### PR TITLE
chore(consensus): [Con-1227] defer shares handling created ahead

### DIFF
--- a/rs/https_outcalls/consensus/src/gossip.rs
+++ b/rs/https_outcalls/consensus/src/gossip.rs
@@ -16,10 +16,10 @@ use ic_types::{
 };
 use std::{collections::BTreeSet, sync::Arc};
 
-/// The upper bound of how many HTTP outcall requests unknown to the local replica will be
+/// The upper bound of how many shares of HTTP outcall requests unknown to the local replica will be
 /// requested via P2P in advance. Since the request ids are strictly increasing, we can simply add
 /// the constant to the latest known request id.
-const MAX_NUMBER_OF_REQUESTS_AHEAD: usize = 10;
+const MAX_NUMBER_OF_REQUESTS_AHEAD: u64 = 10;
 
 /// The canonical implementation of [`PriorityFnFactory`]
 pub struct CanisterHttpGossipImpl {
@@ -73,7 +73,7 @@ impl<Pool: CanisterHttpPool> PriorityFnFactory<CanisterHttpResponseShare, Pool>
             }
 
             let highest_accepted_request_id =
-                next_callback_id + CallbackId::from(MAX_NUMBER_OF_REQUESTS_AHEAD);
+                CallbackId::from(next_callback_id.get() + MAX_NUMBER_OF_REQUESTS_AHEAD);
 
             // The https outcalls share should be fetched in two cases:
             //  - The Id of the share is part of the state which means it is active.

--- a/rs/https_outcalls/consensus/src/gossip.rs
+++ b/rs/https_outcalls/consensus/src/gossip.rs
@@ -10,8 +10,16 @@ use ic_interfaces::{
 use ic_interfaces_state_manager::StateReader;
 use ic_logger::{warn, ReplicaLogger};
 use ic_replicated_state::ReplicatedState;
-use ic_types::{artifact::CanisterHttpResponseId, canister_http::CanisterHttpResponseShare};
+use ic_types::{
+    artifact::CanisterHttpResponseId, canister_http::CanisterHttpResponseShare,
+    messages::CallbackId,
+};
 use std::{collections::BTreeSet, sync::Arc};
+
+/// The upper bound of how many HTTP outcall requests unknown to the local replica will be
+/// requested via P2P in advance. Since the request ids are strictly increasing, we can simply add
+/// the constant to the latest known request id.
+const MAX_NUMBER_OF_REQUESTS_AHEAD: usize = 10;
 
 /// The canonical implementation of [`PriorityFnFactory`]
 pub struct CanisterHttpGossipImpl {
@@ -63,13 +71,23 @@ impl<Pool: CanisterHttpPool> PriorityFnFactory<CanisterHttpResponseShare, Pool>
                 warn!(log, "Dropping canister http response share with callback id: {}, because registry version {} does not match expected version {}", id.content.id, id.content.registry_version, registry_version);
                 return Priority::Drop;
             }
+
+            let highest_accepted_request_id =
+                next_callback_id + CallbackId::from(MAX_NUMBER_OF_REQUESTS_AHEAD);
+
             // The https outcalls share should be fetched in two cases:
             //  - The Id of the share is part of the state which means it is active.
-            //  - The callback Id is higher than the next callback Id (the next callback Id is the Id used next in execution round).
+            //  - The callback Id is higher than the next callback Id (the next callback Id is the Id used next in execution round), but
+            //    not higher that `MAX_NUMBER_OF_REQUESTS_AHEAD`.
             //    Receiving an callback Id higher is possible because the priority fn is updated periodically (every 3s) with the latest state
             //    and can therefore store stale `known_request_ids` and stale `next_callback_id`.
-            if known_request_ids.contains(&id.content.id) || id.content.id >= next_callback_id {
+            if known_request_ids.contains(&id.content.id)
+                || (id.content.id >= next_callback_id
+                    && id.content.id <= highest_accepted_request_id)
+            {
                 Priority::FetchNow
+            } else if id.content.id > highest_accepted_request_id {
+                Priority::Stash
             } else {
                 Priority::Drop
             }

--- a/rs/https_outcalls/consensus/src/pool_manager.rs
+++ b/rs/https_outcalls/consensus/src/pool_manager.rs
@@ -441,6 +441,7 @@ pub mod test {
     use ic_logger::replica_logger::no_op_logger;
     use ic_metrics::MetricsRegistry;
     use ic_registry_subnet_type::SubnetType;
+    use ic_replicated_state::metadata_state::subnet_call_context_manager::SubnetCallContext;
     use ic_test_utilities_logger::with_test_replica_logger;
     use ic_test_utilities_types::ids::subnet_test_id;
     use ic_types::{
@@ -470,6 +471,13 @@ pub mod test {
     ) -> ReplicatedState {
         // Add some pending http calls
         let mut replicated_state = ReplicatedState::new(subnet_test_id(0), SubnetType::System);
+        // This will increase the next_call_id to 1
+        if let Some(val) = http_calls.values().next() {
+            replicated_state
+                .metadata
+                .subnet_call_context_manager
+                .push_context(SubnetCallContext::CanisterHttpRequest(val.clone()));
+        }
         replicated_state
             .metadata
             .subnet_call_context_manager

--- a/rs/https_outcalls/consensus/src/pool_manager.rs
+++ b/rs/https_outcalls/consensus/src/pool_manager.rs
@@ -120,7 +120,7 @@ impl CanisterHttpPoolManagerImpl {
             .chain(
                 canister_http_pool
                     .get_unvalidated_shares()
-                    // Only check the unvalidated shares belonging to the requests that we can't validate.
+                    // Only check the unvalidated shares belonging to the requests that we can validate.
                     .filter(|share| share.content.id <= next_callback_id)
                     .filter_map(|share| {
                         if active_callback_ids.contains(&share.content.id) {

--- a/rs/https_outcalls/consensus/src/pool_manager.rs
+++ b/rs/https_outcalls/consensus/src/pool_manager.rs
@@ -121,7 +121,7 @@ impl CanisterHttpPoolManagerImpl {
                 canister_http_pool
                     .get_unvalidated_shares()
                     // Only check the unvalidated shares belonging to the requests that we can validate.
-                    .filter(|share| share.content.id <= next_callback_id)
+                    .filter(|share| share.content.id < next_callback_id)
                     .filter_map(|share| {
                         if active_callback_ids.contains(&share.content.id) {
                             None
@@ -296,7 +296,7 @@ impl CanisterHttpPoolManagerImpl {
         canister_http_pool
             .get_unvalidated_shares()
             // Only consider shares belonging to the requests that we can validate.
-            .filter(|share| share.content.id <= next_callback_id)
+            .filter(|share| share.content.id < next_callback_id)
             .filter_map(|share| {
                 if existing_signed_requests.contains(&(share.signature.signer, share.content.id)) {
                     return Some(CanisterHttpChangeAction::HandleInvalid(


### PR DESCRIPTION
1. We modify the priority function so that we never fetch shares corresponding to more than `10` requests after the one we currently know.
2. We change the purging and the validation functions to only work on shares that belong to known and expected request ids.