### PR TITLE
chore(ICP/ICRC-ledger): FI-1404: return value in BalanceStrore.get_balance

### DIFF
--- a/rs/rosetta-api/ledger_canister_blocks_synchronizer/src/balance_book.rs
+++ b/rs/rosetta-api/ledger_canister_blocks_synchronizer/src/balance_book.rs
@@ -183,7 +183,7 @@ impl BalancesStore for ClientBalancesStore {
         self.acc_to_hist
             .get(k)
             .and_then(|hist| hist.get_last_ref())
-            .copied()
+            .cloned()
     }
 
     // In here, ledger removes zero amount accounts from it's map,

--- a/rs/rosetta-api/ledger_canister_blocks_synchronizer/src/balance_book.rs
+++ b/rs/rosetta-api/ledger_canister_blocks_synchronizer/src/balance_book.rs
@@ -179,8 +179,11 @@ impl BalancesStore for ClientBalancesStore {
     type AccountId = AccountIdentifier;
     type Tokens = Tokens;
 
-    fn get_balance(&self, k: &AccountIdentifier) -> Option<&Tokens> {
-        self.acc_to_hist.get(k).and_then(|hist| hist.get_last_ref())
+    fn get_balance(&self, k: &AccountIdentifier) -> Option<Tokens> {
+        self.acc_to_hist
+            .get(k)
+            .and_then(|hist| hist.get_last_ref())
+            .copied()
     }
 
     // In here, ledger removes zero amount accounts from it's map,

--- a/rs/rosetta-api/ledger_canister_blocks_synchronizer/tests/store_tests.rs
+++ b/rs/rosetta-api/ledger_canister_blocks_synchronizer/tests/store_tests.rs
@@ -165,13 +165,13 @@ async fn store_account_balances_test() {
         if let Some(acc_str) = from_account {
             let id = AccountIdentifier::from_hex(acc_str.as_str()).unwrap();
             let amount_from = store.get_account_balance(&id, &hb.index).unwrap();
-            let amount_local = *context.balance_book.store.get_balance(&id).unwrap();
+            let amount_local = context.balance_book.store.get_balance(&id).unwrap();
             assert_eq!(amount_from, amount_local);
         }
         if let Some(acc_str) = to_account {
             let id = AccountIdentifier::from_hex(acc_str.as_str()).unwrap();
             let amount_to = store.get_account_balance(&id, &hb.index).unwrap();
-            let amount_local = *context.balance_book.store.get_balance(&id).unwrap();
+            let amount_local = context.balance_book.store.get_balance(&id).unwrap();
             assert_eq!(amount_to, amount_local);
         }
     }

--- a/rs/rosetta-api/ledger_core/src/balances.rs
+++ b/rs/rosetta-api/ledger_core/src/balances.rs
@@ -9,7 +9,7 @@ pub trait BalancesStore {
     type Tokens;
 
     /// Returns the balance on the specified account.
-    fn get_balance(&self, k: &Self::AccountId) -> Option<&Self::Tokens>;
+    fn get_balance(&self, k: &Self::AccountId) -> Option<Self::Tokens>;
 
     /// Update balance for an account using function f.
     /// Its arg is previous balance or None if not found and
@@ -34,8 +34,8 @@ where
     type AccountId = AccountId;
     type Tokens = Tokens;
 
-    fn get_balance(&self, k: &Self::AccountId) -> Option<&Self::Tokens> {
-        self.get(k)
+    fn get_balance(&self, k: &Self::AccountId) -> Option<Self::Tokens> {
+        self.get(k).cloned()
     }
 
     fn update<F, E>(&mut self, k: AccountId, mut f: F) -> Result<Self::Tokens, E>
@@ -225,7 +225,6 @@ where
     pub fn account_balance(&self, account: &S::AccountId) -> S::Tokens {
         self.store
             .get_balance(account)
-            .cloned()
             .unwrap_or_else(S::Tokens::zero)
     }
 


### PR DESCRIPTION
This modification is needed for the stable structure migration. StableBTreeMap is only able to return elements by value: https://docs.rs/ic-stable-structures/0.6.5/ic_stable_structures/btreemap/struct.BTreeMap.html#method.get