### PR TITLE
fix(IDX): disable unused aarch64-darwin code

### DIFF
--- a/rs/execution_environment/src/hypervisor/tests.rs
+++ b/rs/execution_environment/src/hypervisor/tests.rs
@@ -41,6 +41,7 @@ use ic_types::{
 };
 use ic_universal_canister::{call_args, wasm, UNIVERSAL_CANISTER_WASM};
 use proptest::prelude::*;
+#[cfg(not(all(target_arch = "aarch64", target_vendor = "apple")))]
 use proptest::test_runner::{TestRng, TestRunner};
 use std::collections::BTreeSet;
 use std::mem::size_of;
@@ -3864,6 +3865,7 @@ impl MemoryAccessor {
         assert_empty_reply(result);
     }
 
+    #[cfg(not(all(target_arch = "aarch64", target_vendor = "apple")))]
     fn verify_dirty_pages(&self, is_dirty_page: &[bool]) {
         let execution_state = self.test.execution_state(self.canister_id);
         let mut actual_dirty = vec![false; is_dirty_page.len()];
@@ -3922,6 +3924,7 @@ fn write_after_grow() {
 }
 
 #[derive(Debug, Clone)]
+#[cfg(not(all(target_arch = "aarch64", target_vendor = "apple")))]
 enum Operation {
     Read(i32),
     Write(i32, u8),
@@ -3929,6 +3932,7 @@ enum Operation {
     GrowAndWrite(u8),
 }
 
+#[cfg(not(all(target_arch = "aarch64", target_vendor = "apple")))]
 fn random_operations(
     num_pages: i32,
     num_operations: usize,

--- a/rs/execution_environment/src/scheduler/test_utilities.rs
+++ b/rs/execution_environment/src/scheduler/test_utilities.rs
@@ -744,6 +744,7 @@ impl SchedulerTestBuilder {
         Self { batch_time, ..self }
     }
 
+    #[cfg(not(all(target_arch = "aarch64", target_vendor = "apple")))]
     pub fn with_round_summary(self, round_summary: ExecutionRoundSummary) -> Self {
         Self {
             round_summary: Some(round_summary),


### PR DESCRIPTION
This removes (via `cfg`) some code that isn't built on Apple Silicon. This fixes clippy hints for Apple Silicon.