### PR TITLE
chore(IDX): switch sync to self-hosted

### DIFF
--- a/.github/workflows/sync-public-with-private.yml
+++ b/.github/workflows/sync-public-with-private.yml
@@ -7,7 +7,10 @@ on:
 
 jobs:
   sync:
-    runs-on: ubuntu-latest
+    runs-on:
+      labels: dind-small
+    container:
+      image: ghcr.io/dfinity/minimal-runner-image:0.1
     if: ${{ github.repository != 'dfinity/ic' }}
     steps:
     - name: Checkout


### PR DESCRIPTION
This runs frequently that we should use our self-hosted runners to avoid using up minutes.