### PR TITLE
refactor(nervous_system): Use candid methods in ledger canister client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9508,6 +9508,7 @@ name = "ic-nervous-system-canisters"
 version = "0.9.0"
 dependencies = [
  "async-trait",
+ "candid",
  "dfn_candid",
  "dfn_core",
  "ic-base-types",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9508,8 +9508,8 @@ name = "ic-nervous-system-canisters"
 version = "0.9.0"
 dependencies = [
  "async-trait",
+ "dfn_candid",
  "dfn_core",
- "dfn_protobuf",
  "ic-base-types",
  "ic-ledger-core",
  "ic-nervous-system-common",
@@ -9563,7 +9563,6 @@ dependencies = [
  "by_address",
  "bytes",
  "dfn_core",
- "dfn_protobuf",
  "ic-base-types",
  "ic-canister-log 0.2.0",
  "ic-canisters-http-types",
@@ -9669,7 +9668,6 @@ dependencies = [
  "candid",
  "canister-test",
  "cycles-minting-canister",
- "dfn_protobuf",
  "ic-base-types",
  "ic-crypto-sha2",
  "ic-error-types",

--- a/rs/nervous_system/canisters/BUILD.bazel
+++ b/rs/nervous_system/canisters/BUILD.bazel
@@ -13,6 +13,7 @@ DEPENDENCIES = [
     "//rs/rust_canisters/dfn_candid",
     "//rs/rust_canisters/dfn_core",
     "//rs/types/base_types",
+    "@crate_index//:candid",
 ]
 
 MACRO_DEPENDENCIES = [

--- a/rs/nervous_system/canisters/BUILD.bazel
+++ b/rs/nervous_system/canisters/BUILD.bazel
@@ -12,7 +12,6 @@ DEPENDENCIES = [
     "//rs/rosetta-api/ledger_core",
     "//rs/rust_canisters/dfn_candid",
     "//rs/rust_canisters/dfn_core",
-    "//rs/rust_canisters/dfn_protobuf",
     "//rs/types/base_types",
 ]
 

--- a/rs/nervous_system/canisters/BUILD.bazel
+++ b/rs/nervous_system/canisters/BUILD.bazel
@@ -10,6 +10,7 @@ DEPENDENCIES = [
     "//rs/nns/constants",
     "//rs/rosetta-api/icp_ledger",
     "//rs/rosetta-api/ledger_core",
+    "//rs/rust_canisters/dfn_candid",
     "//rs/rust_canisters/dfn_core",
     "//rs/rust_canisters/dfn_protobuf",
     "//rs/types/base_types",

--- a/rs/nervous_system/canisters/Cargo.toml
+++ b/rs/nervous_system/canisters/Cargo.toml
@@ -14,7 +14,6 @@ path = "src/lib.rs"
 async-trait = { workspace = true }
 dfn_candid = { path = "../../rust_canisters/dfn_candid" }
 dfn_core = { path = "../../rust_canisters/dfn_core" }
-dfn_protobuf = { path = "../../rust_canisters/dfn_protobuf" }
 ic-base-types = { path = "../../types/base_types" }
 ic-ledger-core = { path = "../../rosetta-api/ledger_core" }
 ic-nervous-system-common = { path = "../common" }

--- a/rs/nervous_system/canisters/Cargo.toml
+++ b/rs/nervous_system/canisters/Cargo.toml
@@ -12,6 +12,7 @@ path = "src/lib.rs"
 
 [dependencies]
 async-trait = { workspace = true }
+candid = { workspace = true }
 dfn_candid = { path = "../../rust_canisters/dfn_candid" }
 dfn_core = { path = "../../rust_canisters/dfn_core" }
 ic-base-types = { path = "../../types/base_types" }

--- a/rs/nervous_system/canisters/Cargo.toml
+++ b/rs/nervous_system/canisters/Cargo.toml
@@ -12,6 +12,7 @@ path = "src/lib.rs"
 
 [dependencies]
 async-trait = { workspace = true }
+dfn_candid = { path = "../../rust_canisters/dfn_candid" }
 dfn_core = { path = "../../rust_canisters/dfn_core" }
 dfn_protobuf = { path = "../../rust_canisters/dfn_protobuf" }
 ic-base-types = { path = "../../types/base_types" }

--- a/rs/nervous_system/canisters/src/ledger.rs
+++ b/rs/nervous_system/canisters/src/ledger.rs
@@ -104,7 +104,7 @@ impl IcpLedger for IcpLedgerCanister {
         let result: Result<Tokens, (Option<i32>, String)> =
             call(self.id, "icrc1_total_supply", candid_one, ())
                 .await
-                .map(|e8s| Tokens::from_e8s(e8s));
+                .map(Tokens::from_e8s);
 
         result.map_err(|(code, msg)| {
             NervousSystemError::new_with_message(

--- a/rs/nervous_system/canisters/src/ledger.rs
+++ b/rs/nervous_system/canisters/src/ledger.rs
@@ -94,7 +94,7 @@ impl IcpLedger for IcpLedgerCanister {
 
         result.map_err(|(code, msg)| {
             NervousSystemError::new_with_message(format!(
-                "Error calling method 'send' of the ledger canister. Code: {:?}. Message: {}",
+                "Error calling method 'transfer' of the ledger canister. Code: {:?}. Message: {}",
                 code, msg
             ))
         })
@@ -109,7 +109,7 @@ impl IcpLedger for IcpLedgerCanister {
         result.map_err(|(code, msg)| {
             NervousSystemError::new_with_message(
                 format!(
-                    "Error calling method 'total_supply' of the ledger canister. Code: {:?}. Message: {}",
+                    "Error calling method 'icrc1_total_supply' of the ledger canister. Code: {:?}. Message: {}",
                     code, msg
                 )
             )
@@ -133,7 +133,7 @@ impl IcpLedger for IcpLedgerCanister {
         result.map_err(|(code, msg)| {
             NervousSystemError::new_with_message(
                 format!(
-                    "Error calling method 'account_balance_pb' of the ledger canister. Code: {:?}. Message: {}",
+                    "Error calling method 'account_balance' of the ledger canister. Code: {:?}. Message: {}",
                     code, msg
                 )
             )

--- a/rs/nervous_system/canisters/src/ledger.rs
+++ b/rs/nervous_system/canisters/src/ledger.rs
@@ -1,4 +1,5 @@
 use async_trait::async_trait;
+use candid::Nat;
 use dfn_candid::candid_one;
 use dfn_core::{call, CanisterId};
 use ic_ledger_core::block::BlockIndex;
@@ -110,7 +111,10 @@ impl IcpLedger for IcpLedgerCanister {
         let result: Result<Tokens, (Option<i32>, String)> =
             call(self.id, "icrc1_total_supply", candid_one, ())
                 .await
-                .map(Tokens::from_e8s);
+                .map(|e8s: Nat| {
+                    Tokens::try_from(e8s)
+                        .expect("Should always succeed, as ICP ledger internally stores u64")
+                });
 
         result.map_err(|(code, msg)| {
             NervousSystemError::new_with_message(

--- a/rs/nervous_system/canisters/src/ledger.rs
+++ b/rs/nervous_system/canisters/src/ledger.rs
@@ -128,8 +128,7 @@ impl IcpLedger for IcpLedgerCanister {
                 account: account.to_address(),
             },
         )
-        .await
-        .map(|e8s| Tokens::from_e8s(e8s));
+        .await;
 
         result.map_err(|(code, msg)| {
             NervousSystemError::new_with_message(

--- a/rs/nervous_system/common/BUILD.bazel
+++ b/rs/nervous_system/common/BUILD.bazel
@@ -13,7 +13,6 @@ DEPENDENCIES = [
     "//rs/rosetta-api/ledger_core",
     "//rs/rust_canisters/canister_log",
     "//rs/rust_canisters/dfn_core",
-    "//rs/rust_canisters/dfn_protobuf",
     "//rs/rust_canisters/http_types",
     "//rs/types/base_types",
     "@crate_index//:base64",

--- a/rs/nervous_system/common/Cargo.toml
+++ b/rs/nervous_system/common/Cargo.toml
@@ -18,7 +18,6 @@ bytes = { workspace = true }
 by_address = "1.1.0"
 async-trait = { workspace = true }
 dfn_core = { path = "../../rust_canisters/dfn_core" }
-dfn_protobuf = { path = "../../rust_canisters/dfn_protobuf" }
 ic-base-types = { path = "../../types/base_types" }
 ic-canister-log = { path = "../../rust_canisters/canister_log" }
 ic-canisters-http-types = { path = "../../rust_canisters/http_types" }

--- a/rs/nervous_system/integration_tests/Cargo.toml
+++ b/rs/nervous_system/integration_tests/Cargo.toml
@@ -11,7 +11,6 @@ documentation.workspace = true
 assert_matches = { workspace = true }
 candid = { workspace = true }
 cycles-minting-canister = { path = "../../nns/cmc" }
-dfn_protobuf = { path = "../../rust_canisters/dfn_protobuf" }
 ic-base-types = { path = "../../types/base_types" }
 ic-ledger-core = { path = "../../rosetta-api/ledger_core" }
 ic-nervous-system-clients = { path = "../clients" }

--- a/rs/nns/test_utils/src/sns_wasm.rs
+++ b/rs/nns/test_utils/src/sns_wasm.rs
@@ -123,7 +123,8 @@ pub fn add_wasm_via_proposal(env: &StateMachine, wasm: SnsWasm) -> SnsWasm {
     let proposal_id = ProposalId(wasm.proposal_id.unwrap());
 
     while get_proposal_info(env, proposal_id).unwrap().status == (ProposalStatus::Open as i32) {
-        std::thread::sleep(Duration::from_millis(100));
+        env.tick();
+        env.advance_time(Duration::from_millis(100));
     }
 
     wasm
@@ -239,7 +240,8 @@ pub fn update_sns_subnet_list_via_proposal(
     let pid = make_proposal_with_test_neuron_1(env, proposal);
 
     while get_proposal_info(env, pid).unwrap().status == (ProposalStatus::Open as i32) {
-        std::thread::sleep(Duration::from_millis(100));
+        env.tick();
+        env.advance_time(Duration::from_millis(100));
     }
 }
 
@@ -391,7 +393,8 @@ pub fn wait_for_proposal_status(
         if is_status_achieved(status) {
             return;
         }
-        std::thread::sleep(Duration::from_millis(100));
+        machine.tick();
+        machine.advance_time(Duration::from_secs(1));
     }
     panic!("Proposal {} never exited the Open state.", proposal_id);
 }
@@ -410,11 +413,11 @@ pub fn add_freshly_built_sns_wasms(
     for (sns_canister_type, (proposal_id, sns_wasm)) in
         add_freshly_built_sns_wasms_and_return_immediately(machine, filter_wasm)
     {
-        fn is_not_open(status: i32) -> bool {
-            status != ProposalStatus::Open as i32
+        fn is_executed(status: i32) -> bool {
+            status == ProposalStatus::Executed as i32
         }
         let timeout = Duration::from_secs(120);
-        wait_for_proposal_status(machine, proposal_id, is_not_open, timeout);
+        wait_for_proposal_status(machine, proposal_id, is_executed, timeout);
 
         result.insert(sns_canister_type, sns_wasm);
     }

--- a/rs/rust_canisters/dfn_candid/BUILD.bazel
+++ b/rs/rust_canisters/dfn_candid/BUILD.bazel
@@ -4,6 +4,7 @@ load("//bazel:defs.bzl", "rust_ic_test")
 
 package(default_visibility = [
     # Keep sorted.
+    "//rs/nervous_system/canisters:__pkg__",
     "//rs/nervous_system/clients:__pkg__",
     "//rs/nervous_system/common:__subpackages__",
     "//rs/nervous_system/runtime:__pkg__",


### PR DESCRIPTION
In order to prepare to switch from dfn_core to ic_cdk, we need to use candid compatible methods.  This step temporarily makes more use of dfn_candid to allow us to migrate from dfn_protobuf.  It will be followed up by using the Runtime trait, and then a switch from DfnRuntime to CdkRuntime.