### PR TITLE
fix(setupos): update default ipv6 prefix and gw for setupos testnets

### DIFF
--- a/ic-os/setupos/config/config.ini
+++ b/ic-os/setupos/config/config.ini
@@ -9,10 +9,10 @@
 # Update the following IPv6 settings as per your network configuration.
 #
 # Define the network part of your IPv6 address:
-ipv6_prefix=2a00:fb01:400:200
+ipv6_prefix=2a00:fb01:400:44
 #
 # Define the gateway address for your IPv6 network. Ensure it's within your network range:
-ipv6_gateway=2a00:fb01:400:200::1
+ipv6_gateway=2a00:fb01:400:44::1
 
 
 # ------------------------------


### PR DESCRIPTION
For manual testnet deployments from setupos, use the current zh2 test machine prefixes as defaults to make it easier.