### PR TITLE
chore(IDX): Remove verbose failures

### DIFF
--- a/.github/workflows-source/ci-main.yml
+++ b/.github/workflows-source/ci-main.yml
@@ -165,7 +165,6 @@ jobs:
         with:
           BAZEL_COMMAND: "build"
           BAZEL_TARGETS: "//rs/..."
-          BAZEL_CI_CONFIG: "--config=ci"
           BAZEL_EXTRA_ARGS: "--keep_going --config=fuzzing --build_tag_filters=libfuzzer"
 
   bazel-build-fuzzers-afl:
@@ -180,7 +179,6 @@ jobs:
         with:
           BAZEL_COMMAND: "build"
           BAZEL_TARGETS: "//rs/..."
-          BAZEL_CI_CONFIG: "--config=ci"
           BAZEL_EXTRA_ARGS: "--keep_going --config=afl"
 
   python-ci-tests:

--- a/.github/workflows-source/ci-main.yml
+++ b/.github/workflows-source/ci-main.yml
@@ -137,6 +137,7 @@ jobs:
           echo "$HOME/.cargo/bin:" >> $GITHUB_PATH
       - <<: *before-script
       - name: Run Bazel Test Darwin x86-64
+        # TODO: remove '//rs/execution_environment:execution_environment_test' once flakiness is resolved
         id: bazel-test-darwin-x86-64
         if: steps.filter.outputs.bazel-test-darwin-x86-64 != 'false' || github.event_name == 'schedule'
         uses:  ./.github/actions/bazel-test-all/
@@ -145,7 +146,7 @@ jobs:
           BAZEL_COMMAND: test
           BAZEL_EXTRA_ARGS: "--test_tag_filters=test_macos"
           BAZEL_STARTUP_ARGS: "--output_base /var/tmp/bazel-output//${ROOT_PIPELINE_ID}"
-          BAZEL_TARGETS: "//rs/... //publish/binaries/..."
+          BAZEL_TARGETS: "//rs/... //publish/binaries/... -//rs/execution_environment:execution_environment_test"
           HONEYCOMB_API_TOKEN: ${{ secrets.HONEYCOMB_API_TOKEN }}
       - name: Purge Bazel Output
         if: always()

--- a/.github/workflows-source/ci-main.yml
+++ b/.github/workflows-source/ci-main.yml
@@ -78,7 +78,6 @@ jobs:
           BAZEL_CI_CONFIG: "--config=ci --repository_cache=/cache/bazel"
           # check if PR title contains release and set timeout filters accordingly
           BAZEL_EXTRA_ARGS_RULES: ${{ contains(env.TITLE, 'release') && '--test_timeout_filters=short,moderate' || '' }}
-          BAZEL_EXTRA_ARGS: "--keep_going --verbose_failures"
           # run on diff only if it is a pull request, otherwise run all targets
           RUN_ON_DIFF_ONLY: ${{ contains(github.event_name, 'pull_request') && 'true' || 'false'}}
           HONEYCOMB_API_TOKEN: ${{ secrets.HONEYCOMB_API_TOKEN }}

--- a/.github/workflows-source/schedule-daily.yml
+++ b/.github/workflows-source/schedule-daily.yml
@@ -134,7 +134,7 @@ jobs:
           BAZEL_COMMAND: "test"
           BAZEL_TARGETS: "//rs/nns/..."
           BAZEL_CI_CONFIG: "--config=ci --repository_cache=/cache/bazel"
-          BAZEL_EXTRA_ARGS: "--keep_going --verbose_failures --test_tag_filters=nns_tests_nightly --test_env=SSH_AUTH_SOCK --test_env=NNS_CANISTER_UPGRADE_SEQUENCE=all"
+          BAZEL_EXTRA_ARGS: "--keep_going --test_tag_filters=nns_tests_nightly --test_env=SSH_AUTH_SOCK --test_env=NNS_CANISTER_UPGRADE_SEQUENCE=all"
           HONEYCOMB_API_TOKEN: ${{ secrets.HONEYCOMB_API_TOKEN }}
           SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
 

--- a/.github/workflows-source/schedule-daily.yml
+++ b/.github/workflows-source/schedule-daily.yml
@@ -1,8 +1,10 @@
 name: Schedule Daily
+
 on:
   schedule:
     - cron: "0 1 * * *"
   workflow_dispatch:
+
 env:
   AWS_SHARED_CREDENTIALS_CONTENT: ${{ secrets.AWS_SHARED_CREDENTIALS_FILE }}
   BAZEL_STARTUP_ARGS: "--output_base=/var/tmp/bazel-output/"
