### PR TITLE
feat(nns): Added include_public_neurons_in_full_neurons to ListNeurons.

### DIFF
--- a/rs/nervous_system/integration_tests/src/pocket_ic_helpers.rs
+++ b/rs/nervous_system/integration_tests/src/pocket_ic_helpers.rs
@@ -674,6 +674,7 @@ pub mod nns {
                         neuron_ids: vec![],
                         include_neurons_readable_by_caller: true,
                         include_empty_neurons_readable_by_caller: None,
+                        include_public_neurons_in_full_neurons: None,
                     })
                     .unwrap(),
                 )

--- a/rs/nns/governance/api/src/ic_nns_governance.pb.v1.rs
+++ b/rs/nns/governance/api/src/ic_nns_governance.pb.v1.rs
@@ -3076,6 +3076,16 @@ pub struct ListNeurons {
     /// compatibility. Here, being "empty" means 0 stake, 0 maturity and 0 staked maturity.
     #[prost(bool, optional, tag = "3")]
     pub include_empty_neurons_readable_by_caller: ::core::option::Option<bool>,
+    /// If this is set to true, and a neuron in the "requested list" has its
+    /// visibility set to public, then, it will (also) be included in the
+    /// full_neurons field in the response (which is of type ListNeuronsResponse).
+    /// Note that this has no effect on which neurons are in the "requested list".
+    /// In particular, this does not cause all public neurons to become part of the
+    /// requested list. In general, you probably want to set this to true, but
+    /// since this feature was added later, it is opt in to avoid confusing
+    /// existing (unmigrated) callers.
+    #[prost(bool, optional, tag = "4")]
+    pub include_public_neurons_in_full_neurons: ::core::option::Option<bool>,
 }
 /// A response to a `ListNeurons` request.
 ///

