### PR TITLE
feat: Ensure we don't compare PageMaps in prod

### DIFF
--- a/rs/replicated_state/src/canister_snapshots.rs
+++ b/rs/replicated_state/src/canister_snapshots.rs
@@ -16,7 +16,8 @@ use std::{
 ///
 /// Additionally, keeps track of all the accumulated changes
 /// since the last flush to the disk.
-#[derive(Clone, Debug, Default, PartialEq, Eq)]
+#[derive(Clone, Debug, Default)]
+#[cfg_attr(feature = "debug_assertions", derive(PartialEq, Eq))]
 pub struct CanisterSnapshots {
     snapshots: BTreeMap<SnapshotId, Arc<CanisterSnapshot>>,
     /// Snapshot operations are consumed by the `StateManager` in order to
@@ -233,7 +234,8 @@ impl CanisterSnapshots {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "debug_assertions", derive(PartialEq, Eq))]
 pub struct PageMemory {
     /// The contents of this memory.
     pub page_map: PageMap,
@@ -259,7 +261,8 @@ impl From<&PageMemory> for Memory {
 }
 
 /// Contains all information related to a canister's execution state.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "debug_assertions", derive(PartialEq, Eq))]
 pub struct ExecutionStateSnapshot {
     /// The raw canister module.
     pub wasm_binary: CanisterModule,
@@ -270,7 +273,8 @@ pub struct ExecutionStateSnapshot {
 }
 
 /// Contains all information related to a canister snapshot.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "debug_assertions", derive(PartialEq, Eq))]
 pub struct CanisterSnapshot {
     /// Identifies the canister to which this snapshot belongs.
     canister_id: CanisterId,

--- a/rs/replicated_state/src/canister_snapshots.rs
+++ b/rs/replicated_state/src/canister_snapshots.rs
@@ -17,7 +17,7 @@ use std::{
 /// Additionally, keeps track of all the accumulated changes
 /// since the last flush to the disk.
 #[derive(Clone, Debug, Default)]
-#[cfg_attr(feature = "debug_assertions", derive(PartialEq, Eq))]
+#[cfg_attr(debug_assertions, derive(PartialEq, Eq))]
 pub struct CanisterSnapshots {
     snapshots: BTreeMap<SnapshotId, Arc<CanisterSnapshot>>,
     /// Snapshot operations are consumed by the `StateManager` in order to
@@ -235,7 +235,7 @@ impl CanisterSnapshots {
 }
 
 #[derive(Clone, Debug)]
-#[cfg_attr(feature = "debug_assertions", derive(PartialEq, Eq))]
+#[cfg_attr(debug_assertions, derive(PartialEq, Eq))]
 pub struct PageMemory {
     /// The contents of this memory.
     pub page_map: PageMap,
@@ -262,7 +262,7 @@ impl From<&PageMemory> for Memory {
 
 /// Contains all information related to a canister's execution state.
 #[derive(Clone, Debug)]
-#[cfg_attr(feature = "debug_assertions", derive(PartialEq, Eq))]
+#[cfg_attr(debug_assertions, derive(PartialEq, Eq))]
 pub struct ExecutionStateSnapshot {
     /// The raw canister module.
     pub wasm_binary: CanisterModule,
@@ -274,7 +274,7 @@ pub struct ExecutionStateSnapshot {
 
 /// Contains all information related to a canister snapshot.
 #[derive(Clone, Debug)]
-#[cfg_attr(feature = "debug_assertions", derive(PartialEq, Eq))]
+#[cfg_attr(debug_assertions, derive(PartialEq, Eq))]
 pub struct CanisterSnapshot {
     /// Identifies the canister to which this snapshot belongs.
     canister_id: CanisterId,

--- a/rs/replicated_state/src/canister_state.rs
+++ b/rs/replicated_state/src/canister_state.rs
@@ -110,7 +110,7 @@ impl SchedulerState {
 
 /// The full state of a single canister.
 #[derive(Clone, Debug)]
-#[cfg_attr(feature = "debug_assertions", derive(PartialEq))]
+#[cfg_attr(debug_assertions, derive(PartialEq))]
 pub struct CanisterState {
     /// See `SystemState` for documentation.
     pub system_state: SystemState,

--- a/rs/replicated_state/src/canister_state.rs
+++ b/rs/replicated_state/src/canister_state.rs
@@ -109,7 +109,8 @@ impl SchedulerState {
 }
 
 /// The full state of a single canister.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "debug_assertions", derive(PartialEq))]
 pub struct CanisterState {
     /// See `SystemState` for documentation.
     pub system_state: SystemState,

--- a/rs/replicated_state/src/canister_state/execution_state.rs
+++ b/rs/replicated_state/src/canister_state/execution_state.rs
@@ -304,6 +304,7 @@ impl Memory {
     }
 }
 
+#[cfg(debug_assertions)]
 impl PartialEq for Memory {
     fn eq(&self, other: &Self) -> bool {
         // Skip the sandbox memory since it is not relevant for equality.
@@ -474,6 +475,7 @@ pub struct ExecutionState {
 
 // We have to implement it by hand as embedder_cache can not be compared for
 // equality (and doesn't need to be).
+#[cfg(debug_assertions)]
 impl PartialEq for ExecutionState {
     fn eq(&self, rhs: &Self) -> bool {
         // Destruction is done on purpose, to ensure if the new

--- a/rs/replicated_state/src/canister_state/system_state.rs
+++ b/rs/replicated_state/src/canister_state/system_state.rs
@@ -266,7 +266,7 @@ impl CanisterHistory {
 /// The state here cannot be directly modified by the Wasm module in the
 /// canister but can be indirectly via the SystemApi interface.
 #[derive(Clone, Debug)]
-#[cfg_attr(feature = "debug_assertions", derive(PartialEq, Eq))]
+#[cfg_attr(debug_assertions, derive(PartialEq, Eq))]
 pub struct SystemState {
     pub controllers: BTreeSet<PrincipalId>,
     pub canister_id: CanisterId,

--- a/rs/replicated_state/src/canister_state/system_state.rs
+++ b/rs/replicated_state/src/canister_state/system_state.rs
@@ -265,7 +265,8 @@ impl CanisterHistory {
 /// Contains structs needed for running and maintaining the canister on the IC.
 /// The state here cannot be directly modified by the Wasm module in the
 /// canister but can be indirectly via the SystemApi interface.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "debug_assertions", derive(PartialEq, Eq))]
 pub struct SystemState {
     pub controllers: BTreeSet<PrincipalId>,
     pub canister_id: CanisterId,

--- a/rs/replicated_state/src/canister_state/system_state/wasm_chunk_store.rs
+++ b/rs/replicated_state/src/canister_state/system_state/wasm_chunk_store.rs
@@ -34,7 +34,8 @@ struct ChunkInfo {
 
 /// Uploaded chunks which can be assembled to create a Wasm module.
 /// It is cheap to clone because the data is stored in a [`PageMap`].
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "debug_assertions", derive(PartialEq, Eq))]
 pub struct WasmChunkStore {
     data: PageMap,
     metadata: WasmChunkStoreMetadata,

--- a/rs/replicated_state/src/canister_state/system_state/wasm_chunk_store.rs
+++ b/rs/replicated_state/src/canister_state/system_state/wasm_chunk_store.rs
@@ -35,7 +35,7 @@ struct ChunkInfo {
 /// Uploaded chunks which can be assembled to create a Wasm module.
 /// It is cheap to clone because the data is stored in a [`PageMap`].
 #[derive(Clone, Debug)]
-#[cfg_attr(feature = "debug_assertions", derive(PartialEq, Eq))]
+#[cfg_attr(debug_assertions, derive(PartialEq, Eq))]
 pub struct WasmChunkStore {
     data: PageMap,
     metadata: WasmChunkStoreMetadata,

--- a/rs/replicated_state/src/page_map.rs
+++ b/rs/replicated_state/src/page_map.rs
@@ -1083,6 +1083,7 @@ impl Buffer {
 //
 // So we compare the total number of pages and equality of each page
 // instead.
+#[cfg(debug_assertions)]
 impl PartialEq for PageMap {
     fn eq(&self, rhs: &PageMap) -> bool {
         if self.num_host_pages() != rhs.num_host_pages() {
@@ -1092,6 +1093,7 @@ impl PartialEq for PageMap {
         self.host_pages_iter().eq(rhs.host_pages_iter())
     }
 }
+#[cfg(debug_assertions)]
 impl Eq for PageMap {}
 
 impl std::fmt::Debug for PageMap {

--- a/rs/replicated_state/src/replicated_state.rs
+++ b/rs/replicated_state/src/replicated_state.rs
@@ -364,7 +364,8 @@ impl MemoryTaken {
 //
 // * We don't derive `Serialize` and `Deserialize` because these are handled by
 // our OP layer.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "debug_assertions", derive(PartialEq))]
 pub struct ReplicatedState {
     /// States of all canisters, indexed by canister ids.
     pub canister_states: BTreeMap<CanisterId, CanisterState>,

--- a/rs/replicated_state/src/replicated_state.rs
+++ b/rs/replicated_state/src/replicated_state.rs
@@ -365,7 +365,7 @@ impl MemoryTaken {
 // * We don't derive `Serialize` and `Deserialize` because these are handled by
 // our OP layer.
 #[derive(Clone, Debug)]
-#[cfg_attr(feature = "debug_assertions", derive(PartialEq))]
+#[cfg_attr(debug_assertions, derive(PartialEq))]
 pub struct ReplicatedState {
     /// States of all canisters, indexed by canister ids.
     pub canister_states: BTreeMap<CanisterId, CanisterState>,


### PR DESCRIPTION
`PageMaps` can be hundreds of gigabytes in prod, so a comparison is not viable for production code. However, we do want to compare them in tests. This change only implements `PartialEq` for `PageMap` if the `debug_assertions` are on.