### PR TITLE
feat(EXC-1715): Canister Backtrace Flag

### DIFF
--- a/rs/config/src/embedders.rs
+++ b/rs/config/src/embedders.rs
@@ -108,6 +108,8 @@ pub struct FeatureFlags {
     // TODO(IC-1674): remove this flag once the feature is enabled by default.
     /// Indicates whether the best-effort responses feature is enabled.
     pub best_effort_responses: FlagStatus,
+    /// Collect a backtrace from the canister when it panics.
+    pub canister_backtrace: FlagStatus,
 }
 
 impl FeatureFlags {
@@ -118,6 +120,7 @@ impl FeatureFlags {
             wasm_native_stable_memory: FlagStatus::Enabled,
             wasm64: FlagStatus::Disabled,
             best_effort_responses: FlagStatus::Disabled,
+            canister_backtrace: FlagStatus::Disabled,
         }
     }
 }

--- a/rs/embedders/src/wasm_executor.rs
+++ b/rs/embedders/src/wasm_executor.rs
@@ -594,6 +594,7 @@ pub fn process(
         execution_parameters.clone(),
         subnet_available_memory,
         embedder.config().feature_flags.wasm_native_stable_memory,
+        embedder.config().feature_flags.canister_backtrace,
         embedder.config().max_sum_exported_function_name_lengths,
         stable_memory.clone(),
         out_of_instructions_handler,

--- a/rs/embedders/src/wasmtime_embedder.rs
+++ b/rs/embedders/src/wasmtime_embedder.rs
@@ -516,6 +516,7 @@ impl WasmtimeEmbedder {
             store,
             write_barrier: self.config.feature_flags.write_barrier,
             wasm_native_stable_memory: self.config.feature_flags.wasm_native_stable_memory,
+            canister_backtrace: self.config.feature_flags.canister_backtrace,
             modification_tracking,
             dirty_page_overhead: self.config.dirty_page_overhead,
             #[cfg(debug_assertions)]
@@ -763,6 +764,8 @@ pub struct WasmtimeInstance {
     store: wasmtime::Store<StoreData>,
     write_barrier: FlagStatus,
     wasm_native_stable_memory: FlagStatus,
+    #[allow(unused)]
+    canister_backtrace: FlagStatus,
     modification_tracking: ModificationTracking,
     dirty_page_overhead: NumInstructions,
     #[cfg(debug_assertions)]

--- a/rs/embedders/src/wasmtime_embedder/wasmtime_embedder_tests.rs
+++ b/rs/embedders/src/wasmtime_embedder/wasmtime_embedder_tests.rs
@@ -89,9 +89,7 @@ fn test_wasmtime_system_api() {
         EmbeddersConfig::default()
             .feature_flags
             .wasm_native_stable_memory,
-        EmbeddersConfig::default()
-            .feature_flags
-            .canister_backtrace,
+        EmbeddersConfig::default().feature_flags.canister_backtrace,
         EmbeddersConfig::default().max_sum_exported_function_name_lengths,
         Memory::new_for_testing(),
         Rc::new(DefaultOutOfInstructionsHandler::default()),

--- a/rs/embedders/src/wasmtime_embedder/wasmtime_embedder_tests.rs
+++ b/rs/embedders/src/wasmtime_embedder/wasmtime_embedder_tests.rs
@@ -89,6 +89,9 @@ fn test_wasmtime_system_api() {
         EmbeddersConfig::default()
             .feature_flags
             .wasm_native_stable_memory,
+        EmbeddersConfig::default()
+            .feature_flags
+            .canister_backtrace,
         EmbeddersConfig::default().max_sum_exported_function_name_lengths,
         Memory::new_for_testing(),
         Rc::new(DefaultOutOfInstructionsHandler::default()),

--- a/rs/embedders/tests/wasmtime_random_memory_writes.rs
+++ b/rs/embedders/tests/wasmtime_random_memory_writes.rs
@@ -108,6 +108,7 @@ fn test_api_for_update(
         EmbeddersConfig::default()
             .feature_flags
             .wasm_native_stable_memory,
+        EmbeddersConfig::default().feature_flags.canister_backtrace,
         EmbeddersConfig::default().max_sum_exported_function_name_lengths,
         Memory::new_for_testing(),
         Rc::new(DefaultOutOfInstructionsHandler::new(instruction_limit)),

--- a/rs/system_api/src/lib.rs
+++ b/rs/system_api/src/lib.rs
@@ -963,6 +963,11 @@ pub struct SystemApiImpl {
     /// still be read through the hidden read API for speed on the first access.
     wasm_native_stable_memory: FlagStatus,
 
+    /// Canister backtraces are enabled. This means we should attempt to collect
+    /// a backtrace if the canister calls the trap API.
+    #[allow(unused)]
+    canister_backtrace: FlagStatus,
+
     /// The maximum sum of `<name>` lengths in exported functions called `canister_update <name>`,
     /// `canister_query <name>`, or `canister_composite_query <name>`.
     max_sum_exported_function_name_lengths: usize,
@@ -1005,6 +1010,7 @@ impl SystemApiImpl {
         execution_parameters: ExecutionParameters,
         subnet_available_memory: SubnetAvailableMemory,
         wasm_native_stable_memory: FlagStatus,
+        canister_backtrace: FlagStatus,
         max_sum_exported_function_name_lengths: usize,
         stable_memory: Memory,
         out_of_instructions_handler: Rc<dyn OutOfInstructionsHandler>,
@@ -1028,6 +1034,7 @@ impl SystemApiImpl {
             memory_usage,
             execution_parameters,
             wasm_native_stable_memory,
+            canister_backtrace,
             max_sum_exported_function_name_lengths,
             stable_memory,
             sandbox_safe_system_state,

--- a/rs/system_api/tests/common/mod.rs
+++ b/rs/system_api/tests/common/mod.rs
@@ -205,6 +205,7 @@ pub fn get_system_api(
         EmbeddersConfig::default()
             .feature_flags
             .wasm_native_stable_memory,
+        EmbeddersConfig::default().feature_flags.canister_backtrace,
         EmbeddersConfig::default().max_sum_exported_function_name_lengths,
         Memory::new_for_testing(),
         Rc::new(DefaultOutOfInstructionsHandler::default()),

--- a/rs/system_api/tests/system_api.rs
+++ b/rs/system_api/tests/system_api.rs
@@ -1455,6 +1455,7 @@ fn growing_wasm_memory_updates_subnet_available_memory() {
         EmbeddersConfig::default()
             .feature_flags
             .wasm_native_stable_memory,
+        EmbeddersConfig::default().feature_flags.canister_backtrace,
         EmbeddersConfig::default().max_sum_exported_function_name_lengths,
         Memory::new_for_testing(),
         Rc::new(DefaultOutOfInstructionsHandler::default()),
@@ -1527,6 +1528,7 @@ fn push_output_request_respects_memory_limits() {
         EmbeddersConfig::default()
             .feature_flags
             .wasm_native_stable_memory,
+        EmbeddersConfig::default().feature_flags.canister_backtrace,
         EmbeddersConfig::default().max_sum_exported_function_name_lengths,
         Memory::new_for_testing(),
         Rc::new(DefaultOutOfInstructionsHandler::default()),
@@ -1638,6 +1640,7 @@ fn push_output_request_oversized_request_memory_limits() {
         EmbeddersConfig::default()
             .feature_flags
             .wasm_native_stable_memory,
+        EmbeddersConfig::default().feature_flags.canister_backtrace,
         EmbeddersConfig::default().max_sum_exported_function_name_lengths,
         Memory::new_for_testing(),
         Rc::new(DefaultOutOfInstructionsHandler::default()),

--- a/rs/test_utilities/embedders/src/lib.rs
+++ b/rs/test_utilities/embedders/src/lib.rs
@@ -164,6 +164,7 @@ impl WasmtimeInstanceBuilder {
                 subnet_memory_capacity,
             ),
             embedder.config().feature_flags.wasm_native_stable_memory,
+            embedder.config().feature_flags.canister_backtrace,
             embedder.config().max_sum_exported_function_name_lengths,
             Memory::new_for_testing(),
             Rc::new(ic_system_api::DefaultOutOfInstructionsHandler::new(


### PR DESCRIPTION
Add a feature flag to enable canister backtraces. Follow up PRs will use this flag and actually collect the backtraces.