### PR TITLE
fix(IDX): remove unused async-socks5

### DIFF
--- a/Cargo.Bazel.Fuzzing.json.lock
+++ b/Cargo.Bazel.Fuzzing.json.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "b247ef9162fa1f00966a494647064891c0eaf9a60194f4b296d11a8fcf0da440",
+  "checksum": "93bfcb06da59a01bffd3d4673b873b0d654f691bc97e2317ea54bce3c2d87a26",
   "crates": {
     "abnf 0.12.0": {
       "name": "abnf",
@@ -34956,30 +34956,38 @@
         ],
         "crate_features": {
           "common": [
-            "elf",
-            "errno",
             "general",
             "ioctl",
             "no_std"
           ],
           "selects": {
             "aarch64-unknown-linux-gnu": [
+              "elf",
+              "errno",
               "prctl",
               "system"
             ],
             "aarch64-unknown-nixos-gnu": [
+              "elf",
+              "errno",
               "prctl",
               "system"
             ],
             "arm-unknown-linux-gnueabi": [
+              "elf",
+              "errno",
               "prctl",
               "system"
             ],
             "armv7-unknown-linux-gnueabi": [
+              "elf",
+              "errno",
               "prctl",
               "system"
             ],
             "i686-unknown-linux-gnu": [
+              "elf",
+              "errno",
               "prctl",
               "system"
             ],
@@ -34992,10 +35000,14 @@
               "system"
             ],
             "x86_64-unknown-linux-gnu": [
+              "elf",
+              "errno",
               "prctl",
               "system"
             ],
             "x86_64-unknown-nixos-gnu": [
+              "elf",
+              "errno",
               "prctl",
               "system"
             ]

--- a/Cargo.Bazel.Fuzzing.json.lock
+++ b/Cargo.Bazel.Fuzzing.json.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "93bfcb06da59a01bffd3d4673b873b0d654f691bc97e2317ea54bce3c2d87a26",
+  "checksum": "1fad9b01754dfc8ab5ab938fd7be19e742886c39dc6ca6831e681dd9402ab23c",
   "crates": {
     "abnf 0.12.0": {
       "name": "abnf",
@@ -3628,67 +3628,6 @@
         "MIT"
       ],
       "license_file": null
-    },
-    "async-socks5 0.5.1": {
-      "name": "async-socks5",
-      "version": "0.5.1",
-      "package_url": "https://github.com/ark0f/async-socks5",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/async-socks5/0.5.1/download",
-          "sha256": "77f634add2445eb2c1f785642a67ca1073fedd71e73dc3ca69435ef9b9bdedc7"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "async_socks5",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": false,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "async_socks5",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "thiserror 1.0.57",
-              "target": "thiserror"
-            },
-            {
-              "id": "tokio 1.38.0",
-              "target": "tokio"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2018",
-        "proc_macro_deps": {
-          "common": [
-            {
-              "id": "async-trait 0.1.74",
-              "target": "async_trait"
-            }
-          ],
-          "selects": {}
-        },
-        "version": "0.5.1"
-      },
-      "license": "Apache-2.0 OR MIT",
-      "license_ids": [
-        "Apache-2.0",
-        "MIT"
-      ],
-      "license_file": "LICENSE-APACHE.md"
     },
     "async-stream 0.3.5": {
       "name": "async-stream",
@@ -16996,10 +16935,6 @@
             {
               "id": "async-scoped 0.8.0",
               "target": "async_scoped"
-            },
-            {
-              "id": "async-socks5 0.5.1",
-              "target": "async_socks5"
             },
             {
               "id": "async-stream 0.3.5",
@@ -77133,7 +77068,6 @@
     "assert_matches 1.5.0",
     "async-recursion 1.0.5",
     "async-scoped 0.8.0",
-    "async-socks5 0.5.1",
     "async-stream 0.3.5",
     "async-trait 0.1.74",
     "axum 0.6.20",

--- a/Cargo.Bazel.Fuzzing.toml.lock
+++ b/Cargo.Bazel.Fuzzing.toml.lock
@@ -638,17 +638,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-socks5"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77f634add2445eb2c1f785642a67ca1073fedd71e73dc3ca69435ef9b9bdedc7"
-dependencies = [
- "async-trait",
- "thiserror",
- "tokio",
-]
-
-[[package]]
 name = "async-stream"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2889,7 +2878,6 @@ dependencies = [
  "assert_matches",
  "async-recursion",
  "async-scoped",
- "async-socks5",
  "async-stream",
  "async-trait",
  "axum 0.6.20",

--- a/Cargo.Bazel.json.lock
+++ b/Cargo.Bazel.json.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "4bdf46f1f0aa26a4541b4a3abea2ff8849949d29bced733835fd9efac6405194",
+  "checksum": "1a9a8930729d40296f094b770a48d7eb9050c3ff157aa5ec0991fe3f164b2f8a",
   "crates": {
     "abnf 0.12.0": {
       "name": "abnf",
@@ -35002,30 +35002,38 @@
         ],
         "crate_features": {
           "common": [
-            "elf",
-            "errno",
             "general",
             "ioctl",
             "no_std"
           ],
           "selects": {
             "aarch64-unknown-linux-gnu": [
+              "elf",
+              "errno",
               "prctl",
               "system"
             ],
             "aarch64-unknown-nixos-gnu": [
+              "elf",
+              "errno",
               "prctl",
               "system"
             ],
             "arm-unknown-linux-gnueabi": [
+              "elf",
+              "errno",
               "prctl",
               "system"
             ],
             "armv7-unknown-linux-gnueabi": [
+              "elf",
+              "errno",
               "prctl",
               "system"
             ],
             "i686-unknown-linux-gnu": [
+              "elf",
+              "errno",
               "prctl",
               "system"
             ],
@@ -35038,10 +35046,14 @@
               "system"
             ],
             "x86_64-unknown-linux-gnu": [
+              "elf",
+              "errno",
               "prctl",
               "system"
             ],
             "x86_64-unknown-nixos-gnu": [
+              "elf",
+              "errno",
               "prctl",
               "system"
             ]

--- a/Cargo.Bazel.json.lock
+++ b/Cargo.Bazel.json.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "1a9a8930729d40296f094b770a48d7eb9050c3ff157aa5ec0991fe3f164b2f8a",
+  "checksum": "26f9d3c20340bdce0d732a7492a82ee00e59e45663d0c847dcb88caab0e3a92f",
   "crates": {
     "abnf 0.12.0": {
       "name": "abnf",
@@ -3642,67 +3642,6 @@
         "MIT"
       ],
       "license_file": null
-    },
-    "async-socks5 0.5.1": {
-      "name": "async-socks5",
-      "version": "0.5.1",
-      "package_url": "https://github.com/ark0f/async-socks5",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/async-socks5/0.5.1/download",
-          "sha256": "77f634add2445eb2c1f785642a67ca1073fedd71e73dc3ca69435ef9b9bdedc7"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "async_socks5",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": false,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "async_socks5",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "thiserror 1.0.57",
-              "target": "thiserror"
-            },
-            {
-              "id": "tokio 1.38.0",
-              "target": "tokio"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2018",
-        "proc_macro_deps": {
-          "common": [
-            {
-              "id": "async-trait 0.1.73",
-              "target": "async_trait"
-            }
-          ],
-          "selects": {}
-        },
-        "version": "0.5.1"
-      },
-      "license": "Apache-2.0 OR MIT",
-      "license_ids": [
-        "Apache-2.0",
-        "MIT"
-      ],
-      "license_file": "LICENSE-APACHE.md"
     },
     "async-stream 0.3.5": {
       "name": "async-stream",
@@ -16829,10 +16768,6 @@
             {
               "id": "async-scoped 0.8.0",
               "target": "async_scoped"
-            },
-            {
-              "id": "async-socks5 0.5.1",
-              "target": "async_socks5"
             },
             {
               "id": "async-stream 0.3.5",
@@ -77284,7 +77219,6 @@
     "assert_matches 1.5.0",
     "async-recursion 1.0.5",
     "async-scoped 0.8.0",
-    "async-socks5 0.5.1",
     "async-stream 0.3.5",
     "async-trait 0.1.73",
     "axum 0.6.20",

--- a/Cargo.Bazel.toml.lock
+++ b/Cargo.Bazel.toml.lock
@@ -640,17 +640,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-socks5"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77f634add2445eb2c1f785642a67ca1073fedd71e73dc3ca69435ef9b9bdedc7"
-dependencies = [
- "async-trait",
- "thiserror",
- "tokio",
-]
-
-[[package]]
 name = "async-stream"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2879,7 +2868,6 @@ dependencies = [
  "assert_matches",
  "async-recursion",
  "async-scoped",
- "async-socks5",
  "async-stream",
  "async-trait",
  "axum 0.6.20",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,6 +86,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+ "zstd 0.12.4",
 ]
 
 [[package]]
@@ -8721,7 +8722,6 @@ name = "ic-ledger-canister-blocks-synchronizer"
 version = "0.1.0"
 dependencies = [
  "actix-rt",
- "actix-web",
  "async-trait",
  "candid",
  "chrono",
@@ -8739,7 +8739,6 @@ dependencies = [
  "proptest",
  "rusqlite",
  "serde",
- "serde_bytes",
  "tokio",
  "tracing",
  "url",

--- a/bazel/external_crates.bzl
+++ b/bazel/external_crates.bzl
@@ -146,9 +146,6 @@ def external_crates_repository(name, cargo_lockfile, lockfile, sanitizers_enable
                     "use-tokio",
                 ],
             ),
-            "async-socks5": crate.spec(
-                version = "^0.5.1",
-            ),
             "async-stream": crate.spec(
                 version = "^0.3.5",
             ),

--- a/rs/rosetta-api/Cargo.toml
+++ b/rs/rosetta-api/Cargo.toml
@@ -8,12 +8,7 @@ default-run = "ic-rosetta-api"
 
 [dependencies]
 actix-rt = "2.2.0"
-actix-web = { version = "4.0.1", default-features = false, features = [
-    "compress-brotli",
-    "compress-gzip",
-    "cookies",
-    "macros",
-] }
+actix-web = "4.0.1"
 anyhow = { workspace = true }
 async-trait = { workspace = true }
 base64 = { workspace = true }

--- a/rs/rosetta-api/ledger_canister_blocks_synchronizer/BUILD.bazel
+++ b/rs/rosetta-api/ledger_canister_blocks_synchronizer/BUILD.bazel
@@ -28,7 +28,6 @@ PROC_MACRO_DEPENDENCIES = [
 TEST_DEPENDENCIES = [
     "//rs/rosetta-api/ledger_canister_blocks_synchronizer/test_utils",
     "@crate_index//:actix-rt",
-    "@crate_index//:actix-web",
     "@crate_index//:proptest",
 ]
 

--- a/rs/rosetta-api/ledger_canister_blocks_synchronizer/Cargo.toml
+++ b/rs/rosetta-api/ledger_canister_blocks_synchronizer/Cargo.toml
@@ -27,10 +27,8 @@ url = "2.2.1"
 
 [dev-dependencies]
 actix-rt = "2.2.0"
-actix-web = { version = "4.0.1", default-features = false, features = ["macros", "compress-brotli", "compress-gzip", "cookies"] }
 ic-ledger-canister-blocks-synchronizer-test-utils = { path = "test_utils" }
 proptest = "1.0"
-serde_bytes = { workspace = true }
 
 [lib]
 path = "src/lib.rs"


### PR DESCRIPTION
The crate dependency is not present in the Cargo build, and is not used in the Bazel build.