### PR TITLE
feat(registry): Fix (undeployed) Registry API type name [override-didc-check]

### DIFF
--- a/rs/registry/canister/canister/canister.rs
+++ b/rs/registry/canister/canister/canister.rs
@@ -45,7 +45,7 @@ use registry_canister::{
         do_revise_elected_replica_versions::ReviseElectedGuestosVersionsPayload,
         do_set_firewall_config::SetFirewallConfigPayload,
         do_update_api_boundary_nodes_version::{
-            DeployGuestOsToSomeApiBoundaryNodes, UpdateApiBoundaryNodesVersionPayload,
+            DeployGuestosToSomeApiBoundaryNodes, UpdateApiBoundaryNodesVersionPayload,
         },
         do_update_elected_hostos_versions::{
             ReviseElectedHostosVersionsPayload, UpdateElectedHostosVersionsPayload,
@@ -600,7 +600,7 @@ fn deploy_guestos_to_some_api_boundary_nodes() {
 }
 
 #[candid_method(update, rename = "deploy_guestos_to_some_api_boundary_nodes")]
-fn deploy_guestos_to_some_api_boundary_nodes_(payload: DeployGuestOsToSomeApiBoundaryNodes) {
+fn deploy_guestos_to_some_api_boundary_nodes_(payload: DeployGuestosToSomeApiBoundaryNodes) {
     registry_mut().do_deploy_guestos_to_some_api_boundary_nodes(payload);
     recertify_registry();
 }

--- a/rs/registry/canister/canister/registry.did
+++ b/rs/registry/canister/canister/registry.did
@@ -296,7 +296,7 @@ type UpdateApiBoundaryNodesVersionPayload = record {
   node_ids : vec principal;
 };
 
-type DeployGuestOsToSomeApiBoundaryNodes = record {
+type DeployGuestosToSomeApiBoundaryNodes = record {
   version : text;
   node_ids : vec principal;
 };
@@ -435,7 +435,7 @@ service : {
   deploy_guestos_to_all_unassigned_nodes : (
     DeployGuestosToAllUnassignedNodesPayload
   ) -> ();
-  deploy_guestos_to_some_api_boundary_nodes : (DeployGuestOsToSomeApiBoundaryNodes) -> ();
+  deploy_guestos_to_some_api_boundary_nodes : (DeployGuestosToSomeApiBoundaryNodes) -> ();
   deploy_hostos_to_some_nodes : (DeployHostosToSomeNodes) -> ();
   get_build_metadata : () -> (text) query;
   get_node_operators_and_dcs_of_node_provider : (principal) -> (GetNodeOperatorsAndDcsOfNodeProviderResponse) query;

--- a/rs/registry/canister/src/mutations/do_update_api_boundary_nodes_version.rs
+++ b/rs/registry/canister/src/mutations/do_update_api_boundary_nodes_version.rs
@@ -11,7 +11,7 @@ use crate::{common::LOG_PREFIX, registry::Registry};
 
 use super::common::{check_api_boundary_nodes_exist, check_replica_version_is_blessed};
 
-/// Deprecated; please use `DeployGuestOsToSomeApiBoundaryNodes` instead.
+/// Deprecated; please use `DeployGuestosToSomeApiBoundaryNodes` instead.
 #[derive(CandidType, Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 pub struct UpdateApiBoundaryNodesVersionPayload {
     pub node_ids: Vec<NodeId>,
@@ -19,12 +19,12 @@ pub struct UpdateApiBoundaryNodesVersionPayload {
 }
 
 #[derive(CandidType, Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
-pub struct DeployGuestOsToSomeApiBoundaryNodes {
+pub struct DeployGuestosToSomeApiBoundaryNodes {
     pub node_ids: Vec<NodeId>,
     pub version: String,
 }
 
-impl From<UpdateApiBoundaryNodesVersionPayload> for DeployGuestOsToSomeApiBoundaryNodes {
+impl From<UpdateApiBoundaryNodesVersionPayload> for DeployGuestosToSomeApiBoundaryNodes {
     fn from(src: UpdateApiBoundaryNodesVersionPayload) -> Self {
         let UpdateApiBoundaryNodesVersionPayload { node_ids, version } = src;
 
@@ -38,14 +38,14 @@ impl Registry {
         &mut self,
         payload: UpdateApiBoundaryNodesVersionPayload,
     ) {
-        let payload = DeployGuestOsToSomeApiBoundaryNodes::from(payload);
+        let payload = DeployGuestosToSomeApiBoundaryNodes::from(payload);
         self.do_deploy_guestos_to_some_api_boundary_nodes(payload);
     }
 
     /// Updates the version for a set of ApiBoundaryNodeRecords
     pub fn do_deploy_guestos_to_some_api_boundary_nodes(
         &mut self,
-        payload: DeployGuestOsToSomeApiBoundaryNodes,
+        payload: DeployGuestosToSomeApiBoundaryNodes,
     ) {
         println!(
             "{}do_update_api_boundary_nodes_version: {:?}",
@@ -69,7 +69,7 @@ impl Registry {
 
     fn validate_update_api_boundary_nodes_version_payload(
         &self,
-        payload: &DeployGuestOsToSomeApiBoundaryNodes,
+        payload: &DeployGuestosToSomeApiBoundaryNodes,
     ) {
         check_api_boundary_nodes_exist(self, &payload.node_ids);
         check_replica_version_is_blessed(self, &payload.version);


### PR DESCRIPTION
This PR renames `UpdateNodesHost`**`O`**`sVersionPayload` as `UpdateNodesHostosVersionPayload` to precisely follow the in-code capitalization convention for GuestOS. This is technically a breaking change, but it's safe to merge as the Registry has not been upgraded since the new type name was introduced in the [previous PR](https://github.com/dfinity/ic/pull/864).