### PR TITLE
feat(release): Use explicit action type and verify arg hashes when submitting NNS canister upgrade proposals

### DIFF
--- a/testnet/tools/nns-tools/lib/proposals.sh
+++ b/testnet/tools/nns-tools/lib/proposals.sh
@@ -157,10 +157,11 @@ This should match \`wasm_module\` field of this proposal.$(if [ ! -z "$CANDID_AR
 [latest-didc]: https://github.com/dfinity/candid/releases/latest
 
 \`\`\`
-didc encode '$CANDID_ARGS'
+didc encode '$CANDID_ARGS' | xxd -r -p | sha256sum
+
 \`\`\`
 
-This should match the \`arg_hex\` field of this proposal.
+This should match the \`arg_hash\` field of this proposal.
 "
         fi)
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++

--- a/testnet/tools/nns-tools/submit-mainnet-nns-upgrade-proposal.sh
+++ b/testnet/tools/nns-tools/submit-mainnet-nns-upgrade-proposal.sh
@@ -103,6 +103,7 @@ submit_nns_upgrade_proposal_mainnet() {
         --wasm-module-path="$WASM_GZ"
 
         # Misc
+        --use-explicit-action-type
         --wasm-module-sha256="$WASM_SHA"
         --proposer="$NEURON_ID"
     )


### PR DESCRIPTION
# Why

Now we can create NNS canister upgrade proposals as `ProtocolCanisterManagement` proposals using the `InstallCode` proposal type, we should update our release script to use the new feature.

# Why

* Always send `--use-explicit-action-type` arg when invoking `ic-admin` for sending proposals
* Verify `arg_hash` instead of `arg_hex`, since that's what `InstallCode` proposal exposes