### PR TITLE
feat(nns): Redact private neuron info fields.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9624,6 +9624,7 @@ dependencies = [
  "ic-nervous-system-proto",
  "ic-nervous-system-root",
  "ic-nervous-system-runtime",
+ "ic-nervous-system-temporary",
  "ic-neurons-fund",
  "ic-nns-common",
  "ic-nns-constants",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9504,6 +9504,13 @@ name = "ic-nervous-system-string"
 version = "0.0.1"
 
 [[package]]
+name = "ic-nervous-system-temporary"
+version = "0.0.1"
+dependencies = [
+ "rand 0.8.5",
+]
+
+[[package]]
 name = "ic-neurons-fund"
 version = "0.0.1"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -179,6 +179,7 @@ members = [
     "rs/nervous_system/root",
     "rs/nervous_system/runtime",
     "rs/nervous_system/string",
+    "rs/nervous_system/temporary",
     "rs/nervous_system/tools/sync-with-released-nevous-system-wasms",
     "rs/nns/constants",
     "rs/nns/common",

--- a/rs/nervous_system/temporary/BUILD.bazel
+++ b/rs/nervous_system/temporary/BUILD.bazel
@@ -2,15 +2,15 @@ load("@rules_rust//rust:defs.bzl", "rust_doc_test", "rust_library", "rust_test_s
 
 package(default_visibility = ["//visibility:public"])
 
-DEPENDENCIES = [] # Nice.
+DEPENDENCIES = []  # Nice.
 
 DEV_DEPENDENCIES = [
-    "@crate_index//:rand", # Used by doc test.
+    "@crate_index//:rand",  # Used by doc test.
 ]
 
 LIB_SRCS = glob(
     ["src/**"],
-    exclude=["**/*tests.rs"],
+    exclude = ["**/*tests.rs"],
 )
 
 rust_library(

--- a/rs/nervous_system/temporary/BUILD.bazel
+++ b/rs/nervous_system/temporary/BUILD.bazel
@@ -1,0 +1,34 @@
+load("@rules_rust//rust:defs.bzl", "rust_doc_test", "rust_library", "rust_test_suite")
+
+package(default_visibility = ["//visibility:public"])
+
+DEPENDENCIES = [] # Nice.
+
+DEV_DEPENDENCIES = [
+    "@crate_index//:rand", # Used by doc test.
+]
+
+LIB_SRCS = glob(
+    ["src/**"],
+    exclude=["**/*tests.rs"],
+)
+
+rust_library(
+    name = "temporary",
+    srcs = LIB_SRCS,
+    crate_name = "ic_nervous_system_temporary",
+    version = "0.0.1",
+    deps = DEPENDENCIES,
+)
+
+rust_test_suite(
+    name = "temporary_integration_test",
+    srcs = glob(["tests/**/*.rs"]),
+    deps = [":temporary"] + DEPENDENCIES + DEV_DEPENDENCIES,
+)
+
+rust_doc_test(
+    name = "temporary_doc_test",
+    crate = ":temporary",
+    deps = DEPENDENCIES + DEV_DEPENDENCIES,
+)

--- a/rs/nervous_system/temporary/Cargo.toml
+++ b/rs/nervous_system/temporary/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "ic-nervous-system-temporary"
+version = "0.0.1"
+edition = { workspace = true }
+
+[dev-dependencies]
+rand = { workspace = true }

--- a/rs/nervous_system/temporary/src/lib.rs
+++ b/rs/nervous_system/temporary/src/lib.rs
@@ -1,0 +1,96 @@
+//! This should probably not be used outside of test.
+//!
+//! This is for "feature flags". That is,
+//!
+//!     use ic_nervous_system_temporary::Temporary;
+//!     use std::cell::RefCell;
+//!     use rand::Rng;
+//!
+//!     thread_local! {
+//!         static IS_FOO_ENABLED: RefCell<bool> = RefCell::new(rand::thread_rng().gen());
+//!     }
+//!
+//!     pub fn is_foo_enabled() -> bool {
+//!         IS_FOO_ENABLED.with(|ok| {
+//!             let ok = ok.borrow();
+//!             *ok
+//!         })
+//!     }
+//!
+//!     fn code_under_test() -> i64 {
+//!         if is_foo_enabled() {
+//!             42
+//!         } else {
+//!             99
+//!         }
+//!     }
+//!
+//!     #[cfg(test)]
+//!     fn temporarily_enable_foo() -> Temporary {
+//!         Temporary::new(&FOO, true)
+//!     }
+//!
+//!     #[cfg(test)]
+//!     fn temporarily_disable_foo() -> Temporary {
+//!         Temporary::new(&FOO, false)
+//!     }
+//!
+//!     // Then, in tests, you can see what happens depending on whether the
+//!     // feature is or disabled without having to have separate
+//!     // feature = "test" builds, like so:
+//!
+//!     #[test]
+//!     fn test_foo_enabled() {
+//!         let _restore_foo_on_drop = temporarily_enable_foo();
+//!
+//!         let result = code_under_test();
+//!
+//!         assert_eq!(result, 42);
+//!     }
+//!
+//!     #[test]
+//!     fn test_foo_disabled() {
+//!         let _restore_foo_on_drop = temporarily_disable_foo();
+//!
+//!         let result = code_under_test();
+//!
+//!         assert_eq!(result, 99);
+//!     }
+//!
+//! If you want to call temporarily_*_foo from integration tests, you will have
+//! to get rid of the #[cfg(test)] attributes, and also add pub.
+
+use std::{cell::RefCell, thread::LocalKey};
+
+// This could be generic. That is, add a T parameter. Currently, only bool is supported, because YAGNI.
+#[must_use]
+pub struct Temporary {
+    flag: &'static LocalKey<RefCell<bool>>,
+    original_value: bool,
+}
+
+impl Temporary {
+    pub fn new(flag: &'static LocalKey<RefCell<bool>>, temporary_value: bool) -> Self {
+        // Set to true. Will be set back to false during drop.
+        let original_value = flag.with(|flag| {
+            let mut flag = flag.borrow_mut();
+            let original_value: bool = *flag;
+            *flag = temporary_value;
+            original_value
+        });
+
+        Self {
+            flag,
+            original_value,
+        }
+    }
+}
+
+impl Drop for Temporary {
+    fn drop(&mut self) {
+        self.flag.with(|flag| {
+            let mut flag = flag.borrow_mut();
+            *flag = self.original_value;
+        })
+    }
+}

--- a/rs/nervous_system/temporary/tests/temporary.rs
+++ b/rs/nervous_system/temporary/tests/temporary.rs
@@ -1,16 +1,13 @@
 use ic_nervous_system_temporary::Temporary;
-use std::cell::RefCell;
+use std::cell::Cell;
 
 thread_local! {
-    static IS_FOO_ENABLED: RefCell<bool> = const { RefCell::new(false) };
-    static IS_BAR_ENABLED: RefCell<bool> = const { RefCell::new(true) };
+    static IS_FOO_ENABLED: Cell<bool> = const { Cell::new(false) };
+    static IS_BAR_ENABLED: Cell<bool> = const { Cell::new(true) };
 }
 
 pub fn is_foo_enabled() -> bool {
-    IS_FOO_ENABLED.with(|ok| {
-        let ok = ok.borrow();
-        *ok
-    })
+    IS_FOO_ENABLED.with(|ok| ok.get())
 }
 
 pub fn temporarily_enable_foo() -> Temporary {
@@ -22,10 +19,7 @@ pub fn temporarily_disable_foo() -> Temporary {
 }
 
 pub fn is_bar_enabled() -> bool {
-    IS_BAR_ENABLED.with(|ok| {
-        let ok = ok.borrow();
-        *ok
-    })
+    IS_BAR_ENABLED.with(|ok| ok.get())
 }
 
 pub fn temporarily_enable_bar() -> Temporary {

--- a/rs/nervous_system/temporary/tests/temporary.rs
+++ b/rs/nervous_system/temporary/tests/temporary.rs
@@ -1,0 +1,71 @@
+use ic_nervous_system_temporary::Temporary;
+use std::cell::RefCell;
+
+thread_local! {
+    static IS_FOO_ENABLED: RefCell<bool> = const { RefCell::new(false) };
+    static IS_BAR_ENABLED: RefCell<bool> = const { RefCell::new(true) };
+}
+
+pub fn is_foo_enabled() -> bool {
+    IS_FOO_ENABLED.with(|ok| {
+        let ok = ok.borrow();
+        *ok
+    })
+}
+
+pub fn temporarily_enable_foo() -> Temporary {
+    Temporary::new(&IS_FOO_ENABLED, true)
+}
+
+pub fn temporarily_disable_foo() -> Temporary {
+    Temporary::new(&IS_FOO_ENABLED, false)
+}
+
+pub fn is_bar_enabled() -> bool {
+    IS_BAR_ENABLED.with(|ok| {
+        let ok = ok.borrow();
+        *ok
+    })
+}
+
+pub fn temporarily_enable_bar() -> Temporary {
+    Temporary::new(&IS_BAR_ENABLED, true)
+}
+
+pub fn temporarily_disable_bar() -> Temporary {
+    Temporary::new(&IS_BAR_ENABLED, false)
+}
+
+#[test]
+fn test_temporarily_enable() {
+    assert!(!is_foo_enabled());
+    assert!(is_bar_enabled());
+
+    {
+        let _restore_foo_on_drop = temporarily_enable_foo();
+        let _restore_bar_on_drop = temporarily_enable_bar();
+
+        assert!(is_foo_enabled());
+        assert!(is_bar_enabled());
+    }
+
+    assert!(!is_foo_enabled());
+    assert!(is_bar_enabled());
+}
+
+#[test]
+fn test_temporarily_disable() {
+    assert!(!is_foo_enabled());
+    assert!(is_bar_enabled());
+
+    {
+        let _restore_foo_on_drop = temporarily_disable_foo();
+        let _restore_bar_on_drop = temporarily_disable_bar();
+
+        assert!(!is_foo_enabled());
+        assert!(!is_bar_enabled());
+    }
+
+    assert!(!is_foo_enabled());
+    assert!(is_bar_enabled());
+}

--- a/rs/nns/governance/BUILD.bazel
+++ b/rs/nns/governance/BUILD.bazel
@@ -26,6 +26,7 @@ BASE_DEPENDENCIES = [
     "//rs/nervous_system/proto",
     "//rs/nervous_system/root",
     "//rs/nervous_system/runtime",
+    "//rs/nervous_system/temporary",
     "//rs/nns/cmc",
     "//rs/nns/common",
     "//rs/nns/gtc_accounts",
@@ -130,6 +131,14 @@ MACRO_DEV_DEPENDENCIES = []
 
 ALIASES = {}
 
+LIB_SRCS = glob(
+    ["src/**/*.rs"],
+    exclude = [
+        "**/*tests.rs",
+        "**/tests/**",
+    ],
+)
+
 cargo_build_script(
     name = "build_script",
     srcs = ["build.rs"],
@@ -141,10 +150,7 @@ cargo_build_script(
 
 rust_library(
     name = "governance",
-    srcs = glob(
-        ["src/**/*.rs"],
-        exclude = ["**/*tests.rs"],
-    ),
+    srcs = LIB_SRCS,
     aliases = ALIASES,
     crate_name = "ic_nns_governance",
     proc_macro_deps = MACRO_DEPENDENCIES,
@@ -156,10 +162,7 @@ rust_library(
 
 rust_library(
     name = "governance--test_feature",
-    srcs = glob(
-        ["src/**/*.rs"],
-        exclude = ["**/*tests.rs"],
-    ),
+    srcs = LIB_SRCS,
     aliases = ALIASES,
     crate_features = ["test"],
     crate_name = "ic_nns_governance",
@@ -172,10 +175,7 @@ rust_library(
 
 rust_library(
     name = "governance--canbench_feature",
-    srcs = glob(
-        ["src/**/*.rs"],
-        exclude = ["**/*tests.rs"],
-    ),
+    srcs = LIB_SRCS,
     aliases = ALIASES,
     crate_features = ["canbench-rs"],
     crate_name = "ic_nns_governance",

--- a/rs/nns/governance/Cargo.toml
+++ b/rs/nns/governance/Cargo.toml
@@ -50,6 +50,7 @@ ic-nervous-system-governance = { path = "../../nervous_system/governance" }
 ic-nervous-system-root = { path = "../../nervous_system/root" }
 ic-nervous-system-runtime = { path = "../../nervous_system/runtime" }
 ic-nervous-system-proto = { path = "../../nervous_system/proto" }
+ic-nervous-system-temporary = { path = "../../nervous_system/temporary" }
 ic-neurons-fund = { path = "../../nervous_system/neurons_fund" }
 ic-nns-common = { path = "../common" }
 ic-nns-constants = { path = "../constants" }

--- a/rs/nns/governance/canister/canister.rs
+++ b/rs/nns/governance/canister/canister.rs
@@ -606,7 +606,7 @@ fn get_neuron_info() {
 #[candid_method(query, rename = "get_neuron_info")]
 fn get_neuron_info_(neuron_id: NeuronId) -> Result<NeuronInfo, GovernanceError> {
     governance()
-        .get_neuron_info(&NeuronIdProto::from(neuron_id))
+        .get_neuron_info(&NeuronIdProto::from(neuron_id), caller())
         .map(NeuronInfo::from)
         .map_err(GovernanceError::from)
 }
@@ -625,6 +625,7 @@ fn get_neuron_info_by_id_or_subaccount_(
     governance()
         .get_neuron_info_by_id_or_subaccount(
             &(gov_pb::manage_neuron::NeuronIdOrSubaccount::from(by)),
+            caller(),
         )
         .map(NeuronInfo::from)
         .map_err(GovernanceError::from)

--- a/rs/nns/governance/src/governance.rs
+++ b/rs/nns/governance/src/governance.rs
@@ -2173,7 +2173,7 @@ impl Governance {
             // requested_neuron_ids are supplied by the caller.
             let _ignore_when_neuron_not_found = self.with_neuron(&neuron_id, |neuron| {
                 // Populate neuron_infos.
-                neuron_infos.insert(neuron_id.id, neuron.get_neuron_info(now));
+                neuron_infos.insert(neuron_id.id, neuron.get_neuron_info(now, caller));
 
                 // Populate full_neurons.
                 let let_caller_read_full_neuron =
@@ -2852,7 +2852,7 @@ impl Governance {
 
         // Step 7: builds the response.
         Ok(ManageNeuronResponse::merge_response(
-            build_merge_neurons_response(&source_neuron, &target_neuron, now),
+            build_merge_neurons_response(&source_neuron, &target_neuron, now, *caller),
         ))
     }
 
@@ -2920,7 +2920,7 @@ impl Governance {
 
         // Step 4: builds the response.
         Ok(ManageNeuronResponse::merge_response(
-            build_merge_neurons_response(&source_neuron, &target_neuron, now),
+            build_merge_neurons_response(&source_neuron, &target_neuron, now, *caller),
         ))
     }
 
@@ -3457,9 +3457,13 @@ impl Governance {
     /// Returns the neuron info for a given neuron `id`. This method
     /// does not require authorization, so the `NeuronInfo` of a
     /// neuron is accessible to any caller.
-    pub fn get_neuron_info(&self, id: &NeuronId) -> Result<NeuronInfo, GovernanceError> {
+    pub fn get_neuron_info(
+        &self,
+        id: &NeuronId,
+        requester: PrincipalId,
+    ) -> Result<NeuronInfo, GovernanceError> {
         let now = self.env.now();
-        self.with_neuron(id, |neuron| neuron.get_neuron_info(now))
+        self.with_neuron(id, |neuron| neuron.get_neuron_info(now, requester))
     }
 
     /// Returns the neuron info for a neuron identified by id or subaccount.
@@ -3468,9 +3472,10 @@ impl Governance {
     pub fn get_neuron_info_by_id_or_subaccount(
         &self,
         find_by: &NeuronIdOrSubaccount,
+        requester: PrincipalId,
     ) -> Result<NeuronInfo, GovernanceError> {
         self.with_neuron_by_neuron_id_or_subaccount(find_by, |neuron| {
-            neuron.get_neuron_info(self.env.now())
+            neuron.get_neuron_info(self.env.now(), requester)
         })
     }
 

--- a/rs/nns/governance/src/governance/merge_neurons.rs
+++ b/rs/nns/governance/src/governance/merge_neurons.rs
@@ -345,11 +345,12 @@ pub fn build_merge_neurons_response(
     source: &Neuron,
     target: &Neuron,
     now_seconds: u64,
+    requester: PrincipalId,
 ) -> MergeResponse {
     let source_neuron = Some(NeuronProto::from(source.clone()));
     let target_neuron = Some(NeuronProto::from(target.clone()));
-    let source_neuron_info = Some(source.get_neuron_info(now_seconds));
-    let target_neuron_info = Some(target.get_neuron_info(now_seconds));
+    let source_neuron_info = Some(source.get_neuron_info(now_seconds, requester));
+    let target_neuron_info = Some(target.get_neuron_info(now_seconds, requester));
     MergeResponse {
         source_neuron,
         target_neuron,

--- a/rs/nns/governance/src/lib.rs
+++ b/rs/nns/governance/src/lib.rs
@@ -134,7 +134,7 @@ use candid::DecoderConfig;
 use ic_nervous_system_temporary::Temporary;
 use mockall::automock;
 use std::{
-    cell::RefCell,
+    cell::Cell,
     collections::{BTreeMap, HashMap},
     io,
 };
@@ -184,14 +184,11 @@ thread_local! {
     // 1-line change (by replacing true with `cfg!(feature = "test")`). After
     // the feature has been released, it will go through its "probation" period.
     // If that goes well, then, this can be deleted.
-    static IS_PRIVATE_NEURON_ENFORCEMENT_ENABLED: RefCell<bool> = const { RefCell::new(cfg!(feature = "test")) };
+    static IS_PRIVATE_NEURON_ENFORCEMENT_ENABLED: Cell<bool> = const { Cell::new(cfg!(feature = "test")) };
 }
 
 pub fn is_private_neuron_enforcement_enabled() -> bool {
-    IS_PRIVATE_NEURON_ENFORCEMENT_ENABLED.with(|ok| {
-        let ok = ok.borrow();
-        *ok
-    })
+    IS_PRIVATE_NEURON_ENFORCEMENT_ENABLED.with(|ok| ok.get())
 }
 
 /// Only integration tests should use this.

--- a/rs/nns/governance/src/neuron/types.rs
+++ b/rs/nns/governance/src/neuron/types.rs
@@ -3,6 +3,7 @@ use crate::{
         LOG_PREFIX, MAX_DISSOLVE_DELAY_SECONDS, MAX_NEURON_AGE_FOR_AGE_BONUS,
         MAX_NEURON_RECENT_BALLOTS, MAX_NUM_HOT_KEYS_PER_NEURON,
     },
+    is_private_neuron_enforcement_enabled,
     neuron::{combine_aged_stakes, dissolve_state_and_age::DissolveStateAndAge, neuron_stake_e8s},
     neuron_store::NeuronStoreError,
     pb::v1::{
@@ -707,18 +708,27 @@ impl Neuron {
     }
 
     /// Get the 'public' information associated with this neuron.
-    pub fn get_neuron_info(&self, now_seconds: u64) -> NeuronInfo {
-        // TODO(NNS1-3076): Enforce visibility.
+    pub fn get_neuron_info(&self, now_seconds: u64, requester: PrincipalId) -> NeuronInfo {
+        let mut recent_ballots = vec![];
+        let mut joined_community_fund_timestamp_seconds = None;
+
+        let redact =
+            is_private_neuron_enforcement_enabled() && !self.is_hotkey_or_controller(&requester);
+        if !redact {
+            recent_ballots.append(&mut self.recent_ballots.clone());
+            joined_community_fund_timestamp_seconds = self.joined_community_fund_timestamp_seconds;
+        }
+
         NeuronInfo {
             retrieved_at_timestamp_seconds: now_seconds,
             state: self.state(now_seconds) as i32,
             age_seconds: self.age_seconds(now_seconds),
             dissolve_delay_seconds: self.dissolve_delay_seconds(now_seconds),
-            recent_ballots: self.recent_ballots.clone(),
+            recent_ballots,
             voting_power: self.voting_power(now_seconds),
             created_timestamp_seconds: self.created_timestamp_seconds,
             stake_e8s: self.minted_stake_e8s(),
-            joined_community_fund_timestamp_seconds: self.joined_community_fund_timestamp_seconds,
+            joined_community_fund_timestamp_seconds,
             known_neuron_data: self.known_neuron_data.clone(),
             neuron_type: self.neuron_type,
             visibility: self.visibility.map(|visibility| visibility as i32),

--- a/rs/nns/governance/src/neuron/types.rs
+++ b/rs/nns/governance/src/neuron/types.rs
@@ -720,15 +720,12 @@ impl Neuron {
             joined_community_fund_timestamp_seconds = self.joined_community_fund_timestamp_seconds;
         }
 
-        let mut visibility = self.visibility.map(|visibility| visibility as i32);
-        let force_explicit_visibility =
-            is_private_neuron_enforcement_enabled() && visibility.is_none();
-        if force_explicit_visibility {
-            visibility = Some(if self.known_neuron_data.is_some() {
-                Visibility::Public
-            } else {
-                Visibility::Private
-            } as i32);
+        let visibility = if !is_private_neuron_enforcement_enabled() {
+            None
+        } else if self.known_neuron_data.is_some() {
+            Some(Visibility::Public as i32)
+        } else {
+            Some(self.visibility.unwrap_or(Visibility::Private) as i32)
         };
 
         NeuronInfo {

--- a/rs/nns/governance/tests/governance.rs
+++ b/rs/nns/governance/tests/governance.rs
@@ -14047,6 +14047,24 @@ fn test_neuron_info_private_enforcement() {
             (known_neuron.id.unwrap(), false),
         ];
         main(neuron_id_to_expect_redact);
+
+        for (neuron_id, expected_visibility) in [
+            (
+                no_explicit_visibility_neuron.id.unwrap(),
+                Visibility::Private,
+            ),
+            (private_neuron.id.unwrap(), Visibility::Private),
+            (public_neuron.id.unwrap(), Visibility::Public),
+            (known_neuron.id.unwrap(), Visibility::Public),
+        ] {
+            let neuron_info = governance.get_neuron_info(&neuron_id, controller).unwrap();
+            assert_eq!(
+                neuron_info.visibility,
+                Some(expected_visibility as i32),
+                "{:?}",
+                neuron_info,
+            );
+        }
     }
 
     // Case B: Private neurons are NOT enforced.
@@ -14066,6 +14084,17 @@ fn test_neuron_info_private_enforcement() {
             (known_neuron.id.unwrap(), false),
         ];
         main(neuron_id_to_expect_redact);
+
+        // Insepct visibility. This time, it should always be None.
+        for neuron_id in [
+            no_explicit_visibility_neuron.id.unwrap(),
+            private_neuron.id.unwrap(),
+            public_neuron.id.unwrap(),
+            known_neuron.id.unwrap(),
+        ] {
+            let neuron_info = governance.get_neuron_info(&neuron_id, controller).unwrap();
+            assert_eq!(neuron_info.visibility, None, "{:?}", neuron_info,);
+        }
     }
 }
 

--- a/rs/nns/governance/tests/governance.rs
+++ b/rs/nns/governance/tests/governance.rs
@@ -54,6 +54,7 @@ use ic_nns_governance::{
         REWARD_DISTRIBUTION_PERIOD_SECONDS, WAIT_FOR_QUIET_DEADLINE_INCREASE_SECONDS,
     },
     governance_proto_builder::GovernanceProtoBuilder,
+    is_private_neuron_enforcement_enabled,
     pb::v1::{
         add_or_remove_node_provider::Change,
         governance::{GovernanceCachedMetrics, GovernanceCachedMetricsChange, MigrationsDesc},
@@ -92,6 +93,7 @@ use ic_nns_governance::{
         WaitForQuietStateDesc,
     },
     proposals::create_service_nervous_system::ExecutedCreateServiceNervousSystemProposal,
+    temporarily_disable_private_neuron_enforcement, temporarily_enable_private_neuron_enforcement,
 };
 use ic_nns_governance_init::GovernanceCanisterInitPayloadBuilder;
 use ic_sns_init::pb::v1::SnsInitPayload;
@@ -134,6 +136,10 @@ pub mod fixtures;
 // Using a `pub mod` works around spurious dead code warnings; see
 // https://github.com/rust-lang/rust/issues/46379
 pub mod common;
+
+lazy_static! {
+    static ref RANDOM_PRINCIPAL_ID: PrincipalId = PrincipalId::new_user_test_id(0xDEAD_BEEF);
+}
 
 const DEFAULT_TEST_START_TIMESTAMP_SECONDS: u64 = 999_111_000_u64;
 
@@ -2027,13 +2033,15 @@ fn test_query_for_manage_neuron() {
     );
     // Test that anybody can call `get_neuron_info` as long as the
     // neuron exists.
-    let neuron_info = gov.get_neuron_info(&NeuronId { id: 1 }).unwrap();
+    let neuron_info = gov
+        .get_neuron_info(&NeuronId { id: 1 }, *RANDOM_PRINCIPAL_ID)
+        .unwrap();
     assert_eq!(1066, neuron_info.created_timestamp_seconds);
     assert_eq!(1_000_000_000, neuron_info.stake_e8s,);
     // But not if it doesn't exist.
     assert_eq!(
         ErrorType::NotFound as i32,
-        gov.get_neuron_info(&NeuronId { id: 100 })
+        gov.get_neuron_info(&NeuronId { id: 100 }, *RANDOM_PRINCIPAL_ID)
             .unwrap_err()
             .error_type
     );
@@ -2044,9 +2052,10 @@ fn test_query_for_manage_neuron() {
         .unwrap();
     assert_eq!(
         1066,
-        gov.get_neuron_info_by_id_or_subaccount(&NeuronIdOrSubaccount::Subaccount(
-            neuron_1_subaccount.to_vec()
-        ))
+        gov.get_neuron_info_by_id_or_subaccount(
+            &NeuronIdOrSubaccount::Subaccount(neuron_1_subaccount.to_vec()),
+            *RANDOM_PRINCIPAL_ID,
+        )
         .unwrap()
         .created_timestamp_seconds
     );
@@ -2062,9 +2071,10 @@ fn test_query_for_manage_neuron() {
     // But not if it doesn't exist.
     assert_eq!(
         ErrorType::NotFound as i32,
-        gov.get_neuron_info_by_id_or_subaccount(&NeuronIdOrSubaccount::Subaccount(
-            [0u8; 32].to_vec()
-        ))
+        gov.get_neuron_info_by_id_or_subaccount(
+            &NeuronIdOrSubaccount::Subaccount([0u8; 32].to_vec()),
+            *RANDOM_PRINCIPAL_ID,
+        )
         .unwrap_err()
         .error_type
     );
@@ -2186,7 +2196,7 @@ async fn test_manage_neuron() {
             .status()
     );
     assert_eq!(
-        gov.get_neuron_info(&NeuronId { id: 2 })
+        gov.get_neuron_info(&NeuronId { id: 2 }, principal(2))
             .unwrap()
             .recent_ballots,
         vec![BallotInfo {
@@ -2224,7 +2234,7 @@ async fn test_manage_neuron() {
             .status()
     );
     assert_eq!(
-        gov.get_neuron_info(&NeuronId { id: 3 })
+        gov.get_neuron_info(&NeuronId { id: 3 }, principal(3),)
             .unwrap()
             .recent_ballots,
         vec![BallotInfo {
@@ -4233,7 +4243,9 @@ fn create_mature_neuron(dissolved: bool) -> (fake::FakeDriver, Governance, Neuro
             .with_neuron(&id, |neuron| neuron.clone())
             .expect("Neuron not found");
         assert_eq!(
-            neuron.get_neuron_info(driver.now()).state(),
+            neuron
+                .get_neuron_info(driver.now(), *RANDOM_PRINCIPAL_ID)
+                .state(),
             NeuronState::Dissolved
         );
     } else {
@@ -4812,7 +4824,7 @@ fn test_claim_or_refresh_neuron_does_not_overflow() {
     // some age.
     driver.advance_time_by(12 * ic_nervous_system_common::ONE_MONTH_SECONDS);
 
-    let neuron_info = gov.get_neuron_info(&nid).unwrap();
+    let neuron_info = gov.get_neuron_info(&nid, *RANDOM_PRINCIPAL_ID).unwrap();
     assert_eq!(
         neuron_info.age_seconds,
         12 * ic_nervous_system_common::ONE_MONTH_SECONDS,
@@ -4844,7 +4856,9 @@ fn test_claim_or_refresh_neuron_does_not_overflow() {
 
     assert_eq!(nid_result, nid);
     assert_eq!(
-        gov.get_neuron_info(&nid).unwrap().stake_e8s,
+        gov.get_neuron_info(&nid, *RANDOM_PRINCIPAL_ID)
+            .unwrap()
+            .stake_e8s,
         previous_stake_e8s + 100_000_000_000_000
     );
 }
@@ -4993,7 +5007,9 @@ fn test_neuron_split_fails() {
         .neuron_minimum_stake_e8s;
 
     assert_eq!(
-        neuron.get_neuron_info(driver.now()).state(),
+        neuron
+            .get_neuron_info(driver.now(), *RANDOM_PRINCIPAL_ID)
+            .state(),
         NeuronState::NotDissolving
     );
 
@@ -5106,7 +5122,9 @@ fn test_neuron_split() {
             neuron.maturity_e8s_equivalent = maturity_e8s;
             neuron.staked_maturity_e8s_equivalent = Some(staked_maturity_e8s);
 
-            neuron.get_neuron_info(driver.now()).state()
+            neuron
+                .get_neuron_info(driver.now(), *RANDOM_PRINCIPAL_ID)
+                .state()
         })
         .expect("Neuron not found");
 
@@ -5213,7 +5231,9 @@ fn test_seed_neuron_split() {
         .transaction_fee_e8s;
 
     assert_eq!(
-        neuron.get_neuron_info(driver.now()).state(),
+        neuron
+            .get_neuron_info(driver.now(), *RANDOM_PRINCIPAL_ID)
+            .state(),
         NeuronState::NotDissolving
     );
 
@@ -5285,7 +5305,9 @@ fn test_neuron_spawn() {
 
     let now = driver.now();
     assert_eq!(
-        gov.with_neuron(&id, |neuron| neuron.get_neuron_info(now).state())
+        gov.with_neuron(&id, |neuron| neuron
+            .get_neuron_info(now, *RANDOM_PRINCIPAL_ID)
+            .state())
             .unwrap(),
         NeuronState::NotDissolving
     );
@@ -5458,7 +5480,9 @@ fn test_neuron_spawn_with_subaccount() {
 
     let now = driver.now();
     assert_eq!(
-        gov.with_neuron(&id, |neuron| neuron.get_neuron_info(now).state())
+        gov.with_neuron(&id, |neuron| neuron
+            .get_neuron_info(now, *RANDOM_PRINCIPAL_ID)
+            .state())
             .unwrap(),
         NeuronState::NotDissolving
     );
@@ -5637,7 +5661,9 @@ fn assert_neuron_spawn_partial(
         .with_neuron(&id, |neuron| neuron.clone())
         .expect("Neuron did not exist");
     assert_eq!(
-        neuron.get_neuron_info(driver.now()).state(),
+        neuron
+            .get_neuron_info(driver.now(), *RANDOM_PRINCIPAL_ID)
+            .state(),
         NeuronState::NotDissolving
     );
 
@@ -6007,7 +6033,9 @@ fn test_disburse_to_neuron() {
     // The neuron state should now be "Dissolved", meaning we can
     // now disburse the neuron.
     assert_eq!(
-        parent_neuron.get_neuron_info(driver.now()).state(),
+        parent_neuron
+            .get_neuron_info(driver.now(), *RANDOM_PRINCIPAL_ID)
+            .state(),
         NeuronState::Dissolved
     );
 
@@ -9081,7 +9109,9 @@ fn test_start_dissolving() {
     // Advance time so that the neuron has age.
     fake_driver.advance_time_by(1);
 
-    let neuron_info = gov.get_neuron_info(&NeuronId { id }).unwrap();
+    let neuron_info = gov
+        .get_neuron_info(&NeuronId { id }, *RANDOM_PRINCIPAL_ID)
+        .unwrap();
     assert_eq!(
         neuron_info.dissolve_delay_seconds,
         MIN_DISSOLVE_DELAY_FOR_VOTE_ELIGIBILITY_SECONDS
@@ -9107,7 +9137,9 @@ fn test_start_dissolving() {
     .unwrap()
     .panic_if_error("Manage neuron failed");
 
-    let neuron_info = gov.get_neuron_info(&NeuronId { id }).unwrap();
+    let neuron_info = gov
+        .get_neuron_info(&NeuronId { id }, *RANDOM_PRINCIPAL_ID)
+        .unwrap();
     assert_eq!(neuron_info.state, NeuronState::Dissolving as i32);
     assert_eq!(neuron_info.age_seconds, 0);
 }
@@ -9133,7 +9165,9 @@ fn test_start_dissolving_panics() {
         fake_driver.get_fake_cmc(),
     );
 
-    let neuron_info = gov.get_neuron_info(&NeuronId { id }).unwrap();
+    let neuron_info = gov
+        .get_neuron_info(&NeuronId { id }, *RANDOM_PRINCIPAL_ID)
+        .unwrap();
     assert_eq!(neuron_info.state, NeuronState::Dissolved as i32);
 
     gov.manage_neuron(
@@ -9176,7 +9210,9 @@ fn test_stop_dissolving() {
         fake_driver.get_fake_cmc(),
     );
 
-    let neuron_info = gov.get_neuron_info(&NeuronId { id }).unwrap();
+    let neuron_info = gov
+        .get_neuron_info(&NeuronId { id }, *RANDOM_PRINCIPAL_ID)
+        .unwrap();
     assert_eq!(neuron_info.state, NeuronState::Dissolving as i32);
     assert_eq!(
         neuron_info.dissolve_delay_seconds,
@@ -9204,7 +9240,9 @@ fn test_stop_dissolving() {
     // Advance time so that the neuron has age.
     fake_driver.advance_time_by(1);
 
-    let neuron_info = gov.get_neuron_info(&NeuronId { id }).unwrap();
+    let neuron_info = gov
+        .get_neuron_info(&NeuronId { id }, *RANDOM_PRINCIPAL_ID)
+        .unwrap();
     assert_eq!(neuron_info.state, NeuronState::NotDissolving as i32);
     assert_eq!(
         neuron_info.dissolve_delay_seconds,
@@ -9234,7 +9272,9 @@ fn test_stop_dissolving_panics() {
         fake_driver.get_fake_cmc(),
     );
 
-    let neuron_info = gov.get_neuron_info(&NeuronId { id }).unwrap();
+    let neuron_info = gov
+        .get_neuron_info(&NeuronId { id }, *RANDOM_PRINCIPAL_ID)
+        .unwrap();
     assert_eq!(neuron_info.state, NeuronState::NotDissolving as i32);
     assert_eq!(
         neuron_info.dissolve_delay_seconds,
@@ -9402,7 +9442,9 @@ fn test_increase_dissolve_delay() {
     // Tests for neuron 1. Non-dissolving.
     increase_dissolve_delay(&mut gov, principal_id, 1, 1);
 
-    let neuron_info = gov.get_neuron_info(&NeuronId { id: 1 }).unwrap();
+    let neuron_info = gov
+        .get_neuron_info(&NeuronId { id: 1 }, *RANDOM_PRINCIPAL_ID)
+        .unwrap();
     assert_eq!(neuron_info.state, NeuronState::NotDissolving as i32);
     assert_eq!(
         neuron_info.dissolve_delay_seconds,
@@ -9416,7 +9458,9 @@ fn test_increase_dissolve_delay() {
         u32::try_from(MAX_DISSOLVE_DELAY_SECONDS + 1)
             .expect("MAX_DISSOLVE_DELAY_SECONDS larger than u32"),
     );
-    let neuron_info = gov.get_neuron_info(&NeuronId { id: 1 }).unwrap();
+    let neuron_info = gov
+        .get_neuron_info(&NeuronId { id: 1 }, *RANDOM_PRINCIPAL_ID)
+        .unwrap();
     assert_eq!(neuron_info.state, NeuronState::NotDissolving as i32);
     assert_eq!(
         neuron_info.dissolve_delay_seconds,
@@ -9425,7 +9469,9 @@ fn test_increase_dissolve_delay() {
 
     // Tests for neuron 2. Dissolving.
     increase_dissolve_delay(&mut gov, principal_id, 2, 1);
-    let neuron_info = gov.get_neuron_info(&NeuronId { id: 2 }).unwrap();
+    let neuron_info = gov
+        .get_neuron_info(&NeuronId { id: 2 }, *RANDOM_PRINCIPAL_ID)
+        .unwrap();
     assert_eq!(neuron_info.state, NeuronState::Dissolving as i32);
     assert_eq!(
         neuron_info.dissolve_delay_seconds,
@@ -9439,7 +9485,9 @@ fn test_increase_dissolve_delay() {
         u32::try_from(MAX_DISSOLVE_DELAY_SECONDS + 1)
             .expect("MAX_DISSOLVE_DELAY_SECONDS larger than u32"),
     );
-    let neuron_info = gov.get_neuron_info(&NeuronId { id: 2 }).unwrap();
+    let neuron_info = gov
+        .get_neuron_info(&NeuronId { id: 2 }, *RANDOM_PRINCIPAL_ID)
+        .unwrap();
     assert_eq!(neuron_info.state, NeuronState::Dissolving as i32);
     assert_eq!(
         neuron_info.dissolve_delay_seconds,
@@ -9454,7 +9502,9 @@ fn test_increase_dissolve_delay() {
         u32::try_from(MIN_DISSOLVE_DELAY_FOR_VOTE_ELIGIBILITY_SECONDS)
             .expect("MIN_DISSOLVE_DELAY_FOR_VOTE_ELIGIBILITY_SECONDS larger than u32"),
     );
-    let neuron_info = gov.get_neuron_info(&NeuronId { id: 3 }).unwrap();
+    let neuron_info = gov
+        .get_neuron_info(&NeuronId { id: 3 }, *RANDOM_PRINCIPAL_ID)
+        .unwrap();
     assert_eq!(neuron_info.state, NeuronState::NotDissolving as i32);
     assert_eq!(
         neuron_info.dissolve_delay_seconds,
@@ -9593,21 +9643,20 @@ fn test_join_neurons_fund() {
         );
         // 30 days in now
         assert_eq!(
-            60 * 60 * 24 * 30,
+            Some(60 * 60 * 24 * 30),
             gov.neuron_store
                 .heap_neurons()
                 .get(&3)
                 .unwrap()
                 .joined_community_fund_timestamp_seconds
-                .unwrap_or(0)
         );
         // Check that neuron info displays the same information.
-        let neuron_info = gov.get_neuron_info(&NeuronId { id: 3 }).unwrap();
+        let neuron_info = gov
+            .get_neuron_info(&NeuronId { id: 3 }, principal(principal_b))
+            .unwrap();
         assert_eq!(
-            60 * 60 * 24 * 30,
-            neuron_info
-                .joined_community_fund_timestamp_seconds
-                .unwrap_or(0)
+            Some(60 * 60 * 24 * 30),
+            neuron_info.joined_community_fund_timestamp_seconds
         );
     }
     // Advance time by two days...
@@ -11047,7 +11096,7 @@ async fn test_known_neurons() {
     )
     .unwrap();
     assert_eq!(
-        gov.get_neuron_info(&NeuronId { id: 1 })
+        gov.get_neuron_info(&NeuronId { id: 1 }, *RANDOM_PRINCIPAL_ID)
             .unwrap()
             .known_neuron_data
             .unwrap()
@@ -11127,7 +11176,7 @@ async fn test_known_neurons() {
     )
     .unwrap();
     assert_eq!(
-        gov.get_neuron_info(&NeuronId { id: 2 })
+        gov.get_neuron_info(&NeuronId { id: 2 }, *RANDOM_PRINCIPAL_ID)
             .unwrap()
             .known_neuron_data
             .unwrap()
@@ -13772,6 +13821,286 @@ fn voting_period_seconds_topic_dependency() {
 
     assert_eq!(voting_period_fun(Topic::Governance), 3); // any other topic should be 3
     assert_eq!(voting_period_fun(Topic::NetworkCanisterManagement), 3);
+}
+
+lazy_static! {
+    static ref NEURONS_FUND_NEURON_WITH_HOT_KEYS_AND_BALLOTS: Neuron = {
+        let neuron_id = 577_381_286;
+        let id = Some(NeuronId { id: neuron_id });
+
+        let controller = Some(PrincipalId::new_user_test_id(707_195_149));
+
+        let hot_key = PrincipalId::new_user_test_id(997_765_632);
+        let hot_keys = vec![hot_key];
+
+        let proposal_id = 440_663_685;
+        let recent_ballots = vec![
+            BallotInfo {
+                proposal_id: Some(ProposalId { id: proposal_id }),
+                vote: Vote::Yes as i32,
+            },
+        ];
+
+        let joined_community_fund_timestamp_seconds = Some(605_241_923);
+
+        let account = vec![42; 32];
+        let dissolve_state = Some(DissolveState::DissolveDelaySeconds(999));
+        let cached_neuron_stake_e8s = 10 * E8;
+
+        Neuron {
+            id,
+            controller,
+            hot_keys,
+            recent_ballots,
+            joined_community_fund_timestamp_seconds,
+
+            // Not used, but required for validity.
+            account,
+            dissolve_state,
+            cached_neuron_stake_e8s,
+
+            ..Default::default()
+        }
+    };
+}
+
+#[test]
+fn get_neuron_info_private_enforcement_enabled() {
+    // Step 1: Prepare the world.
+
+    let _restore_on_drop = temporarily_enable_private_neuron_enforcement();
+    assert!(is_private_neuron_enforcement_enabled());
+
+    let neuron_id = NEURONS_FUND_NEURON_WITH_HOT_KEYS_AND_BALLOTS.id.unwrap();
+
+    let governance_proto = GovernanceProtoBuilder::new()
+        .with_neurons(vec![NEURONS_FUND_NEURON_WITH_HOT_KEYS_AND_BALLOTS.clone()])
+        .build();
+
+    let driver = fake::FakeDriver::default(); // Initialize the minting account
+    let governance = Governance::new(
+        governance_proto,
+        driver.get_fake_env(),
+        driver.get_fake_ledger(),
+        driver.get_fake_cmc(),
+    );
+
+    // Step 2: Call the code under test.
+
+    let controller = NEURONS_FUND_NEURON_WITH_HOT_KEYS_AND_BALLOTS
+        .controller
+        .unwrap();
+    let hot_key = *NEURONS_FUND_NEURON_WITH_HOT_KEYS_AND_BALLOTS
+        .hot_keys
+        .first()
+        .unwrap();
+    let random_principal_id = PrincipalId::new_user_test_id(617_157_922);
+
+    // Step 2.1: Call get_neuron_info.
+
+    let get_neuron_info = |requester| governance.get_neuron_info(&neuron_id, requester).unwrap();
+    let controller_get_result = get_neuron_info(controller);
+    let hot_key_get_result = get_neuron_info(hot_key);
+    let random_principal_get_result = get_neuron_info(random_principal_id);
+
+    // Step 2.2: Call list_neurons.
+
+    let list_neurons = |requester| {
+        governance.list_neurons(
+            &ListNeurons {
+                neuron_ids: vec![neuron_id.id],
+                include_neurons_readable_by_caller: false,
+                include_empty_neurons_readable_by_caller: None,
+                include_public_neurons_in_full_neurons: None,
+            },
+            requester,
+        )
+    };
+    let controller_list_result = list_neurons(controller);
+    let hot_key_list_result = list_neurons(hot_key);
+    let random_principal_list_result = list_neurons(random_principal_id);
+
+    // Step 3: Inspect results.
+
+    // Step 3.1: Inspect get_neuron_info results.
+
+    let joined_community_fund_timestamp_seconds =
+        NEURONS_FUND_NEURON_WITH_HOT_KEYS_AND_BALLOTS.joined_community_fund_timestamp_seconds;
+    let recent_ballots = NEURONS_FUND_NEURON_WITH_HOT_KEYS_AND_BALLOTS
+        .recent_ballots
+        .clone();
+
+    // NF status and recent ballots are not redacted when controller calls.
+    assert_eq!(
+        controller_get_result.joined_community_fund_timestamp_seconds,
+        joined_community_fund_timestamp_seconds,
+        "{:#?}",
+        controller_get_result,
+    );
+    assert_eq!(
+        controller_get_result.recent_ballots, recent_ballots,
+        "{:#?}",
+        controller_get_result,
+    );
+
+    // Ditto for hot_key.
+    assert_eq!(hot_key_get_result, controller_get_result);
+
+    // When random principal calls, ballots and NF status are redacted.
+    assert_eq!(
+        random_principal_get_result.joined_community_fund_timestamp_seconds, None,
+        "{:#?}",
+        random_principal_get_result,
+    );
+    assert_eq!(
+        random_principal_get_result.recent_ballots,
+        vec![],
+        "{:#?}",
+        random_principal_get_result,
+    );
+
+    // Step 3.2: Inspect list_neurons results.
+
+    assert_eq!(
+        controller_list_result.neuron_infos,
+        hashmap! {
+            neuron_id.id => controller_get_result,
+        },
+        "{:#?}",
+        controller_list_result,
+    );
+    assert_eq!(
+        hot_key_list_result.neuron_infos,
+        hashmap! {
+            neuron_id.id => hot_key_get_result,
+        },
+        "{:#?}",
+        hot_key_list_result,
+    );
+    assert_eq!(
+        random_principal_list_result.neuron_infos,
+        hashmap! {
+            neuron_id.id => random_principal_get_result,
+        },
+        "{:#?}",
+        random_principal_list_result,
+    );
+}
+
+#[test]
+fn get_neuron_info_private_enforcement_disabled() {
+    // Step 1: Prepare the world.
+
+    // This is the only thing different in step 1 that differs vs. the previous test.
+    let _restore_on_drop = temporarily_disable_private_neuron_enforcement();
+    assert!(!is_private_neuron_enforcement_enabled());
+
+    let neuron_id = NEURONS_FUND_NEURON_WITH_HOT_KEYS_AND_BALLOTS.id.unwrap();
+
+    let governance_proto = GovernanceProtoBuilder::new()
+        .with_neurons(vec![NEURONS_FUND_NEURON_WITH_HOT_KEYS_AND_BALLOTS.clone()])
+        .build();
+
+    let driver = fake::FakeDriver::default(); // Initialize the minting account
+    let governance = Governance::new(
+        governance_proto,
+        driver.get_fake_env(),
+        driver.get_fake_ledger(),
+        driver.get_fake_cmc(),
+    );
+
+    // Step 2: Call the code under test. (Same as in the previous test.)
+
+    let controller = NEURONS_FUND_NEURON_WITH_HOT_KEYS_AND_BALLOTS
+        .controller
+        .unwrap();
+    let hot_key = *NEURONS_FUND_NEURON_WITH_HOT_KEYS_AND_BALLOTS
+        .hot_keys
+        .first()
+        .unwrap();
+    let random_principal_id = PrincipalId::new_user_test_id(617_157_922);
+
+    // Step 2.1: Call get_neuron_info.
+
+    let get_neuron_info = |requester| governance.get_neuron_info(&neuron_id, requester).unwrap();
+    let controller_get_result = get_neuron_info(controller);
+    let hot_key_get_result = get_neuron_info(hot_key);
+    let random_principal_get_result = get_neuron_info(random_principal_id);
+
+    // Step 2.2: Call list_neurons.
+
+    let list_neurons = |requester| {
+        governance.list_neurons(
+            &ListNeurons {
+                neuron_ids: vec![neuron_id.id],
+                include_neurons_readable_by_caller: false,
+                include_empty_neurons_readable_by_caller: None,
+                include_public_neurons_in_full_neurons: None,
+            },
+            requester,
+        )
+    };
+    let controller_list_result = list_neurons(controller);
+    let hot_key_list_result = list_neurons(hot_key);
+    let random_principal_list_result = list_neurons(random_principal_id);
+
+    // Step 3: Inspect results.
+
+    // Step 3.1: Inspect get_neuron_info results.
+
+    let joined_community_fund_timestamp_seconds =
+        NEURONS_FUND_NEURON_WITH_HOT_KEYS_AND_BALLOTS.joined_community_fund_timestamp_seconds;
+    let recent_ballots = NEURONS_FUND_NEURON_WITH_HOT_KEYS_AND_BALLOTS
+        .recent_ballots
+        .clone();
+
+    // NF status and recent ballots are not redacted when controller calls.
+    // (Same as previous test.)
+    assert_eq!(
+        controller_get_result.joined_community_fund_timestamp_seconds,
+        joined_community_fund_timestamp_seconds,
+        "{:#?}",
+        controller_get_result,
+    );
+    assert_eq!(
+        controller_get_result.recent_ballots, recent_ballots,
+        "{:#?}",
+        controller_get_result,
+    );
+
+    // Ditto for hot_key.
+    // (Same as previous test.)
+    assert_eq!(hot_key_get_result, controller_get_result);
+
+    // Unlike previous test, even random principal can see full NeuronInfo.
+    assert_eq!(random_principal_get_result, controller_get_result);
+
+    // Step 3.2: Inspect list_neurons results.
+
+    assert_eq!(
+        controller_list_result.neuron_infos,
+        hashmap! {
+            neuron_id.id => controller_get_result,
+        },
+        "{:#?}",
+        controller_list_result,
+    );
+    assert_eq!(
+        hot_key_list_result.neuron_infos,
+        hashmap! {
+            neuron_id.id => hot_key_get_result,
+        },
+        "{:#?}",
+        hot_key_list_result,
+    );
+    assert_eq!(
+        random_principal_list_result.neuron_infos,
+        hashmap! {
+            neuron_id.id => random_principal_get_result,
+        },
+        "{:#?}",
+        random_principal_list_result,
+    );
 }
 
 // TODO - remove after migration of neuron_store.topic_follow_index to being stored on upgrade

--- a/rs/nns/governance/tests/merge_neurons.rs
+++ b/rs/nns/governance/tests/merge_neurons.rs
@@ -5,8 +5,9 @@
 
 use comparable::{Changed, U64Change};
 use fixtures::NNSStateChange;
-use fixtures::{principal, NNSBuilder, NeuronBuilder};
+use fixtures::{NNSBuilder, NeuronBuilder};
 use futures::future::FutureExt;
+use ic_base_types::PrincipalId;
 use ic_nervous_system_common::ONE_YEAR_SECONDS;
 use ic_nns_common::pb::v1::NeuronId;
 use ic_nns_governance::{
@@ -46,14 +47,16 @@ fn do_test_merge_neurons(
     // Start the NNS 20 years after genesis, to give lots of time for aging.
     let epoch = DEFAULT_TEST_START_TIMESTAMP_SECONDS + (20 * ONE_YEAR_SECONDS);
 
+    let controller = PrincipalId::new_user_test_id(42);
+
     let mut nns = NNSBuilder::new()
         .set_start_time(epoch)
         .set_economics(NetworkEconomics::with_default_values())
         .with_supply(0) // causes minting account to be created
-        .add_account_for(principal(1), 0)
+        .add_account_for(controller, 0)
         // the source
         .add_neuron(
-            NeuronBuilder::new(1, n1_cached_stake, principal(1))
+            NeuronBuilder::new(1, n1_cached_stake, controller)
                 .set_dissolve_delay(n1_dissolve)
                 .set_maturity(n1_maturity)
                 .set_neuron_fees(n1_fees)
@@ -61,7 +64,7 @@ fn do_test_merge_neurons(
         )
         // the target
         .add_neuron(
-            NeuronBuilder::new(2, n2_cached_stake, principal(1))
+            NeuronBuilder::new(2, n2_cached_stake, controller)
                 .set_dissolve_delay(n2_dissolve)
                 .set_maturity(n2_maturity)
                 .set_neuron_fees(n2_fees)
@@ -74,7 +77,7 @@ fn do_test_merge_neurons(
 
     // First simulate
     let simulate_neuron_response = nns.governance.simulate_manage_neuron(
-        &principal(1),
+        &controller,
         ManageNeuron {
             id: Some(NeuronId { id: 2 }),
             neuron_id_or_subaccount: None,
@@ -97,7 +100,7 @@ fn do_test_merge_neurons(
         .governance
         .merge_neurons(
             &NeuronId { id: 2 },
-            &principal(1),
+            &controller,
             &Merge {
                 source_neuron_id: Some(NeuronId { id: 1 }),
             },
@@ -142,11 +145,15 @@ fn do_test_merge_neurons(
             );
             pretty_assertions::assert_eq!(
                 source_neuron_info,
-                nns.governance.get_neuron_info(&source_neuron_id).unwrap()
+                nns.governance
+                    .get_neuron_info(&source_neuron_id, controller)
+                    .unwrap()
             );
             pretty_assertions::assert_eq!(
                 target_neuron_info,
-                nns.governance.get_neuron_info(&target_neuron_id).unwrap()
+                nns.governance
+                    .get_neuron_info(&target_neuron_id, controller)
+                    .unwrap()
             );
         }
         CommandResponse::Error(e) => panic!("Received Error: {}", e),


### PR DESCRIPTION
This feature is currently disabled in release builds, and enabled in feature = "test" builds.

This also includes a tiny new library: ic_nervous_system_temporary. This just makes it easier to test flag-protected features. It makes it pretty easy to test the behavior both when the feature is enabled and when it is disabled without the need to test two different builds. This new library is in its own commit, which should make reviewing this PR easier.