### PR TITLE
fix(IDX): typo in teams mapping

### DIFF
--- a/.github/workflows/team-channels.json
+++ b/.github/workflows/team-channels.json
@@ -8,7 +8,7 @@
     "ic-support": "ic-support-notifications",
     "ic-interface-owners": "interface-owners",
     "ic-message-routing-owners": "eng-message-routing-mr",
-    "ic-owner-owners": "owners-owners",
+    "ic-owners-owners": "owners-owners",
     "ic-testing-verification": "eng-testing",
     "idx": "eng-idx-bots",
     "networking": "eng-networking",


### PR DESCRIPTION
This fixes a typo (missing 's') in the team-channels mapping file. This caused an issue when the `ic-owners-owners` team would be assigned for review.