### PR TITLE
chore: Enable canister snapshots in ic-starter

### DIFF
--- a/rs/starter/src/lib.rs
+++ b/rs/starter/src/lib.rs
@@ -22,6 +22,7 @@ pub fn hypervisor_config(canister_sandboxing: bool) -> HypervisorConfig {
         },
         rate_limiting_of_heap_delta: FlagStatus::Disabled,
         rate_limiting_of_instructions: FlagStatus::Disabled,
+        canister_snapshots: FlagStatus::Enabled,
         query_stats_epoch_length: 60,
         ..HypervisorConfig::default()
     }


### PR DESCRIPTION
This will unblock the SDK team to work on integrating with the canister snapshots feature and testing it out.