### PR TITLE
chore(nns): Add post-upgrade validation for NP Rewards and audit events

### DIFF
--- a/rs/nns/governance/src/storage.rs
+++ b/rs/nns/governance/src/storage.rs
@@ -122,6 +122,8 @@ impl State {
     fn validate(&self) {
         self.stable_neuron_store.validate();
         self.stable_neuron_indexes.validate();
+        validate_stable_log(&self.audit_events_log);
+        validate_stable_log(&self.node_provider_rewards_log);
     }
 }
 
@@ -197,8 +199,18 @@ where
     M: Memory,
 {
     // This is just to verify that any key-value pair can be deserialized without panicking. It is
-    // not guaranteed to catch all deserializations, but should catch a lot of common issues.
+    // guaranteed to catch all deserialization errors, but should help.
     let _ = btree_map.first_key_value();
+}
+
+pub(crate) fn validate_stable_log<Value, M>(log: &StableLog<Value, M, M>)
+where
+    Value: Storable,
+    M: Memory,
+{
+    // This is just to verify that an early value can be deserialized without panicking. It is not
+    // guaranteed to catch all deserialization errors, but should help.
+    let _ = log.get(0);
 }
 
 // Clears and initializes stable memory and stable structures before testing. Typically only needed


### PR DESCRIPTION
This adds a very minimal validation to ensure reading data from stable storage after an upgrade won't panic.