### PR TITLE
feat(registry): Add node_reward_type to NodeRecord

### DIFF
--- a/rs/nns/test_utils/src/registry.rs
+++ b/rs/nns/test_utils/src/registry.rs
@@ -15,14 +15,16 @@ use ic_nervous_system_common_test_keys::{
     TEST_USER1_PRINCIPAL, TEST_USER2_PRINCIPAL, TEST_USER3_PRINCIPAL, TEST_USER4_PRINCIPAL,
     TEST_USER5_PRINCIPAL, TEST_USER6_PRINCIPAL, TEST_USER7_PRINCIPAL,
 };
-use ic_protobuf::registry::subnet::v1::{ChainKeyConfig, InitialNiDkgTranscriptRecord};
 use ic_protobuf::registry::{
     crypto::v1::{PublicKey, X509PublicKeyCert},
     node::v1::{ConnectionEndpoint, NodeRecord},
     node_operator::v1::NodeOperatorRecord,
     replica_version::v1::{BlessedReplicaVersions, ReplicaVersionRecord},
     routing_table::v1::RoutingTable as RoutingTablePB,
-    subnet::v1::{CatchUpPackageContents, SubnetListRecord, SubnetRecord},
+    subnet::v1::{
+        CatchUpPackageContents, ChainKeyConfig, InitialNiDkgTranscriptRecord, SubnetListRecord,
+        SubnetRecord,
+    },
 };
 use ic_registry_canister_api::AddNodePayload;
 use ic_registry_keys::{
@@ -42,9 +44,11 @@ use ic_registry_transport::{
     serialize_get_value_request, Error,
 };
 use ic_test_utilities_types::ids::{subnet_test_id, user_test_id};
-use ic_types::crypto::threshold_sig::ni_dkg::{NiDkgTag, NiDkgTargetId, NiDkgTranscript};
 use ic_types::{
-    crypto::{CurrentNodePublicKeys, KeyPurpose},
+    crypto::{
+        threshold_sig::ni_dkg::{NiDkgTag, NiDkgTargetId, NiDkgTranscript},
+        CurrentNodePublicKeys, KeyPurpose,
+    },
     NodeId, ReplicaVersion,
 };
 use maplit::btreemap;
@@ -54,8 +58,10 @@ use rand::RngCore;
 use registry_canister::mutations::node_management::{
     common::make_add_node_registry_mutations, do_add_node::connection_endpoint_from_string,
 };
-use std::collections::{BTreeMap, BTreeSet};
-use std::convert::TryFrom;
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    convert::TryFrom,
+};
 
 /// ID used in multiple tests.
 pub const TEST_ID: u64 = 999;
@@ -827,6 +833,7 @@ pub fn prepare_add_node_payload(mutation_id: u8) -> (AddNodePayload, ValidNodePu
         // Unused section follows
         p2p_flow_endpoints: Default::default(),
         prometheus_metrics_endpoint: Default::default(),
+        node_type: None,
     };
 
     (payload, node_public_keys)

--- a/rs/nns/test_utils/src/registry.rs
+++ b/rs/nns/test_utils/src/registry.rs
@@ -833,7 +833,7 @@ pub fn prepare_add_node_payload(mutation_id: u8) -> (AddNodePayload, ValidNodePu
         // Unused section follows
         p2p_flow_endpoints: Default::default(),
         prometheus_metrics_endpoint: Default::default(),
-        node_type: None,
+        node_reward_type: None,
     };
 
     (payload, node_public_keys)

--- a/rs/orchestrator/src/firewall.rs
+++ b/rs/orchestrator/src/firewall.rs
@@ -1037,7 +1037,7 @@ mod tests {
                     hostos_version_id: None,
                     public_ipv4_config: None,
                     domain: None,
-                    node_type: None,
+                    node_reward_type: None,
                 }),
             )
             .expect("Failed to add node record.");

--- a/rs/orchestrator/src/firewall.rs
+++ b/rs/orchestrator/src/firewall.rs
@@ -1037,6 +1037,7 @@ mod tests {
                     hostos_version_id: None,
                     public_ipv4_config: None,
                     domain: None,
+                    node_type: None,
                 }),
             )
             .expect("Failed to add node record.");

--- a/rs/orchestrator/src/registration.rs
+++ b/rs/orchestrator/src/registration.rs
@@ -222,6 +222,7 @@ impl NodeRegistration {
             // Unused section follows
             p2p_flow_endpoints: Default::default(),
             prometheus_metrics_endpoint: Default::default(),
+            node_type: None,
         }
     }
 

--- a/rs/orchestrator/src/registration.rs
+++ b/rs/orchestrator/src/registration.rs
@@ -222,7 +222,7 @@ impl NodeRegistration {
             // Unused section follows
             p2p_flow_endpoints: Default::default(),
             prometheus_metrics_endpoint: Default::default(),
-            node_type: None,
+            node_reward_type: None,
         }
     }
 

--- a/rs/prep/src/node.rs
+++ b/rs/prep/src/node.rs
@@ -452,7 +452,7 @@ mod node_configuration {
             chip_id: None,
             public_ipv4_config: None,
             domain: None,
-            node_type: None,
+            node_reward_type: None,
         };
 
         assert_eq!(got, want);

--- a/rs/prep/src/node.rs
+++ b/rs/prep/src/node.rs
@@ -30,8 +30,7 @@ use ic_types::{
     consensus::certification::Certification, crypto::KeyPurpose, Height, NodeId, PrincipalId,
     RegistryVersion, SubnetId,
 };
-use std::net::SocketAddr;
-use std::os::unix::fs::PermissionsExt;
+use std::{net::SocketAddr, os::unix::fs::PermissionsExt};
 
 const CRYPTO_DIR: &str = "crypto";
 const STATE_DIR: &str = "state";
