### PR TITLE
fix(IDX): move build filters

### DIFF
--- a/bazel/conf/.bazelrc.build
+++ b/bazel/conf/.bazelrc.build
@@ -52,6 +52,8 @@ build --build_tag_filters="-system_test,-upload,-fuzz_test"
 test --test_tag_filters="-system_test,-post_master,-fuzz_test"
 test:alltests --test_tag_filters=""
 test:paritytests --test_tag_filters="-system_test"
+build:ci --build_tag_filters="-system_test,-fuzz_test"
+build:ci --verbose_failures
 test:ci --test_tag_filters="-post_master,-system_test_hourly,-system_test_nightly,-system_test_nightly_nns,-system_test_staging,-system_test_hotfix,-fuzz_test,-nns_tests_nightly"
 
 test --test_output=errors

--- a/bazel/conf/.bazelrc.internal
+++ b/bazel/conf/.bazelrc.internal
@@ -30,8 +30,6 @@ build    --remote_upload_local_results=false
 build:ci --remote_upload_local_results=true
 
 build:ci --noremote_local_fallback
-build:ci --build_tag_filters="-system_test,-fuzz_test"
-build:ci --verbose_failures
 
 # Run `bazel build ... --config=local` to build targets without cache (and without build event upload).
 build:local --remote_cache=


### PR DESCRIPTION
This moves some build filters & the verbose flag from the internal bazelrc to the base bazelrc, since they are not internal-only. This was overlooked in https://github.com/dfinity/ic/pull/459.