### PR TITLE
chore: optimize NNS canister builds again

### DIFF
--- a/publish/canisters/BUILD.bazel
+++ b/publish/canisters/BUILD.bazel
@@ -85,9 +85,9 @@ CANISTERS_MAX_SIZE_COMPRESSED_E5_BYTES = {
 NNS_CANISTERS_MAX_SIZE_COMPRESSED_E5_BYTES = {
     "cycles-minting-canister.wasm.gz": "5",
     "genesis-token-canister.wasm.gz": "3",
-    "governance-canister.wasm.gz": "12",
-    "governance-canister_test.wasm.gz": "12",
-    "registry-canister.wasm.gz": "12",
+    "governance-canister.wasm.gz": "13",
+    "governance-canister_test.wasm.gz": "13",
+    "registry-canister.wasm.gz": "13",
     "root-canister.wasm.gz": "4",
 }
 

--- a/rs/nns/governance/BUILD.bazel
+++ b/rs/nns/governance/BUILD.bazel
@@ -233,7 +233,6 @@ rust_canister(
     srcs = ["canister/canister.rs"],
     aliases = ALIASES,
     compile_data = ["canister/governance.did"],
-    opt = "z",  # TODO: undo once dfx-extensions do not ungzip canister modules
     proc_macro_deps = MACRO_DEPENDENCIES,
     service_file = ":canister/governance.did",
     deps = DEPENDENCIES + [
@@ -248,7 +247,6 @@ rust_canister(
     aliases = ALIASES,
     compile_data = ["canister/governance_test.did"],
     crate_features = ["test"],
-    opt = "z",  # TODO: undo once dfx-extensions do not ungzip canister modules
     proc_macro_deps = MACRO_DEPENDENCIES,
     service_file = ":canister/governance_test.did",
     deps = DEPENDENCIES_WITH_TEST_FEATURES + [

--- a/rs/registry/canister/BUILD.bazel
+++ b/rs/registry/canister/BUILD.bazel
@@ -123,7 +123,6 @@ rust_canister(
     srcs = ["canister/canister.rs"],
     aliases = ALIASES,
     compile_data = ["canister/registry.did"],
-    opt = "z",  # TODO: undo once dfx-extensions do not ungzip canister modules
     proc_macro_deps = MACRO_DEPENDENCIES,
     service_file = ":canister/registry.did",
     deps = DEPENDENCIES + [":canister"] + [":build_script"],


### PR DESCRIPTION
The dfx-extensions [PR](https://github.com/dfinity/dfx-extensions/pull/106) keeping the canister WASM gzipped has been released in v0.4.1 and dfx v0.22.0 now uses a higher dfx-extensions v0.4.3 so we can safely switch back to optimizing NNS canister builds for performance (instructions) again, effectively reverting this [commit](https://github.com/dfinity/ic/commit/b32f4a47d41e1c84a2b2a7f9f65c6239ee73e8b1).