### PR TITLE
refactor(nervous_system): Move `Principals` message definition to nervous_system/proto

### DIFF
--- a/buf.yaml
+++ b/buf.yaml
@@ -21,6 +21,10 @@ lint:
     - DEFAULT
 breaking:
   ignore:
+    # Adding to allow us to work around the buf checker for an unreleased proto, remove ASAP
+    - ic_nns_governance/pb/v1/governance.proto
+    # Adding to allow us to work around the buf checker for an unreleased proto, remove ASAP
+    - ic_sns_swap/pb/v1/swap.proto
   use:
     - WIRE
   except:

--- a/rs/nervous_system/proto/proto/ic_nervous_system/pb/v1/nervous_system.proto
+++ b/rs/nervous_system/proto/proto/ic_nervous_system/pb/v1/nervous_system.proto
@@ -27,6 +27,12 @@ message Percentage {
   optional uint64 basis_points = 1;
 }
 
+// A list of principals.
+// Needed to allow prost to generate the equivalent of Optional<Vec<PrincipalId>>.
+message Principals {
+  repeated ic_base_types.pb.v1.PrincipalId principals = 1;
+}
+
 // A Canister that will be transferred to an SNS.
 message Canister {
   // The id of the canister.

--- a/rs/nervous_system/proto/src/gen/ic_nervous_system.pb.v1.rs
+++ b/rs/nervous_system/proto/src/gen/ic_nervous_system.pb.v1.rs
@@ -51,6 +51,15 @@ pub struct Percentage {
     #[prost(uint64, optional, tag = "1")]
     pub basis_points: ::core::option::Option<u64>,
 }
+/// A list of principals.
+/// Needed to allow prost to generate the equivalent of Optional<Vec<PrincipalId>>.
+#[derive(Eq, candid::CandidType, candid::Deserialize, comparable::Comparable, serde::Serialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Principals {
+    #[prost(message, repeated, tag = "1")]
+    pub principals: ::prost::alloc::vec::Vec<::ic_base_types::PrincipalId>,
+}
 /// A Canister that will be transferred to an SNS.
 #[derive(
     Eq,

--- a/rs/nervous_system/proto/src/lib.rs
+++ b/rs/nervous_system/proto/src/lib.rs
@@ -1,6 +1,6 @@
 use crate::pb::v1::Canister;
 use ic_base_types::PrincipalId;
-use pb::v1::{Decimal as DecimalPb, Duration, GlobalTimeOfDay, Percentage, Tokens};
+use pb::v1::{Decimal as DecimalPb, Duration, GlobalTimeOfDay, Percentage, Principals, Tokens};
 use rust_decimal::Decimal;
 use std::str::FromStr;
 
@@ -158,6 +158,18 @@ impl TryFrom<DecimalPb> for Decimal {
                 err,
             )
         })
+    }
+}
+
+impl From<Vec<PrincipalId>> for Principals {
+    fn from(principals: Vec<PrincipalId>) -> Self {
+        Self { principals }
+    }
+}
+
+impl From<Principals> for Vec<PrincipalId> {
+    fn from(principals: Principals) -> Self {
+        principals.principals
     }
 }
 

--- a/rs/nns/governance/api/src/ic_nns_governance.pb.v1.rs
+++ b/rs/nns/governance/api/src/ic_nns_governance.pb.v1.rs
@@ -3171,15 +3171,6 @@ pub mod settle_neurons_fund_participation_request {
         Aborted(Aborted),
     }
 }
-/// A list of principals.
-/// Needed to allow prost to generate the equivalent of Optional<Vec<PrincipalId>>.
-#[derive(candid::CandidType, candid::Deserialize, serde::Serialize, comparable::Comparable)]
-#[allow(clippy::derive_partial_eq_without_eq)]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct Principals {
-    #[prost(message, repeated, tag = "1")]
-    pub principals: ::prost::alloc::vec::Vec<::ic_base_types::PrincipalId>,
-}
 /// Handling the Neurons' Fund and transferring some of its maturity to an SNS treasury is
 /// thus the responsibility of the NNS Governance. When a swap succeeds, a Swap canister should send
 /// a `settle_neurons_fund_participation` request to the NNS Governance, specifying its `result`
