### PR TITLE
fix: adding backup if there are no active rollouts from the rollout dashboard

### DIFF
--- a/.github/scripts/determine-initial-guest-os-versions.py
+++ b/.github/scripts/determine-initial-guest-os-versions.py
@@ -185,7 +185,7 @@ def main():
         raise RuntimeError(f"Didn't find any versions from:\n\t1. {ROLLOUT_DASHBOARD_ENDPOINT}\n\t2. {PUBLIC_DASHBOARD_ENDPOINT}")
     eprint(f"Will qualify, starting from versions: {json.dumps(unique_versions)}")
     matrix = {
-        "versions": unique_versions
+        "version": unique_versions
     }
     print(json.dumps(matrix))
 

--- a/.github/scripts/determine-initial-guest-os-versions.py
+++ b/.github/scripts/determine-initial-guest-os-versions.py
@@ -1,0 +1,148 @@
+import json
+from typing_extensions import Any
+from urllib.request import Request, urlopen
+import urllib.error
+import sys
+
+ROLLOUT_DASHBOARD_ENDPOINT='https://rollout-dashboard.ch1-rel1.dfinity.network/api/v1/rollouts'
+PUBLIC_DASHBOARD_ENDPOINT='https://ic-api.internetcomputer.org/api/v3/subnets?format=json'
+
+# Key definitions
+STATE = 'state'
+FAILED = 'failed'
+COMPLETE = 'complete'
+BATCHES = 'batches'
+SUBNETS = 'subnets'
+GIT_REVISION = 'git_revision'
+EXECUTED_TIMESTAMP_SECONDS = 'executed_timestamp_seconds'
+REPLICA_VERSIONS = 'replica_versions'
+REPLICA_VERSION_ID = 'replica_version_id'
+
+def eprint(*args, **kwargs):
+    print(*args, file=sys.stderr, **kwargs)
+
+def maybe_fetch_data(url : str, timeout : float) -> str | None:
+    """Try fetch data from `url`.
+
+    Will try to fetch data and return `None` if the resource is unavailable for some.
+    If this call fails other resources should be considered.
+    """
+    try:
+        req = Request(url)
+        req.add_header('accept', '*/*')
+        req.add_header('user-agent', 'dfinity-ci')
+        with urlopen(req, timeout=timeout) as response:
+            encoding = response.headers.get_content_charset('utf-8')
+            body = response.read()
+            return body.decode(encoding)
+    except (urllib.error.URLError, urllib.error.HTTPError, TimeoutError) as e:
+        eprint(f"Error fetching data from {url}: {e}")
+        return None
+
+def ensure_json_response(url : str, timeout : float = 10) -> Any | None:
+    response = maybe_fetch_data(url, timeout)
+    if response is None:
+        # Resource was unavailable, if there are
+        # other options they should be considered
+        # at this point
+        return None
+
+    try:
+        return json.loads(response)
+    except (json.JSONDecodeError) as e:
+        # The resource returned some response but it wasn't json.
+        # This error should not be retried and should panic because it was
+        # likely an API change and requires investigation.
+        eprint(f"Received error when decoding the response from {url}: {e}")
+        eprint(f"Response was:\n{response}")
+        exit(1)
+
+def fetch_versions_from_rollout_dashboard() -> list[str] | None:
+    """Fetch data from rollout dashboard
+
+    Panics if the parsed data is not in the expected format.
+    Returns an empty list if the action is retriable.
+    """
+    data = ensure_json_response(ROLLOUT_DASHBOARD_ENDPOINT)
+    if data is None:
+        # Resource was unavailable
+        return []
+
+    versions = set()
+    try:
+        for rollout in data:
+            if rollout.get(STATE, None) is None:
+                raise Exception(f"Expected '{STATE}' in 'rollout'")
+            if rollout.get(STATE) in [FAILED, COMPLETE]:
+                continue
+            if rollout.get(BATCHES, None) is None:
+                raise Exception(f"Expected '{BATCHES}' in 'rollout'")
+            for batch in rollout.get(BATCHES).values():
+                if batch.get(SUBNETS, None) is None:
+                    raise Exception(f"Expected '{SUBNETS}' in 'batch'")
+                for subnet in batch.get(SUBNETS):
+                    if subnet.get(GIT_REVISION, None) is None:
+                        raise Exception(f"Expected '{GIT_REVISION}' in 'subnet'")
+                    versions.add(subnet.get(GIT_REVISION))
+    except Exception as e:
+        # Rollout dashboard returned json but the format changed. Likely an
+        # API change that is not retriable and requires investigation.
+        eprint(f"Error while parsing response from {ROLLOUT_DASHBOARD_ENDPOINT}: {e}")
+        eprint(f"Json response received:\n{data}")
+        exit(1)
+    return list(versions)
+
+def maybe_exectued_timestamp(x : Any) -> int:
+    if x.get(EXECUTED_TIMESTAMP_SECONDS, None) is None:
+        raise Exception(f"Expected '{EXECUTED_TIMESTAMP_SECONDS}' in 'replica_version'")
+    return int(x.get(EXECUTED_TIMESTAMP_SECONDS))
+
+def fetch_versions_from_public_dashboard() -> list[str] | None:
+    """Fetch data from public dashboard
+
+    Panics if the parsed data is not in the expected format.
+    Returns an empty list if the action is retriable.
+    """
+    data = ensure_json_response(PUBLIC_DASHBOARD_ENDPOINT)
+    if data is None:
+        # Resource was unavailable
+        return []
+
+    versions = set()
+    try:
+        if data.get(SUBNETS, None) is None:
+            raise Exception(f"Expected '{SUBNETS}' in response")
+        subnets = data.get(SUBNETS)
+        for subnet in subnets:
+            if subnet.get(REPLICA_VERSIONS, None) is None:
+                raise Exception(f"Expected '{REPLICA_VERSIONS}' in 'subnet'")
+            replica_versions = subnet.get(REPLICA_VERSIONS)
+            replica_version = sorted(replica_versions, key=maybe_exectued_timestamp, reverse=True)[0]
+            if replica_version.get(REPLICA_VERSION_ID, None) is None:
+                raise Exception(f"Expected '{REPLICA_VERSION_ID}' in 'replica_version'")
+            versions.add(replica_version.get(REPLICA_VERSION_ID))
+    except Exception as e:
+        # Public dashboard returned json but the format changed. Likely an
+        # API change that is not retriable and requires investigation.
+        eprint(f"Error while parsing response from {PUBLIC_DASHBOARD_ENDPOINT}: {e}")
+        eprint(f"Json response received:\n{data}")
+        exit(1)
+    return list(versions)
+
+def main():
+    unique_versions = fetch_versions_from_rollout_dashboard()
+    if not unique_versions:
+        eprint("No active rollouts found, will use versions from public dashboard")
+        unique_versions = fetch_versions_from_public_dashboard()
+
+    if not unique_versions:
+        # At this moment if we don't have any starting version we cannot proceed
+        raise Exception(f"Didn't find any versions from:\n\t1. {ROLLOUT_DASHBOARD_ENDPOINT}\n\t2. {PUBLIC_DASHBOARD_ENDPOINT}")
+    eprint(f"Will qualify, starting from versions: {json.dumps(unique_versions)}")
+    matrix = {
+        "versions": unique_versions
+    }
+    print(json.dumps(matrix))
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/determine-initial-guest-os-versions.py
+++ b/.github/scripts/determine-initial-guest-os-versions.py
@@ -98,6 +98,12 @@ def fetch_versions_from_rollout_dashboard() -> list[str] | None:
             for subnet in batch["subnets"]:
                 if subnet["state"] in (SubnetRolloutState.error, SubnetRolloutState.predecessor_failed):
                     # This subnet failed?  We ignore it, because it could not have been upgraded.
