### PR TITLE
feat(idx): disable fastbuild on macos_ci

### DIFF
--- a/bazel/conf/.bazelrc.build
+++ b/bazel/conf/.bazelrc.build
@@ -82,7 +82,6 @@ test:ci --flaky_test_attempts=default
 
 # So that developers can build in debug mode.
 build:dev --compilation_mode=fastbuild
-build:macos_ci --compilation_mode=fastbuild
 build:macos_ci --build_tag_filters="-system_test,-fuzz_test"
 
 # A config to get faster compilation feedback by skipping code generation.


### PR DESCRIPTION
This changes the bazel build on macOS CI to _not_ use `fastbuild`, i.e. changes the bazel build to build in release mode.

This means the published replica should be more performant, and this also reduces the size of some Bazel cache artifacts (librocksdb-sys went from 700MiB to 19MiB).