### PR TITLE
feat(ckerc20): Simplify adding new ckERC20 token (II)

### DIFF
--- a/rs/ethereum/cketh/minter/tests/ckerc20.rs
+++ b/rs/ethereum/cketh/minter/tests/ckerc20.rs
@@ -62,7 +62,7 @@ fn should_refuse_to_add_ckerc20_token_from_unauthorized_principal() {
 fn should_add_ckusdc_and_ckusdt_to_minter_via_orchestrator() {
     let mut ckerc20 = CkErc20Setup::default();
 
-    for token in supported_erc20_tokens(ckerc20.cketh.minter_id.into()) {
+    for token in supported_erc20_tokens() {
         ckerc20.orchestrator = ckerc20
             .orchestrator
             .add_erc20_token(token.clone())
@@ -91,7 +91,7 @@ fn should_retry_to_add_usdc_when_minter_stopped() {
     const RETRY_FREQUENCY: Duration = Duration::from_secs(5);
 
     let mut ckerc20 = CkErc20Setup::default();
-    let usdc = usdc(Principal::anonymous());
+    let usdc = usdc();
     let stop_msg_id = ckerc20
         .env
         .stop_canister_non_blocking(ckerc20.cketh.minter_id);

--- a/rs/ethereum/cketh/test_utils/src/ckerc20.rs
+++ b/rs/ethereum/cketh/test_utils/src/ckerc20.rs
@@ -99,7 +99,7 @@ impl CkErc20Setup {
     }
 
     pub fn add_supported_erc20_tokens(mut self) -> Self {
-        self.supported_erc20_tokens = supported_erc20_tokens(self.cketh.minter_id.into());
+        self.supported_erc20_tokens = supported_erc20_tokens();
         for token in self.supported_erc20_tokens.iter() {
             self.orchestrator = self
                 .orchestrator

--- a/rs/ethereum/ledger-suite-orchestrator/README.adoc
+++ b/rs/ethereum/ledger-suite-orchestrator/README.adoc
@@ -93,29 +93,20 @@ See the <<ckusdc-example>> example for a detailed explanation of the arguments u
 [EXAMPLE]
 .ckUSDC
 ====
-As an example, we detail the arguments used in proposal https://dashboard.internetcomputer.org/proposal/129750[129750] that added the ckUSDC token.
-Note that some of those arguments may no longer be required or use a slightly different syntax.
-Always refer to the Candid interface (`ledger_suite_orchestrator.did`) for the most up-to-date information.
+As an example, we detail the arguments that would be needed to add the ckUSDC token with the latest version of the ledger suite orchestrator.
+Note that the original proposal https://dashboard.internetcomputer.org/proposal/129750[129750] to add ckUSDC used a different version for the ledger suite orchestrator (`4472b0064d347a88649beb526214fde204f906fb`), which explains why some arguments that appear in the proposal are no longer required or use a slightly different syntax. Always refer to the Candid interface (`ledger_suite_orchestrator.did`) for the most up-to-date information.
 
 . `contract`: Uniquely identifies the ERC-20 smart contract.
 .. `chain_id = 1`: designates Ethereum mainnet. This value MUST be `1`.
 .. `address = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"`: address of the ERC-20 smart contract on Ethereum mainnet. The address MUST be a valid Ethereum address corresponding to an ERC-20 smart contract as specified in https://eips.ethereum.org/EIPS/eip-20[EIP-20].
 . `ledger_init_arg`: Initialization arguments for the ledger that will be spawned off by the orchestrator.
-.. `minting_account = record { owner = principal "sv3dd-oaaaa-aaaar-qacoa-cai" }`: Principal that is allowed to mint new tokens. This MUST be the ckETH minter principal.
-.. `fee_collector_account = opt record { owner = principal "sv3dd-oaaaa-aaaar-qacoa-cai"; subaccount = opt blob "\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\0f\ee"; }`: Accounts that collects transaction fees. This SHOULD be the `0000000000000000000000000000000000000000000000000000000000000fee` subaccount of the ckETH minter canister, so that in the future such fees can be used to self-sustain the cycle consumption of the involved canisters.
-.. `feature_flags  = opt record { icrc2 = true };`: Use https://github.com/dfinity/ICRC-1/blob/main/standards/ICRC-2/README.md[ICRC-2] approve and transfer from. This MUST be set to `true`, otherwise withdrawals will not be possible.
-.. `decimals = opt 6`: number of decimals to used by the ledger. This SHOULD be the same number as the one returned by `decimals()` on the ERC-20 smart contract.
-.. `max_memo_length = opt 80`: maximum number of bytes for the memo. Since the memo is encoded by the ckETH minter, this MUST be set to `80`.
-.. `transfer_fee = 10_000`: cost of a user transaction on the ledger (e.g., `icrc1_transfer`, `icrc2_approve`, etc.). The goal of this fee is that it should be high enough to prevent spam (and in the future to pay for the cycles consumption), but low enough to encourage users from using the ckERC20 token. This number SHOULD be between the equivalent of 0.005 USD to 0.01 USD.
+.. `decimals = 6`: number of decimals to used by the ledger. This SHOULD be the same number as the one returned by `decimals()` on the ERC-20 smart contract.
+.. `transfer_fee = 10_000`: cost of a user transaction on the ledger (e.g., `icrc1_transfer`, `icrc2_approve`, etc.). The goal of this fee is that it should be high enough to prevent spam (and in the future to pay for the cycles consumption), but low enough to encourage users from using the ckERC20 token.
+... This number SHOULD be a power of 10 (e.g., 1, 10, 100, 1_000, 10_000, etc.) to ease any user's mental arithmetic.
+... This number SHOULD be between the equivalent of 0.001 USD to 0.01 USD.
 .. `token_symbol = "ckUSDC"`: symbol of the twin ERC-20 token on the IC. This MUST be an ASCII string of at most 20 characters starting with the `ck` prefix. The symbol MUST be unique among all ckERC20 tokens. This SHOULD correspond to the `symbol()` of the ERC-20 smart contract prefixed with `ck`.
 .. `token_name = "ckUSDC"`: name of the twin ERC-20 token on the IC. This MAY be the same as `token_symbol`.
 .. `token_logo = "data:image/svg+xml;base64PHN2ZyB3...+Cg==`: logo of the twin ERC-20 token on the IC. This MUST be a https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URLs[data URL].
-.. `initial_balances = vec {}`: initial balances of the ledger. This SHOULD be an empty vector.
-.. `maximum_number_of_accounts = null`: maximum number of accounts on the ledger. This SHOULD be `null`.
-.. `accounts_overflow_trim_quantity = null`: number of accounts to trim when there are too many accounts on the ledger. This SHOULD be `null`.
-. `git_commit_hash = "4472b0064d347a88649beb526214fde204f906fb"`: This MUST be a 20-byte hexadecimal string that is the git revision in the https://github.com/dfinity/ic[IC repository] used for the spawned off ledger and index canisters for the new ckERC20 token. This MUST match the value given in `ledger_compressed_wasm_hash` and in `index_compressed_wasm_hash`. Consult the ledger suite orchestrator https://vxkom-oyaaa-aaaar-qafda-cai.raw.icp0.io/dashboard[dashboard] to see which versions are available. The latest version SHOULD be used.
-. `ledger_compressed_wasm_hash = "4ca82938d223c77909dcf594a49ea72c07fd513726cfa7a367dd0be0d6abc679"`: This MUST be a 32-byte hexadecimal string corresponding to the SHA2-256 ledger compressed wasm hash built from the git revision specified in `git_commit_hash`.
-. `index_compressed_wasm_hash = "55dd5ea22b65adf877cea893765561ae290b52e7fdfdc043b5c18ffbaaa78f33"`: This MUST be a 32-byte hexadecimal string corresponding to the SHA2-256 index compressed wasm hash built from the git revision specified in `git_commit_hash.
 ====
 
 [TIP]

--- a/rs/ethereum/ledger-suite-orchestrator/ledger_suite_orchestrator.did
+++ b/rs/ethereum/ledger-suite-orchestrator/ledger_suite_orchestrator.did
@@ -57,31 +57,13 @@ type Erc20Contract = record {
 };
 
 // ICRC1 ledger initialization argument that will be used when the orchestrator spawns a new ledger canister.
-// The `archive_options` field will be set by the orchestrator.
+// Other fields, such as `archive_options`, needed to initialize a new ledger will be set by the orchestrator.
 type LedgerInitArg = record {
-    minting_account : LedgerAccount;
-    fee_collector_account : opt LedgerAccount;
     transfer_fee : nat;
-    decimals : opt nat8;
-    max_memo_length : opt nat16;
+    decimals : nat8;
     token_symbol : text;
     token_name : text;
     token_logo : text;
-    initial_balances : vec record { LedgerAccount; nat };
-    feature_flags : opt LedgerFeatureFlags;
-    maximum_number_of_accounts : opt nat64;
-    accounts_overflow_trim_quantity : opt nat64;
-};
-
-type LedgerAccount = record {
-    owner : principal;
-    subaccount : opt LedgerSubaccount;
-};
-
-type LedgerSubaccount = blob;
-
-type LedgerFeatureFlags = record {
-    icrc2 : bool;
 };
 
 type ManagedCanisterIds = record {

--- a/rs/ethereum/ledger-suite-orchestrator/src/candid/mod.rs
+++ b/rs/ethereum/ledger-suite-orchestrator/src/candid/mod.rs
@@ -13,7 +13,7 @@ pub enum OrchestratorArg {
     AddErc20Arg(AddErc20Arg),
 }
 
-#[derive(CandidType, Deserialize, Clone, Debug, PartialEq, Eq)]
+#[derive(CandidType, Deserialize, Clone, Debug, PartialEq, Eq, Default)]
 pub struct InitArg {
     pub more_controller_ids: Vec<Principal>,
     pub minter_id: Option<Principal>,

--- a/rs/ethereum/ledger-suite-orchestrator/src/candid/mod.rs
+++ b/rs/ethereum/ledger-suite-orchestrator/src/candid/mod.rs
@@ -1,8 +1,6 @@
 use crate::scheduler::Erc20Token;
 use crate::state::{Canister, Canisters};
 use candid::{CandidType, Deserialize, Nat, Principal};
-use ic_icrc1_ledger::FeatureFlags as LedgerFeatureFlags;
-use icrc_ledger_types::icrc1::account::Account as LedgerAccount;
 use std::fmt::{Display, Formatter};
 
 #[allow(clippy::large_enum_variant)]
@@ -57,18 +55,11 @@ pub struct Erc20Contract {
 
 #[derive(CandidType, Deserialize, serde::Serialize, Clone, Debug, PartialEq, Eq)]
 pub struct LedgerInitArg {
-    pub minting_account: LedgerAccount,
-    pub fee_collector_account: Option<LedgerAccount>,
-    pub initial_balances: Vec<(LedgerAccount, Nat)>,
     pub transfer_fee: Nat,
-    pub decimals: Option<u8>,
+    pub decimals: u8,
     pub token_name: String,
     pub token_symbol: String,
     pub token_logo: String,
-    pub max_memo_length: Option<u16>,
-    pub feature_flags: Option<LedgerFeatureFlags>,
-    pub maximum_number_of_accounts: Option<u64>,
-    pub accounts_overflow_trim_quantity: Option<u64>,
 }
 
 #[derive(CandidType, Deserialize, Clone, Debug, PartialEq, Eq)]

--- a/rs/ethereum/ledger-suite-orchestrator/src/scheduler/tests.rs
+++ b/rs/ethereum/ledger-suite-orchestrator/src/scheduler/tests.rs
@@ -1396,6 +1396,7 @@ fn register_embedded_wasms() -> LedgerSuiteVersion {
 fn usdc_install_args() -> InstallLedgerSuiteArgs {
     InstallLedgerSuiteArgs {
         contract: usdc(),
+        minter_id: MINTER_PRINCIPAL,
         ledger_init_arg: ledger_init_arg(),
         ledger_compressed_wasm_hash: read_ledger_wasm_hash(),
         index_compressed_wasm_hash: read_index_wasm_hash(),
@@ -1670,10 +1671,10 @@ mod mock {
 }
 
 mod install_ledger_suite_args {
-    use crate::candid::{AddErc20Arg, LedgerInitArg};
-    use crate::scheduler::tests::usdc_metadata;
+    use crate::candid::{AddErc20Arg, InitArg, LedgerInitArg};
+    use crate::scheduler::tests::{usdc_metadata, MINTER_PRINCIPAL};
     use crate::scheduler::{ChainId, Erc20Token, InstallLedgerSuiteArgs, InvalidAddErc20ArgError};
-    use crate::state::test_fixtures::{expect_panic_with_message, new_state};
+    use crate::state::test_fixtures::{expect_panic_with_message, new_state, new_state_from};
     use crate::state::{GitCommitHash, IndexWasm, LedgerSuiteVersion, LedgerWasm, WasmHash};
     use crate::storage::test_fixtures::{
         embedded_ledger_suite_version, empty_task_queue, empty_wasm_store,
@@ -1687,8 +1688,22 @@ mod install_ledger_suite_args {
     const ERC20_CONTRACT_ADDRESS: &str = "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48";
 
     #[test]
+    fn should_error_if_minter_id_missing() {
+        let state = new_state();
+        let wasm_store = wasm_store_with_icrc1_ledger_suite();
+
+        assert_matches!(
+            InstallLedgerSuiteArgs::validate_add_erc20(&state, &wasm_store, valid_add_erc20_arg()),
+            Err(InvalidAddErc20ArgError::InternalError( error )) if error.contains("minter principal")
+        );
+    }
+
+    #[test]
     fn should_error_if_contract_is_already_managed() {
-        let mut state = new_state();
+        let mut state = new_state_from(InitArg {
+            minter_id: Some(MINTER_PRINCIPAL),
+            ..Default::default()
+        });
         let wasm_store = wasm_store_with_icrc1_ledger_suite();
         state.update_ledger_suite_version(embedded_ledger_suite_version());
         let arg = valid_add_erc20_arg();
@@ -1762,7 +1777,10 @@ mod install_ledger_suite_args {
 
     #[test]
     fn should_panic_when_ledger_suite_version_missing() {
-        let state = new_state();
+        let state = new_state_from(InitArg {
+            minter_id: Some(MINTER_PRINCIPAL),
+            ..Default::default()
+        });
         let wasm_store = wasm_store_with_icrc1_ledger_suite();
         assert_eq!(state.ledger_suite_version(), None);
 
@@ -1790,7 +1808,10 @@ mod install_ledger_suite_args {
                 ..embedded_ledger_suite_version()
             },
         ] {
-            let mut state = new_state();
+            let mut state = new_state_from(InitArg {
+                minter_id: Some(MINTER_PRINCIPAL),
+                ..Default::default()
+            });
             state.update_ledger_suite_version(version);
             let wasm_store = wasm_store_with_icrc1_ledger_suite();
 
@@ -1809,7 +1830,10 @@ mod install_ledger_suite_args {
 
     #[test]
     fn should_accept_valid_erc20_arg() {
-        let mut state = new_state();
+        let mut state = new_state_from(InitArg {
+            minter_id: Some(MINTER_PRINCIPAL),
+            ..Default::default()
+        });
         let wasm_store = wasm_store_with_icrc1_ledger_suite();
         state.update_ledger_suite_version(embedded_ledger_suite_version());
         let arg = valid_add_erc20_arg();
@@ -1821,6 +1845,7 @@ mod install_ledger_suite_args {
             result,
             InstallLedgerSuiteArgs {
                 contract: Erc20Token(ChainId(1), ERC20_CONTRACT_ADDRESS.parse().unwrap()),
+                minter_id: MINTER_PRINCIPAL,
                 ledger_init_arg,
                 ledger_compressed_wasm_hash: LedgerWasm::from(crate::state::LEDGER_BYTECODE)
                     .hash()

--- a/rs/ethereum/ledger-suite-orchestrator/src/scheduler/tests.rs
+++ b/rs/ethereum/ledger-suite-orchestrator/src/scheduler/tests.rs
@@ -1404,24 +1404,12 @@ fn usdc_install_args() -> InstallLedgerSuiteArgs {
 }
 
 fn ledger_init_arg() -> LedgerInitArg {
-    use icrc_ledger_types::icrc1::account::Account as LedgerAccount;
-
     LedgerInitArg {
-        minting_account: LedgerAccount {
-            owner: Principal::anonymous(),
-            subaccount: None,
-        },
-        fee_collector_account: None,
-        initial_balances: vec![],
         transfer_fee: 10_000_u32.into(),
-        decimals: None,
+        decimals: 6,
         token_name: "Chain Key USDC".to_string(),
         token_symbol: "ckUSDC".to_string(),
         token_logo: "".to_string(),
-        max_memo_length: None,
-        feature_flags: None,
-        maximum_number_of_accounts: None,
-        accounts_overflow_trim_quantity: None,
     }
 }
 
@@ -1681,7 +1669,7 @@ mod install_ledger_suite_args {
     };
     use crate::storage::{record_icrc1_ledger_suite_wasms, WasmStore};
     use assert_matches::assert_matches;
-    use candid::{Nat, Principal};
+    use candid::Nat;
     use proptest::collection::vec;
     use proptest::{prop_assert_eq, proptest};
 
@@ -1858,29 +1846,17 @@ mod install_ledger_suite_args {
     }
 
     fn valid_add_erc20_arg() -> AddErc20Arg {
-        use icrc_ledger_types::icrc1::account::Account as LedgerAccount;
-
         AddErc20Arg {
             contract: crate::candid::Erc20Contract {
                 chain_id: Nat::from(1_u8),
                 address: ERC20_CONTRACT_ADDRESS.to_string(),
             },
             ledger_init_arg: LedgerInitArg {
-                minting_account: LedgerAccount {
-                    owner: Principal::anonymous(),
-                    subaccount: None,
-                },
-                fee_collector_account: None,
-                initial_balances: vec![],
                 transfer_fee: 10_000_u32.into(),
-                decimals: None,
+                decimals: 6,
                 token_name: "USD Coin".to_string(),
                 token_symbol: "USDC".to_string(),
                 token_logo: "".to_string(),
-                max_memo_length: None,
-                feature_flags: None,
-                maximum_number_of_accounts: None,
-                accounts_overflow_trim_quantity: None,
             },
         }
     }

--- a/rs/ethereum/ledger-suite-orchestrator/src/state/test_fixtures.rs
+++ b/rs/ethereum/ledger-suite-orchestrator/src/state/test_fixtures.rs
@@ -7,12 +7,11 @@ use proptest::option;
 use proptest::prelude::Strategy;
 
 pub fn new_state() -> State {
-    State::try_from(InitArg {
-        more_controller_ids: vec![],
-        minter_id: None,
-        cycles_management: None,
-    })
-    .unwrap()
+    new_state_from(InitArg::default())
+}
+
+pub fn new_state_from(init_arg: InitArg) -> State {
+    State::try_from(init_arg).unwrap()
 }
 
 pub fn expect_panic_with_message<F: FnOnce() -> R, R: std::fmt::Debug>(

--- a/rs/ethereum/ledger-suite-orchestrator/test_utils/src/arbitrary.rs
+++ b/rs/ethereum/ledger-suite-orchestrator/test_utils/src/arbitrary.rs
@@ -21,7 +21,7 @@ pub fn arb_init_arg() -> impl Strategy<Value = InitArg> {
         )
 }
 
-fn arb_principal() -> impl Strategy<Value = Principal> {
+pub fn arb_principal() -> impl Strategy<Value = Principal> {
     vec(any::<u8>(), 0..=29).prop_map(|bytes| Principal::from_slice(&bytes))
 }
 

--- a/rs/ethereum/ledger-suite-orchestrator/test_utils/src/flow.rs
+++ b/rs/ethereum/ledger-suite-orchestrator/test_utils/src/flow.rs
@@ -2,7 +2,7 @@ use crate::metrics::MetricsAssert;
 use crate::universal_canister::UniversalCanister;
 use crate::{
     assert_reply, out_of_band_upgrade, stop_canister, LedgerAccount, LedgerMetadataValue,
-    LedgerSuiteOrchestrator, MAX_TICKS,
+    LedgerSuiteOrchestrator, MAX_TICKS, MINTER_PRINCIPAL,
 };
 use candid::{Decode, Encode, Nat, Principal};
 use ic_base_types::{CanisterId, PrincipalId};
@@ -78,7 +78,7 @@ impl ManagedCanistersAssert {
             .collect();
 
         for _i in 0..ARCHIVE_TRIGGER_THRESHOLD {
-            let from = Principal::anonymous();
+            let from = MINTER_PRINCIPAL;
             let to = Principal::management_canister();
             self.call_ledger_icrc1_transfer(
                 from,

--- a/rs/ethereum/ledger-suite-orchestrator/test_utils/src/lib.rs
+++ b/rs/ethereum/ledger-suite-orchestrator/test_utils/src/lib.rs
@@ -31,6 +31,7 @@ const MAX_TICKS: usize = 10;
 const GIT_COMMIT_HASH: &str = "6a8e5fca2c6b4e12966638c444e994e204b42989";
 pub const GIT_COMMIT_HASH_UPGRADE: &str = "b7fef0f57ca246b18deda3efd34a24bb605c8199";
 pub const CKERC20_TRANSFER_FEE: u64 = 4_000; //0.004 USD for ckUSDC/ckUSDT
+pub const DECIMALS: u8 = 6;
 
 pub const NNS_ROOT_PRINCIPAL: Principal = Principal::from_slice(&[0_u8]);
 pub const MINTER_PRINCIPAL: Principal =
@@ -383,14 +384,14 @@ pub fn tweak_ledger_suite_wasms() -> (LedgerWasm, IndexWasm, ArchiveWasm) {
     )
 }
 
-pub fn supported_erc20_tokens(minter: Principal) -> Vec<AddErc20Arg> {
-    vec![usdc(minter), usdt(minter)]
+pub fn supported_erc20_tokens() -> Vec<AddErc20Arg> {
+    vec![usdc(), usdt()]
 }
 
-pub fn usdc(minter: Principal) -> AddErc20Arg {
+pub fn usdc() -> AddErc20Arg {
     AddErc20Arg {
         contract: usdc_erc20_contract(),
-        ledger_init_arg: ledger_init_arg(minter, "Chain-Key USD Coin", "ckUSDC"),
+        ledger_init_arg: ledger_init_arg("Chain-Key USD Coin", "ckUSDC"),
     }
 }
 
@@ -401,10 +402,10 @@ pub fn usdc_erc20_contract() -> Erc20Contract {
     }
 }
 
-pub fn usdt(minter: Principal) -> AddErc20Arg {
+pub fn usdt() -> AddErc20Arg {
     AddErc20Arg {
         contract: usdt_erc20_contract(),
-        ledger_init_arg: ledger_init_arg(minter, "Chain-Key Tether USD", "ckUSDT"),
+        ledger_init_arg: ledger_init_arg("Chain-Key Tether USD", "ckUSDT"),
     }
 }
 
@@ -416,26 +417,15 @@ pub fn usdt_erc20_contract() -> Erc20Contract {
 }
 
 fn ledger_init_arg<U: Into<String>, V: Into<String>>(
-    minter: Principal,
     token_name: U,
     token_symbol: V,
 ) -> LedgerInitArg {
     LedgerInitArg {
-        minting_account: LedgerAccount {
-            owner: minter,
-            subaccount: None,
-        },
-        fee_collector_account: None,
-        initial_balances: vec![],
         transfer_fee: CKERC20_TRANSFER_FEE.into(),
-        decimals: None,
+        decimals: DECIMALS,
         token_name: token_name.into(),
         token_symbol: token_symbol.into(),
         token_logo: "".to_string(),
-        max_memo_length: Some(80),
-        feature_flags: None,
-        maximum_number_of_accounts: None,
-        accounts_overflow_trim_quantity: None,
     }
 }
 

--- a/rs/ethereum/ledger-suite-orchestrator/test_utils/src/lib.rs
+++ b/rs/ethereum/ledger-suite-orchestrator/test_utils/src/lib.rs
@@ -33,6 +33,8 @@ pub const GIT_COMMIT_HASH_UPGRADE: &str = "b7fef0f57ca246b18deda3efd34a24bb605c8
 pub const CKERC20_TRANSFER_FEE: u64 = 4_000; //0.004 USD for ckUSDC/ckUSDT
 
 pub const NNS_ROOT_PRINCIPAL: Principal = Principal::from_slice(&[0_u8]);
+pub const MINTER_PRINCIPAL: Principal =
+    Principal::from_slice(&[0_u8, 0, 0, 0, 2, 48, 0, 156, 1, 1]);
 
 pub struct LedgerSuiteOrchestrator {
     pub env: Arc<StateMachine>,
@@ -295,7 +297,7 @@ impl LedgerSuiteOrchestrator {
 pub fn default_init_arg() -> InitArg {
     InitArg {
         more_controller_ids: vec![NNS_ROOT_PRINCIPAL],
-        minter_id: None,
+        minter_id: Some(MINTER_PRINCIPAL),
         cycles_management: None,
     }
 }

--- a/rs/ethereum/ledger-suite-orchestrator/tests/tests.rs
+++ b/rs/ethereum/ledger-suite-orchestrator/tests/tests.rs
@@ -7,11 +7,11 @@ use ic_ledger_suite_orchestrator::candid::{
     AddErc20Arg, CyclesManagement, LedgerInitArg, LedgerSuiteVersion, ManagedCanisterStatus,
     ManagedCanisters, OrchestratorArg, OrchestratorInfo, UpdateCyclesManagement, UpgradeArg,
 };
-use ic_ledger_suite_orchestrator_test_utils::arbitrary::arb_init_arg;
+use ic_ledger_suite_orchestrator_test_utils::arbitrary::{arb_init_arg, arb_principal};
 use ic_ledger_suite_orchestrator_test_utils::{
     assert_reply, default_init_arg, ledger_suite_orchestrator_wasm, new_state_machine,
     supported_erc20_tokens, usdc, usdc_erc20_contract, usdt, LedgerSuiteOrchestrator,
-    GIT_COMMIT_HASH_UPGRADE, NNS_ROOT_PRINCIPAL,
+    GIT_COMMIT_HASH_UPGRADE, MINTER_PRINCIPAL, NNS_ROOT_PRINCIPAL,
 };
 use ic_state_machine_tests::ErrorCode;
 use icrc_ledger_types::icrc::generic_metadata_value::MetadataValue as LedgerMetadataValue;
@@ -32,7 +32,8 @@ proptest! {
             .. ProptestConfig::default()
         })]
     #[test]
-    fn should_install_orchestrator_and_add_supported_erc20_tokens(init_arg in arb_init_arg()) {
+    fn should_install_orchestrator_and_add_supported_erc20_tokens(mut init_arg in arb_init_arg(), minter_id in arb_principal()) {
+        init_arg.minter_id = Some(minter_id);
         let more_controllers = init_arg.more_controller_ids.clone();
         let mut orchestrator = LedgerSuiteOrchestrator::new(Arc::new(new_state_machine()), init_arg).register_embedded_wasms();
         let orchestrator_principal: Principal = orchestrator.ledger_suite_orchestrator_id.get().into();
@@ -408,7 +409,7 @@ fn should_retrieve_orchestrator_info() {
                 cycles_top_up_increment: Nat::from(10000000000000_u64),
             },
             more_controller_ids: vec![NNS_ROOT_PRINCIPAL],
-            minter_id: None,
+            minter_id: Some(MINTER_PRINCIPAL),
             ledger_suite_version: Some(LedgerSuiteVersion {
                 ledger_compressed_wasm_hash: embedded_ledger_wasm_hash.to_string(),
                 index_compressed_wasm_hash: embedded_index_wasm_hash.to_string(),

--- a/rs/ethereum/ledger-suite-orchestrator/tests/tests.rs
+++ b/rs/ethereum/ledger-suite-orchestrator/tests/tests.rs
@@ -2,7 +2,6 @@ use assert_matches::assert_matches;
 use candid::{Decode, Encode, Nat, Principal};
 use ic_base_types::{CanisterId, PrincipalId};
 use ic_canisters_http_types::{HttpRequest, HttpResponse};
-use ic_icrc1_ledger::FeatureFlags as LedgerFeatureFlags;
 use ic_ledger_suite_orchestrator::candid::{
     AddErc20Arg, CyclesManagement, LedgerInitArg, LedgerSuiteVersion, ManagedCanisterStatus,
     ManagedCanisters, OrchestratorArg, OrchestratorInfo, UpdateCyclesManagement, UpgradeArg,
@@ -18,7 +17,6 @@ use icrc_ledger_types::icrc::generic_metadata_value::MetadataValue as LedgerMeta
 use icrc_ledger_types::icrc1::account::Account as LedgerAccount;
 use proptest::prelude::ProptestConfig;
 use proptest::proptest;
-use std::str::FromStr;
 use std::sync::Arc;
 
 const MAX_TICKS: usize = 10;
@@ -39,7 +37,7 @@ proptest! {
         let orchestrator_principal: Principal = orchestrator.ledger_suite_orchestrator_id.get().into();
         let controllers: Vec<_> = std::iter::once(orchestrator_principal).chain(more_controllers.into_iter()).collect();
 
-        for token in supported_erc20_tokens(Principal::anonymous()) {
+        for token in supported_erc20_tokens() {
             orchestrator = orchestrator
                 .add_erc20_token(token)
                 .expect_new_ledger_and_index_canisters()
@@ -57,27 +55,11 @@ fn should_spawn_ledger_with_correct_init_args() {
 
     // Adapted from ckETH ledger init args https://dashboard.internetcomputer.org/proposal/126309
     let realistic_usdc_ledger_init_arg = LedgerInitArg {
-        minting_account: LedgerAccount {
-            owner: Principal::from_str("sv3dd-oaaaa-aaaar-qacoa-cai").unwrap(),
-            subaccount: None,
-        },
-        fee_collector_account: Some(LedgerAccount {
-            owner: Principal::from_str("sv3dd-oaaaa-aaaar-qacoa-cai").unwrap(),
-            subaccount: Some([
-                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                0, 0xf, 0xe, 0xe,
-            ]),
-        }),
-        initial_balances: vec![],
         transfer_fee: 2_000_000_000_000_u64.into(),
-        decimals: Some(6),
+        decimals: 6,
         token_name: "USD Coin".to_string(),
         token_symbol: "USDC".to_string(),
         token_logo: CKETH_TOKEN_LOGO.to_string(),
-        max_memo_length: Some(80),
-        feature_flags: Some(LedgerFeatureFlags { icrc2: true }),
-        maximum_number_of_accounts: None,
-        accounts_overflow_trim_quantity: None,
     };
 
     let orchestrator = LedgerSuiteOrchestrator::default();
@@ -93,7 +75,7 @@ fn should_spawn_ledger_with_correct_init_args() {
         .assert_ledger_icrc1_symbol("USDC")
         .assert_ledger_icrc1_total_supply(0_u8)
         .assert_ledger_icrc1_minting_account(LedgerAccount {
-            owner: Principal::from_str("sv3dd-oaaaa-aaaar-qacoa-cai").unwrap(),
+            owner: MINTER_PRINCIPAL,
             subaccount: None,
         })
         .assert_ledger_icrc1_metadata(vec![
@@ -129,7 +111,7 @@ fn should_change_cycles_for_canister_creation() {
     let orchestrator = LedgerSuiteOrchestrator::default();
 
     let orchestrator = orchestrator
-        .add_erc20_token(usdc(Principal::anonymous()))
+        .add_erc20_token(usdc())
         .expect_new_ledger_and_index_canisters()
         .assert_ledger_has_cycles(200_000_000_000_000_u128)
         .assert_index_has_cycles(100_000_000_000_000_u128)
@@ -152,7 +134,7 @@ fn should_change_cycles_for_canister_creation() {
         .unwrap();
 
     orchestrator
-        .add_erc20_token(usdt(Principal::anonymous()))
+        .add_erc20_token(usdt())
         .expect_new_ledger_and_index_canisters()
         .assert_ledger_has_cycles(300_000_000_000_000_u128)
         .assert_index_has_cycles(50_000_000_000_000_u128);
@@ -167,7 +149,7 @@ fn should_spawn_archive_from_ledger_with_correct_controllers() {
     ];
 
     orchestrator
-        .add_erc20_token(usdc(Principal::anonymous()))
+        .add_erc20_token(usdc())
         .expect_new_ledger_and_index_canisters()
         .trigger_creation_of_archive()
         .assert_all_controlled_by(&expected_controllers);
@@ -178,7 +160,7 @@ fn should_discover_new_archive_and_top_up() {
     let orchestrator = LedgerSuiteOrchestrator::default().register_embedded_wasms();
 
     let managed_canisters = orchestrator
-        .add_erc20_token(usdc(Principal::anonymous()).clone())
+        .add_erc20_token(usdc())
         .expect_new_ledger_and_index_canisters()
         .assert_ledger_has_cycles(200_000_000_000_000_u128)
         .check_metrics()
@@ -207,13 +189,12 @@ fn should_discover_new_archive_and_top_up() {
 fn should_reject_adding_an_already_managed_erc20_token() {
     let orchestrator = LedgerSuiteOrchestrator::default().register_embedded_wasms();
     let orchestrator = orchestrator
-        .add_erc20_token(usdc(Principal::anonymous()))
+        .add_erc20_token(usdc())
         .expect_new_ledger_and_index_canisters()
         .setup;
 
-    let result = orchestrator.upgrade_ledger_suite_orchestrator_with_same_wasm(
-        &OrchestratorArg::AddErc20Arg(usdc(Principal::anonymous())),
-    );
+    let result = orchestrator
+        .upgrade_ledger_suite_orchestrator_with_same_wasm(&OrchestratorArg::AddErc20Arg(usdc()));
 
     assert_matches!(result, Err(e) if e.code() == ErrorCode::CanisterCalledTrap && e.description().contains("Erc20ContractAlreadyManaged"));
 }
@@ -226,7 +207,7 @@ fn should_top_up_spawned_canisters() {
     })
     .register_embedded_wasms();
     let orchestrator = orchestrator
-        .add_erc20_token(usdc(Principal::anonymous()))
+        .add_erc20_token(usdc())
         .expect_new_ledger_and_index_canisters()
         .setup;
 
@@ -354,8 +335,8 @@ fn should_retrieve_orchestrator_info() {
     let embedded_ledger_wasm_hash = orchestrator.embedded_ledger_wasm_hash.clone();
     let embedded_index_wasm_hash = orchestrator.embedded_index_wasm_hash.clone();
     let embedded_archive_wasm_hash = orchestrator.embedded_archive_wasm_hash.clone();
-    let usdc = usdc(Principal::anonymous());
-    let usdt = usdt(Principal::anonymous());
+    let usdc = usdc();
+    let usdt = usdt();
 
     let canisters = orchestrator
         .add_erc20_token(usdc.clone())
@@ -468,7 +449,7 @@ fn should_require_to_register_embedded_wasms_before_adding_ckerc20() {
         None
     );
 
-    let usdc = usdc(Principal::anonymous());
+    let usdc = usdc();
     assert_matches!(orchestrator
     .upgrade_ledger_suite_orchestrator_with_same_wasm(&OrchestratorArg::AddErc20Arg(usdc.clone())),
      Err(e) if e.code() == ErrorCode::CanisterCalledTrap && e.description().contains("ERROR: ")
@@ -570,13 +551,13 @@ mod upgrade {
 
         orchestrator_v1
             .register_embedded_wasms()
-            .add_erc20_token(usdc(Principal::anonymous()))
+            .add_erc20_token(usdc())
             .expect_new_ledger_and_index_canisters()
             .assert_ledger_has_wasm_hash(&embedded_ledger_wasm_hash_v1);
 
         orchestrator_v2
             .register_embedded_wasms()
-            .add_erc20_token(usdc(Principal::anonymous()))
+            .add_erc20_token(usdc())
             .expect_new_ledger_and_index_canisters()
             .assert_ledger_has_wasm_hash(&embedded_ledger_wasm_hash_v2);
     }
@@ -594,11 +575,11 @@ mod upgrade {
 
         let orchestrator_v1 = orchestrator_v1
             .register_embedded_wasms()
-            .add_erc20_token(usdc(Principal::anonymous()))
+            .add_erc20_token(usdc())
             .expect_new_ledger_and_index_canisters()
             .assert_ledger_has_wasm_hash(&embedded_ledger_wasm_hash_v1)
             .setup
-            .add_erc20_token(usdt(Principal::anonymous()))
+            .add_erc20_token(usdt())
             .expect_new_ledger_and_index_canisters()
             .assert_ledger_has_wasm_hash(&embedded_ledger_wasm_hash_v1)
             .setup;
@@ -692,14 +673,14 @@ mod upgrade {
             };
 
         let orchestrator = orchestrator
-            .add_erc20_token(usdc(Principal::anonymous()))
+            .add_erc20_token(usdc())
             .expect_new_ledger_and_index_canisters()
             .trigger_creation_of_archive()
             .assert_ledger_has_wasm_hash(&embedded_ledger_wasm_hash)
             .ledger_out_of_band_upgrade(NNS_ROOT_PRINCIPAL, tweak_ledger_wasm)
             .assert_ledger_has_wasm_hash(&tweak_ledger_wasm_hash)
             .setup
-            .add_erc20_token(usdt(Principal::anonymous()))
+            .add_erc20_token(usdt())
             .expect_new_ledger_and_index_canisters()
             .trigger_creation_of_archive()
             .assert_index_has_wasm_hash(&embedded_index_wasm_hash)
@@ -784,7 +765,7 @@ mod upgrade {
         };
 
         let mut orchestrator = orchestrator;
-        for add_erc20 in [usdc(Principal::anonymous()), usdt(Principal::anonymous())] {
+        for add_erc20 in [usdc(), usdt()] {
             orchestrator = orchestrator
                 .add_erc20_token(add_erc20)
                 .expect_new_ledger_and_index_canisters()
@@ -843,12 +824,12 @@ mod upgrade {
 
         let orchestrator_v1 = orchestrator_v1
             .register_embedded_wasms()
-            .add_erc20_token(usdc(Principal::anonymous()))
+            .add_erc20_token(usdc())
             .expect_new_ledger_and_index_canisters()
             .assert_ledger_has_wasm_hash(&embedded_ledger_wasm_hash_v1);
         let mint_index = orchestrator_v1
             .call_ledger_icrc1_transfer(
-                Principal::anonymous(),
+                MINTER_PRINCIPAL,
                 &TransferArg {
                     from_subaccount: None,
                     to: Principal::management_canister().into(),
@@ -914,7 +895,7 @@ mod upgrade {
             assert_ne!(tweak_index_wasm_hash, embedded_index_wasm_hash);
 
             let orchestrator = orchestrator
-                .add_erc20_token(usdc(Principal::anonymous()))
+                .add_erc20_token(usdc())
                 .expect_new_ledger_and_index_canisters()
                 .trigger_creation_of_archive()
                 .assert_ledger_has_wasm_hash(&embedded_ledger_wasm_hash)
@@ -984,7 +965,7 @@ mod upgrade {
         };
 
         let managed_canisters = orchestrator
-            .add_erc20_token(usdc(Principal::anonymous()))
+            .add_erc20_token(usdc())
             .expect_new_ledger_and_index_canisters()
             .assert_ledger_has_wasm_hash(embedded_ledger_wasm_hash.clone())
             .assert_index_has_wasm_hash(embedded_index_wasm_hash.clone())

--- a/rs/tests/src/cross_chain/ic_xc_ledger_suite_orchestrator_test.rs
+++ b/rs/tests/src/cross_chain/ic_xc_ledger_suite_orchestrator_test.rs
@@ -77,9 +77,10 @@ pub fn ic_xc_ledger_suite_orchestrator_test(env: TestEnv) {
         "rs/ethereum/ledger-suite-orchestrator/ledger_suite_orchestrator_canister.wasm.gz",
     );
     let ledger_orchestrator = block_on(async {
+        use std::str::FromStr;
         let init_args = OrchestratorArg::InitArg(InitArg {
             more_controller_ids: vec![ROOT_CANISTER_ID.get().0],
-            minter_id: None,
+            minter_id: Some(Principal::from_str("sv3dd-oaaaa-aaaar-qacoa-cai").unwrap()),
             cycles_management: None,
         });
         let canister = install_nns_controlled_canister(
@@ -365,34 +366,14 @@ fn usdc_contract() -> Erc20Contract {
 }
 
 fn usdc_ledger_init_arg() -> LedgerInitArg {
-    use ic_icrc1_ledger::FeatureFlags as LedgerFeatureFlags;
-    use icrc_ledger_types::icrc1::account::Account as LedgerAccount;
-    use std::str::FromStr;
-
     const CKETH_TOKEN_LOGO: &str = "data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTQ2IiBoZWlnaHQ9IjE0NiIgdmlld0JveD0iMCAwIDE0NiAxNDYiIGZpbGw9Im5vbmUiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CjxyZWN0IHdpZHRoPSIxNDYiIGhlaWdodD0iMTQ2IiByeD0iNzMiIGZpbGw9IiMzQjAwQjkiLz4KPHBhdGggZmlsbC1ydWxlPSJldmVub2RkIiBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGQ9Ik0xNi4zODM3IDc3LjIwNTJDMTguNDM0IDEwNS4yMDYgNDAuNzk0IDEyNy41NjYgNjguNzk0OSAxMjkuNjE2VjEzNS45NEMzNy4zMDg3IDEzMy44NjcgMTIuMTMzIDEwOC42OTEgMTAuMDYwNSA3Ny4yMDUySDE2LjM4MzdaIiBmaWxsPSJ1cmwoI3BhaW50MF9saW5lYXJfMTEwXzU4NikiLz4KPHBhdGggZmlsbC1ydWxlPSJldmVub2RkIiBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGQ9Ik02OC43NjQ2IDE2LjM1MzRDNDAuNzYzOCAxOC40MDM2IDE4LjQwMzcgNDAuNzYzNyAxNi4zNTM1IDY4Ljc2NDZMMTAuMDMwMyA2OC43NjQ2QzEyLjEwMjcgMzcuMjc4NCAzNy4yNzg1IDEyLjEwMjYgNjguNzY0NiAxMC4wMzAyTDY4Ljc2NDYgMTYuMzUzNFoiIGZpbGw9IiMyOUFCRTIiLz4KPHBhdGggZmlsbC1ydWxlPSJldmVub2RkIiBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGQ9Ik0xMjkuNjE2IDY4LjczNDNDMTI3LjU2NiA0MC43MzM0IDEwNS4yMDYgMTguMzczMyA3Ny4yMDUxIDE2LjMyMzFMNzcuMjA1MSA5Ljk5OTk4QzEwOC42OTEgMTIuMDcyNCAxMzMuODY3IDM3LjI0ODEgMTM1LjkzOSA2OC43MzQzTDEyOS42MTYgNjguNzM0M1oiIGZpbGw9InVybCgjcGFpbnQxX2xpbmVhcl8xMTBfNTg2KSIvPgo8cGF0aCBmaWxsLXJ1bGU9ImV2ZW5vZGQiIGNsaXAtcnVsZT0iZXZlbm9kZCIgZD0iTTc3LjIzNTQgMTI5LjU4NkMxMDUuMjM2IDEyNy41MzYgMTI3LjU5NiAxMDUuMTc2IDEyOS42NDcgNzcuMTc0OUwxMzUuOTcgNzcuMTc0OUMxMzMuODk3IDEwOC42NjEgMTA4LjcyMiAxMzMuODM3IDc3LjIzNTQgMTM1LjkwOUw3Ny4yMzU0IDEyOS41ODZaIiBmaWxsPSIjMjlBQkUyIi8+CjxwYXRoIGQ9Ik03My4xOTA0IDMxVjYxLjY4MThMOTkuMTIzIDczLjI2OTZMNzMuMTkwNCAzMVoiIGZpbGw9IndoaXRlIiBmaWxsLW9wYWNpdHk9IjAuNiIvPgo8cGF0aCBkPSJNNzMuMTkwNCAzMUw0Ny4yNTQ0IDczLjI2OTZMNzMuMTkwNCA2MS42ODE4VjMxWiIgZmlsbD0id2hpdGUiLz4KPHBhdGggZD0iTTczLjE5MDQgOTMuMTUyM1YxMTRMOTkuMTQwMyA3OC4wOTg0TDczLjE5MDQgOTMuMTUyM1oiIGZpbGw9IndoaXRlIiBmaWxsLW9wYWNpdHk9IjAuNiIvPgo8cGF0aCBkPSJNNzMuMTkwNCAxMTRWOTMuMTQ4OEw0Ny4yNTQ0IDc4LjA5ODRMNzMuMTkwNCAxMTRaIiBmaWxsPSJ3aGl0ZSIvPgo8cGF0aCBkPSJNNzMuMTkwNCA4OC4zMjY5TDk5LjEyMyA3My4yNjk2TDczLjE5MDQgNjEuNjg4N1Y4OC4zMjY5WiIgZmlsbD0id2hpdGUiIGZpbGwtb3BhY2l0eT0iMC4yIi8+CjxwYXRoIGQ9Ik00Ny4yNTQ0IDczLjI2OTZMNzMuMTkwNCA4OC4zMjY5VjYxLjY4ODdMNDcuMjU0NCA3My4yNjk2WiIgZmlsbD0id2hpdGUiIGZpbGwtb3BhY2l0eT0iMC42Ii8+CjxkZWZzPgo8bGluZWFyR3JhZGllbnQgaWQ9InBhaW50MF9saW5lYXJfMTEwXzU4NiIgeDE9IjUzLjQ3MzYiIHkxPSIxMjIuNzkiIHgyPSIxNC4wMzYyIiB5Mj0iODkuNTc4NiIgZ3JhZGllbnRVbml0cz0idXNlclNwYWNlT25Vc2UiPgo8c3RvcCBvZmZzZXQ9IjAuMjEiIHN0b3AtY29sb3I9IiNFRDFFNzkiLz4KPHN0b3Agb2Zmc2V0PSIxIiBzdG9wLWNvbG9yPSIjNTIyNzg1Ii8+CjwvbGluZWFyR3JhZGllbnQ+CjxsaW5lYXJHcmFkaWVudCBpZD0icGFpbnQxX2xpbmVhcl8xMTBfNTg2IiB4MT0iMTIwLjY1IiB5MT0iNTUuNjAyMSIgeDI9IjgxLjIxMyIgeTI9IjIyLjM5MTQiIGdyYWRpZW50VW5pdHM9InVzZXJTcGFjZU9uVXNlIj4KPHN0b3Agb2Zmc2V0PSIwLjIxIiBzdG9wLWNvbG9yPSIjRjE1QTI0Ii8+CjxzdG9wIG9mZnNldD0iMC42ODQxIiBzdG9wLWNvbG9yPSIjRkJCMDNCIi8+CjwvbGluZWFyR3JhZGllbnQ+CjwvZGVmcz4KPC9zdmc+Cg==";
 
     LedgerInitArg {
-        minting_account: LedgerAccount {
-            owner: Principal::from_str("sv3dd-oaaaa-aaaar-qacoa-cai").unwrap(),
-            subaccount: None,
-        },
-        fee_collector_account: Some(LedgerAccount {
-            owner: Principal::from_str("sv3dd-oaaaa-aaaar-qacoa-cai").unwrap(),
-            subaccount: Some([
-                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                0, 0xf, 0xe, 0xe,
-            ]),
-        }),
-        initial_balances: vec![],
         transfer_fee: 2_000_000_000_000_u64.into(),
-        decimals: Some(6),
+        decimals: 6,
         token_name: "USD Coin".to_string(),
         token_symbol: "USDC".to_string(),
         token_logo: CKETH_TOKEN_LOGO.to_string(),
-        max_memo_length: Some(80),
-        feature_flags: Some(LedgerFeatureFlags { icrc2: true }),
-        maximum_number_of_accounts: None,
-        accounts_overflow_trim_quantity: None,
     }
 }
 


### PR DESCRIPTION
Follow-up on [MR-20019](https://gitlab.com/dfinity-lab/public/ic/-/merge_requests/20019) to simplify adding new ckERC20 tokens by changing the following fields in the ledger initialization arguments:

1. `minting_account` is removed
2. `fee_collector_account` is removed
3. `decimals` is no longer optional (the default value of `8` does not necessarily make sense depending on the underlying ERC-20 token).
4. `max_memo_length` is removed
5. `initial_balances` is removed
6. `feature_flags` is removed
7. `maximum_number_of_accounts` is removed
8. `accounts_overflow_trim_quantity` is removed

The ledger suite orchestrator provides meaningful default values for all removed fields. The same values were used in all the proposals that created ckERC20 tokens ([ckUSDC](https://dashboard.internetcomputer.org/proposal/129750), [ckLINK](https://dashboard.internetcomputer.org/proposal/130395), [ckPEPE](https://dashboard.internetcomputer.org/proposal/130755), [ckOCT](https://dashboard.internetcomputer.org/proposal/130806), [ckSHIB](https://dashboard.internetcomputer.org/proposal/130982), [ckWBTC](https://dashboard.internetcomputer.org/proposal/131053)). 