### PR TITLE
chore(NODE-1399): Update gz references

### DIFF
--- a/ic-os/components/upgrade/manageboot/guestos/manageboot.sh
+++ b/ic-os/components/upgrade/manageboot/guestos/manageboot.sh
@@ -116,7 +116,7 @@ Usage:
       bootloader to use it on next boot. (Caller will still have to
       reboot on next opportunity).
       The new system image can be given in two different ways:
-      - as a singe .tar (or .tar.gz) file containing two files
+      - as a singe .tar (or .tar.zst) file containing two files
         named "boot.img" and "root.img"
       - as two filenames: first the "boot" partition
         image, then the "root" partition image.

--- a/ic-os/docs/Upgrades.adoc
+++ b/ic-os/docs/Upgrades.adoc
@@ -31,7 +31,7 @@ The Bazel command used to build the HostOS/GuestOS images also generates a HostO
 
     $ bazel build //ic-os/{hostos,guestos}/envs/<TARGET>/...
 
-This command will output `update-img.tar{.gz,.zst}` in `/ic/bazel-bin/ic-os/{hostos,guestos}/envs/{prod,dev,dev-malicious}`, which is the tar archive of the HostOS/GuestOS update image.
+This command will output `update-img.tar.zst` in `/ic/bazel-bin/ic-os/{hostos,guestos}/envs/{prod,dev,dev-malicious}`, which is the tar archive of the HostOS/GuestOS update image.
 
 Note that the upgrade images include only the boot and root partitions in a tar archive. Full images, on the other hand, include the entire partition table.
 

--- a/ic-os/guestos/docs/Build.adoc
+++ b/ic-os/guestos/docs/Build.adoc
@@ -20,7 +20,7 @@ bazel build //ic-os/guestos/envs/prod/...
 ----
 
 "prod" can be replaced with "dev" for the dev variant. The built image can be
-found at `/ic/bazel-bin/ic-os/guestos/envs/prod/disk-img.tar{.gz,.zst}`
+found at `/ic/bazel-bin/ic-os/guestos/envs/prod/disk-img.tar.zst`
 
 See notes below on the individual build steps.
 

--- a/rs/ic_os/vsock/vsock_lib/src/host/agent.rs
+++ b/rs/ic_os/vsock/vsock_lib/src/host/agent.rs
@@ -28,7 +28,7 @@ const NODE_ID_FILE_PATH: &str = "/boot/config/node-id";
 const SETUP_HOSTNAME_FILE_PATH: &str = "/opt/ic/bin/setup-hostname.sh";
 
 // upgrade
-const UPGRADE_FILE_PATH: &str = "/tmp/upgrade.tar.gz";
+const UPGRADE_FILE_PATH: &str = "/tmp/upgrade";
 const INSTALL_UPGRADE_FILE_PATH: &str = "/opt/ic/bin/install-upgrade.sh";
 
 const VSOCK_VERSION: HostOSVsockVersion = HostOSVsockVersion {

--- a/rs/nns/integration_tests/src/upgrades_handler.rs
+++ b/rs/nns/integration_tests/src/upgrades_handler.rs
@@ -66,7 +66,7 @@ fn test_submit_and_accept_update_elected_replica_versions_proposal() {
                 }),
                 release_package_urls: elect
                     .as_ref()
-                    .map(|_| vec!["http://release_package.tar.gz".to_string()])
+                    .map(|_| vec!["http://release_package.tar.zst".to_string()])
                     .unwrap_or_default(),
                 replica_version_to_elect: elect,
                 guest_launch_measurement_sha256_hex: None,

--- a/rs/nns/test_utils/src/registry.rs
+++ b/rs/nns/test_utils/src/registry.rs
@@ -271,7 +271,7 @@ pub fn invariant_compliant_mutation_with_subnet_id(
         }
     };
     const MOCK_HASH: &str = "d1bc8d3ba4afc7e109612cb73acbdddac052c93025aa1f82942edabb7deb82a1";
