### PR TITLE
chore(IDX): enable the firewall_max_connections_test on GitHub again

### DIFF
--- a/.github/workflows-source/schedule-hourly.yml
+++ b/.github/workflows-source/schedule-hourly.yml
@@ -70,10 +70,9 @@ jobs:
         uses:  ./.github/actions/bazel-test-all/
         with:
           BAZEL_COMMAND: "test"
-          # The --test_tag_filters=-not_on_github is only temporary until the bonding on ln1-idx1 is configured
           BAZEL_TARGETS: "//..."
           BAZEL_CI_CONFIG: "--config=ci --repository_cache=/cache/bazel"
-          BAZEL_EXTRA_ARGS: "--keep_going --verbose_failures --test_tag_filters=system_test_hourly,-not_on_github --deleted_packages=gitlab-ci/src/gitlab_config"
+          BAZEL_EXTRA_ARGS: "--keep_going --verbose_failures --test_tag_filters=system_test_hourly --deleted_packages=gitlab-ci/src/gitlab_config"
           HONEYCOMB_API_TOKEN: ${{ secrets.HONEYCOMB_API_TOKEN }}
 
   bazel-test-coverage:

--- a/.github/workflows/release-testing.yml
+++ b/.github/workflows/release-testing.yml
@@ -49,8 +49,7 @@ jobs:
         uses: ./.github/actions/bazel-test-all/
         with:
           BAZEL_COMMAND: "test"
-          # The --test_tag_filters=-not_on_github is only temporary until the bonding on ln1-idx1 is configured
-          BAZEL_TARGETS: "//... --test_tag_filters=-not_on_github --deleted_packages=gitlab-ci/src/gitlab_config"
+          BAZEL_TARGETS: "//... --deleted_packages=gitlab-ci/src/gitlab_config"
           BAZEL_CI_CONFIG: "--config=ci --repository_cache=/cache/bazel"
           BAZEL_EXTRA_ARGS: "--keep_going --verbose_failures --test_tag_filters=system_test_nightly"
           HONEYCOMB_API_TOKEN: ${{ secrets.HONEYCOMB_API_TOKEN }}

--- a/.github/workflows/schedule-hourly.yml
+++ b/.github/workflows/schedule-hourly.yml
@@ -65,10 +65,9 @@ jobs:
         uses: ./.github/actions/bazel-test-all/
         with:
           BAZEL_COMMAND: "test"
-          # The --test_tag_filters=-not_on_github is only temporary until the bonding on ln1-idx1 is configured
           BAZEL_TARGETS: "//..."
           BAZEL_CI_CONFIG: "--config=ci --repository_cache=/cache/bazel"
-          BAZEL_EXTRA_ARGS: "--keep_going --verbose_failures --test_tag_filters=system_test_hourly,-not_on_github --deleted_packages=gitlab-ci/src/gitlab_config"
+          BAZEL_EXTRA_ARGS: "--keep_going --verbose_failures --test_tag_filters=system_test_hourly --deleted_packages=gitlab-ci/src/gitlab_config"
           HONEYCOMB_API_TOKEN: ${{ secrets.HONEYCOMB_API_TOKEN }}
   bazel-test-coverage:
     name: Bazel Test Coverage

--- a/rs/tests/networking/BUILD.bazel
+++ b/rs/tests/networking/BUILD.bazel
@@ -119,8 +119,6 @@ system_test(
     flaky = True,
     proc_macro_deps = MACRO_DEPENDENCIES,
     tags = [
-        # The not_on_github is only temporary until the bonding on ln1-idx1 is configured
-        "not_on_github",
         "system_test_hourly",
         "system_test_nightly",
     ],


### PR DESCRIPTION
Bonding has been setup in ln1-idx1 which means [firewall_max_connections_test is succeeding now](https://dash.sf1-idx1.dfinity.network/invocation/6b696acb-71c4-4280-b435-7652307416e8?target=%2F%2Frs%2Ftests%2Fnetworking%3Afirewall_max_connections_test&targetStatus=5).
