### PR TITLE
fix(IDX): hourly schedule BAZEL_TARGET

### DIFF
--- a/.github/workflows-source/schedule-hourly.yml
+++ b/.github/workflows-source/schedule-hourly.yml
@@ -90,7 +90,7 @@ jobs:
         uses:  ./.github/actions/bazel-test-all/
         with:
           BAZEL_COMMAND: "test"
-          BAZEL_TARGETS: "//..."
+          BAZEL_TARGETS: "//rs/..."
           BAZEL_CI_CONFIG: "--config=ci --repository_cache=/cache/bazel"
           BAZEL_EXTRA_ARGS: "--keep_going --test_tag_filters=system_test_hourly"
           HONEYCOMB_API_TOKEN: ${{ secrets.HONEYCOMB_API_TOKEN }}

--- a/.github/workflows/schedule-hourly.yml
+++ b/.github/workflows/schedule-hourly.yml
@@ -86,7 +86,7 @@ jobs:
         uses: ./.github/actions/bazel-test-all/
         with:
           BAZEL_COMMAND: "test"
-          BAZEL_TARGETS: "//..."
+          BAZEL_TARGETS: "//rs/..."
           BAZEL_CI_CONFIG: "--config=ci --repository_cache=/cache/bazel"
           BAZEL_EXTRA_ARGS: "--keep_going --test_tag_filters=system_test_hourly"
           HONEYCOMB_API_TOKEN: ${{ secrets.HONEYCOMB_API_TOKEN }}


### PR DESCRIPTION
Only run `//rs/...` targets to omit `//publish/..` targets. `//rs/...` covers all system tests that have hourly system test tag.