### PR TITLE
fix(IDX): update diff logic to work outside of PRs

### DIFF
--- a/.github/actions/bazel-test-all/action.yaml
+++ b/.github/actions/bazel-test-all/action.yaml
@@ -68,8 +68,8 @@ runs:
           BAZEL_CI_CONFIG: ${{ inputs.BAZEL_CI_CONFIG }}
           BAZEL_EXTRA_ARGS: "${{ inputs.BAZEL_EXTRA_ARGS }} ${{ inputs.BAZEL_EXTRA_ARGS_RULES }}"
           BAZEL_STARTUP_ARGS: ${{ inputs.BAZEL_STARTUP_ARGS }}
-          CI_PULL_REQUEST_TARGET_BRANCH_NAME: ${{ github.event.pull_request.base.ref }}
-          MERGE_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          TARGET_BRANCH_NAME: ${{ github.event.pull_request.base.ref }}
+          TARGET_BRANCH_SHA: ${{ github.event.pull_request.base.sha }}
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
           HONEYCOMB_API_TOKEN: ${{ inputs.HONEYCOMB_API_TOKEN }}
           SSH_PRIVATE_KEY: ${{ inputs.SSH_PRIVATE_KEY }}

--- a/.github/actions/bazel-test-all/action.yaml
+++ b/.github/actions/bazel-test-all/action.yaml
@@ -69,7 +69,7 @@ runs:
           BAZEL_EXTRA_ARGS: "${{ inputs.BAZEL_EXTRA_ARGS }} ${{ inputs.BAZEL_EXTRA_ARGS_RULES }}"
           BAZEL_STARTUP_ARGS: ${{ inputs.BAZEL_STARTUP_ARGS }}
           TARGET_BRANCH_NAME: ${{ github.event.pull_request.base.ref }}
-          TARGET_BRANCH_SHA: ${{ github.event.pull_request.base.sha }}
+          TARGET_BRANCH_SHA: ${{ github.event.pull_request.head.sha }}
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
           HONEYCOMB_API_TOKEN: ${{ inputs.HONEYCOMB_API_TOKEN }}
           SSH_PRIVATE_KEY: ${{ inputs.SSH_PRIVATE_KEY }}

