### PR TITLE
feat(nns-init): Add support for gzipped NNS canister wasms

### DIFF
--- a/rs/nns/init/src/lib.rs
+++ b/rs/nns/init/src/lib.rs
@@ -163,9 +163,8 @@ pub fn set_up_env_vars_for_all_canisters<P: AsRef<Path>>(wasm_dir: P) {
                 continue 'outer;
             }
         }
-        // if no file is found, fail the assert
-        assert!(
-            false,
+        // if no file is found, panic!
+        panic!(
             "The provided --wasm-dir, '{}', must contain all NNS canister wasms, but it misses {}.wasm or {}.wasm.gz",
             wasm_dir.as_ref().display(),
             canister,

--- a/rs/nns/init/src/lib.rs
+++ b/rs/nns/init/src/lib.rs
@@ -151,8 +151,8 @@ pub fn make_hsm_sender(hsm_slot: &str, key_id: &str, pin: &str) -> Sender {
 /// that they can be found later.
 pub fn set_up_env_vars_for_all_canisters<P: AsRef<Path>>(wasm_dir: P) {
     'outer: for canister in &NNS_CANISTER_WASMS {
-        // Can either .wasm or .wasm.gz be found?
-        for ext in &[".wasm", ".wasm.gz"] {
+        // Can either .wasm.gz or .wasm be found?
+        for ext in &[".wasm.gz", ".wasm"] {
             let file_part = format!("{}{}", canister, ext);
             let mut path = wasm_dir.as_ref().to_path_buf();
             path.push(file_part.as_str());
@@ -165,7 +165,7 @@ pub fn set_up_env_vars_for_all_canisters<P: AsRef<Path>>(wasm_dir: P) {
         }
         // if no file is found, panic!
         panic!(
-            "The provided --wasm-dir, '{}', must contain all NNS canister wasms, but it misses {}.wasm or {}.wasm.gz",
+            "The provided --wasm-dir, '{}', must contain all NNS canister wasms, but there is {}.wasm.gz or {}.wasm",
             wasm_dir.as_ref().display(),
             canister,
             canister

--- a/rs/nns/init/src/lib.rs
+++ b/rs/nns/init/src/lib.rs
@@ -150,21 +150,27 @@ pub fn make_hsm_sender(hsm_slot: &str, key_id: &str, pin: &str) -> Sender {
 /// NNS canisters, and sets an environment variable pointing at each of them so
 /// that they can be found later.
 pub fn set_up_env_vars_for_all_canisters<P: AsRef<Path>>(wasm_dir: P) {
-    for canister in &NNS_CANISTER_WASMS {
-        // Can it be found?
-        let file_part = format!("{}.wasm", canister);
-        let mut path = wasm_dir.as_ref().to_path_buf();
-        path.push(file_part.as_str());
+    'outer: for canister in &NNS_CANISTER_WASMS {
+        // Can either .wasm or .wasm.gz be found?
+        for ext in &[".wasm", ".wasm.gz"] {
+            let file_part = format!("{}{}", canister, ext);
+            let mut path = wasm_dir.as_ref().to_path_buf();
+            path.push(file_part.as_str());
+            if path.is_file() {
+                // Sets up the env var following the pattern expected by
+                // WASM::from_location_specified_by_env_var
+                std::env::set_var(Wasm::env_var_name(canister, &[]), path.to_str().unwrap());
+                continue 'outer;
+            }
+        }
+        // if no file is found, fail the assert
         assert!(
-            path.is_file(),
-            "The provided --wasm-dir, '{}', must contain all NNS canister wasms, but it misses {}",
+            false,
+            "The provided --wasm-dir, '{}', must contain all NNS canister wasms, but it misses {}.wasm or {}.wasm.gz",
             wasm_dir.as_ref().display(),
-            file_part
+            canister,
+            canister
         );
-
-        // Sets up the env var following the pattern expected by
-        // WASM::from_location_specified_by_env_var
-        std::env::set_var(Wasm::env_var_name(canister, &[]), path.to_str().unwrap());
     }
 }
 


### PR DESCRIPTION
This commit modifies the `set_up_env_vars_for_all_canisters` function in `lib.rs` to search for NNS canister wasms in the specified directory. It checks for both `.wasm` and `.wasm.gz` files and sets up environment variables accordingly. If a file is not found, it fails with an assertion error, as usual.