### PR TITLE
feat(nervous-system-tools): No TODOs in generated proposal summary.

### DIFF
--- a/testnet/tools/nns-tools/lib/proposals.sh
+++ b/testnet/tools/nns-tools/lib/proposals.sh
@@ -96,11 +96,6 @@ __Source Code__: [$NEXT_COMMIT][new-commit]
 [new-commit]: https://github.com/dfinity/ic/tree/$NEXT_COMMIT
 
 
-## Features, Fixes, and Optimizations
-
-TODO TO BE FILLED OUT BY THE PROPOSER
-
-
 ## New Commits
 
 \`\`\`
@@ -204,11 +199,6 @@ __Proposer__: $PROPOSER\\
 __Source Code__: [$NEXT_COMMIT][new-commit]
 
 [new-commit]: https://github.com/dfinity/ic/tree/$NEXT_COMMIT
-
-
-## Features, Fixes, and Optimizations
-
-TODO TO BE FILLED OUT BY THE PROPOSER
 
 
 ## New Commits


### PR DESCRIPTION
# Motivation

Previously, the release tsar would manually fill out the "Features, Fixes, and Optimizations" section, but this doesn't seem to add much value, because what they more or less do is copy a subset of commit messages from the "New Commits" section. This would only be valuable if the release tsar does some additional interpretation of the commit messages to make it more understandable to a broader audience, but this rarely happens.

At the same time, manually populating this section takes time, and takes up space (which could be considered "spam" or "noise").

Therefore, the NNS team decided (by unanimous consent!) to get rid of this section entirely.

In short, this streamlines the process, and makes proposal summaries more concise.

One recent change that makes us revisit this now: Conventional Commit prefixes are now required on all ic repo PRs. This makes it really easy for people to filter out "boring" commits, and quickly zero in on the more interesting ones in the "New Commits" list. E.g. PR #1647.

# Impact

This means that someone can immediately go to the next step (submitting the proposal) without even looking at the generated proposal summary. Based on the aforementioned poll, this does not seem too risky to the NNS team.

FWIW, the submission script still displays proposal summary, and asks the operator (i.e. release tsar) to confirm.

At least in the near future, the release tsar should probably at least scan the generated summary before trying submitting it.

# Possible Future Work (no promises)

Instead of having to run two separate commands, generating the proposal summary, and submitting the proposal could be just one command (but still with printing the summary to the terminal, and confirmation).

It would be great if we could have "compound" aka multi-step proposals that do multiple actions (e.g. upgrades) in a single proposal. Yvonne said she experiences proposal fatigue, and this is probably also true for other neurons.