### PR TITLE
feat(IDX): run execution tests on namespace

### DIFF
--- a/.github/workflows-source/ci-main.yml
+++ b/.github/workflows-source/ci-main.yml
@@ -172,7 +172,7 @@ jobs:
         with:
           BAZEL_CI_CONFIG: "--config=ci --config macos_ci"
           BAZEL_COMMAND: test
-          BAZEL_EXTRA_ARGS: ${{ github.event_name == 'schedule' && '--test_tag_filters=test_macos,test_macos_master' || '--test_tag_filters=test_macos' }}
+          BAZEL_EXTRA_ARGS: '--test_tag_filters=test_macos'
           BAZEL_STARTUP_ARGS: "--output_base /var/tmp/bazel-output/${ROOT_PIPELINE_ID}"
           BAZEL_TARGETS: "//rs/... //publish/binaries/..."
           HONEYCOMB_API_TOKEN: ${{ secrets.HONEYCOMB_API_TOKEN }}

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -158,7 +158,7 @@ jobs:
         with:
           BAZEL_CI_CONFIG: "--config=ci --config macos_ci"
           BAZEL_COMMAND: test
-          BAZEL_EXTRA_ARGS: ${{ github.event_name == 'schedule' && '--test_tag_filters=test_macos,test_macos_master' || '--test_tag_filters=test_macos' }}
+          BAZEL_EXTRA_ARGS: '--test_tag_filters=test_macos'
           BAZEL_STARTUP_ARGS: "--output_base /var/tmp/bazel-output/${ROOT_PIPELINE_ID}"
           BAZEL_TARGETS: "//rs/... //publish/binaries/..."
           HONEYCOMB_API_TOKEN: ${{ secrets.HONEYCOMB_API_TOKEN }}

--- a/.github/workflows/test-namespace-darwin.yml
+++ b/.github/workflows/test-namespace-darwin.yml
@@ -3,10 +3,11 @@ name: test-namespace
 on: [push]
 
 # Ensure there's only one instance of this workflow for any PR/branch/tag, and
-# cancel the previous one if necessary
+# cancel the previous one if necessary; except on master where we want to build
+# every commit
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.ref_name != 'master' }}
 
 jobs:
   test-namespace:
@@ -33,5 +34,5 @@ jobs:
             --bazelrc=./bazel/conf/.bazelrc.build --bazelrc=/tmp/bazel-cache.bazelrc \
             test \
             --config=ci --config=macos_ci \
-            --test_tag_filters="test_macos,-upload" \
+            --test_tag_filters="test_macos,test_macos_slow,-upload" \
             //rs/... //publish/binaries/...

--- a/gitlab-ci/config/main.yml
+++ b/gitlab-ci/config/main.yml
@@ -301,7 +301,7 @@ bazel-test-macos:
     - !reference [.rules-master-pipeline-no-merge-train-rust-bazel-changed, rules]
     - if: '$CI_PIPELINE_SOURCE == "schedule" && $SCHEDULE_NAME == "run-all-master"'
       variables:
-        BAZEL_EXTRA_ARGS: "--test_tag_filters=test_macos,test_macos_master"
+        BAZEL_EXTRA_ARGS: "--test_tag_filters=test_macos"
   tags:
     - macos
   variables:

--- a/gitlab-ci/config/zz-generated-gitlab-ci.yaml
+++ b/gitlab-ci/config/zz-generated-gitlab-ci.yaml
@@ -1237,7 +1237,7 @@ bazel-test-macos:
       - if: $CI_PIPELINE_SOURCE == "push" && $CI_COMMIT_BRANCH =~ /^(rc--|hotfix-.+-rc--).+/
     - if: $CI_PIPELINE_SOURCE == "schedule" && $SCHEDULE_NAME == "run-all-master"
       variables:
-        BAZEL_EXTRA_ARGS: "--test_tag_filters=test_macos,test_macos_master"
+        BAZEL_EXTRA_ARGS: "--test_tag_filters=test_macos"
   script:
     - "./gitlab-ci/src/bazel-ci/main.sh"
   tags:

--- a/rs/execution_environment/BUILD.bazel
+++ b/rs/execution_environment/BUILD.bazel
@@ -117,7 +117,7 @@ rust_ic_test(
     # TODO(IDX-3164): enable on PR when flakiness issue is resolved
     #                 or we have new darwin runners in use
     tags = [
-        "test_macos_master",
+        "test_macos_slow",
     ],
     deps = DEPENDENCIES + DEV_DEPENDENCIES,
 )


### PR DESCRIPTION
This moves some executions tests (known to be flaky on old Intel macs) to the namespace runners. The namespace workflow is also changed to not cancel current jobs on `master` so that we can check all commits built successfully on `master`. Finally the `test_macos_master` flag is renamed to `test_macos_slow`, which is more representative of what the tests are, and less tied to the environment (branch names, etc).