### PR TITLE
chore(sns): Remove migration code for setting SNS memory limits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11478,7 +11478,6 @@ dependencies = [
  "ic-nervous-system-common-build-metadata",
  "ic-nervous-system-root",
  "ic-nervous-system-runtime",
- "ic-nns-constants",
  "ic-sns-root-protobuf-generator",
  "ic-sns-swap",
  "ic-test-utilities-compare-dirs",

--- a/rs/sns/init/src/lib.rs
+++ b/rs/sns/init/src/lib.rs
@@ -670,8 +670,6 @@ impl SnsInitPayload {
             latest_ledger_archive_poll_timestamp_seconds: None,
             index_canister_id: Some(sns_canister_ids.index),
             testflight,
-            // Newly created canisters don't need their memory limit updated.
-            updated_framework_canisters_memory_limit: Some(true),
         }
     }
 

--- a/rs/sns/integration_tests/src/root.rs
+++ b/rs/sns/integration_tests/src/root.rs
@@ -44,7 +44,6 @@ fn test_get_status() {
                 latest_ledger_archive_poll_timestamp_seconds: None,
                 index_canister_id: Some(PrincipalId::new_user_test_id(45)),
                 testflight: false,
-                updated_framework_canisters_memory_limit: Some(true),
             },
         )
         .await;

--- a/rs/sns/root/BUILD.bazel
+++ b/rs/sns/root/BUILD.bazel
@@ -17,7 +17,6 @@ DEPENDENCIES = [
     "//rs/nervous_system/common",
     "//rs/nervous_system/root",
     "//rs/nervous_system/runtime",
-    "//rs/nns/constants",
     "//rs/rust_canisters/canister_log",
     "//rs/rust_canisters/http_types",
     "//rs/sns/swap",  # TODO[NNS1-2282]

--- a/rs/sns/root/Cargo.toml
+++ b/rs/sns/root/Cargo.toml
@@ -30,7 +30,6 @@ ic-nervous-system-common = { path = "../../nervous_system/common" }
 ic-nervous-system-common-build-metadata = { path = "../../nervous_system/common/build_metadata" }
 ic-nervous-system-root = { path = "../../nervous_system/root" }
 ic-nervous-system-runtime = { path = "../../nervous_system/runtime" }
-ic-nns-constants = { path = "../../nns/constants" }
 ic-sns-swap = { path = "../swap" }
 icrc-ledger-types = { path = "../../../packages/icrc-ledger-types" }
 prost = { workspace = true }

--- a/rs/sns/root/canister/canister.rs
+++ b/rs/sns/root/canister/canister.rs
@@ -362,9 +362,8 @@ async fn heartbeat() {
     // dependencies to run_periodic_tasks.
     let now = CanisterEnvironment {}.now();
     let ledger_client = create_ledger_client();
-    let management_canister = ManagementCanisterClientImpl::<CanisterRuntime>::new(None);
 
-    SnsRootCanister::heartbeat(&STATE, &management_canister, &ledger_client, now).await
+    SnsRootCanister::heartbeat(&STATE, &ledger_client, now).await
 }
 
 // Resources to serve for a given http_request

--- a/rs/sns/root/canister/root.did
+++ b/rs/sns/root/canister/root.did
@@ -145,7 +145,6 @@ type SnsRootCanister = record {
   index_canister_id : opt principal;
   swap_canister_id : opt principal;
   ledger_canister_id : opt principal;
-  updated_framework_canisters_memory_limit : opt bool;
 };
 
 service : (SnsRootCanister) -> {

--- a/rs/sns/root/proto/ic_sns_root/pb/v1/root.proto
+++ b/rs/sns/root/proto/ic_sns_root/pb/v1/root.proto
@@ -46,9 +46,8 @@ message SnsRootCanister {
   // controllers beyond SNS root are allowed when registering a dapp.
   bool testflight = 8;
 
-  // Set to `true` if the framework canisters' memory limit doesn't need to be changed
-  // TODO(NNS1-3286): remove
-  optional bool updated_framework_canisters_memory_limit = 9;
+  reserved "updated_framework_canisters_memory_limit";
+  reserved 9;
 }
 
 message RegisterDappCanisterRequest {

--- a/rs/sns/root/src/gen/ic_sns_root.pb.v1.rs
+++ b/rs/sns/root/src/gen/ic_sns_root.pb.v1.rs
@@ -43,10 +43,6 @@ pub struct SnsRootCanister {
     /// controllers beyond SNS root are allowed when registering a dapp.
     #[prost(bool, tag = "8")]
     pub testflight: bool,
-    /// Set to `true` if the framework canisters' memory limit doesn't need to be changed
-    /// TODO(NNS1-3286): remove
-    #[prost(bool, optional, tag = "9")]
-    pub updated_framework_canisters_memory_limit: ::core::option::Option<bool>,
 }
 #[derive(candid::CandidType, candid::Deserialize, comparable::Comparable)]
 #[allow(clippy::derive_partial_eq_without_eq)]


### PR DESCRIPTION
This reverts commit 0aa15a5bec268e817c45b369bd7c33c708ce8710. (except it doesn't undo the changes to Cargo.lock)

Now that the change with the migration has been released, the code is no longer necessary and can be deleted