### PR TITLE
chore: Move drun ownership to the languages team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -121,7 +121,7 @@ go_deps.bzl               @dfinity/idx
 /rs/cycles_account_manager/                             @dfinity/execution
 /rs/depcheck/                                           @dfinity/ic-interface-owners
 /rs/determinism_test/                                   @dfinity/execution
-/rs/drun/                                               @dfinity/execution
+/rs/drun/                                               @dfinity/languages
 /rs/embedders/                                          @dfinity/runtime
 /rs/ethereum/                                           @dfinity/cross-chain-team
 /rs/execution_environment/                              @dfinity/execution @dfinity/runtime


### PR DESCRIPTION
`drun` is only used by the Languages team for testing. Moving the ownership to them so they can independently evolve it as they see fit.