### PR TITLE
fix: Fix ic-backtrace build.rs

### DIFF
--- a/Cargo.Bazel.Fuzzing.json.lock
+++ b/Cargo.Bazel.Fuzzing.json.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "b8f5c546714a2fd2ce702051dd8da9f2c7e988036a0357c3c75d6deaefba88a6",
+  "checksum": "2d762a45ee0136e5124cb2a9284bd5712b43f30ed72690bdca29c7c2519b9e35",
   "crates": {
     "abnf 0.12.0": {
       "name": "abnf",
@@ -36029,38 +36029,30 @@
         ],
         "crate_features": {
           "common": [
+            "elf",
+            "errno",
             "general",
             "ioctl",
             "no_std"
           ],
           "selects": {
             "aarch64-unknown-linux-gnu": [
-              "elf",
-              "errno",
               "prctl",
               "system"
             ],
             "aarch64-unknown-nixos-gnu": [
-              "elf",
-              "errno",
               "prctl",
               "system"
             ],
             "arm-unknown-linux-gnueabi": [
-              "elf",
-              "errno",
               "prctl",
               "system"
             ],
             "armv7-unknown-linux-gnueabi": [
-              "elf",
-              "errno",
               "prctl",
               "system"
             ],
             "i686-unknown-linux-gnu": [
-              "elf",
-              "errno",
               "prctl",
               "system"
             ],
@@ -36073,14 +36065,10 @@
               "system"
             ],
             "x86_64-unknown-linux-gnu": [
-              "elf",
-              "errno",
               "prctl",
               "system"
             ],
             "x86_64-unknown-nixos-gnu": [
-              "elf",
-              "errno",
               "prctl",
               "system"
             ]
@@ -53677,9 +53665,12 @@
       "version": "0.3.3",
       "package_url": "https://github.com/sfackler/rstack",
       "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/rstack/0.3.3/download",
-          "sha256": "e7df9d3ebd4f17b52e6134efe2fa20021c80688cbe823d481a729a993b730493"
+        "Git": {
+          "remote": "https://github.com/ninegua/rstack",
+          "commitish": {
+            "Rev": "ba2ec279889afde30693f6b034658e5e862da2a9"
+          },
+          "strip_prefix": "rstack"
         }
       },
       "targets": [
@@ -53703,6 +53694,7 @@
         ],
         "crate_features": {
           "common": [
+            "static",
             "unwind",
             "unwind_"
           ],
@@ -53723,7 +53715,7 @@
               "target": "log"
             },
             {
-              "id": "unwind 0.4.1",
+              "id": "unwind 0.4.2",
               "target": "unwind",
               "alias": "unwind_"
             }
@@ -53745,9 +53737,12 @@
       "version": "0.3.0",
       "package_url": "https://github.com/sfackler/rstack",
       "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/rstack-self/0.3.0/download",
-          "sha256": "6dd5030da3aba0ec731502f74ec38e63798eea6bc8b8ba5972129afe3eababd2"
+        "Git": {
+          "remote": "https://github.com/ninegua/rstack",
+          "commitish": {
+            "Rev": "ba2ec279889afde30693f6b034658e5e862da2a9"
+          },
+          "strip_prefix": "rstack-self"
         }
       },
       "targets": [
@@ -53772,6 +53767,7 @@
         "crate_features": {
           "common": [
             "default",
+            "static",
             "unwind"
           ],
           "selects": {}
@@ -69421,14 +69417,17 @@
       ],
       "license_file": "LICENSE.txt"
     },
