### PR TITLE
refactor(nervous_system): Move `Principals` message definition to nervous_system/proto

### DIFF
--- a/rs/nervous_system/integration_tests/tests/sns_lifecycle.rs
+++ b/rs/nervous_system/integration_tests/tests/sns_lifecycle.rs
@@ -1620,9 +1620,9 @@ fn test_sns_lifecycle(
                 .iter()
                 .filter_map(|recipe| {
                     if let Some(Investor::CommunityFund(ref investment)) = recipe.investor {
-                        let hotkey_principal = investment.hotkey_principal.clone();
+                        let controller = investment.try_get_controller().unwrap();
                         let amount_sns_e8s = recipe.sns.clone().unwrap().amount_e8s;
-                        Some((hotkey_principal, amount_sns_e8s))
+                        Some((controller, amount_sns_e8s))
                     } else {
                         None
                     }

--- a/rs/nervous_system/proto/proto/ic_nervous_system/pb/v1/nervous_system.proto
+++ b/rs/nervous_system/proto/proto/ic_nervous_system/pb/v1/nervous_system.proto
@@ -27,6 +27,12 @@ message Percentage {
   optional uint64 basis_points = 1;
 }
 
+// A list of principals.
+// Needed to allow prost to generate the equivalent of Optional<Vec<PrincipalId>>.
+message Principals {
+  repeated ic_base_types.pb.v1.PrincipalId principals = 1;
+}
+
 // A Canister that will be transferred to an SNS.
 message Canister {
   // The id of the canister.

--- a/rs/nervous_system/proto/protobuf_generator/src/lib.rs
+++ b/rs/nervous_system/proto/protobuf_generator/src/lib.rs
@@ -41,6 +41,7 @@ pub fn generate_prost_files(proto_paths: ProtoPaths<'_>, out_dir: &Path) {
         "ic_nervous_system.pb.v1.Canister",
         "#[derive(Ord, PartialOrd)]",
     );
+    config.type_attribute("ic_nervous_system.pb.v1.Canister", "#[derive(Eq)]");
 
     let src_file = proto_paths
         .nervous_system

--- a/rs/nervous_system/proto/src/gen/ic_nervous_system.pb.v1.rs
+++ b/rs/nervous_system/proto/src/gen/ic_nervous_system.pb.v1.rs
@@ -51,6 +51,15 @@ pub struct Percentage {
     #[prost(uint64, optional, tag = "1")]
     pub basis_points: ::core::option::Option<u64>,
 }
+/// A list of principals.
+/// Needed to allow prost to generate the equivalent of Optional<Vec<PrincipalId>>.
+#[derive(Eq, candid::CandidType, candid::Deserialize, comparable::Comparable, serde::Serialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Principals {
+    #[prost(message, repeated, tag = "1")]
+    pub principals: ::prost::alloc::vec::Vec<::ic_base_types::PrincipalId>,
+}
 /// A Canister that will be transferred to an SNS.
 #[derive(
     Eq,
@@ -60,6 +69,7 @@ pub struct Percentage {
     serde::Serialize,
     Ord,
     PartialOrd,
+    Eq,
     Copy,
 )]
 #[allow(clippy::derive_partial_eq_without_eq)]

--- a/rs/nervous_system/proto/src/lib.rs
+++ b/rs/nervous_system/proto/src/lib.rs
@@ -1,6 +1,6 @@
 use crate::pb::v1::Canister;
 use ic_base_types::PrincipalId;
-use pb::v1::{Decimal as DecimalPb, Duration, GlobalTimeOfDay, Percentage, Tokens};
+use pb::v1::{Decimal as DecimalPb, Duration, GlobalTimeOfDay, Percentage, Principals, Tokens};
 use rust_decimal::Decimal;
 use std::str::FromStr;
 
@@ -161,5 +161,16 @@ impl TryFrom<DecimalPb> for Decimal {
     }
 }
 
+impl From<Vec<PrincipalId>> for Principals {
+    fn from(principals: Vec<PrincipalId>) -> Self {
+        Self { principals }
+    }
+}
+
+impl From<Principals> for Vec<PrincipalId> {
+    fn from(principals: Principals) -> Self {
+        principals.principals
+    }
+}
 #[cfg(test)]
 mod tests;

--- a/rs/nns/governance/api/src/ic_nns_governance.pb.v1.rs
+++ b/rs/nns/governance/api/src/ic_nns_governance.pb.v1.rs
@@ -3171,15 +3171,6 @@ pub mod settle_neurons_fund_participation_request {
         Aborted(Aborted),
     }
 }
-/// A list of principals.
-/// Needed to allow prost to generate the equivalent of Optional<Vec<PrincipalId>>.
-#[derive(candid::CandidType, candid::Deserialize, serde::Serialize, comparable::Comparable)]
-#[allow(clippy::derive_partial_eq_without_eq)]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct Principals {
-    #[prost(message, repeated, tag = "1")]
-    pub principals: ::prost::alloc::vec::Vec<::ic_base_types::PrincipalId>,
-}
 /// Handling the Neurons' Fund and transferring some of its maturity to an SNS treasury is
 /// thus the responsibility of the NNS Governance. When a swap succeeds, a Swap canister should send
 /// a `settle_neurons_fund_participation` request to the NNS Governance, specifying its `result`
