### PR TITLE
chore: Use a single sentence for error messages in IngressInductionError

### DIFF
--- a/rs/execution_environment/tests/canister_logging.rs
+++ b/rs/execution_environment/tests/canister_logging.rs
@@ -149,7 +149,7 @@ fn test_fetch_canister_logs_via_execute_ingress() {
         result,
         Err(UserError::new(
             ErrorCode::CanisterRejectedMessage,
-            "Cannot enqueue management message. Method fetch_canister_logs is not allowed to be called via ingress messages.",
+            "Cannot enqueue management message because fetch_canister_logs method is not allowed to be called via ingress messages.",
         ))
     );
 }

--- a/rs/interfaces/src/messaging.rs
+++ b/rs/interfaces/src/messaging.rs
@@ -179,17 +179,17 @@ impl std::fmt::Display for IngressInductionError {
             IngressInductionError::CanisterOutOfCycles(err) => write!(f, "{}", err),
             IngressInductionError::CanisterMethodNotFound(method) => write!(
                 f,
-                "Cannot enqueue management message. Method {} is unknown.",
+                "Cannot enqueue management message because {} method is unknown.",
                 method
             ),
             IngressInductionError::SubnetMethodNotAllowed(method) => write!(
                 f,
-                "Cannot enqueue management message. Method {} is not allowed to be called via ingress messages.",
+                "Cannot enqueue management message because {} method is not allowed to be called via ingress messages.",
                 method
             ),
             IngressInductionError::InvalidManagementPayload => write!(
                 f,
-                "Cannot enqueue management message. Candid payload is invalid."
+                "Cannot enqueue management message because its Candid payload is invalid."
             ),
             IngressInductionError::IngressHistoryFull { capacity } => {
                 write!(f, "Maximum ingress history capacity {} reached", capacity)


### PR DESCRIPTION
This is a follow-up to https://github.com/dfinity/ic/pull/540 that uses a single sentence for some error messages in `IngressInductionError`. Having two sentences seems somewhat redundant while a single sentence feels indeed a bit more readable.