### PR TITLE
chore(PocketIC): use ReadStateResponse and SubnetMetrics type from ic-transport-types

### DIFF
--- a/Cargo.Bazel.Fuzzing.json.lock
+++ b/Cargo.Bazel.Fuzzing.json.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "7059ee8ebf23a06427b529a3b7d636561f31d7f874d553442922453110341f6e",
+  "checksum": "2debd702b24f7c7c56d40695d32c74e12a292344893ba7f1a2441756723febfc",
   "crates": {
     "abnf 0.12.0": {
       "name": "abnf",
@@ -18199,6 +18199,10 @@
             {
               "id": "ic-test-state-machine-client 3.0.1",
               "target": "ic_test_state_machine_client"
+            },
+            {
+              "id": "ic-transport-types 0.37.1",
+              "target": "ic_transport_types"
             },
             {
               "id": "ic-utils 0.37.0",
@@ -78949,6 +78953,7 @@
     "ic-response-verification 2.6.0",
     "ic-stable-structures 0.6.5",
     "ic-test-state-machine-client 3.0.1",
+    "ic-transport-types 0.37.1",
     "ic-utils 0.37.0",
     "ic-verify-bls-signature 0.6.0",
     "ic-wasm 0.8.4",

--- a/Cargo.Bazel.Fuzzing.toml.lock
+++ b/Cargo.Bazel.Fuzzing.toml.lock
@@ -3147,6 +3147,7 @@ dependencies = [
  "ic-response-verification",
  "ic-stable-structures",
  "ic-test-state-machine-client",
+ "ic-transport-types",
  "ic-utils",
  "ic-verify-bls-signature 0.6.0",
  "ic-wasm",

--- a/Cargo.Bazel.json.lock
+++ b/Cargo.Bazel.json.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "69f608e3c94460cdd4fa815962baf0dbeaf2d1f7cb05c8efffae1d0276473ae9",
+  "checksum": "ef752013465c4aa89c0749caba4ca2cd50f4fdbc0c61e65e3cdc9d6010222704",
   "crates": {
     "abnf 0.12.0": {
       "name": "abnf",
@@ -18000,6 +18000,10 @@
             {
               "id": "ic-test-state-machine-client 3.0.1",
               "target": "ic_test_state_machine_client"
+            },
+            {
+              "id": "ic-transport-types 0.37.1",
+              "target": "ic_transport_types"
             },
             {
               "id": "ic-utils 0.37.0",
@@ -79125,6 +79129,7 @@
     "ic-response-verification 2.6.0",
     "ic-stable-structures 0.6.5",
     "ic-test-state-machine-client 3.0.1",
+    "ic-transport-types 0.37.1",
     "ic-utils 0.37.0",
     "ic-verify-bls-signature 0.6.0",
     "ic-wasm 0.8.4",

--- a/Cargo.Bazel.toml.lock
+++ b/Cargo.Bazel.toml.lock
@@ -3136,6 +3136,7 @@ dependencies = [
  "ic-response-verification",
  "ic-stable-structures",
  "ic-test-state-machine-client",
+ "ic-transport-types",
  "ic-utils",
  "ic-verify-bls-signature 0.6.0",
  "ic-wasm",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16518,6 +16518,7 @@ dependencies = [
  "ic-agent",
  "ic-base-types",
  "ic-cdk 0.13.5",
+ "ic-transport-types",
  "ic-universal-canister",
  "icp-ledger",
  "k256",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -541,6 +541,7 @@ ic-certification = "2.6.0"
 ic-http-certification = "2.6.0"
 ic-response-verification = "2.6.0"
 ic-stable-structures = "0.6.5"
+ic-transport-types = { version = "0.37.1" }
 ic-utils = { version = "0.37.0", features = ["raw"] }
 ic_bls12_381 = { version = "=0.10.0", default-features = false, features = [
     "groups",

--- a/bazel/external_crates.bzl
+++ b/bazel/external_crates.bzl
@@ -633,6 +633,9 @@ def external_crates_repository(name, cargo_lockfile, lockfile, sanitizers_enable
             "ic-test-state-machine-client": crate.spec(
                 version = "^3.0.0",
             ),
+            "ic-transport-types": crate.spec(
+                version = "^0.37.1",
+            ),
             "ic-utils": crate.spec(
                 version = "^0.37.0",
                 features = ["raw"],

--- a/packages/pocket-ic/BUILD.bazel
+++ b/packages/pocket-ic/BUILD.bazel
@@ -10,6 +10,7 @@ DEPENDENCIES = [
     "@crate_index//:hex",
     "@crate_index//:ic-agent",
     "@crate_index//:ic-cdk",
+    "@crate_index//:ic-transport-types",
     "@crate_index//:reqwest",
     "@crate_index//:schemars",
     "@crate_index//:serde",

--- a/packages/pocket-ic/Cargo.toml
+++ b/packages/pocket-ic/Cargo.toml
@@ -25,6 +25,7 @@ candid = "^0.10.2"
 hex = { workspace = true }
 ic-agent = { workspace = true }
 ic-cdk = "0.13.5"
+ic-transport-types = { workspace = true }
 reqwest = { workspace = true }
 schemars = "0.8.16"
 serde = { workspace = true }

--- a/packages/pocket-ic/src/lib.rs
+++ b/packages/pocket-ic/src/lib.rs
@@ -46,6 +46,7 @@ use candid::{
 };
 pub use ic_cdk::api::management_canister::main::CanisterSettings;
 use ic_cdk::api::management_canister::main::{CanisterId, CanisterStatusResponse};
+use ic_transport_types::SubnetMetrics;
 use reqwest::Url;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -1316,16 +1317,6 @@ pub enum WasmResult {
     Reject(String),
 }
 
-/// This struct describes the result of retrieving subnet metrics via a read state request.
-#[derive(Debug, Copy, Clone, serde::Serialize, serde::Deserialize)]
-pub struct SubnetMetrics {
-    pub num_canisters: u64,
-    pub canister_state_bytes: u64,
-    #[serde(with = "map_u128")]
-    pub consumed_cycles_total: u128,
-    pub update_transactions_total: u64,
-}
-
 /// Attempt to start a new PocketIC server if it's not already running.
 pub fn start_or_reuse_server() -> Url {
     let bin_path = match std::env::var_os("POCKET_IC_BIN") {
@@ -1375,46 +1366,5 @@ To download the binary, please visit https://github.com/dfinity/pocketic."
             }
         }
         std::thread::sleep(Duration::from_millis(20));
-    }
-}
-
-mod map_u128 {
-    use serde::{
-        de::{Error, IgnoredAny, MapAccess, Visitor},
-        ser::SerializeMap,
-        Deserializer, Serializer,
-    };
-    use std::fmt;
-
-    pub fn serialize<S: Serializer>(val: &u128, s: S) -> Result<S::Ok, S::Error> {
-        let low = *val & u64::MAX as u128;
-        let high = *val >> 64;
-        let mut map = s.serialize_map(Some(2))?;
-        map.serialize_entry(&0, &low)?;
-        map.serialize_entry(&1, &(high != 0).then_some(high))?;
-        map.end()
-    }
-
-    pub fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<u128, D::Error> {
-        d.deserialize_map(MapU128Visitor)
-    }
-
-    struct MapU128Visitor;
-
-    impl<'de> Visitor<'de> for MapU128Visitor {
-        type Value = u128;
-
-        fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-            formatter.write_str("a map of low and high")
-        }
-
-        fn visit_map<A: MapAccess<'de>>(self, mut map: A) -> Result<Self::Value, A::Error> {
-            let (_, low): (IgnoredAny, u64) = map
-                .next_entry()?
-                .ok_or_else(|| A::Error::missing_field("0"))?;
-            let opt: Option<(IgnoredAny, Option<u64>)> = map.next_entry()?;
-            let high = opt.and_then(|x| x.1).unwrap_or(0);
-            Ok((high as u128) << 64 | low as u128)
-        }
     }
 }

--- a/packages/pocket-ic/src/nonblocking.rs
+++ b/packages/pocket-ic/src/nonblocking.rs
@@ -7,9 +7,7 @@ use crate::common::rest::{
     RawSetStableMemory, RawStableMemory, RawSubmitIngressResult, RawSubnetId, RawTime,
     RawVerifyCanisterSigArg, RawWasmResult, SubnetId, Topology,
 };
-use crate::{
-    CallError, PocketIcBuilder, SubnetMetrics, UserError, WasmResult, DEFAULT_MAX_REQUEST_TIME_MS,
-};
+use crate::{CallError, PocketIcBuilder, UserError, WasmResult, DEFAULT_MAX_REQUEST_TIME_MS};
 use candid::{
     decode_args, encode_args,
     utils::{ArgumentDecoder, ArgumentEncoder},
@@ -20,6 +18,7 @@ use ic_cdk::api::management_canister::main::{
     ChunkHash, ClearChunkStoreArgument, InstallChunkedCodeArgument, InstallCodeArgument,
     SkipPreUpgrade, UpdateSettingsArgument, UploadChunkArgument,
 };
+use ic_transport_types::SubnetMetrics;
 use reqwest::Url;
 use serde::{de::DeserializeOwned, Serialize};
 use sha2::{Digest, Sha256};

--- a/packages/pocket-ic/src/nonblocking.rs
+++ b/packages/pocket-ic/src/nonblocking.rs
@@ -18,7 +18,7 @@ use ic_cdk::api::management_canister::main::{
     ChunkHash, ClearChunkStoreArgument, InstallChunkedCodeArgument, InstallCodeArgument,
     SkipPreUpgrade, UpdateSettingsArgument, UploadChunkArgument,
 };
-use ic_transport_types::SubnetMetrics;
+use ic_transport_types::{ReadStateResponse, SubnetMetrics};
 use reqwest::Url;
 use serde::{de::DeserializeOwned, Serialize};
 use sha2::{Digest, Sha256};
@@ -1040,12 +1040,6 @@ impl PocketIc {
     /// Returns subnet metrics for a given subnet.
     #[instrument(ret, skip(self), fields(instance_id=self.instance_id, subnet_id = %subnet_id.to_string()))]
     pub async fn get_subnet_metrics(&self, subnet_id: Principal) -> Option<SubnetMetrics> {
-        #[derive(Debug, Clone, serde::Deserialize, serde::Serialize, PartialEq, Eq)]
-        struct ReadStateResponse {
-            #[serde(with = "serde_bytes")]
-            pub certificate: Vec<u8>,
-        }
-
         let path = vec![
             "subnet".into(),
             ic_agent::hash_tree::Label::from_bytes(subnet_id.as_slice()),


### PR DESCRIPTION
This PR makes the PocketIC library reuse the `ReadStateResponse` and `SubnetMetrics` type from `ic-transport-types` instead of redefining it from scratch (incl. custom deserializer).