@@ -19,7 +21,28 @@ env:
   DOCKER_HUB_PASSWORD_RO: ${{ secrets.DOCKER_HUB_PASSWORD_RO }}
   BUILDEVENT_APIKEY: ${{ secrets.HONEYCOMB_API_TOKEN }}
   BUILDEVENT_DATASET: "github-ci-dfinity"
+
+anchors:
+  image: &image
+    image: ghcr.io/dfinity/ic-build@sha256:5bd0f059ad6e21966e9c644516b6ecd52d5ed44f1b18a76b91b59740a9d639a2
+  dind-large-setup: &dind-large-setup
+    runs-on:
+      group: dind-large
+    container:
+      <<: *image
+    timeout-minutes: 120
+    if: ${{ vars.RUN_CI == 'true' }}
+  checkout: &checkout
+    name: Checkout
+    uses: actions/checkout@v4
+  before-script: &before-script
+    name: Before script
+    id: before-script
+    shell: bash
+    run: ./gitlab-ci/src/ci-scripts/before-script.sh
+
 jobs:
+
   cut-release-candidate:
     name: Cut RC
     runs-on: ubuntu-latest
@@ -41,12 +64,10 @@ jobs:
           RC_BRANCH_NAME="rc--$(date '+%Y-%m-%d_%H-%M')--github"
           git switch --force-create "$RC_BRANCH_NAME" HEAD
           git push --force --set-upstream origin "$RC_BRANCH_NAME"
+
   rust-benchmarks:
     name: Bazel Run Rust Benchmarks
-    runs-on:
-      group: dind-large
-    container:
-      image: ghcr.io/dfinity/ic-build@sha256:5bd0f059ad6e21966e9c644516b6ecd52d5ed44f1b18a76b91b59740a9d639a2
+    <<: *dind-large-setup
     timeout-minutes: 720 # 12 hours
     # TODO: disable in GitLab before enabling here
     if: ${{ vars.RUN_CI == 'true' && false }}
@@ -54,12 +75,8 @@ jobs:
       matrix:
         targets: ["//rs/crypto/...", "//rs/state_manager/..."]
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Before script
-        id: before-script
-        shell: bash
-        run: ./gitlab-ci/src/ci-scripts/before-script.sh
+      - <<: *checkout
+      - <<: *before-script
       - name: Run Rust Benchmarks
         id: rust-benchmarks
         shell: bash
@@ -72,22 +89,16 @@ jobs:
           RUSTFLAGS: "--remap-path-prefix=${CI_PROJECT_DIR}=/ic"
           RUST_BACKTRACE: "full"
           TARGETS: ${{ matrix.targets }}
+
   bazel-test-bare-metal:
     name: Bazel Test Bare Metal
-    runs-on:
-      group: dind-large
-    container:
-      image: ghcr.io/dfinity/ic-build@sha256:5bd0f059ad6e21966e9c644516b6ecd52d5ed44f1b18a76b91b59740a9d639a2
+    <<: *dind-large-setup
     timeout-minutes: 120
     # TODO: enable when zh1 is active again
     if: ${{ vars.RUN_CI == 'true' && false }}
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Before script
-        id: before-script
-        shell: bash
-        run: ./gitlab-ci/src/ci-scripts/before-script.sh
+      - <<: *checkout
+      - <<: *before-script
       - name: Run Bazel Launch Bare Metal
         shell: bash
         run: |
@@ -107,21 +118,15 @@ jobs:
           BAZEL_CI_CONFIG: "--config=ci --repository_cache=/cache/bazel"
           ZH2_DLL01_CSV_SECRETS: "${{ secrets.ZH2_DLL01_CSV_SECRETS }}"
           ZH2_FILE_SHARE_KEY: "${{ secrets.ZH2_FILE_SHARE_KEY }}"
+
   nns-tests-nightly:
     name: Bazel Test NNS Nightly
-    runs-on:
-      group: dind-large
-    container:
-      image: ghcr.io/dfinity/ic-build@sha256:5bd0f059ad6e21966e9c644516b6ecd52d5ed44f1b18a76b91b59740a9d639a2
+    <<: *dind-large-setup
     timeout-minutes: 20
     if: ${{ vars.RUN_CI == 'true' }}
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Before script
-        id: before-script
-        shell: bash
-        run: ./gitlab-ci/src/ci-scripts/before-script.sh
+      - <<: *checkout
+      - <<: *before-script
       - name: Run NNS Tests Nightly
         id: bazel-test-all
         uses: ./.github/actions/bazel-test-all/
