### PR TITLE
chore(nns): Increase random error for protobuf methods to 30%

### DIFF
--- a/rs/nns/governance/canister/canister.rs
+++ b/rs/nns/governance/canister/canister.rs
@@ -863,7 +863,7 @@ fn canister_heartbeat() {
 fn manage_neuron_pb() {
     debug_log("manage_neuron_pb");
     panic_with_probability(
-        0.1,
+        0.3,
         "manage_neuron_pb is deprecated. Please use manage_neuron instead.",
     );
     over_async(protobuf, manage_neuron_)
@@ -885,7 +885,7 @@ fn list_proposals_pb() {
 fn list_neurons_pb() {
     debug_log("list_neurons_pb");
     panic_with_probability(
-        0.1,
+        0.3,
         "list_neurons_pb is deprecated. Please use list_neurons instead.",
     );
     over(protobuf, list_neurons_)


### PR DESCRIPTION
We'd like to deprecate protobuf methods in the NNS Governance by ramping up the random failure gradually. Increase the failure rate from 10% to 30%.