### PR TITLE
fix(node): fix testonly in icos_deploy bazel rules

### DIFF
--- a/testnet/tools/BUILD.bazel
+++ b/testnet/tools/BUILD.bazel
@@ -1,5 +1,6 @@
 genrule(
     name = "icos_deploy",
+    testonly = True,
     srcs = [
         "//ic-os/guestos/envs/dev:version.txt",
         "//ic-os/guestos/envs/dev:upload_disk-img",


### PR DESCRIPTION
Set testonly for icos_deploy to fix static testnet deployment tooling from bazel.