### PR TITLE
chore: remove the redundant sns--test_feature target

### DIFF
--- a/publish/binaries/BUILD.bazel
+++ b/publish/binaries/BUILD.bazel
@@ -91,7 +91,6 @@ TESTONLY_BINARIES = [
     "ic-starter",
     "ic-test-state-machine",
     "pocket-ic",
-    "sns-test-feature",
     "types-test",
     "replicated-state-test",
 ]

--- a/publish/binaries/BUILD.bazel
+++ b/publish/binaries/BUILD.bazel
@@ -65,7 +65,6 @@ BINARIES = {
     "setupos_tool": "//rs/ic_os/setupos_tool:setupos_tool",
     "sns": "//rs/sns/cli:sns",
     "sns-audit": "//rs/sns/audit:sns-audit",
-    "sns-test-feature": "//rs/sns/cli:sns--test_feature",
     "state-tool": "//rs/state_tool:state-tool",
     "systemd-journal-gatewayd-shim": "//rs/boundary_node/systemd_journal_gatewayd_shim:systemd-journal-gatewayd-shim",
     "vsock_guest": "//rs/ic_os/vsock/guest:vsock_guest",

--- a/rs/sns/cli/BUILD.bazel
+++ b/rs/sns/cli/BUILD.bazel
@@ -72,23 +72,6 @@ rust_library(
     deps = DEPENDENCIES,
 )
 
-rust_library(
-    name = "cli--test_feature",
-    srcs = glob(
-        ["src/**/*.rs"],
-        exclude = [
-            "**/*tests.rs",
-            "main.rs",
-        ],
-    ),
-    aliases = ALIASES,
-    crate_features = ["test"],
-    crate_name = "ic_sns_cli",
-    proc_macro_deps = MACRO_DEPENDENCIES,
-    version = "1.0.0",
-    deps = DEPENDENCIES_WITH_TEST_FEATURES,
-)
-
 rust_binary(
     name = "sns",
     srcs = ["src/main.rs"],
@@ -96,17 +79,6 @@ rust_binary(
     proc_macro_deps = MACRO_DEPENDENCIES,
     version = "1.0.0",
     deps = DEPENDENCIES + [":cli"],
-)
-
-rust_binary(
-    name = "sns--test_feature",
-    srcs = ["src/main.rs"],
-    aliases = ALIASES,
-    crate_features = ["test"],
-    crate_name = "sns",
-    proc_macro_deps = MACRO_DEPENDENCIES,
-    version = "1.0.0",
-    deps = DEPENDENCIES_WITH_TEST_FEATURES + [":cli--test_feature"],
 )
 
 rust_test(


### PR DESCRIPTION
`sns--test_feature` is supposed to enable a feature called "`test`" however, when grep-ing the code under `/rs/sns/cli` I don't find 
`[cfg(feature = "test")]  `