### PR TITLE
fix: RUN-874: Fix the return type of some System APIs

### DIFF
--- a/rs/embedders/src/wasmtime_embedder/system_api.rs
+++ b/rs/embedders/src/wasmtime_embedder/system_api.rs
@@ -762,10 +762,7 @@ pub(crate) fn syscalls<
         .func_wrap("ic0", "stable_size", {
             move |mut caller: Caller<'_, StoreData>| {
                 charge_for_cpu(&mut caller, overhead::STABLE_SIZE)?;
-                with_system_api(&mut caller, |s| s.ic0_stable_size()).and_then(|s| {
-                    i32::try_from(s)
-                        .map_err(|e| anyhow::Error::msg(format!("ic0_stable_size failed: {}", e)))
-                })
+                with_system_api(&mut caller, |s| s.ic0_stable_size())
             }
         })
         .unwrap();
@@ -817,10 +814,7 @@ pub(crate) fn syscalls<
         .func_wrap("ic0", "stable64_size", {
             move |mut caller: Caller<'_, StoreData>| {
                 charge_for_cpu(&mut caller, overhead::STABLE64_SIZE)?;
-                with_system_api(&mut caller, |s| s.ic0_stable64_size()).and_then(|s| {
-                    i64::try_from(s)
-                        .map_err(|e| anyhow::Error::msg(format!("ic0_stable64_size failed: {}", e)))
-                })
+                with_system_api(&mut caller, |s| s.ic0_stable64_size())
             }
         })
         .unwrap();
@@ -928,11 +922,7 @@ pub(crate) fn syscalls<
         .func_wrap("ic0", "canister_cycle_balance", {
             move |mut caller: Caller<'_, StoreData>| {
                 charge_for_cpu(&mut caller, overhead::CANISTER_CYCLE_BALANCE)?;
-                with_system_api(&mut caller, |s| s.ic0_canister_cycle_balance()).and_then(|s| {
-                    i64::try_from(s).map_err(|e| {
-                        anyhow::Error::msg(format!("ic0_canister_cycle_balance failed: {}", e))
-                    })
-                })
+                with_system_api(&mut caller, |s| s.ic0_canister_cycle_balance())
             }
         })
         .unwrap();
@@ -958,11 +948,7 @@ pub(crate) fn syscalls<
         .func_wrap("ic0", "msg_cycles_available", {
             move |mut caller: Caller<'_, StoreData>| {
                 charge_for_cpu(&mut caller, overhead::MSG_CYCLES_AVAILABLE)?;
-                with_system_api(&mut caller, |s| s.ic0_msg_cycles_available()).and_then(|s| {
-                    i64::try_from(s).map_err(|e| {
-                        anyhow::Error::msg(format!("ic0_msg_cycles_available failed: {}", e))
-                    })
-                })
+                with_system_api(&mut caller, |s| s.ic0_msg_cycles_available())
             }
         })
         .unwrap();
@@ -988,11 +974,7 @@ pub(crate) fn syscalls<
         .func_wrap("ic0", "msg_cycles_refunded", {
             move |mut caller: Caller<'_, StoreData>| {
                 charge_for_cpu(&mut caller, overhead::MSG_CYCLES_REFUNDED)?;
-                with_system_api(&mut caller, |s| s.ic0_msg_cycles_refunded()).and_then(|s| {
-                    i64::try_from(s).map_err(|e| {
-                        anyhow::Error::msg(format!("ic0_msg_cycles_refunded failed: {}", e))
-                    })
-                })
+                with_system_api(&mut caller, |s| s.ic0_msg_cycles_refunded())
             }
         })
         .unwrap();
@@ -1205,10 +1187,7 @@ pub(crate) fn syscalls<
     linker
         .func_wrap("ic0", "mint_cycles", {
             move |mut caller: Caller<'_, StoreData>, amount: u64| {
-                with_system_api(&mut caller, |s| s.ic0_mint_cycles(amount)).and_then(|s| {
-                    i64::try_from(s)
-                        .map_err(|e| anyhow::Error::msg(format!("ic0_mint_cycles failed: {}", e)))
-                })
+                with_system_api(&mut caller, |s| s.ic0_mint_cycles(amount))
             }
         })
         .unwrap();


### PR DESCRIPTION
Currently some System APIs smaller range of result than specified:
- ic0_canister_cycle_balance (returns i64 instead of u64)
- ic0_msg_cycles_available (returns i64 instead of u64)
- ic0_msg_cycles_refunded (returns i64 instead of u64)
- ic0_mint_cycles (returns i64 instead of u64)
- stable64_size (returns i64 instead of u64)
- stable_size (returns signed i32 instead of unsigned u32)

If the result doesn't fit into the narrow range, then the System APIs trap.
This PR fixes it and changes the System API return the correct range.

Regression tests are added for all System APIs except for `stable[64]_size()`
that can never return values that don't fit in `i32` (because the result is in Wasm pages).