### PR TITLE
fix: [EXC-1673] Consider canister snapshots when calculating available subnet memory

### DIFF
--- a/rs/execution_environment/tests/execution_test.rs
+++ b/rs/execution_environment/tests/execution_test.rs
@@ -721,7 +721,10 @@ fn take_canister_snapshot_request_fails_when_subnet_capacity_reached() {
     let env = StateMachine::new_with_config(StateMachineConfig::new(
         subnet_config,
         HypervisorConfig {
-            subnet_memory_capacity: NumBytes::from(10 * 1024 * 1024), // 10 MiB,
+            // 10 MiB capacity allows for creating two universal canisters and taking
+            // one snapshot but attempting to take a second one would fail.
+            // The value is chosen empirically by running the test a couple times.
+            subnet_memory_capacity: NumBytes::from(10 * 1024 * 1024),
             subnet_memory_reservation: NumBytes::from(0),
             canister_snapshots: FlagStatus::Enabled,
             ..Default::default()

--- a/rs/execution_environment/tests/execution_test.rs
+++ b/rs/execution_environment/tests/execution_test.rs
@@ -716,7 +716,7 @@ fn exceeding_memory_capacity_fails_when_memory_allocation_changes() {
 }
 
 #[test]
-fn stops_executing_take_canister_snapshot_requests_when_subnet_capacity_reached() {
+fn take_canister_snapshot_request_fails_when_subnet_capacity_reached() {
     let subnet_config = SubnetConfig::new(SubnetType::Application);
     let env = StateMachine::new_with_config(StateMachineConfig::new(
         subnet_config,

--- a/rs/replicated_state/src/canister_snapshots.rs
+++ b/rs/replicated_state/src/canister_snapshots.rs
@@ -188,6 +188,15 @@ impl CanisterSnapshots {
             snapshot_ids: _,
         } = self;
     }
+
+    /// Returns the amount of memory taken by all canister snapshots on
+    /// this subnet.
+    pub(crate) fn memory_taken(&self) -> NumBytes {
+        self.snapshots
+            .values()
+            .map(|snapshot| snapshot.size())
+            .sum::<NumBytes>()
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/rs/replicated_state/src/canister_snapshots.rs
+++ b/rs/replicated_state/src/canister_snapshots.rs
@@ -500,18 +500,16 @@ mod tests {
     fn test_memory_usage_correctly_updated_while_adding_and_removing_snapshots() {
         let canister_id = canister_test_id(0);
         let (first_snapshot_id, first_snapshot) = fake_canister_snapshot(canister_id, 1);
-        let mut snapshot_manager = CanisterSnapshots::default();
-        assert_eq!(snapshot_manager.snapshots.len(), 0);
-        assert_eq!(snapshot_manager.unflushed_changes.len(), 0);
-        assert_eq!(snapshot_manager.snapshot_ids.len(), 0);
-        assert_eq!(snapshot_manager.memory_taken(), NumBytes::from(0));
-
-        // Pushing new snapshot updates the `memory_usage`.
         let snapshot1_size = first_snapshot.size();
-        snapshot_manager.push(
+        let mut snapshots = BTreeMap::new();
+        snapshots.insert(
             first_snapshot_id,
             Arc::<CanisterSnapshot>::new(first_snapshot),
         );
+        let mut snapshot_manager = CanisterSnapshots::new(snapshots);
+        assert_eq!(snapshot_manager.snapshots.len(), 1);
+        assert_eq!(snapshot_manager.unflushed_changes.len(), 0);
+        assert_eq!(snapshot_manager.snapshot_ids.len(), 1);
         assert_eq!(
             snapshot_manager.memory_taken(),
             NumBytes::from(snapshot1_size)

--- a/rs/replicated_state/src/replicated_state.rs
+++ b/rs/replicated_state/src/replicated_state.rs
@@ -620,10 +620,13 @@ impl ReplicatedState {
         guaranteed_response_message_memory_taken +=
             (self.subnet_queues.guaranteed_response_memory_usage() as u64).into();
 
+        let canister_snapshots_memory_taken = self.canister_snapshots.memory_taken();
+
         MemoryTaken {
             execution: raw_memory_taken
                 + canister_history_memory_taken
-                + wasm_chunk_store_memory_usage,
+                + wasm_chunk_store_memory_usage
+                + canister_snapshots_memory_taken,
             guaranteed_response_messages: guaranteed_response_message_memory_taken,
             wasm_custom_sections: wasm_custom_sections_memory_taken,
             canister_history: canister_history_memory_taken,

--- a/rs/state_machine_tests/src/lib.rs
+++ b/rs/state_machine_tests/src/lib.rs
@@ -2590,7 +2590,9 @@ impl StateMachine {
         )
         .map(|res| match res {
             WasmResult::Reply(data) => CanisterSnapshotResponse::decode(&data),
-            WasmResult::Reject(reason) => panic!("create_canister call rejected: {}", reason),
+            WasmResult::Reject(reason) => {
+                panic!("take_canister_snapshot call rejected: {}", reason)
+            }
         })?
     }
 

--- a/rs/state_machine_tests/src/lib.rs
+++ b/rs/state_machine_tests/src/lib.rs
@@ -43,9 +43,10 @@ use ic_management_canister_types::{
     self as ic00, CanisterIdRecord, InstallCodeArgs, MasterPublicKeyId, Method, Payload,
 };
 pub use ic_management_canister_types::{
-    CanisterHttpResponsePayload, CanisterInstallMode, CanisterSettingsArgs, CanisterStatusResultV2,
-    CanisterStatusType, EcdsaCurve, EcdsaKeyId, HttpHeader, HttpMethod, SignWithECDSAReply,
-    SignWithSchnorrReply, UpdateSettingsArgs,
+    CanisterHttpResponsePayload, CanisterInstallMode, CanisterSettingsArgs,
+    CanisterSnapshotResponse, CanisterStatusResultV2, CanisterStatusType, EcdsaCurve, EcdsaKeyId,
+    HttpHeader, HttpMethod, SignWithECDSAReply, SignWithSchnorrReply, TakeCanisterSnapshotArgs,
+    UpdateSettingsArgs,
 };
 use ic_messaging::SyncMessageRouting;
 use ic_metrics::MetricsRegistry;
@@ -2570,6 +2571,27 @@ impl StateMachine {
             .encode(),
         )
         .map(|_| ())
+    }
+
+    pub fn take_canister_snapshot(
+        &self,
+        args: TakeCanisterSnapshotArgs,
+    ) -> Result<CanisterSnapshotResponse, UserError> {
+        let state = self.state_manager.get_latest_state().take();
+        let sender = state
+            .canister_state(&args.get_canister_id())
+            .and_then(|s| s.controllers().iter().next().cloned())
+            .unwrap_or_else(PrincipalId::new_anonymous);
+        self.execute_ingress_as(
+            sender,
+            ic00::IC_00,
+            Method::TakeCanisterSnapshot,
+            args.encode(),
+        )
+        .map(|res| match res {
+            WasmResult::Reply(data) => CanisterSnapshotResponse::decode(&data),
+            WasmResult::Reject(reason) => panic!("create_canister call rejected: {}", reason),
+        })?
     }
 
     /// Returns true if the canister with the specified id exists.


### PR DESCRIPTION
This PR fixes a bug when calculating the subnet's available memory at the beginning of a round.

As a refresher, the general flow wrt available memory is the following:
1. At the beginning of every round, we calculate the subnet's available memory by subtracting all resources that take memory from the available capacity.
2. While executing messages in the round, we keep updating the available memory as needed depending on the type of message and the operations triggered by it.

With the new snapshot feature that's being developed, we want the snapshots to be considered against the subnet's capacity since they will be stored on disk and we need to ensure we have enough space available. We already [take into account the available memory](https://sourcegraph.com/github.com/dfinity/ic@c95b51dbc6fc130b3eb019fab31b16be5ccddebb/-/blob/rs/execution_environment/src/canister_manager.rs?L1871) when taking a snapshot, check that there's enough and [update it](https://sourcegraph.com/github.com/dfinity/ic@c95b51dbc6fc130b3eb019fab31b16be5ccddebb/-/blob/rs/execution_environment/src/canister_manager.rs?L1907) once the snapshot has been taken successfully. This all works fine within an execution round.

However, we do not count the memory taken by snapshots when we re-compute the subnet's available memory at the beginning of a round. This means that there might be cases across execution rounds where we're off in terms of available memory (e.g. if other canister changes are added, we might think we're still fine although due to snapshots taking some memory we're already above the limit).

The fix is relatively simple -- we need to iterate over all snapshots and count their memory usage towards the memory that's taken and therefore not available anymore. A regression test is also included.