### PR TITLE
refactor: Use ic_cdk::api::time for ingress message validator crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12559,9 +12559,9 @@ version = "0.9.0"
 dependencies = [
  "assert_matches",
  "base64 0.13.1",
- "dfn_core",
  "hex",
  "ic-canister-client-sender",
+ "ic-cdk 0.13.2",
  "ic-certification-test-utils",
  "ic-constants",
  "ic-crypto-interfaces-sig-verification",

--- a/rs/validator/ingress_message/BUILD.bazel
+++ b/rs/validator/ingress_message/BUILD.bazel
@@ -8,11 +8,11 @@ DEPENDENCIES = [
     "//rs/crypto/interfaces/sig_verification",
     "//rs/crypto/standalone-sig-verifier",
     "//rs/crypto/utils/threshold_sig_der",
-    "//rs/rust_canisters/dfn_core",
     "//rs/types/types",
     "//rs/validator",
     "@crate_index//:base64",
     "@crate_index//:hex",
+    "@crate_index//:ic-cdk",
 ]
 
 DEV_DEPENDENCIES = [

--- a/rs/validator/ingress_message/Cargo.toml
+++ b/rs/validator/ingress_message/Cargo.toml
@@ -8,8 +8,8 @@ documentation.workspace = true
 
 [dependencies]
 base64 = { workspace = true }
-dfn_core = { path = "../../rust_canisters/dfn_core" }
 hex = { workspace = true }
+ic-cdk = { workspace = true }
 ic-crypto-interfaces-sig-verification = { path = "../../crypto/interfaces/sig_verification" }
 ic-crypto-standalone-sig-verifier = { path = "../../crypto/standalone-sig-verifier" }
 ic-crypto-utils-threshold-sig-der = { path = "../../crypto/utils/threshold_sig_der" }


### PR DESCRIPTION
This PR switches the ingress message validator crate from using `dfn_core::now()` (`dfn_core` is deprecated), to use the public Rust CDK instead.

`dfn_core` was written in way that would return some `Time` when compiled to native code which would allow the doc test to run successfully. In contrast, the CDK assumes that it compiles only to `Wasm` targets so we need to add some `cfg` directives to ensure the code can compile in either native or `Wasm` targets.