### PR TITLE
chore(dependency-mgmt): Change `oisy-wallet` node version to 20

### DIFF
--- a/gitlab-ci/src/dependencies/job/npm_scanner_periodic_job.py
+++ b/gitlab-ci/src/dependencies/job/npm_scanner_periodic_job.py
@@ -121,7 +121,7 @@ REPOS_TO_SCAN = [
                 owner=Team.GIX_TEAM,
             )
         ],
-        "18.17.1",
+        DEFAULT_NODE_VERSION,
     ),
     # Removing ic-docutrack temporarily since it supports
     # only pnpm and not npm


### PR DESCRIPTION
`oisy-wallet` supports only node v20 and [above](https://github.com/dfinity/oisy-wallet/blob/2c485e05bf1331da8290e70eedbf564b9f9923ca/package.json#L108)