### PR TITLE
feat(registry): Add consistently-named alias `Registry.deploy_hostos_to_some_nodes`

### DIFF
--- a/rs/registry/canister/canister/canister.rs
+++ b/rs/registry/canister/canister/canister.rs
@@ -50,7 +50,9 @@ use registry_canister::{
         do_update_node_directly::UpdateNodeDirectlyPayload,
         do_update_node_operator_config::UpdateNodeOperatorConfigPayload,
         do_update_node_operator_config_directly::UpdateNodeOperatorConfigDirectlyPayload,
-        do_update_nodes_hostos_version::UpdateNodesHostosVersionPayload,
+        do_update_nodes_hostos_version::{
+            DeployHostosToSomeNodes, UpdateNodesHostosVersionPayload,
+        },
         do_update_ssh_readonly_access_for_all_unassigned_nodes::UpdateSshReadOnlyAccessForAllUnassignedNodesPayload,
         do_update_subnet::UpdateSubnetPayload,
         do_update_unassigned_nodes_config::UpdateUnassignedNodesConfigPayload,
@@ -448,6 +450,8 @@ fn update_elected_hostos_versions_(payload: UpdateElectedHostosVersionsPayload) 
     recertify_registry();
 }
 
+// TODO[NNS1-3000]: Remove this endpoint once mainnet NNS Governance starts calling the new
+// TODO[NNS1-3000]: `deploy_hostos_to_some_nodes` endpoint.
 #[export_name = "canister_update update_nodes_hostos_version"]
 fn update_nodes_hostos_version() {
     check_caller_is_governance_and_log("update_nodes_hostos_version");
@@ -459,6 +463,18 @@ fn update_nodes_hostos_version() {
 #[candid_method(update, rename = "update_nodes_hostos_version")]
 fn update_nodes_hostos_version_(payload: UpdateNodesHostosVersionPayload) {
     registry_mut().do_update_nodes_hostos_version(payload);
+    recertify_registry();
+}
+
+#[export_name = "canister_update deploy_hostos_to_some_nodes"]
+fn deploy_hostos_to_some_nodes() {
+    check_caller_is_governance_and_log("deploy_hostos_to_some_nodes");
+    over(candid_one, deploy_hostos_to_some_nodes_);
+}
+
+#[candid_method(update, rename = "deploy_hostos_to_some_nodes")]
+fn deploy_hostos_to_some_nodes_(payload: DeployHostosToSomeNodes) {
+    registry_mut().do_deploy_hostos_to_some_nodes(payload);
     recertify_registry();
 }
 

--- a/rs/registry/canister/canister/registry.did
+++ b/rs/registry/canister/canister/registry.did
@@ -364,6 +364,11 @@ type UpdateNodesHostosVersionPayload = record {
   node_ids : vec principal;
 };
 
+type DeployHostosToSomeNodes = record {
+  hostos_version_id : opt text;
+  node_ids : vec principal;
+};
+
 type UpdateSshReadOnlyAccessForAllUnassignedNodesPayload = record {
   ssh_readonly_keys : vec text;
 };
@@ -462,6 +467,7 @@ service : {
   ) -> ();
   update_node_rewards_table : (UpdateNodeRewardsTableProposalPayload) -> ();
   update_nodes_hostos_version : (UpdateNodesHostosVersionPayload) -> ();
+  deploy_hostos_to_some_nodes : (DeployHostosToSomeNodes) -> ();
   update_ssh_readonly_access_for_all_unassigned_nodes : (
     UpdateSshReadOnlyAccessForAllUnassignedNodesPayload
   ) -> ();

--- a/rs/registry/canister/canister/registry.did
+++ b/rs/registry/canister/canister/registry.did
@@ -436,6 +436,7 @@ service : {
   deploy_guestos_to_all_unassigned_nodes : (
     DeployGuestosToAllUnassignedNodesPayload
   ) -> ();
+  deploy_hostos_to_some_nodes : (DeployHostosToSomeNodes) -> ();
   get_build_metadata : () -> (text) query;
   get_node_operators_and_dcs_of_node_provider : (principal) -> (GetNodeOperatorsAndDcsOfNodeProviderResponse) query;
   get_node_providers_monthly_xdr_rewards : () -> (GetNodeProvidersMonthlyXdrRewardsResponse) query;
@@ -467,7 +468,6 @@ service : {
   ) -> ();
   update_node_rewards_table : (UpdateNodeRewardsTableProposalPayload) -> ();
   update_nodes_hostos_version : (UpdateNodesHostosVersionPayload) -> ();
-  deploy_hostos_to_some_nodes : (DeployHostosToSomeNodes) -> ();
   update_ssh_readonly_access_for_all_unassigned_nodes : (
     UpdateSshReadOnlyAccessForAllUnassignedNodesPayload
   ) -> ();

--- a/rs/registry/canister/src/mutations/do_update_nodes_hostos_version.rs
+++ b/rs/registry/canister/src/mutations/do_update_nodes_hostos_version.rs
@@ -11,7 +11,15 @@ use serde::Serialize;
 
 impl Registry {
     pub fn do_update_nodes_hostos_version(&mut self, payload: UpdateNodesHostosVersionPayload) {
-        println!("{}do_update_node_hostos_version: {:?}", LOG_PREFIX, payload);
+        let payload = DeployHostosToSomeNodes::from(payload);
+        self.do_deploy_hostos_to_some_nodes(payload)
+    }
+
+    pub fn do_deploy_hostos_to_some_nodes(&mut self, payload: DeployHostosToSomeNodes) {
+        println!(
+            "{}do_deploy_hostos_to_some_nodes: {:?}",
+            LOG_PREFIX, payload
+        );
 
         let mut mutations = Vec::new();
         for node_id in payload.node_ids {
@@ -32,14 +40,37 @@ impl Registry {
     }
 }
 
-/// The argument of a command to update the HostOS version of a single
-/// node to a specific version.
-///
-/// The record will be mutated only if the given version exists.
+/// Deprecated; please use `DeployHostosToSomeNodes` instead.
 #[derive(CandidType, Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 pub struct UpdateNodesHostosVersionPayload {
     /// The node to update.
     pub node_ids: Vec<NodeId>,
     /// The new HostOS version to use.
     pub hostos_version_id: Option<String>,
+}
+
+/// The argument of a command to update the HostOS version of a single
+/// node to a specific version.
+///
+/// The record will be mutated only if the given version exists.
+#[derive(CandidType, Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+pub struct DeployHostosToSomeNodes {
+    /// The node to update.
+    pub node_ids: Vec<NodeId>,
+    /// The new HostOS version to use.
+    pub hostos_version_id: Option<String>,
+}
+
+impl From<UpdateNodesHostosVersionPayload> for DeployHostosToSomeNodes {
+    fn from(src: UpdateNodesHostosVersionPayload) -> Self {
+        let UpdateNodesHostosVersionPayload {
+            node_ids,
+            hostos_version_id,
+        } = src;
+
+        Self {
+            node_ids,
+            hostos_version_id,
+        }
+    }
 }


### PR DESCRIPTION
This PR adds a new Registry function `Registry.deploy_hostos_to_some_nodes` that works exactly like the legacy `update_nodes_hostos_version` function but has a name that is consistent with the new IC OS proposal naming convention (for details, see [NNS Gov proposal](https://dashboard.internetcomputer.org/proposal/129630) and [the forum discussion](https://forum.dfinity.org/t/bringing-clarity-to-icp-upgrade-proposals/29626)).

If and when the Registry is released with this API extension, it will enable switching NNS Governance to call the new function with a consistent name instead of the legacy one; after that, it will become possible to obsolete the legacy function `update_nodes_hostos_version` for good.