### PR TITLE
refactor(nervous_system): create ic-nervous-system-agent crate for interacting with the NNS and SNSes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9266,6 +9266,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b5c7628eac357aecda461130f8074468be5aa4d258a002032d82d817f79f1f8"
 
 [[package]]
+name = "ic-nervous-system-agent"
+version = "0.0.1"
+dependencies = [
+ "anyhow",
+ "candid",
+ "ic-agent",
+ "ic-nns-constants",
+ "ic-sns-wasm",
+ "tempfile",
+ "tokio",
+]
+
+[[package]]
 name = "ic-nervous-system-clients"
 version = "0.0.1"
 dependencies = [
@@ -19221,6 +19234,7 @@ dependencies = [
  "futures",
  "ic-agent",
  "ic-base-types",
+ "ic-nervous-system-agent",
  "ic-nervous-system-clients",
  "ic-nervous-system-common-test-keys",
  "ic-nns-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -160,6 +160,7 @@ members = [
     "rs/monitoring/logger",
     "rs/monitoring/metrics",
     "rs/monitoring/pprof",
+    "rs/nervous_system/agent",
     "rs/nervous_system/clients",
     "rs/nervous_system/collections/union_multi_map",
     "rs/nervous_system/common",

--- a/rs/nervous_system/agent/BUILD.bazel
+++ b/rs/nervous_system/agent/BUILD.bazel
@@ -1,0 +1,35 @@
+load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test")
+
+package(default_visibility = ["//visibility:public"])
+
+DEPENDENCIES = [
+    # Keep sorted.
+    "//rs/nns/constants",
+    "//rs/nns/sns-wasm",
+    "@crate_index//:anyhow",
+    "@crate_index//:candid",
+    "@crate_index//:ic-agent",
+    "@crate_index//:tempfile",
+    "@crate_index//:tokio",
+]
+
+DEV_DEPENDENCIES = DEPENDENCIES + [
+]
+
+MACRO_DEPENDENCIES = [
+]
+
+rust_library(
+    name = "agent",
+    srcs = glob(["src/**"]),
+    crate_name = "ic_nervous_system_agent",
+    proc_macro_deps = MACRO_DEPENDENCIES,
+    version = "0.0.1",
+    deps = DEPENDENCIES,
+)
+
+rust_test(
+    name = "agent_test",
+    crate = ":agent",
+    deps = DEV_DEPENDENCIES,
+)

--- a/rs/nervous_system/agent/Cargo.toml
+++ b/rs/nervous_system/agent/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "ic-nervous-system-agent"
+version = "0.0.1"
+edition = "2021"
+
+[lib]
+name = "ic_nervous_system_agent"
+path = "src/lib.rs"
+
+[dependencies]
+anyhow = { workspace = true }
+candid = { workspace = true }
+ic-agent = { workspace = true }
+ic-nns-constants = { path = "../../nns/constants" }
+ic-sns-wasm = { path = "../../nns/sns-wasm" }
+tempfile = { workspace = true }
+tokio = { workspace = true }

--- a/rs/nervous_system/agent/src/lib.rs
+++ b/rs/nervous_system/agent/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod nns;

--- a/rs/nervous_system/agent/src/nns/mod.rs
+++ b/rs/nervous_system/agent/src/nns/mod.rs
@@ -1,0 +1,1 @@
+pub mod sns_wasm;

--- a/rs/nervous_system/agent/src/nns/sns_wasm.rs
+++ b/rs/nervous_system/agent/src/nns/sns_wasm.rs
@@ -1,4 +1,4 @@
-use anyhow::{anyhow, Result}; // Make sure to include anyhow in your dependencies
+use anyhow::{anyhow, Result};
 use candid::{Decode, Encode, Principal};
 use ic_agent::Agent;
 use ic_nns_constants::SNS_WASM_CANISTER_ID;
@@ -11,7 +11,7 @@ use tokio::io::AsyncWriteExt;
 use tokio::io::BufWriter;
 use tokio::process::Command;
 
-pub(crate) async fn query_sns_upgrade_steps(agent: &Agent) -> Result<ListUpgradeStepsResponse> {
+pub async fn query_sns_upgrade_steps(agent: &Agent) -> Result<ListUpgradeStepsResponse> {
     let sns_wasm_canister_id = Principal::from(SNS_WASM_CANISTER_ID);
     let request = ListUpgradeStepsRequest {
         limit: 0,
@@ -28,7 +28,7 @@ pub(crate) async fn query_sns_upgrade_steps(agent: &Agent) -> Result<ListUpgrade
     Decode!(&response_bytes, ListUpgradeStepsResponse).map_err(|e| anyhow!(e))
 }
 
-pub(crate) async fn get_git_version_for_sns_hash(
+pub async fn get_git_version_for_sns_hash(
     agent: &Agent,
     ic_wasm_path: &Path,
     hash: &[u8],

--- a/rs/nervous_system/tools/sync-with-released-nevous-system-wasms/BUILD.bazel
+++ b/rs/nervous_system/tools/sync-with-released-nevous-system-wasms/BUILD.bazel
@@ -6,6 +6,7 @@ package(default_visibility = ["//visibility:public"])
 # See rs/nervous_system/feature_test.md
 DEPENDENCIES = [
     # Keep sorted.
+    "//rs/nervous_system/agent",
     "//rs/nervous_system/clients",
     "//rs/nns/common",
     "//rs/nns/constants",
@@ -30,7 +31,6 @@ rust_binary(
     name = "sync-with-released-nevous-system-wasms",
     srcs = [
         "src/main.rs",
-        "src/sns_wasm_utils.rs",
     ],
     args = ["$(location //:mainnet-canisters.bzl) $(location @crate_index//:ic-wasm__ic-wasm)"],
     data = [

--- a/rs/nervous_system/tools/sync-with-released-nevous-system-wasms/Cargo.toml
+++ b/rs/nervous_system/tools/sync-with-released-nevous-system-wasms/Cargo.toml
@@ -17,6 +17,7 @@ colored = "2.0.0"
 futures = { workspace = true }
 ic-agent = { workspace = true }
 ic-base-types = { path = "../../../types/base_types" }
+ic-nervous-system-agent = { path = "../../agent" }
 ic-nervous-system-clients = { path = "../../clients" }
 ic-nervous-system-common-test-keys = { path = "../../common/test_keys" }
 ic-nns-common = { path = "../../../nns/common" }

--- a/rs/nervous_system/tools/sync-with-released-nevous-system-wasms/src/main.rs
+++ b/rs/nervous_system/tools/sync-with-released-nevous-system-wasms/src/main.rs
@@ -2,6 +2,7 @@ use anyhow::{anyhow, Result};
 use futures::{stream, StreamExt};
 use ic_agent::Agent;
 use ic_base_types::CanisterId;
+use ic_nervous_system_agent::nns::sns_wasm;
 use ic_nns_constants::{
     CYCLES_MINTING_CANISTER_ID, GENESIS_TOKEN_CANISTER_ID, GOVERNANCE_CANISTER_ID,
     LEDGER_CANISTER_ID, LIFELINE_CANISTER_ID, REGISTRY_CANISTER_ID, ROOT_CANISTER_ID,
@@ -11,8 +12,6 @@ use std::env;
 use std::fs::File;
 use std::io::{BufRead, BufReader, Write};
 use std::path::{Path, PathBuf};
-
-mod sns_wasm_utils;
 
 pub const NNS_CANISTER_NAME_TO_ID: [(&str, CanisterId); 8] = [
     ("registry", REGISTRY_CANISTER_ID),
@@ -84,7 +83,7 @@ async fn main() -> Result<()> {
         .into_iter()
         .collect::<Result<Vec<CanisterUpdate>>>()?;
 
-    let sns_upgrade_steps = sns_wasm_utils::query_sns_upgrade_steps(&agent).await?;
+    let sns_upgrade_steps = sns_wasm::query_sns_upgrade_steps(&agent).await?;
     let latest_sns_version = &sns_upgrade_steps
         .steps
         .last()
@@ -131,8 +130,7 @@ async fn main() -> Result<()> {
             .then(|(canister_name, hash, new_sha256)| async {
                 let canister_name = canister_name.to_string();
                 let new_git_hash =
-                    sns_wasm_utils::get_git_version_for_sns_hash(&agent, &ic_wasm_path, hash)
-                        .await?;
+                    sns_wasm::get_git_version_for_sns_hash(&agent, &ic_wasm_path, hash).await?;
 
                 Ok(CanisterUpdate {
                     canister_name,


### PR DESCRIPTION
I thought it would make sense to have a crate where we would put various helper functions for interaction with SNSes and the NNS. Right now, the only rust helper functions I'm aware of are in some in `//rs/nervous_system/tools/sync-with-released-nevous-system-wasms` for interacting with SNS-W, so I moved just those for now. There are also some that were developed for use in system tests, but they are not trivial to extract so I haven't yet. 

[Next PR →](https://github.com/dfinity/ic/pull/1091)

