### PR TITLE
fix: EXC-1681: Fix a debug assertion in update_socket_timeout

### DIFF
--- a/rs/canister_sandbox/src/transport.rs
+++ b/rs/canister_sandbox/src/transport.rs
@@ -397,13 +397,28 @@ impl SocketReaderWithTimeout {
             )
         };
 
-        debug_assert_eq!(
-            result,
-            0,
-            "setsockopt failed with result={}, error={}",
-            result,
-            std::io::Error::last_os_error()
-        );
+        if result != 0 {
+            // OS error 9 corresponds to the `BAD_FILE_DESCRIPTOR` error.
+            // This error may happen here if the main process terminates the
+            // sandbox process and immediately closes the socket while the
+            // sandbox process is attempting to update socket timeout here.
+            //
+            // Note that this is likely to happen in tests that create many
+            // `SandboxedExecutionController`s and sandbox processes.
+            const BAD_FILE_DESCRIPTOR: i32 = 9;
+            let err = std::io::Error::last_os_error();
+
+            // Any error besides `BAD_FILE_DESCRIPTOR` is unexpected.
+            debug_assert_eq!(
+                err.raw_os_error(),
+                Some(BAD_FILE_DESCRIPTOR),
+                "setsockopt failed with result={}, error={}, kind={:?}, code={:?}",
+                result,
+                err,
+                err.kind(),
+                err.raw_os_error()
+            );
+        }
 
         if result == 0 {
             self.socket_timeout = timeout;

--- a/rs/execution_environment/src/hypervisor/tests.rs
+++ b/rs/execution_environment/src/hypervisor/tests.rs
@@ -7739,3 +7739,24 @@ fn wasm_memory_limit_cannot_exceed_256_tb() {
 
     assert_eq!(err.code(), ErrorCode::CanisterContractViolation);
 }
+
+#[test]
+fn stress_execution_1() {
+    for _ in 0..10000 {
+        let _ = ExecutionTestBuilder::new().build();
+    }
+}
+
+#[test]
+fn stress_execution_2() {
+    for _ in 0..10000 {
+        let _ = ExecutionTestBuilder::new().build();
+    }
+}
+
+#[test]
+fn stress_execution_3() {
+    for _ in 0..10000 {
+        let _ = ExecutionTestBuilder::new().build();
+    }
+}

--- a/rs/execution_environment/src/hypervisor/tests.rs
+++ b/rs/execution_environment/src/hypervisor/tests.rs
@@ -7739,24 +7739,3 @@ fn wasm_memory_limit_cannot_exceed_256_tb() {
 
     assert_eq!(err.code(), ErrorCode::CanisterContractViolation);
 }
-
-#[test]
-fn stress_execution_1() {
-    for _ in 0..10000 {
-        let _ = ExecutionTestBuilder::new().build();
-    }
-}
-
-#[test]
-fn stress_execution_2() {
-    for _ in 0..10000 {
-        let _ = ExecutionTestBuilder::new().build();
-    }
-}
-
-#[test]
-fn stress_execution_3() {
-    for _ in 0..10000 {
-        let _ = ExecutionTestBuilder::new().build();
-    }
-}


### PR DESCRIPTION
This change does not affect production because it adjusts a debug mode assertion.

The assertion was too strict and could fire when running tests in a corner case
when the main process sends a termination message to the sandbox process and
manages to close the socket before the sandbox process reads termination message.

In such cases, an attempt to call `setsockopt` fails with an OS error 9 (bad file descriptor).