@@ -426,8 +425,7 @@ impl NodeSecretKeyStore {
 mod node_configuration {
     use super::*;
     use pretty_assertions::assert_eq;
-    use std::net::SocketAddr;
-    use std::str::FromStr;
+    use std::{net::SocketAddr, str::FromStr};
 
     #[test]
     fn into_proto_http() {
@@ -454,6 +452,7 @@ mod node_configuration {
             chip_id: None,
             public_ipv4_config: None,
             domain: None,
+            node_type: None,
         };
 
         assert_eq!(got, want);

--- a/rs/protobuf/def/registry/node/v1/node.proto
+++ b/rs/protobuf/def/registry/node/v1/node.proto
@@ -26,15 +26,17 @@ message IPv4InterfaceConfig {
 enum NodeType {
   NODE_TYPE_UNSPECIFIED = 0;
   // type0
-  NODE_TYPE_Type0 = 1;
+  NODE_TYPE_TYPE0 = 1;
   // type1
-  NODE_TYPE_Type1 = 2;
+  NODE_TYPE_TYPE1 = 2;
   // type2
-  NODE_TYPE_Type2 = 3;
+  NODE_TYPE_TYPE2 = 3;
   // type3
-  NODE_TYPE_Type3 = 4;
+  NODE_TYPE_TYPE3 = 4;
   // type3.1
-  NODE_TYPE_Type3dot1 = 5;
+  NODE_TYPE_TYPE3DOT1 = 5;
+  // type1.1
+  NODE_TYPE_TYPE1DOT1 = 6;
 }
 
 // A node: one machine running a replica instance.

--- a/rs/protobuf/def/registry/node/v1/node.proto
+++ b/rs/protobuf/def/registry/node/v1/node.proto
@@ -24,16 +24,17 @@ message IPv4InterfaceConfig {
 
 // The type of the node.
 enum NodeType {
+  NODE_TYPE_UNSPECIFIED = 0;
   // type0
-  NODE_TYPE_Type0 = 0;
+  NODE_TYPE_Type0 = 1;
   // type1
-  NODE_TYPE_Type1 = 1;
+  NODE_TYPE_Type1 = 2;
   // type2
-  NODE_TYPE_Type2 = 2;
+  NODE_TYPE_Type2 = 3;
   // type3
-  NODE_TYPE_Type3 = 3;
+  NODE_TYPE_Type3 = 4;
   // type3.1
-  NODE_TYPE_Type3dot1 = 4;
+  NODE_TYPE_Type3dot1 = 5;
 }
 
 // A node: one machine running a replica instance.

--- a/rs/protobuf/def/registry/node/v1/node.proto
+++ b/rs/protobuf/def/registry/node/v1/node.proto
@@ -63,7 +63,7 @@ message NodeRecord {
   // If a Node is to be converted into the ApiBoundaryNode, the domain field should be set.
   optional string domain = 19;
 
-  optional NodeRewardType node_type = 20;
+  optional NodeRewardType node_reward_type = 20;
 
   reserved 1, 2, 3, 4, 7, 8, 9, 10, 11, 12, 13, 14;
   reserved "node_id";

--- a/rs/protobuf/def/registry/node/v1/node.proto
+++ b/rs/protobuf/def/registry/node/v1/node.proto
@@ -22,6 +22,20 @@ message IPv4InterfaceConfig {
   uint32 prefix_length = 3;
 }
 
+// The type of the node.
+enum NodeType {
+  // type0
+  NODE_TYPE_Type0 = 0;
+  // type1
+  NODE_TYPE_Type1 = 1;
+  // type2
+  NODE_TYPE_Type2 = 2;
+  // type3
+  NODE_TYPE_Type3 = 3;
+  // type3.1
+  NODE_TYPE_Type3dot1 = 4;
+}
+
 // A node: one machine running a replica instance.
 message NodeRecord {
   // The endpoint where this node receives xnet messages.
@@ -45,6 +59,8 @@ message NodeRecord {
   // Domain name, which resolves into Node's IPv4 and IPv6.
   // If a Node is to be converted into the ApiBoundaryNode, the domain field should be set.
   optional string domain = 19;
+
+  optional NodeType node_type = 20;
 
   reserved 1, 2, 3, 4, 7, 8, 9, 10, 11, 12, 13, 14;
   reserved "node_id";

--- a/rs/protobuf/def/registry/node/v1/node.proto
+++ b/rs/protobuf/def/registry/node/v1/node.proto
@@ -23,20 +23,20 @@ message IPv4InterfaceConfig {
 }
 
 // The type of the node.
-enum NodeType {
-  NODE_TYPE_UNSPECIFIED = 0;
+enum NodeRewardType {
+  NODE_REWARD_TYPE_UNSPECIFIED = 0;
   // type0
-  NODE_TYPE_TYPE0 = 1;
+  NODE_REWARD_TYPE_TYPE0 = 1;
   // type1
-  NODE_TYPE_TYPE1 = 2;
+  NODE_REWARD_TYPE_TYPE1 = 2;
   // type2
-  NODE_TYPE_TYPE2 = 3;
+  NODE_REWARD_TYPE_TYPE2 = 3;
   // type3
-  NODE_TYPE_TYPE3 = 4;
+  NODE_REWARD_TYPE_TYPE3 = 4;
   // type3.1
-  NODE_TYPE_TYPE3DOT1 = 5;
+  NODE_REWARD_TYPE_TYPE3DOT1 = 5;
   // type1.1
-  NODE_TYPE_TYPE1DOT1 = 6;
+  NODE_REWARD_TYPE_TYPE1DOT1 = 6;
 }
 
 // A node: one machine running a replica instance.
@@ -63,7 +63,7 @@ message NodeRecord {
   // If a Node is to be converted into the ApiBoundaryNode, the domain field should be set.
   optional string domain = 19;
 
-  optional NodeType node_type = 20;
+  optional NodeRewardType node_type = 20;
 
   reserved 1, 2, 3, 4, 7, 8, 9, 10, 11, 12, 13, 14;
   reserved "node_id";

--- a/rs/protobuf/src/gen/registry/registry.node.v1.rs
+++ b/rs/protobuf/src/gen/registry/registry.node.v1.rs
@@ -80,6 +80,8 @@ pub enum NodeType {
     Type3 = 4,
     /// type3.1
     Type3dot1 = 5,
+    /// type1.1
+    Type1dot1 = 6,
 }
 impl NodeType {
     /// String value of the enum field names used in the ProtoBuf definition.
@@ -89,22 +91,24 @@ impl NodeType {
     pub fn as_str_name(&self) -> &'static str {
         match self {
             NodeType::Unspecified => "NODE_TYPE_UNSPECIFIED",
-            NodeType::Type0 => "NODE_TYPE_Type0",
-            NodeType::Type1 => "NODE_TYPE_Type1",
-            NodeType::Type2 => "NODE_TYPE_Type2",
-            NodeType::Type3 => "NODE_TYPE_Type3",
-            NodeType::Type3dot1 => "NODE_TYPE_Type3dot1",
+            NodeType::Type0 => "NODE_TYPE_TYPE0",
+            NodeType::Type1 => "NODE_TYPE_TYPE1",
+            NodeType::Type2 => "NODE_TYPE_TYPE2",
+            NodeType::Type3 => "NODE_TYPE_TYPE3",
+            NodeType::Type3dot1 => "NODE_TYPE_TYPE3DOT1",
+            NodeType::Type1dot1 => "NODE_TYPE_TYPE1DOT1",
         }
     }
     /// Creates an enum from field names used in the ProtoBuf definition.
     pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
         match value {
             "NODE_TYPE_UNSPECIFIED" => Some(Self::Unspecified),
-            "NODE_TYPE_Type0" => Some(Self::Type0),
-            "NODE_TYPE_Type1" => Some(Self::Type1),
-            "NODE_TYPE_Type2" => Some(Self::Type2),
-            "NODE_TYPE_Type3" => Some(Self::Type3),
-            "NODE_TYPE_Type3dot1" => Some(Self::Type3dot1),
+            "NODE_TYPE_TYPE0" => Some(Self::Type0),
+            "NODE_TYPE_TYPE1" => Some(Self::Type1),
+            "NODE_TYPE_TYPE2" => Some(Self::Type2),
+            "NODE_TYPE_TYPE3" => Some(Self::Type3),
+            "NODE_TYPE_TYPE3DOT1" => Some(Self::Type3dot1),
+            "NODE_TYPE_TYPE1DOT1" => Some(Self::Type1dot1),
             _ => None,
         }
     }

--- a/rs/protobuf/src/gen/registry/registry.node.v1.rs
+++ b/rs/protobuf/src/gen/registry/registry.node.v1.rs
@@ -50,4 +50,59 @@ pub struct NodeRecord {
     /// If a Node is to be converted into the ApiBoundaryNode, the domain field should be set.
     #[prost(string, optional, tag = "19")]
     pub domain: ::core::option::Option<::prost::alloc::string::String>,
+    #[prost(enumeration = "NodeType", optional, tag = "20")]
+    pub node_type: ::core::option::Option<i32>,
+}
+/// The type of the node.
+#[derive(
+    serde::Serialize,
+    serde::Deserialize,
+    Clone,
+    Copy,
+    Debug,
+    PartialEq,
+    Eq,
+    Hash,
+    PartialOrd,
+    Ord,
+    ::prost::Enumeration,
+)]
+#[repr(i32)]
+pub enum NodeType {
+    /// type0
+    Type0 = 0,
+    /// type1
+    Type1 = 1,
+    /// type2
+    Type2 = 2,
+    /// type3
+    Type3 = 3,
+    /// type3.1
+    Type3dot1 = 4,
+}
+impl NodeType {
+    /// String value of the enum field names used in the ProtoBuf definition.
+    ///
+    /// The values are not transformed in any way and thus are considered stable
+    /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+    pub fn as_str_name(&self) -> &'static str {
+        match self {
+            NodeType::Type0 => "NODE_TYPE_Type0",
+            NodeType::Type1 => "NODE_TYPE_Type1",
+            NodeType::Type2 => "NODE_TYPE_Type2",
+            NodeType::Type3 => "NODE_TYPE_Type3",
+            NodeType::Type3dot1 => "NODE_TYPE_Type3dot1",
+        }
+    }
+    /// Creates an enum from field names used in the ProtoBuf definition.
+    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+        match value {
+            "NODE_TYPE_Type0" => Some(Self::Type0),
+            "NODE_TYPE_Type1" => Some(Self::Type1),
+            "NODE_TYPE_Type2" => Some(Self::Type2),
+            "NODE_TYPE_Type3" => Some(Self::Type3),
+            "NODE_TYPE_Type3dot1" => Some(Self::Type3dot1),
+            _ => None,
+        }
+    }
 }

--- a/rs/protobuf/src/gen/registry/registry.node.v1.rs
+++ b/rs/protobuf/src/gen/registry/registry.node.v1.rs
@@ -69,16 +69,17 @@ pub struct NodeRecord {
 )]
 #[repr(i32)]
 pub enum NodeType {
+    Unspecified = 0,
     /// type0
-    Type0 = 0,
+    Type0 = 1,
     /// type1
-    Type1 = 1,
+    Type1 = 2,
     /// type2
-    Type2 = 2,
+    Type2 = 3,
     /// type3
-    Type3 = 3,
+    Type3 = 4,
     /// type3.1
-    Type3dot1 = 4,
+    Type3dot1 = 5,
 }
 impl NodeType {
     /// String value of the enum field names used in the ProtoBuf definition.
@@ -87,6 +88,7 @@ impl NodeType {
     /// (if the ProtoBuf definition does not change) and safe for programmatic use.
     pub fn as_str_name(&self) -> &'static str {
         match self {
+            NodeType::Unspecified => "NODE_TYPE_UNSPECIFIED",
             NodeType::Type0 => "NODE_TYPE_Type0",
             NodeType::Type1 => "NODE_TYPE_Type1",
             NodeType::Type2 => "NODE_TYPE_Type2",
@@ -97,6 +99,7 @@ impl NodeType {
     /// Creates an enum from field names used in the ProtoBuf definition.
     pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
         match value {
+            "NODE_TYPE_UNSPECIFIED" => Some(Self::Unspecified),
             "NODE_TYPE_Type0" => Some(Self::Type0),
             "NODE_TYPE_Type1" => Some(Self::Type1),
             "NODE_TYPE_Type2" => Some(Self::Type2),

--- a/rs/protobuf/src/gen/registry/registry.node.v1.rs
+++ b/rs/protobuf/src/gen/registry/registry.node.v1.rs
@@ -51,7 +51,7 @@ pub struct NodeRecord {
     #[prost(string, optional, tag = "19")]
     pub domain: ::core::option::Option<::prost::alloc::string::String>,
     #[prost(enumeration = "NodeRewardType", optional, tag = "20")]
-    pub node_type: ::core::option::Option<i32>,
+    pub node_reward_type: ::core::option::Option<i32>,
 }
 /// The type of the node.
 #[derive(

--- a/rs/protobuf/src/gen/registry/registry.node.v1.rs
+++ b/rs/protobuf/src/gen/registry/registry.node.v1.rs
@@ -50,7 +50,7 @@ pub struct NodeRecord {
     /// If a Node is to be converted into the ApiBoundaryNode, the domain field should be set.
     #[prost(string, optional, tag = "19")]
     pub domain: ::core::option::Option<::prost::alloc::string::String>,
-    #[prost(enumeration = "NodeType", optional, tag = "20")]
+    #[prost(enumeration = "NodeRewardType", optional, tag = "20")]
     pub node_type: ::core::option::Option<i32>,
 }
 /// The type of the node.
@@ -68,7 +68,7 @@ pub struct NodeRecord {
     ::prost::Enumeration,
 )]
 #[repr(i32)]
-pub enum NodeType {
+pub enum NodeRewardType {
     Unspecified = 0,
     /// type0
     Type0 = 1,
@@ -83,32 +83,32 @@ pub enum NodeType {
     /// type1.1
     Type1dot1 = 6,
 }
-impl NodeType {
+impl NodeRewardType {
     /// String value of the enum field names used in the ProtoBuf definition.
     ///
     /// The values are not transformed in any way and thus are considered stable
     /// (if the ProtoBuf definition does not change) and safe for programmatic use.
     pub fn as_str_name(&self) -> &'static str {
         match self {
-            NodeType::Unspecified => "NODE_TYPE_UNSPECIFIED",
-            NodeType::Type0 => "NODE_TYPE_TYPE0",
-            NodeType::Type1 => "NODE_TYPE_TYPE1",
-            NodeType::Type2 => "NODE_TYPE_TYPE2",
-            NodeType::Type3 => "NODE_TYPE_TYPE3",
-            NodeType::Type3dot1 => "NODE_TYPE_TYPE3DOT1",
-            NodeType::Type1dot1 => "NODE_TYPE_TYPE1DOT1",
+            Self::Unspecified => "NODE_REWARD_TYPE_UNSPECIFIED",
+            Self::Type0 => "NODE_REWARD_TYPE_TYPE0",
+            Self::Type1 => "NODE_REWARD_TYPE_TYPE1",
+            Self::Type2 => "NODE_REWARD_TYPE_TYPE2",
+            Self::Type3 => "NODE_REWARD_TYPE_TYPE3",
+            Self::Type3dot1 => "NODE_REWARD_TYPE_TYPE3DOT1",
+            Self::Type1dot1 => "NODE_REWARD_TYPE_TYPE1DOT1",
         }
     }
     /// Creates an enum from field names used in the ProtoBuf definition.
     pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
         match value {
-            "NODE_TYPE_UNSPECIFIED" => Some(Self::Unspecified),
-            "NODE_TYPE_TYPE0" => Some(Self::Type0),
-            "NODE_TYPE_TYPE1" => Some(Self::Type1),
-            "NODE_TYPE_TYPE2" => Some(Self::Type2),
-            "NODE_TYPE_TYPE3" => Some(Self::Type3),
-            "NODE_TYPE_TYPE3DOT1" => Some(Self::Type3dot1),
-            "NODE_TYPE_TYPE1DOT1" => Some(Self::Type1dot1),
+            "NODE_REWARD_TYPE_UNSPECIFIED" => Some(Self::Unspecified),
+            "NODE_REWARD_TYPE_TYPE0" => Some(Self::Type0),
+            "NODE_REWARD_TYPE_TYPE1" => Some(Self::Type1),
+            "NODE_REWARD_TYPE_TYPE2" => Some(Self::Type2),
+            "NODE_REWARD_TYPE_TYPE3" => Some(Self::Type3),
+            "NODE_REWARD_TYPE_TYPE3DOT1" => Some(Self::Type3dot1),
+            "NODE_REWARD_TYPE_TYPE1DOT1" => Some(Self::Type1dot1),
             _ => None,
         }
     }

--- a/rs/protobuf/src/registry/node.rs
+++ b/rs/protobuf/src/registry/node.rs
@@ -1,3 +1,21 @@
+use crate::registry::node::v1::NodeType;
+
 #[allow(clippy::all)]
 #[path = "../gen/registry/registry.node.v1.rs"]
 pub mod v1;
+
+impl From<NodeType> for String {
+    fn from(value: NodeType) -> Self {
+        match value {
+            NodeType::Unspecified => {
+                panic!("Cannot create a node type string from unspecified")
+            }
+            NodeType::Type0 => "type0".to_string(),
+            NodeType::Type1 => "type1".to_string(),
+            NodeType::Type2 => "type2".to_string(),
+            NodeType::Type3 => "type3".to_string(),
+            NodeType::Type3dot1 => "type3.1".to_string(),
+            NodeType::Type1dot1 => "type1.1".to_string(),
+        }
+    }
+}

--- a/rs/protobuf/src/registry/node.rs
+++ b/rs/protobuf/src/registry/node.rs
@@ -1,21 +1,21 @@
-use crate::registry::node::v1::NodeType;
+use crate::registry::node::v1::NodeRewardType;
 
 #[allow(clippy::all)]
 #[path = "../gen/registry/registry.node.v1.rs"]
 pub mod v1;
 
-impl From<NodeType> for String {
-    fn from(value: NodeType) -> Self {
+impl From<NodeRewardType> for String {
+    fn from(value: NodeRewardType) -> Self {
         match value {
-            NodeType::Unspecified => {
+            NodeRewardType::Unspecified => {
                 panic!("Cannot create a node type string from unspecified")
             }
-            NodeType::Type0 => "type0".to_string(),
-            NodeType::Type1 => "type1".to_string(),
-            NodeType::Type2 => "type2".to_string(),
-            NodeType::Type3 => "type3".to_string(),
-            NodeType::Type3dot1 => "type3.1".to_string(),
-            NodeType::Type1dot1 => "type1.1".to_string(),
+            NodeRewardType::Type0 => "type0".to_string(),
+            NodeRewardType::Type1 => "type1".to_string(),
+            NodeRewardType::Type2 => "type2".to_string(),
+            NodeRewardType::Type3 => "type3".to_string(),
+            NodeRewardType::Type3dot1 => "type3.1".to_string(),
+            NodeRewardType::Type1dot1 => "type1.1".to_string(),
         }
     }
 }

--- a/rs/registry/canister/api/src/lib.rs
+++ b/rs/registry/canister/api/src/lib.rs
@@ -184,10 +184,10 @@ pub struct AddNodePayload {
     pub p2p_flow_endpoints: Vec<String>,
     pub prometheus_metrics_endpoint: String,
 
-    // String representation of the node type.  Must be a valid type.
-    // See registry/canister/src/mutations/do_add_node.rs, fn `try_str_to_node_type` for currently
+    // String representation of the node reward type.  Must be a valid type.
+    // See registry/canister/src/mutations/do_add_node.rs, fn `validate_str_as_node_reward_type` for currently
     // accepted types.
-    pub node_type: Option<String>,
+    pub node_reward_type: Option<String>,
 }
 
 /// The payload of a request to update keys of the existing node.

--- a/rs/registry/canister/api/src/lib.rs
+++ b/rs/registry/canister/api/src/lib.rs
@@ -185,7 +185,8 @@ pub struct AddNodePayload {
     pub prometheus_metrics_endpoint: String,
 
     // String representation of the node type.  Must be a valid type.
-    // Currently valid types are type0, type1, type2, type3, and type3.1.
+    // See registry/canister/src/mutations/do_add_node.rs, fn `try_str_to_node_type` for currently
+    // accepted types.
     pub node_type: Option<String>,
 }
 

--- a/rs/registry/canister/api/src/lib.rs
+++ b/rs/registry/canister/api/src/lib.rs
@@ -1,10 +1,7 @@
 use candid::{CandidType, Deserialize};
 use ic_base_types::NodeId;
 use serde::Serialize;
-use std::collections::HashSet;
-use std::fmt;
-use std::net::Ipv4Addr;
-use std::str::FromStr;
+use std::{collections::HashSet, fmt, net::Ipv4Addr, str::FromStr};
 use thiserror::Error;
 
 #[derive(Debug, Error)]
@@ -186,6 +183,10 @@ pub struct AddNodePayload {
     // TODO(NNS1-2444): The fields below are deprecated and they are not read anywhere.
     pub p2p_flow_endpoints: Vec<String>,
     pub prometheus_metrics_endpoint: String,
+
+    // String representation of the node type.  Must be a valid type.
+    // Currently valid types are type0, type1, type2, type3, and type3.1.
+    pub node_type: Option<String>,
 }
 
 /// The payload of a request to update keys of the existing node.

--- a/rs/registry/canister/canister/registry.did
+++ b/rs/registry/canister/canister/registry.did
@@ -42,6 +42,7 @@ type AddNodePayload = record {
   transport_tls_cert : blob;
   ni_dkg_dealing_encryption_pk : blob;
   p2p_flow_endpoints : vec text;
+  node_type : opt text;
 };
 
 type AddNodesToSubnetPayload = record {

--- a/rs/registry/canister/canister/registry.did
+++ b/rs/registry/canister/canister/registry.did
@@ -42,7 +42,7 @@ type AddNodePayload = record {
   transport_tls_cert : blob;
   ni_dkg_dealing_encryption_pk : blob;
   p2p_flow_endpoints : vec text;
-  node_type : opt text;
+  node_reward_type : opt text;
 };
 
 type AddNodesToSubnetPayload = record {

--- a/rs/registry/canister/src/invariants/endpoint.rs
+++ b/rs/registry/canister/src/invariants/endpoint.rs
@@ -391,10 +391,7 @@ mod tests {
                     ip_addr: "200.1.1.3".to_string(),
                     port: 9001,
                 }),
-                hostos_version_id: None,
-                chip_id: None,
-                public_ipv4_config: None,
-                domain: None,
+                ..Default::default()
             }
             .encode_to_vec(),
         );
@@ -421,10 +418,8 @@ mod tests {
                     ip_addr: "200.1.1.1".to_string(),
                     port: 9001,
                 }),
-                hostos_version_id: None,
-                chip_id: None,
-                public_ipv4_config: None,
-                domain: None,
+
+                ..Default::default()
             }
             .encode_to_vec(),
         );
@@ -458,10 +453,7 @@ mod tests {
                     ip_addr: "200.1.1.2".to_string(),
                     port: 9001,
                 }),
-                hostos_version_id: None,
-                chip_id: None,
-                public_ipv4_config: None,
-                domain: None,
+                ..Default::default()
             }
             .encode_to_vec(),
         );

--- a/rs/registry/canister/src/invariants/firewall.rs
+++ b/rs/registry/canister/src/invariants/firewall.rs
@@ -340,7 +340,7 @@ mod tests {
             chip_id: None,
             public_ipv4_config: None,
             domain: None,
-            node_type: None,
+            node_reward_type: None,
         }
     }
 

--- a/rs/registry/canister/src/invariants/firewall.rs
+++ b/rs/registry/canister/src/invariants/firewall.rs
@@ -284,8 +284,9 @@ fn get_firewall_rules(snapshot: &RegistrySnapshot, record_key: String) -> Option
 #[cfg(test)]
 mod tests {
     use super::*;
-    use ic_protobuf::registry::subnet::v1::SubnetListRecord;
-    use ic_protobuf::registry::{firewall::v1::FirewallRuleDirection, node::v1::NodeRecord};
+    use ic_protobuf::registry::{
+        firewall::v1::FirewallRuleDirection, node::v1::NodeRecord, subnet::v1::SubnetListRecord,
+    };
     use ic_registry_keys::{make_node_record_key, make_subnet_list_record_key};
     use prost::Message;
 
@@ -339,6 +340,7 @@ mod tests {
             chip_id: None,
             public_ipv4_config: None,
             domain: None,
+            node_type: None,
         }
     }
 

--- a/rs/registry/canister/src/mutations/node_management/do_add_node.rs
+++ b/rs/registry/canister/src/mutations/node_management/do_add_node.rs
@@ -22,8 +22,7 @@ use crate::mutations::node_management::{
     do_remove_node_directly::RemoveNodeDirectlyPayload,
 };
 use ic_registry_canister_api::AddNodePayload;
-use ic_types::crypto::CurrentNodePublicKeys;
-use ic_types::time::Time;
+use ic_types::{crypto::CurrentNodePublicKeys, time::Time};
 use prost::Message;
 
 impl Registry {
@@ -123,6 +122,7 @@ impl Registry {
             chip_id: payload.chip_id.clone(),
             public_ipv4_config: ipv4_intf_config,
             domain,
+            node_type,
         };
 
         // 7. Insert node, public keys, and crypto keys

--- a/rs/registry/canister/src/mutations/node_management/do_add_node.rs
+++ b/rs/registry/canister/src/mutations/node_management/do_add_node.rs
@@ -77,11 +77,11 @@ impl Registry {
         }
 
         // 3. Get valid type if type is in request
-        let node_type = payload
-            .node_type
+        let node_reward_type = payload
+            .node_reward_type
             .as_ref()
             .map(|t| {
-                validate_str_as_node_type(t).map_err(|e| {
+                validate_str_as_node_reward_type(t).map_err(|e| {
                     format!(
                         "{}do_add_node: Error parsing node type from payload: {}",
                         LOG_PREFIX, e
@@ -89,7 +89,7 @@ impl Registry {
                 })
             })
             .transpose()?
-            .map(|node_type| node_type as i32);
+            .map(|node_reward_type| node_reward_type as i32);
 
         // 4. Validate keys and get the node id
         let (node_id, valid_pks) = valid_keys_from_payload(&payload)
@@ -138,7 +138,7 @@ impl Registry {
             chip_id: payload.chip_id.clone(),
             public_ipv4_config: ipv4_intf_config,
             domain,
-            node_type,
+            node_reward_type,
         };
 
         // 8. Insert node, public keys, and crypto keys
@@ -163,7 +163,7 @@ impl Registry {
 
 // try to convert input string into NodeRewardType enum
 // If a type is no longer supported for newly registered nodes, it should be removed from this function
-fn validate_str_as_node_type<T: AsRef<str> + Display>(
+fn validate_str_as_node_reward_type<T: AsRef<str> + Display>(
     type_string: T,
 ) -> Result<NodeRewardType, String> {
     Ok(match type_string.as_ref() {
@@ -334,7 +334,7 @@ mod tests {
             // Unused section follows
             p2p_flow_endpoints: Default::default(),
             prometheus_metrics_endpoint: Default::default(),
-            node_type: None,
+            node_reward_type: None,
         };
 
         (payload, node_public_keys)
@@ -373,7 +373,7 @@ mod tests {
             // Unused section follows
             p2p_flow_endpoints: Default::default(),
             prometheus_metrics_endpoint: Default::default(),
-            node_type: None,
+            node_reward_type: None,
         };
     }
 

--- a/rs/registry/canister/src/mutations/node_management/do_add_node.rs
+++ b/rs/registry/canister/src/mutations/node_management/do_add_node.rs
@@ -10,7 +10,7 @@ use ic_crypto_node_key_validation::ValidNodePublicKeys;
 use ic_crypto_utils_basic_sig::conversions as crypto_basicsig_conversions;
 use ic_protobuf::registry::{
     crypto::v1::{PublicKey, X509PublicKeyCert},
-    node::v1::{ConnectionEndpoint, IPv4InterfaceConfig, NodeRecord},
+    node::v1::{ConnectionEndpoint, IPv4InterfaceConfig, NodeRecord, NodeType},
 };
 use idna::domain_to_ascii_strict;
 
@@ -75,11 +75,26 @@ impl Registry {
             ));
         }
 
-        // 3. Validate keys and get the node id
+        // 3. Get valid type if type is in request
+        let node_type = payload
+            .node_type
+            .as_ref()
+            .map(|t| {
+                try_str_to_node_type(t).map_err(|e| {
+                    format!(
+                        "{}do_add_node: Error parsing node type from payload: {}",
+                        LOG_PREFIX, e
+                    )
+                })
+            })
+            .transpose()?
+            .map(|node_type| node_type as i32);
+
+        // 4. Validate keys and get the node id
         let (node_id, valid_pks) = valid_keys_from_payload(&payload)
             .map_err(|err| format!("{}do_add_node: {}", LOG_PREFIX, err))?;
 
-        // 4. Validate the domain is valid
+        // 5. Validate the domain is valid
         let domain: Option<String> = payload
             .domain
             .as_ref()
@@ -93,7 +108,7 @@ impl Registry {
             })
             .transpose()?;
 
-        // 5. If there is an IPv4 config, make sure that the IPv4 is not used by anyone else
+        // 6. If there is an IPv4 config, make sure that the IPv4 is not used by anyone else
         let ipv4_intf_config = payload.public_ipv4_config.clone().map(|ipv4_config| {
             ipv4_config.panic_on_invalid();
             IPv4InterfaceConfig {
@@ -113,7 +128,7 @@ impl Registry {
 
         println!("{}do_add_node: The node id is {:?}", LOG_PREFIX, node_id);
 
-        // 6. Create the Node Record
+        // 7. Create the Node Record
         let node_record = NodeRecord {
             xnet: Some(connection_endpoint_from_string(&payload.xnet_endpoint)),
             http: Some(connection_endpoint_from_string(&payload.http_endpoint)),
@@ -125,10 +140,10 @@ impl Registry {
             node_type,
         };
 
-        // 7. Insert node, public keys, and crypto keys
+        // 8. Insert node, public keys, and crypto keys
         let mut mutations = make_add_node_registry_mutations(node_id, node_record, valid_pks);
 
-        // 8. Update the Node Operator record
+        // 9. Update the Node Operator record
         node_operator_record.node_allowance -= 1;
 
         let update_node_operator_record =
@@ -136,13 +151,25 @@ impl Registry {
 
         mutations.push(update_node_operator_record);
 
-        // 9. Check invariants before applying mutations
+        // 10. Check invariants before applying mutations
         self.maybe_apply_mutation_internal(mutations);
 
         println!("{}do_add_node finished: {:?}", LOG_PREFIX, payload);
 
         Ok(node_id)
     }
+}
+
+// try to convert input string inot NodeType enum
+fn try_str_to_node_type(type_string: &str) -> Result<NodeType, String> {
+    Ok(match type_string {
+        "type0" => NodeType::Type0,
+        "type1" => NodeType::Type1,
+        "type2" => NodeType::Type2,
+        "type3" => NodeType::Type3,
+        "type3.1" => NodeType::Type3dot1,
+        _ => return Err(format!("Invalid node type: {}", type_string)),
+    })
 }
 
 /// Parses the ConnectionEndpoint string
@@ -302,6 +329,7 @@ mod tests {
             // Unused section follows
             p2p_flow_endpoints: Default::default(),
             prometheus_metrics_endpoint: Default::default(),
+            node_type: None,
         };
 
         (payload, node_public_keys)
@@ -340,6 +368,7 @@ mod tests {
             // Unused section follows
             p2p_flow_endpoints: Default::default(),
             prometheus_metrics_endpoint: Default::default(),
+            node_type: None,
         };
     }
 

--- a/rs/registry/canister/src/mutations/node_management/do_add_node.rs
+++ b/rs/registry/canister/src/mutations/node_management/do_add_node.rs
@@ -11,7 +11,7 @@ use ic_crypto_node_key_validation::ValidNodePublicKeys;
 use ic_crypto_utils_basic_sig::conversions as crypto_basicsig_conversions;
 use ic_protobuf::registry::{
     crypto::v1::{PublicKey, X509PublicKeyCert},
-    node::v1::{ConnectionEndpoint, IPv4InterfaceConfig, NodeRecord, NodeType},
+    node::v1::{ConnectionEndpoint, IPv4InterfaceConfig, NodeRecord, NodeRewardType},
 };
 use idna::domain_to_ascii_strict;
 
@@ -161,16 +161,18 @@ impl Registry {
     }
 }
 
-// try to convert input string into NodeType enum
+// try to convert input string into NodeRewardType enum
 // If a type is no longer supported for newly registered nodes, it should be removed from this function
-fn validate_str_as_node_type<T: AsRef<str> + Display>(type_string: T) -> Result<NodeType, String> {
+fn validate_str_as_node_type<T: AsRef<str> + Display>(
+    type_string: T,
+) -> Result<NodeRewardType, String> {
     Ok(match type_string.as_ref() {
-        "type0" => NodeType::Type0,
-        "type1" => NodeType::Type1,
-        "type2" => NodeType::Type2,
-        "type3" => NodeType::Type3,
-        "type3.1" => NodeType::Type3dot1,
-        "type1.1" => NodeType::Type1dot1,
+        "type0" => NodeRewardType::Type0,
+        "type1" => NodeRewardType::Type1,
+        "type2" => NodeRewardType::Type2,
+        "type3" => NodeRewardType::Type3,
+        "type3.1" => NodeRewardType::Type3dot1,
+        "type1.1" => NodeRewardType::Type1dot1,
         _ => return Err(format!("Invalid node type: {}", type_string)),
     })
 }

--- a/rs/registry/canister/src/mutations/node_management/do_add_node.rs
+++ b/rs/registry/canister/src/mutations/node_management/do_add_node.rs
@@ -1,4 +1,5 @@
 use crate::{common::LOG_PREFIX, registry::Registry};
+use std::fmt::Display;
 
 use std::net::SocketAddr;
 
@@ -80,7 +81,7 @@ impl Registry {
             .node_type
             .as_ref()
             .map(|t| {
-                try_str_to_node_type(t).map_err(|e| {
+                validate_str_as_node_type(t).map_err(|e| {
                     format!(
                         "{}do_add_node: Error parsing node type from payload: {}",
                         LOG_PREFIX, e
@@ -160,14 +161,16 @@ impl Registry {
     }
 }
 
-// try to convert input string inot NodeType enum
-fn try_str_to_node_type(type_string: &str) -> Result<NodeType, String> {
-    Ok(match type_string {
+// try to convert input string into NodeType enum
+// If a type is no longer supported for newly registered nodes, it should be removed from this function
+fn validate_str_as_node_type<T: AsRef<str> + Display>(type_string: T) -> Result<NodeType, String> {
+    Ok(match type_string.as_ref() {
         "type0" => NodeType::Type0,
         "type1" => NodeType::Type1,
         "type2" => NodeType::Type2,
         "type3" => NodeType::Type3,
         "type3.1" => NodeType::Type3dot1,
+        "type1.1" => NodeType::Type1dot1,
         _ => return Err(format!("Invalid node type: {}", type_string)),
     })
 }

--- a/rs/registry/canister/tests/add_node.rs
+++ b/rs/registry/canister/tests/add_node.rs
@@ -5,15 +5,15 @@ use ic_canister_client_sender::Sender;
 use ic_nervous_system_common_test_keys::{
     TEST_NEURON_1_OWNER_KEYPAIR, TEST_NEURON_1_OWNER_PRINCIPAL, TEST_USER1_KEYPAIR,
 };
-use ic_nns_test_utils::registry::{
-    get_committee_signing_key, get_dkg_dealing_key, get_node_operator_record, get_node_record,
-    get_node_signing_key, get_transport_tls_certificate,
-};
 use ic_nns_test_utils::{
     itest_helpers::{local_test_on_nns_subnet, set_up_registry_canister},
-    registry::{invariant_compliant_mutation_as_atomic_req, prepare_add_node_payload},
+    registry::{
+        get_committee_signing_key, get_dkg_dealing_key, get_node_operator_record, get_node_record,
+        get_node_signing_key, get_transport_tls_certificate,
+        invariant_compliant_mutation_as_atomic_req, prepare_add_node_payload,
+    },
 };
-use ic_protobuf::registry::node_operator::v1::NodeOperatorRecord;
+use ic_protobuf::registry::{node::v1::NodeType, node_operator::v1::NodeOperatorRecord};
 use ic_registry_keys::make_node_operator_record_key;
 use ic_registry_transport::pb::v1::{
     registry_mutation, RegistryAtomicMutateRequest, RegistryMutation,
@@ -36,7 +36,8 @@ fn node_is_created_on_receiving_the_request() {
         )
         .await;
 
-        let (payload, node_pks) = prepare_add_node_payload(1);
+        let (mut payload, node_pks) = prepare_add_node_payload(1);
+        payload.node_type = Some("type3".to_string());
         let node_id = node_pks.node_id();
 
         // Then, ensure there is no value for the node
@@ -51,13 +52,14 @@ fn node_is_created_on_receiving_the_request() {
                 &Sender::from_keypair(&TEST_NEURON_1_OWNER_KEYPAIR),
             )
             .await;
-        println!("registry.update_from_sender(add_node) = {response:?}");
         assert!(response.is_ok());
 
         // Now let's check directly in the registry that the mutation actually happened
         let node_record = get_node_record(&registry, node_id).await;
         // Check if some fields are present
         assert!(node_record.is_some());
+        let node_record = node_record.unwrap();
+        assert_eq!(node_record.node_type, Some(NodeType::Type3 as i32));
 
         // Check that other fields are present
         let node_signing_pubkey_record = get_node_signing_key(&registry, node_id).await.unwrap();
@@ -91,6 +93,50 @@ fn node_is_created_on_receiving_the_request() {
                 .await
                 .unwrap();
         assert_eq!(node_operator_record.node_allowance, 99);
+
+        Ok(())
+    });
+}
+
+#[test]
+fn node_is_not_created_with_invalid_type() {
+    local_test_on_nns_subnet(|runtime| async move {
+        // First prepare the registry with a Node Operator record and make it callable
+        // by anyone
+        let registry = set_up_registry_canister(
+            &runtime,
+            RegistryCanisterInitPayloadBuilder::new()
+                .push_init_mutate_request(invariant_compliant_mutation_as_atomic_req(0))
+                .push_init_mutate_request(init_mutation_with_node_allowance(100))
+                .build(),
+        )
+        .await;
+
+        let (mut payload, node_pks) = prepare_add_node_payload(1);
+        payload.node_type = Some("type1.1".to_string());
+        let node_id = node_pks.node_id();
+
+        // Then, ensure there is no value for the node
+        let node_record = get_node_record(&registry, node_id).await;
+        assert!(node_record.is_none());
+
+        let response: Result<NodeId, String> = registry
+            .update_from_sender(
+                "add_node",
+                candid,
+                (payload,),
+                &Sender::from_keypair(&TEST_NEURON_1_OWNER_KEYPAIR),
+            )
+            .await;
+        assert!(response.is_err());
+        assert!(response
+            .unwrap_err()
+            .to_string()
+            .contains("Invalid node type"));
+
+        // The record should still not be there
+        let node_record = get_node_record(&registry, node_id).await;
+        assert!(node_record.is_none());
 
         Ok(())
     });

--- a/rs/registry/canister/tests/add_node.rs
+++ b/rs/registry/canister/tests/add_node.rs
@@ -113,7 +113,7 @@ fn node_is_not_created_with_invalid_type() {
         .await;
 
         let (mut payload, node_pks) = prepare_add_node_payload(1);
-        payload.node_type = Some("type1.1".to_string());
+        payload.node_type = Some("type0.11".to_string());
         let node_id = node_pks.node_id();
 
         // Then, ensure there is no value for the node

--- a/rs/registry/canister/tests/add_node.rs
+++ b/rs/registry/canister/tests/add_node.rs
@@ -37,7 +37,7 @@ fn node_is_created_on_receiving_the_request() {
         .await;
 
         let (mut payload, node_pks) = prepare_add_node_payload(1);
-        payload.node_type = Some("type3".to_string());
+        payload.node_reward_type = Some("type3".to_string());
         let node_id = node_pks.node_id();
 
         // Then, ensure there is no value for the node
@@ -59,7 +59,10 @@ fn node_is_created_on_receiving_the_request() {
         // Check if some fields are present
         assert!(node_record.is_some());
         let node_record = node_record.unwrap();
-        assert_eq!(node_record.node_type, Some(NodeRewardType::Type3 as i32));
+        assert_eq!(
+            node_record.node_reward_type,
+            Some(NodeRewardType::Type3 as i32)
+        );
 
         // Check that other fields are present
         let node_signing_pubkey_record = get_node_signing_key(&registry, node_id).await.unwrap();
@@ -113,7 +116,7 @@ fn node_is_not_created_with_invalid_type() {
         .await;
 
         let (mut payload, node_pks) = prepare_add_node_payload(1);
-        payload.node_type = Some("type0.11".to_string());
+        payload.node_reward_type = Some("type0.11".to_string());
         let node_id = node_pks.node_id();
 
         // Then, ensure there is no value for the node

--- a/rs/registry/canister/tests/add_node.rs
+++ b/rs/registry/canister/tests/add_node.rs
@@ -13,7 +13,7 @@ use ic_nns_test_utils::{
         invariant_compliant_mutation_as_atomic_req, prepare_add_node_payload,
     },
 };
-use ic_protobuf::registry::{node::v1::NodeType, node_operator::v1::NodeOperatorRecord};
+use ic_protobuf::registry::{node::v1::NodeRewardType, node_operator::v1::NodeOperatorRecord};
 use ic_registry_keys::make_node_operator_record_key;
 use ic_registry_transport::pb::v1::{
     registry_mutation, RegistryAtomicMutateRequest, RegistryMutation,
@@ -59,7 +59,7 @@ fn node_is_created_on_receiving_the_request() {
         // Check if some fields are present
         assert!(node_record.is_some());
         let node_record = node_record.unwrap();
-        assert_eq!(node_record.node_type, Some(NodeType::Type3 as i32));
+        assert_eq!(node_record.node_type, Some(NodeRewardType::Type3 as i32));
 
         // Check that other fields are present
         let node_signing_pubkey_record = get_node_signing_key(&registry, node_id).await.unwrap();

--- a/rs/registry/helpers/src/firewall.rs
+++ b/rs/registry/helpers/src/firewall.rs
@@ -1,18 +1,15 @@
-use crate::deserialize_registry_value;
-use crate::node::NodeRecord;
+use crate::{deserialize_registry_value, node::NodeRecord};
 use ic_interfaces_registry::{RegistryClient, RegistryClientResult};
-use ic_protobuf::registry::firewall::v1::FirewallConfig;
-use ic_protobuf::registry::firewall::v1::FirewallRuleSet;
-use ic_protobuf::registry::node::v1::ConnectionEndpoint;
-use ic_registry_keys::get_node_record_node_id;
-use ic_registry_keys::make_firewall_config_record_key;
-use ic_registry_keys::make_firewall_rules_record_key;
-use ic_registry_keys::make_node_record_key;
-use ic_registry_keys::FirewallRulesScope;
-use ic_registry_keys::NODE_RECORD_KEY_PREFIX;
+use ic_protobuf::registry::{
+    firewall::v1::{FirewallConfig, FirewallRuleSet},
+    node::v1::ConnectionEndpoint,
+};
+use ic_registry_keys::{
+    get_node_record_node_id, make_firewall_config_record_key, make_firewall_rules_record_key,
+    make_node_record_key, FirewallRulesScope, NODE_RECORD_KEY_PREFIX,
+};
 use ic_types::{NodeId, RegistryVersion};
-use std::collections::HashSet;
-use std::net::IpAddr;
+use std::{collections::HashSet, net::IpAddr};
 
 /// A trait that allows access to firewall rules and ancillary information.
 pub trait FirewallRegistry {
@@ -147,11 +144,7 @@ mod tests {
                             ip_addr: ip.to_string(),
                             port: 2457,
                         }),
-                        node_operator_id: vec![],
-                        hostos_version_id: None,
-                        chip_id: None,
-                        public_ipv4_config: None,
-                        domain: None,
+                        ..Default::default()
                     },
                 )
             })

--- a/rs/state_machine_tests/src/lib.rs
+++ b/rs/state_machine_tests/src/lib.rs
@@ -9,8 +9,10 @@ use ic_config::{
     execution_environment::Config as HypervisorConfig, flag_status::FlagStatus,
     state_manager::LsmtConfig, subnet_config::SubnetConfig,
 };
-use ic_consensus::consensus::payload_builder::PayloadBuilderImpl;
-use ic_consensus::dkg::{make_registry_cup, make_registry_cup_from_cup_contents};
+use ic_consensus::{
+    consensus::payload_builder::PayloadBuilderImpl,
+    dkg::{make_registry_cup, make_registry_cup_from_cup_contents},
+};
 use ic_consensus_utils::crypto::SignVerify;
 use ic_crypto_test_utils_ni_dkg::{
     dummy_initial_dkg_transcript_with_master_key, sign_message, SecretKeyBytes,
@@ -23,17 +25,16 @@ use ic_execution_environment::{ExecutionServices, IngressHistoryReaderImpl};
 use ic_http_endpoints_public::{metrics::HttpHandlerMetrics, IngressWatcher, IngressWatcherHandle};
 use ic_https_outcalls_consensus::payload_builder::CanisterHttpPayloadBuilderImpl;
 use ic_ingress_manager::{IngressManager, RandomStateKind};
-use ic_interfaces::batch_payload::BatchPayloadBuilder;
-use ic_interfaces::ingress_pool::IngressPoolObject;
 use ic_interfaces::{
-    batch_payload::{IntoMessages, PastPayload, ProposalContext},
+    batch_payload::{BatchPayloadBuilder, IntoMessages, PastPayload, ProposalContext},
     canister_http::{CanisterHttpChangeAction, CanisterHttpPool},
     certification::{Verifier, VerifierError},
     consensus::{PayloadBuilder as ConsensusPayloadBuilder, PayloadValidationError},
     consensus_pool::ConsensusTime,
     execution_environment::{IngressFilterService, IngressHistoryReader, QueryExecutionService},
     ingress_pool::{
-        IngressPool, PoolSection, UnvalidatedIngressArtifact, ValidatedIngressArtifact,
+        IngressPool, IngressPoolObject, PoolSection, UnvalidatedIngressArtifact,
+        ValidatedIngressArtifact,
     },
     p2p::consensus::MutablePool,
     validation::ValidationResult,
@@ -56,7 +57,6 @@ pub use ic_management_canister_types::{
 };
 use ic_messaging::SyncMessageRouting;
 use ic_metrics::MetricsRegistry;
-use ic_protobuf::types::v1 as pb;
 use ic_protobuf::{
     registry::{
         crypto::v1::{ChainKeySigningSubnetList, PublicKey as PublicKeyProto, X509PublicKeyCert},
@@ -68,7 +68,10 @@ use ic_protobuf::{
         },
         subnet::v1::CatchUpPackageContents,
     },
-    types::v1::{PrincipalId as PrincipalIdIdProto, SubnetId as SubnetIdProto},
+    types::{
+        v1 as pb,
+        v1::{PrincipalId as PrincipalIdIdProto, SubnetId as SubnetIdProto},
+    },
 };
 use ic_registry_client_fake::FakeRegistryClient;
 use ic_registry_client_helpers::{
@@ -143,8 +146,7 @@ pub use ic_types::{
         CanisterHttpMethod, CanisterHttpRequestContext, CanisterHttpRequestId,
         CanisterHttpResponseMetadata,
     },
-    crypto::threshold_sig::ThresholdSigPublicKey,
-    crypto::{CryptoHash, CryptoHashOf},
+    crypto::{threshold_sig::ThresholdSigPublicKey, CryptoHash, CryptoHashOf},
     ingress::{IngressState, IngressStatus, WasmResult},
     messages::{CallbackId, HttpRequestError, MessageId},
     signature::BasicSignature,
@@ -329,6 +331,7 @@ fn make_nodes_registry(
             chip_id: None,
             public_ipv4_config: None,
             domain: None,
+            node_type: None,
         };
         registry_data_provider
             .add(

--- a/rs/state_machine_tests/src/lib.rs
+++ b/rs/state_machine_tests/src/lib.rs
@@ -331,7 +331,7 @@ fn make_nodes_registry(
             chip_id: None,
             public_ipv4_config: None,
             domain: None,
-            node_type: None,
+            node_reward_type: None,
         };
         registry_data_provider
             .add(


### PR DESCRIPTION
This adds support for node_reward_type to NodeRecord and to AddNodePayload.

It adds it as a string to AddNodePayload, but as an enum with validation to NodeRecord.