### PR TITLE
refactor(crypto): CRP-2411 improve error mapping in TLS test client and server

### DIFF
--- a/rs/crypto/tests/tls_handshake.rs
+++ b/rs/crypto/tests/tls_handshake.rs
@@ -3,11 +3,11 @@ use assert_matches::assert_matches;
 use ic_crypto_test_utils_reproducible_rng::reproducible_rng;
 use ic_crypto_test_utils_tls::registry::TlsRegistry;
 use ic_crypto_test_utils_tls::temp_crypto_component_with_tls_keys;
-use ic_crypto_test_utils_tls::test_client::{Client, ClientBuilder};
-use ic_crypto_test_utils_tls::test_server::{Server, ServerBuilder};
+use ic_crypto_test_utils_tls::test_client::{Client, ClientBuilder, TlsTestClientRunError};
+use ic_crypto_test_utils_tls::test_server::{Server, ServerBuilder, TlsTestServerRunError};
 use ic_crypto_test_utils_tls::CipherSuite;
 use ic_crypto_test_utils_tls::TlsVersion;
-use ic_crypto_tls_interfaces::{AuthenticatedPeer, TlsConfigError};
+use ic_crypto_tls_interfaces::AuthenticatedPeer;
 use ic_protobuf::registry::crypto::v1::X509PublicKeyCert;
 use ic_registry_client_fake::FakeRegistryClient;
 use ic_registry_proto_data_provider::ProtoRegistryDataProvider;
@@ -1313,24 +1313,22 @@ fn malformed_cert() -> X509PublicKeyCert {
 }
 
 fn assert_handshake_server_error_containing(
-    server_result: &Result<AuthenticatedPeer, TlsConfigError>,
+    server_result: &Result<AuthenticatedPeer, TlsTestServerRunError>,
     error_substring: &str,
 ) {
     assert_matches!(
         server_result,
-        Err(TlsConfigError::MalformedSelfCertificate { internal_error })
-            if internal_error.contains(error_substring)
+        Err(TlsTestServerRunError(error)) if error.contains(error_substring)
     );
 }
 
 fn assert_handshake_client_error_containing(
-    client_result: &Result<(), TlsConfigError>,
+    client_result: &Result<(), TlsTestClientRunError>,
     error_substring: &str,
 ) {
     assert_matches!(
         client_result,
-        Err(TlsConfigError::MalformedSelfCertificate { internal_error })
-            if internal_error.contains(error_substring)
+        Err(TlsTestClientRunError(error)) if error.contains(error_substring)
     );
 }
 


### PR DESCRIPTION
Improves an error mapping in the TLS test client and server.

In particular, a `TlsConfigError::MalformedSelfCertificate` is used for something that actually isn't a malformed self certificate. This is fixed by letting let the `run` methods of the TLS test server and client return a new, more general error type.

This is a follow-up from [feat: remove the legacy TlsHandshake interface](https://gitlab.com/dfinity-lab/public/ic/-/merge_requests/19354).