### PR TITLE
fix(cketh): Retry HTTPs outcalls

### DIFF
--- a/rs/ethereum/cketh/minter/src/eth_rpc.rs
+++ b/rs/ethereum/cketh/minter/src/eth_rpc.rs
@@ -613,7 +613,8 @@ impl HttpOutcallError {
 }
 
 pub fn is_response_too_large(code: &RejectionCode, message: &str) -> bool {
-    code == &RejectionCode::SysFatal && message.contains("size limit")
+    code == &RejectionCode::SysFatal
+        && (message.contains("size limit") || message.contains("length limit"))
 }
 
 pub type HttpOutcallResult<T> = Result<T, HttpOutcallError>;

--- a/rs/ethereum/cketh/minter/src/state.rs
+++ b/rs/ethereum/cketh/minter/src/state.rs
@@ -515,7 +515,11 @@ impl State {
             self.ledger_suite_orchestrator_id = Some(orchestrator_id);
         }
         if let Some(evm_id) = evm_rpc_id {
-            self.evm_rpc_id = Some(evm_id);
+            if evm_id == Principal::management_canister() {
+                self.evm_rpc_id = None;
+            } else {
+                self.evm_rpc_id = Some(evm_id);
+            }
         }
         self.validate_config()
     }


### PR DESCRIPTION
([XC-190](https://dfinity.atlassian.net/browse/XC-190)): The error message in case the response size estimate of an HTTP outcall changed with release `35bfcad` (proposal [132222](https://dashboard.internetcomputer.org/proposal/132222)). This is used as an indicator in case the minter needs to retry an HTTPs outcalls but with a bigger estimate. Due to this change, this indicator was no longer working, which is fixed by this PR.

[XC-190]: https://dfinity.atlassian.net/browse/XC-190?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