### PR TITLE
chore: update ingress watcher cancellation log level

### DIFF
--- a/rs/http_endpoints/public/src/call/ingress_watcher.rs
+++ b/rs/http_endpoints/public/src/call/ingress_watcher.rs
@@ -1,6 +1,6 @@
 use crate::metrics::HttpHandlerMetrics;
 use ic_async_utils::JoinMap;
-use ic_logger::{error, ReplicaLogger};
+use ic_logger::{info, ReplicaLogger};
 use ic_types::{messages::MessageId, Height};
 use std::{
     cmp::max,
@@ -247,7 +247,7 @@ impl IngressWatcher {
                 }
 
                 _ = self.cancellation_token.cancelled() => {
-                    error!(
+                    info!(
                         self.log,
                         "Ingress watcher event loop cancelled.",
                     );


### PR DESCRIPTION
Currently, an [error](https://github.com/dfinity/ic/blob/26d5f9d0bdca0a817c236134dc9c7317b32c69a5/rs/http_endpoints/public/src/call/ingress_watcher.rs#L250) is logged if the ingress watcher is cancelled, but in production the cancellation token is never used (since a [fresh](https://github.com/dfinity/ic/blob/26d5f9d0bdca0a817c236134dc9c7317b32c69a5/rs/http_endpoints/public/src/lib.rs#L344) one is created when starting the ingress watcher and it is not stored anywhere to be cancelled later), but the cancellation token is cancelled upon [drop](https://github.com/dfinity/ic/blob/26d5f9d0bdca0a817c236134dc9c7317b32c69a5/rs/state_machine_tests/src/lib.rs#L1486) in StateMachine tests resulting in errors being logged. Hence, this PR updates the log level of ingress watcher cancellation from error to info.