### PR TITLE
refactor(nns): migrate rosetta-api and rosetta_tests to use governance api crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10933,6 +10933,7 @@ dependencies = [
  "ic-nns-common",
  "ic-nns-constants",
  "ic-nns-governance",
+ "ic-nns-governance-api",
  "ic-rosetta-test-utils",
  "ic-types",
  "icp-ledger",

--- a/rs/rosetta-api/BUILD.bazel
+++ b/rs/rosetta-api/BUILD.bazel
@@ -19,7 +19,7 @@ DEPENDENCIES = [
     "//rs/crypto/utils/threshold_sig_der",
     "//rs/nns/common",
     "//rs/nns/constants",
-    "//rs/nns/governance",
+    "//rs/nns/governance/api",
     "//rs/rosetta-api/icp_ledger",
     "//rs/rosetta-api/ledger_canister_blocks_synchronizer:ledger_canister_blocks_synchronizer_lib",
     "//rs/rosetta-api/ledger_canister_core",

--- a/rs/rosetta-api/Cargo.toml
+++ b/rs/rosetta-api/Cargo.toml
@@ -30,7 +30,7 @@ ic-ledger-core = { path = "ledger_core" }
 ic-ledger-hash-of = { path = "../../packages/ic-ledger-hash-of" }
 ic-nns-common = { path = "../nns/common" }
 ic-nns-constants = { path = "../nns/constants" }
-ic-nns-governance = { path = "../nns/governance" }
+ic-nns-governance-api = { path = "../nns/governance/api" }
 ic-types = { path = "../types/types" }
 icp-ledger = { path = "icp_ledger" }
 lazy_static = { workspace = true }

--- a/rs/rosetta-api/src/ledger_client.rs
+++ b/rs/rosetta-api/src/ledger_client.rs
@@ -23,12 +23,13 @@ pub mod proposal_info_response;
 use candid::{Decode, Encode};
 use core::ops::Deref;
 use ic_agent::agent::{RejectCode, RejectResponse};
-use ic_nns_governance::pb::v1::{KnownNeuron, ListKnownNeuronsResponse, ProposalInfo};
-use std::convert::TryFrom;
-use std::sync::atomic::AtomicBool;
-use std::sync::Arc;
-use std::time::{Duration, Instant};
-use std::{thread, time};
+use ic_nns_governance_api::pb::v1::{KnownNeuron, ListKnownNeuronsResponse, ProposalInfo};
+use std::{
+    convert::TryFrom,
+    sync::{atomic::AtomicBool, Arc},
+    thread, time,
+    time::{Duration, Instant},
+};
 use url::Url;
 
 use async_trait::async_trait;
@@ -36,44 +37,48 @@ use reqwest::{Client, StatusCode};
 use tracing::{debug, error, warn};
 
 use dfn_candid::CandidOne;
-use ic_ledger_canister_blocks_synchronizer::blocks::{Blocks, RosettaBlocksMode};
-use ic_ledger_canister_blocks_synchronizer::canister_access::CanisterAccess;
-use ic_ledger_canister_blocks_synchronizer::certification::VerificationInfo;
-use ic_ledger_canister_blocks_synchronizer::ledger_blocks_sync::{
-    LedgerBlocksSynchronizer, LedgerBlocksSynchronizerMetrics,
+use ic_ledger_canister_blocks_synchronizer::{
+    blocks::{Blocks, RosettaBlocksMode},
+    canister_access::CanisterAccess,
+    certification::VerificationInfo,
+    ledger_blocks_sync::{LedgerBlocksSynchronizer, LedgerBlocksSynchronizerMetrics},
 };
-use ic_nns_governance::pb::v1::{manage_neuron::NeuronIdOrSubaccount, GovernanceError, NeuronInfo};
-use ic_types::messages::{HttpCallContent, MessageId};
-use ic_types::CanisterId;
-use ic_types::{crypto::threshold_sig::ThresholdSigPublicKey, messages::SignedRequestBytes};
+use ic_nns_governance_api::pb::v1::{
+    manage_neuron::NeuronIdOrSubaccount, GovernanceError, NeuronInfo,
+};
+use ic_types::{
+    crypto::threshold_sig::ThresholdSigPublicKey,
+    messages::{HttpCallContent, MessageId, SignedRequestBytes},
+    CanisterId,
+};
 use icp_ledger::{BlockIndex, Symbol, TransferFee, TransferFeeArgs, DEFAULT_TRANSFER_FEE};
 use on_wire::{FromWire, IntoWire};
 
-use crate::convert;
-use crate::errors::{ApiError, Details, ICError};
-use crate::ledger_client::neuron_response::NeuronResponse;
-use crate::ledger_client::{
-    handle_add_hotkey::handle_add_hotkey,
-    handle_change_auto_stake_maturity::handle_change_auto_stake_maturity,
-    handle_disburse::handle_disburse, handle_follow::handle_follow,
-    handle_merge_maturity::handle_merge_maturity, handle_neuron_info::handle_neuron_info,
-    handle_register_vote::handle_register_vote, handle_remove_hotkey::handle_remove_hotkey,
-    handle_send::handle_send, handle_set_dissolve_timestamp::handle_set_dissolve_timestamp,
-    handle_spawn::handle_spawn, handle_stake::handle_stake,
-    handle_stake_maturity::handle_stake_maturity, handle_start_dissolve::handle_start_dissolve,
-    handle_stop_dissolve::handle_stop_dissolve,
+use crate::{
+    convert,
+    errors::{ApiError, Details, ICError},
+    ledger_client::{
+        handle_add_hotkey::handle_add_hotkey,
+        handle_change_auto_stake_maturity::handle_change_auto_stake_maturity,
+        handle_disburse::handle_disburse, handle_follow::handle_follow,
+        handle_merge_maturity::handle_merge_maturity, handle_neuron_info::handle_neuron_info,
+        handle_register_vote::handle_register_vote, handle_remove_hotkey::handle_remove_hotkey,
+        handle_send::handle_send, handle_set_dissolve_timestamp::handle_set_dissolve_timestamp,
+        handle_spawn::handle_spawn, handle_stake::handle_stake,
+        handle_stake_maturity::handle_stake_maturity, handle_start_dissolve::handle_start_dissolve,
+        handle_stop_dissolve::handle_stop_dissolve, neuron_response::NeuronResponse,
+    },
+    models::{EnvelopePair, SignedTransaction},
+    request::{request_result::RequestResult, transaction_results::TransactionResults, Request},
+    request_types::{RequestType, Status},
+    transaction_id::TransactionIdentifier,
 };
-use crate::models::{EnvelopePair, SignedTransaction};
-use crate::request::request_result::RequestResult;
-use crate::request::transaction_results::TransactionResults;
-use crate::request::Request;
-use crate::request_types::{RequestType, Status};
-use crate::transaction_id::TransactionIdentifier;
 use rosetta_core::objects::ObjectMap;
 
-use self::handle_list_neurons::handle_list_neurons;
-use self::list_neurons_response::ListNeuronsResponse;
-use self::proposal_info_response::ProposalInfoResponse;
+use self::{
+    handle_list_neurons::handle_list_neurons, list_neurons_response::ListNeuronsResponse,
+    proposal_info_response::ProposalInfoResponse,
+};
 
 struct LedgerBlocksSynchronizerMetricsImpl {}
 

--- a/rs/rosetta-api/src/ledger_client/handle_add_hotkey.rs
+++ b/rs/rosetta-api/src/ledger_client/handle_add_hotkey.rs
@@ -1,7 +1,5 @@
-use crate::errors::ApiError;
-use crate::ledger_client::OperationOutput;
-use ic_nns_governance::pb::v1::manage_neuron_response::Command;
-use ic_nns_governance::pb::v1::ManageNeuronResponse;
+use crate::{errors::ApiError, ledger_client::OperationOutput};
+use ic_nns_governance_api::pb::v1::{manage_neuron_response::Command, ManageNeuronResponse};
 
 pub fn handle_add_hotkey(
     bytes: Vec<u8>,

--- a/rs/rosetta-api/src/ledger_client/handle_change_auto_stake_maturity.rs
+++ b/rs/rosetta-api/src/ledger_client/handle_change_auto_stake_maturity.rs
@@ -1,7 +1,5 @@
-use crate::errors::ApiError;
-use crate::ledger_client::OperationOutput;
-use ic_nns_governance::pb::v1::manage_neuron_response::Command;
-use ic_nns_governance::pb::v1::ManageNeuronResponse;
+use crate::{errors::ApiError, ledger_client::OperationOutput};
+use ic_nns_governance_api::pb::v1::{manage_neuron_response::Command, ManageNeuronResponse};
 
 pub fn handle_change_auto_stake_maturity(
     bytes: Vec<u8>,

--- a/rs/rosetta-api/src/ledger_client/handle_disburse.rs
+++ b/rs/rosetta-api/src/ledger_client/handle_disburse.rs
@@ -1,7 +1,8 @@
-use crate::errors::ApiError;
-use crate::ledger_client::OperationOutput;
-use ic_nns_governance::pb::v1::manage_neuron_response::{Command, DisburseResponse};
-use ic_nns_governance::pb::v1::ManageNeuronResponse;
+use crate::{errors::ApiError, ledger_client::OperationOutput};
+use ic_nns_governance_api::pb::v1::{
+    manage_neuron_response::{Command, DisburseResponse},
+    ManageNeuronResponse,
+};
 
 pub fn handle_disburse(
     bytes: Vec<u8>,

--- a/rs/rosetta-api/src/ledger_client/handle_follow.rs
+++ b/rs/rosetta-api/src/ledger_client/handle_follow.rs
@@ -1,7 +1,8 @@
-use crate::errors::ApiError;
-use crate::ledger_client::OperationOutput;
-use ic_nns_governance::pb::v1::manage_neuron_response::{Command, FollowResponse};
-use ic_nns_governance::pb::v1::ManageNeuronResponse;
+use crate::{errors::ApiError, ledger_client::OperationOutput};
+use ic_nns_governance_api::pb::v1::{
+    manage_neuron_response::{Command, FollowResponse},
+    ManageNeuronResponse,
+};
 
 pub fn handle_follow(bytes: Vec<u8>) -> Result<Result<Option<OperationOutput>, ApiError>, String> {
     let response: ManageNeuronResponse = candid::decode_one(bytes.as_ref())

--- a/rs/rosetta-api/src/ledger_client/handle_list_neurons.rs
+++ b/rs/rosetta-api/src/ledger_client/handle_list_neurons.rs
@@ -1,6 +1,5 @@
-use crate::errors::ApiError;
-use crate::ledger_client::OperationOutput;
-use ic_nns_governance::pb::v1::ListNeuronsResponse;
+use crate::{errors::ApiError, ledger_client::OperationOutput};
+use ic_nns_governance_api::pb::v1::ListNeuronsResponse;
 
 pub fn handle_list_neurons(
     bytes: Vec<u8>,

--- a/rs/rosetta-api/src/ledger_client/handle_merge_maturity.rs
+++ b/rs/rosetta-api/src/ledger_client/handle_merge_maturity.rs
@@ -1,7 +1,8 @@
-use crate::errors::ApiError;
-use crate::ledger_client::OperationOutput;
-use ic_nns_governance::pb::v1::manage_neuron_response::{Command, MergeMaturityResponse};
-use ic_nns_governance::pb::v1::ManageNeuronResponse;
+use crate::{errors::ApiError, ledger_client::OperationOutput};
+use ic_nns_governance_api::pb::v1::{
+    manage_neuron_response::{Command, MergeMaturityResponse},
+    ManageNeuronResponse,
+};
 
 pub fn handle_merge_maturity(
     bytes: Vec<u8>,

--- a/rs/rosetta-api/src/ledger_client/handle_neuron_info.rs
+++ b/rs/rosetta-api/src/ledger_client/handle_neuron_info.rs
@@ -1,10 +1,13 @@
-use crate::errors::ApiError;
-use crate::ledger_client::neuron_response::NeuronResponse;
-use crate::ledger_client::OperationOutput;
-use crate::models;
-use ic_nns_governance::pb::v1::{GovernanceError, Neuron, NeuronState};
-use std::collections::HashMap;
-use std::time::{SystemTime, UNIX_EPOCH};
+use crate::{
+    errors::ApiError,
+    ledger_client::{neuron_response::NeuronResponse, OperationOutput},
+    models,
+};
+use ic_nns_governance_api::pb::v1::{GovernanceError, Neuron, NeuronState};
+use std::{
+    collections::HashMap,
+    time::{SystemTime, UNIX_EPOCH},
+};
 
 pub fn handle_neuron_info(
     bytes: Vec<u8>,

--- a/rs/rosetta-api/src/ledger_client/handle_register_vote.rs
+++ b/rs/rosetta-api/src/ledger_client/handle_register_vote.rs
@@ -1,7 +1,8 @@
-use crate::errors::ApiError;
-use crate::ledger_client::OperationOutput;
-use ic_nns_governance::pb::v1::manage_neuron_response::{Command, RegisterVoteResponse};
-use ic_nns_governance::pb::v1::ManageNeuronResponse;
+use crate::{errors::ApiError, ledger_client::OperationOutput};
+use ic_nns_governance_api::pb::v1::{
+    manage_neuron_response::{Command, RegisterVoteResponse},
+    ManageNeuronResponse,
+};
 
 pub fn handle_register_vote(
     bytes: Vec<u8>,

--- a/rs/rosetta-api/src/ledger_client/handle_remove_hotkey.rs
+++ b/rs/rosetta-api/src/ledger_client/handle_remove_hotkey.rs
@@ -1,7 +1,5 @@
-use crate::errors::ApiError;
-use crate::ledger_client::OperationOutput;
-use ic_nns_governance::pb::v1::manage_neuron_response::Command;
-use ic_nns_governance::pb::v1::ManageNeuronResponse;
+use crate::{errors::ApiError, ledger_client::OperationOutput};
+use ic_nns_governance_api::pb::v1::{manage_neuron_response::Command, ManageNeuronResponse};
 
 pub fn handle_remove_hotkey(
     bytes: Vec<u8>,

--- a/rs/rosetta-api/src/ledger_client/handle_set_dissolve_timestamp.rs
+++ b/rs/rosetta-api/src/ledger_client/handle_set_dissolve_timestamp.rs
@@ -1,7 +1,5 @@
-use crate::errors::ApiError;
-use crate::ledger_client::OperationOutput;
-use ic_nns_governance::pb::v1::manage_neuron_response::Command;
-use ic_nns_governance::pb::v1::ManageNeuronResponse;
+use crate::{errors::ApiError, ledger_client::OperationOutput};
+use ic_nns_governance_api::pb::v1::{manage_neuron_response::Command, ManageNeuronResponse};
 
 pub fn handle_set_dissolve_timestamp(
     bytes: Vec<u8>,

--- a/rs/rosetta-api/src/ledger_client/handle_spawn.rs
+++ b/rs/rosetta-api/src/ledger_client/handle_spawn.rs
@@ -1,7 +1,8 @@
-use crate::errors::ApiError;
-use crate::ledger_client::OperationOutput;
-use ic_nns_governance::pb::v1::manage_neuron_response::{Command, SpawnResponse};
-use ic_nns_governance::pb::v1::ManageNeuronResponse;
+use crate::{errors::ApiError, ledger_client::OperationOutput};
+use ic_nns_governance_api::pb::v1::{
+    manage_neuron_response::{Command, SpawnResponse},
+    ManageNeuronResponse,
+};
 
 pub fn handle_spawn(bytes: Vec<u8>) -> Result<Result<Option<OperationOutput>, ApiError>, String> {
     let response: ManageNeuronResponse = candid::decode_one(bytes.as_ref())

--- a/rs/rosetta-api/src/ledger_client/handle_stake.rs
+++ b/rs/rosetta-api/src/ledger_client/handle_stake.rs
@@ -1,7 +1,8 @@
-use crate::errors::ApiError;
-use crate::ledger_client::OperationOutput;
-use ic_nns_governance::pb::v1::claim_or_refresh_neuron_from_account_response::Result as ClaimOrRefreshResult;
-use ic_nns_governance::pb::v1::ClaimOrRefreshNeuronFromAccountResponse;
+use crate::{errors::ApiError, ledger_client::OperationOutput};
+use ic_nns_governance_api::pb::v1::{
+    claim_or_refresh_neuron_from_account_response::Result as ClaimOrRefreshResult,
+    ClaimOrRefreshNeuronFromAccountResponse,
+};
 
 pub fn handle_stake(bytes: Vec<u8>) -> Result<Result<Option<OperationOutput>, ApiError>, String> {
     let res: ClaimOrRefreshNeuronFromAccountResponse =

--- a/rs/rosetta-api/src/ledger_client/handle_stake_maturity.rs
+++ b/rs/rosetta-api/src/ledger_client/handle_stake_maturity.rs
@@ -1,7 +1,8 @@
-use crate::errors::ApiError;
-use crate::ledger_client::OperationOutput;
-use ic_nns_governance::pb::v1::manage_neuron_response::{Command, StakeMaturityResponse};
-use ic_nns_governance::pb::v1::ManageNeuronResponse;
+use crate::{errors::ApiError, ledger_client::OperationOutput};
+use ic_nns_governance_api::pb::v1::{
+    manage_neuron_response::{Command, StakeMaturityResponse},
+    ManageNeuronResponse,
+};
 
 pub fn handle_stake_maturity(
     bytes: Vec<u8>,

--- a/rs/rosetta-api/src/ledger_client/handle_start_dissolve.rs
+++ b/rs/rosetta-api/src/ledger_client/handle_start_dissolve.rs
@@ -1,10 +1,11 @@
-use crate::errors::ApiError;
-use crate::ledger_client::OperationOutput;
-use crate::request_types::RequestType;
-use crate::request_types::START_DISSOLVE;
-use ic_nns_governance::pb::v1::governance_error;
-use ic_nns_governance::pb::v1::manage_neuron_response::Command;
-use ic_nns_governance::pb::v1::ManageNeuronResponse;
+use crate::{
+    errors::ApiError,
+    ledger_client::OperationOutput,
+    request_types::{RequestType, START_DISSOLVE},
+};
+use ic_nns_governance_api::pb::v1::{
+    governance_error, manage_neuron_response::Command, ManageNeuronResponse,
+};
 
 pub fn handle_start_dissolve(
     bytes: Vec<u8>,

--- a/rs/rosetta-api/src/ledger_client/handle_stop_dissolve.rs
+++ b/rs/rosetta-api/src/ledger_client/handle_stop_dissolve.rs
@@ -1,10 +1,11 @@
-use crate::errors::ApiError;
-use crate::ledger_client::OperationOutput;
-use crate::request_types::RequestType;
-use crate::request_types::STOP_DISSOLVE;
-use ic_nns_governance::pb::v1::governance_error;
-use ic_nns_governance::pb::v1::manage_neuron_response::Command;
-use ic_nns_governance::pb::v1::ManageNeuronResponse;
+use crate::{
+    errors::ApiError,
+    ledger_client::OperationOutput,
+    request_types::{RequestType, STOP_DISSOLVE},
+};
+use ic_nns_governance_api::pb::v1::{
+    governance_error, manage_neuron_response::Command, ManageNeuronResponse,
+};
 
 pub fn handle_stop_dissolve(
     bytes: Vec<u8>,

--- a/rs/rosetta-api/src/ledger_client/list_known_neurons_response.rs
+++ b/rs/rosetta-api/src/ledger_client/list_known_neurons_response.rs
@@ -1,5 +1,5 @@
 use crate::errors::ApiError;
-use ic_nns_governance::pb::v1::{KnownNeuron, ListKnownNeuronsResponse as Response};
+use ic_nns_governance_api::pb::v1::{KnownNeuron, ListKnownNeuronsResponse as Response};
 use rosetta_core::objects::ObjectMap;
 use serde_json::Value;
 

--- a/rs/rosetta-api/src/ledger_client/list_neurons_response.rs
+++ b/rs/rosetta-api/src/ledger_client/list_neurons_response.rs
@@ -1,5 +1,5 @@
 use crate::errors::ApiError;
-use ic_nns_governance::pb::v1::ListNeuronsResponse as Response;
+use ic_nns_governance_api::pb::v1::ListNeuronsResponse as Response;
 use rosetta_core::objects::ObjectMap;
 use serde_json::Value;
 

--- a/rs/rosetta-api/src/ledger_client/pending_proposals_response.rs
+++ b/rs/rosetta-api/src/ledger_client/pending_proposals_response.rs
@@ -1,5 +1,5 @@
 use crate::errors::ApiError;
-use ic_nns_governance::pb::v1::ProposalInfo;
+use ic_nns_governance_api::pb::v1::ProposalInfo;
 use rosetta_core::objects::ObjectMap;
 use serde_json::Value;
 

--- a/rs/rosetta-api/src/ledger_client/proposal_info_response.rs
+++ b/rs/rosetta-api/src/ledger_client/proposal_info_response.rs
@@ -1,5 +1,5 @@
 use crate::errors::ApiError;
-use ic_nns_governance::pb::v1::ProposalInfo;
+use ic_nns_governance_api::pb::v1::ProposalInfo;
 use rosetta_core::objects::ObjectMap;
 use serde_json::Value;
 

--- a/rs/rosetta-api/src/request.rs
+++ b/rs/rosetta-api/src/request.rs
@@ -1,10 +1,9 @@
-use crate::convert::principal_id_from_public_key_or_principal;
-use crate::errors::ApiError;
-use crate::models::seconds::Seconds;
-use crate::request_types::*;
-use crate::{convert, models};
+use crate::{
+    convert, convert::principal_id_from_public_key_or_principal, errors::ApiError, models,
+    models::seconds::Seconds, request_types::*,
+};
 use dfn_candid::CandidOne;
-use ic_nns_governance::pb::v1::manage_neuron::{self, configure, Command, Configure};
+use ic_nns_governance_api::pb::v1::manage_neuron::{self, configure, Command, Configure};
 use ic_types::PrincipalId;
 use icp_ledger::Tokens;
 use on_wire::FromWire;
@@ -235,7 +234,7 @@ impl TryFrom<&models::Request> for Request {
 
         let manage_neuron = || {
             {
-                CandidOne::<ic_nns_governance::pb::v1::ManageNeuron>::from_bytes(
+                CandidOne::<ic_nns_governance_api::pb::v1::ManageNeuron>::from_bytes(
                     payload.update_content().arg.0.clone(),
                 )
                 .map_err(|e| {

--- a/rs/rosetta-api/src/request_handler.rs
+++ b/rs/rosetta-api/src/request_handler.rs
@@ -7,43 +7,47 @@ mod construction_payloads;
 mod construction_preprocess;
 mod construction_submit;
 
-use crate::convert::{from_model_account_identifier, neuron_account_from_public_key};
-use crate::errors::{ApiError, Details};
-use crate::ledger_client::list_known_neurons_response::ListKnownNeuronsResponse;
-use crate::ledger_client::pending_proposals_response::PendingProposalsResponse;
-use crate::ledger_client::proposal_info_response::ProposalInfoResponse;
-use crate::ledger_client::LedgerAccess;
-use crate::models::amount::tokens_to_amount;
-use crate::models::{
-    AccountBalanceMetadata, CallResponse, NetworkIdentifier, QueryBlockRangeRequest,
-    QueryBlockRangeResponse,
+use crate::{
+    convert,
+    convert::{from_model_account_identifier, neuron_account_from_public_key},
+    errors::{ApiError, Details},
+    ledger_client::{
+        list_known_neurons_response::ListKnownNeuronsResponse,
+        pending_proposals_response::PendingProposalsResponse,
+        proposal_info_response::ProposalInfoResponse, LedgerAccess,
+    },
+    models,
+    models::{
+        amount::tokens_to_amount, AccountBalanceMetadata, AccountBalanceRequest,
+        AccountBalanceResponse, Allow, BalanceAccountType, BlockIdentifier, BlockResponse,
+        BlockTransaction, BlockTransactionResponse, CallResponse, Error, NetworkIdentifier,
+        NetworkOptionsResponse, NetworkStatusResponse, NeuronInfoResponse, NeuronState,
+        NeuronSubaccountComponents, OperationStatus, Operator, PartialBlockIdentifier,
+        QueryBlockRangeRequest, QueryBlockRangeResponse, SearchTransactionsResponse, Version,
+    },
+    request_types::GetProposalInfo,
+    transaction_id::TransactionIdentifier,
+    API_VERSION, MAX_BLOCKS_PER_QUERY_BLOCK_RANGE_REQUEST, NODE_VERSION,
 };
-use crate::models::{
-    AccountBalanceRequest, AccountBalanceResponse, Allow, BalanceAccountType, BlockIdentifier,
-    BlockResponse, BlockTransaction, BlockTransactionResponse, Error, NetworkOptionsResponse,
-    NetworkStatusResponse, NeuronInfoResponse, NeuronState, NeuronSubaccountComponents,
-    OperationStatus, Operator, PartialBlockIdentifier, SearchTransactionsResponse, Version,
+use ic_ledger_canister_blocks_synchronizer::{
+    blocks::{HashedBlock, RosettaBlocksMode},
+    rosetta_block::RosettaBlock,
 };
-use crate::request_types::GetProposalInfo;
-use crate::transaction_id::TransactionIdentifier;
-use crate::{convert, models, API_VERSION, MAX_BLOCKS_PER_QUERY_BLOCK_RANGE_REQUEST, NODE_VERSION};
-use ic_ledger_canister_blocks_synchronizer::blocks::HashedBlock;
-use ic_ledger_canister_blocks_synchronizer::blocks::RosettaBlocksMode;
-use ic_ledger_canister_blocks_synchronizer::rosetta_block::RosettaBlock;
 use ic_ledger_core::block::BlockType;
 use ic_nns_common::pb::v1::NeuronId;
-use ic_nns_governance::pb::v1::manage_neuron::NeuronIdOrSubaccount;
-use ic_types::crypto::DOMAIN_IC_REQUEST;
-use ic_types::messages::MessageId;
-use ic_types::CanisterId;
+use ic_nns_governance_api::pb::v1::manage_neuron::NeuronIdOrSubaccount;
+use ic_types::{crypto::DOMAIN_IC_REQUEST, messages::MessageId, CanisterId};
 use icp_ledger::{Block, BlockIndex};
-use rosetta_core::objects::ObjectMap;
-use rosetta_core::request_types::MetadataRequest;
-use rosetta_core::response_types::NetworkListResponse;
-use rosetta_core::response_types::{MempoolResponse, MempoolTransactionResponse};
-use std::convert::{TryFrom, TryInto};
-use std::num::TryFromIntError;
-use std::sync::Arc;
+use rosetta_core::{
+    objects::ObjectMap,
+    request_types::MetadataRequest,
+    response_types::{MempoolResponse, MempoolTransactionResponse, NetworkListResponse},
+};
+use std::{
+    convert::{TryFrom, TryInto},
+    num::TryFromIntError,
+    sync::Arc,
+};
 use strum::IntoEnumIterator;
 
 /// The maximum amount of blocks to retrieve in a single search.
@@ -863,7 +867,7 @@ impl RosettaRequestHandler {
     ) -> Result<NeuronInfoResponse, ApiError> {
         let res = self.ledger.neuron_info(neuron_id, verified).await?;
 
-        use ic_nns_governance::pb::v1::NeuronState as PbNeuronState;
+        use ic_nns_governance_api::pb::v1::NeuronState as PbNeuronState;
         let state = match PbNeuronState::try_from(res.state).ok() {
             Some(PbNeuronState::NotDissolving) => NeuronState::NotDissolving,
             Some(PbNeuronState::Spawning) => NeuronState::Spawning,

--- a/rs/rosetta-api/src/request_handler/construction_parse.rs
+++ b/rs/rosetta-api/src/request_handler/construction_parse.rs
@@ -1,23 +1,26 @@
-use crate::convert::{self, from_arg, to_model_account_identifier};
-use crate::errors::ApiError;
-use crate::models::{ConstructionParseRequest, ConstructionParseResponse, ParsedTransaction};
-use crate::request_handler::{verify_network_id, RosettaRequestHandler};
-use crate::request_types::{
-    AddHotKey, ChangeAutoStakeMaturity, Disburse, Follow, ListNeurons, MergeMaturity, NeuronInfo,
-    PublicKeyOrPrincipal, RegisterVote, RemoveHotKey, RequestType, SetDissolveTimestamp, Spawn,
-    Stake, StakeMaturity, StartDissolve, StopDissolve,
+use crate::{
+    convert::{self, from_arg, to_model_account_identifier},
+    errors::ApiError,
+    models::{ConstructionParseRequest, ConstructionParseResponse, ParsedTransaction},
+    request_handler::{verify_network_id, RosettaRequestHandler},
+    request_types::{
+        AddHotKey, ChangeAutoStakeMaturity, Disburse, Follow, ListNeurons, MergeMaturity,
+        NeuronInfo, PublicKeyOrPrincipal, RegisterVote, RemoveHotKey, RequestType,
+        SetDissolveTimestamp, Spawn, Stake, StakeMaturity, StartDissolve, StopDissolve,
+    },
 };
 use rosetta_core::objects::ObjectMap;
 
-use ic_nns_governance::pb::v1::{
+use ic_nns_governance_api::pb::v1::{
     manage_neuron::{self, Command, NeuronIdOrSubaccount},
     ClaimOrRefreshNeuronFromAccount, ManageNeuron,
 };
 
-use crate::models::seconds::Seconds;
-use crate::request::Request;
-use ic_types::messages::{Blob, HttpCallContent, HttpCanisterUpdate};
-use ic_types::PrincipalId;
+use crate::{models::seconds::Seconds, request::Request};
+use ic_types::{
+    messages::{Blob, HttpCallContent, HttpCanisterUpdate},
+    PrincipalId,
+};
 use icp_ledger::{AccountIdentifier, Operation, SendArgs};
 use std::convert::TryFrom;
 
@@ -595,23 +598,23 @@ fn follow(
 #[cfg(test)]
 mod tests {
     use ic_base_types::CanisterId;
-    use proptest::prop_assert;
-    use proptest::test_runner::TestCaseError;
-    use proptest::{prop_assert_eq, proptest, strategy::Strategy};
+    use proptest::{
+        prop_assert, prop_assert_eq, proptest, strategy::Strategy, test_runner::TestCaseError,
+    };
     use rand_chacha::rand_core::OsRng;
-    use std::str::FromStr;
-    use std::time::SystemTime;
+    use std::{str::FromStr, time::SystemTime};
     use url::Url;
 
-    use crate::ledger_client::LedgerClient;
-    use crate::models::operation::OperationType;
-    use crate::models::Amount;
-    use crate::models::{
-        ConstructionCombineRequest, ConstructionDeriveRequest, ConstructionParseRequest,
-        ConstructionPayloadsRequest, ConstructionPayloadsRequestMetadata, Currency, CurveType,
-        Operation, OperationIdentifier, PublicKey, Signature, SignatureType,
+    use crate::{
+        ledger_client::LedgerClient,
+        models::{
+            operation::OperationType, Amount, ConstructionCombineRequest,
+            ConstructionDeriveRequest, ConstructionParseRequest, ConstructionPayloadsRequest,
+            ConstructionPayloadsRequestMetadata, Currency, CurveType, Operation,
+            OperationIdentifier, PublicKey, Signature, SignatureType,
+        },
+        request_handler::RosettaRequestHandler,
     };
-    use crate::request_handler::RosettaRequestHandler;
     use rosetta_core::objects::ObjectMap;
 
     #[test]

--- a/rs/rosetta-api/src/request_handler/construction_payloads.rs
+++ b/rs/rosetta-api/src/request_handler/construction_payloads.rs
@@ -1,34 +1,38 @@
 use dfn_candid::CandidOne;
 use ic_nns_common::pb::v1::NeuronId;
-use ic_types::messages::{Blob, HttpCanisterUpdate, MessageId};
-use ic_types::PrincipalId;
+use ic_types::{
+    messages::{Blob, HttpCanisterUpdate, MessageId},
+    PrincipalId,
+};
 use icp_ledger::{Memo, Operation, SendArgs, Tokens};
 use on_wire::IntoWire;
 use rand::Rng;
-use std::collections::HashMap;
-use std::sync::Arc;
-use std::time::Duration;
+use std::{collections::HashMap, sync::Arc, time::Duration};
 
-use ic_nns_governance::pb::v1::{
+use ic_nns_governance_api::pb::v1::{
     manage_neuron::{self, configure, Command, NeuronIdOrSubaccount},
     ClaimOrRefreshNeuronFromAccount, ManageNeuron,
 };
 
-use crate::convert::{make_read_state_from_update, to_arg, to_model_account_identifier};
-use crate::errors::ApiError;
-use crate::ledger_client::LedgerAccess;
-use crate::models::{
-    AccountIdentifier, ConstructionPayloadsRequest, ConstructionPayloadsRequestMetadata,
-    ConstructionPayloadsResponse, PublicKey, SignatureType, SigningPayload, UnsignedTransaction,
+use crate::{
+    convert,
+    convert::{make_read_state_from_update, to_arg, to_model_account_identifier},
+    errors::ApiError,
+    ledger_client::LedgerAccess,
+    models,
+    models::{
+        AccountIdentifier, ConstructionPayloadsRequest, ConstructionPayloadsRequestMetadata,
+        ConstructionPayloadsResponse, PublicKey, SignatureType, SigningPayload,
+        UnsignedTransaction,
+    },
+    request::Request,
+    request_handler::{make_sig_data, verify_network_id, RosettaRequestHandler},
+    request_types::{
+        AddHotKey, ChangeAutoStakeMaturity, Disburse, Follow, ListNeurons, MergeMaturity,
+        NeuronInfo, PublicKeyOrPrincipal, RegisterVote, RemoveHotKey, RequestType,
+        SetDissolveTimestamp, Spawn, Stake, StakeMaturity, StartDissolve, StopDissolve,
+    },
 };
-use crate::request::Request;
-use crate::request_handler::{make_sig_data, verify_network_id, RosettaRequestHandler};
-use crate::request_types::{
-    AddHotKey, ChangeAutoStakeMaturity, Disburse, Follow, ListNeurons, MergeMaturity, NeuronInfo,
-    PublicKeyOrPrincipal, RegisterVote, RemoveHotKey, RequestType, SetDissolveTimestamp, Spawn,
-    Stake, StakeMaturity, StartDissolve, StopDissolve,
-};
-use crate::{convert, models};
 use rosetta_core::convert::principal_id_from_public_key;
 
 impl RosettaRequestHandler {
@@ -420,7 +424,7 @@ fn handle_list_neurons(
         .map_err(|err| ApiError::InvalidPublicKey(false, err.into()))?;
 
     // Argument for the method called on the governance canister.
-    let args = ic_nns_governance::pb::v1::ListNeurons {
+    let args = ic_nns_governance_api::pb::v1::ListNeurons {
         neuron_ids: vec![],
         include_neurons_readable_by_caller: true,
         include_empty_neurons_readable_by_caller: None,
@@ -885,7 +889,7 @@ fn add_neuron_management_payload(
     account: icp_ledger::AccountIdentifier,
     controller: Option<PrincipalId>, // specify with hotkey.
     neuron_index: u64,
-    command: ic_nns_governance::pb::v1::manage_neuron::Command,
+    command: ic_nns_governance_api::pb::v1::manage_neuron::Command,
     payloads: &mut Vec<SigningPayload>,
     updates: &mut Vec<(RequestType, HttpCanisterUpdate)>,
     pks_map: &HashMap<icp_ledger::AccountIdentifier, &PublicKey>,

--- a/rs/rosetta-api/tests/test_utils/mod.rs
+++ b/rs/rosetta-api/tests/test_utils/mod.rs
@@ -1,24 +1,20 @@
 use async_trait::async_trait;
-use ic_ledger_canister_blocks_synchronizer::blocks::Blocks;
-use ic_ledger_canister_blocks_synchronizer::blocks::HashedBlock;
-use ic_ledger_canister_blocks_synchronizer::blocks::RosettaBlocksMode;
+use ic_ledger_canister_blocks_synchronizer::blocks::{Blocks, HashedBlock, RosettaBlocksMode};
 use ic_ledger_canister_core::ledger::LedgerTransaction;
-use ic_ledger_core::block::BlockType;
-use ic_ledger_core::timestamp::TimeStamp;
-use ic_nns_governance::pb::v1::manage_neuron::NeuronIdOrSubaccount;
-use ic_nns_governance::pb::v1::{KnownNeuron, ProposalInfo};
-use ic_rosetta_api::convert::{from_arg, to_model_account_identifier};
-use ic_rosetta_api::errors::ApiError;
-use ic_rosetta_api::ledger_client::LedgerAccess;
-use ic_rosetta_api::models::{
-    AccountBalanceRequest, EnvelopePair, PartialBlockIdentifier, SignedTransaction,
+use ic_ledger_core::{block::BlockType, timestamp::TimeStamp};
+use ic_nns_governance_api::pb::v1::{
+    manage_neuron::NeuronIdOrSubaccount, KnownNeuron, ProposalInfo,
 };
-use ic_rosetta_api::request::request_result::RequestResult;
-use ic_rosetta_api::request::transaction_results::TransactionResults;
-use ic_rosetta_api::request::Request;
-use ic_rosetta_api::request_handler::RosettaRequestHandler;
-use ic_rosetta_api::request_types::{RequestType, Status};
-use ic_rosetta_api::DEFAULT_TOKEN_SYMBOL;
+use ic_rosetta_api::{
+    convert::{from_arg, to_model_account_identifier},
+    errors::ApiError,
+    ledger_client::LedgerAccess,
+    models::{AccountBalanceRequest, EnvelopePair, PartialBlockIdentifier, SignedTransaction},
+    request::{request_result::RequestResult, transaction_results::TransactionResults, Request},
+    request_handler::RosettaRequestHandler,
+    request_types::{RequestType, Status},
+    DEFAULT_TOKEN_SYMBOL,
+};
 use ic_types::{
     messages::{HttpCallContent, HttpCanisterUpdate},
     CanisterId, PrincipalId,
@@ -26,11 +22,12 @@ use ic_types::{
 use icp_ledger::{
     self, AccountIdentifier, Block, Operation, SendArgs, Tokens, TransferFee, DEFAULT_TRANSFER_FEE,
 };
-use std::convert::TryFrom;
-use std::ops::Deref;
-use std::str::FromStr;
-use std::sync::atomic::AtomicBool;
-use std::sync::{Arc, Mutex};
+use std::{
+    convert::TryFrom,
+    ops::Deref,
+    str::FromStr,
+    sync::{atomic::AtomicBool, Arc, Mutex},
+};
 use tokio::sync::RwLock;
 
 const FIRST_BLOCK_TIMESTAMP_NANOS_SINCE_EPOC: u64 = 1_656_147_600_000_000_000; // 25 June 2022 09:00:00
@@ -232,7 +229,7 @@ impl LedgerAccess for TestLedger {
         &self,
         _id: NeuronIdOrSubaccount,
         _: bool,
-    ) -> Result<ic_nns_governance::pb::v1::NeuronInfo, ApiError> {
+    ) -> Result<ic_nns_governance_api::pb::v1::NeuronInfo, ApiError> {
         panic!("Neuron info not available through TestLedger");
     }
 

--- a/rs/tests/src/rosetta_tests/rosetta_client.rs
+++ b/rs/tests/src/rosetta_tests/rosetta_client.rs
@@ -511,7 +511,7 @@ impl RosettaApiClient {
         .unwrap()
         .pending_proposals
         .into_iter()
-        .map(|p| p.proposal.unwrap().into())
+        .map(|p| p.proposal.unwrap())
         .collect();
         Ok(pending_proposals)
     }

--- a/rs/tests/src/rosetta_tests/tests/list_known_neurons.rs
+++ b/rs/tests/src/rosetta_tests/tests/list_known_neurons.rs
@@ -4,7 +4,7 @@ use crate::rosetta_tests::{
     test_neurons::TestNeurons,
 };
 use ic_ledger_core::Tokens;
-use ic_nns_governance::pb::v1::KnownNeuronData;
+use ic_nns_governance_api::pb::v1::KnownNeuronData;
 use ic_rosetta_api::{
     ledger_client::list_known_neurons_response::ListKnownNeuronsResponse, models::CallResponse,
 };
@@ -61,8 +61,8 @@ pub fn test(env: TestEnv) {
         let mut known_neurons_response =
             ListKnownNeuronsResponse::try_from(Some(known_neurons.result)).unwrap();
         known_neurons_response.known_neurons.sort_by(
-            |a: &ic_nns_governance::pb::v1::KnownNeuron,
-             b: &ic_nns_governance::pb::v1::KnownNeuron| {
+            |a: &ic_nns_governance_api::pb::v1::KnownNeuron,
+             b: &ic_nns_governance_api::pb::v1::KnownNeuron| {
                 a.id.unwrap().partial_cmp(&b.id.unwrap()).unwrap()
             },
         );

--- a/rs/tests/src/rosetta_tests/tests/list_known_neurons.rs
+++ b/rs/tests/src/rosetta_tests/tests/list_known_neurons.rs
@@ -24,31 +24,22 @@ pub fn test(env: TestEnv) {
     let mut neurons = TestNeurons::new(0, &mut ledger_balances);
 
     let neuron0 = neurons.create(|neuron| {
-        neuron.known_neuron_data = Some(
-            KnownNeuronData {
-                name: "0".to_owned(),
-                description: Some("Neuron 0 description".to_owned()),
-            }
-            .into(),
-        )
+        neuron.known_neuron_data = Some(KnownNeuronData {
+            name: "0".to_owned(),
+            description: Some("Neuron 0 description".to_owned()),
+        })
     });
     let neuron1: NeuronDetails = neurons.create(|neuron| {
-        neuron.known_neuron_data = Some(
-            KnownNeuronData {
-                name: "1".to_owned(),
-                description: Some("Neuron 1 description".to_owned()),
-            }
-            .into(),
-        )
+        neuron.known_neuron_data = Some(KnownNeuronData {
+            name: "1".to_owned(),
+            description: Some("Neuron 1 description".to_owned()),
+        })
     });
     let neuron2 = neurons.create(|neuron| {
-        neuron.known_neuron_data = Some(
-            KnownNeuronData {
-                name: "2".to_owned(),
-                description: Some("Neuron 2 description".to_owned()),
-            }
-            .into(),
-        )
+        neuron.known_neuron_data = Some(KnownNeuronData {
+            name: "2".to_owned(),
+            description: Some("Neuron 2 description".to_owned()),
+        })
     });
 
     // Create Rosetta and ledger clients.

--- a/rs/tests/src/rosetta_tests/tests/neuron_voting.rs
+++ b/rs/tests/src/rosetta_tests/tests/neuron_voting.rs
@@ -93,7 +93,7 @@ pub fn test(env: TestEnv) {
         );
         let proposal_info =
             ProposalInfoResponse::try_from(Some(proposal_info_response.result)).unwrap();
-        assert_eq!(proposal_info.0.proposal.unwrap(), proposal.clone().into());
+        assert_eq!(proposal_info.0.proposal.unwrap(), proposal);
         info!(_logger, "Test Register Vote with Vote: Yes");
         test_register_proposal(&client, &neuron2, &first_proposal, &1).await;
         info!(_logger, "Test Register Vote with Vote: No");


### PR DESCRIPTION
Another step in the effort to reduce dependencies on nns canister crates.