### PR TITLE
revert(nns): Re-apply changes from #1496 except for the ones that caused the tests to fail

### DIFF
--- a/rs/nervous_system/integration_tests/src/pocket_ic_helpers.rs
+++ b/rs/nervous_system/integration_tests/src/pocket_ic_helpers.rs
@@ -1,20 +1,20 @@
 use candid::{Decode, Encode, Nat, Principal};
-use canister_test::{CanisterInstallMode, Wasm};
+use canister_test::Wasm;
 use ic_base_types::{CanisterId, PrincipalId, SubnetId};
 use ic_ledger_core::Tokens;
 use ic_nervous_system_common::{E8, ONE_DAY_SECONDS};
 use ic_nervous_system_common_test_keys::{TEST_NEURON_1_ID, TEST_NEURON_1_OWNER_PRINCIPAL};
-use ic_nervous_system_root::change_canister::ChangeCanisterRequest;
 use ic_nns_common::pb::v1::{NeuronId, ProposalId};
 use ic_nns_constants::{
     self, ALL_NNS_CANISTER_IDS, GOVERNANCE_CANISTER_ID, LEDGER_CANISTER_ID, LIFELINE_CANISTER_ID,
     REGISTRY_CANISTER_ID, ROOT_CANISTER_ID, SNS_WASM_CANISTER_ID,
 };
 use ic_nns_governance_api::pb::v1::{
-    manage_neuron, manage_neuron_response, proposal, CreateServiceNervousSystem,
+    install_code::CanisterInstallMode, manage_neuron_response, CreateServiceNervousSystem,
     ExecuteNnsFunction, GetNeuronsFundAuditInfoRequest, GetNeuronsFundAuditInfoResponse,
-    ListNeurons, ListNeuronsResponse, ManageNeuron, ManageNeuronResponse, NetworkEconomics,
-    NnsFunction, Proposal, ProposalInfo, Topic,
+    InstallCodeRequest, ListNeurons, ListNeuronsResponse, MakeProposalRequest,
+    ManageNeuronCommandRequest, ManageNeuronRequest, ManageNeuronResponse, NetworkEconomics,
+    NnsFunction, ProposalActionRequest, ProposalInfo, Topic,
 };
 use ic_nns_test_utils::{
     common::{
@@ -23,7 +23,6 @@ use ic_nns_test_utils::{
         build_mainnet_registry_wasm, build_mainnet_root_wasm, build_mainnet_sns_wasms_wasm,
         build_registry_wasm, build_root_wasm, build_sns_wasms_wasm, NnsInitPayloadsBuilder,
     },
-    governance::UpgradeRootProposal,
     sns_wasm::{
         build_archive_sns_wasm, build_governance_sns_wasm, build_index_ng_sns_wasm,
         build_ledger_sns_wasm, build_mainnet_archive_sns_wasm, build_mainnet_governance_sns_wasm,
@@ -167,14 +166,16 @@ pub fn add_wasm_via_nns_proposal(
         hash: hash.to_vec(),
         wasm: Some(wasm),
     };
-    let proposal = Proposal {
+    let proposal = MakeProposalRequest {
         title: Some(format!("Add WASM for SNS canister type {}", canister_type)),
         summary: "summary".to_string(),
         url: "".to_string(),
-        action: Some(proposal::Action::ExecuteNnsFunction(ExecuteNnsFunction {
-            nns_function: NnsFunction::AddSnsWasm as i32,
-            payload: Encode!(&payload).expect("Error encoding proposal payload"),
-        })),
+        action: Some(ProposalActionRequest::ExecuteNnsFunction(
+            ExecuteNnsFunction {
+                nns_function: NnsFunction::AddSnsWasm as i32,
+                payload: Encode!(&payload).expect("Error encoding proposal payload"),
+            },
+        )),
     };
     nns::governance::propose_and_wait(pocket_ic, proposal)
 }
@@ -183,11 +184,13 @@ pub fn propose_to_set_network_economics_and_wait(
     pocket_ic: &PocketIc,
     network_economics: NetworkEconomics,
 ) -> Result<ProposalInfo, String> {
-    let proposal = Proposal {
+    let proposal = MakeProposalRequest {
         title: Some("Set NetworkEconomics.neurons_fund_economics {}".to_string()),
         summary: "summary".to_string(),
         url: "".to_string(),
-        action: Some(proposal::Action::ManageNetworkEconomics(network_economics)),
+        action: Some(ProposalActionRequest::ManageNetworkEconomics(
+            network_economics,
+        )),
     };
     nns::governance::propose_and_wait(pocket_ic, proposal)
 }
@@ -602,36 +605,19 @@ pub fn upgrade_nns_canister_to_tip_of_master_or_panic(
         return;
     }
 
-    let (payload, nns_function) = if canister_id == ROOT_CANISTER_ID {
-        let payload = UpgradeRootProposal {
-            wasm_module: wasm.bytes(),
-            module_arg: vec![],
-            stop_upgrade_start: true,
-        };
-        (
-            Encode!(&payload).unwrap(),
-            NnsFunction::NnsRootUpgrade as i32,
-        )
-    } else {
-        let payload = ChangeCanisterRequest::new(true, CanisterInstallMode::Upgrade, canister_id)
-            .with_memory_allocation(ic_nns_constants::memory_allocation_of(canister_id))
-            .with_wasm(wasm.bytes());
-        (
-            Encode!(&payload).unwrap(),
-            NnsFunction::NnsCanisterUpgrade as i32,
-        )
-    };
-
     println!("Upgrading {} to the latest version.", label);
     let proposal_info = nns::governance::propose_and_wait(
         pocket_ic,
-        Proposal {
+        MakeProposalRequest {
             title: Some(format!("Upgrade {} to the latest version.", label)),
             summary: "".to_string(),
             url: "".to_string(),
-            action: Some(proposal::Action::ExecuteNnsFunction(ExecuteNnsFunction {
-                nns_function,
-                payload,
+            action: Some(ProposalActionRequest::InstallCode(InstallCodeRequest {
+                canister_id: Some(canister_id.get()),
+                install_mode: Some(CanisterInstallMode::Upgrade as i32),
+                wasm_module: Some(wasm.bytes()),
+                arg: Some(vec![]),
+                skip_stopping_before_installing: None,
             })),
         },
     )
@@ -702,14 +688,14 @@ pub mod nns {
             pocket_ic: &PocketIc,
             sender: PrincipalId,
             neuron_id: NeuronId,
-            command: manage_neuron::Command,
+            command: ManageNeuronCommandRequest,
         ) -> ManageNeuronResponse {
             let result = pocket_ic
                 .update_call(
                     GOVERNANCE_CANISTER_ID.into(),
                     Principal::from(sender),
                     "manage_neuron",
-                    Encode!(&ManageNeuron {
+                    Encode!(&ManageNeuronRequest {
                         id: Some(neuron_id),
                         command: Some(command),
                         neuron_id_or_subaccount: None
@@ -726,13 +712,12 @@ pub mod nns {
 
         pub fn propose_and_wait(
             pocket_ic: &PocketIc,
-            proposal: Proposal,
+            proposal: MakeProposalRequest,
         ) -> Result<ProposalInfo, String> {
             let neuron_id = NeuronId {
                 id: TEST_NEURON_1_ID,
             };
-            let command: manage_neuron::Command =
-                manage_neuron::Command::MakeProposal(Box::new(proposal));
+            let command = ManageNeuronCommandRequest::MakeProposal(Box::new(proposal));
             let response = manage_neuron(
                 pocket_ic,
                 *TEST_NEURON_1_OWNER_PRINCIPAL,
@@ -863,11 +848,11 @@ pub mod nns {
         ) -> (DeployedSns, ProposalId) {
             let proposal_info = propose_and_wait(
                 pocket_ic,
-                Proposal {
+                MakeProposalRequest {
                     title: Some(format!("Create SNS #{}", sns_instance_label)),
                     summary: "".to_string(),
                     url: "".to_string(),
-                    action: Some(proposal::Action::CreateServiceNervousSystem(
+                    action: Some(ProposalActionRequest::CreateServiceNervousSystem(
                         create_service_nervous_system,
                     )),
                 },
@@ -1167,24 +1152,18 @@ pub mod sns {
                 post_upgrade_running_version.swap_wasm_hash.clone(),
             )
             .wasm;
-            let upgrade_canister = ChangeCanisterRequest {
-                stop_before_installing: true,
-                mode: CanisterInstallMode::Upgrade,
-                canister_id: CanisterId::unchecked_from_principal(swap_canister_id),
-                wasm_module: wasm,
-                arg: vec![],
-                compute_allocation: None,
-                memory_allocation: None,
-            };
             nns::governance::propose_and_wait(
                 pocket_ic,
-                Proposal {
+                MakeProposalRequest {
                     title: Some("Enable auto-finalization for the Swap canister".to_string()),
                     summary: "".to_string(),
                     url: "".to_string(),
-                    action: Some(proposal::Action::ExecuteNnsFunction(ExecuteNnsFunction {
-                        nns_function: NnsFunction::NnsCanisterUpgrade as i32,
-                        payload: Encode!(&upgrade_canister).unwrap(),
+                    action: Some(ProposalActionRequest::InstallCode(InstallCodeRequest {
+                        canister_id: Some(swap_canister_id),
+                        install_mode: Some(CanisterInstallMode::Upgrade as i32),
+                        wasm_module: Some(wasm),
+                        arg: Some(vec![]),
+                        skip_stopping_before_installing: None,
                     })),
                 },
             )

--- a/rs/nns/governance/src/governance.rs
+++ b/rs/nns/governance/src/governance.rs
@@ -397,20 +397,14 @@ impl NnsFunction {
     fn allowed_when_resources_are_low(&self) -> bool {
         matches!(
             self,
-            NnsFunction::NnsRootUpgrade
-                | NnsFunction::NnsCanisterUpgrade
-                | NnsFunction::HardResetNnsRootToVersion
-                | NnsFunction::ReviseElectedGuestosVersions
-                | NnsFunction::DeployGuestosToAllSubnetNodes
+            NnsFunction::ReviseElectedGuestosVersions | NnsFunction::DeployGuestosToAllSubnetNodes
         )
     }
 
     fn can_have_large_payload(&self) -> bool {
         matches!(
             self,
-            NnsFunction::NnsCanisterUpgrade
-                | NnsFunction::NnsCanisterInstall
-                | NnsFunction::NnsRootUpgrade
+            NnsFunction::NnsCanisterInstall
                 | NnsFunction::HardResetNnsRootToVersion
                 | NnsFunction::AddSnsWasm
         )
@@ -426,6 +420,8 @@ impl NnsFunction {
                 | NnsFunction::UpdateNodesHostosVersion
                 | NnsFunction::BlessReplicaVersion
                 | NnsFunction::RetireReplicaVersion
+                | NnsFunction::NnsCanisterUpgrade
+                | NnsFunction::NnsRootUpgrade
         )
     }
 }

--- a/rs/nns/governance/src/governance.rs
+++ b/rs/nns/governance/src/governance.rs
@@ -397,14 +397,20 @@ impl NnsFunction {
     fn allowed_when_resources_are_low(&self) -> bool {
         matches!(
             self,
-            NnsFunction::ReviseElectedGuestosVersions | NnsFunction::DeployGuestosToAllSubnetNodes
+            NnsFunction::NnsRootUpgrade
+                | NnsFunction::NnsCanisterUpgrade
+                | NnsFunction::HardResetNnsRootToVersion
+                | NnsFunction::ReviseElectedGuestosVersions
+                | NnsFunction::DeployGuestosToAllSubnetNodes
         )
     }
 
     fn can_have_large_payload(&self) -> bool {
         matches!(
             self,
-            NnsFunction::NnsCanisterInstall
+            NnsFunction::NnsCanisterUpgrade
+                | NnsFunction::NnsCanisterInstall
+                | NnsFunction::NnsRootUpgrade
                 | NnsFunction::HardResetNnsRootToVersion
                 | NnsFunction::AddSnsWasm
         )
@@ -420,8 +426,6 @@ impl NnsFunction {
                 | NnsFunction::UpdateNodesHostosVersion
                 | NnsFunction::BlessReplicaVersion
                 | NnsFunction::RetireReplicaVersion
-                | NnsFunction::NnsCanisterUpgrade
-                | NnsFunction::NnsRootUpgrade
         )
     }
 }

--- a/rs/nns/governance/src/governance/tests/mod.rs
+++ b/rs/nns/governance/src/governance/tests/mod.rs
@@ -1589,10 +1589,6 @@ fn test_validate_execute_nns_function() {
             payload: vec![1u8; PROPOSAL_EXECUTE_NNS_FUNCTION_PAYLOAD_BYTES_MAX],
         },
         ExecuteNnsFunction {
-            nns_function: NnsFunction::NnsCanisterUpgrade as i32,
-            payload: vec![1u8; PROPOSAL_EXECUTE_NNS_FUNCTION_PAYLOAD_BYTES_MAX + 1],
-        },
-        ExecuteNnsFunction {
             nns_function: NnsFunction::IcpXdrConversionRate as i32,
             payload: Encode!(&UpdateIcpXdrConversionRatePayload {
                 xdr_permyriad_per_icp: 101,

--- a/rs/nns/governance/tests/degraded_mode.rs
+++ b/rs/nns/governance/tests/degraded_mode.rs
@@ -6,19 +6,21 @@ use futures::future::FutureExt;
 use ic_base_types::{CanisterId, PrincipalId};
 use ic_nervous_system_common::{cmc::CMC, ledger::IcpLedger, NervousSystemError};
 use ic_nns_common::pb::v1::NeuronId;
+use ic_nns_constants::GOVERNANCE_CANISTER_ID;
 use ic_nns_governance::{
     governance::{
         Environment, Governance, HeapGrowthPotential, HEAP_SIZE_SOFT_LIMIT_IN_WASM32_PAGES,
     },
     pb::v1::{
         governance_error::ErrorType,
+        install_code::CanisterInstallMode,
         manage_neuron::{
             claim_or_refresh::{By, MemoAndController},
             ClaimOrRefresh, Command,
         },
         manage_neuron_response::Command as CommandResponse,
         neuron, proposal, ExecuteNnsFunction, Governance as GovernanceProto, GovernanceError,
-        ManageNeuron, ManageNeuronResponse, Motion, NetworkEconomics, Neuron, NnsFunction,
+        InstallCode, ManageNeuron, ManageNeuronResponse, Motion, NetworkEconomics, Neuron,
         Proposal,
     },
 };
@@ -179,9 +181,12 @@ async fn test_can_submit_nns_canister_upgrade_in_degraded_mode() {
             &Proposal {
                 title: Some("A Reasonable Title".to_string()),
                 summary: "proposal 1".to_string(),
-                action: Some(proposal::Action::ExecuteNnsFunction(ExecuteNnsFunction {
-                    nns_function: NnsFunction::NnsCanisterUpgrade as i32,
-                    payload: Vec::new(),
+                action: Some(proposal::Action::InstallCode(InstallCode {
+                    canister_id: Some(GOVERNANCE_CANISTER_ID.get()),
+                    wasm_module: Some(vec![1, 2, 3]),
+                    install_mode: Some(CanisterInstallMode::Upgrade as i32),
+                    arg: Some(vec![4, 5, 6]),
+                    skip_stopping_before_installing: None,
                 })),
                 ..Default::default()
             },

--- a/rs/nns/integration_tests/src/canister_upgrade.rs
+++ b/rs/nns/integration_tests/src/canister_upgrade.rs
@@ -16,7 +16,7 @@ use ic_nns_test_utils::{
     },
 };
 
-fn test_upgrade_canister(canister_id: CanisterId, canister_wasm: Wasm, use_proposal_action: bool) {
+fn test_upgrade_canister(canister_id: CanisterId, canister_wasm: Wasm) {
     let state_machine = state_machine_builder_for_nns_tests().build();
     let nns_init_payloads = NnsInitPayloadsBuilder::new().with_test_neurons().build();
     setup_nns_canisters(&state_machine, nns_init_payloads);
@@ -32,7 +32,7 @@ fn test_upgrade_canister(canister_id: CanisterId, canister_wasm: Wasm, use_propo
         canister_id,
         modified_wasm.clone(),
         vec![],
-        use_proposal_action,
+        true,
     );
 
     let controller_canister_id = if canister_id == ROOT_CANISTER_ID {
@@ -48,34 +48,29 @@ fn test_upgrade_canister(canister_id: CanisterId, canister_wasm: Wasm, use_propo
         controller_canister_id,
     );
 
-    if use_proposal_action {
-        let proposal_info =
-            nns_governance_get_proposal_info_as_anonymous(&state_machine, proposal_id.id);
-        let action = proposal_info.proposal.unwrap().action.unwrap();
-        if let Action::InstallCode(install_code) = action {
-            assert_eq!(
-                install_code.wasm_module_hash,
-                Some(Sha256::hash(&modified_wasm).to_vec())
-            );
-            assert_eq!(install_code.arg_hash, Some(vec![]));
-            assert_eq!(
-                install_code.install_mode,
-                Some(CanisterInstallMode::Upgrade as i32)
-            );
-            assert_eq!(install_code.canister_id, Some(canister_id.get()));
-            assert_eq!(install_code.skip_stopping_before_installing, None);
-        } else {
-            panic!("Unexpected action: {:?}", action);
-        }
+    let proposal_info =
+        nns_governance_get_proposal_info_as_anonymous(&state_machine, proposal_id.id);
+    let action = proposal_info.proposal.unwrap().action.unwrap();
+    if let Action::InstallCode(install_code) = action {
+        assert_eq!(
+            install_code.wasm_module_hash,
+            Some(Sha256::hash(&modified_wasm).to_vec())
+        );
+        assert_eq!(install_code.arg_hash, Some(vec![]));
+        assert_eq!(
+            install_code.install_mode,
+            Some(CanisterInstallMode::Upgrade as i32)
+        );
+        assert_eq!(install_code.canister_id, Some(canister_id.get()));
+        assert_eq!(install_code.skip_stopping_before_installing, None);
+    } else {
+        panic!("Unexpected action: {:?}", action);
     }
 }
 
 #[test]
 fn upgrade_canisters_by_proposal() {
-    test_upgrade_canister(GOVERNANCE_CANISTER_ID, build_governance_wasm(), true);
-    test_upgrade_canister(GOVERNANCE_CANISTER_ID, build_governance_wasm(), false);
-    test_upgrade_canister(ROOT_CANISTER_ID, build_root_wasm(), false);
-    test_upgrade_canister(ROOT_CANISTER_ID, build_root_wasm(), true);
-    test_upgrade_canister(LIFELINE_CANISTER_ID, build_lifeline_wasm(), true);
-    test_upgrade_canister(LIFELINE_CANISTER_ID, build_lifeline_wasm(), false);
+    test_upgrade_canister(GOVERNANCE_CANISTER_ID, build_governance_wasm());
+    test_upgrade_canister(ROOT_CANISTER_ID, build_root_wasm());
+    test_upgrade_canister(LIFELINE_CANISTER_ID, build_lifeline_wasm());
 }

--- a/rs/nns/integration_tests/src/copy_inactive_neurons_to_stable_memory.rs
+++ b/rs/nns/integration_tests/src/copy_inactive_neurons_to_stable_memory.rs
@@ -40,7 +40,7 @@ fn test_copy_inactive_neurons_to_stable_memory() {
         GOVERNANCE_CANISTER_ID, // Target, i.e. the canister that we want to upgrade.
         new_wasm_content,       // The new code that we want the canister to start running.
         module_arg,
-        false,
+        true,
     );
     println!("Done proposing governance upgrade: {:?}", proposal_id);
 

--- a/rs/nns/integration_tests/src/governance_mem_test.rs
+++ b/rs/nns/integration_tests/src/governance_mem_test.rs
@@ -85,7 +85,7 @@ fn governance_mem_test() {
         GOVERNANCE_CANISTER_ID,
         real_gov_wasm.bytes(),
         module_arg,
-        false,
+        true,
     );
 
     state_machine.tick();

--- a/rs/nns/integration_tests/src/lifeline.rs
+++ b/rs/nns/integration_tests/src/lifeline.rs
@@ -9,15 +9,13 @@ use ic_nervous_system_common_test_keys::{
 };
 use ic_nns_common::pb::v1::NeuronId;
 use ic_nns_constants::{LIFELINE_CANISTER_ID, ROOT_CANISTER_ID};
-use ic_nns_governance_api::{
-    pb::v1::{
-        manage_neuron_response::Command as CommandResponse, NnsFunction, ProposalStatus, Vote,
-    },
-    proposal_submission_helpers::create_external_update_proposal_candid,
+use ic_nns_governance_api::pb::v1::{
+    install_code::CanisterInstallMode as GovernanceCanisterInstallMode,
+    manage_neuron_response::Command as CommandResponse, InstallCodeRequest, MakeProposalRequest,
+    ProposalActionRequest, ProposalStatus, Vote,
 };
 use ic_nns_test_utils::{
     common::NnsInitPayloadsBuilder,
-    governance::UpgradeRootProposal,
     state_test_helpers::{
         get_pending_proposals, get_root_canister_status, nns_cast_vote,
         nns_governance_get_proposal_info_as_anonymous, nns_governance_make_proposal,
@@ -71,17 +69,18 @@ fn test_submit_and_accept_root_canister_upgrade_proposal() {
     let funny: u32 = 422557101; // just a funny number I came up with
     let magic = funny.to_le_bytes();
 
-    let proposal = create_external_update_proposal_candid(
-        "Proposal to upgrade the root canister",
-        "",
-        "",
-        NnsFunction::NnsRootUpgrade,
-        UpgradeRootProposal {
-            wasm_module: wasm_module.clone(),
-            module_arg: magic.to_vec(),
-            stop_upgrade_start: true,
-        },
-    );
+    let proposal = MakeProposalRequest {
+        title: Some("Proposal to upgrade the root canister".to_string()),
+        summary: "".to_string(),
+        url: "".to_string(),
+        action: Some(ProposalActionRequest::InstallCode(InstallCodeRequest {
+            canister_id: Some(ROOT_CANISTER_ID.get()),
+            wasm_module: Some(wasm_module.clone()),
+            install_mode: Some(GovernanceCanisterInstallMode::Upgrade as i32),
+            arg: Some(magic.to_vec()),
+            skip_stopping_before_installing: None,
+        })),
+    };
 
     let neuron_id = NeuronId {
         id: TEST_NEURON_2_ID,
@@ -171,17 +170,18 @@ fn test_submit_and_accept_forced_root_canister_upgrade_proposal() {
 
     let init_arg: &[u8] = &[];
 
-    let proposal = create_external_update_proposal_candid(
-        "Proposal to upgrade the root canister",
-        "",
-        "",
-        NnsFunction::NnsRootUpgrade,
-        UpgradeRootProposal {
-            wasm_module: empty_wasm.to_vec(),
-            module_arg: init_arg.to_vec(),
-            stop_upgrade_start: false,
-        },
-    );
+    let proposal = MakeProposalRequest {
+        title: Some("Proposal to upgrade the root canister".to_string()),
+        summary: "".to_string(),
+        url: "".to_string(),
+        action: Some(ProposalActionRequest::InstallCode(InstallCodeRequest {
+            canister_id: Some(ROOT_CANISTER_ID.get()),
+            wasm_module: Some(empty_wasm.to_vec()),
+            install_mode: Some(GovernanceCanisterInstallMode::Upgrade as i32),
+            arg: Some(init_arg.to_vec()),
+            skip_stopping_before_installing: Some(true),
+        })),
+    };
 
     let neuron_id = NeuronId {
         id: TEST_NEURON_2_ID,
@@ -272,17 +272,18 @@ fn test_lifeline_canister_restarts_root_on_stop_canister_timeout() {
     state_machine.tick();
 
     let root_wasm = Project::cargo_bin_maybe_from_env("root-canister", &[]).bytes();
-    let proposal = create_external_update_proposal_candid(
-        "Tea. Earl Grey. Hot.",
-        "Make It So",
-        "",
-        NnsFunction::NnsRootUpgrade,
-        UpgradeRootProposal {
-            stop_upgrade_start: true,
-            wasm_module: root_wasm,
-            module_arg: vec![],
-        },
-    );
+    let proposal = MakeProposalRequest {
+        title: Some("Tea. Earl Grey. Hot.".to_string()),
+        summary: "Make It So".to_string(),
+        url: "".to_string(),
+        action: Some(ProposalActionRequest::InstallCode(InstallCodeRequest {
+            canister_id: Some(ROOT_CANISTER_ID.get()),
+            wasm_module: Some(root_wasm),
+            install_mode: Some(GovernanceCanisterInstallMode::Upgrade as i32),
+            arg: Some(vec![]),
+            skip_stopping_before_installing: None,
+        })),
+    };
     let neuron_id = NeuronId {
         id: TEST_NEURON_1_ID,
     };

--- a/rs/nns/integration_tests/src/neuron_following.rs
+++ b/rs/nns/integration_tests/src/neuron_following.rs
@@ -22,7 +22,7 @@ use ic_state_machine_tests::StateMachine;
 
 const VALID_TOPIC: i32 = Topic::ParticipantManagement as i32;
 const INVALID_TOPIC: i32 = 69420;
-const NETWORK_CANISTER_MANAGEMENT_TOPIC: i32 = Topic::NetworkCanisterManagement as i32;
+const PROTOCOAL_CANISTER_MANAGEMENT_TOPIC: i32 = Topic::ProtocolCanisterManagement as i32;
 const NEURON_MANAGEMENT_TOPIC: i32 = Topic::NeuronManagement as i32;
 const VOTING_POWER_NEURON_1: u64 = 1_404_004_106;
 const VOTING_POWER_NEURON_2: u64 = 140_400_410;
@@ -210,7 +210,7 @@ fn vote_propagation_with_following() {
         &state_machine,
         &n1,
         &[n2.neuron_id],
-        NETWORK_CANISTER_MANAGEMENT_TOPIC,
+        PROTOCOAL_CANISTER_MANAGEMENT_TOPIC,
     );
 
     // voting doesn't get propagated by mutating the following graph
@@ -250,7 +250,7 @@ fn vote_propagation_with_following() {
         &state_machine,
         &n3,
         &[n2.neuron_id],
-        NETWORK_CANISTER_MANAGEMENT_TOPIC,
+        PROTOCOAL_CANISTER_MANAGEMENT_TOPIC,
     );
 
     // make n2 follow n1
@@ -258,7 +258,7 @@ fn vote_propagation_with_following() {
         &state_machine,
         &n2,
         &[n1.neuron_id],
-        NETWORK_CANISTER_MANAGEMENT_TOPIC,
+        PROTOCOAL_CANISTER_MANAGEMENT_TOPIC,
     );
 
     // now n1 and n2 follow each other (circle), and n3 follows n2
@@ -291,7 +291,7 @@ fn vote_propagation_with_following() {
         &state_machine,
         &n2,
         &[n1a.neuron_id],
-        NETWORK_CANISTER_MANAGEMENT_TOPIC,
+        PROTOCOAL_CANISTER_MANAGEMENT_TOPIC,
     );
 
     // at this point n2 is not influential
@@ -349,14 +349,14 @@ fn vote_propagation_with_following() {
         &state_machine,
         &n1a,
         &[n3.neuron_id],
-        NETWORK_CANISTER_MANAGEMENT_TOPIC,
+        PROTOCOAL_CANISTER_MANAGEMENT_TOPIC,
     );
 
     set_followees_on_topic(
         &state_machine,
         &n3,
         &[n1.neuron_id],
-        NETWORK_CANISTER_MANAGEMENT_TOPIC,
+        PROTOCOAL_CANISTER_MANAGEMENT_TOPIC,
     );
 
     // fire off a new proposal by n1, and see all neurons voting

--- a/rs/nns/integration_tests/src/reinstall_and_upgrade.rs
+++ b/rs/nns/integration_tests/src/reinstall_and_upgrade.rs
@@ -18,7 +18,7 @@ use ic_nns_test_utils::{
     governance::{
         bump_gzip_timestamp, get_pending_proposals, reinstall_nns_canister_by_proposal,
         submit_external_update_proposal, upgrade_nns_canister_by_proposal,
-        upgrade_nns_canister_with_arg_by_proposal, upgrade_root_canister_by_proposal,
+        upgrade_nns_canister_with_arg_by_proposal,
     },
     itest_helpers::{state_machine_test_on_nns_subnet, NnsCanisters},
 };
@@ -49,54 +49,44 @@ fn test_reinstall_and_upgrade_canisters_canonical_ordering() {
 
         for CanisterInstallInfo {
             wasm,
-            use_root,
+            use_root: _,
             canister,
             init_payload,
             mode,
         } in get_nns_canister_wasm(&nns_canisters, init_state).into_iter()
         {
-            if use_root {
-                if mode == CanisterInstallMode::Upgrade {
-                    println!("[Update] Canister: {:?}", canister.canister_id());
-                    if canister.canister_id() == LIFELINE_CANISTER_ID {
-                        let arg: Vec<String> = vec![];
-                        upgrade_nns_canister_with_arg_by_proposal(
-                            canister,
-                            &nns_canisters.governance,
-                            &nns_canisters.root,
-                            bump_gzip_timestamp(&wasm),
-                            Encode!(&arg).unwrap(),
-                        )
-                        .await;
-                    } else {
-                        upgrade_nns_canister_by_proposal(
-                            canister,
-                            &nns_canisters.governance,
-                            &nns_canisters.root,
-                            true,
-                            // Method fails if wasm stays the same
-                            bump_gzip_timestamp(&wasm),
-                            None,
-                        )
-                        .await;
-                    }
-                } else if mode == CanisterInstallMode::Reinstall {
-                    println!("[Reinstall] Canister: {:?}", canister.canister_id());
-                    reinstall_nns_canister_by_proposal(
+            if mode == CanisterInstallMode::Upgrade {
+                println!("[Update] Canister: {:?}", canister.canister_id());
+                if canister.canister_id() == LIFELINE_CANISTER_ID {
+                    let arg: Vec<String> = vec![];
+                    upgrade_nns_canister_with_arg_by_proposal(
                         canister,
                         &nns_canisters.governance,
                         &nns_canisters.root,
-                        wasm,
-                        init_payload,
+                        bump_gzip_timestamp(&wasm),
+                        Encode!(&arg).unwrap(),
+                    )
+                    .await;
+                } else {
+                    upgrade_nns_canister_by_proposal(
+                        canister,
+                        &nns_canisters.governance,
+                        &nns_canisters.root,
+                        true,
+                        // Method fails if wasm stays the same
+                        bump_gzip_timestamp(&wasm),
+                        Some(Encode!(&()).unwrap()),
                     )
                     .await;
                 }
-            } else {
-                // Root Upgrade via Lifeline
-                upgrade_root_canister_by_proposal(
+            } else if mode == CanisterInstallMode::Reinstall {
+                println!("[Reinstall] Canister: {:?}", canister.canister_id());
+                reinstall_nns_canister_by_proposal(
+                    canister,
                     &nns_canisters.governance,
                     &nns_canisters.root,
                     wasm,
+                    init_payload,
                 )
                 .await;
             }
@@ -196,32 +186,22 @@ fn test_reinstall_and_upgrade_canisters_with_state_changes() {
         // Upgrade
         for CanisterInstallInfo {
             wasm,
-            use_root,
+            use_root: _,
             canister,
             init_payload,
             mode,
         } in canister_install_info
         {
             if mode == CanisterInstallMode::Upgrade {
-                if use_root {
-                    upgrade_nns_canister_by_proposal(
-                        canister,
-                        &nns_canisters.governance,
-                        &nns_canisters.root,
-                        false,
-                        wasm,
-                        Some(init_payload),
-                    )
-                    .await;
-                } else {
-                    // Root Upgrade via Lifeline
-                    upgrade_root_canister_by_proposal(
-                        &nns_canisters.governance,
-                        &nns_canisters.root,
-                        wasm,
-                    )
-                    .await;
-                }
+                upgrade_nns_canister_by_proposal(
+                    canister,
+                    &nns_canisters.governance,
+                    &nns_canisters.root,
+                    false,
+                    wasm,
+                    Some(init_payload),
+                )
+                .await;
             }
         }
 
@@ -357,13 +337,6 @@ fn get_nns_canister_wasm<'a>(
         },
         CanisterInstallInfo {
             wasm: bump_gzip_timestamp(&Project::cargo_bin_maybe_from_env("root-canister", &[])),
-            use_root: false,
-            canister: &nns_canisters.root,
-            init_payload: encoded_init_state[5].clone(),
-            mode: CanisterInstallMode::Reinstall,
-        },
-        CanisterInstallInfo {
-            wasm: Project::cargo_bin_maybe_from_env("root-canister", &[]),
             use_root: false,
             canister: &nns_canisters.root,
             init_payload: encoded_init_state[5].clone(),

--- a/rs/nns/integration_tests/src/upgrade_canisters_with_golden_nns_state.rs
+++ b/rs/nns/integration_tests/src/upgrade_canisters_with_golden_nns_state.rs
@@ -237,7 +237,7 @@ fn test_upgrade_canisters_with_golden_nns_state() {
                     *canister_id,
                     wasm_content.clone(),
                     module_arg.clone(),
-                    false,
+                    true,
                 );
 
                 // Step 3: Verify result(s): In a short while, the canister should

--- a/rs/nns/test_utils/src/neuron_helpers.rs
+++ b/rs/nns/test_utils/src/neuron_helpers.rs
@@ -5,9 +5,10 @@ use ic_nervous_system_common_test_keys::{
     TEST_NEURON_2_OWNER_PRINCIPAL, TEST_NEURON_3_ID, TEST_NEURON_3_OWNER_PRINCIPAL,
 };
 use ic_nns_common::{pb::v1::NeuronId, types::ProposalId};
+use ic_nns_constants::ROOT_CANISTER_ID;
 use ic_nns_governance_api::pb::v1::{
-    manage_neuron_response::Command, ExecuteNnsFunction, MakeProposalRequest, Neuron, NnsFunction,
-    ProposalActionRequest,
+    install_code::CanisterInstallMode, manage_neuron_response::Command, InstallCodeRequest,
+    MakeProposalRequest, Neuron, ProposalActionRequest,
 };
 use ic_state_machine_tests::StateMachine;
 use std::collections::HashMap;
@@ -70,12 +71,13 @@ pub fn get_some_proposal() -> MakeProposalRequest {
         title: Some("<proposal created from initialization>".to_string()),
         summary: "".to_string(),
         url: "".to_string(),
-        action: Some(ProposalActionRequest::ExecuteNnsFunction(
-            ExecuteNnsFunction {
-                nns_function: NnsFunction::NnsRootUpgrade as i32,
-                payload: Vec::new(),
-            },
-        )),
+        action: Some(ProposalActionRequest::InstallCode(InstallCodeRequest {
+            canister_id: Some(ROOT_CANISTER_ID.get()),
+            wasm_module: Some(vec![]),
+            install_mode: Some(CanisterInstallMode::Upgrade as i32),
+            arg: Some(vec![]),
+            skip_stopping_before_installing: None,
+        })),
     }
 }
 

--- a/rs/tests/src/ledger_tests/transaction_ledger_correctness.rs
+++ b/rs/tests/src/ledger_tests/transaction_ledger_correctness.rs
@@ -157,12 +157,13 @@ mod holder {
     }
 
     pub async fn upgrade(rt: &Runtime, nns_canister_id: &CanisterId) {
-        ic_nns_test_utils::itest_helpers::upgrade_nns_canister_by_proposal(
+        ic_nns_test_utils::governance::upgrade_nns_canister_by_proposal(
             &Canister::new(rt, *nns_canister_id),
             &Canister::new(rt, ic_nns_constants::GOVERNANCE_CANISTER_ID),
             &Canister::new(rt, ic_nns_constants::ROOT_CANISTER_ID),
             true,
             Wasm::from_bytes(HOLDER_CANISTER_WASM.to_vec()),
+            None,
         )
         .await;
     }


### PR DESCRIPTION
This PR also has an additional commit that re-re-reverts the changes in the original PR (#1496) that caused the tests to start failing. Those changes wll be re-applied after we address the remaining parties that are affected.