### PR TITLE
chore(sns): Move DEFAULT_SNS_FRAMEWORK_CANISTER_WASM_MEMORY_LIMIT constant to ic-nns-common

### DIFF
--- a/rs/nns/constants/src/lib.rs
+++ b/rs/nns/constants/src/lib.rs
@@ -159,6 +159,11 @@ const NNS_GOVERNANCE_CANISTER_MEMORY_ALLOCATION_IN_BYTES: u64 = 10 * 1024 * 1024
 // The default memory allocation to set for the remaining NNS canister (1GiB)
 const NNS_DEFAULT_CANISTER_MEMORY_ALLOCATION_IN_BYTES: u64 = 1024 * 1024 * 1024;
 
+/// The current value is 4 GiB, s.t. the SNS framework canisters never hit the soft memory limit.
+/// This mitigates the risk that an SNS Governance canister runs out of memory and proposals cannot
+/// be passed anymore.
+pub const DEFAULT_SNS_FRAMEWORK_CANISTER_WASM_MEMORY_LIMIT: u64 = 1 << 32;
+
 /// Returns the memory allocation of the given nns canister.
 pub fn memory_allocation_of(canister_id: CanisterId) -> u64 {
     if canister_id == GOVERNANCE_CANISTER_ID {

--- a/rs/nns/sns-wasm/canister/canister.rs
+++ b/rs/nns/sns-wasm/canister/canister.rs
@@ -15,7 +15,7 @@ use ic_nervous_system_clients::{
     canister_status::{canister_status, CanisterStatusResultV2, CanisterStatusType},
 };
 use ic_nervous_system_runtime::DfnRuntime;
-use ic_nns_constants::GOVERNANCE_CANISTER_ID;
+use ic_nns_constants::{DEFAULT_SNS_FRAMEWORK_CANISTER_WASM_MEMORY_LIMIT, GOVERNANCE_CANISTER_ID};
 use ic_nns_handler_root_interface::client::NnsRootCanisterClientImpl;
 use ic_sns_wasm::{
     canister_api::CanisterApi,
@@ -43,11 +43,6 @@ use std::{cell::RefCell, collections::HashMap, convert::TryInto};
 use dfn_core::println;
 
 pub const LOG_PREFIX: &str = "[SNS-WASM] ";
-
-/// The current value is 4 GiB, s.t. the SNS framework canisters never hit the soft memory limit.
-/// This mitigates the risk that an SNS Governance canister runs out of memory and proposals cannot
-/// be passed anymore.
-pub const DEFAULT_SNS_FRAMEWORK_CANISTER_WASM_MEMORY_LIMIT: u64 = 1 << 32;
 
 thread_local! {
     static SNS_WASM: RefCell<SnsWasmCanister<CanisterStableMemory>> = RefCell::new(SnsWasmCanister::new());


### PR DESCRIPTION
This allows the constant to be used in other tests and canisters

[Next PR →](https://github.com/dfinity/ic/pull/1054)