### PR TITLE
refactor(nervous-system): Remove ic-sns-governance and ic-sns-init's test_feature configurations

### DIFF
--- a/publish/binaries/BUILD.bazel
+++ b/publish/binaries/BUILD.bazel
@@ -38,7 +38,6 @@ ALL_BINARIES = {
     "sandbox_launcher": "//rs/canister_sandbox:sandbox_launcher",
     "sns": "//rs/sns/cli:sns",
     "sns-audit": "//rs/sns/audit:sns-audit",
-    "sns-test-feature": "//rs/sns/cli:sns--test_feature",
     "state-tool": "//rs/state_tool:state-tool",
     "systemd-journal-gatewayd-shim": "//rs/boundary_node/systemd_journal_gatewayd_shim:systemd-journal-gatewayd-shim",
     "drun": "//rs/drun:drun",

--- a/rs/nervous_system/integration_tests/BUILD.bazel
+++ b/rs/nervous_system/integration_tests/BUILD.bazel
@@ -11,12 +11,17 @@ BASE_DEPENDENCIES = [
     "//rs/nervous_system/proto",
     "//rs/nervous_system/root",
     "//rs/nns/common",
+    "//rs/nns/governance/api",
+    "//rs/nns/sns-wasm",
     "//rs/rosetta-api/icp_ledger",
     "//rs/rosetta-api/icrc1",
     "//rs/rosetta-api/icrc1/index-ng",
     "//rs/rosetta-api/icrc1/tokens_u64",
     "//rs/rosetta-api/ledger_core",
+    "//rs/sns/governance",
+    "//rs/sns/init",
     "//rs/sns/root",
+    "//rs/sns/swap",
     "//rs/test_utilities/load_wasm",
     "//rs/types/base_types",
     "//rs/types/management_canister_types",
@@ -48,32 +53,9 @@ BASE_DEPENDENCIES = [
     ],
 })
 
