### PR TITLE
fix(IDX): Generate CI config on dev-gh branches

### DIFF
--- a/.github/workflows/ci-generate-ci.yml
+++ b/.github/workflows/ci-generate-ci.yml
@@ -1,6 +1,9 @@
 name: CI Generate CI
 
 on:
+  push:
+    branches:
+      - 'dev-gh-*' # trigger workflow on dev branches
   pull_request:
     paths:
       - ".github/workflows-source/*.yml"
@@ -16,9 +19,16 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        # If this is a pull request, use the HEAD ref instead of the merge commit
+        if: github.event_name == 'pull_request'
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.ref }}
+          token: ${{ secrets.IDX_PUSH_TO_PR }}
+      - name: Checkout
+        uses: actions/checkout@v4
+        if: github.event_name != 'pull_request'
+        with:
           token: ${{ secrets.IDX_PUSH_TO_PR }}
       - name: Set up Python
         uses: actions/setup-python@v5


### PR DESCRIPTION
This changes the `ci-generate-ci` workflow triggers to also run on `dev-gh-*` branches. This helps test out new CI configuration without having to create a (draft) PR.