### PR TITLE
chore(ic-admin): Keep `--use-explicit-action-type` in ic-admin

### DIFF
--- a/rs/registry/admin/src/main.rs
+++ b/rs/registry/admin/src/main.rs
@@ -964,6 +964,10 @@ struct ProposeToChangeNnsCanisterCmd {
     /// See `MemoryAllocation` for the semantics of this field.
     memory_allocation: Option<u64>,
 
+    /// Keeping it around so that scripts that alreay pass this flag don't break.
+    #[clap(long, default_value = "true")]
+    use_explicit_action_type: bool,
+
     /// If true, the proposal will be sent as `ExecuteNnsFunction` instead of `InstallCode`.
     #[clap(long)]
     use_legacy_execute_nns_function: bool,


### PR DESCRIPTION
Some users already use the `--use-explicit-action-type` when using ic-admin to create canister upgrade proposals. Avoid breaking them for now. 

The option isn't technically used. Ideally we want to have a boolean option default to true but can be set to false, but there seems to be no convenient way to do so with clap.