### PR TITLE
chore(sns): Migrate SNS Root's wasm_memory_limit

### DIFF
--- a/rs/sns/governance/canister/governance.did
+++ b/rs/sns/governance/canister/governance.did
@@ -283,6 +283,7 @@ type Governance = record {
   sns_metadata : opt ManageSnsMetadata;
   neurons : vec record { text; Neuron };
   genesis_timestamp_seconds : nat64;
+  migrated_root_wasm_memory_limit : opt bool;
 };
 
 type GovernanceCachedMetrics = record {

--- a/rs/sns/governance/canister/governance_test.did
+++ b/rs/sns/governance/canister/governance_test.did
@@ -292,6 +292,7 @@ type Governance = record {
   sns_metadata : opt ManageSnsMetadata;
   neurons : vec record { text; Neuron };
   genesis_timestamp_seconds : nat64;
+  migrated_root_wasm_memory_limit : opt bool;
 };
 
 type GovernanceCachedMetrics = record {

--- a/rs/sns/governance/proto/ic_sns_governance/pb/v1/governance.proto
+++ b/rs/sns/governance/proto/ic_sns_governance/pb/v1/governance.proto
@@ -1446,6 +1446,8 @@ message Governance {
   }
 
   MaturityModulation maturity_modulation = 26;
+
+  optional bool migrated_root_wasm_memory_limit = 27;
 }
 
 // Request message for 'get_metadata'.

--- a/rs/sns/governance/src/canister_control.rs
+++ b/rs/sns/governance/src/canister_control.rs
@@ -1,3 +1,4 @@
+use crate::governance::Governance;
 use crate::{
     governance::log_prefix,
     logs::{ERROR, INFO},
@@ -15,6 +16,7 @@ use ic_canister_log::log;
 use ic_nervous_system_clients::{
     canister_id_record::CanisterIdRecord,
     canister_status::{CanisterStatusResultFromManagementCanister, CanisterStatusType},
+    update_settings::{CanisterSettings, UpdateSettings},
 };
 use std::convert::TryFrom;
 
@@ -319,4 +321,33 @@ pub async fn perform_execute_generic_nervous_system_function_call(
             Ok(())
         }
     }
+}
+
+pub async fn update_root_canister_settings(
+    governance: &Governance,
+    settings: CanisterSettings,
+) -> Result<(), GovernanceError> {
+    let update_settings_args = UpdateSettings {
+        canister_id: PrincipalId::from(governance.proto.root_canister_id_or_panic()),
+        settings,
+        // allowed to be None
+        sender_canister_version: None,
+    };
+    governance
+        .env
+        .call_canister(
+            ic_management_canister_types::IC_00,
+            "update_settings",
+            Encode!(&update_settings_args).expect("Unable to encode update_settings args."),
+        )
+        .await
+        .map(|_reply| ())
+        .map_err(|err| {
+            let err = GovernanceError::new_with_message(
+                ErrorType::External,
+                format!("Failed to update settings of the root canister: {:?}", err),
+            );
+            log!(ERROR, "{}{:?}", log_prefix(), err);
+            err
+        })
 }

