### PR TITLE
chore: Edit comment for upgrade_canisters_with_golden_nns_state

### DIFF
--- a/rs/nns/integration_tests/BUILD.bazel
+++ b/rs/nns/integration_tests/BUILD.bazel
@@ -356,10 +356,7 @@ rust_ic_test(
     deps = DEPENDENCIES + DEV_DEPENDENCIES,
 )
 
-# This test has tag "manual", which means it only runs when you explicitly specify it. In addition,
-# this requires a couple of environment variables.
-#
-# To run this test,
+# Run this test as follows:
 #
 #     bazel \
 #         test \


### PR DESCRIPTION
This PR makes the comment above `upgrade_canisters_with_golden_nns_state` less misleading.