@@ -3220,7 +3211,7 @@ pub mod settle_neurons_fund_participation_response {
         pub controller: ::core::option::Option<::ic_base_types::PrincipalId>,
         /// The principals that can vote, propose, and follow on behalf of this neuron.
         #[prost(message, optional, tag = "7")]
-        pub hotkeys: ::core::option::Option<super::Principals>,
+        pub hotkeys: ::core::option::Option<::ic_nervous_system_proto::pb::v1::Principals>,
         /// Whether the amount maturity amount of Neurons' Fund participation associated with this neuron
         /// has been capped to reflect the maximum participation amount for this SNS swap.
         #[prost(bool, optional, tag = "4")]

--- a/rs/nns/governance/proto/ic_nns_governance/pb/v1/governance.proto
+++ b/rs/nns/governance/proto/ic_nns_governance/pb/v1/governance.proto
@@ -2606,12 +2606,6 @@ message SettleNeuronsFundParticipationRequest {
   message Aborted {}
 }
 
-// A list of principals.
-// Needed to allow prost to generate the equivalent of Optional<Vec<PrincipalId>>.
-message Principals {
-  repeated ic_base_types.pb.v1.PrincipalId principals = 1;
-}
-
 // Handling the Neurons' Fund and transferring some of its maturity to an SNS treasury is
 // thus the responsibility of the NNS Governance. When a swap succeeds, a Swap canister should send
 // a `settle_neurons_fund_participation` request to the NNS Governance, specifying its `result`
@@ -2634,7 +2628,7 @@ message SettleNeuronsFundParticipationResponse {
     // The principal that can manage this neuron.
     optional ic_base_types.pb.v1.PrincipalId controller = 6;
     // The principals that can vote, propose, and follow on behalf of this neuron.
-    optional Principals hotkeys = 7;
+    optional ic_nervous_system.pb.v1.Principals hotkeys = 7;
 
     // Whether the amount maturity amount of Neurons' Fund participation associated with this neuron
     // has been capped to reflect the maximum participation amount for this SNS swap.

--- a/rs/nns/governance/src/gen/ic_nns_governance.pb.v1.rs
+++ b/rs/nns/governance/src/gen/ic_nns_governance.pb.v1.rs
@@ -3171,15 +3171,6 @@ pub mod settle_neurons_fund_participation_request {
         Aborted(Aborted),
     }
 }
-/// A list of principals.
-/// Needed to allow prost to generate the equivalent of Optional<Vec<PrincipalId>>.
-#[derive(candid::CandidType, candid::Deserialize, serde::Serialize, comparable::Comparable)]
-#[allow(clippy::derive_partial_eq_without_eq)]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct Principals {
-    #[prost(message, repeated, tag = "1")]
-    pub principals: ::prost::alloc::vec::Vec<::ic_base_types::PrincipalId>,
-}
 /// Handling the Neurons' Fund and transferring some of its maturity to an SNS treasury is
 /// thus the responsibility of the NNS Governance. When a swap succeeds, a Swap canister should send
 /// a `settle_neurons_fund_participation` request to the NNS Governance, specifying its `result`
