### PR TITLE
feat(PocketIC): api only HTTP gateway

### DIFF
--- a/packages/pocket-ic/src/common/rest.rs
+++ b/packages/pocket-ic/src/common/rest.rs
@@ -38,6 +38,7 @@ pub struct HttpGatewayConfig {
     pub forward_to: HttpGatewayBackend,
     pub domains: Option<Vec<String>>,
     pub https_config: Option<HttpsConfig>,
+    pub api_only: Option<bool>,
 }
 
 #[derive(Debug, Clone, Eq, Hash, PartialEq, Serialize, Deserialize, JsonSchema)]

--- a/packages/pocket-ic/src/nonblocking.rs
+++ b/packages/pocket-ic/src/nonblocking.rs
@@ -375,6 +375,7 @@ impl PocketIc {
             forward_to: HttpGatewayBackend::PocketIcInstance(self.instance_id),
             domains: domains.clone(),
             https_config: https_config.clone(),
+            api_only: None,
         };
         let res = self
             .reqwest_client

--- a/rs/pocket_ic_server/CHANGELOG.md
+++ b/rs/pocket_ic_server/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - New endpoint `/instances/<instance_id>/api/v2/subnet/...` supporting the IC HTTP subnet read state requests.
 - New endpoint `/api/v2/subnet` of the PocketIC HTTP gateway supporting the IC HTTP subnet read state requests.
 - The argument of the endpoint `/instances/` takes an additional optional field `log_level` specifying the replica log level of the PocketIC instance.
+- The argument of the endpoint `/http_gateway` takes an additional optional field `api_only` specifying if the HTTP gateway should only accept requests for paths starting with `/api/v2` and `/api/v3`.
 
 ### Changed
 - The argument `listen_at` of the endpoint `/http_gateway` has been renamed to `port`.


### PR DESCRIPTION
This PR adds an additional optional field `api_only` to the argument of the endpoint `/http_gateway` to specify if the HTTP gateway should only accept requests for paths starting with `/api/v2` and `/api/v3`. This is useful if we need the PocketIC server to listen to the IC API interface only (i.e., support no other paths) at a dedicated port.