### PR TITLE
feat(ckerc20): Use EVM-RPC canister to call `eth_sendRawTransaction`

### DIFF
--- a/rs/ethereum/cketh/minter/src/eth_rpc.rs
+++ b/rs/ethereum/cketh/minter/src/eth_rpc.rs
@@ -9,7 +9,10 @@ use crate::numeric::{BlockNumber, LogIndex, TransactionCount, Wei, WeiPerGas};
 use crate::state::{mutate_state, State};
 use candid::{candid_method, CandidType, Principal};
 use ethnum;
-use evm_rpc_client::types::candid::HttpOutcallError as EvmHttpOutcallError;
+use evm_rpc_client::types::candid::{
+    HttpOutcallError as EvmHttpOutcallError,
+    SendRawTransactionStatus as EvmSendRawTransactionStatus,
+};
 use ic_canister_log::log;
 use ic_cdk::api::call::{call_with_payment128, RejectionCode};
 use ic_cdk::api::management_canister::http_request::{
@@ -121,6 +124,19 @@ pub enum SendRawTransactionResult {
     InsufficientFunds,
     NonceTooLow,
     NonceTooHigh,
+}
+
+impl From<EvmSendRawTransactionStatus> for SendRawTransactionResult {
+    fn from(value: EvmSendRawTransactionStatus) -> Self {
+        match value {
+            EvmSendRawTransactionStatus::Ok(_) => SendRawTransactionResult::Ok,
+            EvmSendRawTransactionStatus::InsufficientFunds => {
+                SendRawTransactionResult::InsufficientFunds
+            }
+            EvmSendRawTransactionStatus::NonceTooLow => SendRawTransactionResult::NonceTooLow,
+            EvmSendRawTransactionStatus::NonceTooHigh => SendRawTransactionResult::NonceTooHigh,
+        }
+    }
 }
 
 impl HttpResponsePayload for SendRawTransactionResult {

--- a/rs/ethereum/cketh/minter/src/eth_rpc_client/mod.rs
+++ b/rs/ethereum/cketh/minter/src/eth_rpc_client/mod.rs
@@ -792,18 +792,9 @@ impl Reduce for EvmMultiRpcResult<EvmSendRawTransactionStatus> {
     fn reduce(self) -> ReducedResult<Self::Item> {
         ReducedResult::from_internal(self).map_reduce(
             &|tx_status| {
-                Ok::<SendRawTransactionResult, Infallible>(match tx_status {
-                    EvmSendRawTransactionStatus::Ok(_) => SendRawTransactionResult::Ok,
-                    EvmSendRawTransactionStatus::InsufficientFunds => {
-                        SendRawTransactionResult::InsufficientFunds
-                    }
-                    EvmSendRawTransactionStatus::NonceTooLow => {
-                        SendRawTransactionResult::NonceTooLow
-                    }
-                    EvmSendRawTransactionStatus::NonceTooHigh => {
-                        SendRawTransactionResult::NonceTooHigh
-                    }
-                })
+                Ok::<SendRawTransactionResult, Infallible>(SendRawTransactionResult::from(
+                    tx_status,
+                ))
             },
             |results| results.at_least_one_ok().map(|(_provider, result)| result),
         )

--- a/rs/ethereum/cketh/minter/src/eth_rpc_client/mod.rs
+++ b/rs/ethereum/cketh/minter/src/eth_rpc_client/mod.rs
@@ -14,13 +14,13 @@ use crate::logs::{PrintProxySink, DEBUG, INFO, TRACE_HTTP};
 use crate::numeric::{BlockNumber, GasAmount, LogIndex, TransactionCount, Wei, WeiPerGas};
 use crate::state::State;
 use candid::Nat;
-use evm_rpc_client::types::candid::RpcConfig;
 use evm_rpc_client::{
     types::candid::{
         Block as EvmBlock, BlockTag as EvmBlockTag, FeeHistory as EvmFeeHistory,
         FeeHistoryArgs as EvmFeeHistoryArgs, GetLogsArgs as EvmGetLogsArgs,
         GetTransactionCountArgs as EvmGetTransactionCountArgs, LogEntry as EvmLogEntry,
-        MultiRpcResult as EvmMultiRpcResult, RpcError as EvmRpcError, RpcResult as EvmRpcResult,
+        MultiRpcResult as EvmMultiRpcResult, RpcConfig as EvmRpcConfig, RpcError as EvmRpcError,
+        RpcResult as EvmRpcResult, SendRawTransactionStatus as EvmSendRawTransactionStatus,
         TransactionReceipt as EvmTransactionReceipt,
     },
     EvmRpcClient, IcRuntime, OverrideRpcConfig,
@@ -30,6 +30,7 @@ use ic_ethereum_types::Address;
 use num_traits::ToPrimitive;
 use serde::{de::DeserializeOwned, Serialize};
 use std::collections::{BTreeMap, BTreeSet};
+use std::convert::Infallible;
 use std::fmt::{Debug, Display};
 use std::str::FromStr;
 
@@ -72,7 +73,7 @@ impl EthRpcClient {
                     .with_evm_canister_id(evm_rpc_id)
                     .with_min_attached_cycles(MIN_ATTACHED_CYCLES)
                     .with_override_rpc_config(OverrideRpcConfig {
-                        eth_get_logs: Some(RpcConfig {
+                        eth_get_logs: Some(EvmRpcConfig {
                             response_size_estimate: Some(
                                 ETH_GET_LOGS_INITIAL_RESPONSE_SIZE_ESTIMATE + HEADER_SIZE_LIMIT,
                             ),
@@ -102,12 +103,12 @@ impl EthRpcClient {
         method: impl Into<String> + Clone,
         params: I,
         response_size_estimate: ResponseSizeEstimate,
-    ) -> HttpOutcallResult<JsonRpcResult<O>>
+    ) -> MultiCallResults<O>
     where
         I: Serialize + Clone,
         O: DeserializeOwned + HttpResponsePayload + Debug,
     {
-        let mut last_result: Option<HttpOutcallResult<JsonRpcResult<O>>> = None;
+        let mut results: MultiCallResults<O> = MultiCallResults::new();
         for provider in self.providers() {
             log!(
                 DEBUG,
@@ -121,22 +122,21 @@ impl EthRpcClient {
                 response_size_estimate,
             )
             .await;
-            match result {
-                Ok(JsonRpcResult::Result(value)) => return Ok(JsonRpcResult::Result(value)),
-                Ok(json_rpc_error @ JsonRpcResult::Error { .. }) => {
-                    log!(
-                        INFO,
-                        "Provider {provider:?} returned JSON-RPC error {json_rpc_error:?}",
-                    );
-                    last_result = Some(Ok(json_rpc_error));
+            //TODO XC-163: change eth_rpc::call to directly return a
+            // Result<O, SingleCallError>
+            let result: Result<O, SingleCallError> = match result {
+                Ok(JsonRpcResult::Result(value)) => Ok(value),
+                Ok(JsonRpcResult::Error { code, message }) => {
+                    Err(SingleCallError::JsonRpcError { code, message })
                 }
-                Err(e) => {
-                    log!(INFO, "Querying provider {provider:?} returned error {e:?}");
-                    last_result = Some(Err(e));
-                }
+                Err(error) => Err(SingleCallError::HttpOutcallError(error)),
             };
+            results.insert_once(provider.clone(), result);
+            if results.has_ok_results() {
+                return results;
+            }
         }
-        last_result.unwrap_or_else(|| panic!("BUG: No providers in RPC client {:?}", self))
+        results
     }
 
     /// Query all providers in parallel and return all results.
@@ -276,15 +276,24 @@ impl EthRpcClient {
     pub async fn eth_send_raw_transaction(
         &self,
         raw_signed_transaction_hex: String,
-    ) -> HttpOutcallResult<JsonRpcResult<SendRawTransactionResult>> {
+    ) -> Result<SendRawTransactionResult, MultiCallError<SendRawTransactionResult>> {
+        if let Some(evm_rpc_client) = &self.evm_rpc_client {
+            return evm_rpc_client
+                .eth_send_raw_transaction(raw_signed_transaction_hex)
+                .await
+                .reduce()
+                .into();
+        }
         // A successful reply is under 256 bytes, but we expect most calls to end with an error
         // since we submit the same transaction from multiple nodes.
-        self.sequential_call_until_ok(
-            "eth_sendRawTransaction",
-            vec![raw_signed_transaction_hex],
-            ResponseSizeEstimate::new(256),
-        )
-        .await
+        let results: MultiCallResults<SendRawTransactionResult> = self
+            .sequential_call_until_ok(
+                "eth_sendRawTransaction",
+                vec![raw_signed_transaction_hex],
+                ResponseSizeEstimate::new(256),
+            )
+            .await;
+        results.reduce().into()
     }
 
     pub async fn eth_get_finalized_transaction_count(
@@ -399,6 +408,10 @@ impl<T> MultiCallResults<T> {
         }
     }
 
+    fn has_ok_results(&self) -> bool {
+        !self.ok_results.is_empty()
+    }
+
     fn from_non_empty_iter<
         I: IntoIterator<Item = (RpcNodeProvider, HttpOutcallResult<JsonRpcResult<T>>)>,
     >(
@@ -460,6 +473,13 @@ impl<T: PartialEq> MultiCallResults<T> {
             0 => Err(self.expect_error()),
             1 => Err(MultiCallError::InconsistentResults(self)),
             _ => Ok(self.ok_results),
+        }
+    }
+
+    fn at_least_one_ok(self) -> Result<(RpcNodeProvider, T), MultiCallError<T>> {
+        match self.ok_results.len() {
+            0 => Err(self.expect_error()),
+            _ => Ok(self.ok_results.into_iter().next().unwrap()),
         }
     }
 
@@ -763,6 +783,40 @@ impl Reduce for MultiCallResults<Option<TransactionReceipt>> {
 
     fn reduce(self) -> ReducedResult<Self::Item> {
         self.reduce_with_equality().into()
+    }
+}
+
+impl Reduce for EvmMultiRpcResult<EvmSendRawTransactionStatus> {
+    type Item = SendRawTransactionResult;
+
+    fn reduce(self) -> ReducedResult<Self::Item> {
+        ReducedResult::from_internal(self).map_reduce(
+            &|tx_status| {
+                Ok::<SendRawTransactionResult, Infallible>(match tx_status {
+                    EvmSendRawTransactionStatus::Ok(_) => SendRawTransactionResult::Ok,
+                    EvmSendRawTransactionStatus::InsufficientFunds => {
+                        SendRawTransactionResult::InsufficientFunds
+                    }
+                    EvmSendRawTransactionStatus::NonceTooLow => {
+                        SendRawTransactionResult::NonceTooLow
+                    }
+                    EvmSendRawTransactionStatus::NonceTooHigh => {
+                        SendRawTransactionResult::NonceTooHigh
+                    }
+                })
+            },
+            |results| results.at_least_one_ok().map(|(_provider, result)| result),
+        )
+    }
+}
+
+impl Reduce for MultiCallResults<SendRawTransactionResult> {
+    type Item = SendRawTransactionResult;
+
+    fn reduce(self) -> ReducedResult<Self::Item> {
+        self.at_least_one_ok()
+            .map(|(_provider, result)| result)
+            .into()
     }
 }
 

--- a/rs/ethereum/cketh/test_utils/src/flow.rs
+++ b/rs/ethereum/cketh/test_utils/src/flow.rs
@@ -682,9 +682,13 @@ impl<T: AsRef<CkEthSetup>, Req: HasWithdrawalId> SendRawTransactionProcessWithdr
         self,
         mut override_mock: F,
     ) -> Self {
-        let default_eth_send_raw_transaction =
+        let default_eth_send_raw_transaction = if self.setup.as_ref().evm_rpc_id.is_none() {
             MockJsonRpcProviders::when(JsonRpcMethod::EthSendRawTransaction)
-                .respond_with(JsonRpcProvider::Ankr, send_raw_transaction_response());
+                .respond_with(JsonRpcProvider::Ankr, send_raw_transaction_response())
+        } else {
+            MockJsonRpcProviders::when(JsonRpcMethod::EthSendRawTransaction)
+                .respond_for_all_with(send_raw_transaction_response())
+        };
         (override_mock)(default_eth_send_raw_transaction)
             .build()
             .expect_rpc_calls(&self.setup);

--- a/rs/ethereum/evm-rpc-client/src/lib.rs
+++ b/rs/ethereum/evm-rpc-client/src/lib.rs
@@ -5,7 +5,8 @@ pub mod types;
 
 use crate::types::candid::{
     Block, BlockTag, FeeHistory, FeeHistoryArgs, GetLogsArgs, GetTransactionCountArgs, LogEntry,
-    MultiRpcResult, ProviderError, RpcConfig, RpcError, RpcServices, TransactionReceipt,
+    MultiRpcResult, ProviderError, RpcConfig, RpcError, RpcServices, SendRawTransactionStatus,
+    TransactionReceipt,
 };
 use async_trait::async_trait;
 use candid::utils::ArgumentEncoder;
@@ -47,6 +48,7 @@ pub struct OverrideRpcConfig {
     pub eth_fee_history: Option<RpcConfig>,
     pub eth_get_transaction_receipt: Option<RpcConfig>,
     pub eth_get_transaction_count: Option<RpcConfig>,
+    pub eth_send_raw_transaction: Option<RpcConfig>,
 }
 
 impl<L: Sink> EvmRpcClient<IcRuntime, L> {
@@ -110,6 +112,18 @@ impl<R: Runtime, L: Sink> EvmRpcClient<R, L> {
             "eth_getTransactionCount",
             self.override_rpc_config.eth_get_transaction_count.clone(),
             args,
+        )
+        .await
+    }
+
+    pub async fn eth_send_raw_transaction(
+        &self,
+        raw_signed_tx_hex: String,
+    ) -> MultiRpcResult<SendRawTransactionStatus> {
+        self.call_internal(
+            "eth_sendRawTransaction",
+            self.override_rpc_config.eth_send_raw_transaction.clone(),
+            raw_signed_tx_hex,
         )
         .await
     }

--- a/rs/ethereum/evm-rpc-client/src/types.rs
+++ b/rs/ethereum/evm-rpc-client/src/types.rs
@@ -175,6 +175,14 @@ pub mod candid {
         pub block: BlockTag,
     }
 
+    #[derive(Clone, Debug, Eq, PartialEq, CandidType, Deserialize)]
+    pub enum SendRawTransactionStatus {
+        Ok(Option<String>),
+        InsufficientFunds,
+        NonceTooLow,
+        NonceTooHigh,
+    }
+
     pub type RpcResult<T> = Result<T, RpcError>;
 
     #[derive(Clone, Debug, Eq, PartialEq, CandidType, Deserialize)]


### PR DESCRIPTION
([XC-163](https://dfinity.atlassian.net/browse/XC-163)): Continue the migration initiated in [MR-19972](https://gitlab.com/dfinity-lab/public/ic/-/merge_requests/19972) towards using the EVM-RPC canister to interact with the Ethereum JSON-RPC providers. This PR focuses specifically on the `eth_sendRawTransaction` endpoint.

One notable change of behaviour is that when the EVM-RPC canister is used for `eth_sendRawTransaction`, all 3 providers (Ankr, Public Node and Llama Modes) will be queried in parallel, whereas the minter uses a minor optimization in querying all 3 providers sequentially until the first ok result, since the sent transaction is signed and cannot be altered.

[XC-163]: https://dfinity.atlassian.net/browse/XC-163?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