@@ -3220,7 +3211,7 @@ pub mod settle_neurons_fund_participation_response {
         pub controller: ::core::option::Option<::ic_base_types::PrincipalId>,
         /// The principals that can vote, propose, and follow on behalf of this neuron.
         #[prost(message, optional, tag = "7")]
-        pub hotkeys: ::core::option::Option<super::Principals>,
+        pub hotkeys: ::core::option::Option<::ic_nervous_system_proto::pb::v1::Principals>,
         /// Whether the amount maturity amount of Neurons' Fund participation associated with this neuron
         /// has been capped to reflect the maximum participation amount for this SNS swap.
         #[prost(bool, optional, tag = "4")]

--- a/rs/nns/governance/src/governance.rs
+++ b/rs/nns/governance/src/governance.rs
@@ -51,9 +51,9 @@ use crate::{
         NeuronsFundAuditInfo, NeuronsFundData,
         NeuronsFundEconomics as NeuronsFundNetworkEconomicsPb,
         NeuronsFundParticipation as NeuronsFundParticipationPb,
-        NeuronsFundSnapshot as NeuronsFundSnapshotPb, NnsFunction, NodeProvider, Principals,
-        Proposal, ProposalData, ProposalInfo, ProposalRewardStatus, ProposalStatus,
-        RestoreAgingSummary, RewardEvent, RewardNodeProvider, RewardNodeProviders,
+        NeuronsFundSnapshot as NeuronsFundSnapshotPb, NnsFunction, NodeProvider, Proposal,
+        ProposalData, ProposalInfo, ProposalRewardStatus, ProposalStatus, RestoreAgingSummary,
+        RewardEvent, RewardNodeProvider, RewardNodeProviders,
         SettleNeuronsFundParticipationRequest, SettleNeuronsFundParticipationResponse, Tally,
         Topic, UpdateNodeProvider, Vote, WaitForQuietState,
         XdrConversionRate as XdrConversionRatePb,
@@ -1256,17 +1256,6 @@ impl ProposalInfo {
     }
 }
 
-impl From<Vec<PrincipalId>> for Principals {
-    fn from(principals: Vec<PrincipalId>) -> Self {
-        Self { principals }
-    }
-}
-
-impl From<Principals> for Vec<PrincipalId> {
-    fn from(principals: Principals) -> Self {
-        principals.principals
-    }
-}
 #[cfg(test)]
 mod test_wait_for_quiet {
     use crate::pb::v1::{ProposalData, Tally, WaitForQuietState};

--- a/rs/nns/governance/src/pb/conversions.rs
+++ b/rs/nns/governance/src/pb/conversions.rs
@@ -3709,21 +3709,6 @@ impl From<pb_api::settle_neurons_fund_participation_request::Result>
     }
 }
 
-impl From<pb::Principals> for pb_api::Principals {
-    fn from(item: pb::Principals) -> Self {
-        Self {
-            principals: item.principals,
-        }
-    }
-}
-impl From<pb_api::Principals> for pb::Principals {
-    fn from(item: pb_api::Principals) -> Self {
-        Self {
-            principals: item.principals,
-        }
-    }
-}
-
 impl From<pb::SettleNeuronsFundParticipationResponse>
     for pb_api::SettleNeuronsFundParticipationResponse
 {
@@ -3752,7 +3737,7 @@ impl From<pb::settle_neurons_fund_participation_response::NeuronsFundNeuron>
             nns_neuron_id: item.nns_neuron_id,
             amount_icp_e8s: item.amount_icp_e8s,
             controller: item.controller,
-            hotkeys: item.hotkeys.map(|x| x.into()),
+            hotkeys: item.hotkeys,
             is_capped: item.is_capped,
             hotkey_principal: item.hotkey_principal,
         }
@@ -3767,7 +3752,7 @@ impl From<pb_api::settle_neurons_fund_participation_response::NeuronsFundNeuron>
             nns_neuron_id: item.nns_neuron_id,
             amount_icp_e8s: item.amount_icp_e8s,
             controller: item.controller,
-            hotkeys: item.hotkeys.map(|x| x.into()),
+            hotkeys: item.hotkeys,
             is_capped: item.is_capped,
             hotkey_principal: item.hotkey_principal,
         }

--- a/rs/sns/swap/proto/ic_sns_swap/pb/v1/swap.proto
+++ b/rs/sns/swap/proto/ic_sns_swap/pb/v1/swap.proto
@@ -1156,12 +1156,6 @@ message SettleNeuronsFundParticipationRequest {
   message Aborted {}
 }
 
