### PR TITLE
feat(nns): Support upgrading root canister through install_code

### DIFF
--- a/rs/nns/integration_tests/src/canister_upgrade.rs
+++ b/rs/nns/integration_tests/src/canister_upgrade.rs
@@ -52,8 +52,8 @@ fn test_upgrade_canister(canister_id: CanisterId, canister_wasm: Wasm, use_propo
 fn upgrade_canisters_by_proposal() {
     test_upgrade_canister(GOVERNANCE_CANISTER_ID, build_governance_wasm(), true);
     test_upgrade_canister(GOVERNANCE_CANISTER_ID, build_governance_wasm(), false);
-    // TODO(NNS1-3190): Test upgrading root with proposal action when it's supported.
     test_upgrade_canister(ROOT_CANISTER_ID, build_root_wasm(), false);
+    test_upgrade_canister(ROOT_CANISTER_ID, build_root_wasm(), true);
     test_upgrade_canister(LIFELINE_CANISTER_ID, build_lifeline_wasm(), true);
     test_upgrade_canister(LIFELINE_CANISTER_ID, build_lifeline_wasm(), false);
 }


### PR DESCRIPTION
# Why

Previously, `install_code` proposal action is added without supporting upgrading root. This PR supports it.

# Changes

We support creating a proposal with action `install_code` while specifying NNS Root as the target canister, and the proposal execution code will call the correct `upgrade_root` endpoint correctly (unlike upgrading other canisters which calls root). Note that `install` or `reinstall` modes aren't supported. It might not be obvious why `reinstall` isn't supported - HardResetRootToVersion supports "resetting" root, but the reset is implemented as an `uninstall_code` followed by `install_code` (with `Install` mode). This behavior seems to exceed what can be reasonably thought of as the `install_code` proposal action. Therefore, `HardResetRootToVersion` will remain as an NnsFunction and will later be switched to `ProtocolCanisterManagement` topic.