### PR TITLE
feat(nns): Added setting neuron visibility.

### DIFF
--- a/rs/nns/governance/api/src/ic_nns_governance.pb.v1.rs
+++ b/rs/nns/governance/api/src/ic_nns_governance.pb.v1.rs
@@ -752,6 +752,13 @@ pub mod manage_neuron {
         #[prost(bool, tag = "1")]
         pub requested_setting_for_auto_stake_maturity: bool,
     }
+    #[derive(candid::CandidType, candid::Deserialize, serde::Serialize, comparable::Comparable)]
+    #[allow(clippy::derive_partial_eq_without_eq)]
+    #[derive(Clone, PartialEq, ::prost::Message)]
+    pub struct SetVisibility {
+        #[prost(enumeration = "super::Visibility", optional, tag = "1")]
+        pub visibility: ::core::option::Option<i32>,
+    }
     /// Commands that only configure a given neuron, but do not interact
     /// with the outside world. They all require the caller to be the
     /// controller of the neuron.
@@ -759,7 +766,7 @@ pub mod manage_neuron {
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct Configure {
-        #[prost(oneof = "configure::Operation", tags = "1, 2, 3, 4, 5, 6, 7, 8, 9")]
+        #[prost(oneof = "configure::Operation", tags = "1, 2, 3, 4, 5, 6, 7, 8, 9, 10")]
         pub operation: ::core::option::Option<configure::Operation>,
     }
     /// Nested message and enum types in `Configure`.
@@ -788,6 +795,8 @@ pub mod manage_neuron {
             LeaveCommunityFund(super::LeaveCommunityFund),
             #[prost(message, tag = "9")]
             ChangeAutoStakeMaturity(super::ChangeAutoStakeMaturity),
+            #[prost(message, tag = "10")]
+            SetVisibility(super::SetVisibility),
         }
     }
     /// Disburse this neuron's stake: transfer the staked ICP to the

