### PR TITLE
feat(sns-cli): Add `sns health` command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9521,6 +9521,7 @@ dependencies = [
  "ic-nervous-system-clients",
  "ic-nns-constants",
  "ic-sns-governance",
+ "ic-sns-root",
  "ic-sns-wasm",
  "pocket-ic",
  "serde",

--- a/rs/nervous_system/agent/BUILD.bazel
+++ b/rs/nervous_system/agent/BUILD.bazel
@@ -9,6 +9,7 @@ DEPENDENCIES = [
     "//rs/nns/constants",
     "//rs/nns/sns-wasm",
     "//rs/sns/governance",
+    "//rs/sns/root",
     "//rs/types/base_types",
     "@crate_index//:anyhow",
     "@crate_index//:candid",

--- a/rs/nervous_system/agent/Cargo.toml
+++ b/rs/nervous_system/agent/Cargo.toml
@@ -17,6 +17,7 @@ ic-nns-constants = { path = "../../nns/constants" }
 ic-sns-wasm = { path = "../../nns/sns-wasm" }
 ic-sns-governance = { path = "../../sns/governance" }
 pocket-ic = { path = "../../../packages/pocket-ic" }
+ic-sns-root = { path = "../../sns/root" }
 serde = { workspace = true }
 tempfile = { workspace = true }
 thiserror = { workspace = true }

--- a/rs/nervous_system/agent/src/nns/sns_wasm.rs
+++ b/rs/nervous_system/agent/src/nns/sns_wasm.rs
@@ -15,7 +15,7 @@ use tokio::process::Command;
 
 use crate::CallCanisters;
 
-pub async fn query_sns_upgrade_steps<C: CallCanisters>(
+pub async fn query_mainline_sns_upgrade_steps<C: CallCanisters>(
     agent: &C,
 ) -> Result<ListUpgradeStepsResponse, C::Error> {
     let request = ListUpgradeStepsRequest {

--- a/rs/nervous_system/agent/src/sns/governance.rs
+++ b/rs/nervous_system/agent/src/sns/governance.rs
@@ -1,6 +1,9 @@
 use crate::CallCanisters;
 use ic_base_types::PrincipalId;
-use ic_sns_governance::pb::v1::{GetMetadataRequest, GetMetadataResponse};
+use ic_sns_governance::pb::v1::{
+    GetMetadataRequest, GetMetadataResponse, GetRunningSnsVersionRequest,
+    GetRunningSnsVersionResponse,
+};
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -14,5 +17,14 @@ impl GovernanceCanister {
         agent: &C,
     ) -> Result<GetMetadataResponse, C::Error> {
         agent.call(self.canister_id, GetMetadataRequest {}).await
+    }
+
+    pub async fn version<C: CallCanisters>(
+        &self,
+        agent: &C,
+    ) -> Result<GetRunningSnsVersionResponse, C::Error> {
+        agent
+            .call(self.canister_id, GetRunningSnsVersionRequest {})
+            .await
     }
 }

--- a/rs/nervous_system/agent/src/sns/root.rs
+++ b/rs/nervous_system/agent/src/sns/root.rs
@@ -1,7 +1,26 @@
 use ic_base_types::PrincipalId;
+use ic_sns_root::{GetSnsCanistersSummaryRequest, GetSnsCanistersSummaryResponse};
 use serde::{Deserialize, Serialize};
+
+use crate::CallCanisters;
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct RootCanister {
     pub canister_id: PrincipalId,
+}
+
+impl RootCanister {
+    pub async fn sns_canisters_summary<C: CallCanisters>(
+        &self,
+        agent: &C,
+    ) -> Result<GetSnsCanistersSummaryResponse, C::Error> {
+        agent
+            .call(
+                self.canister_id,
+                GetSnsCanistersSummaryRequest {
+                    update_canister_list: None,
+                },
+            )
+            .await
+    }
 }

--- a/rs/nervous_system/tools/sync-with-released-nevous-system-wasms/src/main.rs
+++ b/rs/nervous_system/tools/sync-with-released-nevous-system-wasms/src/main.rs
@@ -83,7 +83,7 @@ async fn main() -> Result<()> {
         .into_iter()
         .collect::<Result<Vec<CanisterUpdate>>>()?;
 
-    let sns_upgrade_steps = sns_wasm::query_sns_upgrade_steps(&agent).await?;
+    let sns_upgrade_steps = sns_wasm::query_mainline_sns_upgrade_steps(&agent).await?;
     let latest_sns_version = &sns_upgrade_steps
         .steps
         .last()

--- a/rs/sns/cli/src/health.rs
+++ b/rs/sns/cli/src/health.rs
@@ -1,0 +1,176 @@
+use crate::table::{as_table, TableRow};
+use crate::utils::{get_snses_with_metadata, SnsWithMetadata};
+use anyhow::Result;
+use clap::Parser;
+use futures::{stream, StreamExt};
+use ic_agent::Agent;
+use ic_nervous_system_agent::nns::sns_wasm;
+use ic_sns_root::types::SnsCanisterType;
+use itertools::Itertools;
+use serde::{Deserialize, Serialize};
+
+/// The arguments used to configure the health command
+#[derive(Debug, Parser)]
+pub struct HealthArgs {
+    /// Output the SNS information as JSON (instead of a human-friendly table).
+    #[clap(long)]
+    json: bool,
+    /// Includes dapp canisters in the output.
+    #[clap(long)]
+    include_dapps: bool,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct SnsHealthInfo {
+    name: String,
+    memory_consumption: Vec<(u64, SnsCanisterType)>,
+    cycles: Vec<(u64, SnsCanisterType)>,
+    num_remaining_upgrade_steps: usize,
+}
+
+impl TableRow for SnsHealthInfo {
+    fn column_names() -> Vec<&'static str> {
+        vec!["Name", "Memory", "Cycles", "Upgrades Remaining"]
+    }
+
+    fn column_values(&self) -> Vec<String> {
+        let high_memory_consumption = self
+            .memory_consumption
+            .iter()
+            .filter(|(memory_consumption, _)| {
+                (*memory_consumption as f64) > 2.5 * 1024.0 * 1024.0 * 1024.0
+            })
+            .map(|(memory_consumption, canister_type)| {
+                format!(
+                    "{canister_type}: ({:.2} GiB)",
+                    *memory_consumption as f64 / 1024.0 / 1024.0 / 1024.0
+                )
+            })
+            .join(", ");
+
+        let high_memory_consumption = if !high_memory_consumption.is_empty() {
+            format!("❌ {high_memory_consumption}")
+        } else {
+            "👍".to_string()
+        };
+
+        let low_cycles = self
+            .cycles
+            .iter()
+            .filter(|(cycles, _)| (*cycles as f64) < 10.0 * 1000.0 * 1000.0 * 1000.0 * 1000.0)
+            .map(|(cycles, canister_type)| {
+                format!(
+                    "{canister_type}: ({:.2} TC)",
+                    *cycles as f64 / 1000.0 / 1000.0 / 1000.0 / 1000.0
+                )
+            })
+            .join(", ");
+        let low_cycles = if !low_cycles.is_empty() {
+            format!("❌ {low_cycles}")
+        } else {
+            "👍".to_string()
+        };
+
+        vec![
+            self.name.clone(),
+            high_memory_consumption,
+            low_cycles,
+            format!("{}", self.num_remaining_upgrade_steps),
+        ]
+    }
+}
+
+pub async fn exec(args: HealthArgs, agent: &Agent) -> Result<()> {
+    eprintln!("Checking SNS's health...");
+
+    let snses = sns_wasm::list_deployed_snses(agent).await?;
+    let num_total_snses = snses.len();
+    let snses_with_metadata = get_snses_with_metadata(agent, snses).await;
+
+    let num_snses_with_metadata = snses_with_metadata.len();
+
+    let health_info: Vec<SnsHealthInfo> = stream::iter(snses_with_metadata)
+        .map(|SnsWithMetadata { sns, name }| async move {
+            let summary = sns.root.sns_canisters_summary(agent).await?;
+            let statuses = summary
+                .into_iter()
+                .inspect(|(canister_summary, ctype)| {
+                    if canister_summary.is_none() {
+                        eprintln!("SNS {name} canister summary is missing {ctype}");
+                    }
+                })
+                .filter_map(|(canister_summary, ctype)| {
+                    canister_summary.map(|canister_summary| (canister_summary, ctype))
+                })
+                .inspect(|(canister_summary, ctype)| {
+                    if canister_summary.status.is_none() {
+                        eprintln!("SNS {name} canister {ctype} has no status");
+                    }
+                })
+                .filter_map(|(canister_summary, ctype)| {
+                    canister_summary
+                        .status
+                        .map(|canister_summary| (canister_summary, ctype))
+                })
+                .collect::<Vec<_>>();
+
+            let statuses = if args.include_dapps {
+                statuses
+            } else {
+                statuses
+                    .into_iter()
+                    .filter(|(_, ctype)| *ctype != SnsCanisterType::Dapp)
+                    .collect()
+            };
+
+            let (memory_consumption, cycles) = statuses
+                .into_iter()
+                .map(|(canister_status, ctype)| {
+                    (
+                        (u64::try_from(canister_status.memory_size.0).unwrap(), ctype),
+                        (u64::try_from(canister_status.cycles.0).unwrap(), ctype),
+                    )
+                })
+                .unzip();
+
+            let num_remaining_upgrade_steps = sns
+                .remaining_upgrade_steps(agent)
+                .await?
+                .steps
+                .len()
+                .saturating_sub(1);
+
+            Result::<SnsHealthInfo, anyhow::Error>::Ok(SnsHealthInfo {
+                name,
+                memory_consumption,
+                cycles,
+                num_remaining_upgrade_steps,
+            })
+        })
+        .buffer_unordered(10)
+        .collect::<Vec<Result<_>>>()
+        .await
+        .into_iter()
+        .inspect(|result| {
+            if let Err(e) = result {
+                println!("Error: {}", e)
+            }
+        })
+        .filter_map(Result::ok)
+        .sorted_by(|a, b| a.name.cmp(&b.name))
+        .collect::<Vec<_>>();
+
+    let output = if args.json {
+        serde_json::to_string(&health_info).unwrap()
+    } else {
+        as_table(health_info.as_ref())
+    };
+    println!("{}", output);
+
+    eprintln!(
+        "Out of {num_total_snses} SNSes, {num_snses_with_metadata} had metadata and I checked the health of {num_healthchecked} of them.",
+        num_healthchecked = health_info.len()
+    );
+
+    Ok(())
+}

--- a/rs/sns/cli/src/lib.rs
+++ b/rs/sns/cli/src/lib.rs
@@ -1,5 +1,5 @@
 use crate::{
-    deploy::DirectSnsDeployerForTests, init_config_file::InitConfigFileArgs,
+    deploy::DirectSnsDeployerForTests, health::HealthArgs, init_config_file::InitConfigFileArgs,
     neuron_id_to_candid_subaccount::NeuronIdToCandidSubaccountArgs,
     prepare_canisters::PrepareCanistersArgs, propose::ProposeArgs,
 };
@@ -30,6 +30,7 @@ use std::{
 use tempfile::NamedTempFile;
 
 pub mod deploy;
+pub mod health;
 pub mod init_config_file;
 pub mod list;
 pub mod neuron_id_to_candid_subaccount;
@@ -77,6 +78,8 @@ pub enum SubCommand {
     NeuronIdToCandidSubaccount(NeuronIdToCandidSubaccountArgs),
     /// List SNSes
     List(list::ListArgs),
+    /// Check SNSes for warnings and errors.
+    Health(HealthArgs),
 }
 
 impl CliArgs {

--- a/rs/sns/cli/src/main.rs
+++ b/rs/sns/cli/src/main.rs
@@ -4,7 +4,7 @@ use anyhow::{bail, Result};
 use clap::Parser;
 
 use ic_sns_cli::{
-    add_sns_wasm_for_tests, deploy_testflight, init_config_file, list,
+    add_sns_wasm_for_tests, deploy_testflight, health, init_config_file, list,
     neuron_id_to_candid_subaccount, prepare_canisters, propose, CliArgs, SubCommand,
 };
 
@@ -27,5 +27,6 @@ async fn main() -> Result<()> {
         SubCommand::Propose(args) => propose::exec(args),
         SubCommand::NeuronIdToCandidSubaccount(args) => neuron_id_to_candid_subaccount::exec(args),
         SubCommand::List(args) => list::exec(args, &agent).await,
+        SubCommand::Health(args) => health::exec(args, &agent).await,
     }
 }

--- a/rs/sns/cli/src/utils.rs
+++ b/rs/sns/cli/src/utils.rs
@@ -1,5 +1,9 @@
 use anyhow::{anyhow, Result};
+use futures::{stream, StreamExt};
 use ic_agent::Agent;
+use ic_nervous_system_agent::sns::Sns;
+use itertools::Itertools;
+use serde::{Deserialize, Serialize};
 
 fn get_agent(ic_url: &str) -> Result<Agent> {
     Agent::builder()
@@ -12,4 +16,33 @@ fn get_agent(ic_url: &str) -> Result<Agent> {
 pub fn get_mainnet_agent() -> Result<Agent> {
     let ic_url = "https://ic0.app/";
     get_agent(ic_url)
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub(crate) struct SnsWithMetadata {
+    pub(crate) name: String,
+    pub(crate) sns: Sns,
+}
+
+pub(crate) async fn get_snses_with_metadata(
+    agent: &Agent,
+    snses: Vec<Sns>,
+) -> Vec<SnsWithMetadata> {
+    let snses_with_metadata = stream::iter(snses)
+        .map(|sns| async move {
+            let metadata = sns.governance.metadata(agent).await?;
+            Ok((sns, metadata))
+        })
+        .buffer_unordered(10) // Do up to 10 requests at a time in parallel
+        .collect::<Vec<anyhow::Result<_>>>()
+        .await;
+    snses_with_metadata
+        .into_iter()
+        .filter_map(Result::ok)
+        .map(|(sns, metadata)| {
+            let name = metadata.name.unwrap_or_else(|| "Unknown".to_string());
+            SnsWithMetadata { name, sns }
+        })
+        .sorted_by(|a, b| a.name.cmp(&b.name))
+        .collect::<Vec<_>>()
 }

--- a/rs/sns/governance/src/request_impls.rs
+++ b/rs/sns/governance/src/request_impls.rs
@@ -4,9 +4,9 @@ use crate::pb::v1::{
     ClaimSwapNeuronsRequest, ClaimSwapNeuronsResponse, FailStuckUpgradeInProgressRequest,
     FailStuckUpgradeInProgressResponse, GetMaturityModulationRequest,
     GetMaturityModulationResponse, GetMetadataRequest, GetMetadataResponse, GetMode,
-    GetModeResponse, GetNeuronResponse, GetProposalResponse, GetSnsInitializationParametersRequest,
-    GetSnsInitializationParametersResponse, ListNeuronsResponse, ListProposalsResponse,
-    ManageNeuronResponse,
+    GetModeResponse, GetNeuronResponse, GetProposalResponse, GetRunningSnsVersionResponse,
+    GetSnsInitializationParametersRequest, GetSnsInitializationParametersResponse,
+    ListNeuronsResponse, ListProposalsResponse, ManageNeuronResponse,
 };
 
 impl Request for ClaimSwapNeuronsRequest {
@@ -72,5 +72,11 @@ impl Request for crate::pb::v1::ListProposals {
 impl Request for crate::pb::v1::ManageNeuron {
     type Response = ManageNeuronResponse;
     const METHOD: &'static str = "manage_neuron";
+    const UPDATE: bool = true;
+}
+
+impl Request for crate::pb::v1::GetRunningSnsVersionRequest {
+    type Response = GetRunningSnsVersionResponse;
+    const METHOD: &'static str = "get_running_sns_version";
     const UPDATE: bool = true;
 }

--- a/rs/sns/root/src/request_impls.rs
+++ b/rs/sns/root/src/request_impls.rs
@@ -1,0 +1,8 @@
+use crate::{GetSnsCanistersSummaryRequest, GetSnsCanistersSummaryResponse};
+use ic_nervous_system_clients::Request;
+
+impl Request for GetSnsCanistersSummaryRequest {
+    type Response = GetSnsCanistersSummaryResponse;
+    const METHOD: &'static str = "get_sns_canisters_summary";
+    const UPDATE: bool = true;
+}

--- a/rs/sns/root/src/types.rs
+++ b/rs/sns/root/src/types.rs
@@ -1,5 +1,9 @@
+use std::fmt::{self, Display, Formatter};
+
 use async_trait::async_trait;
 use ic_base_types::CanisterId;
+use serde::{Deserialize, Serialize};
+
 /// A general trait for the environment in which governance is running.
 #[async_trait]
 pub trait Environment: Send + Sync {
@@ -19,4 +23,30 @@ pub trait Environment: Send + Sync {
         method_name: &str,
         arg: Vec<u8>,
     ) -> Result</* reply: */ Vec<u8>, (/* error_code: */ i32, /* message: */ String)>;
+}
+
+/// Different from the SnsCanisterType in SNS-W because it includes Dap
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Deserialize, Serialize)]
+pub enum SnsCanisterType {
+    Root,
+    Governance,
+    Ledger,
+    Swap,
+    Archive,
+    Index,
+    Dapp,
+}
+
+impl Display for SnsCanisterType {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            SnsCanisterType::Root => write!(f, "root"),
+            SnsCanisterType::Governance => write!(f, "governance"),
+            SnsCanisterType::Ledger => write!(f, "ledger"),
+            SnsCanisterType::Swap => write!(f, "swap"),
+            SnsCanisterType::Dapp => write!(f, "dapp"),
+            SnsCanisterType::Archive => write!(f, "archive"),
+            SnsCanisterType::Index => write!(f, "index"),
+        }
+    }
 }


### PR DESCRIPTION
This adds a `health` command to the sns cli. You can run it like so from the monorepo:

```
$ bazel run :sns --config=local -- health
```

The output at the time of this writing is this:

Checking SNS's health...
| Name                    | Memory | Cycles                                                                      | Upgrades Remaining |
|-------------------------|--------|-----------------------------------------------------------------------------|--------------------|
| BOOM DAO                | 👍      | ❌ index: (9.49 TC)                                                          | 5                  |
| CYCLES-TRANSFER-STATION | 👍      | 👍                                                                           | 5                  |
| Catalyze                | 👍      | ❌ root: (7.01 TC), index: (9.01 TC), archive: (9.36 TC)                     | 0                  |
| DOGMI                   | 👍      | ❌ governance: (5.18 TC), archive: (9.72 TC)                                 | 6                  |
| DecideAI DAO            | 👍      | 👍                                                                           | 4                  |
| Dragginz                | 👍      | 👍                                                                           | 0                  |
| ELNA AI                 | 👍      | 👍                                                                           | 7                  |
| EstateDAO               | 👍      | ❌ index: (8.79 TC)                                                          | 18                 |
| Gold DAO                | 👍      | 👍                                                                           | 4                  |
| ICGhost                 | 👍      | ❌ swap: (2.38 TC)                                                           | 7                  |
| ICLighthouse DAO        | 👍      | ❌ swap: (2.63 TC)                                                           | 7                  |
| ICPCC DAO LLC           | 👍      | ❌ index: (7.17 TC)                                                          | 13                 |
| ICPSwap                 | 👍      | ❌ governance: (9.99 TC)                                                     | 7                  |
| ICPanda DAO             | 👍      | ❌ archive: (8.64 TC)                                                        | 3                  |
| ICVC                    | 👍      | 👍                                                                           | 5                  |
| Juno Build              | 👍      | 👍                                                                           | 0                  |
| Kinic                   | 👍      | 👍                                                                           | 5                  |
| MORA DAO                | 👍      | ❌ root: (7.44 TC), governance: (9.24 TC), swap: (8.70 TC), index: (0.00 TC) | 31                 |
| Motoko                  | 👍      | ❌ archive: (9.64 TC)                                                        | 0                  |
| Neutrinite              | 👍      | 👍                                                                           | 0                  |
| Nuance                  | 👍      | 👍                                                                           | 5                  |
| ORIGYN                  | 👍      | 👍                                                                           | 5                  |
| OpenChat                | 👍      | 👍                                                                           | 5                  |
| OpenFPL                 | 👍      | ❌ ledger: (9.93 TC)                                                         | 8                  |
| SONIC                   | 👍      | 👍                                                                           | 7                  |
| Seers                   | 👍      | 👍                                                                           | 3                  |
| Sneed                   | 👍      | 👍                                                                           | 23                 |
| TRAX                    | 👍      | ❌ ledger: (5.62 TC), swap: (6.29 TC)                                        | 16                 |
| WaterNeuron             | 👍      | 👍                                                                           | 7                  |
| YRAL                    | 👍      | ❌ governance: (7.52 TC), archive: (4.77 TC)                                 | 11                 |
| Yuku DAO                | 👍      | ❌ archive: (9.60 TC)                                                        | 35                 |

Out of 39 SNSes, 31 had metadata and I checked the health of 31 of them.