### PR TITLE
feat(ckbtc): bound KYT canister check_transaction cache with exipry

### DIFF
--- a/rs/bitcoin/kyt/src/state.rs
+++ b/rs/bitcoin/kyt/src/state.rs
@@ -106,13 +106,17 @@ impl<T> FetchTxCache<T> {
         if self.status.insert(txid, status).is_none() {
             // This is a new entry, record its created time.
             self.created.push_back((txid, now));
+            assert_eq!(self.status.len(), self.created.len());
             // Purge the oldest entry when we exceed max_entries.
             if self.created.len() > self.max_entries {
-                return self.created.pop_front().and_then(|(txid, timestamp)| {
+                let removed = self.created.pop_front().and_then(|(txid, timestamp)| {
                     self.status
                         .remove(&txid)
                         .map(|status| (txid, timestamp, status))
                 });
+                assert_eq!(self.status.len(), self.created.len());
+                assert!(self.created.len() <= self.max_entries);
+                return removed;
             }
         }
         None

--- a/rs/bitcoin/kyt/src/state/tests.rs
+++ b/rs/bitcoin/kyt/src/state/tests.rs
@@ -124,3 +124,30 @@ fn test_fetch_tx_cache_bounds() {
         vec![(txid_1, 100, &()), (txid_3, 300, &()), (txid_0, 500, &())]
     );
 }
+
+#[test]
+fn cache_should_have_same_size() {
+    enum Status {
+        Status0,
+        Status1,
+        Status2,
+    }
+
+    let txid_0 = Txid::from([0u8; 32]);
+    let max_entries = 3;
+    let mut cache = FetchTxCache::new(max_entries);
+    assert_eq!(cache.status.len(), 0);
+    assert_eq!(cache.created.len(), 0);
+
+    cache.set_status_with(txid_0, Status::Status0, 0);
+    assert_eq!(cache.status.len(), 1);
+    assert_eq!(cache.created.len(), 1);
+
+    cache.set_status_with(txid_0, Status::Status1, 1);
+    assert_eq!(cache.status.len(), 1);
+    assert_eq!(cache.created.len(), 1);
+
+    cache.set_status_with(txid_0, Status::Status2, 2);
+    assert_eq!(cache.status.len(), 1);
+    assert_eq!(cache.created.len(), 1);
+}


### PR DESCRIPTION
feat: Proper check_transaction result caching with expiry (XC-196)

Implement size bound for cache entries of check_transaction results.
The oldest created entry will be purged when the cache is at capacity.
This ensures the KYT canister's memory usage will be bounded.