### PR TITLE
fix(system-tests-k8s): aws variable

### DIFF
--- a/.github/workflows/release-testing.yml
+++ b/.github/workflows/release-testing.yml
@@ -220,7 +220,7 @@ jobs:
       group: zh1
       labels: dind-large
     container:
-      image: ghcr.io/dfinity/ic-build@sha256:748d5cd92d982531a25cd6c4f247bb6c0e484c9ac654164341f59a7d57d1fffc
+      image: ghcr.io/dfinity/ic-build@sha256:1c0e901df3c7a97fc440c271881400ce6d2e586e2a89cdc39ec939e3dfe5de76
       options: >-
         -e NODE_NAME --privileged --cgroupns host -v /cache:/cache -v /var/sysimage:/var/sysimage -v /var/tmp:/var/tmp
     timeout-minutes: 180 # 3 hours
@@ -243,7 +243,7 @@ jobs:
       group: zh1
       labels: dind-large
     container:
-      image: ghcr.io/dfinity/ic-build@sha256:748d5cd92d982531a25cd6c4f247bb6c0e484c9ac654164341f59a7d57d1fffc
+      image: ghcr.io/dfinity/ic-build@sha256:1c0e901df3c7a97fc440c271881400ce6d2e586e2a89cdc39ec939e3dfe5de76
       options: >-
         -e NODE_NAME --privileged --cgroupns host -v /cache:/cache -v /var/sysimage:/var/sysimage -v /var/tmp:/var/tmp
     timeout-minutes: 180 # 3 hours

--- a/.github/workflows/system-tests-k8s.yml
+++ b/.github/workflows/system-tests-k8s.yml
@@ -85,12 +85,15 @@ jobs:
       - name: Run System Tests on K8s
         id: bazel-test-all
         uses: ./.github/actions/bazel-test-all/
+        env:
+          AWS_SHARED_CREDENTIALS_CONTENT: ${{ secrets.AWS_SHARED_CREDENTIALS_FILE }}
         with:
           BAZEL_COMMAND: "test"
           BAZEL_TARGETS: "${{ env.TARGETS }}"
           BAZEL_CI_CONFIG: "--config=ci --repository_cache=/cache/bazel"
-          BAZEL_EXTRA_ARGS: "--jobs=${{ env.JOBS }} --test_tag_filters=k8s,-manual,-colocated --k8s"
+          BAZEL_EXTRA_ARGS: "--jobs=${{ env.JOBS }} --test_tag_filters=k8s,-manual,-colocated,-system_test_hourly,-system_test_nightly --k8s"
           HONEYCOMB_API_TOKEN: ${{ secrets.HONEYCOMB_API_TOKEN }}
+
       - name: Upload bazel-bep
         uses: actions/upload-artifact@v4
         if: always()

--- a/.github/workflows/system-tests-k8s.yml
+++ b/.github/workflows/system-tests-k8s.yml
@@ -91,7 +91,7 @@ jobs:
           BAZEL_COMMAND: "test"
           BAZEL_TARGETS: "${{ env.TARGETS }}"
           BAZEL_CI_CONFIG: "--config=ci --repository_cache=/cache/bazel"
-          BAZEL_EXTRA_ARGS: "--jobs=${{ env.JOBS }} --test_tag_filters=k8s,-manual,-colocated,-system_test_hourly,-system_test_nightly --k8s"
+          BAZEL_EXTRA_ARGS: "--jobs=${{ env.JOBS }} --test_tag_filters=k8s,-manual,-colocated,-system_test_nightly --k8s"
           HONEYCOMB_API_TOKEN: ${{ secrets.HONEYCOMB_API_TOKEN }}
 
       - name: Upload bazel-bep

--- a/rs/tests/testing_verification/BUILD.bazel
+++ b/rs/tests/testing_verification/BUILD.bazel
@@ -105,7 +105,6 @@ system_test(
     tags = [
         "k8s",
         "system_test_hourly",
-        "system_test_nightly",
     ],
     target_compatible_with = ["@platforms//os:linux"],  # requires libssh that does not build on Mac OS
     runtime_deps = GUESTOS_RUNTIME_DEPS + GRAFANA_RUNTIME_DEPS,


### PR DESCRIPTION
We still rely on AWS in system tests on k8s. Adding it back for now. Removing nightly test on scheduled nightly to focus on system tests that are part of PR and hourly schedule.