### PR TITLE
refactor(nns): no longer generate api types from internal protos

### DIFF
--- a/rs/nns/governance/BUILD.bazel
+++ b/rs/nns/governance/BUILD.bazel
@@ -261,7 +261,6 @@ generated_files_check(
         ":protos",
         "//rs/nervous_system/proto:protos",
         "//rs/nns/common:protos",
-        "//rs/nns/governance/api:src",
         "//rs/rosetta-api/icp_ledger:protos",
         "//rs/sns/root:protos",
         "//rs/sns/swap:protos",

--- a/rs/nns/governance/api/BUILD.bazel
+++ b/rs/nns/governance/api/BUILD.bazel
@@ -67,6 +67,3 @@ rust_library(
     version = "0.9.0",
     deps = DEPENDENCIES_WITH_TEST_FEATURES,
 )
-
-# needed for check_generated_files test
-exports_files(["src"])

--- a/rs/nns/governance/protobuf_generator/src/main.rs
+++ b/rs/nns/governance/protobuf_generator/src/main.rs
@@ -1,5 +1,5 @@
 use ic_nns_governance_protobuf_generator::{generate_prost_files, ProtoPaths};
-use std::{fs::copy, path::PathBuf};
+use std::path::PathBuf;
 
 fn main() {
     let manifest_dir = PathBuf::from(
@@ -36,11 +36,4 @@ fn main() {
         },
         out.as_ref(),
     );
-    // Duplicate into API lib
-    let api_src_lib = manifest_dir.join("../api/src");
-    copy(
-        out.join("ic_nns_governance.pb.v1.rs").as_path(),
-        api_src_lib.join("ic_nns_governance.pb.v1.rs").as_path(),
-    )
-    .unwrap();
 }

--- a/rs/nns/governance/tests/check_generated_files.rs
+++ b/rs/nns/governance/tests/check_generated_files.rs
@@ -1,5 +1,5 @@
 use ic_nns_governance_protobuf_generator::{generate_prost_files, ProtoPaths};
-use ic_test_utilities_compare_dirs::{compare, compare_right_contains_left, CompareError};
+use ic_test_utilities_compare_dirs::{compare, CompareError};
 use std::path::PathBuf;
 
 #[test]
@@ -45,25 +45,6 @@ fn check_generated_files() {
                 gen.display(),
                 command_to_regenerate
             )
-        }
-        Err(CompareError::ContentDiffers { path }) => {
-            panic!(
-                "Source file {} is outdated, run {}",
-                path.display(),
-                command_to_regenerate
-            )
-        }
-        Err(CompareError::IoError { path, cause }) => {
-            panic!("I/O error on {}: {}", path.display(), cause)
-        }
-    }
-
-    let api = manifest_dir.join("api/src");
-
-    match compare_right_contains_left(out_dir.path(), &api) {
-        Ok(_) => {}
-        Err(CompareError::PathsDiffer { .. }) => {
-            panic!("Error should not be possible")
         }
         Err(CompareError::ContentDiffers { path }) => {
             panic!(


### PR DESCRIPTION
We separate the API types used in canister.rs from the internal types used in nns/governance.  This helps both with speeding up the builds (because we can remove dependencies on nns/governance) and with allowing independent evolution of the internal domain types and the API, which will allow us to make better APIs while still supporting older versions of the APIs.