### PR TITLE
feat(RUN-931): Add Doc Links to Contract Violation Errors

### DIFF
--- a/rs/embedders/src/wasmtime_embedder/system_api.rs
+++ b/rs/embedders/src/wasmtime_embedder/system_api.rs
@@ -1213,10 +1213,8 @@ pub(crate) fn syscalls<
                         system_api.ic0_call_with_best_effort_response(timeout_seconds)
                     })
                 } else {
-                    let err = HypervisorError::UserContractViolation {
+                    let err = HypervisorError::ToolchainContractViolation {
                         error: "ic0::call_with_best_effort_response is not enabled.".to_string(),
-                        suggestion: "".to_string(),
-                        doc_link: "".to_string(),
                     };
                     Err(process_err(&mut caller, err))
                 }
@@ -1231,10 +1229,8 @@ pub(crate) fn syscalls<
                 if feature_flags.best_effort_responses == FlagStatus::Enabled {
                     with_system_api(&mut caller, |system_api| system_api.ic0_msg_deadline())
                 } else {
-                    let err = HypervisorError::UserContractViolation {
+                    let err = HypervisorError::ToolchainContractViolation {
                         error: "ic0::msg_deadline is not enabled.".to_string(),
-                        suggestion: "".to_string(),
-                        doc_link: "".to_string(),
                     };
                     Err(process_err(&mut caller, err))
                 }

--- a/rs/execution_environment/src/execution/response/tests.rs
+++ b/rs/execution_environment/src/execution/response/tests.rs
@@ -2979,10 +2979,10 @@ fn test_best_effort_responses_feature_flag_enabled() {
 fn test_best_effort_responses_feature_flag_disabled() {
     match test_best_effort_responses_feature_flag(FlagStatus::Disabled) {
         Err(e) => {
-            assert_eq!(e.code(), ErrorCode::CanisterContractViolation);
-            assert!(e
-                .description()
-                .ends_with("ic0::call_with_best_effort_response is not enabled."));
+            e.assert_contains(
+                ErrorCode::CanisterContractViolation,
+                "ic0::call_with_best_effort_response is not enabled.",
+            );
         }
         _ => panic!("Unexpected result"),
     };
@@ -3020,8 +3020,8 @@ fn test_ic0_msg_deadline_best_effort_responses_feature_flag_disabled() {
     let err = helper_ic0_msg_deadline_best_effort_responses_feature_flag(FlagStatus::Disabled)
         .unwrap_err();
 
-    assert_eq!(err.code(), ErrorCode::CanisterContractViolation);
-    assert!(err
-        .description()
-        .ends_with("ic0::msg_deadline is not enabled."));
+    err.assert_contains(
+        ErrorCode::CanisterContractViolation,
+        "ic0::msg_deadline is not enabled.",
+    );
 }

--- a/rs/execution_environment/src/query_handler/query_cache/tests.rs
+++ b/rs/execution_environment/src/query_handler/query_cache/tests.rs
@@ -5,7 +5,7 @@ use crate::{
     InternalHttpQueryHandler,
 };
 use ic_base_types::CanisterId;
-use ic_error_types::{ErrorCode, UserError};
+use ic_error_types::ErrorCode;
 use ic_interfaces::execution_environment::{SystemApiCallCounters, SystemApiCallId};
 use ic_registry_subnet_type::SubnetType;
 use ic_replicated_state::canister_state::system_state::CyclesUseCase;
@@ -1365,19 +1365,20 @@ fn query_cache_never_caches_calls_to_management_canister() {
         .call_simple(CanisterId::ic_00(), "raw_rand", call_args())
         .build();
 
-    let res_1 = test.non_replicated_query(a_id, "query", q.clone());
+    let res_1 = test
+        .non_replicated_query(a_id, "query", q.clone())
+        .unwrap_err();
     assert_eq!(query_cache_metrics(&test).hits.get(), 0);
     assert_eq!(query_cache_metrics(&test).misses.get(), 1);
-    let description = format!("Error from Canister {a_id}: Canister violated contract: \"ic0_call_new\" cannot be executed in non replicated query mode");
-    assert_eq!(
-        Err(UserError::new(
-            ErrorCode::CanisterContractViolation,
-            description
-        )),
-        res_1
+    let description = format!(
+        "Error from Canister {a_id}: Canister violated contract: \
+        \"ic0_call_new\" cannot be executed in non replicated query mode"
     );
+    res_1.assert_contains(ErrorCode::CanisterContractViolation, &description);
 
-    let res_2 = test.non_replicated_query(a_id, "query", q.clone());
+    let res_2 = test
+        .non_replicated_query(a_id, "query", q.clone())
+        .unwrap_err();
     assert_eq!(query_cache_metrics(&test).hits.get(), 1);
     assert_eq!(query_cache_metrics(&test).misses.get(), 1);
     assert_eq!(res_1, res_2);

--- a/rs/system_api/src/lib.rs
+++ b/rs/system_api/src/lib.rs
@@ -31,6 +31,7 @@ use ic_types::{
     NumInstructions, NumOsPages, PrincipalId, SubnetId, Time, MAX_STABLE_MEMORY_IN_BYTES,
 };
 use ic_utils::deterministic_operations::deterministic_copy_from_slice;
+use ic_wasm_types::doc_ref;
 use request_in_prep::{into_request, RequestInPrep};
 use sandbox_safe_system_state::{CanisterStatusView, SandboxSafeSystemState, SystemStateChanges};
 use serde::{Deserialize, Serialize};
@@ -1134,8 +1135,10 @@ impl SystemApiImpl {
                 "\"{}\" cannot be executed in {} mode",
                 method_name, self.api_type
             ),
-            suggestion: "".to_string(),
-            doc_link: "".to_string(),
+            suggestion: "Check the ICP documentation to make sure APIs are \
+            being called in the correct message types."
+                .to_string(),
+            doc_link: doc_ref("calling-a-system-api-from-the-wrong-mode"),
         }
     }
 
@@ -1873,8 +1876,11 @@ impl SystemApi for SystemApiImpl {
                         );
                         return Err(UserContractViolation {
                             error: string,
-                            suggestion: "".to_string(),
-                            doc_link: "".to_string(),
+                            suggestion:
+                                "Consider checking the response size and returning an error if \
+                                it is too long."
+                                    .to_string(),
+                            doc_link: doc_ref("msg_reply_data_append-payload-too-large"),
                         });
                     }
                     data.extend_from_slice(valid_subslice("msg.reply", src, size, heap)?);
@@ -1911,8 +1917,9 @@ impl SystemApi for SystemApiImpl {
                     );
                         return Err(UserContractViolation {
                             error: string,
-                            suggestion: "".to_string(),
-                            doc_link: "".to_string(),
+                            suggestion: "Try truncating the error messages that are too long."
+                                .to_string(),
+                            doc_link: doc_ref("msg_reject-payload-too-large"),
                         });
                     }
                     let msg_bytes = valid_subslice("ic0.msg_reject", src, size, heap)?;
@@ -3000,8 +3007,10 @@ impl SystemApi for SystemApiImpl {
                     no larger than {} bytes. Found {} bytes.",
                             CERTIFIED_DATA_MAX_LENGTH, size
                         ),
-                        suggestion: "".to_string(),
-                        doc_link: "".to_string(),
+                        suggestion: "Try certifying just the hash of your data instead of \
+                        the full contents."
+                            .to_string(),
+                        doc_link: doc_ref("certified_data_set-payload-too-large"),
                     });
                 }
 

