### PR TITLE
fix(IDX): add REPO_NAME to dependency scaning jobs

### DIFF
--- a/.github/workflows-source/release-testing.yml
+++ b/.github/workflows-source/release-testing.yml
@@ -157,6 +157,8 @@ jobs:
       - name: Dependency Scan for Release
         id: dependency-scan-release-cut
         shell: bash
+        env:
+          REPO_NAME: ${{ github.repository }}
         run: |
           set -euo pipefail
           export PYTHONPATH=$PWD/ci/src:$PWD/ci/src/dependencies

--- a/.github/workflows-source/schedule-daily.yml
+++ b/.github/workflows-source/schedule-daily.yml
@@ -191,6 +191,7 @@ jobs:
       JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
       SLACK_PSEC_BOT_OAUTH_TOKEN: ${{ secrets.SLACK_PSEC_BOT_OAUTH_TOKEN }}
       GITHUB_REF: ${{ github.ref }}
+      REPO_NAME: ${{ github.repository }}
     steps:
       - <<: *checkout
       - <<: *before-script

--- a/.github/workflows/release-testing.yml
+++ b/.github/workflows/release-testing.yml
@@ -212,6 +212,8 @@ jobs:
       - name: Dependency Scan for Release
         id: dependency-scan-release-cut
         shell: bash
+        env:
+          REPO_NAME: ${{ github.repository }}
         run: |
           set -euo pipefail
           export PYTHONPATH=$PWD/ci/src:$PWD/ci/src/dependencies

--- a/.github/workflows/schedule-daily.yml
+++ b/.github/workflows/schedule-daily.yml
@@ -241,6 +241,7 @@ jobs:
       JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
       SLACK_PSEC_BOT_OAUTH_TOKEN: ${{ secrets.SLACK_PSEC_BOT_OAUTH_TOKEN }}
       GITHUB_REF: ${{ github.ref }}
+      REPO_NAME: ${{ github.repository }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
As a follow-up to this PR: https://github.com/dfinity/ic/pull/1709 add the `REPO_NAME` env var where needed.