### PR TITLE
fix: fix crypto cargo build

### DIFF
--- a/rs/crypto/Cargo.toml
+++ b/rs/crypto/Cargo.toml
@@ -39,7 +39,7 @@ ic-registry-client-helpers = { path = "../registry/helpers" }
 ic-registry-keys = { path = "../registry/keys" }
 ic-types = { path = "../types/types" }
 parking_lot = "0.12.1"
-rustls = { workspace = true }
+rustls = { workspace = true, features = ["std"] }
 serde = { workspace = true }
 slog = { workspace = true }
 strum = { workspace = true }


### PR DESCRIPTION
Fix cargo build failures for the crypto crate.

For example, the rustls documentation clearly says "builder_with_provider" is "available on feature std only".

https://docs.rs/rustls/0.23.11/rustls/client/struct.ClientConfig.html#method.builder_with_provider

So I'm not sure why our bazel build didn't see such failures because it seems to be using 0.23.11 without "std" feature either. 