--- a/rs/nns/governance/canister/governance.did
+++ b/rs/nns/governance/canister/governance.did
@@ -499,6 +499,7 @@ type Operation = variant {
   StopDissolving : record {};
   StartDissolving : record {};
   IncreaseDissolveDelay : IncreaseDissolveDelay;
+  SetVisibility : SetVisibility;
   JoinCommunityFund : record {};
   LeaveCommunityFund : record {};
   SetDissolveTimestamp : SetDissolveTimestamp;
@@ -620,6 +621,7 @@ type SetSnsTokenSwapOpenTimeWindow = record {
   request : opt SetOpenTimeWindowRequest;
   swap_canister_id : opt principal;
 };
+type SetVisibility = record { visibility : opt int32 };
 type SettleCommunityFundParticipation = record {
   result : opt Result_8;
   open_sns_token_swap_proposal_id : opt nat64;

--- a/rs/nns/governance/canister/governance_test.did
+++ b/rs/nns/governance/canister/governance_test.did
@@ -499,6 +499,7 @@ type Operation = variant {
   StopDissolving : record {};
   StartDissolving : record {};
   IncreaseDissolveDelay : IncreaseDissolveDelay;
+  SetVisibility : SetVisibility;
   JoinCommunityFund : record {};
   LeaveCommunityFund : record {};
   SetDissolveTimestamp : SetDissolveTimestamp;
@@ -620,6 +621,7 @@ type SetSnsTokenSwapOpenTimeWindow = record {
   request : opt SetOpenTimeWindowRequest;
   swap_canister_id : opt principal;
 };
+type SetVisibility = record { visibility : opt int32 };
 type SettleCommunityFundParticipation = record {
   result : opt Result_8;
   open_sns_token_swap_proposal_id : opt nat64;

--- a/rs/nns/governance/proto/ic_nns_governance/pb/v1/governance.proto
+++ b/rs/nns/governance/proto/ic_nns_governance/pb/v1/governance.proto
@@ -943,6 +943,9 @@ message ManageNeuron {
   message ChangeAutoStakeMaturity {
     bool requested_setting_for_auto_stake_maturity = 1;
   }
+  message SetVisibility {
+    optional Visibility visibility = 1;
+  }
   // Commands that only configure a given neuron, but do not interact
   // with the outside world. They all require the caller to be the
   // controller of the neuron.
@@ -957,6 +960,7 @@ message ManageNeuron {
       JoinCommunityFund join_community_fund = 7;
       LeaveCommunityFund leave_community_fund = 8;
       ChangeAutoStakeMaturity change_auto_stake_maturity = 9;
+      SetVisibility set_visibility = 10;
     }
   }
   // Disburse this neuron's stake: transfer the staked ICP to the

--- a/rs/nns/governance/src/gen/ic_nns_governance.pb.v1.rs
+++ b/rs/nns/governance/src/gen/ic_nns_governance.pb.v1.rs
@@ -752,6 +752,13 @@ pub mod manage_neuron {
         #[prost(bool, tag = "1")]
         pub requested_setting_for_auto_stake_maturity: bool,
     }
+    #[derive(candid::CandidType, candid::Deserialize, serde::Serialize, comparable::Comparable)]
+    #[allow(clippy::derive_partial_eq_without_eq)]
+    #[derive(Clone, PartialEq, ::prost::Message)]
+    pub struct SetVisibility {
+        #[prost(enumeration = "super::Visibility", optional, tag = "1")]
+        pub visibility: ::core::option::Option<i32>,
+    }
     /// Commands that only configure a given neuron, but do not interact
     /// with the outside world. They all require the caller to be the
     /// controller of the neuron.
@@ -759,7 +766,7 @@ pub mod manage_neuron {
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct Configure {
-        #[prost(oneof = "configure::Operation", tags = "1, 2, 3, 4, 5, 6, 7, 8, 9")]
+        #[prost(oneof = "configure::Operation", tags = "1, 2, 3, 4, 5, 6, 7, 8, 9, 10")]
         pub operation: ::core::option::Option<configure::Operation>,
     }
     /// Nested message and enum types in `Configure`.
@@ -788,6 +795,8 @@ pub mod manage_neuron {
             LeaveCommunityFund(super::LeaveCommunityFund),
             #[prost(message, tag = "9")]
             ChangeAutoStakeMaturity(super::ChangeAutoStakeMaturity),
+            #[prost(message, tag = "10")]
+            SetVisibility(super::SetVisibility),
         }
     }
     /// Disburse this neuron's stake: transfer the staked ICP to the

--- a/rs/nns/governance/src/pb/conversions.rs
+++ b/rs/nns/governance/src/pb/conversions.rs
@@ -810,6 +810,21 @@ impl From<pb_api::manage_neuron::ChangeAutoStakeMaturity>
     }
 }
 
+impl From<pb::manage_neuron::SetVisibility> for pb_api::manage_neuron::SetVisibility {
+    fn from(item: pb::manage_neuron::SetVisibility) -> Self {
+        Self {
+            visibility: item.visibility,
+        }
+    }
+}
+impl From<pb_api::manage_neuron::SetVisibility> for pb::manage_neuron::SetVisibility {
+    fn from(item: pb_api::manage_neuron::SetVisibility) -> Self {
+        Self {
+            visibility: item.visibility,
+        }
+    }
+}
+
 impl From<pb::manage_neuron::Configure> for pb_api::manage_neuron::Configure {
     fn from(item: pb::manage_neuron::Configure) -> Self {
         Self {
@@ -855,6 +870,9 @@ impl From<pb::manage_neuron::configure::Operation> for pb_api::manage_neuron::co
             pb::manage_neuron::configure::Operation::ChangeAutoStakeMaturity(v) => {
                 pb_api::manage_neuron::configure::Operation::ChangeAutoStakeMaturity(v.into())
             }
+            pb::manage_neuron::configure::Operation::SetVisibility(v) => {
+                pb_api::manage_neuron::configure::Operation::SetVisibility(v.into())
+            }
         }
     }
 }
@@ -887,6 +905,9 @@ impl From<pb_api::manage_neuron::configure::Operation> for pb::manage_neuron::co
             }
             pb_api::manage_neuron::configure::Operation::ChangeAutoStakeMaturity(v) => {
                 pb::manage_neuron::configure::Operation::ChangeAutoStakeMaturity(v.into())
+            }
+            pb_api::manage_neuron::configure::Operation::SetVisibility(v) => {
+                pb::manage_neuron::configure::Operation::SetVisibility(v.into())
             }
         }
     }

