### PR TITLE
test: Include networking system tests as workspace member

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14922,6 +14922,7 @@ dependencies = [
  "ic-base-types",
  "ic-cdk 0.13.2",
  "ic-management-canister-types",
+ "ic-prep",
  "ic-registry-subnet-features",
  "ic-registry-subnet-type",
  "ic-system-test-driver",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14911,6 +14911,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "networking-system-tests"
+version = "0.9.0"
+dependencies = [
+ "anyhow",
+ "candid",
+ "canister-test",
+ "canister_http",
+ "dfn_candid",
+ "ic-base-types",
+ "ic-cdk 0.13.2",
+ "ic-management-canister-types",
+ "ic-registry-subnet-features",
+ "ic-registry-subnet-type",
+ "ic-system-test-driver",
+ "ic-test-utilities",
+ "ic-test-utilities-types",
+ "ic-types",
+ "ic-utils 0.37.0",
+ "proxy_canister",
+ "reqwest 0.12.5",
+ "slog",
+ "tests",
+ "tokio",
+]
+
+[[package]]
 name = "new_debug_unreachable"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -350,6 +350,7 @@ members = [
     "rs/tests/consensus/utils",
     "rs/tests/driver",
     "rs/tests/httpbin-rs",
+    "rs/tests/networking",
     "rs/tests/networking/canister_http",
     "rs/tests/nested",
     "rs/tests/nns/sns",

--- a/rs/tests/networking/Cargo.toml
+++ b/rs/tests/networking/Cargo.toml
@@ -7,26 +7,27 @@ description.workspace = true
 documentation.workspace = true
 
 [dependencies]
-dfn_candid = { path = "../../rust_canisters/dfn_candid" }
-proxy_canister = { path = "../../rust_canisters/proxy_canister" }
-tests = { path = ".." }
-ic-system-test-driver = { path = "../driver" }
-canister_http = { path = "./canister_http" }
-ic-management-canister-types = { path = "../../types/management_canister_types" }
 anyhow = { workspace = true }
+canister-test = { path = "../../rust_canisters/canister_test" }
+canister_http = { path = "./canister_http" }
 candid = { workspace = true }
+dfn_candid = { path = "../../rust_canisters/dfn_candid" }
+ic-base-types = { path = "../../types/base_types" }
 ic-cdk = { workspace = true }
-slog = { workspace = true }
+ic-management-canister-types = { path = "../../types/management_canister_types" }
+ic-prep = { path = "../../prep" }
 ic-registry-subnet-features = { path = "../../registry/subnet_features" }
 ic-registry-subnet-type = { path = "../../registry/subnet_type" }
-canister-test = { path = "../../rust_canisters/canister_test" }
+ic-system-test-driver = { path = "../driver" }
 ic-test-utilities = { path = "../../test_utilities" }
 ic-test-utilities-types = { path = "../../test_utilities/types" }
 ic-types = { path = "../../types/types" }
-ic-base-types = { path = "../../types/base_types" }
-tokio = { workspace = true }
-reqwest = { workspace = true }
 ic-utils = { workspace = true }
+proxy_canister = { path = "../../rust_canisters/proxy_canister" }
+reqwest = { workspace = true }
+slog = { workspace = true }
+tests = { path = ".." }
+tokio = { workspace = true }
 
 [[bin]]
 name = "ic-systest-canister-http-correctness"

--- a/rs/tests/networking/Cargo.toml
+++ b/rs/tests/networking/Cargo.toml
@@ -47,3 +47,31 @@ path = "canister_http_test.rs"
 [[bin]]
 name = "ic-systest-canister-http-time-out"
 path = "canister_http_time_out_test.rs"
+
+[[bin]]
+name = "ic-systest-firewall-max-connections-test"
+path = "firewall_max_connections_test.rs"
+
+[[bin]]
+name = "ic-systest-firewall-priority-test"
+path = "firewall_priority_test.rs"
+
+[[bin]]
+name = "ic-systest-network-large-test"
+path = "network_large_test.rs"
+
+[[bin]]
+name = "ic-systest-network-reliability-test"
+path = "network_reliability_test.rs"
+
+[[bin]]
+name = "ic-systest-p2p-performance"
+path = "p2p_performance"
+
+[[bin]]
+name = "ic-systest-query-workload-long-test"
+path = "query_workload_long_test.rs"
+
+[[bin]]
+name = "ic-systest-update-workload-large-payload-test"
+path = "update_workload_large_payload_test.rs"

--- a/rs/tests/networking/Cargo.toml
+++ b/rs/tests/networking/Cargo.toml
@@ -66,7 +66,7 @@ path = "network_reliability_test.rs"
 
 [[bin]]
 name = "ic-systest-p2p-performance"
-path = "p2p_performance"
+path = "p2p_performance.rs"
 
 [[bin]]
 name = "ic-systest-query-workload-long-test"
@@ -74,4 +74,4 @@ path = "query_workload_long_test.rs"
 
 [[bin]]
 name = "ic-systest-update-workload-large-payload-test"
-path = "update_workload_large_payload_test.rs"
+path = "update_workload_large_payload.rs"


### PR DESCRIPTION
Rust-analyzer now also lints the networking system tests.