### PR TITLE
fix: //rs/tests/cross_chain:ic_xc_ledger_suite_orchestrator_test

### DIFF
--- a/rs/tests/src/cross_chain/ic_xc_ledger_suite_orchestrator_test.rs
+++ b/rs/tests/src/cross_chain/ic_xc_ledger_suite_orchestrator_test.rs
@@ -222,7 +222,7 @@ async fn install_nns_controlled_canister<'a>(
         governance_canister,
         Sender::from_keypair(&TEST_NEURON_1_OWNER_KEYPAIR),
         NeuronId(TEST_NEURON_1_ID),
-        NnsFunction::NnsCanisterUpgrade,
+        NnsFunction::NnsCanisterInstall,
         proposal_payload,
         "Install Canister".to_string(),
         "<proposal created by install_nns_controlled_canister>".to_string(),


### PR DESCRIPTION
https://github.com/dfinity/ic/pull/1496 broke the `//rs/tests/cross_chain:ic_xc_ledger_suite_orchestrator_test`. See [a recent run of "Bazel System Test Nightly"](https://github.com/dfinity/ic/actions/runs/10913919574/job/30303329131).

When proposing to upgrade an NNS canister the governance canister returns the error:

> The maximum NNS function payload size in a proposal action is 70000 bytes, this payload is: 1556894 bytes

This is because `can_have_large_payload()` used to return `true` when `NnsFunction::NnsCanisterUpgrade` was used as the `NnsFunction` but this was [changed in #1496](https://github.com/dfinity/ic/pull/1496/files#diff-98b58f03b1cbc116d2def85c2e6a81c4be8cda5e6f3cc994f0177db15d62c85eL418).

The fix is to use `NnsFunction::NnsCanisterInstall` rather than `NnsFunction::NnsCanisterUpgrade`.