### PR TITLE
refactor(crypto): CRP-2559 remove CspSigVerifier

### DIFF
--- a/rs/crypto/BUILD.bazel
+++ b/rs/crypto/BUILD.bazel
@@ -14,6 +14,7 @@ package(default_visibility = ["//visibility:public"])
 DEPENDENCIES = [
     # Keep sorted.
     "//rs/config",
+    "//rs/crypto/ed25519",
     "//rs/crypto/interfaces/sig_verification",
     "//rs/crypto/internal/crypto_lib/basic_sig/ed25519",
     "//rs/crypto/internal/crypto_lib/seed",
@@ -60,7 +61,6 @@ DEV_DEPENDENCIES = [
     "//rs/certification/test-utils",
     "//rs/crypto/ecdsa_secp256k1",
     "//rs/crypto/ecdsa_secp256r1",
-    "//rs/crypto/ed25519",
     "//rs/crypto/for_verification_only",
     "//rs/crypto/internal/crypto_lib/basic_sig/der_utils",
     "//rs/crypto/internal/crypto_lib/basic_sig/ecdsa_secp256k1",

--- a/rs/crypto/Cargo.toml
+++ b/rs/crypto/Cargo.toml
@@ -15,6 +15,7 @@ ic-adapter-metrics-server = { path = "../monitoring/adapter_metrics/server" }
 ic-async-utils = { path = "../async_utils" }
 ic-base-types = { path = "../types/base_types" }
 ic-config = { path = "../config" }
+ic-crypto-ed25519 = { path = "ed25519" }
 ic-crypto-ecdsa-secp256r1 = { path = "ecdsa_secp256r1" }
 ic-crypto-ecdsa-secp256k1 = { path = "ecdsa_secp256k1" }
 ic-crypto-interfaces-sig-verification = { path = "interfaces/sig_verification" }
@@ -51,7 +52,6 @@ tokio = { workspace = true }
 assert_matches = { workspace = true }
 criterion = { workspace = true }
 ic-certification-test-utils = { path = "../certification/test-utils" }
-ic-crypto-ed25519 = { path = "ed25519" }
 ic-crypto-for-verification-only = { path = "for_verification_only" }
 ic-crypto-internal-basic-sig-der-utils = { path = "internal/crypto_lib/basic_sig/der_utils" }
 ic-crypto-internal-basic-sig-ecdsa-secp256r1 = { path = "internal/crypto_lib/basic_sig/ecdsa_secp256r1" }

--- a/rs/crypto/internal/crypto_service_provider/src/api/mod.rs
+++ b/rs/crypto/internal/crypto_service_provider/src/api/mod.rs
@@ -5,7 +5,7 @@ mod sign;
 mod threshold;
 
 pub use canister_threshold::CspCreateMEGaKeyError;
-pub use sign::{CspSigVerifier, CspSigner};
+pub use sign::CspSigner;
 pub use threshold::{
     threshold_sign_error::CspThresholdSignError, NiDkgCspClient, ThresholdSignatureCspClient,
 };

--- a/rs/crypto/internal/crypto_service_provider/src/api/sign.rs
+++ b/rs/crypto/internal/crypto_service_provider/src/api/sign.rs
@@ -112,29 +112,3 @@ pub trait CspSigner {
         algorithm_id: AlgorithmId,
     ) -> CryptoResult<()>;
 }
-
-pub trait CspSigVerifier {
-    /// Verifies a batch of signatures under different public keys for the same message.
-    /// # Arguments
-    /// * `key_signature_pairs` pairs of public keys and signatures to be verified
-    /// * `msg` the message data to be verified
-    /// * `algorithm_id` the signature algorithm
-    /// # Errors
-    /// * [`CryptoError::InternalError`] in case of internal CSP error, e.g., if
-    ///   the CSP failed to generate the required randomness.
-    /// * [`CryptoError::SignatureVerification`] if the signature algorithm used
-    ///   is not supported by the trait implementation, or if the signature was
-    ///   checked and found to be invalid.
-    /// * [`CryptoError::MalformedPublicKey`] if the public key seems to be
-    ///   invalid or malformed
-    /// * [`CryptoError::MalformedSignature`] if the signature seems to be invalid
-    ///   or malformed
-    /// # Returns
-    /// `Ok(())` if the signature is valid or an `Err` otherwise
-    fn verify_batch(
-        &self,
-        key_signature_pairs: &[(CspPublicKey, CspSignature)],
-        msg: &[u8],
-        algorithm_id: AlgorithmId,
-    ) -> CryptoResult<()>;
-}

--- a/rs/crypto/internal/crypto_service_provider/src/lib.rs
+++ b/rs/crypto/internal/crypto_service_provider/src/lib.rs
@@ -24,7 +24,7 @@ pub use crate::vault::local_csp_vault::LocalCspVault;
 pub use crate::vault::remote_csp_vault::run_csp_vault_server;
 pub use crate::vault::remote_csp_vault::RemoteCspVault;
 
-use crate::api::{CspSigVerifier, CspSigner, NiDkgCspClient, ThresholdSignatureCspClient};
+use crate::api::{CspSigner, NiDkgCspClient, ThresholdSignatureCspClient};
 use crate::secret_key_store::SecretKeyStore;
 use crate::types::{CspPublicKey, ExternalPublicKeys};
 use crate::vault::api::CspVault;
@@ -41,15 +41,10 @@ mod tests;
 
 /// Describes the interface of the crypto service provider (CSP), e.g. for
 /// signing and key generation. The Csp struct implements this trait.
-pub trait CryptoServiceProvider:
-    CspSigner + CspSigVerifier + ThresholdSignatureCspClient + NiDkgCspClient
-{
-}
+pub trait CryptoServiceProvider: CspSigner + ThresholdSignatureCspClient + NiDkgCspClient {}
 
-impl<T> CryptoServiceProvider for T where
-    T: CspSigner + CspSigVerifier + ThresholdSignatureCspClient + NiDkgCspClient
-{
-}
+impl<T> CryptoServiceProvider for T where T: CspSigner + ThresholdSignatureCspClient + NiDkgCspClient
+{}
 
 /// Implements `CryptoServiceProvider` that uses a `CspVault` for
 /// storing and managing secret keys.

--- a/rs/crypto/internal/crypto_service_provider/src/signer/mod.rs
+++ b/rs/crypto/internal/crypto_service_provider/src/signer/mod.rs
@@ -1,11 +1,9 @@
-use super::api::{CspSigVerifier, CspSigner};
+use super::api::CspSigner;
 use super::types::{CspPop, CspPublicKey, CspSignature};
 use super::Csp;
 use crate::key_id::KeyId;
 use crate::types::MultiBls12_381_Signature;
 use crate::vault::api::{CspBasicSignatureError, CspMultiSignatureError};
-use ed25519::types::PublicKeyBytes;
-use ed25519::types::SignatureBytes;
 use ic_crypto_internal_basic_sig_ecdsa_secp256k1 as ecdsa_secp256k1;
 use ic_crypto_internal_basic_sig_ecdsa_secp256r1 as ecdsa_secp256r1;
 use ic_crypto_internal_basic_sig_ed25519 as ed25519;
@@ -206,84 +204,5 @@ impl CspSigner for Csp {
                 reason: "Not a multi-signature algorithm".to_string(),
             }),
         }
