### PR TITLE
test: stop uploading test canister artifacts 

### DIFF
--- a/publish/canisters/BUILD.bazel
+++ b/publish/canisters/BUILD.bazel
@@ -1,5 +1,4 @@
 load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
-load("//bazel:defs.bzl", "gzip_compress")
 load("//gitlab-ci/src/artifacts:upload.bzl", "upload_artifacts")
 load(
     "//rs/nervous_system:compressed_wasm_size_limits.bzl",
@@ -8,14 +7,11 @@ load(
 )
 
 CANISTERS = {
-    "candid-test-canister.wasm.gz": "//rs/rust_canisters/dfn_candid:candid-test-canister",
     "canister-creator-canister.wasm.gz": "//rs/rust_canisters/canister_creator:canister_creator_canister",
     "cycles-minting-canister.wasm.gz": "//rs/nns/cmc:cycles-minting-canister",
     "genesis-token-canister.wasm.gz": "//rs/nns/gtc:genesis-token-canister",
     "governance-canister.wasm.gz": "//rs/nns/governance:governance-canister",
     "governance-canister_test.wasm.gz": "//rs/nns/governance:governance-canister-test",
-    "governance-mem-test-canister.wasm.gz": "//rs/nns/integration_tests:governance-mem-test-canister",
-    "http_counter.wasm.gz": "//rs/tests/test_canisters/http_counter:http_counter",
     "ic-ckbtc-minter.wasm.gz": "//rs/bitcoin/ckbtc/minter:ckbtc_minter",
     "ic-ckbtc-minter_debug.wasm.gz": "//rs/bitcoin/ckbtc/minter:ckbtc_minter_debug",
     "ic-ckbtc-kyt.wasm.gz": "//rs/bitcoin/ckbtc/kyt:kyt_canister",
@@ -26,49 +22,24 @@ CANISTERS = {
     "ic-icrc1-index-ng-u256.wasm.gz": "//rs/rosetta-api/icrc1/index-ng:index_ng_canister_u256",
     "ic-icrc1-ledger.wasm.gz": "//rs/rosetta-api/icrc1/ledger:ledger_canister",
     "ic-icrc1-ledger-u256.wasm.gz": "//rs/rosetta-api/icrc1/ledger:ledger_canister_u256",
-    "ic-nervous-system-common-test-canister.wasm.gz": "//rs/nervous_system/common/test_canister:test_canister",
     "ic-icp-index-canister.wasm.gz": "//rs/rosetta-api/icp_ledger/index:ic-icp-index-canister",
     "identity-canister.wasm.gz": "//rs/nns/identity:identity-canister",
-    "inter_canister_error_handling.wasm.gz": "//rs/rust_canisters/tests:inter_canister_error_handling",
-    "kv_store.wasm.gz": "//rs/tests/test_canisters/kv_store:kv_store",
-    "json.wasm.gz": "//rs/rust_canisters/tests:json",
     "ledger-canister.wasm.gz": "//rs/rosetta-api/icp_ledger/ledger:ledger-canister-wasm",
     "ledger-canister_notify-method.wasm.gz": "//rs/rosetta-api/icp_ledger/ledger:ledger-canister-wasm-notify-method",
     "lifeline_canister.wasm.gz": "//rs/nns/handlers/lifeline/impl:lifeline_canister",
-    "mem-utils-test-canister.wasm.gz": "//rs/nns/integration_tests:mem-utils-test-canister",
-    "memory-test-canister.wasm.gz": "//rs/rust_canisters/memory_test:memory_test_canister",
-    "nan_canonicalized.wasm.gz": "//rs/rust_canisters/tests:nan_canonicalized",
     "nns-ui-canister.wasm.gz": "//rs/nns/nns-ui:nns-ui-canister",
-    "panics.wasm.gz": "//rs/rust_canisters/tests:panics",
     "pmap_canister.wasm.gz": "//rs/rust_canisters/pmap:pmap_canister",
     "proxy_canister.wasm.gz": "//rs/rust_canisters/proxy_canister:proxy_canister",
     "registry-canister.wasm.gz": "//rs/registry/canister:registry-canister",
-    "response-payload-test-canister.wasm.gz": "//rs/rust_canisters/response_payload_test:response-payload-test-canister",
     "root-canister.wasm.gz": "//rs/nns/handlers/root/impl:root-canister",
     "sns-governance-canister.wasm.gz": "//rs/sns/governance:sns-governance-canister",
     "sns-governance-canister_test.wasm.gz": "//rs/sns/governance:sns-governance-canister-test",
     "sns-governance-mem-test-canister.wasm.gz": "//rs/sns/integration_tests:sns-governance-mem-test-canister",
     "sns-root-canister.wasm.gz": "//rs/sns/root:sns-root-canister",
     "sns-swap-canister.wasm.gz": "//rs/sns/swap:sns-swap-canister",
-    "sns-test-dapp-canister.wasm.gz": "//rs/sns/integration_tests:sns-test-dapp-canister",
     "sns-wasm-canister.wasm.gz": "//rs/nns/sns-wasm:sns-wasm-canister",
-    "stable.wasm.gz": "//rs/rust_canisters/tests:stable",
-    "statesync-test-canister.wasm.gz": "//rs/rust_canisters/statesync_test:statesync_test_canister",
-    "test-notified.wasm.gz": "//rs/rosetta-api/icp_ledger:test_notified_canister",
-    "time.wasm.gz": "//rs/rust_canisters/tests:time",
-    "upgrade-test-canister.wasm.gz": "//rs/nns/handlers/root/impl:upgrade-test-canister",
     "wasm.wasm.gz": "//rs/rust_canisters/dfn_core:wasm",
-    "xnet-test-canister.wasm.gz": "//rs/rust_canisters/xnet_test:xnet-test-canister",
-    "cow_safety.wasm.gz": ":cow_safety.wasm.gz",
-    "counter.wat.gz": ":counter.wat.gz",
-    "xrc-mock-canister.wasm.gz": "//rs/rosetta-api/tvl/xrc_mock:xrc_mock_canister",
-    "bitcoin-mock-canister.wasm.gz": "//rs/bitcoin/mock:bitcoin_canister_mock",
 }
-
-TESTONLY_CANISTERS = [
-    "mem-utils-test-canister.wasm.gz",
-    "governance-mem-test-canister.wasm.gz",
-]
 
 DEFAULT_CANISTERS_MAX_SIZE_E5_BYTES = "21"
 
@@ -97,16 +68,6 @@ CANISTERS_MAX_SIZE_COMPRESSED_E5_BYTES = {
 CANISTERS_MAX_SIZE_COMPRESSED_E5_BYTES.update(NNS_CANISTERS_MAX_SIZE_COMPRESSED_E5_BYTES)
 
 CANISTERS_MAX_SIZE_COMPRESSED_E5_BYTES.update(SNS_CANISTERS_MAX_SIZE_COMPRESSED_E5_BYTES)
-
-gzip_compress(
-    name = "counter.wat.gz",
-    srcs = ["//rs/workload_generator:src/counter.wat"],
-)
-
-gzip_compress(
-    name = "cow_safety.wasm.gz",
-    srcs = ["//rs/tests:src/cow_safety.wasm"],
-)
 
 [
     sh_test(
@@ -156,20 +117,7 @@ COMPRESSED_CANISTERS = {
         out = compressed_file_name,
     )
     for (compressed_file_name, target) in CANISTERS.items() + COMPRESSED_CANISTERS.items()
-    if compressed_file_name.endswith(".wasm.gz") and compressed_file_name !=
-                                                     "cow_safety.wasm.gz" and compressed_file_name not in TESTONLY_CANISTERS
-]
-
-[
-    copy_file(
-        name = "copy_" + compressed_file_name,
-        testonly = True,
-        src = target,
-        out = compressed_file_name,
-    )
-    for (compressed_file_name, target) in CANISTERS.items() + COMPRESSED_CANISTERS.items()
-    if compressed_file_name.endswith(".wasm.gz") and compressed_file_name !=
-                                                     "cow_safety.wasm.gz" and compressed_file_name in TESTONLY_CANISTERS
+    if compressed_file_name.endswith(".wasm.gz")
 ]
 
 filegroup(
@@ -192,7 +140,7 @@ filegroup(
     )
     for (name, target) in CANISTERS.items()
     if (
-        name.endswith(".wasm.gz") and name != "cow_safety.wasm.gz"
+        name.endswith(".wasm.gz")
     )
 ]
 
@@ -203,7 +151,7 @@ filegroup(
         n + "-did"
         for n, t in CANISTERS.items()
         if (
-            n.endswith(".wasm.gz") and n != "cow_safety.wasm.gz"
+            n.endswith(".wasm.gz")
         )
     ],
 )

--- a/publish/canisters/BUILD.bazel
+++ b/publish/canisters/BUILD.bazel
@@ -6,6 +6,10 @@ load(
     "SNS_CANISTERS_MAX_SIZE_COMPRESSED_E5_BYTES",
 )
 
+# The list of canisters that are being published/uploaded to github as artifacts include
+# 1. Officially released canisters that can be downloaded/verified by 3rd parties - https://github.com/dfinity/ic/blob/master/.github/workflows/tag-release.yml
+# 2. Canisters required for dfx - https://github.com/dfinity/dfx-extensions/tree/main/extensions-utils/src/dependencies/download_wasms
+# 3. Mainnet canisters - https://github.com/dfinity/ic/blob/master/mainnet-canisters.bzl
 CANISTERS = {
     "canister-creator-canister.wasm.gz": "//rs/rust_canisters/canister_creator:canister_creator_canister",
     "cycles-minting-canister.wasm.gz": "//rs/nns/cmc:cycles-minting-canister",

--- a/rs/nervous_system/compressed_wasm_size_limits.bzl
+++ b/rs/nervous_system/compressed_wasm_size_limits.bzl
@@ -18,7 +18,6 @@ NNS_CANISTERS_MAX_SIZE_COMPRESSED_E5_BYTES = {
     "genesis-token-canister.wasm.gz": "3",
     "governance-canister.wasm.gz": "12",
     "governance-canister_test.wasm.gz": "12",
-    "governance-mem-test-canister.wasm.gz": "2",
     "registry-canister.wasm.gz": "12",
     "root-canister.wasm.gz": "4",
 }


### PR DESCRIPTION
 The list of canisters that are being published/uploaded to github as artifacts include 
 1. Officially released canisters that can be downloaded/verified by 3rd parties - https://github.com/dfinity/ic/blob/master/.github/workflows/tag-release.yml
 2. Canisters required for dfx - https://github.com/dfinity/dfx-extensions/tree/main/extensions-utils/src/dependencies/download_wasms
 3. Mainnet canisters - https://github.com/dfinity/ic/blob/master/mainnet-canisters.bzl
