### PR TITLE
feat(neurons-fund): Picking a finite number of NNS hotkeys for propagating to Neurons' Fund SNS neurons

### DIFF
--- a/rs/nns/governance/src/neuron_store.rs
+++ b/rs/nns/governance/src/neuron_store.rs
@@ -209,7 +209,7 @@ impl NeuronsFundNeuron {
     /// Concretely, this value should be less than or equal
     /// `MAX_NUMBER_OF_PRINCIPALS_PER_NEURON_FLOOR` - 2
     /// because two permissions will be used for the NNS Governance and the NNS neuron controller.
-    const MAX_HOTKEYS_FROM_NEURONS_FUND_NEURON: usize = 4;
+    const MAX_HOTKEYS_FROM_NEURONS_FUND_NEURON: usize = 3;
 
     /// Returns up to `MAX_HOTKEYS_FROM_NEURONS_FUND_NEURON` elements out of `hotkeys`.
     ///
@@ -217,8 +217,6 @@ impl NeuronsFundNeuron {
     /// the function picks the remaining elements in the order in which they appear in the original
     /// vector.
     pub fn pick_most_important_hotkeys(hotkeys: &Vec<PrincipalId>) -> Vec<PrincipalId> {
-        println!("hotkeys = {:#?}", hotkeys);
-
         // Remove duplicates while preserving the order.
         let mut unique_hotkeys = vec![];
         let mut non_self_auth_hotkeys = vec![];
@@ -240,8 +238,6 @@ impl NeuronsFundNeuron {
             }
         }
 
-        println!("unique_hotkeys = {:#?}", unique_hotkeys);
-
         // If there is space in `unique_hotkeys`, fill it up using `non_self_auth_hotkeys`.
         while unique_hotkeys.len() < Self::MAX_HOTKEYS_FROM_NEURONS_FUND_NEURON
             && !non_self_auth_hotkeys.is_empty()
@@ -249,8 +245,6 @@ impl NeuronsFundNeuron {
             let non_self_authenticating_hotkey = non_self_auth_hotkeys.remove(0);
             unique_hotkeys.push(non_self_authenticating_hotkey);
         }
-
-        println!("unique_hotkeys = {:#?}", unique_hotkeys);
 
         unique_hotkeys
     }

--- a/rs/nns/governance/src/neuron_store/neuron_store_tests.rs
+++ b/rs/nns/governance/src/neuron_store/neuron_store_tests.rs
@@ -755,3 +755,132 @@ fn test_get_full_neuron() {
         })
     );
 }
