### PR TITLE
chore(ic-backup): Increase timeout for downloading binaries from 15s to 60s

### DIFF
--- a/rs/recovery/src/file_sync_helper.rs
+++ b/rs/recovery/src/file_sync_helper.rs
@@ -14,6 +14,7 @@ use std::{
     path::{Path, PathBuf},
     process::Command,
     thread,
+    time::Duration,
 };
 
 /// Given the name and replica version of a binary, download the artifact to the
@@ -32,8 +33,14 @@ pub async fn download_binary(
 
     let mut file = target_dir.join(format!("{}.gz", binary_name));
 
-    info!(logger, "Downloading {} to {:?}...", binary_name, file);
-    let file_downloader = FileDownloader::new(None);
+    info!(
+        logger,
+        "Downloading {} to {}...",
+        binary_name,
+        file.display()
+    );
+    let file_downloader =
+        FileDownloader::new_with_timeout(Some(logger.clone().into()), Duration::from_secs(60));
     file_downloader
         .download_file(&binary_url, &file, None)
         .await

--- a/rs/tests/consensus/BUILD.bazel
+++ b/rs/tests/consensus/BUILD.bazel
@@ -22,7 +22,6 @@ system_test_nns(
     deps = [
         # Keep sorted.
         "//rs/backup",
-        "//rs/recovery",
         "//rs/registry/subnet_type",
         "//rs/tests/consensus/tecdsa/utils",
         "//rs/tests/consensus/utils",

--- a/rs/tests/consensus/backup_manager_test.rs
+++ b/rs/tests/consensus/backup_manager_test.rs
@@ -44,7 +44,6 @@ use ic_consensus_threshold_sig_system_test_utils::run_chain_key_signature_test;
 use ic_management_canister_types::{
     EcdsaCurve, EcdsaKeyId, MasterPublicKeyId, SchnorrAlgorithm, SchnorrKeyId,
 };
-use ic_recovery::file_sync_helper::{download_binary, write_file};
 use ic_registry_subnet_type::SubnetType;
 use ic_system_test_driver::{
     driver::{
@@ -58,7 +57,6 @@ use ic_system_test_driver::{
 };
 use ic_types::{Height, ReplicaVersion};
 use slog::{debug, error, info, Logger};
-use std::time::Duration;
 use std::{
     ffi::OsStr,
     fs::{self, OpenOptions},
@@ -67,6 +65,7 @@ use std::{
     path::{Path, PathBuf},
     process::{Command, Stdio},
 };
+use std::{fs::File, time::Duration};
 
 const DKG_INTERVAL: u64 = 9;
 const SUBNET_SIZE: usize = 4;
@@ -135,17 +134,6 @@ pub fn test(env: TestEnv) {
     copy_file(&binaries_path, &backup_binaries_dir, "sandbox_launcher");
     copy_file(&binaries_path, &backup_binaries_dir, "canister_sandbox");
     copy_file(&binaries_path, &backup_binaries_dir, "compiler_sandbox");
-
-    info!(
-        log,
-        "Download the binaries needed for replay of the mainnet version"
-    );
-    let mainnet_version = read_dependency_to_string("testnet/mainnet_nns_revision.txt")
-        .expect("could not read mainnet version!");
-
-    // Download all the binaries needed for the replay of the mainnet version
-    // This can be moved to the bazel script and completely avoid downloading them
-    download_mainnet_binaries(&log, &backup_dir, &mainnet_version);
 
     // Generate keypair and store the private key
     info!(log, "Create backup user credentials");
@@ -237,7 +225,8 @@ pub fn test(env: TestEnv) {
         serde_json::to_string(&config).expect("Config structure can't be converted to json");
     info!(log, "Config: {}", config_str);
     let config_file = config_dir.join("config.json5");
-    write_file(&config_file, config_str).expect("writing config file failed");
+    let mut f = File::create(&config_file).expect("Should be able to create the config file");
+    write!(f, "{}", config_str).expect("Should be able to write the config file");
 
     info!(log, "Start the backup process in a separate thread");
     let ic_backup_path = binaries_path.join("ic-backup");
@@ -254,6 +243,8 @@ pub fn test(env: TestEnv) {
         .expect("Failed to start backup process");
     info!(log, "Started process: {}", child.id());
 
+    let mainnet_version = read_dependency_to_string("testnet/mainnet_nns_revision.txt")
+        .expect("could not read mainnet version!");
     info!(log, "Elect the mainnet replica version");
     info!(log, "TARGET_VERSION: {}", mainnet_version);
     block_on(bless_public_replica_version(
@@ -494,32 +485,6 @@ fn highest_dir_entry(dir: &PathBuf, radix: u32) -> u64 {
             .fold(0u64, |a: u64, b: u64| -> u64 { a.max(b) }),
         Err(_) => 0,
     }
-}
-
-fn download_mainnet_binaries(log: &Logger, backup_dir: &Path, mainnet_version: &str) {
-    let binaries_dir = backup_dir.join("binaries").join(mainnet_version);
-    let replica_version =
-        ReplicaVersion::try_from(mainnet_version).expect("Replica version should be valid");
-    fs::create_dir_all(&binaries_dir).expect("failure creating backup binaries directory");
-    download_binary_file(log, &replica_version, &binaries_dir, "ic-replay");
-    download_binary_file(log, &replica_version, &binaries_dir, "sandbox_launcher");
-    download_binary_file(log, &replica_version, &binaries_dir, "canister_sandbox");
-}
-
-fn download_binary_file(
-    log: &Logger,
-    replica_version: &ReplicaVersion,
-    binaries_dir: &Path,
-    binary: &str,
-) {
-    info!(log, "Downloading binary: {binary}");
-    block_on(download_binary(
-        log,
-        replica_version.clone(),
-        binary.to_string(),
-        binaries_dir,
-    ))
-    .expect("error downloading binaty");
 }
 
 fn make_key_ids_for_all_schemes() -> Vec<MasterPublicKeyId> {


### PR DESCRIPTION
The following changes have been made:

1. Increased the timeout for downloading binaries from 15s to 60s. Some binaries are quite large and under bad networking conditions 15s might not be enough. This should help with some test flakiness we've observed lately.
2. Removed the logic of downloading mainnet binaries from the `backup_manager_test` system test. The backup script [has its own logic](https://sourcegraph.com/github.com/dfinity/ic/-/blob/rs/backup/src/backup_helper.rs?L162-174) of downloading binaries when they are missing (together with some retry logic), so doing it explicitly in the system test is unnecessary and it's actually important to test that this functionality of the backup script works.
3. We are now passing `Logger` to `FileDownloader` utility, so we get some additional logs which might be useful for debugging.
4. Inlined the `write_file` function in `backup_manager_test` which allowed us to drop the `ic-recovery` dependency from the test.

# Tests
Ran the `backup_manager_test` and inspected the logs to confirm that the binaries have been downloaded
```
(...)
2024-09-09 09:41:40.502 INFO[test:StdErr] Sep 09 09:41:40.502 DEBG [#0] Start downloading binaries., subnet: vnckz
2024-09-09 09:41:40.503 INFO[test:StdErr] Sep 09 09:41:40.503 INFO Downloading ic-replay to /tmp/.tmpfKhyVV/backup/binaries/b0ade55f7e8999e2842fe3f49df163ba224b71a2/ic-replay.gz..., subnet: vnckz
2024-09-09 09:41:40.503 INFO[test:StdErr] Sep 09 09:41:40.503 INFO s:/n:/ic_http_utils/file_downloader Downloading file from: https://download.dfinity.systems/ic/b0ade55f7e8999e2842fe3f49df163ba224b71a2/release/ic-replay.gz, subnet: vnckz
2024-09-09 09:41:40.535 INFO[test:StdErr] Sep 09 09:41:40.535 INFO s:/n:/ic_http_utils/file_downloader Download request initiated to !!REDACTED!!, headers:  !!REDACTED!!, subnet: vnckz
2024-09-09 09:41:40.578 INFO[test:StdErr] Sep 09 09:41:40.578 INFO s:/n:/ic_http_utils/file_downloader Response read, subnet: vnckz
2024-09-09 09:41:40.578 INFO[test:StdErr] Sep 09 09:41:40.578 INFO Unzipping file..., subnet: vnckz
2024-09-09 09:41:40.909 INFO[test:StdErr] Sep 09 09:41:40.909 INFO Adding permissions..., subnet: vnckz
(...)
```