### PR TITLE
feat(nns): Disable NnsCanisterUpgrade and NnsRootUpgrade in favor of InstallCode

### DIFF
--- a/rs/nervous_system/integration_tests/src/pocket_ic_helpers.rs
+++ b/rs/nervous_system/integration_tests/src/pocket_ic_helpers.rs
@@ -4,7 +4,6 @@ use ic_base_types::{CanisterId, PrincipalId, SubnetId};
 use ic_ledger_core::Tokens;
 use ic_nervous_system_common::{E8, ONE_DAY_SECONDS};
 use ic_nervous_system_common_test_keys::{TEST_NEURON_1_ID, TEST_NEURON_1_OWNER_PRINCIPAL};
-use ic_nervous_system_root::change_canister::ChangeCanisterRequest;
 use ic_nns_common::pb::v1::{NeuronId, ProposalId};
 use ic_nns_constants::{
     self, ALL_NNS_CANISTER_IDS, GOVERNANCE_CANISTER_ID, LEDGER_CANISTER_ID, LIFELINE_CANISTER_ID,
@@ -24,7 +23,6 @@ use ic_nns_test_utils::{
         build_mainnet_registry_wasm, build_mainnet_root_wasm, build_mainnet_sns_wasms_wasm,
         build_registry_wasm, build_root_wasm, build_sns_wasms_wasm, NnsInitPayloadsBuilder,
     },
-    governance::UpgradeRootProposal,
     sns_wasm::{
         build_archive_sns_wasm, build_governance_sns_wasm, build_index_ng_sns_wasm,
         build_ledger_sns_wasm, build_mainnet_archive_sns_wasm, build_mainnet_governance_sns_wasm,

--- a/rs/nns/governance/src/governance.rs
+++ b/rs/nns/governance/src/governance.rs
@@ -404,20 +404,14 @@ impl NnsFunction {
     fn allowed_when_resources_are_low(&self) -> bool {
         matches!(
             self,
-            NnsFunction::NnsRootUpgrade
-                | NnsFunction::NnsCanisterUpgrade
-                | NnsFunction::HardResetNnsRootToVersion
-                | NnsFunction::ReviseElectedGuestosVersions
-                | NnsFunction::DeployGuestosToAllSubnetNodes
+            NnsFunction::ReviseElectedGuestosVersions | NnsFunction::DeployGuestosToAllSubnetNodes
         )
     }
 
     fn can_have_large_payload(&self) -> bool {
         matches!(
             self,
-            NnsFunction::NnsCanisterUpgrade
-                | NnsFunction::NnsCanisterInstall
-                | NnsFunction::NnsRootUpgrade
+            NnsFunction::NnsCanisterInstall
                 | NnsFunction::HardResetNnsRootToVersion
                 | NnsFunction::AddSnsWasm
         )
@@ -433,6 +427,8 @@ impl NnsFunction {
                 | NnsFunction::UpdateNodesHostosVersion
                 | NnsFunction::BlessReplicaVersion
                 | NnsFunction::RetireReplicaVersion
+                | NnsFunction::NnsCanisterUpgrade
+                | NnsFunction::NnsRootUpgrade
         )
     }
 }

--- a/rs/nns/governance/src/governance/tests/mod.rs
+++ b/rs/nns/governance/src/governance/tests/mod.rs
@@ -1583,10 +1583,6 @@ fn test_validate_execute_nns_function() {
             payload: vec![1u8; PROPOSAL_EXECUTE_NNS_FUNCTION_PAYLOAD_BYTES_MAX],
         },
         ExecuteNnsFunction {
-            nns_function: NnsFunction::NnsCanisterUpgrade as i32,
-            payload: vec![1u8; PROPOSAL_EXECUTE_NNS_FUNCTION_PAYLOAD_BYTES_MAX + 1],
-        },
-        ExecuteNnsFunction {
             nns_function: NnsFunction::IcpXdrConversionRate as i32,
             payload: Encode!(&UpdateIcpXdrConversionRatePayload {
                 xdr_permyriad_per_icp: 101,

--- a/rs/nns/governance/tests/degraded_mode.rs
+++ b/rs/nns/governance/tests/degraded_mode.rs
@@ -6,19 +6,21 @@ use futures::future::FutureExt;
 use ic_base_types::{CanisterId, PrincipalId};
 use ic_nervous_system_common::{cmc::CMC, ledger::IcpLedger, NervousSystemError};
 use ic_nns_common::pb::v1::NeuronId;
+use ic_nns_constants::GOVERNANCE_CANISTER_ID;
 use ic_nns_governance::{
     governance::{
         Environment, Governance, HeapGrowthPotential, HEAP_SIZE_SOFT_LIMIT_IN_WASM32_PAGES,
     },
     pb::v1::{
         governance_error::ErrorType,
+        install_code::CanisterInstallMode,
         manage_neuron::{
             claim_or_refresh::{By, MemoAndController},
             ClaimOrRefresh, Command,
         },
         manage_neuron_response::Command as CommandResponse,
         neuron, proposal, ExecuteNnsFunction, Governance as GovernanceProto, GovernanceError,
-        ManageNeuron, ManageNeuronResponse, Motion, NetworkEconomics, Neuron, NnsFunction,
+        InstallCode, ManageNeuron, ManageNeuronResponse, Motion, NetworkEconomics, Neuron,
         Proposal,
     },
 };
@@ -179,9 +181,12 @@ async fn test_can_submit_nns_canister_upgrade_in_degraded_mode() {
             &Proposal {
                 title: Some("A Reasonable Title".to_string()),
                 summary: "proposal 1".to_string(),
-                action: Some(proposal::Action::ExecuteNnsFunction(ExecuteNnsFunction {
-                    nns_function: NnsFunction::NnsCanisterUpgrade as i32,
-                    payload: Vec::new(),
+                action: Some(proposal::Action::InstallCode(InstallCode {
+                    canister_id: Some(GOVERNANCE_CANISTER_ID.get()),
+                    wasm_module: Some(vec![1, 2, 3]),
+                    install_mode: Some(CanisterInstallMode::Upgrade as i32),
+                    arg: Some(vec![4, 5, 6]),
+                    skip_stopping_before_installing: None,
                 })),
                 ..Default::default()
             },

--- a/rs/nns/governance/tests/governance.rs
+++ b/rs/nns/governance/tests/governance.rs
@@ -62,6 +62,7 @@ use ic_nns_governance::{
         governance_error::ErrorType::{
             self, InsufficientFunds, NotAuthorized, NotFound, PreconditionFailed, ResourceExhausted,
         },
+        install_code::CanisterInstallMode,
         manage_neuron::{
             self,
             claim_or_refresh::{By, MemoAndController},
@@ -79,8 +80,8 @@ use ic_nns_governance::{
         settle_neurons_fund_participation_request, swap_background_information,
         AddOrRemoveNodeProvider, Ballot, BallotChange, BallotInfo, BallotInfoChange,
         CreateServiceNervousSystem, Empty, ExecuteNnsFunction, Governance as GovernanceProto,
-        GovernanceChange, GovernanceError, IdealMatchedParticipationFunction, KnownNeuron,
-        KnownNeuronData, ListNeurons, ListNeuronsResponse, ListProposalInfo,
+        GovernanceChange, GovernanceError, IdealMatchedParticipationFunction, InstallCode,
+        KnownNeuron, KnownNeuronData, ListNeurons, ListNeuronsResponse, ListProposalInfo,
         ListProposalInfoResponse, ManageNeuron, ManageNeuronResponse, MonthlyNodeProviderRewards,
         Motion, NetworkEconomics, Neuron, NeuronChange, NeuronState, NeuronType, NeuronsFundData,
         NeuronsFundParticipation, NeuronsFundSnapshot, NnsFunction, NodeProvider, Proposal,
@@ -8156,7 +8157,7 @@ fn test_filter_proposals_excluding_topics() {
                 proposer: Some(NeuronId { id: 1 }),
                 proposal: Some(Proposal {
                     action: Some(proposal::Action::ExecuteNnsFunction(ExecuteNnsFunction {
-                        nns_function: NnsFunction::NnsCanisterUpgrade as i32,
+                        nns_function: NnsFunction::HardResetNnsRootToVersion as i32,
                         payload: Vec::new(),
                     })),
                     ..new_motion_proposal()
@@ -8190,7 +8191,7 @@ fn test_filter_proposals_excluding_topics() {
             &ListProposalInfo {
                 exclude_topic: vec![
                     Topic::NetworkEconomics as i32,
-                    Topic::NetworkCanisterManagement as i32
+                    Topic::ProtocolCanisterManagement as i32
                 ],
                 ..Default::default()
             },
@@ -8560,7 +8561,7 @@ async fn test_max_number_of_proposals_with_ballots() {
             ..Default::default()
         },
     ), Err(GovernanceError{error_type, error_message: _}) if error_type==ResourceExhausted as i32);
-    // Let's try a NnsCanisterUpgrade. This proposal type is whitelisted, so it can
+    // Let's try an Installcode for Governance itself. This proposal type is whitelisted, so it can
     // be submitted even though the max is reached.
     assert_matches!(
         gov.make_proposal(
@@ -8569,10 +8570,14 @@ async fn test_max_number_of_proposals_with_ballots() {
             &principal(1),
             &Proposal {
                 title: Some("A Reasonable Title".to_string()),
-                summary: "NnsCanisterUpgrade should go through despite the limit".to_string(),
-                action: Some(proposal::Action::ExecuteNnsFunction(ExecuteNnsFunction {
-                    nns_function: NnsFunction::NnsCanisterUpgrade as i32,
-                    payload: Vec::new(),
+                summary: "InstallCode for Governance should go through despite the limit"
+                    .to_string(),
+                action: Some(proposal::Action::InstallCode(InstallCode {
+                    canister_id: Some(GOVERNANCE_CANISTER_ID.get()),
+                    wasm_module: Some(vec![1, 2, 3]),
+                    install_mode: Some(CanisterInstallMode::Upgrade as i32),
+                    arg: Some(vec![4, 5, 6]),
+                    skip_stopping_before_installing: None,
                 })),
                 ..Default::default()
             },

--- a/rs/nns/integration_tests/src/canister_upgrade.rs
+++ b/rs/nns/integration_tests/src/canister_upgrade.rs
@@ -16,7 +16,7 @@ use ic_nns_test_utils::{
     },
 };
 
-fn test_upgrade_canister(canister_id: CanisterId, canister_wasm: Wasm, use_proposal_action: bool) {
+fn test_upgrade_canister(canister_id: CanisterId, canister_wasm: Wasm) {
     let state_machine = state_machine_builder_for_nns_tests().build();
     let nns_init_payloads = NnsInitPayloadsBuilder::new().with_test_neurons().build();
     setup_nns_canisters(&state_machine, nns_init_payloads);
@@ -32,7 +32,7 @@ fn test_upgrade_canister(canister_id: CanisterId, canister_wasm: Wasm, use_propo
         canister_id,
         modified_wasm.clone(),
         vec![],
-        use_proposal_action,
+        true,
     );
 
     let controller_canister_id = if canister_id == ROOT_CANISTER_ID {
@@ -48,34 +48,29 @@ fn test_upgrade_canister(canister_id: CanisterId, canister_wasm: Wasm, use_propo
         controller_canister_id,
     );
 
-    if use_proposal_action {
-        let proposal_info =
-            nns_governance_get_proposal_info_as_anonymous(&state_machine, proposal_id.id);
-        let action = proposal_info.proposal.unwrap().action.unwrap();
-        if let Action::InstallCode(install_code) = action {
-            assert_eq!(
-                install_code.wasm_module_hash,
-                Some(Sha256::hash(&modified_wasm).to_vec())
-            );
-            assert_eq!(install_code.arg_hash, Some(vec![]));
-            assert_eq!(
-                install_code.install_mode,
-                Some(CanisterInstallMode::Upgrade as i32)
-            );
-            assert_eq!(install_code.canister_id, Some(canister_id.get()));
-            assert_eq!(install_code.skip_stopping_before_installing, None);
-        } else {
-            panic!("Unexpected action: {:?}", action);
-        }
+    let proposal_info =
+        nns_governance_get_proposal_info_as_anonymous(&state_machine, proposal_id.id);
+    let action = proposal_info.proposal.unwrap().action.unwrap();
+    if let Action::InstallCode(install_code) = action {
+        assert_eq!(
+            install_code.wasm_module_hash,
+            Some(Sha256::hash(&modified_wasm).to_vec())
+        );
+        assert_eq!(install_code.arg_hash, Some(vec![]));
+        assert_eq!(
+            install_code.install_mode,
+            Some(CanisterInstallMode::Upgrade as i32)
+        );
+        assert_eq!(install_code.canister_id, Some(canister_id.get()));
+        assert_eq!(install_code.skip_stopping_before_installing, None);
+    } else {
+        panic!("Unexpected action: {:?}", action);
     }
 }
 
 #[test]
 fn upgrade_canisters_by_proposal() {
-    test_upgrade_canister(GOVERNANCE_CANISTER_ID, build_governance_wasm(), true);
-    test_upgrade_canister(GOVERNANCE_CANISTER_ID, build_governance_wasm(), false);
-    test_upgrade_canister(ROOT_CANISTER_ID, build_root_wasm(), false);
-    test_upgrade_canister(ROOT_CANISTER_ID, build_root_wasm(), true);
-    test_upgrade_canister(LIFELINE_CANISTER_ID, build_lifeline_wasm(), true);
-    test_upgrade_canister(LIFELINE_CANISTER_ID, build_lifeline_wasm(), false);
+    test_upgrade_canister(GOVERNANCE_CANISTER_ID, build_governance_wasm());
+    test_upgrade_canister(ROOT_CANISTER_ID, build_root_wasm());
+    test_upgrade_canister(LIFELINE_CANISTER_ID, build_lifeline_wasm());
 }

--- a/rs/nns/integration_tests/src/copy_inactive_neurons_to_stable_memory.rs
+++ b/rs/nns/integration_tests/src/copy_inactive_neurons_to_stable_memory.rs
@@ -40,7 +40,7 @@ fn test_copy_inactive_neurons_to_stable_memory() {
         GOVERNANCE_CANISTER_ID, // Target, i.e. the canister that we want to upgrade.
         new_wasm_content,       // The new code that we want the canister to start running.
         module_arg,
-        false,
+        true,
     );
     println!("Done proposing governance upgrade: {:?}", proposal_id);
 

--- a/rs/nns/integration_tests/src/governance_mem_test.rs
+++ b/rs/nns/integration_tests/src/governance_mem_test.rs
@@ -85,7 +85,7 @@ fn governance_mem_test() {
         GOVERNANCE_CANISTER_ID,
         real_gov_wasm.bytes(),
         module_arg,
-        false,
+        true,
     );
 
     state_machine.tick();

--- a/rs/nns/integration_tests/src/lifeline.rs
+++ b/rs/nns/integration_tests/src/lifeline.rs
@@ -9,15 +9,13 @@ use ic_nervous_system_common_test_keys::{
 };
 use ic_nns_common::pb::v1::NeuronId;
 use ic_nns_constants::{LIFELINE_CANISTER_ID, ROOT_CANISTER_ID};
-use ic_nns_governance_api::{
-    pb::v1::{
-        manage_neuron_response::Command as CommandResponse, NnsFunction, ProposalStatus, Vote,
-    },
-    proposal_helpers::create_external_update_proposal_candid,
+use ic_nns_governance_api::pb::v1::{
+    install_code::CanisterInstallMode as GovernanceCanisterInstallMode,
+    manage_neuron_response::Command as CommandResponse, InstallCodeRequest, MakeProposalRequest,
+    ProposalActionRequest, ProposalStatus, Vote,
 };
 use ic_nns_test_utils::{
     common::NnsInitPayloadsBuilder,
-    governance::UpgradeRootProposal,
     state_test_helpers::{
         get_pending_proposals, get_root_canister_status, nns_cast_vote,
         nns_governance_get_proposal_info_as_anonymous, nns_governance_make_proposal,
@@ -71,17 +69,18 @@ fn test_submit_and_accept_root_canister_upgrade_proposal() {
     let funny: u32 = 422557101; // just a funny number I came up with
     let magic = funny.to_le_bytes();
 
-    let proposal = create_external_update_proposal_candid(
-        "Proposal to upgrade the root canister",
-        "",
-        "",
-        NnsFunction::NnsRootUpgrade,
-        UpgradeRootProposal {
-            wasm_module: wasm_module.clone(),
-            module_arg: magic.to_vec(),
-            stop_upgrade_start: true,
-        },
-    );
+    let proposal = MakeProposalRequest {
+        title: Some("Proposal to upgrade the root canister".to_string()),
+        summary: "".to_string(),
+        url: "".to_string(),
+        action: Some(ProposalActionRequest::InstallCode(InstallCodeRequest {
+            canister_id: Some(ROOT_CANISTER_ID.get()),
+            wasm_module: Some(wasm_module.clone()),
+            install_mode: Some(GovernanceCanisterInstallMode::Upgrade as i32),
+            arg: Some(magic.to_vec()),
+            skip_stopping_before_installing: None,
+        })),
+    };
 
     let neuron_id = NeuronId {
         id: TEST_NEURON_2_ID,
@@ -171,17 +170,18 @@ fn test_submit_and_accept_forced_root_canister_upgrade_proposal() {
 
     let init_arg: &[u8] = &[];
 
-    let proposal = create_external_update_proposal_candid(
-        "Proposal to upgrade the root canister",
-        "",
-        "",
-        NnsFunction::NnsRootUpgrade,
-        UpgradeRootProposal {
-            wasm_module: empty_wasm.to_vec(),
-            module_arg: init_arg.to_vec(),
-            stop_upgrade_start: false,
-        },
-    );
+    let proposal = MakeProposalRequest {
+        title: Some("Proposal to upgrade the root canister".to_string()),
+        summary: "".to_string(),
+        url: "".to_string(),
+        action: Some(ProposalActionRequest::InstallCode(InstallCodeRequest {
+            canister_id: Some(ROOT_CANISTER_ID.get()),
+            wasm_module: Some(empty_wasm.to_vec()),
+            install_mode: Some(GovernanceCanisterInstallMode::Upgrade as i32),
+            arg: Some(init_arg.to_vec()),
+            skip_stopping_before_installing: Some(true),
+        })),
+    };
 
     let neuron_id = NeuronId {
         id: TEST_NEURON_2_ID,
@@ -272,17 +272,18 @@ fn test_lifeline_canister_restarts_root_on_stop_canister_timeout() {
     state_machine.tick();
 
     let root_wasm = Project::cargo_bin_maybe_from_env("root-canister", &[]).bytes();
-    let proposal = create_external_update_proposal_candid(
-        "Tea. Earl Grey. Hot.",
-        "Make It So",
-        "",
-        NnsFunction::NnsRootUpgrade,
-        UpgradeRootProposal {
-            stop_upgrade_start: true,
-            wasm_module: root_wasm,
-            module_arg: vec![],
-        },
-    );
+    let proposal = MakeProposalRequest {
+        title: Some("Tea. Earl Grey. Hot.".to_string()),
+        summary: "Make It So".to_string(),
+        url: "".to_string(),
+        action: Some(ProposalActionRequest::InstallCode(InstallCodeRequest {
+            canister_id: Some(ROOT_CANISTER_ID.get()),
+            wasm_module: Some(root_wasm),
+            install_mode: Some(GovernanceCanisterInstallMode::Upgrade as i32),
+            arg: Some(vec![]),
+            skip_stopping_before_installing: None,
+        })),
+    };
     let neuron_id = NeuronId {
         id: TEST_NEURON_1_ID,
     };

--- a/rs/nns/integration_tests/src/neuron_following.rs
+++ b/rs/nns/integration_tests/src/neuron_following.rs
@@ -22,7 +22,7 @@ use ic_state_machine_tests::StateMachine;
 
 const VALID_TOPIC: i32 = Topic::ParticipantManagement as i32;
 const INVALID_TOPIC: i32 = 69420;
-const NETWORK_CANISTER_MANAGEMENT_TOPIC: i32 = Topic::NetworkCanisterManagement as i32;
+const PROTOCOAL_CANISTER_MANAGEMENT_TOPIC: i32 = Topic::ProtocolCanisterManagement as i32;
 const NEURON_MANAGEMENT_TOPIC: i32 = Topic::NeuronManagement as i32;
 const VOTING_POWER_NEURON_1: u64 = 1_404_004_106;
 const VOTING_POWER_NEURON_2: u64 = 140_400_410;
@@ -210,7 +210,7 @@ fn vote_propagation_with_following() {
         &state_machine,
         &n1,
         &[n2.neuron_id],
-        NETWORK_CANISTER_MANAGEMENT_TOPIC,
+        PROTOCOAL_CANISTER_MANAGEMENT_TOPIC,
     );
 
     // voting doesn't get propagated by mutating the following graph
@@ -250,7 +250,7 @@ fn vote_propagation_with_following() {
         &state_machine,
         &n3,
         &[n2.neuron_id],
-        NETWORK_CANISTER_MANAGEMENT_TOPIC,
+        PROTOCOAL_CANISTER_MANAGEMENT_TOPIC,
     );
 
     // make n2 follow n1
@@ -258,7 +258,7 @@ fn vote_propagation_with_following() {
         &state_machine,
         &n2,
         &[n1.neuron_id],
-        NETWORK_CANISTER_MANAGEMENT_TOPIC,
+        PROTOCOAL_CANISTER_MANAGEMENT_TOPIC,
     );
 
     // now n1 and n2 follow each other (circle), and n3 follows n2
@@ -291,7 +291,7 @@ fn vote_propagation_with_following() {
         &state_machine,
         &n2,
         &[n1a.neuron_id],
-        NETWORK_CANISTER_MANAGEMENT_TOPIC,
+        PROTOCOAL_CANISTER_MANAGEMENT_TOPIC,
     );
 
     // at this point n2 is not influential
@@ -349,14 +349,14 @@ fn vote_propagation_with_following() {
         &state_machine,
         &n1a,
         &[n3.neuron_id],
-        NETWORK_CANISTER_MANAGEMENT_TOPIC,
+        PROTOCOAL_CANISTER_MANAGEMENT_TOPIC,
     );
 
     set_followees_on_topic(
         &state_machine,
         &n3,
         &[n1.neuron_id],
-        NETWORK_CANISTER_MANAGEMENT_TOPIC,
+        PROTOCOAL_CANISTER_MANAGEMENT_TOPIC,
     );
 
     // fire off a new proposal by n1, and see all neurons voting

--- a/rs/nns/integration_tests/src/reinstall_and_upgrade.rs
+++ b/rs/nns/integration_tests/src/reinstall_and_upgrade.rs
@@ -55,7 +55,6 @@ fn test_reinstall_and_upgrade_canisters_canonical_ordering() {
             mode,
         } in get_nns_canister_wasm(&nns_canisters, init_state).into_iter()
         {
-            println!("Upgrading canister: {:?}", canister.canister_id());
             if mode == CanisterInstallMode::Upgrade {
                 println!("[Update] Canister: {:?}", canister.canister_id());
                 if canister.canister_id() == LIFELINE_CANISTER_ID {
@@ -337,7 +336,7 @@ fn get_nns_canister_wasm<'a>(
             mode: CanisterInstallMode::Upgrade,
         },
         CanisterInstallInfo {
-            wasm: Project::cargo_bin_maybe_from_env("root-canister", &[]),
+            wasm: bump_gzip_timestamp(&Project::cargo_bin_maybe_from_env("root-canister", &[])),
             use_root: false,
             canister: &nns_canisters.root,
             init_payload: encoded_init_state[5].clone(),

--- a/rs/nns/integration_tests/src/upgrade_canisters_with_golden_nns_state.rs
+++ b/rs/nns/integration_tests/src/upgrade_canisters_with_golden_nns_state.rs
@@ -237,7 +237,7 @@ fn test_upgrade_canisters_with_golden_nns_state() {
                     *canister_id,
                     wasm_content.clone(),
                     module_arg.clone(),
-                    false,
+                    true,
                 );
 
                 // Step 3: Verify result(s): In a short while, the canister should

--- a/rs/nns/test_utils/src/governance.rs
+++ b/rs/nns/test_utils/src/governance.rs
@@ -6,25 +6,22 @@ use canister_test::{Canister, Wasm};
 use dfn_candid::{candid, candid_one};
 use ic_btc_interface::SetConfigRequest;
 use ic_canister_client_sender::Sender;
-use ic_management_canister_types::CanisterInstallMode;
 use ic_nervous_system_clients::{
     canister_id_record::CanisterIdRecord,
     canister_status::{CanisterStatusResult, CanisterStatusType},
 };
 use ic_nervous_system_common_test_keys::{TEST_NEURON_1_ID, TEST_NEURON_1_OWNER_KEYPAIR};
-use ic_nervous_system_root::change_canister::ChangeCanisterRequest;
 use ic_nns_common::types::{NeuronId, ProposalId};
 use ic_nns_constants::ROOT_CANISTER_ID;
 use ic_nns_governance_api::{
     bitcoin::{BitcoinNetwork, BitcoinSetConfigProposal},
     pb::v1::{
-        add_or_remove_node_provider::Change,
-        manage_neuron::{Command, NeuronIdOrSubaccount},
-        manage_neuron_response::Command as CommandResponse,
-        proposal::Action,
-        AddOrRemoveNodeProvider, ExecuteNnsFunction, GovernanceError, ListNodeProvidersResponse,
-        ManageNeuron, ManageNeuronResponse, NnsFunction, NodeProvider, Proposal, ProposalInfo,
-        ProposalStatus,
+        add_or_remove_node_provider::Change, install_code::CanisterInstallMode,
+        manage_neuron::NeuronIdOrSubaccount, manage_neuron_response::Command as CommandResponse,
+        AddOrRemoveNodeProvider, ExecuteNnsFunction, GovernanceError, InstallCodeRequest,
+        ListNodeProvidersResponse, MakeProposalRequest, ManageNeuronCommandRequest,
+        ManageNeuronRequest, ManageNeuronResponse, NnsFunction, NodeProvider,
+        ProposalActionRequest, ProposalInfo, ProposalStatus,
     },
 };
 pub use ic_nns_handler_lifeline_interface::{
@@ -36,7 +33,7 @@ use std::time::Duration;
 /// serialization/deserialization
 pub async fn submit_proposal(
     governance_canister: &Canister<'_>,
-    proposal: &Proposal,
+    proposal: &MakeProposalRequest,
 ) -> ProposalId {
     governance_canister
         .update_("submit_proposal", candid_one, proposal)
@@ -56,23 +53,25 @@ pub async fn submit_external_update_proposal_allowing_error(
     title: String,
     summary: String,
 ) -> Result<ProposalId, GovernanceError> {
-    let proposal = Proposal {
+    let proposal = MakeProposalRequest {
         title: Some(title),
         summary,
         url: "".to_string(),
-        action: Some(Action::ExecuteNnsFunction(ExecuteNnsFunction {
-            nns_function: nns_function as i32,
-            payload: Encode!(&nns_function_input).expect("Error encoding proposal payload"),
-        })),
+        action: Some(ProposalActionRequest::ExecuteNnsFunction(
+            ExecuteNnsFunction {
+                nns_function: nns_function as i32,
+                payload: Encode!(&nns_function_input).expect("Error encoding proposal payload"),
+            },
+        )),
     };
 
     let response: ManageNeuronResponse = governance_canister
         .update_from_sender(
             "manage_neuron",
             candid_one,
-            ManageNeuron {
+            ManageNeuronRequest {
                 id: None,
-                command: Some(Command::MakeProposal(Box::new(proposal))),
+                command: Some(ManageNeuronCommandRequest::MakeProposal(Box::new(proposal))),
                 neuron_id_or_subaccount: Some(NeuronIdOrSubaccount::NeuronId(
                     proposer_neuron_id.into(),
                 )),
@@ -99,23 +98,25 @@ pub async fn submit_external_update_proposal(
     title: String,
     summary: String,
 ) -> ProposalId {
-    let proposal = Proposal {
+    let proposal = MakeProposalRequest {
         title: Some(title),
         summary,
         url: "".to_string(),
-        action: Some(Action::ExecuteNnsFunction(ExecuteNnsFunction {
-            nns_function: nns_function as i32,
-            payload: Encode!(&nns_function_input).expect("Error encoding proposal payload"),
-        })),
+        action: Some(ProposalActionRequest::ExecuteNnsFunction(
+            ExecuteNnsFunction {
+                nns_function: nns_function as i32,
+                payload: Encode!(&nns_function_input).expect("Error encoding proposal payload"),
+            },
+        )),
     };
 
     let response: ManageNeuronResponse = governance_canister
         .update_from_sender(
             "manage_neuron",
             candid_one,
-            ManageNeuron {
+            ManageNeuronRequest {
                 id: None,
-                command: Some(Command::MakeProposal(Box::new(proposal))),
+                command: Some(ManageNeuronCommandRequest::MakeProposal(Box::new(proposal))),
                 neuron_id_or_subaccount: Some(NeuronIdOrSubaccount::NeuronId(
                     proposer_neuron_id.into(),
                 )),
@@ -132,76 +133,6 @@ pub async fn submit_external_update_proposal(
         CommandResponse::MakeProposal(resp) => ProposalId::from(resp.proposal_id.unwrap()),
         other => panic!("Unexpected response: {:?}", other),
     }
-}
-
-/// Wraps the given nns_function_input into a proposal; sends it to the governance
-/// canister; returns the proposal id.
-pub async fn submit_external_update_proposal_binary(
-    governance_canister: &Canister<'_>,
-    proposer: Sender,
-    proposer_neuron_id: NeuronId,
-    nns_function: NnsFunction,
-    nns_function_input: Vec<u8>,
-    title: String,
-    summary: String,
-) -> ProposalId {
-    let response: ManageNeuronResponse = submit_external_update_proposal_binary_with_response(
-        governance_canister,
-        proposer,
-        proposer_neuron_id,
-        nns_function,
-        nns_function_input,
-        title,
-        summary,
-    )
-    .await;
-
-    match response
-        .panic_if_error("Error making proposal")
-        .command
-        .unwrap()
-    {
-        CommandResponse::MakeProposal(resp) => ProposalId::from(resp.proposal_id.unwrap()),
-        _ => panic!("Invalid response"),
-    }
-}
-
-/// Wraps the given nns_function_input into a proposal; sends it to the governance
-/// canister; returns the `ManageNeuronResponse`
-pub async fn submit_external_update_proposal_binary_with_response(
-    governance_canister: &Canister<'_>,
-    proposer: Sender,
-    proposer_neuron_id: NeuronId,
-    nns_function: NnsFunction,
-    nns_function_input: Vec<u8>,
-    title: String,
-    summary: String,
-) -> ManageNeuronResponse {
-    let proposal = Proposal {
-        title: Some(title),
-        summary,
-        url: "".to_string(),
-        action: Some(Action::ExecuteNnsFunction(ExecuteNnsFunction {
-            nns_function: nns_function as i32,
-            payload: nns_function_input,
-        })),
-    };
-
-    governance_canister
-        .update_from_sender(
-            "manage_neuron",
-            candid_one,
-            ManageNeuron {
-                id: None,
-                command: Some(Command::MakeProposal(Box::new(proposal))),
-                neuron_id_or_subaccount: Some(NeuronIdOrSubaccount::NeuronId(
-                    proposer_neuron_id.into(),
-                )),
-            },
-            &proposer,
-        )
-        .await
-        .expect("Error calling the manage_neuron api.")
 }
 
 /// Thin-wrapper around get_proposal_info to handle
@@ -273,21 +204,25 @@ pub async fn add_node_provider(nns_canisters: &NnsCanisters<'_>, np: NodeProvide
         .update_from_sender(
             "manage_neuron",
             candid_one,
-            ManageNeuron {
+            ManageNeuronRequest {
                 neuron_id_or_subaccount: Some(NeuronIdOrSubaccount::NeuronId(
                     ic_nns_common::pb::v1::NeuronId {
                         id: TEST_NEURON_1_ID,
                     },
                 )),
                 id: None,
-                command: Some(Command::MakeProposal(Box::new(Proposal {
-                    title: Some("Add a Node Provider".to_string()),
-                    summary: "".to_string(),
-                    url: "".to_string(),
-                    action: Some(Action::AddOrRemoveNodeProvider(AddOrRemoveNodeProvider {
-                        change: Some(Change::ToAdd(np)),
-                    })),
-                }))),
+                command: Some(ManageNeuronCommandRequest::MakeProposal(Box::new(
+                    MakeProposalRequest {
+                        title: Some("Add a Node Provider".to_string()),
+                        summary: "".to_string(),
+                        url: "".to_string(),
+                        action: Some(ProposalActionRequest::AddOrRemoveNodeProvider(
+                            AddOrRemoveNodeProvider {
+                                change: Some(Change::ToAdd(np)),
+                            },
+                        )),
+                    },
+                ))),
             },
             &Sender::from_keypair(&TEST_NEURON_1_OWNER_KEYPAIR),
         )
@@ -356,55 +291,6 @@ pub fn bump_gzip_timestamp(wasm: &Wasm) -> Wasm {
     Wasm::from_bytes(new_wasm)
 }
 
-/// Submits a proposal to upgrade the root canister.
-pub async fn upgrade_root_canister_by_proposal(
-    governance: &Canister<'_>,
-    root: &Canister<'_>,
-    wasm: Wasm,
-) {
-    let wasm = wasm.bytes();
-    let new_module_hash = &ic_crypto_sha2::Sha256::hash(&wasm);
-
-    let proposal_id = submit_external_update_proposal(
-        governance,
-        Sender::from_keypair(&TEST_NEURON_1_OWNER_KEYPAIR),
-        NeuronId(TEST_NEURON_1_ID),
-        NnsFunction::NnsRootUpgrade,
-        UpgradeRootProposal {
-            wasm_module: wasm,
-            module_arg: Vec::<u8>::new(),
-            stop_upgrade_start: false,
-        },
-        "Upgrade Root Canister".to_string(),
-        "<proposal created by upgrade_root_canister_by_proposal>".to_string(),
-    )
-    .await;
-
-    assert_eq!(
-        wait_for_final_state(governance, proposal_id).await.status(),
-        ProposalStatus::Executed
-    );
-
-    for _ in 0..100 {
-        let Ok(status): Result<CanisterStatusResult, _> = root
-            .update_(
-                "canister_status",
-                candid_one,
-                CanisterIdRecord::from(ROOT_CANISTER_ID),
-            )
-            .await
-        else {
-            continue;
-        };
-        if status.module_hash.unwrap().as_slice() == new_module_hash
-            && status.status == CanisterStatusType::Running
-        {
-            return;
-        }
-    }
-    panic!("Root canister upgrade did not complete in time.");
-}
-
 /// Perform a change on a canister by upgrading it or
 /// reinstalling entirely, depending on the `how` argument.
 /// Argument `wasm` is ensured to have a different
@@ -435,33 +321,52 @@ async fn change_nns_canister_by_proposal(
         .await
         .unwrap();
     let old_module_hash = status.module_hash.unwrap();
-    assert_ne!(old_module_hash.as_slice(), new_module_hash, "change_nns_canister_by_proposal: both module hashes prev, cur are the same {:?}, but they should be different for upgrade", old_module_hash);
+    assert_ne!(
+        old_module_hash.as_slice(),
+        new_module_hash,
+        "change_nns_canister_by_proposal: both module hashes prev, cur are \
+         the same {:?}, but they should be different for upgrade",
+        old_module_hash
+    );
 
-    let change_canister_request =
-        ChangeCanisterRequest::new(stop_before_installing, how, canister.canister_id())
-            .with_memory_allocation(ic_nns_constants::memory_allocation_of(
-                canister.canister_id(),
-            ))
-            .with_wasm(wasm)
-            .with_arg(Encode!().unwrap());
-    let change_canister_request = if let Some(arg) = arg {
-        change_canister_request.with_arg(arg)
-    } else {
-        change_canister_request
+    let proposal = MakeProposalRequest {
+        title: Some("Upgrade NNS Canister".to_string()),
+        summary: "<proposal created by change_nns_canister_by_proposal>".to_string(),
+        url: "".to_string(),
+        action: Some(ProposalActionRequest::InstallCode(InstallCodeRequest {
+            canister_id: Some(canister.canister_id().get()),
+            wasm_module: Some(wasm.clone()),
+            install_mode: Some(how as i32),
+            arg: Some(arg.unwrap_or_default()),
+            skip_stopping_before_installing: Some(stop_before_installing),
+        })),
     };
 
     // Submitting a proposal also implicitly records a vote from the proposer,
     // which with TEST_NEURON_1 is enough to trigger execution.
-    submit_external_update_proposal(
-        governance,
-        Sender::from_keypair(&TEST_NEURON_1_OWNER_KEYPAIR),
-        NeuronId(TEST_NEURON_1_ID),
-        NnsFunction::NnsCanisterUpgrade,
-        change_canister_request,
-        "Upgrade NNS Canister".to_string(),
-        "<proposal created by change_nns_canister_by_proposal>".to_string(),
-    )
-    .await;
+    let response: ManageNeuronResponse = governance
+        .update_from_sender(
+            "manage_neuron",
+            candid_one,
+            ManageNeuronRequest {
+                id: None,
+                command: Some(ManageNeuronCommandRequest::MakeProposal(Box::new(proposal))),
+                neuron_id_or_subaccount: Some(NeuronIdOrSubaccount::NeuronId(
+                    NeuronId(TEST_NEURON_1_ID).into(),
+                )),
+            },
+            &Sender::from_keypair(&TEST_NEURON_1_OWNER_KEYPAIR),
+        )
+        .await
+        .expect("Error calling the manage_neuron api.");
+    match response
+        .panic_if_error("Error making proposal")
+        .command
+        .unwrap()
+    {
+        CommandResponse::MakeProposal(resp) => resp.proposal_id.expect("No proposal id"),
+        other => panic!("Unexpected response: {:?}", other),
+    };
 
     // Wait 'till the hash matches and the canister is running again.
     loop {

--- a/rs/nns/test_utils/src/neuron_helpers.rs
+++ b/rs/nns/test_utils/src/neuron_helpers.rs
@@ -5,9 +5,10 @@ use ic_nervous_system_common_test_keys::{
     TEST_NEURON_2_OWNER_PRINCIPAL, TEST_NEURON_3_ID, TEST_NEURON_3_OWNER_PRINCIPAL,
 };
 use ic_nns_common::{pb::v1::NeuronId, types::ProposalId};
+use ic_nns_constants::ROOT_CANISTER_ID;
 use ic_nns_governance_api::pb::v1::{
-    manage_neuron_response::Command, ExecuteNnsFunction, MakeProposalRequest, Neuron, NnsFunction,
-    ProposalActionRequest,
+    install_code::CanisterInstallMode, manage_neuron_response::Command, InstallCodeRequest,
+    MakeProposalRequest, Neuron, ProposalActionRequest,
 };
 use ic_state_machine_tests::StateMachine;
 use std::collections::HashMap;
@@ -70,12 +71,13 @@ pub fn get_some_proposal() -> MakeProposalRequest {
         title: Some("<proposal created from initialization>".to_string()),
         summary: "".to_string(),
         url: "".to_string(),
-        action: Some(ProposalActionRequest::ExecuteNnsFunction(
-            ExecuteNnsFunction {
-                nns_function: NnsFunction::NnsRootUpgrade as i32,
-                payload: Vec::new(),
-            },
-        )),
+        action: Some(ProposalActionRequest::InstallCode(InstallCodeRequest {
+            canister_id: Some(ROOT_CANISTER_ID.get()),
+            wasm_module: Some(vec![]),
+            install_mode: Some(CanisterInstallMode::Upgrade as i32),
+            arg: Some(vec![]),
+            skip_stopping_before_installing: None,
+        })),
     }
 }
 

--- a/rs/tests/src/ledger_tests/transaction_ledger_correctness.rs
+++ b/rs/tests/src/ledger_tests/transaction_ledger_correctness.rs
@@ -163,6 +163,7 @@ mod holder {
             &Canister::new(rt, ic_nns_constants::ROOT_CANISTER_ID),
             true,
             Wasm::from_bytes(HOLDER_CANISTER_WASM.to_vec()),
+            None,
         )
         .await;
     }

--- a/rs/tests/src/ledger_tests/transaction_ledger_correctness.rs
+++ b/rs/tests/src/ledger_tests/transaction_ledger_correctness.rs
@@ -157,7 +157,7 @@ mod holder {
     }
 
     pub async fn upgrade(rt: &Runtime, nns_canister_id: &CanisterId) {
-        ic_nns_test_utils::itest_helpers::upgrade_nns_canister_by_proposal(
+        ic_nns_test_utils::governance::upgrade_nns_canister_by_proposal(
             &Canister::new(rt, *nns_canister_id),
             &Canister::new(rt, ic_nns_constants::GOVERNANCE_CANISTER_ID),
             &Canister::new(rt, ic_nns_constants::ROOT_CANISTER_ID),


### PR DESCRIPTION
# Why

`InstallCode` has already been used for upgrading several NNS canisters. Now we don't need `NnsCanisterUpgrade` or `NnsRootUpgrade`.

# What

* Make `NnsCanisterUpgrade` and `NnsRootUpgrade` obsolete by disabling proposal creation
* Switch existing tests using those proposal types to `InstallCode`