### PR TITLE
chore(IDX): switch python tests to self-hosted

### DIFF
--- a/.github/workflows-source/ci-main.yml
+++ b/.github/workflows-source/ci-main.yml
@@ -54,6 +54,12 @@ anchors:
         --privileged --cgroupns host
         -v /cache:/cache -v /var/sysimage:/var/sysimage -v /var/tmp:/var/tmp -v /ceph-s3-info:/ceph-s3-info
     timeout-minutes: 90
+  dind-small-setup: &dind-small-setup
+    runs-on:
+      labels: dind-small
+    container:
+      <<: *image
+    timeout-minutes: 30
   before-script: &before-script
     name: Before script
     id: before-script
@@ -208,8 +214,7 @@ jobs:
 
   python-ci-tests:
     name: Python CI Tests
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
+    <<: *dind-small-setup
     steps:
       - <<: *checkout
       - <<: *python-setup

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -221,7 +221,10 @@ jobs:
           BAZEL_EXTRA_ARGS: "--keep_going --config=afl"
   python-ci-tests:
     name: Python CI Tests
-    runs-on: ubuntu-latest
+    runs-on:
+      labels: dind-small
+    container:
+      image: ghcr.io/dfinity/ic-build@sha256:e16e14fd3b3cb14c0374a766abc0546461c6ee630d6eab67af92b5f107d0e093
     timeout-minutes: 30
     steps:
       - name: Checkout


### PR DESCRIPTION
This workflow runs very frequently and takes up quite a lot of minutes (in total). Switch to self-hosted to save our minutes usage.