### PR TITLE
feat(nns): Allow more proposal types when resources are low

### DIFF
--- a/rs/nns/governance/src/governance.rs
+++ b/rs/nns/governance/src/governance.rs
@@ -406,6 +406,7 @@ impl NnsFunction {
             self,
             NnsFunction::NnsRootUpgrade
                 | NnsFunction::NnsCanisterUpgrade
+                | NnsFunction::HardResetNnsRootToVersion
                 | NnsFunction::ReviseElectedGuestosVersions
                 | NnsFunction::DeployGuestosToAllSubnetNodes
         )
@@ -962,6 +963,8 @@ impl Action {
                     None => false,
                 }
             }
+            Action::InstallCode(_) => true,
+            Action::UpdateCanisterSettings(_) => true,
             _ => false,
         }
     }

--- a/rs/nns/governance/src/governance.rs
+++ b/rs/nns/governance/src/governance.rs
@@ -963,8 +963,10 @@ impl Action {
                     None => false,
                 }
             }
-            Action::InstallCode(_) => true,
-            Action::UpdateCanisterSettings(_) => true,
+            Action::InstallCode(install_code) => install_code.allowed_when_resources_are_low(),
+            Action::UpdateCanisterSettings(update_canister_settings) => {
+                update_canister_settings.allowed_when_resources_are_low()
+            }
             _ => false,
         }
     }

--- a/rs/nns/governance/src/proposals/install_code.rs
+++ b/rs/nns/governance/src/proposals/install_code.rs
@@ -120,6 +120,13 @@ impl InstallCode {
         })
         .map_err(|e| invalid_proposal_error(&format!("Failed to encode payload: {}", e)))
     }
