### PR TITLE
test(consensus): Output e2e latency in the consensus performance test

### DIFF
--- a/rs/tests/consensus/utils/src/performance.rs
+++ b/rs/tests/consensus/utils/src/performance.rs
@@ -23,7 +23,7 @@ const MAX_RETRIES: u32 = 10;
 const RETRY_WAIT: Duration = Duration::from_secs(10);
 const SUCCESS_THRESHOLD: f64 = 0.33; // If more than 33% of the expected calls are successful the test passes
 const REQUESTS_DISPATCH_EXTRA_TIMEOUT: Duration = Duration::from_secs(1);
-const TEST_DURATION: Duration = Duration::from_secs(60);
+const TEST_DURATION: Duration = Duration::from_secs(5 * 60);
 
 const INGRESS_BYTES_COUNT_METRIC: &str = "consensus_ingress_message_bytes_delivered_count";
 const INGRESS_BYTES_SUM_METRIC: &str = "consensus_ingress_message_bytes_delivered_sum";

--- a/rs/tests/consensus/utils/src/performance.rs
+++ b/rs/tests/consensus/utils/src/performance.rs
@@ -273,7 +273,8 @@ async fn get_consensus_metrics(nodes: &[IcNodeSnapshot]) -> ConsensusMetrics {
     let avg_ingress_messages = average(&metrics[INGRESS_MESSAGES_SUM_METRIC]);
     let avg_ingress_bytes = average(&metrics[INGRESS_BYTES_SUM_METRIC]);
     let avg_latency_sum = average_f64(&latency_metrics[INGRESS_MESSAGE_E2E_LATENCY_SUM_METRICS]);
-    let avg_latency_count = average_f64(&latency_metrics[INGRESS_MESSAGE_E2E_LATENCY_COUNT_METRICS]);
+    let avg_latency_count =
+        average_f64(&latency_metrics[INGRESS_MESSAGE_E2E_LATENCY_COUNT_METRICS]);
 
     ConsensusMetrics {
         delivered_blocks: avg_blocks,

--- a/rs/tests/consensus/utils/src/performance.rs
+++ b/rs/tests/consensus/utils/src/performance.rs
@@ -23,11 +23,15 @@ const MAX_RETRIES: u32 = 10;
 const RETRY_WAIT: Duration = Duration::from_secs(10);
 const SUCCESS_THRESHOLD: f64 = 0.33; // If more than 33% of the expected calls are successful the test passes
 const REQUESTS_DISPATCH_EXTRA_TIMEOUT: Duration = Duration::from_secs(1);
-const TEST_DURATION: Duration = Duration::from_secs(5 * 60);
+const TEST_DURATION: Duration = Duration::from_secs(60);
 
 const INGRESS_BYTES_COUNT_METRIC: &str = "consensus_ingress_message_bytes_delivered_count";
 const INGRESS_BYTES_SUM_METRIC: &str = "consensus_ingress_message_bytes_delivered_sum";
 const INGRESS_MESSAGES_SUM_METRIC: &str = "consensus_ingress_messages_delivered_sum";
+const INGRESS_MESSAGE_E2E_LATENCY_SUM_METRICS: &str =
+    "replica_http_ingress_watcher_wait_for_certification_duration_seconds_sum";
+const INGRESS_MESSAGE_E2E_LATENCY_COUNT_METRICS: &str =
+    "replica_http_ingress_watcher_wait_for_certification_duration_seconds_count";
 
 pub fn test_with_rt_handle(
     env: TestEnv,
@@ -165,6 +169,7 @@ pub struct TestMetrics {
     blocks_per_second: f64,
     throughput_bytes_per_second: f64,
     throughput_messages_per_second: f64,
+    average_e2e_latency: f64,
 }
 
 impl TestMetrics {
@@ -180,6 +185,7 @@ impl TestMetrics {
             metrics_difference.delivered_ingress_messages_bytes as f64 / duration.as_secs_f64();
         let throughput_messages_per_second =
             metrics_difference.delivered_ingress_messages as f64 / duration.as_secs_f64();
+        let e2e_latency = metrics_difference.latency_sum / metrics_difference.latency_count;
 
         Self {
             blocks_per_second,
@@ -187,6 +193,7 @@ impl TestMetrics {
                 / (load_metrics.total_calls() as f64),
             throughput_bytes_per_second,
             throughput_messages_per_second,
+            average_e2e_latency: e2e_latency,
         }
     }
 }
@@ -195,11 +202,16 @@ impl std::fmt::Display for TestMetrics {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         writeln!(f, "Success rate: {:.1}%", 100. * self.success_rate)?;
         writeln!(f, "Block rate: {:.1} blocks/s", self.blocks_per_second)?;
-        write!(
+        writeln!(
             f,
             "Throughput: {:.1} MiB/s, {:.1} messages/s",
             self.throughput_bytes_per_second / (1024. * 1024.),
             self.throughput_messages_per_second
+        )?;
+        write!(
+            f,
+            "Avarage E2E ingress message latency: {:.1}s",
+            self.average_e2e_latency
         )
     }
 }
@@ -209,6 +221,8 @@ struct ConsensusMetrics {
     delivered_blocks: u64,
     delivered_ingress_messages: u64,
     delivered_ingress_messages_bytes: u64,
+    latency_sum: f64,
+    latency_count: f64,
 }
 
 impl std::ops::Sub for ConsensusMetrics {
@@ -221,6 +235,8 @@ impl std::ops::Sub for ConsensusMetrics {
                 - other.delivered_ingress_messages,
             delivered_ingress_messages_bytes: self.delivered_ingress_messages_bytes
                 - other.delivered_ingress_messages_bytes,
+            latency_sum: self.latency_sum - other.latency_sum,
+            latency_count: self.latency_count - other.latency_count,
         }
     }
 }
@@ -235,19 +251,36 @@ async fn get_consensus_metrics(nodes: &[IcNodeSnapshot]) -> ConsensusMetrics {
         ],
     );
 
+    let latency_fetcher = MetricsFetcher::new(
+        nodes.iter().cloned(),
+        vec![
+            INGRESS_MESSAGE_E2E_LATENCY_SUM_METRICS.to_string(),
+            INGRESS_MESSAGE_E2E_LATENCY_COUNT_METRICS.to_string(),
+        ],
+    );
+
     let metrics = fetcher
         .fetch::<u64>()
         .await
         .expect("Should be able to fetch the metrics");
 
+    let latency_metrics = latency_fetcher
+        .fetch::<f64>()
+        .await
+        .expect("Should be able to fetch the latency metrics");
+
     let avg_blocks = average(&metrics[INGRESS_BYTES_COUNT_METRIC]);
     let avg_ingress_messages = average(&metrics[INGRESS_MESSAGES_SUM_METRIC]);
     let avg_ingress_bytes = average(&metrics[INGRESS_BYTES_SUM_METRIC]);
+    let avg_latency_sum = average_f64(&latency_metrics[INGRESS_MESSAGE_E2E_LATENCY_SUM_METRICS]);
+    let avg_latency_count = average_f64(&latency_metrics[INGRESS_MESSAGE_E2E_LATENCY_COUNT_METRICS]);
 
     ConsensusMetrics {
         delivered_blocks: avg_blocks,
         delivered_ingress_messages: avg_ingress_messages,
         delivered_ingress_messages_bytes: avg_ingress_bytes,
+        latency_sum: avg_latency_sum,
+        latency_count: avg_latency_count,
     }
 }
 
@@ -279,6 +312,7 @@ pub async fn persist_metrics(
                 "blocks_per_second": metrics.blocks_per_second,
                 "throughput_bytes_per_second": metrics.throughput_bytes_per_second,
                 "throughput_messages_per_second": metrics.throughput_messages_per_second,
+                "average_e2e_latency": metrics.average_e2e_latency,
             }
         }
     );
