### PR TITLE
chore(IDX): bump actions/upload-artifact version

### DIFF
--- a/.github/workflows-source/ci-main.yml
+++ b/.github/workflows-source/ci-main.yml
@@ -91,7 +91,7 @@ jobs:
           RUN_ON_DIFF_ONLY: ${{ contains(github.event_name, 'pull_request') && 'true' || 'false'}}
           HONEYCOMB_API_TOKEN: ${{ secrets.HONEYCOMB_API_TOKEN }}
       - name: Upload bazel-targets
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: bazel-targets
           retention-days: 1
@@ -232,7 +232,7 @@ jobs:
           RUN_ON_DIFF_ONLY: "true"
           BAZEL_COMMAND: "build"
       - name: Upload build-ic.tar
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-ic
           retention-days: 1
@@ -272,11 +272,11 @@ jobs:
     steps:
       - <<: *checkout
       - name: Download bazel-targets [bazel-test-all]
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: bazel-targets
       - name: Download build-ic.tar [build-ic]
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: build-ic
       - name: Build Determinism Test

--- a/.github/workflows-source/ci-main.yml
+++ b/.github/workflows-source/ci-main.yml
@@ -91,7 +91,7 @@ jobs:
           RUN_ON_DIFF_ONLY: ${{ contains(github.event_name, 'pull_request') && 'true' || 'false'}}
           HONEYCOMB_API_TOKEN: ${{ secrets.HONEYCOMB_API_TOKEN }}
       - name: Upload bazel-targets
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: bazel-targets
           retention-days: 1
@@ -232,7 +232,7 @@ jobs:
           RUN_ON_DIFF_ONLY: "true"
           BAZEL_COMMAND: "build"
       - name: Upload build-ic.tar
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: build-ic
           retention-days: 1

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -64,7 +64,7 @@ jobs:
           RUN_ON_DIFF_ONLY: ${{ contains(github.event_name, 'pull_request') && 'true' || 'false'}}
           HONEYCOMB_API_TOKEN: ${{ secrets.HONEYCOMB_API_TOKEN }}
       - name: Upload bazel-targets
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: bazel-targets
           retention-days: 1
@@ -258,7 +258,7 @@ jobs:
           RUN_ON_DIFF_ONLY: "true"
           BAZEL_COMMAND: "build"
       - name: Upload build-ic.tar
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-ic
           retention-days: 1
@@ -300,11 +300,11 @@ jobs:
         with:
           fetch-depth: ${{ github.event_name == 'pull_request' && 256 || 0 }}
       - name: Download bazel-targets [bazel-test-all]
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: bazel-targets
       - name: Download build-ic.tar [build-ic]
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: build-ic
       - name: Build Determinism Test

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -64,7 +64,7 @@ jobs:
           RUN_ON_DIFF_ONLY: ${{ contains(github.event_name, 'pull_request') && 'true' || 'false'}}
           HONEYCOMB_API_TOKEN: ${{ secrets.HONEYCOMB_API_TOKEN }}
       - name: Upload bazel-targets
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: bazel-targets
           retention-days: 1
@@ -258,7 +258,7 @@ jobs:
           RUN_ON_DIFF_ONLY: "true"
           BAZEL_COMMAND: "build"
       - name: Upload build-ic.tar
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: build-ic
           retention-days: 1


### PR DESCRIPTION
Bump `download-artifact` and `upload-artifact` action from `v3` to `v4`.