### PR TITLE
chore(crypto): CRP-2573 explicitly use rustls with std feature in bazel

### DIFF
--- a/Cargo.Bazel.Fuzzing.json.lock
+++ b/Cargo.Bazel.Fuzzing.json.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "a1f76f7855d49a42801141166bc4ea0999089a707d9a8f91d950eda29c5b4023",
+  "checksum": "be486131f305062fe449cda54b30f386dc37dbc1c14eb456fed9b5e40de60dae",
   "crates": {
     "abnf 0.12.0": {
       "name": "abnf",

--- a/Cargo.Bazel.json.lock
+++ b/Cargo.Bazel.json.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "6fc19c391d6fc5ee83c6383b3f8410b4f2bd189026655397f94a88830e709342",
+  "checksum": "8a920674d563ab9d4c7358043cce7d441b5ec0bf606784f111c3fef6f324ce7b",
   "crates": {
     "abnf 0.12.0": {
       "name": "abnf",

--- a/bazel/external_crates.bzl
+++ b/bazel/external_crates.bzl
@@ -1118,7 +1118,7 @@ def external_crates_repository(name, cargo_lockfile, lockfile, sanitizers_enable
             "rustls": crate.spec(
                 default_features = False,
                 version = "^0.23.12",
-                features = ["ring"],
+                features = ["ring", "std"],
             ),
             "rustls-native-certs": crate.spec(
                 version = "^0.7.0",


### PR DESCRIPTION
The `std` feature of `rustls` is required, e.g., for `ClientConfig::builder_with_provider` in `rs/crypto/src/tls/rustls/client_handshake.rs`.

The bazel build succeeds without the `std` feature being explicitly enabled because it is implicitly enabled, e.g., via the use of quinn, [which itself enables it explicitly](https://github.com/quinn-rs/quinn/blob/bb02a12a8435a7732a1d762783eeacbb7e50418e/Cargo.toml#L36).

The `Cargo.toml` recently (via https://github.com/dfinity/ic/pull/955) enabled the `std` feature explicitly because without it the test build failed if only individual crates (such as `ic-signature-verification`) were built. This PR improves the situation by making it explicit also for bazel that `rustls`' `std` feature is needed.

Completes CRP-2573.