### PR TITLE
feat(nns): Add endpoint to get historical node provider rewards

### DIFF
--- a/rs/nns/governance/api/src/ic_nns_governance.pb.v1.rs
+++ b/rs/nns/governance/api/src/ic_nns_governance.pb.v1.rs
@@ -4703,7 +4703,5 @@ pub struct ListNodeProviderRewardsRequest {}
 #[derive(Clone, PartialEq)]
 pub struct ListNodeProviderRewardsResponse {
     /// The list of minted node provider rewards
-    rewards: Vec<MonthlyNodeProviderRewards>,
-    /// The next page token to be used in the next request to get the next set of results.
-    next_page: Option<u32>,
+    pub rewards: Vec<MonthlyNodeProviderRewards>,
 }

--- a/rs/nns/governance/api/src/ic_nns_governance.pb.v1.rs
+++ b/rs/nns/governance/api/src/ic_nns_governance.pb.v1.rs
@@ -4689,3 +4689,21 @@ impl ProposalRewardStatus {
         }
     }
 }
+
+/// A Request to list minted node provider rewards
+#[derive(candid::CandidType, candid::Deserialize, serde::Serialize, comparable::Comparable)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq)]
+pub struct GetMintedNodeProviderRewardsRequest {}
+
+/// A Response to list minted node provider rewards.
+/// Includes optional paging information to get next set of results.
+#[derive(candid::CandidType, candid::Deserialize, serde::Serialize, comparable::Comparable)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq)]
+pub struct GetMintedNodeProviderRewardsResponse {
+    /// The list of minted node provider rewards
+    rewards: Vec<MonthlyNodeProviderRewards>,
+    /// The next page token to be used in the next request to get the next set of results.
+    next_page: Option<u32>,
+}

