### PR TITLE
fix: Remove deprecated assert

### DIFF
--- a/rs/execution_environment/src/execution/response.rs
+++ b/rs/execution_environment/src/execution/response.rs
@@ -452,12 +452,6 @@ impl ResponseHelper {
                 round.counters.charging_from_balance_error,
             );
 
-        if let Some(state_changes) = &canister_state_changes {
-            let requested = state_changes.system_state_changes.removed_cycles();
-            // A cleanup callback cannot accept and send cycles.
-            assert_eq!(requested.get(), 0);
-        }
-
         apply_canister_state_changes(
             canister_state_changes,
             self.canister.execution_state.as_mut().unwrap(),


### PR DESCRIPTION
This assert checks that there are no cases where the cycles balance of a canister can be reduced during execution. However, since this assert [was introduced about 2 years ago](https://github.com/dfinity/ic/commit/1d4692fd686a31a7f396f2d949d67edcaedcbfea), new legitimate cases have been added, like when the storage reservation mechanism kicks in or the canister calls `cycles_burn` API, that can reduce the canister's cycle balance. The assert is therefore deprecated and should be removed.

It replicates the [change](https://github.com/dfinity/ic/commit/5d1beaca74d0bf2ad2e8a37809e1e3ffa5ee9a32) that has already been patched on all IC subnets as part of the security hotfix that was performed over the last couple of days.