### PR TITLE
chore(consensus): [CON-1225] only validate one http outcall share per node per request

### DIFF
--- a/rs/https_outcalls/consensus/src/pool_manager.rs
+++ b/rs/https_outcalls/consensus/src/pool_manager.rs
@@ -291,9 +291,21 @@ impl CanisterHttpPoolManagerImpl {
             return Vec::new();
         };
 
+        let existing_signed_requests: BTreeSet<_> = canister_http_pool
+            .get_validated_shares()
+            .map(|share| (share.signature.signer, share.content.id))
+            .collect();
+
         canister_http_pool
             .get_unvalidated_shares()
             .filter_map(|share| {
+                if existing_signed_requests.contains(&(share.signature.signer, share.content.id)) {
+                    return Some(CanisterHttpChangeAction::HandleInvalid(
+                        share.clone(),
+                        "Redundant share".into(),
+                    ));
+                }
+
                 let node_is_in_committee = self
                     .membership
                     .node_belongs_to_canister_http_committee(
@@ -398,7 +410,7 @@ pub mod test {
     use ic_artifact_pool::canister_http_pool::CanisterHttpPoolImpl;
     use ic_consensus_mocks::{dependencies, Dependencies};
     use ic_consensus_utils::crypto::SignVerify;
-    use ic_interfaces::p2p::consensus::MutablePool;
+    use ic_interfaces::p2p::consensus::{MutablePool, UnvalidatedArtifact};
     use ic_interfaces_state_manager::Labeled;
     use ic_logger::replica_logger::no_op_logger;
     use ic_metrics::MetricsRegistry;
@@ -408,6 +420,7 @@ pub mod test {
     use ic_types::{
         crypto::{CryptoHash, CryptoHashOf},
         messages::CallbackId,
+        time::UNIX_EPOCH,
         Height, RegistryVersion, Time,
     };
     use mockall::predicate::*;
@@ -445,6 +458,127 @@ pub mod test {
             timeout: Time::from_nanos_since_unix_epoch(0),
             content: CanisterHttpResponseContent::Success(Vec::new()),
         }
+    }
+
+    #[test]
+    pub fn test_invalidation_of_redundant_shares() {
+        ic_test_utilities::artifact_pool_config::with_test_pool_config(|pool_config| {
+            with_test_replica_logger(|log| {
+                let Dependencies {
+                    pool,
+                    replica_config,
+                    crypto,
+                    state_manager,
+                    registry,
+                    ..
+                } = dependencies(pool_config.clone(), 5);
+                let mut shim_mock = MockNonBlockingChannel::<CanisterHttpRequest>::new();
+                shim_mock
+                    .expect_try_receive()
+                    .return_const(Err(TryReceiveError::Empty));
+
+                let request = CanisterHttpRequestContext {
+                    request: ic_test_utilities_types::messages::RequestBuilder::new().build(),
+                    url: "".to_string(),
+                    max_response_bytes: None,
+                    headers: vec![],
+                    body: None,
+                    http_method: CanisterHttpMethod::GET,
+                    transform: None,
+                    time: ic_types::Time::from_nanos_since_unix_epoch(10),
+                };
+
+                state_manager
+                    .get_mut()
+                    .expect_get_latest_state()
+                    .return_const(Labeled::new(
+                        Height::from(1),
+                        Arc::new(state_with_pending_http_calls(BTreeMap::from([(
+                            CallbackId::from(7),
+                            request,
+                        )]))),
+                    ));
+
+                let response_metadata = CanisterHttpResponseMetadata {
+                    id: CallbackId::from(7),
+                    timeout: ic_types::Time::from_nanos_since_unix_epoch(10),
+                    registry_version: RegistryVersion::from(1),
+                    content_hash: CryptoHashOf::new(CryptoHash(vec![])),
+                };
+
+                let mut canister_http_pool =
+                    CanisterHttpPoolImpl::new(MetricsRegistry::new(), no_op_logger());
+
+                // Insert the first share as validated.
+                {
+                    let signature = crypto
+                        .sign(
+                            &response_metadata,
+                            replica_config.node_id,
+                            RegistryVersion::from(1),
+                        )
+                        .unwrap();
+
+                    let share = Signed {
+                        content: response_metadata.clone(),
+                        signature,
+                    };
+
+                    let content = empty_canister_http_response(7);
+                    canister_http_pool.apply_changes(vec![
+                        CanisterHttpChangeAction::AddToValidated(share, content),
+                    ]);
+                }
+
+                // Insert the second share as unvalidated.
+                {
+                    let signature = crypto
+                        .sign(
+                            &response_metadata,
+                            replica_config.node_id,
+                            RegistryVersion::from(1),
+                        )
+                        .unwrap();
+
+                    let share = Signed {
+                        content: response_metadata.clone(),
+                        signature,
+                    };
+                    canister_http_pool.insert(UnvalidatedArtifact {
+                        message: share,
+                        peer_id: replica_config.node_id,
+                        timestamp: UNIX_EPOCH,
+                    });
+                }
+
+                let shim: Arc<Mutex<CanisterHttpAdapterClient>> =
+                    Arc::new(Mutex::new(Box::new(shim_mock)));
+
+                let pool_manager = CanisterHttpPoolManagerImpl::new(
+                    state_manager as Arc<_>,
+                    shim,
+                    crypto,
+                    pool.get_cache(),
+                    replica_config,
+                    Arc::clone(&registry) as Arc<_>,
+                    MetricsRegistry::new(),
+                    log,
+                );
+
+                let changes = pool_manager.validate_shares(
+                    pool.get_cache().as_ref(),
+                    &canister_http_pool,
+                    Height::from(0),
+                );
+
+                // Make sure the second share is sorted out as invalid, for the right reason.
+                if let CanisterHttpChangeAction::HandleInvalid(_, err) = &changes[0] {
+                    assert_eq!(err, "Redundant share");
+                } else {
+                    panic!("unexpected change action");
+                }
+            })
+        });
     }
 
     #[test]


### PR DESCRIPTION
When validating the HTTP outcall responses, we should never validate more than one response per node per request. All redundant shares will be now sorted out as invalid.