### PR TITLE
fix(dependency-mgmt): Apply ic-private patch to a leftover test

### DIFF
--- a/ci/src/dependencies/scanner/manager/npm_dependency_manager_test.py
+++ b/ci/src/dependencies/scanner/manager/npm_dependency_manager_test.py
@@ -645,7 +645,7 @@ def test_findings_helper_one_finding(npm_test):
                 fix_version_for_vulnerability={},
             )
         ],
-        projects=["ic"],
+        projects=[__test_get_ic_path()],
         risk_assessor=[],
         risk=None,
         patch_responsible=[],


### PR DESCRIPTION
In #1746 all tests should have been fixed. 

Looks like I missed a single file when applying the patch from `ic-private` to `ic`.

Reference PR - https://github.com/dfinity/ic/pull/1746/files
IC Private PR - https://github.com/dfinity/ic-private/pull/36/files