### PR TITLE
fix(ckerc20): bug in renaming field

### DIFF
--- a/rs/ethereum/ledger-suite-orchestrator/src/scheduler/test_fixtures.rs
+++ b/rs/ethereum/ledger-suite-orchestrator/src/scheduler/test_fixtures.rs
@@ -1,5 +1,8 @@
 use crate::scheduler::Erc20Token;
-use crate::state::{CanistersMetadata, TokenId};
+use crate::state::{
+    Canisters, CanistersMetadata, IndexCanister, LedgerCanister, ManagedCanisterStatus, TokenId,
+    TokenSymbol,
+};
 
 pub const DAI_ADDRESS: &str = "0x6B175474E89094C44Da98b954EedeAC495271d0F";
 pub const USDC_ADDRESS: &str = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48";
@@ -39,6 +42,25 @@ pub fn usdc_metadata() -> CanistersMetadata {
     }
 }
 
+pub fn usdc_ledger_suite() -> Canisters {
+    Canisters {
+        ledger: Some(LedgerCanister::new(ManagedCanisterStatus::Installed {
+            canister_id: "xevnm-gaaaa-aaaar-qafnq-cai".parse().unwrap(),
+            installed_wasm_hash: "8457289d3b3179aa83977ea21bfa2fc85e402e1f64101ecb56a4b963ed33a1e6"
+                .parse()
+                .unwrap(),
+        })),
+        index: Some(IndexCanister::new(ManagedCanisterStatus::Installed {
+            canister_id: "xrs4b-hiaaa-aaaar-qafoa-cai".parse().unwrap(),
+            installed_wasm_hash: "eb3096906bf9a43996d2ca9ca9bfec333a402612f132876c8ed1b01b9844112a"
+                .parse()
+                .unwrap(),
+        })),
+        archives: vec!["t4dy3-uiaaa-aaaar-qafua-cai".parse().unwrap()],
+        metadata: usdc_metadata(),
+    }
+}
+
 pub fn usdt() -> Erc20Token {
     crate::candid::Erc20Contract {
         chain_id: 1_u8.into(),
@@ -55,5 +77,29 @@ pub fn usdt_token_id() -> TokenId {
 pub fn usdt_metadata() -> CanistersMetadata {
     CanistersMetadata {
         token_symbol: "ckUSDT".to_string(),
+    }
+}
+pub fn cketh_token_symbol() -> TokenSymbol {
+    TokenSymbol::from("ckETH".to_string())
+}
+
+pub fn cketh_ledger_suite() -> Canisters {
+    Canisters {
+        ledger: Some(LedgerCanister::new(ManagedCanisterStatus::Installed {
+            canister_id: "ss2fx-dyaaa-aaaar-qacoq-cai".parse().unwrap(),
+            installed_wasm_hash: "8457289d3b3179aa83977ea21bfa2fc85e402e1f64101ecb56a4b963ed33a1e6"
+                .parse()
+                .unwrap(),
+        })),
+        index: Some(IndexCanister::new(ManagedCanisterStatus::Installed {
+            canister_id: "s3zol-vqaaa-aaaar-qacpa-cai".parse().unwrap(),
+            installed_wasm_hash: "eb3096906bf9a43996d2ca9ca9bfec333a402612f132876c8ed1b01b9844112a"
+                .parse()
+                .unwrap(),
+        })),
+        archives: vec!["xob7s-iqaaa-aaaar-qacra-cai".parse().unwrap()],
+        metadata: CanistersMetadata {
+            token_symbol: cketh_token_symbol().to_string(),
+        },
     }
 }

--- a/rs/ethereum/ledger-suite-orchestrator/src/state/mod.rs
+++ b/rs/ethereum/ledger-suite-orchestrator/src/state/mod.rs
@@ -321,6 +321,7 @@ pub struct Canisters {
 
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Debug, Deserialize, Serialize)]
 pub struct CanistersMetadata {
+    #[serde(rename = "ckerc20_token_symbol")]
     pub token_symbol: String,
 }
 


### PR DESCRIPTION
(XC-189): Fix a bug introduced in #1312 where a field stored in stable memory was renamed. The rename is kept transparent using `#[serde(rename)]` and test that ensures that changes in stable memory are backwards-compatible were fixed as well.