### PR TITLE
feat(nns): Change InstallCode proposal to always return wasm_module_hash and arg_hash

### DIFF
--- a/rs/nns/governance/api/src/ic_nns_governance.pb.v1.rs
+++ b/rs/nns/governance/api/src/ic_nns_governance.pb.v1.rs
@@ -1186,6 +1186,107 @@ pub mod manage_neuron_response {
         StakeMaturity(StakeMaturityResponse),
     }
 }
+
+#[derive(candid::CandidType, candid::Deserialize, serde::Serialize, comparable::Comparable)]
+#[compare_default]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ProposalInput {
+    #[prost(string, optional, tag = "20")]
+    pub title: ::core::option::Option<::prost::alloc::string::String>,
+    #[prost(string, tag = "1")]
+    pub summary: ::prost::alloc::string::String,
+    #[prost(string, tag = "2")]
+    pub url: ::prost::alloc::string::String,
+    #[prost(
+        oneof = "ProposalActionInput",
+        tags = "10, 12, 13, 14, 15, 16, 21, 24, 25, 26, 27"
+    )]
+    pub action: ::core::option::Option<ProposalActionInput>,
+}
+
+#[derive(candid::CandidType, candid::Deserialize, serde::Serialize, comparable::Comparable)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Oneof)]
+pub enum ProposalActionInput {
+    #[prost(message, tag = "10")]
+    ManageNeuron(::prost::alloc::boxed::Box<ManageNeuronInput>),
+    #[prost(message, tag = "12")]
+    ManageNetworkEconomics(NetworkEconomics),
+    #[prost(message, tag = "13")]
+    Motion(Motion),
+    #[prost(message, tag = "14")]
+    ExecuteNnsFunction(ExecuteNnsFunction),
+    #[prost(message, tag = "15")]
+    ApproveGenesisKyc(ApproveGenesisKyc),
+    #[prost(message, tag = "16")]
+    AddOrRemoveNodeProvider(AddOrRemoveNodeProvider),
+    #[prost(message, tag = "17")]
+    RewardNodeProvider(RewardNodeProvider),
+    #[prost(message, tag = "18")]
+    SetDefaultFollowees(SetDefaultFollowees),
+    #[prost(message, tag = "19")]
+    RewardNodeProviders(RewardNodeProviders),
+    #[prost(message, tag = "21")]
+    RegisterKnownNeuron(KnownNeuron),
+    #[prost(message, tag = "22")]
+    SetSnsTokenSwapOpenTimeWindow(SetSnsTokenSwapOpenTimeWindow),
+    #[prost(message, tag = "23")]
+    OpenSnsTokenSwap(OpenSnsTokenSwap),
+    #[prost(message, tag = "24")]
+    CreateServiceNervousSystem(CreateServiceNervousSystem),
+    #[prost(message, tag = "25")]
+    InstallCode(InstallCodeInput),
+    #[prost(message, tag = "26")]
+    StopOrStartCanister(StopOrStartCanister),
+    #[prost(message, tag = "27")]
+    UpdateCanisterSettings(UpdateCanisterSettings),
+}
+
+#[derive(candid::CandidType, candid::Deserialize, serde::Serialize, comparable::Comparable)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ManageNeuronInput {
+    #[prost(message, optional, tag = "1")]
+    pub id: ::core::option::Option<::ic_nns_common::pb::v1::NeuronId>,
+    #[prost(oneof = "manage_neuron::NeuronIdOrSubaccount", tags = "11, 12")]
+    pub neuron_id_or_subaccount: ::core::option::Option<manage_neuron::NeuronIdOrSubaccount>,
+    #[prost(
+        oneof = "ManageNeuronCommandInput",
+        tags = "2, 3, 4, 5, 6, 7, 8, 9, 10, 13, 14, 15"
+    )]
+    pub command: ::core::option::Option<ManageNeuronCommandInput>,
+}
+
+#[derive(candid::CandidType, candid::Deserialize, serde::Serialize, comparable::Comparable)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Oneof)]
+pub enum ManageNeuronCommandInput {
+    #[prost(message, tag = "2")]
+    Configure(manage_neuron::Configure),
+    #[prost(message, tag = "3")]
+    Disburse(manage_neuron::Disburse),
+    #[prost(message, tag = "4")]
+    Spawn(manage_neuron::Spawn),
+    #[prost(message, tag = "5")]
+    Follow(manage_neuron::Follow),
+    #[prost(message, tag = "6")]
+    MakeProposal(::prost::alloc::boxed::Box<ProposalInput>),
+    #[prost(message, tag = "7")]
+    RegisterVote(manage_neuron::RegisterVote),
+    #[prost(message, tag = "8")]
+    Split(manage_neuron::Split),
+    #[prost(message, tag = "9")]
+    DisburseToNeuron(manage_neuron::DisburseToNeuron),
+    #[prost(message, tag = "10")]
+    ClaimOrRefresh(manage_neuron::ClaimOrRefresh),
+    #[prost(message, tag = "13")]
+    MergeMaturity(manage_neuron::MergeMaturity),
+    #[prost(message, tag = "14")]
+    Merge(manage_neuron::Merge),
+    #[prost(message, tag = "15")]
+    StakeMaturity(manage_neuron::StakeMaturity),
+}
 #[derive(candid::CandidType, candid::Deserialize, serde::Serialize, comparable::Comparable)]
 #[compare_default]
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -2320,17 +2421,18 @@ pub struct InstallCode {
     /// The install mode. Either install, reinstall, or upgrade. Required.
     #[prost(enumeration = "install_code::CanisterInstallMode", optional, tag = "2")]
     pub install_mode: ::core::option::Option<i32>,
-    /// The wasm module to install. required.
-    #[prost(bytes = "vec", optional, tag = "3")]
-    #[serde(deserialize_with = "ic_utils::deserialize::deserialize_option_blob")]
-    pub wasm_module: ::core::option::Option<::prost::alloc::vec::Vec<u8>>,
-    /// The arg to pass to the canister. Optional.
-    #[prost(bytes = "vec", optional, tag = "4")]
-    #[serde(deserialize_with = "ic_utils::deserialize::deserialize_option_blob")]
-    pub arg: ::core::option::Option<::prost::alloc::vec::Vec<u8>>,
+
     /// Whether to skip stopping the canister before installing. Optional. Default is false.
     #[prost(bool, optional, tag = "5")]
     pub skip_stopping_before_installing: ::core::option::Option<bool>,
+
+    #[prost(bytes = "vec", optional, tag = "6")]
+    #[serde(deserialize_with = "ic_utils::deserialize::deserialize_option_blob")]
+    pub wasm_module_hash: ::core::option::Option<::prost::alloc::vec::Vec<u8>>,
+
+    #[prost(bytes = "vec", optional, tag = "7")]
+    #[serde(deserialize_with = "ic_utils::deserialize::deserialize_option_blob")]
+    pub arg_hash: ::core::option::Option<::prost::alloc::vec::Vec<u8>>,
 }
 /// Nested message and enum types in `InstallCode`.
 pub mod install_code {
@@ -2381,6 +2483,25 @@ pub mod install_code {
         }
     }
 }
+
+#[derive(candid::CandidType, candid::Deserialize, serde::Serialize, comparable::Comparable)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct InstallCodeInput {
+    #[prost(message, optional, tag = "1")]
+    pub canister_id: ::core::option::Option<::ic_base_types::PrincipalId>,
+    #[prost(enumeration = "install_code::CanisterInstallMode", optional, tag = "2")]
+    pub install_mode: ::core::option::Option<i32>,
+    #[prost(bytes = "vec", optional, tag = "3")]
+    #[serde(deserialize_with = "ic_utils::deserialize::deserialize_option_blob")]
+    pub wasm_module: ::core::option::Option<::prost::alloc::vec::Vec<u8>>,
+    #[prost(bytes = "vec", optional, tag = "4")]
+    #[serde(deserialize_with = "ic_utils::deserialize::deserialize_option_blob")]
+    pub arg: ::core::option::Option<::prost::alloc::vec::Vec<u8>>,
+    #[prost(bool, optional, tag = "5")]
+    pub skip_stopping_before_installing: ::core::option::Option<bool>,
+}
+
 #[derive(candid::CandidType, candid::Deserialize, serde::Serialize, comparable::Comparable)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/rs/nns/governance/api/src/ic_nns_governance.pb.v1.rs
+++ b/rs/nns/governance/api/src/ic_nns_governance.pb.v1.rs
@@ -1191,7 +1191,7 @@ pub mod manage_neuron_response {
 #[compare_default]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct ProposalInput {
+pub struct MakeProposalRequest {
     #[prost(string, optional, tag = "20")]
     pub title: ::core::option::Option<::prost::alloc::string::String>,
     #[prost(string, tag = "1")]
@@ -1199,18 +1199,18 @@ pub struct ProposalInput {
     #[prost(string, tag = "2")]
     pub url: ::prost::alloc::string::String,
     #[prost(
-        oneof = "ProposalActionInput",
+        oneof = "ProposalActionRequest",
         tags = "10, 12, 13, 14, 15, 16, 21, 24, 25, 26, 27"
     )]
-    pub action: ::core::option::Option<ProposalActionInput>,
+    pub action: ::core::option::Option<ProposalActionRequest>,
 }
 
 #[derive(candid::CandidType, candid::Deserialize, serde::Serialize, comparable::Comparable)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Oneof)]
