### PR TITLE
feat: EXC-1683: Include snapshot memory usage in charging for resources

### DIFF
--- a/rs/config/src/subnet_config.rs
+++ b/rs/config/src/subnet_config.rs
@@ -159,11 +159,11 @@ const DEFAULT_RESERVED_BALANCE_LIMIT: Cycles = Cycles::new(5 * T);
 
 /// Instructions used to upload a chunk (1MiB) to the wasm chunk store. This is
 /// 1/10th of a round.
-pub const DEFAULT_UPLOAD_CHUNK_INSTRUCTIONS: NumInstructions = NumInstructions::new(100_000);
+pub const DEFAULT_UPLOAD_CHUNK_INSTRUCTIONS: NumInstructions = NumInstructions::new(200_000_000);
 
 /// Baseline cost for creating or loading a canister snapshot.
 pub const DEFAULT_CANISTERS_SNAPSHOT_BASELINE_INSTRUCTIONS: NumInstructions =
-    NumInstructions::new(200_000_000);
+    NumInstructions::new(100_000);
 
 /// The per subnet type configuration for the scheduler component
 #[derive(Clone, Serialize, Deserialize)]

--- a/rs/config/src/subnet_config.rs
+++ b/rs/config/src/subnet_config.rs
@@ -159,7 +159,11 @@ const DEFAULT_RESERVED_BALANCE_LIMIT: Cycles = Cycles::new(5 * T);
 
 /// Instructions used to upload a chunk (1MiB) to the wasm chunk store. This is
 /// 1/10th of a round.
-pub const DEFAULT_UPLOAD_CHUNK_INSTRUCTIONS: NumInstructions = NumInstructions::new(200_000_000);
+pub const DEFAULT_UPLOAD_CHUNK_INSTRUCTIONS: NumInstructions = NumInstructions::new(100_000);
+
+/// Baseline cost for creating or loading a canister snapshot.
+pub const DEFAULT_CANISTERS_SNAPSHOT_BASELINE_INSTRUCTIONS: NumInstructions =
+    NumInstructions::new(200_000_000);
 
 /// The per subnet type configuration for the scheduler component
 #[derive(Clone, Serialize, Deserialize)]
@@ -259,6 +263,9 @@ pub struct SchedulerConfig {
 
     /// Number of instructions to count when uploading a chunk to the wasm store.
     pub upload_wasm_chunk_instructions: NumInstructions,
+
+    /// Number of instructions to count when creating or loading a canister snapshot.
+    pub canister_snapshot_baseline_instructions: NumInstructions,
 }
 
 impl SchedulerConfig {
@@ -286,6 +293,8 @@ impl SchedulerConfig {
             dirty_page_overhead: DEFAULT_DIRTY_PAGE_OVERHEAD,
             accumulated_priority_reset_interval: ACCUMULATED_PRIORITY_RESET_INTERVAL,
             upload_wasm_chunk_instructions: DEFAULT_UPLOAD_CHUNK_INSTRUCTIONS,
+            canister_snapshot_baseline_instructions:
+                DEFAULT_CANISTERS_SNAPSHOT_BASELINE_INSTRUCTIONS,
         }
     }
 
@@ -328,6 +337,7 @@ impl SchedulerConfig {
             dirty_page_overhead: SYSTEM_SUBNET_DIRTY_PAGE_OVERHEAD,
             accumulated_priority_reset_interval: ACCUMULATED_PRIORITY_RESET_INTERVAL,
             upload_wasm_chunk_instructions: NumInstructions::from(0),
+            canister_snapshot_baseline_instructions: NumInstructions::from(0),
         }
     }
 
@@ -358,6 +368,8 @@ impl SchedulerConfig {
             dirty_page_overhead: DEFAULT_DIRTY_PAGE_OVERHEAD,
             accumulated_priority_reset_interval: ACCUMULATED_PRIORITY_RESET_INTERVAL,
             upload_wasm_chunk_instructions: DEFAULT_UPLOAD_CHUNK_INSTRUCTIONS,
+            canister_snapshot_baseline_instructions:
+                DEFAULT_CANISTERS_SNAPSHOT_BASELINE_INSTRUCTIONS,
         }
     }
 

