### PR TITLE
fix: RUN-1001: Follow up on the reserved cycles limit fix

### DIFF
--- a/rs/execution_environment/src/canister_manager.rs
+++ b/rs/execution_environment/src/canister_manager.rs
@@ -2248,9 +2248,6 @@ pub(crate) enum CanisterManagerError {
         requested: Cycles,
         limit: Cycles,
     },
-    // TODO(RUN-1001): Use this error type after successful rollout of the next
-    // replica version.
-    #[allow(dead_code)]
     ReservedCyclesLimitIsTooLow {
         cycles: Cycles,
         limit: Cycles,

--- a/rs/execution_environment/src/canister_settings.rs
+++ b/rs/execution_environment/src/canister_settings.rs
@@ -535,9 +535,12 @@ pub(crate) fn validate_canister_settings(
         .or(canister_reserved_balance_limit);
 
     if let Some(limit) = reserved_balance_limit {
-        // TODO(RUN-1001): return `ReservedCyclesLimitIsTooLow` once
-        // the replica with that error type rolls out successfully.
-        if canister_reserved_balance + reservation_cycles > limit {
+        if canister_reserved_balance > limit {
+            return Err(CanisterManagerError::ReservedCyclesLimitIsTooLow {
+                cycles: canister_reserved_balance,
+                limit,
+            });
+        } else if canister_reserved_balance + reservation_cycles > limit {
             return Err(
                 CanisterManagerError::ReservedCyclesLimitExceededInMemoryAllocation {
                     memory_allocation: new_memory_allocation,

--- a/rs/execution_environment/src/hypervisor/tests.rs
+++ b/rs/execution_environment/src/hypervisor/tests.rs
@@ -6852,10 +6852,7 @@ fn set_reserved_cycles_limit_below_existing_fails() {
         .canister_update_reserved_cycles_limit(canister_id, Cycles::from(reserved_cycles.get() - 1))
         .unwrap_err();
 
-    assert_eq!(
-        err.code(),
-        ErrorCode::ReservedCyclesLimitExceededInMemoryAllocation
-    );
+    assert_eq!(err.code(), ErrorCode::ReservedCyclesLimitIsTooLow);
 }
 
 #[test]


### PR DESCRIPTION
This follows up on `9c7d1c` to use the new error code that was introduced in the original fix, but couldn't be used immediately due to forward/backward compatibility in the replicated state.