### PR TITLE
chore: attempt to fix PocketIC test flakiness

### DIFF
--- a/rs/pocket_ic_server/tests/test.rs
+++ b/rs/pocket_ic_server/tests/test.rs
@@ -78,9 +78,6 @@ fn start_server_helper(
             }
             _ => std::thread::sleep(Duration::from_millis(20)),
         }
-        if start.elapsed() > Duration::from_secs(5) {
-            panic!("Failed to start PocketIC service in time");
-        }
     };
     (url, out)
 }
@@ -235,9 +232,6 @@ fn test_port_file() {
             }
         }
         std::thread::sleep(Duration::from_millis(20));
-        if start.elapsed() > Duration::from_secs(5) {
-            panic!("Failed to start PocketIC service in time");
-        }
     }
 }
 

--- a/rs/pocket_ic_server/tests/test.rs
+++ b/rs/pocket_ic_server/tests/test.rs
@@ -28,7 +28,7 @@ use std::io::Write;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::path::PathBuf;
 use std::process::{Child, Command};
-use std::time::{Duration, Instant};
+use std::time::Duration;
 use tempfile::{NamedTempFile, TempDir};
 
 pub const LOCALHOST: &str = "127.0.0.1";
@@ -67,7 +67,6 @@ fn start_server_helper(
         cmd.stderr(std::process::Stdio::piped());
     }
     let out = cmd.spawn().expect("Failed to start PocketIC binary");
-    let start = Instant::now();
     let url = loop {
         match ready_file_path.try_exists() {
             Ok(true) => {
@@ -221,7 +220,6 @@ fn test_port_file() {
         )
         .spawn()
         .expect("Failed to start PocketIC binary");
-    let start = Instant::now();
     loop {
         if let Ok(port_string) = std::fs::read_to_string(port_file_path.clone()) {
             if !port_string.is_empty() {


### PR DESCRIPTION
This PR attempts to fix PocketIC test flakiness (bazel target `//rs/pocket-ic-server:test`) due to PocketIC server not starting within 5 seconds by removing that requirement which is not needed in a bazel test which has its own timeout.