### PR TITLE
chore: Clamp some spammy registry logs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17534,6 +17534,7 @@ dependencies = [
  "ic-nervous-system-common",
  "ic-nervous-system-common-build-metadata",
  "ic-nervous-system-common-test-keys",
+ "ic-nervous-system-string",
  "ic-nns-common",
  "ic-nns-constants",
  "ic-nns-test-utils",

--- a/rs/registry/canister/BUILD.bazel
+++ b/rs/registry/canister/BUILD.bazel
@@ -18,6 +18,7 @@ DEPENDENCIES = [
     "//rs/crypto/utils/basic_sig",
     "//rs/crypto/utils/ni_dkg",
     "//rs/nervous_system/common",
+    "//rs/nervous_system/string",
     "//rs/nns/common",
     "//rs/nns/constants",
     "//rs/protobuf",

--- a/rs/registry/canister/Cargo.toml
+++ b/rs/registry/canister/Cargo.toml
@@ -30,6 +30,7 @@ ic-metrics-encoder = "1"
 ic-nervous-system-canisters = { path = "../../nervous_system/canisters" }
 ic-nervous-system-common = { path = "../../nervous_system/common" }
 ic-nervous-system-common-build-metadata = { path = "../../nervous_system/common/build_metadata" }
+ic-nervous-system-string = { path = "../../nervous_system/string" }
 ic-nns-common = { path = "../../nns/common" }
 ic-nns-constants = { path = "../../nns/constants" }
 ic-protobuf = { path = "../../protobuf" }

--- a/rs/registry/canister/canister/canister.rs
+++ b/rs/registry/canister/canister/canister.rs
@@ -6,6 +6,7 @@ use dfn_core::{
 };
 use ic_base_types::{NodeId, PrincipalId, PrincipalIdClass};
 use ic_certified_map::{AsHashTree, HashTree};
+use ic_nervous_system_string::clamp_debug_len;
 use ic_nns_constants::{GOVERNANCE_CANISTER_ID, ROOT_CANISTER_ID};
 use ic_protobuf::registry::{
     dc::v1::{AddOrRemoveDataCentersProposalPayload, DataCenterRecord},
@@ -143,7 +144,10 @@ fn canister_init() {
             .expect("The init argument for the registry canister must be a Candid-encoded RegistryCanisterInitPayload.");
     println!(
         "{}canister_init: Initializing with: {}",
-        LOG_PREFIX, init_payload
+        LOG_PREFIX,
+        clamp_debug_len(
+            &init_payload,
+            /* max_len = */ 2000)
     );
     let registry = registry_mut();
 

--- a/rs/registry/canister/canister/canister.rs
+++ b/rs/registry/canister/canister/canister.rs
@@ -145,9 +145,7 @@ fn canister_init() {
     println!(
         "{}canister_init: Initializing with: {}",
         LOG_PREFIX,
-        clamp_debug_len(
-            &init_payload,
-            /* max_len = */ 2000)
+        clamp_debug_len(&init_payload, /* max_len = */ 2000)
     );
     let registry = registry_mut();
 

--- a/rs/registry/canister/src/invariants/checks.rs
+++ b/rs/registry/canister/src/invariants/checks.rs
@@ -19,6 +19,7 @@ use crate::{
 
 #[cfg(target_arch = "wasm32")]
 use dfn_core::println;
+use ic_nervous_system_string::clamp_debug_len;
 use ic_registry_transport::pb::v1::{registry_mutation::Type, RegistryMutation};
 
 impl Registry {
@@ -55,12 +56,14 @@ impl Registry {
 
     pub fn check_global_state_invariants(&self, mutations: &[RegistryMutation]) {
         println!(
-            "{}check_global_state_invariants: {:?}",
+            "{}check_global_state_invariants: {}",
             LOG_PREFIX,
-            mutations
-                .iter()
-                .map(RegistryMutation::to_string)
-                .collect::<Vec<_>>()
+            clamp_debug_len(
+                &(mutations
+                    .iter()
+                    .map(RegistryMutation::to_string)
+                    .collect::<Vec<_>>()),
+                /* max_len = */ 2000)
         );
 
         let snapshot = self.take_latest_snapshot_with_mutations(mutations);

--- a/rs/registry/canister/src/invariants/checks.rs
+++ b/rs/registry/canister/src/invariants/checks.rs
@@ -63,7 +63,8 @@ impl Registry {
                     .iter()
                     .map(RegistryMutation::to_string)
                     .collect::<Vec<_>>()),
-                /* max_len = */ 2000)
+                /* max_len = */ 2000
+            )
         );
 
         let snapshot = self.take_latest_snapshot_with_mutations(mutations);


### PR DESCRIPTION
# Motivation

On local testing, I noticed some logging from the registry canister with pages and pages of comma separated numbers.

For one of these I tracked down that it was added in https://github.com/dfinity/ic/commit/b8f696f07c129c905e4affb54bf0f85acf763926 so I asked ([slack](https://dfinity.slack.com/archives/C0175CHJ0P6/p1726644247928809)) the author if we need these logs. He suggested to log the first 80 bytes.
Since the `clamp_debug_len` function we use preserves an equal amount of text from the start and end, I thought a max length of 800 would work: 5 characters per byte (3 digits, a comma and a space) means 80 bytes is 400 characters.
But after trying this, I realized that the list of numbers is not right at the start of the output. I determined experimentally that a max length of 1300 shows a bit more than 80 of the initial numbers.

The other log statement was added in https://github.com/dfinity/ic/commit/024de2fc73d7f6f5df5a92edf9675851f9ebbf59 and it's unclear by whom.

So I just decided to round 1300 up to 2000 and use that in both places.

# Changes

Use `clamp_debug_len` to limit the length of the output on 2 log statements in the registry canister.

# Tested

I ran
```
rm "$(dfx cache show)"/wasms/*; dfx start --clean --background; DFX_IC_COMMIT=0441f40482386397f7c688bf508ddd901ca6c1b7 dfx nns install; dfx stop
```
And saw large stretches of numbers in the logs.

Then I built the registry canister with the changes, copied it
```
cp bazel-bin/rs/registry/canister/registry-canister.wasm.gz $(dfx cache show)/wasms/registry-canister.wasm
```
and ran
```
dfx start --clean --background; DFX_IC_COMMIT=0441f40482386397f7c688bf508ddd901ca6c1b7 dfx nns install; dfx stop
```
And then the logs looked like this:
```
...
2024-09-19 08:30:06.985929 UTC: [Canister rwlgt-iiaaa-aaaaa-aaaaa-cai] [Registry] canister_init: Initializing with: RegistryCanisterInitPayload {
    mutations: [
        RegistryAtomicMutateRequest {
            mutations: [
                RegistryMutation {
                    mutation_type: Insert,
                    key: [
                        98,
                        108,
                        101,
                        115,
                        115,
                        101,
                        100,
                        95,
                        114,
                        101,
                        112,
                        108,
                        105,
                        99,
                        97,
                        95,
                        118,
                        101,
                        114,
                        115,
                        105,
                        111,
                        110,
                        115,
                    ],
                    value: [
                        10,
             ...     117,
                        110,
                        97,
                        115,
                        115,
                        105,
                        103,
                        110,
                        101,
                        100,
                        95,
                        110,
                        111,
                        100,
                        101,
                        115,
                        95,
                        99,
                        111,
                        110,
                        102,
                        105,
                        103,
                    ],
                    value: [
                        18,
                        5,
                        48,
                        46,
                        57,
                        46,
                        48,
                    ],
                },
            ],
            preconditions: [],
        },
    ],
}
2024-09-19 08:30:06.985929 UTC: [Canister rwlgt-iiaaa-aaaaa-aaaaa-cai] [Registry] Received a mutate call containing a list of 19 mutations
2024-09-19 08:30:06.985929 UTC: [Canister rwlgt-iiaaa-aaaaa-aaaaa-cai] [Registry] check_global_state_invariants: [
    "RegistryMutation { mutation_type: insert, key: blessed_replica_versions, value: \n\u{5}0.9.0 }",
    "RegistryMutation { mutation_type: insert, key: catch_up_package_contents_qla36-av5zu-5q3qc-fgrdu-fzdgf-af7xo-ghzdt-5foq2-g3cp7-r566a-2qe, value: [10, 176, 33, 10, 50, 18, 10, 0, 0, 0, 0, 0, 0, 0, 0, 252, 1, 32, 1, 42, 34, 10, 32, 167, 237, 225, 199, 233, 164, 201, 48, 218, 158, 87, 55, 148, 0, 194, 205, 238, 36, 138, 232, 231, 91, 13, 165, 228, 199, 57, 40, 53, 171, 16, 16, 16, 1, 26, 29, 121, 219, 155, 85, 100, 100, 228, 152, 13, 84, 245, 54, 216, 90, 145, 183, 158, 123, 111, 245, 229, 106, 101, 178, 235, 177, 59, 198, 2, 32, 1, 42, 214, 32, 161, 113, 71, 114, 111, 116, 104, 50, 48, 95, 66, 108, 115, 49, 50, 95, 51, 56, 49, 162, 115, 112, 117, 98, 108, 105, 99, 95, 99, 111, 101, 102, 102, 105, 99, 105, 101, 110, 116, 115, 161, 108, 99, 111, 101, 102, 102, 105, 99, 105, 101, 110, 116, 115, 129, 88, 96, 164, 26, 191, 115, 75, 23, 19, 75, 34, 130, 191, 114, 110, 12, 197, 14, 252,...40, 11, 251, 184, 199, 200, 231, 210, 186, 26, 54, 196, 255, 199, 190, 240, 53, 2] }",
    "RegistryMutation { mutation_type: insert, key: subnet_record_qla36-av5zu-5q3qc-fgrdu-fzdgf-af7xo-ghzdt-5foq2-g3cp7-r566a-2qe, value: [26, 29, 121, 219, 155, 85, 100, 100, 228, 152, 13, 84, 245, 54, 216, 90, 145, 183, 158, 123, 111, 245, 229, 106, 101, 178, 235, 177, 59, 198, 2, 40, 128, 128, 224, 1, 56, 184, 23, 64, 216, 4, 74, 5, 48, 46, 57, 46, 48, 80, 199, 1, 120, 2, 128, 1, 1, 144, 1, 232, 7, 152, 1, 128, 128, 128, 2, 186, 1, 4, 16, 1, 24, 1, 234, 1, 78, 10, 24, 10, 18, 10, 16, 8, 1, 18, 12, 100, 102, 120, 95, 116, 101, 115, 116, 95, 107, 101, 121, 24, 1, 32, 64, 10, 24, 10, 18, 18, 16, 8, 1, 18, 12, 100, 102, 120, 95, 116, 101, 115, 116, 95, 107, 101, 121, 24, 1, 32, 64, 10, 24, 10, 18, 18, 16, 8, 2, 18, 12, 100, 102, 120, 95, 116, 101, 115, 116, 95, 107, 101, 121, 24, 1, 32, 64] }",
    "RegistryMutation { mutation_type: insert, key: unassigned_nodes_config, value: \u{12}\u{5}0.9.0 }",
]
...
```