### PR TITLE
feat(nns): Let InstallCode proposal return wasm_module_hash and arg_hash

### DIFF
--- a/rs/nns/governance/api/src/ic_nns_governance.pb.v1.rs
+++ b/rs/nns/governance/api/src/ic_nns_governance.pb.v1.rs
@@ -1186,6 +1186,101 @@ pub mod manage_neuron_response {
         StakeMaturity(StakeMaturityResponse),
     }
 }
+
+#[derive(candid::CandidType, candid::Deserialize, serde::Serialize, comparable::Comparable)]
+#[compare_default]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct NewProposal {
+    #[prost(string, optional, tag = "20")]
+    pub title: ::core::option::Option<::prost::alloc::string::String>,
+    #[prost(string, tag = "1")]
+    pub summary: ::prost::alloc::string::String,
+    #[prost(string, tag = "2")]
+    pub url: ::prost::alloc::string::String,
+    #[prost(
+        oneof = "NewProposalAction",
+        tags = "10, 12, 13, 14, 15, 16, 21, 24, 25, 26, 27"
+    )]
+    pub action: ::core::option::Option<NewProposalAction>,
+}
+
+#[derive(candid::CandidType, candid::Deserialize, serde::Serialize, comparable::Comparable)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Oneof)]
+pub enum NewProposalAction {
+    #[prost(message, tag = "10")]
+    ManageNeuron(::prost::alloc::boxed::Box<NewManageNeuron>),
+    #[prost(message, tag = "12")]
+    ManageNetworkEconomics(NetworkEconomics),
+    #[prost(message, tag = "13")]
+    Motion(Motion),
+    #[prost(message, tag = "14")]
+    ExecuteNnsFunction(ExecuteNnsFunction),
+    #[prost(message, tag = "15")]
+    ApproveGenesisKyc(ApproveGenesisKyc),
+    #[prost(message, tag = "16")]
+    AddOrRemoveNodeProvider(AddOrRemoveNodeProvider),
+    #[prost(message, tag = "17")]
+    RewardNodeProvider(RewardNodeProvider),
+    #[prost(message, tag = "19")]
+    RewardNodeProviders(RewardNodeProviders),
+    #[prost(message, tag = "21")]
+    RegisterKnownNeuron(KnownNeuron),
+    #[prost(message, tag = "24")]
+    CreateServiceNervousSystem(CreateServiceNervousSystem),
+    #[prost(message, tag = "25")]
+    InstallCode(NewInstallCode),
+    #[prost(message, tag = "26")]
+    StopOrStartCanister(StopOrStartCanister),
+    #[prost(message, tag = "27")]
+    UpdateCanisterSettings(UpdateCanisterSettings),
+}
+
+#[derive(candid::CandidType, candid::Deserialize, serde::Serialize, comparable::Comparable)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct NewManageNeuron {
+    #[prost(message, optional, tag = "1")]
+    pub id: ::core::option::Option<::ic_nns_common::pb::v1::NeuronId>,
+    #[prost(oneof = "manage_neuron::NeuronIdOrSubaccount", tags = "11, 12")]
+    pub neuron_id_or_subaccount: ::core::option::Option<manage_neuron::NeuronIdOrSubaccount>,
+    #[prost(
+        oneof = "NewManageNeuronCommand",
+        tags = "2, 3, 4, 5, 6, 7, 8, 9, 10, 13, 14, 15"
+    )]
+    pub command: ::core::option::Option<NewManageNeuronCommand>,
+}
+
+#[derive(candid::CandidType, candid::Deserialize, serde::Serialize, comparable::Comparable)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Oneof)]
+pub enum NewManageNeuronCommand {
+    #[prost(message, tag = "2")]
+    Configure(manage_neuron::Configure),
+    #[prost(message, tag = "3")]
+    Disburse(manage_neuron::Disburse),
+    #[prost(message, tag = "4")]
+    Spawn(manage_neuron::Spawn),
+    #[prost(message, tag = "5")]
+    Follow(manage_neuron::Follow),
+    #[prost(message, tag = "6")]
+    MakeProposal(::prost::alloc::boxed::Box<NewProposal>),
+    #[prost(message, tag = "7")]
+    RegisterVote(manage_neuron::RegisterVote),
+    #[prost(message, tag = "8")]
+    Split(manage_neuron::Split),
+    #[prost(message, tag = "9")]
+    DisburseToNeuron(manage_neuron::DisburseToNeuron),
+    #[prost(message, tag = "10")]
+    ClaimOrRefresh(manage_neuron::ClaimOrRefresh),
+    #[prost(message, tag = "13")]
+    MergeMaturity(manage_neuron::MergeMaturity),
+    #[prost(message, tag = "14")]
+    Merge(manage_neuron::Merge),
+    #[prost(message, tag = "15")]
+    StakeMaturity(manage_neuron::StakeMaturity),
+}
 #[derive(candid::CandidType, candid::Deserialize, serde::Serialize, comparable::Comparable)]
 #[compare_default]
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -2328,9 +2423,18 @@ pub struct InstallCode {
     #[prost(bytes = "vec", optional, tag = "4")]
     #[serde(deserialize_with = "ic_utils::deserialize::deserialize_option_blob")]
     pub arg: ::core::option::Option<::prost::alloc::vec::Vec<u8>>,
+
     /// Whether to skip stopping the canister before installing. Optional. Default is false.
     #[prost(bool, optional, tag = "5")]
     pub skip_stopping_before_installing: ::core::option::Option<bool>,
+
+    #[prost(bytes = "vec", optional, tag = "6")]
+    #[serde(deserialize_with = "ic_utils::deserialize::deserialize_option_blob")]
+    pub wasm_module_hash: ::core::option::Option<::prost::alloc::vec::Vec<u8>>,
+
+    #[prost(bytes = "vec", optional, tag = "7")]
+    #[serde(deserialize_with = "ic_utils::deserialize::deserialize_option_blob")]
+    pub arg_hash: ::core::option::Option<::prost::alloc::vec::Vec<u8>>,
 }
 /// Nested message and enum types in `InstallCode`.
 pub mod install_code {
@@ -2381,6 +2485,25 @@ pub mod install_code {
         }
     }
 }
+
+#[derive(candid::CandidType, candid::Deserialize, serde::Serialize, comparable::Comparable)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct NewInstallCode {
+    #[prost(message, optional, tag = "1")]
+    pub canister_id: ::core::option::Option<::ic_base_types::PrincipalId>,
+    #[prost(enumeration = "install_code::CanisterInstallMode", optional, tag = "2")]
+    pub install_mode: ::core::option::Option<i32>,
+    #[prost(bytes = "vec", optional, tag = "3")]
+    #[serde(deserialize_with = "ic_utils::deserialize::deserialize_option_blob")]
+    pub wasm_module: ::core::option::Option<::prost::alloc::vec::Vec<u8>>,
+    #[prost(bytes = "vec", optional, tag = "4")]
+    #[serde(deserialize_with = "ic_utils::deserialize::deserialize_option_blob")]
+    pub arg: ::core::option::Option<::prost::alloc::vec::Vec<u8>>,
+    #[prost(bool, optional, tag = "5")]
+    pub skip_stopping_before_installing: ::core::option::Option<bool>,
+}
+
 #[derive(candid::CandidType, candid::Deserialize, serde::Serialize, comparable::Comparable)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/rs/nns/governance/api/src/ic_nns_governance.pb.v1.rs
