### PR TITLE
feat(IDX): limit namespace runs to 1

### DIFF
--- a/.github/workflows/test-namespace-darwin.yml
+++ b/.github/workflows/test-namespace-darwin.yml
@@ -1,6 +1,13 @@
 # Darwin tests on runners from https://namespace.so
 name: test-namespace
 on: [push]
+
+# Ensure there's only one instance of this workflow for any PR/branch/tag, and
+# cancel the previous one if necessary
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test-namespace:
     strategy:


### PR DESCRIPTION
This ensures that we only run a single namespace-backed workflow at a time for any PR, branch or tag. This is similar to what we do with other runners and will help save some resources.