### PR TITLE
fix(execution): Update doc comment

### DIFF
--- a/rs/execution_environment/src/execution_environment.rs
+++ b/rs/execution_environment/src/execution_environment.rs
@@ -453,7 +453,9 @@ impl ExecutionEnvironment {
     }
 
     /// Executes a replicated message sent to a subnet.
-    /// Returns the new replicated state and the number of left instructions.
+    ///
+    /// Returns the new replicated state and an optional number of instructions
+    /// consumed by the message execution.
     #[allow(clippy::cognitive_complexity)]
     #[allow(clippy::too_many_arguments)]
     pub fn execute_subnet_message(


### PR DESCRIPTION
The doc comment for `ExecutionEnvironment::execute_subnet_message` was incorrectly saying that we return instructions left but in reality we return instructions consumed by message execution (e.g. [for installing code](https://sourcegraph.com/github.com/dfinity/ic@af7db79a8e558715eef7a0a71f44db2da1c33da2/-/blob/rs/execution_environment/src/execution_environment.rs?L2996)).