-    let release_package_url = "http://release_package.tar.gz".to_string();
+    let release_package_url = "http://release_package.tar.zst".to_string();
     let replica_version_id = ReplicaVersion::default().to_string();
     let replica_version = ReplicaVersionRecord {
         release_package_sha256_hex: MOCK_HASH.into(),
@@ -518,7 +518,7 @@ pub fn initial_mutations_for_a_multinode_nns_subnet() -> Vec<RegistryMutation> {
 
     let replica_version_id = ReplicaVersion::default().to_string();
     const MOCK_HASH: &str = "d1bc8d3ba4afc7e109612cb73acbdddac052c93025aa1f82942edabb7deb82a1";
-    let release_package_url = "http://release_package.tar.gz".to_string();
+    let release_package_url = "http://release_package.tar.zst".to_string();
     let replica_version = ReplicaVersionRecord {
         release_package_sha256_hex: MOCK_HASH.into(),
         release_package_urls: vec![release_package_url],

--- a/rs/registry/admin/src/main.rs
+++ b/rs/registry/admin/src/main.rs
@@ -3708,7 +3708,7 @@ async fn main() {
             eprintln!("Download IC-OS .. ");
             let tmp_dir = tempfile::tempdir().unwrap().into_path();
             let mut tmp_file = tmp_dir.clone();
-            tmp_file.push("temp.gz");
+            tmp_file.push("temp-image");
 
             // Download the IC-OS upgrade, do not check sha256 yet, we will do that
             // explicitly later

--- a/rs/registry/canister/tests/hostos_version.rs
+++ b/rs/registry/canister/tests/hostos_version.rs
@@ -25,7 +25,7 @@ use common::test_helpers::{
     prepare_registry_with_nodes, prepare_registry_with_nodes_from_template,
 };
 
-const GOOD_PACKAGE_URL: &str = "http://release_package.tar.gz";
+const GOOD_PACKAGE_URL: &str = "http://release_package.tar.zst";
 const GOOD_SHA256_HEX: &str = "C0FFEEC0FFEEC0FFEEC0FFEEC0FFEEC0FFEEC0FFEEC0FFEEC0FFEEC0FFEED00D";
 
 // ~~~~~~~~~~ Adding versions ~~~~~~~~~~

--- a/rs/registry/canister/tests/update_subnet_and_bless_replica_version.rs
+++ b/rs/registry/canister/tests/update_subnet_and_bless_replica_version.rs
@@ -118,7 +118,7 @@ fn test_a_canister_other_than_the_governance_canister_cannot_bless_a_version() {
         let payload = ReviseElectedGuestosVersionsPayload {
             replica_version_to_elect: Some("version_43".into()),
             release_package_sha256_hex: Some(MOCK_HASH.into()),
-            release_package_urls: vec!["http://release_package.tar.gz".into()],
+            release_package_urls: vec!["http://release_package.tar.zst".into()],
             guest_launch_measurement_sha256_hex: None,
             replica_versions_to_unelect: vec![],
         };
@@ -170,7 +170,7 @@ fn test_accepted_proposal_mutates_the_registry() {
         let payload_v43 = ReviseElectedGuestosVersionsPayload {
             replica_version_to_elect: Some("version_43".into()),
             release_package_sha256_hex: Some(MOCK_HASH.into()),
-            release_package_urls: vec!["http://release_package.tar.gz".into()],
+            release_package_urls: vec!["http://release_package.tar.zst".into()],
             guest_launch_measurement_sha256_hex: None,
             replica_versions_to_unelect: vec![],
         };
@@ -215,7 +215,7 @@ fn test_accepted_proposal_mutates_the_registry() {
             .await
         );
         // The URL in the registry should still the old one.
-        let release_package_url = "http://release_package.tar.gz".to_string();
+        let release_package_url = "http://release_package.tar.zst".to_string();
         assert_eq!(
             get_value_or_panic::<ReplicaVersionRecord>(
                 &registry,


### PR DESCRIPTION
NODE-1399

This PR should have no functional impact. It only updates some filenames to be agnostic to either gz or zst images, and it fixes some dummy links to be zst rather than gz.