### PR TITLE
chore(IDX): rename macos runners for clarity

### DIFF
--- a/.github/workflows-source/ci-main.yml
+++ b/.github/workflows-source/ci-main.yml
@@ -153,7 +153,7 @@ jobs:
       - <<: *bazel-bep
 
   bazel-test-macos-intel:
-    name: Bazel Test MacOS Intel
+    name: Bazel Test macOS Intel
     timeout-minutes: 120
     runs-on:
       labels: macOS

--- a/.github/workflows-source/ci-main.yml
+++ b/.github/workflows-source/ci-main.yml
@@ -152,8 +152,8 @@ jobs:
           RUN_ON_DIFF_ONLY: false
       - <<: *bazel-bep
 
-  bazel-test-darwin-x86-64:
-    name: Bazel Test Darwin x86-64
+  bazel-test-macos-intel:
+    name: Bazel Test MacOS Intel
     timeout-minutes: 120
     runs-on:
       labels: macOS

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -138,8 +138,8 @@ jobs:
           path: |
             bazel-bep.pb
             profile.json
-  bazel-test-darwin-x86-64:
-    name: Bazel Test Darwin x86-64
+  bazel-test-macos-intel:
+    name: Bazel Test MacOS Intel
     timeout-minutes: 120
     runs-on:
       labels: macOS

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -139,7 +139,7 @@ jobs:
             bazel-bep.pb
             profile.json
   bazel-test-macos-intel:
-    name: Bazel Test MacOS Intel
+    name: Bazel Test macOS Intel
     timeout-minutes: 120
     runs-on:
       labels: macOS

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -138,8 +138,8 @@ jobs:
           path: |
             bazel-bep.pb
             profile.json
-  bazel-test-macos-intel:
-    name: Bazel Test MacOS Intel
+  bazel-test-darwin-x86-64:
+    name: Bazel Test Darwin x86-64
     timeout-minutes: 120
     runs-on:
       labels: macOS

--- a/.github/workflows/test-namespace-darwin.yaml
+++ b/.github/workflows/test-namespace-darwin.yaml
@@ -19,7 +19,7 @@ jobs:
   bazel-test-macos-apple-silicon:
     name: Bazel Test macOS Apple Silicon
     timeout-minutes: 120
-    runs-on: namespace-profile-darwin-small-cache # profile created in namespace console
+    runs-on: namespace-profile-darwin # profile created in namespace console
     steps:
       - name: Install nsc
         run: |

--- a/.github/workflows/test-namespace-darwin.yaml
+++ b/.github/workflows/test-namespace-darwin.yaml
@@ -16,8 +16,8 @@ concurrency:
   cancel-in-progress: ${{ github.ref_name != 'master' }}
 
 jobs:
-  bazel-test-macos-arm64:
-    name: Bazel Test Darwin arm64 [Namespace]
+  bazel-test-macos-apple-silicon:
+    name: Bazel Test MacOS Apple Silicon
     timeout-minutes: 120
     runs-on: namespace-profile-darwin-small-cache # profile created in namespace console
     steps:

--- a/.github/workflows/test-namespace-darwin.yaml
+++ b/.github/workflows/test-namespace-darwin.yaml
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   bazel-test-macos-apple-silicon:
-    name: Bazel Test MacOS Apple Silicon
+    name: Bazel Test macOS Apple Silicon
     timeout-minutes: 120
     runs-on: namespace-profile-darwin-small-cache # profile created in namespace console
     steps:


### PR DESCRIPTION
Now that we are using two macos runners (old intel for releases and newer apple silicon for CI runs) it's helpful to standardize their names. Eventually we'd like to move completely to Apple Silicon runners and can then remove the specification once old Intel runners are deprecated.