### PR TITLE
chore(IDX): update intel job logic

### DIFF
--- a/.github/workflows-source/ci-main.yml
+++ b/.github/workflows-source/ci-main.yml
@@ -159,7 +159,7 @@ jobs:
     timeout-minutes: 120
     runs-on:
       labels: macOS
-    if: ${{ github.ref_protected }} # Bazel test darwin are still required for building artifacts for the releases, therefore run on protected branches
+    if: ${{ github.ref_protected && github.repository == "ic" }} # Run on protected branches, but only on public repo
     steps:
       - <<: *checkout
       - name: Set PATH

--- a/.github/workflows-source/ci-main.yml
+++ b/.github/workflows-source/ci-main.yml
@@ -159,7 +159,7 @@ jobs:
     timeout-minutes: 120
     runs-on:
       labels: macOS
-    if: ${{ github.ref_protected && github.repository == "ic" }} # Run on protected branches, but only on public repo
+    if: ${{ github.ref_protected && github.repository == 'ic' }} # Run on protected branches, but only on public repo
     steps:
       - <<: *checkout
       - name: Set PATH

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -151,7 +151,7 @@ jobs:
     timeout-minutes: 120
     runs-on:
       labels: macOS
-    if: ${{ github.ref_protected }} # Bazel test darwin are still required for building artifacts for the releases, therefore run on protected branches
+    if: ${{ github.ref_protected && github.repository == "ic" }} # Run on protected branches, but only on public repo
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -151,7 +151,7 @@ jobs:
     timeout-minutes: 120
     runs-on:
       labels: macOS
-    if: ${{ github.ref_protected && github.repository == "ic" }} # Run on protected branches, but only on public repo
+    if: ${{ github.ref_protected && github.repository == 'ic' }} # Run on protected branches, but only on public repo
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
We don't have intel runner configured for `ic-private` so just skip the job instead of letting it hang.