### PR TITLE
fix(proposal-cli): FI-1451: Remove rs/rosetta-api/icrc1/index-ng from git log for ICP index canister

### DIFF
--- a/rs/cross-chain/proposal-cli/src/canister/mod.rs
+++ b/rs/cross-chain/proposal-cli/src/canister/mod.rs
@@ -90,7 +90,6 @@ impl TargetCanister {
                     PathBuf::from("packages/icrc-ledger_types"),
                     PathBuf::from("rs/rosetta-api/icp_ledger/index"),
                     PathBuf::from("rs/rosetta-api/icp_ledger/src"),
-                    PathBuf::from("rs/rosetta-api/icrc1/index-ng"),
                     PathBuf::from("rs/rosetta-api/ledger_canister_core/src"),
                     PathBuf::from("rs/rosetta-api/ledger_core"),
                     PathBuf::from("rs/rust_canisters/http_types"),


### PR DESCRIPTION
Remove the `rs/rosetta-api/icrc1/index-ng` directory from the list of directories from which commits are listed in generating the change log for canister upgrade proposals for the ICP index canister.