### PR TITLE
chore(IDX): switch queue check to self-hosted runner

### DIFF
--- a/.github/workflows/slack-workflow-queue.yml
+++ b/.github/workflows/slack-workflow-queue.yml
@@ -12,7 +12,10 @@ on:
 jobs:
   check-queue:
     name: Check Workflow Wait Queue
-    runs-on: ubuntu-latest
+    runs-on:
+      labels: dind-small
+    container:
+      image: ghcr.io/dfinity/minimal-runner-image:0.1
     steps:
 
       - name: Check for workflows in wait queue


### PR DESCRIPTION
This runs frequently that we should use our self-hosted runners to avoid using up minutes.