### PR TITLE
feat: EXC-1683: Include snapshot memory usage in canister's memory usage

### DIFF
--- a/rs/execution_environment/src/execution_environment/tests/canister_snapshots.rs
+++ b/rs/execution_environment/src/execution_environment/tests/canister_snapshots.rs
@@ -395,6 +395,26 @@ fn canister_request_take_canister_snapshot_creates_new_snapshots() {
             .system_state
             .wasm_chunk_store
     );
+    // Confirm that `snapshots_memory_usage` is updated correctly.
+    assert_eq!(
+        test.canister_state(canister_id)
+            .system_state
+            .snapshots_memory_usage,
+        test.state()
+            .canister_snapshots
+            .memory_usage_by_canister(canister_id),
+    );
+
+    // Grow the canister's memory before taking another snapshot.
+    test.ingress(
+        canister_id,
+        "update",
+        wasm()
+            .memory_size_is_at_least(20 * 1024 * 1024) // 20 MiB
+            .reply_data(&[42])
+            .build(),
+    )
+    .unwrap();
 
     // Take a new snapshot for the canister, and provide a replacement snapshot ID.
     let args: TakeCanisterSnapshotArgs =
@@ -409,6 +429,16 @@ fn canister_request_take_canister_snapshot_creates_new_snapshots() {
     assert_ne!(new_snapshot_id, snapshot_id);
     assert!(!test.state().canister_snapshots.contains(&snapshot_id));
     assert!(test.state().canister_snapshots.contains(&new_snapshot_id));
+
+    // Confirm that `snapshots_memory_usage` is updated correctly.
+    assert_eq!(
+        test.canister_state(canister_id)
+            .system_state
+            .snapshots_memory_usage,
+        test.state()
+            .canister_snapshots
+            .memory_usage_by_canister(canister_id),
+    );
 }
 
 #[test]
@@ -909,6 +939,16 @@ fn delete_canister_snapshot_succeeds() {
     let snapshot_id = response.snapshot_id();
     assert!(test.state().canister_snapshots.get(snapshot_id).is_some());
 
+    // Confirm that `snapshots_memory_usage` is updated correctly.
+    assert_eq!(
+        test.canister_state(canister_id)
+            .system_state
+            .snapshots_memory_usage,
+        test.state()
+            .canister_snapshots
+            .memory_usage_by_canister(canister_id),
+    );
+
     // Deletes canister snapshot successfully.
     let args: DeleteCanisterSnapshotArgs =
         DeleteCanisterSnapshotArgs::new(canister_id, snapshot_id);
@@ -917,6 +957,15 @@ fn delete_canister_snapshot_succeeds() {
     assert!(result.is_ok());
     assert!(test.state().canister_snapshots.get(snapshot_id).is_none());
     assert!(test.state().canister_state(&canister_id).is_some());
+
+    assert_eq!(
+        test.canister_state(canister_id)
+            .system_state
+            .snapshots_memory_usage,
+        test.state()
+            .canister_snapshots
+            .memory_usage_by_canister(canister_id),
+    );
 }
 
 #[test]

--- a/rs/execution_environment/src/execution_environment/tests/canister_snapshots.rs
+++ b/rs/execution_environment/src/execution_environment/tests/canister_snapshots.rs
@@ -402,7 +402,7 @@ fn canister_request_take_canister_snapshot_creates_new_snapshots() {
             .snapshots_memory_usage,
         test.state()
             .canister_snapshots
-            .memory_usage_by_canister(canister_id),
+            .compute_memory_usage_by_canister(canister_id),
     );
 
     // Grow the canister's memory before taking another snapshot.
@@ -437,7 +437,7 @@ fn canister_request_take_canister_snapshot_creates_new_snapshots() {
             .snapshots_memory_usage,
         test.state()
             .canister_snapshots
-            .memory_usage_by_canister(canister_id),
+            .compute_memory_usage_by_canister(canister_id),
     );
 }
 
@@ -946,7 +946,7 @@ fn delete_canister_snapshot_succeeds() {
             .snapshots_memory_usage,
         test.state()
             .canister_snapshots
-            .memory_usage_by_canister(canister_id),
+            .compute_memory_usage_by_canister(canister_id),
     );
 
     // Deletes canister snapshot successfully.
