### PR TITLE
feat: Set default initial notarisation delay for APP subnets to 300ms

### DIFF
--- a/rs/limits/src/lib.rs
+++ b/rs/limits/src/lib.rs
@@ -53,7 +53,7 @@ pub const MEGABYTE: u64 = KILOBYTE * KILOBYTE;
 
 pub const UNIT_DELAY_APP_SUBNET: Duration = Duration::from_millis(1000);
 pub const UNIT_DELAY_NNS_SUBNET: Duration = Duration::from_millis(3000);
-pub const INITIAL_NOTARY_DELAY_APP_SUBNET: Duration = Duration::from_millis(600);
+pub const INITIAL_NOTARY_DELAY_APP_SUBNET: Duration = Duration::from_millis(300);
 pub const INITIAL_NOTARY_DELAY_NNS_SUBNET: Duration = Duration::from_millis(1000);
 pub const MAX_INGRESS_MESSAGES_PER_BLOCK: u64 = 1000;
 pub const MAX_BLOCK_PAYLOAD_SIZE: u64 = 4 * MEGABYTE;


### PR DESCRIPTION
The constants in `rs/limits/src/lib.rs` defines the default notarisation delay for new subnets. As part of the latency milestone, we have increased the block rate of the IC by reducing the initial notarisation delay for APP subnets from 600ms to 300ms through NNS proposals [0].

This MR changes the default initial notarisation delay value, such that new subnets that are created have a 300ms notarisation delay by default.


[0] https://forum.dfinity.org/t/reducing-end-to-end-latencies-on-the-internet-computer/34383/1
 