### PR TITLE
chore(schnorr): CON-1349 Manually implement `Debug` for `ThresholdSchnorrSigInputRef` and omit full message

### DIFF
--- a/rs/types/types/src/consensus/idkg/schnorr.rs
+++ b/rs/types/types/src/consensus/idkg/schnorr.rs
@@ -10,6 +10,7 @@ use ic_protobuf::proxy::{try_from_option_field, ProxyDecodeError};
 use ic_protobuf::types::v1 as pb;
 use serde::{Deserialize, Serialize};
 use std::convert::{AsMut, AsRef, TryFrom, TryInto};
+use std::fmt;
 use std::hash::Hash;
 
 use super::{
@@ -199,13 +200,29 @@ impl TryFrom<&pb::PreSignatureTranscriptRef> for PreSignatureTranscriptRef {
 
 /// Counterpart of ThresholdSchnorrSigInputs that holds transcript references,
 /// instead of the transcripts.
-#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(test, derive(ExhaustiveSet))]
 pub struct ThresholdSchnorrSigInputsRef {
     pub derivation_path: ExtendedDerivationPath,
     pub message: Vec<u8>,
     pub nonce: Randomness,
     pub presig_transcript_ref: PreSignatureTranscriptRef,
+}
+
+impl fmt::Debug for ThresholdSchnorrSigInputsRef {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "ThresholdSchnorrSigInputsRef {{ ")?;
+        write!(f, "derivation_path: {:?}", self.derivation_path)?;
+        write!(f, ", message_length: {} bytes", self.message.len())?;
+        write!(f, ", nonce: 0x{}", hex::encode(self.nonce.as_ref()))?;
+        write!(
+            f,
+            ", presig_transcript_ref: {:?}",
+            self.presig_transcript_ref
+        )?;
+        write!(f, " }}")?;
+        Ok(())
+    }
 }
 
 #[derive(Clone, Debug)]

--- a/rs/types/types/src/consensus/idkg/schnorr.rs
+++ b/rs/types/types/src/consensus/idkg/schnorr.rs
@@ -211,17 +211,12 @@ pub struct ThresholdSchnorrSigInputsRef {
 
 impl fmt::Debug for ThresholdSchnorrSigInputsRef {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "ThresholdSchnorrSigInputsRef {{ ")?;
-        write!(f, "derivation_path: {:?}", self.derivation_path)?;
-        write!(f, ", message_length: {} bytes", self.message.len())?;
-        write!(f, ", nonce: 0x{}", hex::encode(self.nonce.as_ref()))?;
-        write!(
-            f,
-            ", presig_transcript_ref: {:?}",
-            self.presig_transcript_ref
-        )?;
-        write!(f, " }}")?;
-        Ok(())
+        f.debug_struct("ThresholdSchnorrSigInputsRef")
+            .field("derivation_path", &self.derivation_path)
+            .field("message_length_in_bytes", &self.message.len())
+            .field("nonce", &hex::encode(self.nonce.as_ref()))
+            .field("presig_transcript_ref", &self.presig_transcript_ref)
+            .finish()
     }
 }
 


### PR DESCRIPTION
Messages to be signed by tSchnorr may be up to 10 MiB in length, and we shouldn't print them in their entirety. This MR implements the `Debug` trait for `ThresholdSchnorrSigInputRef`, such that only the message length is printed.