--- a/rs/nns/governance/src/pb/convert_struct_to_enum.rs
+++ b/rs/nns/governance/src/pb/convert_struct_to_enum.rs
@@ -1,0 +1,13 @@
+//! This (sub)*module contains lots of implementations of conversions that
+//! "upgrade" a struct into an enum. For example,
+//!
+//!     impl From<SetVisibility> for Operation {
+//!         fn from(src: SetVisibility) -> Operation {
+//!             Operation::SetVisibility(src)
+//!         }
+//!     }
+//!
+//! (Almost all of the code in this (sub)*module is completely mechanical.
+//! Perhaps, with the right Prost incantation, this can be automated away.)
+
+mod manage_neuron;

--- a/rs/nns/governance/src/pb/convert_struct_to_enum/manage_neuron.rs
+++ b/rs/nns/governance/src/pb/convert_struct_to_enum/manage_neuron.rs
@@ -1,0 +1,84 @@
+use crate::pb::v1::{
+    manage_neuron::{
+        ClaimOrRefresh, Command, Configure, Disburse, DisburseToNeuron, Follow, Merge,
+        MergeMaturity, RegisterVote, Spawn, Split, StakeMaturity,
+    },
+    Proposal,
+};
+
+mod configure;
+
+/// This is a special snowflake! Instead of converting from MakeProposal, we
+/// convert from Proposal. Also, box is used for some reason...
+/// (Special snowflakes are evil! Ad hoc bad. Uniform good.)
+impl From<Proposal> for Command {
+    fn from(src: Proposal) -> Command {
+        Command::MakeProposal(Box::new(src))
+    }
+}
+
+impl From<Configure> for Command {
+    fn from(src: Configure) -> Command {
+        Command::Configure(src)
+    }
+}
+
+impl From<Disburse> for Command {
+    fn from(src: Disburse) -> Command {
+        Command::Disburse(src)
+    }
+}
+
+impl From<Spawn> for Command {
+    fn from(src: Spawn) -> Command {
+        Command::Spawn(src)
+    }
+}
+
+impl From<Follow> for Command {
+    fn from(src: Follow) -> Command {
+        Command::Follow(src)
+    }
+}
+
+impl From<RegisterVote> for Command {
+    fn from(src: RegisterVote) -> Command {
+        Command::RegisterVote(src)
+    }
+}
+
+impl From<Split> for Command {
+    fn from(src: Split) -> Command {
+        Command::Split(src)
+    }
+}
+
+impl From<DisburseToNeuron> for Command {
+    fn from(src: DisburseToNeuron) -> Command {
+        Command::DisburseToNeuron(src)
+    }
+}
+
+impl From<ClaimOrRefresh> for Command {
+    fn from(src: ClaimOrRefresh) -> Command {
+        Command::ClaimOrRefresh(src)
+    }
+}
+
+impl From<MergeMaturity> for Command {
+    fn from(src: MergeMaturity) -> Command {
+        Command::MergeMaturity(src)
+    }
+}
+
+impl From<Merge> for Command {
+    fn from(src: Merge) -> Command {
+        Command::Merge(src)
+    }
+}
+
+impl From<StakeMaturity> for Command {
+    fn from(src: StakeMaturity) -> Command {
+        Command::StakeMaturity(src)
+    }
+}

