### PR TITLE
chore(fuzzing): increase maximum timeout for AFL fuzzers from 5s to 20s

### DIFF
--- a/bin/afl_wrapper.sh
+++ b/bin/afl_wrapper.sh
@@ -93,7 +93,7 @@ function afl_env() {
         AFL_IGNORE_TIMEOUTS=1 \
         AFL_KEEP_TIMEOUTS=1 \
         AFL_SKIP_CPUFREQ=1 \
-        /usr/local/bin/afl-fuzz -t +5000 $@
+        /usr/local/bin/afl-fuzz -t +20000 $@
 }
 
 # To run multiple fuzzers in parallel, use the AFL_PARALLEL env variable


### PR DESCRIPTION
On latest master, some fuzzers have trouble coming up within the 5s timeout. This PR bumps the default maximum timeout from 5s to 20s. Note, the timeout for the fuzzer is still auto calculated but 20s is the ceiling. 