### PR TITLE
fix(IDX): remove darwin container check

### DIFF
--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -212,15 +212,9 @@ load(
     "container_pull",
 )
 
-# NOTE: in all the `container_pull` below we set a dummy `puller_darwin` which is expected
-# to fail when called. In general we do not expect docker images to have to be downloaded
-# on Darwin. If a docker image is pulled on Darwin (by mistake), this will make the build
-# fail.
-
 container_pull(
     name = "static-file-server",
     digest = "sha256:c21bed6db05fe08f2da128fe96f5f5a06633348fb5bb37bf3581e6501c6b528a",
-    puller_darwin = "@does-not-exist",
     registry = "registry.gitlab.com/dfinity-lab/open/public-docker-registry",
     repository = "halverneus/static-file-server",
 )
@@ -228,7 +222,6 @@ container_pull(
 container_pull(
     name = "bitcoind",
     digest = "sha256:17c7dd21690f3be34630db7389d2f0bff14649e27a964afef03806a6d631e0f1",
-    puller_darwin = "@does-not-exist",
     registry = "registry.gitlab.com/dfinity-lab/open/public-docker-registry",
     repository = "kylemanna/bitcoind",
 )
@@ -236,7 +229,6 @@ container_pull(
 container_pull(
     name = "jaeger",
     digest = "sha256:f421219dbd77248301fc42ac6e8ba5026f4bada9448ab33ac89061e21cfe3fea",
-    puller_darwin = "@does-not-exist",
     registry = "docker.io",
     repository = "jaegertracing/all-in-one",
 )
@@ -244,7 +236,6 @@ container_pull(
 container_pull(
     name = "minica",
     digest = "sha256:c67e2c1885d438b5927176295d41aaab8a72dd9e1272ba85054bfc78191d05b0",
-    puller_darwin = "@does-not-exist",
     registry = "registry.gitlab.com/dfinity-lab/open/public-docker-registry",
     repository = "ryantk/minica",
 )
@@ -252,7 +243,6 @@ container_pull(
 container_pull(
     name = "rust_base",
     digest = "sha256:8e94f031353596c3fc9db6a2499bcc82dacc40cb71e0703476f9fad41677efdf",
-    puller_darwin = "@does-not-exist",
     registry = "gcr.io",
     repository = "distroless/cc-debian11",
 )
@@ -260,7 +250,6 @@ container_pull(
 container_pull(
     name = "ubuntu_base",
     digest = "sha256:965fbcae990b0467ed5657caceaec165018ef44a4d2d46c7cdea80a9dff0d1ea",
-    puller_darwin = "@does-not-exist",
     registry = "docker.io",
     repository = "ubuntu",
 )
@@ -268,7 +257,6 @@ container_pull(
 container_pull(
     name = "coredns",
     digest = "sha256:be7652ce0b43b1339f3d14d9b14af9f588578011092c1f7893bd55432d83a378",
-    puller_darwin = "@does-not-exist",
     registry = "docker.io",
     repository = "coredns/coredns",
     tag = "1.10.1",
@@ -277,7 +265,6 @@ container_pull(
 container_pull(
     name = "pebble",
     digest = "sha256:fc5a537bf8fbc7cc63aa24ec3142283aa9b6ba54529f86eb8ff31fbde7c5b258",
-    puller_darwin = "@does-not-exist",
     registry = "docker.io",
     repository = "letsencrypt/pebble",
     tag = "v2.3.1",
@@ -286,7 +273,6 @@ container_pull(
 container_pull(
     name = "python3",
     digest = "sha256:0a56f24afa1fc7f518aa690cb8c7be661225e40b157d9bb8c6ef402164d9faa7",
-    puller_darwin = "@does-not-exist",
     registry = "docker.io",
     repository = "python",
     tag = "3-alpine",
@@ -295,7 +281,6 @@ container_pull(
 container_pull(
     name = "alpine_openssl",
     digest = "sha256:cf89651f07a33d2faf4499f72e6f8b0ee2542cd40735d51c7e75b8965c17af0e",
-    puller_darwin = "@does-not-exist",
     registry = "docker.io",
     repository = "alpine/openssl",
 )
@@ -315,7 +300,6 @@ container_pull(
 container_pull(
     name = "ubuntu_test_runtime",
     digest = "sha256:d5b2f17ee8fcd45b4f1580893680b78a540f491e647a9f6971bdaab393e372f7",
-    puller_darwin = "@does-not-exist",
     registry = "registry.gitlab.com",
     repository = "dfinity-lab/open/public-docker-registry/ubuntu_test_runtime_image",
 )
@@ -324,7 +308,6 @@ container_pull(
 container_pull(
     name = "nns-dapp-specs",
     digest = "sha256:9e003fe2740f2813bf9e776b9cabd5cdb1fbe15581fc4b78876708fdf3791b3f",
-    puller_darwin = "@does-not-exist",
     registry = "registry.gitlab.com",
     repository = "dfinity-lab/open/public-docker-registry/nns-dapp-specs",
 )


### PR DESCRIPTION
This removes the custom `darwin_puller` that we set on `container_pull`, which was used to make the container pulls fail on Darwin.

The non-existent label caused issues with `bazel query` so they are removed. If the (now removed) check seems necessary in the future we'll figure out a better way to implement it.