### PR TITLE
chore(IDX): remove targets from rust_canister

### DIFF
--- a/bazel/canisters.bzl
+++ b/bazel/canisters.bzl
@@ -62,7 +62,8 @@ def rust_canister(name, service_file, visibility = ["//visibility:public"], test
     The following targets are generated:
         <name>.raw: the raw Wasm module as built by rustc
         <name>.wasm.gz: the Wasm module, shrunk, with metadata, gzipped.
-
+        <name>_did_git_test: a test that checks the backwards-compatibility of the did service file from HEAD with the same file from the merge-base of the PR.
+        
     Args:
       name: the name of the target that produces a Wasm module.
       service_file: the label pointing the canister candid interface file.

--- a/bazel/canisters.bzl
+++ b/bazel/canisters.bzl
@@ -63,7 +63,7 @@ def rust_canister(name, service_file, visibility = ["//visibility:public"], test
         <name>.raw: the raw Wasm module as built by rustc
         <name>.wasm.gz: the Wasm module, shrunk, with metadata, gzipped.
         <name>_did_git_test: a test that checks the backwards-compatibility of the did service file from HEAD with the same file from the merge-base of the PR.
-        
+
     Args:
       name: the name of the target that produces a Wasm module.
       service_file: the label pointing the canister candid interface file.

--- a/bazel/canisters.bzl
+++ b/bazel/canisters.bzl
@@ -2,11 +2,9 @@
 This module defines utilities for building Rust canisters.
 """
 
-load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
 load("@rules_motoko//motoko:defs.bzl", "motoko_binary")
 load("@rules_rust//rust:defs.bzl", "rust_binary")
 load("//bazel:candid.bzl", "did_git_test")
-load("//bazel:defs.bzl", "gzip_compress")
 
 def _wasm_rust_transition_impl(_settings, attr):
     return {
@@ -53,85 +51,86 @@ wasm_rust_binary_rule = rule(
     implementation = _wasm_binary_impl,
     attrs = {
         "binary": attr.label(mandatory = True, cfg = wasm_rust_transition),
-        "_whitelist_function_transition": attr.label(default = "@bazel_tools//tools/whitelists/function_transition_whitelist"),
+        "_allowlist_function_transition": attr.label(default = "@bazel_tools//tools/allowlists/function_transition_allowlist"),
         "opt": attr.string(mandatory = True),
     },
 )
 
-def rust_canister(name, service_file, **kwargs):
+def rust_canister(name, service_file, visibility = ["//visibility:public"], testonly = False, opt = "3", **kwargs):
     """Defines a Rust program that builds into a WebAssembly module.
+
+    The following targets are generated:
+        <name>.raw: the raw Wasm module as built by rustc
+        <name>.wasm.gz: the Wasm module, shrunk, with metadata, gzipped.
 
     Args:
       name: the name of the target that produces a Wasm module.
       service_file: the label pointing the canister candid interface file.
+      visibility: visibility of the Wasm target
+      opt: opt-level for the Wasm target
+      testonly: testonly attribute for Wasm target
       **kwargs: additional arguments to pass a rust_binary rule.
     """
-    wasm_name = "_wasm_" + name.replace(".", "_")
-    opt = kwargs.pop("opt", "3")
-    kwargs.setdefault("visibility", ["//visibility:public"])
-    kwargs.setdefault("tags", []).append("canister")
-    kwargs.setdefault("testonly", False)
 
+    # Tags for the wasm build (popped because not relevant to bin base build)
+    tags = kwargs.pop("tags", [])
+    tags.append("canister")
+
+    # Sanity checking (no '.' in name)
+    if name.count(".") > 0:
+        fail("name '{}' should not include dots".format(name))
+
+    # Rust binary build (not actually built by default, but transitioned & used in the
+    # wasm build)
+    # NOTE: '_wasm_' is a misnommer since it's not a wasm build but used for legacy
+    # reasons (some targets depend on this)
+    bin_name = "_wasm_" + name.replace(".", "_")
     rust_binary(
-        name = wasm_name,
+        name = bin_name,
         crate_type = "bin",
+        tags = ["manual"],  # don't include in wildcards like //pkg/...
+        visibility = ["//visibility:private"],  # shouldn't be used
+        testonly = testonly,
         **kwargs
     )
 
+    # The actual wasm build, unoptimized
+    wasm_name = name + ".raw"
     wasm_rust_binary_rule(
-        name = name + ".raw",
-        binary = ":" + wasm_name,
+        name = wasm_name,
+        binary = ":" + bin_name,
         opt = opt,
-        testonly = kwargs.get("testonly"),
+        visibility = visibility,
+        testonly = testonly,
+        tags = tags,
     )
 
-    did_git_test(
-        name = name + "_did_git_test",
-        did = service_file,
-    )
-
-    # Invokes canister WebAssembly module optimizer and attaches the candid file.
-    native.genrule(
-        name = name + ".opt",
-        srcs = [name + ".raw", service_file],
-        outs = [name + ".opt.wasm"],
-        testonly = kwargs.get("testonly"),
-        message = "Shrinking canister " + name,
-        tools = ["@crate_index//:ic-wasm__ic-wasm"],
-        cmd_bash = """
-        $(location @crate_index//:ic-wasm__ic-wasm) $(location {input_wasm}) -o $@ shrink && \
-        $(location @crate_index//:ic-wasm__ic-wasm) $@ -o $@ metadata candid:service --visibility public --file $(location {service_file})
-        """.format(input_wasm = name + ".raw", service_file = service_file),
-    )
-
-    native.alias(
-        name = name + ".didfile",
-        actual = service_file,
-    )
-
-    inject_version_into_wasm(
-        name = name + "_with_version.opt",
-        src_wasm = name + ".opt",
+    # The finalized wasm (optimized, versioned, etc)
+    # NOTE: the name should be .wasm.gz, but '.wasm' is used by some targets
+    # and kept for legacy reasons
+    final_name = name + ".wasm"
+    finalize_wasm(
+        name = final_name,
+        src_wasm = wasm_name,
+        service_file = service_file,
         version_file = "//bazel:rc_only_version.txt",
-        testonly = kwargs.get("testonly"),
-    )
-
-    gzip_compress(
-        name = name + ".wasm",
-        srcs = [name + "_with_version.opt"],
-        testonly = kwargs.get("testonly"),
-    )
-
-    copy_file(
-        name = name + "-wasm.gz",
-        src = name + ".wasm",
-        out = name + ".wasm.gz",
-        testonly = kwargs.get("testonly"),
+        visibility = visibility,
+        testonly = testonly,
     )
 
     native.alias(
         name = name,
         actual = name + ".wasm",
+    )
+
+    # DID service related targets
+    native.alias(
+        name = name + ".didfile",
+        actual = service_file,
+    )
+    did_git_test(
+        name = name + "_did_git_test",
+        did = service_file,
     )
 
 def motoko_canister(name, entry, deps):
@@ -146,6 +145,11 @@ def motoko_canister(name, entry, deps):
     raw_wasm = entry.replace(".mo", ".raw")
     raw_did = entry.replace(".mo", ".did")
 
+    native.alias(
+        name = name + ".didfile",
+        actual = raw_did,
+    )
+
     motoko_binary(
         name = name + "_raw",
         entry = entry,
@@ -154,26 +158,11 @@ def motoko_canister(name, entry, deps):
         deps = deps,
     )
 
-    native.alias(
-        name = name + ".didfile",
-        actual = raw_did,
-    )
-
-    inject_version_into_wasm(
-        name = name + "_with_version.opt",
+    finalize_wasm(
+        name = name + ".wasm",
         src_wasm = raw_wasm,
         version_file = "//bazel:rc_only_version.txt",
-    )
-
-    gzip_compress(
-        name = name + ".wasm",
-        srcs = [name + "_with_version.opt"],
-    )
-
-    copy_file(
-        name = name + "-wasm.gz",
-        src = name + ".wasm",
-        out = name + ".wasm.gz",
+        testonly = False,
     )
 
     native.alias(
@@ -181,38 +170,27 @@ def motoko_canister(name, entry, deps):
         actual = name + ".wasm",
     )
 
-def inject_version_into_wasm(*, name, src_wasm, version_file = "//bazel:version.txt", visibility = None, testonly = False):
-    """Generates an output file named `name + '.wasm'`.
+def finalize_wasm(*, name, src_wasm, service_file = None, version_file, testonly, visibility = ["//visibility:public"]):
+    """Generates an output file name `name + '.wasm.gz'`.
 
-    The output file is almost identical to the input (i.e. `src_wasm`), except
-    that it has an additional piece of metadata attached to in the form of a
-    WASM custom section named `icp:public git_commit_id` (no quotes, of course),
-    whose value is the contents of version_file (minus the trailing
-    newline character).
+    The input file is shrunk, annotated with metadata, and gzipped. The canister
+    metadata consists of:
+        'icp:public git_commit_id': version used in the build
+        'icp:public candid:service': the canister's candid service description
     """
     native.genrule(
         name = name,
-        srcs = [
-            src_wasm,
-            version_file,
-        ],
-        outs = [name + ".wasm"],
-        message = "Injecting version into wasm.",
-        tools = ["@crate_index//:ic-wasm__ic-wasm"],
-        cmd_bash = " ".join([
-            "$(location @crate_index//:ic-wasm__ic-wasm)",
-            "$(location %s)" % src_wasm,  # Input file.
-            "--output $@",  # Output file.
-            "metadata",  # Subcommand
-
-            # The name of the custom section will be
-            # "icp:public git_commit_id"
-            "git_commit_id",
-            "--visibility public",
-
-            # Get value to inject from version_file.
-            "--file $(location " + version_file + ")",
-        ]),
+        srcs = [src_wasm, version_file] + ([service_file] if not (service_file == None) else []),
+        outs = [name + ".gz"],
         visibility = visibility,
         testonly = testonly,
+        message = "Finalizing canister " + name,
+        tools = ["@crate_index//:ic-wasm__ic-wasm", "@pigz"],
+        cmd_bash = " && ".join([
+            "{ic_wasm} {input_wasm} -o $@.shrunk shrink",
+            "{ic_wasm} $@.shrunk -o $@.meta metadata candid:service --visibility public --file " + "$(location {})".format(service_file) if not (service_file == None) else "cp $@.shrunk $@.meta",  # if service_file is None, don't include a service file
+            "{ic_wasm} $@.meta -o $@.ver metadata git_commit_id --visibility public --file {version_file}",
+            "{pigz} --processes 16 --no-name $@.ver --stdout > $@",
+        ])
+            .format(input_wasm = "$(location {})".format(src_wasm), ic_wasm = "$(location @crate_index//:ic-wasm__ic-wasm)", version_file = "$(location {})".format(version_file), pigz = "$(location @pigz)"),
     )

--- a/bazel/inject_version_into_wasm_tests/BUILD.bazel
+++ b/bazel/inject_version_into_wasm_tests/BUILD.bazel
@@ -1,8 +1,10 @@
-load("//bazel:canisters.bzl", "inject_version_into_wasm")
+load("//bazel:canisters.bzl", "finalize_wasm")
 
 # Test subject
-inject_version_into_wasm(
+finalize_wasm(
     name = "stamped_trivial",
+    testonly = True,
+    service_file = "service.did",
     src_wasm = "trivial.wasm",
     version_file = "//bazel:version.txt",
 )


### PR DESCRIPTION
This reduces the number of targets that `rust_canister` generates. In particular:

* The bin (transition base) `rust_binary` build is marked as `"manual"` so that the native build is not performed when e.g. running `bazel build //rs/...`
* A lot of intermediary targets (gzipping, metadata, shrinking) are removed and replaced with a single `finalize_wasm` pass, which helps decrease the total number of targets (less data duplicated, fewer cache downloads, etc)

This saves ~300 targets compared to previously (2305 -> 1991), including strictly unnecessary native builds of canisters.

The transition `whitelist` attribute is also replaced with `allowlist` (the former has been deprecated for a while).