### PR TITLE
fix: "Illegal invocation" in service-worker 

### DIFF
--- a/typescript/service-worker/src/sw/http_request.ts
+++ b/typescript/service-worker/src/sw/http_request.ts
@@ -230,7 +230,10 @@ export async function handleRequest(request: Request): Promise<Response> {
   if (maybeCanisterId) {
     try {
       const replicaUrl = new URL(url.origin);
-      const agent = new HttpAgent({ host: replicaUrl.toString() });
+      const agent = new HttpAgent({
+        host: replicaUrl.toString(),
+        fetch: self.fetch.bind(self),
+      });
       const actor = Actor.createActor(canisterIdlFactory, {
         agent,
         canisterId: maybeCanisterId,


### PR DESCRIPTION
This is fix of error message `Failed to fetch response: TypeError: Failed to execute ‘fetch’ on ‘WorkerGlobalScope’: Illegal invocation` while using service-worker in browser.

Found, solved and tested in [this forum topic](https://forum.dfinity.org/t/btcflower-xyz-seems-to-be-hosted-on-ic-but-why-this-domain-name-does-not-need-redirection/10787/6?u=3cl1p5e7)

To solve the problem  you can accept current PR or accept [another PR for agent-js](https://github.com/dfinity/agent-js/pull/527) and update dependencies here

