### PR TITLE
perf: Optimize the implementation of dflate and add a test

### DIFF
--- a/rs/ic_os/dflate/BUILD.bazel
+++ b/rs/ic_os/dflate/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_rust//rust:defs.bzl", "rust_binary", "rust_library")
+load("@rules_rust//rust:defs.bzl", "rust_binary", "rust_library", "rust_test")
 
 package(default_visibility = ["//rs:ic-os-pkg"])
 
@@ -29,4 +29,9 @@ rust_library(
         "@crate_index//:libc",
         "@crate_index//:tar",
     ],
+)
+
+rust_test(
+    name="dflate_lib_test",
+    crate = ":dflate_lib"
 )

--- a/rs/ic_os/dflate/BUILD.bazel
+++ b/rs/ic_os/dflate/BUILD.bazel
@@ -32,6 +32,6 @@ rust_library(
 )
 
 rust_test(
-    name="dflate_lib_test",
-    crate = ":dflate_lib"
+    name = "dflate_lib_test",
+    crate = ":dflate_lib",
 )

--- a/rs/ic_os/dflate/src/lib.rs
+++ b/rs/ic_os/dflate/src/lib.rs
@@ -201,11 +201,11 @@ fn seek_data(file: &File, from: u64) -> Option<u64> {
 }
 
 pub mod tests {
+    use super::*;
     use anyhow::{Context, Result};
     use std::env;
     use std::path::{Path, PathBuf};
     use tar::Archive;
-    use super::*;
 
     fn test_dir() -> Result<PathBuf> {
         let mut path = PathBuf::new();

--- a/rs/ic_os/dflate/src/lib.rs
+++ b/rs/ic_os/dflate/src/lib.rs
@@ -1,5 +1,5 @@
 use std::fs::File;
-use std::io::{Read, Seek, SeekFrom, Write};
+use std::io::{BufReader, Read, Seek, SeekFrom, Write};
 use std::os::fd::AsRawFd;
 
 use anyhow::{bail, Result};
@@ -8,6 +8,8 @@ use tar::{Builder, EntryType, GnuExtSparseHeader, GnuSparseHeader, Header, Heade
 mod tar_util;
 mod types;
 use types::{Block, State};
+
+const MAX_BLOCK_SIZE: usize = 512;
 
 /// Scan through a file looking for empty sections by collecting only regions
 /// containing data, taking advantage of SEEK_DATA/SEEK_HOLE.
@@ -35,17 +37,21 @@ pub fn scan_file_for_holes(source: &mut File, name: String) -> Result<State> {
         };
         let end = seek_hole(source, start);
 
+        let mut reader = BufReader::new(Read::by_ref(source));
+        reader.seek(SeekFrom::Start(start))?;
+
+        // Read buffer that is reused across iterations.
+        let mut buffer = [0; MAX_BLOCK_SIZE];
         // Scan through this data section looking for any empty blocks.
         while start < end {
-            // NOTE: This will always be less than 512, so should totally fit into usize.
-            let to_read = std::cmp::min(end - start, 512);
-            let mut buffer = vec![0; to_read as usize];
-
-            source.seek(SeekFrom::Start(start))?;
-            source.read_exact(&mut buffer)?;
+            let to_read = std::cmp::min(end - start, MAX_BLOCK_SIZE as u64);
+            // We fill the first `to_read` bytes of the buffer. Casting `to_read` to usize is valid,
+            // since its max value is `MAX_BLOCK_SIZE` which itself is a usize.
+            let buffer_slice = &mut buffer[..to_read as usize];
+            reader.read_exact(buffer_slice)?;
 
             // Transition from non-empty to empty - wrap the current block.
-            if is_empty(&buffer) {
+            if is_empty(buffer_slice) {
                 if state.is_in_block() {
                     state.end_block(start);
                 }
@@ -166,7 +172,8 @@ where
 
 // null check from tar-rs
 fn is_empty(block: &[u8]) -> bool {
-    block.iter().all(|i| *i == 0)
+    // Efficiently check whether all elements are 0.
+    block == &[0; MAX_BLOCK_SIZE][..block.len()]
 }
 
 fn seek_hole(file: &File, from: u64) -> u64 {
@@ -191,4 +198,57 @@ fn seek_data(file: &File, from: u64) -> Option<u64> {
     }
 
     Some(out.try_into().unwrap())
+}
+
+pub mod tests {
+    use anyhow::{Context, Result};
+    use std::env;
+    use std::path::{Path, PathBuf};
+    use tar::Archive;
+    use super::*;
+
+    fn test_dir() -> Result<PathBuf> {
+        let mut path = PathBuf::new();
+        path.push(env::var("TEST_TMPDIR").context("Could not read bazel TEST_TMPDIR")?);
+        Ok(path)
+    }
+
+    #[test]
+    fn preserves_input() -> Result<()> {
+        let entries = vec![
+            ("first.txt", vec![0u8; 1024 * 1024]),
+            ("second.txt", vec![1u8; 512 * 1024]),
+            ("third.txt", vec![0u8; 2000 * 1000]),
+        ];
+
+        let mut output = vec![];
+        let mut output_builder = Builder::new(&mut output);
+
+        for (name, content) in &entries {
+            let mut file = File::create_new(test_dir()?.join(name))?;
+            file.write_all(content)?;
+            file.seek(SeekFrom::Start(0))?;
+            let state = scan_file_for_holes(&mut file, name.to_string())?;
+            add_file_to_archive(&mut file, &mut output_builder, state)?;
+        }
+        drop(output_builder);
+
+        // Verify archive size in bytes.
+        assert_eq!(output.len(), 526848);
+
+        let mut archive = Archive::new(&output[..]);
+        let mut output_entries = archive.entries()?;
+
+        // Verify that each entry was correctly preserved.
+        for entry_index in 0..entries.len() {
+            let mut output_entry = output_entries.next().expect("Tew few entries in output")?;
+            assert_eq!(output_entry.path()?, Path::new(entries[entry_index].0));
+
+            let mut output_content = vec![];
+            output_entry.read_to_end(&mut output_content)?;
+            assert_eq!(output_content, entries[entry_index].1);
+        }
+
+        Ok(())
+    }
 }

--- a/rs/ic_os/dflate/src/lib.rs
+++ b/rs/ic_os/dflate/src/lib.rs
@@ -176,7 +176,7 @@ fn is_empty(block: &[u8]) -> bool {
     block == &[0; MAX_BLOCK_SIZE][..block.len()]
 }
 
-fn seek_hole(file: &File, from: u64) -> u64 {
+fn seek_hole(file: &mut File, from: u64) -> u64 {
     // NOTE: u64 does not fully fit in i64, but i64::MAX is 9_223_372_036_854_775_807
     // (8 exbibytes) and we won't be seeing files this large any time soon.
     let unsized_from = from.try_into().unwrap();
@@ -186,7 +186,7 @@ fn seek_hole(file: &File, from: u64) -> u64 {
     out.try_into().unwrap()
 }
 
-fn seek_data(file: &File, from: u64) -> Option<u64> {
+fn seek_data(file: &mut File, from: u64) -> Option<u64> {
     // NOTE: u64 does not fully fit in i64, but i64::MAX is 9_223_372_036_854_775_807
     // (8 exbibytes) and we won't be seeing files this large any time soon.
     let unsized_from = from.try_into().unwrap();

--- a/rs/ic_os/dflate/src/lib.rs
+++ b/rs/ic_os/dflate/src/lib.rs
@@ -200,6 +200,7 @@ fn seek_data(file: &File, from: u64) -> Option<u64> {
     Some(out.try_into().unwrap())
 }
 
+#[cfg(test)]
 pub mod tests {
     use super::*;
     use anyhow::{Context, Result};

--- a/rs/ic_os/dflate/src/lib.rs
+++ b/rs/ic_os/dflate/src/lib.rs
@@ -240,13 +240,13 @@ pub mod tests {
         let mut output_entries = archive.entries()?;
 
         // Verify that each entry was correctly preserved.
-        for entry_index in 0..entries.len() {
+        for (expected_path, expected_content) in &entries {
             let mut output_entry = output_entries.next().expect("Too few entries in output")?;
-            assert_eq!(output_entry.path()?, Path::new(entries[entry_index].0));
+            assert_eq!(output_entry.path()?, Path::new(expected_path));
 
-            let mut output_content = vec![];
-            output_entry.read_to_end(&mut output_content)?;
-            assert_eq!(output_content, entries[entry_index].1);
+            let mut actual_content = vec![];
+            output_entry.read_to_end(&mut actual_content)?;
+            assert_eq!(&actual_content, expected_content);
         }
 
         Ok(())

--- a/rs/ic_os/dflate/src/lib.rs
+++ b/rs/ic_os/dflate/src/lib.rs
@@ -221,9 +221,7 @@ pub mod tests {
             ("third.txt", vec![0u8; 2000 * 1000]),
         ];
 
-        let mut output = vec![];
-        let mut output_builder = Builder::new(&mut output);
-
+        let mut output_builder = Builder::new(vec![]);
         for (name, content) in &entries {
             let mut file = File::create_new(test_dir()?.join(name))?;
             file.write_all(content)?;
@@ -231,7 +229,8 @@ pub mod tests {
             let state = scan_file_for_holes(&mut file, name.to_string())?;
             add_file_to_archive(&mut file, &mut output_builder, state)?;
         }
-        drop(output_builder);
+
+        let output = output_builder.into_inner()?;
 
         // Verify archive size in bytes.
         assert_eq!(output.len(), 526848);
@@ -241,7 +240,7 @@ pub mod tests {
 
         // Verify that each entry was correctly preserved.
         for entry_index in 0..entries.len() {
-            let mut output_entry = output_entries.next().expect("Tew few entries in output")?;
+            let mut output_entry = output_entries.next().expect("Too few entries in output")?;
             assert_eq!(output_entry.path()?, Path::new(entries[entry_index].0));
 
             let mut output_content = vec![];


### PR DESCRIPTION
NODE-1454

The following optimizations were done:
- Use a BufReader and remove unnecessary seeking
- Use a pre-allocated buffer instead of allocating a new buffer for every 512 bytes read
- Modify `is_empty` implementation so Rust generates more efficient assembly

I also added a test which passes both before and after the optimizations.

The optimizations make dflate on average ~2.5x faster in our build invocations, saving ~20seconds when building` //ic-os/guestos/envs/dev`

[NODE-1454]: https://dfinity.atlassian.net/browse/NODE-1454?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