### PR TITLE
feat(IDX): allow tests to depend on mainnet pocket-ic

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -104,7 +104,7 @@ test_suite(
 
 # The pocket-ic server binary. Use this as a test dependency if the test
 # does not require a specific pocket-ic version (see ":pocket-ic-variant"
-# for details). Use this
+# for details).
 # By default returns the pocket-ic server from the source tree to ensure
 # consistency within the source tree. See 'pocket_ic_mainnet_test' for
 # overrides.

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -142,7 +142,7 @@ config_setting(
     },
 )
 
-# The pocket-ic as released; use this for tests that ensure consistency
+# The pocket-ic as released; use this for tests that need to ensure consistency
 # with a release pocket-ic/replica.
 genrule(
     name = "pocket-ic-mainnet",

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@bazel_gazelle//:def.bzl", "gazelle")
+load("@bazel_skylib//rules:common_settings.bzl", "string_setting")
 load("@rules_python//python:pip.bzl", "compile_pip_requirements")
 
 package(default_visibility = ["//visibility:public"])
@@ -97,4 +98,55 @@ test_suite(
     name = "single_large_node",  # the "_test" postfix is dropped on purpose since this target is meant for interactive use.
     tags = ["manual"],
     tests = ["//rs/tests/testing_verification/testnets:single_large_node"],
+)
+
+### Pocket IC
+
+# The pocket-ic server binary. Use this as a test dependency if the test
+# does not require a specific pocket-ic version (see ":pocket-ic-variant"
+# for details). Use this
+# By default returns the pocket-ic server from the source tree to ensure
+# consistency within the source tree. See 'pocket_ic_mainnet_test' for
+# overrides.
+alias(
+    name = "pocket-ic-server",
+    actual = select({
+        ":pocket-ic-variant-mainnet": "//:pocket-ic-mainnet",
+        ":pocket-ic-variant-head": "//rs/pocket_ic_server:pocket-ic-server",
+        "//conditions:default": "//rs/pocket_ic_server:pocket-ic-server",
+    }),
+)
+
+# A setting to switch between different variants of pocket-ic. The
+# default pocket-ic variant/version (head) is the one as in the
+# source tree.
+string_setting(
+    name = "pocket-ic-variant",
+    build_setting_default = "head",
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "pocket-ic-variant-head",
+    flag_values = {
+        ":pocket-ic-variant": "head",
+    },
+)
+
+# A "mainnet" variant of the pocket-ic server which represents a
+# released version of pocket-ic.
+config_setting(
+    name = "pocket-ic-variant-mainnet",
+    flag_values = {
+        ":pocket-ic-variant": "mainnet",
+    },
+)
+
+# The pocket-ic as released; use this for tests that ensure consistency
+# with a release pocket-ic/replica.
+genrule(
+    name = "pocket-ic-mainnet",
+    srcs = ["@pocket-ic-mainnet-gz//file"],
+    outs = ["pocket-ic"],
+    cmd = "gunzip -c $< > $@",
 )

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -103,7 +103,7 @@ test_suite(
 ### Pocket IC
 
 # The pocket-ic server binary. Use this as a test dependency if the test
-# does not require a specific pocket-ic version (see ":pocket-ic-variant"
+# does not require a specific pocket-ic version (see ":pocket-ic-server-variant"
 # for details).
 # By default returns the pocket-ic server from the source tree to ensure
 # consistency within the source tree. See 'pocket_ic_mainnet_test' for
@@ -111,8 +111,8 @@ test_suite(
 alias(
     name = "pocket-ic-server",
     actual = select({
-        ":pocket-ic-variant-mainnet": "//:pocket-ic-mainnet",
-        ":pocket-ic-variant-head": "//rs/pocket_ic_server:pocket-ic-server",
+        ":pocket-ic-server-variant-mainnet": "//:pocket-ic-mainnet",
+        ":pocket-ic-server-variant-head": "//rs/pocket_ic_server:pocket-ic-server",
         "//conditions:default": "//rs/pocket_ic_server:pocket-ic-server",
     }),
 )
@@ -121,24 +121,24 @@ alias(
 # default pocket-ic variant/version (head) is the one as in the
 # source tree.
 string_setting(
-    name = "pocket-ic-variant",
+    name = "pocket-ic-server-variant",
     build_setting_default = "head",
     visibility = ["//visibility:public"],
 )
 
 config_setting(
-    name = "pocket-ic-variant-head",
+    name = "pocket-ic-server-variant-head",
     flag_values = {
-        ":pocket-ic-variant": "head",
+        ":pocket-ic-server-variant": "head",
     },
 )
 
 # A "mainnet" variant of the pocket-ic server which represents a
 # released version of pocket-ic.
 config_setting(
-    name = "pocket-ic-variant-mainnet",
+    name = "pocket-ic-server-variant-mainnet",
     flag_values = {
-        ":pocket-ic-variant": "mainnet",
+        ":pocket-ic-server-variant": "mainnet",
     },
 )
 

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -981,3 +981,9 @@ http_file(
     sha256 = "2a428e8d35518ce22002e498f7d618a9eeeddf57371f965e92cf480dd3cbd046",
     url = "https://github.com/dfinity/examples/releases/download/rust-basic-bitcoin-24-09-16/basic_bitcoin.wasm.gz",
 )
+
+http_file(
+    name = "pocket-ic-mainnet-gz",
+    sha256 = "454891cac2421f3f894759ec5e6b6e48fbb544d79197bc29b88d34b93d78a4f1",
+    url = "https://download.dfinity.systems/ic/52ebccfba8855e23dcad9657a8d6e6be01df71f9/binaries/x86_64-linux/pocket-ic.gz",
+)

--- a/bazel/pocket-ic-tests.bzl
+++ b/bazel/pocket-ic-tests.bzl
@@ -1,0 +1,94 @@
+"""Build helpers for using the pocket-ic"""
+
+load("@bazel_skylib//lib:paths.bzl", "paths")
+
+# This defines a transition used in the pocket-ic declaration.
+# This allows tests to depend on an arbitrary version of pocket-ic
+# and for dependents to override that version.
+def _pocket_ic_mainnet_transition_impl(_settings, _attr):
+    return {
+        "//:pocket-ic-variant": "mainnet",
+    }
+
+pocket_ic_mainnet_transition = transition(
+    implementation = _pocket_ic_mainnet_transition_impl,
+    inputs = [],
+    outputs = [
+        "//:pocket-ic-variant",
+    ],
+)
+
+# Provider that allows wrapping/transitioning a test executable. This
+# ensure all the test data & env is forwarded.
+# Adapted from github.com/aherrman/bazel-transitions-demo:
+# https://github.com/aherrmann/bazel-transitions-demo/blob/f22cf40a62131eace14829f262e8d7c00b0a9a19/flag/defs.bzl#L124
+TestAspectInfo = provider("some descr", fields = ["args", "env"])
+
+def _test_aspect_impl(_target, ctx):
+    data = getattr(ctx.rule.attr, "data", [])
+    args = getattr(ctx.rule.attr, "args", [])
+    env = getattr(ctx.rule.attr, "env", [])
+    args = [ctx.expand_location(arg, data) for arg in args]
+    env = {k: ctx.expand_location(v, data) for (k, v) in env.items()}
+    return [TestAspectInfo(
+        args = args,
+        env = env,
+    )]
+
+_test_aspect = aspect(_test_aspect_impl)
+
+def _pocket_ic_mainnet_test_impl(ctx):
+    test_aspect_info = ctx.attr.test[TestAspectInfo]
+    (_, extension) = paths.split_extension(ctx.executable.test.path)
+    executable = ctx.actions.declare_file(
+        ctx.label.name + extension,
+    )
+    ctx.actions.write(
+        output = executable,
+        content = """\
+#!/usr/bin/env bash
+set -euo pipefail
+{commands}
+""".format(
+            commands = "\n".join([
+                " \\\n".join([
+                    '{}="{}"'.format(k, v)
+                    for k, v in test_aspect_info.env.items()
+                ] + [
+                    ctx.executable.test.short_path,
+                ] + test_aspect_info.args),
+            ]),
+        ),
+        is_executable = True,
+    )
+
+    runfiles = ctx.runfiles(files = [executable, ctx.executable.test] + ctx.files.data)
+    runfiles = runfiles.merge(ctx.attr.test[DefaultInfo].default_runfiles)
+    for data_dep in ctx.attr.data:
+        runfiles = runfiles.merge(data_dep[DefaultInfo].default_runfiles)
+
+    return [DefaultInfo(
+        executable = executable,
+        files = depset(direct = [executable]),
+        runfiles = runfiles,
+    )]
+
+# Rule to override another (test) rule. The resulting rule
+# will use the mainnet pocket-ic varaint.
+pocket_ic_mainnet_test = rule(
+    _pocket_ic_mainnet_test_impl,
+    attrs = {
+        "_allowlist_function_transition": attr.label(
+            default = "@bazel_tools//tools/allowlists/function_transition_allowlist",
+        ),
+        "data": attr.label_list(allow_files = True),
+        "test": attr.label(
+            aspects = [_test_aspect],
+            cfg = "target",
+            executable = True,
+        ),
+    },
+    cfg = pocket_ic_mainnet_transition,
+    executable = True,
+    test = True,
+)

--- a/bazel/pocket-ic-tests.bzl
+++ b/bazel/pocket-ic-tests.bzl
@@ -7,14 +7,14 @@ load("@bazel_skylib//lib:paths.bzl", "paths")
 # and for dependents to override that version.
 def _pocket_ic_mainnet_transition_impl(_settings, _attr):
     return {
-        "//:pocket-ic-variant": "mainnet",
+        "//:pocket-ic-server-variant": "mainnet",
     }
 
 pocket_ic_mainnet_transition = transition(
     implementation = _pocket_ic_mainnet_transition_impl,
     inputs = [],
     outputs = [
-        "//:pocket-ic-variant",
+        "//:pocket-ic-server-variant",
     ],
 )
 

--- a/rs/bitcoin/ckbtc/kyt/BUILD.bazel
+++ b/rs/bitcoin/ckbtc/kyt/BUILD.bazel
@@ -1,6 +1,7 @@
 load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test")
 load("//bazel:canisters.bzl", "rust_canister")
 load("//bazel:defs.bzl", "rust_ic_test")
+load("//bazel:pocket-ic-tests.bzl", "pocket_ic_mainnet_test")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -71,4 +72,9 @@ rust_ic_test(
         "@crate_index//:assert_matches",
         "@crate_index//:candid",
     ],
+)
+
+pocket_ic_mainnet_test(
+    name = "kyt_integration_test_mainnet",
+    test = ":kyt_integration_test",
 )

--- a/rs/bitcoin/kyt/BUILD.bazel
+++ b/rs/bitcoin/kyt/BUILD.bazel
@@ -74,13 +74,13 @@ rust_ic_test(
     env = {
         "CARGO_MANIFEST_DIR": "rs/bitcoin/kyt",
         "IC_BTC_KYT_CANISTER_WASM_PATH": "$(rootpath :btc_kyt_canister)",
-        "POCKET_IC_BIN": "$(rootpath //rs/pocket_ic_server:pocket-ic-server)",
+        "POCKET_IC_BIN": "$(rootpath //:pocket-ic-server)",
     },
     deps = [
         # Keep sorted.
         ":btc_kyt_lib",
+        "//:pocket-ic-server",
         "//packages/pocket-ic",
-        "//rs/pocket_ic_server:pocket-ic-server",
         "//rs/test_utilities/load_wasm",
         "//rs/types/base_types",
         "//rs/types/types",


### PR DESCRIPTION
This adds a build setting & related transition that allows for the pocket-ic version of tests to be overriden. By default `//:pocket-ic-server` points to the pocket-ic server from the source tree. This can be overriden by using `pocket_ic_mainnet_test` or by using the `//:pocket-ic-mainnet` target.