### PR TITLE
feat: EXC-1527: Handle canister snapshots during subnet splitting

### DIFF
--- a/rs/execution_environment/src/execution_environment/tests.rs
+++ b/rs/execution_environment/src/execution_environment/tests.rs
@@ -1322,7 +1322,7 @@ fn canister_snapshots_after_split() {
     test.canister_update_controller(canister_id_2, controllers)
         .unwrap();
 
-    // The snapshots do not exists in the replicated state before the requests.
+    // The snapshots do not exist in the replicated state before the requests.
     assert_eq!(
         test.state()
             .canister_snapshots
@@ -1355,7 +1355,7 @@ fn canister_snapshots_after_split() {
     );
     test.execute_subnet_message();
 
-    // Verify the snapshots exists in the replicated state.
+    // Verify the snapshots exist in the replicated state.
     assert_eq!(
         test.state()
             .canister_snapshots
@@ -1385,7 +1385,7 @@ fn canister_snapshots_after_split() {
         .split(subnet_a, &routing_table, None)
         .unwrap();
 
-    // Restore consistency between stop canister calls tracked by canisters and subnet.
+    // Restore consistency between canister snapshots tracked by canisters and subnet.
     state_a.after_split();
 
     // Split subnet B.
@@ -1395,7 +1395,7 @@ fn canister_snapshots_after_split() {
         .split(subnet_b, &routing_table, None)
         .unwrap();
 
-    // Restore consistency between stop canister calls tracked by canisters and subnet.
+    // Restore consistency between canister snapshots tracked by canisters and subnet.
     state_b.after_split();
 
     // Splitting the original subnet into subnet A' and subnet B,

--- a/rs/replicated_state/src/canister_snapshots.rs
+++ b/rs/replicated_state/src/canister_snapshots.rs
@@ -174,7 +174,7 @@ impl CanisterSnapshots {
             let snapshot = snapshots.get(&snapshot_id).unwrap();
             if !is_local_canister(snapshot.canister_id) {
                 snapshots.remove(&snapshot_id);
-                // TODO: Enable after checkpointing logic is implemented.
+                // TODO(EXC-1656): Add SnapshotOperation::Delete when a snapshot is discarded during a subnet split.
                 // unflushed_changes.push(SnapshotOperation::Delete(snapshot_id));
             }
         }

--- a/rs/replicated_state/src/canister_snapshots.rs
+++ b/rs/replicated_state/src/canister_snapshots.rs
@@ -140,13 +140,10 @@ impl CanisterSnapshots {
         self.unflushed_changes.is_empty()
     }
 
-    pub(crate) fn split<F>(
-        &mut self,
-        is_local_canister: F,
-    ) where
+    pub(crate) fn split<F>(&mut self, is_local_canister: F)
+    where
         F: Fn(CanisterId) -> bool,
     {
-
         // Destructure `self` and put it back together, in order for the compiler to
         // enforce an explicit decision whenever new fields are added.
         let Self {

--- a/rs/replicated_state/src/canister_snapshots.rs
+++ b/rs/replicated_state/src/canister_snapshots.rs
@@ -164,7 +164,7 @@ impl CanisterSnapshots {
         // enforce an explicit decision whenever new fields are added.
         let CanisterSnapshots {
             ref mut snapshots,
-            ref mut unflushed_changes,
+            unflushed_changes: _,
             ref mut snapshot_ids,
         } = self;
 
@@ -174,7 +174,8 @@ impl CanisterSnapshots {
             let snapshot = snapshots.get(&snapshot_id).unwrap();
             if !is_local_canister(snapshot.canister_id) {
                 snapshots.remove(&snapshot_id);
-                unflushed_changes.push(SnapshotOperation::Delete(snapshot_id));
+                // TODO: Enable after checkpointing logic is implemented.
+                // unflushed_changes.push(SnapshotOperation::Delete(snapshot_id));
             }
         }
         snapshot_ids.retain(|canister_id, _| is_local_canister(*canister_id));

--- a/rs/replicated_state/src/canister_snapshots.rs
+++ b/rs/replicated_state/src/canister_snapshots.rs
@@ -164,7 +164,7 @@ impl CanisterSnapshots {
         // enforce an explicit decision whenever new fields are added.
         let CanisterSnapshots {
             ref mut snapshots,
-            unflushed_changes: _,
+            ref mut unflushed_changes,
             ref mut snapshot_ids,
         } = self;
 
@@ -174,8 +174,7 @@ impl CanisterSnapshots {
             let snapshot = snapshots.get(&snapshot_id).unwrap();
             if !is_local_canister(snapshot.canister_id) {
                 snapshots.remove(&snapshot_id);
-                // TODO(EXC-1656): Add SnapshotOperation::Delete when a snapshot is discarded during a subnet split.
-                // unflushed_changes.push(SnapshotOperation::Delete(snapshot_id));
+                unflushed_changes.push(SnapshotOperation::Delete(snapshot_id));
             }
         }
         snapshot_ids.retain(|canister_id, _| is_local_canister(*canister_id));

--- a/rs/replicated_state/src/replicated_state.rs
+++ b/rs/replicated_state/src/replicated_state.rs
@@ -1027,6 +1027,9 @@ impl ReplicatedState {
         // TODO: Validate that canisters are split across no more than 2 subnets.
         canister_states
             .retain(|canister_id, _| routing_table.route(canister_id.get()) == Some(subnet_id));
+        
+        // Retain only the canister snapshots belonging to the local canisters.
+        let canister_snapshots = canister_snapshots.split(&canister_states);
 
         // All subnet messages (ingress and canister) only remain on subnet A' because:
         //

--- a/rs/replicated_state/src/replicated_state.rs
+++ b/rs/replicated_state/src/replicated_state.rs
@@ -992,6 +992,8 @@ impl ReplicatedState {
     /// This first phase only consists of:
     ///  * Splitting the canisters hosted by A among A' and B, as determined by the
     ///    provided routing table.
+    ///  * Splitting the canister snapshots stored by A among A' and B,
+    ///    as determined by the canister splitting.
     ///  * Producing a new, empty `MetadataState` for subnet B, but preserving
     ///    the ingress history unchanged.
     ///
@@ -1016,7 +1018,7 @@ impl ReplicatedState {
             mut subnet_queues,
             consensus_queue,
             epoch_query_stats: _,
-            canister_snapshots,
+            mut canister_snapshots,
         } = self;
 
         // Consensus queue is always empty at the end of the round.

--- a/rs/replicated_state/src/replicated_state.rs
+++ b/rs/replicated_state/src/replicated_state.rs
@@ -1029,7 +1029,7 @@ impl ReplicatedState {
             .retain(|canister_id, _| routing_table.route(canister_id.get()) == Some(subnet_id));
         
         // Retain only the canister snapshots belonging to the local canisters.
-        let canister_snapshots = canister_snapshots.split(&canister_states);
+        canister_snapshots.split(|canister_id| canister_states.contains_key(&canister_id));
 
         // All subnet messages (ingress and canister) only remain on subnet A' because:
         //

--- a/rs/replicated_state/src/replicated_state.rs
+++ b/rs/replicated_state/src/replicated_state.rs
@@ -1027,7 +1027,7 @@ impl ReplicatedState {
         // TODO: Validate that canisters are split across no more than 2 subnets.
         canister_states
             .retain(|canister_id, _| routing_table.route(canister_id.get()) == Some(subnet_id));
-        
+
         // Retain only the canister snapshots belonging to the local canisters.
         canister_snapshots.split(|canister_id| canister_states.contains_key(&canister_id));
 


### PR DESCRIPTION
This MR adds the logic to distribute the canister snapshots accordingly during a subnet split. 