### PR TITLE
chore(nns): Send automatic GitHub Pull Request notifications to #eng-nns-prs.

### DIFF
--- a/.github/workflows/team-channels.json
+++ b/.github/workflows/team-channels.json
@@ -13,7 +13,7 @@
     "InfraSec": "eng-infrasec",
     "languages": "eng-motoko",
     "networking": "eng-networking",
-    "nns-team": "eng-nns",
+    "nns-team": "eng-nns-prs",
     "node": "eng-node-prs",
     "Platform Operations": "eng-platform-ops",
     "pocket-ic": "pocket-ic",


### PR DESCRIPTION
# Motivation

Most members of the NNS team do not consider these notifications to be valuable. For those who actually do want to see these notifications, that is what the #eng-nns-prs channel is for.