### PR TITLE
chore(ICRC_ledger): FI-1488: Split FI nightly tests into their own workflow

### DIFF
--- a/.github/workflows-source/fi-daily.yml
+++ b/.github/workflows-source/fi-daily.yml
@@ -1,0 +1,82 @@
+name: FI Daily
+
+on:
+  schedule:
+    - cron: "0 23 * * *"
+  workflow_dispatch:
+
+env:
+  BAZEL_STARTUP_ARGS: "--output_base=/var/tmp/bazel-output/"
+  CI_COMMIT_SHA: ${{ github.sha }}
+  CI_COMMIT_REF_PROTECTED: ${{ github.ref_protected }}
+  CI_JOB_NAME: ${{ github.job }}
+  CI_JOB_ID: ${{ github.job }} # github does not expose this variable https://github.com/orgs/community/discussions/8945
+  CI_JOB_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+  CI_PIPELINE_SOURCE: ${{ github.event_name }}
+  CI_PROJECT_DIR: ${{ github.workspace }}
+  CI_PULL_REQUEST_TARGET_BRANCH_NAME: ${{ github.ref_name }} # this workflow will always run on the default branch
+  ROOT_PIPELINE_ID: ${{ github.run_id }}
+  BUILDEVENT_DATASET: "github-ci-dfinity"
+
+anchors:
+  image: &image
+    image: ghcr.io/dfinity/ic-build@sha256:1c0e901df3c7a97fc440c271881400ce6d2e586e2a89cdc39ec939e3dfe5de76
+  dind-large-setup: &dind-large-setup
+    runs-on:
+      group: zh1
+      labels: dind-large
+    container:
+      <<: *image
+      options: >-
+        -e NODE_NAME
+        --privileged --cgroupns host
+        -v /cache:/cache -v /var/sysimage:/var/sysimage -v /var/tmp:/var/tmp
+    timeout-minutes: 120
+  checkout: &checkout
+    name: Checkout
+    uses: actions/checkout@v4
+  before-script: &before-script
+    name: Before script
+    id: before-script
+    shell: bash
+    run: |
+      [ -n "${NODE_NAME:-}" ] && echo "Node: $NODE_NAME"
+  docker-login: &docker-login
+    name: Login to Dockerhub
+    shell: bash
+    run: ./ci/scripts/docker-login.sh
+    env:
+      DOCKER_HUB_USER: ${{ vars.DOCKER_HUB_USER }}
+      DOCKER_HUB_PASSWORD_RO: ${{ secrets.DOCKER_HUB_PASSWORD_RO }}
+
+jobs:
+
+  fi-tests-nightly:
+    name: Bazel Test FI Nightly
+    <<: *dind-large-setup
+    timeout-minutes: 1380
+    steps:
+      - <<: *checkout
+      - <<: *before-script
+      - <<: *docker-login
+      - name: Run FI Tests Nightly
+        id: bazel-test-all
+        uses: ./.github/actions/bazel-test-all/
+        with:
+          BAZEL_COMMAND: "test"
+          BAZEL_TARGETS: "//rs/rosetta-api/..."
+          BAZEL_CI_CONFIG: "--config=ci --repository_cache=/cache/bazel"
+          BAZEL_EXTRA_ARGS: "--keep_going --test_tag_filters=fi_tests_nightly --test_env=SSH_AUTH_SOCK --test_timeout=82800"
+          HONEYCOMB_API_TOKEN: ${{ secrets.HONEYCOMB_API_TOKEN }}
+          SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+      - name: Upload bazel-bep
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: ${{ github.job }}-bep
+          retention-days: 14
+          if-no-files-found: ignore
+          compression-level: 9
+          path: |
+            bazel-bep.pb
+            profile.json

--- a/.github/workflows-source/schedule-daily.yml
+++ b/.github/workflows-source/schedule-daily.yml
@@ -136,36 +136,6 @@ jobs:
           ZH2_DLL01_CSV_SECRETS: "${{ secrets.ZH2_DLL01_CSV_SECRETS }}"
           ZH2_FILE_SHARE_KEY: "${{ secrets.ZH2_FILE_SHARE_KEY }}"
 
-  fi-tests-nightly:
-    name: Bazel Test FI Nightly
-    <<: *dind-large-setup
-    timeout-minutes: 240
-    steps:
-      - <<: *checkout
-      - <<: *before-script
-      - <<: *docker-login
-      - name: Run FI Tests Nightly
-        id: bazel-test-all
-        uses: ./.github/actions/bazel-test-all/
-        with:
-          BAZEL_COMMAND: "test"
-          BAZEL_TARGETS: "//rs/rosetta-api/..."
-          BAZEL_CI_CONFIG: "--config=ci --repository_cache=/cache/bazel"
-          BAZEL_EXTRA_ARGS: "--keep_going --test_tag_filters=fi_tests_nightly --test_env=SSH_AUTH_SOCK --test_timeout=7200"
-          HONEYCOMB_API_TOKEN: ${{ secrets.HONEYCOMB_API_TOKEN }}
-          SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
-      - name: Upload bazel-bep
-        uses: actions/upload-artifact@v4
-        if: always()
-        with:
-          name: ${{ github.job }}-bep
-          retention-days: 14
-          if-no-files-found: ignore
-          compression-level: 9
-          path: |
-            bazel-bep.pb
-            profile.json
-
   nns-tests-nightly:
     name: Bazel Test NNS Nightly
     <<: *dind-large-setup

