### PR TITLE
fix(IDX): /cache for benchmarks

### DIFF
--- a/.github/workflows-source/schedule-daily.yml
+++ b/.github/workflows-source/schedule-daily.yml
@@ -78,7 +78,7 @@ jobs:
     container:
       <<: *image
       # running on bare metal machine using ubuntu user
-      options: --user ubuntu
+      options: --user ubuntu -v /cache:/cache
     timeout-minutes: 720 # 12 hours
     strategy:
       matrix:

--- a/.github/workflows/schedule-daily.yml
+++ b/.github/workflows/schedule-daily.yml
@@ -49,7 +49,7 @@ jobs:
     container:
       image: ghcr.io/dfinity/ic-build@sha256:26cc347efa50935342742acddfb5d710fae1982d401911013ad8750f0603c590
       # running on bare metal machine using ubuntu user
-      options: --user ubuntu
+      options: --user ubuntu -v /cache:/cache
     timeout-minutes: 720 # 12 hours
     strategy:
       matrix:


### PR DESCRIPTION
Adding missing `/cache` for bazel benchmarks. This got broken after our recent changes that added `options`.