### PR TITLE
feat(RUN-1021): Revert to the memory allocator

### DIFF
--- a/rs/config/src/state_manager.rs
+++ b/rs/config/src/state_manager.rs
@@ -42,7 +42,7 @@ impl Config {
 }
 
 fn file_backed_memory_allocator_default() -> FlagStatus {
-    FlagStatus::Enabled
+    FlagStatus::Disabled
 }
 
 pub fn lsmt_config_default() -> LsmtConfig {


### PR DESCRIPTION
This PR reverts to the usage of memory-based allocator instead of file-backed allocators. This step enables a future optimization involving huge pages to speed up IO, which will come in the following release.