### PR TITLE
feat(IDX): support eternal system-test-based testnets

### DIFF
--- a/rs/tests/driver/src/driver/farm.rs
+++ b/rs/tests/driver/src/driver/farm.rs
@@ -94,7 +94,7 @@ impl Farm {
         &self,
         group_base_name: &str,
         group_name: &str,
-        ttl: Duration,
+        ttl: Option<Duration>,
         mut spec: GroupSpec,
         env: &TestEnv,
     ) -> FarmResult<()> {
@@ -103,7 +103,7 @@ impl Farm {
             .clone()
             .unwrap_or_else(|| spec.required_host_features.clone());
         let path = format!("group/{}", group_name);
-        let ttl = ttl.as_secs() as u32;
+        let ttl = ttl.map(|ttl| ttl.as_secs() as u32);
         let spec = spec.add_meta(env, group_base_name);
         let body = CreateGroupRequest { ttl, spec };
         let rb = Self::json(self.post(&path), &body);
@@ -431,7 +431,7 @@ struct TimeoutSettings {
 
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Debug, Deserialize, Serialize)]
 struct CreateGroupRequest {
-    pub ttl: u32,
+    pub ttl: Option<u32>,
     pub spec: GroupSpec,
 }
 

--- a/rs/tests/driver/src/driver/group.rs
+++ b/rs/tests/driver/src/driver/group.rs
@@ -90,6 +90,12 @@ pub struct CliArgs {
     pub no_delete_farm_group: bool,
 
     #[clap(
+        long = "no-group-ttl",
+        help = "If set, The group won't have a Time-To-Live set and thus won't be garbage collected"
+    )]
+    pub no_group_ttl: bool,
+
+    #[clap(
         long = "no-summary-report",
         help = "If set, no summary/report events are produced by the test-driver."
     )]
@@ -801,7 +807,7 @@ impl SystemTestGroup {
             args.subproc_id(),
             args.filter_tests,
             args.debug_keepalive,
-            args.no_farm_keepalive,
+            args.no_farm_keepalive || args.no_group_ttl,
             args.group_base_name,
             args.k8s,
         )?;
@@ -820,7 +826,7 @@ impl SystemTestGroup {
                 InfraProvider::Farm.write_attribute(&root_env);
             }
             if with_farm || args.k8s {
-                root_env.create_group_setup(group_ctx.group_base_name.clone());
+                root_env.create_group_setup(group_ctx.group_base_name.clone(), args.no_group_ttl);
             }
             debug!(group_ctx.log(), "Created group context: {:?}", group_ctx);
         }

