### PR TITLE
perf: Route same subnet management messages in a round

### DIFF
--- a/rs/execution_environment/src/execution_environment.rs
+++ b/rs/execution_environment/src/execution_environment.rs
@@ -70,7 +70,8 @@ use ic_types::{
     },
     methods::SystemMethod,
     nominal_cycles::NominalCycles,
-    CanisterId, Cycles, LongExecutionMode, NumBytes, NumInstructions, SubnetId, Time,
+    CanisterId, Cycles, ExecutionRound, LongExecutionMode, NumBytes, NumInstructions, SubnetId,
+    Time,
 };
 use ic_types::{messages::MessageId, methods::WasmMethod};
 use ic_wasm_types::WasmHash;
@@ -355,6 +356,13 @@ impl fmt::Display for DtsInstallCodeStatus {
     }
 }
 
+/// Used during execution of a `RawRand` request to determine
+/// whether it is processed immediately or postponed.
+pub enum RawRandAction {
+    Execute,
+    Postpone(ExecutionRound),
+}
+
 impl ExecutionEnvironment {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
@@ -465,6 +473,7 @@ impl ExecutionEnvironment {
         idkg_subnet_public_keys: &BTreeMap<MasterPublicKeyId, MasterPublicKey>,
         registry_settings: &RegistryExecutionSettings,
         round_limits: &mut RoundLimits,
+        raw_rand_action: &RawRandAction,
     ) -> (ReplicatedState, Option<NumInstructions>) {
         let since = Instant::now(); // Start logging execution time.
 
@@ -868,20 +877,33 @@ impl ExecutionEnvironment {
 
             Ok(Ic00Method::RawRand) => match &msg {
                 CanisterCall::Ingress(_) => self.reject_unexpected_ingress(Ic00Method::RawRand),
-                CanisterCall::Request(_) => {
-                    let res = match EmptyBlob::decode(payload) {
-                        Err(err) => Err(err),
-                        Ok(EmptyBlob) => {
+                CanisterCall::Request(request) => match EmptyBlob::decode(payload) {
+                    Err(err) => ExecuteSubnetMessageResult::Finished {
+                        response: Err(err),
+                        refund: msg.take_cycles(),
+                    },
+                    Ok(_) => match raw_rand_action {
+                        RawRandAction::Execute => {
                             let mut buffer = vec![0u8; 32];
                             rng.fill_bytes(&mut buffer);
-                            Ok(Encode!(&buffer).unwrap())
+                            ExecuteSubnetMessageResult::Finished {
+                                response: Ok(Encode!(&buffer).unwrap()),
+                                refund: msg.take_cycles(),
+                            }
                         }
-                    };
-                    ExecuteSubnetMessageResult::Finished {
-                        response: res,
-                        refund: msg.take_cycles(),
-                    }
-                }
+                        RawRandAction::Postpone(execution_round_id) => {
+                            state
+                                .metadata
+                                .subnet_call_context_manager
+                                .push_raw_rand_request(
+                                    request.as_ref().clone(),
+                                    *execution_round_id,
+                                    state.time(),
+                                );
+                            ExecuteSubnetMessageResult::Processing
+                        }
+                    },
+                },
             },
 
             Ok(Ic00Method::DepositCycles) => match CanisterIdRecord::decode(payload) {

--- a/rs/execution_environment/src/lib.rs
+++ b/rs/execution_environment/src/lib.rs
@@ -17,7 +17,8 @@ pub mod util;
 use crate::ingress_filter::IngressFilterServiceImpl;
 pub use execution_environment::{
     as_num_instructions, as_round_instructions, execute_canister, CompilationCostHandling,
-    ExecuteMessageResult, ExecutionEnvironment, ExecutionResponse, RoundInstructions, RoundLimits,
+    ExecuteMessageResult, ExecutionEnvironment, ExecutionResponse, RawRandAction,
+    RoundInstructions, RoundLimits,
 };
 pub use history::{IngressHistoryReaderImpl, IngressHistoryWriterImpl};
 pub use hypervisor::{Hypervisor, HypervisorMetrics};

--- a/rs/execution_environment/src/scheduler/test_utilities.rs
+++ b/rs/execution_environment/src/scheduler/test_utilities.rs
@@ -7,6 +7,7 @@ use std::{
 
 use ic_base_types::{CanisterId, NumBytes, PrincipalId, SubnetId};
 use ic_config::{
+    execution_environment::Config as ExecConfig,
     flag_status::FlagStatus,
     subnet_config::{SchedulerConfig, SubnetConfig},
 };
@@ -36,7 +37,8 @@ use ic_replicated_state::{
     canister_state::execution_state::{self, WasmMetadata},
     page_map::TestPageAllocatorFileDescriptorImpl,
     testing::{CanisterQueuesTesting, ReplicatedStateTesting},
-    CanisterState, ExecutionState, ExportedFunctions, InputQueueType, Memory, ReplicatedState,
+    CallOrigin, CanisterState, ExecutionState, ExportedFunctions, InputQueueType, Memory,
+    ReplicatedState,
 };
 use ic_system_api::{
     sandbox_safe_system_state::{SandboxSafeSystemState, SystemStateChanges},
@@ -54,7 +56,8 @@ use ic_types::{
     crypto::{canister_threshold_sig::MasterPublicKey, AlgorithmId},
     ingress::{IngressState, IngressStatus},
     messages::{
-        CallContextId, Ingress, MessageId, Request, RequestOrResponse, Response, NO_DEADLINE,
+        CallContextId, CallbackId, Ingress, MessageId, Request, RequestMetadata, RequestOrResponse,
+        Response, NO_DEADLINE,
     },
     methods::{Callback, FuncRef, SystemMethod, WasmClosure, WasmMethod},
     CanisterTimer, ComputeAllocation, Cycles, ExecutionRound, MemoryAllocation, NumInstructions,
@@ -65,7 +68,8 @@ use maplit::btreemap;
 use std::time::Duration;
 
 use crate::{
-    as_round_instructions, ExecutionEnvironment, Hypervisor, IngressHistoryWriterImpl, RoundLimits,
+    as_round_instructions, ExecutionEnvironment, Hypervisor, IngressHistoryWriterImpl,
+    RawRandAction, RoundLimits,
 };
 
 use super::SchedulerImpl;
@@ -107,6 +111,8 @@ pub(crate) struct SchedulerTest {
     xnet_canister_id: CanisterId,
     // The actual scheduler.
     scheduler: SchedulerImpl,
+    // The execution config.
+    config: ExecConfig,
     // The fake Wasm executor.
     wasm_executor: Arc<TestWasmExecutor>,
     // Registry Execution Settings.
@@ -138,6 +144,10 @@ impl SchedulerTest {
         self.state().canister_state(&canister_id).unwrap()
     }
 
+    pub fn own_subnet_id(&self) -> SubnetId {
+        self.state().metadata.own_subnet_id
+    }
+
     pub fn metrics_registry(&self) -> &MetricsRegistry {
         &self.metrics_registry
     }
@@ -155,6 +165,12 @@ impl SchedulerTest {
 
     pub fn subnet_ingress_queue_size(&self) -> usize {
         self.state().subnet_queues().ingress_queue_size()
+    }
+
+    pub fn subnet_available_message_memory(&self) -> i64 {
+        let memory_taken = self.state.as_ref().unwrap().memory_taken();
+        self.config.subnet_message_memory_capacity.get() as i64
+            - memory_taken.guaranteed_response_messages().get() as i64
     }
 
     pub fn last_round(&self) -> ExecutionRound {
@@ -557,9 +573,50 @@ impl SchedulerTest {
             &measurements,
             false,
             long_running_canister_ids,
+            &RawRandAction::Execute,
             self.registry_settings(),
             &BTreeMap::new(),
         )
+    }
+
+    pub fn push_output_request(&mut self, canister_id: &CanisterId, mut request: Request) {
+        let time = self.state.as_ref().unwrap().metadata.batch_time;
+        let canister = self
+            .state
+            .as_mut()
+            .unwrap()
+            .canister_states
+            .get_mut(canister_id)
+            .unwrap();
+
+        assert_eq!(canister.status(), CanisterStatusType::Running);
+        let call_context_manager = canister.system_state.call_context_manager_mut().unwrap();
+
+        let callback_id = call_context_manager.next_callback_id() + 1;
+        request.sender_reply_callback = CallbackId::new(callback_id);
+
+        let call_context_id = call_context_manager.new_call_context(
+            CallOrigin::CanisterUpdate(request.sender, request.sender_reply_callback, NO_DEADLINE),
+            request.payment,
+            Time::from_nanos_since_unix_epoch(0),
+            RequestMetadata::new(0, UNIX_EPOCH),
+        );
+        let _ = call_context_manager.register_callback(Callback::new(
+            call_context_id,
+            request.sender,
+            request.receiver,
+            Cycles::zero(),
+            Cycles::new(42),
+            Cycles::new(84),
+            WasmClosure::new(0, 1),
+            WasmClosure::new(2, 3),
+            None,
+            NO_DEADLINE,
+        ));
+
+        let _ = canister
+            .system_state
+            .push_output_request(request.into(), time);
     }
 
     pub fn charge_for_resource_allocations(&mut self) {
@@ -582,7 +639,7 @@ impl SchedulerTest {
         wasm_executor.round = self.round;
     }
 
-    fn next_canister_id(&mut self) -> CanisterId {
+    pub(crate) fn next_canister_id(&mut self) -> CanisterId {
         let canister_id = canister_test_id(self.next_canister_id);
         self.next_canister_id += 1;
         canister_id
@@ -891,7 +948,7 @@ impl SchedulerTestBuilder {
             self.own_subnet_id,
             self.subnet_type,
             SchedulerImpl::compute_capacity_percent(self.scheduler_config.scheduler_cores),
-            config,
+            config.clone(),
             Arc::clone(&cycles_account_manager),
             self.scheduler_config.scheduler_cores,
             Arc::new(TestPageAllocatorFileDescriptorImpl::new()),
@@ -920,6 +977,7 @@ impl SchedulerTestBuilder {
             user_id: user_test_id(1),
             xnet_canister_id: canister_test_id(first_xnet_canister),
             scheduler,
+            config,
             wasm_executor,
             registry_settings,
             metrics_registry: self.metrics_registry,

--- a/rs/execution_environment/src/scheduler/tests.rs
+++ b/rs/execution_environment/src/scheduler/tests.rs
@@ -18,8 +18,9 @@ use ic_interfaces::execution_environment::SubnetAvailableMemory;
 use ic_logger::replica_logger::no_op_logger;
 use ic_management_canister_types::{
     self as ic00, BoundedHttpHeaders, CanisterHttpResponsePayload, CanisterIdRecord,
-    CanisterStatusType, DerivationPath, EcdsaKeyId, EmptyBlob, Method, Payload as _, SchnorrKeyId,
-    SignWithSchnorrArgs, TakeCanisterSnapshotArgs, UninstallCodeArgs,
+    CanisterInstallModeV2, CanisterStatusType, DerivationPath, EcdsaKeyId, EmptyBlob,
+    InstallCodeArgsV2, Method, Payload as _, SchnorrKeyId, SignWithSchnorrArgs,
+    TakeCanisterSnapshotArgs, UninstallCodeArgs,
 };
 use ic_registry_routing_table::CanisterIdRange;
 use ic_registry_subnet_type::SubnetType;
@@ -5803,4 +5804,310 @@ fn scheduled_heap_delta_limit_scaling() {
     assert_eq!(8, scheduled_limit(45, 50, 9, 10, 5));
     assert_eq!(10, scheduled_limit(50, 50, 9, 10, 5));
     assert_eq!(10, scheduled_limit(55, 50, 9, 10, 5));
+}
+
+#[test]
+fn test_induct_same_subnet_management_messages() {
+    let mut test = SchedulerTestBuilder::new().build();
+    let subnet_id = test.own_subnet_id();
+
+    let sender_id = test.create_canister_with(
+        Cycles::new(10_000_000_000_000),
+        ComputeAllocation::zero(),
+        MemoryAllocation::BestEffort,
+        Some(SystemMethod::CanisterHeartbeat),
+        None,
+        None,
+    );
+    let canister_id = test.create_canister_with(
+        Cycles::new(10_000_000_000_000),
+        ComputeAllocation::zero(),
+        MemoryAllocation::BestEffort,
+        Some(SystemMethod::CanisterHeartbeat),
+        None,
+        None,
+    );
+    test.expect_heartbeat(sender_id, instructions(100));
+    test.expect_heartbeat(canister_id, instructions(101));
+    test.state_mut()
+        .canister_state_mut(&canister_id)
+        .unwrap()
+        .system_state
+        .controllers
+        .insert(sender_id.get());
+
+    // Push request into the output queue of canister identified by `sender_id`.
+    let arg1 = Encode!(&CanisterIdRecord::from(canister_id)).unwrap();
+    test.push_output_request(
+        &sender_id,
+        RequestBuilder::new()
+            .sender(sender_id)
+            .receiver(CanisterId::from(subnet_id))
+            .method_name(Method::StopCanister)
+            .method_payload(arg1.clone())
+            .payment(Cycles::zero())
+            .build(),
+    );
+
+    assert_eq!(test.state().subnet_queues().input_queues_message_count(), 0);
+    assert_eq!(
+        test.state().subnet_queues().output_queues_message_count(),
+        0
+    );
+    assert_eq!(
+        test.state()
+            .metadata
+            .subnet_call_context_manager
+            .stop_canister_calls_len(),
+        0
+    );
+
+    // After executing a round, the stop request is processed.
+    // Response is added in the subnet queues at the end of execution round.
+    test.execute_round(ExecutionRoundType::OrdinaryRound);
+    assert_eq!(test.state().subnet_queues().input_queues_message_count(), 0);
+    assert_eq!(
+        test.canister_state(canister_id).status(),
+        CanisterStatusType::Stopped
+    );
+    assert_eq!(
+        test.state().subnet_queues().output_queues_message_count(),
+        1
+    );
+    assert_eq!(
+        test.state()
+            .metadata
+            .subnet_call_context_manager
+            .stop_canister_calls_len(),
+        0
+    );
+
+    // Check `induct_subnet_messages_to_local` routes messages from subnet
+    // output to the right input canister queue.
+    let mut subnet_available_memory = test.subnet_available_message_memory();
+    test.state_mut()
+        .induct_subnet_messages_to_local(&mut subnet_available_memory, &no_op_logger());
+    assert_eq!(
+        test.state().subnet_queues().output_queues_message_count(),
+        0
+    );
+    assert_eq!(test.state().subnet_queues().input_queues_message_count(), 0);
+}
+
+#[test]
+fn test_postponing_raw_rand_management_message() {
+    let mut test = SchedulerTestBuilder::new().build();
+    let subnet_id = test.own_subnet_id();
+
+    let sender_id = test.create_canister_with(
+        Cycles::new(10_000_000_000_000),
+        ComputeAllocation::zero(),
+        MemoryAllocation::BestEffort,
+        Some(SystemMethod::CanisterHeartbeat),
+        None,
+        None,
+    );
+    test.expect_heartbeat(sender_id, instructions(100));
+
+    // Push request into the output queue of canister identified by `sender_id`.
+    test.push_output_request(
+        &sender_id,
+        RequestBuilder::new()
+            .sender(sender_id)
+            .receiver(CanisterId::from(subnet_id))
+            .method_name(Method::RawRand)
+            .method_payload(EmptyBlob.encode())
+            .payment(Cycles::zero())
+            .build(),
+    );
+
+    assert_eq!(test.state().subnet_queues().input_queues_message_count(), 0);
+    assert_eq!(
+        test.state().subnet_queues().output_queues_message_count(),
+        0
+    );
+    assert_eq!(
+        test.state()
+            .metadata
+            .subnet_call_context_manager
+            .raw_rand_contexts
+            .len(),
+        0
+    );
+
+    // After executing a round, the raw request is postponed.
+    test.execute_round(ExecutionRoundType::OrdinaryRound);
+    assert_eq!(test.state().subnet_queues().input_queues_message_count(), 0);
+    assert_eq!(
+        test.state().subnet_queues().output_queues_message_count(),
+        0
+    );
+    assert_eq!(
+        test.state()
+            .metadata
+            .subnet_call_context_manager
+            .raw_rand_contexts
+            .len(),
+        1
+    );
+}
+
+#[test]
+fn test_execute_raw_rand_routed_by_message_routing() {
+    let mut test = SchedulerTestBuilder::new().build();
+
+    let sender_id = test.create_canister_with(
+        Cycles::new(10_000_000_000_000),
+        ComputeAllocation::zero(),
+        MemoryAllocation::BestEffort,
+        Some(SystemMethod::CanisterHeartbeat),
+        None,
+        None,
+    );
+    test.expect_heartbeat(sender_id, instructions(100));
+
+    // Added directly in the subnet queues.
+    // Will be executed immediately.
+    test.inject_call_to_ic00(
+        Method::RawRand,
+        EmptyBlob.encode(),
+        Cycles::zero(),
+        canister_test_id(10),
+        InputQueueType::LocalSubnet,
+    );
+
+    assert_eq!(test.state().subnet_queues().input_queues_message_count(), 1);
+    assert_eq!(
+        test.state().subnet_queues().output_queues_message_count(),
+        0
+    );
+    assert_eq!(
+        test.state()
+            .metadata
+            .subnet_call_context_manager
+            .raw_rand_contexts
+            .len(),
+        0
+    );
+
+    // After executing a round, the raw request is executed.
+    test.execute_round(ExecutionRoundType::OrdinaryRound);
+    assert_eq!(test.state().subnet_queues().input_queues_message_count(), 0);
+    assert_eq!(
+        test.state().subnet_queues().output_queues_message_count(),
+        1
+    );
+    assert_eq!(
+        test.state()
+            .metadata
+            .subnet_call_context_manager
+            .raw_rand_contexts
+            .len(),
+        0
+    );
+    assert_eq!(
+        fetch_histogram_stats(
+            test.metrics_registry(),
+            "execution_round_subnet_queue_messages",
+        ),
+        Some(HistogramStats { sum: 1.0, count: 3 })
+    );
+}
+
+#[test]
+fn test_inner_round_loop_with_multiple_same_subnet_install_code() {
+    let mut test = SchedulerTestBuilder::new()
+        .with_scheduler_config(SchedulerConfig {
+            scheduler_cores: 2,
+            instruction_overhead_per_execution: NumInstructions::from(0),
+            instruction_overhead_per_canister: NumInstructions::from(0),
+            instruction_overhead_per_canister_for_finalization: NumInstructions::from(0),
+            max_instructions_per_round: NumInstructions::from(300),
+            max_instructions_per_message: NumInstructions::from(20),
+            max_instructions_per_message_without_dts: NumInstructions::from(10),
+            max_instructions_per_slice: NumInstructions::from(10),
+            max_instructions_per_install_code: NumInstructions::new(40),
+            max_instructions_per_install_code_slice: NumInstructions::new(10),
+            ..SchedulerConfig::application_subnet()
+        })
+        .build();
+    let subnet_id = test.own_subnet_id();
+    let canister_1 = test.create_canister();
+    test.inject_call_to_ic00(
+        Method::RawRand,
+        EmptyBlob.encode(),
+        Cycles::zero(),
+        canister_1,
+        InputQueueType::LocalSubnet,
+    );
+
+    let canister_2 = test.create_canister();
+    let install_code = TestInstallCode::Upgrade {
+        post_upgrade: instructions(23),
+    };
+    test.inject_install_code_call_to_ic00(canister_2, install_code);
+
+    let sender_id = test.create_canister_with(
+        Cycles::new(10_000_000_000_000),
+        ComputeAllocation::zero(),
+        MemoryAllocation::BestEffort,
+        Some(SystemMethod::CanisterHeartbeat),
+        None,
+        None,
+    );
+    test.expect_heartbeat(sender_id, instructions(10));
+    test.state_mut()
+        .canister_state_mut(&canister_1)
+        .unwrap()
+        .system_state
+        .controllers
+        .insert(sender_id.get());
+    let args = InstallCodeArgsV2 {
+        mode: CanisterInstallModeV2::Install,
+        canister_id: canister_1.get(),
+        wasm_module: vec![],
+        arg: vec![],
+        compute_allocation: None,
+        memory_allocation: None,
+        sender_canister_version: None,
+    };
+    // Push request into the output queue of canister identified by `sender_id`.
+    test.push_output_request(
+        &sender_id,
+        RequestBuilder::new()
+            .sender(sender_id)
+            .receiver(CanisterId::from(subnet_id))
+            .method_name(Method::InstallCode)
+            .method_payload(args.encode())
+            .payment(Cycles::zero())
+            .build(),
+    );
+
+    assert_eq!(test.state().subnet_queues().input_queues_message_count(), 2);
+    test.execute_round(ExecutionRoundType::OrdinaryRound);
+
+    // Subnet input queues contain the second install code message,
+    // The message was routed during a `inner_round` iteration.
+    assert_eq!(test.state().subnet_queues().input_queues_message_count(), 1);
+    // Subnet output queue contain the response for the`RawRand` message.
+    // Message was not routed because it was added to the subnet queues
+    // without registering any callback id.
+    assert_eq!(
+        test.state().subnet_queues().output_queues_message_count(),
+        1
+    );
+    assert_eq!(
+        test.state()
+            .canister_state(&canister_2)
+            .unwrap()
+            .next_execution(),
+        NextExecution::ContinueInstallCode
+    );
+    assert_eq!(
+        fetch_histogram_stats(
+            test.metrics_registry(),
+            "execution_round_subnet_queue_messages",
+        ),
+        Some(HistogramStats { sum: 1.0, count: 3 })
+    );
 }

--- a/rs/execution_environment/tests/canister_history.rs
+++ b/rs/execution_environment/tests/canister_history.rs
@@ -879,6 +879,7 @@ fn canister_info_retrieval() {
         CanisterChangeOrigin::from_user(user_id1),
         CanisterChangeDetails::code_deployment(Upgrade, UNIVERSAL_CANISTER_WASM_SHA256),
     ));
+    assert_eq!(env.canister_version(canister_id), 3);
 
     // create and install universal_canister
     let ucan = env
@@ -893,6 +894,7 @@ fn canister_info_retrieval() {
             INITIAL_CYCLES_BALANCE,
         )
         .unwrap();
+    assert_eq!(env.canister_version(canister_id), 5);
 
     // users cannot retrieve canister information directly via ingress messages
     let res = env.execute_ingress(
@@ -907,6 +909,7 @@ fn canister_info_retrieval() {
             format!("{} cannot be called by a user.", Method::CanisterInfo)
         ))
     );
+    assert_eq!(env.canister_version(canister_id), 6);
 
     // do not specify the number of requested changes
     let canister_info = get_canister_info(&env, ucan, canister_id, None).unwrap();
@@ -933,6 +936,7 @@ fn canister_info_retrieval() {
         Some(UNIVERSAL_CANISTER_WASM_SHA256.to_vec())
     );
     assert_eq!(canister_info.controllers(), vec![user_id1, user_id2]);
+    assert_eq!(env.canister_version(canister_id), 10);
 
     // retrieve a proper suffix of canister history
     let canister_info = get_canister_info(&env, ucan, canister_id, Some(2)).unwrap();

--- a/rs/execution_environment/tests/canister_history.rs
+++ b/rs/execution_environment/tests/canister_history.rs
@@ -647,7 +647,7 @@ fn canister_history_tracks_changes_from_canister() {
     };
     // check canister history
     let mut reference_change_entries: Vec<CanisterChange> = vec![CanisterChange::new(
-        now.duration_since(UNIX_EPOCH).unwrap().as_nanos() as u64 + 2, // the canister is created in the next round after the ingress message is received
+        now.duration_since(UNIX_EPOCH).unwrap().as_nanos() as u64 + 1, // the canister is created in the same round as the ingress message is received
         0,
         CanisterChangeOrigin::from_canister(ucan.into(), Some(2)),
         CanisterChangeDetails::canister_creation(vec![ucan.into(), user_id1, user_id2]),
@@ -677,7 +677,7 @@ fn canister_history_tracks_changes_from_canister() {
     env.execute_ingress(ucan, "update", ucan_payload).unwrap();
     // check canister history
     reference_change_entries.push(CanisterChange::new(
-        now.duration_since(UNIX_EPOCH).unwrap().as_nanos() as u64 + 2, // the canister is installed in the next round after the ingress message is received
+        now.duration_since(UNIX_EPOCH).unwrap().as_nanos() as u64 + 1, // the canister is installed in the same round as the ingress message is received
         1,
         CanisterChangeOrigin::from_canister(ucan.into(), None),
         CanisterChangeDetails::code_deployment(Install, test_canister_sha256),
@@ -980,7 +980,7 @@ fn canister_info_retrieval() {
     // update reference canister history
     reference_change_entries.push(CanisterChange::new(
         now.duration_since(UNIX_EPOCH).unwrap().as_nanos() as u64 + 1,
-        19,
+        15,
         CanisterChangeOrigin::from_user(user_id2),
         CanisterChangeDetails::CanisterCodeUninstall,
     ));
@@ -1054,7 +1054,7 @@ fn canister_history_load_snapshot_fails_incorrect_sender_version() {
     };
 
     let mut reference_change_entries: Vec<CanisterChange> = vec![CanisterChange::new(
-        now.duration_since(UNIX_EPOCH).unwrap().as_nanos() as u64 + 2, // the canister is created in the next round after the ingress message is received
+        now.duration_since(UNIX_EPOCH).unwrap().as_nanos() as u64 + 1, // the canister is created in the same round as the ingress message is received
         0,
         CanisterChangeOrigin::from_canister(ucan.into(), Some(2)),
         CanisterChangeDetails::canister_creation(vec![ucan.into(), user_id1, user_id2]),

--- a/rs/execution_environment/tests/subnet_size_test.rs
+++ b/rs/execution_environment/tests/subnet_size_test.rs
@@ -444,15 +444,13 @@ fn simulate_sign_with_ecdsa_cost(
         )
         .build();
     // Ignore ingress message response, since SignWithECDSA requires a response
-    // from consensus, which is not simulated in staet_machine_tests.
+    // from consensus, which is not simulated in state_machine_tests.
     let _msg_id = env.send_ingress(
         PrincipalId::new_anonymous(),
         canister_id,
         "update",
         sign_with_ecdsa,
     );
-    // Run `execute_subnet_message`.
-    env.tick();
 
     // Expect `SignWithEcdsa` request to be added into subnet call context manager.
     // Signature fee is deduced from `request.payment`, the excess amount
@@ -461,6 +459,11 @@ fn simulate_sign_with_ecdsa_cost(
     assert_eq!(sign_with_ecdsa_contexts.len(), 1);
     let (_, context) = sign_with_ecdsa_contexts.iter().next().unwrap();
     let payment_after = context.request.payment;
+
+    // Run new execution round.
+    env.tick();
+    let sign_with_ecdsa_contexts = env.sign_with_ecdsa_contexts();
+    assert_eq!(sign_with_ecdsa_contexts.len(), 0);
 
     payment_before - payment_after
 }

--- a/rs/execution_environment/tests/threshold_signatures.rs
+++ b/rs/execution_environment/tests/threshold_signatures.rs
@@ -653,8 +653,6 @@ fn test_sign_with_threshold_key_fee_ignored_for_nns() {
                 .build(),
         );
 
-        env.tick();
-
         // Assert that the request payment is zero.
         let contexts = match method {
             Method::SignWithECDSA => env.sign_with_ecdsa_contexts(),

--- a/rs/replicated_state/src/canister_state/queues.rs
+++ b/rs/replicated_state/src/canister_state/queues.rs
@@ -722,7 +722,7 @@ impl CanisterQueues {
 
     /// Returns a reference to the message at the head of the respective output
     /// queue, if any.
-    pub(super) fn peek_output(&self, canister_id: &CanisterId) -> Option<&RequestOrResponse> {
+    pub(crate) fn peek_output(&self, canister_id: &CanisterId) -> Option<&RequestOrResponse> {
         self.canister_queues.get(canister_id)?.1.peek()
     }
 

--- a/rs/replicated_state/src/replicated_state.rs
+++ b/rs/replicated_state/src/replicated_state.rs
@@ -21,6 +21,7 @@ use ic_interfaces::messaging::{
     IngressInductionError, LABEL_VALUE_CANISTER_NOT_FOUND, LABEL_VALUE_CANISTER_STOPPED,
     LABEL_VALUE_CANISTER_STOPPING,
 };
+use ic_logger::{error, ReplicaLogger};
 use ic_protobuf::state::queues::v1::canister_queues::NextInputQueue as ProtoNextInputQueue;
 use ic_registry_routing_table::RoutingTable;
 use ic_registry_subnet_type::SubnetType;
@@ -767,6 +768,35 @@ impl ReplicatedState {
     /// to push the `Response` into.
     pub fn push_subnet_output_response(&mut self, msg: Arc<Response>) {
         self.subnet_queues.push_output_response(msg)
+    }
+
+    /// Induct messages from the subnet output queues into the input queues
+    /// of the respective canisters while respecting the capacity and
+    /// subnet available memory.
+    pub fn induct_subnet_messages_to_local(
+        &mut self,
+        subnet_available_memory: &mut i64,
+        log: &ReplicaLogger,
+    ) {
+        self.subnet_queues
+            .output_queues_for_each(|canister_id, msg| {
+                match self.canister_states.get_mut(canister_id) {
+                    Some(dest_canister) => dest_canister
+                        .push_input(
+                            (*msg).clone(),
+                            subnet_available_memory,
+                            self.metadata.own_subnet_type,
+                            InputQueueType::LocalSubnet,
+                        )
+                        .map_err(|(err, msg)| {
+                            error!(
+                                log,
+                                "Inducting {:?} on same subnet failed with error '{}'.", &msg, &err
+                            );
+                        }),
+                    None => Err(()),
+                }
+            });
     }
 
     /// Returns a circular iterator that consumes messages from all canisters'

--- a/rs/state_machine_tests/src/lib.rs
+++ b/rs/state_machine_tests/src/lib.rs
@@ -2581,6 +2581,18 @@ impl StateMachine {
             .contains_key(&canister)
     }
 
+    /// Returns the canister version.
+    pub fn canister_version(&self, canister_id: CanisterId) -> u64 {
+        self.state_manager
+            .get_latest_state()
+            .take()
+            .canister_states
+            .get(&canister_id)
+            .unwrap()
+            .system_state
+            .canister_version
+    }
+
     /// Queries the canister with the specified ID using the anonymous principal.
     pub fn query(
         &self,

--- a/rs/test_utilities/execution_environment/src/lib.rs
+++ b/rs/test_utilities/execution_environment/src/lib.rs
@@ -18,7 +18,7 @@ pub use ic_execution_environment::ExecutionResponse;
 use ic_execution_environment::{
     execute_canister, CompilationCostHandling, ExecuteMessageResult, ExecutionEnvironment,
     Hypervisor, IngressFilterMetrics, IngressHistoryWriterImpl, InternalHttpQueryHandler,
-    RoundInstructions, RoundLimits,
+    RawRandAction, RoundInstructions, RoundLimits,
 };
 use ic_interfaces::execution_environment::{
     ChainKeySettings, ExecutionMode, IngressHistoryWriter, RegistryExecutionSettings,
@@ -1204,6 +1204,7 @@ impl ExecutionTest {
             &self.idkg_subnet_public_keys,
             &self.registry_settings,
             &mut round_limits,
+            &RawRandAction::Execute,
         );
         self.subnet_available_memory = round_limits.subnet_available_memory;
         self.state = Some(new_state);

--- a/rs/types/types/src/messages/inter_canister.rs
+++ b/rs/types/types/src/messages/inter_canister.rs
@@ -1,5 +1,6 @@
 use crate::{
-    ingress::WasmResult, time::CoarseTime, CanisterId, CountBytes, Cycles, Funds, NumBytes, Time,
+    ingress::WasmResult, time::CoarseTime, CanisterId, CountBytes, Cycles, Funds, NumBytes,
+    SubnetId, Time,
 };
 use ic_error_types::{RejectCode, UserError};
 #[cfg(test)]
@@ -8,7 +9,7 @@ use ic_management_canister_types::{
     CanisterIdRecord, CanisterInfoRequest, ClearChunkStoreArgs, DeleteCanisterSnapshotArgs,
     InstallChunkedCodeArgs, InstallCodeArgsV2, ListCanisterSnapshotArgs, LoadCanisterSnapshotArgs,
     Method, Payload as _, ProvisionalTopUpCanisterArgs, StoredChunksArgs, TakeCanisterSnapshotArgs,
-    UpdateSettingsArgs, UploadChunkArgs,
+    UpdateSettingsArgs, UploadChunkArgs, IC_00,
 };
 use ic_protobuf::{
     proxy::{try_from_option_field, ProxyDecodeError},
@@ -514,6 +515,17 @@ impl RequestOrResponse {
     pub fn is_best_effort(&self) -> bool {
         self.deadline() != NO_DEADLINE
     }
+
+    /// Returns `true` iff this message is addressed to the given subnet.
+    pub fn is_addressed_to_subnet(&self, own_subnet_id: SubnetId) -> bool {
+        let canister_id = self.receiver();
+        is_subnet_id(canister_id, own_subnet_id)
+    }
+}
+
+/// Checks whether the given canister ID refers to the subnet (directly or as `IC_00`).
+pub fn is_subnet_id(canister_id: CanisterId, own_subnet_id: SubnetId) -> bool {
+    canister_id == IC_00 || canister_id.get_ref() == own_subnet_id.get_ref()
 }
 
 /// Convenience `CountBytes` implementation that returns the same value as


### PR DESCRIPTION
This MR adds new logic to route the same subnet management messages from the canisters to the subnet queues and vice versa. The raw_rand messages that are routed in the same round will be postponed for execution until the next round (to preserve the properties of randomness on the IC), while other messages that were routed in the previous rounds can be executed immediately.