### PR TITLE
refactor(crypto): CRP-2453 remove CspPublicAndSecretKeyStoreChecker

### DIFF
--- a/rs/crypto/internal/crypto_service_provider/src/api/keygen.rs
+++ b/rs/crypto/internal/crypto_service_provider/src/api/keygen.rs
@@ -1,36 +1,5 @@
-use ic_crypto_node_key_validation::ValidNodePublicKeys;
-
-use crate::vault::api::{CspPublicKeyStoreError, ValidatePksAndSksError};
-use crate::{ExternalPublicKeys, PksAndSksContainsErrors};
+use crate::vault::api::CspPublicKeyStoreError;
 use ic_types::crypto::CurrentNodePublicKeys;
-
-/// A trait that allows simultaneously checking the public and secret key stores for the
-/// availability of a key.
-pub trait CspPublicAndSecretKeyStoreChecker {
-    /// Checks whether the keys corresponding to the provided external public keys exist locally.
-    /// In particular, this means the provided public keys themselves are stored locally, as well
-    /// as the corresponding secret keys. Key comparisons will not take timestamps into account.
-    ///
-    /// # Parameters
-    /// The current external node public keys and TLS certificate.
-    ///
-    /// # Returns
-    /// An empty result if all the external public keys, and the corresponding secret keys, were
-    /// all found locally.
-    ///
-    /// # Errors
-    /// * `PksAndSksContainsErrors::NodeKeysErrors` if local public or secret keys were not
-    ///   consistent with the provided external keys.
-    /// * `PksAndSksContainsErrors::TransientInternalError` if a transient internal error, e.g., an RPC
-    ///   error, occurred.
-    fn pks_and_sks_contains(
-        &self,
-        external_public_keys: ExternalPublicKeys,
-    ) -> Result<(), PksAndSksContainsErrors>;
-
-    /// See documentation in [`crate::vault::api::PublicAndSecretKeyStoreCspVault::validate_pks_and_sks`].
-    fn validate_pks_and_sks(&self) -> Result<ValidNodePublicKeys, ValidatePksAndSksError>;
-}
 
 /// A trait that exposes the information about the node public key store.
 pub trait CspPublicKeyStore {

--- a/rs/crypto/internal/crypto_service_provider/src/api/mod.rs
+++ b/rs/crypto/internal/crypto_service_provider/src/api/mod.rs
@@ -7,7 +7,7 @@ mod threshold;
 mod tls;
 
 pub use canister_threshold::CspCreateMEGaKeyError;
-pub use keygen::{CspPublicAndSecretKeyStoreChecker, CspPublicKeyStore};
+pub use keygen::CspPublicKeyStore;
 pub use sign::{CspSigVerifier, CspSigner};
 pub use threshold::{
     threshold_sign_error::CspThresholdSignError, NiDkgCspClient, ThresholdSignatureCspClient,

--- a/rs/crypto/internal/crypto_service_provider/src/lib.rs
+++ b/rs/crypto/internal/crypto_service_provider/src/lib.rs
@@ -26,17 +26,14 @@ pub use crate::vault::remote_csp_vault::run_csp_vault_server;
 pub use crate::vault::remote_csp_vault::RemoteCspVault;
 
 use crate::api::{
-    CspPublicAndSecretKeyStoreChecker, CspPublicKeyStore, CspSigVerifier, CspSigner,
-    CspTlsHandshakeSignerProvider, NiDkgCspClient, ThresholdSignatureCspClient,
+    CspPublicKeyStore, CspSigVerifier, CspSigner, CspTlsHandshakeSignerProvider, NiDkgCspClient,
+    ThresholdSignatureCspClient,
 };
 use crate::secret_key_store::SecretKeyStore;
 use crate::types::{CspPublicKey, ExternalPublicKeys};
-use crate::vault::api::{
-    CspPublicKeyStoreError, CspVault, PksAndSksContainsErrors, ValidatePksAndSksError,
-};
+use crate::vault::api::{CspPublicKeyStoreError, CspVault};
 use ic_config::crypto::CryptoConfig;
 use ic_crypto_internal_logmon::metrics::CryptoMetrics;
-use ic_crypto_node_key_validation::ValidNodePublicKeys;
 use ic_logger::{new_logger, replica_logger::no_op_logger, ReplicaLogger};
 use ic_types::crypto::CurrentNodePublicKeys;
 use key_id::KeyId;
@@ -54,7 +51,6 @@ pub trait CryptoServiceProvider:
     + CspSigVerifier
     + ThresholdSignatureCspClient
     + NiDkgCspClient
-    + CspPublicAndSecretKeyStoreChecker
     + CspTlsHandshakeSignerProvider
     + CspPublicKeyStore
 {
@@ -65,7 +61,6 @@ impl<T> CryptoServiceProvider for T where
         + CspSigVerifier
         + ThresholdSignatureCspClient
         + NiDkgCspClient
-        + CspPublicAndSecretKeyStoreChecker
         + CspTlsHandshakeSignerProvider
         + CspPublicKeyStore
 {
@@ -190,18 +185,5 @@ impl CspPublicKeyStore for Csp {
 
     fn idkg_dealing_encryption_pubkeys_count(&self) -> Result<usize, CspPublicKeyStoreError> {
         self.csp_vault.idkg_dealing_encryption_pubkeys_count()
-    }
-}
-
-impl CspPublicAndSecretKeyStoreChecker for Csp {
-    fn pks_and_sks_contains(
-        &self,
-        external_public_keys: ExternalPublicKeys,
-    ) -> Result<(), PksAndSksContainsErrors> {
-        self.csp_vault.pks_and_sks_contains(external_public_keys)
-    }
-
-    fn validate_pks_and_sks(&self) -> Result<ValidNodePublicKeys, ValidatePksAndSksError> {
-        self.csp_vault.validate_pks_and_sks()
     }
 }

--- a/rs/crypto/src/keygen/mod.rs
+++ b/rs/crypto/src/keygen/mod.rs
@@ -41,7 +41,7 @@ impl<C: CryptoServiceProvider> KeyManager for CryptoComponentImpl<C> {
                 // If retrieval of public keys from the registry was successful, check to make sure
                 // we have the public keys, and the corresponding secret keys locally
                 let pks_and_sks_contains_result =
-                    self.csp.pks_and_sks_contains(registry_public_keys);
+                    self.vault.pks_and_sks_contains(registry_public_keys);
                 match pks_and_sks_contains_result {
                     Ok(()) => {
                         self.observe_all_key_counts(

--- a/rs/crypto/src/keygen/tests.rs
+++ b/rs/crypto/src/keygen/tests.rs
@@ -1859,7 +1859,7 @@ impl SetupBuilder {
         let mut mock_vault = MockLocalCspVault::new();
 
         if let Some(csp_pks_and_sks_contains_result) = self.csp_pks_and_sks_contains_result {
-            mock_csp
+            mock_vault
                 .expect_pks_and_sks_contains()
                 .times(1)
                 .return_const(csp_pks_and_sks_contains_result);

--- a/rs/crypto/test_utils/csp/src/lib.rs
+++ b/rs/crypto/test_utils/csp/src/lib.rs
@@ -1,14 +1,10 @@
 use ic_crypto_internal_csp::api::{
-    CspPublicAndSecretKeyStoreChecker, CspPublicKeyStore, CspSigVerifier, CspSigner,
-    CspThresholdSignError, CspTlsHandshakeSignerProvider, NiDkgCspClient,
-    ThresholdSignatureCspClient,
+    CspPublicKeyStore, CspSigVerifier, CspSigner, CspThresholdSignError,
+    CspTlsHandshakeSignerProvider, NiDkgCspClient, ThresholdSignatureCspClient,
 };
 use ic_crypto_internal_csp::key_id::KeyId;
-use ic_crypto_internal_csp::types::ExternalPublicKeys;
 use ic_crypto_internal_csp::types::{CspPop, CspPublicCoefficients, CspPublicKey, CspSignature};
 use ic_crypto_internal_csp::vault::api::CspPublicKeyStoreError;
-use ic_crypto_internal_csp::vault::api::PksAndSksContainsErrors;
-use ic_crypto_internal_csp::vault::api::ValidatePksAndSksError;
 use ic_crypto_internal_csp::TlsHandshakeCspVault;
 use ic_crypto_internal_threshold_sig_bls12381::api::ni_dkg_errors::{
     CspDkgCreateDealingError, CspDkgCreateReshareDealingError, CspDkgCreateReshareTranscriptError,
@@ -19,7 +15,6 @@ use ic_crypto_internal_types::sign::threshold_sig::ni_dkg::{
     CspFsEncryptionPublicKey, CspNiDkgDealing, CspNiDkgTranscript, Epoch,
 };
 use ic_crypto_internal_types::sign::threshold_sig::public_key::CspThresholdSigPublicKey;
-use ic_crypto_node_key_validation::ValidNodePublicKeys;
 use ic_types::crypto::threshold_sig::ni_dkg::NiDkgId;
 use ic_types::crypto::{AlgorithmId, CryptoResult, CurrentNodePublicKeys};
 use ic_types::{NodeIndex, NumberOfNodes};
@@ -203,15 +198,6 @@ mock! {
         fn observe_minimum_epoch_in_active_transcripts(&self, epoch: Epoch);
 
         fn observe_epoch_in_loaded_transcript(&self, epoch: Epoch);
-    }
-
-    impl CspPublicAndSecretKeyStoreChecker for AllCryptoServiceProvider {
-        fn pks_and_sks_contains(
-            &self,
-            registry_public_keys: ExternalPublicKeys,
-        ) -> Result<(), PksAndSksContainsErrors>;
-
-        fn validate_pks_and_sks(&self) -> Result<ValidNodePublicKeys, ValidatePksAndSksError>;
     }
 
     impl CspPublicKeyStore for AllCryptoServiceProvider {


### PR DESCRIPTION
Refactors the code so that the crypto component bypasses the obsolete `CspPublicAndSecretKeyStoreChecker` and at the same time deletes it.