### PR TITLE
refactor(ckbtc): Do not store full transaction data in state

### DIFF
--- a/rs/bitcoin/kyt/btc_kyt_canister.did
+++ b/rs/bitcoin/kyt/btc_kyt_canister.did
@@ -42,8 +42,8 @@ type CheckTransactionRetriable = variant {
 type CheckTransactionIrrecoverableError = variant {
     // Response size is too large (>400kB) when fetching transaction data.
     ResponseTooLarge : record { txid: blob };
-    // Invalid transaction, e.g. error decoding transaction or transaction id mismatch, etc.
-    InvalidTransaction : text;
+    // Invalid transaction id.
+    InvalidTransactionId : text;
 };
 
 type InitArg = record {

--- a/rs/bitcoin/kyt/src/dashboard/tests.rs
+++ b/rs/bitcoin/kyt/src/dashboard/tests.rs
@@ -130,7 +130,7 @@ fn test_pagination() {
         state::set_fetch_status(
             txid,
             state::FetchTxStatus::Fetched(state::FetchedTx {
-                tx: mock_transaction.clone(),
+                tx: mock_transaction.clone().try_into().unwrap(),
                 input_addresses: vec![],
             }),
         );

--- a/rs/bitcoin/kyt/src/fetch.rs
+++ b/rs/bitcoin/kyt/src/fetch.rs
@@ -1,6 +1,4 @@
-use crate::state::{
-    FetchGuardError, FetchTxStatus, FetchedTx, HttpGetTxError, TransactionInputOutput,
-};
+use crate::state::{FetchGuardError, FetchTxStatus, FetchedTx, HttpGetTxError, TransactionKytData};
 use crate::types::{CheckTransactionResponse, CheckTransactionRetriable, CheckTransactionStatus};
 use crate::{blocklist_contains, state};
 use bitcoin::Transaction;
@@ -112,7 +110,7 @@ pub trait FetchEnv {
         match self.http_get_tx(txid, max_response_bytes).await {
             Ok(tx) => {
                 let input_addresses = tx.input.iter().map(|_| None).collect();
-                match TransactionInputOutput::try_from(tx) {
+                match TransactionKytData::try_from(tx) {
                     Ok(tx) => {
                         let fetched = FetchedTx {
                             tx,

--- a/rs/bitcoin/kyt/src/lib.rs
+++ b/rs/bitcoin/kyt/src/lib.rs
@@ -29,9 +29,7 @@ impl From<(Txid, HttpGetTxError)> for CheckTransactionResponse {
             HttpGetTxError::ResponseTooLarge => {
                 (CheckTransactionIrrecoverableError::ResponseTooLarge { txid }).into()
             }
-            _ => {
-                CheckTransactionIrrecoverableError::InvalidTransaction(format!("{:?}", err)).into()
-            }
+            _ => CheckTransactionRetriable::TransientInternalError(format!("{:?}", err)).into(),
         }
     }
 }

--- a/rs/bitcoin/kyt/src/main.rs
+++ b/rs/bitcoin/kyt/src/main.rs
@@ -62,7 +62,9 @@ async fn check_transaction(args: CheckTransactionArgs) -> CheckTransactionRespon
                 check_transaction_inputs(txid).await
             }
         }
-        Err(err) => CheckTransactionIrrecoverableError::InvalidTransaction(err.to_string()).into(),
+        Err(err) => {
+            CheckTransactionIrrecoverableError::InvalidTransactionId(err.to_string()).into()
+        }
     }
 }
 

--- a/rs/bitcoin/kyt/src/state.rs
+++ b/rs/bitcoin/kyt/src/state.rs
@@ -46,7 +46,7 @@ pub enum FetchTxStatus {
 /// input address will be computed and filled in.
 #[derive(Clone, Debug)]
 pub struct FetchedTx {
-    pub tx: TransactionInputOutput,
+    pub tx: TransactionKytData,
     pub input_addresses: Vec<Option<Address>>,
 }
 
@@ -54,7 +54,7 @@ pub struct FetchedTx {
 /// store relevant bits, including inputs (which are previous
 /// outputs) and output addresses.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
-pub struct TransactionInputOutput {
+pub struct TransactionKytData {
     pub inputs: Vec<PreviousOutput>,
     pub outputs: Vec<Address>,
 }
@@ -65,7 +65,7 @@ pub struct PreviousOutput {
     pub vout: u32,
 }
 
-impl TryFrom<Transaction> for TransactionInputOutput {
+impl TryFrom<Transaction> for TransactionKytData {
     type Error = bitcoin::address::FromScriptError;
 
     fn try_from(tx: Transaction) -> Result<Self, Self::Error> {

--- a/rs/bitcoin/kyt/src/state.rs
+++ b/rs/bitcoin/kyt/src/state.rs
@@ -73,7 +73,7 @@ impl TryFrom<Transaction> for TransactionInputOutput {
             .input
             .iter()
             .map(|input| PreviousOutput {
-                txid: Txid::from(*(input.previous_output.txid.as_ref() as &[u8; 32])),
+                txid: Txid::from(*(input.previous_output.txid.as_ref())),
                 vout: input.previous_output.vout,
             })
             .collect();

--- a/rs/bitcoin/kyt/src/state.rs
+++ b/rs/bitcoin/kyt/src/state.rs
@@ -50,7 +50,7 @@ pub struct FetchedTx {
     pub input_addresses: Vec<Option<Address>>,
 }
 
-/// Instead of storing the full Transaction data, we only
+/// Instead of storing the full transaction data, we only
 /// store relevant bits, including inputs (which are previous
 /// outputs) and output addresses.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]

--- a/rs/bitcoin/kyt/src/state.rs
+++ b/rs/bitcoin/kyt/src/state.rs
@@ -73,7 +73,7 @@ impl TryFrom<Transaction> for TransactionKytData {
             .input
             .iter()
             .map(|input| PreviousOutput {
-                txid: Txid::from(*(input.previous_output.txid.as_ref())),
+                txid: Txid::from(*(input.previous_output.txid.as_ref() as &[u8; 32])),
                 vout: input.previous_output.vout,
             })
             .collect();

--- a/rs/bitcoin/kyt/src/state/tests.rs
+++ b/rs/bitcoin/kyt/src/state/tests.rs
@@ -57,7 +57,7 @@ fn test_fetch_status() {
     set_fetch_status(
         txid_1,
         FetchTxStatus::Fetched(FetchedTx {
-            tx: tx.clone(),
+            tx: tx.clone().try_into().unwrap(),
             input_addresses: vec![None; 2],
         }),
     );

--- a/rs/bitcoin/kyt/src/types.rs
+++ b/rs/bitcoin/kyt/src/types.rs
@@ -55,8 +55,8 @@ pub enum CheckTransactionRetriable {
 pub enum CheckTransactionIrrecoverableError {
     /// Response size is too large (> `RETRY_MAX_RESPONSE_BYTES`) when fetching the transaction data of a txid.
     ResponseTooLarge { txid: Vec<u8> },
-    /// Invalid transaction, e.g. error decoding transaction or transaction id mismatch, etc.
-    InvalidTransaction(String),
+    /// Invalid transaction id because it fails to decode.
+    InvalidTransactionId(String),
 }
 
 impl From<CheckTransactionIrrecoverableError> for CheckTransactionResponse {

--- a/rs/bitcoin/kyt/tests/tests.rs
+++ b/rs/bitcoin/kyt/tests/tests.rs
@@ -378,7 +378,7 @@ fn test_check_transaction_error() {
     assert!(matches!(
         decode::<CheckTransactionResponse>(&result),
         CheckTransactionResponse::Unknown(CheckTransactionStatus::Error(
-            CheckTransactionIrrecoverableError::InvalidTransaction(_)
+            CheckTransactionIrrecoverableError::InvalidTransactionId(_)
         ))
     ));
 


### PR DESCRIPTION
Instead of storing full transaction data in the state, we keep only relevant bits such as output addresses, and the previous output of inputs.

Also `InvalidTransaction` error is changed to `InvalidTransactionId`, and most `HttpGetTxError` are treated as retriable except `ResponseTooLarge`.