### PR TITLE
chore(consensus): change the associated `Error` type of `TryFrom<pb>` from `String` to `ProxyDecodeError` for some consensus types

### DIFF
--- a/rs/types/types/src/batch/ingress.rs
+++ b/rs/types/types/src/batch/ingress.rs
@@ -17,7 +17,7 @@ use std::{
 #[cfg_attr(test, derive(ExhaustiveSet))]
 pub struct IngressPayload {
     /// Pairs of MessageId and its serialized byte position in the buffer.
-    pub id_and_pos: Vec<(IngressMessageId, u64)>,
+    id_and_pos: Vec<(IngressMessageId, u64)>,
     /// All messages are serialized in a single byte buffer, so individual
     /// deserialization is delayed. This allows faster deserialization of
     /// IngressPayload when individual message is not needed (e.g. in

--- a/rs/types/types/src/batch/self_validating.rs
+++ b/rs/types/types/src/batch/self_validating.rs
@@ -2,7 +2,7 @@ use crate::CountBytes;
 use ic_btc_replica_types::BitcoinAdapterResponse;
 #[cfg(test)]
 use ic_exhaustive_derive::ExhaustiveSet;
-use ic_protobuf::types::v1 as pb;
+use ic_protobuf::{proxy::ProxyDecodeError, types::v1 as pb};
 use serde::{Deserialize, Serialize};
 use std::convert::TryFrom;
 
@@ -48,12 +48,12 @@ impl From<&SelfValidatingPayload> for pb::SelfValidatingPayload {
 }
 
 impl TryFrom<pb::SelfValidatingPayload> for SelfValidatingPayload {
-    type Error = String;
+    type Error = ProxyDecodeError;
 
     fn try_from(value: pb::SelfValidatingPayload) -> Result<Self, Self::Error> {
         let mut responses = vec![];
         for r in value.bitcoin_testnet_payload.into_iter() {
-            responses.push(BitcoinAdapterResponse::try_from(r).map_err(|err| err.to_string())?);
+            responses.push(BitcoinAdapterResponse::try_from(r)?);
         }
         Ok(Self(responses))
     }

--- a/rs/types/types/src/batch/xnet.rs
+++ b/rs/types/types/src/batch/xnet.rs
@@ -1,7 +1,11 @@
-use ic_base_types::SubnetId;
+use ic_base_types::{subnet_id_try_from_option, SubnetId};
 #[cfg(test)]
 use ic_exhaustive_derive::ExhaustiveSet;
-use ic_protobuf::{messaging::xnet::v1 as messaging_pb, types::v1 as pb};
+use ic_protobuf::{
+    messaging::xnet::v1 as messaging_pb,
+    proxy::{try_from_option_field, ProxyDecodeError},
+    types::v1 as pb,
+};
 use serde::{Deserialize, Serialize};
 use std::{collections::BTreeMap, convert::TryFrom};
 
@@ -32,7 +36,8 @@ impl From<&XNetPayload> for pb::XNetPayload {
 }
 
 impl TryFrom<pb::XNetPayload> for XNetPayload {
-    type Error = String;
+    type Error = ProxyDecodeError;
+
     fn try_from(payload: pb::XNetPayload) -> Result<Self, Self::Error> {
         Ok(Self {
             stream_slices: payload
@@ -40,21 +45,14 @@ impl TryFrom<pb::XNetPayload> for XNetPayload {
                 .into_iter()
                 .map(|subnet_stream_slice| {
                     Ok((
-                        crate::subnet_id_try_from_protobuf(
-                            subnet_stream_slice.subnet_id.ok_or_else(|| {
-                                String::from("Error: stream_slices missing subnet_id")
-                            })?,
-                        )
-                        .map_err(|e| format!("{:?}", e))?,
-                        CertifiedStreamSlice::try_from(
-                            subnet_stream_slice.stream_slice.ok_or_else(|| {
-                                String::from("Error: stream_slices missing from XNetPayload")
-                            })?,
-                        )
-                        .map_err(|e| format!("{:?}", e))?,
+                        subnet_id_try_from_option(subnet_stream_slice.subnet_id)?,
+                        try_from_option_field(
+                            subnet_stream_slice.stream_slice,
+                            "XNetPayload::subnet_stream_slices::stream_slice",
+                        )?,
                     ))
                 })
-                .collect::<Result<BTreeMap<SubnetId, CertifiedStreamSlice>, String>>()?,
+                .collect::<Result<BTreeMap<SubnetId, CertifiedStreamSlice>, Self::Error>>()?,
         })
     }
 }

--- a/rs/types/types/src/consensus.rs
+++ b/rs/types/types/src/consensus.rs
@@ -374,15 +374,11 @@ impl From<&BlockProposal> for pb::BlockProposal {
 
 impl TryFrom<pb::BlockProposal> for BlockProposal {
     type Error = ProxyDecodeError;
+
     fn try_from(block_proposal: pb::BlockProposal) -> Result<Self, Self::Error> {
         Ok(Signed {
             content: Hashed {
-                value: Block::try_from(
-                    block_proposal
-                        .value
-                        .ok_or_else(|| ProxyDecodeError::MissingField("BlockProposal::value"))?,
-                )
-                .map_err(ProxyDecodeError::Other)?,
+                value: try_from_option_field(block_proposal.value, "BlockProposal::value")?,
                 hash: CryptoHashOf::from(CryptoHash(block_proposal.hash)),
             },
             signature: BasicSignature {
@@ -657,11 +653,11 @@ impl From<&RandomBeacon> for pb::RandomBeacon {
 
 impl TryFrom<pb::RandomBeacon> for RandomBeacon {
     type Error = ProxyDecodeError;
+
     fn try_from(beacon: pb::RandomBeacon) -> Result<Self, Self::Error> {
         Ok(Signed {
             content: RandomBeaconContent {
-                version: ReplicaVersion::try_from(beacon.version.as_str())
-                    .map_err(|e| ProxyDecodeError::ReplicaVersionParseError(Box::new(e)))?,
+                version: ReplicaVersion::try_from(beacon.version)?,
                 height: Height::from(beacon.height),
                 parent: CryptoHashOf::from(CryptoHash(beacon.parent)),
             },
@@ -693,11 +689,11 @@ impl From<&RandomBeaconShare> for pb::RandomBeaconShare {
 
 impl TryFrom<pb::RandomBeaconShare> for RandomBeaconShare {
     type Error = ProxyDecodeError;
+
     fn try_from(beacon: pb::RandomBeaconShare) -> Result<Self, Self::Error> {
         Ok(Signed {
             content: RandomBeaconContent {
-                version: ReplicaVersion::try_from(beacon.version.as_str())
-                    .map_err(|e| ProxyDecodeError::ReplicaVersionParseError(Box::new(e)))?,
+                version: ReplicaVersion::try_from(beacon.version)?,
                 height: Height::from(beacon.height),
                 parent: CryptoHashOf::from(CryptoHash(beacon.parent)),
             },
@@ -751,10 +747,11 @@ impl From<&RandomTape> for pb::RandomTape {
 
 impl TryFrom<pb::RandomTape> for RandomTape {
     type Error = ProxyDecodeError;
+
     fn try_from(tape: pb::RandomTape) -> Result<Self, Self::Error> {
         Ok(Signed {
             content: RandomTapeContent {
-                version: ReplicaVersion::try_from(tape.version.as_str())?,
+                version: ReplicaVersion::try_from(tape.version)?,
                 height: Height::from(tape.height),
             },
             signature: ThresholdSignature {
@@ -783,10 +780,11 @@ impl From<&RandomTapeShare> for pb::RandomTapeShare {
 
 impl TryFrom<pb::RandomTapeShare> for RandomTapeShare {
     type Error = ProxyDecodeError;
+
     fn try_from(tape_share: pb::RandomTapeShare) -> Result<Self, Self::Error> {
         Ok(Signed {
             content: RandomTapeContent {
-                version: ReplicaVersion::try_from(tape_share.version.as_str())?,
+                version: ReplicaVersion::try_from(tape_share.version)?,
                 height: Height::from(tape_share.height),
             },
             signature: ThresholdSignatureShare {
@@ -869,10 +867,10 @@ impl TryFrom<pb::EquivocationProof> for EquivocationProof {
     type Error = ProxyDecodeError;
     fn try_from(proof: pb::EquivocationProof) -> Result<Self, Self::Error> {
         Ok(Self {
-            signer: node_id_try_from_option(proof.signer.clone())?,
-            version: ReplicaVersion::try_from(proof.version.as_str())?,
+            signer: node_id_try_from_option(proof.signer)?,
+            version: ReplicaVersion::try_from(proof.version)?,
             height: Height::new(proof.height),
-            subnet_id: subnet_id_try_from_option(proof.subnet_id.clone())?,
+            subnet_id: subnet_id_try_from_option(proof.subnet_id)?,
             hash1: CryptoHashOf::new(CryptoHash(proof.hash1)),
             signature1: BasicSigOf::new(BasicSig(proof.signature1)),
             hash2: CryptoHashOf::new(CryptoHash(proof.hash2)),
@@ -1326,13 +1324,11 @@ impl From<&Block> for pb::Block {
 }
 
 impl TryFrom<pb::Block> for Block {
-    type Error = String;
+    type Error = ProxyDecodeError;
+
     fn try_from(block: pb::Block) -> Result<Self, Self::Error> {
-        let dkg_payload = dkg::Payload::try_from(
-            block
-                .dkg_payload
-                .ok_or_else(|| String::from("Error: Block missing dkg_payload"))?,
-        )?;
+        let dkg_payload = try_from_option_field(block.dkg_payload, "Block::dkg_payload")?;
+
         let batch = BatchPayload {
             ingress: block
                 .ingress_payload
@@ -1352,12 +1348,15 @@ impl TryFrom<pb::Block> for Block {
             canister_http: block.canister_http_payload_bytes,
             query_stats: block.query_stats_payload_bytes,
         };
+
         let payload = match dkg_payload {
             dkg::Payload::Summary(summary) => {
-                assert!(
-                    batch.is_empty(),
-                    "Error: Summary block has non-empty batch payload."
-                );
+                if !batch.is_empty() {
+                    return Err(ProxyDecodeError::Other(String::from(
+                        "Summary block has non-empty batch payload.",
+                    )));
+                }
+
                 // Convert the idkg summary. Note that the summary may contain
                 // transcript references, and here we are NOT checking if these
                 // references are valid. Such checks, if required, should be done
@@ -1370,8 +1369,7 @@ impl TryFrom<pb::Block> for Block {
                     .idkg_payload
                     .as_ref()
                     .map(|idkg| idkg.try_into())
-                    .transpose()
-                    .map_err(|e: ProxyDecodeError| e.to_string())?;
+                    .transpose()?;
 
                 BlockPayload::Summary(SummaryPayload { dkg: summary, idkg })
             }
@@ -1380,8 +1378,7 @@ impl TryFrom<pb::Block> for Block {
                     .idkg_payload
                     .as_ref()
                     .map(|idkg| idkg.try_into())
-                    .transpose()
-                    .map_err(|e: ProxyDecodeError| e.to_string())?;
+                    .transpose()?;
 
                 BlockPayload::Data(DataPayload {
                     batch,
@@ -1391,8 +1388,7 @@ impl TryFrom<pb::Block> for Block {
             }
         };
         Ok(Block {
-            version: ReplicaVersion::try_from(block.version.as_str())
-                .map_err(|e| format!("Block replica version failed to parse {:?}", e))?,
+            version: ReplicaVersion::try_from(block.version)?,
             parent: CryptoHashOf::from(CryptoHash(block.parent)),
             height: Height::from(block.height),
             rank: Rank(block.rank),

--- a/rs/types/types/src/consensus/catchup.rs
+++ b/rs/types/types/src/consensus/catchup.rs
@@ -116,13 +116,9 @@ impl From<&CatchUpContent> for pb::CatchUpContent {
 
 impl TryFrom<pb::CatchUpContent> for CatchUpContent {
     type Error = ProxyDecodeError;
+
     fn try_from(content: pb::CatchUpContent) -> Result<CatchUpContent, Self::Error> {
-        let block = super::Block::try_from(
-            content
-                .block
-                .ok_or_else(|| ProxyDecodeError::MissingField("CatchUpContent::block"))?,
-        )
-        .map_err(ProxyDecodeError::Other)?;
+        let block = try_from_option_field(content.block, "CatchUpContent::block")?;
 
         let random_beacon =
             try_from_option_field(content.random_beacon, "CatchUpContent::random_beacon")?;

--- a/rs/types/types/src/consensus/dkg.rs
+++ b/rs/types/types/src/consensus/dkg.rs
@@ -62,6 +62,7 @@ impl From<DkgMessageId> for pb::DkgMessageId {
 
 impl TryFrom<pb::DkgMessageId> for DkgMessageId {
     type Error = ProxyDecodeError;
+
     fn try_from(id: pb::DkgMessageId) -> Result<Self, Self::Error> {
         Ok(Self {
             hash: CryptoHash(id.hash.clone()).into(),
@@ -112,6 +113,7 @@ impl From<Message> for pb::DkgMessage {
 
 impl TryFrom<pb::DkgMessage> for Message {
     type Error = ProxyDecodeError;
+
     fn try_from(message: pb::DkgMessage) -> Result<Self, Self::Error> {
         Ok(Self {
             content: DealingContent {
@@ -367,20 +369,23 @@ impl From<&Summary> for pb::Summary {
 
 fn build_tagged_transcripts_map(
     transcripts: &[pb::TaggedNiDkgTranscript],
-) -> Result<BTreeMap<NiDkgTag, NiDkgTranscript>, String> {
+) -> Result<BTreeMap<NiDkgTag, NiDkgTranscript>, ProxyDecodeError> {
     transcripts
         .iter()
         .map(|tagged_transcript| {
             tagged_transcript
                 .transcript
                 .as_ref()
-                .ok_or_else(|| "Transcript missing".to_string())
+                .ok_or_else(|| ProxyDecodeError::MissingField("TaggedNiDkgTranscript::transcript"))
                 .and_then(|t| {
                     Ok((
                         NiDkgTag::try_from(tagged_transcript.tag).map_err(|e| {
-                            format!("Failed to convert NiDkgTag of transcript: {:?}", e)
+                            ProxyDecodeError::Other(format!(
+                                "Failed to convert NiDkgTag of transcript: {:?}",
+                                e
+                            ))
                         })?,
-                        NiDkgTranscript::try_from(t)?,
+                        NiDkgTranscript::try_from(t).map_err(ProxyDecodeError::Other)?,
                     ))
                 })
         })
@@ -446,7 +451,8 @@ fn build_transcript_result(
 }
 
 impl TryFrom<pb::Summary> for Summary {
-    type Error = String;
+    type Error = ProxyDecodeError;
+
     fn try_from(summary: pb::Summary) -> Result<Self, Self::Error> {
         Ok(Self {
             registry_version: RegistryVersion::from(summary.registry_version),
@@ -454,7 +460,8 @@ impl TryFrom<pb::Summary> for Summary {
                 .configs
                 .into_iter()
                 .map(|config| NiDkgConfig::try_from(config).map(|c| (c.dkg_id, c)))
-                .collect::<Result<BTreeMap<_, _>, _>>()?,
+                .collect::<Result<BTreeMap<_, _>, _>>()
+                .map_err(ProxyDecodeError::Other)?,
             current_transcripts: build_tagged_transcripts_map(&summary.current_transcripts)?,
             next_transcripts: build_tagged_transcripts_map(&summary.next_transcripts)?,
             interval_length: Height::from(summary.interval_length),
@@ -462,7 +469,8 @@ impl TryFrom<pb::Summary> for Summary {
             height: Height::from(summary.height),
             transcripts_for_new_subnets_with_callback_ids: build_transcripts_vec_from_pb(
                 summary.transcripts_for_new_subnets_with_callback_ids,
-            )?,
+            )
+            .map_err(ProxyDecodeError::Other)?,
             initial_dkg_attempts: build_initial_dkg_attempts_map(&summary.initial_dkg_attempts),
         })
     }
@@ -494,17 +502,16 @@ pub struct Dealings {
 }
 
 impl TryFrom<pb::Dealings> for Dealings {
-    type Error = String;
+    type Error = ProxyDecodeError;
+
     fn try_from(dealings: pb::Dealings) -> Result<Self, Self::Error> {
         Ok(Self {
             start_height: Height::from(dealings.summary_height),
             messages: dealings
                 .dealings
                 .into_iter()
-                .map(|protobuf_dealing| {
-                    Message::try_from(protobuf_dealing).expect("Couldn't parse the dealing")
-                })
-                .collect(),
+                .map(Message::try_from)
+                .collect::<Result<_, _>>()?,
         })
     }
 }
@@ -563,9 +570,13 @@ impl From<&Dealings> for pb::DkgPayload {
 }
 
 impl TryFrom<pb::DkgPayload> for Payload {
-    type Error = String;
+    type Error = ProxyDecodeError;
+
     fn try_from(summary: pb::DkgPayload) -> Result<Self, Self::Error> {
-        match summary.val.ok_or("Val missing in DkgPayload")? {
+        match summary
+            .val
+            .ok_or(ProxyDecodeError::MissingField("DkgPayload::val"))?
+        {
             pb::dkg_payload::Val::Summary(summary) => {
                 Ok(Payload::Summary(Summary::try_from(summary)?))
             }


### PR DESCRIPTION
Also removed some unnecessary clones