### PR TITLE
chore(dependency-mgmt): format *.py files under `ci/src/dependencies`

### DIFF
--- a/ci/src/dependencies/data_source/dummy_finding_data_source.py
+++ b/ci/src/dependencies/data_source/dummy_finding_data_source.py
@@ -17,9 +17,7 @@ class DummyFindingDataSource(FindingDataSource):
     ) -> Dict[Tuple[str, str, str, str], Finding]:
         return {}
 
-    def get_deleted_findings(
-        self, repository: str, scanner: str, dependency_id: str
-    ) -> List[Finding]:
+    def get_deleted_findings(self, repository: str, scanner: str, dependency_id: str) -> List[Finding]:
         return []
 
     def commit_has_block_exception(self, commit_type: CommitType, commit_hash: str) -> bool:

--- a/ci/src/dependencies/data_source/finding_data_source.py
+++ b/ci/src/dependencies/data_source/finding_data_source.py
@@ -44,9 +44,7 @@ class FindingDataSource(metaclass=abc.ABCMeta):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def get_deleted_findings(
-        self, repository: str, scanner: str, dependency_id: str
-    ) -> List[Finding]:
+    def get_deleted_findings(self, repository: str, scanner: str, dependency_id: str) -> List[Finding]:
         """Retrieve deleted findings with the given properties from data source, returns an empty list if no deleted findings exist or the data source doesn't support retrieval of deleted findings."""
         raise NotImplementedError
 

--- a/ci/src/dependencies/data_source/jira_finding_data_source.py
+++ b/ci/src/dependencies/data_source/jira_finding_data_source.py
@@ -83,7 +83,12 @@ class JiraFindingDataSource(FindingDataSource):
     risk_assessors: List[User]
     app_owner_msg_subscriber: AppOwnerMsgSubscriber
 
