### PR TITLE
chore(ICP-Rosetta): rosetta ledger version upgrade test

### DIFF
--- a/rs/rosetta-api/icp_ledger/rosetta-integration-tests/BUILD.bazel
+++ b/rs/rosetta-api/icp_ledger/rosetta-integration-tests/BUILD.bazel
@@ -50,6 +50,7 @@ rust_test_suite(
         "//rs/rosetta-api:ic-rosetta-api-rosetta-blocks",
         "//rs/rosetta-api/icp_ledger/ledger:ledger-canister-wasm-notify-method",
         "//rs/rosetta-api/test_utils/sender_canister:ic-sender-canister",
+        "@mainnet_icp_ledger_canister//file",
     ],
     env = {
         "CANISTER_LAUNCHER": "$(rootpath //rs/canister_sandbox)",
@@ -59,6 +60,7 @@ rust_test_suite(
         "ROSETTA_PATH": "$(rootpath //rs/rosetta-api:ic-rosetta-api-rosetta-blocks)",
         "SANDBOX_LAUNCHER": "$(rootpath //rs/canister_sandbox:sandbox_launcher)",
         "IC_SENDER_CANISTER_WASM_PATH": "$(rootpath //rs/rosetta-api/test_utils/sender_canister:ic-sender-canister)",
+        "ICP_LEDGER_DEPLOYED_VERSION_WASM_PATH": "$(rootpath @mainnet_icp_ledger_canister//file)",
     },
     # The test is critical to get resources timely and therefore fails sometimes when run on heavily loaded node.
     # TODO(IDX-2225): reconsider when we will use Remote Execution.

--- a/rs/rosetta-api/icp_ledger/rosetta-integration-tests/tests/tests.rs
+++ b/rs/rosetta-api/icp_ledger/rosetta-integration-tests/tests/tests.rs
@@ -12,7 +12,8 @@ use ic_rosetta_api::models::{
 use ic_rosetta_api::request_types::{RosettaBlocksMode, RosettaStatus};
 use ic_sender_canister_lib::{SendArg, SendResult};
 use icp_ledger::{
-    AccountIdentifier, Memo, Operation, TimeStamp, Tokens, Transaction, DEFAULT_TRANSFER_FEE,
+    AccountIdentifier, LedgerCanisterPayload, LedgerCanisterUpgradePayload, Memo, Operation,
+    TimeStamp, Tokens, Transaction, DEFAULT_TRANSFER_FEE,
 };
 use icp_rosetta_integration_tests::{start_rosetta, RosettaContext};
 use icrc_ledger_types::icrc1::account::Account;
@@ -1322,6 +1323,145 @@ async fn test_network_status_single_genesis_transaction() {
         current_block.timestamp
     );
 
+    assert_eq!(
+        network_status.genesis_block_identifier,
+        genesis_block.block_identifier
+    );
+}
+
+#[tokio::test]
+async fn test_rosetta_ledger_upgrade() {
+    let mut env = TestEnv::setup(false, true).await.unwrap();
+
+    // Currently, the ledger canister version is that of this branch
+    // We need to reinstall it to the mainnet version
+    let ledger_wasm_mainnet =
+        std::fs::read(std::env::var("ICP_LEDGER_DEPLOYED_VERSION_WASM_PATH").unwrap()).unwrap();
+    env.pocket_ic
+        .reinstall_canister(
+            env.ledger_id,
+            ledger_wasm_mainnet,
+            icp_ledger_init(env.sender_id),
+            None,
+        )
+        .await
+        .unwrap();
+
+    // Let's create a few transactions to make sure rosetta is working with the mainnet ledger version
+    for _ in 0..100 {
+        let transfer_arg = TransferArg {
+            from_subaccount: None,
+            to: Account::from(Principal::anonymous()),
+            fee: None,
+            created_at_time: None,
+            memo: None,
+            amount: Nat::from(1u64),
+        };
+        let arg = Encode!(&transfer_arg).unwrap();
+        env.pocket_ic
+            .update_call(env.ledger_id, env.sender_id, "icrc1_transfer", arg)
+            .await
+            .unwrap();
+    }
+
+    // We should now have 100 blocks
+    // Let's restart rosetta to make sure it can handle the mainnet ledger version
+    env.restart_rosetta_node(false, false).await.unwrap();
+    env.rosetta.wait_until_synced_up_to(100).await.unwrap();
+
+    // Let's check the network status
+    let network_status = env.rosetta.network_status().await.unwrap();
+    let current_block = env
+        .rosetta
+        .block(PartialBlockIdentifier {
+            index: Some(100),
+            hash: None,
+        })
+        .await
+        .unwrap()
+        .block
+        .unwrap();
+    let genesis_block = env
+        .rosetta
+        .block(PartialBlockIdentifier {
+            index: Some(0),
+            hash: None,
+        })
+        .await
+        .unwrap()
+        .block
+        .unwrap();
+    assert_eq!(
+        network_status.current_block_identifier,
+        current_block.block_identifier
+    );
+    assert_eq!(
+        network_status.genesis_block_identifier,
+        genesis_block.block_identifier
+    );
+
+    // Now we upgrade the ledger canister to the latest version of the current branch
+    let ledger_wasm_current_branch = icp_ledger_wasm_bytes();
+    env.pocket_ic
+        .upgrade_canister(
+            env.ledger_id,
+            ledger_wasm_current_branch,
+            Encode!(&LedgerCanisterUpgradePayload(
+                LedgerCanisterPayload::Upgrade(None)
+            ))
+            .unwrap(),
+            None,
+        )
+        .await
+        .unwrap();
+
+    // Let's create a few transactions to make sure rosetta is working with the current branch ledger version
+    for _ in 0..100 {
+        let transfer_arg = TransferArg {
+            from_subaccount: None,
+            to: Account::from(Principal::anonymous()),
+            fee: None,
+            created_at_time: None,
+            memo: None,
+            amount: Nat::from(1u64),
+        };
+        let arg = Encode!(&transfer_arg).unwrap();
+        env.pocket_ic
+            .update_call(env.ledger_id, env.sender_id, "icrc1_transfer", arg)
+            .await
+            .unwrap();
+    }
+
+    // We should now have 200 blocks
+    env.restart_rosetta_node(false, false).await.unwrap();
+    env.rosetta.wait_until_synced_up_to(200).await.unwrap();
+
+    // Let's check the network status
+    let network_status = env.rosetta.network_status().await.unwrap();
+    let current_block = env
+        .rosetta
+        .block(PartialBlockIdentifier {
+            index: Some(200),
+            hash: None,
+        })
+        .await
+        .unwrap()
+        .block
+        .unwrap();
+    let genesis_block = env
+        .rosetta
+        .block(PartialBlockIdentifier {
+            index: Some(0),
+            hash: None,
+        })
+        .await
+        .unwrap()
+        .block
+        .unwrap();
+    assert_eq!(
+        network_status.current_block_identifier,
+        current_block.block_identifier
+    );
     assert_eq!(
         network_status.genesis_block_identifier,
         genesis_block.block_identifier


### PR DESCRIPTION
This MR introduces the following changes:

1. Add a test that tests the correct behaviour of rosetta when upgrading from the current mainnet 