### PR TITLE
feat(nns): Disallow SetVisibility ManageNeuron proposals.

### DIFF
--- a/rs/nns/governance/src/governance.rs
+++ b/rs/nns/governance/src/governance.rs
@@ -379,7 +379,8 @@ impl ManageNeuron {
             return false;
         };
 
-        let Some(manage_neuron::configure::Operation::SetVisibility(_)) = configure.operation else {
+        let Some(manage_neuron::configure::Operation::SetVisibility(_)) = configure.operation
+        else {
             return false;
         };
 

--- a/rs/nns/governance/src/governance.rs
+++ b/rs/nns/governance/src/governance.rs
@@ -4233,21 +4233,6 @@ impl Governance {
                             managed_neuron_id,
                             |managed_neuron| managed_neuron.controller(),
                         ) {
-                            // TODO(NNS1-3228): Delete this.
-                            if mgmt.is_set_visibility() {
-                                self.set_proposal_execution_status(
-                                    pid,
-                                    Err(GovernanceError::new_with_message(
-                                        ErrorType::Unavailable,
-                                        "Setting neuron visibility via proposal is not allowed yet, \
-                                         but it will be in the not too distant future. If you need \
-                                         this sooner, please, start a new thread at forum.dfinity.org \
-                                         and describe your use case.".to_string(),
-                                    )),
-                                );
-                                return;
-                            }
-
                             let result = self.manage_neuron(&controller, &mgmt).await;
                             match result.command {
                                 Some(manage_neuron_response::Command::Error(err)) => {
@@ -4737,6 +4722,18 @@ impl Governance {
         &self,
         manage_neuron: &ManageNeuron,
     ) -> Result<(), GovernanceError> {
+        // TODO(NNS1-3228): Delete this.
+        if manage_neuron.is_set_visibility() {
+            return Err(GovernanceError::new_with_message(
+                ErrorType::Unavailable,
+                "Setting neuron visibility via proposal is not allowed yet, \
+                 but it will be in the not too distant future. If you need \
+                 this sooner, please, start a new thread at forum.dfinity.org \
+                 and describe your use case."
+                    .to_string(),
+            ));
+        }
+
         let manage_neuron = ManageNeuron::from_proto(manage_neuron.clone()).map_err(|e| {
             GovernanceError::new_with_message(
                 ErrorType::InvalidCommand,

--- a/rs/nns/governance/src/governance.rs
+++ b/rs/nns/governance/src/governance.rs
@@ -379,12 +379,10 @@ impl ManageNeuron {
             return false;
         };
 
-        let Some(manage_neuron::configure::Operation::SetVisibility(_)) = configure.operation
-        else {
-            return false;
-        };
-
-        true
+        matches!(
+            configure.operation,
+            Some(manage_neuron::configure::Operation::SetVisibility(_)),
+        )
     }
 }
 

--- a/rs/nns/governance/tests/governance.rs
+++ b/rs/nns/governance/tests/governance.rs
@@ -6313,6 +6313,87 @@ fn test_add_and_remove_hot_key() {
         .contains(neuron.id.as_ref().unwrap()));
 }
 
+// TODO(NNS1-3228): Delete this.
+#[test]
+fn test_set_visibility_manage_neuron_proposals_are_not_allowed_yet() {
+    // Step 1: Prepare the world.
+
+    let p = match std::env::var("NEURON_CSV_PATH") {
+        Ok(v) => PathBuf::from(v),
+        Err(_) => PathBuf::from("tests/neurons.csv"),
+    };
+    let mut builder = GovernanceCanisterInitPayloadBuilder::new();
+    let init_neurons = &mut builder.add_all_neurons_from_csv_file(&p).proto.neurons;
+
+    let (_, mut gov) = governance_with_neurons(
+        &init_neurons
+            .values()
+            .map(|n| n.clone().into())
+            .collect::<Vec<Neuron>>(),
+    );
+
+    let neuron = init_neurons[&25].clone();
+    let new_controller = init_neurons[&42].controller.unwrap();
+
+    assert!(!gov
+        .neuron_store
+        .get_neuron_ids_readable_by_caller(new_controller)
+        .contains(neuron.id.as_ref().unwrap()));
+
+    // Step 2: Call the code under test.
+
+    // Add a hot key to the neuron and make sure that gets reflected in the
+    // principal to neuron ids index.
+    let error = gov
+        .make_proposal(
+            neuron.id.as_ref().unwrap(),
+            neuron.controller.as_ref().unwrap(),
+            &Proposal {
+                title: Some("SetVisibility".to_string()),
+                summary: "SetVisibility".to_string(),
+                url: "https://forum.dfinity.org/set_visibility".to_string(),
+                action: Some(proposal::Action::ManageNeuron(Box::new(ManageNeuron {
+                    neuron_id_or_subaccount: Some(NeuronIdOrSubaccount::NeuronId(
+                        neuron.id.unwrap(),
+                    )),
+                    command: Some(manage_neuron::Command::Configure(
+                        manage_neuron::Configure {
+                            operation: Some(manage_neuron::configure::Operation::SetVisibility(
+                                SetVisibility {
+                                    visibility: Some(Visibility::Public as i32),
+                                },
+                            )),
+                        },
+                    )),
+                    id: None,
+                }))),
+            },
+        )
+        .unwrap_err();
+
+    // Step 3: Inspect results.
+
+    // Decompose the error.
+    let GovernanceError {
+        error_type,
+        error_message,
+    } = &error;
+
+    // Inspect the error type.
+    assert_eq!(
+        ErrorType::try_from(*error_type),
+        Ok(ErrorType::Unavailable),
+        "{:?}",
+        error,
+    );
+
+    // Make sure the error message looks right.
+    let message = error_message.to_lowercase();
+    for key_word in ["visibility", "allowed", "yet"] {
+        assert!(message.contains(key_word), "{:?}", error);
+    }
+}
+
 #[test]
 fn test_manage_and_reward_node_providers() {
     let p = match std::env::var("NEURON_CSV_PATH") {


### PR DESCRIPTION
Because this is new, and clients (e.g. nns-dapp) do not yet have the latest governance.did to fully deserialize these.

(Technically, clients can partially deserialize such proposals. Also, technically, clients could dynamically fetch the latest governance.did file, but this is a more advanced technique and not the typical way to do things.).

Closes [NNS1-3224](https://dfinity.atlassian.net/browse/NNS1-3224).

This will be reverted per [NNS1-3228](https://dfinity.atlassian.net/browse/NNS1-3228).

[NNS1-3228]: https://dfinity.atlassian.net/browse/NNS1-3228?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[NNS1-3224]: https://dfinity.atlassian.net/browse/NNS1-3224?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