### PR TITLE
chore(IDX): upload bazel-bep on failure or success

### DIFF
--- a/.github/workflows-source/ci-main.yml
+++ b/.github/workflows-source/ci-main.yml
@@ -87,7 +87,9 @@ anchors:
         bazel-targets
   bazel-bep: &bazel-bep
     name: Upload bazel-bep
-    if: always()
+    # runs only if previous step succeeded or failed;
+    # we avoid collecting artifacts of jobs that were cancelled
+    if: success() || failure()
     uses: actions/upload-artifact@v4
     with:
       name: ${{ github.job }}-bep
@@ -132,8 +134,8 @@ jobs:
           # check if PR title contains release and set timeout filters accordingly
           BAZEL_EXTRA_ARGS_RULES: ${{ env.BAZEL_EXTRA_ARGS_RULES || '' }}
           HONEYCOMB_API_TOKEN: ${{ secrets.HONEYCOMB_API_TOKEN }}
-      - <<: *bazel-upload
       - <<: *bazel-bep
+      - <<: *bazel-upload
 
   bazel-build-all-config-check:
     <<: *dind-large-setup
@@ -196,17 +198,7 @@ jobs:
           BAZEL_COMMAND: "build"
           BAZEL_TARGETS: "//rs/..."
           BAZEL_EXTRA_ARGS: "--keep_going --config=fuzzing --build_tag_filters=libfuzzer"
-      - name: Upload bazel-bep
-        uses: actions/upload-artifact@v4
-        if: always()
-        with:
-          name: ${{ github.job }}-bep
-          retention-days: 14
-          if-no-files-found: ignore
-          compression-level: 9
-          path: |
-            bazel-bep.pb
-            profile.json
+      - <<: *bazel-bep
 
   bazel-build-fuzzers-afl:
     name: Bazel Build Fuzzers AFL
@@ -243,6 +235,7 @@ jobs:
         env:
           CI_COMMIT_REF_PROTECTED: ${{ github.ref_protected }}
           CI_DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+
   build-ic:
     name: Build IC
     <<: *dind-large-setup

--- a/.github/workflows-source/release-testing.yml
+++ b/.github/workflows-source/release-testing.yml
@@ -57,6 +57,20 @@ anchors:
     env:
       DOCKER_HUB_USER: ${{ vars.DOCKER_HUB_USER }}
       DOCKER_HUB_PASSWORD_RO: ${{ secrets.DOCKER_HUB_PASSWORD_RO }}
+  bazel-bep: &bazel-bep
+    name: Upload bazel-bep
+    # runs only if previous step succeeded or failed;
+    # we avoid collecting artifacts of jobs that were cancelled
+    if: success() || failure()
+    uses: actions/upload-artifact@v4
+    with:
+      name: ${{ github.job }}-bep
+      retention-days: 14
+      if-no-files-found: ignore
+      compression-level: 9
+      path: |
+        bazel-bep.pb
+        profile.json
 
 jobs:
   ci-main:
@@ -80,17 +94,7 @@ jobs:
           BAZEL_CI_CONFIG: "--config=ci --repository_cache=/cache/bazel"
           BAZEL_EXTRA_ARGS: "--keep_going --test_tag_filters=system_test_nightly"
           HONEYCOMB_API_TOKEN: ${{ secrets.HONEYCOMB_API_TOKEN }}
-      - name: Upload bazel-bep
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ github.job }}-bep
-          retention-days: 14
-          if-no-files-found: ignore
-          compression-level: 9
-          path: |
-            bazel-bep.pb
-            profile.json
+      - <<: *bazel-bep
 
   bazel-system-test-staging:
     name: Bazel System Test Staging
@@ -109,17 +113,7 @@ jobs:
           BAZEL_CI_CONFIG: "--config=ci --repository_cache=/cache/bazel"
           BAZEL_EXTRA_ARGS: "--keep_going --test_tag_filters=system_test_staging"
           HONEYCOMB_API_TOKEN: ${{ secrets.HONEYCOMB_API_TOKEN }}
