### PR TITLE
chore: EXC: Minor change to instruction benchmarks

### DIFF
--- a/rs/execution_environment/benches/lib/src/wat_builder.rs
+++ b/rs/execution_environment/benches/lib/src/wat_builder.rs
@@ -73,11 +73,11 @@ impl Block {
     }
 
     /// Define variables and functions used in the `code` snippet.
-    pub fn define_variables_and_functions(mut self, code: &str, wasm64_enabled: Wasm64) -> Self {
+    pub fn define_variables_and_functions(mut self, code: &str) -> Self {
         for name in ["x", "y", "z", "zero", "address", "one"] {
             for ty in ["i32", "i64", "f32", "f64", "v128"] {
                 if code.contains(&format!("${name}_{ty}")) {
-                    self.declare_variable(name, ty, wasm64_enabled);
+                    self.declare_variable(name, ty);
                 }
             }
         }
@@ -99,8 +99,8 @@ impl Block {
     }
 
     /// Declare a `black_box` variable with specified `name` and `type`.
-    pub fn declare_variable(&mut self, name: &str, ty: &str, wasm64_enabled: Wasm64) -> &mut Self {
-        let memory_var_address = if wasm64_enabled == Wasm64::Enabled {
+    pub fn declare_variable(&mut self, name: &str, ty: &str) -> &mut Self {
+        let memory_var_address = if ty == "i64" {
             // The address should be somewhere beyond 4 GiB.
             // This is 5 GB.
             "5368709120"

--- a/rs/execution_environment/benches/wasm_instructions/helper.rs
+++ b/rs/execution_environment/benches/wasm_instructions/helper.rs
@@ -72,7 +72,7 @@ pub fn benchmark(name: &str, i: usize, r: usize, repeat_code: &str) -> common::B
         Block::default()
             .repeat_n(r, &repeat_code)
             .loop_n(i)
-            .define_variables_and_functions(&repeat_code, wasm64_enabled)
+            .define_variables_and_functions(&repeat_code)
             .into_update_func()
             .into_test_module_wat(wasm64_enabled),
         (i * r) as u64,


### PR DESCRIPTION
This PR simplifies the instruction benchmarks for Wasm64.