### PR TITLE
chore: [MR-616] Drop `CanisterQueue::QueueItem` proto, part 1

### DIFF
--- a/rs/protobuf/def/state/queues/v1/queues.proto
+++ b/rs/protobuf/def/state/queues/v1/queues.proto
@@ -171,7 +171,7 @@ message CanisterQueue {
 
   // [Deprecated] FIFO queue of references into the pool and reject response
   // markers.
-  repeated QueueItem queue_items = 1;
+  repeated QueueItem deprecated_queue = 1;
   // FIFO queue of references into the pool or the compact reject response maps.
   repeated uint64 queue = 4;
   // Maximum number of requests or responses that can be enqueued at any one time.

--- a/rs/protobuf/def/state/queues/v1/queues.proto
+++ b/rs/protobuf/def/state/queues/v1/queues.proto
@@ -169,8 +169,11 @@ message CanisterQueue {
     }
   }
 
-  // FIFO queue of references into the pool and reject response markers.
-  repeated QueueItem queue = 1;
+  // [Deprecated] FIFO queue of references into the pool and reject response
+  // markers.
+  repeated QueueItem queue_items = 1;
+  // FIFO queue of references into the pool or the compact reject response maps.
+  repeated uint64 queue = 4;
   // Maximum number of requests or responses that can be enqueued at any one time.
   uint64 capacity = 2;
   // Number of slots used by or reserved for responses.