-    "unwind 0.4.1": {
+    "unwind 0.4.2": {
       "name": "unwind",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "package_url": "https://github.com/sfackler/rstack",
       "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/unwind/0.4.1/download",
-          "sha256": "f0e0da3c8d6b71dbaf219188cc0e7f9ca3943f3263ca479920338d92d7ea5e07"
+        "Git": {
+          "remote": "https://github.com/ninegua/rstack",
+          "commitish": {
+            "Rev": "ba2ec279889afde30693f6b034658e5e862da2a9"
+          },
+          "strip_prefix": "unwind"
         }
       },
       "targets": [
@@ -69464,7 +69463,8 @@
         ],
         "crate_features": {
           "common": [
-            "ptrace"
+            "ptrace",
+            "static"
           ],
           "selects": {}
         },
@@ -69479,18 +69479,18 @@
               "target": "libc"
             },
             {
-              "id": "unwind 0.4.1",
+              "id": "unwind 0.4.2",
               "target": "build_script_build"
             },
             {
-              "id": "unwind-sys 0.1.3",
+              "id": "unwind-sys 0.1.4",
               "target": "unwind_sys"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.4.1"
+        "version": "0.4.2"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -69499,7 +69499,7 @@
         "link_deps": {
           "common": [
             {
-              "id": "unwind-sys 0.1.3",
+              "id": "unwind-sys 0.1.4",
               "target": "unwind_sys"
             }
           ],
@@ -69513,14 +69513,17 @@
       ],
       "license_file": null
     },
