### PR TITLE
feat: Reduce slice limit for install_code messages in system subnets

### DIFF
--- a/rs/config/src/subnet_config.rs
+++ b/rs/config/src/subnet_config.rs
@@ -303,7 +303,7 @@ impl SchedulerConfig {
         let max_instructions_per_message_without_dts = NumInstructions::from(50 * B);
         let max_instructions_per_install_code = NumInstructions::from(1_000 * B);
         let max_instructions_per_slice = NumInstructions::from(2 * B);
-        let max_instructions_per_install_code_slice = NumInstructions::from(10 * B);
+        let max_instructions_per_install_code_slice = NumInstructions::from(5 * B);
         Self {
             scheduler_cores: NUMBER_OF_EXECUTION_THREADS,
             max_paused_executions: MAX_PAUSED_EXECUTIONS,


### PR DESCRIPTION
Reducing the slice limit for `install_code` messages is now possible after the [update ](https://dashboard.internetcomputer.org/proposal/131699)to the DKG interval on the NNS subnet. Given the 1T limit for `install_code` messages on system subnets, a slice limit of 5B would mean at most 200 slices in the worst case, which is acceptable given the current DKG interval of 500 rounds.

This change brings even closer the configuration for normal messages (using a 2B slice limit) and `install_code` messages.