### PR TITLE
feat: use agent-with-discovery in system-test

### DIFF
--- a/Cargo.Bazel.Fuzzing.json.lock
+++ b/Cargo.Bazel.Fuzzing.json.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "295dee6fe8cf0487e324a176e0ff545059ef9caab88533db17591d32cc2a24fb",
+  "checksum": "b88528cf58a8cc5e67e75820dc107032c23d1ec220acbdeef1b570eec530a894",
   "crates": {
     "abnf 0.12.0": {
       "name": "abnf",
@@ -1936,6 +1936,55 @@
       "license": "MIT OR Apache-2.0",
       "license_ids": [
         "Apache-2.0",
+        "MIT"
+      ],
+      "license_file": null
+    },
+    "ansi_term 0.12.1": {
+      "name": "ansi_term",
+      "version": "0.12.1",
+      "package_url": "https://github.com/ogham/rust-ansi-term",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/ansi_term/0.12.1/download",
+          "sha256": "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "ansi_term",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "ansi_term",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [],
+          "selects": {
+            "cfg(target_os = \"windows\")": [
+              {
+                "id": "winapi 0.3.9",
+                "target": "winapi"
+              }
+            ]
+          }
+        },
+        "edition": "2015",
+        "version": "0.12.1"
+      },
+      "license": "MIT",
+      "license_ids": [
         "MIT"
       ],
       "license_file": null
@@ -17430,7 +17479,7 @@
             {
               "id": "ic-agent 0.36.0",
               "target": "ic_agent",
-              "alias": "ic_agent_call_v3"
+              "alias": "ic_agent_discovery"
             },
             {
               "id": "ic-btc-interface 0.2.0",
@@ -26977,7 +27026,104 @@
             "rustls-native-certs",
             "tls12"
           ],
-          "selects": {}
+          "selects": {
+            "aarch64-apple-darwin": [
+              "webpki-roots"
+            ],
+            "aarch64-apple-ios": [
+              "webpki-roots"
+            ],
+            "aarch64-apple-ios-sim": [
+              "webpki-roots"
+            ],
+            "aarch64-fuchsia": [
+              "webpki-roots"
+            ],
+            "aarch64-linux-android": [
+              "webpki-roots"
+            ],
+            "aarch64-pc-windows-msvc": [
+              "webpki-roots"
+            ],
+            "aarch64-unknown-linux-gnu": [
+              "webpki-roots"
+            ],
+            "aarch64-unknown-nixos-gnu": [
+              "webpki-roots"
+            ],
+            "aarch64-unknown-nto-qnx710": [
+              "webpki-roots"
+            ],
+            "arm-unknown-linux-gnueabi": [
+              "webpki-roots"
+            ],
+            "armv7-linux-androideabi": [
+              "webpki-roots"
+            ],
+            "armv7-unknown-linux-gnueabi": [
+              "webpki-roots"
+            ],
+            "i686-apple-darwin": [
+              "webpki-roots"
+            ],
+            "i686-linux-android": [
+              "webpki-roots"
+            ],
+            "i686-pc-windows-msvc": [
+              "webpki-roots"
+            ],
+            "i686-unknown-freebsd": [
+              "webpki-roots"
+            ],
+            "i686-unknown-linux-gnu": [
+              "webpki-roots"
+            ],
+            "powerpc-unknown-linux-gnu": [
+              "webpki-roots"
+            ],
+            "riscv32imc-unknown-none-elf": [
+              "webpki-roots"
+            ],
+            "riscv64gc-unknown-none-elf": [
+              "webpki-roots"
+            ],
+            "s390x-unknown-linux-gnu": [
+              "webpki-roots"
+            ],
+            "thumbv7em-none-eabi": [
+              "webpki-roots"
+            ],
+            "thumbv8m.main-none-eabi": [
+              "webpki-roots"
+            ],
+            "x86_64-apple-darwin": [
+              "webpki-roots"
+            ],
+            "x86_64-apple-ios": [
+              "webpki-roots"
+            ],
+            "x86_64-fuchsia": [
+              "webpki-roots"
+            ],
+            "x86_64-linux-android": [
+              "webpki-roots"
+            ],
+            "x86_64-pc-windows-msvc": [
+              "webpki-roots"
+            ],
+            "x86_64-unknown-freebsd": [
+              "webpki-roots"
+            ],
+            "x86_64-unknown-linux-gnu": [
+              "webpki-roots"
+            ],
+            "x86_64-unknown-nixos-gnu": [
+              "webpki-roots"
+            ],
+            "x86_64-unknown-none": [
+              "webpki-roots"
+            ]
+          }
         },
         "deps": {
           "common": [
@@ -27021,6 +27167,10 @@
             {
               "id": "tower-service 0.3.2",
               "target": "tower_service"
+            },
+            {
+              "id": "webpki-roots 0.26.1",
+              "target": "webpki_roots"
             }
           ],
           "selects": {}
@@ -27756,7 +27906,7 @@
         "Git": {
           "remote": "https://github.com/dfinity/agent-rs",
           "commitish": {
-            "Rev": "9e45b314fc7496d48065590fac90790e0bdc6eed"
+            "Rev": "1c93d1c683b2207af9b62b4f517c036b563f3af0"
           },
           "strip_prefix": "ic-agent"
         }
@@ -27783,9 +27933,9 @@
         "crate_features": {
           "common": [
             "default",
+            "hyper",
             "pem",
-            "reqwest",
-            "sync_call"
+            "reqwest"
           ],
           "selects": {}
         },
@@ -27828,6 +27978,10 @@
               "target": "http_body"
             },
             {
+              "id": "hyper 1.4.1",
+              "target": "hyper"
+            },
+            {
               "id": "ic-certification 2.5.0",
               "target": "ic_certification"
             },
@@ -27836,7 +27990,7 @@
               "target": "ic_transport_types"
             },
             {
-              "id": "ic-verify-bls-signature 0.5.0",
+              "id": "ic-verify-bls-signature 0.1.0",
               "target": "ic_verify_bls_signature"
             },
             {
@@ -27915,12 +28069,52 @@
           "selects": {
             "cfg(not(target_family = \"wasm\"))": [
               {
+                "id": "arc-swap 1.6.0",
+                "target": "arc_swap"
+              },
+              {
+                "id": "http-body-to-bytes 0.2.0",
+                "target": "http_body_to_bytes"
+              },
+              {
+                "id": "http-body-util 0.1.0",
+                "target": "http_body_util"
+              },
+              {
+                "id": "hyper-rustls 0.27.2",
+                "target": "hyper_rustls"
+              },
+              {
+                "id": "hyper-util 0.1.6",
+                "target": "hyper_util"
+              },
+              {
                 "id": "rustls-webpki 0.102.5",
                 "target": "webpki"
               },
               {
+                "id": "simple_moving_average 1.0.2",
+                "target": "simple_moving_average"
+              },
+              {
                 "id": "tokio 1.38.0",
                 "target": "tokio"
+              },
+              {
+                "id": "tokio-util 0.7.11",
+                "target": "tokio_util"
+              },
+              {
+                "id": "tower 0.4.13",
+                "target": "tower"
+              },
+              {
+                "id": "tracing 0.1.40",
+                "target": "tracing"
+              },
+              {
+                "id": "tracing-subscriber 0.2.25",
+                "target": "tracing_subscriber"
               }
             ]
           }
@@ -27933,7 +28127,14 @@
               "target": "serde_repr"
             }
           ],
-          "selects": {}
+          "selects": {
+            "cfg(not(target_family = \"wasm\"))": [
+              {
+                "id": "async-trait 0.1.74",
+                "target": "async_trait"
+              }
+            ]
+          }
         },
         "version": "0.36.0"
       },
@@ -29524,7 +29725,7 @@
         "Git": {
           "remote": "https://github.com/dfinity/agent-rs",
           "commitish": {
-            "Rev": "9e45b314fc7496d48065590fac90790e0bdc6eed"
+            "Rev": "1c93d1c683b2207af9b62b4f517c036b563f3af0"
           },
           "strip_prefix": "ic-transport-types"
         }
@@ -29573,10 +29774,6 @@
             {
               "id": "serde_bytes 0.11.14",
               "target": "serde_bytes"
-            },
-            {
-              "id": "serde_with 3.8.1",
-              "target": "serde_with"
             },
             {
               "id": "sha2 0.10.8",
@@ -29836,83 +30033,6 @@
         },
         "edition": "2021",
         "version": "0.2.0"
-      },
-      "license": "Apache-2.0",
-      "license_ids": [
-        "Apache-2.0"
-      ],
-      "license_file": null
-    },
-    "ic-verify-bls-signature 0.5.0": {
-      "name": "ic-verify-bls-signature",
-      "version": "0.5.0",
-      "package_url": null,
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/ic-verify-bls-signature/0.5.0/download",
-          "sha256": "d420b25c0091059f6c3c23a21427a81915e6e0aca3b79e0d403ed767f286a3b9"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "ic_verify_bls_signature",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": false,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "ic_verify_bls_signature",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "alloc",
-            "default",
-            "hex",
-            "lazy_static"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "hex 0.4.3",
-              "target": "hex"
-            },
-            {
-              "id": "ic_bls12_381 0.10.0",
-              "target": "ic_bls12_381",
-              "alias": "bls12_381"
-            },
-            {
-              "id": "lazy_static 1.4.0",
-              "target": "lazy_static"
-            },
-            {
-              "id": "pairing 0.23.0",
-              "target": "pairing"
-            },
-            {
-              "id": "rand 0.8.5",
-              "target": "rand"
-            },
-            {
-              "id": "sha2 0.10.8",
-              "target": "sha2"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "version": "0.5.0"
       },
       "license": "Apache-2.0",
       "license_ids": [
@@ -30269,93 +30389,6 @@
           "selects": {}
         },
         "version": "0.9.2"
-      },
-      "license": "MIT/Apache-2.0",
-      "license_ids": [
-        "Apache-2.0",
-        "MIT"
-      ],
-      "license_file": "LICENSE-APACHE"
-    },
-    "ic_bls12_381 0.10.0": {
-      "name": "ic_bls12_381",
-      "version": "0.10.0",
-      "package_url": "https://github.com/dfinity/bls12_381",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/ic_bls12_381/0.10.0/download",
-          "sha256": "22c65787944f32af084dffd0c68c1e544237b76e215654ddea8cd9f527dd8b69"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "ic_bls12_381",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": false,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "ic_bls12_381",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "alloc",
-            "digest",
-            "experimental",
-            "group",
-            "groups",
-            "pairing",
-            "pairings"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "digest 0.10.7",
-              "target": "digest"
-            },
-            {
-              "id": "ff 0.13.0",
-              "target": "ff"
-            },
-            {
-              "id": "group 0.13.0",
-              "target": "group"
-            },
-            {
-              "id": "pairing 0.23.0",
-              "target": "pairing"
-            },
-            {
-              "id": "rand_core 0.6.4",
-              "target": "rand_core"
-            },
-            {
-              "id": "subtle 2.5.0",
-              "target": "subtle"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "rustc_flags": {
-          "common": [
-            "-C",
-            "opt-level=3"
-          ],
-          "selects": {}
-        },
-        "version": "0.10.0"
       },
       "license": "MIT/Apache-2.0",
       "license_ids": [
@@ -37301,6 +37334,53 @@
         "MIT"
       ],
       "license_file": "LICENSE-APACHE"
