### PR TITLE
refactor(nervous_system): Add `controller` and `hotkeys` fields to CfParticipant, CfNeuron, and CfInvestment

### DIFF
--- a/rs/nervous_system/integration_tests/tests/sns_lifecycle.rs
+++ b/rs/nervous_system/integration_tests/tests/sns_lifecycle.rs
@@ -1620,9 +1620,9 @@ fn test_sns_lifecycle(
                 .iter()
                 .filter_map(|recipe| {
                     if let Some(Investor::CommunityFund(ref investment)) = recipe.investor {
-                        let hotkey_principal = investment.hotkey_principal.clone();
+                        let controller = investment.try_get_controller().unwrap();
                         let amount_sns_e8s = recipe.sns.clone().unwrap().amount_e8s;
-                        Some((hotkey_principal, amount_sns_e8s))
+                        Some((controller, amount_sns_e8s))
                     } else {
                         None
                     }

--- a/rs/nns/governance/api/src/ic_nns_governance.pb.v1.rs
+++ b/rs/nns/governance/api/src/ic_nns_governance.pb.v1.rs
@@ -1603,7 +1603,7 @@ pub mod neurons_fund_snapshot {
         /// participation constraints.
         #[prost(bool, optional, tag = "5")]
         pub is_capped: ::core::option::Option<bool>,
-        /// The principal that can manage this neuron.
+        /// The principal that can manage the NNS neuron that participated in the Neurons' Fund.
         #[prost(message, optional, tag = "6")]
         pub controller: ::core::option::Option<::ic_base_types::PrincipalId>,
         /// The principals that can vote, propose, and follow on behalf of this neuron.
@@ -3206,7 +3206,7 @@ pub mod settle_neurons_fund_participation_response {
         /// The amount of Neurons' Fund participation associated with this neuron.
         #[prost(uint64, optional, tag = "2")]
         pub amount_icp_e8s: ::core::option::Option<u64>,
-        /// The principal that can manage this neuron.
+        /// The principal that can manage the NNS neuron that participated in the Neurons' Fund.
         #[prost(message, optional, tag = "6")]
         pub controller: ::core::option::Option<::ic_base_types::PrincipalId>,
         /// The principals that can vote, propose, and follow on behalf of this neuron.

--- a/rs/nns/governance/canister/governance.did
+++ b/rs/nns/governance/canister/governance.did
@@ -42,10 +42,12 @@ type CanisterSummary = record {
 };
 type CfNeuron = record {
   has_created_neuron_recipes : opt bool;
+  hotkeys : opt Principals;
   nns_neuron_id : nat64;
   amount_icp_e8s : nat64;
 };
 type CfParticipant = record {
+  controller : opt principal;
   hotkey_principal : text;
   cf_neurons : vec CfNeuron;
 };

--- a/rs/nns/governance/canister/governance_test.did
+++ b/rs/nns/governance/canister/governance_test.did
@@ -42,10 +42,12 @@ type CanisterSummary = record {
 };
 type CfNeuron = record {
   has_created_neuron_recipes : opt bool;
+  hotkeys : opt Principals;
   nns_neuron_id : nat64;
   amount_icp_e8s : nat64;
 };
 type CfParticipant = record {
+  controller : opt principal;
   hotkey_principal : text;
   cf_neurons : vec CfNeuron;
 };

--- a/rs/nns/governance/proto/ic_nns_governance/pb/v1/governance.proto
+++ b/rs/nns/governance/proto/ic_nns_governance/pb/v1/governance.proto
@@ -1519,7 +1519,7 @@ message NeuronsFundSnapshot {
     // participation constraints.
     optional bool is_capped = 5;
 
-    // The principal that can manage this neuron.
+    // The principal that can manage the NNS neuron that participated in the Neurons' Fund.
     optional ic_base_types.pb.v1.PrincipalId controller = 6;
 
     // The principals that can vote, propose, and follow on behalf of this neuron.
@@ -2625,7 +2625,7 @@ message SettleNeuronsFundParticipationResponse {
     optional uint64 nns_neuron_id = 1;
     // The amount of Neurons' Fund participation associated with this neuron.
     optional uint64 amount_icp_e8s = 2;
-    // The principal that can manage this neuron.
+    // The principal that can manage the NNS neuron that participated in the Neurons' Fund.
     optional ic_base_types.pb.v1.PrincipalId controller = 6;
     // The principals that can vote, propose, and follow on behalf of this neuron.
     optional ic_nervous_system.pb.v1.Principals hotkeys = 7;

--- a/rs/nns/governance/src/gen/ic_nns_governance.pb.v1.rs
+++ b/rs/nns/governance/src/gen/ic_nns_governance.pb.v1.rs
@@ -1603,7 +1603,7 @@ pub mod neurons_fund_snapshot {
         /// participation constraints.
         #[prost(bool, optional, tag = "5")]
         pub is_capped: ::core::option::Option<bool>,
-        /// The principal that can manage this neuron.
+        /// The principal that can manage the NNS neuron that participated in the Neurons' Fund.
         #[prost(message, optional, tag = "6")]
         pub controller: ::core::option::Option<::ic_base_types::PrincipalId>,
         /// The principals that can vote, propose, and follow on behalf of this neuron.
@@ -3206,7 +3206,7 @@ pub mod settle_neurons_fund_participation_response {
         /// The amount of Neurons' Fund participation associated with this neuron.
         #[prost(uint64, optional, tag = "2")]
         pub amount_icp_e8s: ::core::option::Option<u64>,
-        /// The principal that can manage this neuron.
+        /// The principal that can manage the NNS neuron that participated in the Neurons' Fund.
         #[prost(message, optional, tag = "6")]
         pub controller: ::core::option::Option<::ic_base_types::PrincipalId>,
         /// The principals that can vote, propose, and follow on behalf of this neuron.

--- a/rs/nns/governance/src/governance.rs
+++ b/rs/nns/governance/src/governance.rs
@@ -78,6 +78,7 @@ use ic_nervous_system_common::{
 };
 use ic_nervous_system_governance::maturity_modulation::apply_maturity_modulation;
 use ic_nervous_system_proto::pb::v1::GlobalTimeOfDay;
+use ic_nervous_system_proto::pb::v1::Principals;
 use ic_nns_common::{
     pb::v1::{NeuronId, ProposalId},
     types::UpdateIcpXdrConversionRatePayload,
@@ -300,7 +301,7 @@ impl From<NeuronsFundNeuronPortion> for NeuronsFundNeuronPb {
             nns_neuron_id: Some(neuron.id.id),
             amount_icp_e8s: Some(neuron.amount_icp_e8s),
             controller: Some(neuron.controller),
-            hotkeys: Some(neuron.hotkeys.into()),
+            hotkeys: Some(Principals::from(neuron.hotkeys.clone())),
             is_capped: Some(neuron.is_capped),
             hotkey_principal: Some(neuron.controller.to_string()),
         }

--- a/rs/nns/governance/tests/governance.rs
+++ b/rs/nns/governance/tests/governance.rs
@@ -10899,29 +10899,37 @@ lazy_static! {
     };
 
     static ref CF_PARTICIPANTS: Vec<sns_swap_pb::CfParticipant> = {
+        #[allow(deprecated)] // TODO[#NNS-2338]: Remove this once hotkey_principal is removed.
         let mut result = vec![
             sns_swap_pb::CfParticipant {
+                controller: Some(principal(1)),
                 hotkey_principal: principal(1).to_string(),
                 cf_neurons: vec![
                     sns_swap_pb::CfNeuron::try_new(
                         1,
                         NEURONS_FUND_INVESTMENT_E8S * 60 / 100,
+                        vec![],
                     ).unwrap(),
                     sns_swap_pb::CfNeuron::try_new(
                         2,
-                        NEURONS_FUND_INVESTMENT_E8S * 10 / 100
+                        NEURONS_FUND_INVESTMENT_E8S * 10 / 100,
+                        vec![],
                     ).unwrap(),
                 ],
             },
             sns_swap_pb::CfParticipant {
+                controller: Some(principal(2)),
                 hotkey_principal: principal(2).to_string(),
-                cf_neurons: vec![sns_swap_pb::CfNeuron::try_new(
-                    3,
-                    NEURONS_FUND_INVESTMENT_E8S * 30 / 100,
-                ).unwrap()],
+                cf_neurons: vec![
+                    sns_swap_pb::CfNeuron::try_new(
+                        3,
+                        NEURONS_FUND_INVESTMENT_E8S * 30 / 100,
+                        vec![],
+                    ).unwrap()
+                ],
             },
         ];
-        result.sort_by(|p1, p2| p1.hotkey_principal.cmp(&p2.hotkey_principal));
+        result.sort_by_key(|p1| p1.try_get_controller().unwrap());
         result
     };
 

--- a/rs/nns/sns-wasm/canister/sns-wasm.did
+++ b/rs/nns/sns-wasm/canister/sns-wasm.did
@@ -4,10 +4,12 @@ type AirdropDistribution = record { airdrop_neurons : vec NeuronDistribution };
 type Canister = record { id : opt principal };
 type CfNeuron = record {
   has_created_neuron_recipes : opt bool;
+  hotkeys : opt Principals;
   nns_neuron_id : nat64;
   amount_icp_e8s : nat64;
 };
 type CfParticipant = record {
+  controller : opt principal;
   hotkey_principal : text;
   cf_neurons : vec CfNeuron;
 };
@@ -125,6 +127,7 @@ type PrettySnsVersion = record {
   governance_wasm_hash : text;
   index_wasm_hash : text;
 };
+type Principals = record { principals : vec principal };
 type Result = variant { Error : SnsWasmError; Hash : blob };
 type Result_1 = variant { Ok : Ok; Error : SnsWasmError };
 type SnsCanisterIds = record {

--- a/rs/sns/audit/src/lib.rs
+++ b/rs/sns/audit/src/lib.rs
@@ -164,9 +164,9 @@ async fn validate_neurons_fund_sns_swap_participation(
         .into_iter()
         .filter_map(|recipe| {
             if let Some(Investor::CommunityFund(ref investment)) = recipe.investor {
-                let hotkey_principal = investment.hotkey_principal.clone();
+                let controller = investment.try_get_controller().unwrap();
                 let amount_sns_e8s = recipe.sns.clone().unwrap().amount_e8s;
-                Some((hotkey_principal, amount_sns_e8s))
+                Some((controller, amount_sns_e8s))
             } else {
                 None
             }
@@ -177,17 +177,16 @@ async fn validate_neurons_fund_sns_swap_participation(
         format!("SNS swap {} is not in the final state yet, so `neurons_fund_refunds` is not specified.", sns_name)
     })?;
     let refunded_neuron_portions = neurons_fund_refunds.neurons_fund_neuron_portions;
-    let mut refunded_amounts_per_controller = BTreeMap::<String, _>::new();
+    let mut refunded_amounts_per_controller = BTreeMap::new();
     for refunded_neuron_portion in refunded_neuron_portions.iter() {
         #[allow(deprecated)] // TODO(NNS1-3198): remove once hotkey_principal is removed
-        let hotkey_principal = refunded_neuron_portion
+        let controller = refunded_neuron_portion
             .controller
             .or(refunded_neuron_portion.hotkey_principal)
-            .unwrap()
-            .to_string();
+            .unwrap();
         let new_amount_icp_e8s = refunded_neuron_portion.amount_icp_e8s.unwrap();
         refunded_amounts_per_controller
-            .entry(hotkey_principal)
+            .entry(controller)
             .and_modify(|total_amount_icp_e8s| *total_amount_icp_e8s += new_amount_icp_e8s)
             .or_insert(new_amount_icp_e8s);
     }
@@ -199,17 +198,16 @@ async fn validate_neurons_fund_sns_swap_participation(
         .neurons_fund_reserves
         .unwrap()
         .neurons_fund_neuron_portions;
-    let mut initial_amounts_per_controller: BTreeMap<String, _> = BTreeMap::new();
+    let mut initial_amounts_per_controller: BTreeMap<_, _> = BTreeMap::new();
     for initial_neuron_portion in initial_neuron_portions.iter() {
         #[allow(deprecated)] // TODO(NNS1-3198): remove once hotkey_principal is removed
-        let hotkey_principal = initial_neuron_portion
+        let controller = initial_neuron_portion
             .controller
             .or(initial_neuron_portion.hotkey_principal)
-            .unwrap()
-            .to_string();
+            .unwrap();
         let new_amount_icp_e8s = initial_neuron_portion.amount_icp_e8s.unwrap();
         initial_amounts_per_controller
-            .entry(hotkey_principal)
+            .entry(controller)
             .and_modify(|total_amount_icp_e8s| *total_amount_icp_e8s += new_amount_icp_e8s)
             .or_insert(new_amount_icp_e8s);
     }
@@ -221,14 +219,13 @@ async fn validate_neurons_fund_sns_swap_participation(
         .neurons_fund_reserves
         .unwrap()
         .neurons_fund_neuron_portions;
-    let mut final_amounts_per_controller: BTreeMap<String, _> = BTreeMap::new();
+    let mut final_amounts_per_controller = BTreeMap::new();
     for final_neuron_portion in final_neuron_portions.iter() {
         #[allow(deprecated)] // TODO(NNS1-3198): remove once hotkey_principal is removed
         let hotkey_principal = final_neuron_portion
             .controller
             .or(final_neuron_portion.hotkey_principal)
-            .unwrap()
-            .to_string();
+            .unwrap();
         let new_amount_icp_e8s = final_neuron_portion.amount_icp_e8s.unwrap();
         final_amounts_per_controller
             .entry(hotkey_principal)
@@ -284,38 +281,37 @@ async fn validate_neurons_fund_sns_swap_participation(
             == (sns_neurons_per_backet as u128) * (num_nns_nf_neurons as u128),
     );
 
-    let mut sns_neuron_recipes_per_controller = BTreeMap::<String, Vec<u64>>::new();
-    for (hotkey_principal, amount_sns_e8s) in sns_neuron_recipes.into_iter() {
+    let mut sns_neuron_recipes_per_controller = BTreeMap::<_, Vec<u64>>::new();
+    for (controller, amount_sns_e8s) in sns_neuron_recipes.into_iter() {
         sns_neuron_recipes_per_controller
-            .entry(hotkey_principal.clone())
+            .entry(controller)
             .and_modify(|sns_neurons| {
                 sns_neurons.push(amount_sns_e8s);
             })
             .or_insert(vec![amount_sns_e8s]);
     }
 
-    let mut investment_per_controller_icp_e8s = BTreeMap::<String, Vec<u64>>::new();
+    let mut investment_per_controller_icp_e8s = BTreeMap::<_, Vec<u64>>::new();
     for expected_neuron_portion in final_neuron_portions {
         #[allow(deprecated)] // TODO(NNS1-3198): remove once hotkey_principal is removed
         let hotkey_principal = expected_neuron_portion
             .controller
             .or(expected_neuron_portion.hotkey_principal)
-            .unwrap()
-            .to_string();
+            .unwrap();
         let amount_icp_e8s = expected_neuron_portion.amount_icp_e8s.unwrap();
         investment_per_controller_icp_e8s
-            .entry(hotkey_principal.clone())
+            .entry(hotkey_principal)
             .and_modify(|nns_neurons| {
                 nns_neurons.push(amount_icp_e8s);
             })
             .or_insert(vec![amount_icp_e8s]);
     }
 
-    for (hotkey_principal, nns_neurons) in investment_per_controller_icp_e8s.iter() {
+    for (controller, nns_neurons) in investment_per_controller_icp_e8s.iter() {
         let amount_icp_e8s = nns_neurons.iter().sum::<u64>();
         let amount_icp_e8s = u64_to_dec(amount_icp_e8s)?;
         let sns_neurons = sns_neuron_recipes_per_controller
-            .get(hotkey_principal)
+            .get(controller)
             .expect("All Neuron's Fund participants should have SNS neuron recipes.");
         let amount_sns_e8s = sns_neurons.iter().sum::<u64>();
         let amount_sns_e8s = u64_to_dec(amount_sns_e8s)?;
@@ -332,8 +328,8 @@ async fn validate_neurons_fund_sns_swap_participation(
             .collect::<Vec<_>>()
             .join(", ");
         let msg = format!(
-            "Neurons' Fund controller {} participated with {} ICP e8s ({}), receiving {} SNS token e8s ({}). Error = {}% = {} SNS e8s",
-            hotkey_principal, amount_icp_e8s, nns_neurons_str, amount_sns_e8s, sns_neurons_str, error_per_cent, absolute_error_sns_e8s,
+            "Neurons' Fund controller {:?} participated with {} ICP e8s ({}), receiving {} SNS token e8s ({}). Error = {}% = {} SNS e8s",
+            controller, amount_icp_e8s, nns_neurons_str, amount_sns_e8s, sns_neurons_str, error_per_cent, absolute_error_sns_e8s,
         );
         let cummulative_error_tolerance =
             ERROR_TOLERANCE_ICP_E8S * Decimal::from_usize(nns_neurons.len()).unwrap();

--- a/rs/sns/audit/src/lib.rs
+++ b/rs/sns/audit/src/lib.rs
@@ -198,7 +198,7 @@ async fn validate_neurons_fund_sns_swap_participation(
         .neurons_fund_reserves
         .unwrap()
         .neurons_fund_neuron_portions;
-    let mut initial_amounts_per_controller: BTreeMap<_, _> = BTreeMap::new();
+    let mut initial_amounts_per_controller = BTreeMap::new();
     for initial_neuron_portion in initial_neuron_portions.iter() {
         #[allow(deprecated)] // TODO(NNS1-3198): remove once hotkey_principal is removed
         let controller = initial_neuron_portion

--- a/rs/sns/init/src/lib.rs
+++ b/rs/sns/init/src/lib.rs
@@ -338,11 +338,13 @@ impl From<NeuronBasketConstructionParametersValidationError> for Result<(), Stri
 
 impl From<NeuronsFundParticipants> for ic_sns_swap::pb::v1::NeuronsFundParticipants {
     fn from(value: NeuronsFundParticipants) -> Self {
+        #[allow(deprecated)] // TODO(NNS1-3198): remove once hotkey_principal is removed
         Self {
             cf_participants: value
                 .participants
                 .iter()
                 .map(|cf_participant| ic_sns_swap::pb::v1::CfParticipant {
+                    controller: cf_participant.controller,
                     hotkey_principal: cf_participant.hotkey_principal.clone(),
                     cf_neurons: cf_participant.cf_neurons.clone(),
                 })

--- a/rs/sns/integration_tests/src/initialization_flow.rs
+++ b/rs/sns/integration_tests/src/initialization_flow.rs
@@ -565,7 +565,7 @@ fn test_one_proposal_sns_initialization_success_with_neurons_fund_participation(
 
     let cf_participants_principals = cf_participants
         .iter()
-        .map(|cf_participant| cf_participant.hotkey_principal.clone())
+        .map(|cf_participant| cf_participant.try_get_controller().unwrap())
         .collect::<Vec<_>>();
     let neurons = sns_governance_list_neurons(
         &sns_initialization_flow_test.state_machine,
@@ -578,7 +578,7 @@ fn test_one_proposal_sns_initialization_success_with_neurons_fund_participation(
         if neuron.is_neurons_fund_controlled() {
             at_least_one_sns_neuron_is_nf_controlled = true;
             let from_neurons_fund = neuron.permissions.iter().any(|permission| {
-                cf_participants_principals.contains(&permission.principal.unwrap().to_string())
+                cf_participants_principals.contains(&permission.principal.unwrap())
             });
             assert!(
                 from_neurons_fund,

--- a/rs/sns/swap/canister/swap.did
+++ b/rs/sns/swap/canister/swap.did
@@ -12,13 +12,20 @@ type CanisterStatusResultV2 = record {
   module_hash : opt blob;
 };
 type CanisterStatusType = variant { stopped; stopping; running };
-type CfInvestment = record { hotkey_principal : text; nns_neuron_id : nat64 };
+type CfInvestment = record {
+  controller : opt principal;
+  hotkey_principal : text;
+  hotkeys : opt Principals;
+  nns_neuron_id : nat64;
+};
 type CfNeuron = record {
   has_created_neuron_recipes : opt bool;
+  hotkeys : opt Principals;
   nns_neuron_id : nat64;
   amount_icp_e8s : nat64;
 };
 type CfParticipant = record {
+  controller : opt principal;
   hotkey_principal : text;
   cf_neurons : vec CfNeuron;
 };
@@ -211,6 +218,7 @@ type Possibility = variant {
 type Possibility_1 = variant { Ok : Response; Err : CanisterCallError };
 type Possibility_2 = variant { Ok : Ok_1; Err : Error };
 type Possibility_3 = variant { Ok : record {}; Err : CanisterCallError };
+type Principals = record { principals : vec principal };
 type RefreshBuyerTokensRequest = record {
   confirmation_text : opt text;
   buyer : text;

--- a/rs/sns/swap/proto/ic_sns_swap/pb/v1/swap.proto
+++ b/rs/sns/swap/proto/ic_sns_swap/pb/v1/swap.proto
@@ -507,6 +507,8 @@ message CfNeuron {
   // The amount of ICP that the Neurons' Fund invests associated
   // with this neuron.
   uint64 amount_icp_e8s = 2;
+  // The principals that can vote, propose, and follow on behalf of this neuron.
+  optional ic_nervous_system.pb.v1.Principals hotkeys = 4;
 
   // Idempotency flag indicating whether the neuron recipes have been created for
   // the CfNeuron. When set to true, it signifies that the action of creating neuron
@@ -517,10 +519,15 @@ message CfNeuron {
 
 // Represents a Neurons' Fund participant, possibly with several neurons.
 message CfParticipant {
-  // The principal that can vote on behalf of these Neurons' Fund neurons.
-  string hotkey_principal = 1;
+  // The principal that can manage this neuron.
+  optional ic_base_types.pb.v1.PrincipalId controller = 6;
   // Information about the participating neurons. Must not be empty.
   repeated CfNeuron cf_neurons = 2;
+
+  // The principal that can vote on behalf of these Neurons' Fund neurons.
+  // Deprecated. Please use `controller` instead (not `hotkeys`!)
+  // TODO(NNS1-3198): Remove
+  string hotkey_principal = 1 [deprecated = true];
 }
 
 // The construction parameters for the basket of neurons created for all
@@ -681,8 +688,16 @@ message DirectInvestment {
 // Information about a Neurons' Fund investment. The NNS Governance
 // canister is the controller of these neurons.
 message CfInvestment {
-  string hotkey_principal = 1;
+  // The principal that can manage this neuron.
+  optional ic_base_types.pb.v1.PrincipalId controller = 6;
+  // The principals that can vote, propose, and follow on behalf of this neuron.
+  optional ic_nervous_system.pb.v1.Principals hotkeys = 7;
+
   fixed64 nns_neuron_id = 2;
+
+  // Deprecated. Please use `controller` instead (not `hotkey_principal`)!
+  // TODO(NNS1-3198): Remove
+  string hotkey_principal = 1 [deprecated = true];
 }
 
 message TimeWindow {
@@ -1185,6 +1200,7 @@ message SettleNeuronsFundParticipationResponse {
     optional bool is_capped = 4;
 
     // Deprecated. Please use `controller` instead (not `hotkeys`!)
+    // TODO(NNS1-3198): Remove
     optional string hotkey_principal = 3 [deprecated = true];
   }
 

--- a/rs/sns/swap/proto/ic_sns_swap/pb/v1/swap.proto
+++ b/rs/sns/swap/proto/ic_sns_swap/pb/v1/swap.proto
@@ -519,8 +519,8 @@ message CfNeuron {
 
 // Represents a Neurons' Fund participant, possibly with several neurons.
 message CfParticipant {
-  // The principal that can manage this neuron.
-  optional ic_base_types.pb.v1.PrincipalId controller = 6;
+  // The principal that can manage the NNS neuron that participated in the Neurons' Fund.
+  optional ic_base_types.pb.v1.PrincipalId controller = 3;
   // Information about the participating neurons. Must not be empty.
   repeated CfNeuron cf_neurons = 2;
 
@@ -688,9 +688,12 @@ message DirectInvestment {
 // Information about a Neurons' Fund investment. The NNS Governance
 // canister is the controller of these neurons.
 message CfInvestment {
-  // The principal that can manage this neuron.
-  optional ic_base_types.pb.v1.PrincipalId controller = 6;
+  // The principal that can manage the NNS neuron that participated in the Neurons' Fund.
+  optional ic_base_types.pb.v1.PrincipalId controller = 3;
   // The principals that can vote, propose, and follow on behalf of this neuron.
+  // The controller of the corresponding NNS neuron is in the CfParticipant,
+  // which contains a vector of CfInvestments. This is because the controller
+  // is the same for all CfInvestments but the hotkeys may differ.
   optional ic_nervous_system.pb.v1.Principals hotkeys = 7;
 
   fixed64 nns_neuron_id = 2;

--- a/rs/sns/swap/src/gen/ic_sns_swap.pb.v1.rs
+++ b/rs/sns/swap/src/gen/ic_sns_swap.pb.v1.rs
@@ -501,8 +501,8 @@ pub struct CfNeuron {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CfParticipant {
-    /// The principal that can manage this neuron.
-    #[prost(message, optional, tag = "6")]
+    /// The principal that can manage the NNS neuron that participated in the Neurons' Fund.
+    #[prost(message, optional, tag = "3")]
     pub controller: ::core::option::Option<::ic_base_types::PrincipalId>,
     /// Information about the participating neurons. Must not be empty.
     #[prost(message, repeated, tag = "2")]
@@ -690,10 +690,13 @@ pub struct DirectInvestment {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CfInvestment {
-    /// The principal that can manage this neuron.
-    #[prost(message, optional, tag = "6")]
+    /// The principal that can manage the NNS neuron that participated in the Neurons' Fund.
+    #[prost(message, optional, tag = "3")]
     pub controller: ::core::option::Option<::ic_base_types::PrincipalId>,
     /// The principals that can vote, propose, and follow on behalf of this neuron.
+    /// The controller of the corresponding NNS neuron is in the CfParticipant,
+    /// which contains a vector of CfInvestments. This is because the controller
+    /// is the same for all CfInvestments but the hotkeys may differ.
     #[prost(message, optional, tag = "7")]
     pub hotkeys: ::core::option::Option<::ic_nervous_system_proto::pb::v1::Principals>,
     #[prost(fixed64, tag = "2")]

--- a/rs/sns/swap/src/gen/ic_sns_swap.pb.v1.rs
+++ b/rs/sns/swap/src/gen/ic_sns_swap.pb.v1.rs
@@ -486,6 +486,9 @@ pub struct CfNeuron {
     /// with this neuron.
     #[prost(uint64, tag = "2")]
     pub amount_icp_e8s: u64,
+    /// The principals that can vote, propose, and follow on behalf of this neuron.
+    #[prost(message, optional, tag = "4")]
+    pub hotkeys: ::core::option::Option<::ic_nervous_system_proto::pb::v1::Principals>,
     /// Idempotency flag indicating whether the neuron recipes have been created for
     /// the CfNeuron. When set to true, it signifies that the action of creating neuron
     /// recipes has been performed on this structure. If the action is retried, this flag
@@ -498,12 +501,18 @@ pub struct CfNeuron {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CfParticipant {
-    /// The principal that can vote on behalf of these Neurons' Fund neurons.
-    #[prost(string, tag = "1")]
-    pub hotkey_principal: ::prost::alloc::string::String,
+    /// The principal that can manage this neuron.
+    #[prost(message, optional, tag = "6")]
+    pub controller: ::core::option::Option<::ic_base_types::PrincipalId>,
     /// Information about the participating neurons. Must not be empty.
     #[prost(message, repeated, tag = "2")]
     pub cf_neurons: ::prost::alloc::vec::Vec<CfNeuron>,
+    /// The principal that can vote on behalf of these Neurons' Fund neurons.
+    /// Deprecated. Please use `controller` instead (not `hotkeys`!)
+    /// TODO(NNS1-3198): Remove
+    #[deprecated]
+    #[prost(string, tag = "1")]
+    pub hotkey_principal: ::prost::alloc::string::String,
 }
 /// The construction parameters for the basket of neurons created for all
 /// investors in the decentralization swap.
@@ -681,10 +690,19 @@ pub struct DirectInvestment {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CfInvestment {
-    #[prost(string, tag = "1")]
-    pub hotkey_principal: ::prost::alloc::string::String,
+    /// The principal that can manage this neuron.
+    #[prost(message, optional, tag = "6")]
+    pub controller: ::core::option::Option<::ic_base_types::PrincipalId>,
+    /// The principals that can vote, propose, and follow on behalf of this neuron.
+    #[prost(message, optional, tag = "7")]
+    pub hotkeys: ::core::option::Option<::ic_nervous_system_proto::pb::v1::Principals>,
     #[prost(fixed64, tag = "2")]
     pub nns_neuron_id: u64,
+    /// Deprecated. Please use `controller` instead (not `hotkey_principal`)!
+    /// TODO(NNS1-3198): Remove
+    #[deprecated]
+    #[prost(string, tag = "1")]
+    pub hotkey_principal: ::prost::alloc::string::String,
 }
 #[derive(
     candid::CandidType, candid::Deserialize, serde::Serialize, comparable::Comparable, Copy,
@@ -1525,6 +1543,7 @@ pub mod settle_neurons_fund_participation_response {
         #[prost(bool, optional, tag = "4")]
         pub is_capped: ::core::option::Option<bool>,
         /// Deprecated. Please use `controller` instead (not `hotkeys`!)
+        /// TODO(NNS1-3198): Remove
         #[deprecated]
         #[prost(string, optional, tag = "3")]
         pub hotkey_principal: ::core::option::Option<::prost::alloc::string::String>,

--- a/rs/sns/swap/src/swap.rs
+++ b/rs/sns/swap/src/swap.rs
@@ -35,6 +35,7 @@ use ic_canister_log::log;
 use ic_ledger_core::Tokens;
 use ic_nervous_system_clients::ledger_client::ICRC1Ledger;
 use ic_nervous_system_common::{i2d, ledger::compute_neuron_staking_subaccount_bytes};
+use ic_nervous_system_proto::pb::v1::Principals;
 use ic_neurons_fund::{MatchedParticipationFunction, PolynomialNeuronsFundParticipation};
 use ic_sns_governance::pb::v1::{
     claim_swap_neurons_request::NeuronParameters,
@@ -910,14 +911,20 @@ impl Swap {
                         total_participant_icp_e8s,
                     );
 
+                    #[allow(deprecated)] // TODO(NNS1-3198): Remove once hotkey_principal is removed
                     let Some(parsed_principal) =
-                        string_to_principal(&cf_participant.hotkey_principal)
+                    // TODO(NNS1-3198): Simplify once hotkey_principal is removed
+                    cf_participant
+                        .controller
+                        .or(string_to_principal(&cf_participant.hotkey_principal))
                     else {
                         sweep_result.invalid += neuron_basket_construction_parameters.count as u32;
                         return;
                     };
                     match create_sns_neuron_basket_for_cf_participant(
                         &parsed_principal,
+                        // TODO(NNS1-3199): Populate this field
+                        Vec::new(),
                         cf_neuron.nns_neuron_id,
                         amount_sns_e8s,
                         neuron_basket_construction_parameters,
@@ -1625,6 +1632,7 @@ impl Swap {
         let mut neuron_parameters = vec![];
 
         for recipe in &mut self.neuron_recipes {
+            // TODO(NNS1-3207): This match will need to be changed to evaluate to a Participant
             let (hotkey, controller, source_nns_neuron_id) = match recipe.investor.as_ref() {
                 Some(Investor::Direct(DirectInvestment { buyer_principal })) => {
                     let parsed_buyer_principal = match string_to_principal(buyer_principal) {
@@ -1640,25 +1648,19 @@ impl Swap {
 
                     (None, parsed_buyer_principal, None)
                 }
-                Some(Investor::CommunityFund(CfInvestment {
-                    hotkey_principal,
-                    nns_neuron_id,
-                })) => {
-                    let parsed_hotkey_principal = match string_to_principal(hotkey_principal) {
-                        Some(p) => p,
-                        // principal_str should always be parseable as a PrincipalId as that is enforced
-                        // in `refresh_buyer_tokens`. In the case of a bug due to programmer error, increment
-                        // the invalid field. This will require a manual intervention via an upgrade to correct
-                        None => {
+                Some(Investor::CommunityFund(cf_investment)) => {
+                    let nf_neuron_nns_controller = match cf_investment.try_get_controller() {
+                        Ok(controller) => controller,
+                        Err(e) => {
+                            log!(ERROR, "Invalid NF neuron: recipe={recipe:?} error={e}");
                             sweep_result.invalid += 1;
                             continue;
                         }
                     };
-
                     (
-                        Some(parsed_hotkey_principal),
-                        nns_governance.into(),
-                        Some(*nns_neuron_id),
+                        Some(nf_neuron_nns_controller),
+                        PrincipalId::from(nns_governance),
+                        Some(cf_investment.nns_neuron_id),
                     )
                 }
                 // SnsNeuronRecipe.investor should always be present as it is set in `commit`.
@@ -2285,6 +2287,7 @@ impl Swap {
                 }
             };
 
+            #[allow(deprecated)] // TODO(NNS1-3198): Remove once hotkey_principal is removed
             let dst_subaccount = match &recipe.investor {
                 Some(Investor::Direct(DirectInvestment { buyer_principal })) => {
                     match string_to_principal(buyer_principal) {
@@ -2299,6 +2302,8 @@ impl Swap {
                     }
                 }
                 Some(Investor::CommunityFund(CfInvestment {
+                    controller: _,
+                    hotkeys: _,
                     hotkey_principal: _,
                     nns_neuron_id: _,
                 })) => compute_neuron_staking_subaccount_bytes(nns_governance.into(), neuron_memo),
@@ -2502,7 +2507,11 @@ impl Swap {
             let cf_neurons: &mut Vec<CfNeuron> =
                 cf_participant_map.entry(np.controller).or_insert(vec![]);
 
-            let cf_neuron = match CfNeuron::try_new(np.nns_neuron_id, np.amount_icp_e8s) {
+            let cf_neuron = match CfNeuron::try_new(
+                np.nns_neuron_id,
+                np.amount_icp_e8s,
+                np.hotkeys.clone(),
+            ) {
                 Ok(cfn) => cfn,
                 Err(message) => {
                     defects.push(format!("NNS governance returned an invalid NeuronsFundNeuron. It cannot be converted to CfNeuron. Struct: {:?}, Reason: {}", np, message));
@@ -2520,10 +2529,13 @@ impl Swap {
         }
 
         // Convert the intermediate format into its final format
+        #[allow(deprecated)] // TODO(NNS1-3198): Remove once hotkey_principal is removed
         let cf_participants: Vec<CfParticipant> = cf_participant_map
             .into_iter()
-            .map(|(hotkey_principal, cf_neurons)| CfParticipant {
-                hotkey_principal: hotkey_principal.to_string(),
+            .map(|(nf_neuron_nns_controller, cf_neurons)| CfParticipant {
+                controller: Some(nf_neuron_nns_controller),
+                // TODO(NNS1-3198): Remove once hotkey_principal is removed
+                hotkey_principal: nf_neuron_nns_controller.to_string(),
                 cf_neurons,
             })
             .collect();
@@ -3332,7 +3344,7 @@ pub fn principal_to_subaccount(principal_id: &PrincipalId) -> Subaccount {
 
 /// A common pattern throughout the Swap canister is parsing the String
 /// representation of a PrincipalId and logging the error if any.
-fn string_to_principal(maybe_principal_id: &String) -> Option<PrincipalId> {
+pub(crate) fn string_to_principal(maybe_principal_id: &String) -> Option<PrincipalId> {
     match PrincipalId::from_str(maybe_principal_id) {
         Ok(principal_id) => Some(principal_id),
         Err(error_message) => {
@@ -3405,7 +3417,8 @@ fn create_sns_neuron_basket_for_direct_participant(
 
 /// Create the basket of SNS Neuron Recipes for a single Neurons' Fund participant.
 fn create_sns_neuron_basket_for_cf_participant(
-    hotkey_principal: &PrincipalId,
+    controller: &PrincipalId,
+    hotkeys: Vec<PrincipalId>,
     nns_neuron_id: u64,
     amount_sns_token_e8s: u64,
     neuron_basket_construction_parameters: &NeuronBasketConstructionParameters,
@@ -3444,6 +3457,7 @@ fn create_sns_neuron_basket_for_cf_participant(
             vec![neuron_id_with_longest_dissolve_delay.clone()]
         };
 
+        #[allow(deprecated)] // TODO(NNS1-3198): Remove once hotkey_principal is no longer used
         recipes.push(SnsNeuronRecipe {
             sns: Some(TransferableAmount {
                 amount_e8s: scheduled_vesting_event.amount_e8s,
@@ -3453,8 +3467,11 @@ fn create_sns_neuron_basket_for_cf_participant(
                 transfer_fee_paid_e8s: Some(0),
             }),
             investor: Some(Investor::CommunityFund(CfInvestment {
-                hotkey_principal: hotkey_principal.to_string(),
+                controller: Some(*controller),
+                hotkeys: Some(Principals::from(hotkeys.clone())),
                 nns_neuron_id,
+                // TODO(NNS1-3198): Remove
+                hotkey_principal: controller.to_string(),
             })),
             neuron_attributes: Some(NeuronAttributes {
                 memo,
@@ -3970,10 +3987,12 @@ mod tests {
 
     #[test]
     fn test_get_init() {
+        #[allow(deprecated)] // TODO(NNS1-3198): Remove once hotkey_principal is removed
         let swap = Swap {
             init: Some(Init {
                 neurons_fund_participants: Some(NeuronsFundParticipants {
                     cf_participants: vec![CfParticipant {
+                        controller: None,
                         hotkey_principal: "test".to_string(),
                         cf_neurons: vec![CfNeuron::default()],
                     }],
@@ -3996,22 +4015,47 @@ mod tests {
 
     #[test]
     fn test_list_community_fund_participants() {
+        #[allow(deprecated)] // TODO(NNS1-3198): Remove once hotkey_principal is removed
         let cf_participants = vec![
             CfParticipant {
+                controller: Some(PrincipalId::new_user_test_id(992899)),
                 hotkey_principal: PrincipalId::new_user_test_id(992899).to_string(),
-                cf_neurons: vec![CfNeuron::try_new(1, 698047).unwrap()],
+                cf_neurons: vec![CfNeuron::try_new(
+                    1,
+                    698047,
+                    Vec::new(), // TODO(NNS1-3199): Populate if relevant to this test
+                )
+                .unwrap()],
             },
             CfParticipant {
+                controller: Some(PrincipalId::new_user_test_id(800257)),
                 hotkey_principal: PrincipalId::new_user_test_id(800257).to_string(),
-                cf_neurons: vec![CfNeuron::try_new(2, 678574).unwrap()],
+                cf_neurons: vec![CfNeuron::try_new(
+                    2,
+                    678574,
+                    Vec::new(), // TODO(NNS1-3199): Populate if relevant to this test
+                )
+                .unwrap()],
             },
             CfParticipant {
+                controller: Some(PrincipalId::new_user_test_id(818371)),
                 hotkey_principal: PrincipalId::new_user_test_id(818371).to_string(),
-                cf_neurons: vec![CfNeuron::try_new(3, 305256).unwrap()],
+                cf_neurons: vec![CfNeuron::try_new(
+                    3,
+                    305256,
+                    Vec::new(), // TODO(NNS1-3199): Populate if relevant to this test
+                )
+                .unwrap()],
             },
             CfParticipant {
+                controller: Some(PrincipalId::new_user_test_id(657894)),
                 hotkey_principal: PrincipalId::new_user_test_id(657894).to_string(),
-                cf_neurons: vec![CfNeuron::try_new(4, 339747).unwrap()],
+                cf_neurons: vec![CfNeuron::try_new(
+                    4,
+                    339747,
+                    Vec::new(), // TODO(NNS1-3199): Populate if relevant to this test
+                )
+                .unwrap()],
             },
         ];
         let swap = Swap {
@@ -4805,25 +4849,29 @@ mod tests {
 
     #[test]
     fn test_cf_neuron_count() {
+        #[allow(deprecated)] // TODO(NNS1-3198): Remove once hotkey_principal is removed
         let cf_participants = vec![
             CfParticipant {
+                controller: Some(PrincipalId::new_user_test_id(992899)),
                 hotkey_principal: PrincipalId::new_user_test_id(992899).to_string(),
                 cf_neurons: vec![
-                    CfNeuron::try_new(1, 698047).unwrap(),
-                    CfNeuron::try_new(2, 303030).unwrap(),
+                    CfNeuron::try_new(1, 698047, Vec::new()).unwrap(),
+                    CfNeuron::try_new(2, 303030, Vec::new()).unwrap(),
                 ],
             },
             CfParticipant {
+                controller: Some(PrincipalId::new_user_test_id(800257)),
                 hotkey_principal: PrincipalId::new_user_test_id(800257).to_string(),
-                cf_neurons: vec![CfNeuron::try_new(3, 678574).unwrap()],
+                cf_neurons: vec![CfNeuron::try_new(3, 678574, Vec::new()).unwrap()],
             },
             CfParticipant {
+                controller: Some(PrincipalId::new_user_test_id(818371)),
                 hotkey_principal: PrincipalId::new_user_test_id(818371).to_string(),
                 cf_neurons: vec![
-                    CfNeuron::try_new(4, 305256).unwrap(),
-                    CfNeuron::try_new(5, 100000).unwrap(),
-                    CfNeuron::try_new(6, 1010101).unwrap(),
-                    CfNeuron::try_new(7, 102123).unwrap(),
+                    CfNeuron::try_new(4, 305256, Vec::new()).unwrap(),
+                    CfNeuron::try_new(5, 100000, Vec::new()).unwrap(),
+                    CfNeuron::try_new(6, 1010101, Vec::new()).unwrap(),
+                    CfNeuron::try_new(7, 102123, Vec::new()).unwrap(),
                 ],
             },
         ];

--- a/rs/sns/swap/src/types.rs
+++ b/rs/sns/swap/src/types.rs
@@ -18,6 +18,7 @@ use ic_base_types::{CanisterId, PrincipalId};
 use ic_canister_log::log;
 use ic_ledger_core::Tokens;
 use ic_nervous_system_common::{ledger::ICRC1Ledger, ONE_DAY_SECONDS};
+use ic_nervous_system_proto::pb::v1::Principals;
 use ic_sns_governance::pb::v1::{ClaimedSwapNeuronStatus, NeuronId};
 use icrc_ledger_types::icrc1::account::{Account, Subaccount};
 use std::str::FromStr;
@@ -708,16 +709,62 @@ impl DirectInvestment {
 
 impl CfInvestment {
     pub fn validate(&self) -> Result<(), String> {
-        if !is_valid_principal(&self.hotkey_principal) {
-            return Err(format!(
-                "Invalid hotkey_principal {}",
-                self.hotkey_principal
-            ));
-        }
+        self.try_get_controller()?;
+
         if self.nns_neuron_id == 0 {
             return Err("Missing nns_neuron_id".to_string());
         }
         Ok(())
+    }
+
+    /// Tries to get the controller, which may be either in the `controller` or `hotkey_principal` field.
+    /// If both fields are set, requires that they refer to the same principal before returning one.
+    pub fn try_get_controller(&self) -> Result<PrincipalId, String> {
+        #[allow(deprecated)] // TODO(NNS1-3198): Remove once hotkey_principal is removed
+        match (
+            self.controller,
+            crate::swap::string_to_principal(&self.hotkey_principal),
+        ) {
+            (Some(p1), Some(p2)) if p1 == p2 => Ok(p1),
+            // If hotkey_principal refers to a different principal than controller,
+            // or if neither is set, something has gone wrong.
+            (Some(_), Some(_)) => {
+                Err("Invalid NF neuron: controller and hotkey_principal do not match".to_string())
+            }
+            // If both fields are none, something has also gone wrong.
+            (None, None) => Err(
+                "Invalid NF neuron: controller is unset and hotkey_principal is invalid"
+                    .to_string(),
+            ),
+            // If only one is set, just use that one
+            (Some(p), None) => Ok(p),
+            (None, Some(p)) => Ok(p),
+        }
+    }
+}
+
+impl CfParticipant {
+    pub fn try_get_controller(&self) -> Result<PrincipalId, String> {
+        #[allow(deprecated)] // TODO(NNS1-3198): Remove once hotkey_principal is removed
+        match (
+            self.controller,
+            crate::swap::string_to_principal(&self.hotkey_principal),
+        ) {
+            (Some(p1), Some(p2)) if p1 == p2 => Ok(p1),
+            // If hotkey_principal refers to a different principal than controller,
+            // or if neither is set, something has gone wrong.
+            (Some(_), Some(_)) => Err(
+                "Invalid NF participant: controller and hotkey_principal do not match".to_string(),
+            ),
+            // If both fields are none, something has also gone wrong.
+            (None, None) => Err(
+                "Invalid NF participant: controller and hotkey_principal are both unset"
+                    .to_string(),
+            ),
+            // If only one is set, just use that one
+            (Some(p), None) => Ok(p),
+            (None, Some(p)) => Ok(p),
+        }
     }
 }
 
@@ -739,16 +786,12 @@ impl SnsNeuronRecipe {
 
 impl CfParticipant {
     pub fn validate(&self) -> Result<(), String> {
-        if !is_valid_principal(&self.hotkey_principal) {
-            return Err(format!(
-                "Invalid hotkey_principal {}",
-                self.hotkey_principal
-            ));
-        }
+        self.try_get_controller()?;
+
         if self.cf_neurons.is_empty() {
             return Err(format!(
-                "A CF participant ({}) must have at least one neuron",
-                self.hotkey_principal
+                "A CF participant ({:?}) must have at least one neuron",
+                self.try_get_controller()?
             ));
         }
         for n in &self.cf_neurons {
@@ -765,11 +808,16 @@ impl CfParticipant {
 }
 
 impl CfNeuron {
-    pub fn try_new(nns_neuron_id: u64, amount_icp_e8s: u64) -> Result<Self, String> {
+    pub fn try_new(
+        nns_neuron_id: u64,
+        amount_icp_e8s: u64,
+        hotkeys: Vec<PrincipalId>,
+    ) -> Result<Self, String> {
         let cf_neuron = Self {
             nns_neuron_id,
             amount_icp_e8s,
             has_created_neuron_recipes: Some(false),
+            hotkeys: Some(Principals::from(hotkeys.clone())),
         };
 
         cf_neuron.validate()?;
@@ -1174,6 +1222,9 @@ impl TryFrom<crate::pb::v1::settle_neurons_fund_participation_response::NeuronsF
 }
 
 #[cfg(test)]
+// TODO(NNS1-3198): remove #[allow(deprecated)] once hotkey_principal is removed.
+// Unfortunately, this must be applied to the whole module to avoid warnings on the hotkey_principal field in lazy_static.
+#[allow(deprecated)]
 mod tests {
     use super::*;
     use crate::{
@@ -1213,12 +1264,19 @@ mod tests {
         static ref OPEN_REQUEST: OpenRequest = OpenRequest {
             params: Some(PARAMS),
             cf_participants: vec![CfParticipant {
+                controller: Some(PrincipalId::new_user_test_id(423939)),
                 hotkey_principal: PrincipalId::new_user_test_id(423939).to_string(),
-                cf_neurons: vec![CfNeuron::try_new(42 ,99).unwrap()],
-            },],
+                cf_neurons: vec![CfNeuron::try_new(
+                    42,
+                    99,
+                    Vec::new() // TODO(NNS1-3199): populate with some hotkey principals
+                ).unwrap()],
+            }],
             open_sns_token_swap_proposal_id: Some(OPEN_SNS_TOKEN_SWAP_PROPOSAL_ID),
         };
+    }
 
+    lazy_static! {
         // Fill out Init just enough to test Params validation. These values are
         // similar to, but not the same analogous values in NNS.
         static ref INIT: Init = Init {
@@ -1337,10 +1395,11 @@ mod tests {
     #[test]
     fn participant_total_icp_e8s_no_overflow() {
         let participant = CfParticipant {
+            controller: None,
             hotkey_principal: "".to_string(),
             cf_neurons: vec![
-                CfNeuron::try_new(1, u64::MAX).unwrap(),
-                CfNeuron::try_new(2, u64::MAX).unwrap(),
+                CfNeuron::try_new(1, u64::MAX, Vec::new()).unwrap(),
+                CfNeuron::try_new(2, u64::MAX, Vec::new()).unwrap(),
             ],
         };
         let total = participant.participant_total_icp_e8s();

--- a/rs/sns/swap/src/types.rs
+++ b/rs/sns/swap/src/types.rs
@@ -743,31 +743,6 @@ impl CfInvestment {
     }
 }
 
-impl CfParticipant {
-    pub fn try_get_controller(&self) -> Result<PrincipalId, String> {
-        #[allow(deprecated)] // TODO(NNS1-3198): Remove once hotkey_principal is removed
-        match (
-            self.controller,
-            crate::swap::string_to_principal(&self.hotkey_principal),
-        ) {
-            (Some(p1), Some(p2)) if p1 == p2 => Ok(p1),
-            // If hotkey_principal refers to a different principal than controller,
-            // or if neither is set, something has gone wrong.
-            (Some(_), Some(_)) => Err(
-                "Invalid NF participant: controller and hotkey_principal do not match".to_string(),
-            ),
-            // If both fields are none, something has also gone wrong.
-            (None, None) => Err(
-                "Invalid NF participant: controller and hotkey_principal are both unset"
-                    .to_string(),
-            ),
-            // If only one is set, just use that one
-            (Some(p), None) => Ok(p),
-            (None, Some(p)) => Ok(p),
-        }
-    }
-}
-
 impl SnsNeuronRecipe {
     pub fn validate(&self) -> Result<(), String> {
         if let Some(sns) = &self.sns {
@@ -799,11 +774,35 @@ impl CfParticipant {
         }
         Ok(())
     }
+
     pub fn participant_total_icp_e8s(&self) -> u64 {
         self.cf_neurons
             .iter()
             .map(|x| x.amount_icp_e8s)
             .fold(0, |sum, v| sum.saturating_add(v))
+    }
+
+    pub fn try_get_controller(&self) -> Result<PrincipalId, String> {
+        #[allow(deprecated)] // TODO(NNS1-3198): Remove once hotkey_principal is removed
+        match (
+            self.controller,
+            crate::swap::string_to_principal(&self.hotkey_principal),
+        ) {
+            (Some(p1), Some(p2)) if p1 == p2 => Ok(p1),
+            // If hotkey_principal refers to a different principal than controller,
+            // or if neither is set, something has gone wrong.
+            (Some(_), Some(_)) => Err(
+                "Invalid NF participant: controller and hotkey_principal do not match".to_string(),
+            ),
+            // If both fields are none, something has also gone wrong.
+            (None, None) => Err(
+                "Invalid NF participant: controller and hotkey_principal are both unset"
+                    .to_string(),
+            ),
+            // If only one is set, just use that one
+            (Some(p), None) => Ok(p),
+            (None, Some(p)) => Ok(p),
+        }
     }
 }
 

--- a/rs/sns/swap/tests/common/mod.rs
+++ b/rs/sns/swap/tests/common/mod.rs
@@ -240,9 +240,22 @@ pub fn create_generic_sns_neuron_recipes(count: u64) -> Vec<SnsNeuronRecipe> {
 
 pub fn create_generic_cf_participants(count: u64) -> Vec<CfParticipant> {
     (1..count + 1)
-        .map(|i| CfParticipant {
-            hotkey_principal: i2principal_id_string(i),
-            cf_neurons: vec![CfNeuron::try_new(i, E8).unwrap()],
+        .map(|i| {
+            let i = i * 3;
+            #[allow(deprecated)] // TODO(NNS1-3198): remove once hotkey_principal is removed
+            CfParticipant {
+                controller: Some(PrincipalId::new_user_test_id(i)),
+                hotkey_principal: PrincipalId::new_user_test_id(i).to_string(),
+                cf_neurons: vec![CfNeuron::try_new(
+                    i,
+                    E8,
+                    vec![
+                        PrincipalId::new_user_test_id(i + 1),
+                        PrincipalId::new_user_test_id(i + 2),
+                    ],
+                )
+                .unwrap()],
+            }
         })
         .collect()
 }

--- a/rs/sns/swap/tests/swap.rs
+++ b/rs/sns/swap/tests/swap.rs
@@ -32,6 +32,7 @@ use ic_nervous_system_common_test_utils::{
     SpyLedger,
 };
 use ic_nervous_system_proto::pb::v1::Countries;
+use ic_nervous_system_proto::pb::v1::Principals;
 use ic_neurons_fund::{
     InvertibleFunction, MatchingFunction, NeuronsFundParticipationLimits,
     PolynomialMatchingFunction, SerializableFunction,
@@ -874,7 +875,7 @@ fn test_scenario_happy() {
                                                 *neurons_fund_participant_principal_id,
                                             ),
                                             // TODO(NNS1-3199): Populate this field if it is relevant for this test
-                                            hotkeys: Some(vec![].into()),
+                                            hotkeys: Some(Principals::from(Vec::new())),
                                             is_capped: Some(false),
                                             hotkey_principal: Some(
                                                 neurons_fund_participant_principal_id.to_string(),
@@ -1174,7 +1175,7 @@ async fn test_finalize_swap_ok_matched_funding() {
         SpyLedger,
         SpyNnsGovernanceClient,
     > {
-        #[allow(deprecated)] // TODO(NNS1-3198): Remove this once hotkey_principals is removed.
+        #[allow(deprecated)] // TODO(NNS1-3198): Remove this once hotkey_principal is removed.
         CanisterClients {
             sns_governance: SpySnsGovernanceClient::new(vec![
                 SnsGovernanceClientReply::ClaimSwapNeurons(ClaimSwapNeuronsResponse::new(
@@ -1223,7 +1224,7 @@ async fn test_finalize_swap_ok_matched_funding() {
                                     amount_icp_e8s: Some(100 * E8),
                                     controller: Some(PrincipalId::new_user_test_id(1)),
                                     // TODO(NNS1-3199): Populate this field if it is relevant for this test
-                                    hotkeys: Some(vec![].into()),
+                                    hotkeys: Some(Principals::from(Vec::new())),
                                     is_capped: Some(true),
                                     hotkey_principal: Some(
                                         PrincipalId::new_user_test_id(1).to_string(),
@@ -3434,6 +3435,7 @@ async fn test_claim_swap_neuron_correctly_creates_neuron_parameters() {
     // Step 1: Prepare the world
 
     // Create some valid and invalid NeuronRecipes in the state
+    #[allow(deprecated)] // TODO(NNS1-3198): Remove this once hotkey_principal is deprecated
     let mut swap = Swap {
         lifecycle: Committed as i32,
         init: Some(init()),
@@ -3462,6 +3464,8 @@ async fn test_claim_swap_neuron_correctly_creates_neuron_parameters() {
                     followees: vec![NeuronId::new_test_neuron_id(20).into()],
                 }),
                 investor: Some(Investor::CommunityFund(CfInvestment {
+                    controller: Some(*TEST_USER2_PRINCIPAL),
+                    hotkeys: Some(Principals::from(Vec::new())),
                     hotkey_principal: (*TEST_USER2_PRINCIPAL).to_string(),
                     nns_neuron_id: 100,
                 })),
@@ -3930,6 +3934,7 @@ fn test_create_sns_neuron_recipes_skips_already_created_neuron_recipes_for_nf_pa
         .count as u32;
 
     // Create some valid and invalid buyers in the state
+    #[allow(deprecated)] // TODO(NNS1-3198): Remove once hotkey_principal is removed
     let mut swap = Swap {
         lifecycle: Committed as i32,
         init: Some(init()),
@@ -3939,19 +3944,23 @@ fn test_create_sns_neuron_recipes_skips_already_created_neuron_recipes_for_nf_pa
         neurons_fund_participation_icp_e8s: Some(100 * E8),
         cf_participants: vec![
             CfParticipant {
-                hotkey_principal: i2principal_id_string(1001),
+                controller: Some(PrincipalId::new_user_test_id(1001)),
+                hotkey_principal: PrincipalId::new_user_test_id(1001).to_string(),
                 cf_neurons: vec![CfNeuron {
                     nns_neuron_id: 1,
                     amount_icp_e8s: 50 * E8,
                     has_created_neuron_recipes: Some(true),
+                    hotkeys: Some(Principals::from(Vec::new())),
                 }],
             },
             CfParticipant {
-                hotkey_principal: i2principal_id_string(1002),
+                controller: Some(PrincipalId::new_user_test_id(1002)),
+                hotkey_principal: PrincipalId::new_user_test_id(1002).to_string(),
                 cf_neurons: vec![CfNeuron {
                     nns_neuron_id: 2,
                     amount_icp_e8s: 50 * E8,
                     has_created_neuron_recipes: Some(false),
+                    hotkeys: Some(Principals::from(Vec::new())),
                 }],
             },
         ],
@@ -4086,7 +4095,7 @@ async fn test_settle_neurons_fund_participation_returns_successfully_on_subseque
         ..Default::default()
     };
 
-    #[allow(deprecated)] // TODO(NNS1-3198): Remove this once hotkey_principals is removed.
+    #[allow(deprecated)] // TODO(NNS1-3198): Remove this once hotkey_principal is removed.
     let mut spy_nns_governance_client = SpyNnsGovernanceClient::new(vec![
         NnsGovernanceClientReply::SettleNeuronsFundParticipation(
             SettleNeuronsFundParticipationResponse {
@@ -4097,7 +4106,7 @@ async fn test_settle_neurons_fund_participation_returns_successfully_on_subseque
                             amount_icp_e8s: Some(100 * E8),
                             controller: Some(PrincipalId::new_user_test_id(1)),
 
-                            hotkeys: Some(vec![].into()),
+                            hotkeys: Some(Principals::from(Vec::new())),
                             is_capped: Some(true),
                             hotkey_principal: Some(PrincipalId::new_user_test_id(1).to_string()),
                         }],
@@ -4232,7 +4241,7 @@ async fn test_settle_neurons_fund_participation_handles_invalid_governance_respo
         ..Default::default()
     };
 
-    #[allow(deprecated)] // TODO(NNS1-3198): Remove this once hotkey_principals is removed.
+    #[allow(deprecated)] // TODO(NNS1-3198): Remove this once hotkey_principal is removed.
     let mut spy_nns_governance_client = SpyNnsGovernanceClient::new(vec![
         NnsGovernanceClientReply::SettleNeuronsFundParticipation(
             SettleNeuronsFundParticipationResponse {
@@ -4243,7 +4252,7 @@ async fn test_settle_neurons_fund_participation_handles_invalid_governance_respo
                             amount_icp_e8s: Some(0),
                             controller: Some(PrincipalId::new_user_test_id(1)),
                             // TODO(NNS1-3199): Populate this field if it is relevant for this test
-                            hotkeys: Some(vec![].into()),
+                            hotkeys: Some(Principals::from(Vec::new())),
                             is_capped: Some(false),
                             hotkey_principal: Some(PrincipalId::new_user_test_id(1).to_string()),
                         }],


### PR DESCRIPTION
## Change 1: 

A `controller` field has been added to replace `hotkey_principal` (which is now deprecated and will hopefully be removed). New versions of the code populate both fields. New versions of the code only require at least one of the two fields to be populated.

This change is useful because the previous name for `controller`, `hotkey_principal`, is very confusing because it doesn't refer to the NNS neuron's hotkey, instead it refers to the NNS neuron's controller. (It is named that way because it becomes a hotkey on the SNS neuron that is allocated to that NNS neuron, but it does not represent a hotkey on the NNS neuron.)

## Change 2: 

A `hotkeys` field has been added.

This is useful because we want to transfer NF neurons' hotkeys from the NNS over to the SNS.

## Upgrade dependency

**None.** This MR merely extends various API with additional fields, and doesn’t change existing fields. All the new fields are optional, so there is no upgrade dependency introduced by this MR. No canisters currently require these fields to be `Some`.

NNS1-3198 (which tracks the removal `hotkey_principal`) can only be implemented once the old fields are no longer used by any canisters, and will have to be rolled out carefully since the field is non-optional. 

## Misc.

1. I moved the proto definition of `Principals` to nervous_system/proto. I think this is backwards compatible but the buf backwards compatibility checker disagrees. Since we haven't deployed anything that uses Principals yet, it should still be safe to merge