### PR TITLE
chore(NODE-1474): Remove ipv6_address and make ipv6_prefix required in config tool

### DIFF
--- a/rs/ic_os/config/src/lib.rs
+++ b/rs/ic_os/config/src/lib.rs
@@ -54,10 +54,9 @@ mod tests {
     #[test]
     fn test_serialize_and_deserialize() {
         let network_settings = NetworkSettings {
-            ipv6_prefix: None,
-            ipv6_address: None,
+            ipv6_prefix: "2a00:fb01:400:200".to_string(),
             ipv6_prefix_length: 64_u8,
-            ipv6_gateway: "2001:db8::1".parse().unwrap(),
+            ipv6_gateway: "2a00:fb01:400:200::1".parse().unwrap(),
             ipv4_address: None,
             ipv4_gateway: None,
             ipv4_prefix_length: None,

--- a/rs/ic_os/config/src/main.rs
+++ b/rs/ic_os/config/src/main.rs
@@ -65,7 +65,6 @@ pub fn main() -> Result<()> {
             let config_ini_settings = get_config_ini_settings(&config_ini_path)?;
             let ConfigIniSettings {
                 ipv6_prefix,
-                ipv6_address,
                 ipv6_prefix_length,
                 ipv6_gateway,
                 ipv4_address,
@@ -80,7 +79,6 @@ pub fn main() -> Result<()> {
 
             let network_settings = NetworkSettings {
                 ipv6_prefix,
-                ipv6_address,
                 ipv6_prefix_length,
                 ipv6_gateway,
                 ipv4_address,

--- a/rs/ic_os/config/src/types.rs
+++ b/rs/ic_os/config/src/types.rs
@@ -83,10 +83,7 @@ pub struct BackupSpoolSettings {
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 pub struct NetworkSettings {
-    // Config.ini can specify ipv6_prefix and ipv6_gateway, or just an ipv6_address.
-    // ipv6_address takes precedence. Some tests provide only ipv6_address.
-    pub ipv6_prefix: Option<String>,
-    pub ipv6_address: Option<Ipv6Addr>,
+    pub ipv6_prefix: String,
     pub ipv6_prefix_length: u8,
     pub ipv6_gateway: Ipv6Addr,
     pub ipv4_address: Option<Ipv4Addr>,

--- a/rs/ic_os/network/src/info.rs
+++ b/rs/ic_os/network/src/info.rs
@@ -6,11 +6,7 @@ use config::config_ini::ConfigMap;
 
 #[derive(Debug)]
 pub struct NetworkInfo {
-    // Config files can specify ipv6 prefix, address and prefix, or just address.
-    // ipv6_address takes precedence. Some tests provide only the address.
-    // Should be kept as a string until parsing later.
     pub ipv6_prefix: Option<String>,
-    pub ipv6_address: Option<Ipv6Addr>,
     pub ipv6_subnet: u8,
     pub ipv6_gateway: Ipv6Addr,
 }
@@ -65,7 +61,6 @@ impl NetworkInfo {
             ipv6_prefix,
             ipv6_subnet,
             ipv6_gateway,
-            ipv6_address,
         })
     }
 }

--- a/rs/ic_os/network/src/lib.rs
+++ b/rs/ic_os/network/src/lib.rs
@@ -25,11 +25,6 @@ pub fn generate_network_config(
     node_type: NodeType,
     output_directory: &Path,
 ) -> Result<()> {
-    if let Some(address) = network_info.ipv6_address {
-        eprintln!("Found ipv6 address in config");
-        return generate_systemd_config_files(output_directory, network_info, None, &address);
-    };
-
     let deployment_name = deployment_name
         .context("Error: Deployment name not found when attempting to generate mac address")?;
 


### PR DESCRIPTION
ipv6_address isn't used in testing and ipv6_prefix is required and should not be optional in NetworkSettings or NetworkInfo