### PR TITLE
Implement Human Readable Account Format and Subaccount Driving Feature

### DIFF
--- a/packages/icrc-ledger-types/Cargo.toml
+++ b/packages/icrc-ledger-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "icrc-ledger-types"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "Types for interacting with DFINITY's implementation of the ICRC-1 fungible token standard."
 license = "Apache-2.0"
@@ -18,6 +18,7 @@ serde = "1"
 sha2 = "0.10"
 num-traits = "0.2.12"
 ciborium = "0.2"
+easy-hasher = "2.2.1"
 
 [dev-dependencies]
 hex = "0.4"

--- a/packages/icrc-ledger-types/src/icrc1/account.rs
+++ b/packages/icrc-ledger-types/src/icrc1/account.rs
@@ -1,23 +1,65 @@
-use std::fmt;
-
+use super::{
+    base32::base32_encode,
+    subaccount::{Subaccount, DEFAULT_SUBACCOUNT},
+};
 use candid::{CandidType, Deserialize, Principal};
+use easy_hasher::easy_hasher;
 use serde::Serialize;
+use std::{cmp, fmt, hash, str::FromStr};
 
-pub type Subaccount = [u8; 32];
-
-pub const DEFAULT_SUBACCOUNT: &Subaccount = &[0; 32];
-
-// Account representation of ledgers supporting the ICRC1 standard
-#[derive(Serialize, CandidType, Deserialize, Clone, Debug, Copy)]
+#[derive(CandidType, Deserialize, Serialize, Debug, Clone)]
 pub struct Account {
     pub owner: Principal,
     pub subaccount: Option<Subaccount>,
 }
 
 impl Account {
+    pub fn new(owner: Principal, subaccount: Option<Subaccount>) -> Self {
+        Account { owner, subaccount }
+    }
+
+    pub fn from_text(text: &str) -> Result<Self, AccountError> {
+        Self::from_str(text)
+    }
+
     #[inline]
     pub fn effective_subaccount(&self) -> &Subaccount {
-        self.subaccount.as_ref().unwrap_or(DEFAULT_SUBACCOUNT)
+        self.subaccount.as_ref().unwrap_or(&DEFAULT_SUBACCOUNT)
+    }
+
+    fn compute_checksum(&self) -> Vec<u8> {
+        // Create a buffer to hold the principal bytes and the subaccount bytes
+        let mut buffer = Vec::with_capacity(29 + 32);
+
+        // Add the owner principal bytes
+        buffer.extend_from_slice(&self.owner.as_slice());
+
+        // If subaccount exists, add the subaccount bytes. Otherwise add 32 zeros
+        match &self.subaccount {
+            Some(subaccount) => buffer.extend_from_slice(&subaccount.to_vec()),
+            None => buffer.extend_from_slice(&[0u8; 32]),
+        }
+
+        // Compute the CRC32 checksum
+        easy_hasher::raw_crc32(buffer).to_vec()
+    }
+
+    fn compute_base32_checksum(&self) -> String {
+        base32_encode(&self.compute_checksum())
+    }
+
+    pub fn to_text(&self) -> String {
+        self.to_string()
+    }
+
+    /// Returns the subaccount.clone()
+    pub fn subaccount(&self) -> Option<Subaccount> {
+        self.subaccount.clone()
+    }
+
+    /// Returns the owner.clone()
+    pub fn owner(&self) -> Principal {
+        self.owner.clone()
     }
 }
 
