### PR TITLE
feat(PocketIC): store registry file in state_dir

### DIFF
--- a/rs/pocket_ic_server/BUILD.bazel
+++ b/rs/pocket_ic_server/BUILD.bazel
@@ -70,6 +70,7 @@ LIB_DEPENDENCIES = [
 TEST_DEPENDENCIES = [
     # Keep sorted.
     "//packages/pocket-ic:pocket-ic",
+    "//rs/registry/proto_data_provider",
     "//rs/registry/routing_table",
     "//rs/types/types",
     "@crate_index//:candid",

--- a/rs/pocket_ic_server/CHANGELOG.md
+++ b/rs/pocket_ic_server/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   specifies if non-mainnet features (e.g., best-effort responses) should be enabled for the PocketIC instance.
   The topology contains a new field `subnet_seed` which is equal to the directory name of the directory in the `state_dir`
   storing the state of the corresponding subnet.
+  The state directory (if specified) also contains a file `registry.proto` containing the current snapshot of the registry.
 
 ### Fixed
 - Executing a query call on a new PocketIC instance crashed the PocketIC server.

--- a/rs/pocket_ic_server/src/pocket_ic.rs
+++ b/rs/pocket_ic_server/src/pocket_ic.rs
@@ -459,6 +459,12 @@ impl PocketIc {
             subnet.reload_registry();
         }
 
+        // Update the registry file on disk.
+        if let Some(ref state_dir) = state_dir {
+            let registry_proto_path = PathBuf::from(state_dir).join("registry.proto");
+            registry_data_provider.write_to_file(registry_proto_path);
+        }
+
         // Sync the time on the subnets (if only the NNS subnet is loaded
         // from a snapshot, then its time might diverge).
         // Since time must be monotone, we pick the maximum time.
@@ -1963,6 +1969,12 @@ fn route(
                         // Reload registry on the state machines to make sure
                         // all the state machines have a consistent view of the registry.
                         subnet.reload_registry();
+                    }
+                    // Update the registry file on disk.
+                    if let Some(ref state_dir) = pic.state_dir {
+                        let registry_proto_path = PathBuf::from(state_dir).join("registry.proto");
+                        pic.registry_data_provider
+                            .write_to_file(registry_proto_path);
                     }
                     // We need to execute a round on the new subnet to make its state certified.
                     // To keep the PocketIC instance time in sync, we execute a round on all subnets.


### PR DESCRIPTION
This MR makes PocketIC store the registry file on disk if a state_dir is specified for a PocketIC instance. This way, external users of PocketIC can retrieve the registry of a PocketIC instance and use it, e.g., when installing the NNS registry canister to initialize its state.