### PR TITLE
chore(IDX): deduplicate cargo sha crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1883,7 +1883,7 @@ dependencies = [
  "serde",
  "serde_cbor",
  "serde_json",
- "sha2 0.10.8",
+ "sha2 0.9.9",
  "thiserror",
  "tokio",
  "tower",
@@ -1942,7 +1942,7 @@ dependencies = [
  "publicsuffix",
  "serde",
  "serde_cbor",
- "sha2 0.10.8",
+ "sha2 0.9.9",
  "thiserror",
 ]
 
@@ -3057,7 +3057,7 @@ dependencies = [
  "rsa",
  "serde",
  "serde_json",
- "sha2 0.10.8",
+ "sha2 0.9.9",
  "tar",
  "tempfile",
  "tokio",
@@ -6489,7 +6489,7 @@ dependencies = [
  "rsa",
  "rustls 0.21.12",
  "serde",
- "sha2 0.10.8",
+ "sha2 0.9.9",
  "simple_asn1",
  "slog",
  "strum 0.26.2",
@@ -6544,7 +6544,7 @@ dependencies = [
  "hkdf",
  "pem 1.1.1",
  "rand 0.8.5",
- "sha2 0.10.8",
+ "sha2 0.9.9",
  "wycheproof",
  "zeroize",
 ]
@@ -6745,7 +6745,7 @@ dependencies = [
  "rsa",
  "serde",
  "serde_json",
- "sha2 0.10.8",
+ "sha2 0.9.9",
  "simple_asn1",
  "wycheproof",
 ]
@@ -6969,7 +6969,7 @@ dependencies = [
 name = "ic-crypto-internal-sha2"
 version = "0.9.0"
 dependencies = [
- "sha2 0.10.8",
+ "sha2 0.9.9",
 ]
 
 [[package]]
@@ -7059,7 +7059,7 @@ dependencies = [
  "p256",
  "rand 0.8.5",
  "schnorr_fun",
- "sha2 0.10.8",
+ "sha2 0.9.9",
 ]
 
 [[package]]
@@ -12626,7 +12626,7 @@ dependencies = [
  "proptest",
  "serde",
  "serde_bytes",
- "sha2 0.10.8",
+ "sha2 0.9.9",
  "strum 0.26.2",
 ]
 
@@ -13296,7 +13296,7 @@ dependencies = [
  "ic-certified-map",
  "serde",
  "serde_cbor",
- "sha2 0.10.8",
+ "sha2 0.9.9",
 ]
 
 [[package]]
@@ -14345,7 +14345,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with 1.14.0",
- "sha2 0.10.8",
+ "sha2 0.9.9",
  "utils",
 ]
 
@@ -15533,7 +15533,7 @@ dependencies = [
  "serde",
  "serde_bytes",
  "serde_json",
- "sha2 0.10.8",
+ "sha2 0.9.9",
  "tokio",
  "tracing",
  "tracing-appender",
@@ -18981,7 +18981,7 @@ dependencies = [
  "serde_cbor",
  "serde_json",
  "serde_yaml 0.9.34+deprecated",
- "sha2 0.10.8",
+ "sha2 0.9.9",
  "slog",
  "slog-async",
  "slog-term",
@@ -20100,7 +20100,7 @@ dependencies = [
  "rusb",
  "serde",
  "serde_json",
- "sha2 0.10.8",
+ "sha2 0.9.9",
  "tempfile",
  "vsock",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -555,6 +555,8 @@ serde_cbor = "0.11.2"
 serde_json = { version = "1.0.117", features = ["std"] }
 serde_with = "1.14.0"
 serde_yaml = "0.9.33"
+sha2 = "0.9.9"
+sha3 = "0.9.1"
 signature = "2.2.0"
 simple_asn1 = "0.6.2"
 slog = { version = "2.7.0", features = [

--- a/packages/ic-vetkd-utils/Cargo.toml
+++ b/packages/ic-vetkd-utils/Cargo.toml
@@ -17,8 +17,8 @@ rand = { workspace = true }
 rand_chacha = { workspace = true }
 lazy_static = { workspace = true }
 ic_bls12_381 = { version = "0.8.0", default-features = false, features = ["pairings", "alloc", "experimental", "zeroize"] }
-sha2 = "0.9"
-sha3 = "0.9"
+sha2 = { version = "0.9.1" }
+sha3 = { workspace = true }
 pairing = "0.22"
 subtle = "2.5"
 wasm-bindgen = { version = "0.2.84", optional = true }

--- a/packages/icrc-ledger-types/Cargo.toml
+++ b/packages/icrc-ledger-types/Cargo.toml
@@ -19,7 +19,7 @@ num-bigint = "0.4"
 num-traits = { workspace = true }
 serde_bytes = { workspace = true }
 serde = { workspace = true }
-sha2 = "0.10"
+sha2 = { workspace = true }
 itertools ={ workspace = true }
 strum = {workspace = true}
 [dev-dependencies]

--- a/packages/pocket-ic/Cargo.toml
+++ b/packages/pocket-ic/Cargo.toml
@@ -32,7 +32,7 @@ tracing = { workspace = true }
 tracing-appender = { workspace = true }
 tracing-subscriber = { workspace = true }
 schemars = "0.8.16"
-sha2 = "0.10.8"
+sha2 = { workspace = true }
 tokio = { workspace = true }
 
 [dev-dependencies]

--- a/rs/boundary_node/certificate_issuance/certificate_issuer/Cargo.toml
+++ b/rs/boundary_node/certificate_issuance/certificate_issuer/Cargo.toml
@@ -43,7 +43,7 @@ reqwest = { workspace = true, default-features = false, features = [
 serde = { workspace = true }
 serde_cbor = { workspace = true }
 serde_json = { workspace = true }
-sha2 = "0.10.6"
+sha2 = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 tower = { workspace = true }

--- a/rs/boundary_node/certificate_issuance/certificate_orchestrator/Cargo.toml
+++ b/rs/boundary_node/certificate_issuance/certificate_orchestrator/Cargo.toml
@@ -30,7 +30,7 @@ prometheus = { workspace = true }
 publicsuffix = "2.2.3"
 serde = { workspace = true }
 serde_cbor = { workspace = true }
-sha2 = "0.10.6"
+sha2 = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]

--- a/rs/boundary_node/denylist_updater/Cargo.toml
+++ b/rs/boundary_node/denylist_updater/Cargo.toml
@@ -25,7 +25,7 @@ reqwest = { workspace = true }
 rsa = "0.9.2"
 serde = { workspace = true }
 serde_json = { workspace = true }
-sha2 = "0.10.2"
+sha2 = { workspace = true }
 tar = "0.4.38"
 tokio = { workspace = true }
 tracing = { workspace = true }

--- a/rs/crypto/Cargo.toml
+++ b/rs/crypto/Cargo.toml
@@ -99,7 +99,7 @@ prost = { workspace = true }
 rand = { workspace = true }
 rand_chacha = { workspace = true }
 rsa = "0.9.2"
-sha2 = "0.10.2"
+sha2 = { workspace = true }
 simple_asn1 = { workspace = true }
 
 [[bench]]

--- a/rs/crypto/ed25519/Cargo.toml
+++ b/rs/crypto/ed25519/Cargo.toml
@@ -10,7 +10,7 @@ documentation.workspace = true
 curve25519-dalek = { workspace = true }
 ed25519-dalek = { workspace = true }
 hkdf = "0.12"
-sha2 = "0.10"
+sha2 = { workspace = true }
 rand = { workspace = true }
 zeroize = { version = "1.5", features = ["zeroize_derive"] }
 pem = "1"

--- a/rs/crypto/internal/crypto_lib/basic_sig/rsa_pkcs1/Cargo.toml
+++ b/rs/crypto/internal/crypto_lib/basic_sig/rsa_pkcs1/Cargo.toml
@@ -13,7 +13,7 @@ ic-crypto-sha2 = { path = "../../../../sha2" }
 ic-crypto-internal-basic-sig-der-utils = { path = "../der_utils" }
 num-traits = { workspace = true }
 pkcs8 = { workspace = true }
-sha2 = "0.10.2"
+sha2 = { workspace = true }
 serde = { workspace = true }
 simple_asn1 = { workspace = true }
 num-bigint = "~0.4.3"

--- a/rs/crypto/internal/crypto_lib/bls12_381/type/Cargo.toml
+++ b/rs/crypto/internal/crypto_lib/bls12_381/type/Cargo.toml
@@ -20,7 +20,7 @@ itertools = { workspace = true }
 pairing = "0.22"
 paste = "1.0.7"
 subtle = "2.4"
-sha2 = "0.9"
+sha2 = { version = "0.9.1" }
 rand = { workspace = true }
 rand_chacha = { workspace = true }
 lazy_static = { workspace = true }

--- a/rs/crypto/internal/crypto_lib/sha2/Cargo.toml
+++ b/rs/crypto/internal/crypto_lib/sha2/Cargo.toml
@@ -7,5 +7,5 @@ description.workspace = true
 documentation.workspace = true
 
 [dependencies]
-sha2 = "0.10"
+sha2 = { workspace = true }
 

--- a/rs/crypto/internal/crypto_lib/threshold_sig/tecdsa/test_utils/Cargo.toml
+++ b/rs/crypto/internal/crypto_lib/threshold_sig/tecdsa/test_utils/Cargo.toml
@@ -16,4 +16,4 @@ k256 = { workspace = true }
 p256 = { workspace = true }
 rand = { workspace = true }
 schnorr_fun = "0.10"
-sha2 = "0.10"
+sha2 = { workspace = true }

--- a/rs/crypto/sha3/Cargo.toml
+++ b/rs/crypto/sha3/Cargo.toml
@@ -7,7 +7,7 @@ edition.workspace = true
 documentation.workspace = true
 
 [dependencies]
-sha3 = "0.9.1"
+sha3 = { workspace = true }
 
 [dev-dependencies]
 hex = { workspace = true }

--- a/rs/ic_os/network/Cargo.toml
+++ b/rs/ic_os/network/Cargo.toml
@@ -14,4 +14,4 @@ regex = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_with = { version = "^1.6.2" }
-sha2 = { version = "^0.10.2" }
+sha2 = { workspace = true }

--- a/rs/ic_os/vsock/vsock_lib/Cargo.toml
+++ b/rs/ic_os/vsock/vsock_lib/Cargo.toml
@@ -12,6 +12,6 @@ tempfile = { workspace = true }
 vsock = "0.4"
 reqwest = { workspace = true }
 regex = { workspace = true }
-sha2 = "0.10"
+sha2 = { workspace = true }
 anyhow = { workspace = true }
 rusb = "0.9"

--- a/rs/nns/cmc/Cargo.toml
+++ b/rs/nns/cmc/Cargo.toml
@@ -40,7 +40,7 @@ prost = { workspace = true }
 rand = { workspace = true }
 serde = { workspace = true }
 serde_cbor = { workspace = true }
-sha2 = "0.9.1"
+sha2 = { workspace = true }
 yansi = "0.5.0"
 
 [dev-dependencies]

--- a/rs/nns/common/Cargo.toml
+++ b/rs/nns/common/Cargo.toml
@@ -28,7 +28,7 @@ on_wire = { path = "../../rust_canisters/on_wire" }
 prost = { workspace = true }
 serde = { workspace = true }
 serde_bytes = { workspace = true }
-sha2 = "0.9.1"
+sha2 = { workspace = true }
 comparable = { version = "0.5", features = ["derive"] }
 
 [dev-dependencies]

--- a/rs/nns/gtc/Cargo.toml
+++ b/rs/nns/gtc/Cargo.toml
@@ -36,7 +36,7 @@ libsecp256k1 = "0.7.0"
 prost = { workspace = true }
 rand = { workspace = true }
 serde = { workspace = true }
-sha3 = "0.9.1"
+sha3 = { workspace = true }
 simple_asn1 = { workspace = true }
 
 [dev-dependencies]

--- a/rs/tests/Cargo.toml
+++ b/rs/tests/Cargo.toml
@@ -158,7 +158,7 @@ serde_bytes = { workspace = true }
 serde_cbor = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }
-sha2 = "0.10"
+sha2 = { workspace = true }
 slog = { workspace = true }
 slog-async = { workspace = true }
 slog-term = { workspace = true }

--- a/rs/tests/test_canisters/kv_store/Cargo.toml
+++ b/rs/tests/test_canisters/kv_store/Cargo.toml
@@ -19,4 +19,4 @@ base64 = { workspace = true }
 flate2 = { workspace = true }
 serde = { workspace = true }
 serde_cbor = { workspace = true }
-sha2 = "0.10.6"
+sha2 = { workspace = true }


### PR DESCRIPTION
Before this, several versions of both `sha2` and `sha3` were used in the Cargo build. This aligns the crates in the Cargo manifests to use a single version of each, which is aligned with the Bazel definitions.