### PR TITLE
chore: Replace team runtime with team execution in code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -75,8 +75,8 @@ go_deps.bzl               @dfinity/idx
 /gitlab-ci/src/dependencies/                                            @dfinity/product-security
 /gitlab-ci/config/dependencies.yml                                      @dfinity/product-security
 /gitlab-ci/src/gen_gitlab_cargo_pipeline/farm_rate_limit.py             @dfinity/idx
-/gitlab-ci/config/child-pipeline--benchmark.yml                         @dfinity/runtime
-/gitlab-ci/config/spawn-pipeline--benchmark.yml                         @dfinity/runtime
+/gitlab-ci/config/child-pipeline--benchmark.yml                         @dfinity/execution
+/gitlab-ci/config/spawn-pipeline--benchmark.yml                         @dfinity/execution
 /gitlab-ci/config/rosetta.yml                                           @dfinity/finint
 
 # [Testnet]
@@ -103,15 +103,15 @@ go_deps.bzl               @dfinity/idx
 /rs/bitcoin/replica_types/                              @dfinity/execution
 /rs/boundary_node/                                      @dfinity/boundary-node
 /rs/canister_client/                                    @dfinity/networking
-/rs/canister_sandbox/                                   @dfinity/runtime
+/rs/canister_sandbox/                                   @dfinity/execution
 /rs/canonical_state/                                    @dfinity/ic-message-routing-owners
 /rs/canonical_state/tree_hash/                          @dfinity/ic-message-routing-owners @dfinity/crypto-team
 /rs/certification/                                      @dfinity/ic-message-routing-owners @dfinity/crypto-team
 /rs/config/                                             @dfinity/networking
-/rs/config/src/embedders.rs                             @dfinity/runtime
-/rs/config/src/execution_environment.rs                 @dfinity/execution @dfinity/runtime
+/rs/config/src/embedders.rs                             @dfinity/execution
+/rs/config/src/execution_environment.rs                 @dfinity/execution
 /rs/config/src/state_manager.rs                         @dfinity/ic-message-routing-owners
-/rs/config/src/subnet_config.rs                         @dfinity/execution @dfinity/runtime
+/rs/config/src/subnet_config.rs                         @dfinity/execution
 /rs/consensus/                                          @dfinity/consensus
 /rs/constants/                                          @dfinity/ic-interface-owners
 /rs/criterion_time/                                     @dfinity/ic-interface-owners
@@ -123,9 +123,9 @@ go_deps.bzl               @dfinity/idx
 /rs/depcheck/                                           @dfinity/ic-interface-owners
 /rs/determinism_test/                                   @dfinity/execution
 /rs/drun/                                               @dfinity/languages
-/rs/embedders/                                          @dfinity/runtime
+/rs/embedders/                                          @dfinity/execution
 /rs/ethereum/                                           @dfinity/cross-chain-team
-/rs/execution_environment/                              @dfinity/execution @dfinity/runtime
+/rs/execution_environment/                              @dfinity/execution
 /rs/fuzzers/                                            @dfinity/product-security
 /rs/http_endpoints/                                     @dfinity/networking
 /rs/http_endpoints/fuzz/                                @dfinity/product-security
@@ -146,12 +146,12 @@ go_deps.bzl               @dfinity/idx
 /rs/interfaces/src/crypto.rs                            @dfinity/crypto-team
 /rs/interfaces/src/crypto/                              @dfinity/crypto-team
 /rs/interfaces/src/dkg.rs                               @dfinity/consensus
-/rs/interfaces/src/execution_environment.rs             @dfinity/execution @dfinity/runtime
+/rs/interfaces/src/execution_environment.rs             @dfinity/execution
 /rs/interfaces/src/messaging.rs                         @dfinity/ic-message-routing-owners
 /rs/interfaces/src/p2p.rs                               @dfinity/networking
 /rs/interfaces/src/p2p/                                 @dfinity/networking
 /rs/interfaces/state_manager/                           @dfinity/ic-message-routing-owners
-/rs/memory_tracker/                                     @dfinity/runtime
+/rs/memory_tracker/                                     @dfinity/execution
 /rs/messaging/                                          @dfinity/ic-message-routing-owners
 /rs/monitoring/                                         @dfinity/networking
 /rs/monitoring/backtrace/                               @dfinity/networking @dfinity/ic-message-routing-owners