--- a/rs/cycles_account_manager/src/lib.rs
+++ b/rs/cycles_account_manager/src/lib.rs
@@ -273,7 +273,8 @@ impl CyclesAccountManager {
 
     // Returns a list of the idle resource consumption rate in cycles per day
     // for each resource.
-    fn idle_cycles_burned_rate_by_resource(
+    #[doc(hidden)] // pub for usage in tests
+    pub fn idle_cycles_burned_rate_by_resource(
         &self,
         memory_allocation: MemoryAllocation,
         memory_usage: NumBytes,
@@ -1044,12 +1045,13 @@ impl CyclesAccountManager {
         &self,
         log: &ReplicaLogger,
         canister: &mut CanisterState,
+        canister_snapshots_memory_usage: NumBytes,
         duration_since_last_charge: Duration,
         subnet_size: usize,
     ) -> Result<(), CanisterOutOfCyclesError> {
         for (use_case, rate) in self.idle_cycles_burned_rate_by_resource(
             canister.memory_allocation(),
-            canister.memory_usage(),
+            canister.memory_usage() + canister_snapshots_memory_usage,
             canister.message_memory_usage(),
             canister.compute_allocation(),
             subnet_size,

--- a/rs/cycles_account_manager/tests/cycles_account_manager.rs
+++ b/rs/cycles_account_manager/tests/cycles_account_manager.rs
@@ -70,6 +70,7 @@ fn test_can_charge_application_subnets() {
                         .charge_canister_for_resource_allocation_and_usage(
                             &log,
                             &mut canister,
+                            NumBytes::from(0),
                             duration,
                             subnet_size,
                         )
@@ -330,6 +331,7 @@ fn charging_removes_canisters_with_insufficient_balance() {
             .charge_canister_for_resource_allocation_and_usage(
                 &log,
                 &mut canister,
+                NumBytes::from(0),
                 Duration::from_secs(1),
                 subnet_size,
             )
@@ -348,6 +350,7 @@ fn charging_removes_canisters_with_insufficient_balance() {
             .charge_canister_for_resource_allocation_and_usage(
                 &log,
                 &mut canister,
+                NumBytes::from(0),
                 Duration::from_secs(1),
                 subnet_size,
             )
@@ -366,6 +369,7 @@ fn charging_removes_canisters_with_insufficient_balance() {
             .charge_canister_for_resource_allocation_and_usage(
                 &log,
                 &mut canister,
+                NumBytes::from(0),
                 Duration::from_secs(1),
                 subnet_size,
             )

--- a/rs/execution_environment/benches/lib/src/common.rs
+++ b/rs/execution_environment/benches/lib/src/common.rs
@@ -306,6 +306,9 @@ where
         subnet_configs
             .scheduler_config
             .upload_wasm_chunk_instructions,
+        subnet_configs
+            .scheduler_config
+            .canister_snapshot_baseline_instructions,
     );
     for Benchmark(id, wat, expected_ops) in benchmarks {
         run_benchmark(

--- a/rs/execution_environment/src/canister_manager.rs
+++ b/rs/execution_environment/src/canister_manager.rs
@@ -1143,6 +1143,7 @@ impl CanisterManager {
         sender: PrincipalId,
         canister: &mut CanisterState,
         subnet_size: usize,
+        canister_snapshot_usage: NumBytes,
     ) -> Result<CanisterStatusResultV2, CanisterManagerError> {
         // Skip the controller check if the canister itself is requesting its
         // own status, as the canister is considered in the same trust domain.
@@ -1184,7 +1185,7 @@ impl CanisterManager {
             self.cycles_account_manager
                 .idle_cycles_burned_rate(
                     memory_allocation,
-                    canister_memory_usage,
+                    canister_memory_usage + canister_snapshot_usage,
                     canister_message_memory_usage,
                     compute_allocation,
                     subnet_size,

--- a/rs/execution_environment/src/canister_manager.rs
+++ b/rs/execution_environment/src/canister_manager.rs
@@ -2683,6 +2683,8 @@ impl From<CanisterManagerError> for UserError {
                     format!(
                         "Canister {} has reached the maximum number of snapshots allowed: {}.{additional_help}", canister_id, limit,
                     )
+                )
+            }
             CanisterSnapshotNotEnoughCycles(err) => {
                 Self::new(
                 ErrorCode::CanisterOutOfCycles,

--- a/rs/execution_environment/src/canister_manager.rs
+++ b/rs/execution_environment/src/canister_manager.rs
@@ -2074,9 +2074,6 @@ impl CanisterManager {
                 compilation_cost_handling,
             );
 
-            
-
-
             let mut new_execution_state = match new_execution_state {
                 Ok(execution_state) => execution_state,
                 Err(err) => {

--- a/rs/execution_environment/src/canister_manager/tests.rs
+++ b/rs/execution_environment/src/canister_manager/tests.rs
@@ -297,6 +297,7 @@ fn canister_manager_config(
         NumBytes::from(10 * 1024 * 1024),
         SchedulerConfig::application_subnet().upload_wasm_chunk_instructions,
         ic_config::embedders::Config::default().wasm_max_size,
+        SchedulerConfig::application_subnet().canister_snapshot_baseline_instructions,
     )
 }
 

--- a/rs/execution_environment/src/canister_manager/tests.rs
+++ b/rs/execution_environment/src/canister_manager/tests.rs
@@ -2075,7 +2075,12 @@ fn get_canister_status_with_incorrect_controller() {
         let other_sender = user_test_id(1).get();
         let canister = state.canister_state_mut(&canister_id).unwrap();
         assert_eq!(
-            canister_manager.get_canister_status(other_sender, canister, SMALL_APP_SUBNET_MAX_SIZE),
+            canister_manager.get_canister_status(
+                other_sender,
+                canister,
+                SMALL_APP_SUBNET_MAX_SIZE,
+                NumBytes::from(0)
+            ),
             Err(CanisterManagerError::CanisterInvalidController {
                 canister_id,
                 controllers_expected: btreeset! {sender},
@@ -2113,7 +2118,12 @@ fn get_canister_status_of_running_canister() {
 
         let canister = state.canister_state_mut(&canister_id).unwrap();
         let status = canister_manager
-            .get_canister_status(sender, canister, SMALL_APP_SUBNET_MAX_SIZE)
+            .get_canister_status(
+                sender,
+                canister,
+                SMALL_APP_SUBNET_MAX_SIZE,
+                NumBytes::from(0),
+            )
             .unwrap()
             .status();
         assert_eq!(status, CanisterStatusType::Running);
@@ -2148,7 +2158,12 @@ fn get_canister_status_of_self() {
 
         let canister = state.canister_state_mut(&canister_id).unwrap();
         let status = canister_manager
-            .get_canister_status(canister_id.get(), canister, SMALL_APP_SUBNET_MAX_SIZE)
+            .get_canister_status(
+                canister_id.get(),
+                canister,
+                SMALL_APP_SUBNET_MAX_SIZE,
+                NumBytes::from(0),
+            )
             .unwrap()
             .status();
         assert_eq!(status, CanisterStatusType::Running);
@@ -2165,7 +2180,12 @@ fn get_canister_status_of_stopped_canister() {
 
         let canister = state.canister_state_mut(&canister_id).unwrap();
         let status = canister_manager
-            .get_canister_status(sender, canister, SMALL_APP_SUBNET_MAX_SIZE)
+            .get_canister_status(
+                sender,
+                canister,
+                SMALL_APP_SUBNET_MAX_SIZE,
+                NumBytes::from(0),
+            )
             .unwrap()
             .status();
         assert_eq!(status, CanisterStatusType::Stopped);
@@ -2182,7 +2202,12 @@ fn get_canister_status_of_stopping_canister() {
 
         let canister = state.canister_state_mut(&canister_id).unwrap();
         let status = canister_manager
-            .get_canister_status(sender, canister, SMALL_APP_SUBNET_MAX_SIZE)
+            .get_canister_status(
+                sender,
+                canister,
+                SMALL_APP_SUBNET_MAX_SIZE,
+                NumBytes::from(0),
+            )
             .unwrap()
             .status();
         assert_eq!(status, CanisterStatusType::Stopping);
@@ -2577,7 +2602,7 @@ fn can_get_canister_balance() {
 
         let canister = state.canister_state_mut(&canister_id).unwrap();
         assert_matches!(
-            canister_manager.get_canister_status( sender, canister, SMALL_APP_SUBNET_MAX_SIZE),
+            canister_manager.get_canister_status( sender, canister, SMALL_APP_SUBNET_MAX_SIZE, NumBytes::from(0)),
             Ok(res) if res.cycles() == cycles.get()
         );
     });

--- a/rs/execution_environment/src/execution_environment.rs
+++ b/rs/execution_environment/src/execution_environment.rs
@@ -371,6 +371,7 @@ impl ExecutionEnvironment {
         fd_factory: Arc<dyn PageAllocatorFileDescriptor>,
         heap_delta_rate_limit: NumBytes,
         upload_wasm_chunk_instructions: NumInstructions,
+        canister_snapshot_baseline_instructions: NumInstructions,
     ) -> Self {
         // Assert the flag implication: DTS => sandboxing.
         assert!(
@@ -393,6 +394,7 @@ impl ExecutionEnvironment {
             heap_delta_rate_limit,
             upload_wasm_chunk_instructions,
             config.embedders_config.wasm_max_size,
+            canister_snapshot_baseline_instructions,
         );
         let metrics = ExecutionEnvironmentMetrics::new(metrics_registry);
         let canister_manager = CanisterManager::new(
@@ -1408,6 +1410,7 @@ impl ExecutionEnvironment {
                     Ok(args) => {
                         let origin = msg.canister_change_origin(args.get_sender_canister_version());
                         let (result, instruction_used) = self.load_canister_snapshot(
+                            registry_settings.subnet_size,
                             *msg.sender(),
                             &mut state,
                             args,
@@ -2074,6 +2077,7 @@ impl ExecutionEnvironment {
     /// Loads a canister snapshot onto an existing canister.
     fn load_canister_snapshot(
         &self,
+        subnet_size: usize,
         sender: PrincipalId,
         state: &mut ReplicatedState,
         args: LoadCanisterSnapshotArgs,
@@ -2097,6 +2101,7 @@ impl ExecutionEnvironment {
 
         let snapshot_id = args.snapshot_id();
         let (instructions_used, result) = self.canister_manager.load_canister_snapshot(
+            subnet_size,
             sender,
             &old_canister,
             snapshot_id,

--- a/rs/execution_environment/src/execution_environment.rs
+++ b/rs/execution_environment/src/execution_environment.rs
@@ -1890,10 +1890,13 @@ impl ExecutionEnvironment {
         state: &mut ReplicatedState,
         subnet_size: usize,
     ) -> Result<Vec<u8>, UserError> {
+        let canister_snapshot_usage = state
+            .canister_snapshots
+            .memory_usage_by_canister(canister_id);
         let canister = get_canister_mut(canister_id, state)?;
 
         self.canister_manager
-            .get_canister_status(sender, canister, subnet_size)
+            .get_canister_status(sender, canister, subnet_size, canister_snapshot_usage)
             .map(|status| status.encode())
             .map_err(|err| err.into())
     }

--- a/rs/execution_environment/src/lib.rs
+++ b/rs/execution_environment/src/lib.rs
@@ -142,6 +142,7 @@ impl ExecutionServices {
             Arc::clone(&fd_factory),
             scheduler_config.heap_delta_rate_limit,
             scheduler_config.upload_wasm_chunk_instructions,
+            scheduler_config.canister_snapshot_baseline_instructions,
         ));
         let sync_query_handler = Arc::new(InternalHttpQueryHandler::new(
             logger.clone(),

--- a/rs/execution_environment/src/scheduler.rs
+++ b/rs/execution_environment/src/scheduler.rs
@@ -1115,7 +1115,7 @@ impl SchedulerImpl {
 
                 let canister_snapshots_memory_usage = canister_snapshots_usage
                     .get(&canister.canister_id())
-                    .map(|usage| usage.clone())
+                    .copied()
                     .unwrap_or(NumBytes::from(0));
                 if self
                     .cycles_account_manager

--- a/rs/execution_environment/src/scheduler/test_utilities.rs
+++ b/rs/execution_environment/src/scheduler/test_utilities.rs
@@ -202,6 +202,32 @@ impl SchedulerTest {
             .execution_cost(num_instructions, self.subnet_size())
     }
 
+    pub fn compute_resource_charge_cost(
+        &self,
+        memory_allocation: MemoryAllocation,
+        memory_usage: NumBytes,
+        message_memory_usage: NumBytes,
+        compute_allocation: ComputeAllocation,
+        duration: Duration,
+    ) -> Cycles {
+        let seconds_per_day: u128 = 24 * 60 * 60;
+        let mut cost = Cycles::new(0);
+        for (_, rate) in self
+            .scheduler
+            .cycles_account_manager
+            .idle_cycles_burned_rate_by_resource(
+                memory_allocation,
+                memory_usage,
+                message_memory_usage,
+                compute_allocation,
+                self.subnet_size(),
+            )
+        {
+            cost += rate * duration.as_secs() / seconds_per_day;
+        }
+        cost
+    }
+
     /// Creates a canister with the given balance and allocations.
     /// The `system_task` parameter can be used to optionally enable the
     /// heartbeat by passing `Some(SystemMethod::CanisterHeartbeat)`.

--- a/rs/execution_environment/src/scheduler/test_utilities.rs
+++ b/rs/execution_environment/src/scheduler/test_utilities.rs
@@ -196,6 +196,12 @@ impl SchedulerTest {
         )
     }
 
+    pub fn execution_cost(&self, num_instructions: NumInstructions) -> Cycles {
+        self.scheduler
+            .cycles_account_manager
+            .execution_cost(num_instructions, self.subnet_size())
+    }
+
     /// Creates a canister with the given balance and allocations.
     /// The `system_task` parameter can be used to optionally enable the
     /// heartbeat by passing `Some(SystemMethod::CanisterHeartbeat)`.
@@ -897,6 +903,8 @@ impl SchedulerTestBuilder {
             Arc::new(TestPageAllocatorFileDescriptorImpl::new()),
             self.scheduler_config.heap_delta_rate_limit,
             self.scheduler_config.upload_wasm_chunk_instructions,
+            self.scheduler_config
+                .canister_snapshot_baseline_instructions,
         );
         let scheduler = SchedulerImpl::new(
             self.scheduler_config,

--- a/rs/execution_environment/src/scheduler/tests.rs
+++ b/rs/execution_environment/src/scheduler/tests.rs
@@ -13,6 +13,7 @@ use ic_config::{
     execution_environment::STOP_CANISTER_TIMEOUT_DURATION,
     subnet_config::{CyclesAccountManagerConfig, SchedulerConfig, SubnetConfig},
 };
+use ic_cycles_account_manager::IdleCanisterResources;
 use ic_error_types::RejectCode;
 use ic_interfaces::execution_environment::SubnetAvailableMemory;
 use ic_logger::replica_logger::no_op_logger;
@@ -1568,13 +1569,14 @@ fn canister_charging_resource_usage_includes_snapshots_usage() {
             .scheduler()
             .cycles_account_manager
             .duration_between_allocation_charges();
-    let expected_charge = test.compute_resource_charge_cost(
-        canister.memory_allocation(),
-        canister.memory_usage() + canister_snapshots_usage,
-        canister.message_memory_usage(),
-        canister.compute_allocation(),
-        duration,
-    );
+    let idle_canister_resources = IdleCanisterResources {
+        memory_allocation: canister.memory_allocation(),
+        memory_usage: canister.memory_usage(),
+        message_memory_usage: canister.message_memory_usage(),
+        snapshots_memory_usage: canister_snapshots_usage,
+        compute_allocation: canister.compute_allocation(),
+    };
+    let expected_charge = test.compute_resource_charge_cost(idle_canister_resources, duration);
     test.set_time(initial_time + duration);
 
     // Trigger a charge for resources.

--- a/rs/execution_environment/src/scheduler/tests.rs
+++ b/rs/execution_environment/src/scheduler/tests.rs
@@ -23,7 +23,7 @@ use ic_management_canister_types::{
 };
 use ic_registry_routing_table::CanisterIdRange;
 use ic_registry_subnet_type::SubnetType;
-use ic_replicated_state::canister_state::system_state::PausedExecutionId;
+use ic_replicated_state::canister_state::system_state::{CyclesUseCase, PausedExecutionId};
 use ic_replicated_state::testing::{CanisterQueuesTesting, SystemStateTesting};
 use ic_state_machine_tests::{PayloadBuilder, StateMachineBuilder};
 use ic_test_utilities_metrics::{
@@ -1279,6 +1279,20 @@ fn snapshot_is_deleted_when_canister_is_out_of_cycles() {
         0
     );
 
+    // Taking a snapshot of the canister will decrease the balance.
+    // Increase the canister balance to be able to take a new snapshot.
+    let subnet_type = SubnetType::Application;
+    let scheduler_config = SubnetConfig::new(subnet_type).scheduler_config;
+    let canister_snapshot_size = test.canister_state(canister_id).snapshot_memory_usage();
+    let instructions = scheduler_config.canister_snapshot_baseline_instructions
+        + NumInstructions::new(canister_snapshot_size.get());
+    let expected_charge = test.execution_cost(instructions);
+    test.state_mut()
+        .canister_state_mut(&canister_id)
+        .unwrap()
+        .system_state
+        .add_cycles(expected_charge, CyclesUseCase::NonConsumed);
+
     // Take a snapshot of the canister.
     let args: TakeCanisterSnapshotArgs = TakeCanisterSnapshotArgs::new(canister_id, None);
     test.inject_call_to_ic00(
@@ -1370,13 +1384,27 @@ fn snapshot_is_deleted_when_uninstalled_canister_is_out_of_cycles() {
             .len(),
         0
     );
-
     assert!(test
         .state()
         .canister_state(&canister_id)
         .unwrap()
         .execution_state
         .is_some());
+
+    // Taking a snapshot of the canister will decrease the balance.
+    // Increase the canister balance to be able to take a new snapshot.
+    let subnet_type = SubnetType::Application;
+    let scheduler_config = SubnetConfig::new(subnet_type).scheduler_config;
+    let canister_snapshot_size = test.canister_state(canister_id).snapshot_memory_usage();
+    let instructions = scheduler_config.canister_snapshot_baseline_instructions
+        + NumInstructions::new(canister_snapshot_size.get());
+    let expected_charge = test.execution_cost(instructions);
+    test.state_mut()
+        .canister_state_mut(&canister_id)
+        .unwrap()
+        .system_state
+        .add_cycles(expected_charge, CyclesUseCase::NonConsumed);
+
     // Take a snapshot of the canister.
     let args: TakeCanisterSnapshotArgs = TakeCanisterSnapshotArgs::new(canister_id, None);
     test.inject_call_to_ic00(

--- a/rs/replicated_state/src/canister_snapshots.rs
+++ b/rs/replicated_state/src/canister_snapshots.rs
@@ -173,18 +173,6 @@ impl CanisterSnapshots {
         canister_snapshots_usage
     }
 
-    /// Computes the memory usage used by all snapshots belonging to the specified canister ID.
-    // pub fn memory_usage(&self, canister_id: CanisterId) -> NumBytes {
-    //     let mut memory_size = NumBytes::new(0);
-    //     if let Some(snapshot_ids) = self.snapshot_ids.get(&canister_id) {
-    //         for snapshot_id in snapshot_ids {
-    //             debug_assert!(self.snapshots.contains_key(&snapshot_id));
-    //             memory_size += self.snapshots.get(snapshot_id).unwrap().size();
-    //         }
-    //     }
-    //     memory_size
-    // }
-
     /// Adds a new restore snapshot operation in the unflushed changes.
     pub fn add_restore_operation(&mut self, canister_id: CanisterId, snapshot_id: SnapshotId) {
         self.unflushed_changes

--- a/rs/replicated_state/src/canister_snapshots.rs
+++ b/rs/replicated_state/src/canister_snapshots.rs
@@ -160,6 +160,31 @@ impl CanisterSnapshots {
         }
     }
 
+    pub fn memory_usage(&self) -> BTreeMap<CanisterId, NumBytes> {
+        let mut canister_snapshots_usage = BTreeMap::<CanisterId, NumBytes>::new();
+        for (canister_id, snapshot_ids) in &self.snapshot_ids {
+            let mut memory_size = NumBytes::new(0);
+            for snapshot_id in snapshot_ids {
+                debug_assert!(self.snapshots.contains_key(&snapshot_id));
+                memory_size += self.snapshots.get(&snapshot_id).unwrap().size();
+            }
+            canister_snapshots_usage.insert(*canister_id, memory_size);
+        }
+        canister_snapshots_usage
+    }
+
+    /// Computes the memory usage used by all snapshots belonging to the specified canister ID.
+    // pub fn memory_usage(&self, canister_id: CanisterId) -> NumBytes {
+    //     let mut memory_size = NumBytes::new(0);
+    //     if let Some(snapshot_ids) = self.snapshot_ids.get(&canister_id) {
+    //         for snapshot_id in snapshot_ids {
+    //             debug_assert!(self.snapshots.contains_key(&snapshot_id));
+    //             memory_size += self.snapshots.get(snapshot_id).unwrap().size();
+    //         }
+    //     }
+    //     memory_size
+    // }
+
     /// Adds a new restore snapshot operation in the unflushed changes.
     pub fn add_restore_operation(&mut self, canister_id: CanisterId, snapshot_id: SnapshotId) {
         self.unflushed_changes

--- a/rs/replicated_state/src/canister_snapshots.rs
+++ b/rs/replicated_state/src/canister_snapshots.rs
@@ -173,6 +173,18 @@ impl CanisterSnapshots {
         canister_snapshots_usage
     }
 
+    /// Computes the memory usage used by all snapshots belonging to the specified canister ID.
+    pub fn memory_usage_by_canister(&self, canister_id: CanisterId) -> NumBytes {
+        let mut memory_size = NumBytes::new(0);
+        if let Some(snapshot_ids) = self.snapshot_ids.get(&canister_id) {
+            for snapshot_id in snapshot_ids {
+                debug_assert!(self.snapshots.contains_key(&snapshot_id));
+                memory_size += self.snapshots.get(snapshot_id).unwrap().size();
+            }
+        }
+        memory_size
+    }
+
     /// Adds a new restore snapshot operation in the unflushed changes.
     pub fn add_restore_operation(&mut self, canister_id: CanisterId, snapshot_id: SnapshotId) {
         self.unflushed_changes

--- a/rs/test_utilities/execution_environment/src/lib.rs
+++ b/rs/test_utilities/execution_environment/src/lib.rs
@@ -1626,6 +1626,7 @@ pub struct ExecutionTestBuilder {
     resource_saturation_scaling: usize,
     heap_delta_rate_limit: NumBytes,
     upload_wasm_chunk_instructions: NumInstructions,
+    canister_snapshot_baseline_instructions: NumInstructions,
 }
 
 impl Default for ExecutionTestBuilder {
@@ -1665,6 +1666,8 @@ impl Default for ExecutionTestBuilder {
             resource_saturation_scaling: 1,
             heap_delta_rate_limit: scheduler_config.heap_delta_rate_limit,
             upload_wasm_chunk_instructions: scheduler_config.upload_wasm_chunk_instructions,
+            canister_snapshot_baseline_instructions: scheduler_config
+                .canister_snapshot_baseline_instructions,
         }
     }
 }
@@ -2192,6 +2195,7 @@ impl ExecutionTestBuilder {
             Arc::new(TestPageAllocatorFileDescriptorImpl::new()),
             self.heap_delta_rate_limit,
             self.upload_wasm_chunk_instructions,
+            self.canister_snapshot_baseline_instructions,
         );
         let (query_stats_collector, _) =
             ic_query_stats::init_query_stats(self.log.clone(), &config, &metrics_registry);

--- a/rs/test_utilities/execution_environment/src/lib.rs
+++ b/rs/test_utilities/execution_environment/src/lib.rs
@@ -8,7 +8,7 @@ use ic_config::{
     subnet_config::SubnetConfig,
 };
 use ic_constants::SMALL_APP_SUBNET_MAX_SIZE;
-use ic_cycles_account_manager::CyclesAccountManager;
+use ic_cycles_account_manager::{CyclesAccountManager, IdleCanisterResources};
 use ic_embedders::{
     wasm_utils::{compile, decoding::decode_wasm},
     WasmtimeEmbedder,
@@ -328,11 +328,18 @@ impl ExecutionTest {
             .scheduler_state
             .compute_allocation;
         let message_memory_usage = self.canister_state(canister_id).message_memory_usage();
+        let snapshots_memory_usage = self
+            .state()
+            .canister_snapshots
+            .memory_usage_by_canister(canister_id);
         self.cycles_account_manager.idle_cycles_burned_rate(
-            memory_allocation,
-            memory_usage,
-            message_memory_usage,
-            compute_allocation,
+            IdleCanisterResources {
+                memory_allocation,
+                memory_usage,
+                message_memory_usage,
+                snapshots_memory_usage,
+                compute_allocation,
+            },
             self.subnet_size(),
         )
     }


### PR DESCRIPTION
This PR includes snapshot memory usage when calculating a canister's total cycles to pay for resources.