### PR TITLE
A minimal canister that has post_upgrade(x: Option<T>)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15424,6 +15424,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b93853da6d84c2e3c7d730d6473e8817692dd89be387eb01b94d7f108ecb5b8c"
 
 [[package]]
+name = "no-upgrade-args"
+version = "0.9.0"
+dependencies = [
+ "candid",
+ "dfn_candid",
+ "dfn_core",
+ "serde",
+]
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 
 members = [
+    "daniel",
     "packages/icrc-ledger-agent",
     "packages/icrc-ledger-client",
     "packages/icrc-ledger-client-cdk",

--- a/daniel/Cargo.toml
+++ b/daniel/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "no-upgrade-args"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+description.workspace = true
+documentation.workspace = true
+
+[dependencies]
+candid = { workspace = true }
+dfn_candid = { path = "../rs/rust_canisters/dfn_candid" }
+dfn_core = { path = "../rs/rust_canisters/dfn_core" }
+serde = { workspace = true }

--- a/daniel/no_upgrade_args.did
+++ b/daniel/no_upgrade_args.did
@@ -1,0 +1,6 @@
+type Init = record {
+  i: nat64;
+}
+
+service : (opt Init) -> {
+}

--- a/daniel/src/main.rs
+++ b/daniel/src/main.rs
@@ -1,0 +1,29 @@
+use candid::{
+    CandidType,
+};
+use dfn_candid::{
+    CandidOne,
+};
+use dfn_core::{
+    over_init,
+};
+use serde::{
+    Deserialize,
+    Serialize,
+};
+
+#[derive(Clone, Eq, PartialEq, Debug, CandidType, Deserialize, Serialize)]
+pub struct CyclesCanisterInitPayload {
+    i: u64,
+}
+
+#[export_name = "canister_post_upgrade"]
+fn post_upgrade_() {
+    over_init(|CandidOne(args)| post_upgrade(args))
+}
+
+fn post_upgrade(maybe_args: Option<CyclesCanisterInitPayload>) {
+    panic!("\n\nBEGIN\n{:#?}\nEND\n\n", maybe_args);
+}
+
+fn main() {}

--- a/dfx.json
+++ b/dfx.json
@@ -1,0 +1,17 @@
+{
+  "canisters": {
+    "no-upgrade-args": {
+      "type": "custom",
+      "candid": "daniel/no_upgrade_args.did",
+      "wasm": "target/wasm32-unknown-unknown/release/no-upgrade-args.wasm",
+      "build": "cargo build --target wasm32-unknown-unknown --release -p no-upgrade-args"
+    }
+  },
+  "networks": {
+    "local": {
+      "bind": "127.0.0.1:8000",
+      "type": "ephemeral"
+    }
+  },
+  "version": 1
+}


### PR DESCRIPTION
similar to cmc/src/main.rs.

What I'm trying to confirm here is whether passing empty args is the same as passing `()` when upgrading a canister.

I have not been able to figure this out yet...