### PR TITLE
chore(IDX): update slack notification

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,7 +4,7 @@
 
 # [Misc]
 /.devcontainer/           @dfinity/idx
-/.github/                 
+/.github/                 @dfinity/idx
 /buf.yaml                 @dfinity/ic-message-routing-owners
 /cpp/                     @dfinity/node
 /hs/                      @dfinity/utopia

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,7 +4,7 @@
 
 # [Misc]
 /.devcontainer/           @dfinity/idx
-/.github/                 @dfinity/idx
+/.github/                 
 /buf.yaml                 @dfinity/ic-message-routing-owners
 /cpp/                     @dfinity/node
 /hs/                      @dfinity/utopia

--- a/.github/workflows/ci-notify-slack.yml
+++ b/.github/workflows/ci-notify-slack.yml
@@ -20,30 +20,30 @@ jobs:
             const { owner, repo, number: issue_number } = context.issue;
             const team_reviewers = context.payload.pull_request.requested_teams.requested_team.map(team => team.name);
             return team_reviewers;
-      - name: Lookup Slack channel
-        id: lookup
-        run: |
-          TEAM_REVIEWERS=$(echo '${{ steps.get-reviewers.outputs.result }}' | jq -c '.[]')
-          CHANNELS=""
-          for TEAM in $TEAM_REVIEWERS; do
-            CHANNEL=$(jq -r ".$TEAM" .github/workflows/team-channels.json)
-            if [ "$CHANNEL" != "null" ]; then
-              if [ -z "$CHANNELS" ]; then
-                CHANNELS="$CHANNEL"
-              else
-                CHANNELS="$CHANNELS,$CHANNEL"
-              fi
-            fi
-          done
-          echo "channels=${CHANNELS}" >> $GITHUB_OUTPUT
-          echo "message=${MESSAGE}" >> $GITHUB_OUTPUT
-        env:
-          MESSAGE: ":github: <${{ github.event.pull_request.html_url }}|${{ github.event.pull_request.title }}>"
-      - name: Post to a Slack channel
-        id: slack
-        uses: slackapi/slack-github-action@6c661ce58804a1a20f6dc5fbee7f0381b469e001 # v1.25.0
-        with:
-          channel-id: ${{ steps.lookup.outputs.channels }}
-          slack-message: "${{ steps.lookup.outputs.message }}"
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_API_TOKEN }}
+      # - name: Lookup Slack channel
+      #   id: lookup
+      #   run: |
+      #     TEAM_REVIEWERS=$(echo '${{ steps.get-reviewers.outputs.result }}' | jq -c '.[]')
+      #     CHANNELS=""
+      #     for TEAM in $TEAM_REVIEWERS; do
+      #       CHANNEL=$(jq -r ".$TEAM" .github/workflows/team-channels.json)
+      #       if [ "$CHANNEL" != "null" ]; then
+      #         if [ -z "$CHANNELS" ]; then
+      #           CHANNELS="$CHANNEL"
+      #         else
+      #           CHANNELS="$CHANNELS,$CHANNEL"
+      #         fi
+      #       fi
+      #     done
+      #     echo "channels=${CHANNELS}" >> $GITHUB_OUTPUT
+      #     echo "message=${MESSAGE}" >> $GITHUB_OUTPUT
+      #   env:
+      #     MESSAGE: ":github: <${{ github.event.pull_request.html_url }}|${{ github.event.pull_request.title }}>"
+      # - name: Post to a Slack channel
+      #   id: slack
+      #   uses: slackapi/slack-github-action@6c661ce58804a1a20f6dc5fbee7f0381b469e001 # v1.25.0
+      #   with:
+      #     channel-id: ${{ steps.lookup.outputs.channels }}
+      #     slack-message: "${{ steps.lookup.outputs.message }}"
+      #   env:
+      #     SLACK_BOT_TOKEN: ${{ secrets.SLACK_API_TOKEN }}

--- a/.github/workflows/ci-notify-slack.yml
+++ b/.github/workflows/ci-notify-slack.yml
@@ -18,32 +18,22 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const { owner, repo, number: issue_number } = context.issue;
-            const team_reviewers = context.payload.pull_request.requested_teams.map(team => team.name);
+            const team_reviewers = context.payload.requested_team.name;
             return team_reviewers;
       - name: Lookup Slack channel
         id: lookup
         run: |
-          TEAM_REVIEWERS=$(echo '${{ steps.get-reviewers.outputs.result }}' | jq -c '.[]')
-          CHANNELS=""
-          for TEAM in $TEAM_REVIEWERS; do
-            CHANNEL=$(jq -r ".$TEAM" .github/workflows/team-channels.json)
-            if [ "$CHANNEL" != "null" ]; then
-              if [ -z "$CHANNELS" ]; then
-                CHANNELS="$CHANNEL"
-              else
-                CHANNELS="$CHANNELS,$CHANNEL"
-              fi
-            fi
-          done
-          echo "channels=${CHANNELS}" >> $GITHUB_OUTPUT
+          TEAM=${{ steps.get-reviewers.outputs.result }}
+          CHANNEL=$(jq -r ".$TEAM" .github/workflows/team-channels.json)
+          echo "channel=${CHANNEL}" >> $GITHUB_OUTPUT
           echo "message=${MESSAGE}" >> $GITHUB_OUTPUT
         env:
           MESSAGE: ":github: <${{ github.event.pull_request.html_url }}|${{ github.event.pull_request.title }}>"
