### PR TITLE
feat(proposal-cli): Batching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9369,6 +9369,7 @@ dependencies = [
  "candid",
  "candid_parser",
  "clap 4.5.17",
+ "futures",
  "hex",
  "maplit",
  "reqwest 0.12.7",

--- a/rs/cross-chain/proposal-cli/BUILD.bazel
+++ b/rs/cross-chain/proposal-cli/BUILD.bazel
@@ -6,6 +6,7 @@ DEPENDENCIES = [
     "@crate_index//:candid",
     "@crate_index//:candid_parser",
     "@crate_index//:clap",
+    "@crate_index//:futures",
     "@crate_index//:hex",
     "@crate_index//:reqwest",
     "@crate_index//:serde",

--- a/rs/cross-chain/proposal-cli/Cargo.toml
+++ b/rs/cross-chain/proposal-cli/Cargo.toml
@@ -11,6 +11,7 @@ askama = { workspace = true }
 candid = { workspace = true }
 candid_parser = { workspace = true }
 clap = { workspace = true }
+futures = { workspace = true }
 hex = { workspace = true }
 reqwest = { workspace = true }
 serde = { workspace = true }

--- a/rs/cross-chain/proposal-cli/src/dashboard/mod.rs
+++ b/rs/cross-chain/proposal-cli/src/dashboard/mod.rs
@@ -32,4 +32,15 @@ impl DashboardClient {
         let body: CanisterInfo = response.json().await.unwrap();
         body.list_upgrade_proposals()
     }
+
+    pub async fn list_canister_upgrade_proposals_batch(
+        &self,
+        canister_ids: &[Principal],
+    ) -> Vec<BTreeSet<u64>> {
+        let mut fut = Vec::with_capacity(canister_ids.len());
+        for canister_id in canister_ids {
+            fut.push(self.list_canister_upgrade_proposals(canister_id));
+        }
+        futures::future::join_all(fut).await
+    }
 }

--- a/rs/cross-chain/proposal-cli/src/git/mod.rs
+++ b/rs/cross-chain/proposal-cli/src/git/mod.rs
@@ -1,3 +1,4 @@
+use crate::candid::{encode_upgrade_args, UpgradeArgs};
 use crate::canister::TargetCanister;
 use candid::Principal;
 use std::fmt::{Display, Formatter};
@@ -70,6 +71,22 @@ impl GitRepository {
         assert!(git_clone.success());
 
         GitRepository { dir: repo }
+    }
+
+    pub fn encode_args_batch(
+        &self,
+        canisters: &[TargetCanister],
+        args: Option<String>,
+    ) -> Vec<UpgradeArgs> {
+        canisters
+            .iter()
+            .map(|canister| {
+                encode_upgrade_args(
+                    &self.candid_file(canister),
+                    args.clone().unwrap_or(canister.default_upgrade_args()),
+                )
+            })
+            .collect()
     }
 
     pub fn candid_file(&self, canister: &TargetCanister) -> PathBuf {

--- a/rs/cross-chain/proposal-cli/src/git/mod.rs
+++ b/rs/cross-chain/proposal-cli/src/git/mod.rs
@@ -76,6 +76,13 @@ impl GitRepository {
         self.dir.path().join(canister.candid_file())
     }
 
+    pub fn parse_canister_id_batch(&self, canisters: &[TargetCanister]) -> Vec<Principal> {
+        canisters
+            .iter()
+            .map(|canister| self.parse_canister_id(canister))
+            .collect()
+    }
+
     pub fn parse_canister_id(&self, canister: &TargetCanister) -> Principal {
         let canister_ids: serde_json::Value = {
             let path = self.dir.path().join(canister.canister_ids_json_file());
@@ -104,6 +111,18 @@ impl GitRepository {
             .status()
             .expect("failed to checkout the commit");
         assert!(git_checkout.success());
+    }
+
+    pub fn release_notes_batch(
+        &self,
+        canisters: &[TargetCanister],
+        from: &GitCommitHash,
+        to: &GitCommitHash,
+    ) -> Vec<ReleaseNotes> {
+        canisters
+            .iter()
+            .map(|canister| self.release_notes(canister, from, to))
+            .collect()
     }
 
     pub fn release_notes(
@@ -143,14 +162,29 @@ impl GitRepository {
         }
     }
 
+    pub fn build_canister_artifact_batch(
+        &mut self,
+        canister: &[TargetCanister],
+    ) -> Vec<CompressedWasmHash> {
+        self.build_canisters();
+        canister.iter().map(|c| self.sha256_artifact(c)).collect()
+    }
+
     pub fn build_canister_artifact(&mut self, canister: &TargetCanister) -> CompressedWasmHash {
+        self.build_canisters();
+        self.sha256_artifact(canister)
+    }
+
+    fn build_canisters(&mut self) {
         let build = Command::new("./ci/container/build-ic.sh")
             .arg("--canisters")
             .current_dir(self.dir.path())
             .status()
             .expect("failed to build canister artifacts");
         assert!(build.success());
+    }
 
+    fn sha256_artifact(&mut self, canister: &TargetCanister) -> Hash<32> {
         let sha256sum = Command::new("sha256sum")
             .current_dir(self.dir.path())
             .arg(canister.artifact())
@@ -180,7 +214,7 @@ impl GitRepository {
     }
 }
 
-#[derive(Eq, PartialEq, Debug)]
+#[derive(Clone, Eq, PartialEq, Debug)]
 pub struct ReleaseNotes {
     pub command: String,
     pub output: String,

--- a/rs/cross-chain/proposal-cli/src/main.rs
+++ b/rs/cross-chain/proposal-cli/src/main.rs
@@ -5,7 +5,6 @@ mod git;
 mod ic_admin;
 mod proposal;
 
-use crate::candid::encode_upgrade_args;
 use crate::canister::TargetCanister;
 use crate::dashboard::DashboardClient;
 use crate::git::{GitCommitHash, GitRepository};
@@ -112,15 +111,7 @@ async fn main() {
             let dashboard = DashboardClient::new();
             let release_notes = ic_repo.release_notes_batch(&canisters, &from, &to);
             ic_repo.checkout(&to);
-            let upgrade_args: Vec<_> = canisters
-                .iter()
-                .map(|canister| {
-                    encode_upgrade_args(
-                        &ic_repo.candid_file(canister),
-                        args.clone().unwrap_or(canister.default_upgrade_args()),
-                    )
-                })
-                .collect();
+            let upgrade_args: Vec<_> = ic_repo.encode_args_batch(&canisters, args);
             let canister_ids = ic_repo.parse_canister_id_batch(&canisters);
             let last_upgrade_proposal_ids: Vec<_> = dashboard
                 .list_canister_upgrade_proposals_batch(&canister_ids)
@@ -156,15 +147,7 @@ async fn main() {
             let mut ic_repo = GitRepository::clone_ic();
 
             ic_repo.checkout(&at);
-            let install_args: Vec<_> = canisters
-                .iter()
-                .map(|canister| {
-                    encode_upgrade_args(
-                        &ic_repo.candid_file(canister),
-                        args.clone().unwrap_or(canister.default_upgrade_args()),
-                    )
-                })
-                .collect();
+            let install_args: Vec<_> = ic_repo.encode_args_batch(&canisters, args);
             let canister_ids = ic_repo.parse_canister_id_batch(&canisters);
             let compressed_wasm_hashes = ic_repo.build_canister_artifact_batch(&canisters);
 

--- a/rs/cross-chain/proposal-cli/src/main.rs
+++ b/rs/cross-chain/proposal-cli/src/main.rs
@@ -56,8 +56,8 @@ enum Commands {
     /// install a canister
     #[command(arg_required_else_help = true)]
     Install {
-        /// The canister to install
-        canister: TargetCanister,
+        /// The canister(s) to install
+        canisters: Vec<TargetCanister>,
 
         /// The git commit hash at which the canister should be installed
         #[arg(long)]
@@ -147,7 +147,7 @@ async fn main() {
             }
         }
         Commands::Install {
-            canister,
+            canisters,
             at,
             args,
             output_dir,
@@ -156,23 +156,31 @@ async fn main() {
             let mut ic_repo = GitRepository::clone_ic();
 
             ic_repo.checkout(&at);
-            let install_args = encode_upgrade_args(
-                &ic_repo.candid_file(&canister),
-                args.unwrap_or(canister.default_upgrade_args()),
-            );
-            let canister_id = ic_repo.parse_canister_id(&canister);
-            let compressed_wasm_hash = ic_repo.build_canister_artifact(&canister);
-            let output_dir = output_dir.join(canister.to_string()).join(at.to_string());
+            let install_args: Vec<_> = canisters
+                .iter()
+                .map(|canister| {
+                    encode_upgrade_args(
+                        &ic_repo.candid_file(canister),
+                        args.clone().unwrap_or(canister.default_upgrade_args()),
+                    )
+                })
+                .collect();
+            let canister_ids = ic_repo.parse_canister_id_batch(&canisters);
+            let compressed_wasm_hashes = ic_repo.build_canister_artifact_batch(&canisters);
 
-            let proposal = InstallProposalTemplate {
-                canister,
-                at,
-                compressed_wasm_hash,
-                canister_id,
-                install_args,
-            };
+            for (index, canister) in canisters.into_iter().enumerate() {
+                let output_dir = output_dir.join(canister.to_string()).join(at.to_string());
 
-            write_to_disk(output_dir, proposal, submit, &ic_repo);
+                let proposal = InstallProposalTemplate {
+                    canister,
+                    at: at.clone(),
+                    compressed_wasm_hash: compressed_wasm_hashes[index].clone(),
+                    canister_id: canister_ids[index],
+                    install_args: install_args[index].clone(),
+                };
+
+                write_to_disk(output_dir, proposal, submit.clone(), &ic_repo);
+            }
         }
     }
 }


### PR DESCRIPTION
Allows to batch upgrade or install proposals. This is for example useful, when multiple canisters such as a ledger suite (ledger, index, archive) need to be upgraded together from one version to the next.