### PR TITLE
perf(crypto): CRP-2542 Reduce the size of randomizers during Ed25519 batch verification

### DIFF
--- a/rs/crypto/ed25519/src/lib.rs
+++ b/rs/crypto/ed25519/src/lib.rs
@@ -659,8 +659,7 @@ impl PublicKey {
             .collect::<Vec<_>>();
 
         // Select a random Scalar for each signature.
-        // TODO(CRP-2542): Can we use smaller randomizers here?
-        let zs: Vec<Scalar> = (0..n).map(|_| Scalar::random(rng)).collect();
+        let zs: Vec<Scalar> = (0..n).map(|_| Scalar::from(rng.gen::<u128>())).collect();
 
         let b_coefficient: Scalar = signatures
             .iter()


### PR DESCRIPTION
Previously ZIP215 batch verification of Ed25519 signatures used full size (253 bit) randomizers. However 128 bits is sufficient for security here, and is somewhat faster to execute.