+                    # There is a minor corner case where the subnet may be in error (not predecessor_failed)
+                    # but a proposal has been filed *and* approved, which means the subnet is in fact
+                    # already carrying the git revision stated by the subnet object.
+                    # We could expose the proposal number and its state in the rollout dashboard API
+                    # (this information is stored by Airflow and known to it) to settle this uncertainty,
+                    # but I'm not sure it's worth the effort.
                     eprint_fmt(
                         "Version %s targeting subnet %s in rollout %s is %s, disregarding",
                         subnet["git_revision"],

--- a/.github/scripts/determine-initial-guest-os-versions.py
+++ b/.github/scripts/determine-initial-guest-os-versions.py
@@ -126,7 +126,7 @@ def fetch_versions_from_rollout_dashboard(): # type: () -> list[str] | None
     # finish date for the revision.  Let's fish the latest
     # revision for each subnet, and get that.
     return list(set([
-        list(sorted(datestring_revision_tuple))[-1][1]
+        [revision for unused_date, revision in sorted(datestring_revision_tuple)][-1]
         for datestring_revision_tuple in subnet_to_revision.values()
     ]))
 

--- a/.github/scripts/determine-initial-guest-os-versions.py
+++ b/.github/scripts/determine-initial-guest-os-versions.py
@@ -1,8 +1,9 @@
 import json
-from typing_extensions import Any
-from urllib.request import Request, urlopen
-import urllib.error
 import sys
+import urllib.error
+from urllib.request import Request, urlopen
+
+from typing_extensions import Any
 
 ROLLOUT_DASHBOARD_ENDPOINT='https://rollout-dashboard.ch1-rel1.dfinity.network/api/v1/rollouts'
 PUBLIC_DASHBOARD_ENDPOINT='https://ic-api.internetcomputer.org/api/v3/subnets?format=json'
@@ -22,7 +23,8 @@ def eprint(*args, **kwargs):
     print(*args, file=sys.stderr, **kwargs)
 
 def maybe_fetch_data(url : str, timeout : float) -> str | None:
-    """Try fetch data from `url`.
+    """
+    Try fetch data from `url`.
 
     Will try to fetch data and return `None` if the resource is unavailable for some.
     If this call fails other resources should be considered.
@@ -58,7 +60,8 @@ def ensure_json_response(url : str, timeout : float = 10) -> Any | None:
         exit(1)
 
 def fetch_versions_from_rollout_dashboard() -> list[str] | None:
-    """Fetch data from rollout dashboard
+    """
+    Fetch data from rollout dashboard
 
     Panics if the parsed data is not in the expected format.
     Returns an empty list if the action is retriable.
@@ -98,7 +101,8 @@ def maybe_exectued_timestamp(x : Any) -> int:
     return int(x.get(EXECUTED_TIMESTAMP_SECONDS))
 
 def fetch_versions_from_public_dashboard() -> list[str] | None:
-    """Fetch data from public dashboard
+    """
+    Fetch data from public dashboard
 
     Panics if the parsed data is not in the expected format.
     Returns an empty list if the action is retriable.

--- a/.github/scripts/determine-initial-guest-os-versions.py
+++ b/.github/scripts/determine-initial-guest-os-versions.py
@@ -152,6 +152,7 @@ def fetch_versions_from_public_dashboard(): # type: () -> list[str] | None
     versions = set()
     # Manuel: I'm not modifying this because I do not know the shape
     # of this data structure.
+    # Swagger for the public dashboard API: https://ic-api.internetcomputer.org/api/v3/swagger
     try:
         if data.get(SUBNETS, None) is None:
             raise Exception(f"Expected '{SUBNETS}' in response")

--- a/.github/workflows-source/release-testing.yml
+++ b/.github/workflows-source/release-testing.yml
@@ -187,13 +187,18 @@ jobs:
     outputs:
       matrix: ${{ steps.generate.outputs.output }}
     steps:
+      - name: Sparse checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_branch }}
+          sparse-checkout: ".github/scripts/determine-initial-guest-os-versions.py"
       - id: generate
         name: Fetch beginning versions for qualification
         shell: bash
         run: |
