### PR TITLE
test: Disable the child lock in split_neuron to see if any test catches it

### DIFF
--- a/rs/nns/governance/src/governance.rs
+++ b/rs/nns/governance/src/governance.rs
@@ -2662,7 +2662,7 @@ impl Governance {
         .build();
 
         // Add the child neuron to the set of neurons undergoing ledger updates.
-        let _child_lock = self.lock_neuron_for_command(child_nid.id, in_flight_command.clone())?;
+        // let _child_lock = self.lock_neuron_for_command(child_nid.id, in_flight_command.clone())?;
 
         // We need to add the "embryo neuron" to the governance proto only after
         // acquiring the lock. Indeed, in case there is already a pending


### PR DESCRIPTION
This is not meant to be merged; just to see if the CI would currently catch us disabling a lock in split_neuron