### PR TITLE
refactor: remove registry version from tls config interface

### DIFF
--- a/rs/crypto/src/tls/rustls/cert_resolver.rs
+++ b/rs/crypto/src/tls/rustls/cert_resolver.rs
@@ -1,3 +1,6 @@
+use ic_crypto_internal_csp::{key_id::KeyId, TlsHandshakeCspVault};
+use ic_interfaces_registry::RegistryClient;
+use ic_types::NodeId;
 use rustls::{
     client::ResolvesClientCert,
     server::{ClientHello, ResolvesServerCert},
@@ -6,6 +9,10 @@ use rustls::{
 };
 use std::fmt::{Debug, Formatter};
 use std::sync::Arc;
+
+use crate::tls::tls_cert_from_registry;
+
+use super::{certified_key, csp_server_signing_key::CspServerEd25519SigningKey};
 
 #[cfg(test)]
 mod tests;
@@ -16,43 +23,55 @@ mod tests;
 /// scheme. All other factors factors such as server-supplied acceptable issuers
 /// on the client side or details of the `ClientHello` on the server side are
 /// ignored.
-pub struct StaticCertResolver {
-    certified_key: Arc<CertifiedKey>,
-    sig_scheme: SignatureScheme,
+pub struct RegistryCertResolver {
+    node_id: NodeId,
+    registry_client: Arc<dyn RegistryClient>,
+    tls_csp_vault: Arc<dyn TlsHandshakeCspVault>,
 }
 
-impl StaticCertResolver {
+impl Debug for RegistryCertResolver {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "RegistryCertResolver")
+    }
+}
+
+impl RegistryCertResolver {
     /// Creates a new `StaticCertResolver`.
     ///
     /// Returns an error if `certified_key` is incompatible with `sig_scheme`.
     pub fn new(
-        certified_key: CertifiedKey,
-        sig_scheme: SignatureScheme,
-    ) -> Result<Self, KeyIncompatibleWithSigSchemeError> {
-        if certified_key.key.choose_scheme(&[sig_scheme]).is_none() {
-            return Err(KeyIncompatibleWithSigSchemeError {});
+        node_id: NodeId,
+        registry_client: Arc<dyn RegistryClient>,
+        tls_csp_vault: Arc<dyn TlsHandshakeCspVault>,
+    ) -> Self {
+        Self {
+            node_id,
+            registry_client,
+            tls_csp_vault,
         }
-        Ok(Self {
-            certified_key: Arc::new(certified_key),
-            sig_scheme,
-        })
     }
 }
 
-/// Occurs if a certified key is incompatible with a signature scheme.
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
-pub struct KeyIncompatibleWithSigSchemeError {}
-
-impl ResolvesClientCert for StaticCertResolver {
+impl ResolvesClientCert for RegistryCertResolver {
     fn resolve(
         &self,
         _acceptable_issuers: &[&[u8]],
         sigschemes: &[SignatureScheme],
     ) -> Option<Arc<CertifiedKey>> {
-        if !sigschemes.contains(&self.sig_scheme) {
+        if !sigschemes.contains(&SignatureScheme::ED25519) {
             return None;
         }
-        Some(Arc::clone(&self.certified_key))
+        let self_tls_cert = tls_cert_from_registry(
+            self.registry_client.as_ref(),
+            self.node_id,
+            self.registry_client.get_latest_version(),
+        )
+        .ok()?;
+        let self_tls_cert_key_id = KeyId::try_from(&self_tls_cert).ok()?;
+        let ed25519_signing_key =
+            CspServerEd25519SigningKey::new(self_tls_cert_key_id, self.tls_csp_vault.clone());
+        let certified_key = certified_key(self_tls_cert, ed25519_signing_key);
+        Some(Arc::new(certified_key))
     }
 
     fn has_certs(&self) -> bool {
@@ -60,24 +79,24 @@ impl ResolvesClientCert for StaticCertResolver {
     }
 }
 
-impl ResolvesServerCert for StaticCertResolver {
+impl ResolvesServerCert for RegistryCertResolver {
     fn resolve(&self, client_hello: ClientHello) -> Option<Arc<CertifiedKey>> {
-        if !client_hello.signature_schemes().contains(&self.sig_scheme) {
+        if !client_hello
+            .signature_schemes()
+            .contains(&SignatureScheme::ED25519)
+        {
             return None;
         }
-        Some(Arc::clone(&self.certified_key))
-    }
-}
-
-impl Debug for StaticCertResolver {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "StaticCertResolver{{ \
-                certified_key: CertifiedKey{{ cert: {:?}, key: OMITTED, ocsp: {:?} }}, \
-                sig_scheme: {:?} \
-            }}",
-            self.certified_key.cert, self.certified_key.ocsp, self.sig_scheme
+        let self_tls_cert = tls_cert_from_registry(
+            self.registry_client.as_ref(),
+            self.node_id,
+            self.registry_client.get_latest_version(),
         )
+        .ok()?;
+        let self_tls_cert_key_id = KeyId::try_from(&self_tls_cert).ok()?;
+        let ed25519_signing_key =
+            CspServerEd25519SigningKey::new(self_tls_cert_key_id, self.tls_csp_vault.clone());
+        let certified_key = certified_key(self_tls_cert, ed25519_signing_key);
+        Some(Arc::new(certified_key))
     }
 }

--- a/rs/crypto/src/tls/rustls/cert_resolver/tests.rs
+++ b/rs/crypto/src/tls/rustls/cert_resolver/tests.rs
@@ -1,6 +1,5 @@
 #![allow(clippy::unwrap_used)]
 use crate::tls::rustls::cert_resolver::KeyIncompatibleWithSigSchemeError;
-use crate::tls::rustls::cert_resolver::StaticCertResolver;
 use assert_matches::assert_matches;
 use rustls::{
     pki_types::CertificateDer,

--- a/rs/crypto/src/tls/rustls/client_handshake.rs
+++ b/rs/crypto/src/tls/rustls/client_handshake.rs
@@ -1,62 +1,52 @@
-use crate::tls::rustls::cert_resolver::StaticCertResolver;
-use crate::tls::rustls::certified_key;
-use crate::tls::rustls::csp_server_signing_key::CspServerEd25519SigningKey;
+use std::sync::Arc;
+
 use crate::tls::rustls::node_cert_verifier::NodeServerCertVerifier;
-use crate::tls::tls_cert_from_registry;
-use ic_crypto_internal_csp::api::CspTlsHandshakeSignerProvider;
-use ic_crypto_internal_csp::key_id::KeyId;
-use ic_crypto_tls_interfaces::{SomeOrAllNodes, TlsConfigError};
+use ic_crypto_internal_csp::{api::CspTlsHandshakeSignerProvider, TlsHandshakeCspVault};
+use ic_crypto_tls_interfaces::SomeOrAllNodes;
 use ic_interfaces_registry::RegistryClient;
-use ic_types::{NodeId, RegistryVersion};
+use ic_types::NodeId;
 use rustls::{
     client::ResolvesClientCert,
     crypto::ring::cipher_suite::{TLS13_AES_128_GCM_SHA256, TLS13_AES_256_GCM_SHA384},
-    sign::CertifiedKey,
     version::TLS13,
-    ClientConfig, SignatureScheme,
+    ClientConfig,
 };
-use std::sync::Arc;
+
+use super::cert_resolver::RegistryCertResolver;
 
 pub fn client_config<P: CspTlsHandshakeSignerProvider>(
     signer_provider: &P,
     self_node_id: NodeId,
     registry_client: Arc<dyn RegistryClient>,
     server: NodeId,
-    registry_version: RegistryVersion,
-) -> Result<ClientConfig, TlsConfigError> {
-    let self_tls_cert =
-        tls_cert_from_registry(registry_client.as_ref(), self_node_id, registry_version)?;
-    let self_tls_cert_key_id = KeyId::try_from(&self_tls_cert).map_err(|error| {
-        TlsConfigError::MalformedSelfCertificate {
-            internal_error: format!("Cannot instantiate KeyId: {:?}", error),
-        }
-    })?;
-    let ed25519_signing_key =
-        CspServerEd25519SigningKey::new(self_tls_cert_key_id, signer_provider.handshake_signer());
+) -> ClientConfig {
     let server_cert_verifier = NodeServerCertVerifier::new(
         SomeOrAllNodes::new_with_single_node(server),
-        registry_client,
-        registry_version,
+        registry_client.clone(),
     );
     let mut ring_crypto_provider = rustls::crypto::ring::default_provider();
     ring_crypto_provider.cipher_suites = vec![TLS13_AES_256_GCM_SHA384, TLS13_AES_128_GCM_SHA256];
 
-    Ok(
-        ClientConfig::builder_with_provider(Arc::new(ring_crypto_provider))
-            .with_protocol_versions(&[&TLS13])
-            .expect("Valid rustls client config.")
-            .dangerous()
-            .with_custom_certificate_verifier(Arc::new(server_cert_verifier))
-            .with_client_cert_resolver(static_cert_resolver(
-                certified_key(self_tls_cert, ed25519_signing_key),
-                SignatureScheme::ED25519,
-            )),
-    )
+    ClientConfig::builder_with_provider(Arc::new(ring_crypto_provider))
+        .with_protocol_versions(&[&TLS13])
+        .expect("Valid rustls client config.")
+        .dangerous()
+        .with_custom_certificate_verifier(Arc::new(server_cert_verifier))
+        .with_client_cert_resolver(registry_cert_resolver(
+            self_node_id,
+            registry_client,
+            signer_provider.handshake_signer(),
+        ))
 }
 
-fn static_cert_resolver(key: CertifiedKey, scheme: SignatureScheme) -> Arc<dyn ResolvesClientCert> {
-    Arc::new(StaticCertResolver::new(key, scheme).expect(
-        "Failed to create the static cert resolver because the signing key referenced \
-        in the certified key is incompatible with the signature scheme. This is an implementation error.",
+fn registry_cert_resolver(
+    node_id: NodeId,
+    registry_client: Arc<dyn RegistryClient>,
+    tls_csp_vault: Arc<dyn TlsHandshakeCspVault>,
+) -> Arc<dyn ResolvesClientCert> {
+    Arc::new(RegistryCertResolver::new(
+        node_id,
+        registry_client,
+        tls_csp_vault,
     ))
 }

--- a/rs/crypto/src/tls/rustls/server_handshake.rs
+++ b/rs/crypto/src/tls/rustls/server_handshake.rs
@@ -1,78 +1,55 @@
-use crate::tls::rustls::cert_resolver::StaticCertResolver;
-use crate::tls::rustls::certified_key;
-use crate::tls::rustls::csp_server_signing_key::CspServerEd25519SigningKey;
 use crate::tls::rustls::node_cert_verifier::NodeClientCertVerifier;
-use crate::tls::tls_cert_from_registry;
-use ic_crypto_internal_csp::api::CspTlsHandshakeSignerProvider;
-use ic_crypto_internal_csp::key_id::KeyId;
-use ic_crypto_tls_interfaces::{SomeOrAllNodes, TlsConfigError, TlsPublicKeyCert};
+use ic_crypto_internal_csp::{api::CspTlsHandshakeSignerProvider, TlsHandshakeCspVault};
+use ic_crypto_tls_interfaces::SomeOrAllNodes;
 use ic_interfaces_registry::RegistryClient;
-use ic_types::{NodeId, RegistryVersion};
+use ic_types::NodeId;
 use rustls::{
     crypto::ring::cipher_suite::{TLS13_AES_128_GCM_SHA256, TLS13_AES_256_GCM_SHA384},
     server::{danger::ClientCertVerifier, NoClientAuth, ResolvesServerCert},
-    sign::CertifiedKey,
     version::TLS13,
-    ServerConfig, SignatureScheme,
+    ServerConfig,
 };
 use std::sync::Arc;
+
+use super::cert_resolver::RegistryCertResolver;
 
 pub fn server_config<P: CspTlsHandshakeSignerProvider>(
     signer_provider: &P,
     self_node_id: NodeId,
     registry_client: Arc<dyn RegistryClient>,
     allowed_clients: SomeOrAllNodes,
-    registry_version: RegistryVersion,
-) -> Result<ServerConfig, TlsConfigError> {
-    let self_tls_cert =
-        tls_cert_from_registry(registry_client.as_ref(), self_node_id, registry_version)?;
-    let self_tls_cert_key_id = KeyId::try_from(&self_tls_cert).map_err(|error| {
-        TlsConfigError::MalformedSelfCertificate {
-            internal_error: format!("Cannot instantiate KeyId: {:?}", error),
-        }
-    })?;
+) -> ServerConfig {
     let client_cert_verifier = NodeClientCertVerifier::new_with_mandatory_client_auth(
         allowed_clients.clone(),
-        registry_client,
-        registry_version,
+        registry_client.clone(),
     );
-    let ed25519_signing_key =
-        CspServerEd25519SigningKey::new(self_tls_cert_key_id, signer_provider.handshake_signer());
-    Ok(
-        server_config_with_tls13_and_aes_ciphersuites_and_ed25519_signing_key(
-            Arc::new(client_cert_verifier),
-            self_tls_cert,
-            ed25519_signing_key,
-        ),
+    server_config_with_tls13_and_aes_ciphersuites_and_ed25519_signing_key(
+        self_node_id,
+        Arc::new(client_cert_verifier),
+        registry_client,
+        signer_provider.handshake_signer(),
     )
 }
 
 pub fn server_config_without_client_auth<P: CspTlsHandshakeSignerProvider>(
     signer_provider: &P,
     self_node_id: NodeId,
-    registry_client: &dyn RegistryClient,
-    registry_version: RegistryVersion,
-) -> Result<ServerConfig, TlsConfigError> {
-    let self_tls_cert = tls_cert_from_registry(registry_client, self_node_id, registry_version)?;
-    let self_tls_cert_key_id = KeyId::try_from(&self_tls_cert).map_err(|error| {
-        TlsConfigError::MalformedSelfCertificate {
-            internal_error: format!("Cannot instantiate KeyId: {:?}", error),
-        }
-    })?;
-    let ed25519_signing_key =
-        CspServerEd25519SigningKey::new(self_tls_cert_key_id, signer_provider.handshake_signer());
+    registry_client: Arc<dyn RegistryClient>,
+) -> ServerConfig {
     let config = server_config_with_tls13_and_aes_ciphersuites_and_ed25519_signing_key(
+        self_node_id,
         Arc::new(NoClientAuth),
-        self_tls_cert,
-        ed25519_signing_key,
+        registry_client,
+        signer_provider.handshake_signer(),
     );
-    Ok(config)
+    config
 }
 
 fn server_config_with_tls13_and_aes_ciphersuites_and_ed25519_signing_key(
+    node_id: NodeId,
     client_cert_verifier: Arc<dyn ClientCertVerifier>,
-    self_tls_cert: TlsPublicKeyCert,
-    ed25519_signing_key: CspServerEd25519SigningKey,
+    registry_client: Arc<dyn RegistryClient>,
+    tls_csp_vault: Arc<dyn TlsHandshakeCspVault>,
 ) -> ServerConfig {
     let mut ring_crypto_provider = rustls::crypto::ring::default_provider();
     ring_crypto_provider.cipher_suites = vec![TLS13_AES_256_GCM_SHA384, TLS13_AES_128_GCM_SHA256];
@@ -81,15 +58,21 @@ fn server_config_with_tls13_and_aes_ciphersuites_and_ed25519_signing_key(
         .with_protocol_versions(&[&TLS13])
         .expect("Valid rustls server config.")
         .with_client_cert_verifier(client_cert_verifier)
-        .with_cert_resolver(static_cert_resolver(
-            certified_key(self_tls_cert, ed25519_signing_key),
-            SignatureScheme::ED25519,
+        .with_cert_resolver(registry_cert_resolver(
+            node_id,
+            registry_client,
+            tls_csp_vault,
         ))
 }
 
-fn static_cert_resolver(key: CertifiedKey, scheme: SignatureScheme) -> Arc<dyn ResolvesServerCert> {
-    Arc::new(StaticCertResolver::new(key, scheme).expect(
-        "Failed to create the static cert resolver because the signing key referenced \
-        in the certified key is incompatible with the signature scheme. This is an implementation error.",
+fn registry_cert_resolver(
+    node_id: NodeId,
+    registry_client: Arc<dyn RegistryClient>,
+    tls_csp_vault: Arc<dyn TlsHandshakeCspVault>,
+) -> Arc<dyn ResolvesServerCert> {
+    Arc::new(RegistryCertResolver::new(
+        node_id,
+        registry_client,
+        tls_csp_vault,
     ))
 }

--- a/rs/crypto/tls_interfaces/src/lib.rs
+++ b/rs/crypto/tls_interfaces/src/lib.rs
@@ -144,11 +144,7 @@ pub trait TlsConfig {
     /// * If the secret key corresponding to the server certificate cannot be
     ///   found or is malformed in the server's secret key store. Note that this
     ///   is an error in the setup of the node and registry.
-    fn server_config(
-        &self,
-        allowed_clients: SomeOrAllNodes,
-        registry_version: RegistryVersion,
-    ) -> Result<ServerConfig, TlsConfigError>;
+    fn server_config(&self, allowed_clients: SomeOrAllNodes) -> ServerConfig;
 
     /// Generates a rustls server config that does not perform client authentication.
     ///
@@ -170,10 +166,7 @@ pub trait TlsConfig {
     /// * If the secret key corresponding to the server certificate cannot be
     ///   found or is malformed in the server's secret key store. Note that this
     ///   is an error in the setup of the node and registry.
-    fn server_config_without_client_auth(
-        &self,
-        registry_version: RegistryVersion,
-    ) -> Result<ServerConfig, TlsConfigError>;
+    fn server_config_without_client_auth(&self) -> ServerConfig;
 
     /// Generates a rustls client config with an expected peer identity.
     ///
@@ -206,11 +199,7 @@ pub trait TlsConfig {
     /// * If the secret key corresponding to the client certificate cannot be
     ///   found or is malformed in the client's secret key store. Note that this
     ///   is an error in the setup of the node and registry.
-    fn client_config(
-        &self,
-        server: NodeId,
-        registry_version: RegistryVersion,
-    ) -> Result<ClientConfig, TlsConfigError>;
+    fn client_config(&self, server: NodeId) -> ClientConfig;
 }
 
 #[derive(Debug, Error)]

--- a/rs/http_endpoints/public/src/lib.rs
+++ b/rs/http_endpoints/public/src/lib.rs
@@ -30,6 +30,7 @@ pub use call::{CallServiceV2, IngressValidatorBuilder};
 pub use common::cors_layer;
 pub use query::QueryServiceBuilder;
 pub use read_state::canister::{CanisterReadStateService, CanisterReadStateServiceBuilder};
+// use rustls::server::ServerSessionMemoryCache;
 
 use crate::{
     call::ingress_watcher::IngressWatcher,
@@ -454,6 +455,7 @@ pub fn start_server(
     }
 
     let read_timeout = Duration::from_secs(config.connection_read_timeout_seconds);
+    // let tls_session_cache = Arc::new(ServerSessionMemoryCache::new(512));
     rt_handle.spawn(async move {
         loop {
             let (stream, _remote_addr) = tcp_listener.accept().await.unwrap();
@@ -500,9 +502,7 @@ pub fn start_server(
                         .connection_duration
                         .with_label_values(&[LABEL_SECURE])
                         .start_timer();
-                    let mut config = match tls_config
-                        .server_config_without_client_auth(registry_client.get_latest_version())
-                    {
+                    let mut config = match tls_config.server_config_without_client_auth() {
                         Ok(c) => c,
                         Err(err) => {
                             warn!(log, "Failed to get server config from crypto {err}");
@@ -510,6 +510,7 @@ pub fn start_server(
                         }
                     };
                     config.alpn_protocols = vec![ALPN_HTTP2.to_vec(), ALPN_HTTP1_1.to_vec()];
+                    config.session_storage = tls_session_cache.clone();
                     let tls_acceptor = tokio_rustls::TlsAcceptor::from(Arc::new(config));
 
                     match tls_acceptor.accept(stream).await {
@@ -555,6 +556,7 @@ async fn serve_http<S: AsyncRead + AsyncWrite + Send + Unpin + 'static>(
     let hyper_service =
         hyper::service::service_fn(move |request: Request<Incoming>| router.clone().call(request));
     hyper_util::server::conn::auto::Builder::new(TokioExecutor::new())
+        .http2()
         .serve_connection_with_upgrades(stream, hyper_service)
         .await
 }


### PR DESCRIPTION
Currently all `TlsConfig` functions take `RegistryVersion`. The `RegistryVersion` is used for getting the TLS key from registry at a certain `RegistryVersion`. In our code we always use the latest version. This refactor removes the `RegistryVersion` from the API and always uses the latest version internally. This means that a node is not part of the IC (node not registred in registry anymore) all TLS handshakes will fail. 

One important change is that we now resolve our cert on each handshake. This makes it possible to instantiate `ServerConfig/ClientConfig` once and always use the latest registry version even if the Config was created on startup. Previously the `ServerConfig/ClientConfig` was constructed at a specific registry version and therefore to support TLS key upgrades it needs to be reconstructed on each request.