### PR TITLE
chore(NODE-1448): Remove obsolete set-node-id command

### DIFF
--- a/rs/ic_os/vsock/README.md
+++ b/rs/ic_os/vsock/README.md
@@ -20,7 +20,6 @@ The following commands are supported:
 | detach-hsm            |           | Request that the HostOS detach the HSM from the GuestOS virtual machine. Note that the attach and detach-hsm commands are being phased out in favor of the virtual-hsm onboarding, which does not use the vsock. |
 | get-hostos-version    |           | Request that the HostOS return its version.  |
 | upgrade               | URL, hash | Request that the HostOS download and apply a given HostOS upgrade, then trigger a reboot of HostOS. Upgrades are triggered by NNS proposals. Unlike guestOS upgrades, which are triggered at a subnet level, the HostOS upgrades occur by datacenter or by individual nodes to avoid subnet downtime, as rebooting the HostOS typically takes several minutes. |
-| set-node-id           | Node ID   | Request that the HostOS adds the provided node-ID to its hostname as a way to identify which node-ids corresponds to which machines. Note that set-node-id is not currently called by the orchestrator, but we would like this functionality, eventually.  |
 | notify                | message   | Request that the HostOS output a given message a certain number of times to the host terminal. The command is used to log info on the HostOS (e.g., "orchestrator started," "replica starting up").  |
 
 ## Compatibility

--- a/rs/ic_os/vsock/guest/src/main.rs
+++ b/rs/ic_os/vsock/guest/src/main.rs
@@ -1,7 +1,7 @@
 #![cfg(target_os = "linux")]
 
 use clap::{Args, Parser};
-use vsock_lib::protocol::{Command, NodeIdData, NotifyData, Payload, UpgradeData};
+use vsock_lib::protocol::{Command, NotifyData, Payload, UpgradeData};
 use vsock_lib::send_command;
 fn main() -> Result<(), String> {
     let cli = Cli::parse();
@@ -38,10 +38,6 @@ struct Cli {
     /// Request hostOS to return its version
     #[clap(long)]
     get_hostos_version: bool,
-
-    /// Request hostOS to set the node ID.
-    #[clap(long, value_name = "NODE_ID")]
-    set_node_id: Option<String>,
 
     /// Set a custom port
     #[clap(long, default_value = "19090")]
@@ -82,8 +78,6 @@ fn get_command(cli: Cli) -> Result<Command, String> {
         Ok(Command::DetachHSM)
     } else if cli.get_hostos_version {
         Ok(Command::GetHostOSVersion)
-    } else if let Some(node_id) = cli.set_node_id {
-        Ok(Command::SetNodeId(NodeIdData { node_id }))
     } else if let Some(url) = cli.upgrade.upgrade {
         if let Some(target_hash) = cli.upgrade.hash {
             Ok(Command::Upgrade(UpgradeData { url, target_hash }))

--- a/rs/ic_os/vsock/vsock_lib/src/protocol/structures.rs
+++ b/rs/ic_os/vsock/vsock_lib/src/protocol/structures.rs
@@ -40,8 +40,6 @@ impl fmt::Display for Request {
 /// All commands that can be sent to the Host server
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
 pub enum Command {
-    #[serde(rename = "set-node-id")]
-    SetNodeId(NodeIdData),
     #[serde(rename = "attach-hsm")]
     AttachHSM,
     #[serde(rename = "detach-hsm")]
@@ -57,9 +55,6 @@ pub enum Command {
 impl fmt::Display for Command {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            Command::SetNodeId(node_id_data) => {
-                write!(f, "Command: Set Node ID\nNode ID: {}", node_id_data.node_id)
-            }
             Command::AttachHSM => write!(f, "Command: Attach HSM"),
             Command::DetachHSM => write!(f, "Command: Detach HSM"),
             Command::Upgrade(upgrade_data) => write!(
@@ -89,12 +84,6 @@ impl fmt::Display for HostOSVsockVersion {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}.{}.{}", self.major, self.minor, self.patch)
     }
-}
-
-#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
-pub struct NodeIdData {
-    #[serde(rename = "node-id")]
-    pub node_id: String,
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]

--- a/rs/ic_os/vsock/vsock_lib/src/protocol/utils.rs
+++ b/rs/ic_os/vsock/vsock_lib/src/protocol/utils.rs
@@ -65,23 +65,6 @@ pub mod tests {
             serde_json::json!({
                 "sender_cid": 1u32,
                 "message": {
-                    "set-node-id": {
-                        "node-id": "node-id-1"
-                    }
-                }
-            }),
-            serde_json::to_value(Request {
-                guest_cid: 1,
-                command: Command::SetNodeId(NodeIdData {
-                    node_id: "node-id-1".to_string()
-                })
-            })
-            .unwrap()
-        );
-        assert_eq!(
-            serde_json::json!({
-                "sender_cid": 1u32,
-                "message": {
                     "upgrade": {
                         "url": "https://example.com",
                         "target-hash": "0x1111222233334444"
@@ -151,17 +134,6 @@ pub mod tests {
         assert!(request.is_ok());
         let request = request.unwrap();
         assert_eq!(request.command, Command::DetachHSM);
-
-        // Test SetNodeId command
-        let json_str = r#"{"sender_cid": 123, "message": {"set-node-id": {"node-id": "node123"}}}"#;
-        let request = parse_request(json_str);
-        assert!(request.is_ok());
-        let request = request.unwrap();
-        assert_eq!(request.guest_cid, 123);
-        match request.command {
-            Command::SetNodeId(data) => assert_eq!(data.node_id, "node123"),
-            _ => panic!("Expected SetNodeId command"),
-        }
 
         // Test Upgrade command
         let json_str = r#"{"sender_cid": 123, "message": {"upgrade": {"url": "http://example.com/upgrade", "target-hash": "abcd1234hash"}}}"#;


### PR DESCRIPTION
NODE-1448

Set-node-id was a vsock command that was written but never used. This PR removes it from the codebase.