### PR TITLE
chore(nns): Disallow deprecated proposal types at the API layer

### DIFF
--- a/rs/nns/governance/api/src/ic_nns_governance.pb.v1.rs
+++ b/rs/nns/governance/api/src/ic_nns_governance.pb.v1.rs
@@ -1236,16 +1236,10 @@ pub enum ProposalActionRequest {
     AddOrRemoveNodeProvider(AddOrRemoveNodeProvider),
     #[prost(message, tag = "17")]
     RewardNodeProvider(RewardNodeProvider),
-    #[prost(message, tag = "18")]
-    SetDefaultFollowees(SetDefaultFollowees),
     #[prost(message, tag = "19")]
     RewardNodeProviders(RewardNodeProviders),
     #[prost(message, tag = "21")]
     RegisterKnownNeuron(KnownNeuron),
-    #[prost(message, tag = "22")]
-    SetSnsTokenSwapOpenTimeWindow(SetSnsTokenSwapOpenTimeWindow),
-    #[prost(message, tag = "23")]
-    OpenSnsTokenSwap(OpenSnsTokenSwap),
     #[prost(message, tag = "24")]
     CreateServiceNervousSystem(CreateServiceNervousSystem),
     #[prost(message, tag = "25")]

--- a/rs/nns/governance/api/src/proposal_helpers.rs
+++ b/rs/nns/governance/api/src/proposal_helpers.rs
@@ -99,13 +99,8 @@ impl From<ProposalActionRequest> for Action {
             ProposalActionRequest::ApproveGenesisKyc(v) => Action::ApproveGenesisKyc(v),
             ProposalActionRequest::AddOrRemoveNodeProvider(v) => Action::AddOrRemoveNodeProvider(v),
             ProposalActionRequest::RewardNodeProvider(v) => Action::RewardNodeProvider(v),
-            ProposalActionRequest::SetDefaultFollowees(v) => Action::SetDefaultFollowees(v),
             ProposalActionRequest::RewardNodeProviders(v) => Action::RewardNodeProviders(v),
             ProposalActionRequest::RegisterKnownNeuron(v) => Action::RegisterKnownNeuron(v),
-            ProposalActionRequest::SetSnsTokenSwapOpenTimeWindow(v) => {
-                Action::SetSnsTokenSwapOpenTimeWindow(v)
-            }
-            ProposalActionRequest::OpenSnsTokenSwap(v) => Action::OpenSnsTokenSwap(v),
             ProposalActionRequest::CreateServiceNervousSystem(v) => {
                 Action::CreateServiceNervousSystem(v)
             }

--- a/rs/nns/governance/canister/governance.did
+++ b/rs/nns/governance/canister/governance.did
@@ -782,9 +782,6 @@ type ProposalActionRequest = variant {
   CreateServiceNervousSystem : CreateServiceNervousSystem;
   ExecuteNnsFunction : ExecuteNnsFunction;
   RewardNodeProvider : RewardNodeProvider;
-  OpenSnsTokenSwap : OpenSnsTokenSwap;
-  SetSnsTokenSwapOpenTimeWindow : SetSnsTokenSwapOpenTimeWindow;
-  SetDefaultFollowees : SetDefaultFollowees;
   RewardNodeProviders : RewardNodeProviders;
   ManageNetworkEconomics : NetworkEconomics;
   ApproveGenesisKyc : Principals;

--- a/rs/nns/governance/canister/governance_test.did
+++ b/rs/nns/governance/canister/governance_test.did
@@ -784,9 +784,6 @@ type ProposalActionRequest = variant {
   CreateServiceNervousSystem : CreateServiceNervousSystem;
   ExecuteNnsFunction : ExecuteNnsFunction;
   RewardNodeProvider : RewardNodeProvider;
-  OpenSnsTokenSwap : OpenSnsTokenSwap;
-  SetSnsTokenSwapOpenTimeWindow : SetSnsTokenSwapOpenTimeWindow;
-  SetDefaultFollowees : SetDefaultFollowees;
   RewardNodeProviders : RewardNodeProviders;
   ManageNetworkEconomics : NetworkEconomics;
   ApproveGenesisKyc : Principals;

--- a/rs/nns/governance/src/governance.rs
+++ b/rs/nns/governance/src/governance.rs
@@ -4980,10 +4980,12 @@ impl Governance {
             | Action::ApproveGenesisKyc(_)
             | Action::AddOrRemoveNodeProvider(_)
             | Action::RewardNodeProvider(_)
-            | Action::SetDefaultFollowees(_)
             | Action::RewardNodeProviders(_)
             | Action::RegisterKnownNeuron(_) => Ok(()),
 
+            Action::SetDefaultFollowees(obsolete_action) => {
+                Self::validate_obsolete_proposal_action(obsolete_action)
+            }
             Action::SetSnsTokenSwapOpenTimeWindow(obsolete_action) => {
                 Self::validate_obsolete_proposal_action(obsolete_action)
             }

--- a/rs/nns/governance/src/pb/conversions.rs
+++ b/rs/nns/governance/src/pb/conversions.rs
@@ -688,20 +688,11 @@ impl From<pb_api::ProposalActionRequest> for pb::proposal::Action {
             pb_api::ProposalActionRequest::RewardNodeProvider(v) => {
                 pb::proposal::Action::RewardNodeProvider(v.into())
             }
-            pb_api::ProposalActionRequest::SetDefaultFollowees(v) => {
-                pb::proposal::Action::SetDefaultFollowees(v.into())
-            }
             pb_api::ProposalActionRequest::RewardNodeProviders(v) => {
                 pb::proposal::Action::RewardNodeProviders(v.into())
             }
             pb_api::ProposalActionRequest::RegisterKnownNeuron(v) => {
                 pb::proposal::Action::RegisterKnownNeuron(v.into())
-            }
-            pb_api::ProposalActionRequest::SetSnsTokenSwapOpenTimeWindow(v) => {
-                pb::proposal::Action::SetSnsTokenSwapOpenTimeWindow(v.into())
-            }
-            pb_api::ProposalActionRequest::OpenSnsTokenSwap(v) => {
-                pb::proposal::Action::OpenSnsTokenSwap(v.into())
             }
             pb_api::ProposalActionRequest::CreateServiceNervousSystem(v) => {
                 pb::proposal::Action::CreateServiceNervousSystem(v.into())

--- a/rs/nns/governance/tests/governance.rs
+++ b/rs/nns/governance/tests/governance.rs
@@ -24,7 +24,7 @@ use ic_nervous_system_clients::canister_status::{CanisterStatusResultV2, Caniste
 use ic_nervous_system_common::{
     cmc::CMC,
     ledger::{compute_neuron_staking_subaccount_bytes, IcpLedger},
-    NervousSystemError, E8, ONE_DAY_SECONDS, ONE_MONTH_SECONDS, ONE_YEAR_SECONDS,
+    NervousSystemError, E8, ONE_DAY_SECONDS, ONE_YEAR_SECONDS,
 };
 use ic_nervous_system_common_test_keys::{
     TEST_NEURON_1_OWNER_PRINCIPAL, TEST_NEURON_2_OWNER_PRINCIPAL,
@@ -77,17 +77,17 @@ use ic_nns_governance::{
         proposal::{self, Action, ActionDesc},
         reward_node_provider::{RewardMode, RewardToAccount, RewardToNeuron},
         settle_neurons_fund_participation_request, swap_background_information,
-        AddOrRemoveNodeProvider, ApproveGenesisKyc, Ballot, BallotChange, BallotInfo,
-        BallotInfoChange, CreateServiceNervousSystem, Empty, ExecuteNnsFunction,
-        Governance as GovernanceProto, GovernanceChange, GovernanceError,
-        IdealMatchedParticipationFunction, KnownNeuron, KnownNeuronData, ListNeurons,
-        ListProposalInfo, ListProposalInfoResponse, ManageNeuron, ManageNeuronResponse,
-        MonthlyNodeProviderRewards, Motion, NetworkEconomics, Neuron, NeuronChange, NeuronState,
-        NeuronType, NeuronsFundData, NeuronsFundParticipation, NeuronsFundSnapshot, NnsFunction,
-        NodeProvider, Proposal, ProposalChange, ProposalData, ProposalDataChange,
+        AddOrRemoveNodeProvider, Ballot, BallotChange, BallotInfo, BallotInfoChange,
+        CreateServiceNervousSystem, Empty, ExecuteNnsFunction, Governance as GovernanceProto,
+        GovernanceChange, GovernanceError, IdealMatchedParticipationFunction, KnownNeuron,
+        KnownNeuronData, ListNeurons, ListProposalInfo, ListProposalInfoResponse, ManageNeuron,
+        ManageNeuronResponse, MonthlyNodeProviderRewards, Motion, NetworkEconomics, Neuron,
+        NeuronChange, NeuronState, NeuronType, NeuronsFundData, NeuronsFundParticipation,
+        NeuronsFundSnapshot, NnsFunction, NodeProvider, Proposal, ProposalChange, ProposalData,
+        ProposalDataChange,
         ProposalRewardStatus::{self, AcceptVotes, ReadyToSettle},
         ProposalStatus::{self, Rejected},
-        RewardEvent, RewardNodeProvider, RewardNodeProviders, SetDefaultFollowees,
+        RewardEvent, RewardNodeProvider, RewardNodeProviders,
         SettleNeuronsFundParticipationRequest, SwapBackgroundInformation, SwapParticipationLimits,
         Tally, TallyChange, Topic, UpdateNodeProvider, Visibility, Vote, WaitForQuietState,
         WaitForQuietStateDesc,
@@ -7302,251 +7302,6 @@ fn test_network_economics_proposal() {
             .unwrap()
             .neuron_minimum_stake_e8s,
         1234
-    );
-}
-
-fn make_proposal_with_action(
-    gov: &mut Governance,
-    proposer_p: &PrincipalId,
-    proposer_n: &NeuronId,
-    action: proposal::Action,
-) -> ProposalId {
-    let response = match gov
-        .manage_neuron(
-            proposer_p,
-            &ManageNeuron {
-                id: None,
-                neuron_id_or_subaccount: Some(NeuronIdOrSubaccount::NeuronId(*proposer_n)),
-                command: Some(manage_neuron::Command::MakeProposal(Box::new(Proposal {
-                    title: Some("Dummy proposal".to_string()),
-                    summary: "".to_string(),
-                    url: "".to_string(),
-                    action: Some(action),
-                }))),
-            },
-        )
-        .now_or_never()
-        .unwrap()
-        .panic_if_error("Couldn't submit proposal.")
-        .command
-        .unwrap()
-    {
-        manage_neuron_response::Command::MakeProposal(resp) => resp,
-        _ => panic!("Invalid response"),
-    };
-    response.proposal_id.unwrap()
-}
-
-// When a neuron A follows neuron B on topic Unspecified, and B votes on topic
-// T, then A votes the same was as B, except when T is Governance or
-// SnsAndCommunityFund.
-#[test]
-fn test_default_followees() {
-    let p = match std::env::var("NEURON_CSV_PATH") {
-        Ok(v) => PathBuf::from(v),
-        Err(_) => PathBuf::from("tests/neurons.csv"),
-    };
-    let mut builder = GovernanceCanisterInitPayloadBuilder::new();
-    let init_neurons = &mut builder.add_all_neurons_from_csv_file(&p).proto.neurons;
-
-    let voter_pid = *init_neurons[&42].controller.as_ref().unwrap();
-    let voter_neuron = init_neurons[&42].id.unwrap();
-    init_neurons.get_mut(&42).unwrap().dissolve_state = Some(
-        DissolveState::DissolveDelaySeconds(MIN_DISSOLVE_DELAY_FOR_VOTE_ELIGIBILITY_SECONDS).into(),
-    );
-    let (mut driver, mut gov) = governance_with_neurons(
-        &init_neurons
-            .values()
-            .map(|n| n.clone().into())
-            .collect::<Vec<Neuron>>(),
-    );
-
-    let default_followees = hashmap![
-        Topic::Unspecified as i32 => Followees { followees: vec![voter_neuron]},
-    ];
-
-    gov.heap_data
-        .default_followees
-        .clone_from(&default_followees);
-    let from = *TEST_NEURON_1_OWNER_PRINCIPAL;
-    let neuron_stake_e8s = 100 * 100_000_000;
-    let nonce = 1234u64;
-
-    let to_subaccount = Subaccount({
-        let mut sha = Sha256::new();
-        sha.write(&[0x0c]);
-        sha.write(b"neuron-stake");
-        sha.write(from.as_slice());
-        sha.write(&nonce.to_be_bytes());
-        sha.finish()
-    });
-
-    driver.create_account_with_funds(
-        AccountIdentifier::new(GOVERNANCE_CANISTER_ID.get(), Some(to_subaccount)),
-        neuron_stake_e8s,
-    );
-
-    let follower_neuron_id =
-        claim_or_refresh_neuron_by_memo(&mut gov, &from, None, to_subaccount, Memo(nonce), None)
-            .unwrap();
-    match gov
-        .manage_neuron(
-            &from,
-            &ManageNeuron {
-                id: None,
-                neuron_id_or_subaccount: Some(NeuronIdOrSubaccount::NeuronId(follower_neuron_id)),
-                command: Some(manage_neuron::Command::Configure(Configure {
-                    operation: Some(Operation::IncreaseDissolveDelay(IncreaseDissolveDelay {
-                        additional_dissolve_delay_seconds: (6 * ONE_MONTH_SECONDS) as u32,
-                    })),
-                })),
-            },
-        )
-        .now_or_never()
-        .unwrap()
-        .panic_if_error("Couldn't increase dissolve delay.")
-        .command
-        .unwrap()
-    {
-        manage_neuron_response::Command::Configure(_) => (),
-        _ => panic!("Invalid response"),
-    };
-    assert_eq!(
-        gov.neuron_store
-            .with_neuron(&follower_neuron_id, |n| n.clone())
-            .unwrap()
-            .followees,
-        default_followees,
-    );
-    let followed_proposal_ids = |gov: &mut Governance| {
-        gov.neuron_store
-            .with_neuron(&follower_neuron_id, |n| n.clone())
-            .unwrap()
-            .recent_ballots
-            .iter()
-            .map(|b| *b.proposal_id.as_ref().unwrap())
-            .collect::<Vec<ProposalId>>()
-    };
-
-    // Despite having default followees on the Unspecified topic, topics Governance and
-    // SnsAndCommunityFund shouldn't have default following, i.e. when the voter_neuron votes in
-    // all other topics, the neuron we just created should follow, except in these two topics.
-    let not_governance_nor_sns_proposal_id = make_proposal_with_action(
-        &mut gov,
-        &voter_pid,
-        &voter_neuron,
-        proposal::Action::ApproveGenesisKyc(ApproveGenesisKyc {
-            principals: vec![voter_pid],
-        }),
-    );
-    let expected_followed_proposal_ids = vec![not_governance_nor_sns_proposal_id];
-    assert_eq!(
-        followed_proposal_ids(&mut gov),
-        expected_followed_proposal_ids,
-    );
-
-    let governance_proposal_id = make_proposal_with_action(
-        &mut gov,
-        &voter_pid,
-        &voter_neuron,
-        proposal::Action::Motion(Motion {
-            motion_text: "".to_string(),
-        }),
-    );
-    assert!(!followed_proposal_ids(&mut gov).contains(&governance_proposal_id));
-    assert_eq!(
-        followed_proposal_ids(&mut gov),
-        expected_followed_proposal_ids
-    );
-
-    let sns_proposal_id = make_proposal_with_action(
-        &mut gov,
-        &voter_pid,
-        &voter_neuron,
-        CREATE_SERVICE_NERVOUS_SYSTEM_PROPOSAL
-            .action
-            .clone()
-            .unwrap(),
-    );
-    assert!(!followed_proposal_ids(&mut gov).contains(&sns_proposal_id));
-    assert_eq!(
-        followed_proposal_ids(&mut gov),
-        expected_followed_proposal_ids
-    );
-
-    let default_followees2 = hashmap![
-        Topic::ExchangeRate as i32 => Followees { followees: vec![voter_neuron]},
-        Topic::NetworkEconomics as i32 => Followees { followees: vec![voter_neuron]},
-        Topic::Governance as i32 => Followees { followees: vec![voter_neuron]},
-        Topic::SnsAndCommunityFund as i32 => Followees { followees: vec![voter_neuron]},
-        Topic::NodeAdmin as i32 => Followees { followees: vec![voter_neuron]},
-        Topic::ParticipantManagement as i32 => Followees { followees: vec![voter_neuron]},
-        Topic::SubnetManagement as i32 => Followees { followees: vec![voter_neuron]},
-        Topic::NetworkCanisterManagement as i32 => Followees { followees: vec![voter_neuron]},
-        Topic::Kyc as i32 => Followees { followees: vec![voter_neuron]},
-    ];
-
-    // Make a proposal to change the default followees.
-    let change_default_followees_proposal_id = match gov
-        .manage_neuron(
-            &voter_pid,
-            &ManageNeuron {
-                id: None,
-                neuron_id_or_subaccount: Some(NeuronIdOrSubaccount::NeuronId(voter_neuron)),
-                command: Some(manage_neuron::Command::MakeProposal(Box::new(Proposal {
-                    title: Some("Change Network Economics".to_string()),
-                    summary: "Just want to change this param.".to_string(),
-                    url: "".to_string(),
-                    action: Some(proposal::Action::SetDefaultFollowees(SetDefaultFollowees {
-                        default_followees: default_followees2.clone(),
-                    })),
-                }))),
-            },
-        )
-        .now_or_never()
-        .unwrap()
-        .panic_if_error("Couldn't submit proposal.")
-        .command
-        .unwrap()
-    {
-        manage_neuron_response::Command::MakeProposal(resp) => resp.proposal_id.unwrap(),
-        _ => panic!("Invalid response"),
-    };
-
-    assert_eq!(
-        gov.get_proposal_data(change_default_followees_proposal_id)
-            .unwrap()
-            .status(),
-        ProposalStatus::Executed
-    );
-
-    let nonce = 2345u64;
-    let to_subaccount = Subaccount({
-        let mut sha = Sha256::new();
-        sha.write(&[0x0c]);
-        sha.write(b"neuron-stake");
-        sha.write(from.as_slice());
-        sha.write(&nonce.to_be_bytes());
-        sha.finish()
-    });
-
-    driver.create_account_with_funds(
-        AccountIdentifier::new(GOVERNANCE_CANISTER_ID.get(), Some(to_subaccount)),
-        neuron_stake_e8s,
-    );
-
-    let id2 =
-        claim_or_refresh_neuron_by_memo(&mut gov, &from, None, to_subaccount, Memo(nonce), None)
-            .unwrap();
-
-    // The second neuron should have the default followees we set with the proposal.
-    assert!(follower_neuron_id != id2);
-    assert_eq!(
-        gov.neuron_store
-            .with_neuron(&id2, |n| n.clone())
-            .unwrap()
-            .followees,
-        default_followees2
     );
 }
 


### PR DESCRIPTION
# Why

The API layer should disallow proposals with deprecated types to be created. It was already impossible to create `OpenSnsTokenSwap` or `SetSnsTokenSwapOpenTimeWindow` proposals, while `SetDefaultFollowees` is no longer needed as we are actually trying to reset the effect of the previous default following (https://forum.dfinity.org/t/periodic-confirmation-design/34215)

# What

* Remove variants of the action types from the API request type of the proposal action
* Fail validation for `SetDefaultFolllowees`