### PR TITLE
chore(consensus): Rename `get_all_validated` to `get_retransmissions` to better picture how the method is used

### DIFF
--- a/rs/artifact_pool/src/canister_http_pool.rs
+++ b/rs/artifact_pool/src/canister_http_pool.rs
@@ -165,7 +165,7 @@ impl ValidatedPoolReader<CanisterHttpResponseShare> for CanisterHttpPoolImpl {
         self.validated.get(id).map(|()| id.clone())
     }
 
-    fn get_all_validated(&self) -> Box<dyn Iterator<Item = CanisterHttpResponseShare> + '_> {
+    fn get_retransmissions(&self) -> Box<dyn Iterator<Item = CanisterHttpResponseShare> + '_> {
         Box::new(std::iter::empty())
     }
 }

--- a/rs/artifact_pool/src/canister_http_pool.rs
+++ b/rs/artifact_pool/src/canister_http_pool.rs
@@ -7,8 +7,8 @@ use crate::{
 use ic_interfaces::{
     canister_http::{CanisterHttpChangeAction, CanisterHttpChangeSet, CanisterHttpPool},
     p2p::consensus::{
-        ArtifactMutation, ArtifactWithOpt, ChangeResult, MutablePool, UnvalidatedArtifact,
-        ValidatedPoolReader,
+        ArtifactMutation, ArtifactWithOpt, ChangeResult, MutablePool, Retransmittable,
+        UnvalidatedArtifact, ValidatedPoolReader,
     },
 };
 use ic_logger::{warn, ReplicaLogger};
@@ -164,7 +164,9 @@ impl ValidatedPoolReader<CanisterHttpResponseShare> for CanisterHttpPoolImpl {
     fn get(&self, id: &CanisterHttpResponseId) -> Option<CanisterHttpResponseShare> {
         self.validated.get(id).map(|()| id.clone())
     }
+}
 
+impl Retransmittable<CanisterHttpResponseShare> for CanisterHttpPoolImpl {
     fn get_retransmissions(&self) -> Box<dyn Iterator<Item = CanisterHttpResponseShare> + '_> {
         Box::new(std::iter::empty())
     }

--- a/rs/artifact_pool/src/certification_pool.rs
+++ b/rs/artifact_pool/src/certification_pool.rs
@@ -2,7 +2,7 @@ use crate::height_index::HeightIndex;
 use crate::metrics::{PoolMetrics, POOL_TYPE_UNVALIDATED, POOL_TYPE_VALIDATED};
 use crate::pool_common::HasLabel;
 use ic_config::artifact_pool::{ArtifactPoolConfig, PersistentPoolBackend};
-use ic_interfaces::p2p::consensus::ArtifactWithOpt;
+use ic_interfaces::p2p::consensus::{ArtifactWithOpt, Retransmittable};
 use ic_interfaces::{
     certification::{CertificationPool, ChangeAction, ChangeSet},
     consensus_pool::HeightIndexedPool,
@@ -392,7 +392,9 @@ impl ValidatedPoolReader<CertificationMessage> for CertificationPoolImpl {
             }
         }
     }
+}
 
+impl Retransmittable<CertificationMessage> for CertificationPoolImpl {
     fn get_retransmissions(&self) -> Box<dyn Iterator<Item = CertificationMessage> + '_> {
         let certification_range = self.persistent_pool.certifications().height_range();
         let share_range = self.persistent_pool.certification_shares().height_range();

--- a/rs/artifact_pool/src/certification_pool.rs
+++ b/rs/artifact_pool/src/certification_pool.rs
@@ -393,7 +393,7 @@ impl ValidatedPoolReader<CertificationMessage> for CertificationPoolImpl {
         }
     }
 
-    fn get_all_validated(&self) -> Box<dyn Iterator<Item = CertificationMessage> + '_> {
+    fn get_retransmissions(&self) -> Box<dyn Iterator<Item = CertificationMessage> + '_> {
         let certification_range = self.persistent_pool.certifications().height_range();
         let share_range = self.persistent_pool.certification_shares().height_range();
 
@@ -870,7 +870,7 @@ mod tests {
             };
 
             let mut heights = HashSet::new();
-            pool.get_all_validated().for_each(|m| {
+            pool.get_retransmissions().for_each(|m| {
                 if m.height().get() % 2 == 0 {
                     assert!(!m.is_share());
                 }
@@ -883,7 +883,7 @@ mod tests {
                 assert!(heights.insert(m.height()));
             });
             assert_eq!(heights.len(), 20);
-            assert_eq!(pool.get_all_validated().count(), 20);
+            assert_eq!(pool.get_retransmissions().count(), 20);
         });
     }
 }

