### PR TITLE
chore: CON-1257 Rename `ecdsa` block payload field and fix comments

### DIFF
--- a/rs/artifact_pool/benches/load_blocks.rs
+++ b/rs/artifact_pool/benches/load_blocks.rs
@@ -68,7 +68,7 @@ fn prepare(pool: &mut ConsensusPoolImpl, num: usize) {
                 dealings: dkg::Dealings::new_empty(
                     parent.payload.as_ref().dkg_interval_start_height(),
                 ),
-                ecdsa: None,
+                idkg: None,
             }),
         );
         let proposal = BlockProposal::fake(block, node_test_id(i as u64));

--- a/rs/artifact_pool/src/idkg_pool.rs
+++ b/rs/artifact_pool/src/idkg_pool.rs
@@ -370,7 +370,7 @@ impl IDkgPoolImpl {
         let mut initial_dealings = Vec::new();
         if block.payload.is_summary() {
             let block_payload = block.payload.as_ref();
-            if let Some(idkg_summary) = &block_payload.as_summary().ecdsa {
+            if let Some(idkg_summary) = &block_payload.as_summary().idkg {
                 initial_dealings = idkg_summary.initial_dkg_dealings().collect();
             }
         }
@@ -528,7 +528,7 @@ mod tests {
         )
     }
 
-    fn create_ecdsa_dealing(transcript_id: IDkgTranscriptId) -> SignedIDkgDealing {
+    fn create_idkg_dealing(transcript_id: IDkgTranscriptId) -> SignedIDkgDealing {
         let mut idkg_dealing = dummy_idkg_dealing_for_tests();
         idkg_dealing.transcript_id = transcript_id;
         SignedIDkgDealing {
@@ -740,21 +740,19 @@ mod tests {
         let mut object_pool = IDkgObjectPool::new(IDkgMessageType::Dealing, metrics);
 
         let key_1 = {
-            let ecdsa_dealing = IDkgMessage::Dealing(create_ecdsa_dealing(
-                dummy_idkg_transcript_id_for_tests(100),
-            ));
-            let key = IDkgArtifactId::from(&ecdsa_dealing);
+            let dealing =
+                IDkgMessage::Dealing(create_idkg_dealing(dummy_idkg_transcript_id_for_tests(100)));
+            let key = IDkgArtifactId::from(&dealing);
             assert!(object_pool.get_object(&key).is_none());
-            object_pool.insert_object(ecdsa_dealing);
+            object_pool.insert_object(dealing);
             key
         };
         let key_2 = {
-            let ecdsa_dealing = IDkgMessage::Dealing(create_ecdsa_dealing(
-                dummy_idkg_transcript_id_for_tests(200),
-            ));
-            let key = IDkgArtifactId::from(&ecdsa_dealing);
+            let dealing =
+                IDkgMessage::Dealing(create_idkg_dealing(dummy_idkg_transcript_id_for_tests(200)));
+            let key = IDkgArtifactId::from(&dealing);
             assert!(object_pool.get_object(&key).is_none());
-            object_pool.insert_object(ecdsa_dealing);
+            object_pool.insert_object(dealing);
             key
         };
         assert!(object_pool.get_object(&key_1).is_some());
@@ -798,10 +796,9 @@ mod tests {
         let metrics = IDkgPoolMetrics::new(metrics_registry, POOL_IDKG, POOL_TYPE_VALIDATED);
         let mut object_pool = IDkgObjectPool::new(IDkgMessageType::DealingSupport, metrics);
 
-        let ecdsa_dealing = IDkgMessage::Dealing(create_ecdsa_dealing(
-            dummy_idkg_transcript_id_for_tests(100),
-        ));
-        object_pool.insert_object(ecdsa_dealing);
+        let dealing =
+            IDkgMessage::Dealing(create_idkg_dealing(dummy_idkg_transcript_id_for_tests(100)));
+        object_pool.insert_object(dealing);
     }
 
     #[test]
@@ -811,22 +808,20 @@ mod tests {
                 let mut idkg_pool = create_idkg_pool(pool_config, logger);
 
                 let msg_id_1 = {
-                    let ecdsa_dealing =
-                        create_ecdsa_dealing(dummy_idkg_transcript_id_for_tests(100));
-                    let msg_id = ecdsa_dealing.message_id();
+                    let dealing = create_idkg_dealing(dummy_idkg_transcript_id_for_tests(100));
+                    let msg_id = dealing.message_id();
                     idkg_pool.insert(UnvalidatedArtifact {
-                        message: IDkgMessage::Dealing(ecdsa_dealing),
+                        message: IDkgMessage::Dealing(dealing),
                         peer_id: NODE_1,
                         timestamp: UNIX_EPOCH,
                     });
                     msg_id
                 };
                 let msg_id_2 = {
-                    let ecdsa_dealing =
-                        create_ecdsa_dealing(dummy_idkg_transcript_id_for_tests(200));
-                    let msg_id = ecdsa_dealing.message_id();
+                    let dealing = create_idkg_dealing(dummy_idkg_transcript_id_for_tests(200));
+                    let msg_id = dealing.message_id();
                     idkg_pool.insert(UnvalidatedArtifact {
-                        message: IDkgMessage::Dealing(ecdsa_dealing),
+                        message: IDkgMessage::Dealing(dealing),
                         peer_id: NODE_1,
                         timestamp: UNIX_EPOCH,
                     });
@@ -848,21 +843,19 @@ mod tests {
                 let mut idkg_pool = create_idkg_pool(pool_config, logger);
 
                 let msg_id_1 = {
-                    let ecdsa_dealing =
-                        create_ecdsa_dealing(dummy_idkg_transcript_id_for_tests(100));
-                    let msg_id = ecdsa_dealing.message_id();
+                    let dealing = create_idkg_dealing(dummy_idkg_transcript_id_for_tests(100));
+                    let msg_id = dealing.message_id();
                     let change_set = vec![IDkgChangeAction::AddToValidated(IDkgMessage::Dealing(
-                        ecdsa_dealing,
+                        dealing,
                     ))];
                     idkg_pool.apply_changes(change_set);
                     msg_id
                 };
                 let msg_id_2 = {
-                    let ecdsa_dealing =
-                        create_ecdsa_dealing(dummy_idkg_transcript_id_for_tests(200));
-                    let msg_id = ecdsa_dealing.message_id();
+                    let dealing = create_idkg_dealing(dummy_idkg_transcript_id_for_tests(200));
+                    let msg_id = dealing.message_id();
                     idkg_pool.insert(UnvalidatedArtifact {
-                        message: IDkgMessage::Dealing(ecdsa_dealing),
+                        message: IDkgMessage::Dealing(dealing),
                         peer_id: NODE_1,
                         timestamp: UNIX_EPOCH,
                     });
@@ -881,20 +874,18 @@ mod tests {
                 let mut idkg_pool = create_idkg_pool(pool_config, logger);
 
                 let msg_id_1 = {
-                    let ecdsa_dealing =
-                        create_ecdsa_dealing(dummy_idkg_transcript_id_for_tests(100));
-                    let msg_id = ecdsa_dealing.message_id();
+                    let dealing = create_idkg_dealing(dummy_idkg_transcript_id_for_tests(100));
+                    let msg_id = dealing.message_id();
                     let change_set = vec![IDkgChangeAction::AddToValidated(IDkgMessage::Dealing(
-                        ecdsa_dealing,
+                        dealing,
                     ))];
                     idkg_pool.apply_changes(change_set);
                     msg_id
                 };
                 let (msg_id_2, msg_2) = {
-                    let ecdsa_dealing =
-                        create_ecdsa_dealing(dummy_idkg_transcript_id_for_tests(200));
-                    let msg_id = ecdsa_dealing.message_id();
-                    let msg = IDkgMessage::Dealing(ecdsa_dealing);
+                    let dealing = create_idkg_dealing(dummy_idkg_transcript_id_for_tests(200));
+                    let msg_id = dealing.message_id();
+                    let msg = IDkgMessage::Dealing(dealing);
                     idkg_pool.insert(UnvalidatedArtifact {
                         message: msg.clone(),
                         peer_id: NODE_1,
@@ -938,31 +929,28 @@ mod tests {
             with_test_replica_logger(|logger| {
                 let mut idkg_pool = create_idkg_pool(pool_config, logger);
                 let msg_id_1 = {
-                    let ecdsa_dealing =
-                        create_ecdsa_dealing(dummy_idkg_transcript_id_for_tests(100));
-                    let msg_id = ecdsa_dealing.message_id();
+                    let dealing = create_idkg_dealing(dummy_idkg_transcript_id_for_tests(100));
+                    let msg_id = dealing.message_id();
                     let change_set = vec![IDkgChangeAction::AddToValidated(IDkgMessage::Dealing(
-                        ecdsa_dealing,
+                        dealing,
                     ))];
                     idkg_pool.apply_changes(change_set);
                     msg_id
                 };
                 let msg_id_2 = {
-                    let ecdsa_dealing =
-                        create_ecdsa_dealing(dummy_idkg_transcript_id_for_tests(200));
-                    let msg_id = ecdsa_dealing.message_id();
+                    let dealing = create_idkg_dealing(dummy_idkg_transcript_id_for_tests(200));
+                    let msg_id = dealing.message_id();
                     let change_set = vec![IDkgChangeAction::AddToValidated(IDkgMessage::Dealing(
-                        ecdsa_dealing,
+                        dealing,
                     ))];
                     idkg_pool.apply_changes(change_set);
                     msg_id
                 };
                 let msg_id_3 = {
-                    let ecdsa_dealing =
-                        create_ecdsa_dealing(dummy_idkg_transcript_id_for_tests(300));
-                    let msg_id = ecdsa_dealing.message_id();
+                    let dealing = create_idkg_dealing(dummy_idkg_transcript_id_for_tests(300));
+                    let msg_id = dealing.message_id();
                     idkg_pool.insert(UnvalidatedArtifact {
-                        message: IDkgMessage::Dealing(ecdsa_dealing),
+                        message: IDkgMessage::Dealing(dealing),
                         peer_id: NODE_1,
                         timestamp: UNIX_EPOCH,
                     });
@@ -1000,11 +988,10 @@ mod tests {
             with_test_replica_logger(|logger| {
                 let mut idkg_pool = create_idkg_pool(pool_config, logger);
                 let msg_id = {
-                    let ecdsa_dealing =
-                        create_ecdsa_dealing(dummy_idkg_transcript_id_for_tests(200));
-                    let msg_id = ecdsa_dealing.message_id();
+                    let dealing = create_idkg_dealing(dummy_idkg_transcript_id_for_tests(200));
+                    let msg_id = dealing.message_id();
                     idkg_pool.insert(UnvalidatedArtifact {
-                        message: IDkgMessage::Dealing(ecdsa_dealing),
+                        message: IDkgMessage::Dealing(dealing),
                         peer_id: NODE_1,
                         timestamp: UNIX_EPOCH,
                     });
@@ -1028,11 +1015,10 @@ mod tests {
             with_test_replica_logger(|logger| {
                 let mut idkg_pool = create_idkg_pool(pool_config, logger);
                 let msg_id = {
-                    let ecdsa_dealing =
-                        create_ecdsa_dealing(dummy_idkg_transcript_id_for_tests(200));
-                    let msg_id = ecdsa_dealing.message_id();
+                    let dealing = create_idkg_dealing(dummy_idkg_transcript_id_for_tests(200));
+                    let msg_id = dealing.message_id();
                     idkg_pool.insert(UnvalidatedArtifact {
-                        message: IDkgMessage::Dealing(ecdsa_dealing),
+                        message: IDkgMessage::Dealing(dealing),
                         peer_id: NODE_1,
                         timestamp: UNIX_EPOCH,
                     });
@@ -1056,11 +1042,10 @@ mod tests {
                 let mut idkg_pool = create_idkg_pool(pool_config, logger);
 
                 let msg_id = {
-                    let ecdsa_dealing =
-                        create_ecdsa_dealing(dummy_idkg_transcript_id_for_tests(100));
-                    let msg_id = ecdsa_dealing.message_id();
+                    let dealing = create_idkg_dealing(dummy_idkg_transcript_id_for_tests(100));
+                    let msg_id = dealing.message_id();
                     let change_set = vec![IDkgChangeAction::AddToValidated(IDkgMessage::Dealing(
-                        ecdsa_dealing,
+                        dealing,
                     ))];
                     idkg_pool.apply_changes(change_set);
                     msg_id

--- a/rs/artifact_pool/src/lmdb_pool.rs
+++ b/rs/artifact_pool/src/lmdb_pool.rs
@@ -1033,12 +1033,12 @@ impl PoolArtifact for ConsensusMessage {
                 Box::new(move || match payload_type {
                     PayloadType::Summary => BlockPayload::Summary(SummaryPayload {
                         dkg: dkg::Summary::default(),
-                        ecdsa: None,
+                        idkg: None,
                     }),
                     PayloadType::Data => BlockPayload::Data(DataPayload {
                         batch: BatchPayload::default(),
                         dealings: dkg::Dealings::new_empty(start_height),
-                        ecdsa: None,
+                        idkg: None,
                     }),
                 }),
             );

--- a/rs/artifact_pool/src/rocksdb_pool.rs
+++ b/rs/artifact_pool/src/rocksdb_pool.rs
@@ -432,7 +432,7 @@ impl MutablePoolSection<ValidatedConsensusArtifact>
                                     BlockPayload::Data(DataPayload {
                                         batch: BatchPayload::default(),
                                         dealings: Dealings::new_empty(start_height),
-                                        ecdsa: None,
+                                        idkg: None,
                                     })
                                 }),
                             );

--- a/rs/config/src/config_sample.rs
+++ b/rs/config/src/config_sample.rs
@@ -289,7 +289,7 @@ pub const SAMPLE_CONFIG: &str = r#"
          maliciously_disable_execution: false,
          maliciously_corrupt_own_state_at_heights: [],
          maliciously_disable_ingress_validation: false,
-         maliciously_corrupt_ecdsa_dealings: false,
+         maliciously_corrupt_idkg_dealings: false,
          maliciously_alter_certified_hash: false,
          maliciously_alter_state_sync_chunk_sending_side: false,
        },

--- a/rs/consensus/benches/validate_payload.rs
+++ b/rs/consensus/benches/validate_payload.rs
@@ -279,7 +279,7 @@ fn add_past_blocks(
                 dealings: dkg::Dealings::new_empty(
                     block.payload.as_ref().dkg_interval_start_height(),
                 ),
-                ecdsa: None,
+                idkg: None,
             }),
         );
 
@@ -356,7 +356,7 @@ fn validate_payload_benchmark(criterion: &mut Criterion) {
                         dealings: dkg::Dealings::new_empty(
                             tip.payload.as_ref().dkg_interval_start_height(),
                         ),
-                        ecdsa: None,
+                        idkg: None,
                     }),
                 );
 

--- a/rs/consensus/src/consensus/batch_delivery.rs
+++ b/rs/consensus/src/consensus/batch_delivery.rs
@@ -259,7 +259,7 @@ pub fn deliver_batches(
 /// This function creates responses to the system calls that are redirected to
 /// consensus. There are two types of calls being handled here:
 /// - Initial NiDKG transcript creation, where a response may come from summary payloads.
-/// - Threshold ECDSA signature creation, where a response may come from from data payloads.
+/// - Canister threshold signature creation, where a response may come from from data payloads.
 /// - CanisterHttpResponse handling, where a response to a canister http request may come from data payloads.
 pub fn generate_responses_to_subnet_calls(
     block: &Block,
@@ -281,8 +281,10 @@ pub fn generate_responses_to_subnet_calls(
         ))
     } else {
         let block_payload = block_payload.as_ref().as_data();
-        if let Some(payload) = &block_payload.ecdsa {
-            consensus_responses.append(&mut generate_responses_to_sign_with_ecdsa_calls(payload));
+        if let Some(payload) = &block_payload.idkg {
+            consensus_responses.append(&mut generate_responses_to_signature_request_contexts(
+                payload,
+            ));
             consensus_responses.append(&mut generate_responses_to_initial_dealings_calls(payload));
         }
 
@@ -431,9 +433,9 @@ fn generate_dkg_response_payload(
     }
 }
 
-/// Creates responses to `SignWithECDSA` system calls with the computed
+/// Creates responses to `SignWithECDSA` and `SignWithSchnorr` system calls with the computed
 /// signature.
-pub fn generate_responses_to_sign_with_ecdsa_calls(
+pub fn generate_responses_to_signature_request_contexts(
     idkg_payload: &idkg::IDkgPayload,
 ) -> Vec<ConsensusResponse> {
     let mut consensus_responses = Vec::new();

--- a/rs/consensus/src/consensus/block_maker.rs
+++ b/rs/consensus/src/consensus/block_maker.rs
@@ -336,11 +336,11 @@ impl BlockMaker {
 
                     BlockPayload::Summary(SummaryPayload {
                         dkg: summary,
-                        ecdsa: idkg_summary,
+                        idkg: idkg_summary,
                     })
                 }
                 dkg::Payload::Dealings(dealings) => {
-                    let (batch_payload, dealings, ecdsa_data) = match status::get_status(
+                    let (batch_payload, dealings, idkg_data) = match status::get_status(
                         height,
                         self.registry_client.as_ref(),
                         self.replica_config.subnet_id,
@@ -355,7 +355,7 @@ impl BlockMaker {
                         Status::Halting => (
                             BatchPayload::default(),
                             dkg::Dealings::new_empty(dealings.start_height),
-                            /*ecdsa_data=*/ None,
+                            /*idkg_data=*/ None,
                         ),
                         Status::Running => {
                             let batch_payload = self.build_batch_payload(
@@ -367,7 +367,7 @@ impl BlockMaker {
                                 subnet_records,
                             );
 
-                            let ecdsa_data = idkg::create_data_payload(
+                            let idkg_data = idkg::create_data_payload(
                                 self.replica_config.subnet_id,
                                 &*self.registry_client,
                                 &*self.crypto,
@@ -385,7 +385,7 @@ impl BlockMaker {
                             .ok()
                             .flatten();
 
-                            (batch_payload, dealings, ecdsa_data)
+                            (batch_payload, dealings, idkg_data)
                         }
                     };
 
@@ -397,7 +397,7 @@ impl BlockMaker {
                     BlockPayload::Data(DataPayload {
                         batch: batch_payload,
                         dealings,
-                        ecdsa: ecdsa_data,
+                        idkg: idkg_data,
                     })
                 }
             },

--- a/rs/consensus/src/consensus/catchup_package_maker.rs
+++ b/rs/consensus/src/consensus/catchup_package_maker.rs
@@ -15,7 +15,7 @@
 
 use ic_consensus_utils::{
     active_high_threshold_transcript, crypto::ConsensusCrypto,
-    get_oldest_ecdsa_state_registry_version, membership::Membership, pool_reader::PoolReader,
+    get_oldest_idkg_state_registry_version, membership::Membership, pool_reader::PoolReader,
 };
 use ic_interfaces::messaging::MessageRouting;
 use ic_interfaces_state_manager::{
@@ -209,7 +209,7 @@ impl CatchUpPackageMaker {
             }
             Ok(state_hash) => {
                 let summary = start_block.payload.as_ref().as_summary();
-                let registry_version = if let Some(ecdsa) = summary.ecdsa.as_ref() {
+                let registry_version = if let Some(idkg) = summary.idkg.as_ref() {
                     // Should succeed as we already got the hash above
                     let state = self
                         .state_manager
@@ -217,14 +217,14 @@ impl CatchUpPackageMaker {
                         .map_err(|err| {
                             error!(
                                 self.log,
-                                "Cannot make ECDSA CUP at height {}: `get_state_hash_at` \
+                                "Cannot make IDKG CUP at height {}: `get_state_hash_at` \
                                 succeeded but `get_state_at` failed with {}. Will retry",
                                 height,
                                 err,
                             )
                         })
                         .ok()?;
-                    get_oldest_ecdsa_state_registry_version(ecdsa, state.get_ref())
+                    get_oldest_idkg_state_registry_version(idkg, state.get_ref())
                 } else {
                     None
                 };
@@ -439,18 +439,18 @@ mod tests {
             let block = proposal.content.as_mut();
             block.context.certified_height = block.height();
 
-            let mut ecdsa = empty_idkg_payload(subnet_test_id(0));
+            let mut idkg = empty_idkg_payload(subnet_test_id(0));
             // Add the three quadruples using registry version 3, 1 and 2 in order
-            add_available_quadruple_to_payload(&mut ecdsa, pre_sig_id1, RegistryVersion::from(3));
-            add_available_quadruple_to_payload(&mut ecdsa, pre_sig_id2, RegistryVersion::from(1));
-            add_available_quadruple_to_payload(&mut ecdsa, pre_sig_id3, RegistryVersion::from(2));
+            add_available_quadruple_to_payload(&mut idkg, pre_sig_id1, RegistryVersion::from(3));
+            add_available_quadruple_to_payload(&mut idkg, pre_sig_id2, RegistryVersion::from(1));
+            add_available_quadruple_to_payload(&mut idkg, pre_sig_id3, RegistryVersion::from(2));
 
             let dkg = block.payload.as_ref().as_summary().dkg.clone();
             block.payload = Payload::new(
                 ic_types::crypto::crypto_hash,
                 BlockPayload::Summary(SummaryPayload {
                     dkg,
-                    ecdsa: Some(ecdsa),
+                    idkg: Some(idkg),
                 }),
             );
             proposal.content = HashedBlock::new(ic_types::crypto::crypto_hash, block.clone());

--- a/rs/consensus/src/consensus/metrics.rs
+++ b/rs/consensus/src/consensus/metrics.rs
@@ -124,7 +124,7 @@ impl From<&Block> for BlockStats {
             block_hash: get_block_hash_string(block),
             block_height: block.height().get(),
             block_context_certified_height: block.context.certified_height.get(),
-            idkg_stats: block.payload.as_ref().as_ecdsa().map(IDkgStats::from),
+            idkg_stats: block.payload.as_ref().as_idkg().map(IDkgStats::from),
         }
     }
 }

--- a/rs/consensus/src/consensus/proptests.rs
+++ b/rs/consensus/src/consensus/proptests.rs
@@ -145,7 +145,7 @@ fn wrap_batch_payload(height: u64, payload: BatchPayload) -> Payload {
         BlockPayload::Data(DataPayload {
             batch: payload,
             dealings: Dealings::new_empty(Height::from(height)),
-            ecdsa: None,
+            idkg: None,
         }),
     )
 }

--- a/rs/consensus/src/dkg.rs
+++ b/rs/consensus/src/dkg.rs
@@ -469,7 +469,7 @@ pub fn make_registry_cup_from_cup_contents(
         Err(err) => {
             warn!(
                 logger,
-                "Failed constructing ECDSA summary block from CUP contents: {}", err
+                "Failed constructing IDKG summary block from CUP contents: {}", err
             );
 
             None
@@ -498,7 +498,7 @@ pub fn make_registry_cup_from_cup_contents(
             crypto_hash,
             BlockPayload::Summary(SummaryPayload {
                 dkg: dkg_summary,
-                ecdsa: idkg_summary,
+                idkg: idkg_summary,
             }),
         ),
         height: cup_height,
@@ -554,7 +554,7 @@ fn bootstrap_idkg_summary_from_cup_contents(
         initial_dealings,
         logger,
     )
-    .map_err(|err| format!("Failed to create ECDSA summary block: {:?}", err))
+    .map_err(|err| format!("Failed to create IDKG summary block: {:?}", err))
 }
 
 fn bootstrap_idkg_summary(

--- a/rs/consensus/src/dkg/payload_validator.rs
+++ b/rs/consensus/src/dkg/payload_validator.rs
@@ -413,7 +413,7 @@ mod tests {
                 BlockPayload::Data(DataPayload {
                     batch: BatchPayload::default(),
                     dealings: dkg::Dealings::new(Height::from(0), messages.clone()),
-                    ecdsa: idkg::Payload::default(),
+                    idkg: idkg::Payload::default(),
                 }),
             );
             let mut parent = Block::from(pool.make_next_block());

--- a/rs/consensus/src/idkg.rs
+++ b/rs/consensus/src/idkg.rs
@@ -235,7 +235,7 @@ const LOOK_AHEAD: u64 = 10;
 pub(crate) const INACTIVE_TRANSCRIPT_PURGE_SECS: Duration = Duration::from_secs(60);
 
 /// `IDkgImpl` is the consensus component responsible for processing threshold
-/// ECDSA payloads.
+/// IDKG payloads.
 pub struct IDkgImpl {
     /// The Pre-Signer subcomponent
     pub pre_signer: Box<IDkgPreSignerImpl>,
@@ -252,7 +252,7 @@ pub struct IDkgImpl {
 }
 
 impl IDkgImpl {
-    /// Builds a new threshold ECDSA component
+    /// Builds a new IDKG component
     pub fn new(
         node_id: NodeId,
         consensus_block_cache: Arc<dyn ConsensusBlockCache>,
@@ -384,7 +384,7 @@ impl<T: IDkgPool> ChangeSetProducer<T> for IDkgImpl {
                 &metrics.on_state_change_duration,
             );
             #[cfg(any(feature = "malicious_code", test))]
-            if self.malicious_flags.is_ecdsa_malicious() {
+            if self.malicious_flags.is_idkg_malicious() {
                 return super::idkg::malicious_pre_signer::maliciously_alter_changeset(
                     changeset,
                     &self.pre_signer,

--- a/rs/consensus/src/idkg/malicious_pre_signer.rs
+++ b/rs/consensus/src/idkg/malicious_pre_signer.rs
@@ -56,7 +56,7 @@ pub fn maliciously_alter_changeset(
         .into_iter()
         .flat_map(|action| match action {
             IDkgChangeAction::AddToValidated(IDkgMessage::Dealing(dealing))
-                if malicious_flags.maliciously_corrupt_ecdsa_dealings =>
+                if malicious_flags.maliciously_corrupt_idkg_dealings =>
             {
                 let transcript_id = dealing.idkg_dealing().transcript_id;
                 block_reader
@@ -66,7 +66,7 @@ pub fn maliciously_alter_changeset(
                         pre_signer.resolve_ref(params_ref, &block_reader, "malicious_send_dealing")
                     })
                     .map(|params| {
-                        let dealing = maliciously_corrupt_ecdsa_dealings(
+                        let dealing = maliciously_corrupt_idkg_dealings(
                             pre_signer,
                             pre_signer.node_id,
                             dealing,
@@ -83,7 +83,7 @@ pub fn maliciously_alter_changeset(
 }
 
 /// Helper to corrupt the signed crypto dealing for malicious testing
-fn maliciously_corrupt_ecdsa_dealings(
+fn maliciously_corrupt_idkg_dealings(
     pre_signer: &IDkgPreSignerImpl,
     node_id: NodeId,
     idkg_dealing: SignedIDkgDealing,

--- a/rs/consensus/src/idkg/payload_builder.rs
+++ b/rs/consensus/src/idkg/payload_builder.rs
@@ -1,4 +1,4 @@
-//! This module implements the ECDSA payload builder.
+//! This module implements the IDKG payload builder.
 #![allow(clippy::too_many_arguments)]
 #![allow(clippy::enum_variant_names)]
 #![allow(clippy::result_large_err)]
@@ -42,7 +42,7 @@ mod pre_signatures;
 pub(super) mod resharing;
 pub(super) mod signatures;
 
-/// Builds the very first ecdsa summary block. This would trigger the subsequent
+/// Builds the very first idkg summary block. This would trigger the subsequent
 /// data blocks to create the initial key transcript.
 pub(crate) fn make_bootstrap_summary(
     subnet_id: SubnetId,
@@ -57,7 +57,7 @@ pub(crate) fn make_bootstrap_summary(
     Some(IDkgPayload::empty(height, subnet_id, key_transcripts))
 }
 
-/// Builds the very first ecdsa summary block. This would trigger the subsequent
+/// Builds the very first idkg summary block. This would trigger the subsequent
 /// data blocks to create the initial key transcript.
 pub(crate) fn make_bootstrap_summary_with_initial_dealings(
     subnet_id: SubnetId,
@@ -85,7 +85,7 @@ pub(crate) fn make_bootstrap_summary_with_initial_dealings(
                 // Leave the feature disabled if the initial dealings are incorrect.
                 warn!(
                     log,
-                    "make_ecdsa_genesis_summary(): failed to unpack initial dealings"
+                    "make_idkg_genesis_summary(): failed to unpack initial dealings"
                 );
 
                 return Err(IDkgPayloadError::InitialIDkgDealingsNotUnmaskedParams(
@@ -97,7 +97,7 @@ pub(crate) fn make_bootstrap_summary_with_initial_dealings(
 
     info!(
         log,
-        "make_ecdsa_genesis_summary(): height = {}, key_transcript = [{:?}]",
+        "make_idkg_genesis_summary(): height = {}, key_transcript = [{:?}]",
         height,
         key_transcripts
     );
@@ -108,7 +108,7 @@ pub(crate) fn make_bootstrap_summary_with_initial_dealings(
     Ok(Some(payload))
 }
 
-/// Creates a threshold ECDSA summary payload.
+/// Creates an IDKG summary payload.
 pub(crate) fn create_summary_payload(
     subnet_id: SubnetId,
     registry_client: &dyn RegistryClient,
@@ -131,7 +131,7 @@ pub(crate) fn create_summary_payload(
     // For next interval: context.registry_version from the new summary block
     let next_interval_registry_version = context.registry_version;
 
-    // Get ecdsa_config from registry if it exists
+    // Get chain_key_config from registry if it exists
     let Some(chain_key_config) = get_chain_key_config_if_enabled(
         subnet_id,
         curr_interval_registry_version,
@@ -148,15 +148,15 @@ pub(crate) fn create_summary_payload(
         .collect();
 
     // Get idkg_payload from parent block if it exists
-    let Some(idkg_payload) = parent_block.payload.as_ref().as_data().ecdsa.as_ref() else {
-        // Parent block doesn't have ECDSA payload and feature is enabled.
-        // Create the bootstrap summary block, and create a new key for the given key_id.
+    let Some(idkg_payload) = parent_block.payload.as_ref().as_data().idkg.as_ref() else {
+        // Parent block doesn't have IDKG payload and feature is enabled.
+        // Create the bootstrap summary block, and create new keys for the given key_ids.
         //
         // This is safe because registry's do_update_subnet already ensures that only
         // fresh key_id can be assigned to an existing subnet.
         //
-        // Keys already held by existing subnets can only be re-shared when creating
-        // a new subnet, which means the genesis summary ECDSA payload is not empty
+        // Keys already held by existing subnets can only be re-shared when creating or
+        // recovering a subnet, which means the genesis summary IDKG payload is not empty
         // and we won't reach here.
         info!(
             log,
@@ -395,7 +395,7 @@ fn is_time_to_reshare_key_transcript(
     Ok(false)
 }
 
-/// Creates a threshold ECDSA batch payload.
+/// Creates an IDKG batch payload.
 pub(crate) fn create_data_payload(
     subnet_id: SubnetId,
     registry_client: &dyn RegistryClient,
@@ -408,8 +408,8 @@ pub(crate) fn create_data_payload(
     idkg_payload_metrics: &IDkgPayloadMetrics,
     log: &ReplicaLogger,
 ) -> Result<idkg::Payload, IDkgPayloadError> {
-    // Return None if parent block does not have ECDSA payload.
-    if parent_block.payload.as_ref().as_ecdsa().is_none() {
+    // Return None if parent block does not have IDKG payload.
+    if parent_block.payload.as_ref().as_idkg().is_none() {
         return Ok(None);
     };
     let summary_block = pool_reader
@@ -470,7 +470,7 @@ pub(crate) fn create_data_payload(
                 && !parent_block
                     .payload
                     .as_ref()
-                    .as_ecdsa()
+                    .as_idkg()
                     .and_then(|idkg_payload| idkg_payload.key_transcripts.get(key_id))
                     .is_some_and(is_key_transcript_created)
             {
@@ -527,7 +527,7 @@ pub(crate) fn create_data_payload_helper(
         .map(|key_config| key_config.key_id.clone())
         .collect();
 
-    let mut idkg_payload = if let Some(prev_payload) = parent_block.payload.as_ref().as_ecdsa() {
+    let mut idkg_payload = if let Some(prev_payload) = parent_block.payload.as_ref().as_idkg() {
         prev_payload.clone()
     } else {
         return Ok(None);
@@ -676,7 +676,7 @@ pub(crate) fn create_data_payload_helper_2(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::consensus::batch_delivery::generate_responses_to_sign_with_ecdsa_calls;
+    use crate::consensus::batch_delivery::generate_responses_to_signature_request_contexts;
     use crate::idkg::test_utils::*;
     use crate::idkg::utils::algorithm_for_key_id;
     use crate::idkg::utils::block_chain_reader;
@@ -758,7 +758,7 @@ mod tests {
                 height,
                 BTreeMap::new(),
             ),
-            ecdsa: Some(idkg_summary),
+            idkg: Some(idkg_summary),
         })
     }
 
@@ -779,7 +779,7 @@ mod tests {
         BlockPayload::Data(DataPayload {
             batch: BatchPayload::default(),
             dealings: Dealings::new_empty(dkg_interval_start_height),
-            ecdsa: Some(idkg_payload),
+            idkg: Some(idkg_payload),
         })
     }
 
@@ -1088,7 +1088,7 @@ mod tests {
             },
         );
 
-        // create first ecdsa payload
+        // create first payload
         create_data_payload_helper_2(
             &mut idkg_payload,
             Height::from(5),
@@ -1109,10 +1109,10 @@ mod tests {
         .unwrap();
 
         // Assert that we got a response
-        let response1 = generate_responses_to_sign_with_ecdsa_calls(&idkg_payload);
+        let response1 = generate_responses_to_signature_request_contexts(&idkg_payload);
         assert_eq!(response1.len(), 1);
 
-        // create next ecdsa payload
+        // create next payload
         create_data_payload_helper_2(
             &mut idkg_payload,
             Height::from(5),
@@ -1133,7 +1133,7 @@ mod tests {
         .unwrap();
 
         // assert that same signature isn't delivered again.
-        let response2 = generate_responses_to_sign_with_ecdsa_calls(&idkg_payload);
+        let response2 = generate_responses_to_signature_request_contexts(&idkg_payload);
         assert!(response2.is_empty());
     }
 
@@ -1287,7 +1287,7 @@ mod tests {
             let parent_block_payload = BlockPayload::Data(DataPayload {
                 batch: BatchPayload::default(),
                 dealings: Dealings::new_empty(summary_height),
-                ecdsa: Some(data_payload),
+                idkg: Some(data_payload),
             });
             let parent_block = add_block(
                 parent_block_payload,
@@ -1552,7 +1552,7 @@ mod tests {
             let parent_block_payload = BlockPayload::Data(DataPayload {
                 batch: BatchPayload::default(),
                 dealings: Dealings::new_empty(summary_height),
-                ecdsa: Some(data_payload),
+                idkg: Some(data_payload),
             });
             let parent_block = add_block(
                 parent_block_payload,
@@ -1626,7 +1626,7 @@ mod tests {
 
             let pl = BlockPayload::Summary(SummaryPayload {
                 dkg: Summary::fake(),
-                ecdsa: Some(summary.clone()),
+                idkg: Some(summary.clone()),
             });
             let b = Block::new(
                 CryptoHashOf::from(CryptoHash(Vec::new())),

--- a/rs/consensus/src/idkg/payload_builder/key_transcript.rs
+++ b/rs/consensus/src/idkg/payload_builder/key_transcript.rs
@@ -28,7 +28,7 @@ pub(super) fn get_created_key_transcript(
     }
 }
 
-/// Update configuration and data about the next ECDSA key transcript.
+/// Update configuration and data about the next master key transcript.
 /// Returns the newly created transcript, if any.
 ///
 /// Note that when creating next key transcript we must use the registry version

--- a/rs/consensus/src/idkg/payload_builder/pre_signatures.rs
+++ b/rs/consensus/src/idkg/payload_builder/pre_signatures.rs
@@ -23,7 +23,7 @@ use std::collections::{BTreeMap, BTreeSet};
 
 /// Update the pre-signatures in the payload by:
 /// - making new configs when pre-conditions are met;
-/// - gathering ready results (new transcripts) from ecdsa pool;
+/// - gathering ready results (new transcripts) from idkg pool;
 /// - moving completed pre-signatures from "in creation" to "available".
 /// Returns the newly created transcripts.
 pub(super) fn update_pre_signatures_in_creation(
@@ -43,7 +43,7 @@ pub(super) fn update_pre_signatures_in_creation(
             error!(
                 every_n_seconds => 30,
                 log,
-                "The ECDSA payload is missing a key transcript with key_id: {}",
+                "The IDKG payload is missing a key transcript with key_id: {}",
                 pre_signature.key_id());
 
             continue;
@@ -307,7 +307,7 @@ pub(super) fn purge_old_key_pre_signatures(
 
 /// Creating new pre-signatures if necessary by updating pre_signatures_in_creation,
 /// considering currently available pre-signatures, pre-signatures in creation, and
-/// ecdsa configs.
+/// chain key configs.
 pub(super) fn make_new_pre_signatures_if_needed(
     chain_key_config: &ChainKeyConfig,
     idkg_payload: &mut idkg::IDkgPayload,

--- a/rs/consensus/src/idkg/payload_builder/signatures.rs
+++ b/rs/consensus/src/idkg/payload_builder/signatures.rs
@@ -33,7 +33,7 @@ fn reject_response(
 ///   in the previous round, the context will be removed when the previous block is
 ///   finalized)
 /// - rejecting signature contexts that are expired or request an invalid key.
-/// - adding new agreements as "Unreported" by combining shares in the ECDSA pool.
+/// - adding new agreements as "Unreported" by combining shares in the IDKG pool.
 pub(crate) fn update_signature_agreements(
     all_requests: &BTreeMap<CallbackId, SignWithThresholdContext>,
     signature_builder: &dyn ThresholdSignatureBuilder,

--- a/rs/consensus/src/idkg/pre_signer.rs
+++ b/rs/consensus/src/idkg/pre_signer.rs
@@ -31,7 +31,7 @@ use std::sync::Arc;
 use super::utils::update_purge_height;
 
 pub(crate) trait IDkgPreSigner: Send {
-    /// The on_state_change() called from the main ECDSA path.
+    /// The on_state_change() called from the main IDKG path.
     fn on_state_change(
         &self,
         idkg_pool: &dyn IDkgPool,
@@ -858,7 +858,7 @@ impl IDkgPreSignerImpl {
         in_progress: &BTreeSet<IDkgTranscriptId>,
         target_subnet_xnet_transcripts: &BTreeSet<IDkgTranscriptId>,
     ) -> bool {
-        // It is possible the ECDSA component runs and tries to purge the initial
+        // It is possible the IDKG component runs and tries to purge the initial
         // dealings before the finalized tip has the next_key_transcript_creation
         // set up. Avoid this by keeping the initial dealings until the initial
         // resharing completes.
@@ -976,11 +976,11 @@ impl IDkgPreSigner for IDkgPreSignerImpl {
 
 pub(crate) trait IDkgTranscriptBuilder {
     /// Returns the specified transcript if it can be successfully
-    /// built from the current entries in the ECDSA pool
+    /// built from the current entries in the IDKG pool
     fn get_completed_transcript(&self, transcript_id: IDkgTranscriptId) -> Option<IDkgTranscript>;
 
     /// Returns the validated dealings for the given transcript Id from
-    /// the ECDSA pool
+    /// the IDKG pool
     fn get_validated_dealings(&self, transcript_id: IDkgTranscriptId) -> Vec<SignedIDkgDealing>;
 }
 
@@ -1446,7 +1446,7 @@ mod tests {
                     create_transcript_id(5),
                 );
 
-                // Set up the ECDSA pool. Pool has dealings for transcripts 1, 2, 3.
+                // Set up the IDKG pool. Pool has dealings for transcripts 1, 2, 3.
                 // Only dealing for transcript 1 is issued by us.
                 let dealing_1 = create_dealing(id_1, NODE_1);
                 let dealing_2 = create_dealing(id_2, NODE_2);
@@ -1849,7 +1849,7 @@ mod tests {
                     create_pre_signer_dependencies(pool_config, logger);
                 let id_2 = create_transcript_id_with_height(2, Height::from(100));
 
-                // Set up the ECDSA pool
+                // Set up the IDKG pool
                 // Validated pool has: {transcript 2, dealer = NODE_2}
                 let dealing = create_dealing(id_2, NODE_2);
                 let change_set = vec![IDkgChangeAction::AddToValidated(IDkgMessage::Dealing(
@@ -1894,7 +1894,7 @@ mod tests {
                     create_pre_signer_dependencies(pool_config, logger);
                 let id_2 = create_transcript_id_with_height(2, Height::from(100));
 
-                // Set up the ECDSA pool
+                // Set up the IDKG pool
                 // Unvalidated pool has: {transcript 2, dealer = NODE_2, height = 100, internal_dealing_raw = vec[1]}
                 let mut dealing = create_dealing(id_2, NODE_2);
                 dealing.content.internal_dealing_raw = vec![1];
@@ -2286,7 +2286,7 @@ mod tests {
                 let (mut idkg_pool, pre_signer) =
                     create_pre_signer_dependencies(pool_config, logger);
 
-                // Set up the ECDSA pool
+                // Set up the IDKG pool
                 let change_set = vec![IDkgChangeAction::AddToValidated(IDkgMessage::Dealing(
                     dealing.clone(),
                 ))];
@@ -2314,7 +2314,7 @@ mod tests {
                 let (mut idkg_pool, pre_signer) =
                     create_pre_signer_dependencies(pool_config, logger);
 
-                // Set up the ECDSA pool
+                // Set up the IDKG pool
                 let change_set = vec![IDkgChangeAction::AddToValidated(IDkgMessage::Dealing(
                     dealing.clone(),
                 ))];
@@ -2337,7 +2337,7 @@ mod tests {
                 let (mut idkg_pool, pre_signer) =
                     create_pre_signer_dependencies(pool_config, logger);
 
-                // Set up the ECDSA pool
+                // Set up the IDKG pool
                 let change_set = vec![IDkgChangeAction::AddToValidated(IDkgMessage::Dealing(
                     dealing.clone(),
                 ))];
@@ -2368,7 +2368,7 @@ mod tests {
                     create_pre_signer_dependencies(pool_config, logger);
                 let id = create_transcript_id_with_height(1, Height::from(100));
 
-                // Set up the ECDSA pool
+                // Set up the IDKG pool
                 // Validated pool has: support {transcript 2, dealer = NODE_2, signer = NODE_3}
                 let (dealing, support) = create_support(id, NODE_2, NODE_3);
                 let change_set = vec![IDkgChangeAction::AddToValidated(IDkgMessage::Dealing(
@@ -2442,7 +2442,7 @@ mod tests {
                     create_pre_signer_dependencies(pool_config, logger);
                 let id = create_transcript_id_with_height(1, Height::from(10));
 
-                // Set up the ECDSA pool
+                // Set up the IDKG pool
                 // A dealing for a transcript that is requested by finalized block,
                 // and we already have the dealing(share accepted)
                 let (dealing, mut support) = create_support(id, NODE_2, NODE_3);
@@ -2481,7 +2481,7 @@ mod tests {
                     create_pre_signer_dependencies(pool_config, logger);
                 let id = create_transcript_id_with_height(1, Height::from(10));
 
-                // Set up the ECDSA pool
+                // Set up the IDKG pool
                 // A dealing for a transcript that is requested by finalized block,
                 // and we already have the dealing(share accepted)
                 let (dealing, mut support) = create_support(id, NODE_2, NODE_3);
@@ -2520,7 +2520,7 @@ mod tests {
                     create_pre_signer_dependencies(pool_config, logger);
                 let id = create_transcript_id_with_height(1, Height::from(10));
 
-                // Set up the ECDSA pool
+                // Set up the IDKG pool
                 // A dealing for a transcript that is requested by finalized block,
                 // and we already have the dealing(share accepted)
                 let (dealing, mut support) = create_support(id, NODE_2, NODE_3);

--- a/rs/consensus/src/idkg/signer.rs
+++ b/rs/consensus/src/idkg/signer.rs
@@ -82,7 +82,7 @@ impl CombineSigSharesError {
 }
 
 pub(crate) trait ThresholdSigner: Send {
-    /// The on_state_change() called from the main ECDSA path.
+    /// The on_state_change() called from the main IDKG path.
     fn on_state_change(
         &self,
         idkg_pool: &dyn IDkgPool,
@@ -597,7 +597,7 @@ impl ThresholdSigner for ThresholdSignerImpl {
 
 pub(crate) trait ThresholdSignatureBuilder {
     /// Returns the signature for the given context, if it can be successfully
-    /// built from the current sig shares in the ECDSA pool
+    /// built from the current sig shares in the IDKG pool
     fn get_completed_signature(
         &self,
         context: &SignWithThresholdContext,
@@ -988,7 +988,7 @@ mod tests {
             create_request_id(&mut uid_generator, height),
         );
 
-        // Set up the ECDSA pool. Pool has shares for requests 1, 2, 3.
+        // Set up the IDKG pool. Pool has shares for requests 1, 2, 3.
         // Only the share for request 1 is issued by us
         let shares = vec![
             create_signature_share(&key_id, NODE_1, id_1.clone()),
@@ -1429,7 +1429,7 @@ mod tests {
             }),
         );
 
-        // Set up the ECDSA pool
+        // Set up the IDKG pool
         let mut artifacts = Vec::new();
         // A share from a node ahead of us (deferred)
         let message = create_signature_share(&key_id, NODE_2, id_1);
@@ -1532,7 +1532,7 @@ mod tests {
             }),
         );
 
-        // Set up the ECDSA pool
+        // Set up the IDKG pool
         let mut artifacts = Vec::new();
         // A valid share for the first context
         let message = create_signature_share(&key_id, NODE_2, id_1);
@@ -1620,7 +1620,7 @@ mod tests {
             ],
         );
 
-        // Set up the ECDSA pool
+        // Set up the IDKG pool
         let mut artifacts = Vec::new();
         // A share for the first incomplete context (deferred)
         let message = create_signature_share(&key_id, NODE_2, id_1);
@@ -1702,7 +1702,7 @@ mod tests {
 
                 let (mut idkg_pool, signer) = create_signer_dependencies(pool_config, logger);
 
-                // Set up the ECDSA pool
+                // Set up the IDKG pool
                 // Validated pool has: {signature share 2, signer = NODE_2}
                 let share = create_signature_share(&key_id, NODE_2, id_2.clone());
                 let change_set = vec![IDkgChangeAction::AddToValidated(share)];

--- a/rs/consensus/src/idkg/stats.rs
+++ b/rs/consensus/src/idkg/stats.rs
@@ -1,4 +1,4 @@
-//! ECDSA specific stats.
+//! IDKG specific stats.
 
 use crate::idkg::metrics::{
     IDkgPreSignatureMetrics, IDkgTranscriptMetrics, ThresholdSignatureMetrics,

--- a/rs/consensus/src/idkg/test_utils.rs
+++ b/rs/consensus/src/idkg/test_utils.rs
@@ -1818,12 +1818,12 @@ pub(crate) trait IDkgPayloadTestHelper {
         rng: &mut ReproducibleRng,
     ) -> (IDkgTranscript, idkg::UnmaskedTranscript);
 
-    /// Retrieves the only key transcript in the ecdsa payload.
+    /// Retrieves the only key transcript in the idkg payload.
     ///
     /// Panics if there are multiple or no keys.
     fn single_key_transcript(&self) -> &MasterKeyTranscript;
 
-    /// Retrieves the only key transcript in the ecdsa payload.
+    /// Retrieves the only key transcript in the idkg payload.
     ///
     /// Panics if there are multiple or no keys.
     fn single_key_transcript_mut(&mut self) -> &mut MasterKeyTranscript;

--- a/rs/consensus/src/idkg/utils.rs
+++ b/rs/consensus/src/idkg/utils.rs
@@ -1,4 +1,4 @@
-//! Common utils for the ECDSA implementation.
+//! Common utils for the IDKG implementation.
 
 use crate::idkg::complaints::{IDkgTranscriptLoader, TranscriptLoadStatus};
 use crate::idkg::metrics::IDkgPayloadMetrics;
@@ -72,7 +72,7 @@ impl IDkgBlockReader for IDkgBlockReaderImpl {
             .tip()
             .payload
             .as_ref()
-            .as_ecdsa()
+            .as_idkg()
             .map_or(Box::new(std::iter::empty()), |idkg_payload| {
                 Box::new(idkg_payload.iter_transcript_configs_in_creation())
             })
@@ -81,7 +81,7 @@ impl IDkgBlockReader for IDkgBlockReaderImpl {
     fn pre_signatures_in_creation(
         &self,
     ) -> Box<dyn Iterator<Item = (PreSigId, MasterPublicKeyId)> + '_> {
-        self.chain.tip().payload.as_ref().as_ecdsa().map_or(
+        self.chain.tip().payload.as_ref().as_idkg().map_or(
             Box::new(std::iter::empty()),
             |idkg_payload| {
                 Box::new(
@@ -99,7 +99,7 @@ impl IDkgBlockReader for IDkgBlockReaderImpl {
             .tip()
             .payload
             .as_ref()
-            .as_ecdsa()
+            .as_idkg()
             .and_then(|idkg_payload| idkg_payload.available_pre_signatures.get(id))
     }
 
@@ -108,7 +108,7 @@ impl IDkgBlockReader for IDkgBlockReaderImpl {
             .tip()
             .payload
             .as_ref()
-            .as_ecdsa()
+            .as_idkg()
             .map_or(BTreeSet::new(), |payload| payload.active_transcripts())
     }
 
@@ -119,7 +119,7 @@ impl IDkgBlockReader for IDkgBlockReaderImpl {
             .tip()
             .payload
             .as_ref()
-            .as_ecdsa()
+            .as_idkg()
             .map_or(Box::new(std::iter::empty()), |idkg_payload| {
                 Box::new(idkg_payload.iter_xnet_transcripts_source_subnet())
             })
@@ -132,7 +132,7 @@ impl IDkgBlockReader for IDkgBlockReaderImpl {
             .tip()
             .payload
             .as_ref()
-            .as_ecdsa()
+            .as_idkg()
             .map_or(Box::new(std::iter::empty()), |idkg_payload| {
                 Box::new(idkg_payload.iter_xnet_transcripts_target_subnet())
             })
@@ -144,7 +144,7 @@ impl IDkgBlockReader for IDkgBlockReaderImpl {
     ) -> Result<IDkgTranscript, TranscriptLookupError> {
         let idkg_payload = match self.chain.get_block_by_height(transcript_ref.height) {
             Ok(block) => {
-                if let Some(idkg_payload) = block.payload.as_ref().as_ecdsa() {
+                if let Some(idkg_payload) = block.payload.as_ref().as_idkg() {
                     idkg_payload
                 } else {
                     return Err(format!(
@@ -359,7 +359,7 @@ pub(super) fn transcript_op_summary(op: &IDkgTranscriptOperation) -> String {
     }
 }
 
-/// Inspect ecdsa_initializations field in the CUPContent.
+/// Inspect chain_key_initializations field in the CUPContent.
 /// Return key_id and dealings.
 pub(crate) fn inspect_chain_key_initializations(
     ecdsa_initializations: &[pb::EcdsaInitialization],
@@ -476,18 +476,18 @@ pub(crate) fn get_chain_key_config_if_enabled(
 pub(crate) fn get_pre_signature_ids_to_deliver(
     block: &Block,
 ) -> BTreeMap<MasterPublicKeyId, BTreeSet<PreSigId>> {
-    let Some(ecdsa) = block.payload.as_ref().as_ecdsa() else {
+    let Some(idkg) = block.payload.as_ref().as_idkg() else {
         return BTreeMap::new();
     };
 
     let mut pre_sig_ids: BTreeMap<MasterPublicKeyId, BTreeSet<PreSigId>> = BTreeMap::new();
-    for key_id in ecdsa.key_transcripts.keys() {
+    for key_id in idkg.key_transcripts.keys() {
         pre_sig_ids.insert(key_id.clone(), BTreeSet::default());
     }
 
-    for (pre_sig_id, pre_signature) in &ecdsa.available_pre_signatures {
+    for (pre_sig_id, pre_signature) in &idkg.available_pre_signatures {
         let key_id = pre_signature.key_id();
-        if ecdsa
+        if idkg
             .current_key_transcript(&key_id)
             .is_some_and(|current_key_transcript| {
                 current_key_transcript.transcript_id()
@@ -515,7 +515,7 @@ pub(crate) fn get_idkg_subnet_public_keys(
     pool: &PoolReader<'_>,
     log: &ReplicaLogger,
 ) -> Result<BTreeMap<MasterPublicKeyId, MasterPublicKey>, String> {
-    let Some(idkg_payload) = block.payload.as_ref().as_ecdsa() else {
+    let Some(idkg_payload) = block.payload.as_ref().as_idkg() else {
         return Ok(BTreeMap::new());
     };
 
@@ -877,7 +877,7 @@ mod tests {
                 ic_types::crypto::crypto_hash,
                 BlockPayload::Summary(SummaryPayload {
                     dkg: ic_types::consensus::dkg::Summary::fake(),
-                    ecdsa: idkg_payload,
+                    idkg: idkg_payload,
                 }),
             ),
             Height::from(123),
@@ -955,7 +955,7 @@ mod tests {
     }
 
     #[test]
-    fn test_block_without_ecdsa_should_not_deliver_quadruples() {
+    fn test_block_without_idkg_should_not_deliver_quadruples() {
         let block = make_block(None);
         let delivered_ids = get_pre_signature_ids_to_deliver(&block);
 

--- a/rs/consensus/tests/framework/malicious.rs
+++ b/rs/consensus/tests/framework/malicious.rs
@@ -127,7 +127,7 @@ impl<T: IDkgPool> ChangeSetProducer<T> for IDkgWithMaliciousFlags {
     type ChangeSet = IDkgChangeSet;
     fn on_state_change(&self, pool: &T) -> IDkgChangeSet {
         let changeset = IDkgImpl::on_state_change(&self.idkg.borrow(), pool);
-        if self.malicious_flags.is_ecdsa_malicious() {
+        if self.malicious_flags.is_idkg_malicious() {
             malicious_pre_signer::maliciously_alter_changeset(
                 changeset,
                 &self.idkg.borrow().pre_signer,
@@ -150,7 +150,7 @@ pub fn with_malicious_flags(malicious_flags: MaliciousFlags) -> ComponentModifie
             })
         })
     };
-    if malicious_flags.is_ecdsa_malicious() {
+    if malicious_flags.is_idkg_malicious() {
         modifier.idkg = Box::new(move |idkg: IDkgImpl| {
             Box::new(IDkgWithMaliciousFlags {
                 idkg: RefCell::new(idkg),

--- a/rs/consensus/tests/integration.rs
+++ b/rs/consensus/tests/integration.rs
@@ -207,7 +207,7 @@ fn minority_maliciouly_idkg_dealers_would_pass() -> Result<(), String> {
             let mut malicious: Vec<ComponentModifier> = Vec::new();
             for _ in 0..rng.gen_range(1..=f) {
                 let malicious_flags = MaliciousFlags {
-                    maliciously_corrupt_ecdsa_dealings: true,
+                    maliciously_corrupt_idkg_dealings: true,
                     ..MaliciousFlags::default()
                 };
                 malicious.push(malicious::with_malicious_flags(malicious_flags));

--- a/rs/consensus/utils/src/lib.rs
+++ b/rs/consensus/utils/src/lib.rs
@@ -564,19 +564,19 @@ pub fn get_subnet_record(
     }
 }
 
-/// Return the oldest registry version of transcripts in the given ECDSA summary payload that are
+/// Return the oldest registry version of transcripts in the given IDKG summary payload that are
 /// referenced by the given replicated state.
-pub fn get_oldest_ecdsa_state_registry_version(
-    ecdsa: &IDkgPayload,
+pub fn get_oldest_idkg_state_registry_version(
+    idkg: &IDkgPayload,
     state: &ReplicatedState,
 ) -> Option<RegistryVersion> {
     state
         .signature_request_contexts()
         .values()
         .flat_map(|context| context.matched_pre_signature.as_ref())
-        .flat_map(|(pre_sig_id, _)| ecdsa.available_pre_signatures.get(pre_sig_id))
+        .flat_map(|(pre_sig_id, _)| idkg.available_pre_signatures.get(pre_sig_id))
         .flat_map(|pre_signature| pre_signature.get_refs())
-        .flat_map(|transcript_ref| ecdsa.idkg_transcripts.get(&transcript_ref.transcript_id))
+        .flat_map(|transcript_ref| idkg.idkg_transcripts.get(&transcript_ref.transcript_id))
         .map(|transcript| transcript.registry_version)
         .min()
 }
@@ -905,9 +905,9 @@ mod tests {
         ]
     }
 
-    // Create an ECDSA payload with 10 pre-signatures, each using registry version 2, 3 or 4.
+    // Create an IDKG payload with 10 pre-signatures, each using registry version 2, 3 or 4.
     fn idkg_payload_with_pre_sigs(key_id: &MasterPublicKeyId) -> IDkgPayload {
-        let mut ecdsa = empty_idkg_payload(key_id.clone());
+        let mut idkg = empty_idkg_payload(key_id.clone());
         let mut rvs = [
             RegistryVersion::from(2),
             RegistryVersion::from(3),
@@ -919,27 +919,22 @@ mod tests {
             let pre_sig = fake_pre_signature(i as u64, key_id);
             let rv = rvs.next().unwrap();
             for r in pre_sig.get_refs() {
-                ecdsa
-                    .idkg_transcripts
+                idkg.idkg_transcripts
                     .insert(r.transcript_id, fake_transcript(r.transcript_id, rv));
             }
-            ecdsa
-                .available_pre_signatures
+            idkg.available_pre_signatures
                 .insert(PreSigId(i as u64), pre_sig);
         }
-        ecdsa
+        idkg
     }
 
     #[test]
     fn test_empty_state_should_return_no_registry_version() {
         for key_id in fake_key_ids() {
             println!("Running test for key ID {key_id}");
-            let ecdsa = idkg_payload_with_pre_sigs(&key_id);
+            let idkg = idkg_payload_with_pre_sigs(&key_id);
             let state = fake_state_with_contexts(vec![]);
-            assert_eq!(
-                None,
-                get_oldest_ecdsa_state_registry_version(&ecdsa, &state)
-            );
+            assert_eq!(None, get_oldest_idkg_state_registry_version(&idkg, &state));
         }
     }
 
@@ -947,12 +942,9 @@ mod tests {
     fn test_state_without_matches_should_return_no_registry_version() {
         for key_id in fake_key_ids() {
             println!("Running test for key ID {key_id}");
-            let ecdsa = idkg_payload_with_pre_sigs(&key_id);
+            let idkg = idkg_payload_with_pre_sigs(&key_id);
             let state = fake_state_with_contexts(vec![fake_context(None, &key_id)]);
-            assert_eq!(
-                None,
-                get_oldest_ecdsa_state_registry_version(&ecdsa, &state)
-            );
+            assert_eq!(None, get_oldest_idkg_state_registry_version(&idkg, &state));
         }
     }
 
@@ -965,16 +957,16 @@ mod tests {
     }
 
     fn test_should_return_oldest_registry_version(key_id: MasterPublicKeyId) {
-        let ecdsa = idkg_payload_with_pre_sigs(&key_id);
+        let idkg = idkg_payload_with_pre_sigs(&key_id);
         // create contexts for all pre-signatures, but only create a match for
         // pre-signatures with registry version >= 3 (not 2!). Thus the oldest
         // registry version referenced by the state should be 3.
-        let contexts = ecdsa
+        let contexts = idkg
             .available_pre_signatures
             .iter()
             .map(|(id, pre_sig)| {
                 let t_id = pre_sig.key_unmasked().as_ref().transcript_id;
-                let transcript = ecdsa.idkg_transcripts.get(&t_id).unwrap();
+                let transcript = idkg.idkg_transcripts.get(&t_id).unwrap();
                 (transcript.registry_version.get() >= 3).then_some(*id)
             })
             .map(|id| fake_context(id, &key_id))
@@ -982,21 +974,21 @@ mod tests {
         let state = fake_state_with_contexts(contexts);
         assert_eq!(
             Some(RegistryVersion::from(3)),
-            get_oldest_ecdsa_state_registry_version(&ecdsa, &state)
+            get_oldest_idkg_state_registry_version(&idkg, &state)
         );
 
-        let mut ecdsa_without_transcripts = ecdsa.clone();
-        ecdsa_without_transcripts.idkg_transcripts = BTreeMap::new();
+        let mut idkg_without_transcripts = idkg.clone();
+        idkg_without_transcripts.idkg_transcripts = BTreeMap::new();
         assert_eq!(
             None,
-            get_oldest_ecdsa_state_registry_version(&ecdsa_without_transcripts, &state)
+            get_oldest_idkg_state_registry_version(&idkg_without_transcripts, &state)
         );
 
-        let mut ecdsa_without_pre_sigs = ecdsa.clone();
-        ecdsa_without_pre_sigs.available_pre_signatures = BTreeMap::new();
+        let mut idkg_without_pre_sigs = idkg.clone();
+        idkg_without_pre_sigs.available_pre_signatures = BTreeMap::new();
         assert_eq!(
             None,
-            get_oldest_ecdsa_state_registry_version(&ecdsa_without_pre_sigs, &state)
+            get_oldest_idkg_state_registry_version(&idkg_without_pre_sigs, &state)
         );
     }
 }

--- a/rs/orchestrator/src/upgrade.rs
+++ b/rs/orchestrator/src/upgrade.rs
@@ -697,15 +697,15 @@ fn get_master_public_keys(
 ) -> BTreeMap<MasterPublicKeyId, MasterPublicKey> {
     let mut public_keys = BTreeMap::new();
 
-    let Some(ecdsa) = cup.content.block.get_value().payload.as_ref().as_ecdsa() else {
+    let Some(idkg) = cup.content.block.get_value().payload.as_ref().as_idkg() else {
         return public_keys;
     };
 
-    for (key_id, key_transcript) in &ecdsa.key_transcripts {
+    for (key_id, key_transcript) in &idkg.key_transcripts {
         let Some(transcript) = key_transcript
             .current
             .as_ref()
-            .and_then(|transcript_ref| ecdsa.idkg_transcripts.get(&transcript_ref.transcript_id()))
+            .and_then(|transcript_ref| idkg.idkg_transcripts.get(&transcript_ref.transcript_id()))
         else {
             continue;
         };
@@ -859,7 +859,7 @@ mod tests {
             .map(|t| BTreeMap::from_iter(vec![(t.transcript_id, t.clone())]))
             .unwrap_or_default();
 
-        let mut ecdsa = idkg::IDkgPayload::empty(
+        let mut idkg = idkg::IDkgPayload::empty(
             h,
             subnet_test_id(0),
             vec![MasterKeyTranscript {
@@ -868,7 +868,7 @@ mod tests {
                 master_key_id: key_id.clone(),
             }],
         );
-        ecdsa.idkg_transcripts = idkg_transcripts;
+        idkg.idkg_transcripts = idkg_transcripts;
 
         let block = Block::new(
             CryptoHashOf::from(CryptoHash(Vec::new())),
@@ -876,7 +876,7 @@ mod tests {
                 ic_types::crypto::crypto_hash,
                 BlockPayload::Summary(SummaryPayload {
                     dkg: ic_types::consensus::dkg::Summary::fake(),
-                    ecdsa: Some(ecdsa),
+                    idkg: Some(idkg),
                 }),
             ),
             h,

--- a/rs/replica/setup_ic_network/src/lib.rs
+++ b/rs/replica/setup_ic_network/src/lib.rs
@@ -435,7 +435,7 @@ fn start_consensus(
             chain_key_config,
             finalized.payload.as_ref().dkg_interval_start_height(),
             finalized.payload.as_ref().is_summary(),
-            finalized.payload.as_ref().as_ecdsa().is_some(),
+            finalized.payload.as_ref().as_idkg().is_some(),
         );
 
         let idkg_gossip = Arc::new(idkg::IDkgGossipImpl::new(

--- a/rs/test_utilities/consensus/src/fake.rs
+++ b/rs/test_utilities/consensus/src/fake.rs
@@ -26,7 +26,7 @@ impl Fake for SummaryPayload {
     fn fake() -> Self {
         Self {
             dkg: ic_types::consensus::dkg::Summary::fake(),
-            ecdsa: None,
+            idkg: None,
         }
     }
 }
@@ -36,7 +36,7 @@ impl Fake for DataPayload {
         Self {
             batch: BatchPayload::default(),
             dealings: dkg::Dealings::new_empty(Height::from(0)),
-            ecdsa: None,
+            idkg: None,
         }
     }
 }
@@ -264,7 +264,7 @@ impl FromParent for Block {
                 BlockPayload::Data(DataPayload {
                     batch: BatchPayload::default(),
                     dealings: Dealings::new_empty(dkg_start),
-                    ecdsa: None,
+                    idkg: None,
                 }),
             ),
             parent.height.increment(),
@@ -316,7 +316,7 @@ fn test_fake_block_is_binary_compatible() {
             BlockPayload::Data(DataPayload {
                 batch: BatchPayload::default(),
                 dealings: ic_types::consensus::dkg::Dealings::new_empty(Height::from(1)),
-                ecdsa: None,
+                idkg: None,
             }),
         ),
         Height::from(123),
@@ -343,7 +343,7 @@ fn test_fake_block() {
             BlockPayload::Data(DataPayload {
                 batch: BatchPayload::default(),
                 dealings: ic_types::consensus::dkg::Dealings::new_empty(Height::from(1)),
-                ecdsa: None,
+                idkg: None,
             }),
         ),
         Height::from(123),

--- a/rs/test_utilities/consensus/src/lib.rs
+++ b/rs/test_utilities/consensus/src/lib.rs
@@ -146,7 +146,7 @@ pub fn make_genesis(summary: dkg::Summary) -> CatchUpPackage {
             crypto_hash,
             BlockPayload::Summary(SummaryPayload {
                 dkg: summary,
-                ecdsa: None,
+                idkg: None,
             }),
         ),
         height,

--- a/rs/test_utilities/types/src/batch/payload.rs
+++ b/rs/test_utilities/types/src/batch/payload.rs
@@ -79,7 +79,7 @@ mod tests {
             BlockPayload::Data(DataPayload {
                 batch: BatchPayload::default(),
                 dealings: Dealings::new_empty(Height::from(0)),
-                ecdsa: None,
+                idkg: None,
             }),
         );
         let vec = serde_cbor::ser::to_vec(&payload_0).unwrap();
@@ -105,7 +105,7 @@ mod tests {
             BlockPayload::Data(DataPayload {
                 batch: batch_payload_0,
                 dealings: dkg::Dealings::new_empty(Height::new(0)),
-                ecdsa: None,
+                idkg: None,
             }),
         );
         let vec = serde_cbor::ser::to_vec(&payload_0).unwrap();

--- a/rs/tests/src/tecdsa/tecdsa_complaint_test.rs
+++ b/rs/tests/src/tecdsa/tecdsa_complaint_test.rs
@@ -17,8 +17,7 @@ use ic_types::Height;
 use slog::info;
 
 pub fn config(env: TestEnv) {
-    let malicious_behaviour =
-        MaliciousBehaviour::new(true).set_maliciously_corrupt_ecdsa_dealings();
+    let malicious_behaviour = MaliciousBehaviour::new(true).set_maliciously_corrupt_idkg_dealings();
     InternetComputer::new()
         .add_subnet(
             Subnet::new(SubnetType::System)
@@ -79,6 +78,6 @@ pub fn test(env: TestEnv) {
     });
 
     info!(logger, "Checking for malicious logs...");
-    assert_malicious_from_topo(&topology, vec!["maliciously_corrupt_ecdsa_dealings: true"]);
+    assert_malicious_from_topo(&topology, vec!["maliciously_corrupt_idkg_dealings: true"]);
     info!(logger, "Malicious log check succeeded.");
 }

--- a/rs/types/types/src/consensus.rs
+++ b/rs/types/types/src/consensus.rs
@@ -1291,11 +1291,7 @@ impl From<&Block> for pb::Block {
                 None,
                 vec![],
                 vec![],
-                payload
-                    .as_summary()
-                    .ecdsa
-                    .as_ref()
-                    .map(|ecdsa| ecdsa.into()),
+                payload.as_summary().idkg.as_ref().map(|idkg| idkg.into()),
             )
         } else {
             let batch = &payload.as_data().batch;
@@ -1306,7 +1302,7 @@ impl From<&Block> for pb::Block {
                 Some(pb::SelfValidatingPayload::from(&batch.self_validating)),
                 batch.canister_http.clone(),
                 batch.query_stats.clone(),
-                payload.as_data().ecdsa.as_ref().map(|ecdsa| ecdsa.into()),
+                payload.as_data().idkg.as_ref().map(|idkg| idkg.into()),
             )
         };
         Self {
@@ -1362,38 +1358,35 @@ impl TryFrom<pb::Block> for Block {
                     batch.is_empty(),
                     "Error: Summary block has non-empty batch payload."
                 );
-                // Convert the ECDSA summary. Note that the summary may contain
+                // Convert the idkg summary. Note that the summary may contain
                 // transcript references, and here we are NOT checking if these
                 // references are valid. Such checks, if required, should be done
                 // after converting from protobuf to rust internal type.
                 //
                 // If after conversion, the summary block is intend to get a different
                 // height value (e.g. when a new CUP is created), then a call to
-                // ecdsa.update_refs(height) should be manually called.
-                let ecdsa = block
+                // idkg.update_refs(height) should be manually called.
+                let idkg = block
                     .idkg_payload
                     .as_ref()
-                    .map(|ecdsa| ecdsa.try_into())
+                    .map(|idkg| idkg.try_into())
                     .transpose()
                     .map_err(|e: ProxyDecodeError| e.to_string())?;
 
-                BlockPayload::Summary(SummaryPayload {
-                    dkg: summary,
-                    ecdsa,
-                })
+                BlockPayload::Summary(SummaryPayload { dkg: summary, idkg })
             }
             dkg::Payload::Dealings(dealings) => {
-                let ecdsa = block
+                let idkg = block
                     .idkg_payload
                     .as_ref()
-                    .map(|ecdsa| ecdsa.try_into())
+                    .map(|idkg| idkg.try_into())
                     .transpose()
                     .map_err(|e: ProxyDecodeError| e.to_string())?;
 
                 BlockPayload::Data(DataPayload {
                     batch,
                     dealings,
-                    ecdsa,
+                    idkg,
                 })
             }
         };

--- a/rs/types/types/src/consensus/idkg.rs
+++ b/rs/types/types/src/consensus/idkg.rs
@@ -1,4 +1,4 @@
-//! Defines types used for threshold ECDSA key generation.
+//! Defines types used for threshold master key generation.
 
 use crate::artifact::{IdentifiableArtifact, PbArtifact};
 pub use crate::consensus::idkg::common::{
@@ -362,9 +362,9 @@ impl AsMut<TranscriptRef> for UnmaskedTranscriptWithAttributes {
 #[derive(Clone, Debug, Hash, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(test, derive(ExhaustiveSet))]
 pub struct MasterKeyTranscript {
-    /// The ECDSA key transcript used for the current interval.
+    /// The key transcript used for the current interval.
     pub current: Option<UnmaskedTranscriptWithAttributes>,
-    /// Progress of creating the next ECDSA key transcript.
+    /// Progress of creating the next key transcript.
     pub next_in_creation: KeyTranscriptCreation,
     /// Master key Id allowing different signature schemes.
     pub master_key_id: MasterPublicKeyId,
@@ -533,7 +533,7 @@ impl TryFrom<&pb::MasterKeyTranscript> for MasterKeyTranscript {
     }
 }
 
-/// The creation of an ecdsa key transcript goes through one of the three paths below:
+/// The creation of a master key transcript goes through one of the three paths below:
 /// 1. Begin -> RandomTranscript -> ReshareOfMasked -> Created
 /// 2. Begin -> ReshareOfUnmasked -> Created
 /// 3. XnetReshareOfUnmaskedParams -> Created (xnet bootstrapping from initial dealings)
@@ -745,7 +745,7 @@ impl IDkgUIDGenerator {
     }
 }
 
-/// The ECDSA artifact.
+/// The IDKG artifact.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Hash)]
 pub enum IDkgMessage {
     Dealing(SignedIDkgDealing),
@@ -1932,7 +1932,7 @@ impl TryFrom<&pb::IDkgPayload> for IDkgPayload {
 ///
 /// Processing/updates for a particular entity like TranscriptId is scattered across
 /// several paths, called from different contexts (e.g)
-///     - IDkgPreSigner builds the dealings/support shares (ECDSA component context),
+///     - IDkgPreSigner builds the dealings/support shares (IDKG component context),
 ///       across several calls to on_state_change()
 ///     - IDkgTranscriptBuilder builds the verified dealings/transcripts (payload builder context),
 ///       across possibly several calls to get_completed_transcript()
@@ -1976,7 +1976,7 @@ pub trait IDkgStats: Send + Sync {
     fn record_sig_share_aggregation(&self, request_id: &RequestId, duration: Duration);
 }
 
-/// IDkgObject should be implemented by the ECDSA message types
+/// IDkgObject should be implemented by the IDKG message types
 /// (e.g) Dealing, DealingSupport, etc
 pub trait IDkgObject: CryptoHashable + Clone + Sized {
     /// Returns the artifact prefix.

--- a/rs/types/types/src/consensus/idkg/common.rs
+++ b/rs/types/types/src/consensus/idkg/common.rs
@@ -42,7 +42,7 @@ use super::{
 pub type PseudoRandomId = [u8; 32];
 
 /// RequestId is used for two purposes:
-/// 1. to identify the matching request in sign_with_ecdsa_contexts.
+/// 1. to identify the matching request in signature request contexts.
 /// 2. to identify which pre-signature the request is matched to.
 ///
 /// Pre-signatures must be matched with requests in the same order as requests
@@ -643,7 +643,7 @@ impl TryFrom<&pb::UnmaskedTimesMaskedParams> for UnmaskedTimesMaskedParams {
 
 pub type TranscriptLookupError = String;
 
-/// Wrapper to access the ECDSA related info from the blocks.
+/// Wrapper to access the IDKG related info from the blocks.
 pub trait IDkgBlockReader: Send + Sync {
     /// Returns the height of the tip
     fn tip_height(&self) -> Height;

--- a/rs/types/types/src/consensus/payload.rs
+++ b/rs/types/types/src/consensus/payload.rs
@@ -18,7 +18,7 @@ use std::sync::Arc;
 pub struct DataPayload {
     pub batch: BatchPayload,
     pub dealings: dkg::Dealings,
-    pub ecdsa: idkg::Payload,
+    pub idkg: idkg::Payload,
 }
 
 /// The payload of a summary block.
@@ -26,7 +26,7 @@ pub struct DataPayload {
 #[cfg_attr(test, derive(ExhaustiveSet))]
 pub struct SummaryPayload {
     pub dkg: dkg::Summary,
-    pub ecdsa: idkg::Summary,
+    pub idkg: idkg::Summary,
 }
 
 impl SummaryPayload {
@@ -40,12 +40,12 @@ impl SummaryPayload {
     /// Note that this function should generally be called on the CUP instead.
     pub(crate) fn get_oldest_registry_version_in_use(&self) -> RegistryVersion {
         let dkg_version = self.dkg.get_oldest_registry_version_in_use();
-        if let Some(ecdsa_version) = self
-            .ecdsa
+        if let Some(idkg_version) = self
+            .idkg
             .as_ref()
             .and_then(|payload| payload.get_oldest_registry_version_in_use())
         {
-            dkg_version.min(ecdsa_version)
+            dkg_version.min(idkg_version)
         } else {
             dkg_version
         }
@@ -68,7 +68,7 @@ impl BlockPayload {
     pub fn is_empty(&self) -> bool {
         match self {
             BlockPayload::Data(data) => {
-                data.batch.is_empty() && data.dealings.messages.is_empty() && data.ecdsa.is_none()
+                data.batch.is_empty() && data.dealings.messages.is_empty() && data.idkg.is_none()
             }
             _ => false,
         }
@@ -114,10 +114,10 @@ impl BlockPayload {
     }
 
     /// Returns a reference to IDkgPayload if it exists.
-    pub fn as_ecdsa(&self) -> Option<&idkg::IDkgPayload> {
+    pub fn as_idkg(&self) -> Option<&idkg::IDkgPayload> {
         match self {
-            BlockPayload::Data(data) => data.ecdsa.as_ref(),
-            BlockPayload::Summary(data) => data.ecdsa.as_ref(),
+            BlockPayload::Data(data) => data.idkg.as_ref(),
+            BlockPayload::Summary(data) => data.idkg.as_ref(),
         }
     }
 
@@ -242,12 +242,12 @@ impl From<dkg::Payload> for BlockPayload {
         match payload {
             dkg::Payload::Summary(summary) => BlockPayload::Summary(SummaryPayload {
                 dkg: summary,
-                ecdsa: None,
+                idkg: None,
             }),
             dkg::Payload::Dealings(dealings) => BlockPayload::Data(DataPayload {
                 batch: BatchPayload::default(),
                 dealings,
-                ecdsa: idkg::Payload::default(),
+                idkg: idkg::Payload::default(),
             }),
         }
     }

--- a/rs/types/types/src/malicious_behaviour.rs
+++ b/rs/types/types/src/malicious_behaviour.rs
@@ -123,9 +123,9 @@ impl MaliciousBehaviour {
         })
     }
 
-    pub fn set_maliciously_corrupt_ecdsa_dealings(self) -> Self {
+    pub fn set_maliciously_corrupt_idkg_dealings(self) -> Self {
         self.set_malicious_behaviour(|mut s| {
-            s.malicious_flags.maliciously_corrupt_ecdsa_dealings = true;
+            s.malicious_flags.maliciously_corrupt_idkg_dealings = true;
             s
         })
     }

--- a/rs/types/types/src/malicious_flags.rs
+++ b/rs/types/types/src/malicious_flags.rs
@@ -25,7 +25,7 @@ pub struct MaliciousFlags {
     pub maliciously_disable_execution: bool,
     pub maliciously_corrupt_own_state_at_heights: Vec<u64>,
     pub maliciously_disable_ingress_validation: bool,
-    pub maliciously_corrupt_ecdsa_dealings: bool,
+    pub maliciously_corrupt_idkg_dealings: bool,
     /// Delay execution such that it takes at least [`Duration`] time
     pub maliciously_delay_execution: Option<Duration>,
     /// Delay state sync such that it takes at least [`Duration`] time
@@ -54,10 +54,10 @@ impl MaliciousFlags {
             || self.maliciously_notarize_all
     }
 
-    /// This function is to distinguish maliciousness gated by ecdsa's
+    /// This function is to distinguish maliciousness gated by idkg's
     /// implementation.
-    pub fn is_ecdsa_malicious(&self) -> bool {
-        self.maliciously_corrupt_ecdsa_dealings
+    pub fn is_idkg_malicious(&self) -> bool {
+        self.maliciously_corrupt_idkg_dealings
     }
 
     /// Delay the execution as specified by `maliciously_delay_execution`


### PR DESCRIPTION
These fields now hold an `IDkgPayload` instead of an `EcdsaPayload` and should therefore be renamed.

There are some bigger documentation comment blocks that will need a more extensive overhaul, which I will tackle in a different change.