### PR TITLE
feat(RUN-931): Add doc links to Validation Errors

### DIFF
--- a/rs/embedders/src/wasm_utils/validation.rs
+++ b/rs/embedders/src/wasm_utils/validation.rs
@@ -954,8 +954,10 @@ fn validate_export_section(
         }
 
         if sum_exported_function_name_lengths > max_sum_exported_function_name_lengths {
-            let err = format!("The sum of `<name>` lengths in exported functions called `canister_update <name>`, `canister_query <name>`, or `canister_composite_query <name>` exceeds {}.", max_sum_exported_function_name_lengths);
-            return Err(WasmValidationError::UserInvalidExportSection(err));
+            return Err(WasmValidationError::ExportedNamesTooLong {
+                total_length: sum_exported_function_name_lengths,
+                allowed: max_sum_exported_function_name_lengths,
+            });
         }
     }
     Ok(())

--- a/rs/embedders/src/wasm_utils/validation.rs
+++ b/rs/embedders/src/wasm_utils/validation.rs
@@ -905,11 +905,9 @@ fn validate_export_section(
                     func_name = parts[0];
                     let unmangled_func_name = parts[1];
                     if seen_funcs.contains(unmangled_func_name) {
-                        return Err(WasmValidationError::UserInvalidExportSection(format!(
-                            "Duplicate function '{}' exported multiple times \
-                             with different call types: update, query, or composite_query.",
-                            unmangled_func_name
-                        )));
+                        return Err(WasmValidationError::DuplicateExport {
+                            name: unmangled_func_name.to_string(),
+                        });
                     }
                     seen_funcs.insert(unmangled_func_name);
                     number_exported_functions += 1;

--- a/rs/embedders/src/wasm_utils/validation.rs
+++ b/rs/embedders/src/wasm_utils/validation.rs
@@ -945,10 +945,14 @@ fn validate_export_section(
                 }
             }
         }
+
         if number_exported_functions > max_number_exported_functions {
-            let err = format!("The number of exported functions called `canister_update <name>`, `canister_query <name>`, or `canister_composite_query <name>` exceeds {}.", max_number_exported_functions);
-            return Err(WasmValidationError::UserInvalidExportSection(err));
+            return Err(WasmValidationError::TooManyExports {
+                defined: number_exported_functions,
+                allowed: max_number_exported_functions,
+            });
         }
