### PR TITLE
chore: collection of preparatory steps for canister HTTP outcalls in PocketIC and unrelated fixes

### DIFF
--- a/hs/spec_compliance/src/IC/Test/Spec/HTTP.hs
+++ b/hs/spec_compliance/src/IC/Test/Spec/HTTP.hs
@@ -134,9 +134,9 @@ canister_http_calls sub httpbin_proto =
        in [ -- Corner cases
 
             simpleTestCase "invalid domain name" ecid $ \cid ->
-              ic_http_invalid_address_request' (ic00viaWithCyclesRefund 0 cid) sub httpbin_proto "xwWPqqbNqxxHmLXdguF4DN9xGq22nczV.com" Nothing Nothing cid >>= isReject [2],
+              ic_http_invalid_address_request' (ic00viaWithCyclesRefund 0 cid) sub "https://" "xwWPqqbNqxxHmLXdguF4DN9xGq22nczV.com" Nothing Nothing cid >>= isReject [2],
             simpleTestCase "invalid IP address" ecid $ \cid ->
-              ic_http_invalid_address_request' (ic00viaWithCyclesRefund 0 cid) sub httpbin_proto "240.0.0.0" Nothing Nothing cid >>= isReject [2],
+              ic_http_invalid_address_request' (ic00viaWithCyclesRefund 0 cid) sub "https://" "240.0.0.0" Nothing Nothing cid >>= isReject [2],
             -- "Currently, the GET, HEAD, and POST methods are supported for HTTP requests."
 
             simpleTestCase "GET call" ecid $ \cid -> do

--- a/packages/pocket-ic/CHANGELOG.md
+++ b/packages/pocket-ic/CHANGELOG.md
@@ -14,7 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The library functions `PocketIc::install_canister`, `PocketIc::upgrade_canister`, and `PocketIc::reinstall_canister`
   support installing canisters with a large WASM as a sequence of chunks (transparently, i.e.,
   the user does not need to take any extra action).
-- The maximum duration (timeout) of a PocketIC operation is configurable and can be deactivated by specifying it as `None` (the default is a timeout of 5 minutes).
+- The maximum duration (timeout) of a PocketIC operation is configurable using `PocketIcBuilder::with_max_request_time_ms`
+  and can be deactivated by specifying it as `None` (the default is a timeout of 5 minutes).
 - The library function `PocketIc::create_canister_with_id` works for all IC mainnet canister IDs that do not belong to the NNS or II subnet.
 - The library function `PocketIc::uninstall_canister` to uninstall code of an existing canister.
 - The library function `PocketIc::update_canister_settings` to update settings (e.g., compute allocation) of an existing canister.
@@ -22,8 +23,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   an arbitrary unassigned port) and optionally specified domains (default to `localhost`) and using an optionally specified TLS certificate (if provided,
   an HTTPS gateway is created) and configures the PocketIC instance to make progress automatically, i.e., periodically update the time of the PocketIC instance to the real time
   and execute rounds on the subnets.
-- The library function `PocketIc::make_live_https` configuring a PocketIc instance to automatically make progress (updating time and executing rounds)
-  and creating an HTTPS gateway for that instance listening at a dedicated domain and port and using a specified TLS certificate.
 - The function `PocketIcBuilder::with_server_url` to specify the URL of the PocketIC server (if not used, then the URL of an already running PocketIC server
   is derived or a new PocketIC server is started).
 - The function `PocketIcBuilder::with_state_dir` to specify a directory in which the state of the PocketIC instance can be preserved across the PocketIC instance lifetime
@@ -35,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Deprecated `make_deterministic`, use `stop_live` instead
+- The topology contains a list of node IDs instead of subnet size which can be derived from the number of node IDs.
 
 
 

--- a/packages/pocket-ic/src/common/rest.rs
+++ b/packages/pocket-ic/src/common/rest.rs
@@ -264,6 +264,29 @@ impl From<RawSubnetId> for Principal {
     }
 }
 
