### PR TITLE
chore(IDX): Add `languages` team channel

### DIFF
--- a/.github/workflows/team-channels.json
+++ b/.github/workflows/team-channels.json
@@ -12,6 +12,7 @@
     "ic-owners-owners": "owners-owners",
     "idx": "eng-idx-bots",
     "InfraSec": "eng-infrasec",
+    "languages": "eng-motoko",
     "networking": "eng-networking",
     "nns-team": "eng-nns",
     "node": "eng-node-prs",
@@ -20,6 +21,5 @@
     "Product Security": "eng-prodsec",
     "runtime": "runtime-code-reviews",
     "sdk": "sdk",
-    "utopia": "eng-utopia",
-    "languages": "eng-motoko"
+    "utopia": "eng-utopia"
 }

--- a/.github/workflows/team-channels.json
+++ b/.github/workflows/team-channels.json
@@ -20,5 +20,6 @@
     "Product Security": "eng-prodsec",
     "runtime": "runtime-code-reviews",
     "sdk": "sdk",
-    "utopia": "eng-utopia"
+    "utopia": "eng-utopia",
+    "languages": "eng-motoko"
 }


### PR DESCRIPTION
Add Slack channel for "languages" team as used for PR notifications of `drun`, see https://github.com/dfinity/ic/pull/565.