### PR TITLE
perf: CON-1360 Reduce cost of cloning tSchnorr inputs

### DIFF
--- a/rs/consensus/src/ecdsa/signer.rs
+++ b/rs/consensus/src/ecdsa/signer.rs
@@ -2095,7 +2095,7 @@ mod tests {
                     request: RequestBuilder::new().sender(canister_test_id(1)).build(),
                     args: ThresholdArguments::Schnorr(SchnorrArguments {
                         key_id: fake_schnorr_key_id(schnorr_algorithm(algorithm)),
-                        message: message.clone(),
+                        message: Arc::new(message.clone()),
                     }),
                     pseudo_random_id: req_id.pseudo_random_id,
                     derivation_path: vec![],

--- a/rs/consensus/src/ecdsa/test_utils.rs
+++ b/rs/consensus/src/ecdsa/test_utils.rs
@@ -95,7 +95,7 @@ fn fake_signature_request_args(key_id: MasterPublicKeyId) -> ThresholdArguments 
         }),
         MasterPublicKeyId::Schnorr(key_id) => ThresholdArguments::Schnorr(SchnorrArguments {
             key_id,
-            message: vec![1; 48],
+            message: Arc::new(vec![1; 48]),
         }),
     }
 }
@@ -313,7 +313,7 @@ impl From<&ThresholdSchnorrSigInputs> for TestSigInputs {
         }
         let sig_inputs_ref = ThresholdSchnorrSigInputsRef {
             derivation_path: inputs.derivation_path().clone(),
-            message: inputs.message().into(),
+            message: Arc::new(inputs.message().into()),
             nonce: *inputs.nonce(),
             presig_transcript_ref: PreSignatureTranscriptRef {
                 key_id: fake_schnorr_key_id(algorithm),
@@ -1321,7 +1321,7 @@ pub(crate) fn create_schnorr_sig_inputs_with_args(
             caller: PrincipalId::try_from(&vec![caller]).unwrap(),
             derivation_path: vec![],
         },
-        vec![0; 128],
+        Arc::new(vec![0; 128]),
         Randomness::from([0_u8; 32]),
         presig_transcript_ref,
     );

--- a/rs/consensus/utils/src/lib.rs
+++ b/rs/consensus/utils/src/lib.rs
@@ -584,7 +584,7 @@ pub fn get_oldest_ecdsa_state_registry_version(
 #[cfg(test)]
 mod tests {
     use assert_matches::assert_matches;
-    use std::str::FromStr;
+    use std::{str::FromStr, sync::Arc};
 
     use super::*;
     use ic_consensus_mocks::{dependencies_with_subnet_params, Dependencies};
@@ -872,7 +872,7 @@ mod tests {
                 }),
                 MasterPublicKeyId::Schnorr(key_id) => {
                     ThresholdArguments::Schnorr(SchnorrArguments {
-                        message: vec![1; 64],
+                        message: Arc::new(vec![1; 64]),
                         key_id: key_id.clone(),
                     })
                 }

--- a/rs/execution_environment/src/execution_environment.rs
+++ b/rs/execution_environment/src/execution_environment.rs
@@ -2794,7 +2794,10 @@ impl ExecutionEnvironment {
         state.metadata.subnet_call_context_manager.push_context(
             SubnetCallContext::SignWithThreshold(SignWithThresholdContext {
                 request,
-                args: ThresholdArguments::Schnorr(SchnorrArguments { key_id, message }),
+                args: ThresholdArguments::Schnorr(SchnorrArguments {
+                    key_id,
+                    message: Arc::new(message),
+                }),
                 derivation_path,
                 pseudo_random_id,
                 batch_time: state.metadata.batch_time,

--- a/rs/execution_environment/src/scheduler/threshold_signatures.rs
+++ b/rs/execution_environment/src/scheduler/threshold_signatures.rs
@@ -101,6 +101,8 @@ fn match_pre_signatures_by_key_id(
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use super::*;
     use ic_management_canister_types::{EcdsaCurve, EcdsaKeyId, SchnorrAlgorithm, SchnorrKeyId};
     use ic_replicated_state::metadata_state::subnet_call_context_manager::{
@@ -136,7 +138,7 @@ mod tests {
             }),
             MasterPublicKeyId::Schnorr(key_id) => ThresholdArguments::Schnorr(SchnorrArguments {
                 key_id: key_id.clone(),
-                message: vec![1; 64],
+                message: Arc::new(vec![1; 64]),
             }),
         };
         let context = SignWithThresholdContext {

--- a/rs/replicated_state/src/metadata_state/subnet_call_context_manager.rs
+++ b/rs/replicated_state/src/metadata_state/subnet_call_context_manager.rs
@@ -780,14 +780,14 @@ impl TryFrom<pb_metadata::EcdsaArguments> for EcdsaArguments {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct SchnorrArguments {
     pub key_id: SchnorrKeyId,
-    pub message: Vec<u8>,
+    pub message: Arc<Vec<u8>>,
 }
 
 impl From<&SchnorrArguments> for pb_metadata::SchnorrArguments {
     fn from(args: &SchnorrArguments) -> Self {
         Self {
             key_id: Some((&args.key_id).into()),
-            message: args.message.clone(),
+            message: args.message.to_vec(),
         }
     }
 }
@@ -797,7 +797,7 @@ impl TryFrom<pb_metadata::SchnorrArguments> for SchnorrArguments {
     fn try_from(context: pb_metadata::SchnorrArguments) -> Result<Self, Self::Error> {
         Ok(SchnorrArguments {
             key_id: try_from_option_field(context.key_id, "SchnorrArguments::key_id")?,
-            message: context.message,
+            message: Arc::new(context.message),
         })
     }
 }

--- a/rs/types/types/src/consensus/idkg/schnorr.rs
+++ b/rs/types/types/src/consensus/idkg/schnorr.rs
@@ -12,6 +12,7 @@ use serde::{Deserialize, Serialize};
 use std::convert::{AsMut, AsRef, TryFrom, TryInto};
 use std::fmt;
 use std::hash::Hash;
+use std::sync::Arc;
 
 use super::{
     IDkgBlockReader, IDkgTranscriptParamsRef, RandomUnmaskedTranscriptParams,
@@ -204,7 +205,7 @@ impl TryFrom<&pb::PreSignatureTranscriptRef> for PreSignatureTranscriptRef {
 #[cfg_attr(test, derive(ExhaustiveSet))]
 pub struct ThresholdSchnorrSigInputsRef {
     pub derivation_path: ExtendedDerivationPath,
-    pub message: Vec<u8>,
+    pub message: Arc<Vec<u8>>,
     pub nonce: Randomness,
     pub presig_transcript_ref: PreSignatureTranscriptRef,
 }
@@ -230,7 +231,7 @@ pub enum ThresholdSchnorrSigInputsError {
 impl ThresholdSchnorrSigInputsRef {
     pub fn new(
         derivation_path: ExtendedDerivationPath,
-        message: Vec<u8>,
+        message: Arc<Vec<u8>>,
         nonce: Randomness,
         presig_transcript_ref: PreSignatureTranscriptRef,
     ) -> Self {


### PR DESCRIPTION
The threshold Schnorr request context contains the message to be signed, which may be up to 10Mib in size.  When iterating over open request contexts and building the signature inputs, this message is currently being cloned [here](https://sourcegraph.com/github.com/dfinity/ic/-/blob/rs/consensus/src/ecdsa/utils.rs?L292).

Although preliminary performance tests with a large number of maximum size tSchnorr request didn’t reveal any degradation in finalization rate, wrapping this message in an `Arc` reduced the average `on_state_change` duration by a factor of 2.