@@ -29,14 +71,14 @@ impl PartialEq for Account {
 
 impl Eq for Account {}
 
-impl std::cmp::PartialOrd for Account {
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+impl cmp::PartialOrd for Account {
+    fn partial_cmp(&self, other: &Self) -> Option<cmp::Ordering> {
         Some(self.cmp(other))
     }
 }
 
-impl std::cmp::Ord for Account {
-    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+impl cmp::Ord for Account {
+    fn cmp(&self, other: &Self) -> cmp::Ordering {
         self.owner.cmp(&other.owner).then_with(|| {
             self.effective_subaccount()
                 .cmp(other.effective_subaccount())
@@ -44,10 +86,19 @@ impl std::cmp::Ord for Account {
     }
 }
 
-impl std::hash::Hash for Account {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+impl hash::Hash for Account {
+    fn hash<H: hash::Hasher>(&self, state: &mut H) {
         self.owner.hash(state);
         self.effective_subaccount().hash(state);
+    }
+}
+
+impl From<Principal> for Account {
+    fn from(principal: Principal) -> Self {
+        Account {
+            owner: principal,
+            subaccount: None,
+        }
     }
 }
 
@@ -55,16 +106,371 @@ impl fmt::Display for Account {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match &self.subaccount {
             None => write!(f, "{}", self.owner),
-            Some(subaccount) => write!(f, "0x{}.{}", hex::encode(&subaccount[..]), self.owner),
+            Some(subaccount) => {
+                if subaccount.is_default() {
+                    write!(f, "{}", self.owner)
+                } else {
+                    let checksum = self.compute_base32_checksum();
+                    let hex_str = hex::encode(&subaccount.as_slice())
+                        .trim_start_matches('0')
+                        .to_owned();
+                    write!(f, "{}-{}.{}", self.owner, checksum, hex_str)
+                }
+            }
         }
     }
 }
 
-impl From<Principal> for Account {
-    fn from(owner: Principal) -> Self {
-        Self {
-            owner,
-            subaccount: None,
+impl FromStr for Account {
+    type Err = AccountError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let n = s.len();
+
+        if n == 0 {
+            return Err(AccountError::Malformed("empty".into()));
         }
+
+        let last_dash = s.rfind('-');
+        let dot = s.find('.');
+
+        match last_dash {
+            None => {
+                return Err(AccountError::Malformed(
+                    "expected at least one dash ('-') character".into(),
+                ));
+            }
+            Some(last_dash) => {
+                if let Some(dot) = dot {
+                    // There is a subaccount
+                    let num_subaccount_digits = n - dot - 1;
+
+                    if num_subaccount_digits > 64 {
+                        return Err(AccountError::Malformed(
+                            "the subaccount is too long (expected at most 64 characters)".into(),
+                        ));
+                    };
+
+                    if dot < last_dash {
+                        return Err(AccountError::Malformed(
+                            "the subaccount separator does not follow the checksum separator"
+                                .into(),
+                        ));
+                    };
+
+                    if dot - last_dash - 1 != 7 {
+                        return Err(AccountError::BadChecksum);
+                    };
+
+                    // The encoding ends with a dot, the subaccount is empty.
+                    if dot == n - 1 {
+                        return Err(AccountError::NotCanonical);
+                    };
+
+                    // The first digit after the dot must not be a zero.
+                    if s.chars().nth(dot + 1).unwrap() == '0' {
+                        return Err(AccountError::NotCanonical);
+                    };
+
+                    let principal_text = &s[..last_dash];
+                    let owner = Principal::from_text(principal_text)
+                        .map_err(|e| AccountError::InvalidPrincipal(e.to_string()))?;
+
+                    let hex_str = &s[dot + 1..];
+
+                    // Check that the subaccount is not the default.
+                    if hex_str.chars().all(|c| c == '0') {
+                        return Err(AccountError::NotCanonical);
+                    };
+
+                    let subaccount = Subaccount::from_hex(&hex_str)
+                        .map_err(|e| AccountError::InvalidSubaccount(e.to_string()))?;
+
+                    // Check that the checksum matches the subaccount.
+                    let checksum = &s[last_dash + 1..dot];
+                    let expected_checksum = base32_encode(
+                        &Account {
+                            owner,
+                            subaccount: Some(subaccount.clone()),
+                        }
+                        .compute_checksum(),
+                    );
+
+                    if checksum != expected_checksum {
+                        return Err(AccountError::BadChecksum);
+                    };
+
+                    Ok(Account {
+                        owner,
+                        subaccount: Some(subaccount),
+                    })
+                } else {
+                    // There is no subaccount, so it's just a Principal
+                    let owner = Principal::from_text(s)
+                        .map_err(|e| AccountError::InvalidPrincipal(e.to_string()))?;
+                    Ok(Account {
+                        owner,
+                        subaccount: None,
+                    })
+                }
+            }
+        }
+    }
+}
+
+#[derive(CandidType, Clone, Deserialize, Debug, PartialEq)]
+pub enum AccountError {
+    InvalidFormat,
+    BadChecksum,
+    NotCanonical,
+    HexDecode(String),
+    Malformed(String),
+    InvalidPrincipal(String),
+    InvalidSubaccount(String),
+}
+
+impl fmt::Display for AccountError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            AccountError::BadChecksum => write!(f, "Bad checksum"),
+            AccountError::NotCanonical => write!(f, "Not canonical"),
+            AccountError::HexDecode(e) => write!(f, "Hex decode error: {}", e),
+            AccountError::Malformed(e) => write!(f, "Malformed account: {}", e),
+            AccountError::InvalidFormat => write!(f, "Invalid account format"),
+            AccountError::InvalidPrincipal(e) => write!(f, "Invalid principal: {}", e),
+            AccountError::InvalidSubaccount(e) => write!(f, "Invalid subaccount: {}", e),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_account_display() {
+        let account_1 = Account {
+            owner: Principal::from_text(
+                "k2t6j-2nvnp-4zjm3-25dtz-6xhaa-c7boj-5gayf-oj3xs-i43lp-teztq-6ae",
+            )
+            .unwrap(),
+            subaccount: None,
+        };
+        assert_eq!(
+            account_1.to_string(),
+            "k2t6j-2nvnp-4zjm3-25dtz-6xhaa-c7boj-5gayf-oj3xs-i43lp-teztq-6ae"
+        );
+
+        let account_2 = Account {
+            owner: Principal::from_text(
+                "k2t6j-2nvnp-4zjm3-25dtz-6xhaa-c7boj-5gayf-oj3xs-i43lp-teztq-6ae",
+            )
+            .unwrap(),
+            subaccount: Some(Subaccount::from_slice(&[0u8; 32]).unwrap()),
+        };
+        assert_eq!(
+            account_2.to_string(),
+            "k2t6j-2nvnp-4zjm3-25dtz-6xhaa-c7boj-5gayf-oj3xs-i43lp-teztq-6ae"
+        );
+
+        let account_3 = Account {
+            owner: Principal::from_text(
+                "k2t6j-2nvnp-4zjm3-25dtz-6xhaa-c7boj-5gayf-oj3xs-i43lp-teztq-6ae",
+            )
+            .unwrap(),
+            subaccount: Some(Subaccount::from_slice(&[1u8; 32]).unwrap()),
+        };
+        assert_eq!(
+            account_3.to_string(),
+            "k2t6j-2nvnp-4zjm3-25dtz-6xhaa-c7boj-5gayf-oj3xs-i43lp-teztq-6ae-7s4rpcq.101010101010101010101010101010101010101010101010101010101010101"
+        );
+
+        let mut slices = [0u8; 32];
+        slices[31] = 0x01;
+
+        let account_4 = Account {
+            owner: Principal::from_text(
+                "k2t6j-2nvnp-4zjm3-25dtz-6xhaa-c7boj-5gayf-oj3xs-i43lp-teztq-6ae",
+            )
+            .unwrap(),
+            subaccount: Some(Subaccount::from_slice(&slices).unwrap()),
+        };
+
+        assert_eq!(
+            account_4.to_string(),
+            "k2t6j-2nvnp-4zjm3-25dtz-6xhaa-c7boj-5gayf-oj3xs-i43lp-teztq-6ae-6cc627i.1"
+        );
+
+        let slices = [
+            0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e,
+            0x0f, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1a, 0x1b, 0x1c,
+            0x1d, 0x1e, 0x1f, 0x20,
+        ];
+
+        let account_5 = Account {
+            owner: Principal::from_text(
+                "k2t6j-2nvnp-4zjm3-25dtz-6xhaa-c7boj-5gayf-oj3xs-i43lp-teztq-6ae",
+            )
+            .unwrap(),
+            subaccount: Some(Subaccount::from_slice(&slices).unwrap()),
+        };
+        assert_eq!(
+            account_5.to_string(),
+            "k2t6j-2nvnp-4zjm3-25dtz-6xhaa-c7boj-5gayf-oj3xs-i43lp-teztq-6ae-dfxgiyy.102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20"
+        );
+    }
+
+    #[test]
+    fn test_account_parsing() {
+        let account_1 =
+            Account::from_text("k2t6j-2nvnp-4zjm3-25dtz-6xhaa-c7boj-5gayf-oj3xs-i43lp-teztq-6ae")
+                .unwrap();
+
+        let expected_1 = Account {
+            owner: Principal::from_text(
+                "k2t6j-2nvnp-4zjm3-25dtz-6xhaa-c7boj-5gayf-oj3xs-i43lp-teztq-6ae",
+            )
+            .unwrap(),
+            subaccount: None,
+        };
+
+        assert_eq!(account_1, expected_1);
+
+        let account_2 = "k2t6j-2nvnp-4zjm3-25dtz-6xhaa-c7boj-5gayf-oj3xs-i43lp-teztq-6ae"
+            .parse::<Account>()
+            .unwrap();
+
+        let expected_2 = Account {
+            owner: Principal::from_text(
+                "k2t6j-2nvnp-4zjm3-25dtz-6xhaa-c7boj-5gayf-oj3xs-i43lp-teztq-6ae",
+            )
+            .unwrap(),
+            subaccount: Some(Subaccount([0u8; 32])),
+        };
+
+        assert_eq!(account_2, expected_2);
+
+        let account_3 = Account::from_text(
+            "k2t6j-2nvnp-4zjm3-25dtz-6xhaa-c7boj-5gayf-oj3xs-i43lp-teztq-6ae-7s4rpcq.101010101010101010101010101010101010101010101010101010101010101"
+        ).unwrap();
+
+        let expected_3 = Account {
+            owner: Principal::from_text(
+                "k2t6j-2nvnp-4zjm3-25dtz-6xhaa-c7boj-5gayf-oj3xs-i43lp-teztq-6ae",
+            )
+            .unwrap(),
+            subaccount: Some(Subaccount([1u8; 32])),
+        };
+
+        assert_eq!(account_3, expected_3);
+
+        let mut slices = [0u8; 32];
+        slices[31] = 0x01;
+
+        let account_4 = Account {
+            owner: Principal::from_text(
+                "k2t6j-2nvnp-4zjm3-25dtz-6xhaa-c7boj-5gayf-oj3xs-i43lp-teztq-6ae",
+            )
+            .unwrap(),
+            subaccount: Some(Subaccount(slices)),
+        };
+
+        assert_eq!(
+            account_4,
+            "k2t6j-2nvnp-4zjm3-25dtz-6xhaa-c7boj-5gayf-oj3xs-i43lp-teztq-6ae-6cc627i.1"
+                .parse::<Account>()
+                .unwrap()
+        );
+
+        let slices = [
+            0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e,
+            0x0f, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1a, 0x1b, 0x1c,
+            0x1d, 0x1e, 0x1f, 0x20,
+        ];
+
+        let account_5 = Account {
+            owner: Principal::from_text(
+                "k2t6j-2nvnp-4zjm3-25dtz-6xhaa-c7boj-5gayf-oj3xs-i43lp-teztq-6ae",
+            )
+            .unwrap(),
+            subaccount: Some(Subaccount(slices)),
+        };
+
+        assert_eq!(
+            account_5,
+            "k2t6j-2nvnp-4zjm3-25dtz-6xhaa-c7boj-5gayf-oj3xs-i43lp-teztq-6ae-dfxgiyy.102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20"
+                .parse::<Account>()
+                .unwrap()
+        );
+    }
+
+    const TEST_PRINCIPAL: Principal = Principal::from_slice(&[
+        0, 0, 0, 0, 0, 0, 0, 7, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    ]);
+
+    #[test]
+    fn test_subaccount_derivation_path() {
+        let subaccount = Subaccount::new(0);
+        let account = Account::new(TEST_PRINCIPAL, None);
+
+        assert_eq!(account.effective_subaccount(), &subaccount);
+
+        let recover = Account::from_text(&account.to_text()).unwrap();
+
+        assert_eq!(recover, account);
+
+        let subaccount = Subaccount::new(0);
+        let account = Account::new(TEST_PRINCIPAL, Some(subaccount.clone()));
+
+        assert_eq!(account.effective_subaccount(), &subaccount);
+
+        let recover = Account::from_text(&account.to_text()).unwrap();
+
+        assert_eq!(recover, account);
+
+        let subaccount = Subaccount::new(1);
+        let account = Account::new(TEST_PRINCIPAL, Some(subaccount.clone()));
+
+        assert_eq!(account.effective_subaccount(), &subaccount);
+
+        let recover = Account::from_text(&account.to_text()).unwrap();
+
+        assert_eq!(recover, account);
+
+        let subaccount = Subaccount::new(256);
+        let account = Account::new(TEST_PRINCIPAL, Some(subaccount.clone()));
+
+        assert_eq!(account.effective_subaccount(), &subaccount);
+
+        let recover = Account::from_text(&account.to_text()).unwrap();
+
+        assert_eq!(recover, account);
+
+        let subaccount = Subaccount::new(512);
+        let account = Account::new(TEST_PRINCIPAL, Some(subaccount.clone()));
+
+        assert_eq!(account.effective_subaccount(), &subaccount);
+
+        let recover = Account::from_text(&account.to_text()).unwrap();
+
+        assert_eq!(recover, account);
+
+        let subaccount = Subaccount::new(400);
+        let account = Account::new(TEST_PRINCIPAL, Some(subaccount.clone()));
+
+        assert_eq!(account.effective_subaccount(), &subaccount);
+
+        let recover = Account::from_text(&account.to_text()).unwrap();
+
+        assert_eq!(recover, account);
+
+        let subaccount = Subaccount::new(1024);
+        let account = Account::new(TEST_PRINCIPAL, Some(subaccount.clone()));
+
+        assert_eq!(account.effective_subaccount(), &subaccount);
+
+        let recover = Account::from_text(&account.to_text()).unwrap();
+
+        assert_eq!(recover, account);
     }
 }

--- a/packages/icrc-ledger-types/src/icrc1/base32.rs
+++ b/packages/icrc-ledger-types/src/icrc1/base32.rs
@@ -1,0 +1,74 @@
+const BASE32_ALPHABET: &[u8; 32] = b"abcdefghijklmnopqrstuvwxyz234567";
+
+pub fn base32_encode(input: &[u8]) -> String {
+    let mut output = String::with_capacity((input.len() * 8 + 4) / 5);
+
+    for chunk in input.chunks(5) {
+        let mut buffer = 0u64;
+        for (i, &byte) in chunk.iter().enumerate() {
+            buffer |= (byte as u64) << (8 * (4 - i));
+        }
+
+        for i in 0..((chunk.len() * 8 + 4) / 5) {
+            let index = ((buffer >> (35 - 5 * i)) & 0x1f) as usize;
+            output.push(BASE32_ALPHABET[index] as char);
+        }
+    }
+
+    output
+}
+
+pub fn base32_decode(input: &str) -> Result<Vec<u8>, &'static str> {
+    let mut output = Vec::with_capacity(input.len() * 5 / 8);
+    let mut buffer = 0u64;
+    let mut buffer_length = 0;
+
+    for c in input.chars() {
+        buffer <<= 5;
+
+        if let Some(pos) = BASE32_ALPHABET.iter().position(|&x| x == (c as u8)) {
+            buffer |= pos as u64;
+            buffer_length += 5;
+
+            if buffer_length >= 8 {
+                output.push((buffer >> (buffer_length - 8)) as u8);
+                buffer_length -= 8;
+            }
+        } else {
+            return Err("Invalid character in input");
+        }
+    }
+
+    if buffer_length >= 8 {
+        output.push((buffer >> (buffer_length - 8)) as u8);
+    }
+
+    Ok(output)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_base32_encode() {
+        assert_eq!(base32_encode(b""), "");
+        assert_eq!(base32_encode(b"f"), "my");
+        assert_eq!(base32_encode(b"fo"), "mzxq");
+        assert_eq!(base32_encode(b"foo"), "mzxw6");
+        assert_eq!(base32_encode(b"foob"), "mzxw6yq");
+        assert_eq!(base32_encode(b"fooba"), "mzxw6ytb");
+        assert_eq!(base32_encode(b"foobar"), "mzxw6ytboi");
+    }
+
+    #[test]
+    fn test_base32_decode() {
+        assert_eq!(base32_decode(""), Ok(vec![]));
+        assert_eq!(base32_decode("my"), Ok(b"f".to_vec()));
+        assert_eq!(base32_decode("mzxq"), Ok(b"fo".to_vec()));
+        assert_eq!(base32_decode("mzxw6"), Ok(b"foo".to_vec()));
+        assert_eq!(base32_decode("mzxw6yq"), Ok(b"foob".to_vec()));
+        assert_eq!(base32_decode("mzxw6ytb"), Ok(b"fooba".to_vec()));
+        assert_eq!(base32_decode("mzxw6ytboi"), Ok(b"foobar".to_vec()));
+    }
+}

--- a/packages/icrc-ledger-types/src/icrc1/mod.rs
+++ b/packages/icrc-ledger-types/src/icrc1/mod.rs
@@ -1,2 +1,4 @@
 pub mod account;
+mod base32;
+pub mod subaccount;
 pub mod transfer;

--- a/packages/icrc-ledger-types/src/icrc1/subaccount.rs
+++ b/packages/icrc-ledger-types/src/icrc1/subaccount.rs
@@ -1,0 +1,277 @@
+use super::{account::Account, base32::base32_decode};
+use candid::{CandidType, Deserialize, Principal};
+use serde::Serialize;
+
+use std::{cmp, fmt, hash, mem::size_of};
+
+#[derive(CandidType, Deserialize, Serialize, Clone, Copy, Debug, PartialEq)]
+pub struct Subaccount(pub [u8; 32]);
+
+pub const DEFAULT_SUBACCOUNT: Subaccount = Subaccount([0u8; 32]);
+
+impl Default for Subaccount {
+    fn default() -> Self {
+        Subaccount([0u8; 32])
+    }
+}
+
+impl Subaccount {
+    pub fn new(nonce: u64) -> Self {
+        let mut subaccount = [0; 32];
+        // Convert the nonce into bytes in big-endian order
+        let nonce_bytes = nonce.to_be_bytes();
+        // Copy the nonce bytes into the subaccount array starting from the 25th byte
+        // as the nonce in big-endian order with doing this we get the smallest ICRCAccount ids
+        subaccount[24..].copy_from_slice(&nonce_bytes);
+
+        Subaccount(subaccount)
+    }
+
+    pub fn nonce(&self) -> u64 {
+        if self.0[0] == 29 {
+            return 0;
+        }
+
+        let nonce_bytes = &self.0[24..];
+        u64::from_be_bytes(nonce_bytes.try_into().unwrap())
+    }
+
+    pub fn is_default(&self) -> bool {
+        self.0 == [0u8; 32]
+    }
+
+    pub fn as_slice(&self) -> &[u8] {
+        &self.0
+    }
+
+    pub fn from_slice(slice: &[u8]) -> Result<Self, SubaccountError> {
+        if slice.len() != 32 {
+            return Err(SubaccountError::SliceError(
+                "Slice must be 32 bytes long".to_string(),
+            ));
+        }
+
+        let mut subaccount = [0; 32];
+        subaccount.copy_from_slice(slice);
+
+        Ok(Subaccount(subaccount))
+    }
+
+    pub fn to_vec(&self) -> Vec<u8> {
+        self.0.to_vec()
+    }
+
+    pub fn to_hex(&self) -> String {
+        hex::encode(&self.0)
+    }
+
+    pub fn from_hex(hex: &str) -> Result<Self, SubaccountError> {
+        // add leading zeros if necessary
+        let hex = if hex.len() < 64 {
+            let mut hex = hex.to_string();
+            hex.insert_str(0, &"0".repeat(64 - hex.len()));
+            hex
+        } else {
+            hex.to_string()
+        };
+
+        let bytes = hex::decode(hex).map_err(|e| SubaccountError::HexError(e.to_string()))?;
+
+        Subaccount::from_slice(&bytes)
+    }
+
+    pub fn from_base32(base32: &str) -> Result<Self, SubaccountError> {
+        let bytes =
+            base32_decode(base32).map_err(|e| SubaccountError::Base32Error(e.to_string()))?;
+        Subaccount::from_slice(&bytes)
+    }
+}
+
+impl Subaccount {
+    pub fn account(&self, owner: Principal) -> Account {
+        Account::new(owner, Some(self.clone()))
+    }
+}
+
+impl Eq for Subaccount {}
+
+impl cmp::PartialOrd for Subaccount {
+    fn partial_cmp(&self, other: &Self) -> Option<cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl cmp::Ord for Subaccount {
+    fn cmp(&self, other: &Self) -> cmp::Ordering {
+        self.0.cmp(&other.0)
+    }
+}
+
+impl hash::Hash for Subaccount {
+    fn hash<H: hash::Hasher>(&self, state: &mut H) {
+        self.0.hash(state);
+    }
+}
+
+impl From<Principal> for Subaccount {
+    fn from(principal: Principal) -> Self {
+        let mut subaccount = [0; size_of::<Subaccount>()];
+        let principal_id = principal.as_slice();
+
+        subaccount[0] = principal_id.len().try_into().unwrap();
+        subaccount[1..1 + principal_id.len()].copy_from_slice(principal_id);
+
+        Subaccount(subaccount)
+    }
+}
+
+impl From<[u8; 32]> for Subaccount {
+    fn from(bytes: [u8; 32]) -> Self {
+        Self(bytes)
+    }
+}
+
+impl TryFrom<Vec<u8>> for Subaccount {
+    type Error = SubaccountError;
+
+    fn try_from(value: Vec<u8>) -> Result<Self, Self::Error> {
+        if value.len() != 32 {
+            return Err(SubaccountError::InvalidSubaccountLength(value.len()));
+        }
+
+        let mut bytes = [0u8; 32];
+        bytes.copy_from_slice(&value);
+
+        Ok(Self(bytes))
+    }
+}
+
+impl TryFrom<&str> for Subaccount {
+    type Error = SubaccountError;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        let bytes =
+            hex::decode(value).map_err(|e| SubaccountError::InvalidSubaccount(e.to_string()))?;
+
+        Ok(Self::try_from(bytes)?)
+    }
+}
+
+impl fmt::Display for Subaccount {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        hex::encode(&self.0).fmt(f)
+    }
+}
+
+#[derive(CandidType, Deserialize, Serialize, Debug)]
+pub enum SubaccountError {
+    HexError(String),
+    SliceError(String),
+    Base32Error(String),
+    InvalidSubaccount(String),
+    InvalidSubaccountLength(usize),
+}
+
+#[rustfmt::skip]
+impl fmt::Display for SubaccountError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            SubaccountError::InvalidSubaccountLength(len) => write!(f, "InvalidSubaccountLength: {}", len),
+            SubaccountError::InvalidSubaccount(e) => write!(f, "InvalidSubaccount: {}", e),
+            SubaccountError::Base32Error(e) => write!(f, "Subaccount base32 error: {}", e),
+            SubaccountError::SliceError(e) => write!(f, "Subaccount slice error: {}", e),
+            SubaccountError::HexError(e) => write!(f, "Subaccount hex error: {}", e),
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_subaccount() {
+        let subaccount = Subaccount::default();
+        assert_eq!(
+            subaccount.to_owned(),
+            Subaccount([
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, //
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, //
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+            ])
+        );
+
+        let subaccount = Subaccount::new(0);
+        assert_eq!(
+            subaccount.to_owned(),
+            Subaccount([
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, //
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, //
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+            ])
+        );
+
+        let subaccount = Subaccount::new(1);
+
+        assert_eq!(subaccount.nonce(), 1);
+
+        assert_eq!(
+            subaccount.to_owned(),
+            Subaccount([
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, //
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, //
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
+            ])
+        );
+
+        assert_eq!(
+            subaccount.to_hex(),
+            "0000000000000000000000000000000000000000000000000000000000000001"
+        );
+
+        let subaccount = Subaccount::try_from(
+            "0000000000000000000000000000000000000000000000000000000000000001",
+        )
+        .expect("Failed to parse subaccount");
+
+        assert_eq!(
+            subaccount,
+            Subaccount([
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, //
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, //
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
+            ])
+        );
+
+        let subaccount = Subaccount::new(512);
+
+        assert_eq!(
+            subaccount.to_owned(),
+            Subaccount([
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, //
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, //
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0
+            ])
+        )
+    }
+
+    #[test]
+    fn test_account_and_subaccount_with_loop() {
+        let principal = Principal::management_canister();
+
+        for i in 0..30 {
+            let nonce = i / 3;
+
+            let subaccount = Subaccount::new(nonce);
+            let account = Account::new(principal, Some(subaccount.clone()));
+
+            assert_eq!(account.effective_subaccount(), &subaccount);
+
+            let recover = Account::from_text(&account.to_text()).unwrap();
+
+            assert_eq!(recover.effective_subaccount().nonce(), nonce);
+
+            assert_eq!(recover, account);
+        }
+    }
+}

--- a/packages/icrc-ledger-types/src/icrc1/transfer.rs
+++ b/packages/icrc-ledger-types/src/icrc1/transfer.rs
@@ -4,7 +4,7 @@ use serde_bytes::ByteBuf;
 
 pub type BlockIndex = Nat;
 
-use super::account::{Account, Subaccount};
+use super::{account::Account, subaccount::Subaccount};
 
 pub type NumTokens = Nat;
 

--- a/packages/icrc-ledger-types/src/icrc2/approve.rs
+++ b/packages/icrc-ledger-types/src/icrc2/approve.rs
@@ -1,6 +1,8 @@
 use candid::{CandidType, Deserialize, Nat};
 
-use super::super::icrc1::account::{Account, Subaccount};
+use crate::icrc1::subaccount::Subaccount;
+
+use super::super::icrc1::account::Account;
 use super::super::icrc1::transfer::Memo;
 
 #[derive(CandidType, Deserialize, Clone, Debug, PartialEq, Eq)]

--- a/packages/icrc-ledger-types/src/icrc2/transfer_from.rs
+++ b/packages/icrc-ledger-types/src/icrc2/transfer_from.rs
@@ -1,6 +1,8 @@
 use candid::{CandidType, Deserialize, Nat};
 
-use super::super::icrc1::account::{Account, Subaccount};
+use crate::icrc1::subaccount::Subaccount;
+
+use super::super::icrc1::account::Account;
 use super::super::icrc1::transfer::Memo;
 
 #[derive(CandidType, Deserialize, Clone, Debug, PartialEq, Eq)]


### PR DESCRIPTION
This commit introduces two enhancements:

1. Implementation of a human-readable account format, as proposed in the ICRC-1 discussion on the Dfinity forum. The new format improves the readability and user-friendliness of account identifiers.

2. Addition of a feature to drive subaccounts more easily. The new implementation includes several methods that simplify the creation and handling of subaccounts. Methods include creating a new subaccount from a nonce (`new`), retrieving the nonce from a subaccount (`nonce`), checking if a subaccount is the default (`is_default`), converting the subaccount to various formats (`as_slice`, `to_vec`, `to_hex`), and creating a subaccount from different formats (`from_slice`, `from_hex`, `from_base32`). These enhancements increase the flexibility and ease-of-use of the subaccount system.

For further details on the human-readable account format specification, refer to the following:

[standards/ICRC-1/TextualEncoding.md
](https://github.com/dfinity/ICRC-1/blob/main/standards/ICRC-1/TextualEncoding.md)
[ICRC-1 Account Human Readable Format](https://forum.dfinity.org/t/icrc-1-account-human-readable-format/14682/45)
