### PR TITLE
refactor(nervous-system): Make ic-nervous-system-agent generic over how it calls canisters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9541,6 +9541,7 @@ dependencies = [
  "ic-sns-wasm",
  "serde",
  "tempfile",
+ "thiserror",
  "tokio",
 ]
 

--- a/rs/nervous_system/agent/BUILD.bazel
+++ b/rs/nervous_system/agent/BUILD.bazel
@@ -14,6 +14,7 @@ DEPENDENCIES = [
     "@crate_index//:ic-agent",
     "@crate_index//:serde",
     "@crate_index//:tempfile",
+    "@crate_index//:thiserror",
     "@crate_index//:tokio",
 ]
 

--- a/rs/nervous_system/agent/Cargo.toml
+++ b/rs/nervous_system/agent/Cargo.toml
@@ -18,4 +18,5 @@ ic-sns-wasm = { path = "../../nns/sns-wasm" }
 ic-sns-governance = { path = "../../sns/governance" }
 serde = { workspace = true }
 tempfile = { workspace = true }
+thiserror = { workspace = true }
 tokio = { workspace = true }

--- a/rs/nervous_system/agent/src/lib.rs
+++ b/rs/nervous_system/agent/src/lib.rs
@@ -1,37 +1,62 @@
 pub mod nns;
 pub mod sns;
 
-use anyhow::{anyhow, Result};
-use candid::{Decode, Encode, Principal};
+use candid::Principal;
 use ic_agent::Agent;
 use ic_nervous_system_clients::Request;
+use std::fmt::Display;
+use thiserror::Error;
 
