### PR TITLE
fix: adding missing tag for build-image.sh

### DIFF
--- a/gitlab-ci/container/build-image.sh
+++ b/gitlab-ci/container/build-image.sh
@@ -41,6 +41,7 @@ DOCKER_BUILDKIT=1 docker "${ARGS[@]}" build "${BUILD_ARGS[@]}" \
     -t docker.io/dfinity/ic-build:"$DOCKER_IMG_TAG" \
     -t docker.io/dfinity/ic-build:latest \
     -t registry.gitlab.com/dfinity-lab/core/docker/ic-build:"$DOCKER_IMG_TAG" \
+    -t ghcr.io/dfinity/ic-build:"$DOCKER_IMG_TAG" \
     --build-arg RUST_VERSION="$RUST_VERSION" \
     -f gitlab-ci/container/Dockerfile .
 


### PR DESCRIPTION
Fallback option if we cannot pull the ic-build image is to build the image locally. We were missing a tag after migrating to ghcr.io as a container registry. This PR adds it back.