### PR TITLE
feat(registry): Add consistently-named alias `Registry.deploy_guestos_to_some_api_boundary_nodes`

### DIFF
--- a/rs/registry/canister/canister/canister.rs
+++ b/rs/registry/canister/canister/canister.rs
@@ -45,7 +45,9 @@ use registry_canister::{
         do_retire_replica_version::RetireReplicaVersionPayload,
         do_revise_elected_replica_versions::ReviseElectedGuestosVersionsPayload,
         do_set_firewall_config::SetFirewallConfigPayload,
-        do_update_api_boundary_nodes_version::UpdateApiBoundaryNodesVersionPayload,
+        do_update_api_boundary_nodes_version::{
+            DeployGuestOsToSomeApiBoundaryNodes, UpdateApiBoundaryNodesVersionPayload,
+        },
         do_update_elected_hostos_versions::UpdateElectedHostosVersionsPayload,
         do_update_node_directly::UpdateNodeDirectlyPayload,
         do_update_node_operator_config::UpdateNodeOperatorConfigPayload,
@@ -574,6 +576,8 @@ fn remove_api_boundary_nodes_(payload: RemoveApiBoundaryNodesPayload) {
     recertify_registry();
 }
 
+// TODO[NNS1-3000]: Remove this endpoint once mainnet NNS Governance starts calling the new
+// TODO[NNS1-3000]: `deploy_guestos_to_some_api_boundary_nodes` endpoint.
 #[export_name = "canister_update update_api_boundary_nodes_version"]
 fn update_api_boundary_nodes_version() {
     check_caller_is_governance_and_log("update_api_boundary_nodes_version");
@@ -583,6 +587,18 @@ fn update_api_boundary_nodes_version() {
 #[candid_method(update, rename = "update_api_boundary_nodes_version")]
 fn update_api_boundary_nodes_version_(payload: UpdateApiBoundaryNodesVersionPayload) {
     registry_mut().do_update_api_boundary_nodes_version(payload);
+    recertify_registry();
+}
+
+#[export_name = "canister_update deploy_guestos_to_some_api_boundary_nodes"]
+fn deploy_guestos_to_some_api_boundary_nodes() {
+    check_caller_is_governance_and_log("deploy_guestos_to_some_api_boundary_nodes");
+    over(candid_one, deploy_guestos_to_some_api_boundary_nodes_);
+}
+
+#[candid_method(update, rename = "deploy_guestos_to_some_api_boundary_nodes")]
+fn deploy_guestos_to_some_api_boundary_nodes_(payload: DeployGuestOsToSomeApiBoundaryNodes) {
+    registry_mut().do_deploy_guestos_to_some_api_boundary_nodes(payload);
     recertify_registry();
 }
 

--- a/rs/registry/canister/canister/registry.did
+++ b/rs/registry/canister/canister/registry.did
@@ -308,6 +308,11 @@ type UpdateApiBoundaryNodesVersionPayload = record {
   node_ids : vec principal;
 };
 
+type DeployGuestOsToSomeApiBoundaryNodes = record {
+  version : text;
+  node_ids : vec principal;
+};
+
 type UpdateElectedHostosVersionsPayload = record {
   release_package_urls : vec text;
   hostos_version_to_elect : opt text;
@@ -431,6 +436,7 @@ service : {
   deploy_guestos_to_all_unassigned_nodes : (
     DeployGuestosToAllUnassignedNodesPayload
   ) -> ();
+  deploy_guestos_to_some_api_boundary_nodes : (DeployGuestOsToSomeApiBoundaryNodes) -> ();
   get_build_metadata : () -> (text) query;
   get_node_operators_and_dcs_of_node_provider : (principal) -> (GetNodeOperatorsAndDcsOfNodeProviderResponse) query;
   get_node_providers_monthly_xdr_rewards : () -> (GetNodeProvidersMonthlyXdrRewardsResponse) query;

--- a/rs/registry/canister/src/mutations/do_update_api_boundary_nodes_version.rs
+++ b/rs/registry/canister/src/mutations/do_update_api_boundary_nodes_version.rs
@@ -11,17 +11,41 @@ use crate::{common::LOG_PREFIX, registry::Registry};
 
 use super::common::{check_api_boundary_nodes_exist, check_replica_version_is_blessed};
 
+/// Deprcated; please use `DeployGuestOsToSomeApiBoundaryNodes` instead.
 #[derive(CandidType, Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 pub struct UpdateApiBoundaryNodesVersionPayload {
     pub node_ids: Vec<NodeId>,
     pub version: String,
 }
 
+#[derive(CandidType, Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+pub struct DeployGuestOsToSomeApiBoundaryNodes {
+    pub node_ids: Vec<NodeId>,
+    pub version: String,
+}
+
+impl From<UpdateApiBoundaryNodesVersionPayload> for DeployGuestOsToSomeApiBoundaryNodes {
+    fn from(src: UpdateApiBoundaryNodesVersionPayload) -> Self {
+        let UpdateApiBoundaryNodesVersionPayload { node_ids, version } = src;
+
+        Self { node_ids, version }
+    }
+}
+
 impl Registry {
-    /// Updates the version for a set of ApiBoundaryNodeRecords
+    /// Deprecated; please use `do_update_api_boundary_nodes_version`.
     pub fn do_update_api_boundary_nodes_version(
         &mut self,
         payload: UpdateApiBoundaryNodesVersionPayload,
+    ) {
+        let payload = DeployGuestOsToSomeApiBoundaryNodes::from(payload);
+        self.do_deploy_guestos_to_some_api_boundary_nodes(payload);
+    }
+
+    /// Updates the version for a set of ApiBoundaryNodeRecords
+    pub fn do_deploy_guestos_to_some_api_boundary_nodes(
+        &mut self,
+        payload: DeployGuestOsToSomeApiBoundaryNodes,
     ) {
         println!(
             "{}do_update_api_boundary_nodes_version: {:?}",
@@ -45,7 +69,7 @@ impl Registry {
 
     fn validate_update_api_boundary_nodes_version_payload(
         &self,
-        payload: &UpdateApiBoundaryNodesVersionPayload,
+        payload: &DeployGuestOsToSomeApiBoundaryNodes,
     ) {
         check_api_boundary_nodes_exist(self, &payload.node_ids);
         check_replica_version_is_blessed(self, &payload.version);

--- a/rs/registry/canister/src/mutations/do_update_api_boundary_nodes_version.rs
+++ b/rs/registry/canister/src/mutations/do_update_api_boundary_nodes_version.rs
@@ -11,7 +11,7 @@ use crate::{common::LOG_PREFIX, registry::Registry};
 
 use super::common::{check_api_boundary_nodes_exist, check_replica_version_is_blessed};
 
-/// Deprcated; please use `DeployGuestOsToSomeApiBoundaryNodes` instead.
+/// Deprecated; please use `DeployGuestOsToSomeApiBoundaryNodes` instead.
 #[derive(CandidType, Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 pub struct UpdateApiBoundaryNodesVersionPayload {
     pub node_ids: Vec<NodeId>,


### PR DESCRIPTION
This PR adds a new Registry function `Registry.deploy_guestos_to_some_api_boundary_nodes` that works exactly like the legacy `update_api_boundary_nodes_version` function but has a name that is consistent with the new IC OS proposal naming convention (for details, see [NNS Gov proposal](https://dashboard.internetcomputer.org/proposal/129630) and [the forum discussion](https://forum.dfinity.org/t/bringing-clarity-to-icp-upgrade-proposals/29626)).

If and when the Registry is released with this API extension, it will enable switching NNS Governance to call the new function with a consistent name instead of the legacy one; after that, it will become possible to obsolete the legacy function `update_api_boundary_nodes_version` for good.