### PR TITLE
feat(nns): Flag for SetVisibility Proposals.

### DIFF
--- a/rs/nns/governance/src/governance.rs
+++ b/rs/nns/governance/src/governance.rs
@@ -1,5 +1,5 @@
 use crate::{
-    decoder_config, enable_new_canister_management_topics,
+    are_set_visibility_proposals_enabled, decoder_config, enable_new_canister_management_topics,
     governance::{
         merge_neurons::{
             build_merge_neurons_response, calculate_merge_neurons_effect,
@@ -4811,7 +4811,10 @@ impl Governance {
         manage_neuron: &ManageNeuron,
     ) -> Result<(), GovernanceError> {
         // TODO(NNS1-3228): Delete this.
-        if manage_neuron.is_set_visibility() {
+        if manage_neuron.is_set_visibility() &&
+            // But SetVisibility proposals are disabled
+            !are_set_visibility_proposals_enabled()
+        {
             return Err(GovernanceError::new_with_message(
                 ErrorType::Unavailable,
                 "Setting neuron visibility via proposal is not allowed yet, \

--- a/rs/nns/governance/src/lib.rs
+++ b/rs/nns/governance/src/lib.rs
@@ -185,6 +185,8 @@ thread_local! {
     // the feature has been released, it will go through its "probation" period.
     // If that goes well, then, this can be deleted.
     static IS_PRIVATE_NEURON_ENFORCEMENT_ENABLED: Cell<bool> = const { Cell::new(cfg!(feature = "test")) };
+
+    static ARE_SET_VISIBILITY_PROPOSALS_ENABLED: Cell<bool> = const { Cell::new(cfg!(feature = "test")) };
 }
 
 pub fn is_private_neuron_enforcement_enabled() -> bool {
@@ -199,6 +201,20 @@ pub fn temporarily_enable_private_neuron_enforcement() -> Temporary {
 /// Only integration tests should use this.
 pub fn temporarily_disable_private_neuron_enforcement() -> Temporary {
     Temporary::new(&IS_PRIVATE_NEURON_ENFORCEMENT_ENABLED, false)
+}
+
+pub fn are_set_visibility_proposals_enabled() -> bool {
+    ARE_SET_VISIBILITY_PROPOSALS_ENABLED.with(|ok| ok.get())
+}
+
+/// Only integration tests should use this.
+pub fn temporarily_enable_set_visibility_proposals() -> Temporary {
+    Temporary::new(&ARE_SET_VISIBILITY_PROPOSALS_ENABLED, true)
+}
+
+/// Only integration tests should use this.
+pub fn temporarily_disable_set_visibility_proposals() -> Temporary {
+    Temporary::new(&ARE_SET_VISIBILITY_PROPOSALS_ENABLED, false)
 }
 
 pub fn decoder_config() -> DecoderConfig {


### PR DESCRIPTION
As usual for new features, this is disabled in production.

In the future, [this feature will be enabled](https://dfinity.atlassian.net/browse/NNS1-3252). After a probation period, the [flag will be deleted](https://dfinity.atlassian.net/browse/NNS1-3228).

Unblocks [NNS1-3225](https://dfinity.atlassian.net/browse/NNS1-3225).

[NNS1-3225]: https://dfinity.atlassian.net/browse/NNS1-3225?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