### PR TITLE
chore(http_endpoint): put compute intesive code in `/read_state` into `spawn_blocking` 

### DIFF
--- a/rs/http_endpoints/public/src/read_state/canister.rs
+++ b/rs/http_endpoints/public/src/read_state/canister.rs
@@ -156,81 +156,79 @@ pub(crate) async fn canister_read_state(
     let read_state = request.content().clone();
     let registry_version = registry_client.get_latest_version();
 
-    let root_of_trust_provider =
-        RegistryRootOfTrustProvider::new(Arc::clone(&registry_client), registry_version);
-    // Since spawn blocking requires 'static we can't use any references
-    let request_c = request.clone();
-    let targets = match tokio::task::spawn_blocking(move || {
-        validator.validate_request(&request_c, current_time(), &root_of_trust_provider)
-    })
-    .await
-    {
-        Ok(Ok(targets)) => targets,
-        Ok(Err(err)) => {
-            let http_err = validation_error_to_http_error(request.id(), err, &log);
-            return (http_err.status, http_err.message).into_response();
-        }
-        Err(_) => {
-            return StatusCode::INTERNAL_SERVER_ERROR.into_response();
-        }
-    };
     let make_service_unavailable_response = || {
         let status = StatusCode::SERVICE_UNAVAILABLE;
         let text = "Certified state is not available yet. Please try again...".to_string();
         (status, text).into_response()
     };
-    let certified_state_reader = match tokio::task::spawn_blocking(move || {
-        state_reader.get_certified_state_snapshot()
+    let root_of_trust_provider =
+        RegistryRootOfTrustProvider::new(Arc::clone(&registry_client), registry_version);
+    // Since spawn blocking requires 'static we can't use any references
+    let request_c = request.clone();
+    match tokio::task::spawn_blocking(move || {
+        let targets =
+            match validator.validate_request(&request_c, current_time(), &root_of_trust_provider) {
+                Ok(targets) => targets,
+                Err(err) => {
+                    let http_err = validation_error_to_http_error(request.id(), err, &log);
+                    return (http_err.status, http_err.message).into_response();
+                }
+            };
+
+        let certified_state_reader = match state_reader.get_certified_state_snapshot() {
+            Some(reader) => reader,
+            None => return make_service_unavailable_response(),
+        };
+
+        // Verify authorization for requested paths.
+        if let Err(HttpError { status, message }) = verify_paths(
+            certified_state_reader.get_state(),
+            &read_state.source,
+            &read_state.paths,
+            &targets,
+            effective_canister_id.into(),
+        ) {
+            return (status, message).into_response();
+        }
+
+        // Create labeled tree. This may be an expensive operation and by
+        // creating the labeled tree after verifying the paths we know that
+        // the depth is max 4.
+        // Always add "time" to the paths even if not explicitly requested.
+        let mut paths: Vec<Path> = read_state.paths;
+        paths.push(Path::from(Label::from("time")));
+        let labeled_tree = match sparse_labeled_tree_from_paths(&paths) {
+            Ok(tree) => tree,
+            Err(TooLongPathError) => {
+                let status = StatusCode::BAD_REQUEST;
+                let text = "Failed to parse requested paths: path is too long.".to_string();
+                return (status, text).into_response();
+            }
+        };
+
+        let (tree, certification) = match certified_state_reader.read_certified_state(&labeled_tree)
+        {
+            Some(r) => r,
+            None => return make_service_unavailable_response(),
+        };
+
+        let signature = certification.signed.signature.signature.get().0;
+        let res = HttpReadStateResponse {
+            certificate: Blob(into_cbor(&Certificate {
+                tree,
+                signature: Blob(signature),
+                delegation: delegation_from_nns,
+            })),
+        };
+        Cbor(res).into_response()
     })
     .await
     {
-        Ok(Some(reader)) => reader,
-        Ok(None) => return make_service_unavailable_response(),
+        Ok(res) => res,
         Err(_) => {
             return StatusCode::INTERNAL_SERVER_ERROR.into_response();
         }
-    };
-
-    // Verify authorization for requested paths.
-    if let Err(HttpError { status, message }) = verify_paths(
-        certified_state_reader.get_state(),
-        &read_state.source,
-        &read_state.paths,
-        &targets,
-        effective_canister_id.into(),
-    ) {
-        return (status, message).into_response();
     }
-
-    // Create labeled tree. This may be an expensive operation and by
-    // creating the labeled tree after verifying the paths we know that
-    // the depth is max 4.
-    // Always add "time" to the paths even if not explicitly requested.
-    let mut paths: Vec<Path> = read_state.paths;
-    paths.push(Path::from(Label::from("time")));
-    let labeled_tree = match sparse_labeled_tree_from_paths(&paths) {
-        Ok(tree) => tree,
-        Err(TooLongPathError) => {
-            let status = StatusCode::BAD_REQUEST;
-            let text = "Failed to parse requested paths: path is too long.".to_string();
-            return (status, text).into_response();
-        }
-    };
-
-    let (tree, certification) = match certified_state_reader.read_certified_state(&labeled_tree) {
-        Some(r) => r,
-        None => return make_service_unavailable_response(),
-    };
-
-    let signature = certification.signed.signature.signature.get().0;
-    let res = HttpReadStateResponse {
-        certificate: Blob(into_cbor(&Certificate {
-            tree,
-            signature: Blob(signature),
-            delegation: delegation_from_nns,
-        })),
-    };
-    Cbor(res).into_response()
 }
 
 // Verifies that the `user` is authorized to retrieve the `paths` requested.

--- a/rs/http_endpoints/public/src/read_state/subnet.rs
+++ b/rs/http_endpoints/public/src/read_state/subnet.rs
@@ -87,7 +87,7 @@ pub(crate) async fn read_state_subnet(
         }
     };
     let read_state = request.content().clone();
-    match tokio::task::spawn_blocking(move || {
+    let response = tokio::task::spawn_blocking(move || {
         let certified_state_reader = match state_reader.get_certified_state_snapshot() {
             Some(reader) => reader,
             None => return make_service_unavailable_response(),
@@ -131,12 +131,10 @@ pub(crate) async fn read_state_subnet(
         })
         .into_response()
     })
-    .await
-    {
+    .await;
+    match response {
         Ok(res) => res,
-        Err(_) => {
-            return StatusCode::INTERNAL_SERVER_ERROR.into_response();
-        }
+        Err(_) => StatusCode::INTERNAL_SERVER_ERROR.into_response(),
     }
 }
 

--- a/rs/http_endpoints/public/src/read_state/subnet.rs
+++ b/rs/http_endpoints/public/src/read_state/subnet.rs
@@ -87,54 +87,57 @@ pub(crate) async fn read_state_subnet(
         }
     };
     let read_state = request.content().clone();
-    let certified_state_reader = match tokio::task::spawn_blocking(move || {
-        state_reader.get_certified_state_snapshot()
+    match tokio::task::spawn_blocking(move || {
+        let certified_state_reader = match state_reader.get_certified_state_snapshot() {
+            Some(reader) => reader,
+            None => return make_service_unavailable_response(),
+        };
+
+        // Verify authorization for requested paths.
+        if let Err(HttpError { status, message }) =
+            verify_paths(&read_state.paths, effective_canister_id.into())
+        {
+            return (status, message).into_response();
+        }
+
+        // Create labeled tree. This may be an expensive operation and by
+        // creating the labeled tree after verifying the paths we know that
+        // the depth is max 4.
+        // Always add "time" to the paths even if not explicitly requested.
+        let mut paths: Vec<Path> = read_state.paths;
+        paths.push(Path::from(Label::from("time")));
+        let labeled_tree = match sparse_labeled_tree_from_paths(&paths) {
+            Ok(tree) => tree,
+            Err(TooLongPathError) => {
+                let status = StatusCode::BAD_REQUEST;
+                let text = "Failed to parse requested paths: path is too long.".to_string();
+                return (status, text).into_response();
+            }
+        };
+
+        let (tree, certification) = match certified_state_reader.read_certified_state(&labeled_tree)
+        {
+            Some(r) => r,
+            None => return make_service_unavailable_response(),
+        };
+
+        let signature = certification.signed.signature.signature.get().0;
+        Cbor(HttpReadStateResponse {
+            certificate: Blob(into_cbor(&Certificate {
+                tree,
+                signature: Blob(signature),
+                delegation: delegation_from_nns,
+            })),
+        })
+        .into_response()
     })
     .await
     {
-        Ok(Some(reader)) => reader,
-        Ok(None) => return make_service_unavailable_response(),
+        Ok(res) => res,
         Err(_) => {
             return StatusCode::INTERNAL_SERVER_ERROR.into_response();
         }
-    };
-
-    // Verify authorization for requested paths.
-    if let Err(HttpError { status, message }) =
-        verify_paths(&read_state.paths, effective_canister_id.into())
-    {
-        return (status, message).into_response();
     }
-
-    // Create labeled tree. This may be an expensive operation and by
-    // creating the labeled tree after verifying the paths we know that
-    // the depth is max 4.
-    // Always add "time" to the paths even if not explicitly requested.
-    let mut paths: Vec<Path> = read_state.paths;
-    paths.push(Path::from(Label::from("time")));
-    let labeled_tree = match sparse_labeled_tree_from_paths(&paths) {
-        Ok(tree) => tree,
-        Err(TooLongPathError) => {
-            let status = StatusCode::BAD_REQUEST;
-            let text = "Failed to parse requested paths: path is too long.".to_string();
-            return (status, text).into_response();
-        }
-    };
-
-    let (tree, certification) = match certified_state_reader.read_certified_state(&labeled_tree) {
-        Some(r) => r,
-        None => return make_service_unavailable_response(),
-    };
-
-    let signature = certification.signed.signature.signature.get().0;
-    let res = HttpReadStateResponse {
-        certificate: Blob(into_cbor(&Certificate {
-            tree,
-            signature: Blob(signature),
-            delegation: delegation_from_nns,
-        })),
-    };
-    Cbor(res).into_response()
 }
 
 fn verify_paths(paths: &[Path], effective_principal_id: PrincipalId) -> Result<(), HttpError> {


### PR DESCRIPTION
`sparse_labeled_tree_from_paths` can be computationally intensive for certain inputs. To protect the tokio runtime we do the operation on the threadpool (as we already do for other things).