### PR TITLE
refactor(nns): Use governance_api instead of governance types in entrypoint in governance

### DIFF
--- a/rs/nns/governance/api/src/pb.rs
+++ b/rs/nns/governance/api/src/pb.rs
@@ -1,3 +1,21 @@
+use crate::pb::v1::{governance_error::ErrorType, GovernanceError};
+
 #[allow(clippy::all)]
 #[path = "./ic_nns_governance.pb.v1.rs"]
 pub mod v1;
+
+impl GovernanceError {
+    pub fn new(error_type: ErrorType) -> Self {
+        Self {
+            error_type: error_type as i32,
+            ..Default::default()
+        }
+    }
+
+    pub fn new_with_message(error_type: ErrorType, message: impl ToString) -> Self {
+        Self {
+            error_type: error_type as i32,
+            error_message: message.to_string(),
+        }
+    }
+}


### PR DESCRIPTION
As a further step in reducing direct dependencies on the nns governance crate, this reverses the direction of API dependencies so that the API crate defines the types that define the API, and other crates can then depend on the API crate instead of the governance canister crate and library