### PR TITLE
test: Fix state sync tests flakiness

### DIFF
--- a/rs/tests/message_routing/BUILD.bazel
+++ b/rs/tests/message_routing/BUILD.bazel
@@ -8,7 +8,6 @@ system_test_nns(
     env = {
         "XNET_TEST_CANISTER_WASM_PATH": "$(rootpath //rs/rust_canisters/xnet_test:xnet-test-canister)",
     },
-    flaky = False,
     proc_macro_deps = MACRO_DEPENDENCIES,
     tags = [
         "k8s",
@@ -20,7 +19,6 @@ system_test_nns(
 
 system_test(
     name = "memory_safety_test",
-    flaky = False,
     proc_macro_deps = MACRO_DEPENDENCIES,
     tags = [
         "k8s",
@@ -37,7 +35,6 @@ system_test_nns(
     env = {
         "STATESYNC_TEST_CANISTER_WASM_PATH": "$(rootpath //rs/rust_canisters/statesync_test:statesync_test_canister)",
     },
-    flaky = False,
     proc_macro_deps = MACRO_DEPENDENCIES,
     tags = [
         "k8s",
@@ -54,7 +51,6 @@ system_test_nns(
     env = {
         "STATESYNC_TEST_CANISTER_WASM_PATH": "$(rootpath //rs/rust_canisters/statesync_test:statesync_test_canister)",
     },
-    flaky = False,
     proc_macro_deps = MACRO_DEPENDENCIES,
     tags = [
         "k8s",
@@ -72,7 +68,6 @@ system_test_nns(
     env = {
         "STATESYNC_TEST_CANISTER_WASM_PATH": "$(rootpath //rs/rust_canisters/statesync_test:statesync_test_canister)",
     },
-    flaky = False,
     malicious = True,
     proc_macro_deps = MACRO_DEPENDENCIES,
     tags = [

--- a/rs/tests/message_routing/BUILD.bazel
+++ b/rs/tests/message_routing/BUILD.bazel
@@ -37,7 +37,7 @@ system_test_nns(
     env = {
         "STATESYNC_TEST_CANISTER_WASM_PATH": "$(rootpath //rs/rust_canisters/statesync_test:statesync_test_canister)",
     },
-    flaky = True,
+    flaky = False,
     proc_macro_deps = MACRO_DEPENDENCIES,
     tags = [
         "k8s",
@@ -54,7 +54,7 @@ system_test_nns(
     env = {
         "STATESYNC_TEST_CANISTER_WASM_PATH": "$(rootpath //rs/rust_canisters/statesync_test:statesync_test_canister)",
     },
-    flaky = True,
+    flaky = False,
     proc_macro_deps = MACRO_DEPENDENCIES,
     tags = [
         "k8s",
@@ -72,7 +72,7 @@ system_test_nns(
     env = {
         "STATESYNC_TEST_CANISTER_WASM_PATH": "$(rootpath //rs/rust_canisters/statesync_test:statesync_test_canister)",
     },
-    flaky = True,
+    flaky = False,
     malicious = True,
     proc_macro_deps = MACRO_DEPENDENCIES,
     tags = [

--- a/rs/tests/src/message_routing/rejoin_test.rs
+++ b/rs/tests/src/message_routing/rejoin_test.rs
@@ -197,6 +197,8 @@ pub async fn store_and_read_stable(
     universal_canister: &UniversalCanister<'_>,
 ) {
     let mut attempts = 1;
+    // There seem to be situations where we need to retry this, especially after the subnet just unstalled itself and
+    // a rejoining node reports healthy again. Not 100% clear why that is.
     while let Err(err) = universal_canister.try_store_to_stable(0, message).await {
         if attempts >= STORE_TO_STABLE_RETRIES {
             panic!("Failed to write to stable memory.");

--- a/rs/tests/src/message_routing/rejoin_test.rs
+++ b/rs/tests/src/message_routing/rejoin_test.rs
@@ -33,6 +33,7 @@ use std::time::Duration;
 
 const DKG_INTERVAL: u64 = 14;
 const NOTARY_DELAY: Duration = Duration::from_millis(100);
+const STORE_TO_STABLE_RETRIES: u64 = 3;
 
 pub const SUCCESSFUL_STATE_SYNC_DURATION_SECONDS_SUM: &str =
     "state_sync_duration_seconds_sum{status=\"ok\"}";
@@ -143,7 +144,7 @@ pub async fn rejoin_test(
     let canister_update_calls = 3 * dkg_interval;
     for i in 0..canister_update_calls {
         info!(logger, "Performing canister update call {i}");
-        store_and_read_stable(i.to_le_bytes().as_slice(), &universal_canister).await;
+        store_and_read_stable(&logger, i.to_le_bytes().as_slice(), &universal_canister).await;
     }
 
     info!(logger, "Killing {} nodes ...", allowed_failures);
@@ -163,7 +164,7 @@ pub async fn rejoin_test(
 
     info!(logger, "Checking for subnet progress...");
     let message = b"This beautiful prose should be persisted for future generations";
-    store_and_read_stable(message, &universal_canister).await;
+    store_and_read_stable(&logger, message, &universal_canister).await;
 
     info!(
         logger,
@@ -190,8 +191,19 @@ pub async fn rejoin_test(
     );
 }
 
-pub async fn store_and_read_stable(message: &[u8], universal_canister: &UniversalCanister<'_>) {
-    universal_canister.store_to_stable(0, message).await;
+pub async fn store_and_read_stable(
+    logger: &slog::Logger,
+    message: &[u8],
+    universal_canister: &UniversalCanister<'_>,
+) {
+    let mut attempts = 1;
+    while let Err(err) = universal_canister.try_store_to_stable(0, message).await {
+        if attempts >= STORE_TO_STABLE_RETRIES {
+            panic!("Failed to write to stable memory.");
+        }
+        info!(logger, "Retrying writing to stable: {:?}", err);
+        attempts += 1;
+    }
     assert_eq!(
         universal_canister
             .try_read_stable(0, message.len() as u32)

--- a/rs/tests/src/message_routing/rejoin_test_large_state.rs
+++ b/rs/tests/src/message_routing/rejoin_test_large_state.rs
@@ -219,7 +219,7 @@ pub async fn rejoin_test_large_state(
 
     info!(logger, "Get the latest certified height of an active node");
     let message = b"Are you actively making progress?";
-    store_and_read_stable(message, &universal_canister).await;
+    store_and_read_stable(&logger, message, &universal_canister).await;
     let res =
         fetch_metrics::<u64>(&logger, agent_node.clone(), vec![LATEST_CERTIFIED_HEIGHT]).await;
     let latest_certified_height = res[LATEST_CERTIFIED_HEIGHT][0];
@@ -245,7 +245,7 @@ pub async fn rejoin_test_large_state(
 
     info!(logger, "Checking for subnet progress...");
     let message = b"This beautiful prose should be persisted for future generations";
-    store_and_read_stable(message, &universal_canister).await;
+    store_and_read_stable(&logger, message, &universal_canister).await;
 
     info!(
         logger,


### PR DESCRIPTION
This PR fixes the flakiness of some state sync tests by retrying interacting with recently installed subnets instead of just failing.