### PR TITLE
fix: Make the transport implementation used by the test agent to use HTTP/2

### DIFF
--- a/rs/tests/driver/src/util.rs
+++ b/rs/tests/driver/src/util.rs
@@ -783,6 +783,7 @@ pub async fn agent_with_identity_mapping(
 ) -> Result<Agent, AgentError> {
     let builder = reqwest::Client::builder()
         .timeout(AGENT_REQUEST_TIMEOUT)
+        .http2_prior_knowledge()
         .danger_accept_invalid_certs(true);
 
     let builder = match (


### PR DESCRIPTION
We see some nightly benchmarks failing due to the test agent being unable to make TCP handshakes due to hitting the replica firewall limit. This change makes the test agent to submit requests with H/2 to multiplex the requests, meaning 1 TCP connection is enough per replica.