-      - name: Upload bazel-bep
-        uses: actions/upload-artifact@v4
-        if: always()
-        with:
-          name: ${{ github.job }}-bep
-          retention-days: 14
-          if-no-files-found: ignore
-          compression-level: 9
-          path: |
-            bazel-bep.pb
-            profile.json
+      - <<: *bazel-bep
 
   bazel-system-test-hotfix:
     name: Bazel System Test Hotfix
@@ -138,17 +132,7 @@ jobs:
           BAZEL_CI_CONFIG: "--config=ci --repository_cache=/cache/bazel"
           BAZEL_EXTRA_ARGS_RULES: "--test_tag_filters=system_test_hotfix"
           HONEYCOMB_API_TOKEN: ${{ secrets.HONEYCOMB_API_TOKEN }}
-      - name: Upload bazel-bep
-        uses: actions/upload-artifact@v4
-        if: always()
-        with:
-          name: ${{ github.job }}-bep
-          retention-days: 14
-          if-no-files-found: ignore
-          compression-level: 9
-          path: |
-            bazel-bep.pb
-            profile.json
+      - <<: *bazel-bep
 
   dependency-scan-release-cut:
     name: Dependency Scan for Release
@@ -217,3 +201,4 @@ jobs:
           BAZEL_CI_CONFIG: "--config=systest --repository_cache=/cache/bazel"
           BAZEL_EXTRA_ARGS_RULES: "--test_timeout=7200 --test_env=OLD_VERSION=${{ matrix.version }}"
           HONEYCOMB_API_TOKEN: ${{ secrets.HONEYCOMB_API_TOKEN }}
+      - <<: *bazel-bep

--- a/.github/workflows-source/schedule-daily.yml
+++ b/.github/workflows-source/schedule-daily.yml
@@ -48,6 +48,20 @@ anchors:
     env:
       DOCKER_HUB_USER: ${{ vars.DOCKER_HUB_USER }}
       DOCKER_HUB_PASSWORD_RO: ${{ secrets.DOCKER_HUB_PASSWORD_RO }}
+  bazel-bep: &bazel-bep
+    name: Upload bazel-bep
+    # runs only if previous step succeeded or failed;
+    # we avoid collecting artifacts of jobs that were cancelled
+    if: success() || failure()
+    uses: actions/upload-artifact@v4
+    with:
+      name: ${{ github.job }}-bep
+      retention-days: 14
+      if-no-files-found: ignore
+      compression-level: 9
+      path: |
+        bazel-bep.pb
+        profile.json
 
 jobs:
 
@@ -115,17 +129,7 @@ jobs:
           BAZEL_EXTRA_ARGS: "--keep_going --test_tag_filters=fi_tests_nightly --test_env=SSH_AUTH_SOCK --test_timeout=43200"
           HONEYCOMB_API_TOKEN: ${{ secrets.HONEYCOMB_API_TOKEN }}
           SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
-      - name: Upload bazel-bep
-        uses: actions/upload-artifact@v4
-        if: always()
-        with:
-          name: ${{ github.job }}-bep
-          retention-days: 14
-          if-no-files-found: ignore
-          compression-level: 9
-          path: |
-            bazel-bep.pb
-            profile.json
+      - <<: *bazel-bep
 
   nns-tests-nightly:
     name: Bazel Test NNS Nightly
@@ -145,17 +149,7 @@ jobs:
           BAZEL_EXTRA_ARGS: "--keep_going --test_tag_filters=nns_tests_nightly --test_env=SSH_AUTH_SOCK --test_env=NNS_CANISTER_UPGRADE_SEQUENCE=all"
           HONEYCOMB_API_TOKEN: ${{ secrets.HONEYCOMB_API_TOKEN }}
           SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
-      - name: Upload bazel-bep
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ github.job }}-bep
-          retention-days: 14
-          if-no-files-found: ignore
-          compression-level: 9
-          path: |
-            bazel-bep.pb
-            profile.json
+      - <<: *bazel-bep
 
   system-tests-benchmarks-nightly:
     name: Bazel System Test Benchmarks
@@ -180,17 +174,7 @@ jobs:
           # note: there's just one performance cluster, so the job can't be parallelized
           BAZEL_EXTRA_ARGS: "--test_tag_filters=system_test_benchmark --//bazel:enable_upload_perf_systest_results=True --keep_going --jobs 1"
           HONEYCOMB_API_TOKEN: ${{ secrets.HONEYCOMB_API_TOKEN }}
