### PR TITLE
fix(IDX): update darwin trigger logic

### DIFF
--- a/.github/workflows-source/ci-main.yml
+++ b/.github/workflows-source/ci-main.yml
@@ -190,7 +190,7 @@ jobs:
       - <<: *before-script
       - name: Run Bazel Test Darwin x86-64
         id: bazel-test-darwin-x86-64
-        if: steps.filter.outputs.bazel-test-darwin-x86-64 == 'true' || github.event_name == 'schedule'
+        if: steps.filter.outputs.bazel-test-darwin-x86-64 == 'true' || github.event_name != 'pull_request'
         uses:  ./.github/actions/bazel-test-all/
         with:
           BAZEL_CI_CONFIG: "--config=ci --config macos_ci"

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -176,7 +176,7 @@ jobs:
         run: ./gitlab-ci/src/ci-scripts/before-script.sh
       - name: Run Bazel Test Darwin x86-64
         id: bazel-test-darwin-x86-64
-        if: steps.filter.outputs.bazel-test-darwin-x86-64 == 'true' || github.event_name == 'schedule'
+        if: steps.filter.outputs.bazel-test-darwin-x86-64 == 'true' || github.event_name != 'pull_request'
         uses: ./.github/actions/bazel-test-all/
         with:
           BAZEL_CI_CONFIG: "--config=ci --config macos_ci"


### PR DESCRIPTION
Because RC branches can also be manually triggered we want to still run the Darwin tests on all other trigger types. They still won't be triggered on merge trains as we have that logic excluded at the job level.