-    def __init__(self, subscribers: List[FindingDataSourceSubscriber], app_owner_msg_subscriber: AppOwnerMsgSubscriber = ConsoleLoggerAppOwnerMsgSubscriber(), custom_jira: Optional[JIRA] = None):
+    def __init__(
+        self,
+        subscribers: List[FindingDataSourceSubscriber],
+        app_owner_msg_subscriber: AppOwnerMsgSubscriber = ConsoleLoggerAppOwnerMsgSubscriber(),
+        custom_jira: Optional[JIRA] = None,
+    ):
         logging.debug(f"JiraFindingDataSource({subscribers},{custom_jira})")
         self.subscribers = subscribers
         self.jira = (
@@ -98,9 +103,7 @@ class JiraFindingDataSource(FindingDataSource):
     # Remove the unnecessary text strings from the description of the Linux kernel CNA CVEs
     @staticmethod
     def __filter_linux_kernel_cna_cves(vuln_description: str) -> str:
-        filter_strings = [
-            "In the Linux kernel, the following vulnerability has been resolved: "
-        ]
+        filter_strings = ["In the Linux kernel, the following vulnerability has been resolved: "]
         for filter_string in filter_strings:
             vuln_description = vuln_description.replace(filter_string, "")
         return vuln_description
@@ -135,29 +138,29 @@ class JiraFindingDataSource(FindingDataSource):
             # nested square brackets are not supported
             parts: List[str] = []
             is_link = False
-            parsed = ''
+            parsed = ""
             for c in row:
-                if c == '[':
+                if c == "[":
                     if is_link:
                         # nested links are not supported
                         return None
                     else:
                         is_link = True
                         parsed += c
-                elif c == ']':
+                elif c == "]":
                     is_link = False
                     parsed += c
-                elif c == '|':
+                elif c == "|":
                     if is_link:
                         parsed += c
                     else:
                         parts.append(parsed)
-                        parsed = ''
+                        parsed = ""
                 else:
                     parsed += c
             parts.append(parsed)
 
-            if len(parts) > 1 and parts[1].startswith('[') and parts[1].endswith(']'):
+            if len(parts) > 1 and parts[1].startswith("[") and parts[1].endswith("]"):
                 # jira has changed the vulnerability id to a wiki markup link, e.g.
                 # [https://avd.aquasec.com/nvd/cve-2023-35823|https://avd.aquasec.com/nvd/cve-2023-35823]
                 # change it back to https://avd.aquasec.com/nvd/cve-2023-35823
@@ -169,9 +172,21 @@ class JiraFindingDataSource(FindingDataSource):
 
             if len(parts) == 5:
                 # backwards compatibility for entries that don't have risk column
-                res.append(Vulnerability(id=parts[1], name=parts[2], description=parts[3], score=int(parts[4]), risk_note=JIRA_VULNERABILITY_TABLE_RISK_NOTE_MIGRATION_LABEL))
+                res.append(
+                    Vulnerability(
+                        id=parts[1],
+                        name=parts[2],
+                        description=parts[3],
+                        score=int(parts[4]),
+                        risk_note=JIRA_VULNERABILITY_TABLE_RISK_NOTE_MIGRATION_LABEL,
+                    )
+                )
             elif len(parts) == 6:
-                res.append(Vulnerability(id=parts[1], name=parts[2], description=parts[3], score=int(parts[4]), risk_note=parts[5]))
+                res.append(
+                    Vulnerability(
+                        id=parts[1], name=parts[2], description=parts[3], score=int(parts[4]), risk_note=parts[5]
+                    )
+                )
             else:
                 # unexpected format
                 return None
@@ -385,16 +400,20 @@ class JiraFindingDataSource(FindingDataSource):
             summary_update_needed = True
         if finding_old is None or finding_old.vulnerable_dependency != finding_new.vulnerable_dependency:
             res[JIRA_FINDING_TO_CUSTOM_FIELD.get("vulnerable_dependency_id")[0]] = finding_new.vulnerable_dependency.id
-            res[
-                JIRA_FINDING_TO_CUSTOM_FIELD.get("vulnerable_dependency_version")[0]
-            ] = finding_new.vulnerable_dependency.version
+            res[JIRA_FINDING_TO_CUSTOM_FIELD.get("vulnerable_dependency_version")[0]] = (
+                finding_new.vulnerable_dependency.version
+            )
             summary_update_needed = True
             dep_update_needed = True
             patch_version_update_needed = True
-        if finding_old is None or finding_old.vulnerabilities != finding_new.vulnerabilities or finding_new.vulnerabilities[0].risk_note == JIRA_VULNERABILITY_TABLE_RISK_NOTE_MIGRATION_LABEL:
-            res[
-                JIRA_FINDING_TO_CUSTOM_FIELD.get("vulnerabilities")[0]
-            ] = JiraFindingDataSource.__finding_to_jira_vulnerabilities(finding_new.vulnerabilities)
+        if (
+            finding_old is None
+            or finding_old.vulnerabilities != finding_new.vulnerabilities
+            or finding_new.vulnerabilities[0].risk_note == JIRA_VULNERABILITY_TABLE_RISK_NOTE_MIGRATION_LABEL
+        ):
+            res[JIRA_FINDING_TO_CUSTOM_FIELD.get("vulnerabilities")[0]] = (
+                JiraFindingDataSource.__finding_to_jira_vulnerabilities(finding_new.vulnerabilities)
+            )
             patch_version_update_needed = True
         if finding_old is None or finding_old.first_level_dependencies != finding_new.first_level_dependencies:
             dep_update_needed = True
@@ -417,9 +436,9 @@ class JiraFindingDataSource(FindingDataSource):
                 owning_teams.append(JIRA_OWNER_GROUP_BY_TEAM[team])
             res[JIRA_FINDING_TO_CUSTOM_FIELD.get("owning_teams")[0]] = owning_teams
         if finding_old is None or finding_old.patch_responsible != finding_new.patch_responsible:
-            res[
-                JIRA_FINDING_TO_CUSTOM_FIELD.get("patch_responsible")[0]
-            ] = JiraFindingDataSource.__finding_to_jira_users(finding_new.patch_responsible)
+            res[JIRA_FINDING_TO_CUSTOM_FIELD.get("patch_responsible")[0]] = (
+                JiraFindingDataSource.__finding_to_jira_users(finding_new.patch_responsible)
+            )
         if finding_old is None or finding_old.due_date != finding_new.due_date:
             res[JIRA_FINDING_TO_CUSTOM_FIELD.get("due_date")[0]] = JiraFindingDataSource.__finding_to_jira_due_date(
                 finding_new.due_date
@@ -428,16 +447,16 @@ class JiraFindingDataSource(FindingDataSource):
             res[JIRA_FINDING_TO_CUSTOM_FIELD.get("score")[0]] = None if finding_new.score == -1 else finding_new.score
 
         if summary_update_needed:
-            res[
-                "summary"
-            ] = f"[{finding_new.repository}][{finding_new.scanner}] Vulnerability in {finding_new.vulnerable_dependency.name} {finding_new.vulnerable_dependency.version}"[
-                :100
+            res["summary"] = (
+                f"[{finding_new.repository}][{finding_new.scanner}] Vulnerability in {finding_new.vulnerable_dependency.name} {finding_new.vulnerable_dependency.version}"[
+                    :100
                 ]
+            )
         all_deps: List[Dependency] = [finding_new.vulnerable_dependency] + finding_new.first_level_dependencies
         if dep_update_needed:
-            res[
-                JIRA_FINDING_TO_CUSTOM_FIELD.get("dependencies")[0]
-            ] = JiraFindingDataSource.__finding_to_jira_dependencies(all_deps)
+            res[JIRA_FINDING_TO_CUSTOM_FIELD.get("dependencies")[0]] = (
+                JiraFindingDataSource.__finding_to_jira_dependencies(all_deps)
+            )
         if patch_version_update_needed:
             (
                 res[JIRA_FINDING_TO_CUSTOM_FIELD.get("patch_versions")[0]],
@@ -558,9 +577,7 @@ class JiraFindingDataSource(FindingDataSource):
                 res[finding.id()] = deepcopy(finding)
         return res
 
-    def get_deleted_findings(
-        self, repository: str, scanner: str, dependency_id: str
-    ) -> List[Finding]:
+    def get_deleted_findings(self, repository: str, scanner: str, dependency_id: str) -> List[Finding]:
         cache_key = (repository, scanner, dependency_id)
         if cache_key in self.deleted_findings_cached:
             return deepcopy(list(map(lambda x: x[0], self.deleted_findings_cached[cache_key])))
@@ -581,7 +598,11 @@ class JiraFindingDataSource(FindingDataSource):
         result = []
         for issue in issues:
             finding: Finding = self.__jira_to_finding(issue)
-            if finding.repository == repository and finding.scanner == scanner and finding.vulnerable_dependency.id == dependency_id:
+            if (
+                finding.repository == repository
+                and finding.scanner == scanner
+                and finding.vulnerable_dependency.id == dependency_id
+            ):
                 result.append((finding, issue))
         self.deleted_findings_cached[cache_key] = result
         return deepcopy(list(map(lambda x: x[0], result)))
@@ -608,7 +629,9 @@ class JiraFindingDataSource(FindingDataSource):
         for field_name, field_value in fields_to_update.items():
             try:
                 if len(field_value) > 32700:
-                    logging.warning(f"field {field_name} in finding {finding.id()} exceeds character limit with {len(field_value)} characters")
+                    logging.warning(
+                        f"field {field_name} in finding {finding.id()} exceeds character limit with {len(field_value)} characters"
+                    )
                     does_exceed = True
             except TypeError:
                 pass  # some types don't have a length
@@ -707,10 +730,6 @@ class JiraFindingDataSource(FindingDataSource):
             self.risk_assessors = self.__jira_to_finding_users(assessors)
             return self.risk_assessors
         except RuntimeError:
-            logging.error(
-                "could not determine risk assessors by ticket\nusing default risk assessors instead"
-            )
-            logging.debug(
-                f"could not determine risk assessors by ticket, reason:\n{traceback.format_exc()}"
-            )
+            logging.error("could not determine risk assessors by ticket\nusing default risk assessors instead")
+            logging.debug(f"could not determine risk assessors by ticket, reason:\n{traceback.format_exc()}")
             return JIRA_DEFAULT_RISK_ASSESSORS

--- a/ci/src/dependencies/data_source/jira_finding_data_source_test.py
+++ b/ci/src/dependencies/data_source/jira_finding_data_source_test.py
@@ -38,7 +38,7 @@ def jira_ds(jira_lib_mock):
 
 
 def random_string(n):
-    return ''.join(random.choice(string.ascii_letters + string.digits) for _ in range(n))
+    return "".join(random.choice(string.ascii_letters + string.digits) for _ in range(n))
 
 
 def test_get_risk_assessor_return_single_user(jira_ds, jira_lib_mock):
@@ -187,16 +187,16 @@ def test_get_finding_return_issue(jira_ds, jira_lib_mock):
         JIRA_FINDING_TO_CUSTOM_FIELD.get("vulnerable_dependency_id")[0]: "https://crates.io/crates/chrono",
         JIRA_FINDING_TO_CUSTOM_FIELD.get("vulnerable_dependency_version")[0]: "0.4.19",
         JIRA_FINDING_TO_CUSTOM_FIELD.get("dependencies")[0]: "||*id*||*name*||*version*||\n"
-                                                             "|https://crates.io/crates/chrono|chrono|0.4.19|\n"
-                                                             "|https://crates.io/crates/syn|syn|1.0|\n",
+        "|https://crates.io/crates/chrono|chrono|0.4.19|\n"
+        "|https://crates.io/crates/syn|syn|1.0|\n",
         JIRA_FINDING_TO_CUSTOM_FIELD.get("vulnerabilities")[0]: "||*id*||*name*||*description*||*score*||*risk*||\n"
-                                                                "|https://rustsec.org/advisories/RUSTSEC-2020-0159|RUSTSEC-2020-0159|Potential segfault in localtime_r invocations|-1| |\n"
-                                                                "|[https://rustsec.org/advisories/RUSTSEC-2022-0051|https://rustsec.org/advisories/RUSTSEC-2022-0051]|RUSTSEC-2022-0051|Memory corruption in liblz4|100|crit: [look here for more info| https://example.com] or be smart [https://example.com|https://example.com|smart-link]|\n",
+        "|https://rustsec.org/advisories/RUSTSEC-2020-0159|RUSTSEC-2020-0159|Potential segfault in localtime_r invocations|-1| |\n"
+        "|[https://rustsec.org/advisories/RUSTSEC-2022-0051|https://rustsec.org/advisories/RUSTSEC-2022-0051]|RUSTSEC-2022-0051|Memory corruption in liblz4|100|crit: [look here for more info| https://example.com] or be smart [https://example.com|https://example.com|smart-link]|\n",
         JIRA_FINDING_TO_CUSTOM_FIELD.get("patch_versions")[
             0
         ]: "||*dep / vuln*||RUSTSEC-2020-0159||RUSTSEC-2022-0051||\n"
-           "||*chrono*|0.4.20;>=0.5.0||\n"
-           "||*syn*||>=1.9.4|\n",
+        "||*chrono*|0.4.20;>=0.5.0||\n"
+        "||*syn*||>=1.9.4|\n",
         JIRA_FINDING_TO_CUSTOM_FIELD.get("projects")[0]: "* project A\n" "* project B\n" "* project C\n",
         JIRA_FINDING_TO_CUSTOM_FIELD.get("risk_assessor")[0]: [user1, user2],
         JIRA_FINDING_TO_CUSTOM_FIELD.get("risk")[0]: risk,
@@ -222,8 +222,8 @@ def test_get_finding_return_issue(jira_ds, jira_lib_mock):
     assert res1.vulnerable_dependency.version == "0.4.19"
     assert len(res1.vulnerable_dependency.fix_version_for_vulnerability) == 1
     assert res1.vulnerable_dependency.fix_version_for_vulnerability[
-               "https://rustsec.org/advisories/RUSTSEC-2020-0159"
-           ] == ["0.4.20", ">=0.5.0"]
+        "https://rustsec.org/advisories/RUSTSEC-2020-0159"
+    ] == ["0.4.20", ">=0.5.0"]
     assert len(res1.vulnerabilities) == 2
     assert res1.vulnerabilities[0].id == "https://rustsec.org/advisories/RUSTSEC-2020-0159"
     assert res1.vulnerabilities[0].name == "RUSTSEC-2020-0159"
@@ -234,15 +234,18 @@ def test_get_finding_return_issue(jira_ds, jira_lib_mock):
     assert res1.vulnerabilities[1].name == "RUSTSEC-2022-0051"
     assert res1.vulnerabilities[1].description == "Memory corruption in liblz4"
     assert res1.vulnerabilities[1].score == 100
-    assert res1.vulnerabilities[1].risk_note == "crit: [look here for more info| https://example.com] or be smart [https://example.com|https://example.com|smart-link]"
+    assert (
+        res1.vulnerabilities[1].risk_note
+        == "crit: [look here for more info| https://example.com] or be smart [https://example.com|https://example.com|smart-link]"
+    )
     assert len(res1.first_level_dependencies) == 1
     assert res1.first_level_dependencies[0].id == "https://crates.io/crates/syn"
     assert res1.first_level_dependencies[0].name == "syn"
     assert res1.first_level_dependencies[0].version == "1.0"
     assert len(res1.first_level_dependencies[0].fix_version_for_vulnerability) == 1
     assert res1.first_level_dependencies[0].fix_version_for_vulnerability[
-               "https://rustsec.org/advisories/RUSTSEC-2022-0051"
-           ] == [">=1.9.4"]
+        "https://rustsec.org/advisories/RUSTSEC-2022-0051"
+    ] == [">=1.9.4"]
     assert res1.projects == ["project A", "project B", "project C"]
     assert res1.risk_assessor == [User(user1.accountId), User(user2.accountId, user2.displayName, user2.emailAddress)]
     assert res1.risk == SecurityRisk.CRITICAL
@@ -273,9 +276,9 @@ def test_get_open_finding_raise_error_if_two_issues_with_same_id_returned(jira_d
         JIRA_FINDING_TO_CUSTOM_FIELD.get("vulnerable_dependency_version")[0]: "vers",
         JIRA_FINDING_TO_CUSTOM_FIELD.get("dependencies")[0]: "||*id*||*name*||*version*||\n" "|id|chrono|vers|\n",
         JIRA_FINDING_TO_CUSTOM_FIELD.get("vulnerabilities")[0]: "||*id*||*name*||*description*||*score*||\n"
-                                                                "|https://rustsec.org/advisories/RUSTSEC-2020-0159|RUSTSEC-2020-0159|desc|-1|\n",
+        "|https://rustsec.org/advisories/RUSTSEC-2020-0159|RUSTSEC-2020-0159|desc|-1|\n",
         JIRA_FINDING_TO_CUSTOM_FIELD.get("patch_versions")[0]: "||*dep / vuln*||RUSTSEC-2020-0159||\n"
-                                                               "||*chrono*|0.4.20;>=0.5.0||\n",
+        "||*chrono*|0.4.20;>=0.5.0||\n",
         JIRA_FINDING_TO_CUSTOM_FIELD.get("projects")[0]: "* project A",
         JIRA_FINDING_TO_CUSTOM_FIELD.get("risk_assessor")[0]: [user1],
         JIRA_FINDING_TO_CUSTOM_FIELD.get("risk")[0]: None,
@@ -307,9 +310,9 @@ def test_get_finding_return_none_if_primary_key_of_finding_not_matching(jira_ds,
         JIRA_FINDING_TO_CUSTOM_FIELD.get("vulnerable_dependency_version")[0]: "0.4.19",
         JIRA_FINDING_TO_CUSTOM_FIELD.get("scanner")[0]: "scanner",
         JIRA_FINDING_TO_CUSTOM_FIELD.get("dependencies")[0]: "||*id*||*name*||*version*||\n"
-                                                             "|https://crates.io/crates/chrono|chrono|0.4.19|\n",
+        "|https://crates.io/crates/chrono|chrono|0.4.19|\n",
         JIRA_FINDING_TO_CUSTOM_FIELD.get("vulnerabilities")[0]: "||*id*||*name*||*description*||*score*||\n"
-                                                                "|https://rustsec.org/advisories/RUSTSEC-2020-0159|RUSTSEC-2020-0159|Potential segfault in localtime_r invocations|-1|\n",
+        "|https://rustsec.org/advisories/RUSTSEC-2020-0159|RUSTSEC-2020-0159|Potential segfault in localtime_r invocations|-1|\n",
         JIRA_FINDING_TO_CUSTOM_FIELD.get("patch_versions")[0]: None,
         JIRA_FINDING_TO_CUSTOM_FIELD.get("projects")[0]: None,
         JIRA_FINDING_TO_CUSTOM_FIELD.get("risk_assessor")[0]: None,
@@ -476,7 +479,15 @@ def test_create_finding_special_character_escaping(jira_ds, jira_lib_mock):
         "repo",
         "scanner",
         Dependency("id{code}and|pipe{code}", "{code}name{code}", "ver|sion", {"id{code}": ["123;456", ";789"]}),
-        [Vulnerability("id{code}", "{code}na|me{code}", "|description|", 0, "[url with pipe is fine|https://example.com] and{code}")],
+        [
+            Vulnerability(
+                "id{code}",
+                "{code}na|me{code}",
+                "|description|",
+                0,
+                "[url with pipe is fine|https://example.com] and{code}",
+            )
+        ],
         [Dependency("|id|", "{code}name", "ver{code}|sion", {"id{code}": [";321;", "98;7"]})],
         ["proj1{code}", "|proj2", "pr{code}oject3|"],
         [],
@@ -527,7 +538,11 @@ def test_dont_create_finding_with_too_long_field(jira_ds, jira_lib_mock):
         None,
     )
     for i in range(1000):
-        finding_in.vulnerabilities.append(Vulnerability(id=random_string(10), name=random_string(10), description=random_string(10), risk_note=random_string(10)))
+        finding_in.vulnerabilities.append(
+            Vulnerability(
+                id=random_string(10), name=random_string(10), description=random_string(10), risk_note=random_string(10)
+            )
+        )
     jira_lib_mock.search_issues.return_value = []
 
     jira_ds.create_or_update_open_finding(finding_in)
@@ -543,9 +558,9 @@ def test_dont_update_finding_with_too_long_field(jira_ds, jira_lib_mock):
         JIRA_FINDING_TO_CUSTOM_FIELD.get("vulnerable_dependency_version")[0]: "dep_vers",
         JIRA_FINDING_TO_CUSTOM_FIELD.get("scanner")[0]: "scanner",
         JIRA_FINDING_TO_CUSTOM_FIELD.get("dependencies")[0]: "||*id*||*name*||*version*||\n"
-                                                             "|dep_id|dep_name|dep_vers|\n",
+        "|dep_id|dep_name|dep_vers|\n",
         JIRA_FINDING_TO_CUSTOM_FIELD.get("vulnerabilities")[0]: "||*id*||*name*||*description*||*score*||*risk*||\n"
-                                                                "|vuln_id|vuln_name|vuln_version|-1| |\n",
+        "|vuln_id|vuln_name|vuln_version|-1| |\n",
         JIRA_FINDING_TO_CUSTOM_FIELD.get("patch_versions")[0]: None,
         JIRA_FINDING_TO_CUSTOM_FIELD.get("projects")[0]: None,
         JIRA_FINDING_TO_CUSTOM_FIELD.get("risk_assessor")[0]: None,
@@ -574,7 +589,11 @@ def test_dont_update_finding_with_too_long_field(jira_ds, jira_lib_mock):
         None,
     )
     for i in range(1000):
-        finding_in.vulnerabilities.append(Vulnerability(id=random_string(10), name=random_string(10), description=random_string(10), risk_note=random_string(10)))
+        finding_in.vulnerabilities.append(
+            Vulnerability(
+                id=random_string(10), name=random_string(10), description=random_string(10), risk_note=random_string(10)
+            )
+        )
 
     jira_ds.create_or_update_open_finding(finding_in)
 
@@ -591,9 +610,9 @@ def test_delete_finding():
         JIRA_FINDING_TO_CUSTOM_FIELD.get("vulnerable_dependency_id")[0]: "https://crates.io/crates/chrono",
         JIRA_FINDING_TO_CUSTOM_FIELD.get("vulnerable_dependency_version")[0]: "0.4.19",
         JIRA_FINDING_TO_CUSTOM_FIELD.get("dependencies")[0]: "||*id*||*name*||*version*||\n"
-                                                             "|https://crates.io/crates/chrono|chrono|0.4.19|\n",
+        "|https://crates.io/crates/chrono|chrono|0.4.19|\n",
         JIRA_FINDING_TO_CUSTOM_FIELD.get("vulnerabilities")[0]: "||*id*||*name*||*description*||*score*||\n"
-                                                                "|vuln_id|vuln_name|vuln_desc|-1|\n",
+        "|vuln_id|vuln_name|vuln_desc|-1|\n",
         JIRA_FINDING_TO_CUSTOM_FIELD.get("patch_versions")[
             0
         ]: "||*dep / vuln*||RUSTSEC-2020-0159||RUSTSEC-2022-0051||\n",

--- a/ci/src/dependencies/data_source/slack_findings_failover/data.py
+++ b/ci/src/dependencies/data_source/slack_findings_failover/data.py
@@ -38,15 +38,29 @@ class SlackVulnerabilityEvent:
 
     @staticmethod
     def vuln_changed(vuln_id: str, channel_id: str, updated_fields: Dict[str, str]):
-        return SlackVulnerabilityEvent(SlackVulnerabilityEventType.VULN_CHANGED, vuln_id, channel_id, updated_fields=updated_fields)
+        return SlackVulnerabilityEvent(
+            SlackVulnerabilityEventType.VULN_CHANGED, vuln_id, channel_id, updated_fields=updated_fields
+        )
 
     @staticmethod
     def dep_added(vuln_id: str, channel_id: str, finding_id: Tuple[str, str, str, str], added_projects: List[str]):
-        return SlackVulnerabilityEvent(SlackVulnerabilityEventType.DEP_ADDED, vuln_id, channel_id, finding_id=finding_id, added_projects=added_projects)
+        return SlackVulnerabilityEvent(
+            SlackVulnerabilityEventType.DEP_ADDED,
+            vuln_id,
+            channel_id,
+            finding_id=finding_id,
+            added_projects=added_projects,
+        )
 
     @staticmethod
     def dep_removed(vuln_id: str, channel_id: str, finding_id: Tuple[str, str, str, str], removed_projects: List[str]):
-        return SlackVulnerabilityEvent(SlackVulnerabilityEventType.DEP_REMOVED, vuln_id, channel_id, finding_id=finding_id, removed_projects=removed_projects)
+        return SlackVulnerabilityEvent(
+            SlackVulnerabilityEventType.DEP_REMOVED,
+            vuln_id,
+            channel_id,
+            finding_id=finding_id,
+            removed_projects=removed_projects,
+        )
 
 
 @dataclass
@@ -59,7 +73,13 @@ class SlackFinding:
 
     @staticmethod
     def from_finding(finding: Finding) -> "SlackFinding":
-        return SlackFinding(finding.repository, finding.scanner, finding.vulnerable_dependency.id, finding.vulnerable_dependency.version, sorted(finding.projects))
+        return SlackFinding(
+            finding.repository,
+            finding.scanner,
+            finding.vulnerable_dependency.id,
+            finding.vulnerable_dependency.version,
+            sorted(finding.projects),
+        )
 
     def id(self) -> Tuple[str, str, str, str]:
         return self.repository, self.scanner, self.dependency_id, self.dependency_version

--- a/ci/src/dependencies/data_source/slack_findings_failover/parse_format.py
+++ b/ci/src/dependencies/data_source/slack_findings_failover/parse_format.py
@@ -14,7 +14,9 @@ def project_to_list_item(project: str, indent: int) -> BlockKitListItem:
     if proj_parts:
         if proj_parts[2]:
             prefix = proj_parts[0] if proj_parts[0] else ""
-            return BlockKitListItem(text=[BlockKitRichText(text=prefix + proj_parts[1], url=proj_parts[2])], indent=indent)
+            return BlockKitListItem(
+                text=[BlockKitRichText(text=prefix + proj_parts[1], url=proj_parts[2])], indent=indent
+            )
 
         else:
             return BlockKitListItem(text=[BlockKitRichText(project)], indent=indent)
@@ -23,7 +25,7 @@ def project_to_list_item(project: str, indent: int) -> BlockKitListItem:
 
 
 def parse_slack_field(string: str, field_name: str) -> Optional[str]:
-    if match := re.match(fr"^\*{field_name}\*\n\s*(?P<field_value>.*)$", string):
+    if match := re.match(rf"^\*{field_name}\*\n\s*(?P<field_value>.*)$", string):
         return match.group("field_value")
     return None
 

--- a/ci/src/dependencies/data_source/slack_findings_failover/parse_format_test.py
+++ b/ci/src/dependencies/data_source/slack_findings_failover/parse_format_test.py
@@ -7,18 +7,42 @@ from data_source.slack_findings_failover.parse_format import (
 
 def test_parse_slack_field():
     assert parse_slack_field("*name*\ncontent", "name") == "content"
-    assert parse_slack_field("*some name with space*\n   some content with space", "some name with space") == "some content with space"
-    assert parse_slack_field("*name*\nsome content with special char <>!@#$%^&*()_+-=;':\",./", "name") == "some content with special char <>!@#$%^&*()_+-=;':\",./"
+    assert (
+        parse_slack_field("*some name with space*\n   some content with space", "some name with space")
+        == "some content with space"
+    )
+    assert (
+        parse_slack_field("*name*\nsome content with special char <>!@#$%^&*()_+-=;':\",./", "name")
+        == "some content with special char <>!@#$%^&*()_+-=;':\",./"
+    )
 
 
 def test_parse_slack_optional_hyperlink():
     assert parse_slack_optional_hyperlink("foo") == ("foo", None)
-    assert parse_slack_optional_hyperlink("<https://example.com|Example Website>") == ("Example Website", "https://example.com")
-    assert parse_slack_optional_hyperlink("<ftp://example.com:21|Example FTP Server>") == ("Example FTP Server", "ftp://example.com:21")
+    assert parse_slack_optional_hyperlink("<https://example.com|Example Website>") == (
+        "Example Website",
+        "https://example.com",
+    )
+    assert parse_slack_optional_hyperlink("<ftp://example.com:21|Example FTP Server>") == (
+        "Example FTP Server",
+        "ftp://example.com:21",
+    )
 
 
 def test_parse_finding_project():
     assert parse_finding_project("some/project/path") == (None, "some/project/path", None)
-    assert parse_finding_project("PREFIX:C:\\\\a path\\for some (really cool) project") == ("PREFIX:", "C:\\\\a path\\for some (really cool) project", None)
-    assert parse_finding_project("/this is/a (long) linux path    (https://example.com)") == (None, "/this is/a (long) linux path", "https://example.com")
-    assert parse_finding_project("OSP:   /some/project/path (https://example.com)") == ("OSP:   ", "/some/project/path", "https://example.com")
+    assert parse_finding_project("PREFIX:C:\\\\a path\\for some (really cool) project") == (
+        "PREFIX:",
+        "C:\\\\a path\\for some (really cool) project",
+        None,
+    )
+    assert parse_finding_project("/this is/a (long) linux path    (https://example.com)") == (
+        None,
+        "/this is/a (long) linux path",
+        "https://example.com",
+    )
+    assert parse_finding_project("OSP:   /some/project/path (https://example.com)") == (
+        "OSP:   ",
+        "/some/project/path",
+        "https://example.com",
+    )

--- a/ci/src/dependencies/data_source/slack_findings_failover/scan_result.py
+++ b/ci/src/dependencies/data_source/slack_findings_failover/scan_result.py
@@ -22,15 +22,28 @@ class SlackScanResult:
     removed_dependencies: Dict[Tuple[str, str, str, str], Set[str]] = field(default_factory=lambda: {})
 
     def has_updates(self):
-        return self.new_vulnerabilities > 0 or self.changed_vulnerabilities > 0 or self.fixed_vulnerabilities > 0 or len(self.added_dependencies) > 0 or len(self.removed_dependencies) > 0
+        return (
+            self.new_vulnerabilities > 0
+            or self.changed_vulnerabilities > 0
+            or self.fixed_vulnerabilities > 0
+            or len(self.added_dependencies) > 0
+            or len(self.removed_dependencies) > 0
+        )
 
     def get_slack_msg(self, repository: str, scanner: str) -> str:
         block_kit_msg = [
             block_kit_header("Scan Results"),
             block_kit_section_with_two_cols("Repository", repository, "Scanner", scanner),
-            block_kit_section_with_two_cols("Time", get_current_iso_timestamp(), "New Vulnerabilities", str(self.new_vulnerabilities)),
-            block_kit_section_with_two_cols("Changed Vulnerabilities", str(self.changed_vulnerabilities), "Fixed Vulnerabilities", str(self.fixed_vulnerabilities)),
-            block_kit_header("Dependencies")
+            block_kit_section_with_two_cols(
+                "Time", get_current_iso_timestamp(), "New Vulnerabilities", str(self.new_vulnerabilities)
+            ),
+            block_kit_section_with_two_cols(
+                "Changed Vulnerabilities",
+                str(self.changed_vulnerabilities),
+                "Fixed Vulnerabilities",
+                str(self.fixed_vulnerabilities),
+            ),
+            block_kit_header("Dependencies"),
         ]
         dep_sections = []
         if len(self.added_dependencies) > 0:
@@ -44,7 +57,9 @@ class SlackScanResult:
                     list_items.append(BlockKitListItem(text=[BlockKitRichText(f"{dep_id[2]} {dep_id[3]}")], indent=0))
                     for proj in projects:
                         list_items.append(project_to_list_item(proj, 1))
-                block_kit_msg.append(block_kit_bullet_list_with_headline(BlockKitListHeadline.with_text(header), list_items))
+                block_kit_msg.append(
+                    block_kit_bullet_list_with_headline(BlockKitListHeadline.with_text(header), list_items)
+                )
         else:
             block_kit_msg.append(block_kit_bullet_list_with_headline(BlockKitListHeadline.with_text("No changes"), []))
         return json.dumps(block_kit_msg)

--- a/ci/src/dependencies/data_source/slack_findings_failover/vuln_info.py
+++ b/ci/src/dependencies/data_source/slack_findings_failover/vuln_info.py
@@ -51,7 +51,9 @@ class SlackVulnerabilityInfo:
 
     def merge_with(self, findings: Dict[Tuple[str, str, str, str], SlackFinding], channel_id: str, message_id: str):
         if channel_id in self.msg_id_by_channel:
-            raise RuntimeError(f"merging vuln info with vuln info from same channel: existing {self.msg_id_by_channel[channel_id]}, new {message_id}")
+            raise RuntimeError(
+                f"merging vuln info with vuln info from same channel: existing {self.msg_id_by_channel[channel_id]}, new {message_id}"
+            )
         self.msg_id_by_channel[channel_id] = message_id
         for s_finding in findings.values():
             if s_finding.id() in self.finding_by_id:
@@ -78,7 +80,9 @@ class SlackVulnerabilityInfo:
                 res.append(SlackVulnerabilityEvent.dep_added(self.vulnerability.id, channel, s_finding.id(), projects))
         return res
 
-    def get_events_for_remove(self, info_by_project: Dict[str, SlackProjectInfo], repository: str, scanner: str) -> List[SlackVulnerabilityEvent]:
+    def get_events_for_remove(
+        self, info_by_project: Dict[str, SlackProjectInfo], repository: str, scanner: str
+    ) -> List[SlackVulnerabilityEvent]:
         res = []
         channels_to_keep = set()
         for s_finding in self.finding_by_id.values():
@@ -90,7 +94,9 @@ class SlackVulnerabilityInfo:
                             projects_by_channel_id[channel] = []
                         projects_by_channel_id[channel].append(proj)
                 for channel, projects in projects_by_channel_id.items():
-                    res.append(SlackVulnerabilityEvent.dep_removed(self.vulnerability.id, channel, s_finding.id(), projects))
+                    res.append(
+                        SlackVulnerabilityEvent.dep_removed(self.vulnerability.id, channel, s_finding.id(), projects)
+                    )
             else:
                 # if the finding belongs to a different repo/scanner we have to keep the corresponding vuln in the corresponding channel
                 for proj in s_finding.projects:
@@ -102,9 +108,13 @@ class SlackVulnerabilityInfo:
                 rm_events.append(SlackVulnerabilityEvent.vuln_removed(self.vulnerability.id, channel))
         return rm_events + res
 
-    def update_with(self, other: VulnerabilityInfo, info_by_project: Dict[str, SlackProjectInfo], repository: str, scanner: str) -> List[SlackVulnerabilityEvent]:
+    def update_with(
+        self, other: VulnerabilityInfo, info_by_project: Dict[str, SlackProjectInfo], repository: str, scanner: str
+    ) -> List[SlackVulnerabilityEvent]:
         if self.vulnerability.id != other.vulnerability.id:
-            raise RuntimeError(f"trying to merge different vulnerabilities {self.vulnerability.id} and {other.vulnerability.id}")
+            raise RuntimeError(
+                f"trying to merge different vulnerabilities {self.vulnerability.id} and {other.vulnerability.id}"
+            )
         vuln_id = self.vulnerability.id
         res = []
 
@@ -212,7 +222,11 @@ class SlackVulnerabilityInfo:
         if len(filtered_findings) == 0:
             return None
 
-        block_kit_msg.append(block_kit_section_with_two_cols("Risk Assessor", ", ".join(sorted(list(risk_assessors))), "Last Update", get_current_iso_timestamp()))
+        block_kit_msg.append(
+            block_kit_section_with_two_cols(
+                "Risk Assessor", ", ".join(sorted(list(risk_assessors))), "Last Update", get_current_iso_timestamp()
+            )
+        )
         block_kit_msg.append(block_kit_section_with_single_col("Description", self.vulnerability.description))
 
         block_kit_msg.append(block_kit_header("Findings"))
@@ -220,12 +234,20 @@ class SlackVulnerabilityInfo:
         filtered_findings.sort(key=lambda x: x.id())
         for finding in filtered_findings:
             block_kit_msg.append(block_kit_divider())
-            block_kit_msg.append(block_kit_section_with_two_cols("Repository", finding.repository, "Scanner", finding.scanner))
-            block_kit_msg.append(block_kit_section_with_two_cols("Dependency", finding.dependency_id, "Version", finding.dependency_version))
+            block_kit_msg.append(
+                block_kit_section_with_two_cols("Repository", finding.repository, "Scanner", finding.scanner)
+            )
+            block_kit_msg.append(
+                block_kit_section_with_two_cols(
+                    "Dependency", finding.dependency_id, "Version", finding.dependency_version
+                )
+            )
             list_items = []
             for proj in finding.projects:
                 if channel_id in info_by_project[proj].channels:
                     list_items.append(project_to_list_item(proj, 0))
-            block_kit_msg.append(block_kit_bullet_list_with_headline(BlockKitListHeadline.with_text("Projects"), list_items))
+            block_kit_msg.append(
+                block_kit_bullet_list_with_headline(BlockKitListHeadline.with_text("Projects"), list_items)
+            )
 
         return json.dumps(block_kit_msg)

--- a/ci/src/dependencies/data_source/slack_findings_failover/vuln_info_test.py
+++ b/ci/src/dependencies/data_source/slack_findings_failover/vuln_info_test.py
@@ -63,7 +63,7 @@ def test_events_for_add():
     info_by_project = {
         "proj11": SlackProjectInfo("proj11", {"c1"}, {}),
         "proj12": SlackProjectInfo("proj12", {"c1"}, {}),
-        "proj2": SlackProjectInfo("proj2", {"c2"}, {})
+        "proj2": SlackProjectInfo("proj2", {"c2"}, {}),
     }
     svi = SlackVulnerabilityInfo(v, {sf1.id(): sf1, sf2.id(): sf2})
     da1 = SlackVulnerabilityEvent.dep_added(v.id, "c1", sf1.id(), sf1.projects)
@@ -89,9 +89,11 @@ def test_events_for_remove():
         "proj11": SlackProjectInfo("proj11", {"c1"}, {}),
         "proj12": SlackProjectInfo("proj12", {"c1"}, {}),
         "proj2": SlackProjectInfo("proj2", {"c2"}, {}),
-        "proj3": SlackProjectInfo("proj3", {"c2"}, {})
+        "proj3": SlackProjectInfo("proj3", {"c2"}, {}),
     }
-    svi = SlackVulnerabilityInfo(v, {sf1.id(): sf1, sf2.id(): sf2, sf_keep.id(): sf_keep}, {"c1": "msgid1", "c2": "msgid2"})
+    svi = SlackVulnerabilityInfo(
+        v, {sf1.id(): sf1, sf2.id(): sf2, sf_keep.id(): sf_keep}, {"c1": "msgid1", "c2": "msgid2"}
+    )
     dr1 = SlackVulnerabilityEvent.dep_removed(v.id, "c1", sf1.id(), sf1.projects)
     dr2 = SlackVulnerabilityEvent.dep_removed(v.id, "c2", sf2.id(), sf2.projects)
 
@@ -117,7 +119,7 @@ def test_update_with():
     info_by_project = {
         "proj1": SlackProjectInfo("proj1", {"c1"}, {}),
         "proj2": SlackProjectInfo("proj2", {"c2"}, {}),
-        "proj3": SlackProjectInfo("proj3", {"c3"}, {})
+        "proj3": SlackProjectInfo("proj3", {"c3"}, {}),
     }
 
     svi = SlackVulnerabilityInfo(v, {sf1.id(): sf1, sf_fixed.id(): sf_fixed}, {"c1": "msgid1", "c2": "msgid2"})

--- a/ci/src/dependencies/data_source/slack_findings_failover/vuln_store.py
+++ b/ci/src/dependencies/data_source/slack_findings_failover/vuln_store.py
@@ -23,33 +23,57 @@ from integration.slack.slack_block_kit_utils import (
 class SlackVulnerabilityStore:
     slack_api_by_channel: Dict[str, SlackApi]
 
-    def __update_message_if_needed(self, channel_id: str, slack_vuln_info: SlackVulnerabilityInfo, updated_messages: Set[Tuple[str, str]], info_by_project: Dict[str, SlackProjectInfo]) -> str:
+    def __update_message_if_needed(
+        self,
+        channel_id: str,
+        slack_vuln_info: SlackVulnerabilityInfo,
+        updated_messages: Set[Tuple[str, str]],
+        info_by_project: Dict[str, SlackProjectInfo],
+    ) -> str:
         slack_msg_id = slack_vuln_info.msg_id_by_channel.get(channel_id, None)
         if not slack_msg_id:
-            raise RuntimeError(f"could not update slack message for channel {channel_id} for vuln {slack_vuln_info.vulnerability.id}: unknown message id")
+            raise RuntimeError(
+                f"could not update slack message for channel {channel_id} for vuln {slack_vuln_info.vulnerability.id}: unknown message id"
+            )
         msg_key = (channel_id, slack_msg_id)
         if msg_key in updated_messages:
             return slack_msg_id
 
         slack_msg = slack_vuln_info.get_slack_msg_for(channel_id, info_by_project)
         if not slack_msg:
-            raise RuntimeError(f"could not update slack message for channel {channel_id} for vuln {slack_vuln_info.vulnerability.id}: could not create message")
-        self.slack_api_by_channel[channel_id].update_message(message=slack_msg, is_block_kit_message=True, message_id=slack_msg_id)
+            raise RuntimeError(
+                f"could not update slack message for channel {channel_id} for vuln {slack_vuln_info.vulnerability.id}: could not create message"
+            )
+        self.slack_api_by_channel[channel_id].update_message(
+            message=slack_msg, is_block_kit_message=True, message_id=slack_msg_id
+        )
         updated_messages.add(msg_key)
         return slack_msg_id
 
-    def handle_events(self, events: List[SlackVulnerabilityEvent], scan_result_by_channel: Dict[str, SlackScanResult], slack_vuln_info: SlackVulnerabilityInfo, info_by_project: Dict[str, SlackProjectInfo]):
+    def handle_events(
+        self,
+        events: List[SlackVulnerabilityEvent],
+        scan_result_by_channel: Dict[str, SlackScanResult],
+        slack_vuln_info: SlackVulnerabilityInfo,
+        info_by_project: Dict[str, SlackProjectInfo],
+    ):
         updated_messages: Set[Tuple[str, str]] = set()
         for event in events:
             if event.vulnerability_id != slack_vuln_info.vulnerability.id:
-                raise RuntimeError(f"Event vuln id does not match vuln info id {slack_vuln_info.vulnerability.id}: {event}")
+                raise RuntimeError(
+                    f"Event vuln id does not match vuln info id {slack_vuln_info.vulnerability.id}: {event}"
+                )
             t = event.type
             if t == SlackVulnerabilityEventType.VULN_ADDED:
                 scan_result_by_channel[event.channel_id].new_vulnerabilities += 1
                 slack_msg = slack_vuln_info.get_slack_msg_for(event.channel_id, info_by_project)
                 if not slack_msg:
-                    raise RuntimeError(f"could not create slack message for channel {event.channel_id} for vuln {slack_vuln_info.vulnerability.id}")
-                slack_msg_id = self.slack_api_by_channel[event.channel_id].send_message(message=slack_msg, is_block_kit_message=True, thread_id=None)
+                    raise RuntimeError(
+                        f"could not create slack message for channel {event.channel_id} for vuln {slack_vuln_info.vulnerability.id}"
+                    )
+                slack_msg_id = self.slack_api_by_channel[event.channel_id].send_message(
+                    message=slack_msg, is_block_kit_message=True, thread_id=None
+                )
                 if not slack_msg_id:
                     raise RuntimeError(f"could not send slack message for channel {event.channel_id}")
                 slack_vuln_info.msg_id_by_channel[event.channel_id] = slack_msg_id
@@ -57,26 +81,50 @@ class SlackVulnerabilityStore:
             elif t == SlackVulnerabilityEventType.VULN_REMOVED:
                 scan_result_by_channel[event.channel_id].fixed_vulnerabilities += 1
                 if event.channel_id not in slack_vuln_info.msg_id_by_channel:
-                    raise RuntimeError(f"could not mark slack message as fixed for channel {event.channel_id} for vuln {slack_vuln_info.vulnerability.id}")
-                self.slack_api_by_channel[event.channel_id].add_reaction(reaction=VULNERABILITY_MSG_FIXED_REACTION, message_id=slack_vuln_info.msg_id_by_channel[event.channel_id])
+                    raise RuntimeError(
+                        f"could not mark slack message as fixed for channel {event.channel_id} for vuln {slack_vuln_info.vulnerability.id}"
+                    )
+                self.slack_api_by_channel[event.channel_id].add_reaction(
+                    reaction=VULNERABILITY_MSG_FIXED_REACTION,
+                    message_id=slack_vuln_info.msg_id_by_channel[event.channel_id],
+                )
                 updated_messages.add((event.channel_id, slack_vuln_info.msg_id_by_channel[event.channel_id]))
             elif t == SlackVulnerabilityEventType.VULN_CHANGED:
                 scan_result_by_channel[event.channel_id].changed_vulnerabilities += 1
-                slack_msg_id = self.__update_message_if_needed(event.channel_id, slack_vuln_info, updated_messages, info_by_project)
+                slack_msg_id = self.__update_message_if_needed(
+                    event.channel_id, slack_vuln_info, updated_messages, info_by_project
+                )
                 list_items = []
                 for field_name, field_value in event.updated_fields.items():
-                    list_items.append(BlockKitListItem([BlockKitRichText(f"{field_name}: ", True), BlockKitRichText(f"{field_value}")]))
-                vuln_chg_msg_blocks = [block_kit_bullet_list_with_headline(BlockKitListHeadline.with_text("The following fields of the vulnerability were updated (old values are provided):", False), list_items)]
-                self.slack_api_by_channel[event.channel_id].send_message(message=json.dumps(vuln_chg_msg_blocks), is_block_kit_message=True, thread_id=slack_msg_id)
+                    list_items.append(
+                        BlockKitListItem(
+                            [BlockKitRichText(f"{field_name}: ", True), BlockKitRichText(f"{field_value}")]
+                        )
+                    )
+                vuln_chg_msg_blocks = [
+                    block_kit_bullet_list_with_headline(
+                        BlockKitListHeadline.with_text(
+                            "The following fields of the vulnerability were updated (old values are provided):", False
+                        ),
+                        list_items,
+                    )
+                ]
+                self.slack_api_by_channel[event.channel_id].send_message(
+                    message=json.dumps(vuln_chg_msg_blocks), is_block_kit_message=True, thread_id=slack_msg_id
+                )
             elif t == SlackVulnerabilityEventType.DEP_ADDED:
                 if event.finding_id not in scan_result_by_channel[event.channel_id].added_dependencies:
                     scan_result_by_channel[event.channel_id].added_dependencies[event.finding_id] = set()
-                scan_result_by_channel[event.channel_id].added_dependencies[event.finding_id].update(event.added_projects)
+                scan_result_by_channel[event.channel_id].added_dependencies[event.finding_id].update(
+                    event.added_projects
+                )
                 self.__update_message_if_needed(event.channel_id, slack_vuln_info, updated_messages, info_by_project)
             elif t == SlackVulnerabilityEventType.DEP_REMOVED:
                 if event.finding_id not in scan_result_by_channel[event.channel_id].removed_dependencies:
                     scan_result_by_channel[event.channel_id].removed_dependencies[event.finding_id] = set()
-                scan_result_by_channel[event.channel_id].removed_dependencies[event.finding_id].update(event.removed_projects)
+                scan_result_by_channel[event.channel_id].removed_dependencies[event.finding_id].update(
+                    event.removed_projects
+                )
                 self.__update_message_if_needed(event.channel_id, slack_vuln_info, updated_messages, info_by_project)
             else:
                 raise RuntimeError(f"event has unknown type: {event}")

--- a/ci/src/dependencies/data_source/slack_findings_failover/vuln_store_test.py
+++ b/ci/src/dependencies/data_source/slack_findings_failover/vuln_store_test.py
@@ -62,7 +62,10 @@ def test_handle_vuln_removed_event(slack_store, slack_vuln_info, slack_api):
 
 
 def test_handle_vuln_changed_event(slack_store, slack_vuln_info, slack_api):
-    events = [SlackVulnerabilityEvent.vuln_changed("vid", "c1", {"desc": "changed"}), SlackVulnerabilityEvent.vuln_changed("vid", "c2", {"desc": "changed"})]
+    events = [
+        SlackVulnerabilityEvent.vuln_changed("vid", "c1", {"desc": "changed"}),
+        SlackVulnerabilityEvent.vuln_changed("vid", "c2", {"desc": "changed"}),
+    ]
     scan_res = {"c1": SlackScanResult(), "c2": SlackScanResult()}
 
     slack_store.handle_events(events, scan_res, slack_vuln_info, {})
@@ -74,7 +77,10 @@ def test_handle_vuln_changed_event(slack_store, slack_vuln_info, slack_api):
 
 
 def test_handle_dep_added_event(slack_store, slack_vuln_info, slack_api):
-    events = [SlackVulnerabilityEvent.dep_added("vid", "c1", ("scanner", "repo", "did", "dvers"), ["proj1"]), SlackVulnerabilityEvent.dep_added("vid", "c2", ("scanner", "repo", "did", "dvers"), ["proj2"])]
+    events = [
+        SlackVulnerabilityEvent.dep_added("vid", "c1", ("scanner", "repo", "did", "dvers"), ["proj1"]),
+        SlackVulnerabilityEvent.dep_added("vid", "c2", ("scanner", "repo", "did", "dvers"), ["proj2"]),
+    ]
     scan_res = {"c1": SlackScanResult(), "c2": SlackScanResult()}
 
     slack_store.handle_events(events, scan_res, slack_vuln_info, {})
@@ -85,7 +91,10 @@ def test_handle_dep_added_event(slack_store, slack_vuln_info, slack_api):
 
 
 def test_handle_dep_removed_event(slack_store, slack_vuln_info, slack_api):
-    events = [SlackVulnerabilityEvent.dep_removed("vid", "c1", ("scanner", "repo", "did", "dvers"), ["proj1"]), SlackVulnerabilityEvent.dep_removed("vid", "c2", ("scanner", "repo", "did", "dvers"), ["proj2"])]
+    events = [
+        SlackVulnerabilityEvent.dep_removed("vid", "c1", ("scanner", "repo", "did", "dvers"), ["proj1"]),
+        SlackVulnerabilityEvent.dep_removed("vid", "c2", ("scanner", "repo", "did", "dvers"), ["proj2"]),
+    ]
     scan_res = {"c1": SlackScanResult(), "c2": SlackScanResult()}
 
     slack_store.handle_events(events, scan_res, slack_vuln_info, {})

--- a/ci/src/dependencies/data_source/slack_findings_failover_data_store.py
+++ b/ci/src/dependencies/data_source/slack_findings_failover_data_store.py
@@ -17,8 +17,10 @@ from model.project import Project
 from model.team import Team
 
 SUPPORTED_TEAMS = (Team.NODE_TEAM, Team.BOUNDARY_NODE_TEAM)
-SLACK_CHANNEL_CONFIG_BY_TEAM = {Team.NODE_TEAM: SlackChannelConfig(channel_id="C05CYLM94KU", channel="#eng-node-psec"),
-                                Team.BOUNDARY_NODE_TEAM: SlackChannelConfig(channel_id="C06KQKZ3EBW", channel="#eng-boundary-nodes-psec")}
+SLACK_CHANNEL_CONFIG_BY_TEAM = {
+    Team.NODE_TEAM: SlackChannelConfig(channel_id="C05CYLM94KU", channel="#eng-node-psec"),
+    Team.BOUNDARY_NODE_TEAM: SlackChannelConfig(channel_id="C06KQKZ3EBW", channel="#eng-boundary-nodes-psec"),
+}
 SLACK_TEAM_GROUP_ID = {Team.NODE_TEAM: "<!subteam^S05FTRNRC5A>", Team.BOUNDARY_NODE_TEAM: "<!subteam^S0313LYB9FZ>"}
 
 SLACK_LOG_TO_CONSOLE = False
@@ -41,7 +43,7 @@ class SlackFindingsFailoverDataStore(FindingsFailoverDataStore):
         projects: List[Project],
         slack_api: SlackApi = None,
         slack_loader: SlackVulnerabilityLoader = None,
-        slack_store: SlackVulnerabilityStore = None
+        slack_store: SlackVulnerabilityStore = None,
     ):
         for proj in projects:
             if proj.owner and proj.owner not in SUPPORTED_TEAMS:
@@ -57,7 +59,9 @@ class SlackFindingsFailoverDataStore(FindingsFailoverDataStore):
             if slack_api:
                 self.slack_api_by_channel[channel.channel_id] = slack_api
             elif channel.channel_id not in self.slack_api_by_channel:
-                self.slack_api_by_channel[channel.channel_id] = SlackApi(channel, SLACK_LOG_TO_CONSOLE, SLACK_OAUTH_TOKEN)
+                self.slack_api_by_channel[channel.channel_id] = SlackApi(
+                    channel, SLACK_LOG_TO_CONSOLE, SLACK_OAUTH_TOKEN
+                )
 
         self.slack_loader = slack_loader if slack_loader else SlackVulnerabilityLoader(self.slack_api_by_channel)
         self.slack_store = slack_store if slack_store else SlackVulnerabilityStore(self.slack_api_by_channel)
@@ -96,7 +100,11 @@ class SlackFindingsFailoverDataStore(FindingsFailoverDataStore):
         return res
 
     def can_handle(self, finding: Finding) -> bool:
-        is_failover_finding = (finding.repository, finding.scanner, finding.vulnerable_dependency.id) in FAILOVER_FINDING_IDS
+        is_failover_finding = (
+            finding.repository,
+            finding.scanner,
+            finding.vulnerable_dependency.id,
+        ) in FAILOVER_FINDING_IDS
         if is_failover_finding:
             # check that all projects are known if not raise an exception (configuration error)
             self.__info_by_project(set(finding.projects))
@@ -112,7 +120,9 @@ class SlackFindingsFailoverDataStore(FindingsFailoverDataStore):
                 if vuln.id not in vuln_by_vuln_id:
                     vuln_by_vuln_id[vuln.id] = VulnerabilityInfo(vulnerability=vuln, finding_by_id={})
                 if vuln_by_vuln_id[vuln.id].vulnerability != vuln:
-                    raise RuntimeError(f"vulnerability with same id but different values found in current findings: {vuln} {vuln_by_vuln_id[vuln.id].vulnerability}")
+                    raise RuntimeError(
+                        f"vulnerability with same id but different values found in current findings: {vuln} {vuln_by_vuln_id[vuln.id].vulnerability}"
+                    )
                 vuln_by_vuln_id[vuln.id].finding_by_id[finding.id()] = finding
 
         # remove vulns with too low score
@@ -136,18 +146,31 @@ class SlackFindingsFailoverDataStore(FindingsFailoverDataStore):
         # check found vulns against stored vulns to find added or changed vulns
         for vuln_info in vuln_by_vuln_id.values():
             if vuln_info.vulnerability.id in slack_vuln_by_vuln_id:
-                events = slack_vuln_by_vuln_id[vuln_info.vulnerability.id].update_with(vuln_info, info_by_project, repository, scanner)
-                self.slack_store.handle_events(events, scan_result_by_channel, slack_vuln_by_vuln_id[vuln_info.vulnerability.id], info_by_project)
+                events = slack_vuln_by_vuln_id[vuln_info.vulnerability.id].update_with(
+                    vuln_info, info_by_project, repository, scanner
+                )
+                self.slack_store.handle_events(
+                    events, scan_result_by_channel, slack_vuln_by_vuln_id[vuln_info.vulnerability.id], info_by_project
+                )
             else:
                 svi = SlackVulnerabilityInfo.from_vuln_info(vuln_info)
-                self.slack_store.handle_events(svi.get_events_for_add(info_by_project), scan_result_by_channel, svi, info_by_project)
+                self.slack_store.handle_events(
+                    svi.get_events_for_add(info_by_project), scan_result_by_channel, svi, info_by_project
+                )
 
         # check stored vulns against found vulns to find removed vulns
         for slack_vuln_info in slack_vuln_by_vuln_id.values():
             if slack_vuln_info.vulnerability.id not in vuln_by_vuln_id:
-                self.slack_store.handle_events(slack_vuln_info.get_events_for_remove(info_by_project, repository, scanner), scan_result_by_channel, slack_vuln_info, info_by_project)
+                self.slack_store.handle_events(
+                    slack_vuln_info.get_events_for_remove(info_by_project, repository, scanner),
+                    scan_result_by_channel,
+                    slack_vuln_info,
+                    info_by_project,
+                )
 
         # publish scan results for each channel
         for channel_id, scan_result in scan_result_by_channel.items():
             if scan_result.has_updates():
-                self.slack_api_by_channel[channel_id].send_message(message=scan_result.get_slack_msg(repository, scanner), is_block_kit_message=True)
+                self.slack_api_by_channel[channel_id].send_message(
+                    message=scan_result.get_slack_msg(repository, scanner), is_block_kit_message=True
+                )

--- a/ci/src/dependencies/data_source/slack_findings_failover_data_store_test.py
+++ b/ci/src/dependencies/data_source/slack_findings_failover_data_store_test.py
@@ -20,14 +20,40 @@ from model.vulnerability import Vulnerability
 
 
 def test_can_handle_finding():
-    fo_finding = Finding("ic", "BAZEL_TRIVY_CS", Dependency("linux-libc-dev", "linux-libc-dev", "1.0"), [Vulnerability("vid", "vname", "vdesc")], [], ["ic/proj1", "ic/proj1/subproj/foo"], [])
+    fo_finding = Finding(
+        "ic",
+        "BAZEL_TRIVY_CS",
+        Dependency("linux-libc-dev", "linux-libc-dev", "1.0"),
+        [Vulnerability("vid", "vname", "vdesc")],
+        [],
+        ["ic/proj1", "ic/proj1/subproj/foo"],
+        [],
+    )
 
     assert SlackFindingsFailoverDataStore([Project("ic", "ic/proj1", None, Team.NODE_TEAM)]).can_handle(fo_finding)
-    assert SlackFindingsFailoverDataStore([Project("ic", "ic/proj1", None, None, {"ic/proj1/subproj": [Team.BOUNDARY_NODE_TEAM], "ic/proj1": [Team.BOUNDARY_NODE_TEAM]})]).can_handle(fo_finding)
+    assert SlackFindingsFailoverDataStore(
+        [
+            Project(
+                "ic",
+                "ic/proj1",
+                None,
+                None,
+                {"ic/proj1/subproj": [Team.BOUNDARY_NODE_TEAM], "ic/proj1": [Team.BOUNDARY_NODE_TEAM]},
+            )
+        ]
+    ).can_handle(fo_finding)
 
 
 def test_can_not_handle_finding():
-    finding = Finding("ic", "BAZEL_TRIVY_CS", Dependency("linux-libc", "linux-libc", "1.0"), [Vulnerability("vid", "vname", "vdesc")], [], ["ic/proj1", "ic/proj1/subproj/foo"], [])
+    finding = Finding(
+        "ic",
+        "BAZEL_TRIVY_CS",
+        Dependency("linux-libc", "linux-libc", "1.0"),
+        [Vulnerability("vid", "vname", "vdesc")],
+        [],
+        ["ic/proj1", "ic/proj1/subproj/foo"],
+        [],
+    )
 
     assert not SlackFindingsFailoverDataStore([Project("ic", "ic/proj1", None, Team.NODE_TEAM)]).can_handle(finding)
 
@@ -39,22 +65,32 @@ def test_store_findings():
     v1_events = [
         SlackVulnerabilityEvent.vuln_added("vid", SLACK_CHANNEL_CONFIG_BY_TEAM[Team.BOUNDARY_NODE_TEAM].channel_id),
         SlackVulnerabilityEvent.vuln_removed("vid", SLACK_CHANNEL_CONFIG_BY_TEAM[Team.NODE_TEAM].channel_id),
-        SlackVulnerabilityEvent.dep_added("vid", SLACK_CHANNEL_CONFIG_BY_TEAM[Team.BOUNDARY_NODE_TEAM].channel_id, f1.id(), ["proj3"]),
-        SlackVulnerabilityEvent.dep_removed("vid", SLACK_CHANNEL_CONFIG_BY_TEAM[Team.NODE_TEAM].channel_id, sf1.id(), ["proj2"])
+        SlackVulnerabilityEvent.dep_added(
+            "vid", SLACK_CHANNEL_CONFIG_BY_TEAM[Team.BOUNDARY_NODE_TEAM].channel_id, f1.id(), ["proj3"]
+        ),
+        SlackVulnerabilityEvent.dep_removed(
+            "vid", SLACK_CHANNEL_CONFIG_BY_TEAM[Team.NODE_TEAM].channel_id, sf1.id(), ["proj2"]
+        ),
     ]
 
     v_old = Vulnerability("vid_old", "vname_old", "vdesc_old", 8)
     sf_old = SlackFinding("repo", "scanner", "did_old", "dvers_old", ["proj3"])
     v_old_events = [
-        SlackVulnerabilityEvent.vuln_removed("vid_old", SLACK_CHANNEL_CONFIG_BY_TEAM[Team.BOUNDARY_NODE_TEAM].channel_id),
-        SlackVulnerabilityEvent.dep_removed("vid_old", SLACK_CHANNEL_CONFIG_BY_TEAM[Team.BOUNDARY_NODE_TEAM].channel_id, sf_old.id(), ["proj3"])
+        SlackVulnerabilityEvent.vuln_removed(
+            "vid_old", SLACK_CHANNEL_CONFIG_BY_TEAM[Team.BOUNDARY_NODE_TEAM].channel_id
+        ),
+        SlackVulnerabilityEvent.dep_removed(
+            "vid_old", SLACK_CHANNEL_CONFIG_BY_TEAM[Team.BOUNDARY_NODE_TEAM].channel_id, sf_old.id(), ["proj3"]
+        ),
     ]
 
     v_new = Vulnerability("vid_new", "vname_new", "vdesc_new", 9)
     f_new = Finding("repo", "scanner", Dependency("did_new", "dname", "dvers_new"), [v_new], [], ["proj1"], [])
 
     v_below_thresh = Vulnerability("vid_low", "vname_low", "vdesc_low", VULNERABILITY_THRESHOLD_SCORE - 1)
-    f_below_thresh = Finding("repo", "scanner", Dependency("did_low", "dname", "dvers_low"), [v_below_thresh], [], ["proj1"], [])
+    f_below_thresh = Finding(
+        "repo", "scanner", Dependency("did_low", "dname", "dvers_low"), [v_below_thresh], [], ["proj1"], []
+    )
 
     svi1 = Mock()
     svi1.finding_by_id = {sf1.id(): sf1}
@@ -69,7 +105,11 @@ def test_store_findings():
 
     current_findings = [f1, f_new, f_below_thresh]
 
-    projects = [Project("proj1", "proj1", None, Team.NODE_TEAM), Project("proj2", "proj2", None, Team.NODE_TEAM), Project("proj3", "proj3", None, Team.BOUNDARY_NODE_TEAM)]
+    projects = [
+        Project("proj1", "proj1", None, Team.NODE_TEAM),
+        Project("proj2", "proj2", None, Team.NODE_TEAM),
+        Project("proj3", "proj3", None, Team.BOUNDARY_NODE_TEAM),
+    ]
     slack_api = Mock()
     loader = Mock()
     loader.load_findings.return_value = slack_vuln_by_vuln_id
@@ -83,7 +123,9 @@ def test_store_findings():
     assert storage.events_by_vuln_id[v_old.id] == v_old_events
     assert storage.events_by_vuln_id[v_new.id] == [
         SlackVulnerabilityEvent.vuln_added(v_new.id, SLACK_CHANNEL_CONFIG_BY_TEAM[Team.NODE_TEAM].channel_id),
-        SlackVulnerabilityEvent.dep_added(v_new.id, SLACK_CHANNEL_CONFIG_BY_TEAM[Team.NODE_TEAM].channel_id, f_new.id(), f_new.projects)
+        SlackVulnerabilityEvent.dep_added(
+            v_new.id, SLACK_CHANNEL_CONFIG_BY_TEAM[Team.NODE_TEAM].channel_id, f_new.id(), f_new.projects
+        ),
     ]
     assert slack_api.send_message.call_count == 2
 
@@ -92,7 +134,13 @@ class MockSlackStore(SlackVulnerabilityStore):
     def __init__(self):
         self.events_by_vuln_id = {}
 
-    def handle_events(self, events: List[SlackVulnerabilityEvent], scan_result_by_channel: Dict[str, SlackScanResult], slack_vuln_info: SlackVulnerabilityInfo, info_by_project: Dict[str, SlackProjectInfo]):
+    def handle_events(
+        self,
+        events: List[SlackVulnerabilityEvent],
+        scan_result_by_channel: Dict[str, SlackScanResult],
+        slack_vuln_info: SlackVulnerabilityInfo,
+        info_by_project: Dict[str, SlackProjectInfo],
+    ):
         if slack_vuln_info.vulnerability.id in self.events_by_vuln_id:
             raise RuntimeError(f"duplicate vuln id {slack_vuln_info.vulnerability.id}")
         self.events_by_vuln_id[slack_vuln_info.vulnerability.id] = events
@@ -108,10 +156,14 @@ class MockSlackStore(SlackVulnerabilityStore):
             elif t == SlackVulnerabilityEventType.DEP_ADDED:
                 if event.finding_id not in scan_result_by_channel[event.channel_id].added_dependencies:
                     scan_result_by_channel[event.channel_id].added_dependencies[event.finding_id] = set()
-                scan_result_by_channel[event.channel_id].added_dependencies[event.finding_id].update(event.added_projects)
+                scan_result_by_channel[event.channel_id].added_dependencies[event.finding_id].update(
+                    event.added_projects
+                )
             elif t == SlackVulnerabilityEventType.DEP_REMOVED:
                 if event.finding_id not in scan_result_by_channel[event.channel_id].removed_dependencies:
                     scan_result_by_channel[event.channel_id].removed_dependencies[event.finding_id] = set()
-                scan_result_by_channel[event.channel_id].removed_dependencies[event.finding_id].update(event.removed_projects)
+                scan_result_by_channel[event.channel_id].removed_dependencies[event.finding_id].update(
+                    event.removed_projects
+                )
             else:
                 raise RuntimeError(f"unknown event type: {t}")

--- a/ci/src/dependencies/integration/github/github_api.py
+++ b/ci/src/dependencies/integration/github/github_api.py
@@ -55,7 +55,6 @@ class GithubApi:
         else:
             pull_request.create_issue_comment(comment_body)
 
-
     def run_workflow(self, workflow: GithubWorklow) -> bool:
         try:
             repo = self.github.get_repo(workflow.value.project)

--- a/ci/src/dependencies/integration/github/github_trivy_finding_notification_handler.py
+++ b/ci/src/dependencies/integration/github/github_trivy_finding_notification_handler.py
@@ -16,13 +16,16 @@ class GithubTrivyFindingNotificationHandler(NotificationHandler):
         self.pipeline_run = False
 
     def can_handle(self, event: NotificationEvent) -> bool:
-        if isinstance(event, FindingNotificationEvent) and event.finding.scanner == TRIVY_SCANNER_ID and event.finding_has_patch_version:
+        if (
+            isinstance(event, FindingNotificationEvent)
+            and event.finding.scanner == TRIVY_SCANNER_ID
+            and event.finding_has_patch_version
+        ):
             parser_id = OSPackageTrivyResultParser().get_parser_id()
             for proj in event.finding.projects:
                 if proj.startswith(parser_id):
                     return True
         return False
-
 
     def handle(self, event: NotificationEvent):
         if isinstance(event, FindingNotificationEvent):

--- a/ci/src/dependencies/integration/github/github_trivy_finding_notification_handler_test.py
+++ b/ci/src/dependencies/integration/github/github_trivy_finding_notification_handler_test.py
@@ -35,37 +35,62 @@ FINDING_BINARY = Finding(
     more_info="https://dfinity.atlassian.net/browse/SCAVM-5",
 )
 
+
 def test_can_handle_trivy_osp_finding_with_patch_available():
-    event = FindingNotificationEvent(finding=FINDING_OS_PACKAGE, finding_needs_risk_assessment=False, finding_has_patch_version=True, finding_was_resolved=False)
+    event = FindingNotificationEvent(
+        finding=FINDING_OS_PACKAGE,
+        finding_needs_risk_assessment=False,
+        finding_has_patch_version=True,
+        finding_was_resolved=False,
+    )
     handler = GithubTrivyFindingNotificationHandler(github_api=Mock())
 
     assert handler.can_handle(event)
 
+
 def test_can_not_handle_trivy_osp_finding_without_patch():
-    event = FindingNotificationEvent(finding=FINDING_OS_PACKAGE, finding_needs_risk_assessment=False, finding_has_patch_version=False, finding_was_resolved=False)
+    event = FindingNotificationEvent(
+        finding=FINDING_OS_PACKAGE,
+        finding_needs_risk_assessment=False,
+        finding_has_patch_version=False,
+        finding_was_resolved=False,
+    )
     handler = GithubTrivyFindingNotificationHandler(github_api=Mock())
 
     assert not handler.can_handle(event)
+
 
 def test_can_not_handle_trivy_bin_finding_with_patch_available():
-    event = FindingNotificationEvent(finding=FINDING_BINARY, finding_needs_risk_assessment=False, finding_has_patch_version=True, finding_was_resolved=False)
+    event = FindingNotificationEvent(
+        finding=FINDING_BINARY,
+        finding_needs_risk_assessment=False,
+        finding_has_patch_version=True,
+        finding_was_resolved=False,
+    )
     handler = GithubTrivyFindingNotificationHandler(github_api=Mock())
 
     assert not handler.can_handle(event)
+
 
 def test_can_not_handle_finding_from_different_scanner():
     finding = deepcopy(FINDING_OS_PACKAGE)
     finding.scanner = "OTHER_SCANNER"
-    event = FindingNotificationEvent(finding=finding, finding_needs_risk_assessment=False,
-                                     finding_has_patch_version=True, finding_was_resolved=False)
+    event = FindingNotificationEvent(
+        finding=finding, finding_needs_risk_assessment=False, finding_has_patch_version=True, finding_was_resolved=False
+    )
     handler = GithubTrivyFindingNotificationHandler(github_api=Mock())
 
     assert not handler.can_handle(event)
 
+
 def test_call_github_api_during_handle():
     api = Mock()
-    event = FindingNotificationEvent(finding=FINDING_OS_PACKAGE, finding_needs_risk_assessment=False,
-                                     finding_has_patch_version=True, finding_was_resolved=False)
+    event = FindingNotificationEvent(
+        finding=FINDING_OS_PACKAGE,
+        finding_needs_risk_assessment=False,
+        finding_has_patch_version=True,
+        finding_was_resolved=False,
+    )
     handler = GithubTrivyFindingNotificationHandler(github_api=api)
 
     assert handler.can_handle(event)
@@ -74,11 +99,16 @@ def test_call_github_api_during_handle():
 
     api.run_workflow.assert_called_once_with(GithubWorklow.IC_BUILD_PUSH_BASE_CONTAINER_IMAGES)
 
+
 def test_call_github_api_only_once():
     api = Mock()
     api.run_pipeline.return_value = True
-    event = FindingNotificationEvent(finding=FINDING_OS_PACKAGE, finding_needs_risk_assessment=False,
-                                     finding_has_patch_version=True, finding_was_resolved=False)
+    event = FindingNotificationEvent(
+        finding=FINDING_OS_PACKAGE,
+        finding_needs_risk_assessment=False,
+        finding_has_patch_version=True,
+        finding_was_resolved=False,
+    )
     handler = GithubTrivyFindingNotificationHandler(github_api=api)
 
     assert handler.can_handle(event)

--- a/ci/src/dependencies/integration/github/github_workflow_config.py
+++ b/ci/src/dependencies/integration/github/github_workflow_config.py
@@ -13,4 +13,6 @@ class GithubWorkflowConfig:
 
 
 class GithubWorklow(Enum):
-    IC_BUILD_PUSH_BASE_CONTAINER_IMAGES = GithubWorkflowConfig(project="dfinity/ic", workflow_name="container-base-images.yml")
+    IC_BUILD_PUSH_BASE_CONTAINER_IMAGES = GithubWorkflowConfig(
+        project="dfinity/ic", workflow_name="container-base-images.yml"
+    )

--- a/ci/src/dependencies/integration/slack/slack_api.py
+++ b/ci/src/dependencies/integration/slack/slack_api.py
@@ -34,26 +34,32 @@ class SlackApi:
                 return json.loads(http_response.read())
             except urllib.error.HTTPError as e:
                 body = e.read().decode()
-                logging.error(
-                    f"Slack API request {url} failed."
-                )
+                logging.error(f"Slack API request {url} failed.")
                 logging.debug(
                     f"Slack API request {url} failed with HTTP response body: {body}\ntraceback:\n{traceback.format_exc()}"
                 )
             except Exception:
                 logging.error(f"Slack API request {url} could not send the requested message.")
-                logging.debug(f"Slack API request {url} could not send the requested message.\ntraceback:\n{traceback.format_exc()}")
+                logging.debug(
+                    f"Slack API request {url} could not send the requested message.\ntraceback:\n{traceback.format_exc()}"
+                )
             retry -= 1
             if retry >= 0:
                 sleep(1)
         return None
 
-    def send_message(self, message: str, is_block_kit_message: bool = False, thread_id: Optional[str] = None) -> Optional[str]:
+    def send_message(
+        self, message: str, is_block_kit_message: bool = False, thread_id: Optional[str] = None
+    ) -> Optional[str]:
         if self.log_to_console:
-            logging.info("Mock Slack send_message to channel '%s' and thread '%s': '%s'", self.channel_config, thread_id, message)
+            logging.info(
+                "Mock Slack send_message to channel '%s' and thread '%s': '%s'", self.channel_config, thread_id, message
+            )
             return None
 
-        logging.info("Slack send_message to channel '%s' and thread '%s': '%s'", self.channel_config, thread_id, message)
+        logging.info(
+            "Slack send_message to channel '%s' and thread '%s': '%s'", self.channel_config, thread_id, message
+        )
 
         data = {
             "channel": self.channel_config.channel_id,
@@ -72,10 +78,17 @@ class SlackApi:
 
     def update_message(self, message: str, message_id: str, is_block_kit_message: bool = False):
         if self.log_to_console:
-            logging.info("Mock Slack update_message to channel '%s' and message '%s': '%s'", self.channel_config, message_id, message)
+            logging.info(
+                "Mock Slack update_message to channel '%s' and message '%s': '%s'",
+                self.channel_config,
+                message_id,
+                message,
+            )
             return
 
-        logging.info("Slack update_message to channel '%s' and message '%s': '%s'", self.channel_config, message_id, message)
+        logging.info(
+            "Slack update_message to channel '%s' and message '%s': '%s'", self.channel_config, message_id, message
+        )
         data = {
             "channel": self.channel_config.channel_id,
             "ts": message_id,
@@ -88,7 +101,9 @@ class SlackApi:
 
     def delete_message(self, message_id: str):
         if self.log_to_console:
-            logging.info("Mock Slack delete_message from channel '%s' with message id: '%s'", self.channel_config, message_id)
+            logging.info(
+                "Mock Slack delete_message from channel '%s' with message id: '%s'", self.channel_config, message_id
+            )
             return
 
         logging.info("Slack delete_message from channel '%s' with message id: '%s'", self.channel_config, message_id)
@@ -101,9 +116,16 @@ class SlackApi:
 
     def add_reaction(self, reaction: str, message_id: str):
         if self.log_to_console:
-            logging.info("Mock Slack add_reaction to channel '%s' and message '%s': '%s'", self.channel_config, message_id, reaction)
+            logging.info(
+                "Mock Slack add_reaction to channel '%s' and message '%s': '%s'",
+                self.channel_config,
+                message_id,
+                reaction,
+            )
 
-        logging.info("Slack add_reaction to channel '%s' and message '%s': '%s'", self.channel_config, message_id, reaction)
+        logging.info(
+            "Slack add_reaction to channel '%s' and message '%s': '%s'", self.channel_config, message_id, reaction
+        )
         data = {
             "name": reaction,
             "channel": self.channel_config.channel_id,
@@ -125,15 +147,19 @@ class SlackApi:
             self.slack_id_cache[user.email] = api_response["user"]["id"]
             return self.slack_id_cache[user.email]
         else:
-            logging.error(
-                "Slack API users.lookupByEmail for some user returned non ok response."
-            )
+            logging.error("Slack API users.lookupByEmail for some user returned non ok response.")
             logging.debug(
                 f"Slack API users.lookupByEmail for user {user} returned non ok response: {api_response['ok']} with error: {api_response['error'] if 'error' in api_response else 'None'}"
             )
         return None
 
-    def get_channel_history(self, oldest: Optional[str] = None, author: Optional[str] = None, prefix: Optional[str] = None, ignore_reaction: Optional[str] = None) -> List[SlackMessage]:
+    def get_channel_history(
+        self,
+        oldest: Optional[str] = None,
+        author: Optional[str] = None,
+        prefix: Optional[str] = None,
+        ignore_reaction: Optional[str] = None,
+    ) -> List[SlackMessage]:
         def include_message(message: any) -> bool:
             if author and ("user" not in message or message["user"] != author):
                 return False
@@ -155,7 +181,14 @@ class SlackApi:
                             return False
             return True
 
-        logging.info("Slack get_channel_history from channel '%s' with filters: (%s, %s, %s, %s)", self.channel_config, oldest, author, prefix, ignore_reaction)
+        logging.info(
+            "Slack get_channel_history from channel '%s' with filters: (%s, %s, %s, %s)",
+            self.channel_config,
+            oldest,
+            author,
+            prefix,
+            ignore_reaction,
+        )
         cursor = None
         slack_messages = []
         while True:
@@ -179,4 +212,5 @@ class SlackApi:
                     return slack_messages
             else:
                 raise RuntimeError(
-                    f"Slack API conversations.history returned non ok response for URL {url}: {api_response['ok']} with error: {api_response['error'] if 'error' in api_response else 'None'}")
+                    f"Slack API conversations.history returned non ok response for URL {url}: {api_response['ok']} with error: {api_response['error'] if 'error' in api_response else 'None'}"
+                )

--- a/ci/src/dependencies/integration/slack/slack_block_kit_utils.py
+++ b/ci/src/dependencies/integration/slack/slack_block_kit_utils.py
@@ -3,38 +3,22 @@ from typing import Any, Dict, List, Optional
 
 
 def block_kit_header(headline: str) -> Dict[str, Any]:
-    return {
-        "type": "header",
-        "text": {
-            "type": "plain_text",
-            "text": headline
-        }
-    }
+    return {"type": "header", "text": {"type": "plain_text", "text": headline}}
 
 
 def block_kit_section_with_single_col(headline: str, content: str) -> Dict[str, Any]:
-    return {
-        "type": "section",
-        "text": {
-            "type": "mrkdwn",
-            "text": f"*{headline}*\n{content}"
-        }
-    }
+    return {"type": "section", "text": {"type": "mrkdwn", "text": f"*{headline}*\n{content}"}}
 
 
-def block_kit_section_with_two_cols(left_headline: str, left_content: str, right_headline: str, right_content: str) -> Dict[str, Any]:
+def block_kit_section_with_two_cols(
+    left_headline: str, left_content: str, right_headline: str, right_content: str
+) -> Dict[str, Any]:
     return {
         "type": "section",
         "fields": [
-            {
-                "type": "mrkdwn",
-                "text": f"*{left_headline}*\n{left_content}"
-            },
-            {
-                "type": "mrkdwn",
-                "text": f"*{right_headline}*\n{right_content}"
-            }
-        ]
+            {"type": "mrkdwn", "text": f"*{left_headline}*\n{left_content}"},
+            {"type": "mrkdwn", "text": f"*{right_headline}*\n{right_content}"},
+        ],
     }
 
 
@@ -61,14 +45,9 @@ class BlockKitListItem(BlockKitListHeadline):
 
 def __rich_text_section_element_from(text: BlockKitRichText):
     if text.url:
-        res = {
-            "type": "link",
-            "url": text.url
-        }
+        res = {"type": "link", "url": text.url}
     else:
-        res = {
-            "type": "text"
-        }
+        res = {"type": "text"}
     res["text"] = text.text
     if text.bold:
         res["style"] = {"bold": True}
@@ -79,41 +58,29 @@ def __rich_text_section_from(items: List[BlockKitRichText]):
     rich_text_section_elements = []
     for text in items:
         rich_text_section_elements.append(__rich_text_section_element_from(text))
-    return {
-        "type": "rich_text_section",
-        "elements": rich_text_section_elements
-    }
+    return {"type": "rich_text_section", "elements": rich_text_section_elements}
 
 
-def block_kit_bullet_list_with_headline(headline: BlockKitListHeadline, bullets: List[BlockKitListItem]) -> Dict[str, Any]:
+def block_kit_bullet_list_with_headline(
+    headline: BlockKitListHeadline, bullets: List[BlockKitListItem]
+) -> Dict[str, Any]:
     rich_text_elements = [__rich_text_section_from(headline.text)]
     indent = bullets[0].indent if len(bullets) > 0 else 0
     rich_text_list_elements = []
     for item in bullets:
         if indent != item.indent:
-            rich_text_elements.append({
-                "type": "rich_text_list",
-                "style": "bullet",
-                "indent": indent,
-                "elements": rich_text_list_elements
-            })
+            rich_text_elements.append(
+                {"type": "rich_text_list", "style": "bullet", "indent": indent, "elements": rich_text_list_elements}
+            )
             rich_text_list_elements = []
             indent = item.indent
         rich_text_list_elements.append(__rich_text_section_from(item.text))
     if len(rich_text_list_elements) > 0:
-        rich_text_elements.append({
-            "type": "rich_text_list",
-            "style": "bullet",
-            "indent": indent,
-            "elements": rich_text_list_elements
-        })
-    return {
-        "type": "rich_text",
-        "elements": rich_text_elements
-    }
+        rich_text_elements.append(
+            {"type": "rich_text_list", "style": "bullet", "indent": indent, "elements": rich_text_list_elements}
+        )
+    return {"type": "rich_text", "elements": rich_text_elements}
 
 
 def block_kit_divider() -> Dict[str, Any]:
-    return {
-        "type": "divider"
-    }
+    return {"type": "divider"}

--- a/ci/src/dependencies/integration/slack/slack_channel_config.py
+++ b/ci/src/dependencies/integration/slack/slack_channel_config.py
@@ -4,7 +4,7 @@ from typing import Optional
 
 @dataclass
 class SlackChannelConfig:
-    channel_id: Optional[str] # might be None during testing
+    channel_id: Optional[str]  # might be None during testing
     channel: str
 
     def __post_init__(self):

--- a/ci/src/dependencies/integration/slack/slack_default_notification_handler.py
+++ b/ci/src/dependencies/integration/slack/slack_default_notification_handler.py
@@ -25,12 +25,17 @@ SLACK_OAUTH_TOKEN = os.environ.get("SLACK_PSEC_BOT_OAUTH_TOKEN")
 if SLACK_OAUTH_TOKEN is None:
     logging.error("SLACK_OAUTH_TOKEN not set, can't retrieve slack user IDs")
 
+
 class SlackDefaultNotificationHandler(NotificationHandler):
     slack_api: SlackApi
 
     def __init__(
-            self,
-            slack_api: SlackApi = SlackApi(SlackChannelConfig(channel_id=SLACK_CHANNEL_ID, channel=SLACK_CHANNEL), SLACK_LOG_TO_CONSOLE,  SLACK_OAUTH_TOKEN),
+        self,
+        slack_api: SlackApi = SlackApi(
+            SlackChannelConfig(channel_id=SLACK_CHANNEL_ID, channel=SLACK_CHANNEL),
+            SLACK_LOG_TO_CONSOLE,
+            SLACK_OAUTH_TOKEN,
+        ),
     ):
         self.slack_api = slack_api
 
@@ -59,9 +64,7 @@ class SlackDefaultNotificationHandler(NotificationHandler):
         )
 
     def __handle_release_block(self, event: ReleaseBlockedNotificationEvent):
-        self.slack_api.send_message(
-            f"Release Build blocked by CI Pipeline {event.ci_job_url} <!channel>"
-        )
+        self.slack_api.send_message(f"Release Build blocked by CI Pipeline {event.ci_job_url} <!channel>")
 
     def __handle_scan_job_succeeded(self, event: ScanJobSucceededNotificationEvent):
         self.slack_api.send_message(
@@ -100,7 +103,9 @@ class SlackDefaultNotificationHandler(NotificationHandler):
                 msg += "\n- has patch version available"
             self.slack_api.send_message(msg)
         if event.finding_was_resolved:
-            self.slack_api.send_message(f"Finding {NotificationHandler.get_finding_info(event.finding)} was resolved :tada:")
+            self.slack_api.send_message(
+                f"Finding {NotificationHandler.get_finding_info(event.finding)} was resolved :tada:"
+            )
 
     def __handle_app_owner_notification(self, event: AppOwnerNotificationEvent):
         self.slack_api.send_message(event.message + " " + APP_OWNERS)

--- a/ci/src/dependencies/integration/slack/slack_default_notification_handler_test.py
+++ b/ci/src/dependencies/integration/slack/slack_default_notification_handler_test.py
@@ -72,7 +72,9 @@ FINDING_WITH_RISK_NO_PATCH_NO = Finding(
 def test_mr_blocked_event():
     api = MockSlackApi()
     handler = SlackDefaultNotificationHandler(slack_api=api)
-    event = MRBlockedNotificationEvent(scanner_id="scanner_id", ci_job_url="http://ci.job/123", merge_request_url="http://mr.url/321")
+    event = MRBlockedNotificationEvent(
+        scanner_id="scanner_id", ci_job_url="http://ci.job/123", merge_request_url="http://mr.url/321"
+    )
 
     assert handler.can_handle(event)
 
@@ -103,7 +105,9 @@ def test_release_build_blocked_event():
 def test_scan_job_succeeded_event(selected_job_type):
     api = MockSlackApi()
     handler = SlackDefaultNotificationHandler(slack_api=api)
-    event = ScanJobSucceededNotificationEvent(scanner_id="scanner_id", job_type=selected_job_type, ci_job_url="http://ci.job/123")
+    event = ScanJobSucceededNotificationEvent(
+        scanner_id="scanner_id", job_type=selected_job_type, ci_job_url="http://ci.job/123"
+    )
 
     assert handler.can_handle(event)
 
@@ -115,13 +119,16 @@ def test_scan_job_succeeded_event(selected_job_type):
     assert selected_job_type.name in api.messages[0]
     assert "http://ci.job/123" in api.messages[0]
 
+
 @pytest.mark.parametrize(
     "selected_job_type", [ScannerJobType.PERIODIC_SCAN, ScannerJobType.MERGE_SCAN, ScannerJobType.RELEASE_SCAN]
 )
 def test_scan_job_failed_event(selected_job_type):
     api = MockSlackApi()
     handler = SlackDefaultNotificationHandler(slack_api=api)
-    event = ScanJobFailedNotificationEvent(scanner_id="scanner_id", job_type=selected_job_type, ci_job_url="http://ci.job/123", reason="some error reason")
+    event = ScanJobFailedNotificationEvent(
+        scanner_id="scanner_id", job_type=selected_job_type, ci_job_url="http://ci.job/123", reason="some error reason"
+    )
 
     assert handler.can_handle(event)
 
@@ -140,7 +147,9 @@ def test_finding_needs_risk_assessment_event():
     finding = FINDING_WITH_RISK_NO_PATCH_NO
     api = MockSlackApi(finding.risk_assessor)
     handler = SlackDefaultNotificationHandler(slack_api=api)
-    event = FindingNotificationEvent(finding=finding, finding_needs_risk_assessment=True, finding_has_patch_version=False, finding_was_resolved=False)
+    event = FindingNotificationEvent(
+        finding=finding, finding_needs_risk_assessment=True, finding_has_patch_version=False, finding_was_resolved=False
+    )
 
     assert handler.can_handle(event)
 
@@ -151,13 +160,15 @@ def test_finding_needs_risk_assessment_event():
     assert finding.more_info in api.messages[0]
     for user in finding.risk_assessor:
         assert f"<@{api.user_to_slack_id[user.id]}>" in api.messages[0]
+
 
 def test_finding_has_patch_version_event():
     finding = FINDING_WITH_RISK_YES_PATCH_YES
     api = MockSlackApi(finding.risk_assessor)
     handler = SlackDefaultNotificationHandler(slack_api=api)
-    event = FindingNotificationEvent(finding=finding, finding_needs_risk_assessment=False,
-                                     finding_has_patch_version=True, finding_was_resolved=False)
+    event = FindingNotificationEvent(
+        finding=finding, finding_needs_risk_assessment=False, finding_has_patch_version=True, finding_was_resolved=False
+    )
 
     assert handler.can_handle(event)
 
@@ -169,12 +180,14 @@ def test_finding_has_patch_version_event():
     for user in finding.risk_assessor:
         assert f"<@{api.user_to_slack_id[user.id]}>" in api.messages[0]
 
+
 def test_finding_needs_risk_assessment_and_has_patch_version_event():
     finding = FINDING_WITH_RISK_NO_PATCH_YES
     api = MockSlackApi(finding.risk_assessor)
     handler = SlackDefaultNotificationHandler(slack_api=api)
-    event = FindingNotificationEvent(finding=finding, finding_needs_risk_assessment=True,
-                                     finding_has_patch_version=True, finding_was_resolved=False)
+    event = FindingNotificationEvent(
+        finding=finding, finding_needs_risk_assessment=True, finding_has_patch_version=True, finding_was_resolved=False
+    )
 
     assert handler.can_handle(event)
 
@@ -186,13 +199,16 @@ def test_finding_needs_risk_assessment_and_has_patch_version_event():
     assert finding.more_info in api.messages[0]
     for user in finding.risk_assessor:
         assert f"<@{api.user_to_slack_id[user.id]}>" in api.messages[0]
+
 
 def test_notify_channel_if_risk_assessor_is_missing():
     finding = deepcopy(FINDING_WITH_RISK_NO_PATCH_NO)
     finding.risk_assessor = None
     api = MockSlackApi()
     handler = SlackDefaultNotificationHandler(slack_api=api)
-    event = FindingNotificationEvent(finding=finding, finding_needs_risk_assessment=True, finding_has_patch_version=False, finding_was_resolved=False)
+    event = FindingNotificationEvent(
+        finding=finding, finding_needs_risk_assessment=True, finding_has_patch_version=False, finding_was_resolved=False
+    )
 
     assert handler.can_handle(event)
 
@@ -202,11 +218,14 @@ def test_notify_channel_if_risk_assessor_is_missing():
     assert "no risk assessors" in api.messages[0]
     assert "<!channel>" in api.messages[0]
 
+
 def test_notify_channel_if_risk_assessor_ids_are_unknown():
     finding = FINDING_WITH_RISK_NO_PATCH_NO
     api = MockSlackApi()
     handler = SlackDefaultNotificationHandler(slack_api=api)
-    event = FindingNotificationEvent(finding=finding, finding_needs_risk_assessment=True, finding_has_patch_version=False, finding_was_resolved=False)
+    event = FindingNotificationEvent(
+        finding=finding, finding_needs_risk_assessment=True, finding_has_patch_version=False, finding_was_resolved=False
+    )
 
     assert handler.can_handle(event)
 
@@ -222,7 +241,9 @@ def test_finding_was_resolved_event():
     finding = FINDING_WITH_RISK_NO_PATCH_YES
     api = MockSlackApi()
     handler = SlackDefaultNotificationHandler(slack_api=api)
-    event = FindingNotificationEvent(finding=finding, finding_needs_risk_assessment=False, finding_has_patch_version=False, finding_was_resolved=True)
+    event = FindingNotificationEvent(
+        finding=finding, finding_needs_risk_assessment=False, finding_has_patch_version=False, finding_was_resolved=True
+    )
 
     assert handler.can_handle(event)
 
@@ -245,6 +266,7 @@ def test_app_owner_notification_event():
     assert len(api.messages) == 1
     assert APP_OWNERS in api.messages[0]
     assert "some message" in api.messages[0]
+
 
 class MockSlackApi(SlackApi):
     messages: List[str]

--- a/ci/src/dependencies/integration/slack/slack_trivy_finding_notification_handler.py
+++ b/ci/src/dependencies/integration/slack/slack_trivy_finding_notification_handler.py
@@ -11,8 +11,10 @@ from notification.notification_handler import NotificationHandler
 from scanner.manager.bazel_trivy_dependency_manager import TRIVY_SCANNER_ID
 
 SUPPORTED_TEAMS = (Team.NODE_TEAM, Team.BOUNDARY_NODE_TEAM)
-SLACK_CHANNEL_CONFIG_BY_TEAM = {Team.NODE_TEAM : SlackChannelConfig(channel_id="C05CYLM94KU", channel="#eng-node-psec"),
-                                Team.BOUNDARY_NODE_TEAM: SlackChannelConfig(channel_id="C06KQKZ3EBW", channel="#eng-boundary-nodes-psec")}
+SLACK_CHANNEL_CONFIG_BY_TEAM = {
+    Team.NODE_TEAM: SlackChannelConfig(channel_id="C05CYLM94KU", channel="#eng-node-psec"),
+    Team.BOUNDARY_NODE_TEAM: SlackChannelConfig(channel_id="C06KQKZ3EBW", channel="#eng-boundary-nodes-psec"),
+}
 SLACK_TEAM_GROUP_ID = {Team.NODE_TEAM: "<!subteam^S05FTRNRC5A>", Team.BOUNDARY_NODE_TEAM: "<!subteam^S0313LYB9FZ>"}
 
 SLACK_LOG_TO_CONSOLE = False
@@ -21,20 +23,23 @@ SLACK_OAUTH_TOKEN = os.environ.get("SLACK_PSEC_BOT_OAUTH_TOKEN")
 if SLACK_OAUTH_TOKEN is None:
     logging.error("SLACK_OAUTH_TOKEN not set, can't retrieve slack user IDs")
 
+
 class SlackTrivyFindingNotificationHandler(NotificationHandler):
     slack_api_by_team: typing.Dict[Team, SlackApi] = {}
     github_handler: GithubTrivyFindingNotificationHandler
 
     def __init__(
-            self,
-            slack_api: SlackApi = None,
-            github_handler: GithubTrivyFindingNotificationHandler = GithubTrivyFindingNotificationHandler(),
+        self,
+        slack_api: SlackApi = None,
+        github_handler: GithubTrivyFindingNotificationHandler = GithubTrivyFindingNotificationHandler(),
     ):
         for team in SUPPORTED_TEAMS:
             if slack_api:
                 self.slack_api_by_team[team] = slack_api
             else:
-                self.slack_api_by_team[team] = SlackApi(SLACK_CHANNEL_CONFIG_BY_TEAM[team], SLACK_LOG_TO_CONSOLE, SLACK_OAUTH_TOKEN)
+                self.slack_api_by_team[team] = SlackApi(
+                    SLACK_CHANNEL_CONFIG_BY_TEAM[team], SLACK_LOG_TO_CONSOLE, SLACK_OAUTH_TOKEN
+                )
         self.github_handler = github_handler
 
     def can_handle(self, event: NotificationEvent) -> bool:
@@ -50,7 +55,9 @@ class SlackTrivyFindingNotificationHandler(NotificationHandler):
         for team in SUPPORTED_TEAMS:
             if team in event.finding.owning_teams:
                 if event.finding_needs_risk_assessment or event.finding_has_patch_version:
-                    msg: str = f"Finding {NotificationHandler.get_finding_info(event.finding)} for {SLACK_TEAM_GROUP_ID[team]}"
+                    msg: str = (
+                        f"Finding {NotificationHandler.get_finding_info(event.finding)} for {SLACK_TEAM_GROUP_ID[team]}"
+                    )
                     if event.finding_needs_risk_assessment:
                         msg += "\n- needs risk assessment"
                     if event.finding_has_patch_version:
@@ -60,4 +67,6 @@ class SlackTrivyFindingNotificationHandler(NotificationHandler):
                             self.github_handler.handle(event)
                     self.slack_api_by_team[team].send_message(msg)
                 if event.finding_was_resolved:
-                    self.slack_api_by_team[team].send_message(f"Finding {NotificationHandler.get_finding_info(event.finding)} was resolved :tada:")
+                    self.slack_api_by_team[team].send_message(
+                        f"Finding {NotificationHandler.get_finding_info(event.finding)} was resolved :tada:"
+                    )

--- a/ci/src/dependencies/integration/slack/slack_trivy_finding_notification_handler_test.py
+++ b/ci/src/dependencies/integration/slack/slack_trivy_finding_notification_handler_test.py
@@ -77,20 +77,22 @@ def supported_teams_powerset():
             for item in powerset(seq[1:]):
                 yield [seq[0]] + item
                 yield item
-    return powerset(list(SUPPORTED_TEAMS))
-    #return [[Team.NODE_TEAM], [Team.BOUNDARY_NODE_TEAM], [Team.NODE_TEAM, Team.BOUNDARY_NODE_TEAM]]
 
-@pytest.mark.parametrize(
-    "owning_teams", supported_teams_powerset()
-)
+    return powerset(list(SUPPORTED_TEAMS))
+    # return [[Team.NODE_TEAM], [Team.BOUNDARY_NODE_TEAM], [Team.NODE_TEAM, Team.BOUNDARY_NODE_TEAM]]
+
+
+@pytest.mark.parametrize("owning_teams", supported_teams_powerset())
 def test_finding_needs_risk_assessment_event(owning_teams):
     finding = deepcopy(FINDING_WITH_RISK_NO_PATCH_NO)
     finding.owning_teams = owning_teams
     slack_api = MockSlackApi()
     github_handler = Mock()
     github_handler.can_handle.return_value = True
-    handler = SlackTrivyFindingNotificationHandler(slack_api=slack_api,github_handler=github_handler)
-    event = FindingNotificationEvent(finding=finding, finding_needs_risk_assessment=True, finding_has_patch_version=False, finding_was_resolved=False)
+    handler = SlackTrivyFindingNotificationHandler(slack_api=slack_api, github_handler=github_handler)
+    event = FindingNotificationEvent(
+        finding=finding, finding_needs_risk_assessment=True, finding_has_patch_version=False, finding_was_resolved=False
+    )
 
     assert handler.can_handle(event)
 
@@ -107,18 +109,17 @@ def test_finding_needs_risk_assessment_event(owning_teams):
     github_handler.handle.assert_not_called()
 
 
-@pytest.mark.parametrize(
-    "owning_teams", supported_teams_powerset()
-)
+@pytest.mark.parametrize("owning_teams", supported_teams_powerset())
 def test_finding_has_patch_version_event(owning_teams):
     finding = deepcopy(FINDING_WITH_RISK_YES_PATCH_YES)
     finding.owning_teams = owning_teams
     slack_api = MockSlackApi()
     github_handler = Mock()
     github_handler.can_handle.return_value = True
-    handler = SlackTrivyFindingNotificationHandler(slack_api=slack_api,github_handler=github_handler)
-    event = FindingNotificationEvent(finding=finding, finding_needs_risk_assessment=False,
-                                     finding_has_patch_version=True, finding_was_resolved=False)
+    handler = SlackTrivyFindingNotificationHandler(slack_api=slack_api, github_handler=github_handler)
+    event = FindingNotificationEvent(
+        finding=finding, finding_needs_risk_assessment=False, finding_has_patch_version=True, finding_was_resolved=False
+    )
 
     assert handler.can_handle(event)
 
@@ -135,18 +136,17 @@ def test_finding_has_patch_version_event(owning_teams):
     assert github_handler.handle.call_count == len(owning_teams)
 
 
-@pytest.mark.parametrize(
-    "owning_teams", supported_teams_powerset()
-)
+@pytest.mark.parametrize("owning_teams", supported_teams_powerset())
 def test_finding_needs_risk_assessment_and_has_patch_version_event(owning_teams):
     finding = deepcopy(FINDING_WITH_RISK_NO_PATCH_YES)
     finding.owning_teams = owning_teams
     slack_api = MockSlackApi()
     github_handler = Mock()
     github_handler.can_handle.return_value = False
-    handler = SlackTrivyFindingNotificationHandler(slack_api=slack_api,github_handler=github_handler)
-    event = FindingNotificationEvent(finding=finding, finding_needs_risk_assessment=True,
-                                     finding_has_patch_version=True, finding_was_resolved=False)
+    handler = SlackTrivyFindingNotificationHandler(slack_api=slack_api, github_handler=github_handler)
+    event = FindingNotificationEvent(
+        finding=finding, finding_needs_risk_assessment=True, finding_has_patch_version=True, finding_was_resolved=False
+    )
 
     assert handler.can_handle(event)
 
@@ -163,9 +163,8 @@ def test_finding_needs_risk_assessment_and_has_patch_version_event(owning_teams)
     assert github_handler.can_handle.call_count == len(owning_teams)
     github_handler.handle.assert_not_called()
 
-@pytest.mark.parametrize(
-    "owning_teams", supported_teams_powerset()
-)
+
+@pytest.mark.parametrize("owning_teams", supported_teams_powerset())
 def test_finding_was_resolved_event(owning_teams):
     finding = deepcopy(FINDING_WITH_RISK_NO_PATCH_YES)
     finding.owning_teams = owning_teams
@@ -173,7 +172,9 @@ def test_finding_was_resolved_event(owning_teams):
     github_handler = Mock()
     github_handler.can_handle.return_value = True
     handler = SlackTrivyFindingNotificationHandler(slack_api=slack_api, github_handler=github_handler)
-    event = FindingNotificationEvent(finding=finding, finding_needs_risk_assessment=False, finding_has_patch_version=False, finding_was_resolved=True)
+    event = FindingNotificationEvent(
+        finding=finding, finding_needs_risk_assessment=False, finding_has_patch_version=False, finding_was_resolved=True
+    )
 
     assert handler.can_handle(event)
 
@@ -185,10 +186,12 @@ def test_finding_was_resolved_event(owning_teams):
     github_handler.can_handle.assert_not_called()
     github_handler.handle.assert_not_called()
 
+
 def test_supported_teams_slack_config_is_complete():
     for team in SUPPORTED_TEAMS:
         assert team in SLACK_CHANNEL_CONFIG_BY_TEAM
         assert team in SLACK_TEAM_GROUP_ID
+
 
 class MockSlackApi(SlackApi):
     messages: List[str]

--- a/ci/src/dependencies/job/bazel_rust_ic_scanner_merge_job.py
+++ b/ci/src/dependencies/job/bazel_rust_ic_scanner_merge_job.py
@@ -22,12 +22,14 @@ if __name__ == "__main__":
         notify_on_scan_job_succeeded=notify_on_scan_job_succeeded,
         notify_on_scan_job_failed=notify_on_scan_job_failed,
         merge_request_base_url=get_ic_repo_merge_request_base_url(),
-        ci_pipeline_base_url=get_ic_repo_ci_pipeline_base_url()
+        ci_pipeline_base_url=get_ic_repo_ci_pipeline_base_url(),
     )
     notifier = NotificationCreator(config)
     finding_data_source_subscribers = [notifier]
     scanner_subscribers = [notifier]
     scanner_job = DependencyScanner(
-        BazelRustDependencyManager(), JiraFindingDataSource(finding_data_source_subscribers, app_owner_msg_subscriber=notifier), scanner_subscribers
+        BazelRustDependencyManager(),
+        JiraFindingDataSource(finding_data_source_subscribers, app_owner_msg_subscriber=notifier),
+        scanner_subscribers,
     )
     scanner_job.do_merge_request_scan(get_ic_repo_for_rust())

--- a/ci/src/dependencies/job/bazel_rust_ic_scanner_periodic_job.py
+++ b/ci/src/dependencies/job/bazel_rust_ic_scanner_periodic_job.py
@@ -17,13 +17,41 @@ from scanner.manager.bazel_rust_dependency_manager import BazelRustDependencyMan
 from scanner.scanner_job_type import ScannerJobType
 
 REPOS_TO_SCAN = [
-    Repository("nns-dapp", "https://github.com/dfinity/nns-dapp", [Project(name="nns-dapp", path="nns-dapp", owner=Team.NNS_TEAM)]),
-    Repository("internet-identity", "https://github.com/dfinity/internet-identity", [Project(name="internet-identity", path="internet-identity", owner=Team.GIX_TEAM)]),
-    Repository("response-verification", "https://github.com/dfinity/response-verification", [Project(name="response-verification", path="response-verification", owner=Team.TRUST_TEAM)]),
-    Repository("canfund", "https://github.com/dfinity/canfund", [Project(name="canfund", path="canfund", owner=Team.TRUST_TEAM)]),
-    Repository("agent-rs", "https://github.com/dfinity/agent-rs", [Project(name="agent-rs", path="agent-rs", owner=Team.SDK_TEAM)]),
-    Repository("ic-canister-sig-creation", "https://github.com/dfinity/ic-canister-sig-creation", [Project(name="ic-canister-sig-creation", path="ic-canister-sig-creation", owner=Team.GIX_TEAM)]),
-    Repository("ic-gateway", "https://github.com/dfinity/ic-gateway", [Project(name="ic-gateway", path="ic-gateway", owner=Team.BOUNDARY_NODE_TEAM)]),
+    Repository(
+        "nns-dapp",
+        "https://github.com/dfinity/nns-dapp",
+        [Project(name="nns-dapp", path="nns-dapp", owner=Team.NNS_TEAM)],
+    ),
+    Repository(
+        "internet-identity",
+        "https://github.com/dfinity/internet-identity",
+        [Project(name="internet-identity", path="internet-identity", owner=Team.GIX_TEAM)],
+    ),
+    Repository(
+        "response-verification",
+        "https://github.com/dfinity/response-verification",
+        [Project(name="response-verification", path="response-verification", owner=Team.TRUST_TEAM)],
+    ),
+    Repository(
+        "canfund",
+        "https://github.com/dfinity/canfund",
+        [Project(name="canfund", path="canfund", owner=Team.TRUST_TEAM)],
+    ),
+    Repository(
+        "agent-rs",
+        "https://github.com/dfinity/agent-rs",
+        [Project(name="agent-rs", path="agent-rs", owner=Team.SDK_TEAM)],
+    ),
+    Repository(
+        "ic-canister-sig-creation",
+        "https://github.com/dfinity/ic-canister-sig-creation",
+        [Project(name="ic-canister-sig-creation", path="ic-canister-sig-creation", owner=Team.GIX_TEAM)],
+    ),
+    Repository(
+        "ic-gateway",
+        "https://github.com/dfinity/ic-gateway",
+        [Project(name="ic-gateway", path="ic-gateway", owner=Team.BOUNDARY_NODE_TEAM)],
+    ),
 ]
 
 
@@ -50,13 +78,15 @@ def main():
         notify_on_scan_job_succeeded=notify_on_scan_job_succeeded,
         notify_on_scan_job_failed=notify_on_scan_job_failed,
         merge_request_base_url=get_ic_repo_merge_request_base_url(),
-        ci_pipeline_base_url=get_ic_repo_ci_pipeline_base_url()
+        ci_pipeline_base_url=get_ic_repo_ci_pipeline_base_url(),
     )
     notifier = NotificationCreator(config)
     finding_data_source_subscribers = [notifier]
     scanner_subscribers = [notifier]
     scanner_job = DependencyScanner(
-        BazelRustDependencyManager(), JiraFindingDataSource(finding_data_source_subscribers, app_owner_msg_subscriber=notifier), scanner_subscribers
+        BazelRustDependencyManager(),
+        JiraFindingDataSource(finding_data_source_subscribers, app_owner_msg_subscriber=notifier),
+        scanner_subscribers,
     )
     scanner_job.do_periodic_scan([get_ic_repo_for_rust()] + REPOS_TO_SCAN)
 

--- a/ci/src/dependencies/job/bazel_rust_ic_scanner_release_job.py
+++ b/ci/src/dependencies/job/bazel_rust_ic_scanner_release_job.py
@@ -30,12 +30,14 @@ if __name__ == "__main__":
         notify_on_scan_job_succeeded=notify_on_scan_job_succeeded,
         notify_on_scan_job_failed=notify_on_scan_job_failed,
         merge_request_base_url=get_ic_repo_merge_request_base_url(),
-        ci_pipeline_base_url=get_ic_repo_ci_pipeline_base_url()
+        ci_pipeline_base_url=get_ic_repo_ci_pipeline_base_url(),
     )
     notifier = NotificationCreator(config)
     finding_data_source_subscribers = [notifier]
     scanner_subscribers = [notifier]
     scanner_job = DependencyScanner(
-        BazelRustDependencyManager(), JiraFindingDataSource(finding_data_source_subscribers, app_owner_msg_subscriber=notifier), scanner_subscribers
+        BazelRustDependencyManager(),
+        JiraFindingDataSource(finding_data_source_subscribers, app_owner_msg_subscriber=notifier),
+        scanner_subscribers,
     )
     scanner_job.do_release_scan(get_ic_repo_for_rust())

--- a/ci/src/dependencies/job/bazel_trivy_container_ic_scanner_periodic_job.py
+++ b/ci/src/dependencies/job/bazel_trivy_container_ic_scanner_periodic_job.py
@@ -60,7 +60,7 @@ def main():
         notify_on_scan_job_failed=notify_on_scan_job_failed,
         merge_request_base_url=get_ic_repo_merge_request_base_url(),
         ci_pipeline_base_url=get_ic_repo_ci_pipeline_base_url(),
-        notification_handlers=[SlackTrivyFindingNotificationHandler(), SlackDefaultNotificationHandler()]
+        notification_handlers=[SlackTrivyFindingNotificationHandler(), SlackDefaultNotificationHandler()],
     )
     notifier = NotificationCreator(config)
     finding_data_source_subscribers = [notifier]