-          UNIQUE_VERSIONS=$(curl https://rollout-dashboard.ch1-rel1.dfinity.network/api/v1/rollouts | jq -r '.[] | select (.state != "failed") | select (.state != "complete") | .batches | to_entries[] | "\(.value)"' | jq '.subnets[].git_revision' |  sort | uniq | jq -s )
-          echo "Will qualify, starting from versions: ${UNIQUE_VERSIONS}"
-          echo "output=$(jq -cn --argjson versions "$UNIQUE_VERSIONS" '{version: $versions}')" >> $GITHUB_OUTPUT
+          set -euo pipefail
+          OUTPUT=$(python .github/scripts/determine-initial-guest-os-versions.py)
+          echo "output=$OUTPUT" >> $GITHUB_OUTPUT
 
   guest-os-qualification:
     name: Qualifying ${{ matrix.version }} -> ${{ github.sha }}

--- a/.github/workflows/release-testing.yml
+++ b/.github/workflows/release-testing.yml
@@ -226,13 +226,18 @@ jobs:
     outputs:
       matrix: ${{ steps.generate.outputs.output }}
     steps:
+      - name: Sparse checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_branch }}
+          sparse-checkout: ".github/scripts/determine-initial-guest-os-versions.py"
       - id: generate
         name: Fetch beginning versions for qualification
         shell: bash
         run: |
