### PR TITLE
fix(IDX): do upload to the bazel-remote cache for systests

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -93,7 +93,7 @@ test --test_env=RUST_BACKTRACE=full
 test:precommit --build_tests_only --test_tag_filters="smoke"
 
 build:systest --build_tag_filters= --s3_endpoint=https://s3-upload.idx.dfinity.network
-test:systest --test_output=streamed --test_tag_filters=
+test:systest --remote_upload_local_results=true --test_output=streamed --test_tag_filters=
 
 build:testnet --build_tag_filters= --s3_endpoint=https://s3-upload.idx.dfinity.network --ic_version_rc_only=
 test:testnet --test_output=streamed --test_tag_filters=

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -2,7 +2,6 @@ workspace(
     name = "ic",
 )
 
-load("@bazel_tools//tools/build_defs/repo:git.bzl", "new_git_repository")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive", "http_file", "http_jar")
 load("//third_party/lmdb:repository.bzl", "lmdb_repository")
 load("//third_party/lmdb-rkv-0.14.99:repository.bzl", "lmdb_rkv_repository")
@@ -470,16 +469,16 @@ http_jar(
 
 # Official WebAssembly test suite.
 # To be used for testing libraries that handle canister Wasm code.
-
-new_git_repository(
+http_archive(
     name = "wasm_spec_testsuite",
     build_file_content = """filegroup(
-        name = "wast_files",
-        srcs = glob(["**/*.wast"]),
-        visibility = ["//visibility:public"]
-    )""",
-    commit = "4f77306bb63151631d84f58dedf67958eb9911b9",
-    remote = "https://github.com/WebAssembly/testsuite.git",
+         name = "wast_files",
+         srcs = glob(["**/*.wast"]),
+         visibility = ["//visibility:public"]
+     )""",
+    sha256 = "9afc0e7c250b5f0dcf32e9a95860b99a392ab78a653fcf3705778e8a9357f3c4",
+    strip_prefix = "testsuite-4f77306bb63151631d84f58dedf67958eb9911b9",
+    url = "https://github.com/WebAssembly/testsuite/archive/4f77306bb63151631d84f58dedf67958eb9911b9.tar.gz",
 )
 
 mainnet_core_nns_canisters()


### PR DESCRIPTION
Without this it's impossible to run system-tests locally because the IC-OS images won't be uploaded to the bazel cache which means Farm / k8s won't be able to download them to boot VMs.