### PR TITLE
fix(nns-tools): typo correction: wasm_module -> wasm

### DIFF
--- a/testnet/tools/nns-tools/lib/proposals.sh
+++ b/testnet/tools/nns-tools/lib/proposals.sh
@@ -240,7 +240,7 @@ git checkout $NEXT_COMMIT
 sha256sum ./artifacts/canisters/$(_canister_download_name_for_sns_canister_type "$CANISTER_TYPE").wasm.gz
 \`\`\`
 
-This should match \`wasm_module\` field of this proposal.
+This should match \`wasm\` field of this proposal.
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
     )
 


### PR DESCRIPTION
As pointed out by Georgi, [proposals to add new SNS versions use `wasm` instead of `wasm_module`](https://github.com/dfinity/ic/blob/c5545625c47f52d03fe022befe0bf85d24683ebd/rs/nns/sns-wasm/canister/sns-wasm.did#L1-L2), but the template for the proposals to add SNS versions refers to a `wasm_module` field