### PR TITLE
chore(IDX): remove bazel-build-log.json

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -15,10 +15,6 @@ build:fmt --aspects=@rules_rust//rust:defs.bzl%rustfmt_aspect
 build:fmt --output_groups=+rustfmt_checks
 build --@rules_rust//:rustfmt.toml=//:rustfmt.toml
 
-# https://github.com/bazelbuild/rules_rust/pull/2277 breaks our build in CI
-# TODO(levsha): localise the problem and report to the upstream
-build --@rules_rust//rust/settings:experimental_toolchain_generated_sysroot=False
-
 build:ci --progress_report_interval=30
 
 # Use hermetic JDK

--- a/.bazelrc
+++ b/.bazelrc
@@ -49,8 +49,6 @@ build:ci --remote_timeout=5m # Default is 60s.
 build --experimental_remote_downloader=bazel-remote.idx.dfinity.network --experimental_remote_downloader_local_fallback
 build:local --experimental_remote_downloader=
 
-# Does not produce valid JSON. See https://github.com/bazelbuild/bazel/issues/14209
-build --execution_log_json_file=bazel-build-log.json
 build:ci --build_event_binary_file=bazel-bep.pb
 
 build --bes_results_url=https://dash.idx.dfinity.network/invocation/

--- a/.gitignore
+++ b/.gitignore
@@ -118,7 +118,6 @@ scalability/results/
 
 # Bazel outdir dirs
 /bazel-*
-bazel-build-log.json
 bazel-bep.pb
 bazel-bep.txt
 bazel-timestamp.txt

--- a/gitlab-ci/config/main.yml
+++ b/gitlab-ci/config/main.yml
@@ -90,7 +90,6 @@ bazel-build-fuzzers-archives:
   artifacts:
     when: always
     paths:
-      - bazel-build-log*.json*
       - bazel-bep.pb
     reports:
       junit: bazel-testlogs-gitlab/**/test.xml
@@ -113,7 +112,6 @@ bazel-build-fuzzers-archives:
       echo -e "************************************************************************"
       echo -e "\033[0m"
     - cp -R "$(realpath bazel-testlogs)" bazel-testlogs-gitlab
-    - gzip bazel-build-log*.json
     - |
       echo -e "\e[0Ksection_start:$(date +%s):bazel_exporter_logs[collapsed=true]\r\e[0KClick to see Bazel exporter logs"
       bazel run //bazel/exporter:exporter --build_event_binary_file= -- -f "$(pwd)/bazel-bep.pb"
@@ -155,7 +153,6 @@ bazel-test-all:
   artifacts:
     when: always
     paths:
-      - bazel-build-log*.json.gz
       - bazel-bep.pb
       - bazel-targets
     reports:
@@ -319,7 +316,6 @@ bazel-test-macos:
     reports:
       dotenv: nns.release.env
     paths:
-      - bazel-build-log*.json*
       - build-ic.tar
   script:
     - gitlab-ci/src/ci-scripts/build-ic.sh


### PR DESCRIPTION
This changes the default config to not general a build log. The build log is a very large file, and is not used much.

When debugging builds, the build log can simply be re-enabled. It does not seem to be generally useful to generate the build log or to store it.