### PR TITLE
chore(IDX): move spec_compliance test to hourly & nightly

### DIFF
--- a/hs/spec_compliance/BUILD.bazel
+++ b/hs/spec_compliance/BUILD.bazel
@@ -78,6 +78,7 @@ haskell_binary(
     srcs = [
         "bin/ic-ref-test.hs",
     ],
+    tags = ["manual"],
     target_compatible_with = ["@platforms//os:linux"],
     visibility = ["//visibility:public"],
     deps = STACK_DEPS + [
@@ -145,6 +146,7 @@ haskell_library(
     name = "IC-Crypto-BLS",
     srcs = ["src/IC/Crypto/BLS.hsc"],
     src_strip_prefix = "src",
+    tags = ["manual"],
     target_compatible_with = ["@platforms//os:linux"],
     deps = STACK_DEPS + [
         ":IC-Id-Forms",
@@ -158,6 +160,7 @@ haskell_library(
     name = "IC-Id-Fresh",
     srcs = ["src/IC/Id/Fresh.hs"],
     src_strip_prefix = "src",
+    tags = ["manual"],
     target_compatible_with = ["@platforms//os:linux"],
     deps = STACK_DEPS + [
         ":IC-Id-Forms",
@@ -171,6 +174,7 @@ haskell_library(
     name = "IC-Id-Forms",
     srcs = ["src/IC/Id/Forms.hs"],
     src_strip_prefix = "src",
+    tags = ["manual"],
     target_compatible_with = ["@platforms//os:linux"],
     deps = STACK_DEPS + [
         ":IC-Hash",
@@ -183,6 +187,7 @@ haskell_library(
     name = "IC-Utils",
     srcs = ["src/IC/Utils.hs"],
     src_strip_prefix = "src",
+    tags = ["manual"],
     target_compatible_with = ["@platforms//os:linux"],
     deps = STACK_DEPS + [
         ":IC-Constants",
@@ -197,6 +202,7 @@ haskell_library(
     name = "IC-Certificate",
     srcs = ["src/IC/Certificate.hs"],
     src_strip_prefix = "src",
+    tags = ["manual"],
     target_compatible_with = ["@platforms//os:linux"],
     deps = STACK_DEPS + [
         ":IC-HashTree",
@@ -210,6 +216,7 @@ haskell_library(
     srcs = ["src/IC/Management.hs"],
     extra_srcs = ["ic.did"],
     src_strip_prefix = "src",
+    tags = ["manual"],
     target_compatible_with = ["@platforms//os:linux"],
     deps = STACK_DEPS + [
         ":IC-Types",
@@ -222,6 +229,7 @@ haskell_library(
     name = "IC-Purify",
     srcs = ["src/IC/Purify.hs"],
     src_strip_prefix = "src",
+    tags = ["manual"],
     target_compatible_with = ["@platforms//os:linux"],
     deps = STACK_DEPS + [
         "@haskell-candid//:candid",
@@ -233,6 +241,7 @@ haskell_library(
     name = "IC-Crypto",
     srcs = ["src/IC/Crypto.hs"],
     src_strip_prefix = "src",
+    tags = ["manual"],
     target_compatible_with = ["@platforms//os:linux"],
     deps = STACK_DEPS + [
         ":IC-Crypto-BLS",
@@ -251,6 +260,7 @@ haskell_library(
     name = "IC-HTTP-RequestId",
     srcs = ["src/IC/HTTP/RequestId.hs"],
     src_strip_prefix = "src",
+    tags = ["manual"],
     target_compatible_with = ["@platforms//os:linux"],
     deps = STACK_DEPS + [
         ":IC-HTTP-GenR",
@@ -265,6 +275,7 @@ haskell_library(
     name = "IC-HTTP-CBOR",
     srcs = ["src/IC/HTTP/CBOR.hs"],
     src_strip_prefix = "src",
+    tags = ["manual"],
     target_compatible_with = ["@platforms//os:linux"],
     deps = STACK_DEPS + [
         ":IC-HTTP-GenR",
@@ -277,6 +288,7 @@ haskell_library(
     name = "IC-HTTP-GenR",
     srcs = ["src/IC/HTTP/GenR.hs"],
     src_strip_prefix = "src",
+    tags = ["manual"],
     target_compatible_with = ["@platforms//os:linux"],
     deps = STACK_DEPS + [
         "@haskell-candid//:candid",
@@ -288,6 +300,7 @@ haskell_library(
     name = "IC-HTTP-GenR-Parse",
     srcs = ["src/IC/HTTP/GenR/Parse.hs"],
     src_strip_prefix = "src",
+    tags = ["manual"],
     target_compatible_with = ["@platforms//os:linux"],
     deps = STACK_DEPS + [
         ":IC-HTTP-GenR",
@@ -300,6 +313,7 @@ haskell_library(
     name = "IC-Types",
     srcs = ["src/IC/Types.hs"],
     src_strip_prefix = "src",
+    tags = ["manual"],
     target_compatible_with = ["@platforms//os:linux"],
     deps = STACK_DEPS + [
         "@haskell-candid//:candid",
@@ -311,6 +325,7 @@ haskell_library(
     name = "IC-HashTree-CBOR",
     srcs = ["src/IC/HashTree/CBOR.hs"],
     src_strip_prefix = "src",
+    tags = ["manual"],
     target_compatible_with = ["@platforms//os:linux"],
     deps = STACK_DEPS + [
         ":IC-CBOR-Patterns",
@@ -324,6 +339,7 @@ haskell_library(
     name = "IC-HashTree",
     srcs = ["src/IC/HashTree.hs"],
     src_strip_prefix = "src",
+    tags = ["manual"],
     target_compatible_with = ["@platforms//os:linux"],
     deps = STACK_DEPS + [
         "@haskell-candid//:candid",
@@ -335,6 +351,7 @@ haskell_library(
     name = "IC-Constants",
     srcs = ["src/IC/Constants.hs"],
     src_strip_prefix = "src",
+    tags = ["manual"],
     target_compatible_with = ["@platforms//os:linux"],
     deps = STACK_DEPS + [
         ":IC-Types",
@@ -347,6 +364,7 @@ haskell_library(
     name = "IC-Certificate-Value",
     srcs = ["src/IC/Certificate/Value.hs"],
     src_strip_prefix = "src",
+    tags = ["manual"],
     target_compatible_with = ["@platforms//os:linux"],
     deps = STACK_DEPS + [
         ":IC-Types",
@@ -360,6 +378,7 @@ haskell_library(
     name = "IC-Certificate-Validate",
     srcs = ["src/IC/Certificate/Validate.hs"],
     src_strip_prefix = "src",
+    tags = ["manual"],
     target_compatible_with = ["@platforms//os:linux"],
     deps = STACK_DEPS + [
         ":IC-Certificate",
@@ -376,6 +395,7 @@ haskell_library(
     name = "IC-Certificate-CBOR",
     srcs = ["src/IC/Certificate/CBOR.hs"],
     src_strip_prefix = "src",
+    tags = ["manual"],
     target_compatible_with = ["@platforms//os:linux"],
     deps = STACK_DEPS + [
         ":IC-CBOR-Parser",
@@ -392,6 +412,7 @@ haskell_library(
     name = "IC-Crypto-Secp256k1",
     srcs = ["src/IC/Crypto/Secp256k1.hs"],
     src_strip_prefix = "src",
+    tags = ["manual"],
     target_compatible_with = ["@platforms//os:linux"],
     deps = STACK_DEPS + [
         "@haskell-candid//:candid",
@@ -403,6 +424,7 @@ haskell_library(
     name = "IC-Crypto-Ed25519",
     srcs = ["src/IC/Crypto/Ed25519.hs"],
     src_strip_prefix = "src",
+    tags = ["manual"],
     target_compatible_with = ["@platforms//os:linux"],
     deps = STACK_DEPS + [
         "@haskell-candid//:candid",
@@ -414,6 +436,7 @@ haskell_library(
     name = "IC-Crypto-DER-Decode",
     srcs = ["src/IC/Crypto/DER/Decode.hs"],
     src_strip_prefix = "src",
+    tags = ["manual"],
     target_compatible_with = ["@platforms//os:linux"],
     deps = STACK_DEPS + [
         "@haskell-candid//:candid",
@@ -425,6 +448,7 @@ haskell_library(
     name = "IC-Crypto-DER",
     srcs = ["src/IC/Crypto/DER.hs"],
     src_strip_prefix = "src",
+    tags = ["manual"],
     target_compatible_with = ["@platforms//os:linux"],
     deps = STACK_DEPS + [
         ":IC-Crypto-DER-Decode",
@@ -437,6 +461,7 @@ haskell_library(
     name = "IC-Crypto-DER_BLS",
     srcs = ["src/IC/Crypto/DER_BLS.hs"],
     src_strip_prefix = "src",
+    tags = ["manual"],
     target_compatible_with = ["@platforms//os:linux"],
     deps = STACK_DEPS + [
         ":IC-Crypto-BLS",
@@ -450,6 +475,7 @@ haskell_library(
     name = "IC-Crypto-WebAuthn",
     srcs = ["src/IC/Crypto/WebAuthn.hs"],
     src_strip_prefix = "src",
+    tags = ["manual"],
     target_compatible_with = ["@platforms//os:linux"],
     deps = STACK_DEPS + [
         ":IC-CBOR-Parser",
@@ -467,6 +493,7 @@ haskell_library(
     name = "IC-Crypto-CanisterSig",
     srcs = ["src/IC/Crypto/CanisterSig.hs"],
     src_strip_prefix = "src",
+    tags = ["manual"],
     target_compatible_with = ["@platforms//os:linux"],
     deps = STACK_DEPS + [
         ":IC-CBOR-Parser",
@@ -487,6 +514,7 @@ haskell_library(
     name = "IC-Crypto-ECDSA",
     srcs = ["src/IC/Crypto/ECDSA.hs"],
     src_strip_prefix = "src",
+    tags = ["manual"],
     target_compatible_with = ["@platforms//os:linux"],
     deps = STACK_DEPS + [
         "@haskell-candid//:candid",
@@ -498,6 +526,7 @@ haskell_library(
     name = "IC-Version",
     srcs = ["src/IC/Version.hs"],
     src_strip_prefix = "src",
+    tags = ["manual"],
     target_compatible_with = ["@platforms//os:linux"],
     deps = STACK_DEPS + [
         ":SourceId",
@@ -510,6 +539,7 @@ haskell_library(
     name = "IC-Hash",
     srcs = ["src/IC/Hash.hs"],
     src_strip_prefix = "src",
+    tags = ["manual"],
     target_compatible_with = ["@platforms//os:linux"],
     deps = STACK_DEPS + [
         "@haskell-candid//:candid",
@@ -521,6 +551,7 @@ haskell_library(
     name = "IC-CBOR-Utils",
     srcs = ["src/IC/CBOR/Utils.hs"],
     src_strip_prefix = "src",
+    tags = ["manual"],
     target_compatible_with = ["@platforms//os:linux"],
     deps = STACK_DEPS + [
         ":IC-HTTP-CBOR",
@@ -535,6 +566,7 @@ haskell_library(
     name = "IC-CBOR-Parser",
     srcs = ["src/IC/CBOR/Parser.hs"],
     src_strip_prefix = "src",
+    tags = ["manual"],
     target_compatible_with = ["@platforms//os:linux"],
     deps = STACK_DEPS + [
         ":IC-CBOR-Patterns",
@@ -547,6 +579,7 @@ haskell_library(
     name = "IC-CBOR-Patterns",
     srcs = ["src/IC/CBOR/Patterns.hs"],
     src_strip_prefix = "src",
+    tags = ["manual"],
     target_compatible_with = ["@platforms//os:linux"],
     deps = STACK_DEPS + [
         "@haskell-candid//:candid",
@@ -558,6 +591,7 @@ haskell_library(
     name = "IC-DRun-Parse",
     srcs = ["src/IC/DRun/Parse.hs"],
     src_strip_prefix = "src",
+    tags = ["manual"],
     target_compatible_with = ["@platforms//os:linux"],
     deps = STACK_DEPS + [
         "@haskell-candid//:candid",
@@ -569,6 +603,7 @@ haskell_library(
     name = "IC-Test-Secp256k1",
     srcs = ["src/IC/Test/Secp256k1.hs"],
     src_strip_prefix = "src",
+    tags = ["manual"],
     target_compatible_with = ["@platforms//os:linux"],
     deps = STACK_DEPS + [
         ":IC-Crypto-Secp256k1",
@@ -581,6 +616,7 @@ haskell_library(
     name = "IC-Test-Spec",
     srcs = ["src/IC/Test/Spec.hs"],
     src_strip_prefix = "src",
+    tags = ["manual"],
     target_compatible_with = ["@platforms//os:linux"],
     deps = STACK_DEPS + [
         ":IC-Certificate",
@@ -615,6 +651,7 @@ haskell_library(
     name = "IC-Test-WebAuthn",
     srcs = ["src/IC/Test/WebAuthn.hs"],
     src_strip_prefix = "src",
+    tags = ["manual"],
     target_compatible_with = ["@platforms//os:linux"],
     deps = STACK_DEPS + [
         ":IC-Crypto-WebAuthn",
@@ -627,6 +664,7 @@ haskell_library(
     name = "IC-Test-Spec-Utils",
     srcs = ["src/IC/Test/Spec/Utils.hs"],
     src_strip_prefix = "src",
+    tags = ["manual"],
     target_compatible_with = ["@platforms//os:linux"],
     deps = STACK_DEPS + [
         ":IC-Crypto",
@@ -648,6 +686,7 @@ haskell_library(
     name = "IC-Test-Spec-CanisterHistory",
     srcs = ["src/IC/Test/Spec/CanisterHistory.hs"],
     src_strip_prefix = "src",
+    tags = ["manual"],
     target_compatible_with = ["@platforms//os:linux"],
     deps = STACK_DEPS + [
         ":IC-Hash",
@@ -668,6 +707,7 @@ haskell_library(
     name = "IC-Test-Spec-HTTP",
     srcs = ["src/IC/Test/Spec/HTTP.hs"],
     src_strip_prefix = "src",
+    tags = ["manual"],
     target_compatible_with = ["@platforms//os:linux"],
     deps = STACK_DEPS + [
         ":IC-Constants",
@@ -689,6 +729,7 @@ haskell_library(
     name = "IC-Test-Spec-CanisterVersion",
     srcs = ["src/IC/Test/Spec/CanisterVersion.hs"],
     src_strip_prefix = "src",
+    tags = ["manual"],
     target_compatible_with = ["@platforms//os:linux"],
     deps = STACK_DEPS + [
         ":IC-Test-Agent",
@@ -706,6 +747,7 @@ haskell_library(
     name = "IC-Test-Spec-Timer",
     srcs = ["src/IC/Test/Spec/Timer.hs"],
     src_strip_prefix = "src",
+    tags = ["manual"],
     target_compatible_with = ["@platforms//os:linux"],
     deps = STACK_DEPS + [
         ":IC-Management",
@@ -722,6 +764,7 @@ haskell_library(
     name = "IC-Test-BLS",
     srcs = ["src/IC/Test/BLS.hs"],
     src_strip_prefix = "src",
+    tags = ["manual"],
     target_compatible_with = ["@platforms//os:linux"],
     deps = STACK_DEPS + [
         ":IC-Crypto-BLS",
@@ -734,6 +777,7 @@ haskell_library(
     name = "IC-Test-ECDSA",
     srcs = ["src/IC/Test/ECDSA.hs"],
     src_strip_prefix = "src",
+    tags = ["manual"],
     target_compatible_with = ["@platforms//os:linux"],
     deps = STACK_DEPS + [
         ":IC-Crypto-ECDSA",
@@ -746,6 +790,7 @@ haskell_library(
     name = "IC-Test-Agent",
     srcs = ["src/IC/Test/Agent.hs"],
     src_strip_prefix = "src",
+    tags = ["manual"],
     target_compatible_with = ["@platforms//os:linux"],
     deps = STACK_DEPS + [
         ":IC-Certificate",
@@ -775,6 +820,7 @@ haskell_library(
     name = "IC-Test-HashTree",
     srcs = ["src/IC/Test/HashTree.hs"],
     src_strip_prefix = "src",
+    tags = ["manual"],
     target_compatible_with = ["@platforms//os:linux"],
     deps = STACK_DEPS + [
         ":IC-HashTree",
@@ -788,6 +834,7 @@ haskell_library(
     name = "IC-Test-Universal",
     srcs = ["src/IC/Test/Universal.hs"],
     src_strip_prefix = "src",
+    tags = ["manual"],
     target_compatible_with = ["@platforms//os:linux"],
     deps = STACK_DEPS + [
         "@haskell-candid//:candid",
@@ -799,6 +846,7 @@ haskell_library(
     name = "IC-Test-Options",
     srcs = ["src/IC/Test/Options.hs"],
     src_strip_prefix = "src",
+    tags = ["manual"],
     target_compatible_with = ["@platforms//os:linux"],
     deps = STACK_DEPS + [
         ":IC-Constants",
@@ -814,6 +862,7 @@ haskell_library(
     name = "IC-Test-Agent-UnsafeCalls",
     srcs = ["src/IC/Test/Agent/UnsafeCalls.hs"],
     src_strip_prefix = "src",
+    tags = ["manual"],
     target_compatible_with = ["@platforms//os:linux"],
     deps = STACK_DEPS + [
         ":IC-Id-Forms",
@@ -831,6 +880,7 @@ haskell_library(
     name = "IC-Test-Agent-SafeCalls",
     srcs = ["src/IC/Test/Agent/SafeCalls.hs"],
     src_strip_prefix = "src",
+    tags = ["manual"],
     target_compatible_with = ["@platforms//os:linux"],
     deps = STACK_DEPS + [
         ":IC-Id-Forms",
@@ -848,6 +898,7 @@ haskell_library(
     name = "IC-Test-Agent-Calls",
     srcs = ["src/IC/Test/Agent/Calls.hs"],
     src_strip_prefix = "src",
+    tags = ["manual"],
     target_compatible_with = ["@platforms//os:linux"],
     deps = STACK_DEPS + [
         ":IC-Id-Forms",
@@ -862,6 +913,7 @@ haskell_library(
     name = "IC-Test-Agent-UserCalls",
     srcs = ["src/IC/Test/Agent/UserCalls.hs"],
     src_strip_prefix = "src",
+    tags = ["manual"],
     target_compatible_with = ["@platforms//os:linux"],
     deps = STACK_DEPS + [
         ":IC-Id-Forms",
@@ -877,6 +929,7 @@ haskell_library(
     name = "SourceId",
     srcs = ["src/SourceId.hs"],
     src_strip_prefix = "src",
+    tags = ["manual"],
     target_compatible_with = ["@platforms//os:linux"],
     deps = STACK_DEPS + [
         "@haskell-candid//:candid",

--- a/rs/pocket_ic_server/BUILD.bazel
+++ b/rs/pocket_ic_server/BUILD.bazel
@@ -189,6 +189,10 @@ rust_test(
         "POCKET_IC_BIN": "$(rootpath //rs/pocket_ic_server:pocket-ic-server)",
         "IC_REF_TEST_ROOT": "rs/tests/ic-hs",
     },
-    tags = ["cpu:8"],
+    tags = [
+        "cpu:8",
+        "system_test_hourly",
+        "system_test_nightly",
+    ],
     deps = SPEC_TEST_DEPENDENCIES,
 )

--- a/rs/tests/BUILD.bazel
+++ b/rs/tests/BUILD.bazel
@@ -271,6 +271,7 @@ run_binary(
 
 symlink_dirs(
     name = "ic-hs",
+    tags = ["manual"],
     target_compatible_with = ["@platforms//os:linux"],
     targets = {
         "//hs/spec_compliance:ic-ref-test": "bin",

--- a/rs/tests/testing_verification/BUILD.bazel
+++ b/rs/tests/testing_verification/BUILD.bazel
@@ -27,7 +27,11 @@ system_test(
     name = "spec_compliance_application_subnet_test",
     flaky = True,
     proc_macro_deps = MACRO_DEPENDENCIES,
-    tags = ["cpu:4"],
+    tags = [
+        "cpu:4",
+        "system_test_hourly",
+        "system_test_nightly",
+    ],
     target_compatible_with = ["@platforms//os:linux"],  # requires libssh that does not build on Mac OS
     runtime_deps = BOUNDARY_NODE_GUESTOS_RUNTIME_DEPS + GUESTOS_RUNTIME_DEPS + UNIVERSAL_VM_RUNTIME_DEPS + CANISTER_HTTP_RUNTIME_DEPS + IC_HS_RUNTIME_DEPS + NNS_CANISTER_RUNTIME_DEPS + [
         "//ic-os/components:networking/dev-certs/canister_http_test_ca.cert",
@@ -42,7 +46,11 @@ system_test(
     name = "spec_compliance_system_subnet_test",
     flaky = True,
     proc_macro_deps = MACRO_DEPENDENCIES,
-    tags = ["cpu:4"],
+    tags = [
+        "cpu:4",
+        "system_test_hourly",
+        "system_test_nightly",
+    ],
     target_compatible_with = ["@platforms//os:linux"],  # requires libssh that does not build on Mac OS
     runtime_deps = BOUNDARY_NODE_GUESTOS_RUNTIME_DEPS + GUESTOS_RUNTIME_DEPS + UNIVERSAL_VM_RUNTIME_DEPS + CANISTER_HTTP_RUNTIME_DEPS + IC_HS_RUNTIME_DEPS + NNS_CANISTER_RUNTIME_DEPS + [
         "//ic-os/components:networking/dev-certs/canister_http_test_ca.cert",
@@ -57,7 +65,11 @@ system_test(
     name = "spec_compliance_group_01_application_subnet_test",
     flaky = True,
     proc_macro_deps = MACRO_DEPENDENCIES,
-    tags = ["cpu:4"],
+    tags = [
+        "cpu:4",
+        "system_test_hourly",
+        "system_test_nightly",
+    ],
     target_compatible_with = ["@platforms//os:linux"],  # requires libssh that does not build on Mac OS
     runtime_deps = BOUNDARY_NODE_GUESTOS_RUNTIME_DEPS + GUESTOS_RUNTIME_DEPS + UNIVERSAL_VM_RUNTIME_DEPS + CANISTER_HTTP_RUNTIME_DEPS + IC_HS_RUNTIME_DEPS + NNS_CANISTER_RUNTIME_DEPS + [
         "//ic-os/components:networking/dev-certs/canister_http_test_ca.cert",
@@ -72,7 +84,11 @@ system_test(
     name = "spec_compliance_group_01_system_subnet_test",
     flaky = True,
     proc_macro_deps = MACRO_DEPENDENCIES,
-    tags = ["cpu:4"],
+    tags = [
+        "cpu:4",
+        "system_test_hourly",
+        "system_test_nightly",
+    ],
     target_compatible_with = ["@platforms//os:linux"],  # requires libssh that does not build on Mac OS
     runtime_deps = BOUNDARY_NODE_GUESTOS_RUNTIME_DEPS + GUESTOS_RUNTIME_DEPS + UNIVERSAL_VM_RUNTIME_DEPS + CANISTER_HTTP_RUNTIME_DEPS + IC_HS_RUNTIME_DEPS + NNS_CANISTER_RUNTIME_DEPS + [
         "//ic-os/components:networking/dev-certs/canister_http_test_ca.cert",
@@ -87,7 +103,11 @@ system_test(
     name = "spec_compliance_group_02_system_subnet_test",
     flaky = True,
     proc_macro_deps = MACRO_DEPENDENCIES,
-    tags = ["cpu:4"],
+    tags = [
+        "cpu:4",
+        "system_test_hourly",
+        "system_test_nightly",
+    ],
     target_compatible_with = ["@platforms//os:linux"],  # requires libssh that does not build on Mac OS
     runtime_deps = BOUNDARY_NODE_GUESTOS_RUNTIME_DEPS + GUESTOS_RUNTIME_DEPS + UNIVERSAL_VM_RUNTIME_DEPS + CANISTER_HTTP_RUNTIME_DEPS + IC_HS_RUNTIME_DEPS + NNS_CANISTER_RUNTIME_DEPS + [
         "//ic-os/components:networking/dev-certs/canister_http_test_ca.cert",


### PR DESCRIPTION
The `//hs/spec_compliance:...` targets take a long time to build and they get rebuild unnecessarily. Before we figure out why this is the case and fix it we tag them as "manual" so they don't get build automatically and we move their reverse dependencies like the `//rs/tests/testing_verification:spec_compliance_...` tests and `//rs/pocket_ic_server:spec_test` from the CI Main workflow (which runs on PRs) to the hourly and nightly workflows.