### PR TITLE
feat(nns): Added visibility field to neurons.

### DIFF
--- a/rs/nns/governance/api/src/ic_nns_governance.pb.v1.rs
+++ b/rs/nns/governance/api/src/ic_nns_governance.pb.v1.rs
@@ -91,6 +91,9 @@ pub struct NeuronInfo {
     /// of the different states.
     #[prost(enumeration = "NeuronType", optional, tag = "11")]
     pub neuron_type: ::core::option::Option<i32>,
+    /// See the Visibility enum.
+    #[prost(enumeration = "Visibility", optional, tag = "12")]
+    pub visibility: ::core::option::Option<i32>,
 }
 /// A transfer performed from some account to stake a new neuron.
 #[derive(candid::CandidType, candid::Deserialize, serde::Serialize, comparable::Comparable)]
@@ -246,6 +249,9 @@ pub struct Neuron {
     /// of the different states.
     #[prost(enumeration = "NeuronType", optional, tag = "22")]
     pub neuron_type: ::core::option::Option<i32>,
+    /// See the Visibility enum.
+    #[prost(enumeration = "Visibility", optional, tag = "23")]
+    pub visibility: ::core::option::Option<i32>,
     /// At any time, at most one of `when_dissolved` and
     /// `dissolve_delay` are specified.
     ///
@@ -350,6 +356,8 @@ pub struct AbridgedNeuron {
     pub joined_community_fund_timestamp_seconds: ::core::option::Option<u64>,
     #[prost(enumeration = "NeuronType", optional, tag = "22")]
     pub neuron_type: ::core::option::Option<i32>,
+    #[prost(enumeration = "Visibility", optional, tag = "23")]
+    pub visibility: ::core::option::Option<i32>,
     #[prost(oneof = "abridged_neuron::DissolveState", tags = "9, 10")]
     pub dissolve_state: ::core::option::Option<abridged_neuron::DissolveState>,
 }
@@ -3748,6 +3756,55 @@ impl NeuronState {
             "NEURON_STATE_DISSOLVING" => Some(Self::Dissolving),
             "NEURON_STATE_DISSOLVED" => Some(Self::Dissolved),
             "NEURON_STATE_SPAWNING" => Some(Self::Spawning),
+            _ => None,
+        }
+    }
+}
+/// Controls how much information non-controller and non-hot-key principals can
+/// see about this neuron. Currently, if a neuron is private, recent_ballots and
+/// joined_community_fund_timestamp_seconds are redacted when being read by an
+/// unprivileged principal.
+///
+/// <https://forum.dfinity.org/t/request-for-comments-api-changes-for-public-private-neurons/33360>
+#[derive(
+    candid::CandidType,
+    candid::Deserialize,
+    serde::Serialize,
+    comparable::Comparable,
+    Clone,
+    Copy,
+    Debug,
+    PartialEq,
+    Eq,
+    Hash,
+    PartialOrd,
+    Ord,
+    ::prost::Enumeration,
+)]
+#[repr(i32)]
+pub enum Visibility {
+    Unspecified = 0,
+    Private = 1,
+    Public = 2,
+}
+impl Visibility {
+    /// String value of the enum field names used in the ProtoBuf definition.
+    ///
+    /// The values are not transformed in any way and thus are considered stable
+    /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+    pub fn as_str_name(&self) -> &'static str {
+        match self {
+            Visibility::Unspecified => "VISIBILITY_UNSPECIFIED",
+            Visibility::Private => "VISIBILITY_PRIVATE",
+            Visibility::Public => "VISIBILITY_PUBLIC",
+        }
+    }
+    /// Creates an enum from field names used in the ProtoBuf definition.
+    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+        match value {
+            "VISIBILITY_UNSPECIFIED" => Some(Self::Unspecified),
+            "VISIBILITY_PRIVATE" => Some(Self::Private),
+            "VISIBILITY_PUBLIC" => Some(Self::Public),
             _ => None,
         }
     }

