### PR TITLE
refactor(IDX): update custom ci logic

### DIFF
--- a/.github/workflows-source/ci-pr-only.yml
+++ b/.github/workflows-source/ci-pr-only.yml
@@ -158,3 +158,16 @@ jobs:
           export PYTHONPATH=$PWD/gitlab-ci/src:$PWD/gitlab-ci/src/dependencies
           cd gitlab-ci/src/dependencies/
           $SHELL_WRAPPER python3 job/bazel_rust_ic_scanner_merge_job.py
+
+  pr-title-check:
+    name: Check PR Title for Deprecated Flags
+    runs-on: ubuntu-latest
+    steps:
+      - <<: *checkout
+      - name: Check PR Title
+        id: check-pr-title
+        run: |
+          if [[ "$CI_MERGE_REQUEST_TITLE" == *"[RUN_ALL_BAZEL_TARGETS]"* || "$CI_MERGE_REQUEST_TITLE" == *"[S3_UPLOAD]"* ]]; then
+            echo "Error: The flags [RUN_ALL_BAZEL_TARGETS] or [S3_UPLOAD] are deprecated. Please use [RUN_ALL_TARGETS_AND_UPLOAD] instead."
+            exit 1
+          fi

--- a/.github/workflows-source/ci-pr-only.yml
+++ b/.github/workflows-source/ci-pr-only.yml
@@ -167,7 +167,7 @@ jobs:
       - name: Check PR Title
         id: check-pr-title
         run: |
-          if [[ "$CI_MERGE_REQUEST_TITLE" == *"[RUN_ALL_BAZEL_TARGETS]"* || "$CI_MERGE_REQUEST_TITLE" == *"[S3_UPLOAD]"* ]]; then
-            echo "Error: The flags [RUN_ALL_BAZEL_TARGETS] or [S3_UPLOAD] are deprecated. Please use [RUN_ALL_TARGETS_AND_UPLOAD] instead."
+          if [[ "$CI_MERGE_REQUEST_TITLE" == *"[S3_UPLOAD]"* ]]; then
+            echo "Error: The [S3_UPLOAD] flag has been deprecated. Please use [RUN_ALL_BAZEL_TARGETS] instead. It will automatically upload to S3."
             exit 1
           fi

--- a/.github/workflows/ci-pr-only.yml
+++ b/.github/workflows/ci-pr-only.yml
@@ -169,8 +169,8 @@ jobs:
         uses: actions/checkout@v4
       - name: Check PR Title
         id: check-pr-title
-        run: |-
-          if [[ "$CI_MERGE_REQUEST_TITLE" == *"[RUN_ALL_BAZEL_TARGETS]"* || "$CI_MERGE_REQUEST_TITLE" == *"[S3_UPLOAD]"* ]]; then
-            echo "Error: The flags [RUN_ALL_BAZEL_TARGETS] or [S3_UPLOAD] are deprecated. Please use [RUN_ALL_TARGETS_AND_UPLOAD] instead."
+        run: |
+          if [[ "$CI_MERGE_REQUEST_TITLE" == *"[S3_UPLOAD]"* ]]; then
+            echo "Error: The [S3_UPLOAD] flag has been deprecated. Please use [RUN_ALL_BAZEL_TARGETS] instead. It will automatically upload to S3."
             exit 1
           fi

--- a/.github/workflows/ci-pr-only.yml
+++ b/.github/workflows/ci-pr-only.yml
@@ -161,3 +161,16 @@ jobs:
           export PYTHONPATH=$PWD/gitlab-ci/src:$PWD/gitlab-ci/src/dependencies
           cd gitlab-ci/src/dependencies/
           $SHELL_WRAPPER python3 job/bazel_rust_ic_scanner_merge_job.py
+  pr-title-check:
+    name: Check PR Title for Deprecated Flags
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Check PR Title
+        id: check-pr-title
+        run: |-
+          if [[ "$CI_MERGE_REQUEST_TITLE" == *"[RUN_ALL_BAZEL_TARGETS]"* || "$CI_MERGE_REQUEST_TITLE" == *"[S3_UPLOAD]"* ]]; then
+            echo "Error: The flags [RUN_ALL_BAZEL_TARGETS] or [S3_UPLOAD] are deprecated. Please use [RUN_ALL_TARGETS_AND_UPLOAD] instead."
+            exit 1
+          fi

