### PR TITLE
feat: [MR-612] Callback expiration priority queue

### DIFF
--- a/rs/protobuf/def/state/canister_state_bits/v1/canister_state_bits.proto
+++ b/rs/protobuf/def/state/canister_state_bits/v1/canister_state_bits.proto
@@ -72,6 +72,7 @@ message CallContextManager {
   uint64 next_callback_id = 2;
   repeated CallContextEntry call_contexts = 3;
   repeated CallbackEntry callbacks = 4;
+  repeated uint64 unexpired_callbacks = 5;
 }
 
 message CyclesAccount {

--- a/rs/protobuf/src/gen/state/state.canister_state_bits.v1.rs
+++ b/rs/protobuf/src/gen/state/state.canister_state_bits.v1.rs
@@ -118,6 +118,8 @@ pub struct CallContextManager {
     pub call_contexts: ::prost::alloc::vec::Vec<CallContextEntry>,
     #[prost(message, repeated, tag = "4")]
     pub callbacks: ::prost::alloc::vec::Vec<CallbackEntry>,
+    #[prost(uint64, repeated, tag = "5")]
+    pub unexpired_callbacks: ::prost::alloc::vec::Vec<u64>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/rs/replicated_state/src/canister_state/system_state/call_context_manager.rs
+++ b/rs/replicated_state/src/canister_state/system_state/call_context_manager.rs
@@ -781,9 +781,8 @@ impl CallContextManager {
 
         self.stats.on_register_callback(&callback);
         if callback.deadline != NO_DEADLINE {
-            assert!(self
-                .unexpired_callbacks
-                .insert((callback.deadline, callback_id)));
+            self.unexpired_callbacks
+                .insert((callback.deadline, callback_id));
         }
 
         self.callbacks.insert(callback_id, Arc::new(callback));
@@ -816,9 +815,9 @@ impl CallContextManager {
         &mut self,
         now: CoarseTime,
     ) -> impl Iterator<Item = CallbackId> {
-        let mut expired_callbacks = self
-            .unexpired_callbacks
-            .split_off(&(now, CallbackId::from(0)));
+        const MIN_CALLBACK_ID: CallbackId = CallbackId::new(0);
+
+        let mut expired_callbacks = self.unexpired_callbacks.split_off(&(now, MIN_CALLBACK_ID));
         std::mem::swap(&mut self.unexpired_callbacks, &mut expired_callbacks);
         expired_callbacks
             .into_iter()

--- a/rs/replicated_state/src/canister_state/system_state/call_context_manager.rs
+++ b/rs/replicated_state/src/canister_state/system_state/call_context_manager.rs
@@ -20,7 +20,7 @@ use ic_types::{
 };
 use serde::{Deserialize, Serialize};
 use std::collections::btree_map::Entry;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::convert::{From, TryFrom, TryInto};
 use std::sync::Arc;
 use std::time::Duration;
@@ -276,7 +276,7 @@ impl CallContextManagerStats {
 
     /// Calculates the stats for the given call contexts and callbacks.
     ///
-    /// Time complexity: `O(N)`.
+    /// Time complexity: `O(n)`.
     pub(crate) fn calculate_stats(
         call_contexts: &BTreeMap<CallContextId, CallContext>,
         callbacks: &BTreeMap<CallbackId, Arc<Callback>>,
@@ -318,7 +318,7 @@ impl CallContextManagerStats {
     /// corresponding to a potential paused or aborted canister response execution
     /// (since this response was just delivered).
     ///
-    /// Time complexity: `O(N)`.
+    /// Time complexity: `O(n)`.
     #[allow(dead_code)]
     pub(crate) fn calculate_unresponded_callbacks_per_respondent(
         callbacks: &BTreeMap<CallbackId, Arc<Callback>>,
@@ -363,7 +363,7 @@ impl CallContextManagerStats {
     /// This is the count of unresponded call contexts per originator; potentially
     /// plus one for a paused or aborted canister request execution, if any.
     ///
-    /// Time complexity: `O(N)`.
+    /// Time complexity: `O(n)`.
     #[allow(dead_code)]
     pub(crate) fn calculate_unresponded_call_contexts_per_originator(
         call_contexts: &BTreeMap<CallContextId, CallContext>,
@@ -422,6 +422,14 @@ pub struct CallContextManager {
     /// Callbacks still awaiting response, plus the callback of the currently
     /// paused or aborted DTS response execution, if any.
     callbacks: BTreeMap<CallbackId, Arc<Callback>>,
+
+    /// Callback deadline priority queue. Holds all not-yet-expired best-effort
+    /// callbacks, ordered by deadline. `CallbackIds` break ties, ensuring
+    /// deterministic ordering.
+    ///
+    /// When a `CallbackId` is returned by `expired_callbacks()`, it is removed from
+    /// the queue. This ensures that each callback is expired at most once.
+    unexpired_callbacks: BTreeSet<(CoarseTime, CallbackId)>,
 
     /// Guaranteed response and overall callback and call context stats.
     stats: CallContextManagerStats,
@@ -768,12 +776,17 @@ impl CallContextManager {
 
     /// Registers a callback for an outgoing call.
     pub fn register_callback(&mut self, callback: Callback) -> CallbackId {
-        self.stats.on_register_callback(&callback);
-
         self.next_callback_id += 1;
         let callback_id = CallbackId::from(self.next_callback_id);
-        self.callbacks.insert(callback_id, Arc::new(callback));
 
+        self.stats.on_register_callback(&callback);
+        if callback.deadline != NO_DEADLINE {
+            assert!(self
+                .unexpired_callbacks
+                .insert((callback.deadline, callback_id)));
+        }
+
+        self.callbacks.insert(callback_id, Arc::new(callback));
         debug_assert!(self.stats_ok());
 
         callback_id
@@ -784,10 +797,32 @@ impl CallContextManager {
     pub fn unregister_callback(&mut self, callback_id: CallbackId) -> Option<Arc<Callback>> {
         self.callbacks.remove(&callback_id).map(|callback| {
             self.stats.on_unregister_callback(&callback);
+            if callback.deadline != NO_DEADLINE {
+                self.unexpired_callbacks
+                    .remove(&(callback.deadline, callback_id));
+            }
             debug_assert!(self.stats_ok());
 
             callback
         })
+    }
+
+    /// Returns the IDs of all best-effort callbacks whose deadlines have expired
+    /// since the previous call to this method, given the current time.
+    ///
+    /// Note: A given callback will be returned at most once by this function.
+    #[allow(dead_code)]
+    pub(super) fn expired_callbacks(
+        &mut self,
+        now: CoarseTime,
+    ) -> impl Iterator<Item = CallbackId> {
+        let mut expired_callbacks = self
+            .unexpired_callbacks
+            .split_off(&(now, CallbackId::from(0)));
+        std::mem::swap(&mut self.unexpired_callbacks, &mut expired_callbacks);
+        expired_callbacks
+            .into_iter()
+            .map(|(_, callback_id)| callback_id)
     }
 
     /// Returns the call origin, which is either the message ID of the ingress
@@ -909,11 +944,20 @@ impl CallContextManager {
     /// Helper function to concisely validate stats adjustments in debug builds,
     /// by writing `debug_assert!(self.stats_ok())`.
     ///
-    /// Time complexity: `O(N)`.
+    /// Time complexity: `O(n * log(n))`.
     fn stats_ok(&self) -> bool {
         debug_assert_eq!(
             CallContextManagerStats::calculate_stats(&self.call_contexts, &self.callbacks),
             self.stats
+        );
+        // The best we can do here is to check that the set of unexpired_callbacks is a
+        // subset of all best-effort callbacks.
+        let all_callback_deadlines = calculate_callback_deadlines(&self.callbacks);
+        debug_assert!(
+            all_callback_deadlines.is_superset(&self.unexpired_callbacks),
+            "unexpired_callbacks: {:?}, all_callback_deadlines: {:?}",
+            self.unexpired_callbacks,
+            all_callback_deadlines
         );
         true
     }
@@ -964,6 +1008,11 @@ impl From<&CallContextManager> for pb::CallContextManager {
                     callback: Some(callback.as_ref().into()),
                 })
                 .collect(),
+            unexpired_callbacks: item
+                .unexpired_callbacks
+                .iter()
+                .map(|(_, id)| id.get())
+                .collect(),
         }
     }
 }
@@ -996,14 +1045,45 @@ impl TryFrom<pb::CallContextManager> for CallContextManager {
                 )?),
             );
         }
+        let unexpired_callbacks = value
+            .unexpired_callbacks
+            .into_iter()
+            .map(CallbackId::from)
+            .map(|callback_id| {
+                let callback = callbacks.get(&callback_id).ok_or_else(|| {
+                    ProxyDecodeError::Other(format!(
+                        "Unexpired callback not found: {}",
+                        callback_id
+                    ))
+                })?;
+                Ok((callback.deadline, callback_id))
+            })
+            .collect::<Result<_, ProxyDecodeError>>()?;
         let stats = CallContextManagerStats::calculate_stats(&call_contexts, &callbacks);
 
-        Ok(Self {
+        let ccm = Self {
             next_call_context_id: value.next_call_context_id,
             next_callback_id: value.next_callback_id,
             call_contexts,
             callbacks,
+            unexpired_callbacks,
             stats,
-        })
+        };
+        debug_assert!(ccm.stats_ok());
+
+        Ok(ccm)
     }
+}
+
+/// Calculates the deadlines of all best-effort callbacks.
+///
+/// Time complexity: `O(n)`.
+fn calculate_callback_deadlines(
+    callbacks: &BTreeMap<CallbackId, Arc<Callback>>,
+) -> BTreeSet<(CoarseTime, CallbackId)> {
+    callbacks
+        .iter()
+        .map(|(id, callback)| (callback.deadline, *id))
+        .filter(|(deadline, _)| *deadline != NO_DEADLINE)
+        .collect()
 }

--- a/rs/replicated_state/src/canister_state/system_state/call_context_manager.rs
+++ b/rs/replicated_state/src/canister_state/system_state/call_context_manager.rs
@@ -276,7 +276,7 @@ impl CallContextManagerStats {
 
     /// Calculates the stats for the given call contexts and callbacks.
     ///
-    /// Time complexity: `O(n)`.
+    /// Time complexity: `O(|call_contexts| + |callbacks|)`.
     pub(crate) fn calculate_stats(
         call_contexts: &BTreeMap<CallContextId, CallContext>,
         callbacks: &BTreeMap<CallbackId, Arc<Callback>>,
@@ -284,9 +284,11 @@ impl CallContextManagerStats {
         let unresponded_canister_update_call_contexts = call_contexts
             .values()
             .filter(|call_context| !call_context.responded)
-            .filter_map(|call_context| match call_context.call_origin {
-                CallOrigin::CanisterUpdate(originator, _, _) => Some(originator),
-                _ => None,
+            .filter(|call_context| {
+                matches!(
+                    call_context.call_origin,
+                    CallOrigin::CanisterUpdate(_, _, _)
+                )
             })
             .count();
         let unresponded_guaranteed_response_call_contexts = call_contexts

--- a/rs/replicated_state/src/canister_state/system_state/call_context_manager/tests.rs
+++ b/rs/replicated_state/src/canister_state/system_state/call_context_manager/tests.rs
@@ -497,7 +497,7 @@ fn callback_stats() {
 }
 
 #[test]
-fn test_expired_callbacks() {
+fn test_expire_callbacks() {
     fn callback_with_deadline(deadline: CoarseTime) -> Callback {
         Callback::new(
             CallContextId::from(1),

--- a/rs/replicated_state/src/canister_state/system_state/call_context_manager/tests.rs
+++ b/rs/replicated_state/src/canister_state/system_state/call_context_manager/tests.rs
@@ -529,17 +529,17 @@ fn test_expired_callbacks() {
     assert_eq!(5, ccm.callbacks().len());
 
     // No callbacks expire at deadline 1.
-    assert_eq!(0, ccm.expired_callbacks(deadline_1).count());
+    assert_eq!(0, ccm.expire_callbacks(deadline_1).count());
 
     // Expire all callbacks with deadlines before 3.
     assert_eq!(
         vec![callback_1, callback_1b],
-        ccm.expired_callbacks(deadline_3).collect::<Vec<_>>()
+        ccm.expire_callbacks(deadline_3).collect::<Vec<_>>()
     );
     // The callbacks are still in place, expiration doesn't actually touch them.
     assert_eq!(5, ccm.callbacks().len());
     // And making the same call is a no-op.
-    assert_eq!(0, ccm.expired_callbacks(deadline_3).count());
+    assert_eq!(0, ccm.expire_callbacks(deadline_3).count());
 
     // Unregister one of the expired callbacks.
     ccm.unregister_callback(callback_1);
@@ -556,7 +556,7 @@ fn test_expired_callbacks() {
     // 2; in order of their expiration times).
     assert_eq!(
         vec![callback_2, callback_4],
-        ccm.expired_callbacks(deadline_5).collect::<Vec<_>>()
+        ccm.expire_callbacks(deadline_5).collect::<Vec<_>>()
     );
     // 3 + 1 callbacks left.
     assert_eq!(4, ccm.callbacks().len());
@@ -783,7 +783,7 @@ fn roundtrip_encode() {
     // Expire the first callback.
     assert_eq!(
         vec![callback_1],
-        ccm.expired_callbacks(deadline_2).collect::<Vec<_>>()
+        ccm.expire_callbacks(deadline_2).collect::<Vec<_>>()
     );
 
     let encoded: pb::CallContextManager = (&ccm).into();


### PR DESCRIPTION
[MR-612] Implement a priority queue of best-effort callback expiration times in `CallContextManager`; a function that returns newly expired callbacks; and persistence for this queue.

[MR-612]: https://dfinity.atlassian.net/browse/MR-612?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