### PR TITLE
refactor: Remove misleading `callback_id` from `register_callback()` test function

### DIFF
--- a/rs/messaging/src/routing/stream_builder/tests.rs
+++ b/rs/messaging/src/routing/stream_builder/tests.rs
@@ -1056,9 +1056,11 @@ fn canister_states_with_outputs<M: Into<RequestOrResponse>>(
 
         match msg {
             RequestOrResponse::Request(req) => {
-                // Create a matching callback, so that enqueuing any reject response will succeed.
                 let callback_id =
                     register_callback(canister_state, req.sender, req.receiver, req.deadline);
+                // Check the implicit assumption that the test messages were generated with a
+                // `sender_reply_callback` that is consistent with the callback IDs that the
+                // `CallContextManager` generates and registers.
                 assert_eq!(req.sender_reply_callback, callback_id);
 
                 canister_state.push_output_request(req, UNIX_EPOCH).unwrap();

--- a/rs/messaging/src/routing/stream_builder/tests.rs
+++ b/rs/messaging/src/routing/stream_builder/tests.rs
@@ -100,19 +100,6 @@ fn reject_local_request() {
             NO_DEADLINE,
         );
 
-        /*
-                let mut msg = generate_message_for_test(
-                    sender,
-                    receiver,
-                    CallbackId::from(1),
-                    "method".to_string(),
-                    payment,
-                );
-                let callback_id =
-                    register_callback(&mut canister_state, msg.sender, msg.receiver, msg.deadline);
-                msg.sender_reply_callback = callback_id;
-        */
-
         canister_state
             .push_output_request(msg.clone().into(), UNIX_EPOCH)
             .unwrap();
@@ -1072,12 +1059,9 @@ fn canister_states_with_outputs<M: Into<RequestOrResponse>>(
                 // Create a matching callback, so that enqueuing any reject response will succeed.
                 let callback_id =
                     register_callback(canister_state, req.sender, req.receiver, req.deadline);
-                let mut req = (*req).clone();
-                req.sender_reply_callback = callback_id;
+                assert_eq!(req.sender_reply_callback, callback_id);
 
-                canister_state
-                    .push_output_request(req.into(), UNIX_EPOCH)
-                    .unwrap();
+                canister_state.push_output_request(req, UNIX_EPOCH).unwrap();
             }
 
             RequestOrResponse::Response(rep) => {

--- a/rs/messaging/src/routing/stream_handler/tests.rs
+++ b/rs/messaging/src/routing/stream_handler/tests.rs
@@ -3556,9 +3556,10 @@ where
 /// Makes `count` input queue reservations for responses from `remote`.
 fn make_input_queue_reservations(canister: &mut CanisterState, count: usize, remote: CanisterId) {
     for _ in 0..count {
-        let mut msg = test_request(*LOCAL_CANISTER, remote);
-        let callback_id = register_callback(canister, msg.sender, msg.receiver, msg.deadline);
-        msg.sender_reply_callback = callback_id;
+        // Note that this assumes that tests using this function induct messages matching the
+        // callback IDs generated here by the `CallContextManager` in `register_callback()`.
+        let msg = test_request(*LOCAL_CANISTER, remote);
+        register_callback(canister, msg.sender, msg.receiver, msg.deadline);
         canister
             .push_output_request(msg.into(), UNIX_EPOCH)
             .unwrap();

--- a/rs/messaging/src/routing/stream_handler/tests.rs
+++ b/rs/messaging/src/routing/stream_handler/tests.rs
@@ -3556,14 +3556,9 @@ where
 /// Makes `count` input queue reservations for responses from `remote`.
 fn make_input_queue_reservations(canister: &mut CanisterState, count: usize, remote: CanisterId) {
     for _ in 0..count {
-        let msg = test_request(*LOCAL_CANISTER, remote);
-        register_callback(
-            canister,
-            msg.sender,
-            msg.receiver,
-            msg.sender_reply_callback,
-            msg.deadline,
-        );
+        let mut msg = test_request(*LOCAL_CANISTER, remote);
+        let callback_id = register_callback(canister, msg.sender, msg.receiver, msg.deadline);
+        msg.sender_reply_callback = callback_id;
         canister
             .push_output_request(msg.into(), UNIX_EPOCH)
             .unwrap();

--- a/rs/replicated_state/tests/canister_state.rs
+++ b/rs/replicated_state/tests/canister_state.rs
@@ -81,7 +81,6 @@ impl CanisterFixture {
             &mut self.canister_state,
             CANISTER_ID,
             OTHER_CANISTER_ID,
-            CallbackId::from(CALLBACK_ID_RAW),
             NO_DEADLINE,
         );
     }
@@ -207,22 +206,18 @@ fn validate_responses_against_callback_details() {
     let canister_c_id = canister_test_id(17);
 
     // Creating the CallContext and registering the callback for a request from this canister -> canister B.
-    let callback_id_1 = CallbackId::from(1);
-    register_callback(
+    let callback_id_1 = register_callback(
         &mut fixture.canister_state,
         CANISTER_ID,
         canister_b_id,
-        callback_id_1,
         NO_DEADLINE,
     );
 
     // Creating the CallContext and registering the callback for a request from this canister -> canister C.
-    let callback_id_2 = CallbackId::from(2);
-    register_callback(
+    let callback_id_2 = register_callback(
         &mut fixture.canister_state,
         CANISTER_ID,
         canister_c_id,
-        callback_id_2,
         NO_DEADLINE,
     );
 
@@ -287,11 +282,10 @@ fn validate_response_fails_with_mismatching_deadline() {
         let mut fixture = CanisterFixture::running();
 
         // Register a callback with the given `callback_deadline`.
-        register_callback(
+        let callback_id = register_callback(
             &mut fixture.canister_state,
             CANISTER_ID,
             OTHER_CANISTER_ID,
-            CALLBACK_ID,
             callback_deadline,
         );
 
@@ -306,7 +300,7 @@ fn validate_response_fails_with_mismatching_deadline() {
         let response = ResponseBuilder::new()
             .originator(CANISTER_ID)
             .respondent(OTHER_CANISTER_ID)
-            .originator_reply_callback(CALLBACK_ID)
+            .originator_reply_callback(callback_id)
             .deadline(response_deadline)
             .build()
             .into();

--- a/rs/test_utilities/state/src/lib.rs
+++ b/rs/test_utilities/state/src/lib.rs
@@ -767,15 +767,14 @@ pub fn register_callback(
     canister_state: &mut CanisterState,
     originator: CanisterId,
     respondent: CanisterId,
-    callback_id: CallbackId,
     deadline: CoarseTime,
-) {
+) -> CallbackId {
     let call_context_manager = canister_state
         .system_state
         .call_context_manager_mut()
         .unwrap();
     let call_context_id = call_context_manager.new_call_context(
-        CallOrigin::CanisterUpdate(originator, callback_id, deadline),
+        CallOrigin::SystemTask,
         Cycles::zero(),
         Time::from_nanos_since_unix_epoch(0),
         RequestMetadata::new(0, UNIX_EPOCH),
@@ -792,7 +791,7 @@ pub fn register_callback(
         WasmClosure::new(0, 2),
         None,
         deadline,
-    ));
+    ))
 }
 
 /// Helper function to insert a canister in the provided `ReplicatedState`.


### PR DESCRIPTION
The function `register_callback()` takes a `CallbackId` as an argument. This suggests that this `CallbackId` is registered in the `CallContextManager` such that a response using this `CallbackId` can later be inducted successfully by passing this [sanity check](https://sourcegraph.com/github.com/dfinity/ic@rumenov/regtypes/-/blob/rs/replicated_state/src/canister_state/system_state/call_context_manager.rs?L599).

This is false. The `CallbackId` handed to `register_callback()` is used to construct an update call, but the origin of a call is irrelevant for the [sanity check](https://sourcegraph.com/github.com/dfinity/ic@rumenov/regtypes/-/blob/rs/replicated_state/src/canister_state/system_state/call_context_manager.rs?L599) because each message gets its own `CallbackId`. It is in general not possible to ask the `CallContextManager` to register a `CallbackId`, rather you must ask the `CallContextManager` to register a new `Callback` for your call and then the `CallContextManager` generates and registers this `Callback` with a new `CallbackId` and returns it to you. This is the `CallbackId` that must be used to generate the message to pass the [sanity check](https://sourcegraph.com/github.com/dfinity/ic@rumenov/regtypes/-/blob/rs/replicated_state/src/canister_state/system_state/call_context_manager.rs?L599).

Since the origin of the call is irrelevant for the intended purpose of this function, it makes sense to use a system task as the call origin (i.e. a heartbeat or a timer), since that does not require a `CallbackId` as an input and return the `CallbackId` that must be used to construct the message instead.

The changes in this PR are such that the misleading `CallbackId` argument is removed, but otherwise the code is intact. Further changes to improve consistency with how the `CallContextManager` should be used will be done in a different PR.