### PR TITLE
fix(IDX): update dependency tests for ic-private

### DIFF
--- a/ci/src/dependencies/model/ic.py
+++ b/ci/src/dependencies/model/ic.py
@@ -23,7 +23,7 @@ def is_env_for_periodic_job() -> bool:
 
 def get_ic_repo_for_rust() -> Repository:
     repo_name = REPO_NAME.replace("dfinity/", "")
-    return Repository("ic", f"https://github.com/dfinity/{repo_name}", [Project(name="ic", path=repo_name, owner_by_path={f"{repo_name}/rs/crypto": [Team.CRYPTO_TEAM], f"{repo_name}/rs/validator": [Team.CRYPTO_TEAM], f"{repo_name}/rs/canonical_state": [Team.CRYPTO_TEAM]})])
+    return Repository(repo_name, f"https://github.com/dfinity/{repo_name}", [Project(name=repo_name, path=repo_name, owner_by_path={f"{repo_name}/rs/crypto": [Team.CRYPTO_TEAM], f"{repo_name}/rs/validator": [Team.CRYPTO_TEAM], f"{repo_name}/rs/canonical_state": [Team.CRYPTO_TEAM]})])
 
 
 def get_ic_repo_merge_request_base_url() -> str:
@@ -33,6 +33,5 @@ def get_ic_repo_merge_request_base_url() -> str:
 def get_ic_repo_ci_pipeline_base_url() -> str:
     return f"https://github.com/{REPO_NAME}/actions/runs/"
 
-
-def __test_get_ic_path():
+def get_current_repo():
     return REPO_NAME.replace("dfinity/", "")

