### PR TITLE
feat: add a metric to track the total memory usage of XC-canisters

### DIFF
--- a/rs/bitcoin/ckbtc/minter/src/metrics.rs
+++ b/rs/bitcoin/ckbtc/minter/src/metrics.rs
@@ -17,6 +17,12 @@ pub fn encode_metrics(
         "Size of the stable memory allocated by this canister.",
     )?;
 
+    metrics.encode_gauge(
+        "ckbtc_minter_total_memory_bytes",
+        total_memory_size_bytes() as f64,
+        "Total amount of memory (heap and stable memory) that has been allocated by this canister.",
+    )?;
+
     let cycle_balance = ic_cdk::api::canister_balance128() as f64;
 
     metrics.encode_gauge(
@@ -202,4 +208,16 @@ pub fn encode_metrics(
     )?;
 
     Ok(())
+}
+
+/// Returns the total amount of memory (heap, stable memory, etc) that has been allocated.
+#[cfg(target_arch = "wasm32")]
+pub fn total_memory_size_bytes() -> usize {
+    const WASM_PAGE_SIZE_BYTES: usize = 65536;
+    core::arch::wasm32::memory_size(0) * WASM_PAGE_SIZE_BYTES
+}
+
+#[cfg(not(any(target_arch = "wasm32")))]
+pub fn total_memory_size_bytes() -> usize {
+    0
 }

--- a/rs/bitcoin/ckbtc/minter/src/metrics.rs
+++ b/rs/bitcoin/ckbtc/minter/src/metrics.rs
@@ -210,7 +210,7 @@ pub fn encode_metrics(
     Ok(())
 }
 
-/// Returns the total amount of memory (heap, stable memory, etc) that has been allocated.
+/// Returns the total amount of memory (heap and stable memory) that has been allocated.
 #[cfg(target_arch = "wasm32")]
 pub fn total_memory_size_bytes() -> usize {
     const WASM_PAGE_SIZE_BYTES: usize = 65536;

--- a/rs/bitcoin/ckbtc/minter/src/metrics.rs
+++ b/rs/bitcoin/ckbtc/minter/src/metrics.rs
@@ -18,9 +18,9 @@ pub fn encode_metrics(
     )?;
 
     metrics.encode_gauge(
-        "ckbtc_minter_total_memory_bytes",
-        total_memory_size_bytes() as f64,
-        "Total amount of memory (heap and stable memory) that has been allocated by this canister.",
+        "ckbtc_minter_heap_memory_bytes",
+        heap_memory_size_bytes() as f64,
+        "Size of the heap memory allocated by this canister.",
     )?;
 
     let cycle_balance = ic_cdk::api::canister_balance128() as f64;
@@ -210,14 +210,14 @@ pub fn encode_metrics(
     Ok(())
 }
 
-/// Returns the total amount of memory (heap and stable memory) that has been allocated.
+/// Returns the amount of heap memory in bytes that has been allocated.
 #[cfg(target_arch = "wasm32")]
-pub fn total_memory_size_bytes() -> usize {
+pub fn heap_memory_size_bytes() -> usize {
     const WASM_PAGE_SIZE_BYTES: usize = 65536;
     core::arch::wasm32::memory_size(0) * WASM_PAGE_SIZE_BYTES
 }
 
 #[cfg(not(any(target_arch = "wasm32")))]
-pub fn total_memory_size_bytes() -> usize {
+pub fn heap_memory_size_bytes() -> usize {
     0
 }

--- a/rs/ethereum/cketh/minter/src/main.rs
+++ b/rs/ethereum/cketh/minter/src/main.rs
@@ -842,9 +842,9 @@ fn http_request(req: HttpRequest) -> HttpResponse {
                 )?;
 
                 w.encode_gauge(
-                    "cketh_minter_total_memory_bytes",
-                    total_memory_size_bytes() as f64,
-                    "Total amount of memory (heap and stable memory) that has been allocated by this canister.",
+                    "cketh_minter_heap_memory_bytes",
+                    heap_memory_size_bytes() as f64,
+                    "Size of the heap memory allocated by this canister.",
                 )?;
 
                 w.gauge_vec("cycle_balance", "Cycle balance of this canister.")?
@@ -1046,15 +1046,15 @@ fn check_audit_log() {
     })
 }
 
-/// Returns the total amount of memory (heap and stable memory) that has been allocated.
+/// Returns the amount of heap memory in bytes that has been allocated.
 #[cfg(target_arch = "wasm32")]
-pub fn total_memory_size_bytes() -> usize {
+pub fn heap_memory_size_bytes() -> usize {
     const WASM_PAGE_SIZE_BYTES: usize = 65536;
     core::arch::wasm32::memory_size(0) * WASM_PAGE_SIZE_BYTES
 }
 
 #[cfg(not(any(target_arch = "wasm32")))]
-pub fn total_memory_size_bytes() -> usize {
+pub fn heap_memory_size_bytes() -> usize {
     0
 }
 

--- a/rs/ethereum/cketh/minter/src/main.rs
+++ b/rs/ethereum/cketh/minter/src/main.rs
@@ -1046,7 +1046,7 @@ fn check_audit_log() {
     })
 }
 
-/// Returns the total amount of memory (heap, stable memory, etc) that has been allocated.
+/// Returns the total amount of memory (heap and stable memory) that has been allocated.
 #[cfg(target_arch = "wasm32")]
 pub fn total_memory_size_bytes() -> usize {
     const WASM_PAGE_SIZE_BYTES: usize = 65536;

--- a/rs/ethereum/cketh/minter/src/main.rs
+++ b/rs/ethereum/cketh/minter/src/main.rs
@@ -841,6 +841,12 @@ fn http_request(req: HttpRequest) -> HttpResponse {
                     "Size of the stable memory allocated by this canister.",
                 )?;
 
+                w.encode_gauge(
+                    "cketh_minter_total_memory_bytes",
+                    total_memory_size_bytes() as f64,
+                    "Total amount of memory (heap and stable memory) that has been allocated by this canister.",
+                )?;
+
                 w.gauge_vec("cycle_balance", "Cycle balance of this canister.")?
                     .value(
                         &[("canister", "cketh-minter")],
@@ -1038,6 +1044,18 @@ fn check_audit_log() {
             .is_equivalent_to(s)
             .expect("replaying the audit log should produce an equivalent state")
     })
+}
+
+/// Returns the total amount of memory (heap, stable memory, etc) that has been allocated.
+#[cfg(target_arch = "wasm32")]
+pub fn total_memory_size_bytes() -> usize {
+    const WASM_PAGE_SIZE_BYTES: usize = 65536;
+    core::arch::wasm32::memory_size(0) * WASM_PAGE_SIZE_BYTES
+}
+
+#[cfg(not(any(target_arch = "wasm32")))]
+pub fn total_memory_size_bytes() -> usize {
+    0
 }
 
 fn main() {}

--- a/rs/ethereum/ledger-suite-orchestrator/src/main.rs
+++ b/rs/ethereum/ledger-suite-orchestrator/src/main.rs
@@ -180,9 +180,9 @@ fn http_request(
                 )?;
 
                 w.encode_gauge(
-                    "ledger_suite_orchestrator_total_memory_bytes",
-                    total_memory_size_bytes() as f64,
-                    "Total amount of memory (heap and stable memory) that has been allocated by this canister.",
+                    "ledger_suite_orchestrator_heap_memory_bytes",
+                    heap_memory_size_bytes() as f64,
+                    "Size of the heap memory allocated by this canister.",
                 )?;
 
                 w.gauge_vec("cycle_balance", "Cycle balance of this canister.")?
@@ -243,15 +243,15 @@ fn http_request(
     }
 }
 
