### PR TITLE
feat(ckerc20): Use EVM-RPC canister to call `eth_getTransactionReceipt`

### DIFF
--- a/rs/ethereum/cketh/minter/src/eth_rpc_client/responses.rs
+++ b/rs/ethereum/cketh/minter/src/eth_rpc_client/responses.rs
@@ -71,13 +71,24 @@ impl From<TransactionStatus> for ethnum::u256 {
     }
 }
 
+impl TryFrom<u8> for TransactionStatus {
+    type Error = String;
+
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        match value {
+            0 => Ok(TransactionStatus::Failure),
+            1 => Ok(TransactionStatus::Success),
+            _ => Err(format!("invalid transaction status: {}", value)),
+        }
+    }
+}
+
 impl TryFrom<ethnum::u256> for TransactionStatus {
     type Error = String;
 
     fn try_from(value: ethnum::u256) -> Result<Self, Self::Error> {
         match value {
-            ethnum::u256::ZERO => Ok(TransactionStatus::Failure),
-            ethnum::u256::ONE => Ok(TransactionStatus::Success),
+            ethnum::u256::ZERO | ethnum::u256::ONE => TransactionStatus::try_from(value.as_u8()),
             _ => Err(format!("invalid transaction status: {}", value)),
         }
     }

--- a/rs/ethereum/cketh/minter/tests/cketh.rs
+++ b/rs/ethereum/cketh/minter/tests/cketh.rs
@@ -1077,6 +1077,9 @@ fn should_retrieve_minter_info() {
                 max_priority_fee_per_gas: price.max_priority_fee_per_gas,
                 timestamp: price.timestamp.unwrap(),
             }),
+            eth_balance: info_after_deposit
+                .eth_balance
+                .map(|balance| balance - withdrawal_amount),
             ..info_after_deposit
         }
     );

--- a/rs/ethereum/cketh/minter/tests/cketh.rs
+++ b/rs/ethereum/cketh/minter/tests/cketh.rs
@@ -1069,6 +1069,8 @@ fn should_retrieve_minter_info() {
         .setup;
     let info_after_withdrawal = cketh.get_minter_info();
     let price = cketh.eip_1559_transaction_price_expecting_ok(None);
+    let debited_amount =
+        withdrawal_amount - (price.max_transaction_fee - GAS_USED * EFFECTIVE_GAS_PRICE);
     assert_eq!(
         info_after_withdrawal,
         MinterInfo {
@@ -1079,7 +1081,7 @@ fn should_retrieve_minter_info() {
             }),
             eth_balance: info_after_deposit
                 .eth_balance
-                .map(|balance| balance - withdrawal_amount),
+                .map(|balance| balance - debited_amount),
             ..info_after_deposit
         }
     );

--- a/rs/ethereum/cketh/test_utils/src/flow.rs
+++ b/rs/ethereum/cketh/test_utils/src/flow.rs
@@ -818,9 +818,7 @@ impl<T: AsRef<CkEthSetup>, Req: HasWithdrawalId> TransactionReceiptProcessWithdr
         (override_mock)(default_eth_get_transaction_receipt)
             .build()
             .expect_rpc_calls(&self.setup);
-        if self.setup.as_ref().evm_rpc_id.is_some() {
-            self.setup.as_ref().env.tick();
-        }
+        self.setup.as_ref().env.tick();
         self
     }
 

--- a/rs/ethereum/cketh/test_utils/src/flow.rs
+++ b/rs/ethereum/cketh/test_utils/src/flow.rs
@@ -818,6 +818,9 @@ impl<T: AsRef<CkEthSetup>, Req: HasWithdrawalId> TransactionReceiptProcessWithdr
         (override_mock)(default_eth_get_transaction_receipt)
             .build()
             .expect_rpc_calls(&self.setup);
+        if self.setup.as_ref().evm_rpc_id.is_some() {
+            self.setup.as_ref().env.tick();
+        }
         self
     }
 

--- a/rs/ethereum/evm-rpc-client/src/lib.rs
+++ b/rs/ethereum/evm-rpc-client/src/lib.rs
@@ -5,7 +5,7 @@ pub mod types;
 
 use crate::types::candid::{
     Block, BlockTag, FeeHistory, FeeHistoryArgs, GetLogsArgs, LogEntry, MultiRpcResult,
-    ProviderError, RpcConfig, RpcError, RpcServices,
+    ProviderError, RpcConfig, RpcError, RpcServices, TransactionReceipt,
 };
 use async_trait::async_trait;
 use candid::utils::ArgumentEncoder;
@@ -45,6 +45,7 @@ pub struct OverrideRpcConfig {
     pub eth_get_block_by_number: Option<RpcConfig>,
     pub eth_get_logs: Option<RpcConfig>,
     pub eth_fee_history: Option<RpcConfig>,
+    pub eth_get_transaction_receipt: Option<RpcConfig>,
 }
 
 impl<L: Sink> EvmRpcClient<IcRuntime, L> {
@@ -84,6 +85,18 @@ impl<R: Runtime, L: Sink> EvmRpcClient<R, L> {
             "eth_feeHistory",
             self.override_rpc_config.eth_fee_history.clone(),
             args,
+        )
+        .await
+    }
+
+    pub async fn eth_get_transaction_receipt(
+        &self,
+        transaction_hash: String,
+    ) -> MultiRpcResult<Option<TransactionReceipt>> {
+        self.call_internal(
+            "eth_getTransactionReceipt",
+            self.override_rpc_config.eth_get_transaction_receipt.clone(),
+            transaction_hash,
         )
         .await
     }

--- a/rs/ethereum/evm-rpc-client/src/types.rs
+++ b/rs/ethereum/evm-rpc-client/src/types.rs
@@ -142,6 +142,31 @@ pub mod candid {
         pub reward: Vec<Vec<Nat>>,
     }
 
+    #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, CandidType)]
+    pub struct TransactionReceipt {
+        #[serde(rename = "blockHash")]
+        pub block_hash: String,
+        #[serde(rename = "blockNumber")]
+        pub block_number: Nat,
+        #[serde(rename = "effectiveGasPrice")]
+        pub effective_gas_price: Nat,
+        #[serde(rename = "gasUsed")]
+        pub gas_used: Nat,
+        pub status: Nat,
+        #[serde(rename = "transactionHash")]
+        pub transaction_hash: String,
+        #[serde(rename = "contractAddress")]
+        pub contract_address: Option<String>,
+        pub from: String,
+        pub logs: Vec<LogEntry>,
+        #[serde(rename = "logsBloom")]
+        pub logs_bloom: String,
+        pub to: String,
+        #[serde(rename = "transactionIndex")]
+        pub transaction_index: Nat,
+        pub r#type: String,
+    }
+
     pub type RpcResult<T> = Result<T, RpcError>;
 
     #[derive(Clone, Debug, Eq, PartialEq, CandidType, Deserialize)]


### PR DESCRIPTION
([XC-165](https://dfinity.atlassian.net/browse/XC-165)): Continue the migration initiated in [MR-19972](https://gitlab.com/dfinity-lab/public/ic/-/merge_requests/19972) towards using the EVM-RPC canister to interact with the Ethereum JSON-RPC providers. This PR focuses specifically on the `eth_getTransactionReceipt` endpoint.

[XC-165]: https://dfinity.atlassian.net/browse/XC-165?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