### PR TITLE
chore(http-endpoint): Increase `SETTINGS_MAX_CONCURRENT_STREAMS` to 1000

### DIFF
--- a/rs/config/src/http_handler.rs
+++ b/rs/config/src/http_handler.rs
@@ -77,7 +77,7 @@ impl Default for Config {
             port_file_path: None,
             connection_read_timeout_seconds: 1_200, // 20 min
             request_timeout_seconds: 300,           // 5 min
-            http_max_concurrent_streams: 256,
+            http_max_concurrent_streams: 1000,
             max_request_size_bytes: 5 * 1024 * 1024, // 5MB
             max_delegation_certificate_size_bytes: 1024 * 1024, // 1MB
             max_read_state_concurrent_requests: 100,


### PR DESCRIPTION
For the new synchronous call endpoint we need to support concurrent HTTP requests in the order of thousands. We should therefore increase `SETTINGS_MAX_CONCURRENT_STREAMS` to 1000 to avoid intitating multiple TCP handshakes under load.