### PR TITLE
chore(IDX): replace rules_docker with rules_oci

### DIFF
--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -3,8 +3,168 @@ workspace(
 )
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive", "http_file", "http_jar")
+
+# Skylib helpers, loaded first in order to avoid inheriting potential versions pulled in by other deps
+http_archive(
+    name = "bazel_skylib",
+    sha256 = "bc283cdfcd526a52c3201279cda4bc298652efa898b10b4db0837dc51652756f",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.7.1/bazel-skylib-1.7.1.tar.gz",
+        "https://github.com/bazelbuild/bazel-skylib/releases/download/1.7.1/bazel-skylib-1.7.1.tar.gz",
+    ],
+)
+
+load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
+
+bazel_skylib_workspace()
+
+# Bazel helpers by Aspect
+http_archive(
+    name = "aspect_bazel_lib",
+    sha256 = "688354ee6beeba7194243d73eb0992b9a12e8edeeeec5b6544f4b531a3112237",
+    strip_prefix = "bazel-lib-2.8.1",
+    url = "https://github.com/aspect-build/bazel-lib/releases/download/v2.8.1/bazel-lib-v2.8.1.tar.gz",
+)
+
+load("@aspect_bazel_lib//lib:repositories.bzl", "aspect_bazel_lib_dependencies", "aspect_bazel_lib_register_toolchains")
+
+aspect_bazel_lib_dependencies()
+
+aspect_bazel_lib_register_toolchains()
+
+# Rules used to build Ubuntu systems
+http_archive(
+    name = "rules_distroless",
+    sha256 = "8a3440067453ad211f3b34d4a8f68f65663dc5fd6d7834bf81eecf0526785381",
+    strip_prefix = "rules_distroless-0.3.6",
+    url = "https://github.com/GoogleContainerTools/rules_distroless/releases/download/v0.3.6/rules_distroless-v0.3.6.tar.gz",
+)
+
+load("@rules_distroless//distroless:dependencies.bzl", "distroless_dependencies")
+
+distroless_dependencies()
+
+load("@rules_distroless//distroless:toolchains.bzl", "distroless_register_toolchains")
+
+distroless_register_toolchains()
+
+load("@rules_distroless//apt:index.bzl", "deb_index")
+
+# Packageset based on an Ubuntu focal snapshot, see manifest file
+# for details
+# To update, comment out the `lock` field below and run:
+#   bazel run @focal//:lock
+deb_index(
+    name = "focal",
+    lock = "//bazel:focal.lock.json",
+    manifest = "//bazel:focal.yaml",
+)
+
+load("@focal//:packages.bzl", "focal_packages")
+
+focal_packages()
+
+# OCI (docker, podman) container support
+http_archive(
+    name = "rules_oci",
+    sha256 = "79e7f80df2840d14d7bc79099b5ed4553398cce8cff1f0df97289a07f7fd213c",
+    strip_prefix = "rules_oci-2.0.0-rc0",
+    url = "https://github.com/bazel-contrib/rules_oci/releases/download/v2.0.0-rc0/rules_oci-v2.0.0-rc0.tar.gz",
+)
+
+load("@rules_oci//oci:dependencies.bzl", "rules_oci_dependencies")
+
+rules_oci_dependencies()
+
+load("@rules_oci//oci:repositories.bzl", "oci_register_toolchains")
+
+oci_register_toolchains(name = "oci")
+
+load("@rules_oci//oci:pull.bzl", "oci_pull")
 load("//third_party/lmdb:repository.bzl", "lmdb_repository")
 load("mainnet-canisters.bzl", "mainnet_ck_canisters", "mainnet_core_nns_canisters", "mainnet_sns_canisters")
