### PR TITLE
chore(dependency-mgmt): Add REPO_NAME env var to dependency-mgmt CI jobs

### DIFF
--- a/.github/workflows-source/ci-pr-only.yml
+++ b/.github/workflows-source/ci-pr-only.yml
@@ -138,6 +138,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
       SLACK_PSEC_BOT_OAUTH_TOKEN: ${{ secrets.SLACK_PSEC_BOT_OAUTH_TOKEN }}
+      REPO_NAME: ${{ github.repository }}
     steps:
       - <<: *checkout
         with:

--- a/.github/workflows-source/release-testing.yml
+++ b/.github/workflows-source/release-testing.yml
@@ -145,6 +145,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
       SLACK_PSEC_BOT_OAUTH_TOKEN: ${{ secrets.SLACK_PSEC_BOT_OAUTH_TOKEN }}
+      REPO_NAME: ${{ github.repository }}
     steps:
       - <<: *checkout
       - <<: *before-script

--- a/.github/workflows-source/schedule-daily.yml
+++ b/.github/workflows-source/schedule-daily.yml
@@ -191,6 +191,7 @@ jobs:
       JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
       SLACK_PSEC_BOT_OAUTH_TOKEN: ${{ secrets.SLACK_PSEC_BOT_OAUTH_TOKEN }}
       GITHUB_REF: ${{ github.ref }}
+      REPO_NAME: ${{ github.repository }}
     steps:
       - <<: *checkout
       - <<: *before-script

--- a/.github/workflows/ci-pr-only.yml
+++ b/.github/workflows/ci-pr-only.yml
@@ -136,6 +136,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
       SLACK_PSEC_BOT_OAUTH_TOKEN: ${{ secrets.SLACK_PSEC_BOT_OAUTH_TOKEN }}
