### PR TITLE
feat(nervous_system): Deprecate motion_text

### DIFF
--- a/rs/nns/governance/benches/scale.rs
+++ b/rs/nns/governance/benches/scale.rs
@@ -121,9 +121,7 @@ fn make_and_process_proposal(gov: &mut Governance) {
         &Proposal {
             title: Some("Celebrate Good Times".to_string()),
             summary: "test".to_string(),
-            action: Some(proposal::Action::Motion(Motion {
-                motion_text: "dummy text".to_string(),
-            })),
+            action: Some(proposal::Action::Motion(Motion::default())),
             ..Default::default()
         },
     )

--- a/rs/nns/governance/proto/ic_nns_governance/pb/v1/governance.proto
+++ b/rs/nns/governance/proto/ic_nns_governance/pb/v1/governance.proto
@@ -695,8 +695,8 @@ message ExecuteNnsFunction {
 // If adopted, a motion should guide the future strategy of the
 // Internet Computer ecosystem.
 message Motion {
-  // The text of the motion. Maximum 100kib.
-  string motion_text = 1;
+  // Depreacted and must be set to `""`. Use `proposal_summary` instead.
+  string motion_text = 1 [deprecated = true];
 }
 
 // For all Neurons controlled by the given principals, set their

--- a/rs/nns/governance/src/gen/ic_nns_governance.pb.v1.rs
+++ b/rs/nns/governance/src/gen/ic_nns_governance.pb.v1.rs
@@ -396,7 +396,8 @@ pub struct ExecuteNnsFunction {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Motion {
-    /// The text of the motion. Maximum 100kib.
+    /// Depreacted and must be set to `""`. Use `proposal_summary` instead.
+    #[deprecated]
     #[prost(string, tag = "1")]
     pub motion_text: ::prost::alloc::string::String,
 }

--- a/rs/nns/governance/src/governance.rs
+++ b/rs/nns/governance/src/governance.rs
@@ -151,7 +151,6 @@ pub const WAIT_FOR_QUIET_DEADLINE_INCREASE_SECONDS: u64 = 2 * ONE_DAY_SECONDS;
 // proposals
 pub const EXECUTE_NNS_FUNCTION_PAYLOAD_LISTING_BYTES_MAX: usize = 1000;
 // 10 KB
-pub const PROPOSAL_MOTION_TEXT_BYTES_MAX: usize = 10000;
 
 // The maximum dissolve delay allowed for a neuron.
 pub const MAX_DISSOLVE_DELAY_SECONDS: u64 = 8 * ONE_YEAR_SECONDS;
@@ -8102,14 +8101,14 @@ pub fn validate_proposal_url(url: &str) -> Result<(), String> {
 }
 
 fn validate_motion(motion: &Motion) -> Result<(), GovernanceError> {
-    if motion.motion_text.len() > PROPOSAL_MOTION_TEXT_BYTES_MAX {
+    #[allow(deprecated)]
+    // Let's examine the deprecated `motion_text` field to make sure it is unused.
+    if !motion.motion_text.is_empty() {
         return Err(GovernanceError::new_with_message(
             ErrorType::InvalidProposal,
-            format!(
-                "The maximum motion text size in a proposal action is {} bytes, this motion text is: {} bytes",
-                PROPOSAL_MOTION_TEXT_BYTES_MAX,
-                motion.motion_text.len()
-            ),
+            "The motion text is deprecated and should no longer be used. \
+                Please put the contents of the motion in the proposal summary instead."
+                .to_string(),
         ));
     }
 

--- a/rs/nns/governance/src/governance/tests/mod.rs
+++ b/rs/nns/governance/src/governance/tests/mod.rs
@@ -854,9 +854,7 @@ mod metrics_tests {
         let proposal_1 = ProposalData {
             proposal: Some(Proposal {
                 title: Some("Foo Foo Bar".to_string()),
-                action: Some(proposal::Action::Motion(Motion {
-                    motion_text: "Text for this motion".to_string(),
-                })),
+                action: Some(proposal::Action::Motion(Motion::default())),
                 ..Proposal::default()
             }),
             latest_tally: Some(Tally {
@@ -912,9 +910,7 @@ mod metrics_tests {
     #[test]
     fn test_metrics_proposal_deadline_timestamp_seconds() {
         let manage_neuron_action = proposal::Action::ManageNeuron(Box::default());
-        let motion_action = proposal::Action::Motion(Motion {
-            motion_text: "Text for this motion".to_string(),
-        });
+        let motion_action = proposal::Action::Motion(Motion::default());
 
         let open_proposal = ProposalData {
             proposal: Some(Proposal {

--- a/rs/nns/governance/src/pb/conversions.rs
+++ b/rs/nns/governance/src/pb/conversions.rs
@@ -328,6 +328,7 @@ impl From<pb_api::ExecuteNnsFunction> for pb::ExecuteNnsFunction {
 
 impl From<pb::Motion> for pb_api::Motion {
     fn from(item: pb::Motion) -> Self {
+        #[allow(deprecated)]
         Self {
             motion_text: item.motion_text,
         }
@@ -335,6 +336,7 @@ impl From<pb::Motion> for pb_api::Motion {
 }
 impl From<pb_api::Motion> for pb::Motion {
     fn from(item: pb_api::Motion) -> Self {
+        #[allow(deprecated)]
         Self {
             motion_text: item.motion_text,
         }

--- a/rs/nns/governance/tests/degraded_mode.rs
+++ b/rs/nns/governance/tests/degraded_mode.rs
@@ -157,9 +157,7 @@ async fn test_cannot_submit_motion_in_degraded_mode() {
         &Proposal {
             title: Some("A Reasonable Title".to_string()),
             summary: "proposal 1".to_string(),
-            action: Some(proposal::Action::Motion(Motion {
-                motion_text: "Rabbits are cute".to_string(),
-            })),
+            action: Some(proposal::Action::Motion(Motion::default())),
             ..Default::default()
         },
     ),

--- a/rs/nns/governance/tests/fake.rs
+++ b/rs/nns/governance/tests/fake.rs
@@ -572,9 +572,7 @@ impl ProposalNeuronBehavior {
     pub fn propose_and_vote(&self, gov: &mut Governance, summary: String) -> ProposalId {
         // Submit proposal
         let action = match self.proposal_topic {
-            ProposalTopicBehavior::Governance => proposal::Action::Motion(Motion {
-                motion_text: format!("summary: {}", summary),
-            }),
+            ProposalTopicBehavior::Governance => proposal::Action::Motion(Motion::default()),
             ProposalTopicBehavior::NetworkEconomics => {
                 proposal::Action::ManageNetworkEconomics(NetworkEconomics {
                     ..Default::default()

--- a/rs/nns/governance/tests/fixtures/mod.rs
+++ b/rs/nns/governance/tests/fixtures/mod.rs
@@ -70,9 +70,7 @@ pub fn new_motion_proposal() -> Proposal {
     Proposal {
         title: Some("A Reasonable Title".to_string()),
         summary: "Summary".to_string(),
-        action: Some(proposal::Action::Motion(Motion {
-            motion_text: "Some proposal".to_string(),
-        })),
+        action: Some(proposal::Action::Motion(Motion::default())),
         ..Default::default()
     }
 }
@@ -581,9 +579,7 @@ impl ProposalNeuronBehavior {
     pub fn propose_and_vote(&self, nns: &mut NNS, summary: String) -> ProposalId {
         // Submit proposal
         let action = match self.proposal_topic {
-            ProposalTopicBehaviour::Governance => proposal::Action::Motion(Motion {
-                motion_text: format!("summary: {}", summary),
-            }),
+            ProposalTopicBehaviour::Governance => proposal::Action::Motion(Motion::default()),
             ProposalTopicBehaviour::NetworkEconomics => {
                 proposal::Action::ManageNetworkEconomics(NetworkEconomics {
                     ..Default::default()

--- a/rs/nns/integration_tests/test_canisters/governance_mem_test_canister.rs
+++ b/rs/nns/integration_tests/test_canisters/governance_mem_test_canister.rs
@@ -342,6 +342,7 @@ fn allocate_proposal_data(with_ballots: bool, topic: Topic) -> ProposalData {
         _ => 200,
     };
 
+    #[allow(deprecated)] // Required because motion_text is deprecated
     ProposalData {
         id: Some(ProposalIdProto { id: 0 }),
         proposer: Some(NeuronIdProto { id: 0 }),
@@ -355,6 +356,8 @@ fn allocate_proposal_data(with_ballots: bool, topic: Topic) -> ProposalData {
             url: ['a'; 2000].iter().collect(), // 2000-bytes upper limit copied from type definition
             action: Some(Action::Motion(Motion {
                 // We use "motion" for all topics for convenience. All that matters is the size.
+                // This is not a valid proposal, since the motion_text field is deprecated, but
+                // it is fine for our purposes.
                 motion_text: "a".repeat(payload_size),
             })),
         }),

--- a/rs/sns/governance/proto/ic_sns_governance/pb/v1/governance.proto
+++ b/rs/sns/governance/proto/ic_sns_governance/pb/v1/governance.proto
@@ -309,7 +309,7 @@ message ExecuteGenericNervousSystemFunction {
 // ecosystem but does not have immediate effect in the sense that a method is executed.
 message Motion {
   // The text of the motion, which can at most be 100kib.
-  string motion_text = 1;
+  string motion_text = 1 [deprecated = true];
 }
 
 // A proposal function that upgrades a canister that is controlled by the

--- a/rs/sns/governance/src/gen/ic_sns_governance.pb.v1.rs
+++ b/rs/sns/governance/src/gen/ic_sns_governance.pb.v1.rs
@@ -312,6 +312,7 @@ pub struct ExecuteGenericNervousSystemFunction {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Motion {
     /// The text of the motion, which can at most be 100kib.
+    #[deprecated]
     #[prost(string, tag = "1")]
     pub motion_text: ::prost::alloc::string::String,
 }

--- a/rs/sns/governance/src/governance.rs
+++ b/rs/sns/governance/src/governance.rs
@@ -5715,9 +5715,7 @@ mod tests {
             title: "This Proposal is Wunderbar!".to_string(),
             summary: "This will solve all of your problems.".to_string(),
             url: "https://www.example.com/some/path".to_string(),
-            action: Some(Action::Motion(Motion {
-                motion_text: "See the summary.".to_string(),
-            }))
+            action: Some(Action::Motion(Motion::default()))
         };
 
         static ref TEST_ROOT_CANISTER_ID: CanisterId = CanisterId::from(500);

--- a/rs/sns/governance/src/types.rs
+++ b/rs/sns/governance/src/types.rs
@@ -2431,14 +2431,6 @@ impl From<ManageDappCanisterSettings> for ManageDappCanisterSettingsRequest {
     }
 }
 
-impl Motion {
-    pub fn new(text: &str) -> Self {
-        Motion {
-            motion_text: text.to_string(),
-        }
-    }
-}
-
 impl From<Motion> for Action {
     fn from(motion: Motion) -> Action {
         Action::Motion(motion)
@@ -3902,9 +3894,7 @@ pub(crate) mod tests {
     fn test_limited_for_get_proposal() {
         let motion_proposal = ProposalData {
             proposal: Some(Proposal {
-                action: Some(Action::Motion(Motion {
-                    motion_text: "Hello, world!".to_string(),
-                })),
+                action: Some(Action::Motion(Motion::default())),
                 ..Default::default()
             }),
             ..Default::default()

--- a/rs/sns/governance/tests/governance.rs
+++ b/rs/sns/governance/tests/governance.rs
@@ -2075,7 +2075,7 @@ fn test_register_vote_fails_if_neuron_not_present_in_proposal() {
             current_deadline_timestamp_seconds: proposal_deadline,
         }),
         proposal: Some(Proposal {
-            action: Some(Action::Motion(Motion::new("Test"))),
+            action: Some(Action::Motion(Motion::default())),
             ..Proposal::default()
         }),
         // The `ballots` will be initialized to an empty map.
@@ -2113,7 +2113,7 @@ fn test_register_vote_fails_if_neuron_already_voted() {
             current_deadline_timestamp_seconds: proposal_deadline,
         }),
         proposal: Some(Proposal {
-            action: Some(Action::Motion(Motion::new("Test"))),
+            action: Some(Action::Motion(Motion::default())),
             ..Proposal::default()
         }),
         ballots: btreemap! {
@@ -2165,7 +2165,7 @@ fn test_register_vote_fails_if_past_deadline() {
             current_deadline_timestamp_seconds: proposal_deadline,
         }),
         proposal: Some(Proposal {
-            action: Some(Action::Motion(Motion::new("Test"))),
+            action: Some(Action::Motion(Motion::default())),
             ..Proposal::default()
         }),
         ballots: btreemap! {
@@ -2213,7 +2213,7 @@ fn test_register_vote_fails_if_past_deadline_no_wait_for_quiet() {
     let proposal = ProposalData {
         id: Some(proposal_id),
         proposal: Some(Proposal {
-            action: Some(Action::Motion(Motion::new("Test"))),
+            action: Some(Action::Motion(Motion::default())),
             ..Proposal::default()
         }),
         ballots: btreemap! {
@@ -2263,7 +2263,7 @@ fn test_register_vote_happy() {
             current_deadline_timestamp_seconds: proposal_deadline,
         }),
         proposal: Some(Proposal {
-            action: Some(Action::Motion(Motion::new("Test"))),
+            action: Some(Action::Motion(Motion::default())),
             ..Proposal::default()
         }),
         ballots: btreemap! {
@@ -2379,9 +2379,7 @@ fn test_neurons_can_follow_themselves() {
     let (proposal_id, _) = canister_fixture
         .make_default_proposal(
             &proposer_neuron_id,
-            Motion {
-                motion_text: "Test self following".to_string(),
-            },
+            Motion::default(),
             proposer_principal_id,
         )
         .unwrap();
@@ -2473,7 +2471,7 @@ fn test_register_vote_happy_no_wait_for_quiet() {
     let proposal = ProposalData {
         id: Some(proposal_id),
         proposal: Some(Proposal {
-            action: Some(Action::Motion(Motion::new("Test"))),
+            action: Some(Action::Motion(Motion::default())),
             ..Proposal::default()
         }),
         ballots: btreemap! {
@@ -2561,9 +2559,7 @@ fn test_empty_followees_are_filtered() {
     let (proposal_id, _) = canister_fixture
         .make_default_proposal(
             &proposer_neuron_id,
-            Motion {
-                motion_text: "Test self following".to_string(),
-            },
+            Motion::default(),
             proposer_principal_id,
         )
         .unwrap();
@@ -2872,9 +2868,7 @@ async fn test_process_proposals_tallies_votes_for_proposals_where_voting_is_poss
                 current_deadline_timestamp_seconds: 20, // voting period is still open
             }),
             proposal: Some(Proposal {
-                action: Some(Action::Motion(Motion {
-                    motion_text: "Test".to_string(),
-                })),
+                action: Some(Action::Motion(Motion::default())),
                 ..Proposal::default()
             }),
             latest_tally: None,
@@ -2907,9 +2901,7 @@ async fn test_process_proposals_doesnt_tally_votes_for_proposals_where_voting_is
                 current_deadline_timestamp_seconds: 20, // voting period is still open
             }),
             proposal: Some(Proposal {
-                action: Some(Action::Motion(Motion {
-                    motion_text: "Test".to_string(),
-                })),
+                action: Some(Action::Motion(Motion::default())),
                 ..Proposal::default()
             }),
             latest_tally: None,
@@ -2944,9 +2936,7 @@ fn test_motion_has_normal_voting_thresholds() {
         // Create with a test neuron so that the proposal doesn't instantly pass
         .create_with_test_neuron();
 
-    let proposal = Motion {
-        motion_text: "Do stuff".to_string(),
-    };
+    let proposal = Motion::default();
 
     // Create the proposal with neuron_id so it doesn't instantly pass
     let (_, proposal_data) = canister_fixture

--- a/rs/sns/integration_tests/src/nervous_system_parameters.rs
+++ b/rs/sns/integration_tests/src/nervous_system_parameters.rs
@@ -154,9 +154,7 @@ fn test_existing_proposals_unaffected_by_sns_parameter_changes() {
                     &user_1_subaccount,
                     Proposal {
                         title: "We'll let a couple users vote, then wait to see when the proposal closes on its own".into(),
-                        action: Some(Action::Motion(Motion {
-                            motion_text: "Make the Internet Computer AMAZING!".into(),
-                        })),
+                        action: Some(Action::Motion(Motion::default())),
                         ..Default::default()
                     },
                 )

--- a/rs/sns/integration_tests/src/neuron.rs
+++ b/rs/sns/integration_tests/src/neuron.rs
@@ -690,10 +690,8 @@ fn test_neuron_action_is_not_authorized() {
             .expect("Error creating the subaccount");
 
         let proposal_payload = Proposal {
-            title: "Motion to delete this SNS".into(),
-            action: Some(Action::Motion(Motion {
-                motion_text: "I'm a bad actor and this should not be tolerated".into(),
-            })),
+            title: "Motion to delete this SNS. I'm a bad actor and should not be tolerated.".into(),
+            action: Some(Action::Motion(Motion::default())),
             ..Default::default()
         };
 
@@ -1221,9 +1219,7 @@ async fn zero_total_reward_shares() {
     // Step 1.2: Craft a ProposalData that is ReadyToSettle.
     let proposal_id = 99;
     let do_nothing_proposal = Proposal {
-        action: Some(Action::Motion(Motion {
-            motion_text: "For great justice.".to_string(),
-        })),
+        action: Some(Action::Motion(Motion::default())),
         ..Default::default()
     };
     let ready_to_settle_proposal_data = ProposalData {
@@ -1432,9 +1428,7 @@ async fn couple_of_neurons_who_voted_get_rewards() {
     // voted no, and the third did not vote.
     let proposal_id = 99;
     let do_nothing_proposal = Proposal {
-        action: Some(Action::Motion(Motion {
-            motion_text: "For great justice.".to_string(),
-        })),
+        action: Some(Action::Motion(Motion::default())),
         ..Default::default()
     };
     let ready_to_settle_proposal_data = ProposalData {
@@ -2840,9 +2834,7 @@ fn test_disburse_neuron_burns_neuron_fees() {
 
         // Create a proposal and have the user submit it
         let proposal = Proposal {
-            action: Some(Action::Motion(Motion {
-                motion_text: String::from(""),
-            })),
+            action: Some(Action::Motion(Motion::default())),
             ..Default::default()
         };
 
@@ -3051,9 +3043,7 @@ fn test_split_neuron_inheritance() {
 
         // Create a proposal and have the parent submit it
         let proposal = Proposal {
-            action: Some(Action::Motion(Motion {
-                motion_text: String::from(""),
-            })),
+            action: Some(Action::Motion(Motion::default())),
             ..Default::default()
         };
 
@@ -3347,9 +3337,7 @@ fn test_neuron_voting_power_multiplier_with_ballots() {
 
         let proposal_payload = Proposal {
             title: "Test Motion proposal".into(),
-            action: Some(Action::Motion(Motion {
-                motion_text: "motion_text".into(),
-            })),
+            action: Some(Action::Motion(Motion::default())),
             ..Default::default()
         };
 

--- a/rs/sns/integration_tests/src/proposals.rs
+++ b/rs/sns/integration_tests/src/proposals.rs
@@ -17,10 +17,7 @@ use ic_sns_governance::{
         NeuronPermissionType, Proposal, ProposalData, ProposalDecisionStatus, ProposalId,
         ProposalRewardStatus, RewardEvent, Vote, VotingRewardsParameters,
     },
-    proposal::{
-        PROPOSAL_MOTION_TEXT_BYTES_MAX, PROPOSAL_SUMMARY_BYTES_MAX, PROPOSAL_TITLE_BYTES_MAX,
-        PROPOSAL_URL_CHAR_MAX,
-    },
+    proposal::{PROPOSAL_SUMMARY_BYTES_MAX, PROPOSAL_TITLE_BYTES_MAX, PROPOSAL_URL_CHAR_MAX},
     reward,
 };
 use ic_sns_test_utils::{
@@ -76,9 +73,7 @@ fn test_motion_proposal_execution() {
 
             let proposal_payload = Proposal {
                 title: "Test Motion proposal".into(),
-                action: Some(Action::Motion(Motion {
-                    motion_text: "Spoon".into(),
-                })),
+                action: Some(Action::Motion(Motion::default())),
                 ..Default::default()
             };
 
@@ -97,7 +92,7 @@ fn test_motion_proposal_execution() {
 
             match proposal_data.proposal.unwrap().action.unwrap() {
                 Action::Motion(motion) => {
-                    assert_eq!(motion.motion_text, "Spoon".to_string());
+                    assert_eq!(motion, Motion::default());
                 }
                 _ => panic!("Proposal has unexpected action"),
             }
@@ -277,9 +272,7 @@ fn test_voting_with_three_neurons_with_the_same_stake() {
                     &user_1_subaccount,
                     Proposal {
                         title: "This time, we need more than one user to vote".into(),
-                        action: Some(Action::Motion(Motion {
-                            motion_text: "Make the Internet Computer AMAZING!".into(),
-                        })),
+                        action: Some(Action::Motion(Motion::default())),
                         ..Default::default()
                     },
                 )
@@ -510,9 +503,7 @@ fn test_list_proposals_determinism() {
         for i in 0..10 {
             proposals.push(Proposal {
                 title: format!("Test Motion proposal-{}", i),
-                action: Some(Action::Motion(Motion {
-                    motion_text: format!("Motion-{}", i),
-                })),
+                action: Some(Action::Motion(Motion::default())),
                 ..Default::default()
             });
         }
@@ -616,10 +607,11 @@ fn test_proposal_format_validation() {
             .stake_and_claim_neuron(&user.sender, Some(ONE_YEAR_SECONDS as u32))
             .await;
 
-        // Create a proposal with an illegal number of characters in the motion text
+        // Create a proposal with some content in the motion text, which is not allowed as motion_text is deprecated.
+        #[allow(deprecated)]
         let mut proposal = Proposal {
             action: Some(Action::Motion(Motion {
-                motion_text: "X".repeat(PROPOSAL_MOTION_TEXT_BYTES_MAX + 1),
+                motion_text: "Nothing is allowed in here!".to_string(),
             })),
             ..Default::default()
         };
@@ -634,9 +626,7 @@ fn test_proposal_format_validation() {
 
         // Set the motion text to default and update the proposal with an illegal number of
         // characters in the proposal title
-        proposal.action = Some(Action::Motion(Motion {
-            motion_text: String::from(""),
-        }));
+        proposal.action = Some(Action::Motion(Motion::default()));
         proposal.title = "X".repeat(PROPOSAL_TITLE_BYTES_MAX + 1);
 
         // Submit a proposal and expect an error
@@ -727,9 +717,7 @@ fn test_neuron_configuration_needed_for_proposals() {
             .await;
 
         let proposal = Proposal {
-            action: Some(Action::Motion(Motion {
-                motion_text: String::from(""),
-            })),
+            action: Some(Action::Motion(Motion::default())),
             ..Default::default()
         };
 
@@ -857,9 +845,7 @@ fn test_ballots_set_for_multiple_neurons() {
         let proposer = users[0].clone();
 
         let proposal = Proposal {
-            action: Some(Action::Motion(Motion {
-                motion_text: String::from(""),
-            })),
+            action: Some(Action::Motion(Motion::default())),
             ..Default::default()
         };
 
@@ -978,9 +964,7 @@ fn test_ineligible_neuron_voting_fails() {
             .await;
 
         let proposal = Proposal {
-            action: Some(Action::Motion(Motion {
-                motion_text: String::from(""),
-            })),
+            action: Some(Action::Motion(Motion::default())),
             ..Default::default()
         };
 
@@ -1039,9 +1023,7 @@ fn test_repeated_voting_fails() {
             .await;
 
         let proposal = Proposal {
-            action: Some(Action::Motion(Motion {
-                motion_text: String::from(""),
-            })),
+            action: Some(Action::Motion(Motion::default())),
             ..Default::default()
         };
 
@@ -1178,9 +1160,7 @@ fn test_following_and_voting() {
             .await;
 
         let proposal = Proposal {
-            action: Some(Action::Motion(Motion {
-                motion_text: String::from(""),
-            })),
+            action: Some(Action::Motion(Motion::default())),
             ..Default::default()
         };
 
@@ -1283,9 +1263,7 @@ fn test_following_and_voting_from_non_proposer() {
             .await;
 
         let proposal = Proposal {
-            action: Some(Action::Motion(Motion {
-                motion_text: String::from(""),
-            })),
+            action: Some(Action::Motion(Motion::default())),
             ..Default::default()
         };
 
@@ -1385,9 +1363,7 @@ fn test_following_multiple_neurons_reach_majority() {
             .await;
 
         let proposal = Proposal {
-            action: Some(Action::Motion(Motion {
-                motion_text: String::from(""),
-            })),
+            action: Some(Action::Motion(Motion::default())),
             ..Default::default()
         };
 
@@ -1478,9 +1454,7 @@ fn test_proposal_rejection() {
         assert_eq!(neuron.neuron_fees_e8s, 0);
 
         let proposal = Proposal {
-            action: Some(Action::Motion(Motion {
-                motion_text: String::from(""),
-            })),
+            action: Some(Action::Motion(Motion::default())),
             ..Default::default()
         };
 
@@ -1588,9 +1562,7 @@ fn test_proposal_garbage_collection() {
         let proposals: Vec<Proposal> = (0..10)
             .map(|i| Proposal {
                 title: format!("Motion-{}", i),
-                action: Some(Action::Motion(Motion {
-                    motion_text: format!("Motion-{}", i),
-                })),
+                action: Some(Action::Motion(Motion::default())),
                 ..Default::default()
             })
             .collect();

--- a/rs/sns/integration_tests/src/sns_treasury.rs
+++ b/rs/sns/integration_tests/src/sns_treasury.rs
@@ -468,12 +468,10 @@ fn test_sns_treasury_can_transfer_funds_via_proposals() {
             *WHALE,
             whale_neuron_id,
             Proposal {
-                title: "Transfer treasury SNS".to_string(),
-                summary: "Transfer treasury to user".to_string(),
+                title: "Normal benign proposal".to_string(),
+                summary: "This is just a normal benign proposal".to_string(),
                 url: "".to_string(),
-                action: Some(Action::Motion(Motion {
-                    motion_text: "Nothing to see here.".to_string(),
-                })),
+                action: Some(Action::Motion(Motion::default())),
             },
         )
         .unwrap();

--- a/rs/sns/integration_tests/test_canisters/sns_governance_mem_test_canister.rs
+++ b/rs/sns/integration_tests/test_canisters/sns_governance_mem_test_canister.rs
@@ -270,6 +270,7 @@ fn allocate_proposal_data(
         _ => panic!("Undefined proposal action"),
     };
 
+    #[allow(deprecated)]
     let mut proposal_data = ProposalData {
         action,
         id: Some(ProposalId { id }),
@@ -279,6 +280,8 @@ fn allocate_proposal_data(
             url: ['u'; PROPOSAL_URL_CHAR_MAX].iter().collect(),
             action: Some(Action::Motion(Motion {
                 // We use "motion" for all actions for convenience. All that matters is the size.
+                // This is not a valid motion proposal because it has content in motion_text, which is deprecated.
+                // But it is good enough for the purpose of this test.
                 motion_text: "a".repeat(payload_size),
             })),
         }),

--- a/rs/sns/test_utils/src/itest_helpers.rs
+++ b/rs/sns/test_utils/src/itest_helpers.rs
@@ -932,9 +932,7 @@ impl SnsCanisters<'_> {
         // Make and immediately vote on a proposal so that the neuron earns some rewards aka maturity.
         let proposal = Proposal {
             title: "A proposal that should pass unanimously".into(),
-            action: Some(Action::Motion(Motion {
-                motion_text: "GIMMIE MATURITY".into(),
-            })),
+            action: Some(Action::Motion(Motion::default())),
             ..Default::default()
         };
 

--- a/rs/tests/src/rosetta_tests/tests/neuron_voting.rs
+++ b/rs/tests/src/rosetta_tests/tests/neuron_voting.rs
@@ -73,9 +73,7 @@ pub fn test(env: TestEnv) {
     let proposal = MakeProposalRequest {
         title: Some("dummy title".to_string()),
         summary: "test".to_string(),
-        action: Some(ProposalActionRequest::Motion(Motion {
-            motion_text: "dummy text".to_string(),
-        })),
+        action: Some(ProposalActionRequest::Motion(Motion::default())),
         ..Default::default()
     };
     // Create Rosetta and ledger clients.
@@ -100,9 +98,7 @@ pub fn test(env: TestEnv) {
         let expected_proposal = Proposal {
             title: Some("dummy title".to_string()),
             summary: "test".to_string(),
-            action: Some(Action::Motion(Motion {
-                motion_text: "dummy text".to_string(),
-            })),
+            action: Some(Action::Motion(Motion::default())),
             ..Default::default()
         };
         assert_eq!(proposal_info.0.proposal.unwrap(), expected_proposal);


### PR DESCRIPTION
## Problem

I think like the motion_text field on motion proposals is just not useful. Anything you'd want to put in there you can just put in the proposal_summary. And putting anything in there usually doesn't do what you want because it isn't rendered on the nns-dapp or the dashboard, so you just get [an unreadable wall of text](https://dashboard.internetcomputer.org/proposal/132410). So not only is it not useful, it's also a fully loaded footgun that is liable to cost users their proposal submission fee. 

## Solution

The field can't be removed because it isn't optional (and that might cause data loss anyway), but we can at least mark it as deprecated and prevent proposals with a non-empty motion_text from being submitted