### PR TITLE
chore: add metric for executed canisters per round

### DIFF
--- a/rs/execution_environment/src/scheduler.rs
+++ b/rs/execution_environment/src/scheduler.rs
@@ -662,7 +662,7 @@ impl SchedulerImpl {
 
         let mut heartbeat_and_timer_canister_ids = BTreeSet::new();
         let mut non_zero_priority_credit_canister_ids = BTreeSet::new();
-        let mut all_canisters_executed_this_round = BTreeSet::new();
+        let mut round_executed_canister_ids = BTreeSet::new();
 
         // Start iteration loop:
         //      - Execute subnet messages.
@@ -762,7 +762,7 @@ impl SchedulerImpl {
                 );
             let instructions_consumed = instructions_before - round_limits.instructions;
             drop(execution_timer);
-            all_canisters_executed_this_round
+            round_executed_canister_ids
                 .extend(executed_canisters.iter().map(|c| c.canister_id()));
 
             let finalization_timer = self.metrics.round_inner_iteration_fin.start_timer();
@@ -880,7 +880,7 @@ impl SchedulerImpl {
             .observe(round_filtered_canisters.active_canister_ids.len() as f64);
         self.metrics
             .executed_canisters_per_round
-            .set(all_canisters_executed_this_round.len() as i64);
+            .set(round_executed_canister_ids.len() as i64);
 
         self.metrics
             .heap_delta_rate_limited_canisters_per_round

--- a/rs/execution_environment/src/scheduler.rs
+++ b/rs/execution_environment/src/scheduler.rs
@@ -662,6 +662,7 @@ impl SchedulerImpl {
 
         let mut heartbeat_and_timer_canister_ids = BTreeSet::new();
         let mut non_zero_priority_credit_canister_ids = BTreeSet::new();
+        let mut canisters_executed_this_round = BTreeSet::new();
 
         // Start iteration loop:
         //      - Execute subnet messages.
@@ -761,6 +762,8 @@ impl SchedulerImpl {
                 );
             let instructions_consumed = instructions_before - round_limits.instructions;
             drop(execution_timer);
+            canisters_executed_this_round
+                .extend(executed_canisters.iter().map(|c| c.canister_id()));
 
             let finalization_timer = self.metrics.round_inner_iteration_fin.start_timer();
             total_heap_delta += heap_delta;
@@ -875,6 +878,9 @@ impl SchedulerImpl {
         self.metrics
             .executable_canisters_per_round
             .observe(round_filtered_canisters.active_canister_ids.len() as f64);
+        self.metrics
+            .executed_canisters_per_round
+            .set(canisters_executed_this_round.len() as i64);
 
         self.metrics
             .heap_delta_rate_limited_canisters_per_round

--- a/rs/execution_environment/src/scheduler.rs
+++ b/rs/execution_environment/src/scheduler.rs
@@ -662,7 +662,7 @@ impl SchedulerImpl {
 
         let mut heartbeat_and_timer_canister_ids = BTreeSet::new();
         let mut non_zero_priority_credit_canister_ids = BTreeSet::new();
-        let mut canisters_executed_this_round = BTreeSet::new();
+        let mut all_canisters_executed_this_round = BTreeSet::new();
 
         // Start iteration loop:
         //      - Execute subnet messages.
@@ -762,7 +762,7 @@ impl SchedulerImpl {
                 );
             let instructions_consumed = instructions_before - round_limits.instructions;
             drop(execution_timer);
-            canisters_executed_this_round
+            all_canisters_executed_this_round
                 .extend(executed_canisters.iter().map(|c| c.canister_id()));
 
             let finalization_timer = self.metrics.round_inner_iteration_fin.start_timer();
@@ -880,7 +880,7 @@ impl SchedulerImpl {
             .observe(round_filtered_canisters.active_canister_ids.len() as f64);
         self.metrics
             .executed_canisters_per_round
-            .set(canisters_executed_this_round.len() as i64);
+            .set(all_canisters_executed_this_round.len() as i64);
 
         self.metrics
             .heap_delta_rate_limited_canisters_per_round

--- a/rs/execution_environment/src/scheduler.rs
+++ b/rs/execution_environment/src/scheduler.rs
@@ -762,8 +762,7 @@ impl SchedulerImpl {
                 );
             let instructions_consumed = instructions_before - round_limits.instructions;
             drop(execution_timer);
-            round_executed_canister_ids
-                .extend(executed_canisters.iter().map(|c| c.canister_id()));
+            round_executed_canister_ids.extend(executed_canisters.iter().map(|c| c.canister_id()));
 
             let finalization_timer = self.metrics.round_inner_iteration_fin.start_timer();
             total_heap_delta += heap_delta;

--- a/rs/execution_environment/src/scheduler/scheduler_metrics.rs
+++ b/rs/execution_environment/src/scheduler/scheduler_metrics.rs
@@ -37,6 +37,7 @@ pub(super) struct SchedulerMetrics {
     pub(super) instructions_consumed_per_message: Histogram,
     pub(super) instructions_consumed_per_round: Histogram,
     pub(super) executable_canisters_per_round: Histogram,
+    pub(super) executed_canisters_per_round: IntGauge,
     pub(super) expired_ingress_messages_count: IntCounter,
     pub(super) ingress_history_length: IntGauge,
     pub(super) msg_execution_duration: Histogram,
@@ -218,6 +219,10 @@ impl SchedulerMetrics {
                 "Number of canisters that can be executed per round.",
                 // 1, 2, 5, …, 10000, 20000, 50000
                 decimal_buckets(0, 4),
+            ),
+            executed_canisters_per_round: metrics_registry.int_gauge(
+                "scheduler_executed_canisters_per_round",
+                "Number of canisters that were actually executed in the last round.",
             ),
             expired_ingress_messages_count: metrics_registry.int_counter(
                 "scheduler_expired_ingress_messages_count",


### PR DESCRIPTION
This PR introduces a scheduler metric to count the number of canisters actually executed in the past round.

This differs from the `scheduler_executable_canisters_per_round` metric, which shows the number of canisters that are eligible for execution (but may not be executed due to constraints such as round limits).
