### PR TITLE
refactor(nervous_system): Add `Sns` type in `ic-nervous-system-agent`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9453,6 +9453,7 @@ dependencies = [
  "anyhow",
  "candid",
  "ic-agent",
+ "ic-base-types",
  "ic-nervous-system-clients",
  "ic-nns-constants",
  "ic-sns-wasm",

--- a/rs/nervous_system/agent/BUILD.bazel
+++ b/rs/nervous_system/agent/BUILD.bazel
@@ -7,6 +7,7 @@ DEPENDENCIES = [
     "//rs/nervous_system/clients",
     "//rs/nns/constants",
     "//rs/nns/sns-wasm",
+    "//rs/types/base_types",
     "@crate_index//:anyhow",
     "@crate_index//:candid",
     "@crate_index//:ic-agent",

--- a/rs/nervous_system/agent/Cargo.toml
+++ b/rs/nervous_system/agent/Cargo.toml
@@ -11,6 +11,7 @@ path = "src/lib.rs"
 anyhow = { workspace = true }
 candid = { workspace = true }
 ic-agent = { workspace = true }
+ic-base-types = { path = "../../types/base_types" }
 ic-nervous-system-clients = { path = "../clients" }
 ic-nns-constants = { path = "../../nns/constants" }
 ic-sns-wasm = { path = "../../nns/sns-wasm" }

--- a/rs/nervous_system/agent/src/lib.rs
+++ b/rs/nervous_system/agent/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod nns;
+pub mod sns;
 
 use anyhow::{anyhow, Result};
 use candid::{Decode, Encode, Principal};

--- a/rs/nervous_system/agent/src/sns/governance.rs
+++ b/rs/nervous_system/agent/src/sns/governance.rs
@@ -1,0 +1,7 @@
+use ic_base_types::PrincipalId;
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct GovernanceCanister {
+    pub canister_id: PrincipalId,
+}

--- a/rs/nervous_system/agent/src/sns/index.rs
+++ b/rs/nervous_system/agent/src/sns/index.rs
@@ -1,0 +1,7 @@
+use ic_base_types::PrincipalId;
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct IndexCanister {
+    pub canister_id: PrincipalId,
+}

--- a/rs/nervous_system/agent/src/sns/ledger.rs
+++ b/rs/nervous_system/agent/src/sns/ledger.rs
@@ -1,0 +1,7 @@
+use ic_base_types::PrincipalId;
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct LedgerCanister {
+    pub canister_id: PrincipalId,
+}

--- a/rs/nervous_system/agent/src/sns/mod.rs
+++ b/rs/nervous_system/agent/src/sns/mod.rs
@@ -1,0 +1,49 @@
+pub mod governance;
+pub mod index;
+pub mod ledger;
+pub mod root;
+pub mod swap;
+
+use serde::{Deserialize, Serialize};
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct Sns {
+    pub ledger: ledger::LedgerCanister,
+    pub governance: governance::GovernanceCanister,
+    pub index: index::IndexCanister,
+    pub swap: swap::SwapCanister,
+    pub root: root::RootCanister,
+}
+
+impl TryFrom<ic_sns_wasm::pb::v1::DeployedSns> for Sns {
+    type Error = String;
+
+    fn try_from(deployed_sns: ic_sns_wasm::pb::v1::DeployedSns) -> Result<Self, Self::Error> {
+        Ok(Self {
+            ledger: ledger::LedgerCanister {
+                canister_id: deployed_sns
+                    .ledger_canister_id
+                    .ok_or("ledger_canister_id not found")?,
+            },
+            governance: governance::GovernanceCanister {
+                canister_id: deployed_sns
+                    .governance_canister_id
+                    .ok_or("ledger_canister_id not found")?,
+            },
+            index: index::IndexCanister {
+                canister_id: deployed_sns
+                    .index_canister_id
+                    .ok_or("ledger_canister_id not found")?,
+            },
+            swap: swap::SwapCanister {
+                canister_id: deployed_sns
+                    .swap_canister_id
+                    .ok_or("ledger_canister_id not found")?,
+            },
+            root: root::RootCanister {
+                canister_id: deployed_sns
+                    .root_canister_id
+                    .ok_or("ledger_canister_id not found")?,
+            },
+        })
+    }
+}

--- a/rs/nervous_system/agent/src/sns/root.rs
+++ b/rs/nervous_system/agent/src/sns/root.rs
@@ -1,0 +1,7 @@
+use ic_base_types::PrincipalId;
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct RootCanister {
+    pub canister_id: PrincipalId,
+}

--- a/rs/nervous_system/agent/src/sns/swap.rs
+++ b/rs/nervous_system/agent/src/sns/swap.rs
@@ -1,0 +1,7 @@
+use ic_base_types::PrincipalId;
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct SwapCanister {
+    pub canister_id: PrincipalId,
+}


### PR DESCRIPTION
[Next PR →](https://github.com/dfinity/ic/pull/1200)

## Problem

There is no easy way to interact with SNSes in the `ic-nervous-system-agent` crate (which currently only supports SNS-W). It is easy to support NNS canisters as the canister ID is known and fixed. SNS canisters are more tricky since of course you need to specify which particular SNS canister you want to call. 

## Solution

I created an `Sns` type which contains (also new types) `Governance`, `Root`, etc. These types only contain a canister ID. The idea is that we can then add methods, so e.g. to get the metadata of an `Sns` you can just write `sns.governance.metadata().await`. This PR also modifies `ic-nervous-system-agent`'s `list_deployed_snses` to return a vector of `Sns`s instead of `ListDeployedSnsesResponse`.

 