+    },
+    "matchers 0.0.1": {
+      "name": "matchers",
+      "version": "0.0.1",
+      "package_url": "https://github.com/hawkw/matchers",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/matchers/0.0.1/download",
+          "sha256": "f099785f7595cc4b4553a174ce30dd7589ef93391ff414dbb67f62392b9e0ce1"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "matchers",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "matchers",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "regex-automata 0.1.10",
+              "target": "regex_automata"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2018",
+        "version": "0.0.1"
+      },
+      "license": "MIT",
+      "license_ids": [
+        "MIT"
+      ],
+      "license_file": "LICENSE"
     },
     "matchers 0.1.0": {
       "name": "matchers",
@@ -58689,76 +58769,6 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "serde_with 3.8.1": {
-      "name": "serde_with",
-      "version": "3.8.1",
-      "package_url": "https://github.com/jonasbb/serde_with/",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/serde_with/3.8.1/download",
-          "sha256": "0ad483d2ab0149d5a5ebcd9972a3852711e0153d863bf5a5d0391d28883c4a20"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "serde_with",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": false,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "serde_with",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "alloc",
-            "default",
-            "macros",
-            "std"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "serde 1.0.203",
-              "target": "serde"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "proc_macro_deps": {
-          "common": [
-            {
-              "id": "serde_derive 1.0.203",
-              "target": "serde_derive"
-            },
-            {
-              "id": "serde_with_macros 3.8.1",
-              "target": "serde_with_macros"
-            }
-          ],
-          "selects": {}
-        },
-        "version": "3.8.1"
-      },
-      "license": "MIT OR Apache-2.0",
-      "license_ids": [
-        "Apache-2.0",
-        "MIT"
-      ],
-      "license_file": "LICENSE-APACHE"
-    },
     "serde_with_macros 1.5.2": {
       "name": "serde_with_macros",
       "version": "1.5.2",
@@ -58871,66 +58881,6 @@
         },
         "edition": "2021",
         "version": "2.3.3"
