### PR TITLE
fix: fix a metric for counting actually executed canisters per round

### DIFF
--- a/rs/execution_environment/src/scheduler.rs
+++ b/rs/execution_environment/src/scheduler.rs
@@ -898,6 +898,7 @@ impl SchedulerImpl {
     /// The given `canisters_by_thread` defines the priority of canisters.
     /// Returns:
     /// - the new states of the canisters,
+    /// - the actually executed canister ids,
     /// - the ingress results,
     /// - the maximum number of instructions executed on a thread,
     /// - the total heap delta.
@@ -2060,7 +2061,6 @@ fn execute_canisters_on_thread(
 
             let instructions_before = round_limits.instructions;
             let canister_had_paused_execution = canister.has_paused_execution();
-            let canister_id = canister.canister_id();
             let ExecuteCanisterResult {
                 canister: new_canister,
                 instructions_used,
@@ -2077,7 +2077,10 @@ fn execute_canisters_on_thread(
                 &mut round_limits,
                 subnet_size,
             );
-            executed_canister_ids.insert(canister_id);
+            if instructions_used.unwrap_or(0.into()) > 0.into() {
+                // We only want to count the canister as executed if it used instructions.
+                executed_canister_ids.insert(new_canister.canister_id());
+            }
             ingress_results.extend(ingress_status);
             let round_instructions_executed =
                 as_num_instructions(instructions_before - round_limits.instructions);

--- a/rs/execution_environment/src/scheduler.rs
+++ b/rs/execution_environment/src/scheduler.rs
@@ -2060,7 +2060,7 @@ fn execute_canisters_on_thread(
 
             let instructions_before = round_limits.instructions;
             let canister_had_paused_execution = canister.has_paused_execution();
-            let canister_id = canister.canister_id().clone();
+            let canister_id = canister.canister_id();
             let ExecuteCanisterResult {
                 canister: new_canister,
                 instructions_used,

--- a/rs/execution_environment/src/scheduler.rs
+++ b/rs/execution_environment/src/scheduler.rs
@@ -883,7 +883,7 @@ impl SchedulerImpl {
             .observe(round_filtered_canisters.active_canister_ids.len() as f64);
         self.metrics
             .executed_canisters_per_round
-            .set(round_executed_canister_ids.len() as i64);
+            .observe(round_executed_canister_ids.len() as f64);
 
         self.metrics
             .heap_delta_rate_limited_canisters_per_round

--- a/rs/execution_environment/src/scheduler.rs
+++ b/rs/execution_environment/src/scheduler.rs
@@ -2077,7 +2077,7 @@ fn execute_canisters_on_thread(
                 &mut round_limits,
                 subnet_size,
             );
-            if instructions_used.unwrap_or(0.into()) > 0.into() {
+            if instructions_used.map_or(false, |instructions| instructions.get() > 0) {
                 // We only want to count the canister as executed if it used instructions.
                 executed_canister_ids.insert(new_canister.canister_id());
             }

--- a/rs/execution_environment/src/scheduler/scheduler_metrics.rs
+++ b/rs/execution_environment/src/scheduler/scheduler_metrics.rs
@@ -37,7 +37,7 @@ pub(super) struct SchedulerMetrics {
     pub(super) instructions_consumed_per_message: Histogram,
     pub(super) instructions_consumed_per_round: Histogram,
     pub(super) executable_canisters_per_round: Histogram,
-    pub(super) executed_canisters_per_round: IntGauge,
+    pub(super) executed_canisters_per_round: Histogram,
     pub(super) expired_ingress_messages_count: IntCounter,
     pub(super) ingress_history_length: IntGauge,
     pub(super) msg_execution_duration: Histogram,
@@ -220,9 +220,11 @@ impl SchedulerMetrics {
                 // 1, 2, 5, …, 10000, 20000, 50000
                 decimal_buckets(0, 4),
             ),
-            executed_canisters_per_round: metrics_registry.int_gauge(
+            executed_canisters_per_round: metrics_registry.histogram(
                 "scheduler_executed_canisters_per_round",
                 "Number of canisters that were actually executed in the last round.",
+                // 1, 2, 5, …, 10000, 20000, 50000
+                decimal_buckets(0, 4),
             ),
             expired_ingress_messages_count: metrics_registry.int_counter(
                 "scheduler_expired_ingress_messages_count",


### PR DESCRIPTION
This PR improves the tracking of executed canisters during a round by refining the counting logic and switching the associated metric to a histogram.

- The previous implementation used a variable called `executed_canisters`, which represented the number of canisters initially planned for execution. However, not all planned canisters were necessarily executed due to round instruction limit. This has been renamed to `active_canisters` to clarify its meaning. The function now also returns the IDs of the canisters that were actually executed before any instruction limits were reached.

- The metric `scheduler_executed_canisters_per_round` is switched from a gauge to a histogram. Gauges led to data loss as scraping occurred every 10-20 seconds, missing changes between scrapes. A histogram stores the data in buckets, preserving information for accurate calculations. The average can be computed using `hist_stats.sum / hist_stats.count`.
