### PR TITLE
chore(IDX): trigger release workflow after main

### DIFF
--- a/.github/workflows-source/release-testing.yml
+++ b/.github/workflows-source/release-testing.yml
@@ -2,9 +2,13 @@ name: Release Testing
 
 on:
   push:
-    branches:
-      - 'hotfix-*-rc--*'
-      - 'rc--*'
+    workflow_run:
+      workflows: ["Main CI"]
+      types:
+        - completed
+      branches:
+        - 'hotfix-*-rc--*'
+        - 'rc--*'
   workflow_dispatch:
 
 env:
@@ -45,9 +49,17 @@ anchors:
     run: ./gitlab-ci/src/ci-scripts/before-script.sh
 
 jobs:
+  on-failure:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'failure' }}
+    steps:
+      # Todo: send slack notification of failure
+      - run: echo 'The triggering workflow failed'
+
   bazel-system-test-nightly:
     name: Bazel System Test Nightly
     <<: *dind-large-setup
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - <<: *checkout
       - <<: *before-script
@@ -65,6 +77,7 @@ jobs:
     name: Bazel System Test Staging
     continue-on-error: True
     <<: *dind-large-setup
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - <<: *checkout
       - <<: *before-script
@@ -82,6 +95,7 @@ jobs:
     name: Bazel System Test Hotfix
     <<: *dind-large-setup
     timeout-minutes: 90
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - <<: *checkout
       - <<: *before-script

--- a/.github/workflows-source/release-testing.yml
+++ b/.github/workflows-source/release-testing.yml
@@ -49,7 +49,7 @@ anchors:
     run: ./gitlab-ci/src/ci-scripts/before-script.sh
 
 jobs:
-  on-failure:
+  ci-main-failure:
     runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.conclusion == 'failure' }}
     steps:

--- a/.github/workflows-source/release-testing.yml
+++ b/.github/workflows-source/release-testing.yml
@@ -53,8 +53,9 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.conclusion == 'failure' }}
     steps:
-      # Todo: send slack notification of failure
-      - run: echo 'The triggering workflow failed'
+      - run: |
+          echo 'CI Main workflow failed'
+          exit 1
 
   bazel-system-test-nightly:
     name: Bazel System Test Nightly

--- a/.github/workflows-source/release-testing.yml
+++ b/.github/workflows-source/release-testing.yml
@@ -3,7 +3,7 @@ name: Release Testing
 on:
   push:
     workflow_run:
-      workflows: ["Main CI"]
+      workflows: ["CI Main"]
       types:
         - completed
       branches:

--- a/.github/workflows/release-testing.yml
+++ b/.github/workflows/release-testing.yml
@@ -27,7 +27,7 @@ env:
   BUILDEVENT_APIKEY: ${{ secrets.HONEYCOMB_API_TOKEN }}
   BUILDEVENT_DATASET: "github-ci-dfinity"
 jobs:
-  on-failure:
+  ci-main-failure:
     runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.conclusion == 'failure' }}
     steps:

--- a/.github/workflows/release-testing.yml
+++ b/.github/workflows/release-testing.yml
@@ -31,8 +31,9 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.conclusion == 'failure' }}
     steps:
-      # Todo: send slack notification of failure
-      - run: echo 'The triggering workflow failed'
+      - run: |
+          echo 'CI Main workflow failed'
+          exit 1
   bazel-system-test-nightly:
     name: Bazel System Test Nightly
     runs-on:

--- a/.github/workflows/release-testing.yml
+++ b/.github/workflows/release-testing.yml
@@ -1,9 +1,13 @@
 name: Release Testing
 on:
   push:
-    branches:
-      - 'hotfix-*-rc--*'
-      - 'rc--*'
+    workflow_run:
+      workflows: ["Main CI"]
+      types:
+        - completed
+      branches:
+        - 'hotfix-*-rc--*'
+        - 'rc--*'
   workflow_dispatch:
 env:
   CI_COMMIT_SHA: ${{ github.sha }}
@@ -23,6 +27,12 @@ env:
   BUILDEVENT_APIKEY: ${{ secrets.HONEYCOMB_API_TOKEN }}
   BUILDEVENT_DATASET: "github-ci-dfinity"
 jobs:
+  on-failure:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'failure' }}
+    steps:
+      # Todo: send slack notification of failure
+      - run: echo 'The triggering workflow failed'
   bazel-system-test-nightly:
     name: Bazel System Test Nightly
     runs-on:
@@ -31,6 +41,7 @@ jobs:
     container:
       image: ghcr.io/dfinity/ic-build@sha256:26cc347efa50935342742acddfb5d710fae1982d401911013ad8750f0603c590
     timeout-minutes: 180 # 3 hours
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -56,6 +67,7 @@ jobs:
     container:
       image: ghcr.io/dfinity/ic-build@sha256:26cc347efa50935342742acddfb5d710fae1982d401911013ad8750f0603c590
     timeout-minutes: 180 # 3 hours
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -80,6 +92,7 @@ jobs:
     container:
       image: ghcr.io/dfinity/ic-build@sha256:26cc347efa50935342742acddfb5d710fae1982d401911013ad8750f0603c590
     timeout-minutes: 90
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/release-testing.yml
+++ b/.github/workflows/release-testing.yml
@@ -2,7 +2,7 @@ name: Release Testing
 on:
   push:
     workflow_run:
-      workflows: ["Main CI"]
+      workflows: ["CI Main"]
       types:
         - completed
       branches:


### PR DESCRIPTION
This change updates the trigger for the release workflow so that it will be triggered once CI Main has completed on either a hotfix or rc branch but only if it was successful.