### PR TITLE
feat(registry): Add consistently-named alias `Registry.revise_elected_guestos_versions` [override-didc-check]

### DIFF
--- a/rs/registry/canister/canister/canister.rs
+++ b/rs/registry/canister/canister/canister.rs
@@ -384,17 +384,15 @@ fn retire_replica_version_(_payload: RetireReplicaVersionPayload) {
     );
 }
 
-// TODO[NNS1-3000]: Remove this endpoint once mainnet NNS Governance starts calling the new
-// TODO[NNS1-3000]: `revise_elected_replica_versions` endpoint.
-#[export_name = "canister_update update_elected_replica_versions"]
-fn update_elected_replica_versions() {
-    check_caller_is_governance_and_log("update_elected_replica_versions");
-    over(candid_one, update_elected_replica_versions_);
+#[export_name = "canister_update revise_elected_guestos_versions"]
+fn revise_elected_guestos_versions() {
+    check_caller_is_governance_and_log("revise_elected_guestos_versions");
+    over(candid_one, revise_elected_guestos_versions_);
 }
 
-#[candid_method(update, rename = "update_elected_replica_versions")]
-fn update_elected_replica_versions_(payload: ReviseElectedGuestosVersionsPayload) {
-    registry_mut().do_revise_elected_replica_versions(payload);
+#[candid_method(update, rename = "revise_elected_guestos_versions")]
+fn revise_elected_guestos_versions_(payload: ReviseElectedGuestosVersionsPayload) {
+    registry_mut().do_revise_elected_guestos_versions(payload);
     recertify_registry();
 }
 
@@ -412,6 +410,8 @@ fn update_subnet_replica_version_(payload: DeployGuestosToAllSubnetNodesPayload)
     recertify_registry();
 }
 
+// TODO[NNS1-3000]: Remove this endpoint once mainnet NNS Governance starts calling the new
+// TODO[NNS1-3000]: `revise_elected_guestos_versions` endpoint.
 #[export_name = "canister_update revise_elected_replica_versions"]
 fn revise_elected_replica_versions() {
     check_caller_is_governance_and_log("revise_elected_replica_versions");
@@ -420,7 +420,7 @@ fn revise_elected_replica_versions() {
 
 #[candid_method(update, rename = "revise_elected_replica_versions")]
 fn revise_elected_replica_versions_(payload: ReviseElectedGuestosVersionsPayload) {
-    registry_mut().do_revise_elected_replica_versions(payload);
+    registry_mut().do_revise_elected_guestos_versions(payload);
     recertify_registry();
 }
 

--- a/rs/registry/canister/canister/registry.did
+++ b/rs/registry/canister/canister/registry.did
@@ -445,11 +445,11 @@ service : {
   remove_nodes_from_subnet : (RemoveNodesPayload) -> ();
   reroute_canister_ranges : (RerouteCanisterRangesPayload) -> ();
   retire_replica_version : (RetireReplicaVersionPayload) -> ();
+  revise_elected_guestos_versions : (ReviseElectedGuestosVersionsPayload) -> ();
   revise_elected_replica_versions : (ReviseElectedGuestosVersionsPayload) -> ();
   set_firewall_config : (SetFirewallConfigPayload) -> ();
   update_api_boundary_nodes_version : (UpdateApiBoundaryNodesVersionPayload) -> ();
   update_elected_hostos_versions : (UpdateElectedHostosVersionsPayload) -> ();
-  update_elected_replica_versions : (ReviseElectedGuestosVersionsPayload) -> ();
   update_firewall_rules : (UpdateFirewallRulesPayload) -> ();
   update_node_directly : (UpdateNodeDirectlyPayload) -> ();
   update_node_domain_directly : (UpdateNodeDomainDirectlyPayload) -> (UpdateNodeDomainDirectlyResponse);

--- a/rs/registry/canister/src/mutations/do_revise_elected_replica_versions.rs
+++ b/rs/registry/canister/src/mutations/do_revise_elected_replica_versions.rs
@@ -29,7 +29,7 @@ impl Registry {
     ///
     /// This method is called by the governance canister, after a proposal
     /// for updating the elected replica versions has been accepted.
-    pub fn do_revise_elected_replica_versions(
+    pub fn do_revise_elected_guestos_versions(
         &mut self,
         payload: ReviseElectedGuestosVersionsPayload,
     ) {


### PR DESCRIPTION
This PR effectively renames the (already unused) `Registry.update_elected_replica_versions` function into another (not yet used) `Registry.revise_elected_guestos_versions` function that follows the new naming convention for IC OS proposals (for details, see [NNS Gov proposal](https://dashboard.internetcomputer.org/proposal/129630) and [the forum discussion](https://forum.dfinity.org/t/bringing-clarity-to-icp-upgrade-proposals/29626)). 

Note that currently, the NNS Governance calls a yet another alias (`Registry.revise_elected_replica_versions`).

If and when the Registry is released with this API extension, it will enable switching NNS Governance to call the new function with a consistent name instead of the legacy one; after that, it will become possible to obsolete the legacy function `update_elected_hostos_versions` for good.