### PR TITLE
chore: RUN-1025: Saturate function index in system api calls

### DIFF
--- a/rs/embedders/src/wasmtime_embedder/system_api.rs
+++ b/rs/embedders/src/wasmtime_embedder/system_api.rs
@@ -676,22 +676,8 @@ pub(crate) fn syscalls<
                 )?;
                 with_memory_and_system_api(&mut caller, |system_api, memory| {
                     // A valid function index should be much smaller than u32::max
-                    let reply_fun: u32 = reply_fun.try_into().map_err(|_| {
-                        HypervisorError::ToolchainContractViolation {
-                            error: format!(
-                                "ic0_call_new: reply function index out of bounds: {}",
-                                reply_fun
-                            ),
-                        }
-                    })?;
-                    let reject_fun: u32 = reject_fun.try_into().map_err(|_| {
-                        HypervisorError::ToolchainContractViolation {
-                            error: format!(
-                                "ic0_call_new: reject function index out of bounds: {}",
-                                reject_fun
-                            ),
-                        }
-                    })?;
+                    let reply_fun: u32 = reply_fun.try_into().unwrap_or(u32::MAX);
+                    let reject_fun: u32 = reject_fun.try_into().unwrap_or(u32::MAX);
                     system_api.ic0_call_new(
                         callee_src,
                         callee_size,
@@ -732,14 +718,7 @@ pub(crate) fn syscalls<
                 charge_for_cpu(&mut caller, overhead::CALL_ON_CLEANUP)?;
                 with_system_api(&mut caller, |s| {
                     // A valid function index should be much smaller than u32::max
-                    let fun: u32 = fun.try_into().map_err(|_| {
-                        HypervisorError::ToolchainContractViolation {
-                            error: format!(
-                                "ic0_call_on_cleanup: function index out of bounds: {}",
-                                fun
-                            ),
-                        }
-                    })?;
+                    let fun: u32 = fun.try_into().unwrap_or(u32::MAX);
                     s.ic0_call_on_cleanup(fun, env)
                 })
             }

--- a/rs/system_api/src/sandbox_safe_system_state.rs
+++ b/rs/system_api/src/sandbox_safe_system_state.rs
@@ -60,7 +60,7 @@ pub enum CallbackUpdate {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct SystemStateChanges {
     pub(super) new_certified_data: Option<Vec<u8>>,
-    pub(super) callback_updates: Vec<CallbackUpdate>,
+    pub callback_updates: Vec<CallbackUpdate>,
     cycles_balance_change: CyclesBalanceChange,
     // The cycles that move from the main balance to the reserved balance.
     // Invariant: `cycles_balance_change` contains

--- a/rs/system_api/src/sandbox_safe_system_state.rs
+++ b/rs/system_api/src/sandbox_safe_system_state.rs
@@ -60,6 +60,7 @@ pub enum CallbackUpdate {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct SystemStateChanges {
     pub(super) new_certified_data: Option<Vec<u8>>,
+    // pub for testing
     pub callback_updates: Vec<CallbackUpdate>,
     cycles_balance_change: CyclesBalanceChange,
     // The cycles that move from the main balance to the reserved balance.


### PR DESCRIPTION
Allow the canister to specify -1 (and other values >= u32::MAX) as a function index