### PR TITLE
chore: RUN-1015: Derive ParitalEq for all sandbox IPC types

### DIFF
--- a/rs/canister_sandbox/src/protocol/sbxsvc.rs
+++ b/rs/canister_sandbox/src/protocol/sbxsvc.rs
@@ -30,18 +30,18 @@ use super::{
 /// this RPC (controller may perform a "hard kill" after timeout).
 ///
 /// We do not implement graceful termination.
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct TerminateRequest {}
 
 /// Ack signal to the controller that termination was complete.
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct TerminateReply {}
 
 /// Register wasm for a canister that can be executed in the sandbox.
 /// Multiple wasms can be registered to the same sandbox (in order to
 /// support multiple code states e.g. during upgrades). A single wasm
 /// instance can be used concurrently for multiple executions.
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct OpenWasmRequest {
     /// Id used to later refer to this canister runner. Must be unique
     /// per sandbox instance.
@@ -57,10 +57,10 @@ pub struct OpenWasmRequest {
 }
 
 /// Reply to an `OpenWasmRequest`.
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct OpenWasmReply(pub HypervisorResult<(CompilationResult, SerializedModule)>);
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct OpenWasmSerializedRequest {
     /// Id used to later refer to this canister runner. Must be unique
     /// per sandbox instance.
@@ -76,31 +76,31 @@ pub struct OpenWasmSerializedRequest {
 }
 
 /// Reply to an `OpenWasmRequest`.
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct OpenWasmSerializedReply(pub HypervisorResult<()>);
 
 /// Request to close the indicated wasm object.
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct CloseWasmRequest {
     pub wasm_id: WasmId,
 }
 
 /// Reply to a `CloseWasm` request.
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct CloseWasmReply {
     pub success: bool,
 }
 
 /// We build state on the tip or branch off at some specific round via
 /// tagged state.
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub enum StateBranch {
     TipOfTheTip,
     Round(structs::Round),
 }
 
 /// Represents a snapshot of a memory that can be sent to the sandbox process.
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct MemorySerialization {
     pub page_map: PageMapSerialization,
     pub num_wasm_pages: NumWasmPages,
@@ -164,7 +164,7 @@ impl EnumerateInnerFileDescriptors for PageAllocatorSerialization {
 }
 
 /// Describe a request to open a particular memory.
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct OpenMemoryRequest {
     pub memory_id: MemoryId,
     pub memory: MemorySerialization,
@@ -178,25 +178,25 @@ impl EnumerateInnerFileDescriptors for OpenMemoryRequest {
 
 /// Ack to the controller that memory was opened or failed to open. A
 /// failure to open will lead to a panic in the controller.
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct OpenMemoryReply {
     pub success: bool,
 }
 
 /// Request the indicated memory to be purged and dropped.
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct CloseMemoryRequest {
     pub memory_id: MemoryId,
 }
 
 /// Ack memory was successfully closed or not.
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct CloseMemoryReply {
     pub success: bool,
 }
 
 /// Start execution of a canister.
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Serialize, Deserialize, Clone, PartialEq)]
 pub struct StartExecutionRequest {
     /// Id of the newly created invocation of this canister. This is
     /// used to identify the running instance in callbacks as well as
@@ -218,38 +218,38 @@ pub struct StartExecutionRequest {
 }
 
 /// Reply to an `StartExecutionRequest`.
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct StartExecutionReply {
     pub success: bool,
 }
 
 /// Resume execution.
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Serialize, Deserialize, Clone, PartialEq)]
 pub struct ResumeExecutionRequest {
     /// Id of the previously paused execution.
     pub exec_id: ExecId,
 }
 
 /// Reply to an `ResumeExecutionRequest`.
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct ResumeExecutionReply {
     pub success: bool,
 }
 
 /// Abort execution.
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Serialize, Deserialize, Clone, PartialEq)]
 pub struct AbortExecutionRequest {
     /// Id of the previously paused execution.
     pub exec_id: ExecId,
 }
 
 /// Reply to an `AbortExecutionRequest`.
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct AbortExecutionReply {
     pub success: bool,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct CreateExecutionStateRequest {
     pub wasm_id: WasmId,
     #[serde(with = "serde_bytes")]
@@ -267,7 +267,7 @@ impl EnumerateInnerFileDescriptors for CreateExecutionStateRequest {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct CreateExecutionStateSuccessReply {
     pub wasm_memory_modifications: MemoryModifications,
     pub exported_globals: Vec<Global>,
@@ -275,10 +275,10 @@ pub struct CreateExecutionStateSuccessReply {
     pub serialized_module: SerializedModule,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct CreateExecutionStateReply(pub HypervisorResult<CreateExecutionStateSuccessReply>);
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct CreateExecutionStateSerializedRequest {
     pub wasm_id: WasmId,
     /// The serialization of a previously compiled `wasmtime::Module`.
@@ -301,7 +301,7 @@ impl EnumerateInnerFileDescriptors for CreateExecutionStateSerializedRequest {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct CreateExecutionStateSerializedSuccessReply {
     pub wasm_memory_modifications: MemoryModifications,
     pub exported_globals: Vec<Global>,
@@ -309,14 +309,14 @@ pub struct CreateExecutionStateSerializedSuccessReply {
     pub total_sandbox_time: Duration,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct CreateExecutionStateSerializedReply(
     pub HypervisorResult<CreateExecutionStateSerializedSuccessReply>,
 );
 
 /// All possible requests to a sandboxed process.
 #[allow(clippy::large_enum_variant)]
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Serialize, Deserialize, Clone, PartialEq)]
 pub enum Request {
     Terminate(TerminateRequest),
     OpenWasm(OpenWasmRequest),

--- a/rs/canister_sandbox/src/protocol/structs.rs
+++ b/rs/canister_sandbox/src/protocol/structs.rs
@@ -12,10 +12,10 @@ use serde::{Deserialize, Serialize};
 
 use super::id::MemoryId;
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct Round(pub u64);
 
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Serialize, Deserialize, Clone, PartialEq)]
 pub struct SandboxExecInput {
     pub func_ref: FuncRef,
     pub api_type: ApiType,
@@ -32,7 +32,7 @@ pub struct SandboxExecInput {
     pub wasm_reserved_pages: NumWasmPages,
 }
 
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Serialize, Deserialize, Clone, PartialEq)]
 pub struct SandboxExecOutput {
     pub slice: SliceExecutionOutput,
     pub wasm: WasmExecutionOutput,
@@ -42,13 +42,13 @@ pub struct SandboxExecOutput {
 }
 
 /// Describes the memory changes performed by execution.
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct MemoryModifications {
     pub page_delta: PageDeltaSerialization,
     pub size: NumWasmPages,
 }
 
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Serialize, Deserialize, Clone, PartialEq)]
 pub struct StateModifications {
     /// The state of the global variables after execution.
     pub globals: Vec<Global>,

--- a/rs/cycles_account_manager/src/lib.rs
+++ b/rs/cycles_account_manager/src/lib.rs
@@ -76,7 +76,7 @@ impl std::fmt::Display for CyclesAccountManagerError {
 /// This struct maintains an invariant that `usage <= capacity` and
 /// `threshold <= capacity`.  There are no constraints between `usage` and
 /// `threshold`.
-#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq)]
 pub struct ResourceSaturation {
     usage: u64,
     threshold: u64,

--- a/rs/embedders/src/lib.rs
+++ b/rs/embedders/src/lib.rs
@@ -46,7 +46,7 @@ pub struct InstanceRunResult {
 
 /// The results of compiling a Canister which need to be passed back to the main
 /// replica process.
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct CompilationResult {
     /// The number of instructions in the canister's largest function.
     pub largest_function_instruction_count: NumInstructions,

--- a/rs/embedders/src/serialized_module.rs
+++ b/rs/embedders/src/serialized_module.rs
@@ -12,7 +12,7 @@ use crate::wasm_utils::{
 };
 
 /// A `wasmtime::Module` that has been serialized.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct SerializedModuleBytes(#[serde(with = "serde_bytes")] Vec<u8>);
 
 impl TryFrom<&Module> for SerializedModuleBytes {
@@ -51,7 +51,7 @@ impl SerializedModuleBytes {
 /// Contains all data needed to construct a canister's execution state and
 /// execute messages against it. If the execution state already exists, then
 /// only the `bytes` field is needed to handle execution.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct SerializedModule {
     /// The serialized `wasmtime::Module`. This field is wrapped in an `Arc` so
     /// that it can be cheaply moved out of the `SerializedModule` in the cases

--- a/rs/embedders/src/wasm_executor.rs
+++ b/rs/embedders/src/wasm_executor.rs
@@ -103,7 +103,7 @@ impl WasmExecutorMetrics {
 }
 
 /// Contains information about execution of the current slice.
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Serialize, Deserialize, Clone, PartialEq)]
 pub struct SliceExecutionOutput {
     /// The number of instructions executed by the slice.
     pub executed_instructions: NumInstructions,

--- a/rs/interfaces/src/execution_environment.rs
+++ b/rs/interfaces/src/execution_environment.rs
@@ -28,7 +28,7 @@ use tower::util::BoxCloneService;
 /// Instance execution statistics. The stats are cumulative and
 /// contain measurements from the point in time when the instance was
 /// created up until the moment they are requested.
-#[derive(Serialize, Deserialize, Clone, Debug, Default)]
+#[derive(Serialize, Deserialize, Clone, Debug, Default, PartialEq)]
 pub struct InstanceStats {
     /// Total number of (host) OS pages (4KiB) accessed (read or written) by the instance
     /// and loaded into the linear memory.
@@ -241,7 +241,7 @@ pub enum SystemApiCallId {
 
 /// System API call counters, i.e. how many times each tracked System API call
 /// was invoked.
-#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq)]
 pub struct SystemApiCallCounters {
     /// Counter for `ic0.data_certificate_copy()`
     pub data_certificate_copy: usize,
@@ -1256,7 +1256,7 @@ pub trait Scheduler: Send {
     ) -> Self::State;
 }
 
-#[derive(Clone, Serialize, Deserialize, Debug)]
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
 pub struct WasmExecutionOutput {
     pub wasm_result: Result<Option<WasmResult>, HypervisorError>,
     pub num_instructions_left: NumInstructions,

--- a/rs/replicated_state/src/page_map.rs
+++ b/rs/replicated_state/src/page_map.rs
@@ -1103,7 +1103,7 @@ impl std::fmt::Debug for PageMap {
 /// It contains sufficient information to reconstruct `PageMap`
 /// in another process. Note that canister sandboxing does not
 /// need `unflushed_delta`, but the field is kept for consistency here.
-#[derive(Serialize, Deserialize, Clone, Debug)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub struct PageMapSerialization {
     pub storage: StorageSerialization,
     pub base_height: Option<Height>,

--- a/rs/replicated_state/src/page_map/checkpoint.rs
+++ b/rs/replicated_state/src/page_map/checkpoint.rs
@@ -220,7 +220,7 @@ impl Default for Checkpoint {
 ///
 /// It contains sufficient information to reconstruct `Mapping`
 /// in another process.
-#[derive(Serialize, Deserialize, Clone, Debug)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub struct MappingSerialization {
     pub file_descriptor: FileDescriptor,
     pub file_len: FileOffset,
@@ -230,7 +230,7 @@ pub struct MappingSerialization {
 ///
 /// It contains sufficient information to reconstruct `Checkpoint`
 /// in another process.
-#[derive(Serialize, Deserialize, Clone, Debug)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub struct CheckpointSerialization {
     pub mapping: Option<MappingSerialization>,
 }

--- a/rs/replicated_state/src/page_map/page_allocator.rs
+++ b/rs/replicated_state/src/page_map/page_allocator.rs
@@ -153,7 +153,7 @@ pub fn allocated_pages_count() -> usize {
 /// It contains sufficient information to reconstruct the page allocator
 /// in another process ensuring that there are no two page allocators
 /// with the same id.
-#[derive(Serialize, Deserialize, Clone, Debug)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub struct PageAllocatorSerialization {
     pub id: PageAllocatorId,
     pub fd: FileDescriptor,
@@ -182,7 +182,7 @@ pub struct PageSerialization {
 ///
 /// This validation is also useful for checking that the page transfer between
 /// the sandbox and the replica processes works properly.
-#[derive(Serialize, Deserialize, Clone, Copy, Debug, Default)]
+#[derive(Serialize, Deserialize, Clone, Copy, Debug, Default, PartialEq)]
 pub struct PageValidation {
     // The index of a non-zero two-byte word in the page.
     // It is zero if no such word exists.
@@ -193,7 +193,7 @@ pub struct PageValidation {
 }
 
 /// Serialization-friendly representation of an mmap-based page.
-#[derive(Serialize, Deserialize, Clone, Debug)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub struct MmapPageSerialization {
     pub page_index: PageIndex,
     pub file_offset: FileOffset,
@@ -207,7 +207,7 @@ pub struct MmapPageSerialization {
 /// Each page is represented by its offset in the file. The length of the file is
 /// sent along to simplify deserialization. It is guaranteed that the file
 /// offsets of all pages are smaller than the length of the file.
-#[derive(Serialize, Deserialize, Clone, Debug)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub struct PageDeltaSerialization {
     file_len: FileOffset,
     pages: Vec<MmapPageSerialization>,

--- a/rs/replicated_state/src/page_map/storage.rs
+++ b/rs/replicated_state/src/page_map/storage.rs
@@ -1632,19 +1632,19 @@ fn write_overlay(
     Ok(())
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub enum BaseFileSerialization {
     Base(CheckpointSerialization),
     Overlay(Vec<OverlayFileSerialization>),
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub struct StorageSerialization {
     pub base: BaseFileSerialization,
     pub overlays: Vec<OverlayFileSerialization>,
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub struct OverlayFileSerialization {
     pub mapping: MappingSerialization,
 }

--- a/rs/system_api/src/lib.rs
+++ b/rs/system_api/src/lib.rs
@@ -103,7 +103,7 @@ fn summarize(heap: &[u8], start: usize, size: usize) -> u64 {
 /// Supports operations to reduce the message limit while keeping the maximum
 /// slice limit the same, which is useful for messages that have multiple
 /// execution steps such as install, upgrade, and response.
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 pub struct InstructionLimits {
     /// The total instruction limit for message execution. With deterministic
     /// time slicing this limit may exceed the per-round instruction limit.  The
@@ -169,7 +169,7 @@ impl InstructionLimits {
 }
 
 // Canister and subnet configuration parameters required for execution.
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 pub struct ExecutionParameters {
     pub instruction_limits: InstructionLimits,
     pub canister_memory_limit: NumBytes,
@@ -225,7 +225,7 @@ pub enum ModificationTracking {
 /// deserializing will result in duplication of the data, but no issues in
 /// correctness.
 #[allow(clippy::large_enum_variant)]
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize, PartialEq)]
 pub enum ApiType {
     /// For executing the `canister_start` method
     Start {

--- a/rs/system_api/src/sandbox_safe_system_state.rs
+++ b/rs/system_api/src/sandbox_safe_system_state.rs
@@ -33,7 +33,7 @@ use std::str::FromStr;
 use crate::{cycles_balance_change::CyclesBalanceChange, routing, CERTIFIED_DATA_MAX_LENGTH};
 
 /// The information that canisters can see about their own status.
-#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
 pub enum CanisterStatusView {
     Running,
     Stopping,
@@ -50,14 +50,14 @@ impl CanisterStatusView {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub enum CallbackUpdate {
     Register(CallbackId, Callback),
     Unregister(CallbackId),
 }
 
 /// Tracks changes to the system state that the canister has requested.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct SystemStateChanges {
     pub(super) new_certified_data: Option<Vec<u8>>,
     pub(super) callback_updates: Vec<CallbackUpdate>,
@@ -545,7 +545,7 @@ impl SystemStateChanges {
 /// A version of the `SystemState` that can be used in a sandboxed process.
 /// Changes are separately tracked so that we can verify the changes are valid
 /// before applying them to the actual system state.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct SandboxSafeSystemState {
     /// Only public for tests
     #[doc(hidden)]

--- a/rs/types/types/src/methods.rs
+++ b/rs/types/types/src/methods.rs
@@ -374,7 +374,7 @@ impl TryFrom<pb::Callback> for Callback {
 }
 
 /// A reference to a callable function/method in a Wasm module, which can be:
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub enum FuncRef {
     /// A method that a canister can export.
     Method(WasmMethod),


### PR DESCRIPTION
This is a mechanical change that adds `PartialEq` to all types that are used in the IPC between replica and sandbox.

The motivation for this change is to write tests that assert that all IPC types can correctly round-trip with bincode:

```
deserialize(serialize(x)) == x
```