--- a/rs/nns/governance/api/src/ic_nns_governance.pb.v1.rs
+++ b/rs/nns/governance/api/src/ic_nns_governance.pb.v1.rs
@@ -4694,14 +4694,14 @@ impl ProposalRewardStatus {
 #[derive(candid::CandidType, candid::Deserialize, serde::Serialize, comparable::Comparable)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq)]
-pub struct ListMintedNodeProviderRewardsRequest {}
+pub struct ListNodeProviderRewardsRequest {}
 
 /// A Response to list minted node provider rewards.
 /// Includes optional paging information to get next set of results.
 #[derive(candid::CandidType, candid::Deserialize, serde::Serialize, comparable::Comparable)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq)]
-pub struct ListMintedNodeProviderRewardsResponse {
+pub struct ListNodeProviderRewardsResponse {
     /// The list of minted node provider rewards
     rewards: Vec<MonthlyNodeProviderRewards>,
     /// The next page token to be used in the next request to get the next set of results.

--- a/rs/nns/governance/api/src/ic_nns_governance.pb.v1.rs
+++ b/rs/nns/governance/api/src/ic_nns_governance.pb.v1.rs
@@ -4694,14 +4694,14 @@ impl ProposalRewardStatus {
 #[derive(candid::CandidType, candid::Deserialize, serde::Serialize, comparable::Comparable)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq)]
-pub struct GetMintedNodeProviderRewardsRequest {}
+pub struct ListMintedNodeProviderRewardsRequest {}
 
 /// A Response to list minted node provider rewards.
 /// Includes optional paging information to get next set of results.
 #[derive(candid::CandidType, candid::Deserialize, serde::Serialize, comparable::Comparable)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq)]
-pub struct GetMintedNodeProviderRewardsResponse {
+pub struct ListMintedNodeProviderRewardsResponse {
     /// The list of minted node provider rewards
     rewards: Vec<MonthlyNodeProviderRewards>,
     /// The next page token to be used in the next request to get the next set of results.

--- a/rs/nns/governance/canister/canister.rs
+++ b/rs/nns/governance/canister/canister.rs
@@ -49,7 +49,8 @@ use ic_nns_governance_api::{
             ClaimOrRefresh, NeuronIdOrSubaccount, RegisterVote,
         },
         manage_neuron_response, ClaimOrRefreshNeuronFromAccount,
-        ClaimOrRefreshNeuronFromAccountResponse, GetNeuronsFundAuditInfoRequest,
+        ClaimOrRefreshNeuronFromAccountResponse, GetMintedNodeProviderRewardsRequest,
+        GetMintedNodeProviderRewardsResponse, GetNeuronsFundAuditInfoRequest,
         GetNeuronsFundAuditInfoResponse, Governance as ApiGovernanceProto, GovernanceError,
         ListKnownNeuronsResponse, ListNeurons, ListNeuronsResponse, ListNodeProvidersResponse,
         ListProposalInfo, ListProposalInfoResponse, ManageNeuronCommandRequest,
@@ -59,7 +60,6 @@ use ic_nns_governance_api::{
         SettleNeuronsFundParticipationRequest, SettleNeuronsFundParticipationResponse,
         UpdateNodeProvider, Vote,
     },
-    subnet_rental::{SubnetRentalProposalPayload, SubnetRentalRequest},
 };
 use ic_sns_wasm::pb::v1::{AddWasmRequest, SnsWasm};
 use prost::Message;
@@ -734,6 +734,24 @@ async fn get_monthly_node_provider_rewards_() -> Result<RewardNodeProviders, Gov
         rewards,
         use_registry_derived_rewards: Some(true),
     })
+}
+
+#[export_name = "canister_query list_minted_node_provider_rewards"]
+fn list_minted_node_provider_rewards() {
+    debug_log("get_minted_node_provider_rewards");
+    over(candid, |()| list_minted_node_provider_rewards_())
+}
+
+#[candid_method(query, rename = "list_minted_node_provider_rewards")]
+fn list_minted_node_provider_rewards_(
+    _req: GetMintedNodeProviderRewardsRequest,
+) -> GetMintedNodeProviderRewardsResponse {
+    let rewards = governance().list_node_provider_rewards();
+
+    GetMintedNodeProviderRewardsResponse {
+        rewards: rewards.into_iter().map(RewardNodeProvider::from).collect(),
+        next_page: None,
+    }
 }
 
 #[export_name = "canister_query list_known_neurons"]

--- a/rs/nns/governance/canister/canister.rs
+++ b/rs/nns/governance/canister/canister.rs
@@ -53,13 +53,14 @@ use ic_nns_governance_api::{
         GetNeuronsFundAuditInfoResponse, Governance as ApiGovernanceProto, GovernanceError,
         ListKnownNeuronsResponse, ListNeurons, ListNeuronsResponse, ListNodeProviderRewardsRequest,
         ListNodeProviderRewardsResponse, ListNodeProvidersResponse, ListProposalInfo,
-        ListProposalInfoResponse, ManageNeuron, ManageNeuronCommandRequest, ManageNeuronRequest,
+        ListProposalInfoResponse, ManageNeuronCommandRequest, ManageNeuronRequest,
         ManageNeuronResponse, MonthlyNodeProviderRewards, NetworkEconomics, Neuron, NeuronInfo,
         NodeProvider, Proposal, ProposalInfo, RestoreAgingSummary, RewardEvent, RewardNodeProvider,
         RewardNodeProviders, SettleCommunityFundParticipation,
         SettleNeuronsFundParticipationRequest, SettleNeuronsFundParticipationResponse,
         UpdateNodeProvider, Vote,
     },
+    subnet_rental::{SubnetRentalProposalPayload, SubnetRentalRequest},
 };
 use ic_sns_wasm::pb::v1::{AddWasmRequest, SnsWasm};
 use prost::Message;

--- a/rs/nns/governance/canister/canister.rs
+++ b/rs/nns/governance/canister/canister.rs
@@ -739,14 +739,14 @@ async fn get_monthly_node_provider_rewards_() -> Result<RewardNodeProviders, Gov
 #[export_name = "canister_query list_node_provider_rewards"]
 fn list_node_provider_rewards() {
     debug_log("get_minted_node_provider_rewards");
-    over(candid, |()| list_node_provider_rewards_())
+    over(candid, |req| list_node_provider_rewards_(req))
 }
 
 #[candid_method(query, rename = "list_node_provider_rewards")]
 fn list_node_provider_rewards_(
     _req: ListNodeProviderRewardsRequest,
 ) -> ListNodeProviderRewardsResponse {
-    let rewards = governance().list_node_provider_rewards();
+    let rewards = governance().list_node_provider_rewards(5);
 
     ListNodeProviderRewardsResponse {
         rewards: rewards

--- a/rs/nns/governance/canister/canister.rs
+++ b/rs/nns/governance/canister/canister.rs
@@ -51,14 +51,14 @@ use ic_nns_governance_api::{
         manage_neuron_response, ClaimOrRefreshNeuronFromAccount,
         ClaimOrRefreshNeuronFromAccountResponse, GetNeuronsFundAuditInfoRequest,
         GetNeuronsFundAuditInfoResponse, Governance as ApiGovernanceProto, GovernanceError,
-        ListKnownNeuronsResponse, ListMintedNodeProviderRewardsRequest,
-        ListMintedNodeProviderRewardsResponse, ListNeurons, ListNeuronsResponse,
-        ListNodeProvidersResponse, ListProposalInfo, ListProposalInfoResponse, ManageNeuron,
-        ManageNeuronCommandRequest, ManageNeuronRequest, ManageNeuronResponse,
-        MonthlyNodeProviderRewards, NetworkEconomics, Neuron, NeuronInfo, NodeProvider, Proposal,
-        ProposalInfo, RestoreAgingSummary, RewardEvent, RewardNodeProvider, RewardNodeProviders,
-        SettleCommunityFundParticipation, SettleNeuronsFundParticipationRequest,
-        SettleNeuronsFundParticipationResponse, UpdateNodeProvider, Vote,
+        ListKnownNeuronsResponse, ListNeurons, ListNeuronsResponse, ListNodeProviderRewardsRequest,
+        ListNodeProviderRewardsResponse, ListNodeProvidersResponse, ListProposalInfo,
+        ListProposalInfoResponse, ManageNeuron, ManageNeuronCommandRequest, ManageNeuronRequest,
+        ManageNeuronResponse, MonthlyNodeProviderRewards, NetworkEconomics, Neuron, NeuronInfo,
+        NodeProvider, Proposal, ProposalInfo, RestoreAgingSummary, RewardEvent, RewardNodeProvider,
+        RewardNodeProviders, SettleCommunityFundParticipation,
+        SettleNeuronsFundParticipationRequest, SettleNeuronsFundParticipationResponse,
+        UpdateNodeProvider, Vote,
     },
 };
 use ic_sns_wasm::pb::v1::{AddWasmRequest, SnsWasm};
@@ -736,19 +736,19 @@ async fn get_monthly_node_provider_rewards_() -> Result<RewardNodeProviders, Gov
     })
 }
 
