### PR TITLE
feat(sns): Reject new participants if the maximum number of required SNS neurons has been reached

### DIFF
--- a/rs/nervous_system/common/src/lib.rs
+++ b/rs/nervous_system/common/src/lib.rs
@@ -76,6 +76,10 @@ pub const SNS_CREATION_FEE: u64 = 180 * ONE_TRILLION;
 // The number of nanoseconds per second.
 pub const NANO_SECONDS_PER_SECOND: u64 = 1_000_000_000;
 
+/// Maximum allowed number of SNS neurons for direct swap participants that an SNS may create.
+/// This constant must not exceed `NervousSystemParameters::MAX_NUMBER_OF_NEURONS_CEILING`.
+pub const MAX_NEURONS_FOR_DIRECT_PARTICIPANTS: u64 = 100_000;
+
 // The size of a WASM page in bytes, as defined by the WASM specification
 #[cfg(target_arch = "wasm32")]
 const WASM_PAGE_SIZE_BYTES: usize = 65536;

--- a/rs/nervous_system/integration_tests/tests/constraints_dependencies.rs
+++ b/rs/nervous_system/integration_tests/tests/constraints_dependencies.rs
@@ -1,8 +1,9 @@
+use ic_nervous_system_common::MAX_NEURONS_FOR_DIRECT_PARTICIPANTS;
 use ic_nns_governance::governance::MAX_NEURONS_FUND_PARTICIPANTS;
 use ic_sns_governance::pb::v1::NervousSystemParameters;
 use ic_sns_init::{
     distributions::{MAX_AIRDROP_DISTRIBUTION_COUNT, MAX_DEVELOPER_DISTRIBUTION_COUNT},
-    MAX_NEURONS_FOR_DIRECT_PARTICIPANTS, MAX_SNS_NEURONS_PER_BASKET,
+    MAX_SNS_NEURONS_PER_BASKET,
 };
 
 // Test that the total number of SNS neurons created by an SNS swap is within the ceiling expected

--- a/rs/sns/init/src/lib.rs
+++ b/rs/sns/init/src/lib.rs
@@ -8,7 +8,9 @@ use ic_icrc1_index_ng::{IndexArg, InitArg};
 use ic_icrc1_ledger::{InitArgsBuilder as LedgerInitArgsBuilder, LedgerArgument};
 use ic_ledger_canister_core::archive::ArchiveOptions;
 use ic_ledger_core::Tokens;