--- a/rs/artifact_pool/src/consensus_pool.rs
+++ b/rs/artifact_pool/src/consensus_pool.rs
@@ -9,7 +9,7 @@ use crate::{
     metrics::{LABEL_POOL_TYPE, POOL_TYPE_UNVALIDATED, POOL_TYPE_VALIDATED},
 };
 use ic_config::artifact_pool::{ArtifactPoolConfig, PersistentPoolBackend};
-use ic_interfaces::p2p::consensus::ArtifactWithOpt;
+use ic_interfaces::p2p::consensus::{ArtifactWithOpt, Retransmittable};
 use ic_interfaces::{
     consensus_pool::{
         ChangeAction, ChangeSet, ConsensusBlockCache, ConsensusBlockChain, ConsensusPool,
@@ -833,7 +833,9 @@ impl ValidatedPoolReader<ConsensusMessage> for ConsensusPoolImpl {
     fn get(&self, id: &ConsensusMessageId) -> Option<ConsensusMessage> {
         self.validated.get(id)
     }
+}
 
+impl Retransmittable<ConsensusMessage> for ConsensusPoolImpl {
     fn get_retransmissions(&self) -> Box<dyn Iterator<Item = ConsensusMessage> + '_> {
         let node_id = self.node_id;
         let max_catch_up_height = self

--- a/rs/artifact_pool/src/consensus_pool.rs
+++ b/rs/artifact_pool/src/consensus_pool.rs
@@ -834,7 +834,7 @@ impl ValidatedPoolReader<ConsensusMessage> for ConsensusPoolImpl {
         self.validated.get(id)
     }
 
-    fn get_all_validated(&self) -> Box<dyn Iterator<Item = ConsensusMessage> + '_> {
+    fn get_retransmissions(&self) -> Box<dyn Iterator<Item = ConsensusMessage> + '_> {
         let node_id = self.node_id;
         let max_catch_up_height = self
             .validated
@@ -1462,7 +1462,7 @@ mod tests {
                 _ => panic!("No signer for aggregate artifacts"),
             };
 
-            pool.get_all_validated().for_each(|m| {
+            pool.get_retransmissions().for_each(|m| {
                 if m.height().get() <= height_offset + 15 {
                     assert!(!m.is_share());
                 }
@@ -1472,7 +1472,7 @@ mod tests {
             });
 
             assert_eq!(
-                pool.get_all_validated().count(),
+                pool.get_retransmissions().count(),
                 // 1 CUP, 15 heights of aggregates, 5 heights of shares, 20 heights of proposals
                 1 + 15 * 4 + 5 * 4 + 20 * 5
             );

--- a/rs/artifact_pool/src/dkg_pool.rs
+++ b/rs/artifact_pool/src/dkg_pool.rs
@@ -151,7 +151,7 @@ impl ValidatedPoolReader<dkg::Message> for DkgPoolImpl {
         self.validated.get(id).cloned()
     }
 
-    fn get_all_validated(&self) -> Box<dyn Iterator<Item = dkg::Message>> {
+    fn get_retransmissions(&self) -> Box<dyn Iterator<Item = dkg::Message>> {
         Box::new(std::iter::empty())
     }
 }

--- a/rs/artifact_pool/src/dkg_pool.rs
+++ b/rs/artifact_pool/src/dkg_pool.rs
@@ -5,8 +5,8 @@ use crate::{
 use ic_interfaces::{
     dkg::{ChangeAction, ChangeSet, DkgPool},
     p2p::consensus::{
-        ArtifactMutation, ArtifactWithOpt, ChangeResult, MutablePool, UnvalidatedArtifact,
-        ValidatedPoolReader,
+        ArtifactMutation, ArtifactWithOpt, ChangeResult, MutablePool, Retransmittable,
+        UnvalidatedArtifact, ValidatedPoolReader,
     },
 };
 use ic_logger::{warn, ReplicaLogger};
@@ -150,7 +150,9 @@ impl ValidatedPoolReader<dkg::Message> for DkgPoolImpl {
     fn get(&self, id: &DkgMessageId) -> Option<dkg::Message> {
         self.validated.get(id).cloned()
     }
+}
 
+impl Retransmittable<dkg::Message> for DkgPoolImpl {
     fn get_retransmissions(&self) -> Box<dyn Iterator<Item = dkg::Message>> {
         Box::new(std::iter::empty())
     }

--- a/rs/artifact_pool/src/idkg_pool.rs
+++ b/rs/artifact_pool/src/idkg_pool.rs
@@ -486,7 +486,7 @@ impl ValidatedPoolReader<IDkgMessage> for IDkgPoolImpl {
         self.validated.as_pool_section().get(msg_id)
     }
 
-    fn get_all_validated(&self) -> Box<dyn Iterator<Item = IDkgMessage>> {
+    fn get_retransmissions(&self) -> Box<dyn Iterator<Item = IDkgMessage>> {
         Box::new(std::iter::empty())
     }
 }

--- a/rs/artifact_pool/src/idkg_pool.rs
+++ b/rs/artifact_pool/src/idkg_pool.rs
@@ -13,8 +13,8 @@ use crate::{
 };
 use ic_config::artifact_pool::{ArtifactPoolConfig, PersistentPoolBackend};
 use ic_interfaces::p2p::consensus::{
-    ArtifactMutation, ArtifactWithOpt, ChangeResult, MutablePool, UnvalidatedArtifact,
-    ValidatedPoolReader,
+    ArtifactMutation, ArtifactWithOpt, ChangeResult, MutablePool, Retransmittable,
+    UnvalidatedArtifact, ValidatedPoolReader,
 };
 use ic_interfaces::{
     idkg::{
@@ -485,7 +485,9 @@ impl ValidatedPoolReader<IDkgMessage> for IDkgPoolImpl {
     fn get(&self, msg_id: &IDkgMessageId) -> Option<IDkgMessage> {
         self.validated.as_pool_section().get(msg_id)
     }
+}
 
+impl Retransmittable<IDkgMessage> for IDkgPoolImpl {
     fn get_retransmissions(&self) -> Box<dyn Iterator<Item = IDkgMessage>> {
         Box::new(std::iter::empty())
     }

--- a/rs/artifact_pool/src/ingress_pool.rs
+++ b/rs/artifact_pool/src/ingress_pool.rs
@@ -339,8 +339,8 @@ impl ValidatedPoolReader<SignedIngress> for IngressPoolImpl {
         self.validated.get(id).map(|a| a.msg.signed_ingress.clone())
     }
 
-    fn get_all_validated<'a>(&'a self) -> Box<dyn Iterator<Item = SignedIngress> + 'a> {
-        Box::new(vec![].into_iter())
+    fn get_retransmissions(&self) -> Box<dyn Iterator<Item = SignedIngress>> {
+        Box::new(std::iter::empty())
     }
 }
 
@@ -518,7 +518,7 @@ mod tests {
                     );
                 }
                 // empty
-                let filtered_msgs = ingress_pool.get_all_validated();
+                let filtered_msgs = ingress_pool.get_retransmissions();
                 assert!(filtered_msgs.count() == 0);
             })
         })

--- a/rs/artifact_pool/src/ingress_pool.rs
+++ b/rs/artifact_pool/src/ingress_pool.rs
@@ -12,8 +12,8 @@ use ic_interfaces::{
         UnvalidatedIngressArtifact, ValidatedIngressArtifact,
     },
     p2p::consensus::{
-        ArtifactMutation, ArtifactWithOpt, ChangeResult, MutablePool, UnvalidatedArtifact,
-        ValidatedPoolReader,
+        ArtifactMutation, ArtifactWithOpt, ChangeResult, MutablePool, Retransmittable,
+        UnvalidatedArtifact, ValidatedPoolReader,
     },
 };
 use ic_logger::{debug, ReplicaLogger};
@@ -338,7 +338,9 @@ impl ValidatedPoolReader<SignedIngress> for IngressPoolImpl {
     fn get(&self, id: &IngressMessageId) -> Option<SignedIngress> {
         self.validated.get(id).map(|a| a.msg.signed_ingress.clone())
     }
+}
 
+impl Retransmittable<SignedIngress> for IngressPoolImpl {
     fn get_retransmissions(&self) -> Box<dyn Iterator<Item = SignedIngress>> {
         Box::new(std::iter::empty())
     }

--- a/rs/interfaces/src/p2p/consensus.rs
+++ b/rs/interfaces/src/p2p/consensus.rs
@@ -81,7 +81,9 @@ pub trait ValidatedPoolReader<T: IdentifiableArtifact> {
     /// - 'Some`: Artifact from the validated pool.
     /// - `None`: Artifact does not exist in the validated pool.
     fn get(&self, id: &T::Id) -> Option<T>;
+}
 
+pub trait Retransmittable<T: IdentifiableArtifact> {
     /// Get all validated artifacts which need to be retransmitted after the replica restarts.
     fn get_retransmissions(&self) -> Box<dyn Iterator<Item = T> + '_>;
 }

--- a/rs/interfaces/src/p2p/consensus.rs
+++ b/rs/interfaces/src/p2p/consensus.rs
@@ -82,11 +82,8 @@ pub trait ValidatedPoolReader<T: IdentifiableArtifact> {
     /// - `None`: Artifact does not exist in the validated pool.
     fn get(&self, id: &T::Id) -> Option<T>;
 
-    /// Get all validated artifacts.
-    ///
-    /// #Returns:
-    /// A iterator over all the validated artifacts.
-    fn get_all_validated(&self) -> Box<dyn Iterator<Item = T> + '_>;
+    /// Get all validated artifacts which need to be retransmitted after the replica restarts.
+    fn get_retransmissions(&self) -> Box<dyn Iterator<Item = T> + '_>;
 }
 
 /// Unvalidated artifact

--- a/rs/p2p/artifact_downloader/src/fetch_stripped_artifact/assembler.rs
+++ b/rs/p2p/artifact_downloader/src/fetch_stripped_artifact/assembler.rs
@@ -51,7 +51,7 @@ impl<Pool: ValidatedPoolReader<ConsensusMessage>> ValidatedPoolReader<MaybeStrip
             .map(Strippable::strip)
     }
 
-    fn get_all_validated(&self) -> Box<dyn Iterator<Item = MaybeStrippedConsensusMessage> + '_> {
+    fn get_retransmissions(&self) -> Box<dyn Iterator<Item = MaybeStrippedConsensusMessage> + '_> {
         // This method will never be called, so it's okay to return an empty iterator.
         Box::new(std::iter::empty())
     }

--- a/rs/p2p/artifact_downloader/src/fetch_stripped_artifact/assembler.rs
+++ b/rs/p2p/artifact_downloader/src/fetch_stripped_artifact/assembler.rs
@@ -50,11 +50,6 @@ impl<Pool: ValidatedPoolReader<ConsensusMessage>> ValidatedPoolReader<MaybeStrip
             .get(id.as_ref())
             .map(Strippable::strip)
     }
-
-    fn get_retransmissions(&self) -> Box<dyn Iterator<Item = MaybeStrippedConsensusMessage> + '_> {
-        // This method will never be called, so it's okay to return an empty iterator.
-        Box::new(std::iter::empty())
-    }
 }
 
 impl<Pool: ValidatedPoolReader<ConsensusMessage>>

