### PR TITLE
fix(PocketIC): drop PocketIC library timeout

### DIFF
--- a/packages/pocket-ic/src/lib.rs
+++ b/packages/pocket-ic/src/lib.rs
@@ -58,7 +58,7 @@ use std::{
     path::{Path, PathBuf},
     process::Command,
     sync::Arc,
-    time::{Duration, Instant, SystemTime},
+    time::{Duration, SystemTime},
 };
 use tracing::{instrument, warn};
 
@@ -1321,7 +1321,6 @@ To download the binary, please visit https://github.com/dfinity/pocketic."
         cmd.spawn().expect("Failed to start PocketIC binary");
     }
 
-    let start = Instant::now();
     loop {
         if let Ok(port_string) = std::fs::read_to_string(port_file_path.clone()) {
             if port_string.contains("\n") {
@@ -1331,9 +1330,6 @@ To download the binary, please visit https://github.com/dfinity/pocketic."
                     .expect("Failed to parse port to number");
                 break Url::parse(&format!("http://{}:{}/", LOCALHOST, port)).unwrap();
             }
-        }
-        if start.elapsed() > Duration::from_secs(10) {
-            panic!("Failed to start PocketIC service in time");
         }
         std::thread::sleep(Duration::from_millis(20));
     }


### PR DESCRIPTION
This PR drops the PocketIC library timeout of 10s when starting the PocketIC server. Given that other parts of a test might be slow, too, it is not clear why we'd impose a timeout on starting the PocketIC server. Moreover, we have seen this timeout causing flakiness in tests regularly.