### PR TITLE
Deterministic Working Set Limit for 64-Bit Main Memory

### DIFF
--- a/Cargo.Bazel.StaticOpenSSL.json.lock
+++ b/Cargo.Bazel.StaticOpenSSL.json.lock
@@ -21726,7 +21726,7 @@
         "Git": {
           "remote": "https://github.com/dfinity/bitcoin-canister",
           "commitish": {
-            "Rev": "0e996988693f2d55fc9533c44dc20ae5310a1894"
+            "Rev": "b1693619e3d4dbc00d8c79e9b6886e1db48b21f7"
           },
           "strip_prefix": "validation"
         }

--- a/Cargo.Bazel.StaticOpenSSL.toml.lock
+++ b/Cargo.Bazel.StaticOpenSSL.toml.lock
@@ -4333,7 +4333,7 @@ dependencies = [
 [[package]]
 name = "ic-btc-validation"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/bitcoin-canister?rev=0e996988693f2d55fc9533c44dc20ae5310a1894#0e996988693f2d55fc9533c44dc20ae5310a1894"
+source = "git+https://github.com/dfinity/bitcoin-canister?rev=b1693619e3d4dbc00d8c79e9b6886e1db48b21f7#b1693619e3d4dbc00d8c79e9b6886e1db48b21f7"
 dependencies = [
  "bitcoin 0.28.2",
 ]

--- a/Cargo.Bazel.json.lock
+++ b/Cargo.Bazel.json.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "063b137ede9410b4a179abce325613a6e86f8ecdc30828d52c1eda21f9694ebf",
+  "checksum": "c23f7bdd37d1352a14ed64c56e8e1618d88f9a84425666d48f7d2a9be6c38b35",
   "crates": {
     "abnf 0.12.0": {
       "name": "abnf",
@@ -27246,12 +27246,27 @@
         ],
         "crate_features": {
           "common": [
-            "errno",
             "general",
             "ioctl",
             "no_std"
           ],
-          "selects": {}
+          "selects": {
+            "aarch64-unknown-linux-gnu": [
+              "errno"
+            ],
+            "arm-unknown-linux-gnueabi": [
+              "errno"
+            ],
+            "armv7-unknown-linux-gnueabi": [
+              "errno"
+            ],
+            "i686-unknown-linux-gnu": [
+              "errno"
+            ],
+            "x86_64-unknown-linux-gnu": [
+              "errno"
+            ]
+          }
         },
         "edition": "2018",
         "version": "0.3.8"
@@ -27285,12 +27300,27 @@
         ],
         "crate_features": {
           "common": [
-            "errno",
             "general",
             "ioctl",
             "no_std"
           ],
-          "selects": {}
+          "selects": {
+            "aarch64-unknown-linux-gnu": [
+              "errno"
+            ],
+            "arm-unknown-linux-gnueabi": [
+              "errno"
+            ],
+            "armv7-unknown-linux-gnueabi": [
+              "errno"
+            ],
+            "i686-unknown-linux-gnu": [
+              "errno"
+            ],
+            "x86_64-unknown-linux-gnu": [
+              "errno"
+            ]
+          }
         },
         "edition": "2021",
         "version": "0.4.3"

--- a/Cargo.Bazel.json.lock
+++ b/Cargo.Bazel.json.lock
@@ -21726,7 +21726,7 @@
         "Git": {
           "remote": "https://github.com/dfinity/bitcoin-canister",
           "commitish": {
-            "Rev": "0e996988693f2d55fc9533c44dc20ae5310a1894"
+            "Rev": "b1693619e3d4dbc00d8c79e9b6886e1db48b21f7"
           },
           "strip_prefix": "validation"
         }

--- a/Cargo.Bazel.toml.lock
+++ b/Cargo.Bazel.toml.lock
@@ -4333,7 +4333,7 @@ dependencies = [
 [[package]]
 name = "ic-btc-validation"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/bitcoin-canister?rev=0e996988693f2d55fc9533c44dc20ae5310a1894#0e996988693f2d55fc9533c44dc20ae5310a1894"
+source = "git+https://github.com/dfinity/bitcoin-canister?rev=b1693619e3d4dbc00d8c79e9b6886e1db48b21f7#b1693619e3d4dbc00d8c79e9b6886e1db48b21f7"
 dependencies = [
  "bitcoin 0.28.2",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5233,7 +5233,7 @@ dependencies = [
 [[package]]
 name = "ic-btc-validation"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/bitcoin-canister?rev=0e996988693f2d55fc9533c44dc20ae5310a1894#0e996988693f2d55fc9533c44dc20ae5310a1894"
+source = "git+https://github.com/dfinity/bitcoin-canister?rev=b1693619e3d4dbc00d8c79e9b6886e1db48b21f7#b1693619e3d4dbc00d8c79e9b6886e1db48b21f7"
 dependencies = [
  "bitcoin 0.28.2",
 ]

--- a/bazel/external_crates.bzl
+++ b/bazel/external_crates.bzl
@@ -475,7 +475,7 @@ def external_crates_repository(name, static_openssl, cargo_lockfile, lockfile):
             ),
             "ic-btc-validation": crate.spec(
                 git = "https://github.com/dfinity/bitcoin-canister",
-                rev = "0e996988693f2d55fc9533c44dc20ae5310a1894",
+                rev = "b1693619e3d4dbc00d8c79e9b6886e1db48b21f7",
             ),
             "ic-btc-test-utils": crate.spec(
                 git = "https://github.com/dfinity/bitcoin-canister",

--- a/rs/bitcoin/adapter/Cargo.toml
+++ b/rs/bitcoin/adapter/Cargo.toml
@@ -14,7 +14,7 @@ http = "0.2"
 ic-adapter-metrics-server = { path = "../../monitoring/adapter_metrics_server" }
 ic-async-utils = { path = "../../async_utils" }
 ic-btc-service = { path = "../service" }
-ic-btc-validation = { git = "https://github.com/dfinity/bitcoin-canister", rev = "0e996988693f2d55fc9533c44dc20ae5310a1894" }
+ic-btc-validation = { git = "https://github.com/dfinity/bitcoin-canister", rev = "b1693619e3d4dbc00d8c79e9b6886e1db48b21f7" }
 ic-config = { path = "../../config" }
 ic-logger = { path = "../../monitoring/logger" }
 ic-metrics = { path = "../../monitoring/metrics" }

--- a/rs/canister_sandbox/backend_lib/src/sandbox_server.rs
+++ b/rs/canister_sandbox/backend_lib/src/sandbox_server.rs
@@ -165,6 +165,7 @@ mod tests {
         methods::{FuncRef, WasmMethod},
         time::Time,
         CanisterTimer, ComputeAllocation, Cycles, MemoryAllocation, NumBytes, NumInstructions,
+        MAX_WASM_MEMORY_IN_BYTES,
     };
     use mockall::*;
     use std::collections::{BTreeMap, BTreeSet};
@@ -180,7 +181,7 @@ mod tests {
                 NumInstructions::new(INSTRUCTION_LIMIT),
                 NumInstructions::new(INSTRUCTION_LIMIT),
             ),
-            canister_memory_limit: NumBytes::new(4 << 30),
+            canister_memory_limit: NumBytes::new(MAX_WASM_MEMORY_IN_BYTES),
             memory_allocation: MemoryAllocation::default(),
             compute_allocation: ComputeAllocation::default(),
             subnet_type: SubnetType::Application,

--- a/rs/config/src/embedders.rs
+++ b/rs/config/src/embedders.rs
@@ -62,6 +62,10 @@ pub const STABLE_MEMORY_DIRTY_PAGE_LIMIT: u64 = 8 * GiB / (PAGE_SIZE as u64);
 // is allowed to access.
 pub const STABLE_MEMORY_ACCESSED_PAGE_LIMIT: u64 = 8 * GiB / (PAGE_SIZE as u64);
 
+/// Used for 64-bit main memory support:
+/// Limit for the number of pages accessed in a single message.
+pub const MAIN_MEMORY_PAGE_ACCESS_LIMIT: u64 = STABLE_MEMORY_ACCESSED_PAGE_LIMIT;
+
 #[derive(Copy, Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
 pub struct FeatureFlags {
     /// If this flag is enabled, then the output of the `debug_print` system-api

--- a/rs/config/src/embedders.rs
+++ b/rs/config/src/embedders.rs
@@ -63,7 +63,7 @@ pub const STABLE_MEMORY_DIRTY_PAGE_LIMIT: u64 = 8 * GiB / (PAGE_SIZE as u64);
 pub const STABLE_MEMORY_ACCESSED_PAGE_LIMIT: u64 = 8 * GiB / (PAGE_SIZE as u64);
 
 /// Used for 64-bit main memory support:
-/// Limit for the number of pages accessed in a single message.
+/// Limit the number of main memory pages accessed in a single message.
 pub const MAIN_MEMORY_PAGE_ACCESS_LIMIT: u64 = STABLE_MEMORY_ACCESSED_PAGE_LIMIT;
 
 #[derive(Copy, Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]

--- a/rs/drun/src/lib.rs
+++ b/rs/drun/src/lib.rs
@@ -54,6 +54,8 @@ mod message;
 const MAX_BATCHES_UNTIL_RESPONSE: u64 = 10000;
 // how long to wait between batches
 const WAIT_PER_BATCH: Duration = Duration::from_millis(5);
+// Use the new orthogonal persistence.
+const KEEP_MAIN_MEMORY_ON_UPGRADE: bool = true;
 
 pub struct DrunOptions {
     pub msg_filename: String,

--- a/rs/drun/src/message.rs
+++ b/rs/drun/src/message.rs
@@ -3,7 +3,8 @@ use crate::KEEP_MAIN_MEMORY_ON_UPGRADE;
 use super::CanisterId;
 
 use hex::decode;
-use ic_ic00_types::{self as ic00, CanisterInstallMode, Payload};
+use ic00::{CanisterInstallModeV2, UpgradeOptions};
+use ic_ic00_types::{self as ic00, Payload};
 use ic_types::{
     messages::{SignedIngress, UserQuery},
     time::expiry_time_from_now,
@@ -11,7 +12,6 @@ use ic_types::{
 };
 
 use std::{
-    convert::TryFrom,
     fmt,
     fs::File,
     io::{self, Read},
@@ -243,21 +243,32 @@ fn parse_install(
     let canister_id = parse_canister_id(canister_id)?;
     let payload = parse_octet_string(payload)?;
 
+    let install_mode = match mode {
+        "install" => CanisterInstallModeV2::Install,
+        "reinstall" => CanisterInstallModeV2::Reinstall,
+        "upgrade" => CanisterInstallModeV2::Upgrade(Some(UpgradeOptions {
+            skip_pre_upgrade: None,
+            keep_main_memory: Some(KEEP_MAIN_MEMORY_ON_UPGRADE),
+        })),
+        _ => {
+            return Err(String::from("Unsupported install mode: {mode}"));
+        }
+    };
+
     let signed_ingress = SignedIngressBuilder::new()
         // `source` should become a self-authenticating id according
         // to https://sdk.dfinity.org/docs/interface-spec/index.html#id-classes
         .canister_id(ic00::IC_00)
         .method_name(ic00::Method::InstallCode)
         .method_payload(
-            ic00::InstallCodeArgs::new(
-                CanisterInstallMode::try_from(mode.to_string()).unwrap(),
+            ic00::InstallCodeArgsV2::new(
+                install_mode,
                 canister_id,
                 wasm_data,
                 payload,
                 None,
                 None,
                 None,
-                Some(KEEP_MAIN_MEMORY_ON_UPGRADE),
             )
             .encode(),
         )

--- a/rs/drun/src/message.rs
+++ b/rs/drun/src/message.rs
@@ -1,3 +1,5 @@
+use crate::KEEP_MAIN_MEMORY_ON_UPGRADE;
+
 use super::CanisterId;
 
 use hex::decode;
@@ -255,6 +257,7 @@ fn parse_install(
                 None,
                 Some(8 * 1024 * 1024 * 1024), // drun users dont care about memory limits
                 None,
+                Some(KEEP_MAIN_MEMORY_ON_UPGRADE),
             )
             .encode(),
         )

--- a/rs/drun/src/message.rs
+++ b/rs/drun/src/message.rs
@@ -255,7 +255,7 @@ fn parse_install(
                 wasm_data,
                 payload,
                 None,
-                Some(8 * 1024 * 1024 * 1024), // drun users dont care about memory limits
+                None,
                 None,
                 Some(KEEP_MAIN_MEMORY_ON_UPGRADE),
             )

--- a/rs/embedders/src/signal_handler.rs
+++ b/rs/embedders/src/signal_handler.rs
@@ -1,5 +1,8 @@
 use crate::wasmtime_embedder::host_memory::MemoryPageSize;
+use crate::wasmtime_embedder::MAIN_MEMORY_PAGE_ACCESS_LIMIT;
 
+use ic_interfaces::execution_environment::HypervisorResult;
+use ic_replicated_state::EmbedderCache;
 use libc::c_void;
 use memory_tracker::{signal_access_kind_and_address, SigsegvMemoryTracker};
 use std::convert::TryFrom;
@@ -8,6 +11,7 @@ use std::sync::{atomic::Ordering, Arc, Mutex};
 
 /// Helper function to create a memory tracking SIGSEGV handler function.
 pub(crate) fn sigsegv_memory_tracker_handler(
+    cache: EmbedderCache,
     memories: Vec<(Arc<Mutex<SigsegvMemoryTracker>>, MemoryPageSize)>,
 ) -> impl Fn(i32, *const libc::siginfo_t, *const libc::c_void) -> bool + Send + Sync {
     let mut memories: Vec<_> = memories
@@ -81,6 +85,17 @@ pub(crate) fn sigsegv_memory_tracker_handler(
         {
             let delta = heap_size - memory_tracker.area().size();
             memory_tracker.expand(delta);
+
+            // Limiting the number of page accesses in 64-bit main memory support.
+            // This is done by interrupting the wasmtime engine in a controlled way by using the epoch mechanism.
+            if memory_tracker.num_accessed_pages() as u64 > MAIN_MEMORY_PAGE_ACCESS_LIMIT {
+                let module = cache
+                    .downcast::<HypervisorResult<wasmtime::Module>>()
+                    .unwrap()
+                    .as_ref()
+                    .unwrap();
+                module.engine().increment_epoch();
+            }
             true
         } else {
             false

--- a/rs/embedders/src/wasm_executor.rs
+++ b/rs/embedders/src/wasm_executor.rs
@@ -661,7 +661,7 @@ pub fn process(
 
     let wasm_heap_size_after = instance.heap_size(CanisterMemoryType::Heap);
     let wasm_heap_limit =
-        NumWasmPages::from(wasmtime_environ::WASM32_MAX_PAGES as usize) - wasm_reserved_pages;
+        NumWasmPages::from(wasmtime_environ::WASM64_MAX_PAGES as usize) - wasm_reserved_pages;
 
     if wasm_heap_size_after > wasm_heap_limit {
         wasm_result = Err(HypervisorError::WasmReservedPages);

--- a/rs/embedders/src/wasm_utils/instrumentation.rs
+++ b/rs/embedders/src/wasm_utils/instrumentation.rs
@@ -1,6 +1,8 @@
 //! This module is responsible for instrumenting wasm binaries on the Internet
 //! Computer.
 //!
+//! Supports 64-bit main memory by using `wasm64`.
+//!
 //! It exports the function [`instrument`] which takes a Wasm binary and
 //! injects some instrumentation that allows to:
 //!  * Quantify the amount of execution every function of that module conducts.
@@ -26,6 +28,7 @@
 //! ```wasm
 //! (import "__" "out_of_instructions" (func (;0;) (func)))
 //! (import "__" "update_available_memory" (func (;1;) ((param i32 i32 i32) (result i32))))
+//! (import "__" "update_available_memory_64" (func (;1;) ((param i64 i64 i32) (result i64))))
 //! (import "__" "try_grow_stable_memory" (func (;1;) ((param i64 i64 i32) (result i64))))
 //! (import "__" "internal_trap" (func (;1;) ((param i32))))
 //! (import "__" "stable_read_first_access" (func ((param i64) (param i64) (param i64))))
@@ -459,6 +462,7 @@ pub fn instruction_to_cost_new(i: &Operator) -> u64 {
 const INSTRUMENTED_FUN_MODULE: &str = "__";
 const OUT_OF_INSTRUCTIONS_FUN_NAME: &str = "out_of_instructions";
 const UPDATE_MEMORY_FUN_NAME: &str = "update_available_memory";
+const UPDATE_MEMORY_64_FUN_NAME: &str = "update_available_memory_64";
 const TRY_GROW_STABLE_MEMORY_FUN_NAME: &str = "try_grow_stable_memory";
 const INTERNAL_TRAP_FUN_NAME: &str = "internal_trap";
 const STABLE_READ_FIRST_ACCESS_NAME: &str = "stable_read_first_access";
@@ -561,10 +565,21 @@ fn mutate_function_indices(module: &mut Module, f: impl Fn(u32) -> u32) {
 /// added as the last imports, we'd need to increment only non imported
 /// functions, since imported functions precede all others in the function index
 /// space, but this would be error-prone).
-fn inject_helper_functions(mut module: Module, wasm_native_stable_memory: FlagStatus) -> Module {
+fn inject_helper_functions(
+    mut module: Module,
+    wasm_native_stable_memory: FlagStatus,
+    main_memory_mode: MemoryMode,
+) -> Module {
     // insert types
     let ooi_type = FuncType::new([], []);
-    let uam_type = FuncType::new([ValType::I32, ValType::I32, ValType::I32], [ValType::I32]);
+    let uam_type = match main_memory_mode {
+        MemoryMode::Memory32 => {
+            FuncType::new([ValType::I32, ValType::I32, ValType::I32], [ValType::I32])
+        }
+        MemoryMode::Memory64 => {
+            FuncType::new([ValType::I64, ValType::I64, ValType::I32], [ValType::I64])
+        }
+    };
 
     let ooi_type_idx = add_func_type(&mut module, ooi_type);
     let uam_type_idx = add_func_type(&mut module, uam_type);
@@ -576,9 +591,13 @@ fn inject_helper_functions(mut module: Module, wasm_native_stable_memory: FlagSt
         ty: TypeRef::Func(ooi_type_idx),
     };
 
+    let uam_name = match main_memory_mode {
+        MemoryMode::Memory32 => UPDATE_MEMORY_FUN_NAME,
+        MemoryMode::Memory64 => UPDATE_MEMORY_64_FUN_NAME,
+    };
     let uam_imp = Import {
         module: INSTRUMENTED_FUN_MODULE,
-        name: UPDATE_MEMORY_FUN_NAME,
+        name: uam_name,
         ty: TypeRef::Func(uam_type_idx),
     };
 
@@ -629,6 +648,8 @@ fn inject_helper_functions(mut module: Module, wasm_native_stable_memory: FlagSt
     debug_assert!(
         module.imports[InjectedImports::UpdateAvailableMemory as usize].name
             == "update_available_memory"
+            || module.imports[InjectedImports::UpdateAvailableMemory as usize].name
+                == "update_available_memory_64"
     );
     if wasm_native_stable_memory == FlagStatus::Enabled {
         debug_assert!(
@@ -660,6 +681,23 @@ pub(super) struct SpecialIndices {
     pub stable_memory_index: u32,
 }
 
+// Address space used in a Wasm memory.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(super) enum MemoryMode {
+    Memory32,
+    Memory64,
+}
+
+impl MemoryMode {
+    pub fn get(module: &Module<'_>) -> MemoryMode {
+        if module.memories.iter().any(|memory| memory.memory64) {
+            MemoryMode::Memory64
+        } else {
+            MemoryMode::Memory32
+        }
+    }
+}
+
 /// Takes a Wasm binary and inserts the instructions metering and memory grow
 /// instrumentation.
 ///
@@ -675,10 +713,15 @@ pub(super) fn instrument(
     dirty_page_overhead: NumInstructions,
 ) -> Result<InstrumentationOutput, WasmInstrumentationError> {
     let stable_memory_index;
-    let mut module = inject_helper_functions(module, wasm_native_stable_memory);
+    let main_memory_mode = MemoryMode::get(&module);
+    let mut module = inject_helper_functions(module, wasm_native_stable_memory, main_memory_mode);
     module = export_table(module);
-    (module, stable_memory_index) =
-        update_memories(module, write_barrier, wasm_native_stable_memory);
+    (module, stable_memory_index) = update_memories(
+        module,
+        write_barrier,
+        wasm_native_stable_memory,
+        main_memory_mode,
+    );
 
     let mut extra_strs: Vec<String> = Vec::new();
     module = export_mutable_globals(module, &mut extra_strs);
@@ -732,7 +775,12 @@ pub(super) fn instrument(
 
     // inject instructions counter decrementation
     for func_body in &mut module.code_sections {
-        inject_metering(&mut func_body.instructions, &special_indices, metering_type);
+        inject_metering(
+            &mut func_body.instructions,
+            &special_indices,
+            metering_type,
+            main_memory_mode,
+        );
     }
 
     // Collect all the function types of the locally defined functions inside the
@@ -759,7 +807,7 @@ pub(super) fn instrument(
     if !func_types.is_empty() {
         let func_bodies = &mut module.code_sections;
         for (func_ix, func_type) in func_types.into_iter() {
-            inject_update_available_memory(&mut func_bodies[func_ix], &func_type);
+            inject_update_available_memory(&mut func_bodies[func_ix], &func_type, main_memory_mode);
             if write_barrier == FlagStatus::Enabled {
                 inject_mem_barrier(&mut func_bodies[func_ix], &func_type);
             }
@@ -775,6 +823,7 @@ pub(super) fn instrument(
             subnet_type,
             dirty_page_overhead,
             metering_type,
+            main_memory_mode,
         )
     }
 
@@ -854,6 +903,7 @@ fn replace_system_api_functions(
     subnet_type: SubnetType,
     dirty_page_overhead: NumInstructions,
     metering_type: MeteringType,
+    main_memory_mode: MemoryMode,
 ) {
     let api_indexes = calculate_api_indexes(module);
     let number_of_func_imports = module
@@ -870,6 +920,7 @@ fn replace_system_api_functions(
         subnet_type,
         dirty_page_overhead,
         metering_type,
+        main_memory_mode,
     ) {
         if let Some(old_index) = api_indexes.get(&api) {
             let type_idx = add_func_type(module, ty);
@@ -1122,8 +1173,9 @@ enum Scope {
 
 // Describes how to calculate the instruction cost at this injection point.
 // `StaticCost` injection points contain information about the cost of the
-// following basic block. `DynamicCost` injection points assume there is an i32
-// on the stack which should be decremented from the instruction counter.
+// following basic block. `DynamicCost` injection points assume there is an
+// i32 on 32-bit Wasm or an i64 on Wasm Memory64 on the stack which should
+// be decremented from the instruction counter.
 #[derive(Copy, Clone, Debug, PartialEq)]
 enum InjectionPointCostDetail {
     StaticCost { scope: Scope, cost: u64 },
@@ -1177,6 +1229,7 @@ fn inject_metering(
     code: &mut Vec<Operator>,
     export_data_module: &SpecialIndices,
     metering_type: MeteringType,
+    main_memory_mode: MemoryMode,
 ) {
     let points = match metering_type {
         MeteringType::Old => injections_old(code),
@@ -1229,16 +1282,25 @@ fn inject_metering(
                 }
             }
             InjectionPointCostDetail::DynamicCost => {
-                elems.extend_from_slice(&[
-                    I64ExtendI32U,
-                    Call {
-                        function_index: export_data_module.decr_instruction_counter_fn,
-                    },
-                    // decr_instruction_counter returns it's argument unchanged,
-                    // so we can convert back to I32 without worrying about
-                    // overflows.
-                    I32WrapI64,
-                ]);
+                let call = Call {
+                    function_index: export_data_module.decr_instruction_counter_fn,
+                };
+
+                match main_memory_mode {
+                    MemoryMode::Memory32 => {
+                        elems.extend_from_slice(&[
+                            I64ExtendI32U,
+                            call,
+                            // decr_instruction_counter returns it's argument unchanged,
+                            // so we can convert back to I32 without worrying about
+                            // overflows.
+                            I32WrapI64,
+                        ]);
+                    }
+                    MemoryMode::Memory64 => {
+                        elems.extend_from_slice(&[call]);
+                    }
+                };
             }
         }
         last_injection_position = point.position;
@@ -1458,7 +1520,11 @@ fn inject_mem_barrier(func_body: &mut wasm_transform::Body, func_type: &FuncType
 // `table.grow` instruction to make sure that there's enough available memory
 // left to support the requested extra memory. If no `memory.grow` or
 // `table.grow` instructions are present then the code remains unchanged.
-fn inject_update_available_memory(func_body: &mut wasm_transform::Body, func_type: &FuncType) {
+fn inject_update_available_memory(
+    func_body: &mut wasm_transform::Body,
+    func_type: &FuncType,
+    main_memory_mode: MemoryMode,
+) {
     // This is an overestimation of table element size computed based on the
     // existing canister limits.
     const TABLE_ELEMENT_SIZE: u32 = 1024;
@@ -1482,7 +1548,12 @@ fn inject_update_available_memory(func_body: &mut wasm_transform::Body, func_typ
         // the total number of locals.
         let n_locals: u32 = func_body.locals.iter().map(|x| x.0).sum();
         let memory_local_ix = func_type.params().len() as u32 + n_locals;
-        func_body.locals.push((1, ValType::I32));
+
+        let local_type = match main_memory_mode {
+            MemoryMode::Memory32 => ValType::I32,
+            MemoryMode::Memory64 => ValType::I64,
+        };
+        func_body.locals.push((1, local_type));
 
         let orig_elems = &func_body.instructions;
         let mut elems: Vec<Operator> = Vec::new();
@@ -1644,6 +1715,7 @@ fn get_data(
                     offset_expr,
                 } => match offset_expr {
                     Operator::I32Const { value } => *value as usize,
+                    Operator::I64Const { value } => *value as usize,
                     _ => return Err(WasmInstrumentationError::WasmDeserializeError(WasmError::new(
                         "complex initialization expressions for data segments are not supported!".into()
                     ))),
@@ -1690,6 +1762,7 @@ fn update_memories(
     mut module: Module,
     write_barrier: FlagStatus,
     wasm_native_stable_memory: FlagStatus,
+    main_memory_mode: MemoryMode,
 ) -> (Module, u32) {
     let mut stable_index = 0;
 
@@ -1712,7 +1785,7 @@ fn update_memories(
 
     if write_barrier == FlagStatus::Enabled && !module.memories.is_empty() {
         module.memories.push(MemoryType {
-            memory64: false,
+            memory64: main_memory_mode == MemoryMode::Memory64,
             shared: false,
             initial: BYTEMAP_SIZE_IN_WASM_PAGES,
             maximum: Some(BYTEMAP_SIZE_IN_WASM_PAGES),

--- a/rs/embedders/src/wasm_utils/system_api_replacements.rs
+++ b/rs/embedders/src/wasm_utils/system_api_replacements.rs
@@ -42,7 +42,7 @@ pub(super) fn replacement_functions(
 ) -> Vec<(SystemApiFunc, (FuncType, Body<'static>))> {
     let count_clean_pages_fn_index = special_indices.count_clean_pages_fn.unwrap();
     let dirty_pages_counter_index = special_indices.dirty_pages_counter_ix.unwrap();
-    let accessed_pages_counter_index = special_indices.accessed_pages_counter_ix.unwrap();
+    let accessed_pages_counter_index = special_indices.stable_accessed_pages_counter_ix.unwrap();
     let stable_memory_index = special_indices.stable_memory_index;
     let decr_instruction_counter_fn = special_indices.decr_instruction_counter_fn;
 

--- a/rs/embedders/src/wasm_utils/validation.rs
+++ b/rs/embedders/src/wasm_utils/validation.rs
@@ -914,26 +914,37 @@ fn validate_export_section(
 // expression. Required because of OP. See also:
 // instrumentation.rs
 fn validate_data_section(module: &Module) -> Result<(), WasmValidationError> {
-    fn validate_segment(s: &DataSegment) -> Result<(), WasmValidationError> {
+    fn validate_segment(module: &Module, s: &DataSegment) -> Result<(), WasmValidationError> {
         match &s.kind {
             DataSegmentKind::Passive => Err(WasmValidationError::InvalidDataSection(
                 "Empty offset in data segment.".to_string(),
             )),
             DataSegmentKind::Active {
-                memory_index: _,
+                memory_index,
                 offset_expr,
-            } => match offset_expr {
-                Operator::I32Const { .. } => Ok(()),
-                _ => Err(WasmValidationError::InvalidDataSection(format!(
-                    "Invalid offset expression in data segment: {:?}",
-                    offset_expr
-                ))),
-            },
+            } => {
+                let memory_index = *memory_index as usize;
+                if memory_index >= module.memories.len() {
+                    return Err(WasmValidationError::InvalidDataSection(format!(
+                        "Invalid memory index in data segment: {:?}",
+                        memory_index
+                    )));
+                }
+                let memory64 = module.memories[memory_index].memory64;
+                match offset_expr {
+                    Operator::I32Const { .. } if !memory64 => Ok(()),
+                    Operator::I64Const { .. } if memory64 => Ok(()),
+                    _ => Err(WasmValidationError::InvalidDataSection(format!(
+                        "Invalid offset expression in data segment: {:?}",
+                        offset_expr
+                    ))),
+                }
+            }
         }
     }
 
     for d in &module.data {
-        validate_segment(d)?;
+        validate_segment(module, d)?;
     }
     Ok(())
 }
@@ -1324,6 +1335,8 @@ pub fn ensure_determinism(config: &mut Config) {
 fn can_compile(wasm: &BinaryEncodedWasm) -> Result<(), WasmValidationError> {
     let mut config = wasmtime::Config::default();
     ensure_determinism(&mut config);
+    // Support 64-bit main memory.
+    config.wasm_memory64(true);
     let engine = wasmtime::Engine::new(&config).map_err(|_| {
         WasmValidationError::WasmtimeValidation(String::from("Failed to initialize Wasm engine"))
     })?;

--- a/rs/embedders/src/wasm_utils/validation.rs
+++ b/rs/embedders/src/wasm_utils/validation.rs
@@ -16,7 +16,7 @@ use std::{
 use wasmtime::Config;
 
 use crate::wasm_utils::instrumentation::{
-    ACCESSED_PAGES_COUNTER_GLOBAL_NAME, DIRTY_PAGES_COUNTER_GLOBAL_NAME,
+    STABLE_ACCESSED_PAGES_COUNTER_GLOBAL_NAME, DIRTY_PAGES_COUNTER_GLOBAL_NAME,
 };
 use crate::{
     wasm_utils::wasm_transform::{DataSegment, DataSegmentKind, Module},
@@ -30,7 +30,7 @@ pub const RESERVED_SYMBOLS: [&str; 6] = [
     "canister counter_instructions",
     "canister_start",
     DIRTY_PAGES_COUNTER_GLOBAL_NAME,
-    ACCESSED_PAGES_COUNTER_GLOBAL_NAME,
+    STABLE_ACCESSED_PAGES_COUNTER_GLOBAL_NAME,
     STABLE_MEMORY_NAME,
     STABLE_BYTEMAP_MEMORY_NAME,
 ];

--- a/rs/embedders/src/wasm_utils/validation.rs
+++ b/rs/embedders/src/wasm_utils/validation.rs
@@ -1,7 +1,7 @@
 //! This module is responsible for validating the wasm binaries that are
 //! installed on the Internet Computer.
 
-use super::{wasm_transform::Body, Complexity, WasmImportsDetails, WasmValidationDetails};
+use super::{wasm_transform::Body, Complexity, WasmImportsDetails, WasmValidationDetails, instrumentation::MAIN_ACCESSED_PAGES_COUNTER_GLOBAL_NAME};
 
 use ic_config::embedders::Config as EmbeddersConfig;
 use ic_replicated_state::canister_state::execution_state::{
@@ -26,11 +26,12 @@ use wasmparser::{ExternalKind, FuncType, Operator, StructuralType, TypeRef, ValT
 
 /// Symbols that are reserved and cannot be exported by canisters.
 #[doc(hidden)] // pub for usage in tests
-pub const RESERVED_SYMBOLS: [&str; 6] = [
+pub const RESERVED_SYMBOLS: [&str; 7] = [
     "canister counter_instructions",
     "canister_start",
     DIRTY_PAGES_COUNTER_GLOBAL_NAME,
     STABLE_ACCESSED_PAGES_COUNTER_GLOBAL_NAME,
+    MAIN_ACCESSED_PAGES_COUNTER_GLOBAL_NAME,
     STABLE_MEMORY_NAME,
     STABLE_BYTEMAP_MEMORY_NAME,
 ];

--- a/rs/embedders/src/wasm_utils/validation.rs
+++ b/rs/embedders/src/wasm_utils/validation.rs
@@ -81,6 +81,16 @@ fn get_valid_system_apis() -> HashMap<String, HashMap<String, FunctionSignature>
             )],
         ),
         (
+            "msg_caller_copy_64",
+            vec![(
+                API_VERSION_IC0,
+                FunctionSignature {
+                    param_types: vec![ValType::I64, ValType::I64, ValType::I64],
+                    return_type: vec![],
+                },
+            )],
+        ),
+        (
             "msg_arg_data_size",
             vec![(
                 API_VERSION_IC0,
@@ -101,6 +111,16 @@ fn get_valid_system_apis() -> HashMap<String, HashMap<String, FunctionSignature>
             )],
         ),
         (
+            "msg_arg_data_copy_64",
+            vec![(
+                API_VERSION_IC0,
+                FunctionSignature {
+                    param_types: vec![ValType::I64, ValType::I64, ValType::I64],
+                    return_type: vec![],
+                },
+            )],
+        ),
+        (
             "msg_method_name_size",
             vec![(
                 API_VERSION_IC0,
@@ -116,6 +136,16 @@ fn get_valid_system_apis() -> HashMap<String, HashMap<String, FunctionSignature>
                 API_VERSION_IC0,
                 FunctionSignature {
                     param_types: vec![ValType::I32, ValType::I32, ValType::I32],
+                    return_type: vec![],
+                },
+            )],
+        ),
+        (
+            "msg_method_name_copy_64",
+            vec![(
+                API_VERSION_IC0,
+                FunctionSignature {
+                    param_types: vec![ValType::I64, ValType::I64, ValType::I64],
                     return_type: vec![],
                 },
             )],
@@ -161,11 +191,31 @@ fn get_valid_system_apis() -> HashMap<String, HashMap<String, FunctionSignature>
             )],
         ),
         (
+            "msg_reject_msg_copy_64",
+            vec![(
+                API_VERSION_IC0,
+                FunctionSignature {
+                    param_types: vec![ValType::I64, ValType::I64, ValType::I64],
+                    return_type: vec![],
+                },
+            )],
+        ),
+        (
             "msg_reply_data_append",
             vec![(
                 API_VERSION_IC0,
                 FunctionSignature {
                     param_types: vec![ValType::I32, ValType::I32],
+                    return_type: vec![],
+                },
+            )],
+        ),
+        (
+            "msg_reply_data_append_64",
+            vec![(
+                API_VERSION_IC0,
+                FunctionSignature {
+                    param_types: vec![ValType::I64, ValType::I64],
                     return_type: vec![],
                 },
             )],
@@ -191,6 +241,16 @@ fn get_valid_system_apis() -> HashMap<String, HashMap<String, FunctionSignature>
             )],
         ),
         (
+            "msg_reject_64",
+            vec![(
+                API_VERSION_IC0,
+                FunctionSignature {
+                    param_types: vec![ValType::I64, ValType::I64],
+                    return_type: vec![],
+                },
+            )],
+        ),
+        (
             "canister_self_size",
             vec![(
                 API_VERSION_IC0,
@@ -206,6 +266,16 @@ fn get_valid_system_apis() -> HashMap<String, HashMap<String, FunctionSignature>
                 API_VERSION_IC0,
                 FunctionSignature {
                     param_types: vec![ValType::I32, ValType::I32, ValType::I32],
+                    return_type: vec![],
+                },
+            )],
+        ),
+        (
+            "canister_self_copy_64",
+            vec![(
+                API_VERSION_IC0,
+                FunctionSignature {
+                    param_types: vec![ValType::I64, ValType::I64, ValType::I64],
                     return_type: vec![],
                 },
             )],
@@ -241,11 +311,40 @@ fn get_valid_system_apis() -> HashMap<String, HashMap<String, FunctionSignature>
             )],
         ),
         (
+            "call_new_64",
+            vec![(
+                API_VERSION_IC0,
+                FunctionSignature {
+                    param_types: vec![
+                        ValType::I64,
+                        ValType::I64,
+                        ValType::I64,
+                        ValType::I64,
+                        ValType::I32,
+                        ValType::I32,
+                        ValType::I32,
+                        ValType::I32,
+                    ],
+                    return_type: vec![],
+                },
+            )],
+        ),
+        (
             "call_data_append",
             vec![(
                 API_VERSION_IC0,
                 FunctionSignature {
                     param_types: vec![ValType::I32, ValType::I32],
+                    return_type: vec![],
+                },
+            )],
+        ),
+        (
+            "call_data_append_64",
+            vec![(
+                API_VERSION_IC0,
+                FunctionSignature {
+                    param_types: vec![ValType::I64, ValType::I64],
                     return_type: vec![],
                 },
             )],
@@ -287,6 +386,16 @@ fn get_valid_system_apis() -> HashMap<String, HashMap<String, FunctionSignature>
                 API_VERSION_IC0,
                 FunctionSignature {
                     param_types: vec![ValType::I32, ValType::I32],
+                    return_type: vec![],
+                },
+            )],
+        ),
+        (
+            "debug_print_64",
+            vec![(
+                API_VERSION_IC0,
+                FunctionSignature {
+                    param_types: vec![ValType::I64, ValType::I64],
                     return_type: vec![],
                 },
             )],
@@ -422,6 +531,16 @@ fn get_valid_system_apis() -> HashMap<String, HashMap<String, FunctionSignature>
             )],
         ),
         (
+            "trap_64",
+            vec![(
+                API_VERSION_IC0,
+                FunctionSignature {
+                    param_types: vec![ValType::I64, ValType::I64],
+                    return_type: vec![],
+                },
+            )],
+        ),
+        (
             "canister_cycle_balance",
             vec![(
                 API_VERSION_IC0,
@@ -472,6 +591,16 @@ fn get_valid_system_apis() -> HashMap<String, HashMap<String, FunctionSignature>
             )],
         ),
         (
+            "certified_data_set_64",
+            vec![(
+                API_VERSION_IC0,
+                FunctionSignature {
+                    param_types: vec![ValType::I64, ValType::I64],
+                    return_type: vec![],
+                },
+            )],
+        ),
+        (
             "data_certificate_present",
             vec![(
                 API_VERSION_IC0,
@@ -497,6 +626,16 @@ fn get_valid_system_apis() -> HashMap<String, HashMap<String, FunctionSignature>
                 API_VERSION_IC0,
                 FunctionSignature {
                     param_types: vec![ValType::I32, ValType::I32, ValType::I32],
+                    return_type: vec![],
+                },
+            )],
+        ),
+        (
+            "data_certificate_copy_64",
+            vec![(
+                API_VERSION_IC0,
+                FunctionSignature {
+                    param_types: vec![ValType::I64, ValType::I64, ValType::I64],
                     return_type: vec![],
                 },
             )],
@@ -542,11 +681,31 @@ fn get_valid_system_apis() -> HashMap<String, HashMap<String, FunctionSignature>
             )],
         ),
         (
+            "canister_cycle_balance128_64",
+            vec![(
+                API_VERSION_IC0,
+                FunctionSignature {
+                    param_types: vec![ValType::I64],
+                    return_type: vec![],
+                },
+            )],
+        ),
+        (
             "msg_cycles_available128",
             vec![(
                 API_VERSION_IC0,
                 FunctionSignature {
                     param_types: vec![ValType::I32],
+                    return_type: vec![],
+                },
+            )],
+        ),
+        (
+            "msg_cycles_available128_64",
+            vec![(
+                API_VERSION_IC0,
+                FunctionSignature {
+                    param_types: vec![ValType::I64],
                     return_type: vec![],
                 },
             )],
@@ -562,6 +721,16 @@ fn get_valid_system_apis() -> HashMap<String, HashMap<String, FunctionSignature>
             )],
         ),
         (
+            "msg_cycles_refunded128_64",
+            vec![(
+                API_VERSION_IC0,
+                FunctionSignature {
+                    param_types: vec![ValType::I64],
+                    return_type: vec![],
+                },
+            )],
+        ),
+        (
             "msg_cycles_accept128",
             vec![(
                 API_VERSION_IC0,
@@ -572,11 +741,31 @@ fn get_valid_system_apis() -> HashMap<String, HashMap<String, FunctionSignature>
             )],
         ),
         (
+            "msg_cycles_accept128_64",
+            vec![(
+                API_VERSION_IC0,
+                FunctionSignature {
+                    param_types: vec![ValType::I64, ValType::I64, ValType::I64],
+                    return_type: vec![],
+                },
+            )],
+        ),
+        (
             "is_controller",
             vec![(
                 API_VERSION_IC0,
                 FunctionSignature {
                     param_types: vec![ValType::I32, ValType::I32],
+                    return_type: vec![ValType::I32],
+                },
+            )],
+        ),
+        (
+            "is_controller_64",
+            vec![(
+                API_VERSION_IC0,
+                FunctionSignature {
+                    param_types: vec![ValType::I64, ValType::I64],
                     return_type: vec![ValType::I32],
                 },
             )],

--- a/rs/embedders/src/wasmtime_embedder.rs
+++ b/rs/embedders/src/wasmtime_embedder.rs
@@ -17,7 +17,7 @@ use wasmtime::{
 };
 
 pub use host_memory::WasmtimeMemoryCreator;
-use ic_config::embedders::MeteringType;
+use ic_config::embedders::{MeteringType, STABLE_MEMORY_ACCESSED_PAGE_LIMIT};
 use ic_config::{embedders::Config as EmbeddersConfig, flag_status::FlagStatus};
 use ic_interfaces::execution_environment::{
     HypervisorError, HypervisorResult, InstanceStats, SystemApi, TrapCode,
@@ -48,6 +48,10 @@ use self::host_memory::{MemoryPageSize, MemoryStart};
 
 #[cfg(test)]
 mod wasmtime_embedder_tests;
+
+/// Used for 64-bit main memory support:
+/// Limit for the number of pages accessed in a single message.
+pub const MAIN_MEMORY_PAGE_ACCESS_LIMIT: u64 = STABLE_MEMORY_ACCESSED_PAGE_LIMIT;
 
 const BAD_SIGNATURE_MESSAGE: &str = "function invocation does not match its signature";
 pub(crate) const WASM_HEAP_MEMORY_NAME: &str = "memory";
@@ -100,6 +104,10 @@ fn trap_code_to_hypervisor_error(trap: wasmtime::Trap) -> HypervisorError {
             HypervisorError::Trapped(TrapCode::IntegerDivByZero)
         }
         wasmtime::Trap::UnreachableCodeReached => HypervisorError::Trapped(TrapCode::Unreachable),
+        wasmtime::Trap::Interrupt => HypervisorError::MemoryAccessLimitExceeded(
+            format!("Exceeded the limit for the number of modified pages in the main memory in a single message execution: limit: {} KB.",
+                MAIN_MEMORY_PAGE_ACCESS_LIMIT * PAGE_SIZE as u64 / 1024),
+            ),
         _ => {
             // The `wasmtime::TrapCode` enum is marked as #[non_exhaustive]
             // so we have to use the wildcard matching here.
@@ -194,6 +202,8 @@ impl WasmtimeEmbedder {
     pub fn initial_wasmtime_config(embedder_config: &EmbeddersConfig) -> wasmtime::Config {
         let mut config = wasmtime::Config::default();
         config.cranelift_opt_level(OptLevel::None);
+        // The epoch mechanism is used for limiting the number of page accesses in 64-bit main memory support.
+        config.epoch_interruption(true);
         ensure_determinism(&mut config);
         disable_unused_features(&mut config);
         if embedder_config.feature_flags.write_barrier == FlagStatus::Enabled
@@ -201,9 +211,8 @@ impl WasmtimeEmbedder {
         {
             config.wasm_multi_memory(true);
         }
-        if embedder_config.feature_flags.wasm_native_stable_memory == FlagStatus::Enabled {
-            config.wasm_memory64(true);
-        }
+        // Enable 64-bit main memory
+        config.wasm_memory64(true);
         config
             // The maximum size in bytes where a linear memory is considered
             // static. Setting this to maximum Wasm memory size will guarantee
@@ -441,7 +450,8 @@ impl WasmtimeEmbedder {
                 self.instantiate_memory(memory_info, &instance, store, &mut memories, canister_id)?;
         }
 
-        let memory_trackers = sigsegv_memory_tracker(memories, &mut store, self.log.clone());
+        let memory_trackers =
+            sigsegv_memory_tracker(cache.clone(), memories, &mut store, self.log.clone());
 
         let signal_stack = WasmtimeSignalStack::new();
         Ok(WasmtimeInstance {
@@ -597,6 +607,7 @@ pub struct MemorySigSegvInfo {
 }
 
 fn sigsegv_memory_tracker<S>(
+    cache: EmbedderCache,
     memories: HashMap<CanisterMemoryType, MemorySigSegvInfo>,
     store: &mut wasmtime::Store<S>,
     log: ReplicaLogger,
@@ -639,7 +650,9 @@ fn sigsegv_memory_tracker<S>(
         tracked_memories.push((sigsegv_memory_tracker, current_memory_size_in_pages));
     }
 
-    let handler = crate::signal_handler::sigsegv_memory_tracker_handler(tracked_memories);
+    // The epoch mechanism is used for limiting the number of page accesses in 64-bit main memory support.
+    store.set_epoch_deadline(1);
+    let handler = crate::signal_handler::sigsegv_memory_tracker_handler(cache, tracked_memories);
     // http://man7.org/linux/man-pages/man7/signal-safety.7.html
     unsafe {
         store.set_signal_handler(handler);

--- a/rs/embedders/src/wasmtime_embedder/system_api.rs
+++ b/rs/embedders/src/wasmtime_embedder/system_api.rs
@@ -2266,7 +2266,7 @@ const WRITE_ACCESS: u8 = 1;
 const READ_ONLY_ACCESS: u8 = 2;
 
 /// Used during 64-bit main memory to guard the working set limit.
-/// The page is accessed for the first time and this access is a read access.
+/// The page is accessed for the potentially first time and this access is a read access.
 #[inline(never)]
 fn main_read_page_guard<S: SystemApi>(
     mut caller: &mut Caller<'_, StoreData<S>>,
@@ -2283,14 +2283,15 @@ fn main_read_page_guard<S: SystemApi>(
     };
 
     let bytemap = bytemap_mem.data_mut(&mut caller);
-    debug_assert_eq!(bytemap[page_index], NO_ACCESS);
-    bytemap[page_index] = READ_ONLY_ACCESS;
-    first_access_on_main_memory_page(&mut caller)?;
+    if bytemap[page_index] == NO_ACCESS {
+        bytemap[page_index] = READ_ONLY_ACCESS;
+        first_access_on_main_memory_page(&mut caller)?;
+    }
     Ok(())
 }
 
 /// Used during 64-bit main memory to guard the working set limit.
-/// The page is written for the first time and there may have been preceding reads to this page.
+/// The page is written for the potentially first time and there may have been preceding reads to this page.
 #[inline(never)]
 fn main_write_page_guard<S: SystemApi>(
     mut caller: &mut Caller<'_, StoreData<S>>,

--- a/rs/embedders/src/wasmtime_embedder/system_api.rs
+++ b/rs/embedders/src/wasmtime_embedder/system_api.rs
@@ -158,7 +158,7 @@ fn charge_for_system_api_call<S: SystemApi>(
     canister_id: CanisterId,
     caller: &mut Caller<'_, StoreData<S>>,
     system_api_overhead: NumInstructions,
-    num_bytes: u32,
+    num_bytes: u64,
     complexity: ExecutionComplexity,
     dirty_page_cost: NumInstructions,
     stable_memory_dirty_page_limit: NumPages,
@@ -173,7 +173,7 @@ fn charge_for_system_api_call<S: SystemApi>(
     let num_instructions_from_bytes = caller
         .data()
         .system_api
-        .get_num_instructions_from_bytes(NumBytes::from(num_bytes as u64));
+        .get_num_instructions_from_bytes(NumBytes::from(num_bytes));
     let (num_instructions1, overflow1) = num_instructions_from_bytes
         .get()
         .overflowing_add(dirty_page_cost.get());
@@ -418,7 +418,7 @@ pub(crate) fn syscalls<S: SystemApi>(
                     canister_id,
                     &mut caller,
                     system_api::complexity_overhead!(MSG_CALLER_COPY, metering_type),
-                    size as u32,
+                    size as u64,
                     ExecutionComplexity {
                         cpu: system_api_complexity::cpu::MSG_CALLER_COPY,
                         ..Default::default()
@@ -431,6 +431,40 @@ pub(crate) fn syscalls<S: SystemApi>(
                 })?;
                 if feature_flags.write_barrier == FlagStatus::Enabled {
                     mark_writes_on_bytemap(&mut caller, dst as u32 as usize, size as u32 as usize)
+                } else {
+                    Ok(())
+                }
+            }
+        })
+        .unwrap();
+
+    linker
+        .func_wrap("ic0", "msg_caller_copy_64", {
+            let log = log.clone();
+            move |mut caller: Caller<'_, StoreData<S>>, dst: i64, offset: i64, size: i64| {
+                charge_for_system_api_call(
+                    &log,
+                    canister_id,
+                    &mut caller,
+                    system_api::complexity_overhead!(MSG_CALLER_COPY, metering_type),
+                    size as u64,
+                    ExecutionComplexity {
+                        cpu: system_api_complexity::cpu::MSG_CALLER_COPY,
+                        ..Default::default()
+                    },
+                    NumInstructions::from(0),
+                    stable_memory_dirty_page_limit,
+                )?;
+                with_memory_and_system_api(&mut caller, |system_api, memory| {
+                    system_api.ic0_msg_caller_copy_64(
+                        dst as u64,
+                        offset as u64,
+                        size as u64,
+                        memory,
+                    )
+                })?;
+                if feature_flags.write_barrier == FlagStatus::Enabled {
+                    mark_writes_on_bytemap(&mut caller, dst as u64 as usize, size as u32 as usize)
                 } else {
                     Ok(())
                 }
@@ -503,7 +537,7 @@ pub(crate) fn syscalls<S: SystemApi>(
                     canister_id,
                     &mut caller,
                     system_api::complexity_overhead!(MSG_ARG_DATA_COPY, metering_type),
-                    size as u32,
+                    size as u64,
                     ExecutionComplexity {
                         cpu: system_api_complexity::cpu::MSG_ARG_DATA_COPY,
                         ..Default::default()
@@ -516,6 +550,35 @@ pub(crate) fn syscalls<S: SystemApi>(
                 })?;
                 if feature_flags.write_barrier == FlagStatus::Enabled {
                     mark_writes_on_bytemap(&mut caller, dst as u32 as usize, size as u32 as usize)
+                } else {
+                    Ok(())
+                }
+            }
+        })
+        .unwrap();
+
+    linker
+        .func_wrap("ic0", "msg_arg_data_copy_64", {
+            let log = log.clone();
+            move |mut caller: Caller<'_, StoreData<S>>, dst: i64, offset: i64, size: i64| {
+                charge_for_system_api_call(
+                    &log,
+                    canister_id,
+                    &mut caller,
+                    system_api::complexity_overhead!(MSG_ARG_DATA_COPY, metering_type),
+                    size as u64,
+                    ExecutionComplexity {
+                        cpu: system_api_complexity::cpu::MSG_ARG_DATA_COPY,
+                        ..Default::default()
+                    },
+                    NumInstructions::from(0),
+                    stable_memory_dirty_page_limit,
+                )?;
+                with_memory_and_system_api(&mut caller, |system_api, mem| {
+                    system_api.ic0_msg_arg_data_copy_64(dst as u64, offset as u64, size as u64, mem)
+                })?;
+                if feature_flags.write_barrier == FlagStatus::Enabled {
+                    mark_writes_on_bytemap(&mut caller, dst as u64 as usize, size as u64 as usize)
                 } else {
                     Ok(())
                 }
@@ -560,7 +623,7 @@ pub(crate) fn syscalls<S: SystemApi>(
                     canister_id,
                     &mut caller,
                     system_api::complexity_overhead!(MSG_METHOD_NAME_COPY, metering_type),
-                    size as u32,
+                    size as u64,
                     ExecutionComplexity {
                         cpu: system_api_complexity::cpu::MSG_METHOD_NAME_COPY,
                         ..Default::default()
@@ -578,6 +641,40 @@ pub(crate) fn syscalls<S: SystemApi>(
                 })?;
                 if feature_flags.write_barrier == FlagStatus::Enabled {
                     mark_writes_on_bytemap(&mut caller, dst as u32 as usize, size as u32 as usize)
+                } else {
+                    Ok(())
+                }
+            }
+        })
+        .unwrap();
+
+    linker
+        .func_wrap("ic0", "msg_method_name_copy_64", {
+            let log = log.clone();
+            move |mut caller: Caller<'_, StoreData<S>>, dst: i64, offset: i64, size: i64| {
+                charge_for_system_api_call(
+                    &log,
+                    canister_id,
+                    &mut caller,
+                    system_api::complexity_overhead!(MSG_METHOD_NAME_COPY, metering_type),
+                    size as u64,
+                    ExecutionComplexity {
+                        cpu: system_api_complexity::cpu::MSG_METHOD_NAME_COPY,
+                        ..Default::default()
+                    },
+                    NumInstructions::from(0),
+                    stable_memory_dirty_page_limit,
+                )?;
+                with_memory_and_system_api(&mut caller, |system_api, memory| {
+                    system_api.ic0_msg_method_name_copy_64(
+                        dst as u64,
+                        offset as u64,
+                        size as u64,
+                        memory,
+                    )
+                })?;
+                if feature_flags.write_barrier == FlagStatus::Enabled {
+                    mark_writes_on_bytemap(&mut caller, dst as u64 as usize, size as u64 as usize)
                 } else {
                     Ok(())
                 }
@@ -617,7 +714,7 @@ pub(crate) fn syscalls<S: SystemApi>(
                     canister_id,
                     &mut caller,
                     system_api::complexity_overhead!(MSG_REPLY_DATA_APPEND, metering_type),
-                    size as u32,
+                    size as u64,
                     ExecutionComplexity {
                         cpu: system_api_complexity::cpu::MSG_REPLY_DATA_APPEND,
                         ..Default::default()
@@ -627,6 +724,30 @@ pub(crate) fn syscalls<S: SystemApi>(
                 )?;
                 with_memory_and_system_api(&mut caller, |system_api, memory| {
                     system_api.ic0_msg_reply_data_append(src as u32, size as u32, memory)
+                })
+            }
+        })
+        .unwrap();
+
+    linker
+        .func_wrap("ic0", "msg_reply_data_append_64", {
+            let log = log.clone();
+            move |mut caller: Caller<'_, StoreData<S>>, src: i64, size: i64| {
+                charge_for_system_api_call(
+                    &log,
+                    canister_id,
+                    &mut caller,
+                    system_api::complexity_overhead!(MSG_REPLY_DATA_APPEND, metering_type),
+                    size as u64,
+                    ExecutionComplexity {
+                        cpu: system_api_complexity::cpu::MSG_REPLY_DATA_APPEND,
+                        ..Default::default()
+                    },
+                    NumInstructions::from(0),
+                    stable_memory_dirty_page_limit,
+                )?;
+                with_memory_and_system_api(&mut caller, |system_api, memory| {
+                    system_api.ic0_msg_reply_data_append_64(src as u64, size as u64, memory)
                 })
             }
         })
@@ -687,7 +808,7 @@ pub(crate) fn syscalls<S: SystemApi>(
                     canister_id,
                     &mut caller,
                     system_api::complexity_overhead!(MSG_REJECT, metering_type),
-                    size as u32,
+                    size as u64,
                     ExecutionComplexity {
                         cpu: system_api_complexity::cpu::MSG_REJECT,
                         ..Default::default()
@@ -697,6 +818,30 @@ pub(crate) fn syscalls<S: SystemApi>(
                 )?;
                 with_memory_and_system_api(&mut caller, |system_api, memory| {
                     system_api.ic0_msg_reject(src as u32, size as u32, memory)
+                })
+            }
+        })
+        .unwrap();
+
+    linker
+        .func_wrap("ic0", "msg_reject_64", {
+            let log = log.clone();
+            move |mut caller: Caller<'_, StoreData<S>>, src: i64, size: i64| {
+                charge_for_system_api_call(
+                    &log,
+                    canister_id,
+                    &mut caller,
+                    system_api::complexity_overhead!(MSG_REJECT, metering_type),
+                    size as u64,
+                    ExecutionComplexity {
+                        cpu: system_api_complexity::cpu::MSG_REJECT,
+                        ..Default::default()
+                    },
+                    NumInstructions::from(0),
+                    stable_memory_dirty_page_limit,
+                )?;
+                with_memory_and_system_api(&mut caller, |system_api, memory| {
+                    system_api.ic0_msg_reject_64(src as u64, size as u64, memory)
                 })
             }
         })
@@ -739,7 +884,7 @@ pub(crate) fn syscalls<S: SystemApi>(
                     canister_id,
                     &mut caller,
                     system_api::complexity_overhead!(MSG_REJECT_MSG_COPY, metering_type),
-                    size as u32,
+                    size as u64,
                     ExecutionComplexity {
                         cpu: system_api_complexity::cpu::MSG_REJECT_MSG_COPY,
                         ..Default::default()
@@ -757,6 +902,40 @@ pub(crate) fn syscalls<S: SystemApi>(
                 })?;
                 if feature_flags.write_barrier == FlagStatus::Enabled {
                     mark_writes_on_bytemap(&mut caller, dst as u32 as usize, size as u32 as usize)
+                } else {
+                    Ok(())
+                }
+            }
+        })
+        .unwrap();
+
+    linker
+        .func_wrap("ic0", "msg_reject_msg_copy_64", {
+            let log = log.clone();
+            move |mut caller: Caller<'_, StoreData<S>>, dst: i64, offset: i64, size: i64| {
+                charge_for_system_api_call(
+                    &log,
+                    canister_id,
+                    &mut caller,
+                    system_api::complexity_overhead!(MSG_REJECT_MSG_COPY, metering_type),
+                    size as u64,
+                    ExecutionComplexity {
+                        cpu: system_api_complexity::cpu::MSG_REJECT_MSG_COPY,
+                        ..Default::default()
+                    },
+                    NumInstructions::from(0),
+                    stable_memory_dirty_page_limit,
+                )?;
+                with_memory_and_system_api(&mut caller, |system_api, memory| {
+                    system_api.ic0_msg_reject_msg_copy_64(
+                        dst as u64,
+                        offset as u64,
+                        size as u64,
+                        memory,
+                    )
+                })?;
+                if feature_flags.write_barrier == FlagStatus::Enabled {
+                    mark_writes_on_bytemap(&mut caller, dst as u64 as usize, size as u64 as usize)
                 } else {
                     Ok(())
                 }
@@ -801,7 +980,7 @@ pub(crate) fn syscalls<S: SystemApi>(
                     canister_id,
                     &mut caller,
                     system_api::complexity_overhead!(CANISTER_SELF_COPY, metering_type),
-                    size as u32,
+                    size as u64,
                     ExecutionComplexity {
                         cpu: system_api_complexity::cpu::CANISTER_SELF_COPY,
                         ..Default::default()
@@ -827,6 +1006,40 @@ pub(crate) fn syscalls<S: SystemApi>(
         .unwrap();
 
     linker
+        .func_wrap("ic0", "canister_self_copy_64", {
+            let log = log.clone();
+            move |mut caller: Caller<'_, StoreData<S>>, dst: i64, offset: i64, size: i64| {
+                charge_for_system_api_call(
+                    &log,
+                    canister_id,
+                    &mut caller,
+                    system_api::complexity_overhead!(CANISTER_SELF_COPY, metering_type),
+                    size as u64,
+                    ExecutionComplexity {
+                        cpu: system_api_complexity::cpu::CANISTER_SELF_COPY,
+                        ..Default::default()
+                    },
+                    NumInstructions::from(0),
+                    stable_memory_dirty_page_limit,
+                )?;
+                with_memory_and_system_api(&mut caller, |system_api, memory| {
+                    system_api.ic0_canister_self_copy_64(
+                        dst as u64,
+                        offset as u64,
+                        size as u64,
+                        memory,
+                    )
+                })?;
+                if feature_flags.write_barrier == FlagStatus::Enabled {
+                    mark_writes_on_bytemap(&mut caller, dst as u64 as usize, size as u64 as usize)
+                } else {
+                    Ok(())
+                }
+            }
+        })
+        .unwrap();
+
+    linker
         .func_wrap("ic0", "debug_print", {
             let log = log.clone();
             move |mut caller: Caller<'_, StoreData<S>>, offset: i32, length: i32| {
@@ -835,7 +1048,7 @@ pub(crate) fn syscalls<S: SystemApi>(
                     canister_id,
                     &mut caller,
                     system_api::complexity_overhead!(DEBUG_PRINT, metering_type),
-                    length as u32,
+                    length as u64,
                     ExecutionComplexity {
                         cpu: system_api_complexity::cpu::DEBUG_PRINT,
                         ..Default::default()
@@ -863,6 +1076,42 @@ pub(crate) fn syscalls<S: SystemApi>(
         .unwrap();
 
     linker
+        .func_wrap("ic0", "debug_print_64", {
+            let log = log.clone();
+            move |mut caller: Caller<'_, StoreData<S>>, offset: i64, length: i64| {
+                charge_for_system_api_call(
+                    &log,
+                    canister_id,
+                    &mut caller,
+                    system_api::complexity_overhead!(DEBUG_PRINT, metering_type),
+                    length as u64,
+                    ExecutionComplexity {
+                        cpu: system_api_complexity::cpu::DEBUG_PRINT,
+                        ..Default::default()
+                    },
+                    NumInstructions::from(0),
+                    stable_memory_dirty_page_limit,
+                )?;
+                match (
+                    caller.data().system_api.subnet_type(),
+                    feature_flags.rate_limiting_of_debug_prints,
+                ) {
+                    // Debug print is a no-op on non-system subnets with rate limiting.
+                    (SubnetType::Application, FlagStatus::Enabled) => Ok(()),
+                    (SubnetType::VerifiedApplication, FlagStatus::Enabled) => Ok(()),
+                    // If rate limiting is disabled or the subnet is a system subnet, then
+                    // debug print produces output.
+                    (_, FlagStatus::Disabled) | (SubnetType::System, FlagStatus::Enabled) => {
+                        with_memory_and_system_api(&mut caller, |system_api, memory| {
+                            system_api.ic0_debug_print_64(offset as u64, length as u64, memory)
+                        })
+                    }
+                }
+            }
+        })
+        .unwrap();
+
+    linker
         .func_wrap("ic0", "trap", {
             let log = log.clone();
             move |mut caller: Caller<'_, StoreData<S>>, offset: i32, length: i32| -> Result<(), _> {
@@ -871,7 +1120,7 @@ pub(crate) fn syscalls<S: SystemApi>(
                     canister_id,
                     &mut caller,
                     system_api::complexity_overhead!(TRAP, metering_type),
-                    length as u32,
+                    length as u64,
                     ExecutionComplexity {
                         cpu: system_api_complexity::cpu::TRAP,
                         ..Default::default()
@@ -881,6 +1130,30 @@ pub(crate) fn syscalls<S: SystemApi>(
                 )?;
                 with_memory_and_system_api(&mut caller, |system_api, memory| {
                     system_api.ic0_trap(offset as u32, length as u32, memory)
+                })
+            }
+        })
+        .unwrap();
+
+    linker
+        .func_wrap("ic0", "trap_64", {
+            let log = log.clone();
+            move |mut caller: Caller<'_, StoreData<S>>, offset: i64, length: i64| -> Result<(), _> {
+                charge_for_system_api_call(
+                    &log,
+                    canister_id,
+                    &mut caller,
+                    system_api::complexity_overhead!(TRAP, metering_type),
+                    length as u64,
+                    ExecutionComplexity {
+                        cpu: system_api_complexity::cpu::TRAP,
+                        ..Default::default()
+                    },
+                    NumInstructions::from(0),
+                    stable_memory_dirty_page_limit,
+                )?;
+                with_memory_and_system_api(&mut caller, |system_api, memory| {
+                    system_api.ic0_trap_64(offset as u64, length as u64, memory)
                 })
             }
         })
@@ -903,7 +1176,7 @@ pub(crate) fn syscalls<S: SystemApi>(
                     canister_id,
                     &mut caller,
                     system_api::complexity_overhead!(CALL_NEW, metering_type),
-                    (callee_size as u32).saturating_add(name_len as u32),
+                    (callee_size as u64).saturating_add(name_len as u64),
                     ExecutionComplexity {
                         cpu: system_api_complexity::cpu::CALL_NEW,
                         ..Default::default()
@@ -929,6 +1202,48 @@ pub(crate) fn syscalls<S: SystemApi>(
         .unwrap();
 
     linker
+        .func_wrap("ic0", "call_new_64", {
+            let log = log.clone();
+            move |mut caller: Caller<'_, StoreData<S>>,
+                  callee_src: i64,
+                  callee_size: i64,
+                  name_src: i64,
+                  name_len: i64,
+                  reply_fun: i32,
+                  reply_env: i32,
+                  reject_fun: i32,
+                  reject_env: i32| {
+                charge_for_system_api_call(
+                    &log,
+                    canister_id,
+                    &mut caller,
+                    system_api::complexity_overhead!(CALL_NEW, metering_type),
+                    (callee_size as u64).saturating_add(name_len as u64),
+                    ExecutionComplexity {
+                        cpu: system_api_complexity::cpu::CALL_NEW,
+                        ..Default::default()
+                    },
+                    NumInstructions::from(0),
+                    stable_memory_dirty_page_limit,
+                )?;
+                with_memory_and_system_api(&mut caller, |system_api, memory| {
+                    system_api.ic0_call_new_64(
+                        callee_src as u64,
+                        callee_size as u64,
+                        name_src as u64,
+                        name_len as u64,
+                        reply_fun as u32,
+                        reply_env as u32,
+                        reject_fun as u32,
+                        reject_env as u32,
+                        memory,
+                    )
+                })
+            }
+        })
+        .unwrap();
+
+    linker
         .func_wrap("ic0", "call_data_append", {
             let log = log.clone();
             move |mut caller: Caller<'_, StoreData<S>>, src: i32, size: i32| {
@@ -937,7 +1252,7 @@ pub(crate) fn syscalls<S: SystemApi>(
                     canister_id,
                     &mut caller,
                     system_api::complexity_overhead!(CALL_DATA_APPEND, metering_type),
-                    size as u32,
+                    size as u64,
                     ExecutionComplexity {
                         cpu: system_api_complexity::cpu::CALL_DATA_APPEND,
                         ..Default::default()
@@ -947,6 +1262,30 @@ pub(crate) fn syscalls<S: SystemApi>(
                 )?;
                 with_memory_and_system_api(&mut caller, |system_api, memory| {
                     system_api.ic0_call_data_append(src as u32, size as u32, memory)
+                })
+            }
+        })
+        .unwrap();
+
+    linker
+        .func_wrap("ic0", "call_data_append_64", {
+            let log = log.clone();
+            move |mut caller: Caller<'_, StoreData<S>>, src: i64, size: i64| {
+                charge_for_system_api_call(
+                    &log,
+                    canister_id,
+                    &mut caller,
+                    system_api::complexity_overhead!(CALL_DATA_APPEND, metering_type),
+                    size as u64,
+                    ExecutionComplexity {
+                        cpu: system_api_complexity::cpu::CALL_DATA_APPEND,
+                        ..Default::default()
+                    },
+                    NumInstructions::from(0),
+                    stable_memory_dirty_page_limit,
+                )?;
+                with_memory_and_system_api(&mut caller, |system_api, memory| {
+                    system_api.ic0_call_data_append_64(src as u64, size as u64, memory)
                 })
             }
         })
@@ -1111,7 +1450,7 @@ pub(crate) fn syscalls<S: SystemApi>(
                     canister_id,
                     &mut caller,
                     system_api::complexity_overhead!(STABLE_READ, metering_type),
-                    size as u32,
+                    size as u64,
                     ExecutionComplexity {
                         cpu: system_api_complexity::cpu::STABLE_READ,
                         ..Default::default()
@@ -1145,7 +1484,7 @@ pub(crate) fn syscalls<S: SystemApi>(
                     canister_id,
                     &mut caller,
                     system_api::complexity_overhead!(STABLE_WRITE, metering_type),
-                    size,
+                    size as u64,
                     ExecutionComplexity {
                         cpu: system_api_complexity::cpu::STABLE_WRITE,
                         stable_dirty_pages,
@@ -1242,7 +1581,7 @@ pub(crate) fn syscalls<S: SystemApi>(
                     canister_id,
                     &mut caller,
                     system_api::complexity_overhead!(STABLE64_READ, metering_type),
-                    size as u32,
+                    size as u64,
                     ExecutionComplexity {
                         cpu: system_api_complexity::cpu::STABLE64_READ,
                         ..Default::default()
@@ -1276,7 +1615,7 @@ pub(crate) fn syscalls<S: SystemApi>(
                     canister_id,
                     &mut caller,
                     system_api::complexity_overhead!(STABLE64_WRITE, metering_type),
-                    size as u32,
+                    size as u64,
                     ExecutionComplexity {
                         cpu: system_api_complexity::cpu::STABLE64_WRITE,
                         stable_dirty_pages,
@@ -1444,6 +1783,35 @@ pub(crate) fn syscalls<S: SystemApi>(
         .unwrap();
 
     linker
+        .func_wrap("ic0", "canister_cycle_balance128_64", {
+            let log = log.clone();
+            move |mut caller: Caller<'_, StoreData<S>>, dst: u64| {
+                charge_for_system_api_call(
+                    &log,
+                    canister_id,
+                    &mut caller,
+                    system_api::complexity_overhead!(CANISTER_CYCLE_BALANCE128, metering_type),
+                    0,
+                    ExecutionComplexity {
+                        cpu: system_api_complexity::cpu::CANISTER_CYCLE_BALANCE128,
+                        ..Default::default()
+                    },
+                    NumInstructions::from(0),
+                    stable_memory_dirty_page_limit,
+                )?;
+                with_memory_and_system_api(&mut caller, |system_api, memory| {
+                    system_api.ic0_canister_cycle_balance128_64(dst, memory)
+                })?;
+                if feature_flags.write_barrier == FlagStatus::Enabled {
+                    mark_writes_on_bytemap(&mut caller, dst as usize, 16)
+                } else {
+                    Ok(())
+                }
+            }
+        })
+        .unwrap();
+
+    linker
         .func_wrap("ic0", "msg_cycles_available", {
             let log = log.clone();
             move |mut caller: Caller<'_, StoreData<S>>| {
@@ -1490,6 +1858,35 @@ pub(crate) fn syscalls<S: SystemApi>(
                 )?;
                 with_memory_and_system_api(&mut caller, |system_api, memory| {
                     system_api.ic0_msg_cycles_available128(dst, memory)
+                })?;
+                if feature_flags.write_barrier == FlagStatus::Enabled {
+                    mark_writes_on_bytemap(&mut caller, dst as usize, 16)
+                } else {
+                    Ok(())
+                }
+            }
+        })
+        .unwrap();
+
+    linker
+        .func_wrap("ic0", "msg_cycles_available128_64", {
+            let log = log.clone();
+            move |mut caller: Caller<'_, StoreData<S>>, dst: u64| {
+                charge_for_system_api_call(
+                    &log,
+                    canister_id,
+                    &mut caller,
+                    system_api::complexity_overhead!(MSG_CYCLES_AVAILABLE128, metering_type),
+                    0,
+                    ExecutionComplexity {
+                        cpu: system_api_complexity::cpu::MSG_CYCLES_AVAILABLE128,
+                        ..Default::default()
+                    },
+                    NumInstructions::from(0),
+                    stable_memory_dirty_page_limit,
+                )?;
+                with_memory_and_system_api(&mut caller, |system_api, memory| {
+                    system_api.ic0_msg_cycles_available128_64(dst, memory)
                 })?;
                 if feature_flags.write_barrier == FlagStatus::Enabled {
                     mark_writes_on_bytemap(&mut caller, dst as usize, 16)
@@ -1558,6 +1955,35 @@ pub(crate) fn syscalls<S: SystemApi>(
         .unwrap();
 
     linker
+        .func_wrap("ic0", "msg_cycles_refunded128_64", {
+            let log = log.clone();
+            move |mut caller: Caller<'_, StoreData<S>>, dst: u64| {
+                charge_for_system_api_call(
+                    &log,
+                    canister_id,
+                    &mut caller,
+                    system_api::complexity_overhead!(MSG_CYCLES_REFUNDED128, metering_type),
+                    0,
+                    ExecutionComplexity {
+                        cpu: system_api_complexity::cpu::MSG_CYCLES_REFUNDED128,
+                        ..Default::default()
+                    },
+                    NumInstructions::from(0),
+                    stable_memory_dirty_page_limit,
+                )?;
+                with_memory_and_system_api(&mut caller, |system_api, memory| {
+                    system_api.ic0_msg_cycles_refunded128_64(dst, memory)
+                })?;
+                if feature_flags.write_barrier == FlagStatus::Enabled {
+                    mark_writes_on_bytemap(&mut caller, dst as usize, 16)
+                } else {
+                    Ok(())
+                }
+            }
+        })
+        .unwrap();
+
+    linker
         .func_wrap("ic0", "msg_cycles_accept", {
             let log = log.clone();
             move |mut caller: Caller<'_, StoreData<S>>, amount: i64| {
@@ -1602,6 +2028,42 @@ pub(crate) fn syscalls<S: SystemApi>(
                 )?;
                 with_memory_and_system_api(&mut caller, |system_api, memory| {
                     system_api.ic0_msg_cycles_accept128(
+                        Cycles::from_parts(amount_high as u64, amount_low as u64),
+                        dst,
+                        memory,
+                    )
+                })?;
+                if feature_flags.write_barrier == FlagStatus::Enabled {
+                    mark_writes_on_bytemap(&mut caller, dst as usize, 16)
+                } else {
+                    Ok(())
+                }
+            }
+        })
+        .unwrap();
+
+    linker
+        .func_wrap("ic0", "msg_cycles_accept128_64", {
+            let log = log.clone();
+            move |mut caller: Caller<'_, StoreData<S>>,
+                  amount_high: i64,
+                  amount_low: i64,
+                  dst: u64| {
+                charge_for_system_api_call(
+                    &log,
+                    canister_id,
+                    &mut caller,
+                    system_api::complexity_overhead!(MSG_CYCLES_ACCEPT128, metering_type),
+                    0,
+                    ExecutionComplexity {
+                        cpu: system_api_complexity::cpu::MSG_CYCLES_ACCEPT128,
+                        ..Default::default()
+                    },
+                    NumInstructions::from(0),
+                    stable_memory_dirty_page_limit,
+                )?;
+                with_memory_and_system_api(&mut caller, |system_api, memory| {
+                    system_api.ic0_msg_cycles_accept128_64(
                         Cycles::from_parts(amount_high as u64, amount_low as u64),
                         dst,
                         memory,
@@ -1737,7 +2199,7 @@ pub(crate) fn syscalls<S: SystemApi>(
                     canister_id,
                     &mut caller,
                     system_api::complexity_overhead!(CERTIFIED_DATA_SET, metering_type),
-                    size,
+                    size as u64,
                     ExecutionComplexity {
                         cpu: system_api_complexity::cpu::CERTIFIED_DATA_SET,
                         ..Default::default()
@@ -1747,6 +2209,30 @@ pub(crate) fn syscalls<S: SystemApi>(
                 )?;
                 with_memory_and_system_api(&mut caller, |system_api, memory| {
                     system_api.ic0_certified_data_set(src, size, memory)
+                })
+            }
+        })
+        .unwrap();
+
+    linker
+        .func_wrap("ic0", "certified_data_set_64", {
+            let log = log.clone();
+            move |mut caller: Caller<'_, StoreData<S>>, src: u64, size: u64| {
+                charge_for_system_api_call(
+                    &log,
+                    canister_id,
+                    &mut caller,
+                    system_api::complexity_overhead!(CERTIFIED_DATA_SET, metering_type),
+                    size,
+                    ExecutionComplexity {
+                        cpu: system_api_complexity::cpu::CERTIFIED_DATA_SET,
+                        ..Default::default()
+                    },
+                    NumInstructions::from(0),
+                    stable_memory_dirty_page_limit,
+                )?;
+                with_memory_and_system_api(&mut caller, |system_api, memory| {
+                    system_api.ic0_certified_data_set_64(src, size, memory)
                 })
             }
         })
@@ -1807,7 +2293,7 @@ pub(crate) fn syscalls<S: SystemApi>(
                     canister_id,
                     &mut caller,
                     system_api::complexity_overhead!(IS_CONTROLLER, metering_type),
-                    size as u32,
+                    size as u64,
                     ExecutionComplexity {
                         cpu: system_api_complexity::cpu::IS_CONTROLLER,
                         ..Default::default()
@@ -1823,14 +2309,39 @@ pub(crate) fn syscalls<S: SystemApi>(
         .unwrap();
 
     linker
+        .func_wrap("ic0", "is_controller_64", {
+            let log = log.clone();
+            move |mut caller: Caller<'_, StoreData<S>>, src: i64, size: i64| {
+                charge_for_system_api_call(
+                    &log,
+                    canister_id,
+                    &mut caller,
+                    system_api::complexity_overhead!(IS_CONTROLLER, metering_type),
+                    size as u64,
+                    ExecutionComplexity {
+                        cpu: system_api_complexity::cpu::IS_CONTROLLER,
+                        ..Default::default()
+                    },
+                    NumInstructions::from(0),
+                    stable_memory_dirty_page_limit,
+                )?;
+                with_memory_and_system_api(&mut caller, |system_api, memory| {
+                    system_api.ic0_is_controller_64(src as u64, size as u64, memory)
+                })
+            }
+        })
+        .unwrap();
+
+    linker
         .func_wrap("ic0", "data_certificate_copy", {
+            let log = log.clone();
             move |mut caller: Caller<'_, StoreData<S>>, dst: u32, offset: u32, size: u32| {
                 charge_for_system_api_call(
                     &log,
                     canister_id,
                     &mut caller,
                     system_api::complexity_overhead!(DATA_CERTIFICATE_COPY, metering_type),
-                    size,
+                    size as u64,
                     ExecutionComplexity {
                         cpu: system_api_complexity::cpu::DATA_CERTIFICATE_COPY,
                         ..Default::default()
@@ -1840,6 +2351,34 @@ pub(crate) fn syscalls<S: SystemApi>(
                 )?;
                 with_memory_and_system_api(&mut caller, |system_api, memory| {
                     system_api.ic0_data_certificate_copy(dst, offset, size, memory)
+                })?;
+                if feature_flags.write_barrier == FlagStatus::Enabled {
+                    mark_writes_on_bytemap(&mut caller, dst as usize, size as usize)
+                } else {
+                    Ok(())
+                }
+            }
+        })
+        .unwrap();
+
+    linker
+        .func_wrap("ic0", "data_certificate_copy_64", {
+            move |mut caller: Caller<'_, StoreData<S>>, dst: u64, offset: u64, size: u64| {
+                charge_for_system_api_call(
+                    &log,
+                    canister_id,
+                    &mut caller,
+                    system_api::complexity_overhead!(DATA_CERTIFICATE_COPY, metering_type),
+                    size as u64,
+                    ExecutionComplexity {
+                        cpu: system_api_complexity::cpu::DATA_CERTIFICATE_COPY,
+                        ..Default::default()
+                    },
+                    NumInstructions::from(0),
+                    stable_memory_dirty_page_limit,
+                )?;
+                with_memory_and_system_api(&mut caller, |system_api, memory| {
+                    system_api.ic0_data_certificate_copy_64(dst, offset, size, memory)
                 })?;
                 if feature_flags.write_barrier == FlagStatus::Enabled {
                     mark_writes_on_bytemap(&mut caller, dst as usize, size as usize)

--- a/rs/embedders/src/wasmtime_embedder/system_api.rs
+++ b/rs/embedders/src/wasmtime_embedder/system_api.rs
@@ -1650,6 +1650,25 @@ pub(crate) fn syscalls<S: SystemApi>(
         .unwrap();
 
     linker
+        .func_wrap("__", "update_available_memory_64", {
+            move |mut caller: Caller<'_, StoreData<S>>,
+                  native_memory_grow_res: i64,
+                  additional_elements: i64,
+                  element_size: i32| {
+                with_system_api(&mut caller, |s| {
+                    s.update_available_memory(
+                        native_memory_grow_res,
+                        additional_elements as u64,
+                        element_size as u32 as u64,
+                    )
+                })
+                .map(|()| native_memory_grow_res)
+                .map_err(|e| process_err(&mut caller, e))
+            }
+        })
+        .unwrap();
+
+    linker
         .func_wrap("__", "try_grow_stable_memory", {
             let log = log.clone();
             move |mut caller: Caller<'_, StoreData<S>>,

--- a/rs/embedders/src/wasmtime_embedder/system_api.rs
+++ b/rs/embedders/src/wasmtime_embedder/system_api.rs
@@ -409,31 +409,39 @@ pub(crate) fn syscalls<S: SystemApi>(
 
     let mut linker = Linker::new(store.engine());
 
+    let msg_caller_copy_64 = move |log: &ReplicaLogger,
+                                   mut caller: Caller<'_, StoreData<S>>,
+                                   dst: i64,
+                                   offset: i64,
+                                   size: i64| {
+        charge_for_system_api_call(
+            log,
+            canister_id,
+            &mut caller,
+            system_api::complexity_overhead!(MSG_CALLER_COPY, metering_type),
+            size as u64,
+            ExecutionComplexity {
+                cpu: system_api_complexity::cpu::MSG_CALLER_COPY,
+                ..Default::default()
+            },
+            NumInstructions::from(0),
+            stable_memory_dirty_page_limit,
+        )?;
+        with_memory_and_system_api(&mut caller, |system_api, memory| {
+            system_api.ic0_msg_caller_copy_64(dst as u64, offset as u64, size as u64, memory)
+        })?;
+        if feature_flags.write_barrier == FlagStatus::Enabled {
+            mark_writes_on_bytemap(&mut caller, dst as u64 as usize, size as u32 as usize)
+        } else {
+            Ok(())
+        }
+    };
+
     linker
         .func_wrap("ic0", "msg_caller_copy", {
             let log = log.clone();
-            move |mut caller: Caller<'_, StoreData<S>>, dst: i32, offset: i32, size: i32| {
-                charge_for_system_api_call(
-                    &log,
-                    canister_id,
-                    &mut caller,
-                    system_api::complexity_overhead!(MSG_CALLER_COPY, metering_type),
-                    size as u64,
-                    ExecutionComplexity {
-                        cpu: system_api_complexity::cpu::MSG_CALLER_COPY,
-                        ..Default::default()
-                    },
-                    NumInstructions::from(0),
-                    stable_memory_dirty_page_limit,
-                )?;
-                with_memory_and_system_api(&mut caller, |system_api, memory| {
-                    system_api.ic0_msg_caller_copy(dst as u32, offset as u32, size as u32, memory)
-                })?;
-                if feature_flags.write_barrier == FlagStatus::Enabled {
-                    mark_writes_on_bytemap(&mut caller, dst as u32 as usize, size as u32 as usize)
-                } else {
-                    Ok(())
-                }
+            move |caller: Caller<'_, StoreData<S>>, dst: i32, offset: i32, size: i32| {
+                msg_caller_copy_64(&log, caller, dst as i64, offset as i64, size as i64)
             }
         })
         .unwrap();
@@ -441,33 +449,8 @@ pub(crate) fn syscalls<S: SystemApi>(
     linker
         .func_wrap("ic0", "msg_caller_copy_64", {
             let log = log.clone();
-            move |mut caller: Caller<'_, StoreData<S>>, dst: i64, offset: i64, size: i64| {
-                charge_for_system_api_call(
-                    &log,
-                    canister_id,
-                    &mut caller,
-                    system_api::complexity_overhead!(MSG_CALLER_COPY, metering_type),
-                    size as u64,
-                    ExecutionComplexity {
-                        cpu: system_api_complexity::cpu::MSG_CALLER_COPY,
-                        ..Default::default()
-                    },
-                    NumInstructions::from(0),
-                    stable_memory_dirty_page_limit,
-                )?;
-                with_memory_and_system_api(&mut caller, |system_api, memory| {
-                    system_api.ic0_msg_caller_copy_64(
-                        dst as u64,
-                        offset as u64,
-                        size as u64,
-                        memory,
-                    )
-                })?;
-                if feature_flags.write_barrier == FlagStatus::Enabled {
-                    mark_writes_on_bytemap(&mut caller, dst as u64 as usize, size as u32 as usize)
-                } else {
-                    Ok(())
-                }
+            move |caller: Caller<'_, StoreData<S>>, dst: i64, offset: i64, size: i64| {
+                msg_caller_copy_64(&log, caller, dst, offset, size)
             }
         })
         .unwrap();
@@ -528,31 +511,39 @@ pub(crate) fn syscalls<S: SystemApi>(
         })
         .unwrap();
 
+    let msg_arg_data_copy_64 = move |log: &ReplicaLogger,
+                                     mut caller: Caller<'_, StoreData<S>>,
+                                     dst: i64,
+                                     offset: i64,
+                                     size: i64| {
+        charge_for_system_api_call(
+            log,
+            canister_id,
+            &mut caller,
+            system_api::complexity_overhead!(MSG_ARG_DATA_COPY, metering_type),
+            size as u64,
+            ExecutionComplexity {
+                cpu: system_api_complexity::cpu::MSG_ARG_DATA_COPY,
+                ..Default::default()
+            },
+            NumInstructions::from(0),
+            stable_memory_dirty_page_limit,
+        )?;
+        with_memory_and_system_api(&mut caller, |system_api, mem| {
+            system_api.ic0_msg_arg_data_copy_64(dst as u64, offset as u64, size as u64, mem)
+        })?;
+        if feature_flags.write_barrier == FlagStatus::Enabled {
+            mark_writes_on_bytemap(&mut caller, dst as u64 as usize, size as u64 as usize)
+        } else {
+            Ok(())
+        }
+    };
+
     linker
         .func_wrap("ic0", "msg_arg_data_copy", {
             let log = log.clone();
-            move |mut caller: Caller<'_, StoreData<S>>, dst: i32, offset: i32, size: i32| {
-                charge_for_system_api_call(
-                    &log,
-                    canister_id,
-                    &mut caller,
-                    system_api::complexity_overhead!(MSG_ARG_DATA_COPY, metering_type),
-                    size as u64,
-                    ExecutionComplexity {
-                        cpu: system_api_complexity::cpu::MSG_ARG_DATA_COPY,
-                        ..Default::default()
-                    },
-                    NumInstructions::from(0),
-                    stable_memory_dirty_page_limit,
-                )?;
-                with_memory_and_system_api(&mut caller, |system_api, mem| {
-                    system_api.ic0_msg_arg_data_copy(dst as u32, offset as u32, size as u32, mem)
-                })?;
-                if feature_flags.write_barrier == FlagStatus::Enabled {
-                    mark_writes_on_bytemap(&mut caller, dst as u32 as usize, size as u32 as usize)
-                } else {
-                    Ok(())
-                }
+            move |caller: Caller<'_, StoreData<S>>, dst: i32, offset: i32, size: i32| {
+                msg_arg_data_copy_64(&log, caller, dst as i64, offset as i64, size as i64)
             }
         })
         .unwrap();
@@ -560,28 +551,8 @@ pub(crate) fn syscalls<S: SystemApi>(
     linker
         .func_wrap("ic0", "msg_arg_data_copy_64", {
             let log = log.clone();
-            move |mut caller: Caller<'_, StoreData<S>>, dst: i64, offset: i64, size: i64| {
-                charge_for_system_api_call(
-                    &log,
-                    canister_id,
-                    &mut caller,
-                    system_api::complexity_overhead!(MSG_ARG_DATA_COPY, metering_type),
-                    size as u64,
-                    ExecutionComplexity {
-                        cpu: system_api_complexity::cpu::MSG_ARG_DATA_COPY,
-                        ..Default::default()
-                    },
-                    NumInstructions::from(0),
-                    stable_memory_dirty_page_limit,
-                )?;
-                with_memory_and_system_api(&mut caller, |system_api, mem| {
-                    system_api.ic0_msg_arg_data_copy_64(dst as u64, offset as u64, size as u64, mem)
-                })?;
-                if feature_flags.write_barrier == FlagStatus::Enabled {
-                    mark_writes_on_bytemap(&mut caller, dst as u64 as usize, size as u64 as usize)
-                } else {
-                    Ok(())
-                }
+            move |caller: Caller<'_, StoreData<S>>, dst: i64, offset: i64, size: i64| {
+                msg_arg_data_copy_64(&log, caller, dst, offset, size)
             }
         })
         .unwrap();
@@ -614,36 +585,39 @@ pub(crate) fn syscalls<S: SystemApi>(
         })
         .unwrap();
 
+    let msg_method_name_copy_64 = move |log: &ReplicaLogger,
+                                        mut caller: Caller<'_, StoreData<S>>,
+                                        dst: i64,
+                                        offset: i64,
+                                        size: i64| {
+        charge_for_system_api_call(
+            log,
+            canister_id,
+            &mut caller,
+            system_api::complexity_overhead!(MSG_METHOD_NAME_COPY, metering_type),
+            size as u64,
+            ExecutionComplexity {
+                cpu: system_api_complexity::cpu::MSG_METHOD_NAME_COPY,
+                ..Default::default()
+            },
+            NumInstructions::from(0),
+            stable_memory_dirty_page_limit,
+        )?;
+        with_memory_and_system_api(&mut caller, |system_api, memory| {
+            system_api.ic0_msg_method_name_copy_64(dst as u64, offset as u64, size as u64, memory)
+        })?;
+        if feature_flags.write_barrier == FlagStatus::Enabled {
+            mark_writes_on_bytemap(&mut caller, dst as u64 as usize, size as u64 as usize)
+        } else {
+            Ok(())
+        }
+    };
+
     linker
         .func_wrap("ic0", "msg_method_name_copy", {
             let log = log.clone();
-            move |mut caller: Caller<'_, StoreData<S>>, dst: i32, offset: i32, size: i32| {
-                charge_for_system_api_call(
-                    &log,
-                    canister_id,
-                    &mut caller,
-                    system_api::complexity_overhead!(MSG_METHOD_NAME_COPY, metering_type),
-                    size as u64,
-                    ExecutionComplexity {
-                        cpu: system_api_complexity::cpu::MSG_METHOD_NAME_COPY,
-                        ..Default::default()
-                    },
-                    NumInstructions::from(0),
-                    stable_memory_dirty_page_limit,
-                )?;
-                with_memory_and_system_api(&mut caller, |system_api, memory| {
-                    system_api.ic0_msg_method_name_copy(
-                        dst as u32,
-                        offset as u32,
-                        size as u32,
-                        memory,
-                    )
-                })?;
-                if feature_flags.write_barrier == FlagStatus::Enabled {
-                    mark_writes_on_bytemap(&mut caller, dst as u32 as usize, size as u32 as usize)
-                } else {
-                    Ok(())
-                }
+            move |caller: Caller<'_, StoreData<S>>, dst: i32, offset: i32, size: i32| {
+                msg_method_name_copy_64(&log, caller, dst as i64, offset as i64, size as i64)
             }
         })
         .unwrap();
@@ -651,33 +625,8 @@ pub(crate) fn syscalls<S: SystemApi>(
     linker
         .func_wrap("ic0", "msg_method_name_copy_64", {
             let log = log.clone();
-            move |mut caller: Caller<'_, StoreData<S>>, dst: i64, offset: i64, size: i64| {
-                charge_for_system_api_call(
-                    &log,
-                    canister_id,
-                    &mut caller,
-                    system_api::complexity_overhead!(MSG_METHOD_NAME_COPY, metering_type),
-                    size as u64,
-                    ExecutionComplexity {
-                        cpu: system_api_complexity::cpu::MSG_METHOD_NAME_COPY,
-                        ..Default::default()
-                    },
-                    NumInstructions::from(0),
-                    stable_memory_dirty_page_limit,
-                )?;
-                with_memory_and_system_api(&mut caller, |system_api, memory| {
-                    system_api.ic0_msg_method_name_copy_64(
-                        dst as u64,
-                        offset as u64,
-                        size as u64,
-                        memory,
-                    )
-                })?;
-                if feature_flags.write_barrier == FlagStatus::Enabled {
-                    mark_writes_on_bytemap(&mut caller, dst as u64 as usize, size as u64 as usize)
-                } else {
-                    Ok(())
-                }
+            move |caller: Caller<'_, StoreData<S>>, dst: i64, offset: i64, size: i64| {
+                msg_method_name_copy_64(&log, caller, dst, offset, size)
             }
         })
         .unwrap();
@@ -705,26 +654,31 @@ pub(crate) fn syscalls<S: SystemApi>(
         })
         .unwrap();
 
+    let msg_reply_data_append_64 =
+        move |log: &ReplicaLogger, mut caller: Caller<'_, StoreData<S>>, src: i64, size: i64| {
+            charge_for_system_api_call(
+                log,
+                canister_id,
+                &mut caller,
+                system_api::complexity_overhead!(MSG_REPLY_DATA_APPEND, metering_type),
+                size as u64,
+                ExecutionComplexity {
+                    cpu: system_api_complexity::cpu::MSG_REPLY_DATA_APPEND,
+                    ..Default::default()
+                },
+                NumInstructions::from(0),
+                stable_memory_dirty_page_limit,
+            )?;
+            with_memory_and_system_api(&mut caller, |system_api, memory| {
+                system_api.ic0_msg_reply_data_append_64(src as u64, size as u64, memory)
+            })
+        };
+
     linker
         .func_wrap("ic0", "msg_reply_data_append", {
             let log = log.clone();
-            move |mut caller: Caller<'_, StoreData<S>>, src: i32, size: i32| {
-                charge_for_system_api_call(
-                    &log,
-                    canister_id,
-                    &mut caller,
-                    system_api::complexity_overhead!(MSG_REPLY_DATA_APPEND, metering_type),
-                    size as u64,
-                    ExecutionComplexity {
-                        cpu: system_api_complexity::cpu::MSG_REPLY_DATA_APPEND,
-                        ..Default::default()
-                    },
-                    NumInstructions::from(0),
-                    stable_memory_dirty_page_limit,
-                )?;
-                with_memory_and_system_api(&mut caller, |system_api, memory| {
-                    system_api.ic0_msg_reply_data_append(src as u32, size as u32, memory)
-                })
+            move |caller: Caller<'_, StoreData<S>>, src: i32, size: i32| {
+                msg_reply_data_append_64(&log, caller, src as i64, size as i64)
             }
         })
         .unwrap();
@@ -732,23 +686,8 @@ pub(crate) fn syscalls<S: SystemApi>(
     linker
         .func_wrap("ic0", "msg_reply_data_append_64", {
             let log = log.clone();
-            move |mut caller: Caller<'_, StoreData<S>>, src: i64, size: i64| {
-                charge_for_system_api_call(
-                    &log,
-                    canister_id,
-                    &mut caller,
-                    system_api::complexity_overhead!(MSG_REPLY_DATA_APPEND, metering_type),
-                    size as u64,
-                    ExecutionComplexity {
-                        cpu: system_api_complexity::cpu::MSG_REPLY_DATA_APPEND,
-                        ..Default::default()
-                    },
-                    NumInstructions::from(0),
-                    stable_memory_dirty_page_limit,
-                )?;
-                with_memory_and_system_api(&mut caller, |system_api, memory| {
-                    system_api.ic0_msg_reply_data_append_64(src as u64, size as u64, memory)
-                })
+            move |caller: Caller<'_, StoreData<S>>, src: i64, size: i64| {
+                msg_reply_data_append_64(&log, caller, src, size)
             }
         })
         .unwrap();
@@ -799,26 +738,31 @@ pub(crate) fn syscalls<S: SystemApi>(
         })
         .unwrap();
 
+    let msg_reject_64 =
+        move |log: &ReplicaLogger, mut caller: Caller<'_, StoreData<S>>, src: i64, size: i64| {
+            charge_for_system_api_call(
+                log,
+                canister_id,
+                &mut caller,
+                system_api::complexity_overhead!(MSG_REJECT, metering_type),
+                size as u64,
+                ExecutionComplexity {
+                    cpu: system_api_complexity::cpu::MSG_REJECT,
+                    ..Default::default()
+                },
+                NumInstructions::from(0),
+                stable_memory_dirty_page_limit,
+            )?;
+            with_memory_and_system_api(&mut caller, |system_api, memory| {
+                system_api.ic0_msg_reject_64(src as u64, size as u64, memory)
+            })
+        };
+
     linker
         .func_wrap("ic0", "msg_reject", {
             let log = log.clone();
-            move |mut caller: Caller<'_, StoreData<S>>, src: i32, size: i32| {
-                charge_for_system_api_call(
-                    &log,
-                    canister_id,
-                    &mut caller,
-                    system_api::complexity_overhead!(MSG_REJECT, metering_type),
-                    size as u64,
-                    ExecutionComplexity {
-                        cpu: system_api_complexity::cpu::MSG_REJECT,
-                        ..Default::default()
-                    },
-                    NumInstructions::from(0),
-                    stable_memory_dirty_page_limit,
-                )?;
-                with_memory_and_system_api(&mut caller, |system_api, memory| {
-                    system_api.ic0_msg_reject(src as u32, size as u32, memory)
-                })
+            move |caller: Caller<'_, StoreData<S>>, src: i32, size: i32| {
+                msg_reject_64(&log, caller, src as i64, size as i64)
             }
         })
         .unwrap();
@@ -826,23 +770,8 @@ pub(crate) fn syscalls<S: SystemApi>(
     linker
         .func_wrap("ic0", "msg_reject_64", {
             let log = log.clone();
-            move |mut caller: Caller<'_, StoreData<S>>, src: i64, size: i64| {
-                charge_for_system_api_call(
-                    &log,
-                    canister_id,
-                    &mut caller,
-                    system_api::complexity_overhead!(MSG_REJECT, metering_type),
-                    size as u64,
-                    ExecutionComplexity {
-                        cpu: system_api_complexity::cpu::MSG_REJECT,
-                        ..Default::default()
-                    },
-                    NumInstructions::from(0),
-                    stable_memory_dirty_page_limit,
-                )?;
-                with_memory_and_system_api(&mut caller, |system_api, memory| {
-                    system_api.ic0_msg_reject_64(src as u64, size as u64, memory)
-                })
+            move |caller: Caller<'_, StoreData<S>>, src: i64, size: i64| {
+                msg_reject_64(&log, caller, src, size)
             }
         })
         .unwrap();
@@ -875,36 +804,39 @@ pub(crate) fn syscalls<S: SystemApi>(
         })
         .unwrap();
 
+    let msg_reject_msg_copy_64 = move |log: &ReplicaLogger,
+                                       mut caller: Caller<'_, StoreData<S>>,
+                                       dst: i64,
+                                       offset: i64,
+                                       size: i64| {
+        charge_for_system_api_call(
+            log,
+            canister_id,
+            &mut caller,
+            system_api::complexity_overhead!(MSG_REJECT_MSG_COPY, metering_type),
+            size as u64,
+            ExecutionComplexity {
+                cpu: system_api_complexity::cpu::MSG_REJECT_MSG_COPY,
+                ..Default::default()
+            },
+            NumInstructions::from(0),
+            stable_memory_dirty_page_limit,
+        )?;
+        with_memory_and_system_api(&mut caller, |system_api, memory| {
+            system_api.ic0_msg_reject_msg_copy_64(dst as u64, offset as u64, size as u64, memory)
+        })?;
+        if feature_flags.write_barrier == FlagStatus::Enabled {
+            mark_writes_on_bytemap(&mut caller, dst as u64 as usize, size as u64 as usize)
+        } else {
+            Ok(())
+        }
+    };
+
     linker
         .func_wrap("ic0", "msg_reject_msg_copy", {
             let log = log.clone();
-            move |mut caller: Caller<'_, StoreData<S>>, dst: i32, offset: i32, size: i32| {
-                charge_for_system_api_call(
-                    &log,
-                    canister_id,
-                    &mut caller,
-                    system_api::complexity_overhead!(MSG_REJECT_MSG_COPY, metering_type),
-                    size as u64,
-                    ExecutionComplexity {
-                        cpu: system_api_complexity::cpu::MSG_REJECT_MSG_COPY,
-                        ..Default::default()
-                    },
-                    NumInstructions::from(0),
-                    stable_memory_dirty_page_limit,
-                )?;
-                with_memory_and_system_api(&mut caller, |system_api, memory| {
-                    system_api.ic0_msg_reject_msg_copy(
-                        dst as u32,
-                        offset as u32,
-                        size as u32,
-                        memory,
-                    )
-                })?;
-                if feature_flags.write_barrier == FlagStatus::Enabled {
-                    mark_writes_on_bytemap(&mut caller, dst as u32 as usize, size as u32 as usize)
-                } else {
-                    Ok(())
-                }
+            move |caller: Caller<'_, StoreData<S>>, dst: i32, offset: i32, size: i32| {
+                msg_reject_msg_copy_64(&log, caller, dst as i64, offset as i64, size as i64)
             }
         })
         .unwrap();
@@ -912,33 +844,8 @@ pub(crate) fn syscalls<S: SystemApi>(
     linker
         .func_wrap("ic0", "msg_reject_msg_copy_64", {
             let log = log.clone();
-            move |mut caller: Caller<'_, StoreData<S>>, dst: i64, offset: i64, size: i64| {
-                charge_for_system_api_call(
-                    &log,
-                    canister_id,
-                    &mut caller,
-                    system_api::complexity_overhead!(MSG_REJECT_MSG_COPY, metering_type),
-                    size as u64,
-                    ExecutionComplexity {
-                        cpu: system_api_complexity::cpu::MSG_REJECT_MSG_COPY,
-                        ..Default::default()
-                    },
-                    NumInstructions::from(0),
-                    stable_memory_dirty_page_limit,
-                )?;
-                with_memory_and_system_api(&mut caller, |system_api, memory| {
-                    system_api.ic0_msg_reject_msg_copy_64(
-                        dst as u64,
-                        offset as u64,
-                        size as u64,
-                        memory,
-                    )
-                })?;
-                if feature_flags.write_barrier == FlagStatus::Enabled {
-                    mark_writes_on_bytemap(&mut caller, dst as u64 as usize, size as u64 as usize)
-                } else {
-                    Ok(())
-                }
+            move |caller: Caller<'_, StoreData<S>>, dst: i64, offset: i64, size: i64| {
+                msg_reject_msg_copy_64(&log, caller, dst, offset, size)
             }
         })
         .unwrap();
@@ -971,36 +878,39 @@ pub(crate) fn syscalls<S: SystemApi>(
         })
         .unwrap();
 
+    let canister_self_copy_64 = move |log: &ReplicaLogger,
+                                      mut caller: Caller<'_, StoreData<S>>,
+                                      dst: i64,
+                                      offset: i64,
+                                      size: i64| {
+        charge_for_system_api_call(
+            log,
+            canister_id,
+            &mut caller,
+            system_api::complexity_overhead!(CANISTER_SELF_COPY, metering_type),
+            size as u64,
+            ExecutionComplexity {
+                cpu: system_api_complexity::cpu::CANISTER_SELF_COPY,
+                ..Default::default()
+            },
+            NumInstructions::from(0),
+            stable_memory_dirty_page_limit,
+        )?;
+        with_memory_and_system_api(&mut caller, |system_api, memory| {
+            system_api.ic0_canister_self_copy_64(dst as u64, offset as u64, size as u64, memory)
+        })?;
+        if feature_flags.write_barrier == FlagStatus::Enabled {
+            mark_writes_on_bytemap(&mut caller, dst as u64 as usize, size as u64 as usize)
+        } else {
+            Ok(())
+        }
+    };
+
     linker
         .func_wrap("ic0", "canister_self_copy", {
             let log = log.clone();
-            move |mut caller: Caller<'_, StoreData<S>>, dst: i32, offset: i32, size: i32| {
-                charge_for_system_api_call(
-                    &log,
-                    canister_id,
-                    &mut caller,
-                    system_api::complexity_overhead!(CANISTER_SELF_COPY, metering_type),
-                    size as u64,
-                    ExecutionComplexity {
-                        cpu: system_api_complexity::cpu::CANISTER_SELF_COPY,
-                        ..Default::default()
-                    },
-                    NumInstructions::from(0),
-                    stable_memory_dirty_page_limit,
-                )?;
-                with_memory_and_system_api(&mut caller, |system_api, memory| {
-                    system_api.ic0_canister_self_copy(
-                        dst as u32,
-                        offset as u32,
-                        size as u32,
-                        memory,
-                    )
-                })?;
-                if feature_flags.write_barrier == FlagStatus::Enabled {
-                    mark_writes_on_bytemap(&mut caller, dst as u32 as usize, size as u32 as usize)
-                } else {
-                    Ok(())
-                }
+            move |caller: Caller<'_, StoreData<S>>, dst: i32, offset: i32, size: i32| {
+                canister_self_copy_64(&log, caller, dst as i64, offset as i64, size as i64)
             }
         })
         .unwrap();
@@ -1008,69 +918,51 @@ pub(crate) fn syscalls<S: SystemApi>(
     linker
         .func_wrap("ic0", "canister_self_copy_64", {
             let log = log.clone();
-            move |mut caller: Caller<'_, StoreData<S>>, dst: i64, offset: i64, size: i64| {
-                charge_for_system_api_call(
-                    &log,
-                    canister_id,
-                    &mut caller,
-                    system_api::complexity_overhead!(CANISTER_SELF_COPY, metering_type),
-                    size as u64,
-                    ExecutionComplexity {
-                        cpu: system_api_complexity::cpu::CANISTER_SELF_COPY,
-                        ..Default::default()
-                    },
-                    NumInstructions::from(0),
-                    stable_memory_dirty_page_limit,
-                )?;
-                with_memory_and_system_api(&mut caller, |system_api, memory| {
-                    system_api.ic0_canister_self_copy_64(
-                        dst as u64,
-                        offset as u64,
-                        size as u64,
-                        memory,
-                    )
-                })?;
-                if feature_flags.write_barrier == FlagStatus::Enabled {
-                    mark_writes_on_bytemap(&mut caller, dst as u64 as usize, size as u64 as usize)
-                } else {
-                    Ok(())
-                }
+            move |caller: Caller<'_, StoreData<S>>, dst: i64, offset: i64, size: i64| {
+                canister_self_copy_64(&log, caller, dst, offset, size)
             }
         })
         .unwrap();
 
+    let debug_print_64 = move |log: &ReplicaLogger,
+                               mut caller: Caller<'_, StoreData<S>>,
+                               offset: i64,
+                               length: i64| {
+        charge_for_system_api_call(
+            log,
+            canister_id,
+            &mut caller,
+            system_api::complexity_overhead!(DEBUG_PRINT, metering_type),
+            length as u64,
+            ExecutionComplexity {
+                cpu: system_api_complexity::cpu::DEBUG_PRINT,
+                ..Default::default()
+            },
+            NumInstructions::from(0),
+            stable_memory_dirty_page_limit,
+        )?;
+        match (
+            caller.data().system_api.subnet_type(),
+            feature_flags.rate_limiting_of_debug_prints,
+        ) {
+            // Debug print is a no-op on non-system subnets with rate limiting.
+            (SubnetType::Application, FlagStatus::Enabled) => Ok(()),
+            (SubnetType::VerifiedApplication, FlagStatus::Enabled) => Ok(()),
+            // If rate limiting is disabled or the subnet is a system subnet, then
+            // debug print produces output.
+            (_, FlagStatus::Disabled) | (SubnetType::System, FlagStatus::Enabled) => {
+                with_memory_and_system_api(&mut caller, |system_api, memory| {
+                    system_api.ic0_debug_print_64(offset as u64, length as u64, memory)
+                })
+            }
+        }
+    };
+
     linker
         .func_wrap("ic0", "debug_print", {
             let log = log.clone();
-            move |mut caller: Caller<'_, StoreData<S>>, offset: i32, length: i32| {
-                charge_for_system_api_call(
-                    &log,
-                    canister_id,
-                    &mut caller,
-                    system_api::complexity_overhead!(DEBUG_PRINT, metering_type),
-                    length as u64,
-                    ExecutionComplexity {
-                        cpu: system_api_complexity::cpu::DEBUG_PRINT,
-                        ..Default::default()
-                    },
-                    NumInstructions::from(0),
-                    stable_memory_dirty_page_limit,
-                )?;
-                match (
-                    caller.data().system_api.subnet_type(),
-                    feature_flags.rate_limiting_of_debug_prints,
-                ) {
-                    // Debug print is a no-op on non-system subnets with rate limiting.
-                    (SubnetType::Application, FlagStatus::Enabled) => Ok(()),
-                    (SubnetType::VerifiedApplication, FlagStatus::Enabled) => Ok(()),
-                    // If rate limiting is disabled or the subnet is a system subnet, then
-                    // debug print produces output.
-                    (_, FlagStatus::Disabled) | (SubnetType::System, FlagStatus::Enabled) => {
-                        with_memory_and_system_api(&mut caller, |system_api, memory| {
-                            system_api.ic0_debug_print(offset as u32, length as u32, memory)
-                        })
-                    }
-                }
+            move |caller: Caller<'_, StoreData<S>>, offset: i32, length: i32| {
+                debug_print_64(&log, caller, offset as i64, length as i64)
             }
         })
         .unwrap();
@@ -1078,59 +970,40 @@ pub(crate) fn syscalls<S: SystemApi>(
     linker
         .func_wrap("ic0", "debug_print_64", {
             let log = log.clone();
-            move |mut caller: Caller<'_, StoreData<S>>, offset: i64, length: i64| {
-                charge_for_system_api_call(
-                    &log,
-                    canister_id,
-                    &mut caller,
-                    system_api::complexity_overhead!(DEBUG_PRINT, metering_type),
-                    length as u64,
-                    ExecutionComplexity {
-                        cpu: system_api_complexity::cpu::DEBUG_PRINT,
-                        ..Default::default()
-                    },
-                    NumInstructions::from(0),
-                    stable_memory_dirty_page_limit,
-                )?;
-                match (
-                    caller.data().system_api.subnet_type(),
-                    feature_flags.rate_limiting_of_debug_prints,
-                ) {
-                    // Debug print is a no-op on non-system subnets with rate limiting.
-                    (SubnetType::Application, FlagStatus::Enabled) => Ok(()),
-                    (SubnetType::VerifiedApplication, FlagStatus::Enabled) => Ok(()),
-                    // If rate limiting is disabled or the subnet is a system subnet, then
-                    // debug print produces output.
-                    (_, FlagStatus::Disabled) | (SubnetType::System, FlagStatus::Enabled) => {
-                        with_memory_and_system_api(&mut caller, |system_api, memory| {
-                            system_api.ic0_debug_print_64(offset as u64, length as u64, memory)
-                        })
-                    }
-                }
+            move |caller: Caller<'_, StoreData<S>>, offset: i64, length: i64| {
+                debug_print_64(&log, caller, offset, length)
             }
         })
         .unwrap();
 
+    let trap_64 = move |log: &ReplicaLogger,
+                        mut caller: Caller<'_, StoreData<S>>,
+                        offset: i64,
+                        length: i64|
+          -> Result<(), _> {
+        charge_for_system_api_call(
+            &log,
+            canister_id,
+            &mut caller,
+            system_api::complexity_overhead!(TRAP, metering_type),
+            length as u64,
+            ExecutionComplexity {
+                cpu: system_api_complexity::cpu::TRAP,
+                ..Default::default()
+            },
+            NumInstructions::from(0),
+            stable_memory_dirty_page_limit,
+        )?;
+        with_memory_and_system_api(&mut caller, |system_api, memory| {
+            system_api.ic0_trap_64(offset as u64, length as u64, memory)
+        })
+    };
+
     linker
         .func_wrap("ic0", "trap", {
             let log = log.clone();
-            move |mut caller: Caller<'_, StoreData<S>>, offset: i32, length: i32| -> Result<(), _> {
-                charge_for_system_api_call(
-                    &log,
-                    canister_id,
-                    &mut caller,
-                    system_api::complexity_overhead!(TRAP, metering_type),
-                    length as u64,
-                    ExecutionComplexity {
-                        cpu: system_api_complexity::cpu::TRAP,
-                        ..Default::default()
-                    },
-                    NumInstructions::from(0),
-                    stable_memory_dirty_page_limit,
-                )?;
-                with_memory_and_system_api(&mut caller, |system_api, memory| {
-                    system_api.ic0_trap(offset as u32, length as u32, memory)
-                })
+            move |caller: Caller<'_, StoreData<S>>, offset: i32, length: i32| -> Result<(), _> {
+                trap_64(&log, caller, offset as i64, length as i64)
             }
         })
         .unwrap();
@@ -1138,31 +1011,54 @@ pub(crate) fn syscalls<S: SystemApi>(
     linker
         .func_wrap("ic0", "trap_64", {
             let log = log.clone();
-            move |mut caller: Caller<'_, StoreData<S>>, offset: i64, length: i64| -> Result<(), _> {
-                charge_for_system_api_call(
-                    &log,
-                    canister_id,
-                    &mut caller,
-                    system_api::complexity_overhead!(TRAP, metering_type),
-                    length as u64,
-                    ExecutionComplexity {
-                        cpu: system_api_complexity::cpu::TRAP,
-                        ..Default::default()
-                    },
-                    NumInstructions::from(0),
-                    stable_memory_dirty_page_limit,
-                )?;
-                with_memory_and_system_api(&mut caller, |system_api, memory| {
-                    system_api.ic0_trap_64(offset as u64, length as u64, memory)
-                })
+            move |caller: Caller<'_, StoreData<S>>, offset: i64, length: i64| -> Result<(), _> {
+                trap_64(&log, caller, offset, length)
             }
         })
         .unwrap();
 
+    let call_new_64 = move |log: &ReplicaLogger,
+                            mut caller: Caller<'_, StoreData<S>>,
+                            callee_src: i64,
+                            callee_size: i64,
+                            name_src: i64,
+                            name_len: i64,
+                            reply_fun: i32,
+                            reply_env: i32,
+                            reject_fun: i32,
+                            reject_env: i32| {
+        charge_for_system_api_call(
+            log,
+            canister_id,
+            &mut caller,
+            system_api::complexity_overhead!(CALL_NEW, metering_type),
+            (callee_size as u64).saturating_add(name_len as u64),
+            ExecutionComplexity {
+                cpu: system_api_complexity::cpu::CALL_NEW,
+                ..Default::default()
+            },
+            NumInstructions::from(0),
+            stable_memory_dirty_page_limit,
+        )?;
+        with_memory_and_system_api(&mut caller, |system_api, memory| {
+            system_api.ic0_call_new_64(
+                callee_src as u64,
+                callee_size as u64,
+                name_src as u64,
+                name_len as u64,
+                reply_fun as u32,
+                reply_env as u32,
+                reject_fun as u32,
+                reject_env as u32,
+                memory,
+            )
+        })
+    };
+
     linker
         .func_wrap("ic0", "call_new", {
             let log = log.clone();
-            move |mut caller: Caller<'_, StoreData<S>>,
+            move |caller: Caller<'_, StoreData<S>>,
                   callee_src: i32,
                   callee_size: i32,
                   name_src: i32,
@@ -1171,32 +1067,18 @@ pub(crate) fn syscalls<S: SystemApi>(
                   reply_env: i32,
                   reject_fun: i32,
                   reject_env: i32| {
-                charge_for_system_api_call(
+                call_new_64(
                     &log,
-                    canister_id,
-                    &mut caller,
-                    system_api::complexity_overhead!(CALL_NEW, metering_type),
-                    (callee_size as u64).saturating_add(name_len as u64),
-                    ExecutionComplexity {
-                        cpu: system_api_complexity::cpu::CALL_NEW,
-                        ..Default::default()
-                    },
-                    NumInstructions::from(0),
-                    stable_memory_dirty_page_limit,
-                )?;
-                with_memory_and_system_api(&mut caller, |system_api, memory| {
-                    system_api.ic0_call_new(
-                        callee_src as u32,
-                        callee_size as u32,
-                        name_src as u32,
-                        name_len as u32,
-                        reply_fun as u32,
-                        reply_env as u32,
-                        reject_fun as u32,
-                        reject_env as u32,
-                        memory,
-                    )
-                })
+                    caller,
+                    callee_src as i64,
+                    callee_size as i64,
+                    name_src as i64,
+                    name_len as i64,
+                    reply_fun,
+                    reply_env,
+                    reject_fun,
+                    reject_env,
+                )
             }
         })
         .unwrap();
@@ -1204,7 +1086,7 @@ pub(crate) fn syscalls<S: SystemApi>(
     linker
         .func_wrap("ic0", "call_new_64", {
             let log = log.clone();
-            move |mut caller: Caller<'_, StoreData<S>>,
+            move |caller: Caller<'_, StoreData<S>>,
                   callee_src: i64,
                   callee_size: i64,
                   name_src: i64,
@@ -1213,56 +1095,47 @@ pub(crate) fn syscalls<S: SystemApi>(
                   reply_env: i32,
                   reject_fun: i32,
                   reject_env: i32| {
-                charge_for_system_api_call(
+                call_new_64(
                     &log,
-                    canister_id,
-                    &mut caller,
-                    system_api::complexity_overhead!(CALL_NEW, metering_type),
-                    (callee_size as u64).saturating_add(name_len as u64),
-                    ExecutionComplexity {
-                        cpu: system_api_complexity::cpu::CALL_NEW,
-                        ..Default::default()
-                    },
-                    NumInstructions::from(0),
-                    stable_memory_dirty_page_limit,
-                )?;
-                with_memory_and_system_api(&mut caller, |system_api, memory| {
-                    system_api.ic0_call_new_64(
-                        callee_src as u64,
-                        callee_size as u64,
-                        name_src as u64,
-                        name_len as u64,
-                        reply_fun as u32,
-                        reply_env as u32,
-                        reject_fun as u32,
-                        reject_env as u32,
-                        memory,
-                    )
-                })
+                    caller,
+                    callee_src,
+                    callee_size,
+                    name_src,
+                    name_len,
+                    reply_fun,
+                    reply_env,
+                    reject_fun,
+                    reject_env,
+                )
             }
         })
         .unwrap();
 
+    let data_append_64 =
+        move |log: &ReplicaLogger, mut caller: Caller<'_, StoreData<S>>, src: i64, size: i64| {
+            charge_for_system_api_call(
+                log,
+                canister_id,
+                &mut caller,
+                system_api::complexity_overhead!(CALL_DATA_APPEND, metering_type),
+                size as u64,
+                ExecutionComplexity {
+                    cpu: system_api_complexity::cpu::CALL_DATA_APPEND,
+                    ..Default::default()
+                },
+                NumInstructions::from(0),
+                stable_memory_dirty_page_limit,
+            )?;
+            with_memory_and_system_api(&mut caller, |system_api, memory| {
+                system_api.ic0_call_data_append_64(src as u64, size as u64, memory)
+            })
+        };
+
     linker
         .func_wrap("ic0", "call_data_append", {
             let log = log.clone();
-            move |mut caller: Caller<'_, StoreData<S>>, src: i32, size: i32| {
-                charge_for_system_api_call(
-                    &log,
-                    canister_id,
-                    &mut caller,
-                    system_api::complexity_overhead!(CALL_DATA_APPEND, metering_type),
-                    size as u64,
-                    ExecutionComplexity {
-                        cpu: system_api_complexity::cpu::CALL_DATA_APPEND,
-                        ..Default::default()
-                    },
-                    NumInstructions::from(0),
-                    stable_memory_dirty_page_limit,
-                )?;
-                with_memory_and_system_api(&mut caller, |system_api, memory| {
-                    system_api.ic0_call_data_append(src as u32, size as u32, memory)
-                })
+            move |caller: Caller<'_, StoreData<S>>, src: i32, size: i32| {
+                data_append_64(&log, caller, src as i64, size as i64)
             }
         })
         .unwrap();
@@ -1270,23 +1143,8 @@ pub(crate) fn syscalls<S: SystemApi>(
     linker
         .func_wrap("ic0", "call_data_append_64", {
             let log = log.clone();
-            move |mut caller: Caller<'_, StoreData<S>>, src: i64, size: i64| {
-                charge_for_system_api_call(
-                    &log,
-                    canister_id,
-                    &mut caller,
-                    system_api::complexity_overhead!(CALL_DATA_APPEND, metering_type),
-                    size as u64,
-                    ExecutionComplexity {
-                        cpu: system_api_complexity::cpu::CALL_DATA_APPEND,
-                        ..Default::default()
-                    },
-                    NumInstructions::from(0),
-                    stable_memory_dirty_page_limit,
-                )?;
-                with_memory_and_system_api(&mut caller, |system_api, memory| {
-                    system_api.ic0_call_data_append_64(src as u64, size as u64, memory)
-                })
+            move |caller: Caller<'_, StoreData<S>>, src: i64, size: i64| {
+                data_append_64(&log, caller, src, size)
             }
         })
         .unwrap();
@@ -1753,31 +1611,36 @@ pub(crate) fn syscalls<S: SystemApi>(
         })
         .unwrap();
 
+    let canister_cycle_balance128_64 =
+        move |log: &ReplicaLogger, mut caller: Caller<'_, StoreData<S>>, dst: u64| {
+            charge_for_system_api_call(
+                log,
+                canister_id,
+                &mut caller,
+                system_api::complexity_overhead!(CANISTER_CYCLE_BALANCE128, metering_type),
+                0,
+                ExecutionComplexity {
+                    cpu: system_api_complexity::cpu::CANISTER_CYCLE_BALANCE128,
+                    ..Default::default()
+                },
+                NumInstructions::from(0),
+                stable_memory_dirty_page_limit,
+            )?;
+            with_memory_and_system_api(&mut caller, |system_api, memory| {
+                system_api.ic0_canister_cycle_balance128_64(dst, memory)
+            })?;
+            if feature_flags.write_barrier == FlagStatus::Enabled {
+                mark_writes_on_bytemap(&mut caller, dst as usize, 16)
+            } else {
+                Ok(())
+            }
+        };
+
     linker
         .func_wrap("ic0", "canister_cycle_balance128", {
             let log = log.clone();
-            move |mut caller: Caller<'_, StoreData<S>>, dst: u32| {
-                charge_for_system_api_call(
-                    &log,
-                    canister_id,
-                    &mut caller,
-                    system_api::complexity_overhead!(CANISTER_CYCLE_BALANCE128, metering_type),
-                    0,
-                    ExecutionComplexity {
-                        cpu: system_api_complexity::cpu::CANISTER_CYCLE_BALANCE128,
-                        ..Default::default()
-                    },
-                    NumInstructions::from(0),
-                    stable_memory_dirty_page_limit,
-                )?;
-                with_memory_and_system_api(&mut caller, |system_api, memory| {
-                    system_api.ic0_canister_cycle_balance128(dst, memory)
-                })?;
-                if feature_flags.write_barrier == FlagStatus::Enabled {
-                    mark_writes_on_bytemap(&mut caller, dst as usize, 16)
-                } else {
-                    Ok(())
-                }
+            move |caller: Caller<'_, StoreData<S>>, dst: u32| {
+                canister_cycle_balance128_64(&log, caller, dst as u64)
             }
         })
         .unwrap();
@@ -1785,28 +1648,8 @@ pub(crate) fn syscalls<S: SystemApi>(
     linker
         .func_wrap("ic0", "canister_cycle_balance128_64", {
             let log = log.clone();
-            move |mut caller: Caller<'_, StoreData<S>>, dst: u64| {
-                charge_for_system_api_call(
-                    &log,
-                    canister_id,
-                    &mut caller,
-                    system_api::complexity_overhead!(CANISTER_CYCLE_BALANCE128, metering_type),
-                    0,
-                    ExecutionComplexity {
-                        cpu: system_api_complexity::cpu::CANISTER_CYCLE_BALANCE128,
-                        ..Default::default()
-                    },
-                    NumInstructions::from(0),
-                    stable_memory_dirty_page_limit,
-                )?;
-                with_memory_and_system_api(&mut caller, |system_api, memory| {
-                    system_api.ic0_canister_cycle_balance128_64(dst, memory)
-                })?;
-                if feature_flags.write_barrier == FlagStatus::Enabled {
-                    mark_writes_on_bytemap(&mut caller, dst as usize, 16)
-                } else {
-                    Ok(())
-                }
+            move |caller: Caller<'_, StoreData<S>>, dst: u64| {
+                canister_cycle_balance128_64(&log, caller, dst)
             }
         })
         .unwrap();
@@ -1839,31 +1682,36 @@ pub(crate) fn syscalls<S: SystemApi>(
         })
         .unwrap();
 
+    let msg_cycles_available128_64 =
+        move |log: &ReplicaLogger, mut caller: Caller<'_, StoreData<S>>, dst: u64| {
+            charge_for_system_api_call(
+                log,
+                canister_id,
+                &mut caller,
+                system_api::complexity_overhead!(MSG_CYCLES_AVAILABLE128, metering_type),
+                0,
+                ExecutionComplexity {
+                    cpu: system_api_complexity::cpu::MSG_CYCLES_AVAILABLE128,
+                    ..Default::default()
+                },
+                NumInstructions::from(0),
+                stable_memory_dirty_page_limit,
+            )?;
+            with_memory_and_system_api(&mut caller, |system_api, memory| {
+                system_api.ic0_msg_cycles_available128_64(dst, memory)
+            })?;
+            if feature_flags.write_barrier == FlagStatus::Enabled {
+                mark_writes_on_bytemap(&mut caller, dst as usize, 16)
+            } else {
+                Ok(())
+            }
+        };
+
     linker
         .func_wrap("ic0", "msg_cycles_available128", {
             let log = log.clone();
-            move |mut caller: Caller<'_, StoreData<S>>, dst: u32| {
-                charge_for_system_api_call(
-                    &log,
-                    canister_id,
-                    &mut caller,
-                    system_api::complexity_overhead!(MSG_CYCLES_AVAILABLE128, metering_type),
-                    0,
-                    ExecutionComplexity {
-                        cpu: system_api_complexity::cpu::MSG_CYCLES_AVAILABLE128,
-                        ..Default::default()
-                    },
-                    NumInstructions::from(0),
-                    stable_memory_dirty_page_limit,
-                )?;
-                with_memory_and_system_api(&mut caller, |system_api, memory| {
-                    system_api.ic0_msg_cycles_available128(dst, memory)
-                })?;
-                if feature_flags.write_barrier == FlagStatus::Enabled {
-                    mark_writes_on_bytemap(&mut caller, dst as usize, 16)
-                } else {
-                    Ok(())
-                }
+            move |caller: Caller<'_, StoreData<S>>, dst: u32| {
+                msg_cycles_available128_64(&log, caller, dst as u64)
             }
         })
         .unwrap();
@@ -1871,28 +1719,8 @@ pub(crate) fn syscalls<S: SystemApi>(
     linker
         .func_wrap("ic0", "msg_cycles_available128_64", {
             let log = log.clone();
-            move |mut caller: Caller<'_, StoreData<S>>, dst: u64| {
-                charge_for_system_api_call(
-                    &log,
-                    canister_id,
-                    &mut caller,
-                    system_api::complexity_overhead!(MSG_CYCLES_AVAILABLE128, metering_type),
-                    0,
-                    ExecutionComplexity {
-                        cpu: system_api_complexity::cpu::MSG_CYCLES_AVAILABLE128,
-                        ..Default::default()
-                    },
-                    NumInstructions::from(0),
-                    stable_memory_dirty_page_limit,
-                )?;
-                with_memory_and_system_api(&mut caller, |system_api, memory| {
-                    system_api.ic0_msg_cycles_available128_64(dst, memory)
-                })?;
-                if feature_flags.write_barrier == FlagStatus::Enabled {
-                    mark_writes_on_bytemap(&mut caller, dst as usize, 16)
-                } else {
-                    Ok(())
-                }
+            move |caller: Caller<'_, StoreData<S>>, dst: u64| {
+                msg_cycles_available128_64(&log, caller, dst)
             }
         })
         .unwrap();
@@ -1925,31 +1753,36 @@ pub(crate) fn syscalls<S: SystemApi>(
         })
         .unwrap();
 
+    let msg_cycles_refunded128_64 =
+        move |log: &ReplicaLogger, mut caller: Caller<'_, StoreData<S>>, dst: u64| {
+            charge_for_system_api_call(
+                log,
+                canister_id,
+                &mut caller,
+                system_api::complexity_overhead!(MSG_CYCLES_REFUNDED128, metering_type),
+                0,
+                ExecutionComplexity {
+                    cpu: system_api_complexity::cpu::MSG_CYCLES_REFUNDED128,
+                    ..Default::default()
+                },
+                NumInstructions::from(0),
+                stable_memory_dirty_page_limit,
+            )?;
+            with_memory_and_system_api(&mut caller, |system_api, memory| {
+                system_api.ic0_msg_cycles_refunded128_64(dst, memory)
+            })?;
+            if feature_flags.write_barrier == FlagStatus::Enabled {
+                mark_writes_on_bytemap(&mut caller, dst as usize, 16)
+            } else {
+                Ok(())
+            }
+        };
+
     linker
         .func_wrap("ic0", "msg_cycles_refunded128", {
             let log = log.clone();
-            move |mut caller: Caller<'_, StoreData<S>>, dst: u32| {
-                charge_for_system_api_call(
-                    &log,
-                    canister_id,
-                    &mut caller,
-                    system_api::complexity_overhead!(MSG_CYCLES_REFUNDED128, metering_type),
-                    0,
-                    ExecutionComplexity {
-                        cpu: system_api_complexity::cpu::MSG_CYCLES_REFUNDED128,
-                        ..Default::default()
-                    },
-                    NumInstructions::from(0),
-                    stable_memory_dirty_page_limit,
-                )?;
-                with_memory_and_system_api(&mut caller, |system_api, memory| {
-                    system_api.ic0_msg_cycles_refunded128(dst, memory)
-                })?;
-                if feature_flags.write_barrier == FlagStatus::Enabled {
-                    mark_writes_on_bytemap(&mut caller, dst as usize, 16)
-                } else {
-                    Ok(())
-                }
+            move |caller: Caller<'_, StoreData<S>>, dst: u32| {
+                msg_cycles_refunded128_64(&log, caller, dst as u64)
             }
         })
         .unwrap();
@@ -1957,28 +1790,8 @@ pub(crate) fn syscalls<S: SystemApi>(
     linker
         .func_wrap("ic0", "msg_cycles_refunded128_64", {
             let log = log.clone();
-            move |mut caller: Caller<'_, StoreData<S>>, dst: u64| {
-                charge_for_system_api_call(
-                    &log,
-                    canister_id,
-                    &mut caller,
-                    system_api::complexity_overhead!(MSG_CYCLES_REFUNDED128, metering_type),
-                    0,
-                    ExecutionComplexity {
-                        cpu: system_api_complexity::cpu::MSG_CYCLES_REFUNDED128,
-                        ..Default::default()
-                    },
-                    NumInstructions::from(0),
-                    stable_memory_dirty_page_limit,
-                )?;
-                with_memory_and_system_api(&mut caller, |system_api, memory| {
-                    system_api.ic0_msg_cycles_refunded128_64(dst, memory)
-                })?;
-                if feature_flags.write_barrier == FlagStatus::Enabled {
-                    mark_writes_on_bytemap(&mut caller, dst as usize, 16)
-                } else {
-                    Ok(())
-                }
+            move |caller: Caller<'_, StoreData<S>>, dst: u64| {
+                msg_cycles_refunded128_64(&log, caller, dst)
             }
         })
         .unwrap();
@@ -2006,38 +1819,43 @@ pub(crate) fn syscalls<S: SystemApi>(
         })
         .unwrap();
 
+    let msg_cycles_accept128_64 = move |log: &ReplicaLogger,
+                                        mut caller: Caller<'_, StoreData<S>>,
+                                        amount_high: i64,
+                                        amount_low: i64,
+                                        dst: u64| {
+        charge_for_system_api_call(
+            log,
+            canister_id,
+            &mut caller,
+            system_api::complexity_overhead!(MSG_CYCLES_ACCEPT128, metering_type),
+            0,
+            ExecutionComplexity {
+                cpu: system_api_complexity::cpu::MSG_CYCLES_ACCEPT128,
+                ..Default::default()
+            },
+            NumInstructions::from(0),
+            stable_memory_dirty_page_limit,
+        )?;
+        with_memory_and_system_api(&mut caller, |system_api, memory| {
+            system_api.ic0_msg_cycles_accept128_64(
+                Cycles::from_parts(amount_high as u64, amount_low as u64),
+                dst,
+                memory,
+            )
+        })?;
+        if feature_flags.write_barrier == FlagStatus::Enabled {
+            mark_writes_on_bytemap(&mut caller, dst as usize, 16)
+        } else {
+            Ok(())
+        }
+    };
+
     linker
         .func_wrap("ic0", "msg_cycles_accept128", {
             let log = log.clone();
-            move |mut caller: Caller<'_, StoreData<S>>,
-                  amount_high: i64,
-                  amount_low: i64,
-                  dst: u32| {
-                charge_for_system_api_call(
-                    &log,
-                    canister_id,
-                    &mut caller,
-                    system_api::complexity_overhead!(MSG_CYCLES_ACCEPT128, metering_type),
-                    0,
-                    ExecutionComplexity {
-                        cpu: system_api_complexity::cpu::MSG_CYCLES_ACCEPT128,
-                        ..Default::default()
-                    },
-                    NumInstructions::from(0),
-                    stable_memory_dirty_page_limit,
-                )?;
-                with_memory_and_system_api(&mut caller, |system_api, memory| {
-                    system_api.ic0_msg_cycles_accept128(
-                        Cycles::from_parts(amount_high as u64, amount_low as u64),
-                        dst,
-                        memory,
-                    )
-                })?;
-                if feature_flags.write_barrier == FlagStatus::Enabled {
-                    mark_writes_on_bytemap(&mut caller, dst as usize, 16)
-                } else {
-                    Ok(())
-                }
+            move |caller: Caller<'_, StoreData<S>>, amount_high: i64, amount_low: i64, dst: u32| {
+                msg_cycles_accept128_64(&log, caller, amount_high, amount_low, dst as u64)
             }
         })
         .unwrap();
@@ -2045,35 +1863,8 @@ pub(crate) fn syscalls<S: SystemApi>(
     linker
         .func_wrap("ic0", "msg_cycles_accept128_64", {
             let log = log.clone();
-            move |mut caller: Caller<'_, StoreData<S>>,
-                  amount_high: i64,
-                  amount_low: i64,
-                  dst: u64| {
-                charge_for_system_api_call(
-                    &log,
-                    canister_id,
-                    &mut caller,
-                    system_api::complexity_overhead!(MSG_CYCLES_ACCEPT128, metering_type),
-                    0,
-                    ExecutionComplexity {
-                        cpu: system_api_complexity::cpu::MSG_CYCLES_ACCEPT128,
-                        ..Default::default()
-                    },
-                    NumInstructions::from(0),
-                    stable_memory_dirty_page_limit,
-                )?;
-                with_memory_and_system_api(&mut caller, |system_api, memory| {
-                    system_api.ic0_msg_cycles_accept128_64(
-                        Cycles::from_parts(amount_high as u64, amount_low as u64),
-                        dst,
-                        memory,
-                    )
-                })?;
-                if feature_flags.write_barrier == FlagStatus::Enabled {
-                    mark_writes_on_bytemap(&mut caller, dst as usize, 16)
-                } else {
-                    Ok(())
-                }
+            move |caller: Caller<'_, StoreData<S>>, amount_high: i64, amount_low: i64, dst: u64| {
+                msg_cycles_accept128_64(&log, caller, amount_high, amount_low, dst)
             }
         })
         .unwrap();
@@ -2092,40 +1883,49 @@ pub(crate) fn syscalls<S: SystemApi>(
         })
         .unwrap();
 
+    let update_available_memory_64 = move |mut caller: Caller<'_, StoreData<S>>,
+                                           native_memory_grow_res: i64,
+                                           additional_elements: i64,
+                                           element_size: i32| {
+        with_system_api(&mut caller, |s| {
+            s.update_available_memory(
+                native_memory_grow_res,
+                additional_elements as u64,
+                element_size as u32 as u64,
+            )
+        })
+        .map(|()| native_memory_grow_res)
+        .map_err(|e| process_err(&mut caller, e))
+    };
+
     linker
         .func_wrap("__", "update_available_memory", {
-            move |mut caller: Caller<'_, StoreData<S>>,
+            move |caller: Caller<'_, StoreData<S>>,
                   native_memory_grow_res: i32,
                   additional_elements: i32,
                   element_size: i32| {
-                with_system_api(&mut caller, |s| {
-                    s.update_available_memory(
-                        native_memory_grow_res as i64,
-                        additional_elements as u32 as u64,
-                        element_size as u32 as u64,
-                    )
-                })
-                .map(|()| native_memory_grow_res)
-                .map_err(|e| process_err(&mut caller, e))
+                update_available_memory_64(
+                    caller,
+                    native_memory_grow_res as i64,
+                    additional_elements as i64,
+                    element_size,
+                )
             }
         })
         .unwrap();
 
     linker
         .func_wrap("__", "update_available_memory_64", {
-            move |mut caller: Caller<'_, StoreData<S>>,
+            move |caller: Caller<'_, StoreData<S>>,
                   native_memory_grow_res: i64,
                   additional_elements: i64,
                   element_size: i32| {
-                with_system_api(&mut caller, |s| {
-                    s.update_available_memory(
-                        native_memory_grow_res,
-                        additional_elements as u64,
-                        element_size as u32 as u64,
-                    )
-                })
-                .map(|()| native_memory_grow_res)
-                .map_err(|e| process_err(&mut caller, e))
+                update_available_memory_64(
+                    caller,
+                    native_memory_grow_res,
+                    additional_elements,
+                    element_size,
+                )
             }
         })
         .unwrap();
@@ -2190,26 +1990,31 @@ pub(crate) fn syscalls<S: SystemApi>(
         })
         .unwrap();
 
+    let certified_data_set_64 =
+        move |log: &ReplicaLogger, mut caller: Caller<'_, StoreData<S>>, src: u64, size: u64| {
+            charge_for_system_api_call(
+                log,
+                canister_id,
+                &mut caller,
+                system_api::complexity_overhead!(CERTIFIED_DATA_SET, metering_type),
+                size,
+                ExecutionComplexity {
+                    cpu: system_api_complexity::cpu::CERTIFIED_DATA_SET,
+                    ..Default::default()
+                },
+                NumInstructions::from(0),
+                stable_memory_dirty_page_limit,
+            )?;
+            with_memory_and_system_api(&mut caller, |system_api, memory| {
+                system_api.ic0_certified_data_set_64(src, size, memory)
+            })
+        };
+
     linker
         .func_wrap("ic0", "certified_data_set", {
             let log = log.clone();
-            move |mut caller: Caller<'_, StoreData<S>>, src: u32, size: u32| {
-                charge_for_system_api_call(
-                    &log,
-                    canister_id,
-                    &mut caller,
-                    system_api::complexity_overhead!(CERTIFIED_DATA_SET, metering_type),
-                    size as u64,
-                    ExecutionComplexity {
-                        cpu: system_api_complexity::cpu::CERTIFIED_DATA_SET,
-                        ..Default::default()
-                    },
-                    NumInstructions::from(0),
-                    stable_memory_dirty_page_limit,
-                )?;
-                with_memory_and_system_api(&mut caller, |system_api, memory| {
-                    system_api.ic0_certified_data_set(src, size, memory)
-                })
+            move |caller: Caller<'_, StoreData<S>>, src: u32, size: u32| {
+                certified_data_set_64(&log, caller, src as u64, size as u64)
             }
         })
         .unwrap();
@@ -2217,23 +2022,8 @@ pub(crate) fn syscalls<S: SystemApi>(
     linker
         .func_wrap("ic0", "certified_data_set_64", {
             let log = log.clone();
-            move |mut caller: Caller<'_, StoreData<S>>, src: u64, size: u64| {
-                charge_for_system_api_call(
-                    &log,
-                    canister_id,
-                    &mut caller,
-                    system_api::complexity_overhead!(CERTIFIED_DATA_SET, metering_type),
-                    size,
-                    ExecutionComplexity {
-                        cpu: system_api_complexity::cpu::CERTIFIED_DATA_SET,
-                        ..Default::default()
-                    },
-                    NumInstructions::from(0),
-                    stable_memory_dirty_page_limit,
-                )?;
-                with_memory_and_system_api(&mut caller, |system_api, memory| {
-                    system_api.ic0_certified_data_set_64(src, size, memory)
-                })
+            move |caller: Caller<'_, StoreData<S>>, src: u64, size: u64| {
+                certified_data_set_64(&log, caller, src, size)
             }
         })
         .unwrap();
@@ -2284,26 +2074,31 @@ pub(crate) fn syscalls<S: SystemApi>(
         })
         .unwrap();
 
+    let is_controller_64 =
+        move |log: &ReplicaLogger, mut caller: Caller<'_, StoreData<S>>, src: i64, size: i64| {
+            charge_for_system_api_call(
+                log,
+                canister_id,
+                &mut caller,
+                system_api::complexity_overhead!(IS_CONTROLLER, metering_type),
+                size as u64,
+                ExecutionComplexity {
+                    cpu: system_api_complexity::cpu::IS_CONTROLLER,
+                    ..Default::default()
+                },
+                NumInstructions::from(0),
+                stable_memory_dirty_page_limit,
+            )?;
+            with_memory_and_system_api(&mut caller, |system_api, memory| {
+                system_api.ic0_is_controller_64(src as u64, size as u64, memory)
+            })
+        };
+
     linker
         .func_wrap("ic0", "is_controller", {
             let log = log.clone();
-            move |mut caller: Caller<'_, StoreData<S>>, src: i32, size: i32| {
-                charge_for_system_api_call(
-                    &log,
-                    canister_id,
-                    &mut caller,
-                    system_api::complexity_overhead!(IS_CONTROLLER, metering_type),
-                    size as u64,
-                    ExecutionComplexity {
-                        cpu: system_api_complexity::cpu::IS_CONTROLLER,
-                        ..Default::default()
-                    },
-                    NumInstructions::from(0),
-                    stable_memory_dirty_page_limit,
-                )?;
-                with_memory_and_system_api(&mut caller, |system_api, memory| {
-                    system_api.ic0_is_controller(src as u32, size as u32, memory)
-                })
+            move |caller: Caller<'_, StoreData<S>>, src: i32, size: i32| {
+                is_controller_64(&log, caller, src as i64, size as i64)
             }
         })
         .unwrap();
@@ -2311,23 +2106,8 @@ pub(crate) fn syscalls<S: SystemApi>(
     linker
         .func_wrap("ic0", "is_controller_64", {
             let log = log.clone();
-            move |mut caller: Caller<'_, StoreData<S>>, src: i64, size: i64| {
-                charge_for_system_api_call(
-                    &log,
-                    canister_id,
-                    &mut caller,
-                    system_api::complexity_overhead!(IS_CONTROLLER, metering_type),
-                    size as u64,
-                    ExecutionComplexity {
-                        cpu: system_api_complexity::cpu::IS_CONTROLLER,
-                        ..Default::default()
-                    },
-                    NumInstructions::from(0),
-                    stable_memory_dirty_page_limit,
-                )?;
-                with_memory_and_system_api(&mut caller, |system_api, memory| {
-                    system_api.ic0_is_controller_64(src as u64, size as u64, memory)
-                })
+            move |caller: Caller<'_, StoreData<S>>, src: i64, size: i64| {
+                is_controller_64(&log, caller, src, size)
             }
         })
         .unwrap();

--- a/rs/embedders/src/wasmtime_embedder/system_api.rs
+++ b/rs/embedders/src/wasmtime_embedder/system_api.rs
@@ -2324,8 +2324,9 @@ fn main_write_page_guard<S: SystemApi>(
     };
 
     let bytemap = bytemap_mem.data_mut(&mut caller);
+    let first_access = bytemap[page_index] == NO_ACCESS;
     bytemap[page_index] = WRITE_ACCESS;
-    if bytemap[page_index] == NO_ACCESS {
+    if first_access {
         first_access_on_main_memory_page(&mut caller)?;
     }
     Ok(())

--- a/rs/embedders/src/wasmtime_embedder/system_api.rs
+++ b/rs/embedders/src/wasmtime_embedder/system_api.rs
@@ -1910,6 +1910,7 @@ pub(crate) fn syscalls<S: SystemApi>(
                     additional_elements as i64,
                     element_size,
                 )
+                .map(|result| result as i32)
             }
         })
         .unwrap();

--- a/rs/embedders/src/wasmtime_embedder/system_api.rs
+++ b/rs/embedders/src/wasmtime_embedder/system_api.rs
@@ -431,7 +431,7 @@ pub(crate) fn syscalls<S: SystemApi>(
             system_api.ic0_msg_caller_copy_64(dst as u64, offset as u64, size as u64, memory)
         })?;
         if feature_flags.write_barrier == FlagStatus::Enabled {
-            mark_writes_on_bytemap(&mut caller, dst as u64 as usize, size as u32 as usize)
+            mark_writes_on_bytemap(&mut caller, dst as u64 as usize, size as u64 as usize)
         } else {
             Ok(())
         }
@@ -441,7 +441,13 @@ pub(crate) fn syscalls<S: SystemApi>(
         .func_wrap("ic0", "msg_caller_copy", {
             let log = log.clone();
             move |caller: Caller<'_, StoreData<S>>, dst: i32, offset: i32, size: i32| {
-                msg_caller_copy_64(&log, caller, dst as i64, offset as i64, size as i64)
+                msg_caller_copy_64(
+                    &log,
+                    caller,
+                    dst as u32 as i64,
+                    offset as u32 as i64,
+                    size as u32 as i64,
+                )
             }
         })
         .unwrap();
@@ -543,7 +549,13 @@ pub(crate) fn syscalls<S: SystemApi>(
         .func_wrap("ic0", "msg_arg_data_copy", {
             let log = log.clone();
             move |caller: Caller<'_, StoreData<S>>, dst: i32, offset: i32, size: i32| {
-                msg_arg_data_copy_64(&log, caller, dst as i64, offset as i64, size as i64)
+                msg_arg_data_copy_64(
+                    &log,
+                    caller,
+                    dst as u32 as i64,
+                    offset as u32 as i64,
+                    size as u32 as i64,
+                )
             }
         })
         .unwrap();
@@ -617,7 +629,13 @@ pub(crate) fn syscalls<S: SystemApi>(
         .func_wrap("ic0", "msg_method_name_copy", {
             let log = log.clone();
             move |caller: Caller<'_, StoreData<S>>, dst: i32, offset: i32, size: i32| {
-                msg_method_name_copy_64(&log, caller, dst as i64, offset as i64, size as i64)
+                msg_method_name_copy_64(
+                    &log,
+                    caller,
+                    dst as u32 as i64,
+                    offset as u32 as i64,
+                    size as u32 as i64,
+                )
             }
         })
         .unwrap();
@@ -678,7 +696,7 @@ pub(crate) fn syscalls<S: SystemApi>(
         .func_wrap("ic0", "msg_reply_data_append", {
             let log = log.clone();
             move |caller: Caller<'_, StoreData<S>>, src: i32, size: i32| {
-                msg_reply_data_append_64(&log, caller, src as i64, size as i64)
+                msg_reply_data_append_64(&log, caller, src as u32 as i64, size as u32 as i64)
             }
         })
         .unwrap();
@@ -762,7 +780,7 @@ pub(crate) fn syscalls<S: SystemApi>(
         .func_wrap("ic0", "msg_reject", {
             let log = log.clone();
             move |caller: Caller<'_, StoreData<S>>, src: i32, size: i32| {
-                msg_reject_64(&log, caller, src as i64, size as i64)
+                msg_reject_64(&log, caller, src as u32 as i64, size as u32 as i64)
             }
         })
         .unwrap();
@@ -836,7 +854,13 @@ pub(crate) fn syscalls<S: SystemApi>(
         .func_wrap("ic0", "msg_reject_msg_copy", {
             let log = log.clone();
             move |caller: Caller<'_, StoreData<S>>, dst: i32, offset: i32, size: i32| {
-                msg_reject_msg_copy_64(&log, caller, dst as i64, offset as i64, size as i64)
+                msg_reject_msg_copy_64(
+                    &log,
+                    caller,
+                    dst as u32 as i64,
+                    offset as u32 as i64,
+                    size as u32 as i64,
+                )
             }
         })
         .unwrap();
@@ -910,7 +934,13 @@ pub(crate) fn syscalls<S: SystemApi>(
         .func_wrap("ic0", "canister_self_copy", {
             let log = log.clone();
             move |caller: Caller<'_, StoreData<S>>, dst: i32, offset: i32, size: i32| {
-                canister_self_copy_64(&log, caller, dst as i64, offset as i64, size as i64)
+                canister_self_copy_64(
+                    &log,
+                    caller,
+                    dst as u32 as i64,
+                    offset as u32 as i64,
+                    size as u32 as i64,
+                )
             }
         })
         .unwrap();
@@ -962,7 +992,7 @@ pub(crate) fn syscalls<S: SystemApi>(
         .func_wrap("ic0", "debug_print", {
             let log = log.clone();
             move |caller: Caller<'_, StoreData<S>>, offset: i32, length: i32| {
-                debug_print_64(&log, caller, offset as i64, length as i64)
+                debug_print_64(&log, caller, offset as u32 as i64, length as u32 as i64)
             }
         })
         .unwrap();
@@ -1003,7 +1033,7 @@ pub(crate) fn syscalls<S: SystemApi>(
         .func_wrap("ic0", "trap", {
             let log = log.clone();
             move |caller: Caller<'_, StoreData<S>>, offset: i32, length: i32| -> Result<(), _> {
-                trap_64(&log, caller, offset as i64, length as i64)
+                trap_64(&log, caller, offset as u32 as i64, length as u32 as i64)
             }
         })
         .unwrap();
@@ -1070,10 +1100,10 @@ pub(crate) fn syscalls<S: SystemApi>(
                 call_new_64(
                     &log,
                     caller,
-                    callee_src as i64,
-                    callee_size as i64,
-                    name_src as i64,
-                    name_len as i64,
+                    callee_src as u32 as i64,
+                    callee_size as u32 as i64,
+                    name_src as u32 as i64,
+                    name_len as u32 as i64,
                     reply_fun,
                     reply_env,
                     reject_fun,
@@ -1135,7 +1165,7 @@ pub(crate) fn syscalls<S: SystemApi>(
         .func_wrap("ic0", "call_data_append", {
             let log = log.clone();
             move |caller: Caller<'_, StoreData<S>>, src: i32, size: i32| {
-                data_append_64(&log, caller, src as i64, size as i64)
+                data_append_64(&log, caller, src as u32 as i64, size as u32 as i64)
             }
         })
         .unwrap();
@@ -1308,7 +1338,7 @@ pub(crate) fn syscalls<S: SystemApi>(
                     canister_id,
                     &mut caller,
                     system_api::complexity_overhead!(STABLE_READ, metering_type),
-                    size as u64,
+                    size as u32 as u64,
                     ExecutionComplexity {
                         cpu: system_api_complexity::cpu::STABLE_READ,
                         ..Default::default()
@@ -1342,7 +1372,7 @@ pub(crate) fn syscalls<S: SystemApi>(
                     canister_id,
                     &mut caller,
                     system_api::complexity_overhead!(STABLE_WRITE, metering_type),
-                    size as u64,
+                    size as u32 as u64,
                     ExecutionComplexity {
                         cpu: system_api_complexity::cpu::STABLE_WRITE,
                         stable_dirty_pages,
@@ -1451,7 +1481,7 @@ pub(crate) fn syscalls<S: SystemApi>(
                     system_api.ic0_stable64_read(dst as u64, offset as u64, size as u64, memory)
                 })?;
                 if feature_flags.write_barrier == FlagStatus::Enabled {
-                    mark_writes_on_bytemap(&mut caller, dst as u32 as usize, size as u32 as usize)
+                    mark_writes_on_bytemap(&mut caller, dst as u64 as usize, size as u64 as usize)
                 } else {
                     Ok(())
                 }
@@ -1907,7 +1937,7 @@ pub(crate) fn syscalls<S: SystemApi>(
                 update_available_memory_64(
                     caller,
                     native_memory_grow_res as i64,
-                    additional_elements as i64,
+                    additional_elements as u32 as i64,
                     element_size,
                 )
                 .map(|result| result as i32)
@@ -2099,7 +2129,7 @@ pub(crate) fn syscalls<S: SystemApi>(
         .func_wrap("ic0", "is_controller", {
             let log = log.clone();
             move |caller: Caller<'_, StoreData<S>>, src: i32, size: i32| {
-                is_controller_64(&log, caller, src as i64, size as i64)
+                is_controller_64(&log, caller, src as u32 as i64, size as u32 as i64)
             }
         })
         .unwrap();
@@ -2113,59 +2143,47 @@ pub(crate) fn syscalls<S: SystemApi>(
         })
         .unwrap();
 
+    let data_certificate_copy_64 = move |log: &ReplicaLogger,
+                                         mut caller: Caller<'_, StoreData<S>>,
+                                         dst: u64,
+                                         offset: u64,
+                                         size: u64| {
+        charge_for_system_api_call(
+            log,
+            canister_id,
+            &mut caller,
+            system_api::complexity_overhead!(DATA_CERTIFICATE_COPY, metering_type),
+            size,
+            ExecutionComplexity {
+                cpu: system_api_complexity::cpu::DATA_CERTIFICATE_COPY,
+                ..Default::default()
+            },
+            NumInstructions::from(0),
+            stable_memory_dirty_page_limit,
+        )?;
+        with_memory_and_system_api(&mut caller, |system_api, memory| {
+            system_api.ic0_data_certificate_copy_64(dst, offset, size, memory)
+        })?;
+        if feature_flags.write_barrier == FlagStatus::Enabled {
+            mark_writes_on_bytemap(&mut caller, dst as usize, size as usize)
+        } else {
+            Ok(())
+        }
+    };
+
     linker
         .func_wrap("ic0", "data_certificate_copy", {
             let log = log.clone();
-            move |mut caller: Caller<'_, StoreData<S>>, dst: u32, offset: u32, size: u32| {
-                charge_for_system_api_call(
-                    &log,
-                    canister_id,
-                    &mut caller,
-                    system_api::complexity_overhead!(DATA_CERTIFICATE_COPY, metering_type),
-                    size as u64,
-                    ExecutionComplexity {
-                        cpu: system_api_complexity::cpu::DATA_CERTIFICATE_COPY,
-                        ..Default::default()
-                    },
-                    NumInstructions::from(0),
-                    stable_memory_dirty_page_limit,
-                )?;
-                with_memory_and_system_api(&mut caller, |system_api, memory| {
-                    system_api.ic0_data_certificate_copy(dst, offset, size, memory)
-                })?;
-                if feature_flags.write_barrier == FlagStatus::Enabled {
-                    mark_writes_on_bytemap(&mut caller, dst as usize, size as usize)
-                } else {
-                    Ok(())
-                }
+            move |caller: Caller<'_, StoreData<S>>, dst: u32, offset: u32, size: u32| {
+                data_certificate_copy_64(&log, caller, dst as u64, offset as u64, size as u64)
             }
         })
         .unwrap();
 
     linker
         .func_wrap("ic0", "data_certificate_copy_64", {
-            move |mut caller: Caller<'_, StoreData<S>>, dst: u64, offset: u64, size: u64| {
-                charge_for_system_api_call(
-                    &log,
-                    canister_id,
-                    &mut caller,
-                    system_api::complexity_overhead!(DATA_CERTIFICATE_COPY, metering_type),
-                    size as u64,
-                    ExecutionComplexity {
-                        cpu: system_api_complexity::cpu::DATA_CERTIFICATE_COPY,
-                        ..Default::default()
-                    },
-                    NumInstructions::from(0),
-                    stable_memory_dirty_page_limit,
-                )?;
-                with_memory_and_system_api(&mut caller, |system_api, memory| {
-                    system_api.ic0_data_certificate_copy_64(dst, offset, size, memory)
-                })?;
-                if feature_flags.write_barrier == FlagStatus::Enabled {
-                    mark_writes_on_bytemap(&mut caller, dst as usize, size as usize)
-                } else {
-                    Ok(())
-                }
+            move |caller: Caller<'_, StoreData<S>>, dst: u64, offset: u64, size: u64| {
+                data_certificate_copy_64(&log, caller, dst, offset, size)
             }
         })
         .unwrap();

--- a/rs/embedders/src/wasmtime_embedder/system_api.rs
+++ b/rs/embedders/src/wasmtime_embedder/system_api.rs
@@ -2244,16 +2244,16 @@ pub(crate) fn syscalls<S: SystemApi>(
 
     linker
         .func_wrap("__", "main_read_page_guard", {
-            move |mut caller: Caller<'_, StoreData<S>>, page_index: i64| {
-                main_read_page_guard(&mut caller, page_index as u64 as usize)
+            move |mut caller: Caller<'_, StoreData<S>>, page_index: i32| {
+                main_read_page_guard(&mut caller, page_index as u32 as usize)
             }
         })
         .unwrap();
 
     linker
         .func_wrap("__", "main_write_page_guard", {
-            move |mut caller: Caller<'_, StoreData<S>>, page_index: i64| {
-                main_write_page_guard(&mut caller, page_index as u64 as usize)
+            move |mut caller: Caller<'_, StoreData<S>>, page_index: i32| {
+                main_write_page_guard(&mut caller, page_index as u32 as usize)
             }
         })
         .unwrap();

--- a/rs/embedders/src/wasmtime_embedder/wasmtime_embedder_tests.rs
+++ b/rs/embedders/src/wasmtime_embedder/wasmtime_embedder_tests.rs
@@ -83,6 +83,7 @@ fn test_wasmtime_system_api() {
             num_instructions_global: None,
         },
     );
+    store.set_epoch_deadline(1);
 
     let wat = r#"
     (module

--- a/rs/embedders/src/wasmtime_embedder/wasmtime_embedder_tests.rs
+++ b/rs/embedders/src/wasmtime_embedder/wasmtime_embedder_tests.rs
@@ -81,6 +81,7 @@ fn test_wasmtime_system_api() {
         StoreData {
             system_api,
             num_instructions_global: None,
+            accessed_main_memory_pages: None,
         },
     );
 

--- a/rs/embedders/src/wasmtime_embedder/wasmtime_embedder_tests.rs
+++ b/rs/embedders/src/wasmtime_embedder/wasmtime_embedder_tests.rs
@@ -83,7 +83,6 @@ fn test_wasmtime_system_api() {
             num_instructions_global: None,
         },
     );
-    store.set_epoch_deadline(1);
 
     let wat = r#"
     (module

--- a/rs/embedders/tests/wasmtime_random_memory_writes.rs
+++ b/rs/embedders/tests/wasmtime_random_memory_writes.rs
@@ -418,9 +418,11 @@ fn wat2wasm(wat: &str) -> Result<BinaryEncodedWasm, wat::Error> {
 mod tests {
     use super::*;
 
-    use ic_embedders::{wasm_executor::compute_page_delta, wasmtime_embedder::CanisterMemoryType};
+    use ic_embedders::{
+        wasm_executor::compute_page_delta, wasmtime_embedder::CanisterMemoryType, InstanceRunResult,
+    };
     // Get .current() trait method
-    use ic_interfaces::execution_environment::{HypervisorError, SystemApi};
+    use ic_interfaces::execution_environment::{HypervisorError, HypervisorResult, SystemApi};
     use ic_logger::ReplicaLogger;
     use ic_replicated_state::{PageIndex, PageMap};
     use ic_system_api::ModificationTracking;
@@ -1374,5 +1376,93 @@ mod tests {
             apply_writes_and_check_heap(&writes, ModificationTracking::Track, &wat, false)
         }
         apply_writes_and_check_heap(&writes, ModificationTracking::Ignore, &wat, false);
+    }
+
+    fn run_wasm(wat: &str, function_name: &str) -> HypervisorResult<InstanceRunResult> {
+        with_test_replica_logger(|log| {
+            let wasm = wat::parse_str(wat).map(BinaryEncodedWasm::new).unwrap();
+            let embedder = WasmtimeEmbedder::new(ic_config::embedders::Config::default(), log);
+            let (embedder_cache, result) = compile(&embedder, &wasm);
+            result.unwrap();
+            let api = test_api_for_update(
+                no_op_logger(),
+                None,
+                vec![],
+                SubnetType::Application,
+                NumInstructions::new(10_000_000_000),
+            );
+            let instruction_limit = api.slice_instruction_limit();
+            let memory = Memory::new(PageMap::new_for_testing(), NumWasmPages::from(0));
+            let mut instance = embedder
+                .new_instance(
+                    canister_test_id(1),
+                    &embedder_cache,
+                    None,
+                    &memory.clone(),
+                    &memory,
+                    ModificationTracking::Ignore,
+                    api,
+                )
+                .map_err(|r| r.0)
+                .expect("Failed to create instance");
+            instance.set_instruction_counter(i64::try_from(instruction_limit.get()).unwrap());
+            instance.run(FuncRef::Method(WasmMethod::Update(
+                function_name.to_string(),
+            )))
+        })
+    }
+
+    #[test]
+    fn check_64bit_working_set_limit_by_reading() {
+        let wat = r#"
+                (module
+                    (func (export "canister_update test")
+                        (local $address i64)
+                        loop
+                            local.get $address
+                            i64.load
+                            drop
+                            local.get $address
+                            i64.const 4096 ;; OS page
+                            i64.add
+                            local.set $address
+                            br 0
+                        end
+                    )
+                    (memory i64 131073) ;; 8 GB working set limit + 1 Wasm page
+                )
+            "#;
+        let result = run_wasm(wat, "test");
+        match result.unwrap_err() {
+            HypervisorError::MemoryAccessLimitExceeded(_) => {}
+            other_error => panic!("Unexpected error: {other_error:?}"),
+        }
+    }
+
+    #[test]
+    fn check_64bit_working_set_limit_by_writing() {
+        let wat = r#"
+                (module
+                    (func (export "canister_update test")
+                        (local $address i64)
+                        loop
+                            local.get $address
+                            i64.const 0
+                            i64.store
+                            local.get $address
+                            i64.const 4096 ;; OS page
+                            i64.add
+                            local.set $address
+                            br 0
+                        end
+                    )
+                    (memory i64 131073) ;; 8 GB working set limit + 1 Wasm page
+                )
+            "#;
+        let result = run_wasm(wat, "test");
+        match result.unwrap_err() {
+            HypervisorError::MemoryAccessLimitExceeded(_) => {}
+            other_error => panic!("Unexpected error: {other_error:?}"),
+        }
     }
 }

--- a/rs/embedders/tests/wasmtime_simple.rs
+++ b/rs/embedders/tests/wasmtime_simple.rs
@@ -102,7 +102,8 @@ impl WasmtimeSimple {
             &EmbeddersConfig::default(),
         ))
         .expect("Failed to initialize Wasmtime engine");
-        let store = Store::new(&engine, ());
+        let mut store = Store::new(&engine, ());
+        store.set_epoch_deadline(1);
         Self { engine, store }
     }
 

--- a/rs/embedders/tests/wasmtime_simple.rs
+++ b/rs/embedders/tests/wasmtime_simple.rs
@@ -102,8 +102,7 @@ impl WasmtimeSimple {
             &EmbeddersConfig::default(),
         ))
         .expect("Failed to initialize Wasmtime engine");
-        let mut store = Store::new(&engine, ());
-        store.set_epoch_deadline(1);
+        let store = Store::new(&engine, ());
         Self { engine, store }
     }
 

--- a/rs/execution_environment/BUILD.bazel
+++ b/rs/execution_environment/BUILD.bazel
@@ -79,7 +79,6 @@ DEV_DEPENDENCIES = [
     "@crate_index//:mockall_0_7_2",
     "@crate_index//:proptest",
     "@crate_index//:tempfile",
-    "@crate_index//:wasmparser",
     "@crate_index//:wat",
 ]
 

--- a/rs/execution_environment/BUILD.bazel
+++ b/rs/execution_environment/BUILD.bazel
@@ -54,6 +54,7 @@ DEPENDENCIES = [
     "@crate_index//:threadpool",
     "@crate_index//:tokio",
     "@crate_index//:tower",
+    "@crate_index//:wasmparser",
 ]
 
 MACRO_DEPENDENCIES = []

--- a/rs/execution_environment/Cargo.toml
+++ b/rs/execution_environment/Cargo.toml
@@ -56,7 +56,7 @@ strum = "0.23.0"
 threadpool = "1.8.1"
 tokio = { version = "1.17.0", features = ["rt", "sync"] }
 tower = { version = "0.4.11", features = ["buffer", "limit", "timeout"] }
-wasmparser = "0.100.0"
+wasmparser = "0.109.0"
 
 [dev-dependencies]
 assert_matches = "1.3.0"

--- a/rs/execution_environment/Cargo.toml
+++ b/rs/execution_environment/Cargo.toml
@@ -56,6 +56,7 @@ strum = "0.23.0"
 threadpool = "1.8.1"
 tokio = { version = "1.17.0", features = ["rt", "sync"] }
 tower = { version = "0.4.11", features = ["buffer", "limit", "timeout"] }
+wasmparser = "0.100.0"
 
 [dev-dependencies]
 assert_matches = "1.3.0"

--- a/rs/execution_environment/src/canister_manager.rs
+++ b/rs/execution_environment/src/canister_manager.rs
@@ -141,6 +141,7 @@ pub struct InstallCodeContext {
     pub compute_allocation: Option<ComputeAllocation>,
     pub memory_allocation: Option<MemoryAllocation>,
     pub query_allocation: QueryAllocation,
+    pub keep_main_memory: bool,
 }
 
 impl InstallCodeContext {
@@ -243,6 +244,7 @@ impl TryFrom<(CanisterChangeOrigin, InstallCodeArgs)> for InstallCodeContext {
             ))?),
             None => None,
         };
+        let keep_main_memory = args.keep_main_memory.unwrap_or(false);
 
         // TODO(EXE-294): Query allocations are not supported and should be deleted.
         let query_allocation = QueryAllocation::default();
@@ -256,6 +258,7 @@ impl TryFrom<(CanisterChangeOrigin, InstallCodeArgs)> for InstallCodeContext {
             compute_allocation,
             memory_allocation,
             query_allocation,
+            keep_main_memory,
         })
     }
 }

--- a/rs/execution_environment/src/execution.rs
+++ b/rs/execution_environment/src/execution.rs
@@ -9,6 +9,7 @@ mod nonreplicated_response;
 
 pub mod install;
 pub mod install_code;
+mod orthogonal_persistence;
 pub mod upgrade;
 
 // Common helpers.

--- a/rs/execution_environment/src/execution/install.rs
+++ b/rs/execution_environment/src/execution/install.rs
@@ -6,8 +6,8 @@ use crate::canister_manager::{
 };
 use crate::execution::common::{ingress_status_with_processing_state, update_round_limits};
 use crate::execution::install_code::{
-    canister_layout, finish_err, InstallCodeHelper, OriginalContext, PausedInstallCodeHelper,
-    StableMemoryHandling,
+    canister_layout, finish_err, InstallCodeHelper, MemoryHandling, OriginalContext,
+    PausedInstallCodeHelper,
 };
 use crate::execution_environment::{RoundContext, RoundLimits};
 use ic_base_types::PrincipalId;
@@ -99,7 +99,7 @@ pub(crate) fn execute_install(
     if let Err(err) = helper.replace_execution_state_and_allocations(
         instructions_from_compilation,
         result,
-        StableMemoryHandling::Replace,
+        MemoryHandling::Replace,
         &original,
     ) {
         let instructions_left = helper.instructions_left();

--- a/rs/execution_environment/src/execution/orthogonal_persistence.rs
+++ b/rs/execution_environment/src/execution/orthogonal_persistence.rs
@@ -55,9 +55,9 @@ struct PageChunk {
 
 const MB: usize = 1024 * 1024;
 const DATA_SEGMENT_LOWER_LIMIT: usize = 2 * MB;
-const DATA_SEGMENT_UPPER_LIMIT: usize = 4 * MB;
+const DATA_SEGMENT_UPPER_LIMIT: usize = 8 * MB;
 
-// TODO: Possibly simplify by overwriting the entire reserved data segment memory range (2MB, 4MB)
+// TODO: Possibly simplify by overwriting the entire reserved data segment memory range (2MB, 8MB)
 // and only checking the data segment locations.
 
 /// Orthogonal persistence helper
@@ -118,16 +118,16 @@ impl OrthogonalPersistence {
                 DataSegmentKind::Active {
                     memory_index: _,
                     offset_expr,
-                } => match offset_expr {
-                    Operator::I32Const { value } => {
-                        assert!(value >= 0);
-                        let offset = value as usize;
-                        let length = data_segment.data.len();
-                        let data_segment = DataSegment::new(offset, length);
-                        result.push(data_segment);
-                    }
-                    _ => unimplemented!(),
-                },
+                } => {
+                    let length = data_segment.data.len();
+                    let offset = match offset_expr {
+                        Operator::I32Const { value } => value as usize,
+                        Operator::I64Const { value } => value as usize,
+                        _ => unimplemented!(),
+                    };
+                    let data_segment = DataSegment::new(offset, length);
+                    result.push(data_segment);
+                }
                 DataSegmentKind::Passive => {}
             };
         }

--- a/rs/execution_environment/src/execution/orthogonal_persistence.rs
+++ b/rs/execution_environment/src/execution/orthogonal_persistence.rs
@@ -1,0 +1,136 @@
+/// ! True orthogonal persistence support
+///
+/// Retain the Wasm memory on upgrade, with only one exception:
+/// * The new Wasm data segments must be loaded into the old memory.
+///   This data represents static declarations of the new Wasm binary.
+///
+/// Safety assertion:
+/// * The data segments reside in a reserved memory space between 2MB and 4MB
+///   that must not be used by the persistent memory of the runtime system.
+///
+use core::cmp::min;
+use std::sync::Arc;
+
+use ic_embedders::wasm_utils::wasm_transform::{DataSegmentKind, Module};
+use ic_replicated_state::{canister_state::execution_state::WasmBinary, Memory};
+use ic_sys::{PageIndex, PAGE_SIZE};
+use wasmparser::Operator;
+
+struct DataSegment {
+    offset: usize,
+    length: usize,
+}
+
+impl DataSegment {
+    fn new(offset: usize, length: usize) -> Self {
+        assert!(offset >= DATA_SEGMENT_LOWER_LIMIT && offset + length <= DATA_SEGMENT_UPPER_LIMIT);
+        DataSegment { offset, length }
+    }
+
+    fn chunk_in_pages(&self) -> Vec<PageChunk> {
+        let mut result = vec![];
+        let mut current = self.offset;
+        let end = self.offset + self.length;
+        while current < end {
+            let page_index = PageIndex::new((current / PAGE_SIZE) as u64);
+            let offset = current % PAGE_SIZE;
+            let length = min(PAGE_SIZE - offset, end - current);
+            let page_chunk = PageChunk {
+                page_index,
+                offset,
+                length,
+            };
+            result.push(page_chunk);
+            current += length;
+        }
+        result
+    }
+}
+
+struct PageChunk {
+    page_index: PageIndex,
+    offset: usize,
+    length: usize,
+}
+
+const MB: usize = 1024 * 1024;
+const DATA_SEGMENT_LOWER_LIMIT: usize = 2 * MB;
+const DATA_SEGMENT_UPPER_LIMIT: usize = 4 * MB;
+
+// TODO: Possibly simplify by overwriting the entire reserved data segment memory range (2MB, 4MB)
+// and only checking the data segment locations.
+
+/// Orthogonal persistence helper
+pub struct OrthogonalPersistence {
+    wasm_binary: Arc<WasmBinary>,
+    combined_memory: Memory,
+    new_memory: Memory,
+}
+
+impl OrthogonalPersistence {
+    /// Prepare new canister memory on upgrade by retaining the old memory state except the new Wasm data segments.
+    pub fn upgrade_memory(
+        wasm_binary: Arc<WasmBinary>,
+        old_memory: Memory,
+        new_memory: Memory,
+    ) -> Memory {
+        let combined_memory = Memory::new(old_memory.page_map.clone(), old_memory.size);
+        let mut persistence = OrthogonalPersistence {
+            wasm_binary,
+            combined_memory,
+            new_memory,
+        };
+        persistence.upgrade_static_data();
+        persistence.combined_memory
+    }
+
+    fn upgrade_static_data(&mut self) {
+        for data_segment in &self.parse_data_segments() {
+            self.write_data_segment(data_segment);
+        }
+    }
+
+    fn write_data_segment(&mut self, data_segment: &DataSegment) {
+        for page_chunk in &data_segment.chunk_in_pages() {
+            self.write_page_chunk(page_chunk);
+        }
+    }
+
+    fn write_page_chunk(&mut self, page_chunk: &PageChunk) {
+        let page_index = page_chunk.page_index;
+        let current_page = self.combined_memory.page_map.get_page(page_index);
+        let new_page = self.new_memory.page_map.get_page(page_index);
+        let mut combined_page = *current_page;
+        let start = page_chunk.offset;
+        let end = start + page_chunk.length;
+        combined_page[start..end].copy_from_slice(&new_page[start..end]);
+        self.combined_memory
+            .page_map
+            .update(&[(page_index, &combined_page)]);
+    }
+
+    fn parse_data_segments(&self) -> Vec<DataSegment> {
+        let wasm = self.wasm_binary.as_ref().binary.as_slice();
+        let module = Module::parse(wasm, false).unwrap();
+        let mut result = vec![];
+        for data_segment in module.data {
+            match data_segment.kind {
+                DataSegmentKind::Active {
+                    memory_index: _,
+                    offset_expr,
+                } => match offset_expr {
+                    Operator::I32Const { value } => {
+                        assert!(value >= 0);
+                        let offset = value as usize;
+                        let length = data_segment.data.len();
+                        let data_segment = DataSegment::new(offset, length);
+                        result.push(data_segment);
+                    }
+                    _ => unimplemented!(),
+                },
+                DataSegmentKind::Passive => {}
+            };
+        }
+        result
+    }
+}

--- a/rs/execution_environment/src/execution/upgrade.rs
+++ b/rs/execution_environment/src/execution/upgrade.rs
@@ -13,6 +13,7 @@ use crate::execution::install_code::{
 use crate::execution_environment::{RoundContext, RoundLimits};
 use ic_base_types::PrincipalId;
 use ic_embedders::wasm_executor::{CanisterStateChanges, PausedWasmExecution, WasmExecutionResult};
+use ic_ic00_types::CanisterInstallModeV2;
 use ic_interfaces::execution_environment::{HypervisorError, WasmExecutionOutput};
 use ic_logger::{info, warn, ReplicaLogger};
 use ic_replicated_state::{
@@ -243,7 +244,14 @@ fn upgrade_stage_2_and_3a_create_execution_state_and_call_start(
         original.compilation_cost_handling,
     );
 
-    let memory_handling = if context.keep_main_memory {
+    let keep_main_memory = match context.mode {
+        CanisterInstallModeV2::Upgrade(Some(upgrade_options)) => {
+            upgrade_options.keep_main_memory.unwrap_or(false)
+        }
+        _ => false,
+    };
+
+    let memory_handling = if keep_main_memory {
         MemoryHandling::KeepBothMemories
     } else {
         MemoryHandling::KeepOnlyStableMemory

--- a/rs/execution_environment/src/execution/upgrade.rs
+++ b/rs/execution_environment/src/execution/upgrade.rs
@@ -7,8 +7,8 @@ use crate::canister_manager::{
 };
 use crate::execution::common::{ingress_status_with_processing_state, update_round_limits};
 use crate::execution::install_code::{
-    canister_layout, finish_err, InstallCodeHelper, OriginalContext, PausedInstallCodeHelper,
-    StableMemoryHandling,
+    canister_layout, finish_err, InstallCodeHelper, MemoryHandling, OriginalContext,
+    PausedInstallCodeHelper,
 };
 use crate::execution_environment::{RoundContext, RoundLimits};
 use ic_base_types::PrincipalId;
@@ -243,10 +243,15 @@ fn upgrade_stage_2_and_3a_create_execution_state_and_call_start(
         original.compilation_cost_handling,
     );
 
+    let memory_handling = if context.keep_main_memory {
+        MemoryHandling::KeepBothMemories
+    } else {
+        MemoryHandling::KeepOnlyStableMemory
+    };
     if let Err(err) = helper.replace_execution_state_and_allocations(
         instructions_from_compilation,
         result,
-        StableMemoryHandling::Keep,
+        memory_handling,
         &original,
     ) {
         let instructions_left = helper.instructions_left();

--- a/rs/execution_environment/src/execution_environment.rs
+++ b/rs/execution_environment/src/execution_environment.rs
@@ -28,7 +28,7 @@ use ic_ic00_types::{
     CanisterChangeOrigin, CanisterHttpRequestArgs, CanisterIdRecord, CanisterInfoRequest,
     CanisterInfoResponse, CanisterSettingsArgs, ComputeInitialEcdsaDealingsArgs,
     CreateCanisterArgs, ECDSAPublicKeyArgs, ECDSAPublicKeyResponse, EcdsaKeyId, EmptyBlob,
-    InstallCodeArgs, Method as Ic00Method, Payload as Ic00Payload,
+    InstallCodeArgsV2, Method as Ic00Method, Payload as Ic00Payload,
     ProvisionalCreateCanisterWithCyclesArgs, ProvisionalTopUpCanisterArgs, SetControllerArgs,
     SetupInitialDKGArgs, SignWithECDSAArgs, UninstallCodeArgs, UpdateSettingsArgs, IC_00,
 };
@@ -1951,7 +1951,7 @@ impl ExecutionEnvironment {
             state: &mut ReplicatedState,
         ) -> Result<(InstallCodeContext, CanisterState), UserError> {
             let payload = msg.method_payload();
-            let args = InstallCodeArgs::decode(payload)?;
+            let args = InstallCodeArgsV2::decode(payload)?;
             let install_context = InstallCodeContext::try_from((
                 msg.canister_change_origin(args.get_sender_canister_version()),
                 args,

--- a/rs/protobuf/def/types/v1/ic00_types.proto
+++ b/rs/protobuf/def/types/v1/ic00_types.proto
@@ -8,3 +8,15 @@ enum CanisterInstallMode {
   CANISTER_INSTALL_MODE_REINSTALL = 2;
   CANISTER_INSTALL_MODE_UPGRADE = 3;
 }
+
+message CanisterUpgradeOptions {
+  optional bool skip_pre_upgrade = 1;
+  optional bool keep_main_memory = 2;
+}
+
+message CanisterInstallModeV2 {
+  oneof canister_install_mode_v2 {
+    CanisterInstallMode mode = 1;
+    CanisterUpgradeOptions mode2 = 2;
+  }
+}

--- a/rs/protobuf/src/gen/state/types.v1.rs
+++ b/rs/protobuf/src/gen/state/types.v1.rs
@@ -72,6 +72,34 @@ impl NiDkgTag {
     }
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct CanisterUpgradeOptions {
+    #[prost(bool, optional, tag = "1")]
+    pub skip_pre_upgrade: ::core::option::Option<bool>,
+    #[prost(bool, optional, tag = "2")]
+    pub keep_main_memory: ::core::option::Option<bool>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct CanisterInstallModeV2 {
+    #[prost(
+        oneof = "canister_install_mode_v2::CanisterInstallModeV2",
+        tags = "1, 2"
+    )]
+    pub canister_install_mode_v2:
+        ::core::option::Option<canister_install_mode_v2::CanisterInstallModeV2>,
+}
+/// Nested message and enum types in `CanisterInstallModeV2`.
+pub mod canister_install_mode_v2 {
+    #[allow(clippy::derive_partial_eq_without_eq)]
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    pub enum CanisterInstallModeV2 {
+        #[prost(enumeration = "super::CanisterInstallMode", tag = "1")]
+        Mode(i32),
+        #[prost(message, tag = "2")]
+        Mode2(super::CanisterUpgradeOptions),
+    }
+}
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]
 pub enum CanisterInstallMode {

--- a/rs/protobuf/src/gen/types/types.v1.rs
+++ b/rs/protobuf/src/gen/types/types.v1.rs
@@ -1,6 +1,48 @@
 #[derive(serde::Serialize, serde::Deserialize)]
 #[allow(clippy::derive_partial_eq_without_eq)]
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct CanisterUpgradeOptions {
+    #[prost(bool, optional, tag = "1")]
+    pub skip_pre_upgrade: ::core::option::Option<bool>,
+    #[prost(bool, optional, tag = "2")]
+    pub keep_main_memory: ::core::option::Option<bool>,
+}
+#[derive(serde::Serialize, serde::Deserialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct CanisterInstallModeV2 {
+    #[prost(
+        oneof = "canister_install_mode_v2::CanisterInstallModeV2",
+        tags = "1, 2"
+    )]
+    pub canister_install_mode_v2:
+        ::core::option::Option<canister_install_mode_v2::CanisterInstallModeV2>,
+}
+/// Nested message and enum types in `CanisterInstallModeV2`.
+pub mod canister_install_mode_v2 {
+    #[derive(serde::Serialize, serde::Deserialize)]
+    #[allow(clippy::derive_partial_eq_without_eq)]
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    pub enum CanisterInstallModeV2 {
+        #[prost(enumeration = "super::CanisterInstallMode", tag = "1")]
+        Mode(i32),
+        #[prost(message, tag = "2")]
+        Mode2(super::CanisterUpgradeOptions),
+    }
+}
+#[derive(
+    serde::Serialize,
+    serde::Deserialize,
+    Clone,
+    Copy,
+    Debug,
+    PartialEq,
+    Eq,
+    Hash,
+    PartialOrd,
+    Ord,
+    ::prost::Enumeration,
+)]
 #[repr(i32)]
 pub enum CanisterInstallMode {
     Unspecified = 0,

--- a/rs/replicated_state/src/canister_state/execution_state.rs
+++ b/rs/replicated_state/src/canister_state/execution_state.rs
@@ -429,8 +429,7 @@ pub struct ExecutionState {
     /// properly when loading a state from checkpoint.
     pub wasm_binary: Arc<WasmBinary>,
 
-    /// The persistent heap of the module. The size of this memory is expected
-    /// to fit in a `u32`.
+    /// The persistent heap of the module, 64-bit address space.
     pub wasm_memory: Memory,
 
     /// The canister stable memory which is persisted across canister upgrades.

--- a/rs/system_api/src/lib.rs
+++ b/rs/system_api/src/lib.rs
@@ -37,12 +37,16 @@ use serde::{Deserialize, Serialize};
 use stable_memory::StableMemory;
 use std::{
     convert::{From, TryFrom},
+    mem::size_of,
     sync::Arc,
 };
 
+// Check native 64-bit support, assumed by the 64-bit IC call API implementation.
+const _: () = assert!(size_of::<usize>() == size_of::<u64>());
+
 const MULTIPLIER_MAX_SIZE_LOCAL_SUBNET: u64 = 5;
 const MAX_NON_REPLICATED_QUERY_REPLY_SIZE: NumBytes = NumBytes::new(3 << 20);
-const CERTIFIED_DATA_MAX_LENGTH: u32 = 32;
+const CERTIFIED_DATA_MAX_LENGTH: u64 = 32;
 
 // Enables tracing of system calls for local debugging.
 const TRACE_SYSCALLS: bool = false;
@@ -79,10 +83,10 @@ macro_rules! trace_syscall {
 
 // This helper is used in system calls for displaying a summary hash of a heap region.
 #[inline]
-fn summarize(heap: &[u8], start: u32, size: u32) -> u64 {
+fn summarize(heap: &[u8], start: usize, size: usize) -> u64 {
     if TRACE_SYSCALLS {
-        let start = (start as usize).min(heap.len());
-        let end = (start + (size as usize)).min(heap.len());
+        let start = start.min(heap.len());
+        let end = (start + size).min(heap.len());
         // The actual hash function doesn't matter much as long as it is
         // cheap to compute and maps the input to u64 reasonably well.
         let mut sum = 0;
@@ -1355,11 +1359,31 @@ impl SystemApi for SystemApiImpl {
         size: u32,
         heap: &mut [u8],
     ) -> HypervisorResult<()> {
+        self.ic0_msg_caller_copy_64(dst.into(), offset.into(), size.into(), heap)
+    }
+
+    fn ic0_msg_caller_copy_64(
+        &self,
+        dst: u64,
+        offset: u64,
+        size: u64,
+        heap: &mut [u8],
+    ) -> HypervisorResult<()> {
         let result = match self.get_msg_caller_id("ic0_msg_caller_copy") {
             Ok(caller_id) => {
                 let id_bytes = caller_id.as_slice();
-                valid_subslice("ic0.msg_caller_copy heap", dst, size, heap)?;
-                let slice = valid_subslice("ic0.msg_caller_copy id", offset, size, id_bytes)?;
+                valid_subslice(
+                    "ic0.msg_caller_copy heap",
+                    dst as usize,
+                    size as usize,
+                    heap,
+                )?;
+                let slice = valid_subslice(
+                    "ic0.msg_caller_copy id",
+                    offset as usize,
+                    size as usize,
+                    id_bytes,
+                )?;
                 let (dst, size) = (dst as usize, size as usize);
                 deterministic_copy_from_slice(&mut heap[dst..dst + size], slice);
                 Ok(())
@@ -1373,7 +1397,7 @@ impl SystemApi for SystemApiImpl {
             dst,
             offset,
             size,
-            summarize(heap, dst, size)
+            summarize(heap, dst as usize, size as usize)
         );
         result
     }
@@ -1415,6 +1439,16 @@ impl SystemApi for SystemApiImpl {
         size: u32,
         heap: &mut [u8],
     ) -> HypervisorResult<()> {
+        self.ic0_msg_arg_data_copy_64(dst.into(), offset.into(), size.into(), heap)
+    }
+
+    fn ic0_msg_arg_data_copy_64(
+        &self,
+        dst: u64,
+        offset: u64,
+        size: u64,
+        heap: &mut [u8],
+    ) -> HypervisorResult<()> {
         let result = match &self.api_type {
             ApiType::Start { .. }
             | ApiType::SystemTask { .. }
@@ -1439,11 +1473,16 @@ impl SystemApi for SystemApiImpl {
             | ApiType::NonReplicatedQuery {
                 incoming_payload, ..
             } => {
-                valid_subslice("ic0.msg_arg_data_copy heap", dst, size, heap)?;
+                valid_subslice(
+                    "ic0.msg_arg_data_copy heap",
+                    dst as usize,
+                    size as usize,
+                    heap,
+                )?;
                 let payload_subslice = valid_subslice(
                     "ic0.msg_arg_data_copy payload",
-                    offset,
-                    size,
+                    offset as usize,
+                    size as usize,
                     incoming_payload,
                 )?;
                 let (dst, size) = (dst as usize, size as usize);
@@ -1458,7 +1497,7 @@ impl SystemApi for SystemApiImpl {
             dst,
             offset,
             size,
-            summarize(heap, dst, size)
+            summarize(heap, dst as usize, size as usize)
         );
         result
     }
@@ -1488,6 +1527,16 @@ impl SystemApi for SystemApiImpl {
         size: u32,
         heap: &mut [u8],
     ) -> HypervisorResult<()> {
+        self.ic0_msg_method_name_copy_64(dst.into(), offset.into(), size.into(), heap)
+    }
+
+    fn ic0_msg_method_name_copy_64(
+        &self,
+        dst: u64,
+        offset: u64,
+        size: u64,
+        heap: &mut [u8],
+    ) -> HypervisorResult<()> {
         let result = match &self.api_type {
             ApiType::Start { .. }
             | ApiType::RejectCallback { .. }
@@ -1500,11 +1549,16 @@ impl SystemApi for SystemApiImpl {
             | ApiType::NonReplicatedQuery { .. }
             | ApiType::Init { .. } => Err(self.error_for("ic0_msg_method_name_copy")),
             ApiType::InspectMessage { method_name, .. } => {
-                valid_subslice("ic0.msg_method_name_copy heap", dst, size, heap)?;
+                valid_subslice(
+                    "ic0.msg_method_name_copy heap",
+                    dst as usize,
+                    size as usize,
+                    heap,
+                )?;
                 let payload_subslice = valid_subslice(
                     "ic0.msg_method_name_copy payload",
-                    offset,
-                    size,
+                    offset as usize,
+                    size as usize,
                     method_name.as_bytes(),
                 )?;
                 let (dst, size) = (dst as usize, size as usize);
@@ -1519,7 +1573,7 @@ impl SystemApi for SystemApiImpl {
             dst,
             offset,
             size,
-            summarize(heap, dst, size)
+            summarize(heap, dst as usize, size as usize)
         );
         result
     }
@@ -1578,6 +1632,15 @@ impl SystemApi for SystemApiImpl {
         size: u32,
         heap: &[u8],
     ) -> HypervisorResult<()> {
+        self.ic0_msg_reply_data_append_64(src.into(), size.into(), heap)
+    }
+
+    fn ic0_msg_reply_data_append_64(
+        &mut self,
+        src: u64,
+        size: u64,
+        heap: &[u8],
+    ) -> HypervisorResult<()> {
         let result = match self.get_response_info() {
             None => Err(self.error_for("ic0_msg_reply_data_append")),
             Some((data, max_reply_size, response_status)) => match response_status {
@@ -1591,7 +1654,12 @@ impl SystemApi for SystemApiImpl {
                         );
                         return Err(ContractViolation(string));
                     }
-                    data.extend_from_slice(valid_subslice("msg.reply", src, size, heap)?);
+                    data.extend_from_slice(valid_subslice(
+                        "msg.reply",
+                        src as usize,
+                        size as usize,
+                        heap,
+                    )?);
                     Ok(())
                 }
                 ResponseStatus::AlreadyReplied | ResponseStatus::JustRepliedWith(_) => {
@@ -1607,24 +1675,29 @@ impl SystemApi for SystemApiImpl {
             result,
             src,
             size,
-            summarize(heap, src, size)
+            summarize(heap, src as usize, size as usize)
         );
         result
     }
 
     fn ic0_msg_reject(&mut self, src: u32, size: u32, heap: &[u8]) -> HypervisorResult<()> {
+        self.ic0_msg_reject_64(src.into(), size.into(), heap)
+    }
+
+    fn ic0_msg_reject_64(&mut self, src: u64, size: u64, heap: &[u8]) -> HypervisorResult<()> {
         let result = match self.get_response_info() {
             None => Err(self.error_for("ic0_msg_reject")),
             Some((_, max_reply_size, response_status)) => match response_status {
                 ResponseStatus::NotRepliedYet => {
-                    if size as u64 > max_reply_size.get() {
+                    if size > max_reply_size.get() {
                         let string = format!(
                         "ic0.msg_reject: application payload size ({}) cannot be larger than {}",
                         size, max_reply_size
                     );
                         return Err(ContractViolation(string));
                     }
-                    let msg_bytes = valid_subslice("ic0.msg_reject", src, size, heap)?;
+                    let msg_bytes =
+                        valid_subslice("ic0.msg_reject", src as usize, size as usize, heap)?;
                     let msg = String::from_utf8(msg_bytes.to_vec()).map_err(|_| {
                         ContractViolation(
                             "ic0.msg_reject: invalid UTF-8 string provided".to_string(),
@@ -1645,7 +1718,7 @@ impl SystemApi for SystemApiImpl {
             result,
             src,
             size,
-            summarize(heap, src, size)
+            summarize(heap, src as usize, size as usize)
         );
         result
     }
@@ -1674,16 +1747,35 @@ impl SystemApi for SystemApiImpl {
         size: u32,
         heap: &mut [u8],
     ) -> HypervisorResult<()> {
+        self.ic0_msg_reject_msg_copy_64(dst.into(), offset.into(), size.into(), heap)
+    }
+
+    fn ic0_msg_reject_msg_copy_64(
+        &self,
+        dst: u64,
+        offset: u64,
+        size: u64,
+        heap: &mut [u8],
+    ) -> HypervisorResult<()> {
         let result = {
             let reject_context = self
                 .get_reject_context()
                 .ok_or_else(|| self.error_for("ic0_msg_reject_msg_copy"))?;
-            valid_subslice("ic0.msg_reject_msg_copy heap", dst, size, heap)?;
+            valid_subslice(
+                "ic0.msg_reject_msg_copy heap",
+                dst as usize,
+                size as usize,
+                heap,
+            )?;
 
             let msg = reject_context.message();
             let dst = dst as usize;
-            let msg_bytes =
-                valid_subslice("ic0.msg_reject_msg_copy msg", offset, size, msg.as_bytes())?;
+            let msg_bytes = valid_subslice(
+                "ic0.msg_reject_msg_copy msg",
+                offset as usize,
+                size as usize,
+                msg.as_bytes(),
+            )?;
             let size = size as usize;
             deterministic_copy_from_slice(&mut heap[dst..dst + size], msg_bytes);
             Ok(())
@@ -1695,7 +1787,7 @@ impl SystemApi for SystemApiImpl {
             dst,
             offset,
             size,
-            summarize(heap, dst, size)
+            summarize(heap, dst as usize, size as usize)
         );
         result
     }
@@ -1730,6 +1822,16 @@ impl SystemApi for SystemApiImpl {
         size: u32,
         heap: &mut [u8],
     ) -> HypervisorResult<()> {
+        self.ic0_canister_self_copy_64(dst.into(), offset.into(), size.into(), heap)
+    }
+
+    fn ic0_canister_self_copy_64(
+        &mut self,
+        dst: u64,
+        offset: u64,
+        size: u64,
+        heap: &mut [u8],
+    ) -> HypervisorResult<()> {
         let result = match &self.api_type {
             ApiType::Start { .. } => Err(self.error_for("ic0_canister_self_copy")),
             ApiType::Init { .. }
@@ -1742,10 +1844,20 @@ impl SystemApi for SystemApiImpl {
             | ApiType::ReplyCallback { .. }
             | ApiType::RejectCallback { .. }
             | ApiType::InspectMessage { .. } => {
-                valid_subslice("ic0.canister_self_copy heap", dst, size, heap)?;
+                valid_subslice(
+                    "ic0.canister_self_copy heap",
+                    dst as usize,
+                    size as usize,
+                    heap,
+                )?;
                 let canister_id = self.sandbox_safe_system_state.canister_id;
                 let id_bytes = canister_id.get_ref().as_slice();
-                let slice = valid_subslice("ic0.canister_self_copy id", offset, size, id_bytes)?;
+                let slice = valid_subslice(
+                    "ic0.canister_self_copy id",
+                    offset as usize,
+                    size as usize,
+                    id_bytes,
+                )?;
                 let (dst, size) = (dst as usize, size as usize);
                 deterministic_copy_from_slice(&mut heap[dst..dst + size], slice);
                 Ok(())
@@ -1758,7 +1870,7 @@ impl SystemApi for SystemApiImpl {
             dst,
             offset,
             size,
-            summarize(heap, dst, size)
+            summarize(heap, dst as usize, size as usize)
         );
         result
     }
@@ -1769,6 +1881,31 @@ impl SystemApi for SystemApiImpl {
         callee_size: u32,
         name_src: u32,
         name_len: u32,
+        reply_fun: u32,
+        reply_env: u32,
+        reject_fun: u32,
+        reject_env: u32,
+        heap: &[u8],
+    ) -> HypervisorResult<()> {
+        self.ic0_call_new_64(
+            callee_src.into(),
+            callee_size.into(),
+            name_src.into(),
+            name_len.into(),
+            reply_fun,
+            reply_env,
+            reject_fun,
+            reject_env,
+            heap,
+        )
+    }
+
+    fn ic0_call_new_64(
+        &mut self,
+        callee_src: u64,
+        callee_size: u64,
+        name_src: u64,
+        name_len: u64,
         reply_fun: u32,
         reply_env: u32,
         reject_fun: u32,
@@ -1812,10 +1949,10 @@ impl SystemApi for SystemApiImpl {
 
                 let req = RequestInPrep::new(
                     self.sandbox_safe_system_state.canister_id,
-                    callee_src,
-                    callee_size,
-                    name_src,
-                    name_len,
+                    callee_src as usize,
+                    callee_size as usize,
+                    name_src as usize,
+                    name_len as usize,
                     heap,
                     WasmClosure::new(reply_fun, reply_env),
                     WasmClosure::new(reject_fun, reject_env),
@@ -1839,12 +1976,21 @@ impl SystemApi for SystemApiImpl {
             reply_env,
             reject_fun,
             reject_env,
-            summarize(heap, callee_src, callee_size)
+            summarize(heap, callee_src as usize, callee_size as usize)
         );
         result
     }
 
     fn ic0_call_data_append(&mut self, src: u32, size: u32, heap: &[u8]) -> HypervisorResult<()> {
+        self.ic0_call_data_append_64(src.into(), size.into(), heap)
+    }
+
+    fn ic0_call_data_append_64(
+        &mut self,
+        src: u64,
+        size: u64,
+        heap: &[u8],
+    ) -> HypervisorResult<()> {
         let result = match &mut self.api_type {
             ApiType::Start { .. }
             | ApiType::Init { .. }
@@ -1878,7 +2024,7 @@ impl SystemApi for SystemApiImpl {
                 None => Err(HypervisorError::ContractViolation(
                     "ic0.call_data_append called when no call is under construction.".to_string(),
                 )),
-                Some(request) => request.extend_method_payload(src, size, heap),
+                Some(request) => request.extend_method_payload(src as usize, size as usize, heap),
             },
         };
         trace_syscall!(
@@ -1886,7 +2032,7 @@ impl SystemApi for SystemApiImpl {
             ic0_call_data_append,
             src,
             size,
-            summarize(heap, src, size)
+            summarize(heap, src as usize, size as usize)
         );
         result
     }
@@ -2071,7 +2217,7 @@ impl SystemApi for SystemApiImpl {
             dst,
             offset,
             size,
-            summarize(heap, dst, size)
+            summarize(heap, dst as usize, size as usize)
         );
         result
     }
@@ -2093,7 +2239,7 @@ impl SystemApi for SystemApiImpl {
             offset,
             src,
             size,
-            summarize(heap, src, size)
+            summarize(heap, src as usize, size as usize)
         );
         result
     }
@@ -2140,7 +2286,7 @@ impl SystemApi for SystemApiImpl {
             dst,
             offset,
             size,
-            summarize(heap, dst as u32, size as u32)
+            summarize(heap, dst as usize, size as usize)
         );
         result
     }
@@ -2173,7 +2319,7 @@ impl SystemApi for SystemApiImpl {
             offset,
             src,
             size,
-            summarize(heap, src as u32, size as u32)
+            summarize(heap, src as usize, size as usize)
         );
         result
     }
@@ -2378,17 +2524,21 @@ impl SystemApi for SystemApiImpl {
     }
 
     fn ic0_canister_cycle_balance128(&self, dst: u32, heap: &mut [u8]) -> HypervisorResult<()> {
+        self.ic0_canister_cycle_balance128_64(dst.into(), heap)
+    }
+
+    fn ic0_canister_cycle_balance128_64(&self, dst: u64, heap: &mut [u8]) -> HypervisorResult<()> {
         let result = {
             let method_name = "ic0_canister_cycle_balance128";
             let cycles = self.ic0_canister_cycle_balance_helper(method_name)?;
-            copy_cycles_to_heap(cycles, dst, heap, method_name)?;
+            copy_cycles_to_heap(cycles, dst as usize, heap, method_name)?;
             Ok(())
         };
         trace_syscall!(
             self,
             ic0_canister_cycle_balance128,
             dst,
-            summarize(heap, dst, 16)
+            summarize(heap, dst as usize, 16)
         );
         result
     }
@@ -2408,10 +2558,14 @@ impl SystemApi for SystemApiImpl {
     }
 
     fn ic0_msg_cycles_available128(&self, dst: u32, heap: &mut [u8]) -> HypervisorResult<()> {
+        self.ic0_msg_cycles_available128_64(dst.into(), heap)
+    }
+
+    fn ic0_msg_cycles_available128_64(&self, dst: u64, heap: &mut [u8]) -> HypervisorResult<()> {
         let result = {
             let method_name = "ic0_msg_cycles_available128";
             let cycles = self.ic0_msg_cycles_available_helper(method_name)?;
-            copy_cycles_to_heap(cycles, dst, heap, method_name)?;
+            copy_cycles_to_heap(cycles, dst as usize, heap, method_name)?;
             Ok(())
         };
         trace_syscall!(self, ic0_msg_cycles_available128, result);
@@ -2433,17 +2587,21 @@ impl SystemApi for SystemApiImpl {
     }
 
     fn ic0_msg_cycles_refunded128(&self, dst: u32, heap: &mut [u8]) -> HypervisorResult<()> {
+        self.ic0_msg_cycles_refunded128_64(dst.into(), heap)
+    }
+
+    fn ic0_msg_cycles_refunded128_64(&self, dst: u64, heap: &mut [u8]) -> HypervisorResult<()> {
         let result = {
             let method_name = "ic0_msg_cycles_refunded128";
             let cycles = self.ic0_msg_cycles_refunded_helper(method_name)?;
-            copy_cycles_to_heap(cycles, dst, heap, method_name)?;
+            copy_cycles_to_heap(cycles, dst as usize, heap, method_name)?;
             Ok(())
         };
         trace_syscall!(
             self,
             ic0_msg_cycles_refunded128,
             result,
-            summarize(heap, dst, 16)
+            summarize(heap, dst as usize, 16)
         );
         result
     }
@@ -2474,10 +2632,19 @@ impl SystemApi for SystemApiImpl {
         dst: u32,
         heap: &mut [u8],
     ) -> HypervisorResult<()> {
+        self.ic0_msg_cycles_accept128_64(max_amount, dst.into(), heap)
+    }
+
+    fn ic0_msg_cycles_accept128_64(
+        &mut self,
+        max_amount: Cycles,
+        dst: u64,
+        heap: &mut [u8],
+    ) -> HypervisorResult<()> {
         let result = {
             let method_name = "ic0_msg_cycles_accept128";
             let cycles = self.ic0_msg_cycles_accept_helper(method_name, max_amount)?;
-            copy_cycles_to_heap(cycles, dst, heap, method_name)?;
+            copy_cycles_to_heap(cycles, dst as usize, heap, method_name)?;
             Ok(())
         };
         trace_syscall!(self, ic0_msg_cycles_accept128, result);
@@ -2541,6 +2708,16 @@ impl SystemApi for SystemApiImpl {
         size: u32,
         heap: &mut [u8],
     ) -> HypervisorResult<()> {
+        self.ic0_data_certificate_copy_64(dst.into(), offset.into(), size.into(), heap)
+    }
+
+    fn ic0_data_certificate_copy_64(
+        &self,
+        dst: u64,
+        offset: u64,
+        size: u64,
+        heap: &mut [u8],
+    ) -> HypervisorResult<()> {
         let result = match &self.api_type {
             ApiType::Start { .. }
             | ApiType::Init { .. }
@@ -2600,12 +2777,21 @@ impl SystemApi for SystemApiImpl {
             dst,
             offset,
             size,
-            summarize(heap, dst, size)
+            summarize(heap, dst as usize, size as usize)
         );
         result
     }
 
     fn ic0_certified_data_set(&mut self, src: u32, size: u32, heap: &[u8]) -> HypervisorResult<()> {
+        self.ic0_certified_data_set_64(src.into(), size.into(), heap)
+    }
+
+    fn ic0_certified_data_set_64(
+        &mut self,
+        src: u64,
+        size: u64,
+        heap: &[u8],
+    ) -> HypervisorResult<()> {
         let result = match &mut self.api_type {
             ApiType::Start { .. }
             | ApiType::ReplicatedQuery { .. }
@@ -2658,7 +2844,7 @@ impl SystemApi for SystemApiImpl {
             result,
             src,
             size,
-            summarize(heap, src, size)
+            summarize(heap, src as usize, size as usize)
         );
         result
     }
@@ -2708,9 +2894,13 @@ impl SystemApi for SystemApiImpl {
     }
 
     fn ic0_debug_print(&self, src: u32, size: u32, heap: &[u8]) -> HypervisorResult<()> {
-        const MAX_DEBUG_MESSAGE_SIZE: u32 = 32 * 1024;
+        self.ic0_debug_print_64(src.into(), size.into(), heap)
+    }
+
+    fn ic0_debug_print_64(&self, src: u64, size: u64, heap: &[u8]) -> HypervisorResult<()> {
+        const MAX_DEBUG_MESSAGE_SIZE: u64 = 32 * 1024;
         let size = size.min(MAX_DEBUG_MESSAGE_SIZE);
-        let msg = match valid_subslice("ic0.debug_print", src, size, heap) {
+        let msg = match valid_subslice("ic0.debug_print", src as usize, size as usize, heap) {
             Ok(bytes) => String::from_utf8_lossy(bytes).to_string(),
             Err(_) => {
                 // Do not trap here!
@@ -2735,24 +2925,44 @@ impl SystemApi for SystemApiImpl {
                 time, self.sandbox_safe_system_state.canister_id, msg
             ),
         }
-        trace_syscall!(self, ic0_debug_print, src, size, summarize(heap, src, size));
+        trace_syscall!(
+            self,
+            ic0_debug_print,
+            src,
+            size,
+            summarize(heap, src as usize, size as usize)
+        );
         Ok(())
     }
 
     fn ic0_trap(&self, src: u32, size: u32, heap: &[u8]) -> HypervisorResult<()> {
-        const MAX_ERROR_MESSAGE_SIZE: u32 = 16 * 1024;
+        self.ic0_trap_64(src.into(), size.into(), heap)
+    }
+
+    fn ic0_trap_64(&self, src: u64, size: u64, heap: &[u8]) -> HypervisorResult<()> {
+        const MAX_ERROR_MESSAGE_SIZE: u64 = 16 * 1024;
         let size = size.min(MAX_ERROR_MESSAGE_SIZE);
         let result = {
-            let msg = valid_subslice("trap", src, size, heap)
+            let msg = valid_subslice("trap", src as usize, size as usize, heap)
                 .map(|bytes| String::from_utf8_lossy(bytes).to_string())
                 .unwrap_or_else(|_| "(trap message out of memory bounds)".to_string());
             CalledTrap(msg)
         };
-        trace_syscall!(self, ic0_trap, src, size, summarize(heap, src, size));
+        trace_syscall!(
+            self,
+            ic0_trap,
+            src,
+            size,
+            summarize(heap, src as usize, size as usize)
+        );
         Err(result)
     }
 
     fn ic0_is_controller(&self, src: u32, size: u32, heap: &[u8]) -> HypervisorResult<u32> {
+        self.ic0_is_controller_64(src.into(), size.into(), heap)
+    }
+
+    fn ic0_is_controller_64(&self, src: u64, size: u64, heap: &[u8]) -> HypervisorResult<u32> {
         let result = match &self.api_type {
             ApiType::Start { .. }
             | ApiType::Init { .. }
@@ -2765,7 +2975,8 @@ impl SystemApi for SystemApiImpl {
             | ApiType::ReplyCallback { .. }
             | ApiType::RejectCallback { .. }
             | ApiType::InspectMessage { .. } => {
-                let msg_bytes = valid_subslice("ic0.is_controller", src, size, heap)?;
+                let msg_bytes =
+                    valid_subslice("ic0.is_controller", src as usize, size as usize, heap)?;
                 PrincipalId::try_from(msg_bytes)
                     .map(|principal_id| {
                         self.sandbox_safe_system_state
@@ -2783,7 +2994,7 @@ impl SystemApi for SystemApiImpl {
             ic0_is_controller,
             src,
             size,
-            summarize(heap, src, size),
+            summarize(heap, src as usize, size as usize),
             result
         );
         result
@@ -2806,7 +3017,7 @@ impl OutOfInstructionsHandler for DefaultOutOfInstructionsHandler {
 
 pub(crate) fn copy_cycles_to_heap(
     cycles: Cycles,
-    dst: u32,
+    dst: usize,
     heap: &mut [u8],
     method_name: &str,
 ) -> HypervisorResult<()> {
@@ -2815,7 +3026,6 @@ pub(crate) fn copy_cycles_to_heap(
     let size = bytes.len();
     assert_eq!(size, 16);
 
-    let dst = dst as usize;
     let (upper_bound, overflow) = dst.overflowing_add(size);
     if overflow || upper_bound > heap.len() {
         return Err(ContractViolation(format!(
@@ -2833,12 +3043,10 @@ pub(crate) fn copy_cycles_to_heap(
 
 pub(crate) fn valid_subslice<'a>(
     ctx: &str,
-    src: u32,
-    len: u32,
+    src: usize,
+    len: usize,
     slice: &'a [u8],
 ) -> HypervisorResult<&'a [u8]> {
-    let len = len as usize;
-    let src = src as usize;
     if slice.len() < src + len {
         return Err(ContractViolation(format!(
             "{}: src={} + length={} exceeds the slice size={}",

--- a/rs/system_api/src/request_in_prep.rs
+++ b/rs/system_api/src/request_in_prep.rs
@@ -53,10 +53,10 @@ impl RequestInPrep {
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
         sender: CanisterId,
-        callee_src: u32,
-        callee_size: u32,
-        method_name_src: u32,
-        method_name_len: u32,
+        callee_src: usize,
+        callee_size: usize,
+        method_name_src: usize,
+        method_name_len: usize,
         heap: &[u8],
         on_reply: WasmClosure,
         on_reject: WasmClosure,
@@ -131,8 +131,8 @@ impl RequestInPrep {
 
     pub(crate) fn extend_method_payload(
         &mut self,
-        src: u32,
-        size: u32,
+        src: usize,
+        size: usize,
         heap: &[u8],
     ) -> HypervisorResult<()> {
         let current_size = self.method_name.len() + self.method_payload.len();
@@ -143,7 +143,7 @@ impl RequestInPrep {
                 "Request to {}:{} has a payload size of {}, which exceeds the allowed local-subnet limit of {}",
                 self.callee,
                 self.method_name,
-                current_size + size as usize,
+                current_size + size,
                 max_size_local_subnet
             )))
         } else {

--- a/rs/system_api/src/routing.rs
+++ b/rs/system_api/src/routing.rs
@@ -7,7 +7,7 @@ use ic_error_types::UserError;
 use ic_ic00_types::{
     BitcoinGetBalanceArgs, BitcoinGetCurrentFeePercentilesArgs, BitcoinGetUtxosArgs,
     BitcoinSendTransactionArgs, CanisterIdRecord, CanisterInfoRequest,
-    ComputeInitialEcdsaDealingsArgs, ECDSAPublicKeyArgs, EcdsaKeyId, InstallCodeArgs,
+    ComputeInitialEcdsaDealingsArgs, ECDSAPublicKeyArgs, EcdsaKeyId, InstallCodeArgsV2,
     Method as Ic00Method, Payload, ProvisionalTopUpCanisterArgs, SetControllerArgs,
     SignWithECDSAArgs, UninstallCodeArgs, UpdateSettingsArgs,
 };
@@ -67,7 +67,7 @@ pub(super) fn resolve_destination(
         }
         Ok(Ic00Method::InstallCode) => {
             // Find the destination canister from the payload.
-            let args = InstallCodeArgs::decode(payload)?;
+            let args = InstallCodeArgsV2::decode(payload)?;
             let canister_id = args.get_canister_id();
             network_topology
                 .routing_table

--- a/rs/system_api/src/sandbox_safe_system_state.rs
+++ b/rs/system_api/src/sandbox_safe_system_state.rs
@@ -6,7 +6,7 @@ use ic_constants::{LOG_CANISTER_OPERATION_CYCLES_THRESHOLD, SMALL_APP_SUBNET_MAX
 use ic_cycles_account_manager::{CyclesAccountManager, CyclesAccountManagerError};
 use ic_error_types::{ErrorCode, RejectCode, UserError};
 use ic_ic00_types::{
-    CreateCanisterArgs, InstallCodeArgs, Method as Ic00Method, Payload,
+    CreateCanisterArgs, InstallCodeArgsV2, Method as Ic00Method, Payload,
     ProvisionalCreateCanisterWithCyclesArgs, SetControllerArgs, UninstallCodeArgs,
     UpdateSettingsArgs, IC_00,
 };
@@ -193,9 +193,8 @@ impl SystemStateChanges {
         let method = Ic00Method::from_str(&msg.method_name);
         let payload = msg.method_payload();
         match method {
-            Ok(Ic00Method::InstallCode) => {
-                InstallCodeArgs::decode(payload).map(|record| record.get_sender_canister_version())
-            }
+            Ok(Ic00Method::InstallCode) => InstallCodeArgsV2::decode(payload)
+                .map(|record| record.get_sender_canister_version()),
             Ok(Ic00Method::CreateCanister) => CreateCanisterArgs::decode(payload)
                 .map(|record| record.get_sender_canister_version()),
             Ok(Ic00Method::UpdateSettings) => UpdateSettingsArgs::decode(payload)

--- a/rs/system_api/src/system_api_empty.rs
+++ b/rs/system_api/src/system_api_empty.rs
@@ -55,6 +55,9 @@ impl SystemApi for SystemApiEmpty {
     fn ic0_msg_caller_copy(&self, _: u32, _: u32, _: u32, _: &mut [u8]) -> HypervisorResult<()> {
         unimplemented!("{}", MESSAGE_UNIMPLEMENTED)
     }
+    fn ic0_msg_caller_copy_64(&self, _: u64, _: u64, _: u64, _: &mut [u8]) -> HypervisorResult<()> {
+        unimplemented!("{}", MESSAGE_UNIMPLEMENTED)
+    }
     fn ic0_msg_caller_size(&self) -> HypervisorResult<u32> {
         unimplemented!("{}", MESSAGE_UNIMPLEMENTED)
     }
@@ -62,6 +65,15 @@ impl SystemApi for SystemApiEmpty {
         unimplemented!("{}", MESSAGE_UNIMPLEMENTED)
     }
     fn ic0_msg_arg_data_copy(&self, _: u32, _: u32, _: u32, _: &mut [u8]) -> HypervisorResult<()> {
+        unimplemented!("{}", MESSAGE_UNIMPLEMENTED)
+    }
+    fn ic0_msg_arg_data_copy_64(
+        &self,
+        _: u64,
+        _: u64,
+        _: u64,
+        _: &mut [u8],
+    ) -> HypervisorResult<()> {
         unimplemented!("{}", MESSAGE_UNIMPLEMENTED)
     }
     fn ic0_msg_method_name_size(&self) -> HypervisorResult<u32> {
@@ -76,10 +88,22 @@ impl SystemApi for SystemApiEmpty {
     ) -> HypervisorResult<()> {
         unimplemented!("{}", MESSAGE_UNIMPLEMENTED)
     }
+    fn ic0_msg_method_name_copy_64(
+        &self,
+        _: u64,
+        _: u64,
+        _: u64,
+        _: &mut [u8],
+    ) -> HypervisorResult<()> {
+        unimplemented!("{}", MESSAGE_UNIMPLEMENTED)
+    }
     fn ic0_accept_message(&mut self) -> HypervisorResult<()> {
         unimplemented!("{}", MESSAGE_UNIMPLEMENTED)
     }
     fn ic0_msg_reply_data_append(&mut self, _: u32, _: u32, _: &[u8]) -> HypervisorResult<()> {
+        unimplemented!("{}", MESSAGE_UNIMPLEMENTED)
+    }
+    fn ic0_msg_reply_data_append_64(&mut self, _: u64, _: u64, _: &[u8]) -> HypervisorResult<()> {
         unimplemented!("{}", MESSAGE_UNIMPLEMENTED)
     }
     fn ic0_msg_reply(&mut self) -> HypervisorResult<()> {
@@ -91,6 +115,9 @@ impl SystemApi for SystemApiEmpty {
     fn ic0_msg_reject(&mut self, _: u32, _: u32, _: &[u8]) -> HypervisorResult<()> {
         unimplemented!("{}", MESSAGE_UNIMPLEMENTED)
     }
+    fn ic0_msg_reject_64(&mut self, _: u64, _: u64, _: &[u8]) -> HypervisorResult<()> {
+        unimplemented!("{}", MESSAGE_UNIMPLEMENTED)
+    }
     fn ic0_msg_reject_msg_size(&self) -> HypervisorResult<u32> {
         unimplemented!("{}", MESSAGE_UNIMPLEMENTED)
     }
@@ -99,6 +126,15 @@ impl SystemApi for SystemApiEmpty {
         _: u32,
         _: u32,
         _: u32,
+        _: &mut [u8],
+    ) -> HypervisorResult<()> {
+        unimplemented!("{}", MESSAGE_UNIMPLEMENTED)
+    }
+    fn ic0_msg_reject_msg_copy_64(
+        &self,
+        _: u64,
+        _: u64,
+        _: u64,
         _: &mut [u8],
     ) -> HypervisorResult<()> {
         unimplemented!("{}", MESSAGE_UNIMPLEMENTED)
@@ -115,10 +151,25 @@ impl SystemApi for SystemApiEmpty {
     ) -> HypervisorResult<()> {
         unimplemented!("{}", MESSAGE_UNIMPLEMENTED)
     }
+    fn ic0_canister_self_copy_64(
+        &mut self,
+        _: u64,
+        _: u64,
+        _: u64,
+        _: &mut [u8],
+    ) -> HypervisorResult<()> {
+        unimplemented!("{}", MESSAGE_UNIMPLEMENTED)
+    }
     fn ic0_debug_print(&self, _: u32, _: u32, _: &[u8]) -> HypervisorResult<()> {
         unimplemented!("{}", MESSAGE_UNIMPLEMENTED)
     }
+    fn ic0_debug_print_64(&self, _: u64, _: u64, _: &[u8]) -> HypervisorResult<()> {
+        unimplemented!("{}", MESSAGE_UNIMPLEMENTED)
+    }
     fn ic0_trap(&self, _: u32, _: u32, _: &[u8]) -> HypervisorResult<()> {
+        unimplemented!("{}", MESSAGE_UNIMPLEMENTED)
+    }
+    fn ic0_trap_64(&self, _: u64, _: u64, _: &[u8]) -> HypervisorResult<()> {
         unimplemented!("{}", MESSAGE_UNIMPLEMENTED)
     }
     fn ic0_call_new(
@@ -135,7 +186,24 @@ impl SystemApi for SystemApiEmpty {
     ) -> HypervisorResult<()> {
         unimplemented!("{}", MESSAGE_UNIMPLEMENTED)
     }
+    fn ic0_call_new_64(
+        &mut self,
+        _: u64,
+        _: u64,
+        _: u64,
+        _: u64,
+        _: u32,
+        _: u32,
+        _: u32,
+        _: u32,
+        _: &[u8],
+    ) -> HypervisorResult<()> {
+        unimplemented!("{}", MESSAGE_UNIMPLEMENTED)
+    }
     fn ic0_call_data_append(&mut self, _: u32, _: u32, _: &[u8]) -> HypervisorResult<()> {
+        unimplemented!("{}", MESSAGE_UNIMPLEMENTED)
+    }
+    fn ic0_call_data_append_64(&mut self, _: u64, _: u64, _: &[u8]) -> HypervisorResult<()> {
         unimplemented!("{}", MESSAGE_UNIMPLEMENTED)
     }
     fn ic0_call_on_cleanup(&mut self, _: u32, _: u32) -> HypervisorResult<()> {
@@ -209,16 +277,25 @@ impl SystemApi for SystemApiEmpty {
     fn ic0_canister_cycle_balance128(&self, _: u32, _: &mut [u8]) -> HypervisorResult<()> {
         unimplemented!("{}", MESSAGE_UNIMPLEMENTED)
     }
+    fn ic0_canister_cycle_balance128_64(&self, _: u64, _: &mut [u8]) -> HypervisorResult<()> {
+        unimplemented!("{}", MESSAGE_UNIMPLEMENTED)
+    }
     fn ic0_msg_cycles_available(&self) -> HypervisorResult<u64> {
         unimplemented!("{}", MESSAGE_UNIMPLEMENTED)
     }
     fn ic0_msg_cycles_available128(&self, _: u32, _: &mut [u8]) -> HypervisorResult<()> {
         unimplemented!("{}", MESSAGE_UNIMPLEMENTED)
     }
+    fn ic0_msg_cycles_available128_64(&self, _: u64, _: &mut [u8]) -> HypervisorResult<()> {
+        unimplemented!("{}", MESSAGE_UNIMPLEMENTED)
+    }
     fn ic0_msg_cycles_refunded(&self) -> HypervisorResult<u64> {
         unimplemented!("{}", MESSAGE_UNIMPLEMENTED)
     }
     fn ic0_msg_cycles_refunded128(&self, _: u32, _: &mut [u8]) -> HypervisorResult<()> {
+        unimplemented!("{}", MESSAGE_UNIMPLEMENTED)
+    }
+    fn ic0_msg_cycles_refunded128_64(&self, _: u64, _: &mut [u8]) -> HypervisorResult<()> {
         unimplemented!("{}", MESSAGE_UNIMPLEMENTED)
     }
     fn ic0_msg_cycles_accept(&mut self, _: u64) -> HypervisorResult<u64> {
@@ -232,7 +309,18 @@ impl SystemApi for SystemApiEmpty {
     ) -> HypervisorResult<()> {
         unimplemented!("{}", MESSAGE_UNIMPLEMENTED)
     }
+    fn ic0_msg_cycles_accept128_64(
+        &mut self,
+        _: Cycles,
+        _: u64,
+        _: &mut [u8],
+    ) -> HypervisorResult<()> {
+        unimplemented!("{}", MESSAGE_UNIMPLEMENTED)
+    }
     fn ic0_certified_data_set(&mut self, _: u32, _: u32, _: &[u8]) -> HypervisorResult<()> {
+        unimplemented!("{}", MESSAGE_UNIMPLEMENTED)
+    }
+    fn ic0_certified_data_set_64(&mut self, _: u64, _: u64, _: &[u8]) -> HypervisorResult<()> {
         unimplemented!("{}", MESSAGE_UNIMPLEMENTED)
     }
     fn ic0_data_certificate_present(&self) -> HypervisorResult<i32> {
@@ -246,6 +334,15 @@ impl SystemApi for SystemApiEmpty {
         _: u32,
         _: u32,
         _: u32,
+        _: &mut [u8],
+    ) -> HypervisorResult<()> {
+        unimplemented!("{}", MESSAGE_UNIMPLEMENTED)
+    }
+    fn ic0_data_certificate_copy_64(
+        &self,
+        _: u64,
+        _: u64,
+        _: u64,
         _: &mut [u8],
     ) -> HypervisorResult<()> {
         unimplemented!("{}", MESSAGE_UNIMPLEMENTED)
@@ -273,6 +370,9 @@ impl SystemApi for SystemApiEmpty {
         unimplemented!("{}", MESSAGE_UNIMPLEMENTED)
     }
     fn ic0_is_controller(&self, _: u32, _: u32, _: &[u8]) -> HypervisorResult<u32> {
+        unimplemented!("{}", MESSAGE_UNIMPLEMENTED)
+    }
+    fn ic0_is_controller_64(&self, _: u64, _: u64, _: &[u8]) -> HypervisorResult<u32> {
         unimplemented!("{}", MESSAGE_UNIMPLEMENTED)
     }
 }

--- a/rs/system_api/tests/common/mod.rs
+++ b/rs/system_api/tests/common/mod.rs
@@ -25,6 +25,7 @@ use ic_types::{
     messages::{CallContextId, CallbackId, RejectContext},
     methods::SystemMethod,
     ComputeAllocation, Cycles, MemoryAllocation, NumInstructions, PrincipalId, Time,
+    MAX_WASM_MEMORY_IN_BYTES,
 };
 use maplit::btreemap;
 
@@ -39,7 +40,7 @@ pub fn execution_parameters() -> ExecutionParameters {
             NumInstructions::from(5_000_000_000),
             NumInstructions::from(5_000_000_000),
         ),
-        canister_memory_limit: NumBytes::new(4 << 30),
+        canister_memory_limit: NumBytes::new(MAX_WASM_MEMORY_IN_BYTES),
         memory_allocation: MemoryAllocation::default(),
         compute_allocation: ComputeAllocation::default(),
         subnet_type: SubnetType::Application,

--- a/rs/test_utilities/execution_environment/src/lib.rs
+++ b/rs/test_utilities/execution_environment/src/lib.rs
@@ -21,7 +21,7 @@ use ic_execution_environment::{
 };
 use ic_ic00_types::{
     CanisterIdRecord, CanisterInstallMode, CanisterSettingsArgs, CanisterSettingsArgsBuilder,
-    CanisterStatusType, EcdsaKeyId, EmptyBlob, InstallCodeArgs, Method, Payload,
+    CanisterStatusType, EcdsaKeyId, EmptyBlob, InstallCodeArgs, InstallCodeArgsV2, Method, Payload,
     ProvisionalCreateCanisterWithCyclesArgs, UpdateSettingsArgs,
 };
 use ic_interfaces::execution_environment::{
@@ -1994,7 +1994,7 @@ fn get_canister_id_if_install_code(message: CanisterMessage) -> Option<CanisterI
     if message.method_name() != "install_code" {
         return None;
     }
-    match InstallCodeArgs::decode(message.method_payload()) {
+    match InstallCodeArgsV2::decode(message.method_payload()) {
         Err(_) => None,
         Ok(args) => Some(CanisterId::try_from(args.canister_id).unwrap()),
     }

--- a/rs/types/ic00_types/src/lib.rs
+++ b/rs/types/ic00_types/src/lib.rs
@@ -964,6 +964,7 @@ impl Payload<'_> for CanisterStatusResultV2 {}
 ///     compute_allocation: opt nat;
 ///     memory_allocation: opt nat;
 ///     query_allocation: opt nat;
+///     keep_main_memory: opt bool;
 /// })`
 #[derive(Clone, CandidType, Deserialize, Debug)]
 pub struct InstallCodeArgs {
@@ -977,6 +978,7 @@ pub struct InstallCodeArgs {
     pub memory_allocation: Option<candid::Nat>,
     pub query_allocation: Option<candid::Nat>,
     pub sender_canister_version: Option<u64>,
+    pub keep_main_memory: Option<bool>,
 }
 
 impl std::fmt::Display for InstallCodeArgs {
@@ -1010,6 +1012,15 @@ impl std::fmt::Display for InstallCodeArgs {
                 .as_ref()
                 .map(|value| format!("{}", value))
         )?;
+        writeln!(f, "}}")?;
+        writeln!(
+            f,
+            "  keep_main_memory: {:?}",
+            &self
+                .keep_main_memory
+                .as_ref()
+                .map(|value| format!("{}", value))
+        )?;
         writeln!(f, "}}")
     }
 }
@@ -1025,6 +1036,7 @@ impl InstallCodeArgs {
         compute_allocation: Option<u64>,
         memory_allocation: Option<u64>,
         query_allocation: Option<u64>,
+        keep_main_memory: Option<bool>,
     ) -> Self {
         Self {
             mode,
@@ -1035,6 +1047,7 @@ impl InstallCodeArgs {
             memory_allocation: memory_allocation.map(candid::Nat::from),
             query_allocation: query_allocation.map(candid::Nat::from),
             sender_canister_version: None,
+            keep_main_memory,
         }
     }
 

--- a/rs/types/types/src/lib.rs
+++ b/rs/types/types/src/lib.rs
@@ -482,7 +482,7 @@ pub enum LongExecutionMode {
 /// Represents the memory allocation of a canister.
 #[derive(Copy, Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize, Hash)]
 pub enum MemoryAllocation {
-    /// A reserved number of bytes between 0 and 2^48 inclusively that is
+    /// A reserved number of bytes between 0 and 2^64 inclusively that is
     /// guaranteed to be available to the canister. Charging happens based on
     /// the reserved amount of memory, regardless of how much of it is in use.
     Reserved(NumBytes),
@@ -563,7 +563,7 @@ pub const MAX_STABLE_MEMORY_IN_BYTES: u64 = 64 * GB;
 /// The upper limit on the Wasm memory size.
 /// This constant is used by other crates to define other constants, that's why
 /// it is public and `u64` (`NumBytes` cannot be used in const expressions).
-pub const MAX_WASM_MEMORY_IN_BYTES: u64 = 4 * GB;
+pub const MAX_WASM_MEMORY_IN_BYTES: u64 = 64 * GB;
 
 const MIN_MEMORY_ALLOCATION: NumBytes = NumBytes::new(0);
 pub const MAX_MEMORY_ALLOCATION: NumBytes =

--- a/rs/types/types/src/messages/ingress_messages.rs
+++ b/rs/types/types/src/messages/ingress_messages.rs
@@ -11,7 +11,7 @@ use crate::{
 };
 use ic_error_types::{ErrorCode, UserError};
 use ic_ic00_types::{
-    CanisterIdRecord, CanisterInfoRequest, InstallCodeArgs, Method, Payload, SetControllerArgs,
+    CanisterIdRecord, CanisterInfoRequest, InstallCodeArgsV2, Method, Payload, SetControllerArgs,
     UpdateSettingsArgs, IC_00,
 };
 use ic_protobuf::{
@@ -478,7 +478,7 @@ pub fn extract_effective_canister_id(
             Ok(record) => Ok(Some(record.get_canister_id())),
             Err(err) => Err(ParseIngressError::InvalidSubnetPayload(err.to_string())),
         },
-        Ok(Method::InstallCode) => match InstallCodeArgs::decode(ingress.arg()) {
+        Ok(Method::InstallCode) => match InstallCodeArgsV2::decode(ingress.arg()) {
             Ok(record) => Ok(Some(record.get_canister_id())),
             Err(err) => Err(ParseIngressError::InvalidSubnetPayload(err.to_string())),
         },

--- a/rs/types/types/src/messages/inter_canister.rs
+++ b/rs/types/types/src/messages/inter_canister.rs
@@ -3,7 +3,7 @@ use ic_error_types::{RejectCode, TryFromError, UserError};
 #[cfg(test)]
 use ic_exhaustive_derive::ExhaustiveSet;
 use ic_ic00_types::{
-    CanisterIdRecord, CanisterInfoRequest, InstallCodeArgs, Method, Payload as _,
+    CanisterIdRecord, CanisterInfoRequest, InstallCodeArgsV2, Method, Payload as _,
     ProvisionalTopUpCanisterArgs, SetControllerArgs, UpdateSettingsArgs,
 };
 use ic_protobuf::{
@@ -116,7 +116,7 @@ impl Request {
                 Ok(record) => Some(record.get_canister_id()),
                 Err(_) => None,
             },
-            Ok(Method::InstallCode) => match InstallCodeArgs::decode(&self.method_payload) {
+            Ok(Method::InstallCode) => match InstallCodeArgsV2::decode(&self.method_payload) {
                 Ok(record) => Some(record.get_canister_id()),
                 Err(_) => None,
             },

--- a/rs/universal_canister/lib/src/management.rs
+++ b/rs/universal_canister/lib/src/management.rs
@@ -277,13 +277,19 @@ impl<Args: CandidType> From<CandidCallBuilder<Args>> for Call {
 }
 
 #[derive(CandidType, Deserialize)]
+pub struct UpgradeOptions {
+    pub skip_pre_upgrade: Option<bool>,
+    pub keep_main_memory: Option<bool>,
+}
+
+#[derive(CandidType, Deserialize)]
 pub enum InstallMode {
     #[serde(rename = "install")]
     Install,
     #[serde(rename = "reinstall")]
     Reinstall,
     #[serde(rename = "upgrade")]
-    Upgrade,
+    Upgrade(Option<UpgradeOptions>),
 }
 
 #[derive(CandidType)]


### PR DESCRIPTION
# Deterministic Working Set Limit for 64-Bit Main Memory

**Additional PR on top of the IC support for Enhanced Orthogonal Persistence**: https://github.com/dfinity/ic/pull/143

Limiting the amount of pages accessed per IC message. 
* Deterministic: Based on code-instrumentation
* Low runtime overhead of 5% or less on average.

## Specific Aspects
* Using a byte map for the main memory in separate shadow Wasm memory.
* Considering page-crossing accesses of unaligned load or store operations.
* Covering bulk main memory operations, such as `memory.copy` and `memory.fill`.
* Specific optimization for shorter bulk memory operations, with a length <= page size.
* Could also be used for deterministic dirty page tracking.

## Performance Impact

### Runtime Overhead

Wall Time of the IC instrumented Wasm execution, in milliseconds, average of 10 consecutive measurements:

Test Case | Base | Instrumented | **Overhead**
----------|------|--------------|---------
Quicksort (array-centric) | 7163 | 7530 | **5%**
Sort test (array-centric) | 218 | 226 | **4%**
Linked list insertion (object-centric) | 2514 | 2544 | **1%**
List iteration with closures (object-centric) |  5432 | 5611 | **3%**

Average regression: **3.25%**

### Size Overhead

Size increase of the instrumentation: **2.3x** on average.

## Alternative Experiment

Page-fault-based implementation of the working set limit incurs less overheads, but is likely infeasible because of potential non-deterministic page fault handler behavior in the IC runtime. PR: (tbd)
