### PR TITLE
feat(RUN-1029): Handle stable_read/write with Wasm64 heaps and testing infrastructure

### DIFF
--- a/rs/config/src/embedders.rs
+++ b/rs/config/src/embedders.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 use ic_base_types::NumBytes;
 use ic_registry_subnet_type::SubnetType;
 use ic_sys::PAGE_SIZE;
-use ic_types::{NumInstructions, NumOsPages};
+use ic_types::{NumInstructions, NumOsPages, MAX_STABLE_MEMORY_IN_BYTES, MAX_WASM_MEMORY_IN_BYTES};
 use serde::{Deserialize, Serialize};
 
 use crate::flag_status::FlagStatus;
@@ -223,6 +223,12 @@ pub struct Config {
 
     /// The maximum allowed size for an uncompressed canister Wasm module.
     pub wasm_max_size: NumBytes,
+
+    /// The maximum size of the wasm heap memory.
+    pub max_wasm_memory_size: NumBytes,
+
+    /// The maximum size of the stable memory.
+    pub max_stable_memory_size: NumBytes,
 }
 
 impl Config {
@@ -258,6 +264,8 @@ impl Config {
             max_dirty_pages_without_optimization: DEFAULT_MAX_DIRTY_PAGES_WITHOUT_OPTIMIZATION,
             dirty_page_copy_overhead: DIRTY_PAGE_COPY_OVERHEAD,
             wasm_max_size: WASM_MAX_SIZE,
+            max_wasm_memory_size: NumBytes::new(MAX_WASM_MEMORY_IN_BYTES),
+            max_stable_memory_size: NumBytes::new(MAX_STABLE_MEMORY_IN_BYTES),
         }
     }
 }

--- a/rs/embedders/src/wasm_utils.rs
+++ b/rs/embedders/src/wasm_utils.rs
@@ -210,6 +210,8 @@ fn validate_and_instrument(
         config.metering_type,
         config.subnet_type,
         config.dirty_page_overhead,
+        config.max_wasm_memory_size,
+        config.max_stable_memory_size,
     )?;
     Ok((wasm_validation_details, instrumentation_output))
 }

--- a/rs/embedders/src/wasm_utils/instrumentation.rs
+++ b/rs/embedders/src/wasm_utils/instrumentation.rs
@@ -118,8 +118,9 @@ use ic_config::flag_status::FlagStatus;
 use ic_registry_subnet_type::SubnetType;
 use ic_replicated_state::NumWasmPages;
 use ic_sys::PAGE_SIZE;
-use ic_types::{methods::WasmMethod, MAX_WASM_MEMORY_IN_BYTES};
-use ic_types::{NumInstructions, MAX_STABLE_MEMORY_IN_BYTES};
+use ic_types::methods::WasmMethod;
+use ic_types::NumBytes;
+use ic_types::NumInstructions;
 use ic_wasm_types::{BinaryEncodedWasm, WasmError, WasmInstrumentationError};
 use wasmtime_environ::WASM_PAGE_SIZE;
 
@@ -707,14 +708,14 @@ pub(crate) const DIRTY_PAGES_COUNTER_GLOBAL_NAME: &str = "canister counter_dirty
 pub(crate) const ACCESSED_PAGES_COUNTER_GLOBAL_NAME: &str = "canister counter_accessed_pages";
 const CANISTER_START_STR: &str = "canister_start";
 
-/// There is one byte for each OS page in the wasm heap.
-const BYTEMAP_SIZE_IN_WASM_PAGES: u64 =
-    MAX_WASM_MEMORY_IN_BYTES / (PAGE_SIZE as u64) / (WASM_PAGE_SIZE as u64);
+/// There is one byte for each OS page in the memory.
+fn bytemap_size_in_wasm_pages(memory_size: NumBytes) -> u64 {
+    memory_size.get() / (PAGE_SIZE as u64) / (WASM_PAGE_SIZE as u64)
+}
 
