### PR TITLE
fix: Store the version of the snapshot that was loaded in canister history

### DIFF
--- a/rs/execution_environment/src/canister_manager.rs
+++ b/rs/execution_environment/src/canister_manager.rs
@@ -2072,7 +2072,7 @@ impl CanisterManager {
             state.time(),
             origin,
             CanisterChangeDetails::load_snapshot(
-                new_canister.system_state.canister_version,
+                snapshot.canister_version(),
                 snapshot_id.to_vec(),
                 snapshot.taken_at_timestamp().as_nanos_since_unix_epoch(),
             ),

--- a/rs/execution_environment/src/execution_environment/tests/canister_snapshots.rs
+++ b/rs/execution_environment/src/execution_environment/tests/canister_snapshots.rs
@@ -1374,9 +1374,12 @@ fn load_canister_snapshot_succeeds() {
         .unwrap()
         .system_state
         .canister_version;
+    // Canister version should be bumped after loading a snapshot.
     assert!(canister_version_after > canister_version_before);
     assert_eq!(canister_version_after, 2u64);
 
+    // Entry in canister history should contain the information of
+    // the snapshot that was loaded back into the canister.
     let canister_history = test
         .state()
         .canister_state(&canister_id)
@@ -1393,7 +1396,7 @@ fn load_canister_snapshot_succeeds() {
     assert_eq!(
         *last_canister_change.details(),
         CanisterChangeDetails::load_snapshot(
-            canister_version_after,
+            canister_version_before,
             snapshot_id.to_vec(),
             snapshot_taken_at_timestamp
         )


### PR DESCRIPTION
This fixes a discrepancy between the interface spec and the replica wrt the canister version stored in the `load_snaphot` history entry.

The change details of the history entry used to store the version of the canister after loading the snapshot (this already appears in the history entry anyway). However, it should contain the version of the canister at the time that the snapshot was taken -- this, along with the time taken and the snapshot id, fully describes the snapshot that was loaded back into the canister.