### PR TITLE
feat(sns-cli): Rename `Distribution.InitialBalances.governance` as `Distribution.InitialBalances.treasury`.

### DIFF
--- a/rs/sns/cli/src/init_config_file/friendly.rs
+++ b/rs/sns/cli/src/init_config_file/friendly.rs
@@ -243,7 +243,7 @@ pub(crate) struct Neuron {
 #[serde(deny_unknown_fields)]
 pub(crate) struct InitialBalances {
     #[serde(with = "ic_nervous_system_humanize::serde::tokens")]
-    governance: nervous_system_pb::Tokens,
+    treasury: nervous_system_pb::Tokens,
 
     #[serde(with = "ic_nervous_system_humanize::serde::tokens")]
     swap: nervous_system_pb::Tokens,
@@ -523,14 +523,14 @@ impl Distribution {
         let developer_distribution = Some(developer_distribution);
 
         let (treasury_distribution, swap_distribution) = {
-            let InitialBalances { governance, swap } = initial_balances;
+            let InitialBalances { treasury, swap } = initial_balances;
 
-            observed_total_e8s += governance.e8s.unwrap_or_default();
+            observed_total_e8s += treasury.e8s.unwrap_or_default();
             observed_total_e8s += swap.e8s.unwrap_or_default();
 
             (
                 Some(nns_governance_pb::TreasuryDistribution {
-                    total: Some(*governance),
+                    total: Some(*treasury),
                 }),
                 Some(nns_governance_pb::SwapDistribution { total: Some(*swap) }),
             )

--- a/rs/sns/cli/src/init_config_file/friendly/friendly_tests.rs
+++ b/rs/sns/cli/src/init_config_file/friendly/friendly_tests.rs
@@ -119,7 +119,7 @@ fn test_parse() {
             ],
 
             initial_balances: InitialBalances {
-                governance: nervous_system_pb::Tokens { e8s: Some(60 * E8) },
+                treasury: nervous_system_pb::Tokens { e8s: Some(60 * E8) },
                 swap: nervous_system_pb::Tokens { e8s: Some(40 * E8) },
             },
 

--- a/rs/sns/cli/test_sns_init_v2.yaml
+++ b/rs/sns/cli/test_sns_init_v2.yaml
@@ -67,7 +67,7 @@ Distribution:
           vesting_period: 53 weeks
 
     InitialBalances:
-        governance: 60 tokens
+        treasury: 60 tokens
         swap: 40 tokens
 
     # Optional, but highly recommended. This is a literal

--- a/testnet/tools/nns-tools/sns_default_test_init_params_v2.yml
+++ b/testnet/tools/nns-tools/sns_default_test_init_params_v2.yml
@@ -60,7 +60,7 @@ Distribution:
           vesting_period: 1 year 1 second
 
     InitialBalances:
-        governance: 50 tokens
+        treasury: 50 tokens
         swap: 30_000 tokens
 
     total: 30_065 tokens


### PR DESCRIPTION
Currently, `Distribution.InitialBalances.governance` is being mapped to `initialTokenDistribution.treasuryDistribution.total`. 

With this change, `Distribution.InitialBalances.governance` will be renamed to `Distribution.InitialBalances.treasury`.