### PR TITLE
chore(IDX): update release testing logic

### DIFF
--- a/.github/workflows-source/release-testing.yml
+++ b/.github/workflows-source/release-testing.yml
@@ -12,6 +12,9 @@ concurrency:
   group: ${{ github.ref }}
   cancel-in-progress: true
 
+# Skip the workflow if the branch is a hotfix branch and it is running on ic-private
+if: ${{ !(startsWith(github.ref, 'refs/heads/hotfix-') && github.repository != 'ic') }}
+
 env:
   CI_COMMIT_SHA: ${{ github.sha }}
   CI_JOB_NAME: ${{ github.job }}

--- a/.github/workflows-source/release-testing.yml
+++ b/.github/workflows-source/release-testing.yml
@@ -12,8 +12,8 @@ concurrency:
   group: ${{ github.ref }}
   cancel-in-progress: true
 
-# Skip the workflow if the branch is a hotfix branch and it is running on ic-private
-if: ${{ !(startsWith(github.ref, 'refs/heads/hotfix-') && github.repository != 'ic') }}
+# Skip the workflow if the branch is an rc branch and it is running on ic-private
+if: ${{ !(github.repository == 'ic' || !startsWith(github.ref, 'refs/heads/rc--')) }}
 
 env:
   CI_COMMIT_SHA: ${{ github.sha }}

--- a/.github/workflows/release-testing.yml
+++ b/.github/workflows/release-testing.yml
@@ -9,6 +9,8 @@ on:
 concurrency:
   group: ${{ github.ref }}
   cancel-in-progress: true
+# Skip the workflow if the branch is an rc branch and it is running on ic-private
+if: ${{ !(github.repository == 'ic' || !startsWith(github.ref, 'refs/heads/rc--')) }}
 env:
   CI_COMMIT_SHA: ${{ github.sha }}
   CI_JOB_NAME: ${{ github.job }}


### PR DESCRIPTION
We want to start syncing rc branches to `ic-private` but we don't want it to trigger the release workflow.