### PR TITLE
fix(IDX): allow empty OVERRIDE_DIDC_CHECK

### DIFF
--- a/bazel/candid.bzl
+++ b/bazel/candid.bzl
@@ -8,7 +8,7 @@ def _did_git_test_impl(ctx):
 
 set -xeuo pipefail
 
-if [[ $OVERRIDE_DIDC_CHECK == "true" ]]; then
+if [[ ${{OVERRIDE_DIDC_CHECK:-}} == "true" ]]; then
     echo "Override didc check requested. Skipping didc_check."
     exit 0
 fi


### PR DESCRIPTION
This fixes bash errors when OVERRIDE_DIDC_CHECK is unset, by defaulting it to the empty string. This is standard best practice with bash variable and fixes test failures in some environments.