### PR TITLE
feat: RUN-1026: Enable wasm64 in ic_starter

### DIFF
--- a/rs/starter/src/lib.rs
+++ b/rs/starter/src/lib.rs
@@ -15,6 +15,7 @@ pub fn hypervisor_config(canister_sandboxing: bool) -> HypervisorConfig {
             feature_flags: FeatureFlags {
                 rate_limiting_of_debug_prints: FlagStatus::Disabled,
                 best_effort_responses: FlagStatus::Enabled,
+                wasm64: FlagStatus::Enabled,
                 ..FeatureFlags::default()
             },
             ..EmbeddersConfig::default()


### PR DESCRIPTION
Enable wasm64 in ic_starter, so people can start testing the feature with dfx