### PR TITLE
chore: remove the is_beyond_last_checkpoint check when serving requests

### DIFF
--- a/rs/bitcoin/adapter/src/get_successors_handler.rs
+++ b/rs/bitcoin/adapter/src/get_successors_handler.rs
@@ -252,7 +252,6 @@ mod test {
     use bitcoin::Network;
     use ic_metrics::MetricsRegistry;
     use tokio::sync::{mpsc::channel, Mutex};
-    use tonic::Code;
 
     use crate::config::test::ConfigBuilder;
     use ic_btc_adapter_test_utils::{


### PR DESCRIPTION
The check is not giving us much so I would prefer to remove it.

In the stady case the check has no effect since all anchors that are passed as part of the request will be pass the checkpoint.

The check make sense only when the canister is syncing. But even in this case the check doesn't by us much because:

1. it will reject only 1-2 requests because syncing the headers will take just a few seconds.
2. the check is not really preventing forks from happening because we can have a fork pass the checkpoint as well.