### PR TITLE
fix(PocketIC): support IP addresses in frontend URLs to PocketIC HTTP gateway

### DIFF
--- a/rs/pocket_ic_server/src/state_api/state.rs
+++ b/rs/pocket_ic_server/src/state_api/state.rs
@@ -509,17 +509,10 @@ async fn handler(
     request: AxumRequest,
 ) -> Result<Response, ErrorCause> {
     // Resolve the domain
-    let lookup = if let Some(authority) = extract_authority(&request) {
-        state.resolver.resolve(&authority)
-    } else {
-        None
-    };
+    let lookup =
+        extract_authority(&request).and_then(|authority| state.resolver.resolve(&authority));
 
-    let canister_id = if let Some(ref lookup) = lookup {
-        lookup.canister_id
-    } else {
-        None
-    };
+    let canister_id = lookup.as_ref().and_then(|lookup| lookup.canister_id);
     let host_canister_id = host_canister_id.map(|v| v.0);
     let query_param_canister_id = query_param_canister_id.map(|v| v.0);
     let referer_host_canister_id = referer_host_canister_id.map(|v| v.0);

--- a/rs/pocket_ic_server/tests/test.rs
+++ b/rs/pocket_ic_server/tests/test.rs
@@ -345,6 +345,19 @@ async fn test_gateway(server_url: Url, https: bool) {
         .await
         .unwrap();
 
+    // perform frontend asset request for the title page at http://127.0.0.1:<port>/?canisterId=<canister-id>
+    if !https {
+        assert_eq!(proto, "http");
+        let canister_url = format!(
+            "{}://{}:{}/?canisterId={}",
+            "http", "127.0.0.1", port, canister_id
+        );
+        let res = client.get(canister_url).send().await.unwrap();
+        let page = String::from_utf8(res.bytes().await.unwrap().to_vec()).unwrap();
+        println!("page: {}", page);
+        assert!(page.contains("<title>Internet Identity</title>"));
+    }
+
     // perform frontend asset request for the title page at http(s)://localhost:<port>/?canisterId=<canister-id>
     let canister_url = format!(
         "{}://{}:{}/?canisterId={}",


### PR DESCRIPTION
This PR supports IP addresses in frontend URLs to PocketIC HTTP gateway. They are being used in dfx by default and thus this PR makes sure that PocketIC is backward-compatible for dfx users.