### PR TITLE
chore(IDX): consolidate lock-generate and bazel-pin

### DIFF
--- a/bin/bazel-pin.sh
+++ b/bin/bazel-pin.sh
@@ -2,15 +2,26 @@
 
 set -euo pipefail
 
-if [ -n "${IN_NIX_SHELL:-}" ]; then
-    echo "Please do not run $0 inside of nix-shell." >&2
-    exit 1
-fi
+#########
+# USAGE #
+#########
 
-if [[ ${1:-} == "-h" || ${1:-} == "--help" ]]; then
-    cat <<EOF >&2
-    usage:
+function title() {
+    echo "Repin Bazel Crates"
+}
 
+function usage() {
+    cat <<EOF
+Usage:
+  $0 [--force] [PACKAGE...]
+
+Options:
+  --force       when specified, will repin even if repin is not deemed necessary
+EOF
+}
+
+function help() {
+    cat <<EOF
     All packages:
         $0                    # cargo update --workspace
 
@@ -28,15 +39,51 @@ if [[ ${1:-} == "-h" || ${1:-} == "--help" ]]; then
 
     Details: https://bazelbuild.github.io/rules_rust/crate_universe.html#repinning--updating-dependencies
 EOF
+
+}
+
+FORCE_REPIN=0
+CRATES=()
+
+# ARGUMENT PARSING
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -h | --help)
+            title && echo && usage && echo && help
+            exit 0
+            ;;
+        --force)
+            FORCE_REPIN=1
+            shift
+            ;;
+        --*)
+            echo "ERROR: unknown argument $1" && echo
+            usage && echo
+            echo "Use '$0 --help' for more information."
+            exit 1
+            ;;
+        *)
+            CRATES+=("$1")
+            shift
+            ;;
+    esac
+done
+
+if [ $FORCE_REPIN != "1" ] && bazel query @crate_index//:all >/dev/null; then
+    # If this isn't a forced repin and if rules_rust still evaluates successfully (using
+    # bazel query as a proxy) then we don't need to do anything
+    echo "Nothing to repin. Use '$0 --force' to force repin."
     exit 0
 fi
 
-if [[ $# -eq 0 ]]; then
+if [ "${CRATES:-}" == "" ]; then
     echo "Repinning all crates"
     CARGO_BAZEL_REPIN=1 bazel sync --only=crate_index
     SANITIZERS_ENABLED=1 CARGO_BAZEL_REPIN=1 bazel sync --only=crate_index
 else
-    for crate in "$@"; do
+    echo "Repinning ${#CRATES[@]} crates"
+    for crate in "${CRATES[@]}"; do
         echo "Repinning crate: ${crate}"
         CARGO_BAZEL_REPIN="${crate}" bazel sync --only=crate_index
         SANITIZERS_ENABLED=1 CARGO_BAZEL_REPIN="${crate}" bazel sync --only=crate_index

--- a/bin/bazel-pin.sh
+++ b/bin/bazel-pin.sh
@@ -16,7 +16,7 @@ Usage:
   $0 [--force] [PACKAGE...]
 
 Options:
-  --force       when specified, will repin even if repin is not deemed necessary
+  --force       will repin even if repin is not deemed necessary
 EOF
 }
 

--- a/gitlab-ci/src/ci-scripts/lock-generate.sh
+++ b/gitlab-ci/src/ci-scripts/lock-generate.sh
@@ -4,48 +4,27 @@ set -eufo pipefail
 
 EXIT_STATUS=0
 
-# Check that cargo lock file needs to be regenerated.
-cargo check -p ic-sys
+# Update the cargo lockfile, if necessary
+cargo update --workspace
 
-# Check that bazel lock file needs to be regenerated.
-if ! bazel query @crate_index//:all; then
-    CARGO_BAZEL_REPIN=1 bazel sync --only=crate_index
-    # Verify that it fixed.
-    bazel query @crate_index//:all
-    # Ensure pipeline will fail.
-    EXIT_STATUS=1
-fi
+# Repin the bazel crates, if necessary
+./bin/bazel-pin.sh
 
-# The same for fuzzing build
-if ! SANITIZERS_ENABLED=1 bazel query @crate_index//:all; then
-    SANITIZERS_ENABLED=1 CARGO_BAZEL_REPIN=1 bazel sync --only=crate_index
-    # Verify that it fixed.
-    SANITIZERS_ENABLED=1 bazel query @crate_index//:all
-    # Ensure pipeline will fail.
-    EXIT_STATUS=1
-fi
-
+# Stage files and check if anything changed
 git add Cargo.lock Cargo.Bazel.*.lock
 git status
 if ! git diff --cached --quiet; then
-    # If a pull request then update the Cargo.lock file in the MR automatically.
+    # If this is running from a pull request then update the Cargo.lock file in the PR
+    # automatically.
     if [ "$CI_PIPELINE_SOURCE" = "pull_request" ]; then
         # There are some changes staged
-        if [ -z ${GITHUB_ACTION+x} ]; then
-            # On GitLab we have to point the origin to GitLab
-            # Command might fail because the gitlab remote already exists from a previous run.
-            git remote add origin "https://gitlab-ci-token:${GITLAB_API_TOKEN}@gitlab.com/${CI_PROJECT_PATH}.git" || true
-            git remote set-url origin "https://gitlab-ci-token:${GITLAB_API_TOKEN}@gitlab.com/${CI_PROJECT_PATH}.git" || true
-            git config --global user.email "infra+gitlab-automation@dfinity.org"
-            git config --global user.name "IDX GitLab Automation"
-        else
-            # On GitHub the origin is already set correctly.
-            git config --global user.email "infra+github-automation@dfinity.org"
-            git config --global user.name "IDX GitHub Automation"
-        fi
+        git config --global user.email "infra+github-automation@dfinity.org"
+        git config --global user.name "IDX GitHub Automation"
         git commit -m "Automatically updated Cargo*.lock"
         git push
     fi
+
+    # Because the lockfiles need updating, fail the PR
     EXIT_STATUS=1
 fi
 


### PR DESCRIPTION
This consolidates the `lock-generate` and `bazel-pin` scripts, making the former use the latter instead of duplicating the logic.

The `bazel-pin` script is also updated to have more flexible argument handling, and is updated to support a `--force` argument. Unless `--force` is provided, the `bazel-pin` script will try to infer if a repin is indeed necessary, and if not, will not try to repin.

The `lock-generate` script is update to remove references to GitLab.