### PR TITLE
feat(nns): Enable new canister management topics

### DIFF
--- a/rs/nns/governance/src/lib.rs
+++ b/rs/nns/governance/src/lib.rs
@@ -944,7 +944,7 @@ impl NeuronSubsetMetricsPb {
 }
 
 fn enable_new_canister_management_topics() -> bool {
-    cfg!(feature = "test")
+    true
 }
 
 #[cfg(test)]

--- a/rs/nns/governance/src/proposals/install_code.rs
+++ b/rs/nns/governance/src/proposals/install_code.rs
@@ -170,34 +170,9 @@ mod tests {
 
     use crate::pb::v1::governance_error::ErrorType;
 
+    use candid::Decode;
     use ic_nns_constants::REGISTRY_CANISTER_ID;
 
-    #[cfg(feature = "test")]
-    use candid::Decode;
-
-    #[cfg(not(feature = "test"))]
-    #[test]
-    fn test_install_code_disabled() {
-        let install_code = InstallCode {
-            canister_id: Some(REGISTRY_CANISTER_ID.get()),
-            wasm_module: Some(vec![1, 2, 3]),
-            install_mode: Some(CanisterInstallMode::Upgrade as i32),
-            arg: None,
-            skip_stopping_before_installing: None,
-        };
-
-        assert_eq!(
-            install_code.validate(),
-            Err(GovernanceError::new_with_message(
-                ErrorType::InvalidProposal,
-                "Proposal invalid because of InstallCode proposal is not yet \
-                 supported"
-                    .to_string(),
-            ))
-        );
-    }
-
-    #[cfg(feature = "test")]
     #[test]
     fn test_invalid_install_code_proposal() {
         let valid_install_code = InstallCode {
@@ -299,7 +274,6 @@ mod tests {
         );
     }
 
-    #[cfg(feature = "test")]
     #[test]
     fn test_upgrade_non_root_protocol_canister() {
         let install_code = InstallCode {
@@ -335,7 +309,6 @@ mod tests {
         );
     }
 
-    #[cfg(feature = "test")]
     #[test]
     fn test_upgrade_root_protocol_canister() {
         let install_code = InstallCode {
@@ -367,7 +340,6 @@ mod tests {
         );
     }
 
-    #[cfg(feature = "test")]
     #[test]
     fn test_reinstall_code_non_root_protocol_canister() {
         let install_code = InstallCode {
@@ -403,7 +375,6 @@ mod tests {
         );
     }
 
-    #[cfg(feature = "test")]
     #[test]
     fn test_upgrade_canisters_topic_mapping() {
         use ic_base_types::CanisterId;

--- a/rs/nns/governance/src/proposals/stop_or_start_canister.rs
+++ b/rs/nns/governance/src/proposals/stop_or_start_canister.rs
@@ -100,30 +100,10 @@ mod tests {
     use super::*;
 
     use crate::pb::v1::governance_error::ErrorType;
+
+    use candid::Decode;
     use ic_nns_constants::CYCLES_MINTING_CANISTER_ID;
 
-    #[cfg(feature = "test")]
-    use candid::Decode;
-
-    #[cfg(not(feature = "test"))]
-    #[test]
-    fn stop_or_start_canister_disabled() {
-        let stop_or_start_canister = StopOrStartCanister {
-            canister_id: Some(CYCLES_MINTING_CANISTER_ID.get()),
-            action: Some(CanisterAction::Stop as i32),
-        };
-
-        assert_eq!(
-            stop_or_start_canister.validate(),
-            Err(GovernanceError::new_with_message(
-                ErrorType::InvalidProposal,
-                "Proposal invalid because of StopOrStartCanister proposal is not yet supported"
-                    .to_string(),
-            ))
-        );
-    }
-
-    #[cfg(feature = "test")]
     #[test]
     fn test_invalid_stop_or_start_canister() {
         let valid_stop_or_start_canister = StopOrStartCanister {
@@ -205,7 +185,6 @@ mod tests {
         );
     }
 
-    #[cfg(feature = "test")]
     #[test]
     fn test_stop_or_start_cycles_minting_canister() {
         for (canister_action, payload_canister_action) in &[
@@ -241,7 +220,6 @@ mod tests {
         }
     }
 
-    #[cfg(feature = "test")]
     #[test]
     fn test_start_lifeline_canister() {
         let stop_or_start_canister = StopOrStartCanister {
@@ -272,7 +250,6 @@ mod tests {
         );
     }
 
-    #[cfg(feature = "test")]
     #[test]
     fn test_start_canister_topic_mapping() {
         use ic_base_types::CanisterId;

--- a/rs/nns/governance/src/proposals/update_canister_settings.rs
+++ b/rs/nns/governance/src/proposals/update_canister_settings.rs
@@ -133,35 +133,12 @@ mod tests {
     use super::*;
 
     use crate::pb::v1::governance_error::ErrorType;
-    #[cfg(feature = "test")]
     use crate::pb::v1::update_canister_settings::{CanisterSettings, Controllers};
-    #[cfg(feature = "test")]
     use candid::Decode;
-    #[cfg(feature = "test")]
     use ic_base_types::CanisterId;
     use ic_nns_constants::LEDGER_CANISTER_ID;
-    #[cfg(feature = "test")]
     use ic_nns_constants::{GOVERNANCE_CANISTER_ID, SNS_WASM_CANISTER_ID};
 
-    #[cfg(not(feature = "test"))]
-    #[test]
-    fn update_canister_settings_disabled() {
-        let update_canister_settings = UpdateCanisterSettings {
-            canister_id: Some(LEDGER_CANISTER_ID.get()),
-            settings: Some(Default::default()),
-        };
-
-        assert_eq!(
-            update_canister_settings.validate(),
-            Err(GovernanceError::new_with_message(
-                ErrorType::InvalidProposal,
-                "Proposal invalid because of UpdateCanisterSettings proposal is not yet supported"
-                    .to_string(),
-            ))
-        );
-    }
-
-    #[cfg(feature = "test")]
     #[test]
     fn test_invalid_update_canister_settings() {
         let valid_update_canister_settings = UpdateCanisterSettings {
@@ -236,7 +213,6 @@ mod tests {
         );
     }
 
-    #[cfg(feature = "test")]
     #[test]
     fn test_update_ledger_canister_settings() {
         let update_ledger_canister_settings = UpdateCanisterSettings {
@@ -286,7 +262,6 @@ mod tests {
         );
     }
 
-    #[cfg(feature = "test")]
     #[test]
     fn test_update_root_canister_settings() {
         let update_root_canister_settings = UpdateCanisterSettings {
@@ -333,7 +308,6 @@ mod tests {
         );
     }
 
-    #[cfg(feature = "test")]
     #[test]
     fn test_update_canister_settings_topic_mapping() {
         let test_cases = vec![


### PR DESCRIPTION
# Why

The canister management topic split, as well as the new `UpdateCanisterSettings` proposal type is hidden behind the flag `enable_new_canister_management_topics` while they were under development. We want to enable them as the development is complete.

# What

Flip the `enable_new_canister_management_topics` to true
