### PR TITLE
feat(nns): Automatically set SNS Governance, Ledger, Index, Archive canisters memory limits once

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11437,6 +11437,7 @@ dependencies = [
  "ic-nervous-system-common-build-metadata",
  "ic-nervous-system-root",
  "ic-nervous-system-runtime",
+ "ic-nns-constants",
  "ic-sns-root-protobuf-generator",
  "ic-sns-swap",
  "ic-test-utilities-compare-dirs",

--- a/rs/sns/init/src/lib.rs
+++ b/rs/sns/init/src/lib.rs
@@ -670,6 +670,8 @@ impl SnsInitPayload {
             latest_ledger_archive_poll_timestamp_seconds: None,
             index_canister_id: Some(sns_canister_ids.index),
             testflight,
+            // Newly created canisters don't need their memory limit updated.
+            updated_framework_canisters_memory_limit: Some(true),
         }
     }
 

--- a/rs/sns/integration_tests/src/root.rs
+++ b/rs/sns/integration_tests/src/root.rs
@@ -44,6 +44,7 @@ fn test_get_status() {
                 latest_ledger_archive_poll_timestamp_seconds: None,
                 index_canister_id: Some(PrincipalId::new_user_test_id(45)),
                 testflight: false,
+                updated_framework_canisters_memory_limit: Some(true),
             },
         )
         .await;

