### PR TITLE
feat(registry): Remove unused function `Registry.retire_replica_version` [override-didc-check]

### DIFF
--- a/rs/registry/canister/canister/canister.rs
+++ b/rs/registry/canister/canister/canister.rs
@@ -41,7 +41,6 @@ use registry_canister::{
         do_recover_subnet::RecoverSubnetPayload,
         do_remove_api_boundary_nodes::RemoveApiBoundaryNodesPayload,
         do_remove_nodes_from_subnet::RemoveNodesFromSubnetPayload,
-        do_retire_replica_version::RetireReplicaVersionPayload,
         do_revise_elected_replica_versions::ReviseElectedGuestosVersionsPayload,
         do_set_firewall_config::SetFirewallConfigPayload,
         do_update_api_boundary_nodes_version::UpdateApiBoundaryNodesVersionPayload,
@@ -353,22 +352,6 @@ fn atomic_mutate() {
 
     let bytes = serialize_atomic_mutate_response(response_pb).expect("Error serializing response");
     reply(&bytes)
-}
-
-#[export_name = "canister_update retire_replica_version"]
-fn retire_replica_version() {
-    check_caller_is_governance_and_log("retire_replica_version");
-    over(candid_one, |payload: RetireReplicaVersionPayload| {
-        retire_replica_version_(payload)
-    });
-}
-
-#[candid_method(update, rename = "retire_replica_version")]
-fn retire_replica_version_(_payload: RetireReplicaVersionPayload) {
-    panic!(
-        "{}retire_replica_version is deprecated and should no longer be used!",
-        LOG_PREFIX
-    );
 }
 
 #[export_name = "canister_update revise_elected_guestos_versions"]

--- a/rs/registry/canister/canister/registry.did
+++ b/rs/registry/canister/canister/registry.did
@@ -267,8 +267,6 @@ type RerouteCanisterRangesPayload = record {
   destination_subnet : principal;
 };
 
-type RetireReplicaVersionPayload = record { replica_version_ids : vec text };
-
 type ReviseElectedGuestosVersionsPayload = record {
   release_package_urls : vec text;
   replica_versions_to_unelect : vec text;
@@ -444,7 +442,6 @@ service : {
   remove_nodes : (RemoveNodesPayload) -> ();
   remove_nodes_from_subnet : (RemoveNodesPayload) -> ();
   reroute_canister_ranges : (RerouteCanisterRangesPayload) -> ();
-  retire_replica_version : (RetireReplicaVersionPayload) -> ();
   revise_elected_guestos_versions : (ReviseElectedGuestosVersionsPayload) -> ();
   revise_elected_replica_versions : (ReviseElectedGuestosVersionsPayload) -> ();
   set_firewall_config : (SetFirewallConfigPayload) -> ();


### PR DESCRIPTION
This PR removes the unused Registry function `retire_replica_version`, as it could only be used by NNS Governance which no longer uses it.