### PR TITLE
test(sns): Use realistic data to test treasury proposals with inflation.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9841,6 +9841,15 @@ name = "ic-nervous-system-string"
 version = "0.0.1"
 
 [[package]]
+name = "ic-nervous-system-stub-cycles-minting-canister"
+version = "0.0.1"
+dependencies = [
+ "candid",
+ "cycles-minting-canister",
+ "ic-cdk 0.13.5",
+]
+
+[[package]]
 name = "ic-nervous-system-temporary"
 version = "0.0.1"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9841,7 +9841,7 @@ name = "ic-nervous-system-string"
 version = "0.0.1"
 
 [[package]]
-name = "ic-nervous-system-stub-cycles-minting-canister"
+name = "ic-nervous-system-stub-cycles-minting"
 version = "0.0.1"
 dependencies = [
  "candid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -181,6 +181,7 @@ members = [
     "rs/nervous_system/root",
     "rs/nervous_system/runtime",
     "rs/nervous_system/string",
+    "rs/nervous_system/stub_cycles_minting",
     "rs/nervous_system/temporary",
     "rs/nervous_system/tools/sync-with-released-nevous-system-wasms",
     "rs/nns/constants",

--- a/rs/nervous_system/stub_cycles_minting/BUILD.bazel
+++ b/rs/nervous_system/stub_cycles_minting/BUILD.bazel
@@ -1,0 +1,19 @@
+load("//bazel:canisters.bzl", "rust_canister")
+
+package(default_visibility = ["//rs/nervous_system:default_visibility"])
+
+DEPENDENCIES = [
+    # Keep sorted.
+    "@crate_index//:candid",
+    "@crate_index//:ic-cdk",
+    "//rs/nns/cmc",
+]
+
+rust_canister(
+    name = "stub_cycles_minting",
+    srcs = [
+        "src/main.rs",
+    ],
+    service_file = "stub_cycles_minting.did",
+    deps = DEPENDENCIES,
+)

--- a/rs/nervous_system/stub_cycles_minting/Cargo.toml
+++ b/rs/nervous_system/stub_cycles_minting/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "ic-nervous-system-stub-cycles-minting"
+version = "0.0.1"
+edition = { workspace = true }
+
+[[bin]]
+name = "stub-cycles-minting"
+path = "src/main.rs"
+
+[dependencies]
+candid = { workspace = true }
+ic-cdk = { workspace = true }
+cycles-minting-canister = { path = "../../nns/cmc" }

--- a/rs/nervous_system/stub_cycles_minting/src/main.rs
+++ b/rs/nervous_system/stub_cycles_minting/src/main.rs
@@ -1,0 +1,21 @@
+use ic_cdk::api::time as time_timestamp_ns;
+use cycles_minting_canister::{IcpXdrConversionRateCertifiedResponse, IcpXdrConversionRate};
+
+const NANOS_PER_UNIT: u64 = 1_000_000_000;
+
+#[ic_cdk::query]
+fn get_average_icp_xdr_conversion_rate() -> IcpXdrConversionRateCertifiedResponse {
+    IcpXdrConversionRateCertifiedResponse {
+        data: IcpXdrConversionRate {
+            timestamp_seconds: time_timestamp_ns().checked_div(NANOS_PER_UNIT).unwrap(),
+            // 6.12 XDR per ICP, which is close to the current price on the market.
+            xdr_permyriad_per_icp: 61_200,
+        },
+
+        // This stub does not support certified responses.
+        hash_tree: vec![],
+        certificate: vec![],
+    }
+}
+
+fn main() {}

--- a/rs/nervous_system/stub_cycles_minting/stub_cycles_minting.did
+++ b/rs/nervous_system/stub_cycles_minting/stub_cycles_minting.did
@@ -1,0 +1,28 @@
+// The subset of the real cycles-minting canister that we support.
+//
+// Perhaps, surprisingly, this is where we get the average price of ICP, not the
+// exchange rate canister. In particular, we partially support the
+// get_average_icp_xdr_conversion_rate. That method is not declared in cmc.did,
+// even though the canister supplies that method.
+
+type IcpXdrConversionRateResponse = record {
+  data : IcpXdrConversionRate;
+
+  // Certified responses are not supported (yet). OTOH, adding support should
+  // not throw off any existing users.
+  hash_tree : blob;
+  certificate : blob;
+};
+
+type IcpXdrConversionRate = record {
+  // Always contains the current time.
+  timestamp_seconds : nat64;
+
+  // Always contains the value 61_200, which indicates that the price of 1 ICP
+  // is 6.12 XDR, which is close to the current price (as of this writing).
+  xdr_permyriad_per_icp : nat64;
+};
+
+service {
+  get_average_icp_xdr_conversion_rate : () -> (IcpXdrConversionRateResponse) query;
+}

--- a/rs/sns/integration_tests/BUILD.bazel
+++ b/rs/sns/integration_tests/BUILD.bazel
@@ -1,6 +1,6 @@
 load("@rules_rust//rust:defs.bzl", "rust_library")
 load("//bazel:canisters.bzl", "rust_canister")
-load("//bazel:defs.bzl", "rust_ic_test_suite_with_extra_srcs")
+load("//bazel:defs.bzl", "rust_ic_test", "rust_ic_test_suite_with_extra_srcs")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -64,6 +64,7 @@ BASE_DEV_DEPENDENCIES = [
     "//rs/nervous_system/proto",
     "//rs/nervous_system/root",
     "//rs/nns/common",
+    "//rs/nns/test_utils/golden_nns_state",
     "//rs/protobuf",
     "//rs/rosetta-api/icp_ledger",
     "//rs/rust_canisters/http_types",
@@ -82,16 +83,17 @@ BASE_DEV_DEPENDENCIES = [
 
 # Each target declared in this file may choose either these (release-ready)
 # dependencies (`DEV_DEPENDENCIES`), or `TEST_DEV_DEPENDENCIES` feature previews.
-# (Currently not used)
-# DEV_DEPENDENCIES = BASE_DEV_DEPENDENCIES + [
-#     "//rs/nns/governance/api",
-#     "//rs/nns/sns-wasm",
-#     "//rs/nns/test_utils",
-#     "//rs/sns/governance",
-#     "//rs/sns/swap",
-# ]
+DEV_DEPENDENCIES = BASE_DEV_DEPENDENCIES + [
+    # Keep sorted.
+    "//rs/nns/governance/api",
+    "//rs/nns/sns-wasm",
+    "//rs/nns/test_utils",
+    "//rs/sns/governance",
+    "//rs/sns/swap",
+]
 
 TEST_DEV_DEPENDENCIES = BASE_DEV_DEPENDENCIES + [
+    # Keep sorted.
     "//rs/nns/governance/api:api--test_feature",
     "//rs/nns/sns-wasm:sns-wasm--test_feature",
     "//rs/nns/test_utils:test_utils--test_feature",
@@ -201,6 +203,8 @@ rust_ic_test_suite_with_extra_srcs(
         ["src/*.rs"],
         exclude = [
             "src/lib.rs",
+            # Tests that are broken out into their own rules below.
+            "src/inflation_relaxes_treasury_proposal_limits.rs",
         ],
     ),
     aliases = ALIASES,
@@ -215,4 +219,38 @@ rust_ic_test_suite_with_extra_srcs(
     proc_macro_deps = MACRO_DEPENDENCIES + MACRO_DEV_DEPENDENCIES,
     tags = ["cpu:8"],
     deps = DEPENDENCIES_WITH_TEST_FEATURES + TEST_DEV_DEPENDENCIES,
+)
+
+rust_ic_test(
+    name = "inflation_relaxes_treasury_proposal_limits",
+    # Because this downloads ~ 7 GB (via ssh). Not sure how much RAM (at peak)
+    # this uses. Might make sense for this to have a smaller size.
+    size = "enormous",
+    srcs = [
+        "src/inflation_relaxes_treasury_proposal_limits.rs",
+    ],
+
+    # This test depends on/uses the stub_cycles_minting WASM.
+    data = [
+        # Keep sorted.
+        "//rs/nervous_system/stub_cycles_minting",
+        "//rs/sns/governance:sns-governance-canister",
+    ],
+    # Project::cargo_bin_maybe_from_env locates WASMs via environment
+    # variable(s) of this form. See Wasm::env_var_name.
+    env = {
+        # Keep sorted.
+        "SNS_GOVERNANCE_CANISTER_WASM_PATH": "$(rootpath //rs/sns/governance:sns-governance-canister)",
+        "STUB_CYCLES_MINTING_WASM_PATH": "$(rootpath //rs/nervous_system/stub_cycles_minting)",
+    },
+
+    aliases = ALIASES,
+    crate_root = "src/inflation_relaxes_treasury_proposal_limits.rs",
+    proc_macro_deps = MACRO_DEPENDENCIES + MACRO_DEV_DEPENDENCIES,
+    tags = [
+        "nns_tests_nightly",  # Run this test in the nns-tests-nightly GitHub Action job.
+        "no-sandbox",  # such that the test can access the file $SSH_AUTH_SOCK.
+        "requires-network",  # Because mainnet state is downloaded (and used).
+    ],
+    deps = DEPENDENCIES + DEV_DEPENDENCIES,
 )

--- a/rs/sns/integration_tests/src/inflation_relaxes_treasury_proposal_limits.rs
+++ b/rs/sns/integration_tests/src/inflation_relaxes_treasury_proposal_limits.rs
@@ -97,6 +97,4 @@ fn test_inflation_relaxes_treasury_proposal_limits() {
 
     // Without taking inflation into account, this panics.
     result.unwrap();
-
-    panic!("\n\nHELLO INFLATION!\n\n");
 }

--- a/rs/sns/integration_tests/src/inflation_relaxes_treasury_proposal_limits.rs
+++ b/rs/sns/integration_tests/src/inflation_relaxes_treasury_proposal_limits.rs
@@ -1,0 +1,102 @@
+use canister_test::Project;
+use ic_base_types::{CanisterId, PrincipalId};
+use ic_nervous_system_common::E8;
+use ic_nns_constants::CYCLES_MINTING_CANISTER_ID;
+use ic_nns_test_utils::state_test_helpers::sns_make_proposal;
+use ic_nns_test_utils_golden_nns_state::new_state_machine_with_golden_sns_state_or_panic;
+use ic_sns_governance::pb::v1::{Proposal, proposal::Action, TransferSnsTreasuryFunds, NeuronId, transfer_sns_treasury_funds::TransferFrom};
+use ic_types::Cycles;
+use lazy_static::lazy_static;
+use std::str::FromStr;
+
+lazy_static! {
+    // Callee.
+    static ref SNS_GOVERNANCE_CANISTER_ID: CanisterId =
+        CanisterId::try_from_principal_id(PrincipalId::from_str("zqfso-syaaa-aaaaq-aaafq-cai").unwrap()).unwrap();
+
+    // Caller.
+    static ref PROPOSER_PRINCIPAL_ID: PrincipalId =
+        PrincipalId::from_str("gmk4q-vviqd-2vtq3-qmkcv-lbji5-pg2ca-g4rnn-r5cid-7rvm6-yxurj-pqe")
+        .unwrap();
+    static ref PROPOSER_NEURON_ID: NeuronId = NeuronId {
+        id: vec![
+            0x00, 0x0c, 0x03, 0x4e, 0x22, 0x99, 0x6c, 0xe0, 0xdd, 0x9c, 0x14, 0x77,
+            0x18, 0x20, 0x56, 0xc7, 0xa5, 0x6e, 0x00, 0xe0, 0x31, 0x8e, 0x32, 0xe4,
+            0x83, 0xa1, 0x63, 0xa6, 0x0d, 0x57, 0xb9, 0xc7,
+        ],
+    };
+}
+
+#[test]
+fn test_inflation_relaxes_treasury_proposal_limits() {
+    // Step 1: Prepare the world.
+
+    // This is very heavy, but we do it for realistic data. Most of the data
+    // loaded here is not used.
+    let state_machine = new_state_machine_with_golden_sns_state_or_panic();
+
+    eprintln!();
+    eprintln!("Creating stub cycles minting canister...");
+    // Create stub cycles minting canister.
+    //
+    // This is needed to get the price of ICP. It is probably surprising that
+    // such data is fetched from CMC instead of the exchange rate canister, but
+    // this is nevertheless whence SNS governance canisters source such data.
+    state_machine.create_canister_with_cycles(
+        Some(PrincipalId::from(CYCLES_MINTING_CANISTER_ID)),
+        Cycles::from(u64::MAX), // We do not care about this.
+        None, // settings
+    );
+    state_machine.install_existing_canister(
+        CYCLES_MINTING_CANISTER_ID,
+        Project::cargo_bin_maybe_from_env("stub-cycles-minting", /* features = */ &[]).bytes(),
+        vec![], // init args
+    )
+        .unwrap();
+    eprintln!("DONE creating stub cycles minting canister.");
+    eprintln!();
+
+    // Install the latest and greatest SNS Governance code (takes inflation into account).
+    eprintln!();
+    eprintln!("Upgrading SNS governance canister...");
+    state_machine.upgrade_canister(
+        *SNS_GOVERNANCE_CANISTER_ID,
+        Project::cargo_bin_maybe_from_env("sns-governance-canister", /* features = */ &[]).bytes(),
+        vec![], // upgrade args
+    )
+    .unwrap();
+    eprintln!("DONE upgrading SNS governance canister.");
+    eprintln!();
+
+    // Step 2: Call the code under test. Specifically, propose to take some SNS
+    // tokens from an SNS treasury. When inflation is not considered, the
+    // proposal is blocked due to the treasury being (greatly) over-valued. But
+    // with inflation, the proposal amount limit is relaxed, and thus the
+    // proposal is allowed.
+
+    let result = sns_make_proposal(
+        &state_machine,
+        *SNS_GOVERNANCE_CANISTER_ID,
+        *PROPOSER_PRINCIPAL_ID, // caller
+        PROPOSER_NEURON_ID.clone(),
+        Proposal {
+            title: "Making it Rain".to_string(),
+            summary: "Send a heap of SNS tokens to some lucky guy.".to_string(),
+            url: "https://forum.dfinity.org/make-it-rain".to_string(),
+            action: Some(Action::TransferSnsTreasuryFunds(TransferSnsTreasuryFunds {
+                from_treasury: TransferFrom::SnsTokenTreasury as i32,
+                amount_e8s: 1_000_000 * E8, // Currently, this is worth about 3_300 USD.
+                to_principal: Some(PrincipalId::new_user_test_id(42)),
+                to_subaccount: None,
+                memo: None,
+            })),
+        }
+    );
+
+    // Step 3: Inspect results.
+
+    // Without taking inflation into account, this panics.
+    result.unwrap();
+
+    panic!("\n\nHELLO INFLATION!\n\n");
+}


### PR DESCRIPTION
I'm not sure if I want to actually merge this, because the results will soon be not very useful (explained later). Merging this into master would be ok though; no false fails will result.

My main objective with this PR is to show that a test with realistic data does pass when we include the new feature, and that the test fails when the new feature is not enabled.

Currently, it is possible to to run the test without the new feature by commenting out the "Upgrading SNS governance canister..." section of code. However, commenting out won't work later on, because prior to upgrading, the new feature will already be present.

This test has proven its worth: it did find a bug, which would only surface when realistic data is used.

# Entrained Change(s)

stub cycles minting canister. All this does is return 6.12 XDRs per ICP when the get_average_icp_dxr_conversion_rate is called. This is good enough for the purposes of testing SNS treasury proposals.