### PR TITLE
chore(nns): Remove the flag to enable new topics

### DIFF
--- a/rs/nns/governance/src/governance.rs
+++ b/rs/nns/governance/src/governance.rs
@@ -1,5 +1,5 @@
 use crate::{
-    are_set_visibility_proposals_enabled, decoder_config, enable_new_canister_management_topics,
+    are_set_visibility_proposals_enabled, decoder_config,
     governance::{
         merge_neurons::{
             build_merge_neurons_response, calculate_merge_neurons_effect,
@@ -822,20 +822,10 @@ impl Proposal {
                             NnsFunction::SubnetRentalRequest => Topic::SubnetRental,
                             NnsFunction::NnsCanisterInstall
                             | NnsFunction::HardResetNnsRootToVersion
-                            | NnsFunction::BitcoinSetConfig => {
-                                if enable_new_canister_management_topics() {
-                                    Topic::ProtocolCanisterManagement
-                                } else {
-                                    Topic::NetworkCanisterManagement
-                                }
-                            }
+                            | NnsFunction::BitcoinSetConfig => Topic::ProtocolCanisterManagement,
                             NnsFunction::AddSnsWasm
                             | NnsFunction::InsertSnsWasmUpgradePathEntries => {
-                                if enable_new_canister_management_topics() {
-                                    Topic::ServiceNervousSystemManagement
-                                } else {
-                                    Topic::NetworkCanisterManagement
-                                }
+                                Topic::ServiceNervousSystemManagement
                             }
                         }
                     } else {

--- a/rs/nns/governance/src/lib.rs
+++ b/rs/nns/governance/src/lib.rs
@@ -943,9 +943,5 @@ impl NeuronSubsetMetricsPb {
     }
 }
 
-fn enable_new_canister_management_topics() -> bool {
-    true
-}
-
 #[cfg(test)]
 mod tests;

--- a/rs/nns/governance/src/proposals/install_code.rs
+++ b/rs/nns/governance/src/proposals/install_code.rs
@@ -1,6 +1,5 @@
 use super::{invalid_proposal_error, topic_to_manage_canister};
 use crate::{
-    enable_new_canister_management_topics,
     pb::v1::{install_code::CanisterInstallMode, GovernanceError, InstallCode, Topic},
     proposals::call_canister::CallCanister,
 };
@@ -23,12 +22,6 @@ struct UpgradeRootProposalPayload {
 
 impl InstallCode {
     pub fn validate(&self) -> Result<(), GovernanceError> {
-        if !enable_new_canister_management_topics() {
-            return Err(invalid_proposal_error(
-                "InstallCode proposal is not yet supported",
-            ));
-        }
-
         let _ = self.valid_canister_id()?;
         let _ = self.valid_install_mode()?;
         let _ = self.valid_wasm_module()?;

--- a/rs/nns/governance/src/proposals/stop_or_start_canister.rs
+++ b/rs/nns/governance/src/proposals/stop_or_start_canister.rs
@@ -1,6 +1,5 @@
 use super::{invalid_proposal_error, topic_to_manage_canister};
 use crate::{
-    enable_new_canister_management_topics,
     pb::v1::{stop_or_start_canister::CanisterAction, GovernanceError, StopOrStartCanister, Topic},
     proposals::call_canister::CallCanister,
 };
@@ -20,12 +19,6 @@ const CANISTERS_NOT_ALLOWED_TO_STOP: [&CanisterId; 3] = [
 
 impl StopOrStartCanister {
     pub fn validate(&self) -> Result<(), GovernanceError> {
-        if !enable_new_canister_management_topics() {
-            return Err(invalid_proposal_error(
-                "StopOrStartCanister proposal is not yet supported",
-            ));
-        }
-
         let canister_id = self.valid_canister_id()?;
         let canister_action = self.valid_canister_action()?;
         let _ = self.valid_topic()?;

--- a/rs/nns/governance/src/proposals/update_canister_settings.rs
+++ b/rs/nns/governance/src/proposals/update_canister_settings.rs
@@ -1,6 +1,5 @@
 use super::{invalid_proposal_error, topic_to_manage_canister};
 use crate::{
-    enable_new_canister_management_topics,
     pb::v1::{
         update_canister_settings::LogVisibility, GovernanceError, Topic, UpdateCanisterSettings,
     },
@@ -17,12 +16,6 @@ use ic_nns_handler_root_interface::UpdateCanisterSettingsRequest;
 
 impl UpdateCanisterSettings {
     pub fn validate(&self) -> Result<(), GovernanceError> {
-        if !enable_new_canister_management_topics() {
-            return Err(invalid_proposal_error(
-                "UpdateCanisterSettings proposal is not yet supported",
-            ));
-        }
-
         let _ = self.valid_canister_id()?;
         let _ = self.valid_topic()?;
         let _ = self.canister_and_function()?;


### PR DESCRIPTION
The flag `enable_new_canister_management_topics` is already true on the mainnet. Clean up the code paths after replacing the function call with `true`.