### PR TITLE
feat(nns): Implement the execution of UpdateCanisterSettings proposals

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9606,6 +9606,7 @@ dependencies = [
  "ic-nns-governance-init",
  "ic-nns-governance-protobuf-generator",
  "ic-nns-gtc-accounts",
+ "ic-nns-handler-root-interface",
  "ic-protobuf",
  "ic-sns-init",
  "ic-sns-root",

--- a/rs/nervous_system/clients/src/canister_status.rs
+++ b/rs/nervous_system/clients/src/canister_status.rs
@@ -43,6 +43,15 @@ impl std::fmt::Display for CanisterStatusType {
     }
 }
 
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Deserialize, CandidType, Default)]
+pub enum LogVisibility {
+    #[default]
+    #[serde(rename = "controllers")]
+    Controllers = 1,
+    #[serde(rename = "public")]
+    Public = 2,
+}
+
 /// Partial copy-paste of ic-types::ic_00::DefiniteCanisterSettings.
 ///
 /// Only the fields that we need are copied.
@@ -55,6 +64,8 @@ pub struct DefiniteCanisterSettings {
     pub memory_allocation: Option<candid::Nat>,
     pub freezing_threshold: Option<candid::Nat>,
     pub reserved_cycles_limit: Option<candid::Nat>,
+    pub wasm_memory_limit: Option<candid::Nat>,
+    pub log_visibility: Option<LogVisibility>,
 }
 
 /// Partial copy-paste of ic-types::ic_00::CanisterStatusResult.
@@ -98,6 +109,8 @@ pub struct DefiniteCanisterSettingsFromManagementCanister {
     pub memory_allocation: candid::Nat,
     pub freezing_threshold: candid::Nat,
     pub reserved_cycles_limit: candid::Nat,
+    pub wasm_memory_limit: candid::Nat,
+    pub log_visibility: LogVisibility,
 }
 
 impl From<CanisterStatusResultFromManagementCanister> for CanisterStatusResult {
@@ -137,12 +150,16 @@ impl From<DefiniteCanisterSettingsFromManagementCanister> for DefiniteCanisterSe
             memory_allocation,
             freezing_threshold,
             reserved_cycles_limit,
+            wasm_memory_limit,
+            log_visibility,
         } = value;
 
         let compute_allocation = Some(compute_allocation);
         let memory_allocation = Some(memory_allocation);
         let freezing_threshold = Some(freezing_threshold);
         let reserved_cycles_limit = Some(reserved_cycles_limit);
+        let wasm_memory_limit = Some(wasm_memory_limit);
+        let log_visibility = Some(log_visibility);
 
         DefiniteCanisterSettings {
             controllers,
@@ -150,6 +167,8 @@ impl From<DefiniteCanisterSettingsFromManagementCanister> for DefiniteCanisterSe
             memory_allocation,
             freezing_threshold,
             reserved_cycles_limit,
+            wasm_memory_limit,
+            log_visibility,
         }
     }
 }
@@ -172,6 +191,8 @@ impl CanisterStatusResultFromManagementCanister {
                 memory_allocation: candid::Nat::from(45_u32),
                 freezing_threshold: candid::Nat::from(46_u32),
                 reserved_cycles_limit: candid::Nat::from(47_u32),
+                wasm_memory_limit: candid::Nat::from(48_u32),
+                log_visibility: LogVisibility::Controllers,
             },
             cycles: candid::Nat::from(47_u32),
             idle_cycles_burned_per_day: candid::Nat::from(48_u32),
