### PR TITLE
test(consensus): Print the `consensus_time_to_receive_block` metric at the end of `consensus_performance_test`

### DIFF
--- a/rs/tests/consensus/consensus_performance.rs
+++ b/rs/tests/consensus/consensus_performance.rs
@@ -158,6 +158,10 @@ fn test(env: TestEnv, message_size: usize, rps: f64) {
     }
 }
 
+fn test_few_small_messages(env: TestEnv) {
+    test(env, 1, 1.0)
+}
+
 fn test_small_messages(env: TestEnv) {
     test(env, 4_000, 500.0)
 }
@@ -172,6 +176,7 @@ fn main() -> Result<()> {
         // of 10 minutes to setup this large testnet so let's increase the timeout:
         .with_timeout_per_test(Duration::from_secs(60 * 30))
         .with_setup(setup)
+        .add_test(systest!(test_few_small_messages))
         .add_test(systest!(test_small_messages))
         .add_test(systest!(test_large_messages))
         .execute_from_args()?;

--- a/rs/tests/consensus/utils/src/performance.rs
+++ b/rs/tests/consensus/utils/src/performance.rs
@@ -28,15 +28,9 @@ const TEST_DURATION: Duration = Duration::from_secs(60);
 const INGRESS_BYTES_COUNT_METRIC: &str = "consensus_ingress_message_bytes_delivered_count";
 const INGRESS_BYTES_SUM_METRIC: &str = "consensus_ingress_message_bytes_delivered_sum";
 const INGRESS_MESSAGES_SUM_METRIC: &str = "consensus_ingress_messages_delivered_sum";
-const INGRESS_MESSAGE_E2E_LATENCY_SUM_METRICS: &str =
-    "replica_http_ingress_watcher_wait_for_certification_duration_seconds_sum";
-const INGRESS_MESSAGE_E2E_LATENCY_COUNT_METRICS: &str =
-    "replica_http_ingress_watcher_wait_for_certification_duration_seconds_count";
-const TIME_TO_NOTARIZE_SUM_METRICS: &str = "consensus_time_to_notary_sign_sum{{rank=\"0\"}}";
-const TIME_TO_NOTARIZE_COUNT_METRICS: &str = "consensus_time_to_notary_count_sum{{rank=\"0\"}}";
-const TIME_TO_RECEIVE_BLOCK_SUM_METRICS: &str = "consensus_time_to_receive_block_sum{{rank=\"0\"}}";
-const TIME_TO_RECEIVE_BLOCK_COUNT_METRICS: &str =
-    "consensus_time_to_receive_block_count_sum{{rank=\"0\"}}";
+const INGRESS_MESSAGE_E2E_LATENCY_METRICS: &str =
+    "replica_http_ingress_watcher_wait_for_certification_duration_seconds";
+const TIME_TO_RECEIVE_BLOCK_METRICS: &str = "consensus_time_to_receive_block";
 
 pub fn test_with_rt_handle(
     env: TestEnv,
@@ -175,7 +169,6 @@ pub struct TestMetrics {
     throughput_bytes_per_second: f64,
     throughput_messages_per_second: f64,
     average_e2e_latency: f64,
-    average_time_to_notarize: f64,
     average_time_to_receive_block: f64,
 }
 
@@ -192,11 +185,8 @@ impl TestMetrics {
             metrics_difference.delivered_ingress_messages_bytes as f64 / duration.as_secs_f64();
         let throughput_messages_per_second =
             metrics_difference.delivered_ingress_messages as f64 / duration.as_secs_f64();
-        let e2e_latency = metrics_difference.latency_sum / metrics_difference.latency_count;
-        let time_to_notarize =
-            metrics_difference.time_to_notarize_sum / metrics_difference.time_to_notarize_count;
-        let time_to_receive_block = metrics_difference.time_to_receive_block_sum
-            / metrics_difference.time_to_receive_block_count;
+        let e2e_latency = metrics_difference.latency.average();
+        let time_to_receive_block = metrics_difference.time_to_receive_block.average();
 
         Self {
             blocks_per_second,
@@ -205,7 +195,6 @@ impl TestMetrics {
             throughput_bytes_per_second,
             throughput_messages_per_second,
             average_e2e_latency: e2e_latency,
-            average_time_to_notarize: time_to_notarize,
             average_time_to_receive_block: time_to_receive_block,
         }
     }
@@ -220,11 +209,6 @@ impl std::fmt::Display for TestMetrics {
             "Throughput: {:.1} MiB/s, {:.1} messages/s",
             self.throughput_bytes_per_second / (1024. * 1024.),
             self.throughput_messages_per_second
-        )?;
-        writeln!(
-            f,
-            "Average time to notarize a rank 0 block: {:.1}s",
-            self.average_time_to_notarize
         )?;
         writeln!(
             f,
@@ -244,12 +228,8 @@ struct ConsensusMetrics {
     delivered_blocks: u64,
     delivered_ingress_messages: u64,
     delivered_ingress_messages_bytes: u64,
-    latency_sum: f64,
-    latency_count: f64,
-    time_to_notarize_sum: f64,
-    time_to_notarize_count: f64,
-    time_to_receive_block_sum: f64,
-    time_to_receive_block_count: f64,
+    latency: HistogramMetrics,
+    time_to_receive_block: HistogramMetrics,
 }
 
 impl std::ops::Sub for ConsensusMetrics {
@@ -262,14 +242,8 @@ impl std::ops::Sub for ConsensusMetrics {
                 - other.delivered_ingress_messages,
             delivered_ingress_messages_bytes: self.delivered_ingress_messages_bytes
                 - other.delivered_ingress_messages_bytes,
-            latency_sum: self.latency_sum - other.latency_sum,
-            latency_count: self.latency_count - other.latency_count,
-            time_to_notarize_sum: self.time_to_notarize_sum - other.time_to_notarize_sum,
-            time_to_notarize_count: self.time_to_notarize_count - other.time_to_notarize_count,
-            time_to_receive_block_sum: self.time_to_receive_block_sum
-                - other.time_to_receive_block_sum,
-            time_to_receive_block_count: self.time_to_receive_block_count
-                - other.time_to_receive_block_count,
+            latency: self.latency - other.latency,
+            time_to_receive_block: self.time_to_receive_block - other.time_to_receive_block,
         }
     }
 }
@@ -284,51 +258,78 @@ async fn get_consensus_metrics(nodes: &[IcNodeSnapshot]) -> ConsensusMetrics {
         ],
     );
 
-    let latency_fetcher = MetricsFetcher::new(
-        nodes.iter().cloned(),
-        vec![
-            INGRESS_MESSAGE_E2E_LATENCY_SUM_METRICS.to_string(),
-            INGRESS_MESSAGE_E2E_LATENCY_COUNT_METRICS.to_string(),
-            TIME_TO_NOTARIZE_SUM_METRICS.to_string(),
-            TIME_TO_NOTARIZE_COUNT_METRICS.to_string(),
-            TIME_TO_RECEIVE_BLOCK_SUM_METRICS.to_string(),
-            TIME_TO_RECEIVE_BLOCK_COUNT_METRICS.to_string(),
-        ],
-    );
-
     let metrics = fetcher
         .fetch::<u64>()
         .await
         .expect("Should be able to fetch the metrics");
 
-    let latency_metrics = latency_fetcher
-        .fetch::<f64>()
-        .await
-        .expect("Should be able to fetch the latency metrics");
-
     let avg_blocks = average(&metrics[INGRESS_BYTES_COUNT_METRIC]);
     let avg_ingress_messages = average(&metrics[INGRESS_MESSAGES_SUM_METRIC]);
     let avg_ingress_bytes = average(&metrics[INGRESS_BYTES_SUM_METRIC]);
-    let avg_latency_sum = average_f64(&latency_metrics[INGRESS_MESSAGE_E2E_LATENCY_SUM_METRICS]);
-    let avg_latency_count =
-        average_f64(&latency_metrics[INGRESS_MESSAGE_E2E_LATENCY_COUNT_METRICS]);
-    let avg_time_to_notarize_sum = average_f64(&latency_metrics[TIME_TO_NOTARIZE_SUM_METRICS]);
-    let avg_time_to_notarize_count = average_f64(&latency_metrics[TIME_TO_NOTARIZE_COUNT_METRICS]);
-    let avg_time_to_receive_block_sum =
-        average_f64(&latency_metrics[TIME_TO_RECEIVE_BLOCK_SUM_METRICS]);
-    let avg_time_to_receive_block_count =
-        average_f64(&latency_metrics[TIME_TO_RECEIVE_BLOCK_COUNT_METRICS]);
 
     ConsensusMetrics {
         delivered_blocks: avg_blocks,
         delivered_ingress_messages: avg_ingress_messages,
         delivered_ingress_messages_bytes: avg_ingress_bytes,
-        latency_sum: avg_latency_sum,
-        latency_count: avg_latency_count,
-        time_to_notarize_sum: avg_time_to_notarize_sum,
-        time_to_notarize_count: avg_time_to_notarize_count,
-        time_to_receive_block_sum: avg_time_to_receive_block_sum,
-        time_to_receive_block_count: avg_time_to_receive_block_count,
+        latency: HistogramMetrics::fetch(INGRESS_MESSAGE_E2E_LATENCY_METRICS, None, nodes).await,
+        time_to_receive_block: HistogramMetrics::fetch(
+            TIME_TO_RECEIVE_BLOCK_METRICS,
+            Some("rank=\"0\""),
+            nodes,
+        )
+        .await,
+    }
+}
+
+#[derive(Copy, Clone, Debug)]
+struct HistogramMetrics {
+    sum: f64,
+    count: f64,
+}
+
+impl HistogramMetrics {
+    async fn fetch(metrics_name: &str, filter: Option<&str>, nodes: &[IcNodeSnapshot]) -> Self {
+        let (metrics_sum, metrics_count) = if let Some(filter) = filter {
+            (
+                format!("{}_sum{{{}}}", metrics_name, filter),
+                format!("{}_count{{{}}}", metrics_name, filter),
+            )
+        } else {
+            (
+                format!("{}_sum", metrics_name),
+                format!("{}_count", metrics_name),
+            )
+        };
+
+        let fetcher = MetricsFetcher::new(
+            nodes.iter().cloned(),
+            vec![metrics_sum.clone(), metrics_count.clone()],
+        );
+
+        let metrics = dbg!(fetcher
+            .fetch::<f64>()
+            .await
+            .expect("Should be able to fetch the metrics"));
+
+        Self {
+            sum: average_f64(&metrics[&metrics_sum]),
+            count: average_f64(&metrics[&metrics_count]),
+        }
+    }
+
+    fn average(&self) -> f64 {
+        self.sum / self.count
+    }
+}
+
+impl std::ops::Sub for HistogramMetrics {
+    type Output = Self;
+
+    fn sub(self, other: Self) -> Self {
+        Self {
+            sum: self.sum - other.sum,
+            count: self.count - other.count,
+        }
     }
 }
 
@@ -361,6 +362,7 @@ pub async fn persist_metrics(
                 "throughput_bytes_per_second": metrics.throughput_bytes_per_second,
                 "throughput_messages_per_second": metrics.throughput_messages_per_second,
                 "average_e2e_latency": metrics.average_e2e_latency,
+                "average_time_to_receive_block": metrics.average_time_to_receive_block,
             }
         }
     );

