### PR TITLE
feat(nns): Added is-commit-released.sh to nns-tools.

### DIFF
--- a/testnet/tools/nns-tools/is-commit-released.sh
+++ b/testnet/tools/nns-tools/is-commit-released.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+NNS_TOOLS_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
+source "$NNS_TOOLS_DIR/lib/include.sh"
+
+CANISTER_NAME=$1
+QUERY_COMMIT_ID=$2
+
+CANISTER_ID=$(nns_canister_id "$CANISTER_NAME")
+echo "Fetching git_commit_id from $CANISTER_NAME ($CANISTER_ID)..."
+
+CURRENT_COMMIT_ID=$(dfx canister --ic metadata "$CANISTER_ID" 'git_commit_id')
+echo "$CANISTER_NAME reports itself to be on commit $CURRENT_COMMIT_ID."
+
+echo
+if git merge-base --is-ancestor "$QUERY_COMMIT_ID" "$CURRENT_COMMIT_ID"; then
+    echo "🎉 ${QUERY_COMMIT_ID} is included in the code that $CANISTER_NAME is currently running."
+    exit 0
+else
+    echo "🙅 ${QUERY_COMMIT_ID} is not (yet?) being run by $CANISTER_NAME."
+    exit 1
+fi

--- a/testnet/tools/nns-tools/is-commit-released.sh
+++ b/testnet/tools/nns-tools/is-commit-released.sh
@@ -13,6 +13,11 @@ echo "Fetching git_commit_id from $CANISTER_NAME ($CANISTER_ID)..."
 CURRENT_COMMIT_ID=$(dfx canister --ic metadata "$CANISTER_ID" 'git_commit_id')
 echo "$CANISTER_NAME reports itself to be on commit $CURRENT_COMMIT_ID."
 
+# This is in case the commit is not yet in our local repo. This assumes that if
+# the commit was released, it is in the GitHub repo. That might not be true in
+# the case of hotfixes though.
+git fetch origin "$CURRENT_COMMIT_ID"
+
 echo
 if git merge-base --is-ancestor "$QUERY_COMMIT_ID" "$CURRENT_COMMIT_ID"; then
     echo "🎉 ${QUERY_COMMIT_ID} is included in the code that $CANISTER_NAME is currently running."


### PR DESCRIPTION
Simply pass it

1. canister name
2. (query) commit ID

It then asks the canister what commit it's on, and then asks git whether the query commit is an ancestor of the commit the canister is running.

# Future Work

## SNS

This only works for NNS. In the case of SNS, this could answer a couple variations of the same request:

1. If an SNS had the most recent available version, would the query commit be included?
2. Which SNSs do not yet have the query commit?

## No Canister Name

Perhaps, we can (in a future iteration), we can make this even easier by making canister name optional. If omitted, this script could scan all NNS canisters, and print the status of each.

## Pull Request Number Instead of Commit ID

I would also like it if you could pass a PR number, and have it figure out the merge commit. One way to do this:

```
git log --grep ' (#1234)$' --pretty=format:"%H" master
```

This prints out the IDs of matching commits. The problem with this is that it assumes that " (#1234)" (where 1234 is the PR number) occurs at the end of a line. This can cause false matches. Or if the format changes, it can have the opposite problem. Basically, this is not super reliable, but might be good enough for the purposes of this script.