### PR TITLE
fix(IDX): don't pull systest images on Darwin

### DIFF
--- a/rs/rosetta-api/BUILD.bazel
+++ b/rs/rosetta-api/BUILD.bazel
@@ -205,6 +205,9 @@ container_image(
     name = "rosetta_image_base",
     base = "@rust_base//image",
     tags = ["manual"],
+    target_compatible_with = [
+        "@platforms//os:linux",
+    ],
     tars = [
         ":passwd_tar",
         ":data_tar",
@@ -225,6 +228,9 @@ container_image(
     ],
     ports = ["8080"],
     tags = ["manual"],
+    target_compatible_with = [
+        "@platforms//os:linux",
+    ],
     user = "rosetta",
     workdir = "/home/rosetta",
 )

--- a/rs/rosetta-api/icrc1/rosetta/BUILD.bazel
+++ b/rs/rosetta-api/icrc1/rosetta/BUILD.bazel
@@ -247,6 +247,9 @@ container_image(
     name = "ic_icrc_rosetta_image_base",
     base = "@rust_base//image",
     tags = ["manual"],
+    target_compatible_with = [
+        "@platforms//os:linux",
+    ],
     tars = [
         ":passwd_tar",
         ":data_tar",
@@ -267,6 +270,9 @@ container_image(
     ],
     ports = ["8080"],
     tags = ["manual"],
+    target_compatible_with = [
+        "@platforms//os:linux",
+    ],
     user = "ic_icrc_rosetta",
     workdir = "/home/ic_icrc_rosetta",
 )

--- a/rs/tests/BUILD.bazel
+++ b/rs/tests/BUILD.bazel
@@ -140,6 +140,9 @@ copy_file(
     name = "static-file-server_image",
     src = "@static-file-server//image",
     out = "static-file-server.tar",
+    target_compatible_with = [
+        "@platforms//os:linux",
+    ],
 )
 
 exports_files([

--- a/rs/tests/httpbin-rs/BUILD.bazel
+++ b/rs/tests/httpbin-rs/BUILD.bazel
@@ -67,6 +67,9 @@ container_image(
     name = "httpbin_image_base",
     base = "@ubuntu_test_runtime//image",
     tags = ["manual"],
+    target_compatible_with = [
+        "@platforms//os:linux",
+    ],
     tars = [
         ":passwd_tar",
     ],
@@ -85,6 +88,9 @@ container_image(
         ":httpbin",
     ],
     tags = ["manual"],
+    target_compatible_with = [
+        "@platforms//os:linux",
+    ],
     user = "httpbin",
     workdir = "/home/httpbin",
 )

--- a/rs/tests/networking/canister_http/BUILD.bazel
+++ b/rs/tests/networking/canister_http/BUILD.bazel
@@ -47,4 +47,7 @@ copy_file(
     name = "minica_image",
     src = "@minica//image",
     out = "minica.tar",
+    target_compatible_with = [
+        "@platforms//os:linux",
+    ],
 )


### PR DESCRIPTION
This ensures the system test images are not pulled on darwin, even if `//rs/tests/...` is built.

Similar to #772. See also #772 which will add tests ensuring images don't get pulled on Darwin in the future.