### PR TITLE
fix: Add total_size to CanisterSnapshotBits

### DIFF
--- a/rs/protobuf/def/state/canister_snapshot_bits/v1/canister_snapshot_bits.proto
+++ b/rs/protobuf/def/state/canister_snapshot_bits/v1/canister_snapshot_bits.proto
@@ -14,4 +14,5 @@ message CanisterSnapshotBits {
   canister_state_bits.v1.WasmChunkStoreMetadata wasm_chunk_store_metadata = 7;
   uint64 stable_memory_size = 8;
   uint64 wasm_memory_size = 9;
+  uint64 total_size = 10;
 }

--- a/rs/protobuf/src/gen/state/state.canister_snapshot_bits.v1.rs
+++ b/rs/protobuf/src/gen/state/state.canister_snapshot_bits.v1.rs
@@ -20,4 +20,6 @@ pub struct CanisterSnapshotBits {
     pub stable_memory_size: u64,
     #[prost(uint64, tag = "9")]
     pub wasm_memory_size: u64,
+    #[prost(uint64, tag = "10")]
+    pub total_size: u64,
 }

--- a/rs/state_layout/src/state_layout.rs
+++ b/rs/state_layout/src/state_layout.rs
@@ -175,7 +175,7 @@ pub struct CanisterStateBits {
 
 /// This struct contains bits of the `CanisterSnapshot` that are not already
 /// covered somewhere else and are too small to be serialized separately.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct CanisterSnapshotBits {
     /// The ID of the canister snapshot.
     pub snapshot_id: SnapshotId,
@@ -195,6 +195,8 @@ pub struct CanisterSnapshotBits {
     pub stable_memory_size: NumWasmPages,
     /// The size of the wasm memory in pages.
     pub wasm_memory_size: NumWasmPages,
+    /// The total size of the snapshot in bytes.
+    pub total_size: NumBytes,
 }
 
 #[derive(Clone)]
@@ -2166,8 +2168,8 @@ impl TryFrom<pb_canister_state_bits::ExecutionStateBits> for ExecutionStateBits 
     }
 }
 
-impl From<&CanisterSnapshotBits> for pb_canister_snapshot_bits::CanisterSnapshotBits {
-    fn from(item: &CanisterSnapshotBits) -> Self {
+impl From<CanisterSnapshotBits> for pb_canister_snapshot_bits::CanisterSnapshotBits {
+    fn from(item: CanisterSnapshotBits) -> Self {
         Self {
             snapshot_id: item.snapshot_id.get_local_snapshot_id(),
             canister_id: Some((item.canister_id).into()),
@@ -2178,6 +2180,7 @@ impl From<&CanisterSnapshotBits> for pb_canister_snapshot_bits::CanisterSnapshot
             wasm_chunk_store_metadata: Some((&item.wasm_chunk_store_metadata).into()),
             stable_memory_size: item.stable_memory_size.get() as u64,
             wasm_memory_size: item.wasm_memory_size.get() as u64,
+            total_size: item.total_size.get(),
         }
     }
 }
@@ -2216,6 +2219,7 @@ impl TryFrom<pb_canister_snapshot_bits::CanisterSnapshotBits> for CanisterSnapsh
             .unwrap_or_default(),
             stable_memory_size: NumWasmPages::from(item.stable_memory_size as usize),
             wasm_memory_size: NumWasmPages::from(item.wasm_memory_size as usize),
+            total_size: NumBytes::from(item.total_size),
         })
     }
 }

--- a/rs/state_layout/src/state_layout/tests.rs
+++ b/rs/state_layout/src/state_layout/tests.rs
@@ -210,9 +210,11 @@ fn test_canister_snapshots_decode() {
         wasm_chunk_store_metadata: WasmChunkStoreMetadata::default(),
         stable_memory_size: NumWasmPages::new(10),
         wasm_memory_size: NumWasmPages::new(10),
+        total_size: NumBytes::new(100),
     };
 
-    let pb_bits = pb_canister_snapshot_bits::CanisterSnapshotBits::from(&canister_snapshot_bits);
+    let pb_bits =
+        pb_canister_snapshot_bits::CanisterSnapshotBits::from(canister_snapshot_bits.clone());
     let new_canister_snapshot_bits = CanisterSnapshotBits::try_from(pb_bits).unwrap();
 
     assert_eq!(canister_snapshot_bits, new_canister_snapshot_bits);


### PR DESCRIPTION
This commit adds a `total_size` field to `CanisterSnapshotBits`, in accordance to the same field in `CanisterSnaphot`. This is in preparation for loading snapshots from disk during checkpointing, where this field is needed to construct a valid `CanisterSnapshot`.