--- a/.github/workflows/fi-daily.yml
+++ b/.github/workflows/fi-daily.yml
@@ -1,0 +1,63 @@
+name: FI Daily
+on:
+  schedule:
+    - cron: "0 23 * * *"
+  workflow_dispatch:
+env:
+  BAZEL_STARTUP_ARGS: "--output_base=/var/tmp/bazel-output/"
+  CI_COMMIT_SHA: ${{ github.sha }}
+  CI_COMMIT_REF_PROTECTED: ${{ github.ref_protected }}
+  CI_JOB_NAME: ${{ github.job }}
+  CI_JOB_ID: ${{ github.job }} # github does not expose this variable https://github.com/orgs/community/discussions/8945
+  CI_JOB_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+  CI_PIPELINE_SOURCE: ${{ github.event_name }}
+  CI_PROJECT_DIR: ${{ github.workspace }}
+  CI_PULL_REQUEST_TARGET_BRANCH_NAME: ${{ github.ref_name }} # this workflow will always run on the default branch
+  ROOT_PIPELINE_ID: ${{ github.run_id }}
+  BUILDEVENT_DATASET: "github-ci-dfinity"
+jobs:
+  fi-tests-nightly:
+    name: Bazel Test FI Nightly
+    runs-on:
+      group: zh1
+      labels: dind-large
+    container:
+      image: ghcr.io/dfinity/ic-build@sha256:1c0e901df3c7a97fc440c271881400ce6d2e586e2a89cdc39ec939e3dfe5de76
+      options: >-
+        -e NODE_NAME --privileged --cgroupns host -v /cache:/cache -v /var/sysimage:/var/sysimage -v /var/tmp:/var/tmp
+    timeout-minutes: 1380
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Before script
+        id: before-script
+        shell: bash
+        run: |
+          [ -n "${NODE_NAME:-}" ] && echo "Node: $NODE_NAME"
+      - name: Login to Dockerhub
+        shell: bash
+        run: ./ci/scripts/docker-login.sh
+        env:
+          DOCKER_HUB_USER: ${{ vars.DOCKER_HUB_USER }}
+          DOCKER_HUB_PASSWORD_RO: ${{ secrets.DOCKER_HUB_PASSWORD_RO }}
+      - name: Run FI Tests Nightly
+        id: bazel-test-all
+        uses: ./.github/actions/bazel-test-all/
+        with:
+          BAZEL_COMMAND: "test"
+          BAZEL_TARGETS: "//rs/rosetta-api/..."
+          BAZEL_CI_CONFIG: "--config=ci --repository_cache=/cache/bazel"
+          BAZEL_EXTRA_ARGS: "--keep_going --test_tag_filters=fi_tests_nightly --test_env=SSH_AUTH_SOCK --test_timeout=82800"
+          HONEYCOMB_API_TOKEN: ${{ secrets.HONEYCOMB_API_TOKEN }}
+          SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+      - name: Upload bazel-bep
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: ${{ github.job }}-bep
+          retention-days: 14
+          if-no-files-found: ignore
+          compression-level: 9
+          path: |
+            bazel-bep.pb
+            profile.json

--- a/.github/workflows/schedule-daily.yml
+++ b/.github/workflows/schedule-daily.yml
@@ -111,51 +111,6 @@ jobs:
           BAZEL_CI_CONFIG: "--config=ci --repository_cache=/cache/bazel"
           ZH2_DLL01_CSV_SECRETS: "${{ secrets.ZH2_DLL01_CSV_SECRETS }}"
           ZH2_FILE_SHARE_KEY: "${{ secrets.ZH2_FILE_SHARE_KEY }}"
-  fi-tests-nightly:
-    name: Bazel Test FI Nightly
-    runs-on:
-      group: zh1
-      labels: dind-large
-    container:
-      image: ghcr.io/dfinity/ic-build@sha256:1c0e901df3c7a97fc440c271881400ce6d2e586e2a89cdc39ec939e3dfe5de76
-      options: >-
-        -e NODE_NAME --privileged --cgroupns host -v /cache:/cache -v /var/sysimage:/var/sysimage -v /var/tmp:/var/tmp
-    timeout-minutes: 240
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Before script
-        id: before-script
-        shell: bash
-        run: |
-          [ -n "${NODE_NAME:-}" ] && echo "Node: $NODE_NAME"
-      - name: Login to Dockerhub
-        shell: bash
-        run: ./ci/scripts/docker-login.sh
-        env:
-          DOCKER_HUB_USER: ${{ vars.DOCKER_HUB_USER }}
-          DOCKER_HUB_PASSWORD_RO: ${{ secrets.DOCKER_HUB_PASSWORD_RO }}
-      - name: Run FI Tests Nightly
-        id: bazel-test-all
-        uses: ./.github/actions/bazel-test-all/
-        with:
-          BAZEL_COMMAND: "test"
-          BAZEL_TARGETS: "//rs/rosetta-api/..."
-          BAZEL_CI_CONFIG: "--config=ci --repository_cache=/cache/bazel"
-          BAZEL_EXTRA_ARGS: "--keep_going --test_tag_filters=fi_tests_nightly --test_env=SSH_AUTH_SOCK --test_timeout=7200"
-          HONEYCOMB_API_TOKEN: ${{ secrets.HONEYCOMB_API_TOKEN }}
-          SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
-      - name: Upload bazel-bep
-        uses: actions/upload-artifact@v4
-        if: always()
-        with:
-          name: ${{ github.job }}-bep
-          retention-days: 14
-          if-no-files-found: ignore
-          compression-level: 9
-          path: |
-            bazel-bep.pb
-            profile.json
   nns-tests-nightly:
     name: Bazel Test NNS Nightly
     runs-on:


### PR DESCRIPTION
The FI nightly tests are very long-running - the previous two runs timed out after two hours. To be able to run them for longer, without interfering with other jobs, split them out into their own daily workflow.