### PR TITLE
Disable reqwest default features in pocket-ic

### DIFF
--- a/packages/pocket-ic/Cargo.toml
+++ b/packages/pocket-ic/Cargo.toml
@@ -21,7 +21,7 @@ edition.workspace = true
 
 [dependencies]
 candid = "^0.10.2"
-reqwest = { version = "^0.11.22", features = [
+reqwest = { version = "^0.11.22", default-features = false, features = [
     "blocking",
     "json",
     "multipart",


### PR DESCRIPTION
reqwest default features should be disabled in pocket-ic to avoid enabling both the `rust-tls` and `native-tls` features