### PR TITLE
fix(IDX): use jq arg in team lookup

### DIFF
--- a/.github/workflows-source/ci-main.yml
+++ b/.github/workflows-source/ci-main.yml
@@ -64,7 +64,7 @@ anchors:
       fetch-depth: ${{ github.event_name == 'pull_request' && 256 || 0 }}
   python-setup: &python-setup
     name: Set up Python
-    uses: actions/setup-python@v2
+    uses: actions/setup-python@v3
     with:
       python-version: '3.10'
 

--- a/.github/workflows-source/ci-pr-only.yml
+++ b/.github/workflows-source/ci-pr-only.yml
@@ -114,7 +114,7 @@ jobs:
     steps:
       - <<: *checkout
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
           python-version: '3.10'
       - name: Run script

--- a/.github/workflows/ci-generate-ci.yml
+++ b/.github/workflows/ci-generate-ci.yml
@@ -20,7 +20,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.ref }}
           token: ${{ secrets.IDX_PUSH_TO_PR }}
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
           python-version: '3.10'
       - name: Run Generate CI

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -211,7 +211,7 @@ jobs:
         with:
           fetch-depth: ${{ github.event_name == 'pull_request' && 256 || 0 }}
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
           python-version: '3.10'
       - name: Run Python CI Tests

--- a/.github/workflows/ci-notify-slack.yml
+++ b/.github/workflows/ci-notify-slack.yml
@@ -23,7 +23,7 @@ jobs:
         if: steps.get-reviewers.outputs.result != '""'
         run: |
           TEAM=${{ steps.get-reviewers.outputs.result }}
-          CHANNEL=$(jq -r ".$TEAM" .github/workflows/team-channels.json)
+          CHANNEL=$(jq -r --arg team "$TEAM" '.[$team]' .github/workflows/team-channels.json)
           echo "channel=${CHANNEL}" >> $GITHUB_OUTPUT
           echo "message=${MESSAGE}" >> $GITHUB_OUTPUT
         env:

--- a/.github/workflows/ci-pr-only.yml
+++ b/.github/workflows/ci-pr-only.yml
@@ -107,7 +107,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
           python-version: '3.10'
       - name: Run script


### PR DESCRIPTION
By using jq's `--arg` we make sure `jq` interprets the team as a whole string. Without thing, the `jq` filter can expand to e.g. `'.my-team'` which is not valid. For instance with `TEAM="ic-interface-owners"`:

```
jq: error: interface/0 is not defined at <top-level>, line 1:
.ic-interface-owners
```