--- a/rs/protobuf/src/gen/state/state.queues.v1.rs
+++ b/rs/protobuf/src/gen/state/state.queues.v1.rs
@@ -204,9 +204,13 @@ pub mod message_pool {
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CanisterQueue {
-    /// FIFO queue of references into the pool and reject response markers.
+    /// \[Deprecated\] FIFO queue of references into the pool and reject response
+    /// markers.
     #[prost(message, repeated, tag = "1")]
-    pub queue: ::prost::alloc::vec::Vec<canister_queue::QueueItem>,
+    pub queue_items: ::prost::alloc::vec::Vec<canister_queue::QueueItem>,
+    /// FIFO queue of references into the pool or the compact reject response maps.
+    #[prost(uint64, repeated, tag = "4")]
+    pub queue: ::prost::alloc::vec::Vec<u64>,
     /// Maximum number of requests or responses that can be enqueued at any one time.
     #[prost(uint64, tag = "2")]
     pub capacity: u64,

--- a/rs/protobuf/src/gen/state/state.queues.v1.rs
+++ b/rs/protobuf/src/gen/state/state.queues.v1.rs
@@ -207,7 +207,7 @@ pub struct CanisterQueue {
     /// \[Deprecated\] FIFO queue of references into the pool and reject response
     /// markers.
     #[prost(message, repeated, tag = "1")]
-    pub queue_items: ::prost::alloc::vec::Vec<canister_queue::QueueItem>,
+    pub deprecated_queue: ::prost::alloc::vec::Vec<canister_queue::QueueItem>,
     /// FIFO queue of references into the pool or the compact reject response maps.
     #[prost(uint64, repeated, tag = "4")]
     pub queue: ::prost::alloc::vec::Vec<u64>,

--- a/rs/protobuf/src/gen/types/state.queues.v1.rs
+++ b/rs/protobuf/src/gen/types/state.queues.v1.rs
@@ -204,9 +204,13 @@ pub mod message_pool {
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CanisterQueue {
-    /// FIFO queue of references into the pool and reject response markers.
+    /// \[Deprecated\] FIFO queue of references into the pool and reject response
+    /// markers.
     #[prost(message, repeated, tag = "1")]
-    pub queue: ::prost::alloc::vec::Vec<canister_queue::QueueItem>,
+    pub queue_items: ::prost::alloc::vec::Vec<canister_queue::QueueItem>,
+    /// FIFO queue of references into the pool or the compact reject response maps.
+    #[prost(uint64, repeated, tag = "4")]
+    pub queue: ::prost::alloc::vec::Vec<u64>,
     /// Maximum number of requests or responses that can be enqueued at any one time.
     #[prost(uint64, tag = "2")]
     pub capacity: u64,

--- a/rs/protobuf/src/gen/types/state.queues.v1.rs
+++ b/rs/protobuf/src/gen/types/state.queues.v1.rs
@@ -207,7 +207,7 @@ pub struct CanisterQueue {
     /// \[Deprecated\] FIFO queue of references into the pool and reject response
     /// markers.
     #[prost(message, repeated, tag = "1")]
-    pub queue_items: ::prost::alloc::vec::Vec<canister_queue::QueueItem>,
+    pub deprecated_queue: ::prost::alloc::vec::Vec<canister_queue::QueueItem>,
     /// FIFO queue of references into the pool or the compact reject response maps.
     #[prost(uint64, repeated, tag = "4")]
     pub queue: ::prost::alloc::vec::Vec<u64>,

--- a/rs/replicated_state/src/canister_state/queues/message_pool.rs
+++ b/rs/replicated_state/src/canister_state/queues/message_pool.rs
@@ -289,9 +289,9 @@ where
 {
     type Error = ProxyDecodeError;
     fn try_from(item: u64) -> Result<Self, Self::Error> {
-        let reference = Reference(item, PhantomData);
-        if reference.context() == T::context() {
-            Ok(reference)
+        let id = Id(item);
+        if id.context() == T::context() {
+            Ok(Reference(item, PhantomData))
         } else {
             Err(ProxyDecodeError::Other(format!(
                 "Mismatched reference context: {}",

--- a/rs/replicated_state/src/canister_state/queues/message_pool.rs
+++ b/rs/replicated_state/src/canister_state/queues/message_pool.rs
@@ -283,6 +283,30 @@ impl TryFrom<pb_queues::canister_queue::QueueItem> for OutboundReference {
     }
 }
 
+impl<T> TryFrom<u64> for Reference<T>
+where
+    T: ToContext,
+{
+    type Error = ProxyDecodeError;
+    fn try_from(item: u64) -> Result<Self, Self::Error> {
+        let reference = Reference(item, PhantomData);
+        if reference.context() == T::context() {
+            Ok(reference)
+        } else {
+            Err(ProxyDecodeError::Other(format!(
+                "Mismatched reference context: {}",
+                item
+            )))
+        }
+    }
+}
+
+impl<T> From<&Reference<T>> for u64 {
+    fn from(item: &Reference<T>) -> Self {
+        item.0
+    }
+}
+
 /// Helper for encoding / decoding `pb_queues::canister_queues::CallbackReference`.
 #[derive(Clone, Eq, PartialEq, Debug)]
 pub(super) struct CallbackReference(pub(super) InboundReference, pub(super) CallbackId);

--- a/rs/replicated_state/src/canister_state/queues/queue.rs
+++ b/rs/replicated_state/src/canister_state/queues/queue.rs
@@ -298,6 +298,7 @@ impl<T> CanisterQueue<T> {
 impl<T> From<&CanisterQueue<T>> for pb_queues::CanisterQueue {
     fn from(item: &CanisterQueue<T>) -> Self {
         Self {
+            queue_items: item.queue.iter().map(Into::into).collect(),
             queue: item.queue.iter().map(Into::into).collect(),
             capacity: item.capacity as u64,
             response_slots: item.response_slots as u64,
@@ -308,20 +309,27 @@ impl<T> From<&CanisterQueue<T>> for pb_queues::CanisterQueue {
 impl<T> TryFrom<pb_queues::CanisterQueue> for CanisterQueue<T>
 where
     Reference<T>: TryFrom<pb_queues::canister_queue::QueueItem, Error = ProxyDecodeError>,
+    Reference<T>: TryFrom<u64, Error = ProxyDecodeError>,
 {
     type Error = ProxyDecodeError;
 
     fn try_from(item: pb_queues::CanisterQueue) -> Result<Self, Self::Error> {
-        let queue: VecDeque<Reference<T>> = item
-            .queue
-            .into_iter()
-            .map(|queue_item| match queue_item.r {
-                Some(pb_queues::canister_queue::queue_item::R::Reference(_)) => {
-                    Ok(Reference::<T>::try_from(queue_item)?)
-                }
-                None => Err(ProxyDecodeError::MissingField("CanisterQueue::queue::r")),
-            })
-            .collect::<Result<_, ProxyDecodeError>>()?;
+        let queue: VecDeque<Reference<T>> = if item.queue_items.is_empty() {
+            item.queue
+                .into_iter()
+                .map(Reference::<T>::try_from)
+                .collect::<Result<_, _>>()?
+        } else {
+            item.queue_items
+                .into_iter()
+                .map(|queue_item| match queue_item.r {
+                    Some(pb_queues::canister_queue::queue_item::R::Reference(_)) => {
+                        Ok(Reference::<T>::try_from(queue_item)?)
+                    }
+                    None => Err(ProxyDecodeError::MissingField("CanisterQueue::queue::r")),
+                })
+                .collect::<Result<_, ProxyDecodeError>>()?
+        };
         let request_slots = queue
             .iter()
             .filter(|reference| reference.kind() == Kind::Request)

--- a/rs/replicated_state/src/canister_state/queues/queue.rs
+++ b/rs/replicated_state/src/canister_state/queues/queue.rs
@@ -298,7 +298,7 @@ impl<T> CanisterQueue<T> {
 impl<T> From<&CanisterQueue<T>> for pb_queues::CanisterQueue {
     fn from(item: &CanisterQueue<T>) -> Self {
         Self {
-            queue_items: item.queue.iter().map(Into::into).collect(),
+            deprecated_queue: item.queue.iter().map(Into::into).collect(),
             queue: item.queue.iter().map(Into::into).collect(),
             capacity: item.capacity as u64,
             response_slots: item.response_slots as u64,
@@ -314,13 +314,13 @@ where
     type Error = ProxyDecodeError;
 
     fn try_from(item: pb_queues::CanisterQueue) -> Result<Self, Self::Error> {
-        let queue: VecDeque<Reference<T>> = if item.queue_items.is_empty() {
+        let queue: VecDeque<Reference<T>> = if !item.queue.is_empty() {
             item.queue
                 .into_iter()
                 .map(Reference::<T>::try_from)
                 .collect::<Result<_, _>>()?
         } else {
-            item.queue_items
+            item.deprecated_queue
                 .into_iter()
                 .map(|queue_item| match queue_item.r {
                     Some(pb_queues::canister_queue::queue_item::R::Reference(_)) => {

--- a/rs/replicated_state/src/canister_state/queues/tests.rs
+++ b/rs/replicated_state/src/canister_state/queues/tests.rs
@@ -2006,7 +2006,7 @@ fn decode_with_duplicate_reference() {
     // Replace the reference to the second response with a duplicate reference to
     // the third.
     let input_queue = encoded.canister_queues[0].input_queue.as_mut().unwrap();
-    input_queue.queue_items[1] = input_queue.queue_items.get(2).cloned().unwrap();
+    input_queue.deprecated_queue[1] = input_queue.deprecated_queue.get(2).cloned().unwrap();
     input_queue.queue[1] = input_queue.queue[2];
 
     let metrics = CountingMetrics(RefCell::new(0));
@@ -2040,7 +2040,7 @@ fn decode_with_unreferenced_inbound_response() {
 
     // Remove the reference to the second response.
     let input_queue = encoded.canister_queues[0].input_queue.as_mut().unwrap();
-    input_queue.queue_items.remove(1);
+    input_queue.deprecated_queue.remove(1);
     input_queue.queue.remove(1);
 
     let metrics = CountingMetrics(RefCell::new(0));
@@ -2058,7 +2058,7 @@ fn decode_with_unreferenced_shed_response() {
 
     // Remove the reference to the third (shed) response.
     let input_queue = encoded.canister_queues[0].input_queue.as_mut().unwrap();
-    input_queue.queue_items.remove(2);
+    input_queue.deprecated_queue.remove(2);
     input_queue.queue.remove(2);
 
     assert_matches!(

--- a/rs/replicated_state/src/canister_state/queues/tests.rs
+++ b/rs/replicated_state/src/canister_state/queues/tests.rs
@@ -2006,7 +2006,8 @@ fn decode_with_duplicate_reference() {
     // Replace the reference to the second response with a duplicate reference to
     // the third.
     let input_queue = encoded.canister_queues[0].input_queue.as_mut().unwrap();
-    input_queue.queue[1] = input_queue.queue.get(2).cloned().unwrap();
+    input_queue.queue_items[1] = input_queue.queue_items.get(2).cloned().unwrap();
+    input_queue.queue[1] = input_queue.queue[2];
 
     let metrics = CountingMetrics(RefCell::new(0));
     assert_matches!(
@@ -2023,11 +2024,8 @@ fn decode_with_both_response_and_shed_response_for_reference() {
 
     // Make the the shed response have the same reference as one of the responses.
     let input_queue = encoded.canister_queues[0].input_queue.as_ref().unwrap();
-    let queue_item = input_queue.queue.get(1).unwrap();
-    let pb_queues::canister_queue::queue_item::R::Reference(response_id) =
-        queue_item.r.as_ref().unwrap();
     for shed_response in &mut encoded.shed_responses {
-        shed_response.id = *response_id;
+        shed_response.id = input_queue.queue[1];
     }
 
     assert_matches!(
@@ -2042,6 +2040,7 @@ fn decode_with_unreferenced_inbound_response() {
 
     // Remove the reference to the second response.
     let input_queue = encoded.canister_queues[0].input_queue.as_mut().unwrap();
+    input_queue.queue_items.remove(1);
     input_queue.queue.remove(1);
 
     let metrics = CountingMetrics(RefCell::new(0));
@@ -2059,6 +2058,7 @@ fn decode_with_unreferenced_shed_response() {
 
     // Remove the reference to the third (shed) response.
     let input_queue = encoded.canister_queues[0].input_queue.as_mut().unwrap();
+    input_queue.queue_items.remove(2);
     input_queue.queue.remove(2);
 
     assert_matches!(


### PR DESCRIPTION
[MR-616]: Instead of using enum references, as initially planned, we use plain numeric references but look them up in the pool plus a couple of compact reject response maps. So the `CanisterQueue::QueueItem` proto is no longer necessary.

As a first step, add and populate a new, simpler representation of canister queues (using plain integers). In a second step (and after a replica release) we can then drop the old representation and the `CanisterQueue::QueueItem` message.

[MR-616]: https://dfinity.atlassian.net/browse/MR-616?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