### PR TITLE
chore(sns): migrate wasm_memory_limit in non-governance non-root canisters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11712,6 +11712,7 @@ dependencies = [
  "ic-nervous-system-common-build-metadata",
  "ic-nervous-system-root",
  "ic-nervous-system-runtime",
+ "ic-nns-constants",
  "ic-sns-root-protobuf-generator",
  "ic-sns-swap",
  "ic-test-utilities-compare-dirs",

--- a/rs/sns/root/BUILD.bazel
+++ b/rs/sns/root/BUILD.bazel
@@ -17,6 +17,7 @@ DEPENDENCIES = [
     "//rs/nervous_system/common",
     "//rs/nervous_system/root",
     "//rs/nervous_system/runtime",
+    "//rs/nns/constants",
     "//rs/rust_canisters/canister_log",
     "//rs/rust_canisters/http_types",
     "//rs/sns/swap",  # TODO[NNS1-2282]

--- a/rs/sns/root/Cargo.toml
+++ b/rs/sns/root/Cargo.toml
@@ -31,6 +31,7 @@ ic-nervous-system-common = { path = "../../nervous_system/common" }
 ic-nervous-system-common-build-metadata = { path = "../../nervous_system/common/build_metadata" }
 ic-nervous-system-root = { path = "../../nervous_system/root" }
 ic-nervous-system-runtime = { path = "../../nervous_system/runtime" }
+ic-nns-constants = { path = "../../nns/constants" }
 ic-sns-swap = { path = "../swap" }
 icrc-ledger-types = { path = "../../../packages/icrc-ledger-types" }
 prost = { workspace = true }

--- a/rs/sns/root/canister/canister.rs
+++ b/rs/sns/root/canister/canister.rs
@@ -138,6 +138,16 @@ fn canister_post_upgrade() {
     );
     canister_init(state);
 
+    // Kick off migration one minute after upgrade
+    let duration = Duration::from_secs(60);
+    ic_cdk_timers::set_timer(duration, || {
+        ic_cdk::spawn(async {
+            let management_canister_client =
+                ManagementCanisterClientImpl::<CanisterRuntime>::new(None);
+            SnsRootCanister::migrate_canister_settings(&STATE, &management_canister_client).await;
+        })
+    });
+
     log!(INFO, "canister_post_upgrade: Done!");
 }
 

--- a/rs/sns/root/src/lib.rs
+++ b/rs/sns/root/src/lib.rs
@@ -20,6 +20,7 @@ use ic_nervous_system_clients::{
     update_settings::{CanisterSettings, LogVisibility, UpdateSettings},
 };
 use ic_nervous_system_runtime::{CdkRuntime, Runtime};
+use ic_nns_constants::DEFAULT_SNS_NON_GOVERNANCE_CANISTER_WASM_MEMORY_LIMIT;
 use ic_sns_swap::pb::v1::GetCanisterStatusRequest;
 use std::{
     cell::RefCell,
@@ -762,6 +763,48 @@ impl SnsRootCanister {
         });
 
         defects.join("\n")
+    }
+
+    pub async fn migrate_canister_settings(
+        self_ref: &'static LocalKey<RefCell<Self>>,
+        management_canister_client: &impl ManagementCanisterClient,
+    ) {
+        let swap_canister_id = self_ref.with(|state| state.borrow().swap_canister_id);
+        let ledger_canister_id = self_ref.with(|state| state.borrow().ledger_canister_id);
+        let index_canister_id = self_ref.with(|state| state.borrow().index_canister_id);
+        let archive_canister_ids =
+            self_ref.with(|state| state.borrow().archive_canister_ids.clone());
+
+        for canister_id in [swap_canister_id, ledger_canister_id, index_canister_id]
+            .into_iter()
+            .flatten()
+            .chain(archive_canister_ids.into_iter())
+        {
+            let settings = CanisterSettings {
+                wasm_memory_limit: Some(candid::Nat::from(
+                    DEFAULT_SNS_NON_GOVERNANCE_CANISTER_WASM_MEMORY_LIMIT,
+                )),
+                ..Default::default()
+            };
+            let result = management_canister_client
+                .update_settings(UpdateSettings {
+                    canister_id,
+                    settings,
+                    sender_canister_version: management_canister_client.canister_version(),
+                })
+                .await;
+            match result {
+                Ok(_) => (),
+                Err(err) => {
+                    log!(
+                        ERROR,
+                        "Unable to update settings for canister {}: {:?}",
+                        canister_id,
+                        err
+                    );
+                }
+            }
+        }
     }
 }
 
