### PR TITLE
fix: Fix missing log function

### DIFF
--- a/ic-os/components/misc/fetch-property.sh
+++ b/ic-os/components/misc/fetch-property.sh
@@ -6,6 +6,8 @@ set -o pipefail
 
 # Fetch configuration property
 
+source /opt/ic/bin/logging.sh
+
 SCRIPT="$(basename $0)[$$]"
 
 # Get keyword arguments

--- a/ic-os/components/setupos.bzl
+++ b/ic-os/components/setupos.bzl
@@ -25,6 +25,7 @@ component_files = {
     Label("early-boot/initramfs-tools/setupos/initramfs.conf"): "/etc/initramfs-tools/initramfs.conf",
 
     # misc
+    Label("misc/logging.sh"): "/opt/ic/bin/logging.sh",
     Label("misc/chrony/chrony.conf"): "/etc/chrony/chrony.conf",
     Label("misc/chrony/chrony-var.service"): "/etc/systemd/system/chrony-var.service",
     Label("misc/fetch-property.sh"): "/opt/ic/bin/fetch-property.sh",


### PR DESCRIPTION
https://github.com/dfinity/ic/pull/1202 missed an import in `fetch-property.sh`, which fails when deploying HostOS. This was picked up by nightly bare metal testing.