### PR TITLE
fix(IDX): add missing package to cargo workspace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12150,6 +12150,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ic-validator-http-request-arbitrary"
+version = "0.9.0"
+dependencies = [
+ "arbitrary",
+ "ic-base-types",
+ "ic-crypto-tree-hash",
+ "ic-types",
+]
+
+[[package]]
 name = "ic-validator-http-request-test-utils"
 version = "0.9.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -365,6 +365,7 @@ members = [
     "rs/utils/lru_cache",
     "rs/utils/rustfmt",
     "rs/validator",
+    "rs/validator/http_request_arbitrary",
     "rs/validator/ingress_message",
     "rs/validator/ingress_message/test_canister",
     "rs/workload_generator",


### PR DESCRIPTION
This adds the `rs/validator/http_request_arbitrary` package to the top-level `Cargo.toml`. The package was missing from the cargo build, though it is already included in the Bazel build.