### PR TITLE
fix: Exempt local base targets from component tests

### DIFF
--- a/ic-os/components/conformance_tests/defs.bzl
+++ b/ic-os/components/conformance_tests/defs.bzl
@@ -1,6 +1,6 @@
 """ Rules for component conformance tests. """
 
-def component_file_references_test(name, component_files, image):
+def component_file_references_test(name, component_files, image, tags = None):
     """
     Verifies that the `component_files` only reference file paths that are accessible within the provided `image`.
 
@@ -8,6 +8,7 @@ def component_file_references_test(name, component_files, image):
         name: The name of the test rule (must end in _test).
         component_files: A list of Labels that reference components.
         image: The compressed image where the referenced file paths can be found.
+        tags: Tags to apply to the generated test target.
     """
 
     deps = [image]
@@ -25,6 +26,7 @@ def component_file_references_test(name, component_files, image):
             ",".join(component_paths),
             "--image $(location %s)" % image,
         ],
+        tags = tags,
     )
 
 def _check_unused_components_test_impl(ctx):

--- a/ic-os/defs.bzl
+++ b/ic-os/defs.bzl
@@ -186,10 +186,12 @@ def icos_build(
         tags = ["manual"],
     )
 
+    # Inherit tags for this test, to avoid triggering builds for local base images
     component_file_references_test(
         name = name + "_component_file_references_test",
         image = ":partition-root-unsigned.tzst",
         component_files = image_deps["component_files"].keys(),
+        tags = tags,
     )
 
     if upgrades:


### PR DESCRIPTION
The current state triggers a rebuild of local base images, which are normally tagged as `manual`.