@@ -132,21 +137,15 @@ jobs:
           BAZEL_EXTRA_ARGS: "--keep_going --verbose_failures --test_tag_filters=nns_tests_nightly --test_env=SSH_AUTH_SOCK --test_env=NNS_CANISTER_UPGRADE_SEQUENCE=all"
           HONEYCOMB_API_TOKEN: ${{ secrets.HONEYCOMB_API_TOKEN }}
           SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+
   system-tests-benchmarks-nightly:
     name: Bazel System Test Benchmarks
-    runs-on:
-      group: dind-large
-    container:
-      image: ghcr.io/dfinity/ic-build@sha256:5bd0f059ad6e21966e9c644516b6ecd52d5ed44f1b18a76b91b59740a9d639a2
+    <<: *dind-large-setup
     timeout-minutes: 480
     if: ${{ vars.RUN_CI == 'true' }}
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Before script
-        id: before-script
-        shell: bash
-        run: ./gitlab-ci/src/ci-scripts/before-script.sh
+      - <<: *checkout
+      - <<: *before-script
       - name: Test System Test Benchmarks
         id: bazel-system-test-benchmarks
         uses: ./.github/actions/bazel-test-all/

--- a/.github/workflows-source/schedule-hourly.yml
+++ b/.github/workflows-source/schedule-hourly.yml
@@ -72,7 +72,7 @@ jobs:
           BAZEL_COMMAND: "test"
           BAZEL_TARGETS: "//..."
           BAZEL_CI_CONFIG: "--config=ci --repository_cache=/cache/bazel"
-          BAZEL_EXTRA_ARGS: "--keep_going --verbose_failures --test_tag_filters=system_test_hourly --deleted_packages=gitlab-ci/src/gitlab_config"
+          BAZEL_EXTRA_ARGS: "--keep_going --test_tag_filters=system_test_hourly --deleted_packages=gitlab-ci/src/gitlab_config"
           HONEYCOMB_API_TOKEN: ${{ secrets.HONEYCOMB_API_TOKEN }}
 
   bazel-test-coverage:

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -58,7 +58,6 @@ jobs:
           BAZEL_CI_CONFIG: "--config=ci --repository_cache=/cache/bazel"
           # check if PR title contains release and set timeout filters accordingly
           BAZEL_EXTRA_ARGS_RULES: ${{ contains(env.TITLE, 'release') && '--test_timeout_filters=short,moderate' || '' }}
-          BAZEL_EXTRA_ARGS: "--keep_going --verbose_failures"
           # run on diff only if it is a pull request, otherwise run all targets
           RUN_ON_DIFF_ONLY: ${{ contains(github.event_name, 'pull_request') && 'true' || 'false'}}
           HONEYCOMB_API_TOKEN: ${{ secrets.HONEYCOMB_API_TOKEN }}

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -170,7 +170,6 @@ jobs:
         with:
           BAZEL_COMMAND: "build"
           BAZEL_TARGETS: "//rs/..."
-          BAZEL_CI_CONFIG: "--config=ci"
           BAZEL_EXTRA_ARGS: "--keep_going --config=fuzzing --build_tag_filters=libfuzzer"
   bazel-build-fuzzers-afl:
     name: Bazel Build Fuzzers AFL
@@ -195,7 +194,6 @@ jobs:
         with:
           BAZEL_COMMAND: "build"
           BAZEL_TARGETS: "//rs/..."
-          BAZEL_CI_CONFIG: "--config=ci"
           BAZEL_EXTRA_ARGS: "--keep_going --config=afl"
   python-ci-tests:
     name: Python CI Tests

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -132,6 +132,7 @@ jobs:
         shell: bash
         run: ./gitlab-ci/src/ci-scripts/before-script.sh
       - name: Run Bazel Test Darwin x86-64
+        # TODO: remove '//rs/execution_environment:execution_environment_test' once flakiness is resolved
         id: bazel-test-darwin-x86-64
         if: steps.filter.outputs.bazel-test-darwin-x86-64 != 'false' || github.event_name == 'schedule'
         uses: ./.github/actions/bazel-test-all/
@@ -140,7 +141,7 @@ jobs:
           BAZEL_COMMAND: test
           BAZEL_EXTRA_ARGS: "--test_tag_filters=test_macos"
           BAZEL_STARTUP_ARGS: "--output_base /var/tmp/bazel-output//${ROOT_PIPELINE_ID}"
