### PR TITLE
feat(nns): Add topic mapping for canister management topics

### DIFF
--- a/rs/nns/constants/src/lib.rs
+++ b/rs/nns/constants/src/lib.rs
@@ -36,6 +36,8 @@ pub const CYCLES_LEDGER_INDEX_CANISTER_INDEX: u64 = 0x2100003;
 // Bitcoin canisters are deployed to the `w4rem` subnet
 pub const BITCOIN_TESTNET_CANISTER_INDEX: u64 = 0x1a00001;
 pub const BITCOIN_MAINNET_CANISTER_INDEX: u64 = 0x1a00004;
+// SNS Aggregator canister is deployed to the `x33ed` (SNS) subnet.
+pub const SNS_AGGREGATOR_CANISTER_INDEX: u64 = 0x2000010;
 
 /// WARNING: This list is incomplete. In particular, this does NOT include
 /// ledger archive, nor ledger index.
@@ -124,6 +126,9 @@ pub const BITCOIN_TESTNET_CANISTER_ID: CanisterId =
 /// 0x1_a00_004 (27_262_980): ghsi2-tqaaa-aaaan-aaaca-cai
 pub const BITCOIN_MAINNET_CANISTER_ID: CanisterId =
     CanisterId::from_u64(BITCOIN_MAINNET_CANISTER_INDEX);
+/// 0x2_000_010 (33_554_448): 3r4gx-wqaaa-aaaaq-aaaia-cai
+pub const SNS_AGGREGATOR_CANISTER_ID: CanisterId =
+    CanisterId::from_u64(SNS_AGGREGATOR_CANISTER_INDEX);
 
 /// WARNING: This list is incomplete. In particular, this does NOT include
 /// ledger archive, nor ledger index.

--- a/rs/nns/governance/src/proposals/install_code.rs
+++ b/rs/nns/governance/src/proposals/install_code.rs
@@ -77,7 +77,7 @@ impl InstallCode {
 
     pub fn valid_topic(&self) -> Result<Topic, GovernanceError> {
         let canister_id = self.valid_canister_id()?;
-        topic_to_manage_canister(&canister_id)
+        Ok(topic_to_manage_canister(&canister_id))
     }
 
     fn payload_to_upgrade_root(&self) -> Result<Vec<u8>, GovernanceError> {
@@ -202,7 +202,9 @@ mod tests {
         };
 
         let is_invalid_proposal_with_keywords = |install_code: InstallCode, keywords: Vec<&str>| {
-            let error = install_code.validate().unwrap_err();
+            let error = install_code
+                .validate()
+                .expect_err("Expecting validation error for {install_code:?} but got Ok(())");
             assert_eq!(error.error_type, ErrorType::InvalidProposal as i32);
             for keyword in keywords {
                 let error_message = error.error_message.to_lowercase();
@@ -279,14 +281,6 @@ mod tests {
                 "not supported for root canister",
                 "hardresetnnsroottoversion",
             ],
-        );
-
-        is_invalid_proposal_with_keywords(
-            InstallCode {
-                canister_id: Some(ic_nns_constants::SNS_WASM_CANISTER_ID.get()),
-                ..valid_install_code.clone()
-            },
-            vec!["canister id", "not a protocol canister"],
         );
     }
 
@@ -392,5 +386,34 @@ mod tests {
                 memory_allocation: None,
             }
         );
+    }
+
+    #[cfg(feature = "test")]
+    #[test]
+    fn test_upgrade_canisters_topic_mapping() {
+        use ic_base_types::CanisterId;
+        use ic_nns_constants::SNS_WASM_CANISTER_ID;
+
+        let test_cases = vec![
+            (REGISTRY_CANISTER_ID, Topic::ProtocolCanisterManagement),
+            (SNS_WASM_CANISTER_ID, Topic::ServiceNervousSystemManagement),
+            (
+                CanisterId::from_u64(123_456_789),
+                Topic::NetworkCanisterManagement,
+            ),
+        ];
+
+        for (canister_id, expected_topic) in test_cases {
+            let install_code = InstallCode {
+                canister_id: Some(canister_id.get()),
+                wasm_module: Some(vec![1, 2, 3]),
+                install_mode: Some(CanisterInstallMode::Upgrade as i32),
+                arg: Some(vec![4, 5, 6]),
+                skip_stopping_before_installing: None,
+            };
+
+            assert_eq!(install_code.validate(), Ok(()));
+            assert_eq!(install_code.valid_topic(), Ok(expected_topic));
+        }
     }
 }

