### PR TITLE
chore(ICRC_ledger): FI-1488: Bump FI nightly timeout

### DIFF
--- a/.github/workflows-source/schedule-daily.yml
+++ b/.github/workflows-source/schedule-daily.yml
@@ -139,7 +139,7 @@ jobs:
   fi-tests-nightly:
     name: Bazel Test FI Nightly
     <<: *dind-large-setup
-    timeout-minutes: 240
+    timeout-minutes: 720 # 12 hours
     steps:
       - <<: *checkout
       - <<: *before-script
@@ -151,7 +151,7 @@ jobs:
           BAZEL_COMMAND: "test"
           BAZEL_TARGETS: "//rs/rosetta-api/..."
           BAZEL_CI_CONFIG: "--config=ci --repository_cache=/cache/bazel"
-          BAZEL_EXTRA_ARGS: "--keep_going --test_tag_filters=fi_tests_nightly --test_env=SSH_AUTH_SOCK --test_timeout=7200"
+          BAZEL_EXTRA_ARGS: "--keep_going --test_tag_filters=fi_tests_nightly --test_env=SSH_AUTH_SOCK --test_timeout=43200"
           HONEYCOMB_API_TOKEN: ${{ secrets.HONEYCOMB_API_TOKEN }}
           SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
       - name: Upload bazel-bep

--- a/.github/workflows/schedule-daily.yml
+++ b/.github/workflows/schedule-daily.yml
@@ -120,7 +120,7 @@ jobs:
       image: ghcr.io/dfinity/ic-build@sha256:1c0e901df3c7a97fc440c271881400ce6d2e586e2a89cdc39ec939e3dfe5de76
       options: >-
         -e NODE_NAME --privileged --cgroupns host -v /cache:/cache -v /var/sysimage:/var/sysimage -v /var/tmp:/var/tmp
-    timeout-minutes: 240
+    timeout-minutes: 720 # 12 hours
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -142,7 +142,7 @@ jobs:
           BAZEL_COMMAND: "test"
           BAZEL_TARGETS: "//rs/rosetta-api/..."
           BAZEL_CI_CONFIG: "--config=ci --repository_cache=/cache/bazel"
-          BAZEL_EXTRA_ARGS: "--keep_going --test_tag_filters=fi_tests_nightly --test_env=SSH_AUTH_SOCK --test_timeout=7200"
+          BAZEL_EXTRA_ARGS: "--keep_going --test_tag_filters=fi_tests_nightly --test_env=SSH_AUTH_SOCK --test_timeout=43200"
           HONEYCOMB_API_TOKEN: ${{ secrets.HONEYCOMB_API_TOKEN }}
           SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
       - name: Upload bazel-bep


### PR DESCRIPTION
Bump the FI nightly tests timeout to 12h. This matches the current longest timeout in the workflow (the rust benchmarks), and the actual duration is still below that of the benchmarks.