### PR TITLE
fix(IDX): use the correct path to the XRC mock canister WASM

### DIFF
--- a/rs/tests/nns/ic_mainnet_nns_recovery/src/lib.rs
+++ b/rs/tests/nns/ic_mainnet_nns_recovery/src/lib.rs
@@ -353,7 +353,7 @@ fn install_xrc_mock_canister(
         create_canister_from_icp(env.clone(), recovered_nns_node, principal, 10);
 
     let xrc_mock_wasm: PathBuf = fs::canonicalize(
-        env.get_dependency_path("rs/rosetta-api/tvl/xrc_mock/xrc_mock_canister.wasm"),
+        env.get_dependency_path("rs/rosetta-api/tvl/xrc_mock/xrc_mock_canister.wasm.gz"),
     )
     .unwrap();
 


### PR DESCRIPTION
Tested manually using:
```bash
test_tmpdir="/tmp/$(whoami)/test_tmpdir"; echo "test_tmpdir=$test_tmpdir"; rm -rf "$test_tmpdir"; ict testnet create recovered_mainnet_nns --lifetime-mins 5 --set-required-host-features=dc=zh1 --verbose -- --test_tmpdir="$test_tmpdir"
```