### PR TITLE
feat: EXC-1750: Charge canisters proportionally to their load

### DIFF
--- a/rs/execution_environment/src/scheduler/round_schedule.rs
+++ b/rs/execution_environment/src/scheduler/round_schedule.rs
@@ -3,7 +3,9 @@ use std::collections::{BTreeMap, HashMap};
 use ic_base_types::{CanisterId, NumBytes};
 use ic_config::flag_status::FlagStatus;
 use ic_replicated_state::{canister_state::NextExecution, CanisterState};
-use ic_types::{AccumulatedPriority, ComputeAllocation, LongExecutionMode};
+use ic_types::{AccumulatedPriority, ComputeAllocation, ExecutionRound, LongExecutionMode};
+
+use super::SchedulerImpl;
 
 /// Round metrics required to prioritize a canister.
 #[derive(Clone, Debug)]
@@ -228,5 +230,78 @@ impl RoundSchedule {
         }
 
         (canisters_partitioned_by_cores, canisters)
+    }
+
+    /// Finishes canister execution on thread.
+    pub fn finish_canister_execution_on_thread(
+        canister: &mut CanisterState,
+        executed_priority_ids: &mut BTreeMap<CanisterId, AccumulatedPriority>,
+        round_id: ExecutionRound,
+        is_first_iteration: bool,
+        rank: usize,
+    ) {
+        let full_message_execution = match canister.next_execution() {
+            NextExecution::None => true,
+            NextExecution::StartNew => false,
+            // We just finished a full slice of executions.
+            NextExecution::ContinueLong | NextExecution::ContinueInstallCode => true,
+        };
+        let scheduled_first = is_first_iteration && rank == 0;
+
+        if full_message_execution || scheduled_first {
+            // The very first canister is considered to have a full execution round for
+            // scheduling purposes even if it did not complete within the round.
+            canister.scheduler_state.last_full_execution_round = round_id;
+
+            // For now the priority for full execution is always 100.
+            // In future we might use a proportion to the actual load.
+            executed_priority_ids.insert(canister.canister_id(), 100.into());
+        }
+    }
+
+    /// Finishes inner round execution.
+    pub(crate) fn finish_inner_round(
+        &self,
+        canister_states: &mut BTreeMap<CanisterId, CanisterState>,
+        executed_priority_ids: BTreeMap<CanisterId, AccumulatedPriority>,
+    ) {
+        let scheduler_cores = self.scheduler_cores;
+        let compute_capacity_percent =
+            SchedulerImpl::compute_capacity_percent(scheduler_cores) as i64;
+        let number_of_canisters = canister_states.len();
+        let multiplier = (scheduler_cores * number_of_canisters).max(1) as i64;
+
+        // Charge canisters for the priority executed in the previous round.
+        let mut total_executed_priority = 0;
+        for (canister_id, executed_priority) in executed_priority_ids {
+            if let Some(canister) = canister_states.get_mut(&canister_id) {
+                total_executed_priority += executed_priority.get() * multiplier;
+                // If priority credit is non-zero, use it instead of accumulated priority.
+                if canister.scheduler_state.priority_credit != 0.into() {
+                    canister.scheduler_state.priority_credit += executed_priority * multiplier;
+                } else {
+                    canister.scheduler_state.accumulated_priority -= executed_priority * multiplier;
+                }
+            }
+        }
+
+        // Scale the executed priority to compute capacity.
+        let executed_multiplier = total_executed_priority / compute_capacity_percent;
+        // Distribute the executed priority across canisters according to their allocations.
+        let mut total_allocated = 0;
+        for (_canister_id, canister) in canister_states.iter_mut() {
+            let allocated = canister.scheduler_state.compute_allocation.as_percent() as i64
+                * executed_multiplier;
+            total_allocated += allocated;
+            canister.scheduler_state.accumulated_priority += allocated.into();
+        }
+        // Fully distribute the rest across all canisters.
+        let mut to_distribute = total_executed_priority - total_allocated;
+        let n = canister_states.len();
+        for (i, (_canister_id, canister)) in canister_states.iter_mut().enumerate() {
+            let distributed = to_distribute / (n - i) as i64;
+            to_distribute -= distributed;
+            canister.scheduler_state.accumulated_priority += distributed.into();
+        }
     }
 }

--- a/rs/execution_environment/src/scheduler/tests.rs
+++ b/rs/execution_environment/src/scheduler/tests.rs
@@ -5936,3 +5936,96 @@ fn inner_round_long_execution_is_a_full_execution() {
     // The accumulated priority invariant should be respected.
     assert_eq!(total_accumulated_priority - total_priority_credit, 0);
 }