-          BAZEL_TARGETS: "//rs/... //publish/binaries/..."
+          BAZEL_TARGETS: "//rs/... //publish/binaries/... -//rs/execution_environment:execution_environment_test"
           HONEYCOMB_API_TOKEN: ${{ secrets.HONEYCOMB_API_TOKEN }}
       - name: Purge Bazel Output
         if: always()

--- a/.github/workflows/release-testing.yml
+++ b/.github/workflows/release-testing.yml
@@ -51,7 +51,7 @@ jobs:
           BAZEL_COMMAND: "test"
           BAZEL_TARGETS: "//... --deleted_packages=gitlab-ci/src/gitlab_config"
           BAZEL_CI_CONFIG: "--config=ci --repository_cache=/cache/bazel"
-          BAZEL_EXTRA_ARGS: "--keep_going --verbose_failures --test_tag_filters=system_test_nightly"
+          BAZEL_EXTRA_ARGS: "--keep_going --test_tag_filters=system_test_nightly"
           HONEYCOMB_API_TOKEN: ${{ secrets.HONEYCOMB_API_TOKEN }}
 
   bazel-system-test-staging:
@@ -80,5 +80,5 @@ jobs:
           BAZEL_COMMAND: "test"
           BAZEL_TARGETS: "//... --deleted_packages=gitlab-ci/src/gitlab_config"
           BAZEL_CI_CONFIG: "--config=ci --repository_cache=/cache/bazel"
-          BAZEL_EXTRA_ARGS: "--keep_going --verbose_failures --test_tag_filters=system_test_staging"
+          BAZEL_EXTRA_ARGS: "--keep_going --test_tag_filters=system_test_staging"
           HONEYCOMB_API_TOKEN: ${{ secrets.HONEYCOMB_API_TOKEN }}

--- a/.github/workflows/schedule-daily.yml
+++ b/.github/workflows/schedule-daily.yml
@@ -129,7 +129,7 @@ jobs:
           BAZEL_COMMAND: "test"
           BAZEL_TARGETS: "//rs/nns/..."
           BAZEL_CI_CONFIG: "--config=ci --repository_cache=/cache/bazel"
-          BAZEL_EXTRA_ARGS: "--keep_going --verbose_failures --test_tag_filters=nns_tests_nightly --test_env=SSH_AUTH_SOCK --test_env=NNS_CANISTER_UPGRADE_SEQUENCE=all"
+          BAZEL_EXTRA_ARGS: "--keep_going --test_tag_filters=nns_tests_nightly --test_env=SSH_AUTH_SOCK --test_env=NNS_CANISTER_UPGRADE_SEQUENCE=all"
           HONEYCOMB_API_TOKEN: ${{ secrets.HONEYCOMB_API_TOKEN }}
           SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
   system-tests-benchmarks-nightly:

--- a/.github/workflows/schedule-hourly.yml
+++ b/.github/workflows/schedule-hourly.yml
@@ -67,7 +67,7 @@ jobs:
           BAZEL_COMMAND: "test"
           BAZEL_TARGETS: "//..."
           BAZEL_CI_CONFIG: "--config=ci --repository_cache=/cache/bazel"
-          BAZEL_EXTRA_ARGS: "--keep_going --verbose_failures --test_tag_filters=system_test_hourly --deleted_packages=gitlab-ci/src/gitlab_config"
+          BAZEL_EXTRA_ARGS: "--keep_going --test_tag_filters=system_test_hourly --deleted_packages=gitlab-ci/src/gitlab_config"
           HONEYCOMB_API_TOKEN: ${{ secrets.HONEYCOMB_API_TOKEN }}
   bazel-test-coverage:
     name: Bazel Test Coverage

--- a/.github/workflows/team-channels.json
+++ b/.github/workflows/team-channels.json
@@ -9,7 +9,6 @@
     "ic-interface-owners": "interface-owners",
     "ic-message-routing-owners": "eng-message-routing-mr",
     "ic-owners-owners": "owners-owners",
-    "ic-testing-verification": "eng-testing",
     "idx": "eng-idx-bots",
     "networking": "eng-networking",
     "nns-team": "eng-nns",


### PR DESCRIPTION
We previously used `--verbose failures` for debugging but it is not required anymore.

Also remove defaults that are already set by the bazel-test-all action: https://github.com/dfinity/ic/blob/master/.github/actions/bazel-test-all/action.yaml#L10-L15. 