### PR TITLE
fix (RUN-1018): Fix instrumentation for memory.init and table.init in Wasm 64-bit mode

### DIFF
--- a/rs/embedders/src/wasm_utils/instrumentation.rs
+++ b/rs/embedders/src/wasm_utils/instrumentation.rs
@@ -1380,7 +1380,7 @@ enum Scope {
 #[derive(Copy, Clone, Debug, PartialEq)]
 enum InjectionPointCostDetail {
     StaticCost { scope: Scope, cost: u64 },
-    DynamicCost,
+    DynamicCost { extend64_bit: bool },
 }
 
 impl InjectionPointCostDetail {
@@ -1389,7 +1389,7 @@ impl InjectionPointCostDetail {
     fn increment_cost(&mut self, additional_cost: u64) {
         match self {
             Self::StaticCost { scope: _, cost } => *cost += additional_cost,
-            Self::DynamicCost => {}
+            Self::DynamicCost { .. } => {}
         }
     }
 }
@@ -1409,9 +1409,9 @@ impl InjectionPoint {
         }
     }
 
-    fn new_dynamic_cost(position: usize) -> Self {
+    fn new_dynamic_cost(position: usize, extend64_bit: bool) -> Self {
         InjectionPoint {
-            cost_detail: InjectionPointCostDetail::DynamicCost,
+            cost_detail: InjectionPointCostDetail::DynamicCost { extend64_bit },
             position,
         }
     }
@@ -1434,7 +1434,7 @@ fn inject_metering(
 ) {
     let points = match metering_type {
         MeteringType::None => Vec::new(),
-        MeteringType::New => injections(code),
+        MeteringType::New => injections(code, mem_type),
     };
     let points = points.iter().filter(|point| match point.cost_detail {
         InjectionPointCostDetail::StaticCost {
@@ -1442,7 +1442,7 @@ fn inject_metering(
             cost: _,
         } => true,
         InjectionPointCostDetail::StaticCost { scope: _, cost } => cost > 0,
-        InjectionPointCostDetail::DynamicCost => true,
+        InjectionPointCostDetail::DynamicCost { .. } => true,
     });
     let orig_elems = code;
     let mut elems: Vec<Operator> = Vec::new();
@@ -1481,25 +1481,22 @@ fn inject_metering(
                     ]);
                 }
             }
-            InjectionPointCostDetail::DynamicCost => {
-                match mem_type {
-                    WasmMemoryType::Wasm32 => {
-                        elems.extend_from_slice(&[
-                            I64ExtendI32U,
-                            Call {
-                                function_index: export_data_module.decr_instruction_counter_fn,
-                            },
-                            // decr_instruction_counter returns it's argument unchanged,
-                            // so we can convert back to I32 without worrying about
-                            // overflows.
-                            I32WrapI64,
-                        ]);
-                    }
-                    WasmMemoryType::Wasm64 => {
-                        elems.extend_from_slice(&[Call {
+            InjectionPointCostDetail::DynamicCost { extend64_bit } => {
+                if extend64_bit {
+                    elems.extend_from_slice(&[
+                        I64ExtendI32U,
+                        Call {
                             function_index: export_data_module.decr_instruction_counter_fn,
-                        }]);
-                    }
+                        },
+                        // decr_instruction_counter returns its argument unchanged,
+                        // so we can convert back to I32 without worrying about
+                        // overflows.
+                        I32WrapI64,
+                    ]);
+                } else {
+                    elems.extend_from_slice(&[Call {
+                        function_index: export_data_module.decr_instruction_counter_fn,
+                    }]);
                 }
             }
         }
@@ -1779,7 +1776,7 @@ fn inject_try_grow_wasm_memory(
 // with no branches) and before each bulk memory instruction. An injection point
 // contains a "hint" about the context of every basic block, specifically if
 // it's re-entrant or not.
-fn injections(code: &[Operator]) -> Vec<InjectionPoint> {
+fn injections(code: &[Operator], mem_type: WasmMemoryType) -> Vec<InjectionPoint> {
     let mut res = Vec::new();
     use Operator::*;
     // The function itself is a re-entrant code block.
@@ -1817,13 +1814,20 @@ fn injections(code: &[Operator]) -> Vec<InjectionPoint> {
             }
             // Bulk memory instructions require injected metering __before__ the instruction
             // executes so that size arguments can be read from the stack at runtime.
-            MemoryFill { .. }
-            | MemoryCopy { .. }
-            | MemoryInit { .. }
-            | TableCopy { .. }
-            | TableInit { .. }
-            | TableFill { .. } => {
-                res.push(InjectionPoint::new_dynamic_cost(position));
+            MemoryFill { .. } | MemoryCopy { .. } | TableCopy { .. } | TableFill { .. } => {
+                match mem_type {
+                    WasmMemoryType::Wasm32 => {
+                        // These ops in Wasm32 will need to extend the i32 to i64.
+                        res.push(InjectionPoint::new_dynamic_cost(position, true));
+                    }
+                    WasmMemoryType::Wasm64 => {
+                        res.push(InjectionPoint::new_dynamic_cost(position, false));
+                    }
+                }
+            }
+            // MemoryInit and TableInit have i32 arguments even in 64-bit mode.
+            MemoryInit { .. } | TableInit { .. } => {
+                res.push(InjectionPoint::new_dynamic_cost(position, true));
             }
             // Nothing special to be done for other instructions.
             _ => (),

--- a/rs/embedders/tests/wasmtime_embedder.rs
+++ b/rs/embedders/tests/wasmtime_embedder.rs
@@ -1880,6 +1880,33 @@ fn wasm64_memory_copy_test() {
 }
 
 #[test]
+fn wasm64_memory_init_test() {
+    let wat = r#"
+       (module
+            (export "memory" (memory 0))
+            (func (export "canister_update test")
+                i64.const 1024  ;; target memory address
+                i32.const 0     ;; data segment offset
+                i32.const 4     ;; byte length
+                memory.init 0   ;; load passive data segment by index
+            )
+            (memory i64 1)
+            (data (;0;) "\01\02\03\04")
+    )"#;
+
+    let mut config = ic_config::embedders::Config::default();
+    config.feature_flags.wasm64 = FlagStatus::Enabled;
+    let mut instance = WasmtimeInstanceBuilder::new()
+        .with_config(config)
+        .with_wat(wat)
+        .build();
+    match instance.run(FuncRef::Method(WasmMethod::Update("test".to_string()))) {
+        Ok(_) => {}
+        Err(e) => panic!("Error: {:?}", e),
+    }
+}
+
+#[test]
 // Verify behavior of failed memory grow in wasm64 mode
 fn wasm64_handles_memory_grow_failure_test() {
     let wat = r#"


### PR DESCRIPTION
Wasm memory.init and table.init take i32 parameters also in Wasm 64-bit mode.  
This PR adjusts instrumentation such that this cases is properly handled and adds a test for it.