### PR TITLE
chore(ICP-Ledger): FI-1426: remove maximum number of accounts

### DIFF
--- a/rs/rosetta-api/icp_ledger/ledger.did
+++ b/rs/rosetta-api/icp_ledger/ledger.did
@@ -350,7 +350,6 @@ type Value = variant {
 };
 
 type UpgradeArgs = record {
-  maximum_number_of_accounts : opt nat64;
   icrc1_minting_account : opt Account;
   feature_flags : opt FeatureFlags;
 };

--- a/rs/rosetta-api/icp_ledger/ledger/src/lib.rs
+++ b/rs/rosetta-api/icp_ledger/ledger/src/lib.rs
@@ -432,9 +432,6 @@ impl Ledger {
     }
 
     pub fn upgrade(&mut self, args: UpgradeArgs) {
-        if let Some(maximum_number_of_accounts) = args.maximum_number_of_accounts {
-            self.maximum_number_of_accounts = maximum_number_of_accounts;
-        }
         if let Some(icrc1_minting_account) = args.icrc1_minting_account {
             if Some(AccountIdentifier::from(icrc1_minting_account)) != self.minting_account_id {
                 trap_with(

--- a/rs/rosetta-api/icp_ledger/ledger/tests/tests.rs
+++ b/rs/rosetta-api/icp_ledger/ledger/tests/tests.rs
@@ -1119,7 +1119,6 @@ fn test_feature_flags() {
         canister_id,
         ledger_wasm.clone(),
         Encode!(&LedgerCanisterPayload::Upgrade(Some(UpgradeArgs {
-            maximum_number_of_accounts: None,
             icrc1_minting_account: None,
             feature_flags: Some(FeatureFlags { icrc2: false }),
         })))
@@ -1140,7 +1139,6 @@ fn test_feature_flags() {
         canister_id,
         ledger_wasm,
         Encode!(&LedgerCanisterPayload::Upgrade(Some(UpgradeArgs {
-            maximum_number_of_accounts: None,
             icrc1_minting_account: None,
             feature_flags: Some(FeatureFlags { icrc2: true }),
         })))

--- a/rs/rosetta-api/icp_ledger/src/lib.rs
+++ b/rs/rosetta-api/icp_ledger/src/lib.rs
@@ -454,9 +454,6 @@ pub struct LedgerCanisterUpgradePayload(pub LedgerCanisterPayload);
 #[derive(Serialize, Deserialize, CandidType, Clone, Debug, PartialEq, Eq)]
 pub struct UpgradeArgs {
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub maximum_number_of_accounts: Option<usize>,
-
-    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub icrc1_minting_account: Option<Account>,
 
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -643,7 +640,6 @@ impl LedgerCanisterInitPayloadBuilder {
 }
 
 pub struct LedgerCanisterUpgradePayloadBuilder {
-    maximum_number_of_accounts: Option<usize>,
     icrc1_minting_account: Option<Account>,
     feature_flags: Option<FeatureFlags>,
 }
@@ -651,15 +647,9 @@ pub struct LedgerCanisterUpgradePayloadBuilder {
 impl LedgerCanisterUpgradePayloadBuilder {
     fn new() -> Self {
         Self {
-            maximum_number_of_accounts: None,
             icrc1_minting_account: None,
             feature_flags: None,
         }
-    }
-
-    pub fn maximum_number_of_accounts(mut self, maximum_number_of_accounts: usize) -> Self {
-        self.maximum_number_of_accounts = Some(maximum_number_of_accounts);
-        self
     }
 
     pub fn icrc1_minting_account(mut self, minting_account: Account) -> Self {
@@ -670,7 +660,6 @@ impl LedgerCanisterUpgradePayloadBuilder {
     pub fn build(self) -> Result<LedgerCanisterUpgradePayload, String> {
         Ok(LedgerCanisterUpgradePayload(
             LedgerCanisterPayload::Upgrade(Some(UpgradeArgs {
-                maximum_number_of_accounts: self.maximum_number_of_accounts,
                 icrc1_minting_account: self.icrc1_minting_account,
                 feature_flags: self.feature_flags,
             })),

--- a/rs/rosetta-api/icp_ledger/tests/golden_nns_state.rs
+++ b/rs/rosetta-api/icp_ledger/tests/golden_nns_state.rs
@@ -76,11 +76,11 @@ fn upgrade_index(state_machine: &StateMachine, wasm_bytes: Vec<u8>) {
 }
 
 fn upgrade_ledger(state_machine: &StateMachine, wasm_bytes: Vec<u8>) {
-    let ledger_upgrade_args = LedgerCanisterPayload::Upgrade(Some(UpgradeArgs {
-        maximum_number_of_accounts: None,
-        icrc1_minting_account: None,
-        feature_flags: Some(FeatureFlags { icrc2: true }),
-    }));
+    let ledger_upgrade_args: LedgerCanisterPayload =
+        LedgerCanisterPayload::Upgrade(Some(UpgradeArgs {
+            icrc1_minting_account: None,
+            feature_flags: Some(FeatureFlags { icrc2: true }),
+        }));
 
     state_machine
         .upgrade_canister(

--- a/rs/rosetta-api/icp_ledger/tests/tests.rs
+++ b/rs/rosetta-api/icp_ledger/tests/tests.rs
@@ -315,7 +315,6 @@ fn upgrade_test() {
             .upgrade_to_self_binary(
                 CandidOne(Some(
                     LedgerCanisterUpgradePayload::builder()
-                        .maximum_number_of_accounts(28_000_000)
                         .build()
                         .unwrap(),
                 ))
@@ -336,7 +335,6 @@ fn upgrade_test() {
             .upgrade_to_self_binary(
                 CandidOne(Some(
                     LedgerCanisterUpgradePayload::builder()
-                        .maximum_number_of_accounts(28_000_000)
                         .icrc1_minting_account(minting_account_principal.into())
                         .build()
                         .unwrap(),

--- a/rs/rosetta-api/icp_ledger/tests/tests.rs
+++ b/rs/rosetta-api/icp_ledger/tests/tests.rs
@@ -314,9 +314,7 @@ fn upgrade_test() {
         ledger
             .upgrade_to_self_binary(
                 CandidOne(Some(
-                    LedgerCanisterUpgradePayload::builder()
-                        .build()
-                        .unwrap(),
+                    LedgerCanisterUpgradePayload::builder().build().unwrap(),
                 ))
                 .into_bytes()
                 .unwrap(),

--- a/rs/rosetta-api/icrc1/index-ng/tests/tests.rs
+++ b/rs/rosetta-api/icrc1/index-ng/tests/tests.rs
@@ -54,7 +54,6 @@ fn upgrade_ledger(
         change_fee_collector,
         max_memo_length: None,
         feature_flags: None,
-        maximum_number_of_accounts: None,
         accounts_overflow_trim_quantity: None,
         change_archive_options: None,
     }));

--- a/rs/rosetta-api/icrc1/ledger/ledger.did
+++ b/rs/rosetta-api/icrc1/ledger/ledger.did
@@ -144,7 +144,6 @@ type UpgradeArgs = record {
     change_fee_collector : opt ChangeFeeCollector;
     max_memo_length : opt nat16;
     feature_flags : opt FeatureFlags;
-    maximum_number_of_accounts: opt nat64;
     accounts_overflow_trim_quantity: opt nat64;
     change_archive_options : opt ChangeArchiveOptions;
 };

--- a/rs/rosetta-api/icrc1/ledger/sm-tests/src/lib.rs
+++ b/rs/rosetta-api/icrc1/ledger/sm-tests/src/lib.rs
@@ -109,7 +109,6 @@ pub struct UpgradeArgs {
     pub transfer_fee: Option<Nat>,
     pub change_fee_collector: Option<ChangeFeeCollector>,
     pub feature_flags: Option<FeatureFlags>,
-    pub maximum_number_of_accounts: Option<u64>,
     pub accounts_overflow_trim_quantity: Option<u64>,
     pub change_archive_options: Option<ChangeArchiveOptions>,
 }

--- a/rs/rosetta-api/icrc1/ledger/src/lib.rs
+++ b/rs/rosetta-api/icrc1/ledger/src/lib.rs
@@ -314,8 +314,6 @@ pub struct UpgradeArgs {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub feature_flags: Option<FeatureFlags>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub maximum_number_of_accounts: Option<u64>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub accounts_overflow_trim_quantity: Option<u64>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub change_archive_options: Option<ChangeArchiveOptions>,
@@ -648,9 +646,6 @@ impl<Tokens: TokensType> Ledger<Tokens> {
                 );
             }
             self.feature_flags = feature_flags;
-        }
-        if let Some(maximum_number_of_accounts) = args.maximum_number_of_accounts {
-            self.maximum_number_of_accounts = maximum_number_of_accounts.try_into().unwrap();
         }
         if let Some(accounts_overflow_trim_quantity) = args.accounts_overflow_trim_quantity {
             self.accounts_overflow_trim_quantity =


### PR DESCRIPTION
This MR proposes the following changes: 

1. Remove the maximum number of accounts from the upgrade arguments

This change is done, to close a possible vulnerability where the maximum number of accounts is set to 0 or a very small number. 