### PR TITLE
chore: update default dkg-interval-length to use 499 for all subnets

### DIFF
--- a/rs/prep/src/subnet_configuration/constants.rs
+++ b/rs/prep/src/subnet_configuration/constants.rs
@@ -28,7 +28,7 @@ pub const MAX_INGRESS_BYTES_PER_MESSAGE_NNS_SUBNET: u64 = 3 * MEGABYTE + 512 * K
 /// would have after a DKG summary block, making the total length
 /// `DKG_INTERVAL_LENGTH` + 1.
 pub const DKG_INTERVAL_LENGTH_APP_SUBNET: Height = Height::new(499);
-pub const DKG_INTERVAL_LENGTH_NNS_SUBNET: Height = Height::new(199);
+pub const DKG_INTERVAL_LENGTH_NNS_SUBNET: Height = Height::new(499);
 /// The default upper bound for the number of allowed dkg dealings in a
 /// block.
 pub const DKG_DEALINGS_PER_BLOCK: usize = 1;


### PR DESCRIPTION
In the bigger effort of trying to unify configuration between subnets, we are working towards getting all subnets on the same DKG interval length of 499. Currently all subnets except the NNS use this configuration, and we plan to submit a proposal to have the NNS subnet use this configuration as well. Therefore, it makes sense that we update our default values for future subnet creations to also use this value of 499. 