### PR TITLE
SNS governance proposal action: ManageLedgerParameters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9988,6 +9988,7 @@ dependencies = [
  "ic-canisters-http-types",
  "ic-crypto-sha2",
  "ic-ic00-types",
+ "ic-icrc1-ledger",
  "ic-ledger-core",
  "ic-metrics-encoder",
  "ic-nervous-system-clients",

--- a/rs/rosetta-api/icrc1/ledger/ledger.did
+++ b/rs/rosetta-api/icrc1/ledger/ledger.did
@@ -129,6 +129,7 @@ type UpgradeArgs = record {
     token_symbol : opt text;
     token_name : opt text;
     transfer_fee : opt nat;
+    token_decimals : opt nat8;
     change_fee_collector : opt ChangeFeeCollector;
     max_memo_length : opt nat16;
     feature_flags : opt FeatureFlags;

--- a/rs/rosetta-api/icrc1/ledger/src/lib.rs
+++ b/rs/rosetta-api/icrc1/ledger/src/lib.rs
@@ -251,6 +251,8 @@ pub struct UpgradeArgs {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub token_symbol: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub token_decimals: Option<u8>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub transfer_fee: Option<Nat>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub change_fee_collector: Option<ChangeFeeCollector>,
@@ -566,6 +568,9 @@ impl<Tokens: TokensType> Ledger<Tokens> {
         }
         if let Some(token_symbol) = args.token_symbol {
             self.token_symbol = token_symbol;
+        }
+        if let Some(token_decimals) = args.token_decimals {
+            self.decimals = token_decimals;
         }
         if let Some(transfer_fee) = args.transfer_fee {
             self.transfer_fee = Tokens::try_from(transfer_fee.clone()).unwrap_or_else(|e| {

--- a/rs/sns/governance/BUILD.bazel
+++ b/rs/sns/governance/BUILD.bazel
@@ -23,6 +23,7 @@ DEPENDENCIES = [
     "//rs/nns/constants",
     "//rs/protobuf",
     "//rs/rosetta-api/icp_ledger",
+    "//rs/rosetta-api/icrc1/ledger",
     "//rs/rosetta-api/ledger_core",
     "//rs/rust_canisters/canister_log",
     "//rs/rust_canisters/canister_profiler",

--- a/rs/sns/governance/Cargo.toml
+++ b/rs/sns/governance/Cargo.toml
@@ -38,6 +38,7 @@ ic-crypto-sha2 = { path = "../../crypto/sha2/" }
 ic-ic00-types = { path = "../../types/ic00_types" }
 icrc-ledger-client = { path = "../../../packages/icrc-ledger-client" }
 ic-ledger-core = { path = "../../rosetta-api/ledger_core" }
+ic-icrc1-ledger = { path = "../../rosetta-api/icrc1/ledger" }
 ic-metrics-encoder = "1"
 ic-nervous-system-clients = { path = "../../nervous_system/clients" }
 ic-nervous-system-common = { path = "../../nervous_system/common" }

--- a/rs/sns/governance/canister/governance.did
+++ b/rs/sns/governance/canister/governance.did
@@ -11,6 +11,7 @@ type Action = variant {
   Unspecified : record {};
   ManageSnsMetadata : ManageSnsMetadata;
   ExecuteGenericNervousSystemFunction : ExecuteGenericNervousSystemFunction;
+  ManageLedgerParameters : ManageLedgerParameters;
   Motion : Motion;
 };
 type AddNeuronPermissions = record {
@@ -224,6 +225,13 @@ type ListProposals = record {
   include_status : vec int32;
 };
 type ListProposalsResponse = record { proposals : vec ProposalData };
+type ManageLedgerParameters = record {
+  token_symbol : opt text;
+  transfer_fee : opt nat64;
+  set_fee_collector : opt Account;
+  token_decimals : opt nat32;
+  token_name : opt text;
+};
 type ManageNeuron = record { subaccount : vec nat8; command : opt Command };
 type ManageNeuronResponse = record { command : opt Command_1 };
 type ManageSnsMetadata = record {

--- a/rs/sns/governance/proto/ic_sns_governance/pb/v1/governance.proto
+++ b/rs/sns/governance/proto/ic_sns_governance/pb/v1/governance.proto
@@ -344,6 +344,16 @@ message TransferSnsTreasuryFunds {
   optional Subaccount to_subaccount = 5;
 }
 
+// A proposal function that changes the ledger's parameters.
+// Fields with None values will remain unchanged.
+message ManageLedgerParameters {
+  optional string token_name = 1;
+  optional string token_symbol = 2;
+  optional uint32 token_decimals = 3;
+  optional uint64 transfer_fee = 4;
+  optional Account set_fee_collector = 5;
+}
+
 // A proposal function to change the values of SNS metadata.
 // Fields with None values will remain unchanged.
 message ManageSnsMetadata {
@@ -473,6 +483,9 @@ message Proposal {
     //
     // Id = 11.
     DeregisterDappCanisters deregister_dapp_canisters = 15;
+    
+    // Id = 12
+    ManageLedgerParameters manage_ledger_parameters = 16;
   }
 }
 
@@ -650,6 +663,7 @@ message ProposalData {
   // Id 7 - UpgradeSnsToNextVersion proposals.
   // Id 8 - ManageSnsMetadata proposals.
   // Id 9 - TransferSnsTreasuryFunds proposals.
+  // Id 12 - ManageLedgerParameters proposals.
   uint64 action = 1;
 
   // This is stored here temporarily. It is also stored on the map

--- a/rs/sns/governance/src/gen/ic_sns_governance.pb.v1.rs
+++ b/rs/sns/governance/src/gen/ic_sns_governance.pb.v1.rs
@@ -394,6 +394,23 @@ pub mod transfer_sns_treasury_funds {
         }
     }
 }
+/// A proposal function that changes the ledger's parameters.
+/// Fields with None values will remain unchanged.
+#[derive(candid::CandidType, candid::Deserialize, comparable::Comparable)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ManageLedgerParameters {
+    #[prost(string, optional, tag = "1")]
+    pub token_name: ::core::option::Option<::prost::alloc::string::String>,
+    #[prost(string, optional, tag = "2")]
+    pub token_symbol: ::core::option::Option<::prost::alloc::string::String>,
+    #[prost(uint32, optional, tag = "3")]
+    pub token_decimals: ::core::option::Option<u32>,
+    #[prost(uint64, optional, tag = "4")]
+    pub transfer_fee: ::core::option::Option<u64>,
+    #[prost(message, optional, tag = "5")]
+    pub set_fee_collector: ::core::option::Option<Account>,
+}
 /// A proposal function to change the values of SNS metadata.
 /// Fields with None values will remain unchanged.
 #[derive(candid::CandidType, candid::Deserialize, comparable::Comparable)]
@@ -474,7 +491,7 @@ pub struct Proposal {
     /// of this mapping.
     #[prost(
         oneof = "proposal::Action",
-        tags = "4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15"
+        tags = "4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16"
     )]
     pub action: ::core::option::Option<proposal::Action>,
 }
@@ -565,6 +582,9 @@ pub mod proposal {
         /// Id = 11.
         #[prost(message, tag = "15")]
         DeregisterDappCanisters(super::DeregisterDappCanisters),
+        /// Id = 12
+        #[prost(message, tag = "16")]
+        ManageLedgerParameters(super::ManageLedgerParameters),
     }
 }
 #[derive(candid::CandidType, candid::Deserialize, comparable::Comparable)]
@@ -771,6 +791,7 @@ pub struct ProposalData {
     /// Id 7 - UpgradeSnsToNextVersion proposals.
     /// Id 8 - ManageSnsMetadata proposals.
     /// Id 9 - TransferSnsTreasuryFunds proposals.
+    /// Id 12 - ManageLedgerParameters proposals.
     #[prost(uint64, tag = "1")]
     pub action: u64,
     /// This is stored here temporarily. It is also stored on the map

--- a/rs/sns/governance/src/types.rs
+++ b/rs/sns/governance/src/types.rs
@@ -99,6 +99,9 @@ pub mod native_action_ids {
 
     /// DeregisterDappCanisters Action.
     pub const DEREGISTER_DAPP_CANISTERS: u64 = 11;
+    
+    /// ManageLedgerParameters Action.
+    pub const MANAGE_LEDGER_PARAMETERS: u64 = 12;
 }
 
 impl governance::Mode {
@@ -1058,6 +1061,12 @@ impl From<Action> for NervousSystemFunction {
                 ),
                 function_type: Some(FunctionType::NativeNervousSystemFunction(Empty {})),
             },
+            Action::ManageLedgerParameters(_) => NervousSystemFunction {
+                id: native_action_ids::MANAGE_LEDGER_PARAMETERS,
+                name: "Manage ledger parameters".to_string(),
+                description: Some("Proposal to change some parameters in the ledger canister.".to_string()),
+                function_type: Some(FunctionType::NativeNervousSystemFunction(Empty {})),
+            },
         }
     }
 }
@@ -1517,6 +1526,7 @@ impl From<&Action> for u64 {
             Action::DeregisterDappCanisters(_) => native_action_ids::DEREGISTER_DAPP_CANISTERS,
             Action::ManageSnsMetadata(_) => native_action_ids::MANAGE_SNS_METADATA,
             Action::TransferSnsTreasuryFunds(_) => native_action_ids::TRANSFER_SNS_TREASURY_FUNDS,
+            Action::ManageLedgerParameters(_) => native_action_ids::MANAGE_LEDGER_PARAMETERS,
         }
     }
 }

