### PR TITLE
chore(sns): Obsolete `SwapInit.neurons_fund_participants`

### DIFF
--- a/rs/nns/governance/proto/ic_nns_governance/pb/v1/governance.proto
+++ b/rs/nns/governance/proto/ic_nns_governance/pb/v1/governance.proto
@@ -2700,8 +2700,8 @@ message SettleNeuronsFundParticipationRequest {
 // the Neurons' Fund. However, this distribution also needs to be made available to the SNS Swap
 // that will use this information to create SNS neurons of an appropriate size for each
 // Neurons' Fund (as well as direct) participant. That is why in the `committed` case,
-// the NNS Governance should populate the `neurons_fund_participants` field, while in the `aborted`
-// case it should be empty.
+// the NNS Governance provides `neurons_fund_neuron_portions`, while in the `aborted`
+// case it does not.
 //
 // TODO(NNS1-1589): Until the Jira ticket gets solved, changes here need to be
 // manually propagated to (sns) swap.proto.

--- a/rs/nns/governance/src/gen/ic_nns_governance.pb.v1.rs
+++ b/rs/nns/governance/src/gen/ic_nns_governance.pb.v1.rs
@@ -3364,8 +3364,8 @@ pub mod settle_neurons_fund_participation_request {
 /// the Neurons' Fund. However, this distribution also needs to be made available to the SNS Swap
 /// that will use this information to create SNS neurons of an appropriate size for each
 /// Neurons' Fund (as well as direct) participant. That is why in the `committed` case,
-/// the NNS Governance should populate the `neurons_fund_participants` field, while in the `aborted`
-/// case it should be empty.
+/// the NNS Governance provides `neurons_fund_neuron_portions`, while in the `aborted`
+/// case it does not.
 ///
 /// TODO(NNS1-1589): Until the Jira ticket gets solved, changes here need to be
 /// manually propagated to (sns) swap.proto.

--- a/rs/nns/governance/tests/fake.rs
+++ b/rs/nns/governance/tests/fake.rs
@@ -392,7 +392,6 @@ impl Environment for FakeDriver {
                         sns_token_e8s: None,    // TODO[NNS1-2339]
                         neuron_basket_construction_parameters: None, // TODO[NNS1-2339]
                         nns_proposal_id: None,  // TODO[NNS1-2339]
-                        neurons_fund_participants: None, // TODO[NNS1-2339]
                         should_auto_finalize: Some(true),
                         neurons_fund_participation_constraints: None,
                         neurons_fund_participation: None,

--- a/rs/nns/governance/tests/governance.rs
+++ b/rs/nns/governance/tests/governance.rs
@@ -11317,7 +11317,6 @@ lazy_static! {
         sns_token_e8s: None, // TODO[NNS1-2339]
         neuron_basket_construction_parameters: None, // TODO[NNS1-2339]
         nns_proposal_id: None, // TODO[NNS1-2339]
-        neurons_fund_participants: None, // TODO[NNS1-2339]
         should_auto_finalize: Some(true),
         neurons_fund_participation_constraints: None,
         neurons_fund_participation: None,

--- a/rs/sns/init/src/lib.rs
+++ b/rs/sns/init/src/lib.rs
@@ -720,8 +720,6 @@ impl SnsInitPayload {
                 .neurons_fund_participation_constraints
                 .clone(),
             neurons_fund_participation: self.neurons_fund_participation,
-            // Deprecated field
-            neurons_fund_participants: None,
         })
     }
 

--- a/rs/sns/integration_tests/src/payment_flow.rs
+++ b/rs/sns/integration_tests/src/payment_flow.rs
@@ -186,7 +186,6 @@ impl PaymentProtocolTestSetup {
             should_auto_finalize: Some(true),
             max_icp_e8s: None,
             min_icp_e8s: None,
-            neurons_fund_participants: None,
             neurons_fund_participation_constraints: None,
             neurons_fund_participation: None,
         }

--- a/rs/sns/integration_tests/src/swap.rs
+++ b/rs/sns/integration_tests/src/swap.rs
@@ -37,7 +37,6 @@ fn test_upgrade() {
             dissolve_delay_interval_seconds: 10_001,
         }),
         nns_proposal_id: Some(10),
-        neurons_fund_participants: None,
         should_auto_finalize: Some(true),
         neurons_fund_participation_constraints: None,
         neurons_fund_participation: Some(false),

--- a/rs/sns/swap/canister/swap.did
+++ b/rs/sns/swap/canister/swap.did
@@ -121,7 +121,6 @@ type Init = record {
   icp_ledger_canister_id : text;
   sns_ledger_canister_id : text;
   neurons_fund_participation_constraints : opt NeuronsFundParticipationConstraints;
-  neurons_fund_participants : opt NeuronsFundParticipants;
   should_auto_finalize : opt bool;
   max_participant_icp_e8s : opt nat64;
   sns_governance_canister_id : text;
@@ -149,6 +148,9 @@ type ListCommunityFundParticipantsRequest = record {
   offset : opt nat64;
   limit : opt nat32;
 };
+type ListCommunityFundParticipantsResponse = record {
+  cf_participants : vec CfParticipant;
+};
 type ListDirectParticipantsRequest = record {
   offset : opt nat32;
   limit : opt nat32;
@@ -171,7 +173,6 @@ type NeuronBasketConstructionParameters = record {
   count : nat64;
 };
 type NeuronId = record { id : blob };
-type NeuronsFundParticipants = record { cf_participants : vec CfParticipant };
 type NeuronsFundParticipationConstraints = record {
   coefficient_intervals : vec LinearScalingCoefficient;
   max_neurons_fund_participation_icp_e8s : opt nat64;
@@ -296,7 +297,7 @@ service : (Init) -> {
   get_sale_parameters : (record {}) -> (GetSaleParametersResponse) query;
   get_state : (record {}) -> (GetStateResponse) query;
   list_community_fund_participants : (ListCommunityFundParticipantsRequest) -> (
-      NeuronsFundParticipants,
+      ListCommunityFundParticipantsResponse,
     ) query;
   list_direct_participants : (ListDirectParticipantsRequest) -> (
       ListDirectParticipantsResponse,

--- a/rs/sns/swap/proto/ic_sns_swap/pb/v1/swap.proto
+++ b/rs/sns/swap/proto/ic_sns_swap/pb/v1/swap.proto
@@ -410,7 +410,11 @@ message Init {
   optional uint64 nns_proposal_id = 26;
 
   // The Neurons' Fund participants of this SNS decentralization swap.
-  optional NeuronsFundParticipants neurons_fund_participants = 27;
+  //
+  // This field is obsolete, as Neurons' Fund participants are now determined at the end of
+  // a successful swap and cannot be specified during SNS initialization.
+  reserved 27;
+  reserved "neurons_fund_participants";
 
   // Controls whether swap finalization should be attempted automatically in the
   // canister heartbeat. If set to false, `finalize_swap` must be called
@@ -497,11 +501,6 @@ message LinearScalingCoefficient {
   optional uint64 slope_denominator = 4;
   // Intercept of the linear transformation (in ICP e8s).
   optional uint64 intercept_icp_e8s = 5;
-}
-
-// Represents multiple Neurons' Fund participants.
-message NeuronsFundParticipants {
-  repeated CfParticipant cf_participants = 1;
 }
 
 // Represents one NNS neuron from the Neurons' Fund participating in this swap.
@@ -1174,8 +1173,8 @@ message SettleNeuronsFundParticipationRequest {
 // the Neurons' Fund. However, this distribution also needs to be made available to the SNS Swap
 // that will use this information to create SNS neurons of an appropriate size for each
 // Neurons' Fund (as well as direct) participant. That is why in the `committed` case,
-// the NNS Governance should populate the `neurons_fund_participants` field, while in the `aborted`
-// case it should be empty.
+// the NNS Governance provides `neurons_fund_neuron_portions`, while in the `aborted`
+// case it does not.
 //
 // TODO(NNS1-1589): Until the Jira ticket gets solved, changes here need to be
 // manually propagated to (sns) swap.proto.

--- a/rs/sns/swap/src/gen/ic_sns_swap.pb.v1.rs
+++ b/rs/sns/swap/src/gen/ic_sns_swap.pb.v1.rs
@@ -365,9 +365,6 @@ pub struct Init {
     /// swap.
     #[prost(uint64, optional, tag = "26")]
     pub nns_proposal_id: ::core::option::Option<u64>,
-    /// The Neurons' Fund participants of this SNS decentralization swap.
-    #[prost(message, optional, tag = "27")]
-    pub neurons_fund_participants: ::core::option::Option<NeuronsFundParticipants>,
     /// Controls whether swap finalization should be attempted automatically in the
     /// canister heartbeat. If set to false, `finalize_swap` must be called
     /// manually. Note: it is safe to call `finalize_swap` multiple times
@@ -469,14 +466,6 @@ pub struct LinearScalingCoefficient {
     /// Intercept of the linear transformation (in ICP e8s).
     #[prost(uint64, optional, tag = "5")]
     pub intercept_icp_e8s: ::core::option::Option<u64>,
-}
-/// Represents multiple Neurons' Fund participants.
-#[derive(candid::CandidType, candid::Deserialize, serde::Serialize, comparable::Comparable)]
-#[allow(clippy::derive_partial_eq_without_eq)]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct NeuronsFundParticipants {
-    #[prost(message, repeated, tag = "1")]
-    pub cf_participants: ::prost::alloc::vec::Vec<CfParticipant>,
 }
 /// Represents one NNS neuron from the Neurons' Fund participating in this swap.
 #[derive(candid::CandidType, candid::Deserialize, serde::Serialize, comparable::Comparable, Eq)]
@@ -1493,8 +1482,8 @@ pub mod settle_neurons_fund_participation_request {
 /// the Neurons' Fund. However, this distribution also needs to be made available to the SNS Swap
 /// that will use this information to create SNS neurons of an appropriate size for each
 /// Neurons' Fund (as well as direct) participant. That is why in the `committed` case,
-/// the NNS Governance should populate the `neurons_fund_participants` field, while in the `aborted`
-/// case it should be empty.
+/// the NNS Governance provides `neurons_fund_neuron_portions`, while in the `aborted`
+/// case it does not.
 ///
 /// TODO(NNS1-1589): Until the Jira ticket gets solved, changes here need to be
 /// manually propagated to (sns) swap.proto.

--- a/rs/sns/swap/src/swap.rs
+++ b/rs/sns/swap/src/swap.rs
@@ -3060,13 +3060,8 @@ impl Swap {
         GetSaleParametersResponse { params }
     }
 
-    /// Extracts a subset of Init fields. Currently, only `neurons_fund_participants` is excluded,
-    /// as that data is provided via a dedicated endpoint `list_community_fund_participants`.
     pub fn get_init(&self, _request: &GetInitRequest) -> GetInitResponse {
-        let init = Init {
-            neurons_fund_participants: None,
-            ..self.init.clone().expect("Swap.init must be defined")
-        };
+        let init = self.init.clone().expect("Swap.init must be defined");
         GetInitResponse { init: Some(init) }
     }
 
@@ -3799,7 +3794,7 @@ mod tests {
     use super::*;
     use crate::pb::v1::{
         new_sale_ticket_response::Ok, CfNeuron, CfParticipant, NeuronBasketConstructionParameters,
-        NeuronsFundParticipants, Params,
+        Params,
     };
     use crate::swap_builder::SwapBuilder;
     use ic_nervous_system_common::{E8, ONE_DAY_SECONDS};
@@ -4052,24 +4047,11 @@ mod tests {
 
     #[test]
     fn test_get_init() {
-        #[allow(deprecated)] // TODO(NNS1-3198): Remove once hotkey_principal is removed
         let swap = Swap {
-            init: Some(Init {
-                neurons_fund_participants: Some(NeuronsFundParticipants {
-                    cf_participants: vec![CfParticipant {
-                        controller: None,
-                        hotkey_principal: "test".to_string(),
-                        cf_neurons: vec![CfNeuron::default()],
-                    }],
-                }),
-                ..Default::default()
-            }),
+            init: Some(Init::default()),
             ..Default::default()
         };
-        let expected_init = Init {
-            neurons_fund_participants: None,
-            ..swap.init.clone().unwrap()
-        };
+        let expected_init = swap.init.clone().unwrap();
         assert_eq!(
             swap.get_init(&GetInitRequest {}),
             GetInitResponse {

--- a/rs/sns/swap/src/swap_builder.rs
+++ b/rs/sns/swap/src/swap_builder.rs
@@ -41,7 +41,6 @@ pub struct SwapBuilder {
     // The following fields are deprecated and thus don't need to be represented here.
     // min_icp_e8s,
     // max_icp_e8s,
-    // neurons_fund_participants,
 }
 
 fn i2canister_id(i: u64) -> CanisterId {
@@ -247,7 +246,6 @@ impl SwapBuilder {
             // The following fields are deprecated.
             min_icp_e8s: None,
             max_icp_e8s: None,
-            neurons_fund_participants: None,
         };
         let swap = Swap::new(init);
         Swap {

--- a/rs/sns/swap/src/types.rs
+++ b/rs/sns/swap/src/types.rs
@@ -251,10 +251,6 @@ impl Init {
             // 19
             obsolete_field_names.push("max_icp_e8s".to_string());
         }
-        if self.neurons_fund_participants.is_some() {
-            // 27
-            obsolete_field_names.push("neurons_fund_participants".to_string());
-        }
         if obsolete_field_names.is_empty() {
             Ok(())
         } else {

--- a/rs/sns/swap/tests/swap.rs
+++ b/rs/sns/swap/tests/swap.rs
@@ -137,7 +137,6 @@ fn init_with_confirmation_text(confirmation_text: Option<String>) -> Init {
         // The following fields are deprecated.
         min_icp_e8s: None,
         max_icp_e8s: None,
-        neurons_fund_participants: None,
     };
     assert_is_ok!(result.validate());
     result

--- a/rs/sns/test_utils/src/itest_helpers.rs
+++ b/rs/sns/test_utils/src/itest_helpers.rs
@@ -265,7 +265,6 @@ impl SnsTestsInitPayloadBuilder {
                 dissolve_delay_interval_seconds: 10_001,
             }),
             nns_proposal_id: Some(10),
-            neurons_fund_participants: None,
             neurons_fund_participation: Some(false),
             neurons_fund_participation_constraints: None,
             ..Default::default()


### PR DESCRIPTION
Since the NF participants cannot be specified upfront anymore, we remove `SwapInit.neurons_fund_participants`.