### PR TITLE
test(network-simulation): Increase transmission control buffers

### DIFF
--- a/rs/tests/consensus/tecdsa/tecdsa_performance_test.rs
+++ b/rs/tests/consensus/tecdsa/tecdsa_performance_test.rs
@@ -41,7 +41,7 @@
 use anyhow::Result;
 use futures::future::join_all;
 use ic_consensus_system_test_utils::{
-    limit_tc_ssh_command, rw_message::install_nns_with_customizations_and_check_progress,
+    rw_message::install_nns_with_customizations_and_check_progress,
     subnet::enable_chain_key_signing_on_subnet,
 };
 use ic_consensus_threshold_sig_system_test_utils::{
@@ -53,11 +53,12 @@ use ic_registry_subnet_type::SubnetType;
 use ic_system_test_driver::canister_agent::HasCanisterAgentCapability;
 use ic_system_test_driver::canister_requests;
 use ic_system_test_driver::driver::group::SystemTestGroup;
-use ic_system_test_driver::driver::test_env_api::{HasPublicApiUrl, SshSession};
+use ic_system_test_driver::driver::test_env_api::HasPublicApiUrl;
 use ic_system_test_driver::driver::{
     farm::HostFeature,
     ic::{AmountOfMemoryKiB, ImageSizeGiB, InternetComputer, NrOfVCPUs, Subnet, VmResources},
     prometheus_vm::{HasPrometheus, PrometheusVm},
+    simulate_network::{FixedNetworkSimulation, SimulateNetwork},
     test_env::TestEnv,
     test_env_api::{HasTopologySnapshot, IcNodeContainer, NnsCustomizations},
 };
@@ -89,6 +90,9 @@ const MAX_RUNTIME_BLOCKING_THREADS: usize = MAX_RUNTIME_THREADS;
 // Network parameters
 const BANDWIDTH_MBITS: u32 = 80; // artificial cap on bandwidth
 const LATENCY: Duration = Duration::from_millis(120); // artificial added latency
+const NETWORK_SIMULATION: FixedNetworkSimulation = FixedNetworkSimulation::new()
+    .with_latency(LATENCY)
+    .with_bandwidth(BANDWIDTH_MBITS);
 
 // Signature parameters
 const PRE_SIGNATURES_TO_CREATE: u32 = 30;
@@ -221,17 +225,7 @@ pub fn tecdsa_performance_test(
 
     if apply_network_settings {
         info!(log, "Optional Step: Modify all nodes' traffic using tc");
-        app_subnet.nodes().for_each(|node| {
-            info!(log, "Modifying node {}", node.get_ip_addr());
-            let session = node
-                .block_on_ssh_session()
-                .expect("Failed to ssh into node");
-            node.block_on_bash_script_from_session(
-                &session,
-                &limit_tc_ssh_command(BANDWIDTH_MBITS, LATENCY),
-            )
-            .expect("Failed to execute bash script from session");
-        });
+        app_subnet.apply_network_settings(NETWORK_SIMULATION);
     }
 
     // create the runtime that lives until this variable is dropped.

--- a/rs/tests/consensus/utils/src/lib.rs
+++ b/rs/tests/consensus/utils/src/lib.rs
@@ -1,4 +1,4 @@
-use std::{path::PathBuf, time::Duration};
+use std::path::PathBuf;
 
 use ic_system_test_driver::driver::test_env_api::set_var_to_path;
 

--- a/rs/tests/consensus/utils/src/lib.rs
+++ b/rs/tests/consensus/utils/src/lib.rs
@@ -8,35 +8,6 @@ pub mod ssh_access;
 pub mod subnet;
 pub mod upgrade;
 
-/**
- * 1. Delete existing tc rules (if present).
- * 2. Add a root qdisc (queueing discipline) for an htb (hierarchical token bucket).
- * 3. Add a class with bandwidth limit.
- * 4. Add a qdisc to introduce latency.
- * 5. Add a filter to associate IPv6 traffic with the class and specific port.
- * 6. Read the active tc rules.
- */
-pub fn limit_tc_ssh_command(bandwith_mbit_per_sec: u32, latency: Duration) -> String {
-    const DEVICE_NAME: &str = "enp1s0"; // network interface name
-
-    let cfg = ic_system_test_driver::util::get_config();
-    let p2p_listen_port = cfg.transport.unwrap().listening_port;
-    format!(
-        r#"set -euo pipefail
-sudo tc qdisc del dev {device} root 2> /dev/null || true
-sudo tc qdisc add dev {device} root handle 1: htb default 10
-sudo tc class add dev {device} parent 1: classid 1:10 htb rate {bandwidth_mbit}mbit ceil {bandwidth_mbit}mbit
-sudo tc qdisc add dev {device} parent 1:10 handle 10: netem delay {latency_ms}ms
-sudo tc filter add dev {device} parent 1: protocol ipv6 prio 1 u32 match ip6 dport {p2p_listen_port} 0xFFFF flowid 1:10
-sudo tc qdisc show dev {device}
-"#,
-        device = DEVICE_NAME,
-        bandwidth_mbit = bandwith_mbit_per_sec,
-        latency_ms = latency.as_millis(),
-        p2p_listen_port = p2p_listen_port
-    )
-}
-
 pub fn set_sandbox_env_vars(dir: PathBuf) {
     set_var_to_path("SANDBOX_BINARY", dir.join("canister_sandbox"));
     set_var_to_path("LAUNCHER_BINARY", dir.join("sandbox_launcher"));

--- a/rs/tests/driver/src/driver/simulate_network.rs
+++ b/rs/tests/driver/src/driver/simulate_network.rs
@@ -1,67 +1,140 @@
 //! This module contains functionality to simulate a subnet's
 /// network, RTT and Packet Loss, during system tests.
 use super::{
-    super::driver::test_env_api::SshSession,
+    super::{driver::test_env_api::SshSession, util::get_config},
     test_env_api::{IcNodeContainer, SubnetSnapshot},
 };
 use std::time::Duration;
 
-pub fn simulate_network(subnet: SubnetSnapshot, topology: &NetworkSimulation) {
-    let nodes: Vec<_> = subnet.nodes().collect();
+pub trait SimulateNetwork<NetworkSettings> {
+    fn apply_network_settings(&self, network_settings: NetworkSettings);
+}
 
-    match topology {
-        NetworkSimulation::Subnet(subnet) => {
-            assert_eq!(
-                nodes.len(),
-                subnet.subnet_size(),
-                "Subnet size must match the size of the simulated topology."
-            );
+impl SimulateNetwork<ProductionSubnetTopology> for SubnetSnapshot {
+    fn apply_network_settings(&self, network_settings: ProductionSubnetTopology) {
+        let nodes: Vec<_> = self.nodes().collect();
 
-            const ARRAY_REPEAT_VALUE: String = String::new();
-            let mut tc_commands: [String; 13] = [ARRAY_REPEAT_VALUE; 13];
+        assert_eq!(
+            nodes.len(),
+            network_settings.subnet_size(),
+            "Subnet size must match the size of the simulated topology."
+        );
 
-            let packet_loss = subnet.packet_loss();
-            let rtt = subnet.rtt();
+        const ARRAY_REPEAT_VALUE: String = String::new();
+        let mut tc_commands: [String; 13] = [ARRAY_REPEAT_VALUE; 13];
 
-            for source_node in 0..13 {
-                let mut tc_command =
-                    String::from("sudo tc qdisc del dev enp1s0 root 2> /dev/null || true \n");
-                tc_command.push_str("sudo tc qdisc add dev enp1s0 root handle 1: prio \n");
+        let packet_loss = network_settings.packet_loss();
+        let rtt = network_settings.rtt();
 
-                let source_ip = nodes[source_node].get_ip_addr();
-                for destination_node in 0..13 {
-                    if source_node == destination_node {
-                        continue;
-                    }
-                    let destination_ip = nodes[destination_node].get_ip_addr();
+        for source_node in 0..13 {
+            let mut tc_command =
+                String::from("sudo tc qdisc del dev enp1s0 root 2> /dev/null || true \n");
+            tc_command.push_str("sudo tc qdisc add dev enp1s0 root handle 1: prio \n");
 
-                    tc_command.push_str(&format!(
+            let source_ip = nodes[source_node].get_ip_addr();
+            for destination_node in 0..13 {
+                if source_node == destination_node {
+                    continue;
+                }
+                let destination_ip = nodes[destination_node].get_ip_addr();
+
+                tc_command.push_str(&format!(
                         "sudo tc qdisc add dev enp1s0 parent 1:{destination_node} handle {destination_node}0: netem limit 10000000 loss {:.3}% delay {}ms \n",
                         packet_loss[(12) * source_node + destination_node].2 * 100.0,
                         (rtt[(12) * source_node + destination_node].2 * 1000.0 / 2.0) as u64
                     ));
-                    tc_command.push_str(&format!("sudo tc filter add dev enp1s0 protocol ip parent 1:0 prio {destination_node} u32 match ip6 src {source_ip} match ip6 dst {destination_ip} flowid 1:{destination_node} \n"));
-                }
-                tc_commands[source_node] = tc_command;
+                tc_command.push_str(&format!("sudo tc filter add dev enp1s0 protocol ip parent 1:0 prio {destination_node} u32 match ip6 src {source_ip} match ip6 dst {destination_ip} flowid 1:{destination_node} \n"));
             }
-
-            nodes.iter().enumerate().for_each(|(idx, node)| {
-                let session = node
-                    .block_on_ssh_session()
-                    .expect("Failed to ssh into node");
-                node.block_on_bash_script_from_session(&session, &tc_commands[idx])
-                    .expect("Failed to execute bash script from session");
-            });
+            tc_commands[source_node] = tc_command;
         }
-        NetworkSimulation::FixedRtt(rtt) => {
-            let latency = rtt.div_f64(2.0);
-            nodes.iter().for_each(|node| {
-                let session = node
-                    .block_on_ssh_session()
-                    .expect("Failed to ssh into node");
-                node.block_on_bash_script_from_session(&session, &limit_tc_ssh_command(latency))
-                    .expect("Failed to execute bash script from session");
-            });
+
+        nodes.iter().enumerate().for_each(|(idx, node)| {
+            let session = node
+                .block_on_ssh_session()
+                .expect("Failed to ssh into node");
+            node.block_on_bash_script_from_session(&session, &tc_commands[idx])
+                .expect("Failed to execute bash script from session");
+        });
+    }
+}
+
+impl SimulateNetwork<FixedNetworkSimulation> for SubnetSnapshot {
+    fn apply_network_settings(&self, network_settings: FixedNetworkSimulation) {
+        let nodes: Vec<_> = self.nodes().collect();
+
+        const DEVICE_NAME: &str = "enp1s0"; // network interface name
+
+        let cfg = get_config();
+        let p2p_listen_port = cfg.transport.unwrap().listening_port;
+
+        let bandwidth_mbit_per_sec = network_settings
+            .bandwidth_mbit_per_sec
+            .unwrap_or(100_000_000);
+        let latency_ms = network_settings.latency.map(|d| d.as_millis()).unwrap_or(0);
+
+        let packet_loss = network_settings.packet_loss.unwrap_or(0.0);
+        assert!(
+            (0.0..=1.0).contains(&packet_loss),
+            "Packet loss must be between 0.0 and 1.0"
+        );
+
+        let packet_loss_percentage = format!("{:.3}", packet_loss);
+        let command = format!(
+            r#"set -euo pipefail
+sudo tc qdisc del dev {DEVICE_NAME} root 2> /dev/null || true
+sudo tc qdisc add dev {DEVICE_NAME} root handle 1: htb default 10
+sudo tc class add dev {DEVICE_NAME} parent 1: classid 1:10 htb rate {bandwidth_mbit_per_sec}mbit ceil {bandwidth_mbit_per_sec}mbit
+sudo tc qdisc add dev {DEVICE_NAME} parent 1:10 handle 10: netem delay {latency_ms}ms loss {packet_loss_percentage}% limit 10000000
+sudo tc filter add dev {DEVICE_NAME} parent 1: protocol ipv6 prio 1 u32 match ip6 dport {p2p_listen_port} 0xFFFF flowid 1:10
+sudo tc qdisc show dev {DEVICE_NAME}
+"#,
+        );
+
+        nodes.iter().for_each(|node| {
+            let session = node
+                .block_on_ssh_session()
+                .expect("Failed to ssh into node");
+            node.block_on_bash_script_from_session(&session, &command)
+                .expect("Failed to execute bash script from session");
+        });
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct FixedNetworkSimulation {
+    packet_loss: Option<f64>,
+    latency: Option<Duration>,
+    bandwidth_mbit_per_sec: Option<u32>,
+}
+
+impl FixedNetworkSimulation {
+    pub const fn new() -> Self {
+        Self {
+            packet_loss: None,
+            latency: None,
+            bandwidth_mbit_per_sec: None,
+        }
+    }
+
+    /// Sets the packet loss in each direction in decimal form (0.0 to 1.0).
+    pub const fn with_packet_loss(self, packet_loss: f64) -> Self {
+        Self {
+            packet_loss: Some(packet_loss),
+            ..self
+        }
+    }
+
+    pub const fn with_latency(self, latency: Duration) -> Self {
+        Self {
+            latency: Some(latency),
+            ..self
+        }
+    }
+
+    pub const fn with_bandwidth(self, bandwidth_mbit_per_sec: u32) -> Self {
+        Self {
+            bandwidth_mbit_per_sec: Some(bandwidth_mbit_per_sec),
+            ..self
         }
     }
 }
@@ -70,13 +143,6 @@ pub fn simulate_network(subnet: SubnetSnapshot, topology: &NetworkSimulation) {
 pub enum ProductionSubnetTopology {
     LHG73,
     IO67,
-}
-
-#[derive(Clone, Debug)]
-pub enum NetworkSimulation {
-    Subnet(ProductionSubnetTopology),
-    /// Sets the RTT to a fixed value between all nodes.
-    FixedRtt(Duration),
 }
 
 impl ProductionSubnetTopology {
@@ -100,23 +166,6 @@ impl ProductionSubnetTopology {
             ProductionSubnetTopology::IO67 => 13,
         }
     }
-}
-
-/**
- * 1. Delete existing tc rules (if present).
- * 2. Add a qdisc to introduce latency and increase queue size to 1_000_000.
- * 3. Read the active tc rules.
- */
-fn limit_tc_ssh_command(latency: Duration) -> String {
-    format!(
-        r#"set -euo pipefail
-        sudo tc qdisc del dev {device} root 2> /dev/null || true
-        sudo tc qdisc add dev {device} root netem limit 10000000 delay {latency_ms}ms
-        sudo tc qdisc show dev {device}
-"#,
-        device = "enp1s0",
-        latency_ms = latency.as_millis(),
-    )
 }
 
 const LHG_73_RTT: [(u64, u64, f64); 156] = [

--- a/rs/tests/driver/src/driver/simulate_network.rs
+++ b/rs/tests/driver/src/driver/simulate_network.rs
@@ -100,7 +100,7 @@ sudo tc qdisc show dev {DEVICE_NAME}
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Default, Clone, Debug)]
 pub struct FixedNetworkSimulation {
     packet_loss: Option<f64>,
     latency: Option<Duration>,

--- a/rs/tests/networking/p2p_performance.rs
+++ b/rs/tests/networking/p2p_performance.rs
@@ -2,10 +2,7 @@ use anyhow::Result;
 use std::time::Duration;
 
 use ic_system_test_driver::{
-    driver::{
-        group::SystemTestGroup,
-        simulate_network::{NetworkSimulation, ProductionSubnetTopology},
-    },
+    driver::{group::SystemTestGroup, simulate_network::ProductionSubnetTopology},
     systest,
 };
 use ic_tests::networking::p2p_performance_workload::{config, test};
@@ -21,8 +18,7 @@ const DOWNLOAD_PROMETHEUS_DATA: bool = true;
 const TASK_TIMEOUT_DELTA: Duration = Duration::from_secs(3600);
 const OVERALL_TIMEOUT_DELTA: Duration = Duration::from_secs(3600);
 // Network topology
-const NETWORK_SIMULATION: Option<NetworkSimulation> =
-    Some(NetworkSimulation::Subnet(ProductionSubnetTopology::IO67));
+const NETWORK_SIMULATION: Option<ProductionSubnetTopology> = Some(ProductionSubnetTopology::IO67);
 
 fn main() -> Result<()> {
     let per_task_timeout: Duration = WORKLOAD_RUNTIME + TASK_TIMEOUT_DELTA;

--- a/rs/tests/src/networking/p2p_performance_workload.rs
+++ b/rs/tests/src/networking/p2p_performance_workload.rs
@@ -4,7 +4,7 @@ use ic_system_test_driver::{
         farm::HostFeature,
         ic::{AmountOfMemoryKiB, ImageSizeGiB, InternetComputer, NrOfVCPUs, Subnet, VmResources},
         prometheus_vm::{HasPrometheus, PrometheusVm},
-        simulate_network::{simulate_network, NetworkSimulation},
+        simulate_network::{ProductionSubnetTopology, SimulateNetwork},
         test_env::TestEnv,
         test_env_api::{
             get_dependency_path, HasPublicApiUrl, HasTopologySnapshot, IcNodeContainer,
@@ -42,7 +42,7 @@ pub fn config(
     env: TestEnv,
     nodes_nns_subnet: usize,
     nodes_app_subnet: usize,
-    network_simulation: Option<NetworkSimulation>,
+    network_simulation: Option<ProductionSubnetTopology>,
     boot_image_minimal_size_gibibytes: Option<ImageSizeGiB>,
 ) {
     let logger = env.logger();
@@ -120,7 +120,7 @@ pub fn config(
         env.topology_snapshot()
             .subnets()
             .filter(|s| s.subnet_type() == SubnetType::Application)
-            .for_each(|s| simulate_network(s, &network_simulation));
+            .for_each(|s| s.apply_network_settings(network_simulation.clone()));
     }
 }
 


### PR DESCRIPTION
This MR refactors the `simulate_network` module to support more functionality, and refactors all system tests in the `consensus` directory to use this module.

The previous implementation of setting simulated latencies in the consensus system tests were faulty due to the transmission control buffers overflowing, leading to packets being dropped. This is now fixed.

As a consequence, the [SUCCESS_THRESHOLD](https://github.com/dfinity/ic/blob/d253a7a508d37d8922ea7968e98f52e8c139edf8/rs/tests/consensus/consensus_performance.rs#L89) in `consensus_performance.rs` can be removed as all requests now succeed.