### PR TITLE
chore(ic-admin): Remove deprecated commands for subnet node add and remove

### DIFF
--- a/rs/registry/admin/src/main.rs
+++ b/rs/registry/admin/src/main.rs
@@ -3935,7 +3935,9 @@ async fn main() {
         SubCommand::ProposeToChangeSubnetMembership(cmd) => {
             let (proposer, sender) = cmd.proposer_and_sender(sender);
             if !opts.silence_notices {
-                println!("Notice: invoking this command can undesirably worsen the decentralization.");
+                println!(
+                    "Notice: invoking this command can undesirably worsen the decentralization."
+                );
                 println!(
                     "Notice: Consider using instead the DRE tool https://dfinity.github.io/dre/ to submit this proposal"
                 )

--- a/rs/registry/admin/src/main.rs
+++ b/rs/registry/admin/src/main.rs
@@ -129,12 +129,10 @@ use registry_canister::mutations::{
     complete_canister_migration::CompleteCanisterMigrationPayload,
     do_add_api_boundary_nodes::AddApiBoundaryNodesPayload,
     do_add_node_operator::AddNodeOperatorPayload,
-    do_add_nodes_to_subnet::AddNodesToSubnetPayload,
     do_change_subnet_membership::ChangeSubnetMembershipPayload,
     do_deploy_guestos_to_all_subnet_nodes::DeployGuestosToAllSubnetNodesPayload,
     do_deploy_guestos_to_all_unassigned_nodes::DeployGuestosToAllUnassignedNodesPayload,
     do_remove_api_boundary_nodes::RemoveApiBoundaryNodesPayload,
-    do_remove_nodes_from_subnet::RemoveNodesFromSubnetPayload,
     do_revise_elected_replica_versions::ReviseElectedGuestosVersionsPayload,
     do_set_firewall_config::SetFirewallConfigPayload,
     do_update_api_boundary_nodes_version::DeployGuestosToSomeApiBoundaryNodes,
@@ -194,12 +192,12 @@ const IC_DOMAINS: &[&str; 3] = &["ic0.app", "icp0.io", "icp-api.io"];
 #[derive(Parser)]
 #[clap(version = "1.0")]
 struct Opts {
-    #[clap(short = 'r', long, aliases = &["registry-url", "nns-url"], value_delimiter = ',')]
+    #[clap(short = 'r', long, aliases = &["registry-url", "nns-url"], value_delimiter = ',', global = true)]
     /// The URL of an NNS entry point. That is, the URL of any replica on the
     /// NNS subnet.
     nns_urls: Vec<Url>,
 
-    #[clap(short = 's', long)]
+    #[clap(short = 's', long, global = true)]
     /// The pem file containing a secret key to use while authenticating with
     /// the NNS.
     secret_key_pem: Option<PathBuf>,
@@ -208,34 +206,37 @@ struct Opts {
     subcmd: SubCommand,
 
     /// Use an HSM to sign calls.
-    #[clap(long)]
+    #[clap(long, global = true)]
     use_hsm: bool,
 
     /// The slot related to the HSM key that shall be used.
     #[clap(
         long = "slot",
-        help = "Only required if use-hsm is set. Ignored otherwise."
+        help = "Only required if use-hsm is set. Ignored otherwise.",
+        global = true,
     )]
     hsm_slot: Option<String>,
 
     /// The id of the key on the HSM that shall be used.
     #[clap(
         long = "key-id",
-        help = "Only required if use-hsm is set. Ignored otherwise."
+        help = "Only required if use-hsm is set. Ignored otherwise.",
+        global = true,
     )]
     key_id: Option<String>,
 
     /// The PIN used to unlock the HSM.
     #[clap(
         long = "pin",
-        help = "Only required if use-hsm is set. Ignored otherwise."
+        help = "Only required if use-hsm is set. Ignored otherwise.",
+        global = true,
     )]
     pin: Option<String>,
 
     /// Verify NNS responses against NNS public key.
     #[clap(
         long = "verify-nns-responses",
