### PR TITLE
fix(proposal-cli): use relative paths for generated `ic-admin` command

### DIFF
--- a/rs/cross-chain/proposal-cli/src/ic_admin/mod.rs
+++ b/rs/cross-chain/proposal-cli/src/ic_admin/mod.rs
@@ -6,7 +6,7 @@ use crate::proposal::ProposalTemplate;
 use askama::Template;
 use candid::Principal;
 use clap::Args;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf, StripPrefixError};
 
 #[derive(Debug, Clone, Args)]
 pub struct IcAdminArgs {
@@ -73,6 +73,16 @@ pub struct ProposalFiles {
     pub wasm: PathBuf,
     pub arg: PathBuf,
     pub summary: PathBuf,
+}
+
+impl ProposalFiles {
+    pub fn strip_prefix(self, base: &Path) -> Result<Self, StripPrefixError> {
+        Ok(Self {
+            wasm: self.wasm.strip_prefix(base)?.to_path_buf(),
+            arg: self.arg.strip_prefix(base)?.to_path_buf(),
+            summary: self.summary.strip_prefix(base)?.to_path_buf(),
+        })
+    }
 }
 
 #[derive(Template)]

--- a/rs/cross-chain/proposal-cli/src/main.rs
+++ b/rs/cross-chain/proposal-cli/src/main.rs
@@ -231,7 +231,9 @@ fn write_to_disk<P: Into<ProposalTemplate>>(
             wasm: artifact,
             arg: bin_args_file_path,
             summary: proposal_summary,
-        };
+        }
+        .strip_prefix(&output_dir)
+        .unwrap();
         let command = submit.render_command(&proposal, proposal_files);
         let submit_script = output_dir.join("submit.sh");
         let mut submit_file = fs::OpenOptions::new()


### PR DESCRIPTION
(XC-173): Improve the generated `ic-admin` command introduced in #1007 by using relative paths to reference the files associated with the submission of a proposal (wasm, binary arguments and summary). This is needed because typically the proposal will be submitted from a different machine than where those files were generated.