-      # - name: Post to a Slack channel
-      #   id: slack
-      #   uses: slackapi/slack-github-action@6c661ce58804a1a20f6dc5fbee7f0381b469e001 # v1.25.0
-      #   with:
-      #     channel-id: ${{ steps.lookup.outputs.channels }}
-      #     slack-message: "${{ steps.lookup.outputs.message }}"
-      #   env:
-      #     SLACK_BOT_TOKEN: ${{ secrets.SLACK_API_TOKEN }}
+      - name: Post to a Slack channel
+        id: slack
+        uses: slackapi/slack-github-action@6c661ce58804a1a20f6dc5fbee7f0381b469e001 # v1.25.0
+        with:
+          channel-id: ${{ steps.lookup.outputs.channel }}
+          slack-message: "${{ steps.lookup.outputs.message }}"
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_API_TOKEN }}

--- a/.github/workflows/ci-notify-slack.yml
+++ b/.github/workflows/ci-notify-slack.yml
@@ -21,25 +21,25 @@ jobs:
             const { owner, repo, number: issue_number } = context.issue;
             const team_reviewers = context.payload.pull_request.requested_teams.map(team => team.name);
             return team_reviewers;
-      # - name: Lookup Slack channel
-      #   id: lookup
-      #   run: |
-      #     TEAM_REVIEWERS=$(echo '${{ steps.get-reviewers.outputs.result }}' | jq -c '.[]')
-      #     CHANNELS=""
-      #     for TEAM in $TEAM_REVIEWERS; do
-      #       CHANNEL=$(jq -r ".$TEAM" .github/workflows/team-channels.json)
-      #       if [ "$CHANNEL" != "null" ]; then
-      #         if [ -z "$CHANNELS" ]; then
-      #           CHANNELS="$CHANNEL"
-      #         else
-      #           CHANNELS="$CHANNELS,$CHANNEL"
-      #         fi
-      #       fi
-      #     done
-      #     echo "channels=${CHANNELS}" >> $GITHUB_OUTPUT
-      #     echo "message=${MESSAGE}" >> $GITHUB_OUTPUT
-      #   env:
-      #     MESSAGE: ":github: <${{ github.event.pull_request.html_url }}|${{ github.event.pull_request.title }}>"
+      - name: Lookup Slack channel
+        id: lookup
+        run: |
+          TEAM_REVIEWERS=$(echo '${{ steps.get-reviewers.outputs.result }}' | jq -c '.[]')
+          CHANNELS=""
+          for TEAM in $TEAM_REVIEWERS; do
+            CHANNEL=$(jq -r ".$TEAM" .github/workflows/team-channels.json)
+            if [ "$CHANNEL" != "null" ]; then
+              if [ -z "$CHANNELS" ]; then
+                CHANNELS="$CHANNEL"
+              else
+                CHANNELS="$CHANNELS,$CHANNEL"
+              fi
+            fi
+          done
+          echo "channels=${CHANNELS}" >> $GITHUB_OUTPUT
+          echo "message=${MESSAGE}" >> $GITHUB_OUTPUT
+        env:
+          MESSAGE: ":github: <${{ github.event.pull_request.html_url }}|${{ github.event.pull_request.title }}>"
       # - name: Post to a Slack channel
       #   id: slack
       #   uses: slackapi/slack-github-action@6c661ce58804a1a20f6dc5fbee7f0381b469e001 # v1.25.0

--- a/.github/workflows/ci-notify-slack.yml
+++ b/.github/workflows/ci-notify-slack.yml
@@ -18,7 +18,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const { owner, repo, number: issue_number } = context.issue;
-            const team_reviewers = context.payload.pull_request.requested_teams.map(team => team.name);
+            const team_reviewers = context.payload.pull_request.requested_teams.requested_team.map(team => team.name);
             return team_reviewers;
       - name: Lookup Slack channel
         id: lookup

--- a/.github/workflows/ci-notify-slack.yml
+++ b/.github/workflows/ci-notify-slack.yml
@@ -17,8 +17,9 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
+            console.log(JSON.stringify(context.payload.pull_request))
             const { owner, repo, number: issue_number } = context.issue;
-            const team_reviewers = context.payload.pull_request.requested_teams.requested_team.map(team => team.name);
+            const team_reviewers = context.payload.pull_request.requested_teams.map(team => team.name);
             return team_reviewers;
       # - name: Lookup Slack channel
       #   id: lookup

--- a/.github/workflows/ci-notify-slack.yml
+++ b/.github/workflows/ci-notify-slack.yml
@@ -17,7 +17,6 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            console.log(JSON.stringify(context.payload.pull_request))
             const { owner, repo, number: issue_number } = context.issue;
             const team_reviewers = context.payload.pull_request.requested_teams.map(team => team.name);
             return team_reviewers;

--- a/.github/workflows/ci-notify-slack.yml
+++ b/.github/workflows/ci-notify-slack.yml
@@ -2,7 +2,7 @@ name: PR Slack Notification
 
 on:
   pull_request:
-    types: [ready_for_review]
+    types: [review_requested]
 
 jobs:
   notify-slack:


### PR DESCRIPTION
It seems that the action "ready for review" triggers before "review requested" so the payload doesn't always have the complete teams. This fix changes the trigger and will both trigger if a PR is directly opened as a non-draft and if additional reviewers are added later.