### PR TITLE
feat(nns): Switch NNS functions to new topics behind a feature flag

### DIFF
--- a/rs/nns/governance/src/governance.rs
+++ b/rs/nns/governance/src/governance.rs
@@ -1,5 +1,5 @@
 use crate::{
-    decoder_config,
+    decoder_config, enable_new_canister_management_topics,
     governance::{
         merge_neurons::{
             build_merge_neurons_response, calculate_merge_neurons_effect,
@@ -775,14 +775,9 @@ impl Proposal {
                             | NnsFunction::DeployGuestosToAllUnassignedNodes => {
                                 Topic::IcOsVersionDeployment
                             }
-                            NnsFunction::NnsCanisterInstall
-                            | NnsFunction::NnsCanisterUpgrade
+                            NnsFunction::NnsCanisterUpgrade
                             | NnsFunction::NnsRootUpgrade
-                            | NnsFunction::HardResetNnsRootToVersion
-                            | NnsFunction::StopOrStartNnsCanister
-                            | NnsFunction::AddSnsWasm
-                            | NnsFunction::BitcoinSetConfig
-                            | NnsFunction::InsertSnsWasmUpgradePathEntries => {
+                            | NnsFunction::StopOrStartNnsCanister => {
                                 Topic::NetworkCanisterManagement
                             }
                             NnsFunction::IcpXdrConversionRate => Topic::ExchangeRate,
@@ -811,6 +806,23 @@ impl Proposal {
                                 Topic::ApiBoundaryNodeManagement
                             }
                             NnsFunction::SubnetRentalRequest => Topic::SubnetRental,
+                            NnsFunction::NnsCanisterInstall
+                            | NnsFunction::HardResetNnsRootToVersion
+                            | NnsFunction::BitcoinSetConfig => {
+                                if enable_new_canister_management_topics() {
+                                    Topic::ProtocolCanisterManagement
+                                } else {
+                                    Topic::NetworkCanisterManagement
+                                }
+                            }
+                            NnsFunction::AddSnsWasm
+                            | NnsFunction::InsertSnsWasmUpgradePathEntries => {
+                                if enable_new_canister_management_topics() {
+                                    Topic::ServiceNervousSystemManagement
+                                } else {
+                                    Topic::NetworkCanisterManagement
+                                }
+                            }
                         }
                     } else {
                         println!(

--- a/rs/nns/governance/src/lib.rs
+++ b/rs/nns/governance/src/lib.rs
@@ -898,5 +898,9 @@ impl NeuronSubsetMetricsPb {
     }
 }
 
+fn enable_new_canister_management_topics() -> bool {
+    cfg!(feature = "test")
+}
+
 #[cfg(test)]
 mod tests;

--- a/rs/nns/governance/src/proposals/install_code.rs
+++ b/rs/nns/governance/src/proposals/install_code.rs
@@ -1,5 +1,6 @@
 use super::{invalid_proposal_error, topic_to_manage_canister};
 use crate::{
+    enable_new_canister_management_topics,
     pb::v1::{install_code::CanisterInstallMode, GovernanceError, InstallCode, Topic},
     proposals::call_canister::CallCanister,
 };
@@ -22,7 +23,7 @@ struct UpgradeRootProposalPayload {
 
 impl InstallCode {
     pub fn validate(&self) -> Result<(), GovernanceError> {
-        if !cfg!(feature = "test") {
+        if !enable_new_canister_management_topics() {
             return Err(invalid_proposal_error(
                 "InstallCode proposal is not yet supported",
             ));

--- a/rs/nns/governance/src/proposals/stop_or_start_canister.rs
+++ b/rs/nns/governance/src/proposals/stop_or_start_canister.rs
@@ -1,5 +1,6 @@
 use super::{invalid_proposal_error, topic_to_manage_canister};
 use crate::{
+    enable_new_canister_management_topics,
     pb::v1::{stop_or_start_canister::CanisterAction, GovernanceError, StopOrStartCanister, Topic},
     proposals::call_canister::CallCanister,
 };
@@ -19,7 +20,7 @@ const CANISTERS_NOT_ALLOWED_TO_STOP: [&CanisterId; 3] = [
 
 impl StopOrStartCanister {
     pub fn validate(&self) -> Result<(), GovernanceError> {
-        if !cfg!(feature = "test") {
+        if !enable_new_canister_management_topics() {
             return Err(invalid_proposal_error(
                 "StopOrStartCanister proposal is not yet supported",
             ));

--- a/rs/nns/governance/src/proposals/update_canister_settings.rs
+++ b/rs/nns/governance/src/proposals/update_canister_settings.rs
@@ -1,5 +1,6 @@
 use super::{invalid_proposal_error, topic_to_manage_canister};
 use crate::{
+    enable_new_canister_management_topics,
     pb::v1::{
         update_canister_settings::CanisterSettings, GovernanceError, Topic, UpdateCanisterSettings,
     },
@@ -11,7 +12,7 @@ use ic_nns_constants::ROOT_CANISTER_ID;
 
 impl UpdateCanisterSettings {
     pub fn validate(&self) -> Result<(), GovernanceError> {
-        if !cfg!(feature = "test") {
+        if !enable_new_canister_management_topics() {
             return Err(invalid_proposal_error(
                 "UpdateCanisterSettings proposal is not yet supported",
             ));


### PR DESCRIPTION
# Why

Context: https://forum.dfinity.org/t/refine-nns-proposals-topics/32125. Some NNS functions should be switched to new topics based on the new definition of the 3 related topics (2 new)

# What

* Define a feature flag `enable_new_canister_management_topics`
* Move some existing logic behind `enable_new_canister_management_topics`
* Use new topics for some `ExecuteNnsFunction`s, conditioned on the flag