### PR TITLE
fix(snapshots): Compute the correct subnet available memory after snapshot operations

### DIFF
--- a/rs/execution_environment/src/canister_manager.rs
+++ b/rs/execution_environment/src/canister_manager.rs
@@ -1912,10 +1912,10 @@ impl CanisterManager {
             // Verify that the subnet has enough memory for a new snapshot.
             if let Err(err) = round_limits
                 .subnet_available_memory
-                .check_available_memory(new_snapshot_size, NumBytes::from(0), NumBytes::from(0))
+                .check_available_memory(new_snapshot_increase, NumBytes::from(0), NumBytes::from(0))
                 .map_err(
                     |_| CanisterManagerError::SubnetMemoryCapacityOverSubscribed {
-                        requested: new_snapshot_size,
+                        requested: new_snapshot_increase,
                         available: NumBytes::from(
                             round_limits
                                 .subnet_available_memory
@@ -1951,11 +1951,6 @@ impl CanisterManager {
             {
                 return (Err(err), NumInstructions::new(0));
             };
-            // Actually deduct memory from the subnet. It's safe to unwrap
-            // here because we already checked the available memory above.
-            round_limits.subnet_available_memory
-                        .try_decrement(new_snapshot_size, NumBytes::from(0), NumBytes::from(0))
-                        .expect("Error: Cannot fail to decrement SubnetAvailableMemory after checking for availability");
         }
 
         // Charge for taking a snapshot of the canister.
@@ -1997,7 +1992,18 @@ impl CanisterManager {
                     .canister_snapshots
                     .compute_memory_usage_by_canister(canister.canister_id()),
             );
+            round_limits.subnet_available_memory.increment(
+                replace_snapshot_size,
+                NumBytes::from(0),
+                NumBytes::from(0),
+            );
         }
+
+        // Actually deduct memory from the subnet. It's safe to unwrap
+        // here because we already checked the available memory above.
+        round_limits.subnet_available_memory
+            .try_decrement(new_snapshot_size, NumBytes::from(0), NumBytes::from(0))
+            .expect("Error: Cannot fail to decrement SubnetAvailableMemory after checking for availability");
 
         if self.config.rate_limiting_of_heap_delta == FlagStatus::Enabled {
             canister.scheduler_state.heap_delta_debit += new_snapshot.heap_delta();
@@ -2239,6 +2245,7 @@ impl CanisterManager {
         canister: &mut CanisterState,
         delete_snapshot_id: SnapshotId,
         state: &mut ReplicatedState,
+        round_limits: &mut RoundLimits,
     ) -> Result<(), CanisterManagerError> {
         // Check sender is a controller.
         validate_controller(canister, &sender)?;
@@ -2262,7 +2269,7 @@ impl CanisterManager {
             }
         }
         let old_snapshot = state.canister_snapshots.remove(delete_snapshot_id);
-        // Already confirmed that `replace_snapshot` exists.
+        // Already confirmed that `old_snapshot` exists.
         let old_snapshot_size = old_snapshot.unwrap().size();
         canister.system_state.snapshots_memory_usage = canister
             .system_state
@@ -2276,6 +2283,11 @@ impl CanisterManager {
             state
                 .canister_snapshots
                 .compute_memory_usage_by_canister(canister.canister_id()),
+        );
+        round_limits.subnet_available_memory.increment(
+            old_snapshot_size,
+            NumBytes::from(0),
+            NumBytes::from(0),
         );
         Ok(())
     }

--- a/rs/execution_environment/src/execution_environment.rs
+++ b/rs/execution_environment/src/execution_environment.rs
@@ -1500,7 +1500,7 @@ impl ExecutionEnvironment {
             Ok(Ic00Method::DeleteCanisterSnapshot) => match self.config.canister_snapshots {
                 FlagStatus::Enabled => {
                     let res = DeleteCanisterSnapshotArgs::decode(payload).and_then(|args| {
-                        self.delete_canister_snapshot(*msg.sender(), &mut state, args)
+                        self.delete_canister_snapshot(*msg.sender(), &mut state, args, round_limits)
                     });
                     ExecuteSubnetMessageResult::Finished {
                         response: res,
@@ -2193,6 +2193,7 @@ impl ExecutionEnvironment {
         sender: PrincipalId,
         state: &mut ReplicatedState,
         args: DeleteCanisterSnapshotArgs,
+        round_limits: &mut RoundLimits,
     ) -> Result<Vec<u8>, UserError> {
         let canister_id = args.get_canister_id();
         // Take canister out.
@@ -2208,7 +2209,13 @@ impl ExecutionEnvironment {
 
         let result = self
             .canister_manager
-            .delete_canister_snapshot(sender, &mut canister, args.get_snapshot_id(), state)
+            .delete_canister_snapshot(
+                sender,
+                &mut canister,
+                args.get_snapshot_id(),
+                state,
+                round_limits,
+            )
             .map(|()| EmptyBlob.encode())
             .map_err(|err| err.into());
 

--- a/rs/execution_environment/src/execution_environment/tests/canister_snapshots.rs
+++ b/rs/execution_environment/src/execution_environment/tests/canister_snapshots.rs
@@ -691,6 +691,7 @@ fn canister_snapshot_reserves_cycles_difference() {
     assert!(
         reserved_cycles_after_a_new_snapshot
             > reserved_cycles_after_snapshot_1 + reserved_cycles_after_snapshot_1
+                - reserved_cycles_after_snapshot_2
     );
 }
 
@@ -736,6 +737,115 @@ fn take_canister_snapshot_fails_subnet_memory_exceeded() {
     if let Err(err) = result {
         assert_eq!(err.code(), ErrorCode::SubnetOversubscribed);
     }
+}
+
+#[test]
+fn take_canister_snapshot_works_when_enough_subnet_memory_after_replacing_old_snapshot() {
+    const CYCLES: Cycles = Cycles::new(20_000_000_000_000);
+    const CAPACITY: u64 = 500 * 1024 * 1024; // 500 MiB
+    const THRESHOLD: u64 = CAPACITY / 2;
+
+    let mut test = ExecutionTestBuilder::new()
+        .with_snapshots(FlagStatus::Enabled)
+        .with_heap_delta_rate_limit(NumBytes::new(1_000_000_000))
+        .with_subnet_execution_memory(CAPACITY as i64)
+        .with_subnet_memory_reservation(0)
+        .with_subnet_memory_threshold(THRESHOLD as i64)
+        .build();
+
+    let mut canisters = vec![];
+    // Create 2 canisters that use 100MiB of memory. This should allow for having 2 snapshots of them as
+    // well with 500MiB capacity but not for a third one (unless it replaces one of the previous ones).
+    for _ in 0..2 {
+        // Create canister.
+        let canister_id = test
+            .canister_from_cycles_and_binary(CYCLES, UNIVERSAL_CANISTER_WASM.into())
+            .unwrap();
+        test.canister_update_reserved_cycles_limit(canister_id, CYCLES)
+            .unwrap();
+
+        // Grow the canister's memory before taking a snapshot.
+        test.ingress(
+            canister_id,
+            "update",
+            wasm()
+                .memory_size_is_at_least(100 * 1024 * 1024) // 100 MiB
+                .reply_data(&[42])
+                .build(),
+        )
+        .unwrap();
+        canisters.push(canister_id);
+    }
+
+    // Take a snapshot of first canister.
+    let args: TakeCanisterSnapshotArgs = TakeCanisterSnapshotArgs::new(canisters[0], None);
+    let result = test
+        .subnet_message("take_canister_snapshot", args.encode())
+        .unwrap();
+    let snapshot_id = CanisterSnapshotResponse::decode(&result.bytes())
+        .unwrap()
+        .snapshot_id();
+
+    // Taking a snapshot of second canister.
+    let args: TakeCanisterSnapshotArgs = TakeCanisterSnapshotArgs::new(canisters[1], None);
+    test.subnet_message("take_canister_snapshot", args.encode())
+        .unwrap();
+
+    // Grow the first canister's memory before taking another snapshot.
+    test.ingress(
+        canisters[0],
+        "update",
+        wasm()
+            .memory_size_is_at_least(120 * 1024 * 1024) // 120 MiB
+            .reply_data(&[42])
+            .build(),
+    )
+    .unwrap();
+
+    // Taking another snapshot of the first canister while replacing the old one
+    // should work.
+    let args: TakeCanisterSnapshotArgs =
+        TakeCanisterSnapshotArgs::new(canisters[0], Some(snapshot_id));
+    test.subnet_message("take_canister_snapshot", args.encode())
+        .unwrap();
+}
+
+#[test]
+fn take_canister_snapshot_does_not_reduce_subnet_available_memory_when_failing_to_create_snapshot()
+{
+    const CYCLES: Cycles = Cycles::new(20_000_000_000_000);
+    const CAPACITY: u64 = 500 * 1024 * 1024; // 500 MiB
+    const THRESHOLD: u64 = CAPACITY / 2;
+
+    let mut test = ExecutionTestBuilder::new()
+        .with_snapshots(FlagStatus::Enabled)
+        .with_heap_delta_rate_limit(NumBytes::new(1_000_000_000))
+        .with_subnet_execution_memory(CAPACITY as i64)
+        .with_subnet_memory_reservation(0)
+        .with_subnet_memory_threshold(THRESHOLD as i64)
+        .build();
+
+    let canister_id = test.create_canister(CYCLES);
+
+    let subnet_available_memory_before_taking_snapshot =
+        test.subnet_available_memory().get_execution_memory();
+
+    // Take a snapshot of the canister, should fail because the canister is empty.
+    let args: TakeCanisterSnapshotArgs = TakeCanisterSnapshotArgs::new(canister_id, None);
+    let result = test.subnet_message("take_canister_snapshot", args.encode());
+    assert_eq!(
+        result.unwrap_err().code(),
+        ErrorCode::CanisterRejectedMessage
+    );
+
+    let subnet_available_memory_after_taking_snapshot =
+        test.subnet_available_memory().get_execution_memory();
+
+    // Since the snapshot was not created, the subnet available memory should not have changed.
+    assert_eq!(
+        subnet_available_memory_before_taking_snapshot,
+        subnet_available_memory_after_taking_snapshot
+    );
 }
 
 #[test]
@@ -1029,10 +1139,16 @@ fn delete_canister_snapshot_fails_snapshot_does_not_belong_to_canister() {
 #[test]
 fn delete_canister_snapshot_succeeds() {
     const CYCLES: Cycles = Cycles::new(1_000_000_000_000);
+    const CAPACITY: u64 = 1_000_000_000_000;
+    const THRESHOLD: u64 = CAPACITY / 2;
+
     let own_subnet = subnet_test_id(1);
     let caller_canister = canister_test_id(1);
     let mut test = ExecutionTestBuilder::new()
         .with_own_subnet_id(own_subnet)
+        .with_subnet_execution_memory(CAPACITY as i64)
+        .with_subnet_memory_reservation(0)
+        .with_subnet_memory_threshold(THRESHOLD as i64)
         .with_snapshots(FlagStatus::Enabled)
         .with_caller(own_subnet, caller_canister)
         .build();
@@ -1049,6 +1165,8 @@ fn delete_canister_snapshot_succeeds() {
     let response = CanisterSnapshotResponse::decode(&result.unwrap().bytes()).unwrap();
     let snapshot_id = response.snapshot_id();
     assert!(test.state().canister_snapshots.get(snapshot_id).is_some());
+    let subnet_available_memory_after_taking_snapshot =
+        test.subnet_available_memory().get_execution_memory() as u64;
 
     // Confirm that `snapshots_memory_usage` is updated correctly.
     assert_eq!(
@@ -1064,6 +1182,8 @@ fn delete_canister_snapshot_succeeds() {
     let args: DeleteCanisterSnapshotArgs =
         DeleteCanisterSnapshotArgs::new(canister_id, snapshot_id);
     let result = test.subnet_message("delete_canister_snapshot", args.encode());
+    let subnet_available_memory_after_deleting_snapshot =
+        test.subnet_available_memory().get_execution_memory() as u64;
 
     assert!(result.is_ok());
     assert!(test.state().canister_snapshots.get(snapshot_id).is_none());
@@ -1076,6 +1196,12 @@ fn delete_canister_snapshot_succeeds() {
         test.state()
             .canister_snapshots
             .compute_memory_usage_by_canister(canister_id),
+    );
+
+    assert_gt!(
+        subnet_available_memory_after_deleting_snapshot,
+        subnet_available_memory_after_taking_snapshot,
+        "Expected subnet available memory to increase after deleting a snapshot"
     );
 }
 


### PR DESCRIPTION
This PR fixes the logic of computing the subnet's available memory after some snapshot operations. More specifically, there were some cases where the accounting was incorrect:

1. When a snapshot creation would fail, we wouldn't add back the available memory deducted previously.
2. When deleting a snapshot (through `delete_canister_snapshot`) or replacing an existing snapshot, we wouldn't add back the memory taken by this snapshot.

These bugs were low impact as the calculation of available memory happens fresh at the beginning of every execution round, i.e. the above would only temporarily make the available memory look less than it should be within the same execution round that the snapshot operation happened. However, for the sake of correctness, it's best to fix these cases.

The changes included are the following:
1. In `take_canister_snapshot`, we take into account the potential replace snapshot and only try to check if there's enough available memory for the diff in the snapshot size (between new and one that's being replaced). Then when the replace snapshot is removed, we increment the available memory and decrement it only after the new snapshot has been created successfully.
2. In `delete_canister_snapshot`, we increment the available subnet memory by the amount taken by the snapshot.
3. Some new tests are added and existing ones are adjusted to cover the new code.

Closes EXC-1702.