### PR TITLE
fix: increase the pool size for idle connections per host

### DIFF
--- a/rs/xnet/payload_builder/src/lib.rs
+++ b/rs/xnet/payload_builder/src/lib.rs
@@ -1566,7 +1566,7 @@ impl XNetClientImpl {
         // TODO(MR-28) Make timeout configurable.
         let http_client: Client<TlsConnector, _> = Client::builder()
             .pool_idle_timeout(Some(Duration::from_secs(600)))
-            .pool_max_idle_per_host(1)
+            .pool_max_idle_per_host(5)
             .executor(ExecuteOnRuntime(runtime_handle))
             .build(
                 #[cfg(not(test))]


### PR DESCRIPTION
Since we detach tokio tasks that perform xnet calls in theory we can have 5-10 concurrent xnet requests between two replicas. Since we use http1, keep connections a bigger pool of idle connections so we don't do TLS handshake per request.