### PR TITLE
refactor(nervous_system): Remove most usages of hotkey_principal

### DIFF
--- a/rs/nervous_system/common/src/lib.rs
+++ b/rs/nervous_system/common/src/lib.rs
@@ -113,6 +113,17 @@ macro_rules! assert_is_err {
     };
 }
 
+pub fn obsolete_string_field<T: AsRef<str>>(obselete_field: T, replacement: Option<T>) -> String {
+    match replacement {
+        Some(replacement) => format!(
+            "The field `{}` is obsolete. Please use `{}` instead.",
+            obselete_field.as_ref(),
+            replacement.as_ref(),
+        ),
+        None => format!("The field `{}` is obsolete.", obselete_field.as_ref()),
+    }
+}
+
 /// Besides dividing, this also converts to Decimal (from u64).
 ///
 /// The only way this can fail is if denominations_per_token is 0. Therefore, if you pass a positive

--- a/rs/nervous_system/integration_tests/tests/sns_lifecycle.rs
+++ b/rs/nervous_system/integration_tests/tests/sns_lifecycle.rs
@@ -1270,7 +1270,6 @@ fn test_sns_lifecycle(
                 nns_proposal_id
             );
         };
-        #[allow(deprecated)] // TODO(NNS1-3198): remove once hotkey_principal is removed
         neurons_fund_audit_info
             .final_neurons_fund_participation
             .unwrap()
@@ -1280,10 +1279,7 @@ fn test_sns_lifecycle(
             .into_iter()
             .map(|neurons_fund_neuron_portion| {
                 (
-                    neurons_fund_neuron_portion
-                        .controller
-                        .or(neurons_fund_neuron_portion.hotkey_principal)
-                        .unwrap(),
+                    neurons_fund_neuron_portion.controller.unwrap(),
                     neurons_fund_neuron_portion,
                 )
             })
@@ -1738,7 +1734,6 @@ fn test_sns_lifecycle(
             );
         };
         // Maps neuron IDs to maturity equivalent ICP e8s.
-        #[allow(deprecated)] // TODO(NNS1-3198): remove once hotkey_principal is removed
         let mut final_neurons_fund_participation: BTreeMap<PrincipalId, Vec<u64>> =
             neurons_fund_audit_info
                 .final_neurons_fund_participation
