### PR TITLE
chore: RUN-1035: Adapt wasm heap memory throughput benchmarks to run in Wasm64 mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3706,6 +3706,7 @@ dependencies = [
  "criterion",
  "ic-test-utilities-execution-environment",
  "ic-types",
+ "ic-wasm-transform",
 ]
 
 [[package]]

--- a/rs/embedders/benches/embedders_bench/Cargo.toml
+++ b/rs/embedders/benches/embedders_bench/Cargo.toml
@@ -12,4 +12,4 @@ canister-test = { path = "../../../rust_canisters/canister_test" }
 criterion = { workspace = true }
 ic-test-utilities-execution-environment = { path = "../../../test_utilities/execution_environment" }
 ic-types = { path = "../../../types/types" }
-ic-wasm-transform = { path = "../wasm_transform" }
+ic-wasm-transform = { path = "../../../wasm_transform" }

--- a/rs/embedders/benches/embedders_bench/Cargo.toml
+++ b/rs/embedders/benches/embedders_bench/Cargo.toml
@@ -12,3 +12,4 @@ canister-test = { path = "../../../rust_canisters/canister_test" }
 criterion = { workspace = true }
 ic-test-utilities-execution-environment = { path = "../../../test_utilities/execution_environment" }
 ic-types = { path = "../../../types/types" }
+ic-wasm-transform = { path = "../wasm_transform" }

--- a/rs/embedders/benches/heap.rs
+++ b/rs/embedders/benches/heap.rs
@@ -18,37 +18,95 @@ fn accessed_pages(step: usize) -> Option<Throughput> {
     ))
 }
 
-fn bench_name(method: &str, source: Source) -> String {
+fn bench_name(memory_type: &str, method: &str, source: Source) -> String {
     match source {
         Source::Checkpoint => {
-            format!("{}_checkpoint", method)
+            format!("{}_{}_checkpoint", memory_type, method)
         }
         Source::PageDelta => {
-            format!("{}_page_delta", method)
+            format!("{}_{}_page_delta", memory_type, method)
         }
     }
 }
 
+fn load_wat_and_prepare(is_wasm64: bool) -> Vec<u8> {
+    let wat_str = if is_wasm64 {
+        let wat_str = std::str::from_utf8(HEAP_WAT).unwrap();
+        // Replace all i32 with i64. This is sufficient to execute the canister in Wasm64 mode.
+        let wat_str = wat_str.replace("i32", "i64");
+        // Replace memory with memory 64 to enable Wasm64 mode.
+        wat_str.replace(
+            "(memory (export \"memory\") 16384)",
+            "(memory (export \"memory\") i64 16384)",
+        )
+    } else {
+        std::str::from_utf8(HEAP_WAT).unwrap().to_string()
+    };
+    wat::parse_str(wat_str).unwrap()
+}
+
 fn query_bench(c: &mut Criterion, method: &str, step: usize, source: Source) {
-    let wasm = wat::parse_str(std::str::from_utf8(HEAP_WAT).unwrap()).unwrap();
+    let wasm32 = load_wat_and_prepare(false);
+    let wasm64 = load_wat_and_prepare(true);
     let throughput = accessed_pages(step);
     let action = match source {
         Source::Checkpoint => PostSetupAction::PerformCheckpoint,
         Source::PageDelta => PostSetupAction::None,
     };
-    let name = bench_name(method, source);
-    embedders_bench::query_bench(c, &name, &wasm, &[], method, &[], throughput, action);
+    let name_wasm32 = bench_name("wasm32", method, source);
+    let name_wasm64 = bench_name("wasm64", method, source);
+    embedders_bench::query_bench(
+        c,
+        &name_wasm32,
+        &wasm32,
+        &[],
+        method,
+        &[],
+        throughput.clone(),
+        action,
+    );
+    embedders_bench::query_bench(
+        c,
+        &name_wasm64,
+        &wasm64,
+        &[],
+        method,
+        &[],
+        throughput,
+        action,
+    );
 }
 
 fn update_bench(c: &mut Criterion, method: &str, step: usize, source: Source) {
-    let wasm = wat::parse_str(std::str::from_utf8(HEAP_WAT).unwrap()).unwrap();
+    let wasm32 = load_wat_and_prepare(false);
+    let wasm64 = load_wat_and_prepare(true);
     let throughput = accessed_pages(step);
     let action = match source {
         Source::Checkpoint => PostSetupAction::PerformCheckpoint,
         Source::PageDelta => PostSetupAction::None,
     };
-    let name = bench_name(method, source);
-    embedders_bench::update_bench(c, &name, &wasm, &[], method, &[], throughput, action);
+    let name_wasm32 = bench_name("wasm32", method, source);
+    let name_wasm64 = bench_name("wasm64", method, source);
+    embedders_bench::update_bench(
+        c,
+        &name_wasm32,
+        &wasm32,
+        &[],
+        method,
+        &[],
+        throughput.clone(),
+        action,
+    );
+    embedders_bench::update_bench(
+        c,
+        &name_wasm64,
+        &wasm64,
+        &[],
+        method,
+        &[],
+        throughput,
+        action,
+    );
 }
 
 ////////////////////////////////////////////////////////////////////////

--- a/rs/test_utilities/execution_environment/src/lib.rs
+++ b/rs/test_utilities/execution_environment/src/lib.rs
@@ -1976,6 +1976,11 @@ impl ExecutionTestBuilder {
         self
     }
 
+    pub fn with_max_wasm_memory_size(mut self, wasm_memory_size: NumBytes) -> Self {
+        self.execution_config.embedders_config.max_wasm_memory_size = wasm_memory_size;
+        self
+    }
+
     pub fn with_metering_type(mut self, metering_type: MeteringType) -> Self {
         self.execution_config.embedders_config.metering_type = metering_type;
         self


### PR DESCRIPTION
This PR changes the wasm heap memory throughput benchmarks to allow them to run in Wasm64 mode.