@@ -196,17 +196,17 @@ go_deps.bzl               @dfinity/idx
 /rs/replicated_state/                                   @dfinity/execution @dfinity/ic-message-routing-owners
 /rs/replicated_state/src/canister_state/queues.rs       @dfinity/ic-message-routing-owners
 /rs/replicated_state/src/canister_state/queues          @dfinity/ic-message-routing-owners
-/rs/replicated_state/src/page_map.rs                    @dfinity/ic-message-routing-owners @dfinity/runtime
-/rs/replicated_state/src/page_map/                      @dfinity/ic-message-routing-owners @dfinity/runtime
+/rs/replicated_state/src/page_map.rs                    @dfinity/ic-message-routing-owners @dfinity/execution
+/rs/replicated_state/src/page_map/                      @dfinity/ic-message-routing-owners @dfinity/execution
 /rs/rosetta-api/                                        @dfinity/finint
 /rs/rust_canisters/                                     @dfinity/nns-team
-/rs/rust_canisters/memory_test/                         @dfinity/execution @dfinity/runtime
-/rs/rust_canisters/call_tree_test/                      @dfinity/execution @dfinity/runtime
+/rs/rust_canisters/memory_test/                         @dfinity/execution
+/rs/rust_canisters/call_tree_test/                      @dfinity/execution
 /rs/rust_canisters/proxy_canister/                      @dfinity/networking
-/rs/rust_canisters/response_payload_test/               @dfinity/runtime
-/rs/rust_canisters/stable_structures/                   @dfinity/runtime
-/rs/rust_canisters/stable_memory_integrity              @dfinity/runtime
-/rs/rust_canisters/canister_creator                     @dfinity/runtime @dfinity/execution
+/rs/rust_canisters/response_payload_test/               @dfinity/execution
+/rs/rust_canisters/stable_structures/                   @dfinity/execution
+/rs/rust_canisters/stable_memory_integrity              @dfinity/execution
+/rs/rust_canisters/canister_creator                     @dfinity/execution
 /rs/rust_canisters/xnet_test/                           @dfinity/ic-message-routing-owners
 /rs/scenario_tests/                                     @dfinity/idx
 /rs/sns/                                                @dfinity/nns-team
@@ -215,13 +215,13 @@ go_deps.bzl               @dfinity/idx
 /rs/state_machine_tests/                                @dfinity/ic-message-routing-owners @dfinity/pocket-ic
 /rs/state_manager/                                      @dfinity/ic-message-routing-owners
 /rs/state_tool/                                         @dfinity/ic-message-routing-owners
-/rs/sys/                                                @dfinity/ic-message-routing-owners @dfinity/runtime
+/rs/sys/                                                @dfinity/ic-message-routing-owners @dfinity/execution
 /rs/system_api/                                         @dfinity/execution
 /rs/test_utilities/                                     @dfinity/ic-interface-owners
 /rs/test_utilities/artifact_pool/                       @dfinity/consensus
 /rs/test_utilities/consensus/                           @dfinity/consensus
-/rs/test_utilities/embedders/                           @dfinity/runtime
-/rs/test_utilities/execution_environment/               @dfinity/execution @dfinity/runtime
+/rs/test_utilities/embedders/                           @dfinity/execution
+/rs/test_utilities/execution_environment/               @dfinity/execution
 /rs/test_utilities/in_memory_logger/                    @dfinity/crypto-team
 /rs/test_utilities/src/crypto.rs                        @dfinity/crypto-team
 /rs/test_utilities/src/crypto/                          @dfinity/crypto-team
@@ -251,7 +251,7 @@ go_deps.bzl               @dfinity/idx
 /rs/tests/src/cross_chain/                              @dfinity/cross-chain-team @dfinity/idx
 /rs/tests/src/crypto/                                   @dfinity/crypto-team @dfinity/idx
 /rs/tests/src/custom_domains_integration/               @dfinity/boundary-node @dfinity/idx
-/rs/tests/src/execution/                                @dfinity/execution @dfinity/runtime @dfinity/idx
+/rs/tests/src/execution/                                @dfinity/execution @dfinity/idx
 /rs/tests/src/ipv4_tests/                               @dfinity/node  @dfinity/idx
 /rs/tests/src/ledger_tests/                             @dfinity/finint  @dfinity/idx
 /rs/tests/src/message_routing/                          @dfinity/ic-message-routing-owners  @dfinity/idx
