### PR TITLE
chore: CON-1085 Remove allow `result_large_err` clippy lint

### DIFF
--- a/rs/consensus/src/consensus/validator.rs
+++ b/rs/consensus/src/consensus/validator.rs
@@ -1,4 +1,3 @@
-#![allow(clippy::try_err)]
 //! This module encapsulates functions required for validating consensus
 //! artifacts.
 

--- a/rs/consensus/src/idkg/payload_builder.rs
+++ b/rs/consensus/src/idkg/payload_builder.rs
@@ -1,8 +1,4 @@
 //! This module implements the IDKG payload builder.
-#![allow(clippy::too_many_arguments)]
-#![allow(clippy::enum_variant_names)]
-#![allow(clippy::result_large_err)]
-
 use super::pre_signer::{IDkgTranscriptBuilder, IDkgTranscriptBuilderImpl};
 use super::signer::{ThresholdSignatureBuilder, ThresholdSignatureBuilderImpl};
 use super::utils::{block_chain_reader, get_chain_key_config_if_enabled, InvalidChainCacheError};
@@ -565,6 +561,7 @@ pub(crate) fn create_data_payload_helper(
     Ok(Some(idkg_payload))
 }
 
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn create_data_payload_helper_2(
     idkg_payload: &mut IDkgPayload,
     height: Height,

--- a/rs/consensus/src/idkg/payload_builder/errors.rs
+++ b/rs/consensus/src/idkg/payload_builder/errors.rs
@@ -30,7 +30,7 @@ pub(crate) enum IDkgPayloadError {
     IDkgTranscriptIdError(IDkgTranscriptIdError),
     ThresholdEcdsaSigInputsCreationError(ThresholdEcdsaSigInputsCreationError),
     TranscriptLookupError(idkg::TranscriptLookupError),
-    TranscriptCastError(idkg::TranscriptCastError),
+    TranscriptCastError(Box<idkg::TranscriptCastError>),
     InvalidChainCacheError(InvalidChainCacheError),
     InitialIDkgDealingsNotUnmaskedParams(Box<InitialIDkgDealings>),
 }
@@ -79,7 +79,7 @@ impl From<ThresholdEcdsaSigInputsCreationError> for IDkgPayloadError {
 
 impl From<idkg::TranscriptCastError> for IDkgPayloadError {
     fn from(err: idkg::TranscriptCastError) -> Self {
-        IDkgPayloadError::TranscriptCastError(err)
+        IDkgPayloadError::TranscriptCastError(Box::new(err))
     }
 }
 


### PR DESCRIPTION
Additionally remove two other lints that were ignored for no reason