@@ -325,4 +359,10 @@ fn average(nums: &[u64]) -> u64 {
     assert!(!nums.is_empty());
 
     nums.iter().sum::<u64>() / (nums.len() as u64)
+}
+
+fn average_f64(nums: &[f64]) -> f64 {
+    assert!(!nums.is_empty());
+
+    nums.iter().sum::<f64>() / (nums.len() as f64)
 }


### PR DESCRIPTION
I'm using `replica_http_ingress_watcher_wait_for_certification_duration_seconds` metrics to compute, essentially doing the following query:
```
avg(delta(replica_http_ingress_watcher_wait_for_certification_duration_seconds_sum[15m]) / delta(replica_http_ingress_watcher_wait_for_certification_duration_seconds_count[15m]))
```

```
2024-09-05 15:44:34.488 INFO[uvms_logs_stream:StdOut] [uvm=test-driver] TEST_LOG: Task setup               PASSED  in 132.36s   -- Exited with code 0.
2024-09-05 15:44:34.488 INFO[uvms_logs_stream:StdOut] [uvm=test-driver] TEST_LOG: Task test_small_messages PASSED  in 103.57s
2024-09-05 15:44:34.488 INFO[uvms_logs_stream:StdOut] [uvm=test-driver] TEST_LOG:      Success rate: 100.0%
2024-09-05 15:44:34.488 INFO[uvms_logs_stream:StdOut] [uvm=test-driver] TEST_LOG:      Block rate: 0.4 blocks/s
2024-09-05 15:44:34.601 INFO[uvms_logs_stream:StdOut] [uvm=test-driver] TEST_LOG:      Throughput: 1.3 MiB/s, 305.1 messages/s
2024-09-05 15:44:34.601 INFO[uvms_logs_stream:StdOut] [uvm=test-driver] TEST_LOG:      Avarage E2E ingress message latency: 14.7s
2024-09-05 15:44:34.601 INFO[uvms_logs_stream:StdOut] [uvm=test-driver] TEST_LOG: Task test_large_messages PASSED  in 120.63s
2024-09-05 15:44:34.601 INFO[uvms_logs_stream:StdOut] [uvm=test-driver] TEST_LOG:      Success rate: 100.0%
2024-09-05 15:44:34.601 INFO[uvms_logs_stream:StdOut] [uvm=test-driver] TEST_LOG:      Block rate: 0.5 blocks/s
2024-09-05 15:44:34.601 INFO[uvms_logs_stream:StdOut] [uvm=test-driver] TEST_LOG:      Throughput: 1.3 MiB/s, 1.4 messages/s
2024-09-05 15:44:34.601 INFO[uvms_logs_stream:StdOut] [uvm=test-driver] TEST_LOG:      Avarage E2E ingress message latency: 15.4s
2024-09-05 15:44:34.601 INFO[uvms_logs_stream:StdOut] [uvm=test-driver] TEST_LOG: ===========================================================================
```