### PR TITLE
chore: adding back xnet test canister

### DIFF
--- a/publish/canisters/BUILD.bazel
+++ b/publish/canisters/BUILD.bazel
@@ -35,6 +35,7 @@ CANISTERS = {
     "sns-swap-canister.wasm.gz": "//rs/sns/swap:sns-swap-canister",
     "sns-wasm-canister.wasm.gz": "//rs/nns/sns-wasm:sns-wasm-canister",
     "wasm.wasm.gz": "//rs/rust_canisters/dfn_core:wasm",
+    # Needed by DRE team for qualification
     "xnet-test-canister.wasm.gz": "//rs/rust_canisters/xnet_test:xnet-test-canister",
 }
 

--- a/publish/canisters/BUILD.bazel
+++ b/publish/canisters/BUILD.bazel
@@ -35,6 +35,7 @@ CANISTERS = {
     "sns-swap-canister.wasm.gz": "//rs/sns/swap:sns-swap-canister",
     "sns-wasm-canister.wasm.gz": "//rs/nns/sns-wasm:sns-wasm-canister",
     "wasm.wasm.gz": "//rs/rust_canisters/dfn_core:wasm",
+    "xnet-test-canister.wasm.gz": "//rs/rust_canisters/xnet_test:xnet-test-canister",
 }
 
 COMPRESSED_CANISTERS = {


### PR DESCRIPTION
An artifact used by DRE qualification. Our team will look into removing this dependency ASAP. Until then this is needed.