### PR TITLE
chore(ICP-Rosetta): move dependencies to workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -454,6 +454,8 @@ jsonrpc = { git = "https://github.com/apoelstra/rust-jsonrpc", rev = "e42044d" }
 anyhow = "^1"
 arbitrary = { version = "1.3.2", features = ["derive"] }
 arrayvec = "0.7.4"
+actix-web = "4.9.0"
+actix-rt = "2.10.0"
 askama = { version = "0.12.1", features = ["serde-json"] }
 assert_matches = "1.5.0"
 async-recursion = "1.0.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -620,6 +620,7 @@ reqwest = { version = "0.12.7", default-features = false, features = [
     "socks",
     "stream",
 ] }
+rolling-file = "0.2.0"
 rstest = "0.19.0"
 rustls = { version = "0.23.12", default-features = false, features = [
     "ring",

--- a/rs/rosetta-api/Cargo.toml
+++ b/rs/rosetta-api/Cargo.toml
@@ -7,8 +7,8 @@ edition = "2021"
 default-run = "ic-rosetta-api"
 
 [dependencies]
-actix-rt = "2.10.0"
-actix-web = "4.9.0"
+actix-rt = { workspace = true }
+actix-web = { workspace = true }
 anyhow = { workspace = true }
 async-trait = { workspace = true }
 base64 = { workspace = true }

--- a/rs/rosetta-api/Cargo.toml
+++ b/rs/rosetta-api/Cargo.toml
@@ -39,7 +39,7 @@ on_wire = { path = "../rust_canisters/on_wire" }
 prometheus = { workspace = true }
 rand = { workspace = true }
 reqwest = { workspace = true }
-rolling-file = "0.2.0"
+rolling-file = { workspace = true }
 rosetta-core = { path = "rosetta_core" }
 serde = { workspace = true }
 serde_cbor = { workspace = true }


### PR DESCRIPTION
This MR introduces the following chnages:

1. Move ICP Rosetta dependencies to the workspace file. 