### PR TITLE
Prototype: 64-Bit Main Memory for Motoko

### DIFF
--- a/Cargo.Bazel.StaticOpenSSL.json.lock
+++ b/Cargo.Bazel.StaticOpenSSL.json.lock
@@ -21726,7 +21726,7 @@
         "Git": {
           "remote": "https://github.com/dfinity/bitcoin-canister",
           "commitish": {
-            "Rev": "0e996988693f2d55fc9533c44dc20ae5310a1894"
+            "Rev": "b1693619e3d4dbc00d8c79e9b6886e1db48b21f7"
           },
           "strip_prefix": "validation"
         }

--- a/Cargo.Bazel.StaticOpenSSL.toml.lock
+++ b/Cargo.Bazel.StaticOpenSSL.toml.lock
@@ -4333,7 +4333,7 @@ dependencies = [
 [[package]]
 name = "ic-btc-validation"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/bitcoin-canister?rev=0e996988693f2d55fc9533c44dc20ae5310a1894#0e996988693f2d55fc9533c44dc20ae5310a1894"
+source = "git+https://github.com/dfinity/bitcoin-canister?rev=b1693619e3d4dbc00d8c79e9b6886e1db48b21f7#b1693619e3d4dbc00d8c79e9b6886e1db48b21f7"
 dependencies = [
  "bitcoin 0.28.2",
 ]

--- a/Cargo.Bazel.json.lock
+++ b/Cargo.Bazel.json.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "063b137ede9410b4a179abce325613a6e86f8ecdc30828d52c1eda21f9694ebf",
+  "checksum": "c23f7bdd37d1352a14ed64c56e8e1618d88f9a84425666d48f7d2a9be6c38b35",
   "crates": {
     "abnf 0.12.0": {
       "name": "abnf",
@@ -27246,12 +27246,27 @@
         ],
         "crate_features": {
           "common": [
-            "errno",
             "general",
             "ioctl",
             "no_std"
           ],
-          "selects": {}
+          "selects": {
+            "aarch64-unknown-linux-gnu": [
+              "errno"
+            ],
+            "arm-unknown-linux-gnueabi": [
+              "errno"
+            ],
+            "armv7-unknown-linux-gnueabi": [
+              "errno"
+            ],
+            "i686-unknown-linux-gnu": [
+              "errno"
+            ],
+            "x86_64-unknown-linux-gnu": [
+              "errno"
+            ]
+          }
         },
         "edition": "2018",
         "version": "0.3.8"
@@ -27285,12 +27300,27 @@
         ],
         "crate_features": {
           "common": [
-            "errno",
             "general",
             "ioctl",
             "no_std"
           ],
-          "selects": {}
+          "selects": {
+            "aarch64-unknown-linux-gnu": [
+              "errno"
+            ],
+            "arm-unknown-linux-gnueabi": [
+              "errno"
+            ],
+            "armv7-unknown-linux-gnueabi": [
+              "errno"
+            ],
+            "i686-unknown-linux-gnu": [
+              "errno"
+            ],
+            "x86_64-unknown-linux-gnu": [
+              "errno"
+            ]
+          }
         },
         "edition": "2021",
         "version": "0.4.3"

--- a/Cargo.Bazel.json.lock
+++ b/Cargo.Bazel.json.lock
@@ -21726,7 +21726,7 @@
         "Git": {
           "remote": "https://github.com/dfinity/bitcoin-canister",
           "commitish": {
-            "Rev": "0e996988693f2d55fc9533c44dc20ae5310a1894"
+            "Rev": "b1693619e3d4dbc00d8c79e9b6886e1db48b21f7"
           },
           "strip_prefix": "validation"
         }

--- a/Cargo.Bazel.toml.lock
+++ b/Cargo.Bazel.toml.lock
@@ -4333,7 +4333,7 @@ dependencies = [
 [[package]]
 name = "ic-btc-validation"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/bitcoin-canister?rev=0e996988693f2d55fc9533c44dc20ae5310a1894#0e996988693f2d55fc9533c44dc20ae5310a1894"
+source = "git+https://github.com/dfinity/bitcoin-canister?rev=b1693619e3d4dbc00d8c79e9b6886e1db48b21f7#b1693619e3d4dbc00d8c79e9b6886e1db48b21f7"
 dependencies = [
  "bitcoin 0.28.2",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1544,9 +1544,9 @@ dependencies = [
 
 [[package]]
 name = "candid"
-version = "0.9.6"
+version = "0.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88f6eec0ae850e006ef0fe306f362884d370624094ec55a6a26de18b251774be"
+checksum = "f391a0d11d997af68e1a06b5e2ab354079cecb82b6eefb26addb38adf66d351d"
 dependencies = [
  "anyhow",
  "binread",
@@ -1561,7 +1561,7 @@ dependencies = [
  "num-traits",
  "num_enum 0.6.1",
  "paste 1.0.12",
- "pretty 0.12.1",
+ "pretty 0.12.3",
  "serde",
  "serde_bytes",
  "sha2 0.10.6",
@@ -2202,9 +2202,9 @@ dependencies = [
 
 [[package]]
 name = "const-hex"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08849ed393c907c90016652a01465a12d86361cd38ad2a7de026c56a520cc259"
+checksum = "aa72a10d0e914cad6bcad4e7409e68d230c1c2db67896e19a37f758b1fcbdab5"
 dependencies = [
  "cfg-if 1.0.0",
  "cpufeatures",
@@ -5522,12 +5522,12 @@ dependencies = [
 
 [[package]]
 name = "ic-cbor"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ea3e22289cb2b7d8afa98f9a42d3ee559841edf84a2e9116a2971d89cf38d40"
+checksum = "767fe244224c02f2adad1d43909de93d35d5caada28eed3f270d89735ba5bdd0"
 dependencies = [
- "candid 0.9.6",
- "ic-certification 0.26.1",
+ "candid 0.9.7",
+ "ic-certification 1.2.0",
  "leb128",
  "nom 7.1.3",
  "thiserror",
@@ -5552,7 +5552,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d4c0b932bf454d5d60e61e13c3c944972fcfd74dc82b9ed5c8b0a75979cf50"
 dependencies = [
- "candid 0.9.6",
+ "candid 0.9.7",
  "ic-cdk-macros 0.7.1",
  "ic0",
  "serde",
@@ -5579,7 +5579,7 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "411c0dd4c149132b68e679274d397053332ee29996c6a541075895881916333b"
 dependencies = [
- "candid 0.9.6",
+ "candid 0.9.7",
  "proc-macro2 1.0.64",
  "quote 1.0.29",
  "serde",
@@ -5603,13 +5603,13 @@ dependencies = [
 
 [[package]]
 name = "ic-certificate-verification"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff07d2f6f19f9a986a24234994fe3e76733fe760b2a63a3b515b785026c2f467"
+checksum = "07bc3fa76751b637bb0c0e37f4089d7f5a3fbacfed3c5fbcfef0d6797a54d63f"
 dependencies = [
- "candid 0.9.6",
+ "candid 0.9.7",
  "ic-cbor",
- "ic-certification 0.26.1",
+ "ic-certification 1.2.0",
  "leb128",
  "miracl_core_bls12381",
  "nom 7.1.3",
@@ -5651,9 +5651,9 @@ dependencies = [
 
 [[package]]
 name = "ic-certification"
-version = "0.26.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d423020cc19ee52cb7fde4f64000d3dd6e8c5703947bf6d7911db5fb3428a8e"
+checksum = "a59dc342d11b2067e19d0f146bdec3674de921303ffc762f114d201ebbe0e68a"
 dependencies = [
  "hex",
  "sha2 0.10.6",
@@ -10021,9 +10021,9 @@ dependencies = [
 
 [[package]]
 name = "ic-representation-independent-hash"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed17f7c50c497229594763c92a2f98fef73bdfe34c9c2210e557dbc90a00d97c"
+checksum = "410e3ccb16b86e8c4bca7270981370f6961492f1921f29f5dd1de621efb869ea"
 dependencies = [
  "leb128",
  "sha2 0.10.6",
@@ -10031,18 +10031,18 @@ dependencies = [
 
 [[package]]
 name = "ic-response-verification"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa988769b9f4586db83f3a57c4c074405700df67b6e7d70d5505ee84c5657fa9"
+checksum = "bc87254b89cea2b84fb2e3101527e457d01da1bdfdbf8b8699dcbc40ad11dcea"
 dependencies = [
  "base64 0.21.0",
- "candid 0.9.6",
+ "candid 0.9.7",
  "flate2",
  "hex",
  "http",
  "ic-cbor",
  "ic-certificate-verification",
- "ic-certification 0.26.1",
+ "ic-certification 1.2.0",
  "ic-representation-independent-hash",
  "leb128",
  "log",
@@ -11667,9 +11667,9 @@ dependencies = [
 
 [[package]]
 name = "ic0"
-version = "0.18.11"
+version = "0.18.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "576c539151d4769fb4d1a0c25c4108dd18facd04c5695b02cf2d226ab4e43aa5"
+checksum = "16efdbe5d9b0ea368da50aedbf7640a054139569236f1a5249deb5fd9af5a5d5"
 
 [[package]]
 name = "ic_bls12_381"
@@ -11755,7 +11755,7 @@ checksum = "1de228913a69be63eec41a6435701d5c1daa6b4e156a92748cf5c50690ca8e40"
 dependencies = [
  "anyhow",
  "async-trait",
- "candid 0.9.6",
+ "candid 0.9.7",
  "serde",
  "thiserror",
 ]
@@ -11767,7 +11767,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "917e17fd43d9afc946d75422a1282ecacb03867dfee9ab3863868388c9a4b127"
 dependencies = [
  "anyhow",
- "candid 0.9.6",
+ "candid 0.9.7",
  "futures",
  "icrc1-test-env",
 ]
@@ -14220,7 +14220,7 @@ name = "pocket-ic"
 version = "0.0.1"
 dependencies = [
  "base64 0.21.0",
- "candid 0.9.6",
+ "candid 0.9.7",
  "ic-cdk 0.10.0",
  "reqwest",
  "serde",
@@ -14233,7 +14233,7 @@ name = "pocket-ic-backend"
 version = "0.0.1"
 dependencies = [
  "axum",
- "candid 0.9.6",
+ "candid 0.9.7",
  "clap 3.2.23",
  "hex",
  "ic-cdk 0.10.0",
@@ -14374,13 +14374,13 @@ dependencies = [
 
 [[package]]
 name = "pretty"
-version = "0.12.1"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "563c9d701c3a31dfffaaf9ce23507ba09cbe0b9125ba176d15e629b0235e9acc"
+checksum = "b55c4d17d994b637e2f4daf6e5dc5d660d209d5642377d675d7a1c3ab69fa579"
 dependencies = [
  "arrayvec 0.5.2",
  "typed-arena",
- "unicode-segmentation",
+ "unicode-width",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5233,7 +5233,7 @@ dependencies = [
 [[package]]
 name = "ic-btc-validation"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/bitcoin-canister?rev=0e996988693f2d55fc9533c44dc20ae5310a1894#0e996988693f2d55fc9533c44dc20ae5310a1894"
+source = "git+https://github.com/dfinity/bitcoin-canister?rev=b1693619e3d4dbc00d8c79e9b6886e1db48b21f7#b1693619e3d4dbc00d8c79e9b6886e1db48b21f7"
 dependencies = [
  "bitcoin 0.28.2",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -61,7 +61,7 @@ dependencies = [
  "actix-service",
  "actix-utils",
  "ahash 0.8.3",
- "base64 0.21.2",
+ "base64 0.21.0",
  "bitflags 1.3.2",
  "brotli",
  "bytes",
@@ -94,7 +94,7 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "465a6172cf69b960917811022d8f29bc0b7fa1398bc4f78b3c466673db1213b6"
 dependencies = [
- "quote 1.0.31",
+ "quote 1.0.29",
  "syn 1.0.109",
 ]
 
@@ -209,8 +209,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2262160a7ae29e3415554a3f1fc04c764b1540c116aa524683208078b7a75bc9"
 dependencies = [
  "actix-router",
- "proc-macro2 1.0.66",
- "quote 1.0.31",
+ "proc-macro2 1.0.64",
+ "quote 1.0.29",
  "syn 1.0.109",
 ]
 
@@ -391,9 +391,9 @@ checksum = "34fde25430d87a9388dadbe6e34d7f72a462c8b43ac8d309b42b0a8505d7e2a5"
 
 [[package]]
 name = "anyhow"
-version = "1.0.72"
+version = "1.0.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b13c32d80ecc7ab747b80c3784bce54ee8a7a0cc4fbda9bf4cda2cf6fe90854"
+checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
 
 [[package]]
 name = "arbitrary"
@@ -464,7 +464,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87bf87e6e8b47264efa9bde63d6225c6276a52e05e91bf37eaa8afd0032d6b71"
 dependencies = [
  "askama_shared",
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.64",
  "syn 1.0.109",
 ]
 
@@ -487,8 +487,8 @@ dependencies = [
  "nom 7.1.3",
  "num-traits",
  "percent-encoding 2.2.0",
- "proc-macro2 1.0.66",
- "quote 1.0.31",
+ "proc-macro2 1.0.64",
+ "quote 1.0.29",
  "serde",
  "serde_json",
  "syn 1.0.109",
@@ -517,8 +517,8 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "726535892e8eae7e70657b4c8ea93d26b8553afb1ce617caee529ef96d7dee6c"
 dependencies = [
- "proc-macro2 1.0.66",
- "quote 1.0.31",
+ "proc-macro2 1.0.64",
+ "quote 1.0.29",
  "syn 1.0.109",
  "synstructure",
 ]
@@ -529,8 +529,8 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2777730b2039ac0f95f093556e61b6d26cebed5393ca6f152717777cec3a42ed"
 dependencies = [
- "proc-macro2 1.0.66",
- "quote 1.0.31",
+ "proc-macro2 1.0.64",
+ "quote 1.0.29",
  "syn 1.0.109",
 ]
 
@@ -587,8 +587,8 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7d78656ba01f1b93024b7c3a0467f1608e4be67d725749fdcd7d2c7678fd7a2"
 dependencies = [
- "proc-macro2 1.0.66",
- "quote 1.0.31",
+ "proc-macro2 1.0.64",
+ "quote 1.0.29",
  "syn 1.0.109",
 ]
 
@@ -632,20 +632,20 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4655ae1a7b0cdf149156f780c5bf3f1352bc53cbd9e0a361a7ef7b22947e965"
 dependencies = [
- "proc-macro2 1.0.66",
- "quote 1.0.31",
+ "proc-macro2 1.0.64",
+ "quote 1.0.29",
  "syn 1.0.109",
 ]
 
 [[package]]
 name = "async-trait"
-version = "0.1.72"
+version = "0.1.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc6dde6e4ed435a4c1ee4e73592f5ba9da2151af10076cc04858746af9352d09"
+checksum = "bc00ceb34980c03614e35a3a4e218276a0a824e911d07651cd0d858a51e8c0f0"
 dependencies = [
- "proc-macro2 1.0.66",
- "quote 1.0.31",
- "syn 2.0.28",
+ "proc-macro2 1.0.64",
+ "quote 1.0.29",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -666,8 +666,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fee3da8ef1276b0bee5dd1c7258010d8fffd31801447323115a25560e1327b89"
 dependencies = [
  "proc-macro-error",
- "proc-macro2 1.0.66",
- "quote 1.0.31",
+ "proc-macro2 1.0.64",
+ "quote 1.0.29",
  "syn 1.0.109",
 ]
 
@@ -749,7 +749,7 @@ dependencies = [
  "hyper",
  "openssl",
  "pin-project-lite",
- "rustls 0.21.2",
+ "rustls 0.21.5",
  "rustls-pemfile",
  "tokio",
  "tokio-openssl",
@@ -838,9 +838,9 @@ checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
-version = "0.21.2"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "604178f6c5c21f02dc555784810edfb88d34ac2c73b2eae109655649ee73ce3d"
+checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
 
 [[package]]
 name = "base64-url"
@@ -912,8 +912,8 @@ dependencies = [
  "lazy_static",
  "lazycell",
  "peeking_take_while",
- "proc-macro2 1.0.66",
- "quote 1.0.31",
+ "proc-macro2 1.0.64",
+ "quote 1.0.29",
  "regex",
  "rustc-hash",
  "shlex",
@@ -935,8 +935,8 @@ dependencies = [
  "lazycell",
  "log",
  "peeking_take_while",
- "proc-macro2 1.0.66",
- "quote 1.0.31",
+ "proc-macro2 1.0.64",
+ "quote 1.0.29",
  "regex",
  "rustc-hash",
  "shlex",
@@ -961,8 +961,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d9672209df1714ee804b1f4d4f68c8eb2a90b1f7a07acf472f88ce198ef1fed"
 dependencies = [
  "either",
- "proc-macro2 1.0.66",
- "quote 1.0.31",
+ "proc-macro2 1.0.64",
+ "quote 1.0.29",
  "syn 1.0.109",
 ]
 
@@ -1116,9 +1116,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.3.2"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dbe3c979c178231552ecba20214a8272df4e09f232a87aef4320cf06539aded"
+checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
 
 [[package]]
 name = "bitvec"
@@ -1202,7 +1202,7 @@ dependencies = [
  "borsh-derive-internal",
  "borsh-schema-derive-internal",
  "proc-macro-crate 0.1.5",
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.64",
  "syn 1.0.109",
 ]
 
@@ -1212,8 +1212,8 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "186b734fa1c9f6743e90c95d7233c9faab6360d1a96d4ffa19d9cfd1e9350f8a"
 dependencies = [
- "proc-macro2 1.0.66",
- "quote 1.0.31",
+ "proc-macro2 1.0.64",
+ "quote 1.0.29",
  "syn 1.0.109",
 ]
 
@@ -1223,8 +1223,8 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99b7ff1008316626f485991b960ade129253d4034014616b94f309a15366cc49"
 dependencies = [
- "proc-macro2 1.0.66",
- "quote 1.0.31",
+ "proc-macro2 1.0.64",
+ "quote 1.0.29",
  "syn 1.0.109",
 ]
 
@@ -1393,8 +1393,8 @@ dependencies = [
  "num-traits",
  "proc-macro-error",
  "proc-macro-hack",
- "proc-macro2 1.0.66",
- "quote 1.0.31",
+ "proc-macro2 1.0.64",
+ "quote 1.0.29",
  "serde_json",
  "syn 1.0.109",
  "xz2",
@@ -1445,8 +1445,8 @@ version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e31225543cb46f81a7e224762764f4a6a0f097b1db0b175f69e8065efaa42de5"
 dependencies = [
- "proc-macro2 1.0.66",
- "quote 1.0.31",
+ "proc-macro2 1.0.64",
+ "quote 1.0.29",
  "syn 1.0.109",
 ]
 
@@ -1544,14 +1544,14 @@ dependencies = [
 
 [[package]]
 name = "candid"
-version = "0.9.1"
+version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4df671c37a9c6168db0334f2b289dd4e02dea1bbefe1fb22c5d43b12d865aacd"
+checksum = "88f6eec0ae850e006ef0fe306f362884d370624094ec55a6a26de18b251774be"
 dependencies = [
  "anyhow",
  "binread",
  "byteorder",
- "candid_derive 0.6.2",
+ "candid_derive 0.6.3",
  "codespan-reporting",
  "crc32fast",
  "data-encoding",
@@ -1576,21 +1576,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58f1f4db7c7d04b87b70b3a35c5dc5c2c9dd73cef8bdf6760e2f18a0d45350dd"
 dependencies = [
  "lazy_static",
- "proc-macro2 1.0.66",
- "quote 1.0.31",
+ "proc-macro2 1.0.64",
+ "quote 1.0.29",
  "syn 1.0.109",
 ]
 
 [[package]]
 name = "candid_derive"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "810b3bd60244f282090652ffc7c30a9d23892e72dfe443e46ee55569044f7dd5"
+checksum = "158403ea38fab5904ae47a5d67eb7047650a91681407f5ccbcbcabc4f4ffb489"
 dependencies = [
  "lazy_static",
- "proc-macro2 1.0.66",
- "quote 1.0.31",
- "syn 2.0.28",
+ "proc-macro2 1.0.64",
+ "quote 1.0.29",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -1999,8 +1999,8 @@ checksum = "ea0c8bce528c4be4da13ea6fead8965e95b6073585a2f05204bd8f4119f82a65"
 dependencies = [
  "heck 0.4.1",
  "proc-macro-error",
- "proc-macro2 1.0.66",
- "quote 1.0.31",
+ "proc-macro2 1.0.64",
+ "quote 1.0.29",
  "syn 1.0.109",
 ]
 
@@ -2011,9 +2011,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8cd2b2a819ad6eec39e8f1d6b53001af1e5469f8c177579cdaeb313115b825f"
 dependencies = [
  "heck 0.4.1",
- "proc-macro2 1.0.66",
- "quote 1.0.31",
- "syn 2.0.28",
+ "proc-macro2 1.0.64",
+ "quote 1.0.29",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -2114,8 +2114,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a54b9c40054eb8999c5d1d36fdc90e4e5f7ff0d1d9621706f360b3cbc8beb828"
 dependencies = [
  "convert_case 0.4.0",
- "proc-macro2 1.0.66",
- "quote 1.0.31",
+ "proc-macro2 1.0.64",
+ "quote 1.0.29",
  "syn 1.0.109",
 ]
 
@@ -2126,8 +2126,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb5437e327e861081c91270becff184859f706e3e50f5301a9d4dc8eb50752c3"
 dependencies = [
  "convert_case 0.6.0",
- "proc-macro2 1.0.66",
- "quote 1.0.31",
+ "proc-macro2 1.0.64",
+ "quote 1.0.29",
  "syn 1.0.109",
 ]
 
@@ -2198,6 +2198,18 @@ checksum = "a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc"
 dependencies = [
  "cfg-if 1.0.0",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "const-hex"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08849ed393c907c90016652a01465a12d86361cd38ad2a7de026c56a520cc259"
+dependencies = [
+ "cfg-if 1.0.0",
+ "cpufeatures",
+ "hex",
+ "serde",
 ]
 
 [[package]]
@@ -2294,18 +2306,18 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.97.1"
+version = "0.97.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c289b8eac3a97329a524e953b5fd68a8416ca629e1a37287f12d9e0760aadbc"
+checksum = "7aae6f552c4c0ccfb30b9559b77bc985a387d998e1736cbbe6b14c903f3656cf"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.97.1"
+version = "0.97.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bf07ba80f53fa7f7dc97b11087ea867f7ae4621cfca21a909eca92c0b96c7d9"
+checksum = "95551de96900cefae691ce895ff2abc691ae3a0b97911a76b45faf99e432937b"
 dependencies = [
  "bumpalo",
  "cranelift-bforest",
@@ -2324,42 +2336,42 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.97.1"
+version = "0.97.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40a7ca088173130c5c033e944756e3e441fbf3f637f32b4f6eb70252580c6dd4"
+checksum = "36a3ad7b2bb03de3383f258b00ca29d80234bebd5130cb6ef3bae37ada5baab0"
 dependencies = [
  "cranelift-codegen-shared",
 ]
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.97.1"
+version = "0.97.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0114095ec7d2fbd658ed100bd007006360bc2530f57c6eee3d3838869140dbf9"
+checksum = "915918fee4142c85fb04bafe0bcd697e2fd6c15a260301ea6f8d2ea332a30e86"
 
 [[package]]
 name = "cranelift-control"
-version = "0.97.1"
+version = "0.97.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d56031683a55a949977e756d21826eb17a1f346143a1badc0e120a15615cd38"
+checksum = "37e447d548cd7f4fcb87fbd10edbd66a4f77966d17785ed50a08c8f3835483c8"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.97.1"
+version = "0.97.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6565198b5684367371e2b946ceca721eb36965e75e3592fad12fc2e15f65d7b"
+checksum = "9d8ab3352a1e5966968d7ab424bd3de8e6b58314760745c3817c2eec3fa2f918"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.97.1"
+version = "0.97.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25f28cc44847c8b98cb921e6bfc0f7b228f4d27519376fea724d181da91709a6"
+checksum = "1bffa38431f7554aa1594f122263b87c9e04abc55c9f42b81d37342ac44f79f0"
 dependencies = [
  "cranelift-codegen",
  "log",
@@ -2369,15 +2381,15 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.97.1"
+version = "0.97.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80b658177e72178c438f7de5d6645c56d97af38e17fcb0b500459007b4e05cc5"
+checksum = "84cef66a71c77938148b72bf006892c89d6be9274a08f7e669ff15a56145d701"
 
 [[package]]
 name = "cranelift-native"
-version = "0.97.1"
+version = "0.97.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf1c7de7221e6afcc5e13ced3b218faab3bc65b47eac67400046a05418aecd6a"
+checksum = "f33c7e5eb446e162d2d10b17fe68e1f091020cc2e4e38b5501c21099600b0a1b"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -2386,9 +2398,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-wasm"
-version = "0.97.1"
+version = "0.97.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76b0d28ebe8edb6b503630c489aa4669f1e2d13b97bec7271a0fcb0e159be3ad"
+checksum = "632f7b64fa6a8c5b980eb6a17ef22089e15cb9f779f1ed3bd3072beab0686c09"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -2663,7 +2675,7 @@ version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d2301688392eb071b0bf1a37be05c469d3cc4dbbd95df672fe28ab021e6a096"
 dependencies = [
- "quote 1.0.31",
+ "quote 1.0.29",
  "syn 1.0.109",
 ]
 
@@ -2723,8 +2735,8 @@ dependencies = [
  "cc",
  "codespan-reporting",
  "once_cell",
- "proc-macro2 1.0.66",
- "quote 1.0.31",
+ "proc-macro2 1.0.64",
+ "quote 1.0.29",
  "scratch",
  "syn 1.0.109",
 ]
@@ -2741,8 +2753,8 @@ version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b75aed41bb2e6367cae39e6326ef817a851db13c13e4f3263714ca3cfb8de56"
 dependencies = [
- "proc-macro2 1.0.66",
- "quote 1.0.31",
+ "proc-macro2 1.0.64",
+ "quote 1.0.29",
  "syn 1.0.109",
 ]
 
@@ -2803,8 +2815,8 @@ checksum = "859d65a907b6852c9361e3185c862aae7fafd2887876799fa55f5f99dc40d610"
 dependencies = [
  "fnv",
  "ident_case",
- "proc-macro2 1.0.66",
- "quote 1.0.31",
+ "proc-macro2 1.0.64",
+ "quote 1.0.29",
  "strsim 0.10.0",
  "syn 1.0.109",
 ]
@@ -2816,7 +2828,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835"
 dependencies = [
  "darling_core",
- "quote 1.0.31",
+ "quote 1.0.29",
  "syn 1.0.109",
 ]
 
@@ -2992,8 +3004,8 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
 dependencies = [
- "proc-macro2 1.0.66",
- "quote 1.0.31",
+ "proc-macro2 1.0.64",
+ "quote 1.0.29",
  "syn 1.0.109",
 ]
 
@@ -3002,8 +3014,8 @@ name = "derive_more"
 version = "0.99.8-alpha.0"
 source = "git+https://github.com/dfinity-lab/derive_more?branch=master#9f1b894e6fde640da4e9ea71a8fc0e4dd98d01da"
 dependencies = [
- "proc-macro2 1.0.66",
- "quote 1.0.31",
+ "proc-macro2 1.0.64",
+ "quote 1.0.29",
  "syn 1.0.109",
 ]
 
@@ -3014,8 +3026,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
 dependencies = [
  "convert_case 0.4.0",
- "proc-macro2 1.0.66",
- "quote 1.0.31",
+ "proc-macro2 1.0.64",
+ "quote 1.0.29",
  "rustc_version",
  "syn 1.0.109",
 ]
@@ -3093,8 +3105,8 @@ dependencies = [
 name = "dfn_macro"
 version = "0.8.0"
 dependencies = [
- "proc-macro2 1.0.66",
- "quote 1.0.31",
+ "proc-macro2 1.0.64",
+ "quote 1.0.29",
  "rustversion",
  "syn 1.0.109",
 ]
@@ -3217,8 +3229,8 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3bf95dc3f046b9da4f2d51833c0d3547d8564ef6910f5c1ed130306a75b92886"
 dependencies = [
- "proc-macro2 1.0.66",
- "quote 1.0.31",
+ "proc-macro2 1.0.64",
+ "quote 1.0.29",
  "syn 1.0.109",
 ]
 
@@ -3302,8 +3314,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb0188e3c3ba8df5753894d54461f0e39bc91741dc5b22e1c46999ec2c71f4e4"
 dependencies = [
  "enum-ordinalize",
- "proc-macro2 1.0.66",
- "quote 1.0.31",
+ "proc-macro2 1.0.64",
+ "quote 1.0.29",
  "syn 1.0.109",
 ]
 
@@ -3411,8 +3423,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9720bba047d567ffc8a3cba48bf19126600e249ab7f128e9233e6376976a116"
 dependencies = [
  "heck 0.4.1",
- "proc-macro2 1.0.66",
- "quote 1.0.31",
+ "proc-macro2 1.0.64",
+ "quote 1.0.29",
  "syn 1.0.109",
 ]
 
@@ -3424,8 +3436,8 @@ checksum = "a62bb1df8b45ecb7ffa78dca1c17a438fb193eb083db0b1b494d2a61bcb5096a"
 dependencies = [
  "num-bigint 0.4.3",
  "num-traits",
- "proc-macro2 1.0.66",
- "quote 1.0.31",
+ "proc-macro2 1.0.64",
+ "quote 1.0.29",
  "rustc_version",
  "syn 1.0.109",
 ]
@@ -3572,19 +3584,19 @@ dependencies = [
 
 [[package]]
 name = "ethers-core"
-version = "2.0.8"
+version = "2.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60ca2514feb98918a0a31de7e1983c29f2267ebf61b2dc5d4294f91e5b866623"
+checksum = "c0a17f0708692024db9956b31d7a20163607d2745953f5ae8125ab368ba280ad"
 dependencies = [
  "arrayvec 0.7.2",
  "bytes",
  "chrono",
+ "const-hex",
  "elliptic-curve 0.13.5",
  "ethabi",
  "generic-array",
- "hex",
  "k256 0.13.1",
- "num_enum 0.6.1",
+ "num_enum 0.7.0",
  "open-fastrlp",
  "rand 0.8.5",
  "rlp",
@@ -3680,14 +3692,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6999dc1837253364c2ebb0704ba97994bd874e8f195d665c50b7548f6ea92764"
+
+[[package]]
 name = "fe-derive"
 version = "0.1.0"
 dependencies = [
  "hex",
  "num-bigint-dig",
  "num-traits",
- "proc-macro2 1.0.66",
- "quote 1.0.31",
+ "proc-macro2 1.0.64",
+ "quote 1.0.29",
  "syn 1.0.109",
 ]
 
@@ -3812,9 +3830,9 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
 dependencies = [
- "proc-macro2 1.0.66",
- "quote 1.0.31",
- "syn 2.0.28",
+ "proc-macro2 1.0.64",
+ "quote 1.0.29",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -3937,7 +3955,7 @@ version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49a9d51ce47660b1e808d3c990b4709f2f415d928835a17dfd16991515c46bce"
 dependencies = [
- "fastrand",
+ "fastrand 1.9.0",
  "futures-core",
  "futures-io",
  "memchr",
@@ -3952,9 +3970,9 @@ version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
- "proc-macro2 1.0.66",
- "quote 1.0.31",
- "syn 2.0.28",
+ "proc-macro2 1.0.64",
+ "quote 1.0.29",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -4008,7 +4026,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27d12c0aed7f1e24276a241aadc4cb8ea9f83000f34bc062b7cc2d51e3b0fabd"
 dependencies = [
- "bitflags 2.3.2",
+ "bitflags 2.4.0",
  "debugid",
  "fxhash",
  "serde",
@@ -4076,8 +4094,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5f0b1b5644ef64a224a3bf1feea56b7aa34e28f04b1a3ef9ac8f3f0e28219b9"
 dependencies = [
  "proc-macro-error",
- "proc-macro2 1.0.66",
- "quote 1.0.31",
+ "proc-macro2 1.0.64",
+ "quote 1.0.29",
  "syn 1.0.109",
 ]
 
@@ -4087,8 +4105,8 @@ version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c746dc576d32875419faf6928ea7f74027f4c34aeee5bd9b540fb37b4448561"
 dependencies = [
- "proc-macro2 1.0.66",
- "quote 1.0.31",
+ "proc-macro2 1.0.64",
+ "quote 1.0.29",
  "syn 1.0.109",
 ]
 
@@ -4098,8 +4116,8 @@ version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69e0cd8a998937e25c6ba7cc276b96ec5cc3f4dc4ab5de9ede4fb152bdd5c5eb"
 dependencies = [
- "proc-macro2 1.0.66",
- "quote 1.0.31",
+ "proc-macro2 1.0.64",
+ "quote 1.0.29",
  "syn 1.0.109",
 ]
 
@@ -4476,7 +4494,7 @@ dependencies = [
  "axum",
  "axum-server",
  "clap 4.3.3",
- "rustls 0.21.2",
+ "rustls 0.21.5",
  "rustls-pemfile",
  "serde_json",
  "tokio",
@@ -4590,7 +4608,7 @@ dependencies = [
  "http",
  "hyper",
  "log",
- "rustls 0.21.2",
+ "rustls 0.21.5",
  "rustls-native-certs",
  "tokio",
  "tokio-rustls 0.24.0",
@@ -4781,7 +4799,7 @@ dependencies = [
 name = "ic-admin-derive"
 version = "0.8.0"
 dependencies = [
- "quote 1.0.31",
+ "quote 1.0.29",
  "syn 1.0.109",
 ]
 
@@ -5073,7 +5091,7 @@ dependencies = [
  "rand 0.8.5",
  "rcgen",
  "reqwest",
- "rustls 0.21.2",
+ "rustls 0.21.5",
  "serde",
  "serde_cbor",
  "serde_json",
@@ -5084,7 +5102,7 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.24.0",
  "tower",
- "tower-http 0.4.3",
+ "tower-http 0.4.4",
  "tracing",
  "tracing-subscriber",
  "url",
@@ -5503,6 +5521,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "ic-cbor"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ea3e22289cb2b7d8afa98f9a42d3ee559841edf84a2e9116a2971d89cf38d40"
+dependencies = [
+ "candid 0.9.6",
+ "ic-certification 0.26.1",
+ "leb128",
+ "nom 7.1.3",
+ "thiserror",
+]
+
+[[package]]
 name = "ic-cdk"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5521,8 +5552,8 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d4c0b932bf454d5d60e61e13c3c944972fcfd74dc82b9ed5c8b0a75979cf50"
 dependencies = [
- "candid 0.9.1",
- "ic-cdk-macros 0.7.0",
+ "candid 0.9.6",
+ "ic-cdk-macros 0.7.1",
  "ic0",
  "serde",
  "serde_bytes",
@@ -5535,8 +5566,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebf50458685a0fc6b0e414cdba487610aeb199ac94db52d9fd76270565debee7"
 dependencies = [
  "candid 0.8.4",
- "proc-macro2 1.0.66",
- "quote 1.0.31",
+ "proc-macro2 1.0.64",
+ "quote 1.0.29",
  "serde",
  "serde_tokenstream",
  "syn 1.0.109",
@@ -5544,13 +5575,13 @@ dependencies = [
 
 [[package]]
 name = "ic-cdk-macros"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4587624e64b8db56224033ee74e5c246d39be15375d03d3df7c117d49d18487"
+checksum = "411c0dd4c149132b68e679274d397053332ee29996c6a541075895881916333b"
 dependencies = [
- "candid 0.9.1",
- "proc-macro2 1.0.66",
- "quote 1.0.31",
+ "candid 0.9.6",
+ "proc-macro2 1.0.64",
+ "quote 1.0.29",
  "serde",
  "serde_tokenstream",
  "syn 1.0.109",
@@ -5568,6 +5599,21 @@ dependencies = [
  "serde",
  "serde_bytes",
  "slotmap",
+]
+
+[[package]]
+name = "ic-certificate-verification"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff07d2f6f19f9a986a24234994fe3e76733fe760b2a63a3b515b785026c2f467"
+dependencies = [
+ "candid 0.9.6",
+ "ic-cbor",
+ "ic-certification 0.26.1",
+ "leb128",
+ "miracl_core_bls12381",
+ "nom 7.1.3",
+ "thiserror",
 ]
 
 [[package]]
@@ -5605,9 +5651,9 @@ dependencies = [
 
 [[package]]
 name = "ic-certification"
-version = "0.25.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6561f6ae522da62b6fb89c0594337c18e96a69fa1f89baae8542f3634023635b"
+checksum = "3d423020cc19ee52cb7fde4f64000d3dd6e8c5703947bf6d7911db5fb3428a8e"
 dependencies = [
  "hex",
  "sha2 0.10.6",
@@ -7339,9 +7385,9 @@ dependencies = [
 name = "ic-exhaustive-derive"
 version = "0.1.0"
 dependencies = [
- "proc-macro2 1.0.66",
- "quote 1.0.31",
- "syn 2.0.28",
+ "proc-macro2 1.0.64",
+ "quote 1.0.29",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -7672,7 +7718,7 @@ dependencies = [
  "serde_with",
  "tempfile",
  "tokio",
- "tower-http 0.4.3",
+ "tower-http 0.4.4",
  "tower-request-id",
  "tracing",
  "tracing-subscriber",
@@ -9021,7 +9067,7 @@ dependencies = [
 name = "ic-nns-test-utils-macros"
 version = "0.8.0"
 dependencies = [
- "quote 1.0.31",
+ "quote 1.0.29",
  "syn 1.0.109",
 ]
 
@@ -9975,9 +10021,9 @@ dependencies = [
 
 [[package]]
 name = "ic-representation-independent-hash"
-version = "1.0.2"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab64ba650b76df61e8566ebecae1d51388e01894d4a429a20ce8862f07118f8a"
+checksum = "ed17f7c50c497229594763c92a2f98fef73bdfe34c9c2210e557dbc90a00d97c"
 dependencies = [
  "leb128",
  "sha2 0.10.6",
@@ -9985,20 +10031,21 @@ dependencies = [
 
 [[package]]
 name = "ic-response-verification"
-version = "1.0.2"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61afc21ecaf6af2f55d27944a9f306cee970409f73ed97a133391a597be80b25"
+checksum = "fa988769b9f4586db83f3a57c4c074405700df67b6e7d70d5505ee84c5657fa9"
 dependencies = [
- "base64 0.21.2",
- "candid 0.9.1",
+ "base64 0.21.0",
+ "candid 0.9.6",
  "flate2",
  "hex",
  "http",
- "ic-certification 0.25.0",
+ "ic-cbor",
+ "ic-certificate-verification",
+ "ic-certification 0.26.1",
  "ic-representation-independent-hash",
  "leb128",
  "log",
- "miracl_core_bls12381",
  "nom 7.1.3",
  "sha2 0.10.6",
  "thiserror",
@@ -11702,24 +11749,25 @@ dependencies = [
 
 [[package]]
 name = "icrc1-test-env"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "742ac065f9340e129b1e2497036aafed4937d66d7ab225c4989a1405496b9b18"
+checksum = "1de228913a69be63eec41a6435701d5c1daa6b4e156a92748cf5c50690ca8e40"
 dependencies = [
  "anyhow",
  "async-trait",
- "candid 0.8.4",
+ "candid 0.9.6",
  "serde",
+ "thiserror",
 ]
 
 [[package]]
 name = "icrc1-test-suite"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e65c993be0c4fc3fa8f2209834ec39674fb327bde0ec07b5c0b2f40fd0dd8a9c"
+checksum = "917e17fd43d9afc946d75422a1282ecacb03867dfee9ab3863868388c9a4b127"
 dependencies = [
  "anyhow",
- "candid 0.8.4",
+ "candid 0.9.6",
  "futures",
  "icrc1-test-env",
 ]
@@ -11749,7 +11797,7 @@ dependencies = [
  "opentelemetry 0.20.0",
  "opentelemetry-prometheus",
  "prometheus 0.13.3",
- "rustls 0.21.2",
+ "rustls 0.21.5",
  "rustls-native-certs",
  "rustls-pemfile",
  "serde",
@@ -11835,8 +11883,8 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11d7a9f6330b71fea57921c9b61c47ee6e84f72d394754eff6163ae67e7395eb"
 dependencies = [
- "proc-macro2 1.0.66",
- "quote 1.0.31",
+ "proc-macro2 1.0.64",
+ "quote 1.0.29",
  "syn 1.0.109",
 ]
 
@@ -11946,7 +11994,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b94f62e8dd2b561e7646bd0cc92e4c9d940859fc1c146ad8ab6e5d3e6f7c03"
 dependencies = [
- "base64 0.21.2",
+ "base64 0.21.0",
  "hyper",
  "hyper-rustls 0.24.0",
  "ring",
@@ -12635,6 +12683,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a9bad9f94746442c783ca431b22403b519cd7fbeed0533fdd6328b2f2212128"
+
+[[package]]
 name = "lmdb-rkv"
 version = "0.14.99"
 source = "git+https://github.com/dfinity-lab/lmdb-rs?rev=1cf86b5cc09947e94a787065cadd163a42ef7f18#1cf86b5cc09947e94a787065cadd163a42ef7f18"
@@ -12768,8 +12822,8 @@ checksum = "a1d849148dbaf9661a6151d1ca82b13bb4c4c128146a88d05253b38d4e2f496c"
 dependencies = [
  "beef",
  "fnv",
- "proc-macro2 1.0.66",
- "quote 1.0.31",
+ "proc-macro2 1.0.64",
+ "quote 1.0.29",
  "regex-syntax",
  "syn 1.0.109",
 ]
@@ -12976,8 +13030,8 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1154809406efdb7982841adb6311b3d095b46f78342dd646736122fe6b19e267"
 dependencies = [
- "proc-macro2 1.0.66",
- "quote 1.0.31",
+ "proc-macro2 1.0.64",
+ "quote 1.0.29",
  "syn 1.0.109",
 ]
 
@@ -13066,8 +13120,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a673cb441f78cd9af4f5919c28576a3cc325fb6b54e42f7047dacce3c718c17b"
 dependencies = [
  "cfg-if 0.1.10",
- "proc-macro2 1.0.66",
- "quote 1.0.31",
+ "proc-macro2 1.0.64",
+ "quote 1.0.29",
  "syn 1.0.109",
 ]
 
@@ -13078,8 +13132,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c461918bf7f59eefb1459252756bf2351a995d6bd510d0b2061bd86bcdabfa6"
 dependencies = [
  "cfg-if 0.1.10",
- "proc-macro2 1.0.66",
- "quote 1.0.31",
+ "proc-macro2 1.0.64",
+ "quote 1.0.29",
  "syn 1.0.109",
 ]
 
@@ -13090,8 +13144,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22ce75669015c4f47b289fd4d4f56e894e4c96003ffdf3ac51313126f94c6cbb"
 dependencies = [
  "cfg-if 1.0.0",
- "proc-macro2 1.0.66",
- "quote 1.0.31",
+ "proc-macro2 1.0.64",
+ "quote 1.0.29",
  "syn 1.0.109",
 ]
 
@@ -13393,14 +13447,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_enum"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70bf6736f74634d299d00086f02986875b3c2d924781a6a2cb6c201e73da0ceb"
+dependencies = [
+ "num_enum_derive 0.7.0",
+]
+
+[[package]]
 name = "num_enum_derive"
 version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcbff9bc912032c62bf65ef1d5aea88983b420f4f839db1e9b0c281a25c9c799"
 dependencies = [
  "proc-macro-crate 1.3.1",
- "proc-macro2 1.0.66",
- "quote 1.0.31",
+ "proc-macro2 1.0.64",
+ "quote 1.0.29",
  "syn 1.0.109",
 ]
 
@@ -13411,9 +13474,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96667db765a921f7b295ffee8b60472b686a51d4f21c2ee4ffdb94c7013b65a6"
 dependencies = [
  "proc-macro-crate 1.3.1",
- "proc-macro2 1.0.66",
- "quote 1.0.31",
- "syn 2.0.28",
+ "proc-macro2 1.0.64",
+ "quote 1.0.29",
+ "syn 2.0.32",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56ea360eafe1022f7cc56cd7b869ed57330fb2453d0c7831d99b74c65d2f5597"
+dependencies = [
+ "proc-macro-crate 1.3.1",
+ "proc-macro2 1.0.64",
+ "quote 1.0.29",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -13476,9 +13551,9 @@ version = "0.8.0"
 
 [[package]]
 name = "once_cell"
-version = "1.18.0"
+version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
+checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
 
 [[package]]
 name = "oorandom"
@@ -13512,8 +13587,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "003b2be5c6c53c1cfeb0a238b8a1c3915cd410feb684457a36c10038f764bb1c"
 dependencies = [
  "bytes",
- "proc-macro2 1.0.66",
- "quote 1.0.31",
+ "proc-macro2 1.0.64",
+ "quote 1.0.29",
  "syn 1.0.109",
 ]
 
@@ -13551,8 +13626,8 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b501e44f11665960c7e7fcf062c7d96a14ade4aa98116c004b2e37b5be7d736c"
 dependencies = [
- "proc-macro2 1.0.66",
- "quote 1.0.31",
+ "proc-macro2 1.0.64",
+ "quote 1.0.29",
  "syn 1.0.109",
 ]
 
@@ -13645,7 +13720,7 @@ dependencies = [
  "futures-util",
  "once_cell",
  "opentelemetry_api",
- "ordered-float 3.7.0",
+ "ordered-float 3.9.1",
  "percent-encoding 2.2.0",
  "rand 0.8.5",
  "regex",
@@ -13729,9 +13804,9 @@ dependencies = [
 
 [[package]]
 name = "ordered-float"
-version = "3.7.0"
+version = "3.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fc2dbde8f8a79f2102cc474ceb0ad68e3b80b85289ea62389b60e66777e4213"
+checksum = "2a54938017eacd63036332b4ae5c8a49fc8c0c1d6d629893057e4f13609edd06"
 dependencies = [
  "num-traits",
 ]
@@ -13794,13 +13869,13 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec-derive"
-version = "3.6.4"
+version = "3.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a296c3079b5fefbc499e1de58dc26c09b1b9a5952d26694ee89f04a43ebbb3e"
+checksum = "9d884d78fcf214d70b1e239fcd1c6e5e95aa3be1881918da2e488cc946c7a476"
 dependencies = [
  "proc-macro-crate 1.3.1",
- "proc-macro2 1.0.66",
- "quote 1.0.31",
+ "proc-macro2 1.0.64",
+ "quote 1.0.29",
  "syn 1.0.109",
 ]
 
@@ -13928,7 +14003,7 @@ version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b13fe415cdf3c8e44518e18a7c95a13431d9bdf6d15367d82b23c377fdd441a"
 dependencies = [
- "base64 0.21.2",
+ "base64 0.21.0",
  "serde",
 ]
 
@@ -13981,8 +14056,8 @@ checksum = "75a1ef20bf3193c15ac345acb32e26b3dc3223aff4d77ae4fc5359567683796b"
 dependencies = [
  "pest",
  "pest_meta",
- "proc-macro2 1.0.66",
- "quote 1.0.31",
+ "proc-macro2 1.0.64",
+ "quote 1.0.29",
  "syn 1.0.109",
 ]
 
@@ -14057,8 +14132,8 @@ version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "069bdb1e05adc7a8990dce9cc75370895fbe4e3d58b9b73bf1aee56359344a55"
 dependencies = [
- "proc-macro2 1.0.66",
- "quote 1.0.31",
+ "proc-macro2 1.0.64",
+ "quote 1.0.29",
  "syn 1.0.109",
 ]
 
@@ -14144,8 +14219,8 @@ dependencies = [
 name = "pocket-ic"
 version = "0.0.1"
 dependencies = [
- "base64 0.21.2",
- "candid 0.9.1",
+ "base64 0.21.0",
+ "candid 0.9.6",
  "ic-cdk 0.10.0",
  "reqwest",
  "serde",
@@ -14158,7 +14233,7 @@ name = "pocket-ic-backend"
 version = "0.0.1"
 dependencies = [
  "axum",
- "candid 0.9.1",
+ "candid 0.9.6",
  "clap 3.2.23",
  "hex",
  "ic-cdk 0.10.0",
@@ -14360,7 +14435,7 @@ version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ebcd279d20a4a0a2404a33056388e950504d891c855c7975b9a8fef75f3bf04"
 dependencies = [
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.64",
  "syn 1.0.109",
 ]
 
@@ -14424,8 +14499,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
  "proc-macro-error-attr",
- "proc-macro2 1.0.66",
- "quote 1.0.31",
+ "proc-macro2 1.0.64",
+ "quote 1.0.29",
  "syn 1.0.109",
  "version_check",
 ]
@@ -14436,8 +14511,8 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
- "proc-macro2 1.0.66",
- "quote 1.0.31",
+ "proc-macro2 1.0.64",
+ "quote 1.0.29",
  "version_check",
 ]
 
@@ -14458,9 +14533,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.66"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
+checksum = "78803b62cbf1f46fde80d7c0e803111524b9877184cfe7c3033659490ac7a7da"
 dependencies = [
  "unicode-ident",
 ]
@@ -14612,8 +14687,8 @@ checksum = "4ea9b0f8cbe5e15a8a042d030bd96668db28ecb567ec37d691971ff5731d2b1b"
 dependencies = [
  "anyhow",
  "itertools 0.10.5",
- "proc-macro2 1.0.66",
- "quote 1.0.31",
+ "proc-macro2 1.0.64",
+ "quote 1.0.29",
  "syn 1.0.109",
 ]
 
@@ -14673,8 +14748,8 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16b845dbfca988fa33db069c0e230574d15a3088f147a87b64c7589eb662c9ac"
 dependencies = [
- "proc-macro2 1.0.66",
- "quote 1.0.31",
+ "proc-macro2 1.0.64",
+ "quote 1.0.29",
  "syn 1.0.109",
 ]
 
@@ -14731,7 +14806,7 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash",
- "rustls 0.21.2",
+ "rustls 0.21.5",
  "thiserror",
  "tokio",
  "tracing",
@@ -14747,7 +14822,7 @@ dependencies = [
  "rand 0.8.5",
  "ring",
  "rustc-hash",
- "rustls 0.21.2",
+ "rustls 0.21.5",
  "rustls-native-certs",
  "slab",
  "thiserror",
@@ -14779,11 +14854,11 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.31"
+version = "1.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fe8a65d69dd0808184ebb5f836ab526bb259db23c657efa38711b1072ee47f0"
+checksum = "573015e8ab27661678357f27dc26460738fd2b6c86e46f386fde94cb5d913105"
 dependencies = [
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.64",
 ]
 
 [[package]]
@@ -15090,8 +15165,8 @@ version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c501201393982e275433bc55de7d6ae6f00e7699cd5572c5b57581cd69c881b"
 dependencies = [
- "proc-macro2 1.0.66",
- "quote 1.0.31",
+ "proc-macro2 1.0.64",
+ "quote 1.0.29",
  "syn 1.0.109",
 ]
 
@@ -15222,7 +15297,7 @@ version = "0.11.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cde824a14b7c14f85caff81225f411faacc04a2013f41670f41443742b1c1c55"
 dependencies = [
- "base64 0.21.2",
+ "base64 0.21.0",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -15242,7 +15317,7 @@ dependencies = [
  "once_cell",
  "percent-encoding 2.2.0",
  "pin-project-lite",
- "rustls 0.21.2",
+ "rustls 0.21.5",
  "rustls-pemfile",
  "serde",
  "serde_json",
@@ -15361,8 +15436,8 @@ version = "0.7.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff26ed6c7c4dfc2aa9480b86a60e3c7233543a270a680e10758a507c5a4ce476"
 dependencies = [
- "proc-macro2 1.0.66",
- "quote 1.0.31",
+ "proc-macro2 1.0.64",
+ "quote 1.0.29",
  "syn 1.0.109",
 ]
 
@@ -15389,8 +15464,8 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e33d7b2abe0c340d8797fe2907d3f20d3b5ea5908683618bfe80df7f621f672a"
 dependencies = [
- "proc-macro2 1.0.66",
- "quote 1.0.31",
+ "proc-macro2 1.0.64",
+ "quote 1.0.29",
  "syn 1.0.109",
 ]
 
@@ -15517,7 +15592,7 @@ version = "1.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f4709403426683ccd5e1ef02b24a2468fe87f8df8a2a792743bb369d7656efa"
 dependencies = [
- "quote 1.0.31",
+ "quote 1.0.29",
  "rust_decimal",
 ]
 
@@ -15595,6 +15670,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "0.38.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac5ffa1efe7548069688cd7028f32591853cd7b5b756d41bcffd2353e4fc75b4"
+dependencies = [
+ "bitflags 2.4.0",
+ "errno 0.3.1",
+ "libc",
+ "linux-raw-sys 0.4.7",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "rustls"
 version = "0.20.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -15608,9 +15696,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.2"
+version = "0.21.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e32ca28af694bc1bbf399c33a516dbdf1c90090b8ab23c2bc24f834aa2247f5f"
+checksum = "79ea77c539259495ce8ca47f53e66ae0330a8819f67e23ac96ca02f50e7b7d36"
 dependencies = [
  "log",
  "ring",
@@ -15636,14 +15724,14 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d194b56d58803a43635bdc398cd17e383d6f71f9182b9a192c127ca42494a59b"
 dependencies = [
- "base64 0.21.2",
+ "base64 0.21.0",
 ]
 
 [[package]]
 name = "rustls-webpki"
-version = "0.100.1"
+version = "0.101.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6207cd5ed3d8dca7816f8f3725513a34609c0c765bf652b8c3cb4cfd87db46b"
+checksum = "15f36a6828982f422756984e47912a7a51dcbc2a197aa791158f8ca61cd8204e"
 dependencies = [
  "ring",
  "untrusted",
@@ -15701,8 +15789,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "912e55f6d20e0e80d63733872b40e1227c0bce1e1ab81ba67d696339bfd7fd29"
 dependencies = [
  "proc-macro-crate 1.3.1",
- "proc-macro2 1.0.66",
- "quote 1.0.31",
+ "proc-macro2 1.0.64",
+ "quote 1.0.29",
  "syn 1.0.109",
 ]
 
@@ -15930,9 +16018,9 @@ version = "1.0.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389894603bd18c46fa56231694f8d827779c0951a667087194cf9de94ed24682"
 dependencies = [
- "proc-macro2 1.0.66",
- "quote 1.0.31",
- "syn 2.0.28",
+ "proc-macro2 1.0.64",
+ "quote 1.0.29",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -15984,9 +16072,9 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bcec881020c684085e55a25f7fd888954d56609ef363479dc5a1305eb0d40cab"
 dependencies = [
- "proc-macro2 1.0.66",
- "quote 1.0.31",
- "syn 2.0.28",
+ "proc-macro2 1.0.64",
+ "quote 1.0.29",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -15995,7 +16083,7 @@ version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "797ba1d80299b264f3aac68ab5d12e5825a561749db4df7cd7c8083900c5d4e9"
 dependencies = [
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.64",
  "serde",
  "syn 1.0.109",
 ]
@@ -16029,8 +16117,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e182d6ec6f05393cc0e5ed1bf81ad6db3a8feedf8ee515ecdd369809bcce8082"
 dependencies = [
  "darling",
- "proc-macro2 1.0.66",
- "quote 1.0.31",
+ "proc-macro2 1.0.64",
+ "quote 1.0.29",
  "syn 1.0.109",
 ]
 
@@ -16066,8 +16154,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1b95bb2f4f624565e8fe8140c789af7e2082c0e0561b5a82a1b678baa9703dc"
 dependencies = [
  "proc-macro-error",
- "proc-macro2 1.0.66",
- "quote 1.0.31",
+ "proc-macro2 1.0.64",
+ "quote 1.0.29",
  "rustversion",
  "syn 1.0.109",
 ]
@@ -16429,8 +16517,8 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a945ec7f7ce853e89ffa36be1e27dce9a43e82ff9093bf3461c30d5da74ed11b"
 dependencies = [
- "proc-macro2 1.0.66",
- "quote 1.0.31",
+ "proc-macro2 1.0.64",
+ "quote 1.0.29",
  "syn 1.0.109",
 ]
 
@@ -16624,8 +16712,8 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bd9c2155aa89fb2c2cb87d99a610c689e7c47099b3e9f1c8a8f53faf4e3d2e3"
 dependencies = [
- "proc-macro2 1.0.66",
- "quote 1.0.31",
+ "proc-macro2 1.0.64",
+ "quote 1.0.29",
  "structmeta-derive",
  "syn 1.0.109",
 ]
@@ -16636,8 +16724,8 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bafede0d0a2f21910f36d47b1558caae3076ed80f6f3ad0fc85a91e6ba7e5938"
 dependencies = [
- "proc-macro2 1.0.66",
- "quote 1.0.31",
+ "proc-macro2 1.0.64",
+ "quote 1.0.29",
  "syn 1.0.109",
 ]
 
@@ -16668,7 +16756,7 @@ version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
 dependencies = [
- "strum_macros 0.25.1",
+ "strum_macros 0.25.2",
 ]
 
 [[package]]
@@ -16678,8 +16766,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87c85aa3f8ea653bfd3ddf25f7ee357ee4d204731f6aa9ad04002306f6e2774c"
 dependencies = [
  "heck 0.3.3",
- "proc-macro2 1.0.66",
- "quote 1.0.31",
+ "proc-macro2 1.0.64",
+ "quote 1.0.29",
  "syn 1.0.109",
 ]
 
@@ -16690,8 +16778,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5bb0dc7ee9c15cea6199cde9a127fa16a4c5819af85395457ad72d68edc85a38"
 dependencies = [
  "heck 0.3.3",
- "proc-macro2 1.0.66",
- "quote 1.0.31",
+ "proc-macro2 1.0.64",
+ "quote 1.0.29",
  "rustversion",
  "syn 1.0.109",
 ]
@@ -16703,23 +16791,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
 dependencies = [
  "heck 0.4.1",
- "proc-macro2 1.0.66",
- "quote 1.0.31",
+ "proc-macro2 1.0.64",
+ "quote 1.0.29",
  "rustversion",
  "syn 1.0.109",
 ]
 
 [[package]]
 name = "strum_macros"
-version = "0.25.1"
+version = "0.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6069ca09d878a33f883cc06aaa9718ede171841d3832450354410b718b097232"
+checksum = "ad8d03b598d3d0fff69bf533ee3ef19b8eeb342729596df84bcc7e1f96ec4059"
 dependencies = [
  "heck 0.4.1",
- "proc-macro2 1.0.66",
- "quote 1.0.31",
+ "proc-macro2 1.0.64",
+ "quote 1.0.29",
  "rustversion",
- "syn 2.0.28",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -16784,19 +16872,19 @@ version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
- "proc-macro2 1.0.66",
- "quote 1.0.31",
+ "proc-macro2 1.0.64",
+ "quote 1.0.29",
  "unicode-ident",
 ]
 
 [[package]]
 name = "syn"
-version = "2.0.28"
+version = "2.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04361975b3f5e348b2189d8dc55bc942f278b2d482a6a0365de5bdd62d351567"
+checksum = "239814284fd6f1a4ffe4ca893952cdd93c224b6a1571c9a9eadd670295c0c9e2"
 dependencies = [
- "proc-macro2 1.0.66",
- "quote 1.0.31",
+ "proc-macro2 1.0.64",
+ "quote 1.0.29",
  "unicode-ident",
 ]
 
@@ -16812,8 +16900,8 @@ version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
 dependencies = [
- "proc-macro2 1.0.66",
- "quote 1.0.31",
+ "proc-macro2 1.0.64",
+ "quote 1.0.29",
  "syn 1.0.109",
  "unicode-xid 0.2.4",
 ]
@@ -16877,22 +16965,21 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ee42b4e559f17bce0385ebf511a7beb67d5cc33c12c96b7f4e9789919d9c10f"
 dependencies = [
- "proc-macro2 1.0.66",
- "quote 1.0.31",
+ "proc-macro2 1.0.64",
+ "quote 1.0.29",
  "syn 1.0.109",
 ]
 
 [[package]]
 name = "tempfile"
-version = "3.6.0"
+version = "3.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31c0432476357e58790aaa47a8efb0c5138f137343f3b5f23bd36a27e3b0a6d6"
+checksum = "cb94d2f3cc536af71caac6b6fcebf65860b347e7ce0cc9ebe8f70d3e521054ef"
 dependencies = [
- "autocfg 1.1.0",
  "cfg-if 1.0.0",
- "fastrand",
+ "fastrand 2.0.0",
  "redox_syscall 0.3.5",
- "rustix 0.37.20",
+ "rustix 0.38.3",
  "windows-sys 0.48.0",
 ]
 
@@ -16957,8 +17044,8 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62d6408d1406657be2f9d1701fbae379331d30d2f6e92050710edb0d34eeb480"
 dependencies = [
- "proc-macro2 1.0.66",
- "quote 1.0.31",
+ "proc-macro2 1.0.64",
+ "quote 1.0.29",
  "structmeta",
  "syn 1.0.109",
 ]
@@ -17120,7 +17207,7 @@ dependencies = [
  "reqwest",
  "ring",
  "rust_decimal",
- "rustls 0.21.2",
+ "rustls 0.21.5",
  "serde",
  "serde_bytes",
  "serde_cbor",
@@ -17170,9 +17257,9 @@ version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
- "proc-macro2 1.0.66",
- "quote 1.0.31",
- "syn 2.0.28",
+ "proc-macro2 1.0.64",
+ "quote 1.0.29",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -17345,9 +17432,9 @@ version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
- "proc-macro2 1.0.66",
- "quote 1.0.31",
- "syn 2.0.28",
+ "proc-macro2 1.0.64",
+ "quote 1.0.29",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -17401,7 +17488,7 @@ version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0d409377ff5b1e3ca6437aa86c1eb7d40c134bfec254e44c830defa92669db5"
 dependencies = [
- "rustls 0.21.2",
+ "rustls 0.21.5",
  "tokio",
 ]
 
@@ -17549,9 +17636,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5bf5e9b9c0f7e0a7c027dcfaba7b2c60816c7049171f679d99ee2ff65d0de8c4"
 dependencies = [
  "prettyplease",
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.64",
  "prost-build",
- "quote 1.0.31",
+ "quote 1.0.29",
  "syn 1.0.109",
 ]
 
@@ -17597,11 +17684,11 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55ae70283aba8d2a8b411c695c437fe25b8b5e44e23e780662002fc72fb47a82"
+checksum = "61c5bb1d698276a2443e5ecfabc1008bf15a36c12e6a7176e7bf089ea9131140"
 dependencies = [
- "bitflags 2.3.2",
+ "bitflags 2.4.0",
  "bytes",
  "futures-core",
  "futures-util",
@@ -17673,8 +17760,8 @@ version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
 dependencies = [
- "proc-macro2 1.0.66",
- "quote 1.0.31",
+ "proc-macro2 1.0.64",
+ "quote 1.0.29",
  "syn 1.0.109",
 ]
 
@@ -17846,9 +17933,9 @@ dependencies = [
 
 [[package]]
 name = "turmoil"
-version = "0.5.6"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d480a6336949f5dc88332df0bffdc60a91363eb2b310fe9d9d083b0789a6f70"
+checksum = "1e72ab712288bd737d0abc60712e031fb48488bbce7810ac2135da067e916469"
 dependencies = [
  "bytes",
  "futures",
@@ -18253,8 +18340,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a6e5bd22c71e77d60140b0bd5be56155a37e5bd14e24f5f87298040d0cc40d7"
 dependencies = [
  "heck 0.3.3",
- "proc-macro2 1.0.66",
- "quote 1.0.31",
+ "proc-macro2 1.0.64",
+ "quote 1.0.29",
  "syn 1.0.109",
 ]
 
@@ -18337,9 +18424,9 @@ dependencies = [
  "bumpalo",
  "log",
  "once_cell",
- "proc-macro2 1.0.66",
- "quote 1.0.31",
- "syn 2.0.28",
+ "proc-macro2 1.0.64",
+ "quote 1.0.29",
+ "syn 2.0.32",
  "wasm-bindgen-shared",
 ]
 
@@ -18361,7 +18448,7 @@ version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dee495e55982a3bd48105a7b947fd2a9b4a8ae3010041b9e0faab3f9cd028f1d"
 dependencies = [
- "quote 1.0.31",
+ "quote 1.0.29",
  "wasm-bindgen-macro-support",
 ]
 
@@ -18371,9 +18458,9 @@ version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
- "proc-macro2 1.0.66",
- "quote 1.0.31",
- "syn 2.0.28",
+ "proc-macro2 1.0.64",
+ "quote 1.0.29",
+ "syn 2.0.32",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -18472,9 +18559,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime"
-version = "10.0.1"
+version = "10.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd02b992d828b91efaf2a7499b21205fe4ab3002e401e3fe0f227aaeb4001d93"
+checksum = "1bc104ced94ff0a6981bde77a0bc29aab4af279914a4143b8d1af9fd4b2c9d41"
 dependencies = [
  "anyhow",
  "bincode",
@@ -18502,18 +18589,18 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-asm-macros"
-version = "10.0.1"
+version = "10.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "284466ef356ce2d909bc0ad470b60c4d0df5df2de9084457e118131b3c779b92"
+checksum = "d2b28e5661a9b5f7610a62ab3c69222fa161f7bd31d04529e856461d8c3e706b"
 dependencies = [
  "cfg-if 1.0.0",
 ]
 
 [[package]]
 name = "wasmtime-cranelift"
-version = "10.0.1"
+version = "10.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e1aa99cbf3f8edb5ad8408ba380f5ab481528ecd8a5053acf758e006d6727fd"
+checksum = "4fc1e39ce9aa0fa0b319541ed423960b06cfa7343eca1574f811ea34275739c2"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -18534,9 +18621,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cranelift-shared"
-version = "10.0.1"
+version = "10.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cce31fd55978601acc103acbb8a26f81c89a6eae12d3a1c59f34151dfa609484"
+checksum = "2dd32739326690e51c76551d7cbf29d371e7de4dc7b37d2d503be314ab5b7d04"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -18550,9 +18637,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-environ"
-version = "10.0.1"
+version = "10.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f9e58e0ee7d43ff13e75375c726b16bce022db798d3a099a65eeaa7d7a544b"
+checksum = "32b60e4ae5c9ae81750d8bc59110bf25444aa1d9266c19999c3b64b801db3c73"
 dependencies = [
  "anyhow",
  "cranelift-entity",
@@ -18569,9 +18656,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit"
-version = "10.0.1"
+version = "10.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0f2eaeb01bb67266416507829bd8e0bb60278444e4cbd048e280833ebeaa02"
+checksum = "655b23a10eddfe7814feb548a466f3f25aa4bb4f43098a147305c544a2de28e1"
 dependencies = [
  "addr2line",
  "anyhow",
@@ -18593,18 +18680,18 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit-debug"
-version = "10.0.1"
+version = "10.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f42e59d62542bfb73ce30672db7eaf4084a60b434b688ac4f05b287d497de082"
+checksum = "e46b7e98979a69d3df093076bde8431204e3c96a770e8d216fea365c627d88a4"
 dependencies = [
  "once_cell",
 ]
 
 [[package]]
 name = "wasmtime-jit-icache-coherence"
-version = "10.0.1"
+version = "10.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b49ceb7e2105a8ebe5614d7bbab6f6ef137a284e371633af60b34925493081f"
+checksum = "6fb1e7c68ede63dc7a98c3e473162954e224951854e229c8b4e74697fe17dbdd"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
@@ -18613,9 +18700,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-runtime"
-version = "10.0.1"
+version = "10.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a5de4762421b0b2b19e02111ca403632852b53e506e03b4b227ffb0fbfa63c2"
+checksum = "843e33bf9e0f0c57902c87a1dea1389cc23865c65f007214318dbdfcb3fd4ae5"
 dependencies = [
  "anyhow",
  "cc",
@@ -18638,9 +18725,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-types"
-version = "10.0.1"
+version = "10.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcbb7c138f797192f46afdd3ec16f85ef007c3bb45fa8e5174031f17b0be4c4a"
+checksum = "7473a07bebd85671bada453123e3d465c8e0a59668ff79f5004076e6a2235ef5"
 dependencies = [
  "cranelift-entity",
  "serde",
@@ -18952,7 +19039,7 @@ checksum = "bd7b0b5b253ebc0240d6aac6dd671c495c467420577bf634d3064ae7e6fa2b4c"
 dependencies = [
  "assert-json-diff",
  "async-trait",
- "base64 0.21.2",
+ "base64 0.21.0",
  "deadpool",
  "futures",
  "futures-timer",
@@ -19131,8 +19218,8 @@ version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44bf07cb3e50ea2003396695d58bf46bc9887a1f362260446fad6bc4e79bd36c"
 dependencies = [
- "proc-macro2 1.0.66",
- "quote 1.0.31",
+ "proc-macro2 1.0.64",
+ "quote 1.0.29",
  "syn 1.0.109",
  "synstructure",
 ]

--- a/bazel/external_crates.bzl
+++ b/bazel/external_crates.bzl
@@ -475,7 +475,7 @@ def external_crates_repository(name, static_openssl, cargo_lockfile, lockfile):
             ),
             "ic-btc-validation": crate.spec(
                 git = "https://github.com/dfinity/bitcoin-canister",
-                rev = "0e996988693f2d55fc9533c44dc20ae5310a1894",
+                rev = "b1693619e3d4dbc00d8c79e9b6886e1db48b21f7",
             ),
             "ic-btc-test-utils": crate.spec(
                 git = "https://github.com/dfinity/bitcoin-canister",

--- a/rs/bitcoin/adapter/Cargo.toml
+++ b/rs/bitcoin/adapter/Cargo.toml
@@ -14,7 +14,7 @@ http = "0.2"
 ic-adapter-metrics-server = { path = "../../monitoring/adapter_metrics_server" }
 ic-async-utils = { path = "../../async_utils" }
 ic-btc-service = { path = "../service" }
-ic-btc-validation = { git = "https://github.com/dfinity/bitcoin-canister", rev = "0e996988693f2d55fc9533c44dc20ae5310a1894" }
+ic-btc-validation = { git = "https://github.com/dfinity/bitcoin-canister", rev = "b1693619e3d4dbc00d8c79e9b6886e1db48b21f7" }
 ic-config = { path = "../../config" }
 ic-logger = { path = "../../monitoring/logger" }
 ic-metrics = { path = "../../monitoring/metrics" }

--- a/rs/canister_sandbox/backend_lib/src/sandbox_server.rs
+++ b/rs/canister_sandbox/backend_lib/src/sandbox_server.rs
@@ -165,6 +165,7 @@ mod tests {
         methods::{FuncRef, WasmMethod},
         time::Time,
         CanisterTimer, ComputeAllocation, Cycles, MemoryAllocation, NumBytes, NumInstructions,
+        MAX_WASM_MEMORY_IN_BYTES,
     };
     use mockall::*;
     use std::collections::{BTreeMap, BTreeSet};
@@ -180,7 +181,7 @@ mod tests {
                 NumInstructions::new(INSTRUCTION_LIMIT),
                 NumInstructions::new(INSTRUCTION_LIMIT),
             ),
-            canister_memory_limit: NumBytes::new(4 << 30),
+            canister_memory_limit: NumBytes::new(MAX_WASM_MEMORY_IN_BYTES),
             memory_allocation: MemoryAllocation::default(),
             compute_allocation: ComputeAllocation::default(),
             subnet_type: SubnetType::Application,

--- a/rs/drun/src/message.rs
+++ b/rs/drun/src/message.rs
@@ -253,7 +253,7 @@ fn parse_install(
                 wasm_data,
                 payload,
                 None,
-                Some(8 * 1024 * 1024 * 1024), // drun users dont care about memory limits
+                None,
                 None,
             )
             .encode(),

--- a/rs/embedders/src/signal_handler.rs
+++ b/rs/embedders/src/signal_handler.rs
@@ -1,5 +1,8 @@
 use crate::wasmtime_embedder::host_memory::MemoryPageSize;
+use crate::wasmtime_embedder::MAIN_MEMORY_PAGE_ACCESS_LIMIT;
 
+use ic_interfaces::execution_environment::HypervisorResult;
+use ic_replicated_state::EmbedderCache;
 use libc::c_void;
 use memory_tracker::{signal_access_kind_and_address, SigsegvMemoryTracker};
 use std::convert::TryFrom;
@@ -8,6 +11,7 @@ use std::sync::{atomic::Ordering, Arc, Mutex};
 
 /// Helper function to create a memory tracking SIGSEGV handler function.
 pub(crate) fn sigsegv_memory_tracker_handler(
+    cache: EmbedderCache,
     memories: Vec<(Arc<Mutex<SigsegvMemoryTracker>>, MemoryPageSize)>,
 ) -> impl Fn(i32, *const libc::siginfo_t, *const libc::c_void) -> bool + Send + Sync {
     let mut memories: Vec<_> = memories
@@ -81,6 +85,17 @@ pub(crate) fn sigsegv_memory_tracker_handler(
         {
             let delta = heap_size - memory_tracker.area().size();
             memory_tracker.expand(delta);
+
+            // Limiting the number of page accesses in 64-bit main memory support.
+            // This is done by interrupting the wasmtime engine in a controlled way by using the epoch mechanism.
+            if memory_tracker.num_accessed_pages() as u64 > MAIN_MEMORY_PAGE_ACCESS_LIMIT {
+                let module = cache
+                    .downcast::<HypervisorResult<wasmtime::Module>>()
+                    .unwrap()
+                    .as_ref()
+                    .unwrap();
+                module.engine().increment_epoch();
+            }
             true
         } else {
             false

--- a/rs/embedders/src/wasm_executor.rs
+++ b/rs/embedders/src/wasm_executor.rs
@@ -661,7 +661,7 @@ pub fn process(
 
     let wasm_heap_size_after = instance.heap_size(CanisterMemoryType::Heap);
     let wasm_heap_limit =
-        NumWasmPages::from(wasmtime_environ::WASM32_MAX_PAGES as usize) - wasm_reserved_pages;
+        NumWasmPages::from(wasmtime_environ::WASM64_MAX_PAGES as usize) - wasm_reserved_pages;
 
     if wasm_heap_size_after > wasm_heap_limit {
         wasm_result = Err(HypervisorError::WasmReservedPages);

--- a/rs/embedders/src/wasm_utils/instrumentation.rs
+++ b/rs/embedders/src/wasm_utils/instrumentation.rs
@@ -27,8 +27,8 @@
 //!
 //! ```wasm
 //! (import "__" "out_of_instructions" (func (;0;) (func)))
-//! (import "__" "update_available_memory" (func (;1;) ((param i64 i64 i32) (result i64))))
-//! (import "__" "try_grow_stable_memory" (func (;1;) ((param i64 i64 i32) (result i64))))
+//! (import "__" "update_available_memory" (func (;1;) ((param i32 i32 i32) (result i32))))
+//! (import "__" "update_available_memory_64" (func (;1;) ((param i64 i64 i32) (result i64))))
 //! (import "__" "internal_trap" (func (;1;) ((param i32))))
 //! (import "__" "stable_read_first_access" (func ((param i64) (param i64) (param i64))))
 //! ```
@@ -461,6 +461,7 @@ pub fn instruction_to_cost_new(i: &Operator) -> u64 {
 const INSTRUMENTED_FUN_MODULE: &str = "__";
 const OUT_OF_INSTRUCTIONS_FUN_NAME: &str = "out_of_instructions";
 const UPDATE_MEMORY_FUN_NAME: &str = "update_available_memory";
+const UPDATE_MEMORY_64_FUN_NAME: &str = "update_available_memory_64";
 const TRY_GROW_STABLE_MEMORY_FUN_NAME: &str = "try_grow_stable_memory";
 const INTERNAL_TRAP_FUN_NAME: &str = "internal_trap";
 const STABLE_READ_FIRST_ACCESS_NAME: &str = "stable_read_first_access";
@@ -563,11 +564,21 @@ fn mutate_function_indices(module: &mut Module, f: impl Fn(u32) -> u32) {
 /// added as the last imports, we'd need to increment only non imported
 /// functions, since imported functions precede all others in the function index
 /// space, but this would be error-prone).
-fn inject_helper_functions(mut module: Module, wasm_native_stable_memory: FlagStatus) -> Module {
+fn inject_helper_functions(
+    mut module: Module,
+    wasm_native_stable_memory: FlagStatus,
+    main_memory_mode: MemoryMode,
+) -> Module {
     // insert types
     let ooi_type = FuncType::new([], []);
-
-    let uam_type = FuncType::new([ValType::I64, ValType::I64, ValType::I32], [ValType::I64]);
+    let uam_type = match main_memory_mode {
+        MemoryMode::Memory32 => {
+            FuncType::new([ValType::I32, ValType::I32, ValType::I32], [ValType::I32])
+        }
+        MemoryMode::Memory64 => {
+            FuncType::new([ValType::I64, ValType::I64, ValType::I32], [ValType::I64])
+        }
+    };
 
     let ooi_type_idx = add_func_type(&mut module, ooi_type);
     let uam_type_idx = add_func_type(&mut module, uam_type);
@@ -579,9 +590,13 @@ fn inject_helper_functions(mut module: Module, wasm_native_stable_memory: FlagSt
         ty: TypeRef::Func(ooi_type_idx),
     };
 
+    let uam_name = match main_memory_mode {
+        MemoryMode::Memory32 => UPDATE_MEMORY_FUN_NAME,
+        MemoryMode::Memory64 => UPDATE_MEMORY_64_FUN_NAME,
+    };
     let uam_imp = Import {
         module: INSTRUMENTED_FUN_MODULE,
-        name: UPDATE_MEMORY_FUN_NAME,
+        name: uam_name,
         ty: TypeRef::Func(uam_type_idx),
     };
 
@@ -632,6 +647,8 @@ fn inject_helper_functions(mut module: Module, wasm_native_stable_memory: FlagSt
     debug_assert!(
         module.imports[InjectedImports::UpdateAvailableMemory as usize].name
             == "update_available_memory"
+            || module.imports[InjectedImports::UpdateAvailableMemory as usize].name
+                == "update_available_memory_64"
     );
     if wasm_native_stable_memory == FlagStatus::Enabled {
         debug_assert!(
@@ -663,6 +680,23 @@ pub(super) struct SpecialIndices {
     pub stable_memory_index: u32,
 }
 
+// Address space used in a Wasm memory.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(super) enum MemoryMode {
+    Memory32,
+    Memory64,
+}
+
+impl MemoryMode {
+    pub fn get(memory_type: &MemoryType) -> MemoryMode {
+        if memory_type.memory64 {
+            MemoryMode::Memory64
+        } else {
+            MemoryMode::Memory32
+        }
+    }
+}
+
 /// Takes a Wasm binary and inserts the instructions metering and memory grow
 /// instrumentation.
 ///
@@ -678,10 +712,15 @@ pub(super) fn instrument(
     dirty_page_overhead: NumInstructions,
 ) -> Result<InstrumentationOutput, WasmInstrumentationError> {
     let stable_memory_index;
-    let mut module = inject_helper_functions(module, wasm_native_stable_memory);
+    let main_memory_mode = MemoryMode::get(&module.memories[0]);
+    let mut module = inject_helper_functions(module, wasm_native_stable_memory, main_memory_mode);
     module = export_table(module);
-    (module, stable_memory_index) =
-        update_memories(module, write_barrier, wasm_native_stable_memory);
+    (module, stable_memory_index) = update_memories(
+        module,
+        write_barrier,
+        wasm_native_stable_memory,
+        main_memory_mode,
+    );
 
     let mut extra_strs: Vec<String> = Vec::new();
     module = export_mutable_globals(module, &mut extra_strs);
@@ -735,7 +774,12 @@ pub(super) fn instrument(
 
     // inject instructions counter decrementation
     for func_body in &mut module.code_sections {
-        inject_metering(&mut func_body.instructions, &special_indices, metering_type);
+        inject_metering(
+            &mut func_body.instructions,
+            &special_indices,
+            metering_type,
+            main_memory_mode,
+        );
     }
 
     // Collect all the function types of the locally defined functions inside the
@@ -762,7 +806,7 @@ pub(super) fn instrument(
     if !func_types.is_empty() {
         let func_bodies = &mut module.code_sections;
         for (func_ix, func_type) in func_types.into_iter() {
-            inject_update_available_memory(&mut func_bodies[func_ix], &func_type);
+            inject_update_available_memory(&mut func_bodies[func_ix], &func_type, main_memory_mode);
             if write_barrier == FlagStatus::Enabled {
                 inject_mem_barrier(&mut func_bodies[func_ix], &func_type);
             }
@@ -778,6 +822,7 @@ pub(super) fn instrument(
             subnet_type,
             dirty_page_overhead,
             metering_type,
+            main_memory_mode,
         )
     }
 
@@ -857,6 +902,7 @@ fn replace_system_api_functions(
     subnet_type: SubnetType,
     dirty_page_overhead: NumInstructions,
     metering_type: MeteringType,
+    main_memory_mode: MemoryMode,
 ) {
     let api_indexes = calculate_api_indexes(module);
     let number_of_func_imports = module
@@ -873,6 +919,7 @@ fn replace_system_api_functions(
         subnet_type,
         dirty_page_overhead,
         metering_type,
+        main_memory_mode,
     ) {
         if let Some(old_index) = api_indexes.get(&api) {
             let type_idx = add_func_type(module, ty);
@@ -1125,8 +1172,9 @@ enum Scope {
 
 // Describes how to calculate the instruction cost at this injection point.
 // `StaticCost` injection points contain information about the cost of the
-// following basic block. `DynamicCost` injection points assume there is an i64
-// on the stack which should be decremented from the instruction counter.
+// following basic block. `DynamicCost` injection points assume there is an
+// i32 on 32-bit Wasm or an i64 on Wasm Memory64 on the stack which should
+// be decremented from the instruction counter.
 #[derive(Copy, Clone, Debug, PartialEq)]
 enum InjectionPointCostDetail {
     StaticCost { scope: Scope, cost: u64 },
@@ -1180,6 +1228,7 @@ fn inject_metering(
     code: &mut Vec<Operator>,
     export_data_module: &SpecialIndices,
     metering_type: MeteringType,
+    main_memory_mode: MemoryMode,
 ) {
     let points = match metering_type {
         MeteringType::Old => injections_old(code),
@@ -1232,9 +1281,25 @@ fn inject_metering(
                 }
             }
             InjectionPointCostDetail::DynamicCost => {
-                elems.extend_from_slice(&[Call {
+                let call = Call {
                     function_index: export_data_module.decr_instruction_counter_fn,
-                }]);
+                };
+
+                match main_memory_mode {
+                    MemoryMode::Memory32 => {
+                        elems.extend_from_slice(&[
+                            I64ExtendI32U,
+                            call,
+                            // decr_instruction_counter returns it's argument unchanged,
+                            // so we can convert back to I32 without worrying about
+                            // overflows.
+                            I32WrapI64,
+                        ]);
+                    }
+                    MemoryMode::Memory64 => {
+                        elems.extend_from_slice(&[call]);
+                    }
+                };
             }
         }
         last_injection_position = point.position;
@@ -1454,7 +1519,11 @@ fn inject_mem_barrier(func_body: &mut wasm_transform::Body, func_type: &FuncType
 // `table.grow` instruction to make sure that there's enough available memory
 // left to support the requested extra memory. If no `memory.grow` or
 // `table.grow` instructions are present then the code remains unchanged.
-fn inject_update_available_memory(func_body: &mut wasm_transform::Body, func_type: &FuncType) {
+fn inject_update_available_memory(
+    func_body: &mut wasm_transform::Body,
+    func_type: &FuncType,
+    main_memory_mode: MemoryMode,
+) {
     // This is an overestimation of table element size computed based on the
     // existing canister limits.
     const TABLE_ELEMENT_SIZE: u32 = 1024;
@@ -1478,7 +1547,12 @@ fn inject_update_available_memory(func_body: &mut wasm_transform::Body, func_typ
         // the total number of locals.
         let n_locals: u32 = func_body.locals.iter().map(|x| x.0).sum();
         let memory_local_ix = func_type.params().len() as u32 + n_locals;
-        func_body.locals.push((1, ValType::I64));
+
+        let local_type = match main_memory_mode {
+            MemoryMode::Memory32 => ValType::I32,
+            MemoryMode::Memory64 => ValType::I64,
+        };
+        func_body.locals.push((1, local_type));
 
         let orig_elems = &func_body.instructions;
         let mut elems: Vec<Operator> = Vec::new();
@@ -1687,6 +1761,7 @@ fn update_memories(
     mut module: Module,
     write_barrier: FlagStatus,
     wasm_native_stable_memory: FlagStatus,
+    main_memory_mode: MemoryMode,
 ) -> (Module, u32) {
     let mut stable_index = 0;
 
@@ -1709,7 +1784,7 @@ fn update_memories(
 
     if write_barrier == FlagStatus::Enabled && !module.memories.is_empty() {
         module.memories.push(MemoryType {
-            memory64: true,
+            memory64: main_memory_mode == MemoryMode::Memory64,
             shared: false,
             initial: BYTEMAP_SIZE_IN_WASM_PAGES,
             maximum: Some(BYTEMAP_SIZE_IN_WASM_PAGES),

--- a/rs/embedders/src/wasm_utils/instrumentation.rs
+++ b/rs/embedders/src/wasm_utils/instrumentation.rs
@@ -565,9 +565,9 @@ fn mutate_function_indices(module: &mut Module, f: impl Fn(u32) -> u32) {
 /// space, but this would be error-prone).
 fn inject_helper_functions(mut module: Module, wasm_native_stable_memory: FlagStatus) -> Module {
     // insert types
-    let ooi_type = Type::Func([], []);
+    let ooi_type = FuncType::new([], []);
 
-    let uam_type = Type::Func([ValType::I64, ValType::I64, ValType::I32], [ValType::I64]);
+    let uam_type = FuncType::new([ValType::I64, ValType::I64, ValType::I32], [ValType::I64]);
 
     let ooi_type_idx = add_func_type(&mut module, ooi_type);
     let uam_type_idx = add_func_type(&mut module, uam_type);

--- a/rs/embedders/src/wasm_utils/instrumentation.rs
+++ b/rs/embedders/src/wasm_utils/instrumentation.rs
@@ -1,6 +1,8 @@
 //! This module is responsible for instrumenting wasm binaries on the Internet
 //! Computer.
 //!
+//! Supports 64-bit main memory by using `wasm64`.
+//!
 //! It exports the function [`instrument`] which takes a Wasm binary and
 //! injects some instrumentation that allows to:
 //!  * Quantify the amount of execution every function of that module conducts.
@@ -25,7 +27,7 @@
 //!
 //! ```wasm
 //! (import "__" "out_of_instructions" (func (;0;) (func)))
-//! (import "__" "update_available_memory" (func (;1;) ((param i32 i32 i32) (result i32))))
+//! (import "__" "update_available_memory" (func (;1;) ((param i64 i64 i32) (result i64))))
 //! (import "__" "try_grow_stable_memory" (func (;1;) ((param i64 i64 i32) (result i64))))
 //! (import "__" "internal_trap" (func (;1;) ((param i32))))
 //! (import "__" "stable_read_first_access" (func ((param i64) (param i64) (param i64))))
@@ -563,8 +565,9 @@ fn mutate_function_indices(module: &mut Module, f: impl Fn(u32) -> u32) {
 /// space, but this would be error-prone).
 fn inject_helper_functions(mut module: Module, wasm_native_stable_memory: FlagStatus) -> Module {
     // insert types
-    let ooi_type = FuncType::new([], []);
-    let uam_type = FuncType::new([ValType::I32, ValType::I32, ValType::I32], [ValType::I32]);
+    let ooi_type = Type::Func([], []);
+
+    let uam_type = Type::Func([ValType::I64, ValType::I64, ValType::I32], [ValType::I64]);
 
     let ooi_type_idx = add_func_type(&mut module, ooi_type);
     let uam_type_idx = add_func_type(&mut module, uam_type);
@@ -1122,7 +1125,7 @@ enum Scope {
 
 // Describes how to calculate the instruction cost at this injection point.
 // `StaticCost` injection points contain information about the cost of the
-// following basic block. `DynamicCost` injection points assume there is an i32
+// following basic block. `DynamicCost` injection points assume there is an i64
 // on the stack which should be decremented from the instruction counter.
 #[derive(Copy, Clone, Debug, PartialEq)]
 enum InjectionPointCostDetail {
@@ -1229,16 +1232,9 @@ fn inject_metering(
                 }
             }
             InjectionPointCostDetail::DynamicCost => {
-                elems.extend_from_slice(&[
-                    I64ExtendI32U,
-                    Call {
-                        function_index: export_data_module.decr_instruction_counter_fn,
-                    },
-                    // decr_instruction_counter returns it's argument unchanged,
-                    // so we can convert back to I32 without worrying about
-                    // overflows.
-                    I32WrapI64,
-                ]);
+                elems.extend_from_slice(&[Call {
+                    function_index: export_data_module.decr_instruction_counter_fn,
+                }]);
             }
         }
         last_injection_position = point.position;
@@ -1482,7 +1478,7 @@ fn inject_update_available_memory(func_body: &mut wasm_transform::Body, func_typ
         // the total number of locals.
         let n_locals: u32 = func_body.locals.iter().map(|x| x.0).sum();
         let memory_local_ix = func_type.params().len() as u32 + n_locals;
-        func_body.locals.push((1, ValType::I32));
+        func_body.locals.push((1, ValType::I64));
 
         let orig_elems = &func_body.instructions;
         let mut elems: Vec<Operator> = Vec::new();
@@ -1644,6 +1640,7 @@ fn get_data(
                     offset_expr,
                 } => match offset_expr {
                     Operator::I32Const { value } => *value as usize,
+                    Operator::I64Const { value } => *value as usize,
                     _ => return Err(WasmInstrumentationError::WasmDeserializeError(WasmError::new(
                         "complex initialization expressions for data segments are not supported!".into()
                     ))),
@@ -1712,7 +1709,7 @@ fn update_memories(
 
     if write_barrier == FlagStatus::Enabled && !module.memories.is_empty() {
         module.memories.push(MemoryType {
-            memory64: false,
+            memory64: true,
             shared: false,
             initial: BYTEMAP_SIZE_IN_WASM_PAGES,
             maximum: Some(BYTEMAP_SIZE_IN_WASM_PAGES),

--- a/rs/embedders/src/wasm_utils/system_api_replacements.rs
+++ b/rs/embedders/src/wasm_utils/system_api_replacements.rs
@@ -23,7 +23,11 @@ use ic_types::NumInstructions;
 use wasmparser::{BlockType, FuncType, Operator, ValType};
 use wasmtime_environ::WASM_PAGE_SIZE;
 
-use super::{instrumentation::SpecialIndices, wasm_transform::Body, SystemApiFunc};
+use super::{
+    instrumentation::{MemoryMode, SpecialIndices},
+    wasm_transform::Body,
+    SystemApiFunc,
+};
 
 use crate::wasmtime_embedder::system_api_complexity::system_api;
 
@@ -34,6 +38,7 @@ pub(super) fn replacement_functions(
     subnet_type: SubnetType,
     dirty_page_overhead: NumInstructions,
     metering_type: MeteringType,
+    main_memory_mode: MemoryMode,
 ) -> Vec<(SystemApiFunc, (FuncType, Body<'static>))> {
     let count_clean_pages_fn_index = special_indices.count_clean_pages_fn.unwrap();
     let dirty_pages_counter_index = special_indices.dirty_pages_counter_ix.unwrap();
@@ -742,8 +747,16 @@ pub(super) fn replacement_functions(
                             },
                             Else,
                             LocalGet { local_index: DST },
+                            match main_memory_mode {
+                                MemoryMode::Memory32 => I32WrapI64,
+                                MemoryMode::Memory64 => Nop,
+                            },
                             LocalGet { local_index: SRC },
                             LocalGet { local_index: LEN },
+                            match main_memory_mode {
+                                MemoryMode::Memory32 => I32WrapI64,
+                                MemoryMode::Memory64 => Nop,
+                            },
                             MemoryCopy {
                                 dst_mem: 0,
                                 src_mem: stable_memory_index,
@@ -1222,7 +1235,15 @@ pub(super) fn replacement_functions(
                             // copy memory contents
                             LocalGet { local_index: DST },
                             LocalGet { local_index: SRC },
+                            match main_memory_mode {
+                                MemoryMode::Memory32 => I32WrapI64,
+                                MemoryMode::Memory64 => Nop,
+                            },
                             LocalGet { local_index: LEN },
+                            match main_memory_mode {
+                                MemoryMode::Memory32 => I32WrapI64,
+                                MemoryMode::Memory64 => Nop,
+                            },
                             MemoryCopy {
                                 dst_mem: stable_memory_index,
                                 src_mem: 0,

--- a/rs/embedders/src/wasm_utils/system_api_replacements.rs
+++ b/rs/embedders/src/wasm_utils/system_api_replacements.rs
@@ -742,10 +742,8 @@ pub(super) fn replacement_functions(
                             },
                             Else,
                             LocalGet { local_index: DST },
-                            I32WrapI64,
                             LocalGet { local_index: SRC },
                             LocalGet { local_index: LEN },
-                            I32WrapI64,
                             MemoryCopy {
                                 dst_mem: 0,
                                 src_mem: stable_memory_index,
@@ -1224,9 +1222,7 @@ pub(super) fn replacement_functions(
                             // copy memory contents
                             LocalGet { local_index: DST },
                             LocalGet { local_index: SRC },
-                            I32WrapI64,
                             LocalGet { local_index: LEN },
-                            I32WrapI64,
                             MemoryCopy {
                                 dst_mem: stable_memory_index,
                                 src_mem: 0,

--- a/rs/embedders/src/wasm_utils/validation.rs
+++ b/rs/embedders/src/wasm_utils/validation.rs
@@ -81,6 +81,16 @@ fn get_valid_system_apis() -> HashMap<String, HashMap<String, FunctionSignature>
             )],
         ),
         (
+            "msg_caller_copy_64",
+            vec![(
+                API_VERSION_IC0,
+                FunctionSignature {
+                    param_types: vec![ValType::I64, ValType::I64, ValType::I64],
+                    return_type: vec![],
+                },
+            )],
+        ),
+        (
             "msg_arg_data_size",
             vec![(
                 API_VERSION_IC0,
@@ -101,6 +111,16 @@ fn get_valid_system_apis() -> HashMap<String, HashMap<String, FunctionSignature>
             )],
         ),
         (
+            "msg_arg_data_copy_64",
+            vec![(
+                API_VERSION_IC0,
+                FunctionSignature {
+                    param_types: vec![ValType::I64, ValType::I64, ValType::I64],
+                    return_type: vec![],
+                },
+            )],
+        ),
+        (
             "msg_method_name_size",
             vec![(
                 API_VERSION_IC0,
@@ -116,6 +136,16 @@ fn get_valid_system_apis() -> HashMap<String, HashMap<String, FunctionSignature>
                 API_VERSION_IC0,
                 FunctionSignature {
                     param_types: vec![ValType::I32, ValType::I32, ValType::I32],
+                    return_type: vec![],
+                },
+            )],
+        ),
+        (
+            "msg_method_name_copy_64",
+            vec![(
+                API_VERSION_IC0,
+                FunctionSignature {
+                    param_types: vec![ValType::I64, ValType::I64, ValType::I64],
                     return_type: vec![],
                 },
             )],
@@ -161,11 +191,31 @@ fn get_valid_system_apis() -> HashMap<String, HashMap<String, FunctionSignature>
             )],
         ),
         (
+            "msg_reject_msg_copy_64",
+            vec![(
+                API_VERSION_IC0,
+                FunctionSignature {
+                    param_types: vec![ValType::I64, ValType::I64, ValType::I64],
+                    return_type: vec![],
+                },
+            )],
+        ),
+        (
             "msg_reply_data_append",
             vec![(
                 API_VERSION_IC0,
                 FunctionSignature {
                     param_types: vec![ValType::I32, ValType::I32],
+                    return_type: vec![],
+                },
+            )],
+        ),
+        (
+            "msg_reply_data_append_64",
+            vec![(
+                API_VERSION_IC0,
+                FunctionSignature {
+                    param_types: vec![ValType::I64, ValType::I64],
                     return_type: vec![],
                 },
             )],
@@ -191,6 +241,16 @@ fn get_valid_system_apis() -> HashMap<String, HashMap<String, FunctionSignature>
             )],
         ),
         (
+            "msg_reject_64",
+            vec![(
+                API_VERSION_IC0,
+                FunctionSignature {
+                    param_types: vec![ValType::I64, ValType::I64],
+                    return_type: vec![],
+                },
+            )],
+        ),
+        (
             "canister_self_size",
             vec![(
                 API_VERSION_IC0,
@@ -206,6 +266,16 @@ fn get_valid_system_apis() -> HashMap<String, HashMap<String, FunctionSignature>
                 API_VERSION_IC0,
                 FunctionSignature {
                     param_types: vec![ValType::I32, ValType::I32, ValType::I32],
+                    return_type: vec![],
+                },
+            )],
+        ),
+        (
+            "canister_self_copy_64",
+            vec![(
+                API_VERSION_IC0,
+                FunctionSignature {
+                    param_types: vec![ValType::I64, ValType::I64, ValType::I64],
                     return_type: vec![],
                 },
             )],
@@ -241,11 +311,40 @@ fn get_valid_system_apis() -> HashMap<String, HashMap<String, FunctionSignature>
             )],
         ),
         (
+            "call_new_64",
+            vec![(
+                API_VERSION_IC0,
+                FunctionSignature {
+                    param_types: vec![
+                        ValType::I64,
+                        ValType::I64,
+                        ValType::I64,
+                        ValType::I64,
+                        ValType::I32,
+                        ValType::I32,
+                        ValType::I32,
+                        ValType::I32,
+                    ],
+                    return_type: vec![],
+                },
+            )],
+        ),
+        (
             "call_data_append",
             vec![(
                 API_VERSION_IC0,
                 FunctionSignature {
                     param_types: vec![ValType::I32, ValType::I32],
+                    return_type: vec![],
+                },
+            )],
+        ),
+        (
+            "call_data_append_64",
+            vec![(
+                API_VERSION_IC0,
+                FunctionSignature {
+                    param_types: vec![ValType::I64, ValType::I64],
                     return_type: vec![],
                 },
             )],
@@ -287,6 +386,16 @@ fn get_valid_system_apis() -> HashMap<String, HashMap<String, FunctionSignature>
                 API_VERSION_IC0,
                 FunctionSignature {
                     param_types: vec![ValType::I32, ValType::I32],
+                    return_type: vec![],
+                },
+            )],
+        ),
+        (
+            "debug_print_64",
+            vec![(
+                API_VERSION_IC0,
+                FunctionSignature {
+                    param_types: vec![ValType::I64, ValType::I64],
                     return_type: vec![],
                 },
             )],
@@ -422,6 +531,16 @@ fn get_valid_system_apis() -> HashMap<String, HashMap<String, FunctionSignature>
             )],
         ),
         (
+            "trap_64",
+            vec![(
+                API_VERSION_IC0,
+                FunctionSignature {
+                    param_types: vec![ValType::I64, ValType::I64],
+                    return_type: vec![],
+                },
+            )],
+        ),
+        (
             "canister_cycle_balance",
             vec![(
                 API_VERSION_IC0,
@@ -472,6 +591,16 @@ fn get_valid_system_apis() -> HashMap<String, HashMap<String, FunctionSignature>
             )],
         ),
         (
+            "certified_data_set_64",
+            vec![(
+                API_VERSION_IC0,
+                FunctionSignature {
+                    param_types: vec![ValType::I64, ValType::I64],
+                    return_type: vec![],
+                },
+            )],
+        ),
+        (
             "data_certificate_present",
             vec![(
                 API_VERSION_IC0,
@@ -497,6 +626,16 @@ fn get_valid_system_apis() -> HashMap<String, HashMap<String, FunctionSignature>
                 API_VERSION_IC0,
                 FunctionSignature {
                     param_types: vec![ValType::I32, ValType::I32, ValType::I32],
+                    return_type: vec![],
+                },
+            )],
+        ),
+        (
+            "data_certificate_copy_64",
+            vec![(
+                API_VERSION_IC0,
+                FunctionSignature {
+                    param_types: vec![ValType::I64, ValType::I64, ValType::I64],
                     return_type: vec![],
                 },
             )],
@@ -542,11 +681,31 @@ fn get_valid_system_apis() -> HashMap<String, HashMap<String, FunctionSignature>
             )],
         ),
         (
+            "canister_cycle_balance128_64",
+            vec![(
+                API_VERSION_IC0,
+                FunctionSignature {
+                    param_types: vec![ValType::I64],
+                    return_type: vec![],
+                },
+            )],
+        ),
+        (
             "msg_cycles_available128",
             vec![(
                 API_VERSION_IC0,
                 FunctionSignature {
                     param_types: vec![ValType::I32],
+                    return_type: vec![],
+                },
+            )],
+        ),
+        (
+            "msg_cycles_available128_64",
+            vec![(
+                API_VERSION_IC0,
+                FunctionSignature {
+                    param_types: vec![ValType::I64],
                     return_type: vec![],
                 },
             )],
@@ -562,6 +721,16 @@ fn get_valid_system_apis() -> HashMap<String, HashMap<String, FunctionSignature>
             )],
         ),
         (
+            "msg_cycles_refunded128_64",
+            vec![(
+                API_VERSION_IC0,
+                FunctionSignature {
+                    param_types: vec![ValType::I64],
+                    return_type: vec![],
+                },
+            )],
+        ),
+        (
             "msg_cycles_accept128",
             vec![(
                 API_VERSION_IC0,
@@ -572,11 +741,31 @@ fn get_valid_system_apis() -> HashMap<String, HashMap<String, FunctionSignature>
             )],
         ),
         (
+            "msg_cycles_accept128_64",
+            vec![(
+                API_VERSION_IC0,
+                FunctionSignature {
+                    param_types: vec![ValType::I64, ValType::I64, ValType::I64],
+                    return_type: vec![],
+                },
+            )],
+        ),
+        (
             "is_controller",
             vec![(
                 API_VERSION_IC0,
                 FunctionSignature {
                     param_types: vec![ValType::I32, ValType::I32],
+                    return_type: vec![ValType::I32],
+                },
+            )],
+        ),
+        (
+            "is_controller_64",
+            vec![(
+                API_VERSION_IC0,
+                FunctionSignature {
+                    param_types: vec![ValType::I64, ValType::I64],
                     return_type: vec![ValType::I32],
                 },
             )],

--- a/rs/embedders/src/wasm_utils/validation.rs
+++ b/rs/embedders/src/wasm_utils/validation.rs
@@ -923,7 +923,7 @@ fn validate_data_section(module: &Module) -> Result<(), WasmValidationError> {
                 memory_index: _,
                 offset_expr,
             } => match offset_expr {
-                Operator::I32Const { .. } => Ok(()),
+                Operator::I64Const { .. } => Ok(()),
                 _ => Err(WasmValidationError::InvalidDataSection(format!(
                     "Invalid offset expression in data segment: {:?}",
                     offset_expr
@@ -1324,6 +1324,8 @@ pub fn ensure_determinism(config: &mut Config) {
 fn can_compile(wasm: &BinaryEncodedWasm) -> Result<(), WasmValidationError> {
     let mut config = wasmtime::Config::default();
     ensure_determinism(&mut config);
+    // Support 64-bit main memory.
+    config.wasm_memory64(true);
     let engine = wasmtime::Engine::new(&config).map_err(|_| {
         WasmValidationError::WasmtimeValidation(String::from("Failed to initialize Wasm engine"))
     })?;

--- a/rs/embedders/src/wasmtime_embedder.rs
+++ b/rs/embedders/src/wasmtime_embedder.rs
@@ -17,7 +17,7 @@ use wasmtime::{
 };
 
 pub use host_memory::WasmtimeMemoryCreator;
-use ic_config::embedders::MeteringType;
+use ic_config::embedders::{MeteringType, STABLE_MEMORY_ACCESSED_PAGE_LIMIT};
 use ic_config::{embedders::Config as EmbeddersConfig, flag_status::FlagStatus};
 use ic_interfaces::execution_environment::{
     HypervisorError, HypervisorResult, InstanceStats, SystemApi, TrapCode,
@@ -48,6 +48,10 @@ use self::host_memory::{MemoryPageSize, MemoryStart};
 
 #[cfg(test)]
 mod wasmtime_embedder_tests;
+
+/// Used for 64-bit main memory support:
+/// Limit for the number of pages accessed in a single message.
+pub const MAIN_MEMORY_PAGE_ACCESS_LIMIT: u64 = STABLE_MEMORY_ACCESSED_PAGE_LIMIT;
 
 const BAD_SIGNATURE_MESSAGE: &str = "function invocation does not match its signature";
 pub(crate) const WASM_HEAP_MEMORY_NAME: &str = "memory";
@@ -100,6 +104,10 @@ fn trap_code_to_hypervisor_error(trap: wasmtime::Trap) -> HypervisorError {
             HypervisorError::Trapped(TrapCode::IntegerDivByZero)
         }
         wasmtime::Trap::UnreachableCodeReached => HypervisorError::Trapped(TrapCode::Unreachable),
+        wasmtime::Trap::Interrupt => HypervisorError::MemoryAccessLimitExceeded(
+            format!("Exceeded the limit for the number of modified pages in the main memory in a single message execution: limit: {} KB.",
+                MAIN_MEMORY_PAGE_ACCESS_LIMIT * PAGE_SIZE as u64 / 1024),
+            ),
         _ => {
             // The `wasmtime::TrapCode` enum is marked as #[non_exhaustive]
             // so we have to use the wildcard matching here.
@@ -194,6 +202,8 @@ impl WasmtimeEmbedder {
     pub fn initial_wasmtime_config(embedder_config: &EmbeddersConfig) -> wasmtime::Config {
         let mut config = wasmtime::Config::default();
         config.cranelift_opt_level(OptLevel::None);
+        // The epoch mechanism is used for limiting the number of page accesses in 64-bit main memory support.
+        config.epoch_interruption(true);
         ensure_determinism(&mut config);
         disable_unused_features(&mut config);
         if embedder_config.feature_flags.write_barrier == FlagStatus::Enabled
@@ -440,7 +450,8 @@ impl WasmtimeEmbedder {
                 self.instantiate_memory(memory_info, &instance, store, &mut memories, canister_id)?;
         }
 
-        let memory_trackers = sigsegv_memory_tracker(memories, &mut store, self.log.clone());
+        let memory_trackers =
+            sigsegv_memory_tracker(cache.clone(), memories, &mut store, self.log.clone());
 
         let signal_stack = WasmtimeSignalStack::new();
         Ok(WasmtimeInstance {
@@ -596,6 +607,7 @@ pub struct MemorySigSegvInfo {
 }
 
 fn sigsegv_memory_tracker<S>(
+    cache: EmbedderCache,
     memories: HashMap<CanisterMemoryType, MemorySigSegvInfo>,
     store: &mut wasmtime::Store<S>,
     log: ReplicaLogger,
@@ -638,7 +650,9 @@ fn sigsegv_memory_tracker<S>(
         tracked_memories.push((sigsegv_memory_tracker, current_memory_size_in_pages));
     }
 
-    let handler = crate::signal_handler::sigsegv_memory_tracker_handler(tracked_memories);
+    // The epoch mechanism is used for limiting the number of page accesses in 64-bit main memory support.
+    store.set_epoch_deadline(1);
+    let handler = crate::signal_handler::sigsegv_memory_tracker_handler(cache, tracked_memories);
     // http://man7.org/linux/man-pages/man7/signal-safety.7.html
     unsafe {
         store.set_signal_handler(handler);

--- a/rs/embedders/src/wasmtime_embedder.rs
+++ b/rs/embedders/src/wasmtime_embedder.rs
@@ -201,9 +201,8 @@ impl WasmtimeEmbedder {
         {
             config.wasm_multi_memory(true);
         }
-        if embedder_config.feature_flags.wasm_native_stable_memory == FlagStatus::Enabled {
-            config.wasm_memory64(true);
-        }
+        // Enable 64-bit main memory
+        config.wasm_memory64(true);
         config
             // The maximum size in bytes where a linear memory is considered
             // static. Setting this to maximum Wasm memory size will guarantee

--- a/rs/embedders/src/wasmtime_embedder/system_api.rs
+++ b/rs/embedders/src/wasmtime_embedder/system_api.rs
@@ -2095,6 +2095,25 @@ pub(crate) fn syscalls<S: SystemApi>(
     linker
         .func_wrap("__", "update_available_memory", {
             move |mut caller: Caller<'_, StoreData<S>>,
+                  native_memory_grow_res: i32,
+                  additional_elements: i32,
+                  element_size: i32| {
+                with_system_api(&mut caller, |s| {
+                    s.update_available_memory(
+                        native_memory_grow_res as i64,
+                        additional_elements as u32 as u64,
+                        element_size as u32 as u64,
+                    )
+                })
+                .map(|()| native_memory_grow_res)
+                .map_err(|e| process_err(&mut caller, e))
+            }
+        })
+        .unwrap();
+
+    linker
+        .func_wrap("__", "update_available_memory_64", {
+            move |mut caller: Caller<'_, StoreData<S>>,
                   native_memory_grow_res: i64,
                   additional_elements: i64,
                   element_size: i32| {

--- a/rs/embedders/src/wasmtime_embedder/system_api.rs
+++ b/rs/embedders/src/wasmtime_embedder/system_api.rs
@@ -158,7 +158,7 @@ fn charge_for_system_api_call<S: SystemApi>(
     canister_id: CanisterId,
     caller: &mut Caller<'_, StoreData<S>>,
     system_api_overhead: NumInstructions,
-    num_bytes: u32,
+    num_bytes: u64,
     complexity: ExecutionComplexity,
     dirty_page_cost: NumInstructions,
     stable_memory_dirty_page_limit: NumPages,
@@ -173,7 +173,7 @@ fn charge_for_system_api_call<S: SystemApi>(
     let num_instructions_from_bytes = caller
         .data()
         .system_api
-        .get_num_instructions_from_bytes(NumBytes::from(num_bytes as u64));
+        .get_num_instructions_from_bytes(NumBytes::from(num_bytes));
     let (num_instructions1, overflow1) = num_instructions_from_bytes
         .get()
         .overflowing_add(dirty_page_cost.get());
@@ -418,7 +418,7 @@ pub(crate) fn syscalls<S: SystemApi>(
                     canister_id,
                     &mut caller,
                     system_api::complexity_overhead!(MSG_CALLER_COPY, metering_type),
-                    size as u32,
+                    size as u64,
                     ExecutionComplexity {
                         cpu: system_api_complexity::cpu::MSG_CALLER_COPY,
                         ..Default::default()
@@ -431,6 +431,40 @@ pub(crate) fn syscalls<S: SystemApi>(
                 })?;
                 if feature_flags.write_barrier == FlagStatus::Enabled {
                     mark_writes_on_bytemap(&mut caller, dst as u32 as usize, size as u32 as usize)
+                } else {
+                    Ok(())
+                }
+            }
+        })
+        .unwrap();
+
+    linker
+        .func_wrap("ic0", "msg_caller_copy_64", {
+            let log = log.clone();
+            move |mut caller: Caller<'_, StoreData<S>>, dst: i64, offset: i64, size: i64| {
+                charge_for_system_api_call(
+                    &log,
+                    canister_id,
+                    &mut caller,
+                    system_api::complexity_overhead!(MSG_CALLER_COPY, metering_type),
+                    size as u64,
+                    ExecutionComplexity {
+                        cpu: system_api_complexity::cpu::MSG_CALLER_COPY,
+                        ..Default::default()
+                    },
+                    NumInstructions::from(0),
+                    stable_memory_dirty_page_limit,
+                )?;
+                with_memory_and_system_api(&mut caller, |system_api, memory| {
+                    system_api.ic0_msg_caller_copy_64(
+                        dst as u64,
+                        offset as u64,
+                        size as u64,
+                        memory,
+                    )
+                })?;
+                if feature_flags.write_barrier == FlagStatus::Enabled {
+                    mark_writes_on_bytemap(&mut caller, dst as u64 as usize, size as u32 as usize)
                 } else {
                     Ok(())
                 }
@@ -503,7 +537,7 @@ pub(crate) fn syscalls<S: SystemApi>(
                     canister_id,
                     &mut caller,
                     system_api::complexity_overhead!(MSG_ARG_DATA_COPY, metering_type),
-                    size as u32,
+                    size as u64,
                     ExecutionComplexity {
                         cpu: system_api_complexity::cpu::MSG_ARG_DATA_COPY,
                         ..Default::default()
@@ -516,6 +550,35 @@ pub(crate) fn syscalls<S: SystemApi>(
                 })?;
                 if feature_flags.write_barrier == FlagStatus::Enabled {
                     mark_writes_on_bytemap(&mut caller, dst as u32 as usize, size as u32 as usize)
+                } else {
+                    Ok(())
+                }
+            }
+        })
+        .unwrap();
+
+    linker
+        .func_wrap("ic0", "msg_arg_data_copy_64", {
+            let log = log.clone();
+            move |mut caller: Caller<'_, StoreData<S>>, dst: i64, offset: i64, size: i64| {
+                charge_for_system_api_call(
+                    &log,
+                    canister_id,
+                    &mut caller,
+                    system_api::complexity_overhead!(MSG_ARG_DATA_COPY, metering_type),
+                    size as u64,
+                    ExecutionComplexity {
+                        cpu: system_api_complexity::cpu::MSG_ARG_DATA_COPY,
+                        ..Default::default()
+                    },
+                    NumInstructions::from(0),
+                    stable_memory_dirty_page_limit,
+                )?;
+                with_memory_and_system_api(&mut caller, |system_api, mem| {
+                    system_api.ic0_msg_arg_data_copy_64(dst as u64, offset as u64, size as u64, mem)
+                })?;
+                if feature_flags.write_barrier == FlagStatus::Enabled {
+                    mark_writes_on_bytemap(&mut caller, dst as u64 as usize, size as u64 as usize)
                 } else {
                     Ok(())
                 }
@@ -560,7 +623,7 @@ pub(crate) fn syscalls<S: SystemApi>(
                     canister_id,
                     &mut caller,
                     system_api::complexity_overhead!(MSG_METHOD_NAME_COPY, metering_type),
-                    size as u32,
+                    size as u64,
                     ExecutionComplexity {
                         cpu: system_api_complexity::cpu::MSG_METHOD_NAME_COPY,
                         ..Default::default()
@@ -578,6 +641,40 @@ pub(crate) fn syscalls<S: SystemApi>(
                 })?;
                 if feature_flags.write_barrier == FlagStatus::Enabled {
                     mark_writes_on_bytemap(&mut caller, dst as u32 as usize, size as u32 as usize)
+                } else {
+                    Ok(())
+                }
+            }
+        })
+        .unwrap();
+
+    linker
+        .func_wrap("ic0", "msg_method_name_copy_64", {
+            let log = log.clone();
+            move |mut caller: Caller<'_, StoreData<S>>, dst: i64, offset: i64, size: i64| {
+                charge_for_system_api_call(
+                    &log,
+                    canister_id,
+                    &mut caller,
+                    system_api::complexity_overhead!(MSG_METHOD_NAME_COPY, metering_type),
+                    size as u64,
+                    ExecutionComplexity {
+                        cpu: system_api_complexity::cpu::MSG_METHOD_NAME_COPY,
+                        ..Default::default()
+                    },
+                    NumInstructions::from(0),
+                    stable_memory_dirty_page_limit,
+                )?;
+                with_memory_and_system_api(&mut caller, |system_api, memory| {
+                    system_api.ic0_msg_method_name_copy_64(
+                        dst as u64,
+                        offset as u64,
+                        size as u64,
+                        memory,
+                    )
+                })?;
+                if feature_flags.write_barrier == FlagStatus::Enabled {
+                    mark_writes_on_bytemap(&mut caller, dst as u64 as usize, size as u64 as usize)
                 } else {
                     Ok(())
                 }
@@ -617,7 +714,7 @@ pub(crate) fn syscalls<S: SystemApi>(
                     canister_id,
                     &mut caller,
                     system_api::complexity_overhead!(MSG_REPLY_DATA_APPEND, metering_type),
-                    size as u32,
+                    size as u64,
                     ExecutionComplexity {
                         cpu: system_api_complexity::cpu::MSG_REPLY_DATA_APPEND,
                         ..Default::default()
@@ -627,6 +724,30 @@ pub(crate) fn syscalls<S: SystemApi>(
                 )?;
                 with_memory_and_system_api(&mut caller, |system_api, memory| {
                     system_api.ic0_msg_reply_data_append(src as u32, size as u32, memory)
+                })
+            }
+        })
+        .unwrap();
+
+    linker
+        .func_wrap("ic0", "msg_reply_data_append_64", {
+            let log = log.clone();
+            move |mut caller: Caller<'_, StoreData<S>>, src: i64, size: i64| {
+                charge_for_system_api_call(
+                    &log,
+                    canister_id,
+                    &mut caller,
+                    system_api::complexity_overhead!(MSG_REPLY_DATA_APPEND, metering_type),
+                    size as u64,
+                    ExecutionComplexity {
+                        cpu: system_api_complexity::cpu::MSG_REPLY_DATA_APPEND,
+                        ..Default::default()
+                    },
+                    NumInstructions::from(0),
+                    stable_memory_dirty_page_limit,
+                )?;
+                with_memory_and_system_api(&mut caller, |system_api, memory| {
+                    system_api.ic0_msg_reply_data_append_64(src as u64, size as u64, memory)
                 })
             }
         })
@@ -687,7 +808,7 @@ pub(crate) fn syscalls<S: SystemApi>(
                     canister_id,
                     &mut caller,
                     system_api::complexity_overhead!(MSG_REJECT, metering_type),
-                    size as u32,
+                    size as u64,
                     ExecutionComplexity {
                         cpu: system_api_complexity::cpu::MSG_REJECT,
                         ..Default::default()
@@ -697,6 +818,30 @@ pub(crate) fn syscalls<S: SystemApi>(
                 )?;
                 with_memory_and_system_api(&mut caller, |system_api, memory| {
                     system_api.ic0_msg_reject(src as u32, size as u32, memory)
+                })
+            }
+        })
+        .unwrap();
+
+    linker
+        .func_wrap("ic0", "msg_reject_64", {
+            let log = log.clone();
+            move |mut caller: Caller<'_, StoreData<S>>, src: i64, size: i64| {
+                charge_for_system_api_call(
+                    &log,
+                    canister_id,
+                    &mut caller,
+                    system_api::complexity_overhead!(MSG_REJECT, metering_type),
+                    size as u64,
+                    ExecutionComplexity {
+                        cpu: system_api_complexity::cpu::MSG_REJECT,
+                        ..Default::default()
+                    },
+                    NumInstructions::from(0),
+                    stable_memory_dirty_page_limit,
+                )?;
+                with_memory_and_system_api(&mut caller, |system_api, memory| {
+                    system_api.ic0_msg_reject_64(src as u64, size as u64, memory)
                 })
             }
         })
@@ -739,7 +884,7 @@ pub(crate) fn syscalls<S: SystemApi>(
                     canister_id,
                     &mut caller,
                     system_api::complexity_overhead!(MSG_REJECT_MSG_COPY, metering_type),
-                    size as u32,
+                    size as u64,
                     ExecutionComplexity {
                         cpu: system_api_complexity::cpu::MSG_REJECT_MSG_COPY,
                         ..Default::default()
@@ -757,6 +902,40 @@ pub(crate) fn syscalls<S: SystemApi>(
                 })?;
                 if feature_flags.write_barrier == FlagStatus::Enabled {
                     mark_writes_on_bytemap(&mut caller, dst as u32 as usize, size as u32 as usize)
+                } else {
+                    Ok(())
+                }
+            }
+        })
+        .unwrap();
+
+    linker
+        .func_wrap("ic0", "msg_reject_msg_copy_64", {
+            let log = log.clone();
+            move |mut caller: Caller<'_, StoreData<S>>, dst: i64, offset: i64, size: i64| {
+                charge_for_system_api_call(
+                    &log,
+                    canister_id,
+                    &mut caller,
+                    system_api::complexity_overhead!(MSG_REJECT_MSG_COPY, metering_type),
+                    size as u64,
+                    ExecutionComplexity {
+                        cpu: system_api_complexity::cpu::MSG_REJECT_MSG_COPY,
+                        ..Default::default()
+                    },
+                    NumInstructions::from(0),
+                    stable_memory_dirty_page_limit,
+                )?;
+                with_memory_and_system_api(&mut caller, |system_api, memory| {
+                    system_api.ic0_msg_reject_msg_copy_64(
+                        dst as u64,
+                        offset as u64,
+                        size as u64,
+                        memory,
+                    )
+                })?;
+                if feature_flags.write_barrier == FlagStatus::Enabled {
+                    mark_writes_on_bytemap(&mut caller, dst as u64 as usize, size as u64 as usize)
                 } else {
                     Ok(())
                 }
@@ -801,7 +980,7 @@ pub(crate) fn syscalls<S: SystemApi>(
                     canister_id,
                     &mut caller,
                     system_api::complexity_overhead!(CANISTER_SELF_COPY, metering_type),
-                    size as u32,
+                    size as u64,
                     ExecutionComplexity {
                         cpu: system_api_complexity::cpu::CANISTER_SELF_COPY,
                         ..Default::default()
@@ -827,6 +1006,40 @@ pub(crate) fn syscalls<S: SystemApi>(
         .unwrap();
 
     linker
+        .func_wrap("ic0", "canister_self_copy_64", {
+            let log = log.clone();
+            move |mut caller: Caller<'_, StoreData<S>>, dst: i64, offset: i64, size: i64| {
+                charge_for_system_api_call(
+                    &log,
+                    canister_id,
+                    &mut caller,
+                    system_api::complexity_overhead!(CANISTER_SELF_COPY, metering_type),
+                    size as u64,
+                    ExecutionComplexity {
+                        cpu: system_api_complexity::cpu::CANISTER_SELF_COPY,
+                        ..Default::default()
+                    },
+                    NumInstructions::from(0),
+                    stable_memory_dirty_page_limit,
+                )?;
+                with_memory_and_system_api(&mut caller, |system_api, memory| {
+                    system_api.ic0_canister_self_copy_64(
+                        dst as u64,
+                        offset as u64,
+                        size as u64,
+                        memory,
+                    )
+                })?;
+                if feature_flags.write_barrier == FlagStatus::Enabled {
+                    mark_writes_on_bytemap(&mut caller, dst as u64 as usize, size as u64 as usize)
+                } else {
+                    Ok(())
+                }
+            }
+        })
+        .unwrap();
+
+    linker
         .func_wrap("ic0", "debug_print", {
             let log = log.clone();
             move |mut caller: Caller<'_, StoreData<S>>, offset: i32, length: i32| {
@@ -835,7 +1048,7 @@ pub(crate) fn syscalls<S: SystemApi>(
                     canister_id,
                     &mut caller,
                     system_api::complexity_overhead!(DEBUG_PRINT, metering_type),
-                    length as u32,
+                    length as u64,
                     ExecutionComplexity {
                         cpu: system_api_complexity::cpu::DEBUG_PRINT,
                         ..Default::default()
@@ -863,6 +1076,42 @@ pub(crate) fn syscalls<S: SystemApi>(
         .unwrap();
 
     linker
+        .func_wrap("ic0", "debug_print_64", {
+            let log = log.clone();
+            move |mut caller: Caller<'_, StoreData<S>>, offset: i64, length: i64| {
+                charge_for_system_api_call(
+                    &log,
+                    canister_id,
+                    &mut caller,
+                    system_api::complexity_overhead!(DEBUG_PRINT, metering_type),
+                    length as u64,
+                    ExecutionComplexity {
+                        cpu: system_api_complexity::cpu::DEBUG_PRINT,
+                        ..Default::default()
+                    },
+                    NumInstructions::from(0),
+                    stable_memory_dirty_page_limit,
+                )?;
+                match (
+                    caller.data().system_api.subnet_type(),
+                    feature_flags.rate_limiting_of_debug_prints,
+                ) {
+                    // Debug print is a no-op on non-system subnets with rate limiting.
+                    (SubnetType::Application, FlagStatus::Enabled) => Ok(()),
+                    (SubnetType::VerifiedApplication, FlagStatus::Enabled) => Ok(()),
+                    // If rate limiting is disabled or the subnet is a system subnet, then
+                    // debug print produces output.
+                    (_, FlagStatus::Disabled) | (SubnetType::System, FlagStatus::Enabled) => {
+                        with_memory_and_system_api(&mut caller, |system_api, memory| {
+                            system_api.ic0_debug_print_64(offset as u64, length as u64, memory)
+                        })
+                    }
+                }
+            }
+        })
+        .unwrap();
+
+    linker
         .func_wrap("ic0", "trap", {
             let log = log.clone();
             move |mut caller: Caller<'_, StoreData<S>>, offset: i32, length: i32| -> Result<(), _> {
@@ -871,7 +1120,7 @@ pub(crate) fn syscalls<S: SystemApi>(
                     canister_id,
                     &mut caller,
                     system_api::complexity_overhead!(TRAP, metering_type),
-                    length as u32,
+                    length as u64,
                     ExecutionComplexity {
                         cpu: system_api_complexity::cpu::TRAP,
                         ..Default::default()
@@ -881,6 +1130,30 @@ pub(crate) fn syscalls<S: SystemApi>(
                 )?;
                 with_memory_and_system_api(&mut caller, |system_api, memory| {
                     system_api.ic0_trap(offset as u32, length as u32, memory)
+                })
+            }
+        })
+        .unwrap();
+
+    linker
+        .func_wrap("ic0", "trap_64", {
+            let log = log.clone();
+            move |mut caller: Caller<'_, StoreData<S>>, offset: i64, length: i64| -> Result<(), _> {
+                charge_for_system_api_call(
+                    &log,
+                    canister_id,
+                    &mut caller,
+                    system_api::complexity_overhead!(TRAP, metering_type),
+                    length as u64,
+                    ExecutionComplexity {
+                        cpu: system_api_complexity::cpu::TRAP,
+                        ..Default::default()
+                    },
+                    NumInstructions::from(0),
+                    stable_memory_dirty_page_limit,
+                )?;
+                with_memory_and_system_api(&mut caller, |system_api, memory| {
+                    system_api.ic0_trap_64(offset as u64, length as u64, memory)
                 })
             }
         })
@@ -903,7 +1176,7 @@ pub(crate) fn syscalls<S: SystemApi>(
                     canister_id,
                     &mut caller,
                     system_api::complexity_overhead!(CALL_NEW, metering_type),
-                    (callee_size as u32).saturating_add(name_len as u32),
+                    (callee_size as u64).saturating_add(name_len as u64),
                     ExecutionComplexity {
                         cpu: system_api_complexity::cpu::CALL_NEW,
                         ..Default::default()
@@ -929,6 +1202,48 @@ pub(crate) fn syscalls<S: SystemApi>(
         .unwrap();
 
     linker
+        .func_wrap("ic0", "call_new_64", {
+            let log = log.clone();
+            move |mut caller: Caller<'_, StoreData<S>>,
+                  callee_src: i64,
+                  callee_size: i64,
+                  name_src: i64,
+                  name_len: i64,
+                  reply_fun: i32,
+                  reply_env: i32,
+                  reject_fun: i32,
+                  reject_env: i32| {
+                charge_for_system_api_call(
+                    &log,
+                    canister_id,
+                    &mut caller,
+                    system_api::complexity_overhead!(CALL_NEW, metering_type),
+                    (callee_size as u64).saturating_add(name_len as u64),
+                    ExecutionComplexity {
+                        cpu: system_api_complexity::cpu::CALL_NEW,
+                        ..Default::default()
+                    },
+                    NumInstructions::from(0),
+                    stable_memory_dirty_page_limit,
+                )?;
+                with_memory_and_system_api(&mut caller, |system_api, memory| {
+                    system_api.ic0_call_new_64(
+                        callee_src as u64,
+                        callee_size as u64,
+                        name_src as u64,
+                        name_len as u64,
+                        reply_fun as u32,
+                        reply_env as u32,
+                        reject_fun as u32,
+                        reject_env as u32,
+                        memory,
+                    )
+                })
+            }
+        })
+        .unwrap();
+
+    linker
         .func_wrap("ic0", "call_data_append", {
             let log = log.clone();
             move |mut caller: Caller<'_, StoreData<S>>, src: i32, size: i32| {
@@ -937,7 +1252,7 @@ pub(crate) fn syscalls<S: SystemApi>(
                     canister_id,
                     &mut caller,
                     system_api::complexity_overhead!(CALL_DATA_APPEND, metering_type),
-                    size as u32,
+                    size as u64,
                     ExecutionComplexity {
                         cpu: system_api_complexity::cpu::CALL_DATA_APPEND,
                         ..Default::default()
@@ -947,6 +1262,30 @@ pub(crate) fn syscalls<S: SystemApi>(
                 )?;
                 with_memory_and_system_api(&mut caller, |system_api, memory| {
                     system_api.ic0_call_data_append(src as u32, size as u32, memory)
+                })
+            }
+        })
+        .unwrap();
+
+    linker
+        .func_wrap("ic0", "call_data_append_64", {
+            let log = log.clone();
+            move |mut caller: Caller<'_, StoreData<S>>, src: i64, size: i64| {
+                charge_for_system_api_call(
+                    &log,
+                    canister_id,
+                    &mut caller,
+                    system_api::complexity_overhead!(CALL_DATA_APPEND, metering_type),
+                    size as u64,
+                    ExecutionComplexity {
+                        cpu: system_api_complexity::cpu::CALL_DATA_APPEND,
+                        ..Default::default()
+                    },
+                    NumInstructions::from(0),
+                    stable_memory_dirty_page_limit,
+                )?;
+                with_memory_and_system_api(&mut caller, |system_api, memory| {
+                    system_api.ic0_call_data_append_64(src as u64, size as u64, memory)
                 })
             }
         })
@@ -1111,7 +1450,7 @@ pub(crate) fn syscalls<S: SystemApi>(
                     canister_id,
                     &mut caller,
                     system_api::complexity_overhead!(STABLE_READ, metering_type),
-                    size as u32,
+                    size as u64,
                     ExecutionComplexity {
                         cpu: system_api_complexity::cpu::STABLE_READ,
                         ..Default::default()
@@ -1145,7 +1484,7 @@ pub(crate) fn syscalls<S: SystemApi>(
                     canister_id,
                     &mut caller,
                     system_api::complexity_overhead!(STABLE_WRITE, metering_type),
-                    size,
+                    size as u64,
                     ExecutionComplexity {
                         cpu: system_api_complexity::cpu::STABLE_WRITE,
                         stable_dirty_pages,
@@ -1242,7 +1581,7 @@ pub(crate) fn syscalls<S: SystemApi>(
                     canister_id,
                     &mut caller,
                     system_api::complexity_overhead!(STABLE64_READ, metering_type),
-                    size as u32,
+                    size as u64,
                     ExecutionComplexity {
                         cpu: system_api_complexity::cpu::STABLE64_READ,
                         ..Default::default()
@@ -1276,7 +1615,7 @@ pub(crate) fn syscalls<S: SystemApi>(
                     canister_id,
                     &mut caller,
                     system_api::complexity_overhead!(STABLE64_WRITE, metering_type),
-                    size as u32,
+                    size as u64,
                     ExecutionComplexity {
                         cpu: system_api_complexity::cpu::STABLE64_WRITE,
                         stable_dirty_pages,
@@ -1444,6 +1783,35 @@ pub(crate) fn syscalls<S: SystemApi>(
         .unwrap();
 
     linker
+        .func_wrap("ic0", "canister_cycle_balance128_64", {
+            let log = log.clone();
+            move |mut caller: Caller<'_, StoreData<S>>, dst: u64| {
+                charge_for_system_api_call(
+                    &log,
+                    canister_id,
+                    &mut caller,
+                    system_api::complexity_overhead!(CANISTER_CYCLE_BALANCE128, metering_type),
+                    0,
+                    ExecutionComplexity {
+                        cpu: system_api_complexity::cpu::CANISTER_CYCLE_BALANCE128,
+                        ..Default::default()
+                    },
+                    NumInstructions::from(0),
+                    stable_memory_dirty_page_limit,
+                )?;
+                with_memory_and_system_api(&mut caller, |system_api, memory| {
+                    system_api.ic0_canister_cycle_balance128_64(dst, memory)
+                })?;
+                if feature_flags.write_barrier == FlagStatus::Enabled {
+                    mark_writes_on_bytemap(&mut caller, dst as usize, 16)
+                } else {
+                    Ok(())
+                }
+            }
+        })
+        .unwrap();
+
+    linker
         .func_wrap("ic0", "msg_cycles_available", {
             let log = log.clone();
             move |mut caller: Caller<'_, StoreData<S>>| {
@@ -1490,6 +1858,35 @@ pub(crate) fn syscalls<S: SystemApi>(
                 )?;
                 with_memory_and_system_api(&mut caller, |system_api, memory| {
                     system_api.ic0_msg_cycles_available128(dst, memory)
+                })?;
+                if feature_flags.write_barrier == FlagStatus::Enabled {
+                    mark_writes_on_bytemap(&mut caller, dst as usize, 16)
+                } else {
+                    Ok(())
+                }
+            }
+        })
+        .unwrap();
+
+    linker
+        .func_wrap("ic0", "msg_cycles_available128_64", {
+            let log = log.clone();
+            move |mut caller: Caller<'_, StoreData<S>>, dst: u64| {
+                charge_for_system_api_call(
+                    &log,
+                    canister_id,
+                    &mut caller,
+                    system_api::complexity_overhead!(MSG_CYCLES_AVAILABLE128, metering_type),
+                    0,
+                    ExecutionComplexity {
+                        cpu: system_api_complexity::cpu::MSG_CYCLES_AVAILABLE128,
+                        ..Default::default()
+                    },
+                    NumInstructions::from(0),
+                    stable_memory_dirty_page_limit,
+                )?;
+                with_memory_and_system_api(&mut caller, |system_api, memory| {
+                    system_api.ic0_msg_cycles_available128_64(dst, memory)
                 })?;
                 if feature_flags.write_barrier == FlagStatus::Enabled {
                     mark_writes_on_bytemap(&mut caller, dst as usize, 16)
@@ -1558,6 +1955,35 @@ pub(crate) fn syscalls<S: SystemApi>(
         .unwrap();
 
     linker
+        .func_wrap("ic0", "msg_cycles_refunded128_64", {
+            let log = log.clone();
+            move |mut caller: Caller<'_, StoreData<S>>, dst: u64| {
+                charge_for_system_api_call(
+                    &log,
+                    canister_id,
+                    &mut caller,
+                    system_api::complexity_overhead!(MSG_CYCLES_REFUNDED128, metering_type),
+                    0,
+                    ExecutionComplexity {
+                        cpu: system_api_complexity::cpu::MSG_CYCLES_REFUNDED128,
+                        ..Default::default()
+                    },
+                    NumInstructions::from(0),
+                    stable_memory_dirty_page_limit,
+                )?;
+                with_memory_and_system_api(&mut caller, |system_api, memory| {
+                    system_api.ic0_msg_cycles_refunded128_64(dst, memory)
+                })?;
+                if feature_flags.write_barrier == FlagStatus::Enabled {
+                    mark_writes_on_bytemap(&mut caller, dst as usize, 16)
+                } else {
+                    Ok(())
+                }
+            }
+        })
+        .unwrap();
+
+    linker
         .func_wrap("ic0", "msg_cycles_accept", {
             let log = log.clone();
             move |mut caller: Caller<'_, StoreData<S>>, amount: i64| {
@@ -1602,6 +2028,42 @@ pub(crate) fn syscalls<S: SystemApi>(
                 )?;
                 with_memory_and_system_api(&mut caller, |system_api, memory| {
                     system_api.ic0_msg_cycles_accept128(
+                        Cycles::from_parts(amount_high as u64, amount_low as u64),
+                        dst,
+                        memory,
+                    )
+                })?;
+                if feature_flags.write_barrier == FlagStatus::Enabled {
+                    mark_writes_on_bytemap(&mut caller, dst as usize, 16)
+                } else {
+                    Ok(())
+                }
+            }
+        })
+        .unwrap();
+
+    linker
+        .func_wrap("ic0", "msg_cycles_accept128_64", {
+            let log = log.clone();
+            move |mut caller: Caller<'_, StoreData<S>>,
+                  amount_high: i64,
+                  amount_low: i64,
+                  dst: u64| {
+                charge_for_system_api_call(
+                    &log,
+                    canister_id,
+                    &mut caller,
+                    system_api::complexity_overhead!(MSG_CYCLES_ACCEPT128, metering_type),
+                    0,
+                    ExecutionComplexity {
+                        cpu: system_api_complexity::cpu::MSG_CYCLES_ACCEPT128,
+                        ..Default::default()
+                    },
+                    NumInstructions::from(0),
+                    stable_memory_dirty_page_limit,
+                )?;
+                with_memory_and_system_api(&mut caller, |system_api, memory| {
+                    system_api.ic0_msg_cycles_accept128_64(
                         Cycles::from_parts(amount_high as u64, amount_low as u64),
                         dst,
                         memory,
@@ -1718,7 +2180,7 @@ pub(crate) fn syscalls<S: SystemApi>(
                     canister_id,
                     &mut caller,
                     system_api::complexity_overhead!(CERTIFIED_DATA_SET, metering_type),
-                    size,
+                    size as u64,
                     ExecutionComplexity {
                         cpu: system_api_complexity::cpu::CERTIFIED_DATA_SET,
                         ..Default::default()
@@ -1728,6 +2190,30 @@ pub(crate) fn syscalls<S: SystemApi>(
                 )?;
                 with_memory_and_system_api(&mut caller, |system_api, memory| {
                     system_api.ic0_certified_data_set(src, size, memory)
+                })
+            }
+        })
+        .unwrap();
+
+    linker
+        .func_wrap("ic0", "certified_data_set_64", {
+            let log = log.clone();
+            move |mut caller: Caller<'_, StoreData<S>>, src: u64, size: u64| {
+                charge_for_system_api_call(
+                    &log,
+                    canister_id,
+                    &mut caller,
+                    system_api::complexity_overhead!(CERTIFIED_DATA_SET, metering_type),
+                    size,
+                    ExecutionComplexity {
+                        cpu: system_api_complexity::cpu::CERTIFIED_DATA_SET,
+                        ..Default::default()
+                    },
+                    NumInstructions::from(0),
+                    stable_memory_dirty_page_limit,
+                )?;
+                with_memory_and_system_api(&mut caller, |system_api, memory| {
+                    system_api.ic0_certified_data_set_64(src, size, memory)
                 })
             }
         })
@@ -1788,7 +2274,7 @@ pub(crate) fn syscalls<S: SystemApi>(
                     canister_id,
                     &mut caller,
                     system_api::complexity_overhead!(IS_CONTROLLER, metering_type),
-                    size as u32,
+                    size as u64,
                     ExecutionComplexity {
                         cpu: system_api_complexity::cpu::IS_CONTROLLER,
                         ..Default::default()
@@ -1804,14 +2290,39 @@ pub(crate) fn syscalls<S: SystemApi>(
         .unwrap();
 
     linker
+        .func_wrap("ic0", "is_controller_64", {
+            let log = log.clone();
+            move |mut caller: Caller<'_, StoreData<S>>, src: i64, size: i64| {
+                charge_for_system_api_call(
+                    &log,
+                    canister_id,
+                    &mut caller,
+                    system_api::complexity_overhead!(IS_CONTROLLER, metering_type),
+                    size as u64,
+                    ExecutionComplexity {
+                        cpu: system_api_complexity::cpu::IS_CONTROLLER,
+                        ..Default::default()
+                    },
+                    NumInstructions::from(0),
+                    stable_memory_dirty_page_limit,
+                )?;
+                with_memory_and_system_api(&mut caller, |system_api, memory| {
+                    system_api.ic0_is_controller_64(src as u64, size as u64, memory)
+                })
+            }
+        })
+        .unwrap();
+
+    linker
         .func_wrap("ic0", "data_certificate_copy", {
+            let log = log.clone();
             move |mut caller: Caller<'_, StoreData<S>>, dst: u32, offset: u32, size: u32| {
                 charge_for_system_api_call(
                     &log,
                     canister_id,
                     &mut caller,
                     system_api::complexity_overhead!(DATA_CERTIFICATE_COPY, metering_type),
-                    size,
+                    size as u64,
                     ExecutionComplexity {
                         cpu: system_api_complexity::cpu::DATA_CERTIFICATE_COPY,
                         ..Default::default()
@@ -1821,6 +2332,34 @@ pub(crate) fn syscalls<S: SystemApi>(
                 )?;
                 with_memory_and_system_api(&mut caller, |system_api, memory| {
                     system_api.ic0_data_certificate_copy(dst, offset, size, memory)
+                })?;
+                if feature_flags.write_barrier == FlagStatus::Enabled {
+                    mark_writes_on_bytemap(&mut caller, dst as usize, size as usize)
+                } else {
+                    Ok(())
+                }
+            }
+        })
+        .unwrap();
+
+    linker
+        .func_wrap("ic0", "data_certificate_copy_64", {
+            move |mut caller: Caller<'_, StoreData<S>>, dst: u64, offset: u64, size: u64| {
+                charge_for_system_api_call(
+                    &log,
+                    canister_id,
+                    &mut caller,
+                    system_api::complexity_overhead!(DATA_CERTIFICATE_COPY, metering_type),
+                    size as u64,
+                    ExecutionComplexity {
+                        cpu: system_api_complexity::cpu::DATA_CERTIFICATE_COPY,
+                        ..Default::default()
+                    },
+                    NumInstructions::from(0),
+                    stable_memory_dirty_page_limit,
+                )?;
+                with_memory_and_system_api(&mut caller, |system_api, memory| {
+                    system_api.ic0_data_certificate_copy_64(dst, offset, size, memory)
                 })?;
                 if feature_flags.write_barrier == FlagStatus::Enabled {
                     mark_writes_on_bytemap(&mut caller, dst as usize, size as usize)

--- a/rs/embedders/src/wasmtime_embedder/system_api.rs
+++ b/rs/embedders/src/wasmtime_embedder/system_api.rs
@@ -409,31 +409,39 @@ pub(crate) fn syscalls<S: SystemApi>(
 
     let mut linker = Linker::new(store.engine());
 
+    let msg_caller_copy_64 = move |log: &ReplicaLogger,
+                                   mut caller: Caller<'_, StoreData<S>>,
+                                   dst: i64,
+                                   offset: i64,
+                                   size: i64| {
+        charge_for_system_api_call(
+            log,
+            canister_id,
+            &mut caller,
+            system_api::complexity_overhead!(MSG_CALLER_COPY, metering_type),
+            size as u64,
+            ExecutionComplexity {
+                cpu: system_api_complexity::cpu::MSG_CALLER_COPY,
+                ..Default::default()
+            },
+            NumInstructions::from(0),
+            stable_memory_dirty_page_limit,
+        )?;
+        with_memory_and_system_api(&mut caller, |system_api, memory| {
+            system_api.ic0_msg_caller_copy_64(dst as u64, offset as u64, size as u64, memory)
+        })?;
+        if feature_flags.write_barrier == FlagStatus::Enabled {
+            mark_writes_on_bytemap(&mut caller, dst as u64 as usize, size as u32 as usize)
+        } else {
+            Ok(())
+        }
+    };
+
     linker
         .func_wrap("ic0", "msg_caller_copy", {
             let log = log.clone();
-            move |mut caller: Caller<'_, StoreData<S>>, dst: i32, offset: i32, size: i32| {
-                charge_for_system_api_call(
-                    &log,
-                    canister_id,
-                    &mut caller,
-                    system_api::complexity_overhead!(MSG_CALLER_COPY, metering_type),
-                    size as u64,
-                    ExecutionComplexity {
-                        cpu: system_api_complexity::cpu::MSG_CALLER_COPY,
-                        ..Default::default()
-                    },
-                    NumInstructions::from(0),
-                    stable_memory_dirty_page_limit,
-                )?;
-                with_memory_and_system_api(&mut caller, |system_api, memory| {
-                    system_api.ic0_msg_caller_copy(dst as u32, offset as u32, size as u32, memory)
-                })?;
-                if feature_flags.write_barrier == FlagStatus::Enabled {
-                    mark_writes_on_bytemap(&mut caller, dst as u32 as usize, size as u32 as usize)
-                } else {
-                    Ok(())
-                }
+            move |caller: Caller<'_, StoreData<S>>, dst: i32, offset: i32, size: i32| {
+                msg_caller_copy_64(&log, caller, dst as i64, offset as i64, size as i64)
             }
         })
         .unwrap();
@@ -441,33 +449,8 @@ pub(crate) fn syscalls<S: SystemApi>(
     linker
         .func_wrap("ic0", "msg_caller_copy_64", {
             let log = log.clone();
-            move |mut caller: Caller<'_, StoreData<S>>, dst: i64, offset: i64, size: i64| {
-                charge_for_system_api_call(
-                    &log,
-                    canister_id,
-                    &mut caller,
-                    system_api::complexity_overhead!(MSG_CALLER_COPY, metering_type),
-                    size as u64,
-                    ExecutionComplexity {
-                        cpu: system_api_complexity::cpu::MSG_CALLER_COPY,
-                        ..Default::default()
-                    },
-                    NumInstructions::from(0),
-                    stable_memory_dirty_page_limit,
-                )?;
-                with_memory_and_system_api(&mut caller, |system_api, memory| {
-                    system_api.ic0_msg_caller_copy_64(
-                        dst as u64,
-                        offset as u64,
-                        size as u64,
-                        memory,
-                    )
-                })?;
-                if feature_flags.write_barrier == FlagStatus::Enabled {
-                    mark_writes_on_bytemap(&mut caller, dst as u64 as usize, size as u32 as usize)
-                } else {
-                    Ok(())
-                }
+            move |caller: Caller<'_, StoreData<S>>, dst: i64, offset: i64, size: i64| {
+                msg_caller_copy_64(&log, caller, dst, offset, size)
             }
         })
         .unwrap();
@@ -528,31 +511,39 @@ pub(crate) fn syscalls<S: SystemApi>(
         })
         .unwrap();
 
+    let msg_arg_data_copy_64 = move |log: &ReplicaLogger,
+                                     mut caller: Caller<'_, StoreData<S>>,
+                                     dst: i64,
+                                     offset: i64,
+                                     size: i64| {
+        charge_for_system_api_call(
+            log,
+            canister_id,
+            &mut caller,
+            system_api::complexity_overhead!(MSG_ARG_DATA_COPY, metering_type),
+            size as u64,
+            ExecutionComplexity {
+                cpu: system_api_complexity::cpu::MSG_ARG_DATA_COPY,
+                ..Default::default()
+            },
+            NumInstructions::from(0),
+            stable_memory_dirty_page_limit,
+        )?;
+        with_memory_and_system_api(&mut caller, |system_api, mem| {
+            system_api.ic0_msg_arg_data_copy_64(dst as u64, offset as u64, size as u64, mem)
+        })?;
+        if feature_flags.write_barrier == FlagStatus::Enabled {
+            mark_writes_on_bytemap(&mut caller, dst as u64 as usize, size as u64 as usize)
+        } else {
+            Ok(())
+        }
+    };
+
     linker
         .func_wrap("ic0", "msg_arg_data_copy", {
             let log = log.clone();
-            move |mut caller: Caller<'_, StoreData<S>>, dst: i32, offset: i32, size: i32| {
-                charge_for_system_api_call(
-                    &log,
-                    canister_id,
-                    &mut caller,
-                    system_api::complexity_overhead!(MSG_ARG_DATA_COPY, metering_type),
-                    size as u64,
-                    ExecutionComplexity {
-                        cpu: system_api_complexity::cpu::MSG_ARG_DATA_COPY,
-                        ..Default::default()
-                    },
-                    NumInstructions::from(0),
-                    stable_memory_dirty_page_limit,
-                )?;
-                with_memory_and_system_api(&mut caller, |system_api, mem| {
-                    system_api.ic0_msg_arg_data_copy(dst as u32, offset as u32, size as u32, mem)
-                })?;
-                if feature_flags.write_barrier == FlagStatus::Enabled {
-                    mark_writes_on_bytemap(&mut caller, dst as u32 as usize, size as u32 as usize)
-                } else {
-                    Ok(())
-                }
+            move |caller: Caller<'_, StoreData<S>>, dst: i32, offset: i32, size: i32| {
+                msg_arg_data_copy_64(&log, caller, dst as i64, offset as i64, size as i64)
             }
         })
         .unwrap();
@@ -560,28 +551,8 @@ pub(crate) fn syscalls<S: SystemApi>(
     linker
         .func_wrap("ic0", "msg_arg_data_copy_64", {
             let log = log.clone();
-            move |mut caller: Caller<'_, StoreData<S>>, dst: i64, offset: i64, size: i64| {
-                charge_for_system_api_call(
-                    &log,
-                    canister_id,
-                    &mut caller,
-                    system_api::complexity_overhead!(MSG_ARG_DATA_COPY, metering_type),
-                    size as u64,
-                    ExecutionComplexity {
-                        cpu: system_api_complexity::cpu::MSG_ARG_DATA_COPY,
-                        ..Default::default()
-                    },
-                    NumInstructions::from(0),
-                    stable_memory_dirty_page_limit,
-                )?;
-                with_memory_and_system_api(&mut caller, |system_api, mem| {
-                    system_api.ic0_msg_arg_data_copy_64(dst as u64, offset as u64, size as u64, mem)
-                })?;
-                if feature_flags.write_barrier == FlagStatus::Enabled {
-                    mark_writes_on_bytemap(&mut caller, dst as u64 as usize, size as u64 as usize)
-                } else {
-                    Ok(())
-                }
+            move |caller: Caller<'_, StoreData<S>>, dst: i64, offset: i64, size: i64| {
+                msg_arg_data_copy_64(&log, caller, dst, offset, size)
             }
         })
         .unwrap();
@@ -614,36 +585,39 @@ pub(crate) fn syscalls<S: SystemApi>(
         })
         .unwrap();
 
+    let msg_method_name_copy_64 = move |log: &ReplicaLogger,
+                                        mut caller: Caller<'_, StoreData<S>>,
+                                        dst: i64,
+                                        offset: i64,
+                                        size: i64| {
+        charge_for_system_api_call(
+            log,
+            canister_id,
+            &mut caller,
+            system_api::complexity_overhead!(MSG_METHOD_NAME_COPY, metering_type),
+            size as u64,
+            ExecutionComplexity {
+                cpu: system_api_complexity::cpu::MSG_METHOD_NAME_COPY,
+                ..Default::default()
+            },
+            NumInstructions::from(0),
+            stable_memory_dirty_page_limit,
+        )?;
+        with_memory_and_system_api(&mut caller, |system_api, memory| {
+            system_api.ic0_msg_method_name_copy_64(dst as u64, offset as u64, size as u64, memory)
+        })?;
+        if feature_flags.write_barrier == FlagStatus::Enabled {
+            mark_writes_on_bytemap(&mut caller, dst as u64 as usize, size as u64 as usize)
+        } else {
+            Ok(())
+        }
+    };
+
     linker
         .func_wrap("ic0", "msg_method_name_copy", {
             let log = log.clone();
-            move |mut caller: Caller<'_, StoreData<S>>, dst: i32, offset: i32, size: i32| {
-                charge_for_system_api_call(
-                    &log,
-                    canister_id,
-                    &mut caller,
-                    system_api::complexity_overhead!(MSG_METHOD_NAME_COPY, metering_type),
-                    size as u64,
-                    ExecutionComplexity {
-                        cpu: system_api_complexity::cpu::MSG_METHOD_NAME_COPY,
-                        ..Default::default()
-                    },
-                    NumInstructions::from(0),
-                    stable_memory_dirty_page_limit,
-                )?;
-                with_memory_and_system_api(&mut caller, |system_api, memory| {
-                    system_api.ic0_msg_method_name_copy(
-                        dst as u32,
-                        offset as u32,
-                        size as u32,
-                        memory,
-                    )
-                })?;
-                if feature_flags.write_barrier == FlagStatus::Enabled {
-                    mark_writes_on_bytemap(&mut caller, dst as u32 as usize, size as u32 as usize)
-                } else {
-                    Ok(())
-                }
+            move |caller: Caller<'_, StoreData<S>>, dst: i32, offset: i32, size: i32| {
+                msg_method_name_copy_64(&log, caller, dst as i64, offset as i64, size as i64)
             }
         })
         .unwrap();
@@ -651,33 +625,8 @@ pub(crate) fn syscalls<S: SystemApi>(
     linker
         .func_wrap("ic0", "msg_method_name_copy_64", {
             let log = log.clone();
-            move |mut caller: Caller<'_, StoreData<S>>, dst: i64, offset: i64, size: i64| {
-                charge_for_system_api_call(
-                    &log,
-                    canister_id,
-                    &mut caller,
-                    system_api::complexity_overhead!(MSG_METHOD_NAME_COPY, metering_type),
-                    size as u64,
-                    ExecutionComplexity {
-                        cpu: system_api_complexity::cpu::MSG_METHOD_NAME_COPY,
-                        ..Default::default()
-                    },
-                    NumInstructions::from(0),
-                    stable_memory_dirty_page_limit,
-                )?;
-                with_memory_and_system_api(&mut caller, |system_api, memory| {
-                    system_api.ic0_msg_method_name_copy_64(
-                        dst as u64,
-                        offset as u64,
-                        size as u64,
-                        memory,
-                    )
-                })?;
-                if feature_flags.write_barrier == FlagStatus::Enabled {
-                    mark_writes_on_bytemap(&mut caller, dst as u64 as usize, size as u64 as usize)
-                } else {
-                    Ok(())
-                }
+            move |caller: Caller<'_, StoreData<S>>, dst: i64, offset: i64, size: i64| {
+                msg_method_name_copy_64(&log, caller, dst, offset, size)
             }
         })
         .unwrap();
@@ -705,26 +654,31 @@ pub(crate) fn syscalls<S: SystemApi>(
         })
         .unwrap();
 
+    let msg_reply_data_append_64 =
+        move |log: &ReplicaLogger, mut caller: Caller<'_, StoreData<S>>, src: i64, size: i64| {
+            charge_for_system_api_call(
+                log,
+                canister_id,
+                &mut caller,
+                system_api::complexity_overhead!(MSG_REPLY_DATA_APPEND, metering_type),
+                size as u64,
+                ExecutionComplexity {
+                    cpu: system_api_complexity::cpu::MSG_REPLY_DATA_APPEND,
+                    ..Default::default()
+                },
+                NumInstructions::from(0),
+                stable_memory_dirty_page_limit,
+            )?;
+            with_memory_and_system_api(&mut caller, |system_api, memory| {
+                system_api.ic0_msg_reply_data_append_64(src as u64, size as u64, memory)
+            })
+        };
+
     linker
         .func_wrap("ic0", "msg_reply_data_append", {
             let log = log.clone();
-            move |mut caller: Caller<'_, StoreData<S>>, src: i32, size: i32| {
-                charge_for_system_api_call(
-                    &log,
-                    canister_id,
-                    &mut caller,
-                    system_api::complexity_overhead!(MSG_REPLY_DATA_APPEND, metering_type),
-                    size as u64,
-                    ExecutionComplexity {
-                        cpu: system_api_complexity::cpu::MSG_REPLY_DATA_APPEND,
-                        ..Default::default()
-                    },
-                    NumInstructions::from(0),
-                    stable_memory_dirty_page_limit,
-                )?;
-                with_memory_and_system_api(&mut caller, |system_api, memory| {
-                    system_api.ic0_msg_reply_data_append(src as u32, size as u32, memory)
-                })
+            move |caller: Caller<'_, StoreData<S>>, src: i32, size: i32| {
+                msg_reply_data_append_64(&log, caller, src as i64, size as i64)
             }
         })
         .unwrap();
@@ -732,23 +686,8 @@ pub(crate) fn syscalls<S: SystemApi>(
     linker
         .func_wrap("ic0", "msg_reply_data_append_64", {
             let log = log.clone();
-            move |mut caller: Caller<'_, StoreData<S>>, src: i64, size: i64| {
-                charge_for_system_api_call(
-                    &log,
-                    canister_id,
-                    &mut caller,
-                    system_api::complexity_overhead!(MSG_REPLY_DATA_APPEND, metering_type),
-                    size as u64,
-                    ExecutionComplexity {
-                        cpu: system_api_complexity::cpu::MSG_REPLY_DATA_APPEND,
-                        ..Default::default()
-                    },
-                    NumInstructions::from(0),
-                    stable_memory_dirty_page_limit,
-                )?;
-                with_memory_and_system_api(&mut caller, |system_api, memory| {
-                    system_api.ic0_msg_reply_data_append_64(src as u64, size as u64, memory)
-                })
+            move |caller: Caller<'_, StoreData<S>>, src: i64, size: i64| {
+                msg_reply_data_append_64(&log, caller, src, size)
             }
         })
         .unwrap();
@@ -799,26 +738,31 @@ pub(crate) fn syscalls<S: SystemApi>(
         })
         .unwrap();
 
+    let msg_reject_64 =
+        move |log: &ReplicaLogger, mut caller: Caller<'_, StoreData<S>>, src: i64, size: i64| {
+            charge_for_system_api_call(
+                log,
+                canister_id,
+                &mut caller,
+                system_api::complexity_overhead!(MSG_REJECT, metering_type),
+                size as u64,
+                ExecutionComplexity {
+                    cpu: system_api_complexity::cpu::MSG_REJECT,
+                    ..Default::default()
+                },
+                NumInstructions::from(0),
+                stable_memory_dirty_page_limit,
+            )?;
+            with_memory_and_system_api(&mut caller, |system_api, memory| {
+                system_api.ic0_msg_reject_64(src as u64, size as u64, memory)
+            })
+        };
+
     linker
         .func_wrap("ic0", "msg_reject", {
             let log = log.clone();
-            move |mut caller: Caller<'_, StoreData<S>>, src: i32, size: i32| {
-                charge_for_system_api_call(
-                    &log,
-                    canister_id,
-                    &mut caller,
-                    system_api::complexity_overhead!(MSG_REJECT, metering_type),
-                    size as u64,
-                    ExecutionComplexity {
-                        cpu: system_api_complexity::cpu::MSG_REJECT,
-                        ..Default::default()
-                    },
-                    NumInstructions::from(0),
-                    stable_memory_dirty_page_limit,
-                )?;
-                with_memory_and_system_api(&mut caller, |system_api, memory| {
-                    system_api.ic0_msg_reject(src as u32, size as u32, memory)
-                })
+            move |caller: Caller<'_, StoreData<S>>, src: i32, size: i32| {
+                msg_reject_64(&log, caller, src as i64, size as i64)
             }
         })
         .unwrap();
@@ -826,23 +770,8 @@ pub(crate) fn syscalls<S: SystemApi>(
     linker
         .func_wrap("ic0", "msg_reject_64", {
             let log = log.clone();
-            move |mut caller: Caller<'_, StoreData<S>>, src: i64, size: i64| {
-                charge_for_system_api_call(
-                    &log,
-                    canister_id,
-                    &mut caller,
-                    system_api::complexity_overhead!(MSG_REJECT, metering_type),
-                    size as u64,
-                    ExecutionComplexity {
-                        cpu: system_api_complexity::cpu::MSG_REJECT,
-                        ..Default::default()
-                    },
-                    NumInstructions::from(0),
-                    stable_memory_dirty_page_limit,
-                )?;
-                with_memory_and_system_api(&mut caller, |system_api, memory| {
-                    system_api.ic0_msg_reject_64(src as u64, size as u64, memory)
-                })
+            move |caller: Caller<'_, StoreData<S>>, src: i64, size: i64| {
+                msg_reject_64(&log, caller, src, size)
             }
         })
         .unwrap();
@@ -875,36 +804,39 @@ pub(crate) fn syscalls<S: SystemApi>(
         })
         .unwrap();
 
+    let msg_reject_msg_copy_64 = move |log: &ReplicaLogger,
+                                       mut caller: Caller<'_, StoreData<S>>,
+                                       dst: i64,
+                                       offset: i64,
+                                       size: i64| {
+        charge_for_system_api_call(
+            log,
+            canister_id,
+            &mut caller,
+            system_api::complexity_overhead!(MSG_REJECT_MSG_COPY, metering_type),
+            size as u64,
+            ExecutionComplexity {
+                cpu: system_api_complexity::cpu::MSG_REJECT_MSG_COPY,
+                ..Default::default()
+            },
+            NumInstructions::from(0),
+            stable_memory_dirty_page_limit,
+        )?;
+        with_memory_and_system_api(&mut caller, |system_api, memory| {
+            system_api.ic0_msg_reject_msg_copy_64(dst as u64, offset as u64, size as u64, memory)
+        })?;
+        if feature_flags.write_barrier == FlagStatus::Enabled {
+            mark_writes_on_bytemap(&mut caller, dst as u64 as usize, size as u64 as usize)
+        } else {
+            Ok(())
+        }
+    };
+
     linker
         .func_wrap("ic0", "msg_reject_msg_copy", {
             let log = log.clone();
-            move |mut caller: Caller<'_, StoreData<S>>, dst: i32, offset: i32, size: i32| {
-                charge_for_system_api_call(
-                    &log,
-                    canister_id,
-                    &mut caller,
-                    system_api::complexity_overhead!(MSG_REJECT_MSG_COPY, metering_type),
-                    size as u64,
-                    ExecutionComplexity {
-                        cpu: system_api_complexity::cpu::MSG_REJECT_MSG_COPY,
-                        ..Default::default()
-                    },
-                    NumInstructions::from(0),
-                    stable_memory_dirty_page_limit,
-                )?;
-                with_memory_and_system_api(&mut caller, |system_api, memory| {
-                    system_api.ic0_msg_reject_msg_copy(
-                        dst as u32,
-                        offset as u32,
-                        size as u32,
-                        memory,
-                    )
-                })?;
-                if feature_flags.write_barrier == FlagStatus::Enabled {
-                    mark_writes_on_bytemap(&mut caller, dst as u32 as usize, size as u32 as usize)
-                } else {
-                    Ok(())
-                }
+            move |caller: Caller<'_, StoreData<S>>, dst: i32, offset: i32, size: i32| {
+                msg_reject_msg_copy_64(&log, caller, dst as i64, offset as i64, size as i64)
             }
         })
         .unwrap();
@@ -912,33 +844,8 @@ pub(crate) fn syscalls<S: SystemApi>(
     linker
         .func_wrap("ic0", "msg_reject_msg_copy_64", {
             let log = log.clone();
-            move |mut caller: Caller<'_, StoreData<S>>, dst: i64, offset: i64, size: i64| {
-                charge_for_system_api_call(
-                    &log,
-                    canister_id,
-                    &mut caller,
-                    system_api::complexity_overhead!(MSG_REJECT_MSG_COPY, metering_type),
-                    size as u64,
-                    ExecutionComplexity {
-                        cpu: system_api_complexity::cpu::MSG_REJECT_MSG_COPY,
-                        ..Default::default()
-                    },
-                    NumInstructions::from(0),
-                    stable_memory_dirty_page_limit,
-                )?;
-                with_memory_and_system_api(&mut caller, |system_api, memory| {
-                    system_api.ic0_msg_reject_msg_copy_64(
-                        dst as u64,
-                        offset as u64,
-                        size as u64,
-                        memory,
-                    )
-                })?;
-                if feature_flags.write_barrier == FlagStatus::Enabled {
-                    mark_writes_on_bytemap(&mut caller, dst as u64 as usize, size as u64 as usize)
-                } else {
-                    Ok(())
-                }
+            move |caller: Caller<'_, StoreData<S>>, dst: i64, offset: i64, size: i64| {
+                msg_reject_msg_copy_64(&log, caller, dst, offset, size)
             }
         })
         .unwrap();
@@ -971,36 +878,39 @@ pub(crate) fn syscalls<S: SystemApi>(
         })
         .unwrap();
 
+    let canister_self_copy_64 = move |log: &ReplicaLogger,
+                                      mut caller: Caller<'_, StoreData<S>>,
+                                      dst: i64,
+                                      offset: i64,
+                                      size: i64| {
+        charge_for_system_api_call(
+            log,
+            canister_id,
+            &mut caller,
+            system_api::complexity_overhead!(CANISTER_SELF_COPY, metering_type),
+            size as u64,
+            ExecutionComplexity {
+                cpu: system_api_complexity::cpu::CANISTER_SELF_COPY,
+                ..Default::default()
+            },
+            NumInstructions::from(0),
+            stable_memory_dirty_page_limit,
+        )?;
+        with_memory_and_system_api(&mut caller, |system_api, memory| {
+            system_api.ic0_canister_self_copy_64(dst as u64, offset as u64, size as u64, memory)
+        })?;
+        if feature_flags.write_barrier == FlagStatus::Enabled {
+            mark_writes_on_bytemap(&mut caller, dst as u64 as usize, size as u64 as usize)
+        } else {
+            Ok(())
+        }
+    };
+
     linker
         .func_wrap("ic0", "canister_self_copy", {
             let log = log.clone();
-            move |mut caller: Caller<'_, StoreData<S>>, dst: i32, offset: i32, size: i32| {
-                charge_for_system_api_call(
-                    &log,
-                    canister_id,
-                    &mut caller,
-                    system_api::complexity_overhead!(CANISTER_SELF_COPY, metering_type),
-                    size as u64,
-                    ExecutionComplexity {
-                        cpu: system_api_complexity::cpu::CANISTER_SELF_COPY,
-                        ..Default::default()
-                    },
-                    NumInstructions::from(0),
-                    stable_memory_dirty_page_limit,
-                )?;
-                with_memory_and_system_api(&mut caller, |system_api, memory| {
-                    system_api.ic0_canister_self_copy(
-                        dst as u32,
-                        offset as u32,
-                        size as u32,
-                        memory,
-                    )
-                })?;
-                if feature_flags.write_barrier == FlagStatus::Enabled {
-                    mark_writes_on_bytemap(&mut caller, dst as u32 as usize, size as u32 as usize)
-                } else {
-                    Ok(())
-                }
+            move |caller: Caller<'_, StoreData<S>>, dst: i32, offset: i32, size: i32| {
+                canister_self_copy_64(&log, caller, dst as i64, offset as i64, size as i64)
             }
         })
         .unwrap();
@@ -1008,69 +918,51 @@ pub(crate) fn syscalls<S: SystemApi>(
     linker
         .func_wrap("ic0", "canister_self_copy_64", {
             let log = log.clone();
-            move |mut caller: Caller<'_, StoreData<S>>, dst: i64, offset: i64, size: i64| {
-                charge_for_system_api_call(
-                    &log,
-                    canister_id,
-                    &mut caller,
-                    system_api::complexity_overhead!(CANISTER_SELF_COPY, metering_type),
-                    size as u64,
-                    ExecutionComplexity {
-                        cpu: system_api_complexity::cpu::CANISTER_SELF_COPY,
-                        ..Default::default()
-                    },
-                    NumInstructions::from(0),
-                    stable_memory_dirty_page_limit,
-                )?;
-                with_memory_and_system_api(&mut caller, |system_api, memory| {
-                    system_api.ic0_canister_self_copy_64(
-                        dst as u64,
-                        offset as u64,
-                        size as u64,
-                        memory,
-                    )
-                })?;
-                if feature_flags.write_barrier == FlagStatus::Enabled {
-                    mark_writes_on_bytemap(&mut caller, dst as u64 as usize, size as u64 as usize)
-                } else {
-                    Ok(())
-                }
+            move |caller: Caller<'_, StoreData<S>>, dst: i64, offset: i64, size: i64| {
+                canister_self_copy_64(&log, caller, dst, offset, size)
             }
         })
         .unwrap();
 
+    let debug_print_64 = move |log: &ReplicaLogger,
+                               mut caller: Caller<'_, StoreData<S>>,
+                               offset: i64,
+                               length: i64| {
+        charge_for_system_api_call(
+            log,
+            canister_id,
+            &mut caller,
+            system_api::complexity_overhead!(DEBUG_PRINT, metering_type),
+            length as u64,
+            ExecutionComplexity {
+                cpu: system_api_complexity::cpu::DEBUG_PRINT,
+                ..Default::default()
+            },
+            NumInstructions::from(0),
+            stable_memory_dirty_page_limit,
+        )?;
+        match (
+            caller.data().system_api.subnet_type(),
+            feature_flags.rate_limiting_of_debug_prints,
+        ) {
+            // Debug print is a no-op on non-system subnets with rate limiting.
+            (SubnetType::Application, FlagStatus::Enabled) => Ok(()),
+            (SubnetType::VerifiedApplication, FlagStatus::Enabled) => Ok(()),
+            // If rate limiting is disabled or the subnet is a system subnet, then
+            // debug print produces output.
+            (_, FlagStatus::Disabled) | (SubnetType::System, FlagStatus::Enabled) => {
+                with_memory_and_system_api(&mut caller, |system_api, memory| {
+                    system_api.ic0_debug_print_64(offset as u64, length as u64, memory)
+                })
+            }
+        }
+    };
+
     linker
         .func_wrap("ic0", "debug_print", {
             let log = log.clone();
-            move |mut caller: Caller<'_, StoreData<S>>, offset: i32, length: i32| {
-                charge_for_system_api_call(
-                    &log,
-                    canister_id,
-                    &mut caller,
-                    system_api::complexity_overhead!(DEBUG_PRINT, metering_type),
-                    length as u64,
-                    ExecutionComplexity {
-                        cpu: system_api_complexity::cpu::DEBUG_PRINT,
-                        ..Default::default()
-                    },
-                    NumInstructions::from(0),
-                    stable_memory_dirty_page_limit,
-                )?;
-                match (
-                    caller.data().system_api.subnet_type(),
-                    feature_flags.rate_limiting_of_debug_prints,
-                ) {
-                    // Debug print is a no-op on non-system subnets with rate limiting.
-                    (SubnetType::Application, FlagStatus::Enabled) => Ok(()),
-                    (SubnetType::VerifiedApplication, FlagStatus::Enabled) => Ok(()),
-                    // If rate limiting is disabled or the subnet is a system subnet, then
-                    // debug print produces output.
-                    (_, FlagStatus::Disabled) | (SubnetType::System, FlagStatus::Enabled) => {
-                        with_memory_and_system_api(&mut caller, |system_api, memory| {
-                            system_api.ic0_debug_print(offset as u32, length as u32, memory)
-                        })
-                    }
-                }
+            move |caller: Caller<'_, StoreData<S>>, offset: i32, length: i32| {
+                debug_print_64(&log, caller, offset as i64, length as i64)
             }
         })
         .unwrap();
@@ -1078,59 +970,40 @@ pub(crate) fn syscalls<S: SystemApi>(
     linker
         .func_wrap("ic0", "debug_print_64", {
             let log = log.clone();
-            move |mut caller: Caller<'_, StoreData<S>>, offset: i64, length: i64| {
-                charge_for_system_api_call(
-                    &log,
-                    canister_id,
-                    &mut caller,
-                    system_api::complexity_overhead!(DEBUG_PRINT, metering_type),
-                    length as u64,
-                    ExecutionComplexity {
-                        cpu: system_api_complexity::cpu::DEBUG_PRINT,
-                        ..Default::default()
-                    },
-                    NumInstructions::from(0),
-                    stable_memory_dirty_page_limit,
-                )?;
-                match (
-                    caller.data().system_api.subnet_type(),
-                    feature_flags.rate_limiting_of_debug_prints,
-                ) {
-                    // Debug print is a no-op on non-system subnets with rate limiting.
-                    (SubnetType::Application, FlagStatus::Enabled) => Ok(()),
-                    (SubnetType::VerifiedApplication, FlagStatus::Enabled) => Ok(()),
-                    // If rate limiting is disabled or the subnet is a system subnet, then
-                    // debug print produces output.
-                    (_, FlagStatus::Disabled) | (SubnetType::System, FlagStatus::Enabled) => {
-                        with_memory_and_system_api(&mut caller, |system_api, memory| {
-                            system_api.ic0_debug_print_64(offset as u64, length as u64, memory)
-                        })
-                    }
-                }
+            move |caller: Caller<'_, StoreData<S>>, offset: i64, length: i64| {
+                debug_print_64(&log, caller, offset, length)
             }
         })
         .unwrap();
 
+    let trap_64 = move |log: &ReplicaLogger,
+                        mut caller: Caller<'_, StoreData<S>>,
+                        offset: i64,
+                        length: i64|
+          -> Result<(), _> {
+        charge_for_system_api_call(
+            &log,
+            canister_id,
+            &mut caller,
+            system_api::complexity_overhead!(TRAP, metering_type),
+            length as u64,
+            ExecutionComplexity {
+                cpu: system_api_complexity::cpu::TRAP,
+                ..Default::default()
+            },
+            NumInstructions::from(0),
+            stable_memory_dirty_page_limit,
+        )?;
+        with_memory_and_system_api(&mut caller, |system_api, memory| {
+            system_api.ic0_trap_64(offset as u64, length as u64, memory)
+        })
+    };
+
     linker
         .func_wrap("ic0", "trap", {
             let log = log.clone();
-            move |mut caller: Caller<'_, StoreData<S>>, offset: i32, length: i32| -> Result<(), _> {
-                charge_for_system_api_call(
-                    &log,
-                    canister_id,
-                    &mut caller,
-                    system_api::complexity_overhead!(TRAP, metering_type),
-                    length as u64,
-                    ExecutionComplexity {
-                        cpu: system_api_complexity::cpu::TRAP,
-                        ..Default::default()
-                    },
-                    NumInstructions::from(0),
-                    stable_memory_dirty_page_limit,
-                )?;
-                with_memory_and_system_api(&mut caller, |system_api, memory| {
-                    system_api.ic0_trap(offset as u32, length as u32, memory)
-                })
+            move |caller: Caller<'_, StoreData<S>>, offset: i32, length: i32| -> Result<(), _> {
+                trap_64(&log, caller, offset as i64, length as i64)
             }
         })
         .unwrap();
@@ -1138,31 +1011,54 @@ pub(crate) fn syscalls<S: SystemApi>(
     linker
         .func_wrap("ic0", "trap_64", {
             let log = log.clone();
-            move |mut caller: Caller<'_, StoreData<S>>, offset: i64, length: i64| -> Result<(), _> {
-                charge_for_system_api_call(
-                    &log,
-                    canister_id,
-                    &mut caller,
-                    system_api::complexity_overhead!(TRAP, metering_type),
-                    length as u64,
-                    ExecutionComplexity {
-                        cpu: system_api_complexity::cpu::TRAP,
-                        ..Default::default()
-                    },
-                    NumInstructions::from(0),
-                    stable_memory_dirty_page_limit,
-                )?;
-                with_memory_and_system_api(&mut caller, |system_api, memory| {
-                    system_api.ic0_trap_64(offset as u64, length as u64, memory)
-                })
+            move |caller: Caller<'_, StoreData<S>>, offset: i64, length: i64| -> Result<(), _> {
+                trap_64(&log, caller, offset, length)
             }
         })
         .unwrap();
 
+    let call_new_64 = move |log: &ReplicaLogger,
+                            mut caller: Caller<'_, StoreData<S>>,
+                            callee_src: i64,
+                            callee_size: i64,
+                            name_src: i64,
+                            name_len: i64,
+                            reply_fun: i32,
+                            reply_env: i32,
+                            reject_fun: i32,
+                            reject_env: i32| {
+        charge_for_system_api_call(
+            log,
+            canister_id,
+            &mut caller,
+            system_api::complexity_overhead!(CALL_NEW, metering_type),
+            (callee_size as u64).saturating_add(name_len as u64),
+            ExecutionComplexity {
+                cpu: system_api_complexity::cpu::CALL_NEW,
+                ..Default::default()
+            },
+            NumInstructions::from(0),
+            stable_memory_dirty_page_limit,
+        )?;
+        with_memory_and_system_api(&mut caller, |system_api, memory| {
+            system_api.ic0_call_new_64(
+                callee_src as u64,
+                callee_size as u64,
+                name_src as u64,
+                name_len as u64,
+                reply_fun as u32,
+                reply_env as u32,
+                reject_fun as u32,
+                reject_env as u32,
+                memory,
+            )
+        })
+    };
+
     linker
         .func_wrap("ic0", "call_new", {
             let log = log.clone();
-            move |mut caller: Caller<'_, StoreData<S>>,
+            move |caller: Caller<'_, StoreData<S>>,
                   callee_src: i32,
                   callee_size: i32,
                   name_src: i32,
@@ -1171,32 +1067,18 @@ pub(crate) fn syscalls<S: SystemApi>(
                   reply_env: i32,
                   reject_fun: i32,
                   reject_env: i32| {
-                charge_for_system_api_call(
+                call_new_64(
                     &log,
-                    canister_id,
-                    &mut caller,
-                    system_api::complexity_overhead!(CALL_NEW, metering_type),
-                    (callee_size as u64).saturating_add(name_len as u64),
-                    ExecutionComplexity {
-                        cpu: system_api_complexity::cpu::CALL_NEW,
-                        ..Default::default()
-                    },
-                    NumInstructions::from(0),
-                    stable_memory_dirty_page_limit,
-                )?;
-                with_memory_and_system_api(&mut caller, |system_api, memory| {
-                    system_api.ic0_call_new(
-                        callee_src as u32,
-                        callee_size as u32,
-                        name_src as u32,
-                        name_len as u32,
-                        reply_fun as u32,
-                        reply_env as u32,
-                        reject_fun as u32,
-                        reject_env as u32,
-                        memory,
-                    )
-                })
+                    caller,
+                    callee_src as i64,
+                    callee_size as i64,
+                    name_src as i64,
+                    name_len as i64,
+                    reply_fun,
+                    reply_env,
+                    reject_fun,
+                    reject_env,
+                )
             }
         })
         .unwrap();
@@ -1204,7 +1086,7 @@ pub(crate) fn syscalls<S: SystemApi>(
     linker
         .func_wrap("ic0", "call_new_64", {
             let log = log.clone();
-            move |mut caller: Caller<'_, StoreData<S>>,
+            move |caller: Caller<'_, StoreData<S>>,
                   callee_src: i64,
                   callee_size: i64,
                   name_src: i64,
@@ -1213,56 +1095,47 @@ pub(crate) fn syscalls<S: SystemApi>(
                   reply_env: i32,
                   reject_fun: i32,
                   reject_env: i32| {
-                charge_for_system_api_call(
+                call_new_64(
                     &log,
-                    canister_id,
-                    &mut caller,
-                    system_api::complexity_overhead!(CALL_NEW, metering_type),
-                    (callee_size as u64).saturating_add(name_len as u64),
-                    ExecutionComplexity {
-                        cpu: system_api_complexity::cpu::CALL_NEW,
-                        ..Default::default()
-                    },
-                    NumInstructions::from(0),
-                    stable_memory_dirty_page_limit,
-                )?;
-                with_memory_and_system_api(&mut caller, |system_api, memory| {
-                    system_api.ic0_call_new_64(
-                        callee_src as u64,
-                        callee_size as u64,
-                        name_src as u64,
-                        name_len as u64,
-                        reply_fun as u32,
-                        reply_env as u32,
-                        reject_fun as u32,
-                        reject_env as u32,
-                        memory,
-                    )
-                })
+                    caller,
+                    callee_src,
+                    callee_size,
+                    name_src,
+                    name_len,
+                    reply_fun,
+                    reply_env,
+                    reject_fun,
+                    reject_env,
+                )
             }
         })
         .unwrap();
 
+    let data_append_64 =
+        move |log: &ReplicaLogger, mut caller: Caller<'_, StoreData<S>>, src: i64, size: i64| {
+            charge_for_system_api_call(
+                log,
+                canister_id,
+                &mut caller,
+                system_api::complexity_overhead!(CALL_DATA_APPEND, metering_type),
+                size as u64,
+                ExecutionComplexity {
+                    cpu: system_api_complexity::cpu::CALL_DATA_APPEND,
+                    ..Default::default()
+                },
+                NumInstructions::from(0),
+                stable_memory_dirty_page_limit,
+            )?;
+            with_memory_and_system_api(&mut caller, |system_api, memory| {
+                system_api.ic0_call_data_append_64(src as u64, size as u64, memory)
+            })
+        };
+
     linker
         .func_wrap("ic0", "call_data_append", {
             let log = log.clone();
-            move |mut caller: Caller<'_, StoreData<S>>, src: i32, size: i32| {
-                charge_for_system_api_call(
-                    &log,
-                    canister_id,
-                    &mut caller,
-                    system_api::complexity_overhead!(CALL_DATA_APPEND, metering_type),
-                    size as u64,
-                    ExecutionComplexity {
-                        cpu: system_api_complexity::cpu::CALL_DATA_APPEND,
-                        ..Default::default()
-                    },
-                    NumInstructions::from(0),
-                    stable_memory_dirty_page_limit,
-                )?;
-                with_memory_and_system_api(&mut caller, |system_api, memory| {
-                    system_api.ic0_call_data_append(src as u32, size as u32, memory)
-                })
+            move |caller: Caller<'_, StoreData<S>>, src: i32, size: i32| {
+                data_append_64(&log, caller, src as i64, size as i64)
             }
         })
         .unwrap();
@@ -1270,23 +1143,8 @@ pub(crate) fn syscalls<S: SystemApi>(
     linker
         .func_wrap("ic0", "call_data_append_64", {
             let log = log.clone();
-            move |mut caller: Caller<'_, StoreData<S>>, src: i64, size: i64| {
-                charge_for_system_api_call(
-                    &log,
-                    canister_id,
-                    &mut caller,
-                    system_api::complexity_overhead!(CALL_DATA_APPEND, metering_type),
-                    size as u64,
-                    ExecutionComplexity {
-                        cpu: system_api_complexity::cpu::CALL_DATA_APPEND,
-                        ..Default::default()
-                    },
-                    NumInstructions::from(0),
-                    stable_memory_dirty_page_limit,
-                )?;
-                with_memory_and_system_api(&mut caller, |system_api, memory| {
-                    system_api.ic0_call_data_append_64(src as u64, size as u64, memory)
-                })
+            move |caller: Caller<'_, StoreData<S>>, src: i64, size: i64| {
+                data_append_64(&log, caller, src, size)
             }
         })
         .unwrap();
@@ -1753,31 +1611,36 @@ pub(crate) fn syscalls<S: SystemApi>(
         })
         .unwrap();
 
+    let canister_cycle_balance128_64 =
+        move |log: &ReplicaLogger, mut caller: Caller<'_, StoreData<S>>, dst: u64| {
+            charge_for_system_api_call(
+                log,
+                canister_id,
+                &mut caller,
+                system_api::complexity_overhead!(CANISTER_CYCLE_BALANCE128, metering_type),
+                0,
+                ExecutionComplexity {
+                    cpu: system_api_complexity::cpu::CANISTER_CYCLE_BALANCE128,
+                    ..Default::default()
+                },
+                NumInstructions::from(0),
+                stable_memory_dirty_page_limit,
+            )?;
+            with_memory_and_system_api(&mut caller, |system_api, memory| {
+                system_api.ic0_canister_cycle_balance128_64(dst, memory)
+            })?;
+            if feature_flags.write_barrier == FlagStatus::Enabled {
+                mark_writes_on_bytemap(&mut caller, dst as usize, 16)
+            } else {
+                Ok(())
+            }
+        };
+
     linker
         .func_wrap("ic0", "canister_cycle_balance128", {
             let log = log.clone();
-            move |mut caller: Caller<'_, StoreData<S>>, dst: u32| {
-                charge_for_system_api_call(
-                    &log,
-                    canister_id,
-                    &mut caller,
-                    system_api::complexity_overhead!(CANISTER_CYCLE_BALANCE128, metering_type),
-                    0,
-                    ExecutionComplexity {
-                        cpu: system_api_complexity::cpu::CANISTER_CYCLE_BALANCE128,
-                        ..Default::default()
-                    },
-                    NumInstructions::from(0),
-                    stable_memory_dirty_page_limit,
-                )?;
-                with_memory_and_system_api(&mut caller, |system_api, memory| {
-                    system_api.ic0_canister_cycle_balance128(dst, memory)
-                })?;
-                if feature_flags.write_barrier == FlagStatus::Enabled {
-                    mark_writes_on_bytemap(&mut caller, dst as usize, 16)
-                } else {
-                    Ok(())
-                }
+            move |caller: Caller<'_, StoreData<S>>, dst: u32| {
+                canister_cycle_balance128_64(&log, caller, dst as u64)
             }
         })
         .unwrap();
@@ -1785,28 +1648,8 @@ pub(crate) fn syscalls<S: SystemApi>(
     linker
         .func_wrap("ic0", "canister_cycle_balance128_64", {
             let log = log.clone();
-            move |mut caller: Caller<'_, StoreData<S>>, dst: u64| {
-                charge_for_system_api_call(
-                    &log,
-                    canister_id,
-                    &mut caller,
-                    system_api::complexity_overhead!(CANISTER_CYCLE_BALANCE128, metering_type),
-                    0,
-                    ExecutionComplexity {
-                        cpu: system_api_complexity::cpu::CANISTER_CYCLE_BALANCE128,
-                        ..Default::default()
-                    },
-                    NumInstructions::from(0),
-                    stable_memory_dirty_page_limit,
-                )?;
-                with_memory_and_system_api(&mut caller, |system_api, memory| {
-                    system_api.ic0_canister_cycle_balance128_64(dst, memory)
-                })?;
-                if feature_flags.write_barrier == FlagStatus::Enabled {
-                    mark_writes_on_bytemap(&mut caller, dst as usize, 16)
-                } else {
-                    Ok(())
-                }
+            move |caller: Caller<'_, StoreData<S>>, dst: u64| {
+                canister_cycle_balance128_64(&log, caller, dst)
             }
         })
         .unwrap();
@@ -1839,31 +1682,36 @@ pub(crate) fn syscalls<S: SystemApi>(
         })
         .unwrap();
 
+    let msg_cycles_available128_64 =
+        move |log: &ReplicaLogger, mut caller: Caller<'_, StoreData<S>>, dst: u64| {
+            charge_for_system_api_call(
+                log,
+                canister_id,
+                &mut caller,
+                system_api::complexity_overhead!(MSG_CYCLES_AVAILABLE128, metering_type),
+                0,
+                ExecutionComplexity {
+                    cpu: system_api_complexity::cpu::MSG_CYCLES_AVAILABLE128,
+                    ..Default::default()
+                },
+                NumInstructions::from(0),
+                stable_memory_dirty_page_limit,
+            )?;
+            with_memory_and_system_api(&mut caller, |system_api, memory| {
+                system_api.ic0_msg_cycles_available128_64(dst, memory)
+            })?;
+            if feature_flags.write_barrier == FlagStatus::Enabled {
+                mark_writes_on_bytemap(&mut caller, dst as usize, 16)
+            } else {
+                Ok(())
+            }
+        };
+
     linker
         .func_wrap("ic0", "msg_cycles_available128", {
             let log = log.clone();
-            move |mut caller: Caller<'_, StoreData<S>>, dst: u32| {
-                charge_for_system_api_call(
-                    &log,
-                    canister_id,
-                    &mut caller,
-                    system_api::complexity_overhead!(MSG_CYCLES_AVAILABLE128, metering_type),
-                    0,
-                    ExecutionComplexity {
-                        cpu: system_api_complexity::cpu::MSG_CYCLES_AVAILABLE128,
-                        ..Default::default()
-                    },
-                    NumInstructions::from(0),
-                    stable_memory_dirty_page_limit,
-                )?;
-                with_memory_and_system_api(&mut caller, |system_api, memory| {
-                    system_api.ic0_msg_cycles_available128(dst, memory)
-                })?;
-                if feature_flags.write_barrier == FlagStatus::Enabled {
-                    mark_writes_on_bytemap(&mut caller, dst as usize, 16)
-                } else {
-                    Ok(())
-                }
+            move |caller: Caller<'_, StoreData<S>>, dst: u32| {
+                msg_cycles_available128_64(&log, caller, dst as u64)
             }
         })
         .unwrap();
@@ -1871,28 +1719,8 @@ pub(crate) fn syscalls<S: SystemApi>(
     linker
         .func_wrap("ic0", "msg_cycles_available128_64", {
             let log = log.clone();
-            move |mut caller: Caller<'_, StoreData<S>>, dst: u64| {
-                charge_for_system_api_call(
-                    &log,
-                    canister_id,
-                    &mut caller,
-                    system_api::complexity_overhead!(MSG_CYCLES_AVAILABLE128, metering_type),
-                    0,
-                    ExecutionComplexity {
-                        cpu: system_api_complexity::cpu::MSG_CYCLES_AVAILABLE128,
-                        ..Default::default()
-                    },
-                    NumInstructions::from(0),
-                    stable_memory_dirty_page_limit,
-                )?;
-                with_memory_and_system_api(&mut caller, |system_api, memory| {
-                    system_api.ic0_msg_cycles_available128_64(dst, memory)
-                })?;
-                if feature_flags.write_barrier == FlagStatus::Enabled {
-                    mark_writes_on_bytemap(&mut caller, dst as usize, 16)
-                } else {
-                    Ok(())
-                }
+            move |caller: Caller<'_, StoreData<S>>, dst: u64| {
+                msg_cycles_available128_64(&log, caller, dst)
             }
         })
         .unwrap();
@@ -1925,31 +1753,36 @@ pub(crate) fn syscalls<S: SystemApi>(
         })
         .unwrap();
 
+    let msg_cycles_refunded128_64 =
+        move |log: &ReplicaLogger, mut caller: Caller<'_, StoreData<S>>, dst: u64| {
+            charge_for_system_api_call(
+                log,
+                canister_id,
+                &mut caller,
+                system_api::complexity_overhead!(MSG_CYCLES_REFUNDED128, metering_type),
+                0,
+                ExecutionComplexity {
+                    cpu: system_api_complexity::cpu::MSG_CYCLES_REFUNDED128,
+                    ..Default::default()
+                },
+                NumInstructions::from(0),
+                stable_memory_dirty_page_limit,
+            )?;
+            with_memory_and_system_api(&mut caller, |system_api, memory| {
+                system_api.ic0_msg_cycles_refunded128_64(dst, memory)
+            })?;
+            if feature_flags.write_barrier == FlagStatus::Enabled {
+                mark_writes_on_bytemap(&mut caller, dst as usize, 16)
+            } else {
+                Ok(())
+            }
+        };
+
     linker
         .func_wrap("ic0", "msg_cycles_refunded128", {
             let log = log.clone();
-            move |mut caller: Caller<'_, StoreData<S>>, dst: u32| {
-                charge_for_system_api_call(
-                    &log,
-                    canister_id,
-                    &mut caller,
-                    system_api::complexity_overhead!(MSG_CYCLES_REFUNDED128, metering_type),
-                    0,
-                    ExecutionComplexity {
-                        cpu: system_api_complexity::cpu::MSG_CYCLES_REFUNDED128,
-                        ..Default::default()
-                    },
-                    NumInstructions::from(0),
-                    stable_memory_dirty_page_limit,
-                )?;
-                with_memory_and_system_api(&mut caller, |system_api, memory| {
-                    system_api.ic0_msg_cycles_refunded128(dst, memory)
-                })?;
-                if feature_flags.write_barrier == FlagStatus::Enabled {
-                    mark_writes_on_bytemap(&mut caller, dst as usize, 16)
-                } else {
-                    Ok(())
-                }
+            move |caller: Caller<'_, StoreData<S>>, dst: u32| {
+                msg_cycles_refunded128_64(&log, caller, dst as u64)
             }
         })
         .unwrap();
@@ -1957,28 +1790,8 @@ pub(crate) fn syscalls<S: SystemApi>(
     linker
         .func_wrap("ic0", "msg_cycles_refunded128_64", {
             let log = log.clone();
-            move |mut caller: Caller<'_, StoreData<S>>, dst: u64| {
-                charge_for_system_api_call(
-                    &log,
-                    canister_id,
-                    &mut caller,
-                    system_api::complexity_overhead!(MSG_CYCLES_REFUNDED128, metering_type),
-                    0,
-                    ExecutionComplexity {
-                        cpu: system_api_complexity::cpu::MSG_CYCLES_REFUNDED128,
-                        ..Default::default()
-                    },
-                    NumInstructions::from(0),
-                    stable_memory_dirty_page_limit,
-                )?;
-                with_memory_and_system_api(&mut caller, |system_api, memory| {
-                    system_api.ic0_msg_cycles_refunded128_64(dst, memory)
-                })?;
-                if feature_flags.write_barrier == FlagStatus::Enabled {
-                    mark_writes_on_bytemap(&mut caller, dst as usize, 16)
-                } else {
-                    Ok(())
-                }
+            move |caller: Caller<'_, StoreData<S>>, dst: u64| {
+                msg_cycles_refunded128_64(&log, caller, dst)
             }
         })
         .unwrap();
@@ -2006,38 +1819,43 @@ pub(crate) fn syscalls<S: SystemApi>(
         })
         .unwrap();
 
+    let msg_cycles_accept128_64 = move |log: &ReplicaLogger,
+                                        mut caller: Caller<'_, StoreData<S>>,
+                                        amount_high: i64,
+                                        amount_low: i64,
+                                        dst: u64| {
+        charge_for_system_api_call(
+            log,
+            canister_id,
+            &mut caller,
+            system_api::complexity_overhead!(MSG_CYCLES_ACCEPT128, metering_type),
+            0,
+            ExecutionComplexity {
+                cpu: system_api_complexity::cpu::MSG_CYCLES_ACCEPT128,
+                ..Default::default()
+            },
+            NumInstructions::from(0),
+            stable_memory_dirty_page_limit,
+        )?;
+        with_memory_and_system_api(&mut caller, |system_api, memory| {
+            system_api.ic0_msg_cycles_accept128_64(
+                Cycles::from_parts(amount_high as u64, amount_low as u64),
+                dst,
+                memory,
+            )
+        })?;
+        if feature_flags.write_barrier == FlagStatus::Enabled {
+            mark_writes_on_bytemap(&mut caller, dst as usize, 16)
+        } else {
+            Ok(())
+        }
+    };
+
     linker
         .func_wrap("ic0", "msg_cycles_accept128", {
             let log = log.clone();
-            move |mut caller: Caller<'_, StoreData<S>>,
-                  amount_high: i64,
-                  amount_low: i64,
-                  dst: u32| {
-                charge_for_system_api_call(
-                    &log,
-                    canister_id,
-                    &mut caller,
-                    system_api::complexity_overhead!(MSG_CYCLES_ACCEPT128, metering_type),
-                    0,
-                    ExecutionComplexity {
-                        cpu: system_api_complexity::cpu::MSG_CYCLES_ACCEPT128,
-                        ..Default::default()
-                    },
-                    NumInstructions::from(0),
-                    stable_memory_dirty_page_limit,
-                )?;
-                with_memory_and_system_api(&mut caller, |system_api, memory| {
-                    system_api.ic0_msg_cycles_accept128(
-                        Cycles::from_parts(amount_high as u64, amount_low as u64),
-                        dst,
-                        memory,
-                    )
-                })?;
-                if feature_flags.write_barrier == FlagStatus::Enabled {
-                    mark_writes_on_bytemap(&mut caller, dst as usize, 16)
-                } else {
-                    Ok(())
-                }
+            move |caller: Caller<'_, StoreData<S>>, amount_high: i64, amount_low: i64, dst: u32| {
+                msg_cycles_accept128_64(&log, caller, amount_high, amount_low, dst as u64)
             }
         })
         .unwrap();
@@ -2045,35 +1863,8 @@ pub(crate) fn syscalls<S: SystemApi>(
     linker
         .func_wrap("ic0", "msg_cycles_accept128_64", {
             let log = log.clone();
-            move |mut caller: Caller<'_, StoreData<S>>,
-                  amount_high: i64,
-                  amount_low: i64,
-                  dst: u64| {
-                charge_for_system_api_call(
-                    &log,
-                    canister_id,
-                    &mut caller,
-                    system_api::complexity_overhead!(MSG_CYCLES_ACCEPT128, metering_type),
-                    0,
-                    ExecutionComplexity {
-                        cpu: system_api_complexity::cpu::MSG_CYCLES_ACCEPT128,
-                        ..Default::default()
-                    },
-                    NumInstructions::from(0),
-                    stable_memory_dirty_page_limit,
-                )?;
-                with_memory_and_system_api(&mut caller, |system_api, memory| {
-                    system_api.ic0_msg_cycles_accept128_64(
-                        Cycles::from_parts(amount_high as u64, amount_low as u64),
-                        dst,
-                        memory,
-                    )
-                })?;
-                if feature_flags.write_barrier == FlagStatus::Enabled {
-                    mark_writes_on_bytemap(&mut caller, dst as usize, 16)
-                } else {
-                    Ok(())
-                }
+            move |caller: Caller<'_, StoreData<S>>, amount_high: i64, amount_low: i64, dst: u64| {
+                msg_cycles_accept128_64(&log, caller, amount_high, amount_low, dst)
             }
         })
         .unwrap();
@@ -2092,40 +1883,49 @@ pub(crate) fn syscalls<S: SystemApi>(
         })
         .unwrap();
 
+    let update_available_memory_64 = move |mut caller: Caller<'_, StoreData<S>>,
+                                           native_memory_grow_res: i64,
+                                           additional_elements: i64,
+                                           element_size: i32| {
+        with_system_api(&mut caller, |s| {
+            s.update_available_memory(
+                native_memory_grow_res,
+                additional_elements as u64,
+                element_size as u32 as u64,
+            )
+        })
+        .map(|()| native_memory_grow_res)
+        .map_err(|e| process_err(&mut caller, e))
+    };
+
     linker
         .func_wrap("__", "update_available_memory", {
-            move |mut caller: Caller<'_, StoreData<S>>,
+            move |caller: Caller<'_, StoreData<S>>,
                   native_memory_grow_res: i32,
                   additional_elements: i32,
                   element_size: i32| {
-                with_system_api(&mut caller, |s| {
-                    s.update_available_memory(
-                        native_memory_grow_res as i64,
-                        additional_elements as u32 as u64,
-                        element_size as u32 as u64,
-                    )
-                })
-                .map(|()| native_memory_grow_res)
-                .map_err(|e| process_err(&mut caller, e))
+                update_available_memory_64(
+                    caller,
+                    native_memory_grow_res as i64,
+                    additional_elements as i64,
+                    element_size,
+                )
             }
         })
         .unwrap();
 
     linker
         .func_wrap("__", "update_available_memory_64", {
-            move |mut caller: Caller<'_, StoreData<S>>,
+            move |caller: Caller<'_, StoreData<S>>,
                   native_memory_grow_res: i64,
                   additional_elements: i64,
                   element_size: i32| {
-                with_system_api(&mut caller, |s| {
-                    s.update_available_memory(
-                        native_memory_grow_res,
-                        additional_elements as u64,
-                        element_size as u32 as u64,
-                    )
-                })
-                .map(|()| native_memory_grow_res)
-                .map_err(|e| process_err(&mut caller, e))
+                update_available_memory_64(
+                    caller,
+                    native_memory_grow_res,
+                    additional_elements,
+                    element_size,
+                )
             }
         })
         .unwrap();
@@ -2190,26 +1990,31 @@ pub(crate) fn syscalls<S: SystemApi>(
         })
         .unwrap();
 
+    let certified_data_set_64 =
+        move |log: &ReplicaLogger, mut caller: Caller<'_, StoreData<S>>, src: u64, size: u64| {
+            charge_for_system_api_call(
+                log,
+                canister_id,
+                &mut caller,
+                system_api::complexity_overhead!(CERTIFIED_DATA_SET, metering_type),
+                size,
+                ExecutionComplexity {
+                    cpu: system_api_complexity::cpu::CERTIFIED_DATA_SET,
+                    ..Default::default()
+                },
+                NumInstructions::from(0),
+                stable_memory_dirty_page_limit,
+            )?;
+            with_memory_and_system_api(&mut caller, |system_api, memory| {
+                system_api.ic0_certified_data_set_64(src, size, memory)
+            })
+        };
+
     linker
         .func_wrap("ic0", "certified_data_set", {
             let log = log.clone();
-            move |mut caller: Caller<'_, StoreData<S>>, src: u32, size: u32| {
-                charge_for_system_api_call(
-                    &log,
-                    canister_id,
-                    &mut caller,
-                    system_api::complexity_overhead!(CERTIFIED_DATA_SET, metering_type),
-                    size as u64,
-                    ExecutionComplexity {
-                        cpu: system_api_complexity::cpu::CERTIFIED_DATA_SET,
-                        ..Default::default()
-                    },
-                    NumInstructions::from(0),
-                    stable_memory_dirty_page_limit,
-                )?;
-                with_memory_and_system_api(&mut caller, |system_api, memory| {
-                    system_api.ic0_certified_data_set(src, size, memory)
-                })
+            move |caller: Caller<'_, StoreData<S>>, src: u32, size: u32| {
+                certified_data_set_64(&log, caller, src as u64, size as u64)
             }
         })
         .unwrap();
@@ -2217,23 +2022,8 @@ pub(crate) fn syscalls<S: SystemApi>(
     linker
         .func_wrap("ic0", "certified_data_set_64", {
             let log = log.clone();
-            move |mut caller: Caller<'_, StoreData<S>>, src: u64, size: u64| {
-                charge_for_system_api_call(
-                    &log,
-                    canister_id,
-                    &mut caller,
-                    system_api::complexity_overhead!(CERTIFIED_DATA_SET, metering_type),
-                    size,
-                    ExecutionComplexity {
-                        cpu: system_api_complexity::cpu::CERTIFIED_DATA_SET,
-                        ..Default::default()
-                    },
-                    NumInstructions::from(0),
-                    stable_memory_dirty_page_limit,
-                )?;
-                with_memory_and_system_api(&mut caller, |system_api, memory| {
-                    system_api.ic0_certified_data_set_64(src, size, memory)
-                })
+            move |caller: Caller<'_, StoreData<S>>, src: u64, size: u64| {
+                certified_data_set_64(&log, caller, src, size)
             }
         })
         .unwrap();
@@ -2284,26 +2074,31 @@ pub(crate) fn syscalls<S: SystemApi>(
         })
         .unwrap();
 
+    let is_controller_64 =
+        move |log: &ReplicaLogger, mut caller: Caller<'_, StoreData<S>>, src: i64, size: i64| {
+            charge_for_system_api_call(
+                log,
+                canister_id,
+                &mut caller,
+                system_api::complexity_overhead!(IS_CONTROLLER, metering_type),
+                size as u64,
+                ExecutionComplexity {
+                    cpu: system_api_complexity::cpu::IS_CONTROLLER,
+                    ..Default::default()
+                },
+                NumInstructions::from(0),
+                stable_memory_dirty_page_limit,
+            )?;
+            with_memory_and_system_api(&mut caller, |system_api, memory| {
+                system_api.ic0_is_controller_64(src as u64, size as u64, memory)
+            })
+        };
+
     linker
         .func_wrap("ic0", "is_controller", {
             let log = log.clone();
-            move |mut caller: Caller<'_, StoreData<S>>, src: i32, size: i32| {
-                charge_for_system_api_call(
-                    &log,
-                    canister_id,
-                    &mut caller,
-                    system_api::complexity_overhead!(IS_CONTROLLER, metering_type),
-                    size as u64,
-                    ExecutionComplexity {
-                        cpu: system_api_complexity::cpu::IS_CONTROLLER,
-                        ..Default::default()
-                    },
-                    NumInstructions::from(0),
-                    stable_memory_dirty_page_limit,
-                )?;
-                with_memory_and_system_api(&mut caller, |system_api, memory| {
-                    system_api.ic0_is_controller(src as u32, size as u32, memory)
-                })
+            move |caller: Caller<'_, StoreData<S>>, src: i32, size: i32| {
+                is_controller_64(&log, caller, src as i64, size as i64)
             }
         })
         .unwrap();
@@ -2311,23 +2106,8 @@ pub(crate) fn syscalls<S: SystemApi>(
     linker
         .func_wrap("ic0", "is_controller_64", {
             let log = log.clone();
-            move |mut caller: Caller<'_, StoreData<S>>, src: i64, size: i64| {
-                charge_for_system_api_call(
-                    &log,
-                    canister_id,
-                    &mut caller,
-                    system_api::complexity_overhead!(IS_CONTROLLER, metering_type),
-                    size as u64,
-                    ExecutionComplexity {
-                        cpu: system_api_complexity::cpu::IS_CONTROLLER,
-                        ..Default::default()
-                    },
-                    NumInstructions::from(0),
-                    stable_memory_dirty_page_limit,
-                )?;
-                with_memory_and_system_api(&mut caller, |system_api, memory| {
-                    system_api.ic0_is_controller_64(src as u64, size as u64, memory)
-                })
+            move |caller: Caller<'_, StoreData<S>>, src: i64, size: i64| {
+                is_controller_64(&log, caller, src, size)
             }
         })
         .unwrap();

--- a/rs/embedders/src/wasmtime_embedder/system_api.rs
+++ b/rs/embedders/src/wasmtime_embedder/system_api.rs
@@ -1910,6 +1910,7 @@ pub(crate) fn syscalls<S: SystemApi>(
                     additional_elements as i64,
                     element_size,
                 )
+                .map(|result| result as i32)
             }
         })
         .unwrap();

--- a/rs/embedders/src/wasmtime_embedder/system_api.rs
+++ b/rs/embedders/src/wasmtime_embedder/system_api.rs
@@ -431,7 +431,7 @@ pub(crate) fn syscalls<S: SystemApi>(
             system_api.ic0_msg_caller_copy_64(dst as u64, offset as u64, size as u64, memory)
         })?;
         if feature_flags.write_barrier == FlagStatus::Enabled {
-            mark_writes_on_bytemap(&mut caller, dst as u64 as usize, size as u32 as usize)
+            mark_writes_on_bytemap(&mut caller, dst as u64 as usize, size as u64 as usize)
         } else {
             Ok(())
         }
@@ -441,7 +441,13 @@ pub(crate) fn syscalls<S: SystemApi>(
         .func_wrap("ic0", "msg_caller_copy", {
             let log = log.clone();
             move |caller: Caller<'_, StoreData<S>>, dst: i32, offset: i32, size: i32| {
-                msg_caller_copy_64(&log, caller, dst as i64, offset as i64, size as i64)
+                msg_caller_copy_64(
+                    &log,
+                    caller,
+                    dst as u32 as i64,
+                    offset as u32 as i64,
+                    size as u32 as i64,
+                )
             }
         })
         .unwrap();
@@ -543,7 +549,13 @@ pub(crate) fn syscalls<S: SystemApi>(
         .func_wrap("ic0", "msg_arg_data_copy", {
             let log = log.clone();
             move |caller: Caller<'_, StoreData<S>>, dst: i32, offset: i32, size: i32| {
-                msg_arg_data_copy_64(&log, caller, dst as i64, offset as i64, size as i64)
+                msg_arg_data_copy_64(
+                    &log,
+                    caller,
+                    dst as u32 as i64,
+                    offset as u32 as i64,
+                    size as u32 as i64,
+                )
             }
         })
         .unwrap();
@@ -617,7 +629,13 @@ pub(crate) fn syscalls<S: SystemApi>(
         .func_wrap("ic0", "msg_method_name_copy", {
             let log = log.clone();
             move |caller: Caller<'_, StoreData<S>>, dst: i32, offset: i32, size: i32| {
-                msg_method_name_copy_64(&log, caller, dst as i64, offset as i64, size as i64)
+                msg_method_name_copy_64(
+                    &log,
+                    caller,
+                    dst as u32 as i64,
+                    offset as u32 as i64,
+                    size as u32 as i64,
+                )
             }
         })
         .unwrap();
@@ -678,7 +696,7 @@ pub(crate) fn syscalls<S: SystemApi>(
         .func_wrap("ic0", "msg_reply_data_append", {
             let log = log.clone();
             move |caller: Caller<'_, StoreData<S>>, src: i32, size: i32| {
-                msg_reply_data_append_64(&log, caller, src as i64, size as i64)
+                msg_reply_data_append_64(&log, caller, src as u32 as i64, size as u32 as i64)
             }
         })
         .unwrap();
@@ -762,7 +780,7 @@ pub(crate) fn syscalls<S: SystemApi>(
         .func_wrap("ic0", "msg_reject", {
             let log = log.clone();
             move |caller: Caller<'_, StoreData<S>>, src: i32, size: i32| {
-                msg_reject_64(&log, caller, src as i64, size as i64)
+                msg_reject_64(&log, caller, src as u32 as i64, size as u32 as i64)
             }
         })
         .unwrap();
@@ -836,7 +854,13 @@ pub(crate) fn syscalls<S: SystemApi>(
         .func_wrap("ic0", "msg_reject_msg_copy", {
             let log = log.clone();
             move |caller: Caller<'_, StoreData<S>>, dst: i32, offset: i32, size: i32| {
-                msg_reject_msg_copy_64(&log, caller, dst as i64, offset as i64, size as i64)
+                msg_reject_msg_copy_64(
+                    &log,
+                    caller,
+                    dst as u32 as i64,
+                    offset as u32 as i64,
+                    size as u32 as i64,
+                )
             }
         })
         .unwrap();
@@ -910,7 +934,13 @@ pub(crate) fn syscalls<S: SystemApi>(
         .func_wrap("ic0", "canister_self_copy", {
             let log = log.clone();
             move |caller: Caller<'_, StoreData<S>>, dst: i32, offset: i32, size: i32| {
-                canister_self_copy_64(&log, caller, dst as i64, offset as i64, size as i64)
+                canister_self_copy_64(
+                    &log,
+                    caller,
+                    dst as u32 as i64,
+                    offset as u32 as i64,
+                    size as u32 as i64,
+                )
             }
         })
         .unwrap();
@@ -962,7 +992,7 @@ pub(crate) fn syscalls<S: SystemApi>(
         .func_wrap("ic0", "debug_print", {
             let log = log.clone();
             move |caller: Caller<'_, StoreData<S>>, offset: i32, length: i32| {
-                debug_print_64(&log, caller, offset as i64, length as i64)
+                debug_print_64(&log, caller, offset as u32 as i64, length as u32 as i64)
             }
         })
         .unwrap();
@@ -1003,7 +1033,7 @@ pub(crate) fn syscalls<S: SystemApi>(
         .func_wrap("ic0", "trap", {
             let log = log.clone();
             move |caller: Caller<'_, StoreData<S>>, offset: i32, length: i32| -> Result<(), _> {
-                trap_64(&log, caller, offset as i64, length as i64)
+                trap_64(&log, caller, offset as u32 as i64, length as u32 as i64)
             }
         })
         .unwrap();
@@ -1070,10 +1100,10 @@ pub(crate) fn syscalls<S: SystemApi>(
                 call_new_64(
                     &log,
                     caller,
-                    callee_src as i64,
-                    callee_size as i64,
-                    name_src as i64,
-                    name_len as i64,
+                    callee_src as u32 as i64,
+                    callee_size as u32 as i64,
+                    name_src as u32 as i64,
+                    name_len as u32 as i64,
                     reply_fun,
                     reply_env,
                     reject_fun,
@@ -1135,7 +1165,7 @@ pub(crate) fn syscalls<S: SystemApi>(
         .func_wrap("ic0", "call_data_append", {
             let log = log.clone();
             move |caller: Caller<'_, StoreData<S>>, src: i32, size: i32| {
-                data_append_64(&log, caller, src as i64, size as i64)
+                data_append_64(&log, caller, src as u32 as i64, size as u32 as i64)
             }
         })
         .unwrap();
@@ -1308,7 +1338,7 @@ pub(crate) fn syscalls<S: SystemApi>(
                     canister_id,
                     &mut caller,
                     system_api::complexity_overhead!(STABLE_READ, metering_type),
-                    size as u64,
+                    size as u32 as u64,
                     ExecutionComplexity {
                         cpu: system_api_complexity::cpu::STABLE_READ,
                         ..Default::default()
@@ -1342,7 +1372,7 @@ pub(crate) fn syscalls<S: SystemApi>(
                     canister_id,
                     &mut caller,
                     system_api::complexity_overhead!(STABLE_WRITE, metering_type),
-                    size as u64,
+                    size as u32 as u64,
                     ExecutionComplexity {
                         cpu: system_api_complexity::cpu::STABLE_WRITE,
                         stable_dirty_pages,
@@ -1451,7 +1481,7 @@ pub(crate) fn syscalls<S: SystemApi>(
                     system_api.ic0_stable64_read(dst as u64, offset as u64, size as u64, memory)
                 })?;
                 if feature_flags.write_barrier == FlagStatus::Enabled {
-                    mark_writes_on_bytemap(&mut caller, dst as u32 as usize, size as u32 as usize)
+                    mark_writes_on_bytemap(&mut caller, dst as u64 as usize, size as u64 as usize)
                 } else {
                     Ok(())
                 }
@@ -1907,7 +1937,7 @@ pub(crate) fn syscalls<S: SystemApi>(
                 update_available_memory_64(
                     caller,
                     native_memory_grow_res as i64,
-                    additional_elements as i64,
+                    additional_elements as u32 as i64,
                     element_size,
                 )
                 .map(|result| result as i32)
@@ -2099,7 +2129,7 @@ pub(crate) fn syscalls<S: SystemApi>(
         .func_wrap("ic0", "is_controller", {
             let log = log.clone();
             move |caller: Caller<'_, StoreData<S>>, src: i32, size: i32| {
-                is_controller_64(&log, caller, src as i64, size as i64)
+                is_controller_64(&log, caller, src as u32 as i64, size as u32 as i64)
             }
         })
         .unwrap();
@@ -2113,59 +2143,47 @@ pub(crate) fn syscalls<S: SystemApi>(
         })
         .unwrap();
 
+    let data_certificate_copy_64 = move |log: &ReplicaLogger,
+                                         mut caller: Caller<'_, StoreData<S>>,
+                                         dst: u64,
+                                         offset: u64,
+                                         size: u64| {
+        charge_for_system_api_call(
+            log,
+            canister_id,
+            &mut caller,
+            system_api::complexity_overhead!(DATA_CERTIFICATE_COPY, metering_type),
+            size,
+            ExecutionComplexity {
+                cpu: system_api_complexity::cpu::DATA_CERTIFICATE_COPY,
+                ..Default::default()
+            },
+            NumInstructions::from(0),
+            stable_memory_dirty_page_limit,
+        )?;
+        with_memory_and_system_api(&mut caller, |system_api, memory| {
+            system_api.ic0_data_certificate_copy_64(dst, offset, size, memory)
+        })?;
+        if feature_flags.write_barrier == FlagStatus::Enabled {
+            mark_writes_on_bytemap(&mut caller, dst as usize, size as usize)
+        } else {
+            Ok(())
+        }
+    };
+
     linker
         .func_wrap("ic0", "data_certificate_copy", {
             let log = log.clone();
-            move |mut caller: Caller<'_, StoreData<S>>, dst: u32, offset: u32, size: u32| {
-                charge_for_system_api_call(
-                    &log,
-                    canister_id,
-                    &mut caller,
-                    system_api::complexity_overhead!(DATA_CERTIFICATE_COPY, metering_type),
-                    size as u64,
-                    ExecutionComplexity {
-                        cpu: system_api_complexity::cpu::DATA_CERTIFICATE_COPY,
-                        ..Default::default()
-                    },
-                    NumInstructions::from(0),
-                    stable_memory_dirty_page_limit,
-                )?;
-                with_memory_and_system_api(&mut caller, |system_api, memory| {
-                    system_api.ic0_data_certificate_copy(dst, offset, size, memory)
-                })?;
-                if feature_flags.write_barrier == FlagStatus::Enabled {
-                    mark_writes_on_bytemap(&mut caller, dst as usize, size as usize)
-                } else {
-                    Ok(())
-                }
+            move |caller: Caller<'_, StoreData<S>>, dst: u32, offset: u32, size: u32| {
+                data_certificate_copy_64(&log, caller, dst as u64, offset as u64, size as u64)
             }
         })
         .unwrap();
 
     linker
         .func_wrap("ic0", "data_certificate_copy_64", {
-            move |mut caller: Caller<'_, StoreData<S>>, dst: u64, offset: u64, size: u64| {
-                charge_for_system_api_call(
-                    &log,
-                    canister_id,
-                    &mut caller,
-                    system_api::complexity_overhead!(DATA_CERTIFICATE_COPY, metering_type),
-                    size as u64,
-                    ExecutionComplexity {
-                        cpu: system_api_complexity::cpu::DATA_CERTIFICATE_COPY,
-                        ..Default::default()
-                    },
-                    NumInstructions::from(0),
-                    stable_memory_dirty_page_limit,
-                )?;
-                with_memory_and_system_api(&mut caller, |system_api, memory| {
-                    system_api.ic0_data_certificate_copy_64(dst, offset, size, memory)
-                })?;
-                if feature_flags.write_barrier == FlagStatus::Enabled {
-                    mark_writes_on_bytemap(&mut caller, dst as usize, size as usize)
-                } else {
-                    Ok(())
-                }
+            move |caller: Caller<'_, StoreData<S>>, dst: u64, offset: u64, size: u64| {
+                data_certificate_copy_64(&log, caller, dst, offset, size)
             }
         })
         .unwrap();

--- a/rs/embedders/src/wasmtime_embedder/system_api.rs
+++ b/rs/embedders/src/wasmtime_embedder/system_api.rs
@@ -1633,13 +1633,13 @@ pub(crate) fn syscalls<S: SystemApi>(
     linker
         .func_wrap("__", "update_available_memory", {
             move |mut caller: Caller<'_, StoreData<S>>,
-                  native_memory_grow_res: i32,
-                  additional_elements: i32,
+                  native_memory_grow_res: i64,
+                  additional_elements: i64,
                   element_size: i32| {
                 with_system_api(&mut caller, |s| {
                     s.update_available_memory(
-                        native_memory_grow_res as i64,
-                        additional_elements as u32 as u64,
+                        native_memory_grow_res,
+                        additional_elements as u64,
                         element_size as u32 as u64,
                     )
                 })

--- a/rs/embedders/src/wasmtime_embedder/wasmtime_embedder_tests.rs
+++ b/rs/embedders/src/wasmtime_embedder/wasmtime_embedder_tests.rs
@@ -83,6 +83,7 @@ fn test_wasmtime_system_api() {
             num_instructions_global: None,
         },
     );
+    store.set_epoch_deadline(1);
 
     let wat = r#"
     (module

--- a/rs/embedders/tests/wasmtime_random_memory_writes.rs
+++ b/rs/embedders/tests/wasmtime_random_memory_writes.rs
@@ -418,9 +418,11 @@ fn wat2wasm(wat: &str) -> Result<BinaryEncodedWasm, wat::Error> {
 mod tests {
     use super::*;
 
-    use ic_embedders::{wasm_executor::compute_page_delta, wasmtime_embedder::CanisterMemoryType};
+    use ic_embedders::{
+        wasm_executor::compute_page_delta, wasmtime_embedder::CanisterMemoryType, InstanceRunResult,
+    };
     // Get .current() trait method
-    use ic_interfaces::execution_environment::{HypervisorError, SystemApi};
+    use ic_interfaces::execution_environment::{HypervisorError, HypervisorResult, SystemApi};
     use ic_logger::ReplicaLogger;
     use ic_replicated_state::{PageIndex, PageMap};
     use ic_system_api::ModificationTracking;
@@ -1374,5 +1376,93 @@ mod tests {
             apply_writes_and_check_heap(&writes, ModificationTracking::Track, &wat, false)
         }
         apply_writes_and_check_heap(&writes, ModificationTracking::Ignore, &wat, false);
+    }
+
+    fn run_wasm(wat: &str, function_name: &str) -> HypervisorResult<InstanceRunResult> {
+        with_test_replica_logger(|log| {
+            let wasm = wat::parse_str(wat).map(BinaryEncodedWasm::new).unwrap();
+            let embedder = WasmtimeEmbedder::new(ic_config::embedders::Config::default(), log);
+            let (embedder_cache, result) = compile(&embedder, &wasm);
+            result.unwrap();
+            let api = test_api_for_update(
+                no_op_logger(),
+                None,
+                vec![],
+                SubnetType::Application,
+                NumInstructions::new(10_000_000_000),
+            );
+            let instruction_limit = api.slice_instruction_limit();
+            let memory = Memory::new(PageMap::new_for_testing(), NumWasmPages::from(0));
+            let mut instance = embedder
+                .new_instance(
+                    canister_test_id(1),
+                    &embedder_cache,
+                    None,
+                    &memory.clone(),
+                    &memory,
+                    ModificationTracking::Ignore,
+                    api,
+                )
+                .map_err(|r| r.0)
+                .expect("Failed to create instance");
+            instance.set_instruction_counter(i64::try_from(instruction_limit.get()).unwrap());
+            instance.run(FuncRef::Method(WasmMethod::Update(
+                function_name.to_string(),
+            )))
+        })
+    }
+
+    #[test]
+    fn check_64bit_working_set_limit_by_reading() {
+        let wat = r#"
+                (module
+                    (func (export "canister_update test")
+                        (local $address i64)
+                        loop
+                            local.get $address
+                            i64.load
+                            drop
+                            local.get $address
+                            i64.const 4096 ;; OS page
+                            i64.add
+                            local.set $address
+                            br 0
+                        end
+                    )
+                    (memory i64 131073) ;; 8 GB working set limit + 1 Wasm page
+                )
+            "#;
+        let result = run_wasm(wat, "test");
+        match result.unwrap_err() {
+            HypervisorError::MemoryAccessLimitExceeded(_) => {}
+            other_error => panic!("Unexpected error: {other_error:?}"),
+        }
+    }
+
+    #[test]
+    fn check_64bit_working_set_limit_by_writing() {
+        let wat = r#"
+                (module
+                    (func (export "canister_update test")
+                        (local $address i64)
+                        loop
+                            local.get $address
+                            i64.const 0
+                            i64.store
+                            local.get $address
+                            i64.const 4096 ;; OS page
+                            i64.add
+                            local.set $address
+                            br 0
+                        end
+                    )
+                    (memory i64 131073) ;; 8 GB working set limit + 1 Wasm page
+                )
+            "#;
+        let result = run_wasm(wat, "test");
+        match result.unwrap_err() {
+            HypervisorError::MemoryAccessLimitExceeded(_) => {}
+            other_error => panic!("Unexpected error: {other_error:?}"),
+        }
     }
 }

--- a/rs/embedders/tests/wasmtime_simple.rs
+++ b/rs/embedders/tests/wasmtime_simple.rs
@@ -102,7 +102,8 @@ impl WasmtimeSimple {
             &EmbeddersConfig::default(),
         ))
         .expect("Failed to initialize Wasmtime engine");
-        let store = Store::new(&engine, ());
+        let mut store = Store::new(&engine, ());
+        store.set_epoch_deadline(1);
         Self { engine, store }
     }
 

--- a/rs/replicated_state/src/canister_state/execution_state.rs
+++ b/rs/replicated_state/src/canister_state/execution_state.rs
@@ -429,8 +429,7 @@ pub struct ExecutionState {
     /// properly when loading a state from checkpoint.
     pub wasm_binary: Arc<WasmBinary>,
 
-    /// The persistent heap of the module. The size of this memory is expected
-    /// to fit in a `u32`.
+    /// The persistent heap of the module, 64-bit address space.
     pub wasm_memory: Memory,
 
     /// The canister stable memory which is persisted across canister upgrades.

--- a/rs/system_api/src/lib.rs
+++ b/rs/system_api/src/lib.rs
@@ -37,12 +37,16 @@ use serde::{Deserialize, Serialize};
 use stable_memory::StableMemory;
 use std::{
     convert::{From, TryFrom},
+    mem::size_of,
     sync::Arc,
 };
 
+// Check native 64-bit support, assumed by the 64-bit IC call API implementation.
+const _: () = assert!(size_of::<usize>() == size_of::<u64>());
+
 const MULTIPLIER_MAX_SIZE_LOCAL_SUBNET: u64 = 5;
 const MAX_NON_REPLICATED_QUERY_REPLY_SIZE: NumBytes = NumBytes::new(3 << 20);
-const CERTIFIED_DATA_MAX_LENGTH: u32 = 32;
+const CERTIFIED_DATA_MAX_LENGTH: u64 = 32;
 
 // Enables tracing of system calls for local debugging.
 const TRACE_SYSCALLS: bool = false;
@@ -79,10 +83,10 @@ macro_rules! trace_syscall {
 
 // This helper is used in system calls for displaying a summary hash of a heap region.
 #[inline]
-fn summarize(heap: &[u8], start: u32, size: u32) -> u64 {
+fn summarize(heap: &[u8], start: usize, size: usize) -> u64 {
     if TRACE_SYSCALLS {
-        let start = (start as usize).min(heap.len());
-        let end = (start + (size as usize)).min(heap.len());
+        let start = start.min(heap.len());
+        let end = (start + size).min(heap.len());
         // The actual hash function doesn't matter much as long as it is
         // cheap to compute and maps the input to u64 reasonably well.
         let mut sum = 0;
@@ -1355,11 +1359,31 @@ impl SystemApi for SystemApiImpl {
         size: u32,
         heap: &mut [u8],
     ) -> HypervisorResult<()> {
+        self.ic0_msg_caller_copy_64(dst.into(), offset.into(), size.into(), heap)
+    }
+
+    fn ic0_msg_caller_copy_64(
+        &self,
+        dst: u64,
+        offset: u64,
+        size: u64,
+        heap: &mut [u8],
+    ) -> HypervisorResult<()> {
         let result = match self.get_msg_caller_id("ic0_msg_caller_copy") {
             Ok(caller_id) => {
                 let id_bytes = caller_id.as_slice();
-                valid_subslice("ic0.msg_caller_copy heap", dst, size, heap)?;
-                let slice = valid_subslice("ic0.msg_caller_copy id", offset, size, id_bytes)?;
+                valid_subslice(
+                    "ic0.msg_caller_copy heap",
+                    dst as usize,
+                    size as usize,
+                    heap,
+                )?;
+                let slice = valid_subslice(
+                    "ic0.msg_caller_copy id",
+                    offset as usize,
+                    size as usize,
+                    id_bytes,
+                )?;
                 let (dst, size) = (dst as usize, size as usize);
                 deterministic_copy_from_slice(&mut heap[dst..dst + size], slice);
                 Ok(())
@@ -1373,7 +1397,7 @@ impl SystemApi for SystemApiImpl {
             dst,
             offset,
             size,
-            summarize(heap, dst, size)
+            summarize(heap, dst as usize, size as usize)
         );
         result
     }
@@ -1415,6 +1439,16 @@ impl SystemApi for SystemApiImpl {
         size: u32,
         heap: &mut [u8],
     ) -> HypervisorResult<()> {
+        self.ic0_msg_arg_data_copy_64(dst.into(), offset.into(), size.into(), heap)
+    }
+
+    fn ic0_msg_arg_data_copy_64(
+        &self,
+        dst: u64,
+        offset: u64,
+        size: u64,
+        heap: &mut [u8],
+    ) -> HypervisorResult<()> {
         let result = match &self.api_type {
             ApiType::Start { .. }
             | ApiType::SystemTask { .. }
@@ -1439,11 +1473,16 @@ impl SystemApi for SystemApiImpl {
             | ApiType::NonReplicatedQuery {
                 incoming_payload, ..
             } => {
-                valid_subslice("ic0.msg_arg_data_copy heap", dst, size, heap)?;
+                valid_subslice(
+                    "ic0.msg_arg_data_copy heap",
+                    dst as usize,
+                    size as usize,
+                    heap,
+                )?;
                 let payload_subslice = valid_subslice(
                     "ic0.msg_arg_data_copy payload",
-                    offset,
-                    size,
+                    offset as usize,
+                    size as usize,
                     incoming_payload,
                 )?;
                 let (dst, size) = (dst as usize, size as usize);
@@ -1458,7 +1497,7 @@ impl SystemApi for SystemApiImpl {
             dst,
             offset,
             size,
-            summarize(heap, dst, size)
+            summarize(heap, dst as usize, size as usize)
         );
         result
     }
@@ -1488,6 +1527,16 @@ impl SystemApi for SystemApiImpl {
         size: u32,
         heap: &mut [u8],
     ) -> HypervisorResult<()> {
+        self.ic0_msg_method_name_copy_64(dst.into(), offset.into(), size.into(), heap)
+    }
+
+    fn ic0_msg_method_name_copy_64(
+        &self,
+        dst: u64,
+        offset: u64,
+        size: u64,
+        heap: &mut [u8],
+    ) -> HypervisorResult<()> {
         let result = match &self.api_type {
             ApiType::Start { .. }
             | ApiType::RejectCallback { .. }
@@ -1500,11 +1549,16 @@ impl SystemApi for SystemApiImpl {
             | ApiType::NonReplicatedQuery { .. }
             | ApiType::Init { .. } => Err(self.error_for("ic0_msg_method_name_copy")),
             ApiType::InspectMessage { method_name, .. } => {
-                valid_subslice("ic0.msg_method_name_copy heap", dst, size, heap)?;
+                valid_subslice(
+                    "ic0.msg_method_name_copy heap",
+                    dst as usize,
+                    size as usize,
+                    heap,
+                )?;
                 let payload_subslice = valid_subslice(
                     "ic0.msg_method_name_copy payload",
-                    offset,
-                    size,
+                    offset as usize,
+                    size as usize,
                     method_name.as_bytes(),
                 )?;
                 let (dst, size) = (dst as usize, size as usize);
@@ -1519,7 +1573,7 @@ impl SystemApi for SystemApiImpl {
             dst,
             offset,
             size,
-            summarize(heap, dst, size)
+            summarize(heap, dst as usize, size as usize)
         );
         result
     }
@@ -1578,6 +1632,15 @@ impl SystemApi for SystemApiImpl {
         size: u32,
         heap: &[u8],
     ) -> HypervisorResult<()> {
+        self.ic0_msg_reply_data_append_64(src.into(), size.into(), heap)
+    }
+
+    fn ic0_msg_reply_data_append_64(
+        &mut self,
+        src: u64,
+        size: u64,
+        heap: &[u8],
+    ) -> HypervisorResult<()> {
         let result = match self.get_response_info() {
             None => Err(self.error_for("ic0_msg_reply_data_append")),
             Some((data, max_reply_size, response_status)) => match response_status {
@@ -1591,7 +1654,12 @@ impl SystemApi for SystemApiImpl {
                         );
                         return Err(ContractViolation(string));
                     }
-                    data.extend_from_slice(valid_subslice("msg.reply", src, size, heap)?);
+                    data.extend_from_slice(valid_subslice(
+                        "msg.reply",
+                        src as usize,
+                        size as usize,
+                        heap,
+                    )?);
                     Ok(())
                 }
                 ResponseStatus::AlreadyReplied | ResponseStatus::JustRepliedWith(_) => {
@@ -1607,24 +1675,29 @@ impl SystemApi for SystemApiImpl {
             result,
             src,
             size,
-            summarize(heap, src, size)
+            summarize(heap, src as usize, size as usize)
         );
         result
     }
 
     fn ic0_msg_reject(&mut self, src: u32, size: u32, heap: &[u8]) -> HypervisorResult<()> {
+        self.ic0_msg_reject_64(src.into(), size.into(), heap)
+    }
+
+    fn ic0_msg_reject_64(&mut self, src: u64, size: u64, heap: &[u8]) -> HypervisorResult<()> {
         let result = match self.get_response_info() {
             None => Err(self.error_for("ic0_msg_reject")),
             Some((_, max_reply_size, response_status)) => match response_status {
                 ResponseStatus::NotRepliedYet => {
-                    if size as u64 > max_reply_size.get() {
+                    if size > max_reply_size.get() {
                         let string = format!(
                         "ic0.msg_reject: application payload size ({}) cannot be larger than {}",
                         size, max_reply_size
                     );
                         return Err(ContractViolation(string));
                     }
-                    let msg_bytes = valid_subslice("ic0.msg_reject", src, size, heap)?;
+                    let msg_bytes =
+                        valid_subslice("ic0.msg_reject", src as usize, size as usize, heap)?;
                     let msg = String::from_utf8(msg_bytes.to_vec()).map_err(|_| {
                         ContractViolation(
                             "ic0.msg_reject: invalid UTF-8 string provided".to_string(),
@@ -1645,7 +1718,7 @@ impl SystemApi for SystemApiImpl {
             result,
             src,
             size,
-            summarize(heap, src, size)
+            summarize(heap, src as usize, size as usize)
         );
         result
     }
@@ -1674,16 +1747,35 @@ impl SystemApi for SystemApiImpl {
         size: u32,
         heap: &mut [u8],
     ) -> HypervisorResult<()> {
+        self.ic0_msg_reject_msg_copy_64(dst.into(), offset.into(), size.into(), heap)
+    }
+
+    fn ic0_msg_reject_msg_copy_64(
+        &self,
+        dst: u64,
+        offset: u64,
+        size: u64,
+        heap: &mut [u8],
+    ) -> HypervisorResult<()> {
         let result = {
             let reject_context = self
                 .get_reject_context()
                 .ok_or_else(|| self.error_for("ic0_msg_reject_msg_copy"))?;
-            valid_subslice("ic0.msg_reject_msg_copy heap", dst, size, heap)?;
+            valid_subslice(
+                "ic0.msg_reject_msg_copy heap",
+                dst as usize,
+                size as usize,
+                heap,
+            )?;
 
             let msg = reject_context.message();
             let dst = dst as usize;
-            let msg_bytes =
-                valid_subslice("ic0.msg_reject_msg_copy msg", offset, size, msg.as_bytes())?;
+            let msg_bytes = valid_subslice(
+                "ic0.msg_reject_msg_copy msg",
+                offset as usize,
+                size as usize,
+                msg.as_bytes(),
+            )?;
             let size = size as usize;
             deterministic_copy_from_slice(&mut heap[dst..dst + size], msg_bytes);
             Ok(())
@@ -1695,7 +1787,7 @@ impl SystemApi for SystemApiImpl {
             dst,
             offset,
             size,
-            summarize(heap, dst, size)
+            summarize(heap, dst as usize, size as usize)
         );
         result
     }
@@ -1730,6 +1822,16 @@ impl SystemApi for SystemApiImpl {
         size: u32,
         heap: &mut [u8],
     ) -> HypervisorResult<()> {
+        self.ic0_canister_self_copy_64(dst.into(), offset.into(), size.into(), heap)
+    }
+
+    fn ic0_canister_self_copy_64(
+        &mut self,
+        dst: u64,
+        offset: u64,
+        size: u64,
+        heap: &mut [u8],
+    ) -> HypervisorResult<()> {
         let result = match &self.api_type {
             ApiType::Start { .. } => Err(self.error_for("ic0_canister_self_copy")),
             ApiType::Init { .. }
@@ -1742,10 +1844,20 @@ impl SystemApi for SystemApiImpl {
             | ApiType::ReplyCallback { .. }
             | ApiType::RejectCallback { .. }
             | ApiType::InspectMessage { .. } => {
-                valid_subslice("ic0.canister_self_copy heap", dst, size, heap)?;
+                valid_subslice(
+                    "ic0.canister_self_copy heap",
+                    dst as usize,
+                    size as usize,
+                    heap,
+                )?;
                 let canister_id = self.sandbox_safe_system_state.canister_id;
                 let id_bytes = canister_id.get_ref().as_slice();
-                let slice = valid_subslice("ic0.canister_self_copy id", offset, size, id_bytes)?;
+                let slice = valid_subslice(
+                    "ic0.canister_self_copy id",
+                    offset as usize,
+                    size as usize,
+                    id_bytes,
+                )?;
                 let (dst, size) = (dst as usize, size as usize);
                 deterministic_copy_from_slice(&mut heap[dst..dst + size], slice);
                 Ok(())
@@ -1758,7 +1870,7 @@ impl SystemApi for SystemApiImpl {
             dst,
             offset,
             size,
-            summarize(heap, dst, size)
+            summarize(heap, dst as usize, size as usize)
         );
         result
     }
@@ -1769,6 +1881,31 @@ impl SystemApi for SystemApiImpl {
         callee_size: u32,
         name_src: u32,
         name_len: u32,
+        reply_fun: u32,
+        reply_env: u32,
+        reject_fun: u32,
+        reject_env: u32,
+        heap: &[u8],
+    ) -> HypervisorResult<()> {
+        self.ic0_call_new_64(
+            callee_src.into(),
+            callee_size.into(),
+            name_src.into(),
+            name_len.into(),
+            reply_fun,
+            reply_env,
+            reject_fun,
+            reject_env,
+            heap,
+        )
+    }
+
+    fn ic0_call_new_64(
+        &mut self,
+        callee_src: u64,
+        callee_size: u64,
+        name_src: u64,
+        name_len: u64,
         reply_fun: u32,
         reply_env: u32,
         reject_fun: u32,
@@ -1812,10 +1949,10 @@ impl SystemApi for SystemApiImpl {
 
                 let req = RequestInPrep::new(
                     self.sandbox_safe_system_state.canister_id,
-                    callee_src,
-                    callee_size,
-                    name_src,
-                    name_len,
+                    callee_src as usize,
+                    callee_size as usize,
+                    name_src as usize,
+                    name_len as usize,
                     heap,
                     WasmClosure::new(reply_fun, reply_env),
                     WasmClosure::new(reject_fun, reject_env),
@@ -1839,12 +1976,21 @@ impl SystemApi for SystemApiImpl {
             reply_env,
             reject_fun,
             reject_env,
-            summarize(heap, callee_src, callee_size)
+            summarize(heap, callee_src as usize, callee_size as usize)
         );
         result
     }
 
     fn ic0_call_data_append(&mut self, src: u32, size: u32, heap: &[u8]) -> HypervisorResult<()> {
+        self.ic0_call_data_append_64(src.into(), size.into(), heap)
+    }
+
+    fn ic0_call_data_append_64(
+        &mut self,
+        src: u64,
+        size: u64,
+        heap: &[u8],
+    ) -> HypervisorResult<()> {
         let result = match &mut self.api_type {
             ApiType::Start { .. }
             | ApiType::Init { .. }
@@ -1878,7 +2024,7 @@ impl SystemApi for SystemApiImpl {
                 None => Err(HypervisorError::ContractViolation(
                     "ic0.call_data_append called when no call is under construction.".to_string(),
                 )),
-                Some(request) => request.extend_method_payload(src, size, heap),
+                Some(request) => request.extend_method_payload(src as usize, size as usize, heap),
             },
         };
         trace_syscall!(
@@ -1886,7 +2032,7 @@ impl SystemApi for SystemApiImpl {
             ic0_call_data_append,
             src,
             size,
-            summarize(heap, src, size)
+            summarize(heap, src as usize, size as usize)
         );
         result
     }
@@ -2071,7 +2217,7 @@ impl SystemApi for SystemApiImpl {
             dst,
             offset,
             size,
-            summarize(heap, dst, size)
+            summarize(heap, dst as usize, size as usize)
         );
         result
     }
@@ -2093,7 +2239,7 @@ impl SystemApi for SystemApiImpl {
             offset,
             src,
             size,
-            summarize(heap, src, size)
+            summarize(heap, src as usize, size as usize)
         );
         result
     }
@@ -2140,7 +2286,7 @@ impl SystemApi for SystemApiImpl {
             dst,
             offset,
             size,
-            summarize(heap, dst as u32, size as u32)
+            summarize(heap, dst as usize, size as usize)
         );
         result
     }
@@ -2173,7 +2319,7 @@ impl SystemApi for SystemApiImpl {
             offset,
             src,
             size,
-            summarize(heap, src as u32, size as u32)
+            summarize(heap, src as usize, size as usize)
         );
         result
     }
@@ -2378,17 +2524,21 @@ impl SystemApi for SystemApiImpl {
     }
 
     fn ic0_canister_cycle_balance128(&self, dst: u32, heap: &mut [u8]) -> HypervisorResult<()> {
+        self.ic0_canister_cycle_balance128_64(dst.into(), heap)
+    }
+
+    fn ic0_canister_cycle_balance128_64(&self, dst: u64, heap: &mut [u8]) -> HypervisorResult<()> {
         let result = {
             let method_name = "ic0_canister_cycle_balance128";
             let cycles = self.ic0_canister_cycle_balance_helper(method_name)?;
-            copy_cycles_to_heap(cycles, dst, heap, method_name)?;
+            copy_cycles_to_heap(cycles, dst as usize, heap, method_name)?;
             Ok(())
         };
         trace_syscall!(
             self,
             ic0_canister_cycle_balance128,
             dst,
-            summarize(heap, dst, 16)
+            summarize(heap, dst as usize, 16)
         );
         result
     }
@@ -2408,10 +2558,14 @@ impl SystemApi for SystemApiImpl {
     }
 
     fn ic0_msg_cycles_available128(&self, dst: u32, heap: &mut [u8]) -> HypervisorResult<()> {
+        self.ic0_msg_cycles_available128_64(dst.into(), heap)
+    }
+
+    fn ic0_msg_cycles_available128_64(&self, dst: u64, heap: &mut [u8]) -> HypervisorResult<()> {
         let result = {
             let method_name = "ic0_msg_cycles_available128";
             let cycles = self.ic0_msg_cycles_available_helper(method_name)?;
-            copy_cycles_to_heap(cycles, dst, heap, method_name)?;
+            copy_cycles_to_heap(cycles, dst as usize, heap, method_name)?;
             Ok(())
         };
         trace_syscall!(self, ic0_msg_cycles_available128, result);
@@ -2433,17 +2587,21 @@ impl SystemApi for SystemApiImpl {
     }
 
     fn ic0_msg_cycles_refunded128(&self, dst: u32, heap: &mut [u8]) -> HypervisorResult<()> {
+        self.ic0_msg_cycles_refunded128_64(dst.into(), heap)
+    }
+
+    fn ic0_msg_cycles_refunded128_64(&self, dst: u64, heap: &mut [u8]) -> HypervisorResult<()> {
         let result = {
             let method_name = "ic0_msg_cycles_refunded128";
             let cycles = self.ic0_msg_cycles_refunded_helper(method_name)?;
-            copy_cycles_to_heap(cycles, dst, heap, method_name)?;
+            copy_cycles_to_heap(cycles, dst as usize, heap, method_name)?;
             Ok(())
         };
         trace_syscall!(
             self,
             ic0_msg_cycles_refunded128,
             result,
-            summarize(heap, dst, 16)
+            summarize(heap, dst as usize, 16)
         );
         result
     }
@@ -2474,10 +2632,19 @@ impl SystemApi for SystemApiImpl {
         dst: u32,
         heap: &mut [u8],
     ) -> HypervisorResult<()> {
+        self.ic0_msg_cycles_accept128_64(max_amount, dst.into(), heap)
+    }
+
+    fn ic0_msg_cycles_accept128_64(
+        &mut self,
+        max_amount: Cycles,
+        dst: u64,
+        heap: &mut [u8],
+    ) -> HypervisorResult<()> {
         let result = {
             let method_name = "ic0_msg_cycles_accept128";
             let cycles = self.ic0_msg_cycles_accept_helper(method_name, max_amount)?;
-            copy_cycles_to_heap(cycles, dst, heap, method_name)?;
+            copy_cycles_to_heap(cycles, dst as usize, heap, method_name)?;
             Ok(())
         };
         trace_syscall!(self, ic0_msg_cycles_accept128, result);
@@ -2541,6 +2708,16 @@ impl SystemApi for SystemApiImpl {
         size: u32,
         heap: &mut [u8],
     ) -> HypervisorResult<()> {
+        self.ic0_data_certificate_copy_64(dst.into(), offset.into(), size.into(), heap)
+    }
+
+    fn ic0_data_certificate_copy_64(
+        &self,
+        dst: u64,
+        offset: u64,
+        size: u64,
+        heap: &mut [u8],
+    ) -> HypervisorResult<()> {
         let result = match &self.api_type {
             ApiType::Start { .. }
             | ApiType::Init { .. }
@@ -2600,12 +2777,21 @@ impl SystemApi for SystemApiImpl {
             dst,
             offset,
             size,
-            summarize(heap, dst, size)
+            summarize(heap, dst as usize, size as usize)
         );
         result
     }
 
     fn ic0_certified_data_set(&mut self, src: u32, size: u32, heap: &[u8]) -> HypervisorResult<()> {
+        self.ic0_certified_data_set_64(src.into(), size.into(), heap)
+    }
+
+    fn ic0_certified_data_set_64(
+        &mut self,
+        src: u64,
+        size: u64,
+        heap: &[u8],
+    ) -> HypervisorResult<()> {
         let result = match &mut self.api_type {
             ApiType::Start { .. }
             | ApiType::ReplicatedQuery { .. }
@@ -2658,7 +2844,7 @@ impl SystemApi for SystemApiImpl {
             result,
             src,
             size,
-            summarize(heap, src, size)
+            summarize(heap, src as usize, size as usize)
         );
         result
     }
@@ -2708,9 +2894,13 @@ impl SystemApi for SystemApiImpl {
     }
 
     fn ic0_debug_print(&self, src: u32, size: u32, heap: &[u8]) -> HypervisorResult<()> {
-        const MAX_DEBUG_MESSAGE_SIZE: u32 = 32 * 1024;
+        self.ic0_debug_print_64(src.into(), size.into(), heap)
+    }
+
+    fn ic0_debug_print_64(&self, src: u64, size: u64, heap: &[u8]) -> HypervisorResult<()> {
+        const MAX_DEBUG_MESSAGE_SIZE: u64 = 32 * 1024;
         let size = size.min(MAX_DEBUG_MESSAGE_SIZE);
-        let msg = match valid_subslice("ic0.debug_print", src, size, heap) {
+        let msg = match valid_subslice("ic0.debug_print", src as usize, size as usize, heap) {
             Ok(bytes) => String::from_utf8_lossy(bytes).to_string(),
             Err(_) => {
                 // Do not trap here!
@@ -2735,24 +2925,44 @@ impl SystemApi for SystemApiImpl {
                 time, self.sandbox_safe_system_state.canister_id, msg
             ),
         }
-        trace_syscall!(self, ic0_debug_print, src, size, summarize(heap, src, size));
+        trace_syscall!(
+            self,
+            ic0_debug_print,
+            src,
+            size,
+            summarize(heap, src as usize, size as usize)
+        );
         Ok(())
     }
 
     fn ic0_trap(&self, src: u32, size: u32, heap: &[u8]) -> HypervisorResult<()> {
-        const MAX_ERROR_MESSAGE_SIZE: u32 = 16 * 1024;
+        self.ic0_trap_64(src.into(), size.into(), heap)
+    }
+
+    fn ic0_trap_64(&self, src: u64, size: u64, heap: &[u8]) -> HypervisorResult<()> {
+        const MAX_ERROR_MESSAGE_SIZE: u64 = 16 * 1024;
         let size = size.min(MAX_ERROR_MESSAGE_SIZE);
         let result = {
-            let msg = valid_subslice("trap", src, size, heap)
+            let msg = valid_subslice("trap", src as usize, size as usize, heap)
                 .map(|bytes| String::from_utf8_lossy(bytes).to_string())
                 .unwrap_or_else(|_| "(trap message out of memory bounds)".to_string());
             CalledTrap(msg)
         };
-        trace_syscall!(self, ic0_trap, src, size, summarize(heap, src, size));
+        trace_syscall!(
+            self,
+            ic0_trap,
+            src,
+            size,
+            summarize(heap, src as usize, size as usize)
+        );
         Err(result)
     }
 
     fn ic0_is_controller(&self, src: u32, size: u32, heap: &[u8]) -> HypervisorResult<u32> {
+        self.ic0_is_controller_64(src.into(), size.into(), heap)
+    }
+
+    fn ic0_is_controller_64(&self, src: u64, size: u64, heap: &[u8]) -> HypervisorResult<u32> {
         let result = match &self.api_type {
             ApiType::Start { .. }
             | ApiType::Init { .. }
@@ -2765,7 +2975,8 @@ impl SystemApi for SystemApiImpl {
             | ApiType::ReplyCallback { .. }
             | ApiType::RejectCallback { .. }
             | ApiType::InspectMessage { .. } => {
-                let msg_bytes = valid_subslice("ic0.is_controller", src, size, heap)?;
+                let msg_bytes =
+                    valid_subslice("ic0.is_controller", src as usize, size as usize, heap)?;
                 PrincipalId::try_from(msg_bytes)
                     .map(|principal_id| {
                         self.sandbox_safe_system_state
@@ -2783,7 +2994,7 @@ impl SystemApi for SystemApiImpl {
             ic0_is_controller,
             src,
             size,
-            summarize(heap, src, size),
+            summarize(heap, src as usize, size as usize),
             result
         );
         result
@@ -2806,7 +3017,7 @@ impl OutOfInstructionsHandler for DefaultOutOfInstructionsHandler {
 
 pub(crate) fn copy_cycles_to_heap(
     cycles: Cycles,
-    dst: u32,
+    dst: usize,
     heap: &mut [u8],
     method_name: &str,
 ) -> HypervisorResult<()> {
@@ -2815,7 +3026,6 @@ pub(crate) fn copy_cycles_to_heap(
     let size = bytes.len();
     assert_eq!(size, 16);
 
-    let dst = dst as usize;
     let (upper_bound, overflow) = dst.overflowing_add(size);
     if overflow || upper_bound > heap.len() {
         return Err(ContractViolation(format!(
@@ -2833,12 +3043,10 @@ pub(crate) fn copy_cycles_to_heap(
 
 pub(crate) fn valid_subslice<'a>(
     ctx: &str,
-    src: u32,
-    len: u32,
+    src: usize,
+    len: usize,
     slice: &'a [u8],
 ) -> HypervisorResult<&'a [u8]> {
-    let len = len as usize;
-    let src = src as usize;
     if slice.len() < src + len {
         return Err(ContractViolation(format!(
             "{}: src={} + length={} exceeds the slice size={}",

--- a/rs/system_api/src/request_in_prep.rs
+++ b/rs/system_api/src/request_in_prep.rs
@@ -53,10 +53,10 @@ impl RequestInPrep {
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
         sender: CanisterId,
-        callee_src: u32,
-        callee_size: u32,
-        method_name_src: u32,
-        method_name_len: u32,
+        callee_src: usize,
+        callee_size: usize,
+        method_name_src: usize,
+        method_name_len: usize,
         heap: &[u8],
         on_reply: WasmClosure,
         on_reject: WasmClosure,
@@ -131,8 +131,8 @@ impl RequestInPrep {
 
     pub(crate) fn extend_method_payload(
         &mut self,
-        src: u32,
-        size: u32,
+        src: usize,
+        size: usize,
         heap: &[u8],
     ) -> HypervisorResult<()> {
         let current_size = self.method_name.len() + self.method_payload.len();
@@ -143,7 +143,7 @@ impl RequestInPrep {
                 "Request to {}:{} has a payload size of {}, which exceeds the allowed local-subnet limit of {}",
                 self.callee,
                 self.method_name,
-                current_size + size as usize,
+                current_size + size,
                 max_size_local_subnet
             )))
         } else {

--- a/rs/system_api/src/system_api_empty.rs
+++ b/rs/system_api/src/system_api_empty.rs
@@ -55,6 +55,9 @@ impl SystemApi for SystemApiEmpty {
     fn ic0_msg_caller_copy(&self, _: u32, _: u32, _: u32, _: &mut [u8]) -> HypervisorResult<()> {
         unimplemented!("{}", MESSAGE_UNIMPLEMENTED)
     }
+    fn ic0_msg_caller_copy_64(&self, _: u64, _: u64, _: u64, _: &mut [u8]) -> HypervisorResult<()> {
+        unimplemented!("{}", MESSAGE_UNIMPLEMENTED)
+    }
     fn ic0_msg_caller_size(&self) -> HypervisorResult<u32> {
         unimplemented!("{}", MESSAGE_UNIMPLEMENTED)
     }
@@ -62,6 +65,15 @@ impl SystemApi for SystemApiEmpty {
         unimplemented!("{}", MESSAGE_UNIMPLEMENTED)
     }
     fn ic0_msg_arg_data_copy(&self, _: u32, _: u32, _: u32, _: &mut [u8]) -> HypervisorResult<()> {
+        unimplemented!("{}", MESSAGE_UNIMPLEMENTED)
+    }
+    fn ic0_msg_arg_data_copy_64(
+        &self,
+        _: u64,
+        _: u64,
+        _: u64,
+        _: &mut [u8],
+    ) -> HypervisorResult<()> {
         unimplemented!("{}", MESSAGE_UNIMPLEMENTED)
     }
     fn ic0_msg_method_name_size(&self) -> HypervisorResult<u32> {
@@ -76,10 +88,22 @@ impl SystemApi for SystemApiEmpty {
     ) -> HypervisorResult<()> {
         unimplemented!("{}", MESSAGE_UNIMPLEMENTED)
     }
+    fn ic0_msg_method_name_copy_64(
+        &self,
+        _: u64,
+        _: u64,
+        _: u64,
+        _: &mut [u8],
+    ) -> HypervisorResult<()> {
+        unimplemented!("{}", MESSAGE_UNIMPLEMENTED)
+    }
     fn ic0_accept_message(&mut self) -> HypervisorResult<()> {
         unimplemented!("{}", MESSAGE_UNIMPLEMENTED)
     }
     fn ic0_msg_reply_data_append(&mut self, _: u32, _: u32, _: &[u8]) -> HypervisorResult<()> {
+        unimplemented!("{}", MESSAGE_UNIMPLEMENTED)
+    }
+    fn ic0_msg_reply_data_append_64(&mut self, _: u64, _: u64, _: &[u8]) -> HypervisorResult<()> {
         unimplemented!("{}", MESSAGE_UNIMPLEMENTED)
     }
     fn ic0_msg_reply(&mut self) -> HypervisorResult<()> {
@@ -91,6 +115,9 @@ impl SystemApi for SystemApiEmpty {
     fn ic0_msg_reject(&mut self, _: u32, _: u32, _: &[u8]) -> HypervisorResult<()> {
         unimplemented!("{}", MESSAGE_UNIMPLEMENTED)
     }
+    fn ic0_msg_reject_64(&mut self, _: u64, _: u64, _: &[u8]) -> HypervisorResult<()> {
+        unimplemented!("{}", MESSAGE_UNIMPLEMENTED)
+    }
     fn ic0_msg_reject_msg_size(&self) -> HypervisorResult<u32> {
         unimplemented!("{}", MESSAGE_UNIMPLEMENTED)
     }
@@ -99,6 +126,15 @@ impl SystemApi for SystemApiEmpty {
         _: u32,
         _: u32,
         _: u32,
+        _: &mut [u8],
+    ) -> HypervisorResult<()> {
+        unimplemented!("{}", MESSAGE_UNIMPLEMENTED)
+    }
+    fn ic0_msg_reject_msg_copy_64(
+        &self,
+        _: u64,
+        _: u64,
+        _: u64,
         _: &mut [u8],
     ) -> HypervisorResult<()> {
         unimplemented!("{}", MESSAGE_UNIMPLEMENTED)
@@ -115,10 +151,25 @@ impl SystemApi for SystemApiEmpty {
     ) -> HypervisorResult<()> {
         unimplemented!("{}", MESSAGE_UNIMPLEMENTED)
     }
+    fn ic0_canister_self_copy_64(
+        &mut self,
+        _: u64,
+        _: u64,
+        _: u64,
+        _: &mut [u8],
+    ) -> HypervisorResult<()> {
+        unimplemented!("{}", MESSAGE_UNIMPLEMENTED)
+    }
     fn ic0_debug_print(&self, _: u32, _: u32, _: &[u8]) -> HypervisorResult<()> {
         unimplemented!("{}", MESSAGE_UNIMPLEMENTED)
     }
+    fn ic0_debug_print_64(&self, _: u64, _: u64, _: &[u8]) -> HypervisorResult<()> {
+        unimplemented!("{}", MESSAGE_UNIMPLEMENTED)
+    }
     fn ic0_trap(&self, _: u32, _: u32, _: &[u8]) -> HypervisorResult<()> {
+        unimplemented!("{}", MESSAGE_UNIMPLEMENTED)
+    }
+    fn ic0_trap_64(&self, _: u64, _: u64, _: &[u8]) -> HypervisorResult<()> {
         unimplemented!("{}", MESSAGE_UNIMPLEMENTED)
     }
     fn ic0_call_new(
@@ -135,7 +186,24 @@ impl SystemApi for SystemApiEmpty {
     ) -> HypervisorResult<()> {
         unimplemented!("{}", MESSAGE_UNIMPLEMENTED)
     }
+    fn ic0_call_new_64(
+        &mut self,
+        _: u64,
+        _: u64,
+        _: u64,
+        _: u64,
+        _: u32,
+        _: u32,
+        _: u32,
+        _: u32,
+        _: &[u8],
+    ) -> HypervisorResult<()> {
+        unimplemented!("{}", MESSAGE_UNIMPLEMENTED)
+    }
     fn ic0_call_data_append(&mut self, _: u32, _: u32, _: &[u8]) -> HypervisorResult<()> {
+        unimplemented!("{}", MESSAGE_UNIMPLEMENTED)
+    }
+    fn ic0_call_data_append_64(&mut self, _: u64, _: u64, _: &[u8]) -> HypervisorResult<()> {
         unimplemented!("{}", MESSAGE_UNIMPLEMENTED)
     }
     fn ic0_call_on_cleanup(&mut self, _: u32, _: u32) -> HypervisorResult<()> {
@@ -209,16 +277,25 @@ impl SystemApi for SystemApiEmpty {
     fn ic0_canister_cycle_balance128(&self, _: u32, _: &mut [u8]) -> HypervisorResult<()> {
         unimplemented!("{}", MESSAGE_UNIMPLEMENTED)
     }
+    fn ic0_canister_cycle_balance128_64(&self, _: u64, _: &mut [u8]) -> HypervisorResult<()> {
+        unimplemented!("{}", MESSAGE_UNIMPLEMENTED)
+    }
     fn ic0_msg_cycles_available(&self) -> HypervisorResult<u64> {
         unimplemented!("{}", MESSAGE_UNIMPLEMENTED)
     }
     fn ic0_msg_cycles_available128(&self, _: u32, _: &mut [u8]) -> HypervisorResult<()> {
         unimplemented!("{}", MESSAGE_UNIMPLEMENTED)
     }
+    fn ic0_msg_cycles_available128_64(&self, _: u64, _: &mut [u8]) -> HypervisorResult<()> {
+        unimplemented!("{}", MESSAGE_UNIMPLEMENTED)
+    }
     fn ic0_msg_cycles_refunded(&self) -> HypervisorResult<u64> {
         unimplemented!("{}", MESSAGE_UNIMPLEMENTED)
     }
     fn ic0_msg_cycles_refunded128(&self, _: u32, _: &mut [u8]) -> HypervisorResult<()> {
+        unimplemented!("{}", MESSAGE_UNIMPLEMENTED)
+    }
+    fn ic0_msg_cycles_refunded128_64(&self, _: u64, _: &mut [u8]) -> HypervisorResult<()> {
         unimplemented!("{}", MESSAGE_UNIMPLEMENTED)
     }
     fn ic0_msg_cycles_accept(&mut self, _: u64) -> HypervisorResult<u64> {
@@ -232,7 +309,18 @@ impl SystemApi for SystemApiEmpty {
     ) -> HypervisorResult<()> {
         unimplemented!("{}", MESSAGE_UNIMPLEMENTED)
     }
+    fn ic0_msg_cycles_accept128_64(
+        &mut self,
+        _: Cycles,
+        _: u64,
+        _: &mut [u8],
+    ) -> HypervisorResult<()> {
+        unimplemented!("{}", MESSAGE_UNIMPLEMENTED)
+    }
     fn ic0_certified_data_set(&mut self, _: u32, _: u32, _: &[u8]) -> HypervisorResult<()> {
+        unimplemented!("{}", MESSAGE_UNIMPLEMENTED)
+    }
+    fn ic0_certified_data_set_64(&mut self, _: u64, _: u64, _: &[u8]) -> HypervisorResult<()> {
         unimplemented!("{}", MESSAGE_UNIMPLEMENTED)
     }
     fn ic0_data_certificate_present(&self) -> HypervisorResult<i32> {
@@ -246,6 +334,15 @@ impl SystemApi for SystemApiEmpty {
         _: u32,
         _: u32,
         _: u32,
+        _: &mut [u8],
+    ) -> HypervisorResult<()> {
+        unimplemented!("{}", MESSAGE_UNIMPLEMENTED)
+    }
+    fn ic0_data_certificate_copy_64(
+        &self,
+        _: u64,
+        _: u64,
+        _: u64,
         _: &mut [u8],
     ) -> HypervisorResult<()> {
         unimplemented!("{}", MESSAGE_UNIMPLEMENTED)
@@ -273,6 +370,9 @@ impl SystemApi for SystemApiEmpty {
         unimplemented!("{}", MESSAGE_UNIMPLEMENTED)
     }
     fn ic0_is_controller(&self, _: u32, _: u32, _: &[u8]) -> HypervisorResult<u32> {
+        unimplemented!("{}", MESSAGE_UNIMPLEMENTED)
+    }
+    fn ic0_is_controller_64(&self, _: u64, _: u64, _: &[u8]) -> HypervisorResult<u32> {
         unimplemented!("{}", MESSAGE_UNIMPLEMENTED)
     }
 }

--- a/rs/system_api/tests/common/mod.rs
+++ b/rs/system_api/tests/common/mod.rs
@@ -25,6 +25,7 @@ use ic_types::{
     messages::{CallContextId, CallbackId, RejectContext},
     methods::SystemMethod,
     ComputeAllocation, Cycles, MemoryAllocation, NumInstructions, PrincipalId, Time,
+    MAX_WASM_MEMORY_IN_BYTES,
 };
 use maplit::btreemap;
 
@@ -39,7 +40,7 @@ pub fn execution_parameters() -> ExecutionParameters {
             NumInstructions::from(5_000_000_000),
             NumInstructions::from(5_000_000_000),
         ),
-        canister_memory_limit: NumBytes::new(4 << 30),
+        canister_memory_limit: NumBytes::new(MAX_WASM_MEMORY_IN_BYTES),
         memory_allocation: MemoryAllocation::default(),
         compute_allocation: ComputeAllocation::default(),
         subnet_type: SubnetType::Application,

--- a/rs/types/types/src/lib.rs
+++ b/rs/types/types/src/lib.rs
@@ -482,7 +482,7 @@ pub enum LongExecutionMode {
 /// Represents the memory allocation of a canister.
 #[derive(Copy, Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize, Hash)]
 pub enum MemoryAllocation {
-    /// A reserved number of bytes between 0 and 2^48 inclusively that is
+    /// A reserved number of bytes between 0 and 2^64 inclusively that is
     /// guaranteed to be available to the canister. Charging happens based on
     /// the reserved amount of memory, regardless of how much of it is in use.
     Reserved(NumBytes),
@@ -563,7 +563,7 @@ pub const MAX_STABLE_MEMORY_IN_BYTES: u64 = 64 * GB;
 /// The upper limit on the Wasm memory size.
 /// This constant is used by other crates to define other constants, that's why
 /// it is public and `u64` (`NumBytes` cannot be used in const expressions).
-pub const MAX_WASM_MEMORY_IN_BYTES: u64 = 4 * GB;
+pub const MAX_WASM_MEMORY_IN_BYTES: u64 = 64 * GB;
 
 const MIN_MEMORY_ALLOCATION: NumBytes = NumBytes::new(0);
 pub const MAX_MEMORY_ALLOCATION: NumBytes =


### PR DESCRIPTION
**DO NOT MERGE**

Prototype for related to ideas of enhancing Motoko's orthogonal persistence: 
* Extend the main memory to 64-bit (still transient in this PR). 
* Limit the number of page accesses on main memory per message.
* Provide a 64-bit IC API. 
* Automatic detection of 32-bit or 64-bit Wasm execution. 

Related PRs for more details:
* IC Enhanced Orthogonal Persistence Support for Motoko: https://github.com/dfinity/ic/pull/143
* Motoko 64-Bit: https://github.com/dfinity/motoko/pull/4136
* Motoko Stable Heap for Scalable Upgrades: https://github.com/dfinity/motoko/pull/4225