-      },
-      "license": "MIT OR Apache-2.0",
-      "license_ids": [
-        "Apache-2.0",
-        "MIT"
-      ],
-      "license_file": "LICENSE-APACHE"
-    },
-    "serde_with_macros 3.8.1": {
-      "name": "serde_with_macros",
-      "version": "3.8.1",
-      "package_url": "https://github.com/jonasbb/serde_with/",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/serde_with_macros/3.8.1/download",
-          "sha256": "65569b702f41443e8bc8bbb1c5779bd0450bbe723b56198980e80ec45780bce2"
-        }
-      },
-      "targets": [
-        {
-          "ProcMacro": {
-            "crate_name": "serde_with_macros",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": false,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "serde_with_macros",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "darling 0.20.3",
-              "target": "darling"
-            },
-            {
-              "id": "proc-macro2 1.0.85",
-              "target": "proc_macro2"
-            },
-            {
-              "id": "quote 1.0.35",
-              "target": "quote"
-            },
-            {
-              "id": "syn 2.0.66",
-              "target": "syn"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "version": "3.8.1"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -66077,7 +66027,232 @@
             "slab",
             "time"
           ],
-          "selects": {}
+          "selects": {
+            "aarch64-apple-darwin": [
+              "compat",
+              "full",
+              "futures-io",
+              "io-util",
+              "net"
+            ],
+            "aarch64-apple-ios": [
+              "compat",
+              "full",
+              "futures-io",
+              "io-util",
+              "net"
+            ],
+            "aarch64-apple-ios-sim": [
+              "compat",
+              "full",
+              "futures-io",
+              "io-util",
+              "net"
+            ],
+            "aarch64-fuchsia": [
+              "compat",
+              "full",
+              "futures-io",
+              "io-util",
+              "net"
+            ],
+            "aarch64-linux-android": [
+              "compat",
+              "full",
+              "futures-io",
+              "io-util",
+              "net"
+            ],
+            "aarch64-pc-windows-msvc": [
+              "compat",
+              "full",
+              "futures-io",
+              "io-util",
+              "net"
+            ],
+            "aarch64-unknown-linux-gnu": [
+              "compat",
+              "full",
+              "futures-io",
+              "io-util",
+              "net"
+            ],
+            "aarch64-unknown-nixos-gnu": [
+              "compat",
+              "full",
+              "futures-io",
+              "io-util",
+              "net"
+            ],
+            "aarch64-unknown-nto-qnx710": [
+              "compat",
+              "full",
+              "futures-io",
+              "io-util",
+              "net"
+            ],
+            "arm-unknown-linux-gnueabi": [
+              "compat",
+              "full",
+              "futures-io",
+              "io-util",
+              "net"
+            ],
+            "armv7-linux-androideabi": [
+              "compat",
+              "full",
+              "futures-io",
+              "io-util",
+              "net"
+            ],
+            "armv7-unknown-linux-gnueabi": [
+              "compat",
+              "full",
+              "futures-io",
+              "io-util",
+              "net"
+            ],
+            "i686-apple-darwin": [
+              "compat",
+              "full",
+              "futures-io",
+              "io-util",
+              "net"
+            ],
+            "i686-linux-android": [
+              "compat",
+              "full",
+              "futures-io",
+              "io-util",
+              "net"
+            ],
+            "i686-pc-windows-msvc": [
+              "compat",
+              "full",
+              "futures-io",
+              "io-util",
+              "net"
+            ],
+            "i686-unknown-freebsd": [
+              "compat",
+              "full",
+              "futures-io",
+              "io-util",
+              "net"
+            ],
+            "i686-unknown-linux-gnu": [
+              "compat",
+              "full",
+              "futures-io",
+              "io-util",
+              "net"
+            ],
+            "powerpc-unknown-linux-gnu": [
+              "compat",
+              "full",
+              "futures-io",
+              "io-util",
+              "net"
+            ],
+            "riscv32imc-unknown-none-elf": [
+              "compat",
+              "full",
+              "futures-io",
+              "io-util",
+              "net"
+            ],
+            "riscv64gc-unknown-none-elf": [
+              "compat",
+              "full",
+              "futures-io",
+              "io-util",
+              "net"
+            ],
+            "s390x-unknown-linux-gnu": [
+              "compat",
+              "full",
+              "futures-io",
+              "io-util",
+              "net"
+            ],
+            "thumbv7em-none-eabi": [
+              "compat",
+              "full",
+              "futures-io",
+              "io-util",
+              "net"
+            ],
+            "thumbv8m.main-none-eabi": [
+              "compat",
+              "full",
+              "futures-io",
+              "io-util",
+              "net"
+            ],
+            "x86_64-apple-darwin": [
+              "compat",
+              "full",
+              "futures-io",
+              "io-util",
+              "net"
+            ],
+            "x86_64-apple-ios": [
+              "compat",
+              "full",
+              "futures-io",
+              "io-util",
+              "net"
+            ],
+            "x86_64-fuchsia": [
+              "compat",
+              "full",
+              "futures-io",
+              "io-util",
+              "net"
+            ],
+            "x86_64-linux-android": [
+              "compat",
+              "full",
+              "futures-io",
+              "io-util",
+              "net"
+            ],
+            "x86_64-pc-windows-msvc": [
+              "compat",
+              "full",
+              "futures-io",
+              "io-util",
+              "net"
+            ],
+            "x86_64-unknown-freebsd": [
+              "compat",
+              "full",
+              "futures-io",
+              "io-util",
+              "net"
+            ],
+            "x86_64-unknown-linux-gnu": [
+              "compat",
+              "full",
+              "futures-io",
+              "io-util",
+              "net"
+            ],
+            "x86_64-unknown-nixos-gnu": [
+              "compat",
+              "full",
+              "futures-io",
+              "io-util",
+              "net"
+            ],
+            "x86_64-unknown-none": [
+              "compat",
+              "full",
+              "futures-io",
+              "io-util",
+              "net"
+            ]
+          }
         },
         "deps": {
           "common": [
@@ -66088,6 +66263,10 @@
             {
               "id": "futures-core 0.3.30",
               "target": "futures_core"
+            },
+            {
+              "id": "futures-io 0.3.30",
+              "target": "futures_io"
             },
             {
               "id": "futures-sink 0.3.30",
@@ -67493,6 +67672,68 @@
       ],
       "license_file": "LICENSE"
     },
+    "tracing-log 0.1.4": {
+      "name": "tracing-log",
+      "version": "0.1.4",
+      "package_url": "https://github.com/tokio-rs/tracing",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/tracing-log/0.1.4/download",
+          "sha256": "f751112709b4e791d8ce53e32c4ed2d353565a795ce84da2285393f41557bdf2"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "tracing_log",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "tracing_log",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": {
+          "common": [
+            "log-tracer",
+            "std"
+          ],
+          "selects": {}
+        },
+        "deps": {
+          "common": [
+            {
+              "id": "log 0.4.20",
+              "target": "log"
+            },
+            {
+              "id": "once_cell 1.19.0",
+              "target": "once_cell"
+            },
+            {
+              "id": "tracing-core 0.1.32",
+              "target": "tracing_core"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2018",
+        "version": "0.1.4"
+      },
+      "license": "MIT",
+      "license_ids": [
+        "MIT"
+      ],
+      "license_file": "LICENSE"
+    },
     "tracing-log 0.2.0": {
       "name": "tracing-log",
       "version": "0.2.0",
@@ -67819,6 +68060,129 @@
         },
         "edition": "2021",
         "version": "0.2.0"
+      },
+      "license": "MIT",
+      "license_ids": [
+        "MIT"
+      ],
+      "license_file": "LICENSE"
+    },
+    "tracing-subscriber 0.2.25": {
+      "name": "tracing-subscriber",
+      "version": "0.2.25",
+      "package_url": "https://github.com/tokio-rs/tracing",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/tracing-subscriber/0.2.25/download",
+          "sha256": "0e0d2eaa99c3c2e41547cfa109e910a68ea03823cccad4a0525dcbc9b01e8c71"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "tracing_subscriber",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "tracing_subscriber",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": {
+          "common": [
+            "ansi",
+            "ansi_term",
+            "chrono",
+            "default",
+            "env-filter",
+            "fmt",
+            "json",
+            "lazy_static",
+            "matchers",
+            "regex",
+            "registry",
+            "serde",
+            "serde_json",
+            "sharded-slab",
+            "smallvec",
+            "thread_local",
+            "tracing",
+            "tracing-log",
+            "tracing-serde"
+          ],
+          "selects": {}
+        },
+        "deps": {
+          "common": [
+            {
+              "id": "ansi_term 0.12.1",
+              "target": "ansi_term"
+            },
+            {
+              "id": "chrono 0.4.38",
+              "target": "chrono"
+            },
+            {
+              "id": "lazy_static 1.4.0",
+              "target": "lazy_static"
+            },
+            {
+              "id": "matchers 0.0.1",
+              "target": "matchers"
+            },
+            {
+              "id": "regex 1.10.5",
+              "target": "regex"
+            },
+            {
+              "id": "serde 1.0.203",
+              "target": "serde"
+            },
+            {
+              "id": "serde_json 1.0.108",
+              "target": "serde_json"
+            },
+            {
+              "id": "sharded-slab 0.1.7",
+              "target": "sharded_slab"
+            },
+            {
+              "id": "smallvec 1.13.2",
+              "target": "smallvec"
+            },
+            {
+              "id": "thread_local 1.1.7",
+              "target": "thread_local"
+            },
+            {
+              "id": "tracing 0.1.40",
+              "target": "tracing"
+            },
+            {
+              "id": "tracing-core 0.1.32",
+              "target": "tracing_core"
+            },
+            {
+              "id": "tracing-log 0.1.4",
+              "target": "tracing_log"
+            },
+            {
+              "id": "tracing-serde 0.1.3",
+              "target": "tracing_serde"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2018",
+        "version": "0.2.25"
       },
       "license": "MIT",
       "license_ids": [

--- a/Cargo.Bazel.Fuzzing.json.lock
+++ b/Cargo.Bazel.Fuzzing.json.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "12c572ec2d0d27cc1208080e614691626f7517d2d7e8b27db6ab9eba3889e0be",
+  "checksum": "11969a79056a8bfab479319f8ca5e59fc600e162f39105acf6faf4b6bc8dc99f",
   "crates": {
     "abnf 0.12.0": {
       "name": "abnf",
@@ -27903,9 +27903,9 @@
       "package_url": "https://github.com/dfinity/agent-rs",
       "repository": {
         "Git": {
-          "remote": "https://github.com/dfinity/agent-rs",
+          "remote": "https://github.com/nikolay-komarevskiy/agent-rs",
           "commitish": {
-            "Rev": "05a7baa2514c9d1e6adcc35a45a9236228ad606e"
+            "Rev": "fe39797feacadc9de64e6a8eee33a9355329c694"
           },
           "strip_prefix": "ic-agent"
         }
@@ -29722,9 +29722,9 @@
       "package_url": "https://github.com/dfinity/agent-rs",
       "repository": {
         "Git": {
-          "remote": "https://github.com/dfinity/agent-rs",
+          "remote": "https://github.com/nikolay-komarevskiy/agent-rs",
           "commitish": {
-            "Rev": "05a7baa2514c9d1e6adcc35a45a9236228ad606e"
+            "Rev": "fe39797feacadc9de64e6a8eee33a9355329c694"
           },
           "strip_prefix": "ic-transport-types"
         }

--- a/Cargo.Bazel.Fuzzing.json.lock
+++ b/Cargo.Bazel.Fuzzing.json.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "b88528cf58a8cc5e67e75820dc107032c23d1ec220acbdeef1b570eec530a894",
+  "checksum": "12c572ec2d0d27cc1208080e614691626f7517d2d7e8b27db6ab9eba3889e0be",
   "crates": {
     "abnf 0.12.0": {
       "name": "abnf",
@@ -17477,9 +17477,8 @@
               "target": "ic_agent"
             },
             {
-              "id": "ic-agent 0.36.0",
-              "target": "ic_agent",
-              "alias": "ic_agent_discovery"
+              "id": "ic-agent-with-discovery 0.36.0",
+              "target": "ic_agent_with_discovery"
             },
             {
               "id": "ic-btc-interface 0.2.0",
@@ -27898,15 +27897,15 @@
       ],
       "license_file": null
     },
-    "ic-agent 0.36.0": {
-      "name": "ic-agent",
+    "ic-agent-with-discovery 0.36.0": {
+      "name": "ic-agent-with-discovery",
       "version": "0.36.0",
       "package_url": "https://github.com/dfinity/agent-rs",
       "repository": {
         "Git": {
           "remote": "https://github.com/dfinity/agent-rs",
           "commitish": {
-            "Rev": "1c93d1c683b2207af9b62b4f517c036b563f3af0"
+            "Rev": "05a7baa2514c9d1e6adcc35a45a9236228ad606e"
           },
           "strip_prefix": "ic-agent"
         }
@@ -27914,7 +27913,7 @@
       "targets": [
         {
           "Library": {
-            "crate_name": "ic_agent",
+            "crate_name": "ic_agent_with_discovery",
             "crate_root": "src/lib.rs",
             "srcs": {
               "allow_empty": false,
@@ -27925,7 +27924,7 @@
           }
         }
       ],
-      "library_target_name": "ic_agent",
+      "library_target_name": "ic_agent_with_discovery",
       "common_attrs": {
         "compile_data_glob": [
           "**"
@@ -29725,7 +29724,7 @@
         "Git": {
           "remote": "https://github.com/dfinity/agent-rs",
           "commitish": {
-            "Rev": "1c93d1c683b2207af9b62b4f517c036b563f3af0"
+            "Rev": "05a7baa2514c9d1e6adcc35a45a9236228ad606e"
           },
           "strip_prefix": "ic-transport-types"
         }
@@ -79436,7 +79435,7 @@
     "hyper-util 0.1.6",
     "hyperlocal-next 0.9.0",
     "ic-agent 0.35.0",
-    "ic-agent 0.36.0",
+    "ic-agent-with-discovery 0.36.0",
     "ic-btc-interface 0.2.0",
     "ic-btc-test-utils 0.1.0",
     "ic-btc-validation 0.1.0",

--- a/Cargo.Bazel.Fuzzing.toml.lock
+++ b/Cargo.Bazel.Fuzzing.toml.lock
@@ -3005,8 +3005,8 @@ dependencies = [
  "hyper-socks2",
  "hyper-util",
  "hyperlocal-next",
- "ic-agent 0.35.0",
- "ic-agent 0.36.0",
+ "ic-agent",
+ "ic-agent-with-discovery",
  "ic-btc-interface",
  "ic-btc-test-utils",
  "ic-btc-validation",
@@ -4835,9 +4835,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "ic-agent"
+name = "ic-agent-with-discovery"
 version = "0.36.0"
-source = "git+https://github.com/dfinity/agent-rs?rev=1c93d1c683b2207af9b62b4f517c036b563f3af0#1c93d1c683b2207af9b62b4f517c036b563f3af0"
+source = "git+https://github.com/dfinity/agent-rs?rev=05a7baa2514c9d1e6adcc35a45a9236228ad606e#05a7baa2514c9d1e6adcc35a45a9236228ad606e"
 dependencies = [
  "arc-swap",
  "async-lock 3.3.0",
@@ -5203,7 +5203,7 @@ dependencies = [
 [[package]]
 name = "ic-transport-types"
 version = "0.36.0"
-source = "git+https://github.com/dfinity/agent-rs?rev=1c93d1c683b2207af9b62b4f517c036b563f3af0#1c93d1c683b2207af9b62b4f517c036b563f3af0"
+source = "git+https://github.com/dfinity/agent-rs?rev=05a7baa2514c9d1e6adcc35a45a9236228ad606e#05a7baa2514c9d1e6adcc35a45a9236228ad606e"
 dependencies = [
  "candid",
  "hex",
@@ -5225,7 +5225,7 @@ dependencies = [
  "async-trait",
  "candid",
  "futures-util",
- "ic-agent 0.35.0",
+ "ic-agent",
  "once_cell",
  "semver",
  "serde",

--- a/Cargo.Bazel.Fuzzing.toml.lock
+++ b/Cargo.Bazel.Fuzzing.toml.lock
@@ -4837,7 +4837,7 @@ dependencies = [
 [[package]]
 name = "ic-agent-with-discovery"
 version = "0.36.0"
-source = "git+https://github.com/dfinity/agent-rs?rev=05a7baa2514c9d1e6adcc35a45a9236228ad606e#05a7baa2514c9d1e6adcc35a45a9236228ad606e"
+source = "git+https://github.com/nikolay-komarevskiy/agent-rs?rev=fe39797feacadc9de64e6a8eee33a9355329c694#fe39797feacadc9de64e6a8eee33a9355329c694"
 dependencies = [
  "arc-swap",
  "async-lock 3.3.0",
@@ -5203,7 +5203,7 @@ dependencies = [
 [[package]]
 name = "ic-transport-types"
 version = "0.36.0"
-source = "git+https://github.com/dfinity/agent-rs?rev=05a7baa2514c9d1e6adcc35a45a9236228ad606e#05a7baa2514c9d1e6adcc35a45a9236228ad606e"
+source = "git+https://github.com/nikolay-komarevskiy/agent-rs?rev=fe39797feacadc9de64e6a8eee33a9355329c694#fe39797feacadc9de64e6a8eee33a9355329c694"
 dependencies = [
  "candid",
  "hex",

--- a/Cargo.Bazel.Fuzzing.toml.lock
+++ b/Cargo.Bazel.Fuzzing.toml.lock
@@ -351,6 +351,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
+name = "ansi_term"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+dependencies = [
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3019,7 +3028,7 @@ dependencies = [
  "ic-wasm",
  "ic-xrc-types",
  "ic0 0.18.11",
- "ic_bls12_381 0.9.2",
+ "ic_bls12_381",
  "ic_principal",
  "icrc1-test-env",
  "icrc1-test-suite",
@@ -3207,7 +3216,7 @@ dependencies = [
  "tracing-opentelemetry 0.24.0",
  "tracing-serde",
  "tracing-slog",
- "tracing-subscriber",
+ "tracing-subscriber 0.3.18",
  "trust-dns-resolver",
  "turmoil",
  "url",
@@ -4688,6 +4697,7 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.26.0",
  "tower-service",
+ "webpki-roots 0.26.1",
 ]
 
 [[package]]
@@ -4827,9 +4837,11 @@ dependencies = [
 [[package]]
 name = "ic-agent"
 version = "0.36.0"
-source = "git+https://github.com/dfinity/agent-rs?rev=9e45b314fc7496d48065590fac90790e0bdc6eed#9e45b314fc7496d48065590fac90790e0bdc6eed"
+source = "git+https://github.com/dfinity/agent-rs?rev=1c93d1c683b2207af9b62b4f517c036b563f3af0#1c93d1c683b2207af9b62b4f517c036b563f3af0"
 dependencies = [
+ "arc-swap",
  "async-lock 3.3.0",
+ "async-trait",
  "backoff",
  "cached 0.52.0",
  "candid",
@@ -4838,9 +4850,14 @@ dependencies = [
  "hex",
  "http 1.1.0",
  "http-body 1.0.0",
+ "http-body-to-bytes",
+ "http-body-util",
+ "hyper 1.4.1",
+ "hyper-rustls 0.27.2",
+ "hyper-util",
  "ic-certification",
  "ic-transport-types 0.36.0",
- "ic-verify-bls-signature 0.5.0",
+ "ic-verify-bls-signature 0.1.0",
  "k256",
  "leb128",
  "p256",
@@ -4858,9 +4875,14 @@ dependencies = [
  "serde_repr",
  "sha2 0.10.8",
  "simple_asn1",
+ "simple_moving_average",
  "thiserror",
  "time",
  "tokio",
+ "tokio-util",
+ "tower",
+ "tracing",
+ "tracing-subscriber 0.2.25",
  "url",
 ]
 
@@ -5181,7 +5203,7 @@ dependencies = [
 [[package]]
 name = "ic-transport-types"
 version = "0.36.0"
-source = "git+https://github.com/dfinity/agent-rs?rev=9e45b314fc7496d48065590fac90790e0bdc6eed#9e45b314fc7496d48065590fac90790e0bdc6eed"
+source = "git+https://github.com/dfinity/agent-rs?rev=1c93d1c683b2207af9b62b4f517c036b563f3af0#1c93d1c683b2207af9b62b4f517c036b563f3af0"
 dependencies = [
  "candid",
  "hex",
@@ -5190,7 +5212,6 @@ dependencies = [
  "serde",
  "serde_bytes",
  "serde_repr",
- "serde_with 3.8.1",
  "sha2 0.10.8",
  "thiserror",
 ]
@@ -5241,20 +5262,6 @@ dependencies = [
  "pairing 0.22.0",
  "rand 0.6.5",
  "sha2 0.9.9",
-]
-
-[[package]]
-name = "ic-verify-bls-signature"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d420b25c0091059f6c3c23a21427a81915e6e0aca3b79e0d403ed767f286a3b9"
-dependencies = [
- "hex",
- "ic_bls12_381 0.10.0",
- "lazy_static",
- "pairing 0.23.0",
- "rand 0.8.5",
- "sha2 0.10.8",
 ]
 
 [[package]]
@@ -5315,20 +5322,6 @@ dependencies = [
  "rand_core 0.6.4",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "ic_bls12_381"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22c65787944f32af084dffd0c68c1e544237b76e215654ddea8cd9f527dd8b69"
-dependencies = [
- "digest 0.10.7",
- "ff 0.13.0",
- "group 0.13.0",
- "pairing 0.23.0",
- "rand_core 0.6.4",
- "subtle",
 ]
 
 [[package]]
@@ -6476,6 +6469,15 @@ name = "match_cfg"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffbee8634e0d45d258acb448e7eaab3fce7a0a467395d4d9f228e3c1f01fb2e4"
+
+[[package]]
+name = "matchers"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f099785f7595cc4b4553a174ce30dd7589ef93391ff414dbb67f62392b9e0ce1"
+dependencies = [
+ "regex-automata 0.1.10",
+]
 
 [[package]]
 name = "matchers"
@@ -7932,7 +7934,7 @@ dependencies = [
  "serde_json",
  "tracing",
  "tracing-appender",
- "tracing-subscriber",
+ "tracing-subscriber 0.3.18",
 ]
 
 [[package]]
@@ -9961,24 +9963,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_with"
-version = "3.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ad483d2ab0149d5a5ebcd9972a3852711e0153d863bf5a5d0391d28883c4a20"
-dependencies = [
- "base64 0.22.0",
- "chrono",
- "hex",
- "indexmap 1.9.3",
- "indexmap 2.2.6",
- "serde",
- "serde_derive",
- "serde_json",
- "serde_with_macros 3.8.1",
- "time",
-]
-
-[[package]]
 name = "serde_with_macros"
 version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9995,18 +9979,6 @@ name = "serde_with_macros"
 version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "881b6f881b17d13214e5d494c939ebab463d01264ce1811e9d4ac3a882e7695f"
-dependencies = [
- "darling 0.20.3",
- "proc-macro2 1.0.85",
- "quote 1.0.35",
- "syn 2.0.66",
-]
-
-[[package]]
-name = "serde_with_macros"
-version = "3.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65569b702f41443e8bc8bbb1c5779bd0450bbe723b56198980e80ec45780bce2"
 dependencies = [
  "darling 0.20.3",
  "proc-macro2 1.0.85",
@@ -11181,6 +11153,7 @@ checksum = "9cf6b47b3771c49ac75ad09a6162f53ad4b8088b76ac60e8ec1455b31a189fe1"
 dependencies = [
  "bytes",
  "futures-core",
+ "futures-io",
  "futures-sink",
  "futures-util",
  "hashbrown 0.14.5",
@@ -11404,7 +11377,7 @@ dependencies = [
  "crossbeam-channel",
  "thiserror",
  "time",
- "tracing-subscriber",
+ "tracing-subscriber 0.3.18",
 ]
 
 [[package]]
@@ -11436,7 +11409,18 @@ checksum = "0bae117ee14789185e129aaee5d93750abe67fdc5a9a62650452bfe4e122a3a9"
 dependencies = [
  "lazy_static",
  "tracing",
- "tracing-subscriber",
+ "tracing-subscriber 0.3.18",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f751112709b4e791d8ce53e32c4ed2d353565a795ce84da2285393f41557bdf2"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
 ]
 
 [[package]]
@@ -11460,7 +11444,7 @@ dependencies = [
  "opentelemetry 0.18.0",
  "tracing",
  "tracing-core",
- "tracing-subscriber",
+ "tracing-subscriber 0.3.18",
 ]
 
 [[package]]
@@ -11476,8 +11460,8 @@ dependencies = [
  "smallvec",
  "tracing",
  "tracing-core",
- "tracing-log",
- "tracing-subscriber",
+ "tracing-log 0.2.0",
+ "tracing-subscriber 0.3.18",
  "web-time",
 ]
 
@@ -11504,11 +11488,33 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
+version = "0.2.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e0d2eaa99c3c2e41547cfa109e910a68ea03823cccad4a0525dcbc9b01e8c71"
+dependencies = [
+ "ansi_term",
+ "chrono",
+ "lazy_static",
+ "matchers 0.0.1",
+ "regex",
+ "serde",
+ "serde_json",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log 0.1.4",
+ "tracing-serde",
+]
+
+[[package]]
+name = "tracing-subscriber"
 version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
 dependencies = [
- "matchers",
+ "matchers 0.1.0",
  "nu-ansi-term",
  "once_cell",
  "regex",
@@ -11519,7 +11525,7 @@ dependencies = [
  "thread_local",
  "tracing",
  "tracing-core",
- "tracing-log",
+ "tracing-log 0.2.0",
  "tracing-serde",
 ]
 
@@ -11634,7 +11640,7 @@ dependencies = [
  "tokio-test",
  "tokio-util",
  "tracing",
- "tracing-subscriber",
+ "tracing-subscriber 0.3.18",
 ]
 
 [[package]]

--- a/Cargo.Bazel.json.lock
+++ b/Cargo.Bazel.json.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "4c9bf48f66e240354f058554292e9dda3cb7bc4ad5fb71923fe11a089938c6b6",
+  "checksum": "c0ade5849cf08bb4212707fcb14410a41339f89bdf5390198bb03202cc13ae7b",
   "crates": {
     "abnf 0.12.0": {
       "name": "abnf",
@@ -1950,6 +1950,55 @@
       "license": "MIT OR Apache-2.0",
       "license_ids": [
         "Apache-2.0",
+        "MIT"
+      ],
+      "license_file": null
+    },
+    "ansi_term 0.12.1": {
+      "name": "ansi_term",
+      "version": "0.12.1",
+      "package_url": "https://github.com/ogham/rust-ansi-term",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/ansi_term/0.12.1/download",
+          "sha256": "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "ansi_term",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "ansi_term",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [],
+          "selects": {
+            "cfg(target_os = \"windows\")": [
+              {
+                "id": "winapi 0.3.9",
+                "target": "winapi"
+              }
+            ]
+          }
+        },
+        "edition": "2015",
+        "version": "0.12.1"
+      },
+      "license": "MIT",
+      "license_ids": [
         "MIT"
       ],
       "license_file": null
@@ -17263,7 +17312,7 @@
             {
               "id": "ic-agent 0.36.0",
               "target": "ic_agent",
-              "alias": "ic_agent_call_v3"
+              "alias": "ic_agent_discovery"
             },
             {
               "id": "ic-btc-interface 0.2.0",
@@ -26880,7 +26929,104 @@
             "rustls-native-certs",
             "tls12"
           ],
-          "selects": {}
+          "selects": {
+            "aarch64-apple-darwin": [
+              "webpki-roots"
+            ],
+            "aarch64-apple-ios": [
+              "webpki-roots"
+            ],
+            "aarch64-apple-ios-sim": [
+              "webpki-roots"
+            ],
+            "aarch64-fuchsia": [
+              "webpki-roots"
+            ],
+            "aarch64-linux-android": [
+              "webpki-roots"
+            ],
+            "aarch64-pc-windows-msvc": [
+              "webpki-roots"
+            ],
+            "aarch64-unknown-linux-gnu": [
+              "webpki-roots"
+            ],
+            "aarch64-unknown-nixos-gnu": [
+              "webpki-roots"
+            ],
+            "aarch64-unknown-nto-qnx710": [
+              "webpki-roots"
+            ],
+            "arm-unknown-linux-gnueabi": [
+              "webpki-roots"
+            ],
+            "armv7-linux-androideabi": [
+              "webpki-roots"
+            ],
+            "armv7-unknown-linux-gnueabi": [
+              "webpki-roots"
+            ],
+            "i686-apple-darwin": [
+              "webpki-roots"
+            ],
+            "i686-linux-android": [
+              "webpki-roots"
+            ],
+            "i686-pc-windows-msvc": [
+              "webpki-roots"
+            ],
+            "i686-unknown-freebsd": [
+              "webpki-roots"
+            ],
+            "i686-unknown-linux-gnu": [
+              "webpki-roots"
+            ],
+            "powerpc-unknown-linux-gnu": [
+              "webpki-roots"
+            ],
+            "riscv32imc-unknown-none-elf": [
+              "webpki-roots"
+            ],
+            "riscv64gc-unknown-none-elf": [
+              "webpki-roots"
+            ],
+            "s390x-unknown-linux-gnu": [
+              "webpki-roots"
+            ],
+            "thumbv7em-none-eabi": [
+              "webpki-roots"
+            ],
+            "thumbv8m.main-none-eabi": [
+              "webpki-roots"
+            ],
+            "x86_64-apple-darwin": [
+              "webpki-roots"
+            ],
+            "x86_64-apple-ios": [
+              "webpki-roots"
+            ],
+            "x86_64-fuchsia": [
+              "webpki-roots"
+            ],
+            "x86_64-linux-android": [
+              "webpki-roots"
+            ],
+            "x86_64-pc-windows-msvc": [
+              "webpki-roots"
+            ],
+            "x86_64-unknown-freebsd": [
+              "webpki-roots"
+            ],
+            "x86_64-unknown-linux-gnu": [
+              "webpki-roots"
+            ],
+            "x86_64-unknown-nixos-gnu": [
+              "webpki-roots"
+            ],
+            "x86_64-unknown-none": [
+              "webpki-roots"
+            ]
+          }
         },
         "deps": {
           "common": [
@@ -26924,6 +27070,10 @@
             {
               "id": "tower-service 0.3.2",
               "target": "tower_service"
+            },
+            {
+              "id": "webpki-roots 0.26.1",
+              "target": "webpki_roots"
             }
           ],
           "selects": {}
@@ -27659,7 +27809,7 @@
         "Git": {
           "remote": "https://github.com/dfinity/agent-rs",
           "commitish": {
-            "Rev": "9e45b314fc7496d48065590fac90790e0bdc6eed"
+            "Rev": "1c93d1c683b2207af9b62b4f517c036b563f3af0"
           },
           "strip_prefix": "ic-agent"
         }
@@ -27686,9 +27836,9 @@
         "crate_features": {
           "common": [
             "default",
+            "hyper",
             "pem",
-            "reqwest",
-            "sync_call"
+            "reqwest"
           ],
           "selects": {}
         },
@@ -27731,6 +27881,10 @@
               "target": "http_body"
             },
             {
+              "id": "hyper 1.4.1",
+              "target": "hyper"
+            },
+            {
               "id": "ic-certification 2.5.0",
               "target": "ic_certification"
             },
@@ -27739,7 +27893,7 @@
               "target": "ic_transport_types"
             },
             {
-              "id": "ic-verify-bls-signature 0.5.0",
+              "id": "ic-verify-bls-signature 0.1.0",
               "target": "ic_verify_bls_signature"
             },
             {
@@ -27818,12 +27972,52 @@
           "selects": {
             "cfg(not(target_family = \"wasm\"))": [
               {
+                "id": "arc-swap 1.6.0",
+                "target": "arc_swap"
+              },
+              {
+                "id": "http-body-to-bytes 0.2.0",
+                "target": "http_body_to_bytes"
+              },
+              {
+                "id": "http-body-util 0.1.0",
+                "target": "http_body_util"
+              },
+              {
+                "id": "hyper-rustls 0.27.2",
+                "target": "hyper_rustls"
+              },
+              {
+                "id": "hyper-util 0.1.6",
+                "target": "hyper_util"
+              },
+              {
                 "id": "rustls-webpki 0.102.5",
                 "target": "webpki"
               },
               {
+                "id": "simple_moving_average 1.0.2",
+                "target": "simple_moving_average"
+              },
+              {
                 "id": "tokio 1.38.0",
                 "target": "tokio"
+              },
+              {
+                "id": "tokio-util 0.7.11",
+                "target": "tokio_util"
+              },
+              {
+                "id": "tower 0.4.13",
+                "target": "tower"
+              },
+              {
+                "id": "tracing 0.1.40",
+                "target": "tracing"
+              },
+              {
+                "id": "tracing-subscriber 0.2.25",
+                "target": "tracing_subscriber"
               }
             ]
           }
@@ -27836,7 +28030,14 @@
               "target": "serde_repr"
             }
           ],
-          "selects": {}
+          "selects": {
+            "cfg(not(target_family = \"wasm\"))": [
+              {
+                "id": "async-trait 0.1.73",
+                "target": "async_trait"
+              }
+            ]
+          }
         },
         "version": "0.36.0"
       },
@@ -29405,7 +29606,7 @@
         "Git": {
           "remote": "https://github.com/dfinity/agent-rs",
           "commitish": {
-            "Rev": "9e45b314fc7496d48065590fac90790e0bdc6eed"
+            "Rev": "1c93d1c683b2207af9b62b4f517c036b563f3af0"
           },
           "strip_prefix": "ic-transport-types"
         }
@@ -29454,10 +29655,6 @@
             {
               "id": "serde_bytes 0.11.14",
               "target": "serde_bytes"
-            },
-            {
-              "id": "serde_with 3.8.1",
-              "target": "serde_with"
             },
             {
               "id": "sha2 0.10.8",
@@ -29717,83 +29914,6 @@
         },
         "edition": "2021",
         "version": "0.2.0"
-      },
-      "license": "Apache-2.0",
-      "license_ids": [
-        "Apache-2.0"
-      ],
-      "license_file": null
-    },
-    "ic-verify-bls-signature 0.5.0": {
-      "name": "ic-verify-bls-signature",
-      "version": "0.5.0",
-      "package_url": null,
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/ic-verify-bls-signature/0.5.0/download",
-          "sha256": "d420b25c0091059f6c3c23a21427a81915e6e0aca3b79e0d403ed767f286a3b9"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "ic_verify_bls_signature",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": false,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "ic_verify_bls_signature",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "alloc",
-            "default",
-            "hex",
-            "lazy_static"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "hex 0.4.3",
-              "target": "hex"
-            },
-            {
-              "id": "ic_bls12_381 0.10.0",
-              "target": "ic_bls12_381",
-              "alias": "bls12_381"
-            },
-            {
-              "id": "lazy_static 1.4.0",
-              "target": "lazy_static"
-            },
-            {
-              "id": "pairing 0.23.0",
-              "target": "pairing"
-            },
-            {
-              "id": "rand 0.8.5",
-              "target": "rand"
-            },
-            {
-              "id": "sha2 0.10.8",
-              "target": "sha2"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "version": "0.5.0"
       },
       "license": "Apache-2.0",
       "license_ids": [
@@ -30150,93 +30270,6 @@
           "selects": {}
         },
         "version": "0.9.2"
-      },
-      "license": "MIT/Apache-2.0",
-      "license_ids": [
-        "Apache-2.0",
-        "MIT"
-      ],
-      "license_file": "LICENSE-APACHE"
-    },
-    "ic_bls12_381 0.10.0": {
-      "name": "ic_bls12_381",
-      "version": "0.10.0",
-      "package_url": "https://github.com/dfinity/bls12_381",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/ic_bls12_381/0.10.0/download",
-          "sha256": "22c65787944f32af084dffd0c68c1e544237b76e215654ddea8cd9f527dd8b69"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "ic_bls12_381",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": false,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "ic_bls12_381",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "alloc",
-            "digest",
-            "experimental",
-            "group",
-            "groups",
-            "pairing",
-            "pairings"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "digest 0.10.7",
-              "target": "digest"
-            },
-            {
-              "id": "ff 0.13.0",
-              "target": "ff"
-            },
-            {
-              "id": "group 0.13.0",
-              "target": "group"
-            },
-            {
-              "id": "pairing 0.23.0",
-              "target": "pairing"
-            },
-            {
-              "id": "rand_core 0.6.4",
-              "target": "rand_core"
-            },
-            {
-              "id": "subtle 2.5.0",
-              "target": "subtle"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "rustc_flags": {
-          "common": [
-            "-C",
-            "opt-level=3"
-          ],
-          "selects": {}
-        },
-        "version": "0.10.0"
       },
       "license": "MIT/Apache-2.0",
       "license_ids": [
@@ -37351,6 +37384,53 @@
         "MIT"
       ],
       "license_file": "LICENSE-APACHE"
+    },
+    "matchers 0.0.1": {
+      "name": "matchers",
+      "version": "0.0.1",
+      "package_url": "https://github.com/hawkw/matchers",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/matchers/0.0.1/download",
+          "sha256": "f099785f7595cc4b4553a174ce30dd7589ef93391ff414dbb67f62392b9e0ce1"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "matchers",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "matchers",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "regex-automata 0.1.10",
+              "target": "regex_automata"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2018",
+        "version": "0.0.1"
+      },
+      "license": "MIT",
+      "license_ids": [
+        "MIT"
+      ],
+      "license_file": "LICENSE"
     },
     "matchers 0.1.0": {
       "name": "matchers",
@@ -58871,76 +58951,6 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "serde_with 3.8.1": {
-      "name": "serde_with",
-      "version": "3.8.1",
-      "package_url": "https://github.com/jonasbb/serde_with/",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/serde_with/3.8.1/download",
-          "sha256": "0ad483d2ab0149d5a5ebcd9972a3852711e0153d863bf5a5d0391d28883c4a20"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "serde_with",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": false,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "serde_with",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "alloc",
-            "default",
-            "macros",
-            "std"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "serde 1.0.203",
-              "target": "serde"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "proc_macro_deps": {
-          "common": [
-            {
-              "id": "serde_derive 1.0.203",
-              "target": "serde_derive"
-            },
-            {
-              "id": "serde_with_macros 3.8.1",
-              "target": "serde_with_macros"
-            }
-          ],
-          "selects": {}
-        },
-        "version": "3.8.1"
-      },
-      "license": "MIT OR Apache-2.0",
-      "license_ids": [
-        "Apache-2.0",
-        "MIT"
-      ],
-      "license_file": "LICENSE-APACHE"
-    },
     "serde_with_macros 1.5.2": {
       "name": "serde_with_macros",
       "version": "1.5.2",
@@ -59053,66 +59063,6 @@
         },
         "edition": "2021",
         "version": "2.3.3"
-      },
-      "license": "MIT OR Apache-2.0",
-      "license_ids": [
-        "Apache-2.0",
-        "MIT"
-      ],
-      "license_file": "LICENSE-APACHE"
-    },
-    "serde_with_macros 3.8.1": {
-      "name": "serde_with_macros",
-      "version": "3.8.1",
-      "package_url": "https://github.com/jonasbb/serde_with/",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/serde_with_macros/3.8.1/download",
-          "sha256": "65569b702f41443e8bc8bbb1c5779bd0450bbe723b56198980e80ec45780bce2"
-        }
-      },
-      "targets": [
-        {
-          "ProcMacro": {
-            "crate_name": "serde_with_macros",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": false,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "serde_with_macros",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "darling 0.20.3",
-              "target": "darling"
-            },
-            {
-              "id": "proc-macro2 1.0.85",
-              "target": "proc_macro2"
-            },
-            {
-              "id": "quote 1.0.35",
-              "target": "quote"
-            },
-            {
-              "id": "syn 2.0.66",
-              "target": "syn"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "version": "3.8.1"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -66259,7 +66209,232 @@
             "slab",
             "time"
           ],
-          "selects": {}
+          "selects": {
+            "aarch64-apple-darwin": [
+              "compat",
+              "full",
+              "futures-io",
+              "io-util",
+              "net"
+            ],
+            "aarch64-apple-ios": [
+              "compat",
+              "full",
+              "futures-io",
+              "io-util",
+              "net"
+            ],
+            "aarch64-apple-ios-sim": [
+              "compat",
+              "full",
+              "futures-io",
+              "io-util",
+              "net"
+            ],
+            "aarch64-fuchsia": [
+              "compat",
+              "full",
+              "futures-io",
+              "io-util",
+              "net"
+            ],
+            "aarch64-linux-android": [
+              "compat",
+              "full",
+              "futures-io",
+              "io-util",
+              "net"
+            ],
+            "aarch64-pc-windows-msvc": [
+              "compat",
+              "full",
+              "futures-io",
+              "io-util",
+              "net"
+            ],
+            "aarch64-unknown-linux-gnu": [
+              "compat",
+              "full",
+              "futures-io",
+              "io-util",
+              "net"
+            ],
+            "aarch64-unknown-nixos-gnu": [
+              "compat",
+              "full",
+              "futures-io",
+              "io-util",
+              "net"
+            ],
+            "aarch64-unknown-nto-qnx710": [
+              "compat",
+              "full",
+              "futures-io",
+              "io-util",
+              "net"
+            ],
+            "arm-unknown-linux-gnueabi": [
+              "compat",
+              "full",
+              "futures-io",
+              "io-util",
+              "net"
+            ],
+            "armv7-linux-androideabi": [
+              "compat",
+              "full",
+              "futures-io",
+              "io-util",
+              "net"
+            ],
+            "armv7-unknown-linux-gnueabi": [
+              "compat",
+              "full",
+              "futures-io",
+              "io-util",
+              "net"
+            ],
+            "i686-apple-darwin": [
+              "compat",
+              "full",
+              "futures-io",
+              "io-util",
+              "net"
+            ],
+            "i686-linux-android": [
+              "compat",
+              "full",
+              "futures-io",
+              "io-util",
+              "net"
+            ],
+            "i686-pc-windows-msvc": [
+              "compat",
+              "full",
+              "futures-io",
+              "io-util",
+              "net"
+            ],
+            "i686-unknown-freebsd": [
+              "compat",
+              "full",
+              "futures-io",
+              "io-util",
+              "net"
+            ],
+            "i686-unknown-linux-gnu": [
+              "compat",
+              "full",
+              "futures-io",
+              "io-util",
+              "net"
+            ],
+            "powerpc-unknown-linux-gnu": [
+              "compat",
+              "full",
+              "futures-io",
+              "io-util",
+              "net"
+            ],
+            "riscv32imc-unknown-none-elf": [
+              "compat",
+              "full",
+              "futures-io",
+              "io-util",
+              "net"
+            ],
+            "riscv64gc-unknown-none-elf": [
+              "compat",
+              "full",
+              "futures-io",
+              "io-util",
+              "net"
+            ],
+            "s390x-unknown-linux-gnu": [
+              "compat",
+              "full",
+              "futures-io",
+              "io-util",
+              "net"
+            ],
+            "thumbv7em-none-eabi": [
+              "compat",
+              "full",
+              "futures-io",
+              "io-util",
+              "net"
+            ],
+            "thumbv8m.main-none-eabi": [
+              "compat",
+              "full",
+              "futures-io",
+              "io-util",
+              "net"
+            ],
+            "x86_64-apple-darwin": [
+              "compat",
+              "full",
+              "futures-io",
+              "io-util",
+              "net"
+            ],
+            "x86_64-apple-ios": [
+              "compat",
+              "full",
+              "futures-io",
+              "io-util",
+              "net"
+            ],
+            "x86_64-fuchsia": [
+              "compat",
+              "full",
+              "futures-io",
+              "io-util",
+              "net"
+            ],
+            "x86_64-linux-android": [
+              "compat",
+              "full",
+              "futures-io",
+              "io-util",
+              "net"
+            ],
+            "x86_64-pc-windows-msvc": [
+              "compat",
+              "full",
+              "futures-io",
+              "io-util",
+              "net"
+            ],
+            "x86_64-unknown-freebsd": [
+              "compat",
+              "full",
+              "futures-io",
+              "io-util",
+              "net"
+            ],
+            "x86_64-unknown-linux-gnu": [
+              "compat",
+              "full",
+              "futures-io",
+              "io-util",
+              "net"
+            ],
+            "x86_64-unknown-nixos-gnu": [
+              "compat",
+              "full",
+              "futures-io",
+              "io-util",
+              "net"
+            ],
+            "x86_64-unknown-none": [
+              "compat",
+              "full",
+              "futures-io",
+              "io-util",
+              "net"
+            ]
+          }
         },
         "deps": {
           "common": [
@@ -66270,6 +66445,10 @@
             {
               "id": "futures-core 0.3.30",
               "target": "futures_core"
+            },
+            {
+              "id": "futures-io 0.3.30",
+              "target": "futures_io"
             },
             {
               "id": "futures-sink 0.3.30",
@@ -67675,6 +67854,68 @@
       ],
       "license_file": "LICENSE"
     },
+    "tracing-log 0.1.4": {
+      "name": "tracing-log",
+      "version": "0.1.4",
+      "package_url": "https://github.com/tokio-rs/tracing",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/tracing-log/0.1.4/download",
+          "sha256": "f751112709b4e791d8ce53e32c4ed2d353565a795ce84da2285393f41557bdf2"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "tracing_log",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "tracing_log",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": {
+          "common": [
+            "log-tracer",
+            "std"
+          ],
+          "selects": {}
+        },
+        "deps": {
+          "common": [
+            {
+              "id": "log 0.4.20",
+              "target": "log"
+            },
+            {
+              "id": "once_cell 1.19.0",
+              "target": "once_cell"
+            },
+            {
+              "id": "tracing-core 0.1.32",
+              "target": "tracing_core"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2018",
+        "version": "0.1.4"
+      },
+      "license": "MIT",
+      "license_ids": [
+        "MIT"
+      ],
+      "license_file": "LICENSE"
+    },
     "tracing-log 0.2.0": {
       "name": "tracing-log",
       "version": "0.2.0",
@@ -68001,6 +68242,129 @@
         },
         "edition": "2021",
         "version": "0.2.0"
+      },
+      "license": "MIT",
+      "license_ids": [
+        "MIT"
+      ],
+      "license_file": "LICENSE"
+    },
+    "tracing-subscriber 0.2.25": {
+      "name": "tracing-subscriber",
+      "version": "0.2.25",
+      "package_url": "https://github.com/tokio-rs/tracing",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/tracing-subscriber/0.2.25/download",
+          "sha256": "0e0d2eaa99c3c2e41547cfa109e910a68ea03823cccad4a0525dcbc9b01e8c71"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "tracing_subscriber",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "tracing_subscriber",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": {
+          "common": [
+            "ansi",
+            "ansi_term",
+            "chrono",
+            "default",
+            "env-filter",
+            "fmt",
+            "json",
+            "lazy_static",
+            "matchers",
+            "regex",
+            "registry",
+            "serde",
+            "serde_json",
+            "sharded-slab",
+            "smallvec",
+            "thread_local",
+            "tracing",
+            "tracing-log",
+            "tracing-serde"
+          ],
+          "selects": {}
+        },
+        "deps": {
+          "common": [
+            {
+              "id": "ansi_term 0.12.1",
+              "target": "ansi_term"
+            },
+            {
+              "id": "chrono 0.4.38",
+              "target": "chrono"
+            },
+            {
+              "id": "lazy_static 1.4.0",
+              "target": "lazy_static"
+            },
+            {
+              "id": "matchers 0.0.1",
+              "target": "matchers"
+            },
+            {
+              "id": "regex 1.10.5",
+              "target": "regex"
+            },
+            {
+              "id": "serde 1.0.203",
+              "target": "serde"
+            },
+            {
+              "id": "serde_json 1.0.108",
+              "target": "serde_json"
+            },
+            {
+              "id": "sharded-slab 0.1.4",
+              "target": "sharded_slab"
+            },
+            {
+              "id": "smallvec 1.13.2",
+              "target": "smallvec"
+            },
+            {
+              "id": "thread_local 1.1.7",
+              "target": "thread_local"
+            },
+            {
+              "id": "tracing 0.1.40",
+              "target": "tracing"
+            },
+            {
+              "id": "tracing-core 0.1.32",
+              "target": "tracing_core"
+            },
+            {
+              "id": "tracing-log 0.1.4",
+              "target": "tracing_log"
+            },
+            {
+              "id": "tracing-serde 0.1.3",
+              "target": "tracing_serde"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2018",
+        "version": "0.2.25"
       },
       "license": "MIT",
       "license_ids": [

--- a/Cargo.Bazel.json.lock
+++ b/Cargo.Bazel.json.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "35dba37464c5f4e0d5e6d658bb47692a53d0783189bfdc96d8d2fea6520cc873",
+  "checksum": "929162aa2a34e5602d4248ba15981a35e5300b068d5b72d74d7b684f00f0f39a",
   "crates": {
     "abnf 0.12.0": {
       "name": "abnf",
@@ -27806,9 +27806,9 @@
       "package_url": "https://github.com/dfinity/agent-rs",
       "repository": {
         "Git": {
-          "remote": "https://github.com/dfinity/agent-rs",
+          "remote": "https://github.com/nikolay-komarevskiy/agent-rs",
           "commitish": {
-            "Rev": "05a7baa2514c9d1e6adcc35a45a9236228ad606e"
+            "Rev": "fe39797feacadc9de64e6a8eee33a9355329c694"
           },
           "strip_prefix": "ic-agent"
         }
@@ -29603,9 +29603,9 @@
       "package_url": "https://github.com/dfinity/agent-rs",
       "repository": {
         "Git": {
-          "remote": "https://github.com/dfinity/agent-rs",
+          "remote": "https://github.com/nikolay-komarevskiy/agent-rs",
           "commitish": {
-            "Rev": "05a7baa2514c9d1e6adcc35a45a9236228ad606e"
+            "Rev": "fe39797feacadc9de64e6a8eee33a9355329c694"
           },
           "strip_prefix": "ic-transport-types"
         }

--- a/Cargo.Bazel.json.lock
+++ b/Cargo.Bazel.json.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "c0ade5849cf08bb4212707fcb14410a41339f89bdf5390198bb03202cc13ae7b",
+  "checksum": "35dba37464c5f4e0d5e6d658bb47692a53d0783189bfdc96d8d2fea6520cc873",
   "crates": {
     "abnf 0.12.0": {
       "name": "abnf",
@@ -17310,9 +17310,8 @@
               "target": "ic_agent"
             },
             {
-              "id": "ic-agent 0.36.0",
-              "target": "ic_agent",
-              "alias": "ic_agent_discovery"
+              "id": "ic-agent-with-discovery 0.36.0",
+              "target": "ic_agent_with_discovery"
             },
             {
               "id": "ic-btc-interface 0.2.0",
@@ -27801,15 +27800,15 @@
       ],
       "license_file": null
     },
-    "ic-agent 0.36.0": {
-      "name": "ic-agent",
+    "ic-agent-with-discovery 0.36.0": {
+      "name": "ic-agent-with-discovery",
       "version": "0.36.0",
       "package_url": "https://github.com/dfinity/agent-rs",
       "repository": {
         "Git": {
           "remote": "https://github.com/dfinity/agent-rs",
           "commitish": {
-            "Rev": "1c93d1c683b2207af9b62b4f517c036b563f3af0"
+            "Rev": "05a7baa2514c9d1e6adcc35a45a9236228ad606e"
           },
           "strip_prefix": "ic-agent"
         }
@@ -27817,7 +27816,7 @@
       "targets": [
         {
           "Library": {
-            "crate_name": "ic_agent",
+            "crate_name": "ic_agent_with_discovery",
             "crate_root": "src/lib.rs",
             "srcs": {
               "allow_empty": false,
@@ -27828,7 +27827,7 @@
           }
         }
       ],
-      "library_target_name": "ic_agent",
+      "library_target_name": "ic_agent_with_discovery",
       "common_attrs": {
         "compile_data_glob": [
           "**"
@@ -29606,7 +29605,7 @@
         "Git": {
           "remote": "https://github.com/dfinity/agent-rs",
           "commitish": {
-            "Rev": "1c93d1c683b2207af9b62b4f517c036b563f3af0"
+            "Rev": "05a7baa2514c9d1e6adcc35a45a9236228ad606e"
           },
           "strip_prefix": "ic-transport-types"
         }
@@ -79554,7 +79553,7 @@
     "hyper-util 0.1.6",
     "hyperlocal-next 0.9.0",
     "ic-agent 0.35.0",
-    "ic-agent 0.36.0",
+    "ic-agent-with-discovery 0.36.0",
     "ic-btc-interface 0.2.0",
     "ic-btc-test-utils 0.1.0",
     "ic-btc-validation 0.1.0",

--- a/Cargo.Bazel.toml.lock
+++ b/Cargo.Bazel.toml.lock
@@ -353,6 +353,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
+name = "ansi_term"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+dependencies = [
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3009,7 +3018,7 @@ dependencies = [
  "ic-wasm",
  "ic-xrc-types",
  "ic0 0.18.11",
- "ic_bls12_381 0.9.2",
+ "ic_bls12_381",
  "ic_principal",
  "icrc1-test-env",
  "icrc1-test-suite",
@@ -3197,7 +3206,7 @@ dependencies = [
  "tracing-opentelemetry 0.24.0",
  "tracing-serde",
  "tracing-slog",
- "tracing-subscriber",
+ "tracing-subscriber 0.3.18",
  "trust-dns-resolver",
  "turmoil",
  "url",
@@ -4685,6 +4694,7 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.26.0",
  "tower-service",
+ "webpki-roots 0.26.1",
 ]
 
 [[package]]
@@ -4824,9 +4834,11 @@ dependencies = [
 [[package]]
 name = "ic-agent"
 version = "0.36.0"
-source = "git+https://github.com/dfinity/agent-rs?rev=9e45b314fc7496d48065590fac90790e0bdc6eed#9e45b314fc7496d48065590fac90790e0bdc6eed"
+source = "git+https://github.com/dfinity/agent-rs?rev=1c93d1c683b2207af9b62b4f517c036b563f3af0#1c93d1c683b2207af9b62b4f517c036b563f3af0"
 dependencies = [
+ "arc-swap",
  "async-lock 3.3.0",
+ "async-trait",
  "backoff",
  "cached 0.52.0",
  "candid",
@@ -4835,9 +4847,14 @@ dependencies = [
  "hex",
  "http 1.1.0",
  "http-body 1.0.0",
+ "http-body-to-bytes",
+ "http-body-util",
+ "hyper 1.4.1",
+ "hyper-rustls 0.27.2",
+ "hyper-util",
  "ic-certification",
  "ic-transport-types 0.36.0",
- "ic-verify-bls-signature 0.5.0",
+ "ic-verify-bls-signature 0.1.0",
  "k256",
  "leb128",
  "p256",
@@ -4855,9 +4872,14 @@ dependencies = [
  "serde_repr",
  "sha2 0.10.8",
  "simple_asn1",
+ "simple_moving_average",
  "thiserror",
  "time",
  "tokio",
+ "tokio-util",
+ "tower",
+ "tracing",
+ "tracing-subscriber 0.2.25",
  "url",
 ]
 
@@ -5178,7 +5200,7 @@ dependencies = [
 [[package]]
 name = "ic-transport-types"
 version = "0.36.0"
-source = "git+https://github.com/dfinity/agent-rs?rev=9e45b314fc7496d48065590fac90790e0bdc6eed#9e45b314fc7496d48065590fac90790e0bdc6eed"
+source = "git+https://github.com/dfinity/agent-rs?rev=1c93d1c683b2207af9b62b4f517c036b563f3af0#1c93d1c683b2207af9b62b4f517c036b563f3af0"
 dependencies = [
  "candid",
  "hex",
@@ -5187,7 +5209,6 @@ dependencies = [
  "serde",
  "serde_bytes",
  "serde_repr",
- "serde_with 3.8.1",
  "sha2 0.10.8",
  "thiserror",
 ]
@@ -5238,20 +5259,6 @@ dependencies = [
  "pairing 0.22.0",
  "rand 0.6.5",
  "sha2 0.9.9",
-]
-
-[[package]]
-name = "ic-verify-bls-signature"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d420b25c0091059f6c3c23a21427a81915e6e0aca3b79e0d403ed767f286a3b9"
-dependencies = [
- "hex",
- "ic_bls12_381 0.10.0",
- "lazy_static",
- "pairing 0.23.0",
- "rand 0.8.5",
- "sha2 0.10.8",
 ]
 
 [[package]]
@@ -5312,20 +5319,6 @@ dependencies = [
  "rand_core 0.6.4",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "ic_bls12_381"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22c65787944f32af084dffd0c68c1e544237b76e215654ddea8cd9f527dd8b69"
-dependencies = [
- "digest 0.10.7",
- "ff 0.13.0",
- "group 0.13.0",
- "pairing 0.23.0",
- "rand_core 0.6.4",
- "subtle",
 ]
 
 [[package]]
@@ -6491,6 +6484,15 @@ name = "match_cfg"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffbee8634e0d45d258acb448e7eaab3fce7a0a467395d4d9f228e3c1f01fb2e4"
+
+[[package]]
+name = "matchers"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f099785f7595cc4b4553a174ce30dd7589ef93391ff414dbb67f62392b9e0ce1"
+dependencies = [
+ "regex-automata 0.1.10",
+]
 
 [[package]]
 name = "matchers"
@@ -7946,7 +7948,7 @@ dependencies = [
  "serde_json",
  "tracing",
  "tracing-appender",
- "tracing-subscriber",
+ "tracing-subscriber 0.3.18",
 ]
 
 [[package]]
@@ -9997,24 +9999,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_with"
-version = "3.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ad483d2ab0149d5a5ebcd9972a3852711e0153d863bf5a5d0391d28883c4a20"
-dependencies = [
- "base64 0.22.0",
- "chrono",
- "hex",
- "indexmap 1.9.3",
- "indexmap 2.2.6",
- "serde",
- "serde_derive",
- "serde_json",
- "serde_with_macros 3.8.1",
- "time",
-]
-
-[[package]]
 name = "serde_with_macros"
 version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10031,18 +10015,6 @@ name = "serde_with_macros"
 version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "881b6f881b17d13214e5d494c939ebab463d01264ce1811e9d4ac3a882e7695f"
-dependencies = [
- "darling 0.20.3",
- "proc-macro2 1.0.85",
- "quote 1.0.35",
- "syn 2.0.66",
-]
-
-[[package]]
-name = "serde_with_macros"
-version = "3.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65569b702f41443e8bc8bbb1c5779bd0450bbe723b56198980e80ec45780bce2"
 dependencies = [
  "darling 0.20.3",
  "proc-macro2 1.0.85",
@@ -11217,6 +11189,7 @@ checksum = "9cf6b47b3771c49ac75ad09a6162f53ad4b8088b76ac60e8ec1455b31a189fe1"
 dependencies = [
  "bytes",
  "futures-core",
+ "futures-io",
  "futures-sink",
  "futures-util",
  "hashbrown 0.14.5",
@@ -11440,7 +11413,7 @@ dependencies = [
  "crossbeam-channel",
  "thiserror",
  "time",
- "tracing-subscriber",
+ "tracing-subscriber 0.3.18",
 ]
 
 [[package]]
@@ -11472,7 +11445,18 @@ checksum = "0bae117ee14789185e129aaee5d93750abe67fdc5a9a62650452bfe4e122a3a9"
 dependencies = [
  "lazy_static",
  "tracing",
- "tracing-subscriber",
+ "tracing-subscriber 0.3.18",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f751112709b4e791d8ce53e32c4ed2d353565a795ce84da2285393f41557bdf2"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
 ]
 
 [[package]]
@@ -11496,7 +11480,7 @@ dependencies = [
  "opentelemetry 0.18.0",
  "tracing",
  "tracing-core",
- "tracing-subscriber",
+ "tracing-subscriber 0.3.18",
 ]
 
 [[package]]
@@ -11512,8 +11496,8 @@ dependencies = [
  "smallvec",
  "tracing",
  "tracing-core",
- "tracing-log",
- "tracing-subscriber",
+ "tracing-log 0.2.0",
+ "tracing-subscriber 0.3.18",
  "web-time",
 ]
 
@@ -11540,11 +11524,33 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
+version = "0.2.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e0d2eaa99c3c2e41547cfa109e910a68ea03823cccad4a0525dcbc9b01e8c71"
+dependencies = [
+ "ansi_term",
+ "chrono",
+ "lazy_static",
+ "matchers 0.0.1",
+ "regex",
+ "serde",
+ "serde_json",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log 0.1.4",
+ "tracing-serde",
+]
+
+[[package]]
+name = "tracing-subscriber"
 version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
 dependencies = [
- "matchers",
+ "matchers 0.1.0",
  "nu-ansi-term",
  "once_cell",
  "regex",
@@ -11555,7 +11561,7 @@ dependencies = [
  "thread_local",
  "tracing",
  "tracing-core",
- "tracing-log",
+ "tracing-log 0.2.0",
  "tracing-serde",
 ]
 
@@ -11670,7 +11676,7 @@ dependencies = [
  "tokio-test",
  "tokio-util",
  "tracing",
- "tracing-subscriber",
+ "tracing-subscriber 0.3.18",
 ]
 
 [[package]]

--- a/Cargo.Bazel.toml.lock
+++ b/Cargo.Bazel.toml.lock
@@ -4834,7 +4834,7 @@ dependencies = [
 [[package]]
 name = "ic-agent-with-discovery"
 version = "0.36.0"
-source = "git+https://github.com/dfinity/agent-rs?rev=05a7baa2514c9d1e6adcc35a45a9236228ad606e#05a7baa2514c9d1e6adcc35a45a9236228ad606e"
+source = "git+https://github.com/nikolay-komarevskiy/agent-rs?rev=fe39797feacadc9de64e6a8eee33a9355329c694#fe39797feacadc9de64e6a8eee33a9355329c694"
 dependencies = [
  "arc-swap",
  "async-lock 3.3.0",
@@ -5200,7 +5200,7 @@ dependencies = [
 [[package]]
 name = "ic-transport-types"
 version = "0.36.0"
-source = "git+https://github.com/dfinity/agent-rs?rev=05a7baa2514c9d1e6adcc35a45a9236228ad606e#05a7baa2514c9d1e6adcc35a45a9236228ad606e"
+source = "git+https://github.com/nikolay-komarevskiy/agent-rs?rev=fe39797feacadc9de64e6a8eee33a9355329c694#fe39797feacadc9de64e6a8eee33a9355329c694"
 dependencies = [
  "candid",
  "hex",

--- a/Cargo.Bazel.toml.lock
+++ b/Cargo.Bazel.toml.lock
@@ -2995,8 +2995,8 @@ dependencies = [
  "hyper-socks2",
  "hyper-util",
  "hyperlocal-next",
- "ic-agent 0.35.0",
- "ic-agent 0.36.0",
+ "ic-agent",
+ "ic-agent-with-discovery",
  "ic-btc-interface",
  "ic-btc-test-utils",
  "ic-btc-validation",
@@ -4832,9 +4832,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "ic-agent"
+name = "ic-agent-with-discovery"
 version = "0.36.0"
-source = "git+https://github.com/dfinity/agent-rs?rev=1c93d1c683b2207af9b62b4f517c036b563f3af0#1c93d1c683b2207af9b62b4f517c036b563f3af0"
+source = "git+https://github.com/dfinity/agent-rs?rev=05a7baa2514c9d1e6adcc35a45a9236228ad606e#05a7baa2514c9d1e6adcc35a45a9236228ad606e"
 dependencies = [
  "arc-swap",
  "async-lock 3.3.0",
@@ -5200,7 +5200,7 @@ dependencies = [
 [[package]]
 name = "ic-transport-types"
 version = "0.36.0"
-source = "git+https://github.com/dfinity/agent-rs?rev=1c93d1c683b2207af9b62b4f517c036b563f3af0#1c93d1c683b2207af9b62b4f517c036b563f3af0"
+source = "git+https://github.com/dfinity/agent-rs?rev=05a7baa2514c9d1e6adcc35a45a9236228ad606e#05a7baa2514c9d1e6adcc35a45a9236228ad606e"
 dependencies = [
  "candid",
  "hex",
@@ -5222,7 +5222,7 @@ dependencies = [
  "async-trait",
  "candid",
  "futures-util",
- "ic-agent 0.35.0",
+ "ic-agent",
  "once_cell",
  "semver",
  "serde",

--- a/bazel/external_crates.bzl
+++ b/bazel/external_crates.bzl
@@ -19,7 +19,7 @@ def sanitize_external_crates(sanitizers_enabled):
     }
 
 IC_AGENT_CALL_V3_REV = "9e45b314fc7496d48065590fac90790e0bdc6eed"
-IC_AGENT_DISCOVERY_REV = "05a7baa2514c9d1e6adcc35a45a9236228ad606e"
+IC_AGENT_DISCOVERY_REV = "fe39797feacadc9de64e6a8eee33a9355329c694"
 
 ICRC_1_REV = "26a80d777e079644cd69e883e18dad1a201f5b1a"
 
@@ -572,7 +572,7 @@ def external_crates_repository(name, cargo_lockfile, lockfile, sanitizers_enable
             ),
             "ic-agent-with-discovery": crate.spec(
                 package = "ic-agent-with-discovery",
-                git = "https://github.com/dfinity/agent-rs",
+                git = "https://github.com/nikolay-komarevskiy/agent-rs",
                 rev = IC_AGENT_DISCOVERY_REV,
                 features = [
                     "hyper",

--- a/bazel/external_crates.bzl
+++ b/bazel/external_crates.bzl
@@ -19,7 +19,7 @@ def sanitize_external_crates(sanitizers_enabled):
     }
 
 IC_AGENT_CALL_V3_REV = "9e45b314fc7496d48065590fac90790e0bdc6eed"
-IC_AGENT_DISCOVERY_REV = "1c93d1c683b2207af9b62b4f517c036b563f3af0"
+IC_AGENT_DISCOVERY_REV = "05a7baa2514c9d1e6adcc35a45a9236228ad606e"
 
 ICRC_1_REV = "26a80d777e079644cd69e883e18dad1a201f5b1a"
 
@@ -570,8 +570,8 @@ def external_crates_repository(name, cargo_lockfile, lockfile, sanitizers_enable
                     "pem",
                 ],
             ),
-            "ic-agent-discovery": crate.spec(
-                package = "ic-agent",
+            "ic-agent-with-discovery": crate.spec(
+                package = "ic-agent-with-discovery",
                 git = "https://github.com/dfinity/agent-rs",
                 rev = IC_AGENT_DISCOVERY_REV,
                 features = [

--- a/bazel/external_crates.bzl
+++ b/bazel/external_crates.bzl
@@ -19,6 +19,7 @@ def sanitize_external_crates(sanitizers_enabled):
     }
 
 IC_AGENT_CALL_V3_REV = "9e45b314fc7496d48065590fac90790e0bdc6eed"
+IC_AGENT_DISCOVERY_REV = "1c93d1c683b2207af9b62b4f517c036b563f3af0"
 
 ICRC_1_REV = "26a80d777e079644cd69e883e18dad1a201f5b1a"
 
@@ -569,12 +570,15 @@ def external_crates_repository(name, cargo_lockfile, lockfile, sanitizers_enable
                     "pem",
                 ],
             ),
-            # TODO: [NET-1734] Delete this once the feature is merged to master.
-            "ic-agent-call-v3": crate.spec(
+            "ic-agent-discovery": crate.spec(
                 package = "ic-agent",
                 git = "https://github.com/dfinity/agent-rs",
-                rev = IC_AGENT_CALL_V3_REV,
-                features = ["sync_call"],
+                rev = IC_AGENT_DISCOVERY_REV,
+                features = [
+                    "hyper",
+                    "reqwest",
+                    "pem",
+                ],
             ),
             "ic-btc-interface": crate.spec(
                 version = "^0.2.0",

--- a/rs/tests/boundary_nodes/BUILD.bazel
+++ b/rs/tests/boundary_nodes/BUILD.bazel
@@ -154,11 +154,14 @@ system_test(
 system_test(
     name = "api_boundary_node_decentralization_test",
     flaky = True,
+    aliases = {
+        "@crate_index//:ic_agent_discovery": "ic_agent_discovery",
+    },
     proc_macro_deps = MACRO_DEPENDENCIES,
     tags = [
         "k8s",
     ],
     target_compatible_with = ["@platforms//os:linux"],  # requires libssh that does not build on Mac OS
     runtime_deps = BOUNDARY_NODE_GUESTOS_RUNTIME_DEPS + GUESTOS_RUNTIME_DEPS + NNS_CANISTER_RUNTIME_DEPS + GRAFANA_RUNTIME_DEPS,
-    deps = DEPENDENCIES + ["//rs/tests"],
+    deps = DEPENDENCIES + ["@crate_index//:ic_agent_discovery"] + ["//rs/tests"],
 )

--- a/rs/tests/boundary_nodes/BUILD.bazel
+++ b/rs/tests/boundary_nodes/BUILD.bazel
@@ -154,14 +154,11 @@ system_test(
 system_test(
     name = "api_boundary_node_decentralization_test",
     flaky = True,
-    aliases = {
-        "@crate_index//:ic_agent_discovery": "ic_agent_discovery",
-    },
     proc_macro_deps = MACRO_DEPENDENCIES,
     tags = [
         "k8s",
     ],
     target_compatible_with = ["@platforms//os:linux"],  # requires libssh that does not build on Mac OS
     runtime_deps = BOUNDARY_NODE_GUESTOS_RUNTIME_DEPS + GUESTOS_RUNTIME_DEPS + NNS_CANISTER_RUNTIME_DEPS + GRAFANA_RUNTIME_DEPS,
-    deps = DEPENDENCIES + ["@crate_index//:ic_agent_discovery"] + ["//rs/tests"],
+    deps = DEPENDENCIES + ["//rs/tests"],
 )

--- a/rs/tests/common.bzl
+++ b/rs/tests/common.bzl
@@ -124,6 +124,7 @@ DEPENDENCIES = [
     "@crate_index//:http_0_2_12",
     "@crate_index//:humantime",
     "@crate_index//:ic-agent",
+    "@crate_index//:ic-agent-with-discovery",
     "@crate_index//:ic-btc-interface",
     "@crate_index//:ic-cdk",
     "@crate_index//:ic-utils",

--- a/rs/tests/src/boundary_nodes/api_boundary_nodes_integration.rs
+++ b/rs/tests/src/boundary_nodes/api_boundary_nodes_integration.rs
@@ -89,6 +89,7 @@ pub fn decentralization_test(env: TestEnv) {
 }
 
 async fn test(env: TestEnv) {
+    use ic_agent_discovery;
     let log = env.logger();
     let nns_node = env.get_first_healthy_nns_node_snapshot();
     let unassigned_nodes: Vec<_> = env.topology_snapshot().unassigned_nodes().collect();

--- a/rs/tests/src/boundary_nodes/api_boundary_nodes_integration.rs
+++ b/rs/tests/src/boundary_nodes/api_boundary_nodes_integration.rs
@@ -1,11 +1,3 @@
-use discower_bowndary::{
-    check::{HealthCheck, HealthCheckImpl},
-    fetch::{NodesFetcher, NodesFetcherImpl},
-    node::Node,
-    route_provider::HealthCheckRouteProvider,
-    snapshot_health_based::HealthBasedSnapshot,
-    transport::{TransportProvider, TransportProviderImpl},
-};
 use ic_base_types::NodeId;
 use k256::SecretKey;
 use std::{collections::HashSet, time::Instant};
@@ -13,9 +5,7 @@ use tokio::time::sleep;
 
 use crate::boundary_nodes::{
     constants::{BOUNDARY_NODE_NAME, COUNTER_CANISTER_WAT},
-    helpers::{
-        install_canisters, read_counters_on_counter_canisters, set_counters_on_counter_canisters,
-    },
+    helpers::install_canisters,
     setup::TEST_PRIVATE_KEY,
 };
 use candid::{Decode, Encode};
@@ -46,9 +36,14 @@ use registry_canister::mutations::{
 use std::{net::SocketAddr, sync::Arc, time::Duration};
 
 use anyhow::bail;
-use ic_agent::{
+use ic_agent_with_discovery::{
     agent::{
         http_transport::{
+            dynamic_routing::{
+                dynamic_route_provider::DynamicRouteProviderBuilder, health_check::HealthChecker,
+                node::Node, nodes_fetch::NodesFetcher,
+                snapshot::round_robin_routing::RoundRobinRoutingSnapshot,
+            },
             reqwest_transport::reqwest::{redirect::Policy, Client, ClientBuilder},
             route_provider::RouteProvider,
             ReqwestTransport,
@@ -89,7 +84,6 @@ pub fn decentralization_test(env: TestEnv) {
 }
 
 async fn test(env: TestEnv) {
-    use ic_agent_with_discovery;
     let log = env.logger();
     let nns_node = env.get_first_healthy_nns_node_snapshot();
     let unassigned_nodes: Vec<_> = env.topology_snapshot().unassigned_nodes().collect();
@@ -97,7 +91,19 @@ async fn test(env: TestEnv) {
 
     // Identity is needed to execute `update_node_domain_directly` as the caller is checked.
     let agent_with_identity = {
-        let mut agent = nns_node.build_default_agent_async().await;
+        // let addr = nns_node.get_public_addr();
+        let url = nns_node.get_public_url();
+        let client = Client::builder()
+            .danger_accept_invalid_certs(true)
+            // .resolve(addr, url)
+            .build()
+            .expect("Could not create HTTP client.");
+        let transport = ReqwestTransport::create_with_client(url, client).unwrap();
+        let mut agent = Agent::builder().with_transport(transport).build().unwrap();
+        agent
+            .fetch_root_key()
+            .await
+            .expect("Failed to fetch root key");
         let identity = Secp256k1Identity::from_private_key(
             SecretKey::from_sec1_pem(TEST_PRIVATE_KEY).unwrap(),
         );
@@ -209,27 +215,26 @@ async fn test(env: TestEnv) {
             .next()
             .unwrap()
             .subnet_id
-            .get();
-        let api_bn_fetch_interval = Duration::from_secs(5);
-        let transport_provider =
-            Arc::new(TransportProviderImpl::new(http_client.clone())) as Arc<dyn TransportProvider>;
-        let fetcher = Arc::new(NodesFetcherImpl::new(transport_provider, subnet_id.into()));
+            .get()
+            .0;
+        // let fetcher = Arc::new(NodesFetcherImpl::new(transport_provider, subnet_id.into()));
         let health_timeout = Duration::from_secs(5);
         let check_interval = Duration::from_secs(1);
-        let checker = Arc::new(HealthCheckImpl::new(http_client.clone(), health_timeout));
-        let seed_nodes = vec![Node::new("api1.com"), Node::new("api2.com")];
-        let snapshot = HealthBasedSnapshot::new();
-        let route_provider = Arc::new(HealthCheckRouteProvider::new(
-            snapshot,
-            Arc::clone(&fetcher) as Arc<dyn NodesFetcher>,
-            api_bn_fetch_interval,
-            Arc::clone(&checker) as Arc<dyn HealthCheck>,
-            check_interval,
-            seed_nodes,
-        ));
-
-        route_provider.run().await;
-
+        let seed_nodes = vec![
+            Node::new("api1.com").unwrap(),
+            Node::new("api2.com").unwrap(),
+        ];
+        let snapshot = RoundRobinRoutingSnapshot::new();
+        let route_provider =
+            DynamicRouteProviderBuilder::new(snapshot, seed_nodes, http_client.clone())
+                .with_checker(Arc::new(HealthChecker::new(
+                    http_client.clone(),
+                    Duration::from_secs(5),
+                )))
+                .with_fetcher(Arc::new(NodesFetcher::new(http_client.clone(), subnet_id)))
+                .build()
+                .await;
+        let route_provider = Arc::new(route_provider) as Arc<dyn RouteProvider>;
         info!(
             log,
             "Assert: HealthCheckRouteProvider has discovered API BNs {:?} and routes calls correctly", &all_api_domains[..2]
@@ -237,7 +242,7 @@ async fn test(env: TestEnv) {
 
         assert_routing_via_domains(
             &log,
-            Arc::clone(&route_provider) as Arc<dyn RouteProvider>,
+            Arc::clone(&route_provider),
             all_api_domains[..2].to_vec(),
             API_BN_DISCOVERY_TIMEOUT,
             ROUTE_CALL_INTERVAL,
@@ -251,7 +256,7 @@ async fn test(env: TestEnv) {
         // This agent routes directly via ipv6 addresses and doesn't employ domain names.
         // Ideally, domains with valid certificates should be used in testing.
         let transport = ReqwestTransport::create_with_client_route(
-            Arc::clone(&route_provider) as Arc<dyn RouteProvider>,
+            Arc::clone(&route_provider),
             http_client.clone(),
         )
         .unwrap();
@@ -440,10 +445,6 @@ async fn test(env: TestEnv) {
     .await;
 
     assert_eq!(counters, vec![2, 6]);
-
-    info!(log, "Gracefully stopping HealthCheckRouteProvider");
-
-    route_provider.stop().await;
 }
 
 pub fn read_state_via_subnet_path_test(env: TestEnv) {
@@ -691,4 +692,110 @@ async fn assert_routing_via_domains(
         sleep(route_call_interval).await;
     }
     panic!("Expected routes {expected_domains:?} were not observed over {route_calls} consecutive routing calls");
+}
+
+pub async fn set_counters_on_counter_canisters(
+    log: &slog::Logger,
+    agent: Agent,
+    canisters: Vec<Principal>,
+    counter_values: Vec<u32>,
+    backoff: Duration,
+    retry_timeout: Duration,
+) {
+    let mut requests_all = vec![];
+    // Dispatch all write calls sequentially. As there is no polling, each call should return very fast.
+    for (idx, canister_id) in canisters.into_iter().enumerate() {
+        let mut requests = vec![];
+        let calls_count = counter_values[idx];
+        for _ in 0..calls_count {
+            let request_id = ic_system_test_driver::retry_with_msg_async!(
+                format!("write call on canister={canister_id}"),
+                log,
+                retry_timeout,
+                backoff,
+                || async {
+                    let result = agent.update(&canister_id, "write").call().await;
+                    if let Ok(id) = result {
+                        Ok(id)
+                    } else {
+                        bail!(
+                            "write call on canister={canister_id} failed, err: {:?}",
+                            result.unwrap_err()
+                        )
+                    }
+                }
+            )
+            .await
+            .expect("write call on canister={canister_id} failed");
+
+            requests.push((canister_id, request_id));
+        }
+        requests_all.push(requests);
+    }
+
+    // Poll all results sequentially.
+    // Overall polling duration should be roughly equal to a single polling duration. As all requests were submitted at nearly same time.
+    for (canister_id, request_id) in requests_all.into_iter().flatten() {
+        ic_system_test_driver::retry_with_msg_async!(
+            format!("call wait on canister={canister_id}"),
+            log,
+            retry_timeout,
+            backoff,
+            || async {
+                let result = agent.wait(request_id, canister_id).await;
+                if result.is_ok() {
+                    Ok(())
+                } else {
+                    bail!(
+                        "wait call on canister={canister_id} failed, err: {:?}",
+                        result.unwrap_err()
+                    )
+                }
+            }
+        )
+        .await
+        .expect("wait call on canister={canister_id} failed");
+    }
+}
+
+pub async fn read_counters_on_counter_canisters(
+    log: &slog::Logger,
+    agent: Agent,
+    canisters: Vec<Principal>,
+    backoff: Duration,
+    retry_timeout: Duration,
+) -> Vec<u32> {
+    // Perform query read calls on canisters sequentially.
+    let mut results = vec![];
+    for canister_id in canisters {
+        let read_result = ic_system_test_driver::retry_with_msg_async!(
+            format!("call read on canister={canister_id}"),
+            log,
+            retry_timeout,
+            backoff,
+            || async {
+                let read_result = agent.query(&canister_id, "read").call().await;
+                if let Ok(bytes) = read_result {
+                    Ok(bytes)
+                } else {
+                    bail!(
+                        "read call on canister={canister_id} failed, err: {:?}",
+                        read_result.unwrap_err()
+                    )
+                }
+            }
+        )
+        .await
+        .expect("read call on canister={canister_id} failed after {max_attempts} attempts");
+
+        let counter = u32::from_le_bytes(
+            read_result
+                .as_slice()
+                .try_into()
+                .expect("slice with incorrect length"),
+        );
+
+        results.push(counter)
+    }
+    results
 }

--- a/rs/tests/src/boundary_nodes/api_boundary_nodes_integration.rs
+++ b/rs/tests/src/boundary_nodes/api_boundary_nodes_integration.rs
@@ -89,7 +89,7 @@ pub fn decentralization_test(env: TestEnv) {
 }
 
 async fn test(env: TestEnv) {
-    use ic_agent_discovery;
+    use ic_agent_with_discovery;
     let log = env.logger();
     let nns_node = env.get_first_healthy_nns_node_snapshot();
     let unassigned_nodes: Vec<_> = env.topology_snapshot().unassigned_nodes().collect();

--- a/rs/tests/src/boundary_nodes/api_boundary_nodes_integration.rs
+++ b/rs/tests/src/boundary_nodes/api_boundary_nodes_integration.rs
@@ -217,9 +217,6 @@ async fn test(env: TestEnv) {
             .subnet_id
             .get()
             .0;
-        // let fetcher = Arc::new(NodesFetcherImpl::new(transport_provider, subnet_id.into()));
-        let health_timeout = Duration::from_secs(5);
-        let check_interval = Duration::from_secs(1);
         let seed_nodes = vec![
             Node::new("api1.com").unwrap(),
             Node::new("api2.com").unwrap(),


### PR DESCRIPTION
This PR is for checking that the new `ic-agent` with [dynamic routing](https://github.com/dfinity/agent-rs/pull/568) can be smoothly integrated into the [api_boundary_node_decentralization_test](https://sourcegraph.com/github.com/dfinity/ic/-/blob/rs/tests/boundary_nodes/BUILD.bazel?L155). Run of the [CI job](https://dash.zh1-idx1.dfinity.network/invocation/3d9862ab-04c2-431e-b189-3dd506a2bc4f?target=%2F%2Frs%2Ftests%2Fboundary_nodes%3Aapi_boundary_node_decentralization_test&targetStatus=5) indicates that it does:
```
//rs/tests/boundary_nodes:api_boundary_node_decentralization_test        PASSED in 250.0s
```

