### PR TITLE
docs(nns): Small corrections in nns-tools.

### DIFF
--- a/testnet/tools/nns-tools/README.md
+++ b/testnet/tools/nns-tools/README.md
@@ -445,6 +445,9 @@ Plug in your HSM key. Unplug your Ubikey.
 Optionally, you can test that your security hardware is ready by running
 
 ```bash
+pkcs11-tool --list-slots
+
+# If you want to practice entering your password:
 pkcs11-tool --login --test
 ```
 

--- a/testnet/tools/nns-tools/README.md
+++ b/testnet/tools/nns-tools/README.md
@@ -26,9 +26,13 @@ my_useful_function() {
 
 ## Upgrade Testing via Bazel
 
-TL;DR:
-
 ```
+# Run from the usual place.
+ssh -A devenv
+cd src/ic
+./gitlab-ci/container/container-run.sh
+
+# Within the container.
 bazel test \
     --test_env=SSH_AUTH_SOCK \
     --test_env=NNS_CANISTER_UPGRADE_SEQUENCE=all \
@@ -37,16 +41,10 @@ bazel test \
     //rs/nns/integration_tests:upgrade_canisters_with_golden_nns_state
 ```
 
-This is a new way of doing upgrade/release testing (as of May 2024). (The old way is still
+This takes about 5 min on my devenv.
+
+(This is a new way of doing upgrade/release testing (as of May 2024). The old way is still
 documented elsewhere in this README.)
-
-Perform these instructions from the usual place:
-
-```
-ssh -A devenv
-cd src/ic
-./gitlab-ci/container/container-run.sh
-```
 
 One special requirement for this to work is access to zh1-pyr07. This can be
 requested from the consensus team, e.g. Christian Müller.
@@ -447,7 +445,7 @@ Plug in your HSM key. Unplug your Ubikey.
 Optionally, you can test that your security hardware is ready by running
 
 ```bash
-pkcs11-tool --list-slots
+pkcs11-tool --login --test
 ```
 
 Finally, run
@@ -478,9 +476,7 @@ For example:
 
 The script validates your proposal text. Specifically, it enforces the following requirements:
 
-1. The proposed canister ID is consistent with the human-readable canister name in the title.
-2. The hash in the proposal matches the hash of the WASM generated for that git version.
-3. There are no TODO items left in the proposal text.
+1. There are no TODO items left in the proposal text.
 
 If your proposal text checks out, the script then prompts you for your HSM pin.
 

--- a/testnet/tools/nns-tools/lib/proposals.sh
+++ b/testnet/tools/nns-tools/lib/proposals.sh
@@ -157,11 +157,11 @@ This should match \`wasm_module\` field of this proposal.$(if [ ! -z "$CANDID_AR
 [latest-didc]: https://github.com/dfinity/candid/releases/latest
 
 \`\`\`
-didc encode '$CANDID_ARGS' | xxd -r -p | sha256sum
+didc encode '$CANDID_ARGS'
 
 \`\`\`
 
-This should match the \`arg_hash\` field of this proposal.
+This should match the \`arg_hex\` field of this proposal.
 "
         fi)
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++

--- a/testnet/tools/nns-tools/list-new-commits.sh
+++ b/testnet/tools/nns-tools/list-new-commits.sh
@@ -41,6 +41,8 @@ for canister_name in "${NNS_CANISTERS[@]}"; do
     git --no-pager log --format="%C(auto) %h %s" "$released_commit_id".."$RELEASE_CANDIDATE_COMMIT_ID" -- $root
 done
 
+echo
+echo
 echo SNS
 echo =====
 


### PR DESCRIPTION
# Changes

1. README:

    1. Refactored instructions for how to do upgrade test. One additional piece of information: it takes about 5 minutes to run. (If it takes much longer, operator should start start suspecting that something is wrong, and begin investigating.)

    2. `pkcs11-tool --login --test` (not just `--list-slots`) is a stronger way to test HSM key, because it prompts for PIN, not just that you can talk to the hardware.

    3. Removed some recently obsolete information.

2. Generating NNS proposal text: corrections in the section about argument verification.