### PR TITLE
feat: service-worker. Add support for chunk certification

### DIFF
--- a/typescript/service-worker/src/sw/http_request.ts
+++ b/typescript/service-worker/src/sw/http_request.ts
@@ -325,7 +325,6 @@ export async function handleRequest(request: Request): Promise<Response> {
         }
       }
       if (bodyValid) {
-        console.log('Body valid', {httpRequest, httpResponse, headers});
         return new Response(identity.buffer, {
           status: httpResponse.status_code,
           headers,


### PR DESCRIPTION
That is a part of proposal about chunks certification (with backward compatibility).

_These improvements are a proposal to improve the certification infrastructure around IC and might be considered as a recommendation for dfinity-team._

### Goal
Make it possible to certify asset chunks. Validate chunk certificates on the service-worker and icx-proxy.

### Why
At the moment, the service-worker and icx-proxy does not support the certification of chunkified files. Moreover, right now it is not possible to correctly stream chunkified and large audio and video files to the front-end.
This problems could be solved independently if it would be possible to install an additional service-worker in the certified zone of the domain `ic0.app` (for 206 partial http-request handling). But is is impossible because there is unable to place custom worker on `ic0.app` domain.
Making your own custom player for audio and video is extremely difficult due to the large number of formats and non-native implementation.

### Details
To make this possible, support for HTTP-range requests for `http_request` query method has been added. This is done to support native html `audio/video` element (which uses 206 partial http-request) and to determine the index of the chunk throught 206 partial http-request.
Using 206 partial http-requests allows you to focus only on certification in the worker and icx-proxy.

### Steps
1. It all starts with [PR for certified-assets-canister in cdk-rs](https://github.com/dfinity/cdk-rs/pull/219)
2. Did file was updated in [PR for certified-assets-canister](https://github.com/dfinity/certified-assets/pull/25)
3. (Here) Service-worker started supporting chunk_tree certificate verification
4. icx-proxy started supporting chunk_tree certificate verification in [PR for icx-proxy](https://github.com/dfinity/icx-proxy/pull/24)
5. Added support for new certified-assets-canister did in [PR for agent-rs](https://github.com/dfinity/agent-rs/pull/313)