### PR TITLE
chore(IDX): set wasm paths via env

### DIFF
--- a/rs/bitcoin/ckbtc/minter/BUILD.bazel
+++ b/rs/bitcoin/ckbtc/minter/BUILD.bazel
@@ -134,16 +134,16 @@ rust_ic_test(
     srcs = ["tests/tests.rs"],
     data = [
         ":ckbtc_minter_debug.wasm",
-        "//rs/bitcoin/ckbtc/kyt:kyt_canister.wasm",
-        "//rs/bitcoin/mock:bitcoin_canister_mock.wasm",
-        "//rs/rosetta-api/icrc1/ledger:ledger_canister.wasm",
+        "//rs/bitcoin/ckbtc/kyt:kyt_canister",
+        "//rs/bitcoin/mock:bitcoin_canister_mock",
+        "//rs/rosetta-api/icrc1/ledger:ledger_canister",
     ],
     env = {
         "CARGO_MANIFEST_DIR": "rs/bitcoin/ckbtc/minter",
         "IC_CKBTC_MINTER_WASM_PATH": "$(rootpath :ckbtc_minter_debug.wasm)",
-        "IC_ICRC1_LEDGER_WASM_PATH": "$(rootpath //rs/rosetta-api/icrc1/ledger:ledger_canister.wasm)",
-        "IC_CKBTC_KYT_WASM_PATH": "$(rootpath //rs/bitcoin/ckbtc/kyt:kyt_canister.wasm)",
-        "IC_BITCOIN_CANISTER_MOCK_WASM_PATH": "$(rootpath //rs/bitcoin/mock:bitcoin_canister_mock.wasm)",
+        "IC_ICRC1_LEDGER_WASM_PATH": "$(rootpath //rs/rosetta-api/icrc1/ledger:ledger_canister)",
+        "IC_CKBTC_KYT_WASM_PATH": "$(rootpath //rs/bitcoin/ckbtc/kyt:kyt_canister)",
+        "IC_BITCOIN_CANISTER_MOCK_WASM_PATH": "$(rootpath //rs/bitcoin/mock:bitcoin_canister_mock)",
     },
     deps = [
         # Keep sorted.

--- a/rs/tests/boundary_nodes/BUILD.bazel
+++ b/rs/tests/boundary_nodes/BUILD.bazel
@@ -14,6 +14,10 @@ TEST_CANISTERS_RUNTIME_DEPS = [
 
 system_test(
     name = "boundary_node_integration_test",
+    env = {
+        "KV_STORE_WASM_PATH": "$(rootpath //rs/tests/test_canisters/kv_store)",
+        "HTTP_COUNTER_WASM_PATH": "$(rootpath //rs/tests/test_canisters/http_counter)",
+    },
     flaky = True,
     proc_macro_deps = MACRO_DEPENDENCIES,
     tags = [
@@ -26,6 +30,10 @@ system_test(
 
 system_test(
     name = "boundary_node_integration_on_playnet_test",
+    env = {
+        "KV_STORE_WASM_PATH": "$(rootpath //rs/tests/test_canisters/kv_store)",
+        "HTTP_COUNTER_WASM_PATH": "$(rootpath //rs/tests/test_canisters/http_counter)",
+    },
     flaky = True,
     proc_macro_deps = MACRO_DEPENDENCIES,
     tags = [
@@ -52,6 +60,9 @@ system_test(
 
 system_test(
     name = "certificate_orchestrator_test",
+    env = {
+        "CERTIFICATE_ORCHESTRATOR_WASM_PATH": "$(rootpath //rs/boundary_node/certificate_issuance/certificate_orchestrator:certificate_orchestrator)",
+    },
     proc_macro_deps = MACRO_DEPENDENCIES,
     tags = [
         "k8s",
@@ -123,6 +134,9 @@ system_test(
 
 system_test(
     name = "custom_domains_integration_test",
+    env = {
+        "CERTIFICATE_ORCHESTRATOR_WASM_PATH": "$(rootpath //rs/boundary_node/certificate_issuance/certificate_orchestrator:certificate_orchestrator)",
+    },
     proc_macro_deps = MACRO_DEPENDENCIES,
     tags = [
         "manual",

--- a/rs/tests/financial_integrations/BUILD.bazel
+++ b/rs/tests/financial_integrations/BUILD.bazel
@@ -32,6 +32,9 @@ system_test(
 
 system_test(
     name = "icrc1_agent_test",
+    env = {
+        "LEDGER_WASM_PATH": "$(rootpath //rs/rosetta-api/icrc1/ledger:ledger_canister)",
+    },
     flaky = True,
     proc_macro_deps = MACRO_DEPENDENCIES,
     tags = [

--- a/rs/tests/financial_integrations/ckbtc/BUILD.bazel
+++ b/rs/tests/financial_integrations/ckbtc/BUILD.bazel
@@ -13,6 +13,11 @@ CKBTC_RUNTIME_DEPS = [
 
 system_test(
     name = "ckbtc_minter_basics_test",
+    env = {
+        "IC_CKBTC_KYT_WASM_PATH": "$(rootpath //rs/bitcoin/ckbtc/kyt:kyt_canister)",
+        "IC_CKBTC_MINTER_WASM_PATH": "$(rootpath //rs/bitcoin/ckbtc/minter:ckbtc_minter_debug)",
+        "LEDGER_WASM_PATH": "$(rootpath //rs/rosetta-api/icrc1/ledger:ledger_canister)",
+    },
     flaky = True,
     proc_macro_deps = MACRO_DEPENDENCIES,
     tags = [
@@ -29,6 +34,11 @@ system_test(
 
 system_test(
     name = "ckbtc_minter_batching",
+    env = {
+        "IC_CKBTC_KYT_WASM_PATH": "$(rootpath //rs/bitcoin/ckbtc/kyt:kyt_canister)",
+        "IC_CKBTC_MINTER_WASM_PATH": "$(rootpath //rs/bitcoin/ckbtc/minter:ckbtc_minter_debug)",
+        "LEDGER_WASM_PATH": "$(rootpath //rs/rosetta-api/icrc1/ledger:ledger_canister)",
+    },
     flaky = True,
     proc_macro_deps = MACRO_DEPENDENCIES,
     tags = [
@@ -45,6 +55,11 @@ system_test(
 
 system_test(
     name = "ckbtc_minter_heartbeat",
+    env = {
+        "IC_CKBTC_KYT_WASM_PATH": "$(rootpath //rs/bitcoin/ckbtc/kyt:kyt_canister)",
+        "IC_CKBTC_MINTER_WASM_PATH": "$(rootpath //rs/bitcoin/ckbtc/minter:ckbtc_minter_debug)",
+        "LEDGER_WASM_PATH": "$(rootpath //rs/rosetta-api/icrc1/ledger:ledger_canister)",
+    },
     flaky = True,
     proc_macro_deps = MACRO_DEPENDENCIES,
     tags = [
@@ -61,6 +76,11 @@ system_test(
 
 system_test(
     name = "ckbtc_minter_kyt",
+    env = {
+        "IC_CKBTC_KYT_WASM_PATH": "$(rootpath //rs/bitcoin/ckbtc/kyt:kyt_canister)",
+        "IC_CKBTC_MINTER_WASM_PATH": "$(rootpath //rs/bitcoin/ckbtc/minter:ckbtc_minter_debug)",
+        "LEDGER_WASM_PATH": "$(rootpath //rs/rosetta-api/icrc1/ledger:ledger_canister)",
+    },
     flaky = True,
     proc_macro_deps = MACRO_DEPENDENCIES,
     tags = [
@@ -77,6 +97,11 @@ system_test(
 
 system_test(
     name = "ckbtc_minter_update_balance",
+    env = {
+        "IC_CKBTC_KYT_WASM_PATH": "$(rootpath //rs/bitcoin/ckbtc/kyt:kyt_canister)",
+        "IC_CKBTC_MINTER_WASM_PATH": "$(rootpath //rs/bitcoin/ckbtc/minter:ckbtc_minter_debug)",
+        "LEDGER_WASM_PATH": "$(rootpath //rs/rosetta-api/icrc1/ledger:ledger_canister)",
+    },
     flaky = True,
     proc_macro_deps = MACRO_DEPENDENCIES,
     tags = [
@@ -93,6 +118,11 @@ system_test(
 
 system_test(
     name = "ckbtc_minter_retrieve_btc",
+    env = {
+        "IC_CKBTC_KYT_WASM_PATH": "$(rootpath //rs/bitcoin/ckbtc/kyt:kyt_canister)",
+        "IC_CKBTC_MINTER_WASM_PATH": "$(rootpath //rs/bitcoin/ckbtc/minter:ckbtc_minter_debug)",
+        "LEDGER_WASM_PATH": "$(rootpath //rs/rosetta-api/icrc1/ledger:ledger_canister)",
+    },
     flaky = True,
     proc_macro_deps = MACRO_DEPENDENCIES,
     tags = [

--- a/rs/tests/message_routing/BUILD.bazel
+++ b/rs/tests/message_routing/BUILD.bazel
@@ -5,6 +5,9 @@ package(default_visibility = ["//visibility:public"])
 
 system_test(
     name = "global_reboot_test",
+    env = {
+        "XNET_TEST_CANISTER_WASM_PATH": "$(rootpath //rs/rust_canisters/xnet_test:xnet-test-canister)",
+    },
     flaky = False,
     proc_macro_deps = MACRO_DEPENDENCIES,
     tags = [

--- a/rs/tests/networking/BUILD.bazel
+++ b/rs/tests/networking/BUILD.bazel
@@ -24,6 +24,9 @@ CANISTER_HTTP_BASE_DEPS = [
 
 system_test(
     name = "canister_http_test",
+    env = {
+        "PROXY_WASM_PATH": "$(rootpath //rs/rust_canisters/proxy_canister:proxy_canister)",
+    },
     flaky = True,
     proc_macro_deps = MACRO_DEPENDENCIES,
     tags = ["k8s"],
@@ -38,6 +41,9 @@ system_test(
 
 system_test(
     name = "canister_http_socks_test",
+    env = {
+        "PROXY_WASM_PATH": "$(rootpath //rs/rust_canisters/proxy_canister:proxy_canister)",
+    },
     flaky = True,
     proc_macro_deps = MACRO_DEPENDENCIES,
     tags = [
@@ -61,6 +67,9 @@ system_test(
 
 system_test(
     name = "canister_http_correctness_test",
+    env = {
+        "PROXY_WASM_PATH": "$(rootpath //rs/rust_canisters/proxy_canister:proxy_canister)",
+    },
     flaky = True,
     proc_macro_deps = MACRO_DEPENDENCIES,
     tags = ["k8s"],
@@ -81,6 +90,9 @@ system_test(
 
 system_test(
     name = "canister_http_fault_tolerance_test",
+    env = {
+        "PROXY_WASM_PATH": "$(rootpath //rs/rust_canisters/proxy_canister:proxy_canister)",
+    },
     flaky = True,
     proc_macro_deps = MACRO_DEPENDENCIES,
     tags = [
@@ -105,6 +117,9 @@ system_test(
 
 system_test(
     name = "canister_http_time_out_test",
+    env = {
+        "PROXY_WASM_PATH": "$(rootpath //rs/rust_canisters/proxy_canister:proxy_canister)",
+    },
     flaky = True,
     proc_macro_deps = MACRO_DEPENDENCIES,
     tags = [

--- a/rs/tests/networking/canister_http/canister_http.rs
+++ b/rs/tests/networking/canister_http/canister_http.rs
@@ -15,6 +15,7 @@ use ic_system_test_driver::driver::{
 use ic_system_test_driver::util::{self, create_and_install};
 pub use ic_types::{CanisterId, PrincipalId};
 use slog::info;
+use std::env;
 use std::net::{Ipv4Addr, Ipv6Addr};
 use std::time::Duration;
 
@@ -234,7 +235,7 @@ pub fn create_proxy_canister<'a>(
     let proxy_canister_id = rt.block_on(create_and_install(
         &node.build_default_agent(),
         node.effective_canister_id(),
-        &env.load_wasm("rs/rust_canisters/proxy_canister/proxy_canister.wasm"),
+        &env.load_wasm(env::var("PROXY_WASM_PATH").expect("PROXY_WASM_PATH not set")),
     ));
     info!(
         &env.logger(),

--- a/rs/tests/networking/canister_http_fault_tolerance_test.rs
+++ b/rs/tests/networking/canister_http_fault_tolerance_test.rs
@@ -39,6 +39,7 @@ use ic_types::{CanisterId, PrincipalId};
 use ic_utils::interfaces::ManagementCanister;
 use proxy_canister::{RemoteHttpRequest, RemoteHttpResponse};
 use slog::info;
+use std::env;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 
@@ -113,7 +114,7 @@ pub fn test(env: TestEnv) {
             .0;
         mgr.install_code(
             &cid,
-            &env.load_wasm("rs/rust_canisters/proxy_canister/proxy_canister.wasm"),
+            &env.load_wasm(env::var("PROXY_WASM_PATH").expect("PROXY_WASM_PATH not set")),
         )
         .call_and_wait()
         .await

--- a/rs/tests/src/boundary_nodes/boundary_nodes_integration.rs
+++ b/rs/tests/src/boundary_nodes/boundary_nodes_integration.rs
@@ -35,7 +35,7 @@ use ic_system_test_driver::{
     },
     util::{agent_observes_canister_module, assert_create_agent, block_on},
 };
-use std::{iter, net::SocketAddrV6, time::Duration};
+use std::{env, iter, net::SocketAddrV6, time::Duration};
 
 use anyhow::{anyhow, bail, Error};
 use futures::stream::FuturesUnordered;
@@ -638,7 +638,8 @@ pub fn http_canister_test(env: TestEnv) {
     rt.block_on(async move {
         info!(&logger, "Creating replica agent...");
         let agent = assert_create_agent(install_node.0.as_str()).await;
-        let kv_store_canister = env.load_wasm("rs/tests/test_canisters/kv_store/kv_store.wasm");
+        let kv_store_canister =
+            env.load_wasm(env::var("KV_STORE_WASM_PATH").expect("KV_STORE_WASM_PATH not set"));
 
         info!(&logger, "installing canister");
         let canister_id = create_canister(&agent, install_node.1, &kv_store_canister, None)
@@ -819,7 +820,8 @@ pub fn prefix_canister_id_test(env: TestEnv) {
     rt.block_on(async move {
         info!(&logger, "Creating replica agent...");
         let agent = assert_create_agent(install_node.0.as_str()).await;
-        let kv_store_canister = env.load_wasm("rs/tests/test_canisters/kv_store/kv_store.wasm");
+        let kv_store_canister =
+            env.load_wasm(env::var("KV_STORE_WASM_PATH").expect("KV_STORE_WASM_PATH not set"));
 
         info!(&logger, "installing canister");
         let canister_id = create_canister(&agent, install_node.1, &kv_store_canister, None)
@@ -992,7 +994,8 @@ pub fn proxy_http_canister_test(env: TestEnv) {
     rt.block_on(async move {
         info!(&logger, "Creating replica agent...");
         let agent = assert_create_agent(install_node.0.as_str()).await;
-        let kv_store_canister = env.load_wasm("rs/tests/test_canisters/kv_store/kv_store.wasm");
+        let kv_store_canister =
+            env.load_wasm(env::var("KV_STORE_WASM_PATH").expect("KV_STORE_WASM_PATH not set"));
 
         info!(&logger, "installing canister");
         let canister_id = create_canister(&agent, install_node.1, &kv_store_canister, None)
@@ -1211,7 +1214,7 @@ pub fn denylist_test(env: TestEnv) {
         info!(&logger, "creating replica agent");
         let agent = assert_create_agent(install_node.as_ref().unwrap().0.as_str()).await;
 
-        let http_counter_canister = env.load_wasm("rs/tests/test_canisters/http_counter/http_counter.wasm");
+        let http_counter_canister = env.load_wasm(env::var("HTTP_COUNTER_WASM_PATH").expect("HTTP_COUNTER_WASM_PATH not set"));
 
         info!(&logger, "installing canister");
         let canister_id = create_canister(&agent, install_node.clone().unwrap().1, &http_counter_canister, None)
@@ -1322,7 +1325,7 @@ pub fn canister_allowlist_test(env: TestEnv) {
         info!(&logger, "creating replica agent");
         let agent = assert_create_agent(install_node.as_ref().unwrap().0.as_str()).await;
 
-        let http_counter_canister = env.load_wasm("rs/tests/test_canisters/http_counter/http_counter.wasm");
+        let http_counter_canister = env.load_wasm(env::var("HTTP_COUNTER_WASM_PATH").expect("HTTP_COUNTER_WASM_PATH not set"));
 
         info!(&logger, "installing canister");
         let canister_id = create_canister(&agent, install_node.clone().unwrap().1, &http_counter_canister, None)
@@ -2005,7 +2008,7 @@ pub fn icx_proxy_test(env: TestEnv) {
         .block_on(install_canister(
             env.clone(),
             logger.clone(),
-            "rs/tests/test_canisters/http_counter/http_counter.wasm",
+            &env::var("HTTP_COUNTER_WASM_PATH").expect("HTTP_COUNTER_WASM_PATH not set"),
         ))
         .unwrap();
 

--- a/rs/tests/src/certificate_orchestrator.rs
+++ b/rs/tests/src/certificate_orchestrator.rs
@@ -25,6 +25,7 @@ use ic_system_test_driver::{
     util::agent_observes_canister_module,
 };
 
+use std::env;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use anyhow::{anyhow, bail, Error};
@@ -58,9 +59,6 @@ pub fn config(env: TestEnv) {
             .for_each(|node| node.await_status_is_healthy().unwrap())
     });
 }
-
-const CERTIFICATE_ORCHESTRATOR_WASM: &str =
-    "rs/boundary_node/certificate_issuance/certificate_orchestrator/certificate_orchestrator.wasm";
 
 const CHECK_TIMEOUT: Duration = Duration::from_secs(60);
 const CHECK_SLEEP: Duration = Duration::from_secs(1);
@@ -99,8 +97,11 @@ pub fn access_control_test(env: TestEnv) {
     .unwrap();
 
     let app_node = env.get_first_healthy_application_node_snapshot();
-    let cid =
-        app_node.create_and_install_canister_with_arg(CERTIFICATE_ORCHESTRATOR_WASM, Some(args));
+    let cid = app_node.create_and_install_canister_with_arg(
+        &env::var("CERTIFICATE_ORCHESTRATOR_WASM_PATH")
+            .expect("CERTIFICATE_ORCHESTRATOR_WASM_PATH not set"),
+        Some(args),
+    );
 
     info!(&logger, "creating agent");
     let agent = app_node.build_default_agent();
@@ -255,8 +256,11 @@ pub fn registration_test(env: TestEnv) {
     .unwrap();
 
     let app_node = env.get_first_healthy_application_node_snapshot();
-    let cid =
-        app_node.create_and_install_canister_with_arg(CERTIFICATE_ORCHESTRATOR_WASM, Some(args));
+    let cid = app_node.create_and_install_canister_with_arg(
+        &env::var("CERTIFICATE_ORCHESTRATOR_WASM_PATH")
+            .expect("CERTIFICATE_ORCHESTRATOR_WASM_PATH not set"),
+        Some(args),
+    );
 
     info!(&logger, "creating agent");
     let agent = app_node.build_default_agent();
@@ -615,8 +619,11 @@ pub fn expiration_test(env: TestEnv) {
     .unwrap();
 
     let app_node = env.get_first_healthy_application_node_snapshot();
-    let cid =
-        app_node.create_and_install_canister_with_arg(CERTIFICATE_ORCHESTRATOR_WASM, Some(args));
+    let cid = app_node.create_and_install_canister_with_arg(
+        &env::var("CERTIFICATE_ORCHESTRATOR_WASM_PATH")
+            .expect("CERTIFICATE_ORCHESTRATOR_WASM_PATH not set"),
+        Some(args),
+    );
 
     info!(&logger, "creating agent");
     let agent = app_node.build_default_agent();
@@ -869,8 +876,11 @@ pub fn renewal_expiration_test(env: TestEnv) {
     .unwrap();
 
     let app_node = env.get_first_healthy_application_node_snapshot();
-    let cid =
-        app_node.create_and_install_canister_with_arg(CERTIFICATE_ORCHESTRATOR_WASM, Some(args));
+    let cid = app_node.create_and_install_canister_with_arg(
+        &env::var("CERTIFICATE_ORCHESTRATOR_WASM_PATH")
+            .expect("CERTIFICATE_ORCHESTRATOR_WASM_PATH not set"),
+        Some(args),
+    );
 
     info!(&logger, "creating agent");
     let agent = app_node.build_default_agent();
@@ -1093,8 +1103,11 @@ pub fn task_queue_test(env: TestEnv) {
     .unwrap();
 
     let app_node = env.get_first_healthy_application_node_snapshot();
-    let cid =
-        app_node.create_and_install_canister_with_arg(CERTIFICATE_ORCHESTRATOR_WASM, Some(args));
+    let cid = app_node.create_and_install_canister_with_arg(
+        &env::var("CERTIFICATE_ORCHESTRATOR_WASM_PATH")
+            .expect("CERTIFICATE_ORCHESTRATOR_WASM_PATH not set"),
+        Some(args),
+    );
 
     info!(&logger, "creating agent");
     let agent = app_node.build_default_agent();
@@ -1474,8 +1487,11 @@ pub fn retry_test(env: TestEnv) {
     .unwrap();
 
     let app_node = env.get_first_healthy_application_node_snapshot();
-    let cid =
-        app_node.create_and_install_canister_with_arg(CERTIFICATE_ORCHESTRATOR_WASM, Some(args));
+    let cid = app_node.create_and_install_canister_with_arg(
+        &env::var("CERTIFICATE_ORCHESTRATOR_WASM_PATH")
+            .expect("CERTIFICATE_ORCHESTRATOR_WASM_PATH not set"),
+        Some(args),
+    );
 
     info!(&logger, "creating agent");
     let agent = app_node.build_default_agent();
@@ -1649,8 +1665,11 @@ pub fn certificate_export_test(env: TestEnv) {
     .unwrap();
 
     let app_node = env.get_first_healthy_application_node_snapshot();
-    let cid =
-        app_node.create_and_install_canister_with_arg(CERTIFICATE_ORCHESTRATOR_WASM, Some(args));
+    let cid = app_node.create_and_install_canister_with_arg(
+        &env::var("CERTIFICATE_ORCHESTRATOR_WASM_PATH")
+            .expect("CERTIFICATE_ORCHESTRATOR_WASM_PATH not set"),
+        Some(args),
+    );
 
     info!(&logger, "creating agent");
     let agent = app_node.build_default_agent();

--- a/rs/tests/src/ckbtc/lib.rs
+++ b/rs/tests/src/ckbtc/lib.rs
@@ -47,7 +47,7 @@ use ic_types_test_utils::ids::subnet_test_id;
 use icp_ledger::ArchiveOptions;
 use registry_canister::mutations::do_update_subnet::UpdateSubnetPayload;
 use slog::{debug, info, Logger};
-use std::{str::FromStr, time::Duration};
+use std::{env, str::FromStr, time::Duration};
 
 pub(crate) const TEST_KEY_LOCAL: &str = "dfx_test_key";
 
@@ -313,7 +313,9 @@ pub(crate) async fn install_minter(
 
     install_rust_canister_from_path(
         canister,
-        env.get_dependency_path("rs/bitcoin/ckbtc/minter/ckbtc_minter_debug.wasm"),
+        env.get_dependency_path(
+            &env::var("IC_CKBTC_MINTER_WASM_PATH").expect("IC_CKBTC_MINTER_WASM_PATH not set"),
+        ),
         Some(Encode!(&minter_arg).unwrap()),
     )
     .await;
@@ -336,7 +338,9 @@ pub(crate) async fn install_kyt(
 
     install_rust_canister_from_path(
         kyt_canister,
-        env.get_dependency_path("rs/bitcoin/ckbtc/kyt/kyt_canister.wasm"),
+        env.get_dependency_path(
+            &env::var("IC_CKBTC_KYT_WASM_PATH").expect("IC_CKBTC_KYT_WASM_PATH not set"),
+        ),
         Some(Encode!(&kyt_init_args).unwrap()),
     )
     .await;

--- a/rs/tests/src/custom_domains_integration/setup.rs
+++ b/rs/tests/src/custom_domains_integration/setup.rs
@@ -17,7 +17,7 @@ use ic_system_test_driver::{
 };
 
 use serde_json::json;
-use std::{io::Read, net::SocketAddrV6, time::Duration};
+use std::{env, io::Read, net::SocketAddrV6, time::Duration};
 
 use anyhow::{anyhow, Context, Error};
 use candid::{Encode, Principal};
@@ -35,9 +35,6 @@ use rand::{rngs::OsRng, SeedableRng};
 use rand_chacha::ChaChaRng;
 use reqwest::{redirect::Policy, Client, ClientBuilder};
 use tokio::task::{self, JoinHandle};
-
-const CERTIFICATE_ORCHESTRATOR_WASM: &str =
-    "rs/boundary_node/certificate_issuance/certificate_orchestrator/certificate_orchestrator.wasm";
 
 pub(crate) const CLOUDFLARE_API_PYTHON_PATH: &str = "/config/cloudflare_api.py";
 pub(crate) const PEBBLE_CACHE_PYTHON_PATH: &str = "/config/pebble_cache.py";
@@ -419,7 +416,8 @@ async fn setup_certificate_orchestartor(
         move || {
             env.get_first_healthy_application_node_snapshot()
                 .create_and_install_canister_with_arg(
-                    CERTIFICATE_ORCHESTRATOR_WASM,
+                    &env::var("CERTIFICATE_ORCHESTRATOR_WASM_PATH")
+                        .expect("CERTIFICATE_ORCHESTRATOR_WASM_PATH not set"),
                     Encode!(&InitArg {
                         id_seed: 0,
                         root_principals,

--- a/rs/tests/src/icrc1_agent_test/mod.rs
+++ b/rs/tests/src/icrc1_agent_test/mod.rs
@@ -18,6 +18,7 @@ use icrc_ledger_types::{
     icrc::generic_metadata_value::MetadataValue as Value, icrc3::blocks::GetBlocksRequest,
 };
 use on_wire::IntoWire;
+use std::env;
 
 use ic_system_test_driver::{
     driver::{
@@ -404,7 +405,7 @@ pub async fn install_icrc1_ledger<'a>(
 ) {
     install_rust_canister_from_path(
         canister,
-        env.get_dependency_path("rs/rosetta-api/icrc1/ledger/ledger_canister.wasm"),
+        env.get_dependency_path(&env::var("LEDGER_WASM_PATH").expect("LEDGER_WASM_PATH not set")),
         Some(Encode!(&args).unwrap()),
     )
     .await

--- a/rs/tests/src/message_routing/global_reboot_test.rs
+++ b/rs/tests/src/message_routing/global_reboot_test.rs
@@ -25,6 +25,7 @@ Success::
 
 end::catalog[] */
 
+use std::env;
 use std::time::Duration;
 
 use ic_system_test_driver::driver::test_env::TestEnv;
@@ -77,9 +78,9 @@ pub fn test(env: TestEnv) {
         .map(|n| runtime_from_url(n.get_public_url(), n.effective_canister_id()))
         .collect();
     // Step 1: Install Xnet canisters on each subnet.
-    let wasm = Wasm::from_file(
-        env.get_dependency_path("rs/rust_canisters/xnet_test/xnet-test-canister.wasm"),
-    );
+    let wasm = Wasm::from_file(env.get_dependency_path(
+        env::var("XNET_TEST_CANISTER_WASM_PATH").expect("XNET_TEST_CANISTER_WASM_PATH not set"),
+    ));
     info!(log, "Installing Xnet canisters on subnets ...");
     let canisters = install_canisters(&runtimes, SUBNETS_COUNT, CANISTERS_PER_SUBNET, wasm);
     let canisters_count = canisters.iter().map(Vec::len).sum::<usize>();

--- a/rs/tests/src/message_routing/mod.rs
+++ b/rs/tests/src/message_routing/mod.rs
@@ -12,6 +12,7 @@ mod common {
     use dfn_candid::candid;
     use futures::{future::join_all, Future};
     use slog::info;
+    use std::env;
     use xnet_test::CanisterId;
 
     use ic_system_test_driver::driver::{test_env::TestEnv, test_env_api::HasDependencies};
@@ -58,9 +59,9 @@ mod common {
         canisters_per_subnet: usize,
     ) -> Vec<Vec<Canister>> {
         let logger = env.logger();
-        let wasm = Wasm::from_file(
-            env.get_dependency_path("rs/rust_canisters/xnet_test/xnet-test-canister.wasm"),
-        );
+        let wasm = Wasm::from_file(env.get_dependency_path(
+            env::var("XNET_TEST_CANISTER_WASM_PATH").expect("XNET_TEST_CANISTER_WASM_PATH not set"),
+        ));
         let mut futures: Vec<Vec<_>> = Vec::new();
         for subnet_idx in 0..subnets {
             futures.push(vec![]);

--- a/rs/tests/src/nns_dapp.rs
+++ b/rs/tests/src/nns_dapp.rs
@@ -153,7 +153,7 @@ pub fn install_ii_nns_dapp_and_subnet_rental(
         .with_token_name("ckETH".to_string())
         .build();
     let cketh_canister_id = nns_node.create_and_install_canister_with_arg(
-        &env::var("ICRC1_LEDGER_WASM_PATH").unwrap(),
+        &env::var("ICRC1_LEDGER_WASM_PATH").expect("ICRC1_LEDGER_WASM_PATH not set"),
         Some(Encode!(&(LedgerArgument::Init(cketh_init_args))).unwrap()),
     );
 

--- a/rs/tests/testing_verification/testnets/src_testing.rs
+++ b/rs/tests/testing_verification/testnets/src_testing.rs
@@ -191,7 +191,7 @@ pub fn setup(env: TestEnv) {
     // we set the exchange rate to 12 XDR per 1 ICP
     let xrc_payload = new_icp_cxdr_mock_exchange_rate_canister_init_payload(12_000_000_000);
     let xrc_canister_id = xrc_node.create_and_install_canister_with_arg(
-        &env::var("XRC_WASM_PATH").unwrap(),
+        &env::var("XRC_WASM_PATH").expect("XRC_WASM_PATH not set"),
         Some(Encode!(&xrc_payload).unwrap()),
     );
     assert_eq!(xrc_canister_id, default_xrc_principal_id.into());


### PR DESCRIPTION
This updates tests to read the path of Wasm modules from environment variables, instead of hard coding Bazel-specific paths. This continues what was done for the NNS dapp here: https://github.com/dfinity/ic/pull/389