### PR TITLE
chore(crypto): CRP-2547 Annotate where parallelism can be used in NIDKG

### DIFF
--- a/rs/crypto/internal/crypto_lib/threshold_sig/bls12_381/src/ni_dkg/fs_ni_dkg/forward_secure.rs
+++ b/rs/crypto/internal/crypto_lib/threshold_sig/bls12_381/src/ni_dkg/fs_ni_dkg/forward_secure.rs
@@ -814,6 +814,7 @@ pub fn dec_chunks(
 
     let mut powers = Vec::with_capacity(m);
 
+    // TODO(CRP-2550) These multipairings could be computed in parallel
     for i in 0..m {
         let x = Gt::multipairing(&[
             (&cj[i], G2Prepared::generator()),
@@ -837,6 +838,7 @@ pub fn dec_chunks(
 
             for i in 0..dlogs.len() {
                 if dlogs[i].is_none() {
+                    // TODO(CRP-2550) All BSGS could be run in parallel
                     // It may take hours to brute force a cheater's discrete log.
                     dlogs[i] = cheating_solver.solve(&powers[i]);
                 }
@@ -888,6 +890,7 @@ pub fn verify_ciphertext_integrity(
     let g1_neg = G1Affine::generator().neg();
     let precomp_id = G2Prepared::from(&id);
 
+    // TODO(CRP-2550) Each of these checks could be run in parallel
     for i in 0..NUM_CHUNKS {
         let r = &crsz.rr[i];
         let s = &crsz.ss[i];

--- a/rs/crypto/internal/crypto_lib/threshold_sig/bls12_381/src/ni_dkg/fs_ni_dkg/nizk_sharing.rs
+++ b/rs/crypto/internal/crypto_lib/threshold_sig/bls12_381/src/ni_dkg/fs_ni_dkg/nizk_sharing.rs
@@ -259,64 +259,75 @@ pub fn verify_sharing(
     // Hash of Instance
     // x = oracle(instance)
     let x = instance.hash_to_scalar();
+    let xpow = Scalar::xpowers(&x, instance.public_keys.len());
 
     let first_move = FirstMoveSharing::from(nizk);
     // Verifier's challenge
     // x' = oracle(x, F, A, Y)
     let x_challenge = sharing_proof_challenge(&x, &first_move);
 
-    // First verification equation
-    // R^x' * F == g_1^z_r
-    let lhs = &instance.combined_randomizer * &x_challenge + &first_move.blinder_g1;
-    let rhs = &instance.g1_gen * &nizk.z_r;
-    if lhs != rhs {
-        return Err(ZkProofSharingError::InvalidProof);
-    }
+    // TODO(CRP-2550): The verification can run in three threads
 
-    // Second verification equation
-    // Verify: product [A_k ^ sum [i^k * x^i | i <- [1..n]] | k <- [0..t-1]]^x' * A
-    // == g_2^z_alpha
-
-    let xpow = Scalar::xpowers(&x, instance.public_keys.len());
-
-    let mut ik = vec![Scalar::one(); instance.public_keys.len()];
-
-    let mut scalars = Vec::with_capacity(instance.public_coefficients.len());
-    for _pc in &instance.public_coefficients {
-        let acc = Scalar::muln_vartime(&ik, &xpow);
-        scalars.push(acc);
-
-        for i in 0..ik.len() {
-            ik[i] *= Scalar::from_u64((i + 1) as u64);
+    // Thread 1
+    {
+        // First verification equation
+        // R^x' * F == g_1^z_r
+        let lhs = &instance.combined_randomizer * &x_challenge + &first_move.blinder_g1;
+        let rhs = &instance.g1_gen * &nizk.z_r;
+        if lhs != rhs {
+            return Err(ZkProofSharingError::InvalidProof);
         }
     }
-    let lhs = G2Projective::muln_affine_vartime(&instance.public_coefficients[..], &scalars[..])
-        * &x_challenge
-        + &nizk.aa;
 
-    let rhs = &instance.g2_gen * &nizk.z_alpha;
+    // Thread 2
+    {
+        // Second verification equation
+        // Verify: product [A_k ^ sum [i^k * x^i | i <- [1..n]] | k <- [0..t-1]]^x' * A
+        // == g_2^z_alpha
 
-    if lhs != rhs {
-        return Err(ZkProofSharingError::InvalidProof);
+        let mut ik = vec![Scalar::one(); instance.public_keys.len()];
+
+        let mut scalars = Vec::with_capacity(instance.public_coefficients.len());
+        for _pc in &instance.public_coefficients {
+            let acc = Scalar::muln_vartime(&ik, &xpow);
+            scalars.push(acc);
+
+            for i in 0..ik.len() {
+                ik[i] *= Scalar::from_u64((i + 1) as u64);
+            }
+        }
+        let lhs = G2Projective::muln_affine_vartime(&instance.public_coefficients[..], &scalars[..])
+            * &x_challenge
+            + &nizk.aa;
+
+        let rhs = &instance.g2_gen * &nizk.z_alpha;
+
+        if lhs != rhs {
+            return Err(ZkProofSharingError::InvalidProof);
+        }
     }
 
-    // Third verification equation
-    // LHS = product [C_i ^ x^i | i <- [1..n]]^x' * Y
-    // RHS = product [y_i ^ x^i | i <- 1..n]^z_r * g_1^z_alpha
+    // Thread 3
+    {
+        // Third verification equation
+        // LHS = product [C_i ^ x^i | i <- [1..n]]^x' * Y
+        // RHS = product [y_i ^ x^i | i <- 1..n]^z_r * g_1^z_alpha
 
-    let cc_mul_xi = G1Projective::muln_affine_vartime(&instance.combined_ciphertexts, &xpow);
-    let lhs = cc_mul_xi * &x_challenge + &nizk.yy;
+        let cc_mul_xi = G1Projective::muln_affine_vartime(&instance.combined_ciphertexts, &xpow);
+        let lhs = cc_mul_xi * &x_challenge + &nizk.yy;
 
-    let pk_mul_xi = G1Projective::muln_affine_vartime(&instance.public_keys, &xpow);
-    let rhs = G1Projective::mul2(
-        &pk_mul_xi,
-        &nizk.z_r,
-        &G1Projective::from(&instance.g1_gen),
-        &nizk.z_alpha,
-    );
+        let pk_mul_xi = G1Projective::muln_affine_vartime(&instance.public_keys, &xpow);
+        let rhs = G1Projective::mul2(
+            &pk_mul_xi,
+            &nizk.z_r,
+            &G1Projective::from(&instance.g1_gen),
+            &nizk.z_alpha,
+        );
 
-    if lhs != rhs {
-        return Err(ZkProofSharingError::InvalidProof);
+        if lhs != rhs {
+            return Err(ZkProofSharingError::InvalidProof);
+        }
     }
+
     Ok(())
 }

--- a/rs/crypto/internal/crypto_lib/threshold_sig/bls12_381/src/ni_dkg/fs_ni_dkg/nizk_sharing.rs
+++ b/rs/crypto/internal/crypto_lib/threshold_sig/bls12_381/src/ni_dkg/fs_ni_dkg/nizk_sharing.rs
@@ -296,9 +296,10 @@ pub fn verify_sharing(
                 ik[i] *= Scalar::from_u64((i + 1) as u64);
             }
         }
-        let lhs = G2Projective::muln_affine_vartime(&instance.public_coefficients[..], &scalars[..])
-            * &x_challenge
-            + &nizk.aa;
+        let lhs =
+            G2Projective::muln_affine_vartime(&instance.public_coefficients[..], &scalars[..])
+                * &x_challenge
+                + &nizk.aa;
 
         let rhs = &instance.g2_gen * &nizk.z_alpha;
 

--- a/rs/crypto/internal/crypto_lib/threshold_sig/bls12_381/src/ni_dkg/groth20_bls12_381/encryption.rs
+++ b/rs/crypto/internal/crypto_lib/threshold_sig/bls12_381/src/ni_dkg/groth20_bls12_381/encryption.rs
@@ -366,6 +366,8 @@ pub fn verify_zk_proofs(
         })
     })?;
 
+    // TODO(CRP-2525) The proofs can be verified independently
+
     crypto::verify_ciphertext_integrity(
         &ciphertext,
         epoch,


### PR DESCRIPTION
If we decide to add parallel execution within the cryptography later this provides some guidepoints for doing so within NIDKG