### PR TITLE
fix(ICRC-1 Ledger): add effective subaccount to ICRC-21

### DIFF
--- a/packages/icrc-ledger-types/src/icrc21/lib.rs
+++ b/packages/icrc-ledger-types/src/icrc21/lib.rs
@@ -135,7 +135,7 @@ impl ConsentMessageBuilder {
 
     pub fn build(self) -> Result<ConsentMessage, Icrc21Error> {
         let mut message = "".to_string();
-        let extract_subaccount =|account:Account| -> Result<String,Icrc21Error>{
+        let extract_subaccount = |account: Account| -> Result<String, Icrc21Error> {
             Ok(match account.subaccount {
                 None => hex::encode(account.effective_subaccount().as_slice()),
                 Some(_) => account
@@ -144,8 +144,7 @@ impl ConsentMessageBuilder {
                     .last()
                     .ok_or(Icrc21Error::GenericError {
                         error_code: Nat::from(500u64),
-                        description: "Subaccount has an unexpected format."
-                            .to_owned(),
+                        description: "Subaccount has an unexpected format.".to_owned(),
                     })?
                     .to_string(),
             })

--- a/packages/icrc-ledger-types/src/icrc21/lib.rs
+++ b/packages/icrc-ledger-types/src/icrc21/lib.rs
@@ -169,13 +169,19 @@ impl ConsentMessageBuilder {
                 if from_account.owner == Principal::anonymous() {
                     message.push_str(&format!(
                         "\n\n**From Subaccount:**\n{}",
-                        from_account.to_string().split('.').last().ok_or(
-                            Icrc21Error::GenericError {
-                                error_code: Nat::from(500u64),
-                                description: "Sender Subaccount has an unexpected format."
-                                    .to_owned(),
-                            }
-                        )?
+                        match from_account.subaccount {
+                            None => hex::encode(from_account.effective_subaccount().as_slice()),
+                            Some(_) => from_account
+                                .to_string()
+                                .split('.')
+                                .last()
+                                .ok_or(Icrc21Error::GenericError {
+                                    error_code: Nat::from(500u64),
+                                    description: "Sender Subaccount has an unexpected format."
+                                        .to_owned(),
+                                })?
+                                .to_string(),
+                        }
                     ));
                 } else {
                     message.push_str(&format!("\n\n**From:**\n{}", from_account));
@@ -250,13 +256,19 @@ impl ConsentMessageBuilder {
                 if approver_account.owner == Principal::anonymous() {
                     message.push_str(&format!(
                         "\n\n**Your Subaccount:**\n{}",
-                        approver_account.to_string().split('.').last().ok_or(
-                            Icrc21Error::GenericError {
-                                error_code: Nat::from(500u64),
-                                description: "Approver Subaccount has an unexpected format."
-                                    .to_owned(),
-                            }
-                        )?
+                        match approver_account.subaccount {
+                            None => hex::encode(approver_account.effective_subaccount().as_slice()),
+                            Some(_) => approver_account
+                                .to_string()
+                                .split('.')
+                                .last()
+                                .ok_or(Icrc21Error::GenericError {
+                                    error_code: Nat::from(500u64),
+                                    description: "Approver Subaccount has an unexpected format."
+                                        .to_owned(),
+                                })?
+                                .to_string(),
+                        }
                     ));
                 } else {
                     message.push_str(&format!("\n\n**Your account:**\n{}", approver_account));
@@ -273,13 +285,19 @@ impl ConsentMessageBuilder {
                 if approver_account.owner == Principal::anonymous() {
                     message.push_str(&format!(
                         "\n\n**Transaction fees to be paid by your subaccount:**\n{}",
-                        approver_account.to_string().split('.').last().ok_or(
-                            Icrc21Error::GenericError {
-                                error_code: Nat::from(500u64),
-                                description: "Approver Subaccount has an unexpected format."
-                                    .to_owned(),
-                            }
-                        )?
+                        match approver_account.subaccount {
+                            None => hex::encode(approver_account.effective_subaccount().as_slice()),
+                            Some(_) => approver_account
+                                .to_string()
+                                .split('.')
+                                .last()
+                                .ok_or(Icrc21Error::GenericError {
+                                    error_code: Nat::from(500u64),
+                                    description: "Approver Subaccount has an unexpected format."
+                                        .to_owned(),
+                                })?
+                                .to_string(),
+                        }
                     ));
                 } else {
                     message.push_str(&format!(
@@ -326,13 +344,19 @@ impl ConsentMessageBuilder {
                 if spender_account.owner == Principal::anonymous() {
                     message.push_str(&format!(
                         "\n\n**Subaccount sending the transfer request:**\n{}",
-                        spender_account.to_string().split('.').last().ok_or(
-                            Icrc21Error::GenericError {
-                                error_code: Nat::from(500u64),
-                                description: "Spender Subaccount has an unexpected format."
-                                    .to_owned(),
-                            }
-                        )?
+                        match spender_account.subaccount {
+                            None => hex::encode(spender_account.effective_subaccount().as_slice()),
+                            Some(_) => spender_account
+                                .to_string()
+                                .split('.')
+                                .last()
+                                .ok_or(Icrc21Error::GenericError {
+                                    error_code: Nat::from(500u64),
+                                    description: "Spender Subaccount has an unexpected format."
+                                        .to_owned(),
+                                })?
+                                .to_string(),
+                        }
                     ));
                 } else {
                     message.push_str(&format!(

--- a/rs/rosetta-api/icrc1/ledger/sm-tests/src/lib.rs
+++ b/rs/rosetta-api/icrc1/ledger/sm-tests/src/lib.rs
@@ -3815,6 +3815,25 @@ test_bytes";
         "Expected: {}, got: {}",
         expected_message, message
     );
+
+    args.arg = Encode!(&TransferArg {
+        from_subaccount: None,
+        ..transfer_args.clone()
+    })
+    .unwrap();
+
+    let message = extract_icrc21_message_string(
+        &icrc21_consent_message(env, canister_id, Principal::anonymous(), args.clone())
+            .unwrap()
+            .consent_message,
+    );
+
+    let expected_message = expected_transfer_message.replace("\n\n**From:**\nd2zjj-uyaaa-aaaaa-aaaap-4ai-qmfzyha.101010101010101010101010101010101010101010101010101010101010101","\n\n**From Subaccount:**\n0000000000000000000000000000000000000000000000000000000000000000" );
+    assert_eq!(
+        message, expected_message,
+        "Expected: {}, got: {}",
+        expected_message, message
+    );
 }
 
 fn test_icrc21_approve_message(
@@ -3980,6 +3999,27 @@ test_bytes";
         "Expected: {}, got: {}",
         expected_message, message
     );
+
+    args.arg = Encode!(&ApproveArgs {
+        from_subaccount: None,
+        ..approve_args.clone()
+    })
+    .unwrap();
+    args.user_preferences.metadata.utc_offset_minutes = None;
+
+    let message = extract_icrc21_message_string(
+        &icrc21_consent_message(env, canister_id, Principal::anonymous(), args.clone())
+            .unwrap()
+            .consent_message,
+    );
+
+    let expected_message = expected_approve_message.replace("\n\n**Your account:**\nd2zjj-uyaaa-aaaaa-aaaap-4ai-qmfzyha.101010101010101010101010101010101010101010101010101010101010101","\n\n**Your Subaccount:**\n0000000000000000000000000000000000000000000000000000000000000000" )
+    .replace("\n\n**Transaction fees to be paid by:**\nd2zjj-uyaaa-aaaaa-aaaap-4ai-qmfzyha.101010101010101010101010101010101010101010101010101010101010101","\n\n**Transaction fees to be paid by your subaccount:**\n0000000000000000000000000000000000000000000000000000000000000000" );
+    assert_eq!(
+        message, expected_message,
+        "Expected: {}, got: {}",
+        expected_message, message
+    );
 }
 
 fn test_icrc21_transfer_from_message(
@@ -4054,6 +4094,27 @@ test_bytes";
     "\n\n**Account sending the transfer request:**\ndjduj-3qcaa-aaaaa-aaaap-4ai-5r7aoqy.303030303030303030303030303030303030303030303030303030303030303",
     "\n\n**Subaccount sending the transfer request:**\n303030303030303030303030303030303030303030303030303030303030303",
 );
+    assert_eq!(
+        message, expected_message,
+        "Expected: {}, got: {}",
+        expected_message, message
+    );
+
+    args.arg = Encode!(&TransferFromArgs {
+        spender_subaccount: None,
+        ..transfer_from_args.clone()
+    })
+    .unwrap();
+
+    let message = extract_icrc21_message_string(
+        &icrc21_consent_message(env, canister_id, Principal::anonymous(), args.clone())
+            .unwrap()
+            .consent_message,
+    );
+
+    let expected_message = expected_transfer_from_message.replace(
+        "\n\n**Account sending the transfer request:**\ndjduj-3qcaa-aaaaa-aaaap-4ai-5r7aoqy.303030303030303030303030303030303030303030303030303030303030303",
+        "\n\n**Subaccount sending the transfer request:**\n0000000000000000000000000000000000000000000000000000000000000000" );
     assert_eq!(
         message, expected_message,
         "Expected: {}, got: {}",

--- a/rs/rosetta-api/icrc1/ledger/sm-tests/src/lib.rs
+++ b/rs/rosetta-api/icrc1/ledger/sm-tests/src/lib.rs
@@ -3809,7 +3809,7 @@ test_bytes";
             .unwrap()
             .consent_message,
     );
-    let expected_message = expected_transfer_message.replace("\n\n**From:**\nd2zjj-uyaaa-aaaaa-aaaap-4ai-qmfzyha.101010101010101010101010101010101010101010101010101010101010101","\n\n**From Subaccount:**\n101010101010101010101010101010101010101010101010101010101010101" );
+    let expected_message = expected_transfer_message.replace("\n\n**From:**\nd2zjj-uyaaa-aaaaa-aaaap-4ai-qmfzyha.101010101010101010101010101010101010101010101010101010101010101","\n\n**From subaccount:**\n101010101010101010101010101010101010101010101010101010101010101" );
     assert_eq!(
         message, expected_message,
         "Expected: {}, got: {}",
@@ -3828,7 +3828,7 @@ test_bytes";
             .consent_message,
     );
 
-    let expected_message = expected_transfer_message.replace("\n\n**From:**\nd2zjj-uyaaa-aaaaa-aaaap-4ai-qmfzyha.101010101010101010101010101010101010101010101010101010101010101","\n\n**From Subaccount:**\n0000000000000000000000000000000000000000000000000000000000000000" );
+    let expected_message = expected_transfer_message.replace("\n\n**From:**\nd2zjj-uyaaa-aaaaa-aaaap-4ai-qmfzyha.101010101010101010101010101010101010101010101010101010101010101","\n\n**From subaccount:**\n0000000000000000000000000000000000000000000000000000000000000000" );
     assert_eq!(
         message, expected_message,
         "Expected: {}, got: {}",
@@ -3976,7 +3976,7 @@ test_bytes";
     );
     let expected_message = expected_approve_message
 .replace("\n\n**Transaction fees to be paid by:**\nd2zjj-uyaaa-aaaaa-aaaap-4ai-qmfzyha.101010101010101010101010101010101010101010101010101010101010101","\n\n**Transaction fees to be paid by your subaccount:**\n101010101010101010101010101010101010101010101010101010101010101" )
-.replace("\n\n**Your account:**\nd2zjj-uyaaa-aaaaa-aaaap-4ai-qmfzyha.101010101010101010101010101010101010101010101010101010101010101","\n\n**Your Subaccount:**\n101010101010101010101010101010101010101010101010101010101010101");
+.replace("\n\n**Your account:**\nd2zjj-uyaaa-aaaaa-aaaap-4ai-qmfzyha.101010101010101010101010101010101010101010101010101010101010101","\n\n**Your subaccount:**\n101010101010101010101010101010101010101010101010101010101010101");
     assert_eq!(
         message, expected_message,
         "Expected: {}, got: {}",
@@ -4013,7 +4013,7 @@ test_bytes";
             .consent_message,
     );
 
-    let expected_message = expected_approve_message.replace("\n\n**Your account:**\nd2zjj-uyaaa-aaaaa-aaaap-4ai-qmfzyha.101010101010101010101010101010101010101010101010101010101010101","\n\n**Your Subaccount:**\n0000000000000000000000000000000000000000000000000000000000000000" )
+    let expected_message = expected_approve_message.replace("\n\n**Your account:**\nd2zjj-uyaaa-aaaaa-aaaap-4ai-qmfzyha.101010101010101010101010101010101010101010101010101010101010101","\n\n**Your subaccount:**\n0000000000000000000000000000000000000000000000000000000000000000" )
     .replace("\n\n**Transaction fees to be paid by:**\nd2zjj-uyaaa-aaaaa-aaaap-4ai-qmfzyha.101010101010101010101010101010101010101010101010101010101010101","\n\n**Transaction fees to be paid by your subaccount:**\n0000000000000000000000000000000000000000000000000000000000000000" );
     assert_eq!(
         message, expected_message,
@@ -4054,7 +4054,7 @@ fn test_icrc21_transfer_from_message(
 
     let expected_transfer_from_message = "# Transfer from a withdrawal account
 
-**Withdrawal Account:**
+**Withdrawal account:**
 d2zjj-uyaaa-aaaaa-aaaap-4ai-qmfzyha.101010101010101010101010101010101010101010101010101010101010101
 
 **Account sending the transfer request:**


### PR DESCRIPTION
This MR proposes the following changes: 

1. If no subaccount is set, display the effective subaccount when the anonymous principal is making the icrc21 call. 