+
+#[test_strategy::proptest(ProptestConfig { cases: 8, ..ProptestConfig::default() })]
+fn charge_canisters_for_full_execution(#[strategy(2..10_usize)] scheduler_cores: usize) {
+    let instructions = 20;
+    let messages_per_round = 2;
+    let mut test = SchedulerTestBuilder::new()
+        .with_scheduler_config(SchedulerConfig {
+            scheduler_cores,
+            max_instructions_per_round: (instructions * messages_per_round).into(),
+            max_instructions_per_message: instructions.into(),
+            max_instructions_per_message_without_dts: instructions.into(),
+            max_instructions_per_slice: instructions.into(),
+            instruction_overhead_per_execution: 0.into(),
+            instruction_overhead_per_canister: 0.into(),
+            instruction_overhead_per_canister_for_finalization: 0.into(),
+            ..SchedulerConfig::application_subnet()
+        })
+        .build();
+
+    // Bump up the round number.
+    test.execute_round(ExecutionRoundType::OrdinaryRound);
+
+    // Create `messages_per_round * 2` canisters for each scheduler core.
+    let num_canisters = scheduler_cores as u64 * messages_per_round * 2;
+    let mut canister_ids = vec![];
+    for _ in 0..num_canisters {
+        let canister_id = test.create_canister();
+        // Send one messages per canister. Having `max_messages_per_round * 2` canisters,
+        // only half of them will finish in one round.
+        test.send_ingress(canister_id, ingress(instructions));
+        canister_ids.push(canister_id);
+    }
+
+    test.execute_round(ExecutionRoundType::OrdinaryRound);
+
+    let mut total_accumulated_priority = 0;
+    let mut total_priority_credit = 0;
+    for (i, canister) in test.state().canisters_iter().enumerate() {
+        if i < num_canisters as usize / 2 {
+            // The first half of the canisters should finish their messages.
+            prop_assert_eq!(canister.system_state.queues().ingress_queue_size(), 0);
+            prop_assert_eq!(canister.system_state.canister_metrics.executed, 1);
+            prop_assert_eq!(
+                canister.scheduler_state.last_full_execution_round,
+                test.last_round()
+            );
+        } else {
+            // The second half of the canisters should still have their messages.
+            prop_assert_eq!(canister.system_state.queues().ingress_queue_size(), 1);
+            prop_assert_eq!(canister.system_state.canister_metrics.executed, 0);
+            prop_assert_eq!(canister.scheduler_state.last_full_execution_round, 0.into());
+        }
+        total_accumulated_priority += canister.scheduler_state.accumulated_priority.get();
+        total_priority_credit += canister.scheduler_state.priority_credit.get();
+    }
+    prop_assert_eq!(total_accumulated_priority - total_priority_credit, 0);
+
+    // Send one more message for first half of the canisters.
+    for (i, canister) in canister_ids.iter().enumerate() {
+        if i < num_canisters as usize / 2 {
+            test.send_ingress(*canister, ingress(instructions));
+        }
+    }
+
+    test.execute_round(ExecutionRoundType::OrdinaryRound);
+
+    let mut total_accumulated_priority = 0;
+    let mut total_priority_credit = 0;
+    for (i, canister) in test.state().canisters_iter().enumerate() {
+        // Now all the canisters should be executed once.
+        prop_assert_eq!(canister.system_state.canister_metrics.executed, 1);
+        if i < num_canisters as usize / 2 {
+            // The first half of the canisters should have messages.
+            prop_assert_eq!(canister.system_state.queues().ingress_queue_size(), 1);
+            // The first half of the canisters should be executed two rounds ago.
+            prop_assert_eq!(
+                canister.scheduler_state.last_full_execution_round.get(),
+                test.last_round().get() - 1
+            );
+        } else {
+            // The second half of the canisters should finish their messages.
+            prop_assert_eq!(canister.system_state.queues().ingress_queue_size(), 0);
+            // The second half of the canisters should be executed in the last round.
+            prop_assert_eq!(
+                canister.scheduler_state.last_full_execution_round,
+                test.last_round()
+            );
+        }
+        total_accumulated_priority += canister.scheduler_state.accumulated_priority.get();
+        total_priority_credit += canister.scheduler_state.priority_credit.get();
+    }
+    prop_assert_eq!(total_accumulated_priority - total_priority_credit, 0);
+}


### PR DESCRIPTION
This change applies charges for executed canisters proportionally to their actual load (number of executed instructions).

This should prioritize interactive canisters vs batch canisters.