### PR TITLE
fix: RUN-1014: Free SandboxedExecutionController threads

### DIFF
--- a/rs/canister_sandbox/src/replica_controller/launch_as_process.rs
+++ b/rs/canister_sandbox/src/replica_controller/launch_as_process.rs
@@ -60,6 +60,9 @@ pub fn spawn_launcher_process(
             SocketReaderConfig::default(),
         );
         reply_handler.flush_with_errors();
+        // Send a notification to the writer thread to stop.
+        // Otherwise, the writer thread will remain waiting forever.
+        out.stop();
     });
 
     Ok((svc, child_handle))

--- a/rs/canister_sandbox/src/replica_controller/sandboxed_execution_controller.rs
+++ b/rs/canister_sandbox/src/replica_controller/sandboxed_execution_controller.rs
@@ -37,6 +37,7 @@ use std::collections::{HashMap, VecDeque};
 use std::convert::TryInto;
 use std::path::PathBuf;
 use std::process::ExitStatus;
+use std::sync::mpsc::Receiver;
 use std::sync::Weak;
 use std::sync::{Arc, Mutex};
 use std::thread;
@@ -644,10 +645,15 @@ pub struct SandboxedExecutionController {
     metrics: Arc<SandboxedExecutionMetrics>,
     launcher_service: Box<dyn LauncherService>,
     fd_factory: Arc<dyn PageAllocatorFileDescriptor>,
+    stop_monitoring_thread: std::sync::mpsc::Sender<bool>,
 }
 
 impl Drop for SandboxedExecutionController {
     fn drop(&mut self) {
+        // Ignore the result because even if it fails, there is not much that
+        // can be done.
+        let _ = self.stop_monitoring_thread.send(true);
+
         // Evict all the sandbox processes.
         let mut guard = self.backends.lock().unwrap();
         evict_sandbox_processes(&mut guard, 0, 0, Duration::default());
@@ -1058,6 +1064,7 @@ impl SandboxedExecutionController {
         let backends_copy = Arc::clone(&backends);
         let metrics_copy = Arc::clone(&metrics);
         let logger_copy = logger.clone();
+        let (tx, rx) = std::sync::mpsc::channel();
 
         std::thread::spawn(move || {
             SandboxedExecutionController::monitor_and_evict_sandbox_processes(
@@ -1067,6 +1074,7 @@ impl SandboxedExecutionController {
                 min_sandbox_count,
                 max_sandbox_count,
                 max_sandbox_idle_time,
+                rx,
             );
         });
 
@@ -1101,6 +1109,7 @@ impl SandboxedExecutionController {
             metrics,
             launcher_service,
             fd_factory: Arc::clone(&fd_factory),
+            stop_monitoring_thread: tx,
         })
     }
 
@@ -1115,6 +1124,7 @@ impl SandboxedExecutionController {
         min_sandbox_count: usize,
         max_sandbox_count: usize,
         max_sandbox_idle_time: Duration,
+        stop_request: Receiver<bool>,
     ) {
         loop {
             let sandbox_processes = get_sandbox_process_stats(&backends);
@@ -1219,7 +1229,9 @@ impl SandboxedExecutionController {
             // based on the time measured to perform the collection and e.g.
             // ensure that we are 99% idle instead of using a static duration
             // here.
-            std::thread::sleep(SANDBOX_PROCESS_UPDATE_INTERVAL);
+            if let Ok(true) = stop_request.recv_timeout(SANDBOX_PROCESS_UPDATE_INTERVAL) {
+                break;
+            }
         }
     }
 


### PR DESCRIPTION
This fixes two thread leaks per SandboxedExecutionController. Note that in production replica that fix has little impact because there is only one controller that has the same lifetime as the process itself.

However, in tests that create many instances of the controller, this considerably reduces the number of threads.

Kudos to mraszyk@ for reporting the issue and providing a way to reproduce the leak and verify the fix.

Fixes:

- the sandbox monitoring thread was not terminated properly. The fix introduces a channel to request termination when the controller is dropped.

- the background writing thread of the launcher service was not terminated properly.  The fix terminates the writing thread when the reading thread exits (similar to other places).