### PR TITLE
chore(EXC-1721): Backtrace Test Canister

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -196,6 +196,7 @@ go_deps.bzl               @dfinity/idx
 /rs/replicated_state/src/page_map/                      @dfinity/ic-message-routing-owners @dfinity/execution
 /rs/rosetta-api/                                        @dfinity/finint
 /rs/rust_canisters/                                     @dfinity/nns-team
+/rs/rust_canisters/backtrace-canister					@difinity/execution
 /rs/rust_canisters/memory_test/                         @dfinity/execution
 /rs/rust_canisters/call_tree_test/                      @dfinity/execution
 /rs/rust_canisters/proxy_canister/                      @dfinity/networking

--- a/Cargo.Bazel.Fuzzing.json.lock
+++ b/Cargo.Bazel.Fuzzing.json.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "78eea62df2bc566c12ff628f2434e8e7e975a218e19e97ba9ac6e796e5febb94",
+  "checksum": "9a303195556dbcad653778b542317a8a1bfa00c6b83b48dea37e655a8c17e583",
   "crates": {
     "abnf 0.12.0": {
       "name": "abnf",
@@ -18009,7 +18009,7 @@
               "target": "ic_verify_bls_signature"
             },
             {
-              "id": "ic-wasm 0.8.1",
+              "id": "ic-wasm 0.8.4",
               "target": "ic_wasm"
             },
             {
@@ -30213,14 +30213,14 @@
       ],
       "license_file": null
     },
