### PR TITLE
refactor(nervous_system): Remove support for NeuronParameters

### DIFF
--- a/rs/sns/governance/canister/canister.rs
+++ b/rs/sns/governance/canister/canister.rs
@@ -576,14 +576,14 @@ fn get_mode_(request: GetMode) -> GetModeResponse {
 /// only callable by the Swap canister that was deployed along with this
 /// SNS Governance canister.
 ///
-/// This API takes a request of multiple `NeuronParameters` that provide
+/// This API takes a request of multiple `NeuronRecipes` that provide
 /// the configurable parameters of the to-be-created neurons. Since these neurons
 /// are responsible for the decentralization of an SNS during the Swap, there are
 /// a few differences in neuron creation that occur in comparison to the normal
 /// `ManageNeuron::ClaimOrRefresh` API. See `Governance::claim_swap_neurons` for
 /// more details.
 ///
-/// This method is idempotent. If called with a `NeuronParameters` of an already
+/// This method is idempotent. If called with a `NeuronRecipes` of an already
 /// created Neuron, the `ClaimSwapNeuronsResponse.skipped_claims` field will be
 /// incremented and execution will continue.
 #[export_name = "canister_update claim_swap_neurons"]

--- a/rs/sns/governance/proto/ic_sns_governance/pb/v1/governance.proto
+++ b/rs/sns/governance/proto/ic_sns_governance/pb/v1/governance.proto
@@ -1953,8 +1953,7 @@ message GetModeResponse {
 
 // The request for the `claim_swap_neurons` method.
 message ClaimSwapNeuronsRequest {
-  // NeuronParameters groups parameters for creating a neuron in the
-  // `claim_swap_neurons` method.
+  // This type has been replaced by NeuronRecipe and should not be used.
   // TODO(NNS1-3198): Remove this message once `NeuronRecipe` is used systematically.
   message NeuronParameters {
     reserved "memo";
@@ -2048,7 +2047,7 @@ message ClaimSwapNeuronsRequest {
 
   // The set of parameters that define the neurons created in `claim_swap_neurons`. For
   // each NeuronParameter, one neuron will be created.
-  // Deprecated. Use [`recipes`] instead.
+  // Deprecated. Use [`neuron_recipes`] instead.
   repeated NeuronParameters neuron_parameters = 1 [deprecated = true];
 }
 
@@ -2119,14 +2118,14 @@ message ClaimSwapNeuronsResponse {
 
   // The ok result from `claim_swap_neurons. For every requested neuron,
   // a SwapNeuron message is returned, and should equal the count of
-  // `ClaimSwapNeuronsRequest.neuron_parameters`.
+  // `ClaimSwapNeuronsRequest.neuron_recipes`.
   message ClaimedSwapNeurons {
     repeated SwapNeuron swap_neurons = 1;
   }
 
   // SwapNeuron associates the status of a neuron attempting to be
   // claimed with a NeuronId. The `id` field will correspond with a
-  // `ClaimSwapNeuronsRequest.neuron_parameters.neuron_id` field in
+  // `ClaimSwapNeuronsRequest.neuron_recipes.neuron_id` field in
   // the request object used in `claim_swap_neurons`.
   message SwapNeuron {
     NeuronId id = 1;

--- a/rs/sns/governance/src/gen/ic_sns_governance.pb.v1.rs
+++ b/rs/sns/governance/src/gen/ic_sns_governance.pb.v1.rs
@@ -2524,15 +2524,14 @@ pub struct ClaimSwapNeuronsRequest {
     pub neuron_recipes: ::core::option::Option<claim_swap_neurons_request::NeuronRecipes>,
     /// The set of parameters that define the neurons created in `claim_swap_neurons`. For
     /// each NeuronParameter, one neuron will be created.
-    /// Deprecated. Use \[`recipes`\] instead.
+    /// Deprecated. Use \[`neuron_recipes`\] instead.
     #[deprecated]
     #[prost(message, repeated, tag = "1")]
     pub neuron_parameters: ::prost::alloc::vec::Vec<claim_swap_neurons_request::NeuronParameters>,
 }
 /// Nested message and enum types in `ClaimSwapNeuronsRequest`.
 pub mod claim_swap_neurons_request {
-    /// NeuronParameters groups parameters for creating a neuron in the
-    /// `claim_swap_neurons` method.
+    /// This type has been replaced by NeuronRecipe and should not be used.
     /// TODO(NNS1-3198): Remove this message once `NeuronRecipe` is used systematically.
     #[derive(candid::CandidType, candid::Deserialize, comparable::Comparable)]
     #[allow(clippy::derive_partial_eq_without_eq)]
@@ -2665,7 +2664,7 @@ pub struct ClaimSwapNeuronsResponse {
 pub mod claim_swap_neurons_response {
     /// The ok result from `claim_swap_neurons. For every requested neuron,
     /// a SwapNeuron message is returned, and should equal the count of
-    /// `ClaimSwapNeuronsRequest.neuron_parameters`.
+    /// `ClaimSwapNeuronsRequest.neuron_recipes`.
     #[derive(candid::CandidType, candid::Deserialize, comparable::Comparable)]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
@@ -2675,7 +2674,7 @@ pub mod claim_swap_neurons_response {
     }
     /// SwapNeuron associates the status of a neuron attempting to be
     /// claimed with a NeuronId. The `id` field will correspond with a
-    /// `ClaimSwapNeuronsRequest.neuron_parameters.neuron_id` field in
+    /// `ClaimSwapNeuronsRequest.neuron_recipes.neuron_id` field in
     /// the request object used in `claim_swap_neurons`.
     #[derive(candid::CandidType, candid::Deserialize, comparable::Comparable)]
     #[allow(clippy::derive_partial_eq_without_eq)]

--- a/rs/sns/governance/src/governance.rs
+++ b/rs/sns/governance/src/governance.rs
@@ -3887,6 +3887,10 @@ impl Governance {
         let mut swap_neurons = vec![];
 
         let Some(neuron_recipes) = request.neuron_recipes else {
+            log!(
+                ERROR,
+                "Swap called claim_swap_neurons, but did not populate `neuron_recipes`."
+            );
             return ClaimSwapNeuronsResponse::new_with_error(ClaimSwapNeuronsError::Internal);
         };
 

--- a/rs/sns/governance/src/governance.rs
+++ b/rs/sns/governance/src/governance.rs
@@ -20,7 +20,6 @@ use crate::{
             SetDappControllersResponse,
         },
         v1::{
-            claim_swap_neurons_request::NeuronRecipes,
             claim_swap_neurons_response::SwapNeuron,
             get_neuron_response, get_proposal_response,
             governance::{
@@ -3836,9 +3835,9 @@ impl Governance {
     /// Preconditions:
     /// - The caller must be the Sale canister deployed along with this SNS Governance
     ///   canister.
-    /// - Each NeuronParameters' `stake_e8s` is at least neuron_minimum_stake_e8s
+    /// - Each NeuronRecipe's `stake_e8s` is at least neuron_minimum_stake_e8s
     ///   as defined in the `NervousSystemParameters`
-    /// - Each NeuronParameters' `followees` does not exceed max_followees_per_function
+    /// - Each NeuronRecipe's `followees` does not exceed max_followees_per_function
     ///   as defined in the `NervousSystemParameters`
     /// - There is available memory in the Governance canister for the newly created
     ///   Neuron.
@@ -3887,14 +3886,19 @@ impl Governance {
 
         let mut swap_neurons = vec![];
 
-        // TODO(NNS1-3198): Simplify this code after `NeuronParameters` is made obsolete.
-        let neuron_recipes_from_new_source = request.neuron_recipes;
+        let Some(neuron_recipes) = request.neuron_recipes else {
+            return ClaimSwapNeuronsResponse::new_with_error(ClaimSwapNeuronsError::Internal);
+        };
+
+        // TODO(NNS1-3198): Remove this after `NeuronParameters` is fully removed
         #[allow(deprecated)]
-        let neuron_recipes_from_legacy_source =
-            Some(NeuronRecipes::from(request.neuron_parameters));
-        let neuron_recipes = neuron_recipes_from_new_source
-            .or(neuron_recipes_from_legacy_source)
-            .unwrap_or_default();
+        if !request.neuron_parameters.is_empty() {
+            log!(
+                ERROR,
+                "NeuronParameters is obselete. Please use NeuronRecipes instead."
+            );
+            return ClaimSwapNeuronsResponse::new_with_error(ClaimSwapNeuronsError::Internal);
+        }
 
         for neuron_recipe in Vec::<_>::from(neuron_recipes) {
             match neuron_recipe.validate(

--- a/rs/sns/governance/src/types.rs
+++ b/rs/sns/governance/src/types.rs
@@ -9,7 +9,7 @@ use crate::{
         v1::{
             claim_swap_neurons_request::{
                 neuron_recipe::{self, Participant},
-                NeuronParameters, NeuronRecipe, NeuronRecipes,
+                NeuronRecipe, NeuronRecipes,
             },
             claim_swap_neurons_response::{ClaimSwapNeuronsResult, ClaimedSwapNeurons, SwapNeuron},
             get_neuron_response,
@@ -49,7 +49,7 @@ use ic_nervous_system_common::{
     ledger_validation::MAX_LOGO_LENGTH, validate_proposal_url, NervousSystemError,
     DEFAULT_TRANSFER_FEE, ONE_DAY_SECONDS, ONE_MONTH_SECONDS, ONE_YEAR_SECONDS,
 };
-use ic_nervous_system_proto::pb::v1::{Duration as PbDuration, Percentage, Principals};
+use ic_nervous_system_proto::pb::v1::{Duration as PbDuration, Percentage};
 use ic_sns_governance_proposal_criticality::{
     ProposalCriticality, VotingDurationParameters, VotingPowerThresholds,
 };
@@ -2508,59 +2508,6 @@ impl UpgradeSnsControlledCanister {
     }
 }
 
-// TODO(NNS1-3198): Remove this function after `NeuronParameters` is made obsolete.
-impl From<Vec<NeuronParameters>> for NeuronRecipes {
-    fn from(src: Vec<NeuronParameters>) -> Self {
-        let neuron_recipes = src
-            .into_iter()
-            .map(
-                |NeuronParameters {
-                     neuron_id,
-                     controller,
-                     hotkey,
-                     stake_e8s,
-                     dissolve_delay_seconds,
-                     source_nns_neuron_id,
-                     followees,
-                 }| {
-                    let followees = Some(NeuronIds {
-                        neuron_ids: followees,
-                    });
-                    let participant = if let Some(source_nns_neuron_id) = source_nns_neuron_id {
-                        let nns_neuron_id = Some(source_nns_neuron_id);
-
-                        // Historical misnomer.
-                        let nns_neuron_controller = hotkey;
-
-                        // NNS neurons' hotkeys cannot be specified in the legacy `NeuronParameters` struct.
-                        let nns_neuron_hotkeys = Some(Principals { principals: vec![] });
-
-                        Some(neuron_recipe::Participant::NeuronsFund(
-                            neuron_recipe::NeuronsFund {
-                                nns_neuron_id,
-                                nns_neuron_controller,
-                                nns_neuron_hotkeys,
-                            },
-                        ))
-                    } else {
-                        Some(neuron_recipe::Participant::Direct(neuron_recipe::Direct {}))
-                    };
-                    NeuronRecipe {
-                        neuron_id,
-                        controller,
-                        stake_e8s,
-                        dissolve_delay_seconds,
-                        participant,
-                        followees,
-                    }
-                },
-            )
-            .collect();
-
-        Self { neuron_recipes }
-    }
-}
-
 impl From<Vec<NeuronRecipe>> for NeuronRecipes {
     fn from(neuron_recipes: Vec<NeuronRecipe>) -> Self {
         NeuronRecipes { neuron_recipes }
@@ -2806,6 +2753,7 @@ pub(crate) mod tests {
     };
     use ic_base_types::PrincipalId;
     use ic_nervous_system_common_test_keys::TEST_USER1_PRINCIPAL;
+    use ic_nervous_system_proto::pb::v1::Principals;
     use lazy_static::lazy_static;
     use maplit::{btreemap, hashset};
     use std::convert::TryInto;

--- a/rs/sns/governance/tests/governance.rs
+++ b/rs/sns/governance/tests/governance.rs
@@ -1713,10 +1713,11 @@ fn test_claim_swap_neurons_rejects_unauthorized_access() {
     let mut canister_fixture = GovernanceCanisterFixtureBuilder::new().create();
 
     // Build the request, but leave it empty as it is not relevant to the test
-    #[allow(deprecated)] // TODO: remove once neuron_parameters is removed
     let request = ClaimSwapNeuronsRequest {
-        neuron_parameters: vec![],
-        neuron_recipes: None,
+        neuron_recipes: Some(NeuronRecipes {
+            neuron_recipes: Vec::new(),
+        }),
+        ..Default::default()
     };
 
     // Generate a principal id that should not be authorized to call claim_swap_neurons
@@ -1755,21 +1756,20 @@ fn test_claim_swap_neurons_rejects_unauthorized_access() {
 }
 
 #[test]
-fn test_claim_swap_neurons_reports_invalid_neuron_parameters() {
+fn test_claim_swap_neurons_reports_invalid_neuron_recipes() {
     // Set up the test environment with default sale canister id
     let mut canister_fixture = GovernanceCanisterFixtureBuilder::new().create();
 
     // Create a neuron id so the test can identify the correct item in the response
     let test_neuron_id = NeuronId::new_test_neuron_id(1);
 
-    // Create a request with an invalid NeuronParameter
-    #[allow(deprecated)] // TODO: remove once neuron_parameters is removed
+    // Create a request with an invalid NeuronRecipes
     let request = ClaimSwapNeuronsRequest {
-        neuron_parameters: vec![],
         neuron_recipes: Some(NeuronRecipes::from(vec![NeuronRecipe {
             neuron_id: Some(test_neuron_id.clone()),
             ..Default::default() // The rest of the fields are unset and will fail validation
         }])),
+        ..Default::default()
     };
 
     // Call the method
@@ -1809,9 +1809,7 @@ fn test_claim_swap_neurons_reports_already_existing_neurons() {
 
     // Create a request with a neuron id that should collide with the neuron already inserted into
     // Governance
-    #[allow(deprecated)] // TODO: remove once neuron_parameters is removed
     let request = ClaimSwapNeuronsRequest {
-        neuron_parameters: vec![],
         neuron_recipes: Some(NeuronRecipes::from(vec![NeuronRecipe {
             neuron_id: Some(neuron_id.clone()),
             controller: Some(user_principal),
@@ -1820,6 +1818,7 @@ fn test_claim_swap_neurons_reports_already_existing_neurons() {
             dissolve_delay_seconds: Some(0),
             followees: Some(NeuronIds::from(vec![])),
         }])),
+        ..Default::default()
     };
 
     let authorized_sale_principal = canister_fixture.get_sale_canister_id();
@@ -1859,9 +1858,7 @@ fn test_claim_swap_neurons_reports_failure_if_neuron_cannot_be_added() {
     let test_neuron_id_failure = NeuronId::new_test_neuron_id(2);
 
     // Create a request with a NeuronParameter should succeed
-    #[allow(deprecated)] // TODO: remove once neuron_parameters is removed
     let request = ClaimSwapNeuronsRequest {
-        neuron_parameters: vec![],
         neuron_recipes: Some(NeuronRecipes::from(vec![
             NeuronRecipe {
                 neuron_id: Some(test_neuron_id_success.clone()),
@@ -1880,6 +1877,7 @@ fn test_claim_swap_neurons_reports_failure_if_neuron_cannot_be_added() {
                 followees: Some(NeuronIds::from(vec![])),
             },
         ])),
+        ..Default::default()
     };
 
     // Call the method
@@ -1937,13 +1935,12 @@ fn test_claim_swap_neurons_succeeds() {
         followees: Some(NeuronIds::from(vec![NeuronId::new_test_neuron_id(20)])),
     };
 
-    #[allow(deprecated)] // TODO: remove once neuron_parameters is removed
     let request = ClaimSwapNeuronsRequest {
-        neuron_parameters: vec![],
         neuron_recipes: Some(NeuronRecipes::from(vec![
             direct_participant_neuron_recipe.clone(),
             nf_participant_neuron_recipe.clone(),
         ])),
+        ..Default::default()
     };
 
     // Call the method

--- a/rs/sns/swap/src/swap.rs
+++ b/rs/sns/swap/src/swap.rs
@@ -1676,7 +1676,7 @@ impl Swap {
             }
         }
 
-        // If neuron_parameters is empty, all recipes are either Invalid or Skipped and there
+        // If neuron_recipes is empty, all recipes are either Invalid or Skipped and there
         // is no work to do.
         if neuron_recipes.is_empty() {
             return sweep_result;
@@ -1723,11 +1723,11 @@ impl Swap {
                 batch_count,
             );
 
-            #[allow(deprecated)] // Remove once neuron_parameters is removed
+            #[allow(deprecated)] // TODO(NNS1-3198): Remove once `neuron_parameters` is removed
             let reply = sns_governance_client
                 .claim_swap_neurons(ClaimSwapNeuronsRequest {
-                    neuron_parameters: vec![],
                     neuron_recipes: Some(NeuronRecipes::from(batch)),
+                    neuron_parameters: vec![],
                 })
                 .await;
 


### PR DESCRIPTION
## Problem

We deprecated the `NeuronParameters` struct and the field it was used in, but still have code in SNS governance for handling that field. It can safely be removed now that swap is upgraded.

## Solution

Remove support for it in SNS Governance

[Previous PR](https://github.com/dfinity/ic/pull/870)