### PR TITLE
fix(IDX): checkout correct branch

### DIFF
--- a/.github/workflows-source/release-testing.yml
+++ b/.github/workflows-source/release-testing.yml
@@ -43,7 +43,7 @@ anchors:
     name: Checkout
     uses: actions/checkout@v4
     with:
-      ref: ${{ github.event.workflow_run.head_sha }}
+      ref: ${{ github.event.workflow_run.head_branch }}
   before-script: &before-script
     name: Before script
     id: before-script

--- a/.github/workflows/release-testing.yml
+++ b/.github/workflows/release-testing.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.workflow_run.head_sha }}
+          ref: ${{ github.event.workflow_run.head_branch }}
       - name: Before script
         id: before-script
         shell: bash
@@ -77,7 +77,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.workflow_run.head_sha }}
+          ref: ${{ github.event.workflow_run.head_branch }}
       - name: Before script
         id: before-script
         shell: bash
@@ -104,7 +104,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.workflow_run.head_sha }}
+          ref: ${{ github.event.workflow_run.head_branch }}
       - name: Before script
         id: before-script
         shell: bash


### PR DESCRIPTION
If we check out the ref instead of the branch we end up in a detached HEAD state.