### PR TITLE
feat(consensus): [CON-1396] Purge equivocation proofs below and at finalized height

### DIFF
--- a/rs/artifact_pool/src/inmemory_pool.rs
+++ b/rs/artifact_pool/src/inmemory_pool.rs
@@ -76,6 +76,9 @@ impl<T: IntoInner<ConsensusMessage> + HasTimestamp + Clone> InMemoryPoolSection<
                 PurgeableArtifactType::FinalizationShare => {
                     purge!(finalization_share, FinalizationShare);
                 }
+                PurgeableArtifactType::EquivocationProof => {
+                    purge!(equivocation_proof, EquivocationProof);
+                }
             }
         } else {
             purge!(random_beacon, RandomBeacon);

--- a/rs/artifact_pool/src/lmdb_pool.rs
+++ b/rs/artifact_pool/src/lmdb_pool.rs
@@ -1189,6 +1189,7 @@ impl PersistentHeightIndexedPool<ConsensusMessage> {
                     let type_key = match artifact_type {
                         PurgeableArtifactType::NotarizationShare => TypeKey::NotarizationShare,
                         PurgeableArtifactType::FinalizationShare => TypeKey::FinalizationShare,
+                        PurgeableArtifactType::EquivocationProof => TypeKey::EquivocationProof,
                     };
 
                     purged.extend(

--- a/rs/artifact_pool/src/test_utils.rs
+++ b/rs/artifact_pool/src/test_utils.rs
@@ -13,16 +13,17 @@ use ic_interfaces::consensus_pool::{
 };
 use ic_logger::ReplicaLogger;
 use ic_test_utilities_consensus::{fake::*, make_genesis};
-use ic_test_utilities_types::ids::node_test_id;
+use ic_test_utilities_types::ids::{node_test_id, subnet_test_id};
 use ic_types::{
     artifact::ConsensusMessageId,
     consensus::{
         dkg::Summary, Block, BlockPayload, BlockProposal, ConsensusMessage,
-        ConsensusMessageHashable, Finalization, FinalizationContent, FinalizationShare,
-        Notarization, NotarizationContent, NotarizationShare, RandomBeacon, RandomBeaconContent,
-        RandomBeaconShare, RandomTape, RandomTapeContent, RandomTapeShare, Rank,
+        ConsensusMessageHashable, EquivocationProof, Finalization, FinalizationContent,
+        FinalizationShare, Notarization, NotarizationContent, NotarizationShare, RandomBeacon,
+        RandomBeaconContent, RandomBeaconShare, RandomTape, RandomTapeContent, RandomTapeShare,
+        Rank,
     },
-    crypto::{ThresholdSigShare, ThresholdSigShareOf},
+    crypto::{BasicSigOf, CryptoHash, CryptoHashOf, ThresholdSigShare, ThresholdSigShareOf},
     signature::*,
     time::UNIX_EPOCH,
     Height,
@@ -142,6 +143,7 @@ where
         let fzs_ops = finalization_share_ops();
         let rt_ops = random_tape_ops();
         let rts_ops = random_tape_share_ops();
+        let ep_ops = equivocation_proof_ops(/*heights=*/ 1..18);
 
         // Insert a bunch of items and test that the pool returns them
         {
@@ -173,6 +175,9 @@ where
 
             pool.mutate(rts_ops.clone());
             match_ops_to_results(&rts_ops, pool.random_tape_share(), true);
+
+            pool.mutate(ep_ops.clone());
+            match_ops_to_results(&ep_ops, pool.equivocation_proof(), false);
         }
 
         // Test the matching after a reboot.
@@ -187,6 +192,7 @@ where
             match_ops_to_results(&fzs_ops, pool.finalization_share(), true);
             match_ops_to_results(&rt_ops, pool.random_tape(), false);
             match_ops_to_results(&rts_ops, pool.random_tape_share(), true);
+            match_ops_to_results(&ep_ops, pool.equivocation_proof(), false);
         }
 
         // Test purging shares below
@@ -203,7 +209,8 @@ where
             let finalized_height = pool.finalization().max_height().unwrap();
             let range_to_delete = HeightRange::new(Height::from(0), finalized_height.decrement());
 
-            // Only notarization shares and finalization shares should be deleted
+            // Only notarization shares, finalization shares and equivocation
+            // proofs should be deleted
             let expected_count = [
                 count_total(pool.random_beacon_share()),
                 count_total(pool.notarization_share())
@@ -211,6 +218,8 @@ where
                 count_total(pool.finalization_share())
                     - count(pool.finalization_share(), &range_to_delete),
                 count_total(pool.random_tape_share()),
+                count_total(pool.equivocation_proof())
+                    - count(pool.equivocation_proof(), &range_to_delete),
             ];
 
             let mut expected_to_be_purged = Vec::new();
@@ -224,10 +233,16 @@ where
                     .get_by_height_range(range_to_delete.clone())
                     .map(|n| n.get_id()),
             );
+            expected_to_be_purged.extend(
+                pool.equivocation_proof()
+                    .get_by_height_range(range_to_delete.clone())
+                    .map(|n| n.get_id()),
+            );
 
             let mut ops = PoolSectionOps::new();
             ops.purge_type_below(PurgeableArtifactType::NotarizationShare, finalized_height);
             ops.purge_type_below(PurgeableArtifactType::FinalizationShare, finalized_height);
+            ops.purge_type_below(PurgeableArtifactType::EquivocationProof, finalized_height);
             let purged = pool.mutate(ops);
 
             assert_eq!(expected_to_be_purged.len(), purged.len());
@@ -243,6 +258,8 @@ where
             assert_eq!(count_total(pool.finalization_share()), expected_count[2]);
             assert!(count(pool.random_tape_share(), &range_to_delete) > 0);
             assert_eq!(count_total(pool.random_tape_share()), expected_count[3]);
+            assert_eq!(count(pool.equivocation_proof(), &range_to_delete), 0);
+            assert_eq!(count_total(pool.equivocation_proof()), expected_count[4]);
 
             let expected_to_be_purged = pool
                 .block_proposal()
@@ -490,6 +507,31 @@ pub(crate) fn block_proposal_ops(
     for height in heights {
         let block_proposal = fake_block_proposal(Height::from(height));
         let msg = ConsensusMessage::BlockProposal(block_proposal);
+        ops.insert(ValidatedConsensusArtifact {
+            msg,
+            timestamp: UNIX_EPOCH,
+        });
+    }
+    ops
+}
+
+fn equivocation_proof_ops(
+    heights: impl IntoIterator<Item = u64>,
+) -> PoolSectionOps<ValidatedConsensusArtifact> {
+    let block = fake_block_proposal(Height::from(1));
+    let mut ops = PoolSectionOps::new();
+    for height in heights {
+        let equivocation_proof = EquivocationProof {
+            signer: node_test_id(0),
+            version: block.content.get_value().version.clone(),
+            height: Height::new(height),
+            subnet_id: subnet_test_id(0),
+            hash1: CryptoHashOf::new(CryptoHash(vec![height as u8])),
+            signature1: BasicSigOf::new(ic_types::crypto::BasicSig(vec![])),
+            hash2: CryptoHashOf::new(CryptoHash(vec![1, height as u8])),
+            signature2: BasicSigOf::new(ic_types::crypto::BasicSig(vec![])),
+        };
+        let msg = ConsensusMessage::EquivocationProof(equivocation_proof);
         ops.insert(ValidatedConsensusArtifact {
             msg,
             timestamp: UNIX_EPOCH,

--- a/rs/consensus/src/consensus/purger.rs
+++ b/rs/consensus/src/consensus/purger.rs
@@ -536,6 +536,10 @@ mod tests {
                     ChangeAction::PurgeValidatedOfTypeBelow(
                         PurgeableArtifactType::FinalizationShare,
                         purge_height.increment()
+                    ),
+                    ChangeAction::PurgeValidatedOfTypeBelow(
+                        PurgeableArtifactType::EquivocationProof,
+                        purge_height.increment()
                     )
                 ]
             );
@@ -572,6 +576,10 @@ mod tests {
                     ),
                     ChangeAction::PurgeValidatedOfTypeBelow(
                         PurgeableArtifactType::FinalizationShare,
+                        pool_reader.get_finalized_height().increment()
+                    ),
+                    ChangeAction::PurgeValidatedOfTypeBelow(
+                        PurgeableArtifactType::EquivocationProof,
                         pool_reader.get_finalized_height().increment()
                     ),
                     ChangeAction::PurgeValidatedBelow(get_purge_height(&pool_reader).unwrap()),

--- a/rs/consensus/src/consensus/purger.rs
+++ b/rs/consensus/src/consensus/purger.rs
@@ -650,6 +650,13 @@ mod tests {
                 pool.advance_round_normal_operation();
             }
 
+            // Add an additional equivocation proof above the finalized height
+            pool.insert_validated(pool.make_next_beacon());
+            let block = pool.make_next_block();
+            pool.insert_validated(block.clone());
+            pool.notarize(&block);
+            pool.insert_validated(pool.make_equivocation_proof(Rank(0), Height::new(11)));
+
             // We expect to purge equivocation proofs below AND at the finalized height.
             let pool_reader = PoolReader::new(&pool);
             let changeset = purger.on_state_change(&pool_reader);

--- a/rs/interfaces/src/consensus_pool.rs
+++ b/rs/interfaces/src/consensus_pool.rs
@@ -70,6 +70,7 @@ pub enum ChangeAction {
 pub enum PurgeableArtifactType {
     NotarizationShare,
     FinalizationShare,
+    EquivocationProof,
 }
 
 impl From<ChangeAction> for ChangeSet {


### PR DESCRIPTION
Equivocation proofs are not needed at `h <= finalized_height`. Purging them more aggressively gives us a better upper bound for the artifact counts.