### PR TITLE
chore(FI): FI-1505: Mark some FI tests as flaky

### DIFF
--- a/rs/rosetta-api/BUILD.bazel
+++ b/rs/rosetta-api/BUILD.bazel
@@ -181,6 +181,7 @@ rust_test_suite_with_extra_srcs(
         "tests/system_tests/common/*.rs",
         "tests/system_tests/test_cases/*.rs",
     ]),
+    flaky = True,
     proc_macro_deps = MACRO_DEV_DEPENDENCIES,
     deps = DEV_DEPENDENCIES + DEPENDENCIES,
 )

--- a/rs/rosetta-api/icp_ledger/index/BUILD.bazel
+++ b/rs/rosetta-api/icp_ledger/index/BUILD.bazel
@@ -103,5 +103,6 @@ rust_ic_test(
         "LEDGER_CANISTER_NOTIFY_METHOD_WASM_PATH": "$(rootpath //rs/rosetta-api/icp_ledger/ledger:ledger-canister-wasm-notify-method)",
         "LEDGER_CANISTER_WASM_PATH": "$(rootpath //rs/rosetta-api/icp_ledger/ledger:ledger-canister-wasm)",
     },
+    flaky = True,
     deps = [":ic-icp-index"] + DEPENDENCIES + DEV_DEPENDENCIES,
 )

--- a/rs/rosetta-api/icp_ledger/ledger/BUILD.bazel
+++ b/rs/rosetta-api/icp_ledger/ledger/BUILD.bazel
@@ -137,6 +137,7 @@ rust_ic_test(
         "ICP_LEDGER_DEPLOYED_VERSION_WASM_PATH": "$(rootpath @mainnet_icp_ledger_canister//file)",
         "LEDGER_CANISTER_WASM_PATH": "$(rootpath :ledger-canister-wasm)",
     },
+    flaky = True,
     deps = [
         # Keep sorted.
         ":ledger",


### PR DESCRIPTION
To unblock developers, (temporarily) mark the following FI tests as flaky:

- `//rs/rosetta-api/icp_ledger/ledger:ledger_canister_test`
- `//rs/rosetta-api/icp_ledger/index:ic_icp_index_test`
- `//rs/rosetta-api:icp_rosetta_system_tests_tests/system_tests/system_tests`