+
+# file server used in tests
+oci_pull(
+    name = "static-file-server",
+    # $ docker pull halverneus/static-file-server
+    # $ docker tag halverneus/static-file-server dfinitydev/halverneus-static-file-server:latest
+    # $ docker push dfinitydev/halverneus-static-file-server:latest
+    #latest: digest: sha256:...
+    image = "docker.io/dfinitydev/halverneus-static-file-server@sha256:80eb204716e0928e27e378ed817056c1167b2b1a878b1ac4ce496964dd9a3ccd",
+    platforms = [
+        "linux/amd64",
+    ],
+)
+
+# bitcoin container used in test
+oci_pull(
+    name = "bitcoind",
+    image = "docker.io/kylemanna/bitcoind@sha256:17c7dd21690f3be34630db7389d2f0bff14649e27a964afef03806a6d631e0f1",
+)
+
+# Tracing image used in tests
+# we can't use the official image: https://github.com/bazel-contrib/rules_oci/issues/695
+#
+# Instead we copy the official image to our repository:
+# $ docker pull halverneus/static-file-server
+# $ docker tag halverneus/static-file-server dfinitydev/halverneus-static-file-server:latest
+# $ docker push dfinitydev/halverneus-static-file-server:latest
+# > latest: digest: sha256:...
+oci_pull(
+    name = "jaeger",
+    image = "docker.io/dfinitydev/jaegertracing-all-in-one@sha256:b85a6bbb949a62377010b8418d7a860c9d0ea7058d83e7cb5ade4fba046c4a76",
+    platforms = [
+        "linux/amd64",
+    ],
+)
+
+# Used by tests
+oci_pull(
+    name = "minica",
+    image = "docker.io/ryantk/minica@sha256:c67e2c1885d438b5927176295d41aaab8a72dd9e1272ba85054bfc78191d05b0",
+    platforms = ["linux/amd64"],
+)
+
+# used by rosetta image
+oci_pull(
+    name = "rust_base",
+    image = "gcr.io/distroless/cc-debian11@sha256:8e94f031353596c3fc9db6a2499bcc82dacc40cb71e0703476f9fad41677efdf",
+    platforms = ["linux/amd64"],
+)
+
+# used in various places as base
+oci_pull(
+    name = "ubuntu_base",
+    image = "docker.io/library/ubuntu@sha256:965fbcae990b0467ed5657caceaec165018ef44a4d2d46c7cdea80a9dff0d1ea",
+    platforms = ["linux/amd64"],
+)
+
+# used by boundary node tests
+oci_pull(
+    name = "coredns",
+    image = "docker.io/coredns/coredns@sha256:be7652ce0b43b1339f3d14d9b14af9f588578011092c1f7893bd55432d83a378",
+    platforms = ["linux/amd64"],
+)
+
+# used by custom domains tests
+oci_pull(
+    name = "pebble",
+    image = "docker.io/letsencrypt/pebble@sha256:fc5a537bf8fbc7cc63aa24ec3142283aa9b6ba54529f86eb8ff31fbde7c5b258",
+    platforms = ["linux/amd64"],
+)
+
+oci_pull(
+    name = "python3",
+    image = "docker.io/library/python@sha256:0a56f24afa1fc7f518aa690cb8c7be661225e40b157d9bb8c6ef402164d9faa7",
+    platforms = ["linux/amd64"],
+)
+
+oci_pull(
+    name = "alpine_openssl",
+    image = "docker.io/alpine/openssl@sha256:cf89651f07a33d2faf4499f72e6f8b0ee2542cd40735d51c7e75b8965c17af0e",
+    platforms = ["linux/amd64"],
+)
 
 http_archive(
     name = "aspect_rules_sol",
@@ -21,19 +181,6 @@ sol_register_toolchains(
     name = "solc",
     sol_version = "0.8.18",
 )
-
-http_archive(
-    name = "bazel_skylib",
-    sha256 = "9f38886a40548c6e96c106b752f242130ee11aaa068a56ba7e56f4511f33e4f2",
-    urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.6.1/bazel-skylib-1.6.1.tar.gz",
-        "https://github.com/bazelbuild/bazel-skylib/releases/download/1.4.2/bazel-skylib-1.6.1.tar.gz",
-    ],
-)
-
-load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
-
-bazel_skylib_workspace()
 
 http_archive(
     name = "io_bazel_rules_go",
@@ -172,137 +319,11 @@ load("@rules_pkg//:deps.bzl", "rules_pkg_dependencies")
 
 rules_pkg_dependencies()
 
-# Docker container support
-
-http_archive(
-    name = "io_bazel_rules_docker",
-    sha256 = "b1e80761a8a8243d03ebca8845e9cc1ba6c82ce7c5179ce2b295cd36f7e394bf",
-    urls = ["https://github.com/bazelbuild/rules_docker/releases/download/v0.25.0/rules_docker-v0.25.0.tar.gz"],
-)
-
-load(
-    "@io_bazel_rules_docker//toolchains/docker:toolchain.bzl",
-    docker_toolchain_configure = "toolchain_configure",
-)
-
-docker_toolchain_configure(
-    name = "docker_config",
-    gzip_target = "@pigz",
-)
-
-load(
-    "@io_bazel_rules_docker//repositories:repositories.bzl",
-    container_repositories = "repositories",
-)
-
 # Bitcoin core
 
 load("//third_party/bitcoin-core:bitcoin-core_repository.bzl", "bitcoin_core_repository")
 
 bitcoin_core_repository()
-
-container_repositories()
-
-load("@io_bazel_rules_docker//repositories:deps.bzl", container_deps = "deps")
-
-container_deps(go_repository_default_config = "@//:WORKSPACE.bazel")
-
-load(
-    "@io_bazel_rules_docker//container:container.bzl",
-    "container_pull",
-)
-
-container_pull(
-    name = "static-file-server",
-    digest = "sha256:c387c31ffb55ac5b6b4654bc9924f73eb8fb5214ebb8552a7eeffc8849f0e7dd",
-    registry = "docker.io",
-    repository = "halverneus/static-file-server",
-)
-
-container_pull(
-    name = "bitcoind",
-    digest = "sha256:17c7dd21690f3be34630db7389d2f0bff14649e27a964afef03806a6d631e0f1",
-    registry = "docker.io",
-    repository = "kylemanna/bitcoind",
-)
-
-container_pull(
-    name = "jaeger",
-    digest = "sha256:f421219dbd77248301fc42ac6e8ba5026f4bada9448ab33ac89061e21cfe3fea",
-    registry = "docker.io",
-    repository = "jaegertracing/all-in-one",
-)
-
-container_pull(
-    name = "minica",
-    digest = "sha256:c67e2c1885d438b5927176295d41aaab8a72dd9e1272ba85054bfc78191d05b0",
-    registry = "docker.io",
-    repository = "ryantk/minica",
-)
-
-container_pull(
-    name = "rust_base",
-    digest = "sha256:8e94f031353596c3fc9db6a2499bcc82dacc40cb71e0703476f9fad41677efdf",
-    registry = "gcr.io",
-    repository = "distroless/cc-debian11",
-)
-
-container_pull(
-    name = "ubuntu_base",
-    digest = "sha256:965fbcae990b0467ed5657caceaec165018ef44a4d2d46c7cdea80a9dff0d1ea",
-    registry = "docker.io",
-    repository = "ubuntu",
-)
-
-container_pull(
-    name = "coredns",
-    digest = "sha256:be7652ce0b43b1339f3d14d9b14af9f588578011092c1f7893bd55432d83a378",
-    registry = "docker.io",
-    repository = "coredns/coredns",
-    tag = "1.10.1",
-)
-
-container_pull(
-    name = "pebble",
-    digest = "sha256:fc5a537bf8fbc7cc63aa24ec3142283aa9b6ba54529f86eb8ff31fbde7c5b258",
-    registry = "docker.io",
-    repository = "letsencrypt/pebble",
-    tag = "v2.3.1",
-)
-
-container_pull(
-    name = "python3",
-    digest = "sha256:0a56f24afa1fc7f518aa690cb8c7be661225e40b157d9bb8c6ef402164d9faa7",
-    registry = "docker.io",
-    repository = "python",
-    tag = "3-alpine",
-)
-
-container_pull(
-    name = "alpine_openssl",
-    digest = "sha256:cf89651f07a33d2faf4499f72e6f8b0ee2542cd40735d51c7e75b8965c17af0e",
-    registry = "docker.io",
-    repository = "alpine/openssl",
-)
-
-# This image was built with bazel (bazel build //rs/tests:ubuntu_test_runtime_image)
-# then uploaded to our GitLab registry using:
-#
-#  $ bazel build //rs/tests:ubuntu_test_runtime_image
-#  $ docker login registry.gitlab.com
-#  $ docker load -i bazel-bin/rs/tests/ubuntu_test_runtime_image.tar
-#  $ docker tag ubuntu_test_runtime_image:latest "registry.gitlab.com/dfinity-lab/open/public-docker-registry/ubuntu_test_runtime_image:latest"
-#  $ docker image push  "registry.gitlab.com/dfinity-lab/open/public-docker-registry/ubuntu_test_runtime_image:latest"
-#
-# The reason we can't directly depend on //rs/tests:ubuntu_test_runtime_image is that
-# the target //rs/tests/httpbin-rs:httpbin_image_base
-# fails to build in our container (ci/container/container-run.sh).
-container_pull(
-    name = "ubuntu_test_runtime",
-    digest = "sha256:d5b2f17ee8fcd45b4f1580893680b78a540f491e647a9f6971bdaab393e372f7",
-    registry = "registry.gitlab.com",
-    repository = "dfinity-lab/open/public-docker-registry/ubuntu_test_runtime_image",
-)
 
 # Third party dependencies that require special treatment
 
@@ -431,17 +452,6 @@ idl_to_json(name = "idl2json")
 load("//bazel:jq.bzl", "jq_repository")
 
 jq_repository(name = "jq")
-
-http_archive(
-    name = "aspect_bazel_lib",
-    sha256 = "79381b0975ba7d2d5653239e5bab12cf54d89b10217fe771b8edd95047a2e44b",
-    strip_prefix = "bazel-lib-1.12.1",
-    url = "https://github.com/aspect-build/bazel-lib/archive/refs/tags/v1.12.1.tar.gz",
-)
-
-load("@aspect_bazel_lib//lib:repositories.bzl", "aspect_bazel_lib_dependencies")
-
-aspect_bazel_lib_dependencies()
 
 # TLA+ tools
 http_jar(

--- a/bazel/focal.lock.json
+++ b/bazel/focal.lock.json
@@ -1,0 +1,1711 @@
+{
+	"packages": [
+		{
+			"arch": "amd64",
+			"dependencies": [
+				{
+					"key": "openssl_1.1.1f-1ubuntu2.22_amd64",
+					"name": "openssl",
+					"version": "1.1.1f-1ubuntu2.22"
+				},
+				{
+					"key": "libssl1.1_1.1.1f-1ubuntu2.22_amd64",
+					"name": "libssl1.1",
+					"version": "1.1.1f-1ubuntu2.22"
+				},
+				{
+					"key": "libc6_2.31-0ubuntu9.14_amd64",
+					"name": "libc6",
+					"version": "2.31-0ubuntu9.14"
+				},
+				{
+					"key": "libcrypt1_1-4.4.10-10ubuntu4_amd64",
+					"name": "libcrypt1",
+					"version": "1:4.4.10-10ubuntu4"
+				},
+				{
+					"key": "libgcc-s1_10.5.0-1ubuntu1_20.04_amd64",
+					"name": "libgcc-s1",
+					"version": "10.5.0-1ubuntu1~20.04"
+				},
+				{
+					"key": "gcc-10-base_10.5.0-1ubuntu1_20.04_amd64",
+					"name": "gcc-10-base",
+					"version": "10.5.0-1ubuntu1~20.04"
+				}
+			],
+			"key": "ca-certificates_20230311ubuntu0.20.04.1_amd64",
+			"name": "ca-certificates",
+			"sha256": "ec23973dbb9317eb746d44aa6795556ee591d75eb9f7292a6672e69f215afcb9",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/c/ca-certificates/ca-certificates_20230311ubuntu0.20.04.1_all.deb",
+			"version": "20230311ubuntu0.20.04.1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "openssl_1.1.1f-1ubuntu2.22_amd64",
+			"name": "openssl",
+			"sha256": "d5b1e5de1627b6b895adbb030ccb8fc16125c5d0ef3604d898da136fc2bd6ad2",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/o/openssl/openssl_1.1.1f-1ubuntu2.22_amd64.deb",
+			"version": "1.1.1f-1ubuntu2.22"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [
+				{
+					"key": "libc6_2.31-0ubuntu9.14_amd64",
+					"name": "libc6",
+					"version": "2.31-0ubuntu9.14"
+				},
+				{
+					"key": "libcrypt1_1-4.4.10-10ubuntu4_amd64",
+					"name": "libcrypt1",
+					"version": "1:4.4.10-10ubuntu4"
+				},
+				{
+					"key": "libgcc-s1_10.5.0-1ubuntu1_20.04_amd64",
+					"name": "libgcc-s1",
+					"version": "10.5.0-1ubuntu1~20.04"
+				},
+				{
+					"key": "gcc-10-base_10.5.0-1ubuntu1_20.04_amd64",
+					"name": "gcc-10-base",
+					"version": "10.5.0-1ubuntu1~20.04"
+				}
+			],
+			"key": "libssl1.1_1.1.1f-1ubuntu2.22_amd64",
+			"name": "libssl1.1",
+			"sha256": "df9d07d552aab0c7e5b9fbcc568913acd20d50fb8b1e34876fa348b7a0c82d48",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2.22_amd64.deb",
+			"version": "1.1.1f-1ubuntu2.22"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libc6_2.31-0ubuntu9.14_amd64",
+			"name": "libc6",
+			"sha256": "a469164a97599aaef2552512acfd91c8830dc8d5e8053f9c02215ff9cd36673c",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/g/glibc/libc6_2.31-0ubuntu9.14_amd64.deb",
+			"version": "2.31-0ubuntu9.14"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libcrypt1_1-4.4.10-10ubuntu4_amd64",
+			"name": "libcrypt1",
+			"sha256": "231b4dbbe5865775f118cfa61394f1e16fa7102b6953a327e672499a20876d73",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/libx/libxcrypt/libcrypt1_4.4.10-10ubuntu4_amd64.deb",
+			"version": "1:4.4.10-10ubuntu4"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libgcc-s1_10.5.0-1ubuntu1_20.04_amd64",
+			"name": "libgcc-s1",
+			"sha256": "4aa7b9c9f3225df65a750ae0ff5c890fc6108c82a609b3c5abd45d211838bf3c",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/g/gcc-10/libgcc-s1_10.5.0-1ubuntu1~20.04_amd64.deb",
+			"version": "10.5.0-1ubuntu1~20.04"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "gcc-10-base_10.5.0-1ubuntu1_20.04_amd64",
+			"name": "gcc-10-base",
+			"sha256": "8fac06791057b1bba6178466e160bb3ec2a795297f10e88e34daf762572ed5c0",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/g/gcc-10/gcc-10-base_10.5.0-1ubuntu1~20.04_amd64.deb",
+			"version": "10.5.0-1ubuntu1~20.04"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [
+				{
+					"key": "libselinux1_3.0-1build2_amd64",
+					"name": "libselinux1",
+					"version": "3.0-1build2"
+				},
+				{
+					"key": "libpcre2-8-0_10.34-7ubuntu0.1_amd64",
+					"name": "libpcre2-8-0",
+					"version": "10.34-7ubuntu0.1"
+				},
+				{
+					"key": "libc6_2.31-0ubuntu9.14_amd64",
+					"name": "libc6",
+					"version": "2.31-0ubuntu9.14"
+				},
+				{
+					"key": "libcrypt1_1-4.4.10-10ubuntu4_amd64",
+					"name": "libcrypt1",
+					"version": "1:4.4.10-10ubuntu4"
+				},
+				{
+					"key": "libgcc-s1_10.5.0-1ubuntu1_20.04_amd64",
+					"name": "libgcc-s1",
+					"version": "10.5.0-1ubuntu1~20.04"
+				},
+				{
+					"key": "gcc-10-base_10.5.0-1ubuntu1_20.04_amd64",
+					"name": "gcc-10-base",
+					"version": "10.5.0-1ubuntu1~20.04"
+				},
+				{
+					"key": "libattr1_1-2.4.48-5_amd64",
+					"name": "libattr1",
+					"version": "1:2.4.48-5"
+				},
+				{
+					"key": "libacl1_2.2.53-6_amd64",
+					"name": "libacl1",
+					"version": "2.2.53-6"
+				}
+			],
+			"key": "coreutils_8.30-3ubuntu2_amd64",
+			"name": "coreutils",
+			"sha256": "99aa50af84de1737735f2f51e570d60f5842aa1d4a3129527906e7ffda368853",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/c/coreutils/coreutils_8.30-3ubuntu2_amd64.deb",
+			"version": "8.30-3ubuntu2"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libselinux1_3.0-1build2_amd64",
+			"name": "libselinux1",
+			"sha256": "1b8674b6f9e62fbae768d9ffbd686955d08db889ee4107d15ae02d1ec033cc7b",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/libs/libselinux/libselinux1_3.0-1build2_amd64.deb",
+			"version": "3.0-1build2"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libpcre2-8-0_10.34-7ubuntu0.1_amd64",
+			"name": "libpcre2-8-0",
+			"sha256": "5229f14c06074ae5f2d6dd7cef2c9dff8dd57c6ecf1381ff019fe5d233cc275f",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/p/pcre2/libpcre2-8-0_10.34-7ubuntu0.1_amd64.deb",
+			"version": "10.34-7ubuntu0.1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libattr1_1-2.4.48-5_amd64",
+			"name": "libattr1",
+			"sha256": "d916bb73d9a160ccaa48d997c823af528cb6b4174c5234c744b40ae5aa85ce98",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/a/attr/libattr1_2.4.48-5_amd64.deb",
+			"version": "1:2.4.48-5"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libacl1_2.2.53-6_amd64",
+			"name": "libacl1",
+			"sha256": "9fa9cc2f8eeccd8d29efcb998111b082432c65de75ca60ad9c333289bb3bb765",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/a/acl/libacl1_2.2.53-6_amd64.deb",
+			"version": "2.2.53-6"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [
+				{
+					"key": "libsigsegv2_2.12-2_amd64",
+					"name": "libsigsegv2",
+					"version": "2.12-2"
+				},
+				{
+					"key": "libc6_2.31-0ubuntu9.14_amd64",
+					"name": "libc6",
+					"version": "2.31-0ubuntu9.14"
+				},
+				{
+					"key": "libcrypt1_1-4.4.10-10ubuntu4_amd64",
+					"name": "libcrypt1",
+					"version": "1:4.4.10-10ubuntu4"
+				},
+				{
+					"key": "libgcc-s1_10.5.0-1ubuntu1_20.04_amd64",
+					"name": "libgcc-s1",
+					"version": "10.5.0-1ubuntu1~20.04"
+				},
+				{
+					"key": "gcc-10-base_10.5.0-1ubuntu1_20.04_amd64",
+					"name": "gcc-10-base",
+					"version": "10.5.0-1ubuntu1~20.04"
+				},
+				{
+					"key": "libreadline8_8.0-4_amd64",
+					"name": "libreadline8",
+					"version": "8.0-4"
+				},
+				{
+					"key": "libtinfo6_6.2-0ubuntu2.1_amd64",
+					"name": "libtinfo6",
+					"version": "6.2-0ubuntu2.1"
+				},
+				{
+					"key": "readline-common_8.0-4_amd64",
+					"name": "readline-common",
+					"version": "8.0-4"
+				},
+				{
+					"key": "libmpfr6_4.0.2-1_amd64",
+					"name": "libmpfr6",
+					"version": "4.0.2-1"
+				},
+				{
+					"key": "libgmp10_2-6.2.0-p-dfsg-4ubuntu0.1_amd64",
+					"name": "libgmp10",
+					"version": "2:6.2.0+dfsg-4ubuntu0.1"
+				}
+			],
+			"key": "gawk_1-5.0.1-p-dfsg-1ubuntu0.1_amd64",
+			"name": "gawk",
+			"sha256": "5d48f427156f9d65f433a90af21033051102db391b1c1a7a07babd17dced5453",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/g/gawk/gawk_5.0.1+dfsg-1ubuntu0.1_amd64.deb",
+			"version": "1:5.0.1+dfsg-1ubuntu0.1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libsigsegv2_2.12-2_amd64",
+			"name": "libsigsegv2",
+			"sha256": "58279e0a8af9cc299d7195f4b5dc1922f4b0779c1166d3715b335944102f9f7e",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/libs/libsigsegv/libsigsegv2_2.12-2_amd64.deb",
+			"version": "2.12-2"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libreadline8_8.0-4_amd64",
+			"name": "libreadline8",
+			"sha256": "5c0e982098eeb1b69a1360f4dc20553397d0a41240f3b2fc2812ee3f02274a82",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/r/readline/libreadline8_8.0-4_amd64.deb",
+			"version": "8.0-4"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libtinfo6_6.2-0ubuntu2.1_amd64",
+			"name": "libtinfo6",
+			"sha256": "711a3a901c3a71561565558865699efa9c07a99fdc810ffe086a5636f89c6431",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/n/ncurses/libtinfo6_6.2-0ubuntu2.1_amd64.deb",
+			"version": "6.2-0ubuntu2.1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "readline-common_8.0-4_amd64",
+			"name": "readline-common",
+			"sha256": "38c3ac67e2dab4122a2f948f433c4cb5d5653d82b323f3ff30599797b7adee9f",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/r/readline/readline-common_8.0-4_all.deb",
+			"version": "8.0-4"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libmpfr6_4.0.2-1_amd64",
+			"name": "libmpfr6",
+			"sha256": "d098b67c3e1492a1c21a6a0d9befc88344e59a0d0eb6109384f85d8524a608cb",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/m/mpfr4/libmpfr6_4.0.2-1_amd64.deb",
+			"version": "4.0.2-1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libgmp10_2-6.2.0-p-dfsg-4ubuntu0.1_amd64",
+			"name": "libgmp10",
+			"sha256": "541dc5050b0cecdecbfe155641588ba08da645b61b11fc4bcb045f2f4773da43",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/g/gmp/libgmp10_6.2.0+dfsg-4ubuntu0.1_amd64.deb",
+			"version": "2:6.2.0+dfsg-4ubuntu0.1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [
+				{
+					"key": "libudev1_245.4-4ubuntu3.23_amd64",
+					"name": "libudev1",
+					"version": "245.4-4ubuntu3.23"
+				},
+				{
+					"key": "libc6_2.31-0ubuntu9.14_amd64",
+					"name": "libc6",
+					"version": "2.31-0ubuntu9.14"
+				},
+				{
+					"key": "libcrypt1_1-4.4.10-10ubuntu4_amd64",
+					"name": "libcrypt1",
+					"version": "1:4.4.10-10ubuntu4"
+				},
+				{
+					"key": "libgcc-s1_10.5.0-1ubuntu1_20.04_amd64",
+					"name": "libgcc-s1",
+					"version": "10.5.0-1ubuntu1~20.04"
+				},
+				{
+					"key": "gcc-10-base_10.5.0-1ubuntu1_20.04_amd64",
+					"name": "gcc-10-base",
+					"version": "10.5.0-1ubuntu1~20.04"
+				}
+			],
+			"key": "dosfstools_4.1-2_amd64",
+			"name": "dosfstools",
+			"sha256": "58492d84924cee267cb3cba0e64e1241accde967748e6a1f31820fa74892ee32",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/d/dosfstools/dosfstools_4.1-2_amd64.deb",
+			"version": "4.1-2"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libudev1_245.4-4ubuntu3.23_amd64",
+			"name": "libudev1",
+			"sha256": "a9521025f12a45a91ed198fa10221e149caaba0f1156e07a641ebf02a5449805",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/s/systemd/libudev1_245.4-4ubuntu3.23_amd64.deb",
+			"version": "245.4-4ubuntu3.23"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [
+				{
+					"key": "liblzma5_5.2.4-1ubuntu1.1_amd64",
+					"name": "liblzma5",
+					"version": "5.2.4-1ubuntu1.1"
+				},
+				{
+					"key": "libc6_2.31-0ubuntu9.14_amd64",
+					"name": "libc6",
+					"version": "2.31-0ubuntu9.14"
+				},
+				{
+					"key": "libcrypt1_1-4.4.10-10ubuntu4_amd64",
+					"name": "libcrypt1",
+					"version": "1:4.4.10-10ubuntu4"
+				},
+				{
+					"key": "libgcc-s1_10.5.0-1ubuntu1_20.04_amd64",
+					"name": "libgcc-s1",
+					"version": "10.5.0-1ubuntu1~20.04"
+				},
+				{
+					"key": "gcc-10-base_10.5.0-1ubuntu1_20.04_amd64",
+					"name": "gcc-10-base",
+					"version": "10.5.0-1ubuntu1~20.04"
+				}
+			],
+			"key": "libunwind8_1.2.1-9ubuntu0.1_amd64",
+			"name": "libunwind8",
+			"sha256": "269f62bfb9fc6d7e5bbfb600b8f688e2d94099ff9dc0fddc28351330915212d1",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/libu/libunwind/libunwind8_1.2.1-9ubuntu0.1_amd64.deb",
+			"version": "1.2.1-9ubuntu0.1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "liblzma5_5.2.4-1ubuntu1.1_amd64",
+			"name": "liblzma5",
+			"sha256": "f545d34c86119802fbae869a09e1077a714e12a01ef6a3ef67fdc745e5db311d",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/x/xz-utils/liblzma5_5.2.4-1ubuntu1.1_amd64.deb",
+			"version": "5.2.4-1ubuntu1.1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [
+				{
+					"key": "libc6_2.31-0ubuntu9.14_amd64",
+					"name": "libc6",
+					"version": "2.31-0ubuntu9.14"
+				},
+				{
+					"key": "libcrypt1_1-4.4.10-10ubuntu4_amd64",
+					"name": "libcrypt1",
+					"version": "1:4.4.10-10ubuntu4"
+				},
+				{
+					"key": "libgcc-s1_10.5.0-1ubuntu1_20.04_amd64",
+					"name": "libgcc-s1",
+					"version": "10.5.0-1ubuntu1~20.04"
+				},
+				{
+					"key": "gcc-10-base_10.5.0-1ubuntu1_20.04_amd64",
+					"name": "gcc-10-base",
+					"version": "10.5.0-1ubuntu1~20.04"
+				}
+			],
+			"key": "mtools_4.0.24-1_amd64",
+			"name": "mtools",
+			"sha256": "69e3dd6afa31643cf57a2475eb4156998cbc3144ec07985a9d65b0e78731743c",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/m/mtools/mtools_4.0.24-1_amd64.deb",
+			"version": "4.0.24-1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [
+				{
+					"key": "zlib1g_1-1.2.11.dfsg-2ubuntu1.5_amd64",
+					"name": "zlib1g",
+					"version": "1:1.2.11.dfsg-2ubuntu1.5"
+				},
+				{
+					"key": "libc6_2.31-0ubuntu9.14_amd64",
+					"name": "libc6",
+					"version": "2.31-0ubuntu9.14"
+				},
+				{
+					"key": "libcrypt1_1-4.4.10-10ubuntu4_amd64",
+					"name": "libcrypt1",
+					"version": "1:4.4.10-10ubuntu4"
+				},
+				{
+					"key": "libgcc-s1_10.5.0-1ubuntu1_20.04_amd64",
+					"name": "libgcc-s1",
+					"version": "10.5.0-1ubuntu1~20.04"
+				},
+				{
+					"key": "gcc-10-base_10.5.0-1ubuntu1_20.04_amd64",
+					"name": "gcc-10-base",
+					"version": "10.5.0-1ubuntu1~20.04"
+				},
+				{
+					"key": "libssl1.1_1.1.1f-1ubuntu2.22_amd64",
+					"name": "libssl1.1",
+					"version": "1.1.1f-1ubuntu2.22"
+				},
+				{
+					"key": "libselinux1_3.0-1build2_amd64",
+					"name": "libselinux1",
+					"version": "3.0-1build2"
+				},
+				{
+					"key": "libpcre2-8-0_10.34-7ubuntu0.1_amd64",
+					"name": "libpcre2-8-0",
+					"version": "10.34-7ubuntu0.1"
+				},
+				{
+					"key": "libgssapi-krb5-2_1.17-6ubuntu4.4_amd64",
+					"name": "libgssapi-krb5-2",
+					"version": "1.17-6ubuntu4.4"
+				},
+				{
+					"key": "libkrb5support0_1.17-6ubuntu4.4_amd64",
+					"name": "libkrb5support0",
+					"version": "1.17-6ubuntu4.4"
+				},
+				{
+					"key": "libkrb5-3_1.17-6ubuntu4.4_amd64",
+					"name": "libkrb5-3",
+					"version": "1.17-6ubuntu4.4"
+				},
+				{
+					"key": "libkeyutils1_1.6-6ubuntu1.1_amd64",
+					"name": "libkeyutils1",
+					"version": "1.6-6ubuntu1.1"
+				},
+				{
+					"key": "libk5crypto3_1.17-6ubuntu4.4_amd64",
+					"name": "libk5crypto3",
+					"version": "1.17-6ubuntu4.4"
+				},
+				{
+					"key": "libcom-err2_1.45.5-2ubuntu1.1_amd64",
+					"name": "libcom-err2",
+					"version": "1.45.5-2ubuntu1.1"
+				},
+				{
+					"key": "libfido2-1_1.3.1-1ubuntu2_amd64",
+					"name": "libfido2-1",
+					"version": "1.3.1-1ubuntu2"
+				},
+				{
+					"key": "libudev1_245.4-4ubuntu3.23_amd64",
+					"name": "libudev1",
+					"version": "245.4-4ubuntu3.23"
+				},
+				{
+					"key": "libcbor0.6_0.6.0-0ubuntu1_amd64",
+					"name": "libcbor0.6",
+					"version": "0.6.0-0ubuntu1"
+				},
+				{
+					"key": "libedit2_3.1-20191231-1_amd64",
+					"name": "libedit2",
+					"version": "3.1-20191231-1"
+				},
+				{
+					"key": "libtinfo6_6.2-0ubuntu2.1_amd64",
+					"name": "libtinfo6",
+					"version": "6.2-0ubuntu2.1"
+				},
+				{
+					"key": "libbsd0_0.10.0-1_amd64",
+					"name": "libbsd0",
+					"version": "0.10.0-1"
+				},
+				{
+					"key": "passwd_1-4.8.1-1ubuntu5.20.04.5_amd64",
+					"name": "passwd",
+					"version": "1:4.8.1-1ubuntu5.20.04.5"
+				},
+				{
+					"key": "libpam-modules_1.3.1-5ubuntu4.7_amd64",
+					"name": "libpam-modules",
+					"version": "1.3.1-5ubuntu4.7"
+				},
+				{
+					"key": "libpam-modules-bin_1.3.1-5ubuntu4.7_amd64",
+					"name": "libpam-modules-bin",
+					"version": "1.3.1-5ubuntu4.7"
+				},
+				{
+					"key": "libpam0g_1.3.1-5ubuntu4.7_amd64",
+					"name": "libpam0g",
+					"version": "1.3.1-5ubuntu4.7"
+				},
+				{
+					"key": "libaudit1_1-2.8.5-2ubuntu6_amd64",
+					"name": "libaudit1",
+					"version": "1:2.8.5-2ubuntu6"
+				},
+				{
+					"key": "libcap-ng0_0.7.9-2.1build1_amd64",
+					"name": "libcap-ng0",
+					"version": "0.7.9-2.1build1"
+				},
+				{
+					"key": "libaudit-common_1-2.8.5-2ubuntu6_amd64",
+					"name": "libaudit-common",
+					"version": "1:2.8.5-2ubuntu6"
+				},
+				{
+					"key": "libdb5.3_5.3.28-p-dfsg1-0.6ubuntu2_amd64",
+					"name": "libdb5.3",
+					"version": "5.3.28+dfsg1-0.6ubuntu2"
+				},
+				{
+					"key": "libsemanage1_3.0-1build2_amd64",
+					"name": "libsemanage1",
+					"version": "3.0-1build2"
+				},
+				{
+					"key": "libsepol1_3.0-1ubuntu0.1_amd64",
+					"name": "libsepol1",
+					"version": "3.0-1ubuntu0.1"
+				},
+				{
+					"key": "libbz2-1.0_1.0.8-2_amd64",
+					"name": "libbz2-1.0",
+					"version": "1.0.8-2"
+				},
+				{
+					"key": "libsemanage-common_3.0-1build2_amd64",
+					"name": "libsemanage-common",
+					"version": "3.0-1build2"
+				},
+				{
+					"key": "dpkg_1.19.7ubuntu3.2_amd64",
+					"name": "dpkg",
+					"version": "1.19.7ubuntu3.2"
+				},
+				{
+					"key": "tar_1.30-p-dfsg-7ubuntu0.20.04.4_amd64",
+					"name": "tar",
+					"version": "1.30+dfsg-7ubuntu0.20.04.4"
+				},
+				{
+					"key": "libacl1_2.2.53-6_amd64",
+					"name": "libacl1",
+					"version": "2.2.53-6"
+				},
+				{
+					"key": "libzstd1_1.4.4-p-dfsg-3ubuntu0.1_amd64",
+					"name": "libzstd1",
+					"version": "1.4.4+dfsg-3ubuntu0.1"
+				},
+				{
+					"key": "liblzma5_5.2.4-1ubuntu1.1_amd64",
+					"name": "liblzma5",
+					"version": "5.2.4-1ubuntu1.1"
+				},
+				{
+					"key": "adduser_3.118ubuntu2_amd64",
+					"name": "adduser",
+					"version": "3.118ubuntu2"
+				}
+			],
+			"key": "openssh-client_1-8.2p1-4ubuntu0.11_amd64",
+			"name": "openssh-client",
+			"sha256": "4df6dd0ce56ef519f884483b8b993027d54fd7f80baf4c415236fc5180b345c2",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/o/openssh/openssh-client_8.2p1-4ubuntu0.11_amd64.deb",
+			"version": "1:8.2p1-4ubuntu0.11"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "zlib1g_1-1.2.11.dfsg-2ubuntu1.5_amd64",
+			"name": "zlib1g",
+			"sha256": "bf67018f5303466eb468680b637a5d3f3bb17b9d44decf3d82d40b35babcd3e0",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/z/zlib/zlib1g_1.2.11.dfsg-2ubuntu1.5_amd64.deb",
+			"version": "1:1.2.11.dfsg-2ubuntu1.5"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libgssapi-krb5-2_1.17-6ubuntu4.4_amd64",
+			"name": "libgssapi-krb5-2",
+			"sha256": "873956e64e6e8c3dcbe2f62beaf919199a63e026483d1823410f9f79c954b1e2",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/k/krb5/libgssapi-krb5-2_1.17-6ubuntu4.4_amd64.deb",
+			"version": "1.17-6ubuntu4.4"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libkrb5support0_1.17-6ubuntu4.4_amd64",
+			"name": "libkrb5support0",
+			"sha256": "4997d0cbd7b5bcd940a981f5ab231de89febe3ee0ee53c113a0b4bf556cb97e1",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/k/krb5/libkrb5support0_1.17-6ubuntu4.4_amd64.deb",
+			"version": "1.17-6ubuntu4.4"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libkrb5-3_1.17-6ubuntu4.4_amd64",
+			"name": "libkrb5-3",
+			"sha256": "4457de873b2ad6f81311f6464568321751a4a8382526155f8560ec04ccfb9e94",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/k/krb5/libkrb5-3_1.17-6ubuntu4.4_amd64.deb",
+			"version": "1.17-6ubuntu4.4"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libkeyutils1_1.6-6ubuntu1.1_amd64",
+			"name": "libkeyutils1",
+			"sha256": "5a098b2585e549b997a979c38e5bfcc07a5df3efef4753e41ad4dab1122d576c",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/k/keyutils/libkeyutils1_1.6-6ubuntu1.1_amd64.deb",
+			"version": "1.6-6ubuntu1.1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libk5crypto3_1.17-6ubuntu4.4_amd64",
+			"name": "libk5crypto3",
+			"sha256": "046e292eb3beb82cc83365a4580a2c0448b484e8ce47f6057771cf44ccc9be45",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/k/krb5/libk5crypto3_1.17-6ubuntu4.4_amd64.deb",
+			"version": "1.17-6ubuntu4.4"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libcom-err2_1.45.5-2ubuntu1.1_amd64",
+			"name": "libcom-err2",
+			"sha256": "25ad33e306bf4ed08fbd39bf32db643f189c6ed1ec2acb19553d6a2bf69e590d",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/e/e2fsprogs/libcom-err2_1.45.5-2ubuntu1.1_amd64.deb",
+			"version": "1.45.5-2ubuntu1.1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libfido2-1_1.3.1-1ubuntu2_amd64",
+			"name": "libfido2-1",
+			"sha256": "3af0d3b8ef2cff01d9a2f04bca11cf16fd91a6f5d5bd2fcf915c7ff24ffacc04",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/libf/libfido2/libfido2-1_1.3.1-1ubuntu2_amd64.deb",
+			"version": "1.3.1-1ubuntu2"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libcbor0.6_0.6.0-0ubuntu1_amd64",
+			"name": "libcbor0.6",
+			"sha256": "bcf2b0dd3b62cc29d28b1a4150f6023c8b57c5dbf3cb4cdb8ee51bcdaf072739",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/libc/libcbor/libcbor0.6_0.6.0-0ubuntu1_amd64.deb",
+			"version": "0.6.0-0ubuntu1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libedit2_3.1-20191231-1_amd64",
+			"name": "libedit2",
+			"sha256": "51a1190157e2dfe2c26bbdc114d1fc659456def2e78e6e9582809cf92a0a49a4",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/libe/libedit/libedit2_3.1-20191231-1_amd64.deb",
+			"version": "3.1-20191231-1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libbsd0_0.10.0-1_amd64",
+			"name": "libbsd0",
+			"sha256": "4f668025fe923a372eb7fc368d6769fcfff6809233d48fd20fc072917cd82e60",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/libb/libbsd/libbsd0_0.10.0-1_amd64.deb",
+			"version": "0.10.0-1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "passwd_1-4.8.1-1ubuntu5.20.04.5_amd64",
+			"name": "passwd",
+			"sha256": "839d12b834d2ec87945020482493b435ac0297eba9dcbd9ce049f1c542790de9",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/s/shadow/passwd_4.8.1-1ubuntu5.20.04.5_amd64.deb",
+			"version": "1:4.8.1-1ubuntu5.20.04.5"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libpam-modules_1.3.1-5ubuntu4.7_amd64",
+			"name": "libpam-modules",
+			"sha256": "aef66cca70cd3b384cc12d385076fc793206be25ffaf7ff52334e14f95d03e0e",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/p/pam/libpam-modules_1.3.1-5ubuntu4.7_amd64.deb",
+			"version": "1.3.1-5ubuntu4.7"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libpam-modules-bin_1.3.1-5ubuntu4.7_amd64",
+			"name": "libpam-modules-bin",
+			"sha256": "644e9b03c46d7b99d6bcfe6105d57eeeb00086273081633f5e89951df4600df3",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/p/pam/libpam-modules-bin_1.3.1-5ubuntu4.7_amd64.deb",
+			"version": "1.3.1-5ubuntu4.7"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libpam0g_1.3.1-5ubuntu4.7_amd64",
+			"name": "libpam0g",
+			"sha256": "afc769e31f70c5ccfd9f184019b382c0e4455b0b6494704ec010b811baeea511",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/p/pam/libpam0g_1.3.1-5ubuntu4.7_amd64.deb",
+			"version": "1.3.1-5ubuntu4.7"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libaudit1_1-2.8.5-2ubuntu6_amd64",
+			"name": "libaudit1",
+			"sha256": "fb539f4d848d00e9472444285831e0204b9e92e7ee65dbb72b56e144a6dbedf8",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/a/audit/libaudit1_2.8.5-2ubuntu6_amd64.deb",
+			"version": "1:2.8.5-2ubuntu6"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libcap-ng0_0.7.9-2.1build1_amd64",
+			"name": "libcap-ng0",
+			"sha256": "e8606a60a92aa8054d1620781889a8b709c3db8714e3b03b3987f81c7e168d06",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/libc/libcap-ng/libcap-ng0_0.7.9-2.1build1_amd64.deb",
+			"version": "0.7.9-2.1build1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libaudit-common_1-2.8.5-2ubuntu6_amd64",
+			"name": "libaudit-common",
+			"sha256": "9fa4a291df5682f5fee12aacdddd9ed09445c352c80d8a1af36056866e4b4906",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/a/audit/libaudit-common_2.8.5-2ubuntu6_all.deb",
+			"version": "1:2.8.5-2ubuntu6"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libdb5.3_5.3.28-p-dfsg1-0.6ubuntu2_amd64",
+			"name": "libdb5.3",
+			"sha256": "330775026b5e31340387fb58e12e40e241ca34cbbb6c0c28331bd83cb47c3656",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/d/db5.3/libdb5.3_5.3.28+dfsg1-0.6ubuntu2_amd64.deb",
+			"version": "5.3.28+dfsg1-0.6ubuntu2"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libsemanage1_3.0-1build2_amd64",
+			"name": "libsemanage1",
+			"sha256": "0d0acf32d855061b30ee8d2a84421e08adbaa781ce8884730ec3c3e3b49bd1f9",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/libs/libsemanage/libsemanage1_3.0-1build2_amd64.deb",
+			"version": "3.0-1build2"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libsepol1_3.0-1ubuntu0.1_amd64",
+			"name": "libsepol1",
+			"sha256": "83811dd753b41ed1bb7cf31fdebcb51dd6e1ad452c4f5ce6a39791ec64152108",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/libs/libsepol/libsepol1_3.0-1ubuntu0.1_amd64.deb",
+			"version": "3.0-1ubuntu0.1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libbz2-1.0_1.0.8-2_amd64",
+			"name": "libbz2-1.0",
+			"sha256": "f3632ec38402ca0f9c61a6854469f1a0eba9389d3f73827b466033c3d5bbec69",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/b/bzip2/libbz2-1.0_1.0.8-2_amd64.deb",
+			"version": "1.0.8-2"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libsemanage-common_3.0-1build2_amd64",
+			"name": "libsemanage-common",
+			"sha256": "4141f803c811277d2ea56568a676a79f06017b8c5eb57891741808a27c55fffb",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/libs/libsemanage/libsemanage-common_3.0-1build2_all.deb",
+			"version": "3.0-1build2"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [
+				{
+					"key": "tar_1.30-p-dfsg-7ubuntu0.20.04.4_amd64",
+					"name": "tar",
+					"version": "1.30+dfsg-7ubuntu0.20.04.4"
+				},
+				{
+					"key": "libselinux1_3.0-1build2_amd64",
+					"name": "libselinux1",
+					"version": "3.0-1build2"
+				},
+				{
+					"key": "libpcre2-8-0_10.34-7ubuntu0.1_amd64",
+					"name": "libpcre2-8-0",
+					"version": "10.34-7ubuntu0.1"
+				},
+				{
+					"key": "libc6_2.31-0ubuntu9.14_amd64",
+					"name": "libc6",
+					"version": "2.31-0ubuntu9.14"
+				},
+				{
+					"key": "libcrypt1_1-4.4.10-10ubuntu4_amd64",
+					"name": "libcrypt1",
+					"version": "1:4.4.10-10ubuntu4"
+				},
+				{
+					"key": "libgcc-s1_10.5.0-1ubuntu1_20.04_amd64",
+					"name": "libgcc-s1",
+					"version": "10.5.0-1ubuntu1~20.04"
+				},
+				{
+					"key": "gcc-10-base_10.5.0-1ubuntu1_20.04_amd64",
+					"name": "gcc-10-base",
+					"version": "10.5.0-1ubuntu1~20.04"
+				},
+				{
+					"key": "libacl1_2.2.53-6_amd64",
+					"name": "libacl1",
+					"version": "2.2.53-6"
+				},
+				{
+					"key": "zlib1g_1-1.2.11.dfsg-2ubuntu1.5_amd64",
+					"name": "zlib1g",
+					"version": "1:1.2.11.dfsg-2ubuntu1.5"
+				},
+				{
+					"key": "libzstd1_1.4.4-p-dfsg-3ubuntu0.1_amd64",
+					"name": "libzstd1",
+					"version": "1.4.4+dfsg-3ubuntu0.1"
+				},
+				{
+					"key": "liblzma5_5.2.4-1ubuntu1.1_amd64",
+					"name": "liblzma5",
+					"version": "5.2.4-1ubuntu1.1"
+				},
+				{
+					"key": "libbz2-1.0_1.0.8-2_amd64",
+					"name": "libbz2-1.0",
+					"version": "1.0.8-2"
+				}
+			],
+			"key": "dpkg_1.19.7ubuntu3.2_amd64",
+			"name": "dpkg",
+			"sha256": "6fdb88a04deb4cc57a164a43de7efe2ab36fd31f6b1df9a3aca4b39fc0a4d87f",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/d/dpkg/dpkg_1.19.7ubuntu3.2_amd64.deb",
+			"version": "1.19.7ubuntu3.2"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "tar_1.30-p-dfsg-7ubuntu0.20.04.4_amd64",
+			"name": "tar",
+			"sha256": "7387a202f0c71a5638c9514f854f2efd9809e24fa5212d1c7227b02bd06be5ec",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/t/tar/tar_1.30+dfsg-7ubuntu0.20.04.4_amd64.deb",
+			"version": "1.30+dfsg-7ubuntu0.20.04.4"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libzstd1_1.4.4-p-dfsg-3ubuntu0.1_amd64",
+			"name": "libzstd1",
+			"sha256": "7a4422dadb90510dc90765c308d65e61a3e244ceb3886394335e48cff7559e69",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/libz/libzstd/libzstd1_1.4.4+dfsg-3ubuntu0.1_amd64.deb",
+			"version": "1.4.4+dfsg-3ubuntu0.1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "adduser_3.118ubuntu2_amd64",
+			"name": "adduser",
+			"sha256": "5f7ea9d1d52a2a9c349468f89d160230e21c8542faed1b1a97c23bce873e17b4",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/a/adduser/adduser_3.118ubuntu2_all.deb",
+			"version": "3.118ubuntu2"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [
+				{
+					"key": "libpopt0_1.16-14_amd64",
+					"name": "libpopt0",
+					"version": "1.16-14"
+				},
+				{
+					"key": "libc6_2.31-0ubuntu9.14_amd64",
+					"name": "libc6",
+					"version": "2.31-0ubuntu9.14"
+				},
+				{
+					"key": "libcrypt1_1-4.4.10-10ubuntu4_amd64",
+					"name": "libcrypt1",
+					"version": "1:4.4.10-10ubuntu4"
+				},
+				{
+					"key": "libgcc-s1_10.5.0-1ubuntu1_20.04_amd64",
+					"name": "libgcc-s1",
+					"version": "10.5.0-1ubuntu1~20.04"
+				},
+				{
+					"key": "gcc-10-base_10.5.0-1ubuntu1_20.04_amd64",
+					"name": "gcc-10-base",
+					"version": "10.5.0-1ubuntu1~20.04"
+				},
+				{
+					"key": "libacl1_2.2.53-6_amd64",
+					"name": "libacl1",
+					"version": "2.2.53-6"
+				},
+				{
+					"key": "lsb-base_11.1.0ubuntu2_amd64",
+					"name": "lsb-base",
+					"version": "11.1.0ubuntu2"
+				},
+				{
+					"key": "init-system-helpers_1.57_amd64",
+					"name": "init-system-helpers",
+					"version": "1.57"
+				},
+				{
+					"key": "perl-base_5.30.0-9ubuntu0.5_amd64",
+					"name": "perl-base",
+					"version": "5.30.0-9ubuntu0.5"
+				},
+				{
+					"key": "dpkg_1.19.7ubuntu3.2_amd64",
+					"name": "dpkg",
+					"version": "1.19.7ubuntu3.2"
+				},
+				{
+					"key": "tar_1.30-p-dfsg-7ubuntu0.20.04.4_amd64",
+					"name": "tar",
+					"version": "1.30+dfsg-7ubuntu0.20.04.4"
+				},
+				{
+					"key": "libselinux1_3.0-1build2_amd64",
+					"name": "libselinux1",
+					"version": "3.0-1build2"
+				},
+				{
+					"key": "libpcre2-8-0_10.34-7ubuntu0.1_amd64",
+					"name": "libpcre2-8-0",
+					"version": "10.34-7ubuntu0.1"
+				},
+				{
+					"key": "zlib1g_1-1.2.11.dfsg-2ubuntu1.5_amd64",
+					"name": "zlib1g",
+					"version": "1:1.2.11.dfsg-2ubuntu1.5"
+				},
+				{
+					"key": "libzstd1_1.4.4-p-dfsg-3ubuntu0.1_amd64",
+					"name": "libzstd1",
+					"version": "1.4.4+dfsg-3ubuntu0.1"
+				},
+				{
+					"key": "liblzma5_5.2.4-1ubuntu1.1_amd64",
+					"name": "liblzma5",
+					"version": "5.2.4-1ubuntu1.1"
+				},
+				{
+					"key": "libbz2-1.0_1.0.8-2_amd64",
+					"name": "libbz2-1.0",
+					"version": "1.0.8-2"
+				}
+			],
+			"key": "rsync_3.1.3-8ubuntu0.7_amd64",
+			"name": "rsync",
+			"sha256": "272c2377df80d037eeaa7af2fcbde7d31c25d807b7e889fc0a90fe8bb83f6263",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/r/rsync/rsync_3.1.3-8ubuntu0.7_amd64.deb",
+			"version": "3.1.3-8ubuntu0.7"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libpopt0_1.16-14_amd64",
+			"name": "libpopt0",
+			"sha256": "8548aa6b6a1f2a7b865a13f8643eb2a1caca9113f82c89f24e75c84d7099eed1",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/p/popt/libpopt0_1.16-14_amd64.deb",
+			"version": "1.16-14"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "lsb-base_11.1.0ubuntu2_amd64",
+			"name": "lsb-base",
+			"sha256": "eb40f6e96189cbde27a9cc4681f7ba7b4d51552d1ad74b876aea6a7ccb83f628",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/l/lsb/lsb-base_11.1.0ubuntu2_all.deb",
+			"version": "11.1.0ubuntu2"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "init-system-helpers_1.57_amd64",
+			"name": "init-system-helpers",
+			"sha256": "5628715888e797fcddf2c5b3c3923b0a76dad78916025a52e19375703dd9586c",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/i/init-system-helpers/init-system-helpers_1.57_all.deb",
+			"version": "1.57"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "perl-base_5.30.0-9ubuntu0.5_amd64",
+			"name": "perl-base",
+			"sha256": "9997a2d7cf8a0ce2270730414c269e04a3ad6457280c21741c9e8f2489b18ba7",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/p/perl/perl-base_5.30.0-9ubuntu0.5_amd64.deb",
+			"version": "5.30.0-9ubuntu0.5"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [
+				{
+					"key": "zlib1g_1-1.2.11.dfsg-2ubuntu1.5_amd64",
+					"name": "zlib1g",
+					"version": "1:1.2.11.dfsg-2ubuntu1.5"
+				},
+				{
+					"key": "libc6_2.31-0ubuntu9.14_amd64",
+					"name": "libc6",
+					"version": "2.31-0ubuntu9.14"
+				},
+				{
+					"key": "libcrypt1_1-4.4.10-10ubuntu4_amd64",
+					"name": "libcrypt1",
+					"version": "1:4.4.10-10ubuntu4"
+				},
+				{
+					"key": "libgcc-s1_10.5.0-1ubuntu1_20.04_amd64",
+					"name": "libgcc-s1",
+					"version": "10.5.0-1ubuntu1~20.04"
+				},
+				{
+					"key": "gcc-10-base_10.5.0-1ubuntu1_20.04_amd64",
+					"name": "gcc-10-base",
+					"version": "10.5.0-1ubuntu1~20.04"
+				},
+				{
+					"key": "libstdc-p--p-6_10.5.0-1ubuntu1_20.04_amd64",
+					"name": "libstdc++6",
+					"version": "10.5.0-1ubuntu1~20.04"
+				},
+				{
+					"key": "liblzma5_5.2.4-1ubuntu1.1_amd64",
+					"name": "liblzma5",
+					"version": "5.2.4-1ubuntu1.1"
+				},
+				{
+					"key": "liblz4-1_1.9.2-2ubuntu0.20.04.1_amd64",
+					"name": "liblz4-1",
+					"version": "1.9.2-2ubuntu0.20.04.1"
+				}
+			],
+			"key": "zstd_1.4.4-p-dfsg-3_amd64",
+			"name": "zstd",
+			"sha256": "fa2c41d144ab414c70fbbf176dcd7adbe77fc1cb0a060fc7eec8a09ec94cd1c7",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/universe/libz/libzstd/zstd_1.4.4+dfsg-3_amd64.deb",
+			"version": "1.4.4+dfsg-3"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libstdc-p--p-6_10.5.0-1ubuntu1_20.04_amd64",
+			"name": "libstdc++6",
+			"sha256": "7f9222342d3551d063bf651319ec397c39278eeeb9ab5950ae0e8c28ef0af431",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/g/gcc-10/libstdc++6_10.5.0-1ubuntu1~20.04_amd64.deb",
+			"version": "10.5.0-1ubuntu1~20.04"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "liblz4-1_1.9.2-2ubuntu0.20.04.1_amd64",
+			"name": "liblz4-1",
+			"sha256": "a9b706941eb8e2a0012869dbe63c7337fc9629aaf919563f63e92baa2a3a7c18",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/l/lz4/liblz4-1_1.9.2-2ubuntu0.20.04.1_amd64.deb",
+			"version": "1.9.2-2ubuntu0.20.04.1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [
+				{
+					"key": "libc6_2.31-0ubuntu9.14_amd64",
+					"name": "libc6",
+					"version": "2.31-0ubuntu9.14"
+				},
+				{
+					"key": "libcrypt1_1-4.4.10-10ubuntu4_amd64",
+					"name": "libcrypt1",
+					"version": "1:4.4.10-10ubuntu4"
+				},
+				{
+					"key": "libgcc-s1_10.5.0-1ubuntu1_20.04_amd64",
+					"name": "libgcc-s1",
+					"version": "10.5.0-1ubuntu1~20.04"
+				},
+				{
+					"key": "gcc-10-base_10.5.0-1ubuntu1_20.04_amd64",
+					"name": "gcc-10-base",
+					"version": "10.5.0-1ubuntu1~20.04"
+				}
+			],
+			"key": "gzip_1.10-0ubuntu4.1_amd64",
+			"name": "gzip",
+			"sha256": "218a588ffe646e69dcde814634cb85bcaad1486da4fa3060937ab12ef04fed9c",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/g/gzip/gzip_1.10-0ubuntu4.1_amd64.deb",
+			"version": "1.10-0ubuntu4.1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [
+				{
+					"key": "libsystemd0_245.4-4ubuntu3.23_amd64",
+					"name": "libsystemd0",
+					"version": "245.4-4ubuntu3.23"
+				},
+				{
+					"key": "liblzma5_5.2.4-1ubuntu1.1_amd64",
+					"name": "liblzma5",
+					"version": "5.2.4-1ubuntu1.1"
+				},
+				{
+					"key": "libc6_2.31-0ubuntu9.14_amd64",
+					"name": "libc6",
+					"version": "2.31-0ubuntu9.14"
+				},
+				{
+					"key": "libcrypt1_1-4.4.10-10ubuntu4_amd64",
+					"name": "libcrypt1",
+					"version": "1:4.4.10-10ubuntu4"
+				},
+				{
+					"key": "libgcc-s1_10.5.0-1ubuntu1_20.04_amd64",
+					"name": "libgcc-s1",
+					"version": "10.5.0-1ubuntu1~20.04"
+				},
+				{
+					"key": "gcc-10-base_10.5.0-1ubuntu1_20.04_amd64",
+					"name": "gcc-10-base",
+					"version": "10.5.0-1ubuntu1~20.04"
+				},
+				{
+					"key": "liblz4-1_1.9.2-2ubuntu0.20.04.1_amd64",
+					"name": "liblz4-1",
+					"version": "1.9.2-2ubuntu0.20.04.1"
+				},
+				{
+					"key": "libgcrypt20_1.8.5-5ubuntu1.1_amd64",
+					"name": "libgcrypt20",
+					"version": "1.8.5-5ubuntu1.1"
+				},
+				{
+					"key": "libgpg-error0_1.37-1_amd64",
+					"name": "libgpg-error0",
+					"version": "1.37-1"
+				},
+				{
+					"key": "libstdc-p--p-6_10.5.0-1ubuntu1_20.04_amd64",
+					"name": "libstdc++6",
+					"version": "10.5.0-1ubuntu1~20.04"
+				},
+				{
+					"key": "libseccomp2_2.5.1-1ubuntu1_20.04.2_amd64",
+					"name": "libseccomp2",
+					"version": "2.5.1-1ubuntu1~20.04.2"
+				},
+				{
+					"key": "libgnutls30_3.6.13-2ubuntu1.10_amd64",
+					"name": "libgnutls30",
+					"version": "3.6.13-2ubuntu1.10"
+				},
+				{
+					"key": "libunistring2_0.9.10-2_amd64",
+					"name": "libunistring2",
+					"version": "0.9.10-2"
+				},
+				{
+					"key": "libtasn1-6_4.16.0-2_amd64",
+					"name": "libtasn1-6",
+					"version": "4.16.0-2"
+				},
+				{
+					"key": "libp11-kit0_0.23.20-1ubuntu0.1_amd64",
+					"name": "libp11-kit0",
+					"version": "0.23.20-1ubuntu0.1"
+				},
+				{
+					"key": "libffi7_3.3-4_amd64",
+					"name": "libffi7",
+					"version": "3.3-4"
+				},
+				{
+					"key": "libnettle7_3.5.1-p-really3.5.1-2ubuntu0.2_amd64",
+					"name": "libnettle7",
+					"version": "3.5.1+really3.5.1-2ubuntu0.2"
+				},
+				{
+					"key": "libidn2-0_2.2.0-2_amd64",
+					"name": "libidn2-0",
+					"version": "2.2.0-2"
+				},
+				{
+					"key": "libhogweed5_3.5.1-p-really3.5.1-2ubuntu0.2_amd64",
+					"name": "libhogweed5",
+					"version": "3.5.1+really3.5.1-2ubuntu0.2"
+				},
+				{
+					"key": "libgmp10_2-6.2.0-p-dfsg-4ubuntu0.1_amd64",
+					"name": "libgmp10",
+					"version": "2:6.2.0+dfsg-4ubuntu0.1"
+				},
+				{
+					"key": "ubuntu-keyring_2020.02.11.4_amd64",
+					"name": "ubuntu-keyring",
+					"version": "2020.02.11.4"
+				},
+				{
+					"key": "libapt-pkg6.0_2.0.10_amd64",
+					"name": "libapt-pkg6.0",
+					"version": "2.0.10"
+				},
+				{
+					"key": "zlib1g_1-1.2.11.dfsg-2ubuntu1.5_amd64",
+					"name": "zlib1g",
+					"version": "1:1.2.11.dfsg-2ubuntu1.5"
+				},
+				{
+					"key": "libzstd1_1.4.4-p-dfsg-3ubuntu0.1_amd64",
+					"name": "libzstd1",
+					"version": "1.4.4+dfsg-3ubuntu0.1"
+				},
+				{
+					"key": "libudev1_245.4-4ubuntu3.23_amd64",
+					"name": "libudev1",
+					"version": "245.4-4ubuntu3.23"
+				},
+				{
+					"key": "libbz2-1.0_1.0.8-2_amd64",
+					"name": "libbz2-1.0",
+					"version": "1.0.8-2"
+				},
+				{
+					"key": "adduser_3.118ubuntu2_amd64",
+					"name": "adduser",
+					"version": "3.118ubuntu2"
+				},
+				{
+					"key": "passwd_1-4.8.1-1ubuntu5.20.04.5_amd64",
+					"name": "passwd",
+					"version": "1:4.8.1-1ubuntu5.20.04.5"
+				},
+				{
+					"key": "libpam-modules_1.3.1-5ubuntu4.7_amd64",
+					"name": "libpam-modules",
+					"version": "1.3.1-5ubuntu4.7"
+				},
+				{
+					"key": "libpam-modules-bin_1.3.1-5ubuntu4.7_amd64",
+					"name": "libpam-modules-bin",
+					"version": "1.3.1-5ubuntu4.7"
+				},
+				{
+					"key": "libselinux1_3.0-1build2_amd64",
+					"name": "libselinux1",
+					"version": "3.0-1build2"
+				},
+				{
+					"key": "libpcre2-8-0_10.34-7ubuntu0.1_amd64",
+					"name": "libpcre2-8-0",
+					"version": "10.34-7ubuntu0.1"
+				},
+				{
+					"key": "libpam0g_1.3.1-5ubuntu4.7_amd64",
+					"name": "libpam0g",
+					"version": "1.3.1-5ubuntu4.7"
+				},
+				{
+					"key": "libaudit1_1-2.8.5-2ubuntu6_amd64",
+					"name": "libaudit1",
+					"version": "1:2.8.5-2ubuntu6"
+				},
+				{
+					"key": "libcap-ng0_0.7.9-2.1build1_amd64",
+					"name": "libcap-ng0",
+					"version": "0.7.9-2.1build1"
+				},
+				{
+					"key": "libaudit-common_1-2.8.5-2ubuntu6_amd64",
+					"name": "libaudit-common",
+					"version": "1:2.8.5-2ubuntu6"
+				},
+				{
+					"key": "libdb5.3_5.3.28-p-dfsg1-0.6ubuntu2_amd64",
+					"name": "libdb5.3",
+					"version": "5.3.28+dfsg1-0.6ubuntu2"
+				},
+				{
+					"key": "libsemanage1_3.0-1build2_amd64",
+					"name": "libsemanage1",
+					"version": "3.0-1build2"
+				},
+				{
+					"key": "libsepol1_3.0-1ubuntu0.1_amd64",
+					"name": "libsepol1",
+					"version": "3.0-1ubuntu0.1"
+				},
+				{
+					"key": "libsemanage-common_3.0-1build2_amd64",
+					"name": "libsemanage-common",
+					"version": "3.0-1build2"
+				}
+			],
+			"key": "apt_2.0.10_amd64",
+			"name": "apt",
+			"sha256": "642a65e0cd79c4f3202976ae1e70c0339927947e6b5c77abac7abb35d0ca9404",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/a/apt/apt_2.0.10_amd64.deb",
+			"version": "2.0.10"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libsystemd0_245.4-4ubuntu3.23_amd64",
+			"name": "libsystemd0",
+			"sha256": "147da635fb19d7e2a25e3f9f26ee4de719704dd14decb84ed43a97c2454a015b",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/s/systemd/libsystemd0_245.4-4ubuntu3.23_amd64.deb",
+			"version": "245.4-4ubuntu3.23"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libgcrypt20_1.8.5-5ubuntu1.1_amd64",
+			"name": "libgcrypt20",
+			"sha256": "f040f801e2cced9bd82e484c23678cb9b464d04974a9cf4cf25fc9ad09d9e90d",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/libg/libgcrypt20/libgcrypt20_1.8.5-5ubuntu1.1_amd64.deb",
+			"version": "1.8.5-5ubuntu1.1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libgpg-error0_1.37-1_amd64",
+			"name": "libgpg-error0",
+			"sha256": "4744163850851f60080a8b0fdf3dd3258d93114bd83f8024414737a2826da7fe",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/libg/libgpg-error/libgpg-error0_1.37-1_amd64.deb",
+			"version": "1.37-1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libseccomp2_2.5.1-1ubuntu1_20.04.2_amd64",
+			"name": "libseccomp2",
+			"sha256": "e2fe929b69bec68e5e00eaecc2e661da0b31d8a5e9df298df43e2ba40983bdc1",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/libs/libseccomp/libseccomp2_2.5.1-1ubuntu1~20.04.2_amd64.deb",
+			"version": "2.5.1-1ubuntu1~20.04.2"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libgnutls30_3.6.13-2ubuntu1.10_amd64",
+			"name": "libgnutls30",
+			"sha256": "0e11ab42085fffeecdb9700288e63e59a883d1c081a37c878e3b807d5f8d6894",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/g/gnutls28/libgnutls30_3.6.13-2ubuntu1.10_amd64.deb",
+			"version": "3.6.13-2ubuntu1.10"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libunistring2_0.9.10-2_amd64",
+			"name": "libunistring2",
+			"sha256": "4ccfbc1e3a1cbc42616bd4fd407e01eb1434996c8500ac2fbccb7a2e1bcb166a",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/libu/libunistring/libunistring2_0.9.10-2_amd64.deb",
+			"version": "0.9.10-2"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libtasn1-6_4.16.0-2_amd64",
+			"name": "libtasn1-6",
+			"sha256": "f4d9cbcc2c915a58557ecf3ea6ffb42321c8a2f444945af57e64d9ce18744329",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/libt/libtasn1-6/libtasn1-6_4.16.0-2_amd64.deb",
+			"version": "4.16.0-2"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libp11-kit0_0.23.20-1ubuntu0.1_amd64",
+			"name": "libp11-kit0",
+			"sha256": "e6c415cef9c7e829e43cac6cfea7371222005650cf4751eee22fd19710d4fa8e",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/p/p11-kit/libp11-kit0_0.23.20-1ubuntu0.1_amd64.deb",
+			"version": "0.23.20-1ubuntu0.1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libffi7_3.3-4_amd64",
+			"name": "libffi7",
+			"sha256": "4584aa8fef1bf5086168ce2f7078cd2ebd78fdc4cc0d86d958d795d4e0b0f50d",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/libf/libffi/libffi7_3.3-4_amd64.deb",
+			"version": "3.3-4"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libnettle7_3.5.1-p-really3.5.1-2ubuntu0.2_amd64",
+			"name": "libnettle7",
+			"sha256": "3496aed83407fde71e0dc5988b28e8fd7f07a2f27fcf3e0f214c7cd86667eecd",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/n/nettle/libnettle7_3.5.1+really3.5.1-2ubuntu0.2_amd64.deb",
+			"version": "3.5.1+really3.5.1-2ubuntu0.2"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libidn2-0_2.2.0-2_amd64",
+			"name": "libidn2-0",
+			"sha256": "698abe11d444c7e87c656c2083373d1e0fae04b3a64be0371adb2bb180092537",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/libi/libidn2/libidn2-0_2.2.0-2_amd64.deb",
+			"version": "2.2.0-2"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libhogweed5_3.5.1-p-really3.5.1-2ubuntu0.2_amd64",
+			"name": "libhogweed5",
+			"sha256": "12d76fa6c9149af3da228e3062faaefd7d12e0c6fd3424579627672437a84f14",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/n/nettle/libhogweed5_3.5.1+really3.5.1-2ubuntu0.2_amd64.deb",
+			"version": "3.5.1+really3.5.1-2ubuntu0.2"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "ubuntu-keyring_2020.02.11.4_amd64",
+			"name": "ubuntu-keyring",
+			"sha256": "2684fae16e90a9ff3cb4dc08a8af5bd9973d38763b60e5f458dea0b403a39788",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/u/ubuntu-keyring/ubuntu-keyring_2020.02.11.4_all.deb",
+			"version": "2020.02.11.4"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libapt-pkg6.0_2.0.10_amd64",
+			"name": "libapt-pkg6.0",
+			"sha256": "31c9edaf662200d5ae5c3ca891786a5717af247cd31c528f1b6a1644574c3490",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/a/apt/libapt-pkg6.0_2.0.10_amd64.deb",
+			"version": "2.0.10"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [
+				{
+					"key": "debianutils_4.9.1_amd64",
+					"name": "debianutils",
+					"version": "4.9.1"
+				},
+				{
+					"key": "libc6_2.31-0ubuntu9.14_amd64",
+					"name": "libc6",
+					"version": "2.31-0ubuntu9.14"
+				},
+				{
+					"key": "libcrypt1_1-4.4.10-10ubuntu4_amd64",
+					"name": "libcrypt1",
+					"version": "1:4.4.10-10ubuntu4"
+				},
+				{
+					"key": "libgcc-s1_10.5.0-1ubuntu1_20.04_amd64",
+					"name": "libgcc-s1",
+					"version": "10.5.0-1ubuntu1~20.04"
+				},
+				{
+					"key": "gcc-10-base_10.5.0-1ubuntu1_20.04_amd64",
+					"name": "gcc-10-base",
+					"version": "10.5.0-1ubuntu1~20.04"
+				},
+				{
+					"key": "base-files_11ubuntu5.8_amd64",
+					"name": "base-files",
+					"version": "11ubuntu5.8"
+				},
+				{
+					"key": "libtinfo6_6.2-0ubuntu2.1_amd64",
+					"name": "libtinfo6",
+					"version": "6.2-0ubuntu2.1"
+				}
+			],
+			"key": "bash_5.0-6ubuntu1.2_amd64",
+			"name": "bash",
+			"sha256": "58e03b3be46c54eeb22ede348baf2b8251a6f3e0ce4f0bf0191c516f90f1f283",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/b/bash/bash_5.0-6ubuntu1.2_amd64.deb",
+			"version": "5.0-6ubuntu1.2"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "debianutils_4.9.1_amd64",
+			"name": "debianutils",
+			"sha256": "535571a8898bb69476b1d0ed6893b4700c312bff14fc7687b7f1fdfe18f55a1f",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/d/debianutils/debianutils_4.9.1_amd64.deb",
+			"version": "4.9.1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "base-files_11ubuntu5.8_amd64",
+			"name": "base-files",
+			"sha256": "f92bb87ad4347c4b9c33c3e4f013a483ac637d65e56d330f429b0be7c1739a74",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/b/base-files/base-files_11ubuntu5.8_amd64.deb",
+			"version": "11ubuntu5.8"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [
+				{
+					"key": "libperl5.30_5.30.0-9ubuntu0.5_amd64",
+					"name": "libperl5.30",
+					"version": "5.30.0-9ubuntu0.5"
+				},
+				{
+					"key": "perl-modules-5.30_5.30.0-9ubuntu0.5_amd64",
+					"name": "perl-modules-5.30",
+					"version": "5.30.0-9ubuntu0.5"
+				},
+				{
+					"key": "perl-base_5.30.0-9ubuntu0.5_amd64",
+					"name": "perl-base",
+					"version": "5.30.0-9ubuntu0.5"
+				},
+				{
+					"key": "dpkg_1.19.7ubuntu3.2_amd64",
+					"name": "dpkg",
+					"version": "1.19.7ubuntu3.2"
+				},
+				{
+					"key": "tar_1.30-p-dfsg-7ubuntu0.20.04.4_amd64",
+					"name": "tar",
+					"version": "1.30+dfsg-7ubuntu0.20.04.4"
+				},
+				{
+					"key": "libselinux1_3.0-1build2_amd64",
+					"name": "libselinux1",
+					"version": "3.0-1build2"
+				},
+				{
+					"key": "libpcre2-8-0_10.34-7ubuntu0.1_amd64",
+					"name": "libpcre2-8-0",
+					"version": "10.34-7ubuntu0.1"
+				},
+				{
+					"key": "libc6_2.31-0ubuntu9.14_amd64",
+					"name": "libc6",
+					"version": "2.31-0ubuntu9.14"
+				},
+				{
+					"key": "libcrypt1_1-4.4.10-10ubuntu4_amd64",
+					"name": "libcrypt1",
+					"version": "1:4.4.10-10ubuntu4"
+				},
+				{
+					"key": "libgcc-s1_10.5.0-1ubuntu1_20.04_amd64",
+					"name": "libgcc-s1",
+					"version": "10.5.0-1ubuntu1~20.04"
+				},
+				{
+					"key": "gcc-10-base_10.5.0-1ubuntu1_20.04_amd64",
+					"name": "gcc-10-base",
+					"version": "10.5.0-1ubuntu1~20.04"
+				},
+				{
+					"key": "libacl1_2.2.53-6_amd64",
+					"name": "libacl1",
+					"version": "2.2.53-6"
+				},
+				{
+					"key": "zlib1g_1-1.2.11.dfsg-2ubuntu1.5_amd64",
+					"name": "zlib1g",
+					"version": "1:1.2.11.dfsg-2ubuntu1.5"
+				},
+				{
+					"key": "libzstd1_1.4.4-p-dfsg-3ubuntu0.1_amd64",
+					"name": "libzstd1",
+					"version": "1.4.4+dfsg-3ubuntu0.1"
+				},
+				{
+					"key": "liblzma5_5.2.4-1ubuntu1.1_amd64",
+					"name": "liblzma5",
+					"version": "5.2.4-1ubuntu1.1"
+				},
+				{
+					"key": "libbz2-1.0_1.0.8-2_amd64",
+					"name": "libbz2-1.0",
+					"version": "1.0.8-2"
+				},
+				{
+					"key": "libgdbm6_1.18.1-5_amd64",
+					"name": "libgdbm6",
+					"version": "1.18.1-5"
+				},
+				{
+					"key": "libgdbm-compat4_1.18.1-5_amd64",
+					"name": "libgdbm-compat4",
+					"version": "1.18.1-5"
+				},
+				{
+					"key": "libdb5.3_5.3.28-p-dfsg1-0.6ubuntu2_amd64",
+					"name": "libdb5.3",
+					"version": "5.3.28+dfsg1-0.6ubuntu2"
+				}
+			],
+			"key": "perl_5.30.0-9ubuntu0.5_amd64",
+			"name": "perl",
+			"sha256": "e98e1122172fe4d32bf45503c2dedf5d4771a2995a7070f19bb8d31e998c0fb5",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/p/perl/perl_5.30.0-9ubuntu0.5_amd64.deb",
+			"version": "5.30.0-9ubuntu0.5"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libperl5.30_5.30.0-9ubuntu0.5_amd64",
+			"name": "libperl5.30",
+			"sha256": "7546cd8f74d9300823c4470a55abf2e6e97be1961e2033cd927e775b774eba3d",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/p/perl/libperl5.30_5.30.0-9ubuntu0.5_amd64.deb",
+			"version": "5.30.0-9ubuntu0.5"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "perl-modules-5.30_5.30.0-9ubuntu0.5_amd64",
+			"name": "perl-modules-5.30",
+			"sha256": "f2093f468af836518bfe80269a94526c75c9c67582e45adf1ec4ed305fd9ee6e",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/p/perl/perl-modules-5.30_5.30.0-9ubuntu0.5_all.deb",
+			"version": "5.30.0-9ubuntu0.5"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libgdbm6_1.18.1-5_amd64",
+			"name": "libgdbm6",
+			"sha256": "8ac1108585490fc2321df8d27cc565054003d86fab0ab8b8e2a4a2d050a53098",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/g/gdbm/libgdbm6_1.18.1-5_amd64.deb",
+			"version": "1.18.1-5"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libgdbm-compat4_1.18.1-5_amd64",
+			"name": "libgdbm-compat4",
+			"sha256": "4f93394bda7be86b94fb32ac1bdf1a0b7124b8150962b55512371c3a816a382d",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/g/gdbm/libgdbm-compat4_1.18.1-5_amd64.deb",
+			"version": "1.18.1-5"
+		}
+	],
+	"version": 1
+}

