### PR TITLE
fix(IDX): double CPU reservation for //rs/nervous_system/integration_tests:integration_tests_test_tests/sns_ledger_upgrade

### DIFF
--- a/rs/nervous_system/integration_tests/BUILD.bazel
+++ b/rs/nervous_system/integration_tests/BUILD.bazel
@@ -185,7 +185,7 @@ rust_test_suite_with_extra_srcs(
     flaky = True,
     proc_macro_deps = MACRO_DEPENDENCIES + MACRO_DEV_DEPENDENCIES,
     tags = [
-        "cpu:3",
+        "cpu:6",
     ],
     deps = [":nervous_system_integration_tests"] + DEPENDENCIES_WITH_TEST_FEATURES + DEV_DEPENDENCIES,
 )


### PR DESCRIPTION
This test is still a bit flaky. Let's go for 6 CPUs since that's also the default number of vCPUs for IC nodes in system-tests.