### PR TITLE
test(schnorr): CON-1337 Add tSchnorr keys to backup manager test

### DIFF
--- a/.github/workflows/team-channels.json
+++ b/.github/workflows/team-channels.json
@@ -1,6 +1,6 @@
 {
     "boundary-node": "eng-boundary-nodes",
-    "consensus": "eng-consensus",
+    "Consensus": "eng-consensus",
     "dept-crypto-library": "eng-crypto-mr",
     "dre": "eng-release-bots",
     "execution": "eng-execution-mrs",

--- a/rs/tests/consensus/backup_manager_test.rs
+++ b/rs/tests/consensus/backup_manager_test.rs
@@ -28,7 +28,9 @@ use ic_backup::{
     config::{ColdStorage, Config, SubnetConfig},
 };
 use ic_base_types::SubnetId;
-use ic_management_canister_types::{EcdsaCurve, EcdsaKeyId, MasterPublicKeyId};
+use ic_management_canister_types::{
+    EcdsaCurve, EcdsaKeyId, MasterPublicKeyId, SchnorrAlgorithm, SchnorrKeyId,
+};
 use ic_recovery::file_sync_helper::{download_binary, write_file};
 use ic_registry_subnet_type::SubnetType;
 use ic_tests::{

--- a/rs/tests/consensus/backup_manager_test.rs
+++ b/rs/tests/consensus/backup_manager_test.rs
@@ -170,10 +170,7 @@ pub fn test(env: TestEnv) {
         &nns_canister,
         env.topology_snapshot().root_subnet_id(),
         None,
-        vec![
-            MasterPublicKeyId::Ecdsa(make_key(KEY_ID1)),
-            MasterPublicKeyId::Ecdsa(make_key(KEY_ID2)),
-        ],
+        make_key_ids_for_all_schemes(),
         &log,
     );
 
@@ -523,12 +520,19 @@ fn download_binary_file(
     .expect("error downloading binaty");
 }
 
-const KEY_ID1: &str = "secp256k1";
-const KEY_ID2: &str = "secp256k1_2";
-
-fn make_key(name: &str) -> EcdsaKeyId {
-    EcdsaKeyId {
-        curve: EcdsaCurve::Secp256k1,
-        name: name.to_string(),
-    }
+fn make_key_ids_for_all_schemes() -> Vec<MasterPublicKeyId> {
+    vec![
+        MasterPublicKeyId::Ecdsa(EcdsaKeyId {
+            curve: EcdsaCurve::Secp256k1,
+            name: "some_ecdsa_key".to_string(),
+        }),
+        MasterPublicKeyId::Schnorr(SchnorrKeyId {
+            algorithm: SchnorrAlgorithm::Ed25519,
+            name: "some_eddsa_key".to_string(),
+        }),
+        MasterPublicKeyId::Schnorr(SchnorrKeyId {
+            algorithm: SchnorrAlgorithm::Bip340Secp256k1,
+            name: "some_bip340_key".to_string(),
+        }),
+    ]
 }


### PR DESCRIPTION
This will ensure that we can backup blocks containing tSchnorr payloads.