--- a/rs/tests/consensus/utils/src/performance.rs
+++ b/rs/tests/consensus/utils/src/performance.rs
@@ -23,7 +23,7 @@ const MAX_RETRIES: u32 = 10;
 const RETRY_WAIT: Duration = Duration::from_secs(10);
 const SUCCESS_THRESHOLD: f64 = 0.33; // If more than 33% of the expected calls are successful the test passes
 const REQUESTS_DISPATCH_EXTRA_TIMEOUT: Duration = Duration::from_secs(1);
-const TEST_DURATION: Duration = Duration::from_secs(60);
+const TEST_DURATION: Duration = Duration::from_secs(5 * 60);
 
 const INGRESS_BYTES_COUNT_METRIC: &str = "consensus_ingress_message_bytes_delivered_count";
 const INGRESS_BYTES_SUM_METRIC: &str = "consensus_ingress_message_bytes_delivered_sum";
@@ -306,10 +306,10 @@ impl HistogramMetrics {
             vec![metrics_sum.clone(), metrics_count.clone()],
         );
 
-        let metrics = dbg!(fetcher
+        let metrics = fetcher
             .fetch::<f64>()
             .await
-            .expect("Should be able to fetch the metrics"));
+            .expect("Should be able to fetch the metrics");
 
         Self {
             sum: average_f64(&metrics[&metrics_sum]),


### PR DESCRIPTION
I think it's a useful metrics to keep track of.
Also, added a small test case where we send very few, very small messages.

```
2024-09-18 14:55:22.612 INFO[uvms_logs_stream:StdOut] [uvm=test-driver] TEST_LOG: ===== Summary for //rs/tests/consensus:consensus_performance_colocate =====
2024-09-18 14:55:22.612 INFO[uvms_logs_stream:StdOut] [uvm=test-driver] TEST_LOG: Task setup                   PASSED  in 126.30s   -- Exited with code 0.
2024-09-18 14:55:22.612 INFO[uvms_logs_stream:StdOut] [uvm=test-driver] TEST_LOG: Task test_few_small_messages PASSED  in  98.22s
2024-09-18 14:55:22.612 INFO[uvms_logs_stream:StdOut] [uvm=test-driver] TEST_LOG:      Success rate: 100.0%
2024-09-18 14:55:22.616 INFO[setup:rs/tests/testing_verification/colocate_test.rs:321:0] Test execution finished with exit code 0.
2024-09-18 14:55:22.616 INFO[setup:rs/tests/testing_verification/colocate_test.rs:239:0] Wait extra 10 sec to collect last uvm logs
2024-09-18 14:55:22.725 INFO[uvms_logs_stream:StdOut] [uvm=test-driver] TEST_LOG:      Block rate: 1.2 blocks/s
2024-09-18 14:55:22.725 INFO[uvms_logs_stream:StdOut] [uvm=test-driver] TEST_LOG:      Throughput: 0.0 MiB/s, 1.0 messages/s
2024-09-18 14:55:22.725 INFO[uvms_logs_stream:StdOut] [uvm=test-driver] TEST_LOG:      Average time to receive a rank 0 block: 0.2s
2024-09-18 14:55:22.725 INFO[uvms_logs_stream:StdOut] [uvm=test-driver] TEST_LOG:      Avarage E2E ingress message latency: 2.2s
2024-09-18 14:55:22.725 INFO[uvms_logs_stream:StdOut] [uvm=test-driver] TEST_LOG: Task test_small_messages     PASSED  in 104.33s
2024-09-18 14:55:22.725 INFO[uvms_logs_stream:StdOut] [uvm=test-driver] TEST_LOG:      Success rate: 100.0%
2024-09-18 14:55:22.725 INFO[uvms_logs_stream:StdOut] [uvm=test-driver] TEST_LOG:      Block rate: 0.5 blocks/s
2024-09-18 14:55:22.725 INFO[uvms_logs_stream:StdOut] [uvm=test-driver] TEST_LOG:      Throughput: 1.5 MiB/s, 354.1 messages/s
2024-09-18 14:55:22.725 INFO[uvms_logs_stream:StdOut] [uvm=test-driver] TEST_LOG:      Average time to receive a rank 0 block: 1.9s
2024-09-18 14:55:22.725 INFO[uvms_logs_stream:StdOut] [uvm=test-driver] TEST_LOG:      Avarage E2E ingress message latency: 14.1s
2024-09-18 14:55:22.725 INFO[uvms_logs_stream:StdOut] [uvm=test-driver] TEST_LOG: Task test_large_messages     PASSED  in 115.55s
2024-09-18 14:55:22.725 INFO[uvms_logs_stream:StdOut] [uvm=test-driver] TEST_LOG:      Success rate: 100.0%
2024-09-18 14:55:22.725 INFO[uvms_logs_stream:StdOut] [uvm=test-driver] TEST_LOG:      Block rate: 0.5 blocks/s
2024-09-18 14:55:22.725 INFO[uvms_logs_stream:StdOut] [uvm=test-driver] TEST_LOG:      Throughput: 1.2 MiB/s, 1.3 messages/s
2024-09-18 14:55:22.725 INFO[uvms_logs_stream:StdOut] [uvm=test-driver] TEST_LOG:      Average time to receive a rank 0 block: 2.0s
2024-09-18 14:55:22.725 INFO[uvms_logs_stream:StdOut] [uvm=test-driver] TEST_LOG:      Avarage E2E ingress message latency: 15.3s
2024-09-18 14:55:22.725 INFO[uvms_logs_stream:StdOut] [uvm=test-driver] TEST_LOG: ===========================================================================
```