### PR TITLE
fix(tests): Reduce Schnorr Message Size in upgrade_downgrade Tests

### DIFF
--- a/rs/tests/src/orchestrator/upgrade_downgrade.rs
+++ b/rs/tests/src/orchestrator/upgrade_downgrade.rs
@@ -53,7 +53,7 @@ const DKG_INTERVAL: u64 = 9;
 
 const ALLOWED_FAILURES: usize = 1;
 const SUBNET_SIZE: usize = 3 * ALLOWED_FAILURES + 1; // 4 nodes
-const SCHNORR_MSG_SIZE_BYTES: usize = 2_096_000; // 2MiB minus some message overhead
+const SCHNORR_MSG_SIZE_BYTES: usize = 32;
 
 const REQUESTS_DISPATCH_EXTRA_TIMEOUT: Duration = Duration::from_secs(1);
 


### PR DESCRIPTION
In this test we send ingress messages to make sure that we can store and read messages after an upgrade. At the same time we send a workload of ECDSA/Schnorr messages to test the compatibility.

Because the Schnorr messages have a size of ~2MB, they sometimes block other ingress messages from being included, meaning they will expire and cause flakiness of the test.

As this isn't a performance test, reducing Schnorr messages to have a more reasonable size shouldn't be an issue.