--- a/.github/actions/bazel-test-all/action.yaml
+++ b/.github/actions/bazel-test-all/action.yaml
@@ -69,6 +69,7 @@ runs:
           BAZEL_EXTRA_ARGS: "${{ inputs.BAZEL_EXTRA_ARGS }} ${{ inputs.BAZEL_EXTRA_ARGS_RULES }}"
           BAZEL_STARTUP_ARGS: ${{ inputs.BAZEL_STARTUP_ARGS }}
           CI_PULL_REQUEST_TARGET_BRANCH_NAME: ${{ github.event.pull_request.base.ref }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
           MERGE_BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HONEYCOMB_API_TOKEN: ${{ inputs.HONEYCOMB_API_TOKEN }}
           SSH_PRIVATE_KEY: ${{ inputs.SSH_PRIVATE_KEY }}

--- a/.github/actions/bazel-test-all/action.yaml
+++ b/.github/actions/bazel-test-all/action.yaml
@@ -68,9 +68,8 @@ runs:
           BAZEL_CI_CONFIG: ${{ inputs.BAZEL_CI_CONFIG }}
           BAZEL_EXTRA_ARGS: "${{ inputs.BAZEL_EXTRA_ARGS }} ${{ inputs.BAZEL_EXTRA_ARGS_RULES }}"
           BAZEL_STARTUP_ARGS: ${{ inputs.BAZEL_STARTUP_ARGS }}
-          CI_PULL_REQUEST_TARGET_BRANCH_NAME: ${{ github.event.pull_request.base.ref }}
+          TARGET_BRANCH_NAME: ${{ github.event.pull_request.base.ref }}
           TARGET_BRANCH_SHA: ${{ github.event.pull_request.base.sha }}
-          MERGE_BASE_SHA: ${{ github.event.pull_request.base.sha }}
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
           HONEYCOMB_API_TOKEN: ${{ inputs.HONEYCOMB_API_TOKEN }}
           SSH_PRIVATE_KEY: ${{ inputs.SSH_PRIVATE_KEY }}

--- a/.github/actions/bazel-test-all/action.yaml
+++ b/.github/actions/bazel-test-all/action.yaml
@@ -69,7 +69,7 @@ runs:
           BAZEL_EXTRA_ARGS: "${{ inputs.BAZEL_EXTRA_ARGS }} ${{ inputs.BAZEL_EXTRA_ARGS_RULES }}"
           BAZEL_STARTUP_ARGS: ${{ inputs.BAZEL_STARTUP_ARGS }}
           CI_PULL_REQUEST_TARGET_BRANCH_NAME: ${{ github.event.pull_request.base.ref }}
+          TARGET_BRANCH_SHA: ${{ github.event.pull_request.base.sha }}
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
-          MERGE_BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HONEYCOMB_API_TOKEN: ${{ inputs.HONEYCOMB_API_TOKEN }}
           SSH_PRIVATE_KEY: ${{ inputs.SSH_PRIVATE_KEY }}

--- a/.github/actions/bazel-test-all/action.yaml
+++ b/.github/actions/bazel-test-all/action.yaml
@@ -70,6 +70,7 @@ runs:
           BAZEL_STARTUP_ARGS: ${{ inputs.BAZEL_STARTUP_ARGS }}
           CI_PULL_REQUEST_TARGET_BRANCH_NAME: ${{ github.event.pull_request.base.ref }}
           TARGET_BRANCH_SHA: ${{ github.event.pull_request.base.sha }}
+          MERGE_BASE_SHA: ${{ github.event.pull_request.base.sha }}
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
           HONEYCOMB_API_TOKEN: ${{ inputs.HONEYCOMB_API_TOKEN }}
           SSH_PRIVATE_KEY: ${{ inputs.SSH_PRIVATE_KEY }}

--- a/.github/actions/bazel-test-all/action.yaml
+++ b/.github/actions/bazel-test-all/action.yaml
@@ -68,8 +68,8 @@ runs:
           BAZEL_CI_CONFIG: ${{ inputs.BAZEL_CI_CONFIG }}
           BAZEL_EXTRA_ARGS: "${{ inputs.BAZEL_EXTRA_ARGS }} ${{ inputs.BAZEL_EXTRA_ARGS_RULES }}"
           BAZEL_STARTUP_ARGS: ${{ inputs.BAZEL_STARTUP_ARGS }}
-          TARGET_BRANCH_NAME: ${{ github.event.pull_request.base.ref }}
-          TARGET_BRANCH_SHA: ${{ github.event.pull_request.base.sha }}
+          CI_PULL_REQUEST_TARGET_BRANCH_NAME: ${{ github.event.pull_request.base.ref }}
+          MERGE_BASE_SHA: ${{ github.event.pull_request.base.sha }}
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
           HONEYCOMB_API_TOKEN: ${{ inputs.HONEYCOMB_API_TOKEN }}
           SSH_PRIVATE_KEY: ${{ inputs.SSH_PRIVATE_KEY }}

--- a/.github/actions/bazel-test-all/action.yaml
+++ b/.github/actions/bazel-test-all/action.yaml
@@ -69,7 +69,7 @@ runs:
           BAZEL_EXTRA_ARGS: "${{ inputs.BAZEL_EXTRA_ARGS }} ${{ inputs.BAZEL_EXTRA_ARGS_RULES }}"
           BAZEL_STARTUP_ARGS: ${{ inputs.BAZEL_STARTUP_ARGS }}
           TARGET_BRANCH_NAME: ${{ github.event.pull_request.base.ref }}
-          TARGET_BRANCH_SHA: ${{ github.event.pull_request.head.sha }}
+          MERGE_BASE_SHA: ${{ github.event.pull_request.base.sha }}
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
           HONEYCOMB_API_TOKEN: ${{ inputs.HONEYCOMB_API_TOKEN }}
           SSH_PRIVATE_KEY: ${{ inputs.SSH_PRIVATE_KEY }}

--- a/.github/workflows-source/ci-main.yml
+++ b/.github/workflows-source/ci-main.yml
@@ -261,7 +261,7 @@ jobs:
         env:
           BAZEL_COMMAND: "build"
           RUN_ON_DIFF_ONLY: ${{ !contains(github.event.pull_request.labels.*.name, 'CI_ALL_BAZEL_TARGETS') }}
-          TARGET_BRANCH_SHA: ${{ github.event.pull_request.head.sha }}
+          MERGE_BASE_SHA: ${{ github.event.pull_request.base.sha }}
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
       - name: Upload build-ic.tar
         uses: actions/upload-artifact@v4

--- a/.github/workflows-source/ci-main.yml
+++ b/.github/workflows-source/ci-main.yml
@@ -262,6 +262,8 @@ jobs:
           BAZEL_COMMAND: "build"
           RUN_ON_DIFF_ONLY: ${{ !contains(github.event.pull_request.labels.*.name, 'CI_ALL_BAZEL_TARGETS') }}
           MERGE_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          CI_PULL_REQUEST_TARGET_BRANCH_NAME: ${{ github.event.pull_request.base.ref }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
       - name: Upload build-ic.tar
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows-source/ci-main.yml
+++ b/.github/workflows-source/ci-main.yml
@@ -261,7 +261,7 @@ jobs:
         env:
           BAZEL_COMMAND: "build"
           RUN_ON_DIFF_ONLY: ${{ !contains(github.event.pull_request.labels.*.name, 'CI_ALL_BAZEL_TARGETS') }}
-          TARGET_BRANCH_SHA: ${{ github.event.pull_request.head.sha }}
+          MERGE_BASE_SHA: ${{ github.event.pull_request.head.sha }}
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
       - name: Upload build-ic.tar
         uses: actions/upload-artifact@v4

--- a/.github/workflows-source/ci-main.yml
+++ b/.github/workflows-source/ci-main.yml
@@ -262,6 +262,7 @@ jobs:
           BAZEL_COMMAND: "build"
           RUN_ON_DIFF_ONLY: ${{ !contains(github.event.pull_request.labels.*.name, 'CI_ALL_BAZEL_TARGETS') }}
           MERGE_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          TARGET_BRANCH_NAME: ${{ github.event.pull_request.base.ref }}
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
       - name: Upload build-ic.tar
         uses: actions/upload-artifact@v4

--- a/.github/workflows-source/ci-main.yml
+++ b/.github/workflows-source/ci-main.yml
@@ -261,8 +261,7 @@ jobs:
         env:
           BAZEL_COMMAND: "build"
           RUN_ON_DIFF_ONLY: ${{ !contains(github.event.pull_request.labels.*.name, 'CI_ALL_BAZEL_TARGETS') }}
-          MERGE_BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          CI_PULL_REQUEST_TARGET_BRANCH_NAME: ${{ github.event.pull_request.base.ref }}
+          TARGET_BRANCH_SHA: ${{ github.event.pull_request.head.sha }}
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
       - name: Upload build-ic.tar
         uses: actions/upload-artifact@v4

--- a/.github/workflows-source/ci-main.yml
+++ b/.github/workflows-source/ci-main.yml
@@ -261,7 +261,7 @@ jobs:
         env:
           BAZEL_COMMAND: "build"
           RUN_ON_DIFF_ONLY: ${{ !contains(github.event.pull_request.labels.*.name, 'CI_ALL_BAZEL_TARGETS') }}
-          MERGE_BASE_SHA: ${{ github.event.pull_request.head.sha }}
+          TARGET_BRANCH_SHA: ${{ github.event.pull_request.head.sha }}
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
       - name: Upload build-ic.tar
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -347,7 +347,7 @@ jobs:
         env:
           BAZEL_COMMAND: "build"
           RUN_ON_DIFF_ONLY: ${{ !contains(github.event.pull_request.labels.*.name, 'CI_ALL_BAZEL_TARGETS') }}
-          MERGE_BASE_SHA: ${{ github.event.pull_request.head.sha }}
+          TARGET_BRANCH_SHA: ${{ github.event.pull_request.head.sha }}
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
       - name: Upload build-ic.tar
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -348,6 +348,7 @@ jobs:
           BAZEL_COMMAND: "build"
           RUN_ON_DIFF_ONLY: ${{ !contains(github.event.pull_request.labels.*.name, 'CI_ALL_BAZEL_TARGETS') }}
           MERGE_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          TARGET_BRANCH_NAME: ${{ github.event.pull_request.base.ref }}
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
       - name: Upload build-ic.tar
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -347,7 +347,7 @@ jobs:
         env:
           BAZEL_COMMAND: "build"
           RUN_ON_DIFF_ONLY: ${{ !contains(github.event.pull_request.labels.*.name, 'CI_ALL_BAZEL_TARGETS') }}
-          TARGET_BRANCH_SHA: ${{ github.event.pull_request.head.sha }}
+          MERGE_BASE_SHA: ${{ github.event.pull_request.head.sha }}
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
       - name: Upload build-ic.tar
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -347,9 +347,9 @@ jobs:
         env:
           BAZEL_COMMAND: "build"
           RUN_ON_DIFF_ONLY: ${{ !contains(github.event.pull_request.labels.*.name, 'CI_ALL_BAZEL_TARGETS') }}
-          MERGE_BASE_SHA: ${{ github.event.pull_request.base.sha }}
           CI_PULL_REQUEST_TARGET_BRANCH_NAME: ${{ github.event.pull_request.base.ref }}
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          TARGET_BRANCH_SHA: ${{ github.event.pull_request.head.sha }}
       - name: Upload build-ic.tar
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -347,9 +347,8 @@ jobs:
         env:
           BAZEL_COMMAND: "build"
           RUN_ON_DIFF_ONLY: ${{ !contains(github.event.pull_request.labels.*.name, 'CI_ALL_BAZEL_TARGETS') }}
-          CI_PULL_REQUEST_TARGET_BRANCH_NAME: ${{ github.event.pull_request.base.ref }}
-          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
           TARGET_BRANCH_SHA: ${{ github.event.pull_request.head.sha }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
       - name: Upload build-ic.tar
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -348,6 +348,8 @@ jobs:
           BAZEL_COMMAND: "build"
           RUN_ON_DIFF_ONLY: ${{ !contains(github.event.pull_request.labels.*.name, 'CI_ALL_BAZEL_TARGETS') }}
           MERGE_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          CI_PULL_REQUEST_TARGET_BRANCH_NAME: ${{ github.event.pull_request.base.ref }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
       - name: Upload build-ic.tar
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -347,7 +347,7 @@ jobs:
         env:
           BAZEL_COMMAND: "build"
           RUN_ON_DIFF_ONLY: ${{ !contains(github.event.pull_request.labels.*.name, 'CI_ALL_BAZEL_TARGETS') }}
-          TARGET_BRANCH_SHA: ${{ github.event.pull_request.head.sha }}
+          MERGE_BASE_SHA: ${{ github.event.pull_request.base.sha }}
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
       - name: Upload build-ic.tar
         uses: actions/upload-artifact@v4

--- a/bazel/candid.bzl
+++ b/bazel/candid.bzl
@@ -13,10 +13,10 @@ if [[ ${{OVERRIDE_DIDC_CHECK:-}} == "true" ]]; then
     exit 0
 fi
 
-# Note that MERGE_BASE_SHA is only set on Pull Requests.
+# Note that TARGET_BRANCH_SHA is only set on Pull Requests.
 # On other events we set the merge_base to HEAD which means we compare the
 # did interface file against itself.
-readonly merge_base=${{MERGE_BASE_SHA:-HEAD}}
+readonly merge_base=${{TARGET_BRANCH_SHA:-HEAD}}
 
 readonly tmpfile=$(mktemp $TEST_TMPDIR/prev.XXXXXX)
 readonly errlog=$(mktemp $TEST_TMPDIR/err.XXXXXX)
@@ -53,7 +53,7 @@ fi
 
     return [
         DefaultInfo(runfiles = runfiles),
-        RunEnvironmentInfo(inherited_environment = ["MERGE_BASE_SHA", "OVERRIDE_DIDC_CHECK"]),
+        RunEnvironmentInfo(inherited_environment = ["TARGET_BRANCH_SHA", "OVERRIDE_DIDC_CHECK"]),
     ]
 
 CHECK_DID = attr.label(

--- a/bazel/candid.bzl
+++ b/bazel/candid.bzl
@@ -13,10 +13,10 @@ if [[ ${{OVERRIDE_DIDC_CHECK:-}} == "true" ]]; then
     exit 0
 fi
 
-# Note that TARGET_BRANCH_SHA is only set on Pull Requests.
+# Note that MERGE_BASE_SHA is only set on Pull Requests.
 # On other events we set the merge_base to HEAD which means we compare the
 # did interface file against itself.
-readonly merge_base=${{TARGET_BRANCH_SHA:-HEAD}}
+readonly merge_base=${{MERGE_BASE_SHA:-HEAD}}
 
 readonly tmpfile=$(mktemp $TEST_TMPDIR/prev.XXXXXX)
 readonly errlog=$(mktemp $TEST_TMPDIR/err.XXXXXX)
@@ -53,7 +53,7 @@ fi
 
     return [
         DefaultInfo(runfiles = runfiles),
-        RunEnvironmentInfo(inherited_environment = ["TARGET_BRANCH_SHA", "OVERRIDE_DIDC_CHECK"]),
+        RunEnvironmentInfo(inherited_environment = ["MERGE_BASE_SHA", "OVERRIDE_DIDC_CHECK"]),
     ]
 
 CHECK_DID = attr.label(

--- a/ci/bazel-scripts/diff.sh
+++ b/ci/bazel-scripts/diff.sh
@@ -13,8 +13,10 @@ set -euo pipefail
 set -x
 cd "$(git rev-parse --show-toplevel)"
 
-TARGET_BRANCH="${CI_PULL_REQUEST_TARGET_BRANCH_NAME:-$DEFAULT_BRANCH}"
-MERGE_BASE=$(git merge-base HEAD "$TARGET_BRANCH")
+# since default branch is not the same in ic-private, we can't set it to master, throw error if missing
+DEFAULT_BRANCH_SHA=$(git rev-parse origin/$DEFAULT_BRANCH)
+TARGET_BRANCH_SHA="${TARGET_BRANCH_SHA:-$DEFAULT_BRANCH_SHA}"
+MERGE_BASE=$(git merge-base HEAD "$TARGET_BRANCH_SHA")
 COMMIT_RANGE=${COMMIT_RANGE:-$MERGE_BASE".."}
 DIFF_FILES=$(git diff --name-only "${COMMIT_RANGE}")
 

--- a/ci/bazel-scripts/diff.sh
+++ b/ci/bazel-scripts/diff.sh
@@ -14,7 +14,7 @@ set -x
 cd "$(git rev-parse --show-toplevel)"
 
 # since default branch is not the same in ic-private, we can't set it to master, throw error if missing
-DEFAULT_BRANCH_SHA=$(git rev-parse origin/$DEFAULT_BRANCH)
+DEFAULT_BRANCH_SHA=$(git rev-parse $DEFAULT_BRANCH)
 TARGET_BRANCH_SHA="${TARGET_BRANCH_SHA:-$DEFAULT_BRANCH_SHA}"
 MERGE_BASE=$(git merge-base HEAD "$TARGET_BRANCH_SHA")
 COMMIT_RANGE=${COMMIT_RANGE:-$MERGE_BASE".."}

--- a/ci/bazel-scripts/diff.sh
+++ b/ci/bazel-scripts/diff.sh
@@ -13,7 +13,8 @@ set -euo pipefail
 set -x
 cd "$(git rev-parse --show-toplevel)"
 
-MERGE_BASE="${MERGE_BASE_SHA:-HEAD}"
+TARGET_BRANCH="${CI_PULL_REQUEST_TARGET_BRANCH_NAME:-$DEFAULT_BRANCH}"
+MERGE_BASE=$(git merge-base HEAD "$TARGET_BRANCH")
 COMMIT_RANGE=${COMMIT_RANGE:-$MERGE_BASE".."}
 DIFF_FILES=$(git diff --name-only "${COMMIT_RANGE}")
 

--- a/ci/bazel-scripts/diff.sh
+++ b/ci/bazel-scripts/diff.sh
@@ -16,7 +16,7 @@ cd "$(git rev-parse --show-toplevel)"
 # since default branch is not the same in ic-private, we can't set it to master, throw error if missing
 git fetch origin
 DEFAULT_BRANCH_SHA=$(git rev-parse origin/$DEFAULT_BRANCH)
-TARGET_BRANCH_SHA="${TARGET_BRANCH_SHA:-$DEFAULT_BRANCH_SHA}"
+TARGET_BRANCH_SHA="${MERGE_BASE_SHA:-$DEFAULT_BRANCH_SHA}"
 MERGE_BASE=$(git merge-base HEAD "$TARGET_BRANCH_SHA")
 COMMIT_RANGE=${COMMIT_RANGE:-$MERGE_BASE".."}
 DIFF_FILES=$(git diff --name-only "${COMMIT_RANGE}")

--- a/ci/bazel-scripts/diff.sh
+++ b/ci/bazel-scripts/diff.sh
@@ -14,9 +14,9 @@ set -x
 cd "$(git rev-parse --show-toplevel)"
 
 # since default branch is not the same in ic-private, we can't set it to master, throw error if missing
-git fetch origin
-DEFAULT_BRANCH_SHA=$(git rev-parse origin/$DEFAULT_BRANCH)
-TARGET_BRANCH_SHA="${TARGET_BRANCH_SHA:-$DEFAULT_BRANCH_SHA}"
+git fetch origin $DEFAULT_BRANCH
+TARGET_BRANCH_NAME="${TARGET_BRANCH_NAME:-$DEFAULT_BRANCH}"
+TARGET_BRANCH_SHA=$(git rev-parse origin/$TARGET_BRANCH_NAME)
 MERGE_BASE=$(git merge-base HEAD "$TARGET_BRANCH_SHA")
 COMMIT_RANGE=${COMMIT_RANGE:-$MERGE_BASE".."}
 DIFF_FILES=$(git diff --name-only "${COMMIT_RANGE}")

--- a/ci/bazel-scripts/diff.sh
+++ b/ci/bazel-scripts/diff.sh
@@ -16,7 +16,7 @@ cd "$(git rev-parse --show-toplevel)"
 # since default branch is not the same in ic-private, we can't set it to master, throw error if missing
 git fetch origin
 DEFAULT_BRANCH_SHA=$(git rev-parse origin/$DEFAULT_BRANCH)
-TARGET_BRANCH_SHA="${MERGE_BASE_SHA:-$DEFAULT_BRANCH_SHA}"
+TARGET_BRANCH_SHA="${TARGET_BRANCH_SHA:-$DEFAULT_BRANCH_SHA}"
 MERGE_BASE=$(git merge-base HEAD "$TARGET_BRANCH_SHA")
 COMMIT_RANGE=${COMMIT_RANGE:-$MERGE_BASE".."}
 DIFF_FILES=$(git diff --name-only "${COMMIT_RANGE}")

--- a/ci/bazel-scripts/diff.sh
+++ b/ci/bazel-scripts/diff.sh
@@ -14,7 +14,8 @@ set -x
 cd "$(git rev-parse --show-toplevel)"
 
 # since default branch is not the same in ic-private, we can't set it to master, throw error if missing
-DEFAULT_BRANCH_SHA=$(git rev-parse $DEFAULT_BRANCH)
+git fetch origin
+DEFAULT_BRANCH_SHA=$(git rev-parse origin/$DEFAULT_BRANCH)
 TARGET_BRANCH_SHA="${TARGET_BRANCH_SHA:-$DEFAULT_BRANCH_SHA}"
 MERGE_BASE=$(git merge-base HEAD "$TARGET_BRANCH_SHA")
 COMMIT_RANGE=${COMMIT_RANGE:-$MERGE_BASE".."}

--- a/ci/bazel-scripts/main.sh
+++ b/ci/bazel-scripts/main.sh
@@ -21,7 +21,7 @@ for pattern in "${protected_branches[@]}"; do
 done
 
 # if we are on a protected branch or targeting a rc branch we set ic_version to the commit_sha and upload to s3
-if [[ "${IS_PROTECTED_BRANCH:-}" == "true" ]] || [[ "${CI_PULL_REQUEST_TARGET_BRANCH_NAME:-}" == "rc--"* ]]; then
+if [[ "${IS_PROTECTED_BRANCH:-}" == "true" ]] || [[ "${TARGET_BRANCH_NAME:-}" == "rc--"* ]]; then
     ic_version_rc_only="${CI_COMMIT_SHA}"
     s3_upload="True"
     RUN_ON_DIFF_ONLY="false"

--- a/ci/bazel-scripts/main.sh
+++ b/ci/bazel-scripts/main.sh
@@ -21,7 +21,7 @@ for pattern in "${protected_branches[@]}"; do
 done
 
 # if we are on a protected branch or targeting a rc branch we set ic_version to the commit_sha and upload to s3
-if [[ "${IS_PROTECTED_BRANCH:-}" == "true" ]] || [[ "${TARGET_BRANCH_NAME:-}" == "rc--"* ]]; then
+if [[ "${IS_PROTECTED_BRANCH:-}" == "true" ]] || [[ "${CI_PULL_REQUEST_TARGET_BRANCH_NAME:-}" == "rc--"* ]]; then
     ic_version_rc_only="${CI_COMMIT_SHA}"
     s3_upload="True"
     RUN_ON_DIFF_ONLY="false"

--- a/ci/src/git_changes/git_changes.py
+++ b/ci/src/git_changes/git_changes.py
@@ -23,7 +23,7 @@ import git
 
 def target_branch() -> str:
     default_branch = os.getenv("CI_DEFAULT_BRANCH", "master")
-    return os.getenv("TARGET_BRANCH_NAME", default_branch)
+    return os.getenv("CI_PULL_REQUEST_TARGET_BRANCH_NAME", default_branch)
 
 
 def git_fetch_target_branch(git_repo, max_attempts=10):

--- a/ci/src/git_changes/git_changes.py
+++ b/ci/src/git_changes/git_changes.py
@@ -23,7 +23,7 @@ import git
 
 def target_branch() -> str:
     default_branch = os.getenv("CI_DEFAULT_BRANCH", "master")
-    return os.getenv("CI_PULL_REQUEST_TARGET_BRANCH_NAME", default_branch)
+    return os.getenv("TARGET_BRANCH_NAME", default_branch)
 
 
 def git_fetch_target_branch(git_repo, max_attempts=10):


### PR DESCRIPTION
This PR contains two changes:
- Update `diff.sh` to compare differences against the default branch if it was not created on a PR and therefore no `TARGET_BRANCH` is available.
- rename `CI_PULL_REQUEST_TARGET_BRANCH_NAME` to `TARGET_BRANCH_NAME` for simplicity