-      - name: Upload bazel-bep
-        uses: actions/upload-artifact@v4
-        if: always()
-        with:
-          name: ${{ github.job }}-bep
-          retention-days: 14
-          if-no-files-found: ignore
-          compression-level: 9
-          path: |
-            bazel-bep.pb
-            profile.json
+      - <<: *bazel-bep
 
   dependency-scan-nightly:
     name: Dependency Scan Nightly

--- a/.github/workflows-source/schedule-hourly.yml
+++ b/.github/workflows-source/schedule-hourly.yml
@@ -47,6 +47,20 @@ anchors:
     env:
       DOCKER_HUB_USER: ${{ vars.DOCKER_HUB_USER }}
       DOCKER_HUB_PASSWORD_RO: ${{ secrets.DOCKER_HUB_PASSWORD_RO }}
+  bazel-bep: &bazel-bep
+    name: Upload bazel-bep
+    # runs only if previous step succeeded or failed;
+    # we avoid collecting artifacts of jobs that were cancelled
+    if: success() || failure()
+    uses: actions/upload-artifact@v4
+    with:
+      name: ${{ github.job }}-bep
+      retention-days: 14
+      if-no-files-found: ignore
+      compression-level: 9
+      path: |
+        bazel-bep.pb
+        profile.json
 
 jobs:
   bazel-build-all-no-cache:
@@ -64,15 +78,7 @@ jobs:
           BAZEL_CI_CONFIG: "--config=ci"
           BAZEL_COMMAND: "build"
           BAZEL_EXTRA_ARGS: "--repository_cache= --disk_cache= --noremote_accept_cached --remote_instance_name=${CI_COMMIT_SHA} --@rules_rust//rust/settings:pipelined_compilation=True"
-      - name: Upload bazel-bep
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ github.job }}-bep
-          retention-days: 14
-          if-no-files-found: ignore
-          compression-level: 9
-          path: bazel-bep.pb
+      - <<: *bazel-bep
 
   bazel-system-test-hourly:
     name: Bazel System Tests Hourly
@@ -93,17 +99,7 @@ jobs:
           BAZEL_CI_CONFIG: "--config=ci --repository_cache=/cache/bazel"
           BAZEL_EXTRA_ARGS: "--keep_going --test_tag_filters=system_test_hourly"
           HONEYCOMB_API_TOKEN: ${{ secrets.HONEYCOMB_API_TOKEN }}
-      - name: Upload bazel-bep
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ github.job }}-bep
-          retention-days: 14
-          if-no-files-found: ignore
-          compression-level: 9
-          path: |
-            bazel-bep.pb
-            profile.json
+      - <<: *bazel-bep
 
   bazel-test-coverage:
     name: Bazel Test Coverage

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -79,16 +79,10 @@ jobs:
           # check if PR title contains release and set timeout filters accordingly
           BAZEL_EXTRA_ARGS_RULES: ${{ env.BAZEL_EXTRA_ARGS_RULES || '' }}
           HONEYCOMB_API_TOKEN: ${{ secrets.HONEYCOMB_API_TOKEN }}
-      - name: Upload bazel-targets
-        uses: actions/upload-artifact@v4
-        with:
-          name: bazel-targets
-          retention-days: 14
-          if-no-files-found: error
-          path: |
-            bazel-targets
       - name: Upload bazel-bep
-        if: always()
+        # runs only if previous step succeeded or failed;
+        # we avoid collecting artifacts of jobs that were cancelled
+        if: success() || failure()
         uses: actions/upload-artifact@v4
         with:
           name: ${{ github.job }}-bep
@@ -98,6 +92,14 @@ jobs:
           path: |
             bazel-bep.pb
             profile.json
+      - name: Upload bazel-targets
+        uses: actions/upload-artifact@v4
+        with:
+          name: bazel-targets
+          retention-days: 14
+          if-no-files-found: error
+          path: |
+            bazel-targets
   bazel-build-all-config-check:
     runs-on:
       labels: dind-large
