### PR TITLE
feat(PocketIC): dashboard endpoint in PocketIC HTTP gateway

### DIFF
--- a/rs/pocket_ic_server/CHANGELOG.md
+++ b/rs/pocket_ic_server/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The argument of the endpoint `/instances/` takes an additional optional field `log_level` specifying the replica log level of the PocketIC instance.
 - ECDSA support (IC mainnet-like): there are three ECDSA keys with names `dfx_test_key1`, `test_key_1`, and `key_1` on the II and fiduciary subnet.
 - tSchnorr support (IC mainnet-like): there are three Schnorr keys with names `dfx_test_key1`, `test_key_1`, and `key_1` and algorithm BIP340 as well as three Schnorr keys with names `dfx_test_key1`, `test_key_1`, and `key_1` and algorithm Ed25519 on the II and fiduciary subnet. The messages to sign with tSchnorr must be of length 32 bytes.
+- New endpoint `/_/dashboard` of the PocketIC HTTP gateway returning the dashboard of the underlying PocketIC instance or replica.
 
 ### Changed
 - The argument `listen_at` of the endpoint `/http_gateway` has been renamed to `port`.

--- a/rs/pocket_ic_server/src/state_api/state.rs
+++ b/rs/pocket_ic_server/src/state_api/state.rs
@@ -725,6 +725,23 @@ impl ApiState {
                 .map_err(|e| ErrorCause::ConnectionFailure(e.to_string()))
         }
 
+        async fn handler_dashboard(
+            State(replica_url): State<String>,
+            bytes: Bytes,
+        ) -> Result<HyperResponse<Incoming>, ErrorCause> {
+            let client =
+                Client::builder(hyper_util::rt::TokioExecutor::new()).build(HttpConnector::new());
+            let url = format!("{}/_/dashboard", replica_url);
+            let req = Request::builder()
+                .uri(url)
+                .body(Full::<Bytes>::new(bytes))
+                .unwrap();
+            client
+                .request(req)
+                .await
+                .map_err(|e| ErrorCause::ConnectionFailure(e.to_string()))
+        }
+
         async fn handler_api_canister(
             api_version: ApiVersion,
             replica_url: String,
@@ -930,6 +947,7 @@ impl ApiState {
                 )
                 .fallback(|| async { (StatusCode::NOT_FOUND, "") });
             let router = Router::new()
+                .route("/_/dashboard", get(handler_dashboard))
                 .nest("/api/v2", router_api_v2)
                 .nest("/api/v3", router_api_v3)
                 .fallback(

--- a/rs/pocket_ic_server/tests/test.rs
+++ b/rs/pocket_ic_server/tests/test.rs
@@ -435,7 +435,7 @@ fn test_dashboard() {
         application: 1,
         ..Default::default()
     };
-    let pic = PocketIc::from_config_and_server_url(subnet_config_set, server_url.clone());
+    let mut pic = PocketIc::from_config_and_server_url(subnet_config_set, server_url.clone());
 
     // retrieve the NNS and application subnets
     let topology = pic.topology();
@@ -447,14 +447,20 @@ fn test_dashboard() {
     let canister_2 = pic.create_canister_on_subnet(None, None, app_subnet);
     assert_eq!(pic.get_subnet(canister_2).unwrap(), app_subnet);
 
+    let gateway = pic.make_live(None);
+
     let client = Client::new();
-    let dashboard_url = format!("{}instances/{}/_/dashboard", server_url, pic.instance_id());
-    let dashboard = client.get(dashboard_url).send().unwrap();
-    let page = String::from_utf8(dashboard.bytes().unwrap().to_vec()).unwrap();
-    assert!(page.contains(&canister_1.to_string()));
-    assert!(page.contains(&canister_2.to_string()));
-    assert!(page.contains(&nns_subnet.to_string()));
-    assert!(page.contains(&app_subnet.to_string()));
+    let instance_dashboard_url =
+        format!("{}instances/{}/_/dashboard", server_url, pic.instance_id());
+    let gateway_dashboard_url = gateway.join("_/dashboard").unwrap().to_string();
+    for dashboard_url in [instance_dashboard_url, gateway_dashboard_url] {
+        let dashboard = client.get(dashboard_url).send().unwrap();
+        let page = String::from_utf8(dashboard.bytes().unwrap().to_vec()).unwrap();
+        assert!(page.contains(&canister_1.to_string()));
+        assert!(page.contains(&canister_2.to_string()));
+        assert!(page.contains(&nns_subnet.to_string()));
+        assert!(page.contains(&app_subnet.to_string()));
+    }
 }
 
 #[test]


### PR DESCRIPTION
This PR adds a new endpoint `/_/dashboard` of the PocketIC HTTP gateway returning the dashboard of the underlying PocketIC instance or replica.

This way, the URL of the PocketIC HTTP gateway can be used to access the dashboard and no separate URL of the PocketIC instance (having a non-empty URL path of the form `/instances/<instance_id>`) or replica is needed.

On the other hand, the path `/_/dashboard` becomes reserved and cannot be used for frontend canister assets (note that paths with prefixes `/api/v2` and `/api/v3` are already reserved and thus this PR does not make a qualitative difference here).