+++ b/rs/nns/governance/api/src/ic_nns_governance.pb.v1.rs
@@ -2415,14 +2415,6 @@ pub struct InstallCode {
     /// The install mode. Either install, reinstall, or upgrade. Required.
     #[prost(enumeration = "install_code::CanisterInstallMode", optional, tag = "2")]
     pub install_mode: ::core::option::Option<i32>,
-    /// The wasm module to install. required.
-    #[prost(bytes = "vec", optional, tag = "3")]
-    #[serde(deserialize_with = "ic_utils::deserialize::deserialize_option_blob")]
-    pub wasm_module: ::core::option::Option<::prost::alloc::vec::Vec<u8>>,
-    /// The arg to pass to the canister. Optional.
-    #[prost(bytes = "vec", optional, tag = "4")]
-    #[serde(deserialize_with = "ic_utils::deserialize::deserialize_option_blob")]
-    pub arg: ::core::option::Option<::prost::alloc::vec::Vec<u8>>,
 
     /// Whether to skip stopping the canister before installing. Optional. Default is false.
     #[prost(bool, optional, tag = "5")]

--- a/rs/nns/governance/canister/canister.rs
+++ b/rs/nns/governance/canister/canister.rs
@@ -47,16 +47,16 @@ use ic_nns_governance_api::pb::v1::{
     governance_error::ErrorType,
     manage_neuron::{
         claim_or_refresh::{By, MemoAndController},
-        ClaimOrRefresh, Command, NeuronIdOrSubaccount, RegisterVote,
+        ClaimOrRefresh, NeuronIdOrSubaccount, RegisterVote,
     },
     manage_neuron_response, ClaimOrRefreshNeuronFromAccount,
     ClaimOrRefreshNeuronFromAccountResponse, GetNeuronsFundAuditInfoRequest,
     GetNeuronsFundAuditInfoResponse, Governance as ApiGovernanceProto, GovernanceError,
     ListKnownNeuronsResponse, ListNeurons, ListNeuronsResponse, ListNodeProvidersResponse,
-    ListProposalInfo, ListProposalInfoResponse, ManageNeuron, ManageNeuronResponse,
-    MonthlyNodeProviderRewards, NetworkEconomics, Neuron, NeuronInfo, NodeProvider, Proposal,
-    ProposalInfo, RestoreAgingSummary, RewardEvent, RewardNodeProvider, RewardNodeProviders,
-    SettleCommunityFundParticipation, SettleNeuronsFundParticipationRequest,
+    ListProposalInfo, ListProposalInfoResponse, ManageNeuronResponse, MonthlyNodeProviderRewards,
+    NetworkEconomics, Neuron, NeuronInfo, NewManageNeuron, NewManageNeuronCommand, NodeProvider,
+    Proposal, ProposalInfo, RestoreAgingSummary, RewardEvent, RewardNodeProvider,
+    RewardNodeProviders, SettleCommunityFundParticipation, SettleNeuronsFundParticipationRequest,
     SettleNeuronsFundParticipationResponse, UpdateNodeProvider, Vote,
 };
 use ic_sns_wasm::pb::v1::{AddWasmRequest, SnsWasm};
@@ -405,9 +405,9 @@ fn vote() {
     over_async(
         candid,
         |(neuron_id, proposal_id, vote): (NeuronId, ProposalId, Vote)| async move {
-            manage_neuron_(ManageNeuron {
+            manage_neuron_(NewManageNeuron {
                 id: Some(NeuronIdProto::from(neuron_id)),
-                command: Some(Command::RegisterVote(RegisterVote {
+                command: Some(NewManageNeuronCommand::RegisterVote(RegisterVote {
                     proposal: Some(ProposalIdProto::from(proposal_id)),
                     vote: vote as i32,
                 })),
@@ -446,9 +446,9 @@ fn claim_or_refresh_neuron_from_account() {
 async fn claim_or_refresh_neuron_from_account_(
     claim_or_refresh: ClaimOrRefreshNeuronFromAccount,
 ) -> ClaimOrRefreshNeuronFromAccountResponse {
-    let manage_neuron_response = manage_neuron_(ManageNeuron {
+    let manage_neuron_response = manage_neuron_(NewManageNeuron {
         id: None,
-        command: Some(Command::ClaimOrRefresh(ClaimOrRefresh {
+        command: Some(NewManageNeuronCommand::ClaimOrRefresh(ClaimOrRefresh {
             by: Some(By::MemoAndController(MemoAndController {
                 memo: claim_or_refresh.memo,
                 controller: claim_or_refresh.controller,
@@ -523,7 +523,7 @@ fn manage_neuron() {
 }
 
 #[candid_method(update, rename = "manage_neuron")]
-async fn manage_neuron_(manage_neuron: ManageNeuron) -> ManageNeuronResponse {
+async fn manage_neuron_(manage_neuron: NewManageNeuron) -> ManageNeuronResponse {
     let response = governance_mut()
         .manage_neuron(&caller(), &(gov_pb::ManageNeuron::from(manage_neuron)))
         .await;
@@ -555,7 +555,7 @@ fn simulate_manage_neuron() {
 }
 
 #[candid_method(update, rename = "simulate_manage_neuron")]
-fn simulate_manage_neuron_(manage_neuron: ManageNeuron) -> ManageNeuronResponse {
+fn simulate_manage_neuron_(manage_neuron: NewManageNeuron) -> ManageNeuronResponse {
     let response =
         governance().simulate_manage_neuron(&caller(), gov_pb::ManageNeuron::from(manage_neuron));
     ManageNeuronResponse::from(response)

--- a/rs/nns/governance/canister/governance.did
+++ b/rs/nns/governance/canister/governance.did
@@ -266,8 +266,6 @@ type InitialTokenDistribution = record {
   swap_distribution : opt SwapDistribution;
 };
 type InstallCode = record {
-  arg : opt blob;
-  wasm_module : opt blob;
   skip_stopping_before_installing : opt bool;
   wasm_module_hash : opt blob;
   canister_id : opt principal;

--- a/rs/nns/governance/canister/governance.did
+++ b/rs/nns/governance/canister/governance.did
@@ -269,7 +269,9 @@ type InstallCode = record {
   arg : opt blob;
   wasm_module : opt blob;
   skip_stopping_before_installing : opt bool;
+  wasm_module_hash : opt blob;
   canister_id : opt principal;
+  arg_hash : opt blob;
   install_mode : opt int32;
 };
 type KnownNeuron = record {
@@ -492,6 +494,53 @@ type NeuronsFundParticipation = record {
 };
 type NeuronsFundSnapshot = record {
   neurons_fund_neuron_portions : vec NeuronsFundNeuronPortion;
+};
+type NewInstallCode = record {
+  arg : opt blob;
+  wasm_module : opt blob;
+  skip_stopping_before_installing : opt bool;
+  canister_id : opt principal;
+  install_mode : opt int32;
+};
+type NewManageNeuron = record {
+  id : opt NeuronId;
+  command : opt NewManageNeuronCommand;
+  neuron_id_or_subaccount : opt NeuronIdOrSubaccount;
+};
+type NewManageNeuronCommand = variant {
+  Spawn : Spawn;
+  Split : Split;
+  Follow : Follow;
+  ClaimOrRefresh : ClaimOrRefresh;
+  Configure : Configure;
+  RegisterVote : RegisterVote;
+  Merge : Merge;
+  DisburseToNeuron : DisburseToNeuron;
+  MakeProposal : NewProposal;
+  StakeMaturity : StakeMaturity;
+  MergeMaturity : MergeMaturity;
+  Disburse : Disburse;
+};
+type NewProposal = record {
+  url : text;
+  title : opt text;
+  action : opt NewProposalAction;
+  summary : text;
+};
+type NewProposalAction = variant {
+  RegisterKnownNeuron : KnownNeuron;
+  ManageNeuron : NewManageNeuron;
+  UpdateCanisterSettings : UpdateCanisterSettings;
+  InstallCode : NewInstallCode;
+  StopOrStartCanister : StopOrStartCanister;
+  CreateServiceNervousSystem : CreateServiceNervousSystem;
+  ExecuteNnsFunction : ExecuteNnsFunction;
+  RewardNodeProvider : RewardNodeProvider;
+  RewardNodeProviders : RewardNodeProviders;
+  ManageNetworkEconomics : NetworkEconomics;
+  ApproveGenesisKyc : Principals;
+  AddOrRemoveNodeProvider : AddOrRemoveNodeProvider;
+  Motion : Motion;
 };
 type NodeProvider = record {
   id : opt principal;
@@ -751,14 +800,14 @@ service : (Governance) -> {
   list_neurons : (ListNeurons) -> (ListNeuronsResponse) query;
   list_node_providers : () -> (ListNodeProvidersResponse) query;
   list_proposals : (ListProposalInfo) -> (ListProposalInfoResponse) query;
-  manage_neuron : (ManageNeuron) -> (ManageNeuronResponse);
+  manage_neuron : (NewManageNeuron) -> (ManageNeuronResponse);
   settle_community_fund_participation : (SettleCommunityFundParticipation) -> (
       Result,
     );
   settle_neurons_fund_participation : (
       SettleNeuronsFundParticipationRequest,
     ) -> (SettleNeuronsFundParticipationResponse);
-  simulate_manage_neuron : (ManageNeuron) -> (ManageNeuronResponse);
+  simulate_manage_neuron : (NewManageNeuron) -> (ManageNeuronResponse);
   transfer_gtc_neuron : (NeuronId, NeuronId) -> (Result);
   update_node_provider : (UpdateNodeProvider) -> (Result);
 }

--- a/rs/nns/governance/canister/governance_test.did
+++ b/rs/nns/governance/canister/governance_test.did
@@ -266,8 +266,6 @@ type InitialTokenDistribution = record {
   swap_distribution : opt SwapDistribution;
 };
 type InstallCode = record {
-  arg : opt blob;
-  wasm_module : opt blob;
   skip_stopping_before_installing : opt bool;
   wasm_module_hash : opt blob;
   canister_id : opt principal;

--- a/rs/nns/governance/canister/governance_test.did
+++ b/rs/nns/governance/canister/governance_test.did
@@ -269,7 +269,9 @@ type InstallCode = record {
   arg : opt blob;
   wasm_module : opt blob;
   skip_stopping_before_installing : opt bool;
+  wasm_module_hash : opt blob;
   canister_id : opt principal;
+  arg_hash : opt blob;
   install_mode : opt int32;
 };
 type KnownNeuron = record {
@@ -492,6 +494,53 @@ type NeuronsFundParticipation = record {
 };
 type NeuronsFundSnapshot = record {
   neurons_fund_neuron_portions : vec NeuronsFundNeuronPortion;
+};
+type NewInstallCode = record {
+  arg : opt blob;
+  wasm_module : opt blob;
+  skip_stopping_before_installing : opt bool;
+  canister_id : opt principal;
+  install_mode : opt int32;
+};
+type NewManageNeuron = record {
+  id : opt NeuronId;
+  command : opt NewManageNeuronCommand;
+  neuron_id_or_subaccount : opt NeuronIdOrSubaccount;
+};
+type NewManageNeuronCommand = variant {
+  Spawn : Spawn;
+  Split : Split;
+  Follow : Follow;
+  ClaimOrRefresh : ClaimOrRefresh;
+  Configure : Configure;
+  RegisterVote : RegisterVote;
+  Merge : Merge;
+  DisburseToNeuron : DisburseToNeuron;
+  MakeProposal : NewProposal;
+  StakeMaturity : StakeMaturity;
+  MergeMaturity : MergeMaturity;
+  Disburse : Disburse;
+};
+type NewProposal = record {
+  url : text;
+  title : opt text;
+  action : opt NewProposalAction;
+  summary : text;
+};
+type NewProposalAction = variant {
+  RegisterKnownNeuron : KnownNeuron;
+  ManageNeuron : NewManageNeuron;
+  UpdateCanisterSettings : UpdateCanisterSettings;
+  InstallCode : NewInstallCode;
+  StopOrStartCanister : StopOrStartCanister;
+  CreateServiceNervousSystem : CreateServiceNervousSystem;
+  ExecuteNnsFunction : ExecuteNnsFunction;
+  RewardNodeProvider : RewardNodeProvider;
+  RewardNodeProviders : RewardNodeProviders;
+  ManageNetworkEconomics : NetworkEconomics;
+  ApproveGenesisKyc : Principals;
+  AddOrRemoveNodeProvider : AddOrRemoveNodeProvider;
+  Motion : Motion;
 };
 type NodeProvider = record {
   id : opt principal;
@@ -751,14 +800,14 @@ service : (Governance) -> {
   list_neurons : (ListNeurons) -> (ListNeuronsResponse) query;
   list_node_providers : () -> (ListNodeProvidersResponse) query;
   list_proposals : (ListProposalInfo) -> (ListProposalInfoResponse) query;
-  manage_neuron : (ManageNeuron) -> (ManageNeuronResponse);
+  manage_neuron : (NewManageNeuron) -> (ManageNeuronResponse);
   settle_community_fund_participation : (SettleCommunityFundParticipation) -> (
       Result,
     );
   settle_neurons_fund_participation : (
       SettleNeuronsFundParticipationRequest,
     ) -> (SettleNeuronsFundParticipationResponse);
-  simulate_manage_neuron : (ManageNeuron) -> (ManageNeuronResponse);
+  simulate_manage_neuron : (NewManageNeuron) -> (ManageNeuronResponse);
   transfer_gtc_neuron : (NeuronId, NeuronId) -> (Result);
   update_neuron : (Neuron) -> (opt GovernanceError);
   update_node_provider : (UpdateNodeProvider) -> (Result);

--- a/rs/nns/governance/src/pb/conversions.rs
+++ b/rs/nns/governance/src/pb/conversions.rs
@@ -555,6 +555,16 @@ impl From<pb_api::Proposal> for pb::Proposal {
         }
     }
 }
+impl From<pb_api::NewProposal> for pb::Proposal {
+    fn from(item: pb_api::NewProposal) -> Self {
+        Self {
+            title: item.title,
+            summary: item.summary,
+            url: item.url,
+            action: item.action.map(|x| x.into()),
+        }
+    }
+}
 
 impl From<pb::proposal::Action> for pb_api::proposal::Action {
     fn from(item: pb::proposal::Action) -> Self {
@@ -656,6 +666,49 @@ impl From<pb_api::proposal::Action> for pb::proposal::Action {
         }
     }
 }
+impl From<pb_api::NewProposalAction> for pb::proposal::Action {
+    fn from(item: pb_api::NewProposalAction) -> Self {
+        match item {
+            pb_api::NewProposalAction::ManageNeuron(v) => {
+                pb::proposal::Action::ManageNeuron(Box::new((*v).into()))
+            }
+            pb_api::NewProposalAction::ManageNetworkEconomics(v) => {
+                pb::proposal::Action::ManageNetworkEconomics(v.into())
+            }
+            pb_api::NewProposalAction::Motion(v) => pb::proposal::Action::Motion(v.into()),
+            pb_api::NewProposalAction::ExecuteNnsFunction(v) => {
+                pb::proposal::Action::ExecuteNnsFunction(v.into())
+            }
+            pb_api::NewProposalAction::ApproveGenesisKyc(v) => {
+                pb::proposal::Action::ApproveGenesisKyc(v.into())
+            }
+            pb_api::NewProposalAction::AddOrRemoveNodeProvider(v) => {
+                pb::proposal::Action::AddOrRemoveNodeProvider(v.into())
+            }
+            pb_api::NewProposalAction::RewardNodeProvider(v) => {
+                pb::proposal::Action::RewardNodeProvider(v.into())
+            }
+            pb_api::NewProposalAction::RewardNodeProviders(v) => {
+                pb::proposal::Action::RewardNodeProviders(v.into())
+            }
+            pb_api::NewProposalAction::RegisterKnownNeuron(v) => {
+                pb::proposal::Action::RegisterKnownNeuron(v.into())
+            }
+            pb_api::NewProposalAction::CreateServiceNervousSystem(v) => {
+                pb::proposal::Action::CreateServiceNervousSystem(v.into())
+            }
+            pb_api::NewProposalAction::InstallCode(v) => {
+                pb::proposal::Action::InstallCode(v.into())
+            }
+            pb_api::NewProposalAction::StopOrStartCanister(v) => {
+                pb::proposal::Action::StopOrStartCanister(v.into())
+            }
+            pb_api::NewProposalAction::UpdateCanisterSettings(v) => {
+                pb::proposal::Action::UpdateCanisterSettings(v.into())
+            }
+        }
+    }
+}
 
 impl From<pb::Empty> for pb_api::Empty {
     fn from(_: pb::Empty) -> Self {
@@ -679,6 +732,15 @@ impl From<pb::ManageNeuron> for pb_api::ManageNeuron {
 }
 impl From<pb_api::ManageNeuron> for pb::ManageNeuron {
     fn from(item: pb_api::ManageNeuron) -> Self {
+        Self {
+            id: item.id,
+            neuron_id_or_subaccount: item.neuron_id_or_subaccount.map(|x| x.into()),
+            command: item.command.map(|x| x.into()),
+        }
+    }
+}
+impl From<pb_api::NewManageNeuron> for pb::ManageNeuron {
+    fn from(item: pb_api::NewManageNeuron) -> Self {
         Self {
             id: item.id,
             neuron_id_or_subaccount: item.neuron_id_or_subaccount.map(|x| x.into()),
@@ -1242,6 +1304,42 @@ impl From<pb_api::manage_neuron::Command> for pb::manage_neuron::Command {
             }
             pb_api::manage_neuron::Command::Merge(v) => pb::manage_neuron::Command::Merge(v.into()),
             pb_api::manage_neuron::Command::StakeMaturity(v) => {
+                pb::manage_neuron::Command::StakeMaturity(v.into())
+            }
+        }
+    }
+}
+impl From<pb_api::NewManageNeuronCommand> for pb::manage_neuron::Command {
+    fn from(item: pb_api::NewManageNeuronCommand) -> Self {
+        match item {
+            pb_api::NewManageNeuronCommand::Configure(v) => {
+                pb::manage_neuron::Command::Configure(v.into())
+            }
+            pb_api::NewManageNeuronCommand::Disburse(v) => {
+                pb::manage_neuron::Command::Disburse(v.into())
+            }
+            pb_api::NewManageNeuronCommand::Spawn(v) => pb::manage_neuron::Command::Spawn(v.into()),
+            pb_api::NewManageNeuronCommand::Follow(v) => {
+                pb::manage_neuron::Command::Follow(v.into())
+            }
+            pb_api::NewManageNeuronCommand::MakeProposal(v) => {
+                pb::manage_neuron::Command::MakeProposal(Box::new((*v).into()))
+            }
+            pb_api::NewManageNeuronCommand::RegisterVote(v) => {
+                pb::manage_neuron::Command::RegisterVote(v.into())
+            }
+            pb_api::NewManageNeuronCommand::Split(v) => pb::manage_neuron::Command::Split(v.into()),
+            pb_api::NewManageNeuronCommand::DisburseToNeuron(v) => {
+                pb::manage_neuron::Command::DisburseToNeuron(v.into())
+            }
+            pb_api::NewManageNeuronCommand::ClaimOrRefresh(v) => {
+                pb::manage_neuron::Command::ClaimOrRefresh(v.into())
+            }
+            pb_api::NewManageNeuronCommand::MergeMaturity(v) => {
+                pb::manage_neuron::Command::MergeMaturity(v.into())
+            }
+            pb_api::NewManageNeuronCommand::Merge(v) => pb::manage_neuron::Command::Merge(v.into()),
+            pb_api::NewManageNeuronCommand::StakeMaturity(v) => {
                 pb::manage_neuron::Command::StakeMaturity(v.into())
             }
         }
@@ -2784,6 +2882,25 @@ impl From<pb_api::create_service_nervous_system::governance_parameters::VotingRe
 
 impl From<pb::InstallCode> for pb_api::InstallCode {
     fn from(item: pb::InstallCode) -> Self {
+        let wasm_module_hash = item
+            .wasm_module
+            .map(|wasm_module| super::calculate_hash(&wasm_module).to_vec());
+        let arg_hash = item.arg.map(|arg| super::calculate_hash(&arg).to_vec());
+
+        Self {
+            canister_id: item.canister_id,
+            install_mode: item.install_mode,
+            wasm_module: None,
+            arg: None,
+            skip_stopping_before_installing: item.skip_stopping_before_installing,
+
+            wasm_module_hash,
+            arg_hash,
+        }
+    }
+}
+impl From<pb_api::InstallCode> for pb::InstallCode {
+    fn from(item: pb_api::InstallCode) -> Self {
         Self {
             canister_id: item.canister_id,
             install_mode: item.install_mode,
@@ -2793,8 +2910,8 @@ impl From<pb::InstallCode> for pb_api::InstallCode {
         }
     }
 }
-impl From<pb_api::InstallCode> for pb::InstallCode {
-    fn from(item: pb_api::InstallCode) -> Self {
+impl From<pb_api::NewInstallCode> for pb::InstallCode {
+    fn from(item: pb_api::NewInstallCode) -> Self {
         Self {
             canister_id: item.canister_id,
             install_mode: item.install_mode,

--- a/rs/nns/governance/src/pb/conversions.rs
+++ b/rs/nns/governance/src/pb/conversions.rs
@@ -2890,10 +2890,7 @@ impl From<pb::InstallCode> for pb_api::InstallCode {
         Self {
             canister_id: item.canister_id,
             install_mode: item.install_mode,
-            wasm_module: None,
-            arg: None,
             skip_stopping_before_installing: item.skip_stopping_before_installing,
-
             wasm_module_hash,
             arg_hash,
         }
@@ -2904,9 +2901,11 @@ impl From<pb_api::InstallCode> for pb::InstallCode {
         Self {
             canister_id: item.canister_id,
             install_mode: item.install_mode,
-            wasm_module: item.wasm_module,
-            arg: item.arg,
             skip_stopping_before_installing: item.skip_stopping_before_installing,
+            // Note: the api->internal conversion here only happens when decoding from protobuf in
+            // canister_init.
+            wasm_module: None,
+            arg: None,
         }
     }
 }

--- a/rs/nns/governance/src/pb/mod.rs
+++ b/rs/nns/governance/src/pb/mod.rs
@@ -1,4 +1,5 @@
 use crate::pb::v1::ArchivedMonthlyNodeProviderRewards;
+use ic_crypto_sha2::Sha256;
 use ic_stable_structures::{storable::Bound, Storable};
 use prost::Message;
 use std::borrow::Cow;
@@ -23,4 +24,11 @@ impl Storable for ArchivedMonthlyNodeProviderRewards {
     }
 
     const BOUND: Bound = Bound::Unbounded;
+}
+
+/// Calculates the SHA256 hash of the given bytes.
+fn calculate_hash(bytes: &[u8]) -> [u8; 32] {
+    let mut wasm_sha = Sha256::new();
+    wasm_sha.write(bytes);
+    wasm_sha.finish()
 }

--- a/rs/nns/governance/src/proposals/proposal_submission.rs
+++ b/rs/nns/governance/src/proposals/proposal_submission.rs
@@ -3,8 +3,8 @@
 use candid::{CandidType, Decode, Encode};
 use ic_nns_common::types::{NeuronId, ProposalId};
 use ic_nns_governance_api::pb::v1::{
-    manage_neuron::Command, manage_neuron_response::Command as CommandResponse, proposal,
-    ExecuteNnsFunction, ManageNeuron, ManageNeuronResponse, NnsFunction, Proposal,
+    manage_neuron::Command, manage_neuron_response::Command as CommandResponse, ExecuteNnsFunction,
+    ManageNeuron, ManageNeuronResponse, NewProposal, NewProposalAction, NnsFunction, Proposal,
 };
 
 /// Simplified the process of creating an ExternalUpdate proposal.
@@ -14,7 +14,7 @@ pub fn create_external_update_proposal_candid<T: CandidType>(
     url: &str,
     nns_function: NnsFunction,
     payload: T,
-) -> Proposal {
+) -> NewProposal {
     create_external_update_proposal_binary(
         title,
         summary,
@@ -30,12 +30,12 @@ pub fn create_external_update_proposal_binary(
     url: &str,
     nns_function: NnsFunction,
     payload: Vec<u8>,
-) -> Proposal {
-    Proposal {
+) -> NewProposal {
+    NewProposal {
         title: Some(title.to_string()),
         summary: summary.to_string(),
         url: url.to_string(),
-        action: Some(proposal::Action::ExecuteNnsFunction(ExecuteNnsFunction {
+        action: Some(NewProposalAction::ExecuteNnsFunction(ExecuteNnsFunction {
             nns_function: nns_function as i32,
             payload,
         })),

--- a/rs/nns/integration_tests/BUILD.bazel
+++ b/rs/nns/integration_tests/BUILD.bazel
@@ -417,6 +417,7 @@ rust_ic_test(
         "nns_tests_nightly",  # Run this test in the nns-tests-nightly GitHub Action job.
         "no-sandbox",  # such that the test can access the file $SSH_AUTH_SOCK.
         "requires-network",  # Because mainnet state is downloaded (and used).
+        "manual",
     ],
     deps = DEPENDENCIES + DEV_DEPENDENCIES,
 )

--- a/rs/nns/integration_tests/BUILD.bazel
+++ b/rs/nns/integration_tests/BUILD.bazel
@@ -414,10 +414,10 @@ rust_ic_test(
     env = DEV_ENV,
     proc_macro_deps = MACRO_DEPENDENCIES + MACRO_DEV_DEPENDENCIES,
     tags = [
+        "manual",
         "nns_tests_nightly",  # Run this test in the nns-tests-nightly GitHub Action job.
         "no-sandbox",  # such that the test can access the file $SSH_AUTH_SOCK.
         "requires-network",  # Because mainnet state is downloaded (and used).
-        "manual",
     ],
     deps = DEPENDENCIES + DEV_DEPENDENCIES,
 )

--- a/rs/nns/integration_tests/src/create_service_nervous_system.rs
+++ b/rs/nns/integration_tests/src/create_service_nervous_system.rs
@@ -11,12 +11,13 @@ use ic_nns_governance_api::pb::v1::{
     governance_error::ErrorType,
     manage_neuron::{self, RegisterVote},
     manage_neuron_response,
-    proposal,
+    proposal::Action,
     // Perhaps surprisingly, CreateServiceNervousSystem is not needed by
     // this file, because we simply use a constant of that type
     ManageNeuron,
     ManageNeuronResponse,
-    Proposal,
+    NewProposal,
+    NewProposalAction,
     ProposalStatus,
     Vote,
 };
@@ -142,7 +143,7 @@ fn test_several_proposals() {
         .into_iter()
         .filter_map(
             |proposal_info| match proposal_info.proposal.as_ref().unwrap().action {
-                Some(proposal::Action::CreateServiceNervousSystem(_)) => {
+                Some(Action::CreateServiceNervousSystem(_)) => {
                     let id = proposal_info.id.as_ref().unwrap().id;
                     Some((id, proposal_info))
                 }
@@ -189,11 +190,11 @@ fn make_proposal(state_machine: &StateMachine, sns_number: u64) -> ManageNeuronR
         state_machine,
         *TEST_NEURON_2_OWNER_PRINCIPAL,
         neuron_id,
-        &Proposal {
+        &NewProposal {
             title: Some(format!("Create SNS #{}", sns_number)),
             summary: "".to_string(),
             url: "".to_string(),
-            action: Some(proposal::Action::CreateServiceNervousSystem(
+            action: Some(NewProposalAction::CreateServiceNervousSystem(
                 CREATE_SERVICE_NERVOUS_SYSTEM_WITH_MATCHED_FUNDING
                     .clone()
                     .into(),

--- a/rs/nns/integration_tests/src/cycles_minting_canister_with_exchange_rate_canister.rs
+++ b/rs/nns/integration_tests/src/cycles_minting_canister_with_exchange_rate_canister.rs
@@ -8,7 +8,7 @@ use ic_nns_common::{
 };
 use ic_nns_constants::{EXCHANGE_RATE_CANISTER_ID, EXCHANGE_RATE_CANISTER_INDEX};
 use ic_nns_governance_api::pb::v1::{
-    manage_neuron_response, proposal::Action, ExecuteNnsFunction, NnsFunction, Proposal,
+    manage_neuron_response, ExecuteNnsFunction, NewProposal, NewProposalAction, NnsFunction,
 };
 use ic_nns_test_utils::{
     common::NnsInitPayloadsBuilder,
@@ -68,11 +68,11 @@ fn propose_icp_xdr_rate(
         id: TEST_NEURON_1_ID,
     };
 
-    let proposal = Proposal {
+    let proposal = NewProposal {
         title: Some(format!("Update ICP/XDR rate to {}", xdr_permyriad_per_icp)),
         summary: "".to_string(),
         url: "".to_string(),
-        action: Some(Action::ExecuteNnsFunction(ExecuteNnsFunction {
+        action: Some(NewProposalAction::ExecuteNnsFunction(ExecuteNnsFunction {
             nns_function: NnsFunction::IcpXdrConversionRate as i32,
             payload: Encode!(&payload).unwrap(),
         })),

--- a/rs/nns/integration_tests/src/known_neurons.rs
+++ b/rs/nns/integration_tests/src/known_neurons.rs
@@ -5,11 +5,10 @@ use ic_nervous_system_common_test_keys::{
 };
 use ic_nns_common::{pb::v1::NeuronId, types::ProposalId};
 use ic_nns_governance_api::pb::v1::{
-    manage_neuron::{Command, NeuronIdOrSubaccount},
-    manage_neuron_response::Command as CommandResponse,
-    proposal::Action,
-    GovernanceError, KnownNeuron, KnownNeuronData, ListKnownNeuronsResponse, ManageNeuron,
-    ManageNeuronResponse, NeuronInfo, Proposal, ProposalStatus,
+    manage_neuron::NeuronIdOrSubaccount, manage_neuron_response::Command as CommandResponse,
+    GovernanceError, KnownNeuron, KnownNeuronData, ListKnownNeuronsResponse, ManageNeuronResponse,
+    NeuronInfo, NewManageNeuron, NewManageNeuronCommand, NewProposal, NewProposalAction,
+    ProposalStatus,
 };
 use ic_nns_test_utils::{
     common::NnsInitPayloadsBuilder,
@@ -44,27 +43,29 @@ fn test_known_neurons() {
             .update_from_sender(
                 "manage_neuron",
                 candid_one,
-                ManageNeuron {
+                NewManageNeuron {
                     neuron_id_or_subaccount: Some(NeuronIdOrSubaccount::NeuronId(
                         ic_nns_common::pb::v1::NeuronId {
                             id: TEST_NEURON_1_ID,
                         },
                     )),
                     id: None,
-                    command: Some(Command::MakeProposal(Box::new(Proposal {
-                        title: Some("Naming neuron 2.".to_string()),
-                        summary: "".to_string(),
-                        url: "".to_string(),
-                        action: Some(Action::RegisterKnownNeuron(KnownNeuron {
-                            id: Some(NeuronId {
-                                id: TEST_NEURON_2_ID,
-                            }),
-                            known_neuron_data: Some(KnownNeuronData {
-                                name: "NeuronTwo".to_string(),
-                                description: None,
-                            }),
-                        })),
-                    }))),
+                    command: Some(NewManageNeuronCommand::MakeProposal(Box::new(
+                        NewProposal {
+                            title: Some("Naming neuron 2.".to_string()),
+                            summary: "".to_string(),
+                            url: "".to_string(),
+                            action: Some(NewProposalAction::RegisterKnownNeuron(KnownNeuron {
+                                id: Some(NeuronId {
+                                    id: TEST_NEURON_2_ID,
+                                }),
+                                known_neuron_data: Some(KnownNeuronData {
+                                    name: "NeuronTwo".to_string(),
+                                    description: None,
+                                }),
+                            })),
+                        },
+                    ))),
                 },
                 &Sender::from_keypair(&TEST_NEURON_1_OWNER_KEYPAIR),
             )
@@ -75,27 +76,29 @@ fn test_known_neurons() {
             .update_from_sender(
                 "manage_neuron",
                 candid_one,
-                ManageNeuron {
+                NewManageNeuron {
                     neuron_id_or_subaccount: Some(NeuronIdOrSubaccount::NeuronId(
                         ic_nns_common::pb::v1::NeuronId {
                             id: TEST_NEURON_1_ID,
                         },
                     )),
                     id: None,
-                    command: Some(Command::MakeProposal(Box::new(Proposal {
-                        title: Some("Naming neuron 3.".to_string()),
-                        summary: "".to_string(),
-                        url: "".to_string(),
-                        action: Some(Action::RegisterKnownNeuron(KnownNeuron {
-                            id: Some(NeuronId {
-                                id: TEST_NEURON_3_ID,
-                            }),
-                            known_neuron_data: Some(KnownNeuronData {
-                                name: "NeuronThree".to_string(),
-                                description: None,
-                            }),
-                        })),
-                    }))),
+                    command: Some(NewManageNeuronCommand::MakeProposal(Box::new(
+                        NewProposal {
+                            title: Some("Naming neuron 3.".to_string()),
+                            summary: "".to_string(),
+                            url: "".to_string(),
+                            action: Some(NewProposalAction::RegisterKnownNeuron(KnownNeuron {
+                                id: Some(NeuronId {
+                                    id: TEST_NEURON_3_ID,
+                                }),
+                                known_neuron_data: Some(KnownNeuronData {
+                                    name: "NeuronThree".to_string(),
+                                    description: None,
+                                }),
+                            })),
+                        },
+                    ))),
                 },
                 &Sender::from_keypair(&TEST_NEURON_1_OWNER_KEYPAIR),
             )

--- a/rs/nns/integration_tests/src/node_assignment.rs
+++ b/rs/nns/integration_tests/src/node_assignment.rs
@@ -6,12 +6,10 @@ use ic_nervous_system_common_test_keys::{
 };
 use ic_nns_common::types::{NeuronId, ProposalId};
 use ic_nns_governance_api::pb::v1::{
-    add_or_remove_node_provider::Change,
-    manage_neuron::{Command, NeuronIdOrSubaccount},
-    manage_neuron_response::Command as CommandResponse,
-    proposal::Action,
-    AddOrRemoveNodeProvider, ManageNeuron, ManageNeuronResponse, NnsFunction, NodeProvider,
-    Proposal, ProposalStatus,
+    add_or_remove_node_provider::Change, manage_neuron::NeuronIdOrSubaccount,
+    manage_neuron_response::Command as CommandResponse, AddOrRemoveNodeProvider,
+    ManageNeuronResponse, NewManageNeuron, NewManageNeuronCommand, NewProposal, NewProposalAction,
+    NnsFunction, NodeProvider, ProposalStatus,
 };
 use ic_nns_test_utils::{
     common::NnsInitPayloadsBuilder,
@@ -49,24 +47,28 @@ fn test_add_and_remove_nodes_from_registry() {
             .update_from_sender(
                 "manage_neuron",
                 candid_one,
-                ManageNeuron {
+                NewManageNeuron {
                     neuron_id_or_subaccount: Some(NeuronIdOrSubaccount::NeuronId(
                         ic_nns_common::pb::v1::NeuronId {
                             id: TEST_NEURON_1_ID,
                         },
                     )),
                     id: None,
-                    command: Some(Command::MakeProposal(Box::new(Proposal {
-                        title: Some("Just want to add this NP.".to_string()),
-                        summary: "".to_string(),
-                        url: "".to_string(),
-                        action: Some(Action::AddOrRemoveNodeProvider(AddOrRemoveNodeProvider {
-                            change: Some(Change::ToAdd(NodeProvider {
-                                id: Some(*TEST_NEURON_1_OWNER_PRINCIPAL),
-                                reward_account: None,
-                            })),
-                        })),
-                    }))),
+                    command: Some(NewManageNeuronCommand::MakeProposal(Box::new(
+                        NewProposal {
+                            title: Some("Just want to add this NP.".to_string()),
+                            summary: "".to_string(),
+                            url: "".to_string(),
+                            action: Some(NewProposalAction::AddOrRemoveNodeProvider(
+                                AddOrRemoveNodeProvider {
+                                    change: Some(Change::ToAdd(NodeProvider {
+                                        id: Some(*TEST_NEURON_1_OWNER_PRINCIPAL),
+                                        reward_account: None,
+                                    })),
+                                },
+                            )),
+                        },
+                    ))),
                 },
                 &Sender::from_keypair(&TEST_NEURON_1_OWNER_KEYPAIR),
             )

--- a/rs/nns/integration_tests/src/node_operator_handler.rs
+++ b/rs/nns/integration_tests/src/node_operator_handler.rs
@@ -8,12 +8,10 @@ use ic_nervous_system_common_test_keys::{
 };
 use ic_nns_common::types::{NeuronId, ProposalId};
 use ic_nns_governance_api::pb::v1::{
-    add_or_remove_node_provider::Change,
-    manage_neuron::{Command, NeuronIdOrSubaccount},
-    manage_neuron_response::Command as CommandResponse,
-    proposal::Action,
-    AddOrRemoveNodeProvider, ManageNeuron, ManageNeuronResponse, NnsFunction, NodeProvider,
-    Proposal, ProposalStatus,
+    add_or_remove_node_provider::Change, manage_neuron::NeuronIdOrSubaccount,
+    manage_neuron_response::Command as CommandResponse, AddOrRemoveNodeProvider,
+    ManageNeuronResponse, NewManageNeuron, NewManageNeuronCommand, NewProposal, NewProposalAction,
+    NnsFunction, NodeProvider, ProposalStatus,
 };
 use ic_nns_test_utils::{
     common::NnsInitPayloadsBuilder,
@@ -52,24 +50,28 @@ fn test_node_operator_records_can_be_added_and_removed() {
             .update_from_sender(
                 "manage_neuron",
                 candid_one,
-                ManageNeuron {
+                NewManageNeuron {
                     neuron_id_or_subaccount: Some(NeuronIdOrSubaccount::NeuronId(
                         ic_nns_common::pb::v1::NeuronId {
                             id: TEST_NEURON_1_ID,
                         },
                     )),
                     id: None,
-                    command: Some(Command::MakeProposal(Box::new(Proposal {
-                        title: Some("Just want to add this NP.".to_string()),
-                        summary: "".to_string(),
-                        url: "".to_string(),
-                        action: Some(Action::AddOrRemoveNodeProvider(AddOrRemoveNodeProvider {
-                            change: Some(Change::ToAdd(NodeProvider {
-                                id: Some(*TEST_NEURON_1_OWNER_PRINCIPAL),
-                                reward_account: None,
-                            })),
-                        })),
-                    }))),
+                    command: Some(NewManageNeuronCommand::MakeProposal(Box::new(
+                        NewProposal {
+                            title: Some("Just want to add this NP.".to_string()),
+                            summary: "".to_string(),
+                            url: "".to_string(),
+                            action: Some(NewProposalAction::AddOrRemoveNodeProvider(
+                                AddOrRemoveNodeProvider {
+                                    change: Some(Change::ToAdd(NodeProvider {
+                                        id: Some(*TEST_NEURON_1_OWNER_PRINCIPAL),
+                                        reward_account: None,
+                                    })),
+                                },
+                            )),
+                        },
+                    ))),
                 },
                 &Sender::from_keypair(&TEST_NEURON_1_OWNER_KEYPAIR),
             )

--- a/rs/nns/integration_tests/src/node_provider_remuneration.rs
+++ b/rs/nns/integration_tests/src/node_provider_remuneration.rs
@@ -13,10 +13,9 @@ use ic_nns_constants::{CYCLES_MINTING_CANISTER_ID, GOVERNANCE_CANISTER_ID, LEDGE
 use ic_nns_governance_api::pb::v1::{
     add_or_remove_node_provider::Change,
     manage_neuron_response::Command as CommandResponse,
-    proposal::Action,
     reward_node_provider::{RewardMode, RewardToAccount},
-    AddOrRemoveNodeProvider, ExecuteNnsFunction, GovernanceError, NetworkEconomics, NnsFunction,
-    NodeProvider, Proposal, RewardNodeProvider, RewardNodeProviders,
+    AddOrRemoveNodeProvider, ExecuteNnsFunction, GovernanceError, NetworkEconomics, NewProposal,
+    NewProposalAction, NnsFunction, NodeProvider, RewardNodeProvider, RewardNodeProviders,
 };
 use ic_nns_test_utils::{
     common::NnsInitPayloadsBuilder,
@@ -466,14 +465,14 @@ fn test_automated_node_provider_remuneration() {
 }
 
 /// Helper function for making NNS proposals for this test
-fn submit_nns_proposal(state_machine: &StateMachine, action: Action) {
+fn submit_nns_proposal(state_machine: &StateMachine, action: NewProposalAction) {
     let response = nns_governance_make_proposal(
         state_machine,
         Sender::from_keypair(&TEST_NEURON_1_OWNER_KEYPAIR).get_principal_id(),
         ProtoNeuronId {
             id: TEST_NEURON_1_ID,
         },
-        &Proposal {
+        &NewProposal {
             title: Some(
                 "<proposal created by test_automated_node_provider_remuneration>".to_string(),
             ),
@@ -577,7 +576,7 @@ fn assert_account_balance(state_machine: &StateMachine, account: AccountIdentifi
 fn reward_node_providers_via_registry(state_machine: &StateMachine) {
     submit_nns_proposal(
         state_machine,
-        Action::RewardNodeProviders(RewardNodeProviders {
+        NewProposalAction::RewardNodeProviders(RewardNodeProviders {
             rewards: vec![],
             use_registry_derived_rewards: Some(true),
         }),
@@ -613,7 +612,7 @@ fn add_data_centers(state_machine: &StateMachine) {
     };
     submit_nns_proposal(
         state_machine,
-        Action::ExecuteNnsFunction(ExecuteNnsFunction {
+        NewProposalAction::ExecuteNnsFunction(ExecuteNnsFunction {
             nns_function: NnsFunction::AddOrRemoveDataCenters as i32,
             payload: Encode!(&payload).unwrap(),
         }),
@@ -669,7 +668,7 @@ fn add_node_rewards_table(state_machine: &StateMachine) {
 
     submit_nns_proposal(
         state_machine,
-        Action::ExecuteNnsFunction(ExecuteNnsFunction {
+        NewProposalAction::ExecuteNnsFunction(ExecuteNnsFunction {
             nns_function: NnsFunction::UpdateNodeRewardsTable as i32,
             payload: Encode!(&payload).unwrap(),
         }),
@@ -679,7 +678,7 @@ fn add_node_rewards_table(state_machine: &StateMachine) {
 fn add_node_provider(state_machine: &StateMachine, node_provider: NodeProvider) {
     submit_nns_proposal(
         state_machine,
-        Action::AddOrRemoveNodeProvider(AddOrRemoveNodeProvider {
+        NewProposalAction::AddOrRemoveNodeProvider(AddOrRemoveNodeProvider {
             change: Some(Change::ToAdd(node_provider)),
         }),
     );
@@ -705,7 +704,7 @@ fn add_node_operator(
 
     submit_nns_proposal(
         state_machine,
-        Action::ExecuteNnsFunction(ExecuteNnsFunction {
+        NewProposalAction::ExecuteNnsFunction(ExecuteNnsFunction {
             nns_function: NnsFunction::AssignNoid as i32,
             payload: Encode!(&payload).unwrap(),
         }),

--- a/rs/nns/integration_tests/src/rewards.rs
+++ b/rs/nns/integration_tests/src/rewards.rs
@@ -8,12 +8,11 @@ use ic_nervous_system_common_test_keys::{
 use ic_nns_common::{pb::v1::NeuronId, types::ProposalId};
 use ic_nns_governance_api::pb::v1::{
     add_or_remove_node_provider::Change,
-    manage_neuron::{Command, NeuronIdOrSubaccount},
+    manage_neuron::NeuronIdOrSubaccount,
     manage_neuron_response::Command as CommandResponse,
-    proposal::Action,
     reward_node_provider::{RewardMode, RewardToAccount},
-    AddOrRemoveNodeProvider, ManageNeuron, ManageNeuronResponse, NodeProvider, Proposal,
-    ProposalStatus, RewardNodeProvider,
+    AddOrRemoveNodeProvider, ManageNeuronResponse, NewManageNeuron, NewManageNeuronCommand,
+    NewProposal, NewProposalAction, NodeProvider, ProposalStatus, RewardNodeProvider,
 };
 use ic_nns_test_utils::{
     common::NnsInitPayloadsBuilder,
@@ -55,22 +54,26 @@ fn test_node_provider_rewards() {
             .update_from_sender(
                 "manage_neuron",
                 candid_one,
-                ManageNeuron {
+                NewManageNeuron {
                     neuron_id_or_subaccount: Some(NeuronIdOrSubaccount::NeuronId(NeuronId {
                         id: TEST_NEURON_1_ID,
                     })),
                     id: None,
-                    command: Some(Command::MakeProposal(Box::new(Proposal {
-                        title: Some("Just want to add this NP.".to_string()),
-                        summary: "".to_string(),
-                        url: "".to_string(),
-                        action: Some(Action::AddOrRemoveNodeProvider(AddOrRemoveNodeProvider {
-                            change: Some(Change::ToAdd(NodeProvider {
-                                id: Some(np_pid),
-                                reward_account: None,
-                            })),
-                        })),
-                    }))),
+                    command: Some(NewManageNeuronCommand::MakeProposal(Box::new(
+                        NewProposal {
+                            title: Some("Just want to add this NP.".to_string()),
+                            summary: "".to_string(),
+                            url: "".to_string(),
+                            action: Some(NewProposalAction::AddOrRemoveNodeProvider(
+                                AddOrRemoveNodeProvider {
+                                    change: Some(Change::ToAdd(NodeProvider {
+                                        id: Some(np_pid),
+                                        reward_account: None,
+                                    })),
+                                },
+                            )),
+                        },
+                    ))),
                 },
                 &user,
             )
@@ -109,26 +112,32 @@ fn test_node_provider_rewards() {
             .update_from_sender(
                 "manage_neuron",
                 candid_one,
-                ManageNeuron {
+                NewManageNeuron {
                     neuron_id_or_subaccount: Some(NeuronIdOrSubaccount::NeuronId(NeuronId {
                         id: TEST_NEURON_1_ID,
                     })),
                     id: None,
-                    command: Some(Command::MakeProposal(Box::new(Proposal {
-                        title: Some("Just want to add this NP.".to_string()),
-                        summary: "".to_string(),
-                        url: "".to_string(),
-                        action: Some(Action::RewardNodeProvider(RewardNodeProvider {
-                            node_provider: Some(NodeProvider {
-                                id: Some(np_pid),
-                                reward_account: None,
-                            }),
-                            amount_e8s: 234 * 100_000_000,
-                            reward_mode: Some(RewardMode::RewardToAccount(RewardToAccount {
-                                to_account: Some(to_account.into()),
-                            })),
-                        })),
-                    }))),
+                    command: Some(NewManageNeuronCommand::MakeProposal(Box::new(
+                        NewProposal {
+                            title: Some("Just want to add this NP.".to_string()),
+                            summary: "".to_string(),
+                            url: "".to_string(),
+                            action: Some(NewProposalAction::RewardNodeProvider(
+                                RewardNodeProvider {
+                                    node_provider: Some(NodeProvider {
+                                        id: Some(np_pid),
+                                        reward_account: None,
+                                    }),
+                                    amount_e8s: 234 * 100_000_000,
+                                    reward_mode: Some(RewardMode::RewardToAccount(
+                                        RewardToAccount {
+                                            to_account: Some(to_account.into()),
+                                        },
+                                    )),
+                                },
+                            )),
+                        },
+                    ))),
                 },
                 &user,
             )

--- a/rs/nns/integration_tests/src/stop_or_start_canister.rs
+++ b/rs/nns/integration_tests/src/stop_or_start_canister.rs
@@ -6,8 +6,8 @@ use ic_nervous_system_root::change_canister::{
 };
 use ic_nns_constants::{REGISTRY_CANISTER_ID, ROOT_CANISTER_ID};
 use ic_nns_governance_api::pb::v1::{
-    manage_neuron_response::Command, proposal::Action, stop_or_start_canister::CanisterAction,
-    ExecuteNnsFunction, NnsFunction, Proposal, StopOrStartCanister,
+    manage_neuron_response::Command, stop_or_start_canister::CanisterAction, ExecuteNnsFunction,
+    NewProposal, NewProposalAction, NnsFunction, StopOrStartCanister,
 };
 use ic_nns_test_utils::{
     common::NnsInitPayloadsBuilder,
@@ -39,7 +39,7 @@ fn test_stop_and_start_registry_canister(use_proposal_action: bool) {
 
     // Step 3: Make a proposal to stop the canister and wait for it to be executed.
     let action = if use_proposal_action {
-        Action::StopOrStartCanister(StopOrStartCanister {
+        NewProposalAction::StopOrStartCanister(StopOrStartCanister {
             canister_id: Some(REGISTRY_CANISTER_ID.get()),
             action: Some(CanisterAction::Stop as i32),
         })
@@ -48,7 +48,7 @@ fn test_stop_and_start_registry_canister(use_proposal_action: bool) {
             canister_id: REGISTRY_CANISTER_ID,
             action: RootCanisterAction::Stop,
         };
-        Action::ExecuteNnsFunction(ExecuteNnsFunction {
+        NewProposalAction::ExecuteNnsFunction(ExecuteNnsFunction {
             nns_function: NnsFunction::StopOrStartNnsCanister as i32,
             payload: Encode!(&stop_or_start_request).unwrap(),
         })
@@ -57,7 +57,7 @@ fn test_stop_and_start_registry_canister(use_proposal_action: bool) {
         &state_machine,
         n1.principal_id,
         n1.neuron_id,
-        &Proposal {
+        &NewProposal {
             title: Some("Stop registry canister".to_string()),
             action: Some(action),
             ..Default::default()
@@ -74,7 +74,7 @@ fn test_stop_and_start_registry_canister(use_proposal_action: bool) {
 
     // Step 5: Make a proposal to start the canister and wait for it to be executed.
     let action = if use_proposal_action {
-        Action::StopOrStartCanister(StopOrStartCanister {
+        NewProposalAction::StopOrStartCanister(StopOrStartCanister {
             canister_id: Some(REGISTRY_CANISTER_ID.get()),
             action: Some(CanisterAction::Start as i32),
         })
@@ -83,7 +83,7 @@ fn test_stop_and_start_registry_canister(use_proposal_action: bool) {
             canister_id: REGISTRY_CANISTER_ID,
             action: RootCanisterAction::Start,
         };
-        Action::ExecuteNnsFunction(ExecuteNnsFunction {
+        NewProposalAction::ExecuteNnsFunction(ExecuteNnsFunction {
             nns_function: NnsFunction::StopOrStartNnsCanister as i32,
             payload: Encode!(&stop_or_start_request).unwrap(),
         })
@@ -92,7 +92,7 @@ fn test_stop_and_start_registry_canister(use_proposal_action: bool) {
         &state_machine,
         n1.principal_id,
         n1.neuron_id,
-        &Proposal {
+        &NewProposal {
             title: Some("Start registry canister".to_string()),
             action: Some(action),
             ..Default::default()

--- a/rs/nns/integration_tests/src/subnet_rental_canister.rs
+++ b/rs/nns/integration_tests/src/subnet_rental_canister.rs
@@ -8,8 +8,7 @@ use ic_nns_constants::{
 };
 use ic_nns_governance_api::pb::v1::{
     manage_neuron_response::{Command as CommandResponse, RegisterVoteResponse},
-    proposal::Action,
-    ExecuteNnsFunction, NnsFunction, Proposal, Vote,
+    ExecuteNnsFunction, NewProposal, NewProposalAction, NnsFunction, Vote,
 };
 use ic_nns_test_utils::{
     common::NnsInitPayloadsBuilder,
@@ -246,11 +245,11 @@ fn subnet_rental_request_lifecycle() {
         user: renter,
         rental_condition_id: RentalConditionId::App13CH,
     };
-    let proposal = Proposal {
+    let proposal = NewProposal {
         title: Some("Create subnet rental request".to_string()),
         summary: "".to_string(),
         url: "".to_string(),
-        action: Some(Action::ExecuteNnsFunction(ExecuteNnsFunction {
+        action: Some(NewProposalAction::ExecuteNnsFunction(ExecuteNnsFunction {
             nns_function: NnsFunction::SubnetRentalRequest as i32,
             payload: Encode!(&subnet_rental_request).expect("Error encoding proposal payload"),
         })),
@@ -396,11 +395,11 @@ fn test_renting_a_subnet_without_paying_fails() {
         user: renter,
         rental_condition_id: RentalConditionId::App13CH,
     };
-    let proposal = Proposal {
+    let proposal = NewProposal {
         title: Some("Create subnet rental request".to_string()),
         summary: "".to_string(),
         url: "".to_string(),
-        action: Some(Action::ExecuteNnsFunction(ExecuteNnsFunction {
+        action: Some(NewProposalAction::ExecuteNnsFunction(ExecuteNnsFunction {
             nns_function: NnsFunction::SubnetRentalRequest as i32,
             payload: Encode!(&subnet_rental_request).expect("Error encoding proposal payload"),
         })),

--- a/rs/nns/integration_tests/src/uninstall_canister_by_proposal.rs
+++ b/rs/nns/integration_tests/src/uninstall_canister_by_proposal.rs
@@ -4,8 +4,7 @@ use ic_nervous_system_clients::canister_id_record::CanisterIdRecord;
 use ic_nns_constants::LIFELINE_CANISTER_INDEX_IN_NNS_SUBNET;
 use ic_nns_governance_api::pb::v1::{
     manage_neuron_response::{Command, MakeProposalResponse},
-    proposal::Action,
-    ExecuteNnsFunction, NnsFunction, Proposal,
+    ExecuteNnsFunction, NewProposal, NewProposalAction, NnsFunction,
 };
 use ic_nns_test_utils::{
     common::NnsInitPayloadsBuilder,
@@ -50,11 +49,11 @@ fn uninstall_canister_by_proposal() {
     let status = get_canister_status_from_root(&state_machine, canister_id);
     assert!(status.module_hash.is_some());
     // Prepare a proposal to uninstall canister code
-    let proposal = Proposal {
+    let proposal = NewProposal {
         title: Some("<proposal to uninstall an NNS canister>".to_string()),
         summary: "".to_string(),
         url: "".to_string(),
-        action: Some(Action::ExecuteNnsFunction(ExecuteNnsFunction {
+        action: Some(NewProposalAction::ExecuteNnsFunction(ExecuteNnsFunction {
             nns_function: NnsFunction::UninstallCode as i32,
             payload: Encode!(&CanisterIdRecord { canister_id })
                 .expect("Error encoding proposal payload"),

--- a/rs/nns/integration_tests/src/update_canister_settings.rs
+++ b/rs/nns/integration_tests/src/update_canister_settings.rs
@@ -4,11 +4,10 @@ use ic_nervous_system_clients::canister_status::{DefiniteCanisterSettings, LogVi
 use ic_nns_constants::{REGISTRY_CANISTER_ID, ROOT_CANISTER_ID};
 use ic_nns_governance_api::pb::v1::{
     manage_neuron_response::Command,
-    proposal::Action,
     update_canister_settings::{
         CanisterSettings, Controllers, LogVisibility as GovernanceLogVisibility,
     },
-    Proposal, UpdateCanisterSettings,
+    NewProposal, NewProposalAction, UpdateCanisterSettings,
 };
 use ic_nns_test_utils::{
     common::NnsInitPayloadsBuilder,
@@ -70,21 +69,23 @@ fn test_update_canister_settings() {
         &state_machine,
         n1.principal_id,
         n1.neuron_id,
-        &Proposal {
+        &NewProposal {
             title: Some("Update canister settings".to_string()),
-            action: Some(Action::UpdateCanisterSettings(UpdateCanisterSettings {
-                canister_id: Some(REGISTRY_CANISTER_ID.get()),
-                settings: Some(CanisterSettings {
-                    controllers: Some(Controllers {
-                        controllers: target_controllers.clone(),
+            action: Some(NewProposalAction::UpdateCanisterSettings(
+                UpdateCanisterSettings {
+                    canister_id: Some(REGISTRY_CANISTER_ID.get()),
+                    settings: Some(CanisterSettings {
+                        controllers: Some(Controllers {
+                            controllers: target_controllers.clone(),
+                        }),
+                        memory_allocation: Some(target_memory_allocation),
+                        compute_allocation: Some(target_compute_allocation),
+                        freezing_threshold: Some(target_freezing_threshold),
+                        wasm_memory_limit: Some(target_wasm_memory_limit),
+                        log_visibility: Some(GovernanceLogVisibility::Public as i32),
                     }),
-                    memory_allocation: Some(target_memory_allocation),
-                    compute_allocation: Some(target_compute_allocation),
-                    freezing_threshold: Some(target_freezing_threshold),
-                    wasm_memory_limit: Some(target_wasm_memory_limit),
-                    log_visibility: Some(GovernanceLogVisibility::Public as i32),
-                }),
-            })),
+                },
+            )),
             ..Default::default()
         },
     );

--- a/rs/nns/integration_tests/src/wait_for_quiet.rs
+++ b/rs/nns/integration_tests/src/wait_for_quiet.rs
@@ -9,12 +9,11 @@ use ic_nns_common::pb::v1::NeuronId;
 use ic_nns_governance::governance::TimeWarp;
 use ic_nns_governance_api::pb::v1::{
     add_or_remove_node_provider::Change,
-    manage_neuron::{self, Command, NeuronIdOrSubaccount},
+    manage_neuron::{self, NeuronIdOrSubaccount},
     manage_neuron_response::Command as CommandResponse,
     neuron::DissolveState,
-    proposal::Action,
-    AddOrRemoveNodeProvider, ManageNeuron, ManageNeuronResponse, Neuron, NodeProvider, Proposal,
-    ProposalInfo, Vote,
+    AddOrRemoveNodeProvider, ManageNeuronResponse, Neuron, NewManageNeuron, NewManageNeuronCommand,
+    NewProposal, NewProposalAction, NodeProvider, ProposalInfo, Vote,
 };
 use ic_nns_test_utils::{
     common::NnsInitPayloadsBuilder,
@@ -60,22 +59,26 @@ fn test_deadline_is_extended_with_wait_for_quiet() {
             .update_from_sender(
                 "manage_neuron",
                 candid_one,
-                ManageNeuron {
+                NewManageNeuron {
                     neuron_id_or_subaccount: Some(NeuronIdOrSubaccount::NeuronId(NeuronId {
                         id: TEST_NEURON_2_ID,
                     })),
                     id: None,
-                    command: Some(Command::MakeProposal(Box::new(Proposal {
-                        title: Some("Just want to add this NP.".to_string()),
-                        summary: "".to_string(),
-                        url: "".to_string(),
-                        action: Some(Action::AddOrRemoveNodeProvider(AddOrRemoveNodeProvider {
-                            change: Some(Change::ToAdd(NodeProvider {
-                                id: Some(*TEST_NEURON_1_OWNER_PRINCIPAL),
-                                reward_account: None,
-                            })),
-                        })),
-                    }))),
+                    command: Some(NewManageNeuronCommand::MakeProposal(Box::new(
+                        NewProposal {
+                            title: Some("Just want to add this NP.".to_string()),
+                            summary: "".to_string(),
+                            url: "".to_string(),
+                            action: Some(NewProposalAction::AddOrRemoveNodeProvider(
+                                AddOrRemoveNodeProvider {
+                                    change: Some(Change::ToAdd(NodeProvider {
+                                        id: Some(*TEST_NEURON_1_OWNER_PRINCIPAL),
+                                        reward_account: None,
+                                    })),
+                                },
+                            )),
+                        },
+                    ))),
                 },
                 &Sender::from_keypair(&TEST_NEURON_2_OWNER_KEYPAIR),
             )
@@ -116,13 +119,15 @@ fn test_deadline_is_extended_with_wait_for_quiet() {
             .update_from_sender(
                 "manage_neuron",
                 candid_one,
-                ManageNeuron {
+                NewManageNeuron {
                     neuron_id_or_subaccount: Some(NeuronIdOrSubaccount::NeuronId(neuron_id_4)),
                     id: None,
-                    command: Some(Command::RegisterVote(manage_neuron::RegisterVote {
-                        proposal: Some(pid),
-                        vote: Vote::No as i32,
-                    })),
+                    command: Some(NewManageNeuronCommand::RegisterVote(
+                        manage_neuron::RegisterVote {
+                            proposal: Some(pid),
+                            vote: Vote::No as i32,
+                        },
+                    )),
                 },
                 &Sender::from_keypair(neuron_4_owner_keypair),
             )

--- a/rs/nns/test_utils/src/neuron_helpers.rs
+++ b/rs/nns/test_utils/src/neuron_helpers.rs
@@ -6,8 +6,8 @@ use ic_nervous_system_common_test_keys::{
 };
 use ic_nns_common::{pb::v1::NeuronId, types::ProposalId};
 use ic_nns_governance_api::pb::v1::{
-    manage_neuron_response::Command, proposal::Action, ExecuteNnsFunction, Neuron, NnsFunction,
-    Proposal,
+    manage_neuron_response::Command, ExecuteNnsFunction, Neuron, NewProposal, NewProposalAction,
+    NnsFunction,
 };
 use ic_state_machine_tests::StateMachine;
 use std::collections::HashMap;
@@ -65,12 +65,12 @@ pub fn get_neuron_3() -> TestNeuronOwner {
     }
 }
 
-pub fn get_some_proposal() -> Proposal {
-    Proposal {
+pub fn get_some_proposal() -> NewProposal {
+    NewProposal {
         title: Some("<proposal created from initialization>".to_string()),
         summary: "".to_string(),
         url: "".to_string(),
-        action: Some(Action::ExecuteNnsFunction(ExecuteNnsFunction {
+        action: Some(NewProposalAction::ExecuteNnsFunction(ExecuteNnsFunction {
             nns_function: NnsFunction::NnsRootUpgrade as i32,
             payload: Vec::new(),
         })),

--- a/rs/sns/integration_tests/src/initialization_flow.rs
+++ b/rs/sns/integration_tests/src/initialization_flow.rs
@@ -17,9 +17,7 @@ use ic_nns_governance_api::pb::v1::{
         swap_parameters::NeuronBasketConstructionParameters,
         GovernanceParameters, InitialTokenDistribution, LedgerParameters, SwapParameters,
     },
-    manage_neuron_response,
-    proposal::Action,
-    CreateServiceNervousSystem, Proposal,
+    manage_neuron_response, CreateServiceNervousSystem, NewProposal, NewProposalAction,
 };
 use ic_nns_test_utils::{
     common::NnsInitPayloadsBuilder,
@@ -235,11 +233,11 @@ impl SnsInitializationFlowTestSetup {
         neuron_id: NeuronId,
         create_service_nervous_system: &CreateServiceNervousSystem,
     ) -> ProposalId {
-        let proposal = Proposal {
+        let proposal = NewProposal {
             title: Some("Proposal to create the SNS-2 ServiceNervousSystem".to_string()),
             summary: "Please do this, if anything just so that the test can pass.".to_string(),
             url: "".to_string(),
-            action: Some(Action::CreateServiceNervousSystem(
+            action: Some(NewProposalAction::CreateServiceNervousSystem(
                 create_service_nervous_system.clone(),
             )),
         };


### PR DESCRIPTION
# Why

The `wasm_module` and `arg` in the InstallCode proposals can be large (especially `wasm_module`), and in most cases, a client is not expected to look at the full WASM anyway. It would be nice if the NNS Governance always returns the hashes while it stores the large blobs for execution.

# Background

## Separated API/Internal Types

Because of the recent work by @max-dfinity , now the NNS Governance has separate API types and internal types, which makes it possible for them to diverge

## InstallCode Proposal

The `InstallCode` proposal replaces the `NnsCanisterUpgrade` NNS Function, and unlike the NNS Function, the `Installcode` proposal is a type known to NNS Governance, so it will be possible for the API/internal types to specify 2 different versions of them: the API type has the hashes, while the internal type has the large blobs.

# What

Since there still needs to be an API type for the request (making such proposal) which includes the blobs, we create a set of API types for requests `New...`, the request types have the blobs while the response types have the hashes. The internal types still have the blobs.

# Why it's prototype

This is a breaking change, so we need some communication, and a closer look to make sure we actually don't depend on the proposals returning the blobs.