### PR TITLE
chore(IDX): make nns_dapp tests bazel-agnostic

### DIFF
--- a/rs/tests/crypto/BUILD.bazel
+++ b/rs/tests/crypto/BUILD.bazel
@@ -10,6 +10,9 @@ II_DEV_CANISTER_RUNTIME_DEPS = [
 
 system_test(
     name = "canister_sig_verification_cache_test",
+    env = {
+        "II_WASM_PATH": "$(rootpath @ii_dev_canister//file)",
+    },
     flaky = False,
     proc_macro_deps = MACRO_DEPENDENCIES,
     tags = [

--- a/rs/tests/gix/BUILD.bazel
+++ b/rs/tests/gix/BUILD.bazel
@@ -5,6 +5,12 @@ package(default_visibility = ["//visibility:public"])
 
 system_test(
     name = "nns_dapp_test",
+    env = {
+        "ICRC1_LEDGER_WASM_PATH": "$(rootpath //rs/rosetta-api/icrc1/ledger:ledger_canister)",
+        "II_WASM_PATH": "$(rootpath @ii_dev_canister//file)",
+        "NNS_DAPP_WASM_PATH": "$(rootpath @nns_dapp_canister//file)",
+        "SUBNET_RENTAL_WASM_PATH": "$(rootpath @subnet_rental_canister//file)",
+    },
     flaky = False,
     proc_macro_deps = MACRO_DEPENDENCIES,
     tags = [
@@ -12,7 +18,7 @@ system_test(
     ],
     target_compatible_with = ["@platforms//os:linux"],  # requires libssh that does not build on Mac OS
     runtime_deps = GUESTOS_RUNTIME_DEPS + NNS_CANISTER_RUNTIME_DEPS + BOUNDARY_NODE_GUESTOS_RUNTIME_DEPS + [
-        "//rs/rosetta-api/icrc1/ledger:ledger_canister.wasm.gz",
+        "//rs/rosetta-api/icrc1/ledger:ledger_canister",
         "@ii_dev_canister//file",
         "@nns_dapp_canister//file",
         "@subnet_rental_canister//file",

--- a/rs/tests/nns/sns/BUILD.bazel
+++ b/rs/tests/nns/sns/BUILD.bazel
@@ -44,6 +44,9 @@ system_test(
 
 system_test(
     name = "aggregation_canister_test",
+    env = {
+        "SNS_AGGREGATOR_WASM_PATH": "$(rootpath @sns_aggregator//file)",
+    },
     flaky = True,
     proc_macro_deps = MACRO_DEPENDENCIES,
     # TODO[NNS1-2658]: re-enable this test
@@ -73,6 +76,9 @@ system_test(
 
 system_test(
     name = "launchpad_direct_load_test",
+    env = {
+        "SNS_AGGREGATOR_WASM_PATH": "$(rootpath @sns_aggregator//file)",
+    },
     proc_macro_deps = MACRO_DEPENDENCIES,
     tags = [
         "manual",
@@ -88,6 +94,9 @@ system_test(
 
 system_test(
     name = "launchpad_direct_auth_load_test",
+    env = {
+        "SNS_AGGREGATOR_WASM_PATH": "$(rootpath @sns_aggregator//file)",
+    },
     proc_macro_deps = MACRO_DEPENDENCIES,
     tags = [
         "manual",
@@ -103,6 +112,9 @@ system_test(
 
 system_test(
     name = "launchpad_aggregator_load_test",
+    env = {
+        "SNS_AGGREGATOR_WASM_PATH": "$(rootpath @sns_aggregator//file)",
+    },
     proc_macro_deps = MACRO_DEPENDENCIES,
     tags = [
         "manual",

--- a/rs/tests/src/nns_dapp.rs
+++ b/rs/tests/src/nns_dapp.rs
@@ -21,13 +21,7 @@ use serde::{Deserialize, Serialize};
 use slog::info;
 use std::collections::HashMap;
 
-pub const ICRC1_LEDGER_WASM: &str = "rs/rosetta-api/icrc1/ledger/ledger_canister.wasm.gz";
-pub const INTERNET_IDENTITY_WASM: &str =
-    "external/ii_dev_canister/file/internet_identity_dev.wasm.gz";
-pub const NNS_DAPP_WASM: &str = "external/nns_dapp_canister/file/nns_dapp_canister.wasm.gz";
-pub const SUBNET_RENTAL_CANISTER_WASM: &str =
-    "external/subnet_rental_canister/file/subnet_rental_canister.wasm";
-pub const SNS_AGGREGATOR_WASM: &str = "external/sns_aggregator/file/sns_aggregator_dev.wasm.gz";
+use std::env;
 
 /// Init and post_upgrade arguments for SNS aggregator.
 #[derive(Debug, Eq, PartialEq, CandidType, Serialize, Deserialize)]
@@ -91,7 +85,7 @@ pub fn install_sns_aggregator(
     let farm_url = boundary_node.get_playnet().unwrap();
 
     let sns_agent = sns_node.build_default_agent();
-    let sns_aggregator_wasm = env.load_wasm(SNS_AGGREGATOR_WASM);
+    let sns_aggregator_wasm = env.load_wasm(env::var("SNS_AGGREGATOR_WASM_PATH").unwrap());
     let logger = env.logger();
     block_on(async move {
         let sns_aggregator_canister_id =
@@ -136,7 +130,7 @@ pub fn install_ii_nns_dapp_and_subnet_rental(
     let topology = env.topology_snapshot();
     let nns_node = topology.root_subnet().nodes().next().unwrap();
     let ii_canister_id =
-        nns_node.create_and_install_canister_with_arg(INTERNET_IDENTITY_WASM, None);
+        nns_node.create_and_install_canister_with_arg(&env::var("II_WASM_PATH").unwrap(), None);
 
     // create the NNS dapp canister so that its canister ID is allocated
     // and the Subnet Rental Canister gets its mainnet canister ID in the next step
@@ -149,8 +143,8 @@ pub fn install_ii_nns_dapp_and_subnet_rental(
 
     // deploy the Subnet Rental Canister
     let nns_node = topology.root_subnet().nodes().next().unwrap();
-    let subnet_rental_canister_id =
-        nns_node.create_and_install_canister_with_arg(SUBNET_RENTAL_CANISTER_WASM, None);
+    let subnet_rental_canister_id = nns_node
+        .create_and_install_canister_with_arg(&env::var("SUBNET_RENTAL_WASM_PATH").unwrap(), None);
     assert_eq!(subnet_rental_canister_id, SUBNET_RENTAL_CANISTER_ID.into());
 
     // deploy the ckETH ledger canister (ICRC1-ledger with "ckETH" as token symbol and name) required by NNS dapp
@@ -159,13 +153,13 @@ pub fn install_ii_nns_dapp_and_subnet_rental(
         .with_token_name("ckETH".to_string())
         .build();
     let cketh_canister_id = nns_node.create_and_install_canister_with_arg(
-        ICRC1_LEDGER_WASM,
+        &env::var("ICRC1_LEDGER_WASM_PATH").unwrap(),
         Some(Encode!(&(LedgerArgument::Init(cketh_init_args))).unwrap()),
     );
 
     // now that we know all required canister IDs, install the NNS dapp
     let nns_agent = nns_node.build_default_agent();
-    let nns_dapp_wasm = env.load_wasm(NNS_DAPP_WASM);
+    let nns_dapp_wasm = env.load_wasm(env::var("NNS_DAPP_WASM_PATH").unwrap());
     let logger = env.logger();
     block_on(async move {
         let nns_dapp_metadata = vec![

--- a/rs/tests/system_tests.bzl
+++ b/rs/tests/system_tests.bzl
@@ -34,7 +34,15 @@ def _run_system_test(ctx):
         ),
     )
 
-    env = dict(ctx.attr.env.items() + [
+    env = dict(ctx.attr.env.items())
+
+    # Expand Make variables in env vars, with runtime_deps as targets
+    for key, value in env.items():
+        # If this looks like a Make variable, try to expand it
+        if value.startswith("$"):
+            env[key] = ctx.expand_location(value, ctx.attr.runtime_deps)
+
+    env = dict(env.items() + [
         ("VERSION_FILE_PATH", ctx.file.version_file_path.short_path),
     ])
     if ctx.executable.colocated_test_bin != None:
@@ -110,6 +118,7 @@ def system_test(
         uses_guestos_dev_test = False,
         uses_setupos_dev = False,
         uses_hostos_dev_test = False,
+        env = {},
         env_inherit = [],
         additional_colocate_tags = [],
         **kwargs):
@@ -139,6 +148,7 @@ def system_test(
       uses_guestos_dev_test: the test uses //ic-os/guestos/envs/dev:update-img-test (will be also automatically added as dependency).
       uses_setupos_dev: the test uses ic-os/setupos/envs/dev (will be also automatically added as dependency).
       uses_hostos_dev_test: the test uses ic-os/hostos/envs/dev:update-img-test (will be also automatically added as dependency).
+      env: environment variables to set in the test (subject to Make variable expansion)
       env_inherit: specifies additional environment variables to inherit from
       the external environment when the test is executed by bazel test.
       additional_colocate_tags: additional tags to pass to the colocated test.
@@ -206,6 +216,7 @@ def system_test(
         src = bin_name,
         runtime_deps = runtime_deps,
         env_deps = _env_deps,
+        env = env,
         env_inherit = env_inherit,
         tags = tags + ["requires-network", "system_test"] +
                (["manual"] if "experimental_system_test_colocation" in tags else []),

--- a/rs/tests/testing_verification/BUILD.bazel
+++ b/rs/tests/testing_verification/BUILD.bazel
@@ -114,6 +114,9 @@ system_test(
 
 system_test(
     name = "ii_delegation_test",
+    env = {
+        "II_WASM_PATH": "$(rootpath @ii_dev_canister//file)",
+    },
     flaky = True,
     proc_macro_deps = MACRO_DEPENDENCIES,
     tags = [

--- a/rs/tests/testing_verification/testnets/BUILD.bazel
+++ b/rs/tests/testing_verification/testnets/BUILD.bazel
@@ -93,6 +93,12 @@ system_test(
 
 system_test(
     name = "small_with_query_stats",
+    env = {
+        "ICRC1_LEDGER_WASM_PATH": "$(rootpath //rs/rosetta-api/icrc1/ledger:ledger_canister)",
+        "II_WASM_PATH": "$(rootpath @ii_dev_canister//file)",
+        "NNS_DAPP_WASM_PATH": "$(rootpath @nns_dapp_canister//file)",
+        "SUBNET_RENTAL_WASM_PATH": "$(rootpath @subnet_rental_canister//file)",
+    },
     flaky = False,
     proc_macro_deps = MACRO_DEPENDENCIES,
     tags = [
@@ -111,6 +117,13 @@ system_test(
 
 system_test(
     name = "sns_testing",
+    env = {
+        "ICRC1_LEDGER_WASM_PATH": "$(rootpath //rs/rosetta-api/icrc1/ledger:ledger_canister)",
+        "II_WASM_PATH": "$(rootpath @ii_dev_canister//file)",
+        "NNS_DAPP_WASM_PATH": "$(rootpath @nns_dapp_canister//file)",
+        "SNS_AGGREGATOR_WASM_PATH": "$(rootpath @sns_aggregator//file)",
+        "SUBNET_RENTAL_WASM_PATH": "$(rootpath @subnet_rental_canister//file)",
+    },
     flaky = False,
     proc_macro_deps = MACRO_DEPENDENCIES,
     tags = [
@@ -143,6 +156,13 @@ system_test(
 
 system_test(
     name = "large",
+    env = {
+        "ICRC1_LEDGER_WASM_PATH": "$(rootpath //rs/rosetta-api/icrc1/ledger:ledger_canister)",
+        "II_WASM_PATH": "$(rootpath @ii_dev_canister//file)",
+        "NNS_DAPP_WASM_PATH": "$(rootpath @nns_dapp_canister//file)",
+        "SNS_AGGREGATOR_WASM_PATH": "$(rootpath @sns_aggregator//file)",
+        "SUBNET_RENTAL_WASM_PATH": "$(rootpath @subnet_rental_canister//file)",
+    },
     flaky = False,
     proc_macro_deps = MACRO_DEPENDENCIES,
     tags = [
@@ -162,6 +182,14 @@ system_test(
 
 system_test(
     name = "src_testing",
+    env = {
+        "ICRC1_LEDGER_WASM_PATH": "$(rootpath //rs/rosetta-api/icrc1/ledger:ledger_canister)",
+        "XRC_WASM_PATH": "$(rootpath //rs/rosetta-api/tvl/xrc_mock:xrc_mock_canister)",
+        "II_WASM_PATH": "$(rootpath @ii_dev_canister//file)",
+        "NNS_DAPP_WASM_PATH": "$(rootpath @nns_dapp_canister//file)",
+        "SNS_AGGREGATOR_WASM_PATH": "$(rootpath @sns_aggregator//file)",
+        "SUBNET_RENTAL_WASM_PATH": "$(rootpath @subnet_rental_canister//file)",
+    },
     flaky = False,
     proc_macro_deps = MACRO_DEPENDENCIES,
     tags = [
@@ -170,8 +198,8 @@ system_test(
     ],
     target_compatible_with = ["@platforms//os:linux"],  # requires libssh that does not build on Mac OS
     runtime_deps = GUESTOS_RUNTIME_DEPS + NNS_CANISTER_RUNTIME_DEPS + SNS_CANISTER_RUNTIME_DEPS + BOUNDARY_NODE_GUESTOS_RUNTIME_DEPS + GRAFANA_RUNTIME_DEPS + [
-        "//rs/rosetta-api/icrc1/ledger:ledger_canister.wasm.gz",
-        "//rs/rosetta-api/tvl/xrc_mock:xrc_mock_canister.wasm.gz",
+        "//rs/rosetta-api/icrc1/ledger:ledger_canister",
+        "//rs/rosetta-api/tvl/xrc_mock:xrc_mock_canister",
         "@ii_dev_canister//file",
         "@nns_dapp_canister//file",
         "@sns_aggregator//file",

--- a/rs/tests/testing_verification/testnets/src_testing.rs
+++ b/rs/tests/testing_verification/testnets/src_testing.rs
@@ -62,13 +62,11 @@ use ic_tests::nns_dapp::{
 };
 use ic_tests::orchestrator::utils::rw_message::install_nns_with_customizations_and_check_progress;
 use ic_xrc_types::{Asset, AssetClass, ExchangeRateMetadata};
+use std::env;
 use std::str::FromStr;
 use xrc_mock::{ExchangeRate, Response, XrcMockInitPayload};
 
 const DEFAULT_XRC_PRINCIPAL_STR: &str = "uf6dk-hyaaa-aaaaq-qaaaq-cai";
-
-pub const EXCHANGE_RATE_CANISTER_WASM: &str =
-    "rs/rosetta-api/tvl/xrc_mock/xrc_mock_canister.wasm.gz";
 
 fn main() -> Result<()> {
     SystemTestGroup::new()
@@ -193,7 +191,7 @@ pub fn setup(env: TestEnv) {
     // we set the exchange rate to 12 XDR per 1 ICP
     let xrc_payload = new_icp_cxdr_mock_exchange_rate_canister_init_payload(12_000_000_000);
     let xrc_canister_id = xrc_node.create_and_install_canister_with_arg(
-        EXCHANGE_RATE_CANISTER_WASM,
+        &env::var("XRC_WASM_PATH").unwrap(),
         Some(Encode!(&xrc_payload).unwrap()),
     );
     assert_eq!(xrc_canister_id, default_xrc_principal_id.into());


### PR DESCRIPTION
This updates the system tests using the NNS dapp (and NNS dapp dependencies) not rely on any bazel-specific paths. Instead, the path to the canisters used by these tests is passed as environment variables (and adds supports for setting runtime environment variables in system tests).

This makes the tests less dependent on bazel-specific paths (`external/`, exact canister names, etc).