### PR TITLE
fix(deps): drop release_max_level_debug from slog features

### DIFF
--- a/Cargo.Bazel.Fuzzing.json.lock
+++ b/Cargo.Bazel.Fuzzing.json.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "78eea62df2bc566c12ff628f2434e8e7e975a218e19e97ba9ac6e796e5febb94",
+  "checksum": "d363f2ee7bfb824995ac6ae7b8ee5339fb984e8ff87b80643dbeaf0876e53a95",
   "crates": {
     "abnf 0.12.0": {
       "name": "abnf",
@@ -60065,7 +60065,6 @@
             "erased-serde",
             "max_level_trace",
             "nested-values",
-            "release_max_level_debug",
             "release_max_level_trace",
             "std"
           ],

--- a/Cargo.Bazel.json.lock
+++ b/Cargo.Bazel.json.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "3d676cd45bf79880542d9d248ec8cd98b46c6de30c352b1a5180335522fcbc12",
+  "checksum": "bc3326bc96361e72a9f9b6d58c1c2608aaa8e5890b432cabfa610ba3d71c5a1d",
   "crates": {
     "abnf 0.12.0": {
       "name": "abnf",
@@ -60214,7 +60214,6 @@
             "erased-serde",
             "max_level_trace",
             "nested-values",
-            "release_max_level_debug",
             "release_max_level_trace",
             "std"
           ],

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -633,7 +633,6 @@ simple_asn1 = "0.6.2"
 slog = { version = "2.7.0", features = [
     "max_level_trace",
     "nested-values",
-    "release_max_level_debug",
     "release_max_level_trace",
 ] }
 slog-async = { version = "2.8.0", features = ["nested-values"] }

--- a/bazel/external_crates.bzl
+++ b/bazel/external_crates.bzl
@@ -1211,7 +1211,6 @@ def external_crates_repository(name, cargo_lockfile, lockfile, sanitizers_enable
                 features = [
                     "max_level_trace",
                     "nested-values",
-                    "release_max_level_debug",
                     "release_max_level_trace",
                 ],
             ),


### PR DESCRIPTION
Currently, the `slog` dependency has two enabled features `release_max_level_debug` and `release_max_level_trace` which are contradictory and `release_max_level_debug` takes [precedence](https://github.com/slog-rs/slog/blob/master/src/lib.rs#L4039). Hence, this PR removes `release_max_level_debug` so that `release_max_level_trace` is effective.