### PR TITLE
feat(nns): hotkey can remove itself from a neuron

### DIFF
--- a/rs/nns/governance/src/neuron/types.rs
+++ b/rs/nns/governance/src/neuron/types.rs
@@ -590,6 +590,27 @@ impl Neuron {
                     ))
                 }
             }
+            Operation::RemoveHotKey(remove_hot_key) => {
+                let caller_asking_to_remove_self = remove_hot_key
+                    .hot_key_to_remove
+                    .as_ref()
+                    .map(|hk| hk == caller)
+                    .unwrap_or_default();
+
+                if self.is_controlled_by(caller)
+                    || (self.is_hotkey_or_controller(caller) && caller_asking_to_remove_self)
+                {
+                    Ok(())
+                } else {
+                    Err(GovernanceError::new_with_message(
+                        ErrorType::NotAuthorized,
+                        format!(
+                            "Caller '{:?}' must be the controller or the hot key that is being removed from the neuron.",
+                            caller,
+                        ),
+                    ))
+                }
+            }
 
             // Only the controller is allowed to perform other configure operations.
             _ => {


### PR DESCRIPTION
Allow hotkeys to remove themselves from neurons, to protect against situations where someone's hotkey is erroneously added to many irrelevant neurons (a form of spam)