### PR TITLE
fix: add missing large testnet runtime dependency

### DIFF
--- a/rs/tests/testing_verification/testnets/BUILD.bazel
+++ b/rs/tests/testing_verification/testnets/BUILD.bazel
@@ -107,7 +107,7 @@ system_test(
     ],
     target_compatible_with = ["@platforms//os:linux"],  # requires libssh that does not build on Mac OS
     runtime_deps = GUESTOS_RUNTIME_DEPS + NNS_CANISTER_RUNTIME_DEPS + BOUNDARY_NODE_GUESTOS_RUNTIME_DEPS + GRAFANA_RUNTIME_DEPS + [
-        "//rs/rosetta-api/icrc1/ledger:ledger_canister.wasm.gz",
+        "//rs/rosetta-api/icrc1/ledger:ledger_canister",
         "@ii_dev_canister//file",
         "@nns_dapp_canister//file",
         "@subnet_rental_canister//file",
@@ -132,7 +132,7 @@ system_test(
     ],
     target_compatible_with = ["@platforms//os:linux"],  # requires libssh that does not build on Mac OS
     runtime_deps = GUESTOS_RUNTIME_DEPS + NNS_CANISTER_RUNTIME_DEPS + SNS_CANISTER_RUNTIME_DEPS + BOUNDARY_NODE_GUESTOS_RUNTIME_DEPS + GRAFANA_RUNTIME_DEPS + [
-        "//rs/rosetta-api/icrc1/ledger:ledger_canister.wasm.gz",
+        "//rs/rosetta-api/icrc1/ledger:ledger_canister",
         "@ii_dev_canister//file",
         "@nns_dapp_canister//file",
         "@sns_aggregator//file",
@@ -172,7 +172,6 @@ system_test(
     target_compatible_with = ["@platforms//os:linux"],  # requires libssh that does not build on Mac OS
     runtime_deps = GUESTOS_RUNTIME_DEPS + NNS_CANISTER_RUNTIME_DEPS + SNS_CANISTER_RUNTIME_DEPS + BOUNDARY_NODE_GUESTOS_RUNTIME_DEPS + GRAFANA_RUNTIME_DEPS + [
         "//rs/rosetta-api/icrc1/ledger:ledger_canister",
-        "//rs/rosetta-api/icrc1/ledger:ledger_canister.wasm.gz",
         "@ii_dev_canister//file",
         "@nns_dapp_canister//file",
         "@sns_aggregator//file",

--- a/rs/tests/testing_verification/testnets/BUILD.bazel
+++ b/rs/tests/testing_verification/testnets/BUILD.bazel
@@ -171,6 +171,7 @@ system_test(
     ],
     target_compatible_with = ["@platforms//os:linux"],  # requires libssh that does not build on Mac OS
     runtime_deps = GUESTOS_RUNTIME_DEPS + NNS_CANISTER_RUNTIME_DEPS + SNS_CANISTER_RUNTIME_DEPS + BOUNDARY_NODE_GUESTOS_RUNTIME_DEPS + GRAFANA_RUNTIME_DEPS + [
+        "//rs/rosetta-api/icrc1/ledger:ledger_canister",
         "//rs/rosetta-api/icrc1/ledger:ledger_canister.wasm.gz",
         "@ii_dev_canister//file",
         "@nns_dapp_canister//file",


### PR DESCRIPTION
Creating a large testnet currently fails with 
```
Analyzing: target //rs/tests/testing_verification/testnets:large (0 packages loaded, 0 targets configured)
ERROR: /ic/rs/tests/testing_verification/testnets/BUILD.bazel:157:12: in run_system_test rule //rs/tests/testing_verification/testnets:large: label '//rs/rosetta-api/icrc1/ledger:ledger_canister' in $(location) expression is not a declared prerequisite of this rule
ERROR: /ic/rs/tests/testing_verification/testnets/BUILD.bazel:157:12: Analysis of target '//rs/tests/testing_verification/testnets:large' failed
ERROR: Analysis of target '//rs/tests/testing_verification/testnets:large' failed; build aborted:
```

This MR adds the ledger canister to the runtime depndencies.