### PR TITLE
feat(NODE-1463): Add cpu field to deployment.json

### DIFF
--- a/ic-os/setupos/data/deployment.json.template
+++ b/ic-os/setupos/data/deployment.json.template
@@ -10,6 +10,6 @@
   },
   "resources": {
     "memory": "490",
-    "cpu_mode": "kvm"
+    "cpu": "kvm"
   }
 }

--- a/ic-os/setupos/data/deployment.json.template
+++ b/ic-os/setupos/data/deployment.json.template
@@ -9,6 +9,7 @@
     "url": "NNS_URL"
   },
   "resources": {
-    "memory": "490"
+    "memory": "490",
+    "cpu_mode": "kvm"
   }
 }

--- a/rs/ic_os/setupos-inject-configuration/src/main.rs
+++ b/rs/ic_os/setupos-inject-configuration/src/main.rs
@@ -74,6 +74,7 @@ struct DeploymentConfig {
     #[arg(long)]
     memory_gb: Option<u32>,
 
+    /// Can be "kvm" or "qemu". If None, is treated as "kvm".
     #[arg(long)]
     cpu: Option<String>,
 }

--- a/rs/ic_os/setupos-inject-configuration/src/main.rs
+++ b/rs/ic_os/setupos-inject-configuration/src/main.rs
@@ -245,7 +245,7 @@ async fn update_deployment(path: &Path, cfg: &DeploymentConfig) -> Result<(), Er
     }
 
     if let Some(cpu_mode) = &cfg.cpu_mode {
-        deployment_json.resources.cpu = Some(cpu_mode.to_owned());
+        deployment_json.resources.cpu_mode = Some(cpu_mode.to_owned());
     }
 
     let mut f = File::create(path).context("failed to open deployment config file")?;

--- a/rs/ic_os/setupos-inject-configuration/src/main.rs
+++ b/rs/ic_os/setupos-inject-configuration/src/main.rs
@@ -75,7 +75,7 @@ struct DeploymentConfig {
     memory_gb: Option<u32>,
 
     #[arg(long)]
-    cpu_mode: Option<String>,
+    cpu: Option<String>,
 }
 
 #[tokio::main]
@@ -244,8 +244,8 @@ async fn update_deployment(path: &Path, cfg: &DeploymentConfig) -> Result<(), Er
         deployment_json.resources.memory = memory;
     }
 
-    if let Some(cpu_mode) = &cfg.cpu_mode {
-        deployment_json.resources.cpu_mode = Some(cpu_mode.to_owned());
+    if let Some(cpu) = &cfg.cpu {
+        deployment_json.resources.cpu = Some(cpu.to_owned());
     }
 
     let mut f = File::create(path).context("failed to open deployment config file")?;

--- a/rs/ic_os/utils/src/deployment.rs
+++ b/rs/ic_os/utils/src/deployment.rs
@@ -36,7 +36,7 @@ pub struct Resources {
     #[serde_as(as = "DisplayFromStr")]
     pub memory: u32,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub cpu_mode: Option<String>,
+    pub cpu: Option<String>,
 }
 
 pub fn read_deployment_file(deployment_json: &Path) -> Result<DeploymentJson> {
@@ -91,7 +91,7 @@ mod test {
       },
       "resources": {
         "memory": "490",
-        "cpu_mode": "kvm"
+        "cpu": "kvm"
       }
     }"#;
 
@@ -100,7 +100,7 @@ mod test {
             deployment: Deployment { name: "mainnet".to_string() },
             logging: Logging { hosts: "elasticsearch-node-0.mercury.dfinity.systems:443 elasticsearch-node-1.mercury.dfinity.systems:443 elasticsearch-node-2.mercury.dfinity.systems:443 elasticsearch-node-3.mercury.dfinity.systems:443".to_string() },
             nns: Nns { url: vec![Url::parse("https://dfinity.org").unwrap()] },
-            resources: Resources { memory: 490, cpu_mode: Some("kvm".to_string()) },
+            resources: Resources { memory: 490, cpu: Some("kvm".to_string()) },
         }
     });
 
@@ -117,13 +117,13 @@ mod test {
               },
               "resources": {
                 "memory": "490",
-                "cpu_mode": "kvm"
+                "cpu": "kvm"
               }
             }
         )
     });
 
-    const DEPLOYMENT_STR_NO_CPU_MODE: &str = r#"{
+    const DEPLOYMENT_STR_NO_CPU: &str = r#"{
   "deployment": {
     "name": "mainnet"
   },
@@ -138,12 +138,12 @@ mod test {
   }
 }"#;
 
-    static DEPLOYMENT_STRUCT_NO_CPU_MODE: Lazy<DeploymentJson> = Lazy::new(|| {
+    static DEPLOYMENT_STRUCT_NO_CPU: Lazy<DeploymentJson> = Lazy::new(|| {
         DeploymentJson {
             deployment: Deployment { name: "mainnet".to_string() },
             logging: Logging { hosts: "elasticsearch-node-0.mercury.dfinity.systems:443 elasticsearch-node-1.mercury.dfinity.systems:443 elasticsearch-node-2.mercury.dfinity.systems:443 elasticsearch-node-3.mercury.dfinity.systems:443".to_string() },
             nns: Nns { url: vec![Url::parse("https://dfinity.org").unwrap()] },
-            resources: Resources { memory: 490, cpu_mode: None },
+            resources: Resources { memory: 490, cpu: None },
         }
     });
 
@@ -159,7 +159,7 @@ mod test {
   },
   "resources": {
     "memory": "490",
-    "cpu_mode": "qemu"
+    "cpu": "qemu"
   }
 }"#;
 
@@ -168,7 +168,7 @@ mod test {
             deployment: Deployment { name: "mainnet".to_string() },
             logging: Logging { hosts: "elasticsearch-node-0.mercury.dfinity.systems:443 elasticsearch-node-1.mercury.dfinity.systems:443 elasticsearch-node-2.mercury.dfinity.systems:443 elasticsearch-node-3.mercury.dfinity.systems:443".to_string() },
             nns: Nns { url: vec![Url::parse("https://dfinity.org").unwrap()] },
-            resources: Resources { memory: 490, cpu_mode: Some("qemu".to_string()) },
+            resources: Resources { memory: 490, cpu: Some("qemu".to_string()) },
         }
     });
 
