### PR TITLE
feat: [MR-572] Check `SystemState` invariants on checkpoint loading

### DIFF
--- a/rs/state_manager/src/checkpoint.rs
+++ b/rs/state_manager/src/checkpoint.rs
@@ -487,6 +487,7 @@ pub fn load_canister_state(
         canister_state_bits.wasm_memory_limit,
         canister_state_bits.next_snapshot_id,
         canister_state_bits.snapshots_memory_usage,
+        metrics,
     );
 
     let canister_state = CanisterState {


### PR DESCRIPTION
[MR-572] Bump `state_manager_checkpoint_soft_invariant_broken` critical error counter if `SystemState::check_invariants()` fails during checkpoint loading.

[MR-572]: https://dfinity.atlassian.net/browse/MR-572?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