### PR TITLE
chore(IDX): remove CI Main from slack notification

### DIFF
--- a/.github/workflows/slack-workflow-run.yml
+++ b/.github/workflows/slack-workflow-run.yml
@@ -8,7 +8,6 @@ on:
       - master
       - rc--*
     workflows:
-      - CI Main
       - Schedule Hourly
       - Schedule Daily
       - Schedule Weekly


### PR DESCRIPTION
Since CI Main triggers release-testing on RC branches, we do not need to be notified for CI Main (would also generate a lot of noise).