### PR TITLE
chore: Move GenesisTokenCanisterInitPayloadBuilder to rs/nns/test_utils

### DIFF
--- a/rs/nns/gtc/src/lib.rs
+++ b/rs/nns/gtc/src/lib.rs
@@ -12,7 +12,6 @@ use ic_nns_governance_api::pb::v1::GovernanceError;
 use sha3::{Digest, Keccak256};
 use std::{collections::HashSet, time::SystemTime};
 
-pub mod init;
 pub mod pb;
 
 pub const LOG_PREFIX: &str = "[GTC] ";

--- a/rs/nns/gtc/tests/test.rs
+++ b/rs/nns/gtc/tests/test.rs
@@ -1,9 +1,10 @@
 use canister_test::{Canister, Runtime};
 use dfn_candid::candid;
-use ic_nns_gtc::{init::GenesisTokenCanisterInitPayloadBuilder, pb::v1::Gtc};
+use ic_nns_gtc::pb::v1::Gtc;
 use ic_nns_gtc_accounts::{ECT_ACCOUNTS, SEED_ROUND_ACCOUNTS};
-use ic_nns_test_utils::itest_helpers::{
-    maybe_upgrade_to_self, set_up_genesis_token_canister, UpgradeTestingScenario,
+use ic_nns_test_utils::{
+    gtc_helpers::GenesisTokenCanisterInitPayloadBuilder,
+    itest_helpers::{maybe_upgrade_to_self, set_up_genesis_token_canister, UpgradeTestingScenario},
 };
 use ic_nns_test_utils_macros::parameterized_upgrades;
 

--- a/rs/nns/test_utils/BUILD.bazel
+++ b/rs/nns/test_utils/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_rust//rust:defs.bzl", "rust_library")
+load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -112,4 +112,11 @@ rust_library(
     proc_macro_deps = MACRO_DEPENDENCIES,
     version = "0.9.0",
     deps = DEPENDENCIES_WITH_TEST_FEATURES,
+)
+
+rust_test(
+    name = "gtc_helper_tests",
+    srcs = glob(["src/gtc_helpers.rs"]),
+    proc_macro_deps = MACRO_DEPENDENCIES,
+    deps = DEPENDENCIES,
 )

--- a/rs/nns/test_utils/BUILD.bazel
+++ b/rs/nns/test_utils/BUILD.bazel
@@ -116,7 +116,7 @@ rust_library(
 
 rust_test(
     name = "gtc_helper_tests",
-    srcs = glob(["src/gtc_helpers.rs"]),
+    srcs = ["src/gtc_helpers.rs"],
     proc_macro_deps = MACRO_DEPENDENCIES,
     deps = DEPENDENCIES,
 )

--- a/rs/nns/test_utils/src/common.rs
+++ b/rs/nns/test_utils/src/common.rs
@@ -1,4 +1,6 @@
-use crate::registry::invariant_compliant_mutation;
+use crate::{
+    gtc_helpers::GenesisTokenCanisterInitPayloadBuilder, registry::invariant_compliant_mutation,
+};
 use canister_test::{Project, Wasm};
 use core::{
     option::Option::{None, Some},
@@ -13,7 +15,7 @@ use ic_nns_constants::{
 };
 use ic_nns_governance_api::pb::v1::{Governance, NetworkEconomics, Neuron};
 use ic_nns_governance_init::GovernanceCanisterInitPayloadBuilder;
-use ic_nns_gtc::{init::GenesisTokenCanisterInitPayloadBuilder, pb::v1::Gtc};
+use ic_nns_gtc::pb::v1::Gtc;
 use ic_nns_gtc_accounts::{ECT_ACCOUNTS, SEED_ROUND_ACCOUNTS};
 use ic_nns_handler_root::init::{RootCanisterInitPayload, RootCanisterInitPayloadBuilder};
 use ic_registry_transport::pb::v1::RegistryAtomicMutateRequest;

--- a/rs/nns/test_utils/src/gtc_helpers.rs
+++ b/rs/nns/test_utils/src/gtc_helpers.rs
@@ -15,7 +15,7 @@ const INVESTOR_TYPE_SR: &str = "sr";
 const INVESTOR_TYPE_ECT: &str = "ect";
 
 // impl From<&Vec<Neuron>> for AccountState can't be done in this crate, but we only need it here.
-fn account_state_from(neurons: &Vec<Neuron>) -> AccountState {
+fn account_state_from(neurons: &[Neuron]) -> AccountState {
     let neuron_ids = neurons
         .iter()
         .map(|neuron| neuron.id.expect("GTC neuron missing ID"))

--- a/rs/nns/test_utils/src/lib.rs
+++ b/rs/nns/test_utils/src/lib.rs
@@ -4,6 +4,7 @@
 //! TODO(NNS1-903) Move the non-test code to a more appropriate crate.
 pub mod common;
 pub mod governance;
+pub mod gtc_helpers;
 pub mod itest_helpers;
 pub mod neuron_helpers;
 pub mod registry;


### PR DESCRIPTION
This PR factors out test-only code from the GTC production crate into rs/nns/test_utils