### PR TITLE
test: Clean up `CanisterQueues` proptests

### DIFF
--- a/rs/replicated_state/src/canister_state.rs
+++ b/rs/replicated_state/src/canister_state.rs
@@ -636,5 +636,5 @@ pub fn num_bytes_try_from(pages: NumWasmPages) -> Result<NumBytes, String> {
 }
 
 pub mod testing {
-    pub use super::queues::testing::{new_canister_queues_for_test, CanisterQueuesTesting};
+    pub use super::queues::testing::{new_canister_output_queues_for_test, CanisterQueuesTesting};
 }

--- a/rs/replicated_state/src/canister_state/queues.rs
+++ b/rs/replicated_state/src/canister_state/queues.rs
@@ -2087,10 +2087,10 @@ pub mod testing {
     }
 
     #[allow(dead_code)]
-    /// Produces `CanisterQueues` together with a `VecDeque` of raw requests
-    /// where the raw requests appear in the same order in the `VecDeque` as
-    /// one would expect them being returned by the iterator.
-    pub fn new_canister_queues_for_test(
+    /// Produces a `CanisterQueues` with requests enqueued in output queues,
+    /// together with a `VecDeque` of raw requests, in the order in which they would
+    /// be returned by `CanisterOutputQueuesIterator`.
+    pub fn new_canister_output_queues_for_test(
         requests: Vec<Request>,
         sender: CanisterId,
         num_receivers: usize,

--- a/rs/replicated_state/src/canister_state/queues/tests.rs
+++ b/rs/replicated_state/src/canister_state/queues/tests.rs
@@ -2018,7 +2018,7 @@ proptest! {
             if let Some(msg) = canister_queues.pop_canister_output(&raw.receiver()) {
                 prop_assert_eq!(raw, msg);
             } else {
-                panic!("Not all unconsumed messages left in canister queues");
+                prop_assert!(false, "Not all unconsumed messages left in canister queues");
             }
         }
 
@@ -2067,7 +2067,7 @@ proptest! {
             if let Some(msg) = canister_queues.pop_canister_output(&raw.receiver()) {
                 prop_assert_eq!(&raw, &msg, "Popped message does not correspond with expected message. popped: {:?}. expected: {:?}.", msg, raw);
             } else {
-                panic!("Not all unconsumed messages left in canister queues");
+                prop_assert!(false, "Not all unconsumed messages left in canister queues");
             }
         }
 

--- a/rs/replicated_state/src/canister_state/queues/tests.rs
+++ b/rs/replicated_state/src/canister_state/queues/tests.rs
@@ -1,4 +1,4 @@
-use super::testing::{new_canister_queues_for_test, CanisterQueuesTesting};
+use super::testing::{new_canister_output_queues_for_test, CanisterQueuesTesting};
 use super::InputQueueType::*;
 use super::*;
 use crate::{CanisterState, SchedulerState, SystemState};
@@ -1937,39 +1937,39 @@ fn test_peek_output_with_stale_references() {
 // `crate` and we wouldn't have access to its non-public methods.
 prop_compose! {
     /// Strategy that generates an arbitrary `CanisterQueues` (and a matching
-    /// iteration order); with up to `max_requests` requests; addressed to up to
-    /// `max_receivers` (if `Some`) or one request per receiver (if `None`).
-    pub fn arb_canister_queues(
+    /// iteration order); with up to `max_requests` outbound requests; addressed to
+    /// up to `max_receivers` (if `Some`) or one request per receiver (if `None`).
+    fn arb_canister_output_queues(
         max_requests: usize,
         max_receivers: Option<usize>,
     )(
         num_receivers in arb_num_receivers(max_receivers),
         reqs in prop::collection::vec(arbitrary::request(), 0..max_requests)
     ) -> (CanisterQueues, VecDeque<RequestOrResponse>) {
-        new_canister_queues_for_test(reqs, canister_test_id(42), num_receivers)
+        new_canister_output_queues_for_test(reqs, canister_test_id(42), num_receivers)
     }
 }
 
 proptest! {
     #[test]
     fn output_into_iter_peek_and_next_consistent(
-        (mut canister_queues, raw_requests) in arb_canister_queues(100, Some(10))
+        (mut canister_queues, raw_requests) in arb_canister_output_queues(10, Some(5))
     ) {
         let mut output_iter = canister_queues.output_into_iter();
 
         let mut popped = 0;
         while let Some(msg) = output_iter.peek() {
             popped += 1;
-            assert_eq!(Some(msg.clone()), output_iter.next());
+            prop_assert_eq!(Some(msg.clone()), output_iter.next());
         }
 
-        assert_eq!(output_iter.next(), None);
-        assert_eq!(raw_requests.len(), popped);
+        prop_assert_eq!(output_iter.next(), None);
+        prop_assert_eq!(raw_requests.len(), popped);
     }
 
     #[test]
     fn output_into_iter_peek_and_next_consistent_with_excludes(
-        (mut canister_queues, raw_requests) in arb_canister_queues(100, None),
+        (mut canister_queues, raw_requests) in arb_canister_output_queues(10, None),
         start in 0..=1,
         exclude_step in 2..=5,
     ) {
@@ -1986,15 +1986,15 @@ proptest! {
                 continue;
             }
             popped += 1;
-            assert_eq!(Some(msg.clone()), output_iter.next());
+            prop_assert_eq!(Some(msg.clone()), output_iter.next());
         }
-        assert_eq!(output_iter.pop(), None);
-        assert_eq!(raw_requests.len(), excluded + popped);
+        prop_assert_eq!(output_iter.pop(), None);
+        prop_assert_eq!(raw_requests.len(), excluded + popped);
     }
 
     #[test]
     fn output_into_iter_leaves_non_consumed_messages_untouched(
-        (mut canister_queues, mut raw_requests) in arb_canister_queues(100, Some(10)),
+        (mut canister_queues, mut raw_requests) in arb_canister_output_queues(10, Some(5)),
     ) {
         let num_requests = raw_requests.len();
 
@@ -2006,29 +2006,29 @@ proptest! {
             for _ in 0..num_requests / 2 {
                 let popped_message = output_iter.next().unwrap();
                 let expected_message = raw_requests.pop_front().unwrap();
-                assert_eq!(popped_message, expected_message);
+                prop_assert_eq!(popped_message, expected_message);
             }
 
-            assert_eq!(canister_queues.output_message_count(), num_requests - num_requests / 2);
+            prop_assert_eq!(canister_queues.output_message_count(), num_requests - num_requests / 2);
         }
 
         // Ensure that the messages that have not been consumed above are still in the queues
         // after dropping `output_iter`.
         while let Some(raw) = raw_requests.pop_front() {
             if let Some(msg) = canister_queues.pop_canister_output(&raw.receiver()) {
-                assert_eq!(raw, msg);
+                prop_assert_eq!(raw, msg);
             } else {
                 panic!("Not all unconsumed messages left in canister queues");
             }
         }
 
         // Ensure that there are no messages left in the canister queues.
-        assert_eq!(canister_queues.output_message_count(), 0);
+        prop_assert_eq!(canister_queues.output_message_count(), 0);
     }
 
     #[test]
     fn output_into_iter_with_exclude_leaves_excluded_queues_untouched(
-        (mut canister_queues, mut raw_requests) in arb_canister_queues(100, None),
+        (mut canister_queues, mut raw_requests) in arb_canister_output_queues(10, None),
         start in 0..=1,
         exclude_step in 2..=5,
     ) {
@@ -2053,42 +2053,42 @@ proptest! {
 
                 let peeked_message = peeked_message.clone();
                 let popped_message = output_iter.pop().unwrap();
-                assert_eq!(popped_message, peeked_message);
+                prop_assert_eq!(&popped_message, &peeked_message);
                 let expected_message = raw_requests.pop_front().unwrap();
-                assert_eq!(popped_message, expected_message);
+                prop_assert_eq!(&popped_message, &expected_message);
             }
 
-            assert_eq!(canister_queues.output_message_count(), excluded);
+            prop_assert_eq!(canister_queues.output_message_count(), excluded);
         }
 
         // Ensure that the messages that have not been consumed above are still in the queues
         // after dropping `output_iter`.
         while let Some(raw) = excluded_requests.pop_front() {
             if let Some(msg) = canister_queues.pop_canister_output(&raw.receiver()) {
-                assert_eq!(raw, msg, "Popped message does not correspond with expected message. popped: {:?}. expected: {:?}.", msg, raw);
+                prop_assert_eq!(&raw, &msg, "Popped message does not correspond with expected message. popped: {:?}. expected: {:?}.", msg, raw);
             } else {
                 panic!("Not all unconsumed messages left in canister queues");
             }
         }
 
         // Ensure that there are no messages left in the canister queues.
-        assert_eq!(canister_queues.output_message_count(), 0);
+        prop_assert_eq!(canister_queues.output_message_count(), 0);
     }
 
     #[test]
     fn output_into_iter_yields_correct_elements(
-        (mut canister_queues, raw_requests) in arb_canister_queues(100, Some(10))
+        (mut canister_queues, raw_requests) in arb_canister_output_queues(10, Some(5))
     ) {
         let recovered: VecDeque<_> = canister_queues
             .output_into_iter()
             .collect();
 
-        assert_eq!(raw_requests, recovered);
+        prop_assert_eq!(raw_requests, recovered);
     }
 
     #[test]
     fn output_into_iter_exclude_leaves_state_untouched(
-        (mut canister_queues, _) in arb_canister_queues(100, Some(10)),
+        (mut canister_queues, _) in arb_canister_output_queues(10, Some(5)),
     ) {
         let expected_canister_queues = canister_queues.clone();
         let mut output_iter = canister_queues.output_into_iter();
@@ -2097,26 +2097,26 @@ proptest! {
             output_iter.exclude_queue();
         }
         // Check that there's nothing left to pop.
-        assert!(output_iter.next().is_none());
+        prop_assert!(output_iter.next().is_none());
 
-        assert_eq!(expected_canister_queues, canister_queues);
+        prop_assert_eq!(expected_canister_queues, canister_queues);
     }
 
     #[test]
     fn output_into_iter_peek_pop_loop_terminates(
-        (mut canister_queues, _) in arb_canister_queues(100, Some(10)),
+        (mut canister_queues, _) in arb_canister_output_queues(10, Some(5)),
     ) {
         let mut output_iter = canister_queues.output_into_iter();
 
         while let Some(msg) = output_iter.peek() {
-            assert_eq!(Some(msg.clone()), output_iter.next());
+            prop_assert_eq!(Some(msg.clone()), output_iter.next());
         }
-        assert_eq!(None, output_iter.next());
+        prop_assert_eq!(None, output_iter.next());
     }
 
     #[test]
     fn output_into_iter_peek_pop_loop_with_excludes_terminates(
-        (mut canister_queues, _) in arb_canister_queues(100, Some(10)),
+        (mut canister_queues, _) in arb_canister_output_queues(10, Some(5)),
         start in 0..=1,
         exclude_step in 2..=5,
     ) {
@@ -2129,13 +2129,13 @@ proptest! {
                 output_iter.exclude_queue();
                 continue;
             }
-            assert_eq!(Some(msg.clone()), output_iter.next());
+            prop_assert_eq!(Some(msg.clone()), output_iter.next());
         }
     }
 
     #[test]
     fn output_into_iter_peek_with_stale_references(
-        (mut canister_queues, _) in arb_canister_queues(100, Some(10)),
+        (mut canister_queues, _) in arb_canister_output_queues(10, Some(5)),
         deadline in any::<u32>(),
     ) {
         let own_canister_id = canister_test_id(13);
@@ -2146,9 +2146,9 @@ proptest! {
         // Peek and pop until the output queues are empty.
         let mut output_iter = canister_queues.output_into_iter();
         while let Some(msg) = output_iter.peek() {
-            assert_eq!(Some(msg.clone()), output_iter.next());
+            prop_assert_eq!(Some(msg.clone()), output_iter.next());
         }
-        assert_eq!(None, output_iter.next());
+        prop_assert_eq!(None, output_iter.next());
     }
 }
 

--- a/rs/replicated_state/tests/replicated_state.rs
+++ b/rs/replicated_state/tests/replicated_state.rs
@@ -21,7 +21,7 @@ use ic_replicated_state::{
     CanisterState, IngressHistoryState, NextInputQueue, ReplicatedState, SchedulerState,
     StateError, SystemState,
 };
-use ic_test_utilities_state::{arb_replicated_state_with_queues, ExecutionStateBuilder};
+use ic_test_utilities_state::{arb_replicated_state_with_output_queues, ExecutionStateBuilder};
 use ic_test_utilities_types::ids::{canister_test_id, message_test_id, user_test_id, SUBNET_1};
 use ic_test_utilities_types::messages::{RequestBuilder, ResponseBuilder};
 use ic_types::ingress::{IngressState, IngressStatus};
@@ -874,19 +874,19 @@ fn compatibility_for_next_input_queue() {
 proptest! {
     #[test]
     fn peek_and_next_consistent(
-        (mut replicated_state, _, total_requests) in arb_replicated_state_with_queues(SUBNET_ID, 20, 20, Some(8))
+        (mut replicated_state, _, total_requests) in arb_replicated_state_with_output_queues(SUBNET_ID, 10, 10, Some(5))
     ) {
         let mut output_iter = replicated_state.output_into_iter();
 
         let mut num_requests = 0;
         while let Some(msg) = output_iter.peek() {
             num_requests += 1;
-            assert_eq!(Some(msg.clone()), output_iter.next());
+            prop_assert_eq!(Some(msg.clone()), output_iter.next());
         }
 
         drop(output_iter);
-        assert_eq!(total_requests, num_requests);
-        assert_eq!(replicated_state.output_message_count(), 0);
+        prop_assert_eq!(total_requests, num_requests);
+        prop_assert_eq!(replicated_state.output_message_count(), 0);
     }
 
     /// Replicated state with multiple canisters, each with multiple output queues
@@ -895,8 +895,8 @@ proptest! {
     /// Expect consumed + excluded to equal initial size. Expect the messages in
     /// excluded queues to be left in the state.
     #[test]
-    fn peek_and_next_consistent_with_ignore(
-        (mut replicated_state, _, total_requests) in arb_replicated_state_with_queues(SUBNET_ID, 20, 20, None),
+    fn peek_and_next_consistent_with_exclude_queue(
+        (mut replicated_state, _, total_requests) in arb_replicated_state_with_output_queues(SUBNET_ID, 10, 10, None),
         start in 0..=1,
         exclude_step in 2..=5,
     ) {
@@ -911,19 +911,19 @@ proptest! {
                 output_iter.exclude_queue();
                 excluded += 1;
             } else {
-                assert_eq!(Some(msg.clone()), output_iter.next());
+                prop_assert_eq!(Some(msg.clone()), output_iter.next());
                 consumed += 1;
             }
         }
 
         drop(output_iter);
-        assert_eq!(total_requests, excluded + consumed);
-        assert_eq!(replicated_state.output_message_count(), excluded);
+        prop_assert_eq!(total_requests, excluded + consumed);
+        prop_assert_eq!(replicated_state.output_message_count(), excluded);
     }
 
     #[test]
     fn iter_yields_correct_elements(
-       (mut replicated_state, mut raw_requests, _total_requests) in arb_replicated_state_with_queues(SUBNET_ID, 20, 20, None),
+       (mut replicated_state, mut raw_requests, _total_requests) in arb_replicated_state_with_output_queues(SUBNET_ID, 10, 10, None),
     ) {
         let mut output_iter = replicated_state.output_into_iter();
 
@@ -934,7 +934,7 @@ proptest! {
             }
 
             if let Some(raw_msg) = requests.pop_front() {
-                assert_eq!(msg, raw_msg, "Popped message does not correspond with expected message. popped: {:?}. expected: {:?}.", msg, raw_msg);
+                prop_assert_eq!(&msg, &raw_msg, "Popped message does not correspond with expected message. popped: {:?}. expected: {:?}.", msg, raw_msg);
             } else {
                 panic!("Pop yielded an element that was not contained in the respective queue");
             }
@@ -944,13 +944,13 @@ proptest! {
 
         drop(output_iter);
         // Ensure that actually all elements have been consumed.
-        assert_eq!(raw_requests.iter().map(|requests| requests.len()).sum::<usize>(), 0);
-        assert_eq!(replicated_state.output_message_count(), 0);
+        prop_assert_eq!(raw_requests.iter().map(|requests| requests.len()).sum::<usize>(), 0);
+        prop_assert_eq!(replicated_state.output_message_count(), 0);
     }
 
     #[test]
-    fn iter_with_ignore_yields_correct_elements(
-       (mut replicated_state, mut raw_requests, total_requests) in arb_replicated_state_with_queues(SUBNET_ID, 10, 10, None),
+    fn iter_with_exclude_queue_yields_correct_elements(
+       (mut replicated_state, mut raw_requests, total_requests) in arb_replicated_state_with_output_queues(SUBNET_ID, 10, 10, None),
         start in 0..=1,
         ignore_step in 2..=5,
     ) {
@@ -973,7 +973,7 @@ proptest! {
                     // Popping the front of the requests will amount to the same as ignoring as
                     // we use queues of size one in this test.
                     let popped = requests.pop_front().unwrap();
-                    assert_eq!(*msg, popped);
+                    prop_assert_eq!(msg, &popped);
                     output_iter.exclude_queue();
                     ignored_requests.push(popped);
                     // We push the queue to the front as the canister gets another chance if one
@@ -985,7 +985,7 @@ proptest! {
                 let msg = output_iter.next().unwrap();
                 if let Some(raw_msg) = requests.pop_front() {
                     consumed += 1;
-                    assert_eq!(msg, raw_msg, "Popped message does not correspond with expected message. popped: {:?}. expected: {:?}.", msg, raw_msg);
+                    prop_assert_eq!(&msg, &raw_msg, "Popped message does not correspond with expected message. popped: {:?}. expected: {:?}.", msg, raw_msg);
                 } else {
                     panic!("Pop yielded an element that was not contained in the respective queue");
                 }
@@ -996,8 +996,8 @@ proptest! {
 
         let remaining_output = replicated_state.output_message_count();
 
-        assert_eq!(remaining_output, total_requests - consumed);
-        assert_eq!(remaining_output, ignored_requests.len());
+        prop_assert_eq!(remaining_output, total_requests - consumed);
+        prop_assert_eq!(remaining_output, ignored_requests.len());
 
         for raw in ignored_requests {
             let queues = if let Some(canister) = replicated_state.canister_states.get_mut(&raw.sender()) {
@@ -1007,16 +1007,16 @@ proptest! {
             };
 
             let msg = queues.pop_canister_output(&raw.receiver()).unwrap();
-            assert_eq!(raw, msg);
+            prop_assert_eq!(raw, msg);
         }
 
-        assert_eq!(replicated_state.output_message_count(), 0);
+        prop_assert_eq!(replicated_state.output_message_count(), 0);
 
     }
 
     #[test]
     fn peek_next_loop_terminates(
-        (mut replicated_state, _, _) in arb_replicated_state_with_queues(SUBNET_ID, 20, 20, Some(8)),
+        (mut replicated_state, _, _) in arb_replicated_state_with_output_queues(SUBNET_ID, 10, 10, Some(5)),
     ) {
         let mut output_iter = replicated_state.output_into_iter();
 
@@ -1027,7 +1027,7 @@ proptest! {
 
     #[test]
     fn ignore_leaves_state_untouched(
-        (mut replicated_state, _, _) in arb_replicated_state_with_queues(SUBNET_ID, 20, 20, Some(8)),
+        (mut replicated_state, _, _) in arb_replicated_state_with_output_queues(SUBNET_ID, 10, 10, Some(5)),
     ) {
         let expected_state = replicated_state.clone();
         {
@@ -1038,12 +1038,12 @@ proptest! {
             }
         }
 
-        assert_eq!(expected_state, replicated_state);
+        prop_assert_eq!(expected_state, replicated_state);
     }
 
     #[test]
-    fn peek_next_loop_with_ignores_terminates(
-        (mut replicated_state, _, _) in arb_replicated_state_with_queues(SUBNET_ID, 20, 20, Some(8)),
+    fn peek_next_loop_with_exclude_queue_terminates(
+        (mut replicated_state, _, _) in arb_replicated_state_with_output_queues(SUBNET_ID, 10, 10, Some(5)),
         start in 0..=1,
         ignore_step in 2..=5,
     ) {

--- a/rs/replicated_state/tests/replicated_state.rs
+++ b/rs/replicated_state/tests/replicated_state.rs
@@ -936,7 +936,7 @@ proptest! {
             if let Some(raw_msg) = requests.pop_front() {
                 prop_assert_eq!(&msg, &raw_msg, "Popped message does not correspond with expected message. popped: {:?}. expected: {:?}.", msg, raw_msg);
             } else {
-                panic!("Pop yielded an element that was not contained in the respective queue");
+                prop_assert!(false, "Pop yielded an element that was not contained in the respective queue");
             }
 
             raw_requests.push_back(requests);
@@ -987,7 +987,7 @@ proptest! {
                     consumed += 1;
                     prop_assert_eq!(&msg, &raw_msg, "Popped message does not correspond with expected message. popped: {:?}. expected: {:?}.", msg, raw_msg);
                 } else {
-                    panic!("Pop yielded an element that was not contained in the respective queue");
+                    prop_assert!(false, "Pop yielded an element that was not contained in the respective queue");
                 }
 
                 raw_requests.push_back(requests);

--- a/rs/test_utilities/state/src/lib.rs
+++ b/rs/test_utilities/state/src/lib.rs
@@ -13,7 +13,7 @@ use ic_replicated_state::{
             CustomSection, CustomSectionType, NextScheduledMethod, WasmBinary, WasmMetadata,
         },
         system_state::CyclesUseCase,
-        testing::new_canister_queues_for_test,
+        testing::new_canister_output_queues_for_test,
     },
     metadata_state::subnet_call_context_manager::{
         BitcoinGetSuccessorsContext, BitcoinSendTransactionInternalContext, SubnetCallContext,
@@ -1098,7 +1098,7 @@ prop_compose! {
 ///
 /// Returns the generated `ReplicatedState`; the requests grouped by canister,
 /// in expected iteration order; and the total number of requests.
-fn new_replicated_state_for_test(
+fn new_replicated_state_with_output_queues(
     own_subnet_id: SubnetId,
     mut output_requests: Vec<Vec<Request>>,
     num_receivers: usize,
@@ -1111,8 +1111,11 @@ fn new_replicated_state_for_test(
     let mut requests = VecDeque::new();
 
     let subnet_queues = if let Some(reqs) = output_requests.pop() {
-        let (queues, raw_requests) =
-            new_canister_queues_for_test(reqs, CanisterId::from(own_subnet_id), num_receivers);
+        let (queues, raw_requests) = new_canister_output_queues_for_test(
+            reqs,
+            CanisterId::from(own_subnet_id),
+            num_receivers,
+        );
         total_requests += raw_requests.len();
         requests.push_back(raw_requests);
         Some(queues)
@@ -1128,8 +1131,11 @@ fn new_replicated_state_for_test(
             let mut canister = CanisterStateBuilder::new()
                 .with_canister_id(canister_id)
                 .build();
-            let (queues, raw_requests) =
-                new_canister_queues_for_test(reqs, canister_test_id(i as u64), num_receivers);
+            let (queues, raw_requests) = new_canister_output_queues_for_test(
+                reqs,
+                canister_test_id(i as u64),
+                num_receivers,
+            );
             canister.system_state.put_queues(queues);
             total_requests += raw_requests.len();
             requests.push_back(raw_requests);
@@ -1160,7 +1166,7 @@ fn new_replicated_state_for_test(
 }
 
 prop_compose! {
-     pub fn arb_replicated_state_with_queues(
+     pub fn arb_replicated_state_with_output_queues(
         own_subnet_id: SubnetId,
         max_canisters: usize,
         max_requests_per_canister: usize,
@@ -1173,7 +1179,7 @@ prop_compose! {
         use rand::{Rng, SeedableRng};
         use rand_chacha::ChaChaRng;
 
-        let (mut replicated_state, mut raw_requests, total_requests) = new_replicated_state_for_test(own_subnet_id, request_queues, num_receivers);
+        let (mut replicated_state, mut raw_requests, total_requests) = new_replicated_state_with_output_queues(own_subnet_id, request_queues, num_receivers);
 
         // We pseudorandomly rotate the queues to match the rotation applied by the iterator.
         // Note that subnet queues are always at the front which is why we need to pop them


### PR DESCRIPTION
* Make it obvious (via naming and documentation) that the strategies only populate output queues.
* Adjust the ratio of messages to queues, to make it more likely (with best-effort messages) for all messages in some queues to expire.
* Use `prop_assert!()` instead of plain `assert!()`.