### PR TITLE
refactor: Redo the ValidateEq annotations for CanisterQueues

### DIFF
--- a/rs/replicated_state/src/canister_state/queues.rs
+++ b/rs/replicated_state/src/canister_state/queues.rs
@@ -103,12 +103,11 @@ pub struct NewCanisterQueues {
     ingress_queue: IngressQueue,
 
     /// Per remote canister input and output queues.
-    #[validate_eq(CompareWithValidateEq)]
     canister_queues: BTreeMap<CanisterId, (CanisterQueue, CanisterQueue)>,
 
     /// Pool holding all messages in `canister_queues`, with support for time-based
     /// expiration and load shedding.
-    #[validate_eq(Ignore)]
+    #[validate_eq(CompareWithValidateEq)]
     pool: MessagePool,
 
     /// Slot and memory reservation stats. Message count and size stats are
@@ -118,7 +117,6 @@ pub struct NewCanisterQueues {
     /// Round-robin schedule for `pop_input()` across ingress, local subnet senders
     /// and remote subnet senders; as well as within local subnet senders and remote
     /// subnet senders.
-    #[validate_eq(CompareWithValidateEq)]
     input_schedule: InputSchedule,
 }
 

--- a/rs/replicated_state/src/canister_state/queues/input_schedule.rs
+++ b/rs/replicated_state/src/canister_state/queues/input_schedule.rs
@@ -7,8 +7,6 @@ use ic_protobuf::proxy::ProxyDecodeError;
 use ic_protobuf::state::queues::v1::canister_queues::NextInputQueue;
 use ic_protobuf::types::v1 as pb_types;
 use ic_types::CanisterId;
-use ic_validate_eq::ValidateEq;
-use ic_validate_eq_derive::ValidateEq;
 use std::collections::{BTreeSet, VecDeque};
 use std::convert::TryFrom;
 
@@ -49,13 +47,12 @@ mod tests;
 ///    may be ensured in either schedule (this is because we rely on
 ///    `ReplicatedState::canister_states` to decide whether a canister is local,
 ///    and this will mis-identify a recently deleted local sender as remote).
-#[derive(Clone, Debug, Default, PartialEq, Eq, ValidateEq)]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub(super) struct InputSchedule {
     /// The input source (local senders, ingress or remote senders) at the front
     /// of the schedule.
     ///
     /// Used to implement round-robin rotation over input sources.
-    #[validate_eq(Ignore)]
     next_input_source: InputSource,
 
     /// FIFO queue of local subnet sender canister IDs ensuring round-robin
@@ -298,7 +295,7 @@ impl TryFrom<(i32, Vec<pb_types::CanisterId>, Vec<pb_types::CanisterId>)> for In
 
 /// Encapsulates information about `CanisterQueues`,
 /// used in detecting a loop when consuming the input messages.
-#[derive(Clone, Debug, Default, PartialEq, Eq, ValidateEq)]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct CanisterQueuesLoopDetector {
     pub local_queue_skip_count: usize,
     pub remote_queue_skip_count: usize,

--- a/rs/replicated_state/src/canister_state/queues/message_pool.rs
+++ b/rs/replicated_state/src/canister_state/queues/message_pool.rs
@@ -8,6 +8,8 @@ use ic_types::messages::{
 };
 use ic_types::time::CoarseTime;
 use ic_types::{CountBytes, Time};
+use ic_validate_eq::ValidateEq;
+use ic_validate_eq_derive::ValidateEq;
 use std::collections::{BTreeMap, BTreeSet};
 use std::ops::{AddAssign, SubAssign};
 use std::sync::Arc;
@@ -169,9 +171,10 @@ impl ResponsePlaceholder {
 /// All pool operations except `expire_messages()` and
 /// `calculate_message_stats()` (only called during deserialization) execute in
 /// at most `O(log(N))` time.
-#[derive(Clone, Eq, PartialEq, Debug, Default)]
+#[derive(Clone, Eq, PartialEq, Debug, Default, ValidateEq)]
 pub(super) struct MessagePool {
     /// Pool contents.
+    #[validate_eq(CompareWithValidateEq)]
     messages: BTreeMap<Id, RequestOrResponse>,
 
     /// Records the (implicit) deadlines of all the outbound guaranteed response

--- a/rs/replicated_state/src/canister_state/queues/queue.rs
+++ b/rs/replicated_state/src/canister_state/queues/queue.rs
@@ -95,7 +95,7 @@ impl CanisterQueueItem {
 /// for that response to be consumed while the request still consumes a slot in
 /// the queue; so we must additionally explicitly limit the number of slots used
 /// by requests to the queue capacity.
-#[derive(Clone, Eq, PartialEq, Debug, ValidateEq)]
+#[derive(Clone, Eq, PartialEq, Debug)]
 pub(crate) struct CanisterQueue {
     /// A FIFO queue of requests and responses.
     ///


### PR DESCRIPTION
Have it compare everything except message payloads.