### PR TITLE
feat(IDX): Add Apple Silicon builds

### DIFF
--- a/.github/workflows/test-namespace-darwin.yml
+++ b/.github/workflows/test-namespace-darwin.yml
@@ -1,0 +1,33 @@
+# Darwin tests on runners from https://namespace.so
+name: test-namespace
+on: [push]
+jobs:
+  test-namespace:
+    strategy:
+      matrix:
+        os: [ namespace-profile-darwin-small ] # profile created in namespace console
+    runs-on: ${{ matrix.os }}
+    steps:
+
+      - name: Install nsc
+        run: |
+          # A recent version is required for `nsc bazel cache setup`
+          curl -fsSL https://get.namespace.so/cloud/install.sh | sh -s -- --version 0.0.386
+
+      - name: Set up Bazel cache
+        run: |
+          # Creates a bazelrc configuration fragment which tells bazel where the cache lives.
+          nsc bazel cache setup --bazelrc=/tmp/bazel-cache.bazelrc
+
+      - uses: actions/checkout@v4
+
+      # Build and test, excluding 'upload' jobs that are not required on macOS (used in reproducibility tests)
+      - name: Test
+        run: |
+          bazel \
+            --noworkspace_rc \
+            --bazelrc=./bazel/conf/.bazelrc.build --bazelrc=/tmp/bazel-cache.bazelrc \
+            test \
+            --config=ci --config=macos_ci \
+            --test_tag_filters="test_macos,-upload" \
+            //rs/... //publish/binaries/...

--- a/gitlab-ci/src/artifacts/upload.bash.template
+++ b/gitlab-ci/src/artifacts/upload.bash.template
@@ -31,6 +31,18 @@ if [ "$(basename $f)" == "SHA256SUMS" ]; then
     cat "$f" >&2
 fi
 
+# XXX: for historical reasons, artifacts are uploaded during a build step, expecting
+# AWS credentials to be present in $HOME. Unfortunately that makes the build non-portable
+# to machines without AWS credentials.
+# Until the upload is moved out of the build itself, this is a  workaround for
+# https://namespace.so runners: if the runner is from namespace (inferring from the presence
+# of /opt/namespace) we simply skip the upload.
+if [ -d /opt/namespace ]; then
+    touch "$2"
+    touch "$3"
+    exit 0
+fi
+
 # Multipart upload does not work trough the proxy for some reasons. Just disabling it for now.
 "@@RCLONE@@" \
     --config="@@RCLONE_CONFIG@@" \


### PR DESCRIPTION
This adds Apple Silicon (aarch64) builds for Darwin. This is a trial run with hardware from provider https://namespace.so.

This new check is not mandatory for PRs to be pass CI.