### PR TITLE
refactor(sns): Remove the open method from swap. [override-didc-check]

### DIFF
--- a/rs/nns/governance/tests/governance.rs
+++ b/rs/nns/governance/tests/governance.rs
@@ -10934,15 +10934,6 @@ fn assert_calls_eq(
                 observed.method_name,
             );
         }
-        "open" => {
-            assert_eq!(
-                Decode!(&observed.request, sns_swap_pb::OpenRequest).unwrap(),
-                Decode!(&expected.request, sns_swap_pb::OpenRequest).unwrap(),
-                "unexpected call request to {}.{}",
-                observed.target,
-                observed.method_name,
-            );
-        }
         _ => {
             assert_eq!(
                 observed.request, expected.request,

--- a/rs/sns/swap/canister/canister.rs
+++ b/rs/sns/swap/canister/canister.rs
@@ -7,7 +7,6 @@ use dfn_core::{
 use ic_base_types::PrincipalId;
 use ic_canister_log::log;
 use ic_canisters_http_types::{HttpRequest, HttpResponse, HttpResponseBuilder};
-use ic_nervous_system_clients::ledger_client::LedgerCanister;
 use ic_nervous_system_clients::{
     canister_id_record::CanisterIdRecord,
     canister_status::CanisterStatusResultV2,
@@ -357,14 +356,6 @@ fn now_seconds() -> u64 {
 /// canister that implements that same interface.
 fn create_real_icp_ledger(id: CanisterId) -> ic_nervous_system_common::ledger::IcpLedgerCanister {
     ic_nervous_system_common::ledger::IcpLedgerCanister::new(id)
-}
-
-/// Returns a real ledger stub that communicates with the specified
-/// canister, which is assumed to be a canister that implements the
-/// ICRC1 interface.
-#[allow(unused)]
-fn create_real_icrc1_ledger(id: CanisterId) -> LedgerCanister {
-    LedgerCanister::new(id)
 }
 
 #[export_name = "canister_init"]

--- a/rs/sns/swap/canister/canister.rs
+++ b/rs/sns/swap/canister/canister.rs
@@ -29,8 +29,7 @@ use ic_sns_swap::{
         ListCommunityFundParticipantsResponse, ListDirectParticipantsRequest,
         ListDirectParticipantsResponse, ListSnsNeuronRecipesRequest, ListSnsNeuronRecipesResponse,
         NewSaleTicketRequest, NewSaleTicketResponse, NotifyPaymentFailureRequest,
-        NotifyPaymentFailureResponse, OpenRequest, OpenResponse, RefreshBuyerTokensRequest,
-        RefreshBuyerTokensResponse, Swap,
+        NotifyPaymentFailureResponse, RefreshBuyerTokensRequest, RefreshBuyerTokensResponse, Swap,
     },
 };
 use ic_stable_structures::{writer::Writer, Memory};
@@ -124,33 +123,6 @@ fn list_community_fund_participants_(
 ) -> ListCommunityFundParticipantsResponse {
     log!(INFO, "list_community_fund_participants");
     swap().list_community_fund_participants(&request)
-}
-
-/// Try to open the swap.
-///
-/// See Swap.open.
-#[export_name = "canister_update open"]
-fn open() {
-    over_async(candid_one, open_)
-}
-
-/// See `open`.
-#[candid_method(update, rename = "open")]
-async fn open_(req: OpenRequest) -> OpenResponse {
-    log!(INFO, "open");
-    // Require authorization.
-    let allowed_canister = swap().init_or_panic().nns_governance_or_panic();
-    if caller() != PrincipalId::from(allowed_canister) {
-        panic!(
-            "This method can only be called by canister {}",
-            allowed_canister
-        );
-    }
-    let sns_ledger = create_real_icrc1_ledger(swap().init_or_panic().sns_ledger_or_panic());
-    match swap_mut().open(id(), &sns_ledger, now_seconds(), req).await {
-        Ok(res) => res,
-        Err(msg) => panic!("{}", msg),
-    }
 }
 
 /// See `Swap.refresh_buyer_token_e8`.
@@ -390,6 +362,7 @@ fn create_real_icp_ledger(id: CanisterId) -> ic_nervous_system_common::ledger::I
 /// Returns a real ledger stub that communicates with the specified
 /// canister, which is assumed to be a canister that implements the
 /// ICRC1 interface.
+#[allow(unused)]
 fn create_real_icrc1_ledger(id: CanisterId) -> LedgerCanister {
     LedgerCanister::new(id)
 }

--- a/rs/sns/swap/canister/swap.did
+++ b/rs/sns/swap/canister/swap.did
@@ -189,11 +189,6 @@ type Ok_1 = record {
   neurons_fund_neurons_count : opt nat64;
 };
 type Ok_2 = record { ticket : opt Ticket };
-type OpenRequest = record {
-  cf_participants : vec CfParticipant;
-  params : opt Params;
-  open_sns_token_swap_proposal_id : opt nat64;
-};
 type Params = record {
   min_participant_icp_e8s : nat64;
   neuron_basket_construction_parameters : opt NeuronBasketConstructionParameters;
@@ -311,7 +306,6 @@ service : (Init) -> {
     ) query;
   new_sale_ticket : (NewSaleTicketRequest) -> (NewSaleTicketResponse);
   notify_payment_failure : (record {}) -> (Ok_2);
-  open : (OpenRequest) -> (record {});
   refresh_buyer_tokens : (RefreshBuyerTokensRequest) -> (
       RefreshBuyerTokensResponse,
     );

--- a/rs/sns/swap/proto/ic_sns_swap/pb/v1/swap.proto
+++ b/rs/sns/swap/proto/ic_sns_swap/pb/v1/swap.proto
@@ -202,6 +202,7 @@ message Swap {
 
   // Derived from `init`, always specified and immutable. In most cases `init`
   // should be used instead.
+  // TODO(NNS1-3213): Deprecate this field
   Params params = 4;
 
   // Neurons' Fund participation.  Specified in the transition from
@@ -224,6 +225,8 @@ message Swap {
   // The proposal ID that was used to create the SNS that opened this swap.
   // Note: the name is a historical artifact because the swap used to be opened
   // with an OpenSnsTokenSwap request.
+  // This is set at installation from `init.nns_proposal_id`, and that field should be used instead.
+  // TODO(NNS1-3213): Deprecate this field
   optional uint64 open_sns_token_swap_proposal_id = 9;
 
   // A lock stored in Swap state. If set to true, then a finalize_swap

--- a/rs/sns/swap/proto/ic_sns_swap/pb/v1/swap.proto
+++ b/rs/sns/swap/proto/ic_sns_swap/pb/v1/swap.proto
@@ -200,8 +200,8 @@ message Swap {
   // Specified on creation. That is, always specified and immutable.
   Init init = 1;
 
-  // Specified in the transition from PENDING to OPEN and immutable
-  // thereafter.
+  // Derived from `init`, always specified and immutable. In most cases `init`
+  // should be used instead.
   Params params = 4;
 
   // Neurons' Fund participation.  Specified in the transition from
@@ -221,8 +221,9 @@ message Swap {
   // to the outcome of the swap.
   repeated SnsNeuronRecipe neuron_recipes = 7;
 
-  // Gets set to whatever value is in the corresponding field of OpenRequest
-  // (that field is required at the application level).
+  // The proposal ID that was used to create the SNS that opened this swap.
+  // Note: the name is a historical artifact because the swap used to be opened
+  // with an OpenSnsTokenSwap request.
   optional uint64 open_sns_token_swap_proposal_id = 9;
 
   // A lock stored in Swap state. If set to true, then a finalize_swap
@@ -772,17 +773,6 @@ message SnsNeuronRecipe {
 //
 // === Request/Response Messages
 //
-
-message OpenRequest {
-  // The parameters of the swap.
-  Params params = 1;
-  // Neurons' Fund participation.
-  repeated CfParticipant cf_participants = 2;
-  // The ID of the proposal whose execution consists of calling this method.
-  optional uint64 open_sns_token_swap_proposal_id = 3;
-}
-
-message OpenResponse {}
 
 message GetCanisterStatusRequest {}
 

--- a/rs/sns/swap/src/gen/ic_sns_swap.pb.v1.rs
+++ b/rs/sns/swap/src/gen/ic_sns_swap.pb.v1.rs
@@ -152,8 +152,8 @@ pub struct Swap {
     /// Specified on creation. That is, always specified and immutable.
     #[prost(message, optional, tag = "1")]
     pub init: ::core::option::Option<Init>,
-    /// Specified in the transition from PENDING to OPEN and immutable
-    /// thereafter.
+    /// Derived from `init`, always specified and immutable. In most cases `init`
+    /// should be used instead.
     #[prost(message, optional, tag = "4")]
     pub params: ::core::option::Option<Params>,
     /// Neurons' Fund participation.  Specified in the transition from
@@ -173,8 +173,9 @@ pub struct Swap {
     /// to the outcome of the swap.
     #[prost(message, repeated, tag = "7")]
     pub neuron_recipes: ::prost::alloc::vec::Vec<SnsNeuronRecipe>,
-    /// Gets set to whatever value is in the corresponding field of OpenRequest
-    /// (that field is required at the application level).
+    /// The proposal ID that was used to create the SNS that opened this swap.
+    /// Note: the name is a historical artifact because the swap used to be opened
+    /// with an OpenSnsTokenSwap request.
     #[prost(uint64, optional, tag = "9")]
     pub open_sns_token_swap_proposal_id: ::core::option::Option<u64>,
     /// A lock stored in Swap state. If set to true, then a finalize_swap
@@ -833,24 +834,6 @@ pub mod sns_neuron_recipe {
         CommunityFund(super::CfInvestment),
     }
 }
-#[derive(candid::CandidType, candid::Deserialize, serde::Serialize, comparable::Comparable)]
-#[allow(clippy::derive_partial_eq_without_eq)]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct OpenRequest {
-    /// The parameters of the swap.
-    #[prost(message, optional, tag = "1")]
-    pub params: ::core::option::Option<Params>,
-    /// Neurons' Fund participation.
-    #[prost(message, repeated, tag = "2")]
-    pub cf_participants: ::prost::alloc::vec::Vec<CfParticipant>,
-    /// The ID of the proposal whose execution consists of calling this method.
-    #[prost(uint64, optional, tag = "3")]
-    pub open_sns_token_swap_proposal_id: ::core::option::Option<u64>,
-}
-#[derive(candid::CandidType, candid::Deserialize, serde::Serialize, comparable::Comparable)]
-#[allow(clippy::derive_partial_eq_without_eq)]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct OpenResponse {}
 #[derive(candid::CandidType, candid::Deserialize, serde::Serialize, comparable::Comparable)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/rs/sns/swap/src/gen/ic_sns_swap.pb.v1.rs
+++ b/rs/sns/swap/src/gen/ic_sns_swap.pb.v1.rs
@@ -154,6 +154,7 @@ pub struct Swap {
     pub init: ::core::option::Option<Init>,
     /// Derived from `init`, always specified and immutable. In most cases `init`
     /// should be used instead.
+    /// TODO(NNS1-3213): Deprecate this field
     #[prost(message, optional, tag = "4")]
     pub params: ::core::option::Option<Params>,
     /// Neurons' Fund participation.  Specified in the transition from
@@ -176,6 +177,8 @@ pub struct Swap {
     /// The proposal ID that was used to create the SNS that opened this swap.
     /// Note: the name is a historical artifact because the swap used to be opened
     /// with an OpenSnsTokenSwap request.
+    /// This is set at installation from `init.nns_proposal_id`, and that field should be used instead.
+    /// TODO(NNS1-3213): Deprecate this field
     #[prost(uint64, optional, tag = "9")]
     pub open_sns_token_swap_proposal_id: ::core::option::Option<u64>,
     /// A lock stored in Swap state. If set to true, then a finalize_swap

--- a/rs/sns/swap/src/swap.rs
+++ b/rs/sns/swap/src/swap.rs
@@ -20,12 +20,11 @@ use crate::{
         ListCommunityFundParticipantsResponse, ListDirectParticipantsRequest,
         ListDirectParticipantsResponse, ListSnsNeuronRecipesRequest, ListSnsNeuronRecipesResponse,
         NeuronBasketConstructionParameters, NeuronId as SaleNeuronId, NewSaleTicketRequest,
-        NewSaleTicketResponse, NotifyPaymentFailureResponse, OpenRequest, OpenResponse,
-        Participant, RefreshBuyerTokensResponse, SetDappControllersCallResult,
-        SetDappControllersRequest, SetDappControllersResponse, SetModeCallResult,
-        SettleNeuronsFundParticipationRequest, SettleNeuronsFundParticipationResponse,
-        SettleNeuronsFundParticipationResult, SnsNeuronRecipe, Swap, SweepResult, Ticket,
-        TransferableAmount,
+        NewSaleTicketResponse, NotifyPaymentFailureResponse, Participant,
+        RefreshBuyerTokensResponse, SetDappControllersCallResult, SetDappControllersRequest,
+        SetDappControllersResponse, SetModeCallResult, SettleNeuronsFundParticipationRequest,
+        SettleNeuronsFundParticipationResponse, SettleNeuronsFundParticipationResult,
+        SnsNeuronRecipe, Swap, SweepResult, Ticket, TransferableAmount,
     },
     types::{NeuronsFundNeuron, ScheduledVestingEvent, TransferResult},
 };
@@ -721,22 +720,6 @@ impl Swap {
         self.auto_finalize_swap_response = Some(auto_finalize_swap_response.clone());
 
         Ok(auto_finalize_swap_response)
-    }
-
-    /// This function is obsolete.
-    pub async fn open(
-        &self,
-        _this_canister: CanisterId,
-        _sns_ledger: &dyn ICRC1Ledger,
-        _now_seconds: u64,
-        _req: OpenRequest,
-    ) -> Result<OpenResponse, String> {
-        Err(
-            "Swap.open is obsolete. An SNS instance should be created via \
-            a `CreateServiceNervousSystem` proposal, the execution of which automatically leads to \
-            the swap being in the open state."
-                .to_string(),
-        )
     }
 
     /// Computes `amount_icp_e8s` scaled by (`total_sns_e8s` divided by

--- a/rs/sns/swap/src/types.rs
+++ b/rs/sns/swap/src/types.rs
@@ -9,7 +9,7 @@ use crate::{
         sns_neuron_recipe::{ClaimedStatus, Investor},
         BuyerState, CfInvestment, CfNeuron, CfParticipant, DirectInvestment,
         ErrorRefundIcpResponse, FinalizeSwapResponse, Init, Lifecycle, NeuronId as SaleNeuronId,
-        OpenRequest, Params, SetDappControllersCallResult, SetModeCallResult,
+        Params, SetDappControllersCallResult, SetModeCallResult,
         SettleNeuronsFundParticipationResult, SnsNeuronRecipe, SweepResult, TransferableAmount,
     },
     swap::is_valid_principal,
@@ -666,38 +666,6 @@ impl TransferableAmount {
     }
 }
 
-impl OpenRequest {
-    pub fn validate(&self, current_timestamp_seconds: u64, init: &Init) -> Result<(), String> {
-        let mut defects = vec![];
-
-        // Inspect params.
-        match self.params.as_ref() {
-            None => {
-                defects.push("The parameters of the swap are missing.".to_string());
-            }
-            Some(params) => {
-                if let Err(err) = params.is_valid_if_initiated_at(current_timestamp_seconds) {
-                    defects.push(err);
-                } else if let Err(err) = params.validate(init) {
-                    defects.push(err);
-                }
-            }
-        }
-
-        // Inspect open_sns_token_swap_proposal_id.
-        if self.open_sns_token_swap_proposal_id.is_none() {
-            defects.push("The open_sns_token_swap_proposal_id field has no value.".to_string());
-        }
-
-        // Return result.
-        if defects.is_empty() {
-            Ok(())
-        } else {
-            Err(defects.join("\n"))
-        }
-    }
-}
-
 impl DirectInvestment {
     pub fn validate(&self) -> Result<(), String> {
         if !is_valid_principal(&self.buyer_principal) {
@@ -1229,18 +1197,15 @@ mod tests {
     use crate::{
         pb::v1::{
             CfNeuron, CfParticipant, Init, ListDirectParticipantsResponse,
-            NeuronBasketConstructionParameters, OpenRequest, Params, Participant,
+            NeuronBasketConstructionParameters, Params, Participant,
         },
         swap::MAX_LIST_DIRECT_PARTICIPANTS_LIMIT,
     };
-    use ic_base_types::PrincipalId;
     use ic_nervous_system_common::{
         assert_is_err, assert_is_ok, E8, ONE_DAY_SECONDS, START_OF_2022_TIMESTAMP_SECONDS,
     };
     use lazy_static::lazy_static;
     use std::mem;
-
-    const OPEN_SNS_TOKEN_SWAP_PROPOSAL_ID: u64 = 489102;
 
     const PARAMS: Params = Params {
         max_participant_icp_e8s: 1_000 * E8,
@@ -1258,22 +1223,6 @@ mod tests {
         }),
         sale_delay_seconds: None,
     };
-
-    lazy_static! {
-        static ref OPEN_REQUEST: OpenRequest = OpenRequest {
-            params: Some(PARAMS),
-            cf_participants: vec![CfParticipant {
-                controller: Some(PrincipalId::new_user_test_id(423939)),
-                hotkey_principal: PrincipalId::new_user_test_id(423939).to_string(),
-                cf_neurons: vec![CfNeuron::try_new(
-                    42,
-                    99,
-                    Vec::new() // TODO(NNS1-3199): populate with some hotkey principals
-                ).unwrap()],
-            }],
-            open_sns_token_swap_proposal_id: Some(OPEN_SNS_TOKEN_SWAP_PROPOSAL_ID),
-        };
-    }
 
     lazy_static! {
         // Fill out Init just enough to test Params validation. These values are
@@ -1316,11 +1265,6 @@ mod tests {
     }
 
     #[test]
-    fn open_request_validate_ok() {
-        assert_is_ok!(OPEN_REQUEST.validate(START_OF_2022_TIMESTAMP_SECONDS, &INIT));
-    }
-
-    #[test]
     fn params_high_participants_validate_ok() {
         let params = Params {
             min_participants: 500,
@@ -1330,65 +1274,6 @@ mod tests {
             ..PARAMS
         };
         params.validate(&INIT).unwrap();
-    }
-
-    #[test]
-    fn open_request_validate_invalid_params() {
-        let request = OpenRequest {
-            params: Some(Params {
-                swap_due_timestamp_seconds: 42,
-                ..PARAMS.clone()
-            }),
-            ..OPEN_REQUEST.clone()
-        };
-
-        assert_is_err!(request.validate(START_OF_2022_TIMESTAMP_SECONDS, &INIT));
-    }
-
-    #[test]
-    fn open_request_reject_one_neuron_in_basket() {
-        let request_fail = OpenRequest {
-            params: Some(Params {
-                neuron_basket_construction_parameters: Some(NeuronBasketConstructionParameters {
-                    count: 1, // 1 should be too little
-                    dissolve_delay_interval_seconds: 7890000,
-                }),
-                ..PARAMS.clone()
-            }),
-            ..OPEN_REQUEST.clone()
-        };
-
-        let request_success = OpenRequest {
-            params: Some(Params {
-                neuron_basket_construction_parameters: Some(NeuronBasketConstructionParameters {
-                    count: 2, // 2 should be enough
-                    dissolve_delay_interval_seconds: 7890000,
-                }),
-                ..PARAMS.clone()
-            }),
-            ..OPEN_REQUEST.clone()
-        };
-
-        let error = request_fail
-            .validate(START_OF_2022_TIMESTAMP_SECONDS, &INIT)
-            .unwrap_err();
-        assert_eq!(
-            error,
-            "neuron_basket_construction_parameters.count (1) must be >= 2".to_string()
-        );
-        request_success
-            .validate(START_OF_2022_TIMESTAMP_SECONDS, &INIT)
-            .unwrap();
-    }
-
-    #[test]
-    fn open_request_validate_no_proposal_id() {
-        let request = OpenRequest {
-            open_sns_token_swap_proposal_id: None,
-            ..OPEN_REQUEST.clone()
-        };
-
-        assert_is_err!(request.validate(START_OF_2022_TIMESTAMP_SECONDS, &INIT));
     }
 
     #[test]

--- a/rs/sns/swap/tests/swap.rs
+++ b/rs/sns/swap/tests/swap.rs
@@ -243,35 +243,6 @@ fn test_init() {
     assert!(swap.validate().is_ok());
 }
 
-#[test]
-fn test_open_is_obsolete() {
-    let swap = SwapBuilder::new().build();
-    let account = Account {
-        owner: SWAP_CANISTER_ID.get().into(),
-        subaccount: None,
-    };
-    let params = params();
-    let open_request = OpenRequest {
-        params: Some(params.clone()),
-        cf_participants: vec![],
-        open_sns_token_swap_proposal_id: Some(OPEN_SNS_TOKEN_SWAP_PROPOSAL_ID),
-    };
-    let response = swap
-        .open(
-            SWAP_CANISTER_ID,
-            &mock_stub(vec![LedgerExpect::AccountBalance(
-                account,
-                Ok(Tokens::ZERO),
-            )]),
-            START_TIMESTAMP_SECONDS,
-            open_request.clone(),
-        )
-        .now_or_never()
-        .unwrap()
-        .unwrap_err();
-    assert!(response.starts_with("Swap.open is obsolete"));
-}
-
 fn now_fn(is_after: bool) -> u64 {
     if is_after {
         END_TIMESTAMP_SECONDS + 10

--- a/rs/sns/test_utils/src/state_test_helpers.rs
+++ b/rs/sns/test_utils/src/state_test_helpers.rs
@@ -7,7 +7,7 @@ use ic_management_canister_types::CanisterInstallMode;
 use ic_nervous_system_clients::{
     canister_id_record::CanisterIdRecord, canister_status::CanisterStatusResultV2,
 };
-use ic_nervous_system_common::{ExplosiveTokens, ONE_DAY_SECONDS};
+use ic_nervous_system_common::ExplosiveTokens;
 use ic_nervous_system_common_test_keys::TEST_USER1_PRINCIPAL;
 use ic_nns_constants::{
     LEDGER_CANISTER_ID as ICP_LEDGER_CANISTER_ID, ROOT_CANISTER_ID as NNS_ROOT_CANISTER_ID,
@@ -36,8 +36,7 @@ use ic_sns_root::{
 use ic_sns_swap::pb::v1::{
     self as swap_pb, ErrorRefundIcpResponse, FinalizeSwapResponse, GetBuyerStateResponse,
     GetBuyersTotalResponse, GetLifecycleResponse, GetOpenTicketResponse, GetSaleParametersResponse,
-    ListCommunityFundParticipantsResponse, NeuronBasketConstructionParameters,
-    NewSaleTicketResponse, NotifyPaymentFailureResponse, OpenRequest, OpenResponse, Params,
+    ListCommunityFundParticipantsResponse, NewSaleTicketResponse, NotifyPaymentFailureResponse,
     RefreshBuyerTokensRequest, RefreshBuyerTokensResponse, Ticket,
 };
 use ic_state_machine_tests::{StateMachine, StateMachineBuilder};
@@ -727,39 +726,6 @@ pub fn list_community_fund_participants(
         .query_as(*sender, *swap_id, "list_community_fund_participants", args)
         .unwrap();
     Decode!(&res.bytes(), ListCommunityFundParticipantsResponse).unwrap()
-}
-
-pub fn open_sale(env: &StateMachine, swap_id: &CanisterId, params: Option<Params>) -> OpenResponse {
-    let args = OpenRequest {
-        params: Some(
-            params.unwrap_or(Params {
-                min_participants: 1,
-                min_icp_e8s: 1,
-                max_icp_e8s: 10_000_000,
-                min_direct_participation_icp_e8s: Some(1),
-                max_direct_participation_icp_e8s: Some(10_000_000),
-                min_participant_icp_e8s: 2_020_000,
-                max_participant_icp_e8s: 10_000_000,
-                swap_due_timestamp_seconds: env
-                    .time()
-                    .duration_since(std::time::UNIX_EPOCH)
-                    .unwrap()
-                    .as_secs()
-                    + 13 * ONE_DAY_SECONDS,
-                sns_token_e8s: 10_000_000,
-                neuron_basket_construction_parameters: Some(NeuronBasketConstructionParameters {
-                    count: 2,
-                    dissolve_delay_interval_seconds: 1,
-                }),
-                sale_delay_seconds: None,
-            }),
-        ),
-        cf_participants: vec![],
-        open_sns_token_swap_proposal_id: Some(0),
-    };
-    let args = Encode!(&args).unwrap();
-    let res = env.execute_ingress(*swap_id, "open", args).unwrap();
-    Decode!(&res.bytes(), OpenResponse).unwrap()
 }
 
 pub fn error_refund(


### PR DESCRIPTION
The only principal that was allowed to call this method was NNS governance, but it no longer does that. It used to be the main thing that the OpenSnsTokenSwap proposal called, but that type of proposal can no longer be used.

Ofc, this is technically a backwards incompatible change, because we removed a method. However, it is safe, because previously, there was only one allowed caller, and that caller has stopped calling the removed method.