### PR TITLE
refactor(IDX): simplify hotfix branch matching logic

### DIFF
--- a/.github/workflows-source/ci-main.yml
+++ b/.github/workflows-source/ci-main.yml
@@ -87,7 +87,7 @@ jobs:
           if [[ "${{ github.event_name }}" == 'merge_group' ]]; then
             echo "BAZEL_EXTRA_ARGS_RULES=--test_timeout_filters=short,moderate --flaky_test_attempts=3" >> $GITHUB_ENV
           fi
-          if [[ $BRANCH_NAME =~ hotfix-.*-rc--.* ]]; then
+          if [[ $BRANCH_NAME =~ ^hotfix-.* ]]; then
             echo "BAZEL_EXTRA_ARGS_RULES=--test_timeout_filters=short,moderate" >> $GITHUB_ENV
           fi
       - name: Run Bazel Test All

--- a/.github/workflows-source/release-testing.yml
+++ b/.github/workflows-source/release-testing.yml
@@ -3,7 +3,7 @@ name: Release Testing
 on:
   push:
     branches:
-      - 'hotfix-*-rc--*'
+      - 'hotfix-*'
       - 'rc--*'
   workflow_dispatch:
 

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -63,7 +63,7 @@ jobs:
           if [[ "${{ github.event_name }}" == 'merge_group' ]]; then
             echo "BAZEL_EXTRA_ARGS_RULES=--test_timeout_filters=short,moderate --flaky_test_attempts=3" >> $GITHUB_ENV
           fi
-          if [[ $BRANCH_NAME =~ hotfix-.*-rc--.* ]]; then
+          if [[ $BRANCH_NAME =~ ^hotfix-.* ]]; then
             echo "BAZEL_EXTRA_ARGS_RULES=--test_timeout_filters=short,moderate" >> $GITHUB_ENV
           fi
       - name: Run Bazel Test All

--- a/.github/workflows/release-testing.yml
+++ b/.github/workflows/release-testing.yml
@@ -2,7 +2,7 @@ name: Release Testing
 on:
   push:
     branches:
-      - 'hotfix-*-rc--*'
+      - 'hotfix-*'
       - 'rc--*'
   workflow_dispatch:
 # new commits interrupt any running workflow on the same branch

--- a/gitlab-ci/src/bazel-ci/main.sh
+++ b/gitlab-ci/src/bazel-ci/main.sh
@@ -12,7 +12,7 @@ if [ "$CI_COMMIT_REF_PROTECTED" = "true" ]; then
     s3_upload="True"
 fi
 
-if [[ "${CI_COMMIT_BRANCH:-}" =~ ^hotfix-.+-rc--.+ ]]; then
+if [[ "${CI_COMMIT_BRANCH:-}" =~ ^hotfix-.* ]]; then
     ic_version_rc_only="${CI_COMMIT_SHA}"
     s3_upload="True"
 fi

--- a/gitlab-ci/src/ci-scripts/build-ic.sh
+++ b/gitlab-ci/src/ci-scripts/build-ic.sh
@@ -10,7 +10,7 @@ fi
 cd "$CI_PROJECT_DIR"
 
 if [ "$CI_COMMIT_REF_PROTECTED" == "true" ] \
-    || [[ "${CI_COMMIT_BRANCH:-}" =~ ^hotfix-.+-rc--.+ ]]; then
+    || [[ "${CI_COMMIT_BRANCH:-}" =~ ^hotfix-.* ]]; then
     gitlab-ci/container/build-ic.sh -i -c -b
 elif [ "${RUN_ON_DIFF_ONLY:-}" == "true" ] \
     && [ "${CI_PIPELINE_SOURCE:-}" == "merge_request_event" -o "${CI_PIPELINE_SOURCE:-}" == "pull_request" ] \


### PR DESCRIPTION
This PR slightly changes the procedure of security hotfixes, where branches now only only need to follow the pattern `hotfix-*` instead of `hotfix-.*-rc--.*`. The reasons for this change are:

a) We have run into a lot of confusion in the past because of incorrect branch names
b) It lets us unify the hotfix process for both regular and ic-os (?) hotfixes

This change is backwards compatible, as branches with the `hotfix-.*-rc--.* ` will still behave the same.