### PR TITLE
chore(nns): NeuronsFundAuditInfo migration

### DIFF
--- a/rs/nns/governance/canister/canister.rs
+++ b/rs/nns/governance/canister/canister.rs
@@ -24,7 +24,7 @@ use ic_nns_governance::{
     decoder_config, encode_metrics,
     governance::{Environment, Governance, HeapGrowthPotential, TimeWarp as GovTimeWarp},
     neuron_data_validation::NeuronDataValidationSummary,
-    pb::{v1 as gov_pb, v1::Governance as InternalGovernanceProto},
+    pb::v1::{self as gov_pb, Governance as InternalGovernanceProto},
     storage::{grow_upgrades_memory_to, validate_stable_storage, with_upgrades_memory},
 };
 #[cfg(feature = "test")]
@@ -385,6 +385,7 @@ fn canister_post_upgrade() {
         restored_state.neurons.len(),
         restored_state.xdr_conversion_rate,
     );
+    let restored_state = migrate_neurons_fund_audit_info(restored_state);
     set_governance(Governance::new_restored(
         restored_state,
         Box::new(CanisterEnv::new()),
@@ -393,6 +394,17 @@ fn canister_post_upgrade() {
     ));
 
     validate_stable_storage();
+}
+
+fn migrate_neurons_fund_audit_info(state: InternalGovernanceProto) -> InternalGovernanceProto {
+    InternalGovernanceProto {
+        proposals: state
+            .proposals
+            .into_iter()
+            .map(|(id, proposal_data)| (id, proposal_data.into_current()))
+            .collect(),
+        ..state
+    }
 }
 
 #[cfg(feature = "test")]

--- a/rs/nns/governance/canister/canister.rs
+++ b/rs/nns/governance/canister/canister.rs
@@ -401,7 +401,7 @@ fn migrate_neurons_fund_audit_info(state: InternalGovernanceProto) -> InternalGo
         proposals: state
             .proposals
             .into_iter()
-            .map(|(id, proposal_data)| (id, proposal_data.into_current()))
+            .map(|(id, proposal_data)| (id, proposal_data.migrate()))
             .collect(),
         ..state
     }

--- a/rs/nns/governance/src/lib.rs
+++ b/rs/nns/governance/src/lib.rs
@@ -156,7 +156,7 @@ mod garbage_collection;
 /// subnetworks that participate in the Internet Computer (IC).
 pub mod governance;
 pub mod governance_proto_builder;
-mod heap_governance_data;
+pub mod heap_governance_data;
 mod known_neuron_index;
 mod migrations;
 mod neuron;

--- a/rs/nns/governance/src/lib.rs
+++ b/rs/nns/governance/src/lib.rs
@@ -156,7 +156,7 @@ mod garbage_collection;
 /// subnetworks that participate in the Internet Computer (IC).
 pub mod governance;
 pub mod governance_proto_builder;
-pub mod heap_governance_data;
+mod heap_governance_data;
 mod known_neuron_index;
 mod migrations;
 mod neuron;
@@ -165,6 +165,7 @@ mod neuron_store;
 pub mod neurons_fund;
 mod node_provider_rewards;
 pub mod pb;
+mod proposal_data_neurons_fund_migration;
 pub mod proposals;
 mod reward;
 pub mod storage;

