### PR TITLE
fix(IDX): Make bash scripts consistent

### DIFF
--- a/rs/tests/consensus/subnet_recovery/orchestrator_universal_vm_activation.sh
+++ b/rs/tests/consensus/subnet_recovery/orchestrator_universal_vm_activation.sh
@@ -1,8 +1,11 @@
-#!/bin/sh
+#!/usr/bin/env bash
 ##########################################################################################
 ############ Configures Universal VM to run static file serving on HTTP ##################
 ##########################################################################################
 
+set -euo pipefail
+
+# set up registry, read by orchestrator tests
 mkdir web
 cd web
 cp /config/registry.tar .

--- a/rs/tests/src/btc_integration/btc_activate.sh
+++ b/rs/tests/src/btc_integration/btc_activate.sh
@@ -1,7 +1,12 @@
-#!/bin/sh
+#!/usr/bin/env bash
+
+# Load and start the bitcoind docker image
+
+set -euo pipefail
+
 cp /config/bitcoin.conf /tmp/bitcoin.conf
 docker load -i /config/bitcoind.tar
 docker run --name=bitcoind-node -d \
     --net=host \
     -v /tmp:/bitcoin/.bitcoin \
-    bitcoind:pinned -rpcbind=[::]:8332 -rpcallowip=::/0
+    bitcoind:pinned -rpcbind='[::]:8332' -rpcallowip='::/0'

--- a/rs/tests/src/custom_domains_integration/activate.sh
+++ b/rs/tests/src/custom_domains_integration/activate.sh
@@ -1,4 +1,8 @@
-#!/run/current-system/sw/bin/bash
+#!/usr/bin/env bash
+
+# Load docker images for various services. Services are started by the test driver.
+
+set -euo pipefail
 
 # load all necessary images
 

--- a/rs/tests/src/jaeger/jaeger_activate.sh
+++ b/rs/tests/src/jaeger/jaeger_activate.sh
@@ -1,4 +1,8 @@
-#!/bin/sh
+#!/usr/bin/env bash
+
+# Load the jaeger docker image and start the service
+
+set -euo pipefail
 
 docker load -i /config/jaeger.tar
 docker run -d --name jaeger \


### PR DESCRIPTION
This updates some activation scrips we had to make them more consistent. In particular scripts are changed to use bash instead of sh, and are changed to error out on the first failure. This makes debugging errors related to activation script easier.