### PR TITLE
feat(icp-ledger): add bazel target for local replica testing

### DIFF
--- a/rs/rosetta-api/icp_ledger/README.md
+++ b/rs/rosetta-api/icp_ledger/README.md
@@ -4,4 +4,26 @@ This package contains the implementation of the ICP ledger canister.
 
 ## Deploying locally
 
+### From a release version
+
 See [Ledger Local Setup](https://internetcomputer.org/docs/current/developer-docs/integrations/ledger/ledger-local-setup).
+
+### From local code (ICP Ledger)
+
+With a running local replica and minter and default accounts properly configures (as described in the [Ledger Local Setup](https://internetcomputer.org/docs/current/developer-docs/integrations/ledger/ledger-local-setup) guide), run:
+
+```bash
+# WARNING: The command below will stop and delete any canister running under id ryjl3-tyaaa-aaaaa-aaaba-cai
+$ bazel run //rs/rosetta-api/icp_ledger/ledger:dfx_deploy
+```
+
+The above command will build an icp canister from your current code and deploy it to the local replica. You can then interact with it just as described in the guide above.
+
+### Debugging
+
+If you want to be able to see the logs coming from your local canister when running it in a local replica, start the replica with:
+
+```bash
+$ dfx start --clean --background -vv --log file --logfile /tmp/dfx.log
+```
+and follow the logs in `/tmp/dfx.log`

--- a/rs/rosetta-api/icp_ledger/ledger/BUILD.bazel
+++ b/rs/rosetta-api/icp_ledger/ledger/BUILD.bazel
@@ -159,3 +159,15 @@ rust_ic_test(
         "@crate_index//:serde_bytes",
     ],
 )
+
+# Deploys the ledger canister to a running local replica.
+sh_binary(
+    name = "dfx_deploy",
+    srcs = ["scripts/dfx_deploy.sh"],
+    data = [
+        "dfx.json",
+        ":ledger-canister-wasm",
+        "//rs/rosetta-api/icp_ledger:ledger.did",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/rs/rosetta-api/icp_ledger/ledger/dfx.json
+++ b/rs/rosetta-api/icp_ledger/ledger/dfx.json
@@ -1,0 +1,22 @@
+{
+    "canisters": {
+        "icp_ledger_canister": {
+            "type": "custom",
+            "candid": "../ledger.did",
+            "wasm": "ledger-canister-wasm.wasm.gz",
+            "remote": {
+                "id": {
+                    "ic": "ryjl3-tyaaa-aaaaa-aaaba-cai"
+                }
+            }
+        }
+    },
+    "defaults": {
+        "build": {
+            "args": "",
+            "packtool": ""
+        }
+    },
+    "output_env_file": ".env",
+    "version": 1
+}

--- a/rs/rosetta-api/icp_ledger/ledger/scripts/dfx_deploy.sh
+++ b/rs/rosetta-api/icp_ledger/ledger/scripts/dfx_deploy.sh
@@ -14,6 +14,12 @@ if [[ -z "$DEFAULT_ACCOUNT_ID" ]]; then
     exit 1
 fi
 
+# Check if dfx is installed
+if ! command -v dfx &>/dev/null; then
+    echo "Error: dfx is not installed"
+    exit 1
+fi
+
 # Check if a local replica is running
 if ! dfx ping &>/dev/null; then
     echo "Error: Local replica is not running"

--- a/rs/rosetta-api/icp_ledger/ledger/scripts/dfx_deploy.sh
+++ b/rs/rosetta-api/icp_ledger/ledger/scripts/dfx_deploy.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+# This script is supposed to be run only through Bazel: bazel run //rs/rosetta-api/icp_ledger/ledger/scripts:dfx_deploy
+# It deploys the icp_ledger_canister canister with the specified arguments
+
+# Check if necessary environment variables are set
+if [[ -z "$MINTER_ACCOUNT_ID" ]]; then
+    echo "Error: MINTER_ACCOUNT_ID environment variable is not set"
+    exit 1
+fi
+
+if [[ -z "$DEFAULT_ACCOUNT_ID" ]]; then
+    echo "Error: DEFAULT_ACCOUNT_ID environment variable is not set"
+    exit 1
+fi
+
+# Check if a local replica is running
+if ! dfx ping &>/dev/null; then
+    echo "Error: Local replica is not running"
+    exit 1
+fi
+
+base_dir=$(pwd)
+dir="$base_dir/rs/rosetta-api/icp_ledger/ledger"
+
+cd $dir
+
+# Force-delete file .dfx/local/canisters/icp_ledger_canister/icp_ledger_canister.wasm.gz if it exists.
+# At the moment this file is somehow immutable (no write permissions) and can't be overwritten by dfx deploy.
+rm -f .dfx/local/canisters/icp_ledger_canister/icp_ledger_canister.wasm.gz
+
+canister_id="ryjl3-tyaaa-aaaaa-aaaba-cai"
+
+# Check if canister is already installed. If so, stop and delete it.
+if dfx canister status $canister_id &>/dev/null; then
+    echo "Canister icp_ledger_canister is already installed. Stopping and deleting..."
+    dfx canister stop $canister_id
+    dfx canister delete --no-withdrawal $canister_id
+fi
+
+echo "Deploying icp_ledger_canister with the following arguments:"
+echo "  MINTER_ACCOUNT_ID: $MINTER_ACCOUNT_ID"
+echo "  DEFAULT_ACCOUNT_ID: $DEFAULT_ACCOUNT_ID"
+echo "In directory: $dir $RUNFILES_DIR"
+
+command="dfx --verbose deploy --mode auto --specified-id ryjl3-tyaaa-aaaaa-aaaba-cai icp_ledger_canister --argument \"
+    (variant {
+        Init = record {
+            minting_account = \\\"$MINTER_ACCOUNT_ID\\\";
+            initial_values = vec {
+                record {
+                    \\\"$DEFAULT_ACCOUNT_ID\\\";
+                    record {
+                        e8s = 10_000_000_000 : nat64;
+                    };
+                };
+            };
+            send_whitelist = vec {};
+            transfer_fee = opt record {
+                e8s = 10_000 : nat64;
+            };
+            token_symbol = opt \\\"LICP\\\";
+            token_name = opt \\\"Local ICP\\\";
+        }
+    })
+\""
+
+echo "Command: $command"
+eval $command
+
+cd $base_dir


### PR DESCRIPTION
Adding a simple bazel target to make it easier building and deploying the icp ledger to a local ic replica using a single command.

The script run by the target also does any necessary cleanup required between deploying a new version of the canister when an older one is currently running there.