### PR TITLE
feat(nns): Add date filtering to list_node_provider_rewards

### DIFF
--- a/rs/nns/governance/api/src/ic_nns_governance.pb.v1.rs
+++ b/rs/nns/governance/api/src/ic_nns_governance.pb.v1.rs
@@ -4701,7 +4701,8 @@ pub struct DateRangeFilter {
     pub end_timestamp_seconds: Option<u64>,
 }
 
-/// A Request to list minted node provider rewards
+/// A Request to list minted node provider rewards.  Rewards are listed in descending order of date
+/// minted, meaning that the latest rewards are always returned first.
 #[derive(candid::CandidType, candid::Deserialize, serde::Serialize, comparable::Comparable)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Debug, Clone, PartialEq)]

--- a/rs/nns/governance/api/src/ic_nns_governance.pb.v1.rs
+++ b/rs/nns/governance/api/src/ic_nns_governance.pb.v1.rs
@@ -4693,31 +4693,33 @@ impl ProposalRewardStatus {
 /// A closed range of dates (i.e. includes both start and end dates)
 #[derive(candid::CandidType, candid::Deserialize, serde::Serialize, comparable::Comparable)]
 #[allow(clippy::derive_partial_eq_without_eq)]
-#[derive(Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct DateRangeFilter {
     /// The start date of the range as seconds since epoch
-    start_timestamp_seconds: Option<u64>,
+    pub start_timestamp_seconds: Option<u64>,
     /// The end date of the range
-    end_timestamp_seconds: Option<u64>,
+    pub end_timestamp_seconds: Option<u64>,
 }
 
 /// A Request to list minted node provider rewards
 #[derive(candid::CandidType, candid::Deserialize, serde::Serialize, comparable::Comparable)]
 #[allow(clippy::derive_partial_eq_without_eq)]
-#[derive(Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct ListNodeProviderRewardsRequest {
     /// The next page - a token used to get the next set of results.
-    page: Option<u32>,
+    pub page: Option<u32>,
     /// Filter for the dates of the rewards
-    date_filter: Option<DateRangeFilter>,
+    pub date_filter: Option<DateRangeFilter>,
 }
 
 /// A Response to list minted node provider rewards.
 /// Includes optional paging information to get next set of results.
 #[derive(candid::CandidType, candid::Deserialize, serde::Serialize, comparable::Comparable)]
 #[allow(clippy::derive_partial_eq_without_eq)]
-#[derive(Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct ListNodeProviderRewardsResponse {
     /// The list of minted node provider rewards
     pub rewards: Vec<MonthlyNodeProviderRewards>,
+    /// The next page token to be used in the next request to get the next set of results.
+    pub next_page: Option<u32>,
 }

--- a/rs/nns/governance/api/src/ic_nns_governance.pb.v1.rs
+++ b/rs/nns/governance/api/src/ic_nns_governance.pb.v1.rs
@@ -4690,11 +4690,27 @@ impl ProposalRewardStatus {
     }
 }
 
+/// A closed range of dates (i.e. includes both start and end dates)
+#[derive(candid::CandidType, candid::Deserialize, serde::Serialize, comparable::Comparable)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq)]
+pub struct DateRangeFilter {
+    /// The start date of the range as seconds since epoch
+    start_timestamp_seconds: Option<u64>,
+    /// The end date of the range
+    end_timestamp_seconds: Option<u64>,
+}
+
 /// A Request to list minted node provider rewards
 #[derive(candid::CandidType, candid::Deserialize, serde::Serialize, comparable::Comparable)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq)]
-pub struct ListNodeProviderRewardsRequest {}
+pub struct ListNodeProviderRewardsRequest {
+    /// The next page - a token used to get the next set of results.
+    page: Option<u32>,
+    /// Filter for the dates of the rewards
+    date_filter: Option<DateRangeFilter>,
+}
 
 /// A Response to list minted node provider rewards.
 /// Includes optional paging information to get next set of results.

--- a/rs/nns/governance/api/src/ic_nns_governance.pb.v1.rs
+++ b/rs/nns/governance/api/src/ic_nns_governance.pb.v1.rs
@@ -4695,9 +4695,10 @@ impl ProposalRewardStatus {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Debug, Clone, PartialEq)]
 pub struct DateRangeFilter {
-    /// The start date of the range as seconds since epoch
+    /// The start date of the range as seconds since epoch.  When not provided,
+    /// no start date is assumed.
     pub start_timestamp_seconds: Option<u64>,
-    /// The end date of the range
+    /// The end date of the range as seconds since epoch.  When not provided, no end date is assumed.
     pub end_timestamp_seconds: Option<u64>,
 }
 
@@ -4707,8 +4708,6 @@ pub struct DateRangeFilter {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Debug, Clone, PartialEq)]
 pub struct ListNodeProviderRewardsRequest {
-    /// The next page - a token used to get the next set of results.
-    pub page: Option<u32>,
     /// Filter for the dates of the rewards
     pub date_filter: Option<DateRangeFilter>,
 }
