### PR TITLE
feat(sns): Postpone enforcing the 100K SNS neuron limit till swap begins

### DIFF
--- a/rs/nervous_system/integration_tests/tests/constraints_dependencies.rs
+++ b/rs/nervous_system/integration_tests/tests/constraints_dependencies.rs
@@ -11,11 +11,14 @@ use ic_sns_init::{
 // against the sum of intermediate limits set for various types of SNS neurons. These intermediate
 // limits are not checked within just one canister, so testing their inter-consistency is done here.
 //
+// Many SNS neurons may be created after a swap succeeds. The number of such neurons is limited to
+// `MAX_NEURONS_FOR_DIRECT_PARTICIPANTS`. This limit is enforced only *during* the swap. In effect,
+// this limits the maximum number of swap participants to `MAX_NEURONS_FOR_DIRECT_PARTICIPANTS` /
+// #number of SNS neurons per participant (a.k.a., the SNS basket count).
+//
 // If a `CreateServiceNervousSystem` proposal is valid, its parameters must comply, in particular,
 // with the following limits (checked at the time of proposal submission):
 // - The number of SNS neurons per basket does not exceed `MAX_SNS_NEURONS_PER_BASKET`.
-// - The number of SNS neurons created for direct swap participants in the worst case cannot exceed
-//   `MAX_NEURONS_FOR_DIRECT_PARTICIPANTS`.
 // - The number of SNS neurons granted to the dapp developers doe snot exceed
 //   `MAX_DEVELOPER_DISTRIBUTION_COUNT`.
 //

--- a/rs/sns/init/src/lib.rs
+++ b/rs/sns/init/src/lib.rs
@@ -3432,7 +3432,6 @@ mod test {
         // Happy scenario: Test that if the constraints are satisfied, the validation passes.
         {
             let sns_init_payload = SnsInitPayload {
-                // This value being high enough ensures there wouldn't be too many SNS neurons.
                 min_participant_icp_e8s: Some(20_000 * E8),
                 ..sns_init_payload.clone()
             };
@@ -3445,7 +3444,7 @@ mod test {
         // Test that if the constraints are violated, the validation, indeed, fails.
         {
             let sns_init_payload = SnsInitPayload {
-                // This value being so low ensures there would be too many SNS neurons.
+                // This value being so low ensures there would be a problem.
                 min_participant_icp_e8s: Some(1),
                 ..sns_init_payload
             };
@@ -3455,12 +3454,23 @@ mod test {
                 .validate_participation_constraints()
                 .unwrap_err();
             {
-                let expected_error_fragment = "min_participant_icp_e8s=1 is too small.";
+                let expected_error_fragment_a = "min_participant_icp_e8s=1 is too small.";
                 assert!(
-                    error.contains(expected_error_fragment),
+                    error.contains(expected_error_fragment_a),
                     "Unexpected error: `{}`\nExpected `{}`",
                     error,
-                    expected_error_fragment
+                    expected_error_fragment_a,
+                );
+
+                let expecrted_error_fragment_b = "the following inequality must hold: \
+                     min_participant_icp_e8s >= neuron_basket_count \
+                     * (neuron_minimum_stake_e8s + transaction_fee_e8s) \
+                     * max_direct_participation_icp_e8s / initial_swap_amount_e8s";
+                assert!(
+                    error.contains(expecrted_error_fragment_b),
+                    "Unexpected error: `{}`\nExpected `{}`",
+                    error,
+                    expecrted_error_fragment_b,
                 );
             }
         }


### PR DESCRIPTION
This PR lifts an overly strict requirement due to which some SNS configurations were deemed invalid if it was possible to exceed the 100K SNS neurons limit for swap participants in the worst case. 

[Recently](https://github.com/dfinity/ic/pull/924), the maximum number of swap participants has started to be enforced during swap participation, so checking the condition upfront is no longer needed for security, and so we lift it to allow for more SNS configurations.