### PR TITLE
feat(proposal-cli): Automatically compute SHA256 of arguments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9364,6 +9364,7 @@ dependencies = [
  "reqwest 0.12.7",
  "serde",
  "serde_json",
+ "sha2 0.10.8",
  "strum",
  "strum_macros",
  "tempfile",

--- a/rs/cross-chain/proposal-cli/BUILD.bazel
+++ b/rs/cross-chain/proposal-cli/BUILD.bazel
@@ -10,6 +10,7 @@ DEPENDENCIES = [
     "@crate_index//:reqwest",
     "@crate_index//:serde",
     "@crate_index//:serde_json",
+    "@crate_index//:sha2",
     "@crate_index//:strum",
     "@crate_index//:tempfile",
     "@crate_index//:tokio",

--- a/rs/cross-chain/proposal-cli/Cargo.toml
+++ b/rs/cross-chain/proposal-cli/Cargo.toml
@@ -15,6 +15,7 @@ hex = { workspace = true }
 reqwest = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+sha2 = { workspace = true }
 strum = { workspace = true }
 strum_macros = { workspace = true }
 tempfile = { workspace = true }

--- a/rs/cross-chain/proposal-cli/src/candid/mod.rs
+++ b/rs/cross-chain/proposal-cli/src/candid/mod.rs
@@ -1,6 +1,7 @@
 #[cfg(test)]
 mod tests;
 
+use crate::git::ArgsHash;
 use candid::types::{Type, TypeInner};
 use candid::TypeEnv;
 use std::path::Path;
@@ -12,6 +13,7 @@ pub struct UpgradeArgs {
     constructor_types: Vec<Type>,
     upgrade_args: String,
     encoded_upgrade_args: Vec<u8>,
+    args_sha256: ArgsHash,
     candid_file_name: String,
 }
 
@@ -49,6 +51,7 @@ pub fn encode_upgrade_args<F: Into<String>>(candid_file: &Path, upgrade_args: F)
         .expect("fail to parse upgrade args")
         .to_bytes_with_types(&env, &upgrade_types)
         .expect("failed to encode");
+    let args_sha256 = ArgsHash::sha256(&encoded_upgrade_args);
     let candid_file_name = candid_file
         .file_name()
         .expect("missing file name")
@@ -58,6 +61,7 @@ pub fn encode_upgrade_args<F: Into<String>>(candid_file: &Path, upgrade_args: F)
         constructor_types: upgrade_types,
         upgrade_args,
         encoded_upgrade_args,
+        args_sha256,
         candid_file_name,
     }
 }

--- a/rs/cross-chain/proposal-cli/src/candid/mod.rs
+++ b/rs/cross-chain/proposal-cli/src/candid/mod.rs
@@ -26,6 +26,10 @@ impl UpgradeArgs {
         hex::encode(&self.encoded_upgrade_args)
     }
 
+    pub fn args_sha256_hex(&self) -> String {
+        self.args_sha256.to_string()
+    }
+
     pub fn didc_encode_cmd(&self) -> String {
         if self.upgrade_args != EMPTY_UPGRADE_ARGS {
             format!(

--- a/rs/cross-chain/proposal-cli/src/git/mod.rs
+++ b/rs/cross-chain/proposal-cli/src/git/mod.rs
@@ -37,8 +37,18 @@ impl<const N: usize> Display for Hash<N> {
     }
 }
 
+impl Hash<32> {
+    pub fn sha256(data: &[u8]) -> Self {
+        use sha2::Digest;
+        let mut hasher = sha2::Sha256::new();
+        hasher.update(data);
+        Self(hasher.finalize().into())
+    }
+}
+
 pub type GitCommitHash = Hash<20>;
 pub type CompressedWasmHash = Hash<32>;
+pub type ArgsHash = Hash<32>;
 
 #[derive(Debug)]
 pub struct GitRepository {

--- a/rs/cross-chain/proposal-cli/src/ic_admin/mod.rs
+++ b/rs/cross-chain/proposal-cli/src/ic_admin/mod.rs
@@ -62,6 +62,7 @@ impl IcAdminArgs {
             wasm_module_path: generated_files.wasm.to_string_lossy().to_string(),
             wasm_module_sha256: proposal.compressed_wasm_hash().clone(),
             arg: generated_files.arg.to_string_lossy().to_string(),
+            arg_sha256: proposal.args_sha256_hex(),
             summary_file: generated_files.summary.to_string_lossy().to_string(),
         }
         .render()
@@ -110,6 +111,9 @@ pub struct IcAdminTemplate {
     /// The path to a binary file containing the initialization or upgrade args of the
     /// canister.
     pub arg: String,
+
+    /// The sha256 of the arg binary file.
+    pub arg_sha256: String,
 
     /// A file containing a human-readable summary of the proposal content.
     pub summary_file: String,

--- a/rs/cross-chain/proposal-cli/src/ic_admin/tests.rs
+++ b/rs/cross-chain/proposal-cli/src/ic_admin/tests.rs
@@ -95,6 +95,7 @@ fn ic_admin_template() -> IcAdminTemplate {
             .parse()
             .unwrap(),
         arg: "arg".to_string(),
+        arg_sha256: "1111111111111111111111111111111111111111111111111111111111111111".to_string(),
         summary_file: "summary.md".to_string(),
     }
 }

--- a/rs/cross-chain/proposal-cli/src/proposal/mod.rs
+++ b/rs/cross-chain/proposal-cli/src/proposal/mod.rs
@@ -61,6 +61,13 @@ impl ProposalTemplate {
             .expect("failed to write hex args");
     }
 
+    pub fn args_sha256_hex(&self) -> String {
+        match self {
+            ProposalTemplate::Upgrade(template) => template.upgrade_args.args_sha256_hex(),
+            ProposalTemplate::Install(template) => template.install_args.args_sha256_hex(),
+        }
+    }
+
     pub fn render(&self) -> String {
         match self {
             ProposalTemplate::Upgrade(template) => template.render(),

--- a/rs/cross-chain/proposal-cli/templates/submit_with_ic_admin.shx
+++ b/rs/cross-chain/proposal-cli/templates/submit_with_ic_admin.shx
@@ -29,4 +29,5 @@ ic-admin \
     --wasm-module-path "{{wasm_module_path}}" \
     --wasm-module-sha256 {{wasm_module_sha256}} \
     --arg "{{arg}}" \
+    --arg-sha256 "{{arg_sha256}}" \
     --summary-file "{{summary_file}}"

--- a/rs/cross-chain/proposal-cli/templates/submit_with_ic_admin.shx
+++ b/rs/cross-chain/proposal-cli/templates/submit_with_ic_admin.shx
@@ -29,5 +29,5 @@ ic-admin \
     --wasm-module-path "{{wasm_module_path}}" \
     --wasm-module-sha256 {{wasm_module_sha256}} \
     --arg "{{arg}}" \
-    --arg-sha256 "{{arg_sha256}}" \
+    --arg-sha256 {{arg_sha256}} \
     --summary-file "{{summary_file}}"


### PR DESCRIPTION
Automatically compute the SHA256 of install or upgrade arguments since as of #1154 `ic-admin` requires `arg-sha256` to be present when `arg` is present.