### PR TITLE
feat(nns): add additional fields to get_monthly_node_provider_rewards

### DIFF
--- a/rs/nns/governance/canister/canister.rs
+++ b/rs/nns/governance/canister/canister.rs
@@ -55,10 +55,9 @@ use ic_nns_governance_api::{
         ListNodeProviderRewardsResponse, ListNodeProvidersResponse, ListProposalInfo,
         ListProposalInfoResponse, ManageNeuronCommandRequest, ManageNeuronRequest,
         ManageNeuronResponse, MonthlyNodeProviderRewards, NetworkEconomics, Neuron, NeuronInfo,
-        NodeProvider, Proposal, ProposalInfo, RestoreAgingSummary, RewardEvent, RewardNodeProvider,
-        RewardNodeProviders, SettleCommunityFundParticipation,
-        SettleNeuronsFundParticipationRequest, SettleNeuronsFundParticipationResponse,
-        UpdateNodeProvider, Vote,
+        NodeProvider, Proposal, ProposalInfo, RestoreAgingSummary, RewardEvent,
+        SettleCommunityFundParticipation, SettleNeuronsFundParticipationRequest,
+        SettleNeuronsFundParticipationResponse, UpdateNodeProvider, Vote,
     },
     subnet_rental::{SubnetRentalProposalPayload, SubnetRentalRequest},
 };
@@ -724,17 +723,10 @@ fn get_monthly_node_provider_rewards() {
 }
 
 #[candid_method(update, rename = "get_monthly_node_provider_rewards")]
-async fn get_monthly_node_provider_rewards_() -> Result<RewardNodeProviders, GovernanceError> {
+async fn get_monthly_node_provider_rewards_() -> Result<MonthlyNodeProviderRewards, GovernanceError>
+{
     let rewards = governance_mut().get_monthly_node_provider_rewards().await?;
-    let rewards = rewards
-        .rewards
-        .into_iter()
-        .map(RewardNodeProvider::from)
-        .collect();
-    Ok(RewardNodeProviders {
-        rewards,
-        use_registry_derived_rewards: Some(true),
-    })
+    Ok(MonthlyNodeProviderRewards::from(rewards))
 }
 
 #[export_name = "canister_query list_node_provider_rewards"]

--- a/rs/nns/governance/canister/governance.did
+++ b/rs/nns/governance/canister/governance.did
@@ -654,7 +654,10 @@ type Result_1 = variant { Error : GovernanceError; NeuronId : NeuronId };
 type Result_10 = variant { Ok : Ok_1; Err : GovernanceError };
 type Result_2 = variant { Ok : Neuron; Err : GovernanceError };
 type Result_3 = variant { Ok : GovernanceCachedMetrics; Err : GovernanceError };
-type Result_4 = variant { Ok : RewardNodeProviders; Err : GovernanceError };
+type Result_4 = variant {
+  Ok : MonthlyNodeProviderRewards;
+  Err : GovernanceError;
+};
 type Result_5 = variant { Ok : NeuronInfo; Err : GovernanceError };
 type Result_6 = variant { Ok : Ok; Err : GovernanceError };
 type Result_7 = variant { Ok : NodeProvider; Err : GovernanceError };

--- a/rs/nns/governance/canister/governance_test.did
+++ b/rs/nns/governance/canister/governance_test.did
@@ -654,7 +654,10 @@ type Result_1 = variant { Error : GovernanceError; NeuronId : NeuronId };
 type Result_10 = variant { Ok : Ok_1; Err : GovernanceError };
 type Result_2 = variant { Ok : Neuron; Err : GovernanceError };
 type Result_3 = variant { Ok : GovernanceCachedMetrics; Err : GovernanceError };
-type Result_4 = variant { Ok : RewardNodeProviders; Err : GovernanceError };
+type Result_4 = variant {
+  Ok : MonthlyNodeProviderRewards;
+  Err : GovernanceError;
+};
 type Result_5 = variant { Ok : NeuronInfo; Err : GovernanceError };
 type Result_6 = variant { Ok : Ok; Err : GovernanceError };
 type Result_7 = variant { Ok : NodeProvider; Err : GovernanceError };


### PR DESCRIPTION
This removes a no longer relevant field from the response (use_registry_derived_rewards) that is only useful as part of the proposal to reward node providers (which is also no longer used).

It also adds all the new fields to the response that are already available and are helpful to clients in using this data.

The two types in the PR are compatible from a candid API perspective, so migrating from one to the other is equivalent to removing an unneeded field and adding the new fields.