### PR TITLE
fix(types): Remove serde derive from `ThresholdSigInputRefs`

### DIFF
--- a/rs/types/types/src/consensus/idkg/ecdsa.rs
+++ b/rs/types/types/src/consensus/idkg/ecdsa.rs
@@ -397,7 +397,7 @@ impl TryFrom<&pb::PreSignatureQuadrupleRef> for PreSignatureQuadrupleRef {
 
 /// Counterpart of ThresholdEcdsaSigInputs that holds transcript references,
 /// instead of the transcripts.
-#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(test, derive(ExhaustiveSet))]
 pub struct ThresholdEcdsaSigInputsRef {
     pub derivation_path: ExtendedDerivationPath,

--- a/rs/types/types/src/consensus/idkg/schnorr.rs
+++ b/rs/types/types/src/consensus/idkg/schnorr.rs
@@ -201,7 +201,7 @@ impl TryFrom<&pb::PreSignatureTranscriptRef> for PreSignatureTranscriptRef {
 
 /// Counterpart of ThresholdSchnorrSigInputs that holds transcript references,
 /// instead of the transcripts.
-#[derive(Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(test, derive(ExhaustiveSet))]
 pub struct ThresholdSchnorrSigInputsRef {
     pub derivation_path: ExtendedDerivationPath,


### PR DESCRIPTION
A [recent change](https://github.com/dfinity/ic/pull/344#issuecomment-2269598600) broke the cargo build with `serde`. It turns out that these types don't need to be (de-)serialized anymore, as they are no longer part of the block payload.