### PR TITLE
chore: Manually update `testnet/mainnet_revisions.json`

### DIFF
--- a/testnet/mainnet_revisions.json
+++ b/testnet/mainnet_revisions.json
@@ -1,6 +1,6 @@
 {
   "subnets": {
-    "tdb26-jop6k-aogll-7ltgs-eruif-6kk7m-qpktf-gdiqx-mxtrf-vb5e6-eqe": "7dee90107a88b836fc72e78993913988f4f73ca2",
+    "tdb26-jop6k-aogll-7ltgs-eruif-6kk7m-qpktf-gdiqx-mxtrf-vb5e6-eqe": "a3831c87440df4821b435050c8a8fcb3745d86f6",
     "io67a-2jmkw-zup3h-snbwi-g6a5n-rm5dn-b6png-lvdpl-nqnto-yih6l-gqe": "a3831c87440df4821b435050c8a8fcb3745d86f6"
   }
 }


### PR DESCRIPTION
The automation updating this file seems broken at the moment. We should still update it such that tests run against the correct mainnet version.

For currently deployed versions see https://grafana.mainnet.dfinity.network/d/release/release?orgId=1