### PR TITLE
chore: refactor state_machine.module_hash in NNS integration tests

### DIFF
--- a/rs/nns/integration_tests/src/reset_root.rs
+++ b/rs/nns/integration_tests/src/reset_root.rs
@@ -23,7 +23,11 @@ fn test_reset_root_with_governance_proposal() {
     setup_nns_canisters(&state_machine, nns_init_payloads);
 
     // First, see what the canister hash is for root
-    let root_version = state_machine.module_hash(ROOT_CANISTER_ID).unwrap();
+    let root_status = state_machine
+        .canister_status_as(LIFELINE_CANISTER_ID.into(), ROOT_CANISTER_ID)
+        .unwrap()
+        .unwrap();
+    let root_version = root_status.module_hash().unwrap();
 
     // Execute proposal
     let new_root = modify_wasm_bytes(&build_root_wasm().bytes(), 42);
@@ -64,11 +68,13 @@ fn test_reset_root_with_governance_proposal() {
 
     nns_wait_for_proposal_execution(&state_machine, proposal_id.id);
 
+    let root_status = state_machine
+        .canister_status_as(LIFELINE_CANISTER_ID.into(), ROOT_CANISTER_ID)
+        .unwrap()
+        .unwrap();
+    let root_version: [u8; 32] = root_status.module_hash().unwrap().try_into().unwrap();
     // Assert the root canister was upgraded
-    assert_eq!(
-        new_root_version,
-        state_machine.module_hash(ROOT_CANISTER_ID).unwrap()
-    );
+    assert_eq!(new_root_version, root_version);
 }
 
 #[test]
@@ -78,7 +84,11 @@ fn test_other_controllers_cannot_reset_root() {
     setup_nns_canisters(&state_machine, nns_init_payloads);
 
     // First, see what the canister hash is for root
-    let root_version = state_machine.module_hash(ROOT_CANISTER_ID).unwrap();
+    let root_status = state_machine
+        .canister_status_as(LIFELINE_CANISTER_ID.into(), ROOT_CANISTER_ID)
+        .unwrap()
+        .unwrap();
+    let root_version = root_status.module_hash().unwrap();
 
     // Execute proposal
     let new_root = modify_wasm_bytes(&build_root_wasm().bytes(), 42);


### PR DESCRIPTION
This PR refactors NNS integration tests to retrieve the module hash of a canister via its canister status instead of via a dedicated function `StateMachine::module_hash` since that dedicated function is not available in PocketIC and thus it'd introduce unnecessary complications to migration of NNS integration tests to PocketIC.