### PR TITLE
fix(dependency-mgmt): Change root path for leftover tests in dependency-mgmt

### DIFF
--- a/ci/src/dependencies/scanner/dependency_scanner_test.py
+++ b/ci/src/dependencies/scanner/dependency_scanner_test.py
@@ -203,7 +203,7 @@ def test_on_periodic_job_one_finding_in_jira(jira_lib_mock):
 def test_on_periodic_job_one_finding_in_jira_transition_to_failover(jira_lib_mock):
     # one finding, present in JIRA
     scanner = "BAZEL_RUST"
-    repository = Repository("ic", "https://github.com/dfinity/ic", [Project("ic", "ic")])
+    repository = Repository("ic", "https://github.com/dfinity/ic", [Project("ic", __test_get_ic_path())])
     jira_finding = Finding(
         repository=repository.name,
         scanner=scanner,

--- a/ci/src/dependencies/scanner/manager/bazel_rust_dependency_manager_test.py
+++ b/ci/src/dependencies/scanner/manager/bazel_rust_dependency_manager_test.py
@@ -5,6 +5,7 @@ import typing
 
 import pytest
 from model.dependency import Dependency
+from model.ic import __test_get_ic_path
 from model.project import Project
 from model.vulnerability import Vulnerability
 from scanner.manager.bazel_rust_dependency_manager import BazelCargoExecutor, BazelRustDependencyManager
@@ -315,7 +316,7 @@ def test_get_findings_for_bazel_repo():
         executor = MockBazelCargoExecutor(expected_cargo_audit_output=json.load(audit), expected_bazel_queries=expected_queries, expected_bazel_responses=expected_responses)
         bazel_test = BazelRustDependencyManager(executor=executor)
 
-        findings = bazel_test.get_findings("ic", Project("ic", "ic"), None)
+        findings = bazel_test.get_findings("ic", Project("ic", __test_get_ic_path()), None)
 
         assert findings is not None
         assert len(findings) == 3

--- a/ci/src/dependencies/scanner/manager/npm_dependency_manager_test.py
+++ b/ci/src/dependencies/scanner/manager/npm_dependency_manager_test.py
@@ -588,7 +588,7 @@ class FakeNPM:
 
 def test_findings_helper_no_vulnerabilities(npm_test):
     repository = "ic"
-    project = Project("ic", "ic")
+    project = Project("ic", __test_get_ic_path())
     fake_npm = FakeNPM(1)
     npm_test._NPMDependencyManager__npm_audit_output = fake_npm.npm_audit_output
     npm_test._NPMDependencyManager__npm_list_output = fake_npm.npm_list_output
@@ -600,7 +600,7 @@ def test_findings_helper_no_vulnerabilities(npm_test):
 
 def test_findings_helper_one_finding(npm_test):
     repository = "ic"
-    project = Project("ic", "ic")
+    project = Project("ic", __test_get_ic_path())
     fake_npm = FakeNPM(2)
     npm_test._NPMDependencyManager__npm_audit_output = fake_npm.npm_audit_output
     npm_test._NPMDependencyManager__npm_list_output = fake_npm.npm_list_output
@@ -651,7 +651,7 @@ def test_findings_helper_one_finding(npm_test):
 
 def test_findings_helper_vulnerable_dependency_not_in_range(npm_test):
     repository = "ic"
-    project = Project("ic", "ic")
+    project = Project("ic", __test_get_ic_path())
     fake_npm = FakeNPM(3)
     npm_test._NPMDependencyManager__npm_audit_output = fake_npm.npm_audit_output
     npm_test._NPMDependencyManager__npm_list_output = fake_npm.npm_list_output
@@ -663,7 +663,7 @@ def test_findings_helper_vulnerable_dependency_not_in_range(npm_test):
 
 def test_findings_helper_transitive_vulnerability(npm_test):
     repository = "ic"
-    project = Project("ic", "ic")
+    project = Project("ic", __test_get_ic_path())
     fake_npm = FakeNPM(4)
     npm_test._NPMDependencyManager__npm_audit_output = fake_npm.npm_audit_output
     npm_test._NPMDependencyManager__npm_list_output = fake_npm.npm_list_output


### PR DESCRIPTION
An old test code got pulled in the recent changes. This causes the dependency management [tests](https://github.com/dfinity/ic-private/actions/runs/10874044541/job/30170884228?pr=30) to fail on `ic-private`