### PR TITLE
feat(ckerc20): Use EVM-RPC canister to call `eth_getTransactionCount`

### DIFF
--- a/rs/ethereum/cketh/minter/src/eth_rpc_client/tests.rs
+++ b/rs/ethereum/cketh/minter/src/eth_rpc_client/tests.rs
@@ -665,10 +665,10 @@ mod evm_rpc_conversion {
     use crate::eth_rpc_client::responses::TransactionReceipt;
     use crate::eth_rpc_client::tests::{ANKR, LLAMA_NODES, PUBLIC_NODE};
     use crate::eth_rpc_client::{
-        providers::RpcNodeProvider, Block, FeeHistory, HttpOutcallError, LogEntry, MultiCallError,
-        MultiCallResults, Reduce, SingleCallError,
+        providers::RpcNodeProvider, Block, Equality, FeeHistory, HttpOutcallError, LogEntry,
+        MinByKey, MultiCallError, MultiCallResults, Reduce, ReduceWithStrategy, SingleCallError,
     };
-    use crate::numeric::{BlockNumber, Wei};
+    use crate::numeric::{BlockNumber, TransactionCount, Wei};
     use crate::test_fixtures::arb::{
         arb_block, arb_evm_rpc_error, arb_fee_history, arb_gas_used_ratio, arb_log_entry,
         arb_nat_256, arb_transaction_receipt,
@@ -679,7 +679,8 @@ mod evm_rpc_conversion {
         Block as EvmBlock, EthMainnetService as EvmEthMainnetService, FeeHistory as EvmFeeHistory,
         HttpOutcallError as EvmHttpOutcallError, LogEntry as EvmLogEntry,
         MultiRpcResult as EvmMultiRpcResult, RpcApi as EvmRpcApi, RpcError as EvmRpcError,
-        RpcService as EvmRpcService, TransactionReceipt as EvmTransactionReceipt,
+        RpcResult as EvmRpcResult, RpcService as EvmRpcService, RpcService,
+        TransactionReceipt as EvmTransactionReceipt,
     };
     use num_bigint::BigUint;
     use proptest::collection::vec;
@@ -901,6 +902,46 @@ mod evm_rpc_conversion {
         }
     }
 
+    proptest! {
+        #[test]
+        fn should_have_consistent_transaction_count_between_minter_and_evm_rpc
+        (
+            first_tx_count in arb_evm_rpc_transaction_count(),
+            second_tx_count in arb_evm_rpc_transaction_count(),
+            third_tx_count in arb_evm_rpc_transaction_count(),
+        ) {
+            let (ankr_evm_rpc_provider, public_node_evm_rpc_provider, llama_nodes_evm_rpc_provider) =
+                evm_rpc_providers();
+            let evm_results = match (&first_tx_count, &second_tx_count, &third_tx_count) {
+                (Ok(count_1), Ok(count_2), Ok(count_3)) if count_1 == count_2 && count_2 == count_3 => {
+                    EvmMultiRpcResult::Consistent(Ok(count_1.clone()))
+                }
+                _ => EvmMultiRpcResult::Inconsistent(vec![
+                    (ankr_evm_rpc_provider, first_tx_count.clone()),
+                    (public_node_evm_rpc_provider, second_tx_count.clone()),
+                    (llama_nodes_evm_rpc_provider, third_tx_count.clone()),
+                ]),
+            };
+            let minter_results: MultiCallResults<TransactionCount> = MultiCallResults::from_iter(vec![
+                (ANKR, first_tx_count.map_err(SingleCallError::from)),
+                (PUBLIC_NODE, second_tx_count.map_err(SingleCallError::from)),
+                (LLAMA_NODES, third_tx_count.map_err(SingleCallError::from)),
+            ])
+            .map(&TransactionCount::try_from, &|e| {
+                panic!("BUG: selected Nat should fit in a U256: {:?}", e)
+            });
+
+            prop_assert_eq_ignoring_provider(
+                ReduceWithStrategy::<Equality>::reduce(evm_results.clone()),
+                ReduceWithStrategy::<Equality>::reduce(minter_results.clone()),
+            )?;
+            prop_assert_eq_ignoring_provider(
+                ReduceWithStrategy::<MinByKey>::reduce(evm_results),
+                ReduceWithStrategy::<MinByKey>::reduce(minter_results),
+            )?;
+        }
+    }
+
     fn test_consistency_between_minter_and_evm_rpc<R, M, E>(
         minter_ok: M,
         evm_rpc_ok: E,
@@ -915,18 +956,8 @@ mod evm_rpc_conversion {
         MultiCallResults<M>: Reduce<Item = R>,
         EvmMultiRpcResult<E>: Reduce<Item = R>,
     {
-        let ankr_evm_rpc_provider = EvmRpcService::Custom(EvmRpcApi {
-            url: "ankr".to_string(),
-            headers: None,
-        });
-        let public_node_evm_rpc_provider = EvmRpcService::Custom(EvmRpcApi {
-            url: "public_node".to_string(),
-            headers: None,
-        });
-        let llama_nodes_evm_rpc_provider = EvmRpcService::Custom(EvmRpcApi {
-            url: "llama".to_string(),
-            headers: None,
-        });
+        let (ankr_evm_rpc_provider, public_node_evm_rpc_provider, llama_nodes_evm_rpc_provider) =
+            evm_rpc_providers();
 
         // 0 error
         let evm_result = EvmMultiRpcResult::Consistent(Ok(evm_rpc_ok.clone()));
@@ -1012,6 +1043,26 @@ mod evm_rpc_conversion {
         prop_assert_eq_ignoring_provider(evm_result.reduce(), minter_result.reduce())?;
 
         Ok(())
+    }
+
+    fn evm_rpc_providers() -> (RpcService, RpcService, RpcService) {
+        let ankr_evm_rpc_provider = EvmRpcService::Custom(EvmRpcApi {
+            url: "ankr".to_string(),
+            headers: None,
+        });
+        let public_node_evm_rpc_provider = EvmRpcService::Custom(EvmRpcApi {
+            url: "public_node".to_string(),
+            headers: None,
+        });
+        let llama_nodes_evm_rpc_provider = EvmRpcService::Custom(EvmRpcApi {
+            url: "llama".to_string(),
+            headers: None,
+        });
+        (
+            ankr_evm_rpc_provider,
+            public_node_evm_rpc_provider,
+            llama_nodes_evm_rpc_provider,
+        )
     }
 
     fn prop_assert_eq_ignoring_provider<
@@ -1315,5 +1366,9 @@ mod evm_rpc_conversion {
                 )
                 .boxed(),
         }
+    }
+
+    fn arb_evm_rpc_transaction_count() -> impl Strategy<Value = EvmRpcResult<Nat>> {
+        proptest::result::maybe_ok(arb_nat_256(), arb_evm_rpc_error())
     }
 }

--- a/rs/ethereum/cketh/minter/src/withdraw.rs
+++ b/rs/ethereum/cketh/minter/src/withdraw.rs
@@ -1,6 +1,5 @@
 use crate::eth_rpc::JsonRpcResult;
-use crate::eth_rpc::{BlockSpec, BlockTag, SendRawTransactionResult};
-use crate::eth_rpc_client::requests::GetTransactionCountParams;
+use crate::eth_rpc::SendRawTransactionResult;
 use crate::eth_rpc_client::responses::TransactionReceipt;
 use crate::eth_rpc_client::EthRpcClient;
 use crate::eth_rpc_client::MultiCallError;
@@ -179,12 +178,8 @@ pub async fn process_retrieve_eth_requests() {
 
 async fn latest_transaction_count() -> Option<TransactionCount> {
     match read_state(EthRpcClient::from_state)
-        .eth_get_transaction_count(GetTransactionCountParams {
-            address: crate::state::minter_address().await,
-            block: BlockSpec::Tag(BlockTag::Latest),
-        })
+        .eth_get_latest_transaction_count(crate::state::minter_address().await)
         .await
-        .reduce_with_min_by_key(|transaction_count| *transaction_count)
     {
         Ok(transaction_count) => Some(transaction_count),
         Err(e) => {
@@ -444,10 +439,6 @@ async fn finalize_transactions_batch() {
 async fn finalized_transaction_count() -> Result<TransactionCount, MultiCallError<TransactionCount>>
 {
     read_state(EthRpcClient::from_state)
-        .eth_get_transaction_count(GetTransactionCountParams {
-            address: crate::state::minter_address().await,
-            block: BlockSpec::Tag(BlockTag::Finalized),
-        })
+        .eth_get_finalized_transaction_count(crate::state::minter_address().await)
         .await
-        .reduce_with_equality()
 }

--- a/rs/ethereum/cketh/test_utils/src/flow.rs
+++ b/rs/ethereum/cketh/test_utils/src/flow.rs
@@ -648,6 +648,7 @@ impl<T: AsRef<CkEthSetup>, Req: HasWithdrawalId> LatestTransactionCountProcessWi
         (override_mock)(default_eth_get_latest_transaction_count)
             .build()
             .expect_rpc_calls(&self.setup);
+        self.setup.as_ref().env.tick();
         self
     }
 

--- a/rs/ethereum/evm-rpc-client/src/lib.rs
+++ b/rs/ethereum/evm-rpc-client/src/lib.rs
@@ -4,12 +4,12 @@ mod tests;
 pub mod types;
 
 use crate::types::candid::{
-    Block, BlockTag, FeeHistory, FeeHistoryArgs, GetLogsArgs, LogEntry, MultiRpcResult,
-    ProviderError, RpcConfig, RpcError, RpcServices, TransactionReceipt,
+    Block, BlockTag, FeeHistory, FeeHistoryArgs, GetLogsArgs, GetTransactionCountArgs, LogEntry,
+    MultiRpcResult, ProviderError, RpcConfig, RpcError, RpcServices, TransactionReceipt,
 };
 use async_trait::async_trait;
 use candid::utils::ArgumentEncoder;
-use candid::{CandidType, Principal};
+use candid::{CandidType, Nat, Principal};
 use ic_canister_log::{log, Sink};
 use ic_cdk::api::call::RejectionCode;
 use serde::de::DeserializeOwned;
@@ -46,6 +46,7 @@ pub struct OverrideRpcConfig {
     pub eth_get_logs: Option<RpcConfig>,
     pub eth_fee_history: Option<RpcConfig>,
     pub eth_get_transaction_receipt: Option<RpcConfig>,
+    pub eth_get_transaction_count: Option<RpcConfig>,
 }
 
 impl<L: Sink> EvmRpcClient<IcRuntime, L> {
@@ -97,6 +98,18 @@ impl<R: Runtime, L: Sink> EvmRpcClient<R, L> {
             "eth_getTransactionReceipt",
             self.override_rpc_config.eth_get_transaction_receipt.clone(),
             transaction_hash,
+        )
+        .await
+    }
+
+    pub async fn eth_get_transaction_count(
+        &self,
+        args: GetTransactionCountArgs,
+    ) -> MultiRpcResult<Nat> {
+        self.call_internal(
+            "eth_getTransactionCount",
+            self.override_rpc_config.eth_get_transaction_count.clone(),
+            args,
         )
         .await
     }

--- a/rs/ethereum/evm-rpc-client/src/types.rs
+++ b/rs/ethereum/evm-rpc-client/src/types.rs
@@ -167,6 +167,14 @@ pub mod candid {
         pub r#type: String,
     }
 
+    #[derive(Clone, Debug, Eq, PartialEq, CandidType, Deserialize)]
+    pub struct GetTransactionCountArgs {
+        /// The address for which the transaction count is requested.
+        pub address: String,
+        /// Integer block number, or "latest" for the last mined block or "pending", "earliest" for not yet mined transactions.
+        pub block: BlockTag,
+    }
+
     pub type RpcResult<T> = Result<T, RpcError>;
 
     #[derive(Clone, Debug, Eq, PartialEq, CandidType, Deserialize)]


### PR DESCRIPTION
([XC-164](https://dfinity.atlassian.net/browse/XC-164)): Continue the migration initiated in [MR-19972](https://gitlab.com/dfinity-lab/public/ic/-/merge_requests/19972) towards using the EVM-RPC canister to interact with the Ethereum JSON-RPC providers. This PR focuses specifically on the `eth_getTransactionCount` endpoint.

This endpoint needs to be handled slightly differently than the other ones because the same type `TransactionCount` is handled differently depending on the block height for which it was queried:
1. `Finalized`. In that case, equality between multiple `TransactionCount` for the same Ethereum address is expected.
2. `Latest`. In that case, equality between multiple `TransactionCount` for the same Ethereum address cannot be expected and so the minimum is taken.

[XC-164]: https://dfinity.atlassian.net/browse/XC-164?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