@@ -3353,6 +3396,92 @@ mod tests {
             MockManagementCanisterClientCall::CanisterStatus(CanisterIdRecord {
                 canister_id: CanisterId::try_from(expected_archive_canisters_principal_ids[1])
                     .unwrap(),
+            }),
+        ];
+        assert_eq!(
+            actual_management_canister_calls,
+            expected_management_canister_calls
+        );
+    }
+
+    #[tokio::test]
+    async fn test_migrate_canister_settings() {
+        // Step 1: Prepare the world.
+        thread_local! {
+            static STATE: RefCell<SnsRootCanister> = RefCell::new(SnsRootCanister {
+                governance_canister_id: Some(PrincipalId::new_user_test_id(99)),
+                swap_canister_id: Some(PrincipalId::new_user_test_id(0)),
+                ledger_canister_id: Some(PrincipalId::new_user_test_id(1)),
+                index_canister_id: Some(PrincipalId::new_user_test_id(2)),
+                dapp_canister_ids: vec![],
+                archive_canister_ids: vec![PrincipalId::new_user_test_id(3), PrincipalId::new_user_test_id(4), PrincipalId::new_user_test_id(5)],
+                ..Default::default()
+            });
+        }
+
+        // Step 1.1: Prepare helpers.
+        let management_canister_client = MockManagementCanisterClient::new(vec![
+            MockManagementCanisterClientReply::UpdateSettings(Ok(())),
+            MockManagementCanisterClientReply::UpdateSettings(Ok(())),
+            MockManagementCanisterClientReply::UpdateSettings(Ok(())),
+            MockManagementCanisterClientReply::UpdateSettings(Ok(())),
+            MockManagementCanisterClientReply::UpdateSettings(Ok(())),
+            MockManagementCanisterClientReply::UpdateSettings(Ok(())),
+        ]);
+
+        // Step 2: Run code under test.
+        SnsRootCanister::migrate_canister_settings(&STATE, &management_canister_client).await;
+
+        // Step 3: Inspect results.
+        let actual_management_canister_calls = management_canister_client.get_calls_snapshot();
+        let expected_management_canister_calls = vec![
+            MockManagementCanisterClientCall::UpdateSettings(UpdateSettings {
+                canister_id: PrincipalId::new_user_test_id(0),
+                settings: CanisterSettings {
+                    wasm_memory_limit: Some(candid::Nat::from(3_u32 * (1_u32 << 30_u32))),
+                    ..Default::default()
+                },
+                sender_canister_version: None,
+            }),
+            MockManagementCanisterClientCall::UpdateSettings(UpdateSettings {
+                canister_id: PrincipalId::new_user_test_id(1),
+                settings: CanisterSettings {
+                    wasm_memory_limit: Some(candid::Nat::from(3_u32 * (1_u32 << 30_u32))),
+                    ..Default::default()
+                },
+                sender_canister_version: None,
+            }),
+            MockManagementCanisterClientCall::UpdateSettings(UpdateSettings {
+                canister_id: PrincipalId::new_user_test_id(2),
+                settings: CanisterSettings {
+                    wasm_memory_limit: Some(candid::Nat::from(3_u32 * (1_u32 << 30_u32))),
+                    ..Default::default()
+                },
+                sender_canister_version: None,
+            }),
+            MockManagementCanisterClientCall::UpdateSettings(UpdateSettings {
+                canister_id: PrincipalId::new_user_test_id(3),
+                settings: CanisterSettings {
+                    wasm_memory_limit: Some(candid::Nat::from(3_u32 * (1_u32 << 30_u32))),
+                    ..Default::default()
+                },
+                sender_canister_version: None,
+            }),
+            MockManagementCanisterClientCall::UpdateSettings(UpdateSettings {
+                canister_id: PrincipalId::new_user_test_id(4),
+                settings: CanisterSettings {
+                    wasm_memory_limit: Some(candid::Nat::from(3_u32 * (1_u32 << 30_u32))),
+                    ..Default::default()
+                },
+                sender_canister_version: None,
+            }),
+            MockManagementCanisterClientCall::UpdateSettings(UpdateSettings {
+                canister_id: PrincipalId::new_user_test_id(5),
+                settings: CanisterSettings {
+                    wasm_memory_limit: Some(candid::Nat::from(3_u32 * (1_u32 << 30_u32))),
+                    ..Default::default()
+                },
+                sender_canister_version: None,
             }),
         ];
         assert_eq!(


### PR DESCRIPTION
All the non-governance and non-root SNS canisters should have their `wasm_memory_limit` set to 3GiB via a root migration. (#1521 took care of this for root via a governance migration.) 

Once this PR is merged and released, all SNS canisters will have the same `wasm_memory_limit` - 4GiB for SNS Governance, 3GiB for all other canisters. I've already verified with the FI team that 3GiB is safe to use with all 3 FI canisters.

Closes [NNS1-3301](https://dfinity.atlassian.net/browse/NNS1-3301)

[NNS1-3301]: https://dfinity.atlassian.net/browse/NNS1-3301?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