### PR TITLE
fix(dependency-mgmt): Export `GITHUB_TOKEN` for `dependency-scan-release-cut` 

### DIFF
--- a/.github/workflows-source/release-testing.yml
+++ b/.github/workflows-source/release-testing.yml
@@ -127,6 +127,7 @@ jobs:
       CI_PROJECT_PATH: ${{ github.repository }}
       CI_PIPELINE_ID: ${{ github.run_id }}
       CI_COMMIT_SHA: ${{ github.sha }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
       SLACK_PSEC_BOT_OAUTH_TOKEN: ${{ secrets.SLACK_PSEC_BOT_OAUTH_TOKEN }}
     steps:

--- a/.github/workflows/release-testing.yml
+++ b/.github/workflows/release-testing.yml
@@ -139,6 +139,7 @@ jobs:
       CI_PROJECT_PATH: ${{ github.repository }}
       CI_PIPELINE_ID: ${{ github.run_id }}
       CI_COMMIT_SHA: ${{ github.sha }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
       SLACK_PSEC_BOT_OAUTH_TOKEN: ${{ secrets.SLACK_PSEC_BOT_OAUTH_TOKEN }}
     steps:

--- a/gitlab-ci/src/dependencies/data_source/jira_finding_data_source.py
+++ b/gitlab-ci/src/dependencies/data_source/jira_finding_data_source.py
@@ -622,7 +622,7 @@ class JiraFindingDataSource(FindingDataSource):
             if len(fields_to_update) > 0:
                 if self.__does_exceed_character_limit(finding, fields_to_update):
                     # in this case we print the whole finding, so we have the updated finding at least in the log
-                    logging.warning(f"skipping update of the following finding because some fields exceed character limit: {finding} ")
+                    logging.warning(f"skipping update of the following finding because some fields exceed character limit: {finding.id()} ")
                 else:
                     logging.debug(f"updating finding fields {fields_to_update}")
                     jira_issue.update(fields_to_update)
@@ -637,7 +637,7 @@ class JiraFindingDataSource(FindingDataSource):
             fields_to_update = self.__finding_diff_to_jira(None, finding)
             if self.__does_exceed_character_limit(finding, fields_to_update):
                 # in this case we print the whole finding, so we have the new finding at least in the log
-                logging.warning(f"skipping creation of the following finding because some fields exceed character limit: {finding}")
+                logging.warning(f"skipping creation of the following finding because some fields exceed character limit: {finding.id()}")
             else:
                 logging.debug(f"creating finding fields {fields_to_update}")
                 jira_issue = self.jira.create_issue(fields_to_update)


### PR DESCRIPTION
- dependency-scan-release-cut doesn't perform any actions on the Github but the token is loaded outside the instantiation which throws an [error](https://github.com/dfinity/ic/actions/runs/9966897303/job/27539714343#step:6:31). Hence, we export the token with default read perms to silence the error. 
- Remove `Finding` from warning logs. 