### PR TITLE
chore(idx): Restore buf.yaml

### DIFF
--- a/buf.yaml
+++ b/buf.yaml
@@ -9,14 +9,12 @@ build:
     - rs/nns/common/proto
     - rs/nns/gtc/proto Temporarily removed because a PR was reverted and then un-reverted
     - rs/nns/handlers/root/impl/proto
-    # Temporarily disabling to work around buf. Remove ASAP after merge.
-    # - rs/nns/governance/proto
+    - rs/nns/governance/proto
     - rs/protobuf/def
     - rs/rosetta-api/icp_ledger/proto
     - rs/sns/governance/proto
     - rs/sns/root/proto
-    # Temporarily disabling to work around buf. Remove ASAP after merge.
-    # rs/sns/swap/proto
+    - rs/sns/swap/proto
     - rs/types/base_types/proto
 lint:
   use:


### PR DESCRIPTION
This MR restores buf.yaml, which was only partially disabled to temporarily remove its restrictions on backwards-incompatible changes