### PR TITLE
perf: Optimize strip_files function

### DIFF
--- a/toolchains/sysimage/build_ext4_image.py
+++ b/toolchains/sysimage/build_ext4_image.py
@@ -96,9 +96,6 @@ def strip_files(fs_basedir, fakeroot_statefile, strip_paths):
         else:
             flattened_paths.append(target_path)
 
-    if not flattened_paths:
-        return
-
     # TODO: replace this with itertools.batched when we have Python 3.12
     BATCH_SIZE = 100
     for batch_start in range(0, len(flattened_paths), BATCH_SIZE):

--- a/toolchains/sysimage/build_ext4_image.py
+++ b/toolchains/sysimage/build_ext4_image.py
@@ -99,9 +99,15 @@ def strip_files(fs_basedir, fakeroot_statefile, strip_paths):
     if not flattened_paths:
         return
 
-    subprocess.run(
-        ["fakeroot", "-s", fakeroot_statefile, "-i", fakeroot_statefile, "rm", "-rf"] + flattened_paths,
-        check=True)
+    # TODO: replace this with itertools.batched when we have Python 3.12
+    BATCH_SIZE = 100
+    for batch_start in range(0, len(flattened_paths), BATCH_SIZE):
+        batch_end = min(batch_start + BATCH_SIZE, len(flattened_paths))
+        subprocess.run(
+            ["fakeroot", "-s", fakeroot_statefile, "-i", fakeroot_statefile, "rm", "-rf"] +
+            flattened_paths[batch_start:batch_end],
+            check=True)
+
 
 def prepare_tree_from_tar(in_file, fakeroot_statefile, fs_basedir, dir_to_extract):
     if in_file:

--- a/toolchains/sysimage/build_ext4_image.py
+++ b/toolchains/sysimage/build_ext4_image.py
@@ -83,6 +83,7 @@ def read_fakeroot_state(statefile):
 
 
 def strip_files(fs_basedir, fakeroot_statefile, strip_paths):
+    flattened_paths = []
     for path in strip_paths:
         if path[0] == "/":
             path = path[1:]
@@ -91,10 +92,16 @@ def strip_files(fs_basedir, fakeroot_statefile, strip_paths):
         if os.path.isdir(target_path):
             for entry in os.listdir(target_path):
                 del_path = os.path.join(target_path, entry)
-                subprocess.run(["fakeroot", "-s", fakeroot_statefile, "-i", fakeroot_statefile, "rm", "-rf", del_path])
+                flattened_paths.append(del_path)
         else:
-            subprocess.run(["fakeroot", "-s", fakeroot_statefile, "-i", fakeroot_statefile, "rm", "-rf", target_path])
+            flattened_paths.append(target_path)
 
+    if not flattened_paths:
+        return
+
+    subprocess.run(
+        ["fakeroot", "-s", fakeroot_statefile, "-i", fakeroot_statefile, "rm", "-rf"] + flattened_paths,
+        check=True)
 
 def prepare_tree_from_tar(in_file, fakeroot_statefile, fs_basedir, dir_to_extract):
     if in_file:


### PR DESCRIPTION
NODE-1454

We'd previously run `rm` for each nested file in directories. When a directory contains many files, this gets slow. By running `rm` only once, we can save 10-20s per build.

The output should still be the same, I verified it by taking the checksum of the generated images.