### PR TITLE
fix(IDX): fix the did_git_test on GitHub

### DIFF
--- a/.github/workflows-source/ci-main.yml
+++ b/.github/workflows-source/ci-main.yml
@@ -79,7 +79,7 @@ jobs:
       labels: dind-large
     steps:
       - <<: *checkout
-	    # The git merge base has to be fetched such that bazel tests like did_git_test
+      # The git merge base has to be fetched such that bazel tests like did_git_test
       # can compare HEAD against the merge base for compatibility.
       - name: Fetch the git merge base
         if: ${{github.event_name == 'pull_request'}}

--- a/.github/workflows-source/ci-main.yml
+++ b/.github/workflows-source/ci-main.yml
@@ -79,11 +79,6 @@ jobs:
       labels: dind-large
     steps:
       - <<: *checkout
-      # The git merge base has to be fetched such that bazel tests like did_git_test
-      # can compare HEAD against the merge base for compatibility.
-      - name: Fetch the git merge base
-        if: ${{github.event_name == 'pull_request'}}
-        run: git fetch origin "$CI_MERGE_REQUEST_TARGET_BRANCH_SHA"
       - <<: *before-script
       - name: Set BAZEL_EXTRA_ARGS_RULES
         shell: bash

--- a/.github/workflows-source/ci-main.yml
+++ b/.github/workflows-source/ci-main.yml
@@ -29,6 +29,7 @@ env:
   CI_PIPELINE_SOURCE: ${{ github.event_name }}
   CI_PROJECT_DIR: ${{ github.workspace }}
   CI_MERGE_REQUEST_TARGET_BRANCH_NAME: ${{ github.event.pull_request.base.ref }}
+  CI_MERGE_REQUEST_TARGET_BRANCH_SHA: ${{ github.event.pull_request.base.sha }}
   BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
   ROOT_PIPELINE_ID: ${{ github.run_id }}
   BAZEL_STARTUP_ARGS: "--output_base=/var/tmp/bazel-output/"

--- a/.github/workflows-source/ci-main.yml
+++ b/.github/workflows-source/ci-main.yml
@@ -79,6 +79,11 @@ jobs:
       labels: dind-large
     steps:
       - <<: *checkout
+	    # The git merge base has to be fetched such that bazel tests like did_git_test
+      # can compare HEAD against the merge base for compatibility.
+      - name: Fetch the git merge base
+        if: ${{github.event_name == 'pull_request'}}
+        run: git fetch origin "$CI_MERGE_REQUEST_TARGET_BRANCH_SHA"
       - <<: *before-script
       - name: Set BAZEL_EXTRA_ARGS_RULES
         shell: bash

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -52,6 +52,11 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: ${{ github.event_name == 'pull_request' && 256 || 0 }}
+      # The git merge base has to be fetched such that bazel tests like did_git_test
+      # can compare HEAD against the merge base for compatibility.
+      - name: Fetch the git merge base
+        if: ${{github.event_name == 'pull_request'}}
+        run: git fetch origin "$CI_MERGE_REQUEST_TARGET_BRANCH_SHA"
       - name: Before script
         id: before-script
         shell: bash

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -52,11 +52,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: ${{ github.event_name == 'pull_request' && 256 || 0 }}
-      # The git merge base has to be fetched such that bazel tests like did_git_test
-      # can compare HEAD against the merge base for compatibility.
-      - name: Fetch the git merge base
-        if: ${{github.event_name == 'pull_request'}}
-        run: git fetch origin "$CI_MERGE_REQUEST_TARGET_BRANCH_SHA"
       - name: Before script
         id: before-script
         shell: bash

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -51,6 +51,11 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: ${{ github.event_name == 'pull_request' && 256 || 0 }}
+      # The git merge base has to be fetched such that bazel tests like did_git_test
+      # can compare HEAD against the merge base for compatibility.
+      - name: Fetch the git merge base
+        if: ${{github.event_name == 'pull_request'}}
+        run: git fetch --depth=256 origin "$CI_MERGE_REQUEST_TARGET_BRANCH_NAME"
       - name: Before script
         id: before-script
         shell: bash

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -25,6 +25,7 @@ env:
   CI_PIPELINE_SOURCE: ${{ github.event_name }}
   CI_PROJECT_DIR: ${{ github.workspace }}
   CI_MERGE_REQUEST_TARGET_BRANCH_NAME: ${{ github.event.pull_request.base.ref }}
