### PR TITLE
fix(IDX): dont send notification for skipped jobs

### DIFF
--- a/.github/workflows/slack-workflow-run.yml
+++ b/.github/workflows/slack-workflow-run.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Post Slack Notification
         uses: slackapi/slack-github-action@6c661ce58804a1a20f6dc5fbee7f0381b469e001 # v1.25.0
-        if: ${{ steps.setup.outputs.message != 'nothing' }}
+        if: ${{ github.event.workflow_run.conclusion != 'skipped' }}
         with:
           channel-id: ${{ steps.setup.outputs.channel }}
           slack-message: "${{ steps.setup.outputs.message }}"


### PR DESCRIPTION
The existing filter doesn't seem to correctly prevent notifications for skipped jobs, we'll ignore them if the conclusion was `skipped`.