-use ic_nervous_system_common::{ledger_validation, DEFAULT_TRANSFER_FEE, E8};
+use ic_nervous_system_common::{
+    ledger_validation, DEFAULT_TRANSFER_FEE, E8, MAX_NEURONS_FOR_DIRECT_PARTICIPANTS,
+};
 use ic_nervous_system_proto::pb::v1::{Canister, Countries};
 use ic_nns_constants::{
     CYCLES_MINTING_CANISTER_ID, EXCHANGE_RATE_CANISTER_ID, GENESIS_TOKEN_CANISTER_ID,
@@ -66,10 +68,6 @@ pub const MAX_FALLBACK_CONTROLLER_PRINCIPAL_IDS_COUNT: usize = 15;
 /// decentralization swap.
 /// Aka, the ceiling for the value `max_direct_participation_icp_e8s`.
 pub const MAX_DIRECT_ICP_CONTRIBUTION_TO_SWAP: u64 = 1_000_000_000 * E8;
-
-/// Maximum allowed number of SNS neurons for direct swap participants that an SNS may create.
-/// This constant must not exceed `NervousSystemParameters::MAX_NUMBER_OF_NEURONS_CEILING`.
-pub const MAX_NEURONS_FOR_DIRECT_PARTICIPANTS: u64 = 100_000;
 
 /// Minimum allowed number of SNS neurons per neuron basket.
 pub const MIN_SNS_NEURONS_PER_BASKET: u64 = 2;

--- a/rs/sns/swap/src/swap.rs
+++ b/rs/sns/swap/src/swap.rs
@@ -33,7 +33,9 @@ use ic_base_types::PrincipalId;
 use ic_canister_log::log;
 use ic_ledger_core::Tokens;
 use ic_nervous_system_clients::ledger_client::ICRC1Ledger;
-use ic_nervous_system_common::{i2d, ledger::compute_neuron_staking_subaccount_bytes};
+use ic_nervous_system_common::{
+    i2d, ledger::compute_neuron_staking_subaccount_bytes, MAX_NEURONS_FOR_DIRECT_PARTICIPANTS,
+};
 use ic_nervous_system_proto::pb::v1::Principals;
 use ic_neurons_fund::{MatchedParticipationFunction, PolynomialNeuronsFundParticipation};
 use ic_sns_governance::pb::v1::claim_swap_neurons_request::{
@@ -66,9 +68,6 @@ use std::{
     str::FromStr,
     time::Duration,
 };
-
-/// TODO: This should be shared with rs/sns/init/src/lib.rs
-pub const MAX_NEURONS_FOR_DIRECT_PARTICIPANTS: u64 = 100_000;
 
 /// The maximum count of participants that can be returned by ListDirectParticipants
 pub const MAX_LIST_DIRECT_PARTICIPANTS_LIMIT: u32 = 20_000;

--- a/rs/sns/swap/src/swap.rs
+++ b/rs/sns/swap/src/swap.rs
@@ -67,6 +67,9 @@ use std::{
     time::Duration,
 };
 
+/// TODO: This should be shared with rs/sns/init/src/lib.rs
+pub const MAX_NEURONS_FOR_DIRECT_PARTICIPANTS: u64 = 100_000;
+
 /// The maximum count of participants that can be returned by ListDirectParticipants
 pub const MAX_LIST_DIRECT_PARTICIPANTS_LIMIT: u32 = 20_000;
 
@@ -1159,6 +1162,30 @@ impl Swap {
         let params = &self.params.as_ref().expect("Expected params to be set");
         // Subtraction safe because of the preceding if-statement.
         let max_increment_e8s = self.available_direct_participation_e8s();
+
+        // Check that the maximum number of participants has not been reached yet.
+        {
+            let num_direct_participants = self.buyers.len() as u64;
+            let num_sns_neurons_per_basket = params
+                .neuron_basket_construction_parameters
+                .as_ref()
+                .expect("neuron_basket_construction_parameters must be specified")
+                .count;
+            if (num_direct_participants + 1) * num_sns_neurons_per_basket
+                > MAX_NEURONS_FOR_DIRECT_PARTICIPANTS
+            {
+                return Err(format!(
+                    "The swap has reached the maximum number of direct participants ({}) and does \
+                     not accept new participants; existing participants may still increase their \
+                     ICP participation amount. This constraint ensures that SNS neuron baskets can \
+                     be created for all existing participants (SNS neuron basket size: {}, \
+                     MAX_NEURONS_FOR_DIRECT_PARTICIPANTS: {}).",
+                    num_direct_participants,
+                    num_sns_neurons_per_basket,
+                    MAX_NEURONS_FOR_DIRECT_PARTICIPANTS,
+                ));
+            }
+        }
 
         // Check that the minimum amount has been transferred before
         // actually creating an entry for the buyer.


### PR DESCRIPTION
This PR implements a more liberal enforcement for the max number of SNS neurons. Currently, we enforce that the worst case is passable (by validating the SNS init config at proposal submission time), while this rejects some viable swap scenarios, including those that occurred in production in the past. With this change, we can enforce the limits much later, so the overly strict SNS init validation could be lifted (this will be a follow-up PR).

For more details, see [this forum thread](https://forum.dfinity.org/t/swaps-to-allow-at-most-100k-sns-neurons-for-direct-participants).