### PR TITLE
fix(schnorr): CON-1257 Remove leftover uses of `ComputeInitialEcdsaDealings`

### DIFF
--- a/rs/consensus/src/consensus/batch_delivery.rs
+++ b/rs/consensus/src/consensus/batch_delivery.rs
@@ -445,7 +445,7 @@ pub fn generate_responses_to_sign_with_ecdsa_calls(
     consensus_responses
 }
 
-/// Creates responses to `ComputeInitialEcdsaDealingsArgs` system calls with the initial
+/// Creates responses to `ComputeInitialIDkgDealingsArgs` system calls with the initial
 /// dealings.
 fn generate_responses_to_initial_dealings_calls(
     ecdsa_payload: &idkg::EcdsaPayload,

--- a/rs/consensus/src/ecdsa/payload_builder/resharing.rs
+++ b/rs/consensus/src/ecdsa/payload_builder/resharing.rs
@@ -222,7 +222,7 @@ mod tests {
         ic_types::batch::ConsensusResponse::new(
             callback_id,
             ic_types::messages::Payload::Data(
-                ic_management_canister_types::ComputeInitialEcdsaDealingsResponse {
+                ic_management_canister_types::ComputeInitialIDkgDealingsResponse {
                     initial_dkg_dealings: initial_dealings.into(),
                 }
                 .encode(),

--- a/rs/consensus/src/ecdsa/payload_verifier.rs
+++ b/rs/consensus/src/ecdsa/payload_verifier.rs
@@ -506,9 +506,9 @@ fn validate_reshare_dealings(
     for (request, config) in prev_payload.ongoing_xnet_reshares.iter() {
         if !curr_payload.ongoing_xnet_reshares.contains_key(request) {
             if let Some(response) = new_reshare_agreement.get(request) {
-                use ic_management_canister_types::ComputeInitialEcdsaDealingsResponse;
+                use ic_management_canister_types::ComputeInitialIDkgDealingsResponse;
                 if let ic_types::messages::Payload::Data(data) = &response.payload {
-                    let dealings_response = ComputeInitialEcdsaDealingsResponse::decode(data)
+                    let dealings_response = ComputeInitialIDkgDealingsResponse::decode(data)
                         .map_err(|err| {
                             InvalidEcdsaPayloadReason::DecodingError(format!("{:?}", err))
                         })?;


### PR DESCRIPTION
We should be using the new type `ComputeInitialIDkgDealings` here. The reason why it works anyway is that both types are the same on the wire.