### PR TITLE
fix(IDX): inline namespace profile

### DIFF
--- a/.github/workflows/test-namespace-darwin.yml
+++ b/.github/workflows/test-namespace-darwin.yml
@@ -10,10 +10,7 @@ concurrency:
 
 jobs:
   test-namespace:
-    strategy:
-      matrix:
-        os: [ namespace-profile-darwin-small ] # profile created in namespace console
-    runs-on: ${{ matrix.os }}
+    runs-on: namespace-profile-darwin-small # profile created in namespace console
     steps:
 
       - name: Install nsc


### PR DESCRIPTION
This inlines the custom `namespace-profile-darwin-small` that we use for Darwin builds. Previously a `matrix` was used, though it was unnecessary since it only contained a single profile.