### PR TITLE
feat(sns): Add periodic task for caching the upgrade steps

### DIFF
--- a/rs/nervous_system/integration_tests/tests/advance_target_version.rs
+++ b/rs/nervous_system/integration_tests/tests/advance_target_version.rs
@@ -8,7 +8,9 @@ use ic_nervous_system_integration_tests::{
     },
 };
 use ic_nns_test_utils::sns_wasm::create_modified_sns_wasm;
-use ic_sns_governance::pb::v1 as sns_pb;
+use ic_sns_governance::{
+    governance::UPGRADE_STEPS_INTERVAL_REFRESH_BACKOFF_SECONDS, pb::v1 as sns_pb,
+};
 use ic_sns_swap::pb::v1::Lifecycle;
 use ic_sns_wasm::pb::v1::SnsCanisterType;
 use pocket_ic::PocketIcBuilder;
@@ -91,7 +93,7 @@ fn test_get_upgrade_journal() {
         assert_eq!(response_timestamp_seconds, Some(1620501459));
     }
 
-    wait_for_next_periodic_task(6 * 60); // 6 min
+    wait_for_next_periodic_task(UPGRADE_STEPS_INTERVAL_REFRESH_BACKOFF_SECONDS);
 
     // State B: after the first periodic task's completion. No changes expected yet.
     {
@@ -135,7 +137,7 @@ fn test_get_upgrade_journal() {
         (new_sns_version_1, new_sns_version_2)
     };
 
-    wait_for_next_periodic_task(6 * 60); // 6 min
+    wait_for_next_periodic_task(UPGRADE_STEPS_INTERVAL_REFRESH_BACKOFF_SECONDS);
 
     // State C: after the second periodic task's completion.
     {

--- a/rs/nervous_system/integration_tests/tests/advance_target_version.rs
+++ b/rs/nervous_system/integration_tests/tests/advance_target_version.rs
@@ -1,0 +1,151 @@
+use ic_base_types::PrincipalId;
+use ic_nervous_system_common::ONE_MONTH_SECONDS;
+use ic_nervous_system_integration_tests::pocket_ic_helpers::sns;
+use ic_nervous_system_integration_tests::{
+    create_service_nervous_system_builder::CreateServiceNervousSystemBuilder,
+    pocket_ic_helpers::{
+        add_wasm_via_nns_proposal, add_wasms_to_sns_wasm, install_nns_canisters, nns,
+    },
+};
+use ic_nns_test_utils::sns_wasm::create_modified_sns_wasm;
+use ic_sns_governance::pb::v1 as sns_pb;
+use ic_sns_swap::pb::v1::Lifecycle;
+use ic_sns_wasm::pb::v1::SnsCanisterType;
+use pocket_ic::PocketIcBuilder;
+use std::time::Duration;
+
+const TICKS_PER_TASK: u64 = 2;
+
+#[test]
+fn test_get_upgrade_journal() {
+    let pocket_ic = PocketIcBuilder::new()
+        .with_nns_subnet()
+        .with_sns_subnet()
+        .build();
+
+    let wait_for_next_periodic_task = |sleep_duration_seconds| {
+        let now = pocket_ic.get_time();
+        pocket_ic.advance_time(Duration::from_secs(sleep_duration_seconds));
+        for _ in 0..TICKS_PER_TASK {
+            pocket_ic.tick();
+        }
+        assert_eq!(
+            pocket_ic.get_time(),
+            now + Duration::from_secs(sleep_duration_seconds)
+                + Duration::from_nanos(TICKS_PER_TASK)
+        );
+    };
+
+    // Install the (master) NNS canisters.
+    let with_mainnet_nns_canisters = false;
+    install_nns_canisters(&pocket_ic, vec![], with_mainnet_nns_canisters, None, vec![]);
+
+    // Publish (master) SNS Wasms to SNS-W.
+    let with_mainnet_sns_wasms = false;
+    let deployed_sns_starting_info =
+        add_wasms_to_sns_wasm(&pocket_ic, with_mainnet_sns_wasms).unwrap();
+    let initial_sns_version = nns::sns_wasm::get_lastest_sns_version(&pocket_ic);
+
+    // Deploy an SNS instance via proposal.
+    let sns = {
+        let create_service_nervous_system = CreateServiceNervousSystemBuilder::default()
+            .with_governance_parameters_neuron_minimum_dissolve_delay_to_vote(ONE_MONTH_SECONDS * 6)
+            .with_one_developer_neuron(
+                PrincipalId::new_user_test_id(830947),
+                ONE_MONTH_SECONDS * 6,
+                756575,
+                0,
+            )
+            .build();
+        let swap_parameters = create_service_nervous_system
+            .swap_parameters
+            .clone()
+            .unwrap();
+
+        let sns_instance_label = "1";
+        let (sns, _) = nns::governance::propose_to_deploy_sns_and_wait(
+            &pocket_ic,
+            create_service_nervous_system,
+            sns_instance_label,
+        );
+
+        sns::swap::await_swap_lifecycle(&pocket_ic, sns.swap.canister_id, Lifecycle::Open).unwrap();
+        sns::swap::smoke_test_participate_and_finalize(
+            &pocket_ic,
+            sns.swap.canister_id,
+            swap_parameters,
+        );
+        sns
+    };
+
+    // State A: right after SNS creation.
+    {
+        let sns_pb::GetUpgradeJournalResponse {
+            upgrade_steps,
+            response_timestamp_seconds,
+        } = sns::governance::get_upgrade_journal(&pocket_ic, sns.governance.canister_id);
+        let upgrade_steps = upgrade_steps
+            .expect("upgrade_steps should be Some")
+            .versions;
+        assert_eq!(upgrade_steps, vec![initial_sns_version.clone()]);
+        assert_eq!(response_timestamp_seconds, Some(1620501459));
+    }
+
+    wait_for_next_periodic_task(6 * 60); // 6 min
+
+    // State B: after the first periodic task's completion. No changes expected yet.
+    {
+        let sns_pb::GetUpgradeJournalResponse { upgrade_steps, .. } =
+            sns::governance::get_upgrade_journal(&pocket_ic, sns.governance.canister_id);
+        let upgrade_steps = upgrade_steps
+            .expect("upgrade_steps should be Some")
+            .versions;
+        assert_eq!(upgrade_steps, vec![initial_sns_version.clone()]);
+    }
+
+    // Publish a new SNS version.
+    let (new_sns_version_1, new_sns_version_2) = {
+        let (_, original_ledger_wasm) = deployed_sns_starting_info
+            .get(&SnsCanisterType::Ledger)
+            .unwrap();
+
+        let new_sns_version_1 = {
+            let ledger_wasm = create_modified_sns_wasm(original_ledger_wasm, Some(1));
+            add_wasm_via_nns_proposal(&pocket_ic, ledger_wasm.clone()).unwrap();
+            let ledger_wasm_hash = ledger_wasm.sha256_hash().to_vec();
+            sns_pb::governance::Version {
+                ledger_wasm_hash,
+                ..initial_sns_version.clone()
+            }
+        };
+
+        let new_sns_version_2 = {
+            let ledger_wasm = create_modified_sns_wasm(original_ledger_wasm, Some(2));
+            add_wasm_via_nns_proposal(&pocket_ic, ledger_wasm.clone()).unwrap();
+            let ledger_wasm_hash = ledger_wasm.sha256_hash().to_vec();
+            sns_pb::governance::Version {
+                ledger_wasm_hash,
+                ..new_sns_version_1.clone()
+            }
+        };
+
+        let sns_version = nns::sns_wasm::get_lastest_sns_version(&pocket_ic);
+        assert_ne!(sns_version, initial_sns_version);
+
+        (new_sns_version_1, new_sns_version_2)
+    };
+
+    wait_for_next_periodic_task(6 * 60); // 6 min
+
+    // State C: after the second periodic task's completion.
+    {
+        let sns_pb::GetUpgradeJournalResponse { upgrade_steps, .. } =
+            sns::governance::get_upgrade_journal(&pocket_ic, sns.governance.canister_id);
+        let upgrade_steps = upgrade_steps.expect("cached_upgrade_steps should be Some");
+
+        assert_eq!(
+            upgrade_steps.versions,
+            vec![initial_sns_version, new_sns_version_1, new_sns_version_2,]
+        );
+    }
+}

--- a/rs/sns/governance/canister/canister.rs
+++ b/rs/sns/governance/canister/canister.rs
@@ -47,9 +47,10 @@ use ic_sns_governance::{
         GetModeResponse, GetNeuron, GetNeuronResponse, GetProposal, GetProposalResponse,
         GetRunningSnsVersionRequest, GetRunningSnsVersionResponse,
         GetSnsInitializationParametersRequest, GetSnsInitializationParametersResponse,
-        Governance as GovernanceProto, ListNervousSystemFunctionsResponse, ListNeurons,
-        ListNeuronsResponse, ListProposals, ListProposalsResponse, ManageNeuron,
-        ManageNeuronResponse, NervousSystemParameters, RewardEvent, SetMode, SetModeResponse,
+        GetUpgradeJournalRequest, GetUpgradeJournalResponse, Governance as GovernanceProto,
+        ListNervousSystemFunctionsResponse, ListNeurons, ListNeuronsResponse, ListProposals,
+        ListProposalsResponse, ManageNeuron, ManageNeuronResponse, NervousSystemParameters,
+        RewardEvent, SetMode, SetModeResponse,
     },
     types::{Environment, HeapGrowthPotential},
 };
@@ -724,6 +725,26 @@ fn add_maturity() {
 #[candid_method(update, rename = "add_maturity")]
 fn add_maturity_(request: AddMaturityRequest) -> AddMaturityResponse {
     governance_mut().add_maturity(request)
+}
+
+#[export_name = "canister_query get_upgrade_journal"]
+fn get_upgrade_journal() {
+    over_async(candid_one, get_upgrade_journal_)
+}
+
+#[candid_method(query, rename = "get_upgrade_journal")]
+async fn get_upgrade_journal_(_arg: GetUpgradeJournalRequest) -> GetUpgradeJournalResponse {
+    let cached_upgrade_steps = governance().proto.cached_upgrade_steps.clone();
+    match cached_upgrade_steps {
+        Some(cached_upgrade_steps) => GetUpgradeJournalResponse {
+            upgrade_steps: cached_upgrade_steps.upgrade_steps,
+            response_timestamp_seconds: cached_upgrade_steps.response_timestamp_seconds,
+        },
+        None => GetUpgradeJournalResponse {
+            upgrade_steps: None,
+            response_timestamp_seconds: None,
+        },
+    }
 }
 
 /// Mints tokens for testing

--- a/rs/sns/governance/canister/canister.rs
+++ b/rs/sns/governance/canister/canister.rs
@@ -729,22 +729,13 @@ fn add_maturity_(request: AddMaturityRequest) -> AddMaturityResponse {
 
 #[export_name = "canister_query get_upgrade_journal"]
 fn get_upgrade_journal() {
-    over_async(candid_one, get_upgrade_journal_)
+    over(candid_one, get_upgrade_journal_)
 }
 
 #[candid_method(query, rename = "get_upgrade_journal")]
-async fn get_upgrade_journal_(_arg: GetUpgradeJournalRequest) -> GetUpgradeJournalResponse {
-    let cached_upgrade_steps = governance().proto.cached_upgrade_steps.clone();
-    match cached_upgrade_steps {
-        Some(cached_upgrade_steps) => GetUpgradeJournalResponse {
-            upgrade_steps: cached_upgrade_steps.upgrade_steps,
-            response_timestamp_seconds: cached_upgrade_steps.response_timestamp_seconds,
-        },
-        None => GetUpgradeJournalResponse {
-            upgrade_steps: None,
-            response_timestamp_seconds: None,
-        },
-    }
+fn get_upgrade_journal_(arg: GetUpgradeJournalRequest) -> GetUpgradeJournalResponse {
+    let GetUpgradeJournalRequest {} = arg;
+    governance().get_upgrade_journal()
 }
 
 /// Mints tokens for testing

--- a/rs/sns/governance/canister/governance.did
+++ b/rs/sns/governance/canister/governance.did
@@ -707,6 +707,13 @@ type WaitForQuietState = record {
   current_deadline_timestamp_seconds : nat64;
 };
 
+type GetUpgradeJournalRequest = record {};
+
+type GetUpgradeJournalResponse = record {
+  upgrade_steps : opt Versions;
+  response_timestamp_seconds : opt nat64;
+};
+
 service : (Governance) -> {
   claim_swap_neurons : (ClaimSwapNeuronsRequest) -> (ClaimSwapNeuronsResponse);
   fail_stuck_upgrade_in_progress : (record {}) -> (record {});
@@ -723,6 +730,7 @@ service : (Governance) -> {
   get_sns_initialization_parameters : (record {}) -> (
       GetSnsInitializationParametersResponse,
     ) query;
+  get_upgrade_journal : (GetUpgradeJournalRequest) -> (GetUpgradeJournalResponse) query;
   list_nervous_system_functions : () -> (
       ListNervousSystemFunctionsResponse,
     ) query;

--- a/rs/sns/governance/canister/governance.did
+++ b/rs/sns/governance/canister/governance.did
@@ -264,6 +264,12 @@ type GetSnsInitializationParametersResponse = record {
   sns_initialization_parameters : text;
 };
 
+type CachedUpgradeSteps = record {
+  upgrade_steps : opt Versions;
+  requested_timestamp_seconds : opt nat64;
+  response_timestamp_seconds : opt nat64;
+};
+
 type Governance = record {
   root_canister_id : opt principal;
   id_to_nervous_system_functions : vec record { nat64; NervousSystemFunction };
@@ -273,6 +279,7 @@ type Governance = record {
   parameters : opt NervousSystemParameters;
   is_finalizing_disburse_maturity : opt bool;
   deployed_version : opt Version;
+  cached_upgrade_steps : opt CachedUpgradeSteps;
   sns_initialization_parameters : text;
   latest_reward_event : opt RewardEvent;
   pending_version : opt UpgradeInProgress;
@@ -686,6 +693,8 @@ type Version = record {
   governance_wasm_hash : blob;
   index_wasm_hash : blob;
 };
+
+type Versions = record { versions : vec Version };
 
 type VotingRewardsParameters = record {
   final_reward_rate_basis_points : opt nat64;

--- a/rs/sns/governance/canister/governance_test.did
+++ b/rs/sns/governance/canister/governance_test.did
@@ -721,6 +721,13 @@ type WaitForQuietState = record {
   current_deadline_timestamp_seconds : nat64;
 };
 
+type GetUpgradeJournalRequest = record {};
+
+type GetUpgradeJournalResponse = record {
+  upgrade_steps : opt Versions;
+  response_timestamp_seconds : opt nat64;
+};
+
 service : (Governance) -> {
   add_maturity : (AddMaturityRequest) -> (AddMaturityResponse);
   claim_swap_neurons : (ClaimSwapNeuronsRequest) -> (ClaimSwapNeuronsResponse);
@@ -738,6 +745,7 @@ service : (Governance) -> {
   get_sns_initialization_parameters : (record {}) -> (
       GetSnsInitializationParametersResponse,
     ) query;
+  get_upgrade_journal : (GetUpgradeJournalRequest) -> (GetUpgradeJournalResponse) query;
   list_nervous_system_functions : () -> (
       ListNervousSystemFunctionsResponse,
     ) query;

--- a/rs/sns/governance/canister/governance_test.did
+++ b/rs/sns/governance/canister/governance_test.did
@@ -273,6 +273,12 @@ type GetSnsInitializationParametersResponse = record {
   sns_initialization_parameters : text;
 };
 
+type CachedUpgradeSteps = record {
+  upgrade_steps : opt Versions;
+  requested_timestamp_seconds : opt nat64;
+  response_timestamp_seconds : opt nat64;
+};
+
 type Governance = record {
   root_canister_id : opt principal;
   id_to_nervous_system_functions : vec record { nat64; NervousSystemFunction };
@@ -282,6 +288,7 @@ type Governance = record {
   parameters : opt NervousSystemParameters;
   is_finalizing_disburse_maturity : opt bool;
   deployed_version : opt Version;
+  cached_upgrade_steps : opt CachedUpgradeSteps;
   sns_initialization_parameters : text;
   latest_reward_event : opt RewardEvent;
   pending_version : opt UpgradeInProgress;
@@ -700,6 +707,8 @@ type Version = record {
   governance_wasm_hash : blob;
   index_wasm_hash : blob;
 };
+
+type Versions = record { versions : vec Version };
 
 type VotingRewardsParameters = record {
   final_reward_rate_basis_points : opt nat64;

--- a/rs/sns/governance/proto/ic_sns_governance/pb/v1/governance.proto
+++ b/rs/sns/governance/proto/ic_sns_governance/pb/v1/governance.proto
@@ -2129,6 +2129,13 @@ message AddMaturityResponse {
   optional uint64 new_maturity_e8s = 1;
 }
 
+message GetUpgradeJournalRequest {}
+
+message GetUpgradeJournalResponse {
+  Governance.Versions upgrade_steps = 1;
+  optional uint64 response_timestamp_seconds = 2;
+}
+
 // A request to mint tokens for a particular principal. The associated endpoint
 // is only available on SNS governance, and only then when SNS governance is
 // compiled with the `test` feature enabled.

--- a/rs/sns/governance/proto/ic_sns_governance/pb/v1/governance.proto
+++ b/rs/sns/governance/proto/ic_sns_governance/pb/v1/governance.proto
@@ -1408,6 +1408,10 @@ message Governance {
     bytes index_wasm_hash = 6;
   }
 
+  message Versions {
+    repeated Governance.Version versions = 1;
+  }
+
   // Current version that this SNS is running.
   Version deployed_version = 23;
 
@@ -1449,6 +1453,23 @@ message Governance {
 
   reserved "migrated_root_wasm_memory_limit";
   reserved 27;
+
+  // The sns's local cache of the upgrade steps recieved from SNS-W.
+  message CachedUpgradeSteps {
+    // The upgrade steps that have been returned from SNS-W the last time we
+    // called list_upgrade_steps.
+    Governance.Versions upgrade_steps = 1;
+    // The timestamp of the request we sent to list_upgrade_steps.
+    // It's possible that this is greater than the response_timestamp_seconds, because
+    // we update it as soon as we send the request, and only update the
+    // response_timestamp and the upgrade_steps when we receive the response.
+    // The primary use of this is that we can avoid calling list_upgrade_steps
+    // more frequently than necessary.
+    optional uint64 requested_timestamp_seconds = 2;
+    // The timestamp of the response we received from list_upgrade_steps (stored in upgrade_steps).
+    optional uint64 response_timestamp_seconds = 3;
+  }
+  CachedUpgradeSteps cached_upgrade_steps = 29;
 }
 
 // Request message for 'get_metadata'.

--- a/rs/sns/governance/src/gen/ic_sns_governance.pb.v1.rs
+++ b/rs/sns/governance/src/gen/ic_sns_governance.pb.v1.rs
@@ -1644,6 +1644,8 @@ pub struct Governance {
     pub is_finalizing_disburse_maturity: ::core::option::Option<bool>,
     #[prost(message, optional, tag = "26")]
     pub maturity_modulation: ::core::option::Option<governance::MaturityModulation>,
+    #[prost(message, optional, tag = "29")]
+    pub cached_upgrade_steps: ::core::option::Option<governance::CachedUpgradeSteps>,
 }
 /// Nested message and enum types in `Governance`.
 pub mod governance {
@@ -1857,6 +1859,18 @@ pub mod governance {
         #[serde(with = "serde_bytes")]
         pub index_wasm_hash: ::prost::alloc::vec::Vec<u8>,
     }
+    #[derive(
+        candid::CandidType,
+        candid::Deserialize,
+        comparable::Comparable,
+        Clone,
+        PartialEq,
+        ::prost::Message,
+    )]
+    pub struct Versions {
+        #[prost(message, repeated, tag = "1")]
+        pub versions: ::prost::alloc::vec::Vec<Version>,
+    }
     /// An upgrade in progress, defined as a version target and a time at which it is considered failed.
     #[derive(
         candid::CandidType,
@@ -1903,6 +1917,32 @@ pub mod governance {
         /// When current_basis_points was last updated (seconds since UNIX epoch).
         #[prost(uint64, optional, tag = "2")]
         pub updated_at_timestamp_seconds: ::core::option::Option<u64>,
+    }
+    /// The sns's local cache of the upgrade steps recieved from SNS-W.
+    #[derive(
+        candid::CandidType,
+        candid::Deserialize,
+        comparable::Comparable,
+        Clone,
+        PartialEq,
+        ::prost::Message,
+    )]
+    pub struct CachedUpgradeSteps {
+        /// The upgrade steps that have been returned from SNS-W the last time we
+        /// called list_upgrade_steps.
+        #[prost(message, optional, tag = "1")]
+        pub upgrade_steps: ::core::option::Option<Versions>,
+        /// The timestamp of the request we sent to list_upgrade_steps.
+        /// It's possible that this is greater than the response_timestamp_seconds, because
+        /// we update it as soon as we send the request, and only update the
+        /// response_timestamp and the upgrade_steps when we receive the response.
+        /// The primary use of this is that we can avoid calling list_upgrade_steps
+        /// more frequently than necessary.
+        #[prost(uint64, optional, tag = "2")]
+        pub requested_timestamp_seconds: ::core::option::Option<u64>,
+        /// The timestamp of the response we received from list_upgrade_steps (stored in upgrade_steps).
+        #[prost(uint64, optional, tag = "3")]
+        pub response_timestamp_seconds: ::core::option::Option<u64>,
     }
     #[derive(
         candid::CandidType,

--- a/rs/sns/governance/src/gen/ic_sns_governance.pb.v1.rs
+++ b/rs/sns/governance/src/gen/ic_sns_governance.pb.v1.rs
@@ -3306,6 +3306,30 @@ pub struct AddMaturityResponse {
     #[prost(uint64, optional, tag = "1")]
     pub new_maturity_e8s: ::core::option::Option<u64>,
 }
+#[derive(
+    candid::CandidType,
+    candid::Deserialize,
+    comparable::Comparable,
+    Clone,
+    Copy,
+    PartialEq,
+    ::prost::Message,
+)]
+pub struct GetUpgradeJournalRequest {}
+#[derive(
+    candid::CandidType,
+    candid::Deserialize,
+    comparable::Comparable,
+    Clone,
+    PartialEq,
+    ::prost::Message,
+)]
+pub struct GetUpgradeJournalResponse {
+    #[prost(message, optional, tag = "1")]
+    pub upgrade_steps: ::core::option::Option<governance::Versions>,
+    #[prost(uint64, optional, tag = "2")]
+    pub response_timestamp_seconds: ::core::option::Option<u64>,
+}
 /// A request to mint tokens for a particular principal. The associated endpoint
 /// is only available on SNS governance, and only then when SNS governance is
 /// compiled with the `test` feature enabled.

--- a/rs/sns/governance/src/governance.rs
+++ b/rs/sns/governance/src/governance.rs
@@ -153,7 +153,7 @@ pub fn log_prefix() -> String {
 pub const TREASURY_SUBACCOUNT_NONCE: u64 = 0;
 
 // How frequently the canister should attempt to refresh the cached_upgrade_steps
-pub const UPGRADE_STEPS_INTERVAL_REFRESH_BACKOFF_SECONDS: u64 = 5 * 60; // 5 minutes
+pub const UPGRADE_STEPS_INTERVAL_REFRESH_BACKOFF_SECONDS: u64 = 60 * 60; // 1 hour
 
 /// Converts bytes to a subaccountpub fn bytes_to_subaccount(bytes: &[u8]) -> Result<icrc_ledger_types::icrc1::account::Subaccount, GovernanceError> {
 pub fn bytes_to_subaccount(

--- a/rs/sns/governance/src/governance.rs
+++ b/rs/sns/governance/src/governance.rs
@@ -45,15 +45,16 @@ use crate::{
             GetMaturityModulationRequest, GetMaturityModulationResponse, GetMetadataRequest,
             GetMetadataResponse, GetMode, GetModeResponse, GetNeuron, GetNeuronResponse,
             GetProposal, GetProposalResponse, GetSnsInitializationParametersRequest,
-            GetSnsInitializationParametersResponse, Governance as GovernanceProto, GovernanceError,
-            ListNervousSystemFunctionsResponse, ListNeurons, ListNeuronsResponse, ListProposals,
-            ListProposalsResponse, ManageDappCanisterSettings, ManageLedgerParameters,
-            ManageNeuron, ManageNeuronResponse, ManageSnsMetadata, MintSnsTokens,
-            MintTokensRequest, MintTokensResponse, NervousSystemFunction, NervousSystemParameters,
-            Neuron, NeuronId, NeuronPermission, NeuronPermissionList, NeuronPermissionType,
-            Proposal, ProposalData, ProposalDecisionStatus, ProposalId, ProposalRewardStatus,
-            RegisterDappCanisters, RewardEvent, Tally, TransferSnsTreasuryFunds,
-            UpgradeSnsControlledCanister, UpgradeSnsToNextVersion, Vote, WaitForQuietState,
+            GetSnsInitializationParametersResponse, GetUpgradeJournalResponse,
+            Governance as GovernanceProto, GovernanceError, ListNervousSystemFunctionsResponse,
+            ListNeurons, ListNeuronsResponse, ListProposals, ListProposalsResponse,
+            ManageDappCanisterSettings, ManageLedgerParameters, ManageNeuron, ManageNeuronResponse,
+            ManageSnsMetadata, MintSnsTokens, MintTokensRequest, MintTokensResponse,
+            NervousSystemFunction, NervousSystemParameters, Neuron, NeuronId, NeuronPermission,
+            NeuronPermissionList, NeuronPermissionType, Proposal, ProposalData,
+            ProposalDecisionStatus, ProposalId, ProposalRewardStatus, RegisterDappCanisters,
+            RewardEvent, Tally, TransferSnsTreasuryFunds, UpgradeSnsControlledCanister,
+            UpgradeSnsToNextVersion, Vote, WaitForQuietState,
         },
     },
     proposal::{
@@ -4729,6 +4730,20 @@ impl Governance {
                 upgrade_steps: Some(upgrade_steps),
                 ..Default::default()
             });
+        }
+    }
+
+    pub fn get_upgrade_journal(&self) -> GetUpgradeJournalResponse {
+        let cached_upgrade_steps = self.proto.cached_upgrade_steps.clone();
+        match cached_upgrade_steps {
+            Some(cached_upgrade_steps) => GetUpgradeJournalResponse {
+                upgrade_steps: cached_upgrade_steps.upgrade_steps,
+                response_timestamp_seconds: cached_upgrade_steps.response_timestamp_seconds,
+            },
+            None => GetUpgradeJournalResponse {
+                upgrade_steps: None,
+                response_timestamp_seconds: None,
+            },
         }
     }
 

--- a/rs/sns/governance/src/governance.rs
+++ b/rs/sns/governance/src/governance.rs
@@ -20,7 +20,8 @@ use crate::{
             governance::{
                 self,
                 neuron_in_flight_command::{self, Command as InFlightCommand},
-                MaturityModulation, NeuronInFlightCommand, SnsMetadata, UpgradeInProgress, Version,
+                CachedUpgradeSteps, MaturityModulation, NeuronInFlightCommand, SnsMetadata,
+                UpgradeInProgress, Version, Versions,
             },
             governance_error::ErrorType,
             manage_neuron::{
@@ -150,6 +151,9 @@ pub fn log_prefix() -> String {
 }
 /// The static MEMO used when calculating the SNS Treasury subaccount.
 pub const TREASURY_SUBACCOUNT_NONCE: u64 = 0;
+
+// How frequently the canister should attempt to refresh the cached_upgrade_steps
+pub const UPGRADE_STEPS_INTERVAL_REFRESH_BACKOFF_SECONDS: u64 = 5 * 60; // 5 minutes
 
 /// Converts bytes to a subaccountpub fn bytes_to_subaccount(bytes: &[u8]) -> Result<icrc_ledger_types::icrc1::account::Subaccount, GovernanceError> {
 pub fn bytes_to_subaccount(
@@ -4597,6 +4601,8 @@ impl Governance {
 
     /// Runs periodic tasks that are not directly triggered by user input.
     pub async fn heartbeat(&mut self) {
+        use dfn_core::println;
+
         self.process_proposals();
 
         if self.should_check_upgrade_status() {
@@ -4632,6 +4638,98 @@ impl Governance {
         self.maybe_move_staked_maturity();
 
         self.maybe_gc();
+
+        log!(INFO, "AAA");
+        println!("AAA");
+        if self.should_refresh_cached_upgrade_steps() {
+            log!(INFO, "BBB");
+            println!("BBB");
+            self.temporarily_lock_refresh_cached_upgrade_steps();
+            log!(INFO, "CCC");
+            println!("CCC");
+            self.refresh_cached_upgrade_steps().await;
+            log!(INFO, "DDD");
+            println!("DDD");
+        }
+        log!(INFO, "EEE");
+        println!("EEE");
+    }
+
+    pub fn temporarily_lock_refresh_cached_upgrade_steps(&mut self) {
+        if let Some(ref mut cached_upgrade_steps) = self.proto.cached_upgrade_steps {
+            cached_upgrade_steps.requested_timestamp_seconds = Some(self.env.now());
+        } else {
+            self.proto.cached_upgrade_steps = Some(CachedUpgradeSteps {
+                requested_timestamp_seconds: Some(self.env.now()),
+                ..Default::default()
+            });
+        }
+    }
+
+    pub fn should_refresh_cached_upgrade_steps(&mut self) -> bool {
+        let now = self.env.now();
+
+        if let Some(ref cached_upgrade_steps) = self.proto.cached_upgrade_steps {
+            let requested_timestamp_seconds = cached_upgrade_steps
+                .requested_timestamp_seconds
+                .unwrap_or(0);
+            if now - requested_timestamp_seconds < UPGRADE_STEPS_INTERVAL_REFRESH_BACKOFF_SECONDS {
+                return false;
+            }
+        }
+
+        true
+    }
+
+    /// Refreshes the cached_upgrade_steps field
+    pub async fn refresh_cached_upgrade_steps(&mut self) {
+        let Some(deployed_version) = self.proto.deployed_version.as_ref() else {
+            log!(
+                ERROR,
+                "Cannot refresh cached_upgrade_steps: deployed_version not set."
+            );
+            return;
+        };
+        let sns_governance_canister_id = self.env.canister_id().get();
+
+        let upgrade_steps = crate::sns_upgrade::get_upgrade_steps(
+            &*self.env,
+            deployed_version.clone(),
+            sns_governance_canister_id,
+        )
+        .await;
+
+        let upgrade_steps = match upgrade_steps {
+            Ok(upgrade_steps) => upgrade_steps,
+            Err(err) => {
+                log!(
+                    ERROR,
+                    "Cannot refresh cached_upgrade_steps: call to SNS-W failed: {}",
+                    err
+                );
+                return;
+            }
+        };
+        let upgrade_steps = Versions {
+            versions: upgrade_steps,
+        };
+
+        // The following code must remain after the async call.
+        if let Some(ref mut cached_upgrade_steps) = self.proto.cached_upgrade_steps {
+            cached_upgrade_steps.response_timestamp_seconds = Some(self.env.now());
+            cached_upgrade_steps.upgrade_steps = Some(upgrade_steps);
+        }
+        // It's unlikely that cached_upgrade_steps is None, the caller is
+        // supposed to set the lock (by setting request_timestamp_seconds) before this function is called,
+        // and that requires cached_upgrade_steps != None.
+        // However, we handle it just in case.
+        else {
+            self.proto.cached_upgrade_steps = Some(CachedUpgradeSteps {
+                response_timestamp_seconds: Some(self.env.now()),
+                upgrade_steps: Some(upgrade_steps),
+                ..Default::default()
+            });
+        }
     }
 
     fn should_update_maturity_modulation(&self) -> bool {

--- a/rs/sns/governance/src/proposal.rs
+++ b/rs/sns/governance/src/proposal.rs
@@ -2489,6 +2489,7 @@ mod tests {
             pending_version: None,
             is_finalizing_disburse_maturity: None,
             maturity_modulation: None,
+            cached_upgrade_steps: None,
         }
     }
 

--- a/rs/sns/governance/src/request_impls.rs
+++ b/rs/sns/governance/src/request_impls.rs
@@ -1,82 +1,73 @@
 use ic_nervous_system_clients::Request;
 
-use crate::pb::v1::{
-    ClaimSwapNeuronsRequest, ClaimSwapNeuronsResponse, FailStuckUpgradeInProgressRequest,
-    FailStuckUpgradeInProgressResponse, GetMaturityModulationRequest,
-    GetMaturityModulationResponse, GetMetadataRequest, GetMetadataResponse, GetMode,
-    GetModeResponse, GetNeuronResponse, GetProposalResponse, GetRunningSnsVersionResponse,
-    GetSnsInitializationParametersRequest, GetSnsInitializationParametersResponse,
-    ListNeuronsResponse, ListProposalsResponse, ManageNeuronResponse,
-};
-
-impl Request for ClaimSwapNeuronsRequest {
-    type Response = ClaimSwapNeuronsResponse;
+impl Request for crate::pb::v1::ClaimSwapNeuronsRequest {
+    type Response = crate::pb::v1::ClaimSwapNeuronsResponse;
     const METHOD: &'static str = "claim_swap_neurons";
     const UPDATE: bool = true;
 }
 
-impl Request for FailStuckUpgradeInProgressRequest {
-    type Response = FailStuckUpgradeInProgressResponse;
+impl Request for crate::pb::v1::FailStuckUpgradeInProgressRequest {
+    type Response = crate::pb::v1::FailStuckUpgradeInProgressResponse;
     const METHOD: &'static str = "fail_stuck_upgrade_in_progress";
     const UPDATE: bool = true;
 }
 
-impl Request for GetMaturityModulationRequest {
-    type Response = GetMaturityModulationResponse;
+impl Request for crate::pb::v1::GetMaturityModulationRequest {
+    type Response = crate::pb::v1::GetMaturityModulationResponse;
     const METHOD: &'static str = "get_maturity_modulation";
     const UPDATE: bool = false;
 }
 
-impl Request for GetMetadataRequest {
-    type Response = GetMetadataResponse;
+impl Request for crate::pb::v1::GetMetadataRequest {
+    type Response = crate::pb::v1::GetMetadataResponse;
     const METHOD: &'static str = "get_metadata";
     const UPDATE: bool = false;
 }
 
-impl Request for GetSnsInitializationParametersRequest {
-    type Response = GetSnsInitializationParametersResponse;
+impl Request for crate::pb::v1::GetSnsInitializationParametersRequest {
+    type Response = crate::pb::v1::GetSnsInitializationParametersResponse;
     const METHOD: &'static str = "get_sns_initialization_parameters";
     const UPDATE: bool = false;
 }
 
-impl Request for GetMode {
-    type Response = GetModeResponse;
+impl Request for crate::pb::v1::GetMode {
+    type Response = crate::pb::v1::GetModeResponse;
     const METHOD: &'static str = "get_mode";
     const UPDATE: bool = false;
 }
 
 impl Request for crate::pb::v1::GetNeuron {
-    type Response = GetNeuronResponse;
+    type Response = crate::pb::v1::GetNeuronResponse;
     const METHOD: &'static str = "get_neuron";
     const UPDATE: bool = false;
 }
 
 impl Request for crate::pb::v1::GetProposal {
-    type Response = GetProposalResponse;
+    type Response = crate::pb::v1::GetProposalResponse;
     const METHOD: &'static str = "get_proposal";
     const UPDATE: bool = false;
 }
 
 impl Request for crate::pb::v1::ListNeurons {
-    type Response = ListNeuronsResponse;
+    type Response = crate::pb::v1::ListNeuronsResponse;
     const METHOD: &'static str = "list_neurons";
     const UPDATE: bool = false;
 }
 
 impl Request for crate::pb::v1::ListProposals {
-    type Response = ListProposalsResponse;
+    type Response = crate::pb::v1::ListProposalsResponse;
     const METHOD: &'static str = "list_proposals";
     const UPDATE: bool = false;
 }
 
 impl Request for crate::pb::v1::ManageNeuron {
-    type Response = ManageNeuronResponse;
+    type Response = crate::pb::v1::ManageNeuronResponse;
     const METHOD: &'static str = "manage_neuron";
     const UPDATE: bool = true;
 }
 
 impl Request for crate::pb::v1::GetRunningSnsVersionRequest {
-    type Response = GetRunningSnsVersionResponse;
+    type Response = crate::pb::v1::GetRunningSnsVersionResponse;
     const METHOD: &'static str = "get_running_sns_version";
-    const UPDATE: bool = true;
+    const UPDATE: bool = false;
 }

--- a/rs/sns/governance/src/request_impls.rs
+++ b/rs/sns/governance/src/request_impls.rs
@@ -71,3 +71,9 @@ impl Request for crate::pb::v1::GetRunningSnsVersionRequest {
     const METHOD: &'static str = "get_running_sns_version";
     const UPDATE: bool = false;
 }
+
+impl Request for crate::pb::v1::GetUpgradeJournalRequest {
+    type Response = crate::pb::v1::GetUpgradeJournalResponse;
+    const METHOD: &'static str = "get_upgrade_journal";
+    const UPDATE: bool = false;
+}

--- a/rs/sns/governance/src/sns_upgrade.rs
+++ b/rs/sns/governance/src/sns_upgrade.rs
@@ -293,6 +293,43 @@ async fn get_next_version(env: &dyn Environment, current_version: &Version) -> O
     response.next_version.map(|v| v.into())
 }
 
+pub(crate) async fn get_upgrade_steps(
+    env: &dyn Environment,
+    current_version: Version,
+    sns_governance_canister_id: PrincipalId,
+) -> Result<Vec<Version>, String> {
+    let request = ListUpgradeStepsRequest {
+        starting_at: Some(current_version.into()),
+        sns_governance_canister_id: Some(sns_governance_canister_id),
+        limit: 0,
+    };
+    let arg = Encode!(&request)
+        .map_err(|e| format!("Could not encode ListUpgradeStepsRequest: {:?}", e))?;
+
+    let response = env
+        .call_canister(SNS_WASM_CANISTER_ID, "list_upgrade_steps", arg)
+        .await
+        .map_err(|e| format!("Request failed for get_next_sns_version: {:?}", e))?;
+
+    let response = Decode!(&response, ListUpgradeStepsResponse)
+        .map_err(|e| format!("Could not decode response to get_next_sns_version: {:?}", e))?;
+    let response_str = format!("{:?}", response);
+
+    response
+        .steps
+        .into_iter()
+        .map(|list_upgrade_step| match list_upgrade_step {
+            ListUpgradeStep {
+                version: Some(version),
+            } => Ok(version.into()),
+            _ => Err(format!(
+                "list_upgrade_steps response had invalid fields: {}",
+                response_str
+            )),
+        })
+        .collect()
+}
+
 /// Returns all SNS canisters known by the Root canister.
 pub(crate) async fn get_all_sns_canisters(
     env: &dyn Environment,
@@ -477,7 +514,7 @@ pub(crate) struct GetNextSnsVersionResponse {
 /// Avoid using outside of tests and the functions in this file.
 /// Specifies the version of an SNS.
 #[derive(Clone, Eq, PartialEq, Hash, ::prost::Message, candid::CandidType, candid::Deserialize)]
-pub(crate) struct SnsVersion {
+pub struct SnsVersion {
     /// The hash of the Root canister WASM.
     #[prost(bytes = "vec", tag = "1")]
     pub root_wasm_hash: ::prost::alloc::vec::Vec<u8>,
@@ -601,4 +638,22 @@ pub struct GetProposalIdThatAddedWasmRequest {
 pub struct GetProposalIdThatAddedWasmResponse {
     #[prost(uint64, optional, tag = "1")]
     pub proposal_id: ::core::option::Option<u64>,
+}
+
+#[derive(Clone, PartialEq, candid::CandidType, candid::Deserialize, Debug)]
+pub struct ListUpgradeStepsRequest {
+    /// If provided, limit response to only include entries for this version and later
+    pub starting_at: ::core::option::Option<SnsVersion>,
+    /// If provided, give responses that this canister would get back
+    pub sns_governance_canister_id: ::core::option::Option<::ic_base_types::PrincipalId>,
+    /// Limit to number of entries (for paging)
+    pub limit: u32,
+}
+#[derive(candid::CandidType, candid::Deserialize, Debug)]
+pub struct ListUpgradeStepsResponse {
+    pub steps: ::prost::alloc::vec::Vec<ListUpgradeStep>,
+}
+#[derive(candid::CandidType, candid::Deserialize, Debug)]
+pub struct ListUpgradeStep {
+    pub version: ::core::option::Option<SnsVersion>,
 }

--- a/rs/sns/governance/tests/fixtures/environment_fixture.rs
+++ b/rs/sns/governance/tests/fixtures/environment_fixture.rs
@@ -4,6 +4,7 @@ use ic_base_types::CanisterId;
 use ic_nervous_system_clients::update_settings::CanisterSettings;
 use ic_sns_governance::{
     pb::sns_root_types::{RegisterDappCanistersRequest, SetDappControllersRequest},
+    sns_upgrade::ListUpgradeStepsRequest,
     types::{Environment, HeapGrowthPotential},
 };
 use rand::{rngs::StdRng, RngCore};
@@ -17,6 +18,7 @@ pub enum CanisterCallRequest {
     RegisterDappCanisters(RegisterDappCanistersRequest),
     SetDappControllers(SetDappControllersRequest),
     UpdateSettings(CanisterSettings),
+    ListUpgradeSteps(ListUpgradeStepsRequest),
 }
 
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
@@ -74,6 +76,9 @@ impl EnvironmentFixture {
             }
             "update_settings" => {
                 CanisterCallRequest::UpdateSettings(Decode!(&args, CanisterSettings)?)
+            }
+            "list_upgrade_steps" => {
+                CanisterCallRequest::ListUpgradeSteps(Decode!(&args, ListUpgradeStepsRequest)?)
             }
             _ => panic!("Unsupported method_name `{method_name}` in decode_canister_call."),
         };

--- a/rs/sns/governance/tests/fixtures/mod.rs
+++ b/rs/sns/governance/tests/fixtures/mod.rs
@@ -38,7 +38,7 @@ use std::{
 
 pub mod environment_fixture;
 
-const DEFAULT_TEST_START_TIMESTAMP_SECONDS: u64 = 999_111_000_u64;
+pub const DEFAULT_TEST_START_TIMESTAMP_SECONDS: u64 = 999_111_000_u64;
 
 /// Constructs a neuron id from a principal_id and memo. This is a
 /// convenient helper method in tests.


### PR DESCRIPTION
This PR implements part of periodic task type A, which fetches the remaining upgrade steps from SNS-W.

This PR does not implement the part of periodic task type A that refreshes deployed_version when an upgrade triggered by a change to target_version is in progress.

This PR also implements a SnsGov.get_upgrade_journal endpoint, which will be used in the future to get all the info needed to audit SNS Upgrades, but for now will just be used to see the cached_upgrade_steps

Remaining work: Add a pocketic test

| [Next PR](https://github.com/dfinity/ic/pull/1854) >