--- a/rs/sns/root/BUILD.bazel
+++ b/rs/sns/root/BUILD.bazel
@@ -17,6 +17,7 @@ DEPENDENCIES = [
     "//rs/nervous_system/common",
     "//rs/nervous_system/root",
     "//rs/nervous_system/runtime",
+    "//rs/nns/constants",
     "//rs/rust_canisters/canister_log",
     "//rs/rust_canisters/http_types",
     "//rs/sns/swap",  # TODO[NNS1-2282]

--- a/rs/sns/root/Cargo.toml
+++ b/rs/sns/root/Cargo.toml
@@ -30,6 +30,7 @@ ic-nervous-system-common = { path = "../../nervous_system/common" }
 ic-nervous-system-common-build-metadata = { path = "../../nervous_system/common/build_metadata" }
 ic-nervous-system-root = { path = "../../nervous_system/root" }
 ic-nervous-system-runtime = { path = "../../nervous_system/runtime" }
+ic-nns-constants = { path = "../../nns/constants" }
 ic-sns-swap = { path = "../swap" }
 icrc-ledger-types = { path = "../../../packages/icrc-ledger-types" }
 prost = { workspace = true }

--- a/rs/sns/root/canister/canister.rs
+++ b/rs/sns/root/canister/canister.rs
@@ -362,8 +362,9 @@ async fn heartbeat() {
     // dependencies to run_periodic_tasks.
     let now = CanisterEnvironment {}.now();
     let ledger_client = create_ledger_client();
+    let management_canister = ManagementCanisterClientImpl::<CanisterRuntime>::new(None);
 
-    SnsRootCanister::heartbeat(&STATE, &ledger_client, now).await
+    SnsRootCanister::heartbeat(&STATE, &management_canister, &ledger_client, now).await
 }
 
 // Resources to serve for a given http_request

--- a/rs/sns/root/canister/root.did
+++ b/rs/sns/root/canister/root.did
@@ -98,6 +98,7 @@ type SnsRootCanister = record {
   index_canister_id : opt principal;
   swap_canister_id : opt principal;
   ledger_canister_id : opt principal;
+  updated_framework_canisters_memory_limit : opt bool;
 };
 service : (SnsRootCanister) -> {
   canister_status : (CanisterIdRecord) -> (CanisterStatusResult);

--- a/rs/sns/root/proto/ic_sns_root/pb/v1/root.proto
+++ b/rs/sns/root/proto/ic_sns_root/pb/v1/root.proto
@@ -45,6 +45,10 @@ message SnsRootCanister {
   // True if the SNS is running in testflight mode. Then additional
   // controllers beyond SNS root are allowed when registering a dapp.
   bool testflight = 8;
+
+  // Set to `true` if the framework canisters' memory limit doesn't need to be changed
+  // TODO(NNS1-3286): remove
+  optional bool updated_framework_canisters_memory_limit = 9;
 }
 
 message RegisterDappCanisterRequest {

--- a/rs/sns/root/src/gen/ic_sns_root.pb.v1.rs
+++ b/rs/sns/root/src/gen/ic_sns_root.pb.v1.rs
@@ -43,6 +43,10 @@ pub struct SnsRootCanister {
     /// controllers beyond SNS root are allowed when registering a dapp.
     #[prost(bool, tag = "8")]
     pub testflight: bool,
+    /// Set to `true` if the framework canisters' memory limit doesn't need to be changed
+    /// TODO(NNS1-3286): remove
+    #[prost(bool, optional, tag = "9")]
+    pub updated_framework_canisters_memory_limit: ::core::option::Option<bool>,
 }
 #[derive(candid::CandidType, candid::Deserialize, comparable::Comparable)]
 #[allow(clippy::derive_partial_eq_without_eq)]

--- a/rs/sns/root/src/lib.rs
+++ b/rs/sns/root/src/lib.rs
@@ -20,6 +20,7 @@ use ic_nervous_system_clients::{
     update_settings::{CanisterSettings, LogVisibility, UpdateSettings},
 };
 use ic_nervous_system_runtime::{CdkRuntime, Runtime};
+use ic_nns_constants::DEFAULT_SNS_FRAMEWORK_CANISTER_WASM_MEMORY_LIMIT;
 use ic_sns_swap::pb::v1::GetCanisterStatusRequest;
 use std::{
     cell::RefCell,
@@ -704,9 +705,74 @@ impl SnsRootCanister {
         }
     }
 
+    pub async fn maybe_update_framework_canisters_memory_limit(
+        self_ref: &'static LocalKey<RefCell<Self>>,
+        management_canister_client: &impl ManagementCanisterClient,
+    ) {
+        // Get Some(canisters) if state.updated_framework_canisters_memory_limit != Some(true).
+        // or None otherwise
+        let canisters = self_ref.with(|state: &RefCell<SnsRootCanister>| {
+            let mut state = state.borrow_mut();
+            // If we have not updated the framework canisters' memory limit
+            if !state
+                .updated_framework_canisters_memory_limit
+                .unwrap_or_default()
+            {
+                state.updated_framework_canisters_memory_limit = Some(true);
+
+                // Since root doesn't own itself, we can't update root automatically
+                // We also can't upgrade Swap as it's owned by the NNS
+                let governance = state.governance_canister_id();
+                let ledger = state.ledger_canister_id();
+                let archives = state.archive_canister_ids.clone();
+                let index = state.index_canister_id();
+
+                Some(
+                    vec![governance, ledger, index]
+                        .into_iter()
+                        .chain(archives.into_iter())
+                        .collect::<Vec<_>>(),
+                )
+            } else {
+                None
+            }
+        });
+        // Update the canisters' settings
+        if let Some(canisters) = canisters {
+            for canister_id in canisters {
+                // Update their settings to set wasm_memory_limit to 4GiB
+                let settings = CanisterSettings {
+                    wasm_memory_limit: Some(Nat::from(
+                        DEFAULT_SNS_FRAMEWORK_CANISTER_WASM_MEMORY_LIMIT,
+                    )),
+                    ..Default::default()
+                };
+                if let Err(error) = management_canister_client
+                    .update_settings(UpdateSettings {
+                        canister_id,
+                        settings,
+                        sender_canister_version: management_canister_client.canister_version(),
+                    })
+                    .await
+                {
+                    log!(
+                        ERROR,
+                        "Failed to update memory limit for canister {canister_id}: {error:?}"
+                    );
+                } else {
+                    log!(
+                        INFO,
+                        "Successfully changed memory limit for canister {canister_id}"
+                    );
+                }
+            }
+        }
+    }
+
     /// Runs periodic tasks that are not directly triggered by user input.
     pub async fn heartbeat(
         self_ref: &'static LocalKey<RefCell<Self>>,
+        management_canister_client: &impl ManagementCanisterClient,
         ledger_client: &impl LedgerCanisterClient,
         current_timestamp_seconds: u64,
     ) {
@@ -726,6 +792,10 @@ impl SnsRootCanister {
             )
             .await;
         }
+
+        // TODO(NNS1-3286): Remove once root with this code has been released
+        Self::maybe_update_framework_canisters_memory_limit(self_ref, management_canister_client)
+            .await;
     }
 
     /// Polls for new archives canisters from the
@@ -1021,6 +1091,7 @@ mod tests {
             latest_ledger_archive_poll_timestamp_seconds: None,
             index_canister_id: Some(PrincipalId::new_user_test_id(4)),
             testflight,
+            updated_framework_canisters_memory_limit: Some(true),
         }
     }
 
@@ -2676,6 +2747,40 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_maybe_update_framework_canisters_memory_limit() {
+        // Step 1: Prepare the world.
+        thread_local! {
+            static SNS_ROOT_CANISTER: RefCell<SnsRootCanister> = RefCell::new(
+                SnsRootCanister {
+                    updated_framework_canisters_memory_limit: Some(false),
+                    ..build_test_sns_root_canister(false)
+                }
+            );
+        }
+
+        let management_canister_client = MockManagementCanisterClient::new(vec![
+            MockManagementCanisterClientReply::UpdateSettings(Ok(())),
+            MockManagementCanisterClientReply::UpdateSettings(Ok(())),
+            MockManagementCanisterClientReply::UpdateSettings(Ok(())),
+        ]);
+
+        SnsRootCanister::maybe_update_framework_canisters_memory_limit(
+            &SNS_ROOT_CANISTER,
+            &management_canister_client,
+        )
+        .await;
+
+        management_canister_client.assert_all_replies_consumed();
+
+        // If we call it again it shouldn't send any messages, and therefore not require any replies
+        SnsRootCanister::maybe_update_framework_canisters_memory_limit(
+            &SNS_ROOT_CANISTER,
+            &management_canister_client,
+        )
+        .await;
+    }
+
+    #[tokio::test]
     async fn test_heartbeat() {
         // Step 1: Prepare the world.
         thread_local! {
@@ -2710,7 +2815,13 @@ mod tests {
         ]);
 
         // Step 2: Call the code under test.
-        SnsRootCanister::heartbeat(&SNS_ROOT_CANISTER, &ledger_canister_client, NOW).await;
+        SnsRootCanister::heartbeat(
+            &SNS_ROOT_CANISTER,
+            &MockManagementCanisterClient::new(vec![]),
+            &ledger_canister_client,
+            NOW,
+        )
+        .await;
 
         // Step 3: Inspect results.
         assert_archive_poll_state_change(
@@ -2721,7 +2832,13 @@ mod tests {
 
         // Running periodic tasks one second in the future should
         // result in no change to state.
-        SnsRootCanister::heartbeat(&SNS_ROOT_CANISTER, &ledger_canister_client, NOW + 1).await;
+        SnsRootCanister::heartbeat(
+            &SNS_ROOT_CANISTER,
+            &MockManagementCanisterClient::new(vec![]),
+            &ledger_canister_client,
+            NOW + 1,
+        )
+        .await;
 
         assert_archive_poll_state_change(
             &SNS_ROOT_CANISTER,
@@ -2733,6 +2850,7 @@ mod tests {
         // result in a new poll.
         SnsRootCanister::heartbeat(
             &SNS_ROOT_CANISTER,
+            &MockManagementCanisterClient::new(vec![]),
             &ledger_canister_client,
             NOW + ONE_DAY_SECONDS,
         )
@@ -2879,7 +2997,13 @@ mod tests {
             };
 
         // Step 2: Call the code under test.
-        SnsRootCanister::heartbeat(&SNS_ROOT_CANISTER, &ledger_canister_client, NOW).await;
+        SnsRootCanister::heartbeat(
+            &SNS_ROOT_CANISTER,
+            &MockManagementCanisterClient::new(vec![]),
+            &ledger_canister_client,
+            NOW,
+        )
+        .await;
 
         // We should now have a single Archive canister registered.
         assert_archive_poll_state_change(
@@ -2989,6 +3113,7 @@ mod tests {
                 latest_ledger_archive_poll_timestamp_seconds: None,
                 index_canister_id: Some(PrincipalId::new_user_test_id(4)),
                 testflight: false,
+                updated_framework_canisters_memory_limit: Some(true),
             });
         }
 
@@ -3141,6 +3266,7 @@ mod tests {
                 latest_ledger_archive_poll_timestamp_seconds: None,
                 index_canister_id: Some(PrincipalId::new_user_test_id(4)),
                 testflight: false,
+                updated_framework_canisters_memory_limit: Some(true),
             });
         }
 
@@ -3370,6 +3496,7 @@ mod tests {
                 latest_ledger_archive_poll_timestamp_seconds: None,
                 index_canister_id: Some(PrincipalId::new_user_test_id(4)),
                 testflight: false,
+                updated_framework_canisters_memory_limit: Some(true),
             });
         }
 


### PR DESCRIPTION
See the description of [NNS1-3202](https://dfinity.atlassian.net/browse/NNS1-3202).

The objective is to set SNS Framework canisters' memory limits to be explicitly 4GiB, rather than None, which will unblock the ongoing effort to change the default when it is not explicitly set.

Changing the memory limits of swap and root will need to be done separately, as they cannot be changed by root

[NNS1-3202]: https://dfinity.atlassian.net/browse/NNS1-3202?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