### PR TITLE
feat: Add new_user_test_ids function to generate multiple user test IDs

### DIFF
--- a/rs/types/base_types/src/principal_id.rs
+++ b/rs/types/base_types/src/principal_id.rs
@@ -201,6 +201,14 @@ impl PrincipalId {
         bytes.push(0xfe); // internal marker for user test ids
         Self::new_opaque(&bytes[..])
     }
+    /// Generates as many user test ids as requested, starting from `starting_index`.
+    /// ```rust
+    /// // generate 3 test IDs, with indices starting at 55:
+    /// let [id1, id2, id3] = PrincipalId::new_user_test_ids(55);
+    /// ```
+    pub fn new_user_test_ids<const N: usize>(starting_index: u64) -> [Self; N] {
+        core::array::from_fn(|i| Self::new_user_test_id(starting_index + i as u64))
+    }
     pub fn new_node_test_id(n: u64) -> Self {
         let mut bytes = n.to_le_bytes().to_vec();
         bytes.push(0xfd); // internal marker for node test ids


### PR DESCRIPTION
This is useful to avoid the classic

```rust
let user1 = PrincipalId:: new_user_test_id(10);
let user2 = PrincipalId:: new_user_test_id(11);
let user3 = PrincipalId:: new_user_test_id(12);
```

As it can now be replaced by 

```rust
let [user1, user2, user3] = PrincipalId:: new_user_test_ids(10);
```