@@ -69,7 +69,7 @@ def main():
         BazelTrivyContainer(app_owner_msg_subscriber=notifier),
         JiraFindingDataSource(finding_data_source_subscribers, app_owner_msg_subscriber=notifier),
         scanner_subscribers,
-        SlackFindingsFailoverDataStore(projects=REPOS_TO_SCAN[0].projects)
+        SlackFindingsFailoverDataStore(projects=REPOS_TO_SCAN[0].projects),
     )
     scanner_job.do_periodic_scan(REPOS_TO_SCAN)
 

--- a/ci/src/dependencies/job/npm_scanner_periodic_job.py
+++ b/ci/src/dependencies/job/npm_scanner_periodic_job.py
@@ -49,7 +49,7 @@ REPOS_TO_SCAN = [
                 owner=Team.GIX_TEAM,
             )
         ],
-        DEFAULT_NODE_VERSION
+        DEFAULT_NODE_VERSION,
     ),
     Repository(
         "agent-js",
@@ -101,7 +101,6 @@ REPOS_TO_SCAN = [
     ),
     # Removing ic-docutrack temporarily since it supports
     # only pnpm and not npm
-
     # Repository(
     #     "ic-docutrack",
     #     "https://github.com/dfinity/ic-docutrack",
@@ -146,7 +145,9 @@ def main():
     finding_data_source_subscribers = [notifier]
     scanner_subscribers = [notifier]
     scanner_job = DependencyScanner(
-        NPMDependencyManager(), JiraFindingDataSource(finding_data_source_subscribers, app_owner_msg_subscriber=notifier), scanner_subscribers
+        NPMDependencyManager(),
+        JiraFindingDataSource(finding_data_source_subscribers, app_owner_msg_subscriber=notifier),
+        scanner_subscribers,
     )
     scanner_job.do_periodic_scan(REPOS_TO_SCAN)
 

--- a/ci/src/dependencies/model/finding.py
+++ b/ci/src/dependencies/model/finding.py
@@ -160,7 +160,12 @@ class Finding:
                 self.owning_teams.append(team)
         self.owning_teams.sort()
 
-    def __copy_vulnerability_notes_and_update_risk(self, vulnerabilities: List[Vulnerability], determine_risk_from_vulnerabilities: bool, related_finding_risk: Optional[SecurityRisk] = None):
+    def __copy_vulnerability_notes_and_update_risk(
+        self,
+        vulnerabilities: List[Vulnerability],
+        determine_risk_from_vulnerabilities: bool,
+        related_finding_risk: Optional[SecurityRisk] = None,
+    ):
         if determine_risk_from_vulnerabilities:
             self.risk = SecurityRisk.INFORMATIONAL
 
@@ -173,18 +178,22 @@ class Finding:
                 if determine_risk_from_vulnerabilities:
                     vulnerability_risk = cur_vulnerability.get_risk()
                     # risk assessment might be only done on finding level and not on vulnerability level => if vulnerability doesn't have a risk, fallback to risk of finding
-                    self.risk = SecurityRisk.new_risk_from(self.risk, vulnerability_risk if vulnerability_risk else related_finding_risk)
+                    self.risk = SecurityRisk.new_risk_from(
+                        self.risk, vulnerability_risk if vulnerability_risk else related_finding_risk
+                    )
             else:
                 self.risk = None
 
-    def update_risk_and_vulnerabilities_for_same_finding(self, same_finding: 'Finding'):
+    def update_risk_and_vulnerabilities_for_same_finding(self, same_finding: "Finding"):
         if self.id() != same_finding.id():
-            raise RuntimeError(f"update_risk_and_vulnerabilities_for_same_finding called with finding with different id {self.id()} != {same_finding.id()}")
+            raise RuntimeError(
+                f"update_risk_and_vulnerabilities_for_same_finding called with finding with different id {self.id()} != {same_finding.id()}"
+            )
         old_vulnerabilities = self.vulnerabilities
         self.vulnerabilities = same_finding.vulnerabilities
         self.__copy_vulnerability_notes_and_update_risk(old_vulnerabilities, False)
 
-    def update_risk_and_vulnerabilities_for_related_findings(self, related_findings: List['Finding']):
+    def update_risk_and_vulnerabilities_for_related_findings(self, related_findings: List["Finding"]):
         if len(related_findings) == 0:
             return
 
@@ -192,8 +201,14 @@ class Finding:
         previous_vulnerabilities_by_id = {}
         related_finding_risk = related_findings[0].risk
         for finding in related_findings:
-            if self.repository != finding.repository or self.scanner != finding.scanner or self.vulnerable_dependency.id != finding.vulnerable_dependency.id:
-                raise RuntimeError(f"update_risk_and_vulnerabilities_for_related_findings called with finding with different id components {self.id()} != {finding.id()}")
+            if (
+                self.repository != finding.repository
+                or self.scanner != finding.scanner
+                or self.vulnerable_dependency.id != finding.vulnerable_dependency.id
+            ):
+                raise RuntimeError(
+                    f"update_risk_and_vulnerabilities_for_related_findings called with finding with different id components {self.id()} != {finding.id()}"
+                )
 
             # if all related findings have the same risk, we use this as fallback if a vulnerability doesn't have a risk set
             if finding.risk != related_finding_risk:
@@ -220,4 +235,6 @@ class Finding:
                     # first time we see this vul, remember it
                     previous_vulnerabilities_by_id[vulnerability.id] = vulnerability
 
-        self.__copy_vulnerability_notes_and_update_risk(list(previous_vulnerabilities_by_id.values()), True, related_finding_risk)
+        self.__copy_vulnerability_notes_and_update_risk(
+            list(previous_vulnerabilities_by_id.values()), True, related_finding_risk
+        )

--- a/ci/src/dependencies/model/finding_test.py
+++ b/ci/src/dependencies/model/finding_test.py
@@ -252,8 +252,11 @@ def test_update_risk_and_vulnerabilities_for_related_findings_set_risk_from_vul(
         "repo",
         "scanner",
         Dependency("dep_id", "dep_name", "dep_version1"),
-        [Vulnerability("v1", "vn1", "vd1", -1, "low"), Vulnerability("v2", "vn2", "vd2", -1, "medium"),
-         Vulnerability("v3", "vn3", "vd3", -1, "critical")],
+        [
+            Vulnerability("v1", "vn1", "vd1", -1, "low"),
+            Vulnerability("v2", "vn2", "vd2", -1, "medium"),
+            Vulnerability("v3", "vn3", "vd3", -1, "critical"),
+        ],
         [],
         [],
         [],
@@ -331,7 +334,6 @@ def test_update_risk_and_vulnerabilities_for_related_findings_set_risk_from_find
     assert finding.risk == SecurityRisk.LOW
     assert len(finding.vulnerabilities) == 1
     assert finding.vulnerabilities[0].risk_note == " "
-
 
 
 def test_update_risk_and_vulnerabilities_for_related_findings_reset_risk_if_new_vul_appears():

--- a/ci/src/dependencies/model/ic.py
+++ b/ci/src/dependencies/model/ic.py
@@ -23,7 +23,21 @@ def is_env_for_periodic_job() -> bool:
 
 def get_ic_repo_for_rust() -> Repository:
     repo_name = REPO_NAME.replace("dfinity/", "")
-    return Repository("ic", f"https://github.com/dfinity/{repo_name}", [Project(name="ic", path=repo_name, owner_by_path={f"{repo_name}/rs/crypto": [Team.CRYPTO_TEAM], f"{repo_name}/rs/validator": [Team.CRYPTO_TEAM], f"{repo_name}/rs/canonical_state": [Team.CRYPTO_TEAM]})])
+    return Repository(
+        "ic",
+        f"https://github.com/dfinity/{repo_name}",
+        [
+            Project(
+                name="ic",
+                path=repo_name,
+                owner_by_path={
+                    f"{repo_name}/rs/crypto": [Team.CRYPTO_TEAM],
+                    f"{repo_name}/rs/validator": [Team.CRYPTO_TEAM],
+                    f"{repo_name}/rs/canonical_state": [Team.CRYPTO_TEAM],
+                },
+            )
+        ],
+    )
 
 
 def get_ic_repo_merge_request_base_url() -> str:

--- a/ci/src/dependencies/model/project_test.py
+++ b/ci/src/dependencies/model/project_test.py
@@ -8,7 +8,16 @@ from model.vulnerability import Vulnerability
 
 @pytest.fixture
 def mock_finding():
-    return Finding(repository="repo", scanner="scanner", vulnerable_dependency=Dependency(id="depid", name="depname", version="depvers"), vulnerabilities=[Vulnerability(id="vulnid", name="vulnname", description="vulndesc")], first_level_dependencies=[], projects=[], risk_assessor=[])
+    return Finding(
+        repository="repo",
+        scanner="scanner",
+        vulnerable_dependency=Dependency(id="depid", name="depname", version="depvers"),
+        vulnerabilities=[Vulnerability(id="vulnid", name="vulnname", description="vulndesc")],
+        first_level_dependencies=[],
+        projects=[],
+        risk_assessor=[],
+    )
+
 
 def test_no_owners(mock_finding):
     project = Project(name="a", path="b")
@@ -17,6 +26,7 @@ def test_no_owners(mock_finding):
 
     assert len(owners) == 0
 
+
 def test_main_owner(mock_finding):
     project = Project(name="a", path="b", owner=Team.CRYPTO_TEAM)
 
@@ -24,6 +34,7 @@ def test_main_owner(mock_finding):
 
     assert len(owners) == 1
     assert owners[0] == Team.CRYPTO_TEAM
+
 
 def test_sub_owner_exact_matching(mock_finding):
     project = Project(name="a", path="b", owner_by_path={"/matching/prefix": [Team.NODE_TEAM, Team.BOUNDARY_NODE_TEAM]})
@@ -35,6 +46,7 @@ def test_sub_owner_exact_matching(mock_finding):
     assert Team.NODE_TEAM in owners
     assert Team.BOUNDARY_NODE_TEAM in owners
 
+
 def test_sub_owner_prefix_matching(mock_finding):
     project = Project(name="a", path="b", owner_by_path={"/matching/prefix": [Team.NODE_TEAM, Team.BOUNDARY_NODE_TEAM]})
     mock_finding.projects.append("/matching/prefix/and/some/more/paths")
@@ -45,24 +57,39 @@ def test_sub_owner_prefix_matching(mock_finding):
     assert Team.NODE_TEAM in owners
     assert Team.BOUNDARY_NODE_TEAM in owners
 
+
 def test_sub_owner_not_matching(mock_finding):
-    project = Project(name="a", path="b", owner_by_path={"/no/matching/prefix": [Team.NODE_TEAM, Team.BOUNDARY_NODE_TEAM]})
+    project = Project(
+        name="a", path="b", owner_by_path={"/no/matching/prefix": [Team.NODE_TEAM, Team.BOUNDARY_NODE_TEAM]}
+    )
     mock_finding.projects.append("/not/matching/prefix")
 
     owners = project.get_owners_for(mock_finding)
 
     assert len(owners) == 0
+
 
 def test_sub_owner_not_matching_when_project_is_prefix_of_path(mock_finding):
-    project = Project(name="a", path="b", owner_by_path={"/not/matching/prefix/too/long": [Team.NODE_TEAM, Team.BOUNDARY_NODE_TEAM]})
+    project = Project(
+        name="a", path="b", owner_by_path={"/not/matching/prefix/too/long": [Team.NODE_TEAM, Team.BOUNDARY_NODE_TEAM]}
+    )
     mock_finding.projects.append("/not/matching/prefix")
 
     owners = project.get_owners_for(mock_finding)
 
     assert len(owners) == 0
 
+
 def test_main_owner_and_sub_owner(mock_finding):
-    project = Project(name="a", path="b", owner=Team.CRYPTO_TEAM, owner_by_path={"/matching/prefix": [Team.NODE_TEAM, Team.BOUNDARY_NODE_TEAM], "/different/prefix": [Team.GIX_TEAM]})
+    project = Project(
+        name="a",
+        path="b",
+        owner=Team.CRYPTO_TEAM,
+        owner_by_path={
+            "/matching/prefix": [Team.NODE_TEAM, Team.BOUNDARY_NODE_TEAM],
+            "/different/prefix": [Team.GIX_TEAM],
+        },
+    )
     mock_finding.projects.append("/not/matching/prefix")
     mock_finding.projects.append("/matching/prefix")
 
@@ -73,8 +100,14 @@ def test_main_owner_and_sub_owner(mock_finding):
     assert Team.NODE_TEAM in owners
     assert Team.CRYPTO_TEAM in owners
 
+
 def test_owner_deduplication(mock_finding):
-    project = Project(name="a", path="b", owner=Team.CRYPTO_TEAM, owner_by_path={"/prefix/a": [Team.TRUST_TEAM, Team.CRYPTO_TEAM], "/prefix/b": [Team.GIX_TEAM, Team.TRUST_TEAM]})
+    project = Project(
+        name="a",
+        path="b",
+        owner=Team.CRYPTO_TEAM,
+        owner_by_path={"/prefix/a": [Team.TRUST_TEAM, Team.CRYPTO_TEAM], "/prefix/b": [Team.GIX_TEAM, Team.TRUST_TEAM]},
+    )
     mock_finding.projects.append("/not/matching/prefix")
     mock_finding.projects.append("/prefix/a/b")
     mock_finding.projects.append("/prefix/b/a")

--- a/ci/src/dependencies/model/security_risk.py
+++ b/ci/src/dependencies/model/security_risk.py
@@ -10,7 +10,7 @@ class SecurityRisk(Enum):
     CRITICAL = 5
 
     @staticmethod
-    def of(word: Optional[str]) -> Optional['SecurityRisk']:
+    def of(word: Optional[str]) -> Optional["SecurityRisk"]:
         if word is None:
             return None
         word = word.strip().upper()
@@ -23,7 +23,7 @@ class SecurityRisk(Enum):
         return None
 
     @staticmethod
-    def new_risk_from(risk_a: Optional['SecurityRisk'], risk_b: Optional['SecurityRisk']):
+    def new_risk_from(risk_a: Optional["SecurityRisk"], risk_b: Optional["SecurityRisk"]):
         if risk_a is None or risk_b is None:
             # if one of the risks is undetermined, new risk should be undetermined
             return None

--- a/ci/src/dependencies/model/security_risk_test.py
+++ b/ci/src/dependencies/model/security_risk_test.py
@@ -3,26 +3,29 @@ from model.security_risk import SecurityRisk
 
 def test_dont_parse_risk():
     assert SecurityRisk.of(None) is None
-    assert SecurityRisk.of('') is None
-    assert SecurityRisk.of(' ') is None
-    assert SecurityRisk.of('no idea')  is None
-    assert SecurityRisk.of('todo') is None
-    assert SecurityRisk.of(';') is None
-    assert SecurityRisk.of('high:') is None
+    assert SecurityRisk.of("") is None
+    assert SecurityRisk.of(" ") is None
+    assert SecurityRisk.of("no idea") is None
+    assert SecurityRisk.of("todo") is None
+    assert SecurityRisk.of(";") is None
+    assert SecurityRisk.of("high:") is None
+
 
 def test_parse_risk_from_full_risk():
-    assert SecurityRisk.of('informational') == SecurityRisk.INFORMATIONAL
-    assert SecurityRisk.of('  LOW') == SecurityRisk.LOW
-    assert SecurityRisk.of('medIUM  ') == SecurityRisk.MEDIUM
-    assert SecurityRisk.of(' high   ') == SecurityRisk.HIGH
-    assert SecurityRisk.of('  CRITICAL   ') == SecurityRisk.CRITICAL
+    assert SecurityRisk.of("informational") == SecurityRisk.INFORMATIONAL
+    assert SecurityRisk.of("  LOW") == SecurityRisk.LOW
+    assert SecurityRisk.of("medIUM  ") == SecurityRisk.MEDIUM
+    assert SecurityRisk.of(" high   ") == SecurityRisk.HIGH
+    assert SecurityRisk.of("  CRITICAL   ") == SecurityRisk.CRITICAL
+
 
 def test_parse_risk_from_partial_risk():
-    assert SecurityRisk.of('info   ') == SecurityRisk.INFORMATIONAL
-    assert SecurityRisk.of(' lo  ') == SecurityRisk.LOW
-    assert SecurityRisk.of('  MEDI') == SecurityRisk.MEDIUM
-    assert SecurityRisk.of('  hI   ') == SecurityRisk.HIGH
-    assert SecurityRisk.of('crit') == SecurityRisk.CRITICAL
+    assert SecurityRisk.of("info   ") == SecurityRisk.INFORMATIONAL
+    assert SecurityRisk.of(" lo  ") == SecurityRisk.LOW
+    assert SecurityRisk.of("  MEDI") == SecurityRisk.MEDIUM
+    assert SecurityRisk.of("  hI   ") == SecurityRisk.HIGH
+    assert SecurityRisk.of("crit") == SecurityRisk.CRITICAL
+
 
 def test_new_risk_from():
     assert SecurityRisk.new_risk_from(SecurityRisk.INFORMATIONAL, SecurityRisk.LOW) == SecurityRisk.LOW

--- a/ci/src/dependencies/model/vulnerability_test.py
+++ b/ci/src/dependencies/model/vulnerability_test.py
@@ -5,48 +5,53 @@ from model.vulnerability import Vulnerability
 
 
 def vuln_with_risk_note(note: Optional[str] = None):
-    return Vulnerability(id='a', name='b', description='c', score=0, risk_note=note if note else '')
+    return Vulnerability(id="a", name="b", description="c", score=0, risk_note=note if note else "")
+
 
 def test_dont_parse_risk_from_note():
     assert vuln_with_risk_note().get_risk() is None
-    assert vuln_with_risk_note('').get_risk() is None
-    assert vuln_with_risk_note(' ').get_risk() is None
-    assert vuln_with_risk_note('n/a').get_risk() is None
-    assert vuln_with_risk_note(':').get_risk() is None
-    assert vuln_with_risk_note(' ; ').get_risk() is None
-    assert vuln_with_risk_note('dont know').get_risk() is None
-    assert vuln_with_risk_note('infolow').get_risk() is None
-    assert vuln_with_risk_note('  lowball, probably').get_risk() is None
-    assert vuln_with_risk_note('mediumrisk').get_risk() is None
-    assert vuln_with_risk_note('higher than expected').get_risk() is None
-    assert vuln_with_risk_note('CRITICALLY').get_risk() is None
+    assert vuln_with_risk_note("").get_risk() is None
+    assert vuln_with_risk_note(" ").get_risk() is None
+    assert vuln_with_risk_note("n/a").get_risk() is None
+    assert vuln_with_risk_note(":").get_risk() is None
+    assert vuln_with_risk_note(" ; ").get_risk() is None
+    assert vuln_with_risk_note("dont know").get_risk() is None
+    assert vuln_with_risk_note("infolow").get_risk() is None
+    assert vuln_with_risk_note("  lowball, probably").get_risk() is None
+    assert vuln_with_risk_note("mediumrisk").get_risk() is None
+    assert vuln_with_risk_note("higher than expected").get_risk() is None
+    assert vuln_with_risk_note("CRITICALLY").get_risk() is None
+
 
 def test_parse_risk_from_note_with_full_risk_as_first_word():
-    assert vuln_with_risk_note('    INFORMATIONAL: some note').get_risk() == SecurityRisk.INFORMATIONAL
-    assert vuln_with_risk_note('    loW  ').get_risk() == SecurityRisk.LOW
-    assert vuln_with_risk_note(' medium because it is not high').get_risk() == SecurityRisk.MEDIUM
-    assert vuln_with_risk_note('high,just because').get_risk() == SecurityRisk.HIGH
-    assert vuln_with_risk_note('    CRITicAL').get_risk() == SecurityRisk.CRITICAL
+    assert vuln_with_risk_note("    INFORMATIONAL: some note").get_risk() == SecurityRisk.INFORMATIONAL
+    assert vuln_with_risk_note("    loW  ").get_risk() == SecurityRisk.LOW
+    assert vuln_with_risk_note(" medium because it is not high").get_risk() == SecurityRisk.MEDIUM
+    assert vuln_with_risk_note("high,just because").get_risk() == SecurityRisk.HIGH
+    assert vuln_with_risk_note("    CRITicAL").get_risk() == SecurityRisk.CRITICAL
     assert vuln_with_risk_note()
 
+
 def test_parse_risk_from_note_with_partial_risk_as_first_word():
-    assert vuln_with_risk_note('info; we are not affected').get_risk() == SecurityRisk.INFORMATIONAL
-    assert vuln_with_risk_note('lo').get_risk() == SecurityRisk.LOW
-    assert vuln_with_risk_note('  MED this needs further look   ').get_risk() == SecurityRisk.MEDIUM
-    assert vuln_with_risk_note('  Hig because i got').get_risk() == SecurityRisk.HIGH
-    assert vuln_with_risk_note('crit: holy moly ').get_risk() == SecurityRisk.CRITICAL
+    assert vuln_with_risk_note("info; we are not affected").get_risk() == SecurityRisk.INFORMATIONAL
+    assert vuln_with_risk_note("lo").get_risk() == SecurityRisk.LOW
+    assert vuln_with_risk_note("  MED this needs further look   ").get_risk() == SecurityRisk.MEDIUM
+    assert vuln_with_risk_note("  Hig because i got").get_risk() == SecurityRisk.HIGH
+    assert vuln_with_risk_note("crit: holy moly ").get_risk() == SecurityRisk.CRITICAL
+
 
 def test_has_risk_note():
-    assert vuln_with_risk_note(' a ').has_risk_note()
-    assert vuln_with_risk_note(';').has_risk_note()
-    assert vuln_with_risk_note(' 1').has_risk_note()
-    assert vuln_with_risk_note('A ').has_risk_note()
+    assert vuln_with_risk_note(" a ").has_risk_note()
+    assert vuln_with_risk_note(";").has_risk_note()
+    assert vuln_with_risk_note(" 1").has_risk_note()
+    assert vuln_with_risk_note("A ").has_risk_note()
+
 
 def test_has_no_risk_note():
     assert not vuln_with_risk_note().has_risk_note()
-    assert not vuln_with_risk_note(' ').has_risk_note()
-    assert not vuln_with_risk_note('  ').has_risk_note()
-    assert not vuln_with_risk_note('\t').has_risk_note()
-    assert not vuln_with_risk_note(' \n').has_risk_note()
-    assert not vuln_with_risk_note(' \r ').has_risk_note()
-    assert not vuln_with_risk_note('\n ').has_risk_note()
+    assert not vuln_with_risk_note(" ").has_risk_note()
+    assert not vuln_with_risk_note("  ").has_risk_note()
+    assert not vuln_with_risk_note("\t").has_risk_note()
+    assert not vuln_with_risk_note(" \n").has_risk_note()
+    assert not vuln_with_risk_note(" \r ").has_risk_note()
+    assert not vuln_with_risk_note("\n ").has_risk_note()

--- a/ci/src/dependencies/notification/broadcast_notification_handler_test.py
+++ b/ci/src/dependencies/notification/broadcast_notification_handler_test.py
@@ -10,21 +10,23 @@ def test_can_handle_if_one_nested_can_handle():
     b = MockNotificationHandler(False)
     c = MockNotificationHandler(True)
 
-    assert BroadcastNotificationHandler(nested_handlers=[a,b,c]).can_handle(Mock())
+    assert BroadcastNotificationHandler(nested_handlers=[a, b, c]).can_handle(Mock())
+
 
 def test_can_not_handle_if_nested_can_not_handle():
     a = MockNotificationHandler(False)
     b = MockNotificationHandler(False)
     c = MockNotificationHandler(False)
 
-    assert not BroadcastNotificationHandler(nested_handlers=[a,b,c]).can_handle(Mock())
+    assert not BroadcastNotificationHandler(nested_handlers=[a, b, c]).can_handle(Mock())
+
 
 def test_call_all_that_can_handle():
     a = MockNotificationHandler(True)
     b = MockNotificationHandler(False)
     c = MockNotificationHandler(True)
     event = Mock()
-    handler = BroadcastNotificationHandler(nested_handlers=[a,b,c])
+    handler = BroadcastNotificationHandler(nested_handlers=[a, b, c])
 
     assert handler.can_handle(event)
 
@@ -34,11 +36,12 @@ def test_call_all_that_can_handle():
     assert len(b.events) == 0
     assert len(c.events) == 1
 
-class MockNotificationHandler(NotificationHandler):
 
+class MockNotificationHandler(NotificationHandler):
     def __init__(self, can_handle_ret: bool):
         self.can_handle_ret = can_handle_ret
         self.events = []
+
     def can_handle(self, event: NotificationEvent) -> bool:
         return self.can_handle_ret
 

--- a/ci/src/dependencies/notification/notification_config.py
+++ b/ci/src/dependencies/notification/notification_config.py
@@ -27,7 +27,9 @@ class NotificationConfig:
     merge_request_base_url: str = "https://github.com/dfinity/ic/pull/"
     ci_pipeline_base_url: str = "https://github.com/dfinity/ic/actions/runs/"
 
-    notification_handlers: List[NotificationHandler] = field(default_factory=lambda: [SlackDefaultNotificationHandler()])
+    notification_handlers: List[NotificationHandler] = field(
+        default_factory=lambda: [SlackDefaultNotificationHandler()]
+    )
 
     def __post_init__(self):
         """Validate field values after initialization"""

--- a/ci/src/dependencies/notification/notification_creator.py
+++ b/ci/src/dependencies/notification/notification_creator.py
@@ -38,7 +38,13 @@ class NotificationCreator(ScannerSubscriber, FindingDataSourceSubscriber, AppOwn
     def on_merge_request_blocked(self, scanner_id: str, job_id: str, merge_request_id: str):
         logging.debug(f"on_merge_request_blocked({scanner_id},{job_id},{merge_request_id})")
         if self.config.notify_on_merge_request_blocked:
-            self.__handle(MRBlockedNotificationEvent(scanner_id, f"{self.config.ci_pipeline_base_url}{job_id}", f"{self.config.merge_request_base_url}{merge_request_id}"))
+            self.__handle(
+                MRBlockedNotificationEvent(
+                    scanner_id,
+                    f"{self.config.ci_pipeline_base_url}{job_id}",
+                    f"{self.config.merge_request_base_url}{merge_request_id}",
+                )
+            )
 
     def on_release_build_blocked(self, scanner_id: str, job_id: str):
         logging.debug(f"on_release_build_blocked({scanner_id},{job_id})")
@@ -48,12 +54,18 @@ class NotificationCreator(ScannerSubscriber, FindingDataSourceSubscriber, AppOwn
     def on_scan_job_succeeded(self, scanner_id: str, job_type: ScannerJobType, job_id: str):
         logging.debug(f"on_scan_job_succeeded({scanner_id},{job_type},{job_id})")
         if self.config.notify_on_scan_job_succeeded[job_type]:
-            self.__handle(ScanJobSucceededNotificationEvent(scanner_id, job_type, f"{self.config.ci_pipeline_base_url}{job_id}"))
+            self.__handle(
+                ScanJobSucceededNotificationEvent(scanner_id, job_type, f"{self.config.ci_pipeline_base_url}{job_id}")
+            )
 
     def on_scan_job_failed(self, scanner_id: str, job_type: ScannerJobType, job_id: str, reason: str):
         logging.debug(f"on_scan_job_failed({scanner_id},{job_type},{job_id},{reason})")
         if self.config.notify_on_scan_job_failed[job_type]:
-            self.__handle(ScanJobFailedNotificationEvent(scanner_id, job_type, f"{self.config.ci_pipeline_base_url}{job_id}", reason))
+            self.__handle(
+                ScanJobFailedNotificationEvent(
+                    scanner_id, job_type, f"{self.config.ci_pipeline_base_url}{job_id}", reason
+                )
+            )
 
     def __is_risk_assessment_needed(self, finding: Finding) -> bool:
         return self.config.notify_on_finding_risk_assessment_needed and finding.risk is None

--- a/ci/src/dependencies/notification/notification_creator_test.py
+++ b/ci/src/dependencies/notification/notification_creator_test.py
@@ -124,7 +124,9 @@ def test_on_scan_job_succeeded_notify_if_enabled(selected_job_type):
     notify_on_scan_job_succeeded = {}
     for job_type in ScannerJobType:
         notify_on_scan_job_succeeded[job_type] = job_type == selected_job_type
-    config = NotificationConfig(notify_on_scan_job_succeeded=notify_on_scan_job_succeeded, notification_handlers=[handler])
+    config = NotificationConfig(
+        notify_on_scan_job_succeeded=notify_on_scan_job_succeeded, notification_handlers=[handler]
+    )
     notifier = NotificationCreator(config)
 
     notifier.on_scan_job_succeeded("scanner_id", selected_job_type, "job_id")
@@ -145,7 +147,9 @@ def test_on_scan_job_succeeded_dont_notify_if_disabled(selected_job_type):
     notify_on_scan_job_succeeded = {}
     for job_type in ScannerJobType:
         notify_on_scan_job_succeeded[job_type] = job_type != selected_job_type
-    config = NotificationConfig(notify_on_scan_job_succeeded=notify_on_scan_job_succeeded, notification_handlers=[handler])
+    config = NotificationConfig(
+        notify_on_scan_job_succeeded=notify_on_scan_job_succeeded, notification_handlers=[handler]
+    )
     notifier = NotificationCreator(config)
 
     notifier.on_scan_job_succeeded("scanner_id", selected_job_type, "job_id")
@@ -347,7 +351,9 @@ def test_on_finding_created_or_updated_notify_if_risk_not_set_and_patch_set_if_e
     finding = FINDING_WITH_RISK_NO_PATCH_YES
     handler = MockNotificationHandler()
     config = NotificationConfig(
-        notify_on_finding_risk_assessment_needed=True, notify_on_finding_patch_version_available=True, notification_handlers=[handler]
+        notify_on_finding_risk_assessment_needed=True,
+        notify_on_finding_patch_version_available=True,
+        notification_handlers=[handler],
     )
     notifier = NotificationCreator(config)
 
@@ -379,6 +385,7 @@ def test_on_finding_deleted():
     assert not event.finding_has_patch_version
     assert event.finding_was_resolved
 
+
 def test_on_finding_deleted_dont_notify_if_disabled():
     handler = MockNotificationHandler()
     notifier = NotificationCreator(NotificationConfig(notify_on_finding_deleted=False, notification_handlers=[handler]))
@@ -386,6 +393,7 @@ def test_on_finding_deleted_dont_notify_if_disabled():
     notifier.on_finding_deleted(FINDING_WITH_RISK_NO_PATCH_YES)
 
     assert len(handler.events) == 0
+
 
 def test_send_notification_to_app_owners():
     handler = MockNotificationHandler()
@@ -398,8 +406,8 @@ def test_send_notification_to_app_owners():
     assert isinstance(event, AppOwnerNotificationEvent)
     assert event.message == "some message"
 
-class MockNotificationHandler(NotificationHandler):
 
+class MockNotificationHandler(NotificationHandler):
     def __init__(self):
         self.events = []
 

--- a/ci/src/dependencies/notification/notification_event.py
+++ b/ci/src/dependencies/notification/notification_event.py
@@ -8,6 +8,7 @@ from scanner.scanner_job_type import ScannerJobType
 class NotificationEvent:
     pass
 
+
 @dataclass
 class MRBlockedNotificationEvent(NotificationEvent):
     scanner_id: str
@@ -31,6 +32,7 @@ class ReleaseBlockedNotificationEvent(NotificationEvent):
         assert self.scanner_id is not None and len(self.scanner_id) > 0
         assert self.ci_job_url is not None and len(self.ci_job_url) > 0
 
+
 @dataclass
 class ScanJobSucceededNotificationEvent(NotificationEvent):
     scanner_id: str
@@ -42,6 +44,7 @@ class ScanJobSucceededNotificationEvent(NotificationEvent):
         assert self.scanner_id is not None and len(self.scanner_id) > 0
         assert self.job_type is not None
         assert self.ci_job_url is not None and len(self.ci_job_url) > 0
+
 
 @dataclass
 class ScanJobFailedNotificationEvent(NotificationEvent):
@@ -56,6 +59,7 @@ class ScanJobFailedNotificationEvent(NotificationEvent):
         assert self.job_type is not None
         assert self.ci_job_url is not None and len(self.ci_job_url) > 0
         assert self.reason is not None and len(self.reason) > 0
+
 
 @dataclass
 class FindingNotificationEvent(NotificationEvent):
@@ -75,6 +79,7 @@ class FindingNotificationEvent(NotificationEvent):
             assert boolean_field is True or boolean_field is False
 
         assert self.finding is not None
+
 
 @dataclass
 class AppOwnerNotificationEvent(NotificationEvent):

--- a/ci/src/dependencies/notification/notification_handler_test.py
+++ b/ci/src/dependencies/notification/notification_handler_test.py
@@ -16,11 +16,17 @@ FINDING_WITH_MORE_INFO = Finding(
     risk_assessor=[User("user_id1", "user_name1", "user1@mail.com"), User("user_id2", "user_name2", "user2@mail.com")],
     more_info="https://dfinity.atlassian.net/browse/SCAVM-5",
 )
+
+
 def test_get_finding_info_from_more_info():
     assert NotificationHandler.get_finding_info(FINDING_WITH_MORE_INFO) == FINDING_WITH_MORE_INFO.more_info
+
 
 def test_get_finding_info_from_primary_key():
     finding = deepcopy(FINDING_WITH_MORE_INFO)
     finding.more_info = None
 
-    assert NotificationHandler.get_finding_info(finding) == f"({finding.repository}, {finding.scanner}, {finding.vulnerable_dependency.id}, {finding.vulnerable_dependency.version})"
+    assert (
+        NotificationHandler.get_finding_info(finding)
+        == f"({finding.repository}, {finding.scanner}, {finding.vulnerable_dependency.id}, {finding.vulnerable_dependency.version})"
+    )

--- a/ci/src/dependencies/scanner/dependency_scanner.py
+++ b/ci/src/dependencies/scanner/dependency_scanner.py
@@ -82,10 +82,10 @@ class DependencyScanner:
                         else:
                             finding_by_id[finding.id()] = finding
 
-                existing_findings: typing.Dict[
-                    typing.Tuple[str, str, str, str], Finding
-                ] = self.finding_data_source.get_open_findings_for_repo_and_scanner(
-                    repository.name, self.dependency_manager.get_scanner_id()
+                existing_findings: typing.Dict[typing.Tuple[str, str, str, str], Finding] = (
+                    self.finding_data_source.get_open_findings_for_repo_and_scanner(
+                        repository.name, self.dependency_manager.get_scanner_id()
+                    )
                 )
                 current_findings: typing.List[Finding] = list(finding_by_id.values())
                 if len(current_findings) > 0:
@@ -131,9 +131,19 @@ class DependencyScanner:
                         else:
                             cur_finding = current_findings[index]
                             cur_finding.risk_assessor = self.finding_data_source.get_risk_assessor()
-                            prev_open_findings = existing_findings_by_vul_dep_id[cur_finding.vulnerable_dependency.id] if cur_finding.vulnerable_dependency.id in existing_findings_by_vul_dep_id else []
-                            prev_deleted_findings = self.finding_data_source.get_deleted_findings(repository.name, self.dependency_manager.get_scanner_id(), cur_finding.vulnerable_dependency.id)
-                            cur_finding.update_risk_and_vulnerabilities_for_related_findings(prev_open_findings + prev_deleted_findings)
+                            prev_open_findings = (
+                                existing_findings_by_vul_dep_id[cur_finding.vulnerable_dependency.id]
+                                if cur_finding.vulnerable_dependency.id in existing_findings_by_vul_dep_id
+                                else []
+                            )
+                            prev_deleted_findings = self.finding_data_source.get_deleted_findings(
+                                repository.name,
+                                self.dependency_manager.get_scanner_id(),
+                                cur_finding.vulnerable_dependency.id,
+                            )
+                            cur_finding.update_risk_and_vulnerabilities_for_related_findings(
+                                prev_open_findings + prev_deleted_findings
+                            )
 
                             # rest of the parameters needs to be set by the risk assessor for a new finding.
                             self.finding_data_source.create_or_update_open_finding(cur_finding)
@@ -144,7 +154,9 @@ class DependencyScanner:
                                 self.finding_data_source.link_findings(prev_deleted_findings[0], cur_finding)
 
                     if self.failover_data_store:
-                        self.failover_data_store.store_findings(repository.name, self.dependency_manager.get_scanner_id(), failover_findings)
+                        self.failover_data_store.store_findings(
+                            repository.name, self.dependency_manager.get_scanner_id(), failover_findings
+                        )
 
                 findings_to_remove = set(existing_findings.keys()).difference(map(lambda x: x.id(), current_findings))
                 for key in findings_to_remove:
@@ -236,9 +248,7 @@ class DependencyScanner:
             sys.exit(1)
         except Exception as err:
             should_fail_job = True
-            logging.error(
-                f"{self.dependency_manager.get_scanner_id()} for {repository.name} failed for {self.job_id}."
-            )
+            logging.error(f"{self.dependency_manager.get_scanner_id()} for {repository.name} failed for {self.job_id}.")
             logging.debug(
                 f"{self.dependency_manager.get_scanner_id()} for {repository.name} failed for {self.job_id} with error:\n{traceback.format_exc()}"
             )
@@ -303,9 +313,7 @@ class DependencyScanner:
             sys.exit(1)
         except Exception as err:
             should_fail_job = True
-            logging.error(
-                f"{self.dependency_manager.get_scanner_id()} for {repository.name} failed for {self.job_id}."
-            )
+            logging.error(f"{self.dependency_manager.get_scanner_id()} for {repository.name} failed for {self.job_id}.")
             logging.debug(
                 f"{self.dependency_manager.get_scanner_id()} for {repository.name} failed for {self.job_id} with error:\n{traceback.format_exc()}"
             )

--- a/ci/src/dependencies/scanner/dependency_scanner_test.py
+++ b/ci/src/dependencies/scanner/dependency_scanner_test.py
@@ -20,6 +20,7 @@ from scanner.manager.bazel_rust_dependency_manager import BazelRustDependencyMan
 def jira_lib_mock():
     return Mock()
 
+
 class FakeBazel(BazelRustDependencyManager):
     def __init__(self, fake_type: int):
         super().__init__()
@@ -128,7 +129,11 @@ def test_on_periodic_job_one_finding(jira_lib_mock):
     fake_bazel = FakeBazel(2)
     scanner_job = DependencyScanner(fake_bazel, jira_lib_mock, [sub1, sub2])
 
-    repository = Repository("ic", "https://github.com/dfinity/ic", [Project(name="ic", path=__test_get_ic_path(), owner=Team.EXECUTION_TEAM)])
+    repository = Repository(
+        "ic",
+        "https://github.com/dfinity/ic",
+        [Project(name="ic", path=__test_get_ic_path(), owner=Team.EXECUTION_TEAM)],
+    )
     finding = fake_bazel.get_findings(repository.name, repository.projects[0], repository.engine_version)[0]
     finding.risk_assessor = [User("mickey", "Mickey Mouse")]
     finding.owning_teams = [Team.EXECUTION_TEAM]
@@ -173,7 +178,13 @@ def test_on_periodic_job_one_finding_in_jira(jira_lib_mock):
     sub2 = Mock()
     fake_bazel = FakeBazel(2)
     scanner_job = DependencyScanner(fake_bazel, jira_lib_mock, [sub1, sub2])
-    repos = [Repository("ic", "https://github.com/dfinity/ic", [Project(name="ic", path=__test_get_ic_path(), owner_by_path={'bear': [Team.NODE_TEAM]})])]
+    repos = [
+        Repository(
+            "ic",
+            "https://github.com/dfinity/ic",
+            [Project(name="ic", path=__test_get_ic_path(), owner_by_path={"bear": [Team.NODE_TEAM]})],
+        )
+    ]
 
     scanner_job.do_periodic_scan(repos)
 
@@ -227,7 +238,13 @@ def test_on_periodic_job_one_finding_in_jira_transition_to_failover(jira_lib_moc
     failover_mock.can_handle.return_value = True
 
     scanner_job = DependencyScanner(fake_bazel, jira_lib_mock, [sub1, sub2], failover_mock)
-    repos = [Repository("ic", "https://github.com/dfinity/ic", [Project(name="ic", path=__test_get_ic_path(), owner_by_path={'bear': [Team.NODE_TEAM]})])]
+    repos = [
+        Repository(
+            "ic",
+            "https://github.com/dfinity/ic",
+            [Project(name="ic", path=__test_get_ic_path(), owner_by_path={"bear": [Team.NODE_TEAM]})],
+        )
+    ]
 
     scanner_job.do_periodic_scan(repos)
 
@@ -410,7 +427,9 @@ def test_on_merge_request_changes_no_findings(jira_lib_mock):
     fake_bazel.get_findings.return_value = []
     scanner_job = DependencyScanner(fake_bazel, jira_lib_mock, [sub1, sub2])
 
-    scanner_job.do_merge_request_scan(Repository("ic", "https://github.com/dfinity/ic", [Project("ic", __test_get_ic_path())]))
+    scanner_job.do_merge_request_scan(
+        Repository("ic", "https://github.com/dfinity/ic", [Project("ic", __test_get_ic_path())])
+    )
     fake_bazel.get_modified_packages.assert_called_once()
     fake_bazel.get_dependency_diff.assert_called_once()
     fake_bazel.get_findings.assert_called_once()
@@ -459,7 +478,9 @@ def test_on_merge_request_changes_all_findings_have_jira_findings(jira_lib_mock)
 
     scanner_job = DependencyScanner(fake_bazel, jira_lib_mock, [sub1, sub2])
 
-    scanner_job.do_merge_request_scan(Repository("ic", "https://github.com/dfinity/ic", [Project("ic", __test_get_ic_path())]))
+    scanner_job.do_merge_request_scan(
+        Repository("ic", "https://github.com/dfinity/ic", [Project("ic", __test_get_ic_path())])
+    )
     fake_bazel.get_modified_packages.assert_called_once()
     fake_bazel.get_dependency_diff.assert_called_once()
     fake_bazel.get_findings.assert_called_once()
@@ -497,7 +518,9 @@ def test_on_merge_request_changes_with_findings_to_flag_and_commit_exception(git
     jira_lib_mock.commit_has_block_exception.return_value = "commit string"
     scanner_job = DependencyScanner(fake_bazel, jira_lib_mock, [sub1, sub2])
 
-    scanner_job.do_merge_request_scan(Repository("ic", "https://github.com/dfinity/ic", [Project("ic", __test_get_ic_path())]))
+    scanner_job.do_merge_request_scan(
+        Repository("ic", "https://github.com/dfinity/ic", [Project("ic", __test_get_ic_path())])
+    )
     fake_bazel.get_modified_packages.assert_called_once()
     fake_bazel.get_dependency_diff.assert_called_once()
     fake_bazel.get_findings.assert_called_once()
@@ -541,8 +564,10 @@ def test_on_merge_request_changes_with_findings_to_flag_no_commit_exception(gith
     scanner_job = DependencyScanner(fake_bazel, jira_lib_mock, [sub1, sub2])
 
     with pytest.raises(SystemExit) as e:
-        scanner_job.do_merge_request_scan(Repository("ic", "https://github.com/dfinity/ic", [Project("ic", __test_get_ic_path())]))
-    assert e.type == SystemExit
+        scanner_job.do_merge_request_scan(
+            Repository("ic", "https://github.com/dfinity/ic", [Project("ic", __test_get_ic_path())])
+        )
+    assert e.type is SystemExit
     assert e.value.code == 1
 
     fake_bazel.get_modified_packages.assert_called_once()
@@ -579,7 +604,9 @@ def test_on_merge_request_job_failed(jira_lib_mock):
     fake_bazel.has_dependencies_changed.side_effect = OSError("Call failed")
 
     scanner_job = DependencyScanner(fake_bazel, jira_lib_mock, [sub1, sub2])
-    scanner_job.do_merge_request_scan(Repository("ic", "https://github.com/dfinity/ic", [Project("ic", __test_get_ic_path())]))
+    scanner_job.do_merge_request_scan(
+        Repository("ic", "https://github.com/dfinity/ic", [Project("ic", __test_get_ic_path())])
+    )
     sub1.on_scan_job_failed.assert_called_once()
     sub2.on_scan_job_failed.assert_called_once()
     sub1.on_scan_job_succeeded.assert_not_called()
@@ -593,7 +620,9 @@ def test_on_release_scan_no_findings(jira_lib_mock):
     fake_bazel.get_findings.return_value = []
     scanner_job = DependencyScanner(fake_bazel, jira_lib_mock, [sub1, sub2])
 
-    scanner_job.do_release_scan(Repository("ic", "https://github.com/dfinity/ic", [Project("ic", __test_get_ic_path())]))
+    scanner_job.do_release_scan(
+        Repository("ic", "https://github.com/dfinity/ic", [Project("ic", __test_get_ic_path())])
+    )
     sub1.on_scan_job_succeeded.assert_called_once()
     sub2.on_scan_job_succeeded.assert_called_once()
     sub1.on_scan_job_failed.assert_not_called()
@@ -640,9 +669,11 @@ def test_on_release_scan_findings_have_jira_findings_with_no_risk(jira_lib_mock)
     scanner_job = DependencyScanner(fake_bazel, jira_lib_mock, [sub1, sub2])
 
     with pytest.raises(SystemExit) as e:
-        scanner_job.do_release_scan(Repository("ic", "https://github.com/dfinity/ic", [Project("ic", __test_get_ic_path())]))
+        scanner_job.do_release_scan(
+            Repository("ic", "https://github.com/dfinity/ic", [Project("ic", __test_get_ic_path())])
+        )
 
-    assert e.type == SystemExit
+    assert e.type is SystemExit
     assert e.value.code == 1
     fake_bazel.get_findings.assert_called_once()
     jira_lib_mock.get_open_finding.assert_called_once()
@@ -694,7 +725,9 @@ def test_on_release_scan_findings_have_jira_findings_with_no_risk_with_exception
 
     scanner_job = DependencyScanner(fake_bazel, jira_lib_mock, [sub1, sub2])
 
-    scanner_job.do_release_scan(Repository("ic", "https://github.com/dfinity/ic", [Project("ic", __test_get_ic_path())]))
+    scanner_job.do_release_scan(
+        Repository("ic", "https://github.com/dfinity/ic", [Project("ic", __test_get_ic_path())])
+    )
     fake_bazel.get_findings.assert_called_once()
     jira_lib_mock.get_open_finding.assert_called_once()
     jira_lib_mock.commit_has_block_exception.assert_called_once()
@@ -746,9 +779,11 @@ def test_on_release_scan_findings_have_jira_findings_with_high_risk_but_no_due_d
     scanner_job = DependencyScanner(fake_bazel, jira_lib_mock, [sub1, sub2])
 
     with pytest.raises(SystemExit) as e:
-        scanner_job.do_release_scan(Repository("ic", "https://github.com/dfinity/ic", [Project("ic", __test_get_ic_path())]))
+        scanner_job.do_release_scan(
+            Repository("ic", "https://github.com/dfinity/ic", [Project("ic", __test_get_ic_path())])
+        )
 
-    assert e.type == SystemExit
+    assert e.type is SystemExit
     assert e.value.code == 1
     fake_bazel.get_findings.assert_called_once()
     jira_lib_mock.get_open_finding.assert_called_once()
@@ -799,7 +834,9 @@ def test_on_release_scan_findings_have_jira_findings_with_high_risk_but_valid_du
 
     scanner_job = DependencyScanner(fake_bazel, jira_lib_mock, [sub1, sub2])
 
-    scanner_job.do_release_scan(Repository("ic", "https://github.com/dfinity/ic", [Project("ic", __test_get_ic_path())]))
+    scanner_job.do_release_scan(
+        Repository("ic", "https://github.com/dfinity/ic", [Project("ic", __test_get_ic_path())])
+    )
     fake_bazel.get_findings.assert_called_once()
     jira_lib_mock.get_open_finding.assert_called_once()
     sub1.on_scan_job_succeeded.assert_called_once()
@@ -848,9 +885,11 @@ def test_on_release_scan_findings_have_jira_findings_with_high_risk_but_expired_
     scanner_job = DependencyScanner(fake_bazel, jira_lib_mock, [sub1, sub2])
 
     with pytest.raises(SystemExit) as e:
-        scanner_job.do_release_scan(Repository("ic", "https://github.com/dfinity/ic", [Project("ic", __test_get_ic_path())]))
+        scanner_job.do_release_scan(
+            Repository("ic", "https://github.com/dfinity/ic", [Project("ic", __test_get_ic_path())])
+        )
 
-    assert e.type == SystemExit
+    assert e.type is SystemExit
     assert e.value.code == 1
     fake_bazel.get_findings.assert_called_once()
     jira_lib_mock.get_open_finding.assert_called_once()
@@ -902,7 +941,9 @@ def test_on_release_scan_findings_have_jira_findings_with_high_risk_but_expired_
 
     scanner_job = DependencyScanner(fake_bazel, jira_lib_mock, [sub1, sub2])
 
-    scanner_job.do_release_scan(Repository("ic", "https://github.com/dfinity/ic", [Project("ic", __test_get_ic_path())]))
+    scanner_job.do_release_scan(
+        Repository("ic", "https://github.com/dfinity/ic", [Project("ic", __test_get_ic_path())])
+    )
     fake_bazel.get_findings.assert_called_once()
     jira_lib_mock.get_open_finding.assert_called_once()
     jira_lib_mock.commit_has_block_exception.assert_called_once()
@@ -940,9 +981,11 @@ def test_on_release_scan_new_findings(jira_lib_mock):
     scanner_job = DependencyScanner(fake_bazel, jira_lib_mock, [sub1, sub2])
 
     with pytest.raises(SystemExit) as e:
-        scanner_job.do_release_scan(Repository("ic", "https://github.com/dfinity/ic", [Project("ic", __test_get_ic_path())]))
+        scanner_job.do_release_scan(
+            Repository("ic", "https://github.com/dfinity/ic", [Project("ic", __test_get_ic_path())])
+        )
 
-    assert e.type == SystemExit
+    assert e.type is SystemExit
     assert e.value.code == 1
     fake_bazel.get_findings.assert_called_once()
     jira_lib_mock.get_open_finding.assert_called_once()
@@ -980,7 +1023,9 @@ def test_on_release_scan_new_findings_with_exception(jira_lib_mock):
 
     scanner_job = DependencyScanner(fake_bazel, jira_lib_mock, [sub1, sub2])
 
-    scanner_job.do_release_scan(Repository("ic", "https://github.com/dfinity/ic", [Project("ic", __test_get_ic_path())]))
+    scanner_job.do_release_scan(
+        Repository("ic", "https://github.com/dfinity/ic", [Project("ic", __test_get_ic_path())])
+    )
     fake_bazel.get_findings.assert_called_once()
     jira_lib_mock.get_open_finding.assert_called_once()
     jira_lib_mock.commit_has_block_exception.assert_called_once()
@@ -999,7 +1044,9 @@ def test_on_release_scan_job_failed(jira_lib_mock):
     fake_bazel.get_findings.side_effect = OSError("Call failed")
     scanner_job = DependencyScanner(fake_bazel, jira_lib_mock, [sub1, sub2])
 
-    scanner_job.do_release_scan(Repository("ic", "https://github.com/dfinity/ic", [Project("ic", __test_get_ic_path())]))
+    scanner_job.do_release_scan(
+        Repository("ic", "https://github.com/dfinity/ic", [Project("ic", __test_get_ic_path())])
+    )
     sub1.on_scan_job_succeeded.assert_not_called()
     sub2.on_scan_job_succeeded.assert_not_called()
     sub1.on_scan_job_failed.assert_called_once()

--- a/ci/src/dependencies/scanner/manager/bazel_rust_dependency_manager_test.py
+++ b/ci/src/dependencies/scanner/manager/bazel_rust_dependency_manager_test.py
@@ -161,7 +161,11 @@ that should be skipped
     executor = MockBazelCargoExecutor(expected_cargo_tree_deps=[dep], expected_cargo_tree_responses=[cargo_tree_output])
     bazel_test = BazelRustDependencyManager(executor=executor)
 
-    first_lvl_deps, projects = bazel_test._BazelRustDependencyManager__get_first_level_dependencies_and_projects_from_cargo(dep, pathlib.PurePath('/some/path/to'))
+    first_lvl_deps, projects = (
+        bazel_test._BazelRustDependencyManager__get_first_level_dependencies_and_projects_from_cargo(
+            dep, pathlib.PurePath("/some/path/to")
+        )
+    )
 
     assert len(first_lvl_deps) == 0
     assert len(projects) == 1
@@ -182,10 +186,16 @@ that should be skipped
     executor = MockBazelCargoExecutor(expected_cargo_tree_deps=[dep], expected_cargo_tree_responses=[cargo_tree_output])
     bazel_test = BazelRustDependencyManager(executor=executor)
 
-    first_lvl_deps, projects = bazel_test._BazelRustDependencyManager__get_first_level_dependencies_and_projects_from_cargo(dep, pathlib.PurePath('/path/to/project'))
+    first_lvl_deps, projects = (
+        bazel_test._BazelRustDependencyManager__get_first_level_dependencies_and_projects_from_cargo(
+            dep, pathlib.PurePath("/path/to/project")
+        )
+    )
 
     assert len(first_lvl_deps) == 1
-    assert first_lvl_deps[0] == Dependency(id="https://crates.io/crates/first-lvl-dep", name="first-lvl-dep", version="0")
+    assert first_lvl_deps[0] == Dependency(
+        id="https://crates.io/crates/first-lvl-dep", name="first-lvl-dep", version="0"
+    )
     assert len(projects) == 2
     projects.sort()
     assert projects[0] == "project/src/project1"
@@ -209,12 +219,18 @@ def test_parse_first_level_dependencies_and_projects_from_cargo_tree_two_deps_th
     executor = MockBazelCargoExecutor(expected_cargo_tree_deps=[dep], expected_cargo_tree_responses=[cargo_tree_output])
     bazel_test = BazelRustDependencyManager(executor=executor)
 
-    first_lvl_deps, projects = bazel_test._BazelRustDependencyManager__get_first_level_dependencies_and_projects_from_cargo(dep, pathlib.PurePath('/path/to/project'))
+    first_lvl_deps, projects = (
+        bazel_test._BazelRustDependencyManager__get_first_level_dependencies_and_projects_from_cargo(
+            dep, pathlib.PurePath("/path/to/project")
+        )
+    )
 
     assert len(first_lvl_deps) == 2
     first_lvl_deps = sorted(first_lvl_deps, key=lambda x: x.id)
     assert first_lvl_deps[0] == Dependency(id="first-lvl-dep", name="first-lvl-dep", version="1")
-    assert first_lvl_deps[1] == Dependency(id="https://crates.io/crates/first-lvl-dep", name="first-lvl-dep", version="0")
+    assert first_lvl_deps[1] == Dependency(
+        id="https://crates.io/crates/first-lvl-dep", name="first-lvl-dep", version="0"
+    )
     assert len(projects) == 3
     projects.sort()
     assert projects[0] == "project/src/project1"
@@ -223,22 +239,37 @@ def test_parse_first_level_dependencies_and_projects_from_cargo_tree_two_deps_th
 
 
 def test_get_findings_for_cargo_only_repo():
-    with open_test_file("test_data/cargo_audit_nns.json") as audit, open_test_file("test_data/cargo_tree_chrono.txt") as chrono, open_test_file("test_data/cargo_tree_time.txt") as time:
-        expected_first_vulnerable_dep = Dependency(id='https://crates.io/crates/chrono', name='chrono', version='0.4.19',
-                                                   fix_version_for_vulnerability={
-                                                       'https://rustsec.org/advisories/RUSTSEC-2020-0159': [
-                                                           '>=0.4.20']})
-        expected_second_vulnerable_dep = Dependency(id='https://crates.io/crates/time', name='time', version='0.1.45',
-                                                    fix_version_for_vulnerability={
-                                                        'https://rustsec.org/advisories/RUSTSEC-2020-0071': ['>=0.2.23',
-                                                                                                             '=0.2.0',
-                                                                                                             '=0.2.1',
-                                                                                                             '=0.2.2',
-                                                                                                             '=0.2.3',
-                                                                                                             '=0.2.4',
-                                                                                                             '=0.2.5',
-                                                                                                             '=0.2.6']})
-        executor = MockBazelCargoExecutor(expected_cargo_audit_output=json.load(audit), expected_cargo_tree_deps=[expected_first_vulnerable_dep, expected_second_vulnerable_dep], expected_cargo_tree_responses=[chrono.read(), time.read()])
+    with open_test_file("test_data/cargo_audit_nns.json") as audit, open_test_file(
+        "test_data/cargo_tree_chrono.txt"
+    ) as chrono, open_test_file("test_data/cargo_tree_time.txt") as time:
+        expected_first_vulnerable_dep = Dependency(
+            id="https://crates.io/crates/chrono",
+            name="chrono",
+            version="0.4.19",
+            fix_version_for_vulnerability={"https://rustsec.org/advisories/RUSTSEC-2020-0159": [">=0.4.20"]},
+        )
+        expected_second_vulnerable_dep = Dependency(
+            id="https://crates.io/crates/time",
+            name="time",
+            version="0.1.45",
+            fix_version_for_vulnerability={
+                "https://rustsec.org/advisories/RUSTSEC-2020-0071": [
+                    ">=0.2.23",
+                    "=0.2.0",
+                    "=0.2.1",
+                    "=0.2.2",
+                    "=0.2.3",
+                    "=0.2.4",
+                    "=0.2.5",
+                    "=0.2.6",
+                ]
+            },
+        )
+        executor = MockBazelCargoExecutor(
+            expected_cargo_audit_output=json.load(audit),
+            expected_cargo_tree_deps=[expected_first_vulnerable_dep, expected_second_vulnerable_dep],
+            expected_cargo_tree_responses=[chrono.read(), time.read()],
+        )
         bazel_test = BazelRustDependencyManager(executor=executor)
 
         findings = bazel_test.get_findings("nns-dapp", Project("nns-dapp", "nns-dapp"), None)
@@ -260,60 +291,101 @@ def test_get_findings_for_cargo_only_repo():
         # unique fields for first finding
         assert findings[0].vulnerable_dependency == expected_first_vulnerable_dep
         assert findings[0].vulnerabilities == [
-            Vulnerability(id='https://rustsec.org/advisories/RUSTSEC-2020-0159', name='RUSTSEC-2020-0159',
-                          description='Potential segfault in `localtime_r` invocations', score=-1)]
+            Vulnerability(
+                id="https://rustsec.org/advisories/RUSTSEC-2020-0159",
+                name="RUSTSEC-2020-0159",
+                description="Potential segfault in `localtime_r` invocations",
+                score=-1,
+            )
+        ]
         assert findings[0].first_level_dependencies == [
-            Dependency(id='cycles-minting-canister', name='cycles-minting-canister', version='0.8.0',
-                       fix_version_for_vulnerability={}),
-            Dependency(id='ic-nervous-system-common', name='ic-nervous-system-common', version='0.8.0',
-                       fix_version_for_vulnerability={}),
-            Dependency(id='ic-nervous-system-root', name='ic-nervous-system-root', version='0.1.0',
-                       fix_version_for_vulnerability={}),
-            Dependency(id='ic-nns-common', name='ic-nns-common', version='0.8.0',
-                       fix_version_for_vulnerability={}),
-            Dependency(id='ic-nns-governance', name='ic-nns-governance', version='0.8.0',
-                       fix_version_for_vulnerability={}),
-            Dependency(id='ic-sns-swap', name='ic-sns-swap', version='0.1.0',
-                       fix_version_for_vulnerability={}),
-            Dependency(id='ic-sns-wasm', name='ic-sns-wasm', version='1.0.0',
-                       fix_version_for_vulnerability={}),
-            Dependency(id='registry-canister', name='registry-canister', version='0.8.0',
-                       fix_version_for_vulnerability={})]
+            Dependency(
+                id="cycles-minting-canister",
+                name="cycles-minting-canister",
+                version="0.8.0",
+                fix_version_for_vulnerability={},
+            ),
+            Dependency(
+                id="ic-nervous-system-common",
+                name="ic-nervous-system-common",
+                version="0.8.0",
+                fix_version_for_vulnerability={},
+            ),
+            Dependency(
+                id="ic-nervous-system-root",
+                name="ic-nervous-system-root",
+                version="0.1.0",
+                fix_version_for_vulnerability={},
+            ),
+            Dependency(id="ic-nns-common", name="ic-nns-common", version="0.8.0", fix_version_for_vulnerability={}),
+            Dependency(
+                id="ic-nns-governance", name="ic-nns-governance", version="0.8.0", fix_version_for_vulnerability={}
+            ),
+            Dependency(id="ic-sns-swap", name="ic-sns-swap", version="0.1.0", fix_version_for_vulnerability={}),
+            Dependency(id="ic-sns-wasm", name="ic-sns-wasm", version="1.0.0", fix_version_for_vulnerability={}),
+            Dependency(
+                id="registry-canister", name="registry-canister", version="0.8.0", fix_version_for_vulnerability={}
+            ),
+        ]
         assert findings[0].score == -1
 
         # unique fields for second finding
         assert findings[1].vulnerable_dependency == expected_second_vulnerable_dep
         assert findings[1].vulnerabilities == [
-            Vulnerability(id='https://rustsec.org/advisories/RUSTSEC-2020-0071', name='RUSTSEC-2020-0071',
-                          description='Potential segfault in the time crate', score=6)]
+            Vulnerability(
+                id="https://rustsec.org/advisories/RUSTSEC-2020-0071",
+                name="RUSTSEC-2020-0071",
+                description="Potential segfault in the time crate",
+                score=6,
+            )
+        ]
         assert findings[1].first_level_dependencies == [
-            Dependency(id='cycles-minting-canister', name='cycles-minting-canister', version='0.8.0',
-                       fix_version_for_vulnerability={}),
-            Dependency(id='https://crates.io/crates/chrono', name='chrono', version='0.4.19',
-                       fix_version_for_vulnerability={}),
-            Dependency(id='ic-nervous-system-common', name='ic-nervous-system-common', version='0.8.0',
-                       fix_version_for_vulnerability={}),
-            Dependency(id='ic-nervous-system-root', name='ic-nervous-system-root', version='0.1.0',
-                       fix_version_for_vulnerability={}),
-            Dependency(id='ic-nns-common', name='ic-nns-common', version='0.8.0',
-                       fix_version_for_vulnerability={}),
-            Dependency(id='ic-nns-governance', name='ic-nns-governance', version='0.8.0',
-                       fix_version_for_vulnerability={}),
-            Dependency(id='ic-sns-swap', name='ic-sns-swap', version='0.1.0',
-                       fix_version_for_vulnerability={}),
-            Dependency(id='ic-sns-wasm', name='ic-sns-wasm', version='1.0.0',
-                       fix_version_for_vulnerability={}),
-            Dependency(id='registry-canister', name='registry-canister', version='0.8.0',
-                       fix_version_for_vulnerability={})]
+            Dependency(
+                id="cycles-minting-canister",
+                name="cycles-minting-canister",
+                version="0.8.0",
+                fix_version_for_vulnerability={},
+            ),
+            Dependency(
+                id="https://crates.io/crates/chrono", name="chrono", version="0.4.19", fix_version_for_vulnerability={}
+            ),
+            Dependency(
+                id="ic-nervous-system-common",
+                name="ic-nervous-system-common",
+                version="0.8.0",
+                fix_version_for_vulnerability={},
+            ),
+            Dependency(
+                id="ic-nervous-system-root",
+                name="ic-nervous-system-root",
+                version="0.1.0",
+                fix_version_for_vulnerability={},
+            ),
+            Dependency(id="ic-nns-common", name="ic-nns-common", version="0.8.0", fix_version_for_vulnerability={}),
+            Dependency(
+                id="ic-nns-governance", name="ic-nns-governance", version="0.8.0", fix_version_for_vulnerability={}
+            ),
+            Dependency(id="ic-sns-swap", name="ic-sns-swap", version="0.1.0", fix_version_for_vulnerability={}),
+            Dependency(id="ic-sns-wasm", name="ic-sns-wasm", version="1.0.0", fix_version_for_vulnerability={}),
+            Dependency(
+                id="registry-canister", name="registry-canister", version="0.8.0", fix_version_for_vulnerability={}
+            ),
+        ]
         assert findings[1].score == 6
 
 
 def test_get_findings_for_bazel_repo():
-    with open_test_file("test_data/cargo_audit_ic.json") as audit, open_test_file("test_data/bazel_queries_ic.json") as bazel:
+    with open_test_file("test_data/cargo_audit_ic.json") as audit, open_test_file(
+        "test_data/bazel_queries_ic.json"
+    ) as bazel:
         bazel_query_and_responses = json.load(bazel)
         expected_queries = bazel_query_and_responses["queries"]
         expected_responses = bazel_query_and_responses["responses"]
-        executor = MockBazelCargoExecutor(expected_cargo_audit_output=json.load(audit), expected_bazel_queries=expected_queries, expected_bazel_responses=expected_responses)
+        executor = MockBazelCargoExecutor(
+            expected_cargo_audit_output=json.load(audit),
+            expected_bazel_queries=expected_queries,
+            expected_bazel_responses=expected_responses,
+        )
         bazel_test = BazelRustDependencyManager(executor=executor)
 
         findings = bazel_test.get_findings("ic", Project("ic", __test_get_ic_path()), None)
@@ -330,127 +402,297 @@ def test_get_findings_for_bazel_repo():
             assert finding.more_info is None
 
             # unique fields for first finding
-            assert findings[0].vulnerable_dependency == Dependency(id='https://crates.io/crates/chrono', name='chrono',
-                                                                   version='0.4.19',
-                                                                   fix_version_for_vulnerability={
-                                                                       'https://rustsec.org/advisories/RUSTSEC-2020-0159': [
-                                                                           '>=0.4.20']})
+            assert findings[0].vulnerable_dependency == Dependency(
+                id="https://crates.io/crates/chrono",
+                name="chrono",
+                version="0.4.19",
+                fix_version_for_vulnerability={"https://rustsec.org/advisories/RUSTSEC-2020-0159": [">=0.4.20"]},
+            )
             assert findings[0].vulnerabilities == [
-                Vulnerability(id='https://rustsec.org/advisories/RUSTSEC-2020-0159', name='RUSTSEC-2020-0159',
-                              description='Potential segfault in `localtime_r` invocations', score=-1)]
+                Vulnerability(
+                    id="https://rustsec.org/advisories/RUSTSEC-2020-0159",
+                    name="RUSTSEC-2020-0159",
+                    description="Potential segfault in `localtime_r` invocations",
+                    score=-1,
+                )
+            ]
             assert findings[0].first_level_dependencies == [
-                Dependency(id='https://crates.io/crates/build-info', name='build-info', version='0.0.26',
-                           fix_version_for_vulnerability={}),
-                Dependency(id='https://crates.io/crates/build-info-build', name='build-info-build',
-                           version='0.0.26', fix_version_for_vulnerability={}),
-                Dependency(id='https://crates.io/crates/cddl', name='cddl', version='0.9.1',
-                           fix_version_for_vulnerability={}),
-                Dependency(id='https://crates.io/crates/cloudflare', name='cloudflare', version='0.9.1',
-                           fix_version_for_vulnerability={}),
-                Dependency(id='https://crates.io/crates/log4rs', name='log4rs', version='1.2.0',
-                           fix_version_for_vulnerability={}),
-                Dependency(id='https://crates.io/crates/prometheus-parse', name='prometheus-parse',
-                           version='0.2.4', fix_version_for_vulnerability={}),
-                Dependency(id='https://crates.io/crates/rsa', name='rsa', version='0.4.0',
-                           fix_version_for_vulnerability={}),
-                Dependency(id='https://crates.io/crates/simple_asn1', name='simple_asn1', version='0.5.4',
-                           fix_version_for_vulnerability={}),
-                Dependency(id='https://crates.io/crates/x509-parser', name='x509-parser', version='0.12.0',
-                           fix_version_for_vulnerability={})]
-            projects = ['/rs/backup', '/rs/canister_client/sender', '/rs/crypto', '/rs/crypto/ecdsa_secp256k1', '/rs/crypto/ecdsa_secp256r1', '/rs/crypto/internal/crypto_lib/basic_sig/cose',
-                                            '/rs/crypto/internal/crypto_lib/basic_sig/der_utils', '/rs/crypto/internal/crypto_lib/basic_sig/ecdsa_secp256k1', '/rs/crypto/internal/crypto_lib/basic_sig/ecdsa_secp256r1',
-                                            '/rs/crypto/internal/crypto_lib/basic_sig/ed25519', '/rs/crypto/internal/crypto_lib/basic_sig/iccsa', '/rs/crypto/internal/crypto_lib/basic_sig/rsa_pkcs1',
-                                            '/rs/crypto/internal/crypto_lib/threshold_sig/bls12_381/der_utils', '/rs/crypto/internal/crypto_service_provider', '/rs/crypto/node_key_validation',
-                                            '/rs/crypto/node_key_validation/tls_cert_validation', '/rs/crypto/utils/basic_sig', '/rs/elastic_common_schema', '/rs/monitoring/logger', '/rs/monitoring/onchain_observability/adapter',
-                                            '/rs/nervous_system/common', '/rs/nns/cmc', '/rs/nns/governance', '/rs/nns/gtc', '/rs/nns/handlers/root/impl', '/rs/nns/handlers/root/interface', '/rs/nns/sns-wasm',
-                                            '/rs/prep', '/rs/registry/canister',
-                                            '/rs/registry/nns_data_provider', '/rs/rosetta-api', '/rs/rosetta-api/icrc1/ledger/sm-tests', '/rs/rosetta-api/ledger_canister_blocks_synchronizer',
-                                            '/rs/rosetta-api/ledger_canister_blocks_synchronizer/test_utils', '/rs/scenario_tests', '/rs/sns/governance', '/rs/sns/root', '/rs/sns/swap', '/rs/tests', '/rs/types/types',
-                                            '/rs/validator',
-                                            '/rs/validator/http_request_test_utils']
+                Dependency(
+                    id="https://crates.io/crates/build-info",
+                    name="build-info",
+                    version="0.0.26",
+                    fix_version_for_vulnerability={},
+                ),
+                Dependency(
+                    id="https://crates.io/crates/build-info-build",
+                    name="build-info-build",
+                    version="0.0.26",
+                    fix_version_for_vulnerability={},
+                ),
+                Dependency(
+                    id="https://crates.io/crates/cddl", name="cddl", version="0.9.1", fix_version_for_vulnerability={}
+                ),
+                Dependency(
+                    id="https://crates.io/crates/cloudflare",
+                    name="cloudflare",
+                    version="0.9.1",
+                    fix_version_for_vulnerability={},
+                ),
+                Dependency(
+                    id="https://crates.io/crates/log4rs",
+                    name="log4rs",
+                    version="1.2.0",
+                    fix_version_for_vulnerability={},
+                ),
+                Dependency(
+                    id="https://crates.io/crates/prometheus-parse",
+                    name="prometheus-parse",
+                    version="0.2.4",
+                    fix_version_for_vulnerability={},
+                ),
+                Dependency(
+                    id="https://crates.io/crates/rsa", name="rsa", version="0.4.0", fix_version_for_vulnerability={}
+                ),
+                Dependency(
+                    id="https://crates.io/crates/simple_asn1",
+                    name="simple_asn1",
+                    version="0.5.4",
+                    fix_version_for_vulnerability={},
+                ),
+                Dependency(
+                    id="https://crates.io/crates/x509-parser",
+                    name="x509-parser",
+                    version="0.12.0",
+                    fix_version_for_vulnerability={},
+                ),
+            ]
+            projects = [
+                "/rs/backup",
+                "/rs/canister_client/sender",
+                "/rs/crypto",
+                "/rs/crypto/ecdsa_secp256k1",
+                "/rs/crypto/ecdsa_secp256r1",
+                "/rs/crypto/internal/crypto_lib/basic_sig/cose",
+                "/rs/crypto/internal/crypto_lib/basic_sig/der_utils",
+                "/rs/crypto/internal/crypto_lib/basic_sig/ecdsa_secp256k1",
+                "/rs/crypto/internal/crypto_lib/basic_sig/ecdsa_secp256r1",
+                "/rs/crypto/internal/crypto_lib/basic_sig/ed25519",
+                "/rs/crypto/internal/crypto_lib/basic_sig/iccsa",
+                "/rs/crypto/internal/crypto_lib/basic_sig/rsa_pkcs1",
+                "/rs/crypto/internal/crypto_lib/threshold_sig/bls12_381/der_utils",
+                "/rs/crypto/internal/crypto_service_provider",
+                "/rs/crypto/node_key_validation",
+                "/rs/crypto/node_key_validation/tls_cert_validation",
+                "/rs/crypto/utils/basic_sig",
+                "/rs/elastic_common_schema",
+                "/rs/monitoring/logger",
+                "/rs/monitoring/onchain_observability/adapter",
+                "/rs/nervous_system/common",
+                "/rs/nns/cmc",
+                "/rs/nns/governance",
+                "/rs/nns/gtc",
+                "/rs/nns/handlers/root/impl",
+                "/rs/nns/handlers/root/interface",
+                "/rs/nns/sns-wasm",
+                "/rs/prep",
+                "/rs/registry/canister",
+                "/rs/registry/nns_data_provider",
+                "/rs/rosetta-api",
+                "/rs/rosetta-api/icrc1/ledger/sm-tests",
+                "/rs/rosetta-api/ledger_canister_blocks_synchronizer",
+                "/rs/rosetta-api/ledger_canister_blocks_synchronizer/test_utils",
+                "/rs/scenario_tests",
+                "/rs/sns/governance",
+                "/rs/sns/root",
+                "/rs/sns/swap",
+                "/rs/tests",
+                "/rs/types/types",
+                "/rs/validator",
+                "/rs/validator/http_request_test_utils",
+            ]
 
             assert len(projects) == len(findings[0].projects)
 
             for project, finding_project in zip(projects, findings[0].projects):
-                assert  __test_get_ic_path() + project == finding_project
+                assert __test_get_ic_path() + project == finding_project
             assert findings[0].score == -1
 
             # unique fields for second finding
-            assert findings[1].vulnerable_dependency == Dependency(id='https://crates.io/crates/rocksdb', name='rocksdb',
-                                                                   version='0.15.0', fix_version_for_vulnerability={
-                    'https://rustsec.org/advisories/RUSTSEC-2022-0046': ['>=0.19.0']})
+            assert findings[1].vulnerable_dependency == Dependency(
+                id="https://crates.io/crates/rocksdb",
+                name="rocksdb",
+                version="0.15.0",
+                fix_version_for_vulnerability={"https://rustsec.org/advisories/RUSTSEC-2022-0046": [">=0.19.0"]},
+            )
             assert findings[1].vulnerabilities == [
-                Vulnerability(id='https://rustsec.org/advisories/RUSTSEC-2022-0046', name='RUSTSEC-2022-0046',
-                              description='Out-of-bounds read when opening multiple column families with TTL',
-                              score=-1)]
+                Vulnerability(
+                    id="https://rustsec.org/advisories/RUSTSEC-2022-0046",
+                    name="RUSTSEC-2022-0046",
+                    description="Out-of-bounds read when opening multiple column families with TTL",
+                    score=-1,
+                )
+            ]
             assert findings[1].first_level_dependencies == []
-            assert findings[1].projects == [__test_get_ic_path() + '/rs/artifact_pool']
+            assert findings[1].projects == [__test_get_ic_path() + "/rs/artifact_pool"]
             assert findings[1].score == -1
 
             # unique fields for third finding
-            assert findings[2].vulnerable_dependency == Dependency(id='https://crates.io/crates/time', name='time',
-                                                                   version='0.1.45',
-                                                                   fix_version_for_vulnerability={
-                                                                       'https://rustsec.org/advisories/RUSTSEC-2020-0071': [
-                                                                           '>=0.2.23',
-                                                                           '=0.2.0',
-                                                                           '=0.2.1',
-                                                                           '=0.2.2',
-                                                                           '=0.2.3',
-                                                                           '=0.2.4',
-                                                                           '=0.2.5',
-                                                                           '=0.2.6']})
+            assert findings[2].vulnerable_dependency == Dependency(
+                id="https://crates.io/crates/time",
+                name="time",
+                version="0.1.45",
+                fix_version_for_vulnerability={
+                    "https://rustsec.org/advisories/RUSTSEC-2020-0071": [
+                        ">=0.2.23",
+                        "=0.2.0",
+                        "=0.2.1",
+                        "=0.2.2",
+                        "=0.2.3",
+                        "=0.2.4",
+                        "=0.2.5",
+                        "=0.2.6",
+                    ]
+                },
+            )
             assert findings[2].vulnerabilities == [
-                Vulnerability(id='https://rustsec.org/advisories/RUSTSEC-2020-0071', name='RUSTSEC-2020-0071',
-                              description='Potential segfault in the time crate', score=6)]
+                Vulnerability(
+                    id="https://rustsec.org/advisories/RUSTSEC-2020-0071",
+                    name="RUSTSEC-2020-0071",
+                    description="Potential segfault in the time crate",
+                    score=6,
+                )
+            ]
             assert findings[2].first_level_dependencies == [
-                Dependency(id='https://crates.io/crates/build-info', name='build-info', version='0.0.26',
-                           fix_version_for_vulnerability={}),
-                Dependency(id='https://crates.io/crates/build-info-build', name='build-info-build',
-                           version='0.0.26', fix_version_for_vulnerability={}),
-                Dependency(id='https://crates.io/crates/cddl', name='cddl', version='0.9.1',
-                           fix_version_for_vulnerability={}),
-                Dependency(id='https://crates.io/crates/chrono', name='chrono', version='0.4.19',
-                           fix_version_for_vulnerability={}),
-                Dependency(id='https://crates.io/crates/cloudflare', name='cloudflare', version='0.9.1',
-                           fix_version_for_vulnerability={}),
-                Dependency(id='https://crates.io/crates/log4rs', name='log4rs', version='1.2.0',
-                           fix_version_for_vulnerability={}),
-                Dependency(id='https://crates.io/crates/prometheus-parse', name='prometheus-parse',
-                           version='0.2.4', fix_version_for_vulnerability={}),
-                Dependency(id='https://crates.io/crates/rsa', name='rsa', version='0.4.0',
-                           fix_version_for_vulnerability={}),
-                Dependency(id='https://crates.io/crates/simple_asn1', name='simple_asn1', version='0.5.4',
-                           fix_version_for_vulnerability={}),
-                Dependency(id='https://crates.io/crates/thread_profiler', name='thread_profiler', version='0.3.0',
-                           fix_version_for_vulnerability={}),
-                Dependency(id='https://crates.io/crates/x509-parser', name='x509-parser', version='0.12.0',
-                           fix_version_for_vulnerability={})]
-            projects_2 = ['/rs/backup', '/rs/canister_client/sender', '/rs/crypto', '/rs/crypto/ecdsa_secp256k1', '/rs/crypto/ecdsa_secp256r1', '/rs/crypto/internal/crypto_lib/basic_sig/cose',
-                                            '/rs/crypto/internal/crypto_lib/basic_sig/der_utils', '/rs/crypto/internal/crypto_lib/basic_sig/ecdsa_secp256k1', '/rs/crypto/internal/crypto_lib/basic_sig/ecdsa_secp256r1',
-                                            '/rs/crypto/internal/crypto_lib/basic_sig/ed25519', '/rs/crypto/internal/crypto_lib/basic_sig/iccsa', '/rs/crypto/internal/crypto_lib/basic_sig/rsa_pkcs1',
-                                            '/rs/crypto/internal/crypto_lib/threshold_sig/bls12_381/der_utils', '/rs/crypto/internal/crypto_service_provider', '/rs/crypto/node_key_validation',
-                                            '/rs/crypto/node_key_validation/tls_cert_validation', '/rs/crypto/utils/basic_sig', '/rs/elastic_common_schema', '/rs/monitoring/logger', '/rs/monitoring/onchain_observability/adapter',
-                                            '/rs/nervous_system/common', '/rs/nns/cmc', '/rs/nns/governance', '/rs/nns/gtc', '/rs/nns/handlers/root/impl', '/rs/nns/handlers/root/interface', '/rs/nns/sns-wasm',
-                                            '/rs/prep', '/rs/registry/canister', '/rs/registry/nns_data_provider', '/rs/replica', '/rs/rosetta-api', '/rs/rosetta-api/icrc1/ledger/sm-tests',
-                                            '/rs/rosetta-api/ledger_canister_blocks_synchronizer', '/rs/rosetta-api/ledger_canister_blocks_synchronizer/test_utils', '/rs/scenario_tests', '/rs/sns/governance', '/rs/sns/root',
-                                            '/rs/sns/swap', '/rs/tests', '/rs/types/types', '/rs/validator', '/rs/validator/http_request_test_utils']
+                Dependency(
+                    id="https://crates.io/crates/build-info",
+                    name="build-info",
+                    version="0.0.26",
+                    fix_version_for_vulnerability={},
+                ),
+                Dependency(
+                    id="https://crates.io/crates/build-info-build",
+                    name="build-info-build",
+                    version="0.0.26",
+                    fix_version_for_vulnerability={},
+                ),
+                Dependency(
+                    id="https://crates.io/crates/cddl", name="cddl", version="0.9.1", fix_version_for_vulnerability={}
+                ),
+                Dependency(
+                    id="https://crates.io/crates/chrono",
+                    name="chrono",
+                    version="0.4.19",
+                    fix_version_for_vulnerability={},
+                ),
+                Dependency(
+                    id="https://crates.io/crates/cloudflare",
+                    name="cloudflare",
+                    version="0.9.1",
+                    fix_version_for_vulnerability={},
+                ),
+                Dependency(
+                    id="https://crates.io/crates/log4rs",
+                    name="log4rs",
+                    version="1.2.0",
+                    fix_version_for_vulnerability={},
+                ),
+                Dependency(
+                    id="https://crates.io/crates/prometheus-parse",
+                    name="prometheus-parse",
+                    version="0.2.4",
+                    fix_version_for_vulnerability={},
+                ),
+                Dependency(
+                    id="https://crates.io/crates/rsa", name="rsa", version="0.4.0", fix_version_for_vulnerability={}
+                ),
+                Dependency(
+                    id="https://crates.io/crates/simple_asn1",
+                    name="simple_asn1",
+                    version="0.5.4",
+                    fix_version_for_vulnerability={},
+                ),
+                Dependency(
+                    id="https://crates.io/crates/thread_profiler",
+                    name="thread_profiler",
+                    version="0.3.0",
+                    fix_version_for_vulnerability={},
+                ),
+                Dependency(
+                    id="https://crates.io/crates/x509-parser",
+                    name="x509-parser",
+                    version="0.12.0",
+                    fix_version_for_vulnerability={},
+                ),
+            ]
+            projects_2 = [
+                "/rs/backup",
+                "/rs/canister_client/sender",
+                "/rs/crypto",
+                "/rs/crypto/ecdsa_secp256k1",
+                "/rs/crypto/ecdsa_secp256r1",
+                "/rs/crypto/internal/crypto_lib/basic_sig/cose",
+                "/rs/crypto/internal/crypto_lib/basic_sig/der_utils",
+                "/rs/crypto/internal/crypto_lib/basic_sig/ecdsa_secp256k1",
+                "/rs/crypto/internal/crypto_lib/basic_sig/ecdsa_secp256r1",
+                "/rs/crypto/internal/crypto_lib/basic_sig/ed25519",
+                "/rs/crypto/internal/crypto_lib/basic_sig/iccsa",
+                "/rs/crypto/internal/crypto_lib/basic_sig/rsa_pkcs1",
+                "/rs/crypto/internal/crypto_lib/threshold_sig/bls12_381/der_utils",
+                "/rs/crypto/internal/crypto_service_provider",
+                "/rs/crypto/node_key_validation",
+                "/rs/crypto/node_key_validation/tls_cert_validation",
+                "/rs/crypto/utils/basic_sig",
+                "/rs/elastic_common_schema",
+                "/rs/monitoring/logger",
+                "/rs/monitoring/onchain_observability/adapter",
+                "/rs/nervous_system/common",
+                "/rs/nns/cmc",
+                "/rs/nns/governance",
+                "/rs/nns/gtc",
+                "/rs/nns/handlers/root/impl",
+                "/rs/nns/handlers/root/interface",
+                "/rs/nns/sns-wasm",
+                "/rs/prep",
+                "/rs/registry/canister",
+                "/rs/registry/nns_data_provider",
+                "/rs/replica",
+                "/rs/rosetta-api",
+                "/rs/rosetta-api/icrc1/ledger/sm-tests",
+                "/rs/rosetta-api/ledger_canister_blocks_synchronizer",
+                "/rs/rosetta-api/ledger_canister_blocks_synchronizer/test_utils",
+                "/rs/scenario_tests",
+                "/rs/sns/governance",
+                "/rs/sns/root",
+                "/rs/sns/swap",
+                "/rs/tests",
+                "/rs/types/types",
+                "/rs/validator",
+                "/rs/validator/http_request_test_utils",
+            ]
             assert len(projects_2) == len(findings[2].projects)
             for project, finding_project in zip(projects_2, findings[2].projects):
