### PR TITLE
fix(release): Fix some minor issues with NNS release scripts

### DIFF
--- a/testnet/tools/nns-tools/lib/canister_wasms.sh
+++ b/testnet/tools/nns-tools/lib/canister_wasms.sh
@@ -5,7 +5,7 @@ assert_that_a_prebuilt_nns_wasm_is_available() {
     local VERSION=$2
 
     DOWNLOAD_NAME=$(_canister_download_name_for_nns_canister_type "$CANISTER_TYPE")
-    DOWNLOAD_URL="https://download.dfinity.systems/ic/${GIT_HASH}/canisters/${DOWNLOAD_NAME}.wasm.gz"
+    DOWNLOAD_URL="https://download.dfinity.systems/ic/${VERSION}/canisters/${DOWNLOAD_NAME}.wasm.gz"
     if ! curl "${DOWNLOAD_URL}" --head --fail --silent &>/dev/null; then
         print_red "There is no pre-built NNS $CANISTER_TYPE WASM at commit $VERSION."
         exit 1

--- a/testnet/tools/nns-tools/lib/proposals.sh
+++ b/testnet/tools/nns-tools/lib/proposals.sh
@@ -65,7 +65,7 @@ generate_nns_upgrade_proposal_text() {
     local CANDID_ARGS=${4:-}
     local OUTPUT_FILE=${5:-}
 
-    assert_that_a_prebuilt_sns_wasm_is_available "$CANISTER_NAME" "$NEXT_COMMIT"
+    assert_that_a_prebuilt_nns_wasm_is_available "$CANISTER_NAME" "$NEXT_COMMIT"
 
     PROPOSER=$(git config user.email | sed 's/@/ at /')
 

--- a/testnet/tools/nns-tools/submit-mainnet-publish-sns-wasm-proposal.sh
+++ b/testnet/tools/nns-tools/submit-mainnet-publish-sns-wasm-proposal.sh
@@ -39,7 +39,7 @@ submit_nns_publish_sns_wasm_proposal_mainnet() {
 
     VERSION=$(grep '__Source Code__: ' $PROPOSAL_FILE | sed -E 's~.*\[(.{40})\].*~\1~')
     PROPOSAL_TITLE=$(grep '.' "$PROPOSAL_FILE" | head -n 1 | sed 's/# //')
-    HUMANIZED_CANISTER_TYPE=$(echo "$PROPOSAL_TITLE" | sed -E 's/Publish SNS (.+) Upgrade to .+/\1/')
+    HUMANIZED_CANISTER_TYPE=$(echo "$PROPOSAL_TITLE" | sed -E 's/Publish SNS (.+) WASM Built at Commit .+/\1/')
     CANISTER_TYPE=$(echo "$HUMANIZED_CANISTER_TYPE" | tr '[:upper:]' '[:lower:]' | sed 's/ /-/')
 
     # Functions that exit if error
@@ -107,6 +107,8 @@ submit_nns_publish_sns_wasm_proposal_mainnet() {
         exit 1
     fi
     echo "$RESPONSE"
+    echo_line
+    PROPOSAL_ID=$(echo "${RESPONSE}" | grep -o 'proposal [0-9]*' | awk '{print $2}' | tr -d '[:space:]')
 
     # Report conclusion.
     echo


### PR DESCRIPTION
Fixing some minor problems with the NNS/SNS release scripts:

* `assert_that_a_prebuilt_sns_wasm_is_available` should be called when publishing SNS canisters, not for upgrading NNS canisters.
* Fix the `HUMANIZED_CANISTER_TYPE` regex capture as the title is changed
* Add regex capture for `PROPOSAL_ID` after sending an SNS publish proposal