### PR TITLE
chore(NODE-1399): Update test driver to use zst images

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11885,7 +11885,6 @@ dependencies = [
  "dfn_core",
  "dfn_protobuf",
  "ed25519-dalek",
- "flate2",
  "futures",
  "hex",
  "http 0.2.12",
@@ -11967,7 +11966,6 @@ dependencies = [
  "kube",
  "lazy_static",
  "leb128",
- "libflate 1.3.0",
  "lifeline",
  "maplit",
  "nix 0.24.3",
@@ -12012,6 +12010,7 @@ dependencies = [
  "url",
  "walkdir",
  "wat",
+ "zstd 0.13.1",
 ]
 
 [[package]]

--- a/rs/ic_os/launch-single-vm/src/main.rs
+++ b/rs/ic_os/launch-single-vm/src/main.rs
@@ -106,7 +106,7 @@ fn main() {
     // Adjust VM configuration for nested setup
     let (image_location, vm_type, vm_size) = if args.nested {
         // Create an empty image, this will be used as the "main" drive
-        let empty_image_name = "empty.img.tar.gz";
+        let empty_image_name = "empty.img.tar.zst";
         let tmp_dir = tempfile::tempdir().unwrap();
         let empty_image = build_empty_image(tmp_dir.path(), empty_image_name).unwrap();
         let empty_image_id = farm

--- a/rs/tests/driver/BUILD.bazel
+++ b/rs/tests/driver/BUILD.bazel
@@ -122,7 +122,6 @@ rust_library(
         "@crate_index//:clap",
         "@crate_index//:crossbeam-channel",
         "@crate_index//:ed25519-dalek",
-        "@crate_index//:flate2",
         "@crate_index//:futures",
         "@crate_index//:hex",
         "@crate_index//:http_0_2_12",
@@ -178,5 +177,6 @@ rust_library(
         "@crate_index//:url",
         "@crate_index//:walkdir",
         "@crate_index//:wat",
+        "@crate_index//:zstd",
     ],
 )

--- a/rs/tests/driver/Cargo.toml
+++ b/rs/tests/driver/Cargo.toml
@@ -24,7 +24,6 @@ dfn_candid = { path = "../../rust_canisters/dfn_candid" }
 dfn_protobuf = { path = "../../rust_canisters/dfn_protobuf" }
 dfn_core = { path = "../../rust_canisters/dfn_core" }
 ed25519-dalek = { workspace = true }
-flate2 = { workspace = true }
 futures = { workspace = true }
 humantime = "2.0"
 humantime-serde = { workspace = true }
@@ -104,7 +103,6 @@ http = "0.2.12"
 lazy_static = { workspace = true }
 icp-ledger = { path = "../../rosetta-api/icp_ledger" }
 leb128 = "0.2.5"
-libflate = "1.3.0"
 lifeline = { path = "../../nns/handlers/lifeline/impl" }
 itertools = { workspace = true }
 maplit = "1.0.2"
@@ -149,5 +147,6 @@ tracing-subscriber = { workspace = true }
 tree-deserializer = { path = "../../tree_deserializer" }
 url = { workspace = true }
 wat = "1.0.52"
+zstd = { workspace = true }
 ic-agent = { workspace = true }
 ic-utils = { workspace = true }

--- a/rs/tests/driver/src/driver/bootstrap.rs
+++ b/rs/tests/driver/src/driver/bootstrap.rs
@@ -669,7 +669,7 @@ fn configure_setupos_image(
 
     let mut img_file = File::open(&uncompressed_image)?;
     let configured_image_file = File::create(configured_image.clone())?;
-    let mut encoder = Encoder::new(compressed_img_file, 0)?;
+    let mut encoder = Encoder::new(configured_image_file, 0)?;
     let _ = io::copy(&mut img_file, &mut encoder)?;
     let mut write_stream = encoder.finish()?;
     write_stream.flush()?;

--- a/rs/tests/driver/src/driver/bootstrap.rs
+++ b/rs/tests/driver/src/driver/bootstrap.rs
@@ -19,7 +19,6 @@ use crate::k8s::images::*;
 use crate::k8s::tnet::{TNet, TNode};
 use crate::util::block_on;
 use anyhow::{bail, Result};
-use zstd::stream::write::Encoder;
 use ic_base_types::NodeId;
 use ic_prep_lib::{
     internet_computer::{IcConfig, InitializedIc, TopologyConfig},
@@ -44,6 +43,7 @@ use std::{
     thread::{self, JoinHandle},
 };
 use url::Url;
+use zstd::stream::write::Encoder;
 
 pub type UnassignedNodes = BTreeMap<NodeIndex, NodeConfiguration>;
 pub type NodeVms = BTreeMap<NodeId, AllocatedVm>;

--- a/rs/tests/driver/src/driver/boundary_node.rs
+++ b/rs/tests/driver/src/driver/boundary_node.rs
@@ -34,7 +34,7 @@ use crate::{
 
 use anyhow::{bail, Result};
 use async_trait::async_trait;
-use flate2::{write::GzEncoder, Compression};
+use zstd::stream::write::Encoder;
 use ic_agent::{Agent, AgentError};
 use kube::ResourceExt;
 use reqwest::Url;
@@ -58,7 +58,7 @@ const PLAYNET_PATH: &str = "playnet.json";
 const BN_AAAA_RECORDS_CREATED_EVENT_NAME: &str = "bn_aaaa_records_created_event";
 
 fn mk_compressed_img_path() -> std::string::String {
-    format!("{}.gz", CONF_IMG_FNAME)
+    format!("{}.zst", CONF_IMG_FNAME)
 }
 
 #[derive(Clone)]
@@ -675,7 +675,7 @@ fn create_config_disk_image(
     let compressed_img_path = boundary_node_dir.join(mk_compressed_img_path());
     let compressed_img_file = File::create(compressed_img_path.clone())?;
 
-    let mut encoder = GzEncoder::new(compressed_img_file, Compression::default());
+    let mut encoder = Encoder::new(compressed_img_file, 0)?;
     let _ = io::copy(&mut img_file, &mut encoder)?;
     let mut write_stream = encoder.finish()?;
     write_stream.flush()?;

--- a/rs/tests/driver/src/driver/boundary_node.rs
+++ b/rs/tests/driver/src/driver/boundary_node.rs
@@ -34,13 +34,13 @@ use crate::{
 
 use anyhow::{bail, Result};
 use async_trait::async_trait;
-use zstd::stream::write::Encoder;
 use ic_agent::{Agent, AgentError};
 use kube::ResourceExt;
 use reqwest::Url;
 use serde::{Deserialize, Serialize};
 use slog::info;
 use ssh2::Session;
+use zstd::stream::write::Encoder;
 
 use crate::driver::{farm::PlaynetCertificate, test_env_api::HasIcDependencies};
 

--- a/rs/tests/driver/src/driver/nested.rs
+++ b/rs/tests/driver/src/driver/nested.rs
@@ -20,7 +20,7 @@ use url::Url;
 
 pub const NESTED_VMS_DIR: &str = "nested_vms";
 pub const NESTED_VM_PATH: &str = "vm.json";
-pub const NESTED_CONFIGURED_IMAGE_PATH: &str = "config.img.gz";
+pub const NESTED_CONFIGURED_IMAGE_PATH: &str = "config.img.zst";
 pub const NESTED_NETWORK_PATH: &str = "ips.json";
 
 pub struct NestedNode {

--- a/rs/tests/driver/src/driver/resource.rs
+++ b/rs/tests/driver/src/driver/resource.rs
@@ -2,7 +2,7 @@ use crate::driver::ic::{AmountOfMemoryKiB, InternetComputer, Node, NrOfVCPUs};
 use crate::driver::universal_vm::UniversalVm;
 use crate::k8s::tnet::TNet;
 use anyhow::{self, bail};
-use flate2::{write::GzEncoder, Compression};
+use zstd::stream::write::Encoder;
 use kube::ResourceExt;
 use serde::{Deserialize, Serialize};
 use slog::{info, warn};
@@ -215,7 +215,7 @@ pub fn get_resource_request_for_nested_nodes(
 
     // Build and upload an empty image.
     // TODO: This is temporary until farm can do this natively.
-    let empty_image_name = "empty.img.tar.gz";
+    let empty_image_name = "empty.img.tar.zst";
     let tmp_dir = tempfile::tempdir().unwrap();
     let empty_image = build_empty_image(tmp_dir.path(), empty_image_name)?;
     let image_id = farm.upload_file(group_name, empty_image, empty_image_name)?;
@@ -481,7 +481,7 @@ pub fn build_empty_image(tmp_dir: &Path, out_file_name: &str) -> anyhow::Result<
 
     let mut tar_file = File::open(tar_path)?;
     let compressed_img_file = File::create(&compressed_img_path)?;
-    let mut encoder = GzEncoder::new(compressed_img_file, Compression::default());
+    let mut encoder = ZstEncoder::new(compressed_img_file, 0)?;
     let _ = io::copy(&mut tar_file, &mut encoder)?;
     let mut write_stream = encoder.finish()?;
     write_stream.flush()?;

--- a/rs/tests/driver/src/driver/resource.rs
+++ b/rs/tests/driver/src/driver/resource.rs
@@ -2,7 +2,6 @@ use crate::driver::ic::{AmountOfMemoryKiB, InternetComputer, Node, NrOfVCPUs};
 use crate::driver::universal_vm::UniversalVm;
 use crate::k8s::tnet::TNet;
 use anyhow::{self, bail};
-use zstd::stream::write::Encoder;
 use kube::ResourceExt;
 use serde::{Deserialize, Serialize};
 use slog::{info, warn};
@@ -13,6 +12,7 @@ use std::net::{Ipv4Addr, Ipv6Addr};
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use url::Url;
+use zstd::stream::write::Encoder;
 
 use crate::driver::farm::FarmResult;
 use crate::driver::farm::FileId;

--- a/rs/tests/driver/src/driver/resource.rs
+++ b/rs/tests/driver/src/driver/resource.rs
@@ -481,7 +481,7 @@ pub fn build_empty_image(tmp_dir: &Path, out_file_name: &str) -> anyhow::Result<
 
     let mut tar_file = File::open(tar_path)?;
     let compressed_img_file = File::create(&compressed_img_path)?;
-    let mut encoder = ZstEncoder::new(compressed_img_file, 0)?;
+    let mut encoder = Encoder::new(compressed_img_file, 0)?;
     let _ = io::copy(&mut tar_file, &mut encoder)?;
     let mut write_stream = encoder.finish()?;
     write_stream.flush()?;


### PR DESCRIPTION
[NODE-1399](https://dfinity.atlassian.net/browse/NODE-1399)

Update test driver to use zst ic-os images instead of gz images

[NODE-1399]: https://dfinity.atlassian.net/browse/NODE-1399?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