### PR TITLE
fix: Remove linking instructions from ic-backtrace

### DIFF
--- a/rs/monitoring/backtrace/BUILD.bazel
+++ b/rs/monitoring/backtrace/BUILD.bazel
@@ -17,5 +17,5 @@ rust_library(
         "@platforms//os:linux",
     ],
     version = "0.9.0",
-    deps = DEPENDENCIES + [":build_script"],
+    deps = DEPENDENCIES,
 )

--- a/rs/monitoring/backtrace/BUILD.bazel
+++ b/rs/monitoring/backtrace/BUILD.bazel
@@ -1,4 +1,3 @@
-load("@rules_rust//cargo:defs.bzl", "cargo_build_script")
 load("@rules_rust//rust:defs.bzl", "rust_library")
 
 package(default_visibility = ["//visibility:public"])
@@ -9,16 +8,6 @@ DEPENDENCIES = [
     "@crate_index//:regex",
     "@crate_index//:rstack-self",
 ]
-
-cargo_build_script(
-    name = "build_script",
-    srcs = ["build.rs"],
-    data = [],
-    target_compatible_with = [
-        "@platforms//os:linux",
-    ],
-    deps = [],
-)
 
 rust_library(
     name = "backtrace",

--- a/rs/monitoring/backtrace/build.rs
+++ b/rs/monitoring/backtrace/build.rs
@@ -1,8 +1,0 @@
-fn main() {
-    if std::env::var("TARGET").unwrap() == "x86_64-unknown-linux-gnu" {
-        println!("cargo:rustc-link-lib=static=unwind");
-        println!("cargo:rustc-link-lib=static=unwind-ptrace");
-        println!("cargo:rustc-link-lib=static=unwind-x86_64");
-        println!("cargo:rustc-link-lib=dylib=lzma");
-    }
-}


### PR DESCRIPTION
The dependencies of ic-backtrace (e.g., unwind-sys) have already included linking instructions for libunwind, and this build.rs gives conflicting information and leads to compilation failures in certain cases.