--- a/rs/p2p/artifact_manager/src/lib.rs
+++ b/rs/p2p/artifact_manager/src/lib.rs
@@ -3,7 +3,7 @@ use ic_interfaces::{
         artifact_manager::JoinGuard,
         consensus::{
             ArtifactMutation, ArtifactWithOpt, ChangeResult, ChangeSetProducer, MutablePool,
-            UnvalidatedArtifact, ValidatedPoolReader,
+            Retransmittable, UnvalidatedArtifact, ValidatedPoolReader,
         },
     },
     time_source::TimeSource,
@@ -272,7 +272,12 @@ pub fn create_ingress_handlers<
 /// Starts the event loop that pools consensus for updates on what needs to be replicated.
 pub fn create_artifact_handler<
     Artifact: IdentifiableArtifact + Send + Sync + 'static,
-    Pool: MutablePool<Artifact> + Send + Sync + ValidatedPoolReader<Artifact> + 'static,
+    Pool: MutablePool<Artifact>
+        + Send
+        + Sync
+        + ValidatedPoolReader<Artifact>
+        + Retransmittable<Artifact>
+        + 'static,
     C: ChangeSetProducer<Pool, ChangeSet = <Pool as MutablePool<Artifact>>::ChangeSet> + 'static,
 >(
     send_advert: Sender<ArtifactMutation<Artifact>>,

--- a/rs/p2p/artifact_manager/src/lib.rs
+++ b/rs/p2p/artifact_manager/src/lib.rs
@@ -284,7 +284,7 @@ pub fn create_artifact_handler<
     UnboundedSender<UnvalidatedArtifactMutation<Artifact>>,
     Box<dyn JoinGuard>,
 ) {
-    let inital_artifacts: Vec<_> = pool.read().unwrap().get_all_validated().collect();
+    let inital_artifacts: Vec<_> = pool.read().unwrap().get_retransmissions().collect();
     let client = Processor::new(pool, change_set_producer);
     let (jh, sender) = run_artifact_processor(
         time_source.clone(),

--- a/rs/p2p/test_utils/src/consensus.rs
+++ b/rs/p2p/test_utils/src/consensus.rs
@@ -274,7 +274,7 @@ impl ValidatedPoolReader<U64Artifact> for TestConsensus<U64Artifact> {
     fn get(&self, id: &<U64Artifact as IdentifiableArtifact>::Id) -> Option<U64Artifact> {
         self.my_pool().get(id).map(|id| self.id_to_msg(*id).into())
     }
-    fn get_all_validated(&self) -> Box<dyn Iterator<Item = U64Artifact> + '_> {
+    fn get_retransmissions(&self) -> Box<dyn Iterator<Item = U64Artifact> + '_> {
         Box::new(
             self.my_pool()
                 .into_iter()

--- a/rs/p2p/test_utils/src/consensus.rs
+++ b/rs/p2p/test_utils/src/consensus.rs
@@ -7,7 +7,7 @@ use std::{
 
 use ic_interfaces::p2p::consensus::{
     ArtifactMutation, ArtifactWithOpt, BouncerFactory, BouncerValue, ChangeResult,
-    ChangeSetProducer, MutablePool, UnvalidatedArtifact, ValidatedPoolReader,
+    ChangeSetProducer, MutablePool, Retransmittable, UnvalidatedArtifact, ValidatedPoolReader,
 };
 use ic_logger::ReplicaLogger;
 use ic_types::artifact::{IdentifiableArtifact, PbArtifact};
@@ -274,6 +274,9 @@ impl ValidatedPoolReader<U64Artifact> for TestConsensus<U64Artifact> {
     fn get(&self, id: &<U64Artifact as IdentifiableArtifact>::Id) -> Option<U64Artifact> {
         self.my_pool().get(id).map(|id| self.id_to_msg(*id).into())
     }
+}
+
+impl Retransmittable<U64Artifact> for TestConsensus<U64Artifact> {
     fn get_retransmissions(&self) -> Box<dyn Iterator<Item = U64Artifact> + '_> {
         Box::new(
             self.my_pool()

--- a/rs/p2p/test_utils/src/mocks.rs
+++ b/rs/p2p/test_utils/src/mocks.rs
@@ -60,7 +60,7 @@ mock! {
 
     impl<A: IdentifiableArtifact> ValidatedPoolReader<A> for ValidatedPoolReader<A> {
         fn get(&self, id: &A::Id) -> Option<A>;
-        fn get_all_validated(
+        fn get_retransmissions(
             &self,
         ) -> Box<dyn Iterator<Item = A>>;
     }

--- a/rs/p2p/test_utils/src/mocks.rs
+++ b/rs/p2p/test_utils/src/mocks.rs
@@ -2,7 +2,10 @@ use async_trait::async_trait;
 use axum::http::{Request, Response};
 use bytes::Bytes;
 use ic_interfaces::p2p::{
-    consensus::{Aborted, ArtifactAssembler, Bouncer, BouncerFactory, Peers, ValidatedPoolReader},
+    consensus::{
+        Aborted, ArtifactAssembler, Bouncer, BouncerFactory, Peers, Retransmittable,
+        ValidatedPoolReader,
+    },
     state_sync::{AddChunkError, Chunk, ChunkId, Chunkable, StateSyncArtifactId, StateSyncClient},
 };
 use ic_quic_transport::{ConnId, Transport};
@@ -60,6 +63,9 @@ mock! {
 
     impl<A: IdentifiableArtifact> ValidatedPoolReader<A> for ValidatedPoolReader<A> {
         fn get(&self, id: &A::Id) -> Option<A>;
+    }
+
+    impl<A: IdentifiableArtifact> Retransmittable<A> for ValidatedPoolReader<A> {
         fn get_retransmissions(
             &self,
         ) -> Box<dyn Iterator<Item = A>>;


### PR DESCRIPTION
I found it quite confusing that `get_all_validated` for several pools returns `std::iter::empty()` (for example [Ingress Pool](https://sourcegraph.com/github.com/dfinity/ic/-/blob/rs/artifact_pool/src/ingress_pool.rs?L342-345)) until I learned how the method is used:

`get_all_validated` [is only called during initialization of replicas](https://sourcegraph.com/github.com/dfinity/ic/-/blob/rs/p2p/artifact_manager/src/lib.rs?L287) in order to advertize/push artifacts which could already exist in some of the persisted pools.

I think a different name for the method would help with avoiding the confusion