### PR TITLE
chore: Improve Upgrade with Alternative URLs test

### DIFF
--- a/rs/tests/src/orchestrator/upgrade_with_alternative_urls.rs
+++ b/rs/tests/src/orchestrator/upgrade_with_alternative_urls.rs
@@ -30,8 +30,8 @@ use crate::{
         test_env_api::*,
     },
     orchestrator::utils::upgrade::{
-        bless_replica_version_with_urls, deploy_guestos_to_all_subnet_nodes,
-        get_assigned_replica_version, UpdateImageType,
+        assert_assigned_replica_version, bless_replica_version_with_urls,
+        deploy_guestos_to_all_subnet_nodes, get_assigned_replica_version, UpdateImageType,
     },
     util::{block_on, get_nns_node},
 };
@@ -92,12 +92,12 @@ pub fn test(env: TestEnv) {
     let test_version = format!("{}-test", original_version);
     block_on(deploy_guestos_to_all_subnet_nodes(
         &nns_node,
-        &ReplicaVersion::try_from(test_version).unwrap(),
+        &ReplicaVersion::try_from(test_version.clone()).unwrap(),
         subnet_id,
     ));
 
-    info!(logger, "Waiting until the replica process is killed");
+    info!(logger, "Waiting until the subnet is upgraded");
 
-    // Wait until the replica process is killed.
-    nns_node.await_status_is_unavailable().unwrap();
+    // Wait until the subnet is upgraded.
+    assert_assigned_replica_version(&nns_node, &test_version, logger);
 }


### PR DESCRIPTION
Previously we would wait until the node becomes unavailable, as a sign that it was upgrading. This is imprecise and sometimes flaky, see [here](https://dash.zh1-idx1.dfinity.network/invocation/997a197e-62ed-4aee-969c-3fa8a0f73de0?target=%2F%2Frs%2Ftests%2Fconsensus%2Forchestrator%3Aupgrade_with_alternative_urls&targetStatus=6#1). The logs reveal that the replica did in fact upgrade successfully, but I suspect the "unhealthy" status didn't persist long enough to be picked up by the test driver.

With this PR we instead wait until the node is running the expected replica version after the upgrade.