-    }
-}
-
-impl CspSigVerifier for Csp {
-    fn verify_batch(
-        &self,
-        key_signature_pairs: &[(CspPublicKey, CspSignature)],
-        msg: &[u8],
-        algorithm_id: AlgorithmId,
-    ) -> CryptoResult<()> {
-        // check that the public keys' `AlgorithmId` field is consistent with `algorithm_id`
-        for (pk, sig) in key_signature_pairs.iter() {
-            if pk.algorithm_id() != algorithm_id {
-                return Err(CryptoError::SignatureVerification {
-                    algorithm: pk.algorithm_id(),
-                    public_key_bytes: pk.pk_bytes().to_vec(),
-                    sig_bytes: sig.as_ref().to_vec(),
-                    internal_error: format!(
-                        "Invalid public key type: expected {algorithm_id} but found {}",
-                        pk.algorithm_id()
-                    ),
-                });
-            };
-        }
-
-        match algorithm_id {
-            // use more efficient batch verification for Ed25519
-            AlgorithmId::Ed25519 => {
-                // generate a random seed to be used in batched sig verification
-                let seed = self.csp_vault.new_public_seed()?;
-                // define a closure to convert a public key and a `CspSignature::Ed25519` to bytes
-                // or return an error if the input is not using Ed25519
-                let pk_and_sig_to_bytes =
-                    |pk: &CspPublicKey,
-                     sig: &CspSignature|
-                     -> CryptoResult<(PublicKeyBytes, SignatureBytes)> {
-                        let sig_bytes = match sig {
-                            CspSignature::Ed25519(bytes) => bytes.0.to_owned(),
-                            sig => {
-                                return Err(CryptoError::SignatureVerification {
-                                    algorithm: pk.algorithm_id(),
-                                    public_key_bytes: pk.pk_bytes().to_vec(),
-                                    sig_bytes: sig.as_ref().to_vec(),
-                                    internal_error: format!(
-                                    "Invalid signature type: expected {algorithm_id} but found {}",
-                                    sig.algorithm()
-                                ),
-                                })
-                            }
-                        };
-                        let mut pk_bytes = [0u8; 32];
-                        pk_bytes.copy_from_slice(pk.pk_bytes());
-
-                        Ok((PublicKeyBytes(pk_bytes), SignatureBytes(sig_bytes)))
-                    };
-
-                let key_sig_bytes_pairs: Vec<(PublicKeyBytes, SignatureBytes)> =
-                    key_signature_pairs
-                        .iter()
-                        .map(|(pk, sig)| pk_and_sig_to_bytes(pk, sig))
-                        .collect::<Result<Vec<_>, _>>()?;
-
-                // False positive `map_identity` warning.
-                // See: https://github.com/rust-lang/rust-clippy/pull/11792 (merged)
-                #[allow(clippy::map_identity)]
-                let pairs_of_refs: Vec<_> = key_sig_bytes_pairs
-                    .iter()
-                    .map(|(pk_bytes, sig_bytes)| (pk_bytes, sig_bytes))
-                    .collect();
-                ed25519::api::verify_batch(&pairs_of_refs[..], msg, seed)?;
-            }
-            // use iterative verification for other `AlgorithmId`s
-            _ => {
-                for (pk, sig) in key_signature_pairs {
-                    self.verify(sig, msg, algorithm_id, (*pk).to_owned())?;
-                }
-            }
-        }
-        Ok(())
     }
 }

