### PR TITLE
refactor(sns): Remove different sns init behavior when cfg(feature = "test")

### DIFF
--- a/rs/sns/init/src/lib.rs
+++ b/rs/sns/init/src/lib.rs
@@ -563,25 +563,6 @@ impl SnsInitPayload {
         Ok(governance)
     }
 
-    #[cfg(feature = "test")]
-    fn maybe_test_balances(&self) -> Vec<(Account, u64)> {
-        // Testing has hardcoded the public key of principal
-        // jg6qm-uw64t-m6ppo-oluwn-ogr5j-dc5pm-lgy2p-eh6px-hebcd-5v73i-nqe
-        // for the button to retrieve tokens.
-        let tester = "jg6qm-uw64t-m6ppo-oluwn-ogr5j-dc5pm-lgy2p-eh6px-hebcd-5v73i-nqe";
-        let principal = PrincipalId::from_str(tester).unwrap().0;
-        let account = Account {
-            owner: principal,
-            subaccount: None,
-        };
-        vec![(account, /* 10k tokens */ 10_000 * /* E8 */ 100_000_000)]
-    }
-
-    #[cfg(not(feature = "test"))]
-    fn maybe_test_balances(&self) -> Vec<(Account, u64)> {
-        vec![]
-    }
-
     /// Construct the params used to initialize a SNS Ledger canister.
     fn ledger_init_args(
         &self,
@@ -629,9 +610,6 @@ impl SnsInitPayload {
         }
 
         for (account, amount) in self.get_all_ledger_accounts(sns_canister_ids)? {
-            payload_builder = payload_builder.with_initial_balance(account, amount);
-        }
-        for (account, amount) in self.maybe_test_balances() {
             payload_builder = payload_builder.with_initial_balance(account, amount);
         }
         Ok(LedgerArgument::Init(payload_builder.build()))


### PR DESCRIPTION
[Next PR →](https://github.com/dfinity/ic/pull/1606)

## Problem

ic-sns-init has :init and :init--test-feature targets, which makes our dependency situation very hairy due to the viral nature of test features. It should be removed, but first ic-sns-init needs to not have any differential behavior between the test and normal configurations.

## Solution

Remove the code that ran when cfg(feature = "test") was true. This was code that set up ledger with a principal with a ton of tokens.

This was probably needed at first, but is no longer, because the test configuration of the SNS Gov canister has a `mint_tokens` API that can be used instead. If this breaks anyone, I will help them switch over to the new API. I think the `nns_dapp` has already switched to the new API.