### PR TITLE
fix(dependency-mgmt): Set `fetch-depth` to 256 for `dependencies-check`

### DIFF
--- a/.github/workflows-source/ci-pr-only.yml
+++ b/.github/workflows-source/ci-pr-only.yml
@@ -129,6 +129,8 @@ jobs:
       SLACK_PSEC_BOT_OAUTH_TOKEN: ${{ secrets.SLACK_PSEC_BOT_OAUTH_TOKEN }}
     steps:
       - <<: *checkout
+        with:
+          fetch-depth: 256
       - <<: *before-script
       - name: Setup python deps
         id: setup-python-deps

--- a/.github/workflows/ci-pr-only.yml
+++ b/.github/workflows/ci-pr-only.yml
@@ -127,6 +127,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 256
       - name: Before script
         id: before-script
         shell: bash


### PR DESCRIPTION
Checkout by default only fetches the latest commit. In `dependencies-check` job, we require the git history to find the merge-base and flag dependencies accordingly. 

Fix tested [here](https://github.com/dfinity/ic/pull/357)