### PR TITLE
chore(IDX): remove install nsc step

### DIFF
--- a/.github/workflows/test-namespace-darwin.yaml
+++ b/.github/workflows/test-namespace-darwin.yaml
@@ -21,10 +21,6 @@ jobs:
     timeout-minutes: 120
     runs-on: namespace-profile-darwin # profile created in namespace console
     steps:
-      - name: Install nsc
-        run: |
-          # A recent version is required for `nsc bazel cache setup`
-          curl -fsSL https://get.namespace.so/cloud/install.sh | sh -s -- --version 0.0.386
       - name: Set up Bazel cache
         run: |
           # Creates a bazelrc configuration fragment which tells bazel where the cache lives.


### PR DESCRIPTION
We can remove this as `nsc` is now installed by default on the runners.