### PR TITLE
chore(nns): Remove DTS config for NNS StateMachine tests (using defaults set at system level)

### DIFF
--- a/rs/nns/test_utils/src/state_test_helpers.rs
+++ b/rs/nns/test_utils/src/state_test_helpers.rs
@@ -13,7 +13,6 @@ use dfn_candid::candid_one;
 use dfn_http::types::{HttpRequest, HttpResponse};
 use dfn_protobuf::ToProto;
 use ic_base_types::{CanisterId, PrincipalId, SubnetId};
-use ic_config::{execution_environment::Config, subnet_config::SubnetConfig};
 use ic_management_canister_types::{
     CanisterInstallMode, CanisterSettingsArgs, CanisterSettingsArgsBuilder, CanisterStatusResultV2,
     UpdateSettingsArgs,
@@ -55,7 +54,6 @@ use ic_nns_governance::pb::v1::{
 };
 use ic_nns_handler_lifeline_interface::UpgradeRootProposal;
 use ic_nns_handler_root::init::RootCanisterInitPayload;
-use ic_registry_subnet_type::SubnetType;
 use ic_sns_governance::pb::v1::{
     self as sns_pb, manage_neuron_response::Command as SnsCommandResponse, GetModeResponse,
 };
@@ -64,11 +62,11 @@ use ic_sns_wasm::{
     init::SnsWasmCanisterInitPayload,
     pb::v1::{ListDeployedSnsesRequest, ListDeployedSnsesResponse},
 };
-use ic_state_machine_tests::{StateMachine, StateMachineBuilder, StateMachineConfig};
+use ic_state_machine_tests::{StateMachine, StateMachineBuilder};
 use ic_test_utilities::universal_canister::{
     call_args, wasm as universal_canister_argument_builder, UNIVERSAL_CANISTER_WASM,
 };
-use ic_types::{ingress::WasmResult, Cycles, NumInstructions};
+use ic_types::{ingress::WasmResult, Cycles};
 use icp_ledger::{AccountIdentifier, BinaryAccountBalanceArgs, BlockIndex, Memo, SendArgs, Tokens};
 use icrc_ledger_types::icrc1::{
     account::Account,
@@ -86,28 +84,12 @@ use std::{convert::TryInto, env, time::Duration};
 /// is omitted so that the canister range of the II subnet is not used
 /// for automatic generation of new canister IDs.
 pub fn state_machine_builder_for_nns_tests() -> StateMachineBuilder {
-    // TODO, remove when this is the value set in the normal IC build
-    // This is to uncover issues in testing that might affect performance in production
-    const MAX_INSTRUCTIONS_PER_SLICE: NumInstructions = NumInstructions::new(2_000_000_000); // 2 Billion is the value used in app subnets
-    const MAX_INSTRUCTIONS_PER_INSTALL_CODE_SLICE: NumInstructions =
-        NumInstructions::new(2_000_000_000);
-
-    let mut subnet_config = SubnetConfig::new(SubnetType::System);
-    subnet_config.scheduler_config.max_instructions_per_slice = MAX_INSTRUCTIONS_PER_SLICE;
-    subnet_config
-        .scheduler_config
-        .max_instructions_per_install_code_slice = MAX_INSTRUCTIONS_PER_INSTALL_CODE_SLICE;
-
     StateMachineBuilder::new()
         .with_current_time()
         .with_extra_canister_range(std::ops::RangeInclusive::<CanisterId>::new(
             CanisterId::from_u64(0x2100000),
             CanisterId::from_u64(0x21FFFFE),
         ))
-        .with_config(Some(StateMachineConfig::new(
-            subnet_config,
-            Config::default(),
-        )))
 }
 
 /// Turn down state machine logging to just errors to reduce noise in tests where this is not relevant


### PR DESCRIPTION
Deterministic Time Slicing, which allows large messages to execute across multiple rounds, was being tested in advance of releasing it as system settings.

Now that t[he system settings are being updated](https://github.com/dfinity/ic/pull/621), we no longer need special configuration to test this on system subnets.