### PR TITLE
feat(ckbtc): NNS proposals to upgrade ckBTC ledger suite to add support for ICRC-21

### DIFF
--- a/rs/bitcoin/ckbtc/mainnet/ckbtc_archive_upgrade_2024_08_23.md
+++ b/rs/bitcoin/ckbtc/mainnet/ckbtc_archive_upgrade_2024_08_23.md
@@ -1,0 +1,52 @@
+# Proposal to upgrade the ckETH archive canister
+
+Git hash: `3d0b3f10417fc6708e8b5d844a0bac5e86f3e17d`
+
+New compressed Wasm hash: `5bd1f69540bd48493018e13bb5ad25aba75d59403ced1d5958bf718147228d31`
+
+Target canister: `xob7s-iqaaa-aaaar-qacra-cai`
+
+Previous ckETH archive proposal: None (was spawned off by the ckETH ledger with git hash `5ecbd59c6c9f9f874d4340f9fbbd96af07aa2576`)
+
+---
+
+## Motivation
+Upgrade the ckETH archive canister to the latest version to add support for the [ICRC-21: Canister Call Consent Messages](https://github.com/dfinity/wg-identity-authentication/blob/fd846030109710cab67d9381485a73db424f2b07/topics/ICRC-21/icrc_21_consent_msg.md) standard.
+
+
+## Upgrade args
+
+```
+git fetch
+git checkout 3d0b3f10417fc6708e8b5d844a0bac5e86f3e17d
+cd rs/rosetta-api/icrc1/archive
+didc encode '()'
+```
+
+## Release Notes
+
+```
+git log --format="%C(auto) %h %s" 5ecbd59c6c9f9f874d4340f9fbbd96af07aa2576..3d0b3f10417fc6708e8b5d844a0bac5e86f3e17d -- rs/rosetta-api/icrc1/archive
+576bb8d17 chore: add buildifier sort comment to Bazel files
+f7fe40b7d Merge branch 'mathias-FI-1310-add-heap-memory-usage-metric' into 'master'
+0c16902ca feat(ledger_suite): FI-1310: Add total memory usage metrics for ledger, archive, and index canisters
+a5c8d79ad feat(FI): FI-1314: Use ic_cdk::api::stable::stable64_size() instead of stable_size() for canister metrics
+1bfe616ec feat: build Rust canisters with opt-level=3 by default
+96d973666 chore(rosetta): FI-1253: Sort dependencies in BUILD.bazel and Cargo.toml files under rs/rosetta-api
+75b477a1e fix: ICRC Archive icrc3_get_block should return at most 100 blocks
+d39f28fbd feat(icrc-archive): support ICRC-3 in the ICRC Archive
+bc81e20f9 chore: upgrade `ic-stable-structures`
+a8f0d7f61 build: upgrade candid to 0.10
+a163262f1 chore(release): Bump up the bazel versions for all crates as well
+ ```
+
+## Wasm Verification
+
+Verify that the hash of the gzipped WASM matches the proposed hash.
+
+```
+git fetch
+git checkout 3d0b3f10417fc6708e8b5d844a0bac5e86f3e17d
+./gitlab-ci/container/build-ic.sh -c
+sha256sum ./artifacts/canisters/ic-icrc1-archive-u256.wasm.gz
+```

--- a/rs/bitcoin/ckbtc/mainnet/ckbtc_archive_upgrade_2024_08_23.md
+++ b/rs/bitcoin/ckbtc/mainnet/ckbtc_archive_upgrade_2024_08_23.md
@@ -1,17 +1,17 @@
-# Proposal to upgrade the ckETH archive canister
+# Proposal to upgrade the ckBTC archive canister
 
 Git hash: `3d0b3f10417fc6708e8b5d844a0bac5e86f3e17d`
 
-New compressed Wasm hash: `5bd1f69540bd48493018e13bb5ad25aba75d59403ced1d5958bf718147228d31`
+New compressed Wasm hash: `5c595c2adc7f6d9971298fee2fa666929711e73341192ab70804c783a0eee03f`
 
-Target canister: `xob7s-iqaaa-aaaar-qacra-cai`
+Target canister: `nbsys-saaaa-aaaar-qaaga-cai`
 
-Previous ckETH archive proposal: None (was spawned off by the ckETH ledger with git hash `5ecbd59c6c9f9f874d4340f9fbbd96af07aa2576`)
+Previous ckBTC archive proposal: https://dashboard.internetcomputer.org/proposal/125589
 
 ---
 
 ## Motivation
-Upgrade the ckETH archive canister to the latest version to add support for the [ICRC-21: Canister Call Consent Messages](https://github.com/dfinity/wg-identity-authentication/blob/fd846030109710cab67d9381485a73db424f2b07/topics/ICRC-21/icrc_21_consent_msg.md) standard.
+Upgrade the ckBTC archive canister to the latest version to add support for the [ICRC-21: Canister Call Consent Messages](https://github.com/dfinity/wg-identity-authentication/blob/fd846030109710cab67d9381485a73db424f2b07/topics/ICRC-21/icrc_21_consent_msg.md) standard.
 
 
 ## Upgrade args
@@ -26,7 +26,7 @@ didc encode '()'
 ## Release Notes
 
 ```
-git log --format="%C(auto) %h %s" 5ecbd59c6c9f9f874d4340f9fbbd96af07aa2576..3d0b3f10417fc6708e8b5d844a0bac5e86f3e17d -- rs/rosetta-api/icrc1/archive
+git log --format=%C(auto) %h %s 24fd80082f40de6d0b3cd7876be09ef1aadbde86..3d0b3f10417fc6708e8b5d844a0bac5e86f3e17d -- rs/rosetta-api/icrc1/archive
 576bb8d17 chore: add buildifier sort comment to Bazel files
 f7fe40b7d Merge branch 'mathias-FI-1310-add-heap-memory-usage-metric' into 'master'
 0c16902ca feat(ledger_suite): FI-1310: Add total memory usage metrics for ledger, archive, and index canisters
@@ -48,5 +48,5 @@ Verify that the hash of the gzipped WASM matches the proposed hash.
 git fetch
 git checkout 3d0b3f10417fc6708e8b5d844a0bac5e86f3e17d
 ./gitlab-ci/container/build-ic.sh -c
-sha256sum ./artifacts/canisters/ic-icrc1-archive-u256.wasm.gz
+sha256sum ./artifacts/canisters/ic-icrc1-archive.wasm.gz
 ```

--- a/rs/bitcoin/ckbtc/mainnet/ckbtc_index_upgrade_2024_08_23.md
+++ b/rs/bitcoin/ckbtc/mainnet/ckbtc_index_upgrade_2024_08_23.md
@@ -1,0 +1,69 @@
+# Proposal to upgrade the ckETH index canister
+
+Git hash: `3d0b3f10417fc6708e8b5d844a0bac5e86f3e17d`
+
+New compressed Wasm hash: `eb3096906bf9a43996d2ca9ca9bfec333a402612f132876c8ed1b01b9844112a`
+
+Target canister: `s3zol-vqaaa-aaaar-qacpa-cai`
+
+Previous ckETH index proposal: https://dashboard.internetcomputer.org/proposal/126173
+
+---
+
+## Motivation
+Upgrade the ckETH index canister to the latest version to add support for the [ICRC-21: Canister Call Consent Messages](https://github.com/dfinity/wg-identity-authentication/blob/fd846030109710cab67d9381485a73db424f2b07/topics/ICRC-21/icrc_21_consent_msg.md) standard.
+
+
+## Upgrade args
+
+```
+git fetch
+git checkout 3d0b3f10417fc6708e8b5d844a0bac5e86f3e17d
+cd rs/rosetta-api/icrc1/index-ng
+didc encode -d index-ng.did -t '(opt IndexArg)' '(null)'
+```
+
+## Release Notes
+
+```
+git log --format="%C(auto) %h %s" 5ecbd59c6c9f9f874d4340f9fbbd96af07aa2576..3d0b3f10417fc6708e8b5d844a0bac5e86f3e17d -- rs/rosetta-api/icrc1/index-ng
+b4be567dc chore: Bump rust version to 1.80 (#642)
+eec6107fa chore: remove obsolete cost scaling feature flag (#502)
+18243444a fix(ICRC-Index): FI-1382: remove comment on removing 0 balance accounts (#341)
+576bb8d17 chore: add buildifier sort comment to Bazel files
+f7fe40b7d Merge branch 'mathias-FI-1310-add-heap-memory-usage-metric' into 'master'
+0c16902ca feat(ledger_suite): FI-1310: Add total memory usage metrics for ledger, archive, and index canisters
+a5c8d79ad feat(FI): FI-1314: Use ic_cdk::api::stable::stable64_size() instead of stable_size() for canister metrics
+610ebf1b7 chore(ICRC1 index-ng): FI-1306: Extract index-ng tests into separate file and shorten runtimes
+d557530ae chore(index-ng): FI-1296: Set index-ng integration test timeout to long
+e73f59f99 feat(icrc1-index-ng): FI-1296: Make index-ng interval for retrieving blocks from the ledger configurable
+1bfe616ec feat: build Rust canisters with opt-level=3 by default
+96d973666 chore(rosetta): FI-1253: Sort dependencies in BUILD.bazel and Cargo.toml files under rs/rosetta-api
+6c404992f chore: enable DTS in all StateMachine tests by default
+e9475596c Merge branch 'FI-1194' into 'master'
+97282de22 feat(icrc-index-ng): support ICRC-3
+00e10d345 feat(ledger): Enable ICRC1 ledger to change archive options upon upgrades
+be2ab73ba chore(icrc-index-ng): test against ledger wo ICRC-3
+0fe5aff1e chore: Move num-traits dependency to workspace
+e1c1033c7 feat(sns): Enable upgrading the SNS Ledger suite to the latest canister versions
+b669077b2 feat(icrc): Add more controllers to archive spawned by ledger
+bc81e20f9 chore: upgrade `ic-stable-structures`
+2c30c7ac8 feat(FI-1114): [ICRC Rosetta] Property based testing
+fbcfbd5e3 feat(ckerc20): PoC for a ledger suite orchestrator canister
+a8f0d7f61 build: upgrade candid to 0.10
+b835f6ebb chore: bump Rust version to 1.75
+6e9c3da68 fix(index-ng): Simplify the timer structure
+dced7733d feat(FI-1074) [ICRC-1 Rosetta] converted principal based valid blockchain strategy to basicidentity
+c603a7f14 feat(icrc_index_ng): read ledger_id from old index state in post_upgrade
+ ```
+
+## Wasm Verification
+
+Verify that the hash of the gzipped WASM matches the proposed hash.
+
+```
+git fetch
+git checkout 3d0b3f10417fc6708e8b5d844a0bac5e86f3e17d
+./gitlab-ci/container/build-ic.sh -c
+sha256sum ./artifacts/canisters/ic-icrc1-index-ng-u256.wasm.gz
+```

--- a/rs/bitcoin/ckbtc/mainnet/ckbtc_index_upgrade_2024_08_23.md
+++ b/rs/bitcoin/ckbtc/mainnet/ckbtc_index_upgrade_2024_08_23.md
@@ -1,17 +1,17 @@
-# Proposal to upgrade the ckETH index canister
+# Proposal to upgrade the ckBTC index canister
 
 Git hash: `3d0b3f10417fc6708e8b5d844a0bac5e86f3e17d`
 
-New compressed Wasm hash: `eb3096906bf9a43996d2ca9ca9bfec333a402612f132876c8ed1b01b9844112a`
+New compressed Wasm hash: `5177e0dede340042a3917665195a76fa26a1c3b3de314a9a52b97dfadd228be0`
 
-Target canister: `s3zol-vqaaa-aaaar-qacpa-cai`
+Target canister: `n5wcd-faaaa-aaaar-qaaea-cai`
 
-Previous ckETH index proposal: https://dashboard.internetcomputer.org/proposal/126173
+Previous ckBTC index proposal: https://dashboard.internetcomputer.org/proposal/125590
 
 ---
 
 ## Motivation
-Upgrade the ckETH index canister to the latest version to add support for the [ICRC-21: Canister Call Consent Messages](https://github.com/dfinity/wg-identity-authentication/blob/fd846030109710cab67d9381485a73db424f2b07/topics/ICRC-21/icrc_21_consent_msg.md) standard.
+Upgrade the ckBTC index canister to the latest version to add support for the [ICRC-21: Canister Call Consent Messages](https://github.com/dfinity/wg-identity-authentication/blob/fd846030109710cab67d9381485a73db424f2b07/topics/ICRC-21/icrc_21_consent_msg.md) standard.
 
 
 ## Upgrade args
@@ -20,13 +20,13 @@ Upgrade the ckETH index canister to the latest version to add support for the [I
 git fetch
 git checkout 3d0b3f10417fc6708e8b5d844a0bac5e86f3e17d
 cd rs/rosetta-api/icrc1/index-ng
-didc encode -d index-ng.did -t '(opt IndexArg)' '(null)'
+didc encode '()'
 ```
 
 ## Release Notes
 
 ```
-git log --format="%C(auto) %h %s" 5ecbd59c6c9f9f874d4340f9fbbd96af07aa2576..3d0b3f10417fc6708e8b5d844a0bac5e86f3e17d -- rs/rosetta-api/icrc1/index-ng
+git log --format=%C(auto) %h %s 24fd80082f40de6d0b3cd7876be09ef1aadbde86..3d0b3f10417fc6708e8b5d844a0bac5e86f3e17d -- rs/rosetta-api/icrc1/index-ng
 b4be567dc chore: Bump rust version to 1.80 (#642)
 eec6107fa chore: remove obsolete cost scaling feature flag (#502)
 18243444a fix(ICRC-Index): FI-1382: remove comment on removing 0 balance accounts (#341)
@@ -55,6 +55,7 @@ b835f6ebb chore: bump Rust version to 1.75
 6e9c3da68 fix(index-ng): Simplify the timer structure
 dced7733d feat(FI-1074) [ICRC-1 Rosetta] converted principal based valid blockchain strategy to basicidentity
 c603a7f14 feat(icrc_index_ng): read ledger_id from old index state in post_upgrade
+5ae303770 chore: bump rust to 1.73
  ```
 
 ## Wasm Verification
@@ -65,5 +66,5 @@ Verify that the hash of the gzipped WASM matches the proposed hash.
 git fetch
 git checkout 3d0b3f10417fc6708e8b5d844a0bac5e86f3e17d
 ./gitlab-ci/container/build-ic.sh -c
-sha256sum ./artifacts/canisters/ic-icrc1-index-ng-u256.wasm.gz
+sha256sum ./artifacts/canisters/ic-icrc1-index.wasm.gz
 ```

--- a/rs/bitcoin/ckbtc/mainnet/ckbtc_index_upgrade_2024_08_26.md
+++ b/rs/bitcoin/ckbtc/mainnet/ckbtc_index_upgrade_2024_08_26.md
@@ -1,0 +1,74 @@
+# Proposal to upgrade the ckBTC index canister
+
+Git hash: `3d0b3f10417fc6708e8b5d844a0bac5e86f3e17d`
+
+New compressed Wasm hash: `08ae5042c8e413716d04a08db886b8c6b01bb610b8197cdbe052c59538b924f0`
+
+Target canister: `n5wcd-faaaa-aaaar-qaaea-cai`
+
+Previous ckBTC index proposal: https://dashboard.internetcomputer.org/proposal/132128
+
+---
+
+## Motivation
+The previous proposal [132128](https://dashboard.internetcomputer.org/proposal/132128) was executed, but the upgrade failed during the `post_upgrade` and the state of the canister was reverted.
+This can be seen by verifying that the currently deployed wasm module (e.g. with `dfx canister --ic info n5wcd-faaaa-aaaar-qaaea-cai`) is still `0x340eb880fb50cb7f437d284f2dc70d796cc86859cb990e39f1c4981e2b52dab5`, which corresponds to the version from the last successfully executed proposal [125590](https://dashboard.internetcomputer.org/proposal/125590).
+The reason for the failure was that the wrong wasm was used (`ic-icrc1-index.wasm.gz` instead of `ic-icrc1-index-ng.wasm.gz`).
+
+Similarly [132128](https://dashboard.internetcomputer.org/proposal/132128), this proposal is meant to upgrade the ckBTC index canister to the latest version to add support for the [ICRC-21: Canister Call Consent Messages](https://github.com/dfinity/wg-identity-authentication/blob/fd846030109710cab67d9381485a73db424f2b07/topics/ICRC-21/icrc_21_consent_msg.md) standard.
+
+
+## Upgrade args
+
+```
+git fetch
+git checkout 3d0b3f10417fc6708e8b5d844a0bac5e86f3e17d
+cd rs/rosetta-api/icrc1/index-ng
+didc encode '()'
+```
+
+## Release Notes
+
+```
+git log --format=%C(auto) %h %s 24fd80082f40de6d0b3cd7876be09ef1aadbde86..3d0b3f10417fc6708e8b5d844a0bac5e86f3e17d -- rs/rosetta-api/icrc1/index-ng
+b4be567dc chore: Bump rust version to 1.80 (#642)
+eec6107fa chore: remove obsolete cost scaling feature flag (#502)
+18243444a fix(ICRC-Index): FI-1382: remove comment on removing 0 balance accounts (#341)
+576bb8d17 chore: add buildifier sort comment to Bazel files
+f7fe40b7d Merge branch 'mathias-FI-1310-add-heap-memory-usage-metric' into 'master'
+0c16902ca feat(ledger_suite): FI-1310: Add total memory usage metrics for ledger, archive, and index canisters
+a5c8d79ad feat(FI): FI-1314: Use ic_cdk::api::stable::stable64_size() instead of stable_size() for canister metrics
+610ebf1b7 chore(ICRC1 index-ng): FI-1306: Extract index-ng tests into separate file and shorten runtimes
+d557530ae chore(index-ng): FI-1296: Set index-ng integration test timeout to long
+e73f59f99 feat(icrc1-index-ng): FI-1296: Make index-ng interval for retrieving blocks from the ledger configurable
+1bfe616ec feat: build Rust canisters with opt-level=3 by default
+96d973666 chore(rosetta): FI-1253: Sort dependencies in BUILD.bazel and Cargo.toml files under rs/rosetta-api
+6c404992f chore: enable DTS in all StateMachine tests by default
+e9475596c Merge branch 'FI-1194' into 'master'
+97282de22 feat(icrc-index-ng): support ICRC-3
+00e10d345 feat(ledger): Enable ICRC1 ledger to change archive options upon upgrades
+be2ab73ba chore(icrc-index-ng): test against ledger wo ICRC-3
+0fe5aff1e chore: Move num-traits dependency to workspace
+e1c1033c7 feat(sns): Enable upgrading the SNS Ledger suite to the latest canister versions
+b669077b2 feat(icrc): Add more controllers to archive spawned by ledger
+bc81e20f9 chore: upgrade `ic-stable-structures`
+2c30c7ac8 feat(FI-1114): [ICRC Rosetta] Property based testing
+fbcfbd5e3 feat(ckerc20): PoC for a ledger suite orchestrator canister
+a8f0d7f61 build: upgrade candid to 0.10
+b835f6ebb chore: bump Rust version to 1.75
+6e9c3da68 fix(index-ng): Simplify the timer structure
+dced7733d feat(FI-1074) [ICRC-1 Rosetta] converted principal based valid blockchain strategy to basicidentity
+c603a7f14 feat(icrc_index_ng): read ledger_id from old index state in post_upgrade
+5ae303770 chore: bump rust to 1.73
+ ```
+
+## Wasm Verification
+
+Verify that the hash of the gzipped WASM matches the proposed hash.
+
+```
+git fetch
+git checkout 3d0b3f10417fc6708e8b5d844a0bac5e86f3e17d
+./gitlab-ci/container/build-ic.sh -c
+sha256sum ./artifacts/canisters/ic-icrc1-index-ng.wasm.gz
+```

--- a/rs/bitcoin/ckbtc/mainnet/ckbtc_index_upgrade_2024_08_26.md
+++ b/rs/bitcoin/ckbtc/mainnet/ckbtc_index_upgrade_2024_08_26.md
@@ -15,7 +15,7 @@ The previous proposal [132128](https://dashboard.internetcomputer.org/proposal/1
 This can be seen by verifying that the currently deployed wasm module (e.g. with `dfx canister --ic info n5wcd-faaaa-aaaar-qaaea-cai`) is still `0x340eb880fb50cb7f437d284f2dc70d796cc86859cb990e39f1c4981e2b52dab5`, which corresponds to the version from the last successfully executed proposal [125590](https://dashboard.internetcomputer.org/proposal/125590).
 The reason for the failure was that the wrong wasm was used (`ic-icrc1-index.wasm.gz` instead of `ic-icrc1-index-ng.wasm.gz`).
 
-Similarly [132128](https://dashboard.internetcomputer.org/proposal/132128), this proposal is meant to upgrade the ckBTC index canister to the latest version to add support for the [ICRC-21: Canister Call Consent Messages](https://github.com/dfinity/wg-identity-authentication/blob/fd846030109710cab67d9381485a73db424f2b07/topics/ICRC-21/icrc_21_consent_msg.md) standard.
+Similarly to [132128](https://dashboard.internetcomputer.org/proposal/132128), this proposal is meant to upgrade the ckBTC index canister to the latest version to add support for the [ICRC-21: Canister Call Consent Messages](https://github.com/dfinity/wg-identity-authentication/blob/fd846030109710cab67d9381485a73db424f2b07/topics/ICRC-21/icrc_21_consent_msg.md) standard.
 
 
 ## Upgrade args

--- a/rs/bitcoin/ckbtc/mainnet/ckbtc_ledger_upgrade_2024_08_23.md
+++ b/rs/bitcoin/ckbtc/mainnet/ckbtc_ledger_upgrade_2024_08_23.md
@@ -1,0 +1,93 @@
+# Proposal to upgrade the ckETH ledger canister
+
+Git hash: `3d0b3f10417fc6708e8b5d844a0bac5e86f3e17d`
+
+New compressed Wasm hash: `8457289d3b3179aa83977ea21bfa2fc85e402e1f64101ecb56a4b963ed33a1e6`
+
+Target canister: `ss2fx-dyaaa-aaaar-qacoq-cai`
+
+Previous ckETH ledger proposal: https://dashboard.internetcomputer.org/proposal/126397
+
+---
+
+## Motivation
+Upgrade the ckETH ledger canister to the latest version to add support for the [ICRC-21: Canister Call Consent Messages](https://github.com/dfinity/wg-identity-authentication/blob/fd846030109710cab67d9381485a73db424f2b07/topics/ICRC-21/icrc_21_consent_msg.md) standard.
+
+
+## Upgrade args
+
+```
+git fetch
+git checkout 3d0b3f10417fc6708e8b5d844a0bac5e86f3e17d
+cd rs/rosetta-api/icrc1/ledger
+didc encode -d ledger.did -t '(LedgerArg)' '(variant {Upgrade = null})'
+```
+
+## Release Notes
+
+```
+git log --format="%C(auto) %h %s" 6a8e5fca2c6b4e12966638c444e994e204b42989..3d0b3f10417fc6708e8b5d844a0bac5e86f3e17d -- rs/rosetta-api/icrc1/ledger
+f2f408333 test(ICRC-Ledger): FI-1377: Add tests for upgrading ICRC ledger with WASMs with different token types (#388)
+14836b59d chore(ICP/ICRC-Ledger): FI-1373: refactor approvals library to allow using regular and stable allowance storage (#382)
+33187dbe8 fix(ICRC-21): FI-1386: add e 8 s to icrc 21 (#340)
+50aa8cfd6 feat(icrc_ledger): FI-1323: Add metric for instructions consumed during upgrade to ICP and ICRC ledgers
+576bb8d17 chore: add buildifier sort comment to Bazel files
+e219f993d chore(ICRC21): FI-1339: Icrc 21 markdown refinement
+d95111e33 Merge branch 'gdemay/XC-92-canbench-icrc1-ledger-archive' into 'master'
+b078dc9f8 test(ledger): Benchmarks ICRC ledger with archiving
+fb4e5bdfe chore(RUN-931): Add doc links to HypervisorErrors
+dd934bbdd test(ledger): Add `canbench` to ICRC1 ledger
+e281f01a2 feat(icrc_ledger): FI-1316: Add a metric for the total number of transactions processed by the ICRC ledger
+5a5fdb589 feat(icrc_ledger): FI-1322: Add metrics for the number of spawned archives
+a8a02bfa1 feat(ICRC-1 Ledger): add icrc21 to icrc1 ledger
+f7fe40b7d Merge branch 'mathias-FI-1310-add-heap-memory-usage-metric' into 'master'
+0c16902ca feat(ledger_suite): FI-1310: Add total memory usage metrics for ledger, archive, and index canisters
+63dba97cb feat(ICP-Ledger): icrc21 transfer from
+180750e6b feat(ICP-Ledger): FI-1178: icrc21 approve
+648a15656 feat(icrc_ledger): FI-1161: Add metric for number of approvals in the ICRC ledger
+ed7f7c98c feat(ICP-Ledger): FI-1177: icrc1 transfer for icrc21 endpoint
+ce2222b6c build: CRP-2131 add testonly to crypto test utils and adjust the dependents
+1bfe616ec feat: build Rust canisters with opt-level=3 by default
+96d973666 chore(rosetta): FI-1253: Sort dependencies in BUILD.bazel and Cargo.toml files under rs/rosetta-api
+7957dab20 chore: rules_rust 0.33.0 -> 0.42.1
+e9475596c Merge branch 'FI-1194' into 'master'
+97282de22 feat(icrc-index-ng): support ICRC-3
+00e10d345 feat(ledger): Enable ICRC1 ledger to change archive options upon upgrades
+f4ec28ce0 chore(icrc-ledger): add icrc3 to supported standards
+cd9a2faeb feat(icrc-ledger): add icrc3_get_blocks
+478571dfc fix: make time in StateMachine tests strictly monotone
+c2c47c413 Merge branch 'dsharifi/async-trait-workspace-dep' into 'master'
+66b0b363c chore: Move async-trait dependency to workspace
+294584d7a feat(icrc-ledger): partial ICRC-3 support in the ICRC Ledger
+f539c0545 chore: Bump rust version to 1.77.1
+b412b7931 chore: Move `hex` dependency to workspace
+1cc624107 Merge branch 'dsharifi/num-traits-workspace-dep' into 'master'
+0fe5aff1e chore: Move num-traits dependency to workspace
+6bfc3729e chore: Move anyhow dependencies to workspace
+e1c1033c7 feat(sns): Enable upgrading the SNS Ledger suite to the latest canister versions
+f3d614b6e chore: rename ic00_types to management_canister_types
+170c5bd4b chore: bump Rust version to `1.76.0`
+b669077b2 feat(icrc): Add more controllers to archive spawned by ledger
+547698dbf feat(icrc_ledger): ICRC-2 always enabled
+2c30c7ac8 feat(FI-1114): [ICRC Rosetta] Property based testing
+85eb8611e Merge branch 'rumenov/cddk' into 'master'
+c25c7462b build: cddl upgrade
+fbcfbd5e3 feat(ckerc20): PoC for a ledger suite orchestrator canister
+fa6adacec Merge branch 'mk/bazel_ic_test2' into 'master'
+40db11f8e Chore: Move sandbox env declarations to a common place
+a8f0d7f61 build: upgrade candid to 0.10
+b835f6ebb chore: bump Rust version to 1.75
+1bed24caa feat(FI-1069): [ICRC Rosetta] Use big uint for rosetta storage
+04bd60ce4 test(icrc1_ledger): FI-1095: Adding tests to verify written ledger blocks
+ ```
+
+## Wasm Verification
+
+Verify that the hash of the gzipped WASM matches the proposed hash.
+
+```
+git fetch
+git checkout 3d0b3f10417fc6708e8b5d844a0bac5e86f3e17d
+./gitlab-ci/container/build-ic.sh -c
+sha256sum ./artifacts/canisters/ic-icrc1-ledger-u256.wasm.gz
+```

--- a/rs/bitcoin/ckbtc/mainnet/ckbtc_ledger_upgrade_2024_08_23.md
+++ b/rs/bitcoin/ckbtc/mainnet/ckbtc_ledger_upgrade_2024_08_23.md
@@ -1,17 +1,17 @@
-# Proposal to upgrade the ckETH ledger canister
+# Proposal to upgrade the ckBTC ledger canister
 
 Git hash: `3d0b3f10417fc6708e8b5d844a0bac5e86f3e17d`
 
-New compressed Wasm hash: `8457289d3b3179aa83977ea21bfa2fc85e402e1f64101ecb56a4b963ed33a1e6`
+New compressed Wasm hash: `e8942f56f9439b89b13bd8037f357126e24f1e7932cf03018243347505959fd4`
 
-Target canister: `ss2fx-dyaaa-aaaar-qacoq-cai`
+Target canister: `mxzaz-hqaaa-aaaar-qaada-cai`
 
-Previous ckETH ledger proposal: https://dashboard.internetcomputer.org/proposal/126397
+Previous ckBTC ledger proposal: https://dashboard.internetcomputer.org/proposal/126394
 
 ---
 
 ## Motivation
-Upgrade the ckETH ledger canister to the latest version to add support for the [ICRC-21: Canister Call Consent Messages](https://github.com/dfinity/wg-identity-authentication/blob/fd846030109710cab67d9381485a73db424f2b07/topics/ICRC-21/icrc_21_consent_msg.md) standard.
+Upgrade the ckBTC ledger canister to the latest version to add support for the [ICRC-21: Canister Call Consent Messages](https://github.com/dfinity/wg-identity-authentication/blob/fd846030109710cab67d9381485a73db424f2b07/topics/ICRC-21/icrc_21_consent_msg.md) standard.
 
 
 ## Upgrade args
@@ -20,13 +20,13 @@ Upgrade the ckETH ledger canister to the latest version to add support for the [
 git fetch
 git checkout 3d0b3f10417fc6708e8b5d844a0bac5e86f3e17d
 cd rs/rosetta-api/icrc1/ledger
-didc encode -d ledger.did -t '(LedgerArg)' '(variant {Upgrade = null})'
+didc encode '()'
 ```
 
 ## Release Notes
 
 ```
-git log --format="%C(auto) %h %s" 6a8e5fca2c6b4e12966638c444e994e204b42989..3d0b3f10417fc6708e8b5d844a0bac5e86f3e17d -- rs/rosetta-api/icrc1/ledger
+git log --format=%C(auto) %h %s 6a8e5fca2c6b4e12966638c444e994e204b42989..3d0b3f10417fc6708e8b5d844a0bac5e86f3e17d -- rs/rosetta-api/icrc1/ledger
 f2f408333 test(ICRC-Ledger): FI-1377: Add tests for upgrading ICRC ledger with WASMs with different token types (#388)
 14836b59d chore(ICP/ICRC-Ledger): FI-1373: refactor approvals library to allow using regular and stable allowance storage (#382)
 33187dbe8 fix(ICRC-21): FI-1386: add e 8 s to icrc 21 (#340)
@@ -89,5 +89,5 @@ Verify that the hash of the gzipped WASM matches the proposed hash.
 git fetch
 git checkout 3d0b3f10417fc6708e8b5d844a0bac5e86f3e17d
 ./gitlab-ci/container/build-ic.sh -c
-sha256sum ./artifacts/canisters/ic-icrc1-ledger-u256.wasm.gz
+sha256sum ./artifacts/canisters/ic-icrc1-ledger.wasm.gz
 ```

--- a/rs/cross-chain/proposal-cli/src/canister/mod.rs
+++ b/rs/cross-chain/proposal-cli/src/canister/mod.rs
@@ -119,7 +119,7 @@ impl TargetCanister {
     pub fn artifact_file_name(&self) -> &str {
         match &self {
             TargetCanister::CkBtcArchive => "ic-icrc1-archive.wasm.gz",
-            TargetCanister::CkBtcIndex => "ic-icrc1-index.wasm.gz",
+            TargetCanister::CkBtcIndex => "ic-icrc1-index-ng.wasm.gz",
             TargetCanister::CkBtcKyt => "ic-ckbtc-kyt.wasm.gz",
             TargetCanister::CkBtcLedger => "ic-icrc1-ledger.wasm.gz",
             TargetCanister::CkBtcMinter => "ic-ckbtc-minter.wasm.gz",


### PR DESCRIPTION
([XC-148](https://dfinity.atlassian.net/browse/XC-148)): NNS proposals to upgrade the ckBTC ledger suite (ledger, index and archive canisters) to `3d0b3f10417fc6708e8b5d844a0bac5e86f3e17d` to add support for the [ICRC-21: Canister Call Consent Messages](https://github.com/dfinity/wg-identity-authentication/blob/fd846030109710cab67d9381485a73db424f2b07/topics/ICRC-21/icrc_21_consent_msg.md) standard. 

[XC-148]: https://dfinity.atlassian.net/browse/XC-148?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