@@ -279,13 +279,13 @@ go_deps.bzl               @dfinity/idx
 /rs/types/types/src/exhaustive.rs                       @dfinity/consensus
 /rs/types/types/src/signature.rs                        @dfinity/consensus
 /rs/types/types/src/signature/                          @dfinity/consensus
-/rs/types/wasm_types/                                   @dfinity/runtime
+/rs/types/wasm_types/                                   @dfinity/execution
 /rs/universal_canister/                                 @dfinity/execution
 /rs/utils/                                              @dfinity/ic-interface-owners
 /rs/utils/ensure/                                       @dfinity/finint
 /rs/validator/                                          @dfinity/crypto-team
-/rs/wasm_transform/                                     @dfinity/runtime
-/rs/workload_generator/                                 @dfinity/runtime
+/rs/wasm_transform/                                     @dfinity/execution
+/rs/workload_generator/                                 @dfinity/execution
 /rs/xnet/                                               @dfinity/ic-message-routing-owners
 
 # [No-Approvals]

--- a/.gitlab/CODEOWNERS
+++ b/.gitlab/CODEOWNERS
@@ -74,8 +74,8 @@ go_deps.bzl               @dfinity-lab/teams/idx
 /gitlab-ci/src/dependencies/                                            @dfinity-lab/teams/prodsec
 /gitlab-ci/config/dependencies.yml                                      @dfinity-lab/teams/prodsec
 /gitlab-ci/src/gen_gitlab_cargo_pipeline/farm_rate_limit.py             @dfinity-lab/teams/idx
-/gitlab-ci/config/child-pipeline--benchmark.yml                         @dfinity-lab/teams/execution-owners
-/gitlab-ci/config/spawn-pipeline--benchmark.yml                         @dfinity-lab/teams/execution-owners
+/gitlab-ci/config/child-pipeline--benchmark.yml                         @dfinity-lab/teams/runtime-owners
+/gitlab-ci/config/spawn-pipeline--benchmark.yml                         @dfinity-lab/teams/runtime-owners
 /gitlab-ci/config/rosetta.yml                                           @dfinity-lab/teams/financial-integrations
 
 # [Testnet]
@@ -102,15 +102,15 @@ go_deps.bzl               @dfinity-lab/teams/idx
 /rs/bitcoin/replica_types/                              @dfinity-lab/teams/execution-owners
 /rs/boundary_node/                                      @dfinity-lab/teams/boundarynode-team
 /rs/canister_client/                                    @dfinity-lab/teams/networking-team
-/rs/canister_sandbox/                                   @dfinity-lab/teams/execution-owners
+/rs/canister_sandbox/                                   @dfinity-lab/teams/runtime-owners
 /rs/canonical_state/                                    @dfinity-lab/teams/message-routing-owners
 /rs/canonical_state/tree_hash/                          @dfinity-lab/teams/message-routing-owners @dfinity-lab/teams/crypto-owners
 /rs/certification/                                      @dfinity-lab/teams/message-routing-owners @dfinity-lab/teams/crypto-owners
 /rs/config/                                             @dfinity-lab/teams/networking-team
-/rs/config/src/embedders.rs                             @dfinity-lab/teams/execution-owners
-/rs/config/src/execution_environment.rs                 @dfinity-lab/teams/execution-owners
+/rs/config/src/embedders.rs                             @dfinity-lab/teams/runtime-owners
+/rs/config/src/execution_environment.rs                 @dfinity-lab/teams/execution-owners @dfinity-lab/teams/runtime-owners
 /rs/config/src/state_manager.rs                         @dfinity-lab/teams/message-routing-owners
-/rs/config/src/subnet_config.rs                         @dfinity-lab/teams/execution-owners
+/rs/config/src/subnet_config.rs                         @dfinity-lab/teams/execution-owners @dfinity-lab/teams/runtime-owners
 /rs/consensus/                                          @dfinity-lab/teams/consensus-owners
 /rs/constants/                                          @dfinity-lab/teams/interface-owners
 /rs/criterion_time/                                     @dfinity-lab/teams/interface-owners
@@ -122,9 +122,9 @@ go_deps.bzl               @dfinity-lab/teams/idx
 /rs/depcheck/                                           @dfinity-lab/teams/interface-owners
 /rs/determinism_test/                                   @dfinity-lab/teams/execution-owners
 /rs/drun/                                               @dfinity-lab/teams/execution-owners
