### PR TITLE
refactor(consensus): Merge imports in consensus crate

### DIFF
--- a/rs/consensus/src/certification.rs
+++ b/rs/consensus/src/certification.rs
@@ -3,9 +3,9 @@
 //! layers by signing state hashes.
 use ic_consensus_utils::crypto::{Aggregate, SignVerify};
 use ic_interfaces::crypto::{Crypto, ThresholdSigner};
-use ic_types::signature::*;
 use ic_types::{
     consensus::certification::CertificationContent, crypto::threshold_sig::ni_dkg::NiDkgId,
+    signature::*,
 };
 
 mod certifier;

--- a/rs/consensus/src/certification/certifier.rs
+++ b/rs/consensus/src/certification/certifier.rs
@@ -1,6 +1,7 @@
-use crate::consensus::MINIMUM_CHAIN_LENGTH;
-
-use super::{verifier::VerifierImpl, CertificationCrypto};
+use crate::{
+    certification::{CertificationCrypto, VerifierImpl},
+    consensus::MINIMUM_CHAIN_LENGTH,
+};
 use ic_consensus_utils::{
     active_high_threshold_transcript, aggregate, membership::Membership, registry_version_at_height,
 };
@@ -15,21 +16,21 @@ use ic_interfaces_state_manager::StateManager;
 use ic_logger::{debug, error, trace, ReplicaLogger};
 use ic_metrics::{buckets::decimal_buckets, MetricsRegistry};
 use ic_replicated_state::ReplicatedState;
