### PR TITLE
feat(nns): More secure random numbers.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9950,6 +9950,7 @@ dependencies = [
  "ic-canisters-http-types",
  "ic-cdk 0.13.5",
  "ic-cdk-macros 0.9.0",
+ "ic-cdk-timers",
  "ic-config",
  "ic-crypto-getrandom-for-wasm",
  "ic-crypto-sha2",

--- a/rs/nns/governance/BUILD.bazel
+++ b/rs/nns/governance/BUILD.bazel
@@ -51,6 +51,7 @@ BASE_DEPENDENCIES = [
     "@crate_index//:dyn-clone",
     "@crate_index//:futures",
     "@crate_index//:ic-cdk",
+    "@crate_index//:ic-cdk-timers",
     "@crate_index//:ic-metrics-encoder",
     "@crate_index//:ic-stable-structures",
     "@crate_index//:itertools",

--- a/rs/nns/governance/Cargo.toml
+++ b/rs/nns/governance/Cargo.toml
@@ -39,6 +39,7 @@ ic-base-types = { path = "../../types/base_types" }
 ic-canisters-http-types = { path = "../../rust_canisters/http_types" }
 ic-cdk = { workspace = true }
 ic-cdk-macros = { workspace = true }
+ic-cdk-timers = { workspace = true }
 ic-crypto-getrandom-for-wasm = { path = "../../crypto/getrandom_for_wasm" }
 ic-crypto-sha2 = { path = "../../crypto/sha2/" }
 ic-ledger-core = { path = "../../rosetta-api/ledger_core" }

--- a/rs/nns/governance/benches/scale.rs
+++ b/rs/nns/governance/benches/scale.rs
@@ -56,6 +56,10 @@ impl Environment for MockEnvironment {
         todo!()
     }
 
+    async fn seed_rng(&mut self) -> Result<(), (i32, String)> {
+        todo!()
+    }
+
     fn execute_nns_function(
         &self,
         _proposal_id: u64,

--- a/rs/nns/governance/benches/scale.rs
+++ b/rs/nns/governance/benches/scale.rs
@@ -56,7 +56,7 @@ impl Environment for MockEnvironment {
         todo!()
     }
 
-    async fn seed_rng(&mut self) -> Result<(), (i32, String)> {
+    fn seed_rng(&mut self, _seed: [u8; 32]) {
         todo!()
     }
 

--- a/rs/nns/governance/benches/scale.rs
+++ b/rs/nns/governance/benches/scale.rs
@@ -60,6 +60,10 @@ impl Environment for MockEnvironment {
         todo!()
     }
 
+    fn get_rng_seed(&self) -> Option<[u8; 32]> {
+        todo!()
+    }
+
     fn execute_nns_function(
         &self,
         _proposal_id: u64,

--- a/rs/nns/governance/benches/scale.rs
+++ b/rs/nns/governance/benches/scale.rs
@@ -20,7 +20,7 @@ use ic_base_types::{CanisterId, PrincipalId};
 use ic_nervous_system_common::{cmc::FakeCmc, ledger::IcpLedger, NervousSystemError};
 use ic_nns_common::pb::v1::NeuronId;
 use ic_nns_governance::{
-    governance::{Environment, Governance, HeapGrowthPotential},
+    governance::{Environment, Governance, HeapGrowthPotential, RngError},
     pb::v1::{
         neuron, proposal, ExecuteNnsFunction, Governance as GovernanceProto, GovernanceError,
         Motion, NetworkEconomics, Neuron, Proposal, Topic,
@@ -48,11 +48,11 @@ impl Environment for MockEnvironment {
         self.secs
     }
 
-    fn random_u64(&mut self) -> u64 {
+    fn random_u64(&mut self) -> Result<u64, RngError> {
         todo!()
     }
 
-    fn random_byte_array(&mut self) -> [u8; 32] {
+    fn random_byte_array(&mut self) -> Result<[u8; 32], RngError> {
         todo!()
     }
 

--- a/rs/nns/governance/canister/canister.rs
+++ b/rs/nns/governance/canister/canister.rs
@@ -165,15 +165,15 @@ fn schedule_seeding(duration: Duration) {
                 Ok((seed,)) => seed,
                 Err((code, msg)) => {
                     println!(
-                        "Error seeding RNG. Error Code: {}. Error Message: {}",
-                        code, msg
+                        "{}Error seeding RNG. Error Code: {}. Error Message: {}",
+                        LOG_PREFIX, code, msg
                     );
                     schedule_seeding(RETRY_SEEDING_INTERVAL);
                     return;
                 }
             };
 
-            governance_mut().env.seed_rng(seed);
+            () = governance_mut().env.seed_rng(seed);
             // Schedule reseeding on a timer with duration SEEDING_INTERVAL
             schedule_seeding(SEEDING_INTERVAL);
         })

--- a/rs/nns/governance/canister/canister.rs
+++ b/rs/nns/governance/canister/canister.rs
@@ -20,7 +20,7 @@ use ic_nns_common::{
 use ic_nns_constants::LEDGER_CANISTER_ID;
 use ic_nns_governance::{
     decoder_config, encode_metrics,
-    governance::{Environment, Governance, HeapGrowthPotential, TimeWarp as GovTimeWarp},
+    governance::{Environment, Governance, HeapGrowthPotential, RngError, TimeWarp as GovTimeWarp},
     neuron_data_validation::NeuronDataValidationSummary,
     pb::v1::{self as gov_pb, Governance as InternalGovernanceProto},
     storage::{grow_upgrades_memory_to, validate_stable_storage, with_upgrades_memory},
@@ -206,14 +206,14 @@ impl Environment for CanisterEnv {
         self.time_warp = new_time_warp;
     }
 
-    fn random_u64(&mut self) -> u64 {
-        self.rng.next_u64()
+    fn random_u64(&mut self) -> Result<u64, RngError> {
+        Ok(self.rng.next_u64())
     }
 
-    fn random_byte_array(&mut self) -> [u8; 32] {
+    fn random_byte_array(&mut self) -> Result<[u8; 32], RngError> {
         let mut bytes = [0u8; 32];
         self.rng.fill_bytes(&mut bytes);
-        bytes
+        Ok(bytes)
     }
 
     fn execute_nns_function(

--- a/rs/nns/governance/canister/canister.rs
+++ b/rs/nns/governance/canister/canister.rs
@@ -173,8 +173,8 @@ fn schedule_seeding(duration: Duration) {
 }
 
 struct CanisterEnv {
-    time_warp: GovTimeWarp,
     rng: Option<ChaCha20Rng>,
+    time_warp: GovTimeWarp,
 }
 
 fn now_nanoseconds() -> u64 {
@@ -197,8 +197,8 @@ fn now_seconds() -> u64 {
 impl CanisterEnv {
     fn new() -> Self {
         CanisterEnv {
-            time_warp: GovTimeWarp { delta_s: 0 },
             rng: None,
+            time_warp: GovTimeWarp { delta_s: 0 },
         }
     }
 }
@@ -221,9 +221,9 @@ impl Environment for CanisterEnv {
     }
 
     fn random_byte_array(&mut self) -> Result<[u8; 32], RngError> {
-        let mut bytes = [0u8; 32];
         match self.rng.as_mut() {
             Some(rand) => {
+                let mut bytes = [0u8; 32];
                 rand.fill_bytes(&mut bytes);
                 Ok(bytes)
             }
@@ -233,6 +233,10 @@ impl Environment for CanisterEnv {
 
     fn seed_rng(&mut self, seed: [u8; 32]) {
         self.rng.replace(ChaCha20Rng::from_seed(seed));
+    }
+
+    fn get_rng_seed(&self) -> Option<[u8; 32]> {
+        self.rng.as_ref().map(|rng| rng.get_seed())
     }
 
     fn execute_nns_function(

--- a/rs/nns/governance/canister/canister.rs
+++ b/rs/nns/governance/canister/canister.rs
@@ -6,6 +6,7 @@ use ic_cdk::{
     api::call::arg_data_raw, caller as ic_cdk_caller, heartbeat, post_upgrade, pre_upgrade,
     println, query, spawn, update,
 };
+use ic_management_canister_types::IC_00;
 use ic_nervous_system_canisters::{cmc::CMCCanister, ledger::IcpLedgerCanister};
 use ic_nervous_system_common::{
     memory_manager_upgrade_storage::{load_protobuf, store_protobuf},
@@ -56,6 +57,7 @@ use rand::{RngCore, SeedableRng};
 use rand_chacha::ChaCha20Rng;
 use std::{
     boxed::Box,
+    cell::RefCell,
     str::FromStr,
     time::{Duration, SystemTime},
 };
@@ -149,8 +151,30 @@ fn set_governance(gov: Governance) {
         .expect("Error initializing the governance canister.");
 }
 
+thread_local! {
+    static RNG: RefCell<Option<ChaCha20Rng>> = RefCell::new(None);
+}
+
+const SEEDING_INTERVAL: Duration = Duration::from_secs(3600);
+
+async fn seed_randomness() {
+    let (seed,): ([u8; 32],) = CdkRuntime::call_with_cleanup(IC_00, "raw_rand", ())
+        .await
+        .expect("Failed to call the management canister");
+    RNG.with_borrow_mut(|rng| *rng = Some(ChaCha20Rng::from_seed(seed)));
+}
+
+fn schedule_seeding(duration: Duration) {
+    ic_cdk_timers::set_timer(duration, || {
+        spawn(async {
+            seed_randomness().await;
+            // Schedule reseeding on a timer with duration SEEDING_INTERVAL
+            schedule_seeding(SEEDING_INTERVAL);
+        })
+    });
+}
+
 struct CanisterEnv {
-    rng: ChaCha20Rng,
     time_warp: GovTimeWarp,
 }
 
@@ -174,23 +198,6 @@ fn now_seconds() -> u64 {
 impl CanisterEnv {
     fn new() -> Self {
         CanisterEnv {
-            // Seed the PRNG with the current time.
-            //
-            // This is safe since all replicas are guaranteed to see the same result of time()
-            // and it isn't easily predictable from the outside.
-            //
-            // Using raw_rand from the ic00 api is an asynchronous call so can't really be
-            // used to generate random numbers for most cases. It could be used to seed
-            // the PRNG, but that wouldn't help much since after inception the pseudo-random
-            // numbers could be predicted.
-            rng: {
-                let now_nanos = Duration::from_nanos(now_nanoseconds()).as_nanos();
-                let mut seed = [0u8; 32];
-                seed[..16].copy_from_slice(&now_nanos.to_be_bytes());
-                seed[16..32].copy_from_slice(&now_nanos.to_be_bytes());
-                ChaCha20Rng::from_seed(seed)
-            },
-
             time_warp: GovTimeWarp { delta_s: 0 },
         }
     }
@@ -207,13 +214,21 @@ impl Environment for CanisterEnv {
     }
 
     fn random_u64(&mut self) -> Result<u64, RngError> {
-        Ok(self.rng.next_u64())
+        RNG.with_borrow_mut(|rng| match rng.as_mut() {
+            Some(rand) => Ok(rand.next_u64()),
+            None => Err(RngError::RngNotInitialized),
+        })
     }
 
     fn random_byte_array(&mut self) -> Result<[u8; 32], RngError> {
         let mut bytes = [0u8; 32];
-        self.rng.fill_bytes(&mut bytes);
-        Ok(bytes)
+        RNG.with_borrow_mut(|rng| match rng.as_mut() {
+            Some(rand) => {
+                rand.fill_bytes(&mut bytes);
+                Ok(bytes)
+            }
+            None => Err(RngError::RngNotInitialized),
+        })
     }
 
     fn execute_nns_function(
@@ -369,6 +384,7 @@ fn canister_init_(init_payload: ApiGovernanceProto) {
         init_payload.neurons.len()
     );
 
+    schedule_seeding(SEEDING_INTERVAL);
     set_governance(Governance::new(
         InternalGovernanceProto::from(init_payload),
         Box::new(CanisterEnv::new()),
@@ -411,6 +427,8 @@ fn canister_post_upgrade() {
         restored_state.neurons.len(),
         restored_state.xdr_conversion_rate,
     );
+
+    schedule_seeding(SEEDING_INTERVAL);
     set_governance(Governance::new_restored(
         restored_state,
         Box::new(CanisterEnv::new()),

--- a/rs/nns/governance/proto/ic_nns_governance/pb/v1/governance.proto
+++ b/rs/nns/governance/proto/ic_nns_governance/pb/v1/governance.proto
@@ -2415,6 +2415,10 @@ message Governance {
 
   // The summary of restore aging event.
   optional RestoreAgingSummary restore_aging_summary = 27;
+
+  // The rng seed used before upgrade, to prevent race conditions in handling
+  // further requests.
+  optional bytes rng_seed = 28;
 }
 
 message XdrConversionRate {

--- a/rs/nns/governance/proto/ic_nns_governance/pb/v1/governance.proto
+++ b/rs/nns/governance/proto/ic_nns_governance/pb/v1/governance.proto
@@ -2416,8 +2416,8 @@ message Governance {
   // The summary of restore aging event.
   optional RestoreAgingSummary restore_aging_summary = 27;
 
-  // The rng seed used before upgrade, to prevent race conditions in handling
-  // further requests.
+  // Used to initialize an internal pseudorandom number generator. This gets replaced periodically using a secure
+  // source of randomness (from the platform)
   optional bytes rng_seed = 28;
 }
 

--- a/rs/nns/governance/src/gen/ic_nns_governance.pb.v1.rs
+++ b/rs/nns/governance/src/gen/ic_nns_governance.pb.v1.rs
@@ -2648,8 +2648,8 @@ pub struct Governance {
     /// The summary of restore aging event.
     #[prost(message, optional, tag = "27")]
     pub restore_aging_summary: ::core::option::Option<RestoreAgingSummary>,
-    /// The rng seed used before upgrade, to prevent race conditions in handling
-    /// further requests.
+    /// Used to initialize an internal pseudorandom number generator. This gets replaced periodically using a secure
+    /// source of randomness (from the platform)
     #[prost(bytes = "vec", optional, tag = "28")]
     pub rng_seed: ::core::option::Option<::prost::alloc::vec::Vec<u8>>,
 }

--- a/rs/nns/governance/src/gen/ic_nns_governance.pb.v1.rs
+++ b/rs/nns/governance/src/gen/ic_nns_governance.pb.v1.rs
@@ -2648,6 +2648,10 @@ pub struct Governance {
     /// The summary of restore aging event.
     #[prost(message, optional, tag = "27")]
     pub restore_aging_summary: ::core::option::Option<RestoreAgingSummary>,
+    /// The rng seed used before upgrade, to prevent race conditions in handling
+    /// further requests.
+    #[prost(bytes = "vec", optional, tag = "28")]
+    pub rng_seed: ::core::option::Option<::prost::alloc::vec::Vec<u8>>,
 }
 /// Nested message and enum types in `Governance`.
 pub mod governance {

--- a/rs/nns/governance/src/governance.rs
+++ b/rs/nns/governance/src/governance.rs
@@ -1459,7 +1459,7 @@ impl From<RngError> for GovernanceError {
     fn from(e: RngError) -> Self {
         match e {
             RngError::RngNotInitialized => GovernanceError::new_with_message(
-                ErrorType::PreconditionFailed,
+                ErrorType::Unavailable,
                 "Rng not initialized.  Try again later.".to_string(),
             ),
         }
@@ -7856,8 +7856,7 @@ impl Governance {
     /// minutes past midnight.
     pub fn randomly_pick_swap_start(&mut self) -> GlobalTimeOfDay {
         // It's not critical that we have perfect randomness here, so we can default to a fixed value
-        // for the edge case where the RNG is not initialized (which should be very rare in the
-        // context of proposal executions)
+        // for the edge case where the RNG is not initialized (which should never happen in practice).
         let time_of_day_seconds = self.env.random_u64().unwrap_or(10_000) % ONE_DAY_SECONDS;
 
         // Round down to nearest multiple of 15 min.

--- a/rs/nns/governance/src/governance.rs
+++ b/rs/nns/governance/src/governance.rs
@@ -1468,7 +1468,7 @@ impl From<RngError> for GovernanceError {
 }
 
 /// A general trait for the environment in which governance is running.
-#[automock]
+/// DO NOT MERGE - re-add automock
 #[async_trait]
 pub trait Environment: Send + Sync {
     /// Returns the current time, in seconds since the epoch.
@@ -1487,6 +1487,9 @@ pub trait Environment: Send + Sync {
     ///
     /// This number is the same in all replicas.
     fn random_byte_array(&mut self) -> Result<[u8; 32], RngError>;
+
+    // Seed the random number generator from the IC (or some other source in tests)
+    async fn seed_rng(&mut self) -> Result<(), (i32, String)>;
 
     /// Executes a `ExecuteNnsFunction`. The standard implementation is
     /// expected to call out to another canister and eventually report the

--- a/rs/nns/governance/src/heap_governance_data.rs
+++ b/rs/nns/governance/src/heap_governance_data.rs
@@ -87,18 +87,7 @@ impl From<XdrConversionRate> for XdrConversionRatePb {
 /// Converts a vector of u8s to array of length 32, which is the length needed for our rng seed.
 /// If the array is the wrong size, this returns an error.
 fn vec_to_array(v: Vec<u8>) -> Result<[u8; 32], String> {
-    let boxed_slice = v.into_boxed_slice();
-    let boxed_array: Box<[u8; 32]> = match boxed_slice.try_into() {
-        Ok(hash) => hash,
-        Err(original) => {
-            return Err(format!(
-                "Expected a hash of length {} but it was {}",
-                32,
-                original.len()
-            ))
-        }
-    };
-    Ok(*boxed_array)
+    <[u8; 32]>::try_from(v).map_err(|v| format!("Expected 32 bytes, got {}", v.len()))
 }
 
 /// Splits the governance proto (from UPGRADES_MEMORY) into HeapGovernanceData and neurons, because

--- a/rs/nns/governance/src/heap_governance_data.rs
+++ b/rs/nns/governance/src/heap_governance_data.rs
@@ -84,9 +84,9 @@ impl From<XdrConversionRate> for XdrConversionRatePb {
     }
 }
 
-/// Converts a vector of u8s to array of length 32 (the size of our sha256 hash)
-/// or returns an error if wrong length is given
-fn vec_to_hash(v: Vec<u8>) -> Result<[u8; 32], String> {
+/// Converts a vector of u8s to array of length 32, which is the length needed for our rng seed.
+/// If the array is the wrong size, this returns an error.
+fn vec_to_array(v: Vec<u8>) -> Result<[u8; 32], String> {
     let boxed_slice = v.into_boxed_slice();
     let boxed_array: Box<[u8; 32]> = match boxed_slice.try_into() {
         Ok(hash) => hash,
@@ -157,7 +157,7 @@ pub fn split_governance_proto(
         });
 
     let rng_seed = rng_seed
-        .map(|seed| vec_to_hash(seed).ok())
+        .map(|seed| vec_to_array(seed).ok())
         .and_then(|seed| seed);
 
     (

--- a/rs/nns/governance/src/heap_governance_data.rs
+++ b/rs/nns/governance/src/heap_governance_data.rs
@@ -105,6 +105,7 @@ fn vec_to_hash(v: Vec<u8>) -> Result<[u8; 32], String> {
 /// we have a dedicated struct NeuronStore owning the heap neurons.
 /// Does not guarantee round-trip equivalence between this and
 /// reassemble_governance_proto if the proto has fields that are None, as they might be filled in by default values.
+#[allow(clippy::type_complexity)]
 pub fn split_governance_proto(
     governance_proto: GovernanceProto,
 ) -> (

--- a/rs/nns/governance/src/neuron_store.rs
+++ b/rs/nns/governance/src/neuron_store.rs
@@ -63,7 +63,7 @@ pub enum NeuronStoreError {
         principal_id: PrincipalId,
         neuron_id: NeuronId,
     },
-    NeuronIdGenerationNotAvailable,
+    NeuronIdGenerationUnavailable,
 }
 
 impl NeuronStoreError {
@@ -161,7 +161,7 @@ impl Display for NeuronStoreError {
                     principal_id, neuron_id
                 )
             }
-            NeuronStoreError::NeuronIdGenerationNotAvailable => {
+            NeuronStoreError::NeuronIdGenerationUnavailable => {
                 write!(
                     f,
                     "Neuron ID generation is not available currently. \
@@ -184,7 +184,7 @@ impl From<NeuronStoreError> for GovernanceError {
             NeuronStoreError::NeuronAlreadyExists(_) => ErrorType::PreconditionFailed,
             NeuronStoreError::InvalidData { .. } => ErrorType::PreconditionFailed,
             NeuronStoreError::NotAuthorizedToGetFullNeuron { .. } => ErrorType::NotAuthorized,
-            NeuronStoreError::NeuronIdGenerationNotAvailable => ErrorType::PreconditionFailed,
+            NeuronStoreError::NeuronIdGenerationUnavailable => ErrorType::Unavailable,
         };
         GovernanceError::new_with_message(error_type, value.to_string())
     }
@@ -397,7 +397,7 @@ impl NeuronStore {
         loop {
             let id = env
                 .random_u64()
-                .map_err(|_| NeuronStoreError::NeuronIdGenerationNotAvailable)?
+                .map_err(|_| NeuronStoreError::NeuronIdGenerationUnavailable)?
                 // Let there be no question that id was chosen
                 // intentionally, not just 0 by default.
                 .saturating_add(1);

--- a/rs/nns/governance/src/neuron_store.rs
+++ b/rs/nns/governance/src/neuron_store.rs
@@ -63,6 +63,7 @@ pub enum NeuronStoreError {
         principal_id: PrincipalId,
         neuron_id: NeuronId,
     },
+    NeuronIdGenerationNotAvailable,
 }
 
 impl NeuronStoreError {
@@ -160,6 +161,13 @@ impl Display for NeuronStoreError {
                     principal_id, neuron_id
                 )
             }
+            NeuronStoreError::NeuronIdGenerationNotAvailable => {
+                write!(
+                    f,
+                    "Neuron ID generation is not available currently. \
+                    Likely due to uninitialized RNG."
+                )
+            }
         }
     }
 }
@@ -176,6 +184,7 @@ impl From<NeuronStoreError> for GovernanceError {
             NeuronStoreError::NeuronAlreadyExists(_) => ErrorType::PreconditionFailed,
             NeuronStoreError::InvalidData { .. } => ErrorType::PreconditionFailed,
             NeuronStoreError::NotAuthorizedToGetFullNeuron { .. } => ErrorType::NotAuthorized,
+            NeuronStoreError::NeuronIdGenerationNotAvailable => ErrorType::PreconditionFailed,
         };
         GovernanceError::new_with_message(error_type, value.to_string())
     }
@@ -384,10 +393,11 @@ impl NeuronStore {
         self.clock.set_time_warp(new_time_warp);
     }
 
-    pub fn new_neuron_id(&self, env: &mut dyn Environment) -> NeuronId {
+    pub fn new_neuron_id(&self, env: &mut dyn Environment) -> Result<NeuronId, NeuronStoreError> {
         loop {
             let id = env
                 .random_u64()
+                .map_err(|_| NeuronStoreError::NeuronIdGenerationNotAvailable)?
                 // Let there be no question that id was chosen
                 // intentionally, not just 0 by default.
                 .saturating_add(1);
@@ -396,7 +406,7 @@ impl NeuronStore {
             let is_unique = !self.contains(neuron_id);
 
             if is_unique {
-                return neuron_id;
+                return Ok(neuron_id);
             }
 
             ic_cdk::println!(

--- a/rs/nns/governance/src/pb/conversions.rs
+++ b/rs/nns/governance/src/pb/conversions.rs
@@ -3231,6 +3231,8 @@ impl From<pb_api::Governance> for pb::Governance {
                 .collect(),
             xdr_conversion_rate: item.xdr_conversion_rate.map(|x| x.into()),
             restore_aging_summary: item.restore_aging_summary.map(|x| x.into()),
+            // This is not intended to be initialized from outside of canister.
+            rng_seed: None,
         }
     }
 }

--- a/rs/nns/governance/src/test_utils.rs
+++ b/rs/nns/governance/src/test_utils.rs
@@ -201,7 +201,7 @@ impl Environment for MockEnvironment {
         unimplemented!();
     }
 
-    async fn seed_rng(&mut self) -> Result<(), (i32, String)> {
+    fn seed_rng(&mut self, _seed: [u8; 32]) {
         unimplemented!()
     }
 

--- a/rs/nns/governance/src/test_utils.rs
+++ b/rs/nns/governance/src/test_utils.rs
@@ -1,5 +1,5 @@
 use crate::{
-    governance::{Environment, HeapGrowthPotential},
+    governance::{Environment, HeapGrowthPotential, RngError},
     pb::v1::{ExecuteNnsFunction, GovernanceError, OpenSnsTokenSwap},
 };
 use async_trait::async_trait;
@@ -193,11 +193,11 @@ impl Environment for MockEnvironment {
         *self.now.lock().unwrap()
     }
 
-    fn random_u64(&mut self) -> u64 {
+    fn random_u64(&mut self) -> Result<u64, RngError> {
         unimplemented!();
     }
 
-    fn random_byte_array(&mut self) -> [u8; 32] {
+    fn random_byte_array(&mut self) -> Result<[u8; 32], RngError> {
         unimplemented!();
     }
 

--- a/rs/nns/governance/src/test_utils.rs
+++ b/rs/nns/governance/src/test_utils.rs
@@ -201,8 +201,10 @@ impl Environment for MockEnvironment {
         unimplemented!();
     }
 
-    fn seed_rng(&mut self, _seed: [u8; 32]) {
-        unimplemented!()
+    fn seed_rng(&mut self, _seed: [u8; 32]) {}
+
+    fn get_rng_seed(&self) -> Option<[u8; 32]> {
+        Some([0; 32])
     }
 
     fn execute_nns_function(

--- a/rs/nns/governance/src/test_utils.rs
+++ b/rs/nns/governance/src/test_utils.rs
@@ -201,6 +201,10 @@ impl Environment for MockEnvironment {
         unimplemented!();
     }
 
+    async fn seed_rng(&mut self) -> Result<(), (i32, String)> {
+        unimplemented!()
+    }
+
     fn execute_nns_function(
         &self,
         _proposal_id: u64,

--- a/rs/nns/governance/tests/degraded_mode.rs
+++ b/rs/nns/governance/tests/degraded_mode.rs
@@ -44,6 +44,10 @@ impl Environment for DegradedEnv {
         unimplemented!()
     }
 
+    async fn seed_rng(&mut self) -> Result<(), (i32, String)> {
+        todo!()
+    }
+
     fn execute_nns_function(&self, _: u64, _: &ExecuteNnsFunction) -> Result<(), GovernanceError> {
         unimplemented!()
     }

--- a/rs/nns/governance/tests/degraded_mode.rs
+++ b/rs/nns/governance/tests/degraded_mode.rs
@@ -48,6 +48,10 @@ impl Environment for DegradedEnv {
         todo!()
     }
 
+    fn get_rng_seed(&self) -> Option<[u8; 32]> {
+        todo!()
+    }
+
     fn execute_nns_function(&self, _: u64, _: &ExecuteNnsFunction) -> Result<(), GovernanceError> {
         unimplemented!()
     }

--- a/rs/nns/governance/tests/degraded_mode.rs
+++ b/rs/nns/governance/tests/degraded_mode.rs
@@ -9,7 +9,8 @@ use ic_nns_common::pb::v1::NeuronId;
 use ic_nns_constants::GOVERNANCE_CANISTER_ID;
 use ic_nns_governance::{
     governance::{
-        Environment, Governance, HeapGrowthPotential, HEAP_SIZE_SOFT_LIMIT_IN_WASM32_PAGES,
+        Environment, Governance, HeapGrowthPotential, RngError,
+        HEAP_SIZE_SOFT_LIMIT_IN_WASM32_PAGES,
     },
     pb::v1::{
         governance_error::ErrorType,
@@ -35,11 +36,11 @@ impl Environment for DegradedEnv {
         111000222
     }
 
-    fn random_u64(&mut self) -> u64 {
-        4 // https://xkcd.com/221
+    fn random_u64(&mut self) -> Result<u64, RngError> {
+        Ok(4) // https://xkcd.com/221
     }
 
-    fn random_byte_array(&mut self) -> [u8; 32] {
+    fn random_byte_array(&mut self) -> Result<[u8; 32], RngError> {
         unimplemented!()
     }
 

--- a/rs/nns/governance/tests/degraded_mode.rs
+++ b/rs/nns/governance/tests/degraded_mode.rs
@@ -44,7 +44,7 @@ impl Environment for DegradedEnv {
         unimplemented!()
     }
 
-    async fn seed_rng(&mut self) -> Result<(), (i32, String)> {
+    fn seed_rng(&mut self, _seed: [u8; 32]) {
         todo!()
     }
 

--- a/rs/nns/governance/tests/fake.rs
+++ b/rs/nns/governance/tests/fake.rs
@@ -14,7 +14,7 @@ use ic_nns_constants::{
     SNS_WASM_CANISTER_ID,
 };
 use ic_nns_governance::{
-    governance::{Environment, Governance, HeapGrowthPotential},
+    governance::{Environment, Governance, HeapGrowthPotential, RngError},
     pb::v1::{
         manage_neuron, manage_neuron::NeuronIdOrSubaccount, manage_neuron_response, proposal,
         ExecuteNnsFunction, GovernanceError, ManageNeuron, ManageNeuronResponse, Motion,
@@ -312,14 +312,14 @@ impl Environment for FakeDriver {
         self.state.try_lock().unwrap().now
     }
 
-    fn random_u64(&mut self) -> u64 {
-        self.state.try_lock().unwrap().rng.next_u64()
+    fn random_u64(&mut self) -> Result<u64, RngError> {
+        Ok(self.state.try_lock().unwrap().rng.next_u64())
     }
 
-    fn random_byte_array(&mut self) -> [u8; 32] {
+    fn random_byte_array(&mut self) -> Result<[u8; 32], RngError> {
         let mut bytes = [0u8; 32];
         self.state.try_lock().unwrap().rng.fill_bytes(&mut bytes);
-        bytes
+        Ok(bytes)
     }
 
     fn execute_nns_function(

--- a/rs/nns/governance/tests/fake.rs
+++ b/rs/nns/governance/tests/fake.rs
@@ -69,7 +69,7 @@ type LedgerMap = HashMap<AccountIdentifier, u64>;
 /// `Ledger`.
 pub struct FakeState {
     pub now: u64,
-    pub rng: ChaCha20Rng,
+    pub rng: Option<ChaCha20Rng>,
     pub accounts: LedgerMap,
 }
 
@@ -320,6 +320,10 @@ impl Environment for FakeDriver {
         let mut bytes = [0u8; 32];
         self.state.try_lock().unwrap().rng.fill_bytes(&mut bytes);
         Ok(bytes)
+    }
+
+    async fn seed_rng(&mut self) -> Result<(), (i32, String)> {
+        todo!()
     }
 
     fn execute_nns_function(

--- a/rs/nns/governance/tests/fake.rs
+++ b/rs/nns/governance/tests/fake.rs
@@ -326,6 +326,10 @@ impl Environment for FakeDriver {
         todo!()
     }
 
+    fn get_rng_seed(&self) -> Option<[u8; 32]> {
+        todo!()
+    }
+
     fn execute_nns_function(
         &self,
         _proposal_id: u64,

--- a/rs/nns/governance/tests/fake.rs
+++ b/rs/nns/governance/tests/fake.rs
@@ -69,7 +69,7 @@ type LedgerMap = HashMap<AccountIdentifier, u64>;
 /// `Ledger`.
 pub struct FakeState {
     pub now: u64,
-    pub rng: Option<ChaCha20Rng>,
+    pub rng: ChaCha20Rng,
     pub accounts: LedgerMap,
 }
 
@@ -322,7 +322,7 @@ impl Environment for FakeDriver {
         Ok(bytes)
     }
 
-    async fn seed_rng(&mut self) -> Result<(), (i32, String)> {
+    fn seed_rng(&mut self, _seed: [u8; 32]) {
         todo!()
     }
 

--- a/rs/nns/governance/tests/fixtures/environment_fixture.rs
+++ b/rs/nns/governance/tests/fixtures/environment_fixture.rs
@@ -46,7 +46,7 @@ where
 /// This state is used to respond to environment calls from Governance in a deterministic way.
 pub struct EnvironmentFixtureState {
     pub now: u64,
-    pub rng: StdRng,
+    pub rng: Option<StdRng>,
     pub observed_canister_calls: VecDeque<CanisterCallRequest>,
     pub mocked_canister_replies: VecDeque<CanisterCallReply>,
 }
@@ -155,6 +155,10 @@ impl Environment for EnvironmentFixture {
     }
 
     fn random_byte_array(&mut self) -> Result<[u8; 32], RngError> {
+        unimplemented!()
+    }
+
+    async fn seed_rng(&mut self) -> Result<(), (i32, String)> {
         unimplemented!()
     }
 

--- a/rs/nns/governance/tests/fixtures/environment_fixture.rs
+++ b/rs/nns/governance/tests/fixtures/environment_fixture.rs
@@ -2,7 +2,7 @@ use async_trait::async_trait;
 use candid::{CandidType, Decode, Encode, Error};
 use ic_base_types::CanisterId;
 use ic_nns_governance::{
-    governance::{Environment, HeapGrowthPotential},
+    governance::{Environment, HeapGrowthPotential, RngError},
     pb::v1::{ExecuteNnsFunction, GovernanceError},
 };
 use ic_sns_root::GetSnsCanistersSummaryRequest;
@@ -145,15 +145,16 @@ impl Environment for EnvironmentFixture {
         self.environment_fixture_state.try_lock().unwrap().now
     }
 
-    fn random_u64(&mut self) -> u64 {
-        self.environment_fixture_state
+    fn random_u64(&mut self) -> Result<u64, RngError> {
+        Ok(self
+            .environment_fixture_state
             .try_lock()
             .unwrap()
             .rng
-            .next_u64()
+            .next_u64())
     }
 
-    fn random_byte_array(&mut self) -> [u8; 32] {
+    fn random_byte_array(&mut self) -> Result<[u8; 32], RngError> {
         unimplemented!()
     }
 

--- a/rs/nns/governance/tests/fixtures/environment_fixture.rs
+++ b/rs/nns/governance/tests/fixtures/environment_fixture.rs
@@ -146,19 +146,25 @@ impl Environment for EnvironmentFixture {
     }
 
     fn random_u64(&mut self) -> Result<u64, RngError> {
-        Ok(self
+        match self
             .environment_fixture_state
             .try_lock()
             .unwrap()
             .rng
-            .next_u64())
+            .as_mut()
+        {
+            Some(rand) => Ok(rand.next_u64()),
+            None => {
+                panic!("No RNG!")
+            } // Err(RngError::RngNotInitialized),
+        }
     }
 
     fn random_byte_array(&mut self) -> Result<[u8; 32], RngError> {
         unimplemented!()
     }
 
-    async fn seed_rng(&mut self) -> Result<(), (i32, String)> {
+    fn seed_rng(&mut self, _seed: [u8; 32]) {
         unimplemented!()
     }
 

--- a/rs/nns/governance/tests/fixtures/mod.rs
+++ b/rs/nns/governance/tests/fixtures/mod.rs
@@ -20,7 +20,8 @@ use ic_nns_common::{
 use ic_nns_constants::LEDGER_CANISTER_ID;
 use ic_nns_governance::{
     governance::{
-        governance_minting_account, neuron_subaccount, Environment, Governance, HeapGrowthPotential,
+        governance_minting_account, neuron_subaccount, Environment, Governance,
+        HeapGrowthPotential, RngError,
     },
     governance_proto_builder::GovernanceProtoBuilder,
     pb::v1::{
@@ -485,11 +486,11 @@ impl Environment for NNSFixture {
         self.nns_state.try_lock().unwrap().environment.now()
     }
 
-    fn random_u64(&mut self) -> u64 {
+    fn random_u64(&mut self) -> Result<u64, RngError> {
         self.nns_state.try_lock().unwrap().environment.random_u64()
     }
 
-    fn random_byte_array(&mut self) -> [u8; 32] {
+    fn random_byte_array(&mut self) -> Result<[u8; 32], RngError> {
         self.nns_state
             .try_lock()
             .unwrap()
@@ -942,11 +943,11 @@ impl Environment for NNS {
         self.fixture.now()
     }
 
-    fn random_u64(&mut self) -> u64 {
+    fn random_u64(&mut self) -> Result<u64, RngError> {
         self.fixture.random_u64()
     }
 
-    fn random_byte_array(&mut self) -> [u8; 32] {
+    fn random_byte_array(&mut self) -> Result<[u8; 32], RngError> {
         self.fixture.random_byte_array()
     }
 

--- a/rs/nns/governance/tests/fixtures/mod.rs
+++ b/rs/nns/governance/tests/fixtures/mod.rs
@@ -172,7 +172,7 @@ impl Default for EnvironmentBuilder {
         EnvironmentBuilder {
             environment_fixture_state: EnvironmentFixtureState {
                 now: 0,
-                rng: StdRng::seed_from_u64(9539),
+                rng: Some(StdRng::seed_from_u64(9539)),
                 observed_canister_calls: VecDeque::new(),
                 mocked_canister_replies: VecDeque::new(),
             },
@@ -498,13 +498,12 @@ impl Environment for NNSFixture {
             .random_byte_array()
     }
 
-    async fn seed_rng(&mut self) -> Result<(), (i32, String)> {
+    fn seed_rng(&mut self, seed: [u8; 32]) {
         self.nns_state
             .try_lock()
             .unwrap()
             .environment
-            .seed_rng()
-            .await
+            .seed_rng(seed)
     }
 
     fn execute_nns_function(
@@ -716,7 +715,8 @@ impl NNS {
         self
     }
 
-    pub(crate) fn get_state(&self) -> NNSState {
+    // Must be mut because clone_proto must be mut, but should not affect state
+    pub(crate) fn get_state(&mut self) -> NNSState {
         NNSState {
             now: self.now(),
             accounts: self
@@ -960,8 +960,8 @@ impl Environment for NNS {
         self.fixture.random_byte_array()
     }
 
-    async fn seed_rng(&mut self) -> Result<(), (i32, String)> {
-        self.fixture.seed_rng().await
+    fn seed_rng(&mut self, seed: [u8; 32]) {
+        self.fixture.seed_rng(seed)
     }
 
     fn execute_nns_function(

--- a/rs/nns/governance/tests/fixtures/mod.rs
+++ b/rs/nns/governance/tests/fixtures/mod.rs
@@ -498,6 +498,15 @@ impl Environment for NNSFixture {
             .random_byte_array()
     }
 
+    async fn seed_rng(&mut self) -> Result<(), (i32, String)> {
+        self.nns_state
+            .try_lock()
+            .unwrap()
+            .environment
+            .seed_rng()
+            .await
+    }
+
     fn execute_nns_function(
         &self,
         proposal_id: u64,
@@ -949,6 +958,10 @@ impl Environment for NNS {
 
     fn random_byte_array(&mut self) -> Result<[u8; 32], RngError> {
         self.fixture.random_byte_array()
+    }
+
+    async fn seed_rng(&mut self) -> Result<(), (i32, String)> {
+        self.fixture.seed_rng().await
     }
 
     fn execute_nns_function(

--- a/rs/nns/governance/tests/governance.rs
+++ b/rs/nns/governance/tests/governance.rs
@@ -11251,7 +11251,7 @@ impl Environment for MockEnvironment<'_> {
         panic!("Unexpected call to Environment::random_byte_array");
     }
 
-    async fn seed_rng(&mut self) -> Result<(), (i32, String)> {
+    fn seed_rng(&mut self, _seed: [u8; 32]) {
         unimplemented!()
     }
 

--- a/rs/nns/governance/tests/governance.rs
+++ b/rs/nns/governance/tests/governance.rs
@@ -11251,6 +11251,10 @@ impl Environment for MockEnvironment<'_> {
         panic!("Unexpected call to Environment::random_byte_array");
     }
 
+    async fn seed_rng(&mut self) -> Result<(), (i32, String)> {
+        unimplemented!()
+    }
+
     fn execute_nns_function(
         &self,
         _proposal_id: u64,

--- a/rs/nns/governance/tests/governance.rs
+++ b/rs/nns/governance/tests/governance.rs
@@ -46,7 +46,7 @@ use ic_nns_governance::{
         test_data::{
             CREATE_SERVICE_NERVOUS_SYSTEM, CREATE_SERVICE_NERVOUS_SYSTEM_WITH_MATCHED_FUNDING,
         },
-        Environment, Governance, HeapGrowthPotential,
+        Environment, Governance, HeapGrowthPotential, RngError,
         EXECUTE_NNS_FUNCTION_PAYLOAD_LISTING_BYTES_MAX, MAX_DISSOLVE_DELAY_SECONDS,
         MAX_NEURON_AGE_FOR_AGE_BONUS, MAX_NUMBER_OF_PROPOSALS_WITH_BALLOTS,
         MIN_DISSOLVE_DELAY_FOR_VOTE_ELIGIBILITY_SECONDS, PROPOSAL_MOTION_TEXT_BYTES_MAX,
@@ -465,7 +465,10 @@ fn check_proposal_status_after_voting_and_after_expiration(
         .map(|(neuron, i)| Neuron {
             id: Some(NeuronId { id: i }),
             controller: Some(principal(i)),
-            account: fake_driver.random_byte_array().to_vec(),
+            account: fake_driver
+                .random_byte_array()
+                .expect("Could not get random byte array")
+                .to_vec(),
             ..neuron
         })
         .collect();
@@ -1204,7 +1207,10 @@ fn fixture_for_following() -> GovernanceProto {
         cached_neuron_stake_e8s: 1_000_000_000, // 10 ICP
         // One year
         dissolve_state: Some(neuron::DissolveState::DissolveDelaySeconds(31557600)),
-        account: driver.random_byte_array().to_vec(),
+        account: driver
+            .random_byte_array()
+            .expect("Could not get random byte array")
+            .to_vec(),
         ..Default::default()
     };
     GovernanceProto {
@@ -1985,7 +1991,10 @@ fn fixture_for_manage_neuron() -> GovernanceProto {
         id: Some(NeuronId { id }),
         controller: Some(principal(id)),
         cached_neuron_stake_e8s: 1_000_000_000, // 10 ICP
-        account: driver.random_byte_array().to_vec(),
+        account: driver
+            .random_byte_array()
+            .expect("Could not get random byte array")
+            .to_vec(),
         dissolve_state: Some(DissolveState::WhenDissolvedTimestampSeconds(0)),
         aging_since_timestamp_seconds: u64::MAX,
         ..Default::default()
@@ -2539,7 +2548,10 @@ fn fixture_two_neurons_second_is_bigger() -> GovernanceProto {
             id: Some(NeuronId { id: 1 }),
             controller: Some(principal(1)),
             cached_neuron_stake_e8s: 23,
-            account: driver.random_byte_array().to_vec(),
+            account: driver
+                .random_byte_array()
+                .expect("Could not get random byte array")
+                .to_vec(),
             // One year
             dissolve_state: Some(neuron::DissolveState::DissolveDelaySeconds(31557600)),
             ..Default::default()
@@ -2548,7 +2560,10 @@ fn fixture_two_neurons_second_is_bigger() -> GovernanceProto {
             id: Some(NeuronId { id: 2 }),
             controller: Some(principal(2)),
             cached_neuron_stake_e8s: 951,
-            account: driver.random_byte_array().to_vec(),
+            account: driver
+                .random_byte_array()
+                .expect("Could not get random byte array")
+                .to_vec(),
             // One year
             dissolve_state: Some(neuron::DissolveState::DissolveDelaySeconds(31557600)),
             ..Default::default()
@@ -3448,7 +3463,10 @@ fn compute_maturities(
             controller: Some(principal(i as u64)),
             cached_neuron_stake_e8s: *stake_e8s,
             dissolve_state: NOTDISSOLVING_MIN_DISSOLVE_DELAY_TO_VOTE,
-            account: fake_driver.random_byte_array().to_vec(),
+            account: fake_driver
+                .random_byte_array()
+                .expect("Could not get random byte array")
+                .to_vec(),
             ..Default::default()
         })
         .collect();
@@ -3910,7 +3928,10 @@ fn fixture_for_approve_kyc() -> GovernanceProto {
             id: Some(NeuronId { id: 1 }),
             controller: Some(principal1),
             cached_neuron_stake_e8s: 10 * E8,
-            account: driver.random_byte_array().to_vec(),
+            account: driver
+                .random_byte_array()
+                .expect("Could not get random byte array")
+                .to_vec(),
             kyc_verified: false,
             dissolve_state: Some(DissolveState::WhenDissolvedTimestampSeconds(0)),
             aging_since_timestamp_seconds: u64::MAX,
@@ -3920,7 +3941,10 @@ fn fixture_for_approve_kyc() -> GovernanceProto {
             id: Some(NeuronId { id: 2 }),
             controller: Some(principal2),
             cached_neuron_stake_e8s: 10 * E8,
-            account: driver.random_byte_array().to_vec(),
+            account: driver
+                .random_byte_array()
+                .expect("Could not get random byte array")
+                .to_vec(),
             kyc_verified: false,
             dissolve_state: Some(DissolveState::WhenDissolvedTimestampSeconds(0)),
             aging_since_timestamp_seconds: u64::MAX,
@@ -3930,7 +3954,10 @@ fn fixture_for_approve_kyc() -> GovernanceProto {
             id: Some(NeuronId { id: 3 }),
             controller: Some(principal2),
             cached_neuron_stake_e8s: 10 * E8,
-            account: driver.random_byte_array().to_vec(),
+            account: driver
+                .random_byte_array()
+                .expect("Could not get random byte array")
+                .to_vec(),
             kyc_verified: false,
             dissolve_state: Some(DissolveState::WhenDissolvedTimestampSeconds(0)),
             aging_since_timestamp_seconds: u64::MAX,
@@ -3940,7 +3967,10 @@ fn fixture_for_approve_kyc() -> GovernanceProto {
             id: Some(NeuronId { id: 4 }),
             controller: Some(principal3),
             cached_neuron_stake_e8s: 10 * E8,
-            account: driver.random_byte_array().to_vec(),
+            account: driver
+                .random_byte_array()
+                .expect("Could not get random byte array")
+                .to_vec(),
             kyc_verified: false,
             dissolve_state: Some(DissolveState::WhenDissolvedTimestampSeconds(0)),
             aging_since_timestamp_seconds: u64::MAX,
@@ -4130,7 +4160,10 @@ fn test_get_neuron_ids_by_principal() {
     let neuron_a = Neuron {
         id: Some(NeuronId { id: 1 }),
         controller: Some(principal1),
-        account: driver.random_byte_array().to_vec(),
+        account: driver
+            .random_byte_array()
+            .expect("Could not get random byte array")
+            .to_vec(),
         dissolve_state: Some(DissolveState::WhenDissolvedTimestampSeconds(0)),
         aging_since_timestamp_seconds: u64::MAX,
         ..Default::default()
@@ -4138,7 +4171,10 @@ fn test_get_neuron_ids_by_principal() {
     let neuron_b = Neuron {
         id: Some(NeuronId { id: 2 }),
         controller: Some(principal2),
-        account: driver.random_byte_array().to_vec(),
+        account: driver
+            .random_byte_array()
+            .expect("Could not get random byte array")
+            .to_vec(),
         dissolve_state: Some(DissolveState::WhenDissolvedTimestampSeconds(0)),
         aging_since_timestamp_seconds: u64::MAX,
         ..Default::default()
@@ -4146,7 +4182,10 @@ fn test_get_neuron_ids_by_principal() {
     let neuron_c = Neuron {
         id: Some(NeuronId { id: 3 }),
         controller: Some(principal2),
-        account: driver.random_byte_array().to_vec(),
+        account: driver
+            .random_byte_array()
+            .expect("Could not get random byte array")
+            .to_vec(),
         dissolve_state: Some(DissolveState::WhenDissolvedTimestampSeconds(0)),
         aging_since_timestamp_seconds: u64::MAX,
         ..Default::default()
@@ -4155,7 +4194,10 @@ fn test_get_neuron_ids_by_principal() {
         id: Some(NeuronId { id: 4 }),
         controller: Some(principal2),
         hot_keys: vec![principal4],
-        account: driver.random_byte_array().to_vec(),
+        account: driver
+            .random_byte_array()
+            .expect("Could not get random byte array")
+            .to_vec(),
         dissolve_state: Some(DissolveState::WhenDissolvedTimestampSeconds(0)),
         aging_since_timestamp_seconds: u64::MAX,
         ..Default::default()
@@ -5656,7 +5698,7 @@ fn test_neuron_spawn_with_subaccount() {
     driver.advance_time_by(1);
 
     // Nonce used for spawn (given as input).
-    let nonce_spawn = driver.random_u64();
+    let nonce_spawn = driver.random_u64().expect("Could not get random number");
 
     let child_nid = gov
         .spawn_neuron(
@@ -7721,7 +7763,7 @@ fn test_filter_proposals_neuron_visibility() {
                 controller: Some(principal1),
                 hot_keys: vec![principal_hot],
                 cached_neuron_stake_e8s: 10 * E8,
-                account: driver.random_byte_array().to_vec(),
+                account: driver.random_byte_array().expect("Could not get random byte array").to_vec(),
                 dissolve_state: Some(DissolveState::WhenDissolvedTimestampSeconds(0)),
                 aging_since_timestamp_seconds: u64::MAX,
                 ..Default::default()
@@ -7730,7 +7772,7 @@ fn test_filter_proposals_neuron_visibility() {
                 id: Some(NeuronId { id: 2 }),
                 controller: Some(principal2),
                 cached_neuron_stake_e8s: 10 * E8,
-                account: driver.random_byte_array().to_vec(),
+                account: driver.random_byte_array().expect("Could not get random byte array").to_vec(),
                 dissolve_state: Some(DissolveState::WhenDissolvedTimestampSeconds(0)),
                 aging_since_timestamp_seconds: u64::MAX,
                 ..Default::default()
@@ -7739,7 +7781,7 @@ fn test_filter_proposals_neuron_visibility() {
                 id: Some(NeuronId { id: 3 }),
                 controller: Some(principal(3)),
                 cached_neuron_stake_e8s: 10 * E8,
-                account: driver.random_byte_array().to_vec(),
+                account: driver.random_byte_array().expect("Could not get random byte array").to_vec(),
                 followees: hashmap! {
                     Topic::NeuronManagement as i32 => neuron::Followees {
                         followees: vec![NeuronId { id: 1 }],
@@ -7815,7 +7857,7 @@ fn test_filter_proposals_include_all_manage_neuron_ignores_visibility() {
                 id: Some(NeuronId { id: 1 }),
                 controller: Some(principal1),
                 cached_neuron_stake_e8s: 10 * E8,
-                account: driver.random_byte_array().to_vec(),
+                account: driver.random_byte_array().expect("Could not get random byte array").to_vec(),
                 dissolve_state: Some(DissolveState::WhenDissolvedTimestampSeconds(0)),
                 aging_since_timestamp_seconds: u64::MAX,
                 ..Default::default()
@@ -7824,7 +7866,7 @@ fn test_filter_proposals_include_all_manage_neuron_ignores_visibility() {
                 id: Some(NeuronId { id: 2 }),
                 controller: Some(principal2),
                 cached_neuron_stake_e8s: 10 * E8,
-                account: driver.random_byte_array().to_vec(),
+                account: driver.random_byte_array().expect("Could not get random byte array").to_vec(),
                 dissolve_state: Some(DissolveState::WhenDissolvedTimestampSeconds(0)),
                 aging_since_timestamp_seconds: u64::MAX,
                 ..Default::default()
@@ -7833,7 +7875,7 @@ fn test_filter_proposals_include_all_manage_neuron_ignores_visibility() {
                 id: Some(NeuronId { id: 3 }),
                 controller: Some(principal(3)),
                 cached_neuron_stake_e8s: 10 * E8,
-                account: driver.random_byte_array().to_vec(),
+                account: driver.random_byte_array().expect("Could not get random byte array").to_vec(),
                 followees: hashmap! {
                     Topic::NeuronManagement as i32 => neuron::Followees {
                         followees: vec![NeuronId { id: 1 }],
@@ -7932,7 +7974,7 @@ fn test_filter_proposals_by_status() {
                 id: Some(NeuronId { id: 1 }),
                 controller: Some(principal1),
                 cached_neuron_stake_e8s: 10 * E8,
-                account: driver.random_byte_array().to_vec(),
+                account: driver.random_byte_array().expect("Could not get random byte array").to_vec(),
                 dissolve_state: Some(DissolveState::WhenDissolvedTimestampSeconds(0)),
                 aging_since_timestamp_seconds: u64::MAX,
                 ..Default::default()
@@ -8032,7 +8074,7 @@ fn test_filter_proposals_by_reward_status() {
                 id: Some(NeuronId { id: 1 }),
                 controller: Some(principal1),
                 cached_neuron_stake_e8s: 10 * E8,
-                account: driver.random_byte_array().to_vec(),
+                account: driver.random_byte_array().expect("Could not get random byte array").to_vec(),
                 dissolve_state: Some(DissolveState::WhenDissolvedTimestampSeconds(0)),
                 aging_since_timestamp_seconds: u64::MAX,
                 ..Default::default()
@@ -8123,7 +8165,7 @@ fn test_filter_proposals_excluding_topics() {
                 id: Some(NeuronId { id: 1 }),
                 controller: Some(principal1),
                 cached_neuron_stake_e8s: 10 * E8,
-                account: driver.random_byte_array().to_vec(),
+                account: driver.random_byte_array().expect("Could not get random byte array").to_vec(),
                 dissolve_state: Some(DissolveState::WhenDissolvedTimestampSeconds(0)),
                 aging_since_timestamp_seconds: u64::MAX,
                 ..Default::default()
@@ -8219,7 +8261,7 @@ fn test_filter_proposal_ballots() {
                 controller: Some(principal1),
                 hot_keys: vec![principal_hot],
                 cached_neuron_stake_e8s: 10 * E8,
-                account: driver.random_byte_array().to_vec(),
+                account: driver.random_byte_array().expect("Could not get random byte array").to_vec(),
                 dissolve_state: Some(DissolveState::WhenDissolvedTimestampSeconds(0)),
                 aging_since_timestamp_seconds: u64::MAX,
                 ..Default::default()
@@ -8229,7 +8271,7 @@ fn test_filter_proposal_ballots() {
                 id: Some(NeuronId { id: 2 }),
                 controller: Some(principal2),
                 cached_neuron_stake_e8s: 10 * E8,
-                account: driver.random_byte_array().to_vec(),
+                account: driver.random_byte_array().expect("Could not get random byte array").to_vec(),
                 dissolve_state: Some(DissolveState::WhenDissolvedTimestampSeconds(0)),
                 aging_since_timestamp_seconds: u64::MAX,
                 ..Default::default()
@@ -8325,7 +8367,7 @@ async fn test_make_proposal_message() {
                 controller: Some(principal1),
                 hot_keys: vec![],
                 cached_neuron_stake_e8s: 10 * E8,
-                account: driver.random_byte_array().to_vec(),
+                account: driver.random_byte_array().expect("Could not get random byte array").to_vec(),
                 dissolve_state: Some(DissolveState::DissolveDelaySeconds(MIN_DISSOLVE_DELAY_FOR_VOTE_ELIGIBILITY_SECONDS)),
                 ..Default::default()
             },
@@ -8408,7 +8450,7 @@ fn test_omit_large_fields() {
                 controller: Some(principal1),
                 hot_keys: vec![],
                 cached_neuron_stake_e8s: 10 * E8,
-                account: driver.random_byte_array().to_vec(),
+                account: driver.random_byte_array().expect("Could not get random byte array").to_vec(),
                 dissolve_state: Some(DissolveState::WhenDissolvedTimestampSeconds(0)),
                 aging_since_timestamp_seconds: u64::MAX,
                 ..Default::default()
@@ -10895,7 +10937,10 @@ async fn test_known_neurons() {
     let neurons = vec![
         Neuron {
             id: Some(NeuronId { id: 1 }),
-            account: driver.random_byte_array().to_vec(),
+            account: driver
+                .random_byte_array()
+                .expect("Could not get random byte array")
+                .to_vec(),
             controller: Some(principal(1)),
             cached_neuron_stake_e8s: 100_000_000,
             dissolve_state: Some(DissolveState::DissolveDelaySeconds(
@@ -10905,7 +10950,10 @@ async fn test_known_neurons() {
         },
         Neuron {
             id: Some(NeuronId { id: 2 }),
-            account: driver.random_byte_array().to_vec(),
+            account: driver
+                .random_byte_array()
+                .expect("Could not get random byte array")
+                .to_vec(),
             controller: Some(principal(2)),
             cached_neuron_stake_e8s: 100_000_000,
             dissolve_state: Some(DissolveState::DissolveDelaySeconds(
@@ -10915,7 +10963,10 @@ async fn test_known_neurons() {
         },
         Neuron {
             id: Some(NeuronId { id: 3 }),
-            account: driver.random_byte_array().to_vec(),
+            account: driver
+                .random_byte_array()
+                .expect("Could not get random byte array")
+                .to_vec(),
             controller: Some(principal(3)),
             cached_neuron_stake_e8s: 100_000_000_000,
             dissolve_state: Some(DissolveState::DissolveDelaySeconds(
@@ -11192,11 +11243,11 @@ impl Environment for MockEnvironment<'_> {
         DEFAULT_TEST_START_TIMESTAMP_SECONDS
     }
 
-    fn random_u64(&mut self) -> u64 {
-        RANDOM_U64
+    fn random_u64(&mut self) -> Result<u64, RngError> {
+        Ok(RANDOM_U64)
     }
 
-    fn random_byte_array(&mut self) -> [u8; 32] {
+    fn random_byte_array(&mut self) -> Result<[u8; 32], RngError> {
         panic!("Unexpected call to Environment::random_byte_array");
     }
 

--- a/rs/nns/governance/tests/governance.rs
+++ b/rs/nns/governance/tests/governance.rs
@@ -11255,6 +11255,10 @@ impl Environment for MockEnvironment<'_> {
         unimplemented!()
     }
 
+    fn get_rng_seed(&self) -> Option<[u8; 32]> {
+        unimplemented!()
+    }
+
     fn execute_nns_function(
         &self,
         _proposal_id: u64,

--- a/rs/nns/integration_tests/src/node_provider_remuneration.rs
+++ b/rs/nns/integration_tests/src/node_provider_remuneration.rs
@@ -186,7 +186,7 @@ fn test_list_node_provider_rewards() {
     for _ in 0..12 {
         // Assert that advancing time by a month triggers an automated monthly NP reward event
         state_machine.advance_time(Duration::from_secs(ONE_MONTH_SECONDS + 1));
-        state_machine.advance_time(Duration::from_secs(60));
+        state_machine.tick();
         state_machine.tick();
 
         let rewards = nns_get_most_recent_monthly_node_provider_rewards(&state_machine).unwrap();

--- a/rs/sns/governance/canister/canister.rs
+++ b/rs/sns/governance/canister/canister.rs
@@ -56,7 +56,11 @@ use ic_sns_governance::{
 use prost::Message;
 use rand::{RngCore, SeedableRng};
 use rand_chacha::ChaCha20Rng;
-use std::{boxed::Box, convert::TryFrom, time::SystemTime};
+use std::{
+    boxed::Box,
+    convert::TryFrom,
+    time::{Duration, SystemTime},
+};
 
 /// Size of the buffer for stable memory reads and writes.
 ///

--- a/rs/sns/governance/canister/canister.rs
+++ b/rs/sns/governance/canister/canister.rs
@@ -56,11 +56,7 @@ use ic_sns_governance::{
 use prost::Message;
 use rand::{RngCore, SeedableRng};
 use rand_chacha::ChaCha20Rng;
-use std::{
-    boxed::Box,
-    convert::TryFrom,
-    time::{Duration, SystemTime},
-};
+use std::{boxed::Box, convert::TryFrom, time::SystemTime};
 
 /// Size of the buffer for stable memory reads and writes.
 ///


### PR DESCRIPTION
In NNS Governance.

This is done by reseeding every hour. The seed is sourced from the raw_rand method of the management canister, and because of this, these seeds are "as secure as it gets". This is a compromise between speed and security that DFINITY's security team is ok with.

Currently, there is no need for secure RNs. However, that could come up in the future, and when it does, it would be too easy for us to overlook (without this change).