### PR TITLE
refactor(nervous-system): Use `Sns` type in integration tests rather than `DeployedSns`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9728,6 +9728,7 @@ dependencies = [
  "ic-icrc1-tokens-u64",
  "ic-ledger-core",
  "ic-management-canister-types",
+ "ic-nervous-system-agent",
  "ic-nervous-system-clients",
  "ic-nervous-system-common",
  "ic-nervous-system-common-test-keys",

--- a/rs/nervous_system/integration_tests/BUILD.bazel
+++ b/rs/nervous_system/integration_tests/BUILD.bazel
@@ -6,6 +6,7 @@ package(default_visibility = ["//visibility:public"])
 # See rs/nervous_system/feature_test.md
 BASE_DEPENDENCIES = [
     # Keep sorted.
+    "//rs/nervous_system/agent",
     "//rs/nervous_system/clients",
     "//rs/nervous_system/common",
     "//rs/nervous_system/proto",

--- a/rs/nervous_system/integration_tests/Cargo.toml
+++ b/rs/nervous_system/integration_tests/Cargo.toml
@@ -13,6 +13,7 @@ candid = { workspace = true }
 cycles-minting-canister = { path = "../../nns/cmc" }
 ic-base-types = { path = "../../types/base_types" }
 ic-ledger-core = { path = "../../rosetta-api/ledger_core" }
+ic-nervous-system-agent = { path = "../agent" }
 ic-nervous-system-clients = { path = "../clients" }
 ic-nervous-system-common = { path = "../common" }
 ic-nervous-system-proto = { path = "../proto" }

--- a/rs/nervous_system/integration_tests/src/pocket_ic_helpers.rs
+++ b/rs/nervous_system/integration_tests/src/pocket_ic_helpers.rs
@@ -2,6 +2,7 @@ use candid::{Decode, Encode, Nat, Principal};
 use canister_test::Wasm;
 use ic_base_types::{CanisterId, PrincipalId, SubnetId};
 use ic_ledger_core::Tokens;
+use ic_nervous_system_agent::sns::Sns;
 use ic_nervous_system_common::{E8, ONE_DAY_SECONDS};
 use ic_nervous_system_common_test_keys::{TEST_NEURON_1_ID, TEST_NEURON_1_OWNER_PRINCIPAL};
 use ic_nns_common::pb::v1::{NeuronId, ProposalId};
@@ -45,8 +46,8 @@ use ic_sns_swap::pb::v1::{
 use ic_sns_test_utils::itest_helpers::populate_canister_ids;
 use ic_sns_wasm::pb::v1::{
     get_deployed_sns_by_proposal_id_response::GetDeployedSnsByProposalIdResult, AddWasmRequest,
-    DeployedSns, GetDeployedSnsByProposalIdRequest, GetDeployedSnsByProposalIdResponse,
-    SnsCanisterType, SnsWasm,
+    GetDeployedSnsByProposalIdRequest, GetDeployedSnsByProposalIdResponse, SnsCanisterType,
+    SnsWasm,
 };
 use icp_ledger::{AccountIdentifier, BinaryAccountBalanceArgs};
 use icrc_ledger_types::icrc1::{
@@ -845,7 +846,7 @@ pub mod nns {
             pocket_ic: &PocketIc,
             create_service_nervous_system: CreateServiceNervousSystem,
             sns_instance_label: &str,
-        ) -> (DeployedSns, ProposalId) {
+        ) -> (Sns, ProposalId) {
             let proposal_info = propose_and_wait(
                 pocket_ic,
                 MakeProposalRequest {
@@ -868,7 +869,8 @@ pub mod nns {
                     nns_proposal_id, sns_instance_label,
                 );
             };
-            (deployed_sns, nns_proposal_id)
+            let sns = Sns::try_from(deployed_sns).expect("Failed to convert DeployedSns to Sns");
+            (sns, nns_proposal_id)
         }
 
         pub fn get_network_economics_parameters(pocket_ic: &PocketIc) -> NetworkEconomics {

--- a/rs/nervous_system/integration_tests/tests/sns_lifecycle.rs
+++ b/rs/nervous_system/integration_tests/tests/sns_lifecycle.rs
@@ -39,7 +39,6 @@ use ic_sns_swap::{
     },
     swap::principal_to_subaccount,
 };
-use ic_sns_wasm::pb::v1::DeployedSns;
 use ic_test_utilities::universal_canister::UNIVERSAL_CANISTER_WASM;
 use icp_ledger::{AccountIdentifier, DEFAULT_TRANSFER_FEE};
 use icrc_ledger_types::icrc1::{account::Account, transfer::TransferArg};
@@ -384,25 +383,15 @@ fn test_sns_lifecycle(
 
     // 2. Create an SNS instance
     let sns_instance_label = "1";
-    let (deployed_sns, nns_proposal_id) = nns::governance::propose_to_deploy_sns_and_wait(
+    let (sns, nns_proposal_id) = nns::governance::propose_to_deploy_sns_and_wait(
         &pocket_ic,
         create_service_nervous_system,
         sns_instance_label,
     );
-    let DeployedSns {
-        governance_canister_id: Some(sns_governance_canister_id),
-        swap_canister_id: Some(swap_canister_id),
-        ledger_canister_id: Some(sns_ledger_canister_id),
-        root_canister_id: Some(sns_root_canister_id),
-        ..
-    } = deployed_sns
-    else {
-        panic!("Cannot find some SNS caniser IDs in {:#?}", deployed_sns);
-    };
 
     // Check that total SNS Ledger supply adds up.
     let original_total_supply_sns_e8s =
-        sns::ledger::icrc1_total_supply(&pocket_ic, sns_ledger_canister_id)
+        sns::ledger::icrc1_total_supply(&pocket_ic, sns.ledger.canister_id)
             .0
             .to_u64()
             .unwrap();
@@ -418,8 +407,8 @@ fn test_sns_lifecycle(
     );
 
     let nervous_system_parameters =
-        sns::governance::get_nervous_system_parameters(&pocket_ic, sns_governance_canister_id);
-    let swap_init = sns::swap::get_init(&pocket_ic, swap_canister_id)
+        sns::governance::get_nervous_system_parameters(&pocket_ic, sns.governance.canister_id);
+    let swap_init = sns::swap::get_init(&pocket_ic, sns.swap.canister_id)
         .init
         .unwrap();
     let sns_neurons_per_backet = swap_init
@@ -430,7 +419,7 @@ fn test_sns_lifecycle(
     // This set is used to determine SNS neurons created as a result of the swap (by excluding those
     // which are in this collection).
     let original_sns_neuron_ids: BTreeSet<_> =
-        sns::governance::list_neurons(&pocket_ic, sns_governance_canister_id)
+        sns::governance::list_neurons(&pocket_ic, sns.governance.canister_id)
             .neurons
             .into_iter()
             .map(|sns_neuron| sns_neuron.id.unwrap())
@@ -438,7 +427,7 @@ fn test_sns_lifecycle(
 
     // Assert that the mode of SNS Governance is `PreInitializationSwap`.
     assert_eq!(
-        sns::governance::get_mode(&pocket_ic, sns_governance_canister_id)
+        sns::governance::get_mode(&pocket_ic, sns.governance.canister_id)
             .mode
             .unwrap(),
         sns_pb::governance::Mode::PreInitializationSwap as i32
@@ -450,7 +439,7 @@ fn test_sns_lifecycle(
     let (sns_neuron_id, sns_neuron_principal_id) =
         sns::governance::find_neuron_with_majority_voting_power(
             &pocket_ic,
-            sns_governance_canister_id,
+            sns.governance.canister_id,
         )
         .expect("cannot find SNS neuron with dissolve delay over 6 months.");
 
@@ -458,7 +447,7 @@ fn test_sns_lifecycle(
     {
         let err = sns::governance::propose_and_wait(
             &pocket_ic,
-            sns_governance_canister_id,
+            sns.governance.canister_id,
             sns_neuron_principal_id,
             sns_neuron_id.clone(),
             sns_pb::Proposal {
@@ -497,7 +486,7 @@ fn test_sns_lifecycle(
     // Check that the dapp canisters are now controlled by SNS Root and NNS Root.
     {
         let expected_new_controllers =
-            BTreeSet::from([sns_root_canister_id, ROOT_CANISTER_ID.get()]);
+            BTreeSet::from([sns.root.canister_id, ROOT_CANISTER_ID.get()]);
         for dapp_canister_id in dapp_canister_ids.clone() {
             let sender = expected_new_controllers // the sender must be a controller
                 .first()
@@ -520,7 +509,7 @@ fn test_sns_lifecycle(
     {
         let start_dissolving_response = sns::governance::start_dissolving_neuron(
             &pocket_ic,
-            sns_governance_canister_id,
+            sns.governance.canister_id,
             sns_neuron_principal_id,
             sns_neuron_id.clone(),
         );
@@ -549,11 +538,11 @@ fn test_sns_lifecycle(
         };
     }
 
-    sns::swap::await_swap_lifecycle(&pocket_ic, swap_canister_id, Lifecycle::Open).unwrap();
+    sns::swap::await_swap_lifecycle(&pocket_ic, sns.swap.canister_id, Lifecycle::Open).unwrap();
 
     // Check that the swap cannot be finalized yet.
     {
-        let response = sns::swap::finalize_swap(&pocket_ic, swap_canister_id);
+        let response = sns::swap::finalize_swap(&pocket_ic, sns.swap.canister_id);
         let error_message = assert_matches!(response, FinalizeSwapResponse {
             error_message: Some(error_message),
             sweep_icp_result: None,
@@ -574,7 +563,7 @@ fn test_sns_lifecycle(
 
     // Check that the derived state correctly reflects the pre-state of the swap.
     {
-        let derived_state = sns::swap::get_derived_state(&pocket_ic, swap_canister_id);
+        let derived_state = sns::swap::get_derived_state(&pocket_ic, sns.swap.canister_id);
         assert_eq!(
             derived_state,
             GetDerivedStateResponse {
@@ -601,7 +590,7 @@ fn test_sns_lifecycle(
     {
         let direct_participant_swap_subaccount = Some(principal_to_subaccount(&direct_participant));
         let direct_participant_swap_account = Account {
-            owner: swap_canister_id.0,
+            owner: sns.swap.canister_id.0,
             subaccount: direct_participant_swap_subaccount,
         };
         // Participate with as much as we have minus the transfer fee
@@ -625,7 +614,7 @@ fn test_sns_lifecycle(
             // Creating a ticket for this participation should succeed even before the ICP transfer.
             let response = sns::swap::new_sale_ticket(
                 &pocket_ic,
-                swap_canister_id,
+                sns.swap.canister_id,
                 direct_participant,
                 expected_accepted_participation_amount_e8s,
             )
@@ -663,7 +652,8 @@ fn test_sns_lifecycle(
     let direct_sns_neuron_recipients = if ensure_swap_timeout_is_reached {
         // Await the end of the swap period.
         pocket_ic.advance_time(Duration::from_secs(30 * ONE_DAY_SECONDS)); // 30 days
-        sns::swap::await_swap_lifecycle(&pocket_ic, swap_canister_id, Lifecycle::Aborted).unwrap();
+        sns::swap::await_swap_lifecycle(&pocket_ic, sns.swap.canister_id, Lifecycle::Aborted)
+            .unwrap();
         vec![]
     } else {
         let mut direct_sns_neuron_recipients = vec![];
@@ -682,16 +672,19 @@ fn test_sns_lifecycle(
 
             // Precondition: The buyer does not have a buyer state.
             {
-                let response =
-                    sns::swap::get_buyer_state(&pocket_ic, swap_canister_id, direct_participant)
-                        .expect("Swap.get_buyer_state response should be Ok.");
+                let response = sns::swap::get_buyer_state(
+                    &pocket_ic,
+                    sns.swap.canister_id,
+                    direct_participant,
+                )
+                .expect("Swap.get_buyer_state response should be Ok.");
                 assert_eq!(response.buyer_state, None);
             }
 
             // Execute the operation under test.
             let response = sns::swap::refresh_buyer_tokens(
                 &pocket_ic,
-                swap_canister_id,
+                sns.swap.canister_id,
                 direct_participant,
                 None,
             );
@@ -707,9 +700,12 @@ fn test_sns_lifecycle(
 
             // Postcondition B: The buyer has an expected buyer state.
             {
-                let response =
-                    sns::swap::get_buyer_state(&pocket_ic, swap_canister_id, direct_participant)
-                        .expect("Swap.get_buyer_state response should be Ok.");
+                let response = sns::swap::get_buyer_state(
+                    &pocket_ic,
+                    sns.swap.canister_id,
+                    direct_participant,
+                )
+                .expect("Swap.get_buyer_state response should be Ok.");
                 let (icp, has_created_neuron_recipes) = assert_matches!(
                     response.buyer_state,
                     Some(BuyerState {
@@ -730,9 +726,12 @@ fn test_sns_lifecycle(
 
             // Postcondition C: the ticket has been deleted.
             {
-                let response =
-                    sns::swap::get_open_ticket(&pocket_ic, swap_canister_id, direct_participant)
-                        .expect("Swap.get_open_ticket response should be Ok.");
+                let response = sns::swap::get_open_ticket(
+                    &pocket_ic,
+                    sns.swap.canister_id,
+                    direct_participant,
+                )
+                .expect("Swap.get_open_ticket response should be Ok.");
                 assert_eq!(response.ticket(), Ok(None));
             }
 
@@ -745,7 +744,8 @@ fn test_sns_lifecycle(
         } else {
             Lifecycle::Committed
         };
-        sns::swap::await_swap_lifecycle(&pocket_ic, swap_canister_id, expected_lifecycle).unwrap();
+        sns::swap::await_swap_lifecycle(&pocket_ic, sns.swap.canister_id, expected_lifecycle)
+            .unwrap();
         direct_sns_neuron_recipients
     };
 
@@ -763,7 +763,7 @@ fn test_sns_lifecycle(
             };
         if let Err(err) = sns::swap::await_swap_finalization_status(
             &pocket_ic,
-            swap_canister_id,
+            sns.swap.canister_id,
             expected_swap_finalization_status,
         ) {
             println!("{}", err);
@@ -778,7 +778,7 @@ fn test_sns_lifecycle(
     // Participation is no longer possible due to Swap being in a terminal state.
     for direct_participant in direct_participants.keys() {
         let err = assert_matches!(
-            sns::swap::refresh_buyer_tokens(&pocket_ic, swap_canister_id, *direct_participant, None),
+            sns::swap::refresh_buyer_tokens(&pocket_ic, sns.swap.canister_id, *direct_participant, None),
             Err(err) => err
         );
         assert!(err.contains("Participation is possible only when the Swap is in the OPEN state."));
@@ -801,7 +801,7 @@ fn test_sns_lifecycle(
             };
 
         let error_refund_icp_result =
-            sns::swap::error_refund_icp(&pocket_ic, swap_canister_id, direct_participant)
+            sns::swap::error_refund_icp(&pocket_ic, sns.swap.canister_id, direct_participant)
                 .result
                 .expect("Error while calling Swap.error_refund_icp");
 
@@ -972,7 +972,7 @@ fn test_sns_lifecycle(
         });
 
         assert_eq!(
-            sns::swap::finalize_swap(&pocket_ic, swap_canister_id),
+            sns::swap::finalize_swap(&pocket_ic, sns.swap.canister_id),
             FinalizeSwapResponse {
                 sweep_icp_result: expected_sweep_icp_result,
                 create_sns_neuron_recipes_result: expected_create_sns_neuron_recipes_result,
@@ -1056,7 +1056,7 @@ fn test_sns_lifecycle(
                 .unwrap_or(0.0) as f64,
         );
 
-        let observed_derived_state = sns::swap::get_derived_state(&pocket_ic, swap_canister_id);
+        let observed_derived_state = sns::swap::get_derived_state(&pocket_ic, sns.swap.canister_id);
         assert_eq!(
             observed_derived_state,
             GetDerivedStateResponse {
@@ -1074,14 +1074,14 @@ fn test_sns_lifecycle(
     // Assert that the mode of SNS Governance is correct
     if swap_finalization_status == SwapFinalizationStatus::Aborted {
         assert_eq!(
-            sns::governance::get_mode(&pocket_ic, sns_governance_canister_id)
+            sns::governance::get_mode(&pocket_ic, sns.governance.canister_id)
                 .mode
                 .unwrap(),
             sns_pb::governance::Mode::PreInitializationSwap as i32,
         );
     } else {
         assert_eq!(
-            sns::governance::get_mode(&pocket_ic, sns_governance_canister_id)
+            sns::governance::get_mode(&pocket_ic, sns.governance.canister_id)
                 .mode
                 .unwrap(),
             sns_pb::governance::Mode::Normal as i32
@@ -1090,7 +1090,7 @@ fn test_sns_lifecycle(
 
     // Validate `get_sns_canisters_summary`.
     {
-        let response = sns::root::get_sns_canisters_summary(&pocket_ic, sns_root_canister_id);
+        let response = sns::root::get_sns_canisters_summary(&pocket_ic, sns.root.canister_id);
         let observed_dapp_canister_ids = response
             .dapps
             .into_iter()
@@ -1111,7 +1111,7 @@ fn test_sns_lifecycle(
     {
         let proposal_result = sns::governance::propose_and_wait(
             &pocket_ic,
-            sns_governance_canister_id,
+            sns.governance.canister_id,
             sns_neuron_principal_id,
             sns_neuron_id.clone(),
             sns_pb::Proposal {
@@ -1156,7 +1156,7 @@ fn test_sns_lifecycle(
     {
         let start_dissolving_response = sns::governance::start_dissolving_neuron(
             &pocket_ic,
-            sns_governance_canister_id,
+            sns.governance.canister_id,
             sns_neuron_principal_id,
             sns_neuron_id,
         );
@@ -1197,14 +1197,14 @@ fn test_sns_lifecycle(
     {
         let sns_governance_canister_balance_sns_e8s = {
             let treasury_subaccount = compute_distribution_subaccount_bytes(
-                sns_governance_canister_id,
+                sns.governance.canister_id,
                 TREASURY_SUBACCOUNT_NONCE,
             );
             let sns_treasury_account = Account {
-                owner: sns_governance_canister_id.0,
+                owner: sns.governance.canister_id.0,
                 subaccount: Some(treasury_subaccount),
             };
-            sns::ledger::icrc1_balance_of(&pocket_ic, sns_ledger_canister_id, sns_treasury_account)
+            sns::ledger::icrc1_balance_of(&pocket_ic, sns.ledger.canister_id, sns_treasury_account)
                 .0
                 .to_u64()
                 .unwrap()
@@ -1219,9 +1219,9 @@ fn test_sns_lifecycle(
     {
         let swap_canister_balance_sns_e8s = sns::ledger::icrc1_balance_of(
             &pocket_ic,
-            sns_ledger_canister_id,
+            sns.ledger.canister_id,
             Account {
-                owner: swap_canister_id.0,
+                owner: sns.swap.canister_id.0,
                 subaccount: None,
             },
         )
@@ -1241,7 +1241,7 @@ fn test_sns_lifecycle(
     //    the number of transactions from the creation of this SNS.
     {
         let total_supply_sns_e8s =
-            sns::ledger::icrc1_total_supply(&pocket_ic, sns_ledger_canister_id)
+            sns::ledger::icrc1_total_supply(&pocket_ic, sns.ledger.canister_id)
                 .0
                 .to_u64()
                 .unwrap();
@@ -1361,7 +1361,7 @@ fn test_sns_lifecycle(
                 }
             };
         let sns_neurons =
-            sns::governance::list_neurons(&pocket_ic, sns_governance_canister_id).neurons;
+            sns::governance::list_neurons(&pocket_ic, sns.governance.canister_id).neurons;
         // Validate that the set of SNS neuron hotkeys and controllers is expected.
         {
             let observed_neuron_permissions = sns_neurons
@@ -1587,9 +1587,9 @@ fn test_sns_lifecycle(
                         let subaccount = sns_neuron.id.as_ref().unwrap().subaccount().unwrap();
                         let observed_balance_e8s = sns::ledger::icrc1_balance_of(
                             &pocket_ic,
-                            sns_ledger_canister_id,
+                            sns.ledger.canister_id,
                             Account {
-                                owner: sns_governance_canister_id.0,
+                                owner: sns.governance.canister_id.0,
                                 subaccount: Some(subaccount),
                             },
                         )
@@ -1671,7 +1671,7 @@ fn test_sns_lifecycle(
     // to a function in the `rs/sns/audit` crate.
     {
         let sns_neuron_recipes =
-            sns::swap::list_sns_neuron_recipes(&pocket_ic, swap_canister_id).sns_neuron_recipes;
+            sns::swap::list_sns_neuron_recipes(&pocket_ic, sns.swap.canister_id).sns_neuron_recipes;
         use ic_sns_swap::pb::v1::sns_neuron_recipe::Investor;
         {
             let direct_participant_sns_neuron_recipes: Vec<_> = sns_neuron_recipes
@@ -1845,7 +1845,7 @@ fn test_sns_lifecycle(
                 fallback_controllers.into_iter().collect::<BTreeSet<_>>()
             } else {
                 // The SNS swap has succeeded  ==>  root should have sole control.
-                BTreeSet::from([sns_root_canister_id])
+                BTreeSet::from([sns.root.canister_id])
             };
         for dapp_canister_id in dapp_canister_ids {
             let sender = expected_new_controllers // the sender must be a controller
@@ -1868,13 +1868,13 @@ fn test_sns_lifecycle(
     // Ensure that the archive canister is spawned and can be found through SNS Root.
     sns::ensure_archive_canister_is_spawned_or_panic(
         &pocket_ic,
-        sns_governance_canister_id,
-        sns_ledger_canister_id,
+        sns.governance.canister_id,
+        sns.ledger.canister_id,
     );
     // SNS Root polls archives every 24 hours, so we need to advance time to trigger the polling.
     pocket_ic.advance_time(Duration::from_secs(24 * 60 * 60));
     pocket_ic.tick();
-    let response = sns::root::get_sns_canisters_summary(&pocket_ic, sns_root_canister_id);
+    let response = sns::root::get_sns_canisters_summary(&pocket_ic, sns.root.canister_id);
     assert!(
         !response.archives_canister_summaries().is_empty(),
         "No archives found from get_sns_canisters_summary response: {:#?}",
@@ -1884,7 +1884,7 @@ fn test_sns_lifecycle(
     // Check that the SNS framework canister settings are as expected
     {
         // get SNS canisters summary
-        let sns_canisters_summary = get_sns_canisters_summary(&pocket_ic, sns_root_canister_id);
+        let sns_canisters_summary = get_sns_canisters_summary(&pocket_ic, sns.root.canister_id);
         fn get_wasm_memory_limit(summary: Option<CanisterSummary>) -> u64 {
             u64::try_from(
                 summary


### PR DESCRIPTION
Unlike `DeployedSns`, the `Sns` type has no optional fields. This means we can remove the repetitive unwrapping in every test that deploys an SNS. The `Sns` type also has some utility functions on it that can be used in the integration tests once #1590 is merged