### PR TITLE
fix(IDX): Bazel build output and bes link

### DIFF
--- a/.github/actions/bazel-test-all/action.yaml
+++ b/.github/actions/bazel-test-all/action.yaml
@@ -31,7 +31,7 @@ runs:
         id: bazel-test-all
         shell: bash
         run: |
-          set -x +e
+          set +e # manual error handling to ensure we can run some post-build commands
 
           # temporarily set permissions again until we can figure out issue
           if [ -e /cache ]; then
@@ -51,7 +51,14 @@ runs:
           BAZEL_EXIT_CODE="$?"
 
           if [ -n "$HONEYCOMB_API_TOKEN" ] && [ -f ./bazel-bep.pb ]; then
-              bazel run //bazel/exporter:exporter --build_event_binary_file= -- -f "$(pwd)/bazel-bep.pb"
+              # avoid output unless an error occurs during bes export. This ensures
+              # only the (more relevant) output from the main bazel command is shown.
+              exportout=$(mktemp)
+              if ! bazel run //bazel/exporter:exporter --build_event_binary_file= -- -f "$(pwd)/bazel-bep.pb" 2> "$exportout" >&2; then
+                echo "bes export failed:"
+                cat "$exportout"
+              fi
+              rm "$exportout"
           fi
 
           exit "$BAZEL_EXIT_CODE"


### PR DESCRIPTION
This streamlines the output as shown on CI in two ways:
* The bazel-exporter output is hidden (unless it errors out) which allows the reader to focus on the output of the main command,
* `set -x` is removed which allows the reader to focus on the output of the main command,
* The BuildBuddy URL is repeated at the end of the build.

NOTE: the previous implementation used process substitution, which might break under some circumstances (when bash doesn't wait for `awk` to finish). Instead, simple piping is used (and stderr & stdout are merged & passed to `awk`).