-/rs/embedders/                                          @dfinity-lab/teams/execution-owners
+/rs/embedders/                                          @dfinity-lab/teams/runtime-owners
 /rs/ethereum/                                           @dfinity-lab/teams/cross-chain-team
-/rs/execution_environment/                              @dfinity-lab/teams/execution-owners
+/rs/execution_environment/                              @dfinity-lab/teams/execution-owners @dfinity-lab/teams/runtime-owners
 /rs/fuzzers/                                            @dfinity-lab/teams/prodsec
 /rs/http_endpoints/                                     @dfinity-lab/teams/networking-team
 /rs/http_endpoints/fuzz/                                @dfinity-lab/teams/prodsec
@@ -145,12 +145,12 @@ go_deps.bzl               @dfinity-lab/teams/idx
 /rs/interfaces/src/crypto.rs                            @dfinity-lab/teams/crypto-owners
 /rs/interfaces/src/crypto/                              @dfinity-lab/teams/crypto-owners
 /rs/interfaces/src/dkg.rs                               @dfinity-lab/teams/consensus-owners
-/rs/interfaces/src/execution_environment.rs             @dfinity-lab/teams/execution-owners
+/rs/interfaces/src/execution_environment.rs             @dfinity-lab/teams/execution-owners @dfinity-lab/teams/runtime-owners
 /rs/interfaces/src/messaging.rs                         @dfinity-lab/teams/message-routing-owners
 /rs/interfaces/src/p2p.rs                               @dfinity-lab/teams/networking-team
 /rs/interfaces/src/p2p/                                 @dfinity-lab/teams/networking-team
 /rs/interfaces/state_manager/                           @dfinity-lab/teams/message-routing-owners
-/rs/memory_tracker/                                     @dfinity-lab/teams/execution-owners
+/rs/memory_tracker/                                     @dfinity-lab/teams/runtime-owners
 /rs/messaging/                                          @dfinity-lab/teams/message-routing-owners
 /rs/monitoring/                                         @dfinity-lab/teams/networking-team
 /rs/monitoring/backtrace/                               @dfinity-lab/teams/networking-team @dfinity-lab/teams/message-routing-owners
@@ -195,17 +195,17 @@ go_deps.bzl               @dfinity-lab/teams/idx
 /rs/replicated_state/                                   @dfinity-lab/teams/execution-owners @dfinity-lab/teams/message-routing-owners
 /rs/replicated_state/src/canister_state/queues.rs       @dfinity-lab/teams/message-routing-owners
 /rs/replicated_state/src/canister_state/queues          @dfinity-lab/teams/message-routing-owners
-/rs/replicated_state/src/page_map.rs                    @dfinity-lab/teams/message-routing-owners @dfinity-lab/teams/execution-owners
-/rs/replicated_state/src/page_map/                      @dfinity-lab/teams/message-routing-owners @dfinity-lab/teams/execution-owners
+/rs/replicated_state/src/page_map.rs                    @dfinity-lab/teams/message-routing-owners @dfinity-lab/teams/runtime-owners
+/rs/replicated_state/src/page_map/                      @dfinity-lab/teams/message-routing-owners @dfinity-lab/teams/runtime-owners
 /rs/rosetta-api/                                        @dfinity-lab/teams/financial-integrations
 /rs/rust_canisters/                                     @dfinity-lab/teams/nns-team
-/rs/rust_canisters/memory_test/                         @dfinity-lab/teams/execution-owners
-/rs/rust_canisters/call_tree_test/                      @dfinity-lab/teams/execution-owners
+/rs/rust_canisters/memory_test/                         @dfinity-lab/teams/execution-owners @dfinity-lab/teams/runtime-owners
+/rs/rust_canisters/call_tree_test/                      @dfinity-lab/teams/execution-owners @dfinity-lab/teams/runtime-owners
 /rs/rust_canisters/proxy_canister/                      @dfinity-lab/teams/networking-team
