### PR TITLE
feat(nns): Omit large fields for InstallCode

### DIFF
--- a/rs/nns/governance/tests/governance.rs
+++ b/rs/nns/governance/tests/governance.rs
@@ -60,6 +60,7 @@ use ic_nns_governance::{
         governance_error::ErrorType::{
             self, InsufficientFunds, NotAuthorized, NotFound, PreconditionFailed, ResourceExhausted,
         },
+        install_code::CanisterInstallMode,
         manage_neuron::{
             self,
             claim_or_refresh::{By, MemoAndController},
@@ -78,7 +79,7 @@ use ic_nns_governance::{
         AddOrRemoveNodeProvider, ApproveGenesisKyc, Ballot, BallotChange, BallotInfo,
         BallotInfoChange, CreateServiceNervousSystem, Empty, ExecuteNnsFunction,
         Governance as GovernanceProto, GovernanceChange, GovernanceError,
-        IdealMatchedParticipationFunction, KnownNeuron, KnownNeuronData, ListNeurons,
+        IdealMatchedParticipationFunction, InstallCode, KnownNeuron, KnownNeuronData, ListNeurons,
         ListProposalInfo, ListProposalInfoResponse, ManageNeuron, ManageNeuronResponse,
         MonthlyNodeProviderRewards, Motion, NetworkEconomics, Neuron, NeuronChange, NeuronState,
         NeuronType, NeuronsFundData, NeuronsFundParticipation, NeuronsFundSnapshot, NnsFunction,
@@ -7587,6 +7588,68 @@ fn test_list_proposals_removes_execute_nns_function_payload() {
         action,
         proposal::Action::ExecuteNnsFunction(eu) if eu.payload.is_empty()
     );
+}
+
+#[test]
+fn test_list_proposals_removes_install_code_large_fields() {
+    let original_install_code = InstallCode {
+        wasm_module: Some(vec![0; 100_000]),
+        arg: Some(vec![0; 1_000]),
+        install_mode: Some(CanisterInstallMode::Upgrade as i32),
+        canister_id: Some(GOVERNANCE_CANISTER_ID.into()),
+        skip_stopping_before_installing: Some(false),
+    };
+    let proto = GovernanceProto {
+        economics: Some(NetworkEconomics::with_default_values()),
+        proposals: btreemap! {
+            1 => ProposalData {
+                id: Some(ProposalId { id: 1 }),
+                proposal: Some(Proposal {
+                    title: Some("Upgrade canister".to_string()),
+                    action: Some(proposal::Action::InstallCode(original_install_code.clone())),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }
+        },
+        ..Default::default()
+    };
+    let driver = fake::FakeDriver::default();
+    let gov = Governance::new(
+        proto,
+        driver.get_fake_env(),
+        driver.get_fake_ledger(),
+        driver.get_fake_cmc(),
+    );
+    let caller = &principal(1);
+
+    let results = gov.list_proposals(
+        caller,
+        &ListProposalInfo {
+            ..Default::default()
+        },
+    );
+
+    let action = results.proposal_info[0]
+        .proposal
+        .as_ref()
+        .unwrap()
+        .action
+        .as_ref()
+        .unwrap();
+    match action {
+        proposal::Action::InstallCode(install_code) => {
+            assert_eq!(
+                install_code,
+                &InstallCode {
+                    wasm_module: None,
+                    arg: None,
+                    ..original_install_code
+                }
+            );
+        }
+        _ => panic!("Unexpected action"),
+    };
 }
 
 #[test]


### PR DESCRIPTION
# Why

The `InstallCode` is to replace the `NnsCanisterUpgrade` and `NnsRootUpgrade` NNS functions. The large fields within them needs to be omitted in the same way as `ExecuteNnsFunction`

# What

* Trigger `omit_large_fields` call `proposal_data_to_info` for multi queries
* Implement the omission logic to clear the wasm_module_and arg