### PR TITLE
fix: CanisterQueues: Check for zero-length encoding after GC

### DIFF
--- a/rs/replicated_state/BUILD.bazel
+++ b/rs/replicated_state/BUILD.bazel
@@ -35,6 +35,7 @@ DEPENDENCIES = [
     "@crate_index//:maplit",
     "@crate_index//:nix",
     "@crate_index//:prometheus",
+    "@crate_index//:prost",
     "@crate_index//:rand",
     "@crate_index//:rand_chacha",
     "@crate_index//:rayon",
@@ -66,7 +67,6 @@ DEV_DEPENDENCIES = [
     "@crate_index//:criterion",
     "@crate_index//:ic-btc-test-utils",
     "@crate_index//:proptest",
-    "@crate_index//:prost",
     "@crate_index//:scoped_threadpool",
     "@crate_index//:serde_cbor",
 ]

--- a/rs/replicated_state/Cargo.toml
+++ b/rs/replicated_state/Cargo.toml
@@ -38,6 +38,7 @@ maplit = "1.0.2"
 nix = { workspace = true }
 phantom_newtype = { path = "../phantom_newtype" }
 prometheus = { workspace = true }
+prost = { workspace = true }
 rand = { workspace = true }
 rand_chacha = { workspace = true }
 rayon = { workspace = true }
@@ -70,7 +71,6 @@ ic-test-utilities-time = { path = "../test_utilities/time" }
 ic-test-utilities-types = { path = "../test_utilities/types" }
 maplit = "1.0.2"
 proptest = { workspace = true }
-prost = { workspace = true }
 scoped_threadpool = "0.1.*"
 serde_cbor = { workspace = true }
 test-strategy = "0.4.0"

--- a/rs/replicated_state/src/canister_state/queues.rs
+++ b/rs/replicated_state/src/canister_state/queues.rs
@@ -919,7 +919,7 @@ impl CanisterQueues {
             self.pool = MessagePool::default();
             self.input_schedule = InputSchedule::default();
 
-            // Trust but verify. Ensure that everything is actually set to default.
+            // Trust but verify. Ensure that the `CanisterQueues` now encodes to zero bytes.
             debug_assert_eq!(
                 0,
                 pb_queues::CanisterQueues::from(self as &Self).encoded_len()

--- a/rs/replicated_state/src/canister_state/queues.rs
+++ b/rs/replicated_state/src/canister_state/queues.rs
@@ -24,6 +24,7 @@ use ic_types::messages::{
 use ic_types::{CanisterId, CountBytes, Time};
 use ic_validate_eq::ValidateEq;
 use ic_validate_eq_derive::ValidateEq;
+use prost::Message;
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::convert::{From, TryFrom};
 use std::sync::Arc;
@@ -919,7 +920,10 @@ impl CanisterQueues {
             self.input_schedule = InputSchedule::default();
 
             // Trust but verify. Ensure that everything is actually set to default.
-            debug_assert_eq!(CanisterQueues::default(), *self);
+            debug_assert_eq!(
+                0,
+                pb_queues::CanisterQueues::from(self as &Self).encoded_len()
+            );
         }
     }
 

--- a/rs/replicated_state/src/canister_state/queues/tests.rs
+++ b/rs/replicated_state/src/canister_state/queues/tests.rs
@@ -2353,6 +2353,9 @@ fn test_garbage_collect_restores_defaults() {
     let mut queues = CanisterQueues::default();
     assert_eq!(CanisterQueues::default(), queues);
 
+    // Set the transient response size to a non-zero value.
+    queues.set_stream_guaranteed_responses_size_bytes(123);
+
     // Push and pop an ingress message.
     queues.push_ingress(IngressBuilder::default().receiver(this).build());
     assert!(queues.pop_input().is_some());
@@ -2361,7 +2364,7 @@ fn test_garbage_collect_restores_defaults() {
 
     // But `garbage_collect()` should restore the struct to its default value.
     queues.garbage_collect();
-    assert_eq!(CanisterQueues::default(), queues);
+    assert_eq!(0, pb_queues::CanisterQueues::from(&queues).encoded_len());
 }
 
 #[test]


### PR DESCRIPTION
What we're actually interested in is that after a garbage collection, a `CanisterQueues` encodes to zero bytes. So check that instead of comparing with default.