--- a/bazel/focal.yaml
+++ b/bazel/focal.yaml
@@ -1,0 +1,37 @@
+# Packages used by our ubuntu base, adapted from:
+#  https://github.com/GoogleContainerTools/rules_distroless/blob/2ce7b477def75579c49bab25266f953f30275c88/examples/ubuntu_snapshot/BUILD.bazel
+#
+#  Anytime this file is changed, the lockfile needs to be regenerated. See WORKSPACE
+#  for instructions.
+version: 1
+
+# Various channels used to pull packages from
+sources:
+  - channel: focal main
+    url: https://snapshot.ubuntu.com/ubuntu/20240301T030400Z
+  - channel: focal universe
+    url: https://snapshot.ubuntu.com/ubuntu/20240301T030400Z
+  - channel: focal-security main
+    url: https://snapshot.ubuntu.com/ubuntu/20240301T030400Z
+  - channel: focal-updates main
+    url: https://snapshot.ubuntu.com/ubuntu/20240301T030400Z
+
+archs:
+  - "amd64"
+
+packages:
+  - "ca-certificates"
+  - "coreutils" # for chmod
+  - "gawk" # for build-bootstrap-config-image
+  - "dosfstools"
+  - "libssl1.1"
+  - "libunwind8"
+  - "mtools"
+  - "openssh-client" # used to SSH into image
+  - "rsync"
+  - "zstd"
+  - "dpkg" # for apt list --installed
+  - "gzip" # for tar-ing up ic regsitry store in systests
+  - "apt"
+  - "bash"
+  - "perl"