@@ -964,7 +964,7 @@ fn delete_canister_snapshot_succeeds() {
             .snapshots_memory_usage,
         test.state()
             .canister_snapshots
-            .memory_usage_by_canister(canister_id),
+            .compute_memory_usage_by_canister(canister_id),
     );
 }
 

--- a/rs/protobuf/def/state/canister_state_bits/v1/canister_state_bits.proto
+++ b/rs/protobuf/def/state/canister_state_bits/v1/canister_state_bits.proto
@@ -433,9 +433,10 @@ message CanisterStateBits {
   optional uint64 wasm_memory_limit = 45;
   // The next local snapshot ID.
   uint64 next_snapshot_id = 46;
+  // Captures the memory usage of all snapshots associated with a canister.
+  uint64 snapshots_memory_usage = 52;
   reserved 47;
   int64 priority_credit = 48;
   LongExecutionMode long_execution_mode = 49;
   optional uint64 wasm_memory_threshold = 50;
-  uint64 snapshots_memory_usage = 52;
 }

--- a/rs/protobuf/def/state/canister_state_bits/v1/canister_state_bits.proto
+++ b/rs/protobuf/def/state/canister_state_bits/v1/canister_state_bits.proto
@@ -437,4 +437,5 @@ message CanisterStateBits {
   int64 priority_credit = 48;
   LongExecutionMode long_execution_mode = 49;
   optional uint64 wasm_memory_threshold = 50;
+  uint64 snapshots_memory_usage = 52;
 }

--- a/rs/protobuf/src/gen/state/state.canister_state_bits.v1.rs
+++ b/rs/protobuf/src/gen/state/state.canister_state_bits.v1.rs
@@ -700,6 +700,8 @@ pub struct CanisterStateBits {
     pub long_execution_mode: i32,
     #[prost(uint64, optional, tag = "50")]
     pub wasm_memory_threshold: ::core::option::Option<u64>,
+    #[prost(uint64, tag = "52")]
+    pub snapshots_memory_usage: u64,
     #[prost(oneof = "canister_state_bits::CanisterStatus", tags = "11, 12, 13")]
     pub canister_status: ::core::option::Option<canister_state_bits::CanisterStatus>,
 }

--- a/rs/protobuf/src/gen/state/state.canister_state_bits.v1.rs
+++ b/rs/protobuf/src/gen/state/state.canister_state_bits.v1.rs
@@ -694,14 +694,15 @@ pub struct CanisterStateBits {
     /// The next local snapshot ID.
     #[prost(uint64, tag = "46")]
     pub next_snapshot_id: u64,
+    /// Captures the memory usage of all snapshots associated with a canister.
+    #[prost(uint64, tag = "52")]
+    pub snapshots_memory_usage: u64,
     #[prost(int64, tag = "48")]
     pub priority_credit: i64,
     #[prost(enumeration = "LongExecutionMode", tag = "49")]
     pub long_execution_mode: i32,
     #[prost(uint64, optional, tag = "50")]
     pub wasm_memory_threshold: ::core::option::Option<u64>,
-    #[prost(uint64, tag = "52")]
-    pub snapshots_memory_usage: u64,
     #[prost(oneof = "canister_state_bits::CanisterStatus", tags = "11, 12, 13")]
     pub canister_status: ::core::option::Option<canister_state_bits::CanisterStatus>,
 }

--- a/rs/replicated_state/src/canister_snapshots.rs
+++ b/rs/replicated_state/src/canister_snapshots.rs
@@ -160,6 +160,22 @@ impl CanisterSnapshots {
         }
     }
 