@@ -131,7 +133,9 @@ jobs:
           BAZEL_TARGETS: "//rs/..."
           BAZEL_CI_CONFIG: "--config=check --config=ci --keep_going"
       - name: Upload bazel-bep
-        if: always()
+        # runs only if previous step succeeded or failed;
+        # we avoid collecting artifacts of jobs that were cancelled
+        if: success() || failure()
         uses: actions/upload-artifact@v4
         with:
           name: ${{ github.job }}-bep
@@ -175,7 +179,9 @@ jobs:
           BAZEL_TARGETS: "//rs/... //publish/binaries/..."
           HONEYCOMB_API_TOKEN: ${{ secrets.HONEYCOMB_API_TOKEN }}
       - name: Upload bazel-bep
-        if: always()
+        # runs only if previous step succeeded or failed;
+        # we avoid collecting artifacts of jobs that were cancelled
+        if: success() || failure()
         uses: actions/upload-artifact@v4
         with:
           name: ${{ github.job }}-bep
@@ -217,8 +223,10 @@ jobs:
           BAZEL_TARGETS: "//rs/..."
           BAZEL_EXTRA_ARGS: "--keep_going --config=fuzzing --build_tag_filters=libfuzzer"
       - name: Upload bazel-bep
+        # runs only if previous step succeeded or failed;
+        # we avoid collecting artifacts of jobs that were cancelled
+        if: success() || failure()
         uses: actions/upload-artifact@v4
-        if: always()
         with:
           name: ${{ github.job }}-bep
           retention-days: 14
@@ -254,7 +262,9 @@ jobs:
           BAZEL_TARGETS: "//rs/..."
           BAZEL_EXTRA_ARGS: "--keep_going --config=afl"
       - name: Upload bazel-bep
-        if: always()
+        # runs only if previous step succeeded or failed;
+        # we avoid collecting artifacts of jobs that were cancelled
+        if: success() || failure()
         uses: actions/upload-artifact@v4
         with:
           name: ${{ github.job }}-bep

--- a/.github/workflows/release-testing.yml
+++ b/.github/workflows/release-testing.yml
@@ -62,7 +62,9 @@ jobs:
           BAZEL_EXTRA_ARGS: "--keep_going --test_tag_filters=system_test_nightly"
           HONEYCOMB_API_TOKEN: ${{ secrets.HONEYCOMB_API_TOKEN }}
       - name: Upload bazel-bep
-        if: always()
+        # runs only if previous step succeeded or failed;
+        # we avoid collecting artifacts of jobs that were cancelled
+        if: success() || failure()
         uses: actions/upload-artifact@v4
         with:
           name: ${{ github.job }}-bep
@@ -109,8 +111,10 @@ jobs:
           BAZEL_EXTRA_ARGS: "--keep_going --test_tag_filters=system_test_staging"
           HONEYCOMB_API_TOKEN: ${{ secrets.HONEYCOMB_API_TOKEN }}
       - name: Upload bazel-bep
+        # runs only if previous step succeeded or failed;
+        # we avoid collecting artifacts of jobs that were cancelled
+        if: success() || failure()
         uses: actions/upload-artifact@v4
-        if: always()
         with:
           name: ${{ github.job }}-bep
           retention-days: 14
@@ -155,8 +159,10 @@ jobs:
           BAZEL_EXTRA_ARGS_RULES: "--test_tag_filters=system_test_hotfix"
           HONEYCOMB_API_TOKEN: ${{ secrets.HONEYCOMB_API_TOKEN }}
       - name: Upload bazel-bep
+        # runs only if previous step succeeded or failed;
+        # we avoid collecting artifacts of jobs that were cancelled
+        if: success() || failure()
         uses: actions/upload-artifact@v4
-        if: always()
         with:
           name: ${{ github.job }}-bep
           retention-days: 14
@@ -274,3 +280,16 @@ jobs:
           BAZEL_CI_CONFIG: "--config=systest --repository_cache=/cache/bazel"
           BAZEL_EXTRA_ARGS_RULES: "--test_timeout=7200 --test_env=OLD_VERSION=${{ matrix.version }}"
           HONEYCOMB_API_TOKEN: ${{ secrets.HONEYCOMB_API_TOKEN }}
