### PR TITLE
fix(RUN-1019): Cap Wasm64 heap memory size

### DIFF
--- a/rs/embedders/src/wasm_utils/instrumentation.rs
+++ b/rs/embedders/src/wasm_utils/instrumentation.rs
@@ -1918,8 +1918,18 @@ fn update_memories(
     let mut stable_index = 0;
 
     if let Some(mem) = module.memories.first_mut() {
-        if mem.memory64 && mem.maximum.is_none() {
-            mem.maximum = Some(MAX_WASM_MEMORY_IN_WASM_PAGES);
+        if mem.memory64 {
+            match mem.maximum {
+                Some(max) => {
+                    // In case the maximum memory size is larger than the maximum allowed, cap it.
+                    if max > MAX_WASM_MEMORY_IN_WASM_PAGES {
+                        mem.maximum = Some(MAX_WASM_MEMORY_IN_WASM_PAGES);
+                    }
+                }
+                None => {
+                    mem.maximum = Some(MAX_WASM_MEMORY_IN_WASM_PAGES);
+                }
+            }
         }
     }
 

--- a/rs/embedders/src/wasmtime_embedder/host_memory.rs
+++ b/rs/embedders/src/wasmtime_embedder/host_memory.rs
@@ -67,11 +67,6 @@ unsafe impl wasmtime::MemoryCreator for WasmtimeMemoryCreator {
         let min = ty.minimum().min(max_pages) as usize;
         let max = ty.maximum().unwrap_or(max_pages).min(max_pages) as usize;
 
-        println!(
-            "Creating memory with min={} max={}, max_pages={}",
-            min, max, max_pages
-        );
-
         let Some(reserved_size) = reserved_size_in_bytes else {
             panic!(
                 "Wasmtime issued request to create a memory without specifying a reserved size."

--- a/rs/embedders/src/wasmtime_embedder/host_memory.rs
+++ b/rs/embedders/src/wasmtime_embedder/host_memory.rs
@@ -67,6 +67,11 @@ unsafe impl wasmtime::MemoryCreator for WasmtimeMemoryCreator {
         let min = ty.minimum().min(max_pages) as usize;
         let max = ty.maximum().unwrap_or(max_pages).min(max_pages) as usize;
 
+        println!(
+            "Creating memory with min={} max={}, max_pages={}",
+            min, max, max_pages
+        );
+
         let Some(reserved_size) = reserved_size_in_bytes else {
             panic!(
                 "Wasmtime issued request to create a memory without specifying a reserved size."

--- a/rs/embedders/tests/wasmtime_embedder.rs
+++ b/rs/embedders/tests/wasmtime_embedder.rs
@@ -2733,3 +2733,22 @@ fn wasm64_cycles_burn128() {
 
     assert_eq!(wasm_heap, expected_heap);
 }
+
+#[test]
+fn large_wasm64_memory_allocation_test() {
+    let wat = r#"
+    (module
+        (func $test (export "canister_update test"))
+        (memory i64 0 16777216)
+    )"#;
+
+    let mut config = ic_config::embedders::Config::default();
+    config.feature_flags.wasm64 = FlagStatus::Enabled;
+    let mut instance = WasmtimeInstanceBuilder::new()
+        .with_config(config)
+        .with_wat(wat)
+        .build();
+    let _res = instance
+        .run(FuncRef::Method(WasmMethod::Update("test".to_string())))
+        .unwrap();
+}

--- a/rs/embedders/tests/wasmtime_embedder.rs
+++ b/rs/embedders/tests/wasmtime_embedder.rs
@@ -2748,7 +2748,9 @@ fn large_wasm64_memory_allocation_test() {
         .with_config(config)
         .with_wat(wat)
         .build();
-    let _res = instance
-        .run(FuncRef::Method(WasmMethod::Update("test".to_string())))
-        .unwrap();
+
+    match instance.run(FuncRef::Method(WasmMethod::Update("test".to_string()))) {
+        Ok(_) => {}
+        Err(e) => panic!("Unexpected error: {:?}", e),
+    }
 }


### PR DESCRIPTION
This MR caps the amount of Wasm64 heap a canister can request to 4 GiB (equal to the current Wasm32 heap size). In the future, this value will grow for Wasm64.