### PR TITLE
chore(sns): Increase MAX_NUMBER_OF_PRINCIPALS_PER_NEURON_FLOOR to 6

### DIFF
--- a/rs/sns/governance/src/types.rs
+++ b/rs/sns/governance/src/types.rs
@@ -376,7 +376,7 @@ impl NervousSystemParameters {
     /// Decreasing it below this number is problematic because SNS Swap assumes
     /// that there are allowed to be at least 5 principals per
     /// neuron during ClaimSwapNeuronsRequest.
-    pub const MAX_NUMBER_OF_PRINCIPALS_PER_NEURON_FLOOR: u64 = 5;
+    pub const MAX_NUMBER_OF_PRINCIPALS_PER_NEURON_FLOOR: u64 = 6;
 
     /// This is an upper bound for `max_dissolve_delay_bonus_percentage`. High values
     /// may improve the incentives when voting, but too-high values may also lead
@@ -441,7 +441,7 @@ impl NervousSystemParameters {
             max_number_of_proposals_with_ballots: Some(700),
             neuron_claimer_permissions: Some(Self::default_neuron_claimer_permissions()),
             neuron_grantable_permissions: Some(NeuronPermissionList::default()),
-            max_number_of_principals_per_neuron: Some(5),
+            max_number_of_principals_per_neuron: Some(6),
             voting_rewards_parameters: Some(VotingRewardsParameters::with_default_values()),
             max_dissolve_delay_bonus_percentage: Some(100),
             max_age_bonus_percentage: Some(25),


### PR DESCRIPTION
This is useful because it allows us to set up 4 hotkeys for NF neurons. The previous value, 5, could only support 3 hotkeys. (The other two principals are set up for the NNS Neuron's controller and NNS governance.)

Note: do we need to reevaluate the maximum number of neurons allowed on the SNS after this change? On the other hand, 6 was always an allowed value for this field, so this change shouldn't increase our worst-case estimate of the memory a neuron may consume.

Known issues: should we automatically increase max_number_of_principals_per_neuron to 6 on existing SNSes? if we don't, users trying to change the nervous system parameters will have to increase  max_number_of_principals_per_neuron to at least 6.

