### PR TITLE
refactor(nns): Some refactoring on how neuron subaccount addresses are calculated

### DIFF
--- a/rs/nervous_system/common/src/tests.rs
+++ b/rs/nervous_system/common/src/tests.rs
@@ -1,5 +1,9 @@
 use super::*;
 
+use crate::ledger::compute_neuron_staking_subaccount_bytes;
+use ic_base_types::PrincipalId;
+use ic_crypto_sha2::Sha256;
+
 #[test]
 fn test_wide_range_of_u64_values() {
     assert!(WIDE_RANGE_OF_U64_VALUES.contains(&0));
@@ -21,4 +25,24 @@ fn test_e8s_to_tokens() {
             e8s
         );
     }
+}
+
+#[test]
+fn test_compute_neuron_staking_subaccount_bytes() {
+    let principal_id = PrincipalId::new_user_test_id(1);
+    let nonce = 42u64;
+
+    // The equivalent implementation in the ic-js is at
+    // https://github.com/dfinity/ic-js/blob/0dd5c1954d94dad6911b73707c454f978624f607/packages/nns/src/governance.canister.ts#L952-L967.
+    let mut hasher = Sha256::new();
+    hasher.write(&[0x0c]);
+    hasher.write(b"neuron-stake");
+    hasher.write(principal_id.as_slice());
+    hasher.write(&nonce.to_be_bytes());
+    let hash = hasher.finish();
+
+    assert_eq!(
+        compute_neuron_staking_subaccount_bytes(principal_id, nonce),
+        hash
+    );
 }


### PR DESCRIPTION
# Why

The logic and documentation around NNS neuron subaccount addresses are confusing.

# What

* Update the link to dfinity_wallet to ic-js.
* Refactor the calculation logic for different neuron subaccounts to using the same function.
* Move the pointer to the ic-js link to a new test for the staking account.