### PR TITLE
chore: [MR-615] Refactor list_state_heights and make it an associated method

### DIFF
--- a/rs/interfaces/state_manager/mocks/src/lib.rs
+++ b/rs/interfaces/state_manager/mocks/src/lib.rs
@@ -46,11 +46,6 @@ mock! {
 
         fn deliver_state_certification(&self, certification: Certification);
 
-        fn list_state_heights(
-            &self,
-            cert_mask: CertificationMask,
-        ) -> Vec<Height>;
-
         fn remove_states_below(&self, height: Height);
 
         fn remove_inmemory_states_below(&self, height: Height);

--- a/rs/interfaces/state_manager/mocks/src/lib.rs
+++ b/rs/interfaces/state_manager/mocks/src/lib.rs
@@ -1,7 +1,7 @@
 use ic_crypto_tree_hash::{LabeledTree, MixedHashTree};
 use ic_interfaces_state_manager::{
-    CertificationMask, CertificationScope, CertifiedStateSnapshot, Labeled, StateHashError,
-    StateManager, StateManagerResult, StateReader,
+    CertificationScope, CertifiedStateSnapshot, Labeled, StateHashError, StateManager,
+    StateManagerResult, StateReader,
 };
 use ic_replicated_state::ReplicatedState;
 use ic_types::{

--- a/rs/interfaces/state_manager/src/lib.rs
+++ b/rs/interfaces/state_manager/src/lib.rs
@@ -222,23 +222,6 @@ pub trait StateManager: StateReader {
         cup_interval_length: Height,
     );
 
-    /// Returns the list of heights corresponding to accessible states matching
-    /// the mask.  E.g. `list_state_heights(CERT_ANY)` will return all
-    /// accessible states.
-    ///
-    /// Note that the initial state at height 0 is considered uncertified from
-    /// the State Manager point of view.  This is because the protocol requires
-    /// each replica to individually obtain the initial state using some
-    /// out-of-band mechanism (i.e., not state sync).  Also note that the
-    /// authenticity of this initial state will be verified by some protocol
-    /// external to this component.
-    ///
-    /// The list of heights is guaranteed to be
-    /// * Non-empty if `cert_mask = CERT_ANY` as it will contain at least height
-    ///   0 even if no states were committed yet.
-    /// * Sorted in ascending order.
-    fn list_state_heights(&self, cert_mask: CertificationMask) -> Vec<Height>;
-
     /// Notify this state manager that states with heights strictly less than
     /// the specified `height` can be removed.
     ///

--- a/rs/state_manager/src/lib.rs
+++ b/rs/state_manager/src/lib.rs
@@ -3179,10 +3179,10 @@ impl StateManager for StateManagerImpl {
 
         let states = self.states.read();
 
-        let heights: BTreeSet<_> = self
-            .checkpoint_heights()
-            .into_iter()
-            .chain(states.snapshots.iter().map(|snapshot| snapshot.height))
+        let heights: BTreeSet<_> = states
+            .snapshots
+            .iter()
+            .map(|snapshot| snapshot.height)
             .filter(|h| {
                 matches(
                     states

--- a/rs/state_manager/src/lib.rs
+++ b/rs/state_manager/src/lib.rs
@@ -3159,10 +3159,6 @@ impl StateManager for StateManagerImpl {
         }
     }
 
-    /// # Panics
-    ///
-    /// This method panics if checkpoint labels can not be retrieved
-    /// from the disk.
     fn list_state_heights(&self, cert_mask: CertificationMask) -> Vec<Height> {
         let _timer = self
             .metrics

--- a/rs/state_manager/src/lib.rs
+++ b/rs/state_manager/src/lib.rs
@@ -32,9 +32,9 @@ use ic_interfaces_certified_stream_store::{
     CertifiedStreamStore, DecodeStreamError, EncodeStreamError,
 };
 use ic_interfaces_state_manager::{
-    CertificationMask, CertificationScope, CertifiedStateSnapshot, Labeled,
-    PermanentStateHashError::*, StateHashError, StateManager, StateManagerError,
-    StateManagerResult, StateReader, TransientStateHashError::*, CERT_CERTIFIED, CERT_UNCERTIFIED,
+    CertificationScope, CertifiedStateSnapshot, Labeled, PermanentStateHashError::*,
+    StateHashError, StateManager, StateManagerError, StateManagerResult, StateReader,
+    TransientStateHashError::*,
 };
 use ic_logger::{debug, error, fatal, info, warn, ReplicaLogger};
 use ic_metrics::{buckets::decimal_buckets, MetricsRegistry};
@@ -2406,17 +2406,24 @@ impl StateManagerImpl {
     /// * Non-empty if `cert_mask = CERT_ANY` as it will contain at least height
     ///   0 even if no states were committed yet.
     /// * Sorted in ascending order.
-    fn list_state_heights(&self, cert_mask: CertificationMask) -> Vec<Height> {
+    #[allow(dead_code)]
+    pub fn list_state_heights(
+        &self,
+        cert_mask: ic_interfaces_state_manager::CertificationMask,
+    ) -> Vec<Height> {
         let _timer = self
             .metrics
             .api_call_duration
             .with_label_values(&["list_state_heights"])
             .start_timer();
 
-        fn matches(cert: Option<&Certification>, mask: CertificationMask) -> bool {
+        fn matches(
+            cert: Option<&Certification>,
+            mask: ic_interfaces_state_manager::CertificationMask,
+        ) -> bool {
             match cert {
-                Some(_) => mask.is_set(CERT_CERTIFIED),
-                None => mask.is_set(CERT_UNCERTIFIED),
+                Some(_) => mask.is_set(ic_interfaces_state_manager::CERT_CERTIFIED),
+                None => mask.is_set(ic_interfaces_state_manager::CERT_UNCERTIFIED),
             }
         }
 

--- a/rs/state_manager/src/lib.rs
+++ b/rs/state_manager/src/lib.rs
@@ -2392,9 +2392,8 @@ impl StateManagerImpl {
         result
     }
 
-    /// Returns the list of heights corresponding to accessible states matching
-    /// the mask.  E.g. `list_state_heights(CERT_ANY)` will return all
-    /// accessible states.
+    /// Returns the list of heights corresponding to snapshots matching
+    /// the mask. E.g. `list_state_heights(CERT_ANY)` will return all snapshots.
     ///
     /// Note that the initial state at height 0 is considered uncertified from
     /// the State Manager point of view.  This is because the protocol requires

--- a/rs/test_utilities/src/state_manager.rs
+++ b/rs/test_utilities/src/state_manager.rs
@@ -4,10 +4,9 @@ use ic_interfaces_certified_stream_store::{
     CertifiedStreamStore, DecodeStreamError, EncodeStreamError,
 };
 use ic_interfaces_state_manager::{
-    CertificationMask, CertificationScope, CertifiedStateSnapshot, Labeled,
-    PermanentStateHashError::*, StateHashError, StateManager, StateManagerError,
-    StateManagerResult, StateReader, TransientStateHashError::*, CERT_ANY, CERT_CERTIFIED,
-    CERT_UNCERTIFIED,
+    CertificationScope, CertifiedStateSnapshot, Labeled, PermanentStateHashError::*,
+    StateHashError, StateManager, StateManagerError, StateManagerResult, StateReader,
+    TransientStateHashError::*,
 };
 use ic_interfaces_state_manager_mocks::MockStateManager;
 use ic_registry_subnet_type::SubnetType;
@@ -41,13 +40,6 @@ struct Snapshot {
 impl Snapshot {
     fn make_labeled_state(&self) -> Labeled<Arc<ReplicatedState>> {
         Labeled::new(self.height, self.state.clone())
-    }
-
-    fn certification_mask(&self) -> CertificationMask {
-        match self.certification {
-            Some(_) => CERT_CERTIFIED,
-            None => CERT_UNCERTIFIED,
-        }
     }
 }
 


### PR DESCRIPTION
Close [MR-615](https://dfinity.atlassian.net/browse/MR-615)

This PR (1) excludes checkpoint_heights from the result of list_state_heights and (2) removes it from the StateReader trait and make it an associated method.

[MR-615]: https://dfinity.atlassian.net/browse/MR-615?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