### PR TITLE
fix: Defragment correct state

### DIFF
--- a/rs/state_manager/src/lib.rs
+++ b/rs/state_manager/src/lib.rs
@@ -2480,7 +2480,7 @@ impl StateManagerImpl {
                 self.lsmt_status,
             )
         };
-        let (cp_layout, mut checkpointed_state, has_downgrade) = match result {
+        let (cp_layout, checkpointed_state, has_downgrade) = match result {
             Ok(response) => response,
             Err(CheckpointError::AlreadyExists(_)) => {
                 warn!(
@@ -2539,8 +2539,8 @@ impl StateManagerImpl {
                 .start_timer();
 
             // This step is a functional no-op, but results in a cleaner memory layout that is ultimately faster to iterate over.
-            let canisters = std::mem::take(&mut checkpointed_state.canister_states);
-            checkpointed_state.canister_states = canisters.into_iter().collect();
+            let canisters = std::mem::take(&mut state.canister_states);
+            state.canister_states = canisters.into_iter().collect();
         }
         {
             let _timer = self


### PR DESCRIPTION
This is a follow-up to commit a438bb7. The idea of the previous commit was to defragment the memory layout of the list of canisters. This fix makes sure we actually defragment the correct state, namely the one that has been fragmented in earlier rounds. The previous PR was perfectly safe, but did not provide the desired performance benefit.