### PR TITLE
feat(nns): Store `wasm_metadata` in SNS-W's stable memory

### DIFF
--- a/rs/nns/sns-wasm/canister/canister.rs
+++ b/rs/nns/sns-wasm/canister/canister.rs
@@ -318,8 +318,6 @@ fn canister_pre_upgrade() {
     println!("{}Executing pre upgrade", LOG_PREFIX);
 
     SNS_WASM.with(|c| {
-        println!("c.wasm_metadata = {:#?}", c.borrow().wasm_metadata);
-        println!("c.wasm_metadata = {:?}", c.borrow().wasm_indexes);
         c.borrow().write_state_to_stable_memory();
     });
 
@@ -334,11 +332,7 @@ fn canister_post_upgrade() {
     println!("{}Executing post upgrade", LOG_PREFIX);
 
     SNS_WASM.with(|c| {
-        println!("c.wasm_metadata = {:#?}", c.borrow().wasm_metadata);
-        println!("c.wasm_metadata = {:?}", c.borrow().wasm_indexes);
         c.replace(SnsWasmCanister::<CanisterStableMemory>::from_stable_memory());
-        println!("c.wasm_metadata = {:#?}", c.borrow().wasm_metadata);
-        println!("c.wasm_metadata = {:?}", c.borrow().wasm_indexes);
     });
 
     println!("{}Completed post upgrade", LOG_PREFIX);

--- a/rs/nns/sns-wasm/canister/canister.rs
+++ b/rs/nns/sns-wasm/canister/canister.rs
@@ -317,7 +317,11 @@ fn canister_init_(init_payload: SnsWasmCanisterInitPayload) {
 fn canister_pre_upgrade() {
     println!("{}Executing pre upgrade", LOG_PREFIX);
 
-    SNS_WASM.with(|c| c.borrow().write_state_to_stable_memory());
+    SNS_WASM.with(|c| {
+        println!("c.wasm_metadata = {:#?}", c.borrow().wasm_metadata);
+        println!("c.wasm_metadata = {:?}", c.borrow().wasm_indexes);
+        c.borrow().write_state_to_stable_memory();
+    });
 
     println!("{}Completed pre upgrade", LOG_PREFIX);
 }
@@ -329,7 +333,13 @@ fn canister_post_upgrade() {
     dfn_core::printer::hook();
     println!("{}Executing post upgrade", LOG_PREFIX);
 
-    SNS_WASM.with(|c| c.replace(SnsWasmCanister::<CanisterStableMemory>::from_stable_memory()));
+    SNS_WASM.with(|c| {
+        println!("c.wasm_metadata = {:#?}", c.borrow().wasm_metadata);
+        println!("c.wasm_metadata = {:?}", c.borrow().wasm_indexes);
+        c.replace(SnsWasmCanister::<CanisterStableMemory>::from_stable_memory());
+        println!("c.wasm_metadata = {:#?}", c.borrow().wasm_metadata);
+        println!("c.wasm_metadata = {:?}", c.borrow().wasm_indexes);
+    });
 
     println!("{}Completed post upgrade", LOG_PREFIX);
 }

--- a/rs/nns/sns-wasm/proto/ic_sns_wasm/pb/v1/sns_wasm.proto
+++ b/rs/nns/sns-wasm/proto/ic_sns_wasm/pb/v1/sns_wasm.proto
@@ -33,6 +33,7 @@ message StableCanisterState {
   bool access_controls_enabled = 5;
   repeated ic_base_types.pb.v1.PrincipalId allowed_principals = 6;
   map<uint64, uint64> nns_proposal_to_deployed_sns = 7;
+  repeated MetadataSection wasm_metadata = 8;
 }
 
 // Details the offset and size of a WASM binary in stable memory and the hash of this binary.

--- a/rs/nns/sns-wasm/src/gen/ic_sns_wasm.pb.v1.rs
+++ b/rs/nns/sns-wasm/src/gen/ic_sns_wasm.pb.v1.rs
@@ -18,6 +18,8 @@ pub struct StableCanisterState {
     pub allowed_principals: ::prost::alloc::vec::Vec<::ic_base_types::PrincipalId>,
     #[prost(btree_map = "uint64, uint64", tag = "7")]
     pub nns_proposal_to_deployed_sns: ::prost::alloc::collections::BTreeMap<u64, u64>,
+    #[prost(message, repeated, tag = "8")]
+    pub wasm_metadata: ::prost::alloc::vec::Vec<MetadataSection>,
 }
 /// Details the offset and size of a WASM binary in stable memory and the hash of this binary.
 #[derive(candid::CandidType, candid::Deserialize, serde::Serialize)]

--- a/rs/nns/sns-wasm/src/sns_wasm.rs
+++ b/rs/nns/sns-wasm/src/sns_wasm.rs
@@ -107,6 +107,8 @@ where
     pub allowed_principals: Vec<PrincipalId>,
     /// Map of nns proposal id to index in the `deployed_sns_list`.
     pub nns_proposal_to_deployed_sns: BTreeMap<u64, u64>,
+    /// Map from WASM hash to the metadata of this WASM.
+    pub wasm_metadata: BTreeMap<[u8; 32], MetadataSection>,
 }
 
 /// Internal implementation to give the wasms we explicitly handle a name (instead of Vec<u8>) for

--- a/rs/nns/sns-wasm/src/stable_memory.rs
+++ b/rs/nns/sns-wasm/src/stable_memory.rs
@@ -166,8 +166,8 @@ mod test {
     use crate::{
         canister_stable_memory::TestCanisterStableMemory,
         pb::v1::{
-            DeployedSns, SnsSpecificSnsUpgrade, SnsUpgrade, SnsVersion, SnsWasmStableIndex,
-            UpgradePath,
+            DeployedSns, MetadataSection as MetadataSectionPb, SnsSpecificSnsUpgrade, SnsUpgrade,
+            SnsVersion, SnsWasmStableIndex, UpgradePath,
         },
     };
     use ic_base_types::PrincipalId;
@@ -199,6 +199,11 @@ mod test {
             hash: vec![1, 3, 6],
             offset: 34811,
             size: 1200,
+        }];
+        let wasm_metadata = vec![MetadataSectionPb {
+            visibility: Some("icp:public".to_string()),
+            name: Some("foo".to_string()),
+            contents: Some(vec![1, 2, 3]),
         }];
 
         let sns_subnet_ids = vec![PrincipalId::new_subnet_test_id(34)];
@@ -250,6 +255,7 @@ mod test {
             access_controls_enabled: true,
             allowed_principals: vec![],
             nns_proposal_to_deployed_sns: btreemap! {1 => 0,},
+            wasm_metadata,
         }
     }
 

--- a/rs/nns/sns-wasm/src/wasm_metadata.rs
+++ b/rs/nns/sns-wasm/src/wasm_metadata.rs
@@ -23,6 +23,7 @@ impl TryFrom<GetWasmMetadataRequestPb> for [u8; 32] {
 }
 
 /// The internal representation of `MetadataSectionPb`.
+#[derive(Clone, Debug)]
 pub struct MetadataSection {
     pub visibility: String,
     pub name: String,
@@ -36,6 +37,31 @@ impl From<MetadataSection> for MetadataSectionPb {
             name: Some(src.name),
             contents: Some(src.contents),
         }
+    }
+}
+
+impl TryFrom<MetadataSectionPb> for MetadataSection {
+    type Error = String;
+
+    fn try_from(src: MetadataSectionPb) -> Result<Self, Self::Error> {
+        let MetadataSectionPb {
+            visibility: Some(visibility),
+            name: Some(name),
+            contents: Some(contents),
+        } = src
+        else {
+            return Err(
+                "Cannot interpret as MetadataSection: fields visibility, name, contents must be \
+                specified."
+                    .to_string(),
+            );
+        };
+
+        Ok(Self {
+            visibility,
+            name,
+            contents,
+        })
     }
 }
 

--- a/rs/nns/sns-wasm/tests/upgrade.rs
+++ b/rs/nns/sns-wasm/tests/upgrade.rs
@@ -89,6 +89,7 @@ fn test_sns_wasm_upgrade() {
     // Ensure the basic wasm response is the same after upgrade
     let get_wasm_response =
         sns_wasm::get_wasm(&machine, SNS_WASM_CANISTER_ID, &first_gov_wasm_hash);
+    println!("get_wasm_response = {:#?}", get_wasm_response);
     assert_eq!(
         types_to_wasms_one
             .get(&SnsCanisterType::Governance)


### PR DESCRIPTION
This PR is the first step towards enabling the `SnsW.get_wasm_metadata` endpoint in production. For that, we need a way to store the metadata in the stable memory, as recomputing it each time is expensive (because canister WASMs stored in SNS-W are often compressed).