--- a/rs/nns/governance/src/proposals/mod.rs
+++ b/rs/nns/governance/src/proposals/mod.rs
@@ -5,7 +5,8 @@ use ic_nns_constants::{
     CYCLES_LEDGER_INDEX_CANISTER_ID, CYCLES_MINTING_CANISTER_ID, EXCHANGE_RATE_CANISTER_ID,
     GENESIS_TOKEN_CANISTER_ID, GOVERNANCE_CANISTER_ID, ICP_LEDGER_ARCHIVE_1_CANISTER_ID,
     ICP_LEDGER_ARCHIVE_CANISTER_ID, LEDGER_CANISTER_ID, LEDGER_INDEX_CANISTER_ID,
-    LIFELINE_CANISTER_ID, REGISTRY_CANISTER_ID, ROOT_CANISTER_ID, SUBNET_RENTAL_CANISTER_ID,
+    LIFELINE_CANISTER_ID, REGISTRY_CANISTER_ID, ROOT_CANISTER_ID, SNS_AGGREGATOR_CANISTER_ID,
+    SNS_WASM_CANISTER_ID, SUBNET_RENTAL_CANISTER_ID,
 };
 
 pub mod call_canister;
@@ -34,14 +35,16 @@ const PROTOCOL_CANISTER_IDS: [&CanisterId; 16] = [
     &CYCLES_LEDGER_INDEX_CANISTER_ID,
 ];
 
-pub(crate) fn topic_to_manage_canister(canister_id: &CanisterId) -> Result<Topic, GovernanceError> {
+const SNS_RELATED_CANISTER_IDS: [&CanisterId; 2] =
+    [&SNS_WASM_CANISTER_ID, &SNS_AGGREGATOR_CANISTER_ID];
+
+pub(crate) fn topic_to_manage_canister(canister_id: &CanisterId) -> Topic {
     if PROTOCOL_CANISTER_IDS.contains(&canister_id) {
-        Ok(Topic::ProtocolCanisterManagement)
+        Topic::ProtocolCanisterManagement
+    } else if SNS_RELATED_CANISTER_IDS.contains(&canister_id) {
+        Topic::ServiceNervousSystemManagement
     } else {
-        Err(invalid_proposal_error(&format!(
-            "Canister id {:?} is not a protocol canister",
-            canister_id
-        )))
+        Topic::NetworkCanisterManagement
     }
 }
 

--- a/rs/nns/governance/src/proposals/stop_or_start_canister.rs
+++ b/rs/nns/governance/src/proposals/stop_or_start_canister.rs
@@ -46,7 +46,7 @@ impl StopOrStartCanister {
 
     pub fn valid_topic(&self) -> Result<Topic, GovernanceError> {
         let canister_id = self.valid_canister_id()?;
-        topic_to_manage_canister(&canister_id)
+        Ok(topic_to_manage_canister(&canister_id))
     }
 
     fn valid_canister_id(&self) -> Result<CanisterId, GovernanceError> {
@@ -133,7 +133,9 @@ mod tests {
 
         let is_invalid_proposal_with_keywords =
             |stop_or_start_canister: StopOrStartCanister, keywords: Vec<&str>| {
-                let error = stop_or_start_canister.validate().unwrap_err();
+                let error = stop_or_start_canister.validate().expect_err(
+                    "Expecting validation error for {stop_or_start_canister:?} but got Ok(())",
+                );
                 assert_eq!(error.error_type, ErrorType::InvalidProposal as i32);
                 for keyword in keywords {
                     let error_message = error.error_message.to_lowercase();
@@ -176,14 +178,6 @@ mod tests {
                 ..valid_stop_or_start_canister.clone()
             },
             vec!["unspecified or unrecognized", "action"],
-        );
-
-        is_invalid_proposal_with_keywords(
-            StopOrStartCanister {
-                canister_id: Some(ic_nns_constants::SNS_WASM_CANISTER_ID.get()),
-                ..valid_stop_or_start_canister.clone()
-            },
-            vec!["canister id", "not a protocol canister"],
         );
 
         is_invalid_proposal_with_keywords(
@@ -276,5 +270,34 @@ mod tests {
                 action: RootCanisterAction::Start,
             }
         );
+    }
+
+    #[cfg(feature = "test")]
+    #[test]
+    fn test_start_canister_topic_mapping() {
+        use ic_base_types::CanisterId;
+        use ic_nns_constants::SNS_WASM_CANISTER_ID;
+
+        let test_cases = vec![
+            (
+                CYCLES_MINTING_CANISTER_ID,
+                Topic::ProtocolCanisterManagement,
+            ),
+            (SNS_WASM_CANISTER_ID, Topic::ServiceNervousSystemManagement),
+            (
+                CanisterId::from_u64(123_456_789),
+                Topic::NetworkCanisterManagement,
+            ),
+        ];
+
+        for (canister_id, expected_topic) in test_cases {
+            let stop_or_start_canister = StopOrStartCanister {
+                canister_id: Some(canister_id.get()),
+                action: Some(CanisterAction::Start as i32),
+            };
+
+            assert_eq!(stop_or_start_canister.validate(), Ok(()));
+            assert_eq!(stop_or_start_canister.valid_topic(), Ok(expected_topic));
+        }
     }
 }


### PR DESCRIPTION
# Why

Before this PR, the new proposal types only supports `ProtocolCanisterManagement` and returns error for other cansiters. 

# What

Define mapping for SNS related canisters and the catch-all.
