### PR TITLE
refactor(nns): Eliminate `ExecutedCreateServiceNervousSystemProposal`

### DIFF
--- a/rs/nns/governance/src/governance.rs
+++ b/rs/nns/governance/src/governance.rs
@@ -4718,7 +4718,8 @@ impl Governance {
         .await
     }
 
-    fn make_sns_init_payload(
+    // This function is public as it is used in various tests, also outside this crate.
+    pub fn make_sns_init_payload(
         create_service_nervous_system: CreateServiceNervousSystem,
         neurons_fund_participation_constraints: Option<NeuronsFundParticipationConstraints>,
         current_timestamp_seconds: u64,

--- a/rs/nns/governance/src/governance.rs
+++ b/rs/nns/governance/src/governance.rs
@@ -63,10 +63,7 @@ use crate::{
         StopOrStartCanister, Tally, Topic, UpdateCanisterSettings, UpdateNodeProvider, Visibility,
         Vote, WaitForQuietState, XdrConversionRate as XdrConversionRatePb,
     },
-    proposals::{
-        call_canister::CallCanister,
-        create_service_nervous_system::ExecutedCreateServiceNervousSystemProposal,
-    },
+    proposals::call_canister::CallCanister,
 };
 use async_trait::async_trait;
 use candid::{Decode, Encode};
@@ -4663,6 +4660,17 @@ impl Governance {
         }
     }
 
+    async fn create_service_nervous_system(
+        &mut self,
+        proposal_id: u64,
+        create_service_nervous_system: &CreateServiceNervousSystem,
+    ) {
+        let result = self
+            .do_create_service_nervous_system(proposal_id, create_service_nervous_system)
+            .await;
+        self.set_proposal_execution_status(proposal_id, result);
+    }
+
     async fn do_create_service_nervous_system(
         &mut self,
         proposal_id: u64,
@@ -4696,61 +4704,103 @@ impl Governance {
                 (NeuronsFundSnapshot::empty(), None)
             };
 
-        let executed_create_service_nervous_system_proposal =
-            ExecutedCreateServiceNervousSystemProposal {
-                current_timestamp_seconds,
-                create_service_nervous_system: create_service_nervous_system.clone(),
-                proposal_id: proposal_id.id,
-                random_swap_start_time: self.randomly_pick_swap_start(),
-                neurons_fund_participation_constraints,
-            };
+        let random_swap_start_time = self.randomly_pick_swap_start();
+        let create_service_nervous_system = create_service_nervous_system.clone();
 
         self.execute_create_service_nervous_system_proposal(
-            executed_create_service_nervous_system_proposal,
+            create_service_nervous_system,
+            neurons_fund_participation_constraints,
+            current_timestamp_seconds,
+            proposal_id,
+            random_swap_start_time,
             initial_neurons_fund_participation_snapshot,
         )
         .await
     }
 
