### PR TITLE
fix: Enable sandboxless build strategy for all ic-os builds

### DIFF
--- a/bazel/conf/.bazelrc.build
+++ b/bazel/conf/.bazelrc.build
@@ -33,7 +33,7 @@ build --@rules_rust//:extra_rustc_flag=-Dbindings_with_variant_name
 build --strip=never
 
 # Build everything ic-os without sandbox
-build --strategy_regexp=ic-os/.*=local
+build --strategy_regexp=ic-os[:/].*=local
 
 build --workspace_status_command=$(pwd)/bazel/workspace_status.sh
 


### PR DESCRIPTION
The previous pattern did not match targets directly in the ic-os directory, only in its subdirectories.