### PR TITLE
chore: update query stats log message to be less confusing in PocketIC

### DIFF
--- a/rs/query_stats/src/payload_builder.rs
+++ b/rs/query_stats/src/payload_builder.rs
@@ -163,7 +163,7 @@ impl QueryStatsPayloadBuilderImpl {
                     warn!(
                         every_n_seconds => 30,
                         self.log,
-                        "Current stats are uninitalized. This warning should go away after some minutes"
+                        "Current stats are uninitalized. This warning should go away after some minutes if the replica is processing query calls."
                     );
                     vec![]
                 }


### PR DESCRIPTION
The log message "Current stats are uninitalized. This warning should go away after some minutes" appears often in PocketIC logs. After some debugging, it turned out that this is because the PocketIC instance is not processing any query calls, but the log message indicates that it should just go away without hinting at what needs to happen. Hence, this PR extends the log message to be less confusing in PocketIC (and also make sense in production).