### PR TITLE
Arshavir/rename-Distribution.InitialBalances.governance-as-Distribution.InitialBalances.treasury

### DIFF
--- a/rs/nervous_system/integration_tests/src/pocket_ic_helpers.rs
+++ b/rs/nervous_system/integration_tests/src/pocket_ic_helpers.rs
@@ -197,10 +197,10 @@ pub fn propose_to_set_network_economics_and_wait(
 
 pub fn add_wasms_to_sns_wasm(
     pocket_ic: &PocketIc,
-    with_mainnet_ledger_wasms: bool,
+    with_mainnet_sns_canister_wasms: bool,
 ) -> Result<BTreeMap<SnsCanisterType, (ProposalInfo, SnsWasm)>, String> {
     let (root_wasm, governance_wasm, swap_wasm, index_wasm, ledger_wasm, archive_wasm) =
-        if with_mainnet_ledger_wasms {
+        if with_mainnet_sns_canister_wasms {
             (
                 ensure_sns_wasm_gzipped(build_mainnet_root_sns_wasm()),
                 ensure_sns_wasm_gzipped(build_mainnet_governance_sns_wasm()),

--- a/rs/sns/cli/src/init_config_file/friendly.rs
+++ b/rs/sns/cli/src/init_config_file/friendly.rs
@@ -243,7 +243,7 @@ pub(crate) struct Neuron {
 #[serde(deny_unknown_fields)]
 pub(crate) struct InitialBalances {
     #[serde(with = "ic_nervous_system_humanize::serde::tokens")]
-    governance: nervous_system_pb::Tokens,
+    treasury: nervous_system_pb::Tokens,
 
     #[serde(with = "ic_nervous_system_humanize::serde::tokens")]
     swap: nervous_system_pb::Tokens,
@@ -523,14 +523,14 @@ impl Distribution {
         let developer_distribution = Some(developer_distribution);
 
         let (treasury_distribution, swap_distribution) = {
-            let InitialBalances { governance, swap } = initial_balances;
+            let InitialBalances { treasury, swap } = initial_balances;
 
-            observed_total_e8s += governance.e8s.unwrap_or_default();
+            observed_total_e8s += treasury.e8s.unwrap_or_default();
             observed_total_e8s += swap.e8s.unwrap_or_default();
 
             (
                 Some(nns_governance_pb::TreasuryDistribution {
-                    total: Some(*governance),
+                    total: Some(*treasury),
                 }),
                 Some(nns_governance_pb::SwapDistribution { total: Some(*swap) }),
             )

--- a/rs/sns/cli/src/init_config_file/friendly/friendly_tests.rs
+++ b/rs/sns/cli/src/init_config_file/friendly/friendly_tests.rs
@@ -119,7 +119,7 @@ fn test_parse() {
             ],
 
             initial_balances: InitialBalances {
-                governance: nervous_system_pb::Tokens { e8s: Some(60 * E8) },
+                treasury: nervous_system_pb::Tokens { e8s: Some(60 * E8) },
                 swap: nervous_system_pb::Tokens { e8s: Some(40 * E8) },
             },
 

--- a/rs/sns/cli/test_sns_init_v2.yaml
+++ b/rs/sns/cli/test_sns_init_v2.yaml
@@ -67,7 +67,7 @@ Distribution:
           vesting_period: 53 weeks
 
     InitialBalances:
-        governance: 60 tokens
+        treasury: 60 tokens
         swap: 40 tokens
 
     # Optional, but highly recommended. This is a literal

--- a/rs/sns/governance/canister/canister.rs
+++ b/rs/sns/governance/canister/canister.rs
@@ -30,10 +30,9 @@ use ic_nervous_system_common::{
 };
 use ic_nervous_system_runtime::DfnRuntime;
 use ic_nns_constants::LEDGER_CANISTER_ID as NNS_LEDGER_CANISTER_ID;
-#[cfg(feature = "test")]
 use ic_sns_governance::pb::v1::{
     AddMaturityRequest, AddMaturityResponse, GovernanceError, MintTokensRequest,
-    MintTokensResponse, Neuron,
+    MintTokensResponse, Neuron, UpgradeToLatestRequest, UpgradeToLatestResponse,
 };
 use ic_sns_governance::{
     governance::{
@@ -731,6 +730,14 @@ fn add_maturity() {
 #[candid_method(update, rename = "add_maturity")]
 fn add_maturity_(request: AddMaturityRequest) -> AddMaturityResponse {
     governance_mut().add_maturity(request)
+}
+
+#[export_name = "canister_update upgrade_to_latest"]
+fn upgrade_to_latest(request: UpgradeToLatestRequest) {
+    //panic!("???");
+    over(candid_one, |request: UpgradeToLatestRequest| {
+        UpgradeToLatestResponse {}
+    })
 }
 
 /// Mints tokens for testing

--- a/rs/sns/governance/proto/ic_sns_governance/pb/v1/governance.proto
+++ b/rs/sns/governance/proto/ic_sns_governance/pb/v1/governance.proto
@@ -2137,3 +2137,11 @@ message Account {
   // subaccount (all bytes set to 0) is used.
   optional Subaccount subaccount = 2;
 }
+
+message UpgradeToLatestRequest {
+
+}
+
+message UpgradeToLatestResponse {
+
+}

--- a/rs/sns/governance/src/gen/ic_sns_governance.pb.v1.rs
+++ b/rs/sns/governance/src/gen/ic_sns_governance.pb.v1.rs
@@ -2722,6 +2722,14 @@ pub struct Account {
     #[prost(message, optional, tag = "2")]
     pub subaccount: ::core::option::Option<Subaccount>,
 }
+#[derive(candid::CandidType, candid::Deserialize, comparable::Comparable)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct UpgradeToLatestRequest {}
+#[derive(candid::CandidType, candid::Deserialize, comparable::Comparable)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct UpgradeToLatestResponse {}
 /// The different types of neuron permissions, i.e., privileges to modify a neuron,
 /// that principals can have.
 #[derive(

--- a/testnet/tools/nns-tools/sns_default_test_init_params_v2.yml
+++ b/testnet/tools/nns-tools/sns_default_test_init_params_v2.yml
@@ -60,7 +60,7 @@ Distribution:
           vesting_period: 1 year 1 second
 
     InitialBalances:
-        governance: 50 tokens
+        treasury: 50 tokens
         swap: 30_000 tokens
 
     total: 30_065 tokens


### PR DESCRIPTION
Currently, `Distribution.InitialBalances.governance` is being mapped to `initialTokenDistribution.treasuryDistribution.total`. With this change, `Distribution.InitialBalances.governance` will be renamed to `Distribution.InitialBalances.treasury`.