-    "ic-wasm 0.8.1": {
+    "ic-wasm 0.8.4": {
       "name": "ic-wasm",
-      "version": "0.8.1",
+      "version": "0.8.4",
       "package_url": "https://github.com/dfinity/ic-wasm",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/ic-wasm/0.8.1/download",
-          "sha256": "941376953c00628d8edae0adcad4b6e882c01cbfd5416d2ac2bc5fb709927737"
+          "url": "https://static.crates.io/crates/ic-wasm/0.8.4/download",
+          "sha256": "45bc33855672981ae4a2f4e77c1a77d1bdc0756fb1b36ad0dbe47df77a955e2d"
         }
       },
       "targets": [
@@ -30305,7 +30305,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.8.1"
+        "version": "0.8.4"
       },
       "license": "Apache-2.0",
       "license_ids": [
@@ -76716,7 +76716,7 @@
   },
   "binary_crates": [
     "canbench 0.1.4",
-    "ic-wasm 0.8.1",
+    "ic-wasm 0.8.4",
     "metrics-proxy 0.1.0"
   ],
   "workspace_members": {
@@ -77922,7 +77922,7 @@
     "ic-test-state-machine-client 3.0.1",
     "ic-utils 0.37.0",
     "ic-verify-bls-signature 0.6.0",
-    "ic-wasm 0.8.1",
+    "ic-wasm 0.8.4",
     "ic-xrc-types 1.2.0",
     "ic0 0.18.11",
     "ic_bls12_381 0.10.0",

--- a/Cargo.Bazel.Fuzzing.toml.lock
+++ b/Cargo.Bazel.Fuzzing.toml.lock
@@ -5270,9 +5270,9 @@ dependencies = [
 
 [[package]]
 name = "ic-wasm"
-version = "0.8.1"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "941376953c00628d8edae0adcad4b6e882c01cbfd5416d2ac2bc5fb709927737"
+checksum = "45bc33855672981ae4a2f4e77c1a77d1bdc0756fb1b36ad0dbe47df77a955e2d"
 dependencies = [
  "anyhow",
  "candid",

--- a/Cargo.Bazel.json.lock
+++ b/Cargo.Bazel.json.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "3d676cd45bf79880542d9d248ec8cd98b46c6de30c352b1a5180335522fcbc12",
+  "checksum": "d5e5c80acd20398c7be1fd7805f7dd33dc747f8d24ad70b7497f6a8933f21a3d",
   "crates": {
     "abnf 0.12.0": {
       "name": "abnf",
@@ -17810,7 +17810,7 @@
               "target": "ic_verify_bls_signature"
             },
             {
-              "id": "ic-wasm 0.8.1",
+              "id": "ic-wasm 0.8.4",
               "target": "ic_wasm"
             },
             {
@@ -30062,14 +30062,14 @@
       ],
       "license_file": null
     },
-    "ic-wasm 0.8.1": {
+    "ic-wasm 0.8.4": {
       "name": "ic-wasm",
-      "version": "0.8.1",
+      "version": "0.8.4",
       "package_url": "https://github.com/dfinity/ic-wasm",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/ic-wasm/0.8.1/download",
-          "sha256": "941376953c00628d8edae0adcad4b6e882c01cbfd5416d2ac2bc5fb709927737"
+          "url": "https://static.crates.io/crates/ic-wasm/0.8.4/download",
+          "sha256": "45bc33855672981ae4a2f4e77c1a77d1bdc0756fb1b36ad0dbe47df77a955e2d"
         }
       },
       "targets": [
@@ -30154,7 +30154,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.8.1"
+        "version": "0.8.4"
       },
       "license": "Apache-2.0",
       "license_ids": [
@@ -76971,7 +76971,7 @@
   },
   "binary_crates": [
     "canbench 0.1.4",
-    "ic-wasm 0.8.1",
+    "ic-wasm 0.8.4",
     "metrics-proxy 0.1.0"
   ],
   "workspace_members": {
@@ -78142,7 +78142,7 @@
     "ic-test-state-machine-client 3.0.1",
     "ic-utils 0.37.0",
     "ic-verify-bls-signature 0.6.0",
-    "ic-wasm 0.8.1",
+    "ic-wasm 0.8.4",
     "ic-xrc-types 1.2.0",
     "ic0 0.18.11",
     "ic_bls12_381 0.10.0",

--- a/Cargo.Bazel.toml.lock
+++ b/Cargo.Bazel.toml.lock
@@ -5266,9 +5266,9 @@ dependencies = [
 
 [[package]]
 name = "ic-wasm"
-version = "0.8.1"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "941376953c00628d8edae0adcad4b6e882c01cbfd5416d2ac2bc5fb709927737"
+checksum = "45bc33855672981ae4a2f4e77c1a77d1bdc0756fb1b36ad0dbe47df77a955e2d"
 dependencies = [
  "anyhow",
  "candid",

--- a/bazel/canisters.bzl
+++ b/bazel/canisters.bzl
@@ -188,9 +188,9 @@ def finalize_wasm(*, name, src_wasm, service_file = None, version_file, testonly
         message = "Finalizing canister " + name,
         tools = ["@crate_index//:ic-wasm__ic-wasm", "@pigz"],
         cmd_bash = " && ".join([
-            "{ic_wasm} {input_wasm} -o $@.shrunk shrink",
-            "{ic_wasm} $@.shrunk -o $@.meta metadata candid:service --visibility public --file " + "$(location {})".format(service_file) if not (service_file == None) else "cp $@.shrunk $@.meta",  # if service_file is None, don't include a service file
-            "{ic_wasm} $@.meta -o $@.ver metadata git_commit_id --visibility public --file {version_file}",
+            "{ic_wasm} {input_wasm} -o $@.shrunk shrink --keep-name-section",
+            "{ic_wasm} $@.shrunk -o $@.meta metadata candid:service --keep-name-section --visibility public --file " + "$(location {})".format(service_file) if not (service_file == None) else "cp $@.shrunk $@.meta",  # if service_file is None, don't include a service file
+            "{ic_wasm} $@.meta -o $@.ver metadata git_commit_id --keep-name-section --visibility public --file {version_file}",
             "{pigz} --processes 16 --no-name $@.ver --stdout > $@",
         ])
             .format(input_wasm = "$(location {})".format(src_wasm), ic_wasm = "$(location @crate_index//:ic-wasm__ic-wasm)", version_file = "$(location {})".format(version_file), pigz = "$(location @pigz)"),

--- a/bazel/external_crates.bzl
+++ b/bazel/external_crates.bzl
@@ -660,7 +660,7 @@ def external_crates_repository(name, cargo_lockfile, lockfile, sanitizers_enable
                 default_features = False,
             ),
             "ic-wasm": crate.spec(
-                version = "^0.8.1",
+                version = "^0.8.4",
                 features = [
                     "exe",
                 ],

--- a/rs/execution_environment/BUILD.bazel
+++ b/rs/execution_environment/BUILD.bazel
@@ -61,6 +61,7 @@ MACRO_DEPENDENCIES = []
 DEV_DEPENDENCIES = [
     # Keep sorted.
     "//rs/interfaces/state_manager/mocks",
+    "//rs/rust_canisters/canister_test",
     "//rs/state_machine_tests",
     "//rs/test_utilities",
     "//rs/test_utilities/execution_environment",
@@ -128,8 +129,10 @@ rust_ic_test_suite(
     srcs = glob(["tests/*.rs"]),
     aliases = ALIASES,
     compile_data = glob(["tests/test-data/**"]),
-    data = DATA,
-    env = ENV,
+    data = DATA + ["//rs/rust_canisters/backtrace_canister:backtrace-canister"],
+    env = dict(ENV.items() + [
+        ("BACKTRACE_CANISTER_WASM_PATH", "$(rootpath //rs/rust_canisters/backtrace_canister:backtrace-canister)"),
+    ]),
     proc_macro_deps = MACRO_DEPENDENCIES + MACRO_DEV_DEPENDENCIES,
     tags = [
         "test_macos",
@@ -157,6 +160,7 @@ BENCH_DEPENDENCIES = [
     "//rs/nns/constants",
     "//rs/registry/subnet_type",
     "//rs/replicated_state",
+    "//rs/rust_canisters/canister_test",
     "//rs/system_api",
     "//rs/test_utilities",
     "//rs/test_utilities/execution_environment",
@@ -231,7 +235,6 @@ rust_ic_bench(
     deps = [
         # Keep sorted.
         "//rs/execution_environment/benches/lib:execution_environment_bench",
-        "//rs/rust_canisters/canister_test",
         "//rs/state_machine_tests",
         "//rs/types/base_types",
         "//rs/types/types_test_utils",
@@ -246,7 +249,6 @@ rust_library(
     deps = [
         # Keep sorted.
         "//rs/execution_environment/benches/lib:execution_environment_bench",
-        "//rs/rust_canisters/canister_test",
         "//rs/state_machine_tests",
         "@crate_index//:candid",
         "@crate_index//:serde",
@@ -264,7 +266,6 @@ rust_ic_bench(
         # Keep sorted.
         ":utils",
         "//rs/execution_environment/benches/lib:execution_environment_bench",
-        "//rs/rust_canisters/canister_test",
         "//rs/state_machine_tests",
         "@crate_index//:candid",
         "@crate_index//:serde",

--- a/rs/execution_environment/tests/backtraces.rs
+++ b/rs/execution_environment/tests/backtraces.rs
@@ -1,0 +1,45 @@
+use candid::Encode;
+use ic_registry_subnet_type::SubnetType;
+use ic_state_machine_tests::{StateMachine, StateMachineBuilder};
+use ic_types::{CanisterId, Cycles};
+
+const B: u128 = 1_000 * 1_000 * 1_000;
+
+fn env_with_backtrace_canister() -> (StateMachine, CanisterId) {
+    let wasm = canister_test::Project::cargo_bin_maybe_from_env("backtrace_canister", &[]);
+
+    let env = StateMachineBuilder::new()
+        .with_subnet_type(SubnetType::Application)
+        .build();
+
+    let initial_cycles = Cycles::new(1_000_000 * B);
+    let canister_id = env
+        .install_canister_with_cycles(wasm.bytes(), vec![], None, initial_cycles)
+        .unwrap();
+
+    (env, canister_id)
+}
+
+#[test]
+fn backtrace_test_unreachable() {
+    let (env, canister_id) = env_with_backtrace_canister();
+    assert!(env
+        .execute_ingress(canister_id, "unreachable", Encode!(&()).unwrap())
+        .is_err());
+}
+
+#[test]
+fn backtrace_test_oob() {
+    let (env, canister_id) = env_with_backtrace_canister();
+    assert!(env
+        .execute_ingress(canister_id, "oob", Encode!(&()).unwrap())
+        .is_err());
+}
+
+#[test]
+fn backtrace_test_ic0_trap() {
+    let (env, canister_id) = env_with_backtrace_canister();
+    assert!(env
+        .execute_ingress(canister_id, "ic0_trap", Encode!(&()).unwrap())
+        .is_err());
+}

--- a/rs/rust_canisters/backtrace_canister/BUILD.bazel
+++ b/rs/rust_canisters/backtrace_canister/BUILD.bazel
@@ -1,0 +1,55 @@
+load("@rules_rust//rust:defs.bzl", "rust_test", "rust_binary")
+load("//bazel:canisters.bzl", "rust_canister")
+
+package(default_visibility = ["//visibility:public"])
+
+DEPENDENCIES = [
+    # Keep sorted.
+    "@crate_index//:candid",
+    "@crate_index//:ic-cdk",
+]
+
+MACRO_DEPENDENCIES = [
+    # Keep sorted.
+    "@crate_index//:ic-cdk-macros",
+]
+
+DEV_DEPENDENCIES = []
+
+MACRO_DEV_DEPENDENCIES = []
+
+ALIASES = {}
+
+rust_canister(
+    name = "backtrace-canister",
+    srcs = ["src/main.rs"],
+    aliases = ALIASES,
+    proc_macro_deps = MACRO_DEPENDENCIES,
+    service_file = ":backtrace_canister.did",
+    deps = DEPENDENCIES,
+)
+
+rust_test(
+    name = "backtrace_canister_test",
+    srcs = ["src/main.rs"],
+    aliases = ALIASES,
+    data = ["backtrace_canister.did"],
+    env = {
+        "DID_PATH": "rs/rust_canisters/backtrace_canister/backtrace_canister.did",
+    },
+    proc_macro_deps = MACRO_DEPENDENCIES + MACRO_DEV_DEPENDENCIES,
+    deps = DEPENDENCIES + DEV_DEPENDENCIES,
+)
+
+rust_binary(
+    name = "backtrace-canister-binary",
+    # testonly = True,
+    srcs = ["src/main.rs"],
+    aliases = ALIASES,
+    proc_macro_deps = MACRO_DEPENDENCIES,
+    visibility = [
+        # "//rs:release-pkg",
+        # "//rs:system-tests-pkg",
+    ],
+    deps = DEPENDENCIES, 
+)

--- a/rs/rust_canisters/backtrace_canister/Cargo.toml
+++ b/rs/rust_canisters/backtrace_canister/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "backtrace-canister"
+version = "0.1.0"
+edition = "2021"
+
+[[bin]]
+name = "backtrace-canister"
+path = "src/main.rs"
+
+[dependencies]
+candid = { workspace = true }
+ic-cdk = { workspace = true }
+ic-cdk-macros = { workspace = true }

--- a/rs/rust_canisters/backtrace_canister/README.md
+++ b/rs/rust_canisters/backtrace_canister/README.md
@@ -1,0 +1,15 @@
+Backtrace Canister
+================================
+
+Build
+-----
+
+```bash
+# Build the Wasm binary
+bazel build //rs/rust_canisters/backtrace_canister:backtrace-canister
+
+# Find the optimized canister binary from the root `ic` directory:
+ls -l bazel-bin/rs/rust_canisters/backtrace_canister/backtrace-canister.wasm.gz
+# From other directories:
+ls -l $(bazel info bazel-bin)/rs/rust_canisters/backtrace_canister/backtrace-canister.wasm.gz
+```

--- a/rs/rust_canisters/backtrace_canister/backtrace_canister.did
+++ b/rs/rust_canisters/backtrace_canister/backtrace_canister.did
@@ -1,0 +1,1 @@
+service : { ic0_trap : () -> (); oob : () -> (); unreachable : () -> () }

--- a/rs/rust_canisters/backtrace_canister/src/main.rs
+++ b/rs/rust_canisters/backtrace_canister/src/main.rs
@@ -1,0 +1,65 @@
+use candid::candid_method;
+use ic_cdk_macros::update;
+
+#[candid_method(update)]
+#[update]
+fn unreachable() {
+    #[cfg(target_arch = "wasm32")]
+    core::arch::wasm32::unreachable();
+    #[cfg(not(target_arch = "wasm32"))]
+    panic!("uh oh");
+}
+
+#[candid_method(update)]
+#[update]
+fn oob() {
+    let address = (u32::MAX - 10) as *const usize; // In the last page of Wasm memory.
+    let _count = unsafe { core::ptr::read_volatile(address) };
+}
+
+#[candid_method(update)]
+#[update]
+fn ic0_trap() {
+    panic!("uh oh");
+}
+
+// When run on native this prints the candid service definition of this
+// canister, from the methods annotated with `candid_method` above.
+//
+// Note that `cargo test` calls `main`, and `export_service` (which defines
+// `__export_service` in the current scope) needs to be called exactly once. So
+// in addition to `not(target_family = "wasm")` we have a `not(test)` guard here
+// to avoid calling `export_service`, which we need to call in the test below.
+#[cfg(not(any(target_family = "wasm", test)))]
+fn main() {
+    // The line below generates did types and service definition from the
+    // methods annotated with `candid_method` above. The definition is then
+    // obtained with `__export_service()`.
+    candid::export_service!();
+    std::print!("{}", __export_service());
+}
+
+#[cfg(any(target_family = "wasm", test))]
+fn main() {}
+
+#[test]
+fn check_candid_file() {
+    let did_path = match std::env::var("DID_PATH") {
+        Ok(v) => v,
+        Err(_e) => "backtrace_canister.did".to_string(),
+    };
+    let candid = String::from_utf8(std::fs::read(did_path).unwrap()).unwrap();
+
+    // See comments in main above
+    candid::export_service!();
+    let expected = __export_service();
+
+    if candid != expected {
+        panic!(
+            "Generated candid definition does not match backtrace_canister.did. Run `bazel \
+            run //rs/rust_canisters/backtrace_canister:backtrace-canister-binary > \
+            rs/rust_canisters/backtrace_canister/backtrace_canister.did` to update \
+            the candid file."
+        )
+    }
+}


### PR DESCRIPTION
Add a `rust_canister` with endpoints which crash in different ways where we'd like to report a canister backtrace. This canister can then be used in tests to assert that the backtrace is present. For now we just add tests that assert the endpoint is an error.

We also need to modify the `ic-wasm` commands for the `rust_canister` bazel rules to ensure that the name section is present in the generated Wasm as it will be needed to produce backtraces.