### PR TITLE
chore: make allowed viewers feature flag configurable and enable it for ic-starter

### DIFF
--- a/rs/config/src/execution_environment.rs
+++ b/rs/config/src/execution_environment.rs
@@ -284,6 +284,10 @@ pub struct Config {
     ///   - let `halfway_to_max = (memory_usage + 4GiB) / 2`
     ///   - use the maximum of `default_wasm_memory_limit` and `halfway_to_max`.
     pub default_wasm_memory_limit: NumBytes,
+
+    // TODO(EXC-1678): remove after release.
+    /// Feature flag to enable/disable allowed viewers for canister log visibility.
+    pub allowed_viewers_feature: FlagStatus,
 }
 
 impl Default for Config {
@@ -356,6 +360,7 @@ impl Default for Config {
             dirty_page_logging: FlagStatus::Disabled,
             max_canister_http_requests_in_flight: MAX_CANISTER_HTTP_REQUESTS_IN_FLIGHT,
             default_wasm_memory_limit: DEFAULT_WASM_MEMORY_LIMIT,
+            allowed_viewers_feature: FlagStatus::Disabled,
         }
     }
 }

--- a/rs/execution_environment/src/query_handler.rs
+++ b/rs/execution_environment/src/query_handler.rs
@@ -204,7 +204,7 @@ impl InternalHttpQueryHandler {
                         query.source(),
                         state.get_ref(),
                         FetchCanisterLogsRequest::decode(&query.method_payload)?,
-                        self.confg.allowed_viewers_feature,
+                        self.config.allowed_viewers_feature,
                     );
                     self.metrics.observe_subnet_query_message(
                         QueryMethod::FetchCanisterLogs,

--- a/rs/execution_environment/src/query_handler.rs
+++ b/rs/execution_environment/src/query_handler.rs
@@ -292,7 +292,7 @@ impl InternalHttpQueryHandler {
 
 // TODO(EXC-1678): remove after release.
 /// Feature flag to enable/disable allowed viewers for canister log visibility.
-const ALLOWED_VIEWERS_ENABLED: bool = false;
+const ALLOWED_VIEWERS_ENABLED: bool = true;
 
 fn fetch_canister_logs(
     sender: PrincipalId,

--- a/rs/starter/src/lib.rs
+++ b/rs/starter/src/lib.rs
@@ -24,6 +24,7 @@ pub fn hypervisor_config(canister_sandboxing: bool) -> HypervisorConfig {
         rate_limiting_of_instructions: FlagStatus::Disabled,
         canister_snapshots: FlagStatus::Enabled,
         query_stats_epoch_length: 60,
+        allowed_viewers_feature: FlagStatus::Enabled,
         ..HypervisorConfig::default()
     }
 }


### PR DESCRIPTION
This PR makes `allowed_viewers` feature flag configurable in execution config and enables it in `ic-starter` for DFX.

So the feature is enabled in DFX for implementation and testing, but is still disabled in prod.