--- a/rs/rosetta-api/BUILD.bazel
+++ b/rs/rosetta-api/BUILD.bazel
@@ -1,10 +1,12 @@
+load("@aspect_bazel_lib//lib:expand_template.bzl", "expand_template")
 load("@bazel_skylib//rules:write_file.bzl", "write_file")
-load("@io_bazel_rules_docker//container:container.bzl", "container_image", "container_push")
-load("@io_bazel_rules_docker//contrib:passwd.bzl", "passwd_entry", "passwd_file")
+load("@rules_distroless//distroless:defs.bzl", "passwd")
+load("@rules_oci//oci:defs.bzl", "oci_image", "oci_push")
 load("@rules_pkg//:pkg.bzl", "pkg_tar")
 load("@rules_pkg//pkg:mappings.bzl", "pkg_attributes", "pkg_mkdirs")
 load("@rules_rust//rust:defs.bzl", "rust_binary", "rust_library", "rust_test")
 load("//bazel:defs.bzl", "rust_test_suite_with_extra_srcs")
+load("//rs/tests:system_tests.bzl", "oci_tar")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -192,42 +194,39 @@ write_file(
 )
 
 ## Create a layer with a rosetta user
-passwd_entry(
-    name = "root_user",
-    uid = 0,
-    username = "root",
-)
-
-passwd_entry(
-    name = "rosetta_user",
-    home = "/home/rosetta",
-    info = "rosetta node user",
-    uid = 1002,
-    username = "rosetta",
-)
-
-passwd_file(
+passwd(
     name = "passwd",
     entries = [
-        ":rosetta_user",
-        ":root_user",
+        dict(
+            gecos = ["root"],
+            gid = 0,
+            home = "/root",
+            shell = "/usr/bin/bash",
+            uid = 0,
+            username = "root",
+        ),
+        dict(
+            gecos = ["rosetta node user"],
+            gid = 1002,
+            home = "/home/rosetta",
+            shell = "/usr/bin/bash",
+            uid = 1002,
+            username = "rosetta",
+        ),
     ],
 )
 
 pkg_tar(
-    name = "passwd_tar",
-    srcs = [":passwd"],
-    mode = "0644",
-    package_dir = "etc",
+    name = "rosetta_image_homedir",
+    srcs = [":ic-rosetta-api"],
+    package_dir = "/home/rosetta",
 )
 
+# Create directories expected/needed by rosetta
 pkg_mkdirs(
     name = "data_dir",
-    # Unfortunately, rules_docker does not preserve the file ownership:
-    # https://github.com/bazelbuild/rules_docker/issues/1928
-    #
     # We make the /data directory rwx for everyone so that "rosetta"
-    # user could write to that directory.
+    # user can write to that directory.
     attributes = pkg_attributes(
         mode = "0777",
         user = "rosetta",
@@ -245,49 +244,63 @@ pkg_tar(
 
 ## An intermediate image with the passwd file and empty directories.
 
-container_image(
+oci_image(
     name = "rosetta_image_base",
-    base = "@rust_base//image",
+    base = "@rust_base//:rust_base",
     tags = ["manual"],
     target_compatible_with = [
         "@platforms//os:linux",
     ],
     tars = [
-        ":passwd_tar",
+        ":passwd",
         ":data_tar",
     ],
 )
 
 ## The final image we can publish.
 
-container_image(
+oci_image(
     name = "rosetta_image",
     base = ":rosetta_image_base",
-    directory = "/home/rosetta",
-    entrypoint = [
-        "/home/rosetta/ic-rosetta-api",
-    ],
-    files = [
-        ":ic-rosetta-api",
-    ],
-    ports = ["8080"],
+    entrypoint = ["/home/rosetta/ic-rosetta-api"],
     tags = ["manual"],
     target_compatible_with = [
         "@platforms//os:linux",
     ],
+    tars = [":rosetta_image_homedir"],
     user = "rosetta",
     workdir = "/home/rosetta",
+)
+
+oci_tar(
+    name = "rosetta_image.tar",
+    image = ":rosetta_image",
+    repo_tags = ["rosetta:image"],
 )
 
 ## Run this target with --embed_label flag[1] to specify the image tag.
 ## [1]: https://bazel.build/reference/command-line-reference#flag--embed_label
 
-container_push(
+# Use the value of --embed_label under --stamp, otherwise use a deterministic constant
+# value to ensure cache hits for actions that depend on this.
+expand_template(
+    name = "stamped",
+    out = "_stamped.tags.txt",
+    stamp_substitutions = {"0.0.0": "{{BUILD_EMBED_LABEL}}"},
+    template = [
+        "0.0.0",
+    ],
+)
+
+# Push image with:
+#  $ bazel run //<path>:push_rosetta_image
+#
+# Usage:
+#   https://github.com/bazel-contrib/rules_oci/blob/main/docs/push.md#usage
+oci_push(
     name = "push_rosetta_image",
-    format = "Docker",
     image = ":rosetta_image",
-    registry = "index.docker.io",
-    repository = "dfinity/rosetta-api",
-    tag = "{BUILD_EMBED_LABEL}",
+    remote_tags = ":stamped",
+    repository = "docker.io/dfinity/rosetta-api",
     tags = ["manual"],
 )

--- a/rs/rosetta-api/README.adoc
+++ b/rs/rosetta-api/README.adoc
@@ -67,20 +67,21 @@ Query Bazel for the produced image
 
 ```
 $ bazel cquery //rs/rosetta-api:rosetta_image.tar --output=files
+<path to image>
 ```
 
 The load the image in docker
 
 ```
-$ docker load -i <bazel_path_to>/rosetta_image.tar
+$ docker load -i <path to image>
 ...
-Loaded image(s): localhost/bazel/rs/rosetta-api:rosetta_image
+Loaded image(s): <image>
 ```
 
 Finally run the image
 
 ```
-$ docker run localhost/bazel/rs/rosetta-api:rosetta_image
+$ docker run <image>
 ```
 
 Remember to mount `/home/rosetta/log` and `/data` to persist logs and data after shutting down the docker container.

--- a/rs/rosetta-api/icrc1/rosetta/BUILD.bazel
+++ b/rs/rosetta-api/icrc1/rosetta/BUILD.bazel
@@ -1,6 +1,7 @@
+load("@aspect_bazel_lib//lib:expand_template.bzl", "expand_template")
 load("@bazel_skylib//rules:write_file.bzl", "write_file")
-load("@io_bazel_rules_docker//container:container.bzl", "container_image", "container_push")
-load("@io_bazel_rules_docker//contrib:passwd.bzl", "passwd_entry", "passwd_file")
+load("@rules_distroless//distroless:defs.bzl", "passwd")
+load("@rules_oci//oci:defs.bzl", "oci_image", "oci_push")
 load("@rules_pkg//:pkg.bzl", "pkg_tar")
 load("@rules_pkg//pkg:mappings.bzl", "pkg_attributes", "pkg_mkdirs")
 load("@rules_rust//rust:defs.bzl", "rust_binary", "rust_library", "rust_test")
@@ -190,42 +191,32 @@ write_file(
 )
 
 ## Create a layer with a rosetta user
-passwd_entry(
-    name = "root_user",
-    uid = 0,
-    username = "root",
-)
-
-passwd_entry(
-    name = "ic_icrc_rosetta_user",
-    home = "/home/ic_icrc_rosetta",
-    info = "icrc rosetta node user",
-    uid = 1002,
-    username = "ic_icrc_rosetta",
-)
-
-passwd_file(
+passwd(
     name = "passwd",
     entries = [
-        ":ic_icrc_rosetta_user",
-        ":root_user",
+        dict(
+            gecos = ["root"],
+            gid = 0,
+            home = "/root",
+            shell = "/usr/bin/bash",
+            uid = 0,
+            username = "root",
+        ),
+        dict(
+            gecos = ["icrc rosetta node user"],
+            gid = 1002,
+            home = "/home/ic_icrc_rosetta",
+            shell = "/usr/bin/bash",
+            uid = 1002,
+            username = "ic_icrc_rosetta",
+        ),
     ],
-)
-
-pkg_tar(
-    name = "passwd_tar",
-    srcs = [":passwd"],
-    mode = "0644",
-    package_dir = "etc",
 )
 
 pkg_mkdirs(
     name = "data_dir",
-    # Unfortunately, rules_docker does not preserve the file ownership:
-    # https://github.com/bazelbuild/rules_docker/issues/1928
-    #
     # We make the /data directory rwx for everyone so that "rosetta"
-    # user could write to that directory.
+    # user can write to that directory.
     attributes = pkg_attributes(
         mode = "0777",
         user = "ic_icrc_rosetta",
@@ -242,37 +233,35 @@ pkg_tar(
 )
 
 ## An intermediate image with the passwd file and empty directories.
-
-container_image(
+oci_image(
     name = "ic_icrc_rosetta_image_base",
-    base = "@rust_base//image",
+    base = "@rust_base",
     tags = ["manual"],
     target_compatible_with = [
         "@platforms//os:linux",
     ],
     tars = [
-        ":passwd_tar",
+        ":passwd",
         ":data_tar",
     ],
 )
 
 ## The final image we can publish.
+pkg_tar(
+    name = "ic_icrc_rosetta_image_homedir",
+    srcs = [":ic-icrc-rosetta-bin"],
+    package_dir = "/home/ic_icrc_rosetta",
+)
 
-container_image(
+oci_image(
     name = "ic_icrc_rosetta_image",
     base = ":ic_icrc_rosetta_image_base",
-    directory = "/home/ic_icrc_rosetta",
-    entrypoint = [
-        "/home/ic_icrc_rosetta/ic-icrc-rosetta-bin",
-    ],
-    files = [
-        ":ic-icrc-rosetta-bin",
-    ],
-    ports = ["8080"],
+    entrypoint = ["/home/ic_icrc_rosetta/ic-icrc-rosetta-bin"],
     tags = ["manual"],
     target_compatible_with = [
         "@platforms//os:linux",
     ],
+    tars = [":ic_icrc_rosetta_image_homedir"],
     user = "ic_icrc_rosetta",
     workdir = "/home/ic_icrc_rosetta",
 )
@@ -280,12 +269,26 @@ container_image(
 ## Run this target with --embed_label flag[1] to specify the image tag.
 ## [1]: https://bazel.build/reference/command-line-reference#flag--embed_label
 
-container_push(
+# Use the value of --embed_label under --stamp, otherwise use a deterministic constant
+# value to ensure cache hits for actions that depend on this.
+expand_template(
+    name = "stamped",
+    out = "_stamped.tags.txt",
+    stamp_substitutions = {"0.0.0": "{{BUILD_EMBED_LABEL}}"},
+    template = [
+        "0.0.0",
+    ],
+)
+
+# Push image with:
+#  $ bazel run //<path>:push_ic_icrc_rosetta_image
+#
+# Usage:
+#   https://github.com/bazel-contrib/rules_oci/blob/main/docs/push.md#usage
+oci_push(
     name = "push_ic_icrc_rosetta_image",
-    format = "Docker",
     image = ":ic_icrc_rosetta_image",
-    registry = "index.docker.io",
-    repository = "dfinity/ic-icrc-rosetta-api",
-    tag = "{BUILD_EMBED_LABEL}",
+    remote_tags = ":stamped",
+    repository = "docker.io/dfinity/ic-icrc-rosetta-api",
     tags = ["manual"],
 )

--- a/rs/tests/BUILD.bazel
+++ b/rs/tests/BUILD.bazel
@@ -1,12 +1,13 @@
+load("@aspect_bazel_lib//lib:tar.bzl", "tar")
 load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
-load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
 load("@bazel_skylib//rules:run_binary.bzl", "run_binary")
-load("@io_bazel_rules_docker//docker/package_managers:download_pkgs.bzl", "download_pkgs")
-load("@io_bazel_rules_docker//docker/package_managers:install_pkgs.bzl", "install_pkgs")
+load("@rules_distroless//apt:defs.bzl", "dpkg_status")
+load("@rules_distroless//distroless:defs.bzl", "passwd")
+load("@rules_oci//oci:defs.bzl", "oci_image")
 load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test")
 load("//bazel:defs.bzl", "symlink_dir", "symlink_dir_test", "symlink_dirs")
 load("//rs/tests:common.bzl", "DEPENDENCIES", "MACRO_DEPENDENCIES")
-load(":system_tests.bzl", "uvm_config_image")
+load(":system_tests.bzl", "oci_tar", "uvm_config_image")
 
 package(default_visibility = ["//rs:system-tests-pkg"])
 
@@ -42,40 +43,99 @@ rust_library(
     deps = DEPENDENCIES,
 )
 
-download_pkgs(
-    name = "ubuntu_test_runtime_pkg",
-    additional_repos = [
-        "deb http://security.ubuntu.com/ubuntu focal-security main",
+# Packages we install into the image; see base image definition and its
+# 'manifest = ...' field for more information
+PACKAGES = [
+    "@focal//ca-certificates/amd64",
+    "@focal//bash/amd64",
+    "@focal//coreutils/amd64",
+    "@focal//gawk/amd64",
+    "@focal//dosfstools/amd64",
+    "@focal//libssl1.1/amd64",
+    "@focal//libunwind8/amd64",
+    "@focal//mtools/amd64",
+    "@focal//openssh-client/amd64",
+    "@focal//rsync/amd64",
+    "@focal//gzip/amd64",
+    "@focal//zstd/amd64",
+]
+
+tar(
+    name = "sh",
+    mtree = [
+        # needed as dpkg assumes sh is installed in a typical debian installation.
+        "./bin/sh type=link link=/bin/bash",
     ],
-    image_tar = "@ubuntu_base//image",
-    packages = [
-        "ca-certificates",
-        "curl",  # TODO: remove since this is for debugging
-        "dosfstools",
-        "libssl1.1",  # the test-driver depends on libssl1.1.
-        "libunwind8",  # idem
-        "mtools",
-        "openssh-client",  # for ssh-keygen.
-        "rsync",  # for //rs/tests/consensus/orchestrator:sr_app_same_nodes_test
-        "zstd",  # for create-universal-vm-config-image.sh.
-    ],
-    tags = ["manual"],
 )
 
-install_pkgs(
-    name = "ubuntu_test_runtime_image",
-    image_tar = "@ubuntu_base//image",
-    installables_tar = ":ubuntu_test_runtime_pkg.tar",
-    installation_cleanup_commands = "rm -rf /var/lib/apt/lists/*",
-    output_image_name = "ubuntu_test_runtime_image",
-    tags = ["manual"],
+tar(
+    name = "mkfsvfat",
+    mtree = [
+        # symlink instead of updating the PATH
+        "./bin/mkfs.vfat type=link link=/sbin/mkfs.vfat",
+    ],
+)
+
+tar(
+    name = "awk",
+    mtree = [
+        # we install the GNU variant but call 'awk' so we symlink
+        "./bin/awk type=link link=/usr/bin/gawk",
+    ],
+)
+
+# Creates /var/lib/dpkg/status with installed package information.
+dpkg_status(
+    name = "dpkg_status",
+    controls = [
+        "%s:control" % package
+        for package in PACKAGES
+    ],
+)
+
+passwd(
+    name = "passwd",
+    entries = [
+        dict(
+            gecos = ["root"],
+            gid = 0,
+            home = "/root",
+            shell = "/usr/bin/bash",
+            uid = 0,
+            username = "root",
+        ),
+    ],
+)
+
+oci_image(
+    name = "ubuntu_test_runtime_image_src",
+    architecture = "amd64",
+    os = "linux",
+    target_compatible_with = [
+        "@platforms//os:linux",
+    ],
+    tars = [
+        ":dpkg_status",
+        ":passwd",  # needed because we ssh in
+
+        # symlinks
+        ":awk",
+        ":mkfsvfat",
+        ":sh",
+    ] + PACKAGES,
+)
+
+oci_tar(
+    name = "ubuntu_test_runtime.tar",
+    image = ":ubuntu_test_runtime_image_src",
+    repo_tags = ["ubuntu_test_runtime:image"],
 )
 
 uvm_config_image(
     name = "colocate_uvm_config_image",
     srcs = [
+        ":ubuntu_test_runtime.tar",
         "//rs/tests:activate-systest-uvm-config",
-        "@ubuntu_test_runtime//image",
     ],
     remap_paths = {
         "activate-systest-uvm-config": "activate",
@@ -133,13 +193,10 @@ symlink_dir_test(
     },
 )
 
-copy_file(
-    name = "static-file-server_image",
-    src = "@static-file-server//image",
-    out = "static-file-server.tar",
-    target_compatible_with = [
-        "@platforms//os:linux",
-    ],
+oci_tar(
+    name = "static-file-server.tar",
+    image = "@static-file-server",
+    repo_tags = ["static-file-server:image"],
 )
 
 exports_files([
@@ -150,9 +207,9 @@ exports_files([
 uvm_config_image(
     name = "btc_uvm_config_image",
     srcs = [
+        ":bitcoind.tar",
         ":src/btc_integration/bitcoin.conf",
         ":src/btc_integration/btc_activate.sh",
-        "@bitcoind//image",
     ],
     remap_paths = {
         "btc_activate.sh": "activate",
@@ -169,7 +226,7 @@ uvm_config_image(
     srcs = [
         # ":src/btc_integration/bitcoin.conf",
         ":src/jaeger/jaeger_activate.sh",
-        "@jaeger//image",
+        ":jaeger_image",
     ],
     remap_paths = {
         "jaeger_activate.sh": "activate",
@@ -255,50 +312,50 @@ symlink_dirs(
     ],
 )
 
-copy_file(
-    name = "coredns_image",
-    src = "@coredns//image",
-    out = "coredns.tar",
-    target_compatible_with = [
-        "@platforms//os:linux",
-    ],
+oci_tar(
+    name = "jaeger.tar",
+    image = "@jaeger",
+    repo_tags = ["jaegertracing/all-in-one:1.58"],
 )
 
-copy_file(
-    name = "pebble_image",
-    src = "@pebble//image",
-    out = "pebble.tar",
-    target_compatible_with = [
-        "@platforms//os:linux",
-    ],
+oci_tar(
+    name = "bitcoind.tar",
+    image = "@bitcoind",
+    repo_tags = ["bitcoind:pinned"],
 )
 
-copy_file(
-    name = "python3_image",
-    src = "@python3//image",
-    out = "python3.tar",
-    target_compatible_with = [
-        "@platforms//os:linux",
-    ],
+oci_tar(
+    name = "coredns.tar",
+    image = "@coredns",
+    repo_tags = ["coredns:latest"],
 )
 
-copy_file(
-    name = "openssl_image",
-    src = "@alpine_openssl//image",
-    out = "openssl.tar",
-    target_compatible_with = [
-        "@platforms//os:linux",
-    ],
+oci_tar(
+    name = "pebble.tar",
+    image = "@pebble",
+    repo_tags = ["pebble:latest"],
+)
+
+oci_tar(
+    name = "python3.tar",
+    image = "@python3",
+    repo_tags = ["python3:latest"],
+)
+
+oci_tar(
+    name = "openssl.tar",
+    image = "@alpine_openssl",
+    repo_tags = ["openssl:latest"],
 )
 
 uvm_config_image(
     name = "custom_domains_uvm_config_image",
     srcs = [
         # Docker images
-        ":coredns_image",
-        ":openssl_image",
-        ":pebble_image",
-        ":python3_image",
+        ":coredns_tar",
+        ":openssl_tar",
+        ":pebble_tar",
+        ":python3_tar",
 
         # Assets
         ":src/custom_domains_integration/activate.sh",

--- a/rs/tests/consensus/subnet_recovery/BUILD.bazel
+++ b/rs/tests/consensus/subnet_recovery/BUILD.bazel
@@ -13,7 +13,7 @@ ORCHESTRATOR_UNIVERSAL_VM_ACTIVATION = [":orchestrator_universal_vm_activation.s
 
 STATIC_FILE_SERVER_IMAGE_RUNTIME_DEPS = [
     # Keep sorted.
-    "//rs/tests:static-file-server_image",
+    "//rs/tests:static-file-server.tar",
 ]
 
 rust_library(

--- a/rs/tests/consensus/subnet_recovery/orchestrator_universal_vm_activation.sh
+++ b/rs/tests/consensus/subnet_recovery/orchestrator_universal_vm_activation.sh
@@ -9,8 +9,7 @@ cp /config/registry.tar .
 chmod -R 755 ./
 
 docker load -i /config/static-file-server.tar
-docker tag bazel/image:image static-file-server
 docker run -d \
     -v "$(pwd)":/web \
     -p 80:8080 \
-    static-file-server
+    static-file-server:image

--- a/rs/tests/httpbin-rs/BUILD.bazel
+++ b/rs/tests/httpbin-rs/BUILD.bazel
@@ -1,7 +1,8 @@
-load("@io_bazel_rules_docker//container:container.bzl", "container_image")
-load("@io_bazel_rules_docker//contrib:passwd.bzl", "passwd_entry", "passwd_file")
+load("@rules_distroless//distroless:defs.bzl", "passwd")
+load("@rules_oci//oci:defs.bzl", "oci_image")
 load("@rules_pkg//:pkg.bzl", "pkg_tar")
 load("@rules_rust//rust:defs.bzl", "rust_binary")
+load("//rs/tests:system_tests.bzl", "oci_tar")
 
 package(default_visibility = ["//rs:system-tests-pkg"])
 
@@ -30,67 +31,66 @@ rust_binary(
     deps = DEPENDENCIES,
 )
 
+pkg_tar(
+    name = "httpbin_image_homedir",
+    srcs = [":httpbin"],
+    package_dir = "/home/httpbin",
+)
+
 ## Create a layer with a httpbin user
 
-passwd_entry(
-    name = "root_user",
-    uid = 0,
-    username = "root",
-)
-
-passwd_entry(
-    name = "httpbin_user",
-    home = "/home/httpbin",
-    info = "httpbin user",
-    uid = 1002,
-    username = "httpbin",
-)
-
-passwd_file(
+passwd(
     name = "passwd",
     entries = [
-        ":httpbin_user",
-        ":root_user",
+        dict(
+            gecos = ["root"],
+            gid = 0,
+            home = "/root",
+            shell = "/usr/bin/bash",
+            uid = 0,
+            username = "root",
+        ),
+        dict(
+            gecos = ["httpbin_user"],
+            gid = 1002,
+            home = "/home/httpbin",
+            shell = "/usr/bin/bash",
+            uid = 1002,
+            username = "httpbin",
+        ),
     ],
-)
-
-pkg_tar(
-    name = "passwd_tar",
-    srcs = [":passwd"],
-    mode = "0644",
-    package_dir = "etc",
 )
 
 ## An intermediate image with the passwd file and empty directories.
 
-container_image(
+oci_image(
     name = "httpbin_image_base",
-    base = "@ubuntu_test_runtime//image",
+    base = "//rs/tests:ubuntu_test_runtime_image_src",
     tags = ["manual"],
     target_compatible_with = [
         "@platforms//os:linux",
     ],
     tars = [
-        ":passwd_tar",
+        ":passwd",
     ],
 )
 
-## The final image we can publish.
-
-container_image(
-    name = "httpbin_image",
+## The final image we export for tests
+oci_image(
+    name = "httpbin_image_src",
     base = ":httpbin_image_base",
-    directory = "/home/httpbin",
-    entrypoint = [
-        "/home/httpbin/httpbin",
-    ],
-    files = [
-        ":httpbin",
-    ],
+    entrypoint = ["/home/httpbin/httpbin"],
     tags = ["manual"],
     target_compatible_with = [
         "@platforms//os:linux",
     ],
+    tars = [":httpbin_image_homedir"],
     user = "httpbin",
     workdir = "/home/httpbin",
+)
+
+oci_tar(
+    name = "httpbin.tar",
+    image = ":httpbin_image_src",
+    repo_tags = ["httpbin:image"],
 )

--- a/rs/tests/networking/canister_http/BUILD.bazel
+++ b/rs/tests/networking/canister_http/BUILD.bazel
@@ -1,6 +1,5 @@
-load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
 load("@rules_rust//rust:defs.bzl", "rust_library")
-load("//rs/tests:system_tests.bzl", "uvm_config_image")
+load("//rs/tests:system_tests.bzl", "oci_tar", "uvm_config_image")
 
 package(default_visibility = ["//rs:system-tests-pkg"])
 
@@ -26,14 +25,20 @@ rust_library(
     ],
 )
 
+oci_tar(
+    name = "minica.tar",
+    image = "@minica",
+    repo_tags = ["minica:image"],
+)
+
 uvm_config_image(
     name = "http_uvm_config_image",
     srcs = [
-        ":minica_image",
+        ":minica.tar",
         ":universal_vm_activation.sh",
         "//ic-os/components:networking/dev-certs/canister_http_test_ca.cert",
         "//ic-os/components:networking/dev-certs/canister_http_test_ca.key",
-        "//rs/tests/httpbin-rs:httpbin_image.tar",
+        "//rs/tests/httpbin-rs:httpbin.tar",
     ],
     remap_paths = {
         "universal_vm_activation.sh": "activate",
@@ -41,13 +46,4 @@ uvm_config_image(
         "canister_http_test_ca.key": "key.pem",
     },
     tags = ["manual"],  # this target will be built if required as a dependency of another target
-)
-
-copy_file(
-    name = "minica_image",
-    src = "@minica//image",
-    out = "minica.tar",
-    target_compatible_with = [
-        "@platforms//os:linux",
-    ],
 )

--- a/rs/tests/networking/canister_http/canister_http.rs
+++ b/rs/tests/networking/canister_http/canister_http.rs
@@ -136,10 +136,9 @@ pub fn start_httpbin_on_uvm(env: &TestEnv) {
 
         echo "Making certs directory in $(pwd) ..."
         docker load -i /config/minica.tar
-        docker tag bazel/image:image minica
         docker run \
             -v "$(pwd)":/output \
-            minica \
+            minica:image \
             -ip-addresses="$ipv6${{ipv4:+,$ipv4}}"
 
         echo "Updating service certificate folder name so it can be fed to ssl-proxy container ..."
@@ -147,15 +146,14 @@ pub fn start_httpbin_on_uvm(env: &TestEnv) {
         sudo chmod -R 755 ipv6
 
         echo "Setting up httpbin on port 20443 ..."
-        docker load -i /config/httpbin_image.tar
-        docker tag bazel/rs/tests/httpbin-rs:httpbin_image httpbin
+        docker load -i /config/httpbin.tar
         sudo docker run \
             --rm \
             -d \
             -p 20443:80 \
             -v "$(pwd)/ipv6":/certs \
             --name httpbin \
-            httpbin \
+            httpbin:image \
             --cert-file /certs/cert.pem --key-file /certs/key.pem --port 80
     "#
         ))

--- a/rs/tests/src/btc_integration/btc_activate.sh
+++ b/rs/tests/src/btc_integration/btc_activate.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 cp /config/bitcoin.conf /tmp/bitcoin.conf
-docker load -i /config/image.tar
+docker load -i /config/bitcoind.tar
 docker run --name=bitcoind-node -d \
     --net=host \
     -v /tmp:/bitcoin/.bitcoin \
-    bazel/image:image -rpcbind=[::]:8332 -rpcallowip=::/0
+    bitcoind:pinned -rpcbind=[::]:8332 -rpcallowip=::/0

--- a/rs/tests/src/custom_domains_integration/activate.sh
+++ b/rs/tests/src/custom_domains_integration/activate.sh
@@ -1,20 +1,8 @@
 #!/run/current-system/sw/bin/bash
 
-function load() {
-    NAME=$1
+# load all necessary images
 
-    # Load image
-    docker load -i "/config/${NAME}.tar"
-
-    # Rename image
-    docker tag \
-        bazel/image:image "${NAME}"
-
-    # Remove temporary image
-    docker rmi bazel/image:image
-}
-
-load coredns
-load pebble
-load python3
-load openssl
+docker load -i "/config/coredns.tar"
+docker load -i "/config/pebble.tar"
+docker load -i "/config/python3.tar"
+docker load -i "/config/openssl.tar"

--- a/rs/tests/src/jaeger/jaeger_activate.sh
+++ b/rs/tests/src/jaeger/jaeger_activate.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-docker load -i /config/image.tar
+docker load -i /config/jaeger.tar
 docker run -d --name jaeger \
     -e COLLECTOR_OTLP_ENABLED=true \
     -e SPAN_STORAGE_TYPE=badger \

--- a/rs/tests/src/rosetta_tests/setup.rs
+++ b/rs/tests/src/rosetta_tests/setup.rs
@@ -268,7 +268,7 @@ docker run -d -u $(id -u) \
     --rm -v /home/admin/rosetta/{port}/data:/data \
     --rm -v /home/admin/rosetta/{port}/logs:/home/rosetta/log \
     --name rosetta-{port} \
-    bazel/rs/rosetta-api:rosetta_image \
+    rosetta:image \
     --blockchain \"{}\" \
     --ic-url \"{}\" \
     --canister-id {} \

--- a/rs/tests/testing_verification/colocate_test.rs
+++ b/rs/tests/testing_verification/colocate_test.rs
@@ -21,7 +21,7 @@ use ic_system_test_driver::driver::test_env::{TestEnv, TestEnvAttribute};
 use ic_system_test_driver::driver::test_env_api::{get_dependency_path, FarmBaseUrl, SshSession};
 use ic_system_test_driver::driver::test_setup::GroupSetup;
 use ic_system_test_driver::driver::universal_vm::{DeployedUniversalVm, UniversalVm, UniversalVms};
-use slog::{debug, error, info, Logger};
+use slog::{error, info, Logger};
 use ssh2::Session;
 
 const UVM_NAME: &str = "test-driver";
@@ -153,12 +153,30 @@ fn setup(env: TestEnv) {
         Path::new("/home/admin").join(ENV_TAR_ZST),
     );
 
-    let docker_env_vars = {
-        let mut env_vars = String::from("");
-        for (key, value) in env::vars() {
-            env_vars.push_str(format!(r#"--env {key}={value:?} \"#).as_str());
-        }
-        env_vars
+    // Create a temporary environment file that we SCP into the UVM. These environment
+    // variables are then forward to the docker container with --env-file.
+    // (scoped to delete tempfile asap)
+    {
+        let tmpdir = tempfile::tempdir().expect("Could not create tempdir");
+        let filepath = tmpdir.path().join("env");
+        let mut file = File::create(filepath.clone()).expect("Could not create tempfile");
+
+        // We remove some problematic (and unnecessary) environment variables
+        // (docker/podman struggles to parse them)
+        let output = Command::new("env")
+            .env("BASH_FUNC_rlocation%%", "")
+            .env("BASH_FUNC_is_absolute%%", "")
+            .output()
+            .unwrap_or_else(|e| panic!("Failed to list env: {e}"));
+
+        file.write_all(&output.stdout).expect("Could not write env");
+
+        scp(
+            log.clone(),
+            &session,
+            filepath,
+            Path::new("/home/admin/env_vars").to_path_buf(),
+        );
     };
 
     let required_host_features = {
@@ -174,8 +192,6 @@ fn setup(env: TestEnv) {
         }
     };
 
-    debug!(log, "Docker env vars: {docker_env_vars}");
-
     info!(log, "Creating final docker image ...");
 
     let forward_ssh_agent =
@@ -189,10 +205,10 @@ cd /home/admin
 tar -xf /home/admin/{RUNFILES_TAR_ZST} --one-top-level=runfiles
 tar -xf /home/admin/{ENV_TAR_ZST} --one-top-level=root_env
 
-docker load -i /config/image.tar
+docker load -i /config/ubuntu_test_runtime.tar
 
 cat <<EOF > /home/admin/Dockerfile
-FROM bazel/image:image
+FROM ubuntu_test_runtime:image
 COPY runfiles /home/root/runfiles
 COPY root_env /home/root/root_env
 RUN chmod 700 /home/root/root_env/{SSH_AUTHORIZED_PRIV_KEYS_DIR}
@@ -211,8 +227,7 @@ else
     echo "No ssh-agent to forward."
 fi
 docker run --name {COLOCATE_CONTAINER_NAME} --network host \
-  {docker_env_vars}
-  --env RUNFILES=/home/root/runfiles \
+  --env-file /home/admin/env_vars --env RUNFILES=/home/root/runfiles \
   "${{DOCKER_RUN_ARGS[@]}}" \
   final \
   /home/root/runfiles/{colocated_test_bin} \


### PR DESCRIPTION
This replaces the now-deprecated
[rules_docker](https://github.com/bazelbuild/rules_docker) with [rules_oci](https://github.com/bazel-contrib/rules_oci). This will allow us to upgrade our Bazel version (done separately).

There are a couple of notable changes. Overall, `rules_oci` is less just-add-water, and some of the `rules_docker` features were split into more rule sets (distroless, aspect).
* `rules_oci` does not expose `tarball`s by default, so a new `oci_tar` macro is introduced to expose `tarball`s.
* The `ubuntu_test_runtime_image` is now based on an Ubuntu snapshot and includes its own lockfile (see `bazel/focal.yaml`). This makes the image build more reproducible, and means the image can now also be built on CI (previously had to be built & uploaded separately).
* Images can now be tagged upon creation, meaning that images do not come with the default `bazel/image:image` tag by default, which helps clarify which image is loaded (relevant for system tests).
* The `_colocate` tests now receive environment variables via an `--env-file` instead of listing all environment variables individually. See `colocate_test.rs` for more details.