### PR TITLE
chore: Update quinn to 0.11.3

### DIFF
--- a/Cargo.Bazel.Fuzzing.json.lock
+++ b/Cargo.Bazel.Fuzzing.json.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "92a7576657e18564e2349fcc09286f4f7c815faa8f2ded784428b29940e6ecaf",
+  "checksum": "fed910ed706c35885421f708c3411a1374904dbf5ff740376ad876d49cbfa1f8",
   "crates": {
     "abnf 0.12.0": {
       "name": "abnf",
@@ -17753,11 +17753,11 @@
               "target": "quickcheck"
             },
             {
-              "id": "quinn 0.11.2",
+              "id": "quinn 0.11.3",
               "target": "quinn"
             },
             {
-              "id": "quinn-udp 0.5.2",
+              "id": "quinn-udp 0.5.4",
               "target": "quinn_udp"
             },
             {
@@ -48499,17 +48499,14 @@
       ],
       "license_file": "LICENSE-MIT"
     },
-    "quinn 0.11.2": {
+    "quinn 0.11.3": {
       "name": "quinn",
-      "version": "0.11.2",
+      "version": "0.11.3",
       "package_url": "https://github.com/quinn-rs/quinn",
       "repository": {
-        "Git": {
-          "remote": "https://github.com/quinn-rs/quinn",
-          "commitish": {
-            "Rev": "fb63829dd1f78a98cb7da0fc757db44d14afd9ff"
-          },
-          "strip_prefix": "quinn"
+        "Http": {
+          "url": "https://static.crates.io/crates/quinn/0.11.3/download",
+          "sha256": "b22d8e7369034b9a7132bc2008cac12f2013c8132b45e0554e6e20e2617f2156"
         }
       },
       "targets": [
@@ -48551,12 +48548,12 @@
               "target": "pin_project_lite"
             },
             {
-              "id": "quinn-proto 0.11.3",
+              "id": "quinn-proto 0.11.6",
               "target": "quinn_proto",
               "alias": "proto"
             },
             {
-              "id": "quinn-udp 0.5.2",
+              "id": "quinn-udp 0.5.4",
               "target": "quinn_udp",
               "alias": "udp"
             },
@@ -48567,6 +48564,10 @@
             {
               "id": "rustls 0.23.11",
               "target": "rustls"
+            },
+            {
+              "id": "socket2 0.5.7",
+              "target": "socket2"
             },
             {
               "id": "thiserror 1.0.62",
@@ -48584,7 +48585,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.11.2"
+        "version": "0.11.3"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -48593,17 +48594,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "quinn-proto 0.11.3": {
+    "quinn-proto 0.11.6": {
       "name": "quinn-proto",
-      "version": "0.11.3",
+      "version": "0.11.6",
       "package_url": "https://github.com/quinn-rs/quinn",
       "repository": {
-        "Git": {
-          "remote": "https://github.com/quinn-rs/quinn",
-          "commitish": {
-            "Rev": "fb63829dd1f78a98cb7da0fc757db44d14afd9ff"
-          },
-          "strip_prefix": "quinn-proto"
+        "Http": {
+          "url": "https://static.crates.io/crates/quinn-proto/0.11.6/download",
+          "sha256": "ba92fb39ec7ad06ca2582c0ca834dfeadcaf06ddfc8e635c80aa7e1c05315fdd"
         }
       },
       "targets": [
@@ -48675,7 +48673,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.11.3"
+        "version": "0.11.6"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -48684,17 +48682,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "quinn-udp 0.5.2": {
+    "quinn-udp 0.5.4": {
       "name": "quinn-udp",
-      "version": "0.5.2",
+      "version": "0.5.4",
       "package_url": "https://github.com/quinn-rs/quinn",
       "repository": {
-        "Git": {
-          "remote": "https://github.com/quinn-rs/quinn",
-          "commitish": {
-            "Rev": "fb63829dd1f78a98cb7da0fc757db44d14afd9ff"
-          },
-          "strip_prefix": "quinn-udp"
+        "Http": {
+          "url": "https://static.crates.io/crates/quinn-udp/0.5.4/download",
+          "sha256": "8bffec3605b73c6f1754535084a85229fa8a30f86014e6c81aeec4abb68b0285"
         }
       },
       "targets": [
@@ -48719,7 +48714,8 @@
         "crate_features": {
           "common": [
             "default",
-            "log"
+            "log",
+            "tracing"
           ],
           "selects": {}
         },
@@ -48752,7 +48748,7 @@
           }
         },
         "edition": "2021",
-        "version": "0.5.2"
+        "version": "0.5.4"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -78439,8 +78435,8 @@
     "protobuf 2.28.0",
     "publicsuffix 2.2.3",
     "quickcheck 1.0.3",
-    "quinn 0.11.2",
-    "quinn-udp 0.5.2",
+    "quinn 0.11.3",
+    "quinn-udp 0.5.4",
     "quote 1.0.35",
     "rand 0.8.5",
     "rand_chacha 0.3.1",

--- a/Cargo.Bazel.Fuzzing.toml.lock
+++ b/Cargo.Bazel.Fuzzing.toml.lock
@@ -8303,8 +8303,9 @@ dependencies = [
 
 [[package]]
 name = "quinn"
-version = "0.11.2"
-source = "git+https://github.com/quinn-rs/quinn?rev=fb63829dd1f78a98cb7da0fc757db44d14afd9ff#fb63829dd1f78a98cb7da0fc757db44d14afd9ff"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b22d8e7369034b9a7132bc2008cac12f2013c8132b45e0554e6e20e2617f2156"
 dependencies = [
  "bytes",
  "pin-project-lite",
@@ -8312,6 +8313,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.0.0",
  "rustls 0.23.11",
+ "socket2 0.5.7",
  "thiserror",
  "tokio",
  "tracing",
@@ -8319,8 +8321,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.3"
-source = "git+https://github.com/quinn-rs/quinn?rev=fb63829dd1f78a98cb7da0fc757db44d14afd9ff#fb63829dd1f78a98cb7da0fc757db44d14afd9ff"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba92fb39ec7ad06ca2582c0ca834dfeadcaf06ddfc8e635c80aa7e1c05315fdd"
 dependencies = [
  "bytes",
  "rand 0.8.5",
@@ -8335,8 +8338,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.2"
-source = "git+https://github.com/quinn-rs/quinn?rev=fb63829dd1f78a98cb7da0fc757db44d14afd9ff#fb63829dd1f78a98cb7da0fc757db44d14afd9ff"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bffec3605b73c6f1754535084a85229fa8a30f86014e6c81aeec4abb68b0285"
 dependencies = [
  "libc",
  "once_cell",

--- a/Cargo.Bazel.json.lock
+++ b/Cargo.Bazel.json.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "a1d219852174090d2a0d452dc91e49815c9c689af583fca62e176e31df466ea0",
+  "checksum": "5d815f09484e8c3700569828efe9c7cf3d9a1ee161331da6a1594082eaa99734",
   "crates": {
     "abnf 0.12.0": {
       "name": "abnf",
@@ -17586,11 +17586,11 @@
               "target": "quickcheck"
             },
             {
-              "id": "quinn 0.11.2",
+              "id": "quinn 0.11.3",
               "target": "quinn"
             },
             {
-              "id": "quinn-udp 0.5.2",
+              "id": "quinn-udp 0.5.4",
               "target": "quinn_udp"
             },
             {
@@ -48514,17 +48514,14 @@
       ],
       "license_file": "LICENSE-MIT"
     },
-    "quinn 0.11.2": {
+    "quinn 0.11.3": {
       "name": "quinn",
-      "version": "0.11.2",
+      "version": "0.11.3",
       "package_url": "https://github.com/quinn-rs/quinn",
       "repository": {
-        "Git": {
-          "remote": "https://github.com/quinn-rs/quinn",
-          "commitish": {
-            "Rev": "fb63829dd1f78a98cb7da0fc757db44d14afd9ff"
-          },
-          "strip_prefix": "quinn"
+        "Http": {
+          "url": "https://static.crates.io/crates/quinn/0.11.3/download",
+          "sha256": "b22d8e7369034b9a7132bc2008cac12f2013c8132b45e0554e6e20e2617f2156"
         }
       },
       "targets": [
@@ -48566,12 +48563,12 @@
               "target": "pin_project_lite"
             },
             {
-              "id": "quinn-proto 0.11.3",
+              "id": "quinn-proto 0.11.6",
               "target": "quinn_proto",
               "alias": "proto"
             },
             {
-              "id": "quinn-udp 0.5.2",
+              "id": "quinn-udp 0.5.4",
               "target": "quinn_udp",
               "alias": "udp"
             },
@@ -48582,6 +48579,10 @@
             {
               "id": "rustls 0.23.11",
               "target": "rustls"
+            },
+            {
+              "id": "socket2 0.5.7",
+              "target": "socket2"
             },
             {
               "id": "thiserror 1.0.62",
@@ -48599,7 +48600,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.11.2"
+        "version": "0.11.3"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -48608,17 +48609,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "quinn-proto 0.11.3": {
+    "quinn-proto 0.11.6": {
       "name": "quinn-proto",
-      "version": "0.11.3",
+      "version": "0.11.6",
       "package_url": "https://github.com/quinn-rs/quinn",
       "repository": {
-        "Git": {
-          "remote": "https://github.com/quinn-rs/quinn",
-          "commitish": {
-            "Rev": "fb63829dd1f78a98cb7da0fc757db44d14afd9ff"
-          },
-          "strip_prefix": "quinn-proto"
+        "Http": {
+          "url": "https://static.crates.io/crates/quinn-proto/0.11.6/download",
+          "sha256": "ba92fb39ec7ad06ca2582c0ca834dfeadcaf06ddfc8e635c80aa7e1c05315fdd"
         }
       },
       "targets": [
@@ -48690,7 +48688,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.11.3"
+        "version": "0.11.6"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -48699,17 +48697,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "quinn-udp 0.5.2": {
+    "quinn-udp 0.5.4": {
       "name": "quinn-udp",
-      "version": "0.5.2",
+      "version": "0.5.4",
       "package_url": "https://github.com/quinn-rs/quinn",
       "repository": {
-        "Git": {
-          "remote": "https://github.com/quinn-rs/quinn",
-          "commitish": {
-            "Rev": "fb63829dd1f78a98cb7da0fc757db44d14afd9ff"
-          },
-          "strip_prefix": "quinn-udp"
+        "Http": {
+          "url": "https://static.crates.io/crates/quinn-udp/0.5.4/download",
+          "sha256": "8bffec3605b73c6f1754535084a85229fa8a30f86014e6c81aeec4abb68b0285"
         }
       },
       "targets": [
@@ -48734,7 +48729,8 @@
         "crate_features": {
           "common": [
             "default",
-            "log"
+            "log",
+            "tracing"
           ],
           "selects": {}
         },
@@ -48767,7 +48763,7 @@
           }
         },
         "edition": "2021",
-        "version": "0.5.2"
+        "version": "0.5.4"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -78557,8 +78553,8 @@
     "protobuf 2.28.0",
     "publicsuffix 2.2.3",
     "quickcheck 1.0.3",
-    "quinn 0.11.2",
-    "quinn-udp 0.5.2",
+    "quinn 0.11.3",
+    "quinn-udp 0.5.4",
     "quote 1.0.35",
     "rand 0.8.5",
     "rand_chacha 0.3.1",

--- a/Cargo.Bazel.toml.lock
+++ b/Cargo.Bazel.toml.lock
@@ -8317,8 +8317,9 @@ dependencies = [
 
 [[package]]
 name = "quinn"
-version = "0.11.2"
-source = "git+https://github.com/quinn-rs/quinn?rev=fb63829dd1f78a98cb7da0fc757db44d14afd9ff#fb63829dd1f78a98cb7da0fc757db44d14afd9ff"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b22d8e7369034b9a7132bc2008cac12f2013c8132b45e0554e6e20e2617f2156"
 dependencies = [
  "bytes",
  "pin-project-lite",
@@ -8326,6 +8327,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.0.0",
  "rustls 0.23.11",
+ "socket2 0.5.7",
  "thiserror",
  "tokio",
  "tracing",
@@ -8333,8 +8335,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.3"
-source = "git+https://github.com/quinn-rs/quinn?rev=fb63829dd1f78a98cb7da0fc757db44d14afd9ff#fb63829dd1f78a98cb7da0fc757db44d14afd9ff"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba92fb39ec7ad06ca2582c0ca834dfeadcaf06ddfc8e635c80aa7e1c05315fdd"
 dependencies = [
  "bytes",
  "rand 0.8.5",
@@ -8349,8 +8352,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.2"
-source = "git+https://github.com/quinn-rs/quinn?rev=fb63829dd1f78a98cb7da0fc757db44d14afd9ff#fb63829dd1f78a98cb7da0fc757db44d14afd9ff"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bffec3605b73c6f1754535084a85229fa8a30f86014e6c81aeec4abb68b0285"
 dependencies = [
  "libc",
  "once_cell",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10074,8 +10074,8 @@ dependencies = [
  "ic-types-test-utils",
  "mockall",
  "pin-project-lite",
- "quinn 0.11.2 (git+https://github.com/quinn-rs/quinn?rev=693c9b7cfbf89c541ba99523237594499984ffed)",
- "quinn-udp 0.5.2 (git+https://github.com/quinn-rs/quinn?rev=693c9b7cfbf89c541ba99523237594499984ffed)",
+ "quinn",
+ "quinn-udp",
  "serde",
  "slog",
  "tempfile",
@@ -10236,8 +10236,8 @@ dependencies = [
  "phantom_newtype",
  "prometheus",
  "prost",
- "quinn 0.11.2 (git+https://github.com/quinn-rs/quinn?rev=693c9b7cfbf89c541ba99523237594499984ffed)",
- "quinn-udp 0.5.2 (git+https://github.com/quinn-rs/quinn?rev=693c9b7cfbf89c541ba99523237594499984ffed)",
+ "quinn",
+ "quinn-udp",
  "rustls 0.23.11",
  "slog",
  "socket2 0.5.7",
@@ -16727,30 +16727,14 @@ dependencies = [
 
 [[package]]
 name = "quinn"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4ceeeeabace7857413798eb1ffa1e9c905a9946a57d81fb69b4b71c4d8eb3ad"
+checksum = "b22d8e7369034b9a7132bc2008cac12f2013c8132b45e0554e6e20e2617f2156"
 dependencies = [
  "bytes",
  "pin-project-lite",
- "quinn-proto 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "quinn-udp 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-hash 1.1.0",
- "rustls 0.23.11",
- "thiserror",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "quinn"
-version = "0.11.2"
-source = "git+https://github.com/quinn-rs/quinn?rev=693c9b7cfbf89c541ba99523237594499984ffed#693c9b7cfbf89c541ba99523237594499984ffed"
-dependencies = [
- "bytes",
- "pin-project-lite",
- "quinn-proto 0.11.3 (git+https://github.com/quinn-rs/quinn?rev=693c9b7cfbf89c541ba99523237594499984ffed)",
- "quinn-udp 0.5.2 (git+https://github.com/quinn-rs/quinn?rev=693c9b7cfbf89c541ba99523237594499984ffed)",
+ "quinn-proto",
+ "quinn-udp",
  "rustc-hash 2.0.0",
  "rustls 0.23.11",
  "socket2 0.5.7",
@@ -16777,38 +16761,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "quinn-proto"
-version = "0.11.3"
-source = "git+https://github.com/quinn-rs/quinn?rev=693c9b7cfbf89c541ba99523237594499984ffed#693c9b7cfbf89c541ba99523237594499984ffed"
-dependencies = [
- "bytes",
- "rand 0.8.5",
- "ring 0.17.8",
- "rustc-hash 2.0.0",
- "rustls 0.23.11",
- "slab",
- "thiserror",
- "tinyvec",
- "tracing",
-]
-
-[[package]]
 name = "quinn-udp"
-version = "0.5.2"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9096629c45860fc7fb143e125eb826b5e721e10be3263160c7d60ca832cf8c46"
-dependencies = [
- "libc",
- "once_cell",
- "socket2 0.5.7",
- "tracing",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "quinn-udp"
-version = "0.5.2"
-source = "git+https://github.com/quinn-rs/quinn?rev=693c9b7cfbf89c541ba99523237594499984ffed#693c9b7cfbf89c541ba99523237594499984ffed"
+checksum = "8bffec3605b73c6f1754535084a85229fa8a30f86014e6c81aeec4abb68b0285"
 dependencies = [
  "libc",
  "once_cell",
@@ -17360,7 +17316,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "quinn 0.11.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quinn",
  "rustls 0.23.11",
  "rustls-native-certs 0.7.0",
  "rustls-pemfile 2.1.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -584,13 +584,13 @@ proptest = "1.0.0"
 prost = "=0.12.2"
 prost-build = "=0.12.2"
 protobuf = "2.28.0"
-quinn = { git = "https://github.com/quinn-rs/quinn", rev = "693c9b7cfbf89c541ba99523237594499984ffed", default-features = false, features = [
+quinn = { version = "0.11.3", default-features = false, features = [
     "ring",
     "log",
     "runtime-tokio",
     "rustls",
 ] }
-quinn-udp = { git = "https://github.com/quinn-rs/quinn", rev = "693c9b7cfbf89c541ba99523237594499984ffed" }
+quinn-udp = "0.11.3"
 rayon = "1.10.0"
 rand = { version = "0.8.5", features = ["small_rng"] }
 rand_chacha = "0.3.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -590,7 +590,7 @@ quinn = { version = "0.11.3", default-features = false, features = [
     "runtime-tokio",
     "rustls",
 ] }
-quinn-udp = "0.11.3"
+quinn-udp = "0.5.4"
 rayon = "1.10.0"
 rand = { version = "0.8.5", features = ["small_rng"] }
 rand_chacha = "0.3.1"

--- a/bazel/external_crates.bzl
+++ b/bazel/external_crates.bzl
@@ -961,8 +961,7 @@ def external_crates_repository(name, cargo_lockfile, lockfile, sanitizers_enable
                 features = ["ring", "log", "runtime-tokio", "rustls"],
             ),
             "quinn-udp": crate.spec(
-                git = "https://github.com/quinn-rs/quinn",
-                rev = "fb63829dd1f78a98cb7da0fc757db44d14afd9ff",
+                version = "^0.5.4",
             ),
             "quote": crate.spec(
                 version = "^1.0",

--- a/bazel/external_crates.bzl
+++ b/bazel/external_crates.bzl
@@ -956,8 +956,7 @@ def external_crates_repository(name, cargo_lockfile, lockfile, sanitizers_enable
                 version = "^1.0.3",
             ),
             "quinn": crate.spec(
-                git = "https://github.com/quinn-rs/quinn",
-                rev = "fb63829dd1f78a98cb7da0fc757db44d14afd9ff",
+                version = "^0.11.3",
                 default_features = False,
                 features = ["ring", "log", "runtime-tokio", "rustls"],
             ),


### PR DESCRIPTION
Previously different versions of quinn were used for Bazel and for Cargo, perhaps by mistake.
This updates both quinn and quinn-udp to their latest crate release version.