### PR TITLE
feat(ic-admin): Let ic-admin accept an  param and let NNS release script pass it

### DIFF
--- a/rs/registry/admin/src/main.rs
+++ b/rs/registry/admin/src/main.rs
@@ -961,6 +961,10 @@ struct ProposeToChangeNnsCanisterCmd {
     /// canister.
     arg: Option<PathBuf>,
 
+    /// The sha256 of the arg binary file.
+    #[clap(long)]
+    arg_sha256: Option<String>,
+
     #[clap(long)]
     /// If set, it will update the canister's compute allocation to this value.
     /// See `ComputeAllocation` for the semantics of this field.
@@ -985,10 +989,7 @@ impl ProposalPayload<UpgradeRootProposal> for ProposeToChangeNnsCanisterCmd {
             &self.wasm_module_sha256,
         )
         .await;
-        let module_arg = self
-            .arg
-            .as_ref()
-            .map_or(vec![], |path| read_file_fully(path));
+        let module_arg = read_arg(&self.arg, &self.arg_sha256);
         let stop_upgrade_start = !self.skip_stopping_before_installing;
         UpgradeRootProposal {
             wasm_module,
@@ -1019,10 +1020,7 @@ impl ProposalPayload<ChangeCanisterRequest> for ProposeToChangeNnsCanisterCmd {
             &self.wasm_module_sha256,
         )
         .await;
-        let arg = self
-            .arg
-            .as_ref()
-            .map_or(vec![], |path| read_file_fully(path));
+        let arg = read_arg(&self.arg, &self.arg_sha256);
         ChangeCanisterRequest {
             stop_before_installing: !self.skip_stopping_before_installing,
             mode: self.mode,
@@ -5493,6 +5491,22 @@ async fn read_wasm_module(
         .expect("Wasm module's sha256 does not match provided sha256");
 
     read_file_fully(&wasm_file_path)
+}
+
+fn read_arg(arg_path: &Option<PathBuf>, arg_sha256: &Option<String>) -> Vec<u8> {
+    match (arg_path, arg_sha256) {
+        // No arguments, which is fine and we default to empty blob.
+        (None, None) => vec![],
+        (Some(arg_path), Some(arg_sha256)) => {
+            check_file_hash(arg_path, arg_sha256)
+                .expect("Upgrade arg's sha256 does not match provided sha256");
+            read_file_fully(arg_path)
+        }
+        (Some(_), None) => panic!("Must provide a sha256 checksum for the upgrade arg",),
+        (None, Some(_)) => {
+            panic!("--arg-sha256 provided without --arg-path");
+        }
+    }
 }
 
 async fn download_wasm_module(url: &Url) -> PathBuf {

--- a/testnet/tools/nns-tools/submit-mainnet-nns-upgrade-proposal.sh
+++ b/testnet/tools/nns-tools/submit-mainnet-nns-upgrade-proposal.sh
@@ -59,6 +59,7 @@ submit_nns_upgrade_proposal_mainnet() {
     CANDID_ARGS_FILE=""
     if [ ! -z "$CANDID_UPGRADE_ARGS" ]; then
         CANDID_ARGS_FILE=$(encode_candid_args_in_file "$CANDID_UPGRADE_ARGS")
+        CANDID_ARGS_HASH=$(sha_256 $CANDID_ARGS_FILE)
     fi
 
     echo_line
@@ -110,6 +111,7 @@ submit_nns_upgrade_proposal_mainnet() {
 
     if [ ! -z "$CANDID_ARGS_FILE" ]; then
         cmd+=(--arg=$CANDID_ARGS_FILE)
+        cmd+=(--arg-sha256="$CANDID_ARGS_HASH")
     fi
 
     if [ "$DRY_RUN" = true ]; then


### PR DESCRIPTION
# Why

For the `wasm_module`, ic-admin accepts the path/url as well as its hash, so it's less error prone for users. Since there is symmetry between `wasm_module` and `arg`, we support the functionality for `arg` as well.

# What

* Add `--arg_sha256` ic-admin argument
* Check `--arg_sha256` against `--arg` when both are provided, and panic when only one of them is
* Provide the new argument to `ic-admin` within the NNS release script