### PR TITLE
test(nns): Analyze list_neurons performance, and look for promising areas for optimization.

### DIFF
--- a/Cargo.Bazel.Fuzzing.json.lock
+++ b/Cargo.Bazel.Fuzzing.json.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "5b2155e68f6b2e6bd7b237383aaf533be77bc89fa1b4b1ea6b70316f0ebd1d7e",
+  "checksum": "5cf6ef1a6b0b7e7b8eb47b1e9641761464c2a9c3642e2aebb84f0d0ee6c3f2ba",
   "crates": {
     "abnf 0.12.0": {
       "name": "abnf",
@@ -1775,7 +1775,7 @@
               "target": "http"
             },
             {
-              "id": "indexmap 2.2.6",
+              "id": "indexmap 2.7.1",
               "target": "indexmap"
             },
             {
@@ -20004,7 +20004,7 @@
               "target": "ic_verify_bls_signature"
             },
             {
-              "id": "ic-wasm 0.8.4",
+              "id": "ic-wasm 0.9.5",
               "target": "ic_wasm"
             },
             {
@@ -20036,7 +20036,7 @@
               "target": "idna"
             },
             {
-              "id": "indexmap 2.2.6",
+              "id": "indexmap 2.7.1",
               "target": "indexmap"
             },
             {
@@ -20750,7 +20750,7 @@
               "target": "walkdir"
             },
             {
-              "id": "walrus 0.21.1",
+              "id": "walrus 0.22.0",
               "target": "walrus"
             },
             {
@@ -27669,7 +27669,7 @@
         "deps": {
           "common": [
             {
-              "id": "indexmap 2.2.6",
+              "id": "indexmap 2.7.1",
               "target": "indexmap"
             }
           ],
@@ -28001,7 +28001,7 @@
               "target": "http"
             },
             {
-              "id": "indexmap 2.2.6",
+              "id": "indexmap 2.7.1",
               "target": "indexmap"
             },
             {
@@ -28088,7 +28088,7 @@
               "target": "http"
             },
             {
-              "id": "indexmap 2.2.6",
+              "id": "indexmap 2.7.1",
               "target": "indexmap"
             },
             {
@@ -28379,7 +28379,8 @@
         ],
         "crate_features": {
           "common": [
-            "default-hasher"
+            "default-hasher",
+            "serde"
           ],
           "selects": {}
         },
@@ -28388,6 +28389,10 @@
             {
               "id": "foldhash 0.1.4",
               "target": "foldhash"
+            },
+            {
+              "id": "serde 1.0.217",
+              "target": "serde"
             }
           ],
           "selects": {}
@@ -28737,54 +28742,6 @@
         "MIT"
       ],
       "license_file": "LICENSE"
-    },
-    "heck 0.3.3": {
-      "name": "heck",
-      "version": "0.3.3",
-      "package_url": "https://github.com/withoutboats/heck",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/heck/0.3.3/download",
-          "sha256": "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "heck",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "heck",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "unicode-segmentation 1.10.1",
-              "target": "unicode_segmentation"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2018",
-        "version": "0.3.3"
-      },
-      "license": "MIT OR Apache-2.0",
-      "license_ids": [
-        "Apache-2.0",
-        "MIT"
-      ],
-      "license_file": "LICENSE-APACHE"
     },
     "heck 0.4.1": {
       "name": "heck",
@@ -34446,14 +34403,14 @@
       ],
       "license_file": null
     },
-    "ic-wasm 0.8.4": {
+    "ic-wasm 0.9.5": {
       "name": "ic-wasm",
-      "version": "0.8.4",
+      "version": "0.9.5",
       "package_url": "https://github.com/dfinity/ic-wasm",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/ic-wasm/0.8.4/download",
-          "sha256": "45bc33855672981ae4a2f4e77c1a77d1bdc0756fb1b36ad0dbe47df77a955e2d"
+          "url": "https://static.crates.io/crates/ic-wasm/0.9.5/download",
+          "sha256": "adf6b69fa1b319ce3ffb65564bc16c15d1b0d91a679d8a9ae6e69c2a71f09ec6"
         }
       },
       "targets": [
@@ -34531,14 +34488,18 @@
               "target": "thiserror"
             },
             {
-              "id": "walrus 0.21.1",
+              "id": "walrus 0.22.0",
               "target": "walrus"
+            },
+            {
+              "id": "wasmparser 0.223.1",
+              "target": "wasmparser"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.8.4"
+        "version": "0.9.5"
       },
       "license": "Apache-2.0",
       "license_ids": [
@@ -36460,14 +36421,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "indexmap 2.2.6": {
+    "indexmap 2.7.1": {
       "name": "indexmap",
-      "version": "2.2.6",
+      "version": "2.7.1",
       "package_url": "https://github.com/indexmap-rs/indexmap",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/indexmap/2.2.6/download",
-          "sha256": "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
+          "url": "https://static.crates.io/crates/indexmap/2.7.1/download",
+          "sha256": "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
         }
       },
       "targets": [
@@ -36504,7 +36465,7 @@
               "target": "equivalent"
             },
             {
-              "id": "hashbrown 0.14.5",
+              "id": "hashbrown 0.15.2",
               "target": "hashbrown"
             },
             {
@@ -36515,7 +36476,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "2.2.6"
+        "version": "2.7.1"
       },
       "license": "Apache-2.0 OR MIT",
       "license_ids": [
@@ -36679,7 +36640,7 @@
               "target": "ahash"
             },
             {
-              "id": "indexmap 2.2.6",
+              "id": "indexmap 2.7.1",
               "target": "indexmap"
             },
             {
@@ -36797,7 +36758,7 @@
               "target": "env_logger"
             },
             {
-              "id": "indexmap 2.2.6",
+              "id": "indexmap 2.7.1",
               "target": "indexmap"
             },
             {
@@ -47598,7 +47559,7 @@
               "target": "hashbrown"
             },
             {
-              "id": "indexmap 2.2.6",
+              "id": "indexmap 2.7.1",
               "target": "indexmap"
             },
             {
@@ -48553,7 +48514,7 @@
               "target": "futures_sink"
             },
             {
-              "id": "indexmap 2.2.6",
+              "id": "indexmap 2.7.1",
               "target": "indexmap"
             },
             {
@@ -51575,7 +51536,7 @@
               "target": "fixedbitset"
             },
             {
-              "id": "indexmap 2.2.6",
+              "id": "indexmap 2.7.1",
               "target": "indexmap"
             }
           ],
@@ -66523,7 +66484,7 @@
               "target": "dyn_clone"
             },
             {
-              "id": "indexmap 2.2.6",
+              "id": "indexmap 2.7.1",
               "target": "indexmap",
               "alias": "indexmap2"
             },