+#[derive(
+    Clone, Serialize, Deserialize, Debug, JsonSchema, PartialEq, Eq, PartialOrd, Ord, Hash,
+)]
+pub struct RawNodeId {
+    #[serde(deserialize_with = "base64::deserialize")]
+    #[serde(serialize_with = "base64::serialize")]
+    pub node_id: Vec<u8>,
+}
+
+impl From<RawNodeId> for Principal {
+    fn from(val: RawNodeId) -> Self {
+        Principal::from_slice(&val.node_id)
+    }
+}
+
+impl From<Principal> for RawNodeId {
+    fn from(principal: Principal) -> Self {
+        Self {
+            node_id: principal.as_slice().to_vec(),
+        }
+    }
+}
+
 #[derive(Serialize, Deserialize, JsonSchema)]
 pub struct RawVerifyCanisterSigArg {
     #[serde(deserialize_with = "base64::deserialize")]
@@ -624,8 +647,8 @@ pub struct SubnetConfig {
     pub subnet_seed: [u8; 32],
     /// Instruction limits for canister execution on this subnet.
     pub instruction_config: SubnetInstructionConfig,
-    /// Number of nodes in the subnet.
-    pub size: u64,
+    /// Node ids of nodes in the subnet.
+    pub node_ids: Vec<RawNodeId>,
     /// Some mainnet subnets have several disjunct canister ranges.
     pub canister_ranges: Vec<CanisterIdRange>,
 }

--- a/packages/pocket-ic/tests/test_canister.did
+++ b/packages/pocket-ic/tests/test_canister.did
@@ -10,7 +10,23 @@ type SignWithEcdsaResult = variant {
   Ok : blob;
   Err : text;
 };
+type HttpHeader = record {
+  name : text;
+  value : text;
+};
+type HttpResponse = record {
+  status : nat;
+  headers : vec HttpHeader;
+  body : blob;
+};
+type TransformArgs = record {
+  response : HttpResponse;
+  context : blob;
+};
 service : {
   ecdsa_public_key : (opt principal, vec blob, text) -> (EcdsaPublicKeyResult);
   sign_with_ecdsa : (blob, vec blob, text) -> (SignWithEcdsaResult);
+  canister_http : () -> (HttpResponse);
+  canister_http_with_transform : () -> (HttpResponse);
+  transform : (TransformArgs) -> (HttpResponse) query;
 }

--- a/packages/pocket-ic/tests/tests.rs
+++ b/packages/pocket-ic/tests/tests.rs
@@ -549,17 +549,18 @@ fn test_multiple_large_xnet_payloads() {
 #[test]
 fn test_get_and_set_and_advance_time() {
     let pic = PocketIc::new();
-    pic.set_time(SystemTime::UNIX_EPOCH + std::time::Duration::from_secs(1234567890));
+    let unix_time_secs = 1630328630;
+    pic.set_time(SystemTime::UNIX_EPOCH + std::time::Duration::from_secs(unix_time_secs));
     let time = pic.get_time();
     assert_eq!(
         time,
-        SystemTime::UNIX_EPOCH + std::time::Duration::from_secs(1234567890)
+        SystemTime::UNIX_EPOCH + std::time::Duration::from_secs(unix_time_secs)
     );
     pic.advance_time(std::time::Duration::from_secs(420));
     let time = pic.get_time();
     assert_eq!(
         time,
-        SystemTime::UNIX_EPOCH + std::time::Duration::from_secs(1234567890 + 420)
+        SystemTime::UNIX_EPOCH + std::time::Duration::from_secs(unix_time_secs + 420)
     );
 }
 

--- a/rs/https_outcalls/adapter/BUILD.bazel
+++ b/rs/https_outcalls/adapter/BUILD.bazel
@@ -63,6 +63,7 @@ rust_library(
     crate_name = "ic_https_outcalls_adapter",
     proc_macro_deps = MACRO_DEPENDENCIES,
     version = "0.1.0",
+    visibility = ["//rs/pocket_ic_server:__subpackages__"],
     deps = DEPENDENCIES,
 )
 

--- a/rs/pocket_ic_server/BUILD.bazel
+++ b/rs/pocket_ic_server/BUILD.bazel
@@ -159,8 +159,10 @@ rust_test(
     data = [
         ":pocket-ic-server",
         "//rs/tests:ic-hs",
+        "//rs/tests/httpbin-rs:httpbin",
     ],
     env = {
+        "HTTPBIN_BIN": "$(rootpath //rs/tests/httpbin-rs:httpbin)",
         "POCKET_IC_BIN": "$(rootpath //rs/pocket_ic_server:pocket-ic-server)",
         "IC_REF_TEST_ROOT": "rs/tests/ic-hs",
     },

--- a/rs/pocket_ic_server/CHANGELOG.md
+++ b/rs/pocket_ic_server/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - A new subnet is created on an existing PocketIC instance if a new canister is created with a specified mainnet canister ID that does not belong to any existing subnet's canister range.
 - The argument of the endpoint `/http_gateway` takes an additional optional field `domains` specifying the domains at which the HTTP gateway is listening (default to `localhost`).
 - The argument of the endpoint `/http_gateway` takes an additional optional field `https_config` specifying the TLS certificate and key. If provided, then an HTTPS gateway is started using that TLS certificate.
-- A new endpoint `/instances/<instance_id>/read/topology` to retrieve the topology of the PocketIC instance.
+- A new endpoint `/instances/<instance_id>/read/topology` to retrieve the topology of the PocketIC instance. The topology contains a list of node IDs instead of subnet size which can be derived from the number of node IDs.
 - New CLI option `--ready-file` to specify a file which is created by the PocketIC server once it is ready to accept HTTP connections.
 - A new endpoint `/instances/<instance_id>/_/dashboard` serving a PocketIC dashboard.
 - ECDSA support (IC mainnet-like): there are three ECDSA keys with names `dfx_test_key1`, `test_key_1`, and `key_1` on the II subnet.

--- a/rs/pocket_ic_server/src/pocket_ic.rs
+++ b/rs/pocket_ic_server/src/pocket_ic.rs
@@ -174,12 +174,19 @@ impl Drop for PocketIc {
 impl PocketIc {
     pub(crate) fn topology(&self) -> Topology {
         let mut topology = Topology(BTreeMap::new());
+        let subnets = self.subnets.read().unwrap();
         for (subnet_seed, config) in self.topology.0.iter() {
             // What will be returned to the client:
             let subnet_config = pocket_ic::common::rest::SubnetConfig {
                 subnet_kind: config.subnet_kind,
                 subnet_seed: *subnet_seed,
-                size: subnet_size(config.subnet_kind),
+                node_ids: subnets
+                    .get(&config.subnet_id)
+                    .unwrap()
+                    .nodes
+                    .iter()
+                    .map(|n| n.node_id.get().0.into())
+                    .collect(),
                 canister_ranges: config.ranges.iter().map(from_range).collect(),
                 instruction_config: config.instruction_config.clone(),
             };

--- a/rs/pocket_ic_server/src/pocket_ic.rs
+++ b/rs/pocket_ic_server/src/pocket_ic.rs
@@ -2084,9 +2084,10 @@ mod tests {
     fn test_time() {
         let mut pic = PocketIc::default();
 
-        let time = Time::from_nanos_since_unix_epoch(21);
+        let unix_time_ns = 1640995200000000000; // 1st Jan 2022
+        let time = Time::from_nanos_since_unix_epoch(unix_time_ns);
         compute_assert_state_change(&mut pic, SetTime { time });
-        let expected_time = OpOut::Time(21);
+        let expected_time = OpOut::Time(unix_time_ns);
         let actual_time = compute_assert_state_immutable(&mut pic, GetTime {});
 
         assert_eq!(expected_time, actual_time);

--- a/rs/pocket_ic_server/src/pocket_ic.rs
+++ b/rs/pocket_ic_server/src/pocket_ic.rs
@@ -1085,9 +1085,7 @@ impl Operation for Query {
     }
 }
 
-pub struct DashboardRequest {
-    pub runtime: Arc<Runtime>,
-}
+pub struct DashboardRequest {}
 
 impl Operation for DashboardRequest {
     fn compute(&self, pic: &mut PocketIc) -> OpOut {
@@ -1137,7 +1135,7 @@ impl Operation for DashboardRequest {
                 .iter()
                 .map(|(name, value)| (name.as_str().to_string(), value.as_bytes().to_vec()))
                 .collect(),
-            self.runtime
+            pic.runtime
                 .block_on(axum::body::to_bytes(resp.into_body(), usize::MAX))
                 .unwrap()
                 .to_vec(),
@@ -1155,7 +1153,6 @@ impl Operation for DashboardRequest {
 
 pub struct StatusRequest {
     pub bytes: Bytes,
-    pub runtime: Arc<Runtime>,
 }
 
 struct PocketHealth;
@@ -1226,7 +1223,7 @@ impl Operation for StatusRequest {
         let root_key_bytes = pic.nns_subnet().map(|nns_subnet| nns_subnet.root_key_der());
         let root_key = PocketRootKey(root_key_bytes);
 
-        let resp = self
+        let resp = pic
             .runtime
             .block_on(async { status(State((Arc::new(root_key), Arc::new(PocketHealth)))).await })
             .into_response();
@@ -1237,7 +1234,7 @@ impl Operation for StatusRequest {
                 .iter()
                 .map(|(name, value)| (name.as_str().to_string(), value.as_bytes().to_vec()))
                 .collect(),
-            self.runtime
+            pic.runtime
                 .block_on(axum::body::to_bytes(resp.into_body(), usize::MAX))
                 .unwrap()
                 .to_vec(),
@@ -1259,7 +1256,6 @@ impl Operation for StatusRequest {
 pub struct CallRequest {
     pub effective_canister_id: CanisterId,
     pub bytes: Bytes,
-    pub runtime: Arc<Runtime>,
 }
 
 #[derive(Clone)]
@@ -1328,7 +1324,7 @@ impl Operation for CallRequest {
                     ))
                     .body(self.bytes.clone().into())
                     .unwrap();
-                let resp = self.runtime.block_on(svc.oneshot(request)).unwrap();
+                let resp = pic.runtime.block_on(svc.oneshot(request)).unwrap();
 
                 if let Ok(UnvalidatedArtifactMutation::Insert((msg, _node_id))) = r.try_recv() {
                     subnet.push_signed_ingress(msg);
@@ -1340,7 +1336,7 @@ impl Operation for CallRequest {
                         .iter()
                         .map(|(name, value)| (name.as_str().to_string(), value.as_bytes().to_vec()))
                         .collect(),
-                    self.runtime
+                    pic.runtime
                         .block_on(axum::body::to_bytes(resp.into_body(), usize::MAX))
                         .unwrap()
                         .to_vec(),
@@ -1364,7 +1360,6 @@ impl Operation for CallRequest {
 pub struct QueryRequest {
     pub effective_canister_id: CanisterId,
     pub bytes: Bytes,
-    pub runtime: Arc<Runtime>,
 }
 
 #[derive(Clone)]
@@ -1425,7 +1420,7 @@ impl Operation for QueryRequest {
                     ))
                     .body(self.bytes.clone().into())
                     .unwrap();
-                let resp = self.runtime.block_on(svc.oneshot(request)).unwrap();
+                let resp = pic.runtime.block_on(svc.oneshot(request)).unwrap();
 
                 OpOut::RawResponse((
                     resp.status().into(),
@@ -1433,7 +1428,7 @@ impl Operation for QueryRequest {
                         .iter()
                         .map(|(name, value)| (name.as_str().to_string(), value.as_bytes().to_vec()))
                         .collect(),
-                    self.runtime
+                    pic.runtime
                         .block_on(axum::body::to_bytes(resp.into_body(), usize::MAX))
                         .unwrap()
                         .to_vec(),
@@ -1458,7 +1453,6 @@ impl Operation for QueryRequest {
 pub struct ReadStateRequest {
     pub effective_canister_id: CanisterId,
     pub bytes: Bytes,
-    pub runtime: Arc<Runtime>,
 }
 
 impl Operation for ReadStateRequest {
@@ -1489,7 +1483,7 @@ impl Operation for ReadStateRequest {
                     ))
                     .body(self.bytes.clone().into())
                     .unwrap();
-                let resp = self.runtime.block_on(svc.oneshot(request)).unwrap();
+                let resp = pic.runtime.block_on(svc.oneshot(request)).unwrap();
 
                 OpOut::RawResponse((
                     resp.status().into(),
@@ -1497,7 +1491,7 @@ impl Operation for ReadStateRequest {
                         .iter()
                         .map(|(name, value)| (name.as_str().to_string(), value.as_bytes().to_vec()))
                         .collect(),
-                    self.runtime
+                    pic.runtime
                         .block_on(axum::body::to_bytes(resp.into_body(), usize::MAX))
                         .unwrap()
                         .to_vec(),

--- a/rs/pocket_ic_server/src/state_api/routes.rs
+++ b/rs/pocket_ic_server/src/state_api/routes.rs
@@ -581,67 +581,54 @@ pub async fn handler_pub_key(
 }
 
 pub async fn handler_dashboard(
-    State(AppState {
-        api_state, runtime, ..
-    }): State<AppState>,
+    State(AppState { api_state, .. }): State<AppState>,
     NoApi(Path(instance_id)): NoApi<Path<InstanceId>>,
 ) -> (StatusCode, NoApi<Response<Body>>) {
-    let op = DashboardRequest { runtime };
+    let op = DashboardRequest {};
     handle_raw(api_state, instance_id, op).await
 }
 
 pub async fn handler_status(
-    State(AppState {
-        api_state, runtime, ..
-    }): State<AppState>,
+    State(AppState { api_state, .. }): State<AppState>,
     NoApi(Path(instance_id)): NoApi<Path<InstanceId>>,
     bytes: Bytes,
 ) -> (StatusCode, NoApi<Response<Body>>) {
-    let op = StatusRequest { bytes, runtime };
+    let op = StatusRequest { bytes };
     handle_raw(api_state, instance_id, op).await
 }
 
 pub async fn handler_call(
-    State(AppState {
-        api_state, runtime, ..
-    }): State<AppState>,
+    State(AppState { api_state, .. }): State<AppState>,
     NoApi(Path((instance_id, effective_canister_id))): NoApi<Path<(InstanceId, CanisterId)>>,
     bytes: Bytes,
 ) -> (StatusCode, NoApi<Response<Body>>) {
     let op = CallRequest {
         effective_canister_id,
         bytes,
-        runtime,
     };
     handle_raw(api_state, instance_id, op).await
 }
 
 pub async fn handler_query(
-    State(AppState {
-        api_state, runtime, ..
-    }): State<AppState>,
+    State(AppState { api_state, .. }): State<AppState>,
     NoApi(Path((instance_id, effective_canister_id))): NoApi<Path<(InstanceId, CanisterId)>>,
     bytes: Bytes,
 ) -> (StatusCode, NoApi<Response<Body>>) {
     let op = QueryRequest {
         effective_canister_id,
         bytes,
-        runtime,
     };
     handle_raw(api_state, instance_id, op).await
 }
 
 pub async fn handler_read_state(
-    State(AppState {
-        api_state, runtime, ..
-    }): State<AppState>,
+    State(AppState { api_state, .. }): State<AppState>,
     NoApi(Path((instance_id, effective_canister_id))): NoApi<Path<(InstanceId, CanisterId)>>,
     bytes: Bytes,
 ) -> (StatusCode, NoApi<Response<Body>>) {
     let op = ReadStateRequest {
         effective_canister_id,
         bytes,
-        runtime,
     };
     handle_raw(api_state, instance_id, op).await
 }

--- a/rs/pocket_ic_server/tests/spec_test.rs
+++ b/rs/pocket_ic_server/tests/spec_test.rs
@@ -54,6 +54,7 @@ fn subnet_config(
 }
 
 fn setup_and_run_ic_ref_test(test_nns: bool, excluded_tests: Vec<&str>, included_tests: Vec<&str>) {
+    // start httpbin webserver to test canister HTTP outcalls
     let httpbin_path = std::env::var_os("HTTPBIN_BIN").expect("Missing httpbin binary path");
     let mut cmd = Command::new(httpbin_path);
     let port_file = NamedTempFile::new().unwrap();

--- a/rs/state_machine_tests/src/lib.rs
+++ b/rs/state_machine_tests/src/lib.rs
@@ -6,7 +6,7 @@ use ic_config::{
     state_manager::LsmtConfig, subnet_config::SubnetConfig,
 };
 use ic_consensus::consensus::payload_builder::PayloadBuilderImpl;
-use ic_consensus::dkg::make_registry_cup;
+use ic_consensus::dkg::{make_registry_cup, make_registry_cup_from_cup_contents};
 use ic_consensus_utils::crypto::SignVerify;
 use ic_constants::{MAX_INGRESS_TTL, PERMITTED_DRIFT, SMALL_APP_SUBNET_MAX_SIZE};
 use ic_crypto_ecdsa_secp256k1::{PrivateKey, PublicKey};
@@ -636,6 +636,7 @@ pub struct StateMachine {
     pub nodes: Vec<StateMachineNode>,
     pub batch_summary: Option<BatchSummary>,
     time_source: Arc<FastForwardTimeSource>,
+    consensus_pool_cache: Arc<FakeConsensusPoolCache>,
     canister_http_pool: Arc<RwLock<CanisterHttpPoolImpl>>,
     canister_http_payload_builder: Arc<CanisterHttpPayloadBuilderImpl>,
     // This field must be the last one so that the temporary directory is deleted at the very end.
@@ -1199,6 +1200,26 @@ impl StateMachine {
     /// after this `StateMachine` has been built.
     pub fn reload_registry(&self) {
         self.registry_client.reload();
+        // Since the latest registry version could have changed,
+        // we update the CUP in `FakeConsensusPoolCache` to refer
+        // to the latest registry version.
+        let registry_version = self.registry_client.get_latest_version();
+        let cup_contents = self
+            .registry_client
+            .get_cup_contents(self.subnet_id, registry_version)
+            .unwrap()
+            .value
+            .unwrap();
+        let cup = make_registry_cup_from_cup_contents(
+            self.registry_client.as_ref(),
+            self.subnet_id,
+            cup_contents,
+            registry_version,
+            &self.replica_logger,
+        )
+        .unwrap();
+        let cup_proto: pb::CatchUpPackage = cup.into();
+        self.consensus_pool_cache.update_cup(cup_proto);
     }
 
     /// Constructs and initializes a new state machine that uses the specified
@@ -1323,11 +1344,11 @@ impl StateMachine {
             metrics_registry.clone(),
             replica_logger.clone(),
         )));
-        let consensus_pool_cache = FakeConsensusPoolCache::new(cup_proto);
+        let consensus_pool_cache = Arc::new(FakeConsensusPoolCache::new(cup_proto));
         let crypto = CryptoReturningOk::default();
         let canister_http_payload_builder = Arc::new(CanisterHttpPayloadBuilderImpl::new(
             canister_http_pool.clone(),
-            Arc::new(consensus_pool_cache),
+            consensus_pool_cache.clone(),
             Arc::new(crypto),
             state_manager.clone(),
             subnet_id,
@@ -1488,6 +1509,7 @@ impl StateMachine {
             nodes,
             batch_summary: None,
             time_source,
+            consensus_pool_cache,
             canister_http_pool,
             canister_http_payload_builder,
         }

--- a/rs/state_machine_tests/src/lib.rs
+++ b/rs/state_machine_tests/src/lib.rs
@@ -606,6 +606,7 @@ impl From<u64> for StateMachineNode {
 /// can be used to test this part of the stack in isolation.
 pub struct StateMachine {
     subnet_id: SubnetId,
+    subnet_type: SubnetType,
     public_key: ThresholdSigPublicKey,
     public_key_der: Vec<u8>,
     secret_key: SecretKeyBytes,
@@ -1476,6 +1477,7 @@ impl StateMachine {
 
         Self {
             subnet_id,
+            subnet_type,
             secret_key,
             public_key,
             public_key_der,
@@ -2827,6 +2829,11 @@ impl StateMachine {
         self.registry_client.update_to_latest_version();
 
         assert_eq!(next_version, self.registry_client.get_latest_version());
+    }
+
+    /// Returns the subnet type of this state machine.
+    pub fn get_subnet_type(&self) -> SubnetType {
+        self.subnet_type
     }
 
     /// Returns the subnet id of this state machine.


### PR DESCRIPTION
This MR contains a collection of preparatory steps for canister HTTP outcalls in PocketIC and unrelated little fixes in PocketIC:
- specification compliance tests for canister HTTP outcalls always use `https://` for invalid (in particular, non-localhost) domains (because the production canister HTTP outcalls adapter only allows `http://` for localhost domains)
- the PocketIC test canister contains (update/query) endpoints for testing canister HTTP outcalls in PocketIC
- the timestamps in PocketIC tests are set to timestamps after GENESIS (because every subnet's time is initialized to GENESIS and thus `StateMachine` produces a warning that time went back if timestamps in PocketIC tests are prior to GENESIS)
- update and fix the changelog (in particular, the function `PocketIc::make_live_https` has been renamed to `PocketIc::make_live_with_params`)
- PocketIC operations contain no tokio runtime which is anyway stored in PocketIC instances
- the CUP in the fake consensus pool cache of `StateMachine` is updated with the latest registry version if the registry is reloaded
- `StateMachine` exposes its subnet type
- open canister HTTPS outcalls adapter to `//rs/pocket_ic_server`
- the PocketIC topology contains a list of node IDs for every subnet instead of the subnet size which can be derived from the length of the node ID list (because the specification compliance tests take a list of node IDs for every subnet as an argument from which the subnet size is derived and the subnet size affects canister HTTP outcalls cycles cost => providing an empty list of node IDs no longer works when testing canister HTTP outcalls in PocketIC)
- httpbin webserver is started in specification compliance tests in PocketIC