### PR TITLE
chore: cleanup Bazel files

### DIFF
--- a/rs/universal_canister/impl/BUILD.bazel
+++ b/rs/universal_canister/impl/BUILD.bazel
@@ -13,7 +13,6 @@ LIB_DEPENDENCIES = [
 DEPENDENCIES = [
     # Keep sorted.
     ":lib",
-    # Keep sorted.
     "@crate_index//:lazy_static",
     "@crate_index//:wee_alloc",
 ]

--- a/scalability/BUILD.bazel
+++ b/scalability/BUILD.bazel
@@ -159,8 +159,8 @@ py_library(
         ":delegation",
         ":misc",
         requirement("ic-py"),
-        requirement("python-gflags"),
         requirement("matplotlib"),
+        requirement("python-gflags"),
         requirement("termcolor"),
     ],
 )
@@ -244,9 +244,9 @@ py_binary(
         ":workload",
         ":workload_experiment",
         ":workload_xrc_hooks",
+        requirement("ic-py"),
         requirement("python-gflags"),
         requirement("six"),
-        requirement("ic-py"),
         requirement("toml"),
     ],
 )


### PR DESCRIPTION
This PR cleans up Bazel files, removes duplicated comment and sorts required dependencies.