--- a/rs/crypto/internal/crypto_service_provider/src/signer/tests.rs
+++ b/rs/crypto/internal/crypto_service_provider/src/signer/tests.rs
@@ -13,9 +13,7 @@ use crate::{LocalCspVault, SecretKeyStore};
 use assert_matches::assert_matches;
 use ic_crypto_internal_multi_sig_bls12381::types as multi_types;
 use ic_crypto_internal_seed::Seed;
-use ic_crypto_internal_test_vectors::ed25519::Ed25519TestVector::{
-    RFC8032_ED25519_1, RFC8032_ED25519_SHA_ABC,
-};
+use ic_crypto_internal_test_vectors::ed25519::Ed25519TestVector::RFC8032_ED25519_SHA_ABC;
 use ic_crypto_internal_test_vectors::multi_bls12_381::{
     TESTVEC_MULTI_BLS12_381_1_PK, TESTVEC_MULTI_BLS12_381_1_SIG,
 };
@@ -331,8 +329,6 @@ mod verify_ed25519 {
     use super::*;
     use rand::{CryptoRng, Rng};
 
-    const FIXED_BATCH_SIZE: usize = 10;
-
     // Here we only test with a single test vector: an extensive test with the
     // entire test vector suite is done at the crypto lib level.
     #[test]
@@ -344,33 +340,6 @@ mod verify_ed25519 {
         assert_eq!(csp.verify(&sig, &msg, AlgorithmId::Ed25519, pk), Ok(()));
     }
 
-    /// Runs basic tests for batch verification of Ed25519 signatures for different input sizes.
-    /// More extensive tests can be found in the tests of `ic-crypto-internal-basic-sig-ed25519` crate.
-    #[test]
-    fn should_correctly_verify_batch_consistently_with_non_batched() {
-        let rng = &mut reproducible_rng();
-        let msg = utils::random_message(rng);
-
-        for batch_size in [1, 2, 3, 4, 5, 10, 20, 50, 100] {
-            let fixtures = Fixture::new_batch(&msg[..], batch_size, rng);
-            let key_sig_pairs = utils::copy_key_sig_pairs(&fixtures[..]);
-
-            for csp in fixtures.iter().map(|f| &f.csp) {
-                assert_eq!(
-                    csp.verify_batch(&key_sig_pairs[..], &msg[..], AlgorithmId::Ed25519),
-                    Ok(())
-                );
-            }
-
-            for Fixture { csp, pk, sig } in fixtures.iter() {
-                assert_eq!(
-                    csp.verify(sig, &msg[..], AlgorithmId::Ed25519, pk.to_owned()),
-                    Ok(())
-                );
-            }
-        }
-    }
-
     #[test]
     fn should_correctly_verify_with_other_csp() {
         let rng = &mut reproducible_rng();
@@ -379,21 +348,6 @@ mod verify_ed25519 {
 
         assert_eq!(
             utils::new_csp(rng).verify(&sig, &msg, AlgorithmId::Ed25519, pk),
-            Ok(())
-        );
-    }
-
-    #[test]
-    fn should_correctly_verify_batch_with_other_csp() {
-        let rng = &mut reproducible_rng();
-        let msg = utils::random_message(rng);
-
-        let fixtures = Fixture::new_batch(&msg[..], FIXED_BATCH_SIZE, rng);
-        let key_sig_pairs = utils::copy_key_sig_pairs(&fixtures[..]);
-        let csp = utils::new_csp(rng);
-
-        assert_eq!(
-            csp.verify_batch(&key_sig_pairs[..], &msg[..], AlgorithmId::Ed25519),
             Ok(())
         );
     }
@@ -413,27 +367,6 @@ mod verify_ed25519 {
     }
 
     #[test]
-    fn should_fail_to_verify_batch_under_signature_with_wrong_public_key() {
-        let rng = &mut reproducible_rng();
-        let msg = utils::random_message(rng);
-
-        let fixtures = Fixture::new_batch(&msg[..], FIXED_BATCH_SIZE, rng);
-        let mut key_sig_pairs = utils::copy_key_sig_pairs(&fixtures[..]);
-        let csp = &fixtures[0].csp;
-
-        let Fixture { sig: wrong_sig, .. } = Fixture::new(&msg[..], rng);
-
-        let (_pk, sig) = utils::random_from(&mut key_sig_pairs[..], rng);
-        assert_ne!(*sig, wrong_sig);
-        *sig = wrong_sig;
-
-        assert_matches!(
-            csp.verify_batch(&key_sig_pairs[..], &msg[..], AlgorithmId::Ed25519),
-            Err(CryptoError::SignatureVerification { .. })
-        );
-    }
-
-    #[test]
     fn should_fail_to_verify_under_wrong_message() {
         let rng = &mut reproducible_rng();
         let msg = utils::random_message(rng);
@@ -443,28 +376,6 @@ mod verify_ed25519 {
 
         assert_matches!(
             csp.verify(&sig, wrong_msg, AlgorithmId::Ed25519, pk),
-            Err(CryptoError::SignatureVerification { .. })
-        );
-    }
-
-    #[test]
-    fn should_fail_to_verify_batch_under_wrong_message() {
-        let rng = &mut reproducible_rng();
-        let msg = utils::random_message(rng);
-
-        let fixtures = Fixture::new_batch(&msg[..], FIXED_BATCH_SIZE, rng);
-        let key_sig_pairs = utils::copy_key_sig_pairs(&fixtures[..]);
-        let csp = &fixtures[0].csp;
-
-        let wrong_msg = loop {
-            let tmp_msg = utils::random_message(rng);
-            if tmp_msg != msg {
-                break tmp_msg;
-            }
-        };
-
-        assert_matches!(
-            csp.verify_batch(&key_sig_pairs[..], &wrong_msg[..], AlgorithmId::Ed25519),
             Err(CryptoError::SignatureVerification { .. })
         );
     }
@@ -484,27 +395,6 @@ mod verify_ed25519 {
     }
 
     #[test]
-    fn should_fail_to_verify_batch_under_wrong_public_key() {
-        let rng = &mut reproducible_rng();
-        let msg = utils::random_message(rng);
-
-        let fixtures = Fixture::new_batch(&msg[..], FIXED_BATCH_SIZE, rng);
-        let mut key_sig_pairs = utils::copy_key_sig_pairs(&fixtures[..]);
-        let csp = &fixtures[0].csp;
-
-        let Fixture { pk: wrong_pk, .. } = Fixture::new(&msg[..], rng);
-
-        let (pk, _sig) = utils::random_from(&mut key_sig_pairs[..], rng);
-        assert_ne!(*pk, wrong_pk);
-        *pk = wrong_pk;
-
-        assert_matches!(
-            csp.verify_batch(&key_sig_pairs[..], &msg[..], AlgorithmId::Ed25519),
-            Err(CryptoError::SignatureVerification { .. })
-        );
-    }
-
-    #[test]
     fn should_fail_to_verify_if_signature_has_wrong_type() {
         let rng = &mut reproducible_rng();
         let msg = utils::random_message(rng);
@@ -514,27 +404,6 @@ mod verify_ed25519 {
 
         assert_matches!(
             csp.verify(&sig_with_wrong_type, &msg, AlgorithmId::Ed25519, pk),
-            Err(CryptoError::SignatureVerification { .. })
-        );
-    }
-
-    #[test]
-    fn should_fail_to_verify_batch_if_signature_has_wrong_type() {
-        let rng = &mut reproducible_rng();
-        let msg = utils::random_message(rng);
-
-        let fixtures = Fixture::new_batch(&msg[..], FIXED_BATCH_SIZE, rng);
-        let mut key_sig_pairs = utils::copy_key_sig_pairs(&fixtures[..]);
-        let csp = &fixtures[0].csp;
-
-        let sig_with_wrong_type =
-            CspSignature::multi_bls12381_individual_from_hex(TESTVEC_MULTI_BLS12_381_1_SIG);
-
-        let (_pk, sig) = utils::random_from(&mut key_sig_pairs[..], rng);
-        *sig = sig_with_wrong_type;
-
-        assert_matches!(
-            csp.verify_batch(&key_sig_pairs[..], &msg[..], AlgorithmId::Ed25519),
             Err(CryptoError::SignatureVerification { .. })
         );
     }
@@ -554,27 +423,6 @@ mod verify_ed25519 {
     }
 
     #[test]
-    fn should_fail_to_verify_batch_if_signer_public_key_has_wrong_type() {
-        let rng = &mut reproducible_rng();
-        let msg = utils::random_message(rng);
-
-        let fixtures = Fixture::new_batch(&msg[..], FIXED_BATCH_SIZE, rng);
-        let mut key_sig_pairs = utils::copy_key_sig_pairs(&fixtures[..]);
-        let csp = &fixtures[0].csp;
-
-        let pk_with_wrong_type =
-            CspPublicKey::multi_bls12381_from_hex(TESTVEC_MULTI_BLS12_381_1_PK);
-
-        let (pk, _sig) = utils::random_from(&mut key_sig_pairs[..], rng);
-        *pk = pk_with_wrong_type;
-
-        assert_matches!(
-            csp.verify_batch(&key_sig_pairs[..], &msg[..], AlgorithmId::Ed25519),
-            Err(CryptoError::SignatureVerification { .. })
-        );
-    }
-
-    #[test]
     fn should_fail_to_verify_under_wrong_algorithm_id() {
         let rng = &mut reproducible_rng();
         let msg = utils::random_message(rng);
@@ -585,22 +433,6 @@ mod verify_ed25519 {
             assert_matches!(
                 csp.verify(&sig, &msg[..], wrong_algorithm_id, pk.to_owned()),
                 Err(CryptoError::SignatureVerification { .. })
-            );
-        }
-    }
-
-    #[test]
-    fn should_fail_to_verify_batch_under_wrong_algorithm_id() {
-        let rng = &mut reproducible_rng();
-        let msg = utils::random_message(rng);
-
-        let fixtures = Fixture::new_batch(&msg[..], FIXED_BATCH_SIZE, rng);
-        let key_sig_pairs = utils::copy_key_sig_pairs(&fixtures[..]);
-
-        for wrong_algorithm_id in AlgorithmId::iter().filter(|id| *id != AlgorithmId::Ed25519) {
-            assert_matches!(
-                fixtures[0].csp.verify_batch(&key_sig_pairs[..], &msg[..], wrong_algorithm_id),
-                Err(e) if e.to_string().contains("Invalid public key type")
             );
         }
     }
@@ -624,21 +456,6 @@ mod verify_ed25519 {
             let mut msg = vec![0u8; rng.gen_range(0..RANDOM_MSG_MAX_LEN)];
             rng.fill_bytes(&mut msg[..]);
             msg
-        }
-
-        pub fn copy_key_sig_pairs(fixtures: &[Fixture]) -> Vec<(CspPublicKey, CspSignature)> {
-            fixtures
-                .iter()
-                .map(|f| (f.pk.clone(), f.sig.clone()))
-                .collect()
-        }
-
-        pub fn random_from<'a, T, R: Rng + CryptoRng>(
-            values: &'a mut [T],
-            rng: &mut R,
-        ) -> &'a mut T {
-            debug_assert!(!values.is_empty());
-            &mut values[rng.gen_range(0..values.len())]
         }
     }
 
@@ -672,9 +489,9 @@ mod verify_ed25519 {
             Self { csp, pk, sig }
         }
 
-        pub fn new_batch<R: Rng + CryptoRng>(msg: &[u8], size: usize, rng: &mut R) -> Vec<Self> {
-            (0..size).map(|_| Fixture::new(msg, rng)).collect()
-        }
+        // pub fn new_batch<R: Rng + CryptoRng>(msg: &[u8], size: usize, rng: &mut R) -> Vec<Self> {
+        //     (0..size).map(|_| Fixture::new(msg, rng)).collect()
+        // }
     }
 }
 
