### PR TITLE
refactor(nns): Cleanup NNS Governance API type definitions

### DIFF
--- a/rs/nns/governance/api/src/ic_nns_governance.pb.v1.rs
+++ b/rs/nns/governance/api/src/ic_nns_governance.pb.v1.rs
@@ -1,3 +1,7 @@
+use ic_base_types::PrincipalId;
+use ic_nns_common::pb::v1::NeuronId;
+use icp_ledger::protobuf::AccountIdentifier;
+
 /// The entity that owns the nodes that run the network.
 ///
 /// Note that this is different from a node operator, the entity that
@@ -14,10 +18,10 @@
 pub struct NodeProvider {
     /// The ID of the node provider.
     #[prost(message, optional, tag = "1")]
-    pub id: ::core::option::Option<::ic_base_types::PrincipalId>,
+    pub id: Option<PrincipalId>,
     /// The account where rewards earned from providing nodes will be sent.
     #[prost(message, optional, tag = "2")]
-    pub reward_account: ::core::option::Option<::icp_ledger::protobuf::AccountIdentifier>,
+    pub reward_account: Option<AccountIdentifier>,
 }
 /// Used to update node provider records
 ///
@@ -29,7 +33,7 @@ pub struct NodeProvider {
 pub struct UpdateNodeProvider {
     /// The account where rewards earned from providing nodes will be sent.
     #[prost(message, optional, tag = "1")]
-    pub reward_account: ::core::option::Option<::icp_ledger::protobuf::AccountIdentifier>,
+    pub reward_account: Option<AccountIdentifier>,
 }
 /// How did a neuron vote in the recent past? This data is used by
 /// other neurons to determine what neurons to follow.
@@ -39,7 +43,7 @@ pub struct UpdateNodeProvider {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BallotInfo {
     #[prost(message, optional, tag = "1")]
-    pub proposal_id: ::core::option::Option<::ic_nns_common::pb::v1::ProposalId>,
+    pub proposal_id: Option<::ic_nns_common::pb::v1::ProposalId>,
     #[prost(enumeration = "Vote", tag = "2")]
     pub vote: i32,
 }
@@ -69,7 +73,7 @@ pub struct NeuronInfo {
     pub dissolve_delay_seconds: u64,
     /// See \[Neuron::recent_ballots\] for a description.
     #[prost(message, repeated, tag = "5")]
-    pub recent_ballots: ::prost::alloc::vec::Vec<BallotInfo>,
+    pub recent_ballots: Vec<BallotInfo>,
     /// Current voting power of the neuron.
     #[prost(uint64, tag = "6")]
     pub voting_power: u64,
@@ -82,18 +86,18 @@ pub struct NeuronInfo {
     pub stake_e8s: u64,
     /// Timestamp when this neuron joined the community fund.
     #[prost(uint64, optional, tag = "9")]
-    pub joined_community_fund_timestamp_seconds: ::core::option::Option<u64>,
+    pub joined_community_fund_timestamp_seconds: Option<u64>,
     /// If this neuron is a known neuron, this is data associated
     /// with it, including the neuron's name and (optionally) a description.
     #[prost(message, optional, tag = "10")]
-    pub known_neuron_data: ::core::option::Option<KnownNeuronData>,
+    pub known_neuron_data: Option<KnownNeuronData>,
     /// The type of the Neuron. See \[NeuronType\] for a description
     /// of the different states.
     #[prost(enumeration = "NeuronType", optional, tag = "11")]
-    pub neuron_type: ::core::option::Option<i32>,
+    pub neuron_type: Option<i32>,
     /// See the Visibility enum.
     #[prost(enumeration = "Visibility", optional, tag = "12")]
-    pub visibility: ::core::option::Option<i32>,
+    pub visibility: Option<i32>,
 }
 /// A transfer performed from some account to stake a new neuron.
 #[derive(candid::CandidType, candid::Deserialize, serde::Serialize, comparable::Comparable)]
@@ -105,15 +109,15 @@ pub struct NeuronStakeTransfer {
     pub transfer_timestamp: u64,
     /// The principal that made the transfer.
     #[prost(message, optional, tag = "2")]
-    pub from: ::core::option::Option<::ic_base_types::PrincipalId>,
+    pub from: Option<PrincipalId>,
     /// The (optional) subaccount from which the transfer was made.
     #[prost(bytes = "vec", tag = "3")]
     #[serde(with = "serde_bytes")]
-    pub from_subaccount: ::prost::alloc::vec::Vec<u8>,
+    pub from_subaccount: Vec<u8>,
     /// The subaccount to which the transfer was made.
     #[prost(bytes = "vec", tag = "4")]
     #[serde(with = "serde_bytes")]
-    pub to_subaccount: ::prost::alloc::vec::Vec<u8>,
+    pub to_subaccount: Vec<u8>,
     /// The amount of stake that was transferred.
     #[prost(uint64, tag = "5")]
     pub neuron_stake_e8s: u64,
@@ -142,25 +146,25 @@ pub struct Neuron {
     /// unique naming scheme instead and chose the ids on the
     /// initialization of the canister.
     #[prost(message, optional, tag = "1")]
-    pub id: ::core::option::Option<::ic_nns_common::pb::v1::NeuronId>,
+    pub id: Option<NeuronId>,
     /// The principal of the ICP ledger account where the locked ICP
     /// balance resides. This principal is indistinguishable from one
     /// identifying a public key pair, such that those browsing the ICP
     /// ledger cannot tell which balances belong to neurons.
     #[prost(bytes = "vec", tag = "2")]
     #[serde(with = "serde_bytes")]
-    pub account: ::prost::alloc::vec::Vec<u8>,
+    pub account: Vec<u8>,
     /// The principal that actually controls the neuron. The principal
     /// must identify a public key pair, which acts as a “master key”,
     /// such that the corresponding secret key should be kept very
     /// secure. The principal may control many neurons.
     #[prost(message, optional, tag = "3")]
-    pub controller: ::core::option::Option<::ic_base_types::PrincipalId>,
+    pub controller: Option<PrincipalId>,
     /// Keys that can be used to perform actions with limited privileges
     /// without exposing the secret key corresponding to the principal
     /// e.g. could be a WebAuthn key.
     #[prost(message, repeated, tag = "4")]
-    pub hot_keys: ::prost::alloc::vec::Vec<::ic_base_types::PrincipalId>,
+    pub hot_keys: Vec<PrincipalId>,
     /// The amount of staked ICP tokens, measured in fractions of 10E-8
     /// of an ICP.
     ///
@@ -196,7 +200,7 @@ pub struct Neuron {
     /// neuron should be spawned and its maturity converted to ICP
     /// according to <https://wiki.internetcomputer.org/wiki/Maturity_modulation.>
     #[prost(uint64, optional, tag = "19")]
-    pub spawn_at_timestamp_seconds: ::core::option::Option<u64>,
+    pub spawn_at_timestamp_seconds: Option<u64>,
     /// Map `Topic` to followees. The key is represented by an integer as
     /// Protobuf does not support enum keys in maps.
     #[prost(map = "int32, message", tag = "11")]
@@ -204,13 +208,13 @@ pub struct Neuron {
     /// Information about how this neuron voted in the recent past. It
     /// only contains proposals that the neuron voted yes or no on.
     #[prost(message, repeated, tag = "12")]
-    pub recent_ballots: ::prost::alloc::vec::Vec<BallotInfo>,
+    pub recent_ballots: Vec<BallotInfo>,
     /// `true` if this neuron has passed KYC, `false` otherwise
     #[prost(bool, tag = "13")]
     pub kyc_verified: bool,
     /// The record of the transfer that was made to create this neuron.
     #[prost(message, optional, tag = "14")]
-    pub transfer: ::core::option::Option<NeuronStakeTransfer>,
+    pub transfer: Option<NeuronStakeTransfer>,
     /// The accumulated unstaked maturity of the neuron, in "e8s equivalent".
     ///
     /// The unit is "e8s equivalent" to insist that, while this quantity is on
@@ -228,11 +232,11 @@ pub struct Neuron {
     /// to 'maturity_e8s_equivalent' and will be able to be spawned (with maturity
     /// modulation).
     #[prost(uint64, optional, tag = "20")]
-    pub staked_maturity_e8s_equivalent: ::core::option::Option<u64>,
+    pub staked_maturity_e8s_equivalent: Option<u64>,
     /// If set and true the maturity rewarded to this neuron for voting will be
     /// automatically staked and will contribute to the neuron's voting power.
     #[prost(bool, optional, tag = "21")]
-    pub auto_stake_maturity: ::core::option::Option<bool>,
+    pub auto_stake_maturity: Option<bool>,
     /// Whether this neuron is "Not for profit", making it dissolvable
     /// by voting.
     #[prost(bool, tag = "16")]
@@ -241,17 +245,17 @@ pub struct Neuron {
     /// a proposal to open an SNS token swap is executed, maturity from this neuron
     /// will be used to participate in the SNS token swap.
     #[prost(uint64, optional, tag = "17")]
-    pub joined_community_fund_timestamp_seconds: ::core::option::Option<u64>,
+    pub joined_community_fund_timestamp_seconds: Option<u64>,
     /// If set, the neuron belongs to the "known neurons". It has been given a name and maybe a description.
     #[prost(message, optional, tag = "18")]
-    pub known_neuron_data: ::core::option::Option<KnownNeuronData>,
+    pub known_neuron_data: Option<KnownNeuronData>,
     /// The type of the Neuron. See \[NeuronType\] for a description
     /// of the different states.
     #[prost(enumeration = "NeuronType", optional, tag = "22")]
-    pub neuron_type: ::core::option::Option<i32>,
+    pub neuron_type: Option<i32>,
     /// See the Visibility enum.
     #[prost(enumeration = "Visibility", optional, tag = "23")]
-    pub visibility: ::core::option::Option<i32>,
+    pub visibility: Option<i32>,
     /// At any time, at most one of `when_dissolved` and
     /// `dissolve_delay` are specified.
     ///
@@ -267,10 +271,12 @@ pub struct Neuron {
     ///
     /// Cf. \[Neuron::stop_dissolving\] and \[Neuron::start_dissolving\].
     #[prost(oneof = "neuron::DissolveState", tags = "9, 10")]
-    pub dissolve_state: ::core::option::Option<neuron::DissolveState>,
+    pub dissolve_state: Option<neuron::DissolveState>,
 }
 /// Nested message and enum types in `Neuron`.
 pub mod neuron {
+    use super::*;
+
     /// Protobuf representing a list of followees of a neuron for a
     /// specific topic.
     #[derive(candid::CandidType, candid::Deserialize, serde::Serialize, comparable::Comparable)]
@@ -278,7 +284,7 @@ pub mod neuron {
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct Followees {
         #[prost(message, repeated, tag = "1")]
-        pub followees: ::prost::alloc::vec::Vec<::ic_nns_common::pb::v1::NeuronId>,
+        pub followees: Vec<NeuronId>,
     }
     /// At any time, at most one of `when_dissolved` and
     /// `dissolve_delay` are specified.
@@ -329,9 +335,9 @@ pub mod neuron {
 pub struct AbridgedNeuron {
     #[prost(bytes = "vec", tag = "2")]
     #[serde(with = "serde_bytes")]
-    pub account: ::prost::alloc::vec::Vec<u8>,
+    pub account: Vec<u8>,
     #[prost(message, optional, tag = "3")]
-    pub controller: ::core::option::Option<::ic_base_types::PrincipalId>,
+    pub controller: Option<PrincipalId>,
     #[prost(uint64, tag = "5")]
     pub cached_neuron_stake_e8s: u64,
     #[prost(uint64, tag = "6")]
@@ -341,25 +347,25 @@ pub struct AbridgedNeuron {
     #[prost(uint64, tag = "8")]
     pub aging_since_timestamp_seconds: u64,
     #[prost(uint64, optional, tag = "19")]
-    pub spawn_at_timestamp_seconds: ::core::option::Option<u64>,
+    pub spawn_at_timestamp_seconds: Option<u64>,
     #[prost(bool, tag = "13")]
     pub kyc_verified: bool,
     #[prost(uint64, tag = "15")]
     pub maturity_e8s_equivalent: u64,
     #[prost(uint64, optional, tag = "20")]
-    pub staked_maturity_e8s_equivalent: ::core::option::Option<u64>,
+    pub staked_maturity_e8s_equivalent: Option<u64>,
     #[prost(bool, optional, tag = "21")]
-    pub auto_stake_maturity: ::core::option::Option<bool>,
+    pub auto_stake_maturity: Option<bool>,
     #[prost(bool, tag = "16")]
     pub not_for_profit: bool,
     #[prost(uint64, optional, tag = "17")]
-    pub joined_community_fund_timestamp_seconds: ::core::option::Option<u64>,
+    pub joined_community_fund_timestamp_seconds: Option<u64>,
     #[prost(enumeration = "NeuronType", optional, tag = "22")]
-    pub neuron_type: ::core::option::Option<i32>,
+    pub neuron_type: Option<i32>,
     #[prost(enumeration = "Visibility", optional, tag = "23")]
-    pub visibility: ::core::option::Option<i32>,
+    pub visibility: Option<i32>,
     #[prost(oneof = "abridged_neuron::DissolveState", tags = "9, 10")]
-    pub dissolve_state: ::core::option::Option<abridged_neuron::DissolveState>,
+    pub dissolve_state: Option<abridged_neuron::DissolveState>,
 }
 /// Nested message and enum types in `AbridgedNeuron`.
 pub mod abridged_neuron {
@@ -387,7 +393,7 @@ pub struct ExecuteNnsFunction {
     /// The payload of the NNS function.
     #[prost(bytes = "vec", tag = "2")]
     #[serde(with = "serde_bytes")]
-    pub payload: ::prost::alloc::vec::Vec<u8>,
+    pub payload: Vec<u8>,
 }
 /// If adopted, a motion should guide the future strategy of the
 /// Internet Computer ecosystem.
@@ -407,7 +413,7 @@ pub struct Motion {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ApproveGenesisKyc {
     #[prost(message, repeated, tag = "1")]
-    pub principals: ::prost::alloc::vec::Vec<::ic_base_types::PrincipalId>,
+    pub principals: Vec<PrincipalId>,
 }
 /// Adds and/or removes NodeProviders from the list of current
 /// node providers.
@@ -416,7 +422,7 @@ pub struct ApproveGenesisKyc {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AddOrRemoveNodeProvider {
     #[prost(oneof = "add_or_remove_node_provider::Change", tags = "1, 2")]
-    pub change: ::core::option::Option<add_or_remove_node_provider::Change>,
+    pub change: Option<add_or_remove_node_provider::Change>,
 }
 /// Nested message and enum types in `AddOrRemoveNodeProvider`.
 pub mod add_or_remove_node_provider {
@@ -439,15 +445,16 @@ pub mod add_or_remove_node_provider {
 pub struct RewardNodeProvider {
     /// The NodeProvider to reward.
     #[prost(message, optional, tag = "1")]
-    pub node_provider: ::core::option::Option<NodeProvider>,
+    pub node_provider: Option<NodeProvider>,
     /// The amount of e8s to mint to reward the node provider.
     #[prost(uint64, tag = "2")]
     pub amount_e8s: u64,
     #[prost(oneof = "reward_node_provider::RewardMode", tags = "4, 5")]
-    pub reward_mode: ::core::option::Option<reward_node_provider::RewardMode>,
+    pub reward_mode: Option<reward_node_provider::RewardMode>,
 }
 /// Nested message and enum types in `RewardNodeProvider`.
 pub mod reward_node_provider {
+    use super::*;
     /// This message specifies how to create a new neuron on behalf of
     /// the node provider.
     ///
@@ -480,7 +487,7 @@ pub mod reward_node_provider {
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct RewardToAccount {
         #[prost(message, optional, tag = "1")]
-        pub to_account: ::core::option::Option<::icp_ledger::protobuf::AccountIdentifier>,
+        pub to_account: Option<AccountIdentifier>,
     }
     #[derive(candid::CandidType, candid::Deserialize, serde::Serialize, comparable::Comparable)]
     #[allow(clippy::derive_partial_eq_without_eq)]
@@ -502,11 +509,11 @@ pub mod reward_node_provider {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RewardNodeProviders {
     #[prost(message, repeated, tag = "1")]
-    pub rewards: ::prost::alloc::vec::Vec<RewardNodeProvider>,
+    pub rewards: Vec<RewardNodeProvider>,
     /// If true, reward Node Providers with the rewards returned by the Registry's
     /// get_node_providers_monthly_xdr_rewards method
     #[prost(bool, optional, tag = "2")]
-    pub use_registry_derived_rewards: ::core::option::Option<bool>,
+    pub use_registry_derived_rewards: Option<bool>,
 }
 /// Changes the default followees to match the one provided.
 /// This completely replaces the default followees so entries for all
@@ -525,11 +532,11 @@ pub struct SetDefaultFollowees {
 pub struct SetSnsTokenSwapOpenTimeWindow {
     /// The swap canister to send the request to.
     #[prost(message, optional, tag = "1")]
-    pub swap_canister_id: ::core::option::Option<::ic_base_types::PrincipalId>,
+    pub swap_canister_id: Option<PrincipalId>,
     /// Arguments that get sent to the swap canister when its set_open_time_window
     /// Candid method is called.
     #[prost(message, optional, tag = "2")]
-    pub request: ::core::option::Option<::ic_sns_swap::pb::v1::SetOpenTimeWindowRequest>,
+    pub request: Option<::ic_sns_swap::pb::v1::SetOpenTimeWindowRequest>,
 }
 /// A proposal is the immutable input of a proposal submission. This contains
 /// all the information from the original proposal submission.
@@ -544,7 +551,7 @@ pub struct Proposal {
     /// A brief description of what the proposal does.
     /// Size in bytes must be in the interval \[5, 256\].
     #[prost(string, optional, tag = "20")]
-    pub title: ::core::option::Option<::prost::alloc::string::String>,
+    pub title: Option<::prost::alloc::string::String>,
     /// Text providing a short description of the proposal, composed
     /// using a maximum of 30000 bytes of characters.
     #[prost(string, tag = "1")]
@@ -562,7 +569,7 @@ pub struct Proposal {
         oneof = "proposal::Action",
         tags = "10, 12, 13, 14, 15, 16, 17, 18, 19, 21, 22, 23, 24, 25, 26, 27"
     )]
-    pub action: ::core::option::Option<proposal::Action>,
+    pub action: Option<proposal::Action>,
 }
 /// Nested message and enum types in `Proposal`.
 pub mod proposal {
@@ -675,18 +682,20 @@ pub struct Empty {}
 pub struct ManageNeuron {
     /// This is the legacy way to specify neuron IDs that is now discouraged.
     #[prost(message, optional, tag = "1")]
-    pub id: ::core::option::Option<::ic_nns_common::pb::v1::NeuronId>,
+    pub id: Option<NeuronId>,
     /// The ID of the neuron to manage. This can either be a subaccount or a neuron ID.
     #[prost(oneof = "manage_neuron::NeuronIdOrSubaccount", tags = "11, 12")]
-    pub neuron_id_or_subaccount: ::core::option::Option<manage_neuron::NeuronIdOrSubaccount>,
+    pub neuron_id_or_subaccount: Option<manage_neuron::NeuronIdOrSubaccount>,
     #[prost(
         oneof = "manage_neuron::Command",
         tags = "2, 3, 4, 5, 6, 7, 8, 9, 10, 13, 14, 15"
     )]
-    pub command: ::core::option::Option<manage_neuron::Command>,
+    pub command: Option<manage_neuron::Command>,
 }
 /// Nested message and enum types in `ManageNeuron`.
 pub mod manage_neuron {
+    use super::*;
+
     /// The dissolve delay of a neuron can be increased up to a maximum
     /// of 8 years.
     #[derive(candid::CandidType, candid::Deserialize, serde::Serialize, comparable::Comparable)]
@@ -715,7 +724,7 @@ pub mod manage_neuron {
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct AddHotKey {
         #[prost(message, optional, tag = "1")]
-        pub new_hot_key: ::core::option::Option<::ic_base_types::PrincipalId>,
+        pub new_hot_key: Option<PrincipalId>,
     }
     /// Remove a hot key that has been previously assigned to the neuron.
     #[derive(candid::CandidType, candid::Deserialize, serde::Serialize, comparable::Comparable)]
@@ -723,7 +732,7 @@ pub mod manage_neuron {
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct RemoveHotKey {
         #[prost(message, optional, tag = "1")]
-        pub hot_key_to_remove: ::core::option::Option<::ic_base_types::PrincipalId>,
+        pub hot_key_to_remove: Option<PrincipalId>,
     }
     /// An (idempotent) alternative to IncreaseDissolveDelay where the dissolve delay
     /// is passed as an absolute timestamp in seconds since the unix epoch.
@@ -760,7 +769,7 @@ pub mod manage_neuron {
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct SetVisibility {
         #[prost(enumeration = "super::Visibility", optional, tag = "1")]
-        pub visibility: ::core::option::Option<i32>,
+        pub visibility: Option<i32>,
     }
     /// Commands that only configure a given neuron, but do not interact
     /// with the outside world. They all require the caller to be the
@@ -770,7 +779,7 @@ pub mod manage_neuron {
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct Configure {
         #[prost(oneof = "configure::Operation", tags = "1, 2, 3, 4, 5, 6, 7, 8, 9, 10")]
-        pub operation: ::core::option::Option<configure::Operation>,
+        pub operation: Option<configure::Operation>,
     }
     /// Nested message and enum types in `Configure`.
     pub mod configure {
@@ -811,10 +820,10 @@ pub mod manage_neuron {
         /// The (optional) amount to transfer. If not specified the cached
         /// stake is used.
         #[prost(message, optional, tag = "1")]
-        pub amount: ::core::option::Option<disburse::Amount>,
+        pub amount: Option<disburse::Amount>,
         /// The principal to which to transfer the stake.
         #[prost(message, optional, tag = "2")]
-        pub to_account: ::core::option::Option<::icp_ledger::protobuf::AccountIdentifier>,
+        pub to_account: Option<AccountIdentifier>,
     }
     /// Nested message and enum types in `Disburse`.
     pub mod disburse {
@@ -846,7 +855,7 @@ pub mod manage_neuron {
     pub struct Merge {
         /// The neuron to merge stake and maturity from.
         #[prost(message, optional, tag = "1")]
-        pub source_neuron_id: ::core::option::Option<::ic_nns_common::pb::v1::NeuronId>,
+        pub source_neuron_id: Option<NeuronId>,
     }
     /// When the maturity of a neuron has risen above a threshold, it can
     /// be instructed to spawn a new neuron. This creates a new neuron
@@ -860,13 +869,13 @@ pub mod manage_neuron {
         /// If not set, the spawned neuron will have the same controller as
         /// this neuron.
         #[prost(message, optional, tag = "1")]
-        pub new_controller: ::core::option::Option<::ic_base_types::PrincipalId>,
+        pub new_controller: Option<PrincipalId>,
         /// The nonce with which to create the subaccount.
         #[prost(uint64, optional, tag = "2")]
-        pub nonce: ::core::option::Option<u64>,
+        pub nonce: Option<u64>,
         /// The percentage to spawn, from 1 to 100 (inclusive).
         #[prost(uint32, optional, tag = "3")]
-        pub percentage_to_spawn: ::core::option::Option<u32>,
+        pub percentage_to_spawn: Option<u32>,
     }
     /// Merge the maturity of a neuron into the current stake.
     /// The caller can choose a percentage of the current maturity to merge into
@@ -890,7 +899,7 @@ pub mod manage_neuron {
     pub struct StakeMaturity {
         /// The percentage of maturity to stake, from 1 to 100 (inclusive).
         #[prost(uint32, optional, tag = "1")]
-        pub percentage_to_stake: ::core::option::Option<u32>,
+        pub percentage_to_stake: Option<u32>,
     }
     /// Disburse a portion of this neuron's stake into another neuron.
     /// This allows to split a neuron but with a new dissolve delay
@@ -901,7 +910,7 @@ pub mod manage_neuron {
     pub struct DisburseToNeuron {
         /// The controller of the new neuron (must be set).
         #[prost(message, optional, tag = "1")]
-        pub new_controller: ::core::option::Option<::ic_base_types::PrincipalId>,
+        pub new_controller: Option<PrincipalId>,
         /// The amount to disburse.
         #[prost(uint64, tag = "2")]
         pub amount_e8s: u64,
@@ -944,7 +953,7 @@ pub mod manage_neuron {
         #[prost(enumeration = "super::Topic", tag = "1")]
         pub topic: i32,
         #[prost(message, repeated, tag = "2")]
-        pub followees: ::prost::alloc::vec::Vec<::ic_nns_common::pb::v1::NeuronId>,
+        pub followees: Vec<NeuronId>,
     }
     /// Have the neuron vote to either adopt or reject a proposal with a specified
     /// id.
@@ -953,7 +962,7 @@ pub mod manage_neuron {
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct RegisterVote {
         #[prost(message, optional, tag = "1")]
-        pub proposal: ::core::option::Option<::ic_nns_common::pb::v1::ProposalId>,
+        pub proposal: Option<::ic_nns_common::pb::v1::ProposalId>,
         #[prost(enumeration = "super::Vote", tag = "2")]
         pub vote: i32,
     }
@@ -963,10 +972,12 @@ pub mod manage_neuron {
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct ClaimOrRefresh {
         #[prost(oneof = "claim_or_refresh::By", tags = "1, 2, 3")]
-        pub by: ::core::option::Option<claim_or_refresh::By>,
+        pub by: Option<claim_or_refresh::By>,
     }
     /// Nested message and enum types in `ClaimOrRefresh`.
     pub mod claim_or_refresh {
+        use super::*;
+
         #[derive(
             candid::CandidType, candid::Deserialize, serde::Serialize, comparable::Comparable,
         )]
@@ -976,7 +987,7 @@ pub mod manage_neuron {
             #[prost(uint64, tag = "1")]
             pub memo: u64,
             #[prost(message, optional, tag = "2")]
-            pub controller: ::core::option::Option<::ic_base_types::PrincipalId>,
+            pub controller: Option<PrincipalId>,
         }
         #[derive(
             candid::CandidType, candid::Deserialize, serde::Serialize, comparable::Comparable,
@@ -1008,9 +1019,9 @@ pub mod manage_neuron {
     pub enum NeuronIdOrSubaccount {
         #[prost(bytes, tag = "11")]
         #[serde(with = "serde_bytes")]
-        Subaccount(::prost::alloc::vec::Vec<u8>),
+        Subaccount(Vec<u8>),
         #[prost(message, tag = "12")]
-        NeuronId(::ic_nns_common::pb::v1::NeuronId),
+        NeuronId(NeuronId),
     }
     #[derive(candid::CandidType, candid::Deserialize, serde::Serialize, comparable::Comparable)]
     #[allow(clippy::derive_partial_eq_without_eq)]
@@ -1053,10 +1064,12 @@ pub struct ManageNeuronResponse {
         oneof = "manage_neuron_response::Command",
         tags = "1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13"
     )]
-    pub command: ::core::option::Option<manage_neuron_response::Command>,
+    pub command: Option<manage_neuron_response::Command>,
 }
 /// Nested message and enum types in `ManageNeuronResponse`.
 pub mod manage_neuron_response {
+    use super::*;
+
     #[derive(candid::CandidType, candid::Deserialize, serde::Serialize, comparable::Comparable)]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
@@ -1075,7 +1088,7 @@ pub mod manage_neuron_response {
     pub struct SpawnResponse {
         /// The ID of the Neuron created from spawning a Neuron
         #[prost(message, optional, tag = "1")]
-        pub created_neuron_id: ::core::option::Option<::ic_nns_common::pb::v1::NeuronId>,
+        pub created_neuron_id: Option<NeuronId>,
     }
     #[derive(candid::CandidType, candid::Deserialize, serde::Serialize, comparable::Comparable)]
     #[allow(clippy::derive_partial_eq_without_eq)]
@@ -1105,9 +1118,9 @@ pub mod manage_neuron_response {
     pub struct MakeProposalResponse {
         /// The ID of the created proposal
         #[prost(message, optional, tag = "1")]
-        pub proposal_id: ::core::option::Option<::ic_nns_common::pb::v1::ProposalId>,
+        pub proposal_id: Option<::ic_nns_common::pb::v1::ProposalId>,
         #[prost(string, optional, tag = "2")]
-        pub message: ::core::option::Option<::prost::alloc::string::String>,
+        pub message: Option<::prost::alloc::string::String>,
     }
     #[derive(candid::CandidType, candid::Deserialize, serde::Serialize, comparable::Comparable)]
     #[allow(clippy::derive_partial_eq_without_eq)]
@@ -1119,7 +1132,7 @@ pub mod manage_neuron_response {
     pub struct SplitResponse {
         /// The ID of the Neuron created from splitting another Neuron
         #[prost(message, optional, tag = "1")]
-        pub created_neuron_id: ::core::option::Option<::ic_nns_common::pb::v1::NeuronId>,
+        pub created_neuron_id: Option<NeuronId>,
     }
     /// A response for merging or simulating merge neurons
     #[derive(candid::CandidType, candid::Deserialize, serde::Serialize, comparable::Comparable)]
@@ -1128,16 +1141,16 @@ pub mod manage_neuron_response {
     pub struct MergeResponse {
         /// The resulting state of the source neuron
         #[prost(message, optional, tag = "1")]
-        pub source_neuron: ::core::option::Option<super::Neuron>,
+        pub source_neuron: Option<super::Neuron>,
         /// The resulting state of the target neuron
         #[prost(message, optional, tag = "2")]
-        pub target_neuron: ::core::option::Option<super::Neuron>,
+        pub target_neuron: Option<super::Neuron>,
         /// The NeuronInfo of the source neuron
         #[prost(message, optional, tag = "3")]
-        pub source_neuron_info: ::core::option::Option<super::NeuronInfo>,
+        pub source_neuron_info: Option<super::NeuronInfo>,
         /// The NeuronInfo of the target neuron
         #[prost(message, optional, tag = "4")]
-        pub target_neuron_info: ::core::option::Option<super::NeuronInfo>,
+        pub target_neuron_info: Option<super::NeuronInfo>,
     }
     #[derive(candid::CandidType, candid::Deserialize, serde::Serialize, comparable::Comparable)]
     #[allow(clippy::derive_partial_eq_without_eq)]
@@ -1145,14 +1158,14 @@ pub mod manage_neuron_response {
     pub struct DisburseToNeuronResponse {
         /// The ID of the Neuron created from disbursing a Neuron
         #[prost(message, optional, tag = "1")]
-        pub created_neuron_id: ::core::option::Option<::ic_nns_common::pb::v1::NeuronId>,
+        pub created_neuron_id: Option<NeuronId>,
     }
     #[derive(candid::CandidType, candid::Deserialize, serde::Serialize, comparable::Comparable)]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct ClaimOrRefreshResponse {
         #[prost(message, optional, tag = "1")]
-        pub refreshed_neuron_id: ::core::option::Option<::ic_nns_common::pb::v1::NeuronId>,
+        pub refreshed_neuron_id: Option<NeuronId>,
     }
     #[derive(candid::CandidType, candid::Deserialize, serde::Serialize, comparable::Comparable)]
     #[allow(clippy::derive_partial_eq_without_eq)]
@@ -1405,7 +1418,7 @@ pub mod governance_error {
             }
         }
         /// Creates an enum from field names used in the ProtoBuf definition.
-        pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+        pub fn from_str_name(value: &str) -> Option<Self> {
             match value {
                 "ERROR_TYPE_UNSPECIFIED" => Some(Self::Unspecified),
                 "ERROR_TYPE_OK" => Some(Self::Ok),
@@ -1477,17 +1490,17 @@ pub struct ProposalData {
     ///
     /// Immutable: The unique id for this proposal.
     #[prost(message, optional, tag = "1")]
-    pub id: ::core::option::Option<::ic_nns_common::pb::v1::ProposalId>,
+    pub id: Option<::ic_nns_common::pb::v1::ProposalId>,
     /// Immutable: The ID of the neuron that made this proposal.
     #[prost(message, optional, tag = "2")]
-    pub proposer: ::core::option::Option<::ic_nns_common::pb::v1::NeuronId>,
+    pub proposer: Option<NeuronId>,
     /// Immutable: The amount of ICP in E8s to be charged to the proposer if the
     /// proposal is rejected.
     #[prost(uint64, tag = "3")]
     pub reject_cost_e8s: u64,
     /// Immutable: The proposal originally submitted.
     #[prost(message, optional, tag = "4")]
-    pub proposal: ::core::option::Option<Proposal>,
+    pub proposal: Option<Proposal>,
     /// Immutable: The timestamp, in seconds from the Unix epoch, when this proposal
     /// was made.
     #[prost(uint64, tag = "5")]
@@ -1501,7 +1514,7 @@ pub struct ProposalData {
     /// decided, the latest_tally will still be updated based on the recent vote,
     /// until the voting deadline.
     #[prost(message, optional, tag = "7")]
-    pub latest_tally: ::core::option::Option<Tally>,
+    pub latest_tally: Option<Tally>,
     /// If specified: the timestamp when this proposal was adopted or
     /// rejected. If not specified, this proposal is still 'open'.
     #[prost(uint64, tag = "8")]
@@ -1517,7 +1530,7 @@ pub struct ProposalData {
     /// When an adopted proposal has failed to executed, this is set the
     /// reason for the failure.
     #[prost(message, optional, tag = "15")]
-    pub failure_reason: ::core::option::Option<GovernanceError>,
+    pub failure_reason: Option<GovernanceError>,
     /// The reward event round at which rewards for votes on this proposal
     /// was distributed.
     ///
@@ -1531,30 +1544,30 @@ pub struct ProposalData {
     pub reward_event_round: u64,
     /// Wait-for-quiet state that needs to be saved in stable memory.
     #[prost(message, optional, tag = "16")]
-    pub wait_for_quiet_state: ::core::option::Option<WaitForQuietState>,
+    pub wait_for_quiet_state: Option<WaitForQuietState>,
     /// This is populated when an OpenSnsTokenSwap proposal is first made.
     #[prost(uint64, optional, tag = "17")]
-    pub original_total_community_fund_maturity_e8s_equivalent: ::core::option::Option<u64>,
+    pub original_total_community_fund_maturity_e8s_equivalent: Option<u64>,
     /// This is populated when OpenSnsTokenSwap is executed. It is used when our
     /// conclude_community_fund_participation Candid method is called to either
     /// mint ICP, or restore CF neuron maturity.
     #[prost(message, repeated, tag = "18")]
-    pub cf_participants: ::prost::alloc::vec::Vec<::ic_sns_swap::pb::v1::CfParticipant>,
+    pub cf_participants: Vec<::ic_sns_swap::pb::v1::CfParticipant>,
     /// This gets set to one of the terminal values (i.e. Committed or Aborted)
     /// when the swap canister calls our conclude_community_fund_participation
     /// Candid method. Initially, it is set to Open, because swap is supposed to
     /// enter that state when we call its open Candid method, which is the main
     /// operation in the execution of an OpenSnsTokenSwap proposal.
     #[prost(enumeration = "::ic_sns_swap::pb::v1::Lifecycle", optional, tag = "19")]
-    pub sns_token_swap_lifecycle: ::core::option::Option<i32>,
+    pub sns_token_swap_lifecycle: Option<i32>,
     #[prost(message, optional, tag = "20")]
-    pub derived_proposal_information: ::core::option::Option<DerivedProposalInformation>,
+    pub derived_proposal_information: Option<DerivedProposalInformation>,
     /// This structure contains data for settling the Neurons' Fund participation at the end of a swap.
     ///
     /// TODO\[NNS1-2566\]: deprecate `original_total_community_fund_maturity_e8s_equivalent` and
     /// `cf_participants` and use only this field for managing the Neurons' Fund swap participation.
     #[prost(message, optional, tag = "21")]
-    pub neurons_fund_data: ::core::option::Option<NeuronsFundData>,
+    pub neurons_fund_data: Option<NeuronsFundData>,
 }
 /// This structure contains data for settling the Neurons' Fund participation in an SNS token swap.
 #[derive(candid::CandidType, candid::Deserialize, serde::Serialize, comparable::Comparable)]
@@ -1564,14 +1577,14 @@ pub struct NeuronsFundData {
     /// Initial Neurons' Fund reserves computed at the time of execution of the proposal through which
     /// the SNS swap is created.
     #[prost(message, optional, tag = "1")]
-    pub initial_neurons_fund_participation: ::core::option::Option<NeuronsFundParticipation>,
+    pub initial_neurons_fund_participation: Option<NeuronsFundParticipation>,
     /// Final Neurons' Fund participation computed at the time of swap finalization. This field should
     /// remain unspecified until either (1) the `settle_neurons_fund_participation` function is called
     /// or (2) the NNS handles an error at the SNS deployment stage.
     ///
     /// If specified, this must be a subset of `initial_neurons_fund_participation`.
     #[prost(message, optional, tag = "2")]
-    pub final_neurons_fund_participation: ::core::option::Option<NeuronsFundParticipation>,
+    pub final_neurons_fund_participation: Option<NeuronsFundParticipation>,
     /// Refunds for any leftover Neurons' Fund maturity that could not be used to participate in
     /// the swap. This field should remain unspecified `settle_neurons_fund_participation` is called.
     ///
@@ -1579,7 +1592,7 @@ pub struct NeuronsFundData {
     /// `initial_neurons_fund_participation.neurons_fund_reserves`
     /// set-minus `final_neurons_fund_participation.neurons_fund_reserves`.
     #[prost(message, optional, tag = "3")]
-    pub neurons_fund_refunds: ::core::option::Option<NeuronsFundSnapshot>,
+    pub neurons_fund_refunds: Option<NeuronsFundSnapshot>,
 }
 /// This is a view of the NeuronsFundData returned by API queries and is NOT used for storage.
 /// Currently, the structure is identical to NeuronsFundData, but this may change over time.
@@ -1590,13 +1603,13 @@ pub struct NeuronsFundData {
 pub struct NeuronsFundAuditInfo {
     /// See documentation for NeuronsFundData.neurons_fund_participation
     #[prost(message, optional, tag = "1")]
-    pub initial_neurons_fund_participation: ::core::option::Option<NeuronsFundParticipation>,
+    pub initial_neurons_fund_participation: Option<NeuronsFundParticipation>,
     /// See documentation for NeuronsFundData.final_neurons_fund_participation
     #[prost(message, optional, tag = "2")]
-    pub final_neurons_fund_participation: ::core::option::Option<NeuronsFundParticipation>,
+    pub final_neurons_fund_participation: Option<NeuronsFundParticipation>,
     /// See documentation for NeuronsFundData.neurons_fund_refunds
     #[prost(message, optional, tag = "3")]
-    pub neurons_fund_refunds: ::core::option::Option<NeuronsFundSnapshot>,
+    pub neurons_fund_refunds: Option<NeuronsFundSnapshot>,
 }
 #[derive(candid::CandidType, candid::Deserialize, serde::Serialize, comparable::Comparable)]
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -1604,14 +1617,14 @@ pub struct NeuronsFundAuditInfo {
 pub struct GetNeuronsFundAuditInfoRequest {
     /// ID of the NNS proposal that resulted in the creation of the corresponding Swap.
     #[prost(message, optional, tag = "1")]
-    pub nns_proposal_id: ::core::option::Option<::ic_nns_common::pb::v1::ProposalId>,
+    pub nns_proposal_id: Option<::ic_nns_common::pb::v1::ProposalId>,
 }
 #[derive(candid::CandidType, candid::Deserialize, serde::Serialize, comparable::Comparable)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetNeuronsFundAuditInfoResponse {
     #[prost(oneof = "get_neurons_fund_audit_info_response::Result", tags = "1, 2")]
-    pub result: ::core::option::Option<get_neurons_fund_audit_info_response::Result>,
+    pub result: Option<get_neurons_fund_audit_info_response::Result>,
 }
 /// Nested message and enum types in `GetNeuronsFundAuditInfoResponse`.
 pub mod get_neurons_fund_audit_info_response {
@@ -1622,7 +1635,7 @@ pub mod get_neurons_fund_audit_info_response {
     pub struct Ok {
         /// Represents public information suitable for auditing Neurons' Fund participation in an SNS swap.
         #[prost(message, optional, tag = "1")]
-        pub neurons_fund_audit_info: ::core::option::Option<super::NeuronsFundAuditInfo>,
+        pub neurons_fund_audit_info: Option<super::NeuronsFundAuditInfo>,
     }
     #[derive(candid::CandidType, candid::Deserialize, serde::Serialize, comparable::Comparable)]
     #[allow(clippy::derive_partial_eq_without_eq)]
@@ -1646,38 +1659,37 @@ pub struct NeuronsFundParticipation {
     /// the amount of maturity stored in `neurons_fund_snapshot` will not not be exceeded for due to
     /// a change in this function.
     #[prost(message, optional, tag = "1")]
-    pub ideal_matched_participation_function:
-        ::core::option::Option<IdealMatchedParticipationFunction>,
+    pub ideal_matched_participation_function: Option<IdealMatchedParticipationFunction>,
     /// The snapshot of the Neurons' Fund allocation of its maximum swap participation amount among
     /// its neurons. This snapshot is computed at the execution time of the NNS proposal leading
     /// to the swap opening.
     #[prost(message, optional, tag = "2")]
-    pub neurons_fund_reserves: ::core::option::Option<NeuronsFundSnapshot>,
+    pub neurons_fund_reserves: Option<NeuronsFundSnapshot>,
     /// Absolute constraints for direct participants of this swap needed in Matched Funding
     /// computations.
     #[prost(message, optional, tag = "3")]
-    pub swap_participation_limits: ::core::option::Option<SwapParticipationLimits>,
+    pub swap_participation_limits: Option<SwapParticipationLimits>,
     /// Neurons' Fund participation is computed for this amount of direct participation.
     #[prost(uint64, optional, tag = "4")]
-    pub direct_participation_icp_e8s: ::core::option::Option<u64>,
+    pub direct_participation_icp_e8s: Option<u64>,
     /// Total amount of maturity in the Neurons' Fund at the time when the Neurons' Fund participation
     /// was created.
     #[prost(uint64, optional, tag = "5")]
-    pub total_maturity_equivalent_icp_e8s: ::core::option::Option<u64>,
+    pub total_maturity_equivalent_icp_e8s: Option<u64>,
     /// Maximum amount that the Neurons' Fund will participate with in this SNS swap, regardless of how
     /// large the value of `direct_participation_icp_e8s` is.
     #[prost(uint64, optional, tag = "6")]
-    pub max_neurons_fund_swap_participation_icp_e8s: ::core::option::Option<u64>,
+    pub max_neurons_fund_swap_participation_icp_e8s: Option<u64>,
     /// How much the Neurons' Fund would ideally like to participate with in this SNS swap, given
     /// the direct participation amount (`direct_participation_icp_e8s`) and matching function
     /// (`ideal_matched_participation_function`).
     #[prost(uint64, optional, tag = "7")]
-    pub intended_neurons_fund_participation_icp_e8s: ::core::option::Option<u64>,
+    pub intended_neurons_fund_participation_icp_e8s: Option<u64>,
     /// How much from `intended_neurons_fund_participation_icp_e8s` was the Neurons' Fund actually able
     /// to allocate, given the specific composition of neurons at the time of execution of the proposal
     /// through which this SNS was created and the participation limits of this SNS.
     #[prost(uint64, optional, tag = "8")]
-    pub allocated_neurons_fund_participation_icp_e8s: ::core::option::Option<u64>,
+    pub allocated_neurons_fund_participation_icp_e8s: Option<u64>,
 }
 /// This function is called "ideal" because it serves as the guideline that the Neurons' Fund will
 /// try to follow, but may deviate from in order to satisfy SNS-specific participation constraints
@@ -1692,7 +1704,7 @@ pub struct IdealMatchedParticipationFunction {
     /// In the future, we could change this message to represent full abstract syntactic trees
     /// comprised of elementary mathematical operators, with literals and variables as tree leaves.
     #[prost(string, optional, tag = "1")]
-    pub serialized_representation: ::core::option::Option<::prost::alloc::string::String>,
+    pub serialized_representation: Option<::prost::alloc::string::String>,
 }
 /// The snapshot of the Neurons' Fund allocation of its maximum swap participation amount among
 /// its neurons. This snapshot is computed at the execution time of the NNS proposal leading
@@ -1703,11 +1715,12 @@ pub struct IdealMatchedParticipationFunction {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct NeuronsFundSnapshot {
     #[prost(message, repeated, tag = "1")]
-    pub neurons_fund_neuron_portions:
-        ::prost::alloc::vec::Vec<neurons_fund_snapshot::NeuronsFundNeuronPortion>,
+    pub neurons_fund_neuron_portions: Vec<neurons_fund_snapshot::NeuronsFundNeuronPortion>,
 }
 /// Nested message and enum types in `NeuronsFundSnapshot`.
 pub mod neurons_fund_snapshot {
+    use super::*;
+
     /// Represents one NNS neuron from the Neurons' Fund participating in this swap.
     #[derive(candid::CandidType, candid::Deserialize, serde::Serialize, comparable::Comparable)]
     #[allow(clippy::derive_partial_eq_without_eq)]
@@ -1715,28 +1728,28 @@ pub mod neurons_fund_snapshot {
     pub struct NeuronsFundNeuronPortion {
         /// The NNS neuron ID of the participating neuron.
         #[prost(message, optional, tag = "1")]
-        pub nns_neuron_id: ::core::option::Option<::ic_nns_common::pb::v1::NeuronId>,
+        pub nns_neuron_id: Option<NeuronId>,
         /// Portion of maturity taken from this neuron. Must be less than or equal to
         /// `maturity_equivalent_icp_e8s`.
         #[prost(uint64, optional, tag = "2")]
-        pub amount_icp_e8s: ::core::option::Option<u64>,
+        pub amount_icp_e8s: Option<u64>,
         /// Overall amount of maturity of the neuron from which this portion is taken.
         #[prost(uint64, optional, tag = "3")]
-        pub maturity_equivalent_icp_e8s: ::core::option::Option<u64>,
+        pub maturity_equivalent_icp_e8s: Option<u64>,
         /// Whether the portion specified by `amount_icp_e8s` is limited due to SNS-specific
         /// participation constraints.
         #[prost(bool, optional, tag = "5")]
-        pub is_capped: ::core::option::Option<bool>,
+        pub is_capped: Option<bool>,
         /// The principal that can manage the NNS neuron that participated in the Neurons' Fund.
         #[prost(message, optional, tag = "6")]
-        pub controller: ::core::option::Option<::ic_base_types::PrincipalId>,
+        pub controller: Option<PrincipalId>,
         /// The principals that can vote, propose, and follow on behalf of this neuron.
         #[prost(message, repeated, tag = "7")]
-        pub hotkeys: ::prost::alloc::vec::Vec<::ic_base_types::PrincipalId>,
+        pub hotkeys: Vec<PrincipalId>,
         /// Deprecated. Please use `controller` instead (not `hotkeys`!)
         #[deprecated]
         #[prost(message, optional, tag = "4")]
-        pub hotkey_principal: ::core::option::Option<::ic_base_types::PrincipalId>,
+        pub hotkey_principal: Option<PrincipalId>,
     }
 }
 /// Absolute constraints of this swap needed that the Neurons' Fund need to be aware of.
@@ -1746,13 +1759,13 @@ pub mod neurons_fund_snapshot {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SwapParticipationLimits {
     #[prost(uint64, optional, tag = "1")]
-    pub min_direct_participation_icp_e8s: ::core::option::Option<u64>,
+    pub min_direct_participation_icp_e8s: Option<u64>,
     #[prost(uint64, optional, tag = "2")]
-    pub max_direct_participation_icp_e8s: ::core::option::Option<u64>,
+    pub max_direct_participation_icp_e8s: Option<u64>,
     #[prost(uint64, optional, tag = "3")]
-    pub min_participant_icp_e8s: ::core::option::Option<u64>,
+    pub min_participant_icp_e8s: Option<u64>,
     #[prost(uint64, optional, tag = "4")]
-    pub max_participant_icp_e8s: ::core::option::Option<u64>,
+    pub max_participant_icp_e8s: Option<u64>,
 }
 /// This message has a couple of unusual features.
 ///
@@ -1770,7 +1783,7 @@ pub struct SwapParticipationLimits {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DerivedProposalInformation {
     #[prost(message, optional, tag = "1")]
-    pub swap_background_information: ::core::option::Option<SwapBackgroundInformation>,
+    pub swap_background_information: Option<SwapBackgroundInformation>,
 }
 /// Additional information about the SNS that's being "swapped".
 ///
@@ -1787,58 +1800,55 @@ pub struct DerivedProposalInformation {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SwapBackgroundInformation {
     #[prost(message, repeated, tag = "7")]
-    pub fallback_controller_principal_ids: ::prost::alloc::vec::Vec<::ic_base_types::PrincipalId>,
+    pub fallback_controller_principal_ids: Vec<PrincipalId>,
     #[prost(message, optional, tag = "8")]
-    pub root_canister_summary: ::core::option::Option<swap_background_information::CanisterSummary>,
+    pub root_canister_summary: Option<swap_background_information::CanisterSummary>,
     #[prost(message, optional, tag = "9")]
-    pub governance_canister_summary:
-        ::core::option::Option<swap_background_information::CanisterSummary>,
+    pub governance_canister_summary: Option<swap_background_information::CanisterSummary>,
     #[prost(message, optional, tag = "10")]
-    pub ledger_canister_summary:
-        ::core::option::Option<swap_background_information::CanisterSummary>,
+    pub ledger_canister_summary: Option<swap_background_information::CanisterSummary>,
     #[prost(message, optional, tag = "11")]
-    pub swap_canister_summary: ::core::option::Option<swap_background_information::CanisterSummary>,
+    pub swap_canister_summary: Option<swap_background_information::CanisterSummary>,
     #[prost(message, repeated, tag = "12")]
-    pub ledger_archive_canister_summaries:
-        ::prost::alloc::vec::Vec<swap_background_information::CanisterSummary>,
+    pub ledger_archive_canister_summaries: Vec<swap_background_information::CanisterSummary>,
     #[prost(message, optional, tag = "13")]
-    pub ledger_index_canister_summary:
-        ::core::option::Option<swap_background_information::CanisterSummary>,
+    pub ledger_index_canister_summary: Option<swap_background_information::CanisterSummary>,
     #[prost(message, repeated, tag = "14")]
-    pub dapp_canister_summaries:
-        ::prost::alloc::vec::Vec<swap_background_information::CanisterSummary>,
+    pub dapp_canister_summaries: Vec<swap_background_information::CanisterSummary>,
 }
 /// Nested message and enum types in `SwapBackgroundInformation`.
 pub mod swap_background_information {
+    use super::*;
+
     /// Transcribed from sns/root.
     #[derive(candid::CandidType, candid::Deserialize, serde::Serialize, comparable::Comparable)]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct CanisterSummary {
         #[prost(message, optional, tag = "1")]
-        pub canister_id: ::core::option::Option<::ic_base_types::PrincipalId>,
+        pub canister_id: Option<PrincipalId>,
         #[prost(message, optional, tag = "2")]
-        pub status: ::core::option::Option<CanisterStatusResultV2>,
+        pub status: Option<CanisterStatusResultV2>,
     }
     #[derive(candid::CandidType, candid::Deserialize, serde::Serialize, comparable::Comparable)]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct CanisterStatusResultV2 {
         #[prost(enumeration = "CanisterStatusType", optional, tag = "1")]
-        pub status: ::core::option::Option<i32>,
+        pub status: Option<i32>,
         #[prost(bytes = "vec", tag = "2")]
         #[serde(with = "serde_bytes")]
-        pub module_hash: ::prost::alloc::vec::Vec<u8>,
+        pub module_hash: Vec<u8>,
         #[prost(message, repeated, tag = "3")]
-        pub controllers: ::prost::alloc::vec::Vec<::ic_base_types::PrincipalId>,
+        pub controllers: Vec<PrincipalId>,
         #[prost(uint64, optional, tag = "4")]
-        pub memory_size: ::core::option::Option<u64>,
+        pub memory_size: Option<u64>,
         #[prost(uint64, optional, tag = "5")]
-        pub cycles: ::core::option::Option<u64>,
+        pub cycles: Option<u64>,
         #[prost(uint64, optional, tag = "6")]
-        pub freezing_threshold: ::core::option::Option<u64>,
+        pub freezing_threshold: Option<u64>,
         #[prost(uint64, optional, tag = "7")]
-        pub idle_cycles_burned_per_day: ::core::option::Option<u64>,
+        pub idle_cycles_burned_per_day: Option<u64>,
     }
     /// A canister can be stopped by calling stop_canister. The effect of
     /// stop_canister can be undone by calling start_canister. Stopping is an
@@ -1880,7 +1890,7 @@ pub mod swap_background_information {
             }
         }
         /// Creates an enum from field names used in the ProtoBuf definition.
-        pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+        pub fn from_str_name(value: &str) -> Option<Self> {
             match value {
                 "CANISTER_STATUS_TYPE_UNSPECIFIED" => Some(Self::Unspecified),
                 "CANISTER_STATUS_TYPE_RUNNING" => Some(Self::Running),
@@ -1908,17 +1918,17 @@ pub struct WaitForQuietState {
 pub struct ProposalInfo {
     /// The unique id for this proposal.
     #[prost(message, optional, tag = "1")]
-    pub id: ::core::option::Option<::ic_nns_common::pb::v1::ProposalId>,
+    pub id: Option<::ic_nns_common::pb::v1::ProposalId>,
     /// The ID of the neuron that made this proposal.
     #[prost(message, optional, tag = "2")]
-    pub proposer: ::core::option::Option<::ic_nns_common::pb::v1::NeuronId>,
+    pub proposer: Option<NeuronId>,
     /// The amount of ICP in E8s to be charged to the proposer if the proposal is
     /// rejected.
     #[prost(uint64, tag = "3")]
     pub reject_cost_e8s: u64,
     /// The proposal originally submitted.
     #[prost(message, optional, tag = "4")]
-    pub proposal: ::core::option::Option<Proposal>,
+    pub proposal: Option<Proposal>,
     /// The timestamp, in seconds from the Unix epoch, when this proposal was made.
     #[prost(uint64, tag = "5")]
     pub proposal_timestamp_seconds: u64,
@@ -1927,7 +1937,7 @@ pub struct ProposalInfo {
     pub ballots: ::std::collections::HashMap<u64, Ballot>,
     /// See \[ProposalData::latest_tally\].
     #[prost(message, optional, tag = "7")]
-    pub latest_tally: ::core::option::Option<Tally>,
+    pub latest_tally: Option<Tally>,
     /// See \[ProposalData::decided_timestamp_seconds\].
     #[prost(uint64, tag = "8")]
     pub decided_timestamp_seconds: u64,
@@ -1939,7 +1949,7 @@ pub struct ProposalInfo {
     pub failed_timestamp_seconds: u64,
     /// See \[ProposalData::failure_reason\].
     #[prost(message, optional, tag = "18")]
-    pub failure_reason: ::core::option::Option<GovernanceError>,
+    pub failure_reason: Option<GovernanceError>,
     /// See \[ProposalData::reward_event_round\].
     #[prost(uint64, tag = "14")]
     pub reward_event_round: u64,
@@ -1953,9 +1963,9 @@ pub struct ProposalInfo {
     #[prost(enumeration = "ProposalRewardStatus", tag = "17")]
     pub reward_status: i32,
     #[prost(uint64, optional, tag = "19")]
-    pub deadline_timestamp_seconds: ::core::option::Option<u64>,
+    pub deadline_timestamp_seconds: Option<u64>,
     #[prost(message, optional, tag = "20")]
-    pub derived_proposal_information: ::core::option::Option<DerivedProposalInformation>,
+    pub derived_proposal_information: Option<DerivedProposalInformation>,
 }
 /// Network economics contains the parameters for several operations related
 /// to the economy of the network. When submitting a NetworkEconomics proposal
@@ -2018,7 +2028,7 @@ pub struct NetworkEconomics {
     pub max_proposals_to_keep_per_topic: u32,
     /// Global Neurons' Fund participation thresholds.
     #[prost(message, optional, tag = "11")]
-    pub neurons_fund_economics: ::core::option::Option<NeuronsFundEconomics>,
+    pub neurons_fund_economics: Option<NeuronsFundEconomics>,
 }
 /// The thresholds specify the shape of the ideal matching function used by the Neurons' Fund to
 /// determine how much to contribute for a given direct participation amount. Note that the actual
@@ -2030,22 +2040,19 @@ pub struct NetworkEconomics {
 pub struct NeuronsFundMatchedFundingCurveCoefficients {
     /// Up to this amount of direct participation, the Neurons' Fund does not contribute to this SNS.
     #[prost(message, optional, tag = "1")]
-    pub contribution_threshold_xdr:
-        ::core::option::Option<::ic_nervous_system_proto::pb::v1::Decimal>,
+    pub contribution_threshold_xdr: Option<::ic_nervous_system_proto::pb::v1::Decimal>,
     /// Say the direct participation amount is `x_icp`. When `x_icp` equals the equavalent of
     /// `one_third_participation_milestone_xdr` in ICP (we use ICP/XDR conversion data from the CMC),
     /// the Neurons' Fund contributes 50% on top of that amount, so the overall contributions would
     /// be `1.5 * x_icp` of which 1/3 comes from the Neurons' Fund.
     #[prost(message, optional, tag = "2")]
-    pub one_third_participation_milestone_xdr:
-        ::core::option::Option<::ic_nervous_system_proto::pb::v1::Decimal>,
+    pub one_third_participation_milestone_xdr: Option<::ic_nervous_system_proto::pb::v1::Decimal>,
     /// Say the direct participation amount is `x_icp`. When `x_icp` equals the equavalent of
     /// `full_participation_milestone_xdr` in ICP (we use ICP/XDR conversion data from the CMC),
     /// the Neurons' Fund contributes 100% on top of that amount, so the overall contributions would
     /// be `2.0 * x_icp` of which a half comes from the Neurons' Fund.
     #[prost(message, optional, tag = "3")]
-    pub full_participation_milestone_xdr:
-        ::core::option::Option<::ic_nervous_system_proto::pb::v1::Decimal>,
+    pub full_participation_milestone_xdr: Option<::ic_nervous_system_proto::pb::v1::Decimal>,
 }
 /// When the Neurons' Fund decides to participates in an SNS swap, the amount of participation is
 /// determined according to the rules of Matched Funding. The amount of ICP tokens contributed by
@@ -2063,20 +2070,20 @@ pub struct NeuronsFundEconomics {
     /// that practically needs to be reserved from the Neurons' Fund for a given SNS swap.
     #[prost(message, optional, tag = "1")]
     pub max_theoretical_neurons_fund_participation_amount_xdr:
-        ::core::option::Option<::ic_nervous_system_proto::pb::v1::Decimal>,
+        Option<::ic_nervous_system_proto::pb::v1::Decimal>,
     /// Thresholds specifying the shape of the matching function used by the Neurons' Fund to
     /// determine how much to contribute for a given direct participation amount.
     #[prost(message, optional, tag = "2")]
     pub neurons_fund_matched_funding_curve_coefficients:
-        ::core::option::Option<NeuronsFundMatchedFundingCurveCoefficients>,
+        Option<NeuronsFundMatchedFundingCurveCoefficients>,
     /// The minimum value of the ICP/XDR conversion rate used by the Neurons' Fund for converting
     /// XDR values into ICP.
     #[prost(message, optional, tag = "3")]
-    pub minimum_icp_xdr_rate: ::core::option::Option<::ic_nervous_system_proto::pb::v1::Percentage>,
+    pub minimum_icp_xdr_rate: Option<::ic_nervous_system_proto::pb::v1::Percentage>,
     /// The maximum value of the ICP/XDR conversion rate used by the Neurons' Fund for converting
     /// XDR values into ICP.
     #[prost(message, optional, tag = "4")]
-    pub maximum_icp_xdr_rate: ::core::option::Option<::ic_nervous_system_proto::pb::v1::Percentage>,
+    pub maximum_icp_xdr_rate: Option<::ic_nervous_system_proto::pb::v1::Percentage>,
 }
 /// A reward event is an event at which neuron maturity is increased
 #[derive(candid::CandidType, candid::Deserialize, serde::Serialize, comparable::Comparable)]
@@ -2105,7 +2112,7 @@ pub struct RewardEvent {
     /// The list of proposals that were taken into account during
     /// this reward event.
     #[prost(message, repeated, tag = "3")]
-    pub settled_proposals: ::prost::alloc::vec::Vec<::ic_nns_common::pb::v1::ProposalId>,
+    pub settled_proposals: Vec<::ic_nns_common::pb::v1::ProposalId>,
     /// The total amount of reward that was distributed during this reward event.
     ///
     /// The unit is "e8s equivalent" to insist that, while this quantity is on
@@ -2120,7 +2127,7 @@ pub struct RewardEvent {
     /// this event. This will only be different from `total_available_e8s_equivalent`
     /// if there were "rollover rounds" included in this event.
     #[prost(uint64, optional, tag = "7")]
-    pub latest_round_available_e8s_equivalent: ::core::option::Option<u64>,
+    pub latest_round_available_e8s_equivalent: Option<u64>,
     /// In some cases, the rewards that would have been distributed in one round are
     /// "rolled over" into the next reward event. This field keeps track of how many
     /// rounds have passed since the last time rewards were distributed (rather
@@ -2140,16 +2147,16 @@ pub struct RewardEvent {
     ///
     /// In both of these cases, the rewards purse rolls over into the next round.
     #[prost(uint64, optional, tag = "6")]
-    pub rounds_since_last_distribution: ::core::option::Option<u64>,
+    pub rounds_since_last_distribution: Option<u64>,
 }
 #[derive(candid::CandidType, candid::Deserialize, serde::Serialize, comparable::Comparable)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct KnownNeuron {
     #[prost(message, optional, tag = "1")]
-    pub id: ::core::option::Option<::ic_nns_common::pb::v1::NeuronId>,
+    pub id: Option<NeuronId>,
     #[prost(message, optional, tag = "2")]
-    pub known_neuron_data: ::core::option::Option<KnownNeuronData>,
+    pub known_neuron_data: Option<KnownNeuronData>,
 }
 /// Known neurons have extra information (a name and optionally a description) that can be used to identify them.
 #[derive(candid::CandidType, candid::Deserialize, serde::Serialize, comparable::Comparable, Eq)]
@@ -2160,7 +2167,7 @@ pub struct KnownNeuronData {
     #[prost(string, tag = "1")]
     pub name: ::prost::alloc::string::String,
     #[prost(string, optional, tag = "2")]
-    pub description: ::core::option::Option<::prost::alloc::string::String>,
+    pub description: Option<::prost::alloc::string::String>,
 }
 /// Proposal action to call the "open" method of an SNS token swap canister.
 #[derive(candid::CandidType, candid::Deserialize, serde::Serialize, comparable::Comparable)]
@@ -2170,14 +2177,14 @@ pub struct OpenSnsTokenSwap {
     /// The ID of the canister where the command will be sent (assuming that the
     /// proposal is adopted, of course).
     #[prost(message, optional, tag = "1")]
-    pub target_swap_canister_id: ::core::option::Option<::ic_base_types::PrincipalId>,
+    pub target_swap_canister_id: Option<PrincipalId>,
     /// Various limits on the swap.
     #[prost(message, optional, tag = "2")]
-    pub params: ::core::option::Option<::ic_sns_swap::pb::v1::Params>,
+    pub params: Option<::ic_sns_swap::pb::v1::Params>,
     /// The amount that the community fund will collectively spend in maturity on
     /// the swap.
     #[prost(uint64, optional, tag = "3")]
-    pub community_fund_investment_e8s: ::core::option::Option<u64>,
+    pub community_fund_investment_e8s: Option<u64>,
 }
 /// Mainly, calls the deploy_new_sns Candid method on the SNS-WASMs canister.
 /// Therefore, most of the fields here have equivalents in SnsInitPayload.
@@ -2190,45 +2197,44 @@ pub struct OpenSnsTokenSwap {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CreateServiceNervousSystem {
     #[prost(string, optional, tag = "1")]
-    pub name: ::core::option::Option<::prost::alloc::string::String>,
+    pub name: Option<::prost::alloc::string::String>,
     #[prost(string, optional, tag = "2")]
-    pub description: ::core::option::Option<::prost::alloc::string::String>,
+    pub description: Option<::prost::alloc::string::String>,
     #[prost(string, optional, tag = "3")]
-    pub url: ::core::option::Option<::prost::alloc::string::String>,
+    pub url: Option<::prost::alloc::string::String>,
     #[prost(message, optional, tag = "4")]
-    pub logo: ::core::option::Option<::ic_nervous_system_proto::pb::v1::Image>,
+    pub logo: Option<::ic_nervous_system_proto::pb::v1::Image>,
     #[prost(message, repeated, tag = "5")]
-    pub fallback_controller_principal_ids: ::prost::alloc::vec::Vec<::ic_base_types::PrincipalId>,
+    pub fallback_controller_principal_ids: Vec<PrincipalId>,
     #[prost(message, repeated, tag = "6")]
-    pub dapp_canisters: ::prost::alloc::vec::Vec<::ic_nervous_system_proto::pb::v1::Canister>,
+    pub dapp_canisters: Vec<::ic_nervous_system_proto::pb::v1::Canister>,
     #[prost(message, optional, tag = "7")]
-    pub initial_token_distribution:
-        ::core::option::Option<create_service_nervous_system::InitialTokenDistribution>,
+    pub initial_token_distribution: Option<create_service_nervous_system::InitialTokenDistribution>,
     #[prost(message, optional, tag = "8")]
-    pub swap_parameters: ::core::option::Option<create_service_nervous_system::SwapParameters>,
+    pub swap_parameters: Option<create_service_nervous_system::SwapParameters>,
     #[prost(message, optional, tag = "9")]
-    pub ledger_parameters: ::core::option::Option<create_service_nervous_system::LedgerParameters>,
+    pub ledger_parameters: Option<create_service_nervous_system::LedgerParameters>,
     #[prost(message, optional, tag = "10")]
-    pub governance_parameters:
-        ::core::option::Option<create_service_nervous_system::GovernanceParameters>,
+    pub governance_parameters: Option<create_service_nervous_system::GovernanceParameters>,
 }
 /// Nested message and enum types in `CreateServiceNervousSystem`.
 pub mod create_service_nervous_system {
+    use super::*;
+
     #[derive(candid::CandidType, candid::Deserialize, serde::Serialize, comparable::Comparable)]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct InitialTokenDistribution {
         #[prost(message, optional, tag = "1")]
-        pub developer_distribution:
-            ::core::option::Option<initial_token_distribution::DeveloperDistribution>,
+        pub developer_distribution: Option<initial_token_distribution::DeveloperDistribution>,
         #[prost(message, optional, tag = "2")]
-        pub treasury_distribution:
-            ::core::option::Option<initial_token_distribution::TreasuryDistribution>,
+        pub treasury_distribution: Option<initial_token_distribution::TreasuryDistribution>,
         #[prost(message, optional, tag = "3")]
-        pub swap_distribution: ::core::option::Option<initial_token_distribution::SwapDistribution>,
+        pub swap_distribution: Option<initial_token_distribution::SwapDistribution>,
     }
     /// Nested message and enum types in `InitialTokenDistribution`.
     pub mod initial_token_distribution {
+        use super::*;
         #[derive(
             candid::CandidType, candid::Deserialize, serde::Serialize, comparable::Comparable,
         )]
@@ -2236,11 +2242,12 @@ pub mod create_service_nervous_system {
         #[derive(Clone, PartialEq, ::prost::Message)]
         pub struct DeveloperDistribution {
             #[prost(message, repeated, tag = "1")]
-            pub developer_neurons:
-                ::prost::alloc::vec::Vec<developer_distribution::NeuronDistribution>,
+            pub developer_neurons: Vec<developer_distribution::NeuronDistribution>,
         }
         /// Nested message and enum types in `DeveloperDistribution`.
         pub mod developer_distribution {
+            use super::*;
+
             #[derive(
                 candid::CandidType, candid::Deserialize, serde::Serialize, comparable::Comparable,
             )]
@@ -2248,17 +2255,15 @@ pub mod create_service_nervous_system {
             #[derive(Clone, PartialEq, ::prost::Message)]
             pub struct NeuronDistribution {
                 #[prost(message, optional, tag = "1")]
-                pub controller: ::core::option::Option<::ic_base_types::PrincipalId>,
+                pub controller: Option<PrincipalId>,
                 #[prost(message, optional, tag = "2")]
-                pub dissolve_delay:
-                    ::core::option::Option<::ic_nervous_system_proto::pb::v1::Duration>,
+                pub dissolve_delay: Option<::ic_nervous_system_proto::pb::v1::Duration>,
                 #[prost(uint64, optional, tag = "3")]
-                pub memo: ::core::option::Option<u64>,
+                pub memo: Option<u64>,
                 #[prost(message, optional, tag = "4")]
-                pub stake: ::core::option::Option<::ic_nervous_system_proto::pb::v1::Tokens>,
+                pub stake: Option<::ic_nervous_system_proto::pb::v1::Tokens>,
                 #[prost(message, optional, tag = "5")]
-                pub vesting_period:
-                    ::core::option::Option<::ic_nervous_system_proto::pb::v1::Duration>,
+                pub vesting_period: Option<::ic_nervous_system_proto::pb::v1::Duration>,
             }
         }
         #[derive(
@@ -2268,7 +2273,7 @@ pub mod create_service_nervous_system {
         #[derive(Clone, PartialEq, ::prost::Message)]
         pub struct TreasuryDistribution {
             #[prost(message, optional, tag = "1")]
-            pub total: ::core::option::Option<::ic_nervous_system_proto::pb::v1::Tokens>,
+            pub total: Option<::ic_nervous_system_proto::pb::v1::Tokens>,
         }
         #[derive(
             candid::CandidType, candid::Deserialize, serde::Serialize, comparable::Comparable,
@@ -2277,7 +2282,7 @@ pub mod create_service_nervous_system {
         #[derive(Clone, PartialEq, ::prost::Message)]
         pub struct SwapDistribution {
             #[prost(message, optional, tag = "1")]
-            pub total: ::core::option::Option<::ic_nervous_system_proto::pb::v1::Tokens>,
+            pub total: Option<::ic_nervous_system_proto::pb::v1::Tokens>,
         }
     }
     #[derive(candid::CandidType, candid::Deserialize, serde::Serialize, comparable::Comparable)]
@@ -2285,47 +2290,41 @@ pub mod create_service_nervous_system {
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct SwapParameters {
         #[prost(uint64, optional, tag = "1")]
-        pub minimum_participants: ::core::option::Option<u64>,
+        pub minimum_participants: Option<u64>,
         #[prost(message, optional, tag = "2")]
-        pub minimum_icp: ::core::option::Option<::ic_nervous_system_proto::pb::v1::Tokens>,
+        pub minimum_icp: Option<::ic_nervous_system_proto::pb::v1::Tokens>,
         #[prost(message, optional, tag = "3")]
-        pub maximum_icp: ::core::option::Option<::ic_nervous_system_proto::pb::v1::Tokens>,
+        pub maximum_icp: Option<::ic_nervous_system_proto::pb::v1::Tokens>,
         #[prost(message, optional, tag = "12")]
-        pub minimum_direct_participation_icp:
-            ::core::option::Option<::ic_nervous_system_proto::pb::v1::Tokens>,
+        pub minimum_direct_participation_icp: Option<::ic_nervous_system_proto::pb::v1::Tokens>,
         #[prost(message, optional, tag = "13")]
-        pub maximum_direct_participation_icp:
-            ::core::option::Option<::ic_nervous_system_proto::pb::v1::Tokens>,
+        pub maximum_direct_participation_icp: Option<::ic_nervous_system_proto::pb::v1::Tokens>,
         #[prost(message, optional, tag = "4")]
-        pub minimum_participant_icp:
-            ::core::option::Option<::ic_nervous_system_proto::pb::v1::Tokens>,
+        pub minimum_participant_icp: Option<::ic_nervous_system_proto::pb::v1::Tokens>,
         #[prost(message, optional, tag = "5")]
-        pub maximum_participant_icp:
-            ::core::option::Option<::ic_nervous_system_proto::pb::v1::Tokens>,
+        pub maximum_participant_icp: Option<::ic_nervous_system_proto::pb::v1::Tokens>,
         #[prost(message, optional, tag = "6")]
         pub neuron_basket_construction_parameters:
-            ::core::option::Option<swap_parameters::NeuronBasketConstructionParameters>,
+            Option<swap_parameters::NeuronBasketConstructionParameters>,
         #[prost(string, optional, tag = "7")]
-        pub confirmation_text: ::core::option::Option<::prost::alloc::string::String>,
+        pub confirmation_text: Option<::prost::alloc::string::String>,
         #[prost(message, optional, tag = "8")]
-        pub restricted_countries:
-            ::core::option::Option<::ic_nervous_system_proto::pb::v1::Countries>,
+        pub restricted_countries: Option<::ic_nervous_system_proto::pb::v1::Countries>,
         /// The swap occurs at a specific time of day, in UTC.
         /// It will happen the first time start_time occurs that's at least 24h after
         /// the proposal is adopted.
         #[prost(message, optional, tag = "9")]
-        pub start_time: ::core::option::Option<::ic_nervous_system_proto::pb::v1::GlobalTimeOfDay>,
+        pub start_time: Option<::ic_nervous_system_proto::pb::v1::GlobalTimeOfDay>,
         #[prost(message, optional, tag = "10")]
-        pub duration: ::core::option::Option<::ic_nervous_system_proto::pb::v1::Duration>,
+        pub duration: Option<::ic_nervous_system_proto::pb::v1::Duration>,
         /// The amount that the Neuron's Fund will collectively spend in maturity on
         /// the swap.
         #[prost(message, optional, tag = "11")]
-        pub neurons_fund_investment_icp:
-            ::core::option::Option<::ic_nervous_system_proto::pb::v1::Tokens>,
+        pub neurons_fund_investment_icp: Option<::ic_nervous_system_proto::pb::v1::Tokens>,
         /// Whether Neurons' Fund participation is requested.
         /// Cannot be set to true until Matched Funding is released
         #[prost(bool, optional, tag = "14")]
-        pub neurons_fund_participation: ::core::option::Option<bool>,
+        pub neurons_fund_participation: Option<bool>,
     }
     /// Nested message and enum types in `SwapParameters`.
     pub mod swap_parameters {
@@ -2336,10 +2335,9 @@ pub mod create_service_nervous_system {
         #[derive(Clone, PartialEq, ::prost::Message)]
         pub struct NeuronBasketConstructionParameters {
             #[prost(uint64, optional, tag = "1")]
-            pub count: ::core::option::Option<u64>,
+            pub count: Option<u64>,
             #[prost(message, optional, tag = "2")]
-            pub dissolve_delay_interval:
-                ::core::option::Option<::ic_nervous_system_proto::pb::v1::Duration>,
+            pub dissolve_delay_interval: Option<::ic_nervous_system_proto::pb::v1::Duration>,
         }
     }
     #[derive(candid::CandidType, candid::Deserialize, serde::Serialize, comparable::Comparable)]
@@ -2347,13 +2345,13 @@ pub mod create_service_nervous_system {
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct LedgerParameters {
         #[prost(message, optional, tag = "1")]
-        pub transaction_fee: ::core::option::Option<::ic_nervous_system_proto::pb::v1::Tokens>,
+        pub transaction_fee: Option<::ic_nervous_system_proto::pb::v1::Tokens>,
         #[prost(string, optional, tag = "2")]
-        pub token_name: ::core::option::Option<::prost::alloc::string::String>,
+        pub token_name: Option<::prost::alloc::string::String>,
         #[prost(string, optional, tag = "3")]
-        pub token_symbol: ::core::option::Option<::prost::alloc::string::String>,
+        pub token_symbol: Option<::prost::alloc::string::String>,
         #[prost(message, optional, tag = "4")]
-        pub token_logo: ::core::option::Option<::ic_nervous_system_proto::pb::v1::Image>,
+        pub token_logo: Option<::ic_nervous_system_proto::pb::v1::Image>,
     }
     /// Proposal Parameters
     /// -------------------
@@ -2362,34 +2360,28 @@ pub mod create_service_nervous_system {
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct GovernanceParameters {
         #[prost(message, optional, tag = "1")]
-        pub proposal_rejection_fee:
-            ::core::option::Option<::ic_nervous_system_proto::pb::v1::Tokens>,
+        pub proposal_rejection_fee: Option<::ic_nervous_system_proto::pb::v1::Tokens>,
         #[prost(message, optional, tag = "2")]
-        pub proposal_initial_voting_period:
-            ::core::option::Option<::ic_nervous_system_proto::pb::v1::Duration>,
+        pub proposal_initial_voting_period: Option<::ic_nervous_system_proto::pb::v1::Duration>,
         #[prost(message, optional, tag = "3")]
         pub proposal_wait_for_quiet_deadline_increase:
-            ::core::option::Option<::ic_nervous_system_proto::pb::v1::Duration>,
+            Option<::ic_nervous_system_proto::pb::v1::Duration>,
         #[prost(message, optional, tag = "4")]
-        pub neuron_minimum_stake: ::core::option::Option<::ic_nervous_system_proto::pb::v1::Tokens>,
+        pub neuron_minimum_stake: Option<::ic_nervous_system_proto::pb::v1::Tokens>,
         #[prost(message, optional, tag = "5")]
         pub neuron_minimum_dissolve_delay_to_vote:
-            ::core::option::Option<::ic_nervous_system_proto::pb::v1::Duration>,
+            Option<::ic_nervous_system_proto::pb::v1::Duration>,
         #[prost(message, optional, tag = "6")]
-        pub neuron_maximum_dissolve_delay:
-            ::core::option::Option<::ic_nervous_system_proto::pb::v1::Duration>,
+        pub neuron_maximum_dissolve_delay: Option<::ic_nervous_system_proto::pb::v1::Duration>,
         #[prost(message, optional, tag = "7")]
         pub neuron_maximum_dissolve_delay_bonus:
-            ::core::option::Option<::ic_nervous_system_proto::pb::v1::Percentage>,
+            Option<::ic_nervous_system_proto::pb::v1::Percentage>,
         #[prost(message, optional, tag = "8")]
-        pub neuron_maximum_age_for_age_bonus:
-            ::core::option::Option<::ic_nervous_system_proto::pb::v1::Duration>,
+        pub neuron_maximum_age_for_age_bonus: Option<::ic_nervous_system_proto::pb::v1::Duration>,
         #[prost(message, optional, tag = "9")]
-        pub neuron_maximum_age_bonus:
-            ::core::option::Option<::ic_nervous_system_proto::pb::v1::Percentage>,
+        pub neuron_maximum_age_bonus: Option<::ic_nervous_system_proto::pb::v1::Percentage>,
         #[prost(message, optional, tag = "10")]
-        pub voting_reward_parameters:
-            ::core::option::Option<governance_parameters::VotingRewardParameters>,
+        pub voting_reward_parameters: Option<governance_parameters::VotingRewardParameters>,
     }
     /// Nested message and enum types in `GovernanceParameters`.
     pub mod governance_parameters {
@@ -2400,14 +2392,12 @@ pub mod create_service_nervous_system {
         #[derive(Clone, PartialEq, ::prost::Message)]
         pub struct VotingRewardParameters {
             #[prost(message, optional, tag = "1")]
-            pub initial_reward_rate:
-                ::core::option::Option<::ic_nervous_system_proto::pb::v1::Percentage>,
+            pub initial_reward_rate: Option<::ic_nervous_system_proto::pb::v1::Percentage>,
             #[prost(message, optional, tag = "2")]
-            pub final_reward_rate:
-                ::core::option::Option<::ic_nervous_system_proto::pb::v1::Percentage>,
+            pub final_reward_rate: Option<::ic_nervous_system_proto::pb::v1::Percentage>,
             #[prost(message, optional, tag = "3")]
             pub reward_rate_transition_duration:
-                ::core::option::Option<::ic_nervous_system_proto::pb::v1::Duration>,
+                Option<::ic_nervous_system_proto::pb::v1::Duration>,
         }
     }
 }
@@ -2417,22 +2407,22 @@ pub mod create_service_nervous_system {
 pub struct InstallCode {
     /// The target canister ID to call install_code on. Required.
     #[prost(message, optional, tag = "1")]
-    pub canister_id: ::core::option::Option<::ic_base_types::PrincipalId>,
+    pub canister_id: Option<PrincipalId>,
     /// The install mode. Either install, reinstall, or upgrade. Required.
     #[prost(enumeration = "install_code::CanisterInstallMode", optional, tag = "2")]
-    pub install_mode: ::core::option::Option<i32>,
+    pub install_mode: Option<i32>,
 
     /// Whether to skip stopping the canister before installing. Optional. Default is false.
     #[prost(bool, optional, tag = "5")]
-    pub skip_stopping_before_installing: ::core::option::Option<bool>,
+    pub skip_stopping_before_installing: Option<bool>,
 
     #[prost(bytes = "vec", optional, tag = "6")]
     #[serde(deserialize_with = "ic_utils::deserialize::deserialize_option_blob")]
-    pub wasm_module_hash: ::core::option::Option<::prost::alloc::vec::Vec<u8>>,
+    pub wasm_module_hash: Option<Vec<u8>>,
 
     #[prost(bytes = "vec", optional, tag = "7")]
     #[serde(deserialize_with = "ic_utils::deserialize::deserialize_option_blob")]
-    pub arg_hash: ::core::option::Option<::prost::alloc::vec::Vec<u8>>,
+    pub arg_hash: Option<Vec<u8>>,
 }
 /// Nested message and enum types in `InstallCode`.
 pub mod install_code {
@@ -2472,7 +2462,7 @@ pub mod install_code {
             }
         }
         /// Creates an enum from field names used in the ProtoBuf definition.
-        pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+        pub fn from_str_name(value: &str) -> Option<Self> {
             match value {
                 "CANISTER_INSTALL_MODE_UNSPECIFIED" => Some(Self::Unspecified),
                 "CANISTER_INSTALL_MODE_INSTALL" => Some(Self::Install),
@@ -2489,7 +2479,7 @@ pub mod install_code {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct InstallCodeRequest {
     #[prost(message, optional, tag = "1")]
-    pub canister_id: ::core::option::Option<::ic_base_types::PrincipalId>,
+    pub canister_id: ::core::option::Option<PrincipalId>,
     #[prost(enumeration = "install_code::CanisterInstallMode", optional, tag = "2")]
     pub install_mode: ::core::option::Option<i32>,
     #[prost(bytes = "vec", optional, tag = "3")]
@@ -2509,13 +2499,13 @@ pub struct StopOrStartCanister {
     /// The target canister ID to call stop_canister or start_canister on. The canister must be
     /// controlled by NNS Root, and it cannot be NNS Governance or Lifeline. Required.
     #[prost(message, optional, tag = "1")]
-    pub canister_id: ::core::option::Option<::ic_base_types::PrincipalId>,
+    pub canister_id: Option<PrincipalId>,
     #[prost(
         enumeration = "stop_or_start_canister::CanisterAction",
         optional,
         tag = "2"
     )]
-    pub action: ::core::option::Option<i32>,
+    pub action: Option<i32>,
 }
 /// Nested message and enum types in `StopOrStartCanister`.
 pub mod stop_or_start_canister {
@@ -2554,7 +2544,7 @@ pub mod stop_or_start_canister {
             }
         }
         /// Creates an enum from field names used in the ProtoBuf definition.
-        pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+        pub fn from_str_name(value: &str) -> Option<Self> {
             match value {
                 "CANISTER_ACTION_UNSPECIFIED" => Some(Self::Unspecified),
                 "CANISTER_ACTION_STOP" => Some(Self::Stop),
@@ -2570,13 +2560,15 @@ pub mod stop_or_start_canister {
 pub struct UpdateCanisterSettings {
     /// The target canister ID to call update_settings on. Required.
     #[prost(message, optional, tag = "1")]
-    pub canister_id: ::core::option::Option<::ic_base_types::PrincipalId>,
+    pub canister_id: Option<PrincipalId>,
     /// The settings to update. Required.
     #[prost(message, optional, tag = "2")]
-    pub settings: ::core::option::Option<update_canister_settings::CanisterSettings>,
+    pub settings: Option<update_canister_settings::CanisterSettings>,
 }
 /// Nested message and enum types in `UpdateCanisterSettings`.
 pub mod update_canister_settings {
+    use super::*;
+
     /// The controllers of the canister. We use a message to wrap the repeated field because prost does
     /// not generate `Option<Vec<T>>` for repeated fields.
     #[derive(candid::CandidType, candid::Deserialize, serde::Serialize, comparable::Comparable)]
@@ -2585,7 +2577,7 @@ pub mod update_canister_settings {
     pub struct Controllers {
         /// The controllers of the canister.
         #[prost(message, repeated, tag = "1")]
-        pub controllers: ::prost::alloc::vec::Vec<::ic_base_types::PrincipalId>,
+        pub controllers: Vec<PrincipalId>,
     }
     /// The CanisterSettings struct as defined in the ic-interface-spec
     /// <https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-candid.>
@@ -2594,17 +2586,17 @@ pub mod update_canister_settings {
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct CanisterSettings {
         #[prost(message, optional, tag = "1")]
-        pub controllers: ::core::option::Option<Controllers>,
+        pub controllers: Option<Controllers>,
         #[prost(uint64, optional, tag = "2")]
-        pub compute_allocation: ::core::option::Option<u64>,
+        pub compute_allocation: Option<u64>,
         #[prost(uint64, optional, tag = "3")]
-        pub memory_allocation: ::core::option::Option<u64>,
+        pub memory_allocation: Option<u64>,
         #[prost(uint64, optional, tag = "4")]
-        pub freezing_threshold: ::core::option::Option<u64>,
+        pub freezing_threshold: Option<u64>,
         #[prost(enumeration = "LogVisibility", optional, tag = "5")]
-        pub log_visibility: ::core::option::Option<i32>,
+        pub log_visibility: Option<i32>,
         #[prost(uint64, optional, tag = "6")]
-        pub wasm_memory_limit: ::core::option::Option<u64>,
+        pub wasm_memory_limit: Option<u64>,
     }
     /// Log visibility of a canister.
     #[derive(
@@ -2643,7 +2635,7 @@ pub mod update_canister_settings {
             }
         }
         /// Creates an enum from field names used in the ProtoBuf definition.
-        pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+        pub fn from_str_name(value: &str) -> Option<Self> {
             match value {
                 "LOG_VISIBILITY_UNSPECIFIED" => Some(Self::Unspecified),
                 "LOG_VISIBILITY_CONTROLLERS" => Some(Self::Controllers),
@@ -2670,7 +2662,7 @@ pub struct Governance {
     /// The transfers that have been made to stake new neurons, but
     /// haven't been claimed by the user, yet.
     #[prost(message, repeated, tag = "3")]
-    pub to_claim_transfers: ::prost::alloc::vec::Vec<NeuronStakeTransfer>,
+    pub to_claim_transfers: Vec<NeuronStakeTransfer>,
     /// Also known as the 'normal voting period'. The maximum time a
     /// proposal (of a topic with "normal" voting period) is open for
     /// voting. If a proposal has not been decided (adopted or rejected)
@@ -2682,10 +2674,10 @@ pub struct Governance {
     pub wait_for_quiet_threshold_seconds: u64,
     /// The network economics configuration parameters.
     #[prost(message, optional, tag = "8")]
-    pub economics: ::core::option::Option<NetworkEconomics>,
+    pub economics: Option<NetworkEconomics>,
     /// The last reward event. Should never be missing.
     #[prost(message, optional, tag = "9")]
-    pub latest_reward_event: ::core::option::Option<RewardEvent>,
+    pub latest_reward_event: Option<RewardEvent>,
     /// Set of in-flight neuron ledger commands.
     ///
     /// Whenever we issue a ledger transfer (for disburse, split, spawn etc)
@@ -2715,7 +2707,7 @@ pub struct Governance {
     pub genesis_timestamp_seconds: u64,
     /// The entities that own the nodes running the IC.
     #[prost(message, repeated, tag = "12")]
-    pub node_providers: ::prost::alloc::vec::Vec<NodeProvider>,
+    pub node_providers: Vec<NodeProvider>,
     /// Default followees
     ///
     /// A map of Topic (as i32) to Neuron id that is set as the default
@@ -2747,40 +2739,41 @@ pub struct Governance {
     /// by the general public and have limited impact, so a different voting period
     /// is appropriate.
     #[prost(uint64, optional, tag = "25")]
-    pub neuron_management_voting_period_seconds: ::core::option::Option<u64>,
+    pub neuron_management_voting_period_seconds: Option<u64>,
     #[prost(message, optional, tag = "15")]
-    pub metrics: ::core::option::Option<governance::GovernanceCachedMetrics>,
+    pub metrics: Option<governance::GovernanceCachedMetrics>,
     #[prost(message, optional, tag = "16")]
-    pub most_recent_monthly_node_provider_rewards:
-        ::core::option::Option<MonthlyNodeProviderRewards>,
+    pub most_recent_monthly_node_provider_rewards: Option<MonthlyNodeProviderRewards>,
     /// Cached value for the maturity modulation as calculated each day.
     #[prost(int32, optional, tag = "17")]
-    pub cached_daily_maturity_modulation_basis_points: ::core::option::Option<i32>,
+    pub cached_daily_maturity_modulation_basis_points: Option<i32>,
     /// The last time that the maturity modulation value was updated.
     #[prost(uint64, optional, tag = "18")]
-    pub maturity_modulation_last_updated_at_timestamp_seconds: ::core::option::Option<u64>,
+    pub maturity_modulation_last_updated_at_timestamp_seconds: Option<u64>,
     /// Whether the heartbeat function is currently spawning neurons, meaning
     /// that it should finish before being called again.
     #[prost(bool, optional, tag = "19")]
-    pub spawning_neurons: ::core::option::Option<bool>,
+    pub spawning_neurons: Option<bool>,
     #[prost(message, optional, tag = "20")]
-    pub making_sns_proposal: ::core::option::Option<governance::MakingSnsProposal>,
+    pub making_sns_proposal: Option<governance::MakingSnsProposal>,
     /// Migration related data.
     #[prost(message, optional, tag = "21")]
-    pub migrations: ::core::option::Option<governance::Migrations>,
+    pub migrations: Option<governance::Migrations>,
     /// A Structure used during upgrade to store the index of topics for neurons to their followers.
     /// This is the inverse of what is stored in a Neuron (its followees).
     #[prost(map = "int32, message", tag = "22")]
     pub topic_followee_index: ::std::collections::HashMap<i32, governance::FollowersMap>,
     /// Local cache for XDR-related conversion rates (the source of truth is in the CMC canister).
     #[prost(message, optional, tag = "26")]
-    pub xdr_conversion_rate: ::core::option::Option<XdrConversionRate>,
+    pub xdr_conversion_rate: Option<XdrConversionRate>,
     /// The summary of restore aging event.
     #[prost(message, optional, tag = "27")]
-    pub restore_aging_summary: ::core::option::Option<RestoreAgingSummary>,
+    pub restore_aging_summary: Option<RestoreAgingSummary>,
 }
 /// Nested message and enum types in `Governance`.
 pub mod governance {
+    use super::*;
+
     /// The possible commands that require interaction with the ledger.
     #[derive(candid::CandidType, candid::Deserialize, serde::Serialize, comparable::Comparable)]
     #[allow(clippy::derive_partial_eq_without_eq)]
@@ -2794,10 +2787,12 @@ pub mod governance {
             oneof = "neuron_in_flight_command::Command",
             tags = "2, 3, 5, 7, 8, 9, 10, 20, 21"
         )]
-        pub command: ::core::option::Option<neuron_in_flight_command::Command>,
+        pub command: Option<neuron_in_flight_command::Command>,
     }
     /// Nested message and enum types in `NeuronInFlightCommand`.
     pub mod neuron_in_flight_command {
+        use super::*;
+
         /// A general place holder for sync commands. The neuron lock is
         /// never left holding a sync command (as it either succeeds to
         /// acquire the lock and releases it in the same call, or never
@@ -2832,7 +2827,7 @@ pub mod governance {
             #[prost(message, tag = "10")]
             Merge(super::super::manage_neuron::Merge),
             #[prost(message, tag = "20")]
-            Spawn(::ic_nns_common::pb::v1::NeuronId),
+            Spawn(NeuronId),
             #[prost(message, tag = "21")]
             SyncCommand(SyncCommand),
         }
@@ -2919,15 +2914,14 @@ pub mod governance {
         pub not_dissolving_neurons_e8s_buckets_ect: ::std::collections::HashMap<u64, f64>,
         /// Deprecated. Use non_self_authenticating_controller_neuron_subset_metrics instead.
         #[prost(uint64, optional, tag = "36")]
-        pub total_voting_power_non_self_authenticating_controller: ::core::option::Option<u64>,
+        pub total_voting_power_non_self_authenticating_controller: Option<u64>,
         #[prost(uint64, optional, tag = "37")]
-        pub total_staked_e8s_non_self_authenticating_controller: ::core::option::Option<u64>,
+        pub total_staked_e8s_non_self_authenticating_controller: Option<u64>,
         #[prost(message, optional, tag = "38")]
         pub non_self_authenticating_controller_neuron_subset_metrics:
-            ::core::option::Option<governance_cached_metrics::NeuronSubsetMetrics>,
+            Option<governance_cached_metrics::NeuronSubsetMetrics>,
         #[prost(message, optional, tag = "39")]
-        pub public_neuron_subset_metrics:
-            ::core::option::Option<governance_cached_metrics::NeuronSubsetMetrics>,
+        pub public_neuron_subset_metrics: Option<governance_cached_metrics::NeuronSubsetMetrics>,
     }
     /// Nested message and enum types in `GovernanceCachedMetrics`.
     pub mod governance_cached_metrics {
@@ -2943,15 +2937,15 @@ pub mod governance {
             /// analogous fields (declared a little lower in this message). For
             /// example, count = count_buckets.values().sum().
             #[prost(uint64, optional, tag = "1")]
-            pub count: ::core::option::Option<u64>,
+            pub count: Option<u64>,
             #[prost(uint64, optional, tag = "2")]
-            pub total_staked_e8s: ::core::option::Option<u64>,
+            pub total_staked_e8s: Option<u64>,
             #[prost(uint64, optional, tag = "3")]
-            pub total_staked_maturity_e8s_equivalent: ::core::option::Option<u64>,
+            pub total_staked_maturity_e8s_equivalent: Option<u64>,
             #[prost(uint64, optional, tag = "4")]
-            pub total_maturity_e8s_equivalent: ::core::option::Option<u64>,
+            pub total_maturity_e8s_equivalent: Option<u64>,
             #[prost(uint64, optional, tag = "5")]
-            pub total_voting_power: ::core::option::Option<u64>,
+            pub total_voting_power: Option<u64>,
             /// These fields are keyed by floor(dissolve delay / 0.5 years). These are
             /// analogous to the (singular) fields above. Here, the usual definition of
             /// year for the IC is used: exactly 365.25 days.
@@ -2980,11 +2974,11 @@ pub mod governance {
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct MakingSnsProposal {
         #[prost(message, optional, tag = "1")]
-        pub proposer_id: ::core::option::Option<::ic_nns_common::pb::v1::NeuronId>,
+        pub proposer_id: Option<NeuronId>,
         #[prost(message, optional, tag = "2")]
-        pub caller: ::core::option::Option<::ic_base_types::PrincipalId>,
+        pub caller: Option<PrincipalId>,
         #[prost(message, optional, tag = "3")]
-        pub proposal: ::core::option::Option<super::Proposal>,
+        pub proposal: Option<super::Proposal>,
     }
     /// Progress of a migration that (potentially) is performed over the course of more than one heartbeat call.
     #[derive(candid::CandidType, candid::Deserialize, serde::Serialize, comparable::Comparable)]
@@ -2993,17 +2987,19 @@ pub mod governance {
     pub struct Migration {
         /// Migration status.
         #[prost(enumeration = "migration::MigrationStatus", optional, tag = "1")]
-        pub status: ::core::option::Option<i32>,
+        pub status: Option<i32>,
         /// The reason why it failed. Should only be present when the status is FAILED.
         /// This is only for debugging and it should not be used programmatically (other than its presence).
         #[prost(string, optional, tag = "2")]
-        pub failure_reason: ::core::option::Option<::prost::alloc::string::String>,
+        pub failure_reason: Option<::prost::alloc::string::String>,
         /// Migration progress (cursor).
         #[prost(oneof = "migration::Progress", tags = "3")]
-        pub progress: ::core::option::Option<migration::Progress>,
+        pub progress: Option<migration::Progress>,
     }
     /// Nested message and enum types in `Migration`.
     pub mod migration {
+        use super::*;
+
         #[derive(
             candid::CandidType,
             candid::Deserialize,
@@ -3044,7 +3040,7 @@ pub mod governance {
                 }
             }
             /// Creates an enum from field names used in the ProtoBuf definition.
-            pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+            pub fn from_str_name(value: &str) -> Option<Self> {
                 match value {
                     "MIGRATION_STATUS_UNSPECIFIED" => Some(Self::Unspecified),
                     "MIGRATION_STATUS_IN_PROGRESS" => Some(Self::InProgress),
@@ -3063,7 +3059,7 @@ pub mod governance {
         pub enum Progress {
             /// Last neuron id migrated.
             #[prost(message, tag = "3")]
-            LastNeuronId(::ic_nns_common::pb::v1::NeuronId),
+            LastNeuronId(NeuronId),
         }
     }
     /// The status of all on-going (and recently completed) migrations (that take
@@ -3078,9 +3074,9 @@ pub mod governance {
     pub struct Migrations {
         /// Migrates neuron indexes to stable storage.
         #[prost(message, optional, tag = "1")]
-        pub neuron_indexes_migration: ::core::option::Option<Migration>,
+        pub neuron_indexes_migration: Option<Migration>,
         #[prost(message, optional, tag = "2")]
-        pub copy_inactive_neurons_to_stable_memory_migration: ::core::option::Option<Migration>,
+        pub copy_inactive_neurons_to_stable_memory_migration: Option<Migration>,
     }
     /// A map of followees to their followers.
     #[derive(candid::CandidType, candid::Deserialize, serde::Serialize, comparable::Comparable)]
@@ -3093,6 +3089,8 @@ pub mod governance {
     }
     /// Nested message and enum types in `FollowersMap`.
     pub mod followers_map {
+        use super::*;
+
         #[derive(
             candid::CandidType, candid::Deserialize, serde::Serialize, comparable::Comparable,
         )]
@@ -3102,7 +3100,7 @@ pub mod governance {
             /// The followers of the neuron with the given ID.
             /// These values will be non-repeating, and order does not matter.
             #[prost(message, repeated, tag = "1")]
-            pub followers: ::prost::alloc::vec::Vec<::ic_nns_common::pb::v1::NeuronId>,
+            pub followers: Vec<NeuronId>,
         }
     }
 }
@@ -3112,10 +3110,10 @@ pub mod governance {
 pub struct XdrConversionRate {
     /// / Time at which this rate has been fetched.
     #[prost(uint64, optional, tag = "1")]
-    pub timestamp_seconds: ::core::option::Option<u64>,
+    pub timestamp_seconds: Option<u64>,
     /// / One ICP is worth this number of 1/10,000ths parts of an XDR.
     #[prost(uint64, optional, tag = "2")]
-    pub xdr_permyriad_per_icp: ::core::option::Option<u64>,
+    pub xdr_permyriad_per_icp: Option<u64>,
 }
 /// Proposals with restricted voting are not included unless the caller
 /// is allowed to vote on them.
@@ -3135,13 +3133,13 @@ pub struct ListProposalInfo {
     /// the specified proposal according to the proposal ID. If not
     /// specified, start with the most recent proposal.
     #[prost(message, optional, tag = "2")]
-    pub before_proposal: ::core::option::Option<::ic_nns_common::pb::v1::ProposalId>,
+    pub before_proposal: Option<::ic_nns_common::pb::v1::ProposalId>,
     /// Exclude proposals with a topic in this list. This is particularly
     /// useful to exclude proposals on the topics TOPIC_EXCHANGE_RATE and
     /// TOPIC_KYC which most users are not likely to be interested in
     /// seeing.
     #[prost(enumeration = "Topic", repeated, tag = "3")]
-    pub exclude_topic: ::prost::alloc::vec::Vec<i32>,
+    pub exclude_topic: Vec<i32>,
     /// Include proposals that have a reward status in this list (see
     /// \[ProposalRewardStatus\] for more information). If this list is
     /// empty, no restriction is applied. For example, many users listing
@@ -3149,30 +3147,30 @@ pub struct ListProposalInfo {
     /// receive voting rewards, i.e., with reward status
     /// PROPOSAL_REWARD_STATUS_ACCEPT_VOTES.
     #[prost(enumeration = "ProposalRewardStatus", repeated, tag = "4")]
-    pub include_reward_status: ::prost::alloc::vec::Vec<i32>,
+    pub include_reward_status: Vec<i32>,
     /// Include proposals that have a status in this list (see
     /// \[ProposalStatus\] for more information). If this list is empty, no
     /// restriction is applied.
     #[prost(enumeration = "ProposalStatus", repeated, tag = "5")]
-    pub include_status: ::prost::alloc::vec::Vec<i32>,
+    pub include_status: Vec<i32>,
     /// Include all ManageNeuron proposals regardless of the visibility of the
     /// proposal to the caller principal. Note that exclude_topic is still
     /// respected even when this option is set to true.
     #[prost(bool, optional, tag = "6")]
-    pub include_all_manage_neuron_proposals: ::core::option::Option<bool>,
+    pub include_all_manage_neuron_proposals: Option<bool>,
     /// Omits "large fields" from the response. Currently only omits the
     /// `logo` and `token_logo` field of CreateServiceNervousSystem proposals. This
     /// is useful to improve download times and to ensure that the response to the
     /// request doesn't exceed the message size limit.
     #[prost(bool, optional, tag = "7")]
-    pub omit_large_fields: ::core::option::Option<bool>,
+    pub omit_large_fields: Option<bool>,
 }
 #[derive(candid::CandidType, candid::Deserialize, serde::Serialize, comparable::Comparable)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ListProposalInfoResponse {
     #[prost(message, repeated, tag = "1")]
-    pub proposal_info: ::prost::alloc::vec::Vec<ProposalInfo>,
+    pub proposal_info: Vec<ProposalInfo>,
 }
 /// A request to list neurons. The "requested list", i.e., the list of
 /// neuron IDs to retrieve information about, is the union of the list
@@ -3186,7 +3184,7 @@ pub struct ListNeurons {
     /// The neurons to get information about. The "requested list"
     /// contains all of these neuron IDs.
     #[prost(fixed64, repeated, packed = "false", tag = "1")]
-    pub neuron_ids: ::prost::alloc::vec::Vec<u64>,
+    pub neuron_ids: Vec<u64>,
     /// If true, the "requested list" also contains the neuron ID of the
     /// neurons that the calling principal is authorized to read.
     #[prost(bool, tag = "2")]
@@ -3198,7 +3196,7 @@ pub struct ListNeurons {
     /// if this field is not provided, it defaults to true, in order to maintain backwards
     /// compatibility. Here, being "empty" means 0 stake, 0 maturity and 0 staked maturity.
     #[prost(bool, optional, tag = "3")]
-    pub include_empty_neurons_readable_by_caller: ::core::option::Option<bool>,
+    pub include_empty_neurons_readable_by_caller: Option<bool>,
     /// If this is set to true, and a neuron in the "requested list" has its
     /// visibility set to public, then, it will (also) be included in the
     /// full_neurons field in the response (which is of type ListNeuronsResponse).
@@ -3208,7 +3206,7 @@ pub struct ListNeurons {
     /// since this feature was added later, it is opt in to avoid confusing
     /// existing (unmigrated) callers.
     #[prost(bool, optional, tag = "4")]
-    pub include_public_neurons_in_full_neurons: ::core::option::Option<bool>,
+    pub include_public_neurons_in_full_neurons: Option<bool>,
 }
 /// A response to a `ListNeurons` request.
 ///
@@ -3226,7 +3224,7 @@ pub struct ListNeuronsResponse {
     /// hot key, or controller or hot key of some followee on the
     /// `ManageNeuron` topic).
     #[prost(message, repeated, tag = "2")]
-    pub full_neurons: ::prost::alloc::vec::Vec<Neuron>,
+    pub full_neurons: Vec<Neuron>,
 }
 /// A response to "ListKnownNeurons"
 #[derive(candid::CandidType, candid::Deserialize, serde::Serialize, comparable::Comparable)]
@@ -3235,7 +3233,7 @@ pub struct ListNeuronsResponse {
 pub struct ListKnownNeuronsResponse {
     /// List of known neurons.
     #[prost(message, repeated, tag = "1")]
-    pub known_neurons: ::prost::alloc::vec::Vec<KnownNeuron>,
+    pub known_neurons: Vec<KnownNeuron>,
 }
 /// Response to list_node_providers
 #[derive(candid::CandidType, candid::Deserialize, serde::Serialize, comparable::Comparable)]
@@ -3244,7 +3242,7 @@ pub struct ListKnownNeuronsResponse {
 pub struct ListNodeProvidersResponse {
     /// List of all "NodeProviders"
     #[prost(message, repeated, tag = "1")]
-    pub node_providers: ::prost::alloc::vec::Vec<NodeProvider>,
+    pub node_providers: Vec<NodeProvider>,
 }
 /// The arguments to the method `claim_or_refresh_neuron_from_account`.
 ///
@@ -3256,7 +3254,7 @@ pub struct ClaimOrRefreshNeuronFromAccount {
     /// The principal for which to refresh the account. If not specified,
     /// defaults to the caller.
     #[prost(message, optional, tag = "1")]
-    pub controller: ::core::option::Option<::ic_base_types::PrincipalId>,
+    pub controller: Option<PrincipalId>,
     /// The memo of the staking transaction.
     #[prost(uint64, tag = "2")]
     pub memo: u64,
@@ -3272,10 +3270,12 @@ pub struct ClaimOrRefreshNeuronFromAccountResponse {
         oneof = "claim_or_refresh_neuron_from_account_response::Result",
         tags = "1, 2"
     )]
-    pub result: ::core::option::Option<claim_or_refresh_neuron_from_account_response::Result>,
+    pub result: Option<claim_or_refresh_neuron_from_account_response::Result>,
 }
 /// Nested message and enum types in `ClaimOrRefreshNeuronFromAccountResponse`.
 pub mod claim_or_refresh_neuron_from_account_response {
+    use super::*;
+
     #[derive(candid::CandidType, candid::Deserialize, serde::Serialize, comparable::Comparable)]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
@@ -3285,7 +3285,7 @@ pub mod claim_or_refresh_neuron_from_account_response {
         Error(super::GovernanceError),
         /// The ID of the neuron that was created or empty in the case of error.
         #[prost(message, tag = "2")]
-        NeuronId(::ic_nns_common::pb::v1::NeuronId),
+        NeuronId(NeuronId),
     }
 }
 /// The monthly Node Provider rewards as of a point in time.
@@ -3298,25 +3298,25 @@ pub struct MonthlyNodeProviderRewards {
     pub timestamp: u64,
     /// The Rewards calculated and rewarded.
     #[prost(message, repeated, tag = "2")]
-    pub rewards: ::prost::alloc::vec::Vec<RewardNodeProvider>,
+    pub rewards: Vec<RewardNodeProvider>,
     /// The XdrConversionRate used to calculate the rewards.  This comes from the CMC canister.
     /// This field snapshots the actual rate used by governance when the rewards were calculated.
     #[prost(message, optional, tag = "3")]
-    pub xdr_conversion_rate: ::core::option::Option<XdrConversionRate>,
+    pub xdr_conversion_rate: Option<XdrConversionRate>,
     /// The minimum xdr permyriad per icp at the time when the rewards were calculated.  This is useful for understanding
     /// why the rewards were what they were if the xdr_conversion_rate falls below this threshold.
     #[prost(uint64, optional, tag = "4")]
-    pub minimum_xdr_permyriad_per_icp: ::core::option::Option<u64>,
+    pub minimum_xdr_permyriad_per_icp: Option<u64>,
     /// The maximum amount of ICP e8s that can be awarded to a single node provider in one event.  This is snapshotted
     /// from the value in network economics.
     #[prost(uint64, optional, tag = "5")]
-    pub maximum_node_provider_rewards_e8s: ::core::option::Option<u64>,
+    pub maximum_node_provider_rewards_e8s: Option<u64>,
     /// The registry version used to calculate these rewards at the time the rewards were calculated.
     #[prost(uint64, optional, tag = "6")]
-    pub registry_version: ::core::option::Option<u64>,
+    pub registry_version: Option<u64>,
     /// The list of node_provieders at the time when the rewards were calculated.
     #[prost(message, repeated, tag = "7")]
-    pub node_providers: ::prost::alloc::vec::Vec<NodeProvider>,
+    pub node_providers: Vec<NodeProvider>,
 }
 /// TODO(NNS1-1589): Until the Jira ticket gets solved, changes here need to be
 /// manually propagated to (sns) swap.proto.
@@ -3329,14 +3329,16 @@ pub struct SettleCommunityFundParticipation {
     /// target_swap_canister_id field in the proposal (more precisely, in the
     /// OpenSnsTokenSwap).
     #[prost(uint64, optional, tag = "1")]
-    pub open_sns_token_swap_proposal_id: ::core::option::Option<u64>,
+    pub open_sns_token_swap_proposal_id: Option<u64>,
     /// Each of the possibilities here corresponds to one of two ways that a swap
     /// can terminate. See also sns_swap_pb::Lifecycle::is_terminal.
     #[prost(oneof = "settle_community_fund_participation::Result", tags = "2, 3")]
-    pub result: ::core::option::Option<settle_community_fund_participation::Result>,
+    pub result: Option<settle_community_fund_participation::Result>,
 }
 /// Nested message and enum types in `SettleCommunityFundParticipation`.
 pub mod settle_community_fund_participation {
+    use super::*;
+
     /// When this happens, ICP needs to be minted, and sent to the SNS governance
     /// canister's main account on the ICP Ledger. As with Aborted, the amount of
     /// ICP that needs to be minted can be deduced from the ProposalData's
@@ -3348,14 +3350,14 @@ pub mod settle_community_fund_participation {
         /// This is where the minted ICP will be sent. In principal, this could be
         /// fetched using the swap canister's get_state method.
         #[prost(message, optional, tag = "1")]
-        pub sns_governance_canister_id: ::core::option::Option<::ic_base_types::PrincipalId>,
+        pub sns_governance_canister_id: Option<PrincipalId>,
         /// Total contribution amount from direct swap participants.
         #[prost(uint64, optional, tag = "2")]
-        pub total_direct_contribution_icp_e8s: ::core::option::Option<u64>,
+        pub total_direct_contribution_icp_e8s: Option<u64>,
         /// Total contribution amount from the Neuron's Fund.
         /// TODO\[NNS1-2570\]: Ensure this field is set.
         #[prost(uint64, optional, tag = "3")]
-        pub total_neurons_fund_contribution_icp_e8s: ::core::option::Option<u64>,
+        pub total_neurons_fund_contribution_icp_e8s: Option<u64>,
     }
     /// When this happens, maturity needs to be restored to CF neurons. The amounts
     /// to be refunded can be found in the ProposalData's cf_participants field.
@@ -3415,17 +3417,19 @@ pub mod settle_community_fund_participation {
 pub struct SettleNeuronsFundParticipationRequest {
     /// Proposal ID of the CreateServiceNervousSystem proposal that created this SNS instance.
     #[prost(uint64, optional, tag = "1")]
-    pub nns_proposal_id: ::core::option::Option<u64>,
+    pub nns_proposal_id: Option<u64>,
     /// Each of the possibilities here corresponds to one of two ways that a swap can terminate.
     /// See also sns_swap_pb::Lifecycle::is_terminal.
     #[prost(
         oneof = "settle_neurons_fund_participation_request::Result",
         tags = "2, 3"
     )]
-    pub result: ::core::option::Option<settle_neurons_fund_participation_request::Result>,
+    pub result: Option<settle_neurons_fund_participation_request::Result>,
 }
 /// Nested message and enum types in `SettleNeuronsFundParticipationRequest`.
 pub mod settle_neurons_fund_participation_request {
+    use super::*;
+
     /// When this happens, the NNS Governance needs to do several things:
     /// (1) Compute the effective amount of ICP per neuron of the Neurons' Fund as a function of
     ///      `total_direct_participation_icp_e8s`. The overall Neurons' Fund participation should
@@ -3451,14 +3455,14 @@ pub mod settle_neurons_fund_participation_request {
     pub struct Committed {
         /// This is where the minted ICP will be sent.
         #[prost(message, optional, tag = "1")]
-        pub sns_governance_canister_id: ::core::option::Option<::ic_base_types::PrincipalId>,
+        pub sns_governance_canister_id: Option<PrincipalId>,
         /// Total amount of participation from direct swap participants.
         #[prost(uint64, optional, tag = "2")]
-        pub total_direct_participation_icp_e8s: ::core::option::Option<u64>,
+        pub total_direct_participation_icp_e8s: Option<u64>,
         /// Total amount of participation from the Neurons' Fund.
         /// TODO\[NNS1-2570\]: Ensure this field is set.
         #[prost(uint64, optional, tag = "3")]
-        pub total_neurons_fund_participation_icp_e8s: ::core::option::Option<u64>,
+        pub total_neurons_fund_participation_icp_e8s: Option<u64>,
     }
     /// When this happens, all priorly reserved maturity for this SNS instance needs to be restored to
     /// the Neurons' Fund neurons.
@@ -3498,10 +3502,12 @@ pub struct SettleNeuronsFundParticipationResponse {
         oneof = "settle_neurons_fund_participation_response::Result",
         tags = "1, 2"
     )]
-    pub result: ::core::option::Option<settle_neurons_fund_participation_response::Result>,
+    pub result: Option<settle_neurons_fund_participation_response::Result>,
 }
 /// Nested message and enum types in `SettleNeuronsFundParticipationResponse`.
 pub mod settle_neurons_fund_participation_response {
+    use super::*;
+
     /// Represents one NNS neuron from the Neurons' Fund participating in this swap.
     #[derive(candid::CandidType, candid::Deserialize, serde::Serialize, comparable::Comparable)]
     #[allow(clippy::derive_partial_eq_without_eq)]
@@ -3509,24 +3515,24 @@ pub mod settle_neurons_fund_participation_response {
     pub struct NeuronsFundNeuron {
         /// The NNS neuron ID of the participating neuron.
         #[prost(uint64, optional, tag = "1")]
-        pub nns_neuron_id: ::core::option::Option<u64>,
+        pub nns_neuron_id: Option<u64>,
         /// The amount of Neurons' Fund participation associated with this neuron.
         #[prost(uint64, optional, tag = "2")]
-        pub amount_icp_e8s: ::core::option::Option<u64>,
+        pub amount_icp_e8s: Option<u64>,
         /// The principal that can manage the NNS neuron that participated in the Neurons' Fund.
         #[prost(message, optional, tag = "6")]
-        pub controller: ::core::option::Option<::ic_base_types::PrincipalId>,
+        pub controller: Option<PrincipalId>,
         /// The principals that can vote, propose, and follow on behalf of this neuron.
         #[prost(message, optional, tag = "7")]
-        pub hotkeys: ::core::option::Option<::ic_nervous_system_proto::pb::v1::Principals>,
+        pub hotkeys: Option<::ic_nervous_system_proto::pb::v1::Principals>,
         /// Whether the amount maturity amount of Neurons' Fund participation associated with this neuron
         /// has been capped to reflect the maximum participation amount for this SNS swap.
         #[prost(bool, optional, tag = "4")]
-        pub is_capped: ::core::option::Option<bool>,
+        pub is_capped: Option<bool>,
         /// Deprecated. Please use `controller` instead (not `hotkeys`!)
         #[deprecated]
         #[prost(string, optional, tag = "3")]
-        pub hotkey_principal: ::core::option::Option<::prost::alloc::string::String>,
+        pub hotkey_principal: Option<::prost::alloc::string::String>,
     }
     /// Request was completed successfully.
     #[derive(candid::CandidType, candid::Deserialize, serde::Serialize, comparable::Comparable)]
@@ -3534,7 +3540,7 @@ pub mod settle_neurons_fund_participation_response {
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct Ok {
         #[prost(message, repeated, tag = "1")]
-        pub neurons_fund_neuron_portions: ::prost::alloc::vec::Vec<NeuronsFundNeuron>,
+        pub neurons_fund_neuron_portions: Vec<NeuronsFundNeuron>,
     }
     #[derive(candid::CandidType, candid::Deserialize, serde::Serialize, comparable::Comparable)]
     #[allow(clippy::derive_partial_eq_without_eq)]
@@ -3555,7 +3561,7 @@ pub struct AuditEvent {
     #[prost(uint64, tag = "1")]
     pub timestamp_seconds: u64,
     #[prost(oneof = "audit_event::Payload", tags = "2, 3, 4")]
-    pub payload: ::core::option::Option<audit_event::Payload>,
+    pub payload: Option<audit_event::Payload>,
 }
 /// Nested message and enum types in `AuditEvent`.
 pub mod audit_event {
@@ -3577,7 +3583,7 @@ pub mod audit_event {
         pub neuron_stake_e8s: u64,
         /// Neuron's dissolve state at the time of reset.
         #[prost(oneof = "reset_aging::NeuronDissolveState", tags = "4, 5")]
-        pub neuron_dissolve_state: ::core::option::Option<reset_aging::NeuronDissolveState>,
+        pub neuron_dissolve_state: Option<reset_aging::NeuronDissolveState>,
     }
     /// Nested message and enum types in `ResetAging`.
     pub mod reset_aging {
@@ -3600,19 +3606,19 @@ pub mod audit_event {
     pub struct RestoreAging {
         /// The neuron id whose aging was restored.
         #[prost(uint64, optional, tag = "1")]
-        pub neuron_id: ::core::option::Option<u64>,
+        pub neuron_id: Option<u64>,
         /// The aging_since_timestamp_seconds before restore.
         #[prost(uint64, optional, tag = "2")]
-        pub previous_aging_since_timestamp_seconds: ::core::option::Option<u64>,
+        pub previous_aging_since_timestamp_seconds: Option<u64>,
         /// The aging_since_timestamp_seconds after restore.
         #[prost(uint64, optional, tag = "3")]
-        pub new_aging_since_timestamp_seconds: ::core::option::Option<u64>,
+        pub new_aging_since_timestamp_seconds: Option<u64>,
         /// Neuron's stake at the time of restore.
         #[prost(uint64, optional, tag = "6")]
-        pub neuron_stake_e8s: ::core::option::Option<u64>,
+        pub neuron_stake_e8s: Option<u64>,
         /// Neuron's dissolve state at the time of restore.
         #[prost(oneof = "restore_aging::NeuronDissolveState", tags = "4, 5")]
-        pub neuron_dissolve_state: ::core::option::Option<restore_aging::NeuronDissolveState>,
+        pub neuron_dissolve_state: Option<restore_aging::NeuronDissolveState>,
     }
     /// Nested message and enum types in `RestoreAging`.
     pub mod restore_aging {
@@ -3635,16 +3641,16 @@ pub mod audit_event {
     pub struct NormalizeDissolveStateAndAge {
         /// The neuron id whose dissolve state and age were normalized.
         #[prost(uint64, optional, tag = "1")]
-        pub neuron_id: ::core::option::Option<u64>,
+        pub neuron_id: Option<u64>,
         /// Which legacy case the neuron falls into.
         #[prost(enumeration = "NeuronLegacyCase", tag = "2")]
         pub neuron_legacy_case: i32,
         /// Previous when_dissolved_timestamp_seconds if the neuron was dissolving or dissolved.
         #[prost(uint64, optional, tag = "3")]
-        pub previous_when_dissolved_timestamp_seconds: ::core::option::Option<u64>,
+        pub previous_when_dissolved_timestamp_seconds: Option<u64>,
         /// Previous aging_since_timestamp_seconds.
         #[prost(uint64, optional, tag = "4")]
-        pub previous_aging_since_timestamp_seconds: ::core::option::Option<u64>,
+        pub previous_aging_since_timestamp_seconds: Option<u64>,
     }
     #[derive(
         candid::CandidType,
@@ -3687,7 +3693,7 @@ pub mod audit_event {
             }
         }
         /// Creates an enum from field names used in the ProtoBuf definition.
-        pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+        pub fn from_str_name(value: &str) -> Option<Self> {
             match value {
                 "NEURON_LEGACY_CASE_UNSPECIFIED" => Some(Self::Unspecified),
                 "NEURON_LEGACY_CASE_DISSOLVING_OR_DISSOLVED" => Some(Self::DissolvingOrDissolved),
@@ -3719,10 +3725,10 @@ pub mod audit_event {
 pub struct RestoreAgingSummary {
     /// The timestamp of the restore aging event.
     #[prost(uint64, optional, tag = "1")]
-    pub timestamp_seconds: ::core::option::Option<u64>,
+    pub timestamp_seconds: Option<u64>,
     /// Groups of neurons that were considered for restoring their aging.
     #[prost(message, repeated, tag = "2")]
-    pub groups: ::prost::alloc::vec::Vec<restore_aging_summary::RestoreAgingNeuronGroup>,
+    pub groups: Vec<restore_aging_summary::RestoreAgingNeuronGroup>,
 }
 /// Nested message and enum types in `RestoreAgingSummary`.
 pub mod restore_aging_summary {
@@ -3734,13 +3740,13 @@ pub mod restore_aging_summary {
         pub group_type: i32,
         /// The number of neurons in this group.
         #[prost(uint64, optional, tag = "2")]
-        pub count: ::core::option::Option<u64>,
+        pub count: Option<u64>,
         /// The previous total stake of neurons in this group when the aging was reset.
         #[prost(uint64, optional, tag = "3")]
-        pub previous_total_stake_e8s: ::core::option::Option<u64>,
+        pub previous_total_stake_e8s: Option<u64>,
         /// The current total stake of neurons in this group when considering to restore aging.
         #[prost(uint64, optional, tag = "4")]
-        pub current_total_stake_e8s: ::core::option::Option<u64>,
+        pub current_total_stake_e8s: Option<u64>,
     }
     #[derive(
         candid::CandidType,
@@ -3794,7 +3800,7 @@ pub mod restore_aging_summary {
             }
         }
         /// Creates an enum from field names used in the ProtoBuf definition.
-        pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+        pub fn from_str_name(value: &str) -> Option<Self> {
             match value {
                 "NEURON_GROUP_TYPE_UNSPECIFIED" => Some(Self::Unspecified),
                 "NEURON_GROUP_TYPE_NOT_PRE_AGING" => Some(Self::NotPreAging),
@@ -3945,7 +3951,7 @@ impl Topic {
         }
     }
     /// Creates an enum from field names used in the ProtoBuf definition.
-    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+    pub fn from_str_name(value: &str) -> Option<Self> {
         match value {
             "TOPIC_UNSPECIFIED" => Some(Self::Unspecified),
             "TOPIC_NEURON_MANAGEMENT" => Some(Self::NeuronManagement),
@@ -4048,7 +4054,7 @@ impl NeuronState {
         }
     }
     /// Creates an enum from field names used in the ProtoBuf definition.
-    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+    pub fn from_str_name(value: &str) -> Option<Self> {
         match value {
             "NEURON_STATE_UNSPECIFIED" => Some(Self::Unspecified),
             "NEURON_STATE_NOT_DISSOLVING" => Some(Self::NotDissolving),
@@ -4102,7 +4108,7 @@ impl Visibility {
         }
     }
     /// Creates an enum from field names used in the ProtoBuf definition.
-    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+    pub fn from_str_name(value: &str) -> Option<Self> {
         match value {
             "VISIBILITY_UNSPECIFIED" => Some(Self::Unspecified),
             "VISIBILITY_PRIVATE" => Some(Self::Private),
@@ -4152,7 +4158,7 @@ impl NeuronType {
         }
     }
     /// Creates an enum from field names used in the ProtoBuf definition.
-    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+    pub fn from_str_name(value: &str) -> Option<Self> {
         match value {
             "NEURON_TYPE_UNSPECIFIED" => Some(Self::Unspecified),
             "NEURON_TYPE_SEED" => Some(Self::Seed),
@@ -4201,7 +4207,7 @@ impl Vote {
         }
     }
     /// Creates an enum from field names used in the ProtoBuf definition.
-    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+    pub fn from_str_name(value: &str) -> Option<Self> {
         match value {
             "VOTE_UNSPECIFIED" => Some(Self::Unspecified),
             "VOTE_YES" => Some(Self::Yes),
@@ -4487,7 +4493,7 @@ impl NnsFunction {
         }
     }
     /// Creates an enum from field names used in the ProtoBuf definition.
-    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+    pub fn from_str_name(value: &str) -> Option<Self> {
         match value {
             "NNS_FUNCTION_UNSPECIFIED" => Some(Self::Unspecified),
             "NNS_FUNCTION_CREATE_SUBNET" => Some(Self::CreateSubnet),
@@ -4614,7 +4620,7 @@ impl ProposalStatus {
         }
     }
     /// Creates an enum from field names used in the ProtoBuf definition.
-    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+    pub fn from_str_name(value: &str) -> Option<Self> {
         match value {
             "PROPOSAL_STATUS_UNSPECIFIED" => Some(Self::Unspecified),
             "PROPOSAL_STATUS_OPEN" => Some(Self::Open),
@@ -4672,7 +4678,7 @@ impl ProposalRewardStatus {
         }
     }
     /// Creates an enum from field names used in the ProtoBuf definition.
-    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+    pub fn from_str_name(value: &str) -> Option<Self> {
         match value {
             "PROPOSAL_REWARD_STATUS_UNSPECIFIED" => Some(Self::Unspecified),
             "PROPOSAL_REWARD_STATUS_ACCEPT_VOTES" => Some(Self::AcceptVotes),


### PR DESCRIPTION
We previously auto-generated these, but the auto-generated added a lot of cruft because the files were not meant to be hand-edited. Now that we're hand-editing them, we can simplify some of that.

This PR does **not** actually change any of the types in a practical sense, it just reorganizes how they refer to the types of their fields