--- a/rs/tests/driver/src/driver/test_env_api.rs
+++ b/rs/tests/driver/src/driver/test_env_api.rs
@@ -139,7 +139,7 @@ use super::{
 use crate::{
     driver::{
         boundary_node::BoundaryNodeVm,
-        constants::{self, kibana_link, SSH_USERNAME},
+        constants::{self, kibana_link, GROUP_TTL, SSH_USERNAME},
         farm::{Farm, GroupSpec},
         log_events,
         test_env::{HasIcPrepDir, SshKeyGen, TestEnv, TestEnvAttribute},
@@ -1142,11 +1142,11 @@ fn fetch_sha256(base_url: String, file: &str, logger: Logger) -> Result<String> 
 }
 
 pub trait HasGroupSetup {
-    fn create_group_setup(&self, group_base_name: String);
+    fn create_group_setup(&self, group_base_name: String, no_group_ttl: bool);
 }
 
 impl HasGroupSetup for TestEnv {
-    fn create_group_setup(&self, group_base_name: String) {
+    fn create_group_setup(&self, group_base_name: String, no_group_ttl: bool) {
         let log = self.logger();
         if self.get_json_path(GroupSetup::attribute_name()).exists() {
             let group_setup = GroupSetup::read_attribute(self);
@@ -1155,7 +1155,10 @@ impl HasGroupSetup for TestEnv {
                 "Group {} already set up.", group_setup.infra_group_name
             );
         } else {
-            let group_setup = GroupSetup::new(group_base_name.clone());
+            // GROUP_TTL should be enough for the setup task to allocate the group on InfraProvider
+            // Afterwards, the group's TTL should be bumped via a keepalive task
+            let timeout = if no_group_ttl { None } else { Some(GROUP_TTL) };
+            let group_setup = GroupSetup::new(group_base_name.clone(), timeout);
             match InfraProvider::read_attribute(self) {
                 InfraProvider::Farm => {
                     let farm_base_url = FarmBaseUrl::read_attribute(self);

--- a/rs/tests/driver/src/driver/test_setup.rs
+++ b/rs/tests/driver/src/driver/test_setup.rs
@@ -1,9 +1,7 @@
+use crate::driver::ic::VmResources;
 use crate::driver::test_env::TestEnvAttribute;
 use serde::{Deserialize, Serialize};
 use std::time::Duration;
-
-use crate::driver::constants::GROUP_TTL;
-use crate::driver::ic::VmResources;
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct GroupSetup {
@@ -11,7 +9,7 @@ pub struct GroupSetup {
     pub infra_group_name: String,
     /// For now, the group timeout strictly translates to the corresponding group
     /// TTL.
-    pub group_timeout: Duration,
+    pub group_timeout: Option<Duration>,
     pub default_vm_resources: Option<VmResources>,
 }
 
@@ -23,7 +21,7 @@ impl GroupSetup {
     // Local
     // old: boundary_nodes_pre_master__boundary_nodes_pot-username-zh1-spm99_zh7_dfinity_network-2784039865
     // new:
-    pub fn new(group_base_name: String) -> Self {
+    pub fn new(group_base_name: String, timeout: Option<Duration>) -> Self {
         // binary_name-timestamp
         let mut res = GroupSetup {
             group_base_name: group_base_name.clone(),
@@ -34,9 +32,7 @@ impl GroupSetup {
             .expect("bad things")
             .as_millis();
         res.infra_group_name = format!("{}--{:?}", group_base_name, time).replace('_', "-");
-        // GROUP_TTL should be enough for the setup task to allocate the group on InfraProvider
-        // Afterwards, the group's TTL should be bumped via a keepalive task
-        res.group_timeout = GROUP_TTL;
+        res.group_timeout = timeout;
         res
     }
 }

--- a/rs/tests/src/mainnet_tests/mainnet_api.rs
+++ b/rs/tests/src/mainnet_tests/mainnet_api.rs
@@ -3,6 +3,7 @@ use ic_system_test_driver::driver::test_env::TestEnvAttribute;
 use ic_system_test_driver::driver::test_env_api::{HasPublicApiUrl, HasRegistryLocalStore};
 use ic_system_test_driver::driver::test_setup::GroupSetup;
 use ic_system_test_driver::driver::{
+    constants::GROUP_TTL,
     test_env::{HasIcPrepDir, TestEnv},
     test_env_api::{HasTopologySnapshot, IcNodeContainer},
 };
@@ -24,7 +25,7 @@ pub fn get_mainnet_delta_6d_c1() -> Changelog {
 pub fn mainnet_config(env: TestEnv) {
     let log = env.logger();
 
-    let group_setup = GroupSetup::new("mainnet_config_group".to_string());
+    let group_setup = GroupSetup::new("mainnet_config_group".to_string(), Some(GROUP_TTL));
     group_setup.write_attribute(&env);
     info!(&log, "Created group_setup directory");
 


### PR DESCRIPTION
# What

This adds support for deploying eternally-lived testnets using the system-testing framework, i.e. testnets that don't automatically get garbage collected.

# Why

Static testnets are EOL, no longer owned and maintained by anyone and currently broken. However there are still two static testnets left:
* `exchanges`: used by the FI team and external parties like Coinbase to test the Rosetta API.
* `bitcoin`: used to test bitcoin support. This is a static testnet since it needs to stay alive since it contains a big state that takes a long time (>1d) to setup.

This means the FI team and the Bitcoin team won't be able to test their code. So we need a replacement. The way forward for testnets is to use system-test-based testnets that are deployed via Farm (or via k8s in the future).

However system-test-based testnets always have a Time-To-Live. This means that they expire after a certain time and will be garbage collected automatically. This won't work as a replacement for the static testnets above. Therefor the system-test framework needs to support testnets without a TTL, i.e. "eternal testnets".

# How

This extends the system-test driver with a `--no-group-ttl` CLI option that when set doesn't specify a Time-To-Live for the group (testnet). This relies on Farm PR: https://github.com/dfinity-lab/farm/pull/204. 

Additionally the `ict testnet create` command gains a `--no-ttl` option:
```
ubuntu@devenv-container:/ic$ ict testnet create --help
Create IC testnet for the desired time period. This command blocks the terminal.

Usage:
  ict testnet create <testnet_name> [flags] [-- <bazel_args>]

Examples:
ict testnet create small --lifetime-mins=20
ict testnet create small --lifetime-mins=20 --verbose --output-dir=./tmp -- --test_tmpdir=./tmp (store artifacts, such as SSH keys)

Flags:
...
      --no-ttl                              Do not set a Time-To-Live (expiration time) for the testnet.
                                            If set the --lifetime-mins setting is ignored.
                                            BE CAREFUL WITH THIS OPTION BECAUSE THIS WILL CAUSE RESOURCE EXHAUSTION
                                            IF YOU FORGET TO DELETE THE TESTNET MANUALLY WHEN NO LONGER USED!
```
Example invocation:
```
ubuntu@devenv-container:/ic$ ict testnet create small --no-ttl
Raw Bazel command to be invoked:
$ bazel test //rs/tests/testing_verification/testnets:small --config=systest --cache_test_results=no --test_timeout=5400 --test_arg=--no-delete-farm-group --test_arg=--no-group-ttl
Testnet is being deployed, please wait ... (check progress in the docker dir /tmp/ict_testnets/2024-09-04_19-28-46.153.log)
{
  "farm": {
    "group": "small--1725478128712",
    "message": "Created new InfraProvider group"
  },
  ...
}

Congrats, testnet with Farm group=small--1725478128712 was deployed successfully!
WARNING Testnet will NOT expire! To prevent resource exhaustion make sure to delete the testnet manually when no longer used using:
curl -X DELETE 'https://farm.dfinity.systems/group/small--1725478128712'

ubuntu@devenv-container:/ic$ curl -X DELETE 'https://farm.dfinity.systems/group/small--1725478128712'
```

# Future Work

Support for eternal testnets also needs to be added to the k8s-based system-testing backend.
This will be done in a future PR.