### PR TITLE
chore(PocketIC): improved error message when failed to start PocketIC

### DIFF
--- a/packages/pocket-ic/src/lib.rs
+++ b/packages/pocket-ic/src/lib.rs
@@ -1295,27 +1295,33 @@ pub fn start_or_reuse_server() -> Url {
             .unwrap_or_else(|_| panic!("Invalid string path for {path:?}")),
     };
 
-    if !Path::new(&bin_path).exists() {
+    if !Path::new(&bin_path).is_file() {
+        let is_dir = if Path::new(&bin_path).is_dir() {
+            " (this is a directory, but it should be a binary file)"
+        } else {
+            ""
+        };
         panic!("
 Could not find the PocketIC binary.
 
-The PocketIC binary could not be found at {:?}. Please specify the path to the binary with the POCKET_IC_BIN environment variable, \
+The PocketIC binary could not be found at {:?}{}. Please specify the path to the binary with the POCKET_IC_BIN environment variable, \
 or place it in your current working directory (you are running PocketIC from {:?}).
 
 To download the binary, please visit https://github.com/dfinity/pocketic."
-, &bin_path, &std::env::current_dir().map(|x| x.display().to_string()).unwrap_or_else(|_| "an unknown directory".to_string()));
+, &bin_path, is_dir, &std::env::current_dir().map(|x| x.display().to_string()).unwrap_or_else(|_| "an unknown directory".to_string()));
     }
 
     // Use the parent process ID to find the PocketIC server port for this `cargo test` run.
     let parent_pid = std::os::unix::process::parent_id();
     let port_file_path = std::env::temp_dir().join(format!("pocket_ic_{}.port", parent_pid));
-    let mut cmd = Command::new(PathBuf::from(bin_path));
+    let mut cmd = Command::new(PathBuf::from(bin_path.clone()));
     cmd.arg("--pid").arg(parent_pid.to_string());
     if std::env::var("POCKET_IC_MUTE_SERVER").is_ok() {
         cmd.stdout(std::process::Stdio::null());
         cmd.stderr(std::process::Stdio::null());
     }
-    cmd.spawn().expect("Failed to start PocketIC binary");
+    cmd.spawn()
+        .unwrap_or_else(|_| panic!("Failed to start PocketIC binary ({})", bin_path));
 
     loop {
         if let Ok(port_string) = std::fs::read_to_string(port_file_path.clone()) {


### PR DESCRIPTION
This PR improves the error message when the PocketIC library fails to start the PocketIC server:
- it explicitly mentions that the specified binary is actually a directory (if applicable),
- it prints the binary path if the library fails to start the binary.