### PR TITLE
feat(ic-admin): Support sending update_canister_settings proposals through ic-admin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5169,6 +5169,8 @@ dependencies = [
  "registry-canister",
  "serde",
  "serde_json",
+ "strum 0.26.2",
+ "strum_macros 0.26.2",
  "tempfile",
  "tokio",
  "url",

--- a/rs/registry/admin/BUILD.bazel
+++ b/rs/registry/admin/BUILD.bazel
@@ -53,6 +53,7 @@ BASE_DEPENDENCIES = [
     "@crate_index//:prost",
     "@crate_index//:serde",
     "@crate_index//:serde_json",
+    "@crate_index//:strum",
     "@crate_index//:tempfile",
     "@crate_index//:tokio",
     "@crate_index//:url",
@@ -83,6 +84,7 @@ MACRO_DEPENDENCIES = [
     # Keep sorted.
     "//rs/registry/admin-derive",
     "@crate_index//:async-trait",
+    "@crate_index//:strum_macros",
 ]
 
 DEV_DEPENDENCIES = [

--- a/rs/registry/admin/Cargo.toml
+++ b/rs/registry/admin/Cargo.toml
@@ -61,6 +61,8 @@ prost = { workspace = true }
 registry-canister = { path = "../canister" }
 serde = { workspace = true }
 serde_json = { workspace = true }
+strum = { workspace = true }
+strum_macros = { workspace = true }
 tokio = { workspace = true }
 candid = { workspace = true }
 tempfile = { workspace = true }

--- a/rs/registry/admin/src/main.rs
+++ b/rs/registry/admin/src/main.rs
@@ -1261,7 +1261,7 @@ impl ProposalPayload<SubnetRentalRequest> for ProposeToRentSubnetCmd {
 }
 
 /// Sub-command to submit a proposal to update the settings of a canister. When neigther
-/// `--controllers` nor `--no-controllers` is provided, the controllers will not be updated.
+/// `--controllers` nor `--remove-all-controllers` is provided, the controllers will not be updated.
 #[derive_common_proposal_fields]
 #[derive(ProposalMetadata, Parser)]
 struct ProposeToUpdateCanisterSettingsCmd {
@@ -1272,9 +1272,9 @@ struct ProposeToUpdateCanisterSettingsCmd {
     /// If set, it will update the canister's controllers to this value.
     #[clap(long, multiple_values(true), group = "update_controllers")]
     controllers: Option<Vec<PrincipalId>>,
-    /// If set, it will update the canister's controllers to an empty list.
+    /// If set, it will remove all controllers of the canister.
     #[clap(long, group = "update_controllers")]
-    no_controllers: bool,
+    remove_all_controllers: bool,
 
     #[clap(long)]
     /// If set, it will update the canister's compute allocation to this value.
@@ -1307,7 +1307,7 @@ impl ProposalAction for ProposeToUpdateCanisterSettingsCmd {
     async fn action(&self) -> Action {
         let canister_id = Some(self.canister_id.get());
 
-        let controllers = if self.no_controllers {
+        let controllers = if self.remove_all_controllers {
             Some(Controllers {
                 controllers: vec![],
             })

--- a/rs/registry/admin/src/main.rs
+++ b/rs/registry/admin/src/main.rs
@@ -57,9 +57,12 @@ use ic_nns_governance::{
         manage_neuron::Command,
         proposal::Action,
         stop_or_start_canister::CanisterAction as GovernanceCanisterAction,
+        update_canister_settings::{
+            CanisterSettings, Controllers, LogVisibility as GovernanceLogVisibility,
+        },
         AddOrRemoveNodeProvider, CreateServiceNervousSystem, GovernanceError, InstallCode,
         ManageNeuron, NnsFunction, NodeProvider, Proposal, RewardNodeProviders,
-        StopOrStartCanister,
+        StopOrStartCanister, UpdateCanisterSettings,
     },
     proposals::proposal_submission::{
         create_external_update_proposal_candid, create_make_proposal_payload,
@@ -165,8 +168,9 @@ use std::{
     time::SystemTime,
 };
 use types::{
-    NodeDetails, ProposalAction, ProposalMetadata, ProposalPayload, ProvisionalWhitelistRecord,
-    Registry, RegistryRecord, RegistryValue, SubnetDescriptor, SubnetRecord,
+    LogVisibility, NodeDetails, ProposalAction, ProposalMetadata, ProposalPayload,
+    ProvisionalWhitelistRecord, Registry, RegistryRecord, RegistryValue, SubnetDescriptor,
+    SubnetRecord,
 };
 use update_subnet::ProposeToUpdateSubnetCmd;
 use url::Url;
@@ -450,6 +454,8 @@ enum SubCommand {
     GetApiBoundaryNodes,
     /// Submits a proposal to express the interest in renting a subnet.
     ProposeToRentSubnet(ProposeToRentSubnetCmd),
+    /// Propose to update the settings of a canister.
+    ProposeToUpdateCanisterSettings(ProposeToUpdateCanisterSettingsCmd),
 }
 
 /// Indicates whether a value should be added or removed.
@@ -1251,6 +1257,88 @@ impl ProposalPayload<SubnetRentalRequest> for ProposeToRentSubnetCmd {
             user: self.user,
             rental_condition_id: self.rental_condition_id,
         }
+    }
+}
+
+/// Sub-command to submit a proposal to update the settings of a canister. When neigther
+/// `--controllers` nor `--no-controllers` is provided, the controllers will not be updated.
+#[derive_common_proposal_fields]
+#[derive(ProposalMetadata, Parser)]
+struct ProposeToUpdateCanisterSettingsCmd {
+    #[clap(long, required = true)]
+    /// The ID of the target canister.
+    canister_id: CanisterId,
+
+    /// If set, it will update the canister's controllers to this value.
+    #[clap(long, multiple_values(true), group = "update_controllers")]
+    controllers: Option<Vec<PrincipalId>>,
+    /// If set, it will update the canister's controllers to an empty list.
+    #[clap(long, group = "update_controllers")]
+    no_controllers: bool,
+
+    #[clap(long)]
+    /// If set, it will update the canister's compute allocation to this value.
+    compute_allocation: Option<u64>,
+    #[clap(long)]
+    /// If set, it will update the canister's memory allocation to this value.
+    memory_allocation: Option<u64>,
+    #[clap(long)]
+    /// If set, it will update the canister's freezing threshold to this value.
+    freezing_threshold: Option<u64>,
+    #[clap(long)]
+    /// If set, it will update the canister's log wasm memory limit to this value.
+    wasm_memory_limit: Option<u64>,
+    #[clap(long)]
+    /// If set, it will update the canister's log visibility to this value.
+    log_visibility: Option<LogVisibility>,
+}
+
+impl ProposalTitle for ProposeToUpdateCanisterSettingsCmd {
+    fn title(&self) -> String {
+        match &self.proposal_title {
+            Some(title) => title.clone(),
+            None => format!("Update canister settings: {}", self.canister_id),
+        }
+    }
+}
+
+#[async_trait]
+impl ProposalAction for ProposeToUpdateCanisterSettingsCmd {
+    async fn action(&self) -> Action {
+        let canister_id = Some(self.canister_id.get());
+
+        let controllers = if self.no_controllers {
+            Some(Controllers {
+                controllers: vec![],
+            })
+        } else {
+            self.controllers
+                .clone()
+                .map(|controllers| Controllers { controllers })
+        };
+        let compute_allocation = self.compute_allocation;
+        let memory_allocation = self.memory_allocation;
+        let freezing_threshold = self.freezing_threshold;
+        let wasm_memory_limit = self.wasm_memory_limit;
+        let log_visibility = match self.log_visibility {
+            Some(LogVisibility::Controllers) => Some(GovernanceLogVisibility::Controllers as i32),
+            Some(LogVisibility::Public) => Some(GovernanceLogVisibility::Public as i32),
+            None => None,
+        };
+
+        let update_settings = UpdateCanisterSettings {
+            canister_id,
+            settings: Some(CanisterSettings {
+                controllers,
+                compute_allocation,
+                memory_allocation,
+                freezing_threshold,
+                wasm_memory_limit,
+                log_visibility,
+            }),
+        };
+
+        Action::UpdateCanisterSettings(update_settings)
     }
 }
 
@@ -3591,6 +3679,7 @@ async fn main() {
                 ProposeToCreateServiceNervousSystem instead"
             ),
             SubCommand::ProposeToRentSubnet(_) => (),
+            SubCommand::ProposeToUpdateCanisterSettings(_) => (),
             _ => panic!(
                 "Specifying a secret key or HSM is only supported for \
                      methods that interact with NNS handlers."
@@ -4860,6 +4949,16 @@ async fn main() {
                 proposer,
             )
             .await;
+        }
+        SubCommand::ProposeToUpdateCanisterSettings(cmd) => {
+            let (proposer, sender) = cmd.proposer_and_sender(sender);
+            let canister_client = make_canister_client(
+                reachable_nns_urls,
+                opts.verify_nns_responses,
+                opts.nns_public_key_pem_file,
+                sender,
+            );
+            propose_action_from_command(cmd, canister_client, proposer).await;
         }
         // Since we're matching on the `SubCommand` type the second time, this match doesn't have
         // to be exhaustive, e.g., we've already verified that the subcommand is not obsolete.

--- a/rs/registry/admin/src/types.rs
+++ b/rs/registry/admin/src/types.rs
@@ -18,12 +18,13 @@ use ic_registry_subnet_features::{ChainKeyConfig, EcdsaConfig, SubnetFeatures};
 use ic_registry_subnet_type::SubnetType;
 use ic_types::{PrincipalId, SubnetId};
 use indexmap::IndexMap;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 use std::{
     convert::{From, TryFrom, TryInto},
     net::{Ipv4Addr, Ipv6Addr},
 };
+use strum_macros::EnumString;
 
 /// All or part of the registry
 #[derive(Default, Serialize)]
@@ -244,6 +245,14 @@ impl SubnetDescriptor {
             }
         }
     }
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize, Eq, EnumString, Copy)]
+pub enum LogVisibility {
+    #[strum(serialize = "controllers")]
+    Controllers,
+    #[strum(serialize = "public")]
+    Public,
 }
 
 /// Trait to extract the payload for each proposal type.


### PR DESCRIPTION
# Why

The `update_canister_settings` proposal type is added to NNS Governance (currently, for testing), and we should make it possible for someone to propose using ic-admin.

# What

Define a subcommand to propose to update canister settings. For updating controllers, clap doesn't seem to support specifying a `Some(vec![])`, therefore another argument `--remove-all-controllers` is added for the case where `controllers` needs to be updated to be an empty list.

# Tests

Tested end-to-end locally with different arguments