-                assert  __test_get_ic_path() + project == finding_project
+                assert __test_get_ic_path() + project == finding_project
             assert findings[2].score == 6
 
 
 class MockBazelCargoExecutor(BazelCargoExecutor):
-
-    def __init__(self, expected_cargo_audit_output: typing.Dict = (), expected_bazel_queries: typing.List[str] = (), expected_bazel_responses: typing.List[str] = (), expected_cargo_tree_deps: typing.List[Dependency] = (),
-                 expected_cargo_tree_responses: typing.List[str] = ()):
+    def __init__(
+        self,
+        expected_cargo_audit_output: typing.Dict = (),
+        expected_bazel_queries: typing.List[str] = (),
+        expected_bazel_responses: typing.List[str] = (),
+        expected_cargo_tree_deps: typing.List[Dependency] = (),
+        expected_cargo_tree_responses: typing.List[str] = (),
+    ):
         self.cargo_audit = expected_cargo_audit_output
 
         assert len(expected_bazel_queries) == len(expected_bazel_responses)
         self.bazel = {}
         for i in range(len(expected_bazel_queries)):
-            assert expected_bazel_queries[i] not in self.bazel or self.bazel[expected_bazel_queries[i]] == expected_bazel_responses[i]
+            assert (
+                expected_bazel_queries[i] not in self.bazel
+                or self.bazel[expected_bazel_queries[i]] == expected_bazel_responses[i]
+            )
             self.bazel[expected_bazel_queries[i]] = expected_bazel_responses[i]
 
         assert len(expected_cargo_tree_deps) == len(expected_cargo_tree_responses)
