### PR TITLE
refactor(nervous_system): use Runtime trait for Ledger

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9509,7 +9509,6 @@ version = "0.9.0"
 dependencies = [
  "async-trait",
  "candid",
- "dfn_candid",
  "dfn_core",
  "ic-base-types",
  "ic-ledger-core",

--- a/rs/nervous_system/canisters/BUILD.bazel
+++ b/rs/nervous_system/canisters/BUILD.bazel
@@ -10,7 +10,6 @@ DEPENDENCIES = [
     "//rs/nns/constants",
     "//rs/rosetta-api/icp_ledger",
     "//rs/rosetta-api/ledger_core",
-    "//rs/rust_canisters/dfn_candid",
     "//rs/rust_canisters/dfn_core",
     "//rs/types/base_types",
     "@crate_index//:candid",

--- a/rs/nervous_system/canisters/Cargo.toml
+++ b/rs/nervous_system/canisters/Cargo.toml
@@ -13,7 +13,6 @@ path = "src/lib.rs"
 [dependencies]
 async-trait = { workspace = true }
 candid = { workspace = true }
-dfn_candid = { path = "../../rust_canisters/dfn_candid" }
 dfn_core = { path = "../../rust_canisters/dfn_core" }
 ic-base-types = { path = "../../types/base_types" }
 ic-ledger-core = { path = "../../rosetta-api/ledger_core" }

--- a/rs/nervous_system/runtime/src/lib.rs
+++ b/rs/nervous_system/runtime/src/lib.rs
@@ -6,7 +6,7 @@ use std::future::Future;
 // A trait to help parameterize the switch from dfn_core to ic_cdk. It should
 // no longer exist after the switch is completed for all NNS/SNS canisters.
 #[async_trait]
-pub trait Runtime {
+pub trait Runtime: Send + Sync {
     // Invokes a Candid `method` on another canister identified by `id`.
     // Whether cleanup is done (call drop() on local variables in the context
     // upon a trap in its callback) depends on the specific Runtime

--- a/rs/nns/governance/canister/canister.rs
+++ b/rs/nns/governance/canister/canister.rs
@@ -342,7 +342,7 @@ fn canister_init_(init_payload: ApiGovernanceProto) {
     set_governance(Governance::new(
         InternalGovernanceProto::from(init_payload),
         Box::new(CanisterEnv::new()),
-        Box::new(IcpLedgerCanister::new(LEDGER_CANISTER_ID)),
+        Box::new(IcpLedgerCanister::<DfnRuntime>::new(LEDGER_CANISTER_ID)),
         Box::new(CMCCanister::<DfnRuntime>::new()),
     ));
 }
@@ -385,7 +385,7 @@ fn canister_post_upgrade() {
     set_governance(Governance::new_restored(
         restored_state,
         Box::new(CanisterEnv::new()),
-        Box::new(IcpLedgerCanister::new(LEDGER_CANISTER_ID)),
+        Box::new(IcpLedgerCanister::<DfnRuntime>::new(LEDGER_CANISTER_ID)),
         Box::new(CMCCanister::<DfnRuntime>::new()),
     ));
 

--- a/rs/rust_canisters/dfn_candid/BUILD.bazel
+++ b/rs/rust_canisters/dfn_candid/BUILD.bazel
@@ -4,7 +4,6 @@ load("//bazel:defs.bzl", "rust_ic_test")
 
 package(default_visibility = [
     # Keep sorted.
-    "//rs/nervous_system/canisters:__pkg__",
     "//rs/nervous_system/clients:__pkg__",
     "//rs/nervous_system/common:__subpackages__",
     "//rs/nervous_system/runtime:__pkg__",

--- a/rs/sns/governance/canister/canister.rs
+++ b/rs/sns/governance/canister/canister.rs
@@ -21,8 +21,9 @@ use ic_canister_log::log;
 use ic_canister_profiler::{measure_span, measure_span_async};
 use ic_canisters_http_types::{HttpRequest, HttpResponse, HttpResponseBuilder};
 use ic_nervous_system_canisters::{cmc::CMCCanister, ledger::IcpLedgerCanister};
-use ic_nervous_system_clients::canister_status::CanisterStatusResultV2;
-use ic_nervous_system_clients::ledger_client::LedgerCanister;
+use ic_nervous_system_clients::{
+    canister_status::CanisterStatusResultV2, ledger_client::LedgerCanister,
+};
 use ic_nervous_system_common::{
     dfn_core_stable_mem_utils::{BufferedStableMemReader, BufferedStableMemWriter},
     serve_logs, serve_logs_v2, serve_metrics,
@@ -222,7 +223,7 @@ fn canister_init_(init_payload: GovernanceProto) {
             init_payload,
             Box::new(CanisterEnv::new()),
             Box::new(LedgerCanister::new(ledger_canister_id)),
-            Box::new(IcpLedgerCanister::new(NNS_LEDGER_CANISTER_ID)),
+            Box::new(IcpLedgerCanister::<DfnRuntime>::new(NNS_LEDGER_CANISTER_ID)),
             Box::new(CMCCanister::<DfnRuntime>::new()),
         ));
     }

--- a/rs/sns/swap/canister/canister.rs
+++ b/rs/sns/swap/canister/canister.rs
@@ -355,8 +355,8 @@ fn now_seconds() -> u64 {
 /// Returns a real ledger stub that communicates with the specified
 /// canister, which is assumed to be the ICP production ledger or a
 /// canister that implements that same interface.
-fn create_real_icp_ledger(id: CanisterId) -> IcpLedgerCanister {
-    IcpLedgerCanister::new(id)
+fn create_real_icp_ledger(id: CanisterId) -> IcpLedgerCanister<DfnRuntime> {
+    IcpLedgerCanister::<DfnRuntime>::new(id)
 }
 
 #[export_name = "canister_init"]

--- a/rs/sns/swap/src/types.rs
+++ b/rs/sns/swap/src/types.rs
@@ -19,6 +19,7 @@ use ic_canister_log::log;
 use ic_ledger_core::Tokens;
 use ic_nervous_system_common::{ledger::ICRC1Ledger, ONE_DAY_SECONDS};
 use ic_nervous_system_proto::pb::v1::Principals;
+use ic_nervous_system_runtime::{DfnRuntime, Runtime};
 use ic_sns_governance::pb::v1::{ClaimedSwapNeuronStatus, NeuronId};
 use icrc_ledger_types::icrc1::account::{Account, Subaccount};
 use std::str::FromStr;
@@ -161,7 +162,7 @@ impl Init {
             let icp_ledger_canister_id = self
                 .icp_ledger()
                 .map_err(|s| format!("unable to get icp ledger canister id: {s}"))?;
-            IcpLedgerCanister::new(icp_ledger_canister_id)
+            IcpLedgerCanister::<DfnRuntime>::new(icp_ledger_canister_id)
         };
 
         let sns_ledger = {

--- a/rs/sns/swap/src/types.rs
+++ b/rs/sns/swap/src/types.rs
@@ -19,7 +19,7 @@ use ic_canister_log::log;
 use ic_ledger_core::Tokens;
 use ic_nervous_system_common::{ledger::ICRC1Ledger, ONE_DAY_SECONDS};
 use ic_nervous_system_proto::pb::v1::Principals;
-use ic_nervous_system_runtime::{DfnRuntime, Runtime};
+use ic_nervous_system_runtime::DfnRuntime;
 use ic_sns_governance::pb::v1::{ClaimedSwapNeuronStatus, NeuronId};
 use icrc_ledger_types::icrc1::account::{Account, Subaccount};
 use std::str::FromStr;


### PR DESCRIPTION
This migrates the ledger canister client to use the Runtime trait instead of directly calling out to dfn_core.

This is the second step in the series to migrate nns governance to ic_cdk from dfn_core