### PR TITLE
refactor(crypto): CRP-2536 replace ed25519-consensus with ic-crypto-ed25519 in prod

### DIFF
--- a/Cargo.Bazel.Fuzzing.json.lock
+++ b/Cargo.Bazel.Fuzzing.json.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "2d859c6729a6586b14b2db3baa7a38bdd3a795a4efb82ff4e2228ce195768e74",
+  "checksum": "b758536f1cf8f05c8b125852d81fa217261d18e1053d0d224c7b9214ede8f88f",
   "crates": {
     "abnf 0.12.0": {
       "name": "abnf",
@@ -17201,10 +17201,6 @@
             {
               "id": "dyn-clone 1.0.14",
               "target": "dyn_clone"
-            },
-            {
-              "id": "ed25519-consensus 2.1.0",
-              "target": "ed25519_consensus"
             },
             {
               "id": "ed25519-dalek 2.1.1",
@@ -76916,7 +76912,6 @@
     "cvt 0.1.2",
     "dashmap 5.5.3",
     "dyn-clone 1.0.14",
-    "ed25519-consensus 2.1.0",
     "ed25519-dalek 2.1.1",
     "educe 0.4.23",
     "either 1.9.0",

--- a/Cargo.Bazel.Fuzzing.toml.lock
+++ b/Cargo.Bazel.Fuzzing.toml.lock
@@ -2945,7 +2945,6 @@ dependencies = [
  "cvt",
  "dashmap",
  "dyn-clone",
- "ed25519-consensus",
  "ed25519-dalek",
  "educe",
  "either",

--- a/Cargo.Bazel.json.lock
+++ b/Cargo.Bazel.json.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "82988fb10c601e8767c857c8de301417b1374bf601cd4348ad0d7c37873935a2",
+  "checksum": "49881c0686b49afcbcc85d7bf40e1dd9489ead36cfa2e9a6ffc6cd8f86402bdb",
   "crates": {
     "abnf 0.12.0": {
       "name": "abnf",
@@ -17034,10 +17034,6 @@
             {
               "id": "dyn-clone 1.0.14",
               "target": "dyn_clone"
-            },
-            {
-              "id": "ed25519-consensus 2.1.0",
-              "target": "ed25519_consensus"
             },
             {
               "id": "ed25519-dalek 2.1.1",
@@ -77034,7 +77030,6 @@
     "cvt 0.1.2",
     "dashmap 5.5.0",
     "dyn-clone 1.0.14",
-    "ed25519-consensus 2.1.0",
     "ed25519-dalek 2.1.1",
     "educe 0.4.22",
     "either 1.8.1",

--- a/Cargo.Bazel.toml.lock
+++ b/Cargo.Bazel.toml.lock
@@ -2935,7 +2935,6 @@ dependencies = [
  "cvt",
  "dashmap",
  "dyn-clone",
- "ed25519-consensus",
  "ed25519-dalek",
  "educe",
  "either",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6565,6 +6565,7 @@ dependencies = [
  "pem 1.1.1",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
+ "thiserror",
  "wycheproof",
  "zeroize",
 ]
@@ -6691,7 +6692,6 @@ dependencies = [
  "assert_matches",
  "base64 0.13.1",
  "curve25519-dalek",
- "ed25519-consensus",
  "hex",
  "ic-crypto-ed25519",
  "ic-crypto-internal-basic-sig-der-utils",
@@ -8275,7 +8275,6 @@ dependencies = [
  "anyhow",
  "candid",
  "clap 4.4.6",
- "ed25519-consensus",
  "hex",
  "ic-agent",
  "ic-crypto-ecdsa-secp256k1",

--- a/bazel/external_crates.bzl
+++ b/bazel/external_crates.bzl
@@ -388,9 +388,6 @@ def external_crates_repository(name, cargo_lockfile, lockfile, sanitizers_enable
             "dyn-clone": crate.spec(
                 version = "^1.0.14",
             ),
-            "ed25519-consensus": crate.spec(
-                version = "^2.0.1",
-            ),
             "ed25519-dalek": crate.spec(
                 version = "^2.1.1",
                 features = ["std", "zeroize", "digest", "batch", "pkcs8", "pem", "hazmat"],

--- a/rs/crypto/ed25519/BUILD.bazel
+++ b/rs/crypto/ed25519/BUILD.bazel
@@ -9,6 +9,7 @@ DEPENDENCIES = [
     "@crate_index//:hkdf",
     "@crate_index//:pem",
     "@crate_index//:rand",
+    "@crate_index//:thiserror",
     "@crate_index//:zeroize",
 ]
 

--- a/rs/crypto/ed25519/Cargo.toml
+++ b/rs/crypto/ed25519/Cargo.toml
@@ -11,6 +11,7 @@ curve25519-dalek = { workspace = true }
 ed25519-dalek = { workspace = true }
 hkdf = "0.12"
 rand = { workspace = true }
+thiserror = { workspace = true }
 zeroize = { version = "1.5", features = ["zeroize_derive"] }
 pem = "1"
 

--- a/rs/crypto/ed25519/src/lib.rs
+++ b/rs/crypto/ed25519/src/lib.rs
@@ -10,16 +10,20 @@ use ed25519_dalek::pkcs8::{DecodePrivateKey, DecodePublicKey, EncodePrivateKey, 
 use ed25519_dalek::{Digest, Sha512};
 use ed25519_dalek::{Signer, SigningKey, VerifyingKey};
 use rand::{CryptoRng, Rng};
+use thiserror::Error;
 use zeroize::ZeroizeOnDrop;
 
 /// An error if a private key cannot be decoded
-#[derive(Clone, Debug)]
+#[derive(Clone, Error, Debug)]
 pub enum PrivateKeyDecodingError {
     /// The outer PEM encoding is invalid
+    #[error("The outer PEM encoding is invalid")]
     InvalidPemEncoding(String),
     /// The PEM label was not the expected value
+    #[error("The PEM label was not the expected value")]
     UnexpectedPemLabel(String),
     /// The private key seems invalid in some way; the string contains details
+    #[error("The private key seems invalid in some way; the string contains details")]
     InvalidKeyEncoding(String),
 }
 
@@ -341,13 +345,16 @@ impl DerivedPrivateKey {
 }
 
 /// An invalid key was encountered
-#[derive(Clone, Debug)]
+#[derive(Clone, Error, Debug)]
 pub enum PublicKeyDecodingError {
     /// The outer PEM encoding is invalid
+    #[error("The outer PEM encoding is invalid")]
     InvalidPemEncoding(String),
     /// The PEM label was not the expected value
+    #[error("The PEM label was not the expected value")]
     UnexpectedPemLabel(String),
     /// The encoding of the public key is invalid, the string contains details
+    #[error("The encoding of the public key is invalid, the string contains details")]
     InvalidKeyEncoding(String),
 }
 
@@ -409,14 +416,20 @@ pub struct PublicKey {
 }
 
 /// An error that occurs when verifying signatures or batches of signatures
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Error, Debug)]
 pub enum SignatureError {
     /// The signature had an invalid length, and cannot possibly be valid
+    #[error("The signature had an invalid length, and cannot possibly be valid")]
     InvalidLength,
-    /// The batch was invalid (eg due to length mismatch between number of
+    /// The batch was invalid (e.g., due to length mismatch between number of
     /// messages and number of signatures)
+    #[error(
+        "The batch was invalid (e.g., due to length mismatch between number of 
+        messages and number of signatures)"
+    )]
     InvalidBatch,
     /// A signature was invalid
+    #[error("A signature was invalid")]
     InvalidSignature,
 }
 

--- a/rs/crypto/ed25519/src/lib.rs
+++ b/rs/crypto/ed25519/src/lib.rs
@@ -17,13 +17,13 @@ use zeroize::ZeroizeOnDrop;
 #[derive(Clone, Error, Debug)]
 pub enum PrivateKeyDecodingError {
     /// The outer PEM encoding is invalid
-    #[error("The outer PEM encoding is invalid")]
+    #[error("The outer PEM encoding is invalid: {0}")]
     InvalidPemEncoding(String),
     /// The PEM label was not the expected value
-    #[error("The PEM label was not the expected value")]
+    #[error("The PEM label was not the expected value: {0}")]
     UnexpectedPemLabel(String),
     /// The private key seems invalid in some way; the string contains details
-    #[error("The private key seems invalid in some way; the string contains details")]
+    #[error("The private key seems invalid in some way: {0}")]
     InvalidKeyEncoding(String),
 }
 
@@ -348,13 +348,13 @@ impl DerivedPrivateKey {
 #[derive(Clone, Error, Debug)]
 pub enum PublicKeyDecodingError {
     /// The outer PEM encoding is invalid
-    #[error("The outer PEM encoding is invalid")]
+    #[error("The outer PEM encoding is invalid: {0}")]
     InvalidPemEncoding(String),
     /// The PEM label was not the expected value
-    #[error("The PEM label was not the expected value")]
+    #[error("The PEM label was not the expected value: {0}")]
     UnexpectedPemLabel(String),
     /// The encoding of the public key is invalid, the string contains details
-    #[error("The encoding of the public key is invalid, the string contains details")]
+    #[error("The encoding of the public key is invalid: {0}")]
     InvalidKeyEncoding(String),
 }
 

--- a/rs/crypto/internal/crypto_lib/basic_sig/ed25519/BUILD.bazel
+++ b/rs/crypto/internal/crypto_lib/basic_sig/ed25519/BUILD.bazel
@@ -11,7 +11,6 @@ DEPENDENCIES = [
     "//rs/types/types",
     "@crate_index//:base64",
     "@crate_index//:curve25519-dalek",
-    "@crate_index//:ed25519-consensus",
     "@crate_index//:hex",
     "@crate_index//:rand",
     "@crate_index//:rand_chacha",

--- a/rs/crypto/internal/crypto_lib/basic_sig/ed25519/Cargo.toml
+++ b/rs/crypto/internal/crypto_lib/basic_sig/ed25519/Cargo.toml
@@ -9,7 +9,6 @@ documentation.workspace = true
 [dependencies]
 base64 = { workspace = true }
 curve25519-dalek = { workspace = true }
-ed25519-consensus = "2.0.1"
 hex = { workspace = true }
 ic-crypto-secrets-containers = { path = "../../../../secrets_containers" }
 ic-crypto-internal-seed = { path = "../../../crypto_lib/seed" }

--- a/rs/crypto/internal/crypto_lib/basic_sig/ed25519/src/api.rs
+++ b/rs/crypto/internal/crypto_lib/basic_sig/ed25519/src/api.rs
@@ -165,7 +165,7 @@ pub fn verify(
         CryptoError::MalformedPublicKey {
             algorithm: AlgorithmId::Ed25519,
             key_bytes: Some(pk.0.to_vec()),
-            internal_error: format!("{e}"),
+            internal_error: e.to_string(),
         }
     })?;
 
@@ -175,7 +175,7 @@ pub fn verify(
             algorithm: AlgorithmId::Ed25519,
             public_key_bytes: public_key.serialize_raw().to_vec(),
             sig_bytes: sig.0.to_vec(),
-            internal_error: format!("{e}"),
+            internal_error: e.to_string(),
         })
 }
 
@@ -201,7 +201,7 @@ pub fn verify_batch(
                 CryptoError::MalformedPublicKey {
                     algorithm: AlgorithmId::Ed25519,
                     key_bytes: Some(key.0.to_vec()),
-                    internal_error: format!("{e}"),
+                    internal_error: e.to_string(),
                 }
             })?,
         );
@@ -215,7 +215,7 @@ pub fn verify_batch(
             algorithm: AlgorithmId::Ed25519,
             public_key_bytes: vec![],
             sig_bytes: vec![],
-            internal_error: format!("{e}"),
+            internal_error: e.to_string(),
         })
 }
 

--- a/rs/crypto/internal/crypto_lib/basic_sig/ed25519/src/api.rs
+++ b/rs/crypto/internal/crypto_lib/basic_sig/ed25519/src/api.rs
@@ -165,7 +165,7 @@ pub fn verify(
         CryptoError::MalformedPublicKey {
             algorithm: AlgorithmId::Ed25519,
             key_bytes: Some(pk.0.to_vec()),
-            internal_error: format!("{e:?}"),
+            internal_error: format!("{e}"),
         }
     })?;
 
@@ -175,7 +175,7 @@ pub fn verify(
             algorithm: AlgorithmId::Ed25519,
             public_key_bytes: public_key.serialize_raw().to_vec(),
             sig_bytes: sig.0.to_vec(),
-            internal_error: format!("{e:?}"),
+            internal_error: format!("{e}"),
         })
 }
 
