### PR TITLE
feat(ckerc20): Use EVM-RPC canister to call `eth_feeHistory`

### DIFF
--- a/rs/ethereum/evm-rpc-client/src/lib.rs
+++ b/rs/ethereum/evm-rpc-client/src/lib.rs
@@ -4,8 +4,8 @@ mod tests;
 pub mod types;
 
 use crate::types::candid::{
-    Block, BlockTag, GetLogsArgs, LogEntry, MultiRpcResult, ProviderError, RpcConfig, RpcError,
-    RpcServices,
+    Block, BlockTag, FeeHistory, FeeHistoryArgs, GetLogsArgs, LogEntry, MultiRpcResult,
+    ProviderError, RpcConfig, RpcError, RpcServices,
 };
 use async_trait::async_trait;
 use candid::utils::ArgumentEncoder;
@@ -44,6 +44,7 @@ pub struct EvmRpcClient<R: Runtime, L: Sink> {
 pub struct OverrideRpcConfig {
     pub eth_get_block_by_number: Option<RpcConfig>,
     pub eth_get_logs: Option<RpcConfig>,
+    pub eth_fee_history: Option<RpcConfig>,
 }
 
 impl<L: Sink> EvmRpcClient<IcRuntime, L> {
@@ -70,6 +71,18 @@ impl<R: Runtime, L: Sink> EvmRpcClient<R, L> {
         self.call_internal(
             "eth_getLogs",
             self.override_rpc_config.eth_get_logs.clone(),
+            args,
+        )
+        .await
+    }
+
+    pub async fn eth_fee_history(
+        &self,
+        args: FeeHistoryArgs,
+    ) -> MultiRpcResult<Option<FeeHistory>> {
+        self.call_internal(
+            "eth_feeHistory",
+            self.override_rpc_config.eth_fee_history.clone(),
             args,
         )
         .await

--- a/rs/ethereum/evm-rpc-client/src/types.rs
+++ b/rs/ethereum/evm-rpc-client/src/types.rs
@@ -103,6 +103,44 @@ pub mod candid {
         pub topics: Option<Vec<Vec<String>>>,
     }
 
+    #[derive(Clone, Debug, PartialEq, Eq, CandidType, Deserialize)]
+    pub struct FeeHistoryArgs {
+        /// Number of blocks in the requested range.
+        /// Typically, providers request this to be between 1 and 1024.
+        #[serde(rename = "blockCount")]
+        pub block_count: u128,
+
+        /// Highest block of the requested range.
+        /// Integer block number, or "latest" for the last mined block or "pending", "earliest" for not yet mined transactions.
+        #[serde(rename = "newestBlock")]
+        pub newest_block: BlockTag,
+
+        /// A monotonically increasing list of percentile values between 0 and 100.
+        /// For each block in the requested range, the transactions will be sorted in ascending order
+        /// by effective tip per gas and the corresponding effective tip for the percentile
+        /// will be determined, accounting for gas consumed.
+        #[serde(rename = "rewardPercentiles")]
+        pub reward_percentiles: Option<Vec<u8>>,
+    }
+
+    #[derive(Debug, Clone, CandidType, Deserialize, PartialEq)]
+    #[serde(rename_all = "camelCase")]
+    pub struct FeeHistory {
+        /// Lowest number block of the returned range.
+        pub oldest_block: Nat,
+        /// An array of block base fees per gas.
+        /// This includes the next block after the newest of the returned range,
+        /// because this value can be derived from the newest block.
+        /// Zeroes are returned for pre-EIP-1559 blocks.
+        pub base_fee_per_gas: Vec<Nat>,
+        /// An array of block gas used ratios (gasUsed / gasLimit).
+        #[serde(default)]
+        #[serde(rename = "gasUsedRatio")]
+        pub gas_used_ratio: Vec<f64>,
+        /// A two-dimensional array of effective priority fees per gas at the requested block percentiles.
+        pub reward: Vec<Vec<Nat>>,
+    }
+
     pub type RpcResult<T> = Result<T, RpcError>;
 
     #[derive(Clone, Debug, Eq, PartialEq, CandidType, Deserialize)]

--- a/rs/ethereum/evm-rpc-client/src/types.rs
+++ b/rs/ethereum/evm-rpc-client/src/types.rs
@@ -123,15 +123,16 @@ pub mod candid {
         pub reward_percentiles: Option<Vec<u8>>,
     }
 
-    #[derive(Debug, Clone, CandidType, Deserialize, PartialEq)]
-    #[serde(rename_all = "camelCase")]
+    #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, CandidType)]
     pub struct FeeHistory {
         /// Lowest number block of the returned range.
+        #[serde(rename = "oldestBlock")]
         pub oldest_block: Nat,
         /// An array of block base fees per gas.
         /// This includes the next block after the newest of the returned range,
         /// because this value can be derived from the newest block.
         /// Zeroes are returned for pre-EIP-1559 blocks.
+        #[serde(rename = "baseFeePerGas")]
         pub base_fee_per_gas: Vec<Nat>,
         /// An array of block gas used ratios (gasUsed / gasLimit).
         #[serde(default)]


### PR DESCRIPTION
(XC-162): Continue the migration initiated in [MR-19972](https://gitlab.com/dfinity-lab/public/ic/-/merge_requests/19972) towards using the EVM-RPC canister to interact with the Ethereum JSON-RPC providers. This PR focuses specifically on the `eth_feeHistory` endpoint.