### PR TITLE
feat(PocketIC): drop ready file in PocketIC server

### DIFF
--- a/rs/pocket_ic_server/CHANGELOG.md
+++ b/rs/pocket_ic_server/CHANGELOG.md
@@ -27,6 +27,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The argument `listen_at` of the endpoint `/http_gateway` has been renamed to `port`.
 - The endpoint `/instances/<instance_id>/auto_progress` returns an error if the corresponding PocketIC instance is already in auto progress mode.
 
+### Removed
+- The option `--ready-file`: the PocketIC server is ready to accept HTTP connections once the port file (specified via `--pid` or `--port-file`) contains a line terminated by a newline character.
+
 
 
 ## 5.0.0 - 2024-07-22

--- a/rs/pocket_ic_server/src/main.rs
+++ b/rs/pocket_ic_server/src/main.rs
@@ -311,7 +311,10 @@ fn setup_tracing(pid: Option<u32>) -> Option<WorkerGuard> {
     guard
 }
 
-// Ensures atomically that this file was created freshly, and gives an error otherwise.
+// Create a file at a given path:
+// - if `create_new` is true, then it ensures atomically that this file was created freshly, and gives an error otherwise;
+// - if `create_new` is false and no file exists at the given path, then it creates a new file at that path;
+// - if `create_new` is false and a path exists at the given path, then it open the file at that path and truncates it to be empty.
 fn create_file<P: AsRef<std::path::Path>>(file_path: P, create_new: bool) -> std::io::Result<File> {
     File::options()
         .read(true)

--- a/rs/pocket_ic_server/src/main.rs
+++ b/rs/pocket_ic_server/src/main.rs
@@ -40,7 +40,7 @@ use tokio::runtime::Runtime;
 use tokio::sync::RwLock;
 use tokio::time::{Duration, Instant};
 use tower_http::trace::TraceLayer;
-use tracing::{debug, error, info};
+use tracing::{debug, info};
 use tracing_appender::non_blocking::WorkerGuard;
 use tracing_subscriber::filter::EnvFilter;
 
@@ -69,9 +69,6 @@ struct Args {
     /// The file to which the PocketIC server port should be written
     #[clap(long, conflicts_with = "pid")]
     port_file: Option<PathBuf>,
-    /// The file which is created by the PocketIC server once it is ready to accept HTTP connections
-    #[clap(long, conflicts_with = "pid")]
-    ready_file: Option<PathBuf>,
     /// The time-to-live of the PocketIC server in seconds
     #[clap(long, default_value_t = TTL_SEC)]
     ttl: u64,
@@ -117,40 +114,27 @@ async fn start(runtime: Arc<Runtime>) {
     // If PocketIC was started with the `--pid` flag, create a port file to communicate the port back to
     // the parent process (e.g., the `cargo test` invocation). Other tests can then see this port file
     // and reuse the same PocketIC server.
-    let use_port_file = args.pid.is_some() || args.port_file.is_some();
-    let mut port_file_path = None;
-    let mut port_file = None;
-    let use_ready_file = args.pid.is_some() || args.ready_file.is_some();
-    let mut ready_file_path = None;
-    if use_port_file {
-        if let Some(ref port_file) = args.port_file {
-            // Clean up port file.
-            let _ = std::fs::remove_file(port_file);
-        }
-        port_file_path = if args.port_file.is_some() {
-            args.port_file
-        } else {
-            Some(std::env::temp_dir().join(format!("pocket_ic_{}.port", args.pid.unwrap())))
-        };
-        port_file = match create_file_atomically(port_file_path.clone().unwrap()) {
+    let port_file_path = match (args.port_file, args.pid) {
+        (Some(port_file_path), None) => Some(port_file_path),
+        (None, Some(pid)) => Some(std::env::temp_dir().join(format!("pocket_ic_{}.port", pid))),
+        (None, None) => None,
+        (Some(_), Some(_)) => panic!("At most one of --port-file and --pid can be provided."),
+    };
+    let create_atomically = args.pid.is_some();
+    let port_file = if let Some(ref port_file_path) = port_file_path {
+        match create_file(port_file_path, create_atomically) {
             Ok(f) => Some(f),
             Err(_) => {
+                if !create_atomically {
+                    panic!("The port file could not be opened!");
+                }
                 // A PocketIC server is already running for this PID, terminate.
                 return;
             }
-        };
-    }
-    if use_ready_file {
-        if let Some(ref ready_file) = args.ready_file {
-            // Clean up ready file.
-            let _ = std::fs::remove_file(ready_file);
         }
-        ready_file_path = if args.ready_file.is_some() {
-            args.ready_file
-        } else {
-            Some(std::env::temp_dir().join(format!("pocket_ic_{}.ready", args.pid.unwrap())))
-        };
-    }
+    } else {
+        None
+    };
 
     let ip_addr = args.ip_addr.unwrap_or("127.0.0.1".to_string());
     let addr = format!("{}:{}", ip_addr, args.port);
@@ -225,9 +209,8 @@ async fn start(runtime: Arc<Runtime>) {
     let handle = Handle::new();
     let shutdown_handle = handle.clone();
     let axum_handle = handle.clone();
-    // This is a safeguard against orphaning this child process.
     let port_file_path_clone = port_file_path.clone();
-    let ready_file_path_clone = ready_file_path.clone();
+    // This is a safeguard against orphaning this child process.
     tokio::spawn(async move {
         loop {
             let guard = app_state.min_alive_until.read().await;
@@ -242,13 +225,9 @@ async fn start(runtime: Arc<Runtime>) {
 
         shutdown_handle.shutdown();
 
-        if use_ready_file {
-            // Clean up ready file.
-            let _ = std::fs::remove_file(ready_file_path_clone.unwrap());
-        }
-        if use_port_file {
+        if let Some(port_file_path) = port_file_path_clone {
             // Clean up port file.
-            let _ = std::fs::remove_file(port_file_path_clone.unwrap());
+            let _ = std::fs::remove_file(port_file_path);
         }
     });
 
@@ -263,19 +242,9 @@ async fn start(runtime: Arc<Runtime>) {
     // Wait until the PocketIC server starts listening.
     while handle.listening().await.is_none() {}
 
-    if use_port_file {
-        let _ = port_file
-            .as_mut()
-            .unwrap()
-            .write_all(real_port.to_string().as_bytes());
-        let _ = port_file.unwrap().flush();
-    }
-    if use_ready_file {
-        // Signal that the port file can safely be read by other clients.
-        let ready_file = create_file_atomically(ready_file_path.clone().unwrap());
-        if ready_file.is_err() {
-            error!("The .ready file already exists; please do not pass the same ready file path to multiple PocketIC server invocations!");
-        }
+    if let Some(mut port_file) = port_file {
+        let _ = port_file.write_all(format!("{}\n", real_port).as_bytes());
+        let _ = port_file.flush();
     }
 
     info!("The PocketIC server is listening on port {}", real_port);
@@ -343,11 +312,13 @@ fn setup_tracing(pid: Option<u32>) -> Option<WorkerGuard> {
 }
 
 // Ensures atomically that this file was created freshly, and gives an error otherwise.
-fn create_file_atomically<P: AsRef<std::path::Path>>(file_path: P) -> std::io::Result<File> {
+fn create_file<P: AsRef<std::path::Path>>(file_path: P, create_new: bool) -> std::io::Result<File> {
     File::options()
         .read(true)
         .write(true)
-        .create_new(true)
+        .truncate(true)
+        .create(!create_new)
+        .create_new(create_new)
         .open(&file_path)
 }
 

--- a/rs/pocket_ic_server/tests/spec_test.rs
+++ b/rs/pocket_ic_server/tests/spec_test.rs
@@ -8,7 +8,7 @@ use pocket_ic::common::rest::DtsFlag;
 use pocket_ic::PocketIcBuilder;
 use spec_compliance::run_ic_ref_test;
 use std::process::{Command, Stdio};
-use std::time::{Duration, Instant};
+use std::time::Duration;
 use tempfile::NamedTempFile;
 
 const LOCALHOST: &str = "127.0.0.1";
@@ -65,16 +65,15 @@ fn setup_and_run_ic_ref_test(test_nns: bool, excluded_tests: Vec<&str>, included
         .stderr(Stdio::inherit())
         .spawn()
         .expect("httpbin binary crashed");
-    let start = Instant::now();
     let httpbin_url = loop {
         let port_string = std::fs::read_to_string(port_file_path.clone())
             .expect("Failed to read port from port file");
         if !port_string.is_empty() {
-            let port: u16 = port_string.parse().expect("Failed to parse port to number");
+            let port: u16 = port_string
+                .trim_end()
+                .parse()
+                .expect("Failed to parse port to number");
             break format!("{}:{}", LOCALHOST, port);
-        }
-        if start.elapsed() > Duration::from_secs(5) {
-            panic!("Failed to start httpbin service in time");
         }
         std::thread::sleep(Duration::from_millis(20));
     };

--- a/rs/pocket_ic_server/tests/test.rs
+++ b/rs/pocket_ic_server/tests/test.rs
@@ -45,17 +45,11 @@ fn start_server_helper(
     } else {
         NamedTempFile::new().unwrap().into_temp_path().to_path_buf()
     };
-    let ready_file_path = if let Some(parent_pid) = parent_pid {
-        std::env::temp_dir().join(format!("pocket_ic_{}.ready", parent_pid))
-    } else {
-        NamedTempFile::new().unwrap().into_temp_path().to_path_buf()
-    };
     let mut cmd = Command::new(PathBuf::from(bin_path));
     if let Some(parent_pid) = parent_pid {
         cmd.arg("--pid").arg(parent_pid.to_string());
     } else {
         cmd.arg("--port-file").arg(port_file_path.clone());
-        cmd.arg("--ready-file").arg(ready_file_path.clone());
     }
     if let Some(ttl) = ttl {
         cmd.arg("--ttl").arg(ttl.to_string());
@@ -68,15 +62,16 @@ fn start_server_helper(
     }
     let out = cmd.spawn().expect("Failed to start PocketIC binary");
     let url = loop {
-        match ready_file_path.try_exists() {
-            Ok(true) => {
-                let port_string = std::fs::read_to_string(port_file_path)
-                    .expect("Failed to read port from port file");
-                let port: u16 = port_string.parse().expect("Failed to parse port to number");
+        if let Ok(port_string) = std::fs::read_to_string(port_file_path.clone()) {
+            if port_string.contains("\n") {
+                let port: u16 = port_string
+                    .trim_end()
+                    .parse()
+                    .expect("Failed to parse port to number");
                 break Url::parse(&format!("http://{}:{}/", LOCALHOST, port)).unwrap();
             }
-            _ => std::thread::sleep(Duration::from_millis(20)),
         }
+        std::thread::sleep(Duration::from_millis(20));
     };
     (url, out)
 }
@@ -207,30 +202,8 @@ fn test_blob_store_wrong_encoding() {
 
 #[test]
 fn test_port_file() {
-    let bin_path = std::env::var_os("POCKET_IC_BIN").expect("Missing PocketIC binary");
-    let port_file_path = std::env::temp_dir().join("pocket_ic.port");
-    Command::new(PathBuf::from(bin_path))
-        .arg("--port-file")
-        .arg(
-            port_file_path
-                .clone()
-                .into_os_string()
-                .into_string()
-                .unwrap(),
-        )
-        .spawn()
-        .expect("Failed to start PocketIC binary");
-    loop {
-        if let Ok(port_string) = std::fs::read_to_string(port_file_path.clone()) {
-            if !port_string.is_empty() {
-                port_string
-                    .parse::<u16>()
-                    .expect("Failed to parse port to number");
-                break;
-            }
-        }
-        std::thread::sleep(Duration::from_millis(20));
-    }
+    // tests the port file by setting the parent PID to None in start_server_helper
+    start_server_helper(None, None, false, false);
 }
 
 async fn test_gateway(server_url: Url, https: bool) {


### PR DESCRIPTION
This PR drops the ready file from the PocketIC server.

Originally, the ready file was added to the PocketIC server for the sake of synchronization (or locking) - we want to have only one test in a cargo test suite start the PocketIC server and thus the individual tests need to agree who starts that server and what the port is:
- the port file is written atomically by the first test that manages to write that file atomically and that test starts the server and writes the port to the port file and afterwards creates the ready file;
- the other tests then poll for the ready file to exist and once it exists, they all know that they can read the port from the port file.

If the other tests attempted to read from the port file without knowing that it has been fully written, then we could get data races. However, we can simplify the code in this PR by getting rid of the ready file by checking for an end marker, e.g. the newline character `\n`, to learn that the port has been fully written.