### PR TITLE
refactor(nervous_system): Added a `request` trait to simplify interacting with our canisters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9483,6 +9483,7 @@ dependencies = [
  "ic-agent",
  "ic-nns-constants",
  "ic-sns-wasm",
+ "serde",
  "tempfile",
  "tokio",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9475,6 +9475,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "ic-nervous-system-interaction"
+version = "0.0.1"
+dependencies = [
+ "anyhow",
+ "candid",
+ "ic-agent",
+ "ic-nns-constants",
+ "ic-sns-wasm",
+ "tempfile",
+ "tokio",
+]
+
+[[package]]
 name = "ic-nervous-system-lock"
 version = "0.0.1"
 dependencies = [
@@ -19252,6 +19265,7 @@ dependencies = [
  "ic-base-types",
  "ic-nervous-system-clients",
  "ic-nervous-system-common-test-keys",
+ "ic-nervous-system-interaction",
  "ic-nns-common",
  "ic-nns-constants",
  "ic-nns-governance",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -169,6 +169,7 @@ members = [
     "rs/nervous_system/common/test_utils",
     "rs/nervous_system/humanize",
     "rs/nervous_system/integration_tests",
+    "rs/nervous_system/interaction",
     "rs/nervous_system/lock",
     "rs/nervous_system/neurons_fund",
     "rs/nervous_system/neurons_fund/nfplot",

--- a/rs/nervous_system/interaction/BUILD.bazel
+++ b/rs/nervous_system/interaction/BUILD.bazel
@@ -9,6 +9,7 @@ DEPENDENCIES = [
     "@crate_index//:anyhow",
     "@crate_index//:candid",
     "@crate_index//:ic-agent",
+    "@crate_index//:serde",
     "@crate_index//:tempfile",
     "@crate_index//:tokio",
 ]

--- a/rs/nervous_system/interaction/BUILD.bazel
+++ b/rs/nervous_system/interaction/BUILD.bazel
@@ -1,0 +1,35 @@
+load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test")
+
+package(default_visibility = ["//visibility:public"])
+
+DEPENDENCIES = [
+    # Keep sorted.
+    "//rs/nns/constants",
+    "//rs/nns/sns-wasm",
+    "@crate_index//:anyhow",
+    "@crate_index//:candid",
+    "@crate_index//:ic-agent",
+    "@crate_index//:tempfile",
+    "@crate_index//:tokio",
+]
+
+DEV_DEPENDENCIES = DEPENDENCIES + [
+]
+
+MACRO_DEPENDENCIES = [
+]
+
+rust_library(
+    name = "interaction",
+    srcs = glob(["src/**"]),
+    crate_name = "ic_nervous_system_interaction",
+    proc_macro_deps = MACRO_DEPENDENCIES,
+    version = "0.0.1",
+    deps = DEPENDENCIES,
+)
+
+rust_test(
+    name = "interaction_test",
+    crate = ":interaction",
+    deps = DEV_DEPENDENCIES,
+)

--- a/rs/nervous_system/interaction/Cargo.toml
+++ b/rs/nervous_system/interaction/Cargo.toml
@@ -13,5 +13,6 @@ candid = { workspace = true }
 ic-agent = { workspace = true }
 ic-nns-constants = { path = "../../nns/constants" }
 ic-sns-wasm = { path = "../../nns/sns-wasm" }
+serde = { workspace = true }
 tempfile = { workspace = true }
 tokio = { workspace = true }

--- a/rs/nervous_system/interaction/Cargo.toml
+++ b/rs/nervous_system/interaction/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "ic-nervous-system-interaction"
+version = "0.0.1"
+edition = "2021"
+
+[lib]
+name = "ic_nervous_system_interaction"
+path = "src/lib.rs"
+
+[dependencies]
+anyhow = { workspace = true }
+candid = { workspace = true }
+ic-agent = { workspace = true }
+ic-nns-constants = { path = "../../nns/constants" }
+ic-sns-wasm = { path = "../../nns/sns-wasm" }
+tempfile = { workspace = true }
+tokio = { workspace = true }

--- a/rs/nervous_system/interaction/src/lib.rs
+++ b/rs/nervous_system/interaction/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod nns;

--- a/rs/nervous_system/interaction/src/lib.rs
+++ b/rs/nervous_system/interaction/src/lib.rs
@@ -1,1 +1,2 @@
 pub mod nns;
+pub mod request;

--- a/rs/nervous_system/interaction/src/nns/mod.rs
+++ b/rs/nervous_system/interaction/src/nns/mod.rs
@@ -1,0 +1,1 @@
+pub mod sns_wasm;

--- a/rs/nervous_system/interaction/src/nns/sns_wasm.rs
+++ b/rs/nervous_system/interaction/src/nns/sns_wasm.rs
@@ -1,9 +1,10 @@
 use anyhow::{anyhow, Result};
-use candid::{Decode, Encode, Principal};
 use ic_agent::Agent;
 use ic_nns_constants::SNS_WASM_CANISTER_ID;
-use ic_sns_wasm::pb::v1::{GetWasmRequest, GetWasmResponse};
-use ic_sns_wasm::pb::v1::{ListUpgradeStepsRequest, ListUpgradeStepsResponse};
+use ic_sns_wasm::pb::v1::{
+    GetWasmRequest, GetWasmResponse, ListDeployedSnsesRequest, ListDeployedSnsesResponse,
+    ListUpgradeStepsRequest, ListUpgradeStepsResponse,
+};
 use std::path::{Path, PathBuf};
 use tempfile::tempdir;
 use tokio::fs::File;
@@ -11,21 +12,15 @@ use tokio::io::AsyncWriteExt;
 use tokio::io::BufWriter;
 use tokio::process::Command;
 
+use crate::request::call;
+
 pub async fn query_sns_upgrade_steps(agent: &Agent) -> Result<ListUpgradeStepsResponse> {
-    let sns_wasm_canister_id = Principal::from(SNS_WASM_CANISTER_ID);
     let request = ListUpgradeStepsRequest {
         limit: 0,
         sns_governance_canister_id: None,
         starting_at: None,
     };
-    let request_bytes = Encode!(&request)?;
-    let response = agent
-        .query(&sns_wasm_canister_id, "list_upgrade_steps")
-        .with_arg(request_bytes)
-        .call()
-        .await?;
-    let response_bytes = response.as_slice();
-    Decode!(&response_bytes, ListUpgradeStepsResponse).map_err(|e| anyhow!(e))
+    call(agent, SNS_WASM_CANISTER_ID, request).await
 }
 
 pub async fn get_git_version_for_sns_hash(
@@ -33,27 +28,21 @@ pub async fn get_git_version_for_sns_hash(
     ic_wasm_path: &Path,
     hash: &[u8],
 ) -> Result<String> {
-    let sns_wasm_canister_id = Principal::from(SNS_WASM_CANISTER_ID);
-
-    let arg = candid::Encode!(&GetWasmRequest {
+    let request = GetWasmRequest {
         hash: hash.to_vec(),
-    })?;
-    let response = agent
-        .query(&sns_wasm_canister_id, "get_wasm")
-        .with_arg(arg)
-        .call()
-        .await?;
-    let response = Decode!(&response.as_slice(), GetWasmResponse).map_err(|e| anyhow!(e))?;
+    };
+    let response: GetWasmResponse = call(agent, SNS_WASM_CANISTER_ID, request).await?;
 
     let dir = tempdir()?;
-
     let wasm_file_gz: PathBuf = write_wasm_to_temp_file(&response, dir.path()).await?;
-
     let wasm_file: PathBuf = decompress_gzip(&wasm_file_gz).await?;
-
     let git_commit_id = extract_git_commit_id(&wasm_file, ic_wasm_path).await?;
 
     Ok(git_commit_id)
+}
+
+pub async fn list_deployed_snses(agent: &Agent) -> Result<ListDeployedSnsesResponse> {
+    call(agent, SNS_WASM_CANISTER_ID, ListDeployedSnsesRequest {}).await
 }
 
 async fn write_wasm_to_temp_file(

--- a/rs/nervous_system/interaction/src/nns/sns_wasm.rs
+++ b/rs/nervous_system/interaction/src/nns/sns_wasm.rs
@@ -1,4 +1,4 @@
-use anyhow::{anyhow, Result}; // Make sure to include anyhow in your dependencies
+use anyhow::{anyhow, Result};
 use candid::{Decode, Encode, Principal};
 use ic_agent::Agent;
 use ic_nns_constants::SNS_WASM_CANISTER_ID;
@@ -11,7 +11,7 @@ use tokio::io::AsyncWriteExt;
 use tokio::io::BufWriter;
 use tokio::process::Command;
 
-pub(crate) async fn query_sns_upgrade_steps(agent: &Agent) -> Result<ListUpgradeStepsResponse> {
+pub async fn query_sns_upgrade_steps(agent: &Agent) -> Result<ListUpgradeStepsResponse> {
     let sns_wasm_canister_id = Principal::from(SNS_WASM_CANISTER_ID);
     let request = ListUpgradeStepsRequest {
         limit: 0,
@@ -28,7 +28,7 @@ pub(crate) async fn query_sns_upgrade_steps(agent: &Agent) -> Result<ListUpgrade
     Decode!(&response_bytes, ListUpgradeStepsResponse).map_err(|e| anyhow!(e))
 }
 
-pub(crate) async fn get_git_version_for_sns_hash(
+pub async fn get_git_version_for_sns_hash(
     agent: &Agent,
     ic_wasm_path: &Path,
     hash: &[u8],

--- a/rs/nervous_system/interaction/src/request.rs
+++ b/rs/nervous_system/interaction/src/request.rs
@@ -1,0 +1,67 @@
+use anyhow::{anyhow, Result};
+use candid::{CandidType, Decode, Encode, Principal};
+use ic_agent::Agent;
+use ic_sns_wasm::pb::v1::{
+    GetWasmRequest, GetWasmResponse, ListDeployedSnsesRequest, ListDeployedSnsesResponse,
+    ListUpgradeStepsRequest, ListUpgradeStepsResponse,
+};
+use serde::de::DeserializeOwned;
+
+pub trait Request: CandidType {
+    type Response: CandidType + DeserializeOwned;
+    const METHOD: &'static str;
+
+    /// Indicates whether the request should be called as a query or an update
+    const UPDATE: bool;
+}
+
+pub async fn call<R: Request>(
+    agent: &Agent,
+    canister_id: impl Into<Principal>,
+    request: R,
+) -> Result<R::Response> {
+    let canister_id = canister_id.into();
+    let request_bytes = Encode!(&request)?;
+    let response = if R::UPDATE {
+        let request = agent
+            .update(&canister_id, R::METHOD)
+            .with_arg(request_bytes)
+            .call()
+            .await?;
+        match request {
+            ic_agent::agent::CallResponse::Response(response) => response,
+            ic_agent::agent::CallResponse::Poll(request_id) => {
+                println!("Waiting for the request to {} to complete...", R::METHOD);
+                agent.wait(&request_id, canister_id).await?
+            }
+        }
+    } else {
+        agent
+            .query(&canister_id, R::METHOD)
+            .with_arg(request_bytes)
+            .call()
+            .await?
+    };
+
+    Decode!(response.as_slice(), R::Response).map_err(|e| anyhow!(e))
+}
+
+// Implementations
+
+impl Request for ListDeployedSnsesRequest {
+    type Response = ListDeployedSnsesResponse;
+    const METHOD: &'static str = "list_deployed_snses";
+    const UPDATE: bool = false;
+}
+
+impl Request for GetWasmRequest {
+    type Response = GetWasmResponse;
+    const METHOD: &'static str = "get_wasm";
+    const UPDATE: bool = false;
+}
+
+impl Request for ListUpgradeStepsRequest {
+    type Response = ListUpgradeStepsResponse;
+    const METHOD: &'static str = "list_upgrade_steps";
+    const UPDATE: bool = false;
+}

--- a/rs/nervous_system/tools/sync-with-released-nevous-system-wasms/BUILD.bazel
+++ b/rs/nervous_system/tools/sync-with-released-nevous-system-wasms/BUILD.bazel
@@ -7,6 +7,7 @@ package(default_visibility = ["//visibility:public"])
 DEPENDENCIES = [
     # Keep sorted.
     "//rs/nervous_system/clients",
+    "//rs/nervous_system/interaction",
     "//rs/nns/common",
     "//rs/nns/constants",
     "//rs/nns/governance",
@@ -30,7 +31,6 @@ rust_binary(
     name = "sync-with-released-nevous-system-wasms",
     srcs = [
         "src/main.rs",
-        "src/sns_wasm_utils.rs",
     ],
     args = ["$(location //:mainnet-canisters.bzl) $(location @crate_index//:ic-wasm__ic-wasm)"],
     data = [

--- a/rs/nervous_system/tools/sync-with-released-nevous-system-wasms/Cargo.toml
+++ b/rs/nervous_system/tools/sync-with-released-nevous-system-wasms/Cargo.toml
@@ -25,6 +25,7 @@ ic-nns-governance = { path = "../../../nns/governance" }
 ic-sns-governance = { path = "../../../sns/governance" }
 ic-sns-swap = { path = "../../../sns/swap" }
 ic-sns-wasm = { path = "../../../nns/sns-wasm" }
+ic-nervous-system-interaction = { path = "../../interaction" }
 rgb = "0.8.37"
 serde = { workspace = true }
 tempfile = { workspace = true }

--- a/rs/nervous_system/tools/sync-with-released-nevous-system-wasms/src/main.rs
+++ b/rs/nervous_system/tools/sync-with-released-nevous-system-wasms/src/main.rs
@@ -2,6 +2,7 @@ use anyhow::{anyhow, Result};
 use futures::{stream, StreamExt};
 use ic_agent::Agent;
 use ic_base_types::CanisterId;
+use ic_nervous_system_interaction::nns::sns_wasm;
 use ic_nns_constants::{
     CYCLES_MINTING_CANISTER_ID, GENESIS_TOKEN_CANISTER_ID, GOVERNANCE_CANISTER_ID,
     LEDGER_CANISTER_ID, LIFELINE_CANISTER_ID, REGISTRY_CANISTER_ID, ROOT_CANISTER_ID,
@@ -11,8 +12,6 @@ use std::env;
 use std::fs::File;
 use std::io::{BufRead, BufReader, Write};
 use std::path::{Path, PathBuf};
-
-mod sns_wasm_utils;
 
 pub const NNS_CANISTER_NAME_TO_ID: [(&str, CanisterId); 8] = [
     ("registry", REGISTRY_CANISTER_ID),
@@ -84,7 +83,7 @@ async fn main() -> Result<()> {
         .into_iter()
         .collect::<Result<Vec<CanisterUpdate>>>()?;
 
-    let sns_upgrade_steps = sns_wasm_utils::query_sns_upgrade_steps(&agent).await?;
+    let sns_upgrade_steps = sns_wasm::query_sns_upgrade_steps(&agent).await?;
     let latest_sns_version = &sns_upgrade_steps
         .steps
         .last()
@@ -131,8 +130,7 @@ async fn main() -> Result<()> {
             .then(|(canister_name, hash, new_sha256)| async {
                 let canister_name = canister_name.to_string();
                 let new_git_hash =
-                    sns_wasm_utils::get_git_version_for_sns_hash(&agent, &ic_wasm_path, hash)
-                        .await?;
+                    sns_wasm::get_git_version_for_sns_hash(&agent, &ic_wasm_path, hash).await?;
 
                 Ok(CanisterUpdate {
                     canister_name,


### PR DESCRIPTION
In the future I would like to automatically generate `Request` implementations from our candid files or from the code that causes them to be generated, but for now they are not that tedious to implement manually