### PR TITLE
chore(cmc): Use the CYCLES_LEDGER_CANISTER_ID constant in ic_nns_constants

### DIFF
--- a/rs/nns/cmc/src/lib.rs
+++ b/rs/nns/cmc/src/lib.rs
@@ -12,13 +12,6 @@ use icp_ledger::{
 use icrc_ledger_types::icrc1::account::Account;
 use serde::{Deserialize, Serialize};
 
-/// `um5iw-rqaaa-aaaaq-qaaba-cai`
-pub const CYCLES_LEDGER_CANISTER_ID: PrincipalId = PrincipalId::new(
-    10,
-    [
-        0, 0, 0, 0, 2, 16, 0, 2, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-    ],
-);
 pub const DEFAULT_CYCLES_PER_XDR: u128 = 1_000_000_000_000u128; // 1T cycles = 1 XDR
 
 pub const PERMYRIAD_DECIMAL_PLACES: u32 = 4;

--- a/rs/nns/integration_tests/src/cycles_minting_canister.rs
+++ b/rs/nns/integration_tests/src/cycles_minting_canister.rs
@@ -4,8 +4,8 @@ use cycles_minting_canister::{
     CanisterSettingsArgs, ChangeSubnetTypeAssignmentArgs, CreateCanister, CreateCanisterError,
     IcpXdrConversionRateCertifiedResponse, NotifyCreateCanister, NotifyError, NotifyMintCyclesArg,
     NotifyMintCyclesSuccess, SubnetListWithType, SubnetTypesToSubnetsResponse,
-    UpdateSubnetTypeArgs, BAD_REQUEST_CYCLES_PENALTY, CYCLES_LEDGER_CANISTER_ID,
-    MEMO_CREATE_CANISTER, MEMO_MINT_CYCLES, MEMO_TOP_UP_CANISTER,
+    UpdateSubnetTypeArgs, BAD_REQUEST_CYCLES_PENALTY, MEMO_CREATE_CANISTER, MEMO_MINT_CYCLES,
+    MEMO_TOP_UP_CANISTER,
 };
 use dfn_candid::candid_one;
 use dfn_protobuf::protobuf;
@@ -22,7 +22,8 @@ use ic_nervous_system_common_test_keys::{
 };
 use ic_nns_common::types::{NeuronId, ProposalId, UpdateIcpXdrConversionRatePayload};
 use ic_nns_constants::{
-    CYCLES_MINTING_CANISTER_ID, GOVERNANCE_CANISTER_ID, LEDGER_CANISTER_INDEX_IN_NNS_SUBNET,
+    CYCLES_LEDGER_CANISTER_ID, CYCLES_MINTING_CANISTER_ID, GOVERNANCE_CANISTER_ID,
+    LEDGER_CANISTER_INDEX_IN_NNS_SUBNET,
 };
 use ic_nns_governance_api::pb::v1::{NnsFunction, ProposalStatus};
 use ic_nns_test_utils::{
@@ -781,7 +782,7 @@ fn notify_mint_cycles(
 fn cycles_ledger_balance_of(state_machine: &StateMachine, account: Account) -> u128 {
     if let WasmResult::Reply(res) = state_machine
         .execute_ingress(
-            CYCLES_LEDGER_CANISTER_ID.try_into().unwrap(),
+            CYCLES_LEDGER_CANISTER_ID,
             "icrc1_balance_of",
             Encode!(&account).unwrap(),
         )

--- a/rs/nns/integration_tests/src/upgrade_canisters_with_golden_nns_state.rs
+++ b/rs/nns/integration_tests/src/upgrade_canisters_with_golden_nns_state.rs
@@ -1,12 +1,12 @@
 use candid::Encode;
-use cycles_minting_canister::{CyclesCanisterInitPayload, CYCLES_LEDGER_CANISTER_ID};
+use cycles_minting_canister::CyclesCanisterInitPayload;
 use ic_base_types::{CanisterId, PrincipalId};
 use ic_crypto_sha2::Sha256;
 use ic_nervous_system_clients::canister_status::CanisterStatusType;
 use ic_nns_constants::{
-    CYCLES_MINTING_CANISTER_ID, GENESIS_TOKEN_CANISTER_ID, GOVERNANCE_CANISTER_ID,
-    LEDGER_CANISTER_ID, LIFELINE_CANISTER_ID, REGISTRY_CANISTER_ID, ROOT_CANISTER_ID,
-    SNS_WASM_CANISTER_ID,
+    CYCLES_LEDGER_CANISTER_ID, CYCLES_MINTING_CANISTER_ID, GENESIS_TOKEN_CANISTER_ID,
+    GOVERNANCE_CANISTER_ID, LEDGER_CANISTER_ID, LIFELINE_CANISTER_ID, REGISTRY_CANISTER_ID,
+    ROOT_CANISTER_ID, SNS_WASM_CANISTER_ID,
 };
 use ic_nns_test_utils::{
     common::modify_wasm_bytes,
@@ -52,9 +52,7 @@ impl NnsCanisterUpgrade {
         let module_arg = if nns_canister_name == "cycles-minting" {
             Encode!(
                 &(Some(CyclesCanisterInitPayload {
-                    cycles_ledger_canister_id: Some(
-                        CanisterId::try_from(CYCLES_LEDGER_CANISTER_ID).unwrap()
-                    ),
+                    cycles_ledger_canister_id: Some(CYCLES_LEDGER_CANISTER_ID),
                     ledger_canister_id: None,
                     governance_canister_id: None,
                     minting_account_id: None,

--- a/rs/nns/test_utils/src/common.rs
+++ b/rs/nns/test_utils/src/common.rs
@@ -4,11 +4,12 @@ use core::{
     option::Option::{None, Some},
     time::Duration,
 };
-use cycles_minting_canister::{CyclesCanisterInitPayload, CYCLES_LEDGER_CANISTER_ID};
+use cycles_minting_canister::CyclesCanisterInitPayload;
 use ic_base_types::{CanisterId, PrincipalId, SubnetId};
 use ic_nns_common::init::{LifelineCanisterInitPayload, LifelineCanisterInitPayloadBuilder};
 use ic_nns_constants::{
-    ALL_NNS_CANISTER_IDS, GOVERNANCE_CANISTER_ID, LEDGER_CANISTER_ID, ROOT_CANISTER_ID,
+    ALL_NNS_CANISTER_IDS, CYCLES_LEDGER_CANISTER_ID, GOVERNANCE_CANISTER_ID, LEDGER_CANISTER_ID,
+    ROOT_CANISTER_ID,
 };
 use ic_nns_governance_api::pb::v1::{Governance, NetworkEconomics, Neuron};
 use ic_nns_governance_init::GovernanceCanisterInitPayloadBuilder;
@@ -86,7 +87,7 @@ impl NnsInitPayloadsBuilder {
                 exchange_rate_canister: None,
                 minting_account_id: Some(GOVERNANCE_CANISTER_ID.get().into()),
                 last_purged_notification: Some(1),
-                cycles_ledger_canister_id: Some(CYCLES_LEDGER_CANISTER_ID.try_into().unwrap()),
+                cycles_ledger_canister_id: Some(CYCLES_LEDGER_CANISTER_ID),
             }),
             lifeline: LifelineCanisterInitPayloadBuilder::new(),
             genesis_token: GenesisTokenCanisterInitPayloadBuilder::new(),

--- a/rs/nns/test_utils/src/state_test_helpers.rs
+++ b/rs/nns/test_utils/src/state_test_helpers.rs
@@ -7,7 +7,6 @@ use candid::{CandidType, Decode, Encode, Nat};
 use canister_test::Wasm;
 use cycles_minting_canister::{
     IcpXdrConversionRateCertifiedResponse, SetAuthorizedSubnetworkListArgs,
-    CYCLES_LEDGER_CANISTER_ID,
 };
 use dfn_candid::candid_one;
 use dfn_http::types::{HttpRequest, HttpResponse};
@@ -28,12 +27,12 @@ use ic_nervous_system_common::{
 use ic_nervous_system_root::change_canister::ChangeCanisterRequest;
 use ic_nns_common::pb::v1::{NeuronId, ProposalId};
 use ic_nns_constants::{
-    canister_id_to_nns_canister_name, memory_allocation_of, CYCLES_MINTING_CANISTER_ID,
-    GENESIS_TOKEN_CANISTER_ID, GOVERNANCE_CANISTER_ID, GOVERNANCE_CANISTER_INDEX_IN_NNS_SUBNET,
-    IDENTITY_CANISTER_ID, LEDGER_CANISTER_ID, LIFELINE_CANISTER_ID, NNS_UI_CANISTER_ID,
-    REGISTRY_CANISTER_ID, ROOT_CANISTER_ID, ROOT_CANISTER_INDEX_IN_NNS_SUBNET,
-    SNS_WASM_CANISTER_ID, SNS_WASM_CANISTER_INDEX_IN_NNS_SUBNET, SUBNET_RENTAL_CANISTER_ID,
-    SUBNET_RENTAL_CANISTER_INDEX_IN_NNS_SUBNET,
+    canister_id_to_nns_canister_name, memory_allocation_of, CYCLES_LEDGER_CANISTER_ID,
+    CYCLES_MINTING_CANISTER_ID, GENESIS_TOKEN_CANISTER_ID, GOVERNANCE_CANISTER_ID,
+    GOVERNANCE_CANISTER_INDEX_IN_NNS_SUBNET, IDENTITY_CANISTER_ID, LEDGER_CANISTER_ID,
+    LIFELINE_CANISTER_ID, NNS_UI_CANISTER_ID, REGISTRY_CANISTER_ID, ROOT_CANISTER_ID,
+    ROOT_CANISTER_INDEX_IN_NNS_SUBNET, SNS_WASM_CANISTER_ID, SNS_WASM_CANISTER_INDEX_IN_NNS_SUBNET,
+    SUBNET_RENTAL_CANISTER_ID, SUBNET_RENTAL_CANISTER_INDEX_IN_NNS_SUBNET,
 };
 use ic_nns_governance_api::pb::v1::{
     self as nns_governance_pb,
@@ -2000,13 +1999,13 @@ pub fn setup_cycles_ledger(state_machine: &StateMachine) {
 
     state_machine.reroute_canister_range(
         std::ops::RangeInclusive::<CanisterId>::new(
-            CYCLES_LEDGER_CANISTER_ID.try_into().unwrap(),
-            CYCLES_LEDGER_CANISTER_ID.try_into().unwrap(),
+            CYCLES_LEDGER_CANISTER_ID,
+            CYCLES_LEDGER_CANISTER_ID,
         ),
         state_machine.get_subnet_id(),
     );
     state_machine.create_canister_with_cycles(
-        Some(CYCLES_LEDGER_CANISTER_ID),
+        Some(CYCLES_LEDGER_CANISTER_ID.get()),
         Cycles::zero(),
         None,
     );
@@ -2020,11 +2019,7 @@ pub fn setup_cycles_ledger(state_machine: &StateMachine) {
     }))
     .unwrap();
     state_machine
-        .install_existing_canister(
-            CYCLES_LEDGER_CANISTER_ID.try_into().unwrap(),
-            cycles_ledger_wasm,
-            arg,
-        )
+        .install_existing_canister(CYCLES_LEDGER_CANISTER_ID, cycles_ledger_wasm, arg)
         .expect("Installing cycles ledger failed");
 }
 

--- a/testnet/tools/nns-tools/README.md
+++ b/testnet/tools/nns-tools/README.md
@@ -79,9 +79,7 @@ Sometimes we prepare a canister release that requires a special upgrade argument
 let module_arg = if nns_canister_name == "cycles-minting" {
     Encode!(
         &(Some(CyclesCanisterInitPayload {
-            cycles_ledger_canister_id: Some(
-                CanisterId::try_from(CYCLES_LEDGER_CANISTER_ID).unwrap()
-            ),
+            cycles_ledger_canister_id: Some(CYCLES_LEDGER_CANISTER_ID),
             ledger_canister_id: None,
             governance_canister_id: None,
             minting_account_id: None,


### PR DESCRIPTION
# Why

The cycles ledger canister id constant is defined in a different way than other NNS canister ids.

# What

Use the constant already defined in ic_nns_constants.
