### PR TITLE
fix: disable node exporter netlink metrics collection

### DIFF
--- a/ic-os/components/monitoring/node_exporter/node_exporter
+++ b/ic-os/components/monitoring/node_exporter/node_exporter
@@ -1,1 +1,1 @@
-OPTIONS="--web.config.file='/etc/node_exporter/web.yml' --collector.textfile.directory='/run/node_exporter/collector_textfile'"
+OPTIONS="--web.config.file='/etc/node_exporter/web.yml' --collector.textfile.directory='/run/node_exporter/collector_textfile' --no-collector.netdev.netlink --no-collector.arp.netlink"

--- a/ic-os/components/prep/guestos/node_exporter/node_exporter.te
+++ b/ic-os/components/prep/guestos/node_exporter/node_exporter.te
@@ -115,3 +115,6 @@ require {
     type user_runtime_root_t;
 }
 allow node_exporter_t user_runtime_root_t:dir { search };
+
+# Allow node_exporter to create and use netlink route sockets
+allow node_exporter_t self:netlink_route_socket create_netlink_socket_perms;

--- a/ic-os/components/prep/guestos/node_exporter/node_exporter.te
+++ b/ic-os/components/prep/guestos/node_exporter/node_exporter.te
@@ -115,13 +115,3 @@ require {
     type user_runtime_root_t;
 }
 allow node_exporter_t user_runtime_root_t:dir { search };
-
-# Allow node_exporter to create and use netlink route sockets
-allow node_exporter_t self:netlink_route_socket create_netlink_socket_perms;
-
-# Allow getattr, search, open, read, lock, ioctl (list_dir_perms) from /var/run/udev
-require {
-    type udev_var_run_t;
-}
-allow node_exporter_t udev_var_run_t:dir list_dir_perms;
-

--- a/ic-os/components/prep/guestos/node_exporter/node_exporter.te
+++ b/ic-os/components/prep/guestos/node_exporter/node_exporter.te
@@ -118,3 +118,10 @@ allow node_exporter_t user_runtime_root_t:dir { search };
 
 # Allow node_exporter to create and use netlink route sockets
 allow node_exporter_t self:netlink_route_socket create_netlink_socket_perms;
+
+# Allow getattr, search, open, read, lock, ioctl (list_dir_perms) from /var/run/udev
+require {
+    type udev_var_run_t;
+}
+allow node_exporter_t udev_var_run_t:dir list_dir_perms;
+


### PR DESCRIPTION
Recently the node exporter was upgraded from 1.2 to 1.8. With this change the `arp` and `netdev` collector switched to using `netlink` to collect metrics. The current selinux policy on the guestos does not allow the node exporter process to open netlink socket and therfore the the `arp` and `netdev` metrics are currently missing.

This MR disables the netlink metrics scarping by switching back to scaping `/proc/net/dev` as was done by default before version 1.4.