### PR TITLE
Fix to allow nizk chunking code to operate on WASM32 and other 32-bit

### DIFF
--- a/rs/crypto/internal/crypto_lib/threshold_sig/bls12_381/src/ni_dkg/fs_ni_dkg/forward_secure.rs
+++ b/rs/crypto/internal/crypto_lib/threshold_sig/bls12_381/src/ni_dkg/fs_ni_dkg/forward_secure.rs
@@ -922,7 +922,7 @@ pub(crate) fn extend_tau(
     map.insert_hashed("ciphertext-chunks", &cc.to_vec());
     map.insert_hashed("randomizers-r", &rr.to_vec());
     map.insert_hashed("randomizers-s", &ss.to_vec());
-    map.insert_hashed("epoch", &(epoch.get() as usize));
+    map.insert_hashed("epoch", &(epoch.get() as u64));
     map.insert_hashed("associated-data", &associated_data.to_vec());
 
     let hash = random_oracle(DOMAIN_CIPHERTEXT_NODE, &map);

--- a/rs/crypto/internal/crypto_lib/threshold_sig/bls12_381/src/ni_dkg/fs_ni_dkg/random_oracles.rs
+++ b/rs/crypto/internal/crypto_lib/threshold_sig/bls12_381/src/ni_dkg/fs_ni_dkg/random_oracles.rs
@@ -49,6 +49,18 @@ impl UniqueHash for usize {
     }
 }
 
+/// Computes the unique digest of an integer.
+///
+/// The digest is the hash of the domain separator appended with the big-endian
+/// encoding of the byte representation of the integer.
+impl UniqueHash for u64 {
+    fn unique_hash(&self) -> [u8; UNIQUE_HASH_OUTPUT_LENGTH] {
+        let mut hasher = new_hasher_with_domain(DOMAIN_RO_INT);
+        hasher.write(&self.to_be_bytes());
+        hasher.finish()
+    }
+}
+
 /// Computes the unique digest of a byte vector.
 ///
 /// The digest is the hash of the domain separator appended with the bytes in


### PR DESCRIPTION
 - Fix 32-bit overflow in nizk verify_chunking when building for WASM32 or other 32-bit architechtures.

 - Add some additional logging and fix another usize -> u64

 - Add function muln_u64_vartime to enable consistent result between 32-bit and 64-bit architectures.

 - Create hash of u64 value rather than usize to avoid different hash result on 32-bit and 64-bit architecture.