-pub(crate) async fn call<R: Request>(
-    agent: &Agent,
-    canister_id: impl Into<Principal>,
-    request: R,
-) -> Result<R::Response> {
-    let canister_id = canister_id.into();
-    let request_bytes = Encode!(&request)?;
-    let response = if R::UPDATE {
-        let request = agent
-            .update(&canister_id, R::METHOD)
-            .with_arg(request_bytes)
-            .call()
-            .await?;
-        match request {
-            ic_agent::agent::CallResponse::Response(response) => response,
-            ic_agent::agent::CallResponse::Poll(request_id) => {
-                agent.wait(&request_id, canister_id).await?
+pub trait CallCanisters {
+    type Error: Display + Send;
+    fn call<R: Request>(
+        &self,
+        canister_id: impl Into<Principal> + Send,
+        request: R,
+    ) -> impl std::future::Future<Output = Result<R::Response, Self::Error>> + Send;
+}
+
+#[derive(Error, Debug)]
+pub enum AgentCallError {
+    #[error("agent error: {0}")]
+    AgentError(#[from] ic_agent::AgentError),
+    #[error("canister request could not be encoded: {0}")]
+    CandidEncodeError(candid::Error),
+    #[error("canister did not respond with the expected response type: {0}")]
+    CandidDecodeError(candid::Error),
+}
+
+impl CallCanisters for Agent {
+    type Error = AgentCallError;
+    async fn call<R: Request>(
+        &self,
+        canister_id: impl Into<Principal> + Send,
+        request: R,
+    ) -> Result<R::Response, Self::Error> {
+        let canister_id = canister_id.into();
+        let request_bytes =
+            candid::encode_one(&request).map_err(AgentCallError::CandidEncodeError)?;
+        let response = if R::UPDATE {
+            let request = self
+                .update(&canister_id, R::METHOD)
+                .with_arg(request_bytes)
+                .call()
+                .await?;
+            match request {
+                ic_agent::agent::CallResponse::Response(response) => response,
+                ic_agent::agent::CallResponse::Poll(request_id) => {
+                    self.wait(&request_id, canister_id).await?
+                }
             }
-        }
-    } else {
-        agent
-            .query(&canister_id, R::METHOD)
-            .with_arg(request_bytes)
-            .call()
-            .await?
-    };
+        } else {
+            self.query(&canister_id, R::METHOD)
+                .with_arg(request_bytes)
+                .call()
+                .await?
+        };
 
-    Decode!(response.as_slice(), R::Response).map_err(|e| anyhow!(e))
+        let response =
+            candid::decode_one(response.as_slice()).map_err(AgentCallError::CandidDecodeError)?;
+        Ok(response)
+    }
 }

--- a/rs/nervous_system/agent/src/nns/sns_wasm.rs
+++ b/rs/nervous_system/agent/src/nns/sns_wasm.rs
@@ -1,5 +1,5 @@
 use crate::sns::Sns;
-use anyhow::{anyhow, Result};
+use anyhow::anyhow;
 use ic_agent::Agent;
 use ic_nns_constants::SNS_WASM_CANISTER_ID;
 use ic_sns_wasm::pb::v1::{
@@ -13,26 +13,40 @@ use tokio::io::AsyncWriteExt;
 use tokio::io::BufWriter;
 use tokio::process::Command;
 
-use crate::call;
+use crate::CallCanisters;
 
-pub async fn query_sns_upgrade_steps(agent: &Agent) -> Result<ListUpgradeStepsResponse> {
+pub async fn query_sns_upgrade_steps<C: CallCanisters>(
+    agent: &C,
+) -> Result<ListUpgradeStepsResponse, C::Error> {
     let request = ListUpgradeStepsRequest {
         limit: 0,
         sns_governance_canister_id: None,
         starting_at: None,
     };
-    call(agent, SNS_WASM_CANISTER_ID, request).await
+    agent.call(SNS_WASM_CANISTER_ID, request).await
+}
+
+pub async fn list_deployed_snses<C: CallCanisters>(agent: &C) -> Result<Vec<Sns>, C::Error> {
+    let response = agent
+        .call(SNS_WASM_CANISTER_ID, ListDeployedSnsesRequest {})
+        .await?;
+    let snses = response
+        .instances
+        .into_iter()
+        .filter_map(|deployed_sns| crate::sns::Sns::try_from(deployed_sns).ok())
+        .collect::<Vec<_>>();
+    Ok(snses)
 }
 
 pub async fn get_git_version_for_sns_hash(
     agent: &Agent,
     ic_wasm_path: &Path,
     hash: &[u8],
-) -> Result<String> {
+) -> anyhow::Result<String> {
     let request = GetWasmRequest {
         hash: hash.to_vec(),
     };
-    let response: GetWasmResponse = call(agent, SNS_WASM_CANISTER_ID, request).await?;
+    let response: GetWasmResponse = agent.call(SNS_WASM_CANISTER_ID, request).await?;
 
     let dir = tempdir()?;
     let wasm_file_gz: PathBuf = write_wasm_to_temp_file(&response, dir.path()).await?;
@@ -42,20 +56,10 @@ pub async fn get_git_version_for_sns_hash(
     Ok(git_commit_id)
 }
 
-pub async fn list_deployed_snses(agent: &Agent) -> Result<Vec<Sns>> {
-    let response = call(agent, SNS_WASM_CANISTER_ID, ListDeployedSnsesRequest {}).await?;
-    let snses = response
-        .instances
-        .into_iter()
-        .filter_map(|deployed_sns| crate::sns::Sns::try_from(deployed_sns).ok())
-        .collect::<Vec<_>>();
-    Ok(snses)
-}
-
 async fn write_wasm_to_temp_file(
     get_wasm_response: &GetWasmResponse,
     path: &Path,
-) -> Result<PathBuf> {
+) -> anyhow::Result<PathBuf> {
     let file_path = path.join("wasm_file.wasm.gz");
     let file = File::create(&file_path).await?;
     let mut writer = BufWriter::new(file);
@@ -65,7 +69,7 @@ async fn write_wasm_to_temp_file(
     Ok(file_path)
 }
 
-async fn decompress_gzip(file_path: &Path) -> Result<PathBuf> {
+async fn decompress_gzip(file_path: &Path) -> anyhow::Result<PathBuf> {
     let output_path = file_path
         .to_str()
         .ok_or_else(|| anyhow!("Failed to convert file path to string"))?
@@ -81,7 +85,10 @@ async fn decompress_gzip(file_path: &Path) -> Result<PathBuf> {
     Ok(PathBuf::from(output_path))
 }
 
-async fn extract_git_commit_id(file_path: &Path, ic_wasm_binary_path: &Path) -> Result<String> {
+async fn extract_git_commit_id(
+    file_path: &Path,
+    ic_wasm_binary_path: &Path,
+) -> anyhow::Result<String> {
     if !file_path.exists() {
         return Err(anyhow!("WASM file does not exist"));
     }

--- a/rs/nervous_system/agent/src/sns/governance.rs
+++ b/rs/nervous_system/agent/src/sns/governance.rs
@@ -1,10 +1,7 @@
-use anyhow::Result;
-use ic_agent::Agent;
+use crate::CallCanisters;
 use ic_base_types::PrincipalId;
 use ic_sns_governance::pb::v1::{GetMetadataRequest, GetMetadataResponse};
 use serde::{Deserialize, Serialize};
-
-use crate::call;
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct GovernanceCanister {
@@ -12,7 +9,10 @@ pub struct GovernanceCanister {
 }
 
 impl GovernanceCanister {
-    pub async fn metadata(&self, agent: &Agent) -> Result<GetMetadataResponse> {
-        call(agent, self.canister_id, GetMetadataRequest {}).await
+    pub async fn metadata<C: CallCanisters>(
+        &self,
+        agent: &C,
+    ) -> Result<GetMetadataResponse, C::Error> {
+        agent.call(self.canister_id, GetMetadataRequest {}).await
     }
 }

--- a/rs/nervous_system/clients/src/request.rs
+++ b/rs/nervous_system/clients/src/request.rs
@@ -1,7 +1,7 @@
 use candid::CandidType;
 use serde::de::DeserializeOwned;
 
-pub trait Request: CandidType {
+pub trait Request: CandidType + Send {
     type Response: CandidType + DeserializeOwned;
     const METHOD: &'static str;
 


### PR DESCRIPTION
## Problem

The ic-nervous-system-agent library is hardcoded to only work with ic_agent. However, we may want to use its functions in a context where we don't have ic_agent. 

## Solution

Create a `CallCanisters` trait that represents an object with the capability to call a canister. Implement that trait for `Agent`. In the future, implementations can also be created for other types. This is easy to do now, since rust now finally supports async traits without hacks. 

The trait has a `call` function, and different implementations support different errors. This is useful because different ways of calling canisters have different plausible errors (e.g. you are not going to get a boundary node error when a canister calls another, but you might when an external user calls a canister).

This also means that ic-nervous-system-agent functions for calling canisters no longer need to return `anyhow::Result`! They can instead return the appropriate error type based on the caller's context. This is more appropriate for libraries that want to give as much information to their callers as possible (as opposed to `anyhow::Result` which is pretty opaque)