### PR TITLE
feat: Limit number of snapshots stored per canister

### DIFF
--- a/rs/config/src/execution_environment.rs
+++ b/rs/config/src/execution_environment.rs
@@ -133,7 +133,7 @@ pub const MAX_COMPILATION_CACHE_SIZE: NumBytes = NumBytes::new(10 * GIB);
 pub const MAX_ALLOWED_CONTROLLERS_COUNT: usize = 10;
 
 /// Maximum number of canister snapshots that can be stored for a single canister.
-pub const MAX_NUMBER_OF_CANISTER_SNAPSHOTS: usize = 1;
+pub const MAX_NUMBER_OF_SNAPSHOTS_PER_CANISTER: usize = 1;
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
 #[serde(default)]

--- a/rs/config/src/execution_environment.rs
+++ b/rs/config/src/execution_environment.rs
@@ -132,6 +132,9 @@ pub const MAX_COMPILATION_CACHE_SIZE: NumBytes = NumBytes::new(10 * GIB);
 /// Maximum number of controllers allowed in a request (specified in the interface spec).
 pub const MAX_ALLOWED_CONTROLLERS_COUNT: usize = 10;
 
+/// Maximum number of canister snapshots that can be stored for a single canister.
+pub const MAX_NUMBER_OF_CANISTER_SNAPSHOTS: usize = 1;
+
 #[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
 #[serde(default)]
 pub struct Config {

--- a/rs/execution_environment/src/canister_manager.rs
+++ b/rs/execution_environment/src/canister_manager.rs
@@ -12,7 +12,7 @@ use crate::{
     util::GOVERNANCE_CANISTER_ID,
 };
 use ic_base_types::NumSeconds;
-use ic_config::flag_status::FlagStatus;
+use ic_config::{execution_environment::MAX_NUMBER_OF_CANISTER_SNAPSHOTS, flag_status::FlagStatus};
 use ic_cycles_account_manager::{CyclesAccountManager, ResourceSaturation};
 use ic_error_types::{ErrorCode, RejectCode, UserError};
 use ic_interfaces::execution_environment::{
@@ -1778,24 +1778,40 @@ impl CanisterManager {
         // Check sender is a controller.
         validate_controller(canister, &sender)?;
 
-        // Check that replace snapshot ID exists if provided.
-        if let Some(replace_snapshot) = replace_snapshot {
-            match state.canister_snapshots.get(replace_snapshot) {
-                None => {
-                    // If not found, the operation fails due to invalid parameters.
-                    return Err(CanisterManagerError::CanisterSnapshotNotFound {
-                        canister_id: canister.canister_id(),
-                        snapshot_id: replace_snapshot,
-                    });
-                }
-                Some(snapshot) => {
-                    // Verify the provided replacement snapshot belongs to this canister.
-                    if snapshot.canister_id() != canister.canister_id() {
-                        return Err(CanisterManagerError::CanisterSnapshotInvalidOwnership {
+        match replace_snapshot {
+            // Check that replace snapshot ID exists if provided.
+            Some(replace_snapshot) => {
+                match state.canister_snapshots.get(replace_snapshot) {
+                    None => {
+                        // If not found, the operation fails due to invalid parameters.
+                        return Err(CanisterManagerError::CanisterSnapshotNotFound {
                             canister_id: canister.canister_id(),
                             snapshot_id: replace_snapshot,
                         });
                     }
+                    Some(snapshot) => {
+                        // Verify the provided replacement snapshot belongs to this canister.
+                        if snapshot.canister_id() != canister.canister_id() {
+                            return Err(CanisterManagerError::CanisterSnapshotInvalidOwnership {
+                                canister_id: canister.canister_id(),
+                                snapshot_id: replace_snapshot,
+                            });
+                        }
+                    }
+                }
+            }
+            // No replace snapshot ID provided, check whether the maximum number of snapshots
+            // has been reached.
+            None => {
+                if state
+                    .canister_snapshots
+                    .snapshots_count(&canister.canister_id())
+                    >= MAX_NUMBER_OF_CANISTER_SNAPSHOTS
+                {
+                    return Err(CanisterManagerError::CanisterSnapshotLimitExceeded {
+                        canister_id: canister.canister_id(),
+                        limit: MAX_NUMBER_OF_CANISTER_SNAPSHOTS,
+                    });
                 }
             }
         }
@@ -2228,6 +2244,10 @@ pub(crate) enum CanisterManagerError {
     CanisterSnapshotExecutionStateNotFound {
         canister_id: CanisterId,
     },
+    CanisterSnapshotLimitExceeded {
+        canister_id: CanisterId,
+        limit: usize,
+    },
     LongExecutionAlreadyInProgress {
         canister_id: CanisterId,
     },
@@ -2275,6 +2295,7 @@ impl AsErrorHelp for CanisterManagerError {
             | CanisterManagerError::CanisterHeapDeltaRateLimited { .. }
             | CanisterManagerError::CanisterSnapshotInvalidOwnership { .. }
             | CanisterManagerError::CanisterSnapshotExecutionStateNotFound { .. }
+            | CanisterManagerError::CanisterSnapshotLimitExceeded { .. }
             | CanisterManagerError::LongExecutionAlreadyInProgress { .. }
             | CanisterManagerError::MissingUpgradeOptionError { .. }
             | CanisterManagerError::InvalidUpgradeOptionError { .. } => ErrorHelp::UserError {
@@ -2563,6 +2584,14 @@ impl From<CanisterManagerError> for UserError {
                     ErrorCode::CanisterRejectedMessage,
                     format!(
                         "Failed to create snapshot for empty canister {}:", canister_id,
+                    )
+                )
+            }
+            CanisterSnapshotLimitExceeded { canister_id, limit } => {
+                Self::new(
+                    ErrorCode::CanisterRejectedMessage,
+                    format!(
+                        "Canister {} has reached the maximum number of snapshots allowed: {}.{additional_help}", canister_id, limit,
                     )
                 )
             }

--- a/rs/execution_environment/src/canister_manager.rs
+++ b/rs/execution_environment/src/canister_manager.rs
@@ -12,7 +12,9 @@ use crate::{
     util::GOVERNANCE_CANISTER_ID,
 };
 use ic_base_types::NumSeconds;
-use ic_config::{execution_environment::MAX_NUMBER_OF_CANISTER_SNAPSHOTS, flag_status::FlagStatus};
+use ic_config::{
+    execution_environment::MAX_NUMBER_OF_SNAPSHOTS_PER_CANISTER, flag_status::FlagStatus,
+};
 use ic_cycles_account_manager::{CyclesAccountManager, ResourceSaturation};
 use ic_error_types::{ErrorCode, RejectCode, UserError};
 use ic_interfaces::execution_environment::{
@@ -1806,11 +1808,11 @@ impl CanisterManager {
                 if state
                     .canister_snapshots
                     .snapshots_count(&canister.canister_id())
-                    >= MAX_NUMBER_OF_CANISTER_SNAPSHOTS
+                    >= MAX_NUMBER_OF_SNAPSHOTS_PER_CANISTER
                 {
                     return Err(CanisterManagerError::CanisterSnapshotLimitExceeded {
                         canister_id: canister.canister_id(),
-                        limit: MAX_NUMBER_OF_CANISTER_SNAPSHOTS,
+                        limit: MAX_NUMBER_OF_SNAPSHOTS_PER_CANISTER,
                     });
                 }
             }

--- a/rs/replicated_state/src/canister_snapshots.rs
+++ b/rs/replicated_state/src/canister_snapshots.rs
@@ -125,6 +125,14 @@ impl CanisterSnapshots {
         snapshots
     }
 
+    /// Returns the number of snapshots stored for the given canister id.
+    pub fn snapshots_count(&self, canister_id: &CanisterId) -> usize {
+        match self.snapshot_ids.get(canister_id) {
+            Some(snapshot_ids) => snapshot_ids.len(),
+            None => 0,
+        }
+    }
+
     /// Adds a new restore snapshot operation in the unflushed changes.
     pub fn add_restore_operation(&mut self, canister_id: CanisterId, snapshot_id: SnapshotId) {
         self.unflushed_changes


### PR DESCRIPTION
This PR implements the limit on number of snapshots per canister as specified in the [interface spec PR](https://github.com/dfinity/interface-spec/pull/259/files#diff-b9a833d6114611a080aee4cd57618feb45aa044bcc11105d44b155b5bbde00ebR2477). The current limit is 1 snapshot per canister.