-#[export_name = "canister_query list_minted_node_provider_rewards"]
-fn list_minted_node_provider_rewards() {
+#[export_name = "canister_query list_node_provider_rewards"]
+fn list_node_provider_rewards() {
     debug_log("get_minted_node_provider_rewards");
-    over(candid, |()| list_minted_node_provider_rewards_())
+    over(candid, |()| list_node_provider_rewards_())
 }
 
-#[candid_method(query, rename = "list_minted_node_provider_rewards")]
-fn list_minted_node_provider_rewards_(
-    _req: ListMintedNodeProviderRewardsRequest,
-) -> ListMintedNodeProviderRewardsResponse {
+#[candid_method(query, rename = "list_node_provider_rewards")]
+fn list_node_provider_rewards_(
+    _req: ListNodeProviderRewardsRequest,
+) -> ListNodeProviderRewardsResponse {
     let rewards = governance().list_node_provider_rewards();
 
-    ListMintedNodeProviderRewardsResponse {
+    ListNodeProviderRewardsResponse {
         rewards: rewards
             .into_iter()
             .map(MonthlyNodeProviderRewards::from)

--- a/rs/nns/governance/canister/canister.rs
+++ b/rs/nns/governance/canister/canister.rs
@@ -49,16 +49,16 @@ use ic_nns_governance_api::{
             ClaimOrRefresh, NeuronIdOrSubaccount, RegisterVote,
         },
         manage_neuron_response, ClaimOrRefreshNeuronFromAccount,
-        ClaimOrRefreshNeuronFromAccountResponse, GetMintedNodeProviderRewardsRequest,
-        GetMintedNodeProviderRewardsResponse, GetNeuronsFundAuditInfoRequest,
+        ClaimOrRefreshNeuronFromAccountResponse, GetNeuronsFundAuditInfoRequest,
         GetNeuronsFundAuditInfoResponse, Governance as ApiGovernanceProto, GovernanceError,
-        ListKnownNeuronsResponse, ListNeurons, ListNeuronsResponse, ListNodeProvidersResponse,
-        ListProposalInfo, ListProposalInfoResponse, ManageNeuronCommandRequest,
-        ManageNeuronRequest, ManageNeuronResponse, MonthlyNodeProviderRewards, NetworkEconomics,
-        Neuron, NeuronInfo, NodeProvider, Proposal, ProposalInfo, RestoreAgingSummary, RewardEvent,
-        RewardNodeProvider, RewardNodeProviders, SettleCommunityFundParticipation,
-        SettleNeuronsFundParticipationRequest, SettleNeuronsFundParticipationResponse,
-        UpdateNodeProvider, Vote,
+        ListKnownNeuronsResponse, ListMintedNodeProviderRewardsRequest,
+        ListMintedNodeProviderRewardsResponse, ListNeurons, ListNeuronsResponse,
+        ListNodeProvidersResponse, ListProposalInfo, ListProposalInfoResponse, ManageNeuron,
+        ManageNeuronCommandRequest, ManageNeuronRequest, ManageNeuronResponse,
+        MonthlyNodeProviderRewards, NetworkEconomics, Neuron, NeuronInfo, NodeProvider, Proposal,
+        ProposalInfo, RestoreAgingSummary, RewardEvent, RewardNodeProvider, RewardNodeProviders,
+        SettleCommunityFundParticipation, SettleNeuronsFundParticipationRequest,
+        SettleNeuronsFundParticipationResponse, UpdateNodeProvider, Vote,
     },
 };
 use ic_sns_wasm::pb::v1::{AddWasmRequest, SnsWasm};
@@ -744,12 +744,15 @@ fn list_minted_node_provider_rewards() {
 
 #[candid_method(query, rename = "list_minted_node_provider_rewards")]
 fn list_minted_node_provider_rewards_(
-    _req: GetMintedNodeProviderRewardsRequest,
-) -> GetMintedNodeProviderRewardsResponse {
+    _req: ListMintedNodeProviderRewardsRequest,
+) -> ListMintedNodeProviderRewardsResponse {
     let rewards = governance().list_node_provider_rewards();
 
-    GetMintedNodeProviderRewardsResponse {
-        rewards: rewards.into_iter().map(RewardNodeProvider::from).collect(),
+    ListMintedNodeProviderRewardsResponse {
+        rewards: rewards
+            .into_iter()
+            .map(MonthlyNodeProviderRewards::from)
+            .collect(),
         next_page: None,
     }
 }

--- a/rs/nns/governance/canister/canister.rs
+++ b/rs/nns/governance/canister/canister.rs
@@ -739,8 +739,8 @@ async fn get_monthly_node_provider_rewards_() -> Result<RewardNodeProviders, Gov
 
 #[export_name = "canister_query list_node_provider_rewards"]
 fn list_node_provider_rewards() {
-    debug_log("get_minted_node_provider_rewards");
-    over(candid, |req| list_node_provider_rewards_(req))
+    debug_log("list_node_provider_rewards");
+    over(candid_one, list_node_provider_rewards_)
 }
 
 #[candid_method(query, rename = "list_node_provider_rewards")]
@@ -754,7 +754,6 @@ fn list_node_provider_rewards_(
             .into_iter()
             .map(MonthlyNodeProviderRewards::from)
             .collect(),
-        next_page: None,
     }
 }
 

--- a/rs/nns/governance/canister/governance.did
+++ b/rs/nns/governance/canister/governance.did
@@ -301,6 +301,9 @@ type ListNeuronsResponse = record {
   neuron_infos : vec record { nat64; NeuronInfo };
   full_neurons : vec Neuron;
 };
+type ListNodeProviderRewardsResponse = record {
+  rewards : vec MonthlyNodeProviderRewards;
+};
 type ListNodeProvidersResponse = record { node_providers : vec NodeProvider };
 type ListProposalInfo = record {
   include_reward_status : vec int32;
@@ -799,6 +802,9 @@ service : (Governance) -> {
   get_restore_aging_summary : () -> (RestoreAgingSummary) query;
   list_known_neurons : () -> (ListKnownNeuronsResponse) query;
   list_neurons : (ListNeurons) -> (ListNeuronsResponse) query;
+  list_node_provider_rewards : (record {}) -> (
+      ListNodeProviderRewardsResponse,
+    ) query;
   list_node_providers : () -> (ListNodeProvidersResponse) query;
   list_proposals : (ListProposalInfo) -> (ListProposalInfoResponse) query;
   manage_neuron : (ManageNeuronRequest) -> (ManageNeuronResponse);

--- a/rs/nns/governance/canister/governance_test.did
+++ b/rs/nns/governance/canister/governance_test.did
@@ -301,6 +301,9 @@ type ListNeuronsResponse = record {
   neuron_infos : vec record { nat64; NeuronInfo };
   full_neurons : vec Neuron;
 };
+type ListNodeProviderRewardsResponse = record {
+  rewards : vec MonthlyNodeProviderRewards;
+};
 type ListNodeProvidersResponse = record { node_providers : vec NodeProvider };
 type ListProposalInfo = record {
   include_reward_status : vec int32;
@@ -799,6 +802,9 @@ service : (Governance) -> {
   get_restore_aging_summary : () -> (RestoreAgingSummary) query;
   list_known_neurons : () -> (ListKnownNeuronsResponse) query;
   list_neurons : (ListNeurons) -> (ListNeuronsResponse) query;
+  list_node_provider_rewards : (record {}) -> (
+      ListNodeProviderRewardsResponse,
+    ) query;
   list_node_providers : () -> (ListNodeProvidersResponse) query;
   list_proposals : (ListProposalInfo) -> (ListProposalInfoResponse) query;
   manage_neuron : (ManageNeuronRequest) -> (ManageNeuronResponse);

--- a/rs/nns/governance/src/governance.rs
+++ b/rs/nns/governance/src/governance.rs
@@ -18,7 +18,9 @@ use crate::{
         NeuronsFund, NeuronsFundNeuronPortion, NeuronsFundSnapshot,
         PolynomialNeuronsFundParticipation, SwapParticipationLimits,
     },
-    node_provider_rewards::{latest_node_provider_rewards, record_node_provider_rewards},
+    node_provider_rewards::{
+        latest_node_provider_rewards, list_node_provider_rewards, record_node_provider_rewards,
+    },
     pb::v1::{
         add_or_remove_node_provider::Change,
         archived_monthly_node_provider_rewards,
@@ -4306,6 +4308,18 @@ impl Governance {
     ) {
         record_node_provider_rewards(most_recent_rewards.clone());
         self.heap_data.most_recent_monthly_node_provider_rewards = Some(most_recent_rewards);
+    }
+
+    pub fn list_node_provider_rewards(&self) -> Vec<MonthlyNodeProviderRewards> {
+        list_node_provider_rewards()
+            .into_iter()
+            .map(|archived| match archived.version {
+                Some(archived_monthly_node_provider_rewards::Version::Version1(v1)) => {
+                    v1.rewards.unwrap()
+                }
+                _ => panic!("Should not be possible!"),
+            })
+            .collect()
     }
 
     pub fn get_most_recent_monthly_node_provider_rewards(

--- a/rs/nns/governance/src/governance.rs
+++ b/rs/nns/governance/src/governance.rs
@@ -188,6 +188,8 @@ pub const MAX_NUMBER_OF_NEURONS: usize = 350_000;
 /// The maximum number results returned by the method `list_proposals`.
 pub const MAX_LIST_PROPOSAL_RESULTS: u32 = 100;
 
+const MAX_LIST_NODE_PROVIDER_REWARDS_RESULTS: u64 = 5;
+
 /// The number of e8s per ICP;
 const E8S_PER_ICP: u64 = TOKEN_SUBDIVIDABLE_BY;
 
@@ -4310,8 +4312,9 @@ impl Governance {
         self.heap_data.most_recent_monthly_node_provider_rewards = Some(most_recent_rewards);
     }
 
-    pub fn list_node_provider_rewards(&self) -> Vec<MonthlyNodeProviderRewards> {
-        list_node_provider_rewards()
+    pub fn list_node_provider_rewards(&self, limit: u64) -> Vec<MonthlyNodeProviderRewards> {
+        let limit = limit.min(MAX_LIST_NODE_PROVIDER_REWARDS_RESULTS);
+        list_node_provider_rewards(limit)
             .into_iter()
             .map(|archived| match archived.version {
                 Some(archived_monthly_node_provider_rewards::Version::Version1(v1)) => {

--- a/rs/nns/governance/src/governance/tests/mod.rs
+++ b/rs/nns/governance/src/governance/tests/mod.rs
@@ -23,6 +23,7 @@ use maplit::{btreemap, hashmap};
 use std::convert::TryFrom;
 
 mod neurons_fund;
+mod node_provider_rewards;
 mod stake_maturity;
 
 #[test]
@@ -1622,55 +1623,6 @@ fn topic_min_max_test() {
         assert!(topic >= Topic::MIN, "Topic::MIN needs to be updated");
         assert!(topic <= Topic::MAX, "Topic::MAX needs to be updated");
     }
-}
-
-#[test]
-fn test_node_provider_rewards_read_from_correct_sources() {
-    let rewards_1 = MonthlyNodeProviderRewards {
-        timestamp: 1,
-        rewards: vec![],
-        xdr_conversion_rate: None,
-        minimum_xdr_permyriad_per_icp: None,
-        maximum_node_provider_rewards_e8s: None,
-        registry_version: None,
-        node_providers: vec![],
-    };
-
-    let rewards_2 = MonthlyNodeProviderRewards {
-        timestamp: 2,
-        rewards: vec![],
-        xdr_conversion_rate: None,
-        minimum_xdr_permyriad_per_icp: None,
-        maximum_node_provider_rewards_e8s: None,
-        registry_version: None,
-        node_providers: vec![],
-    };
-
-    let mut governance = Governance::new(
-        GovernanceProto {
-            most_recent_monthly_node_provider_rewards: Some(rewards_1.clone()),
-            ..Default::default()
-        },
-        Box::new(MockEnvironment::new(vec![], 100)),
-        Box::new(StubIcpLedger {}),
-        Box::new(StubCMC {}),
-    );
-
-    let result_1 = governance.get_most_recent_monthly_node_provider_rewards();
-
-    assert_eq!(result_1.unwrap(), rewards_1);
-
-    governance.update_most_recent_monthly_node_provider_rewards(rewards_2.clone());
-    // TODO stop recording this in heap data
-    assert_eq!(
-        governance
-            .heap_data
-            .most_recent_monthly_node_provider_rewards,
-        Some(rewards_2.clone())
-    );
-
-    let result_2 = governance.get_most_recent_monthly_node_provider_rewards();
-    assert_eq!(result_2.unwrap(), rewards_2);
 }
 
 #[cfg(feature = "test")]

--- a/rs/nns/governance/src/governance/tests/node_provider_rewards.rs
+++ b/rs/nns/governance/src/governance/tests/node_provider_rewards.rs
@@ -90,7 +90,7 @@ fn test_list_node_provider_rewards_api() {
 
     let result = governance.list_node_provider_rewards(2);
 
-    assert_eq!(result, vec![rewards_1, rewards_2]);
+    assert_eq!(result, vec![rewards_2, rewards_1]);
 }
 
 #[test]
@@ -176,6 +176,6 @@ fn test_list_node_provider_rewards_api_with_paging_and_filters() {
     assert_eq!(result.len(), 5);
     assert_eq!(
         result,
-        vec![rewards_2, rewards_3, rewards_4, rewards_5, rewards_6]
+        vec![rewards_6, rewards_5, rewards_4, rewards_3, rewards_2]
     );
 }

--- a/rs/nns/governance/src/governance/tests/node_provider_rewards.rs
+++ b/rs/nns/governance/src/governance/tests/node_provider_rewards.rs
@@ -54,7 +54,7 @@ fn test_node_provider_rewards_read_from_correct_sources() {
 }
 
 #[test]
-fn test_list_minted_node_provider_rewards_api() {
+fn test_list_node_provider_rewards_api() {
     let rewards_1 = MonthlyNodeProviderRewards {
         timestamp: 1721029451, // july 15 2024
         rewards: vec![],
@@ -94,7 +94,7 @@ fn test_list_minted_node_provider_rewards_api() {
 }
 
 #[test]
-fn test_list_minted_node_provider_rewards_api_with_paging_and_filters() {
+fn test_list_node_provider_rewards_api_with_paging_and_filters() {
     let rewards_1 = MonthlyNodeProviderRewards {
         timestamp: 1721029451, // july 15 2024
         rewards: vec![],

--- a/rs/nns/governance/src/governance/tests/node_provider_rewards.rs
+++ b/rs/nns/governance/src/governance/tests/node_provider_rewards.rs
@@ -1,0 +1,145 @@
+use crate::{
+    governance::Governance,
+    pb::v1::{Governance as GovernanceProto, MonthlyNodeProviderRewards},
+    test_utils::{MockEnvironment, StubCMC, StubIcpLedger},
+};
+
+#[test]
+fn test_node_provider_rewards_read_from_correct_sources() {
+    let rewards_1 = MonthlyNodeProviderRewards {
+        timestamp: 1,
+        rewards: vec![],
+        xdr_conversion_rate: None,
+        minimum_xdr_permyriad_per_icp: None,
+        maximum_node_provider_rewards_e8s: None,
+        registry_version: None,
+        node_providers: vec![],
+    };
+
+    let rewards_2 = MonthlyNodeProviderRewards {
+        timestamp: 2,
+        rewards: vec![],
+        xdr_conversion_rate: None,
+        minimum_xdr_permyriad_per_icp: None,
+        maximum_node_provider_rewards_e8s: None,
+        registry_version: None,
+        node_providers: vec![],
+    };
+
+    let mut governance = Governance::new(
+        GovernanceProto {
+            most_recent_monthly_node_provider_rewards: Some(rewards_1.clone()),
+            ..Default::default()
+        },
+        Box::new(MockEnvironment::new(vec![], 100)),
+        Box::new(StubIcpLedger {}),
+        Box::new(StubCMC {}),
+    );
+
+    let result_1 = governance.get_most_recent_monthly_node_provider_rewards();
+
+    assert_eq!(result_1.unwrap(), rewards_1);
+
+    governance.update_most_recent_monthly_node_provider_rewards(rewards_2.clone());
+    // TODO stop recording this in heap data
+    assert_eq!(
+        governance
+            .heap_data
+            .most_recent_monthly_node_provider_rewards,
+        Some(rewards_2.clone())
+    );
+
+    let result_2 = governance.get_most_recent_monthly_node_provider_rewards();
+    assert_eq!(result_2.unwrap(), rewards_2);
+}
+
+#[test]
+fn test_list_minted_node_provider_rewards_api() {
+    let rewards_1 = MonthlyNodeProviderRewards {
+        timestamp: 1721029451, // july 15 2024
+        rewards: vec![],
+        xdr_conversion_rate: None,
+        minimum_xdr_permyriad_per_icp: None,
+        maximum_node_provider_rewards_e8s: None,
+        registry_version: None,
+        node_providers: vec![],
+    };
+
+    let rewards_2 = MonthlyNodeProviderRewards {
+        timestamp: 1723707851, // august 15 2024
+        rewards: vec![],
+        xdr_conversion_rate: None,
+        minimum_xdr_permyriad_per_icp: None,
+        maximum_node_provider_rewards_e8s: None,
+        registry_version: None,
+        node_providers: vec![],
+    };
+
+    let mut governance = Governance::new(
+        GovernanceProto {
+            ..Default::default()
+        },
+        Box::new(MockEnvironment::new(vec![], 100)),
+        Box::new(StubIcpLedger {}),
+        Box::new(StubCMC {}),
+    );
+
+    governance.update_most_recent_monthly_node_provider_rewards(rewards_1.clone());
+
+    governance.update_most_recent_monthly_node_provider_rewards(rewards_2.clone());
+
+    let result = governance.list_node_provider_rewards();
+
+    assert_eq!(result, vec![rewards_1, rewards_2]);
+}
+
+#[test]
+fn test_list_minted_node_provider_rewards_api_with_paging_and_filters() {
+    let rewards_1 = MonthlyNodeProviderRewards {
+        timestamp: 1721029451, // july 15 2024
+        rewards: vec![],
+        xdr_conversion_rate: None,
+        minimum_xdr_permyriad_per_icp: None,
+        maximum_node_provider_rewards_e8s: None,
+        registry_version: None,
+        node_providers: vec![],
+    };
+
+    let rewards_2 = MonthlyNodeProviderRewards {
+        timestamp: 1723707851, // august 15 2024
+        rewards: vec![],
+        xdr_conversion_rate: None,
+        minimum_xdr_permyriad_per_icp: None,
+        maximum_node_provider_rewards_e8s: None,
+        registry_version: None,
+        node_providers: vec![],
+    };
+    let rewards_3 = MonthlyNodeProviderRewards {
+        timestamp: 1726374659, // sept 15 2024
+        rewards: vec![],
+        xdr_conversion_rate: None,
+        minimum_xdr_permyriad_per_icp: None,
+        maximum_node_provider_rewards_e8s: None,
+        registry_version: None,
+        node_providers: vec![],
+    };
+
+    let mut governance = Governance::new(
+        GovernanceProto {
+            ..Default::default()
+        },
+        Box::new(MockEnvironment::new(vec![], 100)),
+        Box::new(StubIcpLedger {}),
+        Box::new(StubCMC {}),
+    );
+
+    governance.update_most_recent_monthly_node_provider_rewards(rewards_1.clone());
+
+    governance.update_most_recent_monthly_node_provider_rewards(rewards_2.clone());
+
+    governance.update_most_recent_monthly_node_provider_rewards(rewards_3.clone());
+
+    let result = governance.list_node_provider_rewards(limit, filter);
+
+    assert_eq!(result, vec![rewards_1, rewards_2]);
+}

--- a/rs/nns/governance/src/governance/tests/node_provider_rewards.rs
+++ b/rs/nns/governance/src/governance/tests/node_provider_rewards.rs
@@ -88,7 +88,7 @@ fn test_list_minted_node_provider_rewards_api() {
 
     governance.update_most_recent_monthly_node_provider_rewards(rewards_2.clone());
 
-    let result = governance.list_node_provider_rewards();
+    let result = governance.list_node_provider_rewards(2);
 
     assert_eq!(result, vec![rewards_1, rewards_2]);
 }
@@ -124,6 +124,36 @@ fn test_list_minted_node_provider_rewards_api_with_paging_and_filters() {
         node_providers: vec![],
     };
 
+    let rewards_4 = MonthlyNodeProviderRewards {
+        timestamp: 1729041067, // oct 15 2024
+        rewards: vec![],
+        xdr_conversion_rate: None,
+        minimum_xdr_permyriad_per_icp: None,
+        maximum_node_provider_rewards_e8s: None,
+        registry_version: None,
+        node_providers: vec![],
+    };
+
+    let rewards_5 = MonthlyNodeProviderRewards {
+        timestamp: 1731707475, // nov 15 2024
+        rewards: vec![],
+        xdr_conversion_rate: None,
+        minimum_xdr_permyriad_per_icp: None,
+        maximum_node_provider_rewards_e8s: None,
+        registry_version: None,
+        node_providers: vec![],
+    };
+
+    let rewards_6 = MonthlyNodeProviderRewards {
+        timestamp: 1734373883, // dec 15 2024
+        rewards: vec![],
+        xdr_conversion_rate: None,
+        minimum_xdr_permyriad_per_icp: None,
+        maximum_node_provider_rewards_e8s: None,
+        registry_version: None,
+        node_providers: vec![],
+    };
+
     let mut governance = Governance::new(
         GovernanceProto {
             ..Default::default()
@@ -134,12 +164,18 @@ fn test_list_minted_node_provider_rewards_api_with_paging_and_filters() {
     );
 
     governance.update_most_recent_monthly_node_provider_rewards(rewards_1.clone());
-
     governance.update_most_recent_monthly_node_provider_rewards(rewards_2.clone());
-
     governance.update_most_recent_monthly_node_provider_rewards(rewards_3.clone());
+    governance.update_most_recent_monthly_node_provider_rewards(rewards_4.clone());
+    governance.update_most_recent_monthly_node_provider_rewards(rewards_5.clone());
+    governance.update_most_recent_monthly_node_provider_rewards(rewards_6.clone());
 
-    let result = governance.list_node_provider_rewards(limit, filter);
+    let result = governance.list_node_provider_rewards(6);
 
-    assert_eq!(result, vec![rewards_1, rewards_2]);
+    // limit of 5
+    assert_eq!(result.len(), 5);
+    assert_eq!(
+        result,
+        vec![rewards_2, rewards_3, rewards_4, rewards_5, rewards_6]
+    );
 }

--- a/rs/nns/governance/src/node_provider_rewards.rs
+++ b/rs/nns/governance/src/node_provider_rewards.rs
@@ -31,7 +31,6 @@ pub(crate) fn latest_node_provider_rewards() -> Option<ArchivedMonthlyNodeProvid
 }
 
 pub(crate) fn list_node_provider_rewards(limit: u64) -> Vec<ArchivedMonthlyNodeProviderRewards> {
-    use dfn_core::println;
     // limit try_into is safe because of u32 is always equal or smaller than usize
     with_node_provider_rewards_log(|log| {
         let len = log.len();

--- a/rs/nns/governance/src/node_provider_rewards.rs
+++ b/rs/nns/governance/src/node_provider_rewards.rs
@@ -36,7 +36,7 @@ pub(crate) fn list_node_provider_rewards(limit: u64) -> Vec<ArchivedMonthlyNodeP
     with_node_provider_rewards_log(|log| {
         let len = log.len();
         let skip = if len >= limit { len - limit } else { 0 };
-        println!("len: {}, skip: {}, limit: {}", len, skip, limit);
+
         log.iter()
             .skip(skip.try_into().unwrap())
             .take(limit.try_into().unwrap())

--- a/rs/nns/governance/src/node_provider_rewards.rs
+++ b/rs/nns/governance/src/node_provider_rewards.rs
@@ -37,12 +37,11 @@ pub(crate) fn list_node_provider_rewards(limit: u64) -> Vec<ArchivedMonthlyNodeP
 
         let end_range = len;
         let start_range = end_range.saturating_sub(limit);
-        let rewards = (start_range..end_range)
+
+        (start_range..end_range)
             .rev()
             .flat_map(|index| log.get(index))
-            .collect();
-
-        rewards
+            .collect()
     })
 }
 

--- a/rs/nns/governance/src/node_provider_rewards.rs
+++ b/rs/nns/governance/src/node_provider_rewards.rs
@@ -30,8 +30,18 @@ pub(crate) fn latest_node_provider_rewards() -> Option<ArchivedMonthlyNodeProvid
     })
 }
 
-pub(crate) fn list_node_provider_rewards() -> Vec<ArchivedMonthlyNodeProviderRewards> {
-    with_node_provider_rewards_log(|log| log.iter().collect())
+pub(crate) fn list_node_provider_rewards(limit: u64) -> Vec<ArchivedMonthlyNodeProviderRewards> {
+    use dfn_core::println;
+    // limit try_into is safe because of u32 is always equal or smaller than usize
+    with_node_provider_rewards_log(|log| {
+        let len = log.len();
+        let skip = if len >= limit { len - limit } else { 0 };
+        println!("len: {}, skip: {}, limit: {}", len, skip, limit);
+        log.iter()
+            .skip(skip.try_into().unwrap())
+            .take(limit.try_into().unwrap())
+            .collect()
+    })
 }
 
 #[cfg(test)]

--- a/rs/nns/governance/src/node_provider_rewards.rs
+++ b/rs/nns/governance/src/node_provider_rewards.rs
@@ -30,6 +30,10 @@ pub(crate) fn latest_node_provider_rewards() -> Option<ArchivedMonthlyNodeProvid
     })
 }
 
+pub(crate) fn list_node_provider_rewards() -> Vec<ArchivedMonthlyNodeProviderRewards> {
+    with_node_provider_rewards_log(|log| log.iter().collect())
+}
+
 #[cfg(test)]
 mod test {
     use super::*;

--- a/rs/nns/governance/src/node_provider_rewards.rs
+++ b/rs/nns/governance/src/node_provider_rewards.rs
@@ -33,13 +33,16 @@ pub(crate) fn latest_node_provider_rewards() -> Option<ArchivedMonthlyNodeProvid
 pub(crate) fn list_node_provider_rewards(limit: u64) -> Vec<ArchivedMonthlyNodeProviderRewards> {
     // limit try_into is safe because of u32 is always equal or smaller than usize
     with_node_provider_rewards_log(|log| {
-        let len = log.len();
-        let skip = if len >= limit { len - limit } else { 0 };
+        let len: u64 = log.len();
 
-        log.iter()
-            .skip(skip.try_into().unwrap())
-            .take(limit.try_into().unwrap())
-            .collect()
+        let end_range = len;
+        let start_range = end_range.saturating_sub(limit);
+        let rewards = (start_range..end_range)
+            .rev()
+            .flat_map(|index| log.get(index))
+            .collect();
+
+        rewards
     })
 }
 

--- a/rs/nns/integration_tests/src/node_provider_remuneration.rs
+++ b/rs/nns/integration_tests/src/node_provider_remuneration.rs
@@ -143,7 +143,7 @@ fn test_list_node_provider_rewards() {
     );
 
     // Assert the most recent monthly Node Provider reward was set as expected
-    let mut most_recent_rewards =
+    let most_recent_rewards =
         nns_get_most_recent_monthly_node_provider_rewards(&state_machine).unwrap();
     let this_rewards_timestamp = most_recent_rewards.timestamp;
 
@@ -207,7 +207,7 @@ fn test_list_node_provider_rewards() {
     assert_eq!(
         received_ts,
         minted_rewards_timestamps[8..13]
-            .into_iter()
+            .iter()
             .rev()
             .cloned()
             .collect::<Vec<_>>()
@@ -217,7 +217,7 @@ fn test_list_node_provider_rewards() {
     assert_eq!(
         response.rewards,
         minted_rewards[8..13]
-            .into_iter()
+            .iter()
             .rev()
             .cloned()
             .collect::<Vec<_>>()

--- a/rs/nns/integration_tests/src/node_provider_remuneration.rs
+++ b/rs/nns/integration_tests/src/node_provider_remuneration.rs
@@ -14,9 +14,9 @@ use ic_nns_governance_api::pb::v1::{
     add_or_remove_node_provider::Change,
     manage_neuron_response::Command as CommandResponse,
     reward_node_provider::{RewardMode, RewardToAccount},
-    AddOrRemoveNodeProvider, ExecuteNnsFunction, GovernanceError, MakeProposalRequest,
-    NetworkEconomics, NnsFunction, NodeProvider, ProposalActionRequest, RewardNodeProvider,
-    RewardNodeProviders,
+    AddOrRemoveNodeProvider, ExecuteNnsFunction, GovernanceError, ListNodeProviderRewardsRequest,
+    MakeProposalRequest, NetworkEconomics, NnsFunction, NodeProvider, ProposalActionRequest,
+    RewardNodeProvider, RewardNodeProviders,
 };
 use ic_nns_test_utils::{
     common::NnsInitPayloadsBuilder,
@@ -24,8 +24,8 @@ use ic_nns_test_utils::{
         get_pending_proposals, ledger_account_balance, nns_get_monthly_node_provider_rewards,
         nns_get_most_recent_monthly_node_provider_rewards, nns_get_network_economics_parameters,
         nns_governance_get_proposal_info, nns_governance_make_proposal,
-        nns_wait_for_proposal_execution, query, setup_nns_canisters,
-        state_machine_builder_for_nns_tests, update_with_sender,
+        nns_list_node_provider_rewards, nns_wait_for_proposal_execution, query,
+        setup_nns_canisters, state_machine_builder_for_nns_tests, update_with_sender,
     },
 };
 use ic_protobuf::registry::{
@@ -68,6 +68,161 @@ impl NodeInfo {
     }
 }
 
+#[test]
+fn test_list_node_provider_rewards() {
+    let state_machine = state_machine_builder_for_nns_tests().build();
+
+    let nns_init_payload = NnsInitPayloadsBuilder::new()
+        .with_initial_invariant_compliant_mutations()
+        .with_test_neurons()
+        .build();
+    setup_nns_canisters(&state_machine, nns_init_payload);
+
+    add_data_centers(&state_machine);
+    add_node_rewards_table(&state_machine);
+
+    // Define the set of node operators and node providers
+    let node_info_1 = NodeInfo::new(
+        *TEST_USER1_PRINCIPAL,
+        *TEST_USER2_PRINCIPAL,
+        AccountIdentifier::from(*TEST_USER2_PRINCIPAL),
+        None,
+    );
+    let reward_mode_1 = Some(RewardMode::RewardToAccount(RewardToAccount {
+        to_account: Some(node_info_1.provider_account.into()),
+    }));
+    let expected_rewards_e8s_1 = ((10 * 24_000) * TOKEN_SUBDIVIDABLE_BY) / 155_000;
+    let expected_node_provider_reward_1 = RewardNodeProvider {
+        node_provider: Some(node_info_1.provider.clone()),
+        amount_e8s: expected_rewards_e8s_1,
+        reward_mode: reward_mode_1.clone(),
+    };
+
+    // Add Node Providers
+    add_node_provider(&state_machine, node_info_1.provider.clone());
+
+    // Add Node Operator 1
+    let rewardable_nodes_1 = btreemap! { "default".to_string() => 10 };
+    add_node_operator(
+        &state_machine,
+        &node_info_1.operator_id,
+        &node_info_1.provider_id,
+        "AN1",
+        rewardable_nodes_1,
+        "0:0:0:0:0:0:0:0",
+    );
+
+    // Set the average conversion rate
+    set_average_icp_xdr_conversion_rate(&state_machine, 155_000);
+
+    // Call get_monthly_node_provider_rewards assert the value is as expected
+    let monthly_node_provider_rewards_result: Result<RewardNodeProviders, GovernanceError> =
+        nns_get_monthly_node_provider_rewards(&state_machine);
+
+    let monthly_node_provider_rewards = monthly_node_provider_rewards_result.unwrap();
+
+    assert!(monthly_node_provider_rewards
+        .rewards
+        .contains(&expected_node_provider_reward_1));
+
+    // Assert account balances are 0
+    assert_account_balance(&state_machine, node_info_1.provider_account, 0);
+
+    // Assert there is no most recent monthly Node Provider reward
+    let most_recent_rewards = nns_get_most_recent_monthly_node_provider_rewards(&state_machine);
+    assert!(most_recent_rewards.is_none());
+
+    // Submit and execute proposal to pay NPs via Registry-driven rewards
+    reward_node_providers_via_registry(&state_machine);
+
+    // Assert account balances are as expected
+    assert_account_balance(
+        &state_machine,
+        node_info_1.provider_account,
+        expected_node_provider_reward_1.amount_e8s,
+    );
+
+    // Assert the most recent monthly Node Provider reward was set as expected
+    let mut most_recent_rewards =
+        nns_get_most_recent_monthly_node_provider_rewards(&state_machine).unwrap();
+    let this_rewards_timestamp = most_recent_rewards.timestamp;
+
+    assert!(most_recent_rewards
+        .rewards
+        .contains(&expected_node_provider_reward_1));
+
+    // Assert advancing time less than a month doesn't trigger monthly NP rewards
+    let mut rewards_were_triggered = false;
+    for _ in 0..5 {
+        state_machine.advance_time(Duration::from_secs(60));
+        let most_recent_rewards =
+            nns_get_most_recent_monthly_node_provider_rewards(&state_machine).unwrap();
+        if most_recent_rewards.timestamp != this_rewards_timestamp {
+            rewards_were_triggered = true;
+            break;
+        }
+    }
+
+    assert!(
+        !rewards_were_triggered,
+        "Automated rewards were triggered even though less than 1 month has passed."
+    );
+
+    // Assert account balances haven't changed
+    assert_account_balance(
+        &state_machine,
+        node_info_1.provider_account,
+        expected_node_provider_reward_1.amount_e8s,
+    );
+
+    // Set a new average conversion rate so that we can assert that the automated monthly
+    // NP rewards paid a different reward than the proposal-based reward.
+    let average_icp_xdr_conversion_rate_for_automated_rewards = 345_000;
+    set_average_icp_xdr_conversion_rate(
+        &state_machine,
+        average_icp_xdr_conversion_rate_for_automated_rewards,
+    );
+
+    let mut minted_rewards = vec![most_recent_rewards.clone()];
+    for _ in 0..12 {
+        // Assert that advancing time by a month triggers an automated monthly NP reward event
+        state_machine.advance_time(Duration::from_secs(ONE_MONTH_SECONDS + 1));
+        state_machine.advance_time(Duration::from_secs(60));
+        state_machine.tick();
+
+        let rewards = nns_get_most_recent_monthly_node_provider_rewards(&state_machine).unwrap();
+
+        minted_rewards.push(rewards.clone());
+    }
+
+    let response =
+        nns_list_node_provider_rewards(&state_machine, ListNodeProviderRewardsRequest {});
+
+    assert_eq!(response.rewards.len(), 5);
+
+    let received_ts: Vec<u64> = response.rewards.iter().map(|r| r.timestamp).collect();
+    let minted_rewards_timestamps: Vec<u64> = minted_rewards.iter().map(|r| r.timestamp).collect();
+
+    // First we test paging all the results with no filters.
+    assert_eq!(
+        received_ts,
+        minted_rewards_timestamps[8..13]
+            .into_iter()
+            .rev()
+            .cloned()
+            .collect::<Vec<_>>()
+    );
+
+    // check rewards are as expected
+    assert_eq!(
+        response.rewards,
+        minted_rewards[8..13]
+            .into_iter()
+            .rev()
+            .cloned()
+            .collect::<Vec<_>>()
+    );
+}
 #[test]
 fn test_automated_node_provider_remuneration() {
     let state_machine = state_machine_builder_for_nns_tests().build();

--- a/rs/nns/test_utils/src/state_test_helpers.rs
+++ b/rs/nns/test_utils/src/state_test_helpers.rs
@@ -47,10 +47,10 @@ use ic_nns_governance_api::pb::v1::{
     },
     manage_neuron_response::{self, ClaimOrRefreshResponse},
     Empty, ExecuteNnsFunction, Governance, GovernanceError, InstallCodeRequest, ListNeurons,
-    ListNeuronsResponse, ListProposalInfo, ListProposalInfoResponse, MakeProposalRequest,
-    ManageNeuronCommandRequest, ManageNeuronRequest, ManageNeuronResponse,
-    MonthlyNodeProviderRewards, NetworkEconomics, NnsFunction, ProposalActionRequest, ProposalInfo,
-    RewardNodeProviders, Vote,
+    ListNeuronsResponse, ListNodeProviderRewardsRequest, ListNodeProviderRewardsResponse,
+    ListProposalInfo, ListProposalInfoResponse, MakeProposalRequest, ManageNeuronCommandRequest,
+    ManageNeuronRequest, ManageNeuronResponse, MonthlyNodeProviderRewards, NetworkEconomics,
+    NnsFunction, ProposalActionRequest, ProposalInfo, RewardNodeProviders, Vote,
 };
 use ic_nns_handler_lifeline_interface::UpgradeRootProposal;
 use ic_nns_handler_root::init::RootCanisterInitPayload;
@@ -1390,6 +1390,26 @@ pub fn nns_get_most_recent_monthly_node_provider_rewards(
     };
 
     Decode!(&result, Option<MonthlyNodeProviderRewards>).unwrap()
+}
+
+pub fn nns_list_node_provider_rewards(
+    state_machine: &StateMachine,
+    list_node_provider_rewards_request: ListNodeProviderRewardsRequest,
+) -> ListNodeProviderRewardsResponse {
+    let result = state_machine
+        .execute_ingress(
+            GOVERNANCE_CANISTER_ID,
+            "list_node_provider_rewards",
+            Encode!(&list_node_provider_rewards_request).unwrap(),
+        )
+        .unwrap();
+
+    let result = match result {
+        WasmResult::Reply(result) => result,
+        WasmResult::Reject(s) => panic!("Call to list_node_provider_rewards failed: {:#?}", s),
+    };
+
+    Decode!(&result, ListNodeProviderRewardsResponse).unwrap()
 }
 
 pub fn nns_get_network_economics_parameters(state_machine: &StateMachine) -> NetworkEconomics {


### PR DESCRIPTION
This adds a simple endpoint to load previous node provider rewards.

Followup work to add a filter will happen.  For now, it includes up to the most recent 5 results.