### PR TITLE
fix(IDX): do not run colocated systests on k8s

### DIFF
--- a/.github/workflows/system-tests-k8s.yml
+++ b/.github/workflows/system-tests-k8s.yml
@@ -84,5 +84,5 @@ jobs:
           BAZEL_COMMAND: "test"
           BAZEL_TARGETS: "${{ env.TARGETS }}"
           BAZEL_CI_CONFIG: "--config=ci --repository_cache=/cache/bazel"
-          BAZEL_EXTRA_ARGS: "--jobs=${{ env.JOBS }} --test_tag_filters=k8s,-manual --k8s"
+          BAZEL_EXTRA_ARGS: "--jobs=${{ env.JOBS }} --test_tag_filters=k8s,-manual,-colocated --k8s"
           HONEYCOMB_API_TOKEN: ${{ secrets.HONEYCOMB_API_TOKEN }}

--- a/rs/tests/system_tests.bzl
+++ b/rs/tests/system_tests.bzl
@@ -263,7 +263,8 @@ def system_test(
         env_inherit = env_inherit,
         env = env,
         tags = tags + ["requires-network", "system_test"] +
-               ([] if "experimental_system_test_colocation" in tags else ["manual"]) + additional_colocate_tags,
+               (["colocated"] if "experimental_system_test_colocation" in tags else ["manual"]) +
+               additional_colocate_tags,
         target_compatible_with = ["@platforms//os:linux"],
         timeout = test_timeout,
         flaky = flaky,


### PR DESCRIPTION
System-tests on k8s are already colocated so let's not run colocated system-tests in the `system-tests-k8s` workflow.

"System Tests K8s" workflow run:https://github.com/dfinity/ic/actions/runs/10290371878/job/28480183263.