-        help = "Verify responses against NNS public key. If --nns-public-key-pem-file is not specified the mainnet NNS public key is used. Requests to ic0.app are always verified with the mainnet NNS public key. "
+        help = "Verify responses against NNS public key. If --nns-public-key-pem-file is not specified the mainnet NNS public key is used. Requests to ic0.app are always verified with the mainnet NNS public key. ",
     )]
     verify_nns_responses: bool,
 
@@ -243,13 +244,17 @@ struct Opts {
     #[clap(
         long = "nns-public-key-pem-file",
         help = "PEM file to overwrite the mainnet NNS public key. Requires --verify-nns-responses.",
-        requires = "verify-nns-responses"
+        requires = "verify-nns-responses",
     )]
     nns_public_key_pem_file: Option<PathBuf>,
 
     /// Return the output in JSON format.
     #[clap(long = "json", global = true)]
     json: bool,
+
+    /// silence notices, can be useful if ic-admin is executed from automation
+    #[clap(long = "silence-notices", global = true)]
+    silence_notices: bool,
 }
 
 /// List of sub-commands accepted by `ic-admin`.
@@ -260,10 +265,9 @@ enum SubCommand {
     GetPublicKey(GetPublicKeyCmd),
     /// Get the last version of a node's TLS certificate key from the registry.
     GetTlsCertificate(GetTlsCertificateCmd),
-    /// Submits a proposal to remove nodes from the subnets they are currently
-    /// assigned to.
-    ProposeToRemoveNodesFromSubnet(ProposeToRemoveNodesFromSubnetCmd),
     /// Submits a proposal to change node membership in a subnet.
+    /// Consider using instead the DRE tool to submit this type of proposals.
+    /// https://github.com/dfinity/dre
     ProposeToChangeSubnetMembership(ProposeToChangeSubnetMembershipCmd),
     /// Get the last version of a node from the registry.
     GetNode(GetNodeCmd),
@@ -295,8 +299,6 @@ enum SubCommand {
     ProposeToCreateSubnet(ProposeToCreateSubnetCmd),
     /// Submits a proposal to create a new service nervous system (usually referred to as SNS).
     ProposeToCreateServiceNervousSystem(ProposeToCreateServiceNervousSystemCmd),
-    /// Submits a proposal to update an existing subnet.
-    ProposeToAddNodesToSubnet(ProposeToAddNodesToSubnetCmd),
     /// Submits a proposal to update a subnet's recovery CUP
     ProposeToUpdateRecoveryCup(ProposeToUpdateRecoveryCupCmd),
     /// Submits a proposal to update an existing subnet's configuration.
@@ -498,41 +500,9 @@ pub trait ProposalTitle {
     fn title(&self) -> String;
 }
 
-/// Sub-command to submit a proposal to remove nodes from a subnet.
-#[derive_common_proposal_fields]
-#[derive(ProposalMetadata, Parser)]
-struct ProposeToRemoveNodesFromSubnetCmd {
-    #[clap(name = "NODE_ID", multiple_values(true), required = true)]
-    /// The node IDs of the nodes that will leave the subnet.
-    pub node_ids: Vec<PrincipalId>,
-}
-
-impl ProposalTitle for ProposeToRemoveNodesFromSubnetCmd {
-    fn title(&self) -> String {
-        match &self.proposal_title {
-            Some(title) => title.clone(),
-            None => format!(
-                "Remove nodes: {} from their assigned subnets",
-                shortened_pids_string(&self.node_ids)
-            ),
-        }
-    }
-}
-
-#[async_trait]
-impl ProposalPayload<RemoveNodesFromSubnetPayload> for ProposeToRemoveNodesFromSubnetCmd {
-    async fn payload(&self, _: &Agent) -> RemoveNodesFromSubnetPayload {
-        let node_ids = self
-            .node_ids
-            .clone()
-            .into_iter()
-            .map(NodeId::from)
-            .collect();
-        RemoveNodesFromSubnetPayload { node_ids }
-    }
-}
-
 /// Sub-command to submit a proposal to replace in a subnet.
+/// Consider using instead the DRE tool to submit this type of proposals.
+/// https://github.com/dfinity/dre
 #[derive_common_proposal_fields]
 #[derive(ProposalMetadata, Parser)]
 struct ProposeToChangeSubnetMembershipCmd {
@@ -951,54 +921,6 @@ impl ProposalPayload<ReviseElectedGuestosVersionsPayload>
         };
         payload.validate().expect("Failed to validate payload");
         payload
-    }
-}
-
-/// Sub-command to submit a proposal to add nodes to an existing subnet.
-#[derive_common_proposal_fields]
-#[derive(ProposalMetadata, Parser)]
-struct ProposeToAddNodesToSubnetCmd {
-    #[clap(long)]
-    #[allow(dead_code)]
-    /// Obsolete. Does nothing
-    subnet_handler_id: Option<String>,
-
-    #[clap(long, required = true, alias = "subnet-id")]
-    /// The subnet to modify
-    subnet: SubnetDescriptor,
-
-    #[clap(name = "NODE_ID", multiple_values(true), required = true)]
-    /// The node IDs of the nodes that will be part of the new subnet.
-    pub node_ids: Vec<PrincipalId>,
-}
-
-impl ProposalTitle for ProposeToAddNodesToSubnetCmd {
-    fn title(&self) -> String {
-        match &self.proposal_title {
-            Some(title) => title.clone(),
-            None => format!(
-                "Add nodes: {} to subnet: {}",
-                shortened_pids_string(&self.node_ids),
-                shortened_subnet_string(&self.subnet)
-            ),
-        }
-    }
-}
-
-#[async_trait]
-impl ProposalPayload<AddNodesToSubnetPayload> for ProposeToAddNodesToSubnetCmd {
-    async fn payload(&self, agent: &Agent) -> AddNodesToSubnetPayload {
-        let registry_canister = RegistryCanister::new_with_agent(agent.clone());
-        let node_ids = self
-            .node_ids
-            .clone()
-            .into_iter()
-            .map(NodeId::from)
-            .collect();
-        AddNodesToSubnetPayload {
-            subnet_id: self.subnet.get_id(&registry_canister).await.get(),
-            node_ids,
-        }
     }
 }
 
