### PR TITLE
chore(PocketIC): change additional_responses type in MockCanisterHttpResponse

### DIFF
--- a/packages/pocket-ic/HOWTO.md
+++ b/packages/pocket-ic/HOWTO.md
@@ -279,6 +279,7 @@ fn test_canister_http() {
             headers: vec![],
             body: body.clone(),
         }),
+        additional_responses: vec![],
     };
     pic.mock_canister_http_response(mock_canister_http_response);
 

--- a/packages/pocket-ic/src/common/rest.rs
+++ b/packages/pocket-ic/src/common/rest.rs
@@ -861,7 +861,7 @@ pub struct RawMockCanisterHttpResponse {
     pub subnet_id: RawSubnetId,
     pub request_id: u64,
     pub response: CanisterHttpResponse,
-    pub additional_responses: Option<Vec<CanisterHttpResponse>>,
+    pub additional_responses: Vec<CanisterHttpResponse>,
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug, Hash, Eq, PartialEq, Ord, PartialOrd)]
@@ -869,7 +869,7 @@ pub struct MockCanisterHttpResponse {
     pub subnet_id: Principal,
     pub request_id: u64,
     pub response: CanisterHttpResponse,
-    pub additional_responses: Option<Vec<CanisterHttpResponse>>,
+    pub additional_responses: Vec<CanisterHttpResponse>,
 }
 
 impl From<RawMockCanisterHttpResponse> for MockCanisterHttpResponse {

--- a/packages/pocket-ic/tests/tests.rs
+++ b/packages/pocket-ic/tests/tests.rs
@@ -1316,7 +1316,7 @@ fn test_canister_http() {
             headers: vec![],
             body: body.clone(),
         }),
-        additional_responses: None,
+        additional_responses: vec![],
     };
     pic.mock_canister_http_response(mock_canister_http_response);
 
@@ -1378,7 +1378,7 @@ fn test_canister_http_with_transform() {
             headers: vec![],
             body: body.clone(),
         }),
-        additional_responses: None,
+        additional_responses: vec![],
     };
     pic.mock_canister_http_response(mock_canister_http_response);
 
@@ -1444,7 +1444,7 @@ fn test_canister_http_with_diverging_responses() {
         subnet_id: canister_http_request.subnet_id,
         request_id: canister_http_request.request_id,
         response: response(0),
-        additional_responses: Some((1..13).map(response).collect()),
+        additional_responses: (1..13).map(response).collect(),
     };
     pic.mock_canister_http_response(mock_canister_http_response);
 
@@ -1508,13 +1508,11 @@ fn test_canister_http_with_one_additional_response() {
             headers: vec![],
             body: body.clone(),
         }),
-        additional_responses: Some(vec![CanisterHttpResponse::CanisterHttpReply(
-            CanisterHttpReply {
-                status: 200,
-                headers: vec![],
-                body: body.clone(),
-            },
-        )]),
+        additional_responses: vec![CanisterHttpResponse::CanisterHttpReply(CanisterHttpReply {
+            status: 200,
+            headers: vec![],
+            body: body.clone(),
+        })],
     };
     pic.mock_canister_http_response(mock_canister_http_response);
 }

--- a/rs/bitcoin/kyt/tests/tests.rs
+++ b/rs/bitcoin/kyt/tests/tests.rs
@@ -130,7 +130,7 @@ fn test_get_inputs() {
 \x56\x61\x33\x88\xac\x14\xa4\x0c\x00"
                 .to_vec(),
         }),
-        additional_responses: None,
+        additional_responses: vec![],
     });
 
     let canister_http_requests = tick_until_next_request(&env);
@@ -153,7 +153,7 @@ fn test_get_inputs() {
 \x56\x61\x33\x88\xac\xb3\xa3\x0c\x00"
                 .to_vec(),
         }),
-        additional_responses: None,
+        additional_responses: vec![],
     });
 
     let result = env

--- a/rs/pocket_ic_server/CHANGELOG.md
+++ b/rs/pocket_ic_server/CHANGELOG.md
@@ -25,8 +25,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ECDSA support (IC mainnet-like): there are three ECDSA keys with names `dfx_test_key1`, `test_key_1`, and `key_1` on the II and fiduciary subnet.
 - tSchnorr support (IC mainnet-like): there are three Schnorr keys with names `dfx_test_key1`, `test_key_1`, and `key_1` and algorithm BIP340 as well as three Schnorr keys with names `dfx_test_key1`, `test_key_1`, and `key_1` and algorithm Ed25519 on the II and fiduciary subnet. The messages to sign with tSchnorr must be of length 32 bytes.
 - New endpoint `/_/dashboard` of the PocketIC HTTP gateway returning the dashboard of the underlying PocketIC instance or replica.
-- The argument of the endpoint `/instances/<instance_id>/mock_canister_http_response` takes an additional optional field `additional_responses` to mock additional responses for a pending canister HTTP outcall;
-  if provided, the total number of responses (one plus the number of additional responses) must be equal to the size of the subnet on which the canister making the HTTP outcall is deployed.
+- The argument of the endpoint `/instances/<instance_id>/mock_canister_http_response` takes an additional field `additional_responses` to mock additional responses for a pending canister HTTP outcall;
+  if non-empty, the total number of responses (one plus the number of additional responses) must be equal to the size of the subnet on which the canister making the HTTP outcall is deployed.
 
 ### Changed
 - The argument `listen_at` of the endpoint `/http_gateway` has been renamed to `port`.

--- a/rs/pocket_ic_server/src/pocket_ic.rs
+++ b/rs/pocket_ic_server/src/pocket_ic.rs
@@ -1120,15 +1120,15 @@ fn process_mock_canister_https_response(
         }
     };
     let content = response_to_content(&mock_canister_http_response.response);
-    let mut contents: Vec<_> =
-        if let Some(ref additional_responses) = &mock_canister_http_response.additional_responses {
-            additional_responses
-                .iter()
-                .map(response_to_content)
-                .collect()
-        } else {
-            vec![content.clone(); subnet.nodes.len() - 1]
-        };
+    let mut contents: Vec<_> = if !mock_canister_http_response.additional_responses.is_empty() {
+        mock_canister_http_response
+            .additional_responses
+            .iter()
+            .map(response_to_content)
+            .collect()
+    } else {
+        vec![content.clone(); subnet.nodes.len() - 1]
+    };
     contents.push(content);
     if contents.len() != subnet.nodes.len() {
         return OpOut::Error(PocketIcError::InvalidMockCanisterHttpResponses((

--- a/rs/pocket_ic_server/src/state_api/state.rs
+++ b/rs/pocket_ic_server/src/state_api/state.rs
@@ -1123,7 +1123,7 @@ impl ApiState {
                 subnet_id,
                 request_id,
                 response,
-                additional_responses: None,
+                additional_responses: vec![],
             };
             mock_canister_http_responses.push(mock_canister_http_response);
         }


### PR DESCRIPTION
This PR changes the type of the `additional_responses` field in `MockCanisterHttpResponse` from `Option<Vec<_>>` to `Vec<_>` since an empty vector can be easily provided instead of `None`.