### PR TITLE
chore(CON13-02): Remove `make_ecdsa_signing_subnet_list_key` from the codebase

### DIFF
--- a/rs/consensus/tests/framework/mod.rs
+++ b/rs/consensus/tests/framework/mod.rs
@@ -59,7 +59,7 @@ pub fn setup_subnet<R: Rng + CryptoRng>(
     let data_provider = Arc::new(ProtoRegistryDataProvider::new());
     let registry_client = Arc::new(FakeRegistryClient::new(Arc::clone(&data_provider) as Arc<_>));
 
-    let threshold_keys_ids = vec![
+    let threshold_key_ids = vec![
         MasterPublicKeyId::Ecdsa(EcdsaKeyId {
             curve: EcdsaCurve::Secp256k1,
             name: "ecdsa_test_key".to_string(),
@@ -77,7 +77,7 @@ pub fn setup_subnet<R: Rng + CryptoRng>(
     let subnet_record = SubnetRecordBuilder::from(node_ids)
         .with_dkg_interval_length(19)
         .with_chain_key_config(ChainKeyConfig {
-            key_configs: threshold_keys
+            key_configs: threshold_key_ids
                 .iter()
                 .map(|key_id| KeyConfig {
                     key_id: key_id.clone(),
@@ -194,14 +194,16 @@ pub fn setup_subnet<R: Rng + CryptoRng>(
         .expect("Could not add node record.");
 
     // Add threshold signing subnet to registry
-    for key_id in threshold_keys {
+    for key_id in threshold_key_ids {
         data_provider
             .add(
                 &ic_registry_keys::make_chain_key_signing_subnet_list_key(&key_id),
                 registry_version,
-                Some(ic_protobuf::registry::crypto::v1::ChainKeySigningSubnetList {
-                    subnets: vec![subnet_id_into_protobuf(subnet_id)],
-                }),
+                Some(
+                    ic_protobuf::registry::crypto::v1::ChainKeySigningSubnetList {
+                        subnets: vec![subnet_id_into_protobuf(subnet_id)],
+                    },
+                ),
             )
             .expect("Could not add chain key signing subnet list");
     }

--- a/rs/consensus/tests/framework/mod.rs
+++ b/rs/consensus/tests/framework/mod.rs
@@ -77,11 +77,6 @@ pub fn setup_subnet<R: Rng + CryptoRng>(
     let subnet_record = SubnetRecordBuilder::from(node_ids)
         .with_dkg_interval_length(19)
         .with_chain_key_config(ChainKeyConfig {
-            // key_configs: vec![KeyConfig {
-            //     key_id: ecdsa_key_id.clone(),
-            //     pre_signatures_to_create_in_advance: 4,
-            //     max_queue_size: 40,
-            // }],
             key_configs: threshold_keys
                 .iter()
                 .map(|key_id| KeyConfig {

--- a/rs/consensus/tests/framework/mod.rs
+++ b/rs/consensus/tests/framework/mod.rs
@@ -204,7 +204,7 @@ pub fn setup_subnet<R: Rng + CryptoRng>(
             .add(
                 &ic_registry_keys::make_chain_key_signing_subnet_list_key(&key_id),
                 registry_version,
-                Some(ic_protobuf::registry::crypto::v1::EcdsaSigningSubnetList {
+                Some(ic_protobuf::registry::crypto::v1::ChainKeySigningSubnetList {
                     subnets: vec![subnet_id_into_protobuf(subnet_id)],
                 }),
             )

--- a/rs/consensus/tests/framework/mod.rs
+++ b/rs/consensus/tests/framework/mod.rs
@@ -16,7 +16,9 @@ pub use types::{
 use ic_crypto_temp_crypto::{NodeKeysToGenerate, TempCryptoComponent, TempCryptoComponentGeneric};
 use ic_crypto_test_utils_ni_dkg::{initial_dkg_transcript, InitialNiDkgConfig};
 use ic_interfaces_registry::RegistryClient;
-use ic_management_canister_types::{EcdsaCurve, EcdsaKeyId, MasterPublicKeyId};
+use ic_management_canister_types::{
+    EcdsaCurve, EcdsaKeyId, MasterPublicKeyId, SchnorrAlgorithm, SchnorrKeyId,
+};
 use ic_protobuf::registry::subnet::v1::{CatchUpPackageContents, InitialNiDkgTranscriptRecord};
 use ic_registry_client_fake::FakeRegistryClient;
 use ic_registry_client_helpers::crypto::CryptoRegistry;
@@ -56,19 +58,38 @@ pub fn setup_subnet<R: Rng + CryptoRng>(
     let registry_version = RegistryVersion::from(initial_version);
     let data_provider = Arc::new(ProtoRegistryDataProvider::new());
     let registry_client = Arc::new(FakeRegistryClient::new(Arc::clone(&data_provider) as Arc<_>));
-    let ecdsa_key_id = EcdsaKeyId {
-        curve: EcdsaCurve::Secp256k1,
-        name: "test_key".to_string(),
-    };
+
+    let threshold_keys = vec![
+        MasterPublicKeyId::Ecdsa(EcdsaKeyId {
+            curve: EcdsaCurve::Secp256k1,
+            name: "ecdsa_test_key".to_string(),
+        }),
+        MasterPublicKeyId::Schnorr(SchnorrKeyId {
+            algorithm: SchnorrAlgorithm::Ed25519,
+            name: "ed25519_test_key".to_string(),
+        }),
+        MasterPublicKeyId::Schnorr(SchnorrKeyId {
+            algorithm: SchnorrAlgorithm::Bip340Secp256k1,
+            name: "bip340_test_key".to_string(),
+        }),
+    ];
 
     let subnet_record = SubnetRecordBuilder::from(node_ids)
         .with_dkg_interval_length(19)
         .with_chain_key_config(ChainKeyConfig {
-            key_configs: vec![KeyConfig {
-                key_id: MasterPublicKeyId::Ecdsa(ecdsa_key_id.clone()),
-                pre_signatures_to_create_in_advance: 4,
-                max_queue_size: 40,
-            }],
+            // key_configs: vec![KeyConfig {
+            //     key_id: ecdsa_key_id.clone(),
+            //     pre_signatures_to_create_in_advance: 4,
+            //     max_queue_size: 40,
+            // }],
+            key_configs: threshold_keys
+                .iter()
+                .map(|key_id| KeyConfig {
+                    key_id: key_id.clone(),
+                    pre_signatures_to_create_in_advance: 4,
+                    max_queue_size: 40,
+                })
+                .collect(),
             ..ChainKeyConfig::default()
         })
         .build();
@@ -177,17 +198,18 @@ pub fn setup_subnet<R: Rng + CryptoRng>(
         )
         .expect("Could not add node record.");
 
-    // Add ECDSA signing subnet to registry
-    data_provider
-        .add(
-            &ic_registry_keys::make_ecdsa_signing_subnet_list_key(&ecdsa_key_id),
-            registry_version,
-            Some(ic_protobuf::registry::crypto::v1::EcdsaSigningSubnetList {
-                subnets: vec![subnet_id_into_protobuf(subnet_id)],
-            }),
-        )
-        .expect("Could not add ECDSA signing subnet list");
-
+    // Add threshold signing subnet to registry
+    for key_id in threshold_keys {
+        data_provider
+            .add(
+                &ic_registry_keys::make_chain_key_signing_subnet_list_key(&key_id),
+                registry_version,
+                Some(ic_protobuf::registry::crypto::v1::EcdsaSigningSubnetList {
+                    subnets: vec![subnet_id_into_protobuf(subnet_id)],
+                }),
+            )
+            .expect("Could not add ECDSA signing subnet list");
+    }
     registry_client.reload();
     registry_client.update_to_latest_version();
 

--- a/rs/consensus/tests/framework/mod.rs
+++ b/rs/consensus/tests/framework/mod.rs
@@ -59,7 +59,7 @@ pub fn setup_subnet<R: Rng + CryptoRng>(
     let data_provider = Arc::new(ProtoRegistryDataProvider::new());
     let registry_client = Arc::new(FakeRegistryClient::new(Arc::clone(&data_provider) as Arc<_>));
 
-    let threshold_keys = vec![
+    let threshold_keys_ids = vec![
         MasterPublicKeyId::Ecdsa(EcdsaKeyId {
             curve: EcdsaCurve::Secp256k1,
             name: "ecdsa_test_key".to_string(),

--- a/rs/consensus/tests/framework/mod.rs
+++ b/rs/consensus/tests/framework/mod.rs
@@ -208,7 +208,7 @@ pub fn setup_subnet<R: Rng + CryptoRng>(
                     subnets: vec![subnet_id_into_protobuf(subnet_id)],
                 }),
             )
-            .expect("Could not add ECDSA signing subnet list");
+            .expect("Could not add chain key signing subnet list");
     }
     registry_client.reload();
     registry_client.update_to_latest_version();

--- a/rs/registry/keys/src/lib.rs
+++ b/rs/registry/keys/src/lib.rs
@@ -35,10 +35,6 @@ pub const DATA_CENTER_KEY_PREFIX: &str = "data_center_record_";
 pub const ECDSA_SIGNING_SUBNET_LIST_KEY_PREFIX: &str = "key_id_";
 pub const CHAIN_KEY_SIGNING_SUBNET_LIST_KEY_PREFIX: &str = "master_public_key_id_";
 
-pub fn make_ecdsa_signing_subnet_list_key(key_id: &EcdsaKeyId) -> String {
-    format!("{}{}", ECDSA_SIGNING_SUBNET_LIST_KEY_PREFIX, key_id)
-}
-
 pub fn get_ecdsa_key_id_from_signing_subnet_list_key(
     signing_subnet_list_key: &str,
 ) -> Result<EcdsaKeyId, RegistryClientError> {
@@ -441,24 +437,6 @@ mod tests {
         let wrong_key = make_crypto_tls_cert_key(node_id);
         let parsed = maybe_parse_crypto_threshold_signing_pubkey_key(&wrong_key);
         assert!(parsed.is_none());
-    }
-
-    #[test]
-    fn ecdsa_signing_subnet_list_key_round_trips() {
-        for curve in EcdsaCurve::iter() {
-            for name in ["secp256k1", "", "other_key", "other key", "other:key"] {
-                let key_id = EcdsaKeyId {
-                    curve,
-                    name: name.to_string(),
-                };
-                let signing_subnet_list_key = make_ecdsa_signing_subnet_list_key(&key_id);
-                assert_eq!(
-                    get_ecdsa_key_id_from_signing_subnet_list_key(&signing_subnet_list_key)
-                        .unwrap(),
-                    key_id
-                );
-            }
-        }
     }
 
     #[test]


### PR DESCRIPTION
There was a test in consensus `framework` left over, that was still not fully migrated to use `make_chain_key_signing_subnet_list`.

This MR migrates the test, (even though it seems we are not even using Threshold Sigs in these tests), and can then remove `make_ecdsa_signing_subnet_list_key` and its test altogether.