### PR TITLE
perf: Optimize the inject_files tool

### DIFF
--- a/rs/ic_os/inject_files/BUILD.bazel
+++ b/rs/ic_os/inject_files/BUILD.bazel
@@ -18,10 +18,10 @@ MACRO_DEPENDENCIES = []
 rust_binary(
     name = "inject-files",
     srcs = glob(["src/**/*.rs"]),
+    data = ["//rs/ic_os/dflate"],
     proc_macro_deps = MACRO_DEPENDENCIES,
     version = "0.1.0",
     deps = DEPENDENCIES,
-    data = ["//rs/ic_os/dflate"]
 )
 
 rust_test(

--- a/rs/ic_os/inject_files/BUILD.bazel
+++ b/rs/ic_os/inject_files/BUILD.bazel
@@ -21,6 +21,7 @@ rust_binary(
     proc_macro_deps = MACRO_DEPENDENCIES,
     version = "0.1.0",
     deps = DEPENDENCIES,
+    data = ["//rs/ic_os/dflate"]
 )
 
 rust_test(

--- a/rs/ic_os/inject_files/BUILD.bazel
+++ b/rs/ic_os/inject_files/BUILD.bazel
@@ -18,7 +18,6 @@ MACRO_DEPENDENCIES = []
 rust_binary(
     name = "inject-files",
     srcs = glob(["src/**/*.rs"]),
-    data = ["//rs/ic_os/dflate"],
     proc_macro_deps = MACRO_DEPENDENCIES,
     version = "0.1.0",
     deps = DEPENDENCIES,


### PR DESCRIPTION
NODE-1454

This change improves the build time of `//ic-os/guestos/envs/dev` by 30s.

Previously we used Tokio's `io::copy` which has very bad performance because (unlike the sync version in stdlib) it reads the file to a user space buffer before copying it to the target. `fs::copy` performs much better but doesn't allow seeking.

I considered a few approaches and decided to use `fs::copy` on the fast path and keep `io::copy` when necessary. Alternative approaches could be using sync IO in our build tools (I believe we don't gain anything from Tokio here but I'd need to verify this claim) or trying to fix Tokio's `io::copy`.