@@ -351,6 +372,8 @@ impl From<CanisterStatusResultFromManagementCanister> for CanisterStatusResultV2
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+
     use crate::canister_status::{
         CanisterStatusResult, CanisterStatusResultFromManagementCanister, CanisterStatusType,
         DefiniteCanisterSettings, DefiniteCanisterSettingsFromManagementCanister,
@@ -371,6 +394,8 @@ mod tests {
                 memory_allocation: candid::Nat::from(98_u32),
                 freezing_threshold: candid::Nat::from(97_u32),
                 reserved_cycles_limit: candid::Nat::from(96_u32),
+                wasm_memory_limit: candid::Nat::from(95_u32),
+                log_visibility: LogVisibility::Controllers,
             },
             cycles: candid::Nat::from(999_u32),
             idle_cycles_burned_per_day: candid::Nat::from(998_u32),
@@ -387,6 +412,8 @@ mod tests {
                 memory_allocation: Some(candid::Nat::from(98_u32)),
                 freezing_threshold: Some(candid::Nat::from(97_u32)),
                 reserved_cycles_limit: Some(candid::Nat::from(96_u32)),
+                wasm_memory_limit: Some(candid::Nat::from(95_u32)),
+                log_visibility: Some(LogVisibility::Controllers),
             },
             cycles: candid::Nat::from(999_u32),
             idle_cycles_burned_per_day: Some(candid::Nat::from(998_u32)),

--- a/rs/nervous_system/clients/src/management_canister_client/tests.rs
+++ b/rs/nervous_system/clients/src/management_canister_client/tests.rs
@@ -1,5 +1,7 @@
 use super::*;
-use crate::canister_status::{CanisterStatusType, DefiniteCanisterSettingsFromManagementCanister};
+use crate::canister_status::{
+    CanisterStatusType, DefiniteCanisterSettingsFromManagementCanister, LogVisibility,
+};
 use candid::Nat;
 use ic_base_types::{CanisterId, PrincipalId};
 use rand::{thread_rng, Rng};
@@ -111,6 +113,8 @@ async fn test_limit_outstanding_calls() {
             memory_allocation: zero.clone(),
             freezing_threshold: zero.clone(),
             reserved_cycles_limit: zero.clone(),
+            wasm_memory_limit: zero.clone(),
+            log_visibility: LogVisibility::Controllers,
         },
         status: CanisterStatusType::Running,
         reserved_cycles: zero.clone(),

--- a/rs/nns/governance/BUILD.bazel
+++ b/rs/nns/governance/BUILD.bazel
@@ -29,6 +29,7 @@ BASE_DEPENDENCIES = [
     "//rs/nns/cmc",
     "//rs/nns/common",
     "//rs/nns/gtc_accounts",
+    "//rs/nns/handlers/root/interface",
     "//rs/protobuf",
     "//rs/registry/canister",
     "//rs/rosetta-api/icp_ledger",

--- a/rs/nns/governance/Cargo.toml
+++ b/rs/nns/governance/Cargo.toml
@@ -56,6 +56,7 @@ ic-nns-constants = { path = "../constants" }
 ic-nns-gtc-accounts = { path = "../gtc_accounts" }
 ic-nns-governance-api = { path = "./api" }
 ic-nns-governance-init = { path = "./init" }
+ic-nns-handler-root-interface = { path = "../handlers/root/interface" }
 ic-protobuf = { path = "../../protobuf" }
 ic-sns-init = { path = "../../sns/init" }                                                         # This is just for a couple of PB definitions.
 ic-sns-root = { path = "../../sns/root" }                                                         # This is just for a couple of PB definitions.

--- a/rs/nns/governance/src/proposals/update_canister_settings.rs
+++ b/rs/nns/governance/src/proposals/update_canister_settings.rs
@@ -87,7 +87,7 @@ impl UpdateCanisterSettings {
         let freezing_threshold = settings.freezing_threshold.map(Nat::from);
         let wasm_memory_limit = settings.wasm_memory_limit.map(Nat::from);
         let log_visibility = match settings.log_visibility {
-            Some(log_visibility_i32) => Some(Self::valid_log_visibility(log_visibility_i32)?),
+            Some(log_visibility) => Some(Self::valid_log_visibility(log_visibility)?),
             None => None,
         };
         // Reserved cycles limit is not supported yet.
@@ -244,6 +244,7 @@ mod tests {
 
         let update_ledger_canister_settings = UpdateCanisterSettings {
             canister_id: Some(LEDGER_CANISTER_ID.get()),
+            // The value of the settings are arbitrary and do not have any meaning.
             settings: Some(CanisterSettings {
                 controllers: Some(Controllers {
                     controllers: vec![GOVERNANCE_CANISTER_ID.get()],

--- a/rs/nns/governance/src/proposals/update_canister_settings.rs
+++ b/rs/nns/governance/src/proposals/update_canister_settings.rs
@@ -36,6 +36,11 @@ impl UpdateCanisterSettings {
             .ok_or(invalid_proposal_error("Canister ID is required"))?;
         let canister_id = CanisterId::try_from(canister_principal_id)
             .map_err(|_| invalid_proposal_error("Invalid canister ID"))?;
+        if canister_id == ROOT_CANISTER_ID {
+            return Err(invalid_proposal_error(
+                "Updating root canister settings is not supported yet.",
+            ));
+        }
         Ok(canister_id)
     }
 
@@ -220,6 +225,14 @@ mod tests {
                 ..valid_update_canister_settings.clone()
             },
             vec!["invalid log visibility", "0"],
+        );
+
+        is_invalid_proposal_with_keywords(
+            UpdateCanisterSettings {
+                canister_id: Some(ROOT_CANISTER_ID.get()),
+                ..valid_update_canister_settings.clone()
+            },
+            vec!["root canister", "not supported"],
         );
     }
 

--- a/rs/nns/handlers/root/impl/canister/canister.rs
+++ b/rs/nns/handlers/root/impl/canister/canister.rs
@@ -38,6 +38,7 @@ use ic_nns_handler_root::{
 };
 use ic_nns_handler_root_interface::{
     ChangeCanisterControllersRequest, ChangeCanisterControllersResponse,
+    UpdateCanisterSettingsRequest, UpdateCanisterSettingsResponse,
 };
 use std::cell::RefCell;
 
@@ -256,6 +257,25 @@ async fn change_canister_controllers_(
 ) -> ChangeCanisterControllersResponse {
     canister_management::change_canister_controllers(
         change_canister_controllers_request,
+        &mut new_management_canister_client(),
+    )
+    .await
+}
+
+/// Updates the canister settings of a canister controlled by NNS Root. Only callable by NNS
+/// Governance.
+#[export_name = "canister_update update_canister_settings"]
+fn update_canister_settings() {
+    check_caller_is_governance();
+    over_async(candid_one, update_canister_settings_);
+}
+
+#[candid_method(update, rename = "update_canister_settings")]
+async fn update_canister_settings_(
+    update_settings: UpdateCanisterSettingsRequest,
+) -> UpdateCanisterSettingsResponse {
+    canister_management::update_canister_settings(
+        update_settings,
         &mut new_management_canister_client(),
     )
     .await

--- a/rs/nns/handlers/root/impl/canister/root.did
+++ b/rs/nns/handlers/root/impl/canister/root.did
@@ -9,6 +9,15 @@ type AddCanisterRequest = record {
 type CanisterAction = variant { Start; Stop };
 type CanisterIdRecord = record { canister_id : principal };
 type CanisterInstallMode = variant { reinstall; upgrade; install };
+type CanisterSettings = record {
+  freezing_threshold : opt nat;
+  controllers : opt vec principal;
+  reserved_cycles_limit : opt nat;
+  log_visibility : opt LogVisibility;
+  wasm_memory_limit : opt nat;
+  memory_allocation : opt nat;
+  compute_allocation : opt nat;
+};
 type CanisterStatusResult = record {
   status : CanisterStatusType;
   memory_size : nat;
@@ -47,12 +56,27 @@ type DefiniteCanisterSettings = record {
   freezing_threshold : opt nat;
   controllers : vec principal;
   reserved_cycles_limit : opt nat;
+  log_visibility : opt LogVisibility;
+  wasm_memory_limit : opt nat;
   memory_allocation : opt nat;
   compute_allocation : opt nat;
 };
+type LogVisibility = variant { controllers; public };
 type StopOrStartCanisterRequest = record {
   action : CanisterAction;
   canister_id : principal;
+};
+type UpdateCanisterSettingsError = record {
+  code : opt int32;
+  description : text;
+};
+type UpdateCanisterSettingsRequest = record {
+  canister_id : principal;
+  settings : CanisterSettings;
+};
+type UpdateCanisterSettingsResponse = variant {
+  Ok;
+  Err : UpdateCanisterSettingsError;
 };
 service : {
   add_nns_canister : (AddCanisterRequest) -> ();
@@ -63,4 +87,7 @@ service : {
   change_nns_canister : (ChangeCanisterRequest) -> ();
   get_build_metadata : () -> (text) query;
   stop_or_start_nns_canister : (StopOrStartCanisterRequest) -> ();
+  update_canister_settings : (UpdateCanisterSettingsRequest) -> (
+      UpdateCanisterSettingsResponse,
+    );
 }

--- a/rs/nns/handlers/root/impl/src/canister_management.rs
+++ b/rs/nns/handlers/root/impl/src/canister_management.rs
@@ -17,6 +17,7 @@ use ic_nns_common::{
 };
 use ic_nns_handler_root_interface::{
     ChangeCanisterControllersRequest, ChangeCanisterControllersResponse,
+    UpdateCanisterSettingsError, UpdateCanisterSettingsRequest, UpdateCanisterSettingsResponse,
 };
 use ic_protobuf::{
     registry::nns::v1::{NnsCanisterRecord, NnsCanisterRecords},
@@ -217,6 +218,30 @@ pub async fn change_canister_controllers(
         Ok(()) => ChangeCanisterControllersResponse::ok(),
         Err((code, description)) => {
             ChangeCanisterControllersResponse::error(Some(code), description)
+        }
+    }
+}
+
+pub async fn update_canister_settings(
+    update_canister_settings_request: UpdateCanisterSettingsRequest,
+    management_canister_client: &mut impl ManagementCanisterClient,
+) -> UpdateCanisterSettingsResponse {
+    let update_settings_args = UpdateSettings {
+        canister_id: update_canister_settings_request.canister_id,
+        settings: update_canister_settings_request.settings,
+        sender_canister_version: management_canister_client.canister_version(),
+    };
+
+    match management_canister_client
+        .update_settings(update_settings_args)
+        .await
+    {
+        Ok(()) => UpdateCanisterSettingsResponse::Ok(()),
+        Err((code, description)) => {
+            UpdateCanisterSettingsResponse::Err(UpdateCanisterSettingsError {
+                code: Some(code),
+                description,
+            })
         }
     }
 }

--- a/rs/nns/handlers/root/interface/src/client.rs
+++ b/rs/nns/handlers/root/interface/src/client.rs
@@ -8,7 +8,9 @@ use dfn_core::call;
 use ic_base_types::PrincipalId;
 use ic_nervous_system_clients::{
     canister_id_record::CanisterIdRecord,
-    canister_status::{CanisterStatusResult, CanisterStatusType, DefiniteCanisterSettings},
+    canister_status::{
+        CanisterStatusResult, CanisterStatusType, DefiniteCanisterSettings, LogVisibility,
+    },
 };
 use ic_nns_constants::ROOT_CANISTER_ID;
 use std::{
@@ -216,6 +218,8 @@ impl SpyNnsRootCanisterClientReply {
                 memory_allocation: Some(candid::Nat::from(8_u32)),
                 freezing_threshold: Some(candid::Nat::from(9_u32)),
                 reserved_cycles_limit: Some(candid::Nat::from(10_u32)),
+                wasm_memory_limit: Some(candid::Nat::from(11_u32)),
+                log_visibility: Some(LogVisibility::Controllers),
             },
             cycles: candid::Nat::from(42_u32),
             idle_cycles_burned_per_day: Some(candid::Nat::from(43_u32)),

--- a/rs/nns/handlers/root/interface/src/lib.rs
+++ b/rs/nns/handlers/root/interface/src/lib.rs
@@ -1,5 +1,6 @@
 use candid::CandidType;
 use ic_base_types::PrincipalId;
+use ic_nervous_system_clients::update_settings::CanisterSettings;
 use serde::Deserialize;
 
 pub mod client;
@@ -60,4 +61,24 @@ impl ChangeCanisterControllersResponse {
             change_canister_controllers_result: ChangeCanisterControllersResult::Ok(()),
         }
     }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Deserialize, CandidType)]
+pub struct UpdateCanisterSettingsRequest {
+    // The canister ID of the target canister.
+    pub canister_id: PrincipalId,
+    // The settings to be updated.
+    pub settings: CanisterSettings,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Deserialize, CandidType)]
+pub enum UpdateCanisterSettingsResponse {
+    Ok(()),
+    Err(UpdateCanisterSettingsError),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Deserialize, CandidType)]
+pub struct UpdateCanisterSettingsError {
+    pub code: Option<i32>,
+    pub description: String,
 }

--- a/rs/nns/integration_tests/src/update_canister_settings.rs
+++ b/rs/nns/integration_tests/src/update_canister_settings.rs
@@ -44,25 +44,25 @@ fn test_update_canister_settings() {
         .unwrap()
         .settings
     };
-    let current_settings = canister_settings();
-    assert_ne!(current_settings.controllers, target_controllers);
+    let original_settings = canister_settings();
+    assert_ne!(original_settings.controllers, target_controllers);
     assert_ne!(
-        current_settings.memory_allocation,
+        original_settings.memory_allocation,
         Some(Nat::from(target_memory_allocation))
     );
     assert_ne!(
-        current_settings.compute_allocation,
+        original_settings.compute_allocation,
         Some(Nat::from(target_compute_allocation))
     );
     assert_ne!(
-        current_settings.freezing_threshold,
+        original_settings.freezing_threshold,
         Some(Nat::from(target_freezing_threshold))
     );
     assert_ne!(
-        current_settings.wasm_memory_limit,
+        original_settings.wasm_memory_limit,
         Some(Nat::from(target_wasm_memory_limit))
     );
-    assert_ne!(current_settings.log_visibility, target_log_visibility);
+    assert_ne!(original_settings.log_visibility, target_log_visibility);
 
     // Step 3: Make a proposal to update settings of the registry canister and make sure the
     // proposal execution succeeds.

--- a/rs/nns/integration_tests/src/update_canister_settings.rs
+++ b/rs/nns/integration_tests/src/update_canister_settings.rs
@@ -1,14 +1,21 @@
-use ic_nns_constants::REGISTRY_CANISTER_ID;
+use candid::Nat;
+use ic_base_types::{CanisterId, PrincipalId};
+use ic_nervous_system_clients::canister_status::{DefiniteCanisterSettings, LogVisibility};
+use ic_nns_constants::{REGISTRY_CANISTER_ID, ROOT_CANISTER_ID};
 use ic_nns_governance::pb::v1::{
-    manage_neuron_response::Command, proposal::Action, update_canister_settings::CanisterSettings,
+    manage_neuron_response::Command,
+    proposal::Action,
+    update_canister_settings::{
+        CanisterSettings, Controllers, LogVisibility as GovernanceLogVisibility,
+    },
     Proposal, UpdateCanisterSettings,
 };
 use ic_nns_test_utils::{
     common::NnsInitPayloadsBuilder,
     neuron_helpers::get_neuron_1,
     state_test_helpers::{
-        nns_governance_make_proposal, nns_wait_for_proposal_failure, setup_nns_canisters,
-        state_machine_builder_for_nns_tests,
+        get_canister_status, nns_governance_make_proposal, nns_wait_for_proposal_execution,
+        setup_nns_canisters, state_machine_builder_for_nns_tests,
     },
 };
 
@@ -20,7 +27,45 @@ fn test_update_canister_settings() {
     setup_nns_canisters(&state_machine, nns_init_payloads);
     let n1 = get_neuron_1();
 
-    // Step 2: Make a proposal to update settings of the registry canister.
+    // Step 2: Define the target settings and make sure they are different from the current ones.
+    let target_controllers = vec![ROOT_CANISTER_ID.get(), PrincipalId::new_user_test_id(1)];
+    let target_memory_allocation = 1u64 << 33;
+    let target_compute_allocation = 10u64;
+    let target_freezing_threshold = 100_000u64;
+    let target_wasm_memory_limit = 1u64 << 32;
+    let target_log_visibility = Some(LogVisibility::Public);
+    let canister_settings = || -> DefiniteCanisterSettings {
+        get_canister_status(
+            &state_machine,
+            ROOT_CANISTER_ID.get(),
+            REGISTRY_CANISTER_ID,
+            CanisterId::ic_00(),
+        )
+        .unwrap()
+        .settings
+    };
+    let current_settings = canister_settings();
+    assert_ne!(current_settings.controllers, target_controllers);
+    assert_ne!(
+        current_settings.memory_allocation,
+        Some(Nat::from(target_memory_allocation))
+    );
+    assert_ne!(
+        current_settings.compute_allocation,
+        Some(Nat::from(target_compute_allocation))
+    );
+    assert_ne!(
+        current_settings.freezing_threshold,
+        Some(Nat::from(target_freezing_threshold))
+    );
+    assert_ne!(
+        current_settings.wasm_memory_limit,
+        Some(Nat::from(target_wasm_memory_limit))
+    );
+    assert_ne!(current_settings.log_visibility, target_log_visibility);
+
+    // Step 3: Make a proposal to update settings of the registry canister and make sure the
+    // proposal execution succeeds.
     let propose_response = nns_governance_make_proposal(
         &state_machine,
         n1.principal_id,
@@ -30,8 +75,14 @@ fn test_update_canister_settings() {
             action: Some(Action::UpdateCanisterSettings(UpdateCanisterSettings {
                 canister_id: Some(REGISTRY_CANISTER_ID.get()),
                 settings: Some(CanisterSettings {
-                    memory_allocation: Some(1 << 32),
-                    ..Default::default()
+                    controllers: Some(Controllers {
+                        controllers: target_controllers.clone(),
+                    }),
+                    memory_allocation: Some(target_memory_allocation),
+                    compute_allocation: Some(target_compute_allocation),
+                    freezing_threshold: Some(target_freezing_threshold),
+                    wasm_memory_limit: Some(target_wasm_memory_limit),
+                    log_visibility: Some(GovernanceLogVisibility::Public as i32),
                 }),
             })),
             ..Default::default()
@@ -41,9 +92,26 @@ fn test_update_canister_settings() {
         Command::MakeProposal(response) => response.proposal_id.unwrap(),
         _ => panic!("Propose didn't return MakeProposal"),
     };
+    nns_wait_for_proposal_execution(&state_machine, proposal_id.id);
 
-    // Step 3: make sure it fails to execute since it's fully implemented yet.
-    // TODO(NNS1-2522): test that the proposal is executed successfully after it's fully
-    // implemented.
-    nns_wait_for_proposal_failure(&state_machine, proposal_id.id);
+    // Step 4: Make sure the settings have been updated.
+    let updated_settings = canister_settings();
+    assert_eq!(updated_settings.controllers, target_controllers);
+    assert_eq!(
+        updated_settings.memory_allocation,
+        Some(Nat::from(target_memory_allocation))
+    );
+    assert_eq!(
+        updated_settings.compute_allocation,
+        Some(Nat::from(target_compute_allocation))
+    );
+    assert_eq!(
+        updated_settings.freezing_threshold,
+        Some(Nat::from(target_freezing_threshold))
+    );
+    assert_eq!(
+        updated_settings.wasm_memory_limit,
+        Some(Nat::from(target_wasm_memory_limit))
+    );
+    assert_eq!(updated_settings.log_visibility, target_log_visibility);
 }

--- a/rs/sns/root/canister/root.did
+++ b/rs/sns/root/canister/root.did
@@ -36,6 +36,8 @@ type DefiniteCanisterSettings = record {
   freezing_threshold : opt nat;
   controllers : vec principal;
   reserved_cycles_limit : opt nat;
+  log_visibility : opt LogVisibility;
+  wasm_memory_limit : opt nat;
   memory_allocation : opt nat;
   compute_allocation : opt nat;
 };
@@ -68,6 +70,7 @@ type ListSnsCanistersResponse = record {
   dapps : vec principal;
   archives : vec principal;
 };
+type LogVisibility = variant { controllers; public };
 type ManageDappCanisterSettingsRequest = record {
   freezing_threshold : opt nat64;
   canister_ids : vec principal;

--- a/rs/sns/swap/canister/canister.rs
+++ b/rs/sns/swap/canister/canister.rs
@@ -570,6 +570,7 @@ mod tests {
         canister_status::{
             CanisterStatusResultFromManagementCanister, CanisterStatusResultV2, CanisterStatusType,
             DefiniteCanisterSettingsArgs, DefiniteCanisterSettingsFromManagementCanister,
+            LogVisibility,
         },
         management_canister_client::{
             MockManagementCanisterClient, MockManagementCanisterClientReply,
@@ -627,6 +628,8 @@ mod tests {
                         memory_allocation: candid::Nat::from(0_u32),
                         freezing_threshold: candid::Nat::from(0_u32),
                         reserved_cycles_limit: candid::Nat::from(0_u32),
+                        wasm_memory_limit: candid::Nat::from(0_u32),
+                        log_visibility: LogVisibility::Controllers,
                     },
                     cycles: candid::Nat::from(0_u32),
                     idle_cycles_burned_per_day: candid::Nat::from(0_u32),


### PR DESCRIPTION
# Why

The `UpdateCanisterSettings` proposal type was defined so that canisters controlled by NNS Root can have their settings changed. This PR implements the execution of the proposal.

# What

* Define an NNS Root endpoint `update_canister_settings` and implement it by calling the management canister
* When the `UpdateCanisterSettings` proposal executes, call the `update_canister_settings` with the correct payload
* The `canister_status` client has its types updated to include new fields `wasm_memory_limit` and `log_visibility`
* Do not allow such proposals targeting NNS Root, since it needs another endpoint sent to Lifeline