### PR TITLE
fix(ci): Fix team label job to not fail if label was already present

### DIFF
--- a/.github/workflows/ci-pr-only-team-tags.yml
+++ b/.github/workflows/ci-pr-only-team-tags.yml
@@ -46,7 +46,7 @@ jobs:
         run: |
           set -exuo pipefail
           for TEAM in ${{ env.requested_teams }}; do
-            if ! gh label list | grep -w "$TEAM"; then
+            if ! gh label list --limit 100 | grep -w "$TEAM"; then
               echo "Creating label: $TEAM"
               gh label create "$TEAM" --color "d4af37"
             else


### PR DESCRIPTION
This fixes the label job in case the label had already been added, so that it does not cause CI to fail.