### PR TITLE
fix(IDX): fix ci logic related to branch protection rules

### DIFF
--- a/.github/workflows-source/ci-main.yml
+++ b/.github/workflows-source/ci-main.yml
@@ -21,8 +21,6 @@ permissions: read-all
 
 env:
   CI_COMMIT_SHA: ${{ github.sha }}
-  CI_COMMIT_REF_PROTECTED: ${{ github.ref_protected }}
-  CI_DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
   CI_JOB_NAME: ${{ github.job }}
   CI_JOB_ID: ${{ github.job }} # github does not expose this variable https://github.com/orgs/community/discussions/8945
   CI_JOB_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
@@ -242,6 +240,9 @@ jobs:
           pytest -m "not fails_on_merge_train" -v -o junit_family=xunit1 \
             --junitxml=../../test_report.xml --cov=. --cov-report=term \
             --cov-report=term-missing --cov-report=html --cov-branch
+        env:
+          CI_COMMIT_REF_PROTECTED: ${{ github.ref_protected }}
+          CI_DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
   build-ic:
     name: Build IC
     <<: *dind-large-setup

--- a/.github/workflows-source/release-testing.yml
+++ b/.github/workflows-source/release-testing.yml
@@ -14,7 +14,6 @@ concurrency:
 
 env:
   CI_COMMIT_SHA: ${{ github.sha }}
-  CI_COMMIT_REF_PROTECTED: ${{ github.ref_protected }}
   CI_JOB_NAME: ${{ github.job }}
   CI_JOB_ID: ${{ github.job }} # github does not expose this variable https://github.com/orgs/community/discussions/8945
   CI_JOB_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/.github/workflows-source/schedule-daily.yml
+++ b/.github/workflows-source/schedule-daily.yml
@@ -8,7 +8,6 @@ on:
 env:
   BAZEL_STARTUP_ARGS: "--output_base=/var/tmp/bazel-output/"
   CI_COMMIT_SHA: ${{ github.sha }}
-  CI_COMMIT_REF_PROTECTED: ${{ github.ref_protected }}
   CI_JOB_NAME: ${{ github.job }}
   CI_JOB_ID: ${{ github.job }} # github does not expose this variable https://github.com/orgs/community/discussions/8945
   CI_JOB_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/.github/workflows-source/schedule-daily.yml
+++ b/.github/workflows-source/schedule-daily.yml
@@ -7,6 +7,7 @@ on:
 
 env:
   BAZEL_STARTUP_ARGS: "--output_base=/var/tmp/bazel-output/"
+  BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
   CI_COMMIT_SHA: ${{ github.sha }}
   CI_JOB_NAME: ${{ github.job }}
   CI_JOB_ID: ${{ github.job }} # github does not expose this variable https://github.com/orgs/community/discussions/8945

--- a/.github/workflows-source/schedule-hourly.yml
+++ b/.github/workflows-source/schedule-hourly.yml
@@ -6,6 +6,7 @@ on:
   workflow_dispatch:
 
 env:
+  BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
   CI_COMMIT_SHA: ${{ github.sha }}
   CI_JOB_NAME: ${{ github.job }}
   CI_JOB_ID: ${{ github.job }} # github does not expose this variable https://github.com/orgs/community/discussions/8945

--- a/.github/workflows-source/schedule-hourly.yml
+++ b/.github/workflows-source/schedule-hourly.yml
@@ -7,7 +7,6 @@ on:
 
 env:
   CI_COMMIT_SHA: ${{ github.sha }}
-  CI_COMMIT_REF_PROTECTED: ${{ github.ref_protected }}
   CI_JOB_NAME: ${{ github.job }}
   CI_JOB_ID: ${{ github.job }} # github does not expose this variable https://github.com/orgs/community/discussions/8945
   CI_JOB_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -17,7 +17,6 @@ concurrency:
 permissions: read-all
 env:
   CI_COMMIT_SHA: ${{ github.sha }}
-  CI_DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
   CI_JOB_NAME: ${{ github.job }}
   CI_JOB_ID: ${{ github.job }} # github does not expose this variable https://github.com/orgs/community/discussions/8945
   CI_JOB_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
@@ -292,6 +291,9 @@ jobs:
           pytest -m "not fails_on_merge_train" -v -o junit_family=xunit1 \
             --junitxml=../../test_report.xml --cov=. --cov-report=term \
             --cov-report=term-missing --cov-report=html --cov-branch
+        env:
+          CI_COMMIT_REF_PROTECTED: ${{ github.ref_protected }}
+          CI_DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
   build-ic:
     name: Build IC
     runs-on:

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -17,7 +17,6 @@ concurrency:
 permissions: read-all
 env:
   CI_COMMIT_SHA: ${{ github.sha }}
-  CI_COMMIT_REF_PROTECTED: ${{ github.ref_protected }}
   CI_DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
   CI_JOB_NAME: ${{ github.job }}
   CI_JOB_ID: ${{ github.job }} # github does not expose this variable https://github.com/orgs/community/discussions/8945

