### PR TITLE
feat(ic-admin): Print hashes rather than entire blobs when submitting InstallCode proposals

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9719,6 +9719,7 @@ dependencies = [
  "candid",
  "comparable",
  "ic-base-types",
+ "ic-crypto-sha2",
  "ic-nervous-system-clients",
  "ic-nervous-system-proto",
  "ic-nns-common",

--- a/rs/nns/governance/api/BUILD.bazel
+++ b/rs/nns/governance/api/BUILD.bazel
@@ -5,6 +5,7 @@ package(default_visibility = ["//visibility:public"])
 # See rs/nervous_system/feature_test.md
 BASE_DEPENDENCIES = [
     # Keep sorted.
+    "//rs/crypto/sha2",
     "//rs/nervous_system/clients",
     "//rs/nervous_system/proto",
     "//rs/nns/common",

--- a/rs/nns/governance/api/Cargo.toml
+++ b/rs/nns/governance/api/Cargo.toml
@@ -15,6 +15,7 @@ bytes = { workspace = true }
 candid = { workspace = true }
 comparable = { version = "0.5", features = ["derive"] }
 ic-base-types = { path = "../../../types/base_types" }
+ic-crypto-sha2 = { path = "../../../crypto/sha2" }
 ic-nervous-system-clients = { path = "../../../nervous_system/clients" }
 ic-nervous-system-proto = { path = "../../../nervous_system/proto" }
 ic-nns-common = { path = "../../common" }

--- a/rs/nns/governance/api/src/proposal_helpers.rs
+++ b/rs/nns/governance/api/src/proposal_helpers.rs
@@ -80,7 +80,9 @@ pub fn decode_make_proposal_response(response: Vec<u8>) -> Result<ProposalId, St
 // being `prost::Message`. The API types still are `prost::Message` because we have some legacy pb
 // endpoints. The conversions make it possible for ic-admin to print the proposal in the format of
 // the response API types.
-// TODO: Remove this after de
+//
+// TODO: Remove this after defining the `Debug` trait in the API types and using them to print
+// proposals in ic-admin.
 fn calculate_hash(bytes: &[u8]) -> [u8; 32] {
     let mut wasm_sha = Sha256::new();
     wasm_sha.write(bytes);
@@ -91,31 +93,25 @@ impl From<ProposalActionRequest> for Action {
     fn from(action: ProposalActionRequest) -> Self {
         match action {
             ProposalActionRequest::ManageNeuron(v) => Action::ManageNeuron(Box::new((*v).into())),
-            ProposalActionRequest::ManageNetworkEconomics(v) => {
-                Action::ManageNetworkEconomics(v.into())
-            }
-            ProposalActionRequest::Motion(v) => Action::Motion(v.into()),
-            ProposalActionRequest::ExecuteNnsFunction(v) => Action::ExecuteNnsFunction(v.into()),
-            ProposalActionRequest::ApproveGenesisKyc(v) => Action::ApproveGenesisKyc(v.into()),
-            ProposalActionRequest::AddOrRemoveNodeProvider(v) => {
-                Action::AddOrRemoveNodeProvider(v.into())
-            }
-            ProposalActionRequest::RewardNodeProvider(v) => Action::RewardNodeProvider(v.into()),
-            ProposalActionRequest::SetDefaultFollowees(v) => Action::SetDefaultFollowees(v.into()),
-            ProposalActionRequest::RewardNodeProviders(v) => Action::RewardNodeProviders(v.into()),
-            ProposalActionRequest::RegisterKnownNeuron(v) => Action::RegisterKnownNeuron(v.into()),
+            ProposalActionRequest::ManageNetworkEconomics(v) => Action::ManageNetworkEconomics(v),
+            ProposalActionRequest::Motion(v) => Action::Motion(v),
+            ProposalActionRequest::ExecuteNnsFunction(v) => Action::ExecuteNnsFunction(v),
+            ProposalActionRequest::ApproveGenesisKyc(v) => Action::ApproveGenesisKyc(v),
+            ProposalActionRequest::AddOrRemoveNodeProvider(v) => Action::AddOrRemoveNodeProvider(v),
+            ProposalActionRequest::RewardNodeProvider(v) => Action::RewardNodeProvider(v),
+            ProposalActionRequest::SetDefaultFollowees(v) => Action::SetDefaultFollowees(v),
+            ProposalActionRequest::RewardNodeProviders(v) => Action::RewardNodeProviders(v),
+            ProposalActionRequest::RegisterKnownNeuron(v) => Action::RegisterKnownNeuron(v),
             ProposalActionRequest::SetSnsTokenSwapOpenTimeWindow(v) => {
-                Action::SetSnsTokenSwapOpenTimeWindow(v.into())
+                Action::SetSnsTokenSwapOpenTimeWindow(v)
             }
-            ProposalActionRequest::OpenSnsTokenSwap(v) => Action::OpenSnsTokenSwap(v.into()),
+            ProposalActionRequest::OpenSnsTokenSwap(v) => Action::OpenSnsTokenSwap(v),
             ProposalActionRequest::CreateServiceNervousSystem(v) => {
-                Action::CreateServiceNervousSystem(v.into())
+                Action::CreateServiceNervousSystem(v)
             }
             ProposalActionRequest::InstallCode(v) => Action::InstallCode(v.into()),
-            ProposalActionRequest::StopOrStartCanister(v) => Action::StopOrStartCanister(v.into()),
-            ProposalActionRequest::UpdateCanisterSettings(v) => {
-                Action::UpdateCanisterSettings(v.into())
-            }
+            ProposalActionRequest::StopOrStartCanister(v) => Action::StopOrStartCanister(v),
+            ProposalActionRequest::UpdateCanisterSettings(v) => Action::UpdateCanisterSettings(v),
         }
     }
 }
@@ -124,9 +120,7 @@ impl From<ManageNeuronRequest> for ManageNeuron {
     fn from(manage_neuron_request: ManageNeuronRequest) -> Self {
         Self {
             id: manage_neuron_request.id,
-            neuron_id_or_subaccount: manage_neuron_request
-                .neuron_id_or_subaccount
-                .map(|x| x.into()),
+            neuron_id_or_subaccount: manage_neuron_request.neuron_id_or_subaccount,
             command: manage_neuron_request.command.map(|x| x.into()),
         }
     }
@@ -135,20 +129,20 @@ impl From<ManageNeuronRequest> for ManageNeuron {
 impl From<ManageNeuronCommandRequest> for Command {
     fn from(item: ManageNeuronCommandRequest) -> Self {
         match item {
-            ManageNeuronCommandRequest::Configure(v) => Command::Configure(v.into()),
-            ManageNeuronCommandRequest::Disburse(v) => Command::Disburse(v.into()),
-            ManageNeuronCommandRequest::Spawn(v) => Command::Spawn(v.into()),
-            ManageNeuronCommandRequest::Follow(v) => Command::Follow(v.into()),
+            ManageNeuronCommandRequest::Configure(v) => Command::Configure(v),
+            ManageNeuronCommandRequest::Disburse(v) => Command::Disburse(v),
+            ManageNeuronCommandRequest::Spawn(v) => Command::Spawn(v),
+            ManageNeuronCommandRequest::Follow(v) => Command::Follow(v),
             ManageNeuronCommandRequest::MakeProposal(v) => {
                 Command::MakeProposal(Box::new((*v).into()))
             }
-            ManageNeuronCommandRequest::RegisterVote(v) => Command::RegisterVote(v.into()),
-            ManageNeuronCommandRequest::Split(v) => Command::Split(v.into()),
-            ManageNeuronCommandRequest::DisburseToNeuron(v) => Command::DisburseToNeuron(v.into()),
-            ManageNeuronCommandRequest::ClaimOrRefresh(v) => Command::ClaimOrRefresh(v.into()),
-            ManageNeuronCommandRequest::MergeMaturity(v) => Command::MergeMaturity(v.into()),
-            ManageNeuronCommandRequest::Merge(v) => Command::Merge(v.into()),
-            ManageNeuronCommandRequest::StakeMaturity(v) => Command::StakeMaturity(v.into()),
+            ManageNeuronCommandRequest::RegisterVote(v) => Command::RegisterVote(v),
+            ManageNeuronCommandRequest::Split(v) => Command::Split(v),
+            ManageNeuronCommandRequest::DisburseToNeuron(v) => Command::DisburseToNeuron(v),
+            ManageNeuronCommandRequest::ClaimOrRefresh(v) => Command::ClaimOrRefresh(v),
+            ManageNeuronCommandRequest::MergeMaturity(v) => Command::MergeMaturity(v),
+            ManageNeuronCommandRequest::Merge(v) => Command::Merge(v),
+            ManageNeuronCommandRequest::StakeMaturity(v) => Command::StakeMaturity(v),
         }
     }
 }

--- a/rs/registry/admin/src/main.rs
+++ b/rs/registry/admin/src/main.rs
@@ -52,6 +52,7 @@ use ic_nns_governance_api::{
             SwapParameters,
         },
         install_code::CanisterInstallMode as GovernanceInstallMode,
+        proposal::Action,
         stop_or_start_canister::CanisterAction as GovernanceCanisterAction,
         update_canister_settings::{
             CanisterSettings, Controllers, LogVisibility as GovernanceLogVisibility,
@@ -5220,7 +5221,7 @@ where
 
     let action = cmd.action().await;
 
-    print_proposal(&action, &cmd);
+    print_proposal(&Action::from(action.clone()), &cmd);
 
     if cmd.is_dry_run() {
         return;


### PR DESCRIPTION
# Why

Currently, the ic-admin prints the entire WASM when submitting the `InstallCode` proposal. We want to only print hashes.

# What

When printing `InstallCode` proposals, we convert it into the "response" API type which contains only hashes.

# Alternative

Ideally, we'd like to implement custom `Debug` trait. However, currently it's impossible to do so while the proposal API type is still `prost:message` which already derives `Debug` trait. 