--- a/rs/nns/governance/src/migrations.rs
+++ b/rs/nns/governance/src/migrations.rs
@@ -1,6 +1,11 @@
 use crate::{
     neuron_store::NeuronStore,
-    pb::v1::governance::{migration::MigrationStatus, Migration, Migrations},
+    pb::v1::{
+        governance::{migration::MigrationStatus, Migration, Migrations},
+        neurons_fund_snapshot::{self, NeuronsFundNeuronPortion},
+        NeuronsFundAuditInfo, NeuronsFundData, NeuronsFundParticipation, NeuronsFundSnapshot,
+        ProposalData,
+    },
 };
 
 impl MigrationStatus {
@@ -26,4 +31,94 @@ pub(crate) fn maybe_run_migrations(
 ) -> Migrations {
     // TODO: move inactive neuron migration here.
     migrations
+}
+
+impl NeuronsFundData {
+    pub fn into_current(self) -> NeuronsFundData {
+        NeuronsFundData {
+            initial_neurons_fund_participation: self
+                .initial_neurons_fund_participation
+                .map(|participation| participation.into_current()),
+            final_neurons_fund_participation: self
+                .final_neurons_fund_participation
+                .map(|participation| participation.into_current()),
+            neurons_fund_refunds: self
+                .neurons_fund_refunds
+                .map(|snapshot| snapshot.into_current()),
+        }
+    }
+}
+
+impl ProposalData {
+    pub fn into_current(self) -> ProposalData {
+        ProposalData {
+            neurons_fund_data: self
+                .neurons_fund_data
+                .map(|neurons_fund_data| neurons_fund_data.into_current()),
+            ..self
+        }
+    }
+}
+
+impl NeuronsFundAuditInfo {
+    pub fn into_current(self) -> NeuronsFundAuditInfo {
+        NeuronsFundAuditInfo {
+            initial_neurons_fund_participation: self
+                .initial_neurons_fund_participation
+                .map(|participation| participation.into_current()),
+            final_neurons_fund_participation: self
+                .final_neurons_fund_participation
+                .map(|participation| participation.into_current()),
+            neurons_fund_refunds: self
+                .neurons_fund_refunds
+                .map(|snapshot| snapshot.into_current()),
+        }
+    }
+}
+
+impl NeuronsFundParticipation {
+    pub fn into_current(self) -> NeuronsFundParticipation {
+        NeuronsFundParticipation {
+            ideal_matched_participation_function: self.ideal_matched_participation_function,
+            neurons_fund_reserves: self
+                .neurons_fund_reserves
+                .map(|snapshot| snapshot.into_current()),
+            swap_participation_limits: self.swap_participation_limits,
+            direct_participation_icp_e8s: self.direct_participation_icp_e8s,
+            total_maturity_equivalent_icp_e8s: self.total_maturity_equivalent_icp_e8s,
+            max_neurons_fund_swap_participation_icp_e8s: self
+                .max_neurons_fund_swap_participation_icp_e8s,
+            intended_neurons_fund_participation_icp_e8s: self
+                .intended_neurons_fund_participation_icp_e8s,
+            allocated_neurons_fund_participation_icp_e8s: self
+                .allocated_neurons_fund_participation_icp_e8s,
+        }
+    }
+}
+
+impl NeuronsFundSnapshot {
+    pub fn into_current(self) -> NeuronsFundSnapshot {
+        NeuronsFundSnapshot {
+            neurons_fund_neuron_portions: self
+                .neurons_fund_neuron_portions
+                .into_iter()
+                .map(|portion| portion.into_current())
+                .collect(),
+        }
+    }
+}
+
+impl neurons_fund_snapshot::NeuronsFundNeuronPortion {
+    #[allow(deprecated)] // hotkey_principal is deprecated to make sure we don't accidentally use it.
+    pub fn into_current(self) -> NeuronsFundNeuronPortion {
+        NeuronsFundNeuronPortion {
+            nns_neuron_id: self.nns_neuron_id,
+            amount_icp_e8s: self.amount_icp_e8s,
+            maturity_equivalent_icp_e8s: self.maturity_equivalent_icp_e8s,
+            is_capped: self.is_capped,
+            controller: self.controller.or(self.hotkey_principal),
+            hotkeys: self.hotkeys,
+            hotkey_principal: self.hotkey_principal,
+        }
+    }
 }

--- a/rs/nns/governance/src/migrations.rs
+++ b/rs/nns/governance/src/migrations.rs
@@ -1,11 +1,6 @@
 use crate::{
     neuron_store::NeuronStore,
-    pb::v1::{
-        governance::{migration::MigrationStatus, Migration, Migrations},
-        neurons_fund_snapshot::{self, NeuronsFundNeuronPortion},
-        NeuronsFundAuditInfo, NeuronsFundData, NeuronsFundParticipation, NeuronsFundSnapshot,
-        ProposalData,
-    },
+    pb::v1::governance::{migration::MigrationStatus, Migration, Migrations},
 };
 
 impl MigrationStatus {
@@ -31,94 +26,4 @@ pub(crate) fn maybe_run_migrations(
 ) -> Migrations {
     // TODO: move inactive neuron migration here.
     migrations
-}
-
-impl NeuronsFundData {
-    pub fn into_current(self) -> NeuronsFundData {
-        NeuronsFundData {
-            initial_neurons_fund_participation: self
-                .initial_neurons_fund_participation
-                .map(|participation| participation.into_current()),
-            final_neurons_fund_participation: self
-                .final_neurons_fund_participation
-                .map(|participation| participation.into_current()),
-            neurons_fund_refunds: self
-                .neurons_fund_refunds
-                .map(|snapshot| snapshot.into_current()),
-        }
-    }
-}
-
-impl ProposalData {
-    pub fn into_current(self) -> ProposalData {
-        ProposalData {
-            neurons_fund_data: self
-                .neurons_fund_data
-                .map(|neurons_fund_data| neurons_fund_data.into_current()),
-            ..self
-        }
-    }
-}
-
-impl NeuronsFundAuditInfo {
-    pub fn into_current(self) -> NeuronsFundAuditInfo {
-        NeuronsFundAuditInfo {
-            initial_neurons_fund_participation: self
-                .initial_neurons_fund_participation
-                .map(|participation| participation.into_current()),
-            final_neurons_fund_participation: self
-                .final_neurons_fund_participation
-                .map(|participation| participation.into_current()),
-            neurons_fund_refunds: self
-                .neurons_fund_refunds
-                .map(|snapshot| snapshot.into_current()),
-        }
-    }
-}
-
-impl NeuronsFundParticipation {
-    pub fn into_current(self) -> NeuronsFundParticipation {
-        NeuronsFundParticipation {
-            ideal_matched_participation_function: self.ideal_matched_participation_function,
-            neurons_fund_reserves: self
-                .neurons_fund_reserves
-                .map(|snapshot| snapshot.into_current()),
-            swap_participation_limits: self.swap_participation_limits,
-            direct_participation_icp_e8s: self.direct_participation_icp_e8s,
-            total_maturity_equivalent_icp_e8s: self.total_maturity_equivalent_icp_e8s,
-            max_neurons_fund_swap_participation_icp_e8s: self
-                .max_neurons_fund_swap_participation_icp_e8s,
-            intended_neurons_fund_participation_icp_e8s: self
-                .intended_neurons_fund_participation_icp_e8s,
-            allocated_neurons_fund_participation_icp_e8s: self
-                .allocated_neurons_fund_participation_icp_e8s,
-        }
-    }
-}
-
-impl NeuronsFundSnapshot {
-    pub fn into_current(self) -> NeuronsFundSnapshot {
-        NeuronsFundSnapshot {
-            neurons_fund_neuron_portions: self
-                .neurons_fund_neuron_portions
-                .into_iter()
-                .map(|portion| portion.into_current())
-                .collect(),
-        }
-    }
-}
-
-impl neurons_fund_snapshot::NeuronsFundNeuronPortion {
-    #[allow(deprecated)] // hotkey_principal is deprecated to make sure we don't accidentally use it.
-    pub fn into_current(self) -> NeuronsFundNeuronPortion {
-        NeuronsFundNeuronPortion {
-            nns_neuron_id: self.nns_neuron_id,
-            amount_icp_e8s: self.amount_icp_e8s,
-            maturity_equivalent_icp_e8s: self.maturity_equivalent_icp_e8s,
-            is_capped: self.is_capped,
-            controller: self.controller.or(self.hotkey_principal),
-            hotkeys: self.hotkeys,
-            hotkey_principal: self.hotkey_principal,
-        }
-    }
 }

--- a/rs/nns/governance/src/proposal_data_neurons_fund_migration.rs
+++ b/rs/nns/governance/src/proposal_data_neurons_fund_migration.rs
@@ -1,0 +1,76 @@
+use crate::pb::v1::{
+    neurons_fund_snapshot::{self, NeuronsFundNeuronPortion},
+    NeuronsFundAuditInfo, NeuronsFundData, NeuronsFundParticipation, NeuronsFundSnapshot,
+    ProposalData,
+};
+
+impl ProposalData {
+    pub fn migrate(self) -> ProposalData {
+        ProposalData {
+            neurons_fund_data: self
+                .neurons_fund_data
+                .map(|neurons_fund_data| neurons_fund_data.migrate()),
+            ..self
+        }
+    }
+}
+
+impl NeuronsFundData {
+    pub fn migrate(self) -> NeuronsFundData {
+        NeuronsFundData {
+            initial_neurons_fund_participation: self
+                .initial_neurons_fund_participation
+                .map(NeuronsFundParticipation::migrate),
+            final_neurons_fund_participation: self
+                .final_neurons_fund_participation
+                .map(NeuronsFundParticipation::migrate),
+            neurons_fund_refunds: self.neurons_fund_refunds.map(NeuronsFundSnapshot::migrate),
+        }
+    }
+}
+
+impl NeuronsFundAuditInfo {
+    pub fn migrate(self) -> NeuronsFundAuditInfo {
+        NeuronsFundAuditInfo {
+            initial_neurons_fund_participation: self
+                .initial_neurons_fund_participation
+                .map(NeuronsFundParticipation::migrate),
+            final_neurons_fund_participation: self
+                .final_neurons_fund_participation
+                .map(NeuronsFundParticipation::migrate),
+            neurons_fund_refunds: self.neurons_fund_refunds.map(NeuronsFundSnapshot::migrate),
+        }
+    }
+}
+
+impl NeuronsFundParticipation {
+    pub fn migrate(self) -> NeuronsFundParticipation {
+        NeuronsFundParticipation {
+            ideal_matched_participation_function: self.ideal_matched_participation_function,
+            neurons_fund_reserves: self.neurons_fund_reserves.map(NeuronsFundSnapshot::migrate),
+            ..self
+        }
+    }
+}
+
+impl NeuronsFundSnapshot {
+    pub fn migrate(self) -> NeuronsFundSnapshot {
+        NeuronsFundSnapshot {
+            neurons_fund_neuron_portions: self
+                .neurons_fund_neuron_portions
+                .into_iter()
+                .map(NeuronsFundNeuronPortion::migrate)
+                .collect(),
+        }
+    }
+}
+
+impl neurons_fund_snapshot::NeuronsFundNeuronPortion {
+    #[allow(deprecated)] // hotkey_principal is deprecated to make sure we don't accidentally use it.
+    pub fn migrate(self) -> NeuronsFundNeuronPortion {
+        NeuronsFundNeuronPortion {
+            controller: self.controller.or(self.hotkey_principal), // <- Actual meat of the migration.
+            ..self
+        }
+    }
+}

--- a/rs/nns/integration_tests/src/hotkeys_migration_test.rs
+++ b/rs/nns/integration_tests/src/hotkeys_migration_test.rs
@@ -154,7 +154,7 @@ fn test_hotkey_principal_migration() {
             neuron_portion,
             NeuronsFundNeuronPortion {
                 // The legacy field is still set.
-                hotkey_principal: Some(_hotkey_principal),
+                hotkey_principal: Some(hotkey_principal),
                 // The new field is not yet set.
                 controller: Some(controller),
                 ..

--- a/rs/nns/integration_tests/src/hotkeys_migration_test.rs
+++ b/rs/nns/integration_tests/src/hotkeys_migration_test.rs
@@ -149,18 +149,17 @@ fn test_hotkey_principal_migration() {
 
     // Assert that all collected neuron portions have been migrated correctly.
     for neuron_portion in neuron_portions {
-        #[rustfmt::skip]
+        #[rustfmt::skip] // Work around rustfmt bug - https://github.com/rust-lang/rustfmt/issues/6300
         assert_matches!(
             neuron_portion,
             NeuronsFundNeuronPortion {
                 // The legacy field is still set.
                 hotkey_principal: Some(_hotkey_principal),
                 // The new field is not yet set.
-                // TODO[NNS1-3292]: Set this data via migration and uncomment this line.
-                // controller: Some(controller),
+                controller: Some(controller),
                 ..
-            } // TODO[NNS1-3292]: Uncomment
-              // if hotkey_principal == controller
+            }
+              if hotkey_principal == controller
         );
     }
 }


### PR DESCRIPTION
## Problem

We have switched from the `hotkey_principal` field to a field named `nns_neuron_controller` in the type `NeuronsFundNeuronPortion`. This is because the type `nns_neuron_controller` more clearly explains the semantics of the type than `hotkey_principal`. However, already-existing `ProposalData`s indirectly contain `NeuronsFundNeuronPortion`s which have `None` for the new field.

## Solution

I've implemented a migration for the `NeuronsFundNeuronPortion`s that are transitively stored in `ProposalData` to use this new field. The migration lives in `pre_upgrade` and iterates over the stored `ProposalData`s, and sets their `neurons_fund_data` field to a value that contains the migrated state. 

< [Previous PR](https://github.com/dfinity/ic/pull/1171) |