### PR TITLE
chore: RUN-988: Fix System API benchmarks

### DIFF
--- a/rs/execution_environment/benches/lib/src/common.rs
+++ b/rs/execution_environment/benches/lib/src/common.rs
@@ -2,7 +2,7 @@
 /// Common System API benchmark functions, types, constants.
 ///
 use criterion::{BatchSize, Criterion};
-use ic_config::embedders::{Config as EmbeddersConfig, MeteringType};
+use ic_config::embedders::{Config as EmbeddersConfig, FeatureFlags};
 use ic_config::execution_environment::Config;
 use ic_config::flag_status::FlagStatus;
 use ic_config::subnet_config::{SchedulerConfig, SubnetConfig};
@@ -262,7 +262,10 @@ where
     ));
     let config = Config {
         embedders_config: EmbeddersConfig {
-            metering_type: MeteringType::New,
+            feature_flags: FeatureFlags {
+                best_effort_responses: FlagStatus::Enabled,
+                ..FeatureFlags::default()
+            },
             ..EmbeddersConfig::default()
         },
         ..Default::default()

--- a/rs/execution_environment/benches/system_api/diff-old-vs-new.sh
+++ b/rs/execution_environment/benches/system_api/diff-old-vs-new.sh
@@ -26,7 +26,7 @@ fi
 echo "Global script configuration:"
 echo
 printf "%20s %s\n" \
-    "OLD_REPO :=" "${OLD_REPO:=git@gitlab.com:dfinity-lab/public/ic.git}" \
+    "OLD_REPO :=" "${OLD_REPO:=git@github.com:dfinity/ic.git}" \
     "OLD_BRANCH :=" "${OLD_BRANCH:=master}" \
     "OLD_COMMIT :=" "${OLD_COMMIT:=}" \
     "" "" \
@@ -103,7 +103,7 @@ init_old() {
 ## This function is called to run remote (old) benchmarks
 run_old() {
     (
-        cd "${OLD_BENCHMARK_DIR}"
+        cd "${OLD_REPO_DIR}"
         bazel run //rs/execution_environment:execute_inspect_message_bench -- ${FILTER} ${OLD_BENCH_ARGS} \
             && bazel run //rs/execution_environment:execute_query_bench -- ${FILTER} ${OLD_BENCH_ARGS} \
             && bazel run //rs/execution_environment:execute_update_bench -- ${FILTER} ${OLD_BENCH_ARGS}

--- a/rs/execution_environment/benches/system_api/execute_inspect_message.rs
+++ b/rs/execution_environment/benches/system_api/execute_inspect_message.rs
@@ -25,7 +25,7 @@ pub fn execute_inspect_message_bench(c: &mut Criterion) {
             520000511,
         ),
         common::Benchmark(
-            "ic0_msg_method_name_copy()/30B".into(),
+            "ic0_msg_method_name_copy()/20B".into(),
             Module::InspectMessage.from_ic0("msg_method_name_copy", Params3(0, 0, 20), Result::No),
             539000511,
         ),

--- a/rs/execution_environment/benches/system_api/execute_update.rs
+++ b/rs/execution_environment/benches/system_api/execute_update.rs
@@ -118,12 +118,12 @@ pub fn execute_update_bench(c: &mut Criterion) {
         common::Benchmark(
             "ic0_debug_print()/1B".into(),
             Module::Test.from_ic0("debug_print", Params2(0, 1), Result::No),
-            119000006,
+            170000006,
         ),
         common::Benchmark(
             "ic0_debug_print()/1K".into(),
             Module::Test.from_ic0("debug_print", Params2(0, 1024), Result::No),
-            1142000006,
+            47366018006,
         ),
         common::Benchmark(
             "ic0_call_new()".into(),
@@ -159,6 +159,15 @@ pub fn execute_update_bench(c: &mut Criterion) {
             "call_new+ic0_call_perform()".into(),
             Module::CallNewLoop.from_ic0("call_perform", NoParams, Result::I32),
             6558000006,
+        ),
+        common::Benchmark(
+            "call_new+ic0_call_with_best_effort_response()".into(),
+            Module::CallNewLoop.from_ic0(
+                "call_with_best_effort_response",
+                Param1(1_i32),
+                Result::No,
+            ),
+            2058000006,
         ),
         common::Benchmark(
             "ic0_stable_size()".into(),
@@ -316,15 +325,6 @@ pub fn execute_update_bench(c: &mut Criterion) {
             "ic0_cycles_burn128()".into(),
             Module::Test.from_ic0("cycles_burn128", Params3(1_i64, 2_i64, 3_i32), Result::No),
             19000006,
-        ),
-        common::Benchmark(
-            "ic0_call_with_best_effort_response()".into(),
-            Module::CallNewLoop.from_ic0(
-                "call_with_best_effort_response",
-                Param1(1_i32),
-                Result::No,
-            ),
-            2058000006,
         ),
         common::Benchmark(
             "ic0_msg_deadline()".into(),


### PR DESCRIPTION
Minor fixes around System API benchmarks:

* Updated repository
* Renamed some benchmarks
* Enabled best effort responses
* Updated `debug_print` expected instructions