### PR TITLE
fix(execution): Canister snapshots should include Wasm globals

### DIFF
--- a/rs/execution_environment/src/canister_manager.rs
+++ b/rs/execution_environment/src/canister_manager.rs
@@ -2140,6 +2140,7 @@ impl CanisterManager {
                 }
             };
 
+            new_execution_state.exported_globals = execution_snapshot.exported_globals.clone();
             new_execution_state.stable_memory = Memory::from(&execution_snapshot.stable_memory);
             new_execution_state.wasm_memory = Memory::from(&execution_snapshot.wasm_memory);
             (instructions_used, Some(new_execution_state))

--- a/rs/execution_environment/src/execution_environment/tests/canister_snapshots.rs
+++ b/rs/execution_environment/src/execution_environment/tests/canister_snapshots.rs
@@ -1757,10 +1757,7 @@ fn snapshot_must_include_globals() {
         .build();
 
     // Create canister.
-    const CYCLES: Cycles = Cycles::new(1_000_000_000_000_000);
-    let canister_id = test.canister_from_cycles_and_binary(CYCLES, wasm).unwrap();
-    test.canister_update_reserved_cycles_limit(canister_id, CYCLES)
-        .unwrap();
+    let canister_id = test.canister_from_binary(wasm).unwrap();
 
     // Check that global is initially 0
     let result = test

--- a/rs/execution_environment/src/execution_environment/tests/canister_snapshots.rs
+++ b/rs/execution_environment/src/execution_environment/tests/canister_snapshots.rs
@@ -1752,17 +1752,12 @@ fn snapshot_must_include_globals() {
       )"#;
     let wasm = wat::parse_str(wat).unwrap();
 
-    const CYCLES: Cycles = Cycles::new(1_000_000_000_000_000);
-    let own_subnet = subnet_test_id(1);
-    let caller_canister = canister_test_id(1);
-
     let mut test = ExecutionTestBuilder::new()
-        .with_own_subnet_id(own_subnet)
         .with_snapshots(FlagStatus::Enabled)
-        .with_caller(own_subnet, caller_canister)
         .build();
 
     // Create canister.
+    const CYCLES: Cycles = Cycles::new(1_000_000_000_000_000);
     let canister_id = test.canister_from_cycles_and_binary(CYCLES, wasm).unwrap();
     test.canister_update_reserved_cycles_limit(canister_id, CYCLES)
         .unwrap();

--- a/rs/protobuf/def/state/canister_snapshot_bits/v1/canister_snapshot_bits.proto
+++ b/rs/protobuf/def/state/canister_snapshot_bits/v1/canister_snapshot_bits.proto
@@ -15,4 +15,5 @@ message CanisterSnapshotBits {
   uint64 stable_memory_size = 8;
   uint64 wasm_memory_size = 9;
   uint64 total_size = 10;
+  repeated canister_state_bits.v1.Global exported_globals = 11;
 }

--- a/rs/protobuf/src/gen/state/state.canister_snapshot_bits.v1.rs
+++ b/rs/protobuf/src/gen/state/state.canister_snapshot_bits.v1.rs
@@ -22,4 +22,6 @@ pub struct CanisterSnapshotBits {
     pub wasm_memory_size: u64,
     #[prost(uint64, tag = "10")]
     pub total_size: u64,
+    #[prost(message, repeated, tag = "11")]
+    pub exported_globals: ::prost::alloc::vec::Vec<super::super::canister_state_bits::v1::Global>,
 }

--- a/rs/replicated_state/src/canister_snapshots.rs
+++ b/rs/replicated_state/src/canister_snapshots.rs
@@ -287,6 +287,7 @@ pub struct ExecutionStateSnapshot {
     /// The Wasm global variables.
     /// Note: The hypervisor instrumentations exports all global variables,
     /// including originally internal global variables.
+    #[validate_eq(Ignore)]
     pub exported_globals: Vec<Global>,
     /// Snapshot of stable memory.
     #[validate_eq(CompareWithValidateEq)]

--- a/rs/replicated_state/src/canister_snapshots.rs
+++ b/rs/replicated_state/src/canister_snapshots.rs
@@ -1,7 +1,7 @@
 use crate::{
-    canister_state::execution_state::Memory,
-    canister_state::system_state::wasm_chunk_store::WasmChunkStore, CanisterState, NumWasmPages,
-    PageMap,
+    canister_state::execution_state::{Global, Memory},
+    canister_state::system_state::wasm_chunk_store::WasmChunkStore,
+    CanisterState, NumWasmPages, PageMap,
 };
 use ic_sys::PAGE_SIZE;
 use ic_types::{CanisterId, NumBytes, SnapshotId, Time};
@@ -284,6 +284,10 @@ pub struct ExecutionStateSnapshot {
     /// The raw canister module.
     #[validate_eq(Ignore)]
     pub wasm_binary: CanisterModule,
+    /// The Wasm global variables.
+    /// Note: The hypervisor instrumentations exports all global variables,
+    /// including originally internal global variables.
+    pub exported_globals: Vec<Global>,
     /// Snapshot of stable memory.
     #[validate_eq(CompareWithValidateEq)]
     pub stable_memory: PageMemory,
@@ -345,6 +349,7 @@ impl CanisterSnapshot {
             .ok_or(CanisterSnapshotError::EmptyExecutionState(canister_id))?;
         let execution_snapshot = ExecutionStateSnapshot {
             wasm_binary: execution_state.wasm_binary.binary.clone(),
+            exported_globals: execution_state.exported_globals.clone(),
             stable_memory: PageMemory::from(&execution_state.stable_memory),
             wasm_memory: PageMemory::from(&execution_state.wasm_memory),
         };
@@ -390,6 +395,10 @@ impl CanisterSnapshot {
 
     pub fn canister_module(&self) -> &CanisterModule {
         &self.execution_snapshot.wasm_binary
+    }
+
+    pub fn exported_globals(&self) -> &Vec<Global> {
+        &self.execution_snapshot.exported_globals
     }
 
     pub fn chunk_store(&self) -> &WasmChunkStore {
@@ -457,6 +466,7 @@ mod tests {
     ) -> (SnapshotId, CanisterSnapshot) {
         let execution_snapshot = ExecutionStateSnapshot {
             wasm_binary: CanisterModule::new(vec![1, 2, 3]),
+            exported_globals: vec![Global::I32(1), Global::I64(2), Global::F64(0.1)],
             stable_memory: PageMemory {
                 page_map: PageMap::new_for_testing(),
                 size: NumWasmPages::new(10),

--- a/rs/replicated_state/src/canister_state/execution_state.rs
+++ b/rs/replicated_state/src/canister_state/execution_state.rs
@@ -106,6 +106,8 @@ impl PartialEq<Global> for Global {
     }
 }
 
+impl Eq for Global {}
+
 impl From<&Global> for pb::Global {
     fn from(item: &Global) -> Self {
         match item {

--- a/rs/state_layout/src/state_layout.rs
+++ b/rs/state_layout/src/state_layout.rs
@@ -201,6 +201,8 @@ pub struct CanisterSnapshotBits {
     pub wasm_memory_size: NumWasmPages,
     /// The total size of the snapshot in bytes.
     pub total_size: NumBytes,
+    /// State of the exported Wasm globals.
+    pub exported_globals: Vec<Global>,
 }
 
 #[derive(Clone)]
@@ -2513,6 +2515,11 @@ impl From<CanisterSnapshotBits> for pb_canister_snapshot_bits::CanisterSnapshotB
             stable_memory_size: item.stable_memory_size.get() as u64,
             wasm_memory_size: item.wasm_memory_size.get() as u64,
             total_size: item.total_size.get(),
+            exported_globals: item
+                .exported_globals
+                .iter()
+                .map(|global| global.into())
+                .collect(),
         }
     }
 }
@@ -2537,6 +2544,12 @@ impl TryFrom<pb_canister_snapshot_bits::CanisterSnapshotBits> for CanisterSnapsh
             }
             None => None,
         };
+
+        let mut exported_globals = Vec::with_capacity(item.exported_globals.len());
+        for global in item.exported_globals.into_iter() {
+            exported_globals.push(global.try_into()?);
+        }
+
         Ok(Self {
             snapshot_id: SnapshotId::from((canister_id, item.snapshot_id)),
             canister_id,
@@ -2552,6 +2565,7 @@ impl TryFrom<pb_canister_snapshot_bits::CanisterSnapshotBits> for CanisterSnapsh
             stable_memory_size: NumWasmPages::from(item.stable_memory_size as usize),
             wasm_memory_size: NumWasmPages::from(item.wasm_memory_size as usize),
             total_size: NumBytes::from(item.total_size),
+            exported_globals,
         })
     }
 }

--- a/rs/state_layout/src/state_layout/tests.rs
+++ b/rs/state_layout/src/state_layout/tests.rs
@@ -212,6 +212,7 @@ fn test_canister_snapshots_decode() {
         stable_memory_size: NumWasmPages::new(10),
         wasm_memory_size: NumWasmPages::new(10),
         total_size: NumBytes::new(100),
+        exported_globals: vec![Global::I32(1), Global::I64(2), Global::F64(3.141)],
     };
 
     let pb_bits =

--- a/rs/state_layout/src/state_layout/tests.rs
+++ b/rs/state_layout/src/state_layout/tests.rs
@@ -212,7 +212,7 @@ fn test_canister_snapshots_decode() {
         stable_memory_size: NumWasmPages::new(10),
         wasm_memory_size: NumWasmPages::new(10),
         total_size: NumBytes::new(100),
-        exported_globals: vec![Global::I32(1), Global::I64(2), Global::F64(3.141)],
+        exported_globals: vec![Global::I32(1), Global::I64(2), Global::F64(0.1)],
     };
 
     let pb_bits =

--- a/rs/state_manager/src/checkpoint.rs
+++ b/rs/state_manager/src/checkpoint.rs
@@ -579,8 +579,11 @@ pub fn load_snapshot<P: ReadPolicy>(
             .deserialize(canister_snapshot_bits.binary_hash)?;
         durations.insert("snapshot_canister_module", starting_time.elapsed());
 
+        let exported_globals = canister_snapshot_bits.exported_globals.clone();
+
         ExecutionStateSnapshot {
             wasm_binary,
+            exported_globals,
             stable_memory,
             wasm_memory,
         }

--- a/rs/state_manager/src/tip.rs
+++ b/rs/state_manager/src/tip.rs
@@ -1076,6 +1076,7 @@ fn serialize_snapshot_to_tip(
             stable_memory_size: canister_snapshot.stable_memory().size,
             wasm_memory_size: canister_snapshot.wasm_memory().size,
             total_size: canister_snapshot.size(),
+            exported_globals: canister_snapshot.exported_globals().clone(),
         }
         .into(),
     )?;


### PR DESCRIPTION
Currently, the canister snapshots do not cover the state of Wasm global variables, such that in realistic canister programs with mutable global variables, the state is not properly recovered when a snapshot is loaded.

This fix adds the Wasm globals to the snapshot state, similar to the execution state. (Side note: All Wasm variables are exported by the Wasm instrumentation.)