### PR TITLE
chore(sns): Remove neuron_parameters from ClaimSwapNeuronsRequest on SNS Governance's side

### DIFF
--- a/rs/sns/governance/canister/governance.did
+++ b/rs/sns/governance/canister/governance.did
@@ -75,7 +75,6 @@ type ClaimOrRefreshResponse = record {
 
 type ClaimSwapNeuronsRequest = record {
   neuron_recipes : opt NeuronRecipes;
-  neuron_parameters : vec NeuronParameters;
 };
 
 type ClaimSwapNeuronsResponse = record {

--- a/rs/sns/governance/canister/governance_test.did
+++ b/rs/sns/governance/canister/governance_test.did
@@ -84,7 +84,6 @@ type ClaimOrRefreshResponse = record {
 
 type ClaimSwapNeuronsRequest = record {
   neuron_recipes : opt NeuronRecipes;
-  neuron_parameters : vec NeuronParameters;
 };
 
 type ClaimSwapNeuronsResponse = record {

--- a/rs/sns/governance/proto/ic_sns_governance/pb/v1/governance.proto
+++ b/rs/sns/governance/proto/ic_sns_governance/pb/v1/governance.proto
@@ -1953,53 +1953,6 @@ message GetModeResponse {
 
 // The request for the `claim_swap_neurons` method.
 message ClaimSwapNeuronsRequest {
-  // This type has been replaced by NeuronRecipe and should not be used.
-  // TODO(NNS1-3198): Remove this message once `NeuronRecipe` is used systematically.
-  message NeuronParameters {
-    reserved "memo";
-    reserved 4;
-
-    // The PrincipalId that will have permissions when the neuron is created.
-    // The permissions that are granted are controlled my
-    // `NervousSystemParameters::neuron_claimer_permissions`. This field
-    // is required.
-    ic_base_types.pb.v1.PrincipalId controller = 1;
-
-    // For Community Fund participants, in addition to the controller (that is
-    // set to the NNS governance), this is another PrincipalId with permissions.
-    // Specifically, the PrincipalId who is the controller of the NNS neuron
-    // that invested in the decentralization sale via the Community Fund will
-    // be granted the following permissions:
-    //    - NeuronPermissionType::SubmitProposal
-    //    - NeuronPermissionType::Vote
-    // This field is not set for other types of participants, therefore it is optional.
-    ic_base_types.pb.v1.PrincipalId hotkey = 2;
-
-    // The stake of the neuron in e8s (10E-8 of a token) that the neuron will be
-    // created with. This field is required.
-    optional uint64 stake_e8s = 3;
-
-    // The duration in seconds that the neuron's dissolve delay will be set to. Neurons
-    // that are for Community Fund investors will be automatically set to dissolving,
-    // while direct investors will be automatically set to non-dissolving.
-    optional uint64 dissolve_delay_seconds = 5;
-
-    // The ID of the NNS neuron whose Community Fund participation resulted in the
-    // creation of this SNS neuron.
-    optional uint64 source_nns_neuron_id = 6;
-
-    // The ID of the SNS Neuron to be created for the participant. If a Neuron with
-    // this NeuronId already exists in SNS Governance, the `ClaimSwapNeuronsResponse`
-    // will return a`ClaimedSwapNeuronStatus::AlreadyExists` for this NeuronId.
-    // This field is required.
-    optional NeuronId neuron_id = 7;
-
-    // The list of NeuronIds that the created Neuron will follow on all SNS Proposal
-    // Actions known to governance at the time. Additional followees and following
-    // relations can be added after neuron creation.
-    repeated NeuronId followees = 8;
-  }
-
   // Replacement for NeuronParameters. Contains the information needed to set up
   // a neuron for a swap participant.
   message NeuronRecipe {
@@ -2045,10 +1998,8 @@ message ClaimSwapNeuronsRequest {
   // each NeuronRecipe, one neuron will be created.
   optional NeuronRecipes neuron_recipes = 2;
 
-  // The set of parameters that define the neurons created in `claim_swap_neurons`. For
-  // each NeuronParameter, one neuron will be created.
-  // Deprecated. Use [`neuron_recipes`] instead.
-  repeated NeuronParameters neuron_parameters = 1 [deprecated = true];
+  reserved 1;
+  reserved "neuron_parameters";
 }
 
 // An enum for representing the various statuses a Neuron being claimed by the

--- a/rs/sns/governance/src/gen/ic_sns_governance.pb.v1.rs
+++ b/rs/sns/governance/src/gen/ic_sns_governance.pb.v1.rs
@@ -2522,62 +2522,9 @@ pub struct ClaimSwapNeuronsRequest {
     /// each NeuronRecipe, one neuron will be created.
     #[prost(message, optional, tag = "2")]
     pub neuron_recipes: ::core::option::Option<claim_swap_neurons_request::NeuronRecipes>,
-    /// The set of parameters that define the neurons created in `claim_swap_neurons`. For
-    /// each NeuronParameter, one neuron will be created.
-    /// Deprecated. Use \[`neuron_recipes`\] instead.
-    #[deprecated]
-    #[prost(message, repeated, tag = "1")]
-    pub neuron_parameters: ::prost::alloc::vec::Vec<claim_swap_neurons_request::NeuronParameters>,
 }
 /// Nested message and enum types in `ClaimSwapNeuronsRequest`.
 pub mod claim_swap_neurons_request {
-    /// This type has been replaced by NeuronRecipe and should not be used.
-    /// TODO(NNS1-3198): Remove this message once `NeuronRecipe` is used systematically.
-    #[derive(candid::CandidType, candid::Deserialize, comparable::Comparable)]
-    #[allow(clippy::derive_partial_eq_without_eq)]
-    #[derive(Clone, PartialEq, ::prost::Message)]
-    pub struct NeuronParameters {
-        /// The PrincipalId that will have permissions when the neuron is created.
-        /// The permissions that are granted are controlled my
-        /// `NervousSystemParameters::neuron_claimer_permissions`. This field
-        /// is required.
-        #[prost(message, optional, tag = "1")]
-        pub controller: ::core::option::Option<::ic_base_types::PrincipalId>,
-        /// For Community Fund participants, in addition to the controller (that is
-        /// set to the NNS governance), this is another PrincipalId with permissions.
-        /// Specifically, the PrincipalId who is the controller of the NNS neuron
-        /// that invested in the decentralization sale via the Community Fund will
-        /// be granted the following permissions:
-        ///     - NeuronPermissionType::SubmitProposal
-        ///     - NeuronPermissionType::Vote
-        /// This field is not set for other types of participants, therefore it is optional.
-        #[prost(message, optional, tag = "2")]
-        pub hotkey: ::core::option::Option<::ic_base_types::PrincipalId>,
-        /// The stake of the neuron in e8s (10E-8 of a token) that the neuron will be
-        /// created with. This field is required.
-        #[prost(uint64, optional, tag = "3")]
-        pub stake_e8s: ::core::option::Option<u64>,
-        /// The duration in seconds that the neuron's dissolve delay will be set to. Neurons
-        /// that are for Community Fund investors will be automatically set to dissolving,
-        /// while direct investors will be automatically set to non-dissolving.
-        #[prost(uint64, optional, tag = "5")]
-        pub dissolve_delay_seconds: ::core::option::Option<u64>,
-        /// The ID of the NNS neuron whose Community Fund participation resulted in the
-        /// creation of this SNS neuron.
-        #[prost(uint64, optional, tag = "6")]
-        pub source_nns_neuron_id: ::core::option::Option<u64>,
-        /// The ID of the SNS Neuron to be created for the participant. If a Neuron with
-        /// this NeuronId already exists in SNS Governance, the `ClaimSwapNeuronsResponse`
-        /// will return a`ClaimedSwapNeuronStatus::AlreadyExists` for this NeuronId.
-        /// This field is required.
-        #[prost(message, optional, tag = "7")]
-        pub neuron_id: ::core::option::Option<super::NeuronId>,
-        /// The list of NeuronIds that the created Neuron will follow on all SNS Proposal
-        /// Actions known to governance at the time. Additional followees and following
-        /// relations can be added after neuron creation.
-        #[prost(message, repeated, tag = "8")]
-        pub followees: ::prost::alloc::vec::Vec<super::NeuronId>,
-    }
     /// Replacement for NeuronParameters. Contains the information needed to set up
     /// a neuron for a swap participant.
     #[derive(candid::CandidType, candid::Deserialize, comparable::Comparable)]

--- a/rs/sns/governance/src/governance.rs
+++ b/rs/sns/governance/src/governance.rs
@@ -3894,16 +3894,6 @@ impl Governance {
             return ClaimSwapNeuronsResponse::new_with_error(ClaimSwapNeuronsError::Internal);
         };
 
-        // TODO(NNS1-3198): Remove this after `NeuronParameters` is fully removed
-        #[allow(deprecated)]
-        if !request.neuron_parameters.is_empty() {
-            log!(
-                ERROR,
-                "NeuronParameters is obselete. Please use NeuronRecipes instead."
-            );
-            return ClaimSwapNeuronsResponse::new_with_error(ClaimSwapNeuronsError::Internal);
-        }
-
         for neuron_recipe in Vec::<_>::from(neuron_recipes) {
             match neuron_recipe.validate(
                 neuron_minimum_stake_e8s,

--- a/rs/sns/governance/tests/governance.rs
+++ b/rs/sns/governance/tests/governance.rs
@@ -1717,7 +1717,6 @@ fn test_claim_swap_neurons_rejects_unauthorized_access() {
         neuron_recipes: Some(NeuronRecipes {
             neuron_recipes: Vec::new(),
         }),
-        ..Default::default()
     };
 
     // Generate a principal id that should not be authorized to call claim_swap_neurons
@@ -1769,7 +1768,6 @@ fn test_claim_swap_neurons_reports_invalid_neuron_recipes() {
             neuron_id: Some(test_neuron_id.clone()),
             ..Default::default() // The rest of the fields are unset and will fail validation
         }])),
-        ..Default::default()
     };
 
     // Call the method
@@ -1818,7 +1816,6 @@ fn test_claim_swap_neurons_reports_already_existing_neurons() {
             dissolve_delay_seconds: Some(0),
             followees: Some(NeuronIds::from(vec![])),
         }])),
-        ..Default::default()
     };
 
     let authorized_sale_principal = canister_fixture.get_sale_canister_id();
@@ -1877,7 +1874,6 @@ fn test_claim_swap_neurons_reports_failure_if_neuron_cannot_be_added() {
                 followees: Some(NeuronIds::from(vec![])),
             },
         ])),
-        ..Default::default()
     };
 
     // Call the method
@@ -1940,7 +1936,6 @@ fn test_claim_swap_neurons_succeeds() {
             direct_participant_neuron_recipe.clone(),
             nf_participant_neuron_recipe.clone(),
         ])),
-        ..Default::default()
     };
 
     // Call the method


### PR DESCRIPTION
The field is deprecated and no longer supported. This change is safe because neuron_parameters was already not supported by `Governance`, this just removes the field entirely from the request it expects. 

[← Previous PR](https://github.com/dfinity/ic/pull/1295)