-pub enum ProposalActionInput {
+pub enum ProposalActionRequest {
     #[prost(message, tag = "10")]
-    ManageNeuron(::prost::alloc::boxed::Box<ManageNeuronInput>),
+    ManageNeuron(::prost::alloc::boxed::Box<ManageNeuronRequest>),
     #[prost(message, tag = "12")]
     ManageNetworkEconomics(NetworkEconomics),
     #[prost(message, tag = "13")]
@@ -1236,7 +1236,7 @@ pub enum ProposalActionInput {
     #[prost(message, tag = "24")]
     CreateServiceNervousSystem(CreateServiceNervousSystem),
     #[prost(message, tag = "25")]
-    InstallCode(InstallCodeInput),
+    InstallCode(InstallCodeRequest),
     #[prost(message, tag = "26")]
     StopOrStartCanister(StopOrStartCanister),
     #[prost(message, tag = "27")]
@@ -1246,22 +1246,22 @@ pub enum ProposalActionInput {
 #[derive(candid::CandidType, candid::Deserialize, serde::Serialize, comparable::Comparable)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct ManageNeuronInput {
+pub struct ManageNeuronRequest {
     #[prost(message, optional, tag = "1")]
     pub id: ::core::option::Option<::ic_nns_common::pb::v1::NeuronId>,
     #[prost(oneof = "manage_neuron::NeuronIdOrSubaccount", tags = "11, 12")]
     pub neuron_id_or_subaccount: ::core::option::Option<manage_neuron::NeuronIdOrSubaccount>,
     #[prost(
-        oneof = "ManageNeuronCommandInput",
+        oneof = "ManageNeuronCommandRequest",
         tags = "2, 3, 4, 5, 6, 7, 8, 9, 10, 13, 14, 15"
     )]
-    pub command: ::core::option::Option<ManageNeuronCommandInput>,
+    pub command: ::core::option::Option<ManageNeuronCommandRequest>,
 }
 
 #[derive(candid::CandidType, candid::Deserialize, serde::Serialize, comparable::Comparable)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Oneof)]
-pub enum ManageNeuronCommandInput {
+pub enum ManageNeuronCommandRequest {
     #[prost(message, tag = "2")]
     Configure(manage_neuron::Configure),
     #[prost(message, tag = "3")]
@@ -1271,7 +1271,7 @@ pub enum ManageNeuronCommandInput {
     #[prost(message, tag = "5")]
     Follow(manage_neuron::Follow),
     #[prost(message, tag = "6")]
-    MakeProposal(::prost::alloc::boxed::Box<ProposalInput>),
+    MakeProposal(::prost::alloc::boxed::Box<MakeProposalRequest>),
     #[prost(message, tag = "7")]
     RegisterVote(manage_neuron::RegisterVote),
     #[prost(message, tag = "8")]
@@ -2487,7 +2487,7 @@ pub mod install_code {
 #[derive(candid::CandidType, candid::Deserialize, serde::Serialize, comparable::Comparable)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct InstallCodeInput {
+pub struct InstallCodeRequest {
     #[prost(message, optional, tag = "1")]
     pub canister_id: ::core::option::Option<::ic_base_types::PrincipalId>,
     #[prost(enumeration = "install_code::CanisterInstallMode", optional, tag = "2")]

--- a/rs/nns/governance/api/src/proposal_helpers.rs
+++ b/rs/nns/governance/api/src/proposal_helpers.rs
@@ -1,6 +1,7 @@
 use crate::pb::v1::{
-    manage_neuron::Command, manage_neuron_response::Command as CommandResponse, proposal,
-    ExecuteNnsFunction, ManageNeuron, ManageNeuronResponse, NnsFunction, Proposal,
+    manage_neuron_response::Command as CommandResponse, ExecuteNnsFunction,
+    ManageNeuronCommandInput, ManageNeuronInput, ManageNeuronResponse, NnsFunction,
+    ProposalActionInput, ProposalInput,
 };
 use candid::{CandidType, Decode, Encode};
 use ic_nns_common::types::{NeuronId, ProposalId};
@@ -12,7 +13,7 @@ pub fn create_external_update_proposal_candid<T: CandidType>(
     url: &str,
     nns_function: NnsFunction,
     payload: T,
-) -> Proposal {
+) -> ProposalInput {
     create_external_update_proposal_binary(
         title,
         summary,
@@ -28,28 +29,30 @@ pub fn create_external_update_proposal_binary(
     url: &str,
     nns_function: NnsFunction,
     payload: Vec<u8>,
-) -> Proposal {
-    Proposal {
+) -> ProposalInput {
+    ProposalInput {
         title: Some(title.to_string()),
         summary: summary.to_string(),
         url: url.to_string(),
-        action: Some(proposal::Action::ExecuteNnsFunction(ExecuteNnsFunction {
-            nns_function: nns_function as i32,
-            payload,
-        })),
+        action: Some(ProposalActionInput::ExecuteNnsFunction(
+            ExecuteNnsFunction {
+                nns_function: nns_function as i32,
+                payload,
+            },
+        )),
     }
 }
 
 /// Wraps the given proposal into a MakeProposal command, and wraps the command
 /// into a payload to call `manage_neuron`.
 pub fn create_make_proposal_payload(
-    proposal: Proposal,
+    proposal: ProposalInput,
     proposer_neuron_id: &NeuronId,
-) -> ManageNeuron {
-    ManageNeuron {
+) -> ManageNeuronInput {
+    ManageNeuronInput {
         id: Some((*proposer_neuron_id).into()),
         neuron_id_or_subaccount: None,
-        command: Some(Command::MakeProposal(Box::new(proposal))),
+        command: Some(ManageNeuronCommandInput::MakeProposal(Box::new(proposal))),
     }
 }
 

--- a/rs/nns/governance/api/src/proposal_helpers.rs
+++ b/rs/nns/governance/api/src/proposal_helpers.rs
@@ -1,7 +1,7 @@
 use crate::pb::v1::{
-    manage_neuron_response::Command as CommandResponse, ExecuteNnsFunction,
-    ManageNeuronCommandInput, ManageNeuronInput, ManageNeuronResponse, NnsFunction,
-    ProposalActionInput, ProposalInput,
+    manage_neuron_response::Command as CommandResponse, ExecuteNnsFunction, MakeProposalRequest,
+    ManageNeuronCommandRequest, ManageNeuronRequest, ManageNeuronResponse, NnsFunction,
+    ProposalActionRequest,
 };
 use candid::{CandidType, Decode, Encode};
 use ic_nns_common::types::{NeuronId, ProposalId};
@@ -13,7 +13,7 @@ pub fn create_external_update_proposal_candid<T: CandidType>(
     url: &str,
     nns_function: NnsFunction,
     payload: T,
-) -> ProposalInput {
+) -> MakeProposalRequest {
     create_external_update_proposal_binary(
         title,
         summary,
@@ -29,12 +29,12 @@ pub fn create_external_update_proposal_binary(
     url: &str,
     nns_function: NnsFunction,
     payload: Vec<u8>,
-) -> ProposalInput {
-    ProposalInput {
+) -> MakeProposalRequest {
+    MakeProposalRequest {
         title: Some(title.to_string()),
         summary: summary.to_string(),
         url: url.to_string(),
-        action: Some(ProposalActionInput::ExecuteNnsFunction(
+        action: Some(ProposalActionRequest::ExecuteNnsFunction(
             ExecuteNnsFunction {
                 nns_function: nns_function as i32,
                 payload,
@@ -46,13 +46,13 @@ pub fn create_external_update_proposal_binary(
 /// Wraps the given proposal into a MakeProposal command, and wraps the command
 /// into a payload to call `manage_neuron`.
 pub fn create_make_proposal_payload(
-    proposal: ProposalInput,
+    proposal: MakeProposalRequest,
     proposer_neuron_id: &NeuronId,
-) -> ManageNeuronInput {
-    ManageNeuronInput {
+) -> ManageNeuronRequest {
+    ManageNeuronRequest {
         id: Some((*proposer_neuron_id).into()),
         neuron_id_or_subaccount: None,
-        command: Some(ManageNeuronCommandInput::MakeProposal(Box::new(proposal))),
+        command: Some(ManageNeuronCommandRequest::MakeProposal(Box::new(proposal))),
     }
 }
 

--- a/rs/nns/governance/canister/canister.rs
+++ b/rs/nns/governance/canister/canister.rs
@@ -46,17 +46,18 @@ use ic_nns_governance_api::{
         governance_error::ErrorType,
         manage_neuron::{
             claim_or_refresh::{By, MemoAndController},
-            ClaimOrRefresh, Command, NeuronIdOrSubaccount, RegisterVote,
+            ClaimOrRefresh, NeuronIdOrSubaccount, RegisterVote,
         },
         manage_neuron_response, ClaimOrRefreshNeuronFromAccount,
         ClaimOrRefreshNeuronFromAccountResponse, GetNeuronsFundAuditInfoRequest,
         GetNeuronsFundAuditInfoResponse, Governance as ApiGovernanceProto, GovernanceError,
         ListKnownNeuronsResponse, ListNeurons, ListNeuronsResponse, ListNodeProvidersResponse,
-        ListProposalInfo, ListProposalInfoResponse, ManageNeuron, ManageNeuronResponse,
-        MonthlyNodeProviderRewards, NetworkEconomics, Neuron, NeuronInfo, NodeProvider, Proposal,
-        ProposalInfo, RestoreAgingSummary, RewardEvent, RewardNodeProvider, RewardNodeProviders,
-        SettleCommunityFundParticipation, SettleNeuronsFundParticipationRequest,
-        SettleNeuronsFundParticipationResponse, UpdateNodeProvider, Vote,
+        ListProposalInfo, ListProposalInfoResponse, ManageNeuronCommandInput, ManageNeuronInput,
+        ManageNeuronResponse, MonthlyNodeProviderRewards, NetworkEconomics, Neuron, NeuronInfo,
+        NodeProvider, Proposal, ProposalInfo, RestoreAgingSummary, RewardEvent, RewardNodeProvider,
+        RewardNodeProviders, SettleCommunityFundParticipation,
+        SettleNeuronsFundParticipationRequest, SettleNeuronsFundParticipationResponse,
+        UpdateNodeProvider, Vote,
     },
     subnet_rental::{SubnetRentalProposalPayload, SubnetRentalRequest},
 };
@@ -406,9 +407,9 @@ fn vote() {
     over_async(
         candid,
         |(neuron_id, proposal_id, vote): (NeuronId, ProposalId, Vote)| async move {
-            manage_neuron_(ManageNeuron {
+            manage_neuron_(ManageNeuronInput {
                 id: Some(NeuronIdProto::from(neuron_id)),
-                command: Some(Command::RegisterVote(RegisterVote {
+                command: Some(ManageNeuronCommandInput::RegisterVote(RegisterVote {
                     proposal: Some(ProposalIdProto::from(proposal_id)),
                     vote: vote as i32,
                 })),
@@ -447,9 +448,9 @@ fn claim_or_refresh_neuron_from_account() {
 async fn claim_or_refresh_neuron_from_account_(
     claim_or_refresh: ClaimOrRefreshNeuronFromAccount,
 ) -> ClaimOrRefreshNeuronFromAccountResponse {
-    let manage_neuron_response = manage_neuron_(ManageNeuron {
+    let manage_neuron_response = manage_neuron_(ManageNeuronInput {
         id: None,
-        command: Some(Command::ClaimOrRefresh(ClaimOrRefresh {
+        command: Some(ManageNeuronCommandInput::ClaimOrRefresh(ClaimOrRefresh {
             by: Some(By::MemoAndController(MemoAndController {
                 memo: claim_or_refresh.memo,
                 controller: claim_or_refresh.controller,
@@ -524,7 +525,7 @@ fn manage_neuron() {
 }
 
 #[candid_method(update, rename = "manage_neuron")]
-async fn manage_neuron_(manage_neuron: ManageNeuron) -> ManageNeuronResponse {
+async fn manage_neuron_(manage_neuron: ManageNeuronInput) -> ManageNeuronResponse {
     let response = governance_mut()
         .manage_neuron(&caller(), &(gov_pb::ManageNeuron::from(manage_neuron)))
         .await;
@@ -556,7 +557,7 @@ fn simulate_manage_neuron() {
 }
 
 #[candid_method(update, rename = "simulate_manage_neuron")]
-fn simulate_manage_neuron_(manage_neuron: ManageNeuron) -> ManageNeuronResponse {
+fn simulate_manage_neuron_(manage_neuron: ManageNeuronInput) -> ManageNeuronResponse {
     let response =
         governance().simulate_manage_neuron(&caller(), gov_pb::ManageNeuron::from(manage_neuron));
     ManageNeuronResponse::from(response)

--- a/rs/nns/governance/canister/canister.rs
+++ b/rs/nns/governance/canister/canister.rs
@@ -52,10 +52,10 @@ use ic_nns_governance_api::{
         ClaimOrRefreshNeuronFromAccountResponse, GetNeuronsFundAuditInfoRequest,
         GetNeuronsFundAuditInfoResponse, Governance as ApiGovernanceProto, GovernanceError,
         ListKnownNeuronsResponse, ListNeurons, ListNeuronsResponse, ListNodeProvidersResponse,
-        ListProposalInfo, ListProposalInfoResponse, ManageNeuronCommandInput, ManageNeuronInput,
-        ManageNeuronResponse, MonthlyNodeProviderRewards, NetworkEconomics, Neuron, NeuronInfo,
-        NodeProvider, Proposal, ProposalInfo, RestoreAgingSummary, RewardEvent, RewardNodeProvider,
-        RewardNodeProviders, SettleCommunityFundParticipation,
+        ListProposalInfo, ListProposalInfoResponse, ManageNeuronCommandRequest,
+        ManageNeuronRequest, ManageNeuronResponse, MonthlyNodeProviderRewards, NetworkEconomics,
+        Neuron, NeuronInfo, NodeProvider, Proposal, ProposalInfo, RestoreAgingSummary, RewardEvent,
+        RewardNodeProvider, RewardNodeProviders, SettleCommunityFundParticipation,
         SettleNeuronsFundParticipationRequest, SettleNeuronsFundParticipationResponse,
         UpdateNodeProvider, Vote,
     },
@@ -407,9 +407,9 @@ fn vote() {
     over_async(
         candid,
         |(neuron_id, proposal_id, vote): (NeuronId, ProposalId, Vote)| async move {
-            manage_neuron_(ManageNeuronInput {
+            manage_neuron_(ManageNeuronRequest {
                 id: Some(NeuronIdProto::from(neuron_id)),
-                command: Some(ManageNeuronCommandInput::RegisterVote(RegisterVote {
+                command: Some(ManageNeuronCommandRequest::RegisterVote(RegisterVote {
                     proposal: Some(ProposalIdProto::from(proposal_id)),
                     vote: vote as i32,
                 })),
@@ -448,9 +448,9 @@ fn claim_or_refresh_neuron_from_account() {
 async fn claim_or_refresh_neuron_from_account_(
     claim_or_refresh: ClaimOrRefreshNeuronFromAccount,
 ) -> ClaimOrRefreshNeuronFromAccountResponse {
-    let manage_neuron_response = manage_neuron_(ManageNeuronInput {
+    let manage_neuron_response = manage_neuron_(ManageNeuronRequest {
         id: None,
-        command: Some(ManageNeuronCommandInput::ClaimOrRefresh(ClaimOrRefresh {
+        command: Some(ManageNeuronCommandRequest::ClaimOrRefresh(ClaimOrRefresh {
             by: Some(By::MemoAndController(MemoAndController {
                 memo: claim_or_refresh.memo,
                 controller: claim_or_refresh.controller,
@@ -525,7 +525,7 @@ fn manage_neuron() {
 }
 
 #[candid_method(update, rename = "manage_neuron")]
-async fn manage_neuron_(manage_neuron: ManageNeuronInput) -> ManageNeuronResponse {
+async fn manage_neuron_(manage_neuron: ManageNeuronRequest) -> ManageNeuronResponse {
     let response = governance_mut()
         .manage_neuron(&caller(), &(gov_pb::ManageNeuron::from(manage_neuron)))
         .await;
@@ -557,7 +557,7 @@ fn simulate_manage_neuron() {
 }
 
 #[candid_method(update, rename = "simulate_manage_neuron")]
-fn simulate_manage_neuron_(manage_neuron: ManageNeuronInput) -> ManageNeuronResponse {
+fn simulate_manage_neuron_(manage_neuron: ManageNeuronRequest) -> ManageNeuronResponse {
     let response =
         governance().simulate_manage_neuron(&caller(), gov_pb::ManageNeuron::from(manage_neuron));
     ManageNeuronResponse::from(response)

--- a/rs/nns/governance/canister/governance.did
+++ b/rs/nns/governance/canister/governance.did
@@ -266,10 +266,10 @@ type InitialTokenDistribution = record {
   swap_distribution : opt SwapDistribution;
 };
 type InstallCode = record {
-  arg : opt blob;
-  wasm_module : opt blob;
   skip_stopping_before_installing : opt bool;
+  wasm_module_hash : opt blob;
   canister_id : opt principal;
+  arg_hash : opt blob;
   install_mode : opt int32;
 };
 type KnownNeuron = record {
@@ -492,6 +492,56 @@ type NeuronsFundParticipation = record {
 };
 type NeuronsFundSnapshot = record {
   neurons_fund_neuron_portions : vec NeuronsFundNeuronPortion;
+};
+type NewInstallCode = record {
+  arg : opt blob;
+  wasm_module : opt blob;
+  skip_stopping_before_installing : opt bool;
+  canister_id : opt principal;
+  install_mode : opt int32;
+};
+type ManageNeuronInput = record {
+  id : opt NeuronId;
+  command : opt ManageNeuronCommandInput;
+  neuron_id_or_subaccount : opt NeuronIdOrSubaccount;
+};
+type ManageNeuronCommandInput = variant {
+  Spawn : Spawn;
+  Split : Split;
+  Follow : Follow;
+  ClaimOrRefresh : ClaimOrRefresh;
+  Configure : Configure;
+  RegisterVote : RegisterVote;
+  Merge : Merge;
+  DisburseToNeuron : DisburseToNeuron;
+  MakeProposal : ProposalInput;
+  StakeMaturity : StakeMaturity;
+  MergeMaturity : MergeMaturity;
+  Disburse : Disburse;
+};
+type ProposalInput = record {
+  url : text;
+  title : opt text;
+  action : opt ProposalActionInput;
+  summary : text;
+};
+type ProposalActionInput = variant {
+  RegisterKnownNeuron : KnownNeuron;
+  ManageNeuron : ManageNeuronInput;
+  UpdateCanisterSettings : UpdateCanisterSettings;
+  InstallCode : NewInstallCode;
+  StopOrStartCanister : StopOrStartCanister;
+  CreateServiceNervousSystem : CreateServiceNervousSystem;
+  ExecuteNnsFunction : ExecuteNnsFunction;
+  RewardNodeProvider : RewardNodeProvider;
+  OpenSnsTokenSwap : OpenSnsTokenSwap;
+  SetSnsTokenSwapOpenTimeWindow : SetSnsTokenSwapOpenTimeWindow;
+  SetDefaultFollowees : SetDefaultFollowees;
+  RewardNodeProviders : RewardNodeProviders;
+  ManageNetworkEconomics : NetworkEconomics;
+  ApproveGenesisKyc : Principals;
+  AddOrRemoveNodeProvider : AddOrRemoveNodeProvider;
+  Motion : Motion;
 };
 type NodeProvider = record {
   id : opt principal;
@@ -751,14 +801,14 @@ service : (Governance) -> {
   list_neurons : (ListNeurons) -> (ListNeuronsResponse) query;
   list_node_providers : () -> (ListNodeProvidersResponse) query;
   list_proposals : (ListProposalInfo) -> (ListProposalInfoResponse) query;
-  manage_neuron : (ManageNeuron) -> (ManageNeuronResponse);
+  manage_neuron : (ManageNeuronInput) -> (ManageNeuronResponse);
   settle_community_fund_participation : (SettleCommunityFundParticipation) -> (
       Result,
     );
   settle_neurons_fund_participation : (
       SettleNeuronsFundParticipationRequest,
     ) -> (SettleNeuronsFundParticipationResponse);
-  simulate_manage_neuron : (ManageNeuron) -> (ManageNeuronResponse);
+  simulate_manage_neuron : (ManageNeuronInput) -> (ManageNeuronResponse);
   transfer_gtc_neuron : (NeuronId, NeuronId) -> (Result);
   update_node_provider : (UpdateNodeProvider) -> (Result);
 }

--- a/rs/nns/governance/canister/governance.did
+++ b/rs/nns/governance/canister/governance.did
@@ -272,6 +272,13 @@ type InstallCode = record {
   arg_hash : opt blob;
   install_mode : opt int32;
 };
+type InstallCodeRequest = record {
+  arg : opt blob;
+  wasm_module : opt blob;
+  skip_stopping_before_installing : opt bool;
+  canister_id : opt principal;
+  install_mode : opt int32;
+};
 type KnownNeuron = record {
   id : opt NeuronId;
   known_neuron_data : opt KnownNeuronData;
@@ -305,6 +312,12 @@ type ListProposalInfo = record {
   include_status : vec int32;
 };
 type ListProposalInfoResponse = record { proposal_info : vec ProposalInfo };
+type MakeProposalRequest = record {
+  url : text;
+  title : opt text;
+  action : opt ProposalActionRequest;
+  summary : text;
+};
 type MakeProposalResponse = record {
   message : opt text;
   proposal_id : opt NeuronId;
@@ -317,6 +330,25 @@ type MakingSnsProposal = record {
 type ManageNeuron = record {
   id : opt NeuronId;
   command : opt Command;
+  neuron_id_or_subaccount : opt NeuronIdOrSubaccount;
+};
+type ManageNeuronCommandRequest = variant {
+  Spawn : Spawn;
+  Split : Split;
+  Follow : Follow;
+  ClaimOrRefresh : ClaimOrRefresh;
+  Configure : Configure;
+  RegisterVote : RegisterVote;
+  Merge : Merge;
+  DisburseToNeuron : DisburseToNeuron;
+  MakeProposal : MakeProposalRequest;
+  StakeMaturity : StakeMaturity;
+  MergeMaturity : MergeMaturity;
+  Disburse : Disburse;
+};
+type ManageNeuronRequest = record {
+  id : opt NeuronId;
+  command : opt ManageNeuronCommandRequest;
   neuron_id_or_subaccount : opt NeuronIdOrSubaccount;
 };
 type ManageNeuronResponse = record { command : opt Command_1 };
@@ -493,56 +525,6 @@ type NeuronsFundParticipation = record {
 type NeuronsFundSnapshot = record {
   neurons_fund_neuron_portions : vec NeuronsFundNeuronPortion;
 };
-type NewInstallCode = record {
-  arg : opt blob;
-  wasm_module : opt blob;
-  skip_stopping_before_installing : opt bool;
-  canister_id : opt principal;
-  install_mode : opt int32;
-};
-type ManageNeuronInput = record {
-  id : opt NeuronId;
-  command : opt ManageNeuronCommandInput;
-  neuron_id_or_subaccount : opt NeuronIdOrSubaccount;
-};
-type ManageNeuronCommandInput = variant {
-  Spawn : Spawn;
-  Split : Split;
-  Follow : Follow;
-  ClaimOrRefresh : ClaimOrRefresh;
-  Configure : Configure;
-  RegisterVote : RegisterVote;
-  Merge : Merge;
-  DisburseToNeuron : DisburseToNeuron;
-  MakeProposal : ProposalInput;
-  StakeMaturity : StakeMaturity;
-  MergeMaturity : MergeMaturity;
-  Disburse : Disburse;
-};
-type ProposalInput = record {
-  url : text;
-  title : opt text;
-  action : opt ProposalActionInput;
-  summary : text;
-};
-type ProposalActionInput = variant {
-  RegisterKnownNeuron : KnownNeuron;
-  ManageNeuron : ManageNeuronInput;
-  UpdateCanisterSettings : UpdateCanisterSettings;
-  InstallCode : NewInstallCode;
-  StopOrStartCanister : StopOrStartCanister;
-  CreateServiceNervousSystem : CreateServiceNervousSystem;
-  ExecuteNnsFunction : ExecuteNnsFunction;
-  RewardNodeProvider : RewardNodeProvider;
-  OpenSnsTokenSwap : OpenSnsTokenSwap;
-  SetSnsTokenSwapOpenTimeWindow : SetSnsTokenSwapOpenTimeWindow;
-  SetDefaultFollowees : SetDefaultFollowees;
-  RewardNodeProviders : RewardNodeProviders;
-  ManageNetworkEconomics : NetworkEconomics;
-  ApproveGenesisKyc : Principals;
-  AddOrRemoveNodeProvider : AddOrRemoveNodeProvider;
-  Motion : Motion;
-};
 type NodeProvider = record {
   id : opt principal;
   reward_account : opt AccountIdentifier;
@@ -587,6 +569,24 @@ type Proposal = record {
   title : opt text;
   action : opt Action;
   summary : text;
+};
+type ProposalActionRequest = variant {
+  RegisterKnownNeuron : KnownNeuron;
+  ManageNeuron : ManageNeuronRequest;
+  UpdateCanisterSettings : UpdateCanisterSettings;
+  InstallCode : InstallCodeRequest;
+  StopOrStartCanister : StopOrStartCanister;
+  CreateServiceNervousSystem : CreateServiceNervousSystem;
+  ExecuteNnsFunction : ExecuteNnsFunction;
+  RewardNodeProvider : RewardNodeProvider;
+  OpenSnsTokenSwap : OpenSnsTokenSwap;
+  SetSnsTokenSwapOpenTimeWindow : SetSnsTokenSwapOpenTimeWindow;
+  SetDefaultFollowees : SetDefaultFollowees;
+  RewardNodeProviders : RewardNodeProviders;
+  ManageNetworkEconomics : NetworkEconomics;
+  ApproveGenesisKyc : Principals;
+  AddOrRemoveNodeProvider : AddOrRemoveNodeProvider;
+  Motion : Motion;
 };
 type ProposalData = record {
   id : opt NeuronId;
@@ -801,14 +801,14 @@ service : (Governance) -> {
   list_neurons : (ListNeurons) -> (ListNeuronsResponse) query;
   list_node_providers : () -> (ListNodeProvidersResponse) query;
   list_proposals : (ListProposalInfo) -> (ListProposalInfoResponse) query;
-  manage_neuron : (ManageNeuronInput) -> (ManageNeuronResponse);
+  manage_neuron : (ManageNeuronRequest) -> (ManageNeuronResponse);
   settle_community_fund_participation : (SettleCommunityFundParticipation) -> (
       Result,
     );
   settle_neurons_fund_participation : (
       SettleNeuronsFundParticipationRequest,
     ) -> (SettleNeuronsFundParticipationResponse);
-  simulate_manage_neuron : (ManageNeuronInput) -> (ManageNeuronResponse);
+  simulate_manage_neuron : (ManageNeuronRequest) -> (ManageNeuronResponse);
   transfer_gtc_neuron : (NeuronId, NeuronId) -> (Result);
   update_node_provider : (UpdateNodeProvider) -> (Result);
 }

--- a/rs/nns/governance/canister/governance_test.did
+++ b/rs/nns/governance/canister/governance_test.did
@@ -272,6 +272,13 @@ type InstallCode = record {
   arg_hash : opt blob;
   install_mode : opt int32;
 };
+type InstallCodeRequest = record {
+  arg : opt blob;
+  wasm_module : opt blob;
+  skip_stopping_before_installing : opt bool;
+  canister_id : opt principal;
+  install_mode : opt int32;
+};
 type KnownNeuron = record {
   id : opt NeuronId;
   known_neuron_data : opt KnownNeuronData;
@@ -305,6 +312,12 @@ type ListProposalInfo = record {
   include_status : vec int32;
 };
 type ListProposalInfoResponse = record { proposal_info : vec ProposalInfo };
+type MakeProposalRequest = record {
+  url : text;
+  title : opt text;
+  action : opt ProposalActionRequest;
+  summary : text;
+};
 type MakeProposalResponse = record {
   message : opt text;
   proposal_id : opt NeuronId;
@@ -317,6 +330,25 @@ type MakingSnsProposal = record {
 type ManageNeuron = record {
   id : opt NeuronId;
   command : opt Command;
+  neuron_id_or_subaccount : opt NeuronIdOrSubaccount;
+};
+type ManageNeuronCommandRequest = variant {
+  Spawn : Spawn;
+  Split : Split;
+  Follow : Follow;
+  ClaimOrRefresh : ClaimOrRefresh;
+  Configure : Configure;
+  RegisterVote : RegisterVote;
+  Merge : Merge;
+  DisburseToNeuron : DisburseToNeuron;
+  MakeProposal : MakeProposalRequest;
+  StakeMaturity : StakeMaturity;
+  MergeMaturity : MergeMaturity;
+  Disburse : Disburse;
+};
+type ManageNeuronRequest = record {
+  id : opt NeuronId;
+  command : opt ManageNeuronCommandRequest;
   neuron_id_or_subaccount : opt NeuronIdOrSubaccount;
 };
 type ManageNeuronResponse = record { command : opt Command_1 };
@@ -493,56 +525,6 @@ type NeuronsFundParticipation = record {
 type NeuronsFundSnapshot = record {
   neurons_fund_neuron_portions : vec NeuronsFundNeuronPortion;
 };
-type NewInstallCode = record {
-  arg : opt blob;
-  wasm_module : opt blob;
-  skip_stopping_before_installing : opt bool;
-  canister_id : opt principal;
-  install_mode : opt int32;
-};
-type ManageNeuronInput = record {
-  id : opt NeuronId;
-  command : opt ManageNeuronCommandInput;
-  neuron_id_or_subaccount : opt NeuronIdOrSubaccount;
-};
-type ManageNeuronCommandInput = variant {
-  Spawn : Spawn;
-  Split : Split;
-  Follow : Follow;
-  ClaimOrRefresh : ClaimOrRefresh;
-  Configure : Configure;
-  RegisterVote : RegisterVote;
-  Merge : Merge;
-  DisburseToNeuron : DisburseToNeuron;
-  MakeProposal : ProposalInput;
-  StakeMaturity : StakeMaturity;
-  MergeMaturity : MergeMaturity;
-  Disburse : Disburse;
-};
-type ProposalInput = record {
-  url : text;
-  title : opt text;
-  action : opt ProposalActionInput;
-  summary : text;
-};
-type ProposalActionInput = variant {
-  RegisterKnownNeuron : KnownNeuron;
-  ManageNeuron : ManageNeuronInput;
-  UpdateCanisterSettings : UpdateCanisterSettings;
-  InstallCode : NewInstallCode;
-  StopOrStartCanister : StopOrStartCanister;
-  CreateServiceNervousSystem : CreateServiceNervousSystem;
-  ExecuteNnsFunction : ExecuteNnsFunction;
-  RewardNodeProvider : RewardNodeProvider;
-  OpenSnsTokenSwap : OpenSnsTokenSwap;
-  SetSnsTokenSwapOpenTimeWindow : SetSnsTokenSwapOpenTimeWindow;
-  SetDefaultFollowees : SetDefaultFollowees;
-  RewardNodeProviders : RewardNodeProviders;
-  ManageNetworkEconomics : NetworkEconomics;
-  ApproveGenesisKyc : Principals;
-  AddOrRemoveNodeProvider : AddOrRemoveNodeProvider;
-  Motion : Motion;
-};
 type NodeProvider = record {
   id : opt principal;
   reward_account : opt AccountIdentifier;
@@ -587,6 +569,24 @@ type Proposal = record {
   title : opt text;
   action : opt Action;
   summary : text;
+};
+type ProposalActionRequest = variant {
+  RegisterKnownNeuron : KnownNeuron;
+  ManageNeuron : ManageNeuronRequest;
+  UpdateCanisterSettings : UpdateCanisterSettings;
+  InstallCode : InstallCodeRequest;
+  StopOrStartCanister : StopOrStartCanister;
+  CreateServiceNervousSystem : CreateServiceNervousSystem;
+  ExecuteNnsFunction : ExecuteNnsFunction;
+  RewardNodeProvider : RewardNodeProvider;
+  OpenSnsTokenSwap : OpenSnsTokenSwap;
+  SetSnsTokenSwapOpenTimeWindow : SetSnsTokenSwapOpenTimeWindow;
+  SetDefaultFollowees : SetDefaultFollowees;
+  RewardNodeProviders : RewardNodeProviders;
+  ManageNetworkEconomics : NetworkEconomics;
+  ApproveGenesisKyc : Principals;
+  AddOrRemoveNodeProvider : AddOrRemoveNodeProvider;
+  Motion : Motion;
 };
 type ProposalData = record {
   id : opt NeuronId;
@@ -801,14 +801,14 @@ service : (Governance) -> {
   list_neurons : (ListNeurons) -> (ListNeuronsResponse) query;
   list_node_providers : () -> (ListNodeProvidersResponse) query;
   list_proposals : (ListProposalInfo) -> (ListProposalInfoResponse) query;
-  manage_neuron : (ManageNeuronInput) -> (ManageNeuronResponse);
+  manage_neuron : (ManageNeuronRequest) -> (ManageNeuronResponse);
   settle_community_fund_participation : (SettleCommunityFundParticipation) -> (
       Result,
     );
   settle_neurons_fund_participation : (
       SettleNeuronsFundParticipationRequest,
     ) -> (SettleNeuronsFundParticipationResponse);
-  simulate_manage_neuron : (ManageNeuronInput) -> (ManageNeuronResponse);
+  simulate_manage_neuron : (ManageNeuronRequest) -> (ManageNeuronResponse);
   transfer_gtc_neuron : (NeuronId, NeuronId) -> (Result);
   update_neuron : (Neuron) -> (opt GovernanceError);
   update_node_provider : (UpdateNodeProvider) -> (Result);

--- a/rs/nns/governance/canister/governance_test.did
+++ b/rs/nns/governance/canister/governance_test.did
@@ -266,10 +266,10 @@ type InitialTokenDistribution = record {
   swap_distribution : opt SwapDistribution;
 };
 type InstallCode = record {
-  arg : opt blob;
-  wasm_module : opt blob;
   skip_stopping_before_installing : opt bool;
+  wasm_module_hash : opt blob;
   canister_id : opt principal;
+  arg_hash : opt blob;
   install_mode : opt int32;
 };
 type KnownNeuron = record {
@@ -492,6 +492,56 @@ type NeuronsFundParticipation = record {
 };
 type NeuronsFundSnapshot = record {
   neurons_fund_neuron_portions : vec NeuronsFundNeuronPortion;
+};
+type NewInstallCode = record {
+  arg : opt blob;
+  wasm_module : opt blob;
+  skip_stopping_before_installing : opt bool;
+  canister_id : opt principal;
+  install_mode : opt int32;
+};
+type ManageNeuronInput = record {
+  id : opt NeuronId;
+  command : opt ManageNeuronCommandInput;
+  neuron_id_or_subaccount : opt NeuronIdOrSubaccount;
+};
+type ManageNeuronCommandInput = variant {
+  Spawn : Spawn;
+  Split : Split;
+  Follow : Follow;
+  ClaimOrRefresh : ClaimOrRefresh;
+  Configure : Configure;
+  RegisterVote : RegisterVote;
+  Merge : Merge;
+  DisburseToNeuron : DisburseToNeuron;
+  MakeProposal : ProposalInput;
+  StakeMaturity : StakeMaturity;
+  MergeMaturity : MergeMaturity;
+  Disburse : Disburse;
+};
+type ProposalInput = record {
+  url : text;
+  title : opt text;
+  action : opt ProposalActionInput;
+  summary : text;
+};
+type ProposalActionInput = variant {
+  RegisterKnownNeuron : KnownNeuron;
+  ManageNeuron : ManageNeuronInput;
+  UpdateCanisterSettings : UpdateCanisterSettings;
+  InstallCode : NewInstallCode;
+  StopOrStartCanister : StopOrStartCanister;
+  CreateServiceNervousSystem : CreateServiceNervousSystem;
+  ExecuteNnsFunction : ExecuteNnsFunction;
+  RewardNodeProvider : RewardNodeProvider;
+  OpenSnsTokenSwap : OpenSnsTokenSwap;
+  SetSnsTokenSwapOpenTimeWindow : SetSnsTokenSwapOpenTimeWindow;
+  SetDefaultFollowees : SetDefaultFollowees;
+  RewardNodeProviders : RewardNodeProviders;
+  ManageNetworkEconomics : NetworkEconomics;
+  ApproveGenesisKyc : Principals;
+  AddOrRemoveNodeProvider : AddOrRemoveNodeProvider;
+  Motion : Motion;
 };
 type NodeProvider = record {
   id : opt principal;
@@ -751,14 +801,14 @@ service : (Governance) -> {
   list_neurons : (ListNeurons) -> (ListNeuronsResponse) query;
   list_node_providers : () -> (ListNodeProvidersResponse) query;
   list_proposals : (ListProposalInfo) -> (ListProposalInfoResponse) query;
-  manage_neuron : (ManageNeuron) -> (ManageNeuronResponse);
+  manage_neuron : (ManageNeuronInput) -> (ManageNeuronResponse);
   settle_community_fund_participation : (SettleCommunityFundParticipation) -> (
       Result,
     );
   settle_neurons_fund_participation : (
       SettleNeuronsFundParticipationRequest,
     ) -> (SettleNeuronsFundParticipationResponse);
-  simulate_manage_neuron : (ManageNeuron) -> (ManageNeuronResponse);
+  simulate_manage_neuron : (ManageNeuronInput) -> (ManageNeuronResponse);
   transfer_gtc_neuron : (NeuronId, NeuronId) -> (Result);
   update_neuron : (Neuron) -> (opt GovernanceError);
   update_node_provider : (UpdateNodeProvider) -> (Result);

--- a/rs/nns/governance/src/pb/conversions.rs
+++ b/rs/nns/governance/src/pb/conversions.rs
@@ -555,8 +555,8 @@ impl From<pb_api::Proposal> for pb::Proposal {
         }
     }
 }
-impl From<pb_api::ProposalInput> for pb::Proposal {
-    fn from(item: pb_api::ProposalInput) -> Self {
+impl From<pb_api::MakeProposalRequest> for pb::Proposal {
+    fn from(item: pb_api::MakeProposalRequest) -> Self {
         Self {
             title: item.title,
             summary: item.summary,
@@ -666,53 +666,53 @@ impl From<pb_api::proposal::Action> for pb::proposal::Action {
         }
     }
 }
-impl From<pb_api::ProposalActionInput> for pb::proposal::Action {
-    fn from(item: pb_api::ProposalActionInput) -> Self {
+impl From<pb_api::ProposalActionRequest> for pb::proposal::Action {
+    fn from(item: pb_api::ProposalActionRequest) -> Self {
         match item {
-            pb_api::ProposalActionInput::ManageNeuron(v) => {
+            pb_api::ProposalActionRequest::ManageNeuron(v) => {
                 pb::proposal::Action::ManageNeuron(Box::new((*v).into()))
             }
-            pb_api::ProposalActionInput::ManageNetworkEconomics(v) => {
+            pb_api::ProposalActionRequest::ManageNetworkEconomics(v) => {
                 pb::proposal::Action::ManageNetworkEconomics(v.into())
             }
-            pb_api::ProposalActionInput::Motion(v) => pb::proposal::Action::Motion(v.into()),
-            pb_api::ProposalActionInput::ExecuteNnsFunction(v) => {
+            pb_api::ProposalActionRequest::Motion(v) => pb::proposal::Action::Motion(v.into()),
+            pb_api::ProposalActionRequest::ExecuteNnsFunction(v) => {
                 pb::proposal::Action::ExecuteNnsFunction(v.into())
             }
-            pb_api::ProposalActionInput::ApproveGenesisKyc(v) => {
+            pb_api::ProposalActionRequest::ApproveGenesisKyc(v) => {
                 pb::proposal::Action::ApproveGenesisKyc(v.into())
             }
-            pb_api::ProposalActionInput::AddOrRemoveNodeProvider(v) => {
+            pb_api::ProposalActionRequest::AddOrRemoveNodeProvider(v) => {
                 pb::proposal::Action::AddOrRemoveNodeProvider(v.into())
             }
-            pb_api::ProposalActionInput::RewardNodeProvider(v) => {
+            pb_api::ProposalActionRequest::RewardNodeProvider(v) => {
                 pb::proposal::Action::RewardNodeProvider(v.into())
             }
-            pb_api::ProposalActionInput::SetDefaultFollowees(v) => {
+            pb_api::ProposalActionRequest::SetDefaultFollowees(v) => {
                 pb::proposal::Action::SetDefaultFollowees(v.into())
             }
-            pb_api::ProposalActionInput::RewardNodeProviders(v) => {
+            pb_api::ProposalActionRequest::RewardNodeProviders(v) => {
                 pb::proposal::Action::RewardNodeProviders(v.into())
             }
-            pb_api::ProposalActionInput::RegisterKnownNeuron(v) => {
+            pb_api::ProposalActionRequest::RegisterKnownNeuron(v) => {
                 pb::proposal::Action::RegisterKnownNeuron(v.into())
             }
-            pb_api::ProposalActionInput::SetSnsTokenSwapOpenTimeWindow(v) => {
+            pb_api::ProposalActionRequest::SetSnsTokenSwapOpenTimeWindow(v) => {
                 pb::proposal::Action::SetSnsTokenSwapOpenTimeWindow(v.into())
             }
-            pb_api::ProposalActionInput::OpenSnsTokenSwap(v) => {
+            pb_api::ProposalActionRequest::OpenSnsTokenSwap(v) => {
                 pb::proposal::Action::OpenSnsTokenSwap(v.into())
             }
-            pb_api::ProposalActionInput::CreateServiceNervousSystem(v) => {
+            pb_api::ProposalActionRequest::CreateServiceNervousSystem(v) => {
                 pb::proposal::Action::CreateServiceNervousSystem(v.into())
             }
-            pb_api::ProposalActionInput::InstallCode(v) => {
+            pb_api::ProposalActionRequest::InstallCode(v) => {
                 pb::proposal::Action::InstallCode(v.into())
             }
-            pb_api::ProposalActionInput::StopOrStartCanister(v) => {
+            pb_api::ProposalActionRequest::StopOrStartCanister(v) => {
                 pb::proposal::Action::StopOrStartCanister(v.into())
             }
-            pb_api::ProposalActionInput::UpdateCanisterSettings(v) => {
+            pb_api::ProposalActionRequest::UpdateCanisterSettings(v) => {
                 pb::proposal::Action::UpdateCanisterSettings(v.into())
             }
         }
@@ -748,8 +748,8 @@ impl From<pb_api::ManageNeuron> for pb::ManageNeuron {
         }
     }
 }
-impl From<pb_api::ManageNeuronInput> for pb::ManageNeuron {
-    fn from(item: pb_api::ManageNeuronInput) -> Self {
+impl From<pb_api::ManageNeuronRequest> for pb::ManageNeuron {
+    fn from(item: pb_api::ManageNeuronRequest) -> Self {
         Self {
             id: item.id,
             neuron_id_or_subaccount: item.neuron_id_or_subaccount.map(|x| x.into()),
@@ -1318,43 +1318,43 @@ impl From<pb_api::manage_neuron::Command> for pb::manage_neuron::Command {
         }
     }
 }
-impl From<pb_api::ManageNeuronCommandInput> for pb::manage_neuron::Command {
-    fn from(item: pb_api::ManageNeuronCommandInput) -> Self {
+impl From<pb_api::ManageNeuronCommandRequest> for pb::manage_neuron::Command {
+    fn from(item: pb_api::ManageNeuronCommandRequest) -> Self {
         match item {
-            pb_api::ManageNeuronCommandInput::Configure(v) => {
+            pb_api::ManageNeuronCommandRequest::Configure(v) => {
                 pb::manage_neuron::Command::Configure(v.into())
             }
-            pb_api::ManageNeuronCommandInput::Disburse(v) => {
+            pb_api::ManageNeuronCommandRequest::Disburse(v) => {
                 pb::manage_neuron::Command::Disburse(v.into())
             }
-            pb_api::ManageNeuronCommandInput::Spawn(v) => {
+            pb_api::ManageNeuronCommandRequest::Spawn(v) => {
                 pb::manage_neuron::Command::Spawn(v.into())
             }
-            pb_api::ManageNeuronCommandInput::Follow(v) => {
+            pb_api::ManageNeuronCommandRequest::Follow(v) => {
                 pb::manage_neuron::Command::Follow(v.into())
             }
-            pb_api::ManageNeuronCommandInput::MakeProposal(v) => {
+            pb_api::ManageNeuronCommandRequest::MakeProposal(v) => {
                 pb::manage_neuron::Command::MakeProposal(Box::new((*v).into()))
             }
-            pb_api::ManageNeuronCommandInput::RegisterVote(v) => {
+            pb_api::ManageNeuronCommandRequest::RegisterVote(v) => {
                 pb::manage_neuron::Command::RegisterVote(v.into())
             }
-            pb_api::ManageNeuronCommandInput::Split(v) => {
+            pb_api::ManageNeuronCommandRequest::Split(v) => {
                 pb::manage_neuron::Command::Split(v.into())
             }
-            pb_api::ManageNeuronCommandInput::DisburseToNeuron(v) => {
+            pb_api::ManageNeuronCommandRequest::DisburseToNeuron(v) => {
                 pb::manage_neuron::Command::DisburseToNeuron(v.into())
             }
-            pb_api::ManageNeuronCommandInput::ClaimOrRefresh(v) => {
+            pb_api::ManageNeuronCommandRequest::ClaimOrRefresh(v) => {
                 pb::manage_neuron::Command::ClaimOrRefresh(v.into())
             }
-            pb_api::ManageNeuronCommandInput::MergeMaturity(v) => {
+            pb_api::ManageNeuronCommandRequest::MergeMaturity(v) => {
                 pb::manage_neuron::Command::MergeMaturity(v.into())
             }
-            pb_api::ManageNeuronCommandInput::Merge(v) => {
+            pb_api::ManageNeuronCommandRequest::Merge(v) => {
                 pb::manage_neuron::Command::Merge(v.into())
             }
-            pb_api::ManageNeuronCommandInput::StakeMaturity(v) => {
+            pb_api::ManageNeuronCommandRequest::StakeMaturity(v) => {
                 pb::manage_neuron::Command::StakeMaturity(v.into())
             }
         }
@@ -2924,8 +2924,8 @@ impl From<pb_api::InstallCode> for pb::InstallCode {
         }
     }
 }
-impl From<pb_api::InstallCodeInput> for pb::InstallCode {
-    fn from(item: pb_api::InstallCodeInput) -> Self {
+impl From<pb_api::InstallCodeRequest> for pb::InstallCode {
+    fn from(item: pb_api::InstallCodeRequest) -> Self {
         Self {
             canister_id: item.canister_id,
             install_mode: item.install_mode,

--- a/rs/nns/governance/src/pb/conversions.rs
+++ b/rs/nns/governance/src/pb/conversions.rs
@@ -555,6 +555,16 @@ impl From<pb_api::Proposal> for pb::Proposal {
         }
     }
 }
+impl From<pb_api::ProposalInput> for pb::Proposal {
+    fn from(item: pb_api::ProposalInput) -> Self {
+        Self {
+            title: item.title,
+            summary: item.summary,
+            url: item.url,
+            action: item.action.map(|x| x.into()),
+        }
+    }
+}
 
 impl From<pb::proposal::Action> for pb_api::proposal::Action {
     fn from(item: pb::proposal::Action) -> Self {
@@ -656,6 +666,58 @@ impl From<pb_api::proposal::Action> for pb::proposal::Action {
         }
     }
 }
+impl From<pb_api::ProposalActionInput> for pb::proposal::Action {
+    fn from(item: pb_api::ProposalActionInput) -> Self {
+        match item {
+            pb_api::ProposalActionInput::ManageNeuron(v) => {
+                pb::proposal::Action::ManageNeuron(Box::new((*v).into()))
+            }
+            pb_api::ProposalActionInput::ManageNetworkEconomics(v) => {
+                pb::proposal::Action::ManageNetworkEconomics(v.into())
+            }
+            pb_api::ProposalActionInput::Motion(v) => pb::proposal::Action::Motion(v.into()),
+            pb_api::ProposalActionInput::ExecuteNnsFunction(v) => {
+                pb::proposal::Action::ExecuteNnsFunction(v.into())
+            }
+            pb_api::ProposalActionInput::ApproveGenesisKyc(v) => {
+                pb::proposal::Action::ApproveGenesisKyc(v.into())
+            }
+            pb_api::ProposalActionInput::AddOrRemoveNodeProvider(v) => {
+                pb::proposal::Action::AddOrRemoveNodeProvider(v.into())
+            }
+            pb_api::ProposalActionInput::RewardNodeProvider(v) => {
+                pb::proposal::Action::RewardNodeProvider(v.into())
+            }
+            pb_api::ProposalActionInput::SetDefaultFollowees(v) => {
+                pb::proposal::Action::SetDefaultFollowees(v.into())
+            }
+            pb_api::ProposalActionInput::RewardNodeProviders(v) => {
+                pb::proposal::Action::RewardNodeProviders(v.into())
+            }
+            pb_api::ProposalActionInput::RegisterKnownNeuron(v) => {
+                pb::proposal::Action::RegisterKnownNeuron(v.into())
+            }
+            pb_api::ProposalActionInput::SetSnsTokenSwapOpenTimeWindow(v) => {
+                pb::proposal::Action::SetSnsTokenSwapOpenTimeWindow(v.into())
+            }
+            pb_api::ProposalActionInput::OpenSnsTokenSwap(v) => {
+                pb::proposal::Action::OpenSnsTokenSwap(v.into())
+            }
+            pb_api::ProposalActionInput::CreateServiceNervousSystem(v) => {
+                pb::proposal::Action::CreateServiceNervousSystem(v.into())
+            }
+            pb_api::ProposalActionInput::InstallCode(v) => {
+                pb::proposal::Action::InstallCode(v.into())
+            }
+            pb_api::ProposalActionInput::StopOrStartCanister(v) => {
+                pb::proposal::Action::StopOrStartCanister(v.into())
+            }
+            pb_api::ProposalActionInput::UpdateCanisterSettings(v) => {
+                pb::proposal::Action::UpdateCanisterSettings(v.into())
+            }
+        }
+    }
+}
 
 impl From<pb::Empty> for pb_api::Empty {
     fn from(_: pb::Empty) -> Self {
@@ -679,6 +741,15 @@ impl From<pb::ManageNeuron> for pb_api::ManageNeuron {
 }
 impl From<pb_api::ManageNeuron> for pb::ManageNeuron {
     fn from(item: pb_api::ManageNeuron) -> Self {
+        Self {
+            id: item.id,
+            neuron_id_or_subaccount: item.neuron_id_or_subaccount.map(|x| x.into()),
+            command: item.command.map(|x| x.into()),
+        }
+    }
+}
+impl From<pb_api::ManageNeuronInput> for pb::ManageNeuron {
+    fn from(item: pb_api::ManageNeuronInput) -> Self {
         Self {
             id: item.id,
             neuron_id_or_subaccount: item.neuron_id_or_subaccount.map(|x| x.into()),
@@ -1242,6 +1313,48 @@ impl From<pb_api::manage_neuron::Command> for pb::manage_neuron::Command {
             }
             pb_api::manage_neuron::Command::Merge(v) => pb::manage_neuron::Command::Merge(v.into()),
             pb_api::manage_neuron::Command::StakeMaturity(v) => {
+                pb::manage_neuron::Command::StakeMaturity(v.into())
+            }
+        }
+    }
+}
+impl From<pb_api::ManageNeuronCommandInput> for pb::manage_neuron::Command {
+    fn from(item: pb_api::ManageNeuronCommandInput) -> Self {
+        match item {
+            pb_api::ManageNeuronCommandInput::Configure(v) => {
+                pb::manage_neuron::Command::Configure(v.into())
+            }
+            pb_api::ManageNeuronCommandInput::Disburse(v) => {
+                pb::manage_neuron::Command::Disburse(v.into())
+            }
+            pb_api::ManageNeuronCommandInput::Spawn(v) => {
+                pb::manage_neuron::Command::Spawn(v.into())
+            }
+            pb_api::ManageNeuronCommandInput::Follow(v) => {
+                pb::manage_neuron::Command::Follow(v.into())
+            }
+            pb_api::ManageNeuronCommandInput::MakeProposal(v) => {
+                pb::manage_neuron::Command::MakeProposal(Box::new((*v).into()))
+            }
+            pb_api::ManageNeuronCommandInput::RegisterVote(v) => {
+                pb::manage_neuron::Command::RegisterVote(v.into())
+            }
+            pb_api::ManageNeuronCommandInput::Split(v) => {
+                pb::manage_neuron::Command::Split(v.into())
+            }
+            pb_api::ManageNeuronCommandInput::DisburseToNeuron(v) => {
+                pb::manage_neuron::Command::DisburseToNeuron(v.into())
+            }
+            pb_api::ManageNeuronCommandInput::ClaimOrRefresh(v) => {
+                pb::manage_neuron::Command::ClaimOrRefresh(v.into())
+            }
+            pb_api::ManageNeuronCommandInput::MergeMaturity(v) => {
+                pb::manage_neuron::Command::MergeMaturity(v.into())
+            }
+            pb_api::ManageNeuronCommandInput::Merge(v) => {
+                pb::manage_neuron::Command::Merge(v.into())
+            }
+            pb_api::ManageNeuronCommandInput::StakeMaturity(v) => {
                 pb::manage_neuron::Command::StakeMaturity(v.into())
             }
         }
@@ -2784,17 +2897,35 @@ impl From<pb_api::create_service_nervous_system::governance_parameters::VotingRe
 
 impl From<pb::InstallCode> for pb_api::InstallCode {
     fn from(item: pb::InstallCode) -> Self {
+        let wasm_module_hash = item
+            .wasm_module
+            .map(|wasm_module| super::calculate_hash(&wasm_module).to_vec());
+        let arg_hash = item.arg.map(|arg| super::calculate_hash(&arg).to_vec());
+
         Self {
             canister_id: item.canister_id,
             install_mode: item.install_mode,
-            wasm_module: item.wasm_module,
-            arg: item.arg,
             skip_stopping_before_installing: item.skip_stopping_before_installing,
+            wasm_module_hash,
+            arg_hash,
         }
     }
 }
 impl From<pb_api::InstallCode> for pb::InstallCode {
     fn from(item: pb_api::InstallCode) -> Self {
+        Self {
+            canister_id: item.canister_id,
+            install_mode: item.install_mode,
+            skip_stopping_before_installing: item.skip_stopping_before_installing,
+            // Note: the api->internal conversion here only happens when decoding from protobuf in
+            // canister_init.
+            wasm_module: None,
+            arg: None,
+        }
+    }
+}
+impl From<pb_api::InstallCodeInput> for pb::InstallCode {
+    fn from(item: pb_api::InstallCodeInput) -> Self {
         Self {
             canister_id: item.canister_id,
             install_mode: item.install_mode,

--- a/rs/nns/governance/src/pb/mod.rs
+++ b/rs/nns/governance/src/pb/mod.rs
@@ -1,4 +1,5 @@
 use crate::pb::v1::ArchivedMonthlyNodeProviderRewards;
+use ic_crypto_sha2::Sha256;
 use ic_stable_structures::{storable::Bound, Storable};
 use prost::Message;
 use std::borrow::Cow;
@@ -23,4 +24,11 @@ impl Storable for ArchivedMonthlyNodeProviderRewards {
     }
 
     const BOUND: Bound = Bound::Unbounded;
+}
+
+/// Calculates the SHA256 hash of the given bytes.
+fn calculate_hash(bytes: &[u8]) -> [u8; 32] {
+    let mut wasm_sha = Sha256::new();
+    wasm_sha.write(bytes);
+    wasm_sha.finish()
 }

--- a/rs/nns/integration_tests/BUILD.bazel
+++ b/rs/nns/integration_tests/BUILD.bazel
@@ -414,7 +414,6 @@ rust_ic_test(
     env = DEV_ENV,
     proc_macro_deps = MACRO_DEPENDENCIES + MACRO_DEV_DEPENDENCIES,
     tags = [
-        "manual",
         "nns_tests_nightly",  # Run this test in the nns-tests-nightly GitHub Action job.
         "no-sandbox",  # such that the test can access the file $SSH_AUTH_SOCK.
         "requires-network",  # Because mainnet state is downloaded (and used).

--- a/rs/nns/integration_tests/BUILD.bazel
+++ b/rs/nns/integration_tests/BUILD.bazel
@@ -414,6 +414,7 @@ rust_ic_test(
     env = DEV_ENV,
     proc_macro_deps = MACRO_DEPENDENCIES + MACRO_DEV_DEPENDENCIES,
     tags = [
+        "manual",
         "nns_tests_nightly",  # Run this test in the nns-tests-nightly GitHub Action job.
         "no-sandbox",  # such that the test can access the file $SSH_AUTH_SOCK.
         "requires-network",  # Because mainnet state is downloaded (and used).

--- a/rs/nns/integration_tests/src/create_service_nervous_system.rs
+++ b/rs/nns/integration_tests/src/create_service_nervous_system.rs
@@ -12,11 +12,11 @@ use ic_nns_governance_api::pb::v1::{
     manage_neuron::{self, RegisterVote},
     manage_neuron_response,
     proposal::Action,
+    MakeProposalRequest,
     // Perhaps surprisingly, CreateServiceNervousSystem is not needed by
     // this file, because we simply use a constant of that type
     ManageNeuron,
     ManageNeuronResponse,
-    MakeProposalRequest,
     ProposalActionRequest,
     ProposalStatus,
     Vote,

--- a/rs/nns/integration_tests/src/create_service_nervous_system.rs
+++ b/rs/nns/integration_tests/src/create_service_nervous_system.rs
@@ -11,12 +11,13 @@ use ic_nns_governance_api::pb::v1::{
     governance_error::ErrorType,
     manage_neuron::{self, RegisterVote},
     manage_neuron_response,
-    proposal,
+    proposal::Action,
     // Perhaps surprisingly, CreateServiceNervousSystem is not needed by
     // this file, because we simply use a constant of that type
     ManageNeuron,
     ManageNeuronResponse,
-    Proposal,
+    ProposalInput,
+    ProposalActionInput,
     ProposalStatus,
     Vote,
 };
@@ -142,7 +143,7 @@ fn test_several_proposals() {
         .into_iter()
         .filter_map(
             |proposal_info| match proposal_info.proposal.as_ref().unwrap().action {
-                Some(proposal::Action::CreateServiceNervousSystem(_)) => {
+                Some(Action::CreateServiceNervousSystem(_)) => {
                     let id = proposal_info.id.as_ref().unwrap().id;
                     Some((id, proposal_info))
                 }
@@ -189,11 +190,11 @@ fn make_proposal(state_machine: &StateMachine, sns_number: u64) -> ManageNeuronR
         state_machine,
         *TEST_NEURON_2_OWNER_PRINCIPAL,
         neuron_id,
-        &Proposal {
+        &ProposalInput {
             title: Some(format!("Create SNS #{}", sns_number)),
             summary: "".to_string(),
             url: "".to_string(),
-            action: Some(proposal::Action::CreateServiceNervousSystem(
+            action: Some(ProposalActionInput::CreateServiceNervousSystem(
                 CREATE_SERVICE_NERVOUS_SYSTEM_WITH_MATCHED_FUNDING
                     .clone()
                     .into(),

--- a/rs/nns/integration_tests/src/create_service_nervous_system.rs
+++ b/rs/nns/integration_tests/src/create_service_nervous_system.rs
@@ -16,8 +16,8 @@ use ic_nns_governance_api::pb::v1::{
     // this file, because we simply use a constant of that type
     ManageNeuron,
     ManageNeuronResponse,
-    ProposalInput,
-    ProposalActionInput,
+    MakeProposalRequest,
+    ProposalActionRequest,
     ProposalStatus,
     Vote,
 };
@@ -190,11 +190,11 @@ fn make_proposal(state_machine: &StateMachine, sns_number: u64) -> ManageNeuronR
         state_machine,
         *TEST_NEURON_2_OWNER_PRINCIPAL,
         neuron_id,
-        &ProposalInput {
+        &MakeProposalRequest {
             title: Some(format!("Create SNS #{}", sns_number)),
             summary: "".to_string(),
             url: "".to_string(),
-            action: Some(ProposalActionInput::CreateServiceNervousSystem(
+            action: Some(ProposalActionRequest::CreateServiceNervousSystem(
                 CREATE_SERVICE_NERVOUS_SYSTEM_WITH_MATCHED_FUNDING
                     .clone()
                     .into(),

--- a/rs/nns/integration_tests/src/cycles_minting_canister_with_exchange_rate_canister.rs
+++ b/rs/nns/integration_tests/src/cycles_minting_canister_with_exchange_rate_canister.rs
@@ -8,7 +8,8 @@ use ic_nns_common::{
 };
 use ic_nns_constants::{EXCHANGE_RATE_CANISTER_ID, EXCHANGE_RATE_CANISTER_INDEX};
 use ic_nns_governance_api::pb::v1::{
-    manage_neuron_response, ExecuteNnsFunction, MakeProposalRequest, ProposalActionRequest, NnsFunction,
+    manage_neuron_response, ExecuteNnsFunction, MakeProposalRequest, NnsFunction,
+    ProposalActionRequest,
 };
 use ic_nns_test_utils::{
     common::NnsInitPayloadsBuilder,
@@ -72,10 +73,12 @@ fn propose_icp_xdr_rate(
         title: Some(format!("Update ICP/XDR rate to {}", xdr_permyriad_per_icp)),
         summary: "".to_string(),
         url: "".to_string(),
-        action: Some(ProposalActionRequest::ExecuteNnsFunction(ExecuteNnsFunction {
-            nns_function: NnsFunction::IcpXdrConversionRate as i32,
-            payload: Encode!(&payload).unwrap(),
-        })),
+        action: Some(ProposalActionRequest::ExecuteNnsFunction(
+            ExecuteNnsFunction {
+                nns_function: NnsFunction::IcpXdrConversionRate as i32,
+                payload: Encode!(&payload).unwrap(),
+            },
+        )),
     };
 
     let response = nns_governance_make_proposal(

--- a/rs/nns/integration_tests/src/cycles_minting_canister_with_exchange_rate_canister.rs
+++ b/rs/nns/integration_tests/src/cycles_minting_canister_with_exchange_rate_canister.rs
@@ -8,7 +8,7 @@ use ic_nns_common::{
 };
 use ic_nns_constants::{EXCHANGE_RATE_CANISTER_ID, EXCHANGE_RATE_CANISTER_INDEX};
 use ic_nns_governance_api::pb::v1::{
-    manage_neuron_response, proposal::Action, ExecuteNnsFunction, NnsFunction, Proposal,
+    manage_neuron_response, ExecuteNnsFunction, ProposalInput, ProposalActionInput, NnsFunction,
 };
 use ic_nns_test_utils::{
     common::NnsInitPayloadsBuilder,
@@ -68,11 +68,11 @@ fn propose_icp_xdr_rate(
         id: TEST_NEURON_1_ID,
     };
 
-    let proposal = Proposal {
+    let proposal = ProposalInput {
         title: Some(format!("Update ICP/XDR rate to {}", xdr_permyriad_per_icp)),
         summary: "".to_string(),
         url: "".to_string(),
-        action: Some(Action::ExecuteNnsFunction(ExecuteNnsFunction {
+        action: Some(ProposalActionInput::ExecuteNnsFunction(ExecuteNnsFunction {
             nns_function: NnsFunction::IcpXdrConversionRate as i32,
             payload: Encode!(&payload).unwrap(),
         })),

--- a/rs/nns/integration_tests/src/cycles_minting_canister_with_exchange_rate_canister.rs
+++ b/rs/nns/integration_tests/src/cycles_minting_canister_with_exchange_rate_canister.rs
@@ -8,7 +8,7 @@ use ic_nns_common::{
 };
 use ic_nns_constants::{EXCHANGE_RATE_CANISTER_ID, EXCHANGE_RATE_CANISTER_INDEX};
 use ic_nns_governance_api::pb::v1::{
-    manage_neuron_response, ExecuteNnsFunction, ProposalInput, ProposalActionInput, NnsFunction,
+    manage_neuron_response, ExecuteNnsFunction, MakeProposalRequest, ProposalActionRequest, NnsFunction,
 };
 use ic_nns_test_utils::{
     common::NnsInitPayloadsBuilder,
@@ -68,11 +68,11 @@ fn propose_icp_xdr_rate(
         id: TEST_NEURON_1_ID,
     };
 
-    let proposal = ProposalInput {
+    let proposal = MakeProposalRequest {
         title: Some(format!("Update ICP/XDR rate to {}", xdr_permyriad_per_icp)),
         summary: "".to_string(),
         url: "".to_string(),
-        action: Some(ProposalActionInput::ExecuteNnsFunction(ExecuteNnsFunction {
+        action: Some(ProposalActionRequest::ExecuteNnsFunction(ExecuteNnsFunction {
             nns_function: NnsFunction::IcpXdrConversionRate as i32,
             payload: Encode!(&payload).unwrap(),
         })),

--- a/rs/nns/integration_tests/src/governance_time_warp.rs
+++ b/rs/nns/integration_tests/src/governance_time_warp.rs
@@ -9,10 +9,10 @@ use ic_nns_common::pb::v1::NeuronId as NeuronIdProto;
 use ic_nns_governance::governance::TimeWarp;
 use ic_nns_governance_api::pb::v1::{
     governance_error::ErrorType,
-    manage_neuron::{Command, Disburse, NeuronIdOrSubaccount},
+    manage_neuron::{Disburse, NeuronIdOrSubaccount},
     manage_neuron_response,
     neuron::DissolveState,
-    ManageNeuron, ManageNeuronResponse, Neuron,
+    ManageNeuronCommandInput, ManageNeuronInput, ManageNeuronResponse, Neuron,
 };
 use ic_nns_test_utils::{
     common::NnsInitPayloadsBuilder,
@@ -69,10 +69,10 @@ fn test_time_warp() {
             .update_from_sender(
                 "manage_neuron",
                 candid_one,
-                ManageNeuron {
+                ManageNeuronInput {
                     id: None,
                     neuron_id_or_subaccount: Some(NeuronIdOrSubaccount::NeuronId(neuron_id_4)),
-                    command: Some(Command::Disburse(Disburse {
+                    command: Some(ManageNeuronCommandInput::Disburse(Disburse {
                         amount: None,
                         to_account: Some(
                             AccountIdentifier::new(*TEST_NEURON_1_OWNER_PRINCIPAL, None).into(),
@@ -108,10 +108,10 @@ fn test_time_warp() {
             .update_from_sender(
                 "manage_neuron",
                 candid_one,
-                ManageNeuron {
+                ManageNeuronInput {
                     id: None,
                     neuron_id_or_subaccount: Some(NeuronIdOrSubaccount::NeuronId(neuron_id_4)),
-                    command: Some(Command::Disburse(Disburse {
+                    command: Some(ManageNeuronCommandInput::Disburse(Disburse {
                         amount: None,
                         to_account: Some(
                             AccountIdentifier::new(*TEST_NEURON_1_OWNER_PRINCIPAL, None).into(),
@@ -146,10 +146,10 @@ fn test_time_warp() {
             .update_from_sender(
                 "manage_neuron",
                 candid_one,
-                ManageNeuron {
+                ManageNeuronInput {
                     id: None,
                     neuron_id_or_subaccount: Some(NeuronIdOrSubaccount::NeuronId(neuron_id_4)),
-                    command: Some(Command::Disburse(Disburse {
+                    command: Some(ManageNeuronCommandInput::Disburse(Disburse {
                         amount: None,
                         to_account: Some(
                             AccountIdentifier::new(*TEST_NEURON_1_OWNER_PRINCIPAL, None).into(),

--- a/rs/nns/integration_tests/src/governance_time_warp.rs
+++ b/rs/nns/integration_tests/src/governance_time_warp.rs
@@ -12,7 +12,7 @@ use ic_nns_governance_api::pb::v1::{
     manage_neuron::{Disburse, NeuronIdOrSubaccount},
     manage_neuron_response,
     neuron::DissolveState,
-    ManageNeuronCommandInput, ManageNeuronInput, ManageNeuronResponse, Neuron,
+    ManageNeuronCommandRequest, ManageNeuronRequest, ManageNeuronResponse, Neuron,
 };
 use ic_nns_test_utils::{
     common::NnsInitPayloadsBuilder,
@@ -69,10 +69,10 @@ fn test_time_warp() {
             .update_from_sender(
                 "manage_neuron",
                 candid_one,
-                ManageNeuronInput {
+                ManageNeuronRequest {
                     id: None,
                     neuron_id_or_subaccount: Some(NeuronIdOrSubaccount::NeuronId(neuron_id_4)),
-                    command: Some(ManageNeuronCommandInput::Disburse(Disburse {
+                    command: Some(ManageNeuronCommandRequest::Disburse(Disburse {
                         amount: None,
                         to_account: Some(
                             AccountIdentifier::new(*TEST_NEURON_1_OWNER_PRINCIPAL, None).into(),
@@ -108,10 +108,10 @@ fn test_time_warp() {
             .update_from_sender(
                 "manage_neuron",
                 candid_one,
-                ManageNeuronInput {
+                ManageNeuronRequest {
                     id: None,
                     neuron_id_or_subaccount: Some(NeuronIdOrSubaccount::NeuronId(neuron_id_4)),
-                    command: Some(ManageNeuronCommandInput::Disburse(Disburse {
+                    command: Some(ManageNeuronCommandRequest::Disburse(Disburse {
                         amount: None,
                         to_account: Some(
                             AccountIdentifier::new(*TEST_NEURON_1_OWNER_PRINCIPAL, None).into(),
@@ -146,10 +146,10 @@ fn test_time_warp() {
             .update_from_sender(
                 "manage_neuron",
                 candid_one,
-                ManageNeuronInput {
+                ManageNeuronRequest {
                     id: None,
                     neuron_id_or_subaccount: Some(NeuronIdOrSubaccount::NeuronId(neuron_id_4)),
-                    command: Some(ManageNeuronCommandInput::Disburse(Disburse {
+                    command: Some(ManageNeuronCommandRequest::Disburse(Disburse {
                         amount: None,
                         to_account: Some(
                             AccountIdentifier::new(*TEST_NEURON_1_OWNER_PRINCIPAL, None).into(),

--- a/rs/nns/integration_tests/src/known_neurons.rs
+++ b/rs/nns/integration_tests/src/known_neurons.rs
@@ -6,9 +6,9 @@ use ic_nervous_system_common_test_keys::{
 use ic_nns_common::{pb::v1::NeuronId, types::ProposalId};
 use ic_nns_governance_api::pb::v1::{
     manage_neuron::NeuronIdOrSubaccount, manage_neuron_response::Command as CommandResponse,
-    GovernanceError, KnownNeuron, KnownNeuronData, ListKnownNeuronsResponse, ManageNeuronResponse,
-    NeuronInfo, ManageNeuronRequest, ManageNeuronCommandRequest, MakeProposalRequest, ProposalActionRequest,
-    ProposalStatus,
+    GovernanceError, KnownNeuron, KnownNeuronData, ListKnownNeuronsResponse, MakeProposalRequest,
+    ManageNeuronCommandRequest, ManageNeuronRequest, ManageNeuronResponse, NeuronInfo,
+    ProposalActionRequest, ProposalStatus,
 };
 use ic_nns_test_utils::{
     common::NnsInitPayloadsBuilder,

--- a/rs/nns/integration_tests/src/known_neurons.rs
+++ b/rs/nns/integration_tests/src/known_neurons.rs
@@ -7,7 +7,7 @@ use ic_nns_common::{pb::v1::NeuronId, types::ProposalId};
 use ic_nns_governance_api::pb::v1::{
     manage_neuron::NeuronIdOrSubaccount, manage_neuron_response::Command as CommandResponse,
     GovernanceError, KnownNeuron, KnownNeuronData, ListKnownNeuronsResponse, ManageNeuronResponse,
-    NeuronInfo, ManageNeuronInput, ManageNeuronCommandInput, ProposalInput, ProposalActionInput,
+    NeuronInfo, ManageNeuronRequest, ManageNeuronCommandRequest, MakeProposalRequest, ProposalActionRequest,
     ProposalStatus,
 };
 use ic_nns_test_utils::{
@@ -43,19 +43,19 @@ fn test_known_neurons() {
             .update_from_sender(
                 "manage_neuron",
                 candid_one,
-                ManageNeuronInput {
+                ManageNeuronRequest {
                     neuron_id_or_subaccount: Some(NeuronIdOrSubaccount::NeuronId(
                         ic_nns_common::pb::v1::NeuronId {
                             id: TEST_NEURON_1_ID,
                         },
                     )),
                     id: None,
-                    command: Some(ManageNeuronCommandInput::MakeProposal(Box::new(
-                        ProposalInput {
+                    command: Some(ManageNeuronCommandRequest::MakeProposal(Box::new(
+                        MakeProposalRequest {
                             title: Some("Naming neuron 2.".to_string()),
                             summary: "".to_string(),
                             url: "".to_string(),
-                            action: Some(ProposalActionInput::RegisterKnownNeuron(KnownNeuron {
+                            action: Some(ProposalActionRequest::RegisterKnownNeuron(KnownNeuron {
                                 id: Some(NeuronId {
                                     id: TEST_NEURON_2_ID,
                                 }),
@@ -76,19 +76,19 @@ fn test_known_neurons() {
             .update_from_sender(
                 "manage_neuron",
                 candid_one,
-                ManageNeuronInput {
+                ManageNeuronRequest {
                     neuron_id_or_subaccount: Some(NeuronIdOrSubaccount::NeuronId(
                         ic_nns_common::pb::v1::NeuronId {
                             id: TEST_NEURON_1_ID,
                         },
                     )),
                     id: None,
-                    command: Some(ManageNeuronCommandInput::MakeProposal(Box::new(
-                        ProposalInput {
+                    command: Some(ManageNeuronCommandRequest::MakeProposal(Box::new(
+                        MakeProposalRequest {
                             title: Some("Naming neuron 3.".to_string()),
                             summary: "".to_string(),
                             url: "".to_string(),
-                            action: Some(ProposalActionInput::RegisterKnownNeuron(KnownNeuron {
+                            action: Some(ProposalActionRequest::RegisterKnownNeuron(KnownNeuron {
                                 id: Some(NeuronId {
                                     id: TEST_NEURON_3_ID,
                                 }),

--- a/rs/nns/integration_tests/src/known_neurons.rs
+++ b/rs/nns/integration_tests/src/known_neurons.rs
@@ -5,11 +5,10 @@ use ic_nervous_system_common_test_keys::{
 };
 use ic_nns_common::{pb::v1::NeuronId, types::ProposalId};
 use ic_nns_governance_api::pb::v1::{
-    manage_neuron::{Command, NeuronIdOrSubaccount},
-    manage_neuron_response::Command as CommandResponse,
-    proposal::Action,
-    GovernanceError, KnownNeuron, KnownNeuronData, ListKnownNeuronsResponse, ManageNeuron,
-    ManageNeuronResponse, NeuronInfo, Proposal, ProposalStatus,
+    manage_neuron::NeuronIdOrSubaccount, manage_neuron_response::Command as CommandResponse,
+    GovernanceError, KnownNeuron, KnownNeuronData, ListKnownNeuronsResponse, ManageNeuronResponse,
+    NeuronInfo, ManageNeuronInput, ManageNeuronCommandInput, ProposalInput, ProposalActionInput,
+    ProposalStatus,
 };
 use ic_nns_test_utils::{
     common::NnsInitPayloadsBuilder,
@@ -44,27 +43,29 @@ fn test_known_neurons() {
             .update_from_sender(
                 "manage_neuron",
                 candid_one,
-                ManageNeuron {
+                ManageNeuronInput {
                     neuron_id_or_subaccount: Some(NeuronIdOrSubaccount::NeuronId(
                         ic_nns_common::pb::v1::NeuronId {
                             id: TEST_NEURON_1_ID,
                         },
                     )),
                     id: None,
-                    command: Some(Command::MakeProposal(Box::new(Proposal {
-                        title: Some("Naming neuron 2.".to_string()),
-                        summary: "".to_string(),
-                        url: "".to_string(),
-                        action: Some(Action::RegisterKnownNeuron(KnownNeuron {
-                            id: Some(NeuronId {
-                                id: TEST_NEURON_2_ID,
-                            }),
-                            known_neuron_data: Some(KnownNeuronData {
-                                name: "NeuronTwo".to_string(),
-                                description: None,
-                            }),
-                        })),
-                    }))),
+                    command: Some(ManageNeuronCommandInput::MakeProposal(Box::new(
+                        ProposalInput {
+                            title: Some("Naming neuron 2.".to_string()),
+                            summary: "".to_string(),
+                            url: "".to_string(),
+                            action: Some(ProposalActionInput::RegisterKnownNeuron(KnownNeuron {
+                                id: Some(NeuronId {
+                                    id: TEST_NEURON_2_ID,
+                                }),
+                                known_neuron_data: Some(KnownNeuronData {
+                                    name: "NeuronTwo".to_string(),
+                                    description: None,
+                                }),
+                            })),
+                        },
+                    ))),
                 },
                 &Sender::from_keypair(&TEST_NEURON_1_OWNER_KEYPAIR),
             )
@@ -75,27 +76,29 @@ fn test_known_neurons() {
             .update_from_sender(
                 "manage_neuron",
                 candid_one,
-                ManageNeuron {
+                ManageNeuronInput {
                     neuron_id_or_subaccount: Some(NeuronIdOrSubaccount::NeuronId(
                         ic_nns_common::pb::v1::NeuronId {
                             id: TEST_NEURON_1_ID,
                         },
                     )),
                     id: None,
-                    command: Some(Command::MakeProposal(Box::new(Proposal {
-                        title: Some("Naming neuron 3.".to_string()),
-                        summary: "".to_string(),
-                        url: "".to_string(),
-                        action: Some(Action::RegisterKnownNeuron(KnownNeuron {
-                            id: Some(NeuronId {
-                                id: TEST_NEURON_3_ID,
-                            }),
-                            known_neuron_data: Some(KnownNeuronData {
-                                name: "NeuronThree".to_string(),
-                                description: None,
-                            }),
-                        })),
-                    }))),
+                    command: Some(ManageNeuronCommandInput::MakeProposal(Box::new(
+                        ProposalInput {
+                            title: Some("Naming neuron 3.".to_string()),
+                            summary: "".to_string(),
+                            url: "".to_string(),
+                            action: Some(ProposalActionInput::RegisterKnownNeuron(KnownNeuron {
+                                id: Some(NeuronId {
+                                    id: TEST_NEURON_3_ID,
+                                }),
+                                known_neuron_data: Some(KnownNeuronData {
+                                    name: "NeuronThree".to_string(),
+                                    description: None,
+                                }),
+                            })),
+                        },
+                    ))),
                 },
                 &Sender::from_keypair(&TEST_NEURON_1_OWNER_KEYPAIR),
             )

--- a/rs/nns/integration_tests/src/node_assignment.rs
+++ b/rs/nns/integration_tests/src/node_assignment.rs
@@ -6,12 +6,10 @@ use ic_nervous_system_common_test_keys::{
 };
 use ic_nns_common::types::{NeuronId, ProposalId};
 use ic_nns_governance_api::pb::v1::{
-    add_or_remove_node_provider::Change,
-    manage_neuron::{Command, NeuronIdOrSubaccount},
-    manage_neuron_response::Command as CommandResponse,
-    proposal::Action,
-    AddOrRemoveNodeProvider, ManageNeuron, ManageNeuronResponse, NnsFunction, NodeProvider,
-    Proposal, ProposalStatus,
+    add_or_remove_node_provider::Change, manage_neuron::NeuronIdOrSubaccount,
+    manage_neuron_response::Command as CommandResponse, AddOrRemoveNodeProvider,
+    ManageNeuronResponse, ManageNeuronInput, ManageNeuronCommandInput, ProposalInput, ProposalActionInput,
+    NnsFunction, NodeProvider, ProposalStatus,
 };
 use ic_nns_test_utils::{
     common::NnsInitPayloadsBuilder,
@@ -49,24 +47,28 @@ fn test_add_and_remove_nodes_from_registry() {
             .update_from_sender(
                 "manage_neuron",
                 candid_one,
-                ManageNeuron {
+                ManageNeuronInput {
                     neuron_id_or_subaccount: Some(NeuronIdOrSubaccount::NeuronId(
                         ic_nns_common::pb::v1::NeuronId {
                             id: TEST_NEURON_1_ID,
                         },
                     )),
                     id: None,
-                    command: Some(Command::MakeProposal(Box::new(Proposal {
-                        title: Some("Just want to add this NP.".to_string()),
-                        summary: "".to_string(),
-                        url: "".to_string(),
-                        action: Some(Action::AddOrRemoveNodeProvider(AddOrRemoveNodeProvider {
-                            change: Some(Change::ToAdd(NodeProvider {
-                                id: Some(*TEST_NEURON_1_OWNER_PRINCIPAL),
-                                reward_account: None,
-                            })),
-                        })),
-                    }))),
+                    command: Some(ManageNeuronCommandInput::MakeProposal(Box::new(
+                        ProposalInput {
+                            title: Some("Just want to add this NP.".to_string()),
+                            summary: "".to_string(),
+                            url: "".to_string(),
+                            action: Some(ProposalActionInput::AddOrRemoveNodeProvider(
+                                AddOrRemoveNodeProvider {
+                                    change: Some(Change::ToAdd(NodeProvider {
+                                        id: Some(*TEST_NEURON_1_OWNER_PRINCIPAL),
+                                        reward_account: None,
+                                    })),
+                                },
+                            )),
+                        },
+                    ))),
                 },
                 &Sender::from_keypair(&TEST_NEURON_1_OWNER_KEYPAIR),
             )

--- a/rs/nns/integration_tests/src/node_assignment.rs
+++ b/rs/nns/integration_tests/src/node_assignment.rs
@@ -8,7 +8,7 @@ use ic_nns_common::types::{NeuronId, ProposalId};
 use ic_nns_governance_api::pb::v1::{
     add_or_remove_node_provider::Change, manage_neuron::NeuronIdOrSubaccount,
     manage_neuron_response::Command as CommandResponse, AddOrRemoveNodeProvider,
-    ManageNeuronResponse, ManageNeuronInput, ManageNeuronCommandInput, ProposalInput, ProposalActionInput,
+    ManageNeuronResponse, ManageNeuronRequest, ManageNeuronCommandRequest, MakeProposalRequest, ProposalActionRequest,
     NnsFunction, NodeProvider, ProposalStatus,
 };
 use ic_nns_test_utils::{
@@ -47,19 +47,19 @@ fn test_add_and_remove_nodes_from_registry() {
             .update_from_sender(
                 "manage_neuron",
                 candid_one,
-                ManageNeuronInput {
+                ManageNeuronRequest {
                     neuron_id_or_subaccount: Some(NeuronIdOrSubaccount::NeuronId(
                         ic_nns_common::pb::v1::NeuronId {
                             id: TEST_NEURON_1_ID,
                         },
                     )),
                     id: None,
-                    command: Some(ManageNeuronCommandInput::MakeProposal(Box::new(
-                        ProposalInput {
+                    command: Some(ManageNeuronCommandRequest::MakeProposal(Box::new(
+                        MakeProposalRequest {
                             title: Some("Just want to add this NP.".to_string()),
                             summary: "".to_string(),
                             url: "".to_string(),
-                            action: Some(ProposalActionInput::AddOrRemoveNodeProvider(
+                            action: Some(ProposalActionRequest::AddOrRemoveNodeProvider(
                                 AddOrRemoveNodeProvider {
                                     change: Some(Change::ToAdd(NodeProvider {
                                         id: Some(*TEST_NEURON_1_OWNER_PRINCIPAL),

--- a/rs/nns/integration_tests/src/node_assignment.rs
+++ b/rs/nns/integration_tests/src/node_assignment.rs
@@ -8,8 +8,8 @@ use ic_nns_common::types::{NeuronId, ProposalId};
 use ic_nns_governance_api::pb::v1::{
     add_or_remove_node_provider::Change, manage_neuron::NeuronIdOrSubaccount,
     manage_neuron_response::Command as CommandResponse, AddOrRemoveNodeProvider,
-    ManageNeuronResponse, ManageNeuronRequest, ManageNeuronCommandRequest, MakeProposalRequest, ProposalActionRequest,
-    NnsFunction, NodeProvider, ProposalStatus,
+    MakeProposalRequest, ManageNeuronCommandRequest, ManageNeuronRequest, ManageNeuronResponse,
+    NnsFunction, NodeProvider, ProposalActionRequest, ProposalStatus,
 };
 use ic_nns_test_utils::{
     common::NnsInitPayloadsBuilder,

--- a/rs/nns/integration_tests/src/node_operator_handler.rs
+++ b/rs/nns/integration_tests/src/node_operator_handler.rs
@@ -10,8 +10,8 @@ use ic_nns_common::types::{NeuronId, ProposalId};
 use ic_nns_governance_api::pb::v1::{
     add_or_remove_node_provider::Change, manage_neuron::NeuronIdOrSubaccount,
     manage_neuron_response::Command as CommandResponse, AddOrRemoveNodeProvider,
-    ManageNeuronResponse, ManageNeuronInput, ManageNeuronCommandInput, ProposalInput, ProposalActionInput,
-    NnsFunction, NodeProvider, ProposalStatus,
+    ManageNeuronCommandRequest, ManageNeuronRequest, ManageNeuronResponse, NnsFunction, NodeProvider,
+    ProposalActionRequest, MakeProposalRequest, ProposalStatus,
 };
 use ic_nns_test_utils::{
     common::NnsInitPayloadsBuilder,
@@ -50,19 +50,19 @@ fn test_node_operator_records_can_be_added_and_removed() {
             .update_from_sender(
                 "manage_neuron",
                 candid_one,
-                ManageNeuronInput {
+                ManageNeuronRequest {
                     neuron_id_or_subaccount: Some(NeuronIdOrSubaccount::NeuronId(
                         ic_nns_common::pb::v1::NeuronId {
                             id: TEST_NEURON_1_ID,
                         },
                     )),
                     id: None,
-                    command: Some(ManageNeuronCommandInput::MakeProposal(Box::new(
-                        ProposalInput {
+                    command: Some(ManageNeuronCommandRequest::MakeProposal(Box::new(
+                        MakeProposalRequest {
                             title: Some("Just want to add this NP.".to_string()),
                             summary: "".to_string(),
                             url: "".to_string(),
-                            action: Some(ProposalActionInput::AddOrRemoveNodeProvider(
+                            action: Some(ProposalActionRequest::AddOrRemoveNodeProvider(
                                 AddOrRemoveNodeProvider {
                                     change: Some(Change::ToAdd(NodeProvider {
                                         id: Some(*TEST_NEURON_1_OWNER_PRINCIPAL),

--- a/rs/nns/integration_tests/src/node_operator_handler.rs
+++ b/rs/nns/integration_tests/src/node_operator_handler.rs
@@ -10,8 +10,8 @@ use ic_nns_common::types::{NeuronId, ProposalId};
 use ic_nns_governance_api::pb::v1::{
     add_or_remove_node_provider::Change, manage_neuron::NeuronIdOrSubaccount,
     manage_neuron_response::Command as CommandResponse, AddOrRemoveNodeProvider,
-    ManageNeuronCommandRequest, ManageNeuronRequest, ManageNeuronResponse, NnsFunction, NodeProvider,
-    ProposalActionRequest, MakeProposalRequest, ProposalStatus,
+    MakeProposalRequest, ManageNeuronCommandRequest, ManageNeuronRequest, ManageNeuronResponse,
+    NnsFunction, NodeProvider, ProposalActionRequest, ProposalStatus,
 };
 use ic_nns_test_utils::{
     common::NnsInitPayloadsBuilder,

--- a/rs/nns/integration_tests/src/node_operator_handler.rs
+++ b/rs/nns/integration_tests/src/node_operator_handler.rs
@@ -8,12 +8,10 @@ use ic_nervous_system_common_test_keys::{
 };
 use ic_nns_common::types::{NeuronId, ProposalId};
 use ic_nns_governance_api::pb::v1::{
-    add_or_remove_node_provider::Change,
-    manage_neuron::{Command, NeuronIdOrSubaccount},
-    manage_neuron_response::Command as CommandResponse,
-    proposal::Action,
-    AddOrRemoveNodeProvider, ManageNeuron, ManageNeuronResponse, NnsFunction, NodeProvider,
-    Proposal, ProposalStatus,
+    add_or_remove_node_provider::Change, manage_neuron::NeuronIdOrSubaccount,
+    manage_neuron_response::Command as CommandResponse, AddOrRemoveNodeProvider,
+    ManageNeuronResponse, ManageNeuronInput, ManageNeuronCommandInput, ProposalInput, ProposalActionInput,
+    NnsFunction, NodeProvider, ProposalStatus,
 };
 use ic_nns_test_utils::{
     common::NnsInitPayloadsBuilder,
@@ -52,24 +50,28 @@ fn test_node_operator_records_can_be_added_and_removed() {
             .update_from_sender(
                 "manage_neuron",
                 candid_one,
-                ManageNeuron {
+                ManageNeuronInput {
                     neuron_id_or_subaccount: Some(NeuronIdOrSubaccount::NeuronId(
                         ic_nns_common::pb::v1::NeuronId {
                             id: TEST_NEURON_1_ID,
                         },
                     )),
                     id: None,
-                    command: Some(Command::MakeProposal(Box::new(Proposal {
-                        title: Some("Just want to add this NP.".to_string()),
-                        summary: "".to_string(),
-                        url: "".to_string(),
-                        action: Some(Action::AddOrRemoveNodeProvider(AddOrRemoveNodeProvider {
-                            change: Some(Change::ToAdd(NodeProvider {
-                                id: Some(*TEST_NEURON_1_OWNER_PRINCIPAL),
-                                reward_account: None,
-                            })),
-                        })),
-                    }))),
+                    command: Some(ManageNeuronCommandInput::MakeProposal(Box::new(
+                        ProposalInput {
+                            title: Some("Just want to add this NP.".to_string()),
+                            summary: "".to_string(),
+                            url: "".to_string(),
+                            action: Some(ProposalActionInput::AddOrRemoveNodeProvider(
+                                AddOrRemoveNodeProvider {
+                                    change: Some(Change::ToAdd(NodeProvider {
+                                        id: Some(*TEST_NEURON_1_OWNER_PRINCIPAL),
+                                        reward_account: None,
+                                    })),
+                                },
+                            )),
+                        },
+                    ))),
                 },
                 &Sender::from_keypair(&TEST_NEURON_1_OWNER_KEYPAIR),
             )

--- a/rs/nns/integration_tests/src/node_provider_remuneration.rs
+++ b/rs/nns/integration_tests/src/node_provider_remuneration.rs
@@ -13,10 +13,9 @@ use ic_nns_constants::{CYCLES_MINTING_CANISTER_ID, GOVERNANCE_CANISTER_ID, LEDGE
 use ic_nns_governance_api::pb::v1::{
     add_or_remove_node_provider::Change,
     manage_neuron_response::Command as CommandResponse,
-    proposal::Action,
     reward_node_provider::{RewardMode, RewardToAccount},
-    AddOrRemoveNodeProvider, ExecuteNnsFunction, GovernanceError, NetworkEconomics, NnsFunction,
-    NodeProvider, Proposal, RewardNodeProvider, RewardNodeProviders,
+    AddOrRemoveNodeProvider, ExecuteNnsFunction, GovernanceError, NetworkEconomics, ProposalInput,
+    ProposalActionInput, NnsFunction, NodeProvider, RewardNodeProvider, RewardNodeProviders,
 };
 use ic_nns_test_utils::{
     common::NnsInitPayloadsBuilder,
@@ -466,14 +465,14 @@ fn test_automated_node_provider_remuneration() {
 }
 
 /// Helper function for making NNS proposals for this test
-fn submit_nns_proposal(state_machine: &StateMachine, action: Action) {
+fn submit_nns_proposal(state_machine: &StateMachine, action: ProposalActionInput) {
     let response = nns_governance_make_proposal(
         state_machine,
         Sender::from_keypair(&TEST_NEURON_1_OWNER_KEYPAIR).get_principal_id(),
         ProtoNeuronId {
             id: TEST_NEURON_1_ID,
         },
-        &Proposal {
+        &ProposalInput {
             title: Some(
                 "<proposal created by test_automated_node_provider_remuneration>".to_string(),
             ),
@@ -577,7 +576,7 @@ fn assert_account_balance(state_machine: &StateMachine, account: AccountIdentifi
 fn reward_node_providers_via_registry(state_machine: &StateMachine) {
     submit_nns_proposal(
         state_machine,
-        Action::RewardNodeProviders(RewardNodeProviders {
+        ProposalActionInput::RewardNodeProviders(RewardNodeProviders {
             rewards: vec![],
             use_registry_derived_rewards: Some(true),
         }),
@@ -613,7 +612,7 @@ fn add_data_centers(state_machine: &StateMachine) {
     };
     submit_nns_proposal(
         state_machine,
-        Action::ExecuteNnsFunction(ExecuteNnsFunction {
+        ProposalActionInput::ExecuteNnsFunction(ExecuteNnsFunction {
             nns_function: NnsFunction::AddOrRemoveDataCenters as i32,
             payload: Encode!(&payload).unwrap(),
         }),
@@ -669,7 +668,7 @@ fn add_node_rewards_table(state_machine: &StateMachine) {
 
     submit_nns_proposal(
         state_machine,
-        Action::ExecuteNnsFunction(ExecuteNnsFunction {
+        ProposalActionInput::ExecuteNnsFunction(ExecuteNnsFunction {
             nns_function: NnsFunction::UpdateNodeRewardsTable as i32,
             payload: Encode!(&payload).unwrap(),
         }),
@@ -679,7 +678,7 @@ fn add_node_rewards_table(state_machine: &StateMachine) {
 fn add_node_provider(state_machine: &StateMachine, node_provider: NodeProvider) {
     submit_nns_proposal(
         state_machine,
-        Action::AddOrRemoveNodeProvider(AddOrRemoveNodeProvider {
+        ProposalActionInput::AddOrRemoveNodeProvider(AddOrRemoveNodeProvider {
             change: Some(Change::ToAdd(node_provider)),
         }),
     );
@@ -705,7 +704,7 @@ fn add_node_operator(
 
     submit_nns_proposal(
         state_machine,
-        Action::ExecuteNnsFunction(ExecuteNnsFunction {
+        ProposalActionInput::ExecuteNnsFunction(ExecuteNnsFunction {
             nns_function: NnsFunction::AssignNoid as i32,
             payload: Encode!(&payload).unwrap(),
         }),

--- a/rs/nns/integration_tests/src/node_provider_remuneration.rs
+++ b/rs/nns/integration_tests/src/node_provider_remuneration.rs
@@ -14,8 +14,9 @@ use ic_nns_governance_api::pb::v1::{
     add_or_remove_node_provider::Change,
     manage_neuron_response::Command as CommandResponse,
     reward_node_provider::{RewardMode, RewardToAccount},
-    AddOrRemoveNodeProvider, ExecuteNnsFunction, GovernanceError, NetworkEconomics, MakeProposalRequest,
-    ProposalActionRequest, NnsFunction, NodeProvider, RewardNodeProvider, RewardNodeProviders,
+    AddOrRemoveNodeProvider, ExecuteNnsFunction, GovernanceError, MakeProposalRequest,
+    NetworkEconomics, NnsFunction, NodeProvider, ProposalActionRequest, RewardNodeProvider,
+    RewardNodeProviders,
 };
 use ic_nns_test_utils::{
     common::NnsInitPayloadsBuilder,

--- a/rs/nns/integration_tests/src/node_provider_remuneration.rs
+++ b/rs/nns/integration_tests/src/node_provider_remuneration.rs
@@ -14,8 +14,8 @@ use ic_nns_governance_api::pb::v1::{
     add_or_remove_node_provider::Change,
     manage_neuron_response::Command as CommandResponse,
     reward_node_provider::{RewardMode, RewardToAccount},
-    AddOrRemoveNodeProvider, ExecuteNnsFunction, GovernanceError, NetworkEconomics, ProposalInput,
-    ProposalActionInput, NnsFunction, NodeProvider, RewardNodeProvider, RewardNodeProviders,
+    AddOrRemoveNodeProvider, ExecuteNnsFunction, GovernanceError, NetworkEconomics, MakeProposalRequest,
+    ProposalActionRequest, NnsFunction, NodeProvider, RewardNodeProvider, RewardNodeProviders,
 };
 use ic_nns_test_utils::{
     common::NnsInitPayloadsBuilder,
@@ -465,14 +465,14 @@ fn test_automated_node_provider_remuneration() {
 }
 
 /// Helper function for making NNS proposals for this test
-fn submit_nns_proposal(state_machine: &StateMachine, action: ProposalActionInput) {
+fn submit_nns_proposal(state_machine: &StateMachine, action: ProposalActionRequest) {
     let response = nns_governance_make_proposal(
         state_machine,
         Sender::from_keypair(&TEST_NEURON_1_OWNER_KEYPAIR).get_principal_id(),
         ProtoNeuronId {
             id: TEST_NEURON_1_ID,
         },
-        &ProposalInput {
+        &MakeProposalRequest {
             title: Some(
                 "<proposal created by test_automated_node_provider_remuneration>".to_string(),
             ),
@@ -576,7 +576,7 @@ fn assert_account_balance(state_machine: &StateMachine, account: AccountIdentifi
 fn reward_node_providers_via_registry(state_machine: &StateMachine) {
     submit_nns_proposal(
         state_machine,
-        ProposalActionInput::RewardNodeProviders(RewardNodeProviders {
+        ProposalActionRequest::RewardNodeProviders(RewardNodeProviders {
             rewards: vec![],
             use_registry_derived_rewards: Some(true),
         }),
@@ -612,7 +612,7 @@ fn add_data_centers(state_machine: &StateMachine) {
     };
     submit_nns_proposal(
         state_machine,
-        ProposalActionInput::ExecuteNnsFunction(ExecuteNnsFunction {
+        ProposalActionRequest::ExecuteNnsFunction(ExecuteNnsFunction {
             nns_function: NnsFunction::AddOrRemoveDataCenters as i32,
             payload: Encode!(&payload).unwrap(),
         }),
@@ -668,7 +668,7 @@ fn add_node_rewards_table(state_machine: &StateMachine) {
 
     submit_nns_proposal(
         state_machine,
-        ProposalActionInput::ExecuteNnsFunction(ExecuteNnsFunction {
+        ProposalActionRequest::ExecuteNnsFunction(ExecuteNnsFunction {
             nns_function: NnsFunction::UpdateNodeRewardsTable as i32,
             payload: Encode!(&payload).unwrap(),
         }),
@@ -678,7 +678,7 @@ fn add_node_rewards_table(state_machine: &StateMachine) {
 fn add_node_provider(state_machine: &StateMachine, node_provider: NodeProvider) {
     submit_nns_proposal(
         state_machine,
-        ProposalActionInput::AddOrRemoveNodeProvider(AddOrRemoveNodeProvider {
+        ProposalActionRequest::AddOrRemoveNodeProvider(AddOrRemoveNodeProvider {
             change: Some(Change::ToAdd(node_provider)),
         }),
     );
@@ -704,7 +704,7 @@ fn add_node_operator(
 
     submit_nns_proposal(
         state_machine,
-        ProposalActionInput::ExecuteNnsFunction(ExecuteNnsFunction {
+        ProposalActionRequest::ExecuteNnsFunction(ExecuteNnsFunction {
             nns_function: NnsFunction::AssignNoid as i32,
             payload: Encode!(&payload).unwrap(),
         }),

--- a/rs/nns/integration_tests/src/rewards.rs
+++ b/rs/nns/integration_tests/src/rewards.rs
@@ -8,12 +8,11 @@ use ic_nervous_system_common_test_keys::{
 use ic_nns_common::{pb::v1::NeuronId, types::ProposalId};
 use ic_nns_governance_api::pb::v1::{
     add_or_remove_node_provider::Change,
-    manage_neuron::{Command, NeuronIdOrSubaccount},
+    manage_neuron::NeuronIdOrSubaccount,
     manage_neuron_response::Command as CommandResponse,
-    proposal::Action,
     reward_node_provider::{RewardMode, RewardToAccount},
-    AddOrRemoveNodeProvider, ManageNeuron, ManageNeuronResponse, NodeProvider, Proposal,
-    ProposalStatus, RewardNodeProvider,
+    AddOrRemoveNodeProvider, ManageNeuronResponse, ManageNeuronInput, ManageNeuronCommandInput,
+    ProposalInput, ProposalActionInput, NodeProvider, ProposalStatus, RewardNodeProvider,
 };
 use ic_nns_test_utils::{
     common::NnsInitPayloadsBuilder,
@@ -55,22 +54,26 @@ fn test_node_provider_rewards() {
             .update_from_sender(
                 "manage_neuron",
                 candid_one,
-                ManageNeuron {
+                ManageNeuronInput {
                     neuron_id_or_subaccount: Some(NeuronIdOrSubaccount::NeuronId(NeuronId {
                         id: TEST_NEURON_1_ID,
                     })),
                     id: None,
-                    command: Some(Command::MakeProposal(Box::new(Proposal {
-                        title: Some("Just want to add this NP.".to_string()),
-                        summary: "".to_string(),
-                        url: "".to_string(),
-                        action: Some(Action::AddOrRemoveNodeProvider(AddOrRemoveNodeProvider {
-                            change: Some(Change::ToAdd(NodeProvider {
-                                id: Some(np_pid),
-                                reward_account: None,
-                            })),
-                        })),
-                    }))),
+                    command: Some(ManageNeuronCommandInput::MakeProposal(Box::new(
+                        ProposalInput {
+                            title: Some("Just want to add this NP.".to_string()),
+                            summary: "".to_string(),
+                            url: "".to_string(),
+                            action: Some(ProposalActionInput::AddOrRemoveNodeProvider(
+                                AddOrRemoveNodeProvider {
+                                    change: Some(Change::ToAdd(NodeProvider {
+                                        id: Some(np_pid),
+                                        reward_account: None,
+                                    })),
+                                },
+                            )),
+                        },
+                    ))),
                 },
                 &user,
             )
@@ -109,26 +112,32 @@ fn test_node_provider_rewards() {
             .update_from_sender(
                 "manage_neuron",
                 candid_one,
-                ManageNeuron {
+                ManageNeuronInput {
                     neuron_id_or_subaccount: Some(NeuronIdOrSubaccount::NeuronId(NeuronId {
                         id: TEST_NEURON_1_ID,
                     })),
                     id: None,
-                    command: Some(Command::MakeProposal(Box::new(Proposal {
-                        title: Some("Just want to add this NP.".to_string()),
-                        summary: "".to_string(),
-                        url: "".to_string(),
-                        action: Some(Action::RewardNodeProvider(RewardNodeProvider {
-                            node_provider: Some(NodeProvider {
-                                id: Some(np_pid),
-                                reward_account: None,
-                            }),
-                            amount_e8s: 234 * 100_000_000,
-                            reward_mode: Some(RewardMode::RewardToAccount(RewardToAccount {
-                                to_account: Some(to_account.into()),
-                            })),
-                        })),
-                    }))),
+                    command: Some(ManageNeuronCommandInput::MakeProposal(Box::new(
+                        ProposalInput {
+                            title: Some("Just want to add this NP.".to_string()),
+                            summary: "".to_string(),
+                            url: "".to_string(),
+                            action: Some(ProposalActionInput::RewardNodeProvider(
+                                RewardNodeProvider {
+                                    node_provider: Some(NodeProvider {
+                                        id: Some(np_pid),
+                                        reward_account: None,
+                                    }),
+                                    amount_e8s: 234 * 100_000_000,
+                                    reward_mode: Some(RewardMode::RewardToAccount(
+                                        RewardToAccount {
+                                            to_account: Some(to_account.into()),
+                                        },
+                                    )),
+                                },
+                            )),
+                        },
+                    ))),
                 },
                 &user,
             )

--- a/rs/nns/integration_tests/src/rewards.rs
+++ b/rs/nns/integration_tests/src/rewards.rs
@@ -11,8 +11,8 @@ use ic_nns_governance_api::pb::v1::{
     manage_neuron::NeuronIdOrSubaccount,
     manage_neuron_response::Command as CommandResponse,
     reward_node_provider::{RewardMode, RewardToAccount},
-    AddOrRemoveNodeProvider, ManageNeuronResponse, ManageNeuronRequest, ManageNeuronCommandRequest,
-    MakeProposalRequest, ProposalActionRequest, NodeProvider, ProposalStatus, RewardNodeProvider,
+    AddOrRemoveNodeProvider, MakeProposalRequest, ManageNeuronCommandRequest, ManageNeuronRequest,
+    ManageNeuronResponse, NodeProvider, ProposalActionRequest, ProposalStatus, RewardNodeProvider,
 };
 use ic_nns_test_utils::{
     common::NnsInitPayloadsBuilder,

--- a/rs/nns/integration_tests/src/rewards.rs
+++ b/rs/nns/integration_tests/src/rewards.rs
@@ -11,8 +11,8 @@ use ic_nns_governance_api::pb::v1::{
     manage_neuron::NeuronIdOrSubaccount,
     manage_neuron_response::Command as CommandResponse,
     reward_node_provider::{RewardMode, RewardToAccount},
-    AddOrRemoveNodeProvider, ManageNeuronResponse, ManageNeuronInput, ManageNeuronCommandInput,
-    ProposalInput, ProposalActionInput, NodeProvider, ProposalStatus, RewardNodeProvider,
+    AddOrRemoveNodeProvider, ManageNeuronResponse, ManageNeuronRequest, ManageNeuronCommandRequest,
+    MakeProposalRequest, ProposalActionRequest, NodeProvider, ProposalStatus, RewardNodeProvider,
 };
 use ic_nns_test_utils::{
     common::NnsInitPayloadsBuilder,
@@ -54,17 +54,17 @@ fn test_node_provider_rewards() {
             .update_from_sender(
                 "manage_neuron",
                 candid_one,
-                ManageNeuronInput {
+                ManageNeuronRequest {
                     neuron_id_or_subaccount: Some(NeuronIdOrSubaccount::NeuronId(NeuronId {
                         id: TEST_NEURON_1_ID,
                     })),
                     id: None,
-                    command: Some(ManageNeuronCommandInput::MakeProposal(Box::new(
-                        ProposalInput {
+                    command: Some(ManageNeuronCommandRequest::MakeProposal(Box::new(
+                        MakeProposalRequest {
                             title: Some("Just want to add this NP.".to_string()),
                             summary: "".to_string(),
                             url: "".to_string(),
-                            action: Some(ProposalActionInput::AddOrRemoveNodeProvider(
+                            action: Some(ProposalActionRequest::AddOrRemoveNodeProvider(
                                 AddOrRemoveNodeProvider {
                                     change: Some(Change::ToAdd(NodeProvider {
                                         id: Some(np_pid),
@@ -112,17 +112,17 @@ fn test_node_provider_rewards() {
             .update_from_sender(
                 "manage_neuron",
                 candid_one,
-                ManageNeuronInput {
+                ManageNeuronRequest {
                     neuron_id_or_subaccount: Some(NeuronIdOrSubaccount::NeuronId(NeuronId {
                         id: TEST_NEURON_1_ID,
                     })),
                     id: None,
-                    command: Some(ManageNeuronCommandInput::MakeProposal(Box::new(
-                        ProposalInput {
+                    command: Some(ManageNeuronCommandRequest::MakeProposal(Box::new(
+                        MakeProposalRequest {
                             title: Some("Just want to add this NP.".to_string()),
                             summary: "".to_string(),
                             url: "".to_string(),
-                            action: Some(ProposalActionInput::RewardNodeProvider(
+                            action: Some(ProposalActionRequest::RewardNodeProvider(
                                 RewardNodeProvider {
                                     node_provider: Some(NodeProvider {
                                         id: Some(np_pid),

--- a/rs/nns/integration_tests/src/stop_or_start_canister.rs
+++ b/rs/nns/integration_tests/src/stop_or_start_canister.rs
@@ -6,8 +6,8 @@ use ic_nervous_system_root::change_canister::{
 };
 use ic_nns_constants::{REGISTRY_CANISTER_ID, ROOT_CANISTER_ID};
 use ic_nns_governance_api::pb::v1::{
-    manage_neuron_response::Command, proposal::Action, stop_or_start_canister::CanisterAction,
-    ExecuteNnsFunction, NnsFunction, Proposal, StopOrStartCanister,
+    manage_neuron_response::Command, stop_or_start_canister::CanisterAction, ExecuteNnsFunction,
+    ProposalInput, ProposalActionInput, NnsFunction, StopOrStartCanister,
 };
 use ic_nns_test_utils::{
     common::NnsInitPayloadsBuilder,
@@ -39,7 +39,7 @@ fn test_stop_and_start_registry_canister(use_proposal_action: bool) {
 
     // Step 3: Make a proposal to stop the canister and wait for it to be executed.
     let action = if use_proposal_action {
-        Action::StopOrStartCanister(StopOrStartCanister {
+        ProposalActionInput::StopOrStartCanister(StopOrStartCanister {
             canister_id: Some(REGISTRY_CANISTER_ID.get()),
             action: Some(CanisterAction::Stop as i32),
         })
@@ -48,7 +48,7 @@ fn test_stop_and_start_registry_canister(use_proposal_action: bool) {
             canister_id: REGISTRY_CANISTER_ID,
             action: RootCanisterAction::Stop,
         };
-        Action::ExecuteNnsFunction(ExecuteNnsFunction {
+        ProposalActionInput::ExecuteNnsFunction(ExecuteNnsFunction {
             nns_function: NnsFunction::StopOrStartNnsCanister as i32,
             payload: Encode!(&stop_or_start_request).unwrap(),
         })
@@ -57,7 +57,7 @@ fn test_stop_and_start_registry_canister(use_proposal_action: bool) {
         &state_machine,
         n1.principal_id,
         n1.neuron_id,
-        &Proposal {
+        &ProposalInput {
             title: Some("Stop registry canister".to_string()),
             action: Some(action),
             ..Default::default()
@@ -74,7 +74,7 @@ fn test_stop_and_start_registry_canister(use_proposal_action: bool) {
 
     // Step 5: Make a proposal to start the canister and wait for it to be executed.
     let action = if use_proposal_action {
-        Action::StopOrStartCanister(StopOrStartCanister {
+        ProposalActionInput::StopOrStartCanister(StopOrStartCanister {
             canister_id: Some(REGISTRY_CANISTER_ID.get()),
             action: Some(CanisterAction::Start as i32),
         })
@@ -83,7 +83,7 @@ fn test_stop_and_start_registry_canister(use_proposal_action: bool) {
             canister_id: REGISTRY_CANISTER_ID,
             action: RootCanisterAction::Start,
         };
-        Action::ExecuteNnsFunction(ExecuteNnsFunction {
+        ProposalActionInput::ExecuteNnsFunction(ExecuteNnsFunction {
             nns_function: NnsFunction::StopOrStartNnsCanister as i32,
             payload: Encode!(&stop_or_start_request).unwrap(),
         })
@@ -92,7 +92,7 @@ fn test_stop_and_start_registry_canister(use_proposal_action: bool) {
         &state_machine,
         n1.principal_id,
         n1.neuron_id,
-        &Proposal {
+        &ProposalInput {
             title: Some("Start registry canister".to_string()),
             action: Some(action),
             ..Default::default()

--- a/rs/nns/integration_tests/src/stop_or_start_canister.rs
+++ b/rs/nns/integration_tests/src/stop_or_start_canister.rs
@@ -7,7 +7,7 @@ use ic_nervous_system_root::change_canister::{
 use ic_nns_constants::{REGISTRY_CANISTER_ID, ROOT_CANISTER_ID};
 use ic_nns_governance_api::pb::v1::{
     manage_neuron_response::Command, stop_or_start_canister::CanisterAction, ExecuteNnsFunction,
-    ProposalInput, ProposalActionInput, NnsFunction, StopOrStartCanister,
+    MakeProposalRequest, ProposalActionRequest, NnsFunction, StopOrStartCanister,
 };
 use ic_nns_test_utils::{
     common::NnsInitPayloadsBuilder,
@@ -39,7 +39,7 @@ fn test_stop_and_start_registry_canister(use_proposal_action: bool) {
 
     // Step 3: Make a proposal to stop the canister and wait for it to be executed.
     let action = if use_proposal_action {
-        ProposalActionInput::StopOrStartCanister(StopOrStartCanister {
+        ProposalActionRequest::StopOrStartCanister(StopOrStartCanister {
             canister_id: Some(REGISTRY_CANISTER_ID.get()),
             action: Some(CanisterAction::Stop as i32),
         })
@@ -48,7 +48,7 @@ fn test_stop_and_start_registry_canister(use_proposal_action: bool) {
             canister_id: REGISTRY_CANISTER_ID,
             action: RootCanisterAction::Stop,
         };
-        ProposalActionInput::ExecuteNnsFunction(ExecuteNnsFunction {
+        ProposalActionRequest::ExecuteNnsFunction(ExecuteNnsFunction {
             nns_function: NnsFunction::StopOrStartNnsCanister as i32,
             payload: Encode!(&stop_or_start_request).unwrap(),
         })
@@ -57,7 +57,7 @@ fn test_stop_and_start_registry_canister(use_proposal_action: bool) {
         &state_machine,
         n1.principal_id,
         n1.neuron_id,
-        &ProposalInput {
+        &MakeProposalRequest {
             title: Some("Stop registry canister".to_string()),
             action: Some(action),
             ..Default::default()
@@ -74,7 +74,7 @@ fn test_stop_and_start_registry_canister(use_proposal_action: bool) {
 
     // Step 5: Make a proposal to start the canister and wait for it to be executed.
     let action = if use_proposal_action {
-        ProposalActionInput::StopOrStartCanister(StopOrStartCanister {
+        ProposalActionRequest::StopOrStartCanister(StopOrStartCanister {
             canister_id: Some(REGISTRY_CANISTER_ID.get()),
             action: Some(CanisterAction::Start as i32),
         })
@@ -83,7 +83,7 @@ fn test_stop_and_start_registry_canister(use_proposal_action: bool) {
             canister_id: REGISTRY_CANISTER_ID,
             action: RootCanisterAction::Start,
         };
-        ProposalActionInput::ExecuteNnsFunction(ExecuteNnsFunction {
+        ProposalActionRequest::ExecuteNnsFunction(ExecuteNnsFunction {
             nns_function: NnsFunction::StopOrStartNnsCanister as i32,
             payload: Encode!(&stop_or_start_request).unwrap(),
         })
@@ -92,7 +92,7 @@ fn test_stop_and_start_registry_canister(use_proposal_action: bool) {
         &state_machine,
         n1.principal_id,
         n1.neuron_id,
-        &ProposalInput {
+        &MakeProposalRequest {
             title: Some("Start registry canister".to_string()),
             action: Some(action),
             ..Default::default()

--- a/rs/nns/integration_tests/src/stop_or_start_canister.rs
+++ b/rs/nns/integration_tests/src/stop_or_start_canister.rs
@@ -7,7 +7,7 @@ use ic_nervous_system_root::change_canister::{
 use ic_nns_constants::{REGISTRY_CANISTER_ID, ROOT_CANISTER_ID};
 use ic_nns_governance_api::pb::v1::{
     manage_neuron_response::Command, stop_or_start_canister::CanisterAction, ExecuteNnsFunction,
-    MakeProposalRequest, ProposalActionRequest, NnsFunction, StopOrStartCanister,
+    MakeProposalRequest, NnsFunction, ProposalActionRequest, StopOrStartCanister,
 };
 use ic_nns_test_utils::{
     common::NnsInitPayloadsBuilder,

--- a/rs/nns/integration_tests/src/subnet_rental_canister.rs
+++ b/rs/nns/integration_tests/src/subnet_rental_canister.rs
@@ -8,7 +8,7 @@ use ic_nns_constants::{
 };
 use ic_nns_governance_api::pb::v1::{
     manage_neuron_response::{Command as CommandResponse, RegisterVoteResponse},
-    ExecuteNnsFunction, ProposalInput, ProposalActionInput, NnsFunction, Vote,
+    ExecuteNnsFunction, MakeProposalRequest, ProposalActionRequest, NnsFunction, Vote,
 };
 use ic_nns_test_utils::{
     common::NnsInitPayloadsBuilder,
@@ -245,11 +245,11 @@ fn subnet_rental_request_lifecycle() {
         user: renter,
         rental_condition_id: RentalConditionId::App13CH,
     };
-    let proposal = ProposalInput {
+    let proposal = MakeProposalRequest {
         title: Some("Create subnet rental request".to_string()),
         summary: "".to_string(),
         url: "".to_string(),
-        action: Some(ProposalActionInput::ExecuteNnsFunction(ExecuteNnsFunction {
+        action: Some(ProposalActionRequest::ExecuteNnsFunction(ExecuteNnsFunction {
             nns_function: NnsFunction::SubnetRentalRequest as i32,
             payload: Encode!(&subnet_rental_request).expect("Error encoding proposal payload"),
         })),
@@ -395,11 +395,11 @@ fn test_renting_a_subnet_without_paying_fails() {
         user: renter,
         rental_condition_id: RentalConditionId::App13CH,
     };
-    let proposal = ProposalInput {
+    let proposal = MakeProposalRequest {
         title: Some("Create subnet rental request".to_string()),
         summary: "".to_string(),
         url: "".to_string(),
-        action: Some(ProposalActionInput::ExecuteNnsFunction(ExecuteNnsFunction {
+        action: Some(ProposalActionRequest::ExecuteNnsFunction(ExecuteNnsFunction {
             nns_function: NnsFunction::SubnetRentalRequest as i32,
             payload: Encode!(&subnet_rental_request).expect("Error encoding proposal payload"),
         })),

--- a/rs/nns/integration_tests/src/subnet_rental_canister.rs
+++ b/rs/nns/integration_tests/src/subnet_rental_canister.rs
@@ -8,8 +8,7 @@ use ic_nns_constants::{
 };
 use ic_nns_governance_api::pb::v1::{
     manage_neuron_response::{Command as CommandResponse, RegisterVoteResponse},
-    proposal::Action,
-    ExecuteNnsFunction, NnsFunction, Proposal, Vote,
+    ExecuteNnsFunction, ProposalInput, ProposalActionInput, NnsFunction, Vote,
 };
 use ic_nns_test_utils::{
     common::NnsInitPayloadsBuilder,
@@ -246,11 +245,11 @@ fn subnet_rental_request_lifecycle() {
         user: renter,
         rental_condition_id: RentalConditionId::App13CH,
     };
-    let proposal = Proposal {
+    let proposal = ProposalInput {
         title: Some("Create subnet rental request".to_string()),
         summary: "".to_string(),
         url: "".to_string(),
-        action: Some(Action::ExecuteNnsFunction(ExecuteNnsFunction {
+        action: Some(ProposalActionInput::ExecuteNnsFunction(ExecuteNnsFunction {
             nns_function: NnsFunction::SubnetRentalRequest as i32,
             payload: Encode!(&subnet_rental_request).expect("Error encoding proposal payload"),
         })),
@@ -396,11 +395,11 @@ fn test_renting_a_subnet_without_paying_fails() {
         user: renter,
         rental_condition_id: RentalConditionId::App13CH,
     };
-    let proposal = Proposal {
+    let proposal = ProposalInput {
         title: Some("Create subnet rental request".to_string()),
         summary: "".to_string(),
         url: "".to_string(),
-        action: Some(Action::ExecuteNnsFunction(ExecuteNnsFunction {
+        action: Some(ProposalActionInput::ExecuteNnsFunction(ExecuteNnsFunction {
             nns_function: NnsFunction::SubnetRentalRequest as i32,
             payload: Encode!(&subnet_rental_request).expect("Error encoding proposal payload"),
         })),

--- a/rs/nns/integration_tests/src/subnet_rental_canister.rs
+++ b/rs/nns/integration_tests/src/subnet_rental_canister.rs
@@ -8,7 +8,7 @@ use ic_nns_constants::{
 };
 use ic_nns_governance_api::pb::v1::{
     manage_neuron_response::{Command as CommandResponse, RegisterVoteResponse},
-    ExecuteNnsFunction, MakeProposalRequest, ProposalActionRequest, NnsFunction, Vote,
+    ExecuteNnsFunction, MakeProposalRequest, NnsFunction, ProposalActionRequest, Vote,
 };
 use ic_nns_test_utils::{
     common::NnsInitPayloadsBuilder,
@@ -249,10 +249,12 @@ fn subnet_rental_request_lifecycle() {
         title: Some("Create subnet rental request".to_string()),
         summary: "".to_string(),
         url: "".to_string(),
-        action: Some(ProposalActionRequest::ExecuteNnsFunction(ExecuteNnsFunction {
-            nns_function: NnsFunction::SubnetRentalRequest as i32,
-            payload: Encode!(&subnet_rental_request).expect("Error encoding proposal payload"),
-        })),
+        action: Some(ProposalActionRequest::ExecuteNnsFunction(
+            ExecuteNnsFunction {
+                nns_function: NnsFunction::SubnetRentalRequest as i32,
+                payload: Encode!(&subnet_rental_request).expect("Error encoding proposal payload"),
+            },
+        )),
     };
     // Make proposal with small neuron. It does not have enough voting power such that the proposal would be adopted immediately.
     let cmd = nns_governance_make_proposal(
@@ -399,10 +401,12 @@ fn test_renting_a_subnet_without_paying_fails() {
         title: Some("Create subnet rental request".to_string()),
         summary: "".to_string(),
         url: "".to_string(),
-        action: Some(ProposalActionRequest::ExecuteNnsFunction(ExecuteNnsFunction {
-            nns_function: NnsFunction::SubnetRentalRequest as i32,
-            payload: Encode!(&subnet_rental_request).expect("Error encoding proposal payload"),
-        })),
+        action: Some(ProposalActionRequest::ExecuteNnsFunction(
+            ExecuteNnsFunction {
+                nns_function: NnsFunction::SubnetRentalRequest as i32,
+                payload: Encode!(&subnet_rental_request).expect("Error encoding proposal payload"),
+            },
+        )),
     };
     // Make proposal with large neuron. It has enough voting power such that the proposal will be adopted immediately.
     let cmd = nns_governance_make_proposal(

--- a/rs/nns/integration_tests/src/uninstall_canister_by_proposal.rs
+++ b/rs/nns/integration_tests/src/uninstall_canister_by_proposal.rs
@@ -4,7 +4,7 @@ use ic_nervous_system_clients::canister_id_record::CanisterIdRecord;
 use ic_nns_constants::LIFELINE_CANISTER_INDEX_IN_NNS_SUBNET;
 use ic_nns_governance_api::pb::v1::{
     manage_neuron_response::{Command, MakeProposalResponse},
-    ExecuteNnsFunction, MakeProposalRequest, ProposalActionRequest, NnsFunction,
+    ExecuteNnsFunction, MakeProposalRequest, NnsFunction, ProposalActionRequest,
 };
 use ic_nns_test_utils::{
     common::NnsInitPayloadsBuilder,
@@ -53,11 +53,13 @@ fn uninstall_canister_by_proposal() {
         title: Some("<proposal to uninstall an NNS canister>".to_string()),
         summary: "".to_string(),
         url: "".to_string(),
-        action: Some(ProposalActionRequest::ExecuteNnsFunction(ExecuteNnsFunction {
-            nns_function: NnsFunction::UninstallCode as i32,
-            payload: Encode!(&CanisterIdRecord { canister_id })
-                .expect("Error encoding proposal payload"),
-        })),
+        action: Some(ProposalActionRequest::ExecuteNnsFunction(
+            ExecuteNnsFunction {
+                nns_function: NnsFunction::UninstallCode as i32,
+                payload: Encode!(&CanisterIdRecord { canister_id })
+                    .expect("Error encoding proposal payload"),
+            },
+        )),
     };
     // To make a proposal we need a neuron
     let n1 = get_neuron_1();

--- a/rs/nns/integration_tests/src/uninstall_canister_by_proposal.rs
+++ b/rs/nns/integration_tests/src/uninstall_canister_by_proposal.rs
@@ -4,7 +4,7 @@ use ic_nervous_system_clients::canister_id_record::CanisterIdRecord;
 use ic_nns_constants::LIFELINE_CANISTER_INDEX_IN_NNS_SUBNET;
 use ic_nns_governance_api::pb::v1::{
     manage_neuron_response::{Command, MakeProposalResponse},
-    ExecuteNnsFunction, ProposalInput, ProposalActionInput, NnsFunction,
+    ExecuteNnsFunction, MakeProposalRequest, ProposalActionRequest, NnsFunction,
 };
 use ic_nns_test_utils::{
     common::NnsInitPayloadsBuilder,
@@ -49,11 +49,11 @@ fn uninstall_canister_by_proposal() {
     let status = get_canister_status_from_root(&state_machine, canister_id);
     assert!(status.module_hash.is_some());
     // Prepare a proposal to uninstall canister code
-    let proposal = ProposalInput {
+    let proposal = MakeProposalRequest {
         title: Some("<proposal to uninstall an NNS canister>".to_string()),
         summary: "".to_string(),
         url: "".to_string(),
-        action: Some(ProposalActionInput::ExecuteNnsFunction(ExecuteNnsFunction {
+        action: Some(ProposalActionRequest::ExecuteNnsFunction(ExecuteNnsFunction {
             nns_function: NnsFunction::UninstallCode as i32,
             payload: Encode!(&CanisterIdRecord { canister_id })
                 .expect("Error encoding proposal payload"),

--- a/rs/nns/integration_tests/src/uninstall_canister_by_proposal.rs
+++ b/rs/nns/integration_tests/src/uninstall_canister_by_proposal.rs
@@ -4,8 +4,7 @@ use ic_nervous_system_clients::canister_id_record::CanisterIdRecord;
 use ic_nns_constants::LIFELINE_CANISTER_INDEX_IN_NNS_SUBNET;
 use ic_nns_governance_api::pb::v1::{
     manage_neuron_response::{Command, MakeProposalResponse},
-    proposal::Action,
-    ExecuteNnsFunction, NnsFunction, Proposal,
+    ExecuteNnsFunction, ProposalInput, ProposalActionInput, NnsFunction,
 };
 use ic_nns_test_utils::{
     common::NnsInitPayloadsBuilder,
@@ -50,11 +49,11 @@ fn uninstall_canister_by_proposal() {
     let status = get_canister_status_from_root(&state_machine, canister_id);
     assert!(status.module_hash.is_some());
     // Prepare a proposal to uninstall canister code
-    let proposal = Proposal {
+    let proposal = ProposalInput {
         title: Some("<proposal to uninstall an NNS canister>".to_string()),
         summary: "".to_string(),
         url: "".to_string(),
-        action: Some(Action::ExecuteNnsFunction(ExecuteNnsFunction {
+        action: Some(ProposalActionInput::ExecuteNnsFunction(ExecuteNnsFunction {
             nns_function: NnsFunction::UninstallCode as i32,
             payload: Encode!(&CanisterIdRecord { canister_id })
                 .expect("Error encoding proposal payload"),

--- a/rs/nns/integration_tests/src/update_canister_settings.rs
+++ b/rs/nns/integration_tests/src/update_canister_settings.rs
@@ -4,11 +4,10 @@ use ic_nervous_system_clients::canister_status::{DefiniteCanisterSettings, LogVi
 use ic_nns_constants::{LIFELINE_CANISTER_ID, REGISTRY_CANISTER_ID, ROOT_CANISTER_ID};
 use ic_nns_governance_api::pb::v1::{
     manage_neuron_response::Command,
-    proposal::Action,
     update_canister_settings::{
         CanisterSettings, Controllers, LogVisibility as GovernanceLogVisibility,
     },
-    Proposal, UpdateCanisterSettings,
+    ProposalInput, ProposalActionInput, UpdateCanisterSettings,
 };
 use ic_nns_test_utils::{
     common::NnsInitPayloadsBuilder,
@@ -75,21 +74,23 @@ fn test_update_canister_settings_proposal(
         &state_machine,
         n1.principal_id,
         n1.neuron_id,
-        &Proposal {
+        &ProposalInput {
             title: Some("Update canister settings".to_string()),
-            action: Some(Action::UpdateCanisterSettings(UpdateCanisterSettings {
-                canister_id: Some(target_canister_id.get()),
-                settings: Some(CanisterSettings {
-                    controllers: Some(Controllers {
-                        controllers: target_controllers.clone(),
+            action: Some(ProposalActionInput::UpdateCanisterSettings(
+                UpdateCanisterSettings {
+                    canister_id: Some(target_canister_id.get()),
+                    settings: Some(CanisterSettings {
+                        controllers: Some(Controllers {
+                            controllers: target_controllers.clone(),
+                        }),
+                        memory_allocation: Some(target_memory_allocation),
+                        compute_allocation: Some(target_compute_allocation),
+                        freezing_threshold: Some(target_freezing_threshold),
+                        wasm_memory_limit: Some(target_wasm_memory_limit),
+                        log_visibility: Some(GovernanceLogVisibility::Public as i32),
                     }),
-                    memory_allocation: Some(target_memory_allocation),
-                    compute_allocation: Some(target_compute_allocation),
-                    freezing_threshold: Some(target_freezing_threshold),
-                    wasm_memory_limit: Some(target_wasm_memory_limit),
-                    log_visibility: Some(GovernanceLogVisibility::Public as i32),
-                }),
-            })),
+                },
+            )),
             ..Default::default()
         },
     );

--- a/rs/nns/integration_tests/src/update_canister_settings.rs
+++ b/rs/nns/integration_tests/src/update_canister_settings.rs
@@ -7,7 +7,7 @@ use ic_nns_governance_api::pb::v1::{
     update_canister_settings::{
         CanisterSettings, Controllers, LogVisibility as GovernanceLogVisibility,
     },
-    ProposalActionRequest, MakeProposalRequest, UpdateCanisterSettings,
+    MakeProposalRequest, ProposalActionRequest, UpdateCanisterSettings,
 };
 use ic_nns_test_utils::{
     common::NnsInitPayloadsBuilder,

--- a/rs/nns/integration_tests/src/update_canister_settings.rs
+++ b/rs/nns/integration_tests/src/update_canister_settings.rs
@@ -7,7 +7,7 @@ use ic_nns_governance_api::pb::v1::{
     update_canister_settings::{
         CanisterSettings, Controllers, LogVisibility as GovernanceLogVisibility,
     },
-    ProposalInput, ProposalActionInput, UpdateCanisterSettings,
+    ProposalActionRequest, MakeProposalRequest, UpdateCanisterSettings,
 };
 use ic_nns_test_utils::{
     common::NnsInitPayloadsBuilder,
@@ -74,9 +74,9 @@ fn test_update_canister_settings_proposal(
         &state_machine,
         n1.principal_id,
         n1.neuron_id,
-        &ProposalInput {
+        &MakeProposalRequest {
             title: Some("Update canister settings".to_string()),
-            action: Some(ProposalActionInput::UpdateCanisterSettings(
+            action: Some(ProposalActionRequest::UpdateCanisterSettings(
                 UpdateCanisterSettings {
                     canister_id: Some(target_canister_id.get()),
                     settings: Some(CanisterSettings {

--- a/rs/nns/integration_tests/src/wait_for_quiet.rs
+++ b/rs/nns/integration_tests/src/wait_for_quiet.rs
@@ -12,8 +12,8 @@ use ic_nns_governance_api::pb::v1::{
     manage_neuron::{self, NeuronIdOrSubaccount},
     manage_neuron_response::Command as CommandResponse,
     neuron::DissolveState,
-    AddOrRemoveNodeProvider, ManageNeuronCommandRequest, ManageNeuronRequest, ManageNeuronResponse,
-    Neuron, NodeProvider, ProposalActionRequest, ProposalInfo, MakeProposalRequest, Vote,
+    AddOrRemoveNodeProvider, MakeProposalRequest, ManageNeuronCommandRequest, ManageNeuronRequest,
+    ManageNeuronResponse, Neuron, NodeProvider, ProposalActionRequest, ProposalInfo, Vote,
 };
 use ic_nns_test_utils::{
     common::NnsInitPayloadsBuilder,

--- a/rs/nns/integration_tests/src/wait_for_quiet.rs
+++ b/rs/nns/integration_tests/src/wait_for_quiet.rs
@@ -12,8 +12,8 @@ use ic_nns_governance_api::pb::v1::{
     manage_neuron::{self, NeuronIdOrSubaccount},
     manage_neuron_response::Command as CommandResponse,
     neuron::DissolveState,
-    AddOrRemoveNodeProvider, ManageNeuronResponse, Neuron, ManageNeuronInput, ManageNeuronCommandInput,
-    ProposalInput, ProposalActionInput, NodeProvider, ProposalInfo, Vote,
+    AddOrRemoveNodeProvider, ManageNeuronCommandRequest, ManageNeuronRequest, ManageNeuronResponse,
+    Neuron, NodeProvider, ProposalActionRequest, ProposalInfo, MakeProposalRequest, Vote,
 };
 use ic_nns_test_utils::{
     common::NnsInitPayloadsBuilder,
@@ -59,17 +59,17 @@ fn test_deadline_is_extended_with_wait_for_quiet() {
             .update_from_sender(
                 "manage_neuron",
                 candid_one,
-                ManageNeuronInput {
+                ManageNeuronRequest {
                     neuron_id_or_subaccount: Some(NeuronIdOrSubaccount::NeuronId(NeuronId {
                         id: TEST_NEURON_2_ID,
                     })),
                     id: None,
-                    command: Some(ManageNeuronCommandInput::MakeProposal(Box::new(
-                        ProposalInput {
+                    command: Some(ManageNeuronCommandRequest::MakeProposal(Box::new(
+                        MakeProposalRequest {
                             title: Some("Just want to add this NP.".to_string()),
                             summary: "".to_string(),
                             url: "".to_string(),
-                            action: Some(ProposalActionInput::AddOrRemoveNodeProvider(
+                            action: Some(ProposalActionRequest::AddOrRemoveNodeProvider(
                                 AddOrRemoveNodeProvider {
                                     change: Some(Change::ToAdd(NodeProvider {
                                         id: Some(*TEST_NEURON_1_OWNER_PRINCIPAL),
@@ -119,10 +119,10 @@ fn test_deadline_is_extended_with_wait_for_quiet() {
             .update_from_sender(
                 "manage_neuron",
                 candid_one,
-                ManageNeuronInput {
+                ManageNeuronRequest {
                     neuron_id_or_subaccount: Some(NeuronIdOrSubaccount::NeuronId(neuron_id_4)),
                     id: None,
-                    command: Some(ManageNeuronCommandInput::RegisterVote(
+                    command: Some(ManageNeuronCommandRequest::RegisterVote(
                         manage_neuron::RegisterVote {
                             proposal: Some(pid),
                             vote: Vote::No as i32,

--- a/rs/nns/integration_tests/src/wait_for_quiet.rs
+++ b/rs/nns/integration_tests/src/wait_for_quiet.rs
@@ -9,12 +9,11 @@ use ic_nns_common::pb::v1::NeuronId;
 use ic_nns_governance::governance::TimeWarp;
 use ic_nns_governance_api::pb::v1::{
     add_or_remove_node_provider::Change,
-    manage_neuron::{self, Command, NeuronIdOrSubaccount},
+    manage_neuron::{self, NeuronIdOrSubaccount},
     manage_neuron_response::Command as CommandResponse,
     neuron::DissolveState,
-    proposal::Action,
-    AddOrRemoveNodeProvider, ManageNeuron, ManageNeuronResponse, Neuron, NodeProvider, Proposal,
-    ProposalInfo, Vote,
+    AddOrRemoveNodeProvider, ManageNeuronResponse, Neuron, ManageNeuronInput, ManageNeuronCommandInput,
+    ProposalInput, ProposalActionInput, NodeProvider, ProposalInfo, Vote,
 };
 use ic_nns_test_utils::{
     common::NnsInitPayloadsBuilder,
@@ -60,22 +59,26 @@ fn test_deadline_is_extended_with_wait_for_quiet() {
             .update_from_sender(
                 "manage_neuron",
                 candid_one,
-                ManageNeuron {
+                ManageNeuronInput {
                     neuron_id_or_subaccount: Some(NeuronIdOrSubaccount::NeuronId(NeuronId {
                         id: TEST_NEURON_2_ID,
                     })),
                     id: None,
-                    command: Some(Command::MakeProposal(Box::new(Proposal {
-                        title: Some("Just want to add this NP.".to_string()),
-                        summary: "".to_string(),
-                        url: "".to_string(),
-                        action: Some(Action::AddOrRemoveNodeProvider(AddOrRemoveNodeProvider {
-                            change: Some(Change::ToAdd(NodeProvider {
-                                id: Some(*TEST_NEURON_1_OWNER_PRINCIPAL),
-                                reward_account: None,
-                            })),
-                        })),
-                    }))),
+                    command: Some(ManageNeuronCommandInput::MakeProposal(Box::new(
+                        ProposalInput {
+                            title: Some("Just want to add this NP.".to_string()),
+                            summary: "".to_string(),
+                            url: "".to_string(),
+                            action: Some(ProposalActionInput::AddOrRemoveNodeProvider(
+                                AddOrRemoveNodeProvider {
+                                    change: Some(Change::ToAdd(NodeProvider {
+                                        id: Some(*TEST_NEURON_1_OWNER_PRINCIPAL),
+                                        reward_account: None,
+                                    })),
+                                },
+                            )),
+                        },
+                    ))),
                 },
                 &Sender::from_keypair(&TEST_NEURON_2_OWNER_KEYPAIR),
             )
@@ -116,13 +119,15 @@ fn test_deadline_is_extended_with_wait_for_quiet() {
             .update_from_sender(
                 "manage_neuron",
                 candid_one,
-                ManageNeuron {
+                ManageNeuronInput {
                     neuron_id_or_subaccount: Some(NeuronIdOrSubaccount::NeuronId(neuron_id_4)),
                     id: None,
-                    command: Some(Command::RegisterVote(manage_neuron::RegisterVote {
-                        proposal: Some(pid),
-                        vote: Vote::No as i32,
-                    })),
+                    command: Some(ManageNeuronCommandInput::RegisterVote(
+                        manage_neuron::RegisterVote {
+                            proposal: Some(pid),
+                            vote: Vote::No as i32,
+                        },
+                    )),
                 },
                 &Sender::from_keypair(neuron_4_owner_keypair),
             )

--- a/rs/nns/test_utils/src/neuron_helpers.rs
+++ b/rs/nns/test_utils/src/neuron_helpers.rs
@@ -6,8 +6,8 @@ use ic_nervous_system_common_test_keys::{
 };
 use ic_nns_common::{pb::v1::NeuronId, types::ProposalId};
 use ic_nns_governance_api::pb::v1::{
-    manage_neuron_response::Command, ExecuteNnsFunction, Neuron, ProposalInput, ProposalActionInput,
-    NnsFunction,
+    manage_neuron_response::Command, ExecuteNnsFunction, MakeProposalRequest, Neuron, NnsFunction,
+    ProposalActionRequest,
 };
 use ic_state_machine_tests::StateMachine;
 use std::collections::HashMap;
@@ -65,15 +65,17 @@ pub fn get_neuron_3() -> TestNeuronOwner {
     }
 }
 
-pub fn get_some_proposal() -> ProposalInput {
-    ProposalInput {
+pub fn get_some_proposal() -> MakeProposalRequest {
+    MakeProposalRequest {
         title: Some("<proposal created from initialization>".to_string()),
         summary: "".to_string(),
         url: "".to_string(),
-        action: Some(ProposalActionInput::ExecuteNnsFunction(ExecuteNnsFunction {
-            nns_function: NnsFunction::NnsRootUpgrade as i32,
-            payload: Vec::new(),
-        })),
+        action: Some(ProposalActionRequest::ExecuteNnsFunction(
+            ExecuteNnsFunction {
+                nns_function: NnsFunction::NnsRootUpgrade as i32,
+                payload: Vec::new(),
+            },
+        )),
     }
 }
 

--- a/rs/nns/test_utils/src/neuron_helpers.rs
+++ b/rs/nns/test_utils/src/neuron_helpers.rs
@@ -6,8 +6,8 @@ use ic_nervous_system_common_test_keys::{
 };
 use ic_nns_common::{pb::v1::NeuronId, types::ProposalId};
 use ic_nns_governance_api::pb::v1::{
-    manage_neuron_response::Command, proposal::Action, ExecuteNnsFunction, Neuron, NnsFunction,
-    Proposal,
+    manage_neuron_response::Command, ExecuteNnsFunction, Neuron, ProposalInput, ProposalActionInput,
+    NnsFunction,
 };
 use ic_state_machine_tests::StateMachine;
 use std::collections::HashMap;
@@ -65,12 +65,12 @@ pub fn get_neuron_3() -> TestNeuronOwner {
     }
 }
 
-pub fn get_some_proposal() -> Proposal {
-    Proposal {
+pub fn get_some_proposal() -> ProposalInput {
+    ProposalInput {
         title: Some("<proposal created from initialization>".to_string()),
         summary: "".to_string(),
         url: "".to_string(),
-        action: Some(Action::ExecuteNnsFunction(ExecuteNnsFunction {
+        action: Some(ProposalActionInput::ExecuteNnsFunction(ExecuteNnsFunction {
             nns_function: NnsFunction::NnsRootUpgrade as i32,
             payload: Vec::new(),
         })),

--- a/rs/nns/test_utils/src/state_test_helpers.rs
+++ b/rs/nns/test_utils/src/state_test_helpers.rs
@@ -46,11 +46,10 @@ use ic_nns_governance_api::pb::v1::{
         JoinCommunityFund, LeaveCommunityFund, RegisterVote, RemoveHotKey, Split, StakeMaturity,
     },
     manage_neuron_response::{self, ClaimOrRefreshResponse},
-    proposal::{self, Action},
-    Empty, ExecuteNnsFunction, Governance, GovernanceError, InstallCode, ListNeurons,
-    ListNeuronsResponse, ListProposalInfo, ListProposalInfoResponse, ManageNeuron,
-    ManageNeuronResponse, MonthlyNodeProviderRewards, NetworkEconomics, NnsFunction, Proposal,
-    ProposalInfo, RewardNodeProviders, Vote,
+    Empty, ExecuteNnsFunction, Governance, GovernanceError, InstallCodeInput, ListNeurons,
+    ListNeuronsResponse, ListProposalInfo, ListProposalInfoResponse, ManageNeuronCommandInput,
+    ManageNeuronInput, ManageNeuronResponse, MonthlyNodeProviderRewards, NetworkEconomics,
+    NnsFunction, ProposalActionInput, ProposalInfo, ProposalInput, RewardNodeProviders, Vote,
 };
 use ic_nns_handler_lifeline_interface::UpgradeRootProposal;
 use ic_nns_handler_root::init::RootCanisterInitPayload;
@@ -811,14 +810,14 @@ fn manage_neuron(
     state_machine: &StateMachine,
     sender: PrincipalId,
     neuron_id: NeuronId,
-    command: nns_governance_pb::manage_neuron::Command,
+    command: nns_governance_pb::ManageNeuronCommandInput,
 ) -> ManageNeuronResponse {
     let result = state_machine
         .execute_ingress_as(
             sender,
             GOVERNANCE_CANISTER_ID,
             "manage_neuron",
-            Encode!(&ManageNeuron {
+            Encode!(&ManageNeuronInput {
                 id: Some(neuron_id),
                 command: Some(command),
                 neuron_id_or_subaccount: None
@@ -846,12 +845,12 @@ impl NnsManageNeuronConfigureOperation for IncreaseDissolveDelay {
 }
 
 trait NnsManageNeuronCommand {
-    fn into_command(self) -> nns_governance_pb::manage_neuron::Command;
+    fn into_command(self) -> nns_governance_pb::ManageNeuronCommandInput;
 }
 
 impl NnsManageNeuronCommand for nns_governance_pb::manage_neuron::Configure {
-    fn into_command(self) -> nns_governance_pb::manage_neuron::Command {
-        nns_governance_pb::manage_neuron::Command::Configure(self)
+    fn into_command(self) -> nns_governance_pb::ManageNeuronCommandInput {
+        nns_governance_pb::ManageNeuronCommandInput::Configure(self)
     }
 }
 
@@ -927,13 +926,13 @@ pub fn nns_claim_or_refresh_neuron(
     memo: u64,
 ) -> NeuronId {
     // Construct request.
-    let command = Some(manage_neuron::Command::ClaimOrRefresh(ClaimOrRefresh {
+    let command = Some(ManageNeuronCommandInput::ClaimOrRefresh(ClaimOrRefresh {
         by: Some(claim_or_refresh::By::MemoAndController(MemoAndController {
             memo,
             controller: Some(controller),
         })),
     }));
-    let manage_neuron = ManageNeuron {
+    let manage_neuron = ManageNeuronInput {
         id: None,
         command,
         neuron_id_or_subaccount: None,
@@ -975,7 +974,7 @@ pub fn nns_disburse_neuron(
         state_machine,
         sender,
         neuron_id,
-        manage_neuron::Command::Disburse(Disburse {
+        ManageNeuronCommandInput::Disburse(Disburse {
             amount: Some(manage_neuron::disburse::Amount { e8s: amount_e8s }),
             to_account: to_account.map(|account| account.into()),
         }),
@@ -1016,7 +1015,7 @@ pub fn nns_propose_upgrade_nns_canister(
     use_proposal_action: bool,
 ) -> ProposalId {
     let action = if use_proposal_action {
-        Some(proposal::Action::InstallCode(InstallCode {
+        Some(ProposalActionInput::InstallCode(InstallCodeInput {
             canister_id: Some(target_canister_id.get()),
             install_mode: Some(3),
             wasm_module: Some(wasm_module),
@@ -1034,10 +1033,12 @@ pub fn nns_propose_upgrade_nns_canister(
 
         let payload = Encode!(&payload).unwrap();
 
-        Some(proposal::Action::ExecuteNnsFunction(ExecuteNnsFunction {
-            nns_function: NnsFunction::NnsCanisterUpgrade as i32,
-            payload,
-        }))
+        Some(ProposalActionInput::ExecuteNnsFunction(
+            ExecuteNnsFunction {
+                nns_function: NnsFunction::NnsCanisterUpgrade as i32,
+                payload,
+            },
+        ))
     } else {
         let payload = UpgradeRootProposal {
             wasm_module,
@@ -1046,15 +1047,17 @@ pub fn nns_propose_upgrade_nns_canister(
         };
         let payload = Encode!(&payload).unwrap();
 
-        Some(proposal::Action::ExecuteNnsFunction(ExecuteNnsFunction {
-            nns_function: NnsFunction::NnsRootUpgrade as i32,
-            payload,
-        }))
+        Some(ProposalActionInput::ExecuteNnsFunction(
+            ExecuteNnsFunction {
+                nns_function: NnsFunction::NnsRootUpgrade as i32,
+                payload,
+            },
+        ))
     };
 
     let target_canister_name = canister_id_to_nns_canister_name(target_canister_id);
 
-    let proposal = Proposal {
+    let proposal = ProposalInput {
         title: Some(format!("Upgrade {}", target_canister_name)),
         action,
         ..Default::default()
@@ -1164,7 +1167,7 @@ pub fn nns_cast_vote(
     proposal_id: u64,
     vote: Vote,
 ) -> ManageNeuronResponse {
-    let command = manage_neuron::Command::RegisterVote(RegisterVote {
+    let command = ManageNeuronCommandInput::RegisterVote(RegisterVote {
         proposal: Some(ic_nns_common::pb::v1::ProposalId { id: proposal_id }),
         vote: vote as i32,
     });
@@ -1178,7 +1181,7 @@ pub fn nns_split_neuron(
     neuron_id: NeuronId,
     amount: u64,
 ) -> ManageNeuronResponse {
-    let command = manage_neuron::Command::Split(Split { amount_e8s: amount });
+    let command = ManageNeuronCommandInput::Split(Split { amount_e8s: amount });
 
     manage_neuron(state_machine, sender, neuron_id, command)
 }
@@ -1221,7 +1224,7 @@ pub fn nns_join_community_fund(
     sender: PrincipalId,
     neuron_id: NeuronId,
 ) -> ManageNeuronResponse {
-    let command = manage_neuron::Command::Configure(Configure {
+    let command = ManageNeuronCommandInput::Configure(Configure {
         operation: Some(Operation::JoinCommunityFund(JoinCommunityFund {})),
     });
 
@@ -1233,7 +1236,7 @@ pub fn nns_leave_community_fund(
     sender: PrincipalId,
     neuron_id: NeuronId,
 ) -> ManageNeuronResponse {
-    let command = manage_neuron::Command::Configure(Configure {
+    let command = ManageNeuronCommandInput::Configure(Configure {
         operation: Some(Operation::LeaveCommunityFund(LeaveCommunityFund {})),
     });
 
@@ -1244,9 +1247,9 @@ pub fn nns_governance_make_proposal(
     state_machine: &StateMachine,
     sender: PrincipalId,
     neuron_id: NeuronId,
-    proposal: &Proposal,
+    proposal: &ProposalInput,
 ) -> ManageNeuronResponse {
-    let command = manage_neuron::Command::MakeProposal(Box::new(proposal.clone()));
+    let command = ManageNeuronCommandInput::MakeProposal(Box::new(proposal.clone()));
 
     manage_neuron(state_machine, sender, neuron_id, command)
 }
@@ -1257,7 +1260,7 @@ pub fn nns_add_hot_key(
     neuron_id: NeuronId,
     new_hot_key: PrincipalId,
 ) -> ManageNeuronResponse {
-    let command = manage_neuron::Command::Configure(Configure {
+    let command = ManageNeuronCommandInput::Configure(Configure {
         operation: Some(Operation::AddHotKey(AddHotKey {
             new_hot_key: Some(new_hot_key),
         })),
@@ -1273,7 +1276,7 @@ pub fn nns_set_followees_for_neuron(
     followees: &[NeuronId],
     topic: i32,
 ) -> ManageNeuronResponse {
-    let command = manage_neuron::Command::Follow(Follow {
+    let command = ManageNeuronCommandInput::Follow(Follow {
         topic,
         followees: followees
             .iter()
@@ -1290,7 +1293,7 @@ pub fn nns_remove_hot_key(
     neuron_id: NeuronId,
     hot_key_to_remove: PrincipalId,
 ) -> ManageNeuronResponse {
-    let command = manage_neuron::Command::Configure(Configure {
+    let command = ManageNeuronCommandInput::Configure(Configure {
         operation: Some(Operation::RemoveHotKey(RemoveHotKey {
             hot_key_to_remove: Some(hot_key_to_remove),
         })),
@@ -1305,7 +1308,7 @@ pub fn nns_stake_maturity(
     neuron_id: NeuronId,
     percentage_to_stake: Option<u32>,
 ) -> ManageNeuronResponse {
-    let command = manage_neuron::Command::StakeMaturity(StakeMaturity {
+    let command = ManageNeuronCommandInput::StakeMaturity(StakeMaturity {
         percentage_to_stake,
     });
 
@@ -1941,14 +1944,16 @@ pub fn cmc_set_default_authorized_subnetworks(
     neuron_id: NeuronId,
 ) {
     let args = SetAuthorizedSubnetworkListArgs { who: None, subnets };
-    let proposal = Proposal {
+    let proposal = ProposalInput {
         title: Some("set subnetworks".to_string()),
         summary: "setting subnetworks".to_string(),
         url: "".to_string(),
-        action: Some(Action::ExecuteNnsFunction(ExecuteNnsFunction {
-            nns_function: NnsFunction::SetAuthorizedSubnetworks as i32,
-            payload: Encode!(&args).unwrap(),
-        })),
+        action: Some(ProposalActionInput::ExecuteNnsFunction(
+            ExecuteNnsFunction {
+                nns_function: NnsFunction::SetAuthorizedSubnetworks as i32,
+                payload: Encode!(&args).unwrap(),
+            },
+        )),
     };
 
     let propose_response = nns_governance_make_proposal(machine, sender, neuron_id, &proposal);

--- a/rs/registry/admin/src/main.rs
+++ b/rs/registry/admin/src/main.rs
@@ -57,8 +57,8 @@ use ic_nns_governance_api::{
             CanisterSettings, Controllers, LogVisibility as GovernanceLogVisibility,
         },
         AddOrRemoveNodeProvider, CreateServiceNervousSystem, GovernanceError, InstallCodeRequest,
-        ManageNeuronCommandRequest, ManageNeuronRequest, NnsFunction, NodeProvider,
-        ProposalActionRequest, MakeProposalRequest, RewardNodeProviders, StopOrStartCanister,
+        MakeProposalRequest, ManageNeuronCommandRequest, ManageNeuronRequest, NnsFunction,
+        NodeProvider, ProposalActionRequest, RewardNodeProviders, StopOrStartCanister,
         UpdateCanisterSettings,
     },
     proposal_helpers::{

--- a/rs/registry/admin/src/main.rs
+++ b/rs/registry/admin/src/main.rs
@@ -52,15 +52,14 @@ use ic_nns_governance_api::{
             SwapParameters,
         },
         install_code::CanisterInstallMode as GovernanceInstallMode,
-        manage_neuron::Command,
-        proposal::Action,
         stop_or_start_canister::CanisterAction as GovernanceCanisterAction,
         update_canister_settings::{
             CanisterSettings, Controllers, LogVisibility as GovernanceLogVisibility,
         },
-        AddOrRemoveNodeProvider, CreateServiceNervousSystem, GovernanceError, InstallCode,
-        ManageNeuron, NnsFunction, NodeProvider, Proposal, RewardNodeProviders,
-        StopOrStartCanister, UpdateCanisterSettings,
+        AddOrRemoveNodeProvider, CreateServiceNervousSystem, GovernanceError, InstallCodeInput,
+        ManageNeuronCommandInput, ManageNeuronInput, NnsFunction, NodeProvider,
+        ProposalActionInput, ProposalInput, RewardNodeProviders, StopOrStartCanister,
+        UpdateCanisterSettings,
     },
     proposal_helpers::{
         create_external_update_proposal_candid, create_make_proposal_payload,
@@ -849,14 +848,14 @@ impl ProposalPayload<StopOrStartCanisterRequest> for StartCanisterCmd {
 
 #[async_trait]
 impl ProposalAction for StartCanisterCmd {
-    async fn action(&self) -> Action {
+    async fn action(&self) -> ProposalActionInput {
         let canister_id = Some(self.canister_id.get());
         let action = Some(GovernanceCanisterAction::Start as i32);
         let start_canister = StopOrStartCanister {
             canister_id,
             action,
         };
-        Action::StopOrStartCanister(start_canister)
+        ProposalActionInput::StopOrStartCanister(start_canister)
     }
 }
 
@@ -894,14 +893,14 @@ impl ProposalPayload<StopOrStartCanisterRequest> for StopCanisterCmd {
 
 #[async_trait]
 impl ProposalAction for StopCanisterCmd {
-    async fn action(&self) -> Action {
+    async fn action(&self) -> ProposalActionInput {
         let canister_id = Some(self.canister_id.get());
         let action = Some(GovernanceCanisterAction::Stop as i32);
         let stop_canister = StopOrStartCanister {
             canister_id,
             action,
         };
-        Action::StopOrStartCanister(stop_canister)
+        ProposalActionInput::StopOrStartCanister(stop_canister)
     }
 }
 
@@ -1117,7 +1116,7 @@ impl ProposalPayload<ChangeCanisterRequest> for ProposeToChangeNnsCanisterCmd {
 
 #[async_trait]
 impl ProposalAction for ProposeToChangeNnsCanisterCmd {
-    async fn action(&self) -> Action {
+    async fn action(&self) -> ProposalActionInput {
         let canister_id = Some(self.canister_id.get());
         let wasm_module = Some(
             read_wasm_module(
@@ -1135,7 +1134,7 @@ impl ProposalAction for ProposeToChangeNnsCanisterCmd {
             CanisterInstallMode::Upgrade => Some(GovernanceInstallMode::Upgrade as i32),
         };
 
-        let install_code = InstallCode {
+        let install_code = InstallCodeInput {
             skip_stopping_before_installing,
             install_mode,
             canister_id,
@@ -1143,7 +1142,7 @@ impl ProposalAction for ProposeToChangeNnsCanisterCmd {
             arg,
         };
 
-        Action::InstallCode(install_code)
+        ProposalActionInput::InstallCode(install_code)
     }
 }
 
@@ -1305,7 +1304,7 @@ impl ProposalTitle for ProposeToUpdateCanisterSettingsCmd {
 
 #[async_trait]
 impl ProposalAction for ProposeToUpdateCanisterSettingsCmd {
-    async fn action(&self) -> Action {
+    async fn action(&self) -> ProposalActionInput {
         let canister_id = Some(self.canister_id.get());
 
         let controllers = if self.remove_all_controllers {
@@ -1339,7 +1338,7 @@ impl ProposalAction for ProposeToUpdateCanisterSettingsCmd {
             }),
         };
 
-        Action::UpdateCanisterSettings(update_settings)
+        ProposalActionInput::UpdateCanisterSettings(update_settings)
     }
 }
 
@@ -3178,13 +3177,13 @@ async fn propose_to_create_service_nervous_system(
 ) {
     let is_dry_run = cmd.is_dry_run();
 
-    let action = Some(Action::CreateServiceNervousSystem(
+    let action = Some(ProposalActionInput::CreateServiceNervousSystem(
         CreateServiceNervousSystem::try_from(cmd.clone()).unwrap(),
     ));
     let title = cmd.title();
     let summary = cmd.summary.clone().unwrap();
     let url = parse_proposal_url(cmd.proposal_url.clone());
-    let proposal = Proposal {
+    let proposal = ProposalInput {
         title: Some(title.clone()),
         summary,
         url,
@@ -6040,13 +6039,13 @@ impl GovernanceCanisterClient {
         title: String,
         summary: String,
     ) -> Result<ProposalId, String> {
-        let serialized = Encode!(&ManageNeuron {
+        let serialized = Encode!(&ManageNeuronInput {
             neuron_id_or_subaccount: None,
-            command: Some(Command::MakeProposal(Box::new(Proposal {
+            command: Some(ManageNeuronCommandInput::MakeProposal(Box::new(ProposalInput {
                 title: Some(title),
                 summary,
                 url,
-                action: Some(Action::AddOrRemoveNodeProvider(payload)),
+                action: Some(ProposalActionInput::AddOrRemoveNodeProvider(payload)),
             }))),
             id: Some((*self.0.proposal_author()).into()),
         })
@@ -6091,19 +6090,21 @@ impl GovernanceCanisterClient {
 
     async fn submit_proposal_action(
         &self,
-        action: Action,
+        action: ProposalActionInput,
         url: String,
         title: String,
         summary: String,
     ) -> Result<ProposalId, String> {
-        let serialized = Encode!(&ManageNeuron {
+        let serialized = Encode!(&ManageNeuronInput {
             neuron_id_or_subaccount: None,
-            command: Some(Command::MakeProposal(Box::new(Proposal {
-                title: Some(title),
-                summary,
-                url,
-                action: Some(action),
-            }))),
+            command: Some(ManageNeuronCommandInput::MakeProposal(Box::new(
+                ProposalInput {
+                    title: Some(title),
+                    summary,
+                    url,
+                    action: Some(action),
+                }
+            ))),
             id: Some((*self.0.proposal_author()).into()),
         })
         .map_err(|e| {
@@ -6123,7 +6124,7 @@ impl GovernanceCanisterClient {
 
     async fn submit_external_proposal(
         &self,
-        submit_proposal_command: &ManageNeuron,
+        submit_proposal_command: &ManageNeuronInput,
         title: &str,
     ) -> Result<ProposalId, String> {
         let serialized = Encode!(submit_proposal_command).map_err(|e| {

--- a/rs/registry/admin/src/types.rs
+++ b/rs/registry/admin/src/types.rs
@@ -5,7 +5,7 @@ use async_trait::async_trait;
 use candid::CandidType;
 use ic_canister_client::{Agent, Sender};
 use ic_nns_common::types::NeuronId;
-use ic_nns_governance_api::pb::v1::ProposalActionInput;
+use ic_nns_governance_api::pb::v1::ProposalActionRequest;
 use ic_protobuf::registry::{
     node::v1::IPv4InterfaceConfig,
     provisional_whitelist::v1::ProvisionalWhitelist as ProvisionalWhitelistProto,
@@ -263,5 +263,5 @@ pub trait ProposalPayload<T: CandidType> {
 
 #[async_trait]
 pub trait ProposalAction {
-    async fn action(&self) -> ProposalActionInput;
+    async fn action(&self) -> ProposalActionRequest;
 }

--- a/rs/registry/admin/src/types.rs
+++ b/rs/registry/admin/src/types.rs
@@ -5,7 +5,7 @@ use async_trait::async_trait;
 use candid::CandidType;
 use ic_canister_client::{Agent, Sender};
 use ic_nns_common::types::NeuronId;
-use ic_nns_governance_api::pb::v1::proposal::Action;
+use ic_nns_governance_api::pb::v1::ProposalActionInput;
 use ic_protobuf::registry::{
     node::v1::IPv4InterfaceConfig,
     provisional_whitelist::v1::ProvisionalWhitelist as ProvisionalWhitelistProto,
@@ -263,5 +263,5 @@ pub trait ProposalPayload<T: CandidType> {
 
 #[async_trait]
 pub trait ProposalAction {
-    async fn action(&self) -> Action;
+    async fn action(&self) -> ProposalActionInput;
 }

--- a/rs/sns/integration_tests/src/initialization_flow.rs
+++ b/rs/sns/integration_tests/src/initialization_flow.rs
@@ -17,9 +17,7 @@ use ic_nns_governance_api::pb::v1::{
         swap_parameters::NeuronBasketConstructionParameters,
         GovernanceParameters, InitialTokenDistribution, LedgerParameters, SwapParameters,
     },
-    manage_neuron_response,
-    proposal::Action,
-    CreateServiceNervousSystem, Proposal,
+    manage_neuron_response, CreateServiceNervousSystem, ProposalInput, ProposalActionInput,
 };
 use ic_nns_test_utils::{
     common::NnsInitPayloadsBuilder,
@@ -235,11 +233,11 @@ impl SnsInitializationFlowTestSetup {
         neuron_id: NeuronId,
         create_service_nervous_system: &CreateServiceNervousSystem,
     ) -> ProposalId {
-        let proposal = Proposal {
+        let proposal = ProposalInput {
             title: Some("Proposal to create the SNS-2 ServiceNervousSystem".to_string()),
             summary: "Please do this, if anything just so that the test can pass.".to_string(),
             url: "".to_string(),
-            action: Some(Action::CreateServiceNervousSystem(
+            action: Some(ProposalActionInput::CreateServiceNervousSystem(
                 create_service_nervous_system.clone(),
             )),
         };

--- a/rs/sns/integration_tests/src/initialization_flow.rs
+++ b/rs/sns/integration_tests/src/initialization_flow.rs
@@ -17,7 +17,7 @@ use ic_nns_governance_api::pb::v1::{
         swap_parameters::NeuronBasketConstructionParameters,
         GovernanceParameters, InitialTokenDistribution, LedgerParameters, SwapParameters,
     },
-    manage_neuron_response, CreateServiceNervousSystem, ProposalInput, ProposalActionInput,
+    manage_neuron_response, CreateServiceNervousSystem, MakeProposalRequest, ProposalActionRequest,
 };
 use ic_nns_test_utils::{
     common::NnsInitPayloadsBuilder,
@@ -233,11 +233,11 @@ impl SnsInitializationFlowTestSetup {
         neuron_id: NeuronId,
         create_service_nervous_system: &CreateServiceNervousSystem,
     ) -> ProposalId {
-        let proposal = ProposalInput {
+        let proposal = MakeProposalRequest {
             title: Some("Proposal to create the SNS-2 ServiceNervousSystem".to_string()),
             summary: "Please do this, if anything just so that the test can pass.".to_string(),
             url: "".to_string(),
-            action: Some(ProposalActionInput::CreateServiceNervousSystem(
+            action: Some(ProposalActionRequest::CreateServiceNervousSystem(
                 create_service_nervous_system.clone(),
             )),
         };

--- a/rs/tests/src/rosetta_tests/governance_client.rs
+++ b/rs/tests/src/rosetta_tests/governance_client.rs
@@ -6,7 +6,7 @@ use ic_nns_common::{pb::v1::ProposalId, types::NeuronId};
 use ic_nns_governance_api::{
     pb::v1::{
         manage_neuron_response, manage_neuron_response::MakeProposalResponse, ManageNeuronResponse,
-        ProposalInfo, ProposalInput,
+        ProposalInfo, MakeProposalRequest,
     },
     proposal_helpers::create_make_proposal_payload,
 };
@@ -54,7 +54,7 @@ impl GovernanceClient {
     pub async fn make_proposal(
         &self,
         neuron_details: &NeuronDetails,
-        proposal: &ProposalInput,
+        proposal: &MakeProposalRequest,
     ) -> ProposalId {
         debug!(&self.logger, "[governance_client] Making Proposal");
         let neuron_id: NeuronId = neuron_details.neuron.id.unwrap().into();

--- a/rs/tests/src/rosetta_tests/governance_client.rs
+++ b/rs/tests/src/rosetta_tests/governance_client.rs
@@ -6,7 +6,7 @@ use ic_nns_common::{pb::v1::ProposalId, types::NeuronId};
 use ic_nns_governance_api::{
     pb::v1::{
         manage_neuron_response, manage_neuron_response::MakeProposalResponse, ManageNeuronResponse,
-        Proposal, ProposalInfo,
+        ProposalInfo, ProposalInput,
     },
     proposal_helpers::create_make_proposal_payload,
 };
@@ -54,7 +54,7 @@ impl GovernanceClient {
     pub async fn make_proposal(
         &self,
         neuron_details: &NeuronDetails,
-        proposal: &Proposal,
+        proposal: &ProposalInput,
     ) -> ProposalId {
         debug!(&self.logger, "[governance_client] Making Proposal");
         let neuron_id: NeuronId = neuron_details.neuron.id.unwrap().into();

--- a/rs/tests/src/rosetta_tests/governance_client.rs
+++ b/rs/tests/src/rosetta_tests/governance_client.rs
@@ -5,8 +5,8 @@ use ic_agent::Agent;
 use ic_nns_common::{pb::v1::ProposalId, types::NeuronId};
 use ic_nns_governance_api::{
     pb::v1::{
-        manage_neuron_response, manage_neuron_response::MakeProposalResponse, ManageNeuronResponse,
-        ProposalInfo, MakeProposalRequest,
+        manage_neuron_response, manage_neuron_response::MakeProposalResponse, MakeProposalRequest,
+        ManageNeuronResponse, ProposalInfo,
     },
     proposal_helpers::create_make_proposal_payload,
 };

--- a/rs/tests/src/rosetta_tests/tests/neuron_voting.rs
+++ b/rs/tests/src/rosetta_tests/tests/neuron_voting.rs
@@ -10,7 +10,8 @@ use crate::rosetta_tests::{
 use ic_agent::Identity;
 use ic_nns_common::pb::v1::ProposalId;
 use ic_nns_governance_api::pb::v1::{
-    neuron::DissolveState, MakeProposalRequest, Motion, Neuron, ProposalActionRequest,
+    neuron::DissolveState, proposal::Action, MakeProposalRequest, Motion, Neuron, Proposal,
+    ProposalActionRequest,
 };
 use ic_rosetta_api::{
     convert::neuron_subaccount_bytes_from_public_key,
@@ -95,7 +96,16 @@ pub fn test(env: TestEnv) {
         );
         let proposal_info =
             ProposalInfoResponse::try_from(Some(proposal_info_response.result)).unwrap();
-        assert_eq!(proposal_info.0.proposal.unwrap(), proposal);
+
+        let expected_proposal = Proposal {
+            title: Some("dummy title".to_string()),
+            summary: "test".to_string(),
+            action: Some(Action::Motion(Motion {
+                motion_text: "dummy text".to_string(),
+            })),
+            ..Default::default()
+        };
+        assert_eq!(proposal_info.0.proposal.unwrap(), expected_proposal);
         info!(_logger, "Test Register Vote with Vote: Yes");
         test_register_proposal(&client, &neuron2, &first_proposal, &1).await;
         info!(_logger, "Test Register Vote with Vote: No");
@@ -112,7 +122,7 @@ pub fn test(env: TestEnv) {
         );
 
         // Number of pending proposals should be 2 since the first proposal was already voted for
-        assert_eq!(pending_proposals, vec![proposal.clone(); 2]);
+        assert_eq!(pending_proposals, vec![expected_proposal.clone(); 2]);
 
         // Vote on one the second proposal
         test_register_proposal(&client, &neuron2, &second_proposal, &1).await;
@@ -120,7 +130,7 @@ pub fn test(env: TestEnv) {
 
         // Now it should be 1 proposal
         let pending_proposals = client.get_pending_proposals().await.unwrap();
-        assert_eq!(pending_proposals, vec![proposal.clone(); 1]);
+        assert_eq!(pending_proposals, vec![expected_proposal.clone(); 1]);
 
         // Vote on third and last proposal
         test_register_proposal(&client, &neuron2, &third_proposal, &1).await;

--- a/rs/tests/src/rosetta_tests/tests/neuron_voting.rs
+++ b/rs/tests/src/rosetta_tests/tests/neuron_voting.rs
@@ -9,7 +9,9 @@ use crate::rosetta_tests::{
 };
 use ic_agent::Identity;
 use ic_nns_common::pb::v1::ProposalId;
-use ic_nns_governance_api::pb::v1::{neuron::DissolveState, proposal, Motion, Neuron, Proposal};
+use ic_nns_governance_api::pb::v1::{
+    neuron::DissolveState, MakeProposalRequest, Motion, Neuron, ProposalActionRequest,
+};
 use ic_rosetta_api::{
     convert::neuron_subaccount_bytes_from_public_key,
     ledger_client::proposal_info_response::ProposalInfoResponse,
@@ -67,10 +69,10 @@ pub fn test(env: TestEnv) {
     let neuron3 = neurons.create(neuron_setup);
     let neurons = neurons.get_neurons();
 
-    let proposal = Proposal {
+    let proposal = MakeProposalRequest {
         title: Some("dummy title".to_string()),
         summary: "test".to_string(),
-        action: Some(proposal::Action::Motion(Motion {
+        action: Some(ProposalActionRequest::Motion(Motion {
             motion_text: "dummy text".to_string(),
         })),
         ..Default::default()


### PR DESCRIPTION
# Why

The `InstallCode` proposal contains unbounded blobs, and when reading such proposals from NNS Governance, there is no need to return the blobs themselves, but the hashes should be enough. The proposal summary should already explain how the proposal can be verified against the hashes.

# What

* Introduce a new set of API types for the proposal for input (when proposals are made), different from the ones in the output (`get_proposal_info`, `list_proposals` and `get_pending_proposals`)
* For the API output types, replace `wasm_module` and `arg` with `wasm_module_hash` and `arg_hash`
* When converting from the internal type to the API output type, calculate the hashes

# Backward Compatibility

Among all the possible requests sent to NNS Governance, the canister should behave in the exact same way as before:
* For everything other than making `InstallCode` proposal, from the candid perspective, there is no change in the interface
* For making `InstallCode` proposal, the request fails before and after this change, since the proposal type is currently disabled.

# Generated files from candid

An ic-js change will be needed after generating from the updated `governance.did` file. 
