### PR TITLE
chore(IDX): relabel CI jobs

### DIFF
--- a/.github/workflows-source/schedule-hourly.yml
+++ b/.github/workflows-source/schedule-hourly.yml
@@ -34,13 +34,6 @@ anchors:
       <<: *image
     timeout-minutes: 120
     if: ${{ vars.RUN_CI == 'true' }} # needed to avoid running on public dfinity org until published
-  dind-large-setup: &dind-large-setup
-    runs-on:
-      labels: dind-runner-large
-    container:
-      <<: *image
-    timeout-minutes: 60
-    if: ${{ vars.RUN_CI == 'true' }}
   checkout: &checkout
     name: Checkout
     uses: actions/checkout@v4
@@ -106,8 +99,7 @@ jobs:
 
   bazel-test-coverage:
     name: Bazel Test Coverage
-    <<: *dind-large-setup
-    timeout-minutes: 120
+    <<: *bazel-large-setup
     steps:
       - <<: *before-script
       - <<: *checkout

--- a/.github/workflows-source/schedule-hourly.yml
+++ b/.github/workflows-source/schedule-hourly.yml
@@ -34,6 +34,13 @@ anchors:
       <<: *image
     timeout-minutes: 120
     if: ${{ vars.RUN_CI == 'true' }} # needed to avoid running on public dfinity org until published
+  dind-large-setup: &dind-large-setup
+    runs-on:
+      labels: dind-runner-large
+    container:
+      <<: *image
+    timeout-minutes: 60
+    if: ${{ vars.RUN_CI == 'true' }}
   checkout: &checkout
     name: Checkout
     uses: actions/checkout@v4
@@ -99,8 +106,8 @@ jobs:
 
   bazel-test-coverage:
     name: Bazel Test Coverage
-    <<: *bazel-large-setup
-    if: ${{ vars.RUN_CI == 'true' }}
+    <<: *dind-large-setup
+    timeout-minutes: 120
     steps:
       - <<: *before-script
       - <<: *checkout

--- a/.github/workflows/schedule-daily.yml
+++ b/.github/workflows/schedule-daily.yml
@@ -49,10 +49,7 @@ jobs:
 
   cut-release-candidate:
     name: Cut RC
-    runs-on:
-      labels: bazel-runner-small
-    container:
-      image: ghcr.io/dfinity/ic-build@sha256:eb85228ebf7511e2589f86788345eb3d1c8144914a8a2fa771d4347ddacac413
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     if: ${{ vars.RUN_CI == 'true' }}
     steps:

--- a/.github/workflows/schedule-daily.yml
+++ b/.github/workflows/schedule-daily.yml
@@ -77,7 +77,8 @@ jobs:
     container:
       image: ghcr.io/dfinity/ic-build@sha256:eb85228ebf7511e2589f86788345eb3d1c8144914a8a2fa771d4347ddacac413
     timeout-minutes: 120
-    if: ${{ vars.RUN_CI == 'true' }}
+    # TODO: enable when zh1 is active again
+    if: ${{ vars.RUN_CI == 'true' && false }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/schedule-hourly.yml
+++ b/.github/workflows/schedule-hourly.yml
@@ -93,11 +93,11 @@ jobs:
   bazel-test-coverage:
     name: Bazel Test Coverage
     runs-on:
-      labels: bazel-runner-large
+      labels: dind-runner-large
     container:
       image: ghcr.io/dfinity/ic-build@sha256:eb85228ebf7511e2589f86788345eb3d1c8144914a8a2fa771d4347ddacac413
-    timeout-minutes: 120
     if: ${{ vars.RUN_CI == 'true' }}
+    timeout-minutes: 120
     steps:
       - name: Before script
         if: always()

--- a/.github/workflows/schedule-hourly.yml
+++ b/.github/workflows/schedule-hourly.yml
@@ -93,11 +93,11 @@ jobs:
   bazel-test-coverage:
     name: Bazel Test Coverage
     runs-on:
-      labels: dind-runner-large
+      labels: bazel-runner-large
     container:
       image: ghcr.io/dfinity/ic-build@sha256:eb85228ebf7511e2589f86788345eb3d1c8144914a8a2fa771d4347ddacac413
-    if: ${{ vars.RUN_CI == 'true' }}
     timeout-minutes: 120
+    if: ${{ vars.RUN_CI == 'true' }} # needed to avoid running on public dfinity org until published
     steps:
       - name: Before script
         if: always()

--- a/.github/workflows/schedule-weekly.yml
+++ b/.github/workflows/schedule-weekly.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   bazel-build-fuzzers-weekly:
     runs-on:
-      labels: dind-runner-large
+      labels: bazel-runner-large
     container:
       image: ghcr.io/dfinity/ic-build@sha256:eb85228ebf7511e2589f86788345eb3d1c8144914a8a2fa771d4347ddacac413
     timeout-minutes: 60 # 1 hour

--- a/.github/workflows/schedule-weekly.yml
+++ b/.github/workflows/schedule-weekly.yml
@@ -8,9 +8,9 @@ on:
 jobs:
   bazel-build-fuzzers-weekly:
     runs-on:
-        labels: bazel-runner-small
+      labels: dind-runner-large
     container:
-        image: ghcr.io/dfinity/ic-build@sha256:eb85228ebf7511e2589f86788345eb3d1c8144914a8a2fa771d4347ddacac413
+      image: ghcr.io/dfinity/ic-build@sha256:eb85228ebf7511e2589f86788345eb3d1c8144914a8a2fa771d4347ddacac413
     timeout-minutes: 60 # 1 hour
     if: ${{ vars.RUN_CI == 'true' }} # needed to avoid running on public dfinity org until published
     steps:


### PR DESCRIPTION
Relabeling `bazel-build-fuzzers-weekly` and `cut-release-candidate` to run on different runners.