### PR TITLE
chore(IDX): exclude workflows with long wait times

### DIFF
--- a/.github/workflows/slack-workflow-queue.yml
+++ b/.github/workflows/slack-workflow-queue.yml
@@ -38,6 +38,12 @@ jobs:
             RUN_STARTED_TIME=$(date -d "$RUN_STARTED_AT" +%s)
             TIME_IN_QUEUE=$((CURRENT_TIME - RUN_STARTED_TIME))
 
+            # exclude workflows with long wait times
+            WORKFLOW_NAME=$(echo "${WORKFLOW}" | jq -r '.name') # Extract name
+            if [ "$WORKFLOW_NAME" = "Schedule Daily" ]; then
+              continue
+            fi
+
             if [ $TIME_IN_QUEUE -ge $WAIT_THRESHOLD_SECONDS ]; then
               WORKFLOW_URL="https://github.com/${{ github.repository }}/actions/runs/${WORKFLOW}"
               MESSAGE="${MESSAGE} <${WORKFLOW_URL}|${WORKFLOW}>"

--- a/.github/workflows/slack-workflow-queue.yml
+++ b/.github/workflows/slack-workflow-queue.yml
@@ -39,6 +39,7 @@ jobs:
             TIME_IN_QUEUE=$((CURRENT_TIME - RUN_STARTED_TIME))
 
             # exclude workflows with long wait times
+            echo "${WORKFLOW}"
             WORKFLOW_NAME=$(echo "${WORKFLOW}" | jq -r '.name') # Extract name
             if [ "$WORKFLOW_NAME" = "Schedule Daily" ]; then
               continue

--- a/.github/workflows/slack-workflow-queue.yml
+++ b/.github/workflows/slack-workflow-queue.yml
@@ -39,8 +39,7 @@ jobs:
             TIME_IN_QUEUE=$((CURRENT_TIME - RUN_STARTED_TIME))
 
             # exclude workflows with long wait times
-            echo "${WORKFLOW}"
-            WORKFLOW_NAME=$(echo "${WORKFLOW}" | jq -r '.name') # Extract name
+            WORKFLOW_NAME=$(echo "${WORKFLOWS_IN_QUEUE}" | jq -r "select(.id == ${WORKFLOW}) | .name") # Extract name
             if [ "$WORKFLOW_NAME" = "Schedule Daily" ]; then
               continue
             fi


### PR DESCRIPTION
The `rust-benchmarks` jobs will have long wait times so it's best to exclude these from the queue time alert.