### PR TITLE
feat(registry): Remove unused function `Registry.bless_replica_version` [override-didc-check]

### DIFF
--- a/rs/registry/canister/canister/canister.rs
+++ b/rs/registry/canister/canister/canister.rs
@@ -34,7 +34,6 @@ use registry_canister::{
         do_add_api_boundary_nodes::AddApiBoundaryNodesPayload,
         do_add_node_operator::AddNodeOperatorPayload,
         do_add_nodes_to_subnet::AddNodesToSubnetPayload,
-        do_bless_replica_version::BlessReplicaVersionPayload,
         do_change_subnet_membership::ChangeSubnetMembershipPayload,
         do_create_subnet::CreateSubnetPayload,
         do_deploy_guestos_to_all_subnet_nodes::DeployGuestosToAllSubnetNodesPayload,
@@ -350,22 +349,6 @@ fn atomic_mutate() {
 
     let bytes = serialize_atomic_mutate_response(response_pb).expect("Error serializing response");
     reply(&bytes)
-}
-
-#[export_name = "canister_update bless_replica_version"]
-fn bless_replica_version() {
-    check_caller_is_governance_and_log("bless_replica_version");
-    over(candid_one, |payload: BlessReplicaVersionPayload| {
-        bless_replica_version_(payload)
-    });
-}
-
-#[candid_method(update, rename = "bless_replica_version")]
-fn bless_replica_version_(_payload: BlessReplicaVersionPayload) {
-    panic!(
-        "{}bless_replica_version is deprecated and should no longer be used!",
-        LOG_PREFIX
-    );
 }
 
 #[export_name = "canister_update retire_replica_version"]

--- a/rs/registry/canister/canister/registry.did
+++ b/rs/registry/canister/canister/registry.did
@@ -54,18 +54,6 @@ type AddOrRemoveDataCentersProposalPayload = record {
   data_centers_to_remove : vec text;
 };
 
-type BlessReplicaVersionPayload = record {
-  release_package_urls : opt vec text;
-  node_manager_sha256_hex : text;
-  release_package_url : text;
-  sha256_hex : text;
-  guest_launch_measurement_sha256_hex : opt text;
-  replica_version_id : text;
-  release_package_sha256_hex : text;
-  node_manager_binary_url : text;
-  binary_url : text;
-};
-
 type CanisterIdRange = record { end : principal; start : principal };
 
 type ChangeSubnetMembershipPayload = record {
@@ -420,7 +408,6 @@ service : {
   add_node_operator : (AddNodeOperatorPayload) -> ();
   add_nodes_to_subnet : (AddNodesToSubnetPayload) -> ();
   add_or_remove_data_centers : (AddOrRemoveDataCentersProposalPayload) -> ();
-  bless_replica_version : (BlessReplicaVersionPayload) -> ();
   change_subnet_membership : (ChangeSubnetMembershipPayload) -> ();
   clear_provisional_whitelist : () -> ();
   complete_canister_migration : (CompleteCanisterMigrationPayload) -> ();


### PR DESCRIPTION
This PR removes the unused Registry function `bless_replica_version`, as it could only be used by NNS Governance which no longer uses it.