### PR TITLE
chore: Avoid cloning NiDKG transcripts

### DIFF
--- a/rs/consensus/src/certification/certifier.rs
+++ b/rs/consensus/src/certification/certifier.rs
@@ -404,10 +404,7 @@ impl CertifierImpl {
             self.membership.as_ref(),
             self.crypto.as_aggregate(),
             Box::new(|cert: &CertificationTuple| {
-                Some(active_high_threshold_nidkg_id(
-                    self.consensus_pool_cache.as_ref(),
-                    cert.height(),
-                )?)
+                active_high_threshold_nidkg_id(self.consensus_pool_cache.as_ref(), cert.height())
             }),
             shares,
         )

--- a/rs/consensus/src/consensus/catchup_package_maker.rs
+++ b/rs/consensus/src/consensus/catchup_package_maker.rs
@@ -14,7 +14,7 @@
 //! block is considered finalized.
 
 use ic_consensus_utils::{
-    active_high_threshold_transcript, crypto::ConsensusCrypto,
+    active_high_threshold_nidkg_id, crypto::ConsensusCrypto,
     get_oldest_idkg_state_registry_version, membership::Membership, pool_reader::PoolReader,
 };
 use ic_interfaces::messaging::MessageRouting;
@@ -235,9 +235,8 @@ impl CatchUpPackageMaker {
                     registry_version,
                 );
                 let share_content = CatchUpShareContent::from(&content);