@@ -471,8 +713,9 @@ class MockBazelCargoExecutor(BazelCargoExecutor):
     def get_cargo_audit_output(self, path: pathlib.Path, cargo_home=None) -> typing.Dict:
         return self.cargo_audit
 
-    def get_cargo_tree_output_for_vulnerable_dependency(self, vulnerable_dependency: Dependency, path: pathlib.Path,
-                                                        cargo_home=None) -> str:
+    def get_cargo_tree_output_for_vulnerable_dependency(
+        self, vulnerable_dependency: Dependency, path: pathlib.Path, cargo_home=None
+    ) -> str:
         dep_key = self.__dependency_key(vulnerable_dependency)
         assert dep_key in self.cargo_tree
         return self.cargo_tree[dep_key]

--- a/ci/src/dependencies/scanner/manager/bazel_trivy_dependency_manager.py
+++ b/ci/src/dependencies/scanner/manager/bazel_trivy_dependency_manager.py
@@ -124,7 +124,6 @@ class TrivyResultParser(abc.ABC):
 
 
 class OSPackageTrivyResultParser(TrivyResultParser):
-
     def get_parser_id(self) -> str:
         return "OSP"
 
@@ -183,7 +182,6 @@ class OSPackageTrivyResultParser(TrivyResultParser):
 
 
 class BinaryTrivyResultParser(TrivyResultParser):
