### PR TITLE
refactor(sns): NNS1-3207: Use NeuronRecipes in SNS Swap

### DIFF
--- a/rs/sns/governance/proto/ic_sns_governance/pb/v1/governance.proto
+++ b/rs/sns/governance/proto/ic_sns_governance/pb/v1/governance.proto
@@ -2049,7 +2049,7 @@ message ClaimSwapNeuronsRequest {
   // The set of parameters that define the neurons created in `claim_swap_neurons`. For
   // each NeuronParameter, one neuron will be created.
   // Deprecated. Use [`recipes`] instead.
-  repeated NeuronParameters neuron_parameters = 1;
+  repeated NeuronParameters neuron_parameters = 1 [deprecated = true];
 }
 
 // An enum for representing the various statuses a Neuron being claimed by the

--- a/rs/sns/governance/src/gen/ic_sns_governance.pb.v1.rs
+++ b/rs/sns/governance/src/gen/ic_sns_governance.pb.v1.rs
@@ -2525,6 +2525,7 @@ pub struct ClaimSwapNeuronsRequest {
     /// The set of parameters that define the neurons created in `claim_swap_neurons`. For
     /// each NeuronParameter, one neuron will be created.
     /// Deprecated. Use \[`recipes`\] instead.
+    #[deprecated]
     #[prost(message, repeated, tag = "1")]
     pub neuron_parameters: ::prost::alloc::vec::Vec<claim_swap_neurons_request::NeuronParameters>,
 }

