### PR TITLE
fix(IDX): Fix `nix` MacOs build for `rocksdb` dependency

### DIFF
--- a/rs/artifact_pool/Cargo.toml
+++ b/rs/artifact_pool/Cargo.toml
@@ -31,7 +31,7 @@ strum = { workspace = true }
 tempfile = { workspace = true }
 
 # Support for rocksdb backend on macos
-[target.'cfg(macos)'.dependencies]
+[target.'cfg(target_os = "macos")'.dependencies]
 rocksdb = { version = "0.22.0", default-features = false }
 
 [dev-dependencies]


### PR DESCRIPTION
Currently, `nix` build fails on MacOS saying that the `rocksdb` dependency is missing. (We still use `nix` for Motoko's CI.) 

I believe, the reason is that `macos` is not a target family but only a target OS. This change resolves this problem.