### PR TITLE
chore(ecdsa): Replace nested if-match-if's with a single match

### DIFF
--- a/rs/execution_environment/src/execution/response.rs
+++ b/rs/execution_environment/src/execution/response.rs
@@ -355,6 +355,10 @@ impl ResponseHelper {
     ) -> Result<ExecuteMessageResult, (Self, HypervisorError, NumInstructions)> {
         self.canister
             .system_state
+            .canister_log
+            .append(&mut output.canister_log);
+        self.canister
+            .system_state
             .apply_ingress_induction_cycles_debit(
                 self.canister.canister_id(),
                 round.log,
@@ -436,6 +440,10 @@ impl ResponseHelper {
         round_limits: &mut RoundLimits,
         call_tree_metrics: &dyn CallTreeMetrics,
     ) -> ExecuteMessageResult {
+        self.canister
+            .system_state
+            .canister_log
+            .append(&mut output.canister_log);
         self.canister
             .system_state
             .apply_ingress_induction_cycles_debit(

--- a/rs/execution_environment/tests/canister_logging.rs
+++ b/rs/execution_environment/tests/canister_logging.rs
@@ -3,15 +3,16 @@ use ic_config::execution_environment::Config as ExecutionConfig;
 use ic_config::flag_status::FlagStatus;
 use ic_config::subnet_config::SubnetConfig;
 use ic_management_canister_types::{
-    CanisterIdRecord, CanisterInstallMode, CanisterLogRecord, CanisterSettingsArgs,
-    CanisterSettingsArgsBuilder, DataSize, FetchCanisterLogsRequest, FetchCanisterLogsResponse,
-    LogVisibility, Payload,
+    self as ic00, CanisterIdRecord, CanisterInstallMode, CanisterLogRecord, CanisterSettingsArgs,
+    CanisterSettingsArgsBuilder, DataSize, EmptyBlob, FetchCanisterLogsRequest,
+    FetchCanisterLogsResponse, LogVisibility, Payload,
 };
 use ic_registry_subnet_type::SubnetType;
 use ic_state_machine_tests::{
     ErrorCode, PrincipalId, StateMachine, StateMachineBuilder, StateMachineConfig,
     SubmitIngressError, UserError,
 };
+use ic_test_utilities::universal_canister::{call_args, wasm, UNIVERSAL_CANISTER_WASM};
 use ic_test_utilities_execution_environment::{get_reply, wat_canister, wat_fn};
 use ic_test_utilities_metrics::fetch_histogram_stats;
 use ic_types::{
@@ -87,23 +88,18 @@ fn setup(
 fn setup_and_install_wasm(
     canister_logging: FlagStatus,
     settings: CanisterSettingsArgs,
-    wat: String,
+    wasm: Vec<u8>,
 ) -> (StateMachine, CanisterId) {
     let (env, canister_id) = setup(canister_logging, settings);
-    env.install_wasm_in_mode(
-        canister_id,
-        CanisterInstallMode::Install,
-        wat::parse_str(wat).unwrap(),
-        vec![],
-    )
-    .unwrap();
+    env.install_wasm_in_mode(canister_id, CanisterInstallMode::Install, wasm, vec![])
+        .unwrap();
 
     (env, canister_id)
 }
 
 fn setup_with_controller(
     canister_logging: FlagStatus,
-    wat: String,
+    wasm: Vec<u8>,
 ) -> (StateMachine, CanisterId, PrincipalId) {
     let controller = PrincipalId::new_user_test_id(42);
     let (env, canister_id) = setup_and_install_wasm(
@@ -112,7 +108,7 @@ fn setup_with_controller(
             .with_log_visibility(LogVisibility::Controllers)
             .with_controller(controller)
             .build(),
-        wat,
+        wasm,
     );
     (env, canister_id, controller)
 }
@@ -155,7 +151,7 @@ fn test_fetch_canister_logs_via_submit_ingress() {
             CanisterSettingsArgsBuilder::new()
                 .with_log_visibility(LogVisibility::Public)
                 .build(),
-            wat_canister().build(),
+            wat_canister().build_wasm(),
         );
         let actual_result = env.submit_ingress_as(
             PrincipalId::new_anonymous(), // Any public user.
@@ -185,7 +181,7 @@ fn test_fetch_canister_logs_via_execute_ingress() {
             CanisterSettingsArgsBuilder::new()
                 .with_log_visibility(LogVisibility::Public)
                 .build(),
-            wat_canister().build(),
+            wat_canister().build_wasm(),
         );
         let actual_result = env.execute_ingress_as(
             PrincipalId::new_anonymous(), // Any public user.
@@ -225,7 +221,7 @@ fn test_fetch_canister_logs_via_query_call() {
             CanisterSettingsArgsBuilder::new()
                 .with_log_visibility(LogVisibility::Public)
                 .build(),
-            wat_canister().build(),
+            wat_canister().build_wasm(),
         );
         let actual_result = env.query_as(
             PrincipalId::new_anonymous(), // Any public user.
@@ -268,7 +264,7 @@ fn test_log_visibility_of_fetch_canister_logs() {
                 .with_log_visibility(log_visibility)
                 .with_controller(controller)
                 .build(),
-            wat_canister().build(),
+            wat_canister().build_wasm(),
         );
         let actual_result = fetch_canister_logs(&env, sender, canister_id);
         assert_eq!(actual_result, expected_result);
@@ -282,7 +278,7 @@ fn test_appending_logs_in_replied_update_call(#[strategy("\\PC*")] message: Stri
         FlagStatus::Enabled,
         wat_canister()
             .update("test", wat_fn().debug_print(message.as_bytes()))
-            .build(),
+            .build_wasm(),
     );
     let timestamp = system_time_to_nanos(env.time_of_next_round());
     let _ = env.execute_ingress(canister_id, "test", vec![]);
@@ -300,7 +296,7 @@ fn test_appending_logs_in_trapped_update_call(#[strategy("\\PC*")] message: Stri
         FlagStatus::Enabled,
         wat_canister()
             .update("test", wat_fn().debug_print(message.as_bytes()).trap())
-            .build(),
+            .build_wasm(),
     );
     let timestamp = system_time_to_nanos(env.time_of_next_round());
     let _ = env.execute_ingress(canister_id, "test", vec![]);
@@ -321,7 +317,7 @@ fn test_appending_logs_in_replied_replicated_query_call(#[strategy("\\PC*")] mes
         FlagStatus::Enabled,
         wat_canister()
             .query("test", wat_fn().debug_print(message.as_bytes()))
-            .build(),
+            .build_wasm(),
     );
     let timestamp = system_time_to_nanos(env.time_of_next_round());
     let _ = env.execute_ingress(canister_id, "test", vec![]);
@@ -339,7 +335,7 @@ fn test_appending_logs_in_trapped_replicated_query_call(#[strategy("\\PC*")] mes
         FlagStatus::Enabled,
         wat_canister()
             .query("test", wat_fn().debug_print(message.as_bytes()).trap())
-            .build(),
+            .build_wasm(),
     );
     let timestamp = system_time_to_nanos(env.time_of_next_round());
     let _ = env.execute_ingress(canister_id, "test", vec![]);
@@ -368,7 +364,7 @@ fn test_canister_log_record_index_increment_for_different_calls() {
                 "test2",
                 wat_fn().debug_print(b"message 2").debug_print(b"message 3"),
             )
-            .build(),
+            .build_wasm(),
     );
 
     // First call.
@@ -408,7 +404,7 @@ fn test_canister_log_record_index_increment_after_node_restart() {
                 "test2",
                 wat_fn().debug_print(b"message 2").debug_print(b"message 3"),
             )
-            .build(),
+            .build_wasm(),
     );
     env.set_checkpoints_enabled(true);
 
@@ -442,7 +438,7 @@ fn test_logging_in_trapped_wasm_execution() {
         FlagStatus::Enabled,
         wat_canister()
             .update("test", wat_fn().stable_grow(1).stable_read(0, 70_000))
-            .build(),
+            .build_wasm(),
     );
     // Grow stable memory by 1 page (64kb), reading outside of the page should trap.
     let timestamp = system_time_to_nanos(env.time_of_next_round());
@@ -462,7 +458,7 @@ fn test_logging_in_trapped_wasm_execution() {
 fn test_logging_explicit_canister_trap_without_message() {
     let (env, canister_id, controller) = setup_with_controller(
         FlagStatus::Enabled,
-        wat_canister().update("test", wat_fn().trap()).build(),
+        wat_canister().update("test", wat_fn().trap()).build_wasm(),
     );
     let timestamp = system_time_to_nanos(env.time_of_next_round());
     let _ = env.execute_ingress(canister_id, "test", vec![]);
@@ -479,7 +475,7 @@ fn test_logging_explicit_canister_trap_with_message() {
         FlagStatus::Enabled,
         wat_canister()
             .update("test", wat_fn().trap_with_blob(b"some text"))
-            .build(),
+            .build_wasm(),
     );
     let timestamp = system_time_to_nanos(env.time_of_next_round());
     let _ = env.execute_ingress(canister_id, "test", vec![]);
@@ -502,7 +498,7 @@ fn test_canister_log_stays_within_limit() {
                 "test",
                 wat_fn().debug_print(&[42; MAX_ALLOWED_CANISTER_LOG_BUFFER_SIZE]),
             )
-            .build(),
+            .build_wasm(),
     );
     for _ in 0..MESSAGES_NUMBER {
         let _ = env.execute_ingress(canister_id, "test", vec![]);
@@ -531,7 +527,7 @@ fn test_canister_log_stays_empty_when_feature_is_disabled() {
                     .debug_print(&[b'd'; MAX_ALLOWED_CANISTER_LOG_BUFFER_SIZE])
                     .trap_with_blob(&[b't'; MAX_ALLOWED_CANISTER_LOG_BUFFER_SIZE]),
             )
-            .build(),
+            .build_wasm(),
     );
     for _ in 0..MESSAGES_NUMBER {
         let _ = env.execute_ingress(canister_id, "test", vec![]);
@@ -554,7 +550,7 @@ fn test_canister_log_in_state_stays_within_limit() {
                     .debug_print(&[b'd'; MAX_ALLOWED_CANISTER_LOG_BUFFER_SIZE])
                     .trap_with_blob(&[b't'; MAX_ALLOWED_CANISTER_LOG_BUFFER_SIZE]),
             )
-            .build(),
+            .build_wasm(),
     );
     for _ in 0..MESSAGES_NUMBER {
         let _ = env.execute_ingress(canister_id, "test", vec![]);
@@ -575,7 +571,7 @@ fn test_logging_trap_in_heartbeat() {
                     .debug_print(b"before trap")
                     .trap_with_blob(b"heartbeat trap!"),
             )
-            .build(),
+            .build_wasm(),
     );
     let timestamp = system_time_to_nanos(env.time());
     let result = fetch_canister_logs(&env, controller, canister_id);
@@ -599,7 +595,7 @@ fn test_logging_trap_in_timer() {
                     .debug_print(b"before trap")
                     .trap_with_blob(b"timer trap!"),
             )
-            .build(),
+            .build_wasm(),
     );
     let timestamp = system_time_to_nanos(env.time());
     let result = fetch_canister_logs(&env, controller, canister_id);
@@ -622,7 +618,7 @@ fn test_canister_log_preserved_after_disabling_and_enabling_again() {
             .update("test1", wat_fn().debug_print(b"message 1"))
             .update("test2", wat_fn().debug_print(b"message 2"))
             .update("test3", wat_fn().debug_print(b"message 3"))
-            .build(),
+            .build_wasm(),
     );
     env.set_checkpoints_enabled(true);
 
@@ -666,7 +662,7 @@ fn test_deleting_logs_on_reinstall() {
             .start(wat_fn().debug_print(b"start_1"))
             .init(wat_fn().debug_print(b"init_1"))
             .update("test_1", wat_fn().debug_print(b"test_1"))
-            .build(),
+            .build_wasm(),
     );
     let timestamp_1_init = system_time_to_nanos(env.time());
     env.advance_time(TIME_STEP);
@@ -691,14 +687,11 @@ fn test_deleting_logs_on_reinstall() {
     env.install_wasm_in_mode(
         canister_id,
         CanisterInstallMode::Reinstall,
-        wat::parse_str(
-            wat_canister()
-                .start(wat_fn().debug_print(b"start_2"))
-                .init(wat_fn().debug_print(b"init_2"))
-                .update("test_2", wat_fn().debug_print(b"test_2"))
-                .build(),
-        )
-        .unwrap(),
+        wat_canister()
+            .start(wat_fn().debug_print(b"start_2"))
+            .init(wat_fn().debug_print(b"init_2"))
+            .update("test_2", wat_fn().debug_print(b"test_2"))
+            .build_wasm(),
         vec![],
     )
     .unwrap();
@@ -726,7 +719,7 @@ fn test_deleting_logs_on_uninstall() {
             .start(wat_fn().debug_print(b"start_1"))
             .init(wat_fn().debug_print(b"init_1"))
             .update("test_1", wat_fn().debug_print(b"test_1"))
-            .build(),
+            .build_wasm(),
     );
     let timestamp_1_init = system_time_to_nanos(env.time());
     env.advance_time(TIME_STEP);
@@ -777,7 +770,7 @@ fn test_logging_debug_print_persists_over_upgrade() {
             .pre_upgrade(wat_fn().debug_print(b"pre_upgrade_1"))
             .post_upgrade(wat_fn().debug_print(b"post_upgrade_1"))
             .update("test", wat_fn().debug_print(b"update_1"))
-            .build(),
+            .build_wasm(),
     );
     let timestamp_init = system_time_to_nanos(env.time());
     env.advance_time(TIME_STEP);
@@ -791,16 +784,13 @@ fn test_logging_debug_print_persists_over_upgrade() {
     let timestamp_upgrade = system_time_to_nanos(env.time_of_next_round());
     let _ = env.upgrade_canister(
         canister_id,
-        wat::parse_str(
-            wat_canister()
-                .start(wat_fn().debug_print(b"start_2"))
-                .init(wat_fn().debug_print(b"init_2"))
-                .pre_upgrade(wat_fn().debug_print(b"pre_upgrade_2"))
-                .post_upgrade(wat_fn().debug_print(b"post_upgrade_2"))
-                .update("test", wat_fn().debug_print(b"update_2"))
-                .build(),
-        )
-        .unwrap(),
+        wat_canister()
+            .start(wat_fn().debug_print(b"start_2"))
+            .init(wat_fn().debug_print(b"init_2"))
+            .pre_upgrade(wat_fn().debug_print(b"pre_upgrade_2"))
+            .post_upgrade(wat_fn().debug_print(b"post_upgrade_2"))
+            .update("test", wat_fn().debug_print(b"update_2"))
+            .build_wasm(),
         vec![],
     );
     env.advance_time(TIME_STEP);
@@ -840,13 +830,10 @@ fn test_logging_trap_at_install_start() {
     let result = env.install_wasm_in_mode(
         canister_id,
         CanisterInstallMode::Install,
-        wat::parse_str(
-            wat_canister()
-                .start(wat_fn().debug_print(b"start_1").trap_with_blob(b"start_1"))
-                .init(wat_fn().debug_print(b"init_1"))
-                .build(),
-        )
-        .unwrap(),
+        wat_canister()
+            .start(wat_fn().debug_print(b"start_1").trap_with_blob(b"start_1"))
+            .init(wat_fn().debug_print(b"init_1"))
+            .build_wasm(),
         vec![],
     );
     // Assert install fails due to trap.
@@ -877,13 +864,10 @@ fn test_logging_trap_at_install_init() {
     let result = env.install_wasm_in_mode(
         canister_id,
         CanisterInstallMode::Install,
-        wat::parse_str(
-            wat_canister()
-                .start(wat_fn().debug_print(b"start_1"))
-                .init(wat_fn().debug_print(b"init_1").trap_with_blob(b"init_1"))
-                .build(),
-        )
-        .unwrap(),
+        wat_canister()
+            .start(wat_fn().debug_print(b"start_1"))
+            .init(wat_fn().debug_print(b"init_1").trap_with_blob(b"init_1"))
+            .build_wasm(),
         vec![],
     );
     // Assert install fails due to trap.
@@ -914,7 +898,7 @@ fn test_logging_trap_in_pre_upgrade() {
             )
             .post_upgrade(wat_fn().debug_print(b"post_upgrade_1"))
             .update("test", wat_fn().debug_print(b"update_1"))
-            .build(),
+            .build_wasm(),
     );
     let timestamp_init = system_time_to_nanos(env.time());
     env.advance_time(TIME_STEP);
@@ -928,16 +912,13 @@ fn test_logging_trap_in_pre_upgrade() {
     let timestamp_upgrade = system_time_to_nanos(env.time_of_next_round());
     let result = env.upgrade_canister(
         canister_id,
-        wat::parse_str(
-            wat_canister()
-                .start(wat_fn().debug_print(b"start_2"))
-                .init(wat_fn().debug_print(b"init_2"))
-                .pre_upgrade(wat_fn().debug_print(b"pre_upgrade_2"))
-                .post_upgrade(wat_fn().debug_print(b"post_upgrade_2"))
-                .update("test", wat_fn().debug_print(b"update_2"))
-                .build(),
-        )
-        .unwrap(),
+        wat_canister()
+            .start(wat_fn().debug_print(b"start_2"))
+            .init(wat_fn().debug_print(b"init_2"))
+            .pre_upgrade(wat_fn().debug_print(b"pre_upgrade_2"))
+            .post_upgrade(wat_fn().debug_print(b"post_upgrade_2"))
+            .update("test", wat_fn().debug_print(b"update_2"))
+            .build_wasm(),
         vec![],
     );
     // Assert upgrade to fail due to trap.
@@ -975,7 +956,7 @@ fn test_logging_trap_after_upgrade_in_start() {
             .pre_upgrade(wat_fn().debug_print(b"pre_upgrade_1"))
             .post_upgrade(wat_fn().debug_print(b"post_upgrade_1"))
             .update("test", wat_fn().debug_print(b"update_1"))
-            .build(),
+            .build_wasm(),
     );
     let timestamp_init = system_time_to_nanos(env.time());
     env.advance_time(TIME_STEP);
@@ -989,16 +970,13 @@ fn test_logging_trap_after_upgrade_in_start() {
     let timestamp_upgrade = system_time_to_nanos(env.time_of_next_round());
     let result = env.upgrade_canister(
         canister_id,
-        wat::parse_str(
-            wat_canister()
-                .start(wat_fn().debug_print(b"start_2").trap_with_blob(b"start_2"))
-                .init(wat_fn().debug_print(b"init_2"))
-                .pre_upgrade(wat_fn().debug_print(b"pre_upgrade_2"))
-                .post_upgrade(wat_fn().debug_print(b"post_upgrade_2"))
-                .update("test", wat_fn().debug_print(b"update_2"))
-                .build(),
-        )
-        .unwrap(),
+        wat_canister()
+            .start(wat_fn().debug_print(b"start_2").trap_with_blob(b"start_2"))
+            .init(wat_fn().debug_print(b"init_2"))
+            .pre_upgrade(wat_fn().debug_print(b"pre_upgrade_2"))
+            .post_upgrade(wat_fn().debug_print(b"post_upgrade_2"))
+            .update("test", wat_fn().debug_print(b"update_2"))
+            .build_wasm(),
         vec![],
     );
     // Assert upgrade to fail due to trap.
@@ -1037,7 +1015,7 @@ fn test_logging_trap_after_upgrade_in_post_upgrade() {
             .pre_upgrade(wat_fn().debug_print(b"pre_upgrade_1"))
             .post_upgrade(wat_fn().debug_print(b"post_upgrade_1"))
             .update("test", wat_fn().debug_print(b"update_1"))
-            .build(),
+            .build_wasm(),
     );
     let timestamp_init = system_time_to_nanos(env.time());
     env.advance_time(TIME_STEP);
@@ -1051,20 +1029,17 @@ fn test_logging_trap_after_upgrade_in_post_upgrade() {
     let timestamp_upgrade = system_time_to_nanos(env.time_of_next_round());
     let result = env.upgrade_canister(
         canister_id,
-        wat::parse_str(
-            wat_canister()
-                .start(wat_fn().debug_print(b"start_2"))
-                .init(wat_fn().debug_print(b"init_2"))
-                .pre_upgrade(wat_fn().debug_print(b"pre_upgrade_2"))
-                .post_upgrade(
-                    wat_fn()
-                        .debug_print(b"post_upgrade_2")
-                        .trap_with_blob(b"post_upgrade_2"),
-                )
-                .update("test", wat_fn().debug_print(b"update_2"))
-                .build(),
-        )
-        .unwrap(),
+        wat_canister()
+            .start(wat_fn().debug_print(b"start_2"))
+            .init(wat_fn().debug_print(b"init_2"))
+            .pre_upgrade(wat_fn().debug_print(b"pre_upgrade_2"))
+            .post_upgrade(
+                wat_fn()
+                    .debug_print(b"post_upgrade_2")
+                    .trap_with_blob(b"post_upgrade_2"),
+            )
+            .update("test", wat_fn().debug_print(b"update_2"))
+            .build_wasm(),
         vec![],
     );
     // Assert upgrade to fail due to trap.
@@ -1114,7 +1089,7 @@ fn test_logging_debug_print_over_dts() {
                     .wait(instructions_per_slice)
                     .debug_print(b"slice_3"),
             )
-            .build(),
+            .build_wasm(),
     );
 
     let timestamp = system_time_to_nanos(env.time_of_next_round());
@@ -1166,7 +1141,7 @@ fn test_logging_trap_over_dts() {
                     .wait(instructions_per_slice)
                     .trap_with_blob(b"slice_3"),
             )
-            .build(),
+            .build_wasm(),
     );
 
     let timestamp = system_time_to_nanos(env.time_of_next_round());
@@ -1223,7 +1198,7 @@ fn test_logging_of_long_running_dts_over_checkpoint() {
                     .debug_print(b"long_slice_4"),
             )
             .update("test_short", wat_fn().debug_print(b"short"))
-            .build(),
+            .build_wasm(),
     );
 
     // Round #A0: slice #0 is processed inside `send_ingress`.
@@ -1305,7 +1280,7 @@ fn test_canister_log_memory_usage_bytes() {
         FlagStatus::Enabled,
         wat_canister()
             .update("test", wat_fn().debug_print(&[37; PAYLOAD_SIZE]))
-            .build(),
+            .build_wasm(),
     );
     // Assert canister log size metric is zero initially.
     let stats = fetch_histogram_stats(env.metrics_registry(), metric).unwrap();
@@ -1318,4 +1293,122 @@ fn test_canister_log_memory_usage_bytes() {
     let stats = fetch_histogram_stats(env.metrics_registry(), metric).unwrap();
     assert_le!(PAYLOAD_SIZE as f64, stats.sum);
     assert_le!(stats.sum, 1.05 * (PAYLOAD_SIZE as f64));
+}
+
+#[test]
+fn test_canister_log_on_reply() {
+    // Test that the log is recorded inside response callback.
+    let (env, canister_id, controller) =
+        setup_with_controller(FlagStatus::Enabled, UNIVERSAL_CANISTER_WASM.to_vec());
+
+    let instructions_per_slice = MAX_INSTRUCTIONS_PER_SLICE.get();
+    let timestamp_init = system_time_to_nanos(env.time_of_next_round());
+    let _ = env.execute_ingress(
+        canister_id,
+        "update",
+        wasm()
+            .debug_print(b"before_call")
+            .call_with_cycles(
+                ic00::IC_00,
+                ic00::Method::RawRand,
+                call_args().other_side(EmptyBlob.encode()).on_reply(
+                    wasm()
+                        .debug_print(b"on_reply slice_0")
+                        .instruction_counter_is_at_least(instructions_per_slice)
+                        .debug_print(b"on_reply slice_1")
+                        .instruction_counter_is_at_least(2 * instructions_per_slice)
+                        .debug_print(b"on_reply slice_2"),
+                ),
+                Cycles::new(0),
+            )
+            .debug_print(b"after_call")
+            .build(),
+    );
+    // The call and its response are processed in different rounds.
+    // All the response slices will have the same initial timestamp of a response round.
+    let call_response_rounds = 2;
+    let round_time_increment = StateMachine::EXECUTE_ROUND_TIME_INCREMENT.as_nanos() as u64;
+    let timestamp_response = timestamp_init + call_response_rounds * round_time_increment;
+
+    // Assert time since the response round advanced by the number of slices minus one.
+    let number_of_slices = 3;
+    let diff_since_response_round = system_time_to_nanos(env.time()) - timestamp_response;
+    assert_eq!(
+        diff_since_response_round,
+        (number_of_slices - 1) * round_time_increment
+    );
+
+    let result = fetch_canister_logs(&env, controller, canister_id);
+    assert_eq!(
+        FetchCanisterLogsResponse::decode(&get_reply(result)).unwrap(),
+        canister_log_response(vec![
+            (0, timestamp_init, b"before_call".to_vec()),
+            (1, timestamp_init, b"after_call".to_vec()),
+            (2, timestamp_response, b"on_reply slice_0".to_vec()),
+            (3, timestamp_response, b"on_reply slice_1".to_vec()),
+            (4, timestamp_response, b"on_reply slice_2".to_vec()),
+        ])
+    );
+}
+
+#[test]
+fn test_canister_log_on_cleanup() {
+    // Test that the log is recorded inside cleanup callback.
+    let (env, canister_id, controller) =
+        setup_with_controller(FlagStatus::Enabled, UNIVERSAL_CANISTER_WASM.to_vec());
+
+    let timestamp_init = system_time_to_nanos(env.time_of_next_round());
+    let instructions_per_slice = MAX_INSTRUCTIONS_PER_SLICE.get();
+    let _ = env.execute_ingress(
+        canister_id,
+        "update",
+        wasm()
+            .debug_print(b"before_call")
+            .call_with_cycles(
+                ic00::IC_00,
+                ic00::Method::RawRand,
+                call_args()
+                    .other_side(EmptyBlob.encode())
+                    .on_reply(
+                        wasm()
+                            .debug_print(b"on_reply slice_0")
+                            .instruction_counter_is_at_least(instructions_per_slice)
+                            .debug_print(b"on_reply slice_1")
+                            .instruction_counter_is_at_least(2 * instructions_per_slice)
+                            .debug_print(b"on_reply slice_2")
+                            .trap_with_blob(b"on_reply trap"),
+                    )
+                    .on_cleanup(wasm().debug_print(b"on_cleanup")),
+                Cycles::new(0),
+            )
+            .debug_print(b"after_call")
+            .build(),
+    );
+    // The call and its response are processed in different rounds.
+    // All the response slices will have the same initial timestamp of a response round.
+    let call_response_rounds = 2;
+    let round_time_increment = StateMachine::EXECUTE_ROUND_TIME_INCREMENT.as_nanos() as u64;
+    let timestamp_response = timestamp_init + call_response_rounds * round_time_increment;
+
+    // Assert time since the response round advanced by the number of slices minus one.
+    let number_of_slices = 3;
+    let diff_since_response_round = system_time_to_nanos(env.time()) - timestamp_response;
+    assert_eq!(
+        diff_since_response_round,
+        (number_of_slices - 1) * round_time_increment
+    );
+
+    let result = fetch_canister_logs(&env, controller, canister_id);
+    assert_eq!(
+        FetchCanisterLogsResponse::decode(&get_reply(result)).unwrap(),
+        canister_log_response(vec![
+            (0, timestamp_init, b"before_call".to_vec()),
+            (1, timestamp_init, b"after_call".to_vec()),
+            (2, timestamp_response, b"on_reply slice_0".to_vec()),
+            (3, timestamp_response, b"on_reply slice_1".to_vec()),
+            (4, timestamp_response, b"on_reply slice_2".to_vec()),
+            (5, timestamp_response, b"[TRAP]: on_reply trap".to_vec()),
+            (6, timestamp_response, b"on_cleanup".to_vec()),
+        ])
+    );
 }

--- a/rs/pocket_ic_server/src/state_api/state.rs
+++ b/rs/pocket_ic_server/src/state_api/state.rs
@@ -543,7 +543,7 @@ impl ApiState {
                 loop {
                     let start = Instant::now();
                     let old = std::mem::replace(&mut now, Instant::now());
-                    advance_time += old.elapsed();
+                    advance_time += now.duration_since(old);
                     let cur_op = AdvanceTimeAndTick(advance_time);
                     let retry_immediately = match Self::update_instances_with_timeout(
                         instances.clone(),

--- a/rs/state_machine_tests/src/lib.rs
+++ b/rs/state_machine_tests/src/lib.rs
@@ -927,6 +927,9 @@ impl Default for StateMachineBuilder {
 }
 
 impl StateMachine {
+    /// Provides the time increment for a single round of execution.
+    pub const EXECUTE_ROUND_TIME_INCREMENT: Duration = Duration::from_nanos(1);
+
     // TODO: cleanup, replace external calls with `StateMachineBuilder`.
     /// Constructs a new environment that uses a temporary directory for storing
     /// states.
@@ -1580,7 +1583,7 @@ impl StateMachine {
     /// Advances time by 1ns (to make sure time is strictly monotone)
     /// and triggers a single round of execution with block payload as an input.
     pub fn execute_payload(&self, payload: PayloadBuilder) -> Height {
-        self.advance_time(Duration::from_nanos(1));
+        self.advance_time(Self::EXECUTE_ROUND_TIME_INCREMENT);
 
         let batch_number = self.message_routing.expected_batch_height();
 
@@ -1700,7 +1703,7 @@ impl StateMachine {
 
     /// Returns the state machine time at the beginning of next round.
     pub fn time_of_next_round(&self) -> SystemTime {
-        self.time() + Duration::from_nanos(1)
+        self.time() + Self::EXECUTE_ROUND_TIME_INCREMENT
     }
 
     /// Returns the current state machine time.
@@ -2862,7 +2865,7 @@ impl PayloadBuilder {
         .unwrap();
 
         self.ingress_messages.push(msg);
-        self.expiry_time += Duration::from_nanos(1);
+        self.expiry_time += StateMachine::EXECUTE_ROUND_TIME_INCREMENT;
         self.nonce = self.nonce.map(|n| n + 1);
         self
     }

--- a/rs/test_utilities/execution_environment/src/wat_canister.rs
+++ b/rs/test_utilities/execution_environment/src/wat_canister.rs
@@ -283,7 +283,12 @@ pub fn wat_canister() -> WatCanisterBuilder {
     WatCanisterBuilder::new()
 }
 
-/// WAT canister builder, allows to create a WAT canister with multiple functions with different content.
+/// The WAT canister builder creates a WAT canister with multiple functions of varying content.
+///
+/// A WAT canister allows for modifiable behavior within tests.
+/// It is similar to the `universal_canister` but addresses specific cases the UC can't.
+/// It modifies methods that occur right after start and before any update call,
+/// covering `init()`, `start()`, and `post_upgrade()` methods.
 pub struct WatCanisterBuilder {
     functions: Vec<WatFunc>,
     memory_offset: i32,
@@ -402,6 +407,11 @@ impl WatCanisterBuilder {
             {data}
         )"#
         )
+    }
+
+    /// Build the Wasm for the WAT canister.
+    pub fn build_wasm(&self) -> Vec<u8> {
+        wat::parse_str(self.build()).unwrap()
     }
 
     fn get_memory_offset(&mut self, message: &[u8]) -> i32 {


### PR DESCRIPTION
Replaced 
```
if {
  match  {
    None => if {} else {}
    Some => if {} else {} 
  }
} else {
  match  {
    None => if {} else {}
    Some => if {} else {} 
  }
},
```
which was hardly readable for me, with one big `match`