### PR TITLE
test(consensus): [CON-1382] Run `consensus_performance_test` nightly

### DIFF
--- a/rs/tests/consensus/BUILD.bazel
+++ b/rs/tests/consensus/BUILD.bazel
@@ -358,7 +358,7 @@ system_test(
     proc_macro_deps = MACRO_DEPENDENCIES,
     tags = [
         "experimental_system_test_colocation",
-        "manual",
+        "system_test_benchmark",
     ],
     target_compatible_with = ["@platforms//os:linux"],  # requires libssh that does not build on Mac OS
     test_timeout = "eternal",


### PR DESCRIPTION
This will be picked up by the [system-test-benchmarks-nightly job](https://github.com/dfinity/ic/blob/master/.github/workflows-source/schedule-daily.yml#L154-L175)