### PR TITLE
fix(IDX): gitlab push ref

### DIFF
--- a/.github/workflows/gitlab-push.yml
+++ b/.github/workflows/gitlab-push.yml
@@ -43,7 +43,7 @@ jobs:
               -o merge_request.draft \
               -o merge_request.title="chore(github-sync-v2): PR#${PR_NUMBER} / ${PR_TITLE}" \
               -o merge_request.description="[GitHub PR ${PR_NUMBER}](${PR_URL}) (branch: ${BRANCH_NAME})" \
-              gitlab "origin/${BRANCH_NAME}:mirroring-v2-${BRANCH_NAME}"
+              gitlab "refs/remotes/origin/${BRANCH_NAME}:refs/heads/mirroring-v2-${BRANCH_NAME}"
 
   push_to_gitlab:
     name: Push To GitLab


### PR DESCRIPTION
Specifying full refname.
```
error: The destination you provided is not a full refname (i.e.,
starting with "refs/"). We tried to guess what you meant by:
- Looking for a ref that matches 'mirroring-v2-marko-push-to-gitlab' on the remote side.
- Checking if the <src> being pushed ('refs/remotes/origin/marko-push-to-gitlab')
  is a ref in "refs/{heads,tags}/". If so we add a corresponding
  refs/{heads,tags}/ prefix on the remote side.
Neither worked, so we gave up. You must fully qualify the ref.
```