### PR TITLE
chore: upgrade nixpkgs in run-p8s.nix to match the version used in the prometheus-vm

### DIFF
--- a/rs/tests/run-p8s.nix
+++ b/rs/tests/run-p8s.nix
@@ -2,9 +2,9 @@
 # See: https://dfinity.atlassian.net/browse/VER-1941
 let
   nixpkgs = builtins.fetchTarball {
-    name = "nixpkgs-release-22.11";
-    url = "https://github.com/nixos/nixpkgs/archive/6047d0269b0006756103db57bd5e47b8c4b6381b.tar.gz";
-    sha256 = "sha256:0hsvb1z8nx9alrhix16bcdjnsa6bv39n691vw8bd1ikvbri4r8yv";
+    name = "nixpkgs-release-24.05";
+    url = "https://github.com/nixos/nixpkgs/archive/9db4f92627fe77165cf6dbb1fbad1c869db93023.tar.gz";
+    sha256 = "sha256:17pc791yicjg56dw3yzqbmjq28k15kvw11lcpy632l09r1v5h30w";
   };
   pkgs = import nixpkgs { };
 in


### PR DESCRIPTION
This upgrades nixpkgs used in the `run-p8s.sh` script to the same [version as used by the prometheus-vm](https://github.com/dfinity-lab/farm/blob/master/nix/sources.json#L9).