-
     def get_parser_id(self) -> str:
         return "BIN"
 
@@ -208,7 +206,9 @@ class BinaryTrivyResultParser(TrivyResultParser):
         binary_name = binary_id.split("/")[-1] if "/" in binary_id and not binary_id.endswith("/") else binary_id
         if binary_id not in file_to_hash:
             raise RuntimeError(f"binary {binary_id} not found in file hash list in repo {repository} project {project}")
-        vulnerable_dependency = Dependency(id=self.sanitize_dependency_id(binary_id), name=binary_name, version=file_to_hash[binary_id])
+        vulnerable_dependency = Dependency(
+            id=self.sanitize_dependency_id(binary_id), name=binary_name, version=file_to_hash[binary_id]
+        )
         all_vulnerability_ids = set()
         max_score = 0
         for _, vulnerabilities in vulnerabilities_by_vuln_dep:
@@ -243,7 +243,6 @@ class BinaryTrivyResultParser(TrivyResultParser):
 
 
 class SecretTrivyResultParser(TrivyResultParser):
-
     def get_parser_id(self) -> str:
         return "SEC"
 
@@ -262,7 +261,9 @@ class SecretTrivyResultParser(TrivyResultParser):
         """For secrets one finding is created"""
         secret_id: str = trivy_data["Results"][result_index]["Target"]
         secret_name = secret_id.split("/")[-1] if "/" in secret_id and not secret_id.endswith("/") else secret_id
