### PR TITLE
feat(nns): Lower probability of panicking deprecated methods

### DIFF
--- a/rs/nns/governance/canister/canister.rs
+++ b/rs/nns/governance/canister/canister.rs
@@ -739,7 +739,7 @@ async fn heartbeat() {
 fn manage_neuron_pb() {
     debug_log("manage_neuron_pb");
     panic_with_probability(
-        0.7,
+        0.1,
         "manage_neuron_pb is deprecated. Please use manage_neuron instead.",
     );
 
@@ -774,7 +774,7 @@ fn list_proposals_pb() {
 fn list_neurons_pb() {
     debug_log("list_neurons_pb");
     panic_with_probability(
-        0.7,
+        0.1,
         "list_neurons_pb is deprecated. Please use list_neurons instead.",
     );
 


### PR DESCRIPTION
Lower the probability of deprecated *_pb methods panicking to give integrators more time to migrate.