### PR TITLE
test(orchestrator): increase subnet size for sr_app_large_with_tecdsa_test to 37

### DIFF
--- a/rs/tests/src/orchestrator/subnet_recovery_app_subnet.rs
+++ b/rs/tests/src/orchestrator/subnet_recovery_app_subnet.rs
@@ -60,7 +60,7 @@ const UNASSIGNED_NODES: usize = 3;
 
 const DKG_INTERVAL_LARGE: u64 = 99;
 const NNS_NODES_LARGE: usize = 40;
-const APP_NODES_LARGE: usize = 34;
+const APP_NODES_LARGE: usize = 37;
 
 pub const CHAIN_KEY_SUBNET_RECOVERY_TIMEOUT: Duration = Duration::from_secs(15 * 60);
 


### PR DESCRIPTION
Increases the subnet size used in the large app subnet recovery test with tECDSA from 34 to 37.

One purpose of this test is to showcase how large app subnets with (all) chain keys enabled can be so that they can still be recovered. In local tests, the test succeeded around 50 times for 37 nodes, which seems sufficient for increasing the value permanently.