-/rs/rust_canisters/response_payload_test/               @dfinity-lab/teams/execution-owners
-/rs/rust_canisters/stable_structures/                   @dfinity-lab/teams/execution-owners
-/rs/rust_canisters/stable_memory_integrity              @dfinity-lab/teams/execution-owners
-/rs/rust_canisters/canister_creator                     @dfinity-lab/teams/execution-owners
+/rs/rust_canisters/response_payload_test/               @dfinity-lab/teams/runtime-owners
+/rs/rust_canisters/stable_structures/                   @dfinity-lab/teams/runtime-owners
+/rs/rust_canisters/stable_memory_integrity              @dfinity-lab/teams/runtime-owners
+/rs/rust_canisters/canister_creator                     @dfinity-lab/teams/runtime-owners @dfinity-lab/teams/execution-owners
 /rs/rust_canisters/xnet_test/                           @dfinity-lab/teams/message-routing-owners
 /rs/scenario_tests/                                     @dfinity-lab/teams/idx
 /rs/sns/                                                @dfinity-lab/teams/nns-team
@@ -214,13 +214,13 @@ go_deps.bzl               @dfinity-lab/teams/idx
 /rs/state_machine_tests/                                @dfinity-lab/teams/message-routing-owners @dfinity-lab/teams/pocket-ic
 /rs/state_manager/                                      @dfinity-lab/teams/message-routing-owners
 /rs/state_tool/                                         @dfinity-lab/teams/message-routing-owners
-/rs/sys/                                                @dfinity-lab/teams/message-routing-owners @dfinity-lab/teams/execution-owners
+/rs/sys/                                                @dfinity-lab/teams/message-routing-owners @dfinity-lab/teams/runtime-owners
 /rs/system_api/                                         @dfinity-lab/teams/execution-owners
 /rs/test_utilities/                                     @dfinity-lab/teams/interface-owners
 /rs/test_utilities/artifact_pool/                       @dfinity-lab/teams/consensus-owners
 /rs/test_utilities/consensus/                           @dfinity-lab/teams/consensus-owners
-/rs/test_utilities/embedders/                           @dfinity-lab/teams/execution-owners
-/rs/test_utilities/execution_environment/               @dfinity-lab/teams/execution-owners
+/rs/test_utilities/embedders/                           @dfinity-lab/teams/runtime-owners
+/rs/test_utilities/execution_environment/               @dfinity-lab/teams/execution-owners @dfinity-lab/teams/runtime-owners
 /rs/test_utilities/in_memory_logger/                    @dfinity-lab/teams/crypto-owners
 /rs/test_utilities/src/crypto.rs                        @dfinity-lab/teams/crypto-owners
 /rs/test_utilities/src/crypto/                          @dfinity-lab/teams/crypto-owners
@@ -250,7 +250,7 @@ go_deps.bzl               @dfinity-lab/teams/idx
 /rs/tests/src/cross_chain/                              @dfinity-lab/teams/cross-chain-team @dfinity-lab/teams/idx
 /rs/tests/src/crypto/                                   @dfinity-lab/teams/crypto-owners @dfinity-lab/teams/idx
 /rs/tests/src/custom_domains_integration/               @dfinity-lab/teams/boundarynode-team @dfinity-lab/teams/idx
-/rs/tests/src/execution/                                @dfinity-lab/teams/execution-owners @dfinity-lab/teams/idx
+/rs/tests/src/execution/                                @dfinity-lab/teams/execution-owners @dfinity-lab/teams/runtime-owners @dfinity-lab/teams/idx
 /rs/tests/src/ipv4_tests/                               @dfinity-lab/teams/node-team  @dfinity-lab/teams/idx
 /rs/tests/src/ledger_tests/                             @dfinity-lab/teams/financial-integrations  @dfinity-lab/teams/idx
 /rs/tests/src/message_routing/                          @dfinity-lab/teams/message-routing-owners  @dfinity-lab/teams/idx
@@ -278,13 +278,13 @@ go_deps.bzl               @dfinity-lab/teams/idx
 /rs/types/types/src/exhaustive.rs                       @dfinity-lab/teams/consensus-owners
 /rs/types/types/src/signature.rs                        @dfinity-lab/teams/consensus-owners
 /rs/types/types/src/signature/                          @dfinity-lab/teams/consensus-owners
-/rs/types/wasm_types/                                   @dfinity-lab/teams/execution-owners
+/rs/types/wasm_types/                                   @dfinity-lab/teams/runtime-owners
 /rs/universal_canister/                                 @dfinity-lab/teams/execution-owners
 /rs/utils/                                              @dfinity-lab/teams/interface-owners
 /rs/utils/ensure/                                       @dfinity-lab/teams/financial-integrations
 /rs/validator/                                          @dfinity-lab/teams/crypto-owners