+
         if sum_exported_function_name_lengths > max_sum_exported_function_name_lengths {
             let err = format!("The sum of `<name>` lengths in exported functions called `canister_update <name>`, `canister_query <name>`, or `canister_composite_query <name>` exceeds {}.", max_sum_exported_function_name_lengths);
             return Err(WasmValidationError::UserInvalidExportSection(err));

--- a/rs/embedders/src/wasmtime_embedder/system_api.rs
+++ b/rs/embedders/src/wasmtime_embedder/system_api.rs
@@ -1213,10 +1213,8 @@ pub(crate) fn syscalls<
                         system_api.ic0_call_with_best_effort_response(timeout_seconds)
                     })
                 } else {
-                    let err = HypervisorError::UserContractViolation {
+                    let err = HypervisorError::ToolchainContractViolation {
                         error: "ic0::call_with_best_effort_response is not enabled.".to_string(),
-                        suggestion: "".to_string(),
-                        doc_link: "".to_string(),
                     };
                     Err(process_err(&mut caller, err))
                 }
@@ -1231,10 +1229,8 @@ pub(crate) fn syscalls<
                 if feature_flags.best_effort_responses == FlagStatus::Enabled {
                     with_system_api(&mut caller, |system_api| system_api.ic0_msg_deadline())
                 } else {
-                    let err = HypervisorError::UserContractViolation {
+                    let err = HypervisorError::ToolchainContractViolation {
                         error: "ic0::msg_deadline is not enabled.".to_string(),
-                        suggestion: "".to_string(),
-                        doc_link: "".to_string(),
                     };
                     Err(process_err(&mut caller, err))
                 }

--- a/rs/embedders/tests/validation.rs
+++ b/rs/embedders/tests/validation.rs
@@ -410,9 +410,10 @@ fn can_validate_too_many_exported_functions() {
     let wasm = wat2wasm(&many_exported_functions(1001)).unwrap();
     assert_eq!(
         validate_wasm_binary(&wasm, &EmbeddersConfig::default()),
-        Err(WasmValidationError::UserInvalidExportSection(
-            "The number of exported functions called `canister_update <name>`, `canister_query <name>`, or `canister_composite_query <name>` exceeds 1000.".to_string()
-        ))
+        Err(WasmValidationError::TooManyExports {
+            defined: 1001,
+            allowed: 1000
+        })
     );
 }
 

--- a/rs/embedders/tests/validation.rs
+++ b/rs/embedders/tests/validation.rs
@@ -334,11 +334,9 @@ fn can_validate_duplicate_update_and_query_methods() {
     .unwrap();
     assert_eq!(
         validate_wasm_binary(&wasm, &EmbeddersConfig::default()),
-        Err(WasmValidationError::UserInvalidExportSection(
-            "Duplicate function 'read' exported multiple times \
-             with different call types: update, query, or composite_query."
-                .to_string()
-        ))
+        Err(WasmValidationError::DuplicateExport {
+            name: "read".to_string()
+        })
     );
 }
 
@@ -353,11 +351,9 @@ fn can_validate_duplicate_update_and_composite_query_methods() {
     .unwrap();
     assert_eq!(
         validate_wasm_binary(&wasm, &EmbeddersConfig::default()),
-        Err(WasmValidationError::UserInvalidExportSection(
-            "Duplicate function 'read' exported multiple times \
-             with different call types: update, query, or composite_query."
-                .to_string()
-        ))
+        Err(WasmValidationError::DuplicateExport {
+            name: "read".to_string()
+        })
     );
 }
 
@@ -372,11 +368,9 @@ fn can_validate_duplicate_query_and_composite_query_methods() {
     .unwrap();
     assert_eq!(
         validate_wasm_binary(&wasm, &EmbeddersConfig::default()),
-        Err(WasmValidationError::UserInvalidExportSection(
-            "Duplicate function 'read' exported multiple times \
-             with different call types: update, query, or composite_query."
-                .to_string()
-        ))
+        Err(WasmValidationError::DuplicateExport {
+            name: "read".to_string()
+        })
     );
 }
 

--- a/rs/embedders/tests/validation.rs
+++ b/rs/embedders/tests/validation.rs
@@ -457,9 +457,10 @@ fn can_validate_too_large_sum_exported_function_name_lengths() {
     .unwrap();
     assert_eq!(
         validate_wasm_binary(&wasm, &EmbeddersConfig::default()),
-        Err(WasmValidationError::UserInvalidExportSection(
-            "The sum of `<name>` lengths in exported functions called `canister_update <name>`, `canister_query <name>`, or `canister_composite_query <name>` exceeds 20000.".to_string()
-        ))
+        Err(WasmValidationError::ExportedNamesTooLong {
+            total_length: 20001,
+            allowed: 20000
+        })
     );
 }
 

--- a/rs/interfaces/src/execution_environment/errors.rs
+++ b/rs/interfaces/src/execution_environment/errors.rs
@@ -2,7 +2,7 @@ use ic_base_types::{NumBytes, PrincipalIdBlobParseError};
 use ic_error_types::UserError;
 use ic_types::{methods::WasmMethod, CanisterId, CountBytes, Cycles, NumInstructions};
 use ic_wasm_types::{
-    AsErrorHelp, ErrorHelp, WasmEngineError, WasmInstrumentationError, WasmValidationError,
+    doc_ref, AsErrorHelp, ErrorHelp, WasmEngineError, WasmInstrumentationError, WasmValidationError,
 };
 use serde::{Deserialize, Serialize};
 
@@ -343,12 +343,6 @@ impl CountBytes for HypervisorError {
 
 impl AsErrorHelp for HypervisorError {
     fn error_help(&self) -> ErrorHelp {
-        fn doc_ref(section: &str) -> String {
-            format!(
-                "http://internetcomputer.org/docs/current/references/execution-errors#{}",
-                section
-            )
-        }
         match self {
             Self::FunctionNotFound(_, _)
             | Self::ToolchainContractViolation { .. }

--- a/rs/system_api/src/lib.rs
+++ b/rs/system_api/src/lib.rs
@@ -31,6 +31,7 @@ use ic_types::{
     NumInstructions, NumOsPages, PrincipalId, SubnetId, Time, MAX_STABLE_MEMORY_IN_BYTES,
 };
 use ic_utils::deterministic_operations::deterministic_copy_from_slice;
+use ic_wasm_types::doc_ref;
 use request_in_prep::{into_request, RequestInPrep};
 use sandbox_safe_system_state::{CanisterStatusView, SandboxSafeSystemState, SystemStateChanges};
 use serde::{Deserialize, Serialize};
@@ -1134,8 +1135,10 @@ impl SystemApiImpl {
                 "\"{}\" cannot be executed in {} mode",
                 method_name, self.api_type
             ),
-            suggestion: "".to_string(),
-            doc_link: "".to_string(),
+            suggestion: "Check the ICP documentation to make sure APIs are \
+            being called in the correct message types."
+                .to_string(),
+            doc_link: doc_ref("calling-a-system-api-from-the-wrong-mode"),
         }
     }
 
@@ -1873,8 +1876,11 @@ impl SystemApi for SystemApiImpl {
                         );
                         return Err(UserContractViolation {
                             error: string,
-                            suggestion: "".to_string(),
-                            doc_link: "".to_string(),
+                            suggestion:
+                                "Consider checking the response size and returning an error if \
+                                it is too long."
+                                    .to_string(),
+                            doc_link: doc_ref("msg_reply_data_append-payload-too-large"),
                         });
                     }
                     data.extend_from_slice(valid_subslice("msg.reply", src, size, heap)?);
@@ -1911,8 +1917,9 @@ impl SystemApi for SystemApiImpl {
                     );
                         return Err(UserContractViolation {
                             error: string,
-                            suggestion: "".to_string(),
-                            doc_link: "".to_string(),
+                            suggestion: "Try truncating the error messages that are too long."
+                                .to_string(),
+                            doc_link: doc_ref("msg_reject-payload-too-large"),
                         });
                     }
                     let msg_bytes = valid_subslice("ic0.msg_reject", src, size, heap)?;
@@ -3000,8 +3007,10 @@ impl SystemApi for SystemApiImpl {
                     no larger than {} bytes. Found {} bytes.",
                             CERTIFIED_DATA_MAX_LENGTH, size
                         ),
-                        suggestion: "".to_string(),
-                        doc_link: "".to_string(),
+                        suggestion: "Try certifying just the hash of your data instead of \
+                        the full contents."
+                            .to_string(),
+                        doc_link: doc_ref("certified_data_set-payload-too-large"),
                     });
                 }
 