-# Each target declared in this file may choose either these (release-ready)
-# dependencies (`DEPENDENCIES`), or `DEPENDENCIES_WITH_TEST_FEATURES` feature previews.
-
-# Currently unused.
-# DEPENDENCIES = BASE_DEPENDENCIES + [
-#     "//rs/sns/init",
-#     "//rs/nns/sns-wasm",
-#     "//rs/nns/handlers/root/impl:root",
-#     "//rs/sns/swap",
-# ] + select({
-#     "@rules_rust//rust/platform:wasm32-unknown-unknown": [],
-#     "//conditions:default": [
-#         "//rs/nns/constants",
-#         "//rs/nns/test_utils",
-#         "//rs/nns/gtc",
-#     ],
-# })
-
 DEPENDENCIES_WITH_TEST_FEATURES = BASE_DEPENDENCIES + [
-    "//rs/sns/init:init--test_feature",
     "//rs/nns/governance:governance--test_feature",
-    "//rs/nns/governance/api:api--test_feature",
-    "//rs/nns/sns-wasm:sns-wasm--test_feature",
     "//rs/nns/handlers/root/impl:root--test_feature",
-    "//rs/sns/governance:governance--test_feature",
-    "//rs/sns/swap:swap--test_feature",
 ] + select({
     "@rules_rust//rust/platform:wasm32-unknown-unknown": [],
     "//conditions:default": [

--- a/rs/nns/governance/BUILD.bazel
+++ b/rs/nns/governance/BUILD.bazel
@@ -15,7 +15,7 @@ filegroup(
 )
 
 # See rs/nervous_system/feature_test.md
-BASE_DEPENDENCIES = [
+DEPENDENCIES = [
     # Keep sorted.
     "//rs/crypto/getrandom_for_wasm",
     "//rs/crypto/sha2",
@@ -30,8 +30,11 @@ BASE_DEPENDENCIES = [
     "//rs/nns/cmc",
     "//rs/nns/common",
     "//rs/nns/constants",
+    "//rs/nns/governance/api",
+    "//rs/nns/governance/init",
     "//rs/nns/gtc_accounts",
     "//rs/nns/handlers/root/interface",
+    "//rs/nns/sns-wasm",
     "//rs/protobuf",
     "//rs/registry/canister",
     "//rs/rosetta-api/icp_ledger",
@@ -39,7 +42,9 @@ BASE_DEPENDENCIES = [
     "//rs/rust_canisters/dfn_http_metrics",
     "//rs/rust_canisters/http_types",
     "//rs/rust_canisters/on_wire",
+    "//rs/sns/init",
     "//rs/sns/root",
+    "//rs/sns/swap",
     "//rs/types/base_types",
     "//rs/types/management_canister_types",
     "//rs/types/types",
@@ -75,24 +80,6 @@ BASE_DEPENDENCIES = [
         "@crate_index//:csv",
     ],
 })
-
-# Each target declared in this file may choose either these (release-ready)
-# dependencies (`DEPENDENCIES`), or `DEPENDENCIES_WITH_TEST_FEATURES` feature previews.
-DEPENDENCIES = BASE_DEPENDENCIES + [
-    "//rs/nns/governance/api",
-    "//rs/nns/sns-wasm",
-    "//rs/sns/init",
-    "//rs/nns/governance/init",
-    "//rs/sns/swap",
-]
-
-DEPENDENCIES_WITH_TEST_FEATURES = BASE_DEPENDENCIES + [
-    "//rs/nns/governance/api:api--test_feature",
-    "//rs/nns/sns-wasm:sns-wasm--test_feature",
-    "//rs/sns/init:init--test_feature",
-    "//rs/sns/swap:swap--test_feature",
-    "//rs/nns/governance/init:init--test_feature",
-]
 
 MACRO_DEPENDENCIES = [
     # Keep sorted.
@@ -169,7 +156,7 @@ rust_library(
     crate_name = "ic_nns_governance",
     proc_macro_deps = MACRO_DEPENDENCIES,
     version = "0.9.0",
-    deps = DEPENDENCIES_WITH_TEST_FEATURES + [
+    deps = DEPENDENCIES + [
         ":build_script",
     ],
 )
@@ -227,7 +214,7 @@ rust_canister(
     crate_features = ["test"],
     proc_macro_deps = MACRO_DEPENDENCIES,
     service_file = ":canister/governance_test.did",
-    deps = DEPENDENCIES_WITH_TEST_FEATURES + [
+    deps = DEPENDENCIES + [
         ":build_script",
         ":governance--test_feature",
         "//rs/nervous_system/canisters",
@@ -275,7 +262,7 @@ rust_test(
     crate_features = ["test"],
     crate_root = "canister/canister.rs",
     proc_macro_deps = MACRO_DEPENDENCIES + MACRO_DEV_DEPENDENCIES,
-    deps = DEPENDENCIES_WITH_TEST_FEATURES + DEV_DEPENDENCIES + [
+    deps = DEPENDENCIES + DEV_DEPENDENCIES + [
         ":build_script",
         ":governance--test_feature",
         "//rs/nervous_system/canisters",
@@ -298,7 +285,7 @@ rust_test(
     aliases = ALIASES,
     crate_features = ["test"],
     proc_macro_deps = MACRO_DEPENDENCIES + MACRO_DEV_DEPENDENCIES,
-    deps = DEPENDENCIES_WITH_TEST_FEATURES + DEV_DEPENDENCIES + [
+    deps = DEPENDENCIES + DEV_DEPENDENCIES + [
         ":build_script",
     ],
 )
@@ -341,7 +328,7 @@ rust_test_suite_with_extra_srcs(
         "tests/*/*.rs",
     ]) + ["tests/fake.rs"],
     proc_macro_deps = MACRO_DEPENDENCIES + MACRO_DEV_DEPENDENCIES,
-    deps = [":governance--test_feature"] + DEPENDENCIES_WITH_TEST_FEATURES + DEV_DEPENDENCIES + [
+    deps = [":governance--test_feature"] + DEPENDENCIES + DEV_DEPENDENCIES + [
         ":build_script",
     ],
 )

--- a/rs/nns/governance/api/BUILD.bazel
+++ b/rs/nns/governance/api/BUILD.bazel
@@ -3,7 +3,7 @@ load("@rules_rust//rust:defs.bzl", "rust_library")
 package(default_visibility = ["//visibility:public"])
 
 # See rs/nervous_system/feature_test.md
-BASE_DEPENDENCIES = [
+DEPENDENCIES = [
     # Keep sorted.
     "//rs/crypto/sha2",
     "//rs/nervous_system/clients",
@@ -13,6 +13,7 @@ BASE_DEPENDENCIES = [
     "//rs/protobuf",
     "//rs/rosetta-api/icp_ledger",
     "//rs/sns/root",
+    "//rs/sns/swap:swap",
     "//rs/types/base_types",
     "//rs/types/types",
     "//rs/utils",
@@ -24,16 +25,6 @@ BASE_DEPENDENCIES = [
     "@crate_index//:serde",
     "@crate_index//:serde_bytes",
     "@crate_index//:strum",
-]
-
-# Each target declared in this file may choose either these (release-ready)
-# dependencies (`DEPENDENCIES`), or `DEPENDENCIES_WITH_TEST_FEATURES` feature previews.
-DEPENDENCIES = BASE_DEPENDENCIES + [
-    "//rs/sns/swap",
-]
-
-DEPENDENCIES_WITH_TEST_FEATURES = BASE_DEPENDENCIES + [
-    "//rs/sns/swap:swap--test_feature",
 ]
 
 MACRO_DEPENDENCIES = [
@@ -67,5 +58,5 @@ rust_library(
     crate_name = "ic_nns_governance_api",
     proc_macro_deps = MACRO_DEPENDENCIES,
     version = "0.9.0",
-    deps = DEPENDENCIES_WITH_TEST_FEATURES,
+    deps = DEPENDENCIES,
 )

--- a/rs/nns/governance/init/BUILD.bazel
+++ b/rs/nns/governance/init/BUILD.bazel
@@ -3,26 +3,17 @@ load("@rules_rust//rust:defs.bzl", "rust_library")
 package(default_visibility = ["//visibility:public"])
 
 # See rs/nervous_system/feature_test.md
-BASE_DEPENDENCIES = [
+DEPENDENCIES = [
     # Keep sorted.
     "//rs/nervous_system/common",
     "//rs/nervous_system/common/test_keys",
     "//rs/nns/common",
+    "//rs/nns/governance/api",
     "//rs/rosetta-api/icp_ledger",
     "//rs/types/base_types",
     "@crate_index//:csv",
     "@crate_index//:rand",
     "@crate_index//:rand_chacha",
-]
-
-# Each target declared in this file may choose either these (release-ready)
-# dependencies (`DEPENDENCIES`), or `DEPENDENCIES_WITH_TEST_FEATURES` feature previews.
-DEPENDENCIES = BASE_DEPENDENCIES + [
-    "//rs/nns/governance/api",
-]
-
-DEPENDENCIES_WITH_TEST_FEATURES = BASE_DEPENDENCIES + [
-    "//rs/nns/governance/api:api--test_feature",
 ]
 
 MACRO_DEPENDENCIES = [
@@ -54,5 +45,5 @@ rust_library(
     crate_name = "ic_nns_governance_init",
     proc_macro_deps = MACRO_DEPENDENCIES,
     version = "0.9.0",
-    deps = DEPENDENCIES_WITH_TEST_FEATURES,
+    deps = DEPENDENCIES,
 )

--- a/rs/nns/gtc/BUILD.bazel
+++ b/rs/nns/gtc/BUILD.bazel
@@ -12,7 +12,7 @@ filegroup(
 )
 
 # See rs/nervous_system/feature_test.md
-BASE_DEPENDENCIES = [
+DEPENDENCIES = [
     # Keep sorted.
     "//rs/crypto/getrandom_for_wasm",
     "//rs/crypto/secp256k1",
@@ -20,6 +20,7 @@ BASE_DEPENDENCIES = [
     "//rs/nervous_system/common",
     "//rs/nns/common",
     "//rs/nns/constants",
+    "//rs/nns/governance/api",
     "//rs/nns/gtc_accounts",
     "//rs/rosetta-api/icp_ledger",
     "//rs/rust_canisters/dfn_candid",
@@ -34,16 +35,6 @@ BASE_DEPENDENCIES = [
     "@crate_index//:rand",
     "@crate_index//:serde",
     "@crate_index//:sha3",
-]
-
-# Each target declared in this file may choose either these (release-ready)
-# dependencies (`DEPENDENCIES`), or `DEPENDENCIES_WITH_TEST_FEATURES` feature previews.
-DEPENDENCIES = BASE_DEPENDENCIES + [
-    "//rs/nns/governance/api",
-]
-
-DEPENDENCIES_WITH_TEST_FEATURES = BASE_DEPENDENCIES + [
-    "//rs/nns/governance/api:api--test_feature",
 ]
 
 MACRO_DEPENDENCIES = [
@@ -113,7 +104,7 @@ rust_library(
     crate_name = "ic_nns_gtc",
     proc_macro_deps = MACRO_DEPENDENCIES,
     version = "0.9.0",
-    deps = DEPENDENCIES_WITH_TEST_FEATURES + [":build_script"],
+    deps = DEPENDENCIES + [":build_script"],
 )
 
 rust_canister(

--- a/rs/nns/integration_tests/BUILD.bazel
+++ b/rs/nns/integration_tests/BUILD.bazel
@@ -12,13 +12,17 @@ BASE_DEPENDENCIES = [
     "//rs/nervous_system/common/test_keys",
     "//rs/nns/cmc",
     "//rs/nns/common",
+    "//rs/nns/governance/api",
+    "//rs/nns/governance/init",
     "//rs/nns/handlers/lifeline/impl:lifeline",
+    "//rs/nns/sns-wasm",
     "//rs/rosetta-api/icp_ledger",
     "//rs/rosetta-api/ledger_core",
     "//rs/rust_canisters/dfn_candid",
     "//rs/rust_canisters/dfn_core",
     "//rs/rust_canisters/dfn_json",
     "//rs/rust_canisters/dfn_protobuf",
+    "//rs/sns/swap",
     "//rs/types/base_types",
     "@crate_index//:assert_matches",
     "@crate_index//:bytes",
@@ -76,12 +80,7 @@ BASE_DEPENDENCIES = [
 DEPENDENCIES = BASE_DEPENDENCIES + [
     # Keep sorted.
     "//rs/nns/governance",
-    "//rs/nns/governance/api",
-    "//rs/nns/governance/init",
     "//rs/nns/handlers/root/impl:root",
-    "//rs/nns/sns-wasm",
-    "//rs/sns/init",
-    "//rs/sns/swap",
 ] + select({
     "@rules_rust//rust/platform:wasm32-unknown-unknown": [],
     "//conditions:default": [
@@ -93,12 +92,8 @@ DEPENDENCIES = BASE_DEPENDENCIES + [
 DEPENDENCIES_WITH_TEST_FEATURES = BASE_DEPENDENCIES + [
     # Keep sorted.
     "//rs/nns/governance:governance--test_feature",
-    "//rs/nns/governance/api:api--test_feature",
-    "//rs/nns/governance/init:init--test_feature",
     "//rs/nns/handlers/root/impl:root--test_feature",
-    "//rs/nns/sns-wasm:sns-wasm--test_feature",
     "//rs/sns/init:init--test_feature",
-    "//rs/sns/swap:swap--test_feature",
 ] + select({
     "@rules_rust//rust/platform:wasm32-unknown-unknown": [],
     "//conditions:default": [

--- a/rs/nns/sns-wasm/BUILD.bazel
+++ b/rs/nns/sns-wasm/BUILD.bazel
@@ -11,7 +11,7 @@ filegroup(
 )
 
 # See rs/nervous_system/feature_test.md
-BASE_DEPENDENCIES = [
+DEPENDENCIES = [
     # Keep sorted.
     "//packages/icrc-ledger-types:icrc_ledger_types",
     "//rs/crypto/sha2",
@@ -24,6 +24,8 @@ BASE_DEPENDENCIES = [
     "//rs/rust_canisters/dfn_candid",
     "//rs/rust_canisters/dfn_core",
     "//rs/rust_canisters/dfn_http_metrics",
+    "//rs/sns/governance",
+    "//rs/sns/init",
     "//rs/sns/root",
     "//rs/types/base_types",
     "//rs/types/management_canister_types",
@@ -40,18 +42,6 @@ BASE_DEPENDENCIES = [
     "@crate_index//:serde",
     "@crate_index//:serde_bytes",
     "@crate_index//:serde_json",
-]
-
-# Each target declared in this file may choose either these (release-ready)
-# dependencies (`DEPENDENCIES`), or `DEPENDENCIES_WITH_TEST_FEATURES` feature previews.
-DEPENDENCIES = BASE_DEPENDENCIES + [
-    "//rs/sns/governance",
-    "//rs/sns/init",
-]
-
-DEPENDENCIES_WITH_TEST_FEATURES = BASE_DEPENDENCIES + [
-    "//rs/sns/governance:governance--test_feature",
-    "//rs/sns/init:init--test_feature",
 ]
 
 MACRO_DEPENDENCIES = [
@@ -104,20 +94,6 @@ rust_library(
     deps = DEPENDENCIES,
 )
 
-rust_library(
-    name = "sns-wasm--test_feature",
-    srcs = glob([
-        "src/**",
-        "gen/**",
-    ]),
-    aliases = ALIASES,
-    crate_features = ["test"],
-    crate_name = "ic_sns_wasm",
-    proc_macro_deps = MACRO_DEPENDENCIES,
-    version = "1.0.0",
-    deps = DEPENDENCIES_WITH_TEST_FEATURES,
-)
-
 rust_canister(
     name = "sns-wasm-canister",
     srcs = ["canister/canister.rs"],
@@ -143,15 +119,6 @@ rust_test(
     crate = ":sns-wasm",
     proc_macro_deps = MACRO_DEPENDENCIES + MACRO_DEV_DEPENDENCIES,
     deps = DEPENDENCIES + DEV_DEPENDENCIES,
-)
-
-rust_test(
-    name = "sns-wasm_test--test_feature",
-    aliases = ALIASES,
-    crate = ":sns-wasm--test_feature",
-    crate_features = ["test"],
-    proc_macro_deps = MACRO_DEPENDENCIES + MACRO_DEV_DEPENDENCIES,
-    deps = DEPENDENCIES_WITH_TEST_FEATURES + DEV_DEPENDENCIES,
 )
 
 rust_ic_test_suite_with_extra_srcs(

--- a/rs/nns/test_utils/BUILD.bazel
+++ b/rs/nns/test_utils/BUILD.bazel
@@ -22,9 +22,12 @@ BASE_DEPENDENCIES = [
     "//rs/nns/cmc",
     "//rs/nns/common",
     "//rs/nns/constants",
+    "//rs/nns/governance/api",
+    "//rs/nns/governance/init",
     "//rs/nns/gtc_accounts",
     "//rs/nns/handlers/lifeline/impl:lifeline",
     "//rs/nns/handlers/lifeline/interface",
+    "//rs/nns/sns-wasm",
     "//rs/protobuf",
     "//rs/registry/canister",
     "//rs/registry/canister/api",
@@ -41,6 +44,8 @@ BASE_DEPENDENCIES = [
     "//rs/rust_canisters/dfn_json",
     "//rs/rust_canisters/dfn_protobuf",
     "//rs/rust_canisters/on_wire",
+    "//rs/sns/governance",
+    "//rs/sns/init",
     "//rs/sns/swap",
     "//rs/state_machine_tests",
     "//rs/test_utilities",
@@ -67,23 +72,13 @@ BASE_DEPENDENCIES = [
 # Each target declared in this file may choose either these (release-ready)
 # dependencies (`DEPENDENCIES`), or `DEPENDENCIES_WITH_TEST_FEATURES` feature previews.
 DEPENDENCIES = BASE_DEPENDENCIES + [
-    "//rs/nns/governance/api",
-    "//rs/nns/governance/init",
     "//rs/nns/gtc",
-    "//rs/nns/sns-wasm",
     "//rs/nns/handlers/root/impl:root",
-    "//rs/sns/governance",
-    "//rs/sns/init",
 ]
 
 DEPENDENCIES_WITH_TEST_FEATURES = BASE_DEPENDENCIES + [
-    "//rs/nns/governance/api:api--test_feature",
-    "//rs/nns/governance/init:init--test_feature",
     "//rs/nns/gtc:gtc--test_feature",
-    "//rs/nns/sns-wasm:sns-wasm--test_feature",
     "//rs/nns/handlers/root/impl:root--test_feature",
-    "//rs/sns/governance:governance--test_feature",
-    "//rs/sns/init:init--test_feature",
 ]
 
 MACRO_DEPENDENCIES = []

--- a/rs/registry/admin/BUILD.bazel
+++ b/rs/registry/admin/BUILD.bazel
@@ -3,7 +3,7 @@ load("@rules_rust//rust:defs.bzl", "rust_binary", "rust_test")
 package(default_visibility = ["//visibility:public"])
 
 # See rs/nervous_system/feature_test.md
-BASE_DEPENDENCIES = [
+DEPENDENCIES = [
     # Keep sorted.
     "//rs/canister_client",
     "//rs/canister_client/sender",
@@ -21,7 +21,11 @@ BASE_DEPENDENCIES = [
     "//rs/nns/cmc",
     "//rs/nns/common",
     "//rs/nns/constants",
+    "//rs/nns/governance/api",
+    "//rs/nns/handlers/root/impl:root",
     "//rs/nns/init",
+    "//rs/nns/sns-wasm",
+    "//rs/nns/test_utils",
     "//rs/prep",
     "//rs/protobuf",
     "//rs/registry/canister",
@@ -36,6 +40,8 @@ BASE_DEPENDENCIES = [
     "//rs/registry/subnet_features",
     "//rs/registry/subnet_type",
     "//rs/registry/transport",
+    "//rs/sns/init",
+    "//rs/sns/swap",
     "//rs/types/management_canister_types",
     "//rs/types/types",
     "@crate_index//:anyhow",
@@ -58,26 +64,6 @@ BASE_DEPENDENCIES = [
     "@crate_index//:tokio",
     "@crate_index//:url",
 ]
-
-# Each target declared in this file may choose either these (release-ready)
-# dependencies (`DEPENDENCIES`), or `DEPENDENCIES_WITH_TEST_FEATURES` feature previews.
-DEPENDENCIES = BASE_DEPENDENCIES + [
-    "//rs/sns/init",
-    "//rs/nns/governance/api",
-    "//rs/nns/sns-wasm",
-    "//rs/nns/handlers/root/impl:root",
-    "//rs/sns/swap",
-    "//rs/nns/test_utils",
-]
-
-# (Currently not used)
-# DEPENDENCIES_WITH_TEST_FEATURES = BASE_DEPENDENCIES + [
-#     "//rs/sns/init:init--test_feature",
-#     "//rs/nns/sns-wasm:sns-wasm--test_feature",
-#     "//rs/nns/handlers/root/impl:root--test_feature",
-#     "//rs/sns/swap:swap--test_feature",
-#     "//rs/nns/test_utils:test_utils--test_feature",
-# ]
 
 MACRO_DEPENDENCIES = [
     # Keep sorted.

--- a/rs/sns/cli/BUILD.bazel
+++ b/rs/sns/cli/BUILD.bazel
@@ -3,7 +3,7 @@ load("@rules_rust//rust:defs.bzl", "rust_binary", "rust_doc_test", "rust_library
 package(default_visibility = ["//visibility:public"])
 
 # See rs/nervous_system/feature_test.md
-BASE_DEPENDENCIES = [
+DEPENDENCIES = [
     # Keep sorted.
     "//rs/crypto/sha2",
     "//rs/nervous_system/agent",
@@ -13,6 +13,10 @@ BASE_DEPENDENCIES = [
     "//rs/nervous_system/proto",
     "//rs/nns/common",
     "//rs/nns/constants",
+    "//rs/nns/governance/api",
+    "//rs/nns/sns-wasm",
+    "//rs/sns/governance",
+    "//rs/sns/init",
     "//rs/sns/root",
     "//rs/types/base_types",
     "@crate_index//:anyhow",
@@ -31,22 +35,6 @@ BASE_DEPENDENCIES = [
     "@crate_index//:tempfile",
     "@crate_index//:thiserror",
     "@crate_index//:tokio",
-]
-
-# Each target declared in this file may choose either these (release-ready)
-# dependencies (`DEPENDENCIES`), or `DEPENDENCIES_WITH_TEST_FEATURES` feature previews.
-DEPENDENCIES = BASE_DEPENDENCIES + [
-    "//rs/nns/governance/api",
-    "//rs/nns/sns-wasm",
-    "//rs/sns/governance",
-    "//rs/sns/init",
-]
-
-DEPENDENCIES_WITH_TEST_FEATURES = BASE_DEPENDENCIES + [
-    "//rs/nns/governance/api:api--test_feature",
-    "//rs/nns/sns-wasm:sns-wasm--test_feature",
-    "//rs/sns/governance:governance--test_feature",
-    "//rs/sns/init:init--test_feature",
 ]
 
 MACRO_DEPENDENCIES = []
@@ -76,23 +64,6 @@ rust_library(
     deps = DEPENDENCIES,
 )
 
-rust_library(
-    name = "cli--test_feature",
-    srcs = glob(
-        ["src/**/*.rs"],
-        exclude = [
-            "**/*tests.rs",
-            "main.rs",
-        ],
-    ),
-    aliases = ALIASES,
-    crate_features = ["test"],
-    crate_name = "ic_sns_cli",
-    proc_macro_deps = MACRO_DEPENDENCIES,
-    version = "1.0.0",
-    deps = DEPENDENCIES_WITH_TEST_FEATURES,
-)
-
 rust_binary(
     name = "sns",
     srcs = ["src/main.rs"],
@@ -100,17 +71,6 @@ rust_binary(
     proc_macro_deps = MACRO_DEPENDENCIES,
     version = "1.0.0",
     deps = DEPENDENCIES + [":cli"],
-)
-
-rust_binary(
-    name = "sns--test_feature",
-    srcs = ["src/main.rs"],
-    aliases = ALIASES,
-    crate_features = ["test"],
-    crate_name = "sns",
-    proc_macro_deps = MACRO_DEPENDENCIES,
-    version = "1.0.0",
-    deps = DEPENDENCIES_WITH_TEST_FEATURES + [":cli--test_feature"],
 )
 
 rust_test(
@@ -138,7 +98,7 @@ rust_test(
         "CARGO_MANIFEST_DIR": "rs/sns/cli",
     },
     proc_macro_deps = MACRO_DEPENDENCIES + MACRO_DEV_DEPENDENCIES,
-    deps = DEPENDENCIES_WITH_TEST_FEATURES + DEV_DEPENDENCIES,
+    deps = DEPENDENCIES + DEV_DEPENDENCIES,
 )
 
 rust_doc_test(

--- a/rs/sns/governance/BUILD.bazel
+++ b/rs/sns/governance/BUILD.bazel
@@ -124,19 +124,6 @@ rust_library(
     deps = DEPENDENCIES + [":build_script"],
 )
 
-rust_library(
-    name = "governance--test_feature",
-    srcs = LIB_SRCS,
-    aliases = ALIASES,
-    crate_features = ["test"],
-    crate_name = "ic_sns_governance",
-    proc_macro_deps = MACRO_DEPENDENCIES,
-    version = "0.9.0",
-    deps = DEPENDENCIES + [
-        ":build_script",
-    ],
-)
-
 rust_canister(
     name = "sns-governance-canister",
     srcs = ["canister/canister.rs"],
@@ -161,7 +148,7 @@ rust_canister(
     service_file = ":canister/governance_test.did",
     deps = DEPENDENCIES + [
         ":build_script",
-        ":governance--test_feature",
+        ":governance",
         "//rs/nervous_system/canisters",
     ],
 )
@@ -196,7 +183,7 @@ rust_test(
     proc_macro_deps = MACRO_DEPENDENCIES + MACRO_DEV_DEPENDENCIES,
     deps = DEPENDENCIES + DEV_DEPENDENCIES + [
         ":build_script",
-        ":governance--test_feature",
+        ":governance",
         "//rs/nervous_system/canisters",
     ],
 )
@@ -217,7 +204,7 @@ rust_test_suite_with_extra_srcs(
         "tests/fixtures/environment_fixture.rs",
     ],
     proc_macro_deps = MACRO_DEPENDENCIES + MACRO_DEV_DEPENDENCIES,
-    deps = [":governance--test_feature"] + DEPENDENCIES + DEV_DEPENDENCIES + [":build_script"],
+    deps = [":governance"] + DEPENDENCIES + DEV_DEPENDENCIES + [":build_script"],
 )
 
 generated_files_check(

--- a/rs/sns/governance/canister/canister.rs
+++ b/rs/sns/governance/canister/canister.rs
@@ -219,13 +219,19 @@ fn canister_init_(init_payload: GovernanceProto) {
             "{}Trying to initialize an already-initialized governance canister!",
             log_prefix()
         );
-        GOVERNANCE = Some(Governance::new(
+        let governance = Governance::new(
             init_payload,
             Box::new(CanisterEnv::new()),
             Box::new(LedgerCanister::new(ledger_canister_id)),
             Box::new(IcpLedgerCanister::<DfnRuntime>::new(NNS_LEDGER_CANISTER_ID)),
             Box::new(CMCCanister::<DfnRuntime>::new()),
-        ));
+        );
+        let governance = if cfg!(feature = "test") {
+            governance.enable_test_features()
+        } else {
+            governance
+        };
+        GOVERNANCE = Some(governance);
     }
 }
 

--- a/rs/sns/governance/src/governance.rs
+++ b/rs/sns/governance/src/governance.rs
@@ -1,8 +1,6 @@
-#[cfg(feature = "test")]
 use crate::pb::v1::{
     AddMaturityRequest, AddMaturityResponse, MintTokensRequest, MintTokensResponse,
 };
-
 use crate::{
     canister_control::{
         get_canister_id, perform_execute_generic_nervous_system_function_call,
@@ -694,6 +692,12 @@ pub struct Governance {
 
     /// The number of proposals after the last time "garbage collection" was run.
     pub latest_gc_num_proposals: usize,
+
+    /// Whether test features are enabled.
+    /// Test features should not be exposed in production. But, code that should
+    /// not run in production can be gated behind a check for this flag as an
+    /// extra layer of protection.
+    pub test_features_enabled: bool,
 }
 
 impl Governance {
@@ -752,11 +756,21 @@ impl Governance {
             closest_proposal_deadline_timestamp_seconds: 0,
             latest_gc_timestamp_seconds: 0,
             latest_gc_num_proposals: 0,
+            test_features_enabled: false,
         };
 
         gov.initialize_indices();
 
         gov
+    }
+
+    pub fn enable_test_features(mut self) -> Self {
+        self.test_features_enabled = true;
+        self
+    }
+
+    pub fn check_test_features_enabled(&self) {
+        assert!(self.test_features_enabled, "Test features are not enabled");
     }
 
     pub fn get_mode(&self, _: GetMode) -> GetModeResponse {
@@ -5364,8 +5378,9 @@ impl Governance {
     /// - the followees are not changed (it's easy to update followees
     ///   via `manage_neuron` and doing it here would require updating
     ///   `function_followee_index`)
-    #[cfg(feature = "test")]
     pub fn update_neuron(&mut self, neuron: Neuron) -> Result<(), GovernanceError> {
+        self.check_test_features_enabled();
+
         let neuron_id = &neuron.id.as_ref().expect("Neuron must have a NeuronId");
 
         // Must clobber an existing neuron.
@@ -5439,11 +5454,12 @@ impl Governance {
         }
     }
 
-    #[cfg(feature = "test")]
     pub fn add_maturity(
         &mut self,
         add_maturity_request: AddMaturityRequest,
     ) -> AddMaturityResponse {
+        self.check_test_features_enabled();
+
         let AddMaturityRequest { id, amount_e8s } = add_maturity_request;
         let id = id.expect("AddMaturityRequest::id is required");
         let amount_e8s = amount_e8s.expect("AddMaturityRequest::amount_e8s is required");
@@ -5459,11 +5475,12 @@ impl Governance {
         }
     }
 
-    #[cfg(feature = "test")]
     pub async fn mint_tokens(
         &mut self,
         mint_tokens_request: MintTokensRequest,
     ) -> MintTokensResponse {
+        self.check_test_features_enabled();
+
         self.ledger
             .transfer_funds(
                 mint_tokens_request.amount_e8s(),
@@ -6596,6 +6613,7 @@ mod tests {
             Box::new(DoNothingLedger {}),
             Box::new(FakeCmc::new()),
         );
+
         // Step 1.3: Record original last_reward_event. That way, we can detect
         // changes (there aren't supposed to be any).
         let original_latest_reward_event = governance.proto.latest_reward_event.clone();
@@ -8623,6 +8641,7 @@ mod tests {
             Box::new(DoNothingLedger {}),
             Box::new(FakeCmc::new()),
         )
+        .enable_test_features()
     }
 
     fn test_neuron_id(controller: PrincipalId) -> NeuronId {
@@ -9329,6 +9348,7 @@ mod tests {
             Box::new(DoNothingLedger {}),
             Box::new(FakeCmc::new()),
         );
+
         SplitNeuronTestSetup {
             controller,
             neuron_id,

--- a/rs/sns/governance/tests/fixtures/mod.rs
+++ b/rs/sns/governance/tests/fixtures/mod.rs
@@ -917,7 +917,8 @@ impl GovernanceCanisterFixtureBuilder {
                 sns_ledger,
                 icp_ledger,
                 Box::new(self.cmc_fixture),
-            ),
+            )
+            .enable_test_features(),
             initial_state: None,
         };
         governance.capture_state();

--- a/rs/sns/init/BUILD.bazel
+++ b/rs/sns/init/BUILD.bazel
@@ -9,17 +9,20 @@ filegroup(
 )
 
 # See rs/nervous_system/feature_test.md
-BASE_DEPENDENCIES = [
+DEPENDENCIES = [
     # Keep sorted.
     "//packages/icrc-ledger-types:icrc_ledger_types",
     "//rs/nervous_system/common",
     "//rs/nervous_system/proto",
     "//rs/nns/constants",
+    "//rs/nns/governance/api",
     "//rs/rosetta-api/icrc1/index-ng",
     "//rs/rosetta-api/icrc1/ledger",
     "//rs/rosetta-api/ledger_canister_core",
     "//rs/rosetta-api/ledger_core",
+    "//rs/sns/governance",
     "//rs/sns/root",
+    "//rs/sns/swap:swap",
     "//rs/types/base_types",
     "@crate_index//:base64",
     "@crate_index//:candid",
@@ -29,20 +32,6 @@ BASE_DEPENDENCIES = [
     "@crate_index//:prost",
     "@crate_index//:serde",
     "@crate_index//:serde_yaml",
-]
-
-# Each target declared in this file may choose either these (release-ready)
-# dependencies (`DEPENDENCIES`), or `DEPENDENCIES_WITH_TEST_FEATURES` feature previews.
-DEPENDENCIES = BASE_DEPENDENCIES + [
-    "//rs/nns/governance/api",
-    "//rs/sns/governance",
-    "//rs/sns/swap",
-]
-
-DEPENDENCIES_WITH_TEST_FEATURES = BASE_DEPENDENCIES + [
-    "//rs/nns/governance/api:api--test_feature",
-    "//rs/sns/governance:governance--test_feature",
-    "//rs/sns/swap:swap--test_feature",
 ]
 
 MACRO_DEPENDENCIES = []
@@ -84,7 +73,7 @@ rust_library(
     crate_name = "ic_sns_init",
     proc_macro_deps = MACRO_DEPENDENCIES,
     version = "0.1.0",
-    deps = DEPENDENCIES_WITH_TEST_FEATURES,
+    deps = DEPENDENCIES,
 )
 
 generated_files_check(

--- a/rs/sns/integration_tests/BUILD.bazel
+++ b/rs/sns/integration_tests/BUILD.bazel
@@ -13,6 +13,8 @@ BASE_DEPENDENCIES = [
     "//rs/nervous_system/common/test_keys",
     "//rs/nns/cmc",
     "//rs/nns/constants",
+    "//rs/nns/governance/api",
+    "//rs/nns/sns-wasm",
     "//rs/registry/subnet_type:subnet_type",
     "//rs/rosetta-api/icp_ledger/ledger",
     "//rs/rosetta-api/icrc1",
@@ -22,7 +24,9 @@ BASE_DEPENDENCIES = [
     "//rs/rust_canisters/canister_test",
     "//rs/rust_canisters/dfn_candid",
     "//rs/rust_canisters/dfn_core",
+    "//rs/sns/governance:governance",
     "//rs/sns/root",
+    "//rs/sns/swap",
     "//rs/state_machine_tests",
     "//rs/test_utilities/load_wasm",
     "//rs/types/base_types",
@@ -42,12 +46,10 @@ BASE_DEPENDENCIES = [
 # Each target declared in this file may choose either these (release-ready)
 # dependencies (`DEPENDENCIES`), or `DEPENDENCIES_WITH_TEST_FEATURES` feature previews.
 DEPENDENCIES = BASE_DEPENDENCIES + [
-    "//rs/sns/init",
     "//rs/sns/test_utils",
 ]
 
 DEPENDENCIES_WITH_TEST_FEATURES = BASE_DEPENDENCIES + [
-    "//rs/sns/init:init--test_feature",
     "//rs/sns/test_utils:test_utils--test_feature",
 ]
 
@@ -69,6 +71,7 @@ BASE_DEV_DEPENDENCIES = [
     "//rs/rust_canisters/http_types",
     "//rs/rust_canisters/on_wire",
     "//rs/sns/governance:build_script",
+    "//rs/sns/init",
     "@crate_index//:assert_matches",
     "@crate_index//:itertools",
     "@crate_index//:lazy_static",
@@ -80,23 +83,8 @@ BASE_DEV_DEPENDENCIES = [
     "@crate_index//:wat",
 ]
 
-# Each target declared in this file may choose either these (release-ready)
-# dependencies (`DEV_DEPENDENCIES`), or `TEST_DEV_DEPENDENCIES` feature previews.
-# (Currently not used)
-# DEV_DEPENDENCIES = BASE_DEV_DEPENDENCIES + [
-#     "//rs/nns/governance/api",
-#     "//rs/nns/sns-wasm",
-#     "//rs/nns/test_utils",
-#     "//rs/sns/governance",
-#     "//rs/sns/swap",
-# ]
-
 TEST_DEV_DEPENDENCIES = BASE_DEV_DEPENDENCIES + [
-    "//rs/nns/governance/api:api--test_feature",
-    "//rs/nns/sns-wasm:sns-wasm--test_feature",
     "//rs/nns/test_utils:test_utils--test_feature",
-    "//rs/sns/governance:governance--test_feature",
-    "//rs/sns/swap:swap--test_feature",
 ]
 
 MACRO_DEV_DEPENDENCIES = [

--- a/rs/sns/swap/BUILD.bazel
+++ b/rs/sns/swap/BUILD.bazel
@@ -12,7 +12,7 @@ filegroup(
 )
 
 # See rs/nervous_system/feature_test.md
-BASE_DEPENDENCIES = [
+DEPENDENCIES = [
     # Keep sorted.
     "//packages/icrc-ledger-types:icrc_ledger_types",
     "//rs/nervous_system/canisters",
@@ -27,6 +27,7 @@ BASE_DEPENDENCIES = [
     "//rs/rust_canisters/dfn_candid",
     "//rs/rust_canisters/dfn_core",
     "//rs/rust_canisters/http_types",
+    "//rs/sns/governance",
     "//rs/types/base_types",
     "//rs/utils",
     "@crate_index//:build-info",
@@ -42,16 +43,6 @@ BASE_DEPENDENCIES = [
     "@crate_index//:rust_decimal",
     "@crate_index//:serde",
     "@crate_index//:serde_bytes",
-]
-
-# Each target declared in this file may choose either these (release-ready)
-# dependencies (`DEPENDENCIES`), or `DEPENDENCIES_WITH_TEST_FEATURES` feature previews.
-DEPENDENCIES = BASE_DEPENDENCIES + [
-    "//rs/sns/governance",
-]
-
-DEPENDENCIES_WITH_TEST_FEATURES = BASE_DEPENDENCIES + [
-    "//rs/sns/governance:governance--test_feature",
 ]
 
 MACRO_DEPENDENCIES = [
@@ -108,19 +99,6 @@ rust_library(
     deps = DEPENDENCIES + [":build_script"],
 )
 
-rust_library(
-    name = "swap--test_feature",
-    srcs = glob([
-        "src/**",
-    ]),
-    aliases = ALIASES,
-    crate_features = ["test"],
-    crate_name = "ic_sns_swap",
-    proc_macro_deps = MACRO_DEPENDENCIES,
-    version = "0.1.0",
-    deps = DEPENDENCIES_WITH_TEST_FEATURES + [":build_script"],
-)
-
 rust_canister(
     name = "sns-swap-canister",
     srcs = ["canister/canister.rs"],
@@ -169,7 +147,7 @@ rust_test_suite_with_extra_srcs(
         "tests/common/doubles.rs",
     ],
     proc_macro_deps = MACRO_DEPENDENCIES + MACRO_DEV_DEPENDENCIES,
-    deps = [":swap--test_feature"] + DEPENDENCIES_WITH_TEST_FEATURES + DEV_DEPENDENCIES + [":build_script"],
+    deps = [":swap"] + DEPENDENCIES + DEV_DEPENDENCIES + [":build_script"],
 )
 
 generated_files_check(

--- a/rs/sns/test_utils/BUILD.bazel
+++ b/rs/sns/test_utils/BUILD.bazel
@@ -25,7 +25,10 @@ BASE_DEPENDENCIES = [
     "//rs/rust_canisters/dfn_candid",
     "//rs/rust_canisters/dfn_protobuf",
     "//rs/rust_canisters/on_wire",
+    "//rs/sns/governance",
+    "//rs/sns/init",
     "//rs/sns/root",
+    "//rs/sns/swap",
     "//rs/state_machine_tests",
     "//rs/types/base_types",
     "//rs/types/management_canister_types",
@@ -44,16 +47,10 @@ BASE_DEPENDENCIES = [
 # dependencies (`DEPENDENCIES`), or `DEPENDENCIES_WITH_TEST_FEATURES` feature previews.
 DEPENDENCIES = BASE_DEPENDENCIES + [
     "//rs/nns/test_utils",
-    "//rs/sns/governance",
-    "//rs/sns/init",
-    "//rs/sns/swap",
 ]
 
 DEPENDENCIES_WITH_TEST_FEATURES = BASE_DEPENDENCIES + [
     "//rs/nns/test_utils:test_utils--test_feature",
-    "//rs/sns/governance:governance--test_feature",
-    "//rs/sns/init:init--test_feature",
-    "//rs/sns/swap:swap--test_feature",
 ]
 
 MACRO_DEPENDENCIES = [


### PR DESCRIPTION
[← Previous PR](https://github.com/dfinity/ic/pull/1609)

There are two reasons to have a --test_feature target:

1. The crate itself has different functionality when cfg(feature = "test") is true
2. The crate is a library that depends on crate that has a --test_feature target, and needs to give the choice to its consumer whether the dependency has --test_feature enabled.

The second rule is "viral" which has lead to a massive outbreak of crates with a `--test_feature` target. In fact most of our crates that had a --test_feature target were in the second category.

The root cause of most of these was that SNS Governance's library had a `--test_feature` target. This PR:

1. Moves the logic for determining whether we are in "test mode" to the canister crate (from the library crate)
2. Remove's SNS Governance's library's --test-feature target
3. Remove's SNS Init's --test-feature target, which did nothing after #1609
4. Reverses the viral outbreak of --test-feature now that these two crates no longer needed it. The following crates have had their --test-feature removed entirely:
   1. `//rs/sns/init:init--test_feature`
   2. `//rs/sns/governance:governance--test_feature`
   4. `//rs/nns/governance/api:api--test_feature`
   5. `//rs/nns/sns-wasm:sns-wasm--test_feature`
   6.  `//rs/sns/cli:cli--test_feature`
   7.  `//rs/sns/swap:swap--test_feature`
   8.  `//rs/nns/governance/init:init--test_feature`
   8.  `//rs/nns/gtc:gtc--test_feature`

And some others no longer depend on any --test_feature crates, which is useful for development