@@ -201,7 +201,7 @@ pub fn verify_batch(
                 CryptoError::MalformedPublicKey {
                     algorithm: AlgorithmId::Ed25519,
                     key_bytes: Some(key.0.to_vec()),
-                    internal_error: format!("{e:?}"),
+                    internal_error: format!("{e}"),
                 }
             })?,
         );
@@ -215,7 +215,7 @@ pub fn verify_batch(
             algorithm: AlgorithmId::Ed25519,
             public_key_bytes: vec![],
             sig_bytes: vec![],
-            internal_error: format!("{e:?}"),
+            internal_error: format!("{e}"),
         })
 }
 

--- a/rs/rosetta-api/icrc1/rosetta/client/BUILD.bazel
+++ b/rs/rosetta-api/icrc1/rosetta/client/BUILD.bazel
@@ -13,7 +13,6 @@ DEPENDENCIES = [
     "@crate_index//:anyhow",
     "@crate_index//:candid",
     "@crate_index//:clap",  # no clap because feature derive
-    "@crate_index//:ed25519-consensus",
     "@crate_index//:hex",
     "@crate_index//:ic-agent",
     "@crate_index//:num-bigint",

--- a/rs/rosetta-api/icrc1/rosetta/client/Cargo.toml
+++ b/rs/rosetta-api/icrc1/rosetta/client/Cargo.toml
@@ -16,7 +16,6 @@ path = "src/lib.rs"
 anyhow = { workspace = true }
 candid = { workspace = true }
 clap = { workspace = true }
-ed25519-consensus = "2.0.1"
 hex = { workspace = true }
 ic-agent = { workspace = true }
 ic-crypto-ecdsa-secp256k1 = { path = "../../../../crypto/ecdsa_secp256k1" }

--- a/rs/rosetta-api/icrc1/rosetta/client/src/lib.rs
+++ b/rs/rosetta-api/icrc1/rosetta/client/src/lib.rs
@@ -69,7 +69,7 @@ impl RosettaClient {
             };
 
             // Verify that the signature is correct
-            let verification_key = ed25519_consensus::VerificationKey::try_from(
+            let verification_key = ic_crypto_ed25519::PublicKey::deserialize_raw(
                 signer_keypair.get_pb_key().as_slice(),
             )
             .with_context(|| {
@@ -80,10 +80,7 @@ impl RosettaClient {
             })?;
 
             if verification_key
-                .verify(
-                    &ed25519_consensus::Signature::try_from(signed_bytes.as_slice())?,
-                    &signable_bytes,
-                )
+                .verify_signature(&signable_bytes, signed_bytes.as_slice())
                 .is_err()
             {
                 bail!("Signature verification failed")


### PR DESCRIPTION
Replaces the remaining usage of the unmaintained `ed25519-consensus` crate with `ic-crypto-ed25519` in the production code.

There were two usages of `ed25519-consensus` left in production code, both of which were about signature _verification_. The usage of `ic-crypto-ed25519` for signature verification is equivalent with `ed25519-consensus` because both crates perform signature verification according to the [ZIP215](https://zips.z.cash/zip-0215) rules.

Other usages of `ed25519-consensus` have been removed earlier in https://github.com/dfinity/ic/commit/cae2f79e404b1a94a4753073eb03033a8686d1b8 and https://github.com/dfinity/ic/commit/9f7ca0a7548d1550a46eff2dbc59d62dee2e8eba.