### PR TITLE
test(ICRC_ledger): FI-1492: Set subnet configs in golden state tests to cover all canister IDs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10360,6 +10360,7 @@ version = "0.0.1"
 dependencies = [
  "ic-base-types",
  "ic-config",
+ "ic-registry-routing-table",
  "ic-registry-subnet-type",
  "ic-state-machine-tests",
  "ic-types",

--- a/rs/nns/test_utils/golden_nns_state/BUILD.bazel
+++ b/rs/nns/test_utils/golden_nns_state/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_rust//rust:defs.bzl", "rust_library")
+load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -38,5 +38,11 @@ rust_library(
     srcs = glob(["src/**"]),
     crate_name = "ic_nns_test_utils_golden_nns_state",
     version = "0.0.1",
+    deps = DEPENDENCIES,
+)
+
+rust_test(
+    name = "golden_nns_state_test",
+    crate = ":golden_nns_state",
     deps = DEPENDENCIES,
 )

--- a/rs/nns/test_utils/golden_nns_state/BUILD.bazel
+++ b/rs/nns/test_utils/golden_nns_state/BUILD.bazel
@@ -5,6 +5,7 @@ package(default_visibility = ["//visibility:public"])
 DEPENDENCIES = [
     # Keep sorted.
     "//rs/config",
+    "//rs/registry/routing_table",
     "//rs/registry/subnet_type",
     "//rs/state_machine_tests",
     "//rs/types/base_types",

--- a/rs/nns/test_utils/golden_nns_state/Cargo.toml
+++ b/rs/nns/test_utils/golden_nns_state/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [dependencies]
 ic-base-types = { path = "../../../types/base_types" }
 ic-config = { path = "../../../config" }
+ic-registry-routing-table = { path = "../../../registry/routing_table" }
 ic-registry-subnet-type = { path = "../../../registry/subnet_type" }
 ic-state-machine-tests = { path = "../../../state_machine_tests" }
 ic-types = { path = "../../../types/types" }

--- a/rs/nns/test_utils/golden_nns_state/src/lib.rs
+++ b/rs/nns/test_utils/golden_nns_state/src/lib.rs
@@ -24,8 +24,8 @@ pub fn new_state_machine_with_golden_fiduciary_state_or_panic() -> StateMachine 
     let setup_config = SetupConfig {
         archive_state_dir_name: "fiduciary_state",
         extra_canister_range: RangeInclusive::new(
-            CanisterId::from_u64(0x2300000),
-            CanisterId::from_u64(0x23FFFFE),
+            CanisterId::from_u64(0),
+            CanisterId::from_u64(u64::MAX),
         ),
         hypervisor_config: Some(Config {
             rate_limiting_of_instructions: FlagStatus::Disabled,
@@ -69,8 +69,8 @@ pub fn new_state_machine_with_golden_sns_state_or_panic() -> StateMachine {
     let setup_config = SetupConfig {
         archive_state_dir_name: "sns_state",
         extra_canister_range: RangeInclusive::new(
-            CanisterId::from_u64(0x2000000),
-            CanisterId::from_u64(0x20FFFFE),
+            CanisterId::from_u64(0),
+            CanisterId::from_u64(u64::MAX),
         ),
         hypervisor_config: Some(Config {
             rate_limiting_of_instructions: FlagStatus::Disabled,


### PR DESCRIPTION
Expand the canister ID ranges for the `StateMachine` app subnet in the golden state tests for the NNS, SNS, and fiduciary subnets to cover all possible canister IDs. This is to avoid scenarios where the tests may fail in case there are some messages to canisters on other subnets that cannot be routed.