### PR TITLE
fix(IDX): use correct env var to the icrc1-ledger WASM path

### DIFF
--- a/rs/tests/gix/BUILD.bazel
+++ b/rs/tests/gix/BUILD.bazel
@@ -6,7 +6,7 @@ package(default_visibility = ["//rs:system-tests-pkg"])
 system_test_nns(
     name = "nns_dapp_test",
     env = {
-        "ICRC1_LEDGER_WASM_PATH": "$(rootpath //rs/rosetta-api/icrc1/ledger:ledger_canister)",
+        "IC_ICRC1_LEDGER_WASM_PATH": "$(rootpath //rs/rosetta-api/icrc1/ledger:ledger_canister)",
         "II_WASM_PATH": "$(rootpath @ii_dev_canister//file)",
         "NNS_DAPP_WASM_PATH": "$(rootpath @nns_dapp_canister//file)",
         "SUBNET_RENTAL_WASM_PATH": "$(rootpath @subnet_rental_canister//file)",

--- a/rs/tests/src/nns_dapp.rs
+++ b/rs/tests/src/nns_dapp.rs
@@ -153,7 +153,7 @@ pub fn install_ii_nns_dapp_and_subnet_rental(
         .with_token_name("ckETH".to_string())
         .build();
     let cketh_canister_id = nns_node.create_and_install_canister_with_arg(
-        &env::var("ICRC1_LEDGER_WASM_PATH").expect("ICRC1_LEDGER_WASM_PATH not set"),
+        &env::var("IC_ICRC1_LEDGER_WASM_PATH").expect("IC_ICRC1_LEDGER_WASM_PATH not set"),
         Some(Encode!(&(LedgerArgument::Init(cketh_init_args))).unwrap()),
     );
 

--- a/rs/tests/testing_verification/testnets/BUILD.bazel
+++ b/rs/tests/testing_verification/testnets/BUILD.bazel
@@ -94,7 +94,7 @@ system_test_nns(
 system_test_nns(
     name = "small_with_query_stats",
     env = {
-        "ICRC1_LEDGER_WASM_PATH": "$(rootpath //rs/rosetta-api/icrc1/ledger:ledger_canister)",
+        "IC_ICRC1_LEDGER_WASM_PATH": "$(rootpath //rs/rosetta-api/icrc1/ledger:ledger_canister)",
         "II_WASM_PATH": "$(rootpath @ii_dev_canister//file)",
         "NNS_DAPP_WASM_PATH": "$(rootpath @nns_dapp_canister//file)",
         "SUBNET_RENTAL_WASM_PATH": "$(rootpath @subnet_rental_canister//file)",


### PR DESCRIPTION
The name of the env var pointing to the ICRC1 Ledger WASM is defined from [the key `ic-icrc1-ledger` here](https://github.com/dfinity/ic/blob/master/rs/tests/common.bzl#L243). So we have to use `IC_ICRC1_LEDGER_WASM_PATH` as the env var and not `ICRC1_LEDGER_WASM_PATH`.

It's also more consistent with [all other references to that canister](https://sourcegraph.com/search?q=repo:%5Egithub%5C.com/dfinity/ic%24+IC_ICRC1_LEDGER_WASM_PATH&patternType=keyword&sm=0).