### PR TITLE
chore: Remove proto field used to migrate payload layout

### DIFF
--- a/rs/consensus/src/ecdsa/metrics.rs
+++ b/rs/consensus/src/ecdsa/metrics.rs
@@ -222,11 +222,6 @@ impl IDkgPayloadMetrics {
             "xnet_reshare_agreements",
             count_by_master_public_key_id(payload.xnet_reshare_agreements.keys(), &expected_keys),
         );
-        self.payload_metrics_set_without_key_id_label("payload_layout_multiple_keys", 1);
-        self.payload_metrics_set_without_key_id_label(
-            "payload_layout_generalized_pre_signatures",
-            1,
-        );
         self.payload_metrics_set_without_key_id_label(
             "key_transcripts",
             payload.key_transcripts.len(),

--- a/rs/protobuf/def/types/v1/idkg.proto
+++ b/rs/protobuf/def/types/v1/idkg.proto
@@ -9,7 +9,7 @@ import "types/v1/signature.proto";
 import "types/v1/types.proto";
 
 message IDkgPayload {
-  reserved 2, 3, 4, 9, 11, 12;
+  reserved 2, 3, 4, 9, 11, 12, 16;
   repeated CompletedSignature signature_agreements = 1;
   registry.subnet.v1.IDkgTranscriptId next_unused_transcript_id = 5;
   repeated registry.subnet.v1.IDkgTranscript idkg_transcripts = 6;
@@ -19,8 +19,6 @@ message IDkgPayload {
   repeated MasterKeyTranscript key_transcripts = 13;
   repeated AvailablePreSignature available_pre_signatures = 14;
   repeated PreSignatureInProgress pre_signatures_in_creation = 15;
-  // TODO: retire these fields, once we start using `pre_signatures`.
-  bool generalized_pre_signatures = 16;
 }
 
 message ConsensusResponse {

--- a/rs/protobuf/src/gen/types/types.v1.rs
+++ b/rs/protobuf/src/gen/types/types.v1.rs
@@ -402,9 +402,6 @@ pub struct IDkgPayload {
     pub available_pre_signatures: ::prost::alloc::vec::Vec<AvailablePreSignature>,
     #[prost(message, repeated, tag = "15")]
     pub pre_signatures_in_creation: ::prost::alloc::vec::Vec<PreSignatureInProgress>,
-    /// TODO: retire these fields, once we start using `pre_signatures`.
-    #[prost(bool, tag = "16")]
-    pub generalized_pre_signatures: bool,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/rs/types/types/src/consensus/idkg.rs
+++ b/rs/types/types/src/consensus/idkg.rs
@@ -1787,8 +1787,6 @@ impl From<&IDkgPayload> for pb::IDkgPayload {
             ongoing_xnet_reshares,
             xnet_reshare_agreements,
             key_transcripts,
-            // Kept for backwards compatibility
-            generalized_pre_signatures: true,
         }
     }
 }


### PR DESCRIPTION
The migration to generalized pre-signatures was completed, therefore this field and corresponding metrics can be removed