### PR TITLE
fix: Restore publishing bitcoin-mock-canister

### DIFF
--- a/publish/canisters/BUILD.bazel
+++ b/publish/canisters/BUILD.bazel
@@ -1,7 +1,7 @@
 load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
 load("//gitlab-ci/src/artifacts:upload.bzl", "upload_artifacts")
 
-# The list of canisters that are being published/uploaded to github as artifacts include
+# The list of canisters that are being published/uploaded as artifacts to our CDN (download.dfinity.systems) include
 # 1. Officially released canisters that can be downloaded/verified by 3rd parties - https://github.com/dfinity/ic/blob/master/.github/workflows/tag-release.yml
 # 2. Mainnet canisters - https://github.com/dfinity/ic/blob/master/mainnet-canisters.bzl
 # 3. Canisters required for dfx - https://github.com/dfinity/dfx-extensions/tree/main/extensions-utils/src/dependencies/download_wasms

--- a/publish/canisters/BUILD.bazel
+++ b/publish/canisters/BUILD.bazel
@@ -37,6 +37,8 @@ CANISTERS = {
     "wasm.wasm.gz": "//rs/rust_canisters/dfn_core:wasm",
     # Needed by DRE team for qualification
     "xnet-test-canister.wasm.gz": "//rs/rust_canisters/xnet_test:xnet-test-canister",
+    # Used in snsdemo repo for NNS dapp test environment
+    "bitcoin-mock-canister.wasm.gz": "//rs/bitcoin/mock:bitcoin_canister_mock",
 }
 
 COMPRESSED_CANISTERS = {

--- a/publish/canisters/BUILD.bazel
+++ b/publish/canisters/BUILD.bazel
@@ -5,6 +5,7 @@ load("//gitlab-ci/src/artifacts:upload.bzl", "upload_artifacts")
 # 1. Officially released canisters that can be downloaded/verified by 3rd parties - https://github.com/dfinity/ic/blob/master/.github/workflows/tag-release.yml
 # 2. Mainnet canisters - https://github.com/dfinity/ic/blob/master/mainnet-canisters.bzl
 # 3. Canisters required for dfx - https://github.com/dfinity/dfx-extensions/tree/main/extensions-utils/src/dependencies/download_wasms
+# 4. Canisters required for test environments.
 CANISTERS = {
     "canister-creator-canister.wasm.gz": "//rs/rust_canisters/canister_creator:canister_creator_canister",
     "cycles-minting-canister.wasm.gz": "//rs/nns/cmc:cycles-minting-canister",


### PR DESCRIPTION
# Motivation

`bitcoin-mock-canister` is used in [snsdemo](https://github.com/dfinity/snsdemo/blob/3913867870d832d2884e32787054f7b902884379/bin/dfx-software-mock-bitcoin-install#L34) which creates the test environment for [NNS dapp](https://github.com/dfinity/nns-dapp/blob/71a89a811ba76f027633b770f2c6128895b2fc89/.github/actions/start_dfx_snapshot/action.yaml#L51).

It was removed in https://github.com/dfinity/ic/pull/533 after which the NNS dapp test environment stopped updating.

# Changes

Add `bitcoin-mock-canister.wasm.gz` back to `CANISTERS` in `publish/canisters/BUILD.bazel`.

# Tested

I'm not sure how to test this. I'm hoping the wasm will be published again after this PR is merged.