### PR TITLE
chore(IDX): only run certain python tests on security-hotfix

### DIFF
--- a/.github/workflows-source/ci-main.yml
+++ b/.github/workflows-source/ci-main.yml
@@ -215,12 +215,16 @@ jobs:
         run: |
           set -xeuo pipefail
           export PYTHONPATH=$PWD/gitlab-ci/src:$PWD/gitlab-ci/src/dependencies
+          # Todo: remove once dependency scanner tests don't reference name of repo
+          REPO_NAME="${GITHUB_REPOSITORY##*/}"
+          ADDITIONAL_FLAGS=""
+          if [[ $REPO_NAME == "ic-private" ]]; then
+            ADDITIONAL_FLAGS="--ignore=dependencies/scanner/"
+          fi
+          export PYTHONPATH=$PWD/gitlab-ci/src:$PWD/gitlab-ci/src/dependencies
           pip3 install --ignore-installed -r requirements.txt
           cd gitlab-ci/src
-          pytest --ignore=gitlab_config/ --ignore=git_changes/ -v -o junit_family=xunit1 \
-            --junitxml=../../test_report.xml --cov=. --cov-report=term \
-            --cov-report=term-missing --cov-report=html --cov-branch
-
+          pytest --ignore=gitlab_config/ --ignore=git_changes/ $ADDITIONAL_FLAGS -v -o junit_family=xunit1 \
   build-ic:
     name: Build IC
     <<: *dind-large-setup

--- a/.github/workflows-source/ci-main.yml
+++ b/.github/workflows-source/ci-main.yml
@@ -225,6 +225,8 @@ jobs:
           pip3 install --ignore-installed -r requirements.txt
           cd gitlab-ci/src
           pytest --ignore=gitlab_config/ --ignore=git_changes/ $ADDITIONAL_FLAGS -v -o junit_family=xunit1 \
+            --junitxml=../../test_report.xml --cov=. --cov-report=term \
+            --cov-report=term-missing --cov-report=html --cov-branch
   build-ic:
     name: Build IC
     <<: *dind-large-setup

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -230,11 +230,16 @@ jobs:
         run: |
           set -xeuo pipefail
           export PYTHONPATH=$PWD/gitlab-ci/src:$PWD/gitlab-ci/src/dependencies
+          # Todo: remove once dependency scanner tests don't reference name of repo
+          REPO_NAME="${GITHUB_REPOSITORY##*/}"
+          ADDITIONAL_FLAGS=""
+          if [[ $REPO_NAME == "ic-private" ]]; then
+            ADDITIONAL_FLAGS="--ignore=dependencies/scanner/"
+          fi
+          export PYTHONPATH=$PWD/gitlab-ci/src:$PWD/gitlab-ci/src/dependencies
           pip3 install --ignore-installed -r requirements.txt
           cd gitlab-ci/src
-          pytest --ignore=gitlab_config/ --ignore=git_changes/ -v -o junit_family=xunit1 \
-            --junitxml=../../test_report.xml --cov=. --cov-report=term \
-            --cov-report=term-missing --cov-report=html --cov-branch
+          pytest --ignore=gitlab_config/ --ignore=git_changes/ $ADDITIONAL_FLAGS -v -o junit_family=xunit1 \
   build-ic:
     name: Build IC
     runs-on:

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -240,6 +240,8 @@ jobs:
           pip3 install --ignore-installed -r requirements.txt
           cd gitlab-ci/src
           pytest --ignore=gitlab_config/ --ignore=git_changes/ $ADDITIONAL_FLAGS -v -o junit_family=xunit1 \
+            --junitxml=../../test_report.xml --cov=. --cov-report=term \
+            --cov-report=term-missing --cov-report=html --cov-branch
   build-ic:
     name: Build IC
     runs-on:


### PR DESCRIPTION
Some dependency scanning alerts are hard-coded to the "ic" repo and fail when run on "ic-private". Since this is a blocker for migration, we need to disable them when run on "ic-private". The long-term correct solution would be to use a variable that references the repo it is being run from instead of hard-coding.