### PR TITLE
feat(evm-rpc): add rpc.sepolia.org service to Candid interface

### DIFF
--- a/rs/ethereum/cketh/minter/src/eth_rpc_client/providers.rs
+++ b/rs/ethereum/cketh/minter/src/eth_rpc_client/providers.rs
@@ -15,6 +15,7 @@ pub(crate) const SEPOLIA_PROVIDERS: &[RpcService] = &[
     RpcService::EthSepolia(EthSepoliaService::Ankr),
     RpcService::EthSepolia(EthSepoliaService::BlockPi),
     RpcService::EthSepolia(EthSepoliaService::PublicNode),
+    RpcService::EthSepolia(EthSepoliaService::Sepolia),
 ];
 
 pub(crate) const ARBITRUM_PROVIDERS: &[RpcService] = &[
@@ -94,6 +95,7 @@ pub enum EthSepoliaService {
     Ankr,
     BlockPi,
     PublicNode,
+    Sepolia,
 }
 
 #[derive(


### PR DESCRIPTION
This PR includes `EthSepoliaService::Sepolia` (https://rpc.sepolia.org) for completeness, since a corresponding RPC provider already exists in the EVM RPC canister.