--- a/rs/nns/governance/src/pb/convert_struct_to_enum/manage_neuron/configure.rs
+++ b/rs/nns/governance/src/pb/convert_struct_to_enum/manage_neuron/configure.rs
@@ -1,0 +1,65 @@
+use crate::pb::v1::manage_neuron::{
+    configure::Operation, AddHotKey, ChangeAutoStakeMaturity, IncreaseDissolveDelay,
+    JoinCommunityFund, LeaveCommunityFund, RemoveHotKey, SetDissolveTimestamp, SetVisibility,
+    StartDissolving, StopDissolving,
+};
+
+impl From<IncreaseDissolveDelay> for Operation {
+    fn from(src: IncreaseDissolveDelay) -> Operation {
+        Operation::IncreaseDissolveDelay(src)
+    }
+}
+
+impl From<StartDissolving> for Operation {
+    fn from(src: StartDissolving) -> Operation {
+        Operation::StartDissolving(src)
+    }
+}
+
+impl From<StopDissolving> for Operation {
+    fn from(src: StopDissolving) -> Operation {
+        Operation::StopDissolving(src)
+    }
+}
+
+impl From<AddHotKey> for Operation {
+    fn from(src: AddHotKey) -> Operation {
+        Operation::AddHotKey(src)
+    }
+}
+
+impl From<RemoveHotKey> for Operation {
+    fn from(src: RemoveHotKey) -> Operation {
+        Operation::RemoveHotKey(src)
+    }
+}
+
+impl From<SetDissolveTimestamp> for Operation {
+    fn from(src: SetDissolveTimestamp) -> Operation {
+        Operation::SetDissolveTimestamp(src)
+    }
+}
+
+impl From<JoinCommunityFund> for Operation {
+    fn from(src: JoinCommunityFund) -> Operation {
+        Operation::JoinCommunityFund(src)
+    }
+}
+
+impl From<LeaveCommunityFund> for Operation {
+    fn from(src: LeaveCommunityFund) -> Operation {
+        Operation::LeaveCommunityFund(src)
+    }
+}
+
+impl From<ChangeAutoStakeMaturity> for Operation {
+    fn from(src: ChangeAutoStakeMaturity) -> Operation {
+        Operation::ChangeAutoStakeMaturity(src)
+    }
+}
+
+impl From<SetVisibility> for Operation {
+    fn from(src: SetVisibility) -> Operation {
+        Operation::SetVisibility(src)
+    }
+}

--- a/rs/nns/governance/src/pb/mod.rs
+++ b/rs/nns/governance/src/pb/mod.rs
@@ -3,3 +3,4 @@
 pub mod v1;
 
 mod conversions;
+mod convert_struct_to_enum;


### PR DESCRIPTION
Setting the visibility of known neurons is not allowed, [per the plan](https://forum.dfinity.org/t/request-for-comments-api-changes-for-public-private-neurons/33360#known-neurons-are-always-public-6).

As described [here](https://forum.dfinity.org/t/request-for-comments-api-changes-for-public-private-neurons/33360#reading-and-writing-visibility-4).

**Entrained change**: Added implementations of Command::from(struct) and Operation::from(struct). If desired, this could be split off pretty easily into another PR, because these changes are in their own commit (thanks to git rebase -i).

Closes [NNS1-3073](https://dfinity.atlassian.net/browse/NNS1-3073).
Closes [NNS1-3082](https://dfinity.atlassian.net/browse/NNS1-3082).

[<< Previous PR](https://github.com/dfinity/ic/pull/488)

[NNS1-3073]: https://dfinity.atlassian.net/browse/NNS1-3073?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[NNS1-3082]: https://dfinity.atlassian.net/browse/NNS1-3082?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