+      REPO_NAME: ${{ github.repository }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/release-testing.yml
+++ b/.github/workflows/release-testing.yml
@@ -188,6 +188,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
       SLACK_PSEC_BOT_OAUTH_TOKEN: ${{ secrets.SLACK_PSEC_BOT_OAUTH_TOKEN }}
+      REPO_NAME: ${{ github.repository }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/release-testing.yml
+++ b/.github/workflows/release-testing.yml
@@ -188,7 +188,6 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
       SLACK_PSEC_BOT_OAUTH_TOKEN: ${{ secrets.SLACK_PSEC_BOT_OAUTH_TOKEN }}
-      REPO_NAME: ${{ github.repository }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/schedule-daily.yml
+++ b/.github/workflows/schedule-daily.yml
@@ -241,6 +241,7 @@ jobs:
       JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
       SLACK_PSEC_BOT_OAUTH_TOKEN: ${{ secrets.SLACK_PSEC_BOT_OAUTH_TOKEN }}
       GITHUB_REF: ${{ github.ref }}
+      REPO_NAME: ${{ github.repository }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/ci/src/dependencies/scanner/dependency_scanner_test.py
+++ b/ci/src/dependencies/scanner/dependency_scanner_test.py
@@ -227,7 +227,7 @@ def test_on_periodic_job_one_finding_in_jira_transition_to_failover(jira_lib_moc
     failover_mock.can_handle.return_value = True
 
     scanner_job = DependencyScanner(fake_bazel, jira_lib_mock, [sub1, sub2], failover_mock)
-    repos = [Repository("ic", "https://github.com/dfinity/ic", [Project(name="ic", path="ic", owner_by_path={'bear': [Team.NODE_TEAM]})])]
+    repos = [Repository("ic", "https://github.com/dfinity/ic", [Project(name="ic", path=__test_get_ic_path(), owner_by_path={'bear': [Team.NODE_TEAM]})])]
 
     scanner_job.do_periodic_scan(repos)
 

--- a/ci/src/dependencies/scanner/manager/bazel_rust_dependency_manager_test.py
+++ b/ci/src/dependencies/scanner/manager/bazel_rust_dependency_manager_test.py
@@ -357,17 +357,22 @@ def test_get_findings_for_bazel_repo():
                            fix_version_for_vulnerability={}),
                 Dependency(id='https://crates.io/crates/x509-parser', name='x509-parser', version='0.12.0',
                            fix_version_for_vulnerability={})]
-            assert findings[0].projects == ['ic/rs/backup', 'ic/rs/canister_client/sender', 'ic/rs/crypto', 'ic/rs/crypto/ecdsa_secp256k1', 'ic/rs/crypto/ecdsa_secp256r1', 'ic/rs/crypto/internal/crypto_lib/basic_sig/cose',
-                                            'ic/rs/crypto/internal/crypto_lib/basic_sig/der_utils', 'ic/rs/crypto/internal/crypto_lib/basic_sig/ecdsa_secp256k1', 'ic/rs/crypto/internal/crypto_lib/basic_sig/ecdsa_secp256r1',
-                                            'ic/rs/crypto/internal/crypto_lib/basic_sig/ed25519', 'ic/rs/crypto/internal/crypto_lib/basic_sig/iccsa', 'ic/rs/crypto/internal/crypto_lib/basic_sig/rsa_pkcs1',
-                                            'ic/rs/crypto/internal/crypto_lib/threshold_sig/bls12_381/der_utils', 'ic/rs/crypto/internal/crypto_service_provider', 'ic/rs/crypto/node_key_validation',
-                                            'ic/rs/crypto/node_key_validation/tls_cert_validation', 'ic/rs/crypto/utils/basic_sig', 'ic/rs/elastic_common_schema', 'ic/rs/monitoring/logger', 'ic/rs/monitoring/onchain_observability/adapter',
-                                            'ic/rs/nervous_system/common', 'ic/rs/nns/cmc', 'ic/rs/nns/governance', 'ic/rs/nns/gtc', 'ic/rs/nns/handlers/root/impl', 'ic/rs/nns/handlers/root/interface', 'ic/rs/nns/sns-wasm',
-                                            'ic/rs/prep', 'ic/rs/registry/canister',
-                                            'ic/rs/registry/nns_data_provider', 'ic/rs/rosetta-api', 'ic/rs/rosetta-api/icrc1/ledger/sm-tests', 'ic/rs/rosetta-api/ledger_canister_blocks_synchronizer',
-                                            'ic/rs/rosetta-api/ledger_canister_blocks_synchronizer/test_utils', 'ic/rs/scenario_tests', 'ic/rs/sns/governance', 'ic/rs/sns/root', 'ic/rs/sns/swap', 'ic/rs/tests', 'ic/rs/types/types',
-                                            'ic/rs/validator',
-                                            'ic/rs/validator/http_request_test_utils']
+            projects = ['/rs/backup', '/rs/canister_client/sender', '/rs/crypto', '/rs/crypto/ecdsa_secp256k1', '/rs/crypto/ecdsa_secp256r1', '/rs/crypto/internal/crypto_lib/basic_sig/cose',
+                                            '/rs/crypto/internal/crypto_lib/basic_sig/der_utils', '/rs/crypto/internal/crypto_lib/basic_sig/ecdsa_secp256k1', '/rs/crypto/internal/crypto_lib/basic_sig/ecdsa_secp256r1',
+                                            '/rs/crypto/internal/crypto_lib/basic_sig/ed25519', '/rs/crypto/internal/crypto_lib/basic_sig/iccsa', '/rs/crypto/internal/crypto_lib/basic_sig/rsa_pkcs1',
+                                            '/rs/crypto/internal/crypto_lib/threshold_sig/bls12_381/der_utils', '/rs/crypto/internal/crypto_service_provider', '/rs/crypto/node_key_validation',
+                                            '/rs/crypto/node_key_validation/tls_cert_validation', '/rs/crypto/utils/basic_sig', '/rs/elastic_common_schema', '/rs/monitoring/logger', '/rs/monitoring/onchain_observability/adapter',
+                                            '/rs/nervous_system/common', '/rs/nns/cmc', '/rs/nns/governance', '/rs/nns/gtc', '/rs/nns/handlers/root/impl', '/rs/nns/handlers/root/interface', '/rs/nns/sns-wasm',
+                                            '/rs/prep', '/rs/registry/canister',
+                                            '/rs/registry/nns_data_provider', '/rs/rosetta-api', '/rs/rosetta-api/icrc1/ledger/sm-tests', '/rs/rosetta-api/ledger_canister_blocks_synchronizer',
+                                            '/rs/rosetta-api/ledger_canister_blocks_synchronizer/test_utils', '/rs/scenario_tests', '/rs/sns/governance', '/rs/sns/root', '/rs/sns/swap', '/rs/tests', '/rs/types/types',
+                                            '/rs/validator',
+                                            '/rs/validator/http_request_test_utils']
+
+            assert len(projects) == len(findings[0].projects)
+
+            for project, finding_project in zip(projects, findings[0].projects):
+                assert  __test_get_ic_path() + project == finding_project
             assert findings[0].score == -1
 
             # unique fields for second finding
@@ -379,7 +384,7 @@ def test_get_findings_for_bazel_repo():
                               description='Out-of-bounds read when opening multiple column families with TTL',
                               score=-1)]
             assert findings[1].first_level_dependencies == []
-            assert findings[1].projects == ['ic/rs/artifact_pool']
+            assert findings[1].projects == [__test_get_ic_path() + '/rs/artifact_pool']
             assert findings[1].score == -1
 
             # unique fields for third finding
@@ -421,15 +426,18 @@ def test_get_findings_for_bazel_repo():
                            fix_version_for_vulnerability={}),
                 Dependency(id='https://crates.io/crates/x509-parser', name='x509-parser', version='0.12.0',
                            fix_version_for_vulnerability={})]