-/// Returns the total amount of memory (heap and stable memory) that has been allocated.
+/// Returns the amount of heap memory in bytes that has been allocated.
 #[cfg(target_arch = "wasm32")]
-pub fn total_memory_size_bytes() -> usize {
+pub fn heap_memory_size_bytes() -> usize {
     const WASM_PAGE_SIZE_BYTES: usize = 65536;
     core::arch::wasm32::memory_size(0) * WASM_PAGE_SIZE_BYTES
 }
 
 #[cfg(not(any(target_arch = "wasm32")))]
-pub fn total_memory_size_bytes() -> usize {
+pub fn heap_memory_size_bytes() -> usize {
     0
 }
 

--- a/rs/ethereum/ledger-suite-orchestrator/src/main.rs
+++ b/rs/ethereum/ledger-suite-orchestrator/src/main.rs
@@ -179,6 +179,12 @@ fn http_request(
                     "Size of the stable memory allocated by this canister.",
                 )?;
 
+                w.encode_gauge(
+                    "ledger_suite_orchestrator_total_memory_bytes",
+                    total_memory_size_bytes() as f64,
+                    "Total amount of memory (heap and stable memory) that has been allocated by this canister.",
+                )?;
+
                 w.gauge_vec("cycle_balance", "Cycle balance of this canister.")?
                     .value(
                         &[("canister", "ledger-suite-orchestrator")],
@@ -235,6 +241,18 @@ fn http_request(
         }
         _ => HttpResponseBuilder::not_found().build(),
     }
+}
+
+/// Returns the total amount of memory (heap, stable memory, etc) that has been allocated.
+#[cfg(target_arch = "wasm32")]
+pub fn total_memory_size_bytes() -> usize {
+    const WASM_PAGE_SIZE_BYTES: usize = 65536;
+    core::arch::wasm32::memory_size(0) * WASM_PAGE_SIZE_BYTES
+}
+
+#[cfg(not(any(target_arch = "wasm32")))]
+pub fn total_memory_size_bytes() -> usize {
+    0
 }
 
 fn main() {}

--- a/rs/ethereum/ledger-suite-orchestrator/src/main.rs
+++ b/rs/ethereum/ledger-suite-orchestrator/src/main.rs
@@ -243,7 +243,7 @@ fn http_request(
     }
 }
 
-/// Returns the total amount of memory (heap, stable memory, etc) that has been allocated.
+/// Returns the total amount of memory (heap and stable memory) that has been allocated.
 #[cfg(target_arch = "wasm32")]
 pub fn total_memory_size_bytes() -> usize {
     const WASM_PAGE_SIZE_BYTES: usize = 65536;


### PR DESCRIPTION
([XC-175](https://dfinity.atlassian.net/browse/XC-175)): Add a new metric `X_heap_memory_bytes` to track the heap memory used by a canister, where `X` is one of the following 3 canisters owned by the cross-chain team:

1. ckBTC minter
2. ckETH minter
3. ckERC20 ledger suite orchestrator

This complements the already existing metric `X_stable_memory_bytes`, that tracks the amount of stable memory used by those canisters.

[XC-175]: https://dfinity.atlassian.net/browse/XC-175?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