### PR TITLE
fix(IDX): make launch-remote-vm testonly because it depends on a testonly target

### DIFF
--- a/ic-os/defs.bzl
+++ b/ic-os/defs.bzl
@@ -556,6 +556,7 @@ EOF
         """,
         executable = True,
         tags = ["manual"],
+        testonly = True,
     )
 
     native.genrule(


### PR DESCRIPTION
This fixes the following error first observed in [this failing job](https://github.com/dfinity/ic/actions/runs/9396755633/job/25878546623?pr=180):

```
$ bazel build //ic-os/guestos/envs/prod:launch-remote-vm --config=check
INFO: Invocation ID: 713803fa-c204-4f6c-8638-523a043c58a4
INFO: Streaming build results to: https://dash.idx.dfinity.network/invocation/713803fa-c204-4f6c-8638-523a043c58a4
INFO: Build option --@rules_rust//rust/settings:pipelined_compilation has changed, discarding analysis cache.
ERROR: /ic/ic-os/guestos/envs/prod/BUILD.bazel:10:11: in genrule rule //ic-os/guestos/envs/prod:launch-remote-vm: non-test target '//ic-os/guestos/envs/prod:launch-remote-vm' depends on testonly target '//rs/ic_os/launch-single-vm:launch-single-vm' and doesn't have testonly attribute set
ERROR: /ic/ic-os/guestos/envs/prod/BUILD.bazel:10:11: Analysis of target '//ic-os/guestos/envs/prod:launch-remote-vm' failed
ERROR: Analysis of target '//ic-os/guestos/envs/prod:launch-remote-vm' failed; build aborted:
INFO: Elapsed time: 4.102s
INFO: 0 processes.
INFO: Streaming build results to: https://dash.idx.dfinity.network/invocation/713803fa-c204-4f6c-8638-523a043c58a4
FAILED: Build did NOT complete successfully (1206 packages loaded, 48009 targets configured)
```