-/rs/wasm_transform/                                     @dfinity-lab/teams/execution-owners
-/rs/workload_generator/                                 @dfinity-lab/teams/execution-owners
+/rs/wasm_transform/                                     @dfinity-lab/teams/runtime-owners
+/rs/workload_generator/                                 @dfinity-lab/teams/runtime-owners
 /rs/xnet/                                               @dfinity-lab/teams/message-routing-owners
 
 # [No-Approvals]

--- a/.gitlab/CODEOWNERS
+++ b/.gitlab/CODEOWNERS
@@ -74,8 +74,8 @@ go_deps.bzl               @dfinity-lab/teams/idx
 /gitlab-ci/src/dependencies/                                            @dfinity-lab/teams/prodsec
 /gitlab-ci/config/dependencies.yml                                      @dfinity-lab/teams/prodsec
 /gitlab-ci/src/gen_gitlab_cargo_pipeline/farm_rate_limit.py             @dfinity-lab/teams/idx
-/gitlab-ci/config/child-pipeline--benchmark.yml                         @dfinity-lab/teams/runtime-owners
-/gitlab-ci/config/spawn-pipeline--benchmark.yml                         @dfinity-lab/teams/runtime-owners
+/gitlab-ci/config/child-pipeline--benchmark.yml                         @dfinity-lab/teams/execution-owners
+/gitlab-ci/config/spawn-pipeline--benchmark.yml                         @dfinity-lab/teams/execution-owners
 /gitlab-ci/config/rosetta.yml                                           @dfinity-lab/teams/financial-integrations
 
 # [Testnet]
@@ -102,15 +102,15 @@ go_deps.bzl               @dfinity-lab/teams/idx
 /rs/bitcoin/replica_types/                              @dfinity-lab/teams/execution-owners
 /rs/boundary_node/                                      @dfinity-lab/teams/boundarynode-team
 /rs/canister_client/                                    @dfinity-lab/teams/networking-team
-/rs/canister_sandbox/                                   @dfinity-lab/teams/runtime-owners
+/rs/canister_sandbox/                                   @dfinity-lab/teams/execution-owners
 /rs/canonical_state/                                    @dfinity-lab/teams/message-routing-owners
 /rs/canonical_state/tree_hash/                          @dfinity-lab/teams/message-routing-owners @dfinity-lab/teams/crypto-owners
 /rs/certification/                                      @dfinity-lab/teams/message-routing-owners @dfinity-lab/teams/crypto-owners
 /rs/config/                                             @dfinity-lab/teams/networking-team
-/rs/config/src/embedders.rs                             @dfinity-lab/teams/runtime-owners
-/rs/config/src/execution_environment.rs                 @dfinity-lab/teams/execution-owners @dfinity-lab/teams/runtime-owners
+/rs/config/src/embedders.rs                             @dfinity-lab/teams/execution-owners
+/rs/config/src/execution_environment.rs                 @dfinity-lab/teams/execution-owners
 /rs/config/src/state_manager.rs                         @dfinity-lab/teams/message-routing-owners
-/rs/config/src/subnet_config.rs                         @dfinity-lab/teams/execution-owners @dfinity-lab/teams/runtime-owners
+/rs/config/src/subnet_config.rs                         @dfinity-lab/teams/execution-owners
 /rs/consensus/                                          @dfinity-lab/teams/consensus-owners
 /rs/constants/                                          @dfinity-lab/teams/interface-owners
 /rs/criterion_time/                                     @dfinity-lab/teams/interface-owners
@@ -122,9 +122,9 @@ go_deps.bzl               @dfinity-lab/teams/idx
 /rs/depcheck/                                           @dfinity-lab/teams/interface-owners
 /rs/determinism_test/                                   @dfinity-lab/teams/execution-owners
 /rs/drun/                                               @dfinity-lab/teams/execution-owners
-/rs/embedders/                                          @dfinity-lab/teams/runtime-owners
+/rs/embedders/                                          @dfinity-lab/teams/execution-owners
 /rs/ethereum/                                           @dfinity-lab/teams/cross-chain-team
-/rs/execution_environment/                              @dfinity-lab/teams/execution-owners @dfinity-lab/teams/runtime-owners
+/rs/execution_environment/                              @dfinity-lab/teams/execution-owners
 /rs/fuzzers/                                            @dfinity-lab/teams/prodsec
 /rs/http_endpoints/                                     @dfinity-lab/teams/networking-team
 /rs/http_endpoints/fuzz/                                @dfinity-lab/teams/prodsec