+
+fn new_non_self_authenticating_principal_id(id: u64) -> PrincipalId {
+    let res = PrincipalId::new_user_test_id(id);
+    assert!(!res.is_self_authenticating());
+    res
+}
+
+fn new_self_authenticating_principal_id(id: u64) -> PrincipalId {
+    let res = PrincipalId::new_self_authenticating(&id.to_be_bytes());
+    assert!(res.is_self_authenticating());
+    res
+}
+
+#[test]
+fn test_pick_most_important_hotkeys_trivial() {
+    assert_eq!(
+        NeuronsFundNeuron::pick_most_important_hotkeys(&vec![]),
+        vec![]
+    );
+}
+
+#[test]
+fn test_pick_most_important_hotkeys_ordering_preserved_for_self_auth() {
+    let hot_keys = vec![
+        new_self_authenticating_principal_id(1),
+        new_self_authenticating_principal_id(2),
+    ];
+
+    assert_eq!(
+        NeuronsFundNeuron::pick_most_important_hotkeys(&hot_keys),
+        vec![
+            new_self_authenticating_principal_id(1),
+            new_self_authenticating_principal_id(2),
+        ],
+    );
+}
+
+#[test]
+fn test_pick_most_important_hotkeys_ordering_preserved_for_non_self_auth() {
+    let hot_keys = vec![
+        new_non_self_authenticating_principal_id(1),
+        new_non_self_authenticating_principal_id(2),
+    ];
+
+    assert_eq!(
+        NeuronsFundNeuron::pick_most_important_hotkeys(&hot_keys),
+        vec![
+            new_non_self_authenticating_principal_id(1),
+            new_non_self_authenticating_principal_id(2),
+        ],
+    );
+}
+
+#[test]
+fn test_pick_most_important_hotkeys_ordering_preserved_for_self_auth_followed_by_non_self_auth() {
+    let hot_keys = vec![
+        new_self_authenticating_principal_id(1),
+        new_non_self_authenticating_principal_id(2),
+    ];
+
+    assert_eq!(
+        NeuronsFundNeuron::pick_most_important_hotkeys(&hot_keys),
+        vec![
+            new_self_authenticating_principal_id(1),
+            new_non_self_authenticating_principal_id(2),
+        ],
+    );
+}
+
+#[test]
+fn test_pick_most_important_hotkeys_ordering_reversed_for_non_self_auth_followed_by_self_auth() {
+    let hot_keys = vec![
+        new_non_self_authenticating_principal_id(1),
+        new_self_authenticating_principal_id(2),
+    ];
+
+    assert_eq!(
+        NeuronsFundNeuron::pick_most_important_hotkeys(&hot_keys),
+        vec![
+            new_self_authenticating_principal_id(2),
+            new_non_self_authenticating_principal_id(1),
+        ],
+    );
+}
+
+#[test]
+fn test_pick_most_important_hotkeys_plenty_self_authenticating() {
+    let hot_keys = vec![
+        new_self_authenticating_principal_id(1),
+        new_non_self_authenticating_principal_id(2),
+        new_self_authenticating_principal_id(3),
+        new_self_authenticating_principal_id(4),
+        new_self_authenticating_principal_id(5),
+        new_self_authenticating_principal_id(6),
+    ];
+
+    assert_eq!(
+        NeuronsFundNeuron::pick_most_important_hotkeys(&hot_keys),
+        vec![
+            new_self_authenticating_principal_id(1),
+            // #2 dropped as a non-self-authenticating principal.
+            new_self_authenticating_principal_id(3),
+            new_self_authenticating_principal_id(4),
+            new_self_authenticating_principal_id(5),
+            // #6 dropped as there are already sufficiently-many hotkeys.
+        ],
+    );
+}
+
+#[test]
+fn test_pick_most_important_hotkeys_few_self_authenticating() {
+    let hot_keys = vec![
+        new_non_self_authenticating_principal_id(1),
+        new_self_authenticating_principal_id(2),
+        new_non_self_authenticating_principal_id(3),
+        new_non_self_authenticating_principal_id(4),
+        new_self_authenticating_principal_id(5),
+    ];
+
+    assert_eq!(
+        NeuronsFundNeuron::pick_most_important_hotkeys(&hot_keys),
+        vec![
+            new_self_authenticating_principal_id(2),
+            new_self_authenticating_principal_id(5),
+            new_non_self_authenticating_principal_id(1),
+            new_non_self_authenticating_principal_id(3),
+        ],
+    );
+}

--- a/rs/nns/governance/src/neuron_store/neuron_store_tests.rs
+++ b/rs/nns/governance/src/neuron_store/neuron_store_tests.rs
@@ -848,7 +848,6 @@ fn test_pick_most_important_hotkeys_plenty_self_authenticating() {
         new_self_authenticating_principal_id(3),
         new_self_authenticating_principal_id(4),
         new_self_authenticating_principal_id(5),
-        new_self_authenticating_principal_id(6),
     ];
 
     assert_eq!(
@@ -858,8 +857,7 @@ fn test_pick_most_important_hotkeys_plenty_self_authenticating() {
             // #2 dropped as a non-self-authenticating principal.
             new_self_authenticating_principal_id(3),
             new_self_authenticating_principal_id(4),
-            new_self_authenticating_principal_id(5),
-            // #6 dropped as there are already sufficiently-many hotkeys.
+            // #5 dropped as there are already sufficiently-many hotkeys.
         ],
     );
 }
@@ -871,14 +869,12 @@ fn test_pick_most_important_hotkeys_few_self_authenticating() {
         new_self_authenticating_principal_id(2),
         new_non_self_authenticating_principal_id(3),
         new_non_self_authenticating_principal_id(4),
-        new_self_authenticating_principal_id(5),
     ];
 
     assert_eq!(
         NeuronsFundNeuron::pick_most_important_hotkeys(&hot_keys),
         vec![
             new_self_authenticating_principal_id(2),
-            new_self_authenticating_principal_id(5),
             new_non_self_authenticating_principal_id(1),
             new_non_self_authenticating_principal_id(3),
         ],


### PR DESCRIPTION
The number of hotkeys for each Neurons' Fund neuron must be limited due to SNS Governance constraints. This PR does the following two things:

1. Introduces a constant for the above-mentioned limit, `MAX_HOTKEYS_FROM_NEURONS_FUND_NEURON`, setting it to 4.
2. Implements a simple tactic for picking up to `MAX_HOTKEYS_FROM_NEURONS_FUND_NEURON` hotkeys out of all NNS neuron hotkeys.