### PR TITLE
fix(IDX): support multiple system_test_benchmarks in the system-tests-benchmarks-nightly job

### DIFF
--- a/.github/workflows-source/schedule-daily.yml
+++ b/.github/workflows-source/schedule-daily.yml
@@ -162,7 +162,7 @@ jobs:
         shell: bash
         run: |
           set -xeuo pipefail
-          echo "BENCHMARK_TARGETS=$(bazel query 'attr(tags, system_test_benchmark, //rs/...)')" >> $GITHUB_ENV
+          echo "BENCHMARK_TARGETS=$(bazel query 'attr(tags, system_test_benchmark, //rs/...)' | tr '\n' ' ')" >> $GITHUB_ENV
       - name: Test System Test Benchmarks
         id: bazel-system-test-benchmarks
         uses: ./.github/actions/bazel-test-all/

--- a/.github/workflows/schedule-daily.yml
+++ b/.github/workflows/schedule-daily.yml
@@ -161,7 +161,7 @@ jobs:
         shell: bash
         run: |
           set -xeuo pipefail
-          echo "BENCHMARK_TARGETS=$(bazel query 'attr(tags, system_test_benchmark, //rs/...)')" >> $GITHUB_ENV
+          echo "BENCHMARK_TARGETS=$(bazel query 'attr(tags, system_test_benchmark, //rs/...)' | tr '\n' ' ')" >> $GITHUB_ENV
       - name: Test System Test Benchmarks
         id: bazel-system-test-benchmarks
         uses: ./.github/actions/bazel-test-all/


### PR DESCRIPTION
Yesterday a 2nd `system_test_benchmarks` was added by https://github.com/dfinity/ic/pull/676 which [caused the error](https://github.com/dfinity/ic/actions/runs/10172391233/job/28134886611#step:5:30) that the `$GITHUB_ENV` was malformed. It apparently can't contain newlines so we turn those into spaces.

Tested it by running the "Schedule Daily" workflow on it here: https://github.com/dfinity/ic/actions/runs/10176317610/job/28145417148