### PR TITLE
chore(PocketIC): make HTTP gateway termination into debug log

### DIFF
--- a/rs/pocket_ic_server/src/state_api/state.rs
+++ b/rs/pocket_ic_server/src/state_api/state.rs
@@ -54,7 +54,7 @@ use tokio::{
 };
 use tonic::Request;
 use tower_http::cors::{Any, CorsLayer};
-use tracing::{error, info, trace};
+use tracing::{debug, error, trace};
 
 // The maximum wait time for a computation to finish synchronously.
 const DEFAULT_SYNC_WAIT_DURATION: Duration = Duration::from_secs(10);
@@ -992,7 +992,7 @@ impl ApiState {
                     .unwrap();
             }
 
-            info!("Terminating HTTP gateway.");
+            debug!("Terminating HTTP gateway.");
         });
 
         // Wait until the HTTP gateway starts listening.


### PR DESCRIPTION
This PR changes the log level of HTTP gateway termination from info to debug so that it doesn't appear in the console by default (analogously to the server termination which has been switched from into to debug in the past).