### PR TITLE
chore(consensus): Simplify `IngressPayload`

### DIFF
--- a/rs/artifact_pool/benches/load_blocks.rs
+++ b/rs/artifact_pool/benches/load_blocks.rs
@@ -48,7 +48,7 @@ fn fake_ingress_payload(count: usize, size: usize) -> IngressPayload {
     let mut ingress_messages = Vec::new();
 
     for nonce in 0..count {
-        let ingress =  SignedIngressBuilder::new()
+        let ingress = SignedIngressBuilder::new()
             .method_payload(vec![0; size])
             .nonce(nonce as u64)
             .build();

--- a/rs/consensus/src/consensus/purger.rs
+++ b/rs/consensus/src/consensus/purger.rs
@@ -781,10 +781,10 @@ mod tests {
                         non_finalized_notarization_2
                     )),
                     ChangeAction::RemoveFromValidated(ConsensusMessage::BlockProposal(
-                        non_finalized_block_proposal_2_0
+                        non_finalized_block_proposal_2_1
                     )),
                     ChangeAction::RemoveFromValidated(ConsensusMessage::BlockProposal(
-                        non_finalized_block_proposal_2_1
+                        non_finalized_block_proposal_2_0
                     )),
                 ]
             );

--- a/rs/ingress_manager/src/ingress_selector.rs
+++ b/rs/ingress_manager/src/ingress_selector.rs
@@ -334,14 +334,12 @@ impl IngressSelector for IngressManager {
 
         // Tracks the sum of cycles needed per canister.
         let mut cycles_needed: BTreeMap<CanisterId, Cycles> = BTreeMap::new();
-        for i in 0..payload.message_count() {
-            let (ingress_id, ingress) = payload
-                .get(i)
-                .map_err(InvalidIngressPayloadReason::IngressPayloadError)?;
+        for ingress_message in payload.as_ref() {
+            let ingress_id = IngressMessageId::from(ingress_message);
 
             self.validate_ingress(
-                ingress_id.clone(),
-                &ingress,
+                ingress_id,
+                ingress_message,
                 &state,
                 context,
                 &settings,

--- a/rs/ingress_manager/src/ingress_selector.rs
+++ b/rs/ingress_manager/src/ingress_selector.rs
@@ -1056,8 +1056,7 @@ mod tests {
 
                 // we should not get it again because it is part of past payloads
                 let mut hash_set = HashSet::new();
-                for i in 0..first_ingress_payload.message_count() {
-                    let (id, _) = first_ingress_payload.get(i).unwrap();
+                for id in first_ingress_payload.message_ids() {
                     hash_set.insert(id);
                 }
                 let second_ingress_payload = ingress_manager.get_ingress_payload(

--- a/rs/protobuf/def/types/v1/consensus.proto
+++ b/rs/protobuf/def/types/v1/consensus.proto
@@ -203,7 +203,13 @@ message IngressIdOffset {
   uint64 offset = 3;
 }
 
+message IngressMessage {
+  uint64 expiry = 1;
+  bytes message_id = 2;
+  bytes ingress_message = 3;
+}
+
 message IngressPayload {
-  repeated IngressIdOffset id_and_pos = 1;
-  bytes buffer = 2;
+  reserved 1, 2;
+  repeated IngressMessage ingress_messages = 3;
 }

--- a/rs/protobuf/def/types/v1/consensus.proto
+++ b/rs/protobuf/def/types/v1/consensus.proto
@@ -204,9 +204,7 @@ message IngressIdOffset {
 }
 
 message IngressMessage {
-  uint64 expiry = 1;
-  bytes message_id = 2;
-  bytes ingress_message = 3;
+  bytes content = 1;
 }
 
 message IngressPayload {

--- a/rs/protobuf/src/gen/types/types.v1.rs
+++ b/rs/protobuf/src/gen/types/types.v1.rs
@@ -1256,11 +1256,19 @@ pub struct IngressIdOffset {
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct IngressPayload {
-    #[prost(message, repeated, tag = "1")]
-    pub id_and_pos: ::prost::alloc::vec::Vec<IngressIdOffset>,
+pub struct IngressMessage {
+    #[prost(uint64, tag = "1")]
+    pub expiry: u64,
     #[prost(bytes = "vec", tag = "2")]
-    pub buffer: ::prost::alloc::vec::Vec<u8>,
+    pub message_id: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "3")]
+    pub ingress_message: ::prost::alloc::vec::Vec<u8>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct IngressPayload {
+    #[prost(message, repeated, tag = "3")]
+    pub ingress_messages: ::prost::alloc::vec::Vec<IngressMessage>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/rs/protobuf/src/gen/types/types.v1.rs
+++ b/rs/protobuf/src/gen/types/types.v1.rs
@@ -1257,12 +1257,8 @@ pub struct IngressIdOffset {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct IngressMessage {
-    #[prost(uint64, tag = "1")]
-    pub expiry: u64,
-    #[prost(bytes = "vec", tag = "2")]
-    pub message_id: ::prost::alloc::vec::Vec<u8>,
-    #[prost(bytes = "vec", tag = "3")]
-    pub ingress_message: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "1")]
+    pub content: ::prost::alloc::vec::Vec<u8>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/rs/state_machine_tests/src/lib.rs
+++ b/rs/state_machine_tests/src/lib.rs
@@ -1244,10 +1244,8 @@ impl StateMachine {
         // Convert payload produced by `PayloadBuilderImpl` into `PayloadBuilder`
         // used by the function `Self::execute_payload` of the `StateMachine`.
         let xnet_payload = batch_payload.xnet.clone();
-        let ingress = &batch_payload.ingress;
-        let ingress_messages = (0..ingress.message_count())
-            .map(|i| ingress.get(i).unwrap().1)
-            .collect();
+        let ingress = batch_payload.ingress;
+        let ingress_messages = ingress.into();
         let (http_responses, _) =
             CanisterHttpPayloadBuilderImpl::into_messages(&batch_payload.canister_http);
         let inducted: Vec<_> = http_responses

--- a/rs/test_utilities/types/src/batch/ingress_payload.rs
+++ b/rs/test_utilities/types/src/batch/ingress_payload.rs
@@ -42,7 +42,6 @@ mod tests {
     use super::*;
     use crate::messages::SignedIngressBuilder;
     use ic_types::time::expiry_time_from_now;
-    use std::convert::TryFrom;
     use std::time::Duration;
 
     #[test]
@@ -81,6 +80,6 @@ mod tests {
 
         assert_eq!(payload.as_ref(), msgs);
         // Converting back to messages should match original
-        assert_eq!(msgs, <Vec<SignedIngress>>::try_from(payload).unwrap());
+        assert_eq!(msgs, <Vec<SignedIngress>>::from(payload));
     }
 }

--- a/rs/types/types/src/batch.rs
+++ b/rs/types/types/src/batch.rs
@@ -151,10 +151,7 @@ impl BatchPayload {
     #[allow(clippy::result_large_err)]
     pub fn into_messages(self) -> Result<BatchMessages, IntoMessagesError> {
         Ok(BatchMessages {
-            signed_ingress_msgs: self
-                .ingress
-                .try_into()
-                .map_err(IntoMessagesError::IngressPayloadError)?,
+            signed_ingress_msgs: self.ingress.into(),
             certified_stream_slices: self.xnet.stream_slices,
             bitcoin_adapter_responses: self.self_validating.0,
             query_stats: QueryStatsPayload::deserialize(&self.query_stats)

--- a/rs/types/types/src/batch.rs
+++ b/rs/types/types/src/batch.rs
@@ -140,7 +140,6 @@ pub struct BatchMessages {
 /// Error type that can occur during an `BatchPayload::into_messages` call
 #[derive(Debug)]
 pub enum IntoMessagesError {
-    IngressPayloadError(IngressPayloadError),
     QueryStatsPayloadError(ProxyDecodeError),
 }
 

--- a/rs/types/types/src/batch/ingress.rs
+++ b/rs/types/types/src/batch/ingress.rs
@@ -172,7 +172,7 @@ mod tests {
             .map(|msg| SignedIngress::try_from(msg).unwrap())
             .collect();
         let ingress_payload = IngressPayload::from(signed_ingresses.clone());
-        let signed_ingresses1 = Vec::<SignedIngress>::try_from(ingress_payload).unwrap();
+        let signed_ingresses1 = Vec::<SignedIngress>::from(ingress_payload);
         assert_eq!(signed_ingresses, signed_ingresses1);
     }
 }

--- a/rs/types/types/src/batch/ingress.rs
+++ b/rs/types/types/src/batch/ingress.rs
@@ -1,7 +1,7 @@
 use crate::{
     artifact::IngressMessageId,
-    messages::{MessageId, SignedIngress, SignedRequestBytes, EXPECTED_MESSAGE_ID_LENGTH},
-    CountBytes, Time,
+    messages::{SignedIngress, SignedRequestBytes},
+    CountBytes,
 };
 #[cfg(test)]
 use ic_exhaustive_derive::ExhaustiveSet;
@@ -9,69 +9,21 @@ use ic_protobuf::{proxy::ProxyDecodeError, types::v1 as pb};
 use serde::{Deserialize, Serialize};
 use std::convert::TryFrom;
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
-struct SerializedIngressMessage {
-    ingress_message_id: IngressMessageId,
-    #[serde(with = "serde_bytes")]
-    buffer: Vec<u8>,
-}
-
 /// Payload that contains Ingress messages
 #[derive(Clone, Debug, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(test, derive(ExhaustiveSet))]
 pub struct IngressPayload {
-    ingress_messages: Vec<SerializedIngressMessage>,
+    ingress_messages: Vec<SignedIngress>,
 }
 
-impl From<SerializedIngressMessage> for pb::IngressMessage {
-    fn from(message: SerializedIngressMessage) -> Self {
-        Self {
-            expiry: message
-                .ingress_message_id
-                .expiry()
-                .as_nanos_since_unix_epoch(),
-            message_id: message.ingress_message_id.message_id.as_bytes().to_vec(),
-            ingress_message: message.buffer,
-        }
-    }
+fn proto_to_ingress(proto: pb::IngressMessage) -> Result<SignedIngress, ProxyDecodeError> {
+    SignedIngress::try_from(SignedRequestBytes::from(proto.content))
+        .map_err(|err| ProxyDecodeError::Other(err.to_string()))
 }
 
-impl TryFrom<pb::IngressMessage> for SerializedIngressMessage {
-    type Error = ProxyDecodeError;
-
-    fn try_from(message: pb::IngressMessage) -> Result<Self, Self::Error> {
-        Ok(Self {
-            ingress_message_id: IngressMessageId::new(
-                Time::from_nanos_since_unix_epoch(message.expiry),
-                MessageId::try_from(message.message_id.as_slice())?,
-            ),
-            buffer: message.ingress_message,
-        })
-    }
-}
-
-impl From<SignedIngress> for SerializedIngressMessage {
-    fn from(ingress: SignedIngress) -> Self {
-        Self {
-            ingress_message_id: IngressMessageId::from(&ingress),
-            buffer: ingress.binary().as_ref().to_vec(),
-        }
-    }
-}
-
-impl TryFrom<SerializedIngressMessage> for SignedIngress {
-    type Error = IngressPayloadError;
-
-    fn try_from(ingress_message: SerializedIngressMessage) -> Result<Self, Self::Error> {
-        let ingress = SignedIngress::try_from(SignedRequestBytes::from(ingress_message.buffer))
-            .map_err(|e| IngressPayloadError::DeserializationFailure(e.to_string()))?;
-        let ingress_id = IngressMessageId::from(&ingress);
-        if ingress_message.ingress_message_id == ingress_id {
-            Ok(ingress)
-        } else {
-            // FIXME:
-            Err(IngressPayloadError::MismatchedMessageIdAtIndex(0))
-        }
+fn ingress_to_proto(ingress: SignedIngress) -> pb::IngressMessage {
+    pb::IngressMessage {
+        content: ingress.binary().as_ref().to_vec(),
     }
 }
 
@@ -81,7 +33,7 @@ impl From<IngressPayload> for pb::IngressPayload {
             ingress_messages: ingress_payload
                 .ingress_messages
                 .into_iter()
-                .map(pb::IngressMessage::from)
+                .map(ingress_to_proto)
                 .collect(),
         }
     }
@@ -91,13 +43,13 @@ impl TryFrom<pb::IngressPayload> for IngressPayload {
     type Error = ProxyDecodeError;
 
     fn try_from(payload: pb::IngressPayload) -> Result<Self, Self::Error> {
-        Ok(Self {
-            ingress_messages: payload
-                .ingress_messages
-                .into_iter()
-                .map(SerializedIngressMessage::try_from)
-                .collect::<Result<_, _>>()?,
-        })
+        let ingress_messages = payload
+            .ingress_messages
+            .into_iter()
+            .map(proto_to_ingress)
+            .collect::<Result<_, _>>()?;
+
+        Ok(Self { ingress_messages })
     }
 }
 
@@ -126,36 +78,13 @@ impl IngressPayload {
     pub fn message_ids(&self) -> Vec<IngressMessageId> {
         self.ingress_messages
             .iter()
-            .map(|ingress_message| ingress_message.ingress_message_id.clone())
-            .collect::<Vec<_>>()
+            .map(IngressMessageId::from)
+            .collect()
     }
 
     /// Return true if the payload is empty.
     pub fn is_empty(&self) -> bool {
         self.ingress_messages.is_empty()
-    }
-
-    /// Return the ingress message at a given index, which is expected to be
-    /// less than `message_count`.
-    pub fn get(
-        &self,
-        index: usize,
-    ) -> Result<(IngressMessageId, SignedIngress), IngressPayloadError> {
-        self.ingress_messages
-            .get(index)
-            .ok_or(IngressPayloadError::IndexOutOfBound(index))
-            .and_then(|ingress_message| {
-                let ingress = SignedIngress::try_from(SignedRequestBytes::from(
-                    ingress_message.buffer.clone(),
-                ))
-                .map_err(|e| IngressPayloadError::DeserializationFailure(e.to_string()))?;
-                let ingress_id = IngressMessageId::from(&ingress);
-                if ingress_message.ingress_message_id == ingress_id {
-                    Ok((ingress_id, ingress))
-                } else {
-                    Err(IngressPayloadError::MismatchedMessageIdAtIndex(index))
-                }
-            })
     }
 }
 
@@ -163,7 +92,7 @@ impl CountBytes for IngressPayload {
     fn count_bytes(&self) -> usize {
         self.ingress_messages
             .iter()
-            .map(|message| message.buffer.len() + EXPECTED_MESSAGE_ID_LENGTH)
+            .map(CountBytes::count_bytes)
             .sum()
     }
 }
@@ -171,22 +100,20 @@ impl CountBytes for IngressPayload {
 impl From<Vec<SignedIngress>> for IngressPayload {
     fn from(msgs: Vec<SignedIngress>) -> IngressPayload {
         Self {
-            ingress_messages: msgs
-                .into_iter()
-                .map(SerializedIngressMessage::from)
-                .collect(),
+            ingress_messages: msgs,
         }
     }
 }
 
-impl TryFrom<IngressPayload> for Vec<SignedIngress> {
-    type Error = IngressPayloadError;
-    fn try_from(payload: IngressPayload) -> Result<Vec<SignedIngress>, Self::Error> {
-        payload
-            .ingress_messages
-            .into_iter()
-            .map(SignedIngress::try_from)
-            .collect()
+impl From<IngressPayload> for Vec<SignedIngress> {
+    fn from(payload: IngressPayload) -> Vec<SignedIngress> {
+        payload.ingress_messages
+    }
+}
+
+impl AsRef<[SignedIngress]> for IngressPayload {
+    fn as_ref(&self) -> &[SignedIngress] {
+        &self.ingress_messages
     }
 }
 

--- a/rs/types/types/src/batch/ingress.rs
+++ b/rs/types/types/src/batch/ingress.rs
@@ -7,38 +7,82 @@ use crate::{
 use ic_exhaustive_derive::ExhaustiveSet;
 use ic_protobuf::{proxy::ProxyDecodeError, types::v1 as pb};
 use serde::{Deserialize, Serialize};
-use std::{
-    convert::TryFrom,
-    io::{Cursor, Write},
-};
+use std::convert::TryFrom;
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+struct SerializedIngressMessage {
+    ingress_message_id: IngressMessageId,
+    #[serde(with = "serde_bytes")]
+    buffer: Vec<u8>,
+}
 
 /// Payload that contains Ingress messages
 #[derive(Clone, Debug, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(test, derive(ExhaustiveSet))]
 pub struct IngressPayload {
-    /// Pairs of MessageId and its serialized byte position in the buffer.
-    id_and_pos: Vec<(IngressMessageId, u64)>,
-    /// All messages are serialized in a single byte buffer, so individual
-    /// deserialization is delayed. This allows faster deserialization of
-    /// IngressPayload when individual message is not needed (e.g. in
-    /// ingress payload deduplication).
-    #[serde(with = "serde_bytes")]
-    buffer: Vec<u8>,
+    ingress_messages: Vec<SerializedIngressMessage>,
 }
 
-impl From<&IngressPayload> for pb::IngressPayload {
-    fn from(ingress_payload: &IngressPayload) -> Self {
+impl From<SerializedIngressMessage> for pb::IngressMessage {
+    fn from(message: SerializedIngressMessage) -> Self {
         Self {
-            id_and_pos: ingress_payload
-                .id_and_pos
-                .iter()
-                .map(|(msg_id, offset)| pb::IngressIdOffset {
-                    expiry: msg_id.expiry().as_nanos_since_unix_epoch(),
-                    message_id: msg_id.message_id.as_bytes().to_vec(),
-                    offset: *offset,
-                })
+            expiry: message
+                .ingress_message_id
+                .expiry()
+                .as_nanos_since_unix_epoch(),
+            message_id: message.ingress_message_id.message_id.as_bytes().to_vec(),
+            ingress_message: message.buffer,
+        }
+    }
+}
+
+impl TryFrom<pb::IngressMessage> for SerializedIngressMessage {
+    type Error = ProxyDecodeError;
+
+    fn try_from(message: pb::IngressMessage) -> Result<Self, Self::Error> {
+        Ok(Self {
+            ingress_message_id: IngressMessageId::new(
+                Time::from_nanos_since_unix_epoch(message.expiry),
+                MessageId::try_from(message.message_id.as_slice())?,
+            ),
+            buffer: message.ingress_message,
+        })
+    }
+}
+
+impl From<SignedIngress> for SerializedIngressMessage {
+    fn from(ingress: SignedIngress) -> Self {
+        Self {
+            ingress_message_id: IngressMessageId::from(&ingress),
+            buffer: ingress.binary().as_ref().to_vec(),
+        }
+    }
+}
+
+impl TryFrom<SerializedIngressMessage> for SignedIngress {
+    type Error = IngressPayloadError;
+
+    fn try_from(ingress_message: SerializedIngressMessage) -> Result<Self, Self::Error> {
+        let ingress = SignedIngress::try_from(SignedRequestBytes::from(ingress_message.buffer))
+            .map_err(|e| IngressPayloadError::DeserializationFailure(e.to_string()))?;
+        let ingress_id = IngressMessageId::from(&ingress);
+        if ingress_message.ingress_message_id == ingress_id {
+            Ok(ingress)
+        } else {
+            // FIXME:
+            Err(IngressPayloadError::MismatchedMessageIdAtIndex(0))
+        }
+    }
+}
+
+impl From<IngressPayload> for pb::IngressPayload {
+    fn from(ingress_payload: IngressPayload) -> Self {
+        Self {
+            ingress_messages: ingress_payload
+                .ingress_messages
+                .into_iter()
+                .map(pb::IngressMessage::from)
                 .collect(),
-            buffer: ingress_payload.buffer.clone(),
         }
     }
 }
@@ -48,20 +92,11 @@ impl TryFrom<pb::IngressPayload> for IngressPayload {
 
     fn try_from(payload: pb::IngressPayload) -> Result<Self, Self::Error> {
         Ok(Self {
-            id_and_pos: payload
-                .id_and_pos
-                .iter()
-                .map(|ingress_offset| {
-                    Ok((
-                        IngressMessageId::new(
-                            Time::from_nanos_since_unix_epoch(ingress_offset.expiry),
-                            MessageId::try_from(ingress_offset.message_id.as_slice())?,
-                        ),
-                        ingress_offset.offset,
-                    ))
-                })
-                .collect::<Result<Vec<_>, Self::Error>>()?,
-            buffer: payload.buffer,
+            ingress_messages: payload
+                .ingress_messages
+                .into_iter()
+                .map(SerializedIngressMessage::try_from)
+                .collect::<Result<_, _>>()?,
         })
     }
 }
@@ -84,20 +119,20 @@ pub enum IngressPayloadError {
 impl IngressPayload {
     /// Return the number of ingress messages contained in this payload
     pub fn message_count(&self) -> usize {
-        self.id_and_pos.len()
+        self.ingress_messages.len()
     }
 
     /// Return all MessageIds in the payload.
     pub fn message_ids(&self) -> Vec<IngressMessageId> {
-        self.id_and_pos
+        self.ingress_messages
             .iter()
-            .map(|(id, _)| id.clone())
+            .map(|ingress_message| ingress_message.ingress_message_id.clone())
             .collect::<Vec<_>>()
     }
 
     /// Return true if the payload is empty.
     pub fn is_empty(&self) -> bool {
-        self.id_and_pos.is_empty()
+        self.ingress_messages.is_empty()
     }
 
     /// Return the ingress message at a given index, which is expected to be
@@ -106,31 +141,19 @@ impl IngressPayload {
         &self,
         index: usize,
     ) -> Result<(IngressMessageId, SignedIngress), IngressPayloadError> {
-        self.id_and_pos
+        self.ingress_messages
             .get(index)
             .ok_or(IngressPayloadError::IndexOutOfBound(index))
-            .and_then(|(id, pos)| {
-                // Return error if pos is out of bound.
-                if *pos > self.buffer.len() as u64 {
-                    Err(IngressPayloadError::IngressPositionOutOfBound(index, *pos))
+            .and_then(|ingress_message| {
+                let ingress = SignedIngress::try_from(SignedRequestBytes::from(
+                    ingress_message.buffer.clone(),
+                ))
+                .map_err(|e| IngressPayloadError::DeserializationFailure(e.to_string()))?;
+                let ingress_id = IngressMessageId::from(&ingress);
+                if ingress_message.ingress_message_id == ingress_id {
+                    Ok((ingress_id, ingress))
                 } else {
-                    let end = {
-                        if index == self.id_and_pos.len() - 1 {
-                            self.buffer.len()
-                        } else {
-                            self.id_and_pos[index + 1].1 as usize
-                        }
-                    };
-                    let ingress = SignedIngress::try_from(SignedRequestBytes::from(Vec::from(
-                        &self.buffer[*pos as usize..end],
-                    )))
-                    .map_err(|e| IngressPayloadError::DeserializationFailure(e.to_string()))?;
-                    let ingress_id = IngressMessageId::from(&ingress);
-                    if *id == ingress_id {
-                        Ok((ingress_id, ingress))
-                    } else {
-                        Err(IngressPayloadError::MismatchedMessageIdAtIndex(index))
-                    }
+                    Err(IngressPayloadError::MismatchedMessageIdAtIndex(index))
                 }
             })
     }
@@ -138,26 +161,20 @@ impl IngressPayload {
 
 impl CountBytes for IngressPayload {
     fn count_bytes(&self) -> usize {
-        self.buffer.len() + self.id_and_pos.len() * EXPECTED_MESSAGE_ID_LENGTH
+        self.ingress_messages
+            .iter()
+            .map(|message| message.buffer.len() + EXPECTED_MESSAGE_ID_LENGTH)
+            .sum()
     }
 }
 
 impl From<Vec<SignedIngress>> for IngressPayload {
     fn from(msgs: Vec<SignedIngress>) -> IngressPayload {
-        let mut buf = Cursor::new(Vec::new());
-        let mut id_and_pos = Vec::new();
-        for ingress in msgs {
-            let id = IngressMessageId::from(&ingress);
-            let pos = buf.position();
-            // This panic will only happen when we run out of memory.
-            buf.write_all(ingress.binary().as_ref())
-                .unwrap_or_else(|err| panic!("SignedIngress serialization error: {:?}", err));
-
-            id_and_pos.push((id, pos));
-        }
-        IngressPayload {
-            id_and_pos,
-            buffer: buf.into_inner(),
+        Self {
+            ingress_messages: msgs
+                .into_iter()
+                .map(SerializedIngressMessage::from)
+                .collect(),
         }
     }
 }
@@ -166,11 +183,10 @@ impl TryFrom<IngressPayload> for Vec<SignedIngress> {
     type Error = IngressPayloadError;
     fn try_from(payload: IngressPayload) -> Result<Vec<SignedIngress>, Self::Error> {
         payload
-            .id_and_pos
-            .iter()
-            .enumerate()
-            .map(|(i, _)| payload.get(i).map(|m| m.1))
-            .collect::<Result<_, _>>()
+            .ingress_messages
+            .into_iter()
+            .map(SignedIngress::try_from)
+            .collect()
     }
 }
 

--- a/rs/types/types/src/batch/ingress.rs
+++ b/rs/types/types/src/batch/ingress.rs
@@ -27,12 +27,13 @@ fn ingress_to_proto(ingress: SignedIngress) -> pb::IngressMessage {
     }
 }
 
-impl From<IngressPayload> for pb::IngressPayload {
-    fn from(ingress_payload: IngressPayload) -> Self {
+impl From<&IngressPayload> for pb::IngressPayload {
+    fn from(ingress_payload: &IngressPayload) -> Self {
         Self {
             ingress_messages: ingress_payload
                 .ingress_messages
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(ingress_to_proto)
                 .collect(),
         }

--- a/rs/types/types/src/consensus.rs
+++ b/rs/types/types/src/consensus.rs
@@ -1298,7 +1298,7 @@ impl From<&Block> for pb::Block {
             (
                 pb::DkgPayload::from(&payload.as_data().dealings),
                 Some(pb::XNetPayload::from(&batch.xnet)),
-                Some(pb::IngressPayload::from(batch.ingress.clone())),
+                Some(pb::IngressPayload::from(&batch.ingress)),
                 Some(pb::SelfValidatingPayload::from(&batch.self_validating)),
                 batch.canister_http.clone(),
                 batch.query_stats.clone(),

--- a/rs/types/types/src/consensus.rs
+++ b/rs/types/types/src/consensus.rs
@@ -1298,7 +1298,7 @@ impl From<&Block> for pb::Block {
             (
                 pb::DkgPayload::from(&payload.as_data().dealings),
                 Some(pb::XNetPayload::from(&batch.xnet)),
-                Some(pb::IngressPayload::from(&batch.ingress)),
+                Some(pb::IngressPayload::from(batch.ingress.clone())),
                 Some(pb::SelfValidatingPayload::from(&batch.self_validating)),
                 batch.canister_http.clone(),
                 batch.query_stats.clone(),

--- a/rs/types/types/src/exhaustive.rs
+++ b/rs/types/types/src/exhaustive.rs
@@ -1,6 +1,5 @@
 //! Implementations and serialization tests of the ExhaustiveSet trait
 
-use crate::messages::{Blob, Delegation, HttpCallContent, HttpCanisterUpdate, HttpRequestEnvelope, SignedDelegation, SignedIngress};
 use crate::consensus::hashed::Hashed;
 use crate::consensus::idkg::common::{PreSignatureInCreation, PreSignatureRef};
 use crate::consensus::idkg::ecdsa::{QuadrupleInCreation, ThresholdEcdsaSigInputsRef};
@@ -27,6 +26,10 @@ use crate::crypto::{
     crypto_hash, AlgorithmId, BasicSig, BasicSigOf, CombinedMultiSig, CombinedMultiSigOf,
     CombinedThresholdSig, CombinedThresholdSigOf, CryptoHash, CryptoHashOf, CryptoHashable,
     IndividualMultiSig, IndividualMultiSigOf, Signed, ThresholdSigShare, ThresholdSigShareOf,
+};
+use crate::messages::{
+    Blob, Delegation, HttpCallContent, HttpCanisterUpdate, HttpRequestEnvelope, SignedDelegation,
+    SignedIngress,
 };
 use crate::signature::{
     BasicSignature, BasicSignatureBatch, MultiSignature, MultiSignatureShare, ThresholdSignature,
@@ -909,8 +912,8 @@ fn replace_by_singleton_if_empty<
 }
 
 impl ExhaustiveSet for SignedIngress {
-    fn exhaustive_set<R: RngCore + CryptoRng>(rng: &mut R) -> Vec<Self> {
-		let ingress_expiry = UNIX_EPOCH;
+    fn exhaustive_set<R: RngCore + CryptoRng>(_rng: &mut R) -> Vec<Self> {
+        let ingress_expiry = UNIX_EPOCH;
         let content = HttpCallContent::Call {
             update: HttpCanisterUpdate {
                 canister_id: Blob(vec![42; 8]),
@@ -944,12 +947,11 @@ impl ExhaustiveSet for SignedIngress {
                 )]),
             },
         ];
-        let signed_ingresses: Vec<SignedIngress> = update_messages
+
+        update_messages
             .into_iter()
             .map(|msg| SignedIngress::try_from(msg).unwrap())
-            .collect();
-
-		vec![]
+            .collect()
     }
 }
 


### PR DESCRIPTION
The current implementation delays the deserialization of the ingress messages until they are accessed.
An upside of this implementation is that if we never access the ingress messages - we will never deserialize them.
An downside is that it's quite complex, error prone, and hard to modify. Moreover, when we actually need to access *all* ingress messages in the payload, the simpler implementation is actually more efficient (at least according to the benchmarks below)

# Benchmarks
Ran `load_blocks` benchmark via `bazel run //rs/artifact_pool:load_blocks_bench` with a modification that each block has 100 ingress messages of 128KB each. (Note that in the benchmark we load all blocks in the pool, i.e. 20)

|  |  Load blocks and sum their heights | Load blocks and sum their ingress counts | Load blocks and sum their ingress nonces|
| - | - | - | - |
| old struct times | 39.260 µs | 25.151 ms | 714.39 ms |
| new struct times |  39.978 µs |  80.508 ms | 173.15 ms |
| change | +2.2538% | +220.09% | -75.762% |

## Conclusions
1. Loading blocks without their payloads is as fast as before (not surprisingly)
2. Loading blocks *and* their payloads without accessing ingresses messages is 3x slower
3. Loading blocks *and* their payload *and* accessing all the ingress messages is 4x faster

# Backwards compatibility
The changes are not backwards compatible but it's okay as we don't preserve `IngressPayload`s across replica versions

# Tests
Ran a benchmark where we send 4 * 1MB ingress messages per second to a subnet with 13 nodes and looked at the flamegraph:
![flamegraph_big_messages](https://github.com/user-attachments/assets/5f1a58e0-0666-45ff-aa4e-8198baa6c7c1)
I didn't observe any deterioration 
          