### PR TITLE
fix(IDX): update checkout ref

### DIFF
--- a/.github/workflows-source/release-testing.yml
+++ b/.github/workflows-source/release-testing.yml
@@ -42,6 +42,8 @@ anchors:
   checkout: &checkout
     name: Checkout
     uses: actions/checkout@v4
+    with:
+      ref: ${{ github.event.workflow_run.head_sha }}
   before-script: &before-script
     name: Before script
     id: before-script

--- a/.github/workflows/release-testing.yml
+++ b/.github/workflows/release-testing.yml
@@ -48,6 +48,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
       - name: Before script
         id: before-script
         shell: bash
@@ -74,6 +76,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
       - name: Before script
         id: before-script
         shell: bash
@@ -99,6 +103,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
       - name: Before script
         id: before-script
         shell: bash


### PR DESCRIPTION
The checkout step cannot get the correct context when triggered by workflow_run and switches to master. We must therefore explicitly specify which ref to checkout.