### PR TITLE
chore(crypto): CRP-2575: bump ic-signature-verification version to 0.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11161,7 +11161,7 @@ dependencies = [
 
 [[package]]
 name = "ic-signature-verification"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "assert_matches",
  "hex",

--- a/packages/ic-signature-verification/CHANGELOG.md
+++ b/packages/ic-signature-verification/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.0] - 2024-08-20
+
+### Added
+
+- Upgrade ic-verify-bls-signature from 0.2 to 0.6.
+- Use ic-verify-bls-signature without the `rand` feature. This allows for compilation to WASM.
+- Point documentation to docs.rs.
+
 ## [0.1.0] - 2024-07-24
 
 ### Added

--- a/packages/ic-signature-verification/Cargo.toml
+++ b/packages/ic-signature-verification/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic-signature-verification"
-version = "0.1.0"
+version = "0.2.0"
 description = "Verification of signatures supported by the Internet Computer"
 license = "Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION
Bumps `ic-signature-verification`'s version to 0.2.0 and updates the changelog.