### PR TITLE
feat: [MR-523] Don't allow responses in subnet input queues

### DIFF
--- a/rs/messaging/src/message_routing.rs
+++ b/rs/messaging/src/message_routing.rs
@@ -102,7 +102,7 @@ const CRITICAL_ERROR_MISSING_OR_INVALID_API_BOUNDARY_NODES: &str =
 const CRITICAL_ERROR_NO_CANISTER_ALLOCATION_RANGE: &str = "mr_empty_canister_allocation_range";
 const CRITICAL_ERROR_FAILED_TO_READ_REGISTRY: &str = "mr_failed_to_read_registry_error";
 pub const CRITICAL_ERROR_NON_INCREASING_BATCH_TIME: &str = "mr_non_increasing_batch_time";
-const CRITICAL_ERROR_INDUCT_RESPONSE_FAILED: &str = "mr_induct_response_failed";
+pub const CRITICAL_ERROR_INDUCT_RESPONSE_FAILED: &str = "mr_induct_response_failed";
 
 /// Records the timestamp when all messages before the given index (down to the
 /// previous `MessageTime`) were first added to / learned about in a stream.
@@ -1388,7 +1388,7 @@ impl MessageRoutingImpl {
         let stream_builder = Box::new(routing::stream_builder::StreamBuilderImpl::new(
             subnet_id,
             metrics_registry,
-            MessageRoutingMetrics::new(metrics_registry),
+            &MessageRoutingMetrics::new(metrics_registry),
             Arc::new(Mutex::new(LatencyMetrics::new_time_in_stream(
                 metrics_registry,
             ))),

--- a/rs/messaging/src/message_routing.rs
+++ b/rs/messaging/src/message_routing.rs
@@ -102,6 +102,7 @@ const CRITICAL_ERROR_MISSING_OR_INVALID_API_BOUNDARY_NODES: &str =
 const CRITICAL_ERROR_NO_CANISTER_ALLOCATION_RANGE: &str = "mr_empty_canister_allocation_range";
 const CRITICAL_ERROR_FAILED_TO_READ_REGISTRY: &str = "mr_failed_to_read_registry_error";
 pub const CRITICAL_ERROR_NON_INCREASING_BATCH_TIME: &str = "mr_non_increasing_batch_time";
+const CRITICAL_ERROR_INDUCT_RESPONSE_FAILED: &str = "mr_induct_response_failed";
 
 /// Records the timestamp when all messages before the given index (down to the
 /// previous `MessageTime`) were first added to / learned about in a stream.
@@ -313,6 +314,9 @@ pub(crate) struct MessageRoutingMetrics {
     /// Critical error: the batch times of successive batches were not strictly
     /// monotonically increasing.
     critical_error_non_increasing_batch_time: IntCounter,
+    /// Critical error counter (see [`MetricsRegistry::error_counter`]) tracking
+    /// failures to induct responses.
+    pub critical_error_induct_response_failed: IntCounter,
 
     /// Metrics for query stats aggregator
     pub query_stats_metrics: QueryStatsAggregatorMetrics,
@@ -407,6 +411,8 @@ impl MessageRoutingMetrics {
                 .error_counter(CRITICAL_ERROR_FAILED_TO_READ_REGISTRY),
             critical_error_non_increasing_batch_time: metrics_registry
                 .error_counter(CRITICAL_ERROR_NON_INCREASING_BATCH_TIME),
+            critical_error_induct_response_failed: metrics_registry
+                .error_counter(CRITICAL_ERROR_INDUCT_RESPONSE_FAILED),
 
             query_stats_metrics: QueryStatsAggregatorMetrics::new(metrics_registry),
 
@@ -550,6 +556,7 @@ impl BatchProcessorImpl {
             subnet_id,
             hypervisor_config.clone(),
             metrics_registry,
+            &metrics,
             Arc::clone(&time_in_stream_metrics),
             log.clone(),
         ));
@@ -570,6 +577,7 @@ impl BatchProcessorImpl {
         let stream_builder = Box::new(routing::stream_builder::StreamBuilderImpl::new(
             subnet_id,
             metrics_registry,
+            &metrics,
             time_in_stream_metrics,
             log.clone(),
         ));
@@ -1380,6 +1388,7 @@ impl MessageRoutingImpl {
         let stream_builder = Box::new(routing::stream_builder::StreamBuilderImpl::new(
             subnet_id,
             metrics_registry,
+            MessageRoutingMetrics::new(metrics_registry),
             Arc::new(Mutex::new(LatencyMetrics::new_time_in_stream(
                 metrics_registry,
             ))),

--- a/rs/messaging/src/routing/stream_builder.rs
+++ b/rs/messaging/src/routing/stream_builder.rs
@@ -45,6 +45,9 @@ struct StreamBuilderMetrics {
     pub critical_error_payload_too_large: IntCounter,
     /// Critical error for responses dropped due to destination not found.
     pub critical_error_response_destination_not_found: IntCounter,
+    /// Critical error counter (see [`MetricsRegistry::error_counter`]) tracking
+    /// failures to induct responses.
+    pub critical_error_induct_response_failed: IntCounter,
 }
 
 /// Desired byte size of an outgoing stream.
@@ -82,7 +85,10 @@ const CRITICAL_ERROR_RESPONSE_DESTINATION_NOT_FOUND: &str =
     "mr_stream_builder_response_destination_not_found";
 
 impl StreamBuilderMetrics {
-    pub fn new(metrics_registry: &MetricsRegistry) -> Self {
+    pub fn new(
+        metrics_registry: &MetricsRegistry,
+        message_routing_metrics: &MessageRoutingMetrics,
+    ) -> Self {
         let stream_messages = metrics_registry.int_gauge_vec(
             METRIC_STREAM_MESSAGES,
             "Messages currently enqueued in streams, by remote subnet.",
@@ -120,6 +126,9 @@ impl StreamBuilderMetrics {
             metrics_registry.error_counter(CRITICAL_ERROR_PAYLOAD_TOO_LARGE);
         let critical_error_response_destination_not_found =
             metrics_registry.error_counter(CRITICAL_ERROR_RESPONSE_DESTINATION_NOT_FOUND);
+        let critical_error_induct_response_failed = message_routing_metrics
+            .critical_error_induct_response_failed
+            .clone();
         // Initialize all `routed_messages` counters with zero, so they are all exported
         // from process start (`IntCounterVec` is really a map).
         for (msg_type, status) in &[
@@ -147,6 +156,7 @@ impl StreamBuilderMetrics {
             critical_error_infinite_loops,
             critical_error_payload_too_large,
             critical_error_response_destination_not_found,
+            critical_error_induct_response_failed,
         }
     }
 }
@@ -171,12 +181,13 @@ impl StreamBuilderImpl {
     pub(crate) fn new(
         subnet_id: SubnetId,
         metrics_registry: &MetricsRegistry,
+        message_routing_metrics: &MessageRoutingMetrics,
         time_in_stream_metrics: Arc<Mutex<LatencyMetrics>>,
         log: ReplicaLogger,
     ) -> Self {
         Self {
             subnet_id,
-            metrics: StreamBuilderMetrics::new(metrics_registry),
+            metrics: StreamBuilderMetrics::new(metrics_registry, message_routing_metrics),
             time_in_stream_metrics,
             log,
         }
@@ -211,9 +222,18 @@ impl StreamBuilderImpl {
                 // Arbitrary large amount, pushing a response always returns memory.
                 &mut (i64::MAX / 2),
             )
-            // Enqueuing a response for a local request.
-            // There should never be the case of getting `CanisterStopped` or `CanisterStopping`.
-            .unwrap();
+            .unwrap_or(|err| {
+                // Local request, we should never get a `CanisterNotFound`, `CanisterStopped` or
+                // `NonMatchingResponse` error.
+                error!(
+                    self.log,
+                    "{}: Failed to enqueue reject response for local request: {}\n{:?}",
+                    CRITICAL_ERROR_INDUCT_RESPONSE_FAILED,
+                    err,
+                    response
+                );
+                self.metrics.critical_error_induct_response_failed.inc();
+            });
     }
 
     /// Records the result of routing an XNet message.

--- a/rs/messaging/src/routing/stream_builder.rs
+++ b/rs/messaging/src/routing/stream_builder.rs
@@ -1,4 +1,6 @@
-use crate::message_routing::LatencyMetrics;
+use crate::message_routing::{
+    LatencyMetrics, MessageRoutingMetrics, CRITICAL_ERROR_INDUCT_RESPONSE_FAILED,
+};
 use ic_error_types::RejectCode;
 use ic_limits::SYSTEM_SUBNET_STREAM_MSG_LIMIT;
 use ic_logger::{error, warn, ReplicaLogger};
@@ -222,7 +224,7 @@ impl StreamBuilderImpl {
                 // Arbitrary large amount, pushing a response always returns memory.
                 &mut (i64::MAX / 2),
             )
-            .unwrap_or(|err| {
+            .unwrap_or_else(|(err, response)| {
                 // Local request, we should never get a `CanisterNotFound`, `CanisterStopped` or
                 // `NonMatchingResponse` error.
                 error!(

--- a/rs/messaging/src/routing/stream_builder/tests.rs
+++ b/rs/messaging/src/routing/stream_builder/tests.rs
@@ -867,7 +867,7 @@ fn new_fixture(log: &ReplicaLogger) -> (StreamBuilderImpl, ReplicatedState, Metr
     let stream_builder = StreamBuilderImpl::new(
         LOCAL_SUBNET,
         &metrics_registry,
-        MessageRoutingMetrics::new(&metrics_registry),
+        &MessageRoutingMetrics::new(&metrics_registry),
         Arc::new(Mutex::new(LatencyMetrics::new_time_in_stream(
             &metrics_registry,
         ))),
@@ -1077,7 +1077,7 @@ fn assert_eq_critical_errors(
     metrics_registry: &MetricsRegistry,
 ) {
     assert_eq!(
-        metric_vec(&[
+        nonzero_values(metric_vec(&[
             (&[("error", &CRITICAL_ERROR_INFINITE_LOOP)], 0),
             (
                 &[("error", &CRITICAL_ERROR_PAYLOAD_TOO_LARGE)],
@@ -1087,7 +1087,7 @@ fn assert_eq_critical_errors(
                 &[("error", &CRITICAL_ERROR_RESPONSE_DESTINATION_NOT_FOUND)],
                 response_destination_not_found
             )
-        ]),
-        fetch_int_counter_vec(metrics_registry, "critical_errors")
+        ])),
+        nonzero_values(fetch_int_counter_vec(metrics_registry, "critical_errors"))
     );
 }

--- a/rs/messaging/src/routing/stream_builder/tests.rs
+++ b/rs/messaging/src/routing/stream_builder/tests.rs
@@ -1,3 +1,5 @@
+use crate::message_routing::MessageRoutingMetrics;
+
 use super::*;
 use ic_base_types::NumSeconds;
 use ic_error_types::RejectCode;
@@ -865,6 +867,7 @@ fn new_fixture(log: &ReplicaLogger) -> (StreamBuilderImpl, ReplicatedState, Metr
     let stream_builder = StreamBuilderImpl::new(
         LOCAL_SUBNET,
         &metrics_registry,
+        MessageRoutingMetrics::new(&metrics_registry),
         Arc::new(Mutex::new(LatencyMetrics::new_time_in_stream(
             &metrics_registry,
         ))),

--- a/rs/messaging/src/routing/stream_handler.rs
+++ b/rs/messaging/src/routing/stream_handler.rs
@@ -1,4 +1,4 @@
-use crate::message_routing::LatencyMetrics;
+use crate::message_routing::{LatencyMetrics, MessageRoutingMetrics};
 use ic_base_types::NumBytes;
 use ic_certification_version::CertificationVersion;
 use ic_config::execution_environment::Config as HypervisorConfig;
@@ -92,13 +92,15 @@ const LABEL_VALUE_TYPE_RESPONSE: &str = "response";
 const LABEL_REMOTE: &str = "remote";
 
 const CRITICAL_ERROR_BAD_REJECT_SIGNAL_FOR_RESPONSE: &str = "mr_bad_reject_signal_for_response";
-const CRITICAL_ERROR_INDUCT_RESPONSE_FAILED: &str = "mr_induct_response_failed";
 const CRITICAL_ERROR_SENDER_SUBNET_MISMATCH: &str = "mr_sender_subnet_mismatch";
 const CRITICAL_ERROR_RECEIVER_SUBNET_MISMATCH: &str = "mr_receiver_subnet_mismatch";
 const CRITICAL_ERROR_REQUEST_MISROUTED: &str = "mr_request_misrouted";
 
 impl StreamHandlerMetrics {
-    pub fn new(metrics_registry: &MetricsRegistry) -> Self {
+    pub fn new(
+        metrics_registry: &MetricsRegistry,
+        message_routing_metrics: &MessageRoutingMetrics,
+    ) -> Self {
         let inducted_xnet_messages = metrics_registry.int_counter_vec(
             METRIC_INDUCTED_XNET_MESSAGES,
             "Counts of XNet message induction attempts, by message type and status.",
@@ -132,8 +134,9 @@ impl StreamHandlerMetrics {
         );
         let critical_error_bad_reject_signal_for_response =
             metrics_registry.error_counter(CRITICAL_ERROR_BAD_REJECT_SIGNAL_FOR_RESPONSE);
-        let critical_error_induct_response_failed =
-            metrics_registry.error_counter(CRITICAL_ERROR_INDUCT_RESPONSE_FAILED);
+        let critical_error_induct_response_failed = message_routing_metrics
+            .critical_error_induct_response_failed
+            .clone();
         let critical_error_sender_subnet_mismatch =
             metrics_registry.error_counter(CRITICAL_ERROR_SENDER_SUBNET_MISMATCH);
         let critical_error_receiver_subnet_mismatch =
@@ -212,6 +215,7 @@ impl StreamHandlerImpl {
         subnet_id: SubnetId,
         hypervisor_config: HypervisorConfig,
         metrics_registry: &MetricsRegistry,
+        message_routing_metrics: &MessageRoutingMetrics,
         time_in_stream_metrics: Arc<Mutex<LatencyMetrics>>,
         log: ReplicaLogger,
     ) -> Self {
@@ -219,7 +223,7 @@ impl StreamHandlerImpl {
             subnet_id,
             guaranteed_response_message_memory_capacity: hypervisor_config
                 .subnet_message_memory_capacity,
-            metrics: StreamHandlerMetrics::new(metrics_registry),
+            metrics: StreamHandlerMetrics::new(metrics_registry, message_routing_metrics),
             time_in_stream_metrics,
             time_in_backlog_metrics: RefCell::new(LatencyMetrics::new_time_in_backlog(
                 metrics_registry,
@@ -830,7 +834,7 @@ impl StreamHandlerImpl {
                                 // Critical error, responses should always be inducted successfully.
                                 error!(
                                     self.log,
-                                    "{}: Inducting response failed: {} {:?}",
+                                    "{}: Inducting response failed: {}\n{:?}",
                                     CRITICAL_ERROR_INDUCT_RESPONSE_FAILED,
                                     err,
                                     response

--- a/rs/messaging/src/routing/stream_handler.rs
+++ b/rs/messaging/src/routing/stream_handler.rs
@@ -1,4 +1,6 @@
-use crate::message_routing::{LatencyMetrics, MessageRoutingMetrics};
+use crate::message_routing::{
+    LatencyMetrics, MessageRoutingMetrics, CRITICAL_ERROR_INDUCT_RESPONSE_FAILED,
+};
 use ic_base_types::NumBytes;
 use ic_certification_version::CertificationVersion;
 use ic_config::execution_environment::Config as HypervisorConfig;

--- a/rs/messaging/src/routing/stream_handler/tests.rs
+++ b/rs/messaging/src/routing/stream_handler/tests.rs
@@ -2897,6 +2897,7 @@ fn with_test_setup_and_config(
             LOCAL_SUBNET,
             hypervisor_config,
             &metrics_registry,
+            &MessageRoutingMetrics::new(&metrics_registry),
             Arc::new(Mutex::new(LatencyMetrics::new_time_in_stream(
                 &metrics_registry,
             ))),
@@ -3374,7 +3375,7 @@ impl MetricsFixture {
 
     fn assert_eq_critical_errors(&self, counts: CriticalErrorCounts) {
         assert_eq!(
-            metric_vec(&[
+            nonzero_values(metric_vec(&[
                 (
                     &[("error", &CRITICAL_ERROR_INDUCT_RESPONSE_FAILED.to_string())],
                     counts.induct_response_failed
@@ -3401,8 +3402,8 @@ impl MetricsFixture {
                     )],
                     counts.receiver_subnet_mismatch
                 )
-            ]),
-            fetch_int_counter_vec(&self.registry, "critical_errors")
+            ])),
+            nonzero_values(fetch_int_counter_vec(&self.registry, "critical_errors"))
         );
     }
 }

--- a/rs/replicated_state/src/canister_state/queues.rs
+++ b/rs/replicated_state/src/canister_state/queues.rs
@@ -386,16 +386,6 @@ impl CanisterQueues {
         msg: RequestOrResponse,
         input_queue_type: InputQueueType,
     ) -> Result<(), (StateError, RequestOrResponse)> {
-        fn non_matching_response(message: &str, response: &Response) -> StateError {
-            StateError::NonMatchingResponse {
-                err_str: message.to_string(),
-                originator: response.originator,
-                callback_id: response.originator_reply_callback,
-                respondent: response.respondent,
-                deadline: response.deadline,
-            }
-        }
-
         let sender = msg.sender();
         let input_queue = match msg {
             RequestOrResponse::Request(_) => {
@@ -423,7 +413,10 @@ impl CanisterQueues {
                             // This is a critical error for guaranteed responses.
                             if response.deadline == NO_DEADLINE {
                                 return Err((
-                                    non_matching_response("Duplicate response", response),
+                                    StateError::non_matching_response(
+                                        "Duplicate response",
+                                        response,
+                                    ),
                                     msg,
                                 ));
                             } else {
@@ -438,7 +431,10 @@ impl CanisterQueues {
                     // Queue does not exist or has no reserved slot for this response.
                     _ => {
                         return Err((
-                            non_matching_response("No reserved response slot", response),
+                            StateError::non_matching_response(
+                                "No reserved response slot",
+                                response,
+                            ),
                             msg,
                         ));
                     }

--- a/rs/replicated_state/src/canister_state/queues.rs
+++ b/rs/replicated_state/src/canister_state/queues.rs
@@ -652,7 +652,10 @@ impl CanisterQueues {
     ///
     /// Returns a `QueueFull` error along with the provided message if either
     /// the output queue or the matching input queue is full.
-    pub fn push_output_request(
+    //
+    // NOTE: DO NOT CHANGE THE VISIBILITY OF THIS METHOD. IT IS ONLY SUPPOSED TO BE
+    // CALLED FOR CANISTERS (I.E. NOT FOR THE SUBNET QUEUES).
+    pub(super) fn push_output_request(
         &mut self,
         request: Arc<Request>,
         time: Time,

--- a/rs/replicated_state/src/canister_state/queues/queue.rs
+++ b/rs/replicated_state/src/canister_state/queues/queue.rs
@@ -647,13 +647,7 @@ impl<T: QueueItem<T> + std::clone::Clone + ValidateEq> QueueWithReservation<T> {
             Ok(())
         } else {
             Err((
-                StateError::NonMatchingResponse {
-                    err_str: "No reserved response slot".to_string(),
-                    originator: response.originator,
-                    callback_id: response.originator_reply_callback,
-                    respondent: response.respondent,
-                    deadline: response.deadline,
-                },
+                StateError::non_matching_response("No reserved response slot", &response),
                 response,
             ))
         }

--- a/rs/replicated_state/src/canister_state/system_state/call_context_manager.rs
+++ b/rs/replicated_state/src/canister_state/system_state/call_context_manager.rs
@@ -605,27 +605,15 @@ impl CallContextManager {
             Some(callback) if response.respondent != callback.respondent
                     || response.originator != callback.originator
                     || response.deadline != callback.deadline => {
-                Err(StateError::NonMatchingResponse {
-                    err_str: format!(
+                Err(StateError::non_matching_response(format!(
                         "invalid details, expected => [originator => {}, respondent => {}, deadline => {}], but got response with",
                         callback.originator, callback.respondent, Time::from(callback.deadline)
-                    ),
-                    originator: response.originator,
-                    callback_id: response.originator_reply_callback,
-                    respondent: response.respondent,
-                    deadline: response.deadline,
-                })
+                    ), response))
             }
             Some(_) => Ok(()),
             None => {
                 // Received an unknown callback ID.
-                Err(StateError::NonMatchingResponse {
-                    err_str: "unknown callback ID".to_string(),
-                    originator: response.originator,
-                    callback_id: response.originator_reply_callback,
-                    respondent: response.respondent,
-                    deadline: response.deadline,
-                })
+                Err(StateError::non_matching_response("unknown callback ID", response))
             }
         }
     }

--- a/rs/replicated_state/src/canister_state/tests.rs
+++ b/rs/replicated_state/src/canister_state/tests.rs
@@ -167,13 +167,7 @@ fn canister_state_push_input_response_no_reserved_slot() {
     let response = default_input_response(fixture.make_callback());
     assert_eq!(
         Err((
-            StateError::NonMatchingResponse {
-                err_str: "No reserved response slot".to_string(),
-                originator: response.originator,
-                callback_id: response.originator_reply_callback,
-                respondent: response.respondent,
-                deadline: response.deadline,
-            },
+            StateError::non_matching_response("No reserved response slot", &response),
             response.clone().into(),
         )),
         fixture.push_input(

--- a/rs/replicated_state/tests/replicated_state.rs
+++ b/rs/replicated_state/tests/replicated_state.rs
@@ -538,6 +538,26 @@ fn push_input_queues_respects_local_remote_subnet() {
 }
 
 #[test]
+fn subnet_queue_push_input_response() {
+    let mut state = ReplicatedState::new(SUBNET_ID, SubnetType::Application);
+
+    let response = response_to(SUBNET_ID.into());
+    assert_eq!(
+        state.push_input(
+            response.clone().into(),
+            &mut SUBNET_AVAILABLE_MEMORY.clone()
+        ),
+        Err((
+            StateError::non_matching_response(
+                "Management canister does not accept canister responses",
+                &response
+            ),
+            response.into()
+        ))
+    );
+}
+
+#[test]
 fn insert_bitcoin_response_non_matching() {
     let mut state = ReplicatedState::new(SUBNET_ID, SubnetType::Application);
 


### PR DESCRIPTION
[MR-523]: The management canister does not make outgoing canister calls (not as itself, at least; it does do so on behalf of canisters, but those responses are routed back directly to the canisters themselves, not into the subnet input queues).

Return an error when a `Response` is about to be enqueued into the subnet input queues.

[MR-523]: https://dfinity.atlassian.net/browse/MR-523?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