### PR TITLE
chore(IDX): introduce the push_to_gitlab_improved job

### DIFF
--- a/.github/workflows/gitlab-push.yml
+++ b/.github/workflows/gitlab-push.yml
@@ -16,6 +16,37 @@ env:
   PR_NUMBER: ${{ github.event.pull_request.number }}
 
 jobs:
+  push_to_gitlab_improved:
+    name: Push To GitLab (Improved)
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Push to GitLab
+        run: |
+          set -eux
+          URL="https://push-from-github:${{ secrets.PUSH_TO_GITLAB_TOKEN }}@gitlab.com/dfinity-lab/public/ic.git"
+
+          if git remote get-url gitlab >/dev/null 2>&1; then
+              git remote set-url gitlab "$URL"
+          else
+              git remote add gitlab "$URL"
+          fi
+
+          BRANCH="mirroring-improved-${BRANCH_NAME}"
+          git fetch origin mirroring
+          git checkout -b "$BRANCH"
+          git cherry-pick "$(git rev-parse origin/mirroring)"
+          git push \
+              -o merge_request.create \
+              -o merge_request.draft \
+              -o merge_request.title="chore(github-sync): PR#${PR_NUMBER} / ${PR_TITLE}" \
+              -o merge_request.description="[GitHub PR ${PR_NUMBER}](${PR_URL}) (branch: ${BRANCH_NAME})" \
+              gitlab "$BRANCH"
+
   push_to_gitlab:
     name: Push To GitLab
     if: github.event.pull_request.merged == true

--- a/.github/workflows/gitlab-push.yml
+++ b/.github/workflows/gitlab-push.yml
@@ -43,7 +43,7 @@ jobs:
           git push \
               -o merge_request.create \
               -o merge_request.draft \
-              -o merge_request.title="chore(github-sync): PR#${PR_NUMBER} / ${PR_TITLE}" \
+              -o merge_request.title="chore(github-sync): (improved) PR#${PR_NUMBER} / ${PR_TITLE}" \
               -o merge_request.description="[GitHub PR ${PR_NUMBER}](${PR_URL}) (branch: ${BRANCH_NAME})" \
               gitlab "$BRANCH"
 


### PR DESCRIPTION
The `push_to_gitlab_improved` GitHub job is an improved version of `push_to_gitlab` which creates a (draft) MR for just the HEAD of the `mirroring` branch. `push_to_gitlab` actually creates a MR for the whole `mirroring` branch which sometimes contains commits of multiple PRs.

Once `push_to_gitlab_improved` is working as expected we'll remove the old `push_to_gitlab` and rename `push_to_gitlab_improved` to it.