--- a/rs/system_api/src/request_in_prep.rs
+++ b/rs/system_api/src/request_in_prep.rs
@@ -8,8 +8,13 @@ use ic_types::{
     time::CoarseTime,
     CanisterId, Cycles, NumBytes, PrincipalId,
 };
+use ic_wasm_types::doc_ref;
 use serde::{Deserialize, Serialize};
 use std::{convert::TryFrom, time::Duration};
+
+const PAYLOAD_SIZE_SUGGESTION: &str = "Check the canister for errors or redesign the target \
+                API to allow shorter messages";
+const PAYLOAD_SIZE_LINK: &str = "canister-made-a-call-with-too-large-payload";
 
 /// Represents an under construction `Request`.
 ///
@@ -68,6 +73,10 @@ impl RequestInPrep {
         multiplier_max_size_local_subnet: u64,
         max_sum_exported_function_name_lengths: usize,
     ) -> HypervisorResult<Self> {
+        const LARGE_NAME_SUGGESTION: &str =
+            "Size of method_name {} exceeds the allowed limit of {}.";
+        const LARGE_NAME_LINK: &str = "canister-made-a-call-with-too-large-method-name";
+
         let method_name = {
             // Check the conditions for method_name length separately to provide
             // a more specific error message instead of combining both based on
@@ -80,8 +89,8 @@ impl RequestInPrep {
                         "Size of method_name {} exceeds the allowed limit of {}.",
                         method_name_len, max_sum_exported_function_name_lengths
                     ),
-                    suggestion: "".to_string(),
-                    doc_link: "".to_string(),
+                    suggestion: LARGE_NAME_SUGGESTION.to_string(),
+                    doc_link: doc_ref(LARGE_NAME_LINK),
                 });
             }
 
@@ -93,8 +102,8 @@ impl RequestInPrep {
                         "Size of method_name {} exceeds the allowed limit of {}.",
                         method_name_len, max_size_local_subnet
                     ),
-                    suggestion: "".to_string(),
-                    doc_link: "".to_string(),
+                    suggestion: LARGE_NAME_SUGGESTION.to_string(),
+                    doc_link: doc_ref(LARGE_NAME_LINK),
                 });
             }
             let method_name = valid_subslice(
@@ -160,8 +169,8 @@ impl RequestInPrep {
                 current_size + size,
                 max_size_local_subnet
             ),
-                suggestion: "".to_string(),
-                doc_link: "".to_string(),
+                suggestion: PAYLOAD_SIZE_SUGGESTION.to_string(),
+                doc_link: doc_ref(PAYLOAD_SIZE_LINK),
             })
         } else {
             let data = valid_subslice("ic0.call_data_append", src, size, heap)?;
@@ -223,8 +232,8 @@ pub(crate) fn into_request(
                 method_name,
                 payload_size, max_size_remote_subnet
             ),
-                suggestion: "".to_string(),
-                doc_link: "".to_string(),
+                suggestion: PAYLOAD_SIZE_SUGGESTION.to_string(),
+                doc_link: doc_ref(PAYLOAD_SIZE_LINK),
             });
         }
     }

