### PR TITLE
refactor(sns-cli): Use anyhow

### DIFF
--- a/rs/sns/cli/src/init_config_file.rs
+++ b/rs/sns/cli/src/init_config_file.rs
@@ -1,4 +1,5 @@
 use crate::generate_sns_init_payload;
+use anyhow::Result;
 use clap::Parser;
 use std::{path::PathBuf, str::FromStr};
 
@@ -22,18 +23,13 @@ enum SubCommand {
     Validate,
 }
 
-pub fn exec(init_config_file_args: InitConfigFileArgs) {
+pub fn exec(init_config_file_args: InitConfigFileArgs) -> Result<()> {
     let init_config_file_path = init_config_file_args
         .init_config_file_path
         .unwrap_or_else(|| PathBuf::from_str(DEFAULT_INIT_CONFIG_PATH).unwrap());
     match init_config_file_args.sub_command {
-        SubCommand::Validate => validate(init_config_file_path),
-    }
-}
-
-fn validate(init_config_file: PathBuf) {
-    if let Err(err) = generate_sns_init_payload(&init_config_file) {
-        eprintln!("{}", err);
-        std::process::exit(1);
+        SubCommand::Validate => {
+            generate_sns_init_payload(init_config_file_path.as_ref()).map(|_| ())
+        }
     }
 }

--- a/rs/sns/cli/src/main.rs
+++ b/rs/sns/cli/src/main.rs
@@ -1,5 +1,6 @@
 //! A command-line tool to initialize, deploy and interact with a SNS (Service Nervous System)
 
+use anyhow::{bail, Result};
 use clap::Parser;
 
 use ic_sns_cli::{
@@ -7,12 +8,11 @@ use ic_sns_cli::{
     prepare_canisters, propose, CliArgs, SubCommand,
 };
 
-fn main() {
+fn main() -> Result<()> {
     let args = match CliArgs::try_parse_from(std::env::args()) {
         Ok(args) => args,
         Err(e) => {
-            eprintln!("{}", e);
-            std::process::exit(1);
+            bail!("{}", e);
         }
     };
 

--- a/rs/sns/cli/src/neuron_id_to_candid_subaccount.rs
+++ b/rs/sns/cli/src/neuron_id_to_candid_subaccount.rs
@@ -1,5 +1,6 @@
 use std::str::FromStr;
 
+use anyhow::{anyhow, Result};
 use candid::IDLValue;
 use clap::Parser;
 use ic_sns_governance::pb::v1::NeuronId;
@@ -27,12 +28,12 @@ pub struct NeuronIdToCandidSubaccountArgs {
     pub escaped: bool,
 }
 
-pub fn neuron_id_to_subaccount(args: NeuronIdToCandidSubaccountArgs) -> Result<String, String> {
+pub fn neuron_id_to_subaccount(args: NeuronIdToCandidSubaccountArgs) -> Result<String> {
     let subaccount = args
         .neuron_id
         .0
         .subaccount()
-        .map_err(|e| e.error_message)?
+        .map_err(|e| anyhow!(e.error_message))?
         .to_vec();
 
     // We'll convert it to a candid string.
@@ -47,8 +48,9 @@ pub fn neuron_id_to_subaccount(args: NeuronIdToCandidSubaccountArgs) -> Result<S
     }
 }
 
-pub fn exec(args: NeuronIdToCandidSubaccountArgs) {
-    println!("{}", neuron_id_to_subaccount(args).unwrap());
+pub fn exec(args: NeuronIdToCandidSubaccountArgs) -> Result<()> {
+    println!("{}", neuron_id_to_subaccount(args)?);
+    Ok(())
 }
 
 #[test]
@@ -101,5 +103,7 @@ fn test_neuron_id_to_subaccount_fail() {
     };
     let error = neuron_id_to_subaccount(args).unwrap_err();
 
-    assert!(error.contains("could not convert slice to array"));
+    assert!(error
+        .to_string()
+        .contains("could not convert slice to array"));
 }

--- a/rs/sns/cli/src/prepare_canisters.rs
+++ b/rs/sns/cli/src/prepare_canisters.rs
@@ -1,4 +1,5 @@
 use crate::call_dfx_or_panic;
+use anyhow::Result;
 use clap::Parser;
 use ic_base_types::PrincipalId;
 use ic_nns_constants::ROOT_CANISTER_ID;
@@ -28,7 +29,7 @@ enum SubCommand {
     RemoveNnsRoot(SubCommandArgs),
 }
 
-pub fn exec(args: PrepareCanistersArgs) {
+pub fn exec(args: PrepareCanistersArgs) -> Result<()> {
     let (operation, sub_args) = match &args.sub_command {
         SubCommand::AddNnsRoot(sub_args) => ("--add-controller", sub_args),
         SubCommand::RemoveNnsRoot(sub_args) => ("--remove-controller", sub_args),
@@ -45,4 +46,6 @@ pub fn exec(args: PrepareCanistersArgs) {
             &canister.to_string(),
         ]);
     }
+
+    Ok(())
 }

--- a/rs/sns/cli/src/propose.rs
+++ b/rs/sns/cli/src/propose.rs
@@ -1,7 +1,8 @@
 use crate::{
-    fetch_canister_controllers_or_exit, get_identity, use_test_neuron_1_owner_identity,
+    fetch_canister_controllers, get_identity, use_test_neuron_1_owner_identity,
     MakeProposalResponse, NnsGovernanceCanister, SaveOriginalDfxIdentityAndRestoreOnExit,
 };
+use anyhow::{anyhow, bail, Context, Result};
 use clap::{ArgGroup, Parser};
 use ic_base_types::{CanisterId, PrincipalId};
 use ic_nervous_system_common::ledger::compute_neuron_staking_subaccount_bytes;
@@ -73,7 +74,7 @@ pub struct ProposeArgs {
     pub skip_confirmation: bool,
 }
 
-pub fn exec(args: ProposeArgs) {
+pub fn exec(args: ProposeArgs) -> Result<()> {
     let ProposeArgs {
         network,
         init_config_file,
@@ -87,20 +88,17 @@ pub fn exec(args: ProposeArgs) {
     let skip_confirmation = skip_confirmation || network == "local";
 
     // Step 0: Load configuration
-    let proposal = load_configuration_and_validate_or_exit(&network, &init_config_file);
+    let proposal = load_configuration_and_validate(&network, &init_config_file)?;
 
     // Step 1: Ensure the save-to file exists and is writeable if specified.
     // We do this check without writing the file to ensure the best chance of successfully
     // saving the data to a file after the Proposal is submitted.
     if let Some(save_to) = &save_to {
-        if let Err(err) = ensure_file_exists_and_is_writeable(save_to.as_path()) {
-            eprintln!("{}", err);
-            std::process::exit(1);
-        }
+        ensure_file_exists_and_is_writeable(save_to.as_path())?
     }
 
     // Step 2: Verify with the user that they want to proceed.
-    inform_user_of_sns_behavior(&proposal, skip_confirmation);
+    inform_user_of_sns_behavior(&proposal, skip_confirmation)?;
 
     // Step 2: Send the proposal.
     eprintln!("Loaded configuration.");
@@ -113,15 +111,9 @@ pub fn exec(args: ProposeArgs) {
     let proposer = if let Some(id) = neuron_id {
         NeuronIdOrSubaccount::NeuronId(NeuronId { id })
     } else if test_neuron_proposer {
-        if let Err(err) = use_test_neuron_1_owner_identity(&checkpoint) {
-            eprintln!(
-                "{}\n\
-                 \n\
-                 Failed to (import and) use test-neuron-1-owner dfx identity.",
-                err,
-            );
-            std::process::exit(1);
-        }
+        use_test_neuron_1_owner_identity(&checkpoint)
+            .context("Failed to (import and) use test-neuron-1-owner dfx identity")?;
+
         NeuronIdOrSubaccount::NeuronId(NeuronId {
             id: TEST_NEURON_1_ID,
         })
@@ -158,30 +150,31 @@ pub fn exec(args: ProposeArgs) {
 
             if let Some(save_to) = &save_to {
                 if let Err(err) = save_proposal_id_to_file(save_to.as_path(), &proposal_id) {
-                    eprintln!("{}", err);
-                    std::process::exit(1);
+                    bail!("{}", err);
                 };
             }
         }
         err => {
-            println!("{:?}", err);
-            println!();
-            println!("💔 Something went wrong. Look up slightly for diagnostics.");
-            println!("Perhaps, share the above error with the community at");
-            println!("https://forum.dfinity.org/c/tokenization");
-            std::process::exit(1)
+            bail!(
+                "{err:?}\n\
+                \n\
+                💔 Something went wrong. Look up slightly for diagnostics.\n\
+                Perhaps, share the above error with the community at\n\
+                https://forum.dfinity.org/c/tokenization"
+            )
         }
     };
+
+    Ok(())
 }
 
-fn confirmation_messages(proposal: &Proposal) -> Vec<String> {
+fn confirmation_messages(proposal: &Proposal) -> Result<Vec<String>> {
     let csns = match &proposal.action {
         Some(Action::CreateServiceNervousSystem(csns)) => csns,
         _ => {
-            eprintln!(
+            return Err(anyhow!(
                 "Internal error: Somehow a proposal was made not of type CreateServiceNervousSystem",
-            );
-            std::process::exit(1);
+            ));
         }
     };
     let fallback_controllers = csns
@@ -220,23 +213,24 @@ Within this restricted mode, some proposal actions will not be allowed:
 Once the swap is completed, the SNS will be in normal mode and these proposal actions will become available again."#
     );
 
-    vec![dapp_canister_controllers, allowed_proposals]
+    Ok(vec![dapp_canister_controllers, allowed_proposals])
 }
 
-fn inform_user_of_sns_behavior(proposal: &Proposal, skip_confirmation: bool) {
-    let messages = confirmation_messages(proposal);
+fn inform_user_of_sns_behavior(proposal: &Proposal, skip_confirmation: bool) -> Result<()> {
+    let messages = confirmation_messages(proposal)?;
     for message in messages {
         println!();
         println!("{}", message);
-        confirm_understanding(skip_confirmation);
+        confirm_understanding(skip_confirmation)?;
     }
+    Ok(())
 }
 
-fn confirm_understanding(skip_confirmation: bool) {
+fn confirm_understanding(skip_confirmation: bool) -> Result<()> {
     use std::io::{self, Write};
 
     if skip_confirmation {
-        return;
+        return Ok(());
     }
 
     let mut input = String::new();
@@ -248,66 +242,63 @@ fn confirm_understanding(skip_confirmation: bool) {
             let input = input.trim().to_lowercase(); // Clean and normalize the input
             if input == "y" || input == "yes" {
                 println!("Confirmed.");
+                Ok(())
             } else {
-                println!("Exiting.");
-                std::process::exit(1); // Exit the program if the response is not affirmative
+                bail!("Exiting.")
             }
         }
         Err(error) => {
-            println!("Error reading input: {}", error);
-            std::process::exit(1); // Exit on input error
+            bail!("Error reading input: {}", error)
         }
     }
 }
 
-fn load_configuration_and_validate_or_exit(
+fn load_configuration_and_validate(
     network: &str,
     configuration_file_path: &PathBuf,
-) -> Proposal {
+) -> Result<Proposal> {
     // Read the file.
-    let init_config_file = std::fs::read_to_string(configuration_file_path).unwrap_or_else(|err| {
+    let init_config_file = std::fs::read_to_string(configuration_file_path).map_err(|err| {
         let current_dir = std::env::current_dir().expect("cannot read env::current_dir");
-        eprintln!(
+        anyhow!(
             "Unable to read the SNS configuration file {:?}:\n{}",
             current_dir.join(configuration_file_path),
             err,
-        );
-        std::process::exit(1);
-    });
+        )
+    })?;
 
     // Parse its contents.
     let init_config_file = serde_yaml::from_str::<
         crate::init_config_file::friendly::SnsConfigurationFile,
     >(&init_config_file)
-    .unwrap_or_else(|err| {
-        eprintln!(
+    .map_err(|err| {
+        anyhow!(
             "Unable to parse the SNS configuration file ({:?}):\n{}",
-            init_config_file, err,
-        );
-        std::process::exit(1);
-    });
+            init_config_file,
+            err,
+        )
+    })?;
     let base_path = match configuration_file_path.parent() {
         Some(ok) => ok,
         None => {
             // This shouldn't happen since we were already able to read from
             // configuration_file_path.
-            eprintln!(
+            bail!(
                 "Configuration file path ({:?}) has no parent.",
                 configuration_file_path,
             );
-            std::process::exit(1);
         }
     };
     let proposal = init_config_file
         .try_convert_to_nns_proposal(base_path)
-        .unwrap_or_else(|err| {
-            eprintln!(
+        .map_err(|err| {
+            anyhow!(
                 "Unable to parse the SNS configuration file. err = {:?}.\n\
                  init_config_file:\n{:#?}",
-                err, init_config_file,
-            );
-            std::process::exit(1);
-        });
+                err,
+                init_config_file,
+            )
+        })?;
 
     // Validate that NNS root is one of the controllers of all dapp canisters,
     // as listed in the configuration file.
@@ -315,43 +306,33 @@ fn load_configuration_and_validate_or_exit(
         Some(Action::CreateServiceNervousSystem(csns)) => csns
             .dapp_canisters
             .iter()
-            .map(|canister| {
-                let canister_id: PrincipalId = canister.id.unwrap_or_else(|| {
-                    eprintln!(
+            .map(|canister| -> Result<CanisterId> {
+                let canister_id: PrincipalId = canister.id.ok_or_else(|| {
+                    anyhow!(
                         "Internal error: Canister.id was found to be None while \
                         validating the CreateServiceNervousSystem.dapp_canisters \
                         field.",
-                    );
-                    std::process::exit(1);
-                });
+                    )
+                })?;
 
-                CanisterId::try_from(canister_id).unwrap_or_else(|err| {
-                    eprintln!(
-                        "{}\n\
-                     \n\
-                     Internal error: Unable to Convert PrincipalId ({}) to CanisterId.",
-                        err, canister_id,
-                    );
-                    std::process::exit(1);
-                })
+                CanisterId::try_from(canister_id)
+                    .map_err(|err| anyhow!("{err}"))
+                    .context(format!(
+                        "Internal error: Unable to Convert PrincipalId ({canister_id}) to CanisterId."
+                    ))
             })
-            .collect::<Vec<_>>(),
+            .collect::<Result<Vec<_>>>()?,
         _ => {
-            eprintln!(
+            return Err(anyhow!(
                 "Internal error: Somehow a proposal was made not of type CreateServiceNervousSystem",
-            );
-            std::process::exit(1);
+            ));
         }
     };
 
-    all_canisters_have_all_required_controllers(network, &canister_ids, &[ROOT_CANISTER_ID.get()])
-        .unwrap_or_else(|err| {
-            eprintln!("{}", err);
-            std::process::exit(1);
-        });
+    all_canisters_have_all_required_controllers(network, &canister_ids, &[ROOT_CANISTER_ID.get()])?;
 
     // Return as the result.
-    proposal
+    Ok(proposal)
 }
 
 struct CanistersWithMissingControllers {
@@ -387,7 +368,7 @@ fn all_canisters_have_all_required_controllers(
     network: &str,
     canister_ids: &[CanisterId],
     required_controllers: &[PrincipalId],
-) -> Result<(), CanistersWithMissingControllers> {
+) -> Result<()> {
     let required_controllers = HashSet::<_, std::collections::hash_map::RandomState>::from_iter(
         required_controllers.iter().cloned(),
     );
@@ -397,7 +378,7 @@ fn all_canisters_have_all_required_controllers(
         .filter(|canister_id| {
             let canister_id = PrincipalId::from(**canister_id);
             let controllers =
-                HashSet::from_iter(fetch_canister_controllers_or_exit(network, canister_id));
+                HashSet::from_iter(fetch_canister_controllers(network, canister_id).unwrap());
             let ok = controllers.is_superset(&required_controllers);
             !ok
         })
@@ -410,10 +391,13 @@ fn all_canisters_have_all_required_controllers(
     }
 
     let inspected_canister_count = canister_ids.len();
-    Err(CanistersWithMissingControllers {
-        inspected_canister_count,
-        defective_canister_ids,
-    })
+    Err(anyhow!(
+        "{}",
+        CanistersWithMissingControllers {
+            inspected_canister_count,
+            defective_canister_ids,
+        }
+    ))
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]
@@ -422,6 +406,8 @@ enum SaveToErrors {
     FileWriteFailed(PathBuf, String),
     InvalidData(String),
 }
+
+impl std::error::Error for SaveToErrors {}
 
 impl Display for SaveToErrors {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
@@ -511,7 +497,7 @@ mod test {
             url: "https://example.com".to_string(),
         };
 
-        let observed_messages = confirmation_messages(&proposal);
+        let observed_messages = confirmation_messages(&proposal).unwrap();
         let expected_messages = vec![
             r#"A CreateServiceNervousSystem proposal will be submitted.
 If adopted, this proposal will create an SNS, which will control these canisters:
@@ -563,7 +549,7 @@ Once the swap is completed, the SNS will be in normal mode and these proposal ac
             url: "https://example.com".to_string(),
         };
 
-        let observed_message = &confirmation_messages(&proposal)[0];
+        let observed_message = &confirmation_messages(&proposal).unwrap()[0];
         let expected_message = r#"A CreateServiceNervousSystem proposal will be submitted. If adopted, this proposal will create an SNS that controls no canisters."#;
         assert_eq!(observed_message, expected_message);
     }


### PR DESCRIPTION
## Problem

It is generally not a very good practice to perform an `.unwrap()` that might plausibly fail, outside of tests. Instead, it is better to return an error. Even in the `main` function, you can return a `Result` instead of using `.unwrap()` or `exit(1)` (and returning an `Err` from the main function will automatically set a non-zero exit code). Using `exit(1)` is particularly dangerous as you may forget to call it, or forget to use `eprintln!` instead of `println!`, in both cases doing something somewhat unexpected that the compiler will not warn you about.

## Solution

Convert all the sns-cli endpoints to return an `anyhow::Result` instead of `()`. This enables them to return errors instead of panicking.

## Impoved code 

### Example 1

Using anyhow makes some of our code a bit more concise as well. For example, compare the original:

```rust
let sns_init_payload = args.generate_sns_init_payload().unwrap_or_else(|err| {
    eprintln!(
        "Error encountered when generating the SnsInitPayload: {}",
        err
    );
    exit(1);
});
```

with:

```rust
let sns_init_payload = args
    .generate_sns_init_payload()
    .context("Generating the SnsInitPayload")?;
```

Which is not exactly equivalent, but the latter returns a (imho) nicer error message. For the unfamiliar, 

```
use anyhow::{anyhow, context};
fn main() {
    return Err(anyhow!("What went wrong.")).context("Error situation");
}
```

outputs:

```
Error: Error situation

Caused by:
    What went wrong.
```

Using `.context()` gives us something that's almost like a human-readable backtrace:

```rust
use anyhow::{anyhow, Context};
fn main() {
    return Err(anyhow!("What went wrong."))
        .context("I think something is about to go wrong")
        .context("Error situation");
}
```
 
outputs:
 
```
Error: Error situation

Caused by:
    0: I think something is about to go wrong
    1: What went wrong.
```

### Example 2

```rust
if let Some(save_to) = &save_to {
    if let Err(err) = ensure_file_exists_and_is_writeable(save_to.as_path()) {
        eprintln!("{}", err);
        std::process::exit(1);
    }
}
```

Becomes

```rust
if let Some(save_to) = &save_to {
    ensure_file_exists_and_is_writeable(save_to.as_path())?
}
```


## Additional notes

I have not actually removed all the occurrences of `.unwrap()` yet, but I have updated all the cases where we called `exit(1)`. 