--- a/rs/system_api/src/request_in_prep.rs
+++ b/rs/system_api/src/request_in_prep.rs
@@ -8,8 +8,13 @@ use ic_types::{
     time::CoarseTime,
     CanisterId, Cycles, NumBytes, PrincipalId,
 };
+use ic_wasm_types::doc_ref;
 use serde::{Deserialize, Serialize};
 use std::{convert::TryFrom, time::Duration};
+
+const PAYLOAD_SIZE_SUGGESTION: &str = "Check the canister for errors or redesign the target \
+                API to allow shorter messages";
+const PAYLOAD_SIZE_LINK: &str = "canister-made-a-call-with-too-large-payload";
 
 /// Represents an under construction `Request`.
 ///
@@ -68,6 +73,10 @@ impl RequestInPrep {
         multiplier_max_size_local_subnet: u64,
         max_sum_exported_function_name_lengths: usize,
     ) -> HypervisorResult<Self> {
+        const LARGE_NAME_SUGGESTION: &str =
+            "Size of method_name {} exceeds the allowed limit of {}.";
+        const LARGE_NAME_LINK: &str = "canister-made-a-call-with-too-large-method-name";
+
         let method_name = {
             // Check the conditions for method_name length separately to provide
             // a more specific error message instead of combining both based on
@@ -80,8 +89,8 @@ impl RequestInPrep {
                         "Size of method_name {} exceeds the allowed limit of {}.",
                         method_name_len, max_sum_exported_function_name_lengths
                     ),
-                    suggestion: "".to_string(),
-                    doc_link: "".to_string(),
+                    suggestion: LARGE_NAME_SUGGESTION.to_string(),
+                    doc_link: doc_ref(LARGE_NAME_LINK),
                 });
             }
 
@@ -93,8 +102,8 @@ impl RequestInPrep {
                         "Size of method_name {} exceeds the allowed limit of {}.",
                         method_name_len, max_size_local_subnet
                     ),
-                    suggestion: "".to_string(),
-                    doc_link: "".to_string(),
+                    suggestion: LARGE_NAME_SUGGESTION.to_string(),
+                    doc_link: doc_ref(LARGE_NAME_LINK),
                 });
             }
             let method_name = valid_subslice(
@@ -160,8 +169,8 @@ impl RequestInPrep {
                 current_size + size,
                 max_size_local_subnet
             ),
-                suggestion: "".to_string(),
-                doc_link: "".to_string(),
+                suggestion: PAYLOAD_SIZE_SUGGESTION.to_string(),
+                doc_link: doc_ref(PAYLOAD_SIZE_LINK),
             })
         } else {
             let data = valid_subslice("ic0.call_data_append", src, size, heap)?;
@@ -223,8 +232,8 @@ pub(crate) fn into_request(
                 method_name,
                 payload_size, max_size_remote_subnet
             ),
-                suggestion: "".to_string(),
-                doc_link: "".to_string(),
+                suggestion: PAYLOAD_SIZE_SUGGESTION.to_string(),
+                doc_link: doc_ref(PAYLOAD_SIZE_LINK),
             });
         }
     }


### PR DESCRIPTION
Add links to the execution errors reference page for the contract violation errors. The errors related to the performance counter API and best-effort messaging aren't handled because they haven't been added to the reference page yet.