### PR TITLE
fix(cketh): Trim logs to 2 MB

### DIFF
--- a/rs/ethereum/cketh/minter/src/main.rs
+++ b/rs/ethereum/cketh/minter/src/main.rs
@@ -1022,7 +1022,7 @@ fn http_request(req: HttpRequest) -> HttpResponse {
             max_skip_timestamp,
         ));
 
-        const MAX_BODY_SIZE: usize = 3_000_000;
+        const MAX_BODY_SIZE: usize = 2_000_000;
         HttpResponseBuilder::ok()
             .header("Content-Type", "application/json; charset=utf-8")
             .with_body_and_content_length(log.serialize_logs(MAX_BODY_SIZE))


### PR DESCRIPTION
Ensure that the HTTP response containing the ckETH minter logs (e.g. https://sv3dd-oaaaa-aaaar-qacoa-cai.raw.icp0.io/logs?sort=desc) is at most 2MB. Otherwise, the logs cannot be retrieved as `Response size exceeds limit`. This is due to a recent change (proposal [122354](https://dashboard.internetcomputer.org/proposal/122354)) in the fiduciary subnet (`pzp6e-ekpqk-3c5x7-2h6so-njoeq-mt45d-h3h6c-q3mxf-vpeq5-fk5o7-yae`), where the various limits used (including the maximum response limit) were re-aligned to that of other subnets (excluding the NNS).
