### PR TITLE
fix(crypto): make crypto-team own ic-signature-verification package

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -50,6 +50,7 @@ go_deps.bzl               @dfinity/idx
 /packages/icrc-ledger-types/         @dfinity/finint
 /packages/ic-ledger-hash-of/         @dfinity/finint
 /packages/pocket-ic/                 @dfinity/pocket-ic
+/packages/ic-signature-verification/ @dfinity/crypto-team
 /packages/ic-vetkd-utils/            @dfinity/crypto-team
 
 # [IC-OS]


### PR DESCRIPTION
Makes the crypto-team own the ic-signature-verification package again. The ownership was correctly set in the past but was accidentally removed.