### PR TITLE
feat(nervous-system): Filter out boring commits when listing new NNS and SNS commits.

### DIFF
--- a/testnet/tools/lib.sh
+++ b/testnet/tools/lib.sh
@@ -3,25 +3,35 @@ repo_root() {
 }
 
 RED_TEXT='\033[0;31m'
-YELLOW_TEXT='\033[0;33m'
 GREEN_TEXT='\033[0;32m'
+YELLOW_TEXT='\033[0;33m'
 BLUE_TEXT='\033[0;34m'
+PURPLE_TEXT='\033[0;35m'
+CYAN_TEXT='\033[0;36m'
 NO_COLOR='\033[0m'
 
 print_red() {
     echo -e "${RED_TEXT}$*${NO_COLOR}" 1>&2
 }
 
-print_yellow() {
-    echo -e "${YELLOW_TEXT}$*${NO_COLOR}" 1>&2
-}
-
 print_green() {
     echo -e "${GREEN_TEXT}$*${NO_COLOR}"
 }
 
+print_yellow() {
+    echo -e "${YELLOW_TEXT}$*${NO_COLOR}" 1>&2
+}
+
 print_blue() {
     echo -e "${BLUE_TEXT}$*${NO_COLOR}"
+}
+
+print_purple() {
+    echo -e "${PURPLE_TEXT}$*${NO_COLOR}"
+}
+
+print_cyan() {
+    echo -e "${CYAN_TEXT}$*${NO_COLOR}"
 }
 
 info() {

--- a/testnet/tools/nns-tools/list-new-commits.sh
+++ b/testnet/tools/nns-tools/list-new-commits.sh
@@ -21,11 +21,14 @@ Usage: $0 <COMMIT_ID>
 
 RELEASE_CANDIDATE_COMMIT_ID="${1:-GARBAGE}"
 
+AUTO_COMMIT_ID=false
 if [[ "${RELEASE_CANDIDATE_COMMIT_ID}" == 'GARBAGE' ]]; then
-    LATEST_COMMIT_WITH_PREBUILT_ARTIFACTS=$(latest_commit_with_prebuilt_artifacts 2>/dev/null)
+    RELEASE_CANDIDATE_COMMIT_ID=$(latest_commit_with_prebuilt_artifacts 2>/dev/null)
+    AUTO_COMMIT_ID=true
+
+    COMMIT_DESCRIPTION=$(git show -s --format="%h (%cd)" --date=relative "${RELEASE_CANDIDATE_COMMIT_ID}")
     echo
-    print_yellow "The latest commit with prebuilt artifacts: ${LATEST_COMMIT_WITH_PREBUILT_ARTIFACTS}"
-    help
+    print_yellow "⚠️  Using the latest commit with prebuilt artifacts: ${COMMIT_DESCRIPTION}"
 fi
 
 NETWORK=ic
@@ -80,6 +83,9 @@ list_new_canister_commits() {
     fi
 }
 
+
+# Begin main.
+
 echo
 print_purple NNS
 print_purple =====
@@ -102,3 +108,9 @@ for CANISTER_NAME in "${SNS_CANISTERS[@]}"; do
 
     list_new_canister_commits "${CANISTER_NAME}" "${CODE_DIRECTORIES}" "${LATEST_RELEASED_COMMIT_ID}"
 done
+
+if [[ "${AUTO_COMMIT_ID}" == true ]]; then
+    echo
+    echo
+    print_yellow "⚠️  Used the latest commit with prebuilt artifacts: ${RELEASE_CANDIDATE_COMMIT_ID}"
+fi

--- a/testnet/tools/nns-tools/list-new-commits.sh
+++ b/testnet/tools/nns-tools/list-new-commits.sh
@@ -47,7 +47,7 @@ list_new_canister_commits() {
             --format="%C(auto) %h %s" \
             "${RANGE}" \
             -- \
-            ${CODE_DIRECTORIES} # No quote here is intentional, because plural.
+            ${CODE_DIRECTORIES} # No quote here is necessary, because plural.
     )
 
     INTERESTING_COMMITS=$(

--- a/testnet/tools/nns-tools/list-new-commits.sh
+++ b/testnet/tools/nns-tools/list-new-commits.sh
@@ -35,6 +35,7 @@ NETWORK=ic
 
 list_new_canister_commits() {
     CANISTER_NAME="${1}"
+    # Notice plural. Multiple values are separated by space. Because bash.
     CODE_DIRECTORIES="${2}"
     LATEST_RELEASED_COMMIT_ID="${3}"
 
@@ -46,7 +47,7 @@ list_new_canister_commits() {
             --format="%C(auto) %h %s" \
             "${RANGE}" \
             -- \
-            "${CODE_DIRECTORIES}"
+            ${CODE_DIRECTORIES}  # No quote here is intentional, because plural.
     )
 
     INTERESTING_COMMITS=$(

--- a/testnet/tools/nns-tools/list-new-commits.sh
+++ b/testnet/tools/nns-tools/list-new-commits.sh
@@ -47,12 +47,12 @@ list_new_canister_commits() {
     )
 
     INTERESTING_COMMITS=$(
-        grep -v -E ' .{10} (chore|refactor|test)\b' <<< "$NEW_COMMITS" \
-        || true
+        grep -v -E ' .{10} (chore|refactor|test)\b' <<<"$NEW_COMMITS" \
+            || true
     )
 
-    COMMIT_COUNT=$(grep . <<< "$NEW_COMMITS" | wc -l || true)
-    INTERESTING_COMMIT_COUNT=$(grep . <<< "$INTERESTING_COMMITS" | wc -l || true)
+    COMMIT_COUNT=$(grep . <<<"$NEW_COMMITS" | wc -l || true)
+    INTERESTING_COMMIT_COUNT=$(grep . <<<"$INTERESTING_COMMITS" | wc -l || true)
 
     # Compose heading for canister.
     HEADING=$(printf "%-14s" "${CANISTER_NAME}") # Add space padding on right of canister name.
@@ -75,7 +75,7 @@ list_new_canister_commits() {
     fi
 
     # Print commits.
-    if [[ "${INTERESTING_COMMITS}" != "" ]] ; then
+    if [[ "${INTERESTING_COMMITS}" != "" ]]; then
         echo "${INTERESTING_COMMITS}"
     fi
 }

--- a/testnet/tools/nns-tools/list-new-commits.sh
+++ b/testnet/tools/nns-tools/list-new-commits.sh
@@ -47,7 +47,7 @@ list_new_canister_commits() {
             --format="%C(auto) %h %s" \
             "${RANGE}" \
             -- \
-            ${CODE_DIRECTORIES}  # No quote here is intentional, because plural.
+            ${CODE_DIRECTORIES} # No quote here is intentional, because plural.
     )
 
     INTERESTING_COMMITS=$(
@@ -83,7 +83,6 @@ list_new_canister_commits() {
         echo "${INTERESTING_COMMITS}"
     fi
 }
-
 
 # Begin main.
 


### PR DESCRIPTION
Overall, tries to make list-new-commits.sh more ergonomic.


# Ergonomics

Boring is defined as having one of the following Conventional Commits prefixes:

- chore
- refactor
- test

Colorizes.

When commit ID is not supplied, warns that one is chosen automatically. (When I originally sent this out for review, commit ID was required, but feedback said this is too inconvenient. So, I switched to printing a warning.)


# Entrained Change(s)

Factored out common code from two loops (one for NNS, the other for SNS).

Adds more print_* colors.


# Possible Future Work (no promises)

Instead of manually reviewing which canisters to upgrade, this could be used to make that choice for us (using the same criterion for using green to print the canister heading). This would help streamline our releases, and in particular, reduce the release tsar's workload.