### PR TITLE
fix(PocketIC): make CallRequest of type V3 deterministic

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -507,6 +507,7 @@ hyper-socks2 = { version = "0.8.0", default-features = false, features = [
     "rustls",
 ] }
 ic-agent = { version = "0.35.0", features = ["hyper"] }
+# TODO: [NET-1734] Delete this once the feature is merged to master.
 ic-agent-call-v3 = { package = "ic-agent", git = "https://github.com/dfinity/agent-rs", rev = "9e45b314fc7496d48065590fac90790e0bdc6eed", features = [
     "sync_call",
 ] }

--- a/rs/pocket_ic_server/CHANGELOG.md
+++ b/rs/pocket_ic_server/CHANGELOG.md
@@ -30,8 +30,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for canister HTTP outcalls: endpoint `/instances/<instance_id>/get_canister_http` to retrieve pending canister HTTP outcalls
   and endpoint `/instances/<instance_id>/mock_canister_http_response` to mock a response for a pending canister HTTP outcall,
   the server produces responses for pending canister HTTP outcalls automatically in the auto-progress mode (started by calling the endpoint `/instances/<instance_id>/auto_progress`).
-- Added new endpoint `/instance/<instance_id>/api/v3/canister/<effective_canister_id>/call` to support update calls to the new
-  synchronous ingress message endpoint.
+- New endpoint `/instance/<instance_id>/api/v3/canister/<effective_canister_id>/call` supporting a synchronous HTTP interface of the IC for update calls.
+  Note that this endpoint might non-deterministically return a response with status code 202 and empty body.
   
 ### Fixed
 - Executing a query call on a new PocketIC instance crashed the PocketIC server.

--- a/rs/pocket_ic_server/CHANGELOG.md
+++ b/rs/pocket_ic_server/CHANGELOG.md
@@ -31,7 +31,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and endpoint `/instances/<instance_id>/mock_canister_http_response` to mock a response for a pending canister HTTP outcall,
   the server produces responses for pending canister HTTP outcalls automatically in the auto-progress mode (started by calling the endpoint `/instances/<instance_id>/auto_progress`).
 - New endpoint `/instance/<instance_id>/api/v3/canister/<effective_canister_id>/call` supporting a synchronous HTTP interface of the IC for update calls.
-  Note that this endpoint might non-deterministically return a response with status code 202 and empty body.
+  Note that this endpoint might non-deterministically return a response with status code 202 and empty body (in this case, the status of the call
+  must be polled at the endpoint `/instance/<instance_id>/api/v3/canister/<effective_canister_id>/read_state`).
   
 ### Fixed
 - Executing a query call on a new PocketIC instance crashed the PocketIC server.