@@ -207,7 +207,7 @@ mod test {
           deployment: Deployment { name: "mainnet".to_string() },
           logging: Logging { hosts: "elasticsearch-node-0.mercury.dfinity.systems:443 elasticsearch-node-1.mercury.dfinity.systems:443 elasticsearch-node-2.mercury.dfinity.systems:443 elasticsearch-node-3.mercury.dfinity.systems:443".to_string() },
           nns: Nns { url: vec![Url::parse("http://[2001:920:401a:1710:5000:6aff:fee4:19cd]:8080").unwrap(), Url::parse("http://[2600:3006:1400:1500:5000:19ff:fe38:c418]:8080").unwrap(), Url::parse("http://[2600:2c01:21:0:5000:27ff:fe23:4839]:8080").unwrap()] },
-          resources: Resources { memory: 490, cpu_mode: None },
+          resources: Resources { memory: 490, cpu: None },
       }
     });
 
@@ -218,9 +218,9 @@ mod test {
         assert_eq!(*DEPLOYMENT_STRUCT, parsed_deployment);
 
         let parsed_deployment: DeploymentJson =
-            { serde_json::from_str(DEPLOYMENT_STR_NO_CPU_MODE).unwrap() };
+            { serde_json::from_str(DEPLOYMENT_STR_NO_CPU).unwrap() };
 
-        assert_eq!(*DEPLOYMENT_STRUCT_NO_CPU_MODE, parsed_deployment);
+        assert_eq!(*DEPLOYMENT_STRUCT_NO_CPU, parsed_deployment);
 
         let parsed_cpu_deployment: DeploymentJson =
             { serde_json::from_str(QEMU_CPU_DEPLOYMENT_STR).unwrap() };
@@ -253,9 +253,9 @@ mod test {
     #[test]
     fn write_deployment() {
         let written_deployment =
-            serde_json::to_string_pretty::<DeploymentJson>(&DEPLOYMENT_STRUCT_NO_CPU_MODE).unwrap();
+            serde_json::to_string_pretty::<DeploymentJson>(&DEPLOYMENT_STRUCT_NO_CPU).unwrap();
 
-        assert_eq!(DEPLOYMENT_STR_NO_CPU_MODE, written_deployment);
+        assert_eq!(DEPLOYMENT_STR_NO_CPU, written_deployment);
 
         let written_cpu_deployment =
             serde_json::to_string_pretty::<DeploymentJson>(&QEMU_CPU_DEPLOYMENT_STRUCT).unwrap();

--- a/rs/ic_os/utils/src/deployment.rs
+++ b/rs/ic_os/utils/src/deployment.rs
@@ -36,6 +36,7 @@ pub struct Resources {
     #[serde_as(as = "DisplayFromStr")]
     pub memory: u32,
     #[serde(skip_serializing_if = "Option::is_none")]
+    /// Can be "kvm" or "qemu". If None, is treated as "kvm".
     pub cpu: Option<String>,
 }
 

--- a/rs/ic_os/utils/src/deployment.rs
+++ b/rs/ic_os/utils/src/deployment.rs
@@ -98,16 +98,24 @@ mod test {
 
     static DEPLOYMENT_STRUCT: Lazy<DeploymentJson> = Lazy::new(|| {
         let hosts = [
-          "elasticsearch-node-0.mercury.dfinity.systems:443",
-          "elasticsearch-node-1.mercury.dfinity.systems:443",
-          "elasticsearch-node-2.mercury.dfinity.systems:443",
-          "elasticsearch-node-3.mercury.dfinity.systems:443"
-        ].join(" ");
+            "elasticsearch-node-0.mercury.dfinity.systems:443",
+            "elasticsearch-node-1.mercury.dfinity.systems:443",
+            "elasticsearch-node-2.mercury.dfinity.systems:443",
+            "elasticsearch-node-3.mercury.dfinity.systems:443",
+        ]
+        .join(" ");
         DeploymentJson {
-            deployment: Deployment { name: "mainnet".to_string() },
+            deployment: Deployment {
+                name: "mainnet".to_string(),
+            },
             logging: Logging { hosts },
-            nns: Nns { url: vec![Url::parse("https://dfinity.org").unwrap()] },
-            resources: Resources { memory: 490, cpu: Some("kvm".to_string()) },
+            nns: Nns {
+                url: vec![Url::parse("https://dfinity.org").unwrap()],
+            },
+            resources: Resources {
+                memory: 490,
+                cpu: Some("kvm".to_string()),
+            },
         }
     });
 
@@ -146,17 +154,25 @@ mod test {
 }"#;
 
     static DEPLOYMENT_STRUCT_NO_CPU: Lazy<DeploymentJson> = Lazy::new(|| {
-      let hosts = [
-        "elasticsearch-node-0.mercury.dfinity.systems:443",
-        "elasticsearch-node-1.mercury.dfinity.systems:443",
-        "elasticsearch-node-2.mercury.dfinity.systems:443",
-        "elasticsearch-node-3.mercury.dfinity.systems:443"
-      ].join(" ");
+        let hosts = [
+            "elasticsearch-node-0.mercury.dfinity.systems:443",
+            "elasticsearch-node-1.mercury.dfinity.systems:443",
+            "elasticsearch-node-2.mercury.dfinity.systems:443",
+            "elasticsearch-node-3.mercury.dfinity.systems:443",
+        ]
+        .join(" ");
         DeploymentJson {
-            deployment: Deployment { name: "mainnet".to_string() },
+            deployment: Deployment {
+                name: "mainnet".to_string(),
+            },
             logging: Logging { hosts },
-            nns: Nns { url: vec![Url::parse("https://dfinity.org").unwrap()] },
-            resources: Resources { memory: 490, cpu: None },
+            nns: Nns {
+                url: vec![Url::parse("https://dfinity.org").unwrap()],
+            },
+            resources: Resources {
+                memory: 490,
+                cpu: None,
+            },
         }
     });
 
@@ -178,16 +194,24 @@ mod test {
 
     static QEMU_CPU_DEPLOYMENT_STRUCT: Lazy<DeploymentJson> = Lazy::new(|| {
         let hosts = [
-          "elasticsearch-node-0.mercury.dfinity.systems:443",
-          "elasticsearch-node-1.mercury.dfinity.systems:443",
-          "elasticsearch-node-2.mercury.dfinity.systems:443",
-          "elasticsearch-node-3.mercury.dfinity.systems:443"
-        ].join(" ");
+            "elasticsearch-node-0.mercury.dfinity.systems:443",
+            "elasticsearch-node-1.mercury.dfinity.systems:443",
+            "elasticsearch-node-2.mercury.dfinity.systems:443",
+            "elasticsearch-node-3.mercury.dfinity.systems:443",
+        ]
+        .join(" ");
         DeploymentJson {
-            deployment: Deployment { name: "mainnet".to_string() },
+            deployment: Deployment {
+                name: "mainnet".to_string(),
+            },
             logging: Logging { hosts },
-            nns: Nns { url: vec![Url::parse("https://dfinity.org").unwrap()] },
-            resources: Resources { memory: 490, cpu: Some("qemu".to_string()) },
+            nns: Nns {
+                url: vec![Url::parse("https://dfinity.org").unwrap()],
+            },
+            resources: Resources {
+                memory: 490,
+                cpu: Some("qemu".to_string()),
+            },
         }
     });
 
@@ -223,17 +247,29 @@ mod test {
 
     static MULTI_URL_STRUCT: Lazy<DeploymentJson> = Lazy::new(|| {
         let hosts = [
-          "elasticsearch-node-0.mercury.dfinity.systems:443",
-          "elasticsearch-node-1.mercury.dfinity.systems:443",
-          "elasticsearch-node-2.mercury.dfinity.systems:443",
-          "elasticsearch-node-3.mercury.dfinity.systems:443"
-        ].join(" ");
+            "elasticsearch-node-0.mercury.dfinity.systems:443",
+            "elasticsearch-node-1.mercury.dfinity.systems:443",
+            "elasticsearch-node-2.mercury.dfinity.systems:443",
+            "elasticsearch-node-3.mercury.dfinity.systems:443",
+        ]
+        .join(" ");
         DeploymentJson {
-          deployment: Deployment { name: "mainnet".to_string() },
-          logging: Logging { hosts },
-          nns: Nns { url: vec![Url::parse("http://[2001:920:401a:1710:5000:6aff:fee4:19cd]:8080").unwrap(), Url::parse("http://[2600:3006:1400:1500:5000:19ff:fe38:c418]:8080").unwrap(), Url::parse("http://[2600:2c01:21:0:5000:27ff:fe23:4839]:8080").unwrap()] },
-          resources: Resources { memory: 490, cpu: None },
-      }
+            deployment: Deployment {
+                name: "mainnet".to_string(),
+            },
+            logging: Logging { hosts },
+            nns: Nns {
+                url: vec![
+                    Url::parse("http://[2001:920:401a:1710:5000:6aff:fee4:19cd]:8080").unwrap(),
+                    Url::parse("http://[2600:3006:1400:1500:5000:19ff:fe38:c418]:8080").unwrap(),
+                    Url::parse("http://[2600:2c01:21:0:5000:27ff:fe23:4839]:8080").unwrap(),
+                ],
+            },
+            resources: Resources {
+                memory: 490,
+                cpu: None,
+            },
+        }
     });
 
     #[test]

--- a/rs/ic_os/utils/src/deployment.rs
+++ b/rs/ic_os/utils/src/deployment.rs
@@ -36,7 +36,7 @@ pub struct Resources {
     #[serde_as(as = "DisplayFromStr")]
     pub memory: u32,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub cpu: Option<String>,
+    pub cpu_mode: Option<String>,
 }
 
 pub fn read_deployment_file(deployment_json: &Path) -> Result<DeploymentJson> {
@@ -80,6 +80,50 @@ mod test {
     use serde_json::{json, Value};
 
     const DEPLOYMENT_STR: &str = r#"{
+      "deployment": {
+        "name": "mainnet"
+      },
+      "logging": {
+        "hosts": "elasticsearch-node-0.mercury.dfinity.systems:443 elasticsearch-node-1.mercury.dfinity.systems:443 elasticsearch-node-2.mercury.dfinity.systems:443 elasticsearch-node-3.mercury.dfinity.systems:443"
+      },
+      "nns": {
+        "url": "https://dfinity.org/"
+      },
+      "resources": {
+        "memory": "490",
+        "cpu_mode": "kvm"
+      }
+    }"#;
+    
+    static DEPLOYMENT_STRUCT: Lazy<DeploymentJson> = Lazy::new(|| {
+        DeploymentJson {
+            deployment: Deployment { name: "mainnet".to_string() },
+            logging: Logging { hosts: "elasticsearch-node-0.mercury.dfinity.systems:443 elasticsearch-node-1.mercury.dfinity.systems:443 elasticsearch-node-2.mercury.dfinity.systems:443 elasticsearch-node-3.mercury.dfinity.systems:443".to_string() },
+            nns: Nns { url: vec![Url::parse("https://dfinity.org").unwrap()] },
+            resources: Resources { memory: 490, cpu_mode: Some("kvm".to_string()) },
+        }
+    });
+
+    static DEPLOYMENT_VALUE: Lazy<Value> = Lazy::new(|| {
+      json!({
+            "deployment": {
+              "name": "mainnet"
+            },
+            "logging": {
+              "hosts": "elasticsearch-node-0.mercury.dfinity.systems:443 elasticsearch-node-1.mercury.dfinity.systems:443 elasticsearch-node-2.mercury.dfinity.systems:443 elasticsearch-node-3.mercury.dfinity.systems:443"
+            },
+            "nns": {
+              "url": "https://dfinity.org/"
+            },
+            "resources": {
+              "memory": "490",
+              "cpu_mode": "kvm"
+            }
+          }
+      )
+    });
+
+    const DEPLOYMENT_STR_NO_CPU_MODE: &str = r#"{
   "deployment": {
     "name": "mainnet"
   },
@@ -94,34 +138,16 @@ mod test {
   }
 }"#;
 
-    static DEPLOYMENT_VALUE: Lazy<Value> = Lazy::new(|| {
-        json!({
-              "deployment": {
-                "name": "mainnet"
-              },
-              "logging": {
-                "hosts": "elasticsearch-node-0.mercury.dfinity.systems:443 elasticsearch-node-1.mercury.dfinity.systems:443 elasticsearch-node-2.mercury.dfinity.systems:443 elasticsearch-node-3.mercury.dfinity.systems:443"
-              },
-              "nns": {
-                "url": "https://dfinity.org/"
-              },
-              "resources": {
-                "memory": "490"
-              }
-            }
-        )
-    });
-
-    static DEPLOYMENT_STRUCT: Lazy<DeploymentJson> = Lazy::new(|| {
+    static DEPLOYMENT_STRUCT_NO_CPU_MODE: Lazy<DeploymentJson> = Lazy::new(|| {
         DeploymentJson {
             deployment: Deployment { name: "mainnet".to_string() },
             logging: Logging { hosts: "elasticsearch-node-0.mercury.dfinity.systems:443 elasticsearch-node-1.mercury.dfinity.systems:443 elasticsearch-node-2.mercury.dfinity.systems:443 elasticsearch-node-3.mercury.dfinity.systems:443".to_string() },
             nns: Nns { url: vec![Url::parse("https://dfinity.org").unwrap()] },
-            resources: Resources { memory: 490, cpu: None },
+            resources: Resources { memory: 490, cpu_mode: None },
         }
     });
 
-    const CPU_DEPLOYMENT_STR: &str = r#"{
+    const QEMU_CPU_DEPLOYMENT_STR: &str = r#"{
   "deployment": {
     "name": "mainnet"
   },
@@ -133,16 +159,16 @@ mod test {
   },
   "resources": {
     "memory": "490",
-    "cpu": "qemu"
+    "cpu_mode": "qemu"
   }
 }"#;
 
-    static CPU_DEPLOYMENT_STRUCT: Lazy<DeploymentJson> = Lazy::new(|| {
+    static QEMU_CPU_DEPLOYMENT_STRUCT: Lazy<DeploymentJson> = Lazy::new(|| {
         DeploymentJson {
             deployment: Deployment { name: "mainnet".to_string() },
             logging: Logging { hosts: "elasticsearch-node-0.mercury.dfinity.systems:443 elasticsearch-node-1.mercury.dfinity.systems:443 elasticsearch-node-2.mercury.dfinity.systems:443 elasticsearch-node-3.mercury.dfinity.systems:443".to_string() },
             nns: Nns { url: vec![Url::parse("https://dfinity.org").unwrap()] },
-            resources: Resources { memory: 490, cpu: Some("qemu".to_string()) },
+            resources: Resources { memory: 490, cpu_mode: Some("qemu".to_string()) },
         }
     });
 
@@ -176,64 +202,68 @@ mod test {
   }
 }"#;
 
-    static MULTI_URL_STRUCT: Lazy<DeploymentJson> = Lazy::new(|| {
-        DeploymentJson {
-            deployment: Deployment { name: "mainnet".to_string() },
-            logging: Logging { hosts: "elasticsearch-node-0.mercury.dfinity.systems:443 elasticsearch-node-1.mercury.dfinity.systems:443 elasticsearch-node-2.mercury.dfinity.systems:443 elasticsearch-node-3.mercury.dfinity.systems:443".to_string() },
-            nns: Nns { url: vec![Url::parse("http://[2001:920:401a:1710:5000:6aff:fee4:19cd]:8080").unwrap(), Url::parse("http://[2600:3006:1400:1500:5000:19ff:fe38:c418]:8080").unwrap(), Url::parse("http://[2600:2c01:21:0:5000:27ff:fe23:4839]:8080").unwrap()] },
-            resources: Resources { memory: 490, cpu: None },
-        }
-    });
+  static MULTI_URL_STRUCT: Lazy<DeploymentJson> = Lazy::new(|| {
+      DeploymentJson {
+          deployment: Deployment { name: "mainnet".to_string() },
+          logging: Logging { hosts: "elasticsearch-node-0.mercury.dfinity.systems:443 elasticsearch-node-1.mercury.dfinity.systems:443 elasticsearch-node-2.mercury.dfinity.systems:443 elasticsearch-node-3.mercury.dfinity.systems:443".to_string() },
+          nns: Nns { url: vec![Url::parse("http://[2001:920:401a:1710:5000:6aff:fee4:19cd]:8080").unwrap(), Url::parse("http://[2600:3006:1400:1500:5000:19ff:fe38:c418]:8080").unwrap(), Url::parse("http://[2600:2c01:21:0:5000:27ff:fe23:4839]:8080").unwrap()] },
+          resources: Resources { memory: 490, cpu_mode: None },
+      }
+  });
 
-    #[test]
-    fn read_deployment() {
-        let parsed_deployment: DeploymentJson = { serde_json::from_str(DEPLOYMENT_STR).unwrap() };
+  #[test]
+  fn read_deployment() {
+      let parsed_deployment: DeploymentJson = { serde_json::from_str(DEPLOYMENT_STR).unwrap() };
 
-        assert_eq!(*DEPLOYMENT_STRUCT, parsed_deployment);
+      assert_eq!(*DEPLOYMENT_STRUCT, parsed_deployment);
 
-        let parsed_cpu_deployment: DeploymentJson =
-            { serde_json::from_str(CPU_DEPLOYMENT_STR).unwrap() };
+      let parsed_deployment: DeploymentJson = { serde_json::from_str(DEPLOYMENT_STR_NO_CPU_MODE).unwrap() };
 
-        assert_eq!(*CPU_DEPLOYMENT_STRUCT, parsed_cpu_deployment);
+      assert_eq!(*DEPLOYMENT_STRUCT_NO_CPU_MODE, parsed_deployment);
 
-        let parsed_multi_url_deployment: DeploymentJson =
-            { serde_json::from_str(MULTI_URL_STR).unwrap() };
+      let parsed_cpu_deployment: DeploymentJson =
+          { serde_json::from_str(QEMU_CPU_DEPLOYMENT_STR).unwrap() };
 
-        assert_eq!(*MULTI_URL_STRUCT, parsed_multi_url_deployment);
+      assert_eq!(*QEMU_CPU_DEPLOYMENT_STRUCT, parsed_cpu_deployment);
 
-        // NOTE: Canonically, url thinks these addresses should have a trailing
-        // slash, so the above case parses with a slash for the sake of the
-        // writeback test below. In practice, we have used addresses without
-        // this slash, so here we verify that this parses to the same value.
-        let parsed_multi_url_sans_slash_deployment: DeploymentJson =
-            { serde_json::from_str(MULTI_URL_SANS_SLASH_STR).unwrap() };
+      let parsed_multi_url_deployment: DeploymentJson =
+          { serde_json::from_str(MULTI_URL_STR).unwrap() };
 
-        assert_eq!(*MULTI_URL_STRUCT, parsed_multi_url_sans_slash_deployment);
+      assert_eq!(*MULTI_URL_STRUCT, parsed_multi_url_deployment);
 
-        // Exercise DeserializeOwned using serde_json::from_value.
-        // DeserializeOwned is used by serde_json::from_reader, which is the
-        // main entrypoint of this code, in practice.
-        let parsed_deployment: DeploymentJson =
-            { serde_json::from_value(DEPLOYMENT_VALUE.clone()).unwrap() };
+      // NOTE: Canonically, url thinks these addresses should have a trailing
+      // slash, so the above case parses with a slash for the sake of the
+      // writeback test below. In practice, we have used addresses without
+      // this slash, so here we verify that this parses to the same value.
+      let parsed_multi_url_sans_slash_deployment: DeploymentJson =
+          { serde_json::from_str(MULTI_URL_SANS_SLASH_STR).unwrap() };
 
-        assert_eq!(*DEPLOYMENT_STRUCT, parsed_deployment);
-    }
+      assert_eq!(*MULTI_URL_STRUCT, parsed_multi_url_sans_slash_deployment);
 
-    #[test]
-    fn write_deployment() {
-        let written_deployment =
-            serde_json::to_string_pretty::<DeploymentJson>(&DEPLOYMENT_STRUCT).unwrap();
+      // Exercise DeserializeOwned using serde_json::from_value.
+      // DeserializeOwned is used by serde_json::from_reader, which is the
+      // main entrypoint of this code, in practice.
+      let parsed_deployment: DeploymentJson =
+          { serde_json::from_value(DEPLOYMENT_VALUE.clone()).unwrap() };
 
-        assert_eq!(DEPLOYMENT_STR, written_deployment);
+      assert_eq!(*DEPLOYMENT_STRUCT, parsed_deployment);
+  }
 
-        let written_cpu_deployment =
-            serde_json::to_string_pretty::<DeploymentJson>(&CPU_DEPLOYMENT_STRUCT).unwrap();
+  #[test]
+  fn write_deployment() {
+      let written_deployment =
+          serde_json::to_string_pretty::<DeploymentJson>(&DEPLOYMENT_STRUCT_NO_CPU_MODE).unwrap();
 
-        assert_eq!(CPU_DEPLOYMENT_STR, written_cpu_deployment);
+      assert_eq!(DEPLOYMENT_STR_NO_CPU_MODE, written_deployment);
 
-        let written_multi_url_deployment =
-            serde_json::to_string_pretty::<DeploymentJson>(&MULTI_URL_STRUCT).unwrap();
+      let written_cpu_deployment =
+          serde_json::to_string_pretty::<DeploymentJson>(&QEMU_CPU_DEPLOYMENT_STRUCT).unwrap();
 
-        assert_eq!(MULTI_URL_STR, written_multi_url_deployment);
-    }
+      assert_eq!(QEMU_CPU_DEPLOYMENT_STR, written_cpu_deployment);
+
+      let written_multi_url_deployment =
+          serde_json::to_string_pretty::<DeploymentJson>(&MULTI_URL_STRUCT).unwrap();
+
+      assert_eq!(MULTI_URL_STR, written_multi_url_deployment);
+  }
 }

--- a/rs/ic_os/utils/src/deployment.rs
+++ b/rs/ic_os/utils/src/deployment.rs
@@ -97,9 +97,15 @@ mod test {
     }"#;
 
     static DEPLOYMENT_STRUCT: Lazy<DeploymentJson> = Lazy::new(|| {
+        let hosts = [
+          "elasticsearch-node-0.mercury.dfinity.systems:443",
+          "elasticsearch-node-1.mercury.dfinity.systems:443",
+          "elasticsearch-node-2.mercury.dfinity.systems:443",
+          "elasticsearch-node-3.mercury.dfinity.systems:443"
+        ].join(" ");
         DeploymentJson {
             deployment: Deployment { name: "mainnet".to_string() },
-            logging: Logging { hosts: "elasticsearch-node-0.mercury.dfinity.systems:443 elasticsearch-node-1.mercury.dfinity.systems:443 elasticsearch-node-2.mercury.dfinity.systems:443 elasticsearch-node-3.mercury.dfinity.systems:443".to_string() },
+            logging: Logging { hosts },
             nns: Nns { url: vec![Url::parse("https://dfinity.org").unwrap()] },
             resources: Resources { memory: 490, cpu: Some("kvm".to_string()) },
         }
@@ -140,9 +146,15 @@ mod test {
 }"#;
 
     static DEPLOYMENT_STRUCT_NO_CPU: Lazy<DeploymentJson> = Lazy::new(|| {
+      let hosts = [
+        "elasticsearch-node-0.mercury.dfinity.systems:443",
+        "elasticsearch-node-1.mercury.dfinity.systems:443",
+        "elasticsearch-node-2.mercury.dfinity.systems:443",
+        "elasticsearch-node-3.mercury.dfinity.systems:443"
+      ].join(" ");
         DeploymentJson {
             deployment: Deployment { name: "mainnet".to_string() },
-            logging: Logging { hosts: "elasticsearch-node-0.mercury.dfinity.systems:443 elasticsearch-node-1.mercury.dfinity.systems:443 elasticsearch-node-2.mercury.dfinity.systems:443 elasticsearch-node-3.mercury.dfinity.systems:443".to_string() },
+            logging: Logging { hosts },
             nns: Nns { url: vec![Url::parse("https://dfinity.org").unwrap()] },
             resources: Resources { memory: 490, cpu: None },
         }
@@ -165,9 +177,15 @@ mod test {
 }"#;
 
     static QEMU_CPU_DEPLOYMENT_STRUCT: Lazy<DeploymentJson> = Lazy::new(|| {
+        let hosts = [
+          "elasticsearch-node-0.mercury.dfinity.systems:443",
+          "elasticsearch-node-1.mercury.dfinity.systems:443",
+          "elasticsearch-node-2.mercury.dfinity.systems:443",
+          "elasticsearch-node-3.mercury.dfinity.systems:443"
+        ].join(" ");
         DeploymentJson {
             deployment: Deployment { name: "mainnet".to_string() },
-            logging: Logging { hosts: "elasticsearch-node-0.mercury.dfinity.systems:443 elasticsearch-node-1.mercury.dfinity.systems:443 elasticsearch-node-2.mercury.dfinity.systems:443 elasticsearch-node-3.mercury.dfinity.systems:443".to_string() },
+            logging: Logging { hosts },
             nns: Nns { url: vec![Url::parse("https://dfinity.org").unwrap()] },
             resources: Resources { memory: 490, cpu: Some("qemu".to_string()) },
         }
@@ -204,9 +222,15 @@ mod test {
 }"#;
 
     static MULTI_URL_STRUCT: Lazy<DeploymentJson> = Lazy::new(|| {
+        let hosts = [
+          "elasticsearch-node-0.mercury.dfinity.systems:443",
+          "elasticsearch-node-1.mercury.dfinity.systems:443",
+          "elasticsearch-node-2.mercury.dfinity.systems:443",
+          "elasticsearch-node-3.mercury.dfinity.systems:443"
+        ].join(" ");
         DeploymentJson {
           deployment: Deployment { name: "mainnet".to_string() },
-          logging: Logging { hosts: "elasticsearch-node-0.mercury.dfinity.systems:443 elasticsearch-node-1.mercury.dfinity.systems:443 elasticsearch-node-2.mercury.dfinity.systems:443 elasticsearch-node-3.mercury.dfinity.systems:443".to_string() },
+          logging: Logging { hosts },
           nns: Nns { url: vec![Url::parse("http://[2001:920:401a:1710:5000:6aff:fee4:19cd]:8080").unwrap(), Url::parse("http://[2600:3006:1400:1500:5000:19ff:fe38:c418]:8080").unwrap(), Url::parse("http://[2600:2c01:21:0:5000:27ff:fe23:4839]:8080").unwrap()] },
           resources: Resources { memory: 490, cpu: None },
       }

--- a/rs/ic_os/utils/src/deployment.rs
+++ b/rs/ic_os/utils/src/deployment.rs
@@ -94,7 +94,7 @@ mod test {
         "cpu_mode": "kvm"
       }
     }"#;
-    
+
     static DEPLOYMENT_STRUCT: Lazy<DeploymentJson> = Lazy::new(|| {
         DeploymentJson {
             deployment: Deployment { name: "mainnet".to_string() },
@@ -105,22 +105,22 @@ mod test {
     });
 
     static DEPLOYMENT_VALUE: Lazy<Value> = Lazy::new(|| {
-      json!({
-            "deployment": {
-              "name": "mainnet"
-            },
-            "logging": {
-              "hosts": "elasticsearch-node-0.mercury.dfinity.systems:443 elasticsearch-node-1.mercury.dfinity.systems:443 elasticsearch-node-2.mercury.dfinity.systems:443 elasticsearch-node-3.mercury.dfinity.systems:443"
-            },
-            "nns": {
-              "url": "https://dfinity.org/"
-            },
-            "resources": {
-              "memory": "490",
-              "cpu_mode": "kvm"
+        json!({
+              "deployment": {
+                "name": "mainnet"
+              },
+              "logging": {
+                "hosts": "elasticsearch-node-0.mercury.dfinity.systems:443 elasticsearch-node-1.mercury.dfinity.systems:443 elasticsearch-node-2.mercury.dfinity.systems:443 elasticsearch-node-3.mercury.dfinity.systems:443"
+              },
+              "nns": {
+                "url": "https://dfinity.org/"
+              },
+              "resources": {
+                "memory": "490",
+                "cpu_mode": "kvm"
+              }
             }
-          }
-      )
+        )
     });
 
     const DEPLOYMENT_STR_NO_CPU_MODE: &str = r#"{
@@ -202,68 +202,69 @@ mod test {
   }
 }"#;
 
-  static MULTI_URL_STRUCT: Lazy<DeploymentJson> = Lazy::new(|| {
-      DeploymentJson {
+    static MULTI_URL_STRUCT: Lazy<DeploymentJson> = Lazy::new(|| {
+        DeploymentJson {
           deployment: Deployment { name: "mainnet".to_string() },
           logging: Logging { hosts: "elasticsearch-node-0.mercury.dfinity.systems:443 elasticsearch-node-1.mercury.dfinity.systems:443 elasticsearch-node-2.mercury.dfinity.systems:443 elasticsearch-node-3.mercury.dfinity.systems:443".to_string() },
           nns: Nns { url: vec![Url::parse("http://[2001:920:401a:1710:5000:6aff:fee4:19cd]:8080").unwrap(), Url::parse("http://[2600:3006:1400:1500:5000:19ff:fe38:c418]:8080").unwrap(), Url::parse("http://[2600:2c01:21:0:5000:27ff:fe23:4839]:8080").unwrap()] },
           resources: Resources { memory: 490, cpu_mode: None },
       }
-  });
+    });
 
-  #[test]
-  fn read_deployment() {
-      let parsed_deployment: DeploymentJson = { serde_json::from_str(DEPLOYMENT_STR).unwrap() };
+    #[test]
+    fn read_deployment() {
+        let parsed_deployment: DeploymentJson = { serde_json::from_str(DEPLOYMENT_STR).unwrap() };
 
-      assert_eq!(*DEPLOYMENT_STRUCT, parsed_deployment);
+        assert_eq!(*DEPLOYMENT_STRUCT, parsed_deployment);
 
-      let parsed_deployment: DeploymentJson = { serde_json::from_str(DEPLOYMENT_STR_NO_CPU_MODE).unwrap() };
+        let parsed_deployment: DeploymentJson =
+            { serde_json::from_str(DEPLOYMENT_STR_NO_CPU_MODE).unwrap() };
 
-      assert_eq!(*DEPLOYMENT_STRUCT_NO_CPU_MODE, parsed_deployment);
+        assert_eq!(*DEPLOYMENT_STRUCT_NO_CPU_MODE, parsed_deployment);
 
-      let parsed_cpu_deployment: DeploymentJson =
-          { serde_json::from_str(QEMU_CPU_DEPLOYMENT_STR).unwrap() };
+        let parsed_cpu_deployment: DeploymentJson =
+            { serde_json::from_str(QEMU_CPU_DEPLOYMENT_STR).unwrap() };
 
-      assert_eq!(*QEMU_CPU_DEPLOYMENT_STRUCT, parsed_cpu_deployment);
+        assert_eq!(*QEMU_CPU_DEPLOYMENT_STRUCT, parsed_cpu_deployment);
 
-      let parsed_multi_url_deployment: DeploymentJson =
-          { serde_json::from_str(MULTI_URL_STR).unwrap() };
+        let parsed_multi_url_deployment: DeploymentJson =
+            { serde_json::from_str(MULTI_URL_STR).unwrap() };
 
-      assert_eq!(*MULTI_URL_STRUCT, parsed_multi_url_deployment);
+        assert_eq!(*MULTI_URL_STRUCT, parsed_multi_url_deployment);
 
-      // NOTE: Canonically, url thinks these addresses should have a trailing
-      // slash, so the above case parses with a slash for the sake of the
-      // writeback test below. In practice, we have used addresses without
-      // this slash, so here we verify that this parses to the same value.
-      let parsed_multi_url_sans_slash_deployment: DeploymentJson =
-          { serde_json::from_str(MULTI_URL_SANS_SLASH_STR).unwrap() };
+        // NOTE: Canonically, url thinks these addresses should have a trailing
+        // slash, so the above case parses with a slash for the sake of the
+        // writeback test below. In practice, we have used addresses without
+        // this slash, so here we verify that this parses to the same value.
+        let parsed_multi_url_sans_slash_deployment: DeploymentJson =
+            { serde_json::from_str(MULTI_URL_SANS_SLASH_STR).unwrap() };
 
-      assert_eq!(*MULTI_URL_STRUCT, parsed_multi_url_sans_slash_deployment);
+        assert_eq!(*MULTI_URL_STRUCT, parsed_multi_url_sans_slash_deployment);
 
-      // Exercise DeserializeOwned using serde_json::from_value.
-      // DeserializeOwned is used by serde_json::from_reader, which is the
-      // main entrypoint of this code, in practice.
-      let parsed_deployment: DeploymentJson =
-          { serde_json::from_value(DEPLOYMENT_VALUE.clone()).unwrap() };
+        // Exercise DeserializeOwned using serde_json::from_value.
+        // DeserializeOwned is used by serde_json::from_reader, which is the
+        // main entrypoint of this code, in practice.
+        let parsed_deployment: DeploymentJson =
+            { serde_json::from_value(DEPLOYMENT_VALUE.clone()).unwrap() };
 
-      assert_eq!(*DEPLOYMENT_STRUCT, parsed_deployment);
-  }
+        assert_eq!(*DEPLOYMENT_STRUCT, parsed_deployment);
+    }
 
-  #[test]
-  fn write_deployment() {
-      let written_deployment =
-          serde_json::to_string_pretty::<DeploymentJson>(&DEPLOYMENT_STRUCT_NO_CPU_MODE).unwrap();
+    #[test]
+    fn write_deployment() {
+        let written_deployment =
+            serde_json::to_string_pretty::<DeploymentJson>(&DEPLOYMENT_STRUCT_NO_CPU_MODE).unwrap();
 
-      assert_eq!(DEPLOYMENT_STR_NO_CPU_MODE, written_deployment);
+        assert_eq!(DEPLOYMENT_STR_NO_CPU_MODE, written_deployment);
 
-      let written_cpu_deployment =
-          serde_json::to_string_pretty::<DeploymentJson>(&QEMU_CPU_DEPLOYMENT_STRUCT).unwrap();
+        let written_cpu_deployment =
+            serde_json::to_string_pretty::<DeploymentJson>(&QEMU_CPU_DEPLOYMENT_STRUCT).unwrap();
 
-      assert_eq!(QEMU_CPU_DEPLOYMENT_STR, written_cpu_deployment);
+        assert_eq!(QEMU_CPU_DEPLOYMENT_STR, written_cpu_deployment);
 
-      let written_multi_url_deployment =
-          serde_json::to_string_pretty::<DeploymentJson>(&MULTI_URL_STRUCT).unwrap();
+        let written_multi_url_deployment =
+            serde_json::to_string_pretty::<DeploymentJson>(&MULTI_URL_STRUCT).unwrap();
 
-      assert_eq!(MULTI_URL_STR, written_multi_url_deployment);
-  }
+        assert_eq!(MULTI_URL_STR, written_multi_url_deployment);
+    }
 }

--- a/rs/tests/driver/src/driver/bootstrap.rs
+++ b/rs/tests/driver/src/driver/bootstrap.rs
@@ -584,7 +584,7 @@ fn configure_setupos_image(
 
     let mac = nested_vm.get_vm()?.mac6;
     let memory = "16";
-    let cpu_mode = "qemu";
+    let cpu = "qemu";
 
     let ssh_authorized_pub_keys_dir = env.get_path(SSH_AUTHORIZED_PUB_KEYS_DIR);
     let admin_keys: Vec<_> = std::fs::read_to_string(ssh_authorized_pub_keys_dir.join("admin"))
@@ -644,8 +644,8 @@ fn configure_setupos_image(
         .arg(&gateway)
         .arg("--memory-gb")
         .arg(memory)
-        .arg("--cpu-mode")
-        .arg(cpu_mode)
+        .arg("--cpu")
+        .arg(cpu)
         .arg("--nns-url")
         .arg(nns_url.to_string())
         .arg("--nns-public-key")


### PR DESCRIPTION
NODE-1463

cpu deployment field has been implicitly used by setupos-inject-config and now it is now explicitly defined in deployment.json. Tests added for backwards compatibility (and once we have the HostOS upgrade to/from version handles, we can be super-duper confident in the backwards compatibility!)

This explicit definition will help with the larger config revamp, as in the new redesign, the cpu mode is explicitly defined in the new IcConfig object

Hourly pipeline succeeded: https://github.com/dfinity/ic/actions/runs/10599061627