-    async fn create_service_nervous_system(
-        &mut self,
-        proposal_id: u64,
-        create_service_nervous_system: &CreateServiceNervousSystem,
-    ) {
-        let result = self
-            .do_create_service_nervous_system(proposal_id, create_service_nervous_system)
-            .await;
-        self.set_proposal_execution_status(proposal_id, result);
+    fn make_sns_init_payload(
+        create_service_nervous_system: CreateServiceNervousSystem,
+        neurons_fund_participation_constraints: Option<NeuronsFundParticipationConstraints>,
+        current_timestamp_seconds: u64,
+        proposal_id: ProposalId,
+        random_swap_start_time: GlobalTimeOfDay,
+    ) -> Result<SnsInitPayload, String> {
+        let start_time = create_service_nervous_system
+            .swap_parameters
+            .as_ref()
+            .and_then(|swap_parameters| swap_parameters.start_time);
+
+        let duration = create_service_nervous_system
+            .swap_parameters
+            .as_ref()
+            .and_then(|swap_parameters| swap_parameters.duration);
+
+        let sns_init_payload = SnsInitPayload::try_from(create_service_nervous_system)?;
+
+        let (swap_start_timestamp_seconds, swap_due_timestamp_seconds) =
+            CreateServiceNervousSystem::swap_start_and_due_timestamps(
+                start_time.unwrap_or(random_swap_start_time),
+                duration.unwrap_or_default(),
+                current_timestamp_seconds,
+            )
+            .map(
+                |(swap_start_timestamp_seconds, swap_due_timestamp_seconds)| {
+                    (
+                        Some(swap_start_timestamp_seconds),
+                        Some(swap_due_timestamp_seconds),
+                    )
+                },
+            )?;
+
+        Ok(SnsInitPayload {
+            neurons_fund_participation_constraints,
+            nns_proposal_id: Some(proposal_id.id),
+            swap_start_timestamp_seconds,
+            swap_due_timestamp_seconds,
+            ..sns_init_payload
+        })
     }
 
     async fn execute_create_service_nervous_system_proposal(
         &mut self,
-        executed_create_service_nervous_system_proposal: ExecutedCreateServiceNervousSystemProposal,
+        create_service_nervous_system: CreateServiceNervousSystem,
+        neurons_fund_participation_constraints: Option<NeuronsFundParticipationConstraints>,
+        current_timestamp_seconds: u64,
+        proposal_id: ProposalId,
+        random_swap_start_time: GlobalTimeOfDay,
         initial_neurons_fund_participation_snapshot: NeuronsFundSnapshot,
     ) -> Result<(), GovernanceError> {
-        let is_start_time_unspecified = executed_create_service_nervous_system_proposal
-            .create_service_nervous_system
+        let is_start_time_unspecified = create_service_nervous_system
             .swap_parameters
             .as_ref()
             .map(|swap_parameters| swap_parameters.start_time.is_none())
             .unwrap_or(false);
 
-        // Step 1: Convert proposal into main request object.
-        let sns_init_payload =
-            match SnsInitPayload::try_from(executed_create_service_nervous_system_proposal.clone())
-            {
-                Ok(ok) => ok,
-                Err(err) => {
-                    return Err(GovernanceError::new_with_message(
-                        ErrorType::InvalidProposal,
-                        format!(
-                            "Failed to convert ExecutedCreateServiceNervousSystemProposal \
-                            to SnsInitPayload: {}",
-                            err,
-                        ),
-                    ))
-                }
-            };
+        // Step 1.1: Convert proposal into SnsInitPayload.
+        let sns_init_payload = Self::make_sns_init_payload(
+            create_service_nervous_system,
+            neurons_fund_participation_constraints,
+            current_timestamp_seconds,
+            proposal_id,
+            random_swap_start_time,
+        )
+        .map_err(|err| {
+            GovernanceError::new_with_message(
+                ErrorType::InvalidProposal,
+                format!(
+                    "Failed to convert CreateServiceNervousSystem proposal to SnsInitPayload: {}",
+                    err,
+                ),
+            )
+        })?;
+
+        // Step 1.2: Validate the SnsInitPayload.
+        sns_init_payload.validate_post_execution().map_err(|err| {
+            GovernanceError::new_with_message(
+                ErrorType::InvalidProposal,
+                format!("Failed to validate SnsInitPayload: {}", err),
+            )
+        })?;
 
         // If the test configuration is active (implying we are not running in
         // production), and the start time has not been specified,
@@ -4770,9 +4820,7 @@ impl Governance {
             println!(
                 "{}The swap's start time for proposal {:?} is unspecified, \
                 so a random time of {:?} will be used.",
-                LOG_PREFIX,
-                executed_create_service_nervous_system_proposal.proposal_id,
-                executed_create_service_nervous_system_proposal.random_swap_start_time
+                LOG_PREFIX, proposal_id, random_swap_start_time,
             );
         }
 
@@ -4783,10 +4831,6 @@ impl Governance {
             call_deploy_new_sns(&mut self.env, sns_init_payload).await;
 
         // Step 3: React to response from deploy_new_sns (Ok or Err).
-
-        let proposal_id = ProposalId {
-            id: executed_create_service_nervous_system_proposal.proposal_id,
-        };
 
         // Step 3.1: If the call was not successful, issue refunds (and then, return).
         if let Err(ref mut err) = &mut deploy_new_sns_response {

--- a/rs/nns/governance/src/governance/tests/mod.rs
+++ b/rs/nns/governance/src/governance/tests/mod.rs
@@ -509,7 +509,7 @@ mod convert_from_create_service_nervous_system_to_sns_init_payload_tests {
 }
 
 #[cfg(feature = "test")]
-mod convert_from_executed_create_service_nervous_system_proposal_to_sns_init_payload_tests_with_test_feature {
+mod convert_create_service_nervous_system_proposal_to_sns_init_payload_tests_with_test_feature {
     use super::*;
     use ic_nervous_system_proto::pb::v1 as pb;
     use ic_sns_init::pb::v1::sns_init_payload;

--- a/rs/nns/governance/src/governance/tests/mod.rs
+++ b/rs/nns/governance/src/governance/tests/mod.rs
@@ -547,23 +547,19 @@ mod convert_from_executed_create_service_nervous_system_proposal_to_sns_init_pay
         let current_timestamp_seconds = 13_245;
         let proposal_id = 1000;
 
-        let executed_create_service_nervous_system_proposal =
-            ExecutedCreateServiceNervousSystemProposal {
-                current_timestamp_seconds,
-                create_service_nervous_system: CREATE_SERVICE_NERVOUS_SYSTEM_WITH_MATCHED_FUNDING
-                    .clone(),
-                proposal_id,
-                random_swap_start_time: GlobalTimeOfDay {
-                    seconds_after_utc_midnight: Some(0),
-                },
-                neurons_fund_participation_constraints: Some(
-                    NEURONS_FUND_PARTICIPATION_CONSTRAINTS.clone(),
-                ),
-            };
-
         // Step 2: Call the code under test.
-        let converted =
-            SnsInitPayload::try_from(executed_create_service_nervous_system_proposal).unwrap();
+        let converted = Governance::make_sns_init_payload(
+            CREATE_SERVICE_NERVOUS_SYSTEM_WITH_MATCHED_FUNDING.clone(),
+            Some(NEURONS_FUND_PARTICIPATION_CONSTRAINTS.clone()),
+            current_timestamp_seconds,
+            ProposalId { id: proposal_id },
+            GlobalTimeOfDay {
+                seconds_after_utc_midnight: Some(0),
+            },
+        )
+        .unwrap();
+
+        converted.validate_post_execution().unwrap();
 
         // Step 3: Inspect the result.
 

--- a/rs/nns/governance/src/proposals/create_service_nervous_system.rs
+++ b/rs/nns/governance/src/proposals/create_service_nervous_system.rs
@@ -3,65 +3,6 @@ use ic_nervous_system_proto::pb::v1::{Duration, GlobalTimeOfDay};
 use ic_sns_init::pb::v1::{self as sns_init_pb, sns_init_payload, SnsInitPayload};
 use ic_sns_swap::pb::v1::NeuronsFundParticipationConstraints;
 
-#[derive(Clone, Debug)]
-pub struct ExecutedCreateServiceNervousSystemProposal {
-    pub current_timestamp_seconds: u64,
-    pub create_service_nervous_system: CreateServiceNervousSystem,
-    pub proposal_id: u64,
-    pub random_swap_start_time: GlobalTimeOfDay,
-    /// Information about the Neurons' Fund participation needed by the Swap canister.
-    pub neurons_fund_participation_constraints: Option<NeuronsFundParticipationConstraints>,
-}
-
-impl TryFrom<ExecutedCreateServiceNervousSystemProposal> for SnsInitPayload {
-    type Error = String;
-
-    fn try_from(src: ExecutedCreateServiceNervousSystemProposal) -> Result<Self, Self::Error> {
-        let mut defects = vec![];
-
-        let current_timestamp_seconds = src.current_timestamp_seconds;
-        let nns_proposal_id = Some(src.proposal_id);
-        let neurons_fund_participation_constraints = src.neurons_fund_participation_constraints;
-        let start_time = src
-            .create_service_nervous_system
-            .swap_parameters
-            .as_ref()
-            .and_then(|swap_parameters| swap_parameters.start_time);
-        let duration = src
-            .create_service_nervous_system
-            .swap_parameters
-            .as_ref()
-            .and_then(|swap_parameters| swap_parameters.duration);
-
-        let (swap_start_timestamp_seconds, swap_due_timestamp_seconds) =
-            match CreateServiceNervousSystem::swap_start_and_due_timestamps(
-                start_time.unwrap_or(src.random_swap_start_time),
-                duration.unwrap_or_default(),
-                current_timestamp_seconds,
-            ) {
-                Ok((swap_start_timestamp_seconds, swap_due_timestamp_seconds)) => (
-                    Some(swap_start_timestamp_seconds),
-                    Some(swap_due_timestamp_seconds),
-                ),
-                Err(err) => {
-                    defects.push(err);
-                    (None, None)
-                }
-            };
-
-        let mut result = SnsInitPayload::try_from(src.create_service_nervous_system)?;
-
-        result.nns_proposal_id = nns_proposal_id;
-        result.swap_start_timestamp_seconds = swap_start_timestamp_seconds;
-        result.swap_due_timestamp_seconds = swap_due_timestamp_seconds;
-        result.neurons_fund_participation_constraints = neurons_fund_participation_constraints;
-
-        result.validate_post_execution()?;
-
-        Ok(result)
-    }
-}
-
 impl CreateServiceNervousSystem {
     pub fn sns_token_e8s(&self) -> Option<u64> {
         self.initial_token_distribution
@@ -366,7 +307,7 @@ impl TryFrom<CreateServiceNervousSystem> for SnsInitPayload {
             neurons_fund_participation,
 
             // These are not known from only the CreateServiceNervousSystem
-            // proposal. See TryFrom<ExecutedCreateServiceNervousSystemProposal>
+            // proposal. See `Governance::make_sns_init_payload`.
             nns_proposal_id: None,
             swap_start_timestamp_seconds: None,
             swap_due_timestamp_seconds: None,

--- a/rs/nns/governance/src/proposals/create_service_nervous_system.rs
+++ b/rs/nns/governance/src/proposals/create_service_nervous_system.rs
@@ -1,7 +1,6 @@
 use crate::pb::v1::{create_service_nervous_system, CreateServiceNervousSystem};
 use ic_nervous_system_proto::pb::v1::{Duration, GlobalTimeOfDay};
 use ic_sns_init::pb::v1::{self as sns_init_pb, sns_init_payload, SnsInitPayload};
-use ic_sns_swap::pb::v1::NeuronsFundParticipationConstraints;
 
 impl CreateServiceNervousSystem {
     pub fn sns_token_e8s(&self) -> Option<u64> {

--- a/rs/sns/cli/src/lib.rs
+++ b/rs/sns/cli/src/lib.rs
@@ -11,14 +11,15 @@ use ic_base_types::PrincipalId;
 use ic_crypto_sha2::Sha256;
 use ic_nervous_system_common_test_keys::TEST_NEURON_1_OWNER_KEYPAIR;
 use ic_nervous_system_proto::pb::v1::GlobalTimeOfDay;
+use ic_nns_common::pb::v1::ProposalId;
 use ic_nns_constants::{GOVERNANCE_CANISTER_ID, SNS_WASM_CANISTER_ID};
 use ic_nns_governance::{
+    governance::Governance,
     pb::v1::{
         manage_neuron::{self, NeuronIdOrSubaccount},
         manage_neuron_response::{self, MakeProposalResponse},
         ManageNeuron, ManageNeuronResponse, Proposal,
     },
-    proposals::create_service_nervous_system::ExecutedCreateServiceNervousSystemProposal,
 };
 use ic_sns_init::pb::v1::SnsInitPayload;
 use ic_sns_wasm::pb::v1::{AddWasmRequest, SnsCanisterType, SnsWasm};
@@ -201,35 +202,31 @@ impl DeployTestflightArgs {
                         .neurons_fund_participation = Some(false);
                 }
 
-                // convert to ExecutedCreateServiceNervousSystemProposal
-                let executed_create_service_nervous_system =
-                    ExecutedCreateServiceNervousSystemProposal {
-                        current_timestamp_seconds: SystemTime::now()
-                            .duration_since(UNIX_EPOCH)
-                            .unwrap()
-                            .as_secs(),
-                        create_service_nervous_system,
-                        random_swap_start_time: GlobalTimeOfDay {
-                            seconds_after_utc_midnight: Some(0),
-                        },
-                        neurons_fund_participation_constraints: None,
-                        // `proposal_id` only exists to be exposed to the user for audit purposes, which don't apply here.
-                        // But it's required, so we can just use any arbitrary value.
-                        proposal_id: 10,
-                    };
+                // Smoke test: If we were to submit this proposal (under some plausible assumptions)
+                // would this proposal yield a valid SnsInitPayload structure?
+                let sns_init_payload = Governance::make_sns_init_payload(
+                    create_service_nervous_system,
+                    // Mock dynamic data using "plausible" values.
+                    None,
+                    SystemTime::now()
+                        .duration_since(UNIX_EPOCH)
+                        .unwrap()
+                        .as_secs(),
+                    ProposalId { id: 10 },
+                    GlobalTimeOfDay {
+                        seconds_after_utc_midnight: Some(0),
+                    },
+                )
+                .and_then(|sns_init_payload| sns_init_payload.validate_post_execution());
 
-                // Last step: more conversion (this time, to the desired type: SnsInitPayload).
-                SnsInitPayload::try_from(executed_create_service_nervous_system)
-                    // This shouldn't be possible -> we could just unwrap here, and there
-                    // should be no danger of panic, but we handle Err anyway, because if
-                    // err is returned, it still makes sense to just return that.
-                    //
-                    // The reason Err should be impossible is
-                    // try_convert_to_create_service_nervous_system itself call
-                    // SnsInitPayload::try_from as part of its validation.
-                    .map_err(|err| {
-                        anyhow!("Invalid configuration in {:?}: {}", init_config_file, err)
-                    })
+                match sns_init_payload {
+                    Err(err) => {
+                        bail!("Invalid configuration in {:?}: {}", init_config_file, err);
+                    }
+                    Ok(sns_init_payload) => {
+                        return Ok(sns_init_payload);
+                    }
+                }
             }
             None => {
                 panic!("The init_config_file is required for the DeployTestflightArgs.");

--- a/rs/sns/cli/src/lib.rs
+++ b/rs/sns/cli/src/lib.rs
@@ -200,9 +200,7 @@ impl DeployTestflightArgs {
                     Err(err) => {
                         bail!("Invalid configuration in {:?}: {}", init_config_file, err);
                     }
-                    Ok(sns_init_payload) => {
-                        return Ok(sns_init_payload);
-                    }
+                    Ok(sns_init_payload) => Ok(sns_init_payload),
                 }
             }
             None => {


### PR DESCRIPTION
This PR refactors the code in NNS Governance responsible for executing `CreateServiceNervousSystem` proposals s.t. it no longer requires the internal type `ExecutedCreateServiceNervousSystemProposal`. This type was intended to be internal but has become public for CLI tools to validate instances of this proposal type, which adds an undesirable crate-level dependency between, e.g., `//rs/nns/governance` and `//rs/sns/init`.