@@ -145,12 +145,12 @@ go_deps.bzl               @dfinity-lab/teams/idx
 /rs/interfaces/src/crypto.rs                            @dfinity-lab/teams/crypto-owners
 /rs/interfaces/src/crypto/                              @dfinity-lab/teams/crypto-owners
 /rs/interfaces/src/dkg.rs                               @dfinity-lab/teams/consensus-owners
-/rs/interfaces/src/execution_environment.rs             @dfinity-lab/teams/execution-owners @dfinity-lab/teams/runtime-owners
+/rs/interfaces/src/execution_environment.rs             @dfinity-lab/teams/execution-owners
 /rs/interfaces/src/messaging.rs                         @dfinity-lab/teams/message-routing-owners
 /rs/interfaces/src/p2p.rs                               @dfinity-lab/teams/networking-team
 /rs/interfaces/src/p2p/                                 @dfinity-lab/teams/networking-team
 /rs/interfaces/state_manager/                           @dfinity-lab/teams/message-routing-owners
-/rs/memory_tracker/                                     @dfinity-lab/teams/runtime-owners
+/rs/memory_tracker/                                     @dfinity-lab/teams/execution-owners
 /rs/messaging/                                          @dfinity-lab/teams/message-routing-owners
 /rs/monitoring/                                         @dfinity-lab/teams/networking-team
 /rs/monitoring/backtrace/                               @dfinity-lab/teams/networking-team @dfinity-lab/teams/message-routing-owners
@@ -195,17 +195,17 @@ go_deps.bzl               @dfinity-lab/teams/idx
 /rs/replicated_state/                                   @dfinity-lab/teams/execution-owners @dfinity-lab/teams/message-routing-owners
 /rs/replicated_state/src/canister_state/queues.rs       @dfinity-lab/teams/message-routing-owners
 /rs/replicated_state/src/canister_state/queues          @dfinity-lab/teams/message-routing-owners
-/rs/replicated_state/src/page_map.rs                    @dfinity-lab/teams/message-routing-owners @dfinity-lab/teams/runtime-owners
-/rs/replicated_state/src/page_map/                      @dfinity-lab/teams/message-routing-owners @dfinity-lab/teams/runtime-owners
+/rs/replicated_state/src/page_map.rs                    @dfinity-lab/teams/message-routing-owners @dfinity-lab/teams/execution-owners
+/rs/replicated_state/src/page_map/                      @dfinity-lab/teams/message-routing-owners @dfinity-lab/teams/execution-owners
 /rs/rosetta-api/                                        @dfinity-lab/teams/financial-integrations
 /rs/rust_canisters/                                     @dfinity-lab/teams/nns-team
-/rs/rust_canisters/memory_test/                         @dfinity-lab/teams/execution-owners @dfinity-lab/teams/runtime-owners
-/rs/rust_canisters/call_tree_test/                      @dfinity-lab/teams/execution-owners @dfinity-lab/teams/runtime-owners
+/rs/rust_canisters/memory_test/                         @dfinity-lab/teams/execution-owners
+/rs/rust_canisters/call_tree_test/                      @dfinity-lab/teams/execution-owners
 /rs/rust_canisters/proxy_canister/                      @dfinity-lab/teams/networking-team
-/rs/rust_canisters/response_payload_test/               @dfinity-lab/teams/runtime-owners
-/rs/rust_canisters/stable_structures/                   @dfinity-lab/teams/runtime-owners
-/rs/rust_canisters/stable_memory_integrity              @dfinity-lab/teams/runtime-owners
-/rs/rust_canisters/canister_creator                     @dfinity-lab/teams/runtime-owners @dfinity-lab/teams/execution-owners
+/rs/rust_canisters/response_payload_test/               @dfinity-lab/teams/execution-owners
+/rs/rust_canisters/stable_structures/                   @dfinity-lab/teams/execution-owners
+/rs/rust_canisters/stable_memory_integrity              @dfinity-lab/teams/execution-owners
+/rs/rust_canisters/canister_creator                     @dfinity-lab/teams/execution-owners
 /rs/rust_canisters/xnet_test/                           @dfinity-lab/teams/message-routing-owners
 /rs/scenario_tests/                                     @dfinity-lab/teams/idx
 /rs/sns/                                                @dfinity-lab/teams/nns-team