@@ -69358,7 +69319,7 @@
         "deps": {
           "common": [
             {
-              "id": "indexmap 2.2.6",
+              "id": "indexmap 2.7.1",
               "target": "indexmap"
             },
             {
@@ -78183,7 +78144,7 @@
         "deps": {
           "common": [
             {
-              "id": "indexmap 2.2.6",
+              "id": "indexmap 2.7.1",
               "target": "indexmap"
             },
             {
@@ -78247,7 +78208,7 @@
         "deps": {
           "common": [
             {
-              "id": "indexmap 2.2.6",
+              "id": "indexmap 2.7.1",
               "target": "indexmap"
             },
             {
@@ -78692,7 +78653,7 @@
               "target": "hdrhistogram"
             },
             {
-              "id": "indexmap 2.2.6",
+              "id": "indexmap 2.7.1",
               "target": "indexmap"
             },
             {
@@ -82361,14 +82322,14 @@
       ],
       "license_file": "LICENSE-MIT"
     },
-    "walrus 0.21.1": {
+    "walrus 0.22.0": {
       "name": "walrus",
-      "version": "0.21.1",
+      "version": "0.22.0",
       "package_url": "https://github.com/rustwasm/walrus",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/walrus/0.21.1/download",
-          "sha256": "467611cafbc8a84834b77d2b4bb191fd2f5769752def8340407e924390c6883b"
+          "url": "https://static.crates.io/crates/walrus/0.22.0/download",
+          "sha256": "d68aa3c7b80be75c8458fc087453e5a31a226cfffede2e9b932393b2ea1c624a"
         }
       },
       "targets": [
@@ -82427,13 +82388,13 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "walrus-macro 0.19.0",
+              "id": "walrus-macro 0.22.0",
               "target": "walrus_macro"
             }
           ],
           "selects": {}
         },
-        "version": "0.21.1"
+        "version": "0.22.0"
       },
       "license": "MIT/Apache-2.0",
       "license_ids": [
@@ -82442,14 +82403,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "walrus-macro 0.19.0": {
+    "walrus-macro 0.22.0": {
       "name": "walrus-macro",
-      "version": "0.19.0",
+      "version": "0.22.0",
       "package_url": "https://github.com/rustwasm/walrus/tree/crates/macro",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/walrus-macro/0.19.0/download",
-          "sha256": "0a6e5bd22c71e77d60140b0bd5be56155a37e5bd14e24f5f87298040d0cc40d7"
+          "url": "https://static.crates.io/crates/walrus-macro/0.22.0/download",
+          "sha256": "439ad39ff894c43c9649fa724cdde9a6fc50b855d517ef071a93e5df82fe51d3"
         }
       },
       "targets": [
@@ -82474,7 +82435,7 @@
         "deps": {
           "common": [
             {
-              "id": "heck 0.3.3",
+              "id": "heck 0.5.0",
               "target": "heck"
             },
             {
@@ -82486,14 +82447,14 @@
               "target": "quote"
             },
             {
-              "id": "syn 1.0.109",
+              "id": "syn 2.0.87",
               "target": "syn"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.19.0"
+        "version": "0.22.0"
       },
       "license": "MIT/Apache-2.0",
       "license_ids": [
@@ -83394,7 +83355,7 @@
               "target": "flagset"
             },
             {
-              "id": "indexmap 2.2.6",
+              "id": "indexmap 2.7.1",
               "target": "indexmap"
             },
             {
@@ -83521,7 +83482,7 @@
               "target": "bitflags"
             },
             {
-              "id": "indexmap 2.2.6",
+              "id": "indexmap 2.7.1",
               "target": "indexmap"
             },
             {
@@ -83593,7 +83554,7 @@
               "target": "hashbrown"
             },
             {
-              "id": "indexmap 2.2.6",
+              "id": "indexmap 2.7.1",
               "target": "indexmap"
             },
             {
@@ -83670,7 +83631,7 @@
               "target": "hashbrown"
             },
             {
-              "id": "indexmap 2.2.6",
+              "id": "indexmap 2.7.1",
               "target": "indexmap"
             },
             {
@@ -83769,6 +83730,107 @@
         },
         "edition": "2021",
         "version": "0.221.2"
+      },
+      "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "data_glob": [
+          "**"
+        ]
+      },
+      "license": "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT",
+      "license_ids": [
+        "Apache-2.0",
+        "MIT"
+      ],
+      "license_file": null
+    },
+    "wasmparser 0.223.1": {
+      "name": "wasmparser",
+      "version": "0.223.1",
+      "package_url": "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasmparser",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/wasmparser/0.223.1/download",
+          "sha256": "664b980991ed9a8c834eb528a8979ab1109edcf52dc05dd5751e2cc3fb31035d"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "wasmparser",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        },
+        {
+          "BuildScript": {
+            "crate_name": "build_script_build",
+            "crate_root": "build.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "wasmparser",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": {
+          "common": [
+            "component-model",
+            "default",
+            "features",
+            "hash-collections",
+            "serde",
+            "simd",
+            "std",
+            "validate"
+          ],
+          "selects": {}
+        },
+        "deps": {
+          "common": [
+            {
+              "id": "bitflags 2.6.0",
+              "target": "bitflags"
+            },
+            {
+              "id": "hashbrown 0.15.2",
+              "target": "hashbrown"
+            },
+            {
+              "id": "indexmap 2.7.1",
+              "target": "indexmap"
+            },
+            {
+              "id": "semver 1.0.22",
+              "target": "semver"
+            },
+            {
+              "id": "serde 1.0.217",
+              "target": "serde"
+            },
+            {
+              "id": "wasmparser 0.223.1",
+              "target": "build_script_build"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "0.223.1"
       },
       "build_script_attrs": {
         "compile_data_glob": [
@@ -83981,7 +84043,7 @@
               "target": "hashbrown"
             },
             {
-              "id": "indexmap 2.2.6",
+              "id": "indexmap 2.7.1",
               "target": "indexmap"
             },
             {
@@ -84707,7 +84769,7 @@
               "target": "gimli"
             },
             {
-              "id": "indexmap 2.2.6",
+              "id": "indexmap 2.7.1",
               "target": "indexmap"
             },
             {
@@ -85215,7 +85277,7 @@
               "target": "heck"
             },
             {
-              "id": "indexmap 2.2.6",
+              "id": "indexmap 2.7.1",
               "target": "indexmap"
             },
             {
@@ -88806,7 +88868,7 @@
               "target": "id_arena"
             },
             {
-              "id": "indexmap 2.2.6",
+              "id": "indexmap 2.7.1",
               "target": "indexmap"
             },
             {
@@ -90363,7 +90425,7 @@
   },
   "binary_crates": [
     "canbench 0.1.9",
-    "ic-wasm 0.8.4",
+    "ic-wasm 0.9.5",
     "metrics-proxy 0.1.0"
   ],
   "workspace_members": {
@@ -91558,7 +91620,7 @@
     "ic-transport-types 0.39.2",
     "ic-utils 0.39.2",
     "ic-verify-bls-signature 0.6.0",
-    "ic-wasm 0.8.4",
+    "ic-wasm 0.9.5",
     "ic-xrc-types 1.2.0",
     "ic0 0.18.11",
     "ic_bls12_381 0.10.0",
@@ -91566,7 +91628,7 @@
     "icrc1-test-env 0.1.1",
     "icrc1-test-suite 0.1.1",
     "idna 1.0.3",
-    "indexmap 2.2.6",
+    "indexmap 2.7.1",
     "indicatif 0.17.7",
     "indoc 1.0.9",
     "inferno 0.12.0",
@@ -91752,7 +91814,7 @@
     "uuid 1.11.0",
     "vsock 0.4.0",
     "walkdir 2.3.3",
-    "walrus 0.21.1",
+    "walrus 0.22.0",
     "warp 0.3.7",
     "wasm-bindgen 0.2.95",
     "wasm-encoder 0.217.0",

--- a/Cargo.Bazel.Fuzzing.json.lock
+++ b/Cargo.Bazel.Fuzzing.json.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "014347ed676868fa1f5da05cc21d6bdf8cca1621a3b9683496a53bc9b2e7ecdf",
+  "checksum": "5b2155e68f6b2e6bd7b237383aaf533be77bc89fa1b4b1ea6b70316f0ebd1d7e",
   "crates": {
     "abnf 0.12.0": {
       "name": "abnf",
@@ -20748,6 +20748,10 @@
             {
               "id": "walkdir 2.3.3",
               "target": "walkdir"
+            },
+            {
+              "id": "walrus 0.21.1",
+              "target": "walrus"
             },
             {
               "id": "warp 0.3.7",
@@ -91748,6 +91752,7 @@
     "uuid 1.11.0",
     "vsock 0.4.0",
     "walkdir 2.3.3",
+    "walrus 0.21.1",
     "warp 0.3.7",
     "wasm-bindgen 0.2.95",
     "wasm-encoder 0.217.0",

--- a/Cargo.Bazel.Fuzzing.toml.lock
+++ b/Cargo.Bazel.Fuzzing.toml.lock
@@ -3502,6 +3502,7 @@ dependencies = [
  "uuid",
  "vsock",
  "walkdir",
+ "walrus",
  "warp",
  "wasm-bindgen",
  "wasm-encoder 0.217.0",

--- a/Cargo.Bazel.Fuzzing.toml.lock
+++ b/Cargo.Bazel.Fuzzing.toml.lock
@@ -325,7 +325,7 @@ dependencies = [
  "bytes",
  "cfg-if 1.0.0",
  "http 1.2.0",
- "indexmap 2.2.6",
+ "indexmap 2.7.1",
  "schemars",
  "serde",
  "serde_json",
@@ -3316,7 +3316,7 @@ dependencies = [
  "icrc1-test-env",
  "icrc1-test-suite",
  "idna 1.0.3",
- "indexmap 2.2.6",
+ "indexmap 2.7.1",
  "indicatif",
  "indoc",
  "inferno 0.12.0",
@@ -4578,7 +4578,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 dependencies = [
  "fallible-iterator 0.3.0",
- "indexmap 2.2.6",
+ "indexmap 2.7.1",
  "stable_deref_trait",
 ]
 
@@ -4640,7 +4640,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap 2.2.6",
+ "indexmap 2.7.1",
  "slab",
  "tokio",
  "tokio-util",
@@ -4659,7 +4659,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 1.2.0",
- "indexmap 2.2.6",
+ "indexmap 2.7.1",
  "slab",
  "tokio",
  "tokio-util",
@@ -4781,15 +4781,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4"
 dependencies = [
  "http 1.2.0",
-]
-
-[[package]]
-name = "heck"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
-dependencies = [
- "unicode-segmentation",
 ]
 
 [[package]]
@@ -5804,9 +5795,9 @@ dependencies = [
 
 [[package]]
 name = "ic-wasm"
-version = "0.8.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45bc33855672981ae4a2f4e77c1a77d1bdc0756fb1b36ad0dbe47df77a955e2d"
+checksum = "adf6b69fa1b319ce3ffb65564bc16c15d1b0d91a679d8a9ae6e69c2a71f09ec6"
 dependencies = [
  "anyhow",
  "candid",
@@ -5817,6 +5808,7 @@ dependencies = [
  "serde_json",
  "thiserror 1.0.68",
  "walrus",
+ "wasmparser 0.223.1",
 ]
 
 [[package]]
@@ -6149,12 +6141,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.2.6"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
+checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.5",
+ "hashbrown 0.15.2",
  "serde",
 ]
 
@@ -6184,7 +6176,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "321f0f839cd44a4686e9504b0a62b4d69a50b62072144c71c68f5873c167b8d9"
 dependencies = [
  "ahash 0.8.11",
- "indexmap 2.2.6",
+ "indexmap 2.7.1",
  "is-terminal",
  "itoa",
  "log",
@@ -6207,7 +6199,7 @@ dependencies = [
  "crossbeam-utils",
  "dashmap 6.1.0",
  "env_logger 0.11.2",
- "indexmap 2.2.6",
+ "indexmap 2.7.1",
  "itoa",
  "log",
  "num-format",
@@ -7823,7 +7815,7 @@ checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
 dependencies = [
  "crc32fast",
  "hashbrown 0.15.2",
- "indexmap 2.2.6",
+ "indexmap 2.7.1",
  "memchr",
 ]
 
@@ -7974,7 +7966,7 @@ checksum = "1e32339a5dc40459130b3bd269e9892439f55b33e772d2a9d402a789baaf4e8a"
 dependencies = [
  "futures-core",
  "futures-sink",
- "indexmap 2.2.6",
+ "indexmap 2.7.1",
  "js-sys",
  "once_cell",
  "pin-project-lite",
@@ -8489,7 +8481,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d3afd2628e69da2be385eb6f2fd57c8ac7977ceeff6dc166ff1657b0e386a9"
 dependencies = [
  "fixedbitset",
- "indexmap 2.2.6",
+ "indexmap 2.7.1",
 ]
 
 [[package]]
@@ -10416,7 +10408,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45a28f4c49489add4ce10783f7911893516f15afe45d015608d41faca6bc4d29"
 dependencies = [
  "dyn-clone",
- "indexmap 2.2.6",
+ "indexmap 2.7.1",
  "schemars_derive",
  "serde",
  "serde_json",
@@ -10891,7 +10883,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.2.6",
+ "indexmap 2.7.1",
  "itoa",
  "ryu",
  "serde",
@@ -12172,7 +12164,7 @@ version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 2.2.6",
+ "indexmap 2.7.1",
  "toml_datetime",
  "winnow 0.5.17",
 ]
@@ -12183,7 +12175,7 @@ version = "0.22.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "583c44c02ad26b0c3f3066fe629275e50627026c51ac2e595cca4c230ce1ce1d"
 dependencies = [
- "indexmap 2.2.6",
+ "indexmap 2.7.1",
  "toml_datetime",
  "winnow 0.6.20",
 ]
@@ -12261,7 +12253,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "hdrhistogram",
- "indexmap 2.2.6",
+ "indexmap 2.7.1",
  "pin-project-lite",
  "slab",
  "sync_wrapper 0.1.2",
@@ -12888,9 +12880,9 @@ dependencies = [
 
 [[package]]
 name = "walrus"
-version = "0.21.1"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "467611cafbc8a84834b77d2b4bb191fd2f5769752def8340407e924390c6883b"
+checksum = "d68aa3c7b80be75c8458fc087453e5a31a226cfffede2e9b932393b2ea1c624a"
 dependencies = [
  "anyhow",
  "gimli 0.26.2",
@@ -12904,14 +12896,14 @@ dependencies = [
 
 [[package]]
 name = "walrus-macro"
-version = "0.19.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a6e5bd22c71e77d60140b0bd5be56155a37e5bd14e24f5f87298040d0cc40d7"
+checksum = "439ad39ff894c43c9649fa724cdde9a6fc50b855d517ef071a93e5df82fe51d3"
 dependencies = [
- "heck 0.3.3",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -13066,7 +13058,7 @@ dependencies = [
  "anyhow",
  "arbitrary",
  "flagset",
- "indexmap 2.2.6",
+ "indexmap 2.7.1",
  "leb128",
  "wasm-encoder 0.212.0",
  "wasmparser 0.212.0",
@@ -13092,7 +13084,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c35daf77afb4f9b14016625144a391085ec2ca99ca9cc53ed291bb53ab5278d"
 dependencies = [
  "bitflags 2.6.0",
- "indexmap 2.2.6",
+ "indexmap 2.7.1",
  "semver",
 ]
 
@@ -13105,7 +13097,7 @@ dependencies = [
  "ahash 0.8.11",
  "bitflags 2.6.0",
  "hashbrown 0.14.5",
- "indexmap 2.2.6",
+ "indexmap 2.7.1",
  "semver",
  "serde",
 ]
@@ -13119,7 +13111,7 @@ dependencies = [
  "ahash 0.8.11",
  "bitflags 2.6.0",
  "hashbrown 0.14.5",
- "indexmap 2.2.6",
+ "indexmap 2.7.1",
  "semver",
  "serde",
 ]
@@ -13132,7 +13124,20 @@ checksum = "9845c470a2e10b61dd42c385839cdd6496363ed63b5c9e420b5488b77bd22083"
 dependencies = [
  "bitflags 2.6.0",
  "hashbrown 0.15.2",
- "indexmap 2.2.6",
+ "indexmap 2.7.1",
+ "semver",
+ "serde",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.223.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "664b980991ed9a8c834eb528a8979ab1109edcf52dc05dd5751e2cc3fb31035d"
+dependencies = [
+ "bitflags 2.6.0",
+ "hashbrown 0.15.2",
+ "indexmap 2.7.1",
  "semver",
  "serde",
 ]
@@ -13171,7 +13176,7 @@ dependencies = [
  "cc",
  "cfg-if 1.0.0",
  "hashbrown 0.14.5",
- "indexmap 2.2.6",
+ "indexmap 2.7.1",
  "libc",
  "log",
  "mach2",
@@ -13268,7 +13273,7 @@ dependencies = [
  "cranelift-bitset",
  "cranelift-entity",
  "gimli 0.31.1",
- "indexmap 2.2.6",
+ "indexmap 2.7.1",
  "log",
  "object 0.36.7",
  "postcard",
@@ -13359,7 +13364,7 @@ checksum = "8358319c2dd1e4db79e3c1c5d3a5af84956615343f9f89f4e4996a36816e06e6"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
- "indexmap 2.2.6",
+ "indexmap 2.7.1",
  "wit-parser",
 ]
 
@@ -13803,7 +13808,7 @@ checksum = "fbe1538eea6ea5ddbe5defd0dc82539ad7ba751e1631e9185d24a931f0a5adc8"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap 2.2.6",
+ "indexmap 2.7.1",
  "log",
  "semver",
  "serde",

--- a/Cargo.Bazel.json.lock
+++ b/Cargo.Bazel.json.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "34b2fa2cada359e6aee6f832cf54bc671aee41960fc4f5e14cd06def81a4e428",
+  "checksum": "4af13c4b3641fd070cb2005708bf4c4f3f1022ea57bdae8780dccba8380cd53d",
   "crates": {
     "abnf 0.12.0": {
       "name": "abnf",
@@ -1779,7 +1779,7 @@
               "target": "http"
             },
             {
-              "id": "indexmap 2.2.6",
+              "id": "indexmap 2.7.1",
               "target": "indexmap"
             },
             {
@@ -19832,7 +19832,7 @@
               "target": "ic_verify_bls_signature"
             },
             {
-              "id": "ic-wasm 0.8.4",
+              "id": "ic-wasm 0.9.5",
               "target": "ic_wasm"
             },
             {
@@ -19864,7 +19864,7 @@
               "target": "idna"
             },
             {
-              "id": "indexmap 2.2.6",
+              "id": "indexmap 2.7.1",
               "target": "indexmap"
             },
             {
@@ -20578,7 +20578,7 @@
               "target": "walkdir"
             },
             {
-              "id": "walrus 0.21.1",
+              "id": "walrus 0.22.0",
               "target": "walrus"
             },
             {
@@ -27520,7 +27520,7 @@
         "deps": {
           "common": [
             {
-              "id": "indexmap 2.2.6",
+              "id": "indexmap 2.7.1",
               "target": "indexmap"
             }
           ],
@@ -27852,7 +27852,7 @@
               "target": "http"
             },
             {
-              "id": "indexmap 2.2.6",
+              "id": "indexmap 2.7.1",
               "target": "indexmap"
             },
             {
@@ -27939,7 +27939,7 @@
               "target": "http"
             },
             {
-              "id": "indexmap 2.2.6",
+              "id": "indexmap 2.7.1",
               "target": "indexmap"
             },
             {
@@ -28230,7 +28230,8 @@
         ],
         "crate_features": {
           "common": [
-            "default-hasher"
+            "default-hasher",
+            "serde"
           ],
           "selects": {}
         },
@@ -28239,6 +28240,10 @@
             {
               "id": "foldhash 0.1.4",
               "target": "foldhash"
+            },
+            {
+              "id": "serde 1.0.217",
+              "target": "serde"
             }
           ],
           "selects": {}
@@ -28592,54 +28597,6 @@
         "MIT"
       ],
       "license_file": "LICENSE"
-    },
-    "heck 0.3.3": {
-      "name": "heck",
-      "version": "0.3.3",
-      "package_url": "https://github.com/withoutboats/heck",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/heck/0.3.3/download",
-          "sha256": "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "heck",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "heck",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "unicode-segmentation 1.10.1",
-              "target": "unicode_segmentation"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2018",
-        "version": "0.3.3"
-      },
-      "license": "MIT OR Apache-2.0",
-      "license_ids": [
-        "Apache-2.0",
-        "MIT"
-      ],
-      "license_file": "LICENSE-APACHE"
     },
     "heck 0.4.1": {
       "name": "heck",
@@ -34280,14 +34237,14 @@
       ],
       "license_file": null
     },
-    "ic-wasm 0.8.4": {
+    "ic-wasm 0.9.5": {
       "name": "ic-wasm",
-      "version": "0.8.4",
+      "version": "0.9.5",
       "package_url": "https://github.com/dfinity/ic-wasm",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/ic-wasm/0.8.4/download",
-          "sha256": "45bc33855672981ae4a2f4e77c1a77d1bdc0756fb1b36ad0dbe47df77a955e2d"
+          "url": "https://static.crates.io/crates/ic-wasm/0.9.5/download",
+          "sha256": "adf6b69fa1b319ce3ffb65564bc16c15d1b0d91a679d8a9ae6e69c2a71f09ec6"
         }
       },
       "targets": [
@@ -34365,14 +34322,18 @@
               "target": "thiserror"
             },
             {
-              "id": "walrus 0.21.1",
+              "id": "walrus 0.22.0",
               "target": "walrus"
+            },
+            {
+              "id": "wasmparser 0.223.1",
+              "target": "wasmparser"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.8.4"
+        "version": "0.9.5"
       },
       "license": "Apache-2.0",
       "license_ids": [
@@ -36294,14 +36255,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "indexmap 2.2.6": {
+    "indexmap 2.7.1": {
       "name": "indexmap",
-      "version": "2.2.6",
+      "version": "2.7.1",
       "package_url": "https://github.com/indexmap-rs/indexmap",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/indexmap/2.2.6/download",
-          "sha256": "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
+          "url": "https://static.crates.io/crates/indexmap/2.7.1/download",
+          "sha256": "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
         }
       },
       "targets": [
@@ -36338,7 +36299,7 @@
               "target": "equivalent"
             },
             {
-              "id": "hashbrown 0.14.5",
+              "id": "hashbrown 0.15.2",
               "target": "hashbrown"
             },
             {
@@ -36349,7 +36310,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "2.2.6"
+        "version": "2.7.1"
       },
       "license": "Apache-2.0 OR MIT",
       "license_ids": [
@@ -36513,7 +36474,7 @@
               "target": "ahash"
             },
             {
-              "id": "indexmap 2.2.6",
+              "id": "indexmap 2.7.1",
               "target": "indexmap"
             },
             {
@@ -36631,7 +36592,7 @@
               "target": "env_logger"
             },
             {
-              "id": "indexmap 2.2.6",
+              "id": "indexmap 2.7.1",
               "target": "indexmap"
             },
             {
@@ -47438,7 +47399,7 @@
               "target": "hashbrown"
             },
             {
-              "id": "indexmap 2.2.6",
+              "id": "indexmap 2.7.1",
               "target": "indexmap"
             },
             {
@@ -48393,7 +48354,7 @@
               "target": "futures_sink"
             },
             {
-              "id": "indexmap 2.2.6",
+              "id": "indexmap 2.7.1",
               "target": "indexmap"
             },
             {
@@ -66402,7 +66363,7 @@
               "target": "dyn_clone"
             },
             {
-              "id": "indexmap 2.2.6",
+              "id": "indexmap 2.7.1",
               "target": "indexmap",
               "alias": "indexmap2"
             },
@@ -69237,7 +69198,7 @@
         "deps": {
           "common": [
             {
-              "id": "indexmap 2.2.6",
+              "id": "indexmap 2.7.1",
               "target": "indexmap"
             },
             {
@@ -78062,7 +78023,7 @@
         "deps": {
           "common": [
             {
-              "id": "indexmap 2.2.6",
+              "id": "indexmap 2.7.1",
               "target": "indexmap"
             },
             {
@@ -78126,7 +78087,7 @@
         "deps": {
           "common": [
             {
-              "id": "indexmap 2.2.6",
+              "id": "indexmap 2.7.1",
               "target": "indexmap"
             },
             {
@@ -78571,7 +78532,7 @@
               "target": "hdrhistogram"
             },
             {
-              "id": "indexmap 2.2.6",
+              "id": "indexmap 2.7.1",
               "target": "indexmap"
             },
             {
@@ -82240,14 +82201,14 @@
       ],
       "license_file": "LICENSE-MIT"
     },
-    "walrus 0.21.1": {
+    "walrus 0.22.0": {
       "name": "walrus",
-      "version": "0.21.1",
+      "version": "0.22.0",
       "package_url": "https://github.com/rustwasm/walrus",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/walrus/0.21.1/download",
-          "sha256": "467611cafbc8a84834b77d2b4bb191fd2f5769752def8340407e924390c6883b"
+          "url": "https://static.crates.io/crates/walrus/0.22.0/download",
+          "sha256": "d68aa3c7b80be75c8458fc087453e5a31a226cfffede2e9b932393b2ea1c624a"
         }
       },
       "targets": [
@@ -82306,13 +82267,13 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "walrus-macro 0.19.0",
+              "id": "walrus-macro 0.22.0",
               "target": "walrus_macro"
             }
           ],
           "selects": {}
         },
-        "version": "0.21.1"
+        "version": "0.22.0"
       },
       "license": "MIT/Apache-2.0",
       "license_ids": [
@@ -82321,14 +82282,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "walrus-macro 0.19.0": {
+    "walrus-macro 0.22.0": {
       "name": "walrus-macro",
-      "version": "0.19.0",
+      "version": "0.22.0",
       "package_url": "https://github.com/rustwasm/walrus/tree/crates/macro",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/walrus-macro/0.19.0/download",
-          "sha256": "0a6e5bd22c71e77d60140b0bd5be56155a37e5bd14e24f5f87298040d0cc40d7"
+          "url": "https://static.crates.io/crates/walrus-macro/0.22.0/download",
+          "sha256": "439ad39ff894c43c9649fa724cdde9a6fc50b855d517ef071a93e5df82fe51d3"
         }
       },
       "targets": [
@@ -82353,7 +82314,7 @@
         "deps": {
           "common": [
             {
-              "id": "heck 0.3.3",
+              "id": "heck 0.5.0",
               "target": "heck"
             },
             {
@@ -82365,14 +82326,14 @@
               "target": "quote"
             },
             {
-              "id": "syn 1.0.109",
+              "id": "syn 2.0.87",
               "target": "syn"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.19.0"
+        "version": "0.22.0"
       },
       "license": "MIT/Apache-2.0",
       "license_ids": [
@@ -83273,7 +83234,7 @@
               "target": "flagset"
             },
             {
-              "id": "indexmap 2.2.6",
+              "id": "indexmap 2.7.1",
               "target": "indexmap"
             },
             {
@@ -83400,7 +83361,7 @@
               "target": "bitflags"
             },
             {
-              "id": "indexmap 2.2.6",
+              "id": "indexmap 2.7.1",
               "target": "indexmap"
             },
             {
@@ -83472,7 +83433,7 @@
               "target": "hashbrown"
             },
             {
-              "id": "indexmap 2.2.6",
+              "id": "indexmap 2.7.1",
               "target": "indexmap"
             },
             {
@@ -83549,7 +83510,7 @@
               "target": "hashbrown"
             },
             {
-              "id": "indexmap 2.2.6",
+              "id": "indexmap 2.7.1",
               "target": "indexmap"
             },
             {
@@ -83648,6 +83609,107 @@
         },
         "edition": "2021",
         "version": "0.221.2"
+      },
+      "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "data_glob": [
+          "**"
+        ]
+      },
+      "license": "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT",
+      "license_ids": [
+        "Apache-2.0",
+        "MIT"
+      ],
+      "license_file": null
+    },
+    "wasmparser 0.223.1": {
+      "name": "wasmparser",
+      "version": "0.223.1",
+      "package_url": "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasmparser",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/wasmparser/0.223.1/download",
+          "sha256": "664b980991ed9a8c834eb528a8979ab1109edcf52dc05dd5751e2cc3fb31035d"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "wasmparser",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        },
+        {
+          "BuildScript": {
+            "crate_name": "build_script_build",
+            "crate_root": "build.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "wasmparser",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": {
+          "common": [
+            "component-model",
+            "default",
+            "features",
+            "hash-collections",
+            "serde",
+            "simd",
+            "std",
+            "validate"
+          ],
+          "selects": {}
+        },
+        "deps": {
+          "common": [
+            {
+              "id": "bitflags 2.6.0",
+              "target": "bitflags"
+            },
+            {
+              "id": "hashbrown 0.15.2",
+              "target": "hashbrown"
+            },
+            {
+              "id": "indexmap 2.7.1",
+              "target": "indexmap"
+            },
+            {
+              "id": "semver 1.0.22",
+              "target": "semver"
+            },
+            {
+              "id": "serde 1.0.217",
+              "target": "serde"
+            },
+            {
+              "id": "wasmparser 0.223.1",
+              "target": "build_script_build"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "0.223.1"
       },
       "build_script_attrs": {
         "compile_data_glob": [
@@ -83860,7 +83922,7 @@
               "target": "hashbrown"
             },
             {
-              "id": "indexmap 2.2.6",
+              "id": "indexmap 2.7.1",
               "target": "indexmap"
             },
             {
@@ -84565,7 +84627,7 @@
               "target": "gimli"
             },
             {
-              "id": "indexmap 2.2.6",
+              "id": "indexmap 2.7.1",
               "target": "indexmap"
             },
             {
@@ -85073,7 +85135,7 @@
               "target": "heck"
             },
             {
-              "id": "indexmap 2.2.6",
+              "id": "indexmap 2.7.1",
               "target": "indexmap"
             },
             {
@@ -88659,7 +88721,7 @@
               "target": "id_arena"
             },
             {
-              "id": "indexmap 2.2.6",
+              "id": "indexmap 2.7.1",
               "target": "indexmap"
             },
             {
@@ -90354,7 +90416,7 @@
   },
   "binary_crates": [
     "canbench 0.1.9",
-    "ic-wasm 0.8.4",
+    "ic-wasm 0.9.5",
     "metrics-proxy 0.1.0"
   ],
   "workspace_members": {
@@ -91471,7 +91533,7 @@
     "ic-transport-types 0.39.2",
     "ic-utils 0.39.0",
     "ic-verify-bls-signature 0.6.0",
-    "ic-wasm 0.8.4",
+    "ic-wasm 0.9.5",
     "ic-xrc-types 1.2.0",
     "ic0 0.18.11",
     "ic_bls12_381 0.10.0",
@@ -91479,7 +91541,7 @@
     "icrc1-test-env 0.1.1",
     "icrc1-test-suite 0.1.1",
     "idna 1.0.3",
-    "indexmap 2.2.6",
+    "indexmap 2.7.1",
     "indicatif 0.17.5",
     "indoc 1.0.9",
     "inferno 0.12.0",
@@ -91665,7 +91727,7 @@
     "uuid 1.11.0",
     "vsock 0.4.0",
     "walkdir 2.3.3",
-    "walrus 0.21.1",
+    "walrus 0.22.0",
     "warp 0.3.7",
     "wasm-bindgen 0.2.95",
     "wasm-encoder 0.217.0",

--- a/Cargo.Bazel.json.lock
+++ b/Cargo.Bazel.json.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "17de1def1da665950e9706970f1d7a252f0741fefc1f3525dabfa2d8461227cf",
+  "checksum": "34b2fa2cada359e6aee6f832cf54bc671aee41960fc4f5e14cd06def81a4e428",
   "crates": {
     "abnf 0.12.0": {
       "name": "abnf",
@@ -20576,6 +20576,10 @@
             {
               "id": "walkdir 2.3.3",
               "target": "walkdir"
+            },
+            {
+              "id": "walrus 0.21.1",
+              "target": "walrus"
             },
             {
               "id": "warp 0.3.7",
@@ -91661,6 +91665,7 @@
     "uuid 1.11.0",
     "vsock 0.4.0",
     "walkdir 2.3.3",
+    "walrus 0.21.1",
     "warp 0.3.7",
     "wasm-bindgen 0.2.95",
     "wasm-encoder 0.217.0",

--- a/Cargo.Bazel.toml.lock
+++ b/Cargo.Bazel.toml.lock
@@ -326,7 +326,7 @@ dependencies = [
  "bytes",
  "cfg-if 1.0.0",
  "http 1.2.0",
- "indexmap 2.2.6",
+ "indexmap 2.7.1",
  "schemars",
  "serde",
  "serde_json",
@@ -3305,7 +3305,7 @@ dependencies = [
  "icrc1-test-env",
  "icrc1-test-suite",
  "idna 1.0.3",
- "indexmap 2.2.6",
+ "indexmap 2.7.1",
  "indicatif",
  "indoc",
  "inferno 0.12.0",
@@ -4567,7 +4567,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 dependencies = [
  "fallible-iterator 0.3.0",
- "indexmap 2.2.6",
+ "indexmap 2.7.1",
  "stable_deref_trait",
 ]
 
@@ -4629,7 +4629,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap 2.2.6",
+ "indexmap 2.7.1",
  "slab",
  "tokio",
  "tokio-util",
@@ -4648,7 +4648,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 1.2.0",
- "indexmap 2.2.6",
+ "indexmap 2.7.1",
  "slab",
  "tokio",
  "tokio-util",
@@ -4771,15 +4771,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4"
 dependencies = [
  "http 1.2.0",
-]
-
-[[package]]
-name = "heck"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
-dependencies = [
- "unicode-segmentation",
 ]
 
 [[package]]
@@ -5794,9 +5785,9 @@ dependencies = [
 
 [[package]]
 name = "ic-wasm"
-version = "0.8.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45bc33855672981ae4a2f4e77c1a77d1bdc0756fb1b36ad0dbe47df77a955e2d"
+checksum = "adf6b69fa1b319ce3ffb65564bc16c15d1b0d91a679d8a9ae6e69c2a71f09ec6"
 dependencies = [
  "anyhow",
  "candid",
@@ -5807,6 +5798,7 @@ dependencies = [
  "serde_json",
  "thiserror 1.0.68",
  "walrus",
+ "wasmparser 0.223.1",
 ]
 
 [[package]]
@@ -6139,12 +6131,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.2.6"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
+checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.5",
+ "hashbrown 0.15.2",
  "serde",
 ]
 
@@ -6174,7 +6166,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "321f0f839cd44a4686e9504b0a62b4d69a50b62072144c71c68f5873c167b8d9"
 dependencies = [
  "ahash 0.8.11",
- "indexmap 2.2.6",
+ "indexmap 2.7.1",
  "is-terminal",
  "itoa",
  "log",
@@ -6197,7 +6189,7 @@ dependencies = [
  "crossbeam-utils",
  "dashmap 6.1.0",
  "env_logger 0.11.2",
- "indexmap 2.2.6",
+ "indexmap 2.7.1",
  "itoa",
  "log",
  "num-format",
@@ -7814,7 +7806,7 @@ checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
 dependencies = [
  "crc32fast",
  "hashbrown 0.15.2",
- "indexmap 2.2.6",
+ "indexmap 2.7.1",
  "memchr",
 ]
 
@@ -7965,7 +7957,7 @@ checksum = "1e32339a5dc40459130b3bd269e9892439f55b33e772d2a9d402a789baaf4e8a"
 dependencies = [
  "futures-core",
  "futures-sink",
- "indexmap 2.2.6",
+ "indexmap 2.7.1",
  "js-sys",
  "once_cell",
  "pin-project-lite",
@@ -10412,7 +10404,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45a28f4c49489add4ce10783f7911893516f15afe45d015608d41faca6bc4d29"
 dependencies = [
  "dyn-clone",
- "indexmap 2.2.6",
+ "indexmap 2.7.1",
  "schemars_derive",
  "serde",
  "serde_json",
@@ -10887,7 +10879,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.2.6",
+ "indexmap 2.7.1",
  "itoa",
  "ryu",
  "serde",
@@ -12168,7 +12160,7 @@ version = "0.19.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8123f27e969974a3dfba720fdb560be359f57b44302d280ba72e76a74480e8a"
 dependencies = [
- "indexmap 2.2.6",
+ "indexmap 2.7.1",
  "toml_datetime",
  "winnow 0.5.0",
 ]
@@ -12179,7 +12171,7 @@ version = "0.22.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "583c44c02ad26b0c3f3066fe629275e50627026c51ac2e595cca4c230ce1ce1d"
 dependencies = [
- "indexmap 2.2.6",
+ "indexmap 2.7.1",
  "toml_datetime",
  "winnow 0.6.20",
 ]
@@ -12257,7 +12249,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "hdrhistogram",
- "indexmap 2.2.6",
+ "indexmap 2.7.1",
  "pin-project-lite",
  "slab",
  "sync_wrapper 0.1.2",
@@ -12884,9 +12876,9 @@ dependencies = [
 
 [[package]]
 name = "walrus"
-version = "0.21.1"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "467611cafbc8a84834b77d2b4bb191fd2f5769752def8340407e924390c6883b"
+checksum = "d68aa3c7b80be75c8458fc087453e5a31a226cfffede2e9b932393b2ea1c624a"
 dependencies = [
  "anyhow",
  "gimli 0.26.2",
@@ -12900,14 +12892,14 @@ dependencies = [
 
 [[package]]
 name = "walrus-macro"
-version = "0.19.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a6e5bd22c71e77d60140b0bd5be56155a37e5bd14e24f5f87298040d0cc40d7"
+checksum = "439ad39ff894c43c9649fa724cdde9a6fc50b855d517ef071a93e5df82fe51d3"
 dependencies = [
- "heck 0.3.3",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -13062,7 +13054,7 @@ dependencies = [
  "anyhow",
  "arbitrary",
  "flagset",
- "indexmap 2.2.6",
+ "indexmap 2.7.1",
  "leb128",
  "wasm-encoder 0.212.0",
  "wasmparser 0.212.0",
@@ -13088,7 +13080,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c35daf77afb4f9b14016625144a391085ec2ca99ca9cc53ed291bb53ab5278d"
 dependencies = [
  "bitflags 2.6.0",
- "indexmap 2.2.6",
+ "indexmap 2.7.1",
  "semver",
 ]
 
@@ -13101,7 +13093,7 @@ dependencies = [
  "ahash 0.8.11",
  "bitflags 2.6.0",
  "hashbrown 0.14.5",
- "indexmap 2.2.6",
+ "indexmap 2.7.1",
  "semver",
  "serde",
 ]
@@ -13115,7 +13107,7 @@ dependencies = [
  "ahash 0.8.11",
  "bitflags 2.6.0",
  "hashbrown 0.14.5",
- "indexmap 2.2.6",
+ "indexmap 2.7.1",
  "semver",
  "serde",
 ]
@@ -13128,7 +13120,20 @@ checksum = "9845c470a2e10b61dd42c385839cdd6496363ed63b5c9e420b5488b77bd22083"
 dependencies = [
  "bitflags 2.6.0",
  "hashbrown 0.15.2",
- "indexmap 2.2.6",
+ "indexmap 2.7.1",
+ "semver",
+ "serde",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.223.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "664b980991ed9a8c834eb528a8979ab1109edcf52dc05dd5751e2cc3fb31035d"
+dependencies = [
+ "bitflags 2.6.0",
+ "hashbrown 0.15.2",
+ "indexmap 2.7.1",
  "semver",
  "serde",
 ]
@@ -13167,7 +13172,7 @@ dependencies = [
  "cc",
  "cfg-if 1.0.0",
  "hashbrown 0.14.5",
- "indexmap 2.2.6",
+ "indexmap 2.7.1",
  "libc",
  "log",
  "mach2",
@@ -13264,7 +13269,7 @@ dependencies = [
  "cranelift-bitset",
  "cranelift-entity",
  "gimli 0.31.1",
- "indexmap 2.2.6",
+ "indexmap 2.7.1",
  "log",
  "object 0.36.7",
  "postcard",
@@ -13355,7 +13360,7 @@ checksum = "8358319c2dd1e4db79e3c1c5d3a5af84956615343f9f89f4e4996a36816e06e6"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
- "indexmap 2.2.6",
+ "indexmap 2.7.1",
  "wit-parser",
 ]
 
@@ -13798,7 +13803,7 @@ checksum = "fbe1538eea6ea5ddbe5defd0dc82539ad7ba751e1631e9185d24a931f0a5adc8"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap 2.2.6",
+ "indexmap 2.7.1",
  "log",
  "semver",
  "serde",

--- a/Cargo.Bazel.toml.lock
+++ b/Cargo.Bazel.toml.lock
@@ -3491,6 +3491,7 @@ dependencies = [
  "uuid",
  "vsock",
  "walkdir",
+ "walrus",
  "warp",
  "wasm-bindgen",
  "wasm-encoder 0.217.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10885,6 +10885,7 @@ dependencies = [
 name = "ic-nns-integration-tests"
 version = "0.9.0"
 dependencies = [
+ "anyhow",
  "assert_matches",
  "async-trait",
  "bytes",
@@ -10921,6 +10922,7 @@ dependencies = [
  "ic-nervous-system-integration-tests",
  "ic-nervous-system-root",
  "ic-nervous-system-runtime",
+ "ic-nervous-system-string",
  "ic-nns-common",
  "ic-nns-constants",
  "ic-nns-governance",
@@ -10949,6 +10951,7 @@ dependencies = [
  "ic-xrc-types",
  "icp-ledger",
  "icrc-ledger-types",
+ "inferno 0.12.1",
  "itertools 0.12.1",
  "lazy_static",
  "lifeline",
@@ -10967,6 +10970,7 @@ dependencies = [
  "serde_cbor",
  "strum",
  "tokio",
+ "wasmparser 0.217.1",
  "wat",
  "xrc-mock",
 ]

--- a/bazel/external_crates.bzl
+++ b/bazel/external_crates.bzl
@@ -161,7 +161,7 @@ def external_crates_repository(name, cargo_lockfile, lockfile, sanitizers_enable
         annotations = CRATE_ANNOTATIONS,
         packages = {
             "walrus": crate.spec(
-                version = "^0.21.1",
+                version = "^0.22",
             ),
             "actix-rt": crate.spec(
                 version = "^2.10.0",
@@ -672,7 +672,7 @@ def external_crates_repository(name, cargo_lockfile, lockfile, sanitizers_enable
                 default_features = False,
             ),
             "ic-wasm": crate.spec(
-                version = "^0.8.4",
+                version = "^0.9.0",
                 features = [
                     "exe",
                 ],

--- a/bazel/external_crates.bzl
+++ b/bazel/external_crates.bzl
@@ -160,6 +160,9 @@ def external_crates_repository(name, cargo_lockfile, lockfile, sanitizers_enable
         cargo_config = "//:bazel/cargo.config",
         annotations = CRATE_ANNOTATIONS,
         packages = {
+            "walrus": crate.spec(
+                version = "^0.21.1",
+            ),
             "actix-rt": crate.spec(
                 version = "^2.10.0",
             ),

--- a/rs/nervous_system/governance/src/index/neuron_principal.rs
+++ b/rs/nervous_system/governance/src/index/neuron_principal.rs
@@ -132,6 +132,7 @@ where
     NeuronId: Storable + Default + Clone + Ord,
     M: Memory,
 {
+    pub // DO NOT MERGE
     principal_and_neuron_id_set: StableBTreeMap<(Principal, NeuronId), (), M>,
 }
 

--- a/rs/nns/governance/BUILD.bazel
+++ b/rs/nns/governance/BUILD.bazel
@@ -236,6 +236,7 @@ rust_canister(
     srcs = ["canister/canister.rs"],
     aliases = ALIASES,
     compile_data = ["canister/governance.did"],
+    keep_name_section = True,
     proc_macro_deps = MACRO_DEPENDENCIES,
     service_file = ":canister/governance.did",
     visibility = ["//visibility:public"],

--- a/rs/nns/governance/canister/canister.rs
+++ b/rs/nns/governance/canister/canister.rs
@@ -673,10 +673,10 @@ fn principal_id_to_neuron_count() // DO NOT MERGE
                 .next()
                 .unwrap()
                 .id() == neuron_id;
-            let count = &mut if is_in_heap {
-                counts.0
+            let count = if is_in_heap {
+                &mut counts.0
             } else {
-                counts.1
+                &mut counts.1
             };
 
             *count += 1;

--- a/rs/nns/governance/canister/canister.rs
+++ b/rs/nns/governance/canister/canister.rs
@@ -899,10 +899,11 @@ fn get_network_economics_parameters() -> NetworkEconomics {
     NetworkEconomics::from(response)
 }
 
-#[heartbeat]
+/* DO NOT MERGE #[heartbeat]
 async fn heartbeat() {
     governance_mut().run_periodic_tasks().await
 }
+*/
 
 // Protobuf interface.
 

--- a/rs/nns/governance/canister/canister.rs
+++ b/rs/nns/governance/canister/canister.rs
@@ -26,9 +26,9 @@ use ic_nns_governance::{
     neuron_data_validation::NeuronDataValidationSummary,
     pb::v1::{self as gov_pb, Governance as InternalGovernanceProto},
     storage::{
-        grow_upgrades_memory_to, validate_stable_storage, with_upgrades_memory,
-        allocate_ic_wasm_instrument_memory_once,
+        allocate_ic_wasm_instrument_memory_once, grow_upgrades_memory_to, validate_stable_storage,
         where_ic_wasm_instrument_memory as where_ic_wasm_instrument_memory_native,
+        with_upgrades_memory,
     },
 };
 #[cfg(feature = "test")]

--- a/rs/nns/governance/canister/canister.rs
+++ b/rs/nns/governance/canister/canister.rs
@@ -477,6 +477,8 @@ fn panic_with_probability(probability: f64, message: &str) {
 fn canister_init() {
     ic_cdk::setup();
 
+    allocate_ic_wasm_instrument_memory_once();
+
     match ApiGovernanceProto::decode(&arg_data_raw()[..]) {
         Err(err) => {
             println!(

--- a/rs/nns/governance/canister/canister.rs
+++ b/rs/nns/governance/canister/canister.rs
@@ -529,6 +529,10 @@ fn canister_pre_upgrade() {
 fn canister_post_upgrade() {
     println!("{}Executing post upgrade", LOG_PREFIX);
 
+    // This primes some caches in Candid. I do not expect this to help us very much, tbh.
+    use candid::CandidType;
+    ListNeuronsResponse::ty();
+
     allocate_ic_wasm_instrument_memory_once();
 
     let restored_state = with_upgrades_memory(|memory| {

--- a/rs/nns/governance/src/storage.rs
+++ b/rs/nns/governance/src/storage.rs
@@ -283,7 +283,7 @@ pub(crate) fn with_stable_neuron_store_mut<R>(
     })
 }
 
-pub(crate) fn with_stable_neuron_indexes<R>(
+pub /* DO NOT MERGE (crate */ fn with_stable_neuron_indexes<R>(
     f: impl FnOnce(&neuron_indexes::StableNeuronIndexes<VM>) -> R,
 ) -> R {
     STATE.with(|state| {

--- a/rs/nns/governance/src/storage.rs
+++ b/rs/nns/governance/src/storage.rs
@@ -156,13 +156,15 @@ impl State {
 /// Once this has been released, it can be deleted. At the same time, forgetting
 /// to delete this is also fine.
 pub fn allocate_ic_wasm_instrument_memory_once() {
-    let instrument_memory = MEMORY_MANAGER.with(|memory_manager| {
-        memory_manager.borrow().get(IC_WASM_INSTRUMENT_MEMORY_ID)
-    });
+    let instrument_memory = MEMORY_MANAGER
+        .with(|memory_manager| memory_manager.borrow().get(IC_WASM_INSTRUMENT_MEMORY_ID));
 
     let grow_pages = IC_WASM_INSTRUMENT_MEMORY_SIZE_PAGES.saturating_sub(instrument_memory.size());
     if grow_pages < 1 {
-        println!("ic-wasm instrument memory has already been alocated. grow_pages = {}", grow_pages /* DO NOT MERGE */);
+        println!(
+            "ic-wasm instrument memory has already been alocated. grow_pages = {}",
+            grow_pages /* DO NOT MERGE */
+        );
         return;
     }
 
@@ -194,8 +196,7 @@ pub fn where_ic_wasm_instrument_memory() -> (u64, u64) {
     // Read bucket size. This is usually 128 pages (where a page is 64 KiB).
     let bucket_size_pages = {
         type Array = [u8; 2];
-        let array = Array::try_from(&buffer[6..8])
-            .expect("Unable to convert from slice to u16.");
+        let array = Array::try_from(&buffer[6..8]).expect("Unable to convert from slice to u16.");
         u16::from_le_bytes(array) as u64
     };
 
@@ -240,7 +241,8 @@ pub fn where_ic_wasm_instrument_memory() -> (u64, u64) {
         // Haven't found any ic-wasm instrument buckets (yet).
     }
 
-    let Some(first_ic_wasm_instrument_bucket_number) = first_ic_wasm_instrument_bucket_number else {
+    let Some(first_ic_wasm_instrument_bucket_number) = first_ic_wasm_instrument_bucket_number
+    else {
         return (0, 0);
     };
 

--- a/rs/nns/governance/src/storage.rs
+++ b/rs/nns/governance/src/storage.rs
@@ -31,6 +31,18 @@ const NODE_PROVIDER_REWARDS_LOG_DATA_MEMORY_ID: MemoryId = MemoryId::new(15);
 
 const VOTING_STATE_MACHINES_MEMORY_ID: MemoryId = MemoryId::new(16);
 
+// Used by ic-wasm instrument for profiling data, which can be used to generate
+// flame graphs.
+const IC_WASM_INSTRUMENT_MEMORY_ID_U8: u8 = 17; // Because MemoryId does not let you convert back.
+const IC_WASM_INSTRUMENT_MEMORY_ID: MemoryId = MemoryId::new(IC_WASM_INSTRUMENT_MEMORY_ID_U8);
+// This is the value used by an example in the documentation. Specifically,
+// https://github.com/dfinity/ic-wasm?tab=readme-ov-file#instrument-experimental
+// I see no explanation for why that example used this value, but if it's in an
+// example, it probably isn't a terrible choice. One good thing about this is
+// that it is a multiple of the standard MemoryManager bucket size (128). A page
+// of stable memory is 64 KiB. Thus, this is equivalent to 256 MiB.
+const IC_WASM_INSTRUMENT_MEMORY_SIZE_PAGES: u64 = 4096;
+
 pub mod neuron_indexes;
 pub mod neurons;
 
@@ -135,6 +147,103 @@ impl State {
         validate_stable_log(&self.audit_events_log);
         validate_stable_log(&self.node_provider_rewards_log);
     }
+}
+
+/// Returns (start_page_index, size_pages) of stable memory that ic-wasm instrument can use.
+///
+/// If the memory has already been allocated, makes no changes.
+///
+/// Once this has been released, it can be deleted. At the same time, forgetting
+/// to delete this is also fine.
+pub fn allocate_ic_wasm_instrument_memory_once() {
+    let instrument_memory = MEMORY_MANAGER.with(|memory_manager| {
+        memory_manager.borrow().get(IC_WASM_INSTRUMENT_MEMORY_ID)
+    });
+
+    let grow_pages = IC_WASM_INSTRUMENT_MEMORY_SIZE_PAGES.saturating_sub(instrument_memory.size());
+    if grow_pages < 1 {
+        println!("ic-wasm instrument memory has already been alocated. grow_pages = {}", grow_pages /* DO NOT MERGE */);
+        return;
+    }
+
+    let grow_failed = instrument_memory.grow(grow_pages) < 0;
+    if grow_failed {
+        println!("Unable to allocate enough space for ic-wasm instrument.");
+    }
+
+    let (start_address, page_limit) = where_ic_wasm_instrument_memory();
+    println!("Finished allocating ic-wasm instrument memory:");
+    println!("  start_address = {}", start_address);
+    println!("  page_limit = {}", page_limit);
+}
+
+pub fn where_ic_wasm_instrument_memory() -> (u64, u64) {
+    // Read the first page of stable memory.
+    let mut buffer = [0_u8; ic_cdk::api::stable::WASM_PAGE_SIZE_IN_BYTES];
+    DefaultMemoryImpl::default().read(0, &mut buffer);
+
+    // Inspect header to make sure stable memory is being managed by MemoryManager.
+    assert_eq!(String::from_utf8_lossy(&buffer[0..3]), "MGR");
+    assert_eq!(buffer[3], 1);
+
+    // let allocated_buckets = buffer[4..6]
+
+    // Read bucket size. This is usually 128 pages (where a page is 64 KiB).
+    let bucket_size_pages = {
+        type Array = [u8; 2];
+        let array = Array::try_from(&buffer[6..8])
+            .expect("Unable to convert from slice to u16.");
+        u16::from_le_bytes(array) as u64
+    };
+
+    // Scan bucket allocations, that is, who ones each bucket.
+
+    // This is copied from ic_stable_structures, which does not make this
+    // public. Notice that this is equal to 2^15.
+    const MAX_NUM_BUCKETS: u64 = 32_768;
+
+    let bucket_allocations_offset =
+        3 // Magic
+        + 1 // Layout version
+        + 2 // Number of allocated buckets
+        + 2 // Bucket size (in pages) = N
+        + 32 // Reserved space
+        + 8 * 255 // Sizes of memories 0 - 254 (in pages)
+    ;
+
+    let mut first_ic_wasm_instrument_bucket_number = None;
+    let mut ic_wasm_instrument_size_buckets = 0;
+    for bucket_number in 1..=MAX_NUM_BUCKETS {
+        let i = (bucket_allocations_offset + bucket_number - 1) as usize;
+        let belongs_to_ic_wasm_instrument = buffer[i] == IC_WASM_INSTRUMENT_MEMORY_ID_U8;
+
+        if belongs_to_ic_wasm_instrument {
+            if first_ic_wasm_instrument_bucket_number.is_none() {
+                first_ic_wasm_instrument_bucket_number = Some(bucket_number);
+            }
+            ic_wasm_instrument_size_buckets += 1;
+            continue;
+        }
+
+        if first_ic_wasm_instrument_bucket_number.is_some() {
+            // Found the first bucket that does not belong to the ic-wasm
+            // instrument Memory after a bucket that does belong to ic-wasm
+            // instrument. There could be more after this, but we ignore those.
+            // Also, if MemoryManager does not fragment our buckets, that
+            // wouldn't happen in practice. Therefore, we stop searching now.
+            break;
+        }
+
+        // Haven't found any ic-wasm instrument buckets (yet).
+    }
+
+    let Some(first_ic_wasm_instrument_bucket_number) = first_ic_wasm_instrument_bucket_number else {
+        return (0, 0);
+    };
+
+    let start_page = 1 + bucket_size_pages * (first_ic_wasm_instrument_bucket_number - 1);
+    let size_pages = ic_wasm_instrument_size_buckets * bucket_size_pages;
+    (start_page, size_pages)
 }
 
 pub fn with_upgrades_memory<R>(f: impl FnOnce(&VM) -> R) -> R {

--- a/rs/nns/governance/src/storage.rs
+++ b/rs/nns/governance/src/storage.rs
@@ -184,7 +184,7 @@ pub fn allocate_ic_wasm_instrument_memory_once() {
 pub fn where_ic_wasm_instrument_memory() -> (u64, u64) {
     // Read the first page of stable memory. This is the area reserved by
     // MemoryManager for its own use. Most of this area is not actually used.
-    let mut buffer = [0_u8; ic_cdk::api::stable::WASM_PAGE_SIZE_IN_BYTES];
+    let mut buffer = [0_u8; ic_cdk::api::stable::WASM_PAGE_SIZE_IN_BYTES as usize];
     DefaultMemoryImpl::default().read(0, &mut buffer);
 
     // Inspect header to make sure stable memory is being managed by MemoryManager.

--- a/rs/nns/governance/src/storage.rs
+++ b/rs/nns/governance/src/storage.rs
@@ -41,7 +41,7 @@ const IC_WASM_INSTRUMENT_MEMORY_ID: MemoryId = MemoryId::new(IC_WASM_INSTRUMENT_
 // example, it probably isn't a terrible choice. One good thing about this is
 // that it is a multiple of the standard MemoryManager bucket size (128). A page
 // of stable memory is 64 KiB. Thus, this is equivalent to 256 MiB.
-const IC_WASM_INSTRUMENT_MEMORY_SIZE_PAGES: u64 = 4096;
+const IC_WASM_INSTRUMENT_MEMORY_SIZE_PAGES: u64 = 4096 /* DO NOT MERGE */ * 8;
 
 pub mod neuron_indexes;
 pub mod neurons;

--- a/rs/nns/governance/src/storage/neuron_indexes.rs
+++ b/rs/nns/governance/src/storage/neuron_indexes.rs
@@ -66,7 +66,7 @@ where
 }
 
 /// Neuron indexes based on stable storage.
-pub(crate) struct StableNeuronIndexes<Memory>
+pub /* DO NOT MERGE (crate)*/ struct StableNeuronIndexes<Memory>
 where
     Memory: ic_stable_structures::Memory,
 {

--- a/rs/nns/integration_tests/BUILD.bazel
+++ b/rs/nns/integration_tests/BUILD.bazel
@@ -13,6 +13,7 @@ BASE_DEPENDENCIES = [
     "//rs/nervous_system/clients",
     "//rs/nervous_system/common",
     "//rs/nervous_system/common/test_keys",
+    "//rs/nervous_system/string",
     "//rs/nns/cmc",
     "//rs/nns/common",
     "//rs/nns/governance/api",
@@ -25,6 +26,7 @@ BASE_DEPENDENCIES = [
     "//rs/rust_canisters/dfn_protobuf",
     "//rs/sns/swap",
     "//rs/types/base_types",
+    "@crate_index//:anyhow",
     "@crate_index//:assert_matches",
     "@crate_index//:bytes",
     "@crate_index//:candid",
@@ -33,10 +35,12 @@ BASE_DEPENDENCIES = [
     "@crate_index//:ic-cdk",
     "@crate_index//:ic-cdk-timers",
     "@crate_index//:ic-stable-structures",
+    "@crate_index//:inferno",
     "@crate_index//:lazy_static",
     "@crate_index//:prometheus-parse",
     "@crate_index//:prost",
     "@crate_index//:strum",
+    "@crate_index//:wasmparser",
 ] + select({
     "@rules_rust//rust/platform:wasm32-unknown-unknown": [],
     "//conditions:default": [

--- a/rs/nns/integration_tests/BUILD.bazel
+++ b/rs/nns/integration_tests/BUILD.bazel
@@ -37,6 +37,7 @@ BASE_DEPENDENCIES = [
     "@crate_index//:ic-stable-structures",
     "@crate_index//:inferno",
     "@crate_index//:lazy_static",
+    "@crate_index//:pretty_assertions",
     "@crate_index//:prometheus-parse",
     "@crate_index//:prost",
     "@crate_index//:strum",

--- a/rs/nns/integration_tests/BUILD.bazel
+++ b/rs/nns/integration_tests/BUILD.bazel
@@ -37,7 +37,6 @@ BASE_DEPENDENCIES = [
     "@crate_index//:ic-stable-structures",
     "@crate_index//:inferno",
     "@crate_index//:lazy_static",
-    "@crate_index//:pretty_assertions",
     "@crate_index//:prometheus-parse",
     "@crate_index//:prost",
     "@crate_index//:strum",

--- a/rs/nns/integration_tests/BUILD.bazel
+++ b/rs/nns/integration_tests/BUILD.bazel
@@ -278,6 +278,7 @@ rust_ic_test_suite_with_extra_srcs(
             "src/copy_inactive_neurons_to_stable_memory.rs",
             "src/governance_mem_test.rs",
             "src/upgrade_canisters_with_golden_nns_state.rs",
+            "src/why_list_neurons_expensive.rs",
         ],
     ),
     aliases = ALIASES,
@@ -424,4 +425,29 @@ rust_ic_test(
         "requires-network",  # Because mainnet state is downloaded (and used).
     ],
     deps = DEPENDENCIES + DEV_DEPENDENCIES,
+)
+
+rust_ic_test(
+    name = "why_list_neurons_expensive",
+    # This uses on the order of 10 GB of disk space.
+    # Therefore, size = "large" is not large enough.
+    size = "enormous",
+    srcs = [
+        "src/why_list_neurons_expensive.rs",
+    ],
+    aliases = ALIASES,
+    crate_root = "src/why_list_neurons_expensive.rs",
+    data = DEV_DATA,
+    env = DEV_ENV,
+    proc_macro_deps = MACRO_DEPENDENCIES + MACRO_DEV_DEPENDENCIES,
+    tags = [
+        "nns_tests_nightly",  # Run this test in the nns-tests-nightly GitHub Action job.
+        "no-sandbox",  # such that the test can access the file $SSH_AUTH_SOCK.
+        "requires-network",  # Because mainnet state is downloaded (and used).
+    ],
+    deps = DEPENDENCIES + DEV_DEPENDENCIES + [
+        "@crate_index//:flate2",
+        "@crate_index//:ic-wasm",
+        "@crate_index//:walrus",
+    ],
 )

--- a/rs/nns/integration_tests/Cargo.toml
+++ b/rs/nns/integration_tests/Cargo.toml
@@ -29,6 +29,7 @@ path = "test_canisters/canister_playground_canister.rs"
 
 # Dependencies required to compile the test canisters.
 [dependencies]
+anyhow = { workspace = true }
 assert_matches = { workspace = true }
 async-trait = { workspace = true }
 bytes = { workspace = true }
@@ -48,6 +49,7 @@ ic-limits = { path = "../../limits" }
 ic-nervous-system-clients = { path = "../../nervous_system/clients" }
 ic-nervous-system-common = { path = "../../nervous_system/common" }
 ic-nervous-system-runtime = { path = "../../nervous_system/runtime" }
+ic-nervous-system-string = { path = "../../nervous_system/string" }
 ic-nns-common = { path = "../common" }
 ic-nns-governance = { path = "../governance" }
 ic-nns-governance-api = { path = "../governance/api" }
@@ -58,11 +60,13 @@ ic-stable-structures = { workspace = true }
 ic-test-utilities-metrics = { path = "../../test_utilities/metrics" }
 icp-ledger = { path = "../../ledger_suite/icp" }
 icrc-ledger-types = { path = "../../../packages/icrc-ledger-types" }
+inferno = { workspace = true}
 lazy_static = { workspace = true }
 lifeline = { path = "../handlers/lifeline/impl" }
 prometheus-parse = { workspace = true }
 prost = { workspace = true }
 strum = { workspace = true }
+wasmparser = { workspace = true }
 
 # Dependencies required to compile the tests.
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/rs/nns/integration_tests/Cargo.toml
+++ b/rs/nns/integration_tests/Cargo.toml
@@ -63,6 +63,7 @@ icrc-ledger-types = { path = "../../../packages/icrc-ledger-types" }
 inferno = { workspace = true}
 lazy_static = { workspace = true }
 lifeline = { path = "../handlers/lifeline/impl" }
+pretty_assertions = { workspace = true }
 prometheus-parse = { workspace = true }
 prost = { workspace = true }
 strum = { workspace = true }

--- a/rs/nns/integration_tests/src/why_list_neurons_expensive.rs
+++ b/rs/nns/integration_tests/src/why_list_neurons_expensive.rs
@@ -123,7 +123,7 @@ fn test_why_list_neurons_expensive() {
 
     // Enable profiling of the governance canister.
 
-    // Have ic-wasm instrument the governance WASM.
+    // Have ic-wasm instrument the governance WASM for profiling.
     let mut instrumented_governance_wasm =
         walrus::Module::from_buffer(&decompress_gz(&governance_wasm_gz))
             .expect("walrus cannot cope with our WASM.");
@@ -138,8 +138,9 @@ fn test_why_list_neurons_expensive() {
     .unwrap();
     let instrumented_governance_wasm = instrumented_governance_wasm.emit_wasm();
 
-    // Read some metadata from the profiling-enabled governance WASM that will
-    // later be used to visualize where instructions are consumed. This is based on
+    // Read some metadata from the profiling-enabled governance WASM. This
+    // metadata will later be used to visualize where instructions are consumed.
+    // This is based on
     // https://sourcegraph.com/github.com/dfinity/ic-repl@746bea25ddd4cc98709f6b9eaa283f32a21ac30d/-/blob/src/helper.rs?L504
     let name_custom_section_payload = Decode!(
         &read_custom_section(&instrumented_governance_wasm, "icp:public name"),
@@ -163,7 +164,7 @@ fn test_why_list_neurons_expensive() {
     println!("Ready for fine-grained performance measurement 👍");
     println!("");
 
-    // Make a bunch of list_neuron calls.
+    // Measure a variety of list_neuron calls.
     for (caller, (heap_neuron_count, stable_memory_neuron_count)) in principal_id_to_neuron_count {
         let is_principal_too_heavy = [
             PrincipalId::from_str("dies2-up6x4-i42et-avcop-xvl3v-it2mm-hqeuj-j4hyu-vz7wl-ewndz-dae").unwrap(),

--- a/rs/nns/integration_tests/src/why_list_neurons_expensive.rs
+++ b/rs/nns/integration_tests/src/why_list_neurons_expensive.rs
@@ -141,7 +141,7 @@ fn test_why_list_neurons_expensive() {
     // Step 2: Run the code under test (while profiling is enabled).
 
     let caller = PrincipalId::new_user_test_id(42); // DO NOT MERGE
-    list_neurons(
+    let result = list_neurons(
         &state_machine,
         caller,
         ListNeurons {
@@ -151,6 +151,9 @@ fn test_why_list_neurons_expensive() {
             neuron_ids: vec![],
         },
     );
+    println!("");
+    println!("list_neurons result:\n{:#?}", result);
+    println!("");
 
     // Step 3: Inspect results. In particular, generate flame graph.
 

--- a/rs/nns/integration_tests/src/why_list_neurons_expensive.rs
+++ b/rs/nns/integration_tests/src/why_list_neurons_expensive.rs
@@ -103,7 +103,7 @@ fn test_why_list_neurons_expensive() {
     // Have ic-wasm instrument the governance WASM for profiling.
     let mut instrumented_governance_wasm =
         walrus::Module::from_buffer(&decompress_gz(&governance_wasm_gz))
-            .expect("walrus cannot cope with our WASM.");
+            .expect("The Walrus library cannot cope with our WASM.");
     ic_wasm::instrumentation::instrument(
         &mut instrumented_governance_wasm,
         ic_wasm::instrumentation::Config {

--- a/rs/nns/integration_tests/src/why_list_neurons_expensive.rs
+++ b/rs/nns/integration_tests/src/why_list_neurons_expensive.rs
@@ -208,7 +208,7 @@ fn test_why_list_neurons_expensive() {
 
         // Print data that can be copied into a spreadsheet for further analysis.
         println!(
-            "{}\t{}\t{}\t{}",
+            "{},{},{},{}",
             caller, heap_neuron_count, stable_memory_neuron_count, unwrap_cost(cost),
         );
     }

--- a/rs/nns/integration_tests/src/why_list_neurons_expensive.rs
+++ b/rs/nns/integration_tests/src/why_list_neurons_expensive.rs
@@ -88,6 +88,28 @@ fn test_why_list_neurons_expensive() {
     println!("  page_limit = {}", page_limit);
     println!("");
 
+    let principal_to_neuron_count = state_machine.execute_ingress(
+        GOVERNANCE_CANISTER_ID,
+        "principal_to_neuron_count",
+        Encode!().unwrap(),
+    )
+    .unwrap();
+    let principal_to_neuron_count = match principal_to_neuron_count {
+        ic_types::ingress::WasmResult::Reply(ok) => ok,
+        doh => panic!("{:?}", doh),
+    };
+    let principal_to_neuron_count = Decode!(
+        &principal_to_neuron_count,
+        Vec<(PrincipalId, u64)>
+    )
+    .unwrap();
+    println!();
+    println!();
+    println!("principal_to_neuron_count:");
+    println!("{:#?}", principal_to_neuron_count);
+    println!();
+    println!();
+
     // DO NOT MERGE: THIS IS A HACK
     let page_limit = page_limit / 2;
 

--- a/rs/nns/integration_tests/src/why_list_neurons_expensive.rs
+++ b/rs/nns/integration_tests/src/why_list_neurons_expensive.rs
@@ -115,16 +115,6 @@ fn test_why_list_neurons_expensive() {
     .unwrap();
     let instrumented_governance_wasm = instrumented_governance_wasm.emit_wasm();
 
-    // Read some metadata from the profiling-enabled governance WASM. This
-    // metadata will later be used to visualize where instructions are consumed.
-    // This is based on
-    // https://sourcegraph.com/github.com/dfinity/ic-repl@746bea25ddd4cc98709f6b9eaa283f32a21ac30d/-/blob/src/helper.rs?L504
-    let name_custom_section_payload = Decode!(
-        &read_custom_section(&instrumented_governance_wasm, "icp:public name"),
-        BTreeMap<u16, String>
-    )
-    .unwrap();
-
     // Install the profiling-enabled governance WASM.
     println!("");
     println!("Installing governance WITH ic-wasm profiling ENABLED...");
@@ -132,7 +122,7 @@ fn test_why_list_neurons_expensive() {
     state_machine
         .upgrade_canister(
             GOVERNANCE_CANISTER_ID,
-            instrumented_governance_wasm,
+            instrumented_governance_wasm.clone(),
             vec![], // args
         )
         .unwrap();
@@ -218,6 +208,13 @@ fn test_why_list_neurons_expensive() {
             "list_neurons_no_width_{:0>4}_heap_neurons_{:0>4}_stable_memory_neurons_{}.svg",
             heap_neuron_count, stable_memory_neuron_count, caller,
         );
+        // I guess this is so that bars are labeled with names, not opaque IDs.
+        // See https://sourcegraph.com/github.com/dfinity/ic-repl@746bea25ddd4cc98709f6b9eaa283f32a21ac30d/-/blob/src/helper.rs?L504
+        let name_custom_section_payload = Decode!(
+            &read_custom_section(&instrumented_governance_wasm, "icp:public name"),
+            BTreeMap<u16, String>
+        )
+        .unwrap();
         let cost = render_profiling( // DO NOT MERGE
             profiling,
             &name_custom_section_payload,

--- a/rs/nns/integration_tests/src/why_list_neurons_expensive.rs
+++ b/rs/nns/integration_tests/src/why_list_neurons_expensive.rs
@@ -61,8 +61,8 @@ fn test_why_list_neurons_expensive() {
         &mut instrumented_governance_wasm,
         ic_wasm::instrumentation::Config {
             trace_only_funcs: vec![],
-            start_address: Some(start_address as i32),
-            page_limit: Some(page_limit as i32),
+            start_address: Some(i64::try_from(start_address).unwrap()),
+            page_limit: Some(i32::try_from(page_limit).unwrap()),
         },
     )
     .unwrap();

--- a/rs/nns/integration_tests/src/why_list_neurons_expensive.rs
+++ b/rs/nns/integration_tests/src/why_list_neurons_expensive.rs
@@ -105,7 +105,7 @@ fn test_why_list_neurons_expensive() {
     };
     let principal_id_to_neuron_count = Decode!(
         &principal_id_to_neuron_count,
-        Vec<(PrincipalId, u64)>
+        Vec<(PrincipalId, (u64, u64))>
     )
     .unwrap();
     {
@@ -164,7 +164,7 @@ fn test_why_list_neurons_expensive() {
     println!("");
 
     // Make a bunch of list_neuron calls.
-    for (caller, neuron_count) in principal_id_to_neuron_count {
+    for (caller, (heap_neuron_count, stable_memory_neuron_count)) in principal_id_to_neuron_count {
         let is_principal_too_heavy = [
             PrincipalId::from_str("dies2-up6x4-i42et-avcop-xvl3v-it2mm-hqeuj-j4hyu-vz7wl-ewndz-dae").unwrap(),
             PrincipalId::from_str("renrk-eyaaa-aaaaa-aaada-cai").unwrap(),
@@ -189,16 +189,27 @@ fn test_why_list_neurons_expensive() {
         let profiling = get_profiling(&state_machine, GOVERNANCE_CANISTER_ID);
 
         // Visualize where instructions get consumed.
+        let title = format!(
+            "{}/{} neurons ({})",
+            heap_neuron_count, stable_memory_neuron_count, caller,
+        );
+        let destination = format!(
+            "list_neurons_{:0>4}_heap_neurons_{:0>4}_stable_memory_neurons_{}.svg",
+            heap_neuron_count, stable_memory_neuron_count, caller,
+        );
         let cost = render_profiling( // DO NOT MERGE
             profiling,
             &name_custom_section_payload,
-            &format!("{} neurons ({})", neuron_count, caller), // title
-            PathBuf::from(format!("list_neurons_{:0>4}_neurons_{}.svg", neuron_count, caller)),
+            &title,
+            PathBuf::from(destination),
         )
         .unwrap();
 
         // Print data that can be copied into a spreadsheet for further analysis.
-        println!("{}\t{}\t{}", caller, neuron_count, unwrap_cost(cost));
+        println!(
+            "{}\t{}\t{}\t{}",
+            caller, heap_neuron_count, stable_memory_neuron_count, unwrap_cost(cost),
+        );
     }
 }
 

--- a/rs/nns/integration_tests/src/why_list_neurons_expensive.rs
+++ b/rs/nns/integration_tests/src/why_list_neurons_expensive.rs
@@ -163,14 +163,8 @@ fn test_why_list_neurons_expensive() {
     println!("Ready for fine-grained performance measurement 👍");
     println!("");
 
-    let mut previous_neuron_count = None;
     // Make a bunch of list_neuron calls.
     for (caller, neuron_count) in principal_id_to_neuron_count {
-
-        if neuron_count > 9000 {
-            continue;
-        }
-
         let is_principal_too_heavy = [
             PrincipalId::from_str("dies2-up6x4-i42et-avcop-xvl3v-it2mm-hqeuj-j4hyu-vz7wl-ewndz-dae").unwrap(),
             PrincipalId::from_str("renrk-eyaaa-aaaaa-aaada-cai").unwrap(),
@@ -178,19 +172,6 @@ fn test_why_list_neurons_expensive() {
         if is_principal_too_heavy {
             continue;
         }
-
-        match previous_neuron_count {
-            None => {
-                previous_neuron_count = Some(neuron_count as f64);
-            }
-            Some(ok) => {
-                let neuron_count = neuron_count as f64;
-                if neuron_count > 0.9 * ok {
-                    continue;
-                }
-                previous_neuron_count = Some(neuron_count);
-            }
-        };
 
         // Call code being measured.
         let _result = list_neurons(

--- a/rs/nns/integration_tests/src/why_list_neurons_expensive.rs
+++ b/rs/nns/integration_tests/src/why_list_neurons_expensive.rs
@@ -94,34 +94,6 @@ fn test_why_list_neurons_expensive() {
     println!("  page_limit = {}", page_limit);
     println!("");
 
-    // Grab a sample of principals that have "associated" neurons. More
-    // precisely, these principals either control or are a hotkey of some
-    // (nonzero number of) neurons. These will later be used as callers of the
-    // list_neurons method.
-    let principal_id_to_neuron_count = state_machine
-        .execute_ingress(
-            GOVERNANCE_CANISTER_ID,
-            "principal_id_to_neuron_count",
-            Encode!().unwrap(),
-        )
-        .unwrap();
-    let principal_id_to_neuron_count = match principal_id_to_neuron_count {
-        ic_types::ingress::WasmResult::Reply(ok) => ok,
-        doh => panic!("{:?}", doh),
-    };
-    let principal_id_to_neuron_count = Decode!(
-        &principal_id_to_neuron_count,
-        Vec<(PrincipalId, (u64, u64))>
-    )
-    .unwrap();
-    println!("");
-    println!("principal_id_to_neuron_count:");
-    println!(
-        "{}",
-        clamp_debug_len(&principal_id_to_neuron_count, 1 << 10)
-    );
-    println!("");
-
     // DO NOT MERGE: This is a hack that makes us use a only around half of the
     // stable memory that was allocated for tracing/profiling.
     let page_limit = page_limit / 2;
@@ -167,6 +139,34 @@ fn test_why_list_neurons_expensive() {
     println!("");
     println!("Done installing governance WITH ic-wasm profiling ENABLED.");
     println!("Ready for fine-grained performance measurement 👍");
+    println!("");
+
+    // Grab a sample of principals that have "associated" neurons. More
+    // precisely, these principals either control or are a hotkey of some
+    // (nonzero number of) neurons. These will later be used as callers of the
+    // list_neurons method.
+    let principal_id_to_neuron_count = state_machine
+        .execute_ingress(
+            GOVERNANCE_CANISTER_ID,
+            "principal_id_to_neuron_count",
+            Encode!().unwrap(),
+        )
+        .unwrap();
+    let principal_id_to_neuron_count = match principal_id_to_neuron_count {
+        ic_types::ingress::WasmResult::Reply(ok) => ok,
+        doh => panic!("{:?}", doh),
+    };
+    let principal_id_to_neuron_count = Decode!(
+        &principal_id_to_neuron_count,
+        Vec<(PrincipalId, (u64, u64))>
+    )
+    .unwrap();
+    println!("");
+    println!("principal_id_to_neuron_count:");
+    println!(
+        "{}",
+        clamp_debug_len(&principal_id_to_neuron_count, 1 << 10)
+    );
     println!("");
 
     // Measure a variety of list_neuron calls.

--- a/rs/nns/integration_tests/src/why_list_neurons_expensive.rs
+++ b/rs/nns/integration_tests/src/why_list_neurons_expensive.rs
@@ -1,0 +1,99 @@
+use candid::{Decode, Encode};
+use flate2::read::GzDecoder;
+use ic_base_types::PrincipalId;
+use ic_nns_constants::GOVERNANCE_CANISTER_ID;
+use ic_nns_governance_api::pb::v1::ListNeurons;
+use ic_nns_test_utils::state_test_helpers::{list_neurons, unwrap_wasm_result, get_profiling};
+use ic_nns_test_utils_golden_nns_state::new_state_machine_with_golden_nns_state_or_panic;
+use std::io::Read; // For flate2.
+
+fn decompress_gz(buffer: &[u8]) -> Vec<u8> {
+    let mut result = vec![];
+    let mut decoder = GzDecoder::new(buffer);
+    decoder.read_to_end(&mut result).unwrap();
+    result
+}
+
+#[test]
+fn test_why_list_neurons_expensive() {
+    // Step 1: Prepare the world
+
+    // Step 1.1: Load golden nns state into a StateMachine.
+    let state_machine = new_state_machine_with_golden_nns_state_or_panic();
+
+    // Step 1.2: Custom governance WASMs
+
+    // Step 1.2.1: Allocate stable memory for ic-wasm profiling. This happens during post_upgrade.
+    println!("\nAllocating stable memory for profiling...\n");
+    let governance_wasm_gz: Vec<u8> = canister_test::Project::cargo_bin_maybe_from_env(
+        "governance-canister",
+        /* features = */ &[],
+    )
+    .bytes();
+    state_machine.upgrade_canister(
+        GOVERNANCE_CANISTER_ID,
+        governance_wasm_gz.clone(),
+        vec![], // args
+    )
+    .unwrap();
+    let (start_address, page_limit) = Decode!(
+        &unwrap_wasm_result(
+            state_machine.query(
+                GOVERNANCE_CANISTER_ID,
+                "where_ic_wasm_instrument_memory",
+                Encode!().unwrap(),
+            )
+        ),
+        u64,
+        u64
+    )
+    .unwrap();
+    println!("");
+    println!("Result from ic_wasm_instrument_memory:");
+    println!("  start_address = {}", start_address);
+    println!("  page_limit = {}", page_limit);
+    println!("");
+
+    // Step 1.2.2: Enable ic-wasm profiling.
+    let mut instrumented_governance_wasm = walrus::Module::from_buffer(&decompress_gz(&governance_wasm_gz))
+        .expect("walrus cannot cope with our WASM.");
+    ic_wasm::instrumentation::instrument(
+        &mut instrumented_governance_wasm,
+        ic_wasm::instrumentation::Config {
+            trace_only_funcs: vec![],
+            start_address: Some(start_address as i32),
+            page_limit: Some(page_limit as i32),
+        },
+    )
+    .unwrap();
+    let instrumented_governance_wasm = instrumented_governance_wasm.emit_wasm();
+    println!("\nInstalling instrumented governance WASM...\n");
+    state_machine.upgrade_canister(
+        GOVERNANCE_CANISTER_ID,
+        instrumented_governance_wasm,
+        vec![], // args
+    )
+    .unwrap();
+    println!("\nDone installing instrumented governance WASM. Ready for fine-grained performance measurement 👍\n");
+
+    // Step 2: Run the code under test.
+
+    let caller = PrincipalId::new_user_test_id(42); // DO NOT MERGE
+    list_neurons(
+        &state_machine,
+        caller,
+        ListNeurons {
+            include_neurons_readable_by_caller: true,
+            include_public_neurons_in_full_neurons: Some(false),
+            include_empty_neurons_readable_by_caller: Some(false),
+            neuron_ids: vec![],
+        },
+    );
+
+    // Step 3: Inspect results. In particular, generate flame graph.
+
+    let profiling = get_profiling(&state_machine, GOVERNANCE_CANISTER_ID);
+    println!("\n\nprofiling:\n{:#?}", profiling);
+
+    panic!("\n\nHELLO WHY list_neurons EXPENSIVE\n\n");
+}

--- a/rs/nns/integration_tests/src/why_list_neurons_expensive.rs
+++ b/rs/nns/integration_tests/src/why_list_neurons_expensive.rs
@@ -183,7 +183,7 @@ fn test_why_list_neurons_expensive() {
     let profiling = get_profiling(&state_machine, GOVERNANCE_CANISTER_ID);
 
     // Step 3.2: Visualize. Output is at list_neurons.svg.
-    let lol_idk = render_profiling(
+    let _lol_idk = render_profiling( // DO NOT MERGE
         profiling,
         &name_custom_section_payload,
         "list_neurons", // title
@@ -192,6 +192,7 @@ fn test_why_list_neurons_expensive() {
     .unwrap();
 }
 
+#[allow(unused)]
 enum CostValue {
     Complete(u64),
     StartCost(u64),

--- a/rs/nns/integration_tests/src/why_list_neurons_expensive.rs
+++ b/rs/nns/integration_tests/src/why_list_neurons_expensive.rs
@@ -1,17 +1,48 @@
+use anyhow::anyhow;
 use candid::{Decode, Encode};
 use flate2::read::GzDecoder;
 use ic_base_types::PrincipalId;
+use ic_cdk::api::stable::WASM_PAGE_SIZE_IN_BYTES;
+use ic_nervous_system_string::clamp_debug_len;
 use ic_nns_constants::GOVERNANCE_CANISTER_ID;
 use ic_nns_governance_api::pb::v1::ListNeurons;
 use ic_nns_test_utils::state_test_helpers::{get_profiling, list_neurons, unwrap_wasm_result};
 use ic_nns_test_utils_golden_nns_state::new_state_machine_with_golden_nns_state_or_panic;
-use std::io::Read; // For flate2.
+use std::{
+    collections::BTreeMap,
+    io::Read, // For flate2.
+    path::PathBuf,
+};
+// TODO: Figure out how to implement read_custom_sections using the walrus
+// library so that we are not using two WASM libraries.
+use wasmparser::{Parser, Payload};
 
 fn decompress_gz(buffer: &[u8]) -> Vec<u8> {
     let mut result = vec![];
     let mut decoder = GzDecoder::new(buffer);
     decoder.read_to_end(&mut result).unwrap();
     result
+}
+
+fn read_custom_section(wasm_bytes: &[u8], query_name: &str) -> Vec<u8> {
+    let parser = Parser::new(0);
+    let mut custom_section_data = None;
+
+    for payload in parser.parse_all(wasm_bytes) {
+        match payload.unwrap() {
+            Payload::CustomSection(custom_section) => {
+                if custom_section.name() == query_name {
+                    custom_section_data = Some(custom_section.data().to_vec());
+                    // This assumes that there are no more custom sections with
+                    // the same name.
+                    break;
+                }
+            }
+            _ => continue, // Ignore other payloads
+        }
+    }
+
+    custom_section_data.unwrap()
 }
 
 #[test]
@@ -37,7 +68,7 @@ fn test_why_list_neurons_expensive() {
             vec![], // args
         )
         .unwrap();
-    let (start_address, page_limit) = Decode!(
+    let (start_page, page_limit) = Decode!(
         &unwrap_wasm_result(state_machine.query(
             GOVERNANCE_CANISTER_ID,
             "where_ic_wasm_instrument_memory",
@@ -47,9 +78,13 @@ fn test_why_list_neurons_expensive() {
         u64
     )
     .unwrap();
+    let start_address = start_page * WASM_PAGE_SIZE_IN_BYTES as u64;
     println!("");
     println!("Result from ic_wasm_instrument_memory:");
-    println!("  start_address = {}", start_address);
+    println!(
+        "  start_page = {} (start_address = {})",
+        start_page, start_address
+    );
     println!("  page_limit = {}", page_limit);
     println!("");
 
@@ -57,6 +92,8 @@ fn test_why_list_neurons_expensive() {
     let page_limit = page_limit / 2;
 
     // Step 1.2.2: Enable ic-wasm profiling.
+
+    // Step 1.2.2.1: Modify governance WASM.
     let mut instrumented_governance_wasm =
         walrus::Module::from_buffer(&decompress_gz(&governance_wasm_gz))
             .expect("walrus cannot cope with our WASM.");
@@ -70,7 +107,25 @@ fn test_why_list_neurons_expensive() {
     )
     .unwrap();
     let instrumented_governance_wasm = instrumented_governance_wasm.emit_wasm();
-    println!("\nInstalling instrumented governance WASM...\n");
+
+    // Step 1.2.2.2: Read some metadata from modified governance WASM that will later be used
+    // visualize. This is based on
+    // https://sourcegraph.com/github.com/dfinity/ic-repl@746bea25ddd4cc98709f6b9eaa283f32a21ac30d/-/blob/src/helper.rs?L504
+    let name_custom_section_payload = Decode!(
+        &read_custom_section(&instrumented_governance_wasm, "icp:public name"),
+        BTreeMap<u16, String>
+    )
+    .unwrap();
+    println!("");
+    println!(
+        "custom section 'name' payload:\n{:#?}",
+        name_custom_section_payload
+    );
+
+    // Step 1.2.2.3: Install modified governance WASM.
+    println!("");
+    println!("Installing governance WITH ic-wasm profiling ENABLED...");
+    println!("");
     state_machine
         .upgrade_canister(
             GOVERNANCE_CANISTER_ID,
@@ -78,9 +133,12 @@ fn test_why_list_neurons_expensive() {
             vec![], // args
         )
         .unwrap();
-    println!("\nDone installing instrumented governance WASM. Ready for fine-grained performance measurement 👍\n");
+    println!("");
+    println!("Done installing governance WITH ic-wasm profiling ENABLED.");
+    println!("Ready for fine-grained performance measurement 👍");
+    println!("");
 
-    // Step 2: Run the code under test.
+    // Step 2: Run the code under test (while profiling is enabled).
 
     let caller = PrincipalId::new_user_test_id(42); // DO NOT MERGE
     list_neurons(
@@ -96,8 +154,100 @@ fn test_why_list_neurons_expensive() {
 
     // Step 3: Inspect results. In particular, generate flame graph.
 
+    // Step 3.1: Fetch measurement.
     let profiling = get_profiling(&state_machine, GOVERNANCE_CANISTER_ID);
-    println!("\n\nprofiling:\n{:#?}", profiling);
 
-    panic!("\n\nHELLO WHY list_neurons EXPENSIVE\n\n");
+    // Step 3.2: Visualize. Output is at list_neurons.svg.
+    let lol_idk = render_profiling(
+        profiling,
+        &name_custom_section_payload,
+        "list_neurons", // title
+        PathBuf::from("list_neurons.svg"),
+    )
+    .unwrap();
+}
+
+enum CostValue {
+    Complete(u64),
+    StartCost(u64),
+}
+
+// Copied from https://github.com/dfinity/ic-repl/blob/746bea25ddd4cc98709f6b9eaa283f32a21ac30d/src/profiling.rs#L85C1-L162C2
+fn render_profiling(
+    input: Vec<(i32, i64)>,
+    names: &BTreeMap<u16, String>,
+    title: &str,
+    filename: PathBuf,
+) -> anyhow::Result<CostValue> {
+    use inferno::flamegraph::{from_reader, Options};
+    let mut stack = Vec::new();
+    let mut prefix = Vec::new();
+    let mut result = Vec::new();
+    let mut total = 0;
+    let mut prev = None;
+    let start_cost = input.first().map(|(_, count)| *count);
+    for (id, count) in input.into_iter() {
+        if id >= 0 {
+            stack.push((id, count, 0));
+            let name = match names.get(&(id as u16)) {
+                Some(name) => name.clone(),
+                None => "func_".to_string() + &id.to_string(),
+            };
+            prefix.push(name);
+        } else {
+            match stack.pop() {
+                None => return Err(anyhow!("pop empty stack")),
+                Some((start_id, start, children)) => {
+                    if start_id != -id {
+                        return Err(anyhow!("func id mismatch"));
+                    }
+                    let cost = count - start;
+                    let frame = prefix.join(";");
+                    prefix.pop().unwrap();
+                    if let Some((parent, parent_cost, children_cost)) = stack.pop() {
+                        stack.push((parent, parent_cost, children_cost + cost));
+                    } else {
+                        total += cost as u64;
+                    }
+                    match prev {
+                        Some(prev) if prev == frame => {
+                            // Add an empty spacer to avoid collapsing adjacent same-named calls
+                            // See https://github.com/jonhoo/inferno/issues/185#issuecomment-671393504
+                            result.push(format!("{};spacer 0", prefix.join(";")));
+                        }
+                        _ => (),
+                    }
+                    result.push(format!("{} {}", frame, cost - children));
+                    prev = Some(frame);
+                }
+            }
+        }
+    }
+    let cost = if !stack.is_empty() {
+        eprintln!("A trap occured or trace is too large");
+        CostValue::StartCost(start_cost.unwrap() as u64)
+    } else {
+        CostValue::Complete(total)
+    };
+    //println!("Cost: {} Wasm instructions", total);
+    let mut opt = Options::default();
+    opt.count_name = "instructions".to_string();
+    let title = if matches!(cost, CostValue::StartCost(_)) {
+        title.to_string() + " (incomplete)"
+    } else {
+        title.to_string()
+    };
+    opt.title = title;
+    opt.image_width = Some(1024);
+    opt.flame_chart = true;
+    opt.no_sort = true;
+    // Reserve result order to make flamegraph from left to right.
+    // See https://github.com/jonhoo/inferno/issues/236
+    result.reverse();
+    let logs = result.join("\n");
+    let reader = std::io::Cursor::new(logs);
+    println!("Flamegraph written to {}", filename.display());
+    let mut writer = std::fs::File::create(&filename)?;
+    from_reader(&mut opt, reader, &mut writer)?;
+    Ok(cost)
 }

--- a/rs/nns/integration_tests/src/why_list_neurons_expensive.rs
+++ b/rs/nns/integration_tests/src/why_list_neurons_expensive.rs
@@ -54,6 +54,9 @@ fn test_why_list_neurons_expensive() {
     println!("  page_limit = {}", page_limit);
     println!("");
 
+    // DO NOT MERGE: THIS IS A HACK
+    let page_limit = page_limit / 2;
+
     // Step 1.2.2: Enable ic-wasm profiling.
     let mut instrumented_governance_wasm = walrus::Module::from_buffer(&decompress_gz(&governance_wasm_gz))
         .expect("walrus cannot cope with our WASM.");

--- a/rs/nns/integration_tests/src/why_list_neurons_expensive.rs
+++ b/rs/nns/integration_tests/src/why_list_neurons_expensive.rs
@@ -190,6 +190,9 @@ fn test_why_list_neurons_expensive() {
                 include_public_neurons_in_full_neurons: Some(false),
                 include_empty_neurons_readable_by_caller: Some(true),
                 neuron_ids: vec![],
+                neuron_subaccounts: None,
+                page_number: None,
+                page_size: None,
             },
         );
         /*

--- a/rs/nns/integration_tests/src/why_list_neurons_expensive.rs
+++ b/rs/nns/integration_tests/src/why_list_neurons_expensive.rs
@@ -88,6 +88,7 @@ fn test_why_list_neurons_expensive() {
     println!("  page_limit = {}", page_limit);
     println!("");
 
+    /*
     let principal_to_neuron_count = state_machine.execute_ingress(
         GOVERNANCE_CANISTER_ID,
         "principal_to_neuron_count",
@@ -109,6 +110,7 @@ fn test_why_list_neurons_expensive() {
     println!("{:#?}", principal_to_neuron_count);
     println!();
     println!();
+    */
 
     // DO NOT MERGE: THIS IS A HACK
     let page_limit = page_limit / 2;
@@ -138,11 +140,13 @@ fn test_why_list_neurons_expensive() {
         BTreeMap<u16, String>
     )
     .unwrap();
+    /*
     println!("");
     println!(
         "custom section 'name' payload:\n{:#?}",
         name_custom_section_payload
     );
+    */
 
     // Step 1.2.2.3: Install modified governance WASM.
     println!("");

--- a/rs/nns/test_utils/src/state_test_helpers.rs
+++ b/rs/nns/test_utils/src/state_test_helpers.rs
@@ -2073,19 +2073,83 @@ pub fn get_average_icp_xdr_conversion_rate(
     Decode!(&bytes, IcpXdrConversionRateCertifiedResponse).unwrap()
 }
 
-/// Returns data that can be turned into a flame graph.
+/// Returned by the __get_profiling canister method.
 ///
-/// That is a pretty vague description, but it is the best I can give.
+/// More precisely, a Vec of these is returned.
 ///
-/// This is modeled after the following piece of code that someone shared with
-/// me about generating flame graphs:
+/// Because types (esp primitive types) do not convey the meaning/significance
+/// of the data they bear (e.g. the components of this type), you should really
+/// convert this to IcWasmTraceEvent. (Hence, "Primitive" is in the name of
+/// this.)
+pub type PrimitiveIcWasmTraceEvent = (
+    // function_id. Positive function_id indicates that the function was
+    // called. Negative indicates -function_id returned. Like paren, these must
+    // match in order for a trace to be well-formed. (If they don't,
+    // convert_trace_format_from_ic_wasm_to_inferno returns Err.)
+    i32,
+
+    // See the IcWasmTraceEvent::timestamp_instructions field.
+    i64,
+);
+
+pub enum IcWasmTraceEventType {
+    Call,
+    Return,
+}
+
+/// There are two kinds of events: function call, and return.
+pub struct IcWasmTraceEvent {
+    pub type_: IcWasmTraceEventType,
+
+    pub function_id: i32,
+
+    /// "When" this event occurred. The "clock" starts running from 0 when the
+    /// current request came in, stops when the canister awaits calls to other
+    /// canisters, and resumes when the await resumes. (And the the units is
+    /// instructions.)
+    pub timestamp_instructions: i64,
+}
+
+impl From<PrimitiveIcWasmTraceEvent> for IcWasmTraceEvent {
+    fn from(event: PrimitiveIcWasmTraceEvent) -> Self {
+        let (function_id, timestamp_instructions) = event;
+
+        let type_ = if function_id < 0 {
+            IcWasmTraceEventType::Return
+        } else {
+            IcWasmTraceEventType::Call
+        };
+
+        let function_id = function_id.abs();
+
+        Self {
+            type_,
+            function_id,
+            timestamp_instructions,
+        }
+    }
+}
+
+/// Returns the trace of the latest request that was executed (possibly, still in flight).
+///
+/// More precisely, a trace is a list of call and return events.
+///
+/// This implementation is based on
 ///
 ///     https://github.com/dfinity/ic-repl/blob/746bea25ddd4cc98709f6b9eaa283f32a21ac30d/src/profiling.rs#L46
 ///
-/// Basically, this de-paginates the __get_profiling (Candid) method of the
-/// callee canister. __get_profiling is a method that you can add to any WASM by
-/// calling ic_wasm::instrumentation::instrument.
-pub fn get_profiling(state_machine: &StateMachine, callee: CanisterId) -> Vec<(i32, i64)> {
+/// Basically, this de-paginates the __get_profiling canister method.
+/// __get_profiling is a method that you can add to any WASM by calling
+/// ic_wasm::instrumentation::instrument.
+pub fn get_profiling(state_machine: &StateMachine, callee: CanisterId) -> Vec<IcWasmTraceEvent> {
+    primitive_get_profiling(state_machine, callee)
+        .into_iter()
+        .map(IcWasmTraceEvent::from)
+        .collect()
+}
+
+// DO NOT MERGE: Get rid of this.
+pub fn primitive_get_profiling(state_machine: &StateMachine, callee: CanisterId) -> Vec<PrimitiveIcWasmTraceEvent> {
     let mut result = vec![];
     let mut current_index = 0;
     loop {

--- a/rs/nns/test_utils/src/state_test_helpers.rs
+++ b/rs/nns/test_utils/src/state_test_helpers.rs
@@ -2085,24 +2085,19 @@ pub fn get_average_icp_xdr_conversion_rate(
 /// Basically, this de-paginates the __get_profiling (Candid) method of the
 /// callee canister. __get_profiling is a method that you can add to any WASM by
 /// calling ic_wasm::instrumentation::instrument.
-pub fn get_profiling(
-    state_machine: &StateMachine,
-    callee: CanisterId,
-) -> Vec<(i32, i64)> {
+pub fn get_profiling(state_machine: &StateMachine, callee: CanisterId) -> Vec<(i32, i64)> {
     let mut result = vec![];
     let mut current_index = 0;
     loop {
         // Call the canister.
-        let get_profiling_result = state_machine.query(
-            callee,
-            "__get_profiling",
-            Encode!(&current_index).unwrap(),
-        );
+        let get_profiling_result =
+            state_machine.query(callee, "__get_profiling", Encode!(&current_index).unwrap());
 
         // Unpack its response.
         let (mut page, next_index): (Vec<(i32, i64)>, Option<i32>) = Decode!(
             &unwrap_wasm_result(get_profiling_result),
-            Vec<(i32, i64)>, Option<i32>
+            Vec<(i32, i64)>,
+            Option<i32>
         )
         .unwrap();
 

--- a/rs/nns/test_utils/src/state_test_helpers.rs
+++ b/rs/nns/test_utils/src/state_test_helpers.rs
@@ -62,7 +62,7 @@ use ic_sns_wasm::{
     init::SnsWasmCanisterInitPayload,
     pb::v1::{ListDeployedSnsesRequest, ListDeployedSnsesResponse},
 };
-use ic_state_machine_tests::{StateMachine, StateMachineBuilder};
+use ic_state_machine_tests::{StateMachine, StateMachineBuilder, UserError};
 use ic_test_utilities::universal_canister::{
     call_args, wasm as universal_canister_argument_builder, UNIVERSAL_CANISTER_WASM,
 };
@@ -97,6 +97,17 @@ pub fn reduce_state_machine_logging_unless_env_set() {
         Ok(_) => {}
         Err(_) => env::set_var("RUST_LOG", "ERROR"),
     }
+}
+
+pub fn unwrap_wasm_result(result: Result<WasmResult, UserError>) -> Vec<u8> {
+    let result = result.unwrap();
+
+    let result = match result {
+        WasmResult::Reply(ok) => ok,
+        _ => panic!("Unable to unwrap WasmResult."),
+    };
+
+    result
 }
 
 pub fn registry_get_changes_since(
@@ -2060,6 +2071,55 @@ pub fn get_average_icp_xdr_conversion_rate(
     )
     .expect("Failed to retrieve the average conversion rate");
     Decode!(&bytes, IcpXdrConversionRateCertifiedResponse).unwrap()
+}
+
+/// Returns data that can be turned into a flame graph.
+///
+/// That is a pretty vague description, but it is the best I can give.
+///
+/// This is modeled after the following piece of code that someone shared with
+/// me about generating flame graphs:
+///
+///     https://github.com/dfinity/ic-repl/blob/746bea25ddd4cc98709f6b9eaa283f32a21ac30d/src/profiling.rs#L46
+///
+/// Basically, this de-paginates the __get_profiling (Candid) method of the
+/// callee canister. __get_profiling is a method that you can add to any WASM by
+/// calling ic_wasm::instrumentation::instrument.
+pub fn get_profiling(
+    state_machine: &StateMachine,
+    callee: CanisterId,
+) -> Vec<(i32, i64)> {
+    let mut result = vec![];
+    let mut current_index = 0;
+    loop {
+        // Call the canister.
+        let get_profiling_result = state_machine.query(
+            callee,
+            "__get_profiling",
+            Encode!(&current_index).unwrap(),
+        );
+
+        // Unpack its response.
+        let (mut page, next_index): (Vec<(i32, i64)>, Option<i32>) = Decode!(
+            &unwrap_wasm_result(get_profiling_result),
+            Vec<(i32, i64)>, Option<i32>
+        )
+        .unwrap();
+
+        // Update result.
+        result.append(&mut page);
+
+        // If there is additional profiling data, fetch it in the next loop iteration.
+
+        let Some(next_index) = next_index else {
+            // We just fetched the last page of data, so we are done.
+            break;
+        };
+
+        current_index = next_index;
+    }
+
+    result
 }
 
 pub fn cmc_set_default_authorized_subnetworks(


### PR DESCRIPTION
# Usage

```
bazel test \
    --test_env=SSH_AUTH_SOCK \
    --test_output=streamed \
    --test_arg=--nocapture \
    //rs/nns/integration_tests:why_list_neurons_expensive \
&& cp -i \
  bazel-bin/rs/nns/integration_tests/test-127765624/why_list_neurons_expensive.runfiles/ic/list_neurons_*.svg \
  ./
```

(You need to be able to scp from dev@zh1-pyr07-zh.dfinity.network.)

# Limitations

1. The method that you want to measure must be an update, not a query. You can change a query to an update to measure it; however, make sure that you do **not** merge such changes, because they are very NOT backwards compatible!

2. You need to disable heartbeat. Otherwise, your flame graphs will have extraneous garbage in them.

# Next Steps

3. Prime Candid's cache by calling `ListNeuronsResponse::ty()` in `post_upgrade`, as suggested by Yan.

4. I'm not using all the space that I allocated to ic-wasm instrument. Before, when I tried to use all of it, I think it stomped on some other VirtualMemory's. (I guess the ideal solution is for ic-wasm instrument to support MemoryManager + VirtualMemory, rather than ask for raw stable memory space, but this might be difficult.)

5. Check the thread in the #dev channel where I am mainly talking to Yan Chen about getting this to work. I might be able to mine that thread for additional tasks to put into this "Next Steps" section...

6. Make as much of this sharable as possible, because every canister developer wants this (not just NNS).

# Analysis

One of the things that the `bazel test` command outputs is instructions vs. neurons. Using linear regression, I developed a very strong model (R^2 = 0.973):

```
Instructions = (1.03 * HeapNeurons + 5.08 StableMemoryNeurons + 47.5) * 1e5
```

This tells us that **the incremental cost of fetching and serving a neuron from heap is about 5x as much as it is from stable memory**.

This is also telling us that the **fixed cost/overhead of list_neurons is about 4.75 million instructions**.

See attached Jupyter notebook for source code: [list_neurons_instructions_vs_neuron_count.ipynb.txt][notebook]

[notebook]: https://github.com/user-attachments/files/17396897/list_neurons_instructions_vs_neuron_count.ipynb.txt

## Observations

When the model underestimates, the principal tends to have many neurons in stable memory. Likewise, when the model overestimates, the principal tends to have very few neurons in stable memory. Not sure why that is. This does not really make sense to me... (warning: I'm not a data scientist.)

### Anedotally

Seems like there can be BIG variance in the amount of instructions needed to load a neuron from stable memory. In some cases, it seems to take 100k instructions. In other cases, it seems to take 1.5M. It seems like what's happening here is that for "fast" stable memory neurons, theres no time spent fetching auxiliary data, but for "slow" stable memory neurons, most of the time fetching the neuron is spent loading auxiliary data. E.g. the neurons of principal ID an2fu-wmt2w-7fhvx-2g6qp-pq5pc-gdxu3-jfcr5-epiid-qhdzc-xnv3a-mae. We might want to dig into this, but I don't think there's time for that if we want to wrap up this investigation this week...

I think principal ID rxnbx-mhkez-7ckve-yboel-dnguy-dos76-hpdlg-fz5bf-xm5ou-72fre-wae is a good example of some (unsurprising) phenomena that seem to generalize:

1. A large chunk of instructions is spent in a couple of areas:
  1. Looking for the caller's neurons. This requires a range StableBTreeMap range scan. We maybe could speed this up if (some) of the index were in heap. It might make sense to split the index so that neurons in heap are **also indexed in heap**. However, this would introduce complexity.
  2. When a neuron is in stable memory, it takes much longer to load compared to heap (already noted earlier when discussing the linear model).
  3. Candid serialization of the response. This is significant when most of a principal's neurons are in heap. (This fact was hinted at earlier when the overhead of list_neurons was discussed in the context of the linear model.)

## Possible Solutions (not necessarily recommended!)

These three areas seem to be outside the control of the NNS. We maybe could speed up our use of stable memory by using a more efficient serialization scheme, but that would introduce more complexity.

When Rust + [WASM 64][64] support becomes mature, that might also help us avoid the cost of stable memory by keeping more data in heap. This has an important drawback though: we would have to "freeze dry" heap data when upgrading. If there is a large amount of this, upgrades become expensive. In any case, it does not seem like Rust + WASM 64 support is coming to the IC soon.

[64]: https://forum.dfinity.org/t/wasm64-beta-release-coming-soon/35791

# Examples

https://drive.google.com/file/d/1eBEuEKtKlmw4hpDkFYgrkX-h40jr9s_H/view?usp=sharing

💡 You will have to download this in order to be able click on boxes in this example ☝️ to zoom in on those boxes, because the Google Drive viewer does not seem to support this.

## Related Work

[Max's range_neurons optimization][zip]. IIUC, this is currently only used in background (data validation) tasks, so it would not help us here.

[zip]: https://github.com/dfinity/ic/pull/2033