### PR TITLE
chore(IDX): trigger Apple Silicon jobs on merge queue

### DIFF
--- a/.github/workflows/test-namespace-darwin.yaml
+++ b/.github/workflows/test-namespace-darwin.yaml
@@ -5,6 +5,7 @@ on:
     branches:
       - master
   pull_request:
+  merge_group:
 
 # Ensure there's only one instance of this workflow for any PR/branch/tag, and
 # cancel the previous one if necessary; except on master where we want to build


### PR DESCRIPTION
We need to add a trigger on merge queue to make this a required check.