### PR TITLE
chore(consensus): move `get_block_maker_delay` function from `consensus_utils` crate to `consensus` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6665,7 +6665,6 @@ version = "0.9.0"
 dependencies = [
  "assert_matches",
  "hex",
- "ic-consensus",
  "ic-consensus-mocks",
  "ic-crypto-prng",
  "ic-interfaces",

--- a/rs/consensus/src/consensus/validator.rs
+++ b/rs/consensus/src/consensus/validator.rs
@@ -13,7 +13,7 @@ use crate::{
 use ic_consensus_utils::{
     active_high_threshold_nidkg_id, active_low_threshold_nidkg_id,
     crypto::ConsensusCrypto,
-    get_oldest_idkg_state_registry_version, is_time_to_make_block,
+    get_oldest_idkg_state_registry_version,
     membership::{Membership, MembershipError},
     pool_reader::PoolReader,
     RoundRobin,
@@ -52,6 +52,8 @@ use std::{
     sync::{Arc, RwLock},
     time::Duration,
 };
+
+use super::block_maker::is_time_to_make_block;
 
 /// The number of seconds spent in unvalidated pool, after which we start
 /// logging why we cannot validate an artifact.
@@ -1889,9 +1891,13 @@ impl Validator {
 #[cfg(test)]
 pub mod test {
     use super::*;
-    use crate::idkg::test_utils::{
-        add_available_quadruple_to_payload, empty_idkg_payload, fake_ecdsa_master_public_key_id,
-        fake_signature_request_context_with_pre_sig, fake_state_with_signature_requests,
+    use crate::{
+        consensus::block_maker::get_block_maker_delay,
+        idkg::test_utils::{
+            add_available_quadruple_to_payload, empty_idkg_payload,
+            fake_ecdsa_master_public_key_id, fake_signature_request_context_with_pre_sig,
+            fake_state_with_signature_requests,
+        },
     };
     use assert_matches::assert_matches;
     use ic_artifact_pool::dkg_pool::DkgPoolImpl;
@@ -1900,7 +1906,6 @@ pub mod test {
         dependencies_with_subnet_params, dependencies_with_subnet_records_with_raw_state_manager,
         Dependencies, RefMockPayloadBuilder,
     };
-    use ic_consensus_utils::get_block_maker_delay;
     use ic_interfaces::{
         messaging::XNetPayloadValidationFailure, p2p::consensus::MutablePool,
         time_source::TimeSource,

--- a/rs/consensus/utils/BUILD.bazel
+++ b/rs/consensus/utils/BUILD.bazel
@@ -20,7 +20,6 @@ DEPENDENCIES = [
 
 DEV_DEPENDENCIES = [
     # Keep sorted.
-    "//rs/consensus",
     "//rs/consensus/mocks",
     "//rs/test_utilities",
     "//rs/test_utilities/registry",

--- a/rs/consensus/utils/Cargo.toml
+++ b/rs/consensus/utils/Cargo.toml
@@ -22,7 +22,6 @@ slog = { workspace = true }
 
 [dev-dependencies]
 assert_matches = { workspace = true }
-ic-consensus = { path = "../" }
 ic-consensus-mocks = { path = "../mocks" }
 ic-management-canister-types = { path = "../../types/management_canister_types" }
 ic-test-utilities = { path = "../../test_utilities" }

--- a/rs/consensus/utils/src/lib.rs
+++ b/rs/consensus/utils/src/lib.rs
@@ -3,7 +3,6 @@ use crate::{crypto::Aggregate, membership::Membership, pool_reader::PoolReader};
 use ic_interfaces::{
     consensus::{PayloadValidationError, PayloadValidationFailure},
     consensus_pool::ConsensusPoolCache,
-    time_source::TimeSource,
     validation::ValidationError,
 };
 use ic_interfaces_registry::RegistryClient;
@@ -84,51 +83,6 @@ pub fn crypto_hashable_to_seed<T: CryptoHashable>(hashable: &T) -> [u8; 32] {
     let n = hash_bytes.len().min(32);
     seed[0..n].copy_from_slice(&hash_bytes[0..n]);
     seed
-}
-
-/// Calculate the required delay for block making based on the block maker's
-/// rank.
-pub fn get_block_maker_delay(
-    log: &ReplicaLogger,
-    registry_client: &dyn RegistryClient,
-    subnet_id: SubnetId,
-    registry_version: RegistryVersion,
-    rank: Rank,
-) -> Option<Duration> {
-    get_notarization_delay_settings(log, registry_client, subnet_id, registry_version)
-        .map(|settings| settings.unit_delay * rank.0 as u32)
-}
-
-/// Return true if the time since round start is greater than the required block
-/// maker delay for the given rank.
-pub fn is_time_to_make_block(
-    log: &ReplicaLogger,
-    registry_client: &dyn RegistryClient,
-    subnet_id: SubnetId,
-    pool: &PoolReader<'_>,
-    height: Height,
-    rank: Rank,
-    time_source: &dyn TimeSource,
-) -> bool {
-    let Some(registry_version) = pool.registry_version(height) else {
-        return false;
-    };
-    let Some(block_maker_delay) =
-        get_block_maker_delay(log, registry_client, subnet_id, registry_version, rank)
-    else {
-        return false;
-    };
-
-    // If the relative time indicates that not enough time has passed, we fall
-    // back to the the monotonic round start time. We do this to safeguard
-    // against a stalled relative clock.
-    pool.get_round_start_time(height)
-        .is_some_and(|start_time| time_source.get_relative_time() >= start_time + block_maker_delay)
-        || pool
-            .get_round_start_instant(height, time_source.get_origin_instant())
-            .is_some_and(|start_instant| {
-                time_source.get_instant() >= start_instant + block_maker_delay
-            })
 }
 
 /// Calculate the required delay for notary based on the rank of block to notarize,


### PR DESCRIPTION
The functions doesn't need to be shared across crates.

Also, removed unneeded dependencies