### PR TITLE
chore: Bump governance-canister / governance-canister_test compressed WASM size limit from 1.3 to 1.4 MB

### DIFF
--- a/publish/canisters/BUILD.bazel
+++ b/publish/canisters/BUILD.bazel
@@ -85,8 +85,8 @@ CANISTERS_MAX_SIZE_COMPRESSED_E5_BYTES = {
 NNS_CANISTERS_MAX_SIZE_COMPRESSED_E5_BYTES = {
     "cycles-minting-canister.wasm.gz": "5",
     "genesis-token-canister.wasm.gz": "3",
-    "governance-canister.wasm.gz": "13",
-    "governance-canister_test.wasm.gz": "13",
+    "governance-canister.wasm.gz": "14",
+    "governance-canister_test.wasm.gz": "14",
     "registry-canister.wasm.gz": "13",
     "root-canister.wasm.gz": "4",
 }


### PR DESCRIPTION
This PR mitigates the recent growth of the compressed WASM size of the NNS Governance canister by bumping the size limit from 1.3 to 1.4 MB.