### PR TITLE
feat: Add new type of task OnLowWasmMemory

### DIFF
--- a/rs/execution_environment/src/execution/update.rs
+++ b/rs/execution_environment/src/execution/update.rs
@@ -149,6 +149,12 @@ pub fn execute_update(
             time,
             helper.call_context_id(),
         ),
+        CanisterCallOrTask::Task(CanisterTask::OnLowWasmMemory) => ApiType::system_task(
+            IC_00.get(),
+            SystemMethod::CanisterOnLowWasmMemory,
+            time,
+            helper.call_context_id(),
+        ),
     };
 
     let memory_usage = helper.canister().memory_usage();
@@ -333,7 +339,9 @@ impl UpdateHelper {
         let initial_cycles_balance = canister.system_state.balance();
 
         match original.call_or_task {
-            CanisterCallOrTask::Call(_) | CanisterCallOrTask::Task(CanisterTask::Heartbeat) => {}
+            CanisterCallOrTask::Call(_)
+            | CanisterCallOrTask::Task(CanisterTask::Heartbeat)
+            | CanisterCallOrTask::Task(CanisterTask::OnLowWasmMemory) => {}
             CanisterCallOrTask::Task(CanisterTask::GlobalTimer) => {
                 // The global timer is one-off.
                 canister.system_state.global_timer = CanisterTimer::Inactive;

--- a/rs/execution_environment/src/execution_environment.rs
+++ b/rs/execution_environment/src/execution_environment.rs
@@ -3201,6 +3201,7 @@ impl ExecutionEnvironment {
         match task {
             ExecutionTask::Heartbeat
             | ExecutionTask::GlobalTimer
+            | ExecutionTask::OnLowWasmMemory
             | ExecutionTask::PausedExecution { .. }
             | ExecutionTask::AbortedExecution { .. } => {
                 panic!(
@@ -3851,6 +3852,10 @@ pub fn execute_canister(
             }
             ExecutionTask::GlobalTimer => {
                 let task = CanisterMessageOrTask::Task(CanisterTask::GlobalTimer);
+                (task, None)
+            }
+            ExecutionTask::OnLowWasmMemory => {
+                let task = CanisterMessageOrTask::Task(CanisterTask::OnLowWasmMemory);
                 (task, None)
             }
             ExecutionTask::AbortedExecution {

--- a/rs/execution_environment/src/execution_environment.rs
+++ b/rs/execution_environment/src/execution_environment.rs
@@ -3298,7 +3298,8 @@ impl ExecutionEnvironment {
                     ExecutionTask::AbortedExecution { .. }
                     | ExecutionTask::AbortedInstallCode { .. }
                     | ExecutionTask::Heartbeat
-                    | ExecutionTask::GlobalTimer => task,
+                    | ExecutionTask::GlobalTimer
+                    | ExecutionTask::OnLowWasmMemory => task,
                     ExecutionTask::PausedExecution { id, .. } => {
                         let paused = self.take_paused_execution(id).unwrap();
                         let (input, prepaid_execution_cycles) = paused.abort(log);

--- a/rs/execution_environment/src/scheduler.rs
+++ b/rs/execution_environment/src/scheduler.rs
@@ -1381,6 +1381,10 @@ impl SchedulerImpl {
                             id
                         );
                     }
+                    // TODO [EXC-1666]
+                    // For now, since OnLowWasmMemory is not used we will copy behaviour similar
+                    // to Heartbeat and GlobalTimer, but when the feature is implemented we will
+                    // come back to it, to revisit if we should keep it after the round ends.
                     ExecutionTask::OnLowWasmMemory => {
                         panic!(
                             "Unexpected on low wasm memory task after a round in canister {:?}",

--- a/rs/protobuf/def/state/canister_state_bits/v1/canister_state_bits.proto
+++ b/rs/protobuf/def/state/canister_state_bits/v1/canister_state_bits.proto
@@ -102,6 +102,7 @@ message WasmMethod {
     SYSTEM_METHOD_CANISTER_HEARTBEAT = 6;
     reserved 7; // deprecated SYSTEM_METHOD_EMPTY
     SYSTEM_METHOD_CANISTER_GLOBAL_TIMER = 8;
+    SYSTEM_METHOD_CANISTER_ON_LOW_WASM_MEMORY = 9;
   }
   oneof wasm_method {
     string update = 1;
@@ -183,6 +184,7 @@ message ExecutionTask {
     CANISTER_TASK_UNSPECIFIED = 0;
     CANISTER_TASK_HEARTBEAT = 1;
     CANISTER_TASK_TIMER = 2;
+    CANISTER_TASK_ON_LOW_WASM_MEMORY = 3;
   }
 
   message AbortedExecution {

--- a/rs/protobuf/src/gen/state/state.canister_state_bits.v1.rs
+++ b/rs/protobuf/src/gen/state/state.canister_state_bits.v1.rs
@@ -168,6 +168,7 @@ pub mod wasm_method {
         CanisterInspectMessage = 5,
         CanisterHeartbeat = 6,
         CanisterGlobalTimer = 8,
+        CanisterOnLowWasmMemory = 9,
     }
     impl SystemMethod {
         /// String value of the enum field names used in the ProtoBuf definition.
@@ -184,6 +185,9 @@ pub mod wasm_method {
                 SystemMethod::CanisterInspectMessage => "SYSTEM_METHOD_CANISTER_INSPECT_MESSAGE",
                 SystemMethod::CanisterHeartbeat => "SYSTEM_METHOD_CANISTER_HEARTBEAT",
                 SystemMethod::CanisterGlobalTimer => "SYSTEM_METHOD_CANISTER_GLOBAL_TIMER",
+                SystemMethod::CanisterOnLowWasmMemory => {
+                    "SYSTEM_METHOD_CANISTER_ON_LOW_WASM_MEMORY"
+                }
             }
         }
         /// Creates an enum from field names used in the ProtoBuf definition.
@@ -197,6 +201,7 @@ pub mod wasm_method {
                 "SYSTEM_METHOD_CANISTER_INSPECT_MESSAGE" => Some(Self::CanisterInspectMessage),
                 "SYSTEM_METHOD_CANISTER_HEARTBEAT" => Some(Self::CanisterHeartbeat),
                 "SYSTEM_METHOD_CANISTER_GLOBAL_TIMER" => Some(Self::CanisterGlobalTimer),
+                "SYSTEM_METHOD_CANISTER_ON_LOW_WASM_MEMORY" => Some(Self::CanisterOnLowWasmMemory),
                 _ => None,
             }
         }
@@ -374,6 +379,7 @@ pub mod execution_task {
         Unspecified = 0,
         Heartbeat = 1,
         Timer = 2,
+        OnLowWasmMemory = 3,
     }
     impl CanisterTask {
         /// String value of the enum field names used in the ProtoBuf definition.
@@ -385,6 +391,7 @@ pub mod execution_task {
                 CanisterTask::Unspecified => "CANISTER_TASK_UNSPECIFIED",
                 CanisterTask::Heartbeat => "CANISTER_TASK_HEARTBEAT",
                 CanisterTask::Timer => "CANISTER_TASK_TIMER",
+                CanisterTask::OnLowWasmMemory => "CANISTER_TASK_ON_LOW_WASM_MEMORY",
             }
         }
         /// Creates an enum from field names used in the ProtoBuf definition.
@@ -393,6 +400,7 @@ pub mod execution_task {
                 "CANISTER_TASK_UNSPECIFIED" => Some(Self::Unspecified),
                 "CANISTER_TASK_HEARTBEAT" => Some(Self::Heartbeat),
                 "CANISTER_TASK_TIMER" => Some(Self::Timer),
+                "CANISTER_TASK_ON_LOW_WASM_MEMORY" => Some(Self::OnLowWasmMemory),
                 _ => None,
             }
         }

--- a/rs/replicated_state/src/canister_state.rs
+++ b/rs/replicated_state/src/canister_state.rs
@@ -217,6 +217,7 @@ impl CanisterState {
             (None, true) => NextExecution::StartNew,
             (Some(ExecutionTask::Heartbeat), _) => NextExecution::StartNew,
             (Some(ExecutionTask::GlobalTimer), _) => NextExecution::StartNew,
+            (Some(ExecutionTask::OnLowWasmMemory), _) => NextExecution::StartNew,
             (Some(ExecutionTask::AbortedExecution { .. }), _)
             | (Some(ExecutionTask::PausedExecution { .. }), _) => NextExecution::ContinueLong,
             (Some(ExecutionTask::AbortedInstallCode { .. }), _)
@@ -236,6 +237,7 @@ impl CanisterState {
             None
             | Some(ExecutionTask::Heartbeat)
             | Some(ExecutionTask::GlobalTimer)
+            | Some(ExecutionTask::OnLowWasmMemory)
             | Some(ExecutionTask::PausedExecution { .. })
             | Some(ExecutionTask::PausedInstallCode(..))
             | Some(ExecutionTask::AbortedInstallCode { .. }) => false,
@@ -249,6 +251,7 @@ impl CanisterState {
             None
             | Some(ExecutionTask::Heartbeat)
             | Some(ExecutionTask::GlobalTimer)
+            | Some(ExecutionTask::OnLowWasmMemory)
             | Some(ExecutionTask::PausedInstallCode(..))
             | Some(ExecutionTask::AbortedExecution { .. })
             | Some(ExecutionTask::AbortedInstallCode { .. }) => false,
@@ -262,6 +265,7 @@ impl CanisterState {
             None
             | Some(ExecutionTask::Heartbeat)
             | Some(ExecutionTask::GlobalTimer)
+            | Some(ExecutionTask::OnLowWasmMemory)
             | Some(ExecutionTask::PausedExecution { .. })
             | Some(ExecutionTask::AbortedExecution { .. })
             | Some(ExecutionTask::AbortedInstallCode { .. }) => false,
@@ -275,6 +279,7 @@ impl CanisterState {
             None
             | Some(ExecutionTask::Heartbeat)
             | Some(ExecutionTask::GlobalTimer)
+            | Some(ExecutionTask::OnLowWasmMemory)
             | Some(ExecutionTask::PausedExecution { .. })
             | Some(ExecutionTask::PausedInstallCode(..))
             | Some(ExecutionTask::AbortedExecution { .. }) => false,
@@ -461,6 +466,12 @@ impl CanisterState {
         self.exports_method(&WasmMethod::System(SystemMethod::CanisterGlobalTimer))
     }
 
+    /// Returns true if the canister exports the `canister_on_low_wasm_memory`
+    /// system method.
+    pub fn exports_on_low_wasm_memory(&self) -> bool {
+        self.exports_method(&WasmMethod::System(SystemMethod::CanisterOnLowWasmMemory))
+    }
+
     /// Returns true if the canister exports the given Wasm method.
     pub fn exports_method(&self, method: &WasmMethod) -> bool {
         match &self.execution_state {
@@ -527,6 +538,7 @@ impl CanisterState {
             ExecutionTask::AbortedInstallCode { .. } => false,
             ExecutionTask::Heartbeat
             | ExecutionTask::GlobalTimer
+            | Some(ExecutionTask::OnLowWasmMemory)
             | ExecutionTask::PausedExecution { .. }
             | ExecutionTask::PausedInstallCode(_)
             | ExecutionTask::AbortedExecution { .. } => true,

--- a/rs/replicated_state/src/canister_state.rs
+++ b/rs/replicated_state/src/canister_state.rs
@@ -538,7 +538,7 @@ impl CanisterState {
             ExecutionTask::AbortedInstallCode { .. } => false,
             ExecutionTask::Heartbeat
             | ExecutionTask::GlobalTimer
-            | Some(ExecutionTask::OnLowWasmMemory)
+            | ExecutionTask::OnLowWasmMemory
             | ExecutionTask::PausedExecution { .. }
             | ExecutionTask::PausedInstallCode(_)
             | ExecutionTask::AbortedExecution { .. } => true,

--- a/rs/replicated_state/src/canister_state/execution_state.rs
+++ b/rs/replicated_state/src/canister_state/execution_state.rs
@@ -157,6 +157,9 @@ pub struct ExportedFunctions {
 
     /// Cached info about exporting a global timer method to skip expensive BTreeSet lookup.
     exports_global_timer: bool,
+
+    /// Cached info about exporting a on low Wasm memory to skip expensive BTreeSet lookup.
+    exports_on_low_wasm_memory: bool,
 }
 
 impl ExportedFunctions {
@@ -165,10 +168,13 @@ impl ExportedFunctions {
             exported_functions.contains(&WasmMethod::System(SystemMethod::CanisterHeartbeat));
         let exports_global_timer =
             exported_functions.contains(&WasmMethod::System(SystemMethod::CanisterGlobalTimer));
+        let exports_on_low_wasm_memory =
+            exported_functions.contains(&WasmMethod::System(SystemMethod::CanisterOnLowWasmMemory));
         Self {
             exported_functions: Arc::new(exported_functions),
             exports_heartbeat,
             exports_global_timer,
+            exports_on_low_wasm_memory,
         }
     }
 
@@ -177,6 +183,9 @@ impl ExportedFunctions {
             // Cached values.
             WasmMethod::System(SystemMethod::CanisterHeartbeat) => self.exports_heartbeat,
             WasmMethod::System(SystemMethod::CanisterGlobalTimer) => self.exports_global_timer,
+            WasmMethod::System(SystemMethod::CanisterOnLowWasmMemory) => {
+                self.exports_on_low_wasm_memory
+            }
             // Expensive lookup.
             _ => self.exported_functions.contains(method),
         }

--- a/rs/replicated_state/src/canister_state/system_state.rs
+++ b/rs/replicated_state/src/canister_state/system_state.rs
@@ -453,6 +453,10 @@ pub enum ExecutionTask {
     /// The task exists only within an execution round, it never gets serialized.
     GlobalTimer,
 
+    /// On low Wasm memory hook.
+    /// The task exists only within an execution round, it never gets serialized.
+    OnLowWasmMemory,
+
     /// A paused execution task exists only within an epoch (between
     /// checkpoints). It is never serialized, and it turns into `AbortedExecution`
     /// before the checkpoint or when there are too many long-running executions.
@@ -498,6 +502,7 @@ impl From<&ExecutionTask> for pb::ExecutionTask {
         match item {
             ExecutionTask::Heartbeat
             | ExecutionTask::GlobalTimer
+            | ExecutionTask::OnLowWasmMemory
             | ExecutionTask::PausedExecution { .. }
             | ExecutionTask::PausedInstallCode(_) => {
                 panic!("Attempt to serialize ephemeral task: {:?}.", item);

--- a/rs/system_api/src/lib.rs
+++ b/rs/system_api/src/lib.rs
@@ -616,8 +616,12 @@ impl ApiType {
                 SystemMethod::CanisterHeartbeat => "heartbeat",
                 SystemMethod::CanisterGlobalTimer => "global timer",
                 SystemMethod::CanisterOnLowWasmMemory => "on low Wasm memory",
-                _ => {
-                    panic!("Only `canister_heartbeat`, `canister_global_timer`, and "canister_on_low_wasm_memory" are allowed.")
+                SystemMethod::CanisterStart
+                | SystemMethod::CanisterInit
+                | SystemMethod::CanisterPreUpgrade
+                | SystemMethod::CanisterPostUpgrade
+                | SystemMethod::CanisterInspectMessage => {
+                    panic!("Only `canister_heartbeat`, `canister_global_timer`, and `canister_on_low_wasm_memory` are allowed.")
                 }
             },
             ApiType::Update { .. } => "update",

--- a/rs/system_api/src/lib.rs
+++ b/rs/system_api/src/lib.rs
@@ -615,7 +615,10 @@ impl ApiType {
             ApiType::SystemTask { system_task, .. } => match system_task {
                 SystemMethod::CanisterHeartbeat => "heartbeat",
                 SystemMethod::CanisterGlobalTimer => "global timer",
-                _ => panic!("Only `canister_heartbeat` and `canister_global_timer` are allowed."),
+                SystemMethod::CanisterOnLowWasmMemory => "on low Wasm memory",
+                _ => {
+                    panic!("Only `canister_heartbeat`, `canister_global_timer`, and "canister_on_low_wasm_memory" are allowed.")
+                }
             },
             ApiType::Update { .. } => "update",
             ApiType::ReplicatedQuery { .. } => "replicated query",

--- a/rs/test_utilities/execution_environment/src/lib.rs
+++ b/rs/test_utilities/execution_environment/src/lib.rs
@@ -998,6 +998,12 @@ impl ExecutionTest {
                     .task_queue
                     .push_front(ExecutionTask::GlobalTimer);
             }
+            CanisterTask::OnLowWasmMemory => {
+                canister
+                    .system_state
+                    .task_queue
+                    .push_front(ExecutionTask::OnLowWasmMemory);
+            }
         }
         let result = execute_canister(
             &self.exec_env,

--- a/rs/types/types/src/messages.rs
+++ b/rs/types/types/src/messages.rs
@@ -846,7 +846,7 @@ mod tests {
         // See note [Handling changes to Enums in Replicated State] for how to proceed.
         assert_eq!(
             CanisterTask::iter().map(|x| x as i32).collect::<Vec<i32>>(),
-            [1, 2]
+            [1, 2, 3]
         );
     }
 

--- a/rs/types/types/src/messages.rs
+++ b/rs/types/types/src/messages.rs
@@ -449,6 +449,7 @@ impl TryFrom<CanisterMessage> for CanisterCall {
 pub enum CanisterTask {
     Heartbeat = 1,
     GlobalTimer = 2,
+    OnLowWasmMemory = 3,
 }
 
 impl From<CanisterTask> for SystemMethod {
@@ -456,6 +457,7 @@ impl From<CanisterTask> for SystemMethod {
         match task {
             CanisterTask::Heartbeat => SystemMethod::CanisterHeartbeat,
             CanisterTask::GlobalTimer => SystemMethod::CanisterGlobalTimer,
+            CanisterTask::OnLowWasmMemory => SystemMethod::CanisterOnLowWasmMemory,
         }
     }
 }
@@ -465,6 +467,7 @@ impl Display for CanisterTask {
         match self {
             Self::Heartbeat => write!(f, "Heartbeat task"),
             Self::GlobalTimer => write!(f, "Global timer task"),
+            Self::OnLowWasmMemory => write!(f, "On low Wasm memory task"),
         }
     }
 }
@@ -474,6 +477,7 @@ impl From<&CanisterTask> for pb::execution_task::CanisterTask {
         match task {
             CanisterTask::Heartbeat => pb::execution_task::CanisterTask::Heartbeat,
             CanisterTask::GlobalTimer => pb::execution_task::CanisterTask::Timer,
+            CanisterTask::OnLowWasmMemory => pb::execution_task::CanisterTask::OnLowWasmMemory,
         }
     }
 }
@@ -491,6 +495,7 @@ impl TryFrom<pb::execution_task::CanisterTask> for CanisterTask {
             }
             pb::execution_task::CanisterTask::Heartbeat => Ok(CanisterTask::Heartbeat),
             pb::execution_task::CanisterTask::Timer => Ok(CanisterTask::GlobalTimer),
+            pb::execution_task::CanisterTask::OnLowWasmMemory => Ok(CanisterTask::OnLowWasmMemory),
         }
     }
 }

--- a/rs/types/types/src/methods.rs
+++ b/rs/types/types/src/methods.rs
@@ -147,6 +147,8 @@ pub enum SystemMethod {
     CanisterHeartbeat = 6,
     /// A system method that is run after a specified time.
     CanisterGlobalTimer = 7,
+    /// A system method that runs when the available Wasm memory is below threshold.
+    CanisterOnLowWasmMemory = 8,
 }
 
 impl TryFrom<&str> for SystemMethod {
@@ -161,6 +163,7 @@ impl TryFrom<&str> for SystemMethod {
             "canister_inspect_message" => Ok(SystemMethod::CanisterInspectMessage),
             "canister_heartbeat" => Ok(SystemMethod::CanisterHeartbeat),
             "canister_global_timer" => Ok(SystemMethod::CanisterGlobalTimer),
+            "canister_on_low_wasm_memory" => Ok(SystemMethod::CanisterOnLowWasmMemory),
             _ => Err(format!("Cannot convert {} to SystemMethod.", value)),
         }
     }
@@ -176,6 +179,7 @@ impl fmt::Display for SystemMethod {
             Self::CanisterInspectMessage => write!(f, "canister_inspect_message"),
             Self::CanisterHeartbeat => write!(f, "canister_heartbeat"),
             Self::CanisterGlobalTimer => write!(f, "canister_global_timer"),
+            Self::CanisterOnLowWasmMemory => write!(f, "canister_on_low_wasm_memory"),
         }
     }
 }
@@ -192,6 +196,7 @@ impl From<&SystemMethod> for pb::wasm_method::SystemMethod {
             SystemMethod::CanisterInspectMessage => PbSystemMethod::CanisterInspectMessage,
             SystemMethod::CanisterHeartbeat => PbSystemMethod::CanisterHeartbeat,
             SystemMethod::CanisterGlobalTimer => PbSystemMethod::CanisterGlobalTimer,
+            SystemMethod::CanisterOnLowWasmMemory => PbSystemMethod::CanisterOnLowWasmMemory,
         }
     }
 }
@@ -214,6 +219,7 @@ impl TryFrom<pb::wasm_method::SystemMethod> for SystemMethod {
             PbSystemMethod::CanisterInspectMessage => Ok(SystemMethod::CanisterInspectMessage),
             PbSystemMethod::CanisterHeartbeat => Ok(SystemMethod::CanisterHeartbeat),
             PbSystemMethod::CanisterGlobalTimer => Ok(SystemMethod::CanisterGlobalTimer),
+            PbSystemMethod::CanisterOnLowWasmMemory => Ok(SystemMethod::CanisterOnLowWasmMemory),
         }
     }
 }

--- a/rs/types/types/src/methods.rs
+++ b/rs/types/types/src/methods.rs
@@ -417,7 +417,7 @@ mod tests {
         // See note [Handling changes to Enums in Replicated State] for how to proceed.
         assert_eq!(
             SystemMethod::iter().map(|x| x as i32).collect::<Vec<i32>>(),
-            [1, 2, 3, 4, 5, 6, 7]
+            [1, 2, 3, 4, 5, 6, 7, 8]
         );
     }
 


### PR DESCRIPTION
This PR starts the implementation of the OnLowWasmMemory hook. Here we are just adding a new type of SystemMehod/CanisterTask/ExecutionTask which is not called anywere.