### PR TITLE
chore: Implement saturating sub for AmountOf

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6619,6 +6619,7 @@ dependencies = [
  "ic-test-utilities-types",
  "ic-types",
  "ic-types-test-utils",
+ "num-traits",
  "phantom_newtype",
  "prometheus",
  "proptest",

--- a/rs/consensus/BUILD.bazel
+++ b/rs/consensus/BUILD.bazel
@@ -26,6 +26,7 @@ DEPENDENCIES = [
     "//rs/types/error_types",
     "//rs/types/management_canister_types",
     "//rs/types/types",
+    "@crate_index//:num-traits",
     "@crate_index//:prometheus",
     "@crate_index//:rand",
     "@crate_index//:rand_chacha",

--- a/rs/consensus/Cargo.toml
+++ b/rs/consensus/Cargo.toml
@@ -27,6 +27,7 @@ ic-registry-subnet-features = { path = "../registry/subnet_features" }
 ic-registry-subnet-type = { path = "../registry/subnet_type" }
 ic-replicated-state = { path = "../replicated_state" }
 ic-types = { path = "../types/types" }
+num-traits = { workspace = true }
 phantom_newtype = { path = "../phantom_newtype" }
 prometheus = { workspace = true }
 rand = { workspace = true }

--- a/rs/consensus/src/consensus/block_maker.rs
+++ b/rs/consensus/src/consensus/block_maker.rs
@@ -31,6 +31,7 @@ use ic_types::{
     time::current_time,
     CountBytes, Height, NodeId, RegistryVersion, SubnetId,
 };
+use num_traits::ops::saturating::SaturatingSub;
 use std::{
     sync::{Arc, RwLock},
     time::Duration,
@@ -540,12 +541,7 @@ const DYNAMIC_DELAY_EXTRA_DURATION: Duration = Duration::from_secs(10);
 
 fn count_non_rank_0_blocks(pool: &PoolReader, block: Block) -> usize {
     let max_height = block.height();
-    let min_height = if max_height > DYNAMIC_DELAY_LOOK_BACK_DISTANCE {
-        max_height - DYNAMIC_DELAY_LOOK_BACK_DISTANCE
-    } else {
-        Height::new(0)
-    };
-
+    let min_height = max_height.saturating_sub(&DYNAMIC_DELAY_LOOK_BACK_DISTANCE);
     pool.get_range(block, min_height, max_height)
         .filter(|block| block.rank > Rank(0))
         .count()

--- a/rs/phantom_newtype/src/amountof.rs
+++ b/rs/phantom_newtype/src/amountof.rs
@@ -307,6 +307,17 @@ where
     }
 }
 
+impl<Unit, Repr> num_traits::SaturatingSub for AmountOf<Unit, Repr>
+where
+    Repr: num_traits::SaturatingSub,
+{
+    /// Saturating subtraction. Computes `self - other`, saturating
+    /// at the relevant high or low boundary of the type.
+    fn saturating_sub(&self, rhs: &Self) -> Self {
+        Self(self.0.saturating_sub(&rhs.0), PhantomData)
+    }
+}
+
 impl<Unit, Repr> AddAssign for AmountOf<Unit, Repr>
 where
     Repr: AddAssign,


### PR DESCRIPTION
Since we're using saturating arithmetic in many places (including `Time`), it might be good to have a blanket implementation for the phantom types. 