--- a/rs/pocket_ic_server/src/pocket_ic.rs
+++ b/rs/pocket_ic_server/src/pocket_ic.rs
@@ -93,6 +93,9 @@ use tower::{
 // See build.rs
 include!(concat!(env!("OUT_DIR"), "/dashboard.rs"));
 
+/// The response type for `/api/v2` and `/api/v3` IC endpoint operations.
+pub(crate) type ApiResponse = BoxFuture<'static, (u16, BTreeMap<String, Vec<u8>>, Vec<u8>)>;
+
 /// We assume that the maximum number of subnets on the mainnet is 1024.
 /// Used for generating canister ID ranges that do not appear on mainnet.
 pub const MAXIMUM_NUMBER_OF_SUBNETS_ON_MAINNET: u64 = 1024;
@@ -1379,8 +1382,7 @@ impl Operation for DashboardRequest {
                 .into_response(),
         };
 
-        #[allow(clippy::type_complexity)]
-        let fut: BoxFuture<'static, (u16, BTreeMap<String, Vec<u8>>, Vec<u8>)> = Box::pin(async {
+        let fut: ApiResponse = Box::pin(async {
             (
                 resp.status().into(),
                 resp.headers()
@@ -1482,8 +1484,7 @@ impl Operation for StatusRequest {
             .block_on(async { status(State((Arc::new(root_key), Arc::new(PocketHealth)))).await })
             .into_response();
 
-        #[allow(clippy::type_complexity)]
-        let fut: BoxFuture<'static, (u16, BTreeMap<String, Vec<u8>>, Vec<u8>)> = Box::pin(async {
+        let fut: ApiResponse = Box::pin(async {
             (
                 resp.status().into(),
                 resp.headers()
@@ -1625,11 +1626,7 @@ impl Operation for CallRequest {
                     .body(self.bytes.clone().into())
                     .unwrap();
 
-                #[allow(clippy::type_complexity)]
-                let fut: BoxFuture<
-                    'static,
-                    (u16, BTreeMap<String, Vec<u8>>, Vec<u8>),
-                > = Box::pin(async {
+                let fut: ApiResponse = Box::pin(async {
                     let resp = svc.oneshot(request).await.unwrap();
                     (
                         resp.status().into(),
@@ -1736,11 +1733,7 @@ impl Operation for QueryRequest {
                     .unwrap();
                 let resp = pic.runtime.block_on(svc.oneshot(request)).unwrap();
 
-                #[allow(clippy::type_complexity)]
-                let fut: BoxFuture<
-                    'static,
-                    (u16, BTreeMap<String, Vec<u8>>, Vec<u8>),
-                > = Box::pin(async {
+                let fut: ApiResponse = Box::pin(async {
                     (
                         resp.status().into(),
                         resp.headers()
@@ -1808,11 +1801,7 @@ impl Operation for ReadStateRequest {
                     .unwrap();
                 let resp = pic.runtime.block_on(svc.oneshot(request)).unwrap();
 
-                #[allow(clippy::type_complexity)]
-                let fut: BoxFuture<
-                    'static,
-                    (u16, BTreeMap<String, Vec<u8>>, Vec<u8>),
-                > = Box::pin(async {
+                let fut: ApiResponse = Box::pin(async {
                     (
                         resp.status().into(),
                         resp.headers()

--- a/rs/pocket_ic_server/src/pocket_ic.rs
+++ b/rs/pocket_ic_server/src/pocket_ic.rs
@@ -9,6 +9,8 @@ use axum::{
     response::{Html, IntoResponse},
 };
 use candid::Decode;
+use futures::future::BoxFuture;
+use futures::FutureExt;
 use hyper::body::Bytes;
 use hyper::header::{HeaderValue, CONTENT_TYPE};
 use hyper::{Method, StatusCode};
@@ -80,7 +82,6 @@ use std::{
 };
 use tempfile::TempDir;
 use tokio::{runtime::Runtime, sync::mpsc};
-use tokio_util::sync::CancellationToken;
 use tonic::transport::{Channel, Server};
 use tonic::transport::{Endpoint, Uri};
 use tonic::{Code, Request, Response, Status};
@@ -95,10 +96,6 @@ include!(concat!(env!("OUT_DIR"), "/dashboard.rs"));
 /// We assume that the maximum number of subnets on the mainnet is 1024.
 /// Used for generating canister ID ranges that do not appear on mainnet.
 pub const MAXIMUM_NUMBER_OF_SUBNETS_ON_MAINNET: u64 = 1024;
-
-/// The interval that pocket-ic should try to execute rounds on all subnets,
-/// when running synchronous update calls for the [`CallRequest`] operation.
-const EXECUTE_ROUND_INTERVAL: Duration = Duration::from_millis(50);
 
 fn compute_subnet_seed(
     ranges: Vec<CanisterIdRange>,
@@ -1578,7 +1575,7 @@ impl Operation for CallRequest {
                 // forwards it to the state machine. The task will automatically terminate
                 // once it submits an ingress message received from the call service to the
                 // `StateMachine`, or if the call service is dropped (in which case `r.recv().await` returns `None`).
-                pic.runtime.spawn(async move {
+                let ingress_proxy_task = pic.runtime.spawn(async move {
                     if let Some(UnvalidatedArtifactMutation::Insert((msg, _node_id))) =
                         r.recv().await
                     {
@@ -1621,43 +1618,38 @@ impl Operation for CallRequest {
                     .body(self.bytes.clone().into())
                     .unwrap();
 
-                let cancellation_token = CancellationToken::new();
-                let cancellation_token_clone = cancellation_token.clone();
-
-                // TODO: Allow parallel execution of V3 ingress messages.
-                //
-                // We are blocking the pic here, when in the CallRequest operation.
-                // This won't let us execute V3 ingress messages concurrently.
-                let resp = std::thread::scope(|s| {
-                    // We have to execute rounds for V3 calls, since the endpoint
-                    // waits for message to be executed and certified.
-                    if let CallRequestVersion::V3 = self.version {
-                        s.spawn(|| {
-                            while !cancellation_token_clone.is_cancelled() {
-                                for subnet in pic.subnets.read().unwrap().values() {
-                                    subnet.execute_round();
-                                }
-                                std::thread::sleep(EXECUTE_ROUND_INTERVAL);
-                            }
-                        });
-                    }
-
-                    let response = pic.runtime.block_on(svc.oneshot(request)).unwrap();
-                    cancellation_token.cancel();
-                    response
+                #[allow(clippy::type_complexity)]
+                let fut: BoxFuture<
+                    'static,
+                    (u16, BTreeMap<String, Vec<u8>>, Vec<u8>),
+                > = Box::pin(async {
+                    let resp = svc.oneshot(request).await.unwrap();
+                    (
+                        resp.status().into(),
+                        resp.headers()
+                            .iter()
+                            .map(|(name, value)| {
+                                (name.as_str().to_string(), value.as_bytes().to_vec())
+                            })
+                            .collect(),
+                        axum::body::to_bytes(resp.into_body(), usize::MAX)
+                            .await
+                            .unwrap()
+                            .to_vec(),
+                    )
                 });
+                let shared = fut.shared();
 
-                OpOut::RawResponse((
-                    resp.status().into(),
-                    resp.headers()
-                        .iter()
-                        .map(|(name, value)| (name.as_str().to_string(), value.as_bytes().to_vec()))
-                        .collect(),
-                    pic.runtime
-                        .block_on(axum::body::to_bytes(resp.into_body(), usize::MAX))
-                        .unwrap()
-                        .to_vec(),
-                ))
+                let service_task = pic.runtime.spawn(shared.clone());
+
+                loop {
+                    if service_task.is_finished() {
+                        let resp = pic.runtime.block_on(shared);
+                        break OpOut::RawResponse(resp);
+                    } else if ingress_proxy_task.is_finished() {
+                        break OpOut::RawResponseV3(shared);
+                    }
+                }
             }
         }
     }
@@ -2404,10 +2396,12 @@ mod tests {
         let unix_time_ns = 1640995200000000000; // 1st Jan 2022
         let time = Time::from_nanos_since_unix_epoch(unix_time_ns);
         compute_assert_state_change(&mut pic, SetTime { time });
-        let expected_time = OpOut::Time(unix_time_ns);
         let actual_time = compute_assert_state_immutable(&mut pic, GetTime {});
 
-        assert_eq!(expected_time, actual_time);
+        match actual_time {
+            OpOut::Time(actual_time_ns) => assert_eq!(unix_time_ns, actual_time_ns),
+            _ => panic!("Unexpected OpOut: {:?}", actual_time),
+        };
     }
 
     #[test]

--- a/rs/pocket_ic_server/src/state_api/routes.rs
+++ b/rs/pocket_ic_server/src/state_api/routes.rs
@@ -11,8 +11,7 @@ use crate::pocket_ic::{
     GetTopology, MockCanisterHttp, PubKey, Query, QueryRequest, ReadStateRequest, SetStableMemory,
     SetTime, StatusRequest, SubmitIngressMessage, Tick,
 };
-use crate::OpId;
-use crate::{pocket_ic::PocketIc, BlobStore, InstanceId, Operation};
+use crate::{async_trait, pocket_ic::PocketIc, BlobStore, InstanceId, OpId, Operation};
 use aide::{
     axum::routing::{delete, get, post, ApiMethodRouter},
     axum::ApiRouter,
@@ -206,15 +205,12 @@ where
         .api_route("/:id/stop", post(stop_http_gateway))
 }
 
-async fn run_operation<T: Serialize>(
+async fn run_operation<T: Serialize + FromOpOut>(
     api_state: Arc<ApiState>,
     instance_id: InstanceId,
     timeout: Option<Duration>,
     op: impl Operation + Send + Sync + 'static,
-) -> (StatusCode, ApiResponse<T>)
-where
-    (StatusCode, ApiResponse<T>): From<OpOut>,
-{
+) -> (StatusCode, ApiResponse<T>) {
     let retry_if_busy = op.retry_if_busy();
     let op = Arc::new(op);
     let mut retry_policy: ExponentialBackoff = ExponentialBackoffBuilder::new()
@@ -277,7 +273,7 @@ where
                             );
                         }
                     }
-                    UpdateReply::Output(op_out) => break op_out.into(),
+                    UpdateReply::Output(op_out) => break FromOpOut::from(op_out).await,
                 }
             }
         }
@@ -287,8 +283,14 @@ where
 #[derive(Debug, Copy, Clone)]
 pub struct OpConversionError;
 
-impl<T: TryFrom<OpOut>> From<OpOut> for (StatusCode, ApiResponse<T>) {
-    fn from(value: OpOut) -> Self {
+#[async_trait]
+trait FromOpOut: Sized {
+    async fn from(value: OpOut) -> (StatusCode, ApiResponse<Self>);
+}
+
+#[async_trait]
+impl<T: TryFrom<OpOut>> FromOpOut for T {
+    async fn from(value: OpOut) -> (StatusCode, ApiResponse<T>) {
         // match errors explicitly to make sure they have a 4xx status code
         match value {
             OpOut::Error(e) => (
@@ -463,8 +465,9 @@ impl TryFrom<OpOut> for Vec<RawCanisterHttpRequest> {
     }
 }
 
-impl From<OpOut> for (StatusCode, ApiResponse<PocketHttpResponse>) {
-    fn from(value: OpOut) -> Self {
+#[async_trait]
+impl FromOpOut for PocketHttpResponse {
+    async fn from(value: OpOut) -> (StatusCode, ApiResponse<PocketHttpResponse>) {
         match value {
             OpOut::RawResponse((status, headers, bytes)) => (
                 StatusCode::from_u16(status).unwrap(),
@@ -472,6 +475,13 @@ impl From<OpOut> for (StatusCode, ApiResponse<PocketHttpResponse>) {
             ),
             OpOut::Error(PocketIcError::RequestRoutingError(e)) => {
                 (StatusCode::BAD_REQUEST, ApiResponse::Error { message: e })
+            }
+            OpOut::RawResponseV3(fut) => {
+                let (status, headers, bytes) = fut.await;
+                (
+                    StatusCode::from_u16(status).unwrap(),
+                    ApiResponse::Success((headers, bytes)),
+                )
             }
             _ => (
                 StatusCode::INTERNAL_SERVER_ERROR,
@@ -736,7 +746,7 @@ async fn handle_raw<T: Operation + Send + Sync + 'static>(
 /// When polling, the type (and therefore the variant) is no longer known. Therefore we need
 /// to try every variant and immediately convert to an axum::Response so that axum understands
 /// the return type.
-fn op_out_to_response(op_out: OpOut) -> Response {
+async fn op_out_to_response(op_out: OpOut) -> Response {
     match op_out {
         OpOut::Pruned => (
             StatusCode::GONE,
@@ -824,6 +834,15 @@ fn op_out_to_response(op_out: OpOut) -> Response {
             }
             resp.body(Body::from(bytes)).unwrap()
         }
+        OpOut::RawResponseV3(fut) => {
+            let (status, headers, bytes) = fut.await;
+            let code = StatusCode::from_u16(status).unwrap();
+            let mut resp = Response::builder().status(code);
+            for (name, value) in headers {
+                resp = resp.header(name, value);
+            }
+            resp.body(Body::from(bytes)).unwrap()
+        }
     }
 }
 
@@ -842,7 +861,7 @@ pub async fn handler_read_graph(
         if let Some((_new_state_label, op_out)) =
             ApiState::read_result(api_state.get_graph(), &state_label, &op_id)
         {
-            op_out_to_response(op_out)
+            op_out_to_response(op_out).await
         } else {
             (
                 StatusCode::NOT_FOUND,

--- a/rs/pocket_ic_server/src/state_api/routes.rs
+++ b/rs/pocket_ic_server/src/state_api/routes.rs
@@ -469,14 +469,10 @@ impl TryFrom<OpOut> for Vec<RawCanisterHttpRequest> {
 impl FromOpOut for PocketHttpResponse {
     async fn from(value: OpOut) -> (StatusCode, ApiResponse<PocketHttpResponse>) {
         match value {
-            OpOut::RawResponse((status, headers, bytes)) => (
-                StatusCode::from_u16(status).unwrap(),
-                ApiResponse::Success((headers, bytes)),
-            ),
             OpOut::Error(PocketIcError::RequestRoutingError(e)) => {
                 (StatusCode::BAD_REQUEST, ApiResponse::Error { message: e })
             }
-            OpOut::RawResponseV3(fut) => {
+            OpOut::RawResponse(fut) => {
                 let (status, headers, bytes) = fut.await;
                 (
                     StatusCode::from_u16(status).unwrap(),
@@ -826,15 +822,7 @@ async fn op_out_to_response(op_out: OpOut) -> Response {
             )),
         )
             .into_response(),
-        OpOut::RawResponse((status, headers, bytes)) => {
-            let code = StatusCode::from_u16(status).unwrap();
-            let mut resp = Response::builder().status(code);
-            for (name, value) in headers {
-                resp = resp.header(name, value);
-            }
-            resp.body(Body::from(bytes)).unwrap()
-        }
-        OpOut::RawResponseV3(fut) => {
+        OpOut::RawResponse(fut) => {
             let (status, headers, bytes) = fut.await;
             let code = StatusCode::from_u16(status).unwrap();
             let mut resp = Response::builder().status(code);

--- a/rs/pocket_ic_server/src/state_api/routes.rs
+++ b/rs/pocket_ic_server/src/state_api/routes.rs
@@ -469,15 +469,15 @@ impl TryFrom<OpOut> for Vec<RawCanisterHttpRequest> {
 impl FromOpOut for PocketHttpResponse {
     async fn from(value: OpOut) -> (StatusCode, ApiResponse<PocketHttpResponse>) {
         match value {
-            OpOut::Error(PocketIcError::RequestRoutingError(e)) => {
-                (StatusCode::BAD_REQUEST, ApiResponse::Error { message: e })
-            }
             OpOut::RawResponse(fut) => {
                 let (status, headers, bytes) = fut.await;
                 (
                     StatusCode::from_u16(status).unwrap(),
                     ApiResponse::Success((headers, bytes)),
                 )
+            }
+            OpOut::Error(PocketIcError::RequestRoutingError(e)) => {
+                (StatusCode::BAD_REQUEST, ApiResponse::Error { message: e })
             }
             _ => (
                 StatusCode::INTERNAL_SERVER_ERROR,

--- a/rs/pocket_ic_server/src/state_api/state.rs
+++ b/rs/pocket_ic_server/src/state_api/state.rs
@@ -188,8 +188,7 @@ pub enum OpOut {
     StableMemBytes(Vec<u8>),
     MaybeSubnetId(Option<SubnetId>),
     Error(PocketIcError),
-    RawResponse((u16, BTreeMap<String, Vec<u8>>, Vec<u8>)),
-    RawResponseV3(Shared<BoxFuture<'static, (u16, BTreeMap<String, Vec<u8>>, Vec<u8>)>>),
+    RawResponse(Shared<BoxFuture<'static, (u16, BTreeMap<String, Vec<u8>>, Vec<u8>)>>),
     Pruned,
     MessageId((EffectivePrincipal, Vec<u8>)),
     Topology(Topology),
@@ -275,19 +274,10 @@ impl std::fmt::Debug for OpOut {
             OpOut::StableMemBytes(bytes) => write!(f, "StableMemory({})", base64::encode(bytes)),
             OpOut::MaybeSubnetId(Some(subnet_id)) => write!(f, "SubnetId({})", subnet_id),
             OpOut::MaybeSubnetId(None) => write!(f, "NoSubnetId"),
-            OpOut::RawResponse((status, headers, bytes)) => {
+            OpOut::RawResponse(fut) => {
                 write!(
                     f,
-                    "ApiV2Resp({}:{:?}:{})",
-                    status,
-                    headers,
-                    base64::encode(bytes)
-                )
-            }
-            OpOut::RawResponseV3(fut) => {
-                write!(
-                    f,
-                    "ApiV3Resp({:?})",
+                    "ApiResp({:?})",
                     fut.peek().map(|(status, headers, bytes)| format!(
                         "{}:{:?}:{}",
                         status,

--- a/rs/pocket_ic_server/tests/test.rs
+++ b/rs/pocket_ic_server/tests/test.rs
@@ -714,19 +714,17 @@ fn test_specified_id_call_v3() {
         .build();
     let endpoint = pic.make_live(None);
 
-    let rt = tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-        .unwrap();
-
     // retrieve the first canister ID on the application subnet
     // which will be the effective canister ID for canister creation
     let topology = pic.topology();
-
     let app_subnet = topology.get_app_subnets()[0];
     let effective_canister_id =
         raw_canister_id_range_into(&topology.0.get(&app_subnet).unwrap().canister_ranges[0]).start;
 
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
     rt.block_on(async {
         let agent = ic_agent_call_v3::Agent::builder()
             .with_url(endpoint.clone())
@@ -742,7 +740,9 @@ fn test_specified_id_call_v3() {
         };
         let bytes = candid::Encode!(&arg).unwrap();
 
-        // This is an agent that targets /api/v3/.../call for ingress messages.
+        // Submit a call to the `/api/v3/.../call` endpoint.
+        // Note that this might be flaky if it takes more than 10 seconds to process the update call
+        // (then `CallResponse::Poll` would be returned and this test would panic).
         agent
             .update(
                 &Principal::management_canister(),


### PR DESCRIPTION
This MR makes the `CallRequest` operation of type V3 deterministic by not executing rounds on a background thread when computing that operation. This also enables parallel update calls of type V3 since no rounds are executed when submitting such update calls (via the `CallRequest` operation).