-    "unwind-sys 0.1.3": {
+    "unwind-sys 0.1.4": {
       "name": "unwind-sys",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "package_url": "https://github.com/sfackler/rstack",
       "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/unwind-sys/0.1.3/download",
-          "sha256": "d554005b247de226d124a523cae6cd6a4348277071258296dda837cf760e02e7"
+        "Git": {
+          "remote": "https://github.com/ninegua/rstack",
+          "commitish": {
+            "Rev": "ba2ec279889afde30693f6b034658e5e862da2a9"
+          },
+          "strip_prefix": "unwind-sys"
         }
       },
       "targets": [
@@ -69556,7 +69559,8 @@
         ],
         "crate_features": {
           "common": [
-            "ptrace"
+            "ptrace",
+            "static"
           ],
           "selects": {}
         },
@@ -69567,14 +69571,14 @@
               "target": "libc"
             },
             {
-              "id": "unwind-sys 0.1.3",
+              "id": "unwind-sys 0.1.4",
               "target": "build_script_build"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.1.3"
+        "version": "0.1.4"
       },
       "build_script_attrs": {
         "data_glob": [

--- a/Cargo.Bazel.Fuzzing.toml.lock
+++ b/Cargo.Bazel.Fuzzing.toml.lock
@@ -9219,8 +9219,7 @@ dependencies = [
 [[package]]
 name = "rstack"
 version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7df9d3ebd4f17b52e6134efe2fa20021c80688cbe823d481a729a993b730493"
+source = "git+https://github.com/ninegua/rstack?rev=ba2ec279889afde30693f6b034658e5e862da2a9#ba2ec279889afde30693f6b034658e5e862da2a9"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
@@ -9231,8 +9230,7 @@ dependencies = [
 [[package]]
 name = "rstack-self"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dd5030da3aba0ec731502f74ec38e63798eea6bc8b8ba5972129afe3eababd2"
+source = "git+https://github.com/ninegua/rstack?rev=ba2ec279889afde30693f6b034658e5e862da2a9#ba2ec279889afde30693f6b034658e5e862da2a9"
 dependencies = [
  "antidote",
  "backtrace",
@@ -11795,9 +11793,8 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "unwind"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0e0da3c8d6b71dbaf219188cc0e7f9ca3943f3263ca479920338d92d7ea5e07"
+version = "0.4.2"
+source = "git+https://github.com/ninegua/rstack?rev=ba2ec279889afde30693f6b034658e5e862da2a9#ba2ec279889afde30693f6b034658e5e862da2a9"
 dependencies = [
  "foreign-types",
  "libc",
@@ -11806,9 +11803,8 @@ dependencies = [
 
 [[package]]
 name = "unwind-sys"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d554005b247de226d124a523cae6cd6a4348277071258296dda837cf760e02e7"
+version = "0.1.4"
+source = "git+https://github.com/ninegua/rstack?rev=ba2ec279889afde30693f6b034658e5e862da2a9#ba2ec279889afde30693f6b034658e5e862da2a9"
 dependencies = [
  "libc",
  "pkg-config",

--- a/Cargo.Bazel.json.lock
+++ b/Cargo.Bazel.json.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "c7b3cc51485548cd37eaeebfd34bdf0d7cbcb2a63ec2796f634161b05aa91b89",
+  "checksum": "8fbce2035b533c5c81efaa94fedf8cfbcfbd7c2af82824dbaebb29a0c6fe3f67",
   "crates": {
     "abnf 0.12.0": {
       "name": "abnf",
@@ -36065,38 +36065,30 @@
         ],
         "crate_features": {
           "common": [
+            "elf",
+            "errno",
             "general",
             "ioctl",
             "no_std"
           ],
           "selects": {
             "aarch64-unknown-linux-gnu": [
-              "elf",
-              "errno",
               "prctl",
               "system"
             ],
             "aarch64-unknown-nixos-gnu": [
-              "elf",
-              "errno",
               "prctl",
               "system"
             ],
             "arm-unknown-linux-gnueabi": [
-              "elf",
-              "errno",
               "prctl",
               "system"
             ],
             "armv7-unknown-linux-gnueabi": [
-              "elf",
-              "errno",
               "prctl",
               "system"
             ],
             "i686-unknown-linux-gnu": [
-              "elf",
-              "errno",
               "prctl",
               "system"
             ],
@@ -36109,14 +36101,10 @@
               "system"
             ],
             "x86_64-unknown-linux-gnu": [
-              "elf",
-              "errno",
               "prctl",
               "system"
             ],
             "x86_64-unknown-nixos-gnu": [
-              "elf",
-              "errno",
               "prctl",
               "system"
             ]
@@ -53726,9 +53714,12 @@
       "version": "0.3.3",
       "package_url": "https://github.com/sfackler/rstack",
       "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/rstack/0.3.3/download",
-          "sha256": "e7df9d3ebd4f17b52e6134efe2fa20021c80688cbe823d481a729a993b730493"
+        "Git": {
+          "remote": "https://github.com/ninegua/rstack",
+          "commitish": {
+            "Rev": "ba2ec279889afde30693f6b034658e5e862da2a9"
+          },
+          "strip_prefix": "rstack"
         }
       },
       "targets": [
@@ -53752,6 +53743,7 @@
         ],
         "crate_features": {
           "common": [
+            "static",
             "unwind",
             "unwind_"
           ],
@@ -53772,7 +53764,7 @@
               "target": "log"
             },
             {
-              "id": "unwind 0.4.1",
+              "id": "unwind 0.4.2",
               "target": "unwind",
               "alias": "unwind_"
             }
@@ -53794,9 +53786,12 @@
       "version": "0.3.0",
       "package_url": "https://github.com/sfackler/rstack",
       "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/rstack-self/0.3.0/download",
-          "sha256": "6dd5030da3aba0ec731502f74ec38e63798eea6bc8b8ba5972129afe3eababd2"
+        "Git": {
+          "remote": "https://github.com/ninegua/rstack",
+          "commitish": {
+            "Rev": "ba2ec279889afde30693f6b034658e5e862da2a9"
+          },
+          "strip_prefix": "rstack-self"
         }
       },
       "targets": [
@@ -53821,6 +53816,7 @@
         "crate_features": {
           "common": [
             "default",
+            "static",
             "unwind"
           ],
           "selects": {}
@@ -69593,14 +69589,17 @@
       ],
       "license_file": "LICENSE.txt"
     },
-    "unwind 0.4.1": {
+    "unwind 0.4.2": {
       "name": "unwind",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "package_url": "https://github.com/sfackler/rstack",
       "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/unwind/0.4.1/download",
-          "sha256": "f0e0da3c8d6b71dbaf219188cc0e7f9ca3943f3263ca479920338d92d7ea5e07"
+        "Git": {
+          "remote": "https://github.com/ninegua/rstack",
+          "commitish": {
+            "Rev": "ba2ec279889afde30693f6b034658e5e862da2a9"
+          },
+          "strip_prefix": "unwind"
         }
       },
       "targets": [
@@ -69636,7 +69635,8 @@
         ],
         "crate_features": {
           "common": [
-            "ptrace"
+            "ptrace",
+            "static"
           ],
           "selects": {}
         },
@@ -69651,18 +69651,18 @@
               "target": "libc"
             },
             {
-              "id": "unwind 0.4.1",
+              "id": "unwind 0.4.2",
               "target": "build_script_build"
             },
             {
-              "id": "unwind-sys 0.1.3",
+              "id": "unwind-sys 0.1.4",
               "target": "unwind_sys"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.4.1"
+        "version": "0.4.2"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -69671,7 +69671,7 @@
         "link_deps": {
           "common": [
             {
-              "id": "unwind-sys 0.1.3",
+              "id": "unwind-sys 0.1.4",
               "target": "unwind_sys"
             }
           ],
@@ -69685,14 +69685,17 @@
       ],
       "license_file": null
     },
-    "unwind-sys 0.1.3": {
+    "unwind-sys 0.1.4": {
       "name": "unwind-sys",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "package_url": "https://github.com/sfackler/rstack",
       "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/unwind-sys/0.1.3/download",
-          "sha256": "d554005b247de226d124a523cae6cd6a4348277071258296dda837cf760e02e7"
+        "Git": {
+          "remote": "https://github.com/ninegua/rstack",
+          "commitish": {
+            "Rev": "ba2ec279889afde30693f6b034658e5e862da2a9"
+          },
+          "strip_prefix": "unwind-sys"
         }
       },
       "targets": [
@@ -69728,7 +69731,8 @@
         ],
         "crate_features": {
           "common": [
-            "ptrace"
+            "ptrace",
+            "static"
           ],
           "selects": {}
         },
@@ -69739,14 +69743,14 @@
               "target": "libc"
             },
             {
-              "id": "unwind-sys 0.1.3",
+              "id": "unwind-sys 0.1.4",
               "target": "build_script_build"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.1.3"
+        "version": "0.1.4"
       },
       "build_script_attrs": {
         "data_glob": [

--- a/Cargo.Bazel.toml.lock
+++ b/Cargo.Bazel.toml.lock
@@ -9238,8 +9238,7 @@ dependencies = [
 [[package]]
 name = "rstack"
 version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7df9d3ebd4f17b52e6134efe2fa20021c80688cbe823d481a729a993b730493"
+source = "git+https://github.com/ninegua/rstack?rev=ba2ec279889afde30693f6b034658e5e862da2a9#ba2ec279889afde30693f6b034658e5e862da2a9"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
@@ -9250,8 +9249,7 @@ dependencies = [
 [[package]]
 name = "rstack-self"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dd5030da3aba0ec731502f74ec38e63798eea6bc8b8ba5972129afe3eababd2"
+source = "git+https://github.com/ninegua/rstack?rev=ba2ec279889afde30693f6b034658e5e862da2a9#ba2ec279889afde30693f6b034658e5e862da2a9"
 dependencies = [
  "antidote",
  "backtrace",
@@ -11830,9 +11828,8 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "unwind"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0e0da3c8d6b71dbaf219188cc0e7f9ca3943f3263ca479920338d92d7ea5e07"
+version = "0.4.2"
+source = "git+https://github.com/ninegua/rstack?rev=ba2ec279889afde30693f6b034658e5e862da2a9#ba2ec279889afde30693f6b034658e5e862da2a9"
 dependencies = [
  "foreign-types",
  "libc",
@@ -11841,9 +11838,8 @@ dependencies = [
 
 [[package]]
 name = "unwind-sys"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d554005b247de226d124a523cae6cd6a4348277071258296dda837cf760e02e7"
+version = "0.1.4"
+source = "git+https://github.com/ninegua/rstack?rev=ba2ec279889afde30693f6b034658e5e862da2a9#ba2ec279889afde30693f6b034658e5e862da2a9"
 dependencies = [
  "libc",
  "pkg-config",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17756,8 +17756,7 @@ dependencies = [
 [[package]]
 name = "rstack"
 version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7df9d3ebd4f17b52e6134efe2fa20021c80688cbe823d481a729a993b730493"
+source = "git+https://github.com/ninegua/rstack?rev=ba2ec279889afde30693f6b034658e5e862da2a9#ba2ec279889afde30693f6b034658e5e862da2a9"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
@@ -17768,8 +17767,7 @@ dependencies = [
 [[package]]
 name = "rstack-self"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dd5030da3aba0ec731502f74ec38e63798eea6bc8b8ba5972129afe3eababd2"
+source = "git+https://github.com/ninegua/rstack?rev=ba2ec279889afde30693f6b034658e5e862da2a9#ba2ec279889afde30693f6b034658e5e862da2a9"
 dependencies = [
  "antidote",
  "backtrace",
@@ -20740,9 +20738,8 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "unwind"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0e0da3c8d6b71dbaf219188cc0e7f9ca3943f3263ca479920338d92d7ea5e07"
+version = "0.4.2"
+source = "git+https://github.com/ninegua/rstack?rev=ba2ec279889afde30693f6b034658e5e862da2a9#ba2ec279889afde30693f6b034658e5e862da2a9"
 dependencies = [
  "foreign-types 0.5.0",
  "libc",
@@ -20751,9 +20748,8 @@ dependencies = [
 
 [[package]]
 name = "unwind-sys"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d554005b247de226d124a523cae6cd6a4348277071258296dda837cf760e02e7"
+version = "0.1.4"
+source = "git+https://github.com/ninegua/rstack?rev=ba2ec279889afde30693f6b034658e5e862da2a9#ba2ec279889afde30693f6b034658e5e862da2a9"
 dependencies = [
  "libc",
  "pkg-config",

--- a/bazel/external_crates.bzl
+++ b/bazel/external_crates.bzl
@@ -1079,7 +1079,9 @@ def external_crates_repository(name, cargo_lockfile, lockfile, sanitizers_enable
                 features = ["sha2"],
             ),
             "rstack-self": crate.spec(
-                version = "^0.3",
+                git = "https://github.com/ninegua/rstack",
+                rev = "ba2ec279889afde30693f6b034658e5e862da2a9",
+                features = ["static"],
             ),
             "rstest": crate.spec(
                 version = "^0.19",

--- a/rs/monitoring/backtrace/Cargo.toml
+++ b/rs/monitoring/backtrace/Cargo.toml
@@ -9,4 +9,4 @@ documentation.workspace = true
 [dependencies]
 lazy_static = { workspace = true }
 regex = { workspace = true }
-rstack-self = "0.3"
+rstack-self = { git = "https://github.com/ninegua/rstack", rev = "ba2ec279889afde30693f6b034658e5e862da2a9", features = ["static"] }

--- a/rs/monitoring/backtrace/build.rs
+++ b/rs/monitoring/backtrace/build.rs
@@ -1,8 +1,5 @@
 fn main() {
     if std::env::var("TARGET").unwrap() == "x86_64-unknown-linux-gnu" {
-        println!("cargo:rustc-link-lib=static=unwind");
-        println!("cargo:rustc-link-lib=static=unwind-ptrace");
-        println!("cargo:rustc-link-lib=static=unwind-x86_64");
         println!("cargo:rustc-link-lib=dylib=lzma");
     }
 }


### PR DESCRIPTION
The dependencies of ic-backtrace (e.g., unwind-sys) have already included linking instructions for libunwind.

Removing such conflicting instructions from ic-backtrace help fix compilation failures in certain cases (e.g. with cargo build).
