### PR TITLE
refactor(nns): Remove unnecessary test_feature library

### DIFF
--- a/rs/nervous_system/integration_tests/BUILD.bazel
+++ b/rs/nervous_system/integration_tests/BUILD.bazel
@@ -32,6 +32,7 @@ BASE_DEPENDENCIES = [
         "//packages/pocket-ic",
         "//rs/crypto/sha2",
         "//rs/nervous_system/common/test_keys",
+        "//rs/nns/constants",
         "//rs/protobuf",
         "//rs/registry/canister",
         "//rs/registry/keys",
@@ -76,7 +77,6 @@ DEPENDENCIES_WITH_TEST_FEATURES = BASE_DEPENDENCIES + [
 ] + select({
     "@rules_rust//rust/platform:wasm32-unknown-unknown": [],
     "//conditions:default": [
-        "//rs/nns/constants:constants--test_feature",
         "//rs/nns/test_utils:test_utils--test_feature",
         "//rs/nns/gtc:gtc--test_feature",
         "//rs/sns/test_utils:test_utils--test_feature",

--- a/rs/nns/constants/BUILD.bazel
+++ b/rs/nns/constants/BUILD.bazel
@@ -15,12 +15,3 @@ rust_library(
     version = "0.9.0",
     deps = DEPENDENCIES,
 )
-
-rust_library(
-    name = "constants--test_feature",
-    srcs = glob(["src/**/*.rs"]),
-    crate_features = ["test"],
-    crate_name = "ic_nns_constants",
-    version = "0.9.0",
-    deps = DEPENDENCIES,
-)

--- a/rs/nns/governance/BUILD.bazel
+++ b/rs/nns/governance/BUILD.bazel
@@ -29,6 +29,7 @@ BASE_DEPENDENCIES = [
     "//rs/nervous_system/temporary",
     "//rs/nns/cmc",
     "//rs/nns/common",
+    "//rs/nns/constants",
     "//rs/nns/gtc_accounts",
     "//rs/nns/handlers/root/interface",
     "//rs/protobuf",
@@ -77,7 +78,6 @@ BASE_DEPENDENCIES = [
 # Each target declared in this file may choose either these (release-ready)
 # dependencies (`DEPENDENCIES`), or `DEPENDENCIES_WITH_TEST_FEATURES` feature previews.
 DEPENDENCIES = BASE_DEPENDENCIES + [
-    "//rs/nns/constants",
     "//rs/nns/governance/api",
     "//rs/nns/sns-wasm",
     "//rs/sns/init",
@@ -87,7 +87,6 @@ DEPENDENCIES = BASE_DEPENDENCIES + [
 
 DEPENDENCIES_WITH_TEST_FEATURES = BASE_DEPENDENCIES + [
     "//rs/nns/governance/api:api--test_feature",
-    "//rs/nns/constants:constants--test_feature",
     "//rs/nns/sns-wasm:sns-wasm--test_feature",
     "//rs/sns/init:init--test_feature",
     "//rs/sns/swap:swap--test_feature",

--- a/rs/nns/integration_tests/BUILD.bazel
+++ b/rs/nns/integration_tests/BUILD.bazel
@@ -41,6 +41,7 @@ BASE_DEPENDENCIES = [
         "//rs/crypto",
         "//rs/crypto/sha2",
         "//rs/nervous_system/root",
+        "//rs/nns/constants",
         "//rs/phantom_newtype",
         "//rs/protobuf",
         "//rs/registry/canister",
@@ -84,7 +85,6 @@ DEPENDENCIES = BASE_DEPENDENCIES + [
 ] + select({
     "@rules_rust//rust/platform:wasm32-unknown-unknown": [],
     "//conditions:default": [
-        "//rs/nns/constants",
         "//rs/nns/test_utils",
         "//rs/nns/gtc",
     ],
@@ -102,7 +102,6 @@ DEPENDENCIES_WITH_TEST_FEATURES = BASE_DEPENDENCIES + [
 ] + select({
     "@rules_rust//rust/platform:wasm32-unknown-unknown": [],
     "//conditions:default": [
-        "//rs/nns/constants:constants--test_feature",
         "//rs/nns/test_utils:test_utils--test_feature",
         "//rs/nns/gtc:gtc--test_feature",
     ],

--- a/rs/nns/sns-wasm/BUILD.bazel
+++ b/rs/nns/sns-wasm/BUILD.bazel
@@ -19,6 +19,7 @@ BASE_DEPENDENCIES = [
     "//rs/nervous_system/common",
     "//rs/nervous_system/proto",
     "//rs/nervous_system/runtime",
+    "//rs/nns/constants",
     "//rs/nns/handlers/root/interface",
     "//rs/rust_canisters/dfn_candid",
     "//rs/rust_canisters/dfn_core",
@@ -46,13 +47,11 @@ BASE_DEPENDENCIES = [
 DEPENDENCIES = BASE_DEPENDENCIES + [
     "//rs/sns/governance",
     "//rs/sns/init",
-    "//rs/nns/constants",
 ]
 
 DEPENDENCIES_WITH_TEST_FEATURES = BASE_DEPENDENCIES + [
     "//rs/sns/governance:governance--test_feature",
     "//rs/sns/init:init--test_feature",
-    "//rs/nns/constants:constants--test_feature",
 ]
 
 MACRO_DEPENDENCIES = [

--- a/rs/nns/test_utils/BUILD.bazel
+++ b/rs/nns/test_utils/BUILD.bazel
@@ -21,6 +21,7 @@ BASE_DEPENDENCIES = [
     "//rs/nervous_system/root",
     "//rs/nns/cmc",
     "//rs/nns/common",
+    "//rs/nns/constants",
     "//rs/nns/gtc_accounts",
     "//rs/nns/handlers/lifeline/impl:lifeline",
     "//rs/nns/handlers/lifeline/interface",
@@ -73,7 +74,6 @@ DEPENDENCIES = BASE_DEPENDENCIES + [
     "//rs/nns/handlers/root/impl:root",
     "//rs/sns/governance",
     "//rs/sns/init",
-    "//rs/nns/constants",
 ]
 
 DEPENDENCIES_WITH_TEST_FEATURES = BASE_DEPENDENCIES + [
@@ -84,7 +84,6 @@ DEPENDENCIES_WITH_TEST_FEATURES = BASE_DEPENDENCIES + [
     "//rs/nns/handlers/root/impl:root--test_feature",
     "//rs/sns/governance:governance--test_feature",
     "//rs/sns/init:init--test_feature",
-    "//rs/nns/constants:constants--test_feature",
 ]
 
 MACRO_DEPENDENCIES = []

--- a/rs/sns/init/BUILD.bazel
+++ b/rs/sns/init/BUILD.bazel
@@ -14,6 +14,7 @@ BASE_DEPENDENCIES = [
     "//packages/icrc-ledger-types:icrc_ledger_types",
     "//rs/nervous_system/common",
     "//rs/nervous_system/proto",
+    "//rs/nns/constants",
     "//rs/rosetta-api/icrc1/index-ng",
     "//rs/rosetta-api/icrc1/ledger",
     "//rs/rosetta-api/ledger_canister_core",
@@ -34,14 +35,12 @@ BASE_DEPENDENCIES = [
 # dependencies (`DEPENDENCIES`), or `DEPENDENCIES_WITH_TEST_FEATURES` feature previews.
 DEPENDENCIES = BASE_DEPENDENCIES + [
     "//rs/nns/governance/api",
-    "//rs/nns/constants",
     "//rs/sns/governance",
     "//rs/sns/swap",
 ]
 
 DEPENDENCIES_WITH_TEST_FEATURES = BASE_DEPENDENCIES + [
     "//rs/nns/governance/api:api--test_feature",
-    "//rs/nns/constants:constants--test_feature",
     "//rs/sns/governance:governance--test_feature",
     "//rs/sns/swap:swap--test_feature",
 ]

--- a/rs/sns/integration_tests/BUILD.bazel
+++ b/rs/sns/integration_tests/BUILD.bazel
@@ -12,6 +12,7 @@ BASE_DEPENDENCIES = [
     "//rs/nervous_system/common",
     "//rs/nervous_system/common/test_keys",
     "//rs/nns/cmc",
+    "//rs/nns/constants",
     "//rs/registry/subnet_type:subnet_type",
     "//rs/rosetta-api/icp_ledger/ledger",
     "//rs/rosetta-api/icrc1",
@@ -43,13 +44,11 @@ BASE_DEPENDENCIES = [
 DEPENDENCIES = BASE_DEPENDENCIES + [
     "//rs/sns/init",
     "//rs/sns/test_utils",
-    "//rs/nns/constants",
 ]
 
 DEPENDENCIES_WITH_TEST_FEATURES = BASE_DEPENDENCIES + [
     "//rs/sns/init:init--test_feature",
     "//rs/sns/test_utils:test_utils--test_feature",
-    "//rs/nns/constants:constants--test_feature",
 ]
 
 MACRO_DEPENDENCIES = [


### PR DESCRIPTION
This removes  "/rs/nns/constants--test_feature", which is unnecessary and complicates our builds.