-        vulnerable_dependency = Dependency(id=self.sanitize_dependency_id(secret_id), name=secret_name, version="current")
+        vulnerable_dependency = Dependency(
+            id=self.sanitize_dependency_id(secret_id), name=secret_name, version="current"
+        )
         vulnerabilities = []
         for secret in trivy_data["Results"][result_index]["Secrets"]:
             vulnerabilities.append(
@@ -313,7 +314,11 @@ class TrivyExecutor:
 class BazelTrivyContainer(DependencyManager):
     """Helper for Trivy-related functions."""
 
-    def __init__(self, executor: TrivyExecutor = TrivyExecutor(), app_owner_msg_subscriber: AppOwnerMsgSubscriber = ConsoleLoggerAppOwnerMsgSubscriber()):
+    def __init__(
+        self,
+        executor: TrivyExecutor = TrivyExecutor(),
+        app_owner_msg_subscriber: AppOwnerMsgSubscriber = ConsoleLoggerAppOwnerMsgSubscriber(),
+    ):
         super().__init__()
         self.parsers = (OSPackageTrivyResultParser(), BinaryTrivyResultParser(), SecretTrivyResultParser())
         self.executor = executor

--- a/ci/src/dependencies/scanner/manager/bazel_trivy_dependency_manager_test.py
+++ b/ci/src/dependencies/scanner/manager/bazel_trivy_dependency_manager_test.py
@@ -116,6 +116,7 @@ def test_return_os_finding():
     assert res[1].score == 7
     assert res[1].more_info is None
 
+
 def test_return_binary_finding():
     binary_finding = {
         "Results": [
@@ -143,9 +144,10 @@ def test_return_binary_finding():
         ]
     }
     executor = Mock()
-    executor.run_trivy_and_parse_data.return_value = binary_finding, {
-        "usr/local/bin/node_exporter": "44f586eee11a2e07fb86afe6d3698925fe4388b7f55abfb29159e7797c87b095"
-    }
+    executor.run_trivy_and_parse_data.return_value = (
+        binary_finding,
+        {"usr/local/bin/node_exporter": "44f586eee11a2e07fb86afe6d3698925fe4388b7f55abfb29159e7797c87b095"},
+    )
     manager = BazelTrivyContainer(executor=executor)
 
     res = manager.get_findings("repo", Project(name="proj", path="/some/path"), None)

--- a/ci/src/dependencies/scanner/manager/npm_dependency_manager.py
+++ b/ci/src/dependencies/scanner/manager/npm_dependency_manager.py
@@ -56,13 +56,15 @@ class NPMDependencyManager(DependencyManager):
             # engines not specified in package.json. Using default should be fine
             return True
 
-        supported_engine_versions = str(data['engines']['node'])
+        supported_engine_versions = str(data["engines"]["node"])
         if satisfies(engine_version, supported_engine_versions, loose=True):
             # engine version is supported
             return True
 
         # We can't run the scan at this point
-        logging.error(f"Engine version is not supported for {repository_name}, Current: {engine_version}; Accepted: {supported_engine_versions}")
+        logging.error(
+            f"Engine version is not supported for {repository_name}, Current: {engine_version}; Accepted: {supported_engine_versions}"
+        )
         return False
 
     @staticmethod
@@ -194,7 +196,9 @@ class NPMDependencyManager(DependencyManager):
         can_run_scan = self.__npm_check_engine(repository_name, engine_version, path)
 
         if not can_run_scan:
-            raise RuntimeError(f"Dependency scan for {repository_name} can't be executed due to engine version mismatch")
+            raise RuntimeError(
+                f"Dependency scan for {repository_name} can't be executed due to engine version mismatch"
+            )
 
         npm_audit_output = self.__npm_audit_output(engine_version, path)
 

--- a/ci/src/dependencies/scanner/manager/npm_dependency_manager_test.py
+++ b/ci/src/dependencies/scanner/manager/npm_dependency_manager_test.py
@@ -26,9 +26,11 @@ def test_clone_repository_from_url(process_executor_mock, npm_test):
     npm_test._NPMDependencyManager__clone_repository_from_url(url, path)
     process_executor_mock.assert_called_once_with("git clone --depth=1 https://localhost", resolved_path, {})
 
+
 def test_npm_check_engine_no_package_json(npm_test):
     path = pathlib.Path()
     assert npm_test._NPMDependencyManager__npm_check_engine("ic", DEFAULT_NODE_VERSION, path) is False
+
 
 @patch("pathlib.Path.exists", return_value=True)
 @patch("builtins.open", new_callable=mock_open, read_data='{"engines":"{}"}')
@@ -36,17 +38,20 @@ def test_npm_check_engine_no_engine_version(_fopen_mock, _path_patch, npm_test):
     path = pathlib.Path()
     assert npm_test._NPMDependencyManager__npm_check_engine("ic", DEFAULT_NODE_VERSION, path) is True
 
+
 @patch("pathlib.Path.exists", return_value=True)
 @patch("builtins.open", new_callable=mock_open, read_data='{"engines":{"node":"<19"}}')
 def test_npm_check_engine_not_compatible(_fopen_mock, _path_patch, npm_test):
     path = pathlib.Path()
     assert npm_test._NPMDependencyManager__npm_check_engine("ic", DEFAULT_NODE_VERSION, path) is False
 
+
 @patch("pathlib.Path.exists", return_value=True)
 @patch("builtins.open", new_callable=mock_open, read_data='{"engines":{"node":">=19"}}')
 def test_npm_check_engine_compatible(_fopen_mock, _path_patch, npm_test):
     path = pathlib.Path()
     assert npm_test._NPMDependencyManager__npm_check_engine("ic", DEFAULT_NODE_VERSION, path) is True
+
 
 @patch("pathlib.Path.exists", return_value=True)
 @patch("builtins.open", new_callable=mock_open, read_data='{"engines":{"node":"<19"}}')
@@ -56,6 +61,7 @@ def test_npm_check_engine_not_compatible_throws_runtime_error(_fopen_mock, _path
         assert npm_test._NPMDependencyManager__npm_check_engine("ic", DEFAULT_NODE_VERSION, path) is False
         _ = npm_test.get_findings("ic", Project("ic", __test_get_ic_path()), DEFAULT_NODE_VERSION)
         assert "Dependency scan for ic can't be executed due to engine version mismatch" in str(e.value)
+
 
 @patch("scanner.process_executor.ProcessExecutor.execute_command", return_value="{'key':'value'}")
 @patch("json.loads")

--- a/ci/src/dependencies/scanner/process_executor.py
+++ b/ci/src/dependencies/scanner/process_executor.py
@@ -11,7 +11,13 @@ class ProcessExecutor:
         self.command = command
 
     @staticmethod
-    def execute_command(command: str, cwd: Path, environment: typing.Dict[str, str], ignore_return_code_if_stdout_is_set: bool = False, log_error_on_fail = True) -> str:
+    def execute_command(
+        command: str,
+        cwd: Path,
+        environment: typing.Dict[str, str],
+        ignore_return_code_if_stdout_is_set: bool = False,
+        log_error_on_fail=True,
+    ) -> str:
         environ = dict(os.environ)
         environ.update(environment)
         logging.info("Executing : " + command)

--- a/ic-os/components/conformance_tests/check_file_references.py
+++ b/ic-os/components/conformance_tests/check_file_references.py
@@ -34,7 +34,6 @@ def check_paths_in_source(source: str, partition_img_path: str) -> [str]:
         partition_img_path: Path to the extracted partition file (partition.img)
 
     Returns a list of errors or empty list on no error.
-
     """
 
     print(f"Checking component {source}")

--- a/ic-os/components/conformance_tests/check_file_references.py
+++ b/ic-os/components/conformance_tests/check_file_references.py
@@ -34,6 +34,7 @@ def check_paths_in_source(source: str, partition_img_path: str) -> [str]:
         partition_img_path: Path to the extracted partition file (partition.img)
 
     Returns a list of errors or empty list on no error.
+
     """
 
     print(f"Checking component {source}")

--- a/pre-commit/ruff.bzl
+++ b/pre-commit/ruff.bzl
@@ -7,14 +7,14 @@ package(default_visibility = ["//visibility:public"])
 exports_files(["ruff"])
 """
 
-VERSION = "0.0.260"
+VERSION = "0.6.8"
 SHA256 = {
-    "aarch64-apple-darwin": "4e045df5e55f1e23b34910865fe66c8e9d4ea98dbdb5320fc8ff09b8c337d69e",
-    "x86_64-apple-darwin": "3b251413bd5dfa60997489b33024b5f596cb3781f5cf3763529fb24cd97059c0",
-    "x86_64-unknown-linux-gnu": "abb106ee7d1434faa733e6dd442b1d306fa32e0840fde24fbbf96c2289968c63",
+    "aarch64-apple-darwin": "e554d55281391138e44b30ccd38c666388e4aeb05417c9ffb98a6cbb014aef0d",
+    "x86_64-apple-darwin": "44039cea2aed4787cedcda0c35e5b352530d6ca2178f39c8bd4ff63526c43aef",
+    "x86_64-unknown-linux-gnu": "7edce7075bf6d43b1ef2a9383b76a43310bbf5d70fa4471330fd5aaf655192b0",
 }
 
-URL = "https://github.com/charliermarsh/ruff/releases/download/v{version}/ruff-{platform}.tar.gz"
+URL = "https://github.com/astral-sh/ruff/releases/download/{version}/ruff-{platform}.tar.gz"
 
 def _ruff_impl(repository_ctx):
     os_arch = repository_ctx.os.arch
@@ -39,7 +39,7 @@ def _ruff_impl(repository_ctx):
         fail("Unsupported platform: '" + platform + "'")
 
     repository_ctx.report_progress("Fetching " + repository_ctx.name)
-    repository_ctx.download_and_extract(url = URL.format(version = VERSION, platform = platform), sha256 = SHA256[platform])
+    repository_ctx.download_and_extract(url = URL.format(version = VERSION, platform = platform), sha256 = SHA256[platform], stripPrefix = "ruff-{platform}".format(platform = platform))
     repository_ctx.file("BUILD.bazel", RUFF_BUILD, executable = True)
 
 _ruff = repository_rule(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,15 +1,42 @@
 [tool.ruff]
-unfixable = []
 
-select = [
-    "C9", # Mccabe
-    "F", # Pyflakes
-    "I", # Isort
-    "N", # Pep-8 naming
-    "D", # Pydocstyle
-    "E", # Pydocstyle error
-    "W", # Pydocstyle warning
+# Exclude a variety of commonly ignored directories.
+exclude = [
+    ".bzr",
+    ".direnv",
+    ".eggs",
+    ".git",
+    ".hg",
+    ".mypy_cache",
+    ".nox",
+    ".pants.d",
+    ".pytype",
+    ".ruff_cache",
+    ".svn",
+    ".tox",
+    ".venv",
+    "__pypackages__",
+    "_build",
+    "buck-out",
+    "build",
+    "dist",
+    "node_modules",
+    "venv",
+    "env",
 ]
+
+line-length = 120
+
+target-version = "py37"
+
+[tool.isort]
+profile = "black"
+remove_redundant_aliases = true
+
+[tool.ruff.lint]
+
+# Allow unused variables when underscore-prefixed.
+dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 
 # Allow autofix for all enabled rules (when `--fix`) is provided.
 fixable = [
@@ -59,37 +86,17 @@ fixable = [
     "YTT",
 ]
 
-# Exclude a variety of commonly ignored directories.
-exclude = [
-    ".bzr",
-    ".direnv",
-    ".eggs",
-    ".git",
-    ".hg",
-    ".mypy_cache",
-    ".nox",
-    ".pants.d",
-    ".pytype",
-    ".ruff_cache",
-    ".svn",
-    ".tox",
-    ".venv",
-    "__pypackages__",
-    "_build",
-    "buck-out",
-    "build",
-    "dist",
-    "node_modules",
-    "venv",
-    "env",
+unfixable = []
+
+select = [
+    "C9", # Mccabe
+    "F", # Pyflakes
+    "I", # Isort
+    "N", # Pep-8 naming
+    "D", # Pydocstyle
+    "E", # Pydocstyle error
+    "W", # Pydocstyle warning
 ]
-
-line-length = 120
-
-# Allow unused variables when underscore-prefixed.
-dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
-
-target-version = "py37"
 
 ignore = [
     "C901",
@@ -125,10 +132,6 @@ ignore = [
     "N999",
 ]
 
-[tool.ruff.mccabe]
+[tool.ruff.lint.mccabe]
 # Unlike Flake8, default to a complexity level of 10.
 max-complexity = 10
-
-[tool.isort]
-profile = "black"
-remove_redundant_aliases = true


### PR DESCRIPTION
The code in `ci/src/dependencies` is not formatted properly. I used to rely on `bazel run //:ruff-format` but TIL it only does the lint fixes and doesn't do formatting. 

In this PR,

- Update ruff to the latest version
- Adapt warnings in pyproject.toml
- Format files in  `ci/src/dependencies` with `bazel run @ruff//:ruff format ci/src/dependencies`
- An empty line lint fix in `ic-os/components/conformance_tests/check_file_references.py`