### PR TITLE
fix(NODE-1483): query_nns_nodes bug

### DIFF
--- a/ic-os/components/misc/fetch-property.sh
+++ b/ic-os/components/misc/fetch-property.sh
@@ -25,7 +25,7 @@ Arguments:
   -c=, --config=        mandatory: specify the configuration file to read from
   -h, --help            show this help message and exit
   -k=, --key=           mandatory: specify the property key
-  -m=, --metric=        mandatory: specify the metric name
+  -m=, --metric=        optional: specify the metric name (required if metrics.sh exists)
 '
             exit 1
             ;;
@@ -45,8 +45,13 @@ Arguments:
 done
 
 function validate_arguments() {
-    if [ "${CONFIG}" == "" -o "${KEY}" == "" -o "${METRIC}" == "" ]; then
+    if [ -z "${CONFIG}" ] || [ -z "${KEY}" ]; then
         $0 --help
+    fi
+
+    if [ -f "/opt/ic/bin/metrics.sh" ] && [ -z "${METRIC:-}" ]; then
+        echo "Error: METRIC is required when metrics.sh exists."
+        exit 1
     fi
 }
 
@@ -67,16 +72,16 @@ try_write_metric() {
 function fetch_property() {
     PROPERTY=$(jq -r "$(echo ${KEY})" ${CONFIG})
 
-    if [ -z "${PROPERTY}" -o "${PROPERTY}" == "null" ]; then
+    if [ -z "${PROPERTY}" ] || [ "${PROPERTY}" == "null" ]; then
         write_log "ERROR: Unable to fetch property: ${KEY}"
-        try_write_metric "$(echo ${METRIC})" \
+        try_write_metric "$(echo ${METRIC:-})" \
             "1" \
             "Property: $(echo ${KEY})" \
             "gauge"
         exit 1
     else
         write_log "Using property: ${PROPERTY}"
-        try_write_metric "$(echo ${METRIC})" \
+        try_write_metric "$(echo ${METRIC:-})" \
             "0" \
             "Property: $(echo ${KEY})" \
             "gauge"

--- a/ic-os/components/setupos-scripts/check-network.sh
+++ b/ic-os/components/setupos-scripts/check-network.sh
@@ -170,7 +170,7 @@ function ping_ipv6_gateway() {
 
 function assemble_nns_nodes_list() {
     NNS_URL_STRING=$(/opt/ic/bin/fetch-property.sh --key=.nns.url --config=${DEPLOYMENT})
-    IFS=',' read -r -a NNS_URL_LIST <<< "$NNS_URL_STRING"
+    IFS=',' read -r -a NNS_URL_LIST <<<"$NNS_URL_STRING"
 }
 
 function query_nns_nodes() {


### PR DESCRIPTION
[NODE-1483](https://dfinity.atlassian.net/browse/NODE-1483)

Two bugs exist in assemble_nns_nodes_list and fetch_property. In assemble_nns_nodes_list, fetch-property is called without passing a metric value, which causes the call to fail to populate NNS_URL_STRING.

Then, when query_nns_nodes was called, the for loop was never entered and no failure was caught. 


This PR updates fetch-property to make the metric field optional if metrics.sh does not exist and it also refactors query_nns_nodes to fail if NNS_URL_LIST is empty.

I tested this change on bare metal 👍 

[NODE-1483]: https://dfinity.atlassian.net/browse/NODE-1483?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