### PR TITLE
feat(ic-admin): Change IC Admin to support creating InstallCode and StopOrStartCansiter proposals

### DIFF
--- a/rs/nns/governance/src/proposals/install_code.rs
+++ b/rs/nns/governance/src/proposals/install_code.rs
@@ -6,6 +6,7 @@ use crate::{
 
 use candid::{CandidType, Deserialize, Encode};
 use ic_base_types::CanisterId;
+use ic_crypto_sha2::Sha256;
 use ic_management_canister_types::CanisterInstallMode as RootCanisterInstallMode;
 use ic_nervous_system_root::change_canister::ChangeCanisterRequest;
 use ic_nns_constants::{LIFELINE_CANISTER_ID, ROOT_CANISTER_ID};

--- a/rs/nns/governance/src/proposals/install_code.rs
+++ b/rs/nns/governance/src/proposals/install_code.rs
@@ -6,7 +6,6 @@ use crate::{
 
 use candid::{CandidType, Deserialize, Encode};
 use ic_base_types::CanisterId;
-use ic_crypto_sha2::Sha256;
 use ic_management_canister_types::CanisterInstallMode as RootCanisterInstallMode;
 use ic_nervous_system_root::change_canister::ChangeCanisterRequest;
 use ic_nns_constants::{LIFELINE_CANISTER_ID, ROOT_CANISTER_ID};

--- a/rs/registry/admin/src/main.rs
+++ b/rs/registry/admin/src/main.rs
@@ -5562,7 +5562,7 @@ async fn propose_to_install_code(
         Some(proposer),
     ));
 
-    let canister_id = Some(PrincipalId::try_from(cmd.canister_id).unwrap());
+    let canister_id = Some(cmd.canister_id.get());
     let wasm_module = Some(
         read_wasm_module(
             &cmd.wasm_module_path,
@@ -5611,7 +5611,7 @@ async fn propose_to_stop_canister(cmd: StopCanisterCmd, agent: Agent, proposer: 
         Some(proposer),
     ));
 
-    let canister_id = PrincipalId::try_from(cmd.canister_id).unwrap();
+    let canister_id = cmd.canister_id.get();
     let stop_canister = StopOrStartCanister {
         canister_id: Some(canister_id),
         action: Some(GovernanceCanisterAction::Stop as i32),
@@ -5646,7 +5646,7 @@ async fn propose_to_start_canister(cmd: StartCanisterCmd, agent: Agent, proposer
         Some(proposer),
     ));
 
-    let canister_id = PrincipalId::try_from(cmd.canister_id).unwrap();
+    let canister_id = cmd.canister_id.get();
     let start_canister = StopOrStartCanister {
         canister_id: Some(canister_id),
         action: Some(GovernanceCanisterAction::Start as i32),

--- a/rs/registry/admin/src/main.rs
+++ b/rs/registry/admin/src/main.rs
@@ -815,10 +815,10 @@ struct StartCanisterCmd {
     #[clap(long)]
     pub canister_id: CanisterId,
 
-    /// If true, the proposal will be sent as an InstallCode proposal instead of ExecuteNnsFunction.
-    /// TODO(NNS1-3223): Remove `no_` prefix after the InstallCode proposal is supported.
+    /// If true, the proposal will be sent as an StopOrStartCanister proposal instead of ExecuteNnsFunction.
+    /// TODO(NNS1-3223): Change to `use_legacy_excutenns` after the StopOrStartCanister proposal is supported.
     #[clap(long)]
-    no_use_legacy_execute_nns_function: bool,
+    use_explicit_action_type: bool,
 }
 
 impl ProposalTitle for StartCanisterCmd {
@@ -847,10 +847,10 @@ struct StopCanisterCmd {
     #[clap(long)]
     pub canister_id: CanisterId,
 
-    /// If true, the proposal will be sent as an InstallCode proposal instead of ExecuteNnsFunction.
-    /// TODO(NNS1-3223): Remove `no_` prefix after the InstallCode proposal is supported.
+    /// If true, the proposal will be sent as an StopOrStartCanister proposal instead of ExecuteNnsFunction.
+    /// TODO(NNS1-3223): Change to `use_legacy_excutenns` after the StopOrStartCanister proposal is supported.
     #[clap(long)]
-    no_use_legacy_execute_nns_function: bool,
+    use_explicit_action_type: bool,
 }
 
 impl ProposalTitle for StopCanisterCmd {
@@ -1018,9 +1018,9 @@ struct ProposeToChangeNnsCanisterCmd {
     memory_allocation: Option<u64>,
 
     /// If true, the proposal will be sent as an InstallCode proposal instead of ExecuteNnsFunction.
-    /// TODO(NNS1-3223): Remove `no_` prefix after the InstallCode proposal is supported.
+    /// TODO(NNS1-3223): Change to `use_legacy_excutenns` after the InstallCode proposal is supported.
     #[clap(long)]
-    no_use_legacy_execute_nns_function: bool,
+    use_explicit_action_type: bool,
 }
 
 #[async_trait]
@@ -3962,7 +3962,7 @@ async fn main() {
                 opts.nns_public_key_pem_file,
                 sender,
             );
-            if cmd.no_use_legacy_execute_nns_function {
+            if cmd.use_explicit_action_type {
                 propose_to_install_code(cmd, canister_client, proposer).await;
             } else if cmd.canister_id == ROOT_CANISTER_ID {
                 propose_external_proposal_from_command::<
@@ -4039,7 +4039,7 @@ async fn main() {
                 opts.nns_public_key_pem_file,
                 sender,
             );
-            if cmd.no_use_legacy_execute_nns_function {
+            if cmd.use_explicit_action_type {
                 propose_to_start_canister(cmd, canister_client, proposer).await;
             } else {
                 propose_external_proposal_from_command(
@@ -4059,7 +4059,7 @@ async fn main() {
                 opts.nns_public_key_pem_file,
                 sender,
             );
-            if cmd.no_use_legacy_execute_nns_function {
+            if cmd.use_explicit_action_type {
                 propose_to_stop_canister(cmd, canister_client, proposer).await;
             } else {
                 propose_external_proposal_from_command(

--- a/rs/registry/admin/src/types.rs
+++ b/rs/registry/admin/src/types.rs
@@ -6,6 +6,7 @@ use candid::CandidType;
 use ic_canister_client::Agent;
 use ic_canister_client::Sender;
 use ic_nns_common::types::NeuronId;
+use ic_nns_governance::pb::v1::proposal::Action;
 use ic_protobuf::registry::{
     node::v1::IPv4InterfaceConfig,
     provisional_whitelist::v1::ProvisionalWhitelist as ProvisionalWhitelistProto,
@@ -250,4 +251,9 @@ impl SubnetDescriptor {
 #[async_trait]
 pub trait ProposalPayload<T: CandidType> {
     async fn payload(&self, agent: &Agent) -> T;
+}
+
+#[async_trait]
+pub trait ProposalAction {
+    async fn action(&self) -> Action;
 }


### PR DESCRIPTION
# Why

The `InstallCode` and `StopOrStartCansiter` are 2 new proposal types to replace the `ExecuteNnsFunction` ones. Support creating them through ic-admin

# What 

Introduce a `no_use_legacy_execute_nns_function` option to use the new way of creating the proposals, and when it's true, create proposals using new format instead.