### PR TITLE
candid(evm-rpc)!: remove `RpcService::Chain` variant

### DIFF
--- a/rs/ethereum/cketh/minter/src/eth_rpc_client/providers.rs
+++ b/rs/ethereum/cketh/minter/src/eth_rpc_client/providers.rs
@@ -50,7 +50,6 @@ pub struct RpcApi {
 
 #[derive(Clone, PartialEq, Eq, Ord, PartialOrd, Hash, Serialize, Deserialize, CandidType)]
 pub enum RpcService {
-    Chain(u64),
     Provider(u64),
     Custom(RpcApi),
     EthMainnet(EthMainnetService),
@@ -63,7 +62,6 @@ pub enum RpcService {
 impl std::fmt::Debug for RpcService {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            RpcService::Chain(chain_id) => write!(f, "Chain({})", chain_id),
             RpcService::Provider(provider_id) => write!(f, "Provider({})", provider_id),
             RpcService::Custom(_) => write!(f, "Custom(..)"), // Redact credentials
             RpcService::EthMainnet(service) => write!(f, "{:?}", service),


### PR DESCRIPTION
This PR removes the `RpcService::Chain` variant (reflected in the EVM RPC Candid interface) due to ambiguity about which RPC provider is used to make the request.

Another option could be to always use a specific service such as [Public Node](https://www.publicnode.com/) for these RPC requests, although this would remain ambiguous and is only valid for some inputs compared to specifying, for instance, `#EthMainnet(#PublicNode)`. The current behavior is to use the RPC provider with the largest `provider_id` matching the provided `chain_id`.

Merges into the `evm-rpc-canister` branch.