### PR TITLE
chore(boundary): increase the number of duration buckets in metrics

### DIFF
--- a/rs/boundary_node/ic_boundary/src/metrics.rs
+++ b/rs/boundary_node/ic_boundary/src/metrics.rs
@@ -46,9 +46,7 @@ use crate::{
 
 const KB: f64 = 1024.0;
 
-pub const HTTP_DURATION_BUCKETS: &[f64] = &[
-    0.01, 0.025, 0.05, 0.1, 0.2, 0.3, 0.5, 0.75, 1.0, 1.5, 2.0, 3.0, 5.0, 7.0, 11.0,
-];
+pub const HTTP_DURATION_BUCKETS: &[f64] = &[0.05, 0.2, 0.5, 1.0, 2.0, 4.0, 7.0, 11.0];
 pub const HTTP_REQUEST_SIZE_BUCKETS: &[f64] = &[128.0, KB, 2.0 * KB, 4.0 * KB, 8.0 * KB];
 pub const HTTP_RESPONSE_SIZE_BUCKETS: &[f64] = &[1.0 * KB, 8.0 * KB, 64.0 * KB, 256.0 * KB];
 

--- a/rs/boundary_node/ic_boundary/src/metrics.rs
+++ b/rs/boundary_node/ic_boundary/src/metrics.rs
@@ -46,7 +46,9 @@ use crate::{
 
 const KB: f64 = 1024.0;
 
-pub const HTTP_DURATION_BUCKETS: &[f64] = &[0.05, 0.2, 1.0, 2.0];
+pub const HTTP_DURATION_BUCKETS: &[f64] = &[
+    0.01, 0.025, 0.05, 0.1, 0.2, 0.3, 0.5, 0.75, 1.0, 1.5, 2.0, 3.0, 5.0, 7.0, 11.0,
+];
 pub const HTTP_REQUEST_SIZE_BUCKETS: &[f64] = &[128.0, KB, 2.0 * KB, 4.0 * KB, 8.0 * KB];
 pub const HTTP_RESPONSE_SIZE_BUCKETS: &[f64] = &[1.0 * KB, 8.0 * KB, 64.0 * KB, 256.0 * KB];
 


### PR DESCRIPTION
**Rationale**:
With the introduction of the `/api/v3/call` (synchronous call), response latency between `ic-boundary` and `replica` can reach up to 10 seconds. To accurately capture and export Prometheus latency metrics, we need to extend the bucket range to accommodate this increased latency.