--- a/rs/nns/governance/api/src/ic_nns_governance.pb.v1.rs
+++ b/rs/nns/governance/api/src/ic_nns_governance.pb.v1.rs
@@ -3766,6 +3766,9 @@ impl NeuronState {
 /// unprivileged principal.
 ///
 /// <https://forum.dfinity.org/t/request-for-comments-api-changes-for-public-private-neurons/33360>
+///
+/// As of Jul 19, this is not yet enforced, but will be once the plan described
+/// above is fully executed.
 #[derive(
     candid::CandidType,
     candid::Deserialize,

--- a/rs/nns/governance/canister/governance.did
+++ b/rs/nns/governance/canister/governance.did
@@ -366,6 +366,7 @@ type Neuron = record {
   dissolve_state : opt DissolveState;
   followees : vec record { int32; Followees };
   neuron_fees_e8s : nat64;
+  visibility : opt int32;
   transfer : opt NeuronStakeTransfer;
   known_neuron_data : opt KnownNeuronData;
   spawn_at_timestamp_seconds : opt nat64;
@@ -400,6 +401,7 @@ type NeuronInfo = record {
   stake_e8s : nat64;
   joined_community_fund_timestamp_seconds : opt nat64;
   retrieved_at_timestamp_seconds : nat64;
+  visibility : opt int32;
   known_neuron_data : opt KnownNeuronData;
   voting_power : nat64;
   age_seconds : nat64;

--- a/rs/nns/governance/canister/governance_test.did
+++ b/rs/nns/governance/canister/governance_test.did
@@ -366,6 +366,7 @@ type Neuron = record {
   dissolve_state : opt DissolveState;
   followees : vec record { int32; Followees };
   neuron_fees_e8s : nat64;
+  visibility : opt int32;
   transfer : opt NeuronStakeTransfer;
   known_neuron_data : opt KnownNeuronData;
   spawn_at_timestamp_seconds : opt nat64;
@@ -400,6 +401,7 @@ type NeuronInfo = record {
   stake_e8s : nat64;
   joined_community_fund_timestamp_seconds : opt nat64;
   retrieved_at_timestamp_seconds : nat64;
+  visibility : opt int32;
   known_neuron_data : opt KnownNeuronData;
   voting_power : nat64;
   age_seconds : nat64;

--- a/rs/nns/governance/proto/ic_nns_governance/pb/v1/governance.proto
+++ b/rs/nns/governance/proto/ic_nns_governance/pb/v1/governance.proto
@@ -201,6 +201,9 @@ message BallotInfo {
 // unprivileged principal.
 //
 // https://forum.dfinity.org/t/request-for-comments-api-changes-for-public-private-neurons/33360
+//
+// As of Jul 19, this is not yet enforced, but will be once the plan described
+// above is fully executed.
 enum Visibility {
   VISIBILITY_UNSPECIFIED = 0;
   VISIBILITY_PRIVATE = 1;

--- a/rs/nns/governance/proto/ic_nns_governance/pb/v1/governance.proto
+++ b/rs/nns/governance/proto/ic_nns_governance/pb/v1/governance.proto
@@ -195,6 +195,18 @@ message BallotInfo {
   Vote vote = 2;
 }
 
+// Controls how much information non-controller and non-hot-key principals can
+// see about this neuron. Currently, if a neuron is private, recent_ballots and
+// joined_community_fund_timestamp_seconds are redacted when being read by an
+// unprivileged principal.
+//
+// https://forum.dfinity.org/t/request-for-comments-api-changes-for-public-private-neurons/33360
+enum Visibility {
+  VISIBILITY_UNSPECIFIED = 0;
+  VISIBILITY_PRIVATE = 1;
+  VISIBILITY_PUBLIC = 2;
+}
+
 // The result of querying for the state of a single neuron.
 message NeuronInfo {
   // The exact time at which this data was computed. This means, for
@@ -229,6 +241,8 @@ message NeuronInfo {
   // The type of the Neuron. See [NeuronType] for a description
   // of the different states.
   optional NeuronType neuron_type = 11;
+  // See the Visibility enum.
+  optional Visibility visibility = 12;
 }
 
 // A transfer performed from some account to stake a new neuron.
@@ -409,6 +423,9 @@ message Neuron {
   // The type of the Neuron. See [NeuronType] for a description
   // of the different states.
   optional NeuronType neuron_type = 22;
+
+  // See the Visibility enum.
+  optional Visibility visibility = 23;
 }
 
 // Subset of Neuron that has no collections or big fields that might not exist in most neurons, and
@@ -433,6 +450,7 @@ message AbridgedNeuron {
   bool not_for_profit = 16;
   optional uint64 joined_community_fund_timestamp_seconds = 17;
   optional NeuronType neuron_type = 22;
+  optional Visibility visibility = 23;
 
   reserved 1;
   reserved "id";

--- a/rs/nns/governance/src/gen/ic_nns_governance.pb.v1.rs
+++ b/rs/nns/governance/src/gen/ic_nns_governance.pb.v1.rs
@@ -91,6 +91,9 @@ pub struct NeuronInfo {
     /// of the different states.
     #[prost(enumeration = "NeuronType", optional, tag = "11")]
     pub neuron_type: ::core::option::Option<i32>,
+    /// See the Visibility enum.
+    #[prost(enumeration = "Visibility", optional, tag = "12")]
+    pub visibility: ::core::option::Option<i32>,
 }
 /// A transfer performed from some account to stake a new neuron.
 #[derive(candid::CandidType, candid::Deserialize, serde::Serialize, comparable::Comparable)]
@@ -246,6 +249,9 @@ pub struct Neuron {
     /// of the different states.
     #[prost(enumeration = "NeuronType", optional, tag = "22")]
     pub neuron_type: ::core::option::Option<i32>,
+    /// See the Visibility enum.
+    #[prost(enumeration = "Visibility", optional, tag = "23")]
+    pub visibility: ::core::option::Option<i32>,
     /// At any time, at most one of `when_dissolved` and
     /// `dissolve_delay` are specified.
     ///
@@ -350,6 +356,8 @@ pub struct AbridgedNeuron {
     pub joined_community_fund_timestamp_seconds: ::core::option::Option<u64>,
     #[prost(enumeration = "NeuronType", optional, tag = "22")]
     pub neuron_type: ::core::option::Option<i32>,
+    #[prost(enumeration = "Visibility", optional, tag = "23")]
+    pub visibility: ::core::option::Option<i32>,
     #[prost(oneof = "abridged_neuron::DissolveState", tags = "9, 10")]
     pub dissolve_state: ::core::option::Option<abridged_neuron::DissolveState>,
 }
@@ -3748,6 +3756,55 @@ impl NeuronState {
             "NEURON_STATE_DISSOLVING" => Some(Self::Dissolving),
             "NEURON_STATE_DISSOLVED" => Some(Self::Dissolved),
             "NEURON_STATE_SPAWNING" => Some(Self::Spawning),
+            _ => None,
+        }
+    }
+}
+/// Controls how much information non-controller and non-hot-key principals can
+/// see about this neuron. Currently, if a neuron is private, recent_ballots and
+/// joined_community_fund_timestamp_seconds are redacted when being read by an
+/// unprivileged principal.
+///
+/// <https://forum.dfinity.org/t/request-for-comments-api-changes-for-public-private-neurons/33360>
+#[derive(
+    candid::CandidType,
+    candid::Deserialize,
+    serde::Serialize,
+    comparable::Comparable,
+    Clone,
+    Copy,
+    Debug,
+    PartialEq,
+    Eq,
+    Hash,
+    PartialOrd,
+    Ord,
+    ::prost::Enumeration,
+)]
+#[repr(i32)]
+pub enum Visibility {
+    Unspecified = 0,
+    Private = 1,
+    Public = 2,
+}
+impl Visibility {
+    /// String value of the enum field names used in the ProtoBuf definition.
+    ///
+    /// The values are not transformed in any way and thus are considered stable
+    /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+    pub fn as_str_name(&self) -> &'static str {
+        match self {
+            Visibility::Unspecified => "VISIBILITY_UNSPECIFIED",
+            Visibility::Private => "VISIBILITY_PRIVATE",
+            Visibility::Public => "VISIBILITY_PUBLIC",
+        }
+    }
+    /// Creates an enum from field names used in the ProtoBuf definition.
+    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+        match value {
+            "VISIBILITY_UNSPECIFIED" => Some(Self::Unspecified),
+            "VISIBILITY_PRIVATE" => Some(Self::Private),
+            "VISIBILITY_PUBLIC" => Some(Self::Public),
             _ => None,
         }
     }

--- a/rs/nns/governance/src/gen/ic_nns_governance.pb.v1.rs
+++ b/rs/nns/governance/src/gen/ic_nns_governance.pb.v1.rs
@@ -3766,6 +3766,9 @@ impl NeuronState {
 /// unprivileged principal.
 ///
 /// <https://forum.dfinity.org/t/request-for-comments-api-changes-for-public-private-neurons/33360>
+///
+/// As of Jul 19, this is not yet enforced, but will be once the plan described
+/// above is fully executed.
 #[derive(
     candid::CandidType,
     candid::Deserialize,

--- a/rs/nns/governance/src/neuron/types.rs
+++ b/rs/nns/governance/src/neuron/types.rs
@@ -12,7 +12,7 @@ use crate::{
         neuron::{DissolveState as NeuronDissolveState, Followees},
         AbridgedNeuron, Ballot, BallotInfo, GovernanceError, KnownNeuronData,
         Neuron as NeuronProto, NeuronInfo, NeuronStakeTransfer, NeuronState, NeuronType, Topic,
-        Vote,
+        Visibility, Vote,
     },
 };
 #[cfg(target_arch = "wasm32")]
@@ -112,7 +112,7 @@ pub struct Neuron {
     pub neuron_type: Option<i32>,
     /// How much unprivileged principals (i.e. is neither controller, nor
     /// hotkey) can see about this neuron.
-    pub visibility: Option<crate::pb::v1::Visibility>,
+    pub visibility: Option<Visibility>,
 }
 
 impl Neuron {
@@ -952,7 +952,7 @@ impl TryFrom<NeuronProto> for Neuron {
             aging_since_timestamp_seconds,
         })?;
         let visibility =
-            visibility.and_then(|visibility| crate::pb::v1::Visibility::try_from(visibility).ok());
+            visibility.and_then(|visibility| Visibility::try_from(visibility).ok());
 
         Ok(Neuron {
             id,
@@ -1156,7 +1156,7 @@ impl From<DecomposedNeuron> for Neuron {
         })
         .expect("Neuron dissolve state and age is invalid");
         let visibility =
-            visibility.and_then(|visibility| crate::pb::v1::Visibility::try_from(visibility).ok());
+            visibility.and_then(|visibility| Visibility::try_from(visibility).ok());
 
         Neuron {
             id,

--- a/rs/nns/governance/src/neuron/types.rs
+++ b/rs/nns/governance/src/neuron/types.rs
@@ -953,13 +953,12 @@ impl TryFrom<NeuronProto> for Neuron {
         })?;
         let visibility = match visibility {
             None => None,
-            Some(visibility) => {
-                Some(Visibility::try_from(visibility)
-                    .map_err(|err| format!(
-                        "Failed to interpret visibility of neuron {:?}: {:?}",
-                        id, err,
-                    ))?)
-            }
+            Some(visibility) => Some(Visibility::try_from(visibility).map_err(|err| {
+                format!(
+                    "Failed to interpret visibility of neuron {:?}: {:?}",
+                    id, err,
+                )
+            })?),
         };
 
         Ok(Neuron {
@@ -1163,8 +1162,7 @@ impl From<DecomposedNeuron> for Neuron {
             aging_since_timestamp_seconds,
         })
         .expect("Neuron dissolve state and age is invalid");
-        let visibility =
-            visibility.and_then(|visibility| Visibility::try_from(visibility).ok());
+        let visibility = visibility.and_then(|visibility| Visibility::try_from(visibility).ok());
 
         Neuron {
             id,

--- a/rs/nns/governance/src/neuron/types.rs
+++ b/rs/nns/governance/src/neuron/types.rs
@@ -647,7 +647,7 @@ impl Neuron {
 
     /// Get the 'public' information associated with this neuron.
     pub fn get_neuron_info(&self, now_seconds: u64) -> NeuronInfo {
-        // TODO(DO NOT MERGE): Enforce visibility.
+        // TODO(NNS1-3076): Enforce visibility.
         NeuronInfo {
             retrieved_at_timestamp_seconds: now_seconds,
             state: self.state(now_seconds) as i32,

--- a/rs/nns/governance/src/neuron/types.rs
+++ b/rs/nns/governance/src/neuron/types.rs
@@ -110,6 +110,9 @@ pub struct Neuron {
     /// The type of the Neuron. See \[NeuronType\] for a description
     /// of the different states.
     pub neuron_type: Option<i32>,
+    /// How much unprivileged principals (i.e. is neither controller, nor
+    /// hotkey) can see about this neuron.
+    pub visibility: Option<crate::pb::v1::Visibility>,
 }
 
 impl Neuron {
@@ -644,6 +647,7 @@ impl Neuron {
 
     /// Get the 'public' information associated with this neuron.
     pub fn get_neuron_info(&self, now_seconds: u64) -> NeuronInfo {
+        // TODO(DO NOT MERGE): Enforce visibility.
         NeuronInfo {
             retrieved_at_timestamp_seconds: now_seconds,
             state: self.state(now_seconds) as i32,
@@ -656,6 +660,7 @@ impl Neuron {
             joined_community_fund_timestamp_seconds: self.joined_community_fund_timestamp_seconds,
             known_neuron_data: self.known_neuron_data.clone(),
             neuron_type: self.neuron_type,
+            visibility: self.visibility.map(|visibility| visibility as i32),
         }
     }
 
@@ -870,6 +875,7 @@ impl From<Neuron> for NeuronProto {
             joined_community_fund_timestamp_seconds,
             known_neuron_data,
             neuron_type,
+            visibility,
         } = neuron;
 
         let id = Some(id);
@@ -879,6 +885,7 @@ impl From<Neuron> for NeuronProto {
             dissolve_state,
             aging_since_timestamp_seconds,
         } = StoredDissolveStateAndAge::from(dissolve_state_and_age);
+        let visibility = visibility.map(|visibility| visibility as i32);
 
         NeuronProto {
             id,
@@ -902,6 +909,7 @@ impl From<Neuron> for NeuronProto {
             joined_community_fund_timestamp_seconds,
             known_neuron_data,
             neuron_type,
+            visibility,
         }
     }
 }
@@ -932,6 +940,7 @@ impl TryFrom<NeuronProto> for Neuron {
             joined_community_fund_timestamp_seconds,
             known_neuron_data,
             neuron_type,
+            visibility,
         } = proto;
 
         let id = id.ok_or("Neuron ID is missing")?;
@@ -942,6 +951,8 @@ impl TryFrom<NeuronProto> for Neuron {
             dissolve_state,
             aging_since_timestamp_seconds,
         })?;
+        let visibility =
+            visibility.and_then(|visibility| crate::pb::v1::Visibility::try_from(visibility).ok());
 
         Ok(Neuron {
             id,
@@ -964,6 +975,7 @@ impl TryFrom<NeuronProto> for Neuron {
             joined_community_fund_timestamp_seconds,
             known_neuron_data,
             neuron_type,
+            visibility,
         })
     }
 }
@@ -1055,6 +1067,7 @@ impl TryFrom<Neuron> for DecomposedNeuron {
             joined_community_fund_timestamp_seconds,
             known_neuron_data,
             neuron_type,
+            visibility,
         } = source;
 
         let account = subaccount.to_vec();
@@ -1064,6 +1077,7 @@ impl TryFrom<Neuron> for DecomposedNeuron {
             aging_since_timestamp_seconds,
         } = StoredDissolveStateAndAge::from(dissolve_state_and_age);
         let dissolve_state = dissolve_state.map(AbridgedNeuronDissolveState::from);
+        let visibility = visibility.map(|visibility| visibility as i32);
 
         let main = AbridgedNeuron {
             account,
@@ -1081,6 +1095,7 @@ impl TryFrom<Neuron> for DecomposedNeuron {
             joined_community_fund_timestamp_seconds,
             neuron_type,
             dissolve_state,
+            visibility,
         };
 
         Ok(Self {
@@ -1129,6 +1144,7 @@ impl From<DecomposedNeuron> for Neuron {
             joined_community_fund_timestamp_seconds,
             neuron_type,
             dissolve_state,
+            visibility,
         } = main;
 
         let subaccount =
@@ -1139,6 +1155,8 @@ impl From<DecomposedNeuron> for Neuron {
             aging_since_timestamp_seconds,
         })
         .expect("Neuron dissolve state and age is invalid");
+        let visibility =
+            visibility.and_then(|visibility| crate::pb::v1::Visibility::try_from(visibility).ok());
 
         Neuron {
             id,
@@ -1161,6 +1179,7 @@ impl From<DecomposedNeuron> for Neuron {
             joined_community_fund_timestamp_seconds,
             known_neuron_data,
             neuron_type,
+            visibility,
         }
     }
 }
@@ -1394,6 +1413,7 @@ impl NeuronBuilder {
         let staked_maturity_e8s_equivalent = None;
         #[cfg(not(test))]
         let known_neuron_data = None;
+        let visibility = None; // Behave like before we added visibility.
 
         Neuron {
             id,
@@ -1416,6 +1436,7 @@ impl NeuronBuilder {
             joined_community_fund_timestamp_seconds,
             known_neuron_data,
             neuron_type,
+            visibility,
         }
     }
 }
@@ -1617,6 +1638,7 @@ mod tests {
             dissolve_state: Some(AbridgedNeuronDissolveState::WhenDissolvedTimestampSeconds(
                 u64::MAX,
             )),
+            visibility: None,
         };
 
         assert!(abridged_neuron.encoded_len() as u32 <= AbridgedNeuron::BOUND.max_size());

--- a/rs/nns/governance/src/neuron/types.rs
+++ b/rs/nns/governance/src/neuron/types.rs
@@ -951,8 +951,16 @@ impl TryFrom<NeuronProto> for Neuron {
             dissolve_state,
             aging_since_timestamp_seconds,
         })?;
-        let visibility =
-            visibility.and_then(|visibility| Visibility::try_from(visibility).ok());
+        let visibility = match visibility {
+            None => None,
+            Some(visibility) => {
+                Some(Visibility::try_from(visibility)
+                    .map_err(|err| format!(
+                        "Failed to interpret visibility of neuron {:?}: {:?}",
+                        id, err,
+                    ))?)
+            }
+        };
 
         Ok(Neuron {
             id,

--- a/rs/nns/governance/src/pb/conversions.rs
+++ b/rs/nns/governance/src/pb/conversions.rs
@@ -64,6 +64,7 @@ impl From<pb::NeuronInfo> for pb_api::NeuronInfo {
             joined_community_fund_timestamp_seconds: item.joined_community_fund_timestamp_seconds,
             known_neuron_data: item.known_neuron_data.map(|x| x.into()),
             neuron_type: item.neuron_type,
+            visibility: item.visibility,
         }
     }
 }
@@ -81,6 +82,7 @@ impl From<pb_api::NeuronInfo> for pb::NeuronInfo {
             joined_community_fund_timestamp_seconds: item.joined_community_fund_timestamp_seconds,
             known_neuron_data: item.known_neuron_data.map(|x| x.into()),
             neuron_type: item.neuron_type,
+            visibility: item.visibility,
         }
     }
 }
@@ -140,6 +142,7 @@ impl From<pb::Neuron> for pb_api::Neuron {
             known_neuron_data: item.known_neuron_data.map(|x| x.into()),
             neuron_type: item.neuron_type,
             dissolve_state: item.dissolve_state.map(|x| x.into()),
+            visibility: item.visibility,
         }
     }
 }
@@ -171,6 +174,7 @@ impl From<pb_api::Neuron> for pb::Neuron {
             known_neuron_data: item.known_neuron_data.map(|x| x.into()),
             neuron_type: item.neuron_type,
             dissolve_state: item.dissolve_state.map(|x| x.into()),
+            visibility: item.visibility,
         }
     }
 }
@@ -215,6 +219,26 @@ impl From<pb_api::neuron::DissolveState> for pb::neuron::DissolveState {
     }
 }
 
+impl From<pb::Visibility> for pb_api::Visibility {
+    fn from(item: pb::Visibility) -> Self {
+        match item {
+            pb::Visibility::Unspecified => pb_api::Visibility::Unspecified,
+            pb::Visibility::Private => pb_api::Visibility::Private,
+            pb::Visibility::Public => pb_api::Visibility::Public,
+        }
+    }
+}
+
+impl From<pb_api::Visibility> for pb::Visibility {
+    fn from(item: pb_api::Visibility) -> Self {
+        match item {
+            pb_api::Visibility::Unspecified => pb::Visibility::Unspecified,
+            pb_api::Visibility::Private => pb::Visibility::Private,
+            pb_api::Visibility::Public => pb::Visibility::Public,
+        }
+    }
+}
+
 impl From<pb::AbridgedNeuron> for pb_api::AbridgedNeuron {
     fn from(item: pb::AbridgedNeuron) -> Self {
         Self {
@@ -233,6 +257,7 @@ impl From<pb::AbridgedNeuron> for pb_api::AbridgedNeuron {
             joined_community_fund_timestamp_seconds: item.joined_community_fund_timestamp_seconds,
             neuron_type: item.neuron_type,
             dissolve_state: item.dissolve_state.map(|x| x.into()),
+            visibility: item.visibility,
         }
     }
 }
@@ -254,6 +279,7 @@ impl From<pb_api::AbridgedNeuron> for pb::AbridgedNeuron {
             joined_community_fund_timestamp_seconds: item.joined_community_fund_timestamp_seconds,
             neuron_type: item.neuron_type,
             dissolve_state: item.dissolve_state.map(|x| x.into()),
+            visibility: item.visibility,
         }
     }
 }

--- a/rs/nns/governance/src/storage/neurons/neurons_tests.rs
+++ b/rs/nns/governance/src/storage/neurons/neurons_tests.rs
@@ -504,6 +504,7 @@ fn test_abridged_neuron_size() {
         joined_community_fund_timestamp_seconds: Some(u64::MAX),
         neuron_type: Some(i32::MAX),
         dissolve_state: Some(DissolveState::WhenDissolvedTimestampSeconds(u64::MAX)),
+        visibility: None,
     };
 
     assert!(abridged_neuron.encoded_len() as u32 <= AbridgedNeuron::BOUND.max_size());

--- a/rs/nns/integration_tests/test_canisters/governance_mem_test_canister.rs
+++ b/rs/nns/integration_tests/test_canisters/governance_mem_test_canister.rs
@@ -314,6 +314,7 @@ fn allocate_neuron(id: u64) -> Neuron {
         known_neuron_data: None,
         spawn_at_timestamp_seconds: None,
         neuron_type: None,
+        visibility: None,
     }
 }
 


### PR DESCRIPTION
This just adds the ability to read the visibility of a neuron. There is not yet the ability to set it. Nor is this enforced.

This follows the plan described [here](https://forum.dfinity.org/t/request-for-comments-api-changes-for-public-private-neurons/33360).

Closes [NNS1-3072](https://dfinity.atlassian.net/browse/NNS1-3072).

[Next PR >>](https://github.com/dfinity/ic/pull/488)

[NNS1-3072]: https://dfinity.atlassian.net/browse/NNS1-3072?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