--- a/ci/bazel-scripts/main.sh
+++ b/ci/bazel-scripts/main.sh
@@ -23,9 +23,11 @@ fi
 # - target branch is not rc--*
 # - uploading to S3 has not been requested
 
-if [[ "${CI_MERGE_REQUEST_TITLE:-}" == *"[RUN_ALL_BAZEL_TARGETS]"* ]] || [[ "${CI_MERGE_REQUEST_TITLE:-}" == *"[S3_UPLOAD]"* ]]; then
+if [[ "${CI_MERGE_REQUEST_TITLE:-}" == *"[RUN_ALL_BAZEL_TARGETS]"* ]]; then
     RUN_ON_DIFF_ONLY="false"
-    s3_upload="True"
+    if [[ "${CI_MERGE_REQUEST_TITLE:-}" == *"[S3_UPLOAD]"* ]]; then
+        s3_upload="True"
+    fi
 fi
 
 if [ "${RUN_ON_DIFF_ONLY:-}" == "true" ] \

--- a/ci/bazel-scripts/main.sh
+++ b/ci/bazel-scripts/main.sh
@@ -23,7 +23,7 @@ fi
 # - target branch is not rc--*
 # - uploading to S3 has not been requested
 
-if [[ "${CI_MERGE_REQUEST_TITLE:-}" == *"[RUN_ALL_TARGETS_AND_UPLOAD]"* ]]; then
+if [[ "${CI_MERGE_REQUEST_TITLE:-}" == *"[RUN_ALL_BAZEL_TARGETS]"* ]]; then
     RUN_ON_DIFF_ONLY="false"
     s3_upload="True"
 fi

--- a/ci/bazel-scripts/main.sh
+++ b/ci/bazel-scripts/main.sh
@@ -23,11 +23,9 @@ fi
 # - target branch is not rc--*
 # - uploading to S3 has not been requested
 
-if [[ "${CI_MERGE_REQUEST_TITLE:-}" == *"[RUN_ALL_BAZEL_TARGETS]"* ]]; then
+if [[ "${CI_MERGE_REQUEST_TITLE:-}" == *"[RUN_ALL_TARGETS_AND_UPLOAD]"* ]]; then
     RUN_ON_DIFF_ONLY="false"
-    if [[ "${CI_MERGE_REQUEST_TITLE:-}" == *"[S3_UPLOAD]"* ]]; then
-        s3_upload="True"
-    fi
+    s3_upload="True"
 fi
 
 if [ "${RUN_ON_DIFF_ONLY:-}" == "true" ] \

--- a/ci/scripts/run-build-ic.sh
+++ b/ci/scripts/run-build-ic.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 VERSION=$(git rev-parse HEAD)
 
-if [[ "${CI_MERGE_REQUEST_TITLE:-}" == *"[RUN_ALL_BAZEL_TARGETS]"* ]]; then
+if [[ "${CI_MERGE_REQUEST_TITLE:-}" == *"[RUN_ALL_TARGETS_AND_UPLOAD]"* ]]; then
     RUN_ON_DIFF_ONLY="false"
 fi
 

--- a/ci/scripts/run-build-ic.sh
+++ b/ci/scripts/run-build-ic.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 VERSION=$(git rev-parse HEAD)
 
-if [[ "${CI_MERGE_REQUEST_TITLE:-}" == *"[RUN_ALL_BAZEL_TARGETS]"* ]] || [[ "${CI_MERGE_REQUEST_TITLE:-}" == *"[S3_UPLOAD]"* ]]; then
+if [[ "${CI_MERGE_REQUEST_TITLE:-}" == *"[RUN_ALL_BAZEL_TARGETS]"* ]]; then
     RUN_ON_DIFF_ONLY="false"
 fi
 

--- a/ci/scripts/run-build-ic.sh
+++ b/ci/scripts/run-build-ic.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 VERSION=$(git rev-parse HEAD)
 
-if [[ "${CI_MERGE_REQUEST_TITLE:-}" == *"[RUN_ALL_TARGETS_AND_UPLOAD]"* ]]; then
+if [[ "${CI_MERGE_REQUEST_TITLE:-}" == *"[RUN_ALL_BAZEL_TARGETS]"* ]]; then
     RUN_ON_DIFF_ONLY="false"
 fi
 


### PR DESCRIPTION
To remove complex CI logic. we will remove the flag `S3_UPLOAD`, since it is interchangeable with `RUN_ALL_BAZEL_TARGETS` (both run all targets and upload to s3). Added a deprecation message as well.