### PR TITLE
chore(nns): Add comments related to arg_hash being empty

### DIFF
--- a/rs/nns/governance/canister/governance.did
+++ b/rs/nns/governance/canister/governance.did
@@ -377,11 +377,13 @@ type InstallCode = record {
   skip_stopping_before_installing : opt bool;
   wasm_module_hash : opt blob;
   canister_id : opt principal;
+  // The hash of the upgrade args. If the upgrade args is empty, then the hash is also empty.
   arg_hash : opt blob;
   install_mode : opt int32;
 };
 
 type InstallCodeRequest = record {
+  // The upgrade arguments passed to the target canister. Required.
   arg : opt blob;
   wasm_module : opt blob;
   skip_stopping_before_installing : opt bool;

--- a/rs/nns/governance/src/pb/conversions.rs
+++ b/rs/nns/governance/src/pb/conversions.rs
@@ -2888,6 +2888,9 @@ impl From<pb::InstallCode> for pb_api::InstallCode {
             .map(|wasm_module| super::calculate_hash(&wasm_module).to_vec());
         let arg = item.arg.unwrap_or_default();
         let arg_hash = if arg.is_empty() {
+            // Since the `arg_hash` is the only thing being returned and it's very common to have
+            // empty args, it is more informative to return an empty vec for this case instead of
+            // `e3b0c442...` (`sha256([])`).
             Some(vec![])
         } else {
             Some(super::calculate_hash(&arg).to_vec())


### PR DESCRIPTION
# Why

The semantics of `arg` when submitting an `InstallCode` proposal and `arg_hash` when such proposal is returned weren't very clear, especially when the `arg` is empty. Explain them better through comments.

# What

Add comments regarding the API related to `arg`, `arg_hash` and implementation.