### PR TITLE
chore(consensus): remove `Meta` database from the `ConsensusPool`

### DIFF
--- a/rs/artifact_pool/BUILD.bazel
+++ b/rs/artifact_pool/BUILD.bazel
@@ -86,9 +86,9 @@ rust_test(
 )
 
 rust_bench(
-    name = "load_blocks_bench",
+    name = "consensus_pool_bench",
     testonly = True,
-    srcs = ["benches/load_blocks.rs"],
+    srcs = ["benches/consensus_pool.rs"],
     aliases = ALIASES,
     proc_macro_deps = MACRO_DEPENDENCIES + DEV_MACRO_DEPENDENCIES,
     deps = DEPENDENCIES + DEV_DEPENDENCIES + [":artifact_pool"],

--- a/rs/artifact_pool/Cargo.toml
+++ b/rs/artifact_pool/Cargo.toml
@@ -51,7 +51,7 @@ slog-envlogger = "2.2.0"
 slog-term = { workspace = true }
 
 [[bench]]
-name = "load_blocks"
+name = "consensus_pool"
 harness = false
 
 [[bin]]

--- a/rs/artifact_pool/src/lmdb_pool.rs
+++ b/rs/artifact_pool/src/lmdb_pool.rs
@@ -551,8 +551,6 @@ impl<Artifact: PoolArtifact> PersistentHeightIndexedPool<Artifact> {
 
         let index_db = self.get_index_db(&key.type_key);
         tx.del(index_db, &key.height_key, Some(&key.id_key.0))
-        //let min_height = tx_get_key(tx, index_db, GetOp::First)?;
-        //let max_height = tx_get_key(tx, index_db, GetOp::Last)?;
     }
 
     /// Remove all index entries for the given [`TypeKey`] with heights
@@ -705,8 +703,8 @@ where
     fn height_range(&self) -> Option<HeightRange> {
         let tx = log_err!(self.db_env.begin_ro_txn(), self.log, "begin_ro_txn")?;
         let index_db = self.get_index_db(&Message::type_key());
-        let min_height = tx_get_key(&tx, index_db, GetOp::First).ok()??;
-        let max_height = tx_get_key(&tx, index_db, GetOp::Last).ok()??;
+        let min_height = tx_get_key(&tx, index_db, GetOp::First).ok().flatten()?;
+        let max_height = tx_get_key(&tx, index_db, GetOp::Last).ok().flatten()?;
 
         Some(HeightRange::new(
             Height::from(min_height),

--- a/rs/artifact_pool/src/lmdb_pool.rs
+++ b/rs/artifact_pool/src/lmdb_pool.rs
@@ -89,7 +89,6 @@ use strum::{AsRefStr, FromRepr, IntoEnumIterator};
 pub(crate) struct PersistentHeightIndexedPool<T> {
     pool_type: PhantomData<T>,
     db_env: Arc<Environment>,
-    meta: Database,
     artifacts: Database,
     indices: Vec<(TypeKey, Database)>,
     log: ReplicaLogger,
@@ -427,15 +426,6 @@ impl<Artifact: PoolArtifact> PersistentHeightIndexedPool<Artifact> {
         let db_env = create_db_env(path, read_only, (Artifact::TYPE_KEYS.len() + 2) as c_uint);
 
         // Create all databases.
-        let meta = if read_only {
-            db_env
-                .open_db(Some("META"))
-                .unwrap_or_else(|err| panic!("Error opening db for metadata: {:?}", err))
-        } else {
-            db_env
-                .create_db(Some("META"), DatabaseFlags::empty())
-                .unwrap_or_else(|err| panic!("Error creating db for metadata: {:?}", err))
-        };
         let artifacts = if read_only {
             db_env
                 .open_db(Some("ARTS"))
@@ -468,40 +458,10 @@ impl<Artifact: PoolArtifact> PersistentHeightIndexedPool<Artifact> {
         Self {
             pool_type: PhantomData,
             db_env: Arc::new(db_env),
-            meta,
             artifacts,
             indices,
             log,
         }
-    }
-
-    /// Update the meta data of the given type_key.
-    fn update_meta(
-        &self,
-        tx: &mut RwTransaction,
-        type_key: &TypeKey,
-        meta: &Meta,
-    ) -> lmdb::Result<()> {
-        if let Some(bytes) = log_err!(
-            bincode::serialize::<Meta>(meta),
-            self.log,
-            "update_meta serialize"
-        ) {
-            tx.put(self.meta, &type_key, &bytes, WriteFlags::empty())
-        } else {
-            Err(lmdb::Error::Panic)
-        }
-    }
-
-    /// Get the meta data of the given type_key.
-    fn get_meta<Tx: Transaction>(&self, tx: &mut Tx, type_key: &TypeKey) -> Option<Meta> {
-        log_err_except!(
-            tx.get(self.meta, &type_key),
-            self.log,
-            lmdb::Error::NotFound,
-            format!("get_meta {:?}", type_key)
-        )
-        .and_then(|bytes| bincode::deserialize::<Meta>(bytes).ok())
     }
 
     /// Get the index database of the given type_key.
@@ -575,19 +535,7 @@ impl<Artifact: PoolArtifact> PersistentHeightIndexedPool<Artifact> {
             &key.height_key,
             &key.id_key,
             WriteFlags::NO_DUP_DATA,
-        )?;
-        // update meta
-        let meta = self
-            .get_meta(tx, &key.type_key)
-            .map(|meta| Meta {
-                min: meta.min.min(key.height_key),
-                max: meta.max.max(key.height_key),
-            })
-            .unwrap_or(Meta {
-                min: key.height_key,
-                max: key.height_key,
-            });
-        self.update_meta(tx, &key.type_key, &meta)
+        )
     }
 
     /// Remove the pool object of the given type/height/id key.
@@ -602,21 +550,13 @@ impl<Artifact: PoolArtifact> PersistentHeightIndexedPool<Artifact> {
         }
 
         let index_db = self.get_index_db(&key.type_key);
-        tx.del(index_db, &key.height_key, Some(&key.id_key.0))?;
-
-        let min_height = tx_get_key(tx, index_db, GetOp::First)?;
-        let max_height = tx_get_key(tx, index_db, GetOp::Last)?;
-
-        match (min_height, max_height) {
-            (Some(min), Some(max)) => self.update_meta(tx, &key.type_key, &Meta { min, max }),
-            (Some(min), None) => self.update_meta(tx, &key.type_key, &Meta { min, max: min }),
-            _ => tx.del(self.meta, &key.type_key, None),
-        }
+        tx.del(index_db, &key.height_key, Some(&key.id_key.0))
+        //let min_height = tx_get_key(tx, index_db, GetOp::First)?;
+        //let max_height = tx_get_key(tx, index_db, GetOp::Last)?;
     }
 
     /// Remove all index entries for the given [`TypeKey`] with heights
-    /// less than the given [`HeightKey`]. Update the type's meta table
-    /// if necessary. Return the [`ArtifactKey`]s of deleted entries.
+    /// less than the given [`HeightKey`] and return the [`ArtifactKey`]s of deleted entries.
     fn tx_purge_index_below(
         &self,
         tx: &mut RwTransaction,
@@ -624,44 +564,20 @@ impl<Artifact: PoolArtifact> PersistentHeightIndexedPool<Artifact> {
         height_key: HeightKey,
     ) -> lmdb::Result<Vec<ArtifactKey>> {
         let mut artifact_ids = Vec::new();
-        // only delete if meta exists
-        if let Some(meta) = self.get_meta(tx, &type_key) {
-            // nothing to delete if min height is already higher
-            if meta.min >= height_key {
-                return Ok(artifact_ids);
+
+        let index_db = self.get_index_db(&type_key);
+        let mut cursor = tx.open_rw_cursor(index_db)?;
+
+        while let Some((key, id)) = cursor.iter().next().transpose()? {
+            if HeightKey::from(key) >= height_key {
+                break;
             }
-
-            let index_db = self.get_index_db(&type_key);
-            {
-                let mut cursor = tx.open_rw_cursor(index_db)?;
-
-                while let Some((key, id)) = cursor.iter().next().transpose()? {
-                    if HeightKey::from(key) >= height_key {
-                        break;
-                    }
-                    artifact_ids.push(ArtifactKey {
-                        type_key,
-                        height_key: HeightKey::from(key),
-                        id_key: IdKey::from(id),
-                    });
-                    cursor.del(WriteFlags::empty())?;
-                }
-            }
-
-            // update meta
-            let meta = if meta.max < height_key {
-                None
-            } else {
-                tx_get_key(tx, index_db, GetOp::First)?.map(|key| Meta {
-                    min: key,
-                    max: meta.max,
-                })
-            };
-
-            match meta {
-                None => tx.del(self.meta, &type_key, None)?,
-                Some(meta) => self.update_meta(tx, &type_key, &meta)?,
-            }
+            artifact_ids.push(ArtifactKey {
+                type_key,
+                height_key: HeightKey::from(key),
+                id_key: IdKey::from(id),
+            });
+            cursor.del(WriteFlags::empty())?;
         }
 
         Ok(artifact_ids)
@@ -787,9 +703,15 @@ where
     <Message as TryFrom<Artifact>>::Error: Debug,
 {
     fn height_range(&self) -> Option<HeightRange> {
-        let mut tx = log_err!(self.db_env.begin_ro_txn(), self.log, "begin_ro_txn")?;
-        self.get_meta(&mut tx, &Message::type_key())
-            .map(|meta| HeightRange::new(Height::from(meta.min), Height::from(meta.max)))
+        let tx = log_err!(self.db_env.begin_ro_txn(), self.log, "begin_ro_txn")?;
+        let index_db = self.get_index_db(&Message::type_key());
+        let min_height = tx_get_key(&tx, index_db, GetOp::First).ok()??;
+        let max_height = tx_get_key(&tx, index_db, GetOp::Last).ok()??;
+
+        Some(HeightRange::new(
+            Height::from(min_height),
+            Height::from(max_height),
+        ))
     }
 
     fn max_height(&self) -> Option<Height> {


### PR DESCRIPTION
The purpose of `Meta` was to keep track of the maximum and the minimum heights in the lmdb pools.
It's not strictly necessary as we can compute these numbers on the fly by looking at the first/last entries in the pools, which should be reasonably fast.
Removing `Meta` means we don't have to keep multiple databases in sync, which is error prone and leads to bugs like in https://github.com/dfinity/ic/pull/598
