### PR TITLE
feat: EXC-1737: Execute subnet messages on aborted canisters

### DIFF
--- a/rs/execution_environment/src/scheduler.rs
+++ b/rs/execution_environment/src/scheduler.rs
@@ -481,8 +481,6 @@ impl SchedulerImpl {
         csprng: &mut Csprng,
         round_limits: &mut RoundLimits,
         measurement_scope: &MeasurementScope,
-        ongoing_long_install_code: bool,
-        long_running_canister_ids: BTreeSet<CanisterId>,
         registry_settings: &RegistryExecutionSettings,
         idkg_subnet_public_keys: &BTreeMap<MasterPublicKeyId, MasterPublicKey>,
     ) -> ReplicatedState {
@@ -490,7 +488,7 @@ impl SchedulerImpl {
             let mut available_subnet_messages = false;
             let mut loop_detector = state.subnet_queues_loop_detector();
             while let Some(msg) = state.peek_subnet_input() {
-                if can_execute_msg(&msg, ongoing_long_install_code, &long_running_canister_ids) {
+                if can_execute_subnet_msg(&msg, &state.canister_states) {
                     available_subnet_messages = true;
                     break;
                 }
@@ -679,20 +677,6 @@ impl SchedulerImpl {
                 );
 
                 // TODO(EXC-1517): Improve inner loop preparation.
-                let mut ongoing_long_install_code = false;
-                let long_running_canister_ids = state
-                    .canister_states
-                    .iter()
-                    .filter_map(|(&canister_id, canister)| match canister.next_execution() {
-                        NextExecution::None | NextExecution::StartNew => None,
-                        NextExecution::ContinueLong => Some(canister_id),
-                        NextExecution::ContinueInstallCode => {
-                            ongoing_long_install_code = true;
-                            Some(canister_id)
-                        }
-                    })
-                    .collect();
-
                 let mut subnet_round_limits = scheduler_round_limits.subnet_round_limits();
                 if !subnet_round_limits.reached() {
                     state = self.drain_subnet_queues(
@@ -700,8 +684,6 @@ impl SchedulerImpl {
                         csprng,
                         &mut subnet_round_limits,
                         &subnet_measurement_scope,
-                        ongoing_long_install_code,
-                        long_running_canister_ids,
                         registry_settings,
                         idkg_subnet_public_keys,
                     );
@@ -2338,40 +2320,97 @@ fn join_consumed_cycles_by_use_case(
     }
 }
 
-/// Helper function that checks if a message can be executed:
+/// Helper function that checks if a subnet message can be executed:
 ///     1. A message cannot be executed if it is directed to a canister
 ///     with another long-running execution in progress.
 ///     2. Install code messages can only be executed sequentially.
-fn can_execute_msg(
+fn can_execute_subnet_msg(
     msg: &CanisterMessage,
-    ongoing_long_install_code: bool,
-    long_running_canister_ids: &BTreeSet<CanisterId>,
+    canister_states: &BTreeMap<CanisterId, CanisterState>,
 ) -> bool {
-    if let Some(effective_canister_id) = msg.effective_canister_id() {
-        if long_running_canister_ids.contains(&effective_canister_id) {
-            return false;
-        }
+    let Some(effective_canister_id) = msg.effective_canister_id() else {
+        // If there is no effective canister ID, we can execute the subnet message.
+        return true;
+    };
+    let Some(effective_canister_state) = canister_states.get(&effective_canister_id) else {
+        // If there is no effective canister state, we can execute the subnet message.
+        return true;
+    };
+    if effective_canister_state.has_paused_execution() {
+        // If there is a paused execution, we can't execute the subnet message.
+        // Note, it does NOT include aborted executions.
+        return false;
     }
+    let maybe_method = match msg {
+        CanisterMessage::Ingress(ingress) => {
+            Ic00Method::from_str(ingress.method_name.as_str()).ok()
+        }
+        CanisterMessage::Request(request) => {
+            Ic00Method::from_str(request.method_name.as_str()).ok()
+        }
+        CanisterMessage::Response(_) => None,
+    };
+    let Some(method) = maybe_method else {
+        // If there is no method name, we can execute the subnet message.
+        return true;
+    };
 
-    if ongoing_long_install_code {
-        let maybe_install_code_method = match msg {
-            CanisterMessage::Ingress(ingress) => {
-                Ic00Method::from_str(ingress.method_name.as_str()).ok()
-            }
-            CanisterMessage::Request(request) => {
-                Ic00Method::from_str(request.method_name.as_str()).ok()
-            }
-            CanisterMessage::Response(_) => None,
-        };
-
+    let ongoing_long_install_code =
+        canister_states
+            .iter()
+            .any(|(_canister_id, canister)| match canister.next_execution() {
+                NextExecution::None | NextExecution::StartNew | NextExecution::ContinueLong => {
+                    false
+                }
+                NextExecution::ContinueInstallCode => true,
+            });
+    let effective_canister_paused_or_aborted = match effective_canister_state.next_execution() {
+        NextExecution::None | NextExecution::StartNew => false,
+        NextExecution::ContinueLong | NextExecution::ContinueInstallCode => true,
+    };
+    match method {
+        // It's safe to allow other subnet on aborted canisters messages,
+        // but for the sake of minimizing the change, allow just this for now...
+        Ic00Method::DepositCycles => true,
         // Only one install code message allowed at a time.
-        match maybe_install_code_method {
-            Some(Ic00Method::InstallCode) | Some(Ic00Method::InstallChunkedCode) => return false,
-            _ => {}
+        Ic00Method::InstallCode | Ic00Method::InstallChunkedCode => {
+            !ongoing_long_install_code && !effective_canister_paused_or_aborted
         }
+        Ic00Method::CanisterStatus
+        | Ic00Method::CanisterInfo
+        | Ic00Method::CreateCanister
+        | Ic00Method::DeleteCanister
+        | Ic00Method::HttpRequest
+        | Ic00Method::ECDSAPublicKey
+        | Ic00Method::RawRand
+        | Ic00Method::SetupInitialDKG
+        | Ic00Method::SignWithECDSA
+        | Ic00Method::StartCanister
+        | Ic00Method::StopCanister
+        | Ic00Method::UninstallCode
+        | Ic00Method::UpdateSettings
+        | Ic00Method::ComputeInitialIDkgDealings
+        | Ic00Method::SchnorrPublicKey
+        | Ic00Method::SignWithSchnorr
+        | Ic00Method::BitcoinGetBalance
+        | Ic00Method::BitcoinGetUtxos
+        | Ic00Method::BitcoinGetBlockHeaders
+        | Ic00Method::BitcoinSendTransaction
+        | Ic00Method::BitcoinGetCurrentFeePercentiles
+        | Ic00Method::BitcoinSendTransactionInternal
+        | Ic00Method::BitcoinGetSuccessors
+        | Ic00Method::NodeMetricsHistory
+        | Ic00Method::FetchCanisterLogs
+        | Ic00Method::ProvisionalCreateCanisterWithCycles
+        | Ic00Method::ProvisionalTopUpCanister
+        | Ic00Method::UploadChunk
+        | Ic00Method::StoredChunks
+        | Ic00Method::ClearChunkStore
+        | Ic00Method::TakeCanisterSnapshot
+        | Ic00Method::LoadCanisterSnapshot
+        | Ic00Method::ListCanisterSnapshots
+        | Ic00Method::DeleteCanisterSnapshot => !effective_canister_paused_or_aborted,
     }
-
-    true
 }
 
 /// Based on the type of the subnet message to execute, figure out its

--- a/rs/execution_environment/src/scheduler.rs
+++ b/rs/execution_environment/src/scheduler.rs
@@ -2388,11 +2388,16 @@ fn can_execute_subnet_msg(
         Ic00Method::InstallCode | Ic00Method::InstallChunkedCode => {
             !ongoing_long_install_code && !effective_canister_is_aborted
         }
+        // Deleting an aborted canister requires to stop it first.
+        Ic00Method::DeleteCanister => !effective_canister_is_aborted,
+        // Stopping an aborted canister does not generate a reply.
+        Ic00Method::StopCanister => !effective_canister_is_aborted,
+        // Loading a snapshot is similar to the install code.
+        Ic00Method::LoadCanisterSnapshot => !effective_canister_is_aborted,
         // It's safe to allow other subnet messages on aborted canisters.
         Ic00Method::CanisterStatus
         | Ic00Method::CanisterInfo
         | Ic00Method::CreateCanister
-        | Ic00Method::DeleteCanister
         | Ic00Method::DepositCycles
         | Ic00Method::HttpRequest
         | Ic00Method::ECDSAPublicKey
@@ -2400,7 +2405,6 @@ fn can_execute_subnet_msg(
         | Ic00Method::SetupInitialDKG
         | Ic00Method::SignWithECDSA
         | Ic00Method::StartCanister
-        | Ic00Method::StopCanister
         | Ic00Method::UninstallCode
         | Ic00Method::UpdateSettings
         | Ic00Method::ComputeInitialIDkgDealings
@@ -2421,7 +2425,6 @@ fn can_execute_subnet_msg(
         | Ic00Method::StoredChunks
         | Ic00Method::ClearChunkStore
         | Ic00Method::TakeCanisterSnapshot
-        | Ic00Method::LoadCanisterSnapshot
         | Ic00Method::ListCanisterSnapshots
         | Ic00Method::DeleteCanisterSnapshot => true,
     }

--- a/rs/execution_environment/src/scheduler/test_utilities.rs
+++ b/rs/execution_environment/src/scheduler/test_utilities.rs
@@ -558,6 +558,7 @@ impl SchedulerTest {
             &mut csprng,
             &mut round_limits,
             &measurements,
+            false,
             self.registry_settings(),
             &BTreeMap::new(),
         )

--- a/rs/execution_environment/src/scheduler/test_utilities.rs
+++ b/rs/execution_environment/src/scheduler/test_utilities.rs
@@ -538,10 +538,7 @@ impl SchedulerTest {
         }
     }
 
-    pub fn drain_subnet_messages(
-        &mut self,
-        long_running_canister_ids: BTreeSet<CanisterId>,
-    ) -> ReplicatedState {
+    pub fn drain_subnet_messages(&mut self) -> ReplicatedState {
         let state = self.state.take().unwrap();
         let compute_allocation_used = state.total_compute_allocation();
         let mut csprng = Csprng::from_seed_and_purpose(
@@ -561,8 +558,6 @@ impl SchedulerTest {
             &mut csprng,
             &mut round_limits,
             &measurements,
-            false,
-            long_running_canister_ids,
             self.registry_settings(),
             &BTreeMap::new(),
         )

--- a/rs/execution_environment/tests/dts.rs
+++ b/rs/execution_environment/tests/dts.rs
@@ -993,27 +993,22 @@ fn dts_pending_execution_blocks_subnet_messages_to_the_same_canister() {
         env.tick();
     }
 
+    // The `update` canister call should be aborted.
     assert_eq!(
         ingress_state(env.ingress_status(&update)),
         Some(IngressState::Processing)
     );
-
-    assert_eq!(
-        ingress_state(env.ingress_status(&status)),
-        Some(IngressState::Received)
-    );
-
+    // The `ic0.install_code` should be blocked by the aborted execution.
     assert_eq!(
         ingress_state(env.ingress_status(&upgrade)),
         Some(IngressState::Received)
     );
+    // The `ic0.canister_status` is allowed for aborted canisters.
+    env.await_ingress(status, 30).unwrap();
 
     env.set_checkpoints_enabled(false);
 
     env.await_ingress(update, 30).unwrap();
-
-    env.await_ingress(status, 30).unwrap();
-
     env.await_ingress(upgrade, 30).unwrap();
 }
 

--- a/rs/execution_environment/tests/dts.rs
+++ b/rs/execution_environment/tests/dts.rs
@@ -9,18 +9,22 @@ use ic_config::{
     subnet_config::{SchedulerConfig, SubnetConfig},
 };
 use ic_management_canister_types::{
-    CanisterIdRecord, CanisterSettingsArgsBuilder, EmptyBlob, InstallCodeArgs, Method, Payload,
-    IC_00,
+    CanisterIdRecord, CanisterInfoRequest, CanisterInstallModeV2, CanisterSettingsArgsBuilder,
+    DeleteCanisterSnapshotArgs, EmptyBlob, InstallCodeArgs, ListCanisterSnapshotArgs, Method,
+    Payload, StoredChunksArgs, UninstallCodeArgs, IC_00,
 };
 use ic_registry_subnet_type::SubnetType;
 use ic_replicated_state::canister_state::{execution_state::NextScheduledMethod, NextExecution};
 use ic_state_machine_tests::{
-    CanisterId, CanisterInstallMode, CryptoHashOfState, ErrorCode, IngressState, IngressStatus,
-    MessageId, PrincipalId, StateMachine, StateMachineConfig,
+    CanisterId, CanisterInstallMode, ClearChunkStoreArgs, CryptoHashOfState, ErrorCode,
+    IngressState, IngressStatus, InstallChunkedCodeArgs, LoadCanisterSnapshotArgs, MessageId,
+    PrincipalId, StateMachine, StateMachineConfig, TakeCanisterSnapshotArgs, UpdateSettingsArgs,
+    UploadChunkArgs,
 };
 use ic_types::{ingress::WasmResult, Cycles, NumInstructions};
-use ic_universal_canister::{call_args, wasm, UNIVERSAL_CANISTER_WASM};
+use ic_universal_canister::{call_args, wasm, CallArgs, UNIVERSAL_CANISTER_WASM};
 use more_asserts::assert_ge;
+use strum::IntoEnumIterator;
 
 const INITIAL_CYCLES_BALANCE: Cycles = Cycles::new(100_000_000_000_000);
 
@@ -183,6 +187,7 @@ fn dts_env(
             message_instruction_limit,
             slice_instruction_limit,
         ))))
+        .with_canister_snapshots(true)
         .with_subnet_type(SubnetType::Application)
         .build()
 }
@@ -1013,89 +1018,257 @@ fn dts_pending_execution_blocks_subnet_messages_to_the_same_canister() {
 }
 
 #[test]
-fn dts_aborted_execution_does_not_block_deposit_cycles() {
-    let slice_instruction_limit = 10_000_000;
-    let env = dts_env(
-        NumInstructions::from(slice_instruction_limit * 10),
-        NumInstructions::from(slice_instruction_limit),
-    );
+fn dts_aborted_execution_does_not_block_subnet_messages() {
+    fn test<F: Fn(CanisterId) -> (Method, CallArgs)>(
+        subnet_complete: bool,
+        aborted_complete: bool,
+        f: F,
+    ) {
+        let slice_instruction_limit = 10_000_000;
+        let env = dts_env(
+            NumInstructions::from(slice_instruction_limit * 10),
+            NumInstructions::from(slice_instruction_limit),
+        );
 
-    let user_id = PrincipalId::new_anonymous();
-    let long_canister_id = env
-        .install_canister_with_cycles(
-            UNIVERSAL_CANISTER_WASM.into(),
-            vec![],
-            None,
-            INITIAL_CYCLES_BALANCE,
-        )
-        .unwrap();
-    let other_canister_id = env
-        .install_canister_with_cycles(
-            UNIVERSAL_CANISTER_WASM.into(),
-            vec![],
-            None,
-            INITIAL_CYCLES_BALANCE,
-        )
-        .unwrap();
+        let user_id = PrincipalId::new_anonymous();
+        let other_canister_id = env
+            .install_canister_with_cycles(
+                UNIVERSAL_CANISTER_WASM.into(),
+                vec![],
+                None,
+                INITIAL_CYCLES_BALANCE,
+            )
+            .unwrap();
+        let aborted_canister_id = env
+            .install_canister_with_cycles(
+                UNIVERSAL_CANISTER_WASM.into(),
+                vec![],
+                Some(
+                    CanisterSettingsArgsBuilder::new()
+                        .with_controllers(vec![user_id, other_canister_id.get()])
+                        .build(),
+                ),
+                INITIAL_CYCLES_BALANCE,
+            )
+            .unwrap();
 
-    env.set_checkpoints_enabled(true);
-    let long_execution_id = env.send_ingress(
-        user_id,
-        long_canister_id,
-        "update",
-        wasm()
-            .instruction_counter_is_at_least(slice_instruction_limit)
-            .reply_data(&[42])
-            .build(),
-    );
+        env.set_checkpoints_enabled(true);
+        let long_execution_id = env.send_ingress(
+            user_id,
+            aborted_canister_id,
+            "update",
+            wasm()
+                .instruction_counter_is_at_least(slice_instruction_limit)
+                .reply_data(&[42])
+                .build(),
+        );
 
-    for _ in 0..5 {
-        // With checkpoints enabled, the update message will be repeatedly
-        // aborted, so there will be no progress.
-        env.tick();
+        for _ in 0..5 {
+            // With checkpoints enabled, the update message will be repeatedly
+            // aborted, so there will be no progress.
+            env.tick();
+        }
+
+        let (method, args) = f(aborted_canister_id);
+        if method == Method::DeleteCanisterSnapshot {
+            env.take_canister_snapshot(TakeCanisterSnapshotArgs::new(aborted_canister_id, None))
+                .unwrap();
+        }
+
+        let args = args
+            .on_reject(wasm().reject_message().reject())
+            .on_reply(wasm().reply_data(&[43]));
+
+        let subnet_message = wasm()
+            .call_with_cycles(IC_00, method, args, 100_000_000_000_u128.into())
+            .build();
+
+        let subnet_message_id =
+            env.send_ingress(user_id, other_canister_id, "update", subnet_message);
+
+        for _ in 0..5 {
+            env.tick();
+        }
+
+        // Make sure the aborted execution is still processing.
+        if aborted_complete {
+            assert_eq!(
+                ingress_state(env.ingress_status(&long_execution_id)),
+                Some(IngressState::Processing)
+            );
+        } else {
+            assert_matches!(
+                ingress_state(env.ingress_status(&long_execution_id)),
+                Some(IngressState::Failed(_))
+            );
+        }
+
+        // Make sure the method is completed, despite the effective canister is aborted.
+        if subnet_complete {
+            assert_eq!(
+                ingress_state(env.ingress_status(&subnet_message_id)),
+                Some(IngressState::Completed(WasmResult::Reply(vec![43])))
+            );
+        }
+
+        env.set_checkpoints_enabled(false);
+        for _ in 0..5 {
+            env.tick();
+        }
+
+        // Make sure the aborted message is completed.
+        if aborted_complete {
+            assert_eq!(
+                ingress_state(env.ingress_status(&long_execution_id)),
+                Some(IngressState::Completed(WasmResult::Reply(vec![42])))
+            );
+        }
+    }
+    fn test_supported<F: Fn(CanisterId) -> (Method, CallArgs)>(f: F) {
+        test(true, true, f);
+    }
+    fn test_unsupported<F: Fn(CanisterId) -> (Method, CallArgs)>(f: F) {
+        test(false, true, f);
+    }
+    fn test_supported_uninstall<F: Fn(CanisterId) -> (Method, CallArgs)>(f: F) {
+        test(true, false, f);
     }
 
-    let args = Encode!(&CanisterIdRecord::from(long_canister_id)).unwrap();
-    let deposit_cycles = wasm()
-        .call_with_cycles(
-            IC_00,
-            Method::DepositCycles,
-            call_args()
-                .other_side(args)
-                .on_reject(wasm().reject_message().reject())
-                .on_reply(wasm().reply_data(&[43])),
-            1_u128.into(),
-        )
-        .build();
-
-    let deposit_message_id = env.send_ingress(user_id, other_canister_id, "update", deposit_cycles);
-
-    for _ in 0..5 {
-        env.tick();
+    for method in Method::iter() {
+        match method {
+            // Supported methods accepting just one argument.
+            Method::CanisterStatus | Method::DepositCycles | Method::StartCanister => {
+                test_supported(|aborted_canister_id| {
+                    let args = CanisterIdRecord::from(aborted_canister_id).encode();
+                    (method, call_args().other_side(args))
+                })
+            }
+            Method::CanisterInfo => test_supported(|aborted_canister_id| {
+                let args = CanisterInfoRequest::new(aborted_canister_id, None).encode();
+                (method, call_args().other_side(args))
+            }),
+            // No effective canister id.
+            Method::CreateCanister
+            | Method::HttpRequest
+            | Method::ECDSAPublicKey
+            | Method::RawRand
+            | Method::SetupInitialDKG
+            | Method::SignWithECDSA
+            | Method::ComputeInitialIDkgDealings
+            | Method::SchnorrPublicKey
+            | Method::SignWithSchnorr
+            | Method::BitcoinGetBalance
+            | Method::BitcoinGetUtxos
+            | Method::BitcoinGetBlockHeaders
+            | Method::BitcoinSendTransaction
+            | Method::BitcoinGetCurrentFeePercentiles
+            | Method::BitcoinSendTransactionInternal
+            | Method::BitcoinGetSuccessors
+            | Method::NodeMetricsHistory
+            | Method::ProvisionalCreateCanisterWithCycles
+            | Method::ProvisionalTopUpCanister => {}
+            // Unsupported methods accepting just one argument.
+            // Deleting an aborted canister requires to stop it first.
+            // Stopping an aborted canister does not generate a reply.
+            Method::DeleteCanister | Method::StopCanister => {
+                test_unsupported(|aborted_canister_id| {
+                    let args = CanisterIdRecord::from(aborted_canister_id).encode();
+                    (method, call_args().other_side(args))
+                })
+            }
+            // Installing code is not supported on aborted canister.
+            Method::InstallCode => test_unsupported(|aborted_canister_id| {
+                let args = InstallCodeArgs {
+                    canister_id: aborted_canister_id.get(),
+                    mode: CanisterInstallMode::Install,
+                    wasm_module: UNIVERSAL_CANISTER_WASM.into(),
+                    arg: vec![],
+                    compute_allocation: None,
+                    memory_allocation: None,
+                    sender_canister_version: None,
+                }
+                .encode();
+                (method, call_args().other_side(args))
+            }),
+            // Installing code is not supported on aborted canister.
+            Method::InstallChunkedCode => test_unsupported(|aborted_canister_id| {
+                let args = InstallChunkedCodeArgs {
+                    mode: CanisterInstallModeV2::Install,
+                    target_canister: aborted_canister_id.get(),
+                    store_canister: None,
+                    chunk_hashes_list: vec![],
+                    wasm_module_hash: vec![],
+                    arg: vec![],
+                    sender_canister_version: None,
+                }
+                .encode();
+                (method, call_args().other_side(args))
+            }),
+            Method::UninstallCode => test_supported_uninstall(|aborted_canister_id| {
+                let args = UninstallCodeArgs::new(aborted_canister_id, None).encode();
+                (method, call_args().other_side(args))
+            }),
+            Method::UpdateSettings => test_supported(|aborted_canister_id| {
+                let settings = CanisterSettingsArgsBuilder::new().build();
+                let args = UpdateSettingsArgs::new(aborted_canister_id, settings).encode();
+                (method, call_args().other_side(args))
+            }),
+            // API is only accessible in non-replicated mode
+            Method::FetchCanisterLogs => {}
+            Method::UploadChunk => test_supported(|aborted_canister_id| {
+                let args = UploadChunkArgs {
+                    canister_id: aborted_canister_id.get(),
+                    chunk: vec![],
+                }
+                .encode();
+                (method, call_args().other_side(args))
+            }),
+            Method::StoredChunks => test_supported(|aborted_canister_id| {
+                let args = StoredChunksArgs {
+                    canister_id: aborted_canister_id.get(),
+                }
+                .encode();
+                (method, call_args().other_side(args))
+            }),
+            Method::ClearChunkStore => test_supported(|aborted_canister_id| {
+                let args = ClearChunkStoreArgs {
+                    canister_id: aborted_canister_id.get(),
+                }
+                .encode();
+                (method, call_args().other_side(args))
+            }),
+            Method::TakeCanisterSnapshot => test_supported(|aborted_canister_id| {
+                let args = TakeCanisterSnapshotArgs {
+                    canister_id: aborted_canister_id.get(),
+                    replace_snapshot: None,
+                }
+                .encode();
+                (method, call_args().other_side(args))
+            }),
+            // Loading a snapshot is similar to the install code.
+            Method::LoadCanisterSnapshot => test_unsupported(|aborted_canister_id| {
+                let args = LoadCanisterSnapshotArgs::new(
+                    aborted_canister_id,
+                    (aborted_canister_id, 0).into(),
+                    None,
+                )
+                .encode();
+                (method, call_args().other_side(args))
+            }),
+            Method::ListCanisterSnapshots => test_supported(|aborted_canister_id| {
+                let args = ListCanisterSnapshotArgs::new(aborted_canister_id).encode();
+                (method, call_args().other_side(args))
+            }),
+            Method::DeleteCanisterSnapshot => test_supported(|aborted_canister_id| {
+                let args = DeleteCanisterSnapshotArgs::new(
+                    aborted_canister_id,
+                    (aborted_canister_id, 0).into(),
+                )
+                .encode();
+                (method, call_args().other_side(args))
+            }),
+        }
     }
-
-    assert_eq!(
-        ingress_state(env.ingress_status(&long_execution_id)),
-        Some(IngressState::Processing)
-    );
-
-    // Make sure the `ic0.deposit_cycles` is completed,
-    // despite the effective canister is aborted.
-    assert_eq!(
-        ingress_state(env.ingress_status(&deposit_message_id)),
-        Some(IngressState::Completed(WasmResult::Reply(vec![43])))
-    );
-
-    env.set_checkpoints_enabled(false);
-    for _ in 0..5 {
-        env.tick();
-    }
-
-    // Make sure the aborted message is completed.
-    assert_eq!(
-        ingress_state(env.ingress_status(&long_execution_id)),
-        Some(IngressState::Completed(WasmResult::Reply(vec![42])))
-    );
 }
 
 #[test]


### PR DESCRIPTION
While in general it's safe to modify the state of aborted canisters, there are a few exceptions. Unlike normal canisters, aborted canisters have already taken messages from the input queues and stored them in their task queues. Therefore, subnet messages that would pause canister execution or alter  the task queue are not allowed for now.