--- a/rs/sns/governance/tests/governance.rs
+++ b/rs/sns/governance/tests/governance.rs
@@ -1713,6 +1713,7 @@ fn test_claim_swap_neurons_rejects_unauthorized_access() {
     let mut canister_fixture = GovernanceCanisterFixtureBuilder::new().create();
 
     // Build the request, but leave it empty as it is not relevant to the test
+    #[allow(deprecated)] // TODO: remove once neuron_parameters is removed
     let request = ClaimSwapNeuronsRequest {
         neuron_parameters: vec![],
         neuron_recipes: None,
@@ -1762,6 +1763,7 @@ fn test_claim_swap_neurons_reports_invalid_neuron_parameters() {
     let test_neuron_id = NeuronId::new_test_neuron_id(1);
 
     // Create a request with an invalid NeuronParameter
+    #[allow(deprecated)] // TODO: remove once neuron_parameters is removed
     let request = ClaimSwapNeuronsRequest {
         neuron_parameters: vec![],
         neuron_recipes: Some(NeuronRecipes::from(vec![NeuronRecipe {
@@ -1807,6 +1809,7 @@ fn test_claim_swap_neurons_reports_already_existing_neurons() {
 
     // Create a request with a neuron id that should collide with the neuron already inserted into
     // Governance
+    #[allow(deprecated)] // TODO: remove once neuron_parameters is removed
     let request = ClaimSwapNeuronsRequest {
         neuron_parameters: vec![],
         neuron_recipes: Some(NeuronRecipes::from(vec![NeuronRecipe {
@@ -1856,6 +1859,7 @@ fn test_claim_swap_neurons_reports_failure_if_neuron_cannot_be_added() {
     let test_neuron_id_failure = NeuronId::new_test_neuron_id(2);
 
     // Create a request with a NeuronParameter should succeed
+    #[allow(deprecated)] // TODO: remove once neuron_parameters is removed
     let request = ClaimSwapNeuronsRequest {
         neuron_parameters: vec![],
         neuron_recipes: Some(NeuronRecipes::from(vec![
@@ -1933,6 +1937,7 @@ fn test_claim_swap_neurons_succeeds() {
         followees: Some(NeuronIds::from(vec![NeuronId::new_test_neuron_id(20)])),
     };
 
+    #[allow(deprecated)] // TODO: remove once neuron_parameters is removed
     let request = ClaimSwapNeuronsRequest {
         neuron_parameters: vec![],
         neuron_recipes: Some(NeuronRecipes::from(vec![

--- a/rs/sns/swap/src/swap.rs
+++ b/rs/sns/swap/src/swap.rs
@@ -1633,7 +1633,7 @@ impl Swap {
                 Ok(neuron_recipe) => {
                     let neuron_id = neuron_recipe.neuron_id.clone().expect(
                         "NeuronRecipe.neuron_id is always set by \
-                        SnsNeuronRecipe::to_sns_neuron_recipe",
+                        SnsNeuronRecipe::to_neuron_recipe",
                     );
                     claimable_neurons_index.insert(neuron_id, recipe);
                     neuron_recipes.push(neuron_recipe);

--- a/rs/sns/swap/src/types.rs
+++ b/rs/sns/swap/src/types.rs
@@ -712,7 +712,7 @@ impl CfInvestment {
 }
 
 impl SnsNeuronRecipe {
-    pub fn validate(&self) -> Result<(), String> {
+    pub(crate) fn validate(&self) -> Result<(), String> {
         if let Some(sns) = &self.sns {
             sns.validate()?;
         } else {
@@ -1079,19 +1079,10 @@ impl From<NeuronId> for SwapNeuronId {
     }
 }
 
-// TODO NNS1-1589: Implementation will not longer be needed when swap.proto can depend on
-// SNS governance.proto
-impl TryInto<NeuronId> for SwapNeuronId {
-    type Error = String;
-
-    fn try_into(self) -> Result<NeuronId, Self::Error> {
-        match Subaccount::try_from(self.id) {
-            Ok(subaccount) => Ok(NeuronId::from(subaccount)),
-            Err(err) => Err(format!(
-                "Followee could not be parsed into NeuronId. Err {:?}",
-                err
-            )),
-        }
+impl From<SwapNeuronId> for NeuronId {
+    fn from(src: SwapNeuronId) -> Self {
+        let SwapNeuronId { id } = src;
+        NeuronId { id }
     }
 }
 

--- a/rs/sns/swap/src/types.rs
+++ b/rs/sns/swap/src/types.rs
@@ -8,7 +8,7 @@ use crate::{
         settle_neurons_fund_participation_result,
         sns_neuron_recipe::{ClaimedStatus, Investor},
         BuyerState, CfInvestment, CfNeuron, CfParticipant, DirectInvestment,
-        ErrorRefundIcpResponse, FinalizeSwapResponse, Init, Lifecycle, NeuronId as SaleNeuronId,
+        ErrorRefundIcpResponse, FinalizeSwapResponse, Init, Lifecycle, NeuronId as SwapNeuronId,
         Params, SetDappControllersCallResult, SetModeCallResult,
         SettleNeuronsFundParticipationResult, SnsNeuronRecipe, SweepResult, TransferableAmount,
     },
@@ -1065,7 +1065,7 @@ impl SettleNeuronsFundParticipationResult {
 
 // TODO NNS1-1589: Implementation will not longer be needed when swap.proto can depend on
 // SNS governance.proto
-impl From<[u8; 32]> for SaleNeuronId {
+impl From<[u8; 32]> for SwapNeuronId {
     fn from(value: [u8; 32]) -> Self {
         Self { id: value.to_vec() }
     }
@@ -1073,7 +1073,7 @@ impl From<[u8; 32]> for SaleNeuronId {
 
 // TODO NNS1-1589: Implementation will not longer be needed when swap.proto can depend on
 // SNS governance.proto
-impl From<NeuronId> for SaleNeuronId {
+impl From<NeuronId> for SwapNeuronId {
     fn from(neuron_id: NeuronId) -> Self {
         Self { id: neuron_id.id }
     }
@@ -1081,7 +1081,7 @@ impl From<NeuronId> for SaleNeuronId {
 
 // TODO NNS1-1589: Implementation will not longer be needed when swap.proto can depend on
 // SNS governance.proto
-impl TryInto<NeuronId> for SaleNeuronId {
+impl TryInto<NeuronId> for SwapNeuronId {
     type Error = String;
 
     fn try_into(self) -> Result<NeuronId, Self::Error> {


### PR DESCRIPTION
#596 added `NeuronRecipes` in `ClaimSwapNeuronsRequest`, a replacement for `NeuronParameters`. This PR uses it in SNS Swap

| [Next PR](https://github.com/dfinity/ic/pull/705) >