@@ -983,28 +800,28 @@ mod multi {
     }
 }
 
-mod batch {
-    use super::*;
+// mod batch {
+//     use super::*;
 
-    #[test]
-    fn should_verify_batch_of_single_signature_without_querying_secret_key_store() {
-        let (_sk, pk, msg, sig) = csp_testvec(RFC8032_ED25519_1);
-        let verifier = Csp::builder_for_test()
-            .with_vault(
-                LocalCspVault::builder_for_test()
-                    .with_mock_stores()
-                    .with_node_secret_key_store(secret_key_store_panicking_on_usage())
-                    .build(),
-            )
-            .build();
-        let key_signature_pairs = vec![(pk, sig)];
-        let algorithm_id = AlgorithmId::Ed25519;
+//     #[test]
+//     fn should_verify_batch_of_single_signature_without_querying_secret_key_store() {
+//         let (_sk, pk, msg, sig) = csp_testvec(RFC8032_ED25519_1);
+//         let verifier = Csp::builder_for_test()
+//             .with_vault(
+//                 LocalCspVault::builder_for_test()
+//                     .with_mock_stores()
+//                     .with_node_secret_key_store(secret_key_store_panicking_on_usage())
+//                     .build(),
+//             )
+//             .build();
+//         let key_signature_pairs = vec![(pk, sig)];
+//         let algorithm_id = AlgorithmId::Ed25519;
 
-        let result = verifier.verify_batch(&key_signature_pairs, &msg, algorithm_id);
+//         let result = verifier.verify_batch(&key_signature_pairs, &msg, algorithm_id);
 
-        assert_matches!(result, Ok(()));
-    }
-}
+//         assert_matches!(result, Ok(()));
+//     }
+// }
 
 fn vault_builder_with_different_seeds<const N: usize>() -> [LocalCspVaultBuilder<
     rand_chacha::ChaCha20Rng,

--- a/rs/crypto/src/sign/basic_sig.rs
+++ b/rs/crypto/src/sign/basic_sig.rs
@@ -1,7 +1,8 @@
 use super::*;
-use ic_crypto_internal_csp::api::{CspSigVerifier, CspSigner};
+use ic_crypto_internal_csp::api::CspSigner;
 use ic_crypto_internal_csp::key_id::KeyId;
 use ic_crypto_internal_csp::types::SigConverter;
+use ic_crypto_internal_csp::vault::api::PublicRandomSeedGeneratorError;
 
 #[cfg(test)]
 mod tests;
@@ -44,8 +45,8 @@ impl BasicSigVerifierInternal {
         Ok(BasicSignatureBatch { signatures_map })
     }
 
-    pub fn verify_basic_sig_batch<S: CspSigVerifier, H: Signable>(
-        csp_signer: &S,
+    pub fn verify_basic_sig_batch<H: Signable>(
+        vault: &dyn CspVault,
         registry: &dyn RegistryClient,
         signatures: &BasicSignatureBatch<H>,
         message: &H,
@@ -53,47 +54,54 @@ impl BasicSigVerifierInternal {
     ) -> CryptoResult<()> {
         if signatures.signatures_map.is_empty() {
             return Err(CryptoError::InvalidArgument {
-            message:
-                "Empty BasicSignatureBatch. At least one signature should be included in the batch."
-                    .to_string(),
-        });
+                message: "Empty BasicSignatureBatch. At least one signature should be included in the batch.".to_string(),
+            });
         };
-        let mut pk_sig_pairs =
-            Vec::<(CspPublicKey, CspSignature)>::with_capacity(signatures.signatures_map.len());
-        let mut first_algorithm_id: Option<AlgorithmId> = None;
+
+        let seed = vault.new_public_seed().map_err(|e| match e {
+            PublicRandomSeedGeneratorError::TransientInternalError { internal_error } => {
+                CryptoError::TransientInternalError { internal_error }
+            }
+        })?;
+        let rng = &mut seed.into_rng();
+
+        let message = message.as_signed_bytes();
+        let mut msgs = Vec::with_capacity(signatures.signatures_map.len());
+        let mut sigs = Vec::with_capacity(signatures.signatures_map.len());
+        let mut keys = Vec::with_capacity(signatures.signatures_map.len());
 
         for (signer, signature) in signatures.signatures_map.iter() {
             let pk_proto =
                 key_from_registry(registry, *signer, KeyPurpose::NodeSigning, registry_version)?;
 
-            let this_algorithm_id = AlgorithmId::from(pk_proto.algorithm);
-            match first_algorithm_id {
-                Some(algorithm_id) => {
-                    if algorithm_id != this_algorithm_id {
-                        return Err(CryptoError::InvalidArgument {
-                        message: format!(
-                            "Inconsistent input AlgorithmIds in batched basic sig verification: {}, {}",
-                            algorithm_id, this_algorithm_id
-                        ),
-                    });
-                    }
-                }
-                None => first_algorithm_id = Some(this_algorithm_id),
+            let pubkey_alg = AlgorithmId::from(pk_proto.algorithm);
+            if pubkey_alg != AlgorithmId::Ed25519 {
+                return Err(CryptoError::AlgorithmNotSupported {
+                    algorithm: pubkey_alg,
+                    reason: format!("Only Ed25519 is supported in batched basic sig verification."),
+                });
             }
+            let pk = ic_crypto_ed25519::PublicKey::deserialize_raw(&pk_proto.key_value).map_err(
+                |e| CryptoError::MalformedPublicKey {
+                    algorithm: AlgorithmId::Ed25519,
+                    key_bytes: Some(pk_proto.key_value),
+                    internal_error: e.to_string(),
+                },
+            )?;
 
-            let csp_pk = CspPublicKey::try_from(pk_proto)?;
-            let csp_sig = SigConverter::for_target(this_algorithm_id).try_from_basic(signature)?;
-            pk_sig_pairs.push((csp_pk, csp_sig));
+            msgs.push(&message[..]);
+            sigs.push(&signature.get_ref().0[..]);
+            keys.push(pk);
         }
-        // `first_algorithm_id.expect()` does not panic because it's guaranteed that there was at least one valid AlgorithmId by
-        // 1) it's checked that `signature_map` is not empty, and
-        // 2) it's checked that at least `pk_proto` is well-formed,
-        // and thus `this_algorithm_id` is never `None` at this point in code.
-        csp_signer.verify_batch(
-            &pk_sig_pairs[..],
-            &message.as_signed_bytes(),
-            first_algorithm_id.expect("Something went wrong with the AlgorithmId assignment"),
-        )?;
+
+        ic_crypto_ed25519::PublicKey::batch_verify(&msgs, &sigs, &keys, rng).map_err(|e| {
+            CryptoError::SignatureVerification {
+                algorithm: AlgorithmId::Ed25519,
+                public_key_bytes: vec![],
+                sig_bytes: vec![],
+                internal_error: e.to_string(),
+            }
+        })?;
         Ok(())
     }
 }

--- a/rs/crypto/src/sign/canister_threshold_sig/idkg.rs
+++ b/rs/crypto/src/sign/canister_threshold_sig/idkg.rs
@@ -371,6 +371,7 @@ impl<C: CryptoServiceProvider> IDkgProtocol for CryptoComponentImpl<C> {
         let start_time = self.metrics.now();
         let result = transcript::create_transcript(
             &self.csp,
+            self.vault.as_ref(),
             self.registry_client.as_ref(),
             params,
             dealings,
@@ -419,6 +420,7 @@ impl<C: CryptoServiceProvider> IDkgProtocol for CryptoComponentImpl<C> {
         let start_time = self.metrics.now();
         let result = transcript::verify_transcript(
             &self.csp,
+            self.vault.as_ref(),
             self.registry_client.as_ref(),
             params,
             transcript,

--- a/rs/crypto/src/sign/mod.rs
+++ b/rs/crypto/src/sign/mod.rs
@@ -196,7 +196,7 @@ impl<C: CryptoServiceProvider, H: Signable> BasicSigVerifier<H> for CryptoCompon
         );
         let start_time = self.metrics.now();
         let result = BasicSigVerifierInternal::verify_basic_sig_batch(
-            &self.csp,
+            self.vault.as_ref(),
             self.registry_client.as_ref(),
             signature,
             message,

--- a/rs/crypto/test_utils/csp/src/lib.rs
+++ b/rs/crypto/test_utils/csp/src/lib.rs
@@ -1,5 +1,5 @@
 use ic_crypto_internal_csp::api::{
-    CspSigVerifier, CspSigner, CspThresholdSignError, NiDkgCspClient, ThresholdSignatureCspClient,
+    CspSigner, CspThresholdSignError, NiDkgCspClient, ThresholdSignatureCspClient,
 };
 use ic_crypto_internal_csp::key_id::KeyId;
 use ic_crypto_internal_csp::types::{CspPop, CspPublicCoefficients, CspPublicKey, CspSignature};
@@ -55,15 +55,6 @@ mock! {
             &self,
             signers: Vec<CspPublicKey>,
             signature: CspSignature,
-            msg: &[u8],
-            algorithm_id: AlgorithmId,
-        ) -> CryptoResult<()>;
-    }
-
-    impl CspSigVerifier for AllCryptoServiceProvider {
-        fn verify_batch(
-            &self,
-            key_signature_pairs: &[(CspPublicKey, CspSignature)],
             msg: &[u8],
             algorithm_id: AlgorithmId,
         ) -> CryptoResult<()>;


### PR DESCRIPTION
Refactors the code so that the crypto component bypasses the obsolete CspSigVerifier and at the same time deletes it. This is a step towards removing the crypto component's obsolete CSP (crypto service provider) layer. Closes CRP-2559 and CRP-2139.