@@ -4721,6 +4720,4 @@ pub struct ListNodeProviderRewardsRequest {
 pub struct ListNodeProviderRewardsResponse {
     /// The list of minted node provider rewards
     pub rewards: Vec<MonthlyNodeProviderRewards>,
-    /// The next page token to be used in the next request to get the next set of results.
-    pub next_page: Option<u32>,
 }

--- a/rs/nns/governance/canister/canister.rs
+++ b/rs/nns/governance/canister/canister.rs
@@ -747,13 +747,14 @@ fn list_node_provider_rewards() {
 fn list_node_provider_rewards_(
     req: ListNodeProviderRewardsRequest,
 ) -> ListNodeProviderRewardsResponse {
-    let rewards = governance().list_node_provider_rewards(5, req.page);
+    let (next_page, rewards) = governance().list_node_provider_rewards(5, req.page);
 
     ListNodeProviderRewardsResponse {
         rewards: rewards
             .into_iter()
             .map(MonthlyNodeProviderRewards::from)
             .collect(),
+        next_page,
     }
 }
 

--- a/rs/nns/governance/canister/canister.rs
+++ b/rs/nns/governance/canister/canister.rs
@@ -747,16 +747,13 @@ fn list_node_provider_rewards() {
 fn list_node_provider_rewards_(
     req: ListNodeProviderRewardsRequest,
 ) -> ListNodeProviderRewardsResponse {
-    let (next_page, rewards) =
-        governance().list_node_provider_rewards(5, req.page, req.date_filter.map(|d| d.into()));
+    let rewards = governance()
+        .list_node_provider_rewards(req.date_filter.map(|d| d.into()))
+        .into_iter()
+        .map(MonthlyNodeProviderRewards::from)
+        .collect();
 
-    ListNodeProviderRewardsResponse {
-        rewards: rewards
-            .into_iter()
-            .map(MonthlyNodeProviderRewards::from)
-            .collect(),
-        next_page,
-    }
+    ListNodeProviderRewardsResponse { rewards }
 }
 
 #[export_name = "canister_query list_known_neurons"]

--- a/rs/nns/governance/canister/canister.rs
+++ b/rs/nns/governance/canister/canister.rs
@@ -745,9 +745,9 @@ fn list_node_provider_rewards() {
 
 #[candid_method(query, rename = "list_node_provider_rewards")]
 fn list_node_provider_rewards_(
-    _req: ListNodeProviderRewardsRequest,
+    req: ListNodeProviderRewardsRequest,
 ) -> ListNodeProviderRewardsResponse {
-    let rewards = governance().list_node_provider_rewards(5);
+    let rewards = governance().list_node_provider_rewards(5, req.page);
 
     ListNodeProviderRewardsResponse {
         rewards: rewards

--- a/rs/nns/governance/canister/canister.rs
+++ b/rs/nns/governance/canister/canister.rs
@@ -747,7 +747,8 @@ fn list_node_provider_rewards() {
 fn list_node_provider_rewards_(
     req: ListNodeProviderRewardsRequest,
 ) -> ListNodeProviderRewardsResponse {
-    let (next_page, rewards) = governance().list_node_provider_rewards(5, req.page);
+    let (next_page, rewards) =
+        governance().list_node_provider_rewards(5, req.page, req.date_filter.map(|d| d.into()));
 
     ListNodeProviderRewardsResponse {
         rewards: rewards

--- a/rs/nns/governance/canister/governance.did
+++ b/rs/nns/governance/canister/governance.did
@@ -137,6 +137,10 @@ type CreateServiceNervousSystem = record {
   swap_parameters : opt SwapParameters;
   initial_token_distribution : opt InitialTokenDistribution;
 };
+type DateRangeFilter = record {
+  start_timestamp_seconds : opt nat64;
+  end_timestamp_seconds : opt nat64;
+};
 type Decimal = record { human_readable : opt text };
 type DerivedProposalInformation = record {
   swap_background_information : opt SwapBackgroundInformation;
@@ -301,7 +305,12 @@ type ListNeuronsResponse = record {
   neuron_infos : vec record { nat64; NeuronInfo };
   full_neurons : vec Neuron;
 };
+type ListNodeProviderRewardsRequest = record {
+  page : opt nat32;
+  date_filter : opt DateRangeFilter;
+};
 type ListNodeProviderRewardsResponse = record {
+  next_page : opt nat32;
   rewards : vec MonthlyNodeProviderRewards;
 };
 type ListNodeProvidersResponse = record { node_providers : vec NodeProvider };
@@ -802,7 +811,7 @@ service : (Governance) -> {
   get_restore_aging_summary : () -> (RestoreAgingSummary) query;
   list_known_neurons : () -> (ListKnownNeuronsResponse) query;
   list_neurons : (ListNeurons) -> (ListNeuronsResponse) query;
-  list_node_provider_rewards : (record {}) -> (
+  list_node_provider_rewards : (ListNodeProviderRewardsRequest) -> (
       ListNodeProviderRewardsResponse,
     ) query;
   list_node_providers : () -> (ListNodeProvidersResponse) query;

--- a/rs/nns/governance/canister/governance.did
+++ b/rs/nns/governance/canister/governance.did
@@ -306,11 +306,9 @@ type ListNeuronsResponse = record {
   full_neurons : vec Neuron;
 };
 type ListNodeProviderRewardsRequest = record {
-  page : opt nat32;
   date_filter : opt DateRangeFilter;
 };
 type ListNodeProviderRewardsResponse = record {
-  next_page : opt nat32;
   rewards : vec MonthlyNodeProviderRewards;
 };
 type ListNodeProvidersResponse = record { node_providers : vec NodeProvider };

--- a/rs/nns/governance/canister/governance_test.did
+++ b/rs/nns/governance/canister/governance_test.did
@@ -137,6 +137,10 @@ type CreateServiceNervousSystem = record {
   swap_parameters : opt SwapParameters;
   initial_token_distribution : opt InitialTokenDistribution;
 };
+type DateRangeFilter = record {
+  start_timestamp_seconds : opt nat64;
+  end_timestamp_seconds : opt nat64;
+};
 type Decimal = record { human_readable : opt text };
 type DerivedProposalInformation = record {
   swap_background_information : opt SwapBackgroundInformation;
@@ -301,7 +305,12 @@ type ListNeuronsResponse = record {
   neuron_infos : vec record { nat64; NeuronInfo };
   full_neurons : vec Neuron;
 };
+type ListNodeProviderRewardsRequest = record {
+  page : opt nat32;
+  date_filter : opt DateRangeFilter;
+};
 type ListNodeProviderRewardsResponse = record {
+  next_page : opt nat32;
   rewards : vec MonthlyNodeProviderRewards;
 };
 type ListNodeProvidersResponse = record { node_providers : vec NodeProvider };
@@ -802,7 +811,7 @@ service : (Governance) -> {
   get_restore_aging_summary : () -> (RestoreAgingSummary) query;
   list_known_neurons : () -> (ListKnownNeuronsResponse) query;
   list_neurons : (ListNeurons) -> (ListNeuronsResponse) query;
-  list_node_provider_rewards : (record {}) -> (
+  list_node_provider_rewards : (ListNodeProviderRewardsRequest) -> (
       ListNodeProviderRewardsResponse,
     ) query;
   list_node_providers : () -> (ListNodeProvidersResponse) query;

--- a/rs/nns/governance/canister/governance_test.did
+++ b/rs/nns/governance/canister/governance_test.did
@@ -306,11 +306,9 @@ type ListNeuronsResponse = record {
   full_neurons : vec Neuron;
 };
 type ListNodeProviderRewardsRequest = record {
-  page : opt nat32;
   date_filter : opt DateRangeFilter;
 };
 type ListNodeProviderRewardsResponse = record {
-  next_page : opt nat32;
   rewards : vec MonthlyNodeProviderRewards;
 };
 type ListNodeProvidersResponse = record { node_providers : vec NodeProvider };

--- a/rs/nns/governance/src/governance.rs
+++ b/rs/nns/governance/src/governance.rs
@@ -189,7 +189,7 @@ pub const MAX_NUMBER_OF_NEURONS: usize = 350_000;
 /// The maximum number results returned by the method `list_proposals`.
 pub const MAX_LIST_PROPOSAL_RESULTS: u32 = 100;
 
-const MAX_LIST_NODE_PROVIDER_REWARDS_RESULTS: u64 = 5;
+const MAX_LIST_NODE_PROVIDER_REWARDS_RESULTS: usize = 24;
 
 /// The number of e8s per ICP;
 const E8S_PER_ICP: u64 = TOKEN_SUBDIVIDABLE_BY;
@@ -4315,13 +4315,9 @@ impl Governance {
 
     pub fn list_node_provider_rewards(
         &self,
-        limit: u64,
-        page: Option<u32>,
         date_filter: Option<DateRangeFilter>,
-    ) -> (Option<u32>, Vec<MonthlyNodeProviderRewards>) {
-        let limit = limit.min(MAX_LIST_NODE_PROVIDER_REWARDS_RESULTS);
-        let (next_page, rewards) = list_node_provider_rewards(limit, page, date_filter);
-        let rewards = rewards
+    ) -> Vec<MonthlyNodeProviderRewards> {
+        list_node_provider_rewards(MAX_LIST_NODE_PROVIDER_REWARDS_RESULTS, date_filter)
             .into_iter()
             .map(|archived| match archived.version {
                 Some(archived_monthly_node_provider_rewards::Version::Version1(v1)) => {
@@ -4329,8 +4325,7 @@ impl Governance {
                 }
                 _ => panic!("Should not be possible!"),
             })
-            .collect();
-        (next_page, rewards)
+            .collect()
     }
 
     pub fn get_most_recent_monthly_node_provider_rewards(

--- a/rs/nns/governance/src/governance.rs
+++ b/rs/nns/governance/src/governance.rs
@@ -4312,9 +4312,13 @@ impl Governance {
         self.heap_data.most_recent_monthly_node_provider_rewards = Some(most_recent_rewards);
     }
 
-    pub fn list_node_provider_rewards(&self, limit: u64) -> Vec<MonthlyNodeProviderRewards> {
+    pub fn list_node_provider_rewards(
+        &self,
+        limit: u64,
+        page: Option<u32>,
+    ) -> Vec<MonthlyNodeProviderRewards> {
         let limit = limit.min(MAX_LIST_NODE_PROVIDER_REWARDS_RESULTS);
-        list_node_provider_rewards(limit)
+        list_node_provider_rewards(limit, page)
             .into_iter()
             .map(|archived| match archived.version {
                 Some(archived_monthly_node_provider_rewards::Version::Version1(v1)) => {

--- a/rs/nns/governance/src/governance.rs
+++ b/rs/nns/governance/src/governance.rs
@@ -4316,9 +4316,10 @@ impl Governance {
         &self,
         limit: u64,
         page: Option<u32>,
-    ) -> Vec<MonthlyNodeProviderRewards> {
+    ) -> (Option<u32>, Vec<MonthlyNodeProviderRewards>) {
         let limit = limit.min(MAX_LIST_NODE_PROVIDER_REWARDS_RESULTS);
-        list_node_provider_rewards(limit, page)
+        let (next_page, rewards) = list_node_provider_rewards(limit, page);
+        let rewards = rewards
             .into_iter()
             .map(|archived| match archived.version {
                 Some(archived_monthly_node_provider_rewards::Version::Version1(v1)) => {
@@ -4326,7 +4327,8 @@ impl Governance {
                 }
                 _ => panic!("Should not be possible!"),
             })
-            .collect()
+            .collect();
+        (next_page, rewards)
     }
 
     pub fn get_most_recent_monthly_node_provider_rewards(

--- a/rs/nns/governance/src/governance.rs
+++ b/rs/nns/governance/src/governance.rs
@@ -20,6 +20,7 @@ use crate::{
     },
     node_provider_rewards::{
         latest_node_provider_rewards, list_node_provider_rewards, record_node_provider_rewards,
+        DateRangeFilter,
     },
     pb::v1::{
         add_or_remove_node_provider::Change,
@@ -4316,9 +4317,10 @@ impl Governance {
         &self,
         limit: u64,
         page: Option<u32>,
+        date_filter: Option<DateRangeFilter>,
     ) -> (Option<u32>, Vec<MonthlyNodeProviderRewards>) {
         let limit = limit.min(MAX_LIST_NODE_PROVIDER_REWARDS_RESULTS);
-        let (next_page, rewards) = list_node_provider_rewards(limit, page);
+        let (next_page, rewards) = list_node_provider_rewards(limit, page, date_filter);
         let rewards = rewards
             .into_iter()
             .map(|archived| match archived.version {

--- a/rs/nns/governance/src/governance/tests/node_provider_rewards.rs
+++ b/rs/nns/governance/src/governance/tests/node_provider_rewards.rs
@@ -88,9 +88,10 @@ fn test_list_node_provider_rewards_api() {
 
     governance.update_most_recent_monthly_node_provider_rewards(rewards_2.clone());
 
-    let result = governance.list_node_provider_rewards(2, None);
+    let (next_page, rewards) = governance.list_node_provider_rewards(2, None);
 
-    assert_eq!(result, vec![rewards_2, rewards_1]);
+    assert_eq!(rewards, vec![rewards_2, rewards_1]);
+    assert_eq!(next_page, None);
 }
 
 #[test]
@@ -170,12 +171,13 @@ fn test_list_node_provider_rewards_api_with_paging_and_filters() {
     governance.update_most_recent_monthly_node_provider_rewards(rewards_5.clone());
     governance.update_most_recent_monthly_node_provider_rewards(rewards_6.clone());
 
-    let result = governance.list_node_provider_rewards(6, None);
+    let (next_page, rewards) = governance.list_node_provider_rewards(6, None);
 
     // limit of 5
-    assert_eq!(result.len(), 5);
+    assert_eq!(rewards.len(), 5);
     assert_eq!(
-        result,
+        rewards,
         vec![rewards_6, rewards_5, rewards_4, rewards_3, rewards_2]
     );
+    assert_eq!(next_page, Some(1));
 }

--- a/rs/nns/governance/src/governance/tests/node_provider_rewards.rs
+++ b/rs/nns/governance/src/governance/tests/node_provider_rewards.rs
@@ -1,5 +1,6 @@
 use crate::{
     governance::Governance,
+    node_provider_rewards::DateRangeFilter,
     pb::v1::{Governance as GovernanceProto, MonthlyNodeProviderRewards},
     test_utils::{MockEnvironment, StubCMC, StubIcpLedger},
 };
@@ -88,73 +89,13 @@ fn test_list_node_provider_rewards_api() {
 
     governance.update_most_recent_monthly_node_provider_rewards(rewards_2.clone());
 
-    let (next_page, rewards) = governance.list_node_provider_rewards(2, None, None);
+    let rewards = governance.list_node_provider_rewards(None);
 
     assert_eq!(rewards, vec![rewards_2, rewards_1]);
-    assert_eq!(next_page, None);
 }
 
 #[test]
 fn test_list_node_provider_rewards_api_with_paging_and_filters() {
-    let rewards_1 = MonthlyNodeProviderRewards {
-        timestamp: 1721029451, // july 15 2024
-        rewards: vec![],
-        xdr_conversion_rate: None,
-        minimum_xdr_permyriad_per_icp: None,
-        maximum_node_provider_rewards_e8s: None,
-        registry_version: None,
-        node_providers: vec![],
-    };
-
-    let rewards_2 = MonthlyNodeProviderRewards {
-        timestamp: 1723707851, // august 15 2024
-        rewards: vec![],
-        xdr_conversion_rate: None,
-        minimum_xdr_permyriad_per_icp: None,
-        maximum_node_provider_rewards_e8s: None,
-        registry_version: None,
-        node_providers: vec![],
-    };
-    let rewards_3 = MonthlyNodeProviderRewards {
-        timestamp: 1726374659, // sept 15 2024
-        rewards: vec![],
-        xdr_conversion_rate: None,
-        minimum_xdr_permyriad_per_icp: None,
-        maximum_node_provider_rewards_e8s: None,
-        registry_version: None,
-        node_providers: vec![],
-    };
-
-    let rewards_4 = MonthlyNodeProviderRewards {
-        timestamp: 1729041067, // oct 15 2024
-        rewards: vec![],
-        xdr_conversion_rate: None,
-        minimum_xdr_permyriad_per_icp: None,
-        maximum_node_provider_rewards_e8s: None,
-        registry_version: None,
-        node_providers: vec![],
-    };
-
-    let rewards_5 = MonthlyNodeProviderRewards {
-        timestamp: 1731707475, // nov 15 2024
-        rewards: vec![],
-        xdr_conversion_rate: None,
-        minimum_xdr_permyriad_per_icp: None,
-        maximum_node_provider_rewards_e8s: None,
-        registry_version: None,
-        node_providers: vec![],
-    };
-
-    let rewards_6 = MonthlyNodeProviderRewards {
-        timestamp: 1734373883, // dec 15 2024
-        rewards: vec![],
-        xdr_conversion_rate: None,
-        minimum_xdr_permyriad_per_icp: None,
-        maximum_node_provider_rewards_e8s: None,
-        registry_version: None,
-        node_providers: vec![],
-    };
-
     let mut governance = Governance::new(
         GovernanceProto {
             ..Default::default()
@@ -164,20 +105,46 @@ fn test_list_node_provider_rewards_api_with_paging_and_filters() {
         Box::new(StubCMC {}),
     );
 
-    governance.update_most_recent_monthly_node_provider_rewards(rewards_1.clone());
-    governance.update_most_recent_monthly_node_provider_rewards(rewards_2.clone());
-    governance.update_most_recent_monthly_node_provider_rewards(rewards_3.clone());
-    governance.update_most_recent_monthly_node_provider_rewards(rewards_4.clone());
-    governance.update_most_recent_monthly_node_provider_rewards(rewards_5.clone());
-    governance.update_most_recent_monthly_node_provider_rewards(rewards_6.clone());
+    let mut rewards_minted = vec![];
 
-    let (next_page, rewards) = governance.list_node_provider_rewards(6, None, None);
+    for i in 1..=25 {
+        let rewards = MonthlyNodeProviderRewards {
+            timestamp: 100 * i, // july 15 2024
+            rewards: vec![],
+            xdr_conversion_rate: None,
+            minimum_xdr_permyriad_per_icp: None,
+            maximum_node_provider_rewards_e8s: None,
+            registry_version: None,
+            node_providers: vec![],
+        };
+        governance.update_most_recent_monthly_node_provider_rewards(rewards.clone());
+        rewards_minted.push(rewards);
+    }
+
+    let rewards = governance.list_node_provider_rewards(Some(DateRangeFilter {
+        start: None,
+        end: Some(rewards_minted[23].timestamp),
+    }));
 
     // limit of 5
-    assert_eq!(rewards.len(), 5);
+    assert_eq!(rewards.len(), 24);
     assert_eq!(
         rewards,
-        vec![rewards_6, rewards_5, rewards_4, rewards_3, rewards_2]
+        rewards_minted[..=23]
+            .iter()
+            .rev()
+            .cloned()
+            .collect::<Vec<_>>()
     );
-    assert_eq!(next_page, Some(1));
+
+    let rewards = governance.list_node_provider_rewards(None);
+    assert_eq!(rewards.len(), 24);
+    assert_eq!(
+        rewards,
+        rewards_minted[1..=24]
+            .iter()
+            .rev()
+            .cloned()
+            .collect::<Vec<_>>()
+    );
 }

--- a/rs/nns/governance/src/governance/tests/node_provider_rewards.rs
+++ b/rs/nns/governance/src/governance/tests/node_provider_rewards.rs
@@ -88,7 +88,7 @@ fn test_list_node_provider_rewards_api() {
 
     governance.update_most_recent_monthly_node_provider_rewards(rewards_2.clone());
 
-    let (next_page, rewards) = governance.list_node_provider_rewards(2, None);
+    let (next_page, rewards) = governance.list_node_provider_rewards(2, None, None);
 
     assert_eq!(rewards, vec![rewards_2, rewards_1]);
     assert_eq!(next_page, None);
@@ -171,7 +171,7 @@ fn test_list_node_provider_rewards_api_with_paging_and_filters() {
     governance.update_most_recent_monthly_node_provider_rewards(rewards_5.clone());
     governance.update_most_recent_monthly_node_provider_rewards(rewards_6.clone());
 
-    let (next_page, rewards) = governance.list_node_provider_rewards(6, None);
+    let (next_page, rewards) = governance.list_node_provider_rewards(6, None, None);
 
     // limit of 5
     assert_eq!(rewards.len(), 5);

--- a/rs/nns/governance/src/governance/tests/node_provider_rewards.rs
+++ b/rs/nns/governance/src/governance/tests/node_provider_rewards.rs
@@ -88,7 +88,7 @@ fn test_list_node_provider_rewards_api() {
 
     governance.update_most_recent_monthly_node_provider_rewards(rewards_2.clone());
 
-    let result = governance.list_node_provider_rewards(2);
+    let result = governance.list_node_provider_rewards(2, None);
 
     assert_eq!(result, vec![rewards_2, rewards_1]);
 }
@@ -170,7 +170,7 @@ fn test_list_node_provider_rewards_api_with_paging_and_filters() {
     governance.update_most_recent_monthly_node_provider_rewards(rewards_5.clone());
     governance.update_most_recent_monthly_node_provider_rewards(rewards_6.clone());
 
-    let result = governance.list_node_provider_rewards(6);
+    let result = governance.list_node_provider_rewards(6, None);
 
     // limit of 5
     assert_eq!(result.len(), 5);

--- a/rs/nns/governance/src/node_provider_rewards.rs
+++ b/rs/nns/governance/src/node_provider_rewards.rs
@@ -57,8 +57,6 @@ pub(crate) fn list_node_provider_rewards(
     let date_filter = date_filter.unwrap_or_default();
     let start_timestamp = date_filter.start.unwrap_or(0);
     let end_timestamp = date_filter.end.unwrap_or(u64::MAX);
-    // If we have 10 entries, they're 0..9
-    // If we are getting newest first, we want to return 9..4, then 4..0
 
     with_node_provider_rewards_log(|log| {
         // naive filtering implementation is okay b/c our data set is very small
@@ -90,8 +88,13 @@ pub(crate) fn list_node_provider_rewards(
 
         let len: u64 = rewards.len().try_into().unwrap();
 
+        // the end of the range is last result minus the page number times the limit
         let end_range = len.saturating_sub(page as u64 * limit);
+        // start of range is just the end minus the limit, but not less than 0
         let start_range = end_range.saturating_sub(limit);
+
+        // If we have 10 entries, they're 0..9
+        // If we are getting newest first, we want to return 9..4, then 4..0, thus the rev() call
         let rewards = (start_range..end_range)
             .rev()
             .map(|index| rewards[index as usize].clone())

--- a/rs/nns/governance/src/node_provider_rewards.rs
+++ b/rs/nns/governance/src/node_provider_rewards.rs
@@ -63,18 +63,18 @@ pub(crate) fn list_node_provider_rewards(
     with_node_provider_rewards_log(|log| {
         // naive filtering implementation is okay b/c our data set is very small
         // (1/month for years will not give us much to work through for some time)
-        // TODO - migrate to BTreeMap storage...
+        // TODO - migrate to BTreeMap storage with keys as dates and change this to use range lookup
         let rewards = log
             .iter()
             .flat_map(|rewards| {
                 let timestamp = rewards
                     .version
                     .clone()
-                    .and_then(|v| match v {
-                        Version::Version1(v1) => Some(v1),
+                    .map(|v| match v {
+                        Version::Version1(v1) => v1,
                     })
                     .and_then(|v1| v1.rewards)
-                    .and_then(|rewards| Some(rewards.timestamp));
+                    .map(|rewards| rewards.timestamp);
 
                 if let Some(timestamp) = timestamp {
                     if timestamp >= start_timestamp && timestamp <= end_timestamp {
@@ -83,7 +83,7 @@ pub(crate) fn list_node_provider_rewards(
                         None
                     }
                 } else {
-                    return None;
+                    None
                 }
             })
             .collect::<Vec<_>>();

--- a/rs/nns/governance/src/node_provider_rewards.rs
+++ b/rs/nns/governance/src/node_provider_rewards.rs
@@ -34,7 +34,7 @@ pub(crate) fn latest_node_provider_rewards() -> Option<ArchivedMonthlyNodeProvid
 pub(crate) fn list_node_provider_rewards(
     limit: u64,
     page: Option<u32>,
-) -> Vec<ArchivedMonthlyNodeProviderRewards> {
+) -> (Option<u32>, Vec<ArchivedMonthlyNodeProviderRewards>) {
     let page = page.unwrap_or(0);
 
     // If we have 10 entries, they're 0..9
@@ -44,11 +44,16 @@ pub(crate) fn list_node_provider_rewards(
         let len = log.len();
         let end_range = len.saturating_sub(page as u64 * limit);
         let start_range = end_range.saturating_sub(limit);
-
-        (start_range..end_range)
+        let rewards = (start_range..end_range)
             .rev()
             .flat_map(|index| log.get(index))
-            .collect()
+            .collect();
+
+        if start_range == 0 {
+            (None, rewards)
+        } else {
+            (Some(page + 1), rewards)
+        }
     })
 }
 

--- a/rs/nns/governance/src/node_provider_rewards.rs
+++ b/rs/nns/governance/src/node_provider_rewards.rs
@@ -1,11 +1,27 @@
 use crate::{
     pb::v1::{
-        archived_monthly_node_provider_rewards, ArchivedMonthlyNodeProviderRewards,
-        MonthlyNodeProviderRewards,
+        archived_monthly_node_provider_rewards, archived_monthly_node_provider_rewards::Version,
+        ArchivedMonthlyNodeProviderRewards, MonthlyNodeProviderRewards,
     },
     storage::with_node_provider_rewards_log,
 };
-use ic_stable_structures::{Memory, Storable};
+
+// Filter type
+#[derive(Default)]
+pub struct DateRangeFilter {
+    start: Option<u64>,
+    end: Option<u64>,
+}
+
+// Conversion from API type
+impl From<ic_nns_governance_api::pb::v1::DateRangeFilter> for DateRangeFilter {
+    fn from(filter: ic_nns_governance_api::pb::v1::DateRangeFilter) -> Self {
+        Self {
+            start: filter.start_timestamp_seconds,
+            end: filter.end_timestamp_seconds,
+        }
+    }
+}
 
 pub(crate) fn record_node_provider_rewards(most_recent_rewards: MonthlyNodeProviderRewards) {
     let rewards = ArchivedMonthlyNodeProviderRewards {
@@ -34,19 +50,51 @@ pub(crate) fn latest_node_provider_rewards() -> Option<ArchivedMonthlyNodeProvid
 pub(crate) fn list_node_provider_rewards(
     limit: u64,
     page: Option<u32>,
+    date_filter: Option<DateRangeFilter>,
 ) -> (Option<u32>, Vec<ArchivedMonthlyNodeProviderRewards>) {
     let page = page.unwrap_or(0);
 
+    let date_filter = date_filter.unwrap_or_default();
+    let start_timestamp = date_filter.start.unwrap_or(0);
+    let end_timestamp = date_filter.end.unwrap_or(u64::MAX);
     // If we have 10 entries, they're 0..9
     // If we are getting newest first, we want to return 9..4, then 4..0
 
     with_node_provider_rewards_log(|log| {
-        let len = log.len();
+        // naive filtering implementation is okay b/c our data set is very small
+        // (1/month for years will not give us much to work through for some time)
+        // TODO - migrate to BTreeMap storage...
+        let rewards = log
+            .iter()
+            .flat_map(|rewards| {
+                let timestamp = rewards
+                    .version
+                    .clone()
+                    .and_then(|v| match v {
+                        Version::Version1(v1) => Some(v1),
+                    })
+                    .and_then(|v1| v1.rewards)
+                    .and_then(|rewards| Some(rewards.timestamp));
+
+                if let Some(timestamp) = timestamp {
+                    if timestamp >= start_timestamp && timestamp <= end_timestamp {
+                        Some(rewards)
+                    } else {
+                        None
+                    }
+                } else {
+                    return None;
+                }
+            })
+            .collect::<Vec<_>>();
+
+        let len: u64 = rewards.len().try_into().unwrap();
+
         let end_range = len.saturating_sub(page as u64 * limit);
         let start_range = end_range.saturating_sub(limit);
         let rewards = (start_range..end_range)
             .rev()
-            .flat_map(|index| log.get(index))
+            .map(|index| rewards[index as usize].clone())
             .collect();
 
         if start_range == 0 {

--- a/rs/nns/integration_tests/src/node_provider_remuneration.rs
+++ b/rs/nns/integration_tests/src/node_provider_remuneration.rs
@@ -296,6 +296,28 @@ fn test_list_node_provider_rewards() {
             page: None,
             date_filter: Some(DateRangeFilter {
                 start_timestamp_seconds: Some(minted_rewards_timestamps[9]),
+                end_timestamp_seconds: None,
+            }),
+        },
+    );
+    let received_ts: Vec<u64> = response.rewards.iter().map(|r| r.timestamp).collect();
+    assert_eq!(
+        received_ts,
+        minted_rewards_timestamps[9..13]
+            .into_iter()
+            .rev()
+            .cloned()
+            .collect::<Vec<_>>()
+    );
+    assert_eq!(response.next_page, None);
+
+    // Next we test the date filter with a start and end_date
+    let response = nns_list_node_provider_rewards(
+        &state_machine,
+        ListNodeProviderRewardsRequest {
+            page: None,
+            date_filter: Some(DateRangeFilter {
+                start_timestamp_seconds: Some(minted_rewards_timestamps[9]),
                 end_timestamp_seconds: Some(minted_rewards_timestamps[11]),
             }),
         },
@@ -310,8 +332,6 @@ fn test_list_node_provider_rewards() {
             .collect::<Vec<_>>()
     );
     assert_eq!(response.next_page, None);
-
-    // Next we test the date filter with a start and end_date
 }
 #[test]
 fn test_automated_node_provider_remuneration() {

--- a/rs/nns/integration_tests/src/node_provider_remuneration.rs
+++ b/rs/nns/integration_tests/src/node_provider_remuneration.rs
@@ -15,8 +15,8 @@ use ic_nns_governance_api::pb::v1::{
     manage_neuron_response::Command as CommandResponse,
     reward_node_provider::{RewardMode, RewardToAccount},
     AddOrRemoveNodeProvider, ExecuteNnsFunction, GovernanceError, ListNodeProviderRewardsRequest,
-    MakeProposalRequest, NetworkEconomics, NnsFunction, NodeProvider, ProposalActionRequest,
-    RewardNodeProvider, RewardNodeProviders,
+    MakeProposalRequest, NetworkEconomics, NnsFunction, NodeProvider, Proposal,
+    ProposalActionRequest, RewardNodeProvider, RewardNodeProviders,
 };
 use ic_nns_test_utils::{
     common::NnsInitPayloadsBuilder,
@@ -120,7 +120,6 @@ fn test_list_node_provider_rewards() {
         nns_get_monthly_node_provider_rewards(&state_machine);
 
     let monthly_node_provider_rewards = monthly_node_provider_rewards_result.unwrap();
-
     assert!(monthly_node_provider_rewards
         .rewards
         .contains(&expected_node_provider_reward_1));
@@ -195,8 +194,13 @@ fn test_list_node_provider_rewards() {
         minted_rewards.push(rewards.clone());
     }
 
-    let response =
-        nns_list_node_provider_rewards(&state_machine, ListNodeProviderRewardsRequest {});
+    let response = nns_list_node_provider_rewards(
+        &state_machine,
+        ListNodeProviderRewardsRequest {
+            page: None,
+            date_filter: None,
+        },
+    );
 
     assert_eq!(response.rewards.len(), 5);
 

--- a/rs/nns/integration_tests/src/node_provider_remuneration.rs
+++ b/rs/nns/integration_tests/src/node_provider_remuneration.rs
@@ -207,7 +207,15 @@ fn test_list_node_provider_rewards() {
     let received_ts: Vec<u64> = response.rewards.iter().map(|r| r.timestamp).collect();
     let minted_rewards_timestamps: Vec<u64> = minted_rewards.iter().map(|r| r.timestamp).collect();
 
-    // First we test paging all the results with no filters.
+    println!(
+        "{:?}",
+        minted_rewards_timestamps
+            .iter()
+            .rev()
+            .cloned()
+            .collect::<Vec<_>>()
+    );
+
     assert_eq!(
         received_ts,
         minted_rewards_timestamps[8..13]
@@ -226,6 +234,45 @@ fn test_list_node_provider_rewards() {
             .cloned()
             .collect::<Vec<_>>()
     );
+    assert_eq!(response.next_page, Some(1));
+
+    let response = nns_list_node_provider_rewards(
+        &state_machine,
+        ListNodeProviderRewardsRequest {
+            page: response.next_page,
+            date_filter: None,
+        },
+    );
+
+    let received_ts: Vec<u64> = response.rewards.iter().map(|r| r.timestamp).collect();
+    assert_eq!(
+        received_ts,
+        minted_rewards_timestamps[3..8]
+            .into_iter()
+            .rev()
+            .cloned()
+            .collect::<Vec<_>>()
+    );
+    assert_eq!(response.next_page, Some(2));
+
+    let response = nns_list_node_provider_rewards(
+        &state_machine,
+        ListNodeProviderRewardsRequest {
+            page: response.next_page,
+            date_filter: None,
+        },
+    );
+
+    let received_ts: Vec<u64> = response.rewards.iter().map(|r| r.timestamp).collect();
+    assert_eq!(
+        received_ts,
+        minted_rewards_timestamps[0..3]
+            .into_iter()
+            .rev()
+            .cloned()
+            .collect::<Vec<_>>()
+    );
+    assert_eq!(response.next_page, None);
 }
 #[test]
 fn test_automated_node_provider_remuneration() {

--- a/rs/nns/integration_tests/src/node_provider_remuneration.rs
+++ b/rs/nns/integration_tests/src/node_provider_remuneration.rs
@@ -16,7 +16,7 @@ use ic_nns_governance_api::pb::v1::{
     reward_node_provider::{RewardMode, RewardToAccount},
     AddOrRemoveNodeProvider, DateRangeFilter, ExecuteNnsFunction, GovernanceError,
     ListNodeProviderRewardsRequest, MakeProposalRequest, NetworkEconomics, NnsFunction,
-    NodeProvider, Proposal, ProposalActionRequest, RewardNodeProvider, RewardNodeProviders,
+    NodeProvider, ProposalActionRequest, RewardNodeProvider, RewardNodeProviders,
 };
 use ic_nns_test_utils::{
     common::NnsInitPayloadsBuilder,
@@ -241,7 +241,7 @@ fn test_list_node_provider_rewards() {
     assert_eq!(
         received_ts,
         minted_rewards_timestamps[3..8]
-            .into_iter()
+            .iter()
             .rev()
             .cloned()
             .collect::<Vec<_>>()
@@ -260,7 +260,7 @@ fn test_list_node_provider_rewards() {
     assert_eq!(
         received_ts,
         minted_rewards_timestamps[0..3]
-            .into_iter()
+            .iter()
             .rev()
             .cloned()
             .collect::<Vec<_>>()
@@ -282,7 +282,7 @@ fn test_list_node_provider_rewards() {
     assert_eq!(
         received_ts,
         minted_rewards_timestamps[7..12]
-            .into_iter()
+            .iter()
             .rev()
             .cloned()
             .collect::<Vec<_>>()
@@ -304,7 +304,7 @@ fn test_list_node_provider_rewards() {
     assert_eq!(
         received_ts,
         minted_rewards_timestamps[9..13]
-            .into_iter()
+            .iter()
             .rev()
             .cloned()
             .collect::<Vec<_>>()
@@ -326,7 +326,7 @@ fn test_list_node_provider_rewards() {
     assert_eq!(
         received_ts,
         minted_rewards_timestamps[9..12]
-            .into_iter()
+            .iter()
             .rev()
             .cloned()
             .collect::<Vec<_>>()

--- a/rs/nns/integration_tests/src/node_provider_remuneration.rs
+++ b/rs/nns/integration_tests/src/node_provider_remuneration.rs
@@ -196,22 +196,18 @@ fn test_list_node_provider_rewards() {
 
     let response = nns_list_node_provider_rewards(
         &state_machine,
-        ListNodeProviderRewardsRequest {
-            page: None,
-            date_filter: None,
-        },
+        ListNodeProviderRewardsRequest { date_filter: None },
     );
 
-    assert_eq!(response.rewards.len(), 5);
+    assert_eq!(response.rewards.len(), 13);
 
     let received_ts: Vec<u64> = response.rewards.iter().map(|r| r.timestamp).collect();
     let minted_rewards_timestamps: Vec<u64> = minted_rewards.iter().map(|r| r.timestamp).collect();
 
-    println!("{:?}", minted_rewards_timestamps);
-    // First we test paging all the results with no filters.
+    // First we test getting all the results with no filters.
     assert_eq!(
         received_ts,
-        minted_rewards_timestamps[8..13]
+        minted_rewards_timestamps[..]
             .iter()
             .rev()
             .cloned()
@@ -221,57 +217,13 @@ fn test_list_node_provider_rewards() {
     // check rewards are as expected
     assert_eq!(
         response.rewards,
-        minted_rewards[8..13]
-            .iter()
-            .rev()
-            .cloned()
-            .collect::<Vec<_>>()
+        minted_rewards[..].iter().rev().cloned().collect::<Vec<_>>()
     );
-    assert_eq!(response.next_page, Some(1));
-
-    let response = nns_list_node_provider_rewards(
-        &state_machine,
-        ListNodeProviderRewardsRequest {
-            page: response.next_page,
-            date_filter: None,
-        },
-    );
-
-    let received_ts: Vec<u64> = response.rewards.iter().map(|r| r.timestamp).collect();
-    assert_eq!(
-        received_ts,
-        minted_rewards_timestamps[3..8]
-            .iter()
-            .rev()
-            .cloned()
-            .collect::<Vec<_>>()
-    );
-    assert_eq!(response.next_page, Some(2));
-
-    let response = nns_list_node_provider_rewards(
-        &state_machine,
-        ListNodeProviderRewardsRequest {
-            page: response.next_page,
-            date_filter: None,
-        },
-    );
-
-    let received_ts: Vec<u64> = response.rewards.iter().map(|r| r.timestamp).collect();
-    assert_eq!(
-        received_ts,
-        minted_rewards_timestamps[0..3]
-            .iter()
-            .rev()
-            .cloned()
-            .collect::<Vec<_>>()
-    );
-    assert_eq!(response.next_page, None);
 
     // Next we test the date filter with no start_date
     let response = nns_list_node_provider_rewards(
         &state_machine,
         ListNodeProviderRewardsRequest {
-            page: None,
             date_filter: Some(DateRangeFilter {
                 start_timestamp_seconds: None,
                 end_timestamp_seconds: Some(minted_rewards_timestamps[11]),
@@ -281,19 +233,17 @@ fn test_list_node_provider_rewards() {
     let received_ts: Vec<u64> = response.rewards.iter().map(|r| r.timestamp).collect();
     assert_eq!(
         received_ts,
-        minted_rewards_timestamps[7..12]
+        minted_rewards_timestamps[0..=11]
             .iter()
             .rev()
             .cloned()
             .collect::<Vec<_>>()
     );
-    assert_eq!(response.next_page, Some(1));
 
     // Next we test the date filter with no end_date
     let response = nns_list_node_provider_rewards(
         &state_machine,
         ListNodeProviderRewardsRequest {
-            page: None,
             date_filter: Some(DateRangeFilter {
                 start_timestamp_seconds: Some(minted_rewards_timestamps[9]),
                 end_timestamp_seconds: None,
@@ -303,19 +253,17 @@ fn test_list_node_provider_rewards() {
     let received_ts: Vec<u64> = response.rewards.iter().map(|r| r.timestamp).collect();
     assert_eq!(
         received_ts,
-        minted_rewards_timestamps[9..13]
+        minted_rewards_timestamps[9..]
             .iter()
             .rev()
             .cloned()
             .collect::<Vec<_>>()
     );
-    assert_eq!(response.next_page, None);
 
     // Next we test the date filter with a start and end_date
     let response = nns_list_node_provider_rewards(
         &state_machine,
         ListNodeProviderRewardsRequest {
-            page: None,
             date_filter: Some(DateRangeFilter {
                 start_timestamp_seconds: Some(minted_rewards_timestamps[9]),
                 end_timestamp_seconds: Some(minted_rewards_timestamps[11]),
@@ -325,13 +273,12 @@ fn test_list_node_provider_rewards() {
     let received_ts: Vec<u64> = response.rewards.iter().map(|r| r.timestamp).collect();
     assert_eq!(
         received_ts,
-        minted_rewards_timestamps[9..12]
+        minted_rewards_timestamps[9..=11]
             .iter()
             .rev()
             .cloned()
             .collect::<Vec<_>>()
     );
-    assert_eq!(response.next_page, None);
 }
 #[test]
 fn test_automated_node_provider_remuneration() {

--- a/rs/nns/test_utils/src/state_test_helpers.rs
+++ b/rs/nns/test_utils/src/state_test_helpers.rs
@@ -46,12 +46,11 @@ use ic_nns_governance_api::pb::v1::{
         JoinCommunityFund, LeaveCommunityFund, RegisterVote, RemoveHotKey, Split, StakeMaturity,
     },
     manage_neuron_response::{self, ClaimOrRefreshResponse},
-    Empty, ExecuteNnsFunction, Governance, GovernanceError, InstallCode, InstallCodeRequest,
-    ListNeurons, ListNeuronsResponse, ListNodeProviderRewardsRequest,
-    ListNodeProviderRewardsResponse, ListProposalInfo, ListProposalInfoResponse,
-    MakeProposalRequest, ManageNeuron, ManageNeuronCommandRequest, ManageNeuronRequest,
-    ManageNeuronResponse, MonthlyNodeProviderRewards, NetworkEconomics, NnsFunction, Proposal,
-    ProposalActionRequest, ProposalInfo, RewardNodeProviders, Vote,
+    Empty, ExecuteNnsFunction, Governance, GovernanceError, InstallCodeRequest, ListNeurons,
+    ListNeuronsResponse, ListNodeProviderRewardsRequest, ListNodeProviderRewardsResponse,
+    ListProposalInfo, ListProposalInfoResponse, MakeProposalRequest, ManageNeuronCommandRequest,
+    ManageNeuronRequest, ManageNeuronResponse, MonthlyNodeProviderRewards, NetworkEconomics,
+    NnsFunction, ProposalActionRequest, ProposalInfo, RewardNodeProviders, Vote,
 };
 use ic_nns_handler_lifeline_interface::UpgradeRootProposal;
 use ic_nns_handler_root::init::RootCanisterInitPayload;

--- a/rs/nns/test_utils/src/state_test_helpers.rs
+++ b/rs/nns/test_utils/src/state_test_helpers.rs
@@ -46,11 +46,12 @@ use ic_nns_governance_api::pb::v1::{
         JoinCommunityFund, LeaveCommunityFund, RegisterVote, RemoveHotKey, Split, StakeMaturity,
     },
     manage_neuron_response::{self, ClaimOrRefreshResponse},
-    Empty, ExecuteNnsFunction, Governance, GovernanceError, InstallCodeRequest, ListNeurons,
-    ListNeuronsResponse, ListNodeProviderRewardsRequest, ListNodeProviderRewardsResponse,
-    ListProposalInfo, ListProposalInfoResponse, MakeProposalRequest, ManageNeuronCommandRequest,
-    ManageNeuronRequest, ManageNeuronResponse, MonthlyNodeProviderRewards, NetworkEconomics,
-    NnsFunction, ProposalActionRequest, ProposalInfo, RewardNodeProviders, Vote,
+    Empty, ExecuteNnsFunction, Governance, GovernanceError, InstallCode, InstallCodeRequest,
+    ListNeurons, ListNeuronsResponse, ListNodeProviderRewardsRequest,
+    ListNodeProviderRewardsResponse, ListProposalInfo, ListProposalInfoResponse,
+    MakeProposalRequest, ManageNeuron, ManageNeuronCommandRequest, ManageNeuronRequest,
+    ManageNeuronResponse, MonthlyNodeProviderRewards, NetworkEconomics, NnsFunction, Proposal,
+    ProposalActionRequest, ProposalInfo, RewardNodeProviders, Vote,
 };
 use ic_nns_handler_lifeline_interface::UpgradeRootProposal;
 use ic_nns_handler_root::init::RootCanisterInitPayload;


### PR DESCRIPTION
Add simple date filtering to list_node_provider_rewards to allow selecting individual reward events.

Also increases rewards limit to 24, as each reward event is about 18kb, so 24 is still only 432kb which gives a lot of room for increasing reward data sizes in the future.