### PR TITLE
feat(proposal-cli): Detect TODOs in summary file

### DIFF
--- a/rs/cross-chain/proposal-cli/templates/install.md
+++ b/rs/cross-chain/proposal-cli/templates/install.md
@@ -9,7 +9,7 @@ Target canister: `{{canister_id}}`
 ---
 
 ## Motivation
-THIS MUST BE FILLED OUT
+TODO: THIS MUST BE FILLED OUT
 
 
 ## Install args

--- a/rs/cross-chain/proposal-cli/templates/submit_with_ic_admin.shx
+++ b/rs/cross-chain/proposal-cli/templates/submit_with_ic_admin.shx
@@ -1,5 +1,10 @@
 #!/bin/sh
 
+if grep --ignore-case --line-number "TODO" "{{summary_file}}"; then
+    echo "Found some TODOs in the summary file, aborting!!"
+    exit 1
+fi
+
 ic-admin \
     {% if args.use_hsm -%}
         --use-hsm \

--- a/rs/cross-chain/proposal-cli/templates/upgrade.md
+++ b/rs/cross-chain/proposal-cli/templates/upgrade.md
@@ -11,7 +11,7 @@ Previous {{canister}} proposal: {{Self::previous_upgrade_proposal_url(self)}}
 ---
 
 ## Motivation
-THIS MUST BE FILLED OUT
+TODO: THIS MUST BE FILLED OUT
 
 
 ## Upgrade args


### PR DESCRIPTION
(XC-173): Small improvement upon #1007 in the generated submission script `submit.sh` that also ensures there is no remaining `TODO` in the summary file before calling `ic-admin`.