### PR TITLE
feat(nns): Use `Some(vec![])` to represent empty args and disallow `None`

### DIFF
--- a/rs/nns/governance/src/governance.rs
+++ b/rs/nns/governance/src/governance.rs
@@ -998,11 +998,6 @@ impl Action {
                 }
                 Action::ExecuteNnsFunction(execute_nns_function)
             }
-            Action::InstallCode(mut install_code) => {
-                install_code.wasm_module = None;
-                install_code.arg = None;
-                Action::InstallCode(install_code)
-            }
             action => action,
         }
     }
@@ -3698,11 +3693,7 @@ impl Governance {
         let proposal = if multi_query {
             if let Some(
                 proposal @ Proposal {
-                    action:
-                        Some(
-                            proposal::Action::ExecuteNnsFunction(_)
-                            | proposal::Action::InstallCode(_),
-                        ),
+                    action: Some(proposal::Action::ExecuteNnsFunction(_)),
                     ..
                 },
             ) = data.proposal.clone()

--- a/rs/nns/governance/src/pb/conversions.rs
+++ b/rs/nns/governance/src/pb/conversions.rs
@@ -2900,7 +2900,12 @@ impl From<pb::InstallCode> for pb_api::InstallCode {
         let wasm_module_hash = item
             .wasm_module
             .map(|wasm_module| super::calculate_hash(&wasm_module).to_vec());
-        let arg_hash = item.arg.map(|arg| super::calculate_hash(&arg).to_vec());
+        let arg = item.arg.unwrap_or_default();
+        let arg_hash = if arg.is_empty() {
+            Some(vec![])
+        } else {
+            Some(super::calculate_hash(&arg).to_vec())
+        };
 
         Self {
             canister_id: item.canister_id,

--- a/rs/nns/governance/src/pb/mod.rs
+++ b/rs/nns/governance/src/pb/mod.rs
@@ -32,3 +32,6 @@ fn calculate_hash(bytes: &[u8]) -> [u8; 32] {
     wasm_sha.write(bytes);
     wasm_sha.finish()
 }
+
+#[cfg(test)]
+mod tests;

--- a/rs/nns/governance/src/pb/tests.rs
+++ b/rs/nns/governance/src/pb/tests.rs
@@ -1,0 +1,47 @@
+use super::*;
+
+use crate::pb::v1 as pb;
+use ic_base_types::PrincipalId;
+use ic_nns_governance_api::pb::v1 as pb_api;
+
+#[test]
+fn install_code_internal_to_api() {
+    let test_cases = vec![
+        (
+            pb::InstallCode {
+                canister_id: Some(PrincipalId::new_user_test_id(1)),
+                install_mode: Some(pb::install_code::CanisterInstallMode::Install as i32),
+                skip_stopping_before_installing: None,
+                wasm_module: Some(vec![1, 2, 3]),
+                arg: Some(vec![]),
+            },
+            pb_api::InstallCode {
+                canister_id: Some(PrincipalId::new_user_test_id(1)),
+                install_mode: Some(pb_api::install_code::CanisterInstallMode::Install as i32),
+                skip_stopping_before_installing: None,
+                wasm_module_hash: Some(Sha256::hash(&[1, 2, 3]).to_vec()),
+                arg_hash: Some(vec![]),
+            },
+        ),
+        (
+            pb::InstallCode {
+                canister_id: Some(PrincipalId::new_user_test_id(1)),
+                install_mode: Some(pb::install_code::CanisterInstallMode::Upgrade as i32),
+                skip_stopping_before_installing: Some(true),
+                wasm_module: Some(vec![1, 2, 3]),
+                arg: Some(vec![4, 5, 6]),
+            },
+            pb_api::InstallCode {
+                canister_id: Some(PrincipalId::new_user_test_id(1)),
+                install_mode: Some(pb_api::install_code::CanisterInstallMode::Upgrade as i32),
+                skip_stopping_before_installing: Some(true),
+                wasm_module_hash: Some(Sha256::hash(&[1, 2, 3]).to_vec()),
+                arg_hash: Some(Sha256::hash(&[4, 5, 6]).to_vec()),
+            },
+        ),
+    ];
+
+    for (internal, api) in test_cases {
+        assert_eq!(pb_api::InstallCode::from(internal), api);
+    }
+}

--- a/rs/nns/governance/src/proposals/install_code.rs
+++ b/rs/nns/governance/src/proposals/install_code.rs
@@ -32,6 +32,7 @@ impl InstallCode {
         let _ = self.valid_canister_id()?;
         let _ = self.valid_install_mode()?;
         let _ = self.valid_wasm_module()?;
+        let _ = self.valid_arg()?;
         let _ = self.valid_topic()?;
         let _ = self.canister_and_function()?;
 
@@ -75,6 +76,12 @@ impl InstallCode {
             .ok_or(invalid_proposal_error("Wasm module is required"))
     }
 
+    fn valid_arg(&self) -> Result<&Vec<u8>, GovernanceError> {
+        self.arg
+            .as_ref()
+            .ok_or(invalid_proposal_error("Argument is required"))
+    }
+
     pub fn valid_topic(&self) -> Result<Topic, GovernanceError> {
         let canister_id = self.valid_canister_id()?;
         Ok(topic_to_manage_canister(&canister_id))
@@ -98,7 +105,7 @@ impl InstallCode {
         let mode = self.valid_install_mode()?;
         let canister_id = self.valid_canister_id()?;
         let wasm_module = self.valid_wasm_module()?.clone();
-        let arg = self.arg.clone().unwrap_or_default();
+        let arg = self.valid_arg()?.clone();
         let compute_allocation = None;
         let memory_allocation = None;
 
@@ -255,6 +262,14 @@ mod tests {
                 ..valid_install_code.clone()
             },
             vec!["wasm module", "required"],
+        );
+
+        is_invalid_proposal_with_keywords(
+            InstallCode {
+                arg: None,
+                ..valid_install_code.clone()
+            },
+            vec!["argument", "required"],
         );
 
         is_invalid_proposal_with_keywords(

--- a/rs/nns/governance/src/proposals/install_code.rs
+++ b/rs/nns/governance/src/proposals/install_code.rs
@@ -374,7 +374,7 @@ mod tests {
             canister_id: Some(LIFELINE_CANISTER_ID.get()),
             wasm_module: Some(vec![1, 2, 3]),
             install_mode: Some(CanisterInstallMode::Reinstall as i32),
-            arg: None,
+            arg: Some(vec![]),
             skip_stopping_before_installing: Some(true),
         };
 

--- a/rs/nns/governance/tests/governance.rs
+++ b/rs/nns/governance/tests/governance.rs
@@ -61,7 +61,6 @@ use ic_nns_governance::{
         governance_error::ErrorType::{
             self, InsufficientFunds, NotAuthorized, NotFound, PreconditionFailed, ResourceExhausted,
         },
-        install_code::CanisterInstallMode,
         manage_neuron::{
             self,
             claim_or_refresh::{By, MemoAndController},
@@ -80,7 +79,7 @@ use ic_nns_governance::{
         AddOrRemoveNodeProvider, ApproveGenesisKyc, Ballot, BallotChange, BallotInfo,
         BallotInfoChange, CreateServiceNervousSystem, Empty, ExecuteNnsFunction,
         Governance as GovernanceProto, GovernanceChange, GovernanceError,
-        IdealMatchedParticipationFunction, InstallCode, KnownNeuron, KnownNeuronData, ListNeurons,
+        IdealMatchedParticipationFunction, KnownNeuron, KnownNeuronData, ListNeurons,
         ListProposalInfo, ListProposalInfoResponse, ManageNeuron, ManageNeuronResponse,
         MonthlyNodeProviderRewards, Motion, NetworkEconomics, Neuron, NeuronChange, NeuronState,
         NeuronType, NeuronsFundData, NeuronsFundParticipation, NeuronsFundSnapshot, NnsFunction,
@@ -7666,68 +7665,6 @@ fn test_list_proposals_removes_execute_nns_function_payload() {
         action,
         proposal::Action::ExecuteNnsFunction(eu) if eu.payload.is_empty()
     );
-}
-
-#[test]
-fn test_list_proposals_removes_install_code_large_fields() {
-    let original_install_code = InstallCode {
-        wasm_module: Some(vec![0; 100_000]),
-        arg: Some(vec![0; 1_000]),
-        install_mode: Some(CanisterInstallMode::Upgrade as i32),
-        canister_id: Some(GOVERNANCE_CANISTER_ID.into()),
-        skip_stopping_before_installing: Some(false),
-    };
-    let proto = GovernanceProto {
-        economics: Some(NetworkEconomics::with_default_values()),
-        proposals: btreemap! {
-            1 => ProposalData {
-                id: Some(ProposalId { id: 1 }),
-                proposal: Some(Proposal {
-                    title: Some("Upgrade canister".to_string()),
-                    action: Some(proposal::Action::InstallCode(original_install_code.clone())),
-                    ..Default::default()
-                }),
-                ..Default::default()
-            }
-        },
-        ..Default::default()
-    };
-    let driver = fake::FakeDriver::default();
-    let gov = Governance::new(
-        proto,
-        driver.get_fake_env(),
-        driver.get_fake_ledger(),
-        driver.get_fake_cmc(),
-    );
-    let caller = &principal(1);
-
-    let results = gov.list_proposals(
-        caller,
-        &ListProposalInfo {
-            ..Default::default()
-        },
-    );
-
-    let action = results.proposal_info[0]
-        .proposal
-        .as_ref()
-        .unwrap()
-        .action
-        .as_ref()
-        .unwrap();
-    match action {
-        proposal::Action::InstallCode(install_code) => {
-            assert_eq!(
-                install_code,
-                &InstallCode {
-                    wasm_module: None,
-                    arg: None,
-                    ..original_install_code
-                }
-            );
-        }
-        _ => panic!("Unexpected action"),
-    };
 }
 
 #[test]

--- a/rs/nns/integration_tests/src/canister_upgrade.rs
+++ b/rs/nns/integration_tests/src/canister_upgrade.rs
@@ -1,8 +1,8 @@
-use candid::Encode;
 use canister_test::Wasm;
 use ic_base_types::{CanisterId, PrincipalId};
 use ic_crypto_sha2::Sha256;
 use ic_nns_constants::{GOVERNANCE_CANISTER_ID, LIFELINE_CANISTER_ID, ROOT_CANISTER_ID};
+use ic_nns_governance_api::pb::v1::{install_code::CanisterInstallMode, proposal::Action};
 use ic_nns_test_utils::common::{
     build_governance_wasm, build_lifeline_wasm, build_root_wasm, modify_wasm_bytes,
 };
@@ -10,7 +10,8 @@ use ic_nns_test_utils::{
     common::NnsInitPayloadsBuilder,
     neuron_helpers::get_neuron_1,
     state_test_helpers::{
-        nns_propose_upgrade_nns_canister, setup_nns_canisters, state_machine_builder_for_nns_tests,
+        nns_governance_get_proposal_info_as_anonymous, nns_propose_upgrade_nns_canister,
+        setup_nns_canisters, state_machine_builder_for_nns_tests,
         wait_for_canister_upgrade_to_succeed,
     },
 };
@@ -24,13 +25,13 @@ fn test_upgrade_canister(canister_id: CanisterId, canister_wasm: Wasm, use_propo
 
     let modified_wasm = modify_wasm_bytes(&canister_wasm.bytes(), 42);
 
-    let _proposal_id = nns_propose_upgrade_nns_canister(
+    let proposal_id = nns_propose_upgrade_nns_canister(
         &state_machine,
         n1.principal_id,
         n1.neuron_id,
         canister_id,
         modified_wasm.clone(),
-        Encode!(&()).unwrap(),
+        vec![],
         use_proposal_action,
     );
 
@@ -46,6 +47,27 @@ fn test_upgrade_canister(canister_id: CanisterId, canister_wasm: Wasm, use_propo
         &Sha256::hash(&modified_wasm),
         controller_canister_id,
     );
+
+    if use_proposal_action {
+        let proposal_info =
+            nns_governance_get_proposal_info_as_anonymous(&state_machine, proposal_id.id);
+        let action = proposal_info.proposal.unwrap().action.unwrap();
+        if let Action::InstallCode(install_code) = action {
+            assert_eq!(
+                install_code.wasm_module_hash,
+                Some(Sha256::hash(&modified_wasm).to_vec())
+            );
+            assert_eq!(install_code.arg_hash, Some(vec![]));
+            assert_eq!(
+                install_code.install_mode,
+                Some(CanisterInstallMode::Upgrade as i32)
+            );
+            assert_eq!(install_code.canister_id, Some(canister_id.get()));
+            assert_eq!(install_code.skip_stopping_before_installing, None);
+        } else {
+            panic!("Unexpected action: {:?}", action);
+        }
+    }
 }
 
 #[test]

--- a/rs/registry/admin/src/main.rs
+++ b/rs/registry/admin/src/main.rs
@@ -1126,7 +1126,11 @@ impl ProposalAction for ProposeToChangeNnsCanisterCmd {
             )
             .await,
         );
-        let arg = self.arg.as_ref().map(|path| read_file_fully(path));
+        let arg = Some(
+            self.arg
+                .as_ref()
+                .map_or(vec![], |path| read_file_fully(path)),
+        );
         let skip_stopping_before_installing = Some(self.skip_stopping_before_installing);
         let install_mode = match self.mode {
             CanisterInstallMode::Install => Some(GovernanceInstallMode::Install as i32),


### PR DESCRIPTION
# Why

The predecessor of `InstallCode` - the NnsCanisterUpgrade function has `Vec<u8>` as the type of [the arg](https://github.com/dfinity/ic/blob/2a2b74684b55c40d514c2e80165432e906dddbf5/rs/nervous_system/root/src/change_canister.rs#L49). We should keep this consistency.

# What

* Only hashes the arg if it's not empty, and returns empty string if the arg is empty. It would be more difficult to understand if we return `sha256([])` instead
* Disallow `None` when submitting the proposal. Since `ic0.install_code` accepts `vec nat8`, we don't want to allow 2 ways (`Some(vec![])`, or `None`) to represent the same thing.
* Send `vec![]` when creating the proposal in ic-admin
* A minor change to stop truncating `wasm_module` and `arg` within the governance crate, since the API type conversion already avoid large fields