+
+    pub fn allowed_when_resources_are_low(&self) -> bool {
+        let Ok(canister_id) = self.valid_canister_id() else {
+            return false;
+        };
+        topic_to_manage_canister(&canister_id) == Topic::ProtocolCanisterManagement
+    }
 }
 
 impl CallCanister for InstallCode {
@@ -171,7 +178,8 @@ mod tests {
     use crate::pb::v1::governance_error::ErrorType;
 
     use candid::Decode;
-    use ic_nns_constants::REGISTRY_CANISTER_ID;
+    use ic_base_types::CanisterId;
+    use ic_nns_constants::{REGISTRY_CANISTER_ID, SNS_WASM_CANISTER_ID};
 
     #[test]
     fn test_invalid_install_code_proposal() {
@@ -293,6 +301,7 @@ mod tests {
             install_code.canister_and_function(),
             Ok((ROOT_CANISTER_ID, "change_nns_canister"))
         );
+        assert!(install_code.allowed_when_resources_are_low());
         let decoded_payload =
             Decode!(&install_code.payload().unwrap(), ChangeCanisterRequest).unwrap();
         assert_eq!(
@@ -328,6 +337,7 @@ mod tests {
             install_code.canister_and_function(),
             Ok((LIFELINE_CANISTER_ID, "upgrade_root"))
         );
+        assert!(install_code.allowed_when_resources_are_low());
         let decoded_payload =
             Decode!(&install_code.payload().unwrap(), UpgradeRootProposalPayload).unwrap();
         assert_eq!(
@@ -341,9 +351,9 @@ mod tests {
     }
 
     #[test]
-    fn test_reinstall_code_non_root_protocol_canister() {
+    fn test_reinstall_code_non_protocol_canister() {
         let install_code = InstallCode {
-            canister_id: Some(LIFELINE_CANISTER_ID.get()),
+            canister_id: Some(SNS_WASM_CANISTER_ID.get()),
             wasm_module: Some(vec![1, 2, 3]),
             install_mode: Some(CanisterInstallMode::Reinstall as i32),
             arg: Some(vec![]),
@@ -353,12 +363,13 @@ mod tests {
         assert_eq!(install_code.validate(), Ok(()));
         assert_eq!(
             install_code.valid_topic(),
-            Ok(Topic::ProtocolCanisterManagement)
+            Ok(Topic::ServiceNervousSystemManagement)
         );
         assert_eq!(
             install_code.canister_and_function(),
             Ok((ROOT_CANISTER_ID, "change_nns_canister"))
         );
+        assert!(!install_code.allowed_when_resources_are_low());
         let decoded_payload =
             Decode!(&install_code.payload().unwrap(), ChangeCanisterRequest).unwrap();
         assert_eq!(
@@ -366,7 +377,7 @@ mod tests {
             ChangeCanisterRequest {
                 stop_before_installing: false,
                 mode: RootCanisterInstallMode::Reinstall,
-                canister_id: LIFELINE_CANISTER_ID,
+                canister_id: SNS_WASM_CANISTER_ID,
                 wasm_module: vec![1, 2, 3],
                 arg: vec![],
                 compute_allocation: None,
@@ -377,9 +388,6 @@ mod tests {
 
     #[test]
     fn test_upgrade_canisters_topic_mapping() {
-        use ic_base_types::CanisterId;
-        use ic_nns_constants::SNS_WASM_CANISTER_ID;
-
         let test_cases = vec![
             (REGISTRY_CANISTER_ID, Topic::ProtocolCanisterManagement),
             (SNS_WASM_CANISTER_ID, Topic::ServiceNervousSystemManagement),

--- a/rs/nns/governance/src/proposals/update_canister_settings.rs
+++ b/rs/nns/governance/src/proposals/update_canister_settings.rs
@@ -98,6 +98,13 @@ impl UpdateCanisterSettings {
             reserved_cycles_limit,
         })
     }
+
+    pub fn allowed_when_resources_are_low(&self) -> bool {
+        let Ok(canister_id) = self.valid_canister_id() else {
+            return false;
+        };
+        topic_to_manage_canister(&canister_id) == Topic::ProtocolCanisterManagement
+    }
 }
 
 impl CallCanister for UpdateCanisterSettings {
@@ -136,8 +143,7 @@ mod tests {
     use crate::pb::v1::update_canister_settings::{CanisterSettings, Controllers};
     use candid::Decode;
     use ic_base_types::CanisterId;
-    use ic_nns_constants::LEDGER_CANISTER_ID;
-    use ic_nns_constants::{GOVERNANCE_CANISTER_ID, SNS_WASM_CANISTER_ID};
+    use ic_nns_constants::{LEDGER_CANISTER_ID, SNS_WASM_CANISTER_ID};
 
     #[test]
     fn test_invalid_update_canister_settings() {
@@ -214,13 +220,13 @@ mod tests {
     }
 
     #[test]
-    fn test_update_ledger_canister_settings() {
-        let update_ledger_canister_settings = UpdateCanisterSettings {
-            canister_id: Some(LEDGER_CANISTER_ID.get()),
+    fn test_update_sns_w_canister_settings() {
+        let update_sns_w_canister_settings = UpdateCanisterSettings {
+            canister_id: Some(SNS_WASM_CANISTER_ID.get()),
             // The value of the settings are arbitrary and do not have any meaning.
             settings: Some(CanisterSettings {
                 controllers: Some(Controllers {
-                    controllers: vec![GOVERNANCE_CANISTER_ID.get()],
+                    controllers: vec![ROOT_CANISTER_ID.get()],
                 }),
                 memory_allocation: Some(1 << 32),
                 wasm_memory_limit: Some(1 << 31),
@@ -230,27 +236,28 @@ mod tests {
             }),
         };
 
-        assert_eq!(update_ledger_canister_settings.validate(), Ok(()));
+        assert_eq!(update_sns_w_canister_settings.validate(), Ok(()));
         assert_eq!(
-            update_ledger_canister_settings.valid_topic(),
-            Ok(Topic::ProtocolCanisterManagement)
+            update_sns_w_canister_settings.valid_topic(),
+            Ok(Topic::ServiceNervousSystemManagement)
         );
         assert_eq!(
-            update_ledger_canister_settings.canister_and_function(),
+            update_sns_w_canister_settings.canister_and_function(),
             Ok((ROOT_CANISTER_ID, "update_canister_settings"))
         );
+        assert!(!update_sns_w_canister_settings.allowed_when_resources_are_low());
 
         let decoded_payload = Decode!(
-            &update_ledger_canister_settings.payload().unwrap(),
+            &update_sns_w_canister_settings.payload().unwrap(),
             UpdateCanisterSettingsRequest
         )
         .unwrap();
         assert_eq!(
             decoded_payload,
             UpdateCanisterSettingsRequest {
-                canister_id: LEDGER_CANISTER_ID.get(),
+                canister_id: SNS_WASM_CANISTER_ID.get(),
                 settings: RootCanisterSettings {
-                    controllers: Some(vec![GOVERNANCE_CANISTER_ID.get()]),
+                    controllers: Some(vec![ROOT_CANISTER_ID.get()]),
                     memory_allocation: Some(Nat::from(1u64 << 32)),
                     wasm_memory_limit: Some(Nat::from(1u64 << 31)),
                     compute_allocation: Some(Nat::from(10u64)),
@@ -288,6 +295,7 @@ mod tests {
             update_root_canister_settings.canister_and_function(),
             Ok((LIFELINE_CANISTER_ID, "update_root_settings"))
         );
+        assert!(update_root_canister_settings.allowed_when_resources_are_low());
 
         let decoded_payload = Decode!(
             &update_root_canister_settings.payload().unwrap(),


### PR DESCRIPTION
# Why

All the proposal types that might be needed for recovering NNS Governance from excessive memory usage, should be allowed when memory usage is high.

# What

* The `InstallCode` replaces `NnsCanisterUpgrade`, therefore it should be allowed.
* The `UpdateCanisterSettings` might be able to change canister settings such as `memory_allocation` and `wasm_memory_limit`
* The NNS Root is the controller of the NNS Governance, so hard-resetting root should be allowed, similar to `NnsRootUpgrade`
* For `InstallCode` and `UpdateCanisterSettings`, only the protocol canisters are allowed