-            assert findings[2].projects == ['ic/rs/backup', 'ic/rs/canister_client/sender', 'ic/rs/crypto', 'ic/rs/crypto/ecdsa_secp256k1', 'ic/rs/crypto/ecdsa_secp256r1', 'ic/rs/crypto/internal/crypto_lib/basic_sig/cose',
-                                            'ic/rs/crypto/internal/crypto_lib/basic_sig/der_utils', 'ic/rs/crypto/internal/crypto_lib/basic_sig/ecdsa_secp256k1', 'ic/rs/crypto/internal/crypto_lib/basic_sig/ecdsa_secp256r1',
-                                            'ic/rs/crypto/internal/crypto_lib/basic_sig/ed25519', 'ic/rs/crypto/internal/crypto_lib/basic_sig/iccsa', 'ic/rs/crypto/internal/crypto_lib/basic_sig/rsa_pkcs1',
-                                            'ic/rs/crypto/internal/crypto_lib/threshold_sig/bls12_381/der_utils', 'ic/rs/crypto/internal/crypto_service_provider', 'ic/rs/crypto/node_key_validation',
-                                            'ic/rs/crypto/node_key_validation/tls_cert_validation', 'ic/rs/crypto/utils/basic_sig', 'ic/rs/elastic_common_schema', 'ic/rs/monitoring/logger', 'ic/rs/monitoring/onchain_observability/adapter',
-                                            'ic/rs/nervous_system/common', 'ic/rs/nns/cmc', 'ic/rs/nns/governance', 'ic/rs/nns/gtc', 'ic/rs/nns/handlers/root/impl', 'ic/rs/nns/handlers/root/interface', 'ic/rs/nns/sns-wasm',
-                                            'ic/rs/prep', 'ic/rs/registry/canister', 'ic/rs/registry/nns_data_provider', 'ic/rs/replica', 'ic/rs/rosetta-api', 'ic/rs/rosetta-api/icrc1/ledger/sm-tests',
-                                            'ic/rs/rosetta-api/ledger_canister_blocks_synchronizer', 'ic/rs/rosetta-api/ledger_canister_blocks_synchronizer/test_utils', 'ic/rs/scenario_tests', 'ic/rs/sns/governance', 'ic/rs/sns/root',
-                                            'ic/rs/sns/swap', 'ic/rs/tests', 'ic/rs/types/types', 'ic/rs/validator', 'ic/rs/validator/http_request_test_utils']
+            projects_2 = ['/rs/backup', '/rs/canister_client/sender', '/rs/crypto', '/rs/crypto/ecdsa_secp256k1', '/rs/crypto/ecdsa_secp256r1', '/rs/crypto/internal/crypto_lib/basic_sig/cose',
+                                            '/rs/crypto/internal/crypto_lib/basic_sig/der_utils', '/rs/crypto/internal/crypto_lib/basic_sig/ecdsa_secp256k1', '/rs/crypto/internal/crypto_lib/basic_sig/ecdsa_secp256r1',
+                                            '/rs/crypto/internal/crypto_lib/basic_sig/ed25519', '/rs/crypto/internal/crypto_lib/basic_sig/iccsa', '/rs/crypto/internal/crypto_lib/basic_sig/rsa_pkcs1',
+                                            '/rs/crypto/internal/crypto_lib/threshold_sig/bls12_381/der_utils', '/rs/crypto/internal/crypto_service_provider', '/rs/crypto/node_key_validation',
+                                            '/rs/crypto/node_key_validation/tls_cert_validation', '/rs/crypto/utils/basic_sig', '/rs/elastic_common_schema', '/rs/monitoring/logger', '/rs/monitoring/onchain_observability/adapter',
+                                            '/rs/nervous_system/common', '/rs/nns/cmc', '/rs/nns/governance', '/rs/nns/gtc', '/rs/nns/handlers/root/impl', '/rs/nns/handlers/root/interface', '/rs/nns/sns-wasm',
+                                            '/rs/prep', '/rs/registry/canister', '/rs/registry/nns_data_provider', '/rs/replica', '/rs/rosetta-api', '/rs/rosetta-api/icrc1/ledger/sm-tests',
+                                            '/rs/rosetta-api/ledger_canister_blocks_synchronizer', '/rs/rosetta-api/ledger_canister_blocks_synchronizer/test_utils', '/rs/scenario_tests', '/rs/sns/governance', '/rs/sns/root',
+                                            '/rs/sns/swap', '/rs/tests', '/rs/types/types', '/rs/validator', '/rs/validator/http_request_test_utils']
+            assert len(projects_2) == len(findings[2].projects)
+            for project, finding_project in zip(projects_2, findings[2].projects):
+                assert  __test_get_ic_path() + project == finding_project
             assert findings[2].score == 6
 
 


### PR DESCRIPTION
- Add REPO_NAME env var to all dependency-mgmt workflows. 
- Hopefully the last regression fix of tests between ic and ic-private.
  -  Failures - https://github.com/dfinity/ic-private/actions/runs/11055160435/job/30713697688
  -  Fix testing - https://github.com/dfinity/ic-private/pull/36
  -  Test is green - https://github.com/dfinity/ic-private/actions/runs/11102905495/job/30843736486