@@ -1750,10 +1745,7 @@ fn test_sns_lifecycle(
                 .fold(
                     BTreeMap::new(),
                     |mut neuron_portions_per_controller, neuron_portion| {
-                        let controller_principal_id = neuron_portion
-                            .controller
-                            .or(neuron_portion.hotkey_principal)
-                            .unwrap();
+                        let controller_principal_id = neuron_portion.controller.unwrap();
                         let amount_icp_e8s = neuron_portion.amount_icp_e8s.unwrap();
                         neuron_portions_per_controller
                             .entry(controller_principal_id)

--- a/rs/nns/governance/api/src/ic_nns_governance.pb.v1.rs
+++ b/rs/nns/governance/api/src/ic_nns_governance.pb.v1.rs
@@ -1735,10 +1735,6 @@ pub mod neurons_fund_snapshot {
         /// The principals that can vote, propose, and follow on behalf of this neuron.
         #[prost(message, repeated, tag = "7")]
         pub hotkeys: Vec<PrincipalId>,
-        /// Deprecated. Please use `controller` instead (not `hotkeys`!)
-        #[deprecated]
-        #[prost(message, optional, tag = "4")]
-        pub hotkey_principal: Option<PrincipalId>,
     }
 }
 /// Absolute constraints of this swap needed that the Neurons' Fund need to be aware of.
@@ -2224,6 +2220,7 @@ pub mod create_service_nervous_system {
     /// Nested message and enum types in `InitialTokenDistribution`.
     pub mod initial_token_distribution {
         use super::*;
+
         #[derive(
             candid::CandidType, candid::Deserialize, serde::Serialize, comparable::Comparable,
         )]
@@ -3517,11 +3514,7 @@ pub mod settle_neurons_fund_participation_response {
         /// Whether the amount maturity amount of Neurons' Fund participation associated with this neuron
         /// has been capped to reflect the maximum participation amount for this SNS swap.
         #[prost(bool, optional, tag = "4")]
-        pub is_capped: Option<bool>,
-        /// Deprecated. Please use `controller` instead (not `hotkeys`!)
-        #[deprecated]
-        #[prost(string, optional, tag = "3")]
-        pub hotkey_principal: Option<::prost::alloc::string::String>,
+        pub is_capped: ::core::option::Option<bool>,
     }
     /// Request was completed successfully.
     #[derive(candid::CandidType, candid::Deserialize, serde::Serialize, comparable::Comparable)]

--- a/rs/nns/governance/canister/governance.did
+++ b/rs/nns/governance/canister/governance.did
@@ -676,7 +676,6 @@ type NeuronsFundMatchedFundingCurveCoefficients = record {
 
 type NeuronsFundNeuron = record {
   controller : opt principal;
-  hotkey_principal : opt text;
   hotkeys : opt Principals;
   is_capped : opt bool;
   nns_neuron_id : opt nat64;
@@ -685,7 +684,6 @@ type NeuronsFundNeuron = record {
 
 type NeuronsFundNeuronPortion = record {
   controller : opt principal;
-  hotkey_principal : opt principal;
   hotkeys : vec principal;
   is_capped : opt bool;
   maturity_equivalent_icp_e8s : opt nat64;

--- a/rs/nns/governance/canister/governance_test.did
+++ b/rs/nns/governance/canister/governance_test.did
@@ -678,7 +678,6 @@ type NeuronsFundMatchedFundingCurveCoefficients = record {
 
 type NeuronsFundNeuron = record {
   controller : opt principal;
-  hotkey_principal : opt text;
   hotkeys : opt Principals;
   is_capped : opt bool;
   nns_neuron_id : opt nat64;
@@ -687,7 +686,6 @@ type NeuronsFundNeuron = record {
 
 type NeuronsFundNeuronPortion = record {
   controller : opt principal;
-  hotkey_principal : opt principal;
   hotkeys : vec principal;
   is_capped : opt bool;
   maturity_equivalent_icp_e8s : opt nat64;

--- a/rs/nns/governance/proto/ic_nns_governance/pb/v1/governance.proto
+++ b/rs/nns/governance/proto/ic_nns_governance/pb/v1/governance.proto
@@ -1552,8 +1552,8 @@ message NeuronsFundSnapshot {
     // The principals that can vote, propose, and follow on behalf of this neuron.
     repeated ic_base_types.pb.v1.PrincipalId hotkeys = 7;
 
-    // Deprecated. Please use `controller` instead (not `hotkeys`!)
-    optional ic_base_types.pb.v1.PrincipalId hotkey_principal = 4 [deprecated = true];
+    reserved 4;
+    reserved "hotkey_principal";
   }
 
   repeated NeuronsFundNeuronPortion neurons_fund_neuron_portions = 1;
@@ -2719,8 +2719,8 @@ message SettleNeuronsFundParticipationResponse {
     // has been capped to reflect the maximum participation amount for this SNS swap.
     optional bool is_capped = 4;
 
-    // Deprecated. Please use `controller` instead (not `hotkeys`!)
-    optional string hotkey_principal = 3 [deprecated = true];
+    reserved 3;
+    reserved "hotkey_principal";
   }
 
   // Request was completed successfully.

--- a/rs/nns/governance/src/gen/ic_nns_governance.pb.v1.rs
+++ b/rs/nns/governance/src/gen/ic_nns_governance.pb.v1.rs
@@ -1627,10 +1627,6 @@ pub mod neurons_fund_snapshot {
         /// The principals that can vote, propose, and follow on behalf of this neuron.
         #[prost(message, repeated, tag = "7")]
         pub hotkeys: ::prost::alloc::vec::Vec<::ic_base_types::PrincipalId>,
-        /// Deprecated. Please use `controller` instead (not `hotkeys`!)
-        #[deprecated]
-        #[prost(message, optional, tag = "4")]
-        pub hotkey_principal: ::core::option::Option<::ic_base_types::PrincipalId>,
     }
 }
 /// Absolute constraints of this swap needed that the Neurons' Fund need to be aware of.
@@ -3397,10 +3393,6 @@ pub mod settle_neurons_fund_participation_response {
         /// has been capped to reflect the maximum participation amount for this SNS swap.
         #[prost(bool, optional, tag = "4")]
         pub is_capped: ::core::option::Option<bool>,
-        /// Deprecated. Please use `controller` instead (not `hotkeys`!)
-        #[deprecated]
-        #[prost(string, optional, tag = "3")]
-        pub hotkey_principal: ::core::option::Option<::prost::alloc::string::String>,
     }
     /// Request was completed successfully.
     #[derive(candid::CandidType, candid::Deserialize, serde::Serialize, comparable::Comparable)]

--- a/rs/nns/governance/src/governance.rs
+++ b/rs/nns/governance/src/governance.rs
@@ -296,21 +296,18 @@ impl From<NeuronsFundNeuronPortion> for NeuronsFundNeuronPortionPb {
             controller: Some(neuron.controller),
             is_capped: Some(neuron.is_capped),
             hotkeys: neuron.hotkeys,
-            hotkey_principal: Some(neuron.controller),
         }
     }
 }
 
 impl From<NeuronsFundNeuronPortion> for NeuronsFundNeuronPb {
     fn from(neuron: NeuronsFundNeuronPortion) -> Self {
-        #[allow(deprecated)] // TODO(NNS1-3198): Remove once hotkey_principal is removed
         Self {
             nns_neuron_id: Some(neuron.id.id),
             amount_icp_e8s: Some(neuron.amount_icp_e8s),
             controller: Some(neuron.controller),
             hotkeys: Some(Principals::from(neuron.hotkeys.clone())),
             is_capped: Some(neuron.is_capped),
-            hotkey_principal: Some(neuron.controller.to_string()),
         }
     }
 }

--- a/rs/nns/governance/src/neurons_fund.rs
+++ b/rs/nns/governance/src/neurons_fund.rs
@@ -422,10 +422,11 @@ impl NeuronsFundNeuronPortionPb {
                 maturity_equivalent_icp_e8s,
             });
         }
-        #[allow(deprecated)] // TODO(NNS1-3198): remove .or(hotkey_principal)
-        let controller = self.controller.or(self.hotkey_principal).ok_or_else(|| {
-            NeuronsFundNeuronPortionError::UnspecifiedField("hotkey_principal".to_string())
-        })?;
+        let Some(controller) = self.controller else {
+            return Err(NeuronsFundNeuronPortionError::UnspecifiedField(
+                "controller".to_string(),
+            ));
+        };
         let hotkeys = self.hotkeys.clone();
         let is_capped = self.is_capped.ok_or_else(|| {
             NeuronsFundNeuronPortionError::UnspecifiedField("is_capped".to_string())
@@ -1745,8 +1746,6 @@ where
                 is_capped: Some(neuron.is_capped),
                 controller: Some(neuron.controller),
                 hotkeys: neuron.hotkeys.clone(),
-                // TODO(NNS1-3198): remove due to the  very misleading name
-                hotkey_principal: Some(neuron.controller),
             })
             .collect();
         let neurons_fund_reserves = Some(NeuronsFundSnapshotPb {

--- a/rs/nns/governance/src/neurons_fund/neurons_fund_anonymization_tests.rs
+++ b/rs/nns/governance/src/neurons_fund/neurons_fund_anonymization_tests.rs
@@ -20,7 +20,6 @@ fn test_neurons_fund_participation_anonymization() {
     let maturity_equivalent_icp_e8s = 100_000_000_000;
     let controller = PrincipalId::default();
     let is_capped = false;
-    #[allow(deprecated)] // TODO(NNS1-3198): Remove this when hotkey_principal is removed
     let n1: NeuronsFundNeuronPortionPb = NeuronsFundNeuronPortionPb {
         nns_neuron_id: Some(id1),
         amount_icp_e8s: Some(amount_icp_e8s),
@@ -28,9 +27,6 @@ fn test_neurons_fund_participation_anonymization() {
         controller: Some(controller),
         hotkeys: vec![],
         is_capped: Some(is_capped),
-
-        // TODO(NNS1-3198): Remove this deprecated field
-        hotkey_principal: Some(controller),
     };
     let n2 = NeuronsFundNeuronPortionPb {
         nns_neuron_id: Some(id2),
@@ -104,7 +100,6 @@ fn test_neurons_fund_snapshot_anonymization() {
     let maturity_equivalent_icp_e8s = 100_000_000_000;
     let controller = PrincipalId::default();
     let is_capped = false;
-    #[allow(deprecated)] // TODO(NNS1-3198): remove hotkey_principal
     let n1: NeuronsFundNeuronPortionPb = NeuronsFundNeuronPortionPb {
         nns_neuron_id: Some(id1),
         amount_icp_e8s: Some(amount_icp_e8s),
@@ -112,8 +107,6 @@ fn test_neurons_fund_snapshot_anonymization() {
         controller: Some(controller),
         hotkeys: vec![],
         is_capped: Some(is_capped),
-        // TODO(NNS1-3198): Remove this deprecated field
-        hotkey_principal: Some(controller),
     };
     let n2 = NeuronsFundNeuronPortionPb {
         nns_neuron_id: Some(id2),
@@ -159,7 +152,6 @@ fn test_neurons_fund_neuron_portion_anonymization() {
     let hotkeys = Vec::new();
     let is_capped = false;
 
-    #[allow(deprecated)] // TODO(NNS1-3198): remove hotkey_principal
     let neuron: NeuronsFundNeuronPortionPb = NeuronsFundNeuronPortionPb {
         nns_neuron_id: Some(id),
         amount_icp_e8s: Some(amount_icp_e8s),
@@ -167,8 +159,6 @@ fn test_neurons_fund_neuron_portion_anonymization() {
         controller: Some(controller),
         hotkeys: vec![],
         is_capped: Some(is_capped),
-        // TODO(NNS1-3198): Remove this deprecated field
-        hotkey_principal: Some(controller),
     };
     assert_eq!(
         neuron.validate(),

--- a/rs/nns/governance/src/pb/conversions.rs
+++ b/rs/nns/governance/src/pb/conversions.rs
@@ -2136,7 +2136,6 @@ impl From<pb::neurons_fund_snapshot::NeuronsFundNeuronPortion>
     for pb_api::neurons_fund_snapshot::NeuronsFundNeuronPortion
 {
     fn from(item: pb::neurons_fund_snapshot::NeuronsFundNeuronPortion) -> Self {
-        #[allow(deprecated)]
         Self {
             nns_neuron_id: item.nns_neuron_id,
             amount_icp_e8s: item.amount_icp_e8s,
@@ -2144,7 +2143,6 @@ impl From<pb::neurons_fund_snapshot::NeuronsFundNeuronPortion>
             is_capped: item.is_capped,
             controller: item.controller,
             hotkeys: item.hotkeys,
-            hotkey_principal: item.hotkey_principal,
         }
     }
 }
@@ -2160,7 +2158,6 @@ impl From<pb_api::neurons_fund_snapshot::NeuronsFundNeuronPortion>
             is_capped: item.is_capped,
             controller: item.controller,
             hotkeys: item.hotkeys,
-            hotkey_principal: item.hotkey_principal,
         }
     }
 }
@@ -4085,7 +4082,6 @@ impl From<pb::settle_neurons_fund_participation_response::NeuronsFundNeuron>
             controller: item.controller,
             hotkeys: item.hotkeys,
             is_capped: item.is_capped,
-            hotkey_principal: item.hotkey_principal,
         }
     }
 }
@@ -4100,7 +4096,6 @@ impl From<pb_api::settle_neurons_fund_participation_response::NeuronsFundNeuron>
             controller: item.controller,
             hotkeys: item.hotkeys,
             is_capped: item.is_capped,
-            hotkey_principal: item.hotkey_principal,
         }
     }
 }

--- a/rs/nns/governance/tests/governance.rs
+++ b/rs/nns/governance/tests/governance.rs
@@ -11191,7 +11191,7 @@ lazy_static! {
         let mut result = vec![
             sns_swap_pb::CfParticipant {
                 controller: Some(principal(1)),
-                hotkey_principal: principal(1).to_string(),
+                hotkey_principal: String::new(),
                 cf_neurons: vec![
                     sns_swap_pb::CfNeuron::try_new(
                         1,
@@ -11207,7 +11207,7 @@ lazy_static! {
             },
             sns_swap_pb::CfParticipant {
                 controller: Some(principal(2)),
-                hotkey_principal: principal(2).to_string(),
+                hotkey_principal: String::new(),
                 cf_neurons: vec![
                     sns_swap_pb::CfNeuron::try_new(
                         3,
@@ -11233,7 +11233,6 @@ lazy_static! {
     );
 
     static ref INITIAL_NEURONS_FUND_PARTICIPATION: Option<NeuronsFundParticipation> =
-    #[allow(deprecated)] // TODO[#NNS-2338]: Remove this once hotkey_principal is removed.
     Some(NeuronsFundParticipation {
         ideal_matched_participation_function: Some(
             IdealMatchedParticipationFunction {
@@ -11260,8 +11259,6 @@ lazy_static! {
                         is_capped: Some(
                             false,
                         ),
-                        // TODO(#NNS-2338): Remove this once hotkey_principal is removed.
-                        hotkey_principal: Some(principal(1)),
                     },
                     NeuronsFundNeuronPortion {
                         nns_neuron_id: Some(
@@ -11280,9 +11277,6 @@ lazy_static! {
                         is_capped: Some(
                             false,
                         ),
-
-                        // TODO(#NNS-2338): Remove this once hotkey_principal is removed.
-                        hotkey_principal: Some(principal(2)),
                     },
                 ],
             },
@@ -11321,7 +11315,6 @@ lazy_static! {
     });
 
     static ref INITIAL_NEURONS_FUND_PARTICIPATION_ABORT: Option<NeuronsFundParticipation> =
-    #[allow(deprecated)] // TODO(#NNS-2338): Remove this once hotkey_principal is removed.
     Some(NeuronsFundParticipation {
         ideal_matched_participation_function: Some(
             IdealMatchedParticipationFunction {
@@ -11367,7 +11360,6 @@ lazy_static! {
     });
 
     static ref INITIAL_NEURONS_FUND_PARTICIPATION_COMMIT: Option<NeuronsFundParticipation> =
-    #[allow(deprecated)] // TODO(#NNS-2338): Remove this once hotkey_principal is removed.
     Some(NeuronsFundParticipation {
         ideal_matched_participation_function: Some(
             IdealMatchedParticipationFunction {
@@ -11394,9 +11386,6 @@ lazy_static! {
                         is_capped: Some(
                             false,
                         ),
-
-                        // TODO[NNS-2338]: Remove this once hotkey_principal is removed.
-                        hotkey_principal: Some(principal(1)),
                     },
                     NeuronsFundNeuronPortion {
                         nns_neuron_id: Some(
@@ -11415,9 +11404,6 @@ lazy_static! {
                         is_capped: Some(
                             false,
                         ),
-
-                        // TODO[NNS-2338]: Remove this once hotkey_principal is removed.
-                        hotkey_principal: Some(principal(2)),
                     },
                 ],
             },
@@ -11456,7 +11442,6 @@ lazy_static! {
     });
 
     static ref NEURONS_FUND_FULL_REFUNDS: Option<NeuronsFundSnapshot> =
-    #[allow(deprecated)] // TODO(NNS1-3198): Remove this once hotkey_principal is removed.
     Some(NeuronsFundSnapshot {
         neurons_fund_neuron_portions: vec![
             NeuronsFundNeuronPortion {
@@ -11476,10 +11461,6 @@ lazy_static! {
                 is_capped: Some(
                     false,
                 ),
-
-
-                // TODO(NNS1-3198): Remove this once hotkey_principal is removed.
-                hotkey_principal: Some(principal(1)),
             },
             NeuronsFundNeuronPortion {
                 nns_neuron_id: Some(
@@ -11498,15 +11479,11 @@ lazy_static! {
                 is_capped: Some(
                     false,
                 ),
-
-                // TODO(NNS1-3198): Remove this once hotkey_principal is removed.
-                hotkey_principal: Some(principal(2)),
             },
         ],
     });
 
     static ref NEURONS_FUND_PARTIAL_REFUNDS: Option<NeuronsFundSnapshot> =
-    #[allow(deprecated)] // TODO(NNS1-3198): Remove this once hotkey_principal is removed.
     Some(NeuronsFundSnapshot {
         neurons_fund_neuron_portions: vec![
             NeuronsFundNeuronPortion {
@@ -11526,9 +11503,6 @@ lazy_static! {
                 is_capped: Some(
                     false,
                 ),
-
-                // TODO(NNS1-3198): Remove this once hotkey_principal is removed.
-                hotkey_principal: Some(principal(1)),
             },
             NeuronsFundNeuronPortion {
                 nns_neuron_id: Some(
@@ -11547,9 +11521,6 @@ lazy_static! {
                 is_capped: Some(
                     false,
                 ),
-
-                // TODO(NNS1-3198): Remove this once hotkey_principal is removed.
-                hotkey_principal: Some(principal(2)),
             },
         ],
     });

--- a/rs/nns/governance/tests/interleaving_tests.rs
+++ b/rs/nns/governance/tests/interleaving_tests.rs
@@ -198,8 +198,6 @@ fn test_cant_interleave_calls_to_settle_neurons_fund() {
                 controller: Some(nf_neurons_controller),
                 hotkeys: Vec::new(),
                 is_capped: Some(false),
-                // TODO(NNS1-3198): Remove this field once it's deprecated
-                hotkey_principal: Some(nf_neurons_controller),
             }],
         }),
         swap_participation_limits: Some(SwapParticipationLimits {

--- a/rs/sns/audit/src/lib.rs
+++ b/rs/sns/audit/src/lib.rs
@@ -179,11 +179,7 @@ async fn validate_neurons_fund_sns_swap_participation(
     let refunded_neuron_portions = neurons_fund_refunds.neurons_fund_neuron_portions;
     let mut refunded_amounts_per_controller = BTreeMap::new();
     for refunded_neuron_portion in refunded_neuron_portions.iter() {
-        #[allow(deprecated)] // TODO(NNS1-3198): remove once hotkey_principal is removed
-        let controller = refunded_neuron_portion
-            .controller
-            .or(refunded_neuron_portion.hotkey_principal)
-            .unwrap();
+        let controller = refunded_neuron_portion.controller.unwrap();
         let new_amount_icp_e8s = refunded_neuron_portion.amount_icp_e8s.unwrap();
         refunded_amounts_per_controller
             .entry(controller)
@@ -200,11 +196,7 @@ async fn validate_neurons_fund_sns_swap_participation(
         .neurons_fund_neuron_portions;
     let mut initial_amounts_per_controller = BTreeMap::new();
     for initial_neuron_portion in initial_neuron_portions.iter() {
-        #[allow(deprecated)] // TODO(NNS1-3198): remove once hotkey_principal is removed
-        let controller = initial_neuron_portion
-            .controller
-            .or(initial_neuron_portion.hotkey_principal)
-            .unwrap();
+        let controller = initial_neuron_portion.controller.unwrap();
         let new_amount_icp_e8s = initial_neuron_portion.amount_icp_e8s.unwrap();
         initial_amounts_per_controller
             .entry(controller)
@@ -221,14 +213,10 @@ async fn validate_neurons_fund_sns_swap_participation(
         .neurons_fund_neuron_portions;
     let mut final_amounts_per_controller = BTreeMap::new();
     for final_neuron_portion in final_neuron_portions.iter() {
-        #[allow(deprecated)] // TODO(NNS1-3198): remove once hotkey_principal is removed
-        let hotkey_principal = final_neuron_portion
-            .controller
-            .or(final_neuron_portion.hotkey_principal)
-            .unwrap();
+        let controller = final_neuron_portion.controller.unwrap();
         let new_amount_icp_e8s = final_neuron_portion.amount_icp_e8s.unwrap();
         final_amounts_per_controller
-            .entry(hotkey_principal)
+            .entry(controller)
             .and_modify(|total_amount_icp_e8s| *total_amount_icp_e8s += new_amount_icp_e8s)
             .or_insert(new_amount_icp_e8s);
     }
@@ -293,14 +281,10 @@ async fn validate_neurons_fund_sns_swap_participation(
 
     let mut investment_per_controller_icp_e8s = BTreeMap::<_, Vec<u64>>::new();
     for expected_neuron_portion in final_neuron_portions {
-        #[allow(deprecated)] // TODO(NNS1-3198): remove once hotkey_principal is removed
-        let hotkey_principal = expected_neuron_portion
-            .controller
-            .or(expected_neuron_portion.hotkey_principal)
-            .unwrap();
+        let controller = expected_neuron_portion.controller.unwrap();
         let amount_icp_e8s = expected_neuron_portion.amount_icp_e8s.unwrap();
         investment_per_controller_icp_e8s
-            .entry(hotkey_principal)
+            .entry(controller)
             .and_modify(|nns_neurons| {
                 nns_neurons.push(amount_icp_e8s);
             })

--- a/rs/sns/swap/proto/ic_sns_swap/pb/v1/swap.proto
+++ b/rs/sns/swap/proto/ic_sns_swap/pb/v1/swap.proto
@@ -1194,9 +1194,8 @@ message SettleNeuronsFundParticipationResponse {
     // has been capped to reflect the maximum participation amount for this SNS swap.
     optional bool is_capped = 4;
 
-    // Deprecated. Please use `controller` instead (not `hotkeys`!)
-    // TODO(NNS1-3198): Remove
-    optional string hotkey_principal = 3 [deprecated = true];
+    reserved 3;
+    reserved "hotkey_principal";
   }
 
   // Request was completed successfully.

--- a/rs/sns/swap/src/gen/ic_sns_swap.pb.v1.rs
+++ b/rs/sns/swap/src/gen/ic_sns_swap.pb.v1.rs
@@ -1520,11 +1520,6 @@ pub mod settle_neurons_fund_participation_response {
         /// has been capped to reflect the maximum participation amount for this SNS swap.
         #[prost(bool, optional, tag = "4")]
         pub is_capped: ::core::option::Option<bool>,
-        /// Deprecated. Please use `controller` instead (not `hotkeys`!)
-        /// TODO(NNS1-3198): Remove
-        #[deprecated]
-        #[prost(string, optional, tag = "3")]
-        pub hotkey_principal: ::core::option::Option<::prost::alloc::string::String>,
     }
     /// Request was completed successfully.
     #[derive(candid::CandidType, candid::Deserialize, serde::Serialize, comparable::Comparable)]

--- a/rs/sns/swap/src/swap.rs
+++ b/rs/sns/swap/src/swap.rs
@@ -2441,7 +2441,7 @@ impl Swap {
             .map(|(nf_neuron_nns_controller, cf_neurons)| CfParticipant {
                 controller: Some(nf_neuron_nns_controller),
                 // TODO(NNS1-3198): Remove once hotkey_principal is removed
-                hotkey_principal: format!("Field `hotkey_principal` is obsolete as a misnomer, as it used to hold the *controller* principal ID of the (Neuron's Fund-participating) NNS neuron, and not NNS neuron hotkeys. Please use field `controller` instead for the NNS neuron controller. If you must know now, the NNS neuron's controller of this neuron is `{}`.", nf_neuron_nns_controller),
+                hotkey_principal: format!("Field `hotkey_principal` is obsolete as a misnomer, as it used to hold the *controller* principal ID of the (Neurons' Fund-participating) NNS neuron, and not NNS neuron hotkeys. Please use field `controller` instead for the NNS neuron controller. If you must know now, the NNS neuron's controller of this neuron is `{}`.", nf_neuron_nns_controller),
                 cf_neurons,
             })
             .collect();
@@ -3372,7 +3372,10 @@ fn create_sns_neuron_basket_for_neurons_fund_participant(
                 hotkeys: Some(Principals::from(hotkeys.clone())),
                 nns_neuron_id,
                 // TODO(NNS1-3198): Remove
-                hotkey_principal: String::new(),
+                hotkey_principal: ic_nervous_system_common::obsolete_string_field(
+                    "hotkey_principal",
+                    Some("controller"),
+                ),
             })),
             neuron_attributes: Some(NeuronAttributes {
                 memo,
@@ -4092,22 +4095,34 @@ mod tests {
         let cf_participants = vec![
             CfParticipant {
                 controller: Some(PrincipalId::new_user_test_id(992899)),
-                hotkey_principal: String::new(),
+                hotkey_principal: ic_nervous_system_common::obsolete_string_field(
+                    "hotkey_principal",
+                    Some("controller"),
+                ),
                 cf_neurons: vec![CfNeuron::try_new(1, 698047, Vec::new()).unwrap()],
             },
             CfParticipant {
                 controller: Some(PrincipalId::new_user_test_id(800257)),
-                hotkey_principal: String::new(),
+                hotkey_principal: ic_nervous_system_common::obsolete_string_field(
+                    "hotkey_principal",
+                    Some("controller"),
+                ),
                 cf_neurons: vec![CfNeuron::try_new(2, 678574, Vec::new()).unwrap()],
             },
             CfParticipant {
                 controller: Some(PrincipalId::new_user_test_id(818371)),
-                hotkey_principal: String::new(),
+                hotkey_principal: ic_nervous_system_common::obsolete_string_field(
+                    "hotkey_principal",
+                    Some("controller"),
+                ),
                 cf_neurons: vec![CfNeuron::try_new(3, 305256, Vec::new()).unwrap()],
             },
             CfParticipant {
                 controller: Some(PrincipalId::new_user_test_id(657894)),
-                hotkey_principal: String::new(),
+                hotkey_principal: ic_nervous_system_common::obsolete_string_field(
+                    "hotkey_principal",
+                    Some("controller"),
+                ),
                 cf_neurons: vec![CfNeuron::try_new(4, 339747, Vec::new()).unwrap()],
             },
         ];
@@ -4906,7 +4921,10 @@ mod tests {
         let cf_participants = vec![
             CfParticipant {
                 controller: Some(PrincipalId::new_user_test_id(992899)),
-                hotkey_principal: String::new(),
+                hotkey_principal: ic_nervous_system_common::obsolete_string_field(
+                    "hotkey_principal",
+                    Some("controller"),
+                ),
                 cf_neurons: vec![
                     CfNeuron::try_new(1, 698047, Vec::new()).unwrap(),
                     CfNeuron::try_new(2, 303030, Vec::new()).unwrap(),
@@ -4914,12 +4932,18 @@ mod tests {
             },
             CfParticipant {
                 controller: Some(PrincipalId::new_user_test_id(800257)),
-                hotkey_principal: String::new(),
+                hotkey_principal: ic_nervous_system_common::obsolete_string_field(
+                    "hotkey_principal",
+                    Some("controller"),
+                ),
                 cf_neurons: vec![CfNeuron::try_new(3, 678574, Vec::new()).unwrap()],
             },
             CfParticipant {
                 controller: Some(PrincipalId::new_user_test_id(818371)),
-                hotkey_principal: String::new(),
+                hotkey_principal: ic_nervous_system_common::obsolete_string_field(
+                    "hotkey_principal",
+                    Some("controller"),
+                ),
                 cf_neurons: vec![
                     CfNeuron::try_new(4, 305256, Vec::new()).unwrap(),
                     CfNeuron::try_new(5, 100000, Vec::new()).unwrap(),

--- a/rs/sns/swap/src/swap.rs
+++ b/rs/sns/swap/src/swap.rs
@@ -2441,7 +2441,7 @@ impl Swap {
             .map(|(nf_neuron_nns_controller, cf_neurons)| CfParticipant {
                 controller: Some(nf_neuron_nns_controller),
                 // TODO(NNS1-3198): Remove once hotkey_principal is removed
-                hotkey_principal: nf_neuron_nns_controller.to_string(),
+                hotkey_principal: format!("Field `hotkey_principal` is obsolete as a misnomer, as it used to hold the *controller* principal ID of the (Neuron's Fund-participating) NNS neuron, and not NNS neuron hotkeys. Please use field `controller` instead for the NNS neuron controller. If you must know now, the NNS neuron's controller of this neuron is `{}`.", nf_neuron_nns_controller),
                 cf_neurons,
             })
             .collect();
@@ -3372,7 +3372,7 @@ fn create_sns_neuron_basket_for_neurons_fund_participant(
                 hotkeys: Some(Principals::from(hotkeys.clone())),
                 nns_neuron_id,
                 // TODO(NNS1-3198): Remove
-                hotkey_principal: controller.to_string(),
+                hotkey_principal: String::new(),
             })),
             neuron_attributes: Some(NeuronAttributes {
                 memo,
@@ -4092,22 +4092,22 @@ mod tests {
         let cf_participants = vec![
             CfParticipant {
                 controller: Some(PrincipalId::new_user_test_id(992899)),
-                hotkey_principal: PrincipalId::new_user_test_id(992899).to_string(),
+                hotkey_principal: String::new(),
                 cf_neurons: vec![CfNeuron::try_new(1, 698047, Vec::new()).unwrap()],
             },
             CfParticipant {
                 controller: Some(PrincipalId::new_user_test_id(800257)),
-                hotkey_principal: PrincipalId::new_user_test_id(800257).to_string(),
+                hotkey_principal: String::new(),
                 cf_neurons: vec![CfNeuron::try_new(2, 678574, Vec::new()).unwrap()],
             },
             CfParticipant {
                 controller: Some(PrincipalId::new_user_test_id(818371)),
-                hotkey_principal: PrincipalId::new_user_test_id(818371).to_string(),
+                hotkey_principal: String::new(),
                 cf_neurons: vec![CfNeuron::try_new(3, 305256, Vec::new()).unwrap()],
             },
             CfParticipant {
                 controller: Some(PrincipalId::new_user_test_id(657894)),
-                hotkey_principal: PrincipalId::new_user_test_id(657894).to_string(),
+                hotkey_principal: String::new(),
                 cf_neurons: vec![CfNeuron::try_new(4, 339747, Vec::new()).unwrap()],
             },
         ];
@@ -4906,7 +4906,7 @@ mod tests {
         let cf_participants = vec![
             CfParticipant {
                 controller: Some(PrincipalId::new_user_test_id(992899)),
-                hotkey_principal: PrincipalId::new_user_test_id(992899).to_string(),
+                hotkey_principal: String::new(),
                 cf_neurons: vec![
                     CfNeuron::try_new(1, 698047, Vec::new()).unwrap(),
                     CfNeuron::try_new(2, 303030, Vec::new()).unwrap(),
@@ -4914,12 +4914,12 @@ mod tests {
             },
             CfParticipant {
                 controller: Some(PrincipalId::new_user_test_id(800257)),
-                hotkey_principal: PrincipalId::new_user_test_id(800257).to_string(),
+                hotkey_principal: String::new(),
                 cf_neurons: vec![CfNeuron::try_new(3, 678574, Vec::new()).unwrap()],
             },
             CfParticipant {
                 controller: Some(PrincipalId::new_user_test_id(818371)),
-                hotkey_principal: PrincipalId::new_user_test_id(818371).to_string(),
+                hotkey_principal: String::new(),
                 cf_neurons: vec![
                     CfNeuron::try_new(4, 305256, Vec::new()).unwrap(),
                     CfNeuron::try_new(5, 100000, Vec::new()).unwrap(),

--- a/rs/sns/swap/src/types.rs
+++ b/rs/sns/swap/src/types.rs
@@ -746,6 +746,7 @@ impl CfParticipant {
             .fold(0, |sum, v| sum.saturating_add(v))
     }
 
+    /// Tries to get the controller, returning an error if it is not set
     pub fn try_get_controller(&self) -> Result<PrincipalId, String> {
         #[allow(deprecated)] // TODO(NNS1-3198): Remove once hotkey_principal is removed
         match (
@@ -1135,25 +1136,16 @@ impl TryFrom<crate::pb::v1::settle_neurons_fund_participation_response::NeuronsF
     fn try_from(
         value: crate::pb::v1::settle_neurons_fund_participation_response::NeuronsFundNeuron,
     ) -> Result<Self, Self::Error> {
-        #[allow(deprecated)] // TODO(NNS1-3198): Remove this once hotkey_principal is removed
         let crate::pb::v1::settle_neurons_fund_participation_response::NeuronsFundNeuron {
             nns_neuron_id,
             amount_icp_e8s,
             controller,
             hotkeys,
             is_capped,
-            hotkey_principal,
         } = value;
         let hotkeys = hotkeys.unwrap_or_default().principals;
-
-        let controller = match (controller, hotkey_principal) {
-            (Some(controller), _) => controller,
-            // TODO(NNS1-3198): Remove this case once hotkey_principal is removed
-            (None, Some(hotkey_principal)) => PrincipalId::from_str(&hotkey_principal)
-                .map_err(|_| format!("Invalid hotkey_principal {}", hotkey_principal))?,
-            (None, None) => {
-                return Err("Either controller or hotkey_principal must be specified".to_string())
-            }
+        let Some(controller) = controller else {
+            return Err("NeuronsFundNeuron.Controller must be specified".to_string());
         };
 
         match (nns_neuron_id, amount_icp_e8s, is_capped) {
@@ -1176,9 +1168,6 @@ impl TryFrom<crate::pb::v1::settle_neurons_fund_participation_response::NeuronsF
 }
 
 #[cfg(test)]
-// TODO(NNS1-3198): remove #[allow(deprecated)] once hotkey_principal is removed.
-// Unfortunately, this must be applied to the whole module to avoid warnings on the hotkey_principal field in lazy_static.
-#[allow(deprecated)]
 mod tests {
     use super::*;
     use crate::{
@@ -1265,6 +1254,7 @@ mod tests {
 
     #[test]
     fn participant_total_icp_e8s_no_overflow() {
+        #[allow(deprecated)] // TODO(NNS1-3198): Remove once hotkey_principal is removed
         let participant = CfParticipant {
             controller: None,
             hotkey_principal: "".to_string(),

--- a/rs/sns/swap/src/types.rs
+++ b/rs/sns/swap/src/types.rs
@@ -1145,7 +1145,7 @@ impl TryFrom<crate::pb::v1::settle_neurons_fund_participation_response::NeuronsF
         } = value;
         let hotkeys = hotkeys.unwrap_or_default().principals;
         let Some(controller) = controller else {
-            return Err("NeuronsFundNeuron.Controller must be specified".to_string());
+            return Err("NeuronsFundNeuron.controller must be specified".to_string());
         };
 
         match (nns_neuron_id, amount_icp_e8s, is_capped) {

--- a/rs/sns/swap/tests/common/mod.rs
+++ b/rs/sns/swap/tests/common/mod.rs
@@ -245,7 +245,10 @@ pub fn create_generic_cf_participants(count: u64) -> Vec<CfParticipant> {
             #[allow(deprecated)] // TODO(NNS1-3198): remove once hotkey_principal is removed
             CfParticipant {
                 controller: Some(PrincipalId::new_user_test_id(i)),
-                hotkey_principal: String::new(),
+                hotkey_principal: ic_nervous_system_common::obsolete_string_field(
+                    "hotkey_principal",
+                    Some("controller"),
+                ),
                 cf_neurons: vec![CfNeuron::try_new(
                     i,
                     E8,

--- a/rs/sns/swap/tests/common/mod.rs
+++ b/rs/sns/swap/tests/common/mod.rs
@@ -245,7 +245,7 @@ pub fn create_generic_cf_participants(count: u64) -> Vec<CfParticipant> {
             #[allow(deprecated)] // TODO(NNS1-3198): remove once hotkey_principal is removed
             CfParticipant {
                 controller: Some(PrincipalId::new_user_test_id(i)),
-                hotkey_principal: PrincipalId::new_user_test_id(i).to_string(),
+                hotkey_principal: String::new(),
                 cf_neurons: vec![CfNeuron::try_new(
                     i,
                     E8,

--- a/rs/sns/swap/tests/swap.rs
+++ b/rs/sns/swap/tests/swap.rs
@@ -3467,7 +3467,10 @@ async fn test_claim_swap_neuron_correctly_creates_neuron_recipes() {
                 investor: Some(Investor::CommunityFund(CfInvestment {
                     controller: Some(*TEST_USER2_PRINCIPAL),
                     hotkeys: Some(Principals::from(vec![*TEST_USER3_PRINCIPAL])),
-                    hotkey_principal: String::new(),
+                    hotkey_principal: ic_nervous_system_common::obsolete_string_field(
+                        "hotkey_principal",
+                        Some("controller"),
+                    ),
                     nns_neuron_id: 100,
                 })),
                 sns: Some(TransferableAmount {
@@ -3953,7 +3956,10 @@ fn test_create_sns_neuron_recipes_skips_already_created_neuron_recipes_for_nf_pa
         cf_participants: vec![
             CfParticipant {
                 controller: Some(PrincipalId::new_user_test_id(1001)),
-                hotkey_principal: String::new(),
+                hotkey_principal: ic_nervous_system_common::obsolete_string_field(
+                    "hotkey_principal",
+                    Some("controller"),
+                ),
                 cf_neurons: vec![CfNeuron {
                     nns_neuron_id: 1,
                     amount_icp_e8s: 50 * E8,
@@ -3963,7 +3969,10 @@ fn test_create_sns_neuron_recipes_skips_already_created_neuron_recipes_for_nf_pa
             },
             CfParticipant {
                 controller: Some(PrincipalId::new_user_test_id(1002)),
-                hotkey_principal: String::new(),
+                hotkey_principal: ic_nervous_system_common::obsolete_string_field(
+                    "hotkey_principal",
+                    Some("controller"),
+                ),
                 cf_neurons: vec![CfNeuron {
                     nns_neuron_id: 2,
                     amount_icp_e8s: 50 * E8,
@@ -4019,7 +4028,10 @@ fn test_create_sns_neuron_recipes_includes_hotkeys() {
         neurons_fund_participation_icp_e8s: Some(100 * E8),
         cf_participants: vec![CfParticipant {
             controller: Some(PrincipalId::new_user_test_id(1001)),
-            hotkey_principal: String::new(),
+            hotkey_principal: ic_nervous_system_common::obsolete_string_field(
+                "hotkey_principal",
+                Some("controller"),
+            ),
             cf_neurons: vec![CfNeuron {
                 nns_neuron_id: 1,
                 amount_icp_e8s: 50 * E8,

--- a/rs/sns/swap/tests/swap.rs
+++ b/rs/sns/swap/tests/swap.rs
@@ -825,7 +825,6 @@ fn test_scenario_happy() {
     // SNS neuron baskets that will need to be created, so overall there should be 6 baskets,
     // `neurons_per_investor` neurons each. Finally, test that `Swap.create_sns_neuron_recipes`
     // produces the 18 expected neurons.
-    #[allow(deprecated)] // TODO(NNS1-3198): Remove once hotkey_principal is removed
     let nns_governance = {
         let mut nns_governance = SpyNnsGovernanceClient::new(vec![
             NnsGovernanceClientReply::SettleNeuronsFundParticipation(
@@ -848,9 +847,6 @@ fn test_scenario_happy() {
                                             ),
                                             hotkeys: Some(Principals::from(Vec::new())),
                                             is_capped: Some(false),
-                                            hotkey_principal: Some(
-                                                neurons_fund_participant_principal_id.to_string(),
-                                            ),
                                         }
                                     },
                                 )
@@ -1146,7 +1142,6 @@ async fn test_finalize_swap_ok_matched_funding() {
         SpyLedger,
         SpyNnsGovernanceClient,
     > {
-        #[allow(deprecated)] // TODO(NNS1-3198): Remove this once hotkey_principal is removed.
         CanisterClients {
             sns_governance: SpySnsGovernanceClient::new(vec![
                 SnsGovernanceClientReply::ClaimSwapNeurons(ClaimSwapNeuronsResponse::new(
@@ -1196,9 +1191,6 @@ async fn test_finalize_swap_ok_matched_funding() {
                                     controller: Some(PrincipalId::new_user_test_id(1)),
                                     hotkeys: Some(Principals::from(Vec::new())),
                                     is_capped: Some(true),
-                                    hotkey_principal: Some(
-                                        PrincipalId::new_user_test_id(1).to_string(),
-                                    ),
                                 }],
                             },
                         )),
@@ -3475,7 +3467,7 @@ async fn test_claim_swap_neuron_correctly_creates_neuron_recipes() {
                 investor: Some(Investor::CommunityFund(CfInvestment {
                     controller: Some(*TEST_USER2_PRINCIPAL),
                     hotkeys: Some(Principals::from(vec![*TEST_USER3_PRINCIPAL])),
-                    hotkey_principal: (*TEST_USER2_PRINCIPAL).to_string(),
+                    hotkey_principal: String::new(),
                     nns_neuron_id: 100,
                 })),
                 sns: Some(TransferableAmount {
@@ -3961,7 +3953,7 @@ fn test_create_sns_neuron_recipes_skips_already_created_neuron_recipes_for_nf_pa
         cf_participants: vec![
             CfParticipant {
                 controller: Some(PrincipalId::new_user_test_id(1001)),
-                hotkey_principal: PrincipalId::new_user_test_id(1001).to_string(),
+                hotkey_principal: String::new(),
                 cf_neurons: vec![CfNeuron {
                     nns_neuron_id: 1,
                     amount_icp_e8s: 50 * E8,
@@ -3971,7 +3963,7 @@ fn test_create_sns_neuron_recipes_skips_already_created_neuron_recipes_for_nf_pa
             },
             CfParticipant {
                 controller: Some(PrincipalId::new_user_test_id(1002)),
-                hotkey_principal: PrincipalId::new_user_test_id(1002).to_string(),
+                hotkey_principal: String::new(),
                 cf_neurons: vec![CfNeuron {
                     nns_neuron_id: 2,
                     amount_icp_e8s: 50 * E8,
@@ -4027,7 +4019,7 @@ fn test_create_sns_neuron_recipes_includes_hotkeys() {
         neurons_fund_participation_icp_e8s: Some(100 * E8),
         cf_participants: vec![CfParticipant {
             controller: Some(PrincipalId::new_user_test_id(1001)),
-            hotkey_principal: PrincipalId::new_user_test_id(1001).to_string(),
+            hotkey_principal: String::new(),
             cf_neurons: vec![CfNeuron {
                 nns_neuron_id: 1,
                 amount_icp_e8s: 50 * E8,
@@ -4177,7 +4169,6 @@ async fn test_settle_neurons_fund_participation_returns_successfully_on_subseque
         ..Default::default()
     };
 
-    #[allow(deprecated)] // TODO(NNS1-3198): Remove this once hotkey_principal is removed.
     let mut spy_nns_governance_client = SpyNnsGovernanceClient::new(vec![
         NnsGovernanceClientReply::SettleNeuronsFundParticipation(
             SettleNeuronsFundParticipationResponse {
@@ -4187,10 +4178,8 @@ async fn test_settle_neurons_fund_participation_returns_successfully_on_subseque
                             nns_neuron_id: Some(43),
                             amount_icp_e8s: Some(100 * E8),
                             controller: Some(PrincipalId::new_user_test_id(1)),
-
                             hotkeys: Some(Principals::from(Vec::new())),
                             is_capped: Some(true),
-                            hotkey_principal: Some(PrincipalId::new_user_test_id(1).to_string()),
                         }],
                     },
                 )),
@@ -4323,7 +4312,6 @@ async fn test_settle_neurons_fund_participation_handles_invalid_governance_respo
         ..Default::default()
     };
 
-    #[allow(deprecated)] // TODO(NNS1-3198): Remove this once hotkey_principal is removed.
     let mut spy_nns_governance_client = SpyNnsGovernanceClient::new(vec![
         NnsGovernanceClientReply::SettleNeuronsFundParticipation(
             SettleNeuronsFundParticipationResponse {
@@ -4335,7 +4323,6 @@ async fn test_settle_neurons_fund_participation_handles_invalid_governance_respo
                             controller: Some(PrincipalId::new_user_test_id(1)),
                             hotkeys: Some(Principals::from(Vec::new())),
                             is_capped: Some(false),
-                            hotkey_principal: Some(PrincipalId::new_user_test_id(1).to_string()),
                         }],
                     },
                 )),
@@ -4356,7 +4343,7 @@ async fn test_settle_neurons_fund_participation_handles_invalid_governance_respo
                     Defects: [\"NNS governance returned an invalid NeuronsFundNeuron. Struct: NeuronsFundNeuron { \
                     nns_neuron_id: Some(0), amount_icp_e8s: Some(0), controller: Some(6fyp7-3ibaa-aaaaa-aaaap-4ai), \
                     hotkeys: Some(Principals { principals: [] }), is_capped: \
-                    Some(false), hotkey_principal: Some(\\\"6fyp7-3ibaa-aaaaa-aaaap-4ai\\\") }, Reason: nns_neuron_id must be specified\"]".to_string()),
+                    Some(false) }, Reason: nns_neuron_id must be specified\"]".to_string()),
             },
         )),
     };


### PR DESCRIPTION
## Problem

We deprecated all fields named hotkey_principal, but still set them (even in cases where the field is optional)

## Solution

Remove it when possible. However It is difficult to remove occurrences of `hotkey_principal` fields with type `String` (rather than `Option<String>). For these cases, we don’t need to fully remove the field, let’s just set it to String::new() at all sites where it is set, and make sure we don’t use that value anywhere.

[← Previous PR](https://github.com/dfinity/ic/pull/1286)