### PR TITLE
feat(cmc): Initialize `average_icp_xdr_conversion_rate`

### DIFF
--- a/rs/nns/cmc/src/exchange_rate_canister.rs
+++ b/rs/nns/cmc/src/exchange_rate_canister.rs
@@ -499,19 +499,17 @@ fn validate_exchange_rate(exchange_rate: &ExchangeRate) -> Result<(), ValidateEx
 #[cfg(test)]
 mod test {
 
+    use super::*;
+    use crate::environment::Environment;
+    use crate::DEFAULT_ICP_XDR_CONVERSION_RATE_TIMESTAMP_SECONDS;
+    use futures::FutureExt;
+    use ic_xrc_types::ExchangeRateMetadata;
     use std::{
         cell::RefCell,
         collections::VecDeque,
         sync::{Arc, Mutex},
         time::UNIX_EPOCH,
     };
-
-    use super::*;
-
-    use crate::environment::Environment;
-
-    use futures::FutureExt;
-    use ic_xrc_types::ExchangeRateMetadata;
 
     #[derive(Default)]
     pub struct TestExchangeRateCanisterEnvironment {
@@ -952,7 +950,14 @@ mod test {
             state.average_icp_xdr_conversion_rate.clone()
         });
 
-        assert!(average_icp_xdr_conversion_rate.is_none());
+        // Require starting with the expected initial ICP/XDR conversion rate.
+        assert!(matches!(
+            average_icp_xdr_conversion_rate,
+            Some(IcpXdrConversionRate {
+                timestamp_seconds,
+                ..
+            }) if timestamp_seconds == DEFAULT_ICP_XDR_CONVERSION_RATE_TIMESTAMP_SECONDS,
+        ));
 
         let now_timestamp_seconds = (dfn_core::api::now()
             .duration_since(UNIX_EPOCH)
@@ -995,6 +1000,16 @@ mod test {
         let average_icp_xdr_conversion_rate = read_state(&STATE, |state| {
             state.average_icp_xdr_conversion_rate.clone()
         });
+
+        // Ensure the observed ICP/XDR conversion rate is different from the initial one.
+        assert!(matches!(
+            average_icp_xdr_conversion_rate,
+            Some(IcpXdrConversionRate {
+                timestamp_seconds,
+                ..
+            }) if timestamp_seconds != DEFAULT_ICP_XDR_CONVERSION_RATE_TIMESTAMP_SECONDS,
+        ));
+
         assert!(
             matches!(average_icp_xdr_conversion_rate, Some(ref rate) if rate.xdr_permyriad_per_icp == 200_000),
             "rate: {:#?}",

--- a/rs/nns/cmc/src/exchange_rate_canister.rs
+++ b/rs/nns/cmc/src/exchange_rate_canister.rs
@@ -501,7 +501,10 @@ mod test {
 
     use super::*;
     use crate::environment::Environment;
-    use crate::DEFAULT_ICP_XDR_CONVERSION_RATE_TIMESTAMP_SECONDS;
+    use crate::{
+        DEFAULT_ICP_XDR_CONVERSION_RATE_TIMESTAMP_SECONDS,
+        DEFAULT_XDR_PERMYRIAD_PER_ICP_CONVERSION_RATE,
+    };
     use futures::FutureExt;
     use ic_xrc_types::ExchangeRateMetadata;
     use std::{
@@ -951,13 +954,14 @@ mod test {
         });
 
         // Require starting with the expected initial ICP/XDR conversion rate.
-        assert!(matches!(
+        let initial_average_icp_xdr_conversion_rate = Some(IcpXdrConversionRate {
+            timestamp_seconds: DEFAULT_ICP_XDR_CONVERSION_RATE_TIMESTAMP_SECONDS,
+            xdr_permyriad_per_icp: DEFAULT_XDR_PERMYRIAD_PER_ICP_CONVERSION_RATE,
+        });
+        assert_eq!(
             average_icp_xdr_conversion_rate,
-            Some(IcpXdrConversionRate {
-                timestamp_seconds,
-                ..
-            }) if timestamp_seconds == DEFAULT_ICP_XDR_CONVERSION_RATE_TIMESTAMP_SECONDS,
-        ));
+            initial_average_icp_xdr_conversion_rate
+        );
 
         let now_timestamp_seconds = (dfn_core::api::now()
             .duration_since(UNIX_EPOCH)
@@ -1002,13 +1006,10 @@ mod test {
         });
 
         // Ensure the observed ICP/XDR conversion rate is different from the initial one.
-        assert!(matches!(
+        assert_ne!(
             average_icp_xdr_conversion_rate,
-            Some(IcpXdrConversionRate {
-                timestamp_seconds,
-                ..
-            }) if timestamp_seconds != DEFAULT_ICP_XDR_CONVERSION_RATE_TIMESTAMP_SECONDS,
-        ));
+            initial_average_icp_xdr_conversion_rate
+        );
 
         assert!(
             matches!(average_icp_xdr_conversion_rate, Some(ref rate) if rate.xdr_permyriad_per_icp == 200_000),

--- a/rs/nns/cmc/src/lib.rs
+++ b/rs/nns/cmc/src/lib.rs
@@ -27,7 +27,8 @@ pub const MINT_CYCLES_REFUND_FEE: Tokens = Tokens::from_e8s(DEFAULT_TRANSFER_FEE
 /// Cycles penalty charged for sending bad requests that incur a lot of work.
 pub const BAD_REQUEST_CYCLES_PENALTY: u128 = 100_000_000; // TODO(SDK-1248) revisit fair pricing. Currently costs significantly more than an update call
 
-pub const DEFAULT_ICP_XDR_CONVERSION_RATE_TIMESTAMP_SECONDS: u64 = 1620633600; // 10 May 2021 10:00:00 AM CEST
+pub const DEFAULT_ICP_XDR_CONVERSION_RATE_TIMESTAMP_SECONDS: u64 = 1_620_633_600; // 10 May 2021 10:00:00 AM CEST
+pub const DEFAULT_XDR_PERMYRIAD_PER_ICP_CONVERSION_RATE: u64 = 1_000_000; // 1 ICP = 100 XDR
 
 #[derive(Serialize, Deserialize, CandidType, Clone, Debug, PartialEq, Eq)]
 pub enum ExchangeRateCanister {

--- a/rs/nns/cmc/src/main.rs
+++ b/rs/nns/cmc/src/main.rs
@@ -400,6 +400,10 @@ impl Default for State {
     fn default() -> Self {
         let resolution = Duration::from_secs(60);
         let max_age = Duration::from_secs(60 * 60);
+        let initial_icp_xdr_conversion_rate = IcpXdrConversionRate {
+            timestamp_seconds: DEFAULT_ICP_XDR_CONVERSION_RATE_TIMESTAMP_SECONDS,
+            xdr_permyriad_per_icp: 1_000_000, // 100 XDR = 1 ICP
+        };
 
         Self {
             ledger_canister_id: CanisterId::ic_00(),
@@ -409,11 +413,8 @@ impl Default for State {
             minting_account_id: None,
             authorized_subnets: BTreeMap::new(),
             default_subnets: vec![],
-            icp_xdr_conversion_rate: Some(IcpXdrConversionRate {
-                timestamp_seconds: DEFAULT_ICP_XDR_CONVERSION_RATE_TIMESTAMP_SECONDS,
-                xdr_permyriad_per_icp: 1_000_000, // 100 XDR = 1 ICP
-            }),
-            average_icp_xdr_conversion_rate: None,
+            icp_xdr_conversion_rate: Some(initial_icp_xdr_conversion_rate.clone()),
+            average_icp_xdr_conversion_rate: Some(initial_icp_xdr_conversion_rate.clone()),
             recent_icp_xdr_rates: Some(vec![
                 IcpXdrConversionRate::default();
                 ICP_XDR_CONVERSION_RATE_CACHE_SIZE
@@ -2767,13 +2768,20 @@ mod tests {
     #[test]
     /// The function verifies that a default ICP/XDR conversion rate is set.
     fn test_default_icp_xdr_conversion_rate() {
-        let state = State::default();
-        let conversion_rate = state.icp_xdr_conversion_rate;
-        let default_rate = IcpXdrConversionRate {
+        let expected_initial_rate = IcpXdrConversionRate {
             timestamp_seconds: 1620633600,
             xdr_permyriad_per_icp: 1_000_000,
         };
-        assert!(matches!(conversion_rate, Some(rate) if rate == default_rate));
+
+        let state = State::default();
+        assert_eq!(
+            state.icp_xdr_conversion_rate,
+            Some(expected_initial_rate.clone()),
+        );
+        assert_eq!(
+            state.average_icp_xdr_conversion_rate,
+            Some(expected_initial_rate),
+        );
     }
 
     #[test]

--- a/rs/nns/cmc/src/main.rs
+++ b/rs/nns/cmc/src/main.rs
@@ -402,7 +402,7 @@ impl Default for State {
         let max_age = Duration::from_secs(60 * 60);
         let initial_icp_xdr_conversion_rate = IcpXdrConversionRate {
             timestamp_seconds: DEFAULT_ICP_XDR_CONVERSION_RATE_TIMESTAMP_SECONDS,
-            xdr_permyriad_per_icp: 1_000_000, // 100 XDR = 1 ICP
+            xdr_permyriad_per_icp: DEFAULT_XDR_PERMYRIAD_PER_ICP_CONVERSION_RATE,
         };
 
         Self {
@@ -2769,8 +2769,8 @@ mod tests {
     /// The function verifies that a default ICP/XDR conversion rate is set.
     fn test_default_icp_xdr_conversion_rate() {
         let expected_initial_rate = IcpXdrConversionRate {
-            timestamp_seconds: 1620633600,
-            xdr_permyriad_per_icp: 1_000_000,
+            timestamp_seconds: DEFAULT_ICP_XDR_CONVERSION_RATE_TIMESTAMP_SECONDS,
+            xdr_permyriad_per_icp: DEFAULT_XDR_PERMYRIAD_PER_ICP_CONVERSION_RATE,
         };
 
         let state = State::default();


### PR DESCRIPTION
This PR initializes `average_icp_xdr_conversion_rate` with the same value that `icp_xdr_conversion_rate` is initialized with. This is convenient for testing, as e.g., the NNS Governance expects there to be some `average_icp_xdr_conversion_rate`, otherwise frequently printing errors to the log.