### PR TITLE
fix(recovery): CON-1344 Reduce SSH timeout and number of attempts in `ic-recovery`

### DIFF
--- a/rs/recovery/src/file_sync_helper.rs
+++ b/rs/recovery/src/file_sync_helper.rs
@@ -220,6 +220,6 @@ mod tests {
                 "/tmp/src",
                 "/tmp/target",
                 "-e",
-                "ssh -o StrictHostKeyChecking=no -o NumberOfPasswordPrompts=0 -o ConnectionAttempts=30 -o ConnectTimeout=60 -A -i /tmp/key_file"]);
+                "ssh -o StrictHostKeyChecking=no -o NumberOfPasswordPrompts=0 -o ConnectionAttempts=4 -o ConnectTimeout=15 -A -i /tmp/key_file"]);
     }
 }

--- a/rs/recovery/src/ssh_helper.rs
+++ b/rs/recovery/src/ssh_helper.rs
@@ -10,9 +10,9 @@ const SSH_ARGS: &[&str] = &[
     "-o",
     "NumberOfPasswordPrompts=0",
     "-o",
-    "ConnectionAttempts=30",
+    "ConnectionAttempts=4",
     "-o",
-    "ConnectTimeout=60",
+    "ConnectTimeout=15",
     "-A",
 ];
 


### PR DESCRIPTION
During a recent recovery it became clear that the SSH timeout is too high. The execution of a recovery step got stuck while trying to download the certification pool of an unavailable node, with no way to skip it.