### PR TITLE
feat: [CON-1373] Introduce metrics to the block stripper/assembler

### DIFF
--- a/rs/p2p/artifact_downloader/src/fetch_stripped_artifact/assembler.rs
+++ b/rs/p2p/artifact_downloader/src/fetch_stripped_artifact/assembler.rs
@@ -211,7 +211,7 @@ impl ArtifactAssembler<ConsensusMessage, MaybeStrippedConsensusMessage>
         }
 
         // Only report the metric if we actually downloaded some ingresses from peers
-        if ingress_messages_from_peers == 0 {
+        if ingress_messages_from_peers > 0 {
             timer.stop_and_record();
         } else {
             timer.stop_and_discard();

--- a/rs/p2p/artifact_downloader/src/fetch_stripped_artifact/metrics.rs
+++ b/rs/p2p/artifact_downloader/src/fetch_stripped_artifact/metrics.rs
@@ -1,10 +1,56 @@
-use ic_metrics::MetricsRegistry;
+use ic_metrics::{buckets::decimal_buckets_with_zero, MetricsRegistry};
+use prometheus::{Histogram, HistogramVec};
+
+const SOURCE_LABEL: &str = "source";
 
 #[derive(Clone)]
-pub(super) struct FetchStrippedConsensusArtifactMetrics {}
+pub(crate) struct FetchStrippedConsensusArtifactMetrics {
+    pub(crate) ingress_messages_in_a_block_count: HistogramVec,
+    pub(crate) download_missing_ingress_messages_duration: Histogram,
+    pub(crate) total_block_assembly_duration: Histogram,
+}
+
+#[derive(Copy, Clone)]
+pub(crate) enum IngressMessageSource {
+    Peer,
+    IngressPool,
+}
+
+impl IngressMessageSource {
+    fn as_str(&self) -> &str {
+        match self {
+            IngressMessageSource::Peer => "peer",
+            IngressMessageSource::IngressPool => "ingress_pool",
+        }
+    }
+}
 
 impl FetchStrippedConsensusArtifactMetrics {
-    pub(crate) fn new(_metrics_registry: &MetricsRegistry) -> Self {
-        Self {}
+    pub(crate) fn new(metrics_registry: &MetricsRegistry) -> Self {
+        Self {
+            ingress_messages_in_a_block_count: metrics_registry.histogram_vec(
+                    "ic_stripped_consensus_artifact_downloader_ingress_messages_in_a_block_count",
+                    "Number of ingress messages in a block partitioned by the source of the \
+                    ingress message (a peer or replica's own ingress pool)",
+                    decimal_buckets_with_zero(0, 3),
+                    &[SOURCE_LABEL],
+            ),
+            download_missing_ingress_messages_duration: metrics_registry.histogram(
+                    "ic_stripped_consensus_artifact_downloader_missing_stripped_ingress_messages_fetch_duration",
+                    "Download time for all the missing ingress messages in the block",
+                    decimal_buckets_with_zero(-2, 1),
+            ),
+            total_block_assembly_duration: metrics_registry.histogram(
+                    "ic_stripped_consensus_artifact_total_duration",
+                    "Total time to download and assemble a block",
+                    decimal_buckets_with_zero(-2, 1),
+            ),
+        }
+    }
+
+    pub(crate) fn report_ingress_messages_count(&self, source: IngressMessageSource, count: u64) {
+        self.ingress_messages_in_a_block_count
+            .with_label_values(&[source.as_str()])
+            .observe(count as f64)
     }
 }

--- a/rs/p2p/artifact_downloader/src/fetch_stripped_artifact/metrics.rs
+++ b/rs/p2p/artifact_downloader/src/fetch_stripped_artifact/metrics.rs
@@ -41,7 +41,7 @@ impl FetchStrippedConsensusArtifactMetrics {
                     decimal_buckets_with_zero(-2, 1),
             ),
             total_block_assembly_duration: metrics_registry.histogram(
-                    "ic_stripped_consensus_artifact_total_duration",
+                    "ic_stripped_consensus_artifact_total_block_assembly_duration",
                     "Total time to download and assemble a block",
                     decimal_buckets_with_zero(-2, 1),
             ),

--- a/rs/p2p/artifact_downloader/src/fetch_stripped_artifact/metrics.rs
+++ b/rs/p2p/artifact_downloader/src/fetch_stripped_artifact/metrics.rs
@@ -37,12 +37,12 @@ impl FetchStrippedConsensusArtifactMetrics {
             ),
             download_missing_ingress_messages_duration: metrics_registry.histogram(
                     "ic_stripped_consensus_artifact_downloader_missing_stripped_ingress_messages_fetch_duration",
-                    "Download time for all the missing ingress messages in the block",
+                    "Download time for all the missing ingress messages in the block, in seconds",
                     decimal_buckets_with_zero(-2, 1),
             ),
             total_block_assembly_duration: metrics_registry.histogram(
                     "ic_stripped_consensus_artifact_total_block_assembly_duration",
-                    "Total time to download and assemble a block",
+                    "Total time to download and assemble a block, in seconds",
                     decimal_buckets_with_zero(-2, 1),
             ),
         }

--- a/rs/p2p/artifact_downloader/src/fetch_stripped_artifact/metrics.rs
+++ b/rs/p2p/artifact_downloader/src/fetch_stripped_artifact/metrics.rs
@@ -1,17 +1,20 @@
 use ic_metrics::{buckets::decimal_buckets_with_zero, MetricsRegistry};
-use prometheus::{Histogram, HistogramVec};
+use prometheus::{Histogram, HistogramVec, IntCounter, IntGauge};
 
 const SOURCE_LABEL: &str = "source";
 
 #[derive(Clone)]
-pub(crate) struct FetchStrippedConsensusArtifactMetrics {
-    pub(crate) ingress_messages_in_a_block_count: HistogramVec,
-    pub(crate) download_missing_ingress_messages_duration: Histogram,
-    pub(crate) total_block_assembly_duration: Histogram,
+pub(super) struct FetchStrippedConsensusArtifactMetrics {
+    pub(super) ingress_messages_in_a_block_count: HistogramVec,
+    pub(super) download_missing_ingress_messages_duration: Histogram,
+    pub(super) missing_ingress_messages_bytes: Histogram,
+    pub(super) total_block_assembly_duration: Histogram,
+    pub(super) active_ingress_message_downloads: IntGauge,
+    pub(super) total_ingress_message_download_errors: IntCounter,
 }
 
 #[derive(Copy, Clone)]
-pub(crate) enum IngressMessageSource {
+pub(super) enum IngressMessageSource {
     Peer,
     IngressPool,
 }
@@ -26,7 +29,7 @@ impl IngressMessageSource {
 }
 
 impl FetchStrippedConsensusArtifactMetrics {
-    pub(crate) fn new(metrics_registry: &MetricsRegistry) -> Self {
+    pub(super) fn new(metrics_registry: &MetricsRegistry) -> Self {
         Self {
             ingress_messages_in_a_block_count: metrics_registry.histogram_vec(
                     "ic_stripped_consensus_artifact_downloader_ingress_messages_in_a_block_count",
@@ -40,17 +43,61 @@ impl FetchStrippedConsensusArtifactMetrics {
                     "Download time for all the missing ingress messages in the block, in seconds",
                     decimal_buckets_with_zero(-2, 1),
             ),
+            missing_ingress_messages_bytes: metrics_registry.histogram(
+                    "ic_stripped_consensus_artifact_downloader_missing_ingress_messages_bytes",
+                    "Size of missing ingress messages, in bytes",
+                    // 0B, 1B, ..., 5MB
+                    decimal_buckets_with_zero(0, 6),
+            ),
             total_block_assembly_duration: metrics_registry.histogram(
                     "ic_stripped_consensus_artifact_total_block_assembly_duration",
                     "Total time to download and assemble a block, in seconds",
                     decimal_buckets_with_zero(-2, 1),
             ),
+            active_ingress_message_downloads: metrics_registry.int_gauge(
+                    "ic_stripped_consensus_artifact_active_ingress_message_downloads",
+                    "The number of active missing ingress message downloads",
+            ),
+            total_ingress_message_download_errors: metrics_registry.int_counter(
+                    "ic_stripped_consensus_artifact_total_ingress_message_download_errors",
+                    "The total number of errors occurred while downloading \
+                    missing ingress messages",
+            ),
         }
     }
 
-    pub(crate) fn report_ingress_messages_count(&self, source: IngressMessageSource, count: u64) {
+    pub(super) fn report_ingress_messages_count(&self, source: IngressMessageSource, count: u64) {
         self.ingress_messages_in_a_block_count
             .with_label_values(&[source.as_str()])
             .observe(count as f64)
+    }
+}
+
+#[derive(Clone)]
+pub(super) struct IngressSenderMetrics {
+    pub(super) ingress_messages_in_ingress_pool: IntCounter,
+    pub(super) ingress_messages_in_block: IntCounter,
+    pub(super) ingress_messages_not_found: IntCounter,
+}
+
+impl IngressSenderMetrics {
+    pub(super) fn new(metrics_registry: &MetricsRegistry) -> Self {
+        Self {
+            ingress_messages_in_ingress_pool: metrics_registry.int_counter(
+                "ic_stripped_consensus_artifact_sender_ingress_messages_in_ingress_pool",
+                "Total number number of handled requests \
+                where the requested ingress message was found in the ingress pool",
+            ),
+            ingress_messages_in_block: metrics_registry.int_counter(
+                "ic_stripped_consensus_artifact_sender_ingress_messages_in_block",
+                "Total number number of handled requests \
+                where the requested ingress message was found in a block in the consensus pool",
+            ),
+            ingress_messages_not_found: metrics_registry.int_counter(
+                "ic_stripped_consensus_artifact_sender_ingress_messages_not_found",
+                "Total number number of handled requests \
+                where the requested ingress message was not found",
+            ),
+        }
     }
 }


### PR DESCRIPTION
Sample of metrics fetched in a middle of `consensus_performance_test`:
```
# HELP ic_stripped_consensus_artifact_downloader_ingress_messages_in_a_block_count Number of ingress messages in a block partitioned by the source of the ingress message (a peer or replica's own ingress pool)
# TYPE ic_stripped_consensus_artifact_downloader_ingress_messages_in_a_block_count histogram
ic_stripped_consensus_artifact_downloader_ingress_messages_in_a_block_count_bucket{source="ingress_pool",le="0"} 131
ic_stripped_consensus_artifact_downloader_ingress_messages_in_a_block_count_bucket{source="ingress_pool",le="1"} 140
ic_stripped_consensus_artifact_downloader_ingress_messages_in_a_block_count_bucket{source="ingress_pool",le="2"} 140
ic_stripped_consensus_artifact_downloader_ingress_messages_in_a_block_count_bucket{source="ingress_pool",le="5"} 140
ic_stripped_consensus_artifact_downloader_ingress_messages_in_a_block_count_bucket{source="ingress_pool",le="10"} 140
ic_stripped_consensus_artifact_downloader_ingress_messages_in_a_block_count_bucket{source="ingress_pool",le="20"} 140
ic_stripped_consensus_artifact_downloader_ingress_messages_in_a_block_count_bucket{source="ingress_pool",le="50"} 140
ic_stripped_consensus_artifact_downloader_ingress_messages_in_a_block_count_bucket{source="ingress_pool",le="100"} 140
ic_stripped_consensus_artifact_downloader_ingress_messages_in_a_block_count_bucket{source="ingress_pool",le="200"} 140
ic_stripped_consensus_artifact_downloader_ingress_messages_in_a_block_count_bucket{source="ingress_pool",le="500"} 170
ic_stripped_consensus_artifact_downloader_ingress_messages_in_a_block_count_bucket{source="ingress_pool",le="1000"} 321
ic_stripped_consensus_artifact_downloader_ingress_messages_in_a_block_count_bucket{source="ingress_pool",le="2000"} 321
ic_stripped_consensus_artifact_downloader_ingress_messages_in_a_block_count_bucket{source="ingress_pool",le="5000"} 321
ic_stripped_consensus_artifact_downloader_ingress_messages_in_a_block_count_bucket{source="ingress_pool",le="+Inf"} 321
ic_stripped_consensus_artifact_downloader_ingress_messages_in_a_block_count_sum{source="ingress_pool"} 91978
ic_stripped_consensus_artifact_downloader_ingress_messages_in_a_block_count_count{source="ingress_pool"} 321
ic_stripped_consensus_artifact_downloader_ingress_messages_in_a_block_count_bucket{source="peer",le="0"} 121
ic_stripped_consensus_artifact_downloader_ingress_messages_in_a_block_count_bucket{source="peer",le="1"} 121
ic_stripped_consensus_artifact_downloader_ingress_messages_in_a_block_count_bucket{source="peer",le="2"} 121
ic_stripped_consensus_artifact_downloader_ingress_messages_in_a_block_count_bucket{source="peer",le="5"} 121
ic_stripped_consensus_artifact_downloader_ingress_messages_in_a_block_count_bucket{source="peer",le="10"} 132
ic_stripped_consensus_artifact_downloader_ingress_messages_in_a_block_count_bucket{source="peer",le="20"} 302
ic_stripped_consensus_artifact_downloader_ingress_messages_in_a_block_count_bucket{source="peer",le="50"} 302
ic_stripped_consensus_artifact_downloader_ingress_messages_in_a_block_count_bucket{source="peer",le="100"} 302
ic_stripped_consensus_artifact_downloader_ingress_messages_in_a_block_count_bucket{source="peer",le="200"} 302
ic_stripped_consensus_artifact_downloader_ingress_messages_in_a_block_count_bucket{source="peer",le="500"} 302
ic_stripped_consensus_artifact_downloader_ingress_messages_in_a_block_count_bucket{source="peer",le="1000"} 321
ic_stripped_consensus_artifact_downloader_ingress_messages_in_a_block_count_bucket{source="peer",le="2000"} 321
ic_stripped_consensus_artifact_downloader_ingress_messages_in_a_block_count_bucket{source="peer",le="5000"} 321
ic_stripped_consensus_artifact_downloader_ingress_messages_in_a_block_count_bucket{source="peer",le="+Inf"} 321
ic_stripped_consensus_artifact_downloader_ingress_messages_in_a_block_count_sum{source="peer"} 11982
ic_stripped_consensus_artifact_downloader_ingress_messages_in_a_block_count_count{source="peer"} 321
# HELP ic_stripped_consensus_artifact_downloader_missing_stripped_ingress_messages_fetch_duration Download time for all the missing ingress messages in the block
# TYPE ic_stripped_consensus_artifact_downloader_missing_stripped_ingress_messages_fetch_duration histogram
ic_stripped_consensus_artifact_downloader_missing_stripped_ingress_messages_fetch_duration_bucket{le="0"} 0
ic_stripped_consensus_artifact_downloader_missing_stripped_ingress_messages_fetch_duration_bucket{le="0.01"} 0
ic_stripped_consensus_artifact_downloader_missing_stripped_ingress_messages_fetch_duration_bucket{le="0.02"} 0
ic_stripped_consensus_artifact_downloader_missing_stripped_ingress_messages_fetch_duration_bucket{le="0.05"} 0
ic_stripped_consensus_artifact_downloader_missing_stripped_ingress_messages_fetch_duration_bucket{le="0.1"} 0
ic_stripped_consensus_artifact_downloader_missing_stripped_ingress_messages_fetch_duration_bucket{le="0.2"} 0
ic_stripped_consensus_artifact_downloader_missing_stripped_ingress_messages_fetch_duration_bucket{le="0.5"} 179
ic_stripped_consensus_artifact_downloader_missing_stripped_ingress_messages_fetch_duration_bucket{le="1"} 199
ic_stripped_consensus_artifact_downloader_missing_stripped_ingress_messages_fetch_duration_bucket{le="2"} 200
ic_stripped_consensus_artifact_downloader_missing_stripped_ingress_messages_fetch_duration_bucket{le="5"} 200
ic_stripped_consensus_artifact_downloader_missing_stripped_ingress_messages_fetch_duration_bucket{le="10"} 200
ic_stripped_consensus_artifact_downloader_missing_stripped_ingress_messages_fetch_duration_bucket{le="20"} 200
ic_stripped_consensus_artifact_downloader_missing_stripped_ingress_messages_fetch_duration_bucket{le="50"} 200
ic_stripped_consensus_artifact_downloader_missing_stripped_ingress_messages_fetch_duration_bucket{le="+Inf"} 200
ic_stripped_consensus_artifact_downloader_missing_stripped_ingress_messages_fetch_duration_sum 88.91445158799998
ic_stripped_consensus_artifact_downloader_missing_stripped_ingress_messages_fetch_duration_count 200
# HELP ic_stripped_consensus_artifact_total_block_assembly_duration Total time to download and assemble a block
# TYPE ic_stripped_consensus_artifact_total_block_assembly_duration histogram
ic_stripped_consensus_artifact_total_block_assembly_duration_bucket{le="0"} 0
ic_stripped_consensus_artifact_total_block_assembly_duration_bucket{le="0.01"} 201
ic_stripped_consensus_artifact_total_block_assembly_duration_bucket{le="0.02"} 201
ic_stripped_consensus_artifact_total_block_assembly_duration_bucket{le="0.05"} 201
ic_stripped_consensus_artifact_total_block_assembly_duration_bucket{le="0.1"} 201
ic_stripped_consensus_artifact_total_block_assembly_duration_bucket{le="0.2"} 201
ic_stripped_consensus_artifact_total_block_assembly_duration_bucket{le="0.5"} 383
ic_stripped_consensus_artifact_total_block_assembly_duration_bucket{le="1"} 397
ic_stripped_consensus_artifact_total_block_assembly_duration_bucket{le="2"} 404
ic_stripped_consensus_artifact_total_block_assembly_duration_bucket{le="5"} 404
ic_stripped_consensus_artifact_total_block_assembly_duration_bucket{le="10"} 404
ic_stripped_consensus_artifact_total_block_assembly_duration_bucket{le="20"} 404
ic_stripped_consensus_artifact_total_block_assembly_duration_bucket{le="50"} 404
ic_stripped_consensus_artifact_total_block_assembly_duration_bucket{le="+Inf"} 404
ic_stripped_consensus_artifact_total_block_assembly_duration_sum 99.41349974500001
ic_stripped_consensus_artifact_total_block_assembly_duration_count 404
```