@@ -3220,7 +3211,7 @@ pub mod settle_neurons_fund_participation_response {
         pub controller: ::core::option::Option<::ic_base_types::PrincipalId>,
         /// The principals that can vote, propose, and follow on behalf of this neuron.
         #[prost(message, optional, tag = "7")]
-        pub hotkeys: ::core::option::Option<super::Principals>,
+        pub hotkeys: ::core::option::Option<::ic_nervous_system_proto::pb::v1::Principals>,
         /// Whether the amount maturity amount of Neurons' Fund participation associated with this neuron
         /// has been capped to reflect the maximum participation amount for this SNS swap.
         #[prost(bool, optional, tag = "4")]

--- a/rs/nns/governance/canister/governance.did
+++ b/rs/nns/governance/canister/governance.did
@@ -11,7 +11,7 @@ type Action = variant {
   SetDefaultFollowees : SetDefaultFollowees;
   RewardNodeProviders : RewardNodeProviders;
   ManageNetworkEconomics : NetworkEconomics;
-  ApproveGenesisKyc : Principals_1;
+  ApproveGenesisKyc : Principals;
   AddOrRemoveNodeProvider : AddOrRemoveNodeProvider;
   Motion : Motion;
 };
@@ -42,7 +42,7 @@ type CanisterSummary = record {
 };
 type CfNeuron = record {
   has_created_neuron_recipes : opt bool;
-  hotkeys : opt Principals_1;
+  hotkeys : opt Principals;
   nns_neuron_id : nat64;
   amount_icp_e8s : nat64;
 };
@@ -515,7 +515,6 @@ type Params = record {
 };
 type Percentage = record { basis_points : opt nat64 };
 type Principals = record { principals : vec principal };
-type Principals_1 = record { principals : vec principal };
 type Progress = variant { LastNeuronId : NeuronId };
 type Proposal = record {
   url : text;

--- a/rs/nns/governance/canister/governance.did
+++ b/rs/nns/governance/canister/governance.did
@@ -11,7 +11,7 @@ type Action = variant {
   SetDefaultFollowees : SetDefaultFollowees;
   RewardNodeProviders : RewardNodeProviders;
   ManageNetworkEconomics : NetworkEconomics;
-  ApproveGenesisKyc : Principals;
+  ApproveGenesisKyc : Principals_1;
   AddOrRemoveNodeProvider : AddOrRemoveNodeProvider;
   Motion : Motion;
 };
@@ -42,10 +42,12 @@ type CanisterSummary = record {
 };
 type CfNeuron = record {
   has_created_neuron_recipes : opt bool;
+  hotkeys : opt Principals_1;
   nns_neuron_id : nat64;
   amount_icp_e8s : nat64;
 };
 type CfParticipant = record {
+  controller : opt principal;
   hotkey_principal : text;
   cf_neurons : vec CfNeuron;
 };
@@ -513,6 +515,7 @@ type Params = record {
 };
 type Percentage = record { basis_points : opt nat64 };
 type Principals = record { principals : vec principal };
+type Principals_1 = record { principals : vec principal };
 type Progress = variant { LastNeuronId : NeuronId };
 type Proposal = record {
   url : text;

--- a/rs/nns/governance/canister/governance_test.did
+++ b/rs/nns/governance/canister/governance_test.did
@@ -11,7 +11,7 @@ type Action = variant {
   SetDefaultFollowees : SetDefaultFollowees;
   RewardNodeProviders : RewardNodeProviders;
   ManageNetworkEconomics : NetworkEconomics;
-  ApproveGenesisKyc : Principals_1;
+  ApproveGenesisKyc : Principals;
   AddOrRemoveNodeProvider : AddOrRemoveNodeProvider;
   Motion : Motion;
 };
@@ -42,7 +42,7 @@ type CanisterSummary = record {
 };
 type CfNeuron = record {
   has_created_neuron_recipes : opt bool;
-  hotkeys : opt Principals_1;
+  hotkeys : opt Principals;
   nns_neuron_id : nat64;
   amount_icp_e8s : nat64;
 };
@@ -515,7 +515,6 @@ type Params = record {
 };
 type Percentage = record { basis_points : opt nat64 };
 type Principals = record { principals : vec principal };
-type Principals_1 = record { principals : vec principal };
 type Progress = variant { LastNeuronId : NeuronId };
 type Proposal = record {
   url : text;

--- a/rs/nns/governance/canister/governance_test.did
+++ b/rs/nns/governance/canister/governance_test.did
@@ -11,7 +11,7 @@ type Action = variant {
   SetDefaultFollowees : SetDefaultFollowees;
   RewardNodeProviders : RewardNodeProviders;
   ManageNetworkEconomics : NetworkEconomics;
-  ApproveGenesisKyc : Principals;
+  ApproveGenesisKyc : Principals_1;
   AddOrRemoveNodeProvider : AddOrRemoveNodeProvider;
   Motion : Motion;
 };
@@ -42,10 +42,12 @@ type CanisterSummary = record {
 };
 type CfNeuron = record {
   has_created_neuron_recipes : opt bool;
+  hotkeys : opt Principals_1;
   nns_neuron_id : nat64;
   amount_icp_e8s : nat64;
 };
 type CfParticipant = record {
+  controller : opt principal;
   hotkey_principal : text;
   cf_neurons : vec CfNeuron;
 };
@@ -513,6 +515,7 @@ type Params = record {
 };
 type Percentage = record { basis_points : opt nat64 };
 type Principals = record { principals : vec principal };
+type Principals_1 = record { principals : vec principal };
 type Progress = variant { LastNeuronId : NeuronId };
 type Proposal = record {
   url : text;

--- a/rs/nns/governance/proto/ic_nns_governance/pb/v1/governance.proto
+++ b/rs/nns/governance/proto/ic_nns_governance/pb/v1/governance.proto
@@ -2606,12 +2606,6 @@ message SettleNeuronsFundParticipationRequest {
   message Aborted {}
 }
 
-// A list of principals.
-// Needed to allow prost to generate the equivalent of Optional<Vec<PrincipalId>>.
-message Principals {
-  repeated ic_base_types.pb.v1.PrincipalId principals = 1;
-}
-
 // Handling the Neurons' Fund and transferring some of its maturity to an SNS treasury is
 // thus the responsibility of the NNS Governance. When a swap succeeds, a Swap canister should send
 // a `settle_neurons_fund_participation` request to the NNS Governance, specifying its `result`
@@ -2634,7 +2628,7 @@ message SettleNeuronsFundParticipationResponse {
     // The principal that can manage this neuron.
     optional ic_base_types.pb.v1.PrincipalId controller = 6;
     // The principals that can vote, propose, and follow on behalf of this neuron.
-    optional Principals hotkeys = 7;
+    optional ic_nervous_system.pb.v1.Principals hotkeys = 7;
 
     // Whether the amount maturity amount of Neurons' Fund participation associated with this neuron
     // has been capped to reflect the maximum participation amount for this SNS swap.

--- a/rs/nns/governance/src/gen/ic_nns_governance.pb.v1.rs
+++ b/rs/nns/governance/src/gen/ic_nns_governance.pb.v1.rs
@@ -3171,15 +3171,6 @@ pub mod settle_neurons_fund_participation_request {
         Aborted(Aborted),
     }
 }
-/// A list of principals.
-/// Needed to allow prost to generate the equivalent of Optional<Vec<PrincipalId>>.
-#[derive(candid::CandidType, candid::Deserialize, serde::Serialize, comparable::Comparable)]
-#[allow(clippy::derive_partial_eq_without_eq)]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct Principals {
-    #[prost(message, repeated, tag = "1")]
-    pub principals: ::prost::alloc::vec::Vec<::ic_base_types::PrincipalId>,
-}
 /// Handling the Neurons' Fund and transferring some of its maturity to an SNS treasury is
 /// thus the responsibility of the NNS Governance. When a swap succeeds, a Swap canister should send
 /// a `settle_neurons_fund_participation` request to the NNS Governance, specifying its `result`
@@ -3220,7 +3211,7 @@ pub mod settle_neurons_fund_participation_response {
         pub controller: ::core::option::Option<::ic_base_types::PrincipalId>,
         /// The principals that can vote, propose, and follow on behalf of this neuron.
         #[prost(message, optional, tag = "7")]
-        pub hotkeys: ::core::option::Option<super::Principals>,
+        pub hotkeys: ::core::option::Option<::ic_nervous_system_proto::pb::v1::Principals>,
         /// Whether the amount maturity amount of Neurons' Fund participation associated with this neuron
         /// has been capped to reflect the maximum participation amount for this SNS swap.
         #[prost(bool, optional, tag = "4")]

--- a/rs/nns/governance/src/governance.rs
+++ b/rs/nns/governance/src/governance.rs
@@ -51,9 +51,9 @@ use crate::{
         NeuronsFundAuditInfo, NeuronsFundData,
         NeuronsFundEconomics as NeuronsFundNetworkEconomicsPb,
         NeuronsFundParticipation as NeuronsFundParticipationPb,
-        NeuronsFundSnapshot as NeuronsFundSnapshotPb, NnsFunction, NodeProvider, Principals,
-        Proposal, ProposalData, ProposalInfo, ProposalRewardStatus, ProposalStatus,
-        RestoreAgingSummary, RewardEvent, RewardNodeProvider, RewardNodeProviders,
+        NeuronsFundSnapshot as NeuronsFundSnapshotPb, NnsFunction, NodeProvider, Proposal,
+        ProposalData, ProposalInfo, ProposalRewardStatus, ProposalStatus, RestoreAgingSummary,
+        RewardEvent, RewardNodeProvider, RewardNodeProviders,
         SettleNeuronsFundParticipationRequest, SettleNeuronsFundParticipationResponse, Tally,
         Topic, UpdateNodeProvider, Vote, WaitForQuietState,
         XdrConversionRate as XdrConversionRatePb,
@@ -78,6 +78,7 @@ use ic_nervous_system_common::{
 };
 use ic_nervous_system_governance::maturity_modulation::apply_maturity_modulation;
 use ic_nervous_system_proto::pb::v1::GlobalTimeOfDay;
+use ic_nervous_system_proto::pb::v1::Principals;
 use ic_nns_common::{
     pb::v1::{NeuronId, ProposalId},
     types::UpdateIcpXdrConversionRatePayload,
@@ -1256,17 +1257,6 @@ impl ProposalInfo {
     }
 }
 
-impl From<Vec<PrincipalId>> for Principals {
-    fn from(principals: Vec<PrincipalId>) -> Self {
-        Self { principals }
-    }
-}
-
-impl From<Principals> for Vec<PrincipalId> {
-    fn from(principals: Principals) -> Self {
-        principals.principals
-    }
-}
 #[cfg(test)]
 mod test_wait_for_quiet {
     use crate::pb::v1::{ProposalData, Tally, WaitForQuietState};

--- a/rs/nns/governance/src/governance.rs
+++ b/rs/nns/governance/src/governance.rs
@@ -300,7 +300,7 @@ impl From<NeuronsFundNeuronPortion> for NeuronsFundNeuronPb {
             nns_neuron_id: Some(neuron.id.id),
             amount_icp_e8s: Some(neuron.amount_icp_e8s),
             controller: Some(neuron.controller),
-            hotkeys: Some(neuron.hotkeys.into()),
+            hotkeys: Some(Principals::from(neuron.hotkeys.clone())),
             is_capped: Some(neuron.is_capped),
             hotkey_principal: Some(neuron.controller.to_string()),
         }

--- a/rs/nns/governance/tests/governance.rs
+++ b/rs/nns/governance/tests/governance.rs
@@ -10899,29 +10899,37 @@ lazy_static! {
     };
 
     static ref CF_PARTICIPANTS: Vec<sns_swap_pb::CfParticipant> = {
+        #[allow(deprecated)] // TODO[#NNS-2338]: Remove this once hotkey_principal is removed.
         let mut result = vec![
             sns_swap_pb::CfParticipant {
+                controller: Some(principal(1)),
                 hotkey_principal: principal(1).to_string(),
                 cf_neurons: vec![
                     sns_swap_pb::CfNeuron::try_new(
                         1,
                         NEURONS_FUND_INVESTMENT_E8S * 60 / 100,
+                        vec![],
                     ).unwrap(),
                     sns_swap_pb::CfNeuron::try_new(
                         2,
-                        NEURONS_FUND_INVESTMENT_E8S * 10 / 100
+                        NEURONS_FUND_INVESTMENT_E8S * 10 / 100,
+                        vec![],
                     ).unwrap(),
                 ],
             },
             sns_swap_pb::CfParticipant {
+                controller: Some(principal(2)),
                 hotkey_principal: principal(2).to_string(),
-                cf_neurons: vec![sns_swap_pb::CfNeuron::try_new(
-                    3,
-                    NEURONS_FUND_INVESTMENT_E8S * 30 / 100,
-                ).unwrap()],
+                cf_neurons: vec![
+                    sns_swap_pb::CfNeuron::try_new(
+                        3,
+                        NEURONS_FUND_INVESTMENT_E8S * 30 / 100,
+                        vec![],
+                    ).unwrap()
+                ],
             },
         ];
-        result.sort_by(|p1, p2| p1.hotkey_principal.cmp(&p2.hotkey_principal));
+        result.sort_by_key(|p1| p1.try_get_controller().unwrap());
         result
     };
 

--- a/rs/nns/sns-wasm/canister/sns-wasm.did
+++ b/rs/nns/sns-wasm/canister/sns-wasm.did
@@ -4,10 +4,12 @@ type AirdropDistribution = record { airdrop_neurons : vec NeuronDistribution };
 type Canister = record { id : opt principal };
 type CfNeuron = record {
   has_created_neuron_recipes : opt bool;
+  hotkeys : opt Principals;
   nns_neuron_id : nat64;
   amount_icp_e8s : nat64;
 };
 type CfParticipant = record {
+  controller : opt principal;
   hotkey_principal : text;
   cf_neurons : vec CfNeuron;
 };
@@ -125,6 +127,7 @@ type PrettySnsVersion = record {
   governance_wasm_hash : text;
   index_wasm_hash : text;
 };
+type Principals = record { principals : vec principal };
 type Result = variant { Error : SnsWasmError; Hash : blob };
 type Result_1 = variant { Ok : Ok; Error : SnsWasmError };
 type SnsCanisterIds = record {

--- a/rs/sns/audit/src/lib.rs
+++ b/rs/sns/audit/src/lib.rs
@@ -164,9 +164,9 @@ async fn validate_neurons_fund_sns_swap_participation(
         .into_iter()
         .filter_map(|recipe| {
             if let Some(Investor::CommunityFund(ref investment)) = recipe.investor {
-                let hotkey_principal = investment.hotkey_principal.clone();
+                let controller = investment.try_get_controller().unwrap();
                 let amount_sns_e8s = recipe.sns.clone().unwrap().amount_e8s;
-                Some((hotkey_principal, amount_sns_e8s))
+                Some((controller, amount_sns_e8s))
             } else {
                 None
             }
@@ -177,17 +177,16 @@ async fn validate_neurons_fund_sns_swap_participation(
         format!("SNS swap {} is not in the final state yet, so `neurons_fund_refunds` is not specified.", sns_name)
     })?;
     let refunded_neuron_portions = neurons_fund_refunds.neurons_fund_neuron_portions;
-    let mut refunded_amounts_per_controller = BTreeMap::<String, _>::new();
+    let mut refunded_amounts_per_controller = BTreeMap::new();
     for refunded_neuron_portion in refunded_neuron_portions.iter() {
         #[allow(deprecated)] // TODO(NNS1-3198): remove once hotkey_principal is removed
-        let hotkey_principal = refunded_neuron_portion
+        let controller = refunded_neuron_portion
             .controller
             .or(refunded_neuron_portion.hotkey_principal)
-            .unwrap()
-            .to_string();
+            .unwrap();
         let new_amount_icp_e8s = refunded_neuron_portion.amount_icp_e8s.unwrap();
         refunded_amounts_per_controller
-            .entry(hotkey_principal)
+            .entry(controller)
             .and_modify(|total_amount_icp_e8s| *total_amount_icp_e8s += new_amount_icp_e8s)
             .or_insert(new_amount_icp_e8s);
     }
@@ -199,17 +198,16 @@ async fn validate_neurons_fund_sns_swap_participation(
         .neurons_fund_reserves
         .unwrap()
         .neurons_fund_neuron_portions;
-    let mut initial_amounts_per_controller: BTreeMap<String, _> = BTreeMap::new();
+    let mut initial_amounts_per_controller: BTreeMap<_, _> = BTreeMap::new();
     for initial_neuron_portion in initial_neuron_portions.iter() {
         #[allow(deprecated)] // TODO(NNS1-3198): remove once hotkey_principal is removed
-        let hotkey_principal = initial_neuron_portion
+        let controller = initial_neuron_portion
             .controller
             .or(initial_neuron_portion.hotkey_principal)
-            .unwrap()
-            .to_string();
+            .unwrap();
         let new_amount_icp_e8s = initial_neuron_portion.amount_icp_e8s.unwrap();
         initial_amounts_per_controller
-            .entry(hotkey_principal)
+            .entry(controller)
             .and_modify(|total_amount_icp_e8s| *total_amount_icp_e8s += new_amount_icp_e8s)
             .or_insert(new_amount_icp_e8s);
     }
@@ -221,14 +219,13 @@ async fn validate_neurons_fund_sns_swap_participation(
         .neurons_fund_reserves
         .unwrap()
         .neurons_fund_neuron_portions;
-    let mut final_amounts_per_controller: BTreeMap<String, _> = BTreeMap::new();
+    let mut final_amounts_per_controller = BTreeMap::new();
     for final_neuron_portion in final_neuron_portions.iter() {
         #[allow(deprecated)] // TODO(NNS1-3198): remove once hotkey_principal is removed
         let hotkey_principal = final_neuron_portion
             .controller
             .or(final_neuron_portion.hotkey_principal)
-            .unwrap()
-            .to_string();
+            .unwrap();
         let new_amount_icp_e8s = final_neuron_portion.amount_icp_e8s.unwrap();
         final_amounts_per_controller
             .entry(hotkey_principal)
@@ -284,38 +281,37 @@ async fn validate_neurons_fund_sns_swap_participation(
             == (sns_neurons_per_backet as u128) * (num_nns_nf_neurons as u128),
     );
 
-    let mut sns_neuron_recipes_per_controller = BTreeMap::<String, Vec<u64>>::new();
-    for (hotkey_principal, amount_sns_e8s) in sns_neuron_recipes.into_iter() {
+    let mut sns_neuron_recipes_per_controller = BTreeMap::<_, Vec<u64>>::new();
+    for (controller, amount_sns_e8s) in sns_neuron_recipes.into_iter() {
         sns_neuron_recipes_per_controller
-            .entry(hotkey_principal.clone())
+            .entry(controller)
             .and_modify(|sns_neurons| {
                 sns_neurons.push(amount_sns_e8s);
             })
             .or_insert(vec![amount_sns_e8s]);
     }
 
-    let mut investment_per_controller_icp_e8s = BTreeMap::<String, Vec<u64>>::new();
+    let mut investment_per_controller_icp_e8s = BTreeMap::<_, Vec<u64>>::new();
     for expected_neuron_portion in final_neuron_portions {
         #[allow(deprecated)] // TODO(NNS1-3198): remove once hotkey_principal is removed
         let hotkey_principal = expected_neuron_portion
             .controller
             .or(expected_neuron_portion.hotkey_principal)
-            .unwrap()
-            .to_string();
+            .unwrap();
         let amount_icp_e8s = expected_neuron_portion.amount_icp_e8s.unwrap();
         investment_per_controller_icp_e8s
-            .entry(hotkey_principal.clone())
+            .entry(hotkey_principal)
             .and_modify(|nns_neurons| {
                 nns_neurons.push(amount_icp_e8s);
             })
             .or_insert(vec![amount_icp_e8s]);
     }
 
-    for (hotkey_principal, nns_neurons) in investment_per_controller_icp_e8s.iter() {
+    for (controller, nns_neurons) in investment_per_controller_icp_e8s.iter() {
         let amount_icp_e8s = nns_neurons.iter().sum::<u64>();
         let amount_icp_e8s = u64_to_dec(amount_icp_e8s)?;
         let sns_neurons = sns_neuron_recipes_per_controller
-            .get(hotkey_principal)
+            .get(controller)
             .expect("All Neuron's Fund participants should have SNS neuron recipes.");
         let amount_sns_e8s = sns_neurons.iter().sum::<u64>();
         let amount_sns_e8s = u64_to_dec(amount_sns_e8s)?;
@@ -332,8 +328,8 @@ async fn validate_neurons_fund_sns_swap_participation(
             .collect::<Vec<_>>()
             .join(", ");
         let msg = format!(
-            "Neurons' Fund controller {} participated with {} ICP e8s ({}), receiving {} SNS token e8s ({}). Error = {}% = {} SNS e8s",
-            hotkey_principal, amount_icp_e8s, nns_neurons_str, amount_sns_e8s, sns_neurons_str, error_per_cent, absolute_error_sns_e8s,
+            "Neurons' Fund controller {:?} participated with {} ICP e8s ({}), receiving {} SNS token e8s ({}). Error = {}% = {} SNS e8s",
+            controller, amount_icp_e8s, nns_neurons_str, amount_sns_e8s, sns_neurons_str, error_per_cent, absolute_error_sns_e8s,
         );
         let cummulative_error_tolerance =
             ERROR_TOLERANCE_ICP_E8S * Decimal::from_usize(nns_neurons.len()).unwrap();

--- a/rs/sns/init/src/lib.rs
+++ b/rs/sns/init/src/lib.rs
@@ -338,11 +338,13 @@ impl From<NeuronBasketConstructionParametersValidationError> for Result<(), Stri
 
 impl From<NeuronsFundParticipants> for ic_sns_swap::pb::v1::NeuronsFundParticipants {
     fn from(value: NeuronsFundParticipants) -> Self {
+        #[allow(deprecated)] // TODO(NNS1-3198): remove once hotkey_principal is removed
         Self {
             cf_participants: value
                 .participants
                 .iter()
                 .map(|cf_participant| ic_sns_swap::pb::v1::CfParticipant {
+                    controller: cf_participant.controller,
                     hotkey_principal: cf_participant.hotkey_principal.clone(),
                     cf_neurons: cf_participant.cf_neurons.clone(),
                 })

--- a/rs/sns/integration_tests/src/initialization_flow.rs
+++ b/rs/sns/integration_tests/src/initialization_flow.rs
@@ -565,7 +565,7 @@ fn test_one_proposal_sns_initialization_success_with_neurons_fund_participation(
 
     let cf_participants_principals = cf_participants
         .iter()
-        .map(|cf_participant| cf_participant.hotkey_principal.clone())
+        .map(|cf_participant| cf_participant.try_get_controller().unwrap())
         .collect::<Vec<_>>();
     let neurons = sns_governance_list_neurons(
         &sns_initialization_flow_test.state_machine,
@@ -578,7 +578,7 @@ fn test_one_proposal_sns_initialization_success_with_neurons_fund_participation(
         if neuron.is_neurons_fund_controlled() {
             at_least_one_sns_neuron_is_nf_controlled = true;
             let from_neurons_fund = neuron.permissions.iter().any(|permission| {
-                cf_participants_principals.contains(&permission.principal.unwrap().to_string())
+                cf_participants_principals.contains(&permission.principal.unwrap())
             });
             assert!(
                 from_neurons_fund,

--- a/rs/sns/swap/canister/swap.did
+++ b/rs/sns/swap/canister/swap.did
@@ -12,13 +12,20 @@ type CanisterStatusResultV2 = record {
   module_hash : opt blob;
 };
 type CanisterStatusType = variant { stopped; stopping; running };
-type CfInvestment = record { hotkey_principal : text; nns_neuron_id : nat64 };
+type CfInvestment = record {
+  controller : opt principal;
+  hotkey_principal : text;
+  hotkeys : opt Principals;
+  nns_neuron_id : nat64;
+};
 type CfNeuron = record {
   has_created_neuron_recipes : opt bool;
+  hotkeys : opt Principals;
   nns_neuron_id : nat64;
   amount_icp_e8s : nat64;
 };
 type CfParticipant = record {
+  controller : opt principal;
   hotkey_principal : text;
   cf_neurons : vec CfNeuron;
 };
@@ -211,6 +218,7 @@ type Possibility = variant {
 type Possibility_1 = variant { Ok : Response; Err : CanisterCallError };
 type Possibility_2 = variant { Ok : Ok_1; Err : Error };
 type Possibility_3 = variant { Ok : record {}; Err : CanisterCallError };
+type Principals = record { principals : vec principal };
 type RefreshBuyerTokensRequest = record {
   confirmation_text : opt text;
   buyer : text;

--- a/rs/sns/swap/proto/ic_sns_swap/pb/v1/swap.proto
+++ b/rs/sns/swap/proto/ic_sns_swap/pb/v1/swap.proto
@@ -508,7 +508,7 @@ message CfNeuron {
   // with this neuron.
   uint64 amount_icp_e8s = 2;
   // The principals that can vote, propose, and follow on behalf of this neuron.
-  optional Principals hotkeys = 4;
+  optional ic_nervous_system.pb.v1.Principals hotkeys = 4;
 
   // Idempotency flag indicating whether the neuron recipes have been created for
   // the CfNeuron. When set to true, it signifies that the action of creating neuron
@@ -691,7 +691,7 @@ message CfInvestment {
   // The principal that can manage this neuron.
   optional ic_base_types.pb.v1.PrincipalId controller = 6;
   // The principals that can vote, propose, and follow on behalf of this neuron.
-  optional Principals hotkeys = 7;
+  optional ic_nervous_system.pb.v1.Principals hotkeys = 7;
 
   fixed64 nns_neuron_id = 2;
 
@@ -1171,12 +1171,6 @@ message SettleNeuronsFundParticipationRequest {
   message Aborted {}
 }
 
-// A list of principals.
-// Needed to allow prost to generate the equivalent of Optional<Vec<PrincipalId>>.
-message Principals {
-  repeated ic_base_types.pb.v1.PrincipalId principals = 1;
-}
-
 // Handling the Neurons' Fund and transferring some of its maturity to an SNS treasury is
 // thus the responsibility of the NNS Governance. When a swap succeeds, a Swap canister should send
 // a `settle_neurons_fund_participation` request to the NNS Governance, specifying its `result`
@@ -1199,7 +1193,7 @@ message SettleNeuronsFundParticipationResponse {
     // The principal that can manage this neuron.
     optional ic_base_types.pb.v1.PrincipalId controller = 6;
     // The principals that can vote, propose, and follow on behalf of this neuron.
-    optional Principals hotkeys = 7;
+    optional ic_nervous_system.pb.v1.Principals hotkeys = 7;
 
     // Whether the amount maturity amount of Neurons' Fund participation associated with this neuron
     // has been capped to reflect the maximum participation amount for this SNS swap.

--- a/rs/sns/swap/proto/ic_sns_swap/pb/v1/swap.proto
+++ b/rs/sns/swap/proto/ic_sns_swap/pb/v1/swap.proto
@@ -507,6 +507,8 @@ message CfNeuron {
   // The amount of ICP that the Neurons' Fund invests associated
   // with this neuron.
   uint64 amount_icp_e8s = 2;
+  // The principals that can vote, propose, and follow on behalf of this neuron.
+  optional Principals hotkeys = 4;
 
   // Idempotency flag indicating whether the neuron recipes have been created for
   // the CfNeuron. When set to true, it signifies that the action of creating neuron
@@ -517,10 +519,15 @@ message CfNeuron {
 
 // Represents a Neurons' Fund participant, possibly with several neurons.
 message CfParticipant {
-  // The principal that can vote on behalf of these Neurons' Fund neurons.
-  string hotkey_principal = 1;
+  // The principal that can manage this neuron.
+  optional ic_base_types.pb.v1.PrincipalId controller = 6;
   // Information about the participating neurons. Must not be empty.
   repeated CfNeuron cf_neurons = 2;
+
+  // The principal that can vote on behalf of these Neurons' Fund neurons.
+  // Deprecated. Please use `controller` instead (not `hotkeys`!)
+  // TODO(NNS1-3198): Remove
+  string hotkey_principal = 1 [deprecated = true];
 }
 
 // The construction parameters for the basket of neurons created for all
@@ -681,8 +688,16 @@ message DirectInvestment {
 // Information about a Neurons' Fund investment. The NNS Governance
 // canister is the controller of these neurons.
 message CfInvestment {
-  string hotkey_principal = 1;
+  // The principal that can manage this neuron.
+  optional ic_base_types.pb.v1.PrincipalId controller = 6;
+  // The principals that can vote, propose, and follow on behalf of this neuron.
+  optional Principals hotkeys = 7;
+
   fixed64 nns_neuron_id = 2;
+
+  // Deprecated. Please use `controller` instead (not `hotkey_principal`)!
+  // TODO(NNS1-3198): Remove
+  string hotkey_principal = 1 [deprecated = true];
 }
 
 message TimeWindow {
@@ -1191,6 +1206,7 @@ message SettleNeuronsFundParticipationResponse {
     optional bool is_capped = 4;
 
     // Deprecated. Please use `controller` instead (not `hotkeys`!)
+    // TODO(NNS1-3198): Remove
     optional string hotkey_principal = 3 [deprecated = true];
   }
 

--- a/rs/sns/swap/protobuf_generator/src/lib.rs
+++ b/rs/sns/swap/protobuf_generator/src/lib.rs
@@ -43,7 +43,6 @@ pub fn generate_prost_files(proto: ProtoPaths<'_>, out: &Path) {
     );
 
     config.type_attribute(".ic_sns_swap.pb.v1.TimeWindow", "#[derive(Copy)]");
-    config.type_attribute(".ic_sns_swap.pb.v1.Principals", "#[derive(Eq)]");
     config.type_attribute(".ic_sns_swap.pb.v1.CfParticipant", "#[derive(Eq)]");
     config.type_attribute(".ic_sns_swap.pb.v1.CfNeuron", "#[derive(Eq)]");
     config.type_attribute(

--- a/rs/sns/swap/protobuf_generator/src/lib.rs
+++ b/rs/sns/swap/protobuf_generator/src/lib.rs
@@ -43,6 +43,7 @@ pub fn generate_prost_files(proto: ProtoPaths<'_>, out: &Path) {
     );
 
     config.type_attribute(".ic_sns_swap.pb.v1.TimeWindow", "#[derive(Copy)]");
+    config.type_attribute(".ic_sns_swap.pb.v1.Principals", "#[derive(Eq)]");
     config.type_attribute(".ic_sns_swap.pb.v1.CfParticipant", "#[derive(Eq)]");
     config.type_attribute(".ic_sns_swap.pb.v1.CfNeuron", "#[derive(Eq)]");
     config.type_attribute(

--- a/rs/sns/swap/src/gen/ic_sns_swap.pb.v1.rs
+++ b/rs/sns/swap/src/gen/ic_sns_swap.pb.v1.rs
@@ -486,6 +486,9 @@ pub struct CfNeuron {
     /// with this neuron.
     #[prost(uint64, tag = "2")]
     pub amount_icp_e8s: u64,
+    /// The principals that can vote, propose, and follow on behalf of this neuron.
+    #[prost(message, optional, tag = "4")]
+    pub hotkeys: ::core::option::Option<Principals>,
     /// Idempotency flag indicating whether the neuron recipes have been created for
     /// the CfNeuron. When set to true, it signifies that the action of creating neuron
     /// recipes has been performed on this structure. If the action is retried, this flag
@@ -498,12 +501,18 @@ pub struct CfNeuron {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CfParticipant {
-    /// The principal that can vote on behalf of these Neurons' Fund neurons.
-    #[prost(string, tag = "1")]
-    pub hotkey_principal: ::prost::alloc::string::String,
+    /// The principal that can manage this neuron.
+    #[prost(message, optional, tag = "6")]
+    pub controller: ::core::option::Option<::ic_base_types::PrincipalId>,
     /// Information about the participating neurons. Must not be empty.
     #[prost(message, repeated, tag = "2")]
     pub cf_neurons: ::prost::alloc::vec::Vec<CfNeuron>,
+    /// The principal that can vote on behalf of these Neurons' Fund neurons.
+    /// Deprecated. Please use `controller` instead (not `hotkeys`!)
+    /// TODO(NNS1-3198): Remove
+    #[deprecated]
+    #[prost(string, tag = "1")]
+    pub hotkey_principal: ::prost::alloc::string::String,
 }
 /// The construction parameters for the basket of neurons created for all
 /// investors in the decentralization swap.
@@ -681,10 +690,19 @@ pub struct DirectInvestment {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CfInvestment {
-    #[prost(string, tag = "1")]
-    pub hotkey_principal: ::prost::alloc::string::String,
+    /// The principal that can manage this neuron.
+    #[prost(message, optional, tag = "6")]
+    pub controller: ::core::option::Option<::ic_base_types::PrincipalId>,
+    /// The principals that can vote, propose, and follow on behalf of this neuron.
+    #[prost(message, optional, tag = "7")]
+    pub hotkeys: ::core::option::Option<Principals>,
     #[prost(fixed64, tag = "2")]
     pub nns_neuron_id: u64,
+    /// Deprecated. Please use `controller` instead (not `hotkey_principal`)!
+    /// TODO(NNS1-3198): Remove
+    #[deprecated]
+    #[prost(string, tag = "1")]
+    pub hotkey_principal: ::prost::alloc::string::String,
 }
 #[derive(
     candid::CandidType, candid::Deserialize, serde::Serialize, comparable::Comparable, Copy,
@@ -1481,7 +1499,7 @@ pub mod settle_neurons_fund_participation_request {
 }
 /// A list of principals.
 /// Needed to allow prost to generate the equivalent of Optional<Vec<PrincipalId>>.
-#[derive(candid::CandidType, candid::Deserialize, serde::Serialize, comparable::Comparable)]
+#[derive(candid::CandidType, candid::Deserialize, serde::Serialize, comparable::Comparable, Eq)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Principals {
@@ -1534,6 +1552,7 @@ pub mod settle_neurons_fund_participation_response {
         #[prost(bool, optional, tag = "4")]
         pub is_capped: ::core::option::Option<bool>,
         /// Deprecated. Please use `controller` instead (not `hotkeys`!)
+        /// TODO(NNS1-3198): Remove
         #[deprecated]
         #[prost(string, optional, tag = "3")]
         pub hotkey_principal: ::core::option::Option<::prost::alloc::string::String>,

--- a/rs/sns/swap/src/gen/ic_sns_swap.pb.v1.rs
+++ b/rs/sns/swap/src/gen/ic_sns_swap.pb.v1.rs
@@ -488,7 +488,7 @@ pub struct CfNeuron {
     pub amount_icp_e8s: u64,
     /// The principals that can vote, propose, and follow on behalf of this neuron.
     #[prost(message, optional, tag = "4")]
-    pub hotkeys: ::core::option::Option<Principals>,
+    pub hotkeys: ::core::option::Option<::ic_nervous_system_proto::pb::v1::Principals>,
     /// Idempotency flag indicating whether the neuron recipes have been created for
     /// the CfNeuron. When set to true, it signifies that the action of creating neuron
     /// recipes has been performed on this structure. If the action is retried, this flag
@@ -695,7 +695,7 @@ pub struct CfInvestment {
     pub controller: ::core::option::Option<::ic_base_types::PrincipalId>,
     /// The principals that can vote, propose, and follow on behalf of this neuron.
     #[prost(message, optional, tag = "7")]
-    pub hotkeys: ::core::option::Option<Principals>,
+    pub hotkeys: ::core::option::Option<::ic_nervous_system_proto::pb::v1::Principals>,
     #[prost(fixed64, tag = "2")]
     pub nns_neuron_id: u64,
     /// Deprecated. Please use `controller` instead (not `hotkey_principal`)!
@@ -1497,15 +1497,6 @@ pub mod settle_neurons_fund_participation_request {
         Aborted(Aborted),
     }
 }
-/// A list of principals.
-/// Needed to allow prost to generate the equivalent of Optional<Vec<PrincipalId>>.
-#[derive(candid::CandidType, candid::Deserialize, serde::Serialize, comparable::Comparable, Eq)]
-#[allow(clippy::derive_partial_eq_without_eq)]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct Principals {
-    #[prost(message, repeated, tag = "1")]
-    pub principals: ::prost::alloc::vec::Vec<::ic_base_types::PrincipalId>,
-}
 /// Handling the Neurons' Fund and transferring some of its maturity to an SNS treasury is
 /// thus the responsibility of the NNS Governance. When a swap succeeds, a Swap canister should send
 /// a `settle_neurons_fund_participation` request to the NNS Governance, specifying its `result`
@@ -1546,7 +1537,7 @@ pub mod settle_neurons_fund_participation_response {
         pub controller: ::core::option::Option<::ic_base_types::PrincipalId>,
         /// The principals that can vote, propose, and follow on behalf of this neuron.
         #[prost(message, optional, tag = "7")]
-        pub hotkeys: ::core::option::Option<super::Principals>,
+        pub hotkeys: ::core::option::Option<::ic_nervous_system_proto::pb::v1::Principals>,
         /// Whether the amount maturity amount of Neurons' Fund participation associated with this neuron
         /// has been capped to reflect the maximum participation amount for this SNS swap.
         #[prost(bool, optional, tag = "4")]

--- a/rs/sns/swap/src/swap.rs
+++ b/rs/sns/swap/src/swap.rs
@@ -21,7 +21,7 @@ use crate::{
         ListDirectParticipantsResponse, ListSnsNeuronRecipesRequest, ListSnsNeuronRecipesResponse,
         NeuronBasketConstructionParameters, NeuronId as SaleNeuronId, NewSaleTicketRequest,
         NewSaleTicketResponse, NotifyPaymentFailureResponse, OpenRequest, OpenResponse,
-        Participant, Principals, RefreshBuyerTokensResponse, SetDappControllersCallResult,
+        Participant, RefreshBuyerTokensResponse, SetDappControllersCallResult,
         SetDappControllersRequest, SetDappControllersResponse, SetModeCallResult,
         SettleNeuronsFundParticipationRequest, SettleNeuronsFundParticipationResponse,
         SettleNeuronsFundParticipationResult, SnsNeuronRecipe, Swap, SweepResult, Ticket,
@@ -35,6 +35,7 @@ use ic_canister_log::log;
 use ic_ledger_core::Tokens;
 use ic_nervous_system_clients::ledger_client::ICRC1Ledger;
 use ic_nervous_system_common::{i2d, ledger::compute_neuron_staking_subaccount_bytes};
+use ic_nervous_system_proto::pb::v1::Principals;
 use ic_neurons_fund::{MatchedParticipationFunction, PolynomialNeuronsFundParticipation};
 use ic_sns_governance::pb::v1::{
     claim_swap_neurons_request::NeuronParameters,

--- a/rs/sns/swap/src/swap.rs
+++ b/rs/sns/swap/src/swap.rs
@@ -21,7 +21,7 @@ use crate::{
         ListDirectParticipantsResponse, ListSnsNeuronRecipesRequest, ListSnsNeuronRecipesResponse,
         NeuronBasketConstructionParameters, NeuronId as SaleNeuronId, NewSaleTicketRequest,
         NewSaleTicketResponse, NotifyPaymentFailureResponse, OpenRequest, OpenResponse,
-        Participant, RefreshBuyerTokensResponse, SetDappControllersCallResult,
+        Participant, Principals, RefreshBuyerTokensResponse, SetDappControllersCallResult,
         SetDappControllersRequest, SetDappControllersResponse, SetModeCallResult,
         SettleNeuronsFundParticipationRequest, SettleNeuronsFundParticipationResponse,
         SettleNeuronsFundParticipationResult, SnsNeuronRecipe, Swap, SweepResult, Ticket,
@@ -910,14 +910,20 @@ impl Swap {
                         total_participant_icp_e8s,
                     );
 
+                    #[allow(deprecated)] // TODO(NNS1-3198): Remove once hotkey_principal is removed
                     let Some(parsed_principal) =
-                        string_to_principal(&cf_participant.hotkey_principal)
+                    // TODO(NNS1-3198): Simplify once hotkey_principal is removed
+                    cf_participant
+                        .controller
+                        .or(string_to_principal(&cf_participant.hotkey_principal))
                     else {
                         sweep_result.invalid += neuron_basket_construction_parameters.count as u32;
                         return;
                     };
                     match create_sns_neuron_basket_for_cf_participant(
                         &parsed_principal,
+                        // TODO(NNS1-3199): Populate this field
+                        Vec::new(),
                         cf_neuron.nns_neuron_id,
                         amount_sns_e8s,
                         neuron_basket_construction_parameters,
@@ -1625,6 +1631,7 @@ impl Swap {
         let mut neuron_parameters = vec![];
 
         for recipe in &mut self.neuron_recipes {
+            // TODO(NNS1-3207): This match will need to be changed to evaluate to a Participant
             let (hotkey, controller, source_nns_neuron_id) = match recipe.investor.as_ref() {
                 Some(Investor::Direct(DirectInvestment { buyer_principal })) => {
                     let parsed_buyer_principal = match string_to_principal(buyer_principal) {
@@ -1640,25 +1647,19 @@ impl Swap {
 
                     (None, parsed_buyer_principal, None)
                 }
-                Some(Investor::CommunityFund(CfInvestment {
-                    hotkey_principal,
-                    nns_neuron_id,
-                })) => {
-                    let parsed_hotkey_principal = match string_to_principal(hotkey_principal) {
-                        Some(p) => p,
-                        // principal_str should always be parseable as a PrincipalId as that is enforced
-                        // in `refresh_buyer_tokens`. In the case of a bug due to programmer error, increment
-                        // the invalid field. This will require a manual intervention via an upgrade to correct
-                        None => {
+                Some(Investor::CommunityFund(cf_investment)) => {
+                    let nf_neuron_nns_controller = match cf_investment.try_get_controller() {
+                        Ok(controller) => controller,
+                        Err(e) => {
+                            log!(ERROR, "Invalid NF neuron: recipe={recipe:?} error={e}");
                             sweep_result.invalid += 1;
                             continue;
                         }
                     };
-
                     (
-                        Some(parsed_hotkey_principal),
-                        nns_governance.into(),
-                        Some(*nns_neuron_id),
+                        Some(nf_neuron_nns_controller),
+                        PrincipalId::from(nns_governance),
+                        Some(cf_investment.nns_neuron_id),
                     )
                 }
                 // SnsNeuronRecipe.investor should always be present as it is set in `commit`.
@@ -2285,6 +2286,7 @@ impl Swap {
                 }
             };
 
+            #[allow(deprecated)] // TODO(NNS1-3198): Remove once hotkey_principal is removed
             let dst_subaccount = match &recipe.investor {
                 Some(Investor::Direct(DirectInvestment { buyer_principal })) => {
                     match string_to_principal(buyer_principal) {
@@ -2299,6 +2301,8 @@ impl Swap {
                     }
                 }
                 Some(Investor::CommunityFund(CfInvestment {
+                    controller: _,
+                    hotkeys: _,
                     hotkey_principal: _,
                     nns_neuron_id: _,
                 })) => compute_neuron_staking_subaccount_bytes(nns_governance.into(), neuron_memo),
@@ -2502,7 +2506,11 @@ impl Swap {
             let cf_neurons: &mut Vec<CfNeuron> =
                 cf_participant_map.entry(np.controller).or_insert(vec![]);
 
-            let cf_neuron = match CfNeuron::try_new(np.nns_neuron_id, np.amount_icp_e8s) {
+            let cf_neuron = match CfNeuron::try_new(
+                np.nns_neuron_id,
+                np.amount_icp_e8s,
+                np.hotkeys.clone(),
+            ) {
                 Ok(cfn) => cfn,
                 Err(message) => {
                     defects.push(format!("NNS governance returned an invalid NeuronsFundNeuron. It cannot be converted to CfNeuron. Struct: {:?}, Reason: {}", np, message));
@@ -2520,10 +2528,13 @@ impl Swap {
         }
 
         // Convert the intermediate format into its final format
+        #[allow(deprecated)] // TODO(NNS1-3198): Remove once hotkey_principal is removed
         let cf_participants: Vec<CfParticipant> = cf_participant_map
             .into_iter()
-            .map(|(hotkey_principal, cf_neurons)| CfParticipant {
-                hotkey_principal: hotkey_principal.to_string(),
+            .map(|(nf_neuron_nns_controller, cf_neurons)| CfParticipant {
+                controller: Some(nf_neuron_nns_controller),
+                // TODO(NNS1-3198): Remove once hotkey_principal is removed
+                hotkey_principal: nf_neuron_nns_controller.to_string(),
                 cf_neurons,
             })
             .collect();
@@ -3332,7 +3343,7 @@ pub fn principal_to_subaccount(principal_id: &PrincipalId) -> Subaccount {
 
 /// A common pattern throughout the Swap canister is parsing the String
 /// representation of a PrincipalId and logging the error if any.
-fn string_to_principal(maybe_principal_id: &String) -> Option<PrincipalId> {
+pub(crate) fn string_to_principal(maybe_principal_id: &String) -> Option<PrincipalId> {
     match PrincipalId::from_str(maybe_principal_id) {
         Ok(principal_id) => Some(principal_id),
         Err(error_message) => {
@@ -3405,7 +3416,8 @@ fn create_sns_neuron_basket_for_direct_participant(
 
 /// Create the basket of SNS Neuron Recipes for a single Neurons' Fund participant.
 fn create_sns_neuron_basket_for_cf_participant(
-    hotkey_principal: &PrincipalId,
+    controller: &PrincipalId,
+    hotkeys: Vec<PrincipalId>,
     nns_neuron_id: u64,
     amount_sns_token_e8s: u64,
     neuron_basket_construction_parameters: &NeuronBasketConstructionParameters,
@@ -3444,6 +3456,7 @@ fn create_sns_neuron_basket_for_cf_participant(
             vec![neuron_id_with_longest_dissolve_delay.clone()]
         };
 
+        #[allow(deprecated)] // TODO(NNS1-3198): Remove once hotkey_principal is no longer used
         recipes.push(SnsNeuronRecipe {
             sns: Some(TransferableAmount {
                 amount_e8s: scheduled_vesting_event.amount_e8s,
@@ -3453,8 +3466,11 @@ fn create_sns_neuron_basket_for_cf_participant(
                 transfer_fee_paid_e8s: Some(0),
             }),
             investor: Some(Investor::CommunityFund(CfInvestment {
-                hotkey_principal: hotkey_principal.to_string(),
+                controller: Some(*controller),
+                hotkeys: Some(Principals::from(hotkeys.clone())),
                 nns_neuron_id,
+                // TODO(NNS1-3198): Remove
+                hotkey_principal: controller.to_string(),
             })),
             neuron_attributes: Some(NeuronAttributes {
                 memo,
@@ -3970,10 +3986,12 @@ mod tests {
 
     #[test]
     fn test_get_init() {
+        #[allow(deprecated)] // TODO(NNS1-3198): Remove once hotkey_principal is removed
         let swap = Swap {
             init: Some(Init {
                 neurons_fund_participants: Some(NeuronsFundParticipants {
                     cf_participants: vec![CfParticipant {
+                        controller: None,
                         hotkey_principal: "test".to_string(),
                         cf_neurons: vec![CfNeuron::default()],
                     }],
@@ -3996,22 +4014,47 @@ mod tests {
 
     #[test]
     fn test_list_community_fund_participants() {
+        #[allow(deprecated)] // TODO(NNS1-3198): Remove once hotkey_principal is removed
         let cf_participants = vec![
             CfParticipant {
+                controller: Some(PrincipalId::new_user_test_id(992899)),
                 hotkey_principal: PrincipalId::new_user_test_id(992899).to_string(),
-                cf_neurons: vec![CfNeuron::try_new(1, 698047).unwrap()],
+                cf_neurons: vec![CfNeuron::try_new(
+                    1,
+                    698047,
+                    Vec::new(), // TODO(NNS1-3199): Populate if relevant to this test
+                )
+                .unwrap()],
             },
             CfParticipant {
+                controller: Some(PrincipalId::new_user_test_id(800257)),
                 hotkey_principal: PrincipalId::new_user_test_id(800257).to_string(),
-                cf_neurons: vec![CfNeuron::try_new(2, 678574).unwrap()],
+                cf_neurons: vec![CfNeuron::try_new(
+                    2,
+                    678574,
+                    Vec::new(), // TODO(NNS1-3199): Populate if relevant to this test
+                )
+                .unwrap()],
             },
             CfParticipant {
+                controller: Some(PrincipalId::new_user_test_id(818371)),
                 hotkey_principal: PrincipalId::new_user_test_id(818371).to_string(),
-                cf_neurons: vec![CfNeuron::try_new(3, 305256).unwrap()],
+                cf_neurons: vec![CfNeuron::try_new(
+                    3,
+                    305256,
+                    Vec::new(), // TODO(NNS1-3199): Populate if relevant to this test
+                )
+                .unwrap()],
             },
             CfParticipant {
+                controller: Some(PrincipalId::new_user_test_id(657894)),
                 hotkey_principal: PrincipalId::new_user_test_id(657894).to_string(),
-                cf_neurons: vec![CfNeuron::try_new(4, 339747).unwrap()],
+                cf_neurons: vec![CfNeuron::try_new(
+                    4,
+                    339747,
+                    Vec::new(), // TODO(NNS1-3199): Populate if relevant to this test
+                )
+                .unwrap()],
             },
         ];
         let swap = Swap {
@@ -4805,25 +4848,29 @@ mod tests {
 
     #[test]
     fn test_cf_neuron_count() {
+        #[allow(deprecated)] // TODO(NNS1-3198): Remove once hotkey_principal is removed
         let cf_participants = vec![
             CfParticipant {
+                controller: Some(PrincipalId::new_user_test_id(992899)),
                 hotkey_principal: PrincipalId::new_user_test_id(992899).to_string(),
                 cf_neurons: vec![
-                    CfNeuron::try_new(1, 698047).unwrap(),
-                    CfNeuron::try_new(2, 303030).unwrap(),
+                    CfNeuron::try_new(1, 698047, Vec::new()).unwrap(),
+                    CfNeuron::try_new(2, 303030, Vec::new()).unwrap(),
                 ],
             },
             CfParticipant {
+                controller: Some(PrincipalId::new_user_test_id(800257)),
                 hotkey_principal: PrincipalId::new_user_test_id(800257).to_string(),
-                cf_neurons: vec![CfNeuron::try_new(3, 678574).unwrap()],
+                cf_neurons: vec![CfNeuron::try_new(3, 678574, Vec::new()).unwrap()],
             },
             CfParticipant {
+                controller: Some(PrincipalId::new_user_test_id(818371)),
                 hotkey_principal: PrincipalId::new_user_test_id(818371).to_string(),
                 cf_neurons: vec![
-                    CfNeuron::try_new(4, 305256).unwrap(),
-                    CfNeuron::try_new(5, 100000).unwrap(),
-                    CfNeuron::try_new(6, 1010101).unwrap(),
-                    CfNeuron::try_new(7, 102123).unwrap(),
+                    CfNeuron::try_new(4, 305256, Vec::new()).unwrap(),
+                    CfNeuron::try_new(5, 100000, Vec::new()).unwrap(),
+                    CfNeuron::try_new(6, 1010101, Vec::new()).unwrap(),
+                    CfNeuron::try_new(7, 102123, Vec::new()).unwrap(),
                 ],
             },
         ];

--- a/rs/sns/swap/src/types.rs
+++ b/rs/sns/swap/src/types.rs
@@ -9,7 +9,7 @@ use crate::{
         sns_neuron_recipe::{ClaimedStatus, Investor},
         BuyerState, CfInvestment, CfNeuron, CfParticipant, DirectInvestment,
         ErrorRefundIcpResponse, FinalizeSwapResponse, Init, Lifecycle, NeuronId as SaleNeuronId,
-        OpenRequest, Params, Principals, SetDappControllersCallResult, SetModeCallResult,
+        OpenRequest, Params, SetDappControllersCallResult, SetModeCallResult,
         SettleNeuronsFundParticipationResult, SnsNeuronRecipe, SweepResult, TransferableAmount,
     },
     swap::is_valid_principal,
@@ -18,6 +18,7 @@ use ic_base_types::{CanisterId, PrincipalId};
 use ic_canister_log::log;
 use ic_ledger_core::Tokens;
 use ic_nervous_system_common::{ledger::ICRC1Ledger, ONE_DAY_SECONDS};
+use ic_nervous_system_proto::pb::v1::Principals;
 use ic_sns_governance::pb::v1::{ClaimedSwapNeuronStatus, NeuronId};
 use icrc_ledger_types::icrc1::account::{Account, Subaccount};
 use std::str::FromStr;
@@ -1217,18 +1218,6 @@ impl TryFrom<crate::pb::v1::settle_neurons_fund_participation_response::NeuronsF
                 nns_neuron_id, amount_icp_e8s, is_capped
             )),
         }
-    }
-}
-
-impl From<Vec<PrincipalId>> for Principals {
-    fn from(principals: Vec<PrincipalId>) -> Self {
-        Self { principals }
-    }
-}
-
-impl From<Principals> for Vec<PrincipalId> {
-    fn from(principals: Principals) -> Self {
-        principals.principals
     }
 }
 

--- a/rs/sns/swap/src/types.rs
+++ b/rs/sns/swap/src/types.rs
@@ -708,16 +708,62 @@ impl DirectInvestment {
 
 impl CfInvestment {
     pub fn validate(&self) -> Result<(), String> {
-        if !is_valid_principal(&self.hotkey_principal) {
-            return Err(format!(
-                "Invalid hotkey_principal {}",
-                self.hotkey_principal
-            ));
-        }
+        self.try_get_controller()?;
+
         if self.nns_neuron_id == 0 {
             return Err("Missing nns_neuron_id".to_string());
         }
         Ok(())
+    }
+
+    /// Tries to get the controller, which may be either in the `controller` or `hotkey_principal` field.
+    /// If both fields are set, requires that they refer to the same principal before returning one.
+    pub fn try_get_controller(&self) -> Result<PrincipalId, String> {
+        #[allow(deprecated)] // TODO(NNS1-3198): Remove once hotkey_principal is removed
+        match (
+            self.controller,
+            crate::swap::string_to_principal(&self.hotkey_principal),
+        ) {
+            (Some(p1), Some(p2)) if p1 == p2 => Ok(p1),
+            // If hotkey_principal refers to a different principal than controller,
+            // or if neither is set, something has gone wrong.
+            (Some(_), Some(_)) => {
+                Err("Invalid NF neuron: controller and hotkey_principal do not match".to_string())
+            }
+            // If both fields are none, something has also gone wrong.
+            (None, None) => Err(
+                "Invalid NF neuron: controller is unset and hotkey_principal is invalid"
+                    .to_string(),
+            ),
+            // If only one is set, just use that one
+            (Some(p), None) => Ok(p),
+            (None, Some(p)) => Ok(p),
+        }
+    }
+}
+
+impl CfParticipant {
+    pub fn try_get_controller(&self) -> Result<PrincipalId, String> {
+        #[allow(deprecated)] // TODO(NNS1-3198): Remove once hotkey_principal is removed
+        match (
+            self.controller,
+            crate::swap::string_to_principal(&self.hotkey_principal),
+        ) {
+            (Some(p1), Some(p2)) if p1 == p2 => Ok(p1),
+            // If hotkey_principal refers to a different principal than controller,
+            // or if neither is set, something has gone wrong.
+            (Some(_), Some(_)) => Err(
+                "Invalid NF participant: controller and hotkey_principal do not match".to_string(),
+            ),
+            // If both fields are none, something has also gone wrong.
+            (None, None) => Err(
+                "Invalid NF participant: controller and hotkey_principal are both unset"
+                    .to_string(),
+            ),
+            // If only one is set, just use that one
+            (Some(p), None) => Ok(p),
+            (None, Some(p)) => Ok(p),
+        }
     }
 }
 
@@ -739,16 +785,12 @@ impl SnsNeuronRecipe {
 
 impl CfParticipant {
     pub fn validate(&self) -> Result<(), String> {
-        if !is_valid_principal(&self.hotkey_principal) {
-            return Err(format!(
-                "Invalid hotkey_principal {}",
-                self.hotkey_principal
-            ));
-        }
+        self.try_get_controller()?;
+
         if self.cf_neurons.is_empty() {
             return Err(format!(
-                "A CF participant ({}) must have at least one neuron",
-                self.hotkey_principal
+                "A CF participant ({:?}) must have at least one neuron",
+                self.try_get_controller()?
             ));
         }
         for n in &self.cf_neurons {
@@ -765,11 +807,16 @@ impl CfParticipant {
 }
 
 impl CfNeuron {
-    pub fn try_new(nns_neuron_id: u64, amount_icp_e8s: u64) -> Result<Self, String> {
+    pub fn try_new(
+        nns_neuron_id: u64,
+        amount_icp_e8s: u64,
+        hotkeys: Vec<PrincipalId>,
+    ) -> Result<Self, String> {
         let cf_neuron = Self {
             nns_neuron_id,
             amount_icp_e8s,
             has_created_neuron_recipes: Some(false),
+            hotkeys: Some(Principals::from(hotkeys.clone())),
         };
 
         cf_neuron.validate()?;
@@ -1186,6 +1233,9 @@ impl From<Principals> for Vec<PrincipalId> {
 }
 
 #[cfg(test)]
+// TODO(NNS1-3198): remove #[allow(deprecated)] once hotkey_principal is removed.
+// Unfortunately, this must be applied to the whole module to avoid warnings on the hotkey_principal field in lazy_static.
+#[allow(deprecated)]
 mod tests {
     use super::*;
     use crate::{
@@ -1225,12 +1275,19 @@ mod tests {
         static ref OPEN_REQUEST: OpenRequest = OpenRequest {
             params: Some(PARAMS),
             cf_participants: vec![CfParticipant {
+                controller: Some(PrincipalId::new_user_test_id(423939)),
                 hotkey_principal: PrincipalId::new_user_test_id(423939).to_string(),
-                cf_neurons: vec![CfNeuron::try_new(42 ,99).unwrap()],
-            },],
+                cf_neurons: vec![CfNeuron::try_new(
+                    42,
+                    99,
+                    Vec::new() // TODO(NNS1-3199): populate with some hotkey principals
+                ).unwrap()],
+            }],
             open_sns_token_swap_proposal_id: Some(OPEN_SNS_TOKEN_SWAP_PROPOSAL_ID),
         };
+    }
 
+    lazy_static! {
         // Fill out Init just enough to test Params validation. These values are
         // similar to, but not the same analogous values in NNS.
         static ref INIT: Init = Init {
@@ -1349,10 +1406,11 @@ mod tests {
     #[test]
     fn participant_total_icp_e8s_no_overflow() {
         let participant = CfParticipant {
+            controller: None,
             hotkey_principal: "".to_string(),
             cf_neurons: vec![
-                CfNeuron::try_new(1, u64::MAX).unwrap(),
-                CfNeuron::try_new(2, u64::MAX).unwrap(),
+                CfNeuron::try_new(1, u64::MAX, Vec::new()).unwrap(),
+                CfNeuron::try_new(2, u64::MAX, Vec::new()).unwrap(),
             ],
         };
         let total = participant.participant_total_icp_e8s();

--- a/rs/sns/swap/tests/common/mod.rs
+++ b/rs/sns/swap/tests/common/mod.rs
@@ -240,9 +240,22 @@ pub fn create_generic_sns_neuron_recipes(count: u64) -> Vec<SnsNeuronRecipe> {
 
 pub fn create_generic_cf_participants(count: u64) -> Vec<CfParticipant> {
     (1..count + 1)
-        .map(|i| CfParticipant {
-            hotkey_principal: i2principal_id_string(i),
-            cf_neurons: vec![CfNeuron::try_new(i, E8).unwrap()],
+        .map(|i| {
+            let i = i * 3;
+            #[allow(deprecated)] // TODO(NNS1-3198): remove once hotkey_principal is removed
+            CfParticipant {
+                controller: Some(PrincipalId::new_user_test_id(i)),
+                hotkey_principal: PrincipalId::new_user_test_id(i).to_string(),
+                cf_neurons: vec![CfNeuron::try_new(
+                    i,
+                    E8,
+                    vec![
+                        PrincipalId::new_user_test_id(i + 1),
+                        PrincipalId::new_user_test_id(i + 2),
+                    ],
+                )
+                .unwrap()],
+            }
         })
         .collect()
 }

--- a/rs/sns/swap/tests/swap.rs
+++ b/rs/sns/swap/tests/swap.rs
@@ -874,7 +874,7 @@ fn test_scenario_happy() {
                                                 *neurons_fund_participant_principal_id,
                                             ),
                                             // TODO(NNS1-3199): Populate this field if it is relevant for this test
-                                            hotkeys: Some(vec![].into()),
+                                            hotkeys: Some(Principals::from(Vec::new())),
                                             is_capped: Some(false),
                                             hotkey_principal: Some(
                                                 neurons_fund_participant_principal_id.to_string(),
@@ -1174,7 +1174,7 @@ async fn test_finalize_swap_ok_matched_funding() {
         SpyLedger,
         SpyNnsGovernanceClient,
     > {
-        #[allow(deprecated)] // TODO(NNS1-3198): Remove this once hotkey_principals is removed.
+        #[allow(deprecated)] // TODO(NNS1-3198): Remove this once hotkey_principal is removed.
         CanisterClients {
             sns_governance: SpySnsGovernanceClient::new(vec![
                 SnsGovernanceClientReply::ClaimSwapNeurons(ClaimSwapNeuronsResponse::new(
@@ -1223,7 +1223,7 @@ async fn test_finalize_swap_ok_matched_funding() {
                                     amount_icp_e8s: Some(100 * E8),
                                     controller: Some(PrincipalId::new_user_test_id(1)),
                                     // TODO(NNS1-3199): Populate this field if it is relevant for this test
-                                    hotkeys: Some(vec![].into()),
+                                    hotkeys: Some(Principals::from(Vec::new())),
                                     is_capped: Some(true),
                                     hotkey_principal: Some(
                                         PrincipalId::new_user_test_id(1).to_string(),
@@ -3434,6 +3434,7 @@ async fn test_claim_swap_neuron_correctly_creates_neuron_parameters() {
     // Step 1: Prepare the world
 
     // Create some valid and invalid NeuronRecipes in the state
+    #[allow(deprecated)] // TODO(NNS1-3198): Remove this once hotkey_principal is deprecated
     let mut swap = Swap {
         lifecycle: Committed as i32,
         init: Some(init()),
@@ -3462,6 +3463,8 @@ async fn test_claim_swap_neuron_correctly_creates_neuron_parameters() {
                     followees: vec![NeuronId::new_test_neuron_id(20).into()],
                 }),
                 investor: Some(Investor::CommunityFund(CfInvestment {
+                    controller: Some(*TEST_USER2_PRINCIPAL),
+                    hotkeys: Some(Principals::from(Vec::new())),
                     hotkey_principal: (*TEST_USER2_PRINCIPAL).to_string(),
                     nns_neuron_id: 100,
                 })),
@@ -3930,6 +3933,7 @@ fn test_create_sns_neuron_recipes_skips_already_created_neuron_recipes_for_nf_pa
         .count as u32;
 
     // Create some valid and invalid buyers in the state
+    #[allow(deprecated)] // TODO(NNS1-3198): Remove once hotkey_principal is removed
     let mut swap = Swap {
         lifecycle: Committed as i32,
         init: Some(init()),
@@ -3939,19 +3943,23 @@ fn test_create_sns_neuron_recipes_skips_already_created_neuron_recipes_for_nf_pa
         neurons_fund_participation_icp_e8s: Some(100 * E8),
         cf_participants: vec![
             CfParticipant {
-                hotkey_principal: i2principal_id_string(1001),
+                controller: Some(PrincipalId::new_user_test_id(1001)),
+                hotkey_principal: PrincipalId::new_user_test_id(1001).to_string(),
                 cf_neurons: vec![CfNeuron {
                     nns_neuron_id: 1,
                     amount_icp_e8s: 50 * E8,
                     has_created_neuron_recipes: Some(true),
+                    hotkeys: Some(Principals::from(Vec::new())),
                 }],
             },
             CfParticipant {
-                hotkey_principal: i2principal_id_string(1002),
+                controller: Some(PrincipalId::new_user_test_id(1002)),
+                hotkey_principal: PrincipalId::new_user_test_id(1002).to_string(),
                 cf_neurons: vec![CfNeuron {
                     nns_neuron_id: 2,
                     amount_icp_e8s: 50 * E8,
                     has_created_neuron_recipes: Some(false),
+                    hotkeys: Some(Principals::from(Vec::new())),
                 }],
             },
         ],
@@ -4086,7 +4094,7 @@ async fn test_settle_neurons_fund_participation_returns_successfully_on_subseque
         ..Default::default()
     };
 
-    #[allow(deprecated)] // TODO(NNS1-3198): Remove this once hotkey_principals is removed.
+    #[allow(deprecated)] // TODO(NNS1-3198): Remove this once hotkey_principal is removed.
     let mut spy_nns_governance_client = SpyNnsGovernanceClient::new(vec![
         NnsGovernanceClientReply::SettleNeuronsFundParticipation(
             SettleNeuronsFundParticipationResponse {
@@ -4097,7 +4105,7 @@ async fn test_settle_neurons_fund_participation_returns_successfully_on_subseque
                             amount_icp_e8s: Some(100 * E8),
                             controller: Some(PrincipalId::new_user_test_id(1)),
 
-                            hotkeys: Some(vec![].into()),
+                            hotkeys: Some(Principals::from(Vec::new())),
                             is_capped: Some(true),
                             hotkey_principal: Some(PrincipalId::new_user_test_id(1).to_string()),
                         }],
@@ -4232,7 +4240,7 @@ async fn test_settle_neurons_fund_participation_handles_invalid_governance_respo
         ..Default::default()
     };
 
-    #[allow(deprecated)] // TODO(NNS1-3198): Remove this once hotkey_principals is removed.
+    #[allow(deprecated)] // TODO(NNS1-3198): Remove this once hotkey_principal is removed.
     let mut spy_nns_governance_client = SpyNnsGovernanceClient::new(vec![
         NnsGovernanceClientReply::SettleNeuronsFundParticipation(
             SettleNeuronsFundParticipationResponse {
@@ -4243,7 +4251,7 @@ async fn test_settle_neurons_fund_participation_handles_invalid_governance_respo
                             amount_icp_e8s: Some(0),
                             controller: Some(PrincipalId::new_user_test_id(1)),
                             // TODO(NNS1-3199): Populate this field if it is relevant for this test
-                            hotkeys: Some(vec![].into()),
+                            hotkeys: Some(Principals::from(Vec::new())),
                             is_capped: Some(false),
                             hotkey_principal: Some(PrincipalId::new_user_test_id(1).to_string()),
                         }],

--- a/rs/sns/swap/tests/swap.rs
+++ b/rs/sns/swap/tests/swap.rs
@@ -32,6 +32,7 @@ use ic_nervous_system_common_test_utils::{
     SpyLedger,
 };
 use ic_nervous_system_proto::pb::v1::Countries;
+use ic_nervous_system_proto::pb::v1::Principals;
 use ic_neurons_fund::{
     InvertibleFunction, MatchingFunction, NeuronsFundParticipationLimits,
     PolynomialMatchingFunction, SerializableFunction,


### PR DESCRIPTION
This is just nice to deduplicate the message type, and keeps SNS Swap's and NNS Governance's proto files clean