### PR TITLE
chore: Pass argument to clamp_debug_len by reference

### DIFF
--- a/rs/nervous_system/string/src/lib.rs
+++ b/rs/nervous_system/string/src/lib.rs
@@ -22,7 +22,7 @@ pub fn clamp_string_len(s: &str, max_len: usize) -> String {
     format!("{}...{}", &s[0..head_len], &s[tail_begin..s.len()])
 }
 
-pub fn clamp_debug_len(object: impl Debug, max_len: usize) -> String {
+pub fn clamp_debug_len(object: &impl Debug, max_len: usize) -> String {
     clamp_string_len(&format!("{:#?}", object), max_len)
 }
 

--- a/rs/nervous_system/string/src/tests.rs
+++ b/rs/nervous_system/string/src/tests.rs
@@ -25,5 +25,5 @@ fn test_clamp_debug_len() {
         i: i32,
     }
 
-    assert_eq!(&clamp_debug_len(S { i: 42 }, 100), "S {\n    i: 42,\n}");
+    assert_eq!(&clamp_debug_len(&S { i: 42 }, 100), "S {\n    i: 42,\n}");
 }

--- a/rs/sns/governance/token_valuation/src/lib.rs
+++ b/rs/sns/governance/token_valuation/src/lib.rs
@@ -358,7 +358,7 @@ impl<MyRuntime: Runtime + Send + Sync> IcpsPerSnsTokenClient<MyRuntime> {
                     "Unable to determine ICPs per SNS token, because calling swap canister \
                      {} failed. Request:\n{}\nerr: {:?}",
                     self.swap_canister_id,
-                    clamp_debug_len(request, /* max_len = */ 100),
+                    clamp_debug_len(&request, /* max_len = */ 100),
                     err,
                 ))
             })


### PR DESCRIPTION
While trying to use `clamp_debug_len` to reduce log spam, I noticed that the argument was being moved.
The solution is to pass the argument by reference.