### PR TITLE
feat: [CON-1373] Introduce metrics to the block stripper/assembler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5313,6 +5313,7 @@ dependencies = [
  "prost",
  "rand 0.8.5",
  "slog",
+ "thiserror",
  "tokio",
  "tower",
  "tracing",

--- a/rs/p2p/artifact_downloader/BUILD.bazel
+++ b/rs/p2p/artifact_downloader/BUILD.bazel
@@ -21,6 +21,7 @@ DEPENDENCIES = [
     "@crate_index//:prost",
     "@crate_index//:rand",
     "@crate_index//:slog",
+    "@crate_index//:thiserror",
     "@crate_index//:tokio",
     "@crate_index//:tracing",
 ]

--- a/rs/p2p/artifact_downloader/Cargo.toml
+++ b/rs/p2p/artifact_downloader/Cargo.toml
@@ -22,6 +22,7 @@ prometheus = { workspace = true }
 prost = { workspace = true }
 rand = { workspace = true }
 slog = { workspace = true }
+thiserror = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
 

--- a/rs/p2p/artifact_downloader/src/fetch_stripped_artifact/assembler.rs
+++ b/rs/p2p/artifact_downloader/src/fetch_stripped_artifact/assembler.rs
@@ -306,10 +306,9 @@ impl StrippedBlockProposal {
         let reconstructed_ingress_payload_proto =
             pb::IngressPayload::from(&reconstructed_ingress_payload);
 
-        reconstructed_block_proposal_proto
-            .value
-            .as_mut()
-            .map(|block| block.ingress_payload = Some(reconstructed_ingress_payload_proto));
+        if let Some(block) = reconstructed_block_proposal_proto.value.as_mut() {
+            block.ingress_payload = Some(reconstructed_ingress_payload_proto);
+        }
 
         reconstructed_block_proposal_proto
             .try_into()

--- a/rs/p2p/artifact_downloader/src/fetch_stripped_artifact/assembler.rs
+++ b/rs/p2p/artifact_downloader/src/fetch_stripped_artifact/assembler.rs
@@ -314,24 +314,19 @@ impl StrippedBlockProposal {
 
 #[cfg(test)]
 mod tests {
-    use ic_test_utilities_consensus::{
-        fake::{Fake, FakeContentSigner},
-        make_genesis,
-    };
     use ic_types::{
-        batch::BatchPayload,
-        consensus::{
-            dkg::{Dealings, Summary},
-            Block, BlockPayload, ConsensusMessageHash, DataPayload, Payload, Rank,
-        },
+        consensus::ConsensusMessageHash,
         crypto::{CryptoHash, CryptoHashOf},
-        messages::{Blob, HttpCallContent, HttpCanisterUpdate, HttpRequestEnvelope},
-        time::expiry_time_from_now,
         Height,
     };
-    use ic_types_test_utils::ids::node_test_id;
 
-    use crate::fetch_stripped_artifact::types::stripped::StrippedIngressPayload;
+    use crate::fetch_stripped_artifact::{
+        test_utils::{
+            fake_block_proposal_with_ingresses, fake_ingress_message,
+            fake_ingress_message_with_arg_size,
+        },
+        types::stripped::StrippedIngressPayload,
+    };
 
     use super::*;
 
@@ -464,60 +459,6 @@ mod tests {
             stripped_ingress_payload: StrippedIngressPayload { ingress_messages },
             unstripped_consensus_message_id: fake_consensus_message_id(),
         }
-    }
-
-    fn fake_block_proposal_with_ingresses(ingress_messages: Vec<SignedIngress>) -> BlockProposal {
-        let parent = make_genesis(Summary::fake()).content.block;
-        let block = Block::new(
-            ic_types::crypto::crypto_hash(parent.as_ref()),
-            Payload::new(
-                ic_types::crypto::crypto_hash,
-                BlockPayload::Data(DataPayload {
-                    batch: BatchPayload {
-                        ingress: IngressPayload::from(ingress_messages),
-                        ..BatchPayload::default()
-                    },
-                    dealings: Dealings::new_empty(Height::from(0)),
-                    idkg: None,
-                }),
-            ),
-            parent.as_ref().height.increment(),
-            Rank(0),
-            parent.as_ref().context.clone(),
-        );
-        BlockProposal::fake(block, node_test_id(0))
-    }
-
-    fn fake_ingress_message(method_name: &str) -> (SignedIngress, IngressMessageId) {
-        fake_ingress_message_with_arg_size(method_name, 0)
-    }
-
-    fn fake_ingress_message_with_arg_size(
-        method_name: &str,
-        arg_size: usize,
-    ) -> (SignedIngress, IngressMessageId) {
-        let ingress_expiry = expiry_time_from_now();
-        let content = HttpCallContent::Call {
-            update: HttpCanisterUpdate {
-                canister_id: Blob(vec![42; 8]),
-                method_name: method_name.to_string(),
-                arg: Blob(vec![0; arg_size]),
-                sender: Blob(vec![0x05]),
-                nonce: Some(Blob(vec![1, 2, 3, 4])),
-                ingress_expiry: ingress_expiry.as_nanos_since_unix_epoch(),
-            },
-        };
-        let ingress = HttpRequestEnvelope::<HttpCallContent> {
-            content,
-            sender_pubkey: Some(Blob(vec![2; 32])),
-            sender_sig: Some(Blob(vec![1; 32])),
-            sender_delegation: None,
-        }
-        .try_into()
-        .unwrap();
-        let ingress_id = IngressMessageId::from(&ingress);
-
-        (ingress, ingress_id)
     }
 
     fn fake_consensus_message_id() -> ConsensusMessageId {

--- a/rs/p2p/artifact_downloader/src/fetch_stripped_artifact/assembler.rs
+++ b/rs/p2p/artifact_downloader/src/fetch_stripped_artifact/assembler.rs
@@ -318,18 +318,9 @@ impl StrippedBlockProposal {
 
 #[cfg(test)]
 mod tests {
-    use ic_types::{
-        consensus::ConsensusMessageHash,
-        crypto::{CryptoHash, CryptoHashOf},
-        Height,
-    };
-
-    use crate::fetch_stripped_artifact::{
-        test_utils::{
-            fake_block_proposal_with_ingresses, fake_ingress_message,
-            fake_ingress_message_with_arg_size,
-        },
-        types::stripped::StrippedIngressPayload,
+    use crate::fetch_stripped_artifact::test_utils::{
+        fake_block_proposal_with_ingresses, fake_ingress_message,
+        fake_ingress_message_with_arg_size, fake_stripped_block_proposal_with_ingresses,
     };
 
     use super::*;
@@ -453,22 +444,5 @@ mod tests {
             stripped_block_proposal.try_insert_ingress_message(ingress_1),
             Err(InsertionError::NotNeeded)
         );
-    }
-
-    fn fake_stripped_block_proposal_with_ingresses(
-        ingress_messages: Vec<MaybeStrippedIngress>,
-    ) -> StrippedBlockProposal {
-        StrippedBlockProposal {
-            block_proposal_without_ingresses_proto: pb::BlockProposal::default(),
-            stripped_ingress_payload: StrippedIngressPayload { ingress_messages },
-            unstripped_consensus_message_id: fake_consensus_message_id(),
-        }
-    }
-
-    fn fake_consensus_message_id() -> ConsensusMessageId {
-        ConsensusMessageId {
-            hash: ConsensusMessageHash::BlockProposal(CryptoHashOf::new(CryptoHash(vec![]))),
-            height: Height::new(42),
-        }
     }
 }

--- a/rs/p2p/artifact_downloader/src/fetch_stripped_artifact/assembler.rs
+++ b/rs/p2p/artifact_downloader/src/fetch_stripped_artifact/assembler.rs
@@ -341,9 +341,14 @@ mod tests {
         let (ingress_2, _ingress_id_2) = fake_ingress_message_with_arg_size("fake_2", 1024);
         let block_proposal =
             fake_block_proposal_with_ingresses(vec![ingress_1.clone(), ingress_2.clone()]);
+        let consensus_message = ConsensusMessage::BlockProposal(block_proposal.clone());
 
         // strip the block
-        let mut stripped_block_proposal = block_proposal.clone().strip();
+        let MaybeStrippedConsensusMessage::StrippedBlockProposal(mut stripped_block_proposal) =
+            consensus_message.strip()
+        else {
+            panic!("Didn't properly strip the block proposal");
+        };
 
         // insert back the missing messages
         stripped_block_proposal
@@ -365,9 +370,14 @@ mod tests {
         let (ingress_2, _ingress_id_2) = fake_ingress_message_with_arg_size("fake_2", 1024);
         let block_proposal =
             fake_block_proposal_with_ingresses(vec![ingress_1.clone(), ingress_2.clone()]);
+        let consensus_message = ConsensusMessage::BlockProposal(block_proposal.clone());
 
         // strip the block
-        let mut stripped_block_proposal = block_proposal.clone().strip();
+        let MaybeStrippedConsensusMessage::StrippedBlockProposal(mut stripped_block_proposal) =
+            consensus_message.strip()
+        else {
+            panic!("Didn't properly strip the block proposal");
+        };
 
         // insert back only one missing messages
         stripped_block_proposal

--- a/rs/p2p/artifact_downloader/src/fetch_stripped_artifact/assembler.rs
+++ b/rs/p2p/artifact_downloader/src/fetch_stripped_artifact/assembler.rs
@@ -2,6 +2,7 @@ use std::{
     sync::{Arc, RwLock},
     time::Duration,
 };
+use thiserror::Error;
 
 use ic_interfaces::p2p::consensus::{
     Aborted, ArtifactAssembler, BouncerFactory, Peers, ValidatedPoolReader,
@@ -226,15 +227,19 @@ async fn get_or_fetch<P: Peers>(
     .await
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Error)]
 pub(crate) enum InsertionError {
+    #[error("Trying to an ingress message which was never missing")]
     NotNeeded,
+    #[error("Trying to an ingress message which was already inserted")]
     AlreadyInserted,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Error)]
 pub(crate) enum AssemblyError {
+    #[error("The block proposal is missing ingress message with id {0}")]
     Missing(IngressMessageId),
+    #[error("The block proposal cannot be deserialized {0}")]
     DeserializationFailed(ProxyDecodeError),
 }
 

--- a/rs/p2p/artifact_downloader/src/fetch_stripped_artifact/assembler.rs
+++ b/rs/p2p/artifact_downloader/src/fetch_stripped_artifact/assembler.rs
@@ -327,6 +327,20 @@ mod tests {
     use super::*;
 
     #[test]
+    fn strip_assemble_roundtrip_test() {
+        todo!()
+        //let (ingress_1, _) = fake_ingress_message("fake_1");
+        //let (ingress_2, _) = fake_ingress_message("fake_2");
+        //let ingress_payload = IngressPayload::from(vec![ingress_1, ingress_2]);
+
+        //// don't strip anything
+        //let stripped_payload = ingress_payload.clone().strip_ingresses(|_| false);
+        //let reconstructed_payload = stripped_payload.try_assemble();
+
+        //assert_eq!(reconstructed_payload, Ok(ingress_payload));
+    }
+
+    #[test]
     fn missing_ingress_messages_test() {
         let (ingress_1, ingress_1_id) = fake_ingress_message("fake_1");
         let (_ingress_2, ingress_2_id) = fake_ingress_message("fake_2");

--- a/rs/p2p/artifact_downloader/src/fetch_stripped_artifact/download.rs
+++ b/rs/p2p/artifact_downloader/src/fetch_stripped_artifact/download.rs
@@ -180,20 +180,17 @@ pub(crate) async fn download_ingress<P: Peers>(
 
 #[cfg(test)]
 mod tests {
-    use crate::fetch_stripped_artifact::test_utils::fake_block_proposal_with_ingresses;
+    use crate::fetch_stripped_artifact::test_utils::{
+        fake_block_proposal_with_ingresses, fake_summary_block_proposal,
+    };
 
     use super::*;
 
     use http_body_util::Full;
     use ic_logger::no_op_logger;
     use ic_p2p_test_utils::mocks::{MockPeers, MockTransport, MockValidatedPoolReader};
-    use ic_test_utilities_consensus::{
-        fake::{Fake, FakeContentSigner},
-        make_genesis,
-    };
     use ic_test_utilities_types::messages::SignedIngressBuilder;
-    use ic_types::consensus::BlockProposal;
-    use ic_types_test_utils::ids::{node_test_id, NODE_1};
+    use ic_types_test_utils::ids::NODE_1;
     use tower::ServiceExt;
 
     fn mock_pools(
@@ -367,15 +364,6 @@ mod tests {
         let block_proposal = fake_block_proposal_with_ingresses(ingress_messages);
 
         ConsensusMessage::BlockProposal(block_proposal)
-    }
-
-    fn fake_summary_block_proposal() -> ConsensusMessage {
-        let block = make_genesis(ic_types::consensus::dkg::Summary::fake())
-            .content
-            .block
-            .into_inner();
-
-        ConsensusMessage::BlockProposal(BlockProposal::fake(block, node_test_id(0)))
     }
 
     fn request(

--- a/rs/p2p/artifact_downloader/src/fetch_stripped_artifact/download.rs
+++ b/rs/p2p/artifact_downloader/src/fetch_stripped_artifact/download.rs
@@ -180,6 +180,8 @@ pub(crate) async fn download_ingress<P: Peers>(
 
 #[cfg(test)]
 mod tests {
+    use crate::fetch_stripped_artifact::test_utils::fake_block_proposal_with_ingresses;
+
     use super::*;
 
     use http_body_util::Full;
@@ -190,9 +192,7 @@ mod tests {
         make_genesis,
     };
     use ic_test_utilities_types::messages::SignedIngressBuilder;
-    use ic_types::batch::{BatchPayload, IngressPayload};
-    use ic_types::consensus::{dkg::Dealings, Block, BlockProposal, DataPayload, Payload, Rank};
-    use ic_types::Height;
+    use ic_types::consensus::BlockProposal;
     use ic_types_test_utils::ids::{node_test_id, NODE_1};
     use tower::ServiceExt;
 
@@ -364,31 +364,9 @@ mod tests {
     // Utility functions below
 
     fn fake_block_proposal(ingress_messages: Vec<SignedIngress>) -> ConsensusMessage {
-        let parent = make_genesis(ic_types::consensus::dkg::Summary::fake())
-            .content
-            .block
-            .into_inner();
+        let block_proposal = fake_block_proposal_with_ingresses(ingress_messages);
 
-        let batch = BatchPayload {
-            ingress: IngressPayload::from(ingress_messages),
-            ..Default::default()
-        };
-
-        let block = Block::new(
-            ic_types::crypto::crypto_hash(&parent),
-            Payload::new(
-                ic_types::crypto::crypto_hash,
-                BlockPayload::Data(DataPayload {
-                    batch,
-                    dealings: Dealings::new_empty(Height::from(0)),
-                    idkg: None,
-                }),
-            ),
-            parent.height.increment(),
-            Rank(0),
-            parent.context.clone(),
-        );
-        ConsensusMessage::BlockProposal(BlockProposal::fake(block, node_test_id(0)))
+        ConsensusMessage::BlockProposal(block_proposal)
     }
 
     fn fake_summary_block_proposal() -> ConsensusMessage {

--- a/rs/p2p/artifact_downloader/src/fetch_stripped_artifact/metrics.rs
+++ b/rs/p2p/artifact_downloader/src/fetch_stripped_artifact/metrics.rs
@@ -1,10 +1,55 @@
-use ic_metrics::MetricsRegistry;
+use ic_metrics::{buckets::decimal_buckets_with_zero, MetricsRegistry};
+use prometheus::{histogram_opts, labels, Histogram};
 
 #[derive(Clone)]
-pub(super) struct FetchStrippedConsensusArtifactMetrics {}
+pub(crate) struct FetchStrippedConsensusArtifactMetrics {
+    pub(crate) missing_stripped_ingress_messages: Histogram,
+    pub(crate) found_stripped_ingress_messages: Histogram,
+    pub(crate) total_ingress_messages: Histogram,
+    pub(crate) download_missing_ingress_messages_duration: Histogram,
+}
 
 impl FetchStrippedConsensusArtifactMetrics {
-    pub(crate) fn new(_metrics_registry: &MetricsRegistry) -> Self {
-        Self {}
+    pub(crate) fn new(metrics_registry: &MetricsRegistry) -> Self {
+        Self {
+            missing_stripped_ingress_messages: metrics_registry.register(
+                Histogram::with_opts(histogram_opts!(
+                    "ic_stripped_consensus_artifact_downloader_missing_stripped_ingress_messages",
+                    "Number of stripped ingress messages in a block which are not in the local \
+                    ingress pool and which have to be downloaded from peers",
+                    decimal_buckets_with_zero(0, 3),
+                    labels! {}
+                ))
+                .unwrap(),
+            ),
+            found_stripped_ingress_messages: metrics_registry.register(
+                Histogram::with_opts(histogram_opts!(
+                    "ic_stripped_consensus_artifact_downloader_found_stripped_ingress_messages",
+                    "Number of stripped ingress messages in a block which are in the local \
+                    ingress pool and which don't have to be downloaded from peers",
+                    decimal_buckets_with_zero(0, 3),
+                    labels! {}
+                ))
+                .unwrap(),
+            ),
+            total_ingress_messages: metrics_registry.register(
+                Histogram::with_opts(histogram_opts!(
+                    "ic_stripped_consensus_artifact_downloader_total_ingress_messages",
+                    "Total number of ingress messages in the block",
+                    decimal_buckets_with_zero(0, 3),
+                    labels! {}
+                ))
+                .unwrap(),
+            ),
+            download_missing_ingress_messages_duration: metrics_registry.register(
+                Histogram::with_opts(histogram_opts!(
+                    "ic_stripped_consensus_artifact_downloader_missing_stripped_ingress_messages_fetch_duration",
+                    "Download time for all the missing ingress messages in the block",
+                    decimal_buckets_with_zero(-2, 1),
+                    labels! {}
+                ))
+                .unwrap(),
+            ),
+        }
     }
 }

--- a/rs/p2p/artifact_downloader/src/fetch_stripped_artifact/mod.rs
+++ b/rs/p2p/artifact_downloader/src/fetch_stripped_artifact/mod.rs
@@ -4,4 +4,7 @@ mod metrics;
 mod stripper;
 mod types;
 
+#[cfg(test)]
+mod test_utils;
+
 pub use assembler::FetchStrippedConsensusArtifact;

--- a/rs/p2p/artifact_downloader/src/fetch_stripped_artifact/stripper.rs
+++ b/rs/p2p/artifact_downloader/src/fetch_stripped_artifact/stripper.rs
@@ -39,10 +39,9 @@ impl Strippable for ConsensusMessage {
                 let mut proto = pb::BlockProposal::from(&block_proposal);
 
                 // Remove the ingress payload from the proto.
-                proto
-                    .value
-                    .as_mut()
-                    .map(|block| block.ingress_payload = None);
+                if let Some(block) = proto.value.as_mut() {
+                    block.ingress_payload = None;
+                }
 
                 let data_payload = block_proposal.content.as_ref().payload.as_ref().as_data();
                 let stripped_ingress_payload = data_payload.batch.ingress.clone().strip();

--- a/rs/p2p/artifact_downloader/src/fetch_stripped_artifact/stripper.rs
+++ b/rs/p2p/artifact_downloader/src/fetch_stripped_artifact/stripper.rs
@@ -86,7 +86,9 @@ impl Strippable for IngressPayload {
 
 #[cfg(test)]
 mod tests {
-    use crate::fetch_stripped_artifact::test_utils::fake_ingress_message_with_arg_size;
+    use crate::fetch_stripped_artifact::test_utils::{
+        fake_ingress_message_with_arg_size, fake_summary_block_proposal,
+    };
 
     use super::*;
 
@@ -107,6 +109,18 @@ mod tests {
                     MaybeStrippedIngress::Stripped(big_ingress_id)
                 ],
             }
+        );
+    }
+
+    #[test]
+    fn summary_blocks_are_not_stripped_test() {
+        let summary_block = fake_summary_block_proposal();
+
+        let stripped = summary_block.clone().strip();
+
+        assert_eq!(
+            stripped,
+            MaybeStrippedConsensusMessage::Unstripped(summary_block)
         );
     }
 }

--- a/rs/p2p/artifact_downloader/src/fetch_stripped_artifact/test_utils.rs
+++ b/rs/p2p/artifact_downloader/src/fetch_stripped_artifact/test_utils.rs
@@ -1,0 +1,72 @@
+use ic_test_utilities_consensus::{
+    fake::{Fake, FakeContentSigner},
+    make_genesis,
+};
+use ic_types::{
+    artifact::IngressMessageId,
+    batch::{BatchPayload, IngressPayload},
+    consensus::{
+        dkg::{Dealings, Summary},
+        Block, BlockPayload, BlockProposal, DataPayload, Payload, Rank,
+    },
+    messages::{Blob, HttpCallContent, HttpCanisterUpdate, HttpRequestEnvelope, SignedIngress},
+    time::expiry_time_from_now,
+    Height,
+};
+use ic_types_test_utils::ids::node_test_id;
+
+pub(crate) fn fake_ingress_message(method_name: &str) -> (SignedIngress, IngressMessageId) {
+    fake_ingress_message_with_arg_size(method_name, 0)
+}
+
+pub(crate) fn fake_ingress_message_with_arg_size(
+    method_name: &str,
+    arg_size: usize,
+) -> (SignedIngress, IngressMessageId) {
+    let ingress_expiry = expiry_time_from_now();
+    let content = HttpCallContent::Call {
+        update: HttpCanisterUpdate {
+            canister_id: Blob(vec![42; 8]),
+            method_name: method_name.to_string(),
+            arg: Blob(vec![0; arg_size]),
+            sender: Blob(vec![0x05]),
+            nonce: Some(Blob(vec![1, 2, 3, 4])),
+            ingress_expiry: ingress_expiry.as_nanos_since_unix_epoch(),
+        },
+    };
+    let ingress = HttpRequestEnvelope::<HttpCallContent> {
+        content,
+        sender_pubkey: Some(Blob(vec![2; 32])),
+        sender_sig: Some(Blob(vec![1; 32])),
+        sender_delegation: None,
+    }
+    .try_into()
+    .unwrap();
+    let ingress_id = IngressMessageId::from(&ingress);
+
+    (ingress, ingress_id)
+}
+
+pub(crate) fn fake_block_proposal_with_ingresses(
+    ingress_messages: Vec<SignedIngress>,
+) -> BlockProposal {
+    let parent = make_genesis(Summary::fake()).content.block;
+    let block = Block::new(
+        ic_types::crypto::crypto_hash(parent.as_ref()),
+        Payload::new(
+            ic_types::crypto::crypto_hash,
+            BlockPayload::Data(DataPayload {
+                batch: BatchPayload {
+                    ingress: IngressPayload::from(ingress_messages),
+                    ..BatchPayload::default()
+                },
+                dealings: Dealings::new_empty(Height::from(0)),
+                idkg: None,
+            }),
+        ),
+        parent.as_ref().height.increment(),
+        Rank(0),
+        parent.as_ref().context.clone(),
+    );
+    BlockProposal::fake(block, node_test_id(0))
+}

--- a/rs/p2p/artifact_downloader/src/fetch_stripped_artifact/test_utils.rs
+++ b/rs/p2p/artifact_downloader/src/fetch_stripped_artifact/test_utils.rs
@@ -1,19 +1,23 @@
+use ic_protobuf::types::v1 as pb;
 use ic_test_utilities_consensus::{
     fake::{Fake, FakeContentSigner},
     make_genesis,
 };
 use ic_types::{
-    artifact::IngressMessageId,
+    artifact::{ConsensusMessageId, IngressMessageId},
     batch::{BatchPayload, IngressPayload},
     consensus::{
         dkg::{Dealings, Summary},
-        Block, BlockPayload, BlockProposal, DataPayload, Payload, Rank,
+        Block, BlockPayload, BlockProposal, ConsensusMessageHash, DataPayload, Payload, Rank,
     },
+    crypto::{CryptoHash, CryptoHashOf},
     messages::{Blob, HttpCallContent, HttpCanisterUpdate, HttpRequestEnvelope, SignedIngress},
     time::expiry_time_from_now,
     Height,
 };
 use ic_types_test_utils::ids::node_test_id;
+
+use super::types::stripped::{MaybeStrippedIngress, StrippedBlockProposal, StrippedIngressPayload};
 
 pub(crate) fn fake_ingress_message(method_name: &str) -> (SignedIngress, IngressMessageId) {
     fake_ingress_message_with_arg_size(method_name, 0)
@@ -69,4 +73,21 @@ pub(crate) fn fake_block_proposal_with_ingresses(
         parent.as_ref().context.clone(),
     );
     BlockProposal::fake(block, node_test_id(0))
+}
+
+pub(crate) fn fake_stripped_block_proposal_with_ingresses(
+    ingress_messages: Vec<MaybeStrippedIngress>,
+) -> StrippedBlockProposal {
+    StrippedBlockProposal {
+        block_proposal_without_ingresses_proto: pb::BlockProposal::default(),
+        stripped_ingress_payload: StrippedIngressPayload { ingress_messages },
+        unstripped_consensus_message_id: fake_consensus_message_id(),
+    }
+}
+
+fn fake_consensus_message_id() -> ConsensusMessageId {
+    ConsensusMessageId {
+        hash: ConsensusMessageHash::BlockProposal(CryptoHashOf::new(CryptoHash(vec![]))),
+        height: Height::new(42),
+    }
 }

--- a/rs/p2p/artifact_downloader/src/fetch_stripped_artifact/test_utils.rs
+++ b/rs/p2p/artifact_downloader/src/fetch_stripped_artifact/test_utils.rs
@@ -8,7 +8,8 @@ use ic_types::{
     batch::{BatchPayload, IngressPayload},
     consensus::{
         dkg::{Dealings, Summary},
-        Block, BlockPayload, BlockProposal, ConsensusMessageHash, DataPayload, Payload, Rank,
+        Block, BlockPayload, BlockProposal, ConsensusMessage, ConsensusMessageHash, DataPayload,
+        Payload, Rank,
     },
     crypto::{CryptoHash, CryptoHashOf},
     messages::{Blob, HttpCallContent, HttpCanisterUpdate, HttpRequestEnvelope, SignedIngress},
@@ -83,6 +84,15 @@ pub(crate) fn fake_stripped_block_proposal_with_ingresses(
         stripped_ingress_payload: StrippedIngressPayload { ingress_messages },
         unstripped_consensus_message_id: fake_consensus_message_id(),
     }
+}
+
+pub(crate) fn fake_summary_block_proposal() -> ConsensusMessage {
+    let block = make_genesis(ic_types::consensus::dkg::Summary::fake())
+        .content
+        .block
+        .into_inner();
+
+    ConsensusMessage::BlockProposal(BlockProposal::fake(block, node_test_id(0)))
 }
 
 fn fake_consensus_message_id() -> ConsensusMessageId {

--- a/rs/p2p/artifact_downloader/src/fetch_stripped_artifact/types/stripped.rs
+++ b/rs/p2p/artifact_downloader/src/fetch_stripped_artifact/types/stripped.rs
@@ -71,8 +71,8 @@ impl TryFrom<pb::StrippedBlockProposal> for StrippedBlockProposal {
                 ingress_messages: value
                     .ingress_messages
                     .into_iter()
-                    .map(|proto| todo!())
-                    .collect(),
+                    .map(MaybeStrippedIngress::try_from)
+                    .collect::<Result<Vec<_>, _>>()?,
             },
             unstripped_consensus_message_id: try_from_option_field(
                 value.unstripped_consensus_message_id,

--- a/rs/p2p/artifact_downloader/src/fetch_stripped_artifact/types/stripped.rs
+++ b/rs/p2p/artifact_downloader/src/fetch_stripped_artifact/types/stripped.rs
@@ -3,14 +3,53 @@ use ic_protobuf::{
     types::v1 as pb,
 };
 use ic_types::{
-    artifact::{ConsensusMessageId, IdentifiableArtifact, PbArtifact},
-    consensus::ConsensusMessage,
+    artifact::{ConsensusMessageId, IdentifiableArtifact, IngressMessageId, PbArtifact},
+    batch::{SelfValidatingPayload, ValidationContext, XNetPayload},
+    consensus::{dkg, idkg, Block, BlockMetadata, ConsensusMessage, Rank},
+    crypto::CryptoHashOf,
+    messages::SignedIngress,
+    signature::BasicSignature,
+    Height, ReplicaVersion,
 };
 
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug)]
-// TODO(kpop): Add all fields necessary to reconstruct a block
+pub(crate) enum MaybeStrippedIngress {
+    Full(IngressMessageId, SignedIngress),
+    Stripped(IngressMessageId),
+}
+
+/// Stripped version of the [`IngressPayload`].
+#[derive(Debug, Default)]
+pub(crate) struct StrippedIngressPayload {
+    pub(crate) ingress_messages: Vec<MaybeStrippedIngress>,
+}
+
+/// Stripped version of the [`DataPayload`].
+#[derive(Debug)]
+pub(crate) struct StrippedDataPayload {
+    pub(crate) ingress: StrippedIngressPayload,
+    //xnet: XNetPayload,
+    //self_validating: SelfValidatingPayload,
+    //canister_http: Vec<u8>,
+    //query_stats: Vec<u8>,
+    //dealings: dkg::Dealings,
+    //idkg: idkg::Payload,
+}
+
+/// Stripped version of the [`BlockProposal`].
+#[derive(Debug)]
 pub struct StrippedBlockProposal {
-    unstripped_consensus_message_id: ConsensusMessageId,
+    //pub(crate) version: ReplicaVersion,
+    //pub(crate) parent: CryptoHashOf<Block>,
+    pub(crate) payload: StrippedDataPayload,
+    //pub(crate) height: Height,
+    //pub(crate) rank: Rank,
+    //pub(crate) context: ValidationContext,
+    //pub(crate) unstripped_id: ConsensusMessageId,
+    //pub(crate) block_hash: CryptoHashOf<Block>,
+    //pub(crate) signature: BasicSignature<BlockMetadata>,
+    pub(crate) unstripped_consensus_message_id: ConsensusMessageId,
 }
 
 #[derive(Debug)]

--- a/rs/p2p/artifact_downloader/src/fetch_stripped_artifact/types/stripped.rs
+++ b/rs/p2p/artifact_downloader/src/fetch_stripped_artifact/types/stripped.rs
@@ -29,6 +29,7 @@ pub struct StrippedBlockProposal {
     pub(crate) unstripped_consensus_message_id: ConsensusMessageId,
 }
 
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug)]
 pub enum MaybeStrippedConsensusMessage {
     StrippedBlockProposal(StrippedBlockProposal),

--- a/rs/p2p/artifact_downloader/src/fetch_stripped_artifact/types/stripped.rs
+++ b/rs/p2p/artifact_downloader/src/fetch_stripped_artifact/types/stripped.rs
@@ -9,14 +9,14 @@ use ic_types::{
 };
 
 #[allow(clippy::large_enum_variant)]
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub(crate) enum MaybeStrippedIngress {
     Full(IngressMessageId, SignedIngress),
     Stripped(IngressMessageId),
 }
 
 /// Stripped version of the [`IngressPayload`].
-#[derive(Debug, Default)]
+#[derive(Debug, Default, PartialEq)]
 pub(crate) struct StrippedIngressPayload {
     pub(crate) ingress_messages: Vec<MaybeStrippedIngress>,
 }

--- a/rs/p2p/artifact_downloader/src/fetch_stripped_artifact/types/stripped.rs
+++ b/rs/p2p/artifact_downloader/src/fetch_stripped_artifact/types/stripped.rs
@@ -4,12 +4,8 @@ use ic_protobuf::{
 };
 use ic_types::{
     artifact::{ConsensusMessageId, IdentifiableArtifact, IngressMessageId, PbArtifact},
-    batch::{SelfValidatingPayload, ValidationContext, XNetPayload},
-    consensus::{dkg, idkg, Block, BlockMetadata, ConsensusMessage, Rank},
-    crypto::CryptoHashOf,
+    consensus::ConsensusMessage,
     messages::SignedIngress,
-    signature::BasicSignature,
-    Height, ReplicaVersion,
 };
 
 #[allow(clippy::large_enum_variant)]
@@ -25,30 +21,11 @@ pub(crate) struct StrippedIngressPayload {
     pub(crate) ingress_messages: Vec<MaybeStrippedIngress>,
 }
 
-/// Stripped version of the [`DataPayload`].
-#[derive(Debug)]
-pub(crate) struct StrippedDataPayload {
-    pub(crate) ingress: StrippedIngressPayload,
-    //xnet: XNetPayload,
-    //self_validating: SelfValidatingPayload,
-    //canister_http: Vec<u8>,
-    //query_stats: Vec<u8>,
-    //dealings: dkg::Dealings,
-    //idkg: idkg::Payload,
-}
-
 /// Stripped version of the [`BlockProposal`].
 #[derive(Debug)]
 pub struct StrippedBlockProposal {
-    //pub(crate) version: ReplicaVersion,
-    //pub(crate) parent: CryptoHashOf<Block>,
-    pub(crate) payload: StrippedDataPayload,
-    //pub(crate) height: Height,
-    //pub(crate) rank: Rank,
-    //pub(crate) context: ValidationContext,
-    //pub(crate) unstripped_id: ConsensusMessageId,
-    //pub(crate) block_hash: CryptoHashOf<Block>,
-    //pub(crate) signature: BasicSignature<BlockMetadata>,
+    pub(crate) block_proposal_without_ingresses_proto: pb::BlockProposal,
+    pub(crate) stripped_ingress_payload: StrippedIngressPayload,
     pub(crate) unstripped_consensus_message_id: ConsensusMessageId,
 }
 

--- a/rs/p2p/artifact_downloader/src/fetch_stripped_artifact/types/stripped.rs
+++ b/rs/p2p/artifact_downloader/src/fetch_stripped_artifact/types/stripped.rs
@@ -9,20 +9,20 @@ use ic_types::{
 };
 
 #[allow(clippy::large_enum_variant)]
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub(crate) enum MaybeStrippedIngress {
     Full(IngressMessageId, SignedIngress),
     Stripped(IngressMessageId),
 }
 
 /// Stripped version of the [`IngressPayload`].
-#[derive(Debug, Default, PartialEq)]
+#[derive(Clone, Debug, Default, PartialEq)]
 pub(crate) struct StrippedIngressPayload {
     pub(crate) ingress_messages: Vec<MaybeStrippedIngress>,
 }
 
 /// Stripped version of the [`BlockProposal`].
-#[derive(Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct StrippedBlockProposal {
     pub(crate) block_proposal_without_ingresses_proto: pb::BlockProposal,
     pub(crate) stripped_ingress_payload: StrippedIngressPayload,
@@ -30,7 +30,7 @@ pub struct StrippedBlockProposal {
 }
 
 #[allow(clippy::large_enum_variant)]
-#[derive(Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum MaybeStrippedConsensusMessage {
     StrippedBlockProposal(StrippedBlockProposal),
     Unstripped(ConsensusMessage),
@@ -83,6 +83,40 @@ impl TryFrom<pb::StrippedBlockProposal> for StrippedBlockProposal {
     }
 }
 
+impl From<StrippedBlockProposal> for pb::StrippedBlockProposal {
+    fn from(value: StrippedBlockProposal) -> Self {
+        Self {
+            block_proposal_without_ingress_payload: Some(
+                value.block_proposal_without_ingresses_proto,
+            ),
+            ingress_messages: value
+                .stripped_ingress_payload
+                .ingress_messages
+                .into_iter()
+                .map(pb::StrippedIngressMessage::from)
+                .collect(),
+            unstripped_consensus_message_id: Some(value.unstripped_consensus_message_id.into()),
+        }
+    }
+}
+
+impl From<MaybeStrippedIngress> for pb::StrippedIngressMessage {
+    fn from(value: MaybeStrippedIngress) -> Self {
+        use pb::stripped_ingress_message::Msg as MaybeStrippedIngressProto;
+
+        let msg = match value {
+            MaybeStrippedIngress::Full(_ingress_id, ingress) => {
+                MaybeStrippedIngressProto::Full(SignedRequestBytes::from(ingress).into())
+            }
+            MaybeStrippedIngress::Stripped(ingress_id) => {
+                MaybeStrippedIngressProto::Stripped(ingress_id.into())
+            }
+        };
+
+        pb::StrippedIngressMessage { msg: Some(msg) }
+    }
+}
+
 impl TryFrom<pb::StrippedIngressMessage> for MaybeStrippedIngress {
     type Error = ProxyDecodeError;
 
@@ -114,7 +148,9 @@ impl From<MaybeStrippedConsensusMessage> for pb::StrippedConsensusMessage {
             MaybeStrippedConsensusMessage::Unstripped(unstripped) => {
                 pb::stripped_consensus_message::Msg::Unstripped(unstripped.into())
             }
-            MaybeStrippedConsensusMessage::StrippedBlockProposal(_) => todo!(),
+            MaybeStrippedConsensusMessage::StrippedBlockProposal(block_proposal) => {
+                pb::stripped_consensus_message::Msg::StrippedBlockProposal(block_proposal.into())
+            }
         };
 
         Self { msg: Some(msg) }
@@ -176,4 +212,31 @@ impl PbArtifact for MaybeStrippedConsensusMessage {
     type PbMessage = pb::StrippedConsensusMessage;
 
     type PbMessageError = ProxyDecodeError;
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::fetch_stripped_artifact::test_utils::{
+        fake_ingress_message, fake_stripped_block_proposal_with_ingresses,
+    };
+
+    use super::*;
+
+    #[test]
+    fn serialize_deserialize_stripped_block_proposal_test() {
+        let (ingress_1, ingress_1_id) = fake_ingress_message("fake_1");
+        let (_ingress_2, ingress_2_id) = fake_ingress_message("fake_2");
+        let stripped_block_proposal = fake_stripped_block_proposal_with_ingresses(vec![
+            MaybeStrippedIngress::Full(ingress_1_id, ingress_1),
+            MaybeStrippedIngress::Stripped(ingress_2_id),
+        ]);
+        let original_consensus_message =
+            MaybeStrippedConsensusMessage::StrippedBlockProposal(stripped_block_proposal);
+
+        let proto = pb::StrippedConsensusMessage::from(original_consensus_message.clone());
+        let consensus_message = MaybeStrippedConsensusMessage::try_from(proto)
+            .expect("Should deserialize a valid proto");
+
+        assert_eq!(consensus_message, original_consensus_message);
+    }
 }

--- a/rs/protobuf/def/types/v1/consensus.proto
+++ b/rs/protobuf/def/types/v1/consensus.proto
@@ -219,7 +219,18 @@ message GetIngressMessageInBlockResponse {
   bytes ingress_message = 1;
 }
 
-message StrippedBlockProposal {}
+message StrippedBlockProposal {
+  BlockProposal block_proposal_without_ingress_payload = 1;
+  repeated StrippedIngressMessage ingress_messages = 2;
+  ConsensusMessageId unstripped_consensus_message_id = 3;
+}
+
+message StrippedIngressMessage {
+  oneof msg {
+    bytes full = 1;
+    IngressMessageId stripped = 2;
+  }
+}
 
 message StrippedConsensusMessage {
   oneof msg {

--- a/rs/protobuf/src/gen/types/types.v1.rs
+++ b/rs/protobuf/src/gen/types/types.v1.rs
@@ -1491,7 +1491,31 @@ pub struct GetIngressMessageInBlockResponse {
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct StrippedBlockProposal {}
+pub struct StrippedBlockProposal {
+    #[prost(message, optional, tag = "1")]
+    pub block_proposal_without_ingress_payload: ::core::option::Option<BlockProposal>,
+    #[prost(message, repeated, tag = "2")]
+    pub ingress_messages: ::prost::alloc::vec::Vec<StrippedIngressMessage>,
+    #[prost(message, optional, tag = "3")]
+    pub unstripped_consensus_message_id: ::core::option::Option<ConsensusMessageId>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct StrippedIngressMessage {
+    #[prost(oneof = "stripped_ingress_message::Msg", tags = "1, 2")]
+    pub msg: ::core::option::Option<stripped_ingress_message::Msg>,
+}
+/// Nested message and enum types in `StrippedIngressMessage`.
+pub mod stripped_ingress_message {
+    #[allow(clippy::derive_partial_eq_without_eq)]
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    pub enum Msg {
+        #[prost(bytes, tag = "1")]
+        Full(::prost::alloc::vec::Vec<u8>),
+        #[prost(message, tag = "2")]
+        Stripped(super::IngressMessageId),
+    }
+}
 #[allow(clippy::large_enum_variant)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]


### PR DESCRIPTION
Example of metrics after 1 minutes of running `consensus_performance` test:

```
# HELP ic_stripped_consensus_artifact_downloader_found_stripped_ingress_messages Number of stripped ingress messages in a block which are in the local ingress pool and which don't have to be downloaded from peers
# TYPE ic_stripped_consensus_artifact_downloader_found_stripped_ingress_messages histogram
ic_stripped_consensus_artifact_downloader_found_stripped_ingress_messages_bucket{le="0"} 23
ic_stripped_consensus_artifact_downloader_found_stripped_ingress_messages_bucket{le="1"} 23
ic_stripped_consensus_artifact_downloader_found_stripped_ingress_messages_bucket{le="2"} 23
ic_stripped_consensus_artifact_downloader_found_stripped_ingress_messages_bucket{le="5"} 59
ic_stripped_consensus_artifact_downloader_found_stripped_ingress_messages_bucket{le="10"} 59
ic_stripped_consensus_artifact_downloader_found_stripped_ingress_messages_bucket{le="20"} 59
ic_stripped_consensus_artifact_downloader_found_stripped_ingress_messages_bucket{le="50"} 59
ic_stripped_consensus_artifact_downloader_found_stripped_ingress_messages_bucket{le="100"} 60
ic_stripped_consensus_artifact_downloader_found_stripped_ingress_messages_bucket{le="200"} 61
ic_stripped_consensus_artifact_downloader_found_stripped_ingress_messages_bucket{le="500"} 61
ic_stripped_consensus_artifact_downloader_found_stripped_ingress_messages_bucket{le="1000"} 111
ic_stripped_consensus_artifact_downloader_found_stripped_ingress_messages_bucket{le="2000"} 111
ic_stripped_consensus_artifact_downloader_found_stripped_ingress_messages_bucket{le="5000"} 111
ic_stripped_consensus_artifact_downloader_found_stripped_ingress_messages_bucket{le="+Inf"} 111
ic_stripped_consensus_artifact_downloader_found_stripped_ingress_messages_sum 26874
ic_stripped_consensus_artifact_downloader_found_stripped_ingress_messages_count 111
# HELP ic_stripped_consensus_artifact_downloader_missing_stripped_ingress_messages Number of stripped ingress messages in a block which are not in the local ingress pool and which have to be downloaded from peers
# TYPE ic_stripped_consensus_artifact_downloader_missing_stripped_ingress_messages histogram
ic_stripped_consensus_artifact_downloader_missing_stripped_ingress_messages_bucket{le="0"} 54
ic_stripped_consensus_artifact_downloader_missing_stripped_ingress_messages_bucket{le="1"} 55
ic_stripped_consensus_artifact_downloader_missing_stripped_ingress_messages_bucket{le="2"} 56
ic_stripped_consensus_artifact_downloader_missing_stripped_ingress_messages_bucket{le="5"} 56
ic_stripped_consensus_artifact_downloader_missing_stripped_ingress_messages_bucket{le="10"} 71
ic_stripped_consensus_artifact_downloader_missing_stripped_ingress_messages_bucket{le="20"} 106
ic_stripped_consensus_artifact_downloader_missing_stripped_ingress_messages_bucket{le="50"} 106
ic_stripped_consensus_artifact_downloader_missing_stripped_ingress_messages_bucket{le="100"} 106
ic_stripped_consensus_artifact_downloader_missing_stripped_ingress_messages_bucket{le="200"} 106
ic_stripped_consensus_artifact_downloader_missing_stripped_ingress_messages_bucket{le="500"} 106
ic_stripped_consensus_artifact_downloader_missing_stripped_ingress_messages_bucket{le="1000"} 111
ic_stripped_consensus_artifact_downloader_missing_stripped_ingress_messages_bucket{le="2000"} 111
ic_stripped_consensus_artifact_downloader_missing_stripped_ingress_messages_bucket{le="5000"} 111
ic_stripped_consensus_artifact_downloader_missing_stripped_ingress_messages_bucket{le="+Inf"} 111
ic_stripped_consensus_artifact_downloader_missing_stripped_ingress_messages_sum 3265
ic_stripped_consensus_artifact_downloader_missing_stripped_ingress_messages_count 111
# HELP ic_stripped_consensus_artifact_downloader_missing_stripped_ingress_messages_fetch_duration Download time for all the missing ingress messages in the block
# TYPE ic_stripped_consensus_artifact_downloader_missing_stripped_ingress_messages_fetch_duration histogram
ic_stripped_consensus_artifact_downloader_missing_stripped_ingress_messages_fetch_duration_bucket{le="0"} 0
ic_stripped_consensus_artifact_downloader_missing_stripped_ingress_messages_fetch_duration_bucket{le="0.01"} 0
ic_stripped_consensus_artifact_downloader_missing_stripped_ingress_messages_fetch_duration_bucket{le="0.02"} 0
ic_stripped_consensus_artifact_downloader_missing_stripped_ingress_messages_fetch_duration_bucket{le="0.05"} 0
ic_stripped_consensus_artifact_downloader_missing_stripped_ingress_messages_fetch_duration_bucket{le="0.1"} 0
ic_stripped_consensus_artifact_downloader_missing_stripped_ingress_messages_fetch_duration_bucket{le="0.2"} 0
ic_stripped_consensus_artifact_downloader_missing_stripped_ingress_messages_fetch_duration_bucket{le="0.5"} 49
ic_stripped_consensus_artifact_downloader_missing_stripped_ingress_messages_fetch_duration_bucket{le="1"} 57
ic_stripped_consensus_artifact_downloader_missing_stripped_ingress_messages_fetch_duration_bucket{le="2"} 57
ic_stripped_consensus_artifact_downloader_missing_stripped_ingress_messages_fetch_duration_bucket{le="5"} 57
ic_stripped_consensus_artifact_downloader_missing_stripped_ingress_messages_fetch_duration_bucket{le="10"} 57
ic_stripped_consensus_artifact_downloader_missing_stripped_ingress_messages_fetch_duration_bucket{le="20"} 57
ic_stripped_consensus_artifact_downloader_missing_stripped_ingress_messages_fetch_duration_bucket{le="50"} 57
ic_stripped_consensus_artifact_downloader_missing_stripped_ingress_messages_fetch_duration_bucket{le="+Inf"} 57
ic_stripped_consensus_artifact_downloader_missing_stripped_ingress_messages_fetch_duration_sum 27.118961200000005
ic_stripped_consensus_artifact_downloader_missing_stripped_ingress_messages_fetch_duration_count 57
# HELP ic_stripped_consensus_artifact_downloader_total_ingress_messages Total number of ingress messages in the block
# TYPE ic_stripped_consensus_artifact_downloader_total_ingress_messages histogram
ic_stripped_consensus_artifact_downloader_total_ingress_messages_bucket{le="0"} 131
ic_stripped_consensus_artifact_downloader_total_ingress_messages_bucket{le="1"} 148
ic_stripped_consensus_artifact_downloader_total_ingress_messages_bucket{le="2"} 149
ic_stripped_consensus_artifact_downloader_total_ingress_messages_bucket{le="5"} 185
ic_stripped_consensus_artifact_downloader_total_ingress_messages_bucket{le="10"} 185
ic_stripped_consensus_artifact_downloader_total_ingress_messages_bucket{le="20"} 185
ic_stripped_consensus_artifact_downloader_total_ingress_messages_bucket{le="50"} 185
ic_stripped_consensus_artifact_downloader_total_ingress_messages_bucket{le="100"} 186
ic_stripped_consensus_artifact_downloader_total_ingress_messages_bucket{le="200"} 187
ic_stripped_consensus_artifact_downloader_total_ingress_messages_bucket{le="500"} 187
ic_stripped_consensus_artifact_downloader_total_ingress_messages_bucket{le="1000"} 242
ic_stripped_consensus_artifact_downloader_total_ingress_messages_bucket{le="2000"} 242
ic_stripped_consensus_artifact_downloader_total_ingress_messages_bucket{le="5000"} 242
ic_stripped_consensus_artifact_downloader_total_ingress_messages_bucket{le="+Inf"} 242
ic_stripped_consensus_artifact_downloader_total_ingress_messages_sum 30155
ic_stripped_consensus_artifact_downloader_total_ingress_messages_count 242
```