@@ -214,13 +214,13 @@ go_deps.bzl               @dfinity-lab/teams/idx
 /rs/state_machine_tests/                                @dfinity-lab/teams/message-routing-owners @dfinity-lab/teams/pocket-ic
 /rs/state_manager/                                      @dfinity-lab/teams/message-routing-owners
 /rs/state_tool/                                         @dfinity-lab/teams/message-routing-owners
-/rs/sys/                                                @dfinity-lab/teams/message-routing-owners @dfinity-lab/teams/runtime-owners
+/rs/sys/                                                @dfinity-lab/teams/message-routing-owners @dfinity-lab/teams/execution-owners
 /rs/system_api/                                         @dfinity-lab/teams/execution-owners
 /rs/test_utilities/                                     @dfinity-lab/teams/interface-owners
 /rs/test_utilities/artifact_pool/                       @dfinity-lab/teams/consensus-owners
 /rs/test_utilities/consensus/                           @dfinity-lab/teams/consensus-owners
-/rs/test_utilities/embedders/                           @dfinity-lab/teams/runtime-owners
-/rs/test_utilities/execution_environment/               @dfinity-lab/teams/execution-owners @dfinity-lab/teams/runtime-owners
+/rs/test_utilities/embedders/                           @dfinity-lab/teams/execution-owners
+/rs/test_utilities/execution_environment/               @dfinity-lab/teams/execution-owners
 /rs/test_utilities/in_memory_logger/                    @dfinity-lab/teams/crypto-owners
 /rs/test_utilities/src/crypto.rs                        @dfinity-lab/teams/crypto-owners
 /rs/test_utilities/src/crypto/                          @dfinity-lab/teams/crypto-owners
@@ -250,7 +250,7 @@ go_deps.bzl               @dfinity-lab/teams/idx
 /rs/tests/src/cross_chain/                              @dfinity-lab/teams/cross-chain-team @dfinity-lab/teams/idx
 /rs/tests/src/crypto/                                   @dfinity-lab/teams/crypto-owners @dfinity-lab/teams/idx
 /rs/tests/src/custom_domains_integration/               @dfinity-lab/teams/boundarynode-team @dfinity-lab/teams/idx
-/rs/tests/src/execution/                                @dfinity-lab/teams/execution-owners @dfinity-lab/teams/runtime-owners @dfinity-lab/teams/idx
+/rs/tests/src/execution/                                @dfinity-lab/teams/execution-owners @dfinity-lab/teams/idx
 /rs/tests/src/ipv4_tests/                               @dfinity-lab/teams/node-team  @dfinity-lab/teams/idx
 /rs/tests/src/ledger_tests/                             @dfinity-lab/teams/financial-integrations  @dfinity-lab/teams/idx
 /rs/tests/src/message_routing/                          @dfinity-lab/teams/message-routing-owners  @dfinity-lab/teams/idx
@@ -278,13 +278,13 @@ go_deps.bzl               @dfinity-lab/teams/idx
 /rs/types/types/src/exhaustive.rs                       @dfinity-lab/teams/consensus-owners
 /rs/types/types/src/signature.rs                        @dfinity-lab/teams/consensus-owners
 /rs/types/types/src/signature/                          @dfinity-lab/teams/consensus-owners
-/rs/types/wasm_types/                                   @dfinity-lab/teams/runtime-owners
+/rs/types/wasm_types/                                   @dfinity-lab/teams/execution-owners
 /rs/universal_canister/                                 @dfinity-lab/teams/execution-owners
 /rs/utils/                                              @dfinity-lab/teams/interface-owners
 /rs/utils/ensure/                                       @dfinity-lab/teams/financial-integrations
 /rs/validator/                                          @dfinity-lab/teams/crypto-owners
-/rs/wasm_transform/                                     @dfinity-lab/teams/runtime-owners
-/rs/workload_generator/                                 @dfinity-lab/teams/runtime-owners
+/rs/wasm_transform/                                     @dfinity-lab/teams/execution-owners
+/rs/workload_generator/                                 @dfinity-lab/teams/execution-owners
 /rs/xnet/                                               @dfinity-lab/teams/message-routing-owners
 
 # [No-Approvals]


### PR DESCRIPTION
This reflects the recent merge of the teams.