### PR TITLE
fix: update cloudflare dependency [S3_UPLOAD]

### DIFF
--- a/Cargo.Bazel.Fuzzing.json.lock
+++ b/Cargo.Bazel.Fuzzing.json.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "fed910ed706c35885421f708c3411a1374904dbf5ff740376ad876d49cbfa1f8",
+  "checksum": "e152d000fdef6934f0c6ca0dafd60bbe8a5054c3b9b6104e4921c5e79b6ed128",
   "crates": {
     "abnf 0.12.0": {
       "name": "abnf",
@@ -11853,15 +11853,15 @@
       ],
       "license_file": null
     },
-    "cloudflare 0.11.0": {
+    "cloudflare 0.12.0": {
       "name": "cloudflare",
-      "version": "0.11.0",
+      "version": "0.12.0",
       "package_url": null,
       "repository": {
         "Git": {
-          "remote": "https://github.com/blind-oracle/cloudflare-rs.git",
+          "remote": "https://github.com/dfinity/cloudflare-rs.git",
           "commitish": {
-            "Rev": "386c8c6a0a95ad0c8a87aa1aac27b26a6cfec5cc"
+            "Rev": "a6538a036926bd756986c9c0a5de356daef48881"
           },
           "strip_prefix": "cloudflare"
         }
@@ -11941,7 +11941,7 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.11.0"
+        "version": "0.12.0"
       },
       "license": "BSD-3-Clause",
       "license_ids": [
@@ -17147,7 +17147,7 @@
               "target": "clap"
             },
             {
-              "id": "cloudflare 0.11.0",
+              "id": "cloudflare 0.12.0",
               "target": "cloudflare"
             },
             {
@@ -51400,7 +51400,11 @@
           "common": [
             "__rustls",
             "__tls",
+            "async-compression",
             "blocking",
+            "brotli",
+            "deflate",
+            "gzip",
             "hyper-rustls",
             "json",
             "mime_guess",
@@ -51472,6 +51476,10 @@
           ],
           "selects": {
             "cfg(not(target_arch = \"wasm32\"))": [
+              {
+                "id": "async-compression 0.4.4",
+                "target": "async_compression"
+              },
               {
                 "id": "encoding_rs 0.8.33",
                 "target": "encoding_rs"
@@ -78279,7 +78287,7 @@
     "cidr 0.2.3",
     "clap 3.2.25",
     "clap 4.4.6",
-    "cloudflare 0.11.0",
+    "cloudflare 0.12.0",
     "colored 2.0.4",
     "comparable 0.5.4",
     "console 0.11.3",

--- a/Cargo.Bazel.Fuzzing.toml.lock
+++ b/Cargo.Bazel.Fuzzing.toml.lock
@@ -2012,8 +2012,8 @@ dependencies = [
 
 [[package]]
 name = "cloudflare"
-version = "0.11.0"
-source = "git+https://github.com/blind-oracle/cloudflare-rs.git?rev=386c8c6a0a95ad0c8a87aa1aac27b26a6cfec5cc#386c8c6a0a95ad0c8a87aa1aac27b26a6cfec5cc"
+version = "0.12.0"
+source = "git+https://github.com/dfinity/cloudflare-rs.git?rev=a6538a036926bd756986c9c0a5de356daef48881#a6538a036926bd756986c9c0a5de356daef48881"
 dependencies = [
  "chrono",
  "http 0.2.12",
@@ -8769,6 +8769,7 @@ version = "0.11.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
 dependencies = [
+ "async-compression",
  "base64 0.21.4",
  "bytes",
  "encoding_rs",

--- a/Cargo.Bazel.json.lock
+++ b/Cargo.Bazel.json.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "5d815f09484e8c3700569828efe9c7cf3d9a1ee161331da6a1594082eaa99734",
+  "checksum": "74a78ec75bce5fb795eb1b07067a370679236206c6891f2fbd43a7b520e01d36",
   "crates": {
     "abnf 0.12.0": {
       "name": "abnf",
@@ -11760,9 +11760,9 @@
       "package_url": null,
       "repository": {
         "Git": {
-          "remote": "https://github.com/blind-oracle/cloudflare-rs.git",
+          "remote": "https://github.com/r-birkner/cloudflare-rs.git",
           "commitish": {
-            "Rev": "386c8c6a0a95ad0c8a87aa1aac27b26a6cfec5cc"
+            "Rev": "966e23a7d63f5a3e91471d4e045b3855f38cb329"
           },
           "strip_prefix": "cloudflare"
         }
@@ -51459,7 +51459,11 @@
           "common": [
             "__rustls",
             "__tls",
+            "async-compression",
             "blocking",
+            "brotli",
+            "deflate",
+            "gzip",
             "hyper-rustls",
             "json",
             "mime_guess",
@@ -51531,6 +51535,10 @@
           ],
           "selects": {
             "cfg(not(target_arch = \"wasm32\"))": [
+              {
+                "id": "async-compression 0.4.3",
+                "target": "async_compression"
+              },
               {
                 "id": "encoding_rs 0.8.32",
                 "target": "encoding_rs"

--- a/Cargo.Bazel.json.lock
+++ b/Cargo.Bazel.json.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "74141f3f2cc8a906034be21622aa5dbd271a54f38b140c3b1cad846ecb847b1c",
+  "checksum": "d73da85c93e5672ba118ae694d4d829bbad178fb459de1fdc410378437c6bc02",
   "crates": {
     "abnf 0.12.0": {
       "name": "abnf",

--- a/Cargo.Bazel.json.lock
+++ b/Cargo.Bazel.json.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "74a78ec75bce5fb795eb1b07067a370679236206c6891f2fbd43a7b520e01d36",
+  "checksum": "74141f3f2cc8a906034be21622aa5dbd271a54f38b140c3b1cad846ecb847b1c",
   "crates": {
     "abnf 0.12.0": {
       "name": "abnf",
@@ -11754,15 +11754,15 @@
       ],
       "license_file": null
     },
-    "cloudflare 0.11.0": {
+    "cloudflare 0.12.0": {
       "name": "cloudflare",
-      "version": "0.11.0",
+      "version": "0.12.0",
       "package_url": null,
       "repository": {
         "Git": {
-          "remote": "https://github.com/r-birkner/cloudflare-rs.git",
+          "remote": "https://github.com/dfinity/cloudflare-rs.git",
           "commitish": {
-            "Rev": "966e23a7d63f5a3e91471d4e045b3855f38cb329"
+            "Rev": "a6538a036926bd756986c9c0a5de356daef48881"
           },
           "strip_prefix": "cloudflare"
         }
@@ -11842,7 +11842,7 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.11.0"
+        "version": "0.12.0"
       },
       "license": "BSD-3-Clause",
       "license_ids": [
@@ -16980,7 +16980,7 @@
               "target": "clap"
             },
             {
-              "id": "cloudflare 0.11.0",
+              "id": "cloudflare 0.12.0",
               "target": "cloudflare"
             },
             {
@@ -78405,7 +78405,7 @@
     "cidr 0.2.3",
     "clap 3.2.25",
     "clap 4.4.8",
-    "cloudflare 0.11.0",
+    "cloudflare 0.12.0",
     "colored 2.0.4",
     "comparable 0.5.4",
     "console 0.11.3",

--- a/Cargo.Bazel.json.lock
+++ b/Cargo.Bazel.json.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "d73da85c93e5672ba118ae694d4d829bbad178fb459de1fdc410378437c6bc02",
+  "checksum": "78efc5b8c1207de7215cd3b5b23cdc4dbd3f2d7aa4ff3ccc08618678733ee6dc",
   "crates": {
     "abnf 0.12.0": {
       "name": "abnf",

--- a/Cargo.Bazel.toml.lock
+++ b/Cargo.Bazel.toml.lock
@@ -2015,7 +2015,7 @@ dependencies = [
 [[package]]
 name = "cloudflare"
 version = "0.11.0"
-source = "git+https://github.com/blind-oracle/cloudflare-rs.git?rev=386c8c6a0a95ad0c8a87aa1aac27b26a6cfec5cc#386c8c6a0a95ad0c8a87aa1aac27b26a6cfec5cc"
+source = "git+https://github.com/r-birkner/cloudflare-rs.git?rev=966e23a7d63f5a3e91471d4e045b3855f38cb329#966e23a7d63f5a3e91471d4e045b3855f38cb329"
 dependencies = [
  "chrono",
  "http 0.2.12",
@@ -8789,6 +8789,7 @@ version = "0.11.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
 dependencies = [
+ "async-compression",
  "base64 0.21.6",
  "bytes",
  "encoding_rs",

--- a/Cargo.Bazel.toml.lock
+++ b/Cargo.Bazel.toml.lock
@@ -2014,8 +2014,8 @@ dependencies = [
 
 [[package]]
 name = "cloudflare"
-version = "0.11.0"
-source = "git+https://github.com/r-birkner/cloudflare-rs.git?rev=966e23a7d63f5a3e91471d4e045b3855f38cb329#966e23a7d63f5a3e91471d4e045b3855f38cb329"
+version = "0.12.0"
+source = "git+https://github.com/dfinity/cloudflare-rs.git?rev=a6538a036926bd756986c9c0a5de356daef48881#a6538a036926bd756986c9c0a5de356daef48881"
 dependencies = [
  "chrono",
  "http 0.2.12",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2177,13 +2177,13 @@ dependencies = [
 
 [[package]]
 name = "cloudflare"
-version = "0.11.0"
-source = "git+https://github.com/blind-oracle/cloudflare-rs.git?rev=386c8c6a0a95ad0c8a87aa1aac27b26a6cfec5cc#386c8c6a0a95ad0c8a87aa1aac27b26a6cfec5cc"
+version = "0.12.0"
+source = "git+https://github.com/dfinity/cloudflare-rs.git?rev=a6538a036926bd756986c9c0a5de356daef48881#a6538a036926bd756986c9c0a5de356daef48881"
 dependencies = [
  "chrono",
  "http 0.2.12",
  "percent-encoding",
- "reqwest 0.11.22",
+ "reqwest 0.11.27",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -5517,7 +5517,7 @@ dependencies = [
  "ratelimit",
  "rcgen",
  "regex",
- "reqwest 0.11.22",
+ "reqwest 0.11.27",
  "rustls 0.21.12",
  "rustls-pemfile 2.1.2",
  "serde",
@@ -17249,10 +17249,11 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.22"
+version = "0.11.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "046cd98826c46c2ac8ddecae268eb5c2e58628688a5fc7a2643704a73faba95b"
+checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
 dependencies = [
+ "async-compression",
  "base64 0.21.5",
  "bytes",
  "encoding_rs",
@@ -17276,6 +17277,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
+ "sync_wrapper 0.1.2",
  "system-configuration",
  "tokio",
  "tokio-rustls 0.24.1",
@@ -17284,7 +17286,7 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams 0.3.0",
+ "wasm-streams",
  "web-sys",
  "webpki-roots 0.25.2",
  "winreg 0.50.0",
@@ -17333,7 +17335,7 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams 0.4.0",
+ "wasm-streams",
  "web-sys",
  "webpki-roots 0.26.1",
  "winreg 0.52.0",
@@ -20931,19 +20933,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b4a05336882dae732ce6bd48b7e11fe597293cb72c13da4f35d7d5f8d53b2a7"
 dependencies = [
  "leb128",
-]
-
-[[package]]
-name = "wasm-streams"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4609d447824375f43e1ffbc051b50ad8f4b3ae8219680c94452ea05eb240ac7"
-dependencies = [
- "futures-util",
- "js-sys",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -468,11 +468,11 @@ chrono = { version = "0.4.38", default-features = false, features = [
 ] }
 ciborium = "0.2.1"
 clap = { version = "4.4.6", features = ["derive", "string"] }
-# cloudflare v0.11 is broken, master is partly fixed but unreleased yet.
+# cloudflare v0.12 is broken, master is partly fixed but unreleased yet.
 # see:
 # - https://github.com/cloudflare/cloudflare-rs/issues/222
 # - https://github.com/cloudflare/cloudflare-rs/issues/236
-cloudflare = { git = "https://github.com/r-birkner/cloudflare-rs.git", rev = "966e23a7d63f5a3e91471d4e045b3855f38cb329", default-features = false, feature = [
+cloudflare = { git = "https://github.com/dfinity/cloudflare-rs.git", rev = "a6538a036926bd756986c9c0a5de356daef48881", default-features = false, feature = [
     "rustls-tls",
 ] }
 humantime-serde = "1.1.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -472,7 +472,7 @@ clap = { version = "4.4.6", features = ["derive", "string"] }
 # see:
 # - https://github.com/cloudflare/cloudflare-rs/issues/222
 # - https://github.com/cloudflare/cloudflare-rs/issues/236
-cloudflare = { git = "https://github.com/blind-oracle/cloudflare-rs.git", rev = "386c8c6a0a95ad0c8a87aa1aac27b26a6cfec5cc", default-features = false, feature = [
+cloudflare = { git = "https://github.com/r-birkner/cloudflare-rs.git", rev = "966e23a7d63f5a3e91471d4e045b3855f38cb329", default-features = false, feature = [
     "rustls-tls",
 ] }
 humantime-serde = "1.1.1"

--- a/bazel/external_crates.bzl
+++ b/bazel/external_crates.bzl
@@ -334,8 +334,8 @@ def external_crates_repository(name, cargo_lockfile, lockfile, sanitizers_enable
                 ],
             ),
             "cloudflare": crate.spec(
-                git = "https://github.com/r-birkner/cloudflare-rs.git",
-                rev = "966e23a7d63f5a3e91471d4e045b3855f38cb329",
+                git = "https://github.com/dfinity/cloudflare-rs.git",
+                rev = "a6538a036926bd756986c9c0a5de356daef48881",
                 default_features = False,
                 features = [
                     "rustls-tls",

--- a/bazel/external_crates.bzl
+++ b/bazel/external_crates.bzl
@@ -334,8 +334,8 @@ def external_crates_repository(name, cargo_lockfile, lockfile, sanitizers_enable
                 ],
             ),
             "cloudflare": crate.spec(
-                git = "https://github.com/blind-oracle/cloudflare-rs.git",
-                rev = "386c8c6a0a95ad0c8a87aa1aac27b26a6cfec5cc",
+                git = "https://github.com/r-birkner/cloudflare-rs.git",
+                rev = "966e23a7d63f5a3e91471d4e045b3855f38cb329",
                 default_features = False,
                 features = [
                     "rustls-tls",

--- a/rs/boundary_node/ic_boundary/Cargo.toml
+++ b/rs/boundary_node/ic_boundary/Cargo.toml
@@ -68,7 +68,7 @@ rand = { workspace = true }
 ratelimit = "0.9.1"
 rcgen = { workspace = true }
 regex = { workspace = true }
-reqwest = { version = "0.11.22", default-features = false, features = [
+reqwest = { version = "0.11.27", default-features = false, features = [
     "blocking",
     "json",
     "multipart",


### PR DESCRIPTION
Switching to our own fork of `cloudflare-rs` as it is not maintained and some APIs are broken due to deprecation of certain fields (`locked` and `multiple_railguns_allowed`).