### PR TITLE
fix(IDX): don't cargo build rocksdb on Linux

### DIFF
--- a/Cargo.Bazel.Fuzzing.json.lock
+++ b/Cargo.Bazel.Fuzzing.json.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "f43d96ffd5ff69815ca063c0a9561a00e012bfb92c25f0d10437cc155e4c4470",
+  "checksum": "0352759c344b7947b84a4586364e8faf54a1bfa8dd88b099b4d9bb3b8cac48e2",
   "crates": {
     "abnf 0.12.0": {
       "name": "abnf",
@@ -35600,30 +35600,38 @@
         ],
         "crate_features": {
           "common": [
-            "elf",
-            "errno",
             "general",
             "ioctl",
             "no_std"
           ],
           "selects": {
             "aarch64-unknown-linux-gnu": [
+              "elf",
+              "errno",
               "prctl",
               "system"
             ],
             "aarch64-unknown-nixos-gnu": [
+              "elf",
+              "errno",
               "prctl",
               "system"
             ],
             "arm-unknown-linux-gnueabi": [
+              "elf",
+              "errno",
               "prctl",
               "system"
             ],
             "armv7-unknown-linux-gnueabi": [
+              "elf",
+              "errno",
               "prctl",
               "system"
             ],
             "i686-unknown-linux-gnu": [
+              "elf",
+              "errno",
               "prctl",
               "system"
             ],
@@ -35636,10 +35644,14 @@
               "system"
             ],
             "x86_64-unknown-linux-gnu": [
+              "elf",
+              "errno",
               "prctl",
               "system"
             ],
             "x86_64-unknown-nixos-gnu": [
+              "elf",
+              "errno",
               "prctl",
               "system"
             ]

--- a/Cargo.Bazel.json.lock
+++ b/Cargo.Bazel.json.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "08c45d269ac4f0bd5506f009d2f66d5b508fa519511993d3312ad4c1ef1c1bf3",
+  "checksum": "7dc5994f6bd4d30b7c768febf71df37ae847ca67277113b03cba541c511cfb17",
   "crates": {
     "abnf 0.12.0": {
       "name": "abnf",
@@ -35646,30 +35646,38 @@
         ],
         "crate_features": {
           "common": [
-            "elf",
-            "errno",
             "general",
             "ioctl",
             "no_std"
           ],
           "selects": {
             "aarch64-unknown-linux-gnu": [
+              "elf",
+              "errno",
               "prctl",
               "system"
             ],
             "aarch64-unknown-nixos-gnu": [
+              "elf",
+              "errno",
               "prctl",
               "system"
             ],
             "arm-unknown-linux-gnueabi": [
+              "elf",
+              "errno",
               "prctl",
               "system"
             ],
             "armv7-unknown-linux-gnueabi": [
+              "elf",
+              "errno",
               "prctl",
               "system"
             ],
             "i686-unknown-linux-gnu": [
+              "elf",
+              "errno",
               "prctl",
               "system"
             ],
@@ -35682,10 +35690,14 @@
               "system"
             ],
             "x86_64-unknown-linux-gnu": [
+              "elf",
+              "errno",
               "prctl",
               "system"
             ],
             "x86_64-unknown-nixos-gnu": [
+              "elf",
+              "errno",
               "prctl",
               "system"
             ]

--- a/rs/artifact_pool/BUILD.bazel
+++ b/rs/artifact_pool/BUILD.bazel
@@ -62,10 +62,6 @@ rust_library(
     name = "artifact_pool",
     srcs = glob(["src/**"]),
     aliases = ALIASES,
-    crate_features = select({
-        "@platforms//os:osx": ["rocksdb_backend"],
-        "//conditions:default": [],
-    }),
     crate_name = "ic_artifact_pool",
     proc_macro_deps = MACRO_DEPENDENCIES,
     version = "0.9.0",

--- a/rs/artifact_pool/Cargo.toml
+++ b/rs/artifact_pool/Cargo.toml
@@ -23,13 +23,16 @@ lmdb-rkv-sys = { git = "https://github.com/dfinity-lab/lmdb-rs", rev = "f62018b2
 nix = { workspace = true }
 prometheus = { workspace = true }
 prost = { workspace = true }
-rocksdb = { version = "0.22.0", optional = true, default-features = false }
 serde = { workspace = true }
 serde-bytes-repr = "0.1.5"
 serde_json = { workspace = true }
 slog = { workspace = true }
 strum = { workspace = true }
 tempfile = { workspace = true }
+
+# Support for rocksdb backend on macos
+[target.'cfg(macos)'.dependencies]
+rocksdb = { version = "0.22.0", default-features = false }
 
 [dev-dependencies]
 criterion = { workspace = true }
@@ -50,10 +53,6 @@ slog-term = { workspace = true }
 [[bench]]
 name = "load_blocks"
 harness = false
-
-[features]
-default = ["rocksdb_backend"]
-rocksdb_backend = ["rocksdb"]
 
 [[bin]]
 name = "ic-consensus-pool-util"

--- a/rs/artifact_pool/src/certification_pool.rs
+++ b/rs/artifact_pool/src/certification_pool.rs
@@ -62,7 +62,7 @@ impl CertificationPoolImpl {
                     log.clone(),
                 ),
             ) as Box<_>,
-            #[cfg(feature = "rocksdb_backend")]
+            #[cfg(target_os = "macos")]
             PersistentPoolBackend::RocksDB(config) => Box::new(
                 crate::rocksdb_pool::PersistentHeightIndexedPool::new_certification_pool(
                     config,

--- a/rs/artifact_pool/src/consensus_pool.rs
+++ b/rs/artifact_pool/src/consensus_pool.rs
@@ -305,7 +305,7 @@ impl UncachedConsensusPoolImpl {
                     log,
                 ),
             ) as Box<_>,
-            #[cfg(feature = "rocksdb_backend")]
+            #[cfg(target_os = "macos")]
             PersistentPoolBackend::RocksDB(config) => Box::new(
                 crate::rocksdb_pool::PersistentHeightIndexedPool::new_consensus_pool(config, log),
             ) as Box<_>,

--- a/rs/artifact_pool/src/lib.rs
+++ b/rs/artifact_pool/src/lib.rs
@@ -16,9 +16,12 @@ pub mod backup;
 mod lmdb_iterator;
 mod lmdb_pool;
 
-#[cfg(feature = "rocksdb_backend")]
+// On macOS we have support for rocksdb in addition to lmdb as lmdb
+// historically caused issues.
+
+#[cfg(target_os = "macos")]
 mod rocksdb_iterator;
-#[cfg(feature = "rocksdb_backend")]
+#[cfg(target_os = "macos")]
 mod rocksdb_pool;
 
 use ic_interfaces::{consensus_pool::ValidatedArtifact, p2p::consensus::UnvalidatedArtifact};


### PR DESCRIPTION
This removes the `rocksdb_backend` cargo feature and instead use `cfg(target_os="macos")` directly. This allows us to use `[target.cfg(maocos).dependencies]` in the artifact pool's `Cargo.toml` to ensure the `rocksdb` crate is only built on macOS (it's not used on Linux but until now was built nonetheless when using cargo).