### PR TITLE
fix: Update heap delta debit and estimate after loading a snashot

### DIFF
--- a/rs/execution_environment/src/canister_manager.rs
+++ b/rs/execution_environment/src/canister_manager.rs
@@ -2080,6 +2080,10 @@ impl CanisterManager {
             .canister_snapshots
             .add_restore_operation(canister_id, snapshot_id);
 
+        if self.config.rate_limiting_of_heap_delta == FlagStatus::Enabled {
+            new_canister.scheduler_state.heap_delta_debit += NumBytes::from(new_memory_usage);
+        }
+
         (instructions_used, Ok(new_canister))
     }
 

--- a/rs/execution_environment/src/execution_environment.rs
+++ b/rs/execution_environment/src/execution_environment.rs
@@ -2111,6 +2111,7 @@ impl ExecutionEnvironment {
 
         let result = match result {
             Ok(new_canister) => {
+                state.metadata.heap_delta_estimate += NumBytes::from(new_canister.memory_usage());
                 state.put_canister_state(new_canister);
                 Ok(EmptyBlob.encode())
             }

--- a/rs/execution_environment/src/execution_environment/tests/canister_snapshots.rs
+++ b/rs/execution_environment/src/execution_environment/tests/canister_snapshots.rs
@@ -24,6 +24,7 @@ use ic_types::{
     CanisterId, Cycles, SnapshotId,
 };
 use ic_universal_canister::{call_args, wasm, UNIVERSAL_CANISTER_WASM};
+use more_asserts::assert_gt;
 use serde_bytes::ByteBuf;
 
 #[test]
@@ -1186,6 +1187,83 @@ fn load_canister_snapshot_fails_snapshot_does_not_belong_to_canister() {
     assert_eq!(
         initial_canister_state,
         test.state().canister_state(&canister_id_2).unwrap().clone()
+    );
+}
+
+#[test]
+fn load_canister_snapshot_fails_when_heap_delta_rate_limited() {
+    const CYCLES: Cycles = Cycles::new(20_000_000_000_000);
+    const CAPACITY: u64 = 500_000_000;
+    const THRESHOLD: u64 = CAPACITY / 2;
+    const WASM_PAGE_SIZE: u64 = 65_536;
+    const NUM_PAGES: u64 = 2_400;
+
+    let mut test = ExecutionTestBuilder::new()
+        .with_snapshots(FlagStatus::Enabled)
+        .with_heap_delta_rate_limit(NumBytes::new(200_000_000))
+        .with_subnet_execution_memory(CAPACITY as i64)
+        .with_subnet_memory_reservation(0)
+        .with_subnet_memory_threshold(THRESHOLD as i64)
+        .build();
+
+    let initial_heap_delta_estimate = test.state().metadata.heap_delta_estimate;
+
+    // Create canister.
+    let canister_id = test
+        .canister_from_cycles_and_binary(CYCLES, UNIVERSAL_CANISTER_WASM.into())
+        .unwrap();
+    test.canister_update_reserved_cycles_limit(canister_id, CYCLES)
+        .unwrap();
+
+    // Increase memory usage.
+    grow_stable_memory(&mut test, canister_id, WASM_PAGE_SIZE, NUM_PAGES);
+
+    // Take a snapshot of the canister.
+    let args: TakeCanisterSnapshotArgs = TakeCanisterSnapshotArgs::new(canister_id, None);
+    let result = test.subnet_message("take_canister_snapshot", args.encode());
+    let snapshot_id = CanisterSnapshotResponse::decode(&result.unwrap().bytes())
+        .unwrap()
+        .snapshot_id();
+
+    let heap_delta_estimate_after_taking_snapshot = test.state().metadata.heap_delta_estimate;
+
+    assert_gt!(
+        heap_delta_estimate_after_taking_snapshot,
+        initial_heap_delta_estimate,
+        "Expected the heap delta estimate to increase after taking a snapshot"
+    );
+
+    // Load canister snapshot back into the canister. This should succeed as there's
+    // still enough heap delta available.
+    let args: LoadCanisterSnapshotArgs =
+        LoadCanisterSnapshotArgs::new(canister_id, snapshot_id, None);
+    let result = test.subnet_message("load_canister_snapshot", args.encode());
+    assert!(result.is_ok());
+
+    let heap_delta_estimate_after_loading_snapshot = test.state().metadata.heap_delta_estimate;
+
+    assert_gt!(
+        heap_delta_estimate_after_loading_snapshot,
+        heap_delta_estimate_after_taking_snapshot,
+        "Expected the heap delta estimate to increase after loading a snapshot"
+    );
+
+    // Load the same snapshot again. This should fail as the canister is heap delta rate limited.
+    let args: LoadCanisterSnapshotArgs =
+        LoadCanisterSnapshotArgs::new(canister_id, snapshot_id, None);
+    let error = test
+        .subnet_message("load_canister_snapshot", args.encode())
+        .unwrap_err();
+    assert_eq!(error.code(), ErrorCode::CanisterHeapDeltaRateLimited);
+    let message = format!("Canister {} is heap delta rate limited", canister_id).to_string();
+    assert!(error.description().contains(&message));
+
+    let heap_delta_estimate_after_loading_snapshot_again =
+        test.state().metadata.heap_delta_estimate;
+    assert_eq!(
+        heap_delta_estimate_after_loading_snapshot_again,
+        heap_delta_estimate_after_loading_snapshot,
+        "Expected the heap delta estimate to remain the same after failing to load snapshot"
     );
 }
 


### PR DESCRIPTION
This PR updates the heap delta debit for the canister and the total estimate for the subnet after successful loading of a canister snapshot. Previously, we only performed the checks but did not update the corresponding values so it would still be possible to exceed the total heap delta.