### PR TITLE
fix: ict `from_config` testnet not accepting additional bazel arguments

### DIFF
--- a/rs/tests/ict/cmd/testnetCreateCmd.go
+++ b/rs/tests/ict/cmd/testnetCreateCmd.go
@@ -144,10 +144,10 @@ func TestnetCommand(cfg *TestnetConfig) func(cmd *cobra.Command, args []string) 
 	return func(cmd *cobra.Command, args []string) error {
 		config := ""
 		if cfg.icConfigPath != "" {
-			if len(args) > 0 {
+			if len(args) > 0 && !strings.HasPrefix(args[0], "--") {
 				return fmt.Errorf("Cannot provide both `--from-ic-config-path` and a name for testnet configuration: %s", args[0])
 			}
-			args = append(args, FROM_CONFIG)
+			args = append([]string{FROM_CONFIG}, args...)
 			json_bytes, err := os.ReadFile(cfg.icConfigPath)
 			if err != nil {
 				return err
@@ -248,7 +248,7 @@ func TestnetCommand(cfg *TestnetConfig) func(cmd *cobra.Command, args []string) 
 					return err
 				} else {
 					cmd.PrintErrf("%sTestnet will expire on %s%s\n", PURPLE, expiration, NC)
-					cmd.PrintErrf("%sNOTE: All further interactions with testnet (e.g., increasing testnet lifetime), should be done manually via Farm API, see %s%s\n", YELLOW, farmBaseUrl + "/swagger-ui", NC)
+					cmd.PrintErrf("%sNOTE: All further interactions with testnet (e.g., increasing testnet lifetime), should be done manually via Farm API, see %s%s\n", YELLOW, farmBaseUrl+"/swagger-ui", NC)
 				}
 			} else {
 				testnetExpirationTime := time.Now().Add(time.Minute * time.Duration(cfg.lifetimeMins))
@@ -283,7 +283,7 @@ func NewTestnetCreateCmd() *cobra.Command {
 	cmd.Flags().BoolVarP(&cfg.noTTL, "no-ttl", "", false, "Do not set a Time-To-Live (expiration time) for the testnet.\nIf set the --lifetime-mins setting is ignored.\nBE CAREFUL WITH THIS OPTION BECAUSE THIS WILL CAUSE RESOURCE EXHAUSTION\nIF YOU FORGET TO DELETE THE TESTNET MANUALLY WHEN NO LONGER USED!")
 	cmd.Flags().BoolVarP(&cfg.isFuzzyMatch, "fuzzy", "", false, "Use fuzzy matching to find similar testnet names. Default: substring match")
 	cmd.Flags().BoolVarP(&cfg.isDryRun, "dry-run", "n", false, "Print raw Bazel command to be invoked without execution")
-	cmd.Flags().BoolVarP(&cfg.isDetached, "experimental-detached", "", false, fmt.Sprintf("Create a testnet without blocking the console\nNOTE: extending testnet lifetime (ttl) should be done manually\nSee Farm API %s", FARM_BASE_URL + "/swagger-ui"))
+	cmd.Flags().BoolVarP(&cfg.isDetached, "experimental-detached", "", false, fmt.Sprintf("Create a testnet without blocking the console\nNOTE: extending testnet lifetime (ttl) should be done manually\nSee Farm API %s", FARM_BASE_URL+"/swagger-ui"))
 	cmd.Flags().StringVarP(&cfg.icConfigPath, "from-ic-config-path", "", "", "Provide a custom config describing the desired layout of the network to be deployed")
 	cmd.PersistentFlags().StringVarP(&cfg.farmBaseUrl, "farm-url", "", "", "Use a custom url for the Farm webservice.")
 	cmd.PersistentFlags().StringVarP(&cfg.requiredHostFeatures, "set-required-host-features", "", "", "Set and override required host features of all hosts spawned.\nFeatures must be one or more of [dc=<dc-name>, host=<host-name>, AMD-SEV-SNP, SNS-load-test, performance], separated by comma (see Examples).")

--- a/rs/tests/testing_verification/testnets/BUILD.bazel
+++ b/rs/tests/testing_verification/testnets/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//rs/tests:common.bzl", "BOUNDARY_NODE_GUESTOS_RUNTIME_DEPS", "DEPENDENCIES", "GRAFANA_RUNTIME_DEPS", "GUESTOS_RUNTIME_DEPS", "IC_MAINNET_NNS_RECOVERY_RUNTIME_DEPS", "MACRO_DEPENDENCIES", "NNS_CANISTER_ENV", "SNS_CANISTER_ENV", "SNS_CANISTER_RUNTIME_DEPS")
+load("//rs/tests:common.bzl", "BOUNDARY_NODE_GUESTOS_RUNTIME_DEPS", "DEPENDENCIES", "GRAFANA_RUNTIME_DEPS", "GUESTOS_RUNTIME_DEPS", "IC_MAINNET_NNS_RECOVERY_RUNTIME_DEPS", "MACRO_DEPENDENCIES", "NNS_CANISTER_ENV", "SNS_CANISTER_ENV", "SNS_CANISTER_RUNTIME_DEPS", "NNS_CANISTER_RUNTIME_DEPS")
 load("//rs/tests:system_tests.bzl", "system_test", "system_test_nns")
 
 package(default_visibility = ["//rs:system-tests-pkg"])
@@ -60,7 +60,7 @@ system_test_nns(
     deps = DEPENDENCIES + ["//rs/tests"],
 )
 
-system_test_nns(
+system_test(
     name = "from_config",
     flaky = False,
     proc_macro_deps = MACRO_DEPENDENCIES,
@@ -69,11 +69,12 @@ system_test_nns(
         "manual",
     ],
     target_compatible_with = ["@platforms//os:linux"],  # requires libssh that does not build on Mac OS
-    runtime_deps = GUESTOS_RUNTIME_DEPS + BOUNDARY_NODE_GUESTOS_RUNTIME_DEPS + GRAFANA_RUNTIME_DEPS,
+    runtime_deps = GUESTOS_RUNTIME_DEPS + BOUNDARY_NODE_GUESTOS_RUNTIME_DEPS + GRAFANA_RUNTIME_DEPS + NNS_CANISTER_RUNTIME_DEPS,
     deps = DEPENDENCIES + [
         "//rs/tests",
         "//rs/tests/dre/utils:os_qualification_utils",
     ],
+    env = NNS_CANISTER_ENV
 )
 
 system_test_nns(

--- a/rs/tests/testing_verification/testnets/BUILD.bazel
+++ b/rs/tests/testing_verification/testnets/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//rs/tests:common.bzl", "BOUNDARY_NODE_GUESTOS_RUNTIME_DEPS", "DEPENDENCIES", "GRAFANA_RUNTIME_DEPS", "GUESTOS_RUNTIME_DEPS", "IC_MAINNET_NNS_RECOVERY_RUNTIME_DEPS", "MACRO_DEPENDENCIES", "NNS_CANISTER_ENV", "SNS_CANISTER_ENV", "SNS_CANISTER_RUNTIME_DEPS", "NNS_CANISTER_RUNTIME_DEPS")
+load("//rs/tests:common.bzl", "BOUNDARY_NODE_GUESTOS_RUNTIME_DEPS", "DEPENDENCIES", "GRAFANA_RUNTIME_DEPS", "GUESTOS_RUNTIME_DEPS", "IC_MAINNET_NNS_RECOVERY_RUNTIME_DEPS", "MACRO_DEPENDENCIES", "NNS_CANISTER_ENV", "NNS_CANISTER_RUNTIME_DEPS", "SNS_CANISTER_ENV", "SNS_CANISTER_RUNTIME_DEPS")
 load("//rs/tests:system_tests.bzl", "system_test", "system_test_nns")
 
 package(default_visibility = ["//rs:system-tests-pkg"])
@@ -62,6 +62,7 @@ system_test_nns(
 
 system_test(
     name = "from_config",
+    env = NNS_CANISTER_ENV,
     flaky = False,
     proc_macro_deps = MACRO_DEPENDENCIES,
     tags = [
@@ -74,7 +75,6 @@ system_test(
         "//rs/tests",
         "//rs/tests/dre/utils:os_qualification_utils",
     ],
-    env = NNS_CANISTER_ENV
 )
 
 system_test_nns(


### PR DESCRIPTION
Addressing the issue of being unable to pass additional args to bazel test from ict. Previously command like:
```bash
ict testnet create --from-ic-config-path /home/nikola/Downloads/test.json --lifetime-mins 10 -- --test_tmpdir=test_tmpdir/
```
Would result in an error:
```bash
There was an error while executing CLI: Cannot provide both `--from-ic-config-path` and a name for testnet configuration: --test_tmpdir=test_tmpdir/
```
Its been addressed here, and this allows us to pass normally additional arguments:
```bash
ict testnet create --from-ic-config-path /home/nikola/Downloads/test.json --lifetime-mins 10 -- --test_tmpdir=/home/nikola/Downloads/output
Raw Bazel command to be invoked:
$ bazel test //rs/tests/testing_verification/testnets:from_config --config=systest --cache_test_results=no --test_timeout=5400 --test_arg=--no-delete-farm-group --test_env=IC_CONFIG='{"subnets":[{"subnet_type":"application","num_nodes":4},{"subnet_type":"application","num_nodes":4},{"subnet_type":"system","num_nodes":4}],"num_unassigned_nodes":0}' --test_tmpdir=/home/nikola/Downloads/output
Testnet is being deployed, please wait ... (check progress in the docker dir /tmp/ict_testnets/2024-09-16_16-26-47.527.log)
```

On top of that, `from_config` testnet has been tweaked to allow using nns canisters from the branch that is being deployed which makes it easier to spawn testnets for testing while working on nns (and other) canisters