### PR TITLE
chore(IDX): remove clippy sysroot workaround

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -15,10 +15,6 @@ build:fmt --aspects=@rules_rust//rust:defs.bzl%rustfmt_aspect
 build:fmt --output_groups=+rustfmt_checks
 build --@rules_rust//:rustfmt.toml=//:rustfmt.toml
 
-# https://github.com/bazelbuild/rules_rust/pull/2277 breaks our build in CI
-# TODO(levsha): localise the problem and report to the upstream
-build --@rules_rust//rust/settings:experimental_toolchain_generated_sysroot=False
-
 build:ci --progress_report_interval=30
 
 # Use hermetic JDK


### PR DESCRIPTION
This removes a workaround that was necessary in the past to work around an issue in clippy. The issue is now fixed in clippy, and our clippy version is recent enough to include the fix.

See also:
* https://github.com/bazelbuild/rules_rust/pull/2277
* https://github.com/rust-lang/rust-clippy/pull/12203