### PR TITLE
feat: RUN-1036: Validate initial wasm memory size for Wasm64

### DIFF
--- a/rs/embedders/src/wasm_utils/instrumentation.rs
+++ b/rs/embedders/src/wasm_utils/instrumentation.rs
@@ -1982,6 +1982,10 @@ fn update_memories(
         if mem.memory64 {
             let max_wasm_memory_size_in_wasm_pages =
                 max_memory_size_in_wasm_pages(max_wasm_memory_size);
+            // Cap the initial memory size to the maximum allowed in case it's larger.
+            if mem.initial > max_wasm_memory_size_in_wasm_pages {
+                mem.initial = max_wasm_memory_size_in_wasm_pages;
+            }
             match mem.maximum {
                 Some(max) => {
                     // In case the maximum memory size is larger than the maximum allowed, cap it.

--- a/rs/embedders/src/wasm_utils/instrumentation.rs
+++ b/rs/embedders/src/wasm_utils/instrumentation.rs
@@ -1982,10 +1982,6 @@ fn update_memories(
         if mem.memory64 {
             let max_wasm_memory_size_in_wasm_pages =
                 max_memory_size_in_wasm_pages(max_wasm_memory_size);
-            // Cap the initial memory size to the maximum allowed in case it's larger.
-            if mem.initial > max_wasm_memory_size_in_wasm_pages {
-                mem.initial = max_wasm_memory_size_in_wasm_pages;
-            }
             match mem.maximum {
                 Some(max) => {
                     // In case the maximum memory size is larger than the maximum allowed, cap it.

--- a/rs/embedders/src/wasm_utils/validation.rs
+++ b/rs/embedders/src/wasm_utils/validation.rs
@@ -1057,7 +1057,7 @@ fn validate_initial_wasm_memory_size(
     module: &Module,
     max_wasm_memory_size_in_bytes: NumBytes,
 ) -> Result<(), WasmValidationError> {
-    if let Some(memory) = module.memories.first() {
+    for memory in &module.memories {
         if memory.memory64 {
             let declared_size_in_wasm_pages = memory.initial;
             let allowed_size_in_wasm_pages =

--- a/rs/types/wasm_types/src/errors.rs
+++ b/rs/types/wasm_types/src/errors.rs
@@ -99,6 +99,11 @@ pub enum WasmValidationError {
     CodeSectionTooLarge { size: u32, allowed: u32 },
     /// The total module size is too large.
     ModuleTooLarge { size: u64, allowed: u64 },
+    // The initial Wasm64 heap memory is too large.
+    InitialWasm64MemoryTooLarge {
+        declared_size: u64,
+        allowed_size: u64,
+    },
 }
 
 impl std::fmt::Display for WasmValidationError {
@@ -204,6 +209,14 @@ impl std::fmt::Display for WasmValidationError {
                 "Wasm module size of {size} exceeds the maximum \
                     allowed size of {allowed}.",
             ),
+            Self::InitialWasm64MemoryTooLarge {
+                declared_size,
+                allowed_size,
+            } => write!(
+                f,
+                "Wasm module declares an initial Wasm64 heap memory size of {declared_size} pages \
+                    which exceeds the maximum allowed size of {allowed_size} pages.",
+            ),
         }
     }
 }
@@ -269,6 +282,10 @@ impl AsErrorHelp for WasmValidationError {
                 `ic-wasm` or splitting the logic across multiple canisters."
                     .to_string(),
                 doc_link: doc_ref("wasm-module-too-large"),
+            },
+            WasmValidationError::InitialWasm64MemoryTooLarge { .. } => ErrorHelp::UserError {
+                suggestion: "Try reducing the initial Wasm64 heap memory size.".to_string(),
+                doc_link: doc_ref("wasm-module-initial-wasm64-memory-too-large"),
             },
         }
     }


### PR DESCRIPTION
In this PR we add an additional validation step for the initial size for Wasm64 memories. The size of initial wasm heap memory should not be more than the protocol allows.