### PR TITLE
fix(IDX): docker.io auth

### DIFF
--- a/bazel/external_crates.bzl
+++ b/bazel/external_crates.bzl
@@ -1,5 +1,5 @@
 """
-This module declares all direct rust dependencies.
+This module declares all direct rust dependencies!
 
 Run `./bin/bazel-pin.sh` from the top-level directory of the working tree after changing this file
 to regenerate Cargo Bazel lockfiles.

--- a/bazel/external_crates.bzl
+++ b/bazel/external_crates.bzl
@@ -1,5 +1,5 @@
 """
-This module declares all direct rust dependencies!
+This module declares all direct rust dependencies.
 
 Run `./bin/bazel-pin.sh` from the top-level directory of the working tree after changing this file
 to regenerate Cargo Bazel lockfiles.

--- a/gitlab-ci/src/ci-scripts/before-script.sh
+++ b/gitlab-ci/src/ci-scripts/before-script.sh
@@ -9,6 +9,7 @@ fi
 # docker-bin used by container_pull in WORKSPACES.bazel
 if which docker-bin 2>/dev/null; then
     docker-bin login -u "$DOCKER_HUB_USER" -p "$DOCKER_HUB_PASSWORD_RO"
+    sudo docker-bin login -u "$DOCKER_HUB_USER" -p "$DOCKER_HUB_PASSWORD_RO"
 fi
 
 # print node name for easier debugging

--- a/gitlab-ci/src/ci-scripts/before-script.sh
+++ b/gitlab-ci/src/ci-scripts/before-script.sh
@@ -8,7 +8,9 @@ if which docker 2>/dev/null; then
 fi
 # docker-bin used by container_pull in WORKSPACES.bazel
 if which docker-bin 2>/dev/null; then
+    # save auth to user's .docker/config.json
     docker-bin login -u "$DOCKER_HUB_USER" -p "$DOCKER_HUB_PASSWORD_RO"
+    # save auth to root's .docker/config.json
     sudo docker-bin login -u "$DOCKER_HUB_USER" -p "$DOCKER_HUB_PASSWORD_RO"
 fi
 


### PR DESCRIPTION
`sudo podman` doesn't seem to get credentials. Adding them to `.docker/auth.json` for root which is the file that rootful podman uses as a fallback if it exists.
```
Error: initializing source docker://dfinity/boundaryos-base@sha256:8c218ad124309aa177c2f41c3766f87edca4485150c4ebe002de281a6932ae83: reading manifest sha256:8c218ad124309aa177c2f41c3766f87edca4485150c4ebe002de281a6932ae83 in docker.io/dfinity/boundaryos-base: toomanyrequests: You have reached your pull rate limit.
```