-const MAX_STABLE_MEMORY_IN_WASM_PAGES: u64 = MAX_STABLE_MEMORY_IN_BYTES / (WASM_PAGE_SIZE as u64);
-const MAX_WASM_MEMORY_IN_WASM_PAGES: u64 = MAX_WASM_MEMORY_IN_BYTES / (WASM_PAGE_SIZE as u64);
-/// There is one byte for each OS page in the stable memory.
-const STABLE_BYTEMAP_SIZE_IN_WASM_PAGES: u64 = MAX_STABLE_MEMORY_IN_WASM_PAGES / (PAGE_SIZE as u64);
+fn max_memory_size_in_wasm_pages(memory_size: NumBytes) -> u64 {
+    memory_size.get() / (WASM_PAGE_SIZE as u64)
+}
 
 fn add_func_type(module: &mut Module, ty: FuncType) -> u32 {
     for (idx, existing_subtype) in module.types.iter().enumerate() {
@@ -917,13 +918,20 @@ pub(super) fn instrument(
     metering_type: MeteringType,
     subnet_type: SubnetType,
     dirty_page_overhead: NumInstructions,
+    max_wasm_memory_size: NumBytes,
+    max_stable_memory_size: NumBytes,
 ) -> Result<InstrumentationOutput, WasmInstrumentationError> {
     let main_memory_type = main_memory_type(&module);
     let stable_memory_index;
     let mut module = inject_helper_functions(module, wasm_native_stable_memory, main_memory_type);
     module = export_table(module);
-    (module, stable_memory_index) =
-        update_memories(module, write_barrier, wasm_native_stable_memory);
+    (module, stable_memory_index) = update_memories(
+        module,
+        write_barrier,
+        wasm_native_stable_memory,
+        max_wasm_memory_size,
+        max_stable_memory_size,
+    );
 
     let mut extra_strs: Vec<String> = Vec::new();
     module = export_mutable_globals(module, &mut extra_strs);
@@ -1023,6 +1031,7 @@ pub(super) fn instrument(
             subnet_type,
             dirty_page_overhead,
             main_memory_type,
+            max_wasm_memory_size,
         )
     }
 
@@ -1107,6 +1116,7 @@ fn replace_system_api_functions(
     subnet_type: SubnetType,
     dirty_page_overhead: NumInstructions,
     main_memory_type: WasmMemoryType,
+    max_wasm_memory_size: NumBytes,
 ) {
     let api_indexes = calculate_api_indexes(module);
     let number_of_func_imports = module
@@ -1123,6 +1133,7 @@ fn replace_system_api_functions(
         subnet_type,
         dirty_page_overhead,
         main_memory_type,
+        max_wasm_memory_size,
     ) {
         if let Some(old_index) = api_indexes.get(&api) {
             let type_idx = add_func_type(module, ty);
@@ -1942,20 +1953,24 @@ fn update_memories(
     mut module: Module,
     write_barrier: FlagStatus,
     wasm_native_stable_memory: FlagStatus,
+    max_wasm_memory_size: NumBytes,
+    max_stable_memory_size: NumBytes,
 ) -> (Module, u32) {
     let mut stable_index = 0;
 
     if let Some(mem) = module.memories.first_mut() {
         if mem.memory64 {
+            let max_wasm_memory_size_in_wasm_pages =
+                max_memory_size_in_wasm_pages(max_wasm_memory_size);
             match mem.maximum {
                 Some(max) => {
                     // In case the maximum memory size is larger than the maximum allowed, cap it.
-                    if max > MAX_WASM_MEMORY_IN_WASM_PAGES {
-                        mem.maximum = Some(MAX_WASM_MEMORY_IN_WASM_PAGES);
+                    if max > max_wasm_memory_size_in_wasm_pages {
+                        mem.maximum = Some(max_wasm_memory_size_in_wasm_pages);
                     }
                 }
                 None => {
-                    mem.maximum = Some(MAX_WASM_MEMORY_IN_WASM_PAGES);
+                    mem.maximum = Some(max_wasm_memory_size_in_wasm_pages);
                 }
             }
         }
@@ -1978,12 +1993,13 @@ fn update_memories(
         module.exports.push(memory_export);
     }
 
+    let wasm_bytemap_size_in_wasm_pages = bytemap_size_in_wasm_pages(max_wasm_memory_size);
     if write_barrier == FlagStatus::Enabled && !module.memories.is_empty() {
         module.memories.push(MemoryType {
             memory64: false,
             shared: false,
-            initial: BYTEMAP_SIZE_IN_WASM_PAGES,
-            maximum: Some(BYTEMAP_SIZE_IN_WASM_PAGES),
+            initial: wasm_bytemap_size_in_wasm_pages,
+            maximum: Some(wasm_bytemap_size_in_wasm_pages),
         });
 
         module.exports.push(Export {
@@ -1999,7 +2015,7 @@ fn update_memories(
             memory64: true,
             shared: false,
             initial: 0,
-            maximum: Some(MAX_STABLE_MEMORY_IN_WASM_PAGES),
+            maximum: Some(max_memory_size_in_wasm_pages(max_stable_memory_size)),
         });
 
         module.exports.push(Export {
@@ -2008,11 +2024,12 @@ fn update_memories(
             index: stable_index,
         });
 
+        let stable_bytemap_size_in_wasm_pages = bytemap_size_in_wasm_pages(max_stable_memory_size);
         module.memories.push(MemoryType {
             memory64: false,
             shared: false,
-            initial: STABLE_BYTEMAP_SIZE_IN_WASM_PAGES,
-            maximum: Some(STABLE_BYTEMAP_SIZE_IN_WASM_PAGES),
+            initial: stable_bytemap_size_in_wasm_pages,
+            maximum: Some(stable_bytemap_size_in_wasm_pages),
         });
 
         module.exports.push(Export {

--- a/rs/embedders/src/wasm_utils/system_api_replacements.rs
+++ b/rs/embedders/src/wasm_utils/system_api_replacements.rs
@@ -24,6 +24,8 @@ use ic_wasm_transform::Body;
 use wasmparser::{BlockType, FuncType, Operator, ValType};
 use wasmtime_environ::WASM_PAGE_SIZE;
 
+use ic_types::NumBytes;
+
 use super::{instrumentation::SpecialIndices, SystemApiFunc};
 
 const MAX_32_BIT_STABLE_MEMORY_IN_PAGES: i64 = 64 * 1024; // 4GiB
@@ -33,6 +35,7 @@ pub(super) fn replacement_functions(
     subnet_type: SubnetType,
     dirty_page_overhead: NumInstructions,
     main_memory_type: WasmMemoryType,
+    max_wasm_memory_size: NumBytes,
 ) -> Vec<(SystemApiFunc, (FuncType, Body<'static>))> {
     let count_clean_pages_fn_index = special_indices.count_clean_pages_fn.unwrap();
     let dirty_pages_counter_index = special_indices.dirty_pages_counter_ix.unwrap();
@@ -47,6 +50,16 @@ pub(super) fn replacement_functions(
     let cast_to_heap_addr_type = match main_memory_type {
         WasmMemoryType::Wasm32 => I32WrapI64,
         WasmMemoryType::Wasm64 => Nop,
+    };
+
+    let max_heap_address = match main_memory_type {
+        // If we are in Wasm32 mode, we can't have a heap address that is larger than u32::MAX, which is 4 GiB.
+        // In Wasm64 mode, we can have heap addresses that are larger than u32::MAX.
+        // The embedders config passes along the largest heap size in Wasm64 mode.
+        // We need to therefore allow the heap addresses to be larger than u32::MAX in Wasm64 mode
+        // for stable_read and stable_write.
+        WasmMemoryType::Wasm32 => u32::MAX as u64,
+        WasmMemoryType::Wasm64 => max_wasm_memory_size.get(),
     };
 
     vec![
@@ -563,11 +576,11 @@ pub(super) fn replacement_functions(
                                 function_index: InjectedImports::InternalTrap as u32,
                             },
                             End,
-                            // check if these i64 hold valid i32 heap addresses
+                            // check if these i64 hold valid heap addresses
                             // check dst
                             LocalGet { local_index: DST },
                             I64Const {
-                                value: u32::MAX as i64,
+                                value: max_heap_address as i64,
                             },
                             I64GtU,
                             If {
@@ -583,7 +596,7 @@ pub(super) fn replacement_functions(
                             // check len
                             LocalGet { local_index: LEN },
                             I64Const {
-                                value: u32::MAX as i64,
+                                value: max_heap_address as i64,
                             },
                             I64GtU,
                             If {
@@ -1076,11 +1089,11 @@ pub(super) fn replacement_functions(
                                 function_index: InjectedImports::InternalTrap as u32,
                             },
                             End,
-                            // check if these i64 hold valid i32 heap addresses
+                            // check if these i64 hold valid heap addresses
                             // check src
                             LocalGet { local_index: SRC },
                             I64Const {
-                                value: u32::MAX as i64,
+                                value: max_heap_address as i64,
                             },
                             I64GtU,
                             If {
@@ -1096,7 +1109,7 @@ pub(super) fn replacement_functions(
                             // check len
                             LocalGet { local_index: LEN },
                             I64Const {
-                                value: u32::MAX as i64,
+                                value: max_heap_address as i64,
                             },
                             I64GtU,
                             If {


### PR DESCRIPTION
In this PR we set the scene for larger Wasm heaps when in 64 bit mode. The changes are as follows:
1. Adding testing infrastructure for heaps beyond 4 GB without modifying a constant that needs code recompiling. This allows for easier overall testing.
2. Handling `stable_read/write` with heap addresses beyond 4 GB when in Wasm64 mode. This allows Motoko to test easier.