+  CI_MERGE_REQUEST_TARGET_BRANCH_SHA: ${{ github.event.pull_request.base.sha }}
   BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
   ROOT_PIPELINE_ID: ${{ github.run_id }}
   BAZEL_STARTUP_ARGS: "--output_base=/var/tmp/bazel-output/"
@@ -51,11 +52,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: ${{ github.event_name == 'pull_request' && 256 || 0 }}
-      # The git merge base has to be fetched such that bazel tests like did_git_test
-      # can compare HEAD against the merge base for compatibility.
-      - name: Fetch the git merge base
-        if: ${{github.event_name == 'pull_request'}}
-        run: git fetch --depth=256 origin "$CI_MERGE_REQUEST_TARGET_BRANCH_NAME"
       - name: Before script
         id: before-script
         shell: bash

--- a/bazel/candid.bzl
+++ b/bazel/candid.bzl
@@ -54,7 +54,7 @@ fi
 
     return [
         DefaultInfo(runfiles = runfiles),
-        RunEnvironmentInfo(inherited_environment = ["CI_MERGE_REQUEST_TARGET_BRANCH_NAME", "CI_MERGE_REQUEST_TITLE"]),
+        RunEnvironmentInfo(inherited_environment = ["CI_MERGE_REQUEST_TARGET_BRANCH_SHA", "CI_MERGE_REQUEST_TITLE"]),
     ]
 
 CHECK_DID = attr.label(

--- a/bazel/candid.bzl
+++ b/bazel/candid.bzl
@@ -14,7 +14,11 @@ if [[ $mr_title == *"[override-didc-check]"* ]]; then
     exit 0
 fi
 
-readonly target_branch_name=${{CI_MERGE_REQUEST_TARGET_BRANCH_NAME:-HEAD}}
+if [ -z "${CI_MERGE_REQUEST_TARGET_BRANCH_NAME:-}" ]; then
+  readonly target_branch_name="HEAD"
+else
+  readonly target_branch_name="origin/$CI_MERGE_REQUEST_TARGET_BRANCH_NAME"
+fi
 readonly merge_base="$(git merge-base "$target_branch_name" HEAD)"
 
 readonly tmpfile=$(mktemp $TEST_TMPDIR/prev.XXXXXX)

--- a/bazel/candid.bzl
+++ b/bazel/candid.bzl
@@ -15,7 +15,7 @@ if [[ $mr_title == *"[override-didc-check]"* ]]; then
 fi
 
 readonly target_branch_name=${{CI_MERGE_REQUEST_TARGET_BRANCH_NAME:-HEAD}}
-readonly merge_base="$(git merge-base $target_branch_name HEAD)"
+readonly merge_base="$(git merge-base "$target_branch_name" HEAD)"
 
 readonly tmpfile=$(mktemp $TEST_TMPDIR/prev.XXXXXX)
 readonly errlog=$(mktemp $TEST_TMPDIR/err.XXXXXX)

--- a/bazel/candid.bzl
+++ b/bazel/candid.bzl
@@ -21,7 +21,7 @@ readonly tmpfile=$(mktemp $TEST_TMPDIR/prev.XXXXXX)
 readonly errlog=$(mktemp $TEST_TMPDIR/err.XXXXXX)
 
 if ! git show $merge_base:{did_path} > $tmpfile 2> $errlog; then
-    if grep -sq -- "exists on disk, but not in \\|does not exist in 'HEAD'" $errlog; then
+    if grep -sq -- "does not exist in" $errlog; then
         echo "{did_path} is a new file, skipping backwards compatibility check"
         exit 0
     else

--- a/bazel/candid.bzl
+++ b/bazel/candid.bzl
@@ -14,7 +14,7 @@ if [[ $mr_title == *"[override-didc-check]"* ]]; then
     exit 0
 fi
 
-if [ -z "${CI_MERGE_REQUEST_TARGET_BRANCH_NAME:-}" ]; then
+if [ -z "${{CI_MERGE_REQUEST_TARGET_BRANCH_NAME:-}}" ]; then
   readonly target_branch_name="HEAD"
 else
   readonly target_branch_name="origin/$CI_MERGE_REQUEST_TARGET_BRANCH_NAME"

--- a/bazel/candid.bzl
+++ b/bazel/candid.bzl
@@ -14,10 +14,8 @@ if [[ $mr_title == *"[override-didc-check]"* ]]; then
     exit 0
 fi
 
-# https://docs.gitlab.com/ee/ci/variables/predefined_variables.html
-# The HEAD SHA of the target branch of the merge request. The variable is empty in merge request pipelines. 
-# The SHA is present only in merged results pipelines.
-readonly merge_base=${{CI_MERGE_REQUEST_TARGET_BRANCH_SHA:-HEAD}}
+readonly target_branch_name=${{CI_MERGE_REQUEST_TARGET_BRANCH_NAME:-HEAD}}
+readonly merge_base="$(git merge-base $target_branch_name HEAD)"
 
 readonly tmpfile=$(mktemp $TEST_TMPDIR/prev.XXXXXX)
 readonly errlog=$(mktemp $TEST_TMPDIR/err.XXXXXX)
@@ -39,7 +37,7 @@ echo DID_PATH={did_path}
 echo "{did_path} passed candid checks"
 
 # In addition to the usual `didc check after.did before.did` it can be helpful to check the reverse as well.
-# This is This is useful when it is expected that clients will "jump the gun", i.e. upgrade before servers. 
+# This is This is useful when it is expected that clients will "jump the gun", i.e. upgrade before servers.
 # This is an unusual (but not unheard of) use case.
 if [ {enable_also_reverse} = True ]; then
     echo "running also-reverse check"
@@ -54,7 +52,7 @@ fi
 
     return [
         DefaultInfo(runfiles = runfiles),
-        RunEnvironmentInfo(inherited_environment = ["CI_MERGE_REQUEST_TARGET_BRANCH_SHA", "CI_MERGE_REQUEST_TITLE"]),
+        RunEnvironmentInfo(inherited_environment = ["CI_MERGE_REQUEST_TARGET_BRANCH_NAME", "CI_MERGE_REQUEST_TITLE"]),
     ]
 
 CHECK_DID = attr.label(


### PR DESCRIPTION
As discussed in [this slack thread](https://dfinity.slack.com/archives/CL7Q2RXUM/p1721393630190629) the variable `CI_MERGE_REQUEST_TARGET_BRANCH_SHA` doesn't exist on GitHub which meant the `did_git_test` would always compare the compatibility of the Candid interface files of the PR with the PR itself, which would obviously always succeed.

We fix this by setting `CI_MERGE_REQUEST_TARGET_BRANCH_SHA` to `${{ github.event.pull_request.base.sha }}`.

Tested in https://github.com/dfinity/ic/pull/500 by applying this fix on a backwards incompatible change and observing that `//rs/sns/swap:sns-swap-canister_did_git_test` [fails](https://dash.zh1-idx1.dfinity.network/invocation/062e1d73-4bfd-43be-a98c-ad0415609d32?target=%2F%2Frs%2Fsns%2Fswap%3Asns-swap-canister_did_git_test&targetStatus=6) as expected.