--- a/.github/workflows/release-testing.yml
+++ b/.github/workflows/release-testing.yml
@@ -11,7 +11,6 @@ concurrency:
   cancel-in-progress: true
 env:
   CI_COMMIT_SHA: ${{ github.sha }}
-  CI_COMMIT_REF_PROTECTED: ${{ github.ref_protected }}
   CI_JOB_NAME: ${{ github.job }}
   CI_JOB_ID: ${{ github.job }} # github does not expose this variable https://github.com/orgs/community/discussions/8945
   CI_JOB_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/.github/workflows/schedule-daily.yml
+++ b/.github/workflows/schedule-daily.yml
@@ -6,7 +6,6 @@ on:
 env:
   BAZEL_STARTUP_ARGS: "--output_base=/var/tmp/bazel-output/"
   CI_COMMIT_SHA: ${{ github.sha }}
-  CI_COMMIT_REF_PROTECTED: ${{ github.ref_protected }}
   CI_JOB_NAME: ${{ github.job }}
   CI_JOB_ID: ${{ github.job }} # github does not expose this variable https://github.com/orgs/community/discussions/8945
   CI_JOB_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/.github/workflows/schedule-daily.yml
+++ b/.github/workflows/schedule-daily.yml
@@ -5,6 +5,7 @@ on:
   workflow_dispatch:
 env:
   BAZEL_STARTUP_ARGS: "--output_base=/var/tmp/bazel-output/"
+  BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
   CI_COMMIT_SHA: ${{ github.sha }}
   CI_JOB_NAME: ${{ github.job }}
   CI_JOB_ID: ${{ github.job }} # github does not expose this variable https://github.com/orgs/community/discussions/8945

--- a/.github/workflows/schedule-hourly.yml
+++ b/.github/workflows/schedule-hourly.yml
@@ -4,6 +4,7 @@ on:
     - cron: "0 * * * *"
   workflow_dispatch:
 env:
+  BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
   CI_COMMIT_SHA: ${{ github.sha }}
   CI_JOB_NAME: ${{ github.job }}
   CI_JOB_ID: ${{ github.job }} # github does not expose this variable https://github.com/orgs/community/discussions/8945

--- a/.github/workflows/schedule-hourly.yml
+++ b/.github/workflows/schedule-hourly.yml
@@ -5,7 +5,6 @@ on:
   workflow_dispatch:
 env:
   CI_COMMIT_SHA: ${{ github.sha }}
-  CI_COMMIT_REF_PROTECTED: ${{ github.ref_protected }}
   CI_JOB_NAME: ${{ github.job }}
   CI_JOB_ID: ${{ github.job }} # github does not expose this variable https://github.com/orgs/community/discussions/8945
   CI_JOB_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/.github/workflows/system-tests-k8s.yml
+++ b/.github/workflows/system-tests-k8s.yml
@@ -32,6 +32,7 @@ env:
     ${{ github.event_name == 'schedule' && '7' ||
     github.event_name == 'workflow_dispatch' && github.event.inputs.jobs ||
     '32' }}
+  BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
   CI_COMMIT_SHA: ${{ github.sha }}
   CI_JOB_NAME: ${{ github.job }}
   CI_JOB_ID: ${{ github.job }}

--- a/.github/workflows/system-tests-k8s.yml
+++ b/.github/workflows/system-tests-k8s.yml
@@ -33,7 +33,6 @@ env:
     github.event_name == 'workflow_dispatch' && github.event.inputs.jobs ||
     '32' }}
   CI_COMMIT_SHA: ${{ github.sha }}
-  CI_COMMIT_REF_PROTECTED: ${{ github.ref_protected }}
   CI_JOB_NAME: ${{ github.job }}
   CI_JOB_ID: ${{ github.job }}
   CI_JOB_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/ci/bazel-scripts/main.sh
+++ b/ci/bazel-scripts/main.sh
@@ -10,7 +10,6 @@ set -eufo pipefail
 ic_version_rc_only="0000000000000000000000000000000000000000"
 s3_upload="False"
 
-# List of protected branch patterns
 protected_branches=("master" "rc--*" "hotfix--*" "master-private")
 
 # if we are on a protected branch or targeting a rc branch we set ic_version to the commit_sha and upload to s3

--- a/ci/bazel-scripts/main.sh
+++ b/ci/bazel-scripts/main.sh
@@ -10,8 +10,19 @@ set -eufo pipefail
 ic_version_rc_only="0000000000000000000000000000000000000000"
 s3_upload="False"
 
+# List of protected branch patterns
+protected_branches=("master" "rc--*" "hotfix--*" "master-private")
+
 # if we are on a protected branch or targeting a rc branch we set ic_version to the commit_sha and upload to s3
-if [[ "$CI_COMMIT_REF_PROTECTED" = "true" ]] || [[ "${CI_PULL_REQUEST_TARGET_BRANCH_NAME:-}" == "rc--"* ]]; then
+for pattern in "${protected_branches[@]}"; do
+  if [[ "$BRANCH_NAME" == $pattern ]]; then
+    IS_PROTECTED_BRANCH="true"
+    break
+  fi
+done
+
+# if we are on a protected branch or targeting a rc branch we set ic_version to the commit_sha and upload to s3
+if [[ "${IS_PROTECTED_BRANCH:-}" == "true" ]] || [[ "${CI_PULL_REQUEST_TARGET_BRANCH_NAME:-}" == "rc--"* ]]; then
     ic_version_rc_only="${CI_COMMIT_SHA}"
     s3_upload="True"
 fi

