### PR TITLE
chore(sns): Remove obsolete field `SnsInitPayload.neurons_fund_participants`

### DIFF
--- a/rs/nns/governance/src/governance/tests/mod.rs
+++ b/rs/nns/governance/src/governance/tests/mod.rs
@@ -200,7 +200,6 @@ mod convert_from_create_service_nervous_system_to_sns_init_payload_tests {
                 initial_token_distribution: None,
                 swap_start_timestamp_seconds: None,
                 swap_due_timestamp_seconds: None,
-                neurons_fund_participants: None,
                 nns_proposal_id: None,
                 neuron_basket_construction_parameters: None,
                 ..converted
@@ -297,7 +296,6 @@ mod convert_from_create_service_nervous_system_to_sns_init_payload_tests {
                 // We'll examine these later
                 initial_token_distribution: None,
                 neuron_basket_construction_parameters: None,
-                neurons_fund_participants: None,
                 swap_start_timestamp_seconds: None,
                 swap_due_timestamp_seconds: None,
                 nns_proposal_id: None,
@@ -400,7 +398,6 @@ mod convert_from_create_service_nervous_system_to_sns_init_payload_tests {
         );
 
         assert_eq!(converted.nns_proposal_id, None);
-        assert_eq!(converted.neurons_fund_participants, None);
         assert_eq!(converted.swap_start_timestamp_seconds, None);
         assert_eq!(converted.swap_due_timestamp_seconds, None);
     }
@@ -607,7 +604,6 @@ mod convert_from_executed_create_service_nervous_system_proposal_to_sns_init_pay
                 confirmation_text: original_swap_parameters.confirmation_text.clone(),
                 restricted_countries: original_swap_parameters.restricted_countries.clone(),
                 nns_proposal_id: Some(proposal_id),
-                neurons_fund_participants: None,
                 neurons_fund_participation: Some(true),
 
                 neurons_fund_participation_constraints: Some(

--- a/rs/nns/governance/src/proposals/create_service_nervous_system.rs
+++ b/rs/nns/governance/src/proposals/create_service_nervous_system.rs
@@ -407,7 +407,6 @@ impl TryFrom<CreateServiceNervousSystem> for SnsInitPayload {
             // These are not known from only the CreateServiceNervousSystem
             // proposal. See TryFrom<ExecutedCreateServiceNervousSystemProposal>
             nns_proposal_id: None,
-            neurons_fund_participants: None,
             swap_start_timestamp_seconds: None,
             swap_due_timestamp_seconds: None,
             neurons_fund_participation_constraints: None,

--- a/rs/nns/sns-wasm/canister/sns-wasm.did
+++ b/rs/nns/sns-wasm/canister/sns-wasm.did
@@ -2,17 +2,6 @@ type AddWasmRequest = record { hash : blob; wasm : opt SnsWasm };
 type AddWasmResponse = record { result : opt Result };
 type AirdropDistribution = record { airdrop_neurons : vec NeuronDistribution };
 type Canister = record { id : opt principal };
-type CfNeuron = record {
-  has_created_neuron_recipes : opt bool;
-  hotkeys : opt Principals;
-  nns_neuron_id : nat64;
-  amount_icp_e8s : nat64;
-};
-type CfParticipant = record {
-  controller : opt principal;
-  hotkey_principal : text;
-  cf_neurons : vec CfNeuron;
-};
 type Countries = record { iso_codes : vec text };
 type DappCanisters = record { canisters : vec Canister };
 type DappCanistersTransferResult = record {
@@ -111,7 +100,6 @@ type NeuronDistribution = record {
   stake_e8s : nat64;
   vesting_period_seconds : opt nat64;
 };
-type NeuronsFundParticipants = record { participants : vec CfParticipant };
 type NeuronsFundParticipationConstraints = record {
   coefficient_intervals : vec LinearScalingCoefficient;
   max_neurons_fund_participation_icp_e8s : opt nat64;
@@ -127,7 +115,6 @@ type PrettySnsVersion = record {
   governance_wasm_hash : text;
   index_wasm_hash : text;
 };
-type Principals = record { principals : vec principal };
 type Result = variant { Error : SnsWasmError; Hash : blob };
 type Result_1 = variant { Ok : Ok; Error : SnsWasmError };
 type SnsCanisterIds = record {
@@ -165,7 +152,6 @@ type SnsInitPayload = record {
   transaction_fee_e8s : opt nat64;
   dapp_canisters : opt DappCanisters;
   neurons_fund_participation_constraints : opt NeuronsFundParticipationConstraints;
-  neurons_fund_participants : opt NeuronsFundParticipants;
   max_age_bonus_percentage : opt nat64;
   initial_token_distribution : opt InitialTokenDistribution;
   reward_rate_transition_duration_seconds : opt nat64;

--- a/rs/sns/init/proto/ic_sns_init/pb/v1/sns_init.proto
+++ b/rs/sns/init/proto/ic_sns_init/pb/v1/sns_init.proto
@@ -213,7 +213,11 @@ message SnsInitPayload {
   optional bool neurons_fund_participation = 40;
 
   // The Neurons' Fund participants of this SNS decentralization swap.
-  optional NeuronsFundParticipants neurons_fund_participants = 35;
+  //
+  // This field is deprecated, as Neurons' Fund participants are now determined at the end of
+  // a successful swap and cannot be specified during SNS initialization.
+  reserved 35;
+  reserved "neurons_fund_participants";
 
   // The token_logo for the SNS project represented as a base64 encoded string.
   optional string token_logo = 36;
@@ -327,8 +331,4 @@ message NeuronDistribution {
 /// A Canister that will be transferred to an SNS.
 message DappCanisters {
   repeated ic_nervous_system.pb.v1.Canister canisters = 1;
-}
-
-message NeuronsFundParticipants {
-  repeated ic_sns_swap.pb.v1.CfParticipant participants  = 1;
 }

--- a/rs/sns/init/src/gen/ic_sns_init.pb.v1.rs
+++ b/rs/sns/init/src/gen/ic_sns_init.pb.v1.rs
@@ -198,9 +198,6 @@ pub struct SnsInitPayload {
     /// Whether or not the neurons' fund is participating
     #[prost(bool, optional, tag = "40")]
     pub neurons_fund_participation: ::core::option::Option<bool>,
-    /// The Neurons' Fund participants of this SNS decentralization swap.
-    #[prost(message, optional, tag = "35")]
-    pub neurons_fund_participants: ::core::option::Option<NeuronsFundParticipants>,
     /// The token_logo for the SNS project represented as a base64 encoded string.
     #[prost(string, optional, tag = "36")]
     pub token_logo: ::core::option::Option<::prost::alloc::string::String>,
@@ -357,11 +354,4 @@ pub struct NeuronDistribution {
 pub struct DappCanisters {
     #[prost(message, repeated, tag = "1")]
     pub canisters: ::prost::alloc::vec::Vec<::ic_nervous_system_proto::pb::v1::Canister>,
-}
-#[derive(candid::CandidType, candid::Deserialize, serde::Serialize, Eq)]
-#[allow(clippy::derive_partial_eq_without_eq)]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct NeuronsFundParticipants {
-    #[prost(message, repeated, tag = "1")]
-    pub participants: ::prost::alloc::vec::Vec<::ic_sns_swap::pb::v1::CfParticipant>,
 }

--- a/rs/sns/init/src/lib.rs
+++ b/rs/sns/init/src/lib.rs
@@ -1,7 +1,6 @@
 use crate::pb::v1::{
     sns_init_payload::InitialTokenDistribution::FractionalDeveloperVotingPower,
-    FractionalDeveloperVotingPower as FractionalDVP, NeuronsFundParticipants, SnsInitPayload,
-    SwapDistribution,
+    FractionalDeveloperVotingPower as FractionalDVP, SnsInitPayload, SwapDistribution,
 };
 use candid::Principal;
 use ic_base_types::{CanisterId, PrincipalId};
@@ -335,23 +334,6 @@ impl From<NeuronBasketConstructionParametersValidationError> for Result<(), Stri
     }
 }
 
-impl From<NeuronsFundParticipants> for ic_sns_swap::pb::v1::NeuronsFundParticipants {
-    fn from(value: NeuronsFundParticipants) -> Self {
-        #[allow(deprecated)] // TODO(NNS1-3198): remove once hotkey_principal is removed
-        Self {
-            cf_participants: value
-                .participants
-                .iter()
-                .map(|cf_participant| ic_sns_swap::pb::v1::CfParticipant {
-                    controller: cf_participant.controller,
-                    hotkey_principal: cf_participant.hotkey_principal.clone(),
-                    cf_neurons: cf_participant.cf_neurons.clone(),
-                })
-                .collect(),
-        }
-    }
-}
-
 #[derive(Clone, Copy)]
 pub enum NeuronsFundParticipationValidationError {
     Unspecified,
@@ -454,7 +436,6 @@ impl SnsInitPayload {
             confirmation_text: None,
             restricted_countries: None,
             nns_proposal_id: None,
-            neurons_fund_participants: None,
             neurons_fund_participation_constraints: None,
             neurons_fund_participation: None,
         }
@@ -467,7 +448,6 @@ impl SnsInitPayload {
     pub fn with_valid_values_for_testing_pre_execution() -> Self {
         Self {
             nns_proposal_id: None,
-            neurons_fund_participants: None,
             swap_start_timestamp_seconds: None,
             swap_due_timestamp_seconds: None,
             neurons_fund_participation_constraints: None,
@@ -538,7 +518,6 @@ impl SnsInitPayload {
                     ),
                 }),
             }),
-            neurons_fund_participants: None,
             ..SnsInitPayload::with_default_values()
         }
     }
@@ -741,7 +720,7 @@ impl SnsInitPayload {
                 .neurons_fund_participation_constraints
                 .clone(),
             neurons_fund_participation: self.neurons_fund_participation,
-            // This field must not be set at Swap initialization time.
+            // Deprecated field
             neurons_fund_participants: None,
         })
     }
@@ -824,7 +803,6 @@ impl SnsInitPayload {
             swap_due_timestamp_seconds: _,
             neuron_basket_construction_parameters: _,
             nns_proposal_id: _,
-            neurons_fund_participants: _,
             token_logo: _,
             neurons_fund_participation_constraints: _,
             neurons_fund_participation: _,
@@ -900,7 +878,6 @@ impl SnsInitPayload {
             // Ensure that the values that can only be known after the execution
             // of the CreateServiceNervousSystem proposal are not set.
             self.validate_nns_proposal_id_pre_execution(),
-            self.validate_neurons_fund_participants_pre_execution(),
             self.validate_swap_start_timestamp_seconds_pre_execution(),
             self.validate_swap_due_timestamp_seconds_pre_execution(),
             self.validate_neurons_fund_participation_constraints(true),
@@ -944,7 +921,6 @@ impl SnsInitPayload {
             self.validate_restricted_countries(),
             self.validate_all_post_execution_swap_parameters_are_set(),
             self.validate_nns_proposal_id(),
-            self.validate_neurons_fund_participants(),
             self.validate_swap_start_timestamp_seconds(),
             self.validate_swap_due_timestamp_seconds(),
             self.validate_neurons_fund_participation_constraints(false),
@@ -1781,28 +1757,6 @@ impl SnsInitPayload {
         match self.nns_proposal_id {
             None => Err("Error: nns_proposal_id must be specified".to_string()),
             Some(_) => Ok(()),
-        }
-    }
-
-    fn validate_neurons_fund_participants_pre_execution(&self) -> Result<(), String> {
-        if self.neurons_fund_participants.is_none() {
-            Ok(())
-        } else {
-            Err(format!(
-                "Error: neurons_fund_participants cannot be specified pre_execution, but was {:?}",
-                self.neurons_fund_participants
-            ))
-        }
-    }
-
-    fn validate_neurons_fund_participants(&self) -> Result<(), String> {
-        if self.neurons_fund_participants.is_none() {
-            Ok(())
-        } else {
-            Err(format!(
-                "Error: neurons_fund_participants can be set only by Swap; was initialized to {:?}",
-                self.neurons_fund_participants
-            ))
         }
     }
 
@@ -3058,7 +3012,6 @@ mod test {
             let mut sns_init_payload =
                 SnsInitPayload::with_valid_values_for_testing_post_execution();
             sns_init_payload.nns_proposal_id = None;
-            sns_init_payload.neurons_fund_participants = None;
             sns_init_payload.swap_start_timestamp_seconds = None;
             sns_init_payload.swap_due_timestamp_seconds = None;
             sns_init_payload.neurons_fund_participation_constraints = None;


### PR DESCRIPTION
Since the NF participants cannot be specified upfront anymore, we remove `SnsInitPayload.neurons_fund_participants`.