### PR TITLE
chore(backup): [CON-1393] Check if the disk usage exceeds threshold only after running ic-replay

### DIFF
--- a/rs/backup/src/backup_helper.rs
+++ b/rs/backup/src/backup_helper.rs
@@ -557,7 +557,13 @@ impl BackupHelper {
         None
     }
 
-    fn get_disk_stats(&self, dir: &Path, threshold: u32, typ: DiskStats) -> Result<u32, String> {
+    fn get_disk_stats(
+        &self,
+        dir: &Path,
+        threshold: u32,
+        typ: DiskStats,
+        notify_if_exceeds_threshold: bool,
+    ) -> Result<u32, String> {
         let mut cmd = Command::new("df");
         cmd.arg(match typ {
             DiskStats::Inodes => "-i",
@@ -578,7 +584,7 @@ impl BackupHelper {
                     let mut num_str = val.to_string();
                     num_str.pop();
                     if let Ok(n) = num_str.parse::<u32>() {
-                        if n >= threshold {
+                        if notify_if_exceeds_threshold && n >= threshold {
                             let resource = match typ {
                                 DiskStats::Inodes => "inodes",
                                 DiskStats::Space => "space",
@@ -653,10 +659,10 @@ impl BackupHelper {
             .map_err(|err| format!("Error creating timestamp file: {:?}", err))?;
         file.write_all(now_str.as_bytes())
             .map_err(|err| format!("Error writing timestamp: {:?}", err))?;
-        self.log_disk_stats()
+        self.log_disk_stats(true)
     }
 
-    pub(crate) fn log_disk_stats(&self) -> Result<(), String> {
+    pub(crate) fn log_disk_stats(&self, notify_if_exceeds_threshold: bool) -> Result<(), String> {
         let mut stats = Vec::new();
         for (dir, threshold, storage_type) in [
             (
@@ -670,8 +676,18 @@ impl BackupHelper {
                 "cold",
             ),
         ] {
-            let space = self.get_disk_stats(dir, threshold, DiskStats::Space)?;
-            let inodes = self.get_disk_stats(dir, threshold, DiskStats::Inodes)?;
+            let space = self.get_disk_stats(
+                dir,
+                threshold,
+                DiskStats::Space,
+                notify_if_exceeds_threshold,
+            )?;
+            let inodes = self.get_disk_stats(
+                dir,
+                threshold,
+                DiskStats::Inodes,
+                notify_if_exceeds_threshold,
+            )?;
             stats.push((dir.as_path(), space, inodes, storage_type));
         }
         self.notification_client

--- a/rs/backup/src/backup_manager.rs
+++ b/rs/backup/src/backup_manager.rs
@@ -404,7 +404,7 @@ impl BackupManager {
                 backup_helper
                     .notification_client
                     .push_metrics_restored_height(last_cp);
-                let _ = backup_helper.log_disk_stats();
+                let _ = backup_helper.log_disk_stats(false);
             }
             info!(self.log, "Replay/Sync - {}", progress.join(", "));
 

--- a/rs/backup/src/notification_client.rs
+++ b/rs/backup/src/notification_client.rs
@@ -120,6 +120,7 @@ impl NotificationClient {
             &Path,
             /*space % usage*/ u32,
             /*inodes % usage*/ u32,
+            /*storage type*/ &str,
         )],
     ) {
         let message = format!(
@@ -128,14 +129,15 @@ impl NotificationClient {
              {}",
             stats
                 .iter()
-                .map(|(dir, space, inodes)| {
+                .map(|(dir, space, inodes, storage_type)| {
                     format!(
-                        "backup_disk_usage{{ic=\"{0}\", dir=\"{1}\", resource=\"space\"}} {2}\n\
-                         backup_disk_usage{{ic=\"{0}\", dir=\"{1}\", resource=\"inodes\"}} {3}\n",
+                        "backup_disk_usage{{ic=\"{0}\", dir=\"{1}\", resource=\"space\", storage_type=\"{4}\"}} {2}\n\
+                         backup_disk_usage{{ic=\"{0}\", dir=\"{1}\", resource=\"inodes\", storage_type=\"{4}\"}} {3}\n",
                         self.network_name,
                         dir.to_str().unwrap_or_default(),
                         space,
-                        inodes
+                        inodes,
+                        storage_type
                     )
                 })
                 .collect::<Vec<_>>()


### PR DESCRIPTION
Currently we check the disk usage every 5 minutes *and* every time we run ic-replay, and report a warning to slack when the remaining disk space is below a threshold.

With this change we will only send such a notification after we run ic-replay.

Also added a "storage type" label to the disk usage metrics so we know whether the metric is about the cold or hot storage (without having to look at the directory name)