### PR TITLE
chore(neurons_fund): Populate hotkeys when necessary in the NNS Governance → Swap → SNS Governance dataflow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11345,6 +11345,7 @@ dependencies = [
 name = "ic-sns-swap"
 version = "0.9.0"
 dependencies = [
+ "assert_matches",
  "async-trait",
  "build-info",
  "build-info-build",

--- a/rs/nns/governance/api/src/ic_nns_governance.pb.v1.rs
+++ b/rs/nns/governance/api/src/ic_nns_governance.pb.v1.rs
@@ -1630,7 +1630,6 @@ pub mod neurons_fund_snapshot {
         #[prost(message, optional, tag = "6")]
         pub controller: ::core::option::Option<::ic_base_types::PrincipalId>,
         /// The principals that can vote, propose, and follow on behalf of this neuron.
-        /// TODO(NNS1-3199): Populate this field with the neuron's hotkeys.
         #[prost(message, repeated, tag = "7")]
         pub hotkeys: ::prost::alloc::vec::Vec<::ic_base_types::PrincipalId>,
         /// Deprecated. Please use `controller` instead (not `hotkeys`!)

--- a/rs/nns/governance/proto/ic_nns_governance/pb/v1/governance.proto
+++ b/rs/nns/governance/proto/ic_nns_governance/pb/v1/governance.proto
@@ -1552,7 +1552,6 @@ message NeuronsFundSnapshot {
     optional ic_base_types.pb.v1.PrincipalId controller = 6;
 
     // The principals that can vote, propose, and follow on behalf of this neuron.
-    // TODO(NNS1-3199): Populate this field with the neuron's hotkeys.
     repeated ic_base_types.pb.v1.PrincipalId hotkeys = 7;
 
     // Deprecated. Please use `controller` instead (not `hotkeys`!)

--- a/rs/nns/governance/src/gen/ic_nns_governance.pb.v1.rs
+++ b/rs/nns/governance/src/gen/ic_nns_governance.pb.v1.rs
@@ -1630,7 +1630,6 @@ pub mod neurons_fund_snapshot {
         #[prost(message, optional, tag = "6")]
         pub controller: ::core::option::Option<::ic_base_types::PrincipalId>,
         /// The principals that can vote, propose, and follow on behalf of this neuron.
-        /// TODO(NNS1-3199): Populate this field with the neuron's hotkeys.
         #[prost(message, repeated, tag = "7")]
         pub hotkeys: ::prost::alloc::vec::Vec<::ic_base_types::PrincipalId>,
         /// Deprecated. Please use `controller` instead (not `hotkeys`!)

--- a/rs/nns/governance/src/governance.rs
+++ b/rs/nns/governance/src/governance.rs
@@ -289,7 +289,7 @@ impl From<NeuronsFundNeuronPortion> for NeuronsFundNeuronPortionPb {
             maturity_equivalent_icp_e8s: Some(neuron.maturity_equivalent_icp_e8s),
             controller: Some(neuron.controller),
             is_capped: Some(neuron.is_capped),
-            hotkeys: Vec::new(), // TODO(NNS1-3199): populate hotkeys
+            hotkeys: neuron.hotkeys,
             hotkey_principal: Some(neuron.controller),
         }
     }

--- a/rs/nns/governance/src/neurons_fund.rs
+++ b/rs/nns/governance/src/neurons_fund.rs
@@ -1744,8 +1744,7 @@ where
                 maturity_equivalent_icp_e8s: Some(neuron.maturity_equivalent_icp_e8s),
                 is_capped: Some(neuron.is_capped),
                 controller: Some(neuron.controller),
-                // TODO(NNS1-3199): populate
-                hotkeys: Vec::new(),
+                hotkeys: neuron.hotkeys.clone(),
                 // TODO(NNS1-3198): remove due to the  very misleading name
                 hotkey_principal: Some(neuron.controller),
             })

--- a/rs/nns/governance/src/neurons_fund/neurons_fund_anonymization_tests.rs
+++ b/rs/nns/governance/src/neurons_fund/neurons_fund_anonymization_tests.rs
@@ -20,17 +20,16 @@ fn test_neurons_fund_participation_anonymization() {
     let maturity_equivalent_icp_e8s = 100_000_000_000;
     let controller = PrincipalId::default();
     let is_capped = false;
-    #[allow(deprecated)] // TODO(NNS1-3199): Remove this when hotkey_principal is removed
+    #[allow(deprecated)] // TODO(NNS1-3198): Remove this when hotkey_principal is removed
     let n1: NeuronsFundNeuronPortionPb = NeuronsFundNeuronPortionPb {
         nns_neuron_id: Some(id1),
         amount_icp_e8s: Some(amount_icp_e8s),
         maturity_equivalent_icp_e8s: Some(maturity_equivalent_icp_e8s),
         controller: Some(controller),
-        // TODO(NNS1-3199): populate this field if that is necessary for this test
         hotkeys: vec![],
         is_capped: Some(is_capped),
 
-        // TODO(NNS1-3199): Remove this deprecated field
+        // TODO(NNS1-3198): Remove this deprecated field
         hotkey_principal: Some(controller),
     };
     let n2 = NeuronsFundNeuronPortionPb {
@@ -111,7 +110,6 @@ fn test_neurons_fund_snapshot_anonymization() {
         amount_icp_e8s: Some(amount_icp_e8s),
         maturity_equivalent_icp_e8s: Some(maturity_equivalent_icp_e8s),
         controller: Some(controller),
-        // TODO(NNS1-3199): populate this field if that is necessary for this test
         hotkeys: vec![],
         is_capped: Some(is_capped),
         // TODO(NNS1-3198): Remove this deprecated field
@@ -158,7 +156,6 @@ fn test_neurons_fund_neuron_portion_anonymization() {
     let amount_icp_e8s = 100_000_000_000;
     let maturity_equivalent_icp_e8s = 100_000_000_000;
     let controller = PrincipalId::default();
-    // TODO(NNS1-3199): Populate this field if it is relevant for this test
     let hotkeys = Vec::new();
     let is_capped = false;
 
@@ -168,7 +165,6 @@ fn test_neurons_fund_neuron_portion_anonymization() {
         amount_icp_e8s: Some(amount_icp_e8s),
         maturity_equivalent_icp_e8s: Some(maturity_equivalent_icp_e8s),
         controller: Some(controller),
-        // TODO(NNS1-3199): populate this field if that is necessary for this test
         hotkeys: vec![],
         is_capped: Some(is_capped),
         // TODO(NNS1-3198): Remove this deprecated field

--- a/rs/nns/governance/src/neurons_fund/neurons_fund_participation_constraints_tests.rs
+++ b/rs/nns/governance/src/neurons_fund/neurons_fund_participation_constraints_tests.rs
@@ -8,9 +8,10 @@ use maplit::{btreemap, btreeset};
 
 fn new_neurons_fund_neuron(id: u64, maturity_equivalent_icp_e8s: u64) -> NeuronsFundNeuron {
     let id = NeuronId { id };
-    let controller = PrincipalId::default();
-    // TODO(NNS1-3199): Populate this field if it is relevant for this test
-    let hotkeys = Vec::new();
+    let controller = PrincipalId::new_user_test_id(55);
+    let hotkey1 = PrincipalId::new_user_test_id(56);
+    let hotkey2 = PrincipalId::new_user_test_id(57);
+    let hotkeys = vec![hotkey1, hotkey2];
     NeuronsFundNeuron {
         id,
         maturity_equivalent_icp_e8s,
@@ -98,7 +99,6 @@ fn test_diff_with_empty_snapshot() {
     );
     let controller = PrincipalId::default();
     let nid = |id: u64| NeuronId { id };
-    // TODO(NNS1-3199): Populate this field if it is relevant for this test
     let hotkeys = Vec::new();
     let snapshot = NeuronsFundSnapshot {
         neurons: btreemap! {
@@ -172,7 +172,6 @@ fn test_diff_with_empty_snapshot() {
 fn test_diff_ok_once_then_err() {
     let controller = PrincipalId::default();
     let nid = |id: u64| NeuronId { id };
-    // TODO(NNS1-3199): Populate this field if it is relevant for this test
     let hotkeys = Vec::new();
     let left = NeuronsFundSnapshot {
         neurons: btreemap! {
@@ -257,7 +256,6 @@ fn test_diff_ok_once_then_err() {
 fn test_diff_extra_neuron_err() {
     let controller = PrincipalId::default();
     let nid = |id: u64| NeuronId { id };
-    // TODO(NNS1-3199): Populate this field if it is relevant for this test
     let hotkeys = Vec::new();
     let left = NeuronsFundSnapshot {
         neurons: btreemap! {
@@ -305,7 +303,6 @@ fn test_diff_extra_neuron_err() {
 fn test_diff_negative_amount_in_diff_err() {
     let controller = PrincipalId::default();
     let nid = |id: u64| NeuronId { id };
-    // TODO(NNS1-3199): Populate this field if it is relevant for this test
     let hotkeys = Vec::new();
     let left = NeuronsFundSnapshot {
         neurons: btreemap! {
@@ -345,7 +342,6 @@ fn test_diff_negative_amount_in_diff_err() {
 #[test]
 fn test_diff_controller_err() {
     let nid = |id: u64| NeuronId { id };
-    // TODO(NNS1-3199): Populate this field if it is relevant for this test
     let hotkeys = Vec::new();
     let left = NeuronsFundSnapshot {
         neurons: btreemap! {
@@ -389,7 +385,6 @@ fn test_diff_controller_err() {
 fn test_diff_maturity_err() {
     let controller = PrincipalId::default();
     let nid = |id: u64| NeuronId { id };
-    // TODO(NNS1-3199): Populate this field if it is relevant for this test
     let hotkeys = Vec::new();
     let left = NeuronsFundSnapshot {
         neurons: btreemap! {
@@ -430,7 +425,6 @@ fn test_diff_maturity_err() {
 fn test_diff_is_capped() {
     let nid = |id: u64| NeuronId { id };
     let controller = PrincipalId::default();
-    // TODO(NNS1-3199): Populate this field if it is relevant for this test
     let hotkeys = Vec::new();
     let test_with = |is_capped_left: bool, is_capped_right: bool| {
         let left = NeuronsFundSnapshot {

--- a/rs/nns/governance/src/neurons_fund/neurons_fund_participation_tests.rs
+++ b/rs/nns/governance/src/neurons_fund/neurons_fund_participation_tests.rs
@@ -39,7 +39,6 @@ fn nid(id: u64) -> NeuronId {
 #[test]
 fn test() {
     let controller = PrincipalId::default();
-    // TODO(NNS1-3199): Populate this field if it is relevant for this test
     let hotkeys = Vec::new();
     let small_neuron = NeuronsFundNeuron {
         id: nid(111),

--- a/rs/nns/governance/src/neurons_fund/polynomial_neurons_fund_participation_tests.rs
+++ b/rs/nns/governance/src/neurons_fund/polynomial_neurons_fund_participation_tests.rs
@@ -57,7 +57,6 @@ fn get_swap_participation_limits_for_tests() -> impl Iterator<Item = SwapPartici
 
 fn get_neuron_sets_for_tests() -> impl Iterator<Item = Vec<NeuronsFundNeuron>> {
     let controller = PrincipalId::default();
-    // TODO(NNS1-3199): Populate this field if it is relevant for this test
     let hotkeys = Vec::new();
     vec![
         // No neurons.

--- a/rs/nns/governance/tests/governance.rs
+++ b/rs/nns/governance/tests/governance.rs
@@ -11406,7 +11406,6 @@ lazy_static! {
                             1_200_000 * E8,
                         ),
                         controller: Some(principal(1)),
-                        // TODO(NNS1-3199): Populate this if it is or can be made relevant for the tests below.
                         hotkeys: Vec::new(),
                         is_capped: Some(
                             false,
@@ -11427,7 +11426,6 @@ lazy_static! {
                             600_000 * E8,
                         ),
                         controller: Some(principal(2)),
-                        // TODO(NNS1-3199): Populate this if it is or can be made relevant for the tests below.
                         hotkeys: Vec::new(),
                         is_capped: Some(
                             false,
@@ -11542,7 +11540,6 @@ lazy_static! {
                             120000000000000,
                         ),
                         controller: Some(principal(1)),
-                        // TODO(NNS1-3199): Populate hotkeys if it's relevant for this test
                         hotkeys: Vec::new(),
                         is_capped: Some(
                             false,
@@ -11564,7 +11561,6 @@ lazy_static! {
                             60000000000000,
                         ),
                         controller: Some(principal(2)),
-                        // TODO(NNS1-3199): Populate hotkeys if it's relevant for this test
                         hotkeys: Vec::new(),
                         is_capped: Some(
                             false,
@@ -11626,7 +11622,6 @@ lazy_static! {
                     120000000000000,
                 ),
                 controller: Some(principal(1)),
-                // TODO(NNS1-3199): Populate hotkeys if it's relevant for this test
                 hotkeys: Vec::new(),
                 is_capped: Some(
                     false,
@@ -11649,7 +11644,6 @@ lazy_static! {
                     60000000000000,
                 ),
                 controller: Some(principal(2)),
-                // TODO(NNS1-3199): Populate hotkeys if it's relevant for this test
                 hotkeys: Vec::new(),
                 is_capped: Some(
                     false,
@@ -11675,7 +11669,6 @@ lazy_static! {
                     15666666667,
                 ),
                 controller: Some(principal(1)),
-                // TODO(NNS1-3199): Populate hotkeys if it's relevant for this test
                 hotkeys: Vec::new(),
                 maturity_equivalent_icp_e8s: Some(
                     120000000000000,
@@ -11697,7 +11690,6 @@ lazy_static! {
                     7833333333,
                 ),
                 controller: Some(principal(2)),
-                // TODO(NNS1-3199): Populate hotkeys if it's relevant for this test
                 hotkeys: Vec::new(),
                 maturity_equivalent_icp_e8s: Some(
                     60000000000000,

--- a/rs/nns/governance/tests/interleaving_tests.rs
+++ b/rs/nns/governance/tests/interleaving_tests.rs
@@ -196,7 +196,6 @@ fn test_cant_interleave_calls_to_settle_neurons_fund() {
                 amount_icp_e8s: Some(max_direct_participation_icp_e8s),
                 maturity_equivalent_icp_e8s: Some(nf_neuron_maturity),
                 controller: Some(nf_neurons_controller),
-                // TODO(NNS1-3199): Populate this field if that is necessary for this test
                 hotkeys: Vec::new(),
                 is_capped: Some(false),
                 // TODO(NNS1-3198): Remove this field once it's deprecated

--- a/rs/sns/governance/src/governance.rs
+++ b/rs/sns/governance/src/governance.rs
@@ -3889,6 +3889,7 @@ impl Governance {
 
         // TODO(NNS1-3198): Simplify this code after `NeuronParameters` is made obsolete.
         let neuron_recipes_from_new_source = request.neuron_recipes;
+        #[allow(deprecated)]
         let neuron_recipes_from_legacy_source =
             Some(NeuronRecipes::from(request.neuron_parameters));
         let neuron_recipes = neuron_recipes_from_new_source

--- a/rs/sns/swap/BUILD.bazel
+++ b/rs/sns/swap/BUILD.bazel
@@ -72,6 +72,7 @@ DEV_DEPENDENCIES = [
     "//rs/nervous_system/common/test_utils",
     "//rs/sns/swap/protobuf_generator:lib",
     "//rs/test_utilities/compare_dirs",
+    "@crate_index//:assert_matches",
     "@crate_index//:candid_parser",
     "@crate_index//:futures",
     "@crate_index//:pretty_assertions",

--- a/rs/sns/swap/Cargo.toml
+++ b/rs/sns/swap/Cargo.toml
@@ -56,6 +56,7 @@ serde_bytes = { workspace = true }
 build-info-build = { workspace = true }
 
 [dev-dependencies]
+assert_matches = { workspace = true }
 candid_parser = { workspace = true }
 proptest = "1.0"
 pretty_assertions = { workspace = true }

--- a/rs/sns/swap/src/swap.rs
+++ b/rs/sns/swap/src/swap.rs
@@ -871,23 +871,24 @@ impl Swap {
 
         // Create the neuron basket for the Neuron Fund investors. The unique
         // identifier for an SNS Neuron is the SNS Ledger Subaccount, which
-        // is a hash of PrincipalId and some unique memo. Since NF
+        // is a hash of PrincipalId and some unique memo. Since Neurons' Fund
         // investors in the swap use the NNS Governance principal_id, there can be
         // neuron id collisions, so there must be a global memo used for all baskets
         // for all NF investors.
-        let mut global_cf_memo: u64 = NEURON_BASKET_MEMO_RANGE_START;
-        for cf_participant in self.cf_participants.iter_mut() {
-            let controller = cf_participant.try_get_controller();
+        let mut global_neurons_fund_memo: u64 = NEURON_BASKET_MEMO_RANGE_START;
+        for neurons_fund_participant in self.cf_participants.iter_mut() {
+            let controller = neurons_fund_participant.try_get_controller();
 
-            for cf_neuron in cf_participant.cf_neurons.iter_mut() {
-                // Create a closure to ensure `global_cf_memo` is incremented in all cases
-                let mut process_cf_neuron = || {
+            for neurons_fund_neuron in neurons_fund_participant.cf_neurons.iter_mut() {
+                // Create a closure to ensure `global_neurons_fund_memo` is incremented in all cases
+                let hotkeys = neurons_fund_neuron.hotkeys.clone().unwrap_or_default();
+                let process_neurons_fund_neuron = || {
                     let controller = match controller.clone() {
                         Ok(nns_neuron_controller_principal) => nns_neuron_controller_principal,
                         Err(e) => {
                             log!(
                                 ERROR,
-                                "Error getting the controller for {cf_neuron:?} principal: {e}"
+                                "Error getting the controller for {neurons_fund_neuron:?} principal: {e}"
                             );
                             sweep_result.invalid +=
                                 neuron_basket_construction_parameters.count as u32;
@@ -898,25 +899,24 @@ impl Swap {
                     // The case that on a previous attempt at creating this neuron recipe, it was
                     // successfully created and recorded. Count the number of neuron recipes that
                     // would have been created.
-                    if cf_neuron.has_created_neuron_recipes == Some(true) {
+                    if neurons_fund_neuron.has_created_neuron_recipes == Some(true) {
                         sweep_result.skipped += neuron_basket_construction_parameters.count as u32;
                         return;
                     }
 
                     let amount_sns_e8s = Swap::scale(
-                        cf_neuron.amount_icp_e8s,
+                        neurons_fund_neuron.amount_icp_e8s,
                         sns_being_offered_e8s,
                         total_participant_icp_e8s,
                     );
 
-                    match create_sns_neuron_basket_for_cf_participant(
+                    match create_sns_neuron_basket_for_neurons_fund_participant(
                         &controller,
-                        // TODO(NNS1-3199): Populate this field
-                        Vec::new(),
-                        cf_neuron.nns_neuron_id,
+                        hotkeys.principals,
+                        neurons_fund_neuron.nns_neuron_id,
                         amount_sns_e8s,
                         neuron_basket_construction_parameters,
-                        global_cf_memo,
+                        global_neurons_fund_memo,
                         nns_governance_canister_id.get(),
                     ) {
                         Ok(cf_participants_sns_neuron_recipes) => {
@@ -926,7 +926,7 @@ impl Swap {
                                 .extend(cf_participants_sns_neuron_recipes);
                             total_sns_tokens_sold_e8s =
                                 total_sns_tokens_sold_e8s.saturating_add(amount_sns_e8s);
-                            cf_neuron.has_created_neuron_recipes = Some(true);
+                            neurons_fund_neuron.has_created_neuron_recipes = Some(true);
                         }
                         Err(error_message) => {
                             log!(
@@ -942,13 +942,15 @@ impl Swap {
                 };
 
                 // Call the closure
-                process_cf_neuron();
+                process_neurons_fund_neuron();
 
                 // Increment the memo by the number neurons in a neuron basket. This means that
-                // previous idempotent calls should increment global_cf_memo and handle overflow
-                match global_cf_memo.checked_add(neuron_basket_construction_parameters.count) {
+                // previous idempotent calls should increment global_neurons_fund_memo and handle overflow
+                match global_neurons_fund_memo
+                    .checked_add(neuron_basket_construction_parameters.count)
+                {
                     Some(new_value) => {
-                        global_cf_memo = new_value;
+                        global_neurons_fund_memo = new_value;
                     }
                     None => {
                         sweep_result.global_failures += 1;
@@ -3401,7 +3403,7 @@ fn create_sns_neuron_basket_for_direct_participant(
 }
 
 /// Create the basket of SNS Neuron Recipes for a single Neurons' Fund participant.
-fn create_sns_neuron_basket_for_cf_participant(
+fn create_sns_neuron_basket_for_neurons_fund_participant(
     controller: &PrincipalId,
     hotkeys: Vec<PrincipalId>,
     nns_neuron_id: u64,
@@ -4005,42 +4007,22 @@ mod tests {
             CfParticipant {
                 controller: Some(PrincipalId::new_user_test_id(992899)),
                 hotkey_principal: PrincipalId::new_user_test_id(992899).to_string(),
-                cf_neurons: vec![CfNeuron::try_new(
-                    1,
-                    698047,
-                    Vec::new(), // TODO(NNS1-3199): Populate if relevant to this test
-                )
-                .unwrap()],
+                cf_neurons: vec![CfNeuron::try_new(1, 698047, Vec::new()).unwrap()],
             },
             CfParticipant {
                 controller: Some(PrincipalId::new_user_test_id(800257)),
                 hotkey_principal: PrincipalId::new_user_test_id(800257).to_string(),
-                cf_neurons: vec![CfNeuron::try_new(
-                    2,
-                    678574,
-                    Vec::new(), // TODO(NNS1-3199): Populate if relevant to this test
-                )
-                .unwrap()],
+                cf_neurons: vec![CfNeuron::try_new(2, 678574, Vec::new()).unwrap()],
             },
             CfParticipant {
                 controller: Some(PrincipalId::new_user_test_id(818371)),
                 hotkey_principal: PrincipalId::new_user_test_id(818371).to_string(),
-                cf_neurons: vec![CfNeuron::try_new(
-                    3,
-                    305256,
-                    Vec::new(), // TODO(NNS1-3199): Populate if relevant to this test
-                )
-                .unwrap()],
+                cf_neurons: vec![CfNeuron::try_new(3, 305256, Vec::new()).unwrap()],
             },
             CfParticipant {
                 controller: Some(PrincipalId::new_user_test_id(657894)),
                 hotkey_principal: PrincipalId::new_user_test_id(657894).to_string(),
-                cf_neurons: vec![CfNeuron::try_new(
-                    4,
-                    339747,
-                    Vec::new(), // TODO(NNS1-3199): Populate if relevant to this test
-                )
-                .unwrap()],
+                cf_neurons: vec![CfNeuron::try_new(4, 339747, Vec::new()).unwrap()],
             },
         ];
         let swap = Swap {

--- a/rs/sns/swap/tests/swap.rs
+++ b/rs/sns/swap/tests/swap.rs
@@ -15,6 +15,7 @@ use crate::common::{
     successful_set_mode_call_result, sweep, try_error_refund_err, try_error_refund_ok,
     verify_direct_participant_icp_balances, verify_direct_participant_sns_balances,
 };
+use assert_matches::assert_matches;
 use candid::Principal;
 use error_refund_icp_response::err::Type::Precondition;
 use futures::{channel::mpsc, future::FutureExt, StreamExt};
@@ -47,7 +48,7 @@ use ic_sns_swap::{
     memory,
     pb::v1::{
         settle_neurons_fund_participation_response::NeuronsFundNeuron,
-        sns_neuron_recipe::{ClaimedStatus, Investor, NeuronAttributes},
+        sns_neuron_recipe::{ClaimedStatus, Investor, Investor::CommunityFund, NeuronAttributes},
         Lifecycle::{Aborted, Committed, Open, Pending, Unspecified},
         NeuronBasketConstructionParameters, SetDappControllersRequest, SetDappControllersResponse,
         *,
@@ -845,7 +846,6 @@ fn test_scenario_happy() {
                                             controller: Some(
                                                 *neurons_fund_participant_principal_id,
                                             ),
-                                            // TODO(NNS1-3199): Populate this field if it is relevant for this test
                                             hotkeys: Some(Principals::from(Vec::new())),
                                             is_capped: Some(false),
                                             hotkey_principal: Some(
@@ -1194,7 +1194,6 @@ async fn test_finalize_swap_ok_matched_funding() {
                                     nns_neuron_id: Some(43),
                                     amount_icp_e8s: Some(100 * E8),
                                     controller: Some(PrincipalId::new_user_test_id(1)),
-                                    // TODO(NNS1-3199): Populate this field if it is relevant for this test
                                     hotkeys: Some(Principals::from(Vec::new())),
                                     is_capped: Some(true),
                                     hotkey_principal: Some(
@@ -3962,6 +3961,72 @@ fn test_create_sns_neuron_recipes_skips_already_created_neuron_recipes_for_nf_pa
     );
 }
 
+/// Test that create_sns_neuron_recipes generate SnsNeuronRecipe with hotkeys
+#[test]
+fn test_create_sns_neuron_recipes_includes_hotkeys() {
+    // Step 1: Prepare the world
+    // Helper variable
+    let neuron_basket_count = params()
+        .neuron_basket_construction_parameters
+        .unwrap()
+        .count as u32;
+
+    // Create some valid and invalid buyers in the state
+    #[allow(deprecated)] // TODO(NNS1-3198): Remove once hotkey_principal is removed
+    let mut swap = Swap {
+        lifecycle: Committed as i32,
+        init: Some(init()),
+        params: Some(params()),
+        buyers: btreemap! {},
+        direct_participation_icp_e8s: Some(0),
+        neurons_fund_participation_icp_e8s: Some(100 * E8),
+        cf_participants: vec![CfParticipant {
+            controller: Some(PrincipalId::new_user_test_id(1001)),
+            hotkey_principal: PrincipalId::new_user_test_id(1001).to_string(),
+            cf_neurons: vec![CfNeuron {
+                nns_neuron_id: 1,
+                amount_icp_e8s: 50 * E8,
+                has_created_neuron_recipes: Some(false),
+                hotkeys: Some(Principals::from(vec![PrincipalId::new_user_test_id(1002)])),
+            }],
+        }],
+        // Create the correct number of recipes for the already processed buyer
+        ..Default::default()
+    };
+
+    // Step 2: Call create_sns_neuron_recipes
+    let sweep_result = swap.create_sns_neuron_recipes();
+
+    // Step 3: Inspect results
+    assert_eq!(
+        sweep_result,
+        SweepResult {
+            success: neuron_basket_count,
+            skipped: 0,
+            failure: 0,
+            invalid: 0,
+            global_failures: 0,
+        }
+    );
+
+    assert_eq!(
+        swap.neuron_recipes.len(),
+        neuron_basket_count as usize * swap.cf_participants.len()
+    );
+
+    // Check that the additional ones were processed
+    let neurons_fund_investment = assert_matches!(
+        swap.neuron_recipes[0].clone().investor.unwrap(),
+        CommunityFund(neurons_fund_investment) => neurons_fund_investment
+    );
+    assert_eq!(
+        neurons_fund_investment.hotkeys,
+        Some(Principals {
+            principals: vec![PrincipalId::new_user_test_id(1002)]
+        }),
+    )
+}
+
 /// Tests that if create sns neuron recipes fails finalize will halt finalization
 #[tokio::test]
 async fn test_finalization_halts_when_create_sns_neuron_recipes_fails() {
@@ -4223,7 +4288,6 @@ async fn test_settle_neurons_fund_participation_handles_invalid_governance_respo
                             nns_neuron_id: Some(0),
                             amount_icp_e8s: Some(0),
                             controller: Some(PrincipalId::new_user_test_id(1)),
-                            // TODO(NNS1-3199): Populate this field if it is relevant for this test
                             hotkeys: Some(Principals::from(Vec::new())),
                             is_capped: Some(false),
                             hotkey_principal: Some(PrincipalId::new_user_test_id(1).to_string()),


### PR DESCRIPTION
Neurons' Fund neuron information starts in NNS Governance, goes to Swap, then goes to SNS Governance. There were some places where we did not populate the hotkeys field, along this chain. This PR rectifies that, although it doesn't yet actually "complete" the chain as that is done in #629