### PR TITLE
chore(registry): Remove dfn_core::println in 2 places where they are no longer used

### DIFF
--- a/rs/registry/canister/src/get_node_providers_monthly_xdr_rewards.rs
+++ b/rs/registry/canister/src/get_node_providers_monthly_xdr_rewards.rs
@@ -3,8 +3,6 @@ use crate::{
     pb::v1::NodeProvidersMonthlyXdrRewards,
     registry::Registry,
 };
-#[cfg(target_arch = "wasm32")]
-use dfn_core::println;
 use ic_protobuf::registry::{
     dc::v1::DataCenterRecord, node_operator::v1::NodeOperatorRecord,
     node_rewards::v2::NodeRewardsTable,
@@ -57,6 +55,9 @@ impl Registry {
 mod tests {
     use super::*;
     use crate::mutations::do_add_node_operator::AddNodeOperatorPayload;
+
+    #[cfg(target_arch = "wasm32")]
+    use dfn_core::println;
     use ic_nervous_system_common_test_keys::{
         TEST_USER1_PRINCIPAL, TEST_USER2_PRINCIPAL, TEST_USER3_PRINCIPAL, TEST_USER4_PRINCIPAL,
     };

--- a/rs/registry/canister/src/invariants/endpoint.rs
+++ b/rs/registry/canister/src/invariants/endpoint.rs
@@ -12,9 +12,6 @@ use prost::alloc::collections::BTreeSet;
 
 use ic_protobuf::registry::node::v1::ConnectionEndpoint;
 
-#[cfg(target_arch = "wasm32")]
-use dfn_core::println;
-
 /// Node records are valid with connection endpoints containing
 /// syntactically correct data ("ip_addr" field parses as an IP address,
 /// "port" field is <= 65535):


### PR DESCRIPTION
# Why

There are 2 instances where clippy should complain when `dfn_core::println` is no longer used but it didn't get caught by CI. We need to figure why CI didn't catch it, but for now, we fix them first.