### PR TITLE
chore(system-tests-k8s): shorter VM name

### DIFF
--- a/rs/tests/financial_integrations/rosetta/BUILD.bazel
+++ b/rs/tests/financial_integrations/rosetta/BUILD.bazel
@@ -39,7 +39,7 @@ system_test_nns(
 )
 
 system_test_nns(
-    name = "rosetta_make_transactions_test",
+    name = "rosetta_transactions_test",
     flaky = True,
     proc_macro_deps = MACRO_DEPENDENCIES,
     tags = [

--- a/rs/tests/financial_integrations/rosetta/BUILD.bazel
+++ b/rs/tests/financial_integrations/rosetta/BUILD.bazel
@@ -39,7 +39,7 @@ system_test_nns(
 )
 
 system_test_nns(
-    name = "rosetta_transactions_test",
+    name = "rosetta_make_transactions_test",
     flaky = True,
     proc_macro_deps = MACRO_DEPENDENCIES,
     tags = [

--- a/rs/tests/src/rosetta_tests/tests/derive.rs
+++ b/rs/tests/src/rosetta_tests/tests/derive.rs
@@ -11,7 +11,7 @@ use icp_ledger::{AccountIdentifier, Subaccount};
 use slog::{info, Logger};
 
 const PORT: u32 = 8101;
-const VM_NAME: &str = "rosetta-test-derive";
+const VM_NAME: &str = "test-derive";
 
 pub fn test(env: TestEnv) {
     let client = setup(&env, PORT, VM_NAME, None, None);

--- a/rs/tests/src/rosetta_tests/tests/list_known_neurons.rs
+++ b/rs/tests/src/rosetta_tests/tests/list_known_neurons.rs
@@ -12,7 +12,7 @@ use ic_system_test_driver::{driver::test_env::TestEnv, util::block_on};
 use std::collections::HashMap;
 
 const PORT: u32 = 8107;
-const VM_NAME: &str = "rosetta-neuron-info";
+const VM_NAME: &str = "neuron-info";
 
 pub fn test(env: TestEnv) {
     let _logger = env.logger();

--- a/rs/tests/src/rosetta_tests/tests/list_neurons.rs
+++ b/rs/tests/src/rosetta_tests/tests/list_neurons.rs
@@ -25,7 +25,7 @@ use rosetta_core::objects::ObjectMap;
 use std::{collections::HashMap, sync::Arc};
 
 const PORT: u32 = 8107;
-const VM_NAME: &str = "rosetta-neuron-info";
+const VM_NAME: &str = "neuron-info";
 
 pub fn test(env: TestEnv) {
     let _logger = env.logger();

--- a/rs/tests/src/rosetta_tests/tests/make_transaction.rs
+++ b/rs/tests/src/rosetta_tests/tests/make_transaction.rs
@@ -22,7 +22,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 const PORT: u32 = 8102;
-const VM_NAME: &str = "rosetta-make-transaction";
+const VM_NAME: &str = "make-transaction";
 
 lazy_static! {
     static ref FEE: Tokens = Tokens::from_e8s(10_000);

--- a/rs/tests/src/rosetta_tests/tests/network.rs
+++ b/rs/tests/src/rosetta_tests/tests/network.rs
@@ -8,7 +8,7 @@ use rosetta_core::response_types::NetworkListResponse;
 use slog::{debug, Logger};
 
 const PORT: u32 = 8100;
-const VM_NAME: &str = "rosetta-test-network";
+const VM_NAME: &str = "test-network";
 
 pub fn test(env: TestEnv) {
     let client = setup(&env, PORT, VM_NAME, None, None);

--- a/rs/tests/src/rosetta_tests/tests/neuron_disburse.rs
+++ b/rs/tests/src/rosetta_tests/tests/neuron_disburse.rs
@@ -30,7 +30,7 @@ use slog::Logger;
 use std::{collections::HashMap, str::FromStr, sync::Arc, time::UNIX_EPOCH};
 
 const PORT: u32 = 8104;
-const VM_NAME: &str = "rosetta-neuron-disburse";
+const VM_NAME: &str = "neuron-disburse";
 
 pub fn test(env: TestEnv) {
     let logger = env.logger();

--- a/rs/tests/src/rosetta_tests/tests/neuron_dissolve.rs
+++ b/rs/tests/src/rosetta_tests/tests/neuron_dissolve.rs
@@ -19,7 +19,7 @@ use std::{
 };
 
 const PORT: u32 = 8105;
-const VM_NAME: &str = "rosetta-neuron-dissolve";
+const VM_NAME: &str = "neuron-dissolve";
 
 pub fn test(env: TestEnv) {
     let _logger = env.logger();

--- a/rs/tests/src/rosetta_tests/tests/neuron_follow.rs
+++ b/rs/tests/src/rosetta_tests/tests/neuron_follow.rs
@@ -27,7 +27,7 @@ use std::{
 };
 
 const PORT: u32 = 8108;
-const VM_NAME: &str = "rosetta-neuron-follow";
+const VM_NAME: &str = "neuron-follow";
 
 pub fn test(env: TestEnv) {
     let _logger = env.logger();

--- a/rs/tests/src/rosetta_tests/tests/neuron_hotkey.rs
+++ b/rs/tests/src/rosetta_tests/tests/neuron_hotkey.rs
@@ -20,7 +20,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 const PORT: u32 = 8105;
-const VM_NAME: &str = "rosetta-neuron-hotkey";
+const VM_NAME: &str = "neuron-hotkey";
 
 pub fn test(env: TestEnv) {
     let logger = env.logger();

--- a/rs/tests/src/rosetta_tests/tests/neuron_info.rs
+++ b/rs/tests/src/rosetta_tests/tests/neuron_info.rs
@@ -25,7 +25,7 @@ use serde_json::{json, Value};
 use std::{collections::HashMap, sync::Arc};
 
 const PORT: u32 = 8107;
-const VM_NAME: &str = "rosetta-neuron-info";
+const VM_NAME: &str = "neuron-info";
 
 pub fn test(env: TestEnv) {
     let _logger = env.logger();

--- a/rs/tests/src/rosetta_tests/tests/neuron_maturity.rs
+++ b/rs/tests/src/rosetta_tests/tests/neuron_maturity.rs
@@ -20,7 +20,7 @@ use icp_ledger::AccountIdentifier;
 use std::{collections::HashMap, sync::Arc};
 
 const PORT: u32 = 8109;
-const VM_NAME: &str = "rosetta-neuron-maturity";
+const VM_NAME: &str = "neuron-maturity";
 
 pub fn test(env: TestEnv) {
     let _logger = env.logger();

--- a/rs/tests/src/rosetta_tests/tests/neuron_spawn.rs
+++ b/rs/tests/src/rosetta_tests/tests/neuron_spawn.rs
@@ -17,7 +17,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 const PORT: u32 = 8106;
-const VM_NAME: &str = "rosetta-neuron-spawn";
+const VM_NAME: &str = "neuron-spawn";
 
 pub fn test(env: TestEnv) {
     let _logger = env.logger();

--- a/rs/tests/src/rosetta_tests/tests/neuron_staking.rs
+++ b/rs/tests/src/rosetta_tests/tests/neuron_staking.rs
@@ -27,7 +27,7 @@ use std::sync::Arc;
 use std::time::UNIX_EPOCH;
 
 const PORT: u32 = 8103;
-const VM_NAME: &str = "rosetta-neuron-staking";
+const VM_NAME: &str = "neuron-staking";
 
 pub fn test(env: TestEnv) {
     let logger = env.logger();

--- a/rs/tests/src/rosetta_tests/tests/neuron_voting.rs
+++ b/rs/tests/src/rosetta_tests/tests/neuron_voting.rs
@@ -29,7 +29,7 @@ use slog::info;
 use std::{collections::HashMap, sync::Arc, time::UNIX_EPOCH};
 
 const PORT: u32 = 8111;
-const VM_NAME: &str = "rosetta-neuron-voting";
+const VM_NAME: &str = "neuron-voting";
 pub fn test(env: TestEnv) {
     let _logger = env.logger();
 


### PR DESCRIPTION
Making UVM name shorter to overcome the issue of names being too long on k8s system tests where UVM name is concatenated from system test name and UVM name.

```
Invalid value: \"rosetta-neuron-hotkey-test-head-nns-szkv7-1-rosetta-neuron-hotkey\": must be no more than 63 characters", reason: "Invalid", code: 422
```