### PR TITLE
test(sns): SNS upgrade-related tests were flaking out.

### DIFF
--- a/rs/nervous_system/integration_tests/BUILD.bazel
+++ b/rs/nervous_system/integration_tests/BUILD.bazel
@@ -178,6 +178,9 @@ rust_test_suite_with_extra_srcs(
     srcs = glob(
         ["tests/**/*.rs"],
     ),
+    tags = [
+        "cpu:2",
+    ],
     aliases = ALIASES,
     data = DEV_DATA,
     env = DEV_ENV,

--- a/rs/nervous_system/integration_tests/BUILD.bazel
+++ b/rs/nervous_system/integration_tests/BUILD.bazel
@@ -178,14 +178,14 @@ rust_test_suite_with_extra_srcs(
     srcs = glob(
         ["tests/**/*.rs"],
     ),
-    tags = [
-        "cpu:2",
-    ],
     aliases = ALIASES,
     data = DEV_DATA,
     env = DEV_ENV,
     extra_srcs = [],
     flaky = True,
     proc_macro_deps = MACRO_DEPENDENCIES + MACRO_DEV_DEPENDENCIES,
+    tags = [
+        "cpu:3",
+    ],
     deps = [":nervous_system_integration_tests"] + DEPENDENCIES_WITH_TEST_FEATURES + DEV_DEPENDENCIES,
 )


### PR DESCRIPTION
Specifically,

- //rs/nervous_system/integration_tests:integration_tests_test_tests/sns_ledger_upgrade
- //rs/nervous_system/integration_tests:integration_tests_test_tests/sns_release_qualification


The solution seems to be to simply give it more cores.