-// A list of principals.
-// Needed to allow prost to generate the equivalent of Optional<Vec<PrincipalId>>.
-message Principals {
-  repeated ic_base_types.pb.v1.PrincipalId principals = 1;
-}
-
 // Handling the Neurons' Fund and transferring some of its maturity to an SNS treasury is
 // thus the responsibility of the NNS Governance. When a swap succeeds, a Swap canister should send
 // a `settle_neurons_fund_participation` request to the NNS Governance, specifying its `result`
@@ -1184,7 +1178,7 @@ message SettleNeuronsFundParticipationResponse {
     // The principal that can manage this neuron.
     optional ic_base_types.pb.v1.PrincipalId controller = 6;
     // The principals that can vote, propose, and follow on behalf of this neuron.
-    optional Principals hotkeys = 7;
+    optional ic_nervous_system.pb.v1.Principals hotkeys = 7;
 
     // Whether the amount maturity amount of Neurons' Fund participation associated with this neuron
     // has been capped to reflect the maximum participation amount for this SNS swap.

--- a/rs/sns/swap/src/gen/ic_sns_swap.pb.v1.rs
+++ b/rs/sns/swap/src/gen/ic_sns_swap.pb.v1.rs
@@ -1479,15 +1479,6 @@ pub mod settle_neurons_fund_participation_request {
         Aborted(Aborted),
     }
 }
-/// A list of principals.
-/// Needed to allow prost to generate the equivalent of Optional<Vec<PrincipalId>>.
-#[derive(candid::CandidType, candid::Deserialize, serde::Serialize, comparable::Comparable)]
-#[allow(clippy::derive_partial_eq_without_eq)]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct Principals {
-    #[prost(message, repeated, tag = "1")]
-    pub principals: ::prost::alloc::vec::Vec<::ic_base_types::PrincipalId>,
-}
 /// Handling the Neurons' Fund and transferring some of its maturity to an SNS treasury is
 /// thus the responsibility of the NNS Governance. When a swap succeeds, a Swap canister should send
 /// a `settle_neurons_fund_participation` request to the NNS Governance, specifying its `result`
@@ -1528,7 +1519,7 @@ pub mod settle_neurons_fund_participation_response {
         pub controller: ::core::option::Option<::ic_base_types::PrincipalId>,
         /// The principals that can vote, propose, and follow on behalf of this neuron.
         #[prost(message, optional, tag = "7")]
-        pub hotkeys: ::core::option::Option<super::Principals>,
+        pub hotkeys: ::core::option::Option<::ic_nervous_system_proto::pb::v1::Principals>,
         /// Whether the amount maturity amount of Neurons' Fund participation associated with this neuron
         /// has been capped to reflect the maximum participation amount for this SNS swap.
         #[prost(bool, optional, tag = "4")]

--- a/rs/sns/swap/src/types.rs
+++ b/rs/sns/swap/src/types.rs
@@ -9,7 +9,7 @@ use crate::{
         sns_neuron_recipe::{ClaimedStatus, Investor},
         BuyerState, CfInvestment, CfNeuron, CfParticipant, DirectInvestment,
         ErrorRefundIcpResponse, FinalizeSwapResponse, Init, Lifecycle, NeuronId as SaleNeuronId,
-        OpenRequest, Params, Principals, SetDappControllersCallResult, SetModeCallResult,
+        OpenRequest, Params, SetDappControllersCallResult, SetModeCallResult,
         SettleNeuronsFundParticipationResult, SnsNeuronRecipe, SweepResult, TransferableAmount,
     },
     swap::is_valid_principal,
@@ -1170,18 +1170,6 @@ impl TryFrom<crate::pb::v1::settle_neurons_fund_participation_response::NeuronsF
                 nns_neuron_id, amount_icp_e8s, is_capped
             )),
         }
-    }
-}
-
-impl From<Vec<PrincipalId>> for Principals {
-    fn from(principals: Vec<PrincipalId>) -> Self {
-        Self { principals }
-    }
-}
-
-impl From<Principals> for Vec<PrincipalId> {
-    fn from(principals: Principals) -> Self {
-        principals.principals
     }
 }
 


### PR DESCRIPTION
This allows us to keep the .did files clean, and keeps our .proto files organized, and lets us deduplicate some code