### PR TITLE
refactor: CanisterId::try_from_principal_id.

### DIFF
--- a/rs/types/base_types/src/canister_id.rs
+++ b/rs/types/base_types/src/canister_id.rs
@@ -1,4 +1,4 @@
-use super::{PrincipalId, PrincipalIdError, SubnetId};
+use super::{PrincipalId, PrincipalIdClass, PrincipalIdError, SubnetId};
 use candid::types::principal::PrincipalError;
 use candid::{CandidType, Principal};
 use ic_protobuf::{proxy::ProxyDecodeError, types::v1 as pb};
@@ -90,6 +90,45 @@ impl CanisterId {
 
         Self(PrincipalId::new_opaque_from_array(data, blob_length))
     }
+
+    /// Converts from PrincipalId.
+    ///
+    /// There is a impl TryFrom<PrincipalId> for CanisterId, but we can't make it
+    /// do the behavior of this (yet), because there could be callers of TryFrom
+    /// who are implicitly relying on Err never being returned.
+    //
+    // Maintainers: Keep this consistent with from_u64.
+    pub fn try_from_principal_id(principal_id: PrincipalId) -> Result<Self, CanisterIdError> {
+        // Must be opaque.
+        if principal_id.class() != Ok(PrincipalIdClass::Opaque) {
+            return Err(CanisterIdError::InvalidPrincipalId(format!(
+                "Principal ID {} is of class {:?} (not Opaque).",
+                principal_id,
+                principal_id.class(),
+            )));
+        }
+
+        // Must be of length 10.
+        let raw = principal_id.as_slice();
+        if raw.len() != 10 {
+            return Err(CanisterIdError::InvalidPrincipalId(format!(
+                "Principal ID {} consists of {} bytes (not 10).",
+                principal_id,
+                raw.len(),
+            )));
+        }
+
+        // Byte 8 (penultimate) must be 0x01.
+        if raw[8] != 0x01 {
+            return Err(CanisterIdError::InvalidPrincipalId(format!(
+                "Byte 8 (9th) of Principal ID {} is not 0x01: {}",
+                principal_id,
+                hex::encode(raw),
+            )));
+        }
+
+        Ok(CanisterId(principal_id))
+    }
 }
 
 impl AsRef<PrincipalId> for CanisterId {
@@ -110,6 +149,7 @@ impl fmt::Display for CanisterId {
     }
 }
 
+/// Deprecated. Use CanisterId::try_from_principal_id.
 impl TryFrom<PrincipalId> for CanisterId {
     type Error = CanisterIdError;
 
@@ -214,3 +254,6 @@ impl From<CanisterId> for Principal {
         principal_id.into()
     }
 }
+
+#[cfg(test)]
+mod tests;

--- a/rs/types/base_types/src/canister_id/tests.rs
+++ b/rs/types/base_types/src/canister_id/tests.rs
@@ -1,0 +1,65 @@
+use super::*;
+use std::str::FromStr;
+
+#[test]
+fn test_try_from_principal_id() {
+    // Happy case.
+    let canister_id = CanisterId::from_u64(42);
+    let principal_id: PrincipalId = canister_id.get();
+    assert_eq!(
+        CanisterId::try_from_principal_id(principal_id),
+        Ok(canister_id)
+    );
+
+    // Typical sad case: not even opaque (here, self-authenticating).
+    let definitely_not_a_canister_id =
+        PrincipalId::from_str("ubktz-haghv-fqsdh-23fhi-3urex-bykoz-pvpfd-5rs6w-qpo3t-nf2dv-oae")
+            .unwrap();
+    match CanisterId::try_from_principal_id(definitely_not_a_canister_id) {
+        Err(CanisterIdError::InvalidPrincipalId(description)) => {
+            let description = description.to_lowercase();
+            for key_word in ["opaque", "self", "authenticating", "class"] {
+                assert!(
+                    description.contains(key_word),
+                    "{} not in {:?}",
+                    key_word,
+                    description
+                );
+            }
+        }
+        wrong => panic!("{:?}", wrong),
+    }
+
+    // Opaque, but wrong length.
+    match CanisterId::try_from_principal_id(PrincipalId::new_opaque(&[0xDE, 0xAD, 0xBE, 0xEF][..]))
+    {
+        Err(CanisterIdError::InvalidPrincipalId(description)) => {
+            let description = description.to_lowercase();
+            for key_word in ["10", "5", "bytes"] {
+                assert!(
+                    description.contains(key_word),
+                    "{} not in {:?}",
+                    key_word,
+                    description
+                );
+            }
+        }
+        wrong => panic!("{:?}", wrong),
+    }
+
+    // Near miss: opaque, length 10, but penultimate is not 0x01 (?!).
+    match CanisterId::try_from_principal_id(PrincipalId::new_opaque(&[42; 9][..])) {
+        Err(CanisterIdError::InvalidPrincipalId(description)) => {
+            let description = description.to_lowercase();
+            for key_word in ["byte", "8", "0x01"] {
+                assert!(
+                    description.contains(key_word),
+                    "{} not in {:?}",
+                    key_word,
+                    description
+                );
+            }
+        }
+        wrong => panic!("{:?}", wrong),
+    }
+}


### PR DESCRIPTION
CanisterId::try_from(principal_id) never actually returns Err, even though not all principal IDs are canister IDs.

This new method does what CanisterId::try_from(principal_id) should have done.

# Future Work

We should look at all callers of `CanisterId::try_from(principal_id)` (including try_into) and figure out what they should call instead:

* `CanisterId::unchecked_from_principal`: This is for callers who assume that `try_from` always returns `Ok` even if the input is invalid. E.g. they immediately do `.unwrap()`, and assume that it never panics.

* `CanisterId::try_from_principal_id`: This is for callers who do NOT make that assumption. That is, they are prepared for Err to be returned. In some cases, they would even prefer that Err be returned, even though so far, `try_from` does not do that.

A simple text search would find all direct callers of `try_from`, but a simple text search would NOT find callers of `try_into` (this is (one reason) why `try_into` is "evil"). To overcome this, we can find all the code that needs to be addressed by commenting out

```
impl TryFrom<PrincipalId> for CanisterId { ...
```

and building everything. I have already made significant progress on that, but those changes should not be in this PR, because this _can_ stand alone, and already adds some value by itself, even though there are hardly any callers (so far). In fact, all those migration changes should probably not be in a single PR, because it would require approval from many teams.

After we get all tests passing with the aforementioned code commented out, we can uncomment, and change the implementation of `try_from` to simply call `try_from_principal_id`. Then, we can change all callers of `try_from_principal_id` back to `try_from`.

Unfortunately, some _other_ "secondary" `TryFrom` implementations (e.g. `impl TryFrom<&[u8]> for CanisterId`) depend on the main one (i.e. `CanisterId::try_from(principal_id)`). Callers of secondary `TryFrom` implementations should be migrated in a similar way.