### PR TITLE
fix(IDX): don't invoke gitlab-ci/src/bazel-ci/diff.sh twice

### DIFF
--- a/gitlab-ci/src/bazel-ci/main.sh
+++ b/gitlab-ci/src/bazel-ci/main.sh
@@ -29,15 +29,6 @@ if [[ "${CI_MERGE_REQUEST_TITLE:-}" == *"[RUN_ALL_BAZEL_TARGETS]"* ]] || [[ "${C
 fi
 
 if [ "${RUN_ON_DIFF_ONLY:-}" == "true" ] \
-    && [ "${CI_PIPELINE_SOURCE:-}" == "merge_request_event" -o "${CI_PIPELINE_SOURCE:-}" == "pull_request" ] \
-    && [ "${CI_MERGE_REQUEST_EVENT_TYPE:-}" != "merge_train" ] \
-    && [[ "${CI_MERGE_REQUEST_TARGET_BRANCH_NAME:-}" != "rc--"* ]]; then
-    # get bazel targets that changed within the MR
-    BAZEL_TARGETS=$("${CI_PROJECT_DIR:-}"/gitlab-ci/src/bazel-ci/diff.sh)
-fi
-
-# github logic
-if [ "${RUN_ON_DIFF_ONLY:-}" == "true" ] \
     && [ "${CI_PIPELINE_SOURCE:-}" == "pull_request" ] \
     && [[ "${CI_MERGE_REQUEST_TARGET_BRANCH_NAME:-}" != "rc--"* ]]; then
     # get bazel targets that changed within the MR


### PR DESCRIPTION
`gitlab-ci/src/bazel-ci/diff.sh` was invoked twice on GitHub: 
once (redundantly) in the code path for GitLab and 
once (correctly) in the code path for GitHub.
We fix this by dropping the code path for GitLab since we don't support it anymore.