### PR TITLE
feat(boundary): rate-limiting canister

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17211,12 +17211,9 @@ name = "rate-limiting"
 version = "0.9.0"
 dependencies = [
  "candid",
- "dfn_candid",
- "dfn_core",
  "ic-cdk 0.13.5",
  "ic-cdk-macros 0.9.0",
  "ic-cdk-timers",
- "registry-canister",
  "serde",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17207,6 +17207,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "977b1e897f9d764566891689e642653e5ed90c6895106acd005eb4c1d0203991"
 
 [[package]]
+name = "rate-limiting"
+version = "0.9.0"
+dependencies = [
+ "candid",
+ "dfn_candid",
+ "dfn_core",
+ "ic-cdk 0.13.5",
+ "ic-cdk-macros 0.9.0",
+ "ic-cdk-timers",
+ "registry-canister",
+ "serde",
+]
+
+[[package]]
 name = "ratelimit"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -364,6 +364,7 @@ members = [
     "rs/tests/test_canisters/http_counter",
     "rs/tests/test_canisters/kv_store",
     "rs/tests/test_canisters/message",
+    "rs/tests/test_canisters/rate_limiting",
     "rs/tests/testing_verification",
     "rs/tests/testing_verification/wabt-tests",
     "rs/tests/testing_verification/spec_compliance",

--- a/rs/tests/test_canisters/rate_limiting/Cargo.toml
+++ b/rs/tests/test_canisters/rate_limiting/Cargo.toml
@@ -8,9 +8,6 @@ documentation.workspace = true
 
 [dependencies]
 candid = { workspace = true }
-dfn_candid = {path = "../../../rust_canisters/dfn_candid"}
-dfn_core = {path = "../../../rust_canisters/dfn_core"}
-registry-canister = { path = "../../../registry/canister" }
 ic-cdk = { workspace = true }
 ic-cdk-macros = { workspace = true }
 ic-cdk-timers = { workspace = true }

--- a/rs/tests/test_canisters/rate_limiting/Cargo.toml
+++ b/rs/tests/test_canisters/rate_limiting/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "rate-limiting"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+description.workspace = true
+documentation.workspace = true
+
+[dependencies]
+candid = { workspace = true }
+dfn_candid = {path = "../../../rust_canisters/dfn_candid"}
+dfn_core = {path = "../../../rust_canisters/dfn_core"}
+registry-canister = { path = "../../../registry/canister" }
+ic-cdk = { workspace = true }
+ic-cdk-macros = { workspace = true }
+ic-cdk-timers = { workspace = true }
+serde = { workspace = true }
+
+[lib]
+crate-type = ["cdylib"]
+path = "src/lib.rs"

--- a/rs/tests/test_canisters/rate_limiting/dfx.json
+++ b/rs/tests/test_canisters/rate_limiting/dfx.json
@@ -1,16 +1,21 @@
 {
+    "version": 1,
     "canisters": {
-      "rate_limiting_canister_backend": {
-        "candid": "src/rate_limiting_backend.did",
-        "type": "rust"
+      "rate_limiting": {
+        "type": "rust",
+        "package": "rate-limiting",
+        "candid": "src/rate_limiting_backend.did"
       }
     },
     "defaults": {
       "build": {
-        "args": "",
         "packtool": ""
       }
     },
-    "output_env_file": ".env",
-    "version": 1
+    "networks": {
+      "local": {
+        "bind": "127.0.0.1:8080",
+        "type": "ephemeral"
+      }
+    }
   }

--- a/rs/tests/test_canisters/rate_limiting/dfx.json
+++ b/rs/tests/test_canisters/rate_limiting/dfx.json
@@ -1,0 +1,16 @@
+{
+    "canisters": {
+      "rate_limiting_canister_backend": {
+        "candid": "src/rate_limiting_backend.did",
+        "type": "rust"
+      }
+    },
+    "defaults": {
+      "build": {
+        "args": "",
+        "packtool": ""
+      }
+    },
+    "output_env_file": ".env",
+    "version": 1
+  }

--- a/rs/tests/test_canisters/rate_limiting/src/canister.rs
+++ b/rs/tests/test_canisters/rate_limiting/src/canister.rs
@@ -1,0 +1,33 @@
+use std::sync::atomic::{AtomicU64, Ordering};
+use serde::{Deserialize, Serialize};
+use candid::{Encode, Principal};
+use ic_cdk::api::call::call;
+use registry_canister::pb::v1::{ApiBoundaryNodeIdRecord, GetApiBoundaryNodeIdsRequest};
+
+static COUNTER: AtomicU64 = AtomicU64::new(0);
+
+#[ic_cdk::query]
+fn counter() -> u64 {
+    COUNTER.load(Ordering::Relaxed)
+}
+
+#[ic_cdk::init]
+fn init(timer_interval_secs: u64) {
+    let interval = std::time::Duration::from_secs(timer_interval_secs);
+    ic_cdk::println!("Starting a periodic task with interval {interval:?}");
+    ic_cdk_timers::set_timer_interval(interval, || {
+        COUNTER.fetch_add(1, Ordering::Relaxed);
+        ic_cdk::spawn(async {
+            let canister_id = Principal::from_text("rwlgt-iiaaa-aaaaa-aaaaa-cai").unwrap();
+            // let args = Encode!(&GetApiBoundaryNodeIdsRequest {}).unwrap();
+            let (result,): (i64,) = call(canister_id, "get_api_boundary_node_ids", ())
+                .await
+                .unwrap();
+        });
+    });
+}
+
+#[ic_cdk::post_upgrade]
+fn post_upgrade(timer_interval_secs: u64) {
+    init(timer_interval_secs)
+}

--- a/rs/tests/test_canisters/rate_limiting/src/canister.rs
+++ b/rs/tests/test_canisters/rate_limiting/src/canister.rs
@@ -19,11 +19,6 @@ static API_BNS_COUNT: AtomicU64 = AtomicU64::new(0);
 pub struct GetApiBoundaryNodeIdsRequest {}
 
 #[derive(CandidType, candid::Deserialize)]
-struct OverwriteConfigResponse {
-    result: bool,
-}
-
-#[derive(CandidType, candid::Deserialize)]
 struct ConfigResponse {
     version: Version,
     active_since: Timestamp,
@@ -31,6 +26,8 @@ struct ConfigResponse {
 }
 
 type GetConfigResponse = Result<ConfigResponse, String>;
+type OverwriteConfigResponse = Result<(), String>;
+type DisclosesRulesResponse = Result<(), String>;
 
 #[derive(Clone)]
 struct StoredConfig {
@@ -95,8 +92,7 @@ fn overwrite_config(config: InputConfig) -> OverwriteConfigResponse {
         configs.insert(version, new_config);
     });
 
-    let result = OverwriteConfigResponse { result: true };
-    result
+    Ok(())
 }
 
 #[ic_cdk_macros::update]

--- a/rs/tests/test_canisters/rate_limiting/src/canister.rs
+++ b/rs/tests/test_canisters/rate_limiting/src/canister.rs
@@ -1,19 +1,67 @@
+use candid::CandidType;
 use candid::Principal;
 use ic_cdk::api::call::call;
+use serde_json::Value;
 use std::sync::atomic::{AtomicU64, Ordering};
+type Id = String;
 
 const REGISTRY_CANISTER_ID: &str = "rwlgt-iiaaa-aaaaa-aaaaa-cai";
 const REGISTRY_CANISTER_METHOD: &str = "get_api_boundary_node_ids";
 
 static API_BNS_COUNT: AtomicU64 = AtomicU64::new(0);
 
+#[derive(CandidType, candid::Deserialize)]
+pub struct GetApiBoundaryNodeIdsRequest {}
+
+#[derive(CandidType, candid::Deserialize)]
+struct OverwriteConfigResponse {
+    result: bool,
+}
+
+#[derive(CandidType, candid::Deserialize)]
+struct GetLatestConfigResponse {
+    config: InputConfig,
+}
+
+#[derive(CandidType, candid::Deserialize, Clone)]
+struct InputConfig {
+    rules: Vec<InputRule>,
+}
+
+#[derive(CandidType, candid::Deserialize, Clone)]
+struct InputRule {
+    id: Id,
+    rule_raw: String,
+    description: String,
+}
+
+thread_local! {
+    static CONFIG: std::cell::RefCell<InputConfig> = std::cell::RefCell::new(InputConfig {rules : vec![]});
+}
+
 #[ic_cdk::query]
 fn get_api_boundary_nodes_count() -> u64 {
     API_BNS_COUNT.load(Ordering::Relaxed)
 }
 
-#[derive(candid::CandidType, candid::Deserialize)]
-pub struct GetApiBoundaryNodeIdsRequest {}
+#[ic_cdk_macros::update]
+fn overwrite_config(config: InputConfig) -> OverwriteConfigResponse {
+    for rule in config.rules.iter() {
+        assert!(serde_json::from_str::<Value>(&rule.rule_raw).is_ok())
+    }
+    CONFIG.with(|p| {
+        *p.borrow_mut() = config;
+    });
+    let result = OverwriteConfigResponse { result: true };
+    result
+}
+
+#[ic_cdk_macros::update]
+fn get_latest_config() -> GetLatestConfigResponse {
+    GetLatestConfigResponse {
+        config: CONFIG.with(|config| config.borrow().clone()),
+    }
+}
 
 #[ic_cdk::init]
 fn init(timer_interval_secs: u64) {

--- a/rs/tests/test_canisters/rate_limiting/src/canister.rs
+++ b/rs/tests/test_canisters/rate_limiting/src/canister.rs
@@ -44,7 +44,7 @@ struct InputRule {
 #[derive(CandidType, candid::Deserialize, Clone)]
 struct OutputRule {
     id: Id,
-    rule_raw: Option<String>,
+    rule_raw: Option<Vec<u8>>,
     description: Option<String>,
 }
 
@@ -78,11 +78,10 @@ fn get_config(version: Option<Version>) -> GetConfigResponse {
         .rules
         .iter()
         .map(|r| {
-            let rule_raw = String::from_utf8(r.rule_raw.clone()).unwrap();
             OutputRule {
                 id: r.id.clone(),
                 description: Some(r.description.clone()),
-                rule_raw: Some(rule_raw),
+                rule_raw: Some(r.rule_raw.clone()),
             }
         })
         .collect();

--- a/rs/tests/test_canisters/rate_limiting/src/canister_mvp.rs
+++ b/rs/tests/test_canisters/rate_limiting/src/canister_mvp.rs
@@ -1,0 +1,316 @@
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+use chrono::Utc;
+
+type Version = u64;
+type Timestamp = u64;
+type Config = Vec<RuleWithMetadata>;
+
+/// Privacy policy of the rate limiting rule.
+#[derive(Clone, Debug, PartialEq, Default)]
+enum Policy {
+    #[default]
+    Public,
+    Private,
+}
+
+/// Version of the rate limiting config and its metadata.
+#[derive(Clone, Default, Debug)]
+struct VersionMetadata {
+    version: Version,
+    active_since: Timestamp,
+    active_till: Option<Timestamp>,
+}
+
+/// Raw rule to be serialized into json/yml and consumed by ic-boundary.
+#[derive(Clone, Default, Debug, Hash, Serialize, Deserialize)]
+struct RuleRaw { /* json_str */
+    canister_id: Option<String>,
+    subnet_id: Option<String>,
+    methods: Vec<String>,
+    request_type: Option<String>,
+    limit: Option<String>,
+}
+
+/// Rate limiting rule with metadata.
+#[derive(Clone, Default, Debug)]
+struct RuleWithMetadata {
+    rule: RuleRaw,
+    rule_hash: String,
+    policy: Policy,
+}
+
+/// Rule representation for response.
+/// Allows to optionally reveal/hide the rule itself, depending on the privacy policy.
+#[derive(Clone, Default, Debug)]
+struct Rule {
+    rule: Option<RuleRaw>,
+    rule_hash: String,
+    policy: Policy,
+}
+
+#[derive(Clone, Default)]
+struct Canister {
+    configs: Vec<(VersionMetadata, Config)>,
+}
+
+#[derive(Debug)]
+struct GetConfigResponse {
+    version: VersionMetadata,
+    config: Vec<Rule>,
+}
+
+#[derive(Debug)]
+struct GetLatestVersionResponse {
+    version: VersionMetadata,
+}
+
+#[derive(Debug)]
+struct GetNLatestVersionsResponse {
+    versions: Vec<VersionMetadata>,
+}
+
+impl Canister {
+    fn new() -> Self {
+        let version = VersionMetadata {
+            version: 1,
+            active_since: Utc::now().timestamp() as Timestamp,
+            active_till: None,
+        };
+        Self {
+            configs: vec![(version, vec![])],
+        }
+    }
+
+    /// Method for auditability/inspection
+    fn get_latest_version(&self) -> GetLatestVersionResponse {
+        GetLatestVersionResponse {
+            version: self.configs.last().unwrap().clone().0,
+        }
+    }
+
+    /// Method for auditability/inspection
+    fn get_n_last_versions(&self, n: usize) -> GetNLatestVersionsResponse {
+        let versions: Vec<VersionMetadata> = self.configs.iter().map(|rule| rule.0.clone()).collect();
+        let start = if n > versions.len() {
+            0
+        } else {
+            versions.len() - n
+        };
+        GetNLatestVersionsResponse {
+            versions: versions[start..].to_vec(),
+        }
+    }
+
+    /// Private method for imposing new rate-limiting config
+    /// Set the new rules and bumps the version.
+    fn overwrite_config(&mut self, config: Vec<(RuleRaw, Policy)>) {
+        let time_now = Utc::now().timestamp() as u64;
+        let (version, _) = self.configs.last_mut().unwrap();
+        version.active_till = Some(time_now);
+
+        let new_config = config
+            .into_iter()
+            .map(|rule| {
+                let mut hasher = Sha256::new();
+                let serialized =
+                    serde_json::to_string(&rule.0).expect("Failed to serialize struct");
+                hasher.update(serialized.as_bytes());
+                let hash_value = hasher.finalize();
+                // Get the resulting hash value
+                RuleWithMetadata {
+                    rule: rule.0,
+                    rule_hash: hex::encode(hash_value),
+                    policy: rule.1,
+                }
+            })
+            .collect();
+
+        let new_version = VersionMetadata {
+            version: version.version + 1,
+            active_since: time_now,
+            active_till: None,
+        };
+
+        self.configs.push((new_version, new_config));
+    }
+
+    /// Method used by:
+    ///  - API boundary nodes for reading the latest rules, serializing them to .yml for ic-boundary
+    ///  - all IC users for auditability/inspection
+    /// Depending on the caller principal and privacy policy returns full or truncated view of the rules.
+    fn get_latest_config(&self, user: &str) -> GetConfigResponse {
+        let (version, rules) = self.configs.last().unwrap();
+
+        let rules: Vec<Rule> = rules
+            .iter()
+            .map(|rule| {
+                let display_rule = if rule.policy == Policy::Private && user != "admin" {
+                    None
+                } else {
+                    Some(rule.rule.clone())
+                };
+                Rule {
+                    rule_hash: rule.rule_hash.clone(),
+                    policy: rule.policy.clone(),
+                    rule: display_rule,
+                }
+            })
+            .collect();
+
+        GetConfigResponse {
+            version: version.clone(),
+            config: rules,
+        }
+    }
+
+    fn get_config_for_version(&self, version: Version) -> GetConfigResponse {
+        let idx = version as usize;
+        let (version, rule) = self.configs[idx - 1].clone();
+
+        let rules: Vec<Rule> = rule
+            .iter()
+            .map(|rule| {
+                let display_rule = if rule.policy == Policy::Private {
+                    None
+                } else {
+                    Some(rule.rule.clone())
+                };
+                Rule {
+                    rule_hash: rule.rule_hash.clone(),
+                    policy: rule.policy.clone(),
+                    rule: display_rule,
+                }
+            })
+            .collect();
+
+        GetConfigResponse { version, config: rules }
+    }
+}
+
+fn main() {
+    // Initialize canister
+    println!("Initializing canister with the first version");
+    let mut canister = Canister::new();
+
+    let version = canister.get_latest_version();
+
+    println!("latest config version {:?}", version);
+
+    let config = canister.get_latest_config("admin");
+    println!("latest config {:?}", config);
+
+    // Add a config with two rules (overwrite config and bump version, can be json_str)
+    let config = vec![
+        (
+            RuleRaw {
+                canister_id: Some("1".to_string()),
+                limit: Some("1req/s".to_string()),
+                request_type: None,
+                subnet_id: None,
+                methods: vec![],
+            },
+            Policy::Private,
+        ),
+        (
+            RuleRaw {
+                canister_id: Some("2".to_string()),
+                limit: Some("1req/s".to_string()),
+                request_type: None,
+                subnet_id: None,
+                methods: vec![],
+            },
+            Policy::Public,
+        ),
+    ];
+
+    println!("overwriting config ...");
+    canister.overwrite_config(config);
+
+    // Check new version and new rules
+    let version = canister.get_latest_version();
+    println!("latest version {:?}", version);
+    let versions = canister.get_n_last_versions(5);
+    println!("last n versions {:#?}", versions);
+    let config = canister.get_latest_config("admin");
+    println!("latest config seen by authorized principal: {:#?}", config);
+    let result = canister.get_latest_config("non_admin");
+    println!("latest config seen by unauthorized principal: {:#?}", result);
+
+    // Overwrite rules
+    let rules = vec![
+        (
+            RuleRaw {
+                canister_id: Some("1".to_string()),
+                limit: Some("1req/s".to_string()),
+                request_type: None,
+                subnet_id: None,
+                methods: vec![],
+            },
+            Policy::Public, // changed from Private to Public
+        ),
+        (
+            RuleRaw {
+                canister_id: Some("2".to_string()),
+                limit: Some("1req/s".to_string()),
+                request_type: None,
+                subnet_id: None,
+                methods: vec![],
+            },
+            Policy::Public, // unchanged
+        ),
+        (
+            RuleRaw {
+                canister_id: Some("3".to_string()),
+                limit: Some("1req/s".to_string()),
+                request_type: None,
+                subnet_id: None,
+                methods: vec![],
+            },
+            Policy::Private, // added new private rule
+        ),
+    ];
+
+    println!("setting new config");
+    canister.overwrite_config(rules);
+
+    // Check new version and rules
+    let version = canister.get_latest_version();
+    println!("latest version {:?}", version);
+    let versions = canister.get_n_last_versions(5);
+    println!("last n versions {:#?}", versions);
+    let config = canister.get_latest_config("admin");
+    println!("latest rules seen by authorized principal are {:#?}", config);
+    let config = canister.get_latest_config("non_admin");
+    println!("latest rules seen by unauthorized principal are {:#?}", config);
+    let config = canister.get_config_for_version(1);
+    println!("config rules for version 1: {:#?}", config);
+    let config = canister.get_config_for_version(2);
+    println!("config rules for version 2: {:#?}", config);
+    let config = canister.get_config_for_version(3);
+    println!("config rules for version 3: {:#?}", config);
+}
+
+// config = [
+//     {
+//         "rule": {
+//             "canister_id": "abcd-1234",
+//             "subnet_id": null,
+//             "methods": null,
+//             "request_type": "call",
+//             "limit": "1req/s"
+//         },
+//         "policy": "Public"
+//     },
+//     {
+//         "rule": {
+//             "canister_id": null,
+//             "subnet_id": "subnet-5678",
+//             "methods": null,
+//             "request_type": "query",
+//             "limit": null
+//         },
+//         "policy": "Private"
+//     }
+// ]

--- a/rs/tests/test_canisters/rate_limiting/src/lib.rs
+++ b/rs/tests/test_canisters/rate_limiting/src/lib.rs
@@ -1,5 +1,2 @@
 #[cfg(target_family = "wasm")]
 pub mod canister;
-
-#[cfg(target_family = "wasm")]
-pub use canister::*;

--- a/rs/tests/test_canisters/rate_limiting/src/lib.rs
+++ b/rs/tests/test_canisters/rate_limiting/src/lib.rs
@@ -1,0 +1,33 @@
+use std::sync::atomic::{AtomicU64, Ordering};
+use serde::{Deserialize, Serialize};
+use candid::{Encode, Principal};
+use ic_cdk::api::call::call;
+use registry_canister::pb::v1::{ApiBoundaryNodeIdRecord, GetApiBoundaryNodeIdsRequest};
+
+static COUNTER: AtomicU64 = AtomicU64::new(0);
+
+#[ic_cdk::query]
+fn counter() -> u64 {
+    COUNTER.load(Ordering::Relaxed)
+}
+
+#[ic_cdk::init]
+fn init(timer_interval_secs: u64) {
+    let interval = std::time::Duration::from_secs(timer_interval_secs);
+    ic_cdk::println!("Starting a periodic task with interval {interval:?}");
+    ic_cdk_timers::set_timer_interval(interval, || {
+        COUNTER.fetch_add(1, Ordering::Relaxed);
+        ic_cdk::spawn(async {
+            let canister_id = Principal::from_text("rwlgt-iiaaa-aaaaa-aaaaa-cai").unwrap();
+            // let args = Encode!(&GetApiBoundaryNodeIdsRequest {}).unwrap();
+            let (result,): (i64,) = call(canister_id, "get_api_boundary_node_ids", ())
+                .await
+                .unwrap();
+        });
+    });
+}
+
+#[ic_cdk::post_upgrade]
+fn post_upgrade(timer_interval_secs: u64) {
+    init(timer_interval_secs)
+}

--- a/rs/tests/test_canisters/rate_limiting/src/lib.rs
+++ b/rs/tests/test_canisters/rate_limiting/src/lib.rs
@@ -1,33 +1,5 @@
-use std::sync::atomic::{AtomicU64, Ordering};
-use serde::{Deserialize, Serialize};
-use candid::{Encode, Principal};
-use ic_cdk::api::call::call;
-use registry_canister::pb::v1::{ApiBoundaryNodeIdRecord, GetApiBoundaryNodeIdsRequest};
+#[cfg(target_family = "wasm")]
+pub mod canister;
 
-static COUNTER: AtomicU64 = AtomicU64::new(0);
-
-#[ic_cdk::query]
-fn counter() -> u64 {
-    COUNTER.load(Ordering::Relaxed)
-}
-
-#[ic_cdk::init]
-fn init(timer_interval_secs: u64) {
-    let interval = std::time::Duration::from_secs(timer_interval_secs);
-    ic_cdk::println!("Starting a periodic task with interval {interval:?}");
-    ic_cdk_timers::set_timer_interval(interval, || {
-        COUNTER.fetch_add(1, Ordering::Relaxed);
-        ic_cdk::spawn(async {
-            let canister_id = Principal::from_text("rwlgt-iiaaa-aaaaa-aaaaa-cai").unwrap();
-            // let args = Encode!(&GetApiBoundaryNodeIdsRequest {}).unwrap();
-            let (result,): (i64,) = call(canister_id, "get_api_boundary_node_ids", ())
-                .await
-                .unwrap();
-        });
-    });
-}
-
-#[ic_cdk::post_upgrade]
-fn post_upgrade(timer_interval_secs: u64) {
-    init(timer_interval_secs)
-}
+#[cfg(target_family = "wasm")]
+pub use canister::*;

--- a/rs/tests/test_canisters/rate_limiting/src/rate_limiting_backend.did
+++ b/rs/tests/test_canisters/rate_limiting/src/rate_limiting_backend.did
@@ -12,6 +12,5 @@ type GetApiBoundaryNodeIdsRequest = record {
 };
 
 service : (nat64) -> {
-    "counter": () -> (nat64) query;
-    get_node_ids : (GetApiBoundaryNodeIdsRequest) -> (GetApiBoundaryNodeIdsResponse) query;
+    get_api_boundary_nodes_count : () -> (nat64) query;
 }

--- a/rs/tests/test_canisters/rate_limiting/src/rate_limiting_backend.did
+++ b/rs/tests/test_canisters/rate_limiting/src/rate_limiting_backend.did
@@ -1,0 +1,17 @@
+type GetApiBoundaryNodeIdsResponse = variant {
+    Ok : vec ApiBoundaryNodeIdRecord;
+    Err : text;
+};
+
+type ApiBoundaryNodeIdRecord = record {
+  id : opt principal;
+};
+
+type GetApiBoundaryNodeIdsRequest = record {
+
+};
+
+service : (nat64) -> {
+    "counter": () -> (nat64) query;
+    get_node_ids : (GetApiBoundaryNodeIdsRequest) -> (GetApiBoundaryNodeIdsResponse) query;
+}

--- a/rs/tests/test_canisters/rate_limiting/src/rate_limiting_backend.did
+++ b/rs/tests/test_canisters/rate_limiting/src/rate_limiting_backend.did
@@ -1,23 +1,35 @@
 type InputRule = record {
   id: text;
-  rule_raw: text;
+  rule_raw: blob;
   description: text;
+};
+
+type OutputRule = record {
+  id: text;
+  rule_raw: opt text;
+  description: opt text;
 };
 
 type InputConfig = record {
   rules: vec InputRule; 
 };
 
+type OutputConfig = record {
+  rules: vec OutputRule; 
+};
+
 type OverwriteConfigResponse = record {
   result: bool;
 };
 
-type GetLatestConfigResponse = record {
-  config: InputConfig
+type GetConfigResponse = record {
+  config: OutputConfig
 };
+
+type Version = nat64;
 
 service : (nat64) -> {
     get_api_boundary_nodes_count : () -> (nat64) query;
     overwrite_config: (InputConfig) -> (OverwriteConfigResponse);
-    get_latest_config: () -> (GetLatestConfigResponse);
+    get_config: (opt Version) -> (GetConfigResponse);
 }

--- a/rs/tests/test_canisters/rate_limiting/src/rate_limiting_backend.did
+++ b/rs/tests/test_canisters/rate_limiting/src/rate_limiting_backend.did
@@ -1,16 +1,23 @@
-type GetApiBoundaryNodeIdsResponse = variant {
-    Ok : vec ApiBoundaryNodeIdRecord;
-    Err : text;
+type InputRule = record {
+  id: text;
+  rule_raw: text;
+  description: text;
 };
 
-type ApiBoundaryNodeIdRecord = record {
-  id : opt principal;
+type InputConfig = record {
+  rules: vec InputRule; 
 };
 
-type GetApiBoundaryNodeIdsRequest = record {
+type OverwriteConfigResponse = record {
+  result: bool;
+};
 
+type GetLatestConfigResponse = record {
+  config: InputConfig
 };
 
 service : (nat64) -> {
     get_api_boundary_nodes_count : () -> (nat64) query;
+    overwrite_config: (InputConfig) -> (OverwriteConfigResponse);
+    get_latest_config: () -> (GetLatestConfigResponse);
 }

--- a/rs/tests/test_canisters/rate_limiting/src/rate_limiting_backend.did
+++ b/rs/tests/test_canisters/rate_limiting/src/rate_limiting_backend.did
@@ -6,7 +6,7 @@ type InputRule = record {
 
 type OutputRule = record {
   id: text;
-  rule_raw: opt text;
+  rule_raw: opt blob;
   description: opt text;
 };
 

--- a/rs/tests/test_canisters/rate_limiting/src/rate_limiting_backend.did
+++ b/rs/tests/test_canisters/rate_limiting/src/rate_limiting_backend.did
@@ -22,8 +22,9 @@ type OutputConfig = record {
   rules: vec OutputRule; 
 };
 
-type OverwriteConfigResponse = record {
-  result: bool;
+type OverwriteConfigResponse = variant {
+  Ok;
+  Err: text;
 };
 
 type ConfigResponse = record {
@@ -37,8 +38,9 @@ type GetConfigResponse = variant {
   Err: text;
 };
 
-type DisclosesRulesResponse = record {
-  result: bool;
+type DisclosesRulesResponse = variant {
+  Ok;
+  Err: text;
 }
 
 service : (nat64) -> {

--- a/rs/tests/test_canisters/rate_limiting/src/rate_limiting_backend.did
+++ b/rs/tests/test_canisters/rate_limiting/src/rate_limiting_backend.did
@@ -1,17 +1,24 @@
 type Version = nat64;
 
+type Timestamp = nat64;
+
 type RuleId = text;
 
+type InitArg = record {
+  registry_polling_period: nat64;
+};
+
 type InputRule = record {
-  id: text;
+  id: RuleId;
   rule_raw: blob;
   description: text;
 };
 
 type OutputRule = record {
-  id: text;
+  id: RuleId;
   rule_raw: opt blob;
   description: opt text;
+  disclosed_at: opt Timestamp;
 };
 
 type InputConfig = record {
@@ -28,8 +35,8 @@ type OverwriteConfigResponse = variant {
 };
 
 type ConfigResponse = record {
-    version: nat64;
-    active_since: nat64;
+    version: Version;
+    active_since: Timestamp;
     config: OutputConfig;
 };
 
@@ -43,7 +50,7 @@ type DisclosesRulesResponse = variant {
   Err: text;
 }
 
-service : (nat64) -> {
+service : (InitArg) -> {
     overwrite_config: (InputConfig) -> (OverwriteConfigResponse);
     get_config: (opt Version) -> (GetConfigResponse);
     disclose_rules: (vec RuleId) -> (DisclosesRulesResponse);

--- a/rs/tests/test_canisters/rate_limiting/src/rate_limiting_backend.did
+++ b/rs/tests/test_canisters/rate_limiting/src/rate_limiting_backend.did
@@ -44,7 +44,6 @@ type DisclosesRulesResponse = variant {
 }
 
 service : (nat64) -> {
-    get_api_boundary_nodes_count : () -> (nat64) query;
     overwrite_config: (InputConfig) -> (OverwriteConfigResponse);
     get_config: (opt Version) -> (GetConfigResponse);
     disclose_rules: (vec RuleId) -> (DisclosesRulesResponse);

--- a/rs/tests/test_canisters/rate_limiting/src/rate_limiting_backend.did
+++ b/rs/tests/test_canisters/rate_limiting/src/rate_limiting_backend.did
@@ -1,3 +1,7 @@
+type Version = nat64;
+
+type RuleId = text;
+
 type InputRule = record {
   id: text;
   rule_raw: blob;
@@ -22,14 +26,24 @@ type OverwriteConfigResponse = record {
   result: bool;
 };
 
-type GetConfigResponse = record {
-  config: OutputConfig
+type ConfigResponse = record {
+    version: nat64;
+    active_since: nat64;
+    config: OutputConfig;
 };
 
-type Version = nat64;
+type GetConfigResponse = variant {
+  Ok: ConfigResponse;
+  Err: text;
+};
+
+type DisclosesRulesResponse = record {
+  result: bool;
+}
 
 service : (nat64) -> {
     get_api_boundary_nodes_count : () -> (nat64) query;
     overwrite_config: (InputConfig) -> (OverwriteConfigResponse);
     get_config: (opt Version) -> (GetConfigResponse);
+    disclose_rules: (vec RuleId) -> (DisclosesRulesResponse);
 }


### PR DESCRIPTION
This is an initial prototype of the future rate-limiting canister. So far this canister has only a single job of periodically quering the registry canister for the existing API boundary nodes.

**How to test**:
- Start a `system-test`. Note: it's better to add a `boundary-node` to the test `setup()`, as this makes canister installation with `dfx` easier:
```
$ ict test //rs/tests/boundary_nodes:api_bn_decentralization_test_head_nns --keepalive
```
- Deploy the canister:
```
$ dfx deploy rate_limiting --network https://ic0.farm.dfinity.systems --no-wallet
```
- Check the API boundary nodes count with either `query` or `update`:
```
$ dfx canister call --network https://ic0.farm.dfinity.systems qsgjb-riaaa-aaaaa-aaaga-cai get_api_boundary_nodes_count --query
(2 : nat64)
```
