### PR TITLE
chore: optimize starting PocketIC server in PocketIC library

### DIFF
--- a/packages/pocket-ic/src/lib.rs
+++ b/packages/pocket-ic/src/lib.rs
@@ -1275,7 +1275,7 @@ To download the binary, please visit https://github.com/dfinity/pocketic."
             }
             _ => std::thread::sleep(Duration::from_millis(20)),
         }
-        if start.elapsed() > Duration::from_secs(5) {
+        if start.elapsed() > Duration::from_secs(10) {
             panic!("Failed to start PocketIC service in time");
         }
     }

--- a/packages/pocket-ic/src/lib.rs
+++ b/packages/pocket-ic/src/lib.rs
@@ -52,6 +52,7 @@ use std::sync::mpsc::channel;
 use std::thread;
 use std::thread::JoinHandle;
 use std::{
+    fs::File,
     path::{Path, PathBuf},
     process::Command,
     sync::Arc,
@@ -1254,16 +1255,19 @@ To download the binary, please visit https://github.com/dfinity/pocketic."
 
     // Use the parent process ID to find the PocketIC server port for this `cargo test` run.
     let parent_pid = std::os::unix::process::parent_id();
-    let mut cmd = Command::new(PathBuf::from(bin_path));
-    cmd.arg("--pid").arg(parent_pid.to_string());
-    if std::env::var("POCKET_IC_MUTE_SERVER").is_ok() {
-        cmd.stdout(std::process::Stdio::null());
-        cmd.stderr(std::process::Stdio::null());
-    }
-    cmd.spawn().expect("Failed to start PocketIC binary");
-
     let port_file_path = std::env::temp_dir().join(format!("pocket_ic_{}.port", parent_pid));
     let ready_file_path = std::env::temp_dir().join(format!("pocket_ic_{}.ready", parent_pid));
+    let started_file_path = std::env::temp_dir().join(format!("pocket_ic_{}.started", parent_pid));
+    if create_file_atomically(started_file_path).is_ok() {
+        let mut cmd = Command::new(PathBuf::from(bin_path));
+        cmd.arg("--pid").arg(parent_pid.to_string());
+        if std::env::var("POCKET_IC_MUTE_SERVER").is_ok() {
+            cmd.stdout(std::process::Stdio::null());
+            cmd.stderr(std::process::Stdio::null());
+        }
+        cmd.spawn().expect("Failed to start PocketIC binary");
+    }
+
     let start = Instant::now();
     loop {
         match ready_file_path.try_exists() {
@@ -1279,4 +1283,13 @@ To download the binary, please visit https://github.com/dfinity/pocketic."
             panic!("Failed to start PocketIC service in time");
         }
     }
+}
+
+// Ensures atomically that this file was created freshly, and gives an error otherwise.
+fn create_file_atomically<P: AsRef<std::path::Path>>(file_path: P) -> std::io::Result<File> {
+    File::options()
+        .read(true)
+        .write(true)
+        .create_new(true)
+        .open(&file_path)
 }


### PR DESCRIPTION
This MR should mitigate test failures due to `Failed to start PocketIC service in time` by only starting the PocketIC server once per test suite (as opposed to once per each individual test and terminating the server early if another one is already running) and doubling the timeout for the PocketIC server to start from 5s to 10s.