--- a/ci/src/dependencies/scanner/dependency_scanner_test.py
+++ b/ci/src/dependencies/scanner/dependency_scanner_test.py
@@ -774,7 +774,7 @@ def test_on_release_scan_findings_have_jira_findings_with_high_risk_but_no_due_d
 
     with pytest.raises(SystemExit) as e:
         scanner_job.do_release_scan(
-            Repository(Repository(REPOSITORY, IC_URL, [Project(REPOSITORY, REPOSITORY)])
+            Repository(REPOSITORY, IC_URL, [Project(REPOSITORY, REPOSITORY)])
         )
 
     assert e.type is SystemExit

--- a/ci/src/dependencies/scanner/dependency_scanner_test.py
+++ b/ci/src/dependencies/scanner/dependency_scanner_test.py
@@ -618,7 +618,7 @@ def test_on_release_scan_no_findings(jira_lib_mock):
     fake_bazel.get_findings.return_value = []
     scanner_job = DependencyScanner(fake_bazel, jira_lib_mock, [sub1, sub2])
 
-    scanner_job.do_merge_request_scan(
+    scanner_job.do_release_scan(
         Repository(REPOSITORY, IC_URL, [Project(REPOSITORY, REPOSITORY)])
     )
     sub1.on_scan_job_succeeded.assert_called_once()
@@ -666,7 +666,7 @@ def test_on_release_scan_findings_have_jira_findings_with_no_risk(jira_lib_mock)
     scanner_job = DependencyScanner(fake_bazel, jira_lib_mock, [sub1, sub2])
 
     with pytest.raises(SystemExit) as e:
-      scanner_job.do_merge_request_scan(
+      scanner_job.do_release_scan(
           Repository(REPOSITORY, IC_URL, [Project(REPOSITORY, REPOSITORY)])
       )
 

--- a/ci/src/dependencies/scanner/dependency_scanner_test.py
+++ b/ci/src/dependencies/scanner/dependency_scanner_test.py
@@ -159,7 +159,7 @@ def test_on_periodic_job_one_finding_in_jira(jira_lib_mock):
     # one finding, present in JIRA
     scanner = "BAZEL_RUST"
     jira_finding = Finding(
-        repository=repository.name,
+        repository=REPOSITORY,
         scanner=scanner,
         vulnerable_dependency=Dependency("VDID1", "chrono", "1.0", {"VID1": ["1.1", "2.0"]}),
         vulnerabilities=[Vulnerability("VID1", "CVE-123", "huuughe vuln", 100)],
@@ -182,7 +182,7 @@ def test_on_periodic_job_one_finding_in_jira(jira_lib_mock):
         Repository(
             REPOSITORY,
             IC_URL,
-            [Project(name=REPOSITORY, path=_REPOSITORY, owner_by_path={"bear": [Team.NODE_TEAM]})],
+            [Project(name=REPOSITORY, path=REPOSITORY, owner_by_path={"bear": [Team.NODE_TEAM]})],
         )
     ]
 
@@ -242,7 +242,7 @@ def test_on_periodic_job_one_finding_in_jira_transition_to_failover(jira_lib_moc
         Repository(
             REPOSITORY,
             IC_URL,
-            [Project(name=REPOSITORY, path=_REPOSITORY, owner_by_path={"bear": [Team.NODE_TEAM]})],
+            [Project(name=REPOSITORY, path=REPOSITORY, owner_by_path={"bear": [Team.NODE_TEAM]})],
         )
     ]
 

--- a/ci/src/dependencies/scanner/dependency_scanner_test.py
+++ b/ci/src/dependencies/scanner/dependency_scanner_test.py
@@ -158,8 +158,9 @@ def test_on_periodic_job_one_finding(jira_lib_mock):
 def test_on_periodic_job_one_finding_in_jira(jira_lib_mock):
     # one finding, present in JIRA
     scanner = "BAZEL_RUST"
+    repository = Repository(REPOSITORY, IC_URL, [Project(REPOSITORY, REPOSITORY)])
     jira_finding = Finding(
-        repository=REPOSITORY,
+        repository=repository.name,
         scanner=scanner,
         vulnerable_dependency=Dependency("VDID1", "chrono", "1.0", {"VID1": ["1.1", "2.0"]}),
         vulnerabilities=[Vulnerability("VID1", "CVE-123", "huuughe vuln", 100)],
@@ -574,7 +575,7 @@ def test_on_merge_request_changes_with_findings_to_flag_no_commit_exception(gith
     jira_lib_mock.commit_has_block_exception.assert_called_once()
     finding_to_flag = [
         Finding(
-            repository=repository,
+            repository=REPOSITORY,
             scanner=scanner,
             vulnerable_dependency=Dependency("VDID1", "chrono", "1.0", {"VID1": ["1.1", "2.0"]}),
             vulnerabilities=[Vulnerability("VID1", "CVE-123", "huuughe vuln", 100)],

--- a/ci/src/dependencies/scanner/manager/bazel_rust_dependency_manager.py
+++ b/ci/src/dependencies/scanner/manager/bazel_rust_dependency_manager.py
@@ -244,7 +244,7 @@ class BazelRustDependencyManager(DependencyManager):
         path = self.root.parent / project.path
 
         # currently only the ic repo uses bazel
-        use_bazel = repository_name == "ic"
+        use_bazel = (repository_name == "ic" or repository_name == "ic-private")
         if use_bazel:
             logging.info("Performing cargo audit on old Cargo.lock")
             old_cargo_audit = self.executor.get_cargo_audit_output(path)

--- a/ci/src/dependencies/scanner/manager/bazel_rust_dependency_manager_test.py
+++ b/ci/src/dependencies/scanner/manager/bazel_rust_dependency_manager_test.py
@@ -5,11 +5,12 @@ import typing
 
 import pytest
 from model.dependency import Dependency
-from model.ic import __test_get_ic_path
+from model.ic import get_current_repo
 from model.project import Project
 from model.vulnerability import Vulnerability
 from scanner.manager.bazel_rust_dependency_manager import BazelCargoExecutor, BazelRustDependencyManager
 
+REPOSITORY=get_current_repo()
 
 @pytest.fixture
 def bazel_test():
@@ -316,12 +317,12 @@ def test_get_findings_for_bazel_repo():
         executor = MockBazelCargoExecutor(expected_cargo_audit_output=json.load(audit), expected_bazel_queries=expected_queries, expected_bazel_responses=expected_responses)
         bazel_test = BazelRustDependencyManager(executor=executor)
 
-        findings = bazel_test.get_findings("ic", Project("ic", __test_get_ic_path()), None)
+        findings = bazel_test.get_findings(REPOSITORY, Project(REPOSITORY, REPOSITORY), None)
 
         assert findings is not None
         assert len(findings) == 3
         for finding in findings:
-            assert finding.repository == "ic"
+            assert finding.repository == REPOSITORY
             assert finding.scanner == bazel_test.get_scanner_id()
             assert finding.risk_assessor == []
             assert finding.risk is None
@@ -372,7 +373,7 @@ def test_get_findings_for_bazel_repo():
             assert len(projects) == len(findings[0].projects)
 
             for project, finding_project in zip(projects, findings[0].projects):
-                assert  __test_get_ic_path() + project == finding_project
+                assert  get_current_repo() + project == finding_project
             assert findings[0].score == -1
 
             # unique fields for second finding
@@ -384,7 +385,7 @@ def test_get_findings_for_bazel_repo():
                               description='Out-of-bounds read when opening multiple column families with TTL',
                               score=-1)]
             assert findings[1].first_level_dependencies == []
-            assert findings[1].projects == [__test_get_ic_path() + '/rs/artifact_pool']
+            assert findings[1].projects == [get_current_repo() + '/rs/artifact_pool']
             assert findings[1].score == -1
 
             # unique fields for third finding
@@ -437,7 +438,7 @@ def test_get_findings_for_bazel_repo():
                                             '/rs/sns/swap', '/rs/tests', '/rs/types/types', '/rs/validator', '/rs/validator/http_request_test_utils']
             assert len(projects_2) == len(findings[2].projects)
             for project, finding_project in zip(projects_2, findings[2].projects):
-                assert  __test_get_ic_path() + project == finding_project
+                assert  get_current_repo() + project == finding_project
             assert findings[2].score == 6
 
 

--- a/ci/src/dependencies/scanner/manager/npm_dependency_manager_test.py
+++ b/ci/src/dependencies/scanner/manager/npm_dependency_manager_test.py
@@ -5,12 +5,13 @@ from unittest.mock import call, mock_open, patch
 import pytest
 from model.dependency import Dependency
 from model.finding import Finding
-from model.ic import __test_get_ic_path
+from model.ic import get_current_repo
 from model.project import Project
 from model.vulnerability import Vulnerability
 from scanner.manager.npm_dependency_manager import NPMDependencyManager
 
 DEFAULT_NODE_VERSION = "19"
+REPOSITORY=get_current_repo()
 
 
 @pytest.fixture
@@ -28,33 +29,33 @@ def test_clone_repository_from_url(process_executor_mock, npm_test):
 
 def test_npm_check_engine_no_package_json(npm_test):
     path = pathlib.Path()
-    assert npm_test._NPMDependencyManager__npm_check_engine("ic", DEFAULT_NODE_VERSION, path) is False
+    assert npm_test._NPMDependencyManager__npm_check_engine(REPOSITORY, DEFAULT_NODE_VERSION, path) is False
 
 @patch("pathlib.Path.exists", return_value=True)
 @patch("builtins.open", new_callable=mock_open, read_data='{"engines":"{}"}')
 def test_npm_check_engine_no_engine_version(_fopen_mock, _path_patch, npm_test):
     path = pathlib.Path()
-    assert npm_test._NPMDependencyManager__npm_check_engine("ic", DEFAULT_NODE_VERSION, path) is True
+    assert npm_test._NPMDependencyManager__npm_check_engine(REPOSITORY, DEFAULT_NODE_VERSION, path) is True
 
 @patch("pathlib.Path.exists", return_value=True)
 @patch("builtins.open", new_callable=mock_open, read_data='{"engines":{"node":"<19"}}')
 def test_npm_check_engine_not_compatible(_fopen_mock, _path_patch, npm_test):
     path = pathlib.Path()
-    assert npm_test._NPMDependencyManager__npm_check_engine("ic", DEFAULT_NODE_VERSION, path) is False
+    assert npm_test._NPMDependencyManager__npm_check_engine(REPOSITORY, DEFAULT_NODE_VERSION, path) is False
 
 @patch("pathlib.Path.exists", return_value=True)
 @patch("builtins.open", new_callable=mock_open, read_data='{"engines":{"node":">=19"}}')
 def test_npm_check_engine_compatible(_fopen_mock, _path_patch, npm_test):
     path = pathlib.Path()
-    assert npm_test._NPMDependencyManager__npm_check_engine("ic", DEFAULT_NODE_VERSION, path) is True
+    assert npm_test._NPMDependencyManager__npm_check_engine(REPOSITORY, DEFAULT_NODE_VERSION, path) is True
 
 @patch("pathlib.Path.exists", return_value=True)
 @patch("builtins.open", new_callable=mock_open, read_data='{"engines":{"node":"<19"}}')
 def test_npm_check_engine_not_compatible_throws_runtime_error(_fopen_mock, _path_patch, npm_test):
     with pytest.raises(RuntimeError) as e:
         path = pathlib.Path()
-        assert npm_test._NPMDependencyManager__npm_check_engine("ic", DEFAULT_NODE_VERSION, path) is False
-        _ = npm_test.get_findings("ic", Project("ic", __test_get_ic_path()), DEFAULT_NODE_VERSION)
+        assert npm_test._NPMDependencyManager__npm_check_engine(REPOSITORY, DEFAULT_NODE_VERSION, path) is False
+        _ = npm_test.get_findings(REPOSITORY, Project(REPOSITORY, REPOSITORY), DEFAULT_NODE_VERSION)
         assert "Dependency scan for ic can't be executed due to engine version mismatch" in str(e.value)
 
 @patch("scanner.process_executor.ProcessExecutor.execute_command", return_value="{'key':'value'}")
@@ -587,8 +588,8 @@ class FakeNPM:
 
 
 def test_findings_helper_no_vulnerabilities(npm_test):
-    repository = "ic"
-    project = Project("ic", __test_get_ic_path())
+    repository = get_current_repo()
+    project = Project(repository, repository)
     fake_npm = FakeNPM(1)
     npm_test._NPMDependencyManager__npm_audit_output = fake_npm.npm_audit_output
     npm_test._NPMDependencyManager__npm_list_output = fake_npm.npm_list_output
@@ -599,8 +600,8 @@ def test_findings_helper_no_vulnerabilities(npm_test):
 
 
 def test_findings_helper_one_finding(npm_test):
-    repository = "ic"
-    project = Project("ic", __test_get_ic_path())
+    repository = get_current_repo()
+    project = Project(repository, repository)
     fake_npm = FakeNPM(2)
     npm_test._NPMDependencyManager__npm_audit_output = fake_npm.npm_audit_output
     npm_test._NPMDependencyManager__npm_list_output = fake_npm.npm_list_output
@@ -609,7 +610,7 @@ def test_findings_helper_one_finding(npm_test):
     findings = npm_test.get_findings(repository, project, DEFAULT_NODE_VERSION)
     assert len(findings) == 1
     assert findings[0] == Finding(
-        repository="ic",
+        repository=REPOSITORY,
         scanner="NPM",
         vulnerable_dependency=Dependency(
             id="https://www.npmjs.com/package/d3-color/v/2.0.1",
@@ -639,7 +640,7 @@ def test_findings_helper_one_finding(npm_test):
                 fix_version_for_vulnerability={},
             )
         ],
-        projects=["ic"],
+        projects=[REPOSITORY],
         risk_assessor=[],
         risk=None,
         patch_responsible=[],
@@ -650,8 +651,8 @@ def test_findings_helper_one_finding(npm_test):
 
 
 def test_findings_helper_vulnerable_dependency_not_in_range(npm_test):
-    repository = "ic"
-    project = Project("ic", __test_get_ic_path())
+    repository = get_current_repo()
+    project = Project(repository, repository)
     fake_npm = FakeNPM(3)
     npm_test._NPMDependencyManager__npm_audit_output = fake_npm.npm_audit_output
     npm_test._NPMDependencyManager__npm_list_output = fake_npm.npm_list_output
@@ -662,8 +663,8 @@ def test_findings_helper_vulnerable_dependency_not_in_range(npm_test):
 
 
 def test_findings_helper_transitive_vulnerability(npm_test):
-    repository = "ic"
-    project = Project("ic", __test_get_ic_path())
+    repository = get_current_repo()
+    project = Project(repository, repository)
     fake_npm = FakeNPM(4)
     npm_test._NPMDependencyManager__npm_audit_output = fake_npm.npm_audit_output
     npm_test._NPMDependencyManager__npm_list_output = fake_npm.npm_list_output


### PR DESCRIPTION
This updates all the direct references to the "ic" repo to use the repo-name instead.