### PR TITLE
chore: Code owners for state manager config

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -109,6 +109,7 @@ go_deps.bzl               @dfinity/idx
 /rs/config/                                             @dfinity/networking
 /rs/config/src/embedders.rs                             @dfinity/runtime
 /rs/config/src/execution_environment.rs                 @dfinity/execution @dfinity/runtime
+/rs/config/src/state_manager.rs                         @dfinity/ic-message-routing-owners
 /rs/config/src/subnet_config.rs                         @dfinity/execution @dfinity/runtime
 /rs/consensus/                                          @dfinity/consensus
 /rs/constants/                                          @dfinity/ic-interface-owners

--- a/.gitlab/CODEOWNERS
+++ b/.gitlab/CODEOWNERS
@@ -109,6 +109,7 @@ go_deps.bzl               @dfinity-lab/teams/idx
 /rs/config/                                             @dfinity-lab/teams/networking-team
 /rs/config/src/embedders.rs                             @dfinity-lab/teams/runtime-owners
 /rs/config/src/execution_environment.rs                 @dfinity-lab/teams/execution-owners @dfinity-lab/teams/runtime-owners
+/rs/config/src/state_manager.rs                         @dfinity-lab/teams/message-routing-owners
 /rs/config/src/subnet_config.rs                         @dfinity-lab/teams/execution-owners @dfinity-lab/teams/runtime-owners
 /rs/consensus/                                          @dfinity-lab/teams/consensus-owners
 /rs/constants/                                          @dfinity-lab/teams/interface-owners


### PR DESCRIPTION
This commit passes the code ownership of the state manager config file from networking to message routing.