--- a/rs/sns/governance/src/gen/ic_sns_governance.pb.v1.rs
+++ b/rs/sns/governance/src/gen/ic_sns_governance.pb.v1.rs
@@ -1491,6 +1491,8 @@ pub struct Governance {
     pub is_finalizing_disburse_maturity: ::core::option::Option<bool>,
     #[prost(message, optional, tag = "26")]
     pub maturity_modulation: ::core::option::Option<governance::MaturityModulation>,
+    #[prost(bool, optional, tag = "27")]
+    pub migrated_root_wasm_memory_limit: ::core::option::Option<bool>,
 }
 /// Nested message and enum types in `Governance`.
 pub mod governance {

--- a/rs/sns/governance/src/governance.rs
+++ b/rs/sns/governance/src/governance.rs
@@ -6,7 +6,7 @@ use crate::pb::v1::{
 use crate::{
     canister_control::{
         get_canister_id, perform_execute_generic_nervous_system_function_call,
-        upgrade_canister_directly,
+        update_root_canister_settings, upgrade_canister_directly,
     },
     logs::{ERROR, INFO},
     neuron::{
@@ -84,6 +84,7 @@ use ic_management_canister_types::{
     CanisterChangeDetails, CanisterInfoRequest, CanisterInfoResponse, CanisterInstallMode,
 };
 use ic_nervous_system_clients::ledger_client::ICRC1Ledger;
+use ic_nervous_system_clients::update_settings::CanisterSettings;
 use ic_nervous_system_collections_union_multi_map::UnionMultiMap;
 use ic_nervous_system_common::{
     cmc::CMC,
@@ -96,7 +97,10 @@ use ic_nervous_system_governance::maturity_modulation::{
 };
 use ic_nervous_system_lock::acquire;
 use ic_nervous_system_root::change_canister::ChangeCanisterRequest;
-use ic_nns_constants::LEDGER_CANISTER_ID as NNS_LEDGER_CANISTER_ID;
+use ic_nns_constants::{
+    DEFAULT_SNS_NON_GOVERNANCE_CANISTER_WASM_MEMORY_LIMIT,
+    LEDGER_CANISTER_ID as NNS_LEDGER_CANISTER_ID,
+};
 use ic_protobuf::types::v1::CanisterInstallMode as CanisterInstallModeProto;
 use ic_sns_governance_proposal_criticality::ProposalCriticality;
 use ic_sns_governance_token_valuation::Valuation;
@@ -4584,6 +4588,32 @@ impl Governance {
         true
     }
 
+    async fn maybe_migrate_root_wasm_memory_limit(&mut self) {
+        if self
+            .proto
+            .migrated_root_wasm_memory_limit
+            .unwrap_or_default()
+        {
+            return;
+        }
+
+        // Set migrated_root_wasm_memory_limit to Some(true) so this doesn't run again
+        self.proto.migrated_root_wasm_memory_limit = Some(true);
+
+        let settings = CanisterSettings {
+            wasm_memory_limit: Some(candid::Nat::from(
+                DEFAULT_SNS_NON_GOVERNANCE_CANISTER_WASM_MEMORY_LIMIT,
+            )),
+            ..Default::default()
+        };
+
+        // Set root settings
+        match update_root_canister_settings(self, settings).await {
+            Ok(_) => (),
+            Err(e) => log!(ERROR, "Failed to update root canister settings: {}", e),
+        }
+    }
+
     /// Runs periodic tasks that are not directly triggered by user input.
     pub async fn heartbeat(&mut self) {
         self.process_proposals();
@@ -4621,6 +4651,8 @@ impl Governance {
         self.maybe_move_staked_maturity();
 
         self.maybe_gc();
+
+        self.maybe_migrate_root_wasm_memory_limit().await;
     }
 
     fn should_update_maturity_modulation(&self) -> bool {

--- a/rs/sns/governance/src/proposal.rs
+++ b/rs/sns/governance/src/proposal.rs
@@ -2489,6 +2489,7 @@ mod tests {
             pending_version: None,
             is_finalizing_disburse_maturity: None,
             maturity_modulation: None,
+            migrated_root_wasm_memory_limit: Some(true),
         }
     }
 

--- a/rs/sns/governance/tests/fixtures/environment_fixture.rs
+++ b/rs/sns/governance/tests/fixtures/environment_fixture.rs
@@ -1,6 +1,7 @@
 use async_trait::async_trait;
 use candid::{CandidType, Decode, Encode, Error};
 use ic_base_types::CanisterId;
+use ic_nervous_system_clients::update_settings::CanisterSettings;
 use ic_sns_governance::{
     pb::sns_root_types::{RegisterDappCanistersRequest, SetDappControllersRequest},
     types::{Environment, HeapGrowthPotential},
@@ -15,6 +16,7 @@ type CanisterCallResult = Result<Vec<u8>, (Option<i32>, String)>;
 pub enum CanisterCallRequest {
     RegisterDappCanisters(RegisterDappCanistersRequest),
     SetDappControllers(SetDappControllersRequest),
+    UpdateSettings(CanisterSettings),
 }
 
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
@@ -69,6 +71,9 @@ impl EnvironmentFixture {
             )?),
             "set_dapp_controllers" => {
                 CanisterCallRequest::SetDappControllers(Decode!(&args, SetDappControllersRequest)?)
+            }
+            "update_settings" => {
+                CanisterCallRequest::UpdateSettings(Decode!(&args, CanisterSettings)?)
             }
             _ => panic!("Unsupported method_name `{method_name}` in decode_canister_call."),
         };
@@ -173,7 +178,7 @@ impl Environment for EnvironmentFixture {
                 .unwrap()
                 .mocked_canister_replies
                 .pop()
-                .expect("Expected there to be a mocked canister reply on the stack"),
+                .unwrap_or_else(|| panic!("Expected there to be a mocked canister reply on the stack for method `{method_name}`")),
         );
 
         match encode_result {

--- a/rs/sns/governance/tests/fixtures/mod.rs
+++ b/rs/sns/governance/tests/fixtures/mod.rs
@@ -854,6 +854,7 @@ impl Default for GovernanceCanisterFixtureBuilder {
                     current_basis_points: Some(0),
                     updated_at_timestamp_seconds: Some(1),
                 }),
+                migrated_root_wasm_memory_limit: Some(true),
                 ..Default::default()
             },
             sns_ledger_transforms: Vec::default(),
@@ -1073,6 +1074,11 @@ impl GovernanceCanisterFixtureBuilder {
 
         // Set up the canister fixture with our neuron.
         self.add_neuron(neuron)
+    }
+
+    pub fn set_migrated_root_wasm_memory_limit(mut self, value: bool) -> Self {
+        self.governance.migrated_root_wasm_memory_limit = Some(value);
+        self
     }
 }
 


### PR DESCRIPTION
#1427 made this change for the root canisters of new SNSes. This PR ensures that all root canisters have the expected settings by migrating existing SNSes. 

The change changes their settings to set wasm_memory_limit to 3GiB. This should be safe – no root canister uses anything close to 3GiB. 