### PR TITLE
fix(PSEC): only run dep-scan-nightly on master

### DIFF
--- a/.github/workflows/schedule-daily.yml
+++ b/.github/workflows/schedule-daily.yml
@@ -196,6 +196,7 @@ jobs:
             profile.json
   dependency-scan-nightly:
     name: Dependency Scan Nightly
+    if: github.ref == 'refs/heads/master'
     runs-on:
       group: zh1
       labels: dind-large


### PR DESCRIPTION
The `dependency-scan-nightly` job in the `schedule-daily` workflow should only run on the master branch.