### PR TITLE
chore: Update error message for subnet methods that are not allowed through ingress messages

### DIFF
--- a/rs/messaging/src/scheduling/valid_set_rule.rs
+++ b/rs/messaging/src/scheduling/valid_set_rule.rs
@@ -250,11 +250,13 @@ impl ValidSetRuleImpl {
         let effective_canister_id =
             match extract_effective_canister_id(&msg, state.metadata.own_subnet_id) {
                 Ok(effective_canister_id) => effective_canister_id,
-                Err(
-                    ParseIngressError::UnknownSubnetMethod
-                    | ParseIngressError::SubnetMethodNotAllowed,
-                ) => {
+                Err(ParseIngressError::UnknownSubnetMethod) => {
                     return Err(IngressInductionError::CanisterMethodNotFound(
+                        msg.method_name().to_string(),
+                    ))
+                }
+                Err(ParseIngressError::SubnetMethodNotAllowed) => {
+                    return Err(IngressInductionError::SubnetMethodNotAllowed(
                         msg.method_name().to_string(),
                     ))
                 }

--- a/rs/replicated_state/src/replicated_state.rs
+++ b/rs/replicated_state/src/replicated_state.rs
@@ -137,6 +137,10 @@ pub enum IngressInductionError {
     /// Message enqueuing failed due to calling an unknown subnet method.
     CanisterMethodNotFound(String),
 
+    /// Message enqueuing failed due to calling a subnet method that is not
+    /// allowed to be called via ingress messages.
+    SubnetMethodNotAllowed(String),
+
     /// Message enqueuing failed due to calling a subnet method with
     /// an invalid payload.
     InvalidManagementPayload,
@@ -280,6 +284,7 @@ pub const LABEL_VALUE_INVALID_RESPONSE: &str = "InvalidResponse";
 pub const LABEL_VALUE_BITCOIN_NON_MATCHING_RESPONSE: &str = "BitcoinNonMatchingResponse";
 pub const LABEL_VALUE_CANISTER_OUT_OF_CYCLES: &str = "CanisterOutOfCycles";
 pub const LABEL_VALUE_CANISTER_METHOD_NOT_FOUND: &str = "CanisterMethodNotFound";
+pub const LABEL_VALUE_SUBNET_METHOD_NOT_ALLOWED: &str = "SubnetMethodNotAllowed";
 pub const LABEL_VALUE_INVALID_MANAGEMENT_PAYLOAD: &str = "InvalidManagementPayload";
 pub const LABEL_VALUE_INGRESS_HISTORY_FULL: &str = "IngressHistoryFull";
 
@@ -313,6 +318,9 @@ impl IngressInductionError {
             IngressInductionError::CanisterOutOfCycles(_) => LABEL_VALUE_CANISTER_OUT_OF_CYCLES,
             IngressInductionError::CanisterMethodNotFound(_) => {
                 LABEL_VALUE_CANISTER_METHOD_NOT_FOUND
+            }
+            IngressInductionError::SubnetMethodNotAllowed(_) => {
+                LABEL_VALUE_SUBNET_METHOD_NOT_ALLOWED
             }
             IngressInductionError::InvalidManagementPayload => {
                 LABEL_VALUE_INVALID_MANAGEMENT_PAYLOAD
@@ -385,6 +393,11 @@ impl std::fmt::Display for IngressInductionError {
                 "Cannot enqueue management message. Method {} is unknown.",
                 method
             ),
+            IngressInductionError::SubnetMethodNotAllowed(method) => write!(
+                f,
+                "Cannot enqueue management message. Method {} is not allowed to be called via ingress messages.",
+                method
+            ),
             IngressInductionError::InvalidManagementPayload => write!(
                 f,
                 "Cannot enqueue management message. Candid payload is invalid."
@@ -404,6 +417,7 @@ impl From<&IngressInductionError> for ErrorCode {
             IngressInductionError::CanisterStopping(_) => ErrorCode::CanisterStopping,
             IngressInductionError::CanisterOutOfCycles { .. } => ErrorCode::CanisterOutOfCycles,
             IngressInductionError::CanisterMethodNotFound(_) => ErrorCode::CanisterMethodNotFound,
+            IngressInductionError::SubnetMethodNotAllowed(_) => ErrorCode::CanisterRejectedMessage,
             IngressInductionError::InvalidManagementPayload => ErrorCode::InvalidManagementPayload,
             IngressInductionError::IngressHistoryFull { .. } => ErrorCode::IngressHistoryFull,
         }

--- a/rs/tests/src/execution/api_tests.rs
+++ b/rs/tests/src/execution/api_tests.rs
@@ -379,7 +379,7 @@ pub fn node_metrics_history_ingress_update_fails(env: TestEnv) {
             assert_reject_msg(
                 result,
                 RejectCode::CanisterReject,
-                "ic00 method node_metrics_history can be not be called via ingress messages",
+                "ic00 method node_metrics_history can not be called via ingress messages",
             );
         }
     })

--- a/rs/tests/src/execution/api_tests.rs
+++ b/rs/tests/src/execution/api_tests.rs
@@ -379,7 +379,7 @@ pub fn node_metrics_history_ingress_update_fails(env: TestEnv) {
             assert_reject_msg(
                 result,
                 RejectCode::CanisterReject,
-                "ic00 method node_metrics_history can be called only by a canister",
+                "ic00 method node_metrics_history can be not be called via ingress messages",
             );
         }
     })

--- a/rs/types/types/src/messages/ingress_messages.rs
+++ b/rs/types/types/src/messages/ingress_messages.rs
@@ -468,7 +468,7 @@ impl ParseIngressError {
             ParseIngressError::SubnetMethodNotAllowed => UserError::new(
                 ErrorCode::CanisterRejectedMessage,
                 format!(
-                    "ic00 method {} can be not be called via ingress messages",
+                    "ic00 method {} can not be called via ingress messages",
                     method_name
                 ),
             ),

--- a/rs/types/types/src/messages/ingress_messages.rs
+++ b/rs/types/types/src/messages/ingress_messages.rs
@@ -454,7 +454,7 @@ pub enum ParseIngressError {
     UnknownSubnetMethod,
     /// Failed to parse method payload.
     InvalidSubnetPayload(String),
-    /// The subnet method can be called only by a canister.
+    /// The subnet method can not be called via ingress messages.
     SubnetMethodNotAllowed,
 }
 
@@ -468,7 +468,7 @@ impl ParseIngressError {
             ParseIngressError::SubnetMethodNotAllowed => UserError::new(
                 ErrorCode::CanisterRejectedMessage,
                 format!(
-                    "ic00 method {} can be called only by a canister",
+                    "ic00 method {} can be not be called via ingress messages",
                     method_name
                 ),
             ),


### PR DESCRIPTION
The error message for subnet methods that were not allowed through ingress was coupled with the error message of a method not found which can be misleading when an ingress message is not inducted. Additionally, improve the error message for `SubnetMethodNotAllowed` when parsing an ingress to mention directly that the message is not allowed through ingress instead of "can only be called by canisters". The two are not exactly equivalent, the example here being `fetch_canister_logs` which can only be called by non-replicated queries.