### PR TITLE
fix(IDX): align rosetta deps

### DIFF
--- a/Cargo.Bazel.Fuzzing.json.lock
+++ b/Cargo.Bazel.Fuzzing.json.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "b247ef9162fa1f00966a494647064891c0eaf9a60194f4b296d11a8fcf0da440",
+  "checksum": "93bfcb06da59a01bffd3d4673b873b0d654f691bc97e2317ea54bce3c2d87a26",
   "crates": {
     "abnf 0.12.0": {
       "name": "abnf",
@@ -34956,30 +34956,38 @@
         ],
         "crate_features": {
           "common": [
-            "elf",
-            "errno",
             "general",
             "ioctl",
             "no_std"
           ],
           "selects": {
             "aarch64-unknown-linux-gnu": [
+              "elf",
+              "errno",
               "prctl",
               "system"
             ],
             "aarch64-unknown-nixos-gnu": [
+              "elf",
+              "errno",
               "prctl",
               "system"
             ],
             "arm-unknown-linux-gnueabi": [
+              "elf",
+              "errno",
               "prctl",
               "system"
             ],
             "armv7-unknown-linux-gnueabi": [
+              "elf",
+              "errno",
               "prctl",
               "system"
             ],
             "i686-unknown-linux-gnu": [
+              "elf",
+              "errno",
               "prctl",
               "system"
             ],
@@ -34992,10 +35000,14 @@
               "system"
             ],
             "x86_64-unknown-linux-gnu": [
+              "elf",
+              "errno",
               "prctl",
               "system"
             ],
             "x86_64-unknown-nixos-gnu": [
+              "elf",
+              "errno",
               "prctl",
               "system"
             ]

--- a/Cargo.Bazel.json.lock
+++ b/Cargo.Bazel.json.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "4bdf46f1f0aa26a4541b4a3abea2ff8849949d29bced733835fd9efac6405194",
+  "checksum": "1a9a8930729d40296f094b770a48d7eb9050c3ff157aa5ec0991fe3f164b2f8a",
   "crates": {
     "abnf 0.12.0": {
       "name": "abnf",
@@ -35002,30 +35002,38 @@
         ],
         "crate_features": {
           "common": [
-            "elf",
-            "errno",
             "general",
             "ioctl",
             "no_std"
           ],
           "selects": {
             "aarch64-unknown-linux-gnu": [
+              "elf",
+              "errno",
               "prctl",
               "system"
             ],
             "aarch64-unknown-nixos-gnu": [
+              "elf",
+              "errno",
               "prctl",
               "system"
             ],
             "arm-unknown-linux-gnueabi": [
+              "elf",
+              "errno",
               "prctl",
               "system"
             ],
             "armv7-unknown-linux-gnueabi": [
+              "elf",
+              "errno",
               "prctl",
               "system"
             ],
             "i686-unknown-linux-gnu": [
+              "elf",
+              "errno",
               "prctl",
               "system"
             ],
@@ -35038,10 +35046,14 @@
               "system"
             ],
             "x86_64-unknown-linux-gnu": [
+              "elf",
+              "errno",
               "prctl",
               "system"
             ],
             "x86_64-unknown-nixos-gnu": [
+              "elf",
+              "errno",
               "prctl",
               "system"
             ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,6 +86,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+ "zstd 0.12.4",
 ]
 
 [[package]]
@@ -8721,7 +8722,6 @@ name = "ic-ledger-canister-blocks-synchronizer"
 version = "0.1.0"
 dependencies = [
  "actix-rt",
- "actix-web",
  "async-trait",
  "candid",
  "chrono",
@@ -8739,7 +8739,6 @@ dependencies = [
  "proptest",
  "rusqlite",
  "serde",
- "serde_bytes",
  "tokio",
  "tracing",
  "url",

--- a/rs/rosetta-api/Cargo.toml
+++ b/rs/rosetta-api/Cargo.toml
@@ -8,12 +8,7 @@ default-run = "ic-rosetta-api"
 
 [dependencies]
 actix-rt = "2.2.0"
-actix-web = { version = "4.0.1", default-features = false, features = [
-    "compress-brotli",
-    "compress-gzip",
-    "cookies",
-    "macros",
-] }
+actix-web = "4.0.1"
 anyhow = { workspace = true }
 async-trait = { workspace = true }
 base64 = { workspace = true }

--- a/rs/rosetta-api/ledger_canister_blocks_synchronizer/BUILD.bazel
+++ b/rs/rosetta-api/ledger_canister_blocks_synchronizer/BUILD.bazel
@@ -28,7 +28,6 @@ PROC_MACRO_DEPENDENCIES = [
 TEST_DEPENDENCIES = [
     "//rs/rosetta-api/ledger_canister_blocks_synchronizer/test_utils",
     "@crate_index//:actix-rt",
-    "@crate_index//:actix-web",
     "@crate_index//:proptest",
 ]
 

--- a/rs/rosetta-api/ledger_canister_blocks_synchronizer/Cargo.toml
+++ b/rs/rosetta-api/ledger_canister_blocks_synchronizer/Cargo.toml
@@ -27,10 +27,8 @@ url = "2.2.1"
 
 [dev-dependencies]
 actix-rt = "2.2.0"
-actix-web = { version = "4.0.1", default-features = false, features = ["macros", "compress-brotli", "compress-gzip", "cookies"] }
 ic-ledger-canister-blocks-synchronizer-test-utils = { path = "test_utils" }
 proptest = "1.0"
-serde_bytes = { workspace = true }
 
 [lib]
 path = "src/lib.rs"


### PR DESCRIPTION
This updates the cargo build to remove the `actix-web` & `serde_bytes` dependencies from the ledger canister blocks synchronizer, and to remove the `actix-web` custom features for the top-level `rosetta` package. This aligns the rosetta cargo build a bit more with the Bazel configuration.