-                if let Some(transcript) = active_high_threshold_transcript(pool.as_cache(), height)
-                {
-                    match self.crypto.sign(&content, my_node_id, transcript.dkg_id) {
+                if let Some(dkg_id) = active_high_threshold_nidkg_id(pool.as_cache(), height) {
+                    match self.crypto.sign(&content, my_node_id, dkg_id) {
                         Ok(signature) => {
                             // Caution: The log string below is checked in replica_determinism_test.
                             // Changing the string might break the test.

--- a/rs/consensus/src/consensus/random_beacon_maker.rs
+++ b/rs/consensus/src/consensus/random_beacon_maker.rs
@@ -1,7 +1,7 @@
 //! Random beacon maker is responsible for creating random beacon share
 //! for the node if the node is a beacon maker and no such share exists.
 use ic_consensus_utils::{
-    active_low_threshold_transcript,
+    active_low_threshold_nidkg_id,
     crypto::ConsensusCrypto,
     membership::{Membership, MembershipError},
     pool_reader::PoolReader,
@@ -80,10 +80,8 @@ impl RandomBeaconMaker {
                 // beacon at height h only after there exists a block at
                 // height h, and we only use the random beacon at height
                 // h-1 in the validation of blocks at height h.
-                if let Some(transcript) =
-                    active_low_threshold_transcript(pool.as_cache(), next_height)
-                {
-                    match self.crypto.sign(&content, my_node_id, transcript.dkg_id) {
+                if let Some(dkg_id) = active_low_threshold_nidkg_id(pool.as_cache(), next_height) {
+                    match self.crypto.sign(&content, my_node_id, dkg_id) {
                         Ok(signature) => Some(RandomBeaconShare { content, signature }),
                         Err(err) => {
                             error!(self.log, "Couldn't create a signature: {:?}", err);

--- a/rs/consensus/src/consensus/random_tape_maker.rs
+++ b/rs/consensus/src/consensus/random_tape_maker.rs
@@ -21,7 +21,7 @@
 //!    random tape is delivered.
 
 use ic_consensus_utils::{
-    active_low_threshold_transcript,
+    active_low_threshold_nidkg_id,
     crypto::ConsensusCrypto,
     membership::{Membership, MembershipError},
     pool_reader::PoolReader,
@@ -132,10 +132,10 @@ impl RandomTapeMaker {
     ) -> Option<RandomTapeShare> {
         let content = RandomTapeContent::new(height);
 
-        if let Some(transcript) = active_low_threshold_transcript(pool.as_cache(), height) {
+        if let Some(dkg_id) = active_low_threshold_nidkg_id(pool.as_cache(), height) {
             match self
                 .crypto
-                .sign(&content, self.replica_config.node_id, transcript.dkg_id)
+                .sign(&content, self.replica_config.node_id, dkg_id)
             {
                 Ok(signature) => Some(RandomTapeShare { content, signature }),
                 Err(err) => {

--- a/rs/consensus/src/consensus/share_aggregator.rs
+++ b/rs/consensus/src/consensus/share_aggregator.rs
@@ -4,7 +4,7 @@
 //! Finalizations from finalization shares.
 use crate::consensus::random_tape_maker::RANDOM_TAPE_CHECK_MAX_HEIGHT_RANGE;
 use ic_consensus_utils::{
-    active_high_threshold_transcript, active_low_threshold_transcript, aggregate,
+    active_high_threshold_nidkg_id, active_low_threshold_nidkg_id, aggregate,
     crypto::ConsensusCrypto, membership::Membership, pool_reader::PoolReader,
     registry_version_at_height,
 };
@@ -61,8 +61,7 @@ impl ShareAggregator {
         let height = pool.get_random_beacon_height().increment();
         let shares = pool.get_random_beacon_shares(height);
         let state_reader = pool.as_cache();
-        let dkg_id = active_low_threshold_transcript(state_reader, height)
-            .map(|transcript| transcript.dkg_id);
+        let dkg_id = active_low_threshold_nidkg_id(state_reader, height);
         to_messages(aggregate(
             &self.log,
             self.membership.as_ref(),
@@ -91,8 +90,7 @@ impl ShareAggregator {
             self.membership.as_ref(),
             self.crypto.as_aggregate(),
             Box::new(|content: &RandomTapeContent| {
-                active_low_threshold_transcript(state_reader, content.height())
-                    .map(|transcript| transcript.dkg_id)
+                active_low_threshold_nidkg_id(state_reader, content.height())
             }),
             shares,
         ))
@@ -150,8 +148,7 @@ impl ShareAggregator {
                 }
             });
             let state_reader = pool.as_cache();
-            let dkg_id = active_high_threshold_transcript(state_reader, height)
-                .map(|transcript| transcript.dkg_id);
+            let dkg_id = active_high_threshold_nidkg_id(state_reader, height);
             let result = aggregate(
                 &self.log,
                 self.membership.as_ref(),

--- a/rs/consensus/src/consensus/validator.rs
+++ b/rs/consensus/src/consensus/validator.rs
@@ -12,7 +12,7 @@ use crate::{
     dkg, idkg,
 };
 use ic_consensus_utils::{
-    active_high_threshold_transcript, active_low_threshold_transcript,
+    active_high_threshold_nidkg_id, active_low_threshold_nidkg_id,
     crypto::ConsensusCrypto,
     get_oldest_idkg_state_registry_version, is_time_to_make_block,
     membership::{Membership, MembershipError},
@@ -199,9 +199,9 @@ impl SignatureVerify for RandomTape {
         pool: &PoolReader<'_>,
         _cfg: &ReplicaConfig,
     ) -> ValidationResult<ValidatorError> {
-        let transcript = active_low_threshold_transcript(pool.as_cache(), self.height())
+        let dkg_id = active_low_threshold_nidkg_id(pool.as_cache(), self.height())
             .ok_or_else(|| ValidationFailure::DkgSummaryNotFound(self.height()))?;
-        if self.signature.signer == transcript.dkg_id {
+        if self.signature.signer == dkg_id {
             crypto.verify_aggregate(self, self.signature.signer)?;
             Ok(())
         } else {
@@ -219,7 +219,7 @@ impl SignatureVerify for RandomTapeShare {
         _cfg: &ReplicaConfig,
     ) -> ValidationResult<ValidatorError> {
         let height = self.height();
-        let transcript = active_low_threshold_transcript(pool.as_cache(), height)
+        let dkg_id = active_low_threshold_nidkg_id(pool.as_cache(), height)
             .ok_or_else(|| ValidationFailure::DkgSummaryNotFound(self.height()))?;
         verify_threshold_committee(
             membership,
@@ -227,7 +227,7 @@ impl SignatureVerify for RandomTapeShare {
             height,
             RandomTape::committee(),
         )?;
-        crypto.verify(self, transcript.dkg_id)?;
+        crypto.verify(self, dkg_id)?;
         Ok(())
     }
 }
@@ -240,9 +240,9 @@ impl SignatureVerify for RandomBeacon {
         pool: &PoolReader<'_>,
         _cfg: &ReplicaConfig,
     ) -> ValidationResult<ValidatorError> {
-        let transcript = active_low_threshold_transcript(pool.as_cache(), self.height())
+        let dkg_id = active_low_threshold_nidkg_id(pool.as_cache(), self.height())
             .ok_or_else(|| ValidationFailure::DkgSummaryNotFound(self.height()))?;
-        if self.signature.signer == transcript.dkg_id {
+        if self.signature.signer == dkg_id {
             crypto.verify_aggregate(self, self.signature.signer)?;
             Ok(())
         } else {
@@ -260,7 +260,7 @@ impl SignatureVerify for RandomBeaconShare {
         _cfg: &ReplicaConfig,
     ) -> ValidationResult<ValidatorError> {
         let height = self.height();
-        let transcript = active_low_threshold_transcript(pool.as_cache(), height)
+        let dkg_id = active_low_threshold_nidkg_id(pool.as_cache(), height)
             .ok_or_else(|| ValidationFailure::DkgSummaryNotFound(self.height()))?;
         verify_threshold_committee(
             membership,
@@ -269,7 +269,7 @@ impl SignatureVerify for RandomBeaconShare {
             RandomBeacon::committee(),
         )?;
 
-        crypto.verify(self, transcript.dkg_id)?;
+        crypto.verify(self, dkg_id)?;
         Ok(())
     }
 }
@@ -283,7 +283,7 @@ impl SignatureVerify for Signed<CatchUpContent, ThresholdSignatureShare<CatchUpC
         _cfg: &ReplicaConfig,
     ) -> ValidationResult<ValidatorError> {
         let height = self.height();
-        let transcript = active_high_threshold_transcript(pool.as_cache(), height)
+        let dkg_id = active_high_threshold_nidkg_id(pool.as_cache(), height)
             .ok_or_else(|| ValidationFailure::DkgSummaryNotFound(self.height()))?;
         verify_threshold_committee(
             membership,
@@ -291,7 +291,7 @@ impl SignatureVerify for Signed<CatchUpContent, ThresholdSignatureShare<CatchUpC
             height,
             CatchUpPackage::committee(),
         )?;
-        crypto.verify(self, transcript.dkg_id)?;
+        crypto.verify(self, dkg_id)?;
         Ok(())
     }
 }

--- a/rs/consensus/utils/src/membership.rs
+++ b/rs/consensus/utils/src/membership.rs
@@ -1,5 +1,5 @@
 use crate::{
-    active_high_threshold_transcript, active_low_threshold_transcript, registry_version_at_height,
+    active_high_threshold_committee, active_low_threshold_committee, registry_version_at_height,
 };
 use ic_crypto_prng::{Csprng, RandomnessPurpose};
 use ic_interfaces::consensus_pool::ConsensusPoolCache;
@@ -206,8 +206,8 @@ impl Membership {
         node_id: NodeId,
         height: Height,
     ) -> Result<bool, MembershipError> {
-        match active_low_threshold_transcript(self.consensus_cache.as_ref(), height) {
-            Some(transcript) => Ok(transcript.committee.position(node_id).is_some()),
+        match active_low_threshold_committee(self.consensus_cache.as_ref(), height) {
+            Some((_, committee)) => Ok(committee.position(node_id).is_some()),
             None => Err(MembershipError::UnableToRetrieveDkgSummary(height)),
         }
     }
@@ -219,8 +219,8 @@ impl Membership {
         node_id: NodeId,
         height: Height,
     ) -> Result<bool, MembershipError> {
-        match active_high_threshold_transcript(self.consensus_cache.as_ref(), height) {
-            Some(transcript) => Ok(transcript.committee.position(node_id).is_some()),
+        match active_high_threshold_committee(self.consensus_cache.as_ref(), height) {
+            Some((_, committee)) => Ok(committee.position(node_id).is_some()),
             None => Err(MembershipError::UnableToRetrieveDkgSummary(height)),
         }
     }
@@ -241,8 +241,8 @@ impl Membership {
         &self,
         height: Height,
     ) -> Result<Threshold, MembershipError> {
-        match active_low_threshold_transcript(self.consensus_cache.as_ref(), height) {
-            Some(transcript) => Ok(transcript.threshold.get().get() as usize),
+        match active_low_threshold_committee(self.consensus_cache.as_ref(), height) {
+            Some((threshold, _)) => Ok(threshold),
             None => Err(MembershipError::UnableToRetrieveDkgSummary(height)),
         }
     }
@@ -252,8 +252,8 @@ impl Membership {
         &self,
         height: Height,
     ) -> Result<Threshold, MembershipError> {
-        match active_high_threshold_transcript(self.consensus_cache.as_ref(), height) {
-            Some(transcript) => Ok(transcript.threshold.get().get() as usize),
+        match active_high_threshold_committee(self.consensus_cache.as_ref(), height) {
+            Some((threshold, _)) => Ok(threshold),
             None => Err(MembershipError::UnableToRetrieveDkgSummary(height)),
         }
     }

--- a/rs/replay/src/validator.rs
+++ b/rs/replay/src/validator.rs
@@ -11,7 +11,7 @@ use ic_consensus::{
     consensus::{dkg_key_manager::DkgKeyManager, validator::Validator, ValidatorMetrics},
 };
 use ic_consensus_utils::{
-    active_high_threshold_transcript, crypto::ConsensusCrypto, membership::Membership,
+    active_high_threshold_nidkg_id, crypto::ConsensusCrypto, membership::Membership,
     pool_reader::PoolReader, registry_version_at_height,
 };
 use ic_interfaces::{
@@ -269,10 +269,8 @@ impl ReplayValidator {
             // The signer is valid.
             Ok(true) => {
                 // Verify the signature.
-                let dkg_id =
-                    active_high_threshold_transcript(self.pool_cache.as_ref(), share.height)
-                        .ok_or_else(|| "Failed to get active transcript.".to_string())?
-                        .dkg_id;
+                let dkg_id = active_high_threshold_nidkg_id(self.pool_cache.as_ref(), share.height)
+                    .ok_or_else(|| "Failed to get active transcript.".to_string())?;
                 self.certification_crypto
                     .verify(&share.signed, dkg_id)
                     .map_err(|e| e.to_string())


### PR DESCRIPTION
NiDKG transcripts may be fairly large (0.4 ~ 0.9 MB on NNS). Currently they are cloned twice whenever we create/verify/aggregate a BLS signature share (once to check committee membership and once to get the DKG id). 

We don't actually need the full transcripts to perform these operations, and can avoid cloning them by extracting only the necessary transcript data (NiDkgId, committee, threshold).