@@ -3608,9 +3530,7 @@ async fn main() {
             SubCommand::ProposeToDeployGuestosToAllSubnetNodes(_) => (),
             SubCommand::ProposeToUpdateSubnetReplicaVersion(_) => (),
             SubCommand::ProposeToCreateSubnet(_) => (),
-            SubCommand::ProposeToAddNodesToSubnet(_) => (),
             SubCommand::ProposeToRemoveNodes(_) => (),
-            SubCommand::ProposeToRemoveNodesFromSubnet(_) => (),
             SubCommand::ProposeToChangeSubnetMembership(_) => (),
             SubCommand::ProposeToChangeNnsCanister(_) => (),
             SubCommand::ProposeToHardResetNnsRootToVersion(_) => (),
@@ -3727,21 +3647,6 @@ async fn main() {
                 make_crypto_tls_cert_key(node_id).as_bytes().to_vec(),
                 &registry_canister,
                 opts.json,
-            )
-            .await;
-        }
-        SubCommand::ProposeToRemoveNodesFromSubnet(cmd) => {
-            let (proposer, sender) = cmd.proposer_and_sender(sender);
-            propose_external_proposal_from_command(
-                cmd,
-                NnsFunction::RemoveNodesFromSubnet,
-                make_canister_client(
-                    reachable_nns_urls,
-                    opts.verify_nns_responses,
-                    opts.nns_public_key_pem_file,
-                    sender,
-                ),
-                proposer,
             )
             .await;
         }
