### PR TITLE
refactor(nns): remove unnecessary mut from call_canister_method signature

### DIFF
--- a/rs/nns/governance/benches/scale.rs
+++ b/rs/nns/governance/benches/scale.rs
@@ -69,7 +69,7 @@ impl Environment for MockEnvironment {
     }
 
     async fn call_canister_method(
-        &mut self,
+        &self,
         _target: CanisterId,
         _method_name: &str,
         _request: Vec<u8>,

--- a/rs/nns/governance/canister/canister.rs
+++ b/rs/nns/governance/canister/canister.rs
@@ -262,7 +262,7 @@ impl Environment for CanisterEnv {
     }
 
     async fn call_canister_method(
-        &mut self,
+        &self,
         target: CanisterId,
         method_name: &str,
         request: Vec<u8>,

--- a/rs/nns/governance/src/governance.rs
+++ b/rs/nns/governance/src/governance.rs
@@ -1490,7 +1490,7 @@ pub trait Environment: Send + Sync {
 
     /// Basically, the same as dfn_core::api::call.
     async fn call_canister_method(
-        &mut self,
+        &self,
         target: CanisterId,
         method_name: &str,
         request: Vec<u8>,

--- a/rs/nns/governance/src/test_utils.rs
+++ b/rs/nns/governance/src/test_utils.rs
@@ -214,7 +214,7 @@ impl Environment for MockEnvironment {
     }
 
     async fn call_canister_method(
-        &mut self,
+        &self,
         target: CanisterId,
         method_name: &str,
         request: Vec<u8>,

--- a/rs/nns/governance/tests/degraded_mode.rs
+++ b/rs/nns/governance/tests/degraded_mode.rs
@@ -52,7 +52,7 @@ impl Environment for DegradedEnv {
     }
 
     async fn call_canister_method(
-        &mut self,
+        &self,
         _target: CanisterId,
         _method_name: &str,
         _request: Vec<u8>,

--- a/rs/nns/governance/tests/fake.rs
+++ b/rs/nns/governance/tests/fake.rs
@@ -336,7 +336,7 @@ impl Environment for FakeDriver {
     }
 
     async fn call_canister_method(
-        &mut self,
+        &self,
         target: CanisterId,
         method_name: &str,
         request: Vec<u8>,

--- a/rs/nns/governance/tests/fixtures/environment_fixture.rs
+++ b/rs/nns/governance/tests/fixtures/environment_fixture.rs
@@ -170,7 +170,7 @@ impl Environment for EnvironmentFixture {
     }
 
     async fn call_canister_method(
-        &mut self,
+        &self,
         target: CanisterId,
         method_name: &str,
         request: Vec<u8>,

--- a/rs/nns/governance/tests/fixtures/mod.rs
+++ b/rs/nns/governance/tests/fixtures/mod.rs
@@ -518,7 +518,7 @@ impl Environment for NNSFixture {
     }
 
     async fn call_canister_method(
-        &mut self,
+        &self,
         target: CanisterId,
         method_name: &str,
         request: Vec<u8>,
@@ -963,7 +963,7 @@ impl Environment for NNS {
     }
 
     async fn call_canister_method(
-        &mut self,
+        &self,
         _target: CanisterId,
         _method_name: &str,
         _request: Vec<u8>,

--- a/rs/nns/governance/tests/governance.rs
+++ b/rs/nns/governance/tests/governance.rs
@@ -11144,7 +11144,7 @@ fn assert_calls_eq(
 #[async_trait]
 impl Environment for MockEnvironment<'_> {
     async fn call_canister_method(
-        &mut self,
+        &self,
         target: CanisterId,
         method_name: &str,
         request: Vec<u8>,


### PR DESCRIPTION
Small refactor to make an interface more correct (it does not mutate the struct state).  

Next: https://github.com/dfinity/ic/pull/1565