+    /// Computes the memory usage used by all snapshots belonging to the specified canister ID.
+    ///
+    /// Used for testing that `SystemState::snapshots_memory_usage` is updated as needed
+    /// whenever taking or deleting a snapshot.
+    #[doc(hidden)]
+    pub fn memory_usage_by_canister(&self, canister_id: CanisterId) -> NumBytes {
+        let mut memory_size = NumBytes::new(0);
+        if let Some(snapshot_ids) = self.snapshot_ids.get(&canister_id) {
+            for snapshot_id in snapshot_ids {
+                debug_assert!(self.snapshots.contains_key(snapshot_id));
+                memory_size += self.snapshots.get(snapshot_id).unwrap().size();
+            }
+        }
+        memory_size
+    }
+
     /// Adds a new restore snapshot operation in the unflushed changes.
     pub fn add_restore_operation(&mut self, canister_id: CanisterId, snapshot_id: SnapshotId) {
         self.unflushed_changes
@@ -537,9 +553,17 @@ mod tests {
             snapshot_manager.memory_taken(),
             NumBytes::from(snapshot1_size)
         );
+        assert_eq!(
+            snapshot_manager.memory_usage_by_canister(canister_id),
+            NumBytes::from(snapshot1_size)
+        );
 
         let other_canister_id = canister_test_id(1);
         let (second_snapshot_id, second_snapshot) = fake_canister_snapshot(other_canister_id, 2);
+        assert_eq!(
+            snapshot_manager.memory_usage_by_canister(other_canister_id),
+            NumBytes::from(0)
+        );
 
         // Pushing another snapshot updates the `memory_usage`.
         let snapshot2_size = second_snapshot.size();
@@ -551,6 +575,10 @@ mod tests {
             snapshot_manager.memory_taken(),
             NumBytes::from(snapshot1_size + snapshot2_size)
         );
+        assert_eq!(
+            snapshot_manager.memory_usage_by_canister(other_canister_id),
+            NumBytes::from(snapshot2_size)
+        );
 
         // Deleting a snapshot updates the `memory_usage`.
         snapshot_manager.remove(first_snapshot_id);
@@ -558,9 +586,17 @@ mod tests {
             snapshot_manager.memory_taken(),
             NumBytes::from(snapshot2_size)
         );
+        assert_eq!(
+            snapshot_manager.memory_usage_by_canister(canister_id),
+            NumBytes::from(0)
+        );
 
         // Deleting the second snapshot brings us back to 0 memory taken.
         snapshot_manager.remove(second_snapshot_id);
         assert_eq!(snapshot_manager.memory_taken(), NumBytes::from(0));
+        assert_eq!(
+            snapshot_manager.memory_usage_by_canister(other_canister_id),
+            NumBytes::from(0)
+        );
     }
 }

