### PR TITLE
Prepare recent version of `drun` for Motoko

### DIFF
--- a/Cargo.Bazel.Fuzzing.json.lock
+++ b/Cargo.Bazel.Fuzzing.json.lock
@@ -23122,7 +23122,7 @@
         "Git": {
           "remote": "https://github.com/dfinity/bitcoin-canister",
           "commitish": {
-            "Rev": "0e996988693f2d55fc9533c44dc20ae5310a1894"
+            "Rev": "b1693619e3d4dbc00d8c79e9b6886e1db48b21f7"
           },
           "strip_prefix": "validation"
         }

--- a/Cargo.Bazel.Fuzzing.toml.lock
+++ b/Cargo.Bazel.Fuzzing.toml.lock
@@ -4584,7 +4584,7 @@ dependencies = [
 [[package]]
 name = "ic-btc-validation"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/bitcoin-canister?rev=0e996988693f2d55fc9533c44dc20ae5310a1894#0e996988693f2d55fc9533c44dc20ae5310a1894"
+source = "git+https://github.com/dfinity/bitcoin-canister?rev=b1693619e3d4dbc00d8c79e9b6886e1db48b21f7#b1693619e3d4dbc00d8c79e9b6886e1db48b21f7"
 dependencies = [
  "bitcoin 0.28.2",
 ]

--- a/Cargo.Bazel.json.lock
+++ b/Cargo.Bazel.json.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "07c928ab24c65a6de0aa80c242d570ded0fbac19f798a12891ea6cfebdc81372",
+  "checksum": "21eff7c897867042017b159ab93457d788e34677165c2a82166abea6fc77e7cd",
   "crates": {
     "abnf 0.12.0": {
       "name": "abnf",
@@ -22953,7 +22953,7 @@
         "Git": {
           "remote": "https://github.com/dfinity/bitcoin-canister",
           "commitish": {
-            "Rev": "0e996988693f2d55fc9533c44dc20ae5310a1894"
+            "Rev": "b1693619e3d4dbc00d8c79e9b6886e1db48b21f7"
           },
           "strip_prefix": "validation"
         }
@@ -28356,12 +28356,27 @@
         ],
         "crate_features": {
           "common": [
-            "errno",
             "general",
             "ioctl",
             "no_std"
           ],
-          "selects": {}
+          "selects": {
+            "aarch64-unknown-linux-gnu": [
+              "errno"
+            ],
+            "arm-unknown-linux-gnueabi": [
+              "errno"
+            ],
+            "armv7-unknown-linux-gnueabi": [
+              "errno"
+            ],
+            "i686-unknown-linux-gnu": [
+              "errno"
+            ],
+            "x86_64-unknown-linux-gnu": [
+              "errno"
+            ]
+          }
         },
         "edition": "2018",
         "version": "0.3.8"
@@ -28395,22 +28410,25 @@
         ],
         "crate_features": {
           "common": [
-            "errno",
             "general",
             "ioctl",
             "no_std"
           ],
           "selects": {
             "aarch64-unknown-linux-gnu": [
+              "errno",
               "prctl"
             ],
             "arm-unknown-linux-gnueabi": [
+              "errno",
               "prctl"
             ],
             "armv7-unknown-linux-gnueabi": [
+              "errno",
               "prctl"
             ],
             "i686-unknown-linux-gnu": [
+              "errno",
               "prctl"
             ],
             "powerpc-unknown-linux-gnu": [
@@ -28420,6 +28438,7 @@
               "prctl"
             ],
             "x86_64-unknown-linux-gnu": [
+              "errno",
               "prctl"
             ]
           }

--- a/Cargo.Bazel.toml.lock
+++ b/Cargo.Bazel.toml.lock
@@ -4566,7 +4566,7 @@ dependencies = [
 [[package]]
 name = "ic-btc-validation"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/bitcoin-canister?rev=0e996988693f2d55fc9533c44dc20ae5310a1894#0e996988693f2d55fc9533c44dc20ae5310a1894"
+source = "git+https://github.com/dfinity/bitcoin-canister?rev=b1693619e3d4dbc00d8c79e9b6886e1db48b21f7#b1693619e3d4dbc00d8c79e9b6886e1db48b21f7"
 dependencies = [
  "bitcoin 0.28.2",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5310,7 +5310,7 @@ dependencies = [
 [[package]]
 name = "ic-btc-validation"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/bitcoin-canister?rev=0e996988693f2d55fc9533c44dc20ae5310a1894#0e996988693f2d55fc9533c44dc20ae5310a1894"
+source = "git+https://github.com/dfinity/bitcoin-canister?rev=b1693619e3d4dbc00d8c79e9b6886e1db48b21f7#b1693619e3d4dbc00d8c79e9b6886e1db48b21f7"
 dependencies = [
  "bitcoin 0.28.2",
 ]

--- a/bazel/external_crates.bzl
+++ b/bazel/external_crates.bzl
@@ -540,7 +540,7 @@ def external_crates_repository(name, cargo_lockfile, lockfile, sanitizers_enable
             ),
             "ic-btc-validation": crate.spec(
                 git = "https://github.com/dfinity/bitcoin-canister",
-                rev = "0e996988693f2d55fc9533c44dc20ae5310a1894",
+                rev = "b1693619e3d4dbc00d8c79e9b6886e1db48b21f7",
             ),
             "ic-btc-test-utils": crate.spec(
                 git = "https://github.com/dfinity/bitcoin-canister",

--- a/rs/bitcoin/adapter/Cargo.toml
+++ b/rs/bitcoin/adapter/Cargo.toml
@@ -16,7 +16,7 @@ http = "0.2"
 ic-adapter-metrics-server = { path = "../../monitoring/adapter_metrics_server" }
 ic-async-utils = { path = "../../async_utils" }
 ic-btc-service = { path = "../service" }
-ic-btc-validation = { git = "https://github.com/dfinity/bitcoin-canister", rev = "0e996988693f2d55fc9533c44dc20ae5310a1894" }
+ic-btc-validation = { git = "https://github.com/dfinity/bitcoin-canister", rev = "b1693619e3d4dbc00d8c79e9b6886e1db48b21f7" }
 ic-config = { path = "../../config" }
 ic-logger = { path = "../../monitoring/logger" }
 ic-metrics = { path = "../../monitoring/metrics" }


### PR DESCRIPTION
**DO NOT MERGE**: Only used for Motoko CI.

Prepare a more recent version of `drun` for Motoko.
* Based on `release-2023-12-13_23-01`
* Synchronized dependencies to build in `nix`, cf. https://github.com/dfinity/ic/pull/124