### PR TITLE
feat: Increase install_code limit for application subnets

### DIFF
--- a/rs/config/src/subnet_config.rs
+++ b/rs/config/src/subnet_config.rs
@@ -60,13 +60,7 @@ const MAX_INSTRUCTIONS_PER_ROUND: NumInstructions = NumInstructions::new(7 * B);
 
 // Limit per `install_code` message. It's bigger than the limit for a regular
 // update call to allow for canisters with bigger state to be upgraded.
-// This is a temporary measure until a longer term solution that alleviates the
-// limitations with the current upgrade process is implemented.
-//
-// The value is picked to allow roughly for 4GB of state to be stored to stable
-// memory during upgrade. We know that we hit `MAX_INSTRUCTIONS_PER_MESSAGE`
-// with roughly 100MB of state, so we set the limit to 40x.
-const MAX_INSTRUCTIONS_PER_INSTALL_CODE: NumInstructions = NumInstructions::new(40 * 5 * B);
+const MAX_INSTRUCTIONS_PER_INSTALL_CODE: NumInstructions = NumInstructions::new(300 * B);
 
 // The limit on the number of instructions a slice of an `install_code` message
 // is allowed to executed.
@@ -343,35 +337,7 @@ impl SchedulerConfig {
     }
 
     pub fn verified_application_subnet() -> Self {
-        // When the `install_code` instruction limit on application subnets is
-        // also increased to 300B, then this line can be removed.
-        let max_instructions_per_install_code = NumInstructions::from(300 * B);
-        Self {
-            scheduler_cores: NUMBER_OF_EXECUTION_THREADS,
-            max_paused_executions: MAX_PAUSED_EXECUTIONS,
-            subnet_heap_delta_capacity: SUBNET_HEAP_DELTA_CAPACITY,
-            heap_delta_initial_reserve: HEAP_DELTA_INITIAL_RESERVE,
-            max_instructions_per_round: MAX_INSTRUCTIONS_PER_ROUND,
-            max_instructions_per_message: MAX_INSTRUCTIONS_PER_MESSAGE,
-            max_instructions_per_message_without_dts: MAX_INSTRUCTIONS_PER_MESSAGE_WITHOUT_DTS,
-            max_instructions_per_slice: MAX_INSTRUCTIONS_PER_SLICE,
-            instruction_overhead_per_execution: INSTRUCTION_OVERHEAD_PER_EXECUTION,
-            instruction_overhead_per_canister: INSTRUCTION_OVERHEAD_PER_CANISTER,
-            instruction_overhead_per_canister_for_finalization:
-                INSTRUCTION_OVERHEAD_PER_CANISTER_FOR_FINALIZATION,
-            max_instructions_per_install_code,
-            max_instructions_per_install_code_slice: MAX_INSTRUCTIONS_PER_INSTALL_CODE_SLICE,
-            max_heap_delta_per_iteration: MAX_HEAP_DELTA_PER_ITERATION,
-            max_message_duration_before_warn_in_seconds:
-                MAX_MESSAGE_DURATION_BEFORE_WARN_IN_SECONDS,
-            heap_delta_rate_limit: NumBytes::from(75 * 1024 * 1024),
-            install_code_rate_limit: MAX_INSTRUCTIONS_PER_SLICE,
-            dirty_page_overhead: DEFAULT_DIRTY_PAGE_OVERHEAD,
-            accumulated_priority_reset_interval: ACCUMULATED_PRIORITY_RESET_INTERVAL,
-            upload_wasm_chunk_instructions: DEFAULT_UPLOAD_CHUNK_INSTRUCTIONS,
-            canister_snapshot_baseline_instructions:
-                DEFAULT_CANISTERS_SNAPSHOT_BASELINE_INSTRUCTIONS,
-        }
+        Self::application_subnet()
     }
 
     pub fn default_for_subnet_type(subnet_type: SubnetType) -> Self {

--- a/rs/execution_environment/src/execution/response/tests.rs
+++ b/rs/execution_environment/src/execution/response/tests.rs
@@ -2487,7 +2487,7 @@ fn cycles_balance_changes_applied_correctly() {
         .universal_canister_with_cycles(Cycles::new(10_000_000_000_000))
         .unwrap();
     let b_id = test
-        .universal_canister_with_cycles(Cycles::new(81_000_000_000))
+        .universal_canister_with_cycles(Cycles::new(121_000_000_000))
         .unwrap();
 
     test.ingress(

--- a/rs/execution_environment/src/execution_environment/tests/canister_task.rs
+++ b/rs/execution_environment/src/execution_environment/tests/canister_task.rs
@@ -580,7 +580,7 @@ fn global_timer_refunds_cycles_for_request_in_prep() {
     .unwrap();
 
     let canister_id = env
-        .install_canister_with_cycles(binary, vec![], None, Cycles::new(100_000_000_000))
+        .install_canister_with_cycles(binary, vec![], None, Cycles::new(121_000_000_000))
         .unwrap();
 
     let result = env.execute_ingress(canister_id, "test", vec![]).unwrap();
@@ -644,7 +644,7 @@ fn global_timer_set_returns_zero_in_canister_global_timer_method() {
     .unwrap();
 
     let canister_id = env
-        .install_canister_with_cycles(binary, vec![], None, Cycles::new(100_000_000_000))
+        .install_canister_with_cycles(binary, vec![], None, Cycles::new(121_000_000_000))
         .unwrap();
 
     let result = env

--- a/rs/execution_environment/src/hypervisor/tests.rs
+++ b/rs/execution_environment/src/hypervisor/tests.rs
@@ -2110,7 +2110,7 @@ fn ic0_call_cycles_add_deducts_cycles() {
             (data (i32.const 0) "some_remote_method XYZ")
             (data (i32.const 100) "\09\03\00\00\00\00\00\00\ff\01")
         )"#;
-    let initial_cycles = Cycles::new(100_000_000_000);
+    let initial_cycles = Cycles::new(121_000_000_000);
     let canister_id = test
         .canister_from_cycles_and_wat(initial_cycles, wat)
         .unwrap();
@@ -2169,7 +2169,7 @@ fn ic0_call_cycles_add_has_no_effect_without_ic0_call_perform() {
             (data (i32.const 100) "\09\03\00\00\00\00\00\00\ff\01")
         )"#;
 
-    let initial_cycles = Cycles::new(100_000_000_000);
+    let initial_cycles = Cycles::new(121_000_000_000);
     let canister_id = test
         .canister_from_cycles_and_wat(initial_cycles, wat)
         .unwrap();

--- a/rs/execution_environment/src/query_handler/tests.rs
+++ b/rs/execution_environment/src/query_handler/tests.rs
@@ -747,11 +747,11 @@ fn queries_to_frozen_canisters_are_rejected() {
     // to be installed (the canister is created with the provisional
     // create canister api that doesn't require additional cycles).
     //
-    // 80_002_460 cycles are needed as prepayment for max install_code instructions
-    //    590_000 cycles are needed for update call execution
-    //     41_070 cycles are needed to cover freeze_threshold_cycles
-    //                   of the canister history memory usage (134 bytes)
-    let low_cycles = Cycles::new(80_000_633_630);
+    // 120_000_002_460 cycles are needed as prepayment for max install_code instructions
+    //         590_000 cycles are needed for update call execution
+    //          41_070 cycles are needed to cover freeze_threshold_cycles
+    //                 of the canister history memory usage (134 bytes)
+    let low_cycles = Cycles::new(120_000_633_530);
     let canister_a = test.universal_canister_with_cycles(low_cycles).unwrap();
     test.update_freezing_threshold(canister_a, freezing_threshold)
         .unwrap();

--- a/rs/execution_environment/tests/canister_logging.rs
+++ b/rs/execution_environment/tests/canister_logging.rs
@@ -59,7 +59,7 @@ fn setup(settings: CanisterSettingsArgs) -> (StateMachine, CanisterId) {
         .with_checkpoints_enabled(false)
         .build();
     let canister_id =
-        env.create_canister_with_cycles(None, Cycles::from(100_000_000_000_u128), Some(settings));
+        env.create_canister_with_cycles(None, Cycles::from(121_000_000_000_u128), Some(settings));
 
     (env, canister_id)
 }

--- a/rs/execution_environment/tests/execution_test.rs
+++ b/rs/execution_environment/tests/execution_test.rs
@@ -1344,7 +1344,7 @@ fn canister_with_reserved_balance_is_not_uninstalled_too_early() {
         HypervisorConfig::default(),
     ));
 
-    let initial_cycles = Cycles::new(100 * B);
+    let initial_cycles = Cycles::new(121 * B);
     let canister_a = create_universal_canister_with_cycles(
         &env,
         Some(
@@ -1402,7 +1402,7 @@ fn canister_with_reserved_balance_is_not_frozen_too_early() {
         HypervisorConfig::default(),
     ));
 
-    let initial_cycles = Cycles::new(200 * B);
+    let initial_cycles = Cycles::new(240 * B);
 
     let canister_id = create_universal_canister_with_cycles(
         &env,
@@ -1754,7 +1754,7 @@ fn heap_delta_initial_reserve_allows_round_executions_right_after_checkpoint() {
 
     fn install_canister(env: &StateMachine) -> Result<CanisterId, UserError> {
         let wasm = wat::parse_str(TEST_CANISTER).expect("invalid WAT");
-        env.install_canister_with_cycles(wasm, vec![], None, Cycles::new(100_000_000_000))
+        env.install_canister_with_cycles(wasm, vec![], None, Cycles::new(121 * B))
     }
 
     fn send_ingress(env: &StateMachine, canister_id: &CanisterId) -> MessageId {
@@ -1917,7 +1917,7 @@ fn current_interval_length_works_on_app_subnets() {
 
     let wasm = wat::parse_str(DIRTY_PAGE_CANISTER).unwrap();
     let _canister_id = env
-        .install_canister_with_cycles(wasm, vec![], None, Cycles::new(100_000_000_000))
+        .install_canister_with_cycles(wasm, vec![], None, Cycles::new(121 * B))
         .unwrap();
 
     // Canister install takes 2 rounds.

--- a/rs/execution_environment/tests/in_replicated_execution.rs
+++ b/rs/execution_environment/tests/in_replicated_execution.rs
@@ -13,7 +13,7 @@ fn setup() -> (StateMachine, CanisterId) {
         .with_checkpoints_enabled(false)
         .build();
     let canister_id =
-        env.create_canister_with_cycles(None, Cycles::from(100_000_000_000_u128), None);
+        env.create_canister_with_cycles(None, Cycles::from(121_000_000_000_u128), None);
     env.install_wasm_in_mode(
         canister_id,
         CanisterInstallMode::Install,


### PR DESCRIPTION
This PR increases the `install_code` message limit for application subnets from 200B to 300B. This setting matches the one for verified application subnets and brings the gap closer between the two types.