--- a/rs/replicated_state/src/canister_snapshots.rs
+++ b/rs/replicated_state/src/canister_snapshots.rs
@@ -165,7 +165,7 @@ impl CanisterSnapshots {
     /// Used for testing that `SystemState::snapshots_memory_usage` is updated as needed
     /// whenever taking or deleting a snapshot.
     #[doc(hidden)]
-    pub fn memory_usage_by_canister(&self, canister_id: CanisterId) -> NumBytes {
+    pub fn compute_memory_usage_by_canister(&self, canister_id: CanisterId) -> NumBytes {
         let mut memory_size = NumBytes::new(0);
         if let Some(snapshot_ids) = self.snapshot_ids.get(&canister_id) {
             for snapshot_id in snapshot_ids {
@@ -347,7 +347,7 @@ impl CanisterSnapshot {
             certified_data: canister.system_state.certified_data.clone(),
             chunk_store: canister.system_state.wasm_chunk_store.clone(),
             execution_snapshot,
-            size: canister.snapshot_memory_usage(),
+            size: canister.snapshot_size_bytes(),
         })
     }
 
@@ -554,14 +554,14 @@ mod tests {
             NumBytes::from(snapshot1_size)
         );
         assert_eq!(
-            snapshot_manager.memory_usage_by_canister(canister_id),
+            snapshot_manager.compute_memory_usage_by_canister(canister_id),
             NumBytes::from(snapshot1_size)
         );
 
         let other_canister_id = canister_test_id(1);
         let (second_snapshot_id, second_snapshot) = fake_canister_snapshot(other_canister_id, 2);
         assert_eq!(
-            snapshot_manager.memory_usage_by_canister(other_canister_id),
+            snapshot_manager.compute_memory_usage_by_canister(other_canister_id),
             NumBytes::from(0)
         );
 
@@ -576,7 +576,7 @@ mod tests {
             NumBytes::from(snapshot1_size + snapshot2_size)
         );
         assert_eq!(
-            snapshot_manager.memory_usage_by_canister(other_canister_id),
+            snapshot_manager.compute_memory_usage_by_canister(other_canister_id),
             NumBytes::from(snapshot2_size)
         );
 
@@ -587,7 +587,7 @@ mod tests {
             NumBytes::from(snapshot2_size)
         );
         assert_eq!(
-            snapshot_manager.memory_usage_by_canister(canister_id),
+            snapshot_manager.compute_memory_usage_by_canister(canister_id),
             NumBytes::from(0)
         );
 
@@ -595,7 +595,7 @@ mod tests {
         snapshot_manager.remove(second_snapshot_id);
         assert_eq!(snapshot_manager.memory_taken(), NumBytes::from(0));
         assert_eq!(
-            snapshot_manager.memory_usage_by_canister(other_canister_id),
+            snapshot_manager.compute_memory_usage_by_canister(other_canister_id),
             NumBytes::from(0)
         );
     }

--- a/rs/replicated_state/src/canister_snapshots.rs
+++ b/rs/replicated_state/src/canister_snapshots.rs
@@ -160,7 +160,7 @@ impl CanisterSnapshots {
         }
     }
 
-    /// Computes the memory usage used by all snapshots belonging to the specified canister ID.
+    /// Computes the total memory usage of all of the specified canister's snapshots.
     ///
     /// Used for testing that `SystemState::snapshots_memory_usage` is updated as needed
     /// whenever taking or deleting a snapshot.

--- a/rs/replicated_state/src/canister_state.rs
+++ b/rs/replicated_state/src/canister_state.rs
@@ -415,11 +415,11 @@ impl CanisterState {
         self.system_state.wasm_chunk_store.memory_usage()
     }
 
-    /// Returns the memory usage of a newly created snapshot based on the current canister's state.
+    /// Returns the snapshot size estimation in bytes based on the current canister's state.
     ///
     /// It represents the memory usage of a snapshot that would be created at the time of the call
     /// and would return a different value if the canister's state changes after the call.
-    pub fn snapshot_memory_usage(&self) -> NumBytes {
+    pub fn snapshot_size_bytes(&self) -> NumBytes {
         let execution_usage = self
             .execution_state
             .as_ref()

--- a/rs/replicated_state/src/canister_state.rs
+++ b/rs/replicated_state/src/canister_state.rs
@@ -369,12 +369,14 @@ impl CanisterState {
 
     /// The amount of memory currently being used by the canister.
     ///
-    /// This only includes execution memory (heap, stable, globals, Wasm),
-    /// canister history memory and wasm chunk storage.
+    /// This includes execution memory (heap, stable, globals, Wasm),
+    /// canister history memory, wasm chunk storage and snapshots that
+    /// belong to this canister.
     pub fn memory_usage(&self) -> NumBytes {
         self.execution_memory_usage()
             + self.canister_history_memory_usage()
             + self.wasm_chunk_store_memory_usage()
+            + self.system_state.snapshots_memory_usage
     }
 
     /// Returns the amount of execution memory (heap, stable, globals, Wasm)

--- a/rs/replicated_state/src/canister_state.rs
+++ b/rs/replicated_state/src/canister_state.rs
@@ -372,6 +372,10 @@ impl CanisterState {
     /// This includes execution memory (heap, stable, globals, Wasm),
     /// canister history memory, wasm chunk storage and snapshots that
     /// belong to this canister.
+    ///
+    /// This amount is used to periodically charge the canister for the memory
+    /// resources it consumes and can be used to calculate the canister's
+    /// idle cycles burn rate and freezing threshold in cycles.
     pub fn memory_usage(&self) -> NumBytes {
         self.execution_memory_usage()
             + self.canister_history_memory_usage()
@@ -411,7 +415,10 @@ impl CanisterState {
         self.system_state.wasm_chunk_store.memory_usage()
     }
 
-    /// Returns the memory usage of a snapshot created based on the current canister's state.
+    /// Returns the memory usage of a newly created snapshot based on the current canister's state.
+    ///
+    /// It represents the memory usage of a snapshot that would be created at the time of the call
+    /// and would return a different value if the canister's state changes after the call.
     pub fn snapshot_memory_usage(&self) -> NumBytes {
         let execution_usage = self
             .execution_state

--- a/rs/replicated_state/src/canister_state/system_state.rs
+++ b/rs/replicated_state/src/canister_state/system_state.rs
@@ -357,7 +357,10 @@ pub struct SystemState {
     /// Next local snapshot id.
     pub next_snapshot_id: u64,
 
-    /// Memory usage of all snapshots that belong to this canister.
+    /// Cumulative memory usage of all snapshots that belong to this canister.
+    ///
+    /// This amount contributes to the total `memory_usage` of the canister as
+    /// reported by `CanisterState::memory_usage`.
     pub snapshots_memory_usage: NumBytes,
 }
 

--- a/rs/replicated_state/src/canister_state/system_state.rs
+++ b/rs/replicated_state/src/canister_state/system_state.rs
@@ -356,6 +356,9 @@ pub struct SystemState {
 
     /// Next local snapshot id.
     pub next_snapshot_id: u64,
+
+    /// Memory usage of all snapshots that belong to this canister.
+    pub snapshots_memory_usage: NumBytes,
 }
 
 /// A wrapper around the different canister statuses.
@@ -726,6 +729,7 @@ impl SystemState {
             canister_log: Default::default(),
             wasm_memory_limit: None,
             next_snapshot_id: 0,
+            snapshots_memory_usage: NumBytes::from(0),
         }
     }
 
@@ -754,6 +758,7 @@ impl SystemState {
         canister_log: CanisterLog,
         wasm_memory_limit: Option<NumBytes>,
         next_snapshot_id: u64,
+        snapshots_memory_usage: NumBytes,
     ) -> Self {
         Self {
             controllers,
@@ -781,6 +786,7 @@ impl SystemState {
             canister_log,
             wasm_memory_limit,
             next_snapshot_id,
+            snapshots_memory_usage,
         }
     }
 

--- a/rs/state_layout/src/state_layout.rs
+++ b/rs/state_layout/src/state_layout.rs
@@ -174,6 +174,7 @@ pub struct CanisterStateBits {
     pub canister_log: CanisterLog,
     pub wasm_memory_limit: Option<NumBytes>,
     pub next_snapshot_id: u64,
+    pub snapshots_memory_usage: NumBytes,
 }
 
 /// This struct contains bits of the `CanisterSnapshot` that are not already
@@ -2179,6 +2180,7 @@ impl From<CanisterStateBits> for pb_canister_state_bits::CanisterStateBits {
             next_canister_log_record_idx: item.canister_log.next_idx(),
             wasm_memory_limit: item.wasm_memory_limit.map(|v| v.get()),
             next_snapshot_id: item.next_snapshot_id,
+            snapshots_memory_usage: item.snapshots_memory_usage.get(),
         }
     }
 }
@@ -2353,6 +2355,7 @@ impl TryFrom<pb_canister_state_bits::CanisterStateBits> for CanisterStateBits {
             ),
             wasm_memory_limit: value.wasm_memory_limit.map(NumBytes::from),
             next_snapshot_id: value.next_snapshot_id,
+            snapshots_memory_usage: NumBytes::from(value.snapshots_memory_usage),
         })
     }
 }

--- a/rs/state_layout/src/state_layout/tests.rs
+++ b/rs/state_layout/src/state_layout/tests.rs
@@ -57,6 +57,7 @@ fn default_canister_state_bits() -> CanisterStateBits {
         canister_log: Default::default(),
         wasm_memory_limit: None,
         next_snapshot_id: 0,
+        snapshots_memory_usage: NumBytes::from(0),
     }
 }
 

--- a/rs/state_manager/src/checkpoint.rs
+++ b/rs/state_manager/src/checkpoint.rs
@@ -469,6 +469,7 @@ pub fn load_canister_state(
         canister_state_bits.canister_log,
         canister_state_bits.wasm_memory_limit,
         canister_state_bits.next_snapshot_id,
+        canister_state_bits.snapshots_memory_usage,
     );
 
     let canister_state = CanisterState {

--- a/rs/state_manager/src/tip.rs
+++ b/rs/state_manager/src/tip.rs
@@ -1039,6 +1039,7 @@ fn serialize_canister_to_tip(
             canister_log: canister_state.system_state.canister_log.clone(),
             wasm_memory_limit: canister_state.system_state.wasm_memory_limit,
             next_snapshot_id: canister_state.system_state.next_snapshot_id,
+            snapshots_memory_usage: canister_state.system_state.snapshots_memory_usage,
         }
         .into(),
     )?;


### PR DESCRIPTION
A new field is added in `SystemState` that captures the memory usage of all snapshots that belong to a canister. The field is updated whenever a snapshot is taken or deleted and it's persisted in the checkpoints as well.

The change is both backwards and forwards compatible as the new field will be initialized to 0 and will remain 0 while the feature is still disabled. Without any snapshots there's no functional difference as a memory usage of 0 would be additionally included in the canister's memory usage.