### PR TITLE
chore: Add logs to capture usages of legacy ICQC feature on system subnets

### DIFF
--- a/rs/execution_environment/src/query_handler/query_context.rs
+++ b/rs/execution_environment/src/query_handler/query_context.rs
@@ -20,7 +20,7 @@ use ic_interfaces::execution_environment::{
     ExecutionMode, HypervisorError, SubnetAvailableMemory, SystemApiCallCounters,
 };
 use ic_interfaces_state_manager::Labeled;
-use ic_logger::{error, ReplicaLogger};
+use ic_logger::{error, info, ReplicaLogger};
 use ic_query_stats::QueryStatsCollector;
 use ic_registry_subnet_type::SubnetType;
 use ic_replicated_state::{
@@ -232,6 +232,14 @@ impl<'a> QueryContext<'a> {
         if let WasmMethod::Query(_) = &method {
             if let Err(err) = &result {
                 if err.code() == ErrorCode::CanisterContractViolation && legacy_icqc_enabled {
+                    if self.own_subnet_type == SubnetType::System {
+                        info!(
+                            self.log,
+                            "Canister's {} query method {} is using the legacy ICQC feature.",
+                            canister_id,
+                            method,
+                        );
+                    }
                     let measurement_scope =
                         MeasurementScope::nested(&metrics.query_retry_call, measurement_scope);
                     let old_canister = self.state.get_ref().get_active_canister(&canister_id)?;


### PR DESCRIPTION
This will help us identify more easily whether there are any legacy ICQC requests on system subnets in preparation of removing the feature eventually.