+      - name: Upload bazel-bep
+        # runs only if previous step succeeded or failed;
+        # we avoid collecting artifacts of jobs that were cancelled
+        if: success() || failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ github.job }}-bep
+          retention-days: 14
+          if-no-files-found: ignore
+          compression-level: 9
+          path: |
+            bazel-bep.pb
+            profile.json

--- a/.github/workflows/schedule-daily.yml
+++ b/.github/workflows/schedule-daily.yml
@@ -109,8 +109,10 @@ jobs:
           HONEYCOMB_API_TOKEN: ${{ secrets.HONEYCOMB_API_TOKEN }}
           SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
       - name: Upload bazel-bep
+        # runs only if previous step succeeded or failed;
+        # we avoid collecting artifacts of jobs that were cancelled
+        if: success() || failure()
         uses: actions/upload-artifact@v4
-        if: always()
         with:
           name: ${{ github.job }}-bep
           retention-days: 14
@@ -154,7 +156,9 @@ jobs:
           HONEYCOMB_API_TOKEN: ${{ secrets.HONEYCOMB_API_TOKEN }}
           SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
       - name: Upload bazel-bep
-        if: always()
+        # runs only if previous step succeeded or failed;
+        # we avoid collecting artifacts of jobs that were cancelled
+        if: success() || failure()
         uses: actions/upload-artifact@v4
         with:
           name: ${{ github.job }}-bep
@@ -204,8 +208,10 @@ jobs:
           BAZEL_EXTRA_ARGS: "--test_tag_filters=system_test_benchmark --//bazel:enable_upload_perf_systest_results=True --keep_going --jobs 1"
           HONEYCOMB_API_TOKEN: ${{ secrets.HONEYCOMB_API_TOKEN }}
       - name: Upload bazel-bep
+        # runs only if previous step succeeded or failed;
+        # we avoid collecting artifacts of jobs that were cancelled
+        if: success() || failure()
         uses: actions/upload-artifact@v4
-        if: always()
         with:
           name: ${{ github.job }}-bep
           retention-days: 14

--- a/.github/workflows/schedule-hourly.yml
+++ b/.github/workflows/schedule-hourly.yml
@@ -48,14 +48,18 @@ jobs:
           BAZEL_COMMAND: "build"
           BAZEL_EXTRA_ARGS: "--repository_cache= --disk_cache= --noremote_accept_cached --remote_instance_name=${CI_COMMIT_SHA} --@rules_rust//rust/settings:pipelined_compilation=True"
       - name: Upload bazel-bep
-        if: always()
+        # runs only if previous step succeeded or failed;
+        # we avoid collecting artifacts of jobs that were cancelled
+        if: success() || failure()
         uses: actions/upload-artifact@v4
         with:
           name: ${{ github.job }}-bep
           retention-days: 14
           if-no-files-found: ignore
           compression-level: 9
-          path: bazel-bep.pb
+          path: |
+            bazel-bep.pb
+            profile.json
   bazel-system-test-hourly:
     name: Bazel System Tests Hourly
     container:
@@ -90,7 +94,9 @@ jobs:
           BAZEL_EXTRA_ARGS: "--keep_going --test_tag_filters=system_test_hourly"
           HONEYCOMB_API_TOKEN: ${{ secrets.HONEYCOMB_API_TOKEN }}
       - name: Upload bazel-bep
-        if: always()
+        # runs only if previous step succeeded or failed;
+        # we avoid collecting artifacts of jobs that were cancelled
+        if: success() || failure()
         uses: actions/upload-artifact@v4
         with:
           name: ${{ github.job }}-bep

--- a/.github/workflows/system-tests-k8s.yml
+++ b/.github/workflows/system-tests-k8s.yml
@@ -95,7 +95,7 @@ jobs:
 
       - name: Upload bazel-bep
         uses: actions/upload-artifact@v4
-        if: always()
+        if: success() || failure()
         with:
           name: ${{ github.job }}-bep
           retention-days: 14


### PR DESCRIPTION
Uploading `profile.json` and BEP files only make sense if file is complete (CI job can get interrupted).