### PR TITLE
refactor(nns): Put TimeWarp in API crate to remove dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10046,7 +10046,6 @@ dependencies = [
  "ic-nervous-system-root",
  "ic-nns-common",
  "ic-nns-constants",
- "ic-nns-governance",
  "ic-nns-governance-api",
  "ic-nns-governance-init",
  "ic-nns-gtc",

--- a/rs/nns/governance/api/src/lib.rs
+++ b/rs/nns/governance/api/src/lib.rs
@@ -2,3 +2,4 @@ pub mod bitcoin;
 pub mod pb;
 pub mod proposal_helpers;
 pub mod subnet_rental;
+pub mod test_api;

--- a/rs/nns/governance/api/src/test_api.rs
+++ b/rs/nns/governance/api/src/test_api.rs
@@ -1,0 +1,7 @@
+/// Affects the perception of time by users of CanisterEnv (i.e. Governance).
+///
+/// Specifically, the time that Governance sees is the real time + delta.
+#[derive(PartialEq, Eq, Clone, Copy, Debug, candid::CandidType, serde::Deserialize)]
+pub struct TimeWarp {
+    pub delta_s: i64,
+}

--- a/rs/nns/governance/src/pb/conversions.rs
+++ b/rs/nns/governance/src/pb/conversions.rs
@@ -4833,3 +4833,11 @@ impl From<pb_api::ProposalRewardStatus> for pb::ProposalRewardStatus {
         }
     }
 }
+
+impl From<ic_nns_governance_api::test_api::TimeWarp> for crate::TimeWarp {
+    fn from(value: ic_nns_governance_api::test_api::TimeWarp) -> Self {
+        Self {
+            delta_s: value.delta_s,
+        }
+    }
+}

--- a/rs/nns/integration_tests/src/governance_time_warp.rs
+++ b/rs/nns/integration_tests/src/governance_time_warp.rs
@@ -6,13 +6,15 @@ use ic_nervous_system_common_test_keys::{
     TEST_NEURON_1_OWNER_KEYPAIR, TEST_NEURON_1_OWNER_PRINCIPAL,
 };
 use ic_nns_common::pb::v1::NeuronId as NeuronIdProto;
-use ic_nns_governance::governance::TimeWarp;
-use ic_nns_governance_api::pb::v1::{
-    governance_error::ErrorType,
-    manage_neuron::{Disburse, NeuronIdOrSubaccount},
-    manage_neuron_response,
-    neuron::DissolveState,
-    ManageNeuronCommandRequest, ManageNeuronRequest, ManageNeuronResponse, Neuron,
+use ic_nns_governance_api::{
+    pb::v1::{
+        governance_error::ErrorType,
+        manage_neuron::{Disburse, NeuronIdOrSubaccount},
+        manage_neuron_response,
+        neuron::DissolveState,
+        ManageNeuronCommandRequest, ManageNeuronRequest, ManageNeuronResponse, Neuron,
+    },
+    test_api::TimeWarp,
 };
 use ic_nns_test_utils::{
     common::NnsInitPayloadsBuilder,

--- a/rs/nns/integration_tests/src/wait_for_quiet.rs
+++ b/rs/nns/integration_tests/src/wait_for_quiet.rs
@@ -6,14 +6,17 @@ use ic_nervous_system_common_test_keys::{
     TEST_NEURON_2_OWNER_KEYPAIR,
 };
 use ic_nns_common::pb::v1::NeuronId;
-use ic_nns_governance::governance::TimeWarp;
-use ic_nns_governance_api::pb::v1::{
-    add_or_remove_node_provider::Change,
-    manage_neuron::{self, NeuronIdOrSubaccount},
-    manage_neuron_response::Command as CommandResponse,
-    neuron::DissolveState,
-    AddOrRemoveNodeProvider, MakeProposalRequest, ManageNeuronCommandRequest, ManageNeuronRequest,
-    ManageNeuronResponse, Neuron, NodeProvider, ProposalActionRequest, ProposalInfo, Vote,
+use ic_nns_governance_api::{
+    pb::v1::{
+        add_or_remove_node_provider::Change,
+        manage_neuron::{self, NeuronIdOrSubaccount},
+        manage_neuron_response::Command as CommandResponse,
+        neuron::DissolveState,
+        AddOrRemoveNodeProvider, MakeProposalRequest, ManageNeuronCommandRequest,
+        ManageNeuronRequest, ManageNeuronResponse, Neuron, NodeProvider, ProposalActionRequest,
+        ProposalInfo, Vote,
+    },
+    test_api::TimeWarp,
 };
 use ic_nns_test_utils::{
     common::NnsInitPayloadsBuilder,

--- a/rs/nns/test_utils/BUILD.bazel
+++ b/rs/nns/test_utils/BUILD.bazel
@@ -67,7 +67,6 @@ BASE_DEPENDENCIES = [
 # Each target declared in this file may choose either these (release-ready)
 # dependencies (`DEPENDENCIES`), or `DEPENDENCIES_WITH_TEST_FEATURES` feature previews.
 DEPENDENCIES = BASE_DEPENDENCIES + [
-    "//rs/nns/governance",
     "//rs/nns/governance/api",
     "//rs/nns/governance/init",
     "//rs/nns/gtc",

--- a/rs/nns/test_utils/Cargo.toml
+++ b/rs/nns/test_utils/Cargo.toml
@@ -38,7 +38,6 @@ ic-nervous-system-common-test-utils = { path = "../../nervous_system/common/test
 ic-nervous-system-root = { path = "../../nervous_system/root" }
 ic-nns-common = { path = "../common" }
 ic-nns-constants = { path = "../constants" }
-ic-nns-governance = { path = "../governance" }
 ic-nns-governance-api = { path = "../governance/api" }
 ic-nns-governance-init = { path = "../governance/init" }
 ic-nns-gtc = { path = "../gtc" }

--- a/rs/nns/test_utils/src/itest_helpers.rs
+++ b/rs/nns/test_utils/src/itest_helpers.rs
@@ -29,8 +29,10 @@ use ic_nns_common::{
     types::{NeuronId, ProposalId},
 };
 use ic_nns_constants::*;
-use ic_nns_governance::governance::TimeWarp;
-use ic_nns_governance_api::pb::v1::{Governance, NnsFunction, ProposalStatus};
+use ic_nns_governance_api::{
+    pb::v1::{Governance, NnsFunction, ProposalStatus},
+    test_api::TimeWarp,
+};
 use ic_nns_gtc::pb::v1::Gtc;
 use ic_nns_handler_root::init::RootCanisterInitPayload;
 use ic_registry_transport::pb::v1::RegistryMutation;


### PR DESCRIPTION
Create a copy of TimeWarp in the api crate, so that we can remove another dependency on the nns governance crate.