### PR TITLE
feat(ic-admin): Check the correspondence between `arg` and `arg_sha256` before submitting install code requests

### DIFF
--- a/rs/registry/admin/src/main.rs
+++ b/rs/registry/admin/src/main.rs
@@ -1038,11 +1038,7 @@ impl ProposalAction for ProposeToChangeNnsCanisterCmd {
             )
             .await,
         );
-        let arg = Some(
-            self.arg
-                .as_ref()
-                .map_or(vec![], |path| read_file_fully(path)),
-        );
+        let arg = Some(read_arg(&self.arg, &self.arg_sha256));
         let skip_stopping_before_installing = Some(self.skip_stopping_before_installing);
         let install_mode = match self.mode {
             CanisterInstallMode::Install => Some(GovernanceInstallMode::Install as i32),


### PR DESCRIPTION
Currently, ic-admin has two code paths for `ProposeToChangeNnsCanister`, depending on `use_legacy_execute_nns_function`. The correspondence between the `arg` and `arg_sha256` CLI arguments is checked only in the legacy flow. The PR fixes that shortcoming.