### PR TITLE
feat(PocketIC): specify IP address of PocketIC server and HTTP gateway

### DIFF
--- a/packages/pocket-ic/src/common/rest.rs
+++ b/packages/pocket-ic/src/common/rest.rs
@@ -28,7 +28,8 @@ pub struct HttpsConfig {
 
 #[derive(Debug, Clone, Eq, Hash, PartialEq, Serialize, Deserialize, JsonSchema)]
 pub struct HttpGatewayConfig {
-    pub listen_at: Option<u16>,
+    pub ip_addr: Option<String>,
+    pub port: Option<u16>,
     pub forward_to: HttpGatewayBackend,
     pub domains: Option<Vec<String>>,
     pub https_config: Option<HttpsConfig>,

--- a/packages/pocket-ic/src/nonblocking.rs
+++ b/packages/pocket-ic/src/nonblocking.rs
@@ -353,7 +353,7 @@ impl PocketIc {
 
     async fn start_http_gateway(
         &mut self,
-        listen_at: Option<u16>,
+        port: Option<u16>,
         domains: Option<Vec<String>>,
         https_config: Option<HttpsConfig>,
     ) -> Url {
@@ -362,7 +362,8 @@ impl PocketIc {
         }
         let endpoint = self.server_url.join("http_gateway").unwrap();
         let http_gateway_config = HttpGatewayConfig {
-            listen_at,
+            ip_addr: None,
+            port,
             forward_to: HttpGatewayBackend::PocketIcInstance(self.instance_id),
             domains: domains.clone(),
             https_config: https_config.clone(),

--- a/rs/pocket_ic_server/CHANGELOG.md
+++ b/rs/pocket_ic_server/CHANGELOG.md
@@ -11,6 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+- New CLI option `--ip_addr` to specify the IP address at which the PocketIC server should listen (defaults to `127.0.0.1`).
+- New argument `ip_addr` of the endpoint `/http_gateway` to specify the IP address at which the HTTP gateway should listen (defaults to `127.0.0.1`).
+
+### Changed
+- The argument `listen_at` of the endpoint `/http_gateway` has been renamed to `port`.
+
 
 
 ## 5.0.0 - 2024-07-22

--- a/rs/pocket_ic_server/src/main.rs
+++ b/rs/pocket_ic_server/src/main.rs
@@ -59,7 +59,10 @@ struct Args {
     /// the same server.
     #[clap(long)]
     pid: Option<u32>,
-    /// The port under which the PocketIC server should be started
+    /// The IP address at which the PocketIC server should listen (defaults to 127.0.0.1)
+    #[clap(long, short)]
+    ip_addr: Option<String>,
+    /// The port at which the PocketIC server should listen
     #[clap(long, short, default_value_t = 0)]
     port: u16,
     /// The file to which the PocketIC server port should be written
@@ -148,7 +151,8 @@ async fn start(runtime: Arc<Runtime>) {
         };
     }
 
-    let addr = format!("127.0.0.1:{}", args.port);
+    let ip_addr = args.ip_addr.unwrap_or("127.0.0.1".to_string());
+    let addr = format!("{}:{}", ip_addr, args.port);
     let listener = tokio::net::TcpListener::bind(&addr)
         .await
         .unwrap_or_else(|_| panic!("Failed to start PocketIC server on port {}", args.port));

--- a/rs/pocket_ic_server/src/state_api/state.rs
+++ b/rs/pocket_ic_server/src/state_api/state.rs
@@ -610,8 +610,11 @@ impl ApiState {
             next.run(request).await
         }
 
-        let port = http_gateway_config.listen_at.unwrap_or_default();
-        let addr = format!("[::]:{}", port);
+        let ip_addr = http_gateway_config
+            .ip_addr
+            .unwrap_or("127.0.0.1".to_string());
+        let port = http_gateway_config.port.unwrap_or_default();
+        let addr = format!("{}:{}", ip_addr, port);
         let listener = std::net::TcpListener::bind(&addr)
             .unwrap_or_else(|_| panic!("Failed to start HTTP gateway on port {}", port));
         let real_port = listener.local_addr().unwrap().port();

--- a/rs/pocket_ic_server/tests/test.rs
+++ b/rs/pocket_ic_server/tests/test.rs
@@ -14,7 +14,7 @@ use reqwest::Client as NonblockingClient;
 use reqwest::{StatusCode, Url};
 use std::io::Read;
 use std::io::Write;
-use std::net::{IpAddr, Ipv6Addr, SocketAddr};
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::path::PathBuf;
 use std::process::{Child, Command};
 use std::time::{Duration, Instant};
@@ -291,19 +291,19 @@ async fn test_gateway(https: bool) {
     let mut builder = NonblockingClient::builder()
         .resolve(
             localhost,
-            SocketAddr::new(IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1)), port),
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), port),
         )
         .resolve(
             sub_localhost,
-            SocketAddr::new(IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1)), port),
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), port),
         )
         .resolve(
             alt_domain,
-            SocketAddr::new(IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1)), port),
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), port),
         )
         .resolve(
             sub_alt_domain,
-            SocketAddr::new(IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1)), port),
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), port),
         );
     // add a custom root certificate
     if https {


### PR DESCRIPTION
The MR makes it possible to specify the IP address at which the PocketIC server and HTTP gateway should listen. The default used to be `[::]`, but it shouldn't take a firewall rule to prevent connections to the PocketIC server from all network interfaces.