--- a/rs/types/wasm_types/src/errors.rs
+++ b/rs/types/wasm_types/src/errors.rs
@@ -1,5 +1,11 @@
 use serde::{Deserialize, Serialize};
 
+pub fn doc_ref(section: &str) -> String {
+    format!(
+        "http://internetcomputer.org/docs/current/references/execution-errors#{}",
+        section
+    )
+}
 pub enum ErrorHelp {
     UserError {
         suggestion: String,
@@ -185,13 +191,31 @@ impl AsErrorHelp for WasmValidationError {
             | WasmValidationError::InvalidGlobalSection(_)
             | WasmValidationError::UnsupportedWasmInstruction { .. }
             | WasmValidationError::TooManyCustomSections { .. } => ErrorHelp::ToolchainError,
-            WasmValidationError::UserInvalidExportSection(_)
-            | WasmValidationError::TooManyFunctions { .. }
-            | WasmValidationError::TooManyGlobals { .. }
-            | WasmValidationError::FunctionComplexityTooHigh { .. }
-            | WasmValidationError::FunctionTooLarge { .. }
-            | WasmValidationError::CodeSectionTooLarge { .. }
-            | WasmValidationError::ModuleTooLarge { .. } => ErrorHelp::UserError {
+            WasmValidationError::UserInvalidExportSection(_) => ErrorHelp::UserError {
+                suggestion: "".to_string(),
+                doc_link: "".to_string(),
+            },
+            WasmValidationError::TooManyFunctions { .. } => ErrorHelp::UserError {
+                suggestion: "".to_string(),
+                doc_link: "".to_string(),
+            },
+            WasmValidationError::TooManyGlobals { .. } => ErrorHelp::UserError {
+                suggestion: "".to_string(),
+                doc_link: "".to_string(),
+            },
+            WasmValidationError::FunctionComplexityTooHigh { .. } => ErrorHelp::UserError {
+                suggestion: "".to_string(),
+                doc_link: "".to_string(),
+            },
+            WasmValidationError::FunctionTooLarge { .. } => ErrorHelp::UserError {
+                suggestion: "".to_string(),
+                doc_link: "".to_string(),
+            },
+            WasmValidationError::CodeSectionTooLarge { .. } => ErrorHelp::UserError {
+                suggestion: "".to_string(),
+                doc_link: "".to_string(),
+            },
+            WasmValidationError::ModuleTooLarge { .. } => ErrorHelp::UserError {
                 suggestion: "".to_string(),
                 doc_link: "".to_string(),
             },

--- a/rs/types/wasm_types/src/errors.rs
+++ b/rs/types/wasm_types/src/errors.rs
@@ -66,6 +66,8 @@ pub enum WasmValidationError {
     UserInvalidExportSection(String),
     /// Same function name is exported multiple times (with different types).
     DuplicateExport { name: String },
+    /// There are too many exports defined in the module.
+    TooManyExports { defined: usize, allowed: usize },
     /// Module contains an invalid data section
     InvalidDataSection(String),
     /// Module contains an invalid custom section
@@ -125,6 +127,9 @@ impl std::fmt::Display for WasmValidationError {
                     "Duplicate function '{name}' exported multiple times \
                         with different call types: update, query, or composite_query."
                 )
+            }
+            Self::TooManyExports { defined, allowed } => {
+                write!(f, "The number of exported functions called `canister_update <name>`, `canister_query <name>`, or `canister_composite_query <name>` is {defined} which exceeds {allowed}.")
             }
             Self::InvalidDataSection(err) => {
                 write!(f, "Wasm module has an invalid data section. {err}")
@@ -207,6 +212,10 @@ impl AsErrorHelp for WasmValidationError {
                 call type, e.g. `{name}_update`, `{name}_query`, etc."
                 ),
                 doc_link: doc_ref("wasm-module-duplicate-exports"),
+            },
+            WasmValidationError::TooManyExports { .. } => ErrorHelp::UserError {
+                suggestion: "Try combining multiple endpoints into a single endpoint.".to_string(),
+                doc_link: doc_ref("wasm-module-exports-too-many-methods"),
             },
             WasmValidationError::UserInvalidExportSection(_) => ErrorHelp::UserError {
                 suggestion: "".to_string(),

--- a/rs/types/wasm_types/src/errors.rs
+++ b/rs/types/wasm_types/src/errors.rs
@@ -236,28 +236,38 @@ impl AsErrorHelp for WasmValidationError {
                 doc_link: doc_ref("wasm-module-sum-of-exported-name-lengths-too-large"),
             },
             WasmValidationError::TooManyFunctions { .. } => ErrorHelp::UserError {
-                suggestion: "".to_string(),
-                doc_link: "".to_string(),
+                suggestion: "Try spliting this canister into multiple canisters.".to_string(),
+                doc_link: "wasm-module-too-many-functions".to_string(),
             },
             WasmValidationError::TooManyGlobals { .. } => ErrorHelp::UserError {
-                suggestion: "".to_string(),
-                doc_link: "".to_string(),
+                suggestion: "Try collecting multiple globals into a single \
+                structured which can be stored on the heap."
+                    .to_string(),
+                doc_link: "wasm-module-too-many-globals".to_string(),
             },
             WasmValidationError::FunctionComplexityTooHigh { .. } => ErrorHelp::UserError {
-                suggestion: "".to_string(),
-                doc_link: "".to_string(),
+                suggestion: "Try breaking large functions up into multiple \
+                smaller functions."
+                    .to_string(),
+                doc_link: "wasm-module-function-complexity-too-high".to_string(),
             },
             WasmValidationError::FunctionTooLarge { .. } => ErrorHelp::UserError {
-                suggestion: "".to_string(),
-                doc_link: "".to_string(),
+                suggestion: "Try breaking large functions up into multiple \
+                smaller functions."
+                    .to_string(),
+                doc_link: "wasm-module-function-too-large".to_string(),
             },
             WasmValidationError::CodeSectionTooLarge { .. } => ErrorHelp::UserError {
-                suggestion: "".to_string(),
-                doc_link: "".to_string(),
+                suggestion: "Try shrinking the module code section using tools like \
+                `ic-wasm` or splitting the logic across multiple canisters."
+                    .to_string(),
+                doc_link: "wasm-module-code-section-too-large".to_string(),
             },
             WasmValidationError::ModuleTooLarge { .. } => ErrorHelp::UserError {
-                suggestion: "".to_string(),
-                doc_link: "".to_string(),
+                suggestion: "Try shrinking the module using tools like \
+                `ic-wasm` or splitting the logic across multiple canisters."
+                    .to_string(),
+                doc_link: "wasm-module-too-large".to_string(),
             },
         }
     }

--- a/rs/types/wasm_types/src/errors.rs
+++ b/rs/types/wasm_types/src/errors.rs
@@ -62,8 +62,6 @@ pub enum WasmValidationError {
     InvalidImportSection(String),
     /// Module contains an invalid export section
     InvalidExportSection(String),
-    /// Module contains an invalid export section caused by a user error.
-    UserInvalidExportSection(String),
     /// Same function name is exported multiple times (with different types).
     DuplicateExport { name: String },
     /// There are too many exports defined in the module.
@@ -119,9 +117,6 @@ impl std::fmt::Display for WasmValidationError {
             }
             Self::InvalidExportSection(err) => {
                 write!(f, "Wasm module has an invalid export section. {err}")
-            }
-            Self::UserInvalidExportSection(err) => {
-                write!(f, "Wasm module has an invalid export section. {}", err)
             }
             Self::DuplicateExport { name } => {
                 write!(
@@ -239,10 +234,6 @@ impl AsErrorHelp for WasmValidationError {
             WasmValidationError::ExportedNamesTooLong { .. } => ErrorHelp::UserError {
                 suggestion: "Try using shorter method names.".to_string(),
                 doc_link: doc_ref("wasm-module-sum-of-exported-name-lengths-too-large"),
-            },
-            WasmValidationError::UserInvalidExportSection(_) => ErrorHelp::UserError {
-                suggestion: "".to_string(),
-                doc_link: "".to_string(),
             },
             WasmValidationError::TooManyFunctions { .. } => ErrorHelp::UserError {
                 suggestion: "".to_string(),

--- a/rs/types/wasm_types/src/lib.rs
+++ b/rs/types/wasm_types/src/lib.rs
@@ -3,7 +3,7 @@
 mod errors;
 
 pub use errors::{
-    AsErrorHelp, ErrorHelp, WasmEngineError, WasmError, WasmInstrumentationError,
+    doc_ref, AsErrorHelp, ErrorHelp, WasmEngineError, WasmError, WasmInstrumentationError,
     WasmValidationError,
 };
 use ic_types::CountBytes;


### PR DESCRIPTION
Add links to the Execution Errors reference page for all user errors
that can occur during smart contract validation.