-          UNIQUE_VERSIONS=$(curl https://rollout-dashboard.ch1-rel1.dfinity.network/api/v1/rollouts | jq -r '.[] | select (.state != "failed") | select (.state != "complete") | .batches | to_entries[] | "\(.value)"' | jq '.subnets[].git_revision' |  sort | uniq | jq -s )
-          echo "Will qualify, starting from versions: ${UNIQUE_VERSIONS}"
-          echo "output=$(jq -cn --argjson versions "$UNIQUE_VERSIONS" '{version: $versions}')" >> $GITHUB_OUTPUT
+          set -euo pipefail
+          OUTPUT=$(python .github/scripts/determine-initial-guest-os-versions.py)
+          echo "output=$OUTPUT" >> $GITHUB_OUTPUT
   guest-os-qualification:
     name: Qualifying ${{ matrix.version }} -> ${{ github.sha }}
     needs: setup-guest-os-qualification


### PR DESCRIPTION
This PR adds a backup option in case there are no viable subnet Git revisions or the rollout dashboard is down. Before this PR the job would fail and say that the matrix was invalid which results in a failed release cut as we can see [here](https://dfinity.slack.com/archives/C024WJPPX5W/p1726110654204759). 

There are some occasions when we expect this situation with the current code base:

1. There was no successful cuts for at least a week.
2. We didn't release because of the holidays (Like we do for Christmas) 
3. We had an urgent fix that was rolled out in a day and no new rollouts were dispatched when the release-testing flow was issued.
4. Rollout dashboard is malfunctioning.

Yet another set of concerns need resolving.  The prior version selection algorithm (in the case of using the rollout dashboard) included all the versions of all the ongoing rollouts.  This has the following problems:

1. If there is no ongoing rollout, we obtain no version data.
2. If there are failed rollouts, but some subnets have in fact been rolled out successfully, we excluded those versions, even though quite logically those versions will be in mainnet if the failed rollout is the most recent rollout.
3. If there is a hotfix rollout, which only targets a handful of subnets, then versions may not be complete.

This PR proposes a way to only have a backup if everything is fine with our primary source of information (rollout dashboard) but there are no active rollouts **OR** if the rollout dashboard is unavailable. If its available but the data is malformed the CI will panic and will require investigation.

In addition to that we refine the algorithm used to select the versions from the primary source of information.  What we do now is:

* Go through time, from past to future, for each subnet, collecting each version that has been targeted to that
  subnet, along with its date (completion date if available, else start time if available, else planned start time) and state.
* If the state of that subnet's rollout instance is failed, then we disregard it.  Else, we take it into account.
* Having iterated through the rollouts one by one, we eventually end up with a list of subnets and a chronological list of
  revisions that have been targeted to those subnets (and either were successfully rolled out, or are pending and may be rolled out in the future).
* For each subnet, we pick (based on the date we collected) the most recent version.

Those are the versions that we're going to test against.

If this fails, that means that the versions on subnets of mainnet shall be the initial versions for qualification. 