--- a/ci/bazel-scripts/main.sh
+++ b/ci/bazel-scripts/main.sh
@@ -14,10 +14,10 @@ protected_branches=("master" "rc--*" "hotfix--*" "master-private")
 
 # if we are on a protected branch or targeting a rc branch we set ic_version to the commit_sha and upload to s3
 for pattern in "${protected_branches[@]}"; do
-  if [[ "$BRANCH_NAME" == $pattern ]]; then
-    IS_PROTECTED_BRANCH="true"
-    break
-  fi
+    if [[ "$BRANCH_NAME" == $pattern ]]; then
+        IS_PROTECTED_BRANCH="true"
+        break
+    fi
 done
 
 # if we are on a protected branch or targeting a rc branch we set ic_version to the commit_sha and upload to s3

--- a/ci/bazel-scripts/main.sh
+++ b/ci/bazel-scripts/main.sh
@@ -10,7 +10,7 @@ set -eufo pipefail
 ic_version_rc_only="0000000000000000000000000000000000000000"
 s3_upload="False"
 
-protected_branches=("master" "rc--*" "hotfix--*" "master-private")
+protected_branches=("master" "rc--*" "hotfix-*" "master-private")
 
 # if we are on a protected branch or targeting a rc branch we set ic_version to the commit_sha and upload to s3
 for pattern in "${protected_branches[@]}"; do

--- a/ci/scripts/run-build-ic.sh
+++ b/ci/scripts/run-build-ic.sh
@@ -5,6 +5,8 @@ VERSION=$(git rev-parse HEAD)
 
 cd "$CI_PROJECT_DIR"
 
+protected_branches=("master" "rc--*" "hotfix--*" "master-private")
+
 # if we are on a protected branch or targeting a rc branch we set ic_version to the commit_sha and upload to s3
 for pattern in "${protected_branches[@]}"; do
   if [[ "$BRANCH_NAME" == $pattern ]]; then

--- a/ci/scripts/run-build-ic.sh
+++ b/ci/scripts/run-build-ic.sh
@@ -5,8 +5,16 @@ VERSION=$(git rev-parse HEAD)
 
 cd "$CI_PROJECT_DIR"
 
+# if we are on a protected branch or targeting a rc branch we set ic_version to the commit_sha and upload to s3
+for pattern in "${protected_branches[@]}"; do
+  if [[ "$BRANCH_NAME" == $pattern ]]; then
+    IS_PROTECTED_BRANCH="true"
+    break
+  fi
+done
+
 # run build with release on protected branches or if a pull_request is targeting an rc branch
-if [ "$CI_COMMIT_REF_PROTECTED" == "true" ] || [[ "${CI_MERGE_REQUEST_TARGET_BRANCH_NAME:-}" == "rc--"* ]]; then
+if [ "${IS_PROTECTED_BRANCH:-}" == "true" ] || [[ "${CI_MERGE_REQUEST_TARGET_BRANCH_NAME:-}" == "rc--"* ]]; then
     ci/container/build-ic.sh -i -c -b
 # if an override was requested to run all bazel targets with no release
 elif [[ "${CI_PULL_REQUEST_TITLE:-}" == *"[RUN_ALL_BAZEL_TARGETS]"* ]]; then

--- a/ci/scripts/run-build-ic.sh
+++ b/ci/scripts/run-build-ic.sh
@@ -5,7 +5,7 @@ VERSION=$(git rev-parse HEAD)
 
 cd "$CI_PROJECT_DIR"
 
-protected_branches=("master" "rc--*" "hotfix--*" "master-private")
+protected_branches=("master" "rc--*" "hotfix-*" "master-private")
 
 # if we are on a protected branch or targeting a rc branch we set ic_version to the commit_sha and upload to s3
 for pattern in "${protected_branches[@]}"; do

--- a/ci/scripts/run-build-ic.sh
+++ b/ci/scripts/run-build-ic.sh
@@ -9,10 +9,10 @@ protected_branches=("master" "rc--*" "hotfix--*" "master-private")
 
 # if we are on a protected branch or targeting a rc branch we set ic_version to the commit_sha and upload to s3
 for pattern in "${protected_branches[@]}"; do
-  if [[ "$BRANCH_NAME" == $pattern ]]; then
-    IS_PROTECTED_BRANCH="true"
-    break
-  fi
+    if [[ "$BRANCH_NAME" == $pattern ]]; then
+        IS_PROTECTED_BRANCH="true"
+        break
+    fi
 done
 
 # run build with release on protected branches or if a pull_request is targeting an rc branch


### PR DESCRIPTION
I'm not sure why this issue didn't show up in a different way sooner, but the `${{ github.ref_protected }}` does not work as expected and usually defaults to `false`. This fix removes this env var and manually checks if the branch is in the list of branches we protect. 