### PR TITLE
Documentation and README Clarity Improvements

### DIFF
--- a/bazel/README.md
+++ b/bazel/README.md
@@ -25,7 +25,7 @@ require some package installation.
 To install Bazel follow the instructions on
 [https://github.com/bazelbuild/bazelisk](https://github.com/bazelbuild/bazelisk).
 IDX recommends and only supports `bazelisk` - do not install the `bazel`
-package with native package managers such as apt get, homebrew, etc..
+package with native package managers such as apt-get, homebrew, etc..
 
 To build Rust and IC-OS code will require a minimal set of packages. On a Linux
 host the

--- a/bazel/README.md
+++ b/bazel/README.md
@@ -2,7 +2,7 @@
 
 This document helps developers understand how to start with Bazel and port
 Cargo development workflows over to Bazel. While this guide focuses on Rust
-development, Bazel is a polygot build system: See the “Language Specific
+development, Bazel is a polyglot build system: See the “Language Specific
 Guides” section below.
 
 If you know C++ or Java, the best introductory reading material might be the

--- a/bazel/README.md
+++ b/bazel/README.md
@@ -40,7 +40,7 @@ bazel test //rs/crypto/sha2:all
 
 Most targets should build on the host machine. However, the IC-OS image only
 builds inside the canonical container (`ic-build-bazel:$TAG`). To enter this
-docker container run `./gitlab-ci/container/conatiner-run.sh`. This container
+docker container run `./gitlab-ci/container/container-run.sh`. This container
 is only available in x86-64 environments.
 
 # Building Blocks

--- a/scalability/Readme.md
+++ b/scalability/Readme.md
@@ -45,7 +45,7 @@ The benchmarking suite is structured as follows:
 
 Currently, there is support for installing canisters, running the workload generator with different configurations and collecting statistics for it.
 
-Maximum capacity experiments run in iterations, where each iteration typically increases stress on the system, until the benchmake suite considers system can no longer process more transactions.
+Maximum capacity experiments run in iterations, where each iteration typically increases stress on the system, until the benchmark suite considers system can no longer process more transactions.
 
 Each experiment has an entry point.  `run_experiment_*.py` for a spot run, or `max_capacity_*.py` for a maximum capacity run. Worth noting that, maximum capacity runs internally call spot runs, in iteration.
 

--- a/scalability/Readme.md
+++ b/scalability/Readme.md
@@ -23,7 +23,7 @@ Make sure you have *two* testnets reserved, then:
   ```
 
 - You can observe the benchmark on the following dashboard: https://grafana.testnet.dfinity.network/d/u016YUeGz/workload-generator-metrics?orgId=1&refresh=5s - make sure to select the target subnetwork *as well as* the subnetwork with workload generators under "IC" and "IC workload generator" at the top respectively.
-- Create the report `python3 generate_report.py --base_dir {your_artifacts_root_dir} --git_revision {IC_revision_your_experiment_ran_on} --timestamp {the_timestamp_marker_of_your_experiment}`. This is normally called from the suite automatically, so in many cases you won't to manually run it.
+- Create the report `python3 generate_report.py --base_dir {your_artifacts_root_dir} --git_revision {IC_revision_your_experiment_ran_on} --timestamp {the_timestamp_marker_of_your_experiment}`. This is normally called from the suite automatically, so in many cases you won't need to manually run it.
 
 # Design philosophy behind the benchmark suite
 


### PR DESCRIPTION
This pull request addresses multiple typographical errors found in the documentation and README files of our project. These changes enhance the readability and accuracy of our documentation, ensuring clarity for developers and users.

### Changes Made

1. **Commit [09f8c2d]:** Corrected the spelling of "polyglot" in `bazel/README.md`.
2. **Commit [0b43146]:** Fixed the command syntax from 'apt get' to 'apt-get' in `bazel/README.md`.
3. **Commit [7a3fb49]:** Changed 'conatiner' to 'container' in the container run command within `bazel/README.md`.
4. **Commit [59b63b8]:** Improved clarity in `scalability/Readme.md` by changing 'you won't to manually run it' to 'you won't need to manually run it'.
5. **Commit [65591dd]:** Corrected 'benchmake suite' to 'benchmark suite' in `scalability/Readme.md`.
