### PR TITLE
chore(IDX): unpin python dependencies

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,23 +1,23 @@
-ansible==6.6.0
+ansible>=6.6.0
 cbor>=1.0.0
 configargparse
-cvss==2.5
+cvss>=2.5
 fabric
 GitPython>=3.1.24
 https://github.com/rocklabs-io/ic-py/archive/53c375a1d6c1d09e8d24588142dece550b801cef.zip
 icmplib
 idracredfishsupport>=0.0.8
 invoke
-jira==3.4.1
+jira>=3.4.1
 junit-xml
 loguru
 matplotlib>=3.6.2, <3.7
 mypy
-nested_lookup==0.2.25
-node_semver==0.9.0
-packaging==21.3
+nested_lookup>=0.2.25
+node_semver>=0.9.0
+packaging>=21.3
 paramiko>=2.11.0
-parse==1.19.0
+parse>=1.19.0
 pytest
 pytest-cov
 PyYAML>=5.4.1
@@ -25,4 +25,4 @@ requests>=2.26.0
 simple-parsing
 tqdm
 uuid
-PyGithub==2.3.0
+PyGithub>=2.3.0


### PR DESCRIPTION
By removing the specific pins from the version (changing `==` to `>=`) we allow for newer versions to get pulled in if they are available. However, after running `bazel run //:python-requirements.update` it appears that they are already at their most recent version (or restricted by other dependencies).