### PR TITLE
refactor: Switch some test canisters in rust_canisters to use public CDK

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1619,10 +1619,10 @@ checksum = "3a4f925191b4367301851c6d99b09890311d74b0d43f274c0b34c86d308a3663"
 name = "call-tree-test"
 version = "0.9.0"
 dependencies = [
- "dfn_core",
- "dfn_json",
- "dfn_macro",
+ "candid",
  "futures",
+ "ic-cdk 0.13.2",
+ "ic-cdk-macros 0.9.0",
  "serde",
  "serde_json",
 ]
@@ -3429,7 +3429,6 @@ name = "downstream-calls-test"
 version = "0.1.0"
 dependencies = [
  "candid",
- "dfn_core",
  "ic-base-types",
  "ic-cdk 0.13.2",
  "ic-cdk-macros 0.9.0",
@@ -3486,7 +3485,6 @@ name = "ecdsa-canister"
 version = "0.1.0"
 dependencies = [
  "candid",
- "dfn_core",
  "ic-cdk 0.13.2",
  "ic-cdk-macros 0.9.0",
  "ic-management-canister-types",
@@ -17347,9 +17345,9 @@ dependencies = [
 name = "response-payload-test"
 version = "0.9.0"
 dependencies = [
- "dfn_core",
- "dfn_json",
- "dfn_macro",
+ "candid",
+ "ic-cdk 0.13.2",
+ "ic-cdk-macros 0.9.0",
  "serde",
 ]
 

--- a/rs/rust_canisters/call_tree_test/BUILD.bazel
+++ b/rs/rust_canisters/call_tree_test/BUILD.bazel
@@ -4,16 +4,16 @@ package(default_visibility = ["//visibility:public"])
 
 DEPENDENCIES = [
     # Keep sorted.
-    "//rs/rust_canisters/dfn_core",
-    "//rs/rust_canisters/dfn_json",
+    "@crate_index//:candid",
     "@crate_index//:futures",
+    "@crate_index//:ic-cdk",
     "@crate_index//:serde",
     "@crate_index//:serde_json",
 ]
 
 MACRO_DEPENDENCIES = [
     # Keep sorted.
-    "//rs/rust_canisters/dfn_macro",
+    "@crate_index//:ic-cdk-macros",
 ]
 
 rust_canister(

--- a/rs/rust_canisters/call_tree_test/Cargo.toml
+++ b/rs/rust_canisters/call_tree_test/Cargo.toml
@@ -11,9 +11,9 @@ name = "call-tree-test-canister"
 path = "src/main.rs"
 
 [dependencies]
-dfn_core = { path = "../dfn_core" }
-dfn_json = { path = "../dfn_json" }
-dfn_macro = { path = "../dfn_macro" }
+candid = { workspace = true }
+ic-cdk = { workspace = true }
+ic-cdk-macros = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 futures = { workspace = true }

--- a/rs/rust_canisters/downstream_calls_test/BUILD.bazel
+++ b/rs/rust_canisters/downstream_calls_test/BUILD.bazel
@@ -5,7 +5,6 @@ package(default_visibility = ["//visibility:public"])
 
 DEPENDENCIES = [
     # Keep sorted.
-    "//rs/rust_canisters/dfn_core",
     "//rs/types/base_types",
     "@crate_index//:candid",
     "@crate_index//:ic-cdk",

--- a/rs/rust_canisters/downstream_calls_test/Cargo.toml
+++ b/rs/rust_canisters/downstream_calls_test/Cargo.toml
@@ -9,7 +9,6 @@ path = "src/main.rs"
 
 [dependencies]
 candid = { workspace = true }
-dfn_core = { path = "../dfn_core" }
 ic-base-types = { path = "../../types/base_types" }
 ic-cdk = { workspace = true }
 ic-cdk-macros = { workspace = true }

--- a/rs/rust_canisters/downstream_calls_test/src/main.rs
+++ b/rs/rust_canisters/downstream_calls_test/src/main.rs
@@ -1,6 +1,6 @@
 use candid::{candid_method, Decode, Encode};
-use dfn_core::api::{call_bytes, Funds};
 use downstream_calls_test::{CallOrResponse, State};
+use ic_cdk::api::call::call_raw;
 use ic_cdk_macros::update;
 
 fn main() {}
@@ -33,17 +33,17 @@ async fn reply_or_defer(mut state: State) -> State {
     loop {
         match state.actions.pop_front() {
             Some(CallOrResponse::Call(canister_id)) => {
-                let response = call_bytes(
-                    canister_id,
+                let response = call_raw(
+                    canister_id.into(),
                     "reply_or_defer",
-                    &Encode!(&State {
+                    Encode!(&State {
                         actions: state.actions,
                         call_count: state.call_count + 1,
                         current_depth: state.current_depth + 1,
                         depth_total: state.depth_total + state.current_depth,
                     })
                     .unwrap(),
-                    Funds::zero(),
+                    0,
                 )
                 .await
                 .expect("calling other canister failed");

--- a/rs/rust_canisters/ecdsa/BUILD.bazel
+++ b/rs/rust_canisters/ecdsa/BUILD.bazel
@@ -5,7 +5,6 @@ package(default_visibility = ["//visibility:public"])
 
 DEPENDENCIES = [
     # Keep sorted.
-    "//rs/rust_canisters/dfn_core",
     "//rs/types/management_canister_types",
     "@crate_index//:candid",
     "@crate_index//:ic-cdk",

--- a/rs/rust_canisters/ecdsa/Cargo.toml
+++ b/rs/rust_canisters/ecdsa/Cargo.toml
@@ -9,7 +9,6 @@ path = "src/main.rs"
 
 [dependencies]
 candid = { workspace = true }
-dfn_core = { path = "../dfn_core" }
 ic-cdk = { workspace = true }
 ic-cdk-macros = { workspace = true }
 ic-management-canister-types = { path = "../../types/management_canister_types" }

--- a/rs/rust_canisters/ecdsa/src/main.rs
+++ b/rs/rust_canisters/ecdsa/src/main.rs
@@ -1,6 +1,5 @@
 use candid::{candid_method, CandidType, Encode};
-use dfn_core::api::{call_bytes, Funds};
-use ic_cdk::api::print;
+use ic_cdk::api::{call::call_raw, print};
 use ic_cdk_macros::update;
 use ic_management_canister_types::{
     DerivationPath, EcdsaCurve, EcdsaKeyId, Method as Ic00Method, SignWithECDSAArgs, IC_00,
@@ -30,10 +29,10 @@ async fn get_sig(options: Options) {
         "calling get sig with key {} and derivation path {:?}",
         options.key_name, options.derivation_path,
     ));
-    let response = call_bytes(
-        IC_00,
+    let response = call_raw(
+        IC_00.into(),
         &Ic00Method::SignWithECDSA.to_string(),
-        &Encode!(&SignWithECDSAArgs {
+        Encode!(&SignWithECDSAArgs {
             message_hash: [0; 32],
             derivation_path: DerivationPath::new(
                 options
@@ -48,7 +47,7 @@ async fn get_sig(options: Options) {
             },
         })
         .unwrap(),
-        Funds::new(1_000_000_000_000),
+        1_000_000_000_000,
     )
     .await;
     print(format!("got result {:?}", response));

--- a/rs/rust_canisters/response_payload_test/BUILD.bazel
+++ b/rs/rust_canisters/response_payload_test/BUILD.bazel
@@ -4,14 +4,14 @@ package(default_visibility = ["//visibility:public"])
 
 DEPENDENCIES = [
     # Keep sorted.
-    "//rs/rust_canisters/dfn_core",
-    "//rs/rust_canisters/dfn_json",
+    "@crate_index//:candid",
+    "@crate_index//:ic-cdk",
     "@crate_index//:serde",
 ]
 
 MACRO_DEPENDENCIES = [
     # Keep sorted.
-    "//rs/rust_canisters/dfn_macro",
+    "@crate_index//:ic-cdk-macros",
 ]
 
 ALIASES = {}

--- a/rs/rust_canisters/response_payload_test/Cargo.toml
+++ b/rs/rust_canisters/response_payload_test/Cargo.toml
@@ -11,9 +11,7 @@ name = "response-payload-test-canister"
 path = "src/main.rs"
 
 [dependencies]
-dfn_core = { path = "../dfn_core" }
-dfn_json = { path = "../dfn_json" }
-dfn_macro = { path = "../dfn_macro" }
+candid = { workspace = true }
+ic-cdk = { workspace = true }
+ic-cdk-macros = { workspace = true }
 serde = { workspace = true }
-
-

--- a/rs/rust_canisters/response_payload_test/src/main.rs
+++ b/rs/rust_canisters/response_payload_test/src/main.rs
@@ -1,14 +1,14 @@
 //! This module contains a canister used for testing responses with variable payload size
-
-use dfn_macro::query;
-use serde::{Deserialize, Serialize};
+use candid::{CandidType, Deserialize};
+use ic_cdk_macros::query;
+use serde::Serialize;
 
 /// All methods get this struct as an argument encoded in a JSON string.
 ///
 /// # Fields
 ///
 /// * `response_size_bytes` - size of the response payload in bytes.
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(CandidType, Serialize, Deserialize, Debug)]
 struct Operation {
     response_size_bytes: usize,
 }


### PR DESCRIPTION
This PR updates some of the test canisters included in `rust_canisters` to use the public CDK instead of the deprecated internal one (`dfn_core` and friends). The change is made for a set of canisters that were easy to port over. There are some more cases that are more nuanced and will happen in individual follow-ups.