### PR TITLE
fix: use only one version of ic-certification

### DIFF
--- a/Cargo.Bazel.Fuzzing.json.lock
+++ b/Cargo.Bazel.Fuzzing.json.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "73df67b5ac0a6b823a9448ab093c25ab4056fdd6fb4990378478b40a216b55c9",
+  "checksum": "50d3f0f01533c5727291c07f5098a83bb372ca285dc77b301fa92d1ae856f821",
   "crates": {
     "abnf 0.12.0": {
       "name": "abnf",
@@ -29464,7 +29464,7 @@
         "Git": {
           "remote": "https://github.com/dfinity/http-gateway",
           "commitish": {
-            "Rev": "a1f63eb17b0a89f7fadcab67b3a0afe1720ef9b3"
+            "Rev": "3be26b5a2c71bf56e05b910951c1935a1ac550c4"
           },
           "strip_prefix": "packages/ic-http-gateway"
         }

--- a/Cargo.Bazel.Fuzzing.toml.lock
+++ b/Cargo.Bazel.Fuzzing.toml.lock
@@ -3076,16 +3076,16 @@ dependencies = [
  "ic-btc-validation",
  "ic-canister-log",
  "ic-canister-sig-creation",
- "ic-cbor 2.6.0",
+ "ic-cbor",
  "ic-cdk 0.13.5",
  "ic-cdk-macros 0.9.0",
  "ic-cdk-timers",
- "ic-certification 2.6.0",
+ "ic-certification",
  "ic-certified-map",
- "ic-http-certification 2.6.0",
+ "ic-http-certification",
  "ic-http-gateway",
  "ic-metrics-encoder",
- "ic-response-verification 2.6.0",
+ "ic-response-verification",
  "ic-stable-structures",
  "ic-test-state-machine-client",
  "ic-utils",
@@ -4860,7 +4860,7 @@ dependencies = [
  "hyper 1.4.1",
  "hyper-rustls 0.27.2",
  "hyper-util",
- "ic-certification 2.6.0",
+ "ic-certification",
  "ic-transport-types",
  "ic-verify-bls-signature 0.5.0",
  "k256",
@@ -4934,8 +4934,8 @@ dependencies = [
  "candid",
  "hex",
  "ic-cdk 0.14.1",
- "ic-certification 2.6.0",
- "ic-representation-independent-hash 2.6.0",
+ "ic-certification",
+ "ic-representation-independent-hash",
  "lazy_static",
  "serde",
  "serde_bytes",
@@ -4951,19 +4951,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02b0e48b4166c891e79d624f3a184b4a7c145d307576872d9a46dedb8c73ea8f"
 dependencies = [
  "candid",
- "ic-certification 2.6.0",
- "leb128",
- "nom",
- "thiserror",
-]
-
-[[package]]
-name = "ic-cbor"
-version = "2.6.0"
-source = "git+https://github.com/dfinity/response-verification#5aa4f1f5533216e9536142c09b249635401999a4"
-dependencies = [
- "candid",
- "ic-certification 2.6.0",
+ "ic-certification",
  "leb128",
  "nom",
  "thiserror",
@@ -5086,26 +5074,8 @@ checksum = "586e09b06a93d930f6a33f5f909bb11d2e4a06be3635dd5da1eb0e6554b7dae4"
 dependencies = [
  "cached 0.47.0",
  "candid",
- "ic-cbor 2.6.0",
- "ic-certification 2.6.0",
- "lazy_static",
- "leb128",
- "miracl_core_bls12381",
- "nom",
- "parking_lot 0.12.1",
- "sha2 0.10.8",
- "thiserror",
-]
-
-[[package]]
-name = "ic-certificate-verification"
-version = "2.6.0"
-source = "git+https://github.com/dfinity/response-verification#5aa4f1f5533216e9536142c09b249635401999a4"
-dependencies = [
- "cached 0.47.0",
- "candid",
- "ic-cbor 2.6.0",
- "ic-certification 2.6.0",
+ "ic-cbor",
+ "ic-certification",
  "lazy_static",
  "leb128",
  "miracl_core_bls12381",
@@ -5128,15 +5098,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ic-certification"
-version = "2.6.0"
-source = "git+https://github.com/dfinity/response-verification#5aa4f1f5533216e9536142c09b249635401999a4"
-dependencies = [
- "hex",
- "sha2 0.10.8",
-]
-
-[[package]]
 name = "ic-certified-map"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5155,22 +5116,8 @@ checksum = "ff0b97e949845039149dc5e7ea6a7c12ee4333bb402e37bc507904643c7b3e41"
 dependencies = [
  "candid",
  "http 0.2.12",
- "ic-certification 2.6.0",
- "ic-representation-independent-hash 2.6.0",
- "serde",
- "thiserror",
- "urlencoding",
-]
-
-[[package]]
-name = "ic-http-certification"
-version = "2.6.0"
-source = "git+https://github.com/dfinity/response-verification#5aa4f1f5533216e9536142c09b249635401999a4"
-dependencies = [
- "candid",
- "http 0.2.12",
- "ic-certification 2.6.0",
- "ic-representation-independent-hash 2.6.0",
+ "ic-certification",
+ "ic-representation-independent-hash",
  "serde",
  "thiserror",
  "urlencoding",
@@ -5179,7 +5126,7 @@ dependencies = [
 [[package]]
 name = "ic-http-gateway"
 version = "0.0.0"
-source = "git+https://github.com/dfinity/http-gateway?rev=a1f63eb17b0a89f7fadcab67b3a0afe1720ef9b3#a1f63eb17b0a89f7fadcab67b3a0afe1720ef9b3"
+source = "git+https://github.com/dfinity/http-gateway?rev=3be26b5a2c71bf56e05b910951c1935a1ac550c4#3be26b5a2c71bf56e05b910951c1935a1ac550c4"
 dependencies = [
  "bytes",
  "candid",
@@ -5188,8 +5135,8 @@ dependencies = [
  "http-body 1.0.1",
  "http-body-util",
  "ic-agent",
- "ic-http-certification 2.6.0",
- "ic-response-verification 2.6.0",
+ "ic-http-certification",
+ "ic-response-verification",
  "ic-utils",
  "thiserror",
 ]
@@ -5211,15 +5158,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ic-representation-independent-hash"
-version = "2.6.0"
-source = "git+https://github.com/dfinity/response-verification#5aa4f1f5533216e9536142c09b249635401999a4"
-dependencies = [
- "leb128",
- "sha2 0.10.8",
-]
-
-[[package]]
 name = "ic-response-verification"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5230,34 +5168,11 @@ dependencies = [
  "flate2",
  "hex",
  "http 0.2.12",
- "ic-cbor 2.6.0",
- "ic-certificate-verification 2.6.0",
- "ic-certification 2.6.0",
- "ic-http-certification 2.6.0",
- "ic-representation-independent-hash 2.6.0",
- "leb128",
- "log",
- "nom",
- "sha2 0.10.8",
- "thiserror",
- "urlencoding",
-]
-
-[[package]]
-name = "ic-response-verification"
-version = "2.6.0"
-source = "git+https://github.com/dfinity/response-verification#5aa4f1f5533216e9536142c09b249635401999a4"
-dependencies = [
- "base64 0.21.4",
- "candid",
- "flate2",
- "hex",
- "http 0.2.12",
- "ic-cbor 2.6.0",
- "ic-certificate-verification 2.6.0",
- "ic-certification 2.6.0",
- "ic-http-certification 2.6.0",
- "ic-representation-independent-hash 2.6.0",
+ "ic-cbor",
+ "ic-certificate-verification",
+ "ic-certification",
+ "ic-http-certification",
+ "ic-representation-independent-hash",
  "leb128",
  "log",
  "nom",
@@ -5295,7 +5210,7 @@ checksum = "875dc4704780383112e8e8b5063a1b98de114321d0c7d3e7f635dcf360a57fba"
 dependencies = [
  "candid",
  "hex",
- "ic-certification 2.6.0",
+ "ic-certification",
  "leb128",
  "serde",
  "serde_bytes",

--- a/Cargo.Bazel.json.lock
+++ b/Cargo.Bazel.json.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "e603cf81ee75152f52e1dc07baa2e012dafebec4714f60b73e01e4bc81dda349",
+  "checksum": "1a204e337a330e45664bf177d84b8773690a8e4654d56b2a95d484bd7ca69d5f",
   "crates": {
     "abnf 0.12.0": {
       "name": "abnf",
@@ -29335,7 +29335,7 @@
         "Git": {
           "remote": "https://github.com/dfinity/http-gateway",
           "commitish": {
-            "Rev": "a1f63eb17b0a89f7fadcab67b3a0afe1720ef9b3"
+            "Rev": "3be26b5a2c71bf56e05b910951c1935a1ac550c4"
           },
           "strip_prefix": "packages/ic-http-gateway"
         }

--- a/Cargo.Bazel.toml.lock
+++ b/Cargo.Bazel.toml.lock
@@ -3065,16 +3065,16 @@ dependencies = [
  "ic-btc-validation",
  "ic-canister-log",
  "ic-canister-sig-creation",
- "ic-cbor 2.6.0",
+ "ic-cbor",
  "ic-cdk 0.13.5",
  "ic-cdk-macros 0.9.0",
  "ic-cdk-timers",
- "ic-certification 2.6.0",
+ "ic-certification",
  "ic-certified-map",
- "ic-http-certification 2.6.0",
+ "ic-http-certification",
  "ic-http-gateway",
  "ic-metrics-encoder",
- "ic-response-verification 2.6.0",
+ "ic-response-verification",
  "ic-stable-structures",
  "ic-test-state-machine-client",
  "ic-utils",
@@ -4856,7 +4856,7 @@ dependencies = [
  "hyper 1.4.1",
  "hyper-rustls 0.27.2",
  "hyper-util",
- "ic-certification 2.6.0",
+ "ic-certification",
  "ic-transport-types",
  "ic-verify-bls-signature 0.5.0",
  "k256",
@@ -4930,8 +4930,8 @@ dependencies = [
  "candid",
  "hex",
  "ic-cdk 0.14.1",
- "ic-certification 2.6.0",
- "ic-representation-independent-hash 2.6.0",
+ "ic-certification",
+ "ic-representation-independent-hash",
  "lazy_static",
  "serde",
  "serde_bytes",
@@ -4947,19 +4947,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02b0e48b4166c891e79d624f3a184b4a7c145d307576872d9a46dedb8c73ea8f"
 dependencies = [
  "candid",
- "ic-certification 2.6.0",
- "leb128",
- "nom",
- "thiserror",
-]
-
-[[package]]
-name = "ic-cbor"
-version = "2.6.0"
-source = "git+https://github.com/dfinity/response-verification#5aa4f1f5533216e9536142c09b249635401999a4"
-dependencies = [
- "candid",
- "ic-certification 2.6.0",
+ "ic-certification",
  "leb128",
  "nom",
  "thiserror",
@@ -5082,26 +5070,8 @@ checksum = "586e09b06a93d930f6a33f5f909bb11d2e4a06be3635dd5da1eb0e6554b7dae4"
 dependencies = [
  "cached 0.47.0",
  "candid",
- "ic-cbor 2.6.0",
- "ic-certification 2.6.0",
- "lazy_static",
- "leb128",
- "miracl_core_bls12381",
- "nom",
- "parking_lot 0.12.1",
- "sha2 0.10.8",
- "thiserror",
-]
-
-[[package]]
-name = "ic-certificate-verification"
-version = "2.6.0"
-source = "git+https://github.com/dfinity/response-verification#5aa4f1f5533216e9536142c09b249635401999a4"
-dependencies = [
- "cached 0.47.0",
- "candid",
- "ic-cbor 2.6.0",
- "ic-certification 2.6.0",
+ "ic-cbor",
+ "ic-certification",
  "lazy_static",
  "leb128",
  "miracl_core_bls12381",
@@ -5124,15 +5094,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ic-certification"
-version = "2.6.0"
-source = "git+https://github.com/dfinity/response-verification#5aa4f1f5533216e9536142c09b249635401999a4"
-dependencies = [
- "hex",
- "sha2 0.10.8",
-]
-
-[[package]]
 name = "ic-certified-map"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5151,22 +5112,8 @@ checksum = "ff0b97e949845039149dc5e7ea6a7c12ee4333bb402e37bc507904643c7b3e41"
 dependencies = [
  "candid",
  "http 0.2.12",
- "ic-certification 2.6.0",
- "ic-representation-independent-hash 2.6.0",
- "serde",
- "thiserror",
- "urlencoding",
-]
-
-[[package]]
-name = "ic-http-certification"
-version = "2.6.0"
-source = "git+https://github.com/dfinity/response-verification#5aa4f1f5533216e9536142c09b249635401999a4"
-dependencies = [
- "candid",
- "http 0.2.12",
- "ic-certification 2.6.0",
- "ic-representation-independent-hash 2.6.0",
+ "ic-certification",
+ "ic-representation-independent-hash",
  "serde",
  "thiserror",
  "urlencoding",
@@ -5175,7 +5122,7 @@ dependencies = [
 [[package]]
 name = "ic-http-gateway"
 version = "0.0.0"
-source = "git+https://github.com/dfinity/http-gateway?rev=a1f63eb17b0a89f7fadcab67b3a0afe1720ef9b3#a1f63eb17b0a89f7fadcab67b3a0afe1720ef9b3"
+source = "git+https://github.com/dfinity/http-gateway?rev=3be26b5a2c71bf56e05b910951c1935a1ac550c4#3be26b5a2c71bf56e05b910951c1935a1ac550c4"
 dependencies = [
  "bytes",
  "candid",
@@ -5184,8 +5131,8 @@ dependencies = [
  "http-body 1.0.1",
  "http-body-util",
  "ic-agent",
- "ic-http-certification 2.6.0",
- "ic-response-verification 2.6.0",
+ "ic-http-certification",
+ "ic-response-verification",
  "ic-utils",
  "thiserror",
 ]
@@ -5207,15 +5154,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ic-representation-independent-hash"
-version = "2.6.0"
-source = "git+https://github.com/dfinity/response-verification#5aa4f1f5533216e9536142c09b249635401999a4"
-dependencies = [
- "leb128",
- "sha2 0.10.8",
-]
-
-[[package]]
 name = "ic-response-verification"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5226,34 +5164,11 @@ dependencies = [
  "flate2",
  "hex",
  "http 0.2.12",
- "ic-cbor 2.6.0",
- "ic-certificate-verification 2.6.0",
- "ic-certification 2.6.0",
- "ic-http-certification 2.6.0",
- "ic-representation-independent-hash 2.6.0",
- "leb128",
- "log",
- "nom",
- "sha2 0.10.8",
- "thiserror",
- "urlencoding",
-]
-
-[[package]]
-name = "ic-response-verification"
-version = "2.6.0"
-source = "git+https://github.com/dfinity/response-verification#5aa4f1f5533216e9536142c09b249635401999a4"
-dependencies = [
- "base64 0.21.6",
- "candid",
- "flate2",
- "hex",
- "http 0.2.12",
- "ic-cbor 2.6.0",
- "ic-certificate-verification 2.6.0",
- "ic-certification 2.6.0",
- "ic-http-certification 2.6.0",
- "ic-representation-independent-hash 2.6.0",
+ "ic-cbor",
+ "ic-certificate-verification",
+ "ic-certification",
+ "ic-http-certification",
+ "ic-representation-independent-hash",
  "leb128",
  "log",
  "nom",
@@ -5291,7 +5206,7 @@ checksum = "875dc4704780383112e8e8b5063a1b98de114321d0c7d3e7f635dcf360a57fba"
 dependencies = [
  "candid",
  "hex",
- "ic-certification 2.6.0",
+ "ic-certification",
  "leb128",
  "serde",
  "serde_bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1944,8 +1944,8 @@ dependencies = [
  "futures",
  "http 1.1.0",
  "ic-agent",
- "ic-http-certification 2.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "ic-response-verification 2.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-http-certification",
+ "ic-response-verification",
  "ic-utils 0.37.0",
  "idna 1.0.2",
  "instant-acme",
@@ -5257,7 +5257,7 @@ dependencies = [
  "hyper 1.4.1",
  "hyper-rustls 0.27.2",
  "hyper-util",
- "ic-certification 2.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-certification 2.6.0",
  "ic-transport-types",
  "ic-verify-bls-signature 0.5.0",
  "k256",
@@ -5914,8 +5914,8 @@ dependencies = [
  "candid",
  "hex",
  "ic-cdk 0.14.1",
- "ic-certification 2.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "ic-representation-independent-hash 2.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-certification 2.6.0",
+ "ic-representation-independent-hash",
  "lazy_static",
  "serde",
  "serde_bytes",
@@ -6008,19 +6008,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02b0e48b4166c891e79d624f3a184b4a7c145d307576872d9a46dedb8c73ea8f"
 dependencies = [
  "candid",
- "ic-certification 2.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "leb128",
- "nom",
- "thiserror",
-]
-
-[[package]]
-name = "ic-cbor"
-version = "2.6.0"
-source = "git+https://github.com/dfinity/response-verification#da70db93832f88ecc556ae082612aedec47d3816"
-dependencies = [
- "candid",
- "ic-certification 2.6.0 (git+https://github.com/dfinity/response-verification)",
+ "ic-certification 2.6.0",
  "leb128",
  "nom",
  "thiserror",
@@ -6143,26 +6131,8 @@ checksum = "586e09b06a93d930f6a33f5f909bb11d2e4a06be3635dd5da1eb0e6554b7dae4"
 dependencies = [
  "cached 0.47.0",
  "candid",
- "ic-cbor 2.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "ic-certification 2.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static",
- "leb128",
- "miracl_core_bls12381",
- "nom",
- "parking_lot 0.12.3",
- "sha2 0.10.8",
- "thiserror",
-]
-
-[[package]]
-name = "ic-certificate-verification"
-version = "2.6.0"
-source = "git+https://github.com/dfinity/response-verification#da70db93832f88ecc556ae082612aedec47d3816"
-dependencies = [
- "cached 0.47.0",
- "candid",
- "ic-cbor 2.6.0 (git+https://github.com/dfinity/response-verification)",
- "ic-certification 2.6.0 (git+https://github.com/dfinity/response-verification)",
+ "ic-cbor",
+ "ic-certification 2.6.0",
  "lazy_static",
  "leb128",
  "miracl_core_bls12381",
@@ -6203,15 +6173,6 @@ dependencies = [
  "hex",
  "serde",
  "serde_bytes",
- "sha2 0.10.8",
-]
-
-[[package]]
-name = "ic-certification"
-version = "2.6.0"
-source = "git+https://github.com/dfinity/response-verification#da70db93832f88ecc556ae082612aedec47d3816"
-dependencies = [
- "hex",
  "sha2 0.10.8",
 ]
 
@@ -8113,22 +8074,8 @@ checksum = "ff0b97e949845039149dc5e7ea6a7c12ee4333bb402e37bc507904643c7b3e41"
 dependencies = [
  "candid",
  "http 0.2.12",
- "ic-certification 2.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "ic-representation-independent-hash 2.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde",
- "thiserror",
- "urlencoding",
-]
-
-[[package]]
-name = "ic-http-certification"
-version = "2.6.0"
-source = "git+https://github.com/dfinity/response-verification#da70db93832f88ecc556ae082612aedec47d3816"
-dependencies = [
- "candid",
- "http 0.2.12",
- "ic-certification 2.6.0 (git+https://github.com/dfinity/response-verification)",
- "ic-representation-independent-hash 2.6.0 (git+https://github.com/dfinity/response-verification)",
+ "ic-certification 2.6.0",
+ "ic-representation-independent-hash",
  "serde",
  "thiserror",
  "urlencoding",
@@ -8238,7 +8185,7 @@ dependencies = [
 [[package]]
 name = "ic-http-gateway"
 version = "0.0.0"
-source = "git+https://github.com/dfinity/http-gateway?rev=a1f63eb17b0a89f7fadcab67b3a0afe1720ef9b3#a1f63eb17b0a89f7fadcab67b3a0afe1720ef9b3"
+source = "git+https://github.com/dfinity/http-gateway?rev=3be26b5a2c71bf56e05b910951c1935a1ac550c4#3be26b5a2c71bf56e05b910951c1935a1ac550c4"
 dependencies = [
  "bytes",
  "candid",
@@ -8247,8 +8194,8 @@ dependencies = [
  "http-body 1.0.1",
  "http-body-util",
  "ic-agent",
- "ic-http-certification 2.6.0 (git+https://github.com/dfinity/response-verification)",
- "ic-response-verification 2.6.0 (git+https://github.com/dfinity/response-verification)",
+ "ic-http-certification",
+ "ic-response-verification",
  "ic-utils 0.37.0",
  "thiserror",
 ]
@@ -8467,7 +8414,7 @@ dependencies = [
  "hex",
  "ic-agent",
  "ic-base-types",
- "ic-certification 2.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-certification 2.6.0",
  "ic-constants",
  "ic-crypto-tree-hash",
  "ic-icrc-rosetta-client",
@@ -11092,15 +11039,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ic-representation-independent-hash"
-version = "2.6.0"
-source = "git+https://github.com/dfinity/response-verification#da70db93832f88ecc556ae082612aedec47d3816"
-dependencies = [
- "leb128",
- "sha2 0.10.8",
-]
-
-[[package]]
 name = "ic-response-verification"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11111,34 +11049,11 @@ dependencies = [
  "flate2",
  "hex",
  "http 0.2.12",
- "ic-cbor 2.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "ic-certificate-verification 2.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "ic-certification 2.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "ic-http-certification 2.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "ic-representation-independent-hash 2.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "leb128",
- "log",
- "nom",
- "sha2 0.10.8",
- "thiserror",
- "urlencoding",
-]
-
-[[package]]
-name = "ic-response-verification"
-version = "2.6.0"
-source = "git+https://github.com/dfinity/response-verification#da70db93832f88ecc556ae082612aedec47d3816"
-dependencies = [
- "base64 0.21.5",
- "candid",
- "flate2",
- "hex",
- "http 0.2.12",
- "ic-cbor 2.6.0 (git+https://github.com/dfinity/response-verification)",
- "ic-certificate-verification 2.6.0 (git+https://github.com/dfinity/response-verification)",
- "ic-certification 2.6.0 (git+https://github.com/dfinity/response-verification)",
- "ic-http-certification 2.6.0 (git+https://github.com/dfinity/response-verification)",
- "ic-representation-independent-hash 2.6.0 (git+https://github.com/dfinity/response-verification)",
+ "ic-cbor",
+ "ic-certificate-verification",
+ "ic-certification 2.6.0",
+ "ic-http-certification",
+ "ic-representation-independent-hash",
  "leb128",
  "log",
  "nom",
@@ -11289,7 +11204,7 @@ dependencies = [
  "assert_matches",
  "hex",
  "ic-canister-sig-creation",
- "ic-certification 2.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-certification 2.6.0",
  "ic-crypto-internal-types",
  "ic-crypto-test-utils-canister-sigs",
  "ic-crypto-test-utils-reproducible-rng",
@@ -12615,7 +12530,7 @@ checksum = "875dc4704780383112e8e8b5063a1b98de114321d0c7d3e7f635dcf360a57fba"
 dependencies = [
  "candid",
  "hex",
- "ic-certification 2.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-certification 2.6.0",
  "leb128",
  "serde",
  "serde_bytes",
@@ -13416,8 +13331,8 @@ dependencies = [
  "ciborium",
  "hex",
  "ic-agent",
- "ic-cbor 2.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "ic-certification 2.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-cbor",
+ "ic-certification 2.6.0",
  "icrc-ledger-types",
 ]
 
@@ -13624,8 +13539,8 @@ dependencies = [
  "hyper-util",
  "hyperlocal-next",
  "ic-agent",
- "ic-http-certification 2.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "ic-response-verification 2.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-http-certification",
+ "ic-response-verification",
  "ic-utils 0.37.0",
  "itertools 0.12.0",
  "maxminddb",

--- a/bazel/external_crates.bzl
+++ b/bazel/external_crates.bzl
@@ -630,7 +630,7 @@ def external_crates_repository(name, cargo_lockfile, lockfile, sanitizers_enable
             ),
             "ic-http-gateway": crate.spec(
                 git = "https://github.com/dfinity/http-gateway",
-                rev = "a1f63eb17b0a89f7fadcab67b3a0afe1720ef9b3",
+                rev = "3be26b5a2c71bf56e05b910951c1935a1ac550c4",
             ),
             "ic-metrics-encoder": crate.spec(
                 version = "^1.1.1",

--- a/packages/ic-signature-verification/Cargo.toml
+++ b/packages/ic-signature-verification/Cargo.toml
@@ -14,7 +14,7 @@ documentation = "https://docs.rs/ic-signature-verification"
 
 [dependencies]
 ic-canister-sig-creation = "1.0"
-ic-certification = "2.5"
+ic-certification = { workspace = true }
 ic-verify-bls-signature = { version = "0.6", default-features = false, features = [
     "alloc",
 ] }

--- a/rs/pocket_ic_server/Cargo.toml
+++ b/rs/pocket_ic_server/Cargo.toml
@@ -33,7 +33,7 @@ ic-crypto-ed25519 = { path = "../crypto/ed25519" }
 ic-crypto-iccsa = { path = "../crypto/iccsa" }
 ic-crypto-sha2 = { path = "../crypto/sha2" }
 ic-crypto-utils-threshold-sig-der = { path = "../crypto/utils/threshold_sig_der" }
-ic-http-gateway = { git = "https://github.com/dfinity/http-gateway", rev = "a1f63eb17b0a89f7fadcab67b3a0afe1720ef9b3" }
+ic-http-gateway = { git = "https://github.com/dfinity/http-gateway", rev = "3be26b5a2c71bf56e05b910951c1935a1ac550c4" }
 ic-http-endpoints-public = { path = "../http_endpoints/public" }
 ic-https-outcalls-adapter = { path = "../https_outcalls/adapter" }
 ic-https-outcalls-adapter-client = { path = "../https_outcalls/client" }


### PR DESCRIPTION
The external ic-certification package was used by multiple dependencies, but with slightly different versions. This PR makes sure only one version is used. To help solve the problem, the ic-http-proxy dependency is also pinned to a more recent version.

Note that the external ic-certification is a different package than the one internal in rs/certification subdir.