### PR TITLE
test: Bump XNet hotfix test timeout

### DIFF
--- a/rs/tests/message_routing/xnet/xnet_slo_3_subnets_hotfix_test.rs
+++ b/rs/tests/message_routing/xnet/xnet_slo_3_subnets_hotfix_test.rs
@@ -12,8 +12,8 @@ const NODES_PER_SUBNET: usize = 4;
 const RUNTIME: Duration = Duration::from_secs(120);
 const REQUEST_RATE: usize = 10;
 
-const PER_TASK_TIMEOUT: Duration = Duration::from_secs(250);
-const OVERALL_TIMEOUT: Duration = Duration::from_secs(350);
+const PER_TASK_TIMEOUT: Duration = Duration::from_secs(350);
+const OVERALL_TIMEOUT: Duration = Duration::from_secs(450);
 
 fn main() -> Result<()> {
     let config = Config::new(SUBNETS, NODES_PER_SUBNET, RUNTIME, REQUEST_RATE);


### PR DESCRIPTION
After setting the XNet tests to non flaky I saw some timeouts of the test below, suggesting that the test setup can be slow in certain scenarios. This PR bumps the timeouts.