--- a/rs/nns/governance/canister/canister.rs
+++ b/rs/nns/governance/canister/canister.rs
@@ -694,9 +694,7 @@ fn list_neurons() {
 
 #[candid_method(query, rename = "list_neurons")]
 fn list_neurons_(req: ListNeurons) -> ListNeuronsResponse {
-    governance()
-        .list_neurons_by_principal(&(req.into()), &caller())
-        .into()
+    governance().list_neurons(&(req.into()), caller()).into()
 }
 
 #[export_name = "canister_query get_metrics"]

--- a/rs/nns/governance/canister/governance.did
+++ b/rs/nns/governance/canister/governance.did
@@ -284,6 +284,7 @@ type LedgerParameters = record {
 };
 type ListKnownNeuronsResponse = record { known_neurons : vec KnownNeuron };
 type ListNeurons = record {
+  include_public_neurons_in_full_neurons : opt bool;
   neuron_ids : vec nat64;
   include_empty_neurons_readable_by_caller : opt bool;
   include_neurons_readable_by_caller : bool;

--- a/rs/nns/governance/canister/governance_test.did
+++ b/rs/nns/governance/canister/governance_test.did
@@ -284,6 +284,7 @@ type LedgerParameters = record {
 };
 type ListKnownNeuronsResponse = record { known_neurons : vec KnownNeuron };
 type ListNeurons = record {
+  include_public_neurons_in_full_neurons : opt bool;
   neuron_ids : vec nat64;
   include_empty_neurons_readable_by_caller : opt bool;
   include_neurons_readable_by_caller : bool;

--- a/rs/nns/governance/proto/ic_nns_governance/pb/v1/governance.proto
+++ b/rs/nns/governance/proto/ic_nns_governance/pb/v1/governance.proto
@@ -2492,6 +2492,15 @@ message ListNeurons {
   // if this field is not provided, it defaults to true, in order to maintain backwards
   // compatibility. Here, being "empty" means 0 stake, 0 maturity and 0 staked maturity.
   optional bool include_empty_neurons_readable_by_caller = 3;
+  // If this is set to true, and a neuron in the "requested list" has its
+  // visibility set to public, then, it will (also) be included in the
+  // full_neurons field in the response (which is of type ListNeuronsResponse).
+  // Note that this has no effect on which neurons are in the "requested list".
+  // In particular, this does not cause all public neurons to become part of the
+  // requested list. In general, you probably want to set this to true, but
+  // since this feature was added later, it is opt in to avoid confusing
+  // existing (unmigrated) callers.
+  optional bool include_public_neurons_in_full_neurons = 4;
 }
 
 // A response to a `ListNeurons` request.

--- a/rs/nns/governance/src/gen/ic_nns_governance.pb.v1.rs
+++ b/rs/nns/governance/src/gen/ic_nns_governance.pb.v1.rs
@@ -3076,6 +3076,16 @@ pub struct ListNeurons {
     /// compatibility. Here, being "empty" means 0 stake, 0 maturity and 0 staked maturity.
     #[prost(bool, optional, tag = "3")]
     pub include_empty_neurons_readable_by_caller: ::core::option::Option<bool>,
+    /// If this is set to true, and a neuron in the "requested list" has its
+    /// visibility set to public, then, it will (also) be included in the
+    /// full_neurons field in the response (which is of type ListNeuronsResponse).
+    /// Note that this has no effect on which neurons are in the "requested list".
+    /// In particular, this does not cause all public neurons to become part of the
+    /// requested list. In general, you probably want to set this to true, but
+    /// since this feature was added later, it is opt in to avoid confusing
+    /// existing (unmigrated) callers.
+    #[prost(bool, optional, tag = "4")]
+    pub include_public_neurons_in_full_neurons: ::core::option::Option<bool>,
 }
 /// A response to a `ListNeurons` request.
 ///

--- a/rs/nns/governance/src/governance.rs
+++ b/rs/nns/governance/src/governance.rs
@@ -2084,10 +2084,10 @@ impl Governance {
     }
 
     /// See `ListNeurons`.
-    pub fn list_neurons_by_principal(
+    pub fn list_neurons(
         &self,
         list_neurons: &ListNeurons,
-        caller: &PrincipalId,
+        caller: PrincipalId,
     ) -> ListNeuronsResponse {
         let now = self.env.now();
 
@@ -2118,10 +2118,10 @@ impl Governance {
         //        NeuronManagement topic.
         let mut implicitly_requested_neuron_ids = if *include_neurons_readable_by_caller {
             if include_empty_neurons_readable_by_caller {
-                self.get_neuron_ids_by_principal(caller)
+                self.get_neuron_ids_by_principal(&caller)
             } else {
                 self.neuron_store
-                    .get_non_empty_neuron_ids_readable_by_caller(*caller)
+                    .get_non_empty_neuron_ids_readable_by_caller(caller)
             }
         } else {
             Vec::new()
@@ -2148,8 +2148,8 @@ impl Governance {
                 // Populate full_neurons.
                 let let_caller_read_full_neuron =
                     // (Caller can vote with neuron if it is the controller or a hotkey of the neuron.)
-                    neuron.is_authorized_to_vote(caller)
-                        || self.neuron_store.can_principal_vote_on_proposals_that_target_neuron(*caller, neuron)
+                    neuron.is_authorized_to_vote(&caller)
+                        || self.neuron_store.can_principal_vote_on_proposals_that_target_neuron(caller, neuron)
                         // neuron is public, and the caller requested that
                         // public neurons be included (in full_neurons).
                         || (include_public_neurons_in_full_neurons

--- a/rs/nns/governance/src/neuron_store.rs
+++ b/rs/nns/governance/src/neuron_store.rs
@@ -797,12 +797,7 @@ impl NeuronStore {
             return Ok(neuron_clone);
         }
 
-        let is_authorized_to_vote_for_any_neuron_manager = neuron_clone
-            .neuron_managers()
-            .into_iter()
-            .any(|neuron_manager| self.is_authorized_to_vote(principal_id, neuron_manager));
-
-        if is_authorized_to_vote_for_any_neuron_manager {
+        if self.can_principal_vote_on_proposals_that_target_neuron(principal_id, &neuron_clone) {
             Ok(neuron_clone)
         } else {
             Err(NeuronStoreError::not_authorized_to_get_full_neuron(
@@ -822,6 +817,17 @@ impl NeuronStore {
             |neuron| neuron.is_authorized_to_vote(&principal_id),
         )
         .unwrap_or(false)
+    }
+
+    pub fn can_principal_vote_on_proposals_that_target_neuron(
+        &self,
+        principal_id: PrincipalId,
+        neuron: &Neuron,
+    ) -> bool {
+        neuron
+            .neuron_managers()
+            .into_iter()
+            .any(|manager_neuron_id| self.is_authorized_to_vote(principal_id, manager_neuron_id))
     }
 
     /// Execute a function with a mutable reference to a neuron, returning the result of the function,

--- a/rs/nns/governance/src/pb/conversions.rs
+++ b/rs/nns/governance/src/pb/conversions.rs
@@ -3594,6 +3594,7 @@ impl From<pb::ListNeurons> for pb_api::ListNeurons {
             neuron_ids: item.neuron_ids,
             include_neurons_readable_by_caller: item.include_neurons_readable_by_caller,
             include_empty_neurons_readable_by_caller: item.include_empty_neurons_readable_by_caller,
+            include_public_neurons_in_full_neurons: item.include_public_neurons_in_full_neurons,
         }
     }
 }
@@ -3603,6 +3604,7 @@ impl From<pb_api::ListNeurons> for pb::ListNeurons {
             neuron_ids: item.neuron_ids,
             include_neurons_readable_by_caller: item.include_neurons_readable_by_caller,
             include_empty_neurons_readable_by_caller: item.include_empty_neurons_readable_by_caller,
+            include_public_neurons_in_full_neurons: item.include_public_neurons_in_full_neurons,
         }
     }
 }

--- a/rs/nns/governance/tests/governance.rs
+++ b/rs/nns/governance/tests/governance.rs
@@ -9716,21 +9716,21 @@ fn test_neuron_set_visibility() {
 
     // Step 2: Call the code under test.
 
-    let set_visibility = SetVisibility {
-        visibility: Some(Visibility::Public as i32),
-    };
-
     let typical_configure_response = configure_neuron(
         controller,
         typical_neuron.id.unwrap(),
-        set_visibility.clone(),
+        SetVisibility {
+            visibility: Some(Visibility::Public as i32),
+        },
         &mut governance,
     );
 
     let known_neuron_configure_response = configure_neuron(
         controller,
         known_neuron.id.unwrap(),
-        set_visibility,
+        SetVisibility {
+            visibility: Some(Visibility::Private as i32),
+        },
         &mut governance,
     );
 
@@ -9773,7 +9773,7 @@ fn test_neuron_set_visibility() {
 
     assert_neuron_visibility(typical_neuron.id.unwrap(), Some(Visibility::Public));
 
-    assert_neuron_visibility(known_neuron.id.unwrap(), None);
+    assert_neuron_visibility(known_neuron.id.unwrap(), Some(Visibility::Public));
 }
 
 #[test]

--- a/rs/nns/integration_tests/src/governance_neurons.rs
+++ b/rs/nns/integration_tests/src/governance_neurons.rs
@@ -526,6 +526,7 @@ fn test_list_neurons() {
             neuron_ids: vec![neuron_id_1.id, neuron_id_2.id, neuron_id_3.id],
             include_neurons_readable_by_caller: false,
             include_empty_neurons_readable_by_caller: Some(false),
+            include_public_neurons_in_full_neurons: None,
         },
     );
     assert_eq!(list_neurons_response.neuron_infos.len(), 3);
@@ -539,6 +540,7 @@ fn test_list_neurons() {
             neuron_ids: vec![],
             include_neurons_readable_by_caller: true,
             include_empty_neurons_readable_by_caller: Some(true),
+            include_public_neurons_in_full_neurons: None,
         },
     );
     assert_eq!(list_neurons_response.neuron_infos.len(), 2);
@@ -552,6 +554,7 @@ fn test_list_neurons() {
             neuron_ids: vec![],
             include_neurons_readable_by_caller: true,
             include_empty_neurons_readable_by_caller: Some(false),
+            include_public_neurons_in_full_neurons: None,
         },
     );
     assert_eq!(list_neurons_response.neuron_infos.len(), 1);
@@ -566,6 +569,7 @@ fn test_list_neurons() {
             neuron_ids: vec![neuron_id_3.id],
             include_neurons_readable_by_caller: true,
             include_empty_neurons_readable_by_caller: None,
+            include_public_neurons_in_full_neurons: None,
         },
     );
     assert_eq!(list_neurons_response.neuron_infos.len(), 3);

--- a/rs/nns/test_utils/src/state_test_helpers.rs
+++ b/rs/nns/test_utils/src/state_test_helpers.rs
@@ -1475,6 +1475,7 @@ pub fn list_neurons_by_principal(
             neuron_ids: vec![],
             include_neurons_readable_by_caller: true,
             include_empty_neurons_readable_by_caller: None,
+            include_public_neurons_in_full_neurons: None,
         },
     )
 }

--- a/rs/rosetta-api/src/request_handler/construction_payloads.rs
+++ b/rs/rosetta-api/src/request_handler/construction_payloads.rs
@@ -424,6 +424,7 @@ fn handle_list_neurons(
         neuron_ids: vec![],
         include_neurons_readable_by_caller: true,
         include_empty_neurons_readable_by_caller: None,
+        include_public_neurons_in_full_neurons: None,
     };
     let update = HttpCanisterUpdate {
         canister_id: Blob(ic_nns_constants::GOVERNANCE_CANISTER_ID.get().to_vec()),

--- a/rs/tests/driver/src/canister_api.rs
+++ b/rs/tests/driver/src/canister_api.rs
@@ -733,6 +733,7 @@ impl ListNnsNeuronsRequest {
                 neuron_ids,
                 include_neurons_readable_by_caller,
                 include_empty_neurons_readable_by_caller: None,
+                include_public_neurons_in_full_neurons: None,
             },
         }
     }


### PR DESCRIPTION
[Per the plan](https://forum.dfinity.org/t/request-for-comments-api-changes-for-public-private-neurons/33360).

The upshot is that people can now read public neurons.

# Entrained Changes(s)

Fixed a bug from a [recent change of mine](https://github.com/dfinity/ic/pull/488) where neuron normalization was not applied 😬

Renamed list_neurons_by_principal to list_neurons in order to exactly match the Candid method name. Also, changed its &PrincipalId parameter to be of type PrincipalId, since that type is Copy.

Overhauled the implementation of (what is now called) Governance::list_neurons. This is the main thing I was touching anyway, but the change could have been smaller.

Added NeuronStore::can_principal_vote_on_proposals_that_target_neuron.

Refactored NeuronStore::get_full_neuron to use can_principal_vote_on_proposals_that_target_neuron.

# References

Closes [NNS1-3077](https://dfinity.atlassian.net/browse/NNS1-3077)

[<< Previous PR](https://github.com/dfinity/ic/pull/517)

[NNS1-3077]: https://dfinity.atlassian.net/browse/NNS1-3077?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