### PR TITLE
Add `maybeResolveCanisterIdFromPathname`

### DIFF
--- a/typescript/service-worker/src/sw/http_request.ts
+++ b/typescript/service-worker/src/sw/http_request.ts
@@ -35,6 +35,8 @@ const [, swDomains] = (() => {
   }
 })() as [Principal | null, string];
 
+const CANISTER_API_REQUEST_REGEX = new RegExp("^\/api/v[0-9]/canister/([A-Za-z0-9-]+)");
+
 /**
  * Split a hostname up-to the first valid canister ID from the right.
  * @param hostname The hostname to analyze.
@@ -61,6 +63,18 @@ function splitHostnameForCanisterId(
   }
 
   return null;
+}
+
+/**
+ * Try to resolve the Canister ID to contact in the pathname.
+ * @param pathname The pathname to look up.
+ * @returns A Canister ID or null if none were found.
+ */
+function maybeResolveCanisterIdFromPathname(
+  pathname: string
+): Principal | null {
+  const matches = pathname.match(CANISTER_API_REQUEST_REGEX);
+  return matches ? Principal.fromText(matches[1]) : null;
 }
 
 /**
@@ -120,6 +134,7 @@ function resolveCanisterIdFromUrl(
   try {
     const url = new URL(urlString);
     return (
+      maybeResolveCanisterIdFromPathname(url.pathname) ||
       maybeResolveCanisterIdFromHostName(url.hostname) ||
       maybeResolveCanisterIdFromSearchParam(url.searchParams, isLocal)
     );


### PR DESCRIPTION
This fixes the following issue. I was experiencing this when accessing my site through my custom domain name:

![](https://user-images.githubusercontent.com/84700/188704975-ad28cce5-cfb6-4a0f-bd2c-e3296c94f996.jpg)

In case it's a factor here, I have 2 canisters; a frontend and backend canister. I would like to have a single canister ID/URL entry point, but I ran into the Wasm module function limit and also https://github.com/dfinity/cdk-rs/issues/310 when trying to do that.

I realize that this PR most likely will not be accepted as this repo isn't accepting outside contributions, but I think it's a good place to socialize the change.