### PR TITLE
chore: upgrade to latest Universal- and Prometheus-VM images

### DIFF
--- a/rs/tests/driver/src/driver/prometheus_vm.rs
+++ b/rs/tests/driver/src/driver/prometheus_vm.rs
@@ -44,7 +44,7 @@ const PROMETHEUS_VM_NAME: &str = "prometheus";
 /// The latest hash can be retrieved by downloading the SHA256SUMS file from:
 /// https://hydra.dfinity.systems/job/dfinity-ci-build/farm/universal-vm.img-prometheus.x86_64-linux/latest
 const DEFAULT_PROMETHEUS_VM_IMG_SHA256: &str =
-    "419f884458cb8158c12b294e8d79d355c836188d416f9b6dd7b63abd08cb9f94";
+    "1462da1e3584fa36f6d956e9f741b530bcc4ba20cddc2ce95d40fabda5881101";
 
 fn get_default_prometheus_vm_img_url() -> String {
     format!("http://download.proxy-global.dfinity.network:8080/farm/prometheus-vm/{DEFAULT_PROMETHEUS_VM_IMG_SHA256}/x86_64-linux/prometheus-vm.img.zst")

--- a/rs/tests/driver/src/driver/resource.rs
+++ b/rs/tests/driver/src/driver/resource.rs
@@ -238,7 +238,7 @@ pub fn get_resource_request_for_nested_nodes(
 /// The latest hash can be retrieved by downloading the SHA256SUMS file from:
 /// https://hydra.dfinity.systems/job/dfinity-ci-build/farm/universal-vm.img.x86_64-linux/latest
 const DEFAULT_UNIVERSAL_VM_IMG_SHA256: &str =
-    "e9676384fdbff9713c543ea4e913782e7ef120282c3c7a491b63cb48f9f0748d";
+    "7727cebf4f228d6a7e869fa669bb6703a53c61a5ab817227f1fb5e4e67d5a368";
 
 pub fn get_resource_request_for_universal_vm(
     universal_vm: &UniversalVm,


### PR DESCRIPTION
This keeps the UVM and PrometheusVM images in sync with [the latest Farm commit](https://github.com/dfinity-lab/farm/commit/efdb2b6e273eb5933ceea68d1b0322e809f27776).