### PR TITLE
chore: improve canister log memory usage metric buckets

### DIFF
--- a/rs/execution_environment/src/metrics.rs
+++ b/rs/execution_environment/src/metrics.rs
@@ -446,37 +446,40 @@ pub fn cycles_histogram<S: Into<String>>(
     metrics_registry.histogram(name, help, decimal_buckets_with_zero(6, 15))
 }
 
-/// Returns buckets appropriate for Wasm and Stable memories
-fn memory_buckets() -> Vec<f64> {
-    const K: u64 = 1024;
-    const M: u64 = K * 1024;
-    const G: u64 = M * 1024;
-    let mut buckets: Vec<_> = [
-        0,
-        4 * K,
-        64 * K,
-        M,
-        10 * M,
-        50 * M,
-        100 * M,
-        500 * M,
-        G,
-        2 * G,
-        3 * G,
-        4 * G,
-        5 * G,
-        6 * G,
-        7 * G,
-        8 * G,
-    ]
-    .iter()
-    .chain([MAX_STABLE_MEMORY_IN_BYTES, MAX_WASM_MEMORY_IN_BYTES].iter())
-    .cloned()
-    .collect();
+/// Returns unique and sorted buckets.
+pub fn unique_sorted_buckets(buckets: &[u64]) -> Vec<f64> {
     // Ensure that all buckets are unique
+    let mut buckets = buckets.to_vec();
     buckets.sort_unstable();
     buckets.dedup();
     buckets.into_iter().map(|x| x as f64).collect()
+}
+
+/// Returns buckets appropriate for Wasm and Stable memories
+fn memory_buckets() -> Vec<f64> {
+    const KIB: u64 = 1024;
+    const MIB: u64 = 1024 * KIB;
+    const GIB: u64 = 1024 * MIB;
+    unique_sorted_buckets(&[
+        0,
+        4 * KIB,
+        64 * KIB,
+        MIB,
+        10 * MIB,
+        50 * MIB,
+        100 * MIB,
+        500 * MIB,
+        GIB,
+        2 * GIB,
+        3 * GIB,
+        4 * GIB,
+        5 * GIB,
+        6 * GIB,
+        7 * GIB,
+        8 * GIB,
+        MAX_STABLE_MEMORY_IN_BYTES,
+        MAX_WASM_MEMORY_IN_BYTES,
+    ])
 }
 
 /// Returns a histogram with buckets appropriate for Canister memory.

--- a/rs/execution_environment/src/scheduler.rs
+++ b/rs/execution_environment/src/scheduler.rs
@@ -1789,6 +1789,7 @@ impl Scheduler for SchedulerImpl {
                             ),
                             FlagStatus::Disabled => NumInstructions::from(0),
                         };
+                    // TODO(EXC-1722): remove after migrating to v2.
                     self.metrics
                         .canister_log_memory_usage
                         .observe(canister.system_state.canister_log.used_space() as f64);

--- a/rs/execution_environment/src/scheduler.rs
+++ b/rs/execution_environment/src/scheduler.rs
@@ -1792,6 +1792,9 @@ impl Scheduler for SchedulerImpl {
                     self.metrics
                         .canister_log_memory_usage
                         .observe(canister.system_state.canister_log.used_space() as f64);
+                    self.metrics
+                        .canister_log_memory_usage_v2
+                        .observe(canister.system_state.canister_log.used_space() as f64);
                     total_canister_history_memory_usage += canister.canister_history_memory_usage();
                     total_canister_memory_usage += canister.memory_usage();
                     total_canister_balance += canister.system_state.balance();

--- a/rs/execution_environment/src/scheduler/scheduler_metrics.rs
+++ b/rs/execution_environment/src/scheduler/scheduler_metrics.rs
@@ -27,7 +27,7 @@ pub(super) struct SchedulerMetrics {
     pub(super) canister_compute_allocation_violation: IntCounter,
     pub(super) canister_balance: Histogram,
     pub(super) canister_binary_size: Histogram,
-    pub(super) canister_log_memory_usage: Histogram,
+    pub(super) canister_log_memory_usage: Histogram, // TODO(EXC-1722): remove after migrating to v2.
     pub(super) canister_log_memory_usage_v2: Histogram,
     pub(super) canister_wasm_memory_usage: Histogram,
     pub(super) canister_stable_memory_usage: Histogram,
@@ -150,6 +150,7 @@ impl SchedulerMetrics {
                 "Canisters Wasm binary size distribution in bytes.",
                 metrics_registry,
             ),
+            // TODO(EXC-1722): remove after migrating to v2.
             canister_log_memory_usage: memory_histogram(
                 "canister_log_memory_usage_bytes",
                 "Canisters log memory usage distribution in bytes.",

--- a/rs/execution_environment/tests/canister_logging.rs
+++ b/rs/execution_environment/tests/canister_logging.rs
@@ -1203,7 +1203,7 @@ fn test_logging_of_long_running_dts_over_checkpoint() {
 #[test]
 fn test_canister_log_memory_usage_bytes() {
     // Test canister logging metrics record the size of the log.
-    let metric = "canister_log_memory_usage_bytes";
+    let metric = "canister_log_memory_usage_bytes_v2";
     const PAYLOAD_SIZE: usize = 1_000;
     let (env, canister_id, _controller) = setup_with_controller(
         wat_canister()


### PR DESCRIPTION
This PR improve canister log memory usage metric by using better buckets.

Originally this metric was using memory buckets for WASM memory which is too big (order of GB) when canister log current limit is 4 KiB.

EXC-1722