### PR TITLE
fix: Fix brown paper bag bug in `InputSchedule`

### DIFF
--- a/rs/replicated_state/src/canister_state/queues/input_schedule.rs
+++ b/rs/replicated_state/src/canister_state/queues/input_schedule.rs
@@ -147,7 +147,8 @@ impl InputSchedule {
             InputQueueType::LocalSubnet => self.local_sender_schedule.pop_front(),
             InputQueueType::RemoteSubnet => self.remote_sender_schedule.pop_front(),
         }?;
-        assert!(self.scheduled_senders.remove(&sender));
+        let removed = self.scheduled_senders.remove(&sender);
+        debug_assert!(removed);
         Some(sender)
     }
 

--- a/rs/replicated_state/src/canister_state/queues/input_schedule.rs
+++ b/rs/replicated_state/src/canister_state/queues/input_schedule.rs
@@ -147,7 +147,7 @@ impl InputSchedule {
             InputQueueType::LocalSubnet => self.local_sender_schedule.pop_front(),
             InputQueueType::RemoteSubnet => self.remote_sender_schedule.pop_front(),
         }?;
-        debug_assert!(self.scheduled_senders.remove(&sender));
+        assert!(self.scheduled_senders.remove(&sender));
         Some(sender)
     }
 


### PR DESCRIPTION
Trying too hard to avoid panics resulted in a panic.

One of the invariants of `InputSchedule` is that the queues and the `scheduled_senders` map stay in sync: a canister is in one of the queues iff it's in `scheduled_senders`. The code originally had an `assert` around `scheduled_senders.remove()`, which I accidentally turned into a `debug_assert`. Meaning that the code would run perfectly fine when tested; but would break in release mode.

Also, the underlying assumption for making this a soft invariant was that worst-case we would end up with a canister that was never scheduled or scheduled too often; maybe with a replica diverging after starting from a checkpoint.

In reality, because we rely on different sources for `has_input()` and `pop_input()`, something that only works if `CanisterQueues` is internally consistent, an inconsistency between `has_input()` (`true`) and `pop_input()` (`None`) resulted in Execution panicking. At a point and with a message ("tried to unwrap a None value") that were almost entirely useless for debugging the root cause.

All of the above happened in a test, the code is not yet used anywhere in production.