--- a/rs/sns/root/canister/canister.rs
+++ b/rs/sns/root/canister/canister.rs
@@ -215,6 +215,25 @@ fn change_canister(proposal: ChangeCanisterProposal) {
     >(proposal));
 }
 
+// This method returns an error to the caller if the upgrade failed. 
+// This is in contrast to the previous method "change_canister" that returns before doing the upgrade. 
+#[candid_method(update)]
+#[update]
+async fn change_canister_with_blocking(proposal: ChangeCanisterProposal) {
+    log!(INFO, "change_ledger_parameters");
+    assert_eq_governance_canister_id(PrincipalId(ic_cdk::api::caller()));
+    assert_change_canister_proposal_is_valid(&proposal);
+    
+    STATE.with(|state| {
+        assert_ne!(state.borrow().governance_canister_id(), proposal.canister_id.get());
+    });
+        
+    // We can await the full outcome of the upgrade. 
+    // This will not cause a deadlock because we made sure that caller is the governance-canister and the target-canister is not the governance-canister.
+    ic_nervous_system_root::change_canister::change_canister::<CanisterRuntime>(proposal).await    
+            
+}
+
 /// This function is deprecated, and `register_dapp_canisters` should be used
 /// instead. (NNS1-1991)
 ///

--- a/rs/sns/root/canister/root.did
+++ b/rs/sns/root/canister/root.did
@@ -92,6 +92,7 @@ type SnsRootCanister = record {
 service : (SnsRootCanister) -> {
   canister_status : (CanisterIdRecord) -> (CanisterStatusResult);
   change_canister : (ChangeCanisterProposal) -> ();
+  change_canister_with_blocking : (ChangeCanisterProposal) -> ();
   get_build_metadata : () -> (text) query;
   get_sns_canisters_summary : (GetSnsCanistersSummaryRequest) -> (
       GetSnsCanistersSummaryResponse,


### PR DESCRIPTION
This change creates a new sns governance proposal action: `ManageLedgerParameters`.

This proposal action lets an sns set the ledger parameters: `transfer_fee`, `token_symbol`, `token_name`, `decimals`, and `fee_collector`. Whereas before this change there was no way for an sns to update these parameters.

The proposal action `ManageLedgerParameters` tells the root canister to upgrade the ledger to it's same current wasm module with an upgrade arg that contains the new values for the parameters that are being set. The ledger in the post_upgrade hook, updates its own values with those parameters that are set in the post_upgrade hook.

  