### PR TITLE
feat(IDX): use dev-gh- for aarch64 darwin

### DIFF
--- a/.github/workflows/test-namespace-darwin.yaml
+++ b/.github/workflows/test-namespace-darwin.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - 'dev-gh-*' # used by developers to trigger CI runs without having to open a PR
   pull_request:
   merge_group:
 


### PR DESCRIPTION
This ports the `dev-gh-*` trick (allowing developers to trigger CI jobs on `push:` outside of `master`) to the Apple Silicon/namespace build.