### PR TITLE
chore(IDX): disable run on diff for bazel-build-all-config-check

### DIFF
--- a/.github/workflows-source/ci-main.yml
+++ b/.github/workflows-source/ci-main.yml
@@ -118,7 +118,10 @@ jobs:
           BAZEL_TARGETS: "//rs/..."
           BAZEL_CI_CONFIG: "--config=check --config=ci --keep_going"
           # run on diff only if it is a pull request, otherwise run all targets
-          RUN_ON_DIFF_ONLY: ${{ contains(github.event_name, 'pull_request') && 'true' || 'false'}}
+          #RUN_ON_DIFF_ONLY: ${{ contains(github.event_name, 'pull_request') && 'true' || 'false'}}
+          # TODO: disabling until the following issue is resolved
+          # https://github.com/dfinity/ic/actions/runs/9699415138/job/26768332602
+          RUN_ON_DIFF_ONLY: false
 
   bazel-test-darwin-x86-64:
     name: Bazel Test Darwin x86-64

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -108,7 +108,10 @@ jobs:
           BAZEL_TARGETS: "//rs/..."
           BAZEL_CI_CONFIG: "--config=check --config=ci --keep_going"
           # run on diff only if it is a pull request, otherwise run all targets
-          RUN_ON_DIFF_ONLY: ${{ contains(github.event_name, 'pull_request') && 'true' || 'false'}}
+          #RUN_ON_DIFF_ONLY: ${{ contains(github.event_name, 'pull_request') && 'true' || 'false'}}
+          # TODO: disabling until the following issue is resolved
+          # https://github.com/dfinity/ic/actions/runs/9699415138/job/26768332602
+          RUN_ON_DIFF_ONLY: false
   bazel-test-darwin-x86-64:
     name: Bazel Test Darwin x86-64
     timeout-minutes: 120


### PR DESCRIPTION
Disabling run diff targets logic as we sometimes have issues that block users.