-use ic_types::consensus::{Committee, HasCommittee, HasHeight};
 use ic_types::{
     artifact::{CertificationMessageId, Priority, PriorityFn},
     artifact_kind::CertificationArtifact,
-    consensus::certification::{
-        Certification, CertificationContent, CertificationMessage, CertificationShare,
+    consensus::{
+        certification::{
+            Certification, CertificationContent, CertificationMessage, CertificationShare,
+        },
+        Committee, HasCommittee, HasHeight,
     },
     crypto::Signed,
     replica_config::ReplicaConfig,
     CryptoHashOfPartialState, Height,
 };
 use prometheus::{Histogram, IntCounter, IntGauge};
-use std::cell::RefCell;
-use std::sync::Arc;
-use std::time::Instant;
+use std::{cell::RefCell, sync::Arc, time::Instant};
 use tokio::sync::watch;
 
 /// The Certification component, processing the changes on the certification
@@ -617,17 +618,18 @@ mod tests {
     use super::*;
     use ic_artifact_pool::certification_pool::CertificationPoolImpl;
     use ic_consensus_mocks::{dependencies, Dependencies};
-    use ic_interfaces::certification::CertificationPool;
-    use ic_interfaces::p2p::consensus::{MutablePool, UnvalidatedArtifact};
+    use ic_interfaces::{
+        certification::CertificationPool,
+        p2p::consensus::{MutablePool, UnvalidatedArtifact},
+    };
     use ic_test_utilities_consensus::fake::*;
     use ic_test_utilities_logger::with_test_replica_logger;
     use ic_test_utilities_types::ids::{node_test_id, subnet_test_id};
-    use ic_types::artifact::CertificationMessageId;
-    use ic_types::consensus::certification::CertificationMessageHash;
     use ic_types::{
-        artifact::Priority,
+        artifact::{CertificationMessageId, Priority},
         consensus::certification::{
-            Certification, CertificationContent, CertificationMessage, CertificationShare,
+            Certification, CertificationContent, CertificationMessage, CertificationMessageHash,
+            CertificationShare,
         },
         crypto::{
             threshold_sig::ni_dkg::{NiDkgId, NiDkgTag, NiDkgTargetSubnet},

--- a/rs/consensus/src/consensus/batch_delivery.rs
+++ b/rs/consensus/src/consensus/batch_delivery.rs
@@ -24,14 +24,16 @@ use ic_protobuf::{
     log::consensus_log_entry::v1::ConsensusLogEntry,
     registry::{crypto::v1::PublicKey as PublicKeyProto, subnet::v1::InitialNiDkgTranscriptRecord},
 };
-use ic_types::{batch::BatchSummary, crypto::threshold_sig::ThresholdSigPublicKey};
 use ic_types::{
-    batch::{Batch, BatchMessages, BlockmakerMetrics, ConsensusResponse},
+    batch::{Batch, BatchMessages, BatchSummary, BlockmakerMetrics, ConsensusResponse},
     consensus::{
         idkg::{self, CompletedSignature},
         Block,
     },
-    crypto::threshold_sig::ni_dkg::{NiDkgId, NiDkgTag, NiDkgTranscript},
+    crypto::threshold_sig::{
+        ni_dkg::{NiDkgId, NiDkgTag, NiDkgTranscript},
+        ThresholdSigPublicKey,
+    },
     messages::{CallbackId, Payload, RejectContext},
     Height, PrincipalId, Randomness, ReplicaVersion, SubnetId,
 };

--- a/rs/consensus/src/consensus/finalizer.rs
+++ b/rs/consensus/src/consensus/finalizer.rs
@@ -250,13 +250,12 @@ mod tests {
     };
     use ic_test_utilities_registry::SubnetRecordBuilder;
     use ic_test_utilities_types::ids::{node_test_id, subnet_test_id};
-    use ic_types::consensus::{HasHeight, HashedBlock};
-    use ic_types::messages::{Payload, NO_DEADLINE};
     use ic_types::{
+        consensus::{HasHeight, HashedBlock},
         crypto::threshold_sig::ni_dkg::{NiDkgId, NiDkgTag, NiDkgTargetId, NiDkgTargetSubnet},
-        messages::{CallbackId, Request},
+        messages::{CallbackId, Payload, Request, NO_DEADLINE},
+        CanisterId, Cycles, PrincipalId, RegistryVersion, SubnetId,
     };
-    use ic_types::{CanisterId, Cycles, PrincipalId, RegistryVersion, SubnetId};
     use std::{
         collections::{BTreeMap, BTreeSet},
         str::FromStr,

--- a/rs/consensus/src/consensus/malicious_consensus.rs
+++ b/rs/consensus/src/consensus/malicious_consensus.rs
@@ -8,12 +8,14 @@ use crate::consensus::{
 use ic_consensus_utils::pool_reader::PoolReader;
 use ic_interfaces::consensus_pool::{ChangeAction, ChangeSet, HeightRange};
 use ic_logger::{info, trace, ReplicaLogger};
-use ic_types::consensus::{
-    hashed, Block, BlockMetadata, BlockProposal, ConsensusMessage, ConsensusMessageHashable,
-    FinalizationContent, FinalizationShare, HasHeight, HashedBlock, NotarizationShare, Rank,
+use ic_types::{
+    consensus::{
+        hashed, Block, BlockMetadata, BlockProposal, ConsensusMessage, ConsensusMessageHashable,
+        FinalizationContent, FinalizationShare, HasHeight, HashedBlock, NotarizationShare, Rank,
+    },
+    malicious_flags::MaliciousFlags,
+    Time,
 };
-use ic_types::malicious_flags::MaliciousFlags;
-use ic_types::Time;
 use std::time::Duration;
 
 /// Return a `ChangeSet` that moves all block proposals in the range to the

--- a/rs/consensus/src/consensus/notary.rs
+++ b/rs/consensus/src/consensus/notary.rs
@@ -202,15 +202,13 @@ mod tests {
     //! Notary unit tests
     use super::*;
     use ic_consensus_mocks::{dependencies_with_subnet_params, Dependencies};
-    use ic_interfaces::consensus_pool::ConsensusPool;
-    use ic_interfaces::time_source::TimeSource;
+    use ic_interfaces::{consensus_pool::ConsensusPool, time_source::TimeSource};
     use ic_logger::replica_logger::no_op_logger;
     use ic_metrics::MetricsRegistry;
     use ic_test_utilities_consensus::fake::*;
     use ic_test_utilities_registry::SubnetRecordBuilder;
     use ic_test_utilities_types::ids::{node_test_id, subnet_test_id};
-    use std::sync::Arc;
-    use std::time::Duration;
+    use std::{sync::Arc, time::Duration};
 
     /// Do basic notary validations
     #[test]

--- a/rs/consensus/src/consensus/random_tape_maker.rs
+++ b/rs/consensus/src/consensus/random_tape_maker.rs
@@ -188,8 +188,7 @@ mod tests {
     use super::*;
     use crate::consensus::add_all_to_validated;
     use ic_consensus_mocks::{dependencies, Dependencies};
-    use ic_interfaces::p2p::consensus::MutablePool;
-    use ic_interfaces::time_source::TimeSource;
+    use ic_interfaces::{p2p::consensus::MutablePool, time_source::TimeSource};
     use ic_logger::replica_logger::no_op_logger;
     use ic_test_utilities::message_routing::FakeMessageRouting;
     use ic_test_utilities_consensus::fake::*;

--- a/rs/consensus/src/consensus/share_aggregator.rs
+++ b/rs/consensus/src/consensus/share_aggregator.rs
@@ -3,23 +3,22 @@
 //! from random beacon shares, Notarizations from notarization shares and
 //! Finalizations from finalization shares.
 use crate::consensus::random_tape_maker::RANDOM_TAPE_CHECK_MAX_HEIGHT_RANGE;
-use ic_consensus_utils::crypto::ConsensusCrypto;
-use ic_consensus_utils::membership::Membership;
-use ic_consensus_utils::pool_reader::PoolReader;
 use ic_consensus_utils::{
     active_high_threshold_transcript, active_low_threshold_transcript, aggregate,
+    crypto::ConsensusCrypto, membership::Membership, pool_reader::PoolReader,
     registry_version_at_height,
 };
 use ic_interfaces::messaging::MessageRouting;
 use ic_logger::ReplicaLogger;
-use ic_types::consensus::{
-    CatchUpContent, ConsensusMessage, ConsensusMessageHashable, FinalizationContent, HasHeight,
-    RandomTapeContent,
+use ic_types::{
+    consensus::{
+        CatchUpContent, ConsensusMessage, ConsensusMessageHashable, FinalizationContent, HasHeight,
+        RandomTapeContent,
+    },
+    crypto::Signed,
+    Height,
 };
-use ic_types::crypto::Signed;
-use ic_types::Height;
-use std::cmp::min;
-use std::sync::Arc;
+use std::{cmp::min, sync::Arc};
 
 /// The ShareAggregator is responsible for aggregating shares of random beacons,
 /// notarizations, and finalizations into full objects

--- a/rs/consensus/src/consensus/validator.rs
+++ b/rs/consensus/src/consensus/validator.rs
@@ -1776,23 +1776,21 @@ pub mod test {
     use ic_test_utilities_consensus::{assert_changeset_matches_pattern, fake::*, matches_pattern};
     use ic_test_utilities_registry::{add_subnet_record, SubnetRecordBuilder};
     use ic_test_utilities_time::FastForwardTimeSource;
-    use ic_test_utilities_types::ids::{node_test_id, subnet_test_id};
-    use ic_test_utilities_types::messages::SignedIngressBuilder;
-    use ic_types::batch::IngressPayload;
-    use ic_types::crypto::BasicSig;
-    use ic_types::crypto::BasicSigOf;
-    use ic_types::Time;
+    use ic_test_utilities_types::{
+        ids::{node_test_id, subnet_test_id},
+        messages::SignedIngressBuilder,
+    };
     use ic_types::{
-        batch::BatchPayload,
+        batch::{BatchPayload, IngressPayload},
         consensus::{
             dkg, idkg::PreSigId, BlockPayload, CatchUpPackageShare, DataPayload, EquivocationProof,
             Finalization, FinalizationShare, HashedBlock, HashedRandomBeacon, NotarizationShare,
             Payload, RandomBeaconContent, RandomTapeContent, SummaryPayload,
         },
-        crypto::{CombinedMultiSig, CombinedMultiSigOf, CryptoHash},
+        crypto::{BasicSig, BasicSigOf, CombinedMultiSig, CombinedMultiSigOf, CryptoHash},
         replica_config::ReplicaConfig,
         signature::ThresholdSignature,
-        CryptoHashOfState, ReplicaVersion,
+        CryptoHashOfState, ReplicaVersion, Time,
     };
     use std::{
         borrow::Borrow,

--- a/rs/consensus/src/dkg.rs
+++ b/rs/consensus/src/dkg.rs
@@ -2,11 +2,13 @@
 //! component into the consensus algorithm that is implemented within this
 //! crate.
 
-use crate::consensus::{check_protocol_version, dkg_key_manager::DkgKeyManager};
-use crate::ecdsa::utils::get_chain_key_config_if_enabled;
-use crate::ecdsa::{
-    make_bootstrap_summary, payload_builder::make_bootstrap_summary_with_initial_dealings,
-    utils::inspect_chain_key_initializations,
+use crate::{
+    consensus::{check_protocol_version, dkg_key_manager::DkgKeyManager},
+    ecdsa::{
+        make_bootstrap_summary,
+        payload_builder::make_bootstrap_summary_with_initial_dealings,
+        utils::{get_chain_key_config_if_enabled, inspect_chain_key_initializations},
+    },
 };
 use ic_consensus_utils::crypto::ConsensusCrypto;
 use ic_interfaces::{
@@ -20,8 +22,6 @@ use ic_logger::{error, info, warn, ReplicaLogger};
 use ic_metrics::buckets::{decimal_buckets, linear_buckets};
 use ic_protobuf::registry::subnet::v1::CatchUpPackageContents;
 use ic_registry_client_helpers::subnet::SubnetRegistry;
-use ic_types::consensus::SummaryPayload;
-use ic_types::crypto::{CombinedThresholdSig, CombinedThresholdSigOf, CryptoHash};
 use ic_types::{
     artifact::{Priority, PriorityFn},
     artifact_kind::DkgArtifact,
@@ -29,17 +29,16 @@ use ic_types::{
     consensus::{
         dkg::{DealingContent, DkgMessageId, Message},
         idkg, Block, BlockPayload, CatchUpContent, CatchUpPackage, HashedBlock, HashedRandomBeacon,
-        Payload, RandomBeaconContent, Rank,
+        Payload, RandomBeaconContent, Rank, SummaryPayload,
     },
     crypto::{
         crypto_hash,
         threshold_sig::ni_dkg::{config::NiDkgConfig, NiDkgId, NiDkgTag, NiDkgTargetSubnet},
-        Signed,
+        CombinedThresholdSig, CombinedThresholdSigOf, CryptoHash, Signed,
     },
     signature::ThresholdSignature,
     Height, NodeId, RegistryVersion, SubnetId, Time,
 };
-pub use payload_builder::{create_payload, make_genesis_summary, PayloadCreationError};
 pub(crate) use payload_validator::{DkgPayloadValidationFailure, InvalidDkgPayloadReason};
 use phantom_newtype::Id;
 use prometheus::Histogram;
@@ -54,6 +53,8 @@ pub(crate) mod payload_validator;
 #[cfg(test)]
 mod test_utils;
 mod utils;
+
+pub use payload_builder::{create_payload, make_genesis_summary, PayloadCreationError};
 
 // The maximal number of DKGs for other subnets we want to run in one interval.
 const MAX_REMOTE_DKGS_PER_INTERVAL: usize = 1;
@@ -585,8 +586,7 @@ fn bootstrap_ecdsa_summary(
 
 #[cfg(test)]
 mod tests {
-    use super::test_utils::complement_state_manager_with_remote_dkg_requests;
-    use super::*;
+    use super::{test_utils::complement_state_manager_with_remote_dkg_requests, *};
     use ic_artifact_pool::dkg_pool::DkgPoolImpl;
     use ic_consensus_mocks::{
         dependencies, dependencies_with_subnet_params,

--- a/rs/consensus/src/dkg/payload_builder.rs
+++ b/rs/consensus/src/dkg/payload_builder.rs
@@ -795,8 +795,7 @@ pub fn make_genesis_summary(
 
 #[cfg(test)]
 mod tests {
-    use super::super::test_utils::complement_state_manager_with_remote_dkg_requests;
-    use super::*;
+    use super::{super::test_utils::complement_state_manager_with_remote_dkg_requests, *};
     use ic_consensus_mocks::{
         dependencies_with_subnet_params, dependencies_with_subnet_records_with_raw_state_manager,
         Dependencies,

--- a/rs/consensus/src/dkg/payload_validator.rs
+++ b/rs/consensus/src/dkg/payload_validator.rs
@@ -243,9 +243,9 @@ mod tests {
     use ic_test_utilities_consensus::fake::FakeContentSigner;
     use ic_test_utilities_registry::SubnetRecordBuilder;
     use ic_test_utilities_types::ids::{node_test_id, subnet_test_id};
-    use ic_types::{batch::BatchPayload, consensus::dkg::DealingContent};
     use ic_types::{
-        consensus::{dkg, idkg, DataPayload, Payload},
+        batch::BatchPayload,
+        consensus::{dkg, dkg::DealingContent, idkg, DataPayload, Payload},
         crypto::threshold_sig::ni_dkg::{NiDkgDealing, NiDkgId, NiDkgTag, NiDkgTargetSubnet},
         RegistryVersion,
     };

--- a/rs/consensus/src/dkg/test_utils.rs
+++ b/rs/consensus/src/dkg/test_utils.rs
@@ -2,10 +2,8 @@ use ic_replicated_state::metadata_state::subnet_call_context_manager::{
     SetupInitialDkgContext, SubnetCallContext,
 };
 use ic_test_utilities::state_manager::RefMockStateManager;
-use ic_test_utilities_types::ids::node_test_id;
-use ic_test_utilities_types::messages::RequestBuilder;
-use ic_types::crypto::threshold_sig::ni_dkg::NiDkgTargetId;
-use ic_types::{Height, RegistryVersion};
+use ic_test_utilities_types::{ids::node_test_id, messages::RequestBuilder};
+use ic_types::{crypto::threshold_sig::ni_dkg::NiDkgTargetId, Height, RegistryVersion};
 use std::sync::Arc;
 
 pub(super) fn complement_state_manager_with_remote_dkg_requests(


### PR DESCRIPTION
This PR merges and organizes the imports of the consensus crate (except the ecdsa submodule, which we should do separately at some point).