### PR TITLE
chore(IDX): darwin continue-on-error

### DIFF
--- a/.github/workflows-source/ci-main.yml
+++ b/.github/workflows-source/ci-main.yml
@@ -153,6 +153,9 @@ jobs:
       - <<: *before-script
       - name: Run Bazel Test Darwin x86-64
         id: bazel-test-darwin-x86-64
+        # TODO: remove when we flakiness is resolved or when we move to hosted runners
+        # settting to true to allow a job to pass when this step fails
+        continue-on-error: true
         if: steps.filter.outputs.bazel-test-darwin-x86-64 != 'false' || github.event_name == 'schedule'
         uses:  ./.github/actions/bazel-test-all/
         with:

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -147,6 +147,9 @@ jobs:
         run: ./gitlab-ci/src/ci-scripts/before-script.sh
       - name: Run Bazel Test Darwin x86-64
         id: bazel-test-darwin-x86-64
+        # TODO: remove when we flakiness is resolved or when we move to hosted runners
+        # settting to true to allow a job to pass when this step fails
+        continue-on-error: true
         if: steps.filter.outputs.bazel-test-darwin-x86-64 != 'false' || github.event_name == 'schedule'
         uses: ./.github/actions/bazel-test-all/
         with:


### PR DESCRIPTION
Temporarily setting `continue-on-error` to prevent a job from failing.