### PR TITLE
feat(sns): Allow UpgradeToNext proposals to run concurrently

### DIFF
--- a/rs/nervous_system/integration_tests/src/pocket_ic_helpers.rs
+++ b/rs/nervous_system/integration_tests/src/pocket_ic_helpers.rs
@@ -198,10 +198,10 @@ pub fn propose_to_set_network_economics_and_wait(
 
 pub fn add_wasms_to_sns_wasm(
     pocket_ic: &PocketIc,
-    with_mainnet_ledger_wasms: bool,
+    with_mainnet_sns_canister_wasms: bool,
 ) -> Result<BTreeMap<SnsCanisterType, (ProposalInfo, SnsWasm)>, String> {
     let (root_wasm, governance_wasm, swap_wasm, index_wasm, ledger_wasm, archive_wasm) =
-        if with_mainnet_ledger_wasms {
+        if with_mainnet_sns_canister_wasms {
             (
                 ensure_sns_wasm_gzipped(build_mainnet_root_sns_wasm()),
                 ensure_sns_wasm_gzipped(build_mainnet_governance_sns_wasm()),

--- a/rs/nervous_system/integration_tests/tests/sns_release_qualification.rs
+++ b/rs/nervous_system/integration_tests/tests/sns_release_qualification.rs
@@ -13,6 +13,7 @@ use ic_nns_test_utils::sns_wasm::{
     build_ledger_sns_wasm, build_root_sns_wasm, build_swap_sns_wasm, create_modified_sns_wasm,
     ensure_sns_wasm_gzipped,
 };
+use ic_sns_root::GetSnsCanistersSummaryRequest;
 use ic_sns_swap::pb::v1::Lifecycle;
 use ic_sns_wasm::pb::v1::SnsCanisterType;
 

--- a/rs/sns/governance/canister/canister.rs
+++ b/rs/sns/governance/canister/canister.rs
@@ -32,8 +32,8 @@ use ic_nervous_system_runtime::DfnRuntime;
 use ic_nns_constants::LEDGER_CANISTER_ID as NNS_LEDGER_CANISTER_ID;
 #[cfg(feature = "test")]
 use ic_sns_governance::pb::v1::{
-    AddMaturityRequest, AddMaturityResponse, GovernanceError, MintTokensRequest,
-    MintTokensResponse, Neuron,
+    AddMaturityRequest, AddMaturityResponse, AdvanceTargetVersionRequest,
+    AdvanceTargetVersionResponse, GovernanceError, MintTokensRequest, MintTokensResponse, Neuron,
 };
 use ic_sns_governance::{
     governance::{
@@ -524,6 +524,7 @@ fn get_running_sns_version_(_: GetRunningSnsVersionRequest) -> GetRunningSnsVers
     GetRunningSnsVersionResponse {
         deployed_version: governance().proto.deployed_version.clone(),
         pending_version: governance().proto.pending_version.clone(),
+        target_version: governance().proto.target_version.clone(),
     }
 }
 
@@ -724,6 +725,14 @@ fn add_maturity() {
 #[candid_method(update, rename = "add_maturity")]
 fn add_maturity_(request: AddMaturityRequest) -> AddMaturityResponse {
     governance_mut().add_maturity(request)
+}
+
+#[cfg(feature = "test")]
+#[export_name = "canister_update advance_target_version"]
+fn advance_target_version(request: AdvanceTargetVersionRequest) {
+    over(candid_one, |request: AdvanceTargetVersionRequest| {
+        AdvanceTargetVersionResponse {}
+    })
 }
 
 /// Mints tokens for testing

--- a/rs/sns/governance/canister/canister.rs
+++ b/rs/sns/governance/canister/canister.rs
@@ -735,6 +735,14 @@ fn advance_target_version(request: AdvanceTargetVersionRequest) {
     })
 }
 
+#[export_name = "canister_update upgrade_to_next"]
+fn upgrade_to_next(request: UpgradeToNextRequest) {
+    over(candid_one, |request: UpgradeToNextRequest| {
+        todo!();
+        UpgradeToNextResponse {}
+    })
+}
+
 /// Mints tokens for testing
 #[cfg(feature = "test")]
 #[export_name = "canister_update mint_tokens"]

--- a/rs/sns/governance/canister/governance.did
+++ b/rs/sns/governance/canister/governance.did
@@ -258,6 +258,7 @@ type GetProposalResponse = record {
 type GetRunningSnsVersionResponse = record {
   deployed_version : opt Version;
   pending_version : opt UpgradeInProgress;
+  target_version : opt Version;
 };
 
 type GetSnsInitializationParametersResponse = record {
@@ -273,6 +274,7 @@ type Governance = record {
   parameters : opt NervousSystemParameters;
   is_finalizing_disburse_maturity : opt bool;
   deployed_version : opt Version;
+  target_version : opt Version;
   sns_initialization_parameters : text;
   latest_reward_event : opt RewardEvent;
   pending_version : opt UpgradeInProgress;

--- a/rs/sns/governance/canister/governance_test.did
+++ b/rs/sns/governance/canister/governance_test.did
@@ -267,6 +267,7 @@ type GetProposalResponse = record {
 type GetRunningSnsVersionResponse = record {
   deployed_version : opt Version;
   pending_version : opt UpgradeInProgress;
+  target_version : opt Version;
 };
 
 type GetSnsInitializationParametersResponse = record {
@@ -282,6 +283,7 @@ type Governance = record {
   parameters : opt NervousSystemParameters;
   is_finalizing_disburse_maturity : opt bool;
   deployed_version : opt Version;
+  target_version : opt Version;
   sns_initialization_parameters : text;
   latest_reward_event : opt RewardEvent;
   pending_version : opt UpgradeInProgress;

--- a/rs/sns/governance/proto/ic_sns_governance/pb/v1/governance.proto
+++ b/rs/sns/governance/proto/ic_sns_governance/pb/v1/governance.proto
@@ -1425,7 +1425,9 @@ message Governance {
   }
 
   // Version SNS is in process of upgrading to.
-  UpgradeInProgress pending_version = 24;
+  // TODO: this probably needs to go into a new field, pending_upgrades or something.
+  optional UpgradeInProgress pending_version = 24;
+  repeated UpgradeInProgress queued_versions = 28;
 
   // True if the heartbeat function is currently finalizing disburse maturity, meaning
   // that it should finish before being called again.
@@ -2148,5 +2150,13 @@ message AdvanceTargetVersionRequest {
 }
 
 message AdvanceTargetVersionResponse {
+
+}
+
+message UpgradeToNextRequest {
+
+}
+
+message UpgradeToNextResponse {
 
 }

--- a/rs/sns/governance/proto/ic_sns_governance/pb/v1/governance.proto
+++ b/rs/sns/governance/proto/ic_sns_governance/pb/v1/governance.proto
@@ -1449,6 +1449,8 @@ message Governance {
 
   reserved "migrated_root_wasm_memory_limit";
   reserved 27;
+
+  Governance.Version target_version = 28;
 }
 
 // Request message for 'get_metadata'.
@@ -1480,6 +1482,8 @@ message GetRunningSnsVersionResponse {
   Governance.Version deployed_version = 1;
   // The upgrade in progress, if any.
   Governance.UpgradeInProgress pending_version = 2;
+  // The target version that the SNS is in the process of upgrading to.
+  Governance.Version target_version = 3;
 }
 
 // Request to fail an upgrade proposal that is Adopted but not Executed or
@@ -2137,4 +2141,12 @@ message Account {
   // The subaccount of the account. If not set then the default
   // subaccount (all bytes set to 0) is used.
   optional Subaccount subaccount = 2;
+}
+
+message AdvanceTargetVersionRequest {
+
+}
+
+message AdvanceTargetVersionResponse {
+
 }

--- a/rs/sns/governance/src/gen/ic_sns_governance.pb.v1.rs
+++ b/rs/sns/governance/src/gen/ic_sns_governance.pb.v1.rs
@@ -1644,6 +1644,8 @@ pub struct Governance {
     pub is_finalizing_disburse_maturity: ::core::option::Option<bool>,
     #[prost(message, optional, tag = "26")]
     pub maturity_modulation: ::core::option::Option<governance::MaturityModulation>,
+    #[prost(message, optional, tag = "28")]
+    pub target_version: ::core::option::Option<governance::Version>,
 }
 /// Nested message and enum types in `Governance`.
 pub mod governance {
@@ -2034,6 +2036,9 @@ pub struct GetRunningSnsVersionResponse {
     /// The upgrade in progress, if any.
     #[prost(message, optional, tag = "2")]
     pub pending_version: ::core::option::Option<governance::UpgradeInProgress>,
+    /// The target version that the SNS is in the process of upgrading to.
+    #[prost(message, optional, tag = "3")]
+    pub target_version: ::core::option::Option<governance::Version>,
 }
 /// Request to fail an upgrade proposal that is Adopted but not Executed or
 /// Failed if it is past the time when it should have been marked as failed.
@@ -3330,6 +3335,26 @@ pub struct Account {
     #[prost(message, optional, tag = "2")]
     pub subaccount: ::core::option::Option<Subaccount>,
 }
+#[derive(
+    candid::CandidType,
+    candid::Deserialize,
+    comparable::Comparable,
+    Clone,
+    Copy,
+    PartialEq,
+    ::prost::Message,
+)]
+pub struct AdvanceTargetVersionRequest {}
+#[derive(
+    candid::CandidType,
+    candid::Deserialize,
+    comparable::Comparable,
+    Clone,
+    Copy,
+    PartialEq,
+    ::prost::Message,
+)]
+pub struct AdvanceTargetVersionResponse {}
 /// The different types of neuron permissions, i.e., privileges to modify a neuron,
 /// that principals can have.
 #[derive(

--- a/rs/sns/governance/src/gen/ic_sns_governance.pb.v1.rs
+++ b/rs/sns/governance/src/gen/ic_sns_governance.pb.v1.rs
@@ -1636,8 +1636,11 @@ pub struct Governance {
     #[prost(message, optional, tag = "23")]
     pub deployed_version: ::core::option::Option<governance::Version>,
     /// Version SNS is in process of upgrading to.
+    /// TODO: this probably needs to go into a new field, pending_upgrades or something.
     #[prost(message, optional, tag = "24")]
     pub pending_version: ::core::option::Option<governance::UpgradeInProgress>,
+    #[prost(message, repeated, tag = "28")]
+    pub queued_versions: ::prost::alloc::vec::Vec<governance::UpgradeInProgress>,
     /// True if the heartbeat function is currently finalizing disburse maturity, meaning
     /// that it should finish before being called again.
     #[prost(bool, optional, tag = "25")]

--- a/rs/sns/governance/src/proposal.rs
+++ b/rs/sns/governance/src/proposal.rs
@@ -2489,6 +2489,7 @@ mod tests {
             pending_version: None,
             is_finalizing_disburse_maturity: None,
             maturity_modulation: None,
+            target_version: None,
         }
     }
 

--- a/rs/sns/governance/src/request_impls.rs
+++ b/rs/sns/governance/src/request_impls.rs
@@ -1,82 +1,79 @@
 use ic_nervous_system_clients::Request;
 
-use crate::pb::v1::{
-    ClaimSwapNeuronsRequest, ClaimSwapNeuronsResponse, FailStuckUpgradeInProgressRequest,
-    FailStuckUpgradeInProgressResponse, GetMaturityModulationRequest,
-    GetMaturityModulationResponse, GetMetadataRequest, GetMetadataResponse, GetMode,
-    GetModeResponse, GetNeuronResponse, GetProposalResponse, GetRunningSnsVersionResponse,
-    GetSnsInitializationParametersRequest, GetSnsInitializationParametersResponse,
-    ListNeuronsResponse, ListProposalsResponse, ManageNeuronResponse,
-};
-
-impl Request for ClaimSwapNeuronsRequest {
-    type Response = ClaimSwapNeuronsResponse;
+impl Request for crate::pb::v1::ClaimSwapNeuronsRequest {
+    type Response = crate::pb::v1::ClaimSwapNeuronsResponse;
     const METHOD: &'static str = "claim_swap_neurons";
     const UPDATE: bool = true;
 }
 
-impl Request for FailStuckUpgradeInProgressRequest {
-    type Response = FailStuckUpgradeInProgressResponse;
+impl Request for crate::pb::v1::FailStuckUpgradeInProgressRequest {
+    type Response = crate::pb::v1::FailStuckUpgradeInProgressResponse;
     const METHOD: &'static str = "fail_stuck_upgrade_in_progress";
     const UPDATE: bool = true;
 }
 
-impl Request for GetMaturityModulationRequest {
-    type Response = GetMaturityModulationResponse;
+impl Request for crate::pb::v1::GetMaturityModulationRequest {
+    type Response = crate::pb::v1::GetMaturityModulationResponse;
     const METHOD: &'static str = "get_maturity_modulation";
     const UPDATE: bool = false;
 }
 
-impl Request for GetMetadataRequest {
-    type Response = GetMetadataResponse;
+impl Request for crate::pb::v1::GetMetadataRequest {
+    type Response = crate::pb::v1::GetMetadataResponse;
     const METHOD: &'static str = "get_metadata";
     const UPDATE: bool = false;
 }
 
-impl Request for GetSnsInitializationParametersRequest {
-    type Response = GetSnsInitializationParametersResponse;
+impl Request for crate::pb::v1::GetSnsInitializationParametersRequest {
+    type Response = crate::pb::v1::GetSnsInitializationParametersResponse;
     const METHOD: &'static str = "get_sns_initialization_parameters";
     const UPDATE: bool = false;
 }
 
-impl Request for GetMode {
-    type Response = GetModeResponse;
+impl Request for crate::pb::v1::GetMode {
+    type Response = crate::pb::v1::GetModeResponse;
     const METHOD: &'static str = "get_mode";
     const UPDATE: bool = false;
 }
 
 impl Request for crate::pb::v1::GetNeuron {
-    type Response = GetNeuronResponse;
+    type Response = crate::pb::v1::GetNeuronResponse;
     const METHOD: &'static str = "get_neuron";
     const UPDATE: bool = false;
 }
 
 impl Request for crate::pb::v1::GetProposal {
-    type Response = GetProposalResponse;
+    type Response = crate::pb::v1::GetProposalResponse;
     const METHOD: &'static str = "get_proposal";
     const UPDATE: bool = false;
 }
 
 impl Request for crate::pb::v1::ListNeurons {
-    type Response = ListNeuronsResponse;
+    type Response = crate::pb::v1::ListNeuronsResponse;
     const METHOD: &'static str = "list_neurons";
     const UPDATE: bool = false;
 }
 
 impl Request for crate::pb::v1::ListProposals {
-    type Response = ListProposalsResponse;
+    type Response = crate::pb::v1::ListProposalsResponse;
     const METHOD: &'static str = "list_proposals";
     const UPDATE: bool = false;
 }
 
 impl Request for crate::pb::v1::ManageNeuron {
-    type Response = ManageNeuronResponse;
+    type Response = crate::pb::v1::ManageNeuronResponse;
     const METHOD: &'static str = "manage_neuron";
     const UPDATE: bool = true;
 }
 
 impl Request for crate::pb::v1::GetRunningSnsVersionRequest {
-    type Response = GetRunningSnsVersionResponse;
+    type Response = crate::pb::v1::GetRunningSnsVersionResponse;
     const METHOD: &'static str = "get_running_sns_version";
+    const UPDATE: bool = false;
+}
+
+impl Request for crate::pb::v1::AdvanceTargetVersionRequest {
+    type Response = crate::pb::v1::AdvanceTargetVersionResponse;
+    const METHOD: &'static str = "advance_target_version";
     const UPDATE: bool = true;
 }

--- a/rs/sns/governance/src/sns_upgrade.rs
+++ b/rs/sns/governance/src/sns_upgrade.rs
@@ -27,6 +27,7 @@ pub(crate) async fn get_upgrade_params(
     env: &dyn Environment,
     root_canister_id: CanisterId,
     current_version: &Version,
+    
 ) -> Result<UpgradeSnsParams, String> {
     let next_version = match get_next_version(env, &current_version.clone()).await {
         Some(next) => next,


### PR DESCRIPTION
## Problem

UpgradeToNext proposals have a global lock, so only one can run at a time.

## Solution

Replace the global lock with a global queue