### PR TITLE
test(ICP_index): FI-1445: Add ICP index canister to canister_ids.json and canister_wasms.sh

### DIFF
--- a/rs/nns/canister_ids.json
+++ b/rs/nns/canister_ids.json
@@ -11,6 +11,10 @@
     "local": "ryjl3-tyaaa-aaaaa-aaaba-cai",
     "mainnet": "ryjl3-tyaaa-aaaaa-aaaba-cai"
   },
+  "icp-index": {
+    "local": "qhbym-qaaaa-aaaaa-aaafq-cai",
+    "mainnet": "qhbym-qaaaa-aaaaa-aaafq-cai"
+  },
   "icp-ledger-archive": {
     "local": "qjdve-lqaaa-aaaaa-aaaeq-cai",
     "mainnet": "qjdve-lqaaa-aaaaa-aaaeq-cai"

--- a/testnet/tools/nns-tools/lib/canister_wasms.sh
+++ b/testnet/tools/nns-tools/lib/canister_wasms.sh
@@ -57,6 +57,8 @@ _canister_download_name_for_nns_canister_type() {
         echo "ledger-canister_notify-method"
     elif [ "$CANISTER_TYPE" == "icp-ledger-archive" ] || [ "$CANISTER_TYPE" == "icp-ledger-archive-1" ]; then
         echo "ledger-archive-node-canister"
+    elif [ "$CANISTER_TYPE" == "icp-index" ]; then
+        echo "ic-icp-index-canister"
     else
         echo "$CANISTER_TYPE"-canister
     fi


### PR DESCRIPTION
Add metadata regarding the ICP index canister to the `rs/nns/canister_ids.json` and `testnet/tools/nns-tools/lib/canister_wasms.sh` files, so that the `testnet/tools/nns-tools/test-canister-upgrade.sh` script can be used to upgrade the ICP index canister on the dynamic testnet with golden state.