@@ -4027,23 +3932,12 @@ async fn main() {
             )
             .await;
         }
-        SubCommand::ProposeToAddNodesToSubnet(cmd) => {
-            let (proposer, sender) = cmd.proposer_and_sender(sender);
-            propose_external_proposal_from_command(
-                cmd,
-                NnsFunction::AddNodeToSubnet,
-                make_canister_client(
-                    reachable_nns_urls,
-                    opts.verify_nns_responses,
-                    opts.nns_public_key_pem_file,
-                    sender,
-                ),
-                proposer,
-            )
-            .await;
-        }
         SubCommand::ProposeToChangeSubnetMembership(cmd) => {
             let (proposer, sender) = cmd.proposer_and_sender(sender);
+            if !opts.silence_notices {
+                println!("Notice: invoking this command can undesirably worsen the decentralization.");
+                println!("Notice: Consider using instead the DRE tool https://dfinity.github.io/dre/ to submit this proposal")
+            }
             propose_external_proposal_from_command(
                 cmd,
                 NnsFunction::ChangeSubnetMembership,

--- a/rs/registry/admin/src/main.rs
+++ b/rs/registry/admin/src/main.rs
@@ -213,7 +213,7 @@ struct Opts {
     #[clap(
         long = "slot",
         help = "Only required if use-hsm is set. Ignored otherwise.",
-        global = true,
+        global = true
     )]
     hsm_slot: Option<String>,
 
@@ -221,7 +221,7 @@ struct Opts {
     #[clap(
         long = "key-id",
         help = "Only required if use-hsm is set. Ignored otherwise.",
-        global = true,
+        global = true
     )]
     key_id: Option<String>,
 
@@ -229,14 +229,14 @@ struct Opts {
     #[clap(
         long = "pin",
         help = "Only required if use-hsm is set. Ignored otherwise.",
-        global = true,
+        global = true
     )]
     pin: Option<String>,
 
     /// Verify NNS responses against NNS public key.
     #[clap(
         long = "verify-nns-responses",
-        help = "Verify responses against NNS public key. If --nns-public-key-pem-file is not specified the mainnet NNS public key is used. Requests to ic0.app are always verified with the mainnet NNS public key. ",
+        help = "Verify responses against NNS public key. If --nns-public-key-pem-file is not specified the mainnet NNS public key is used. Requests to ic0.app are always verified with the mainnet NNS public key. "
     )]
     verify_nns_responses: bool,
 
@@ -244,7 +244,7 @@ struct Opts {
     #[clap(
         long = "nns-public-key-pem-file",
         help = "PEM file to overwrite the mainnet NNS public key. Requires --verify-nns-responses.",
-        requires = "verify-nns-responses",
+        requires = "verify-nns-responses"
     )]
     nns_public_key_pem_file: Option<PathBuf>,
 
@@ -3936,7 +3936,9 @@ async fn main() {
             let (proposer, sender) = cmd.proposer_and_sender(sender);
             if !opts.silence_notices {
                 println!("Notice: invoking this command can undesirably worsen the decentralization.");
-                println!("Notice: Consider using instead the DRE tool https://dfinity.github.io/dre/ to submit this proposal")
+                println!(
+                    "Notice: Consider using instead the DRE tool https://dfinity.github.io/dre/ to submit this proposal"
+                )
             }
             propose_external_proposal_from_command(
                 cmd,


### PR DESCRIPTION
change-subnet-membership should be used instead of separate remove-node and add-node commands.
The `change-subnet-membership` command provides atomic node and removal, so both operations can be performed in a single proposal.

Also, prominently show suggestions to use the DRE tool for submitting this type of proposal, since the DRE tool calculates and optimizes subnet decentralization instead of blindly adding or removing nodes.

