### PR TITLE
feat(nervous-system): Measure canister update calls.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9583,6 +9583,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ic-nervous-system-histogram"
+version = "0.0.1"
+dependencies = [
+ "ic-metrics-encoder",
+ "itertools 0.12.1",
+ "lazy_static",
+ "pretty_assertions",
+ "prometheus-parse",
+]
+
+[[package]]
 name = "ic-nervous-system-humanize"
 version = "0.9.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9631,6 +9631,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ic-nervous-system-instruction-stats-attribute"
+version = "0.0.1"
+dependencies = [
+ "candid",
+ "ic-cdk 0.13.5",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "ic-nervous-system-integration-tests"
 version = "0.9.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9636,6 +9636,7 @@ version = "0.0.1"
 dependencies = [
  "candid",
  "ic-cdk 0.13.5",
+ "ic-nervous-system-instruction-stats",
  "quote",
  "syn 1.0.109",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9626,7 +9626,6 @@ dependencies = [
  "ic-cdk 0.13.5",
  "ic-metrics-encoder",
  "ic-nervous-system-histogram",
- "itertools 0.12.1",
  "lazy_static",
 ]
 
@@ -9636,7 +9635,6 @@ version = "0.0.1"
 dependencies = [
  "candid",
  "ic-cdk 0.13.5",
- "ic-nervous-system-instruction-stats",
  "quote",
  "syn 1.0.109",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9620,6 +9620,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ic-nervous-system-instruction-stats"
+version = "0.0.1"
+dependencies = [
+ "ic-cdk 0.13.5",
+ "ic-metrics-encoder",
+ "ic-nervous-system-histogram",
+ "itertools 0.12.1",
+ "lazy_static",
+]
+
+[[package]]
 name = "ic-nervous-system-integration-tests"
 version = "0.9.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -168,6 +168,7 @@ members = [
     "rs/nervous_system/common/test_keys",
     "rs/nervous_system/common/test_utils",
     "rs/nervous_system/common/validation",
+    "rs/nervous_system/histogram",
     "rs/nervous_system/humanize",
     "rs/nervous_system/initial_supply",
     "rs/nervous_system/integration_tests",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -171,6 +171,7 @@ members = [
     "rs/nervous_system/histogram",
     "rs/nervous_system/humanize",
     "rs/nervous_system/initial_supply",
+    "rs/nervous_system/instruction_stats",
     "rs/nervous_system/integration_tests",
     "rs/nervous_system/lock",
     "rs/nervous_system/neurons_fund",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -172,6 +172,7 @@ members = [
     "rs/nervous_system/humanize",
     "rs/nervous_system/initial_supply",
     "rs/nervous_system/instruction_stats",
+    "rs/nervous_system/instruction_stats_attribute",
     "rs/nervous_system/integration_tests",
     "rs/nervous_system/lock",
     "rs/nervous_system/neurons_fund",

--- a/rs/nervous_system/histogram/BUILD.bazel
+++ b/rs/nervous_system/histogram/BUILD.bazel
@@ -1,0 +1,35 @@
+load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test")
+
+# TODO: Move this library out of the nervous_system directory.
+# In the meantime, allow everyone to use this.
+package(default_visibility = ["//visibility:public"])
+
+DEPENDENCIES = [
+    "@crate_index//:ic-metrics-encoder",
+    "@crate_index//:itertools",
+    "@crate_index//:lazy_static",
+]
+
+DEV_DEPENDENCIES = [
+    "@crate_index//:pretty_assertions",
+    "@crate_index//:prometheus-parse",
+]
+
+LIB_SRCS = glob(
+    ["src/**/*.rs"],
+    exclude = ["**/*tests*/**"],
+)
+
+rust_library(
+    name = "histogram",
+    srcs = LIB_SRCS,
+    crate_name = "ic_nervous_system_histogram",
+    version = "0.0.1",
+    deps = DEPENDENCIES,
+)
+
+rust_test(
+    name = "histogram_test",
+    srcs = glob(["src/**/*.rs"]),
+    deps = DEPENDENCIES + DEV_DEPENDENCIES,
+)

--- a/rs/nervous_system/histogram/Cargo.toml
+++ b/rs/nervous_system/histogram/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "ic-nervous-system-histogram"
+version = "0.0.1"
+edition = { workspace = true }
+
+[dependencies]
+ic-metrics-encoder = "1"
+itertools = { workspace = true }
+lazy_static = { workspace = true }
+
+[dev-dependencies]
+pretty_assertions = { workspace = true }
+prometheus-parse = { workspace = true }

--- a/rs/nervous_system/histogram/src/lib.rs
+++ b/rs/nervous_system/histogram/src/lib.rs
@@ -1,0 +1,131 @@
+use ic_metrics_encoder::LabeledHistogramBuilder;
+use itertools::Itertools;
+use lazy_static::lazy_static;
+use std::collections::BTreeMap;
+
+#[cfg(test)]
+mod tests;
+
+lazy_static! {
+    /// As the name suggests, this is useful when constructing a Histogram.
+    ///
+    /// The value of this is vec![1,2,3, ... 10, 20, 30, ... 100, 125, 150, 175,
+    /// 200, 225, 250, 275, ...] and goes as high as i64 allows.
+    pub static ref STANDARD_POSITIVE_BIN_INCLUSIVE_UPPER_BOUNDS: Vec<i64> = {
+        let units = (1..=9).into_iter().collect::<Vec<i64>>();
+
+        let max_e = i64::MAX.ilog10();
+        let powers_of_ten = (0..=max_e).into_iter().map(|e| 10_i64.pow(e)).collect::<Vec<i64>>();
+
+        let mut result = powers_of_ten
+            .iter()
+            .cartesian_product(units.iter())
+            .filter_map(|(power_of_ten, unit)| power_of_ten.checked_mul(*unit))
+            .unique()
+            .collect::<Vec<i64>>();
+
+        // result now looks like [1, 2, 3, ... 10, 20, 30, ... 100, 200, 300, ...]
+        // Next, we further "subdivide" elements >= 100 into quarters. So for,
+        // example 200 expands to 200, 225, 250, 275.
+
+        let tail = result.split_off(18);
+        debug_assert_eq!(result[result.len() - 1], 90);
+        debug_assert_eq!(tail[0], 100);
+
+        let minors = [0, 25, 50, 75];
+        let mut tail = tail
+            .iter()
+            .cartesian_product(minors.iter())
+            .filter_map(|(major, minor)| {
+                let e = major.ilog10();
+
+                10_i64.pow(e.saturating_sub(2))
+                    .saturating_mul(*minor)
+                    .checked_add(*major)
+            })
+            .collect::<Vec<i64>>();
+
+        // Concatenate tail back onto result.
+        result.append(&mut tail);
+
+        // A sanity check. Looks like we generated 634 upper bounds.
+        debug_assert!(result.len() < 1000, "{:#?}", result);
+
+        result
+    };
+}
+
+/// An "event" has some real number associated with it. For example, a request takes 123 ms to
+/// process.
+///
+/// This does two things:
+///
+/// 1. Groups events based on
+///     a) the real number associated with the event
+///     b) bucketing scheme (more on this later)
+/// 2. Counts how many events there are in each group.
+///
+/// This is designed to plug into ic_metrics_encoder::MetricsEncoder::histogram_vec.
+///
+/// A limitation of this is that instead of being able to use f64 for the real
+/// value associated with an event, you must use i64. You can usually work with
+/// this by picking a sufficiently small unit.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Histogram {
+    // DO NOT MERGE label_name_to_value: HashMap<String, String>,
+
+    bin_inclusive_upper_bound_to_count: BTreeMap<i64, u64>,
+
+    // Counts events that do not fall into one of the finite bins.
+    infinity_bin_count: u64,
+
+    // This can be used to find the mean of observed real values associated with events.
+    sum: i64,
+}
+
+impl Histogram {
+    pub fn new(bin_inclusive_upper_bounds: Vec<i64>) -> Self {
+        let bin_inclusive_upper_bound_to_count = bin_inclusive_upper_bounds
+            .into_iter()
+            .map(|bin_inclusive_upper_bound| (bin_inclusive_upper_bound, 0))
+            .collect();
+
+        Self {
+            infinity_bin_count: 0,
+            bin_inclusive_upper_bound_to_count,
+            sum: 0,
+        }
+    }
+
+    pub fn add_event(&mut self, value: i64) {
+        self.sum += value;
+
+        let count: &mut u64 = self
+            .bin_inclusive_upper_bound_to_count
+            .range_mut(value..)
+            .next()
+            .map(|(_, count)| count)
+            .unwrap_or_else(|| &mut self.infinity_bin_count);
+
+        *count += 1;
+    }
+
+    pub fn encode_metrics<'a, MyWrite: std::io::Write>(
+        &self,
+        metric_labels: &Vec<(String, String)>,
+        out: LabeledHistogramBuilder<'a, MyWrite>,
+    ) -> std::io::Result<LabeledHistogramBuilder<'a, MyWrite>> {
+        let metric_labels = metric_labels
+            .iter()
+            .map(|(name, value)| (name.as_str(), value.as_str()))
+            .collect::<Vec<_>>();
+
+        let bin_inclusive_upper_bound_to_count = self
+            .bin_inclusive_upper_bound_to_count
+            .iter()
+            .map(|(bin_inclusive_upper_bound, count)| (*bin_inclusive_upper_bound as f64, *count as f64))
+            .chain([(f64::INFINITY, self.infinity_bin_count as f64)]);
+
+        out.histogram(&metric_labels, bin_inclusive_upper_bound_to_count, self.sum as f64)
+    }
+}

--- a/rs/nervous_system/histogram/src/tests.rs
+++ b/rs/nervous_system/histogram/src/tests.rs
@@ -2,10 +2,8 @@ use super::*;
 
 use ic_metrics_encoder::MetricsEncoder;
 use pretty_assertions::assert_eq;
-use prometheus_parse::{Scrape, Value, HistogramCount};
-use std::{
-    collections::HashMap,
-};
+use prometheus_parse::{HistogramCount, Scrape, Value};
+use std::collections::HashMap;
 
 #[test]
 fn test_standard_positive_bin_inclusive_upper_bounds() {
@@ -15,15 +13,26 @@ fn test_standard_positive_bin_inclusive_upper_bounds() {
 
     assert_eq!(
         x[0..27],
-        [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 125, 150, 175, 200, 225, 250, 275, 300],
+        [
+            1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 125, 150, 175, 200,
+            225, 250, 275, 300
+        ],
     );
 
     assert_eq!(
         x[(x.len() - 9)..],
-        [7_000_000_000_000_000_000, 7_250_000_000_000_000_000, 7_500_000_000_000_000_000, 7_750_000_000_000_000_000,
-         8_000_000_000_000_000_000, 8_250_000_000_000_000_000, 8_500_000_000_000_000_000, 8_750_000_000_000_000_000,
-         9_000_000_000_000_000_000,
-        ]);
+        [
+            7_000_000_000_000_000_000,
+            7_250_000_000_000_000_000,
+            7_500_000_000_000_000_000,
+            7_750_000_000_000_000_000,
+            8_000_000_000_000_000_000,
+            8_250_000_000_000_000_000,
+            8_500_000_000_000_000_000,
+            8_750_000_000_000_000_000,
+            9_000_000_000_000_000_000,
+        ]
+    );
 
     let mut sorted = x.clone();
     sorted.sort();
@@ -54,14 +63,9 @@ fn test_add_event() {
 
 #[test]
 fn test_encode_metrics() {
-
     // Expected value from the previous test.
     let histogram = Histogram {
-        bin_inclusive_upper_bound_to_count: BTreeMap::from([
-            (10, 1),
-            (15, 2),
-            (20, 1),
-        ]),
+        bin_inclusive_upper_bound_to_count: BTreeMap::from([(10, 1), (15, 2), (20, 1)]),
         infinity_bin_count: 1,
         sum: 10 + 14 + 15 + 16 + 999,
     };
@@ -71,8 +75,10 @@ fn test_encode_metrics() {
         let now_millis = 123_456;
         let mut metrics_encoder = MetricsEncoder::new(&mut out, now_millis);
         let histogram_encoder = metrics_encoder.histogram_vec("latency_ms", "help").unwrap();
-        let labels = vec![("phase".to_string(), "getting_ready".to_string())];
-        histogram.encode_metrics(&labels, histogram_encoder).unwrap();
+        let labels = BTreeMap::from([("phase".to_string(), "getting_ready".to_string())]);
+        histogram
+            .encode_metrics(&labels, histogram_encoder)
+            .unwrap();
     }
 
     let out = String::from_utf8(out.to_vec())

--- a/rs/nervous_system/histogram/src/tests.rs
+++ b/rs/nervous_system/histogram/src/tests.rs
@@ -1,0 +1,129 @@
+use super::*;
+
+use ic_metrics_encoder::MetricsEncoder;
+use pretty_assertions::assert_eq;
+use prometheus_parse::{Scrape, Value, HistogramCount};
+use std::{
+    collections::HashMap,
+};
+
+#[test]
+fn test_standard_positive_bin_inclusive_upper_bounds() {
+    let x = STANDARD_POSITIVE_BIN_INCLUSIVE_UPPER_BOUNDS.clone();
+    assert!(x.len() > 100, "{:#?} (len = {})", x, x.len());
+    assert!(x.len() < 1000, "{:#?} (len = {})", x, x.len());
+
+    assert_eq!(
+        x[0..27],
+        [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 125, 150, 175, 200, 225, 250, 275, 300],
+    );
+
+    assert_eq!(
+        x[(x.len() - 9)..],
+        [7_000_000_000_000_000_000, 7_250_000_000_000_000_000, 7_500_000_000_000_000_000, 7_750_000_000_000_000_000,
+         8_000_000_000_000_000_000, 8_250_000_000_000_000_000, 8_500_000_000_000_000_000, 8_750_000_000_000_000_000,
+         9_000_000_000_000_000_000,
+        ]);
+
+    let mut sorted = x.clone();
+    sorted.sort();
+    assert_eq!(x, sorted, "{:#?} (len = {})", x, x.len());
+}
+
+#[test]
+fn test_add_event() {
+    let mut histogram = Histogram::new(vec![10, 15, 20]);
+
+    for event in [10, 14, 15, 16, 999] {
+        histogram.add_event(event);
+    }
+
+    assert_eq!(
+        histogram,
+        Histogram {
+            bin_inclusive_upper_bound_to_count: BTreeMap::from([
+                (10, 1), // events: 10
+                (15, 2), // events: 14, 15,
+                (20, 1), // events: 16
+            ]),
+            infinity_bin_count: 1, // events: 999
+            sum: 10 + 14 + 15 + 16 + 999,
+        },
+    );
+}
+
+#[test]
+fn test_encode_metrics() {
+
+    // Expected value from the previous test.
+    let histogram = Histogram {
+        bin_inclusive_upper_bound_to_count: BTreeMap::from([
+            (10, 1),
+            (15, 2),
+            (20, 1),
+        ]),
+        infinity_bin_count: 1,
+        sum: 10 + 14 + 15 + 16 + 999,
+    };
+
+    let mut out = vec![];
+    {
+        let now_millis = 123_456;
+        let mut metrics_encoder = MetricsEncoder::new(&mut out, now_millis);
+        let histogram_encoder = metrics_encoder.histogram_vec("latency_ms", "help").unwrap();
+        let labels = vec![("phase".to_string(), "getting_ready".to_string())];
+        histogram.encode_metrics(&labels, histogram_encoder).unwrap();
+    }
+
+    let out = String::from_utf8(out.to_vec())
+        .unwrap()
+        .lines()
+        .map(|s| Ok(s.to_owned()))
+        .collect::<Vec<_>>()
+        .into_iter();
+
+    let scrape = Scrape::parse(out).unwrap();
+
+    let name_to_sample = scrape
+        .samples
+        .into_iter()
+        .map(|sample| (sample.metric.clone(), sample))
+        .collect::<HashMap<_, _>>();
+
+    let mut names = name_to_sample.keys().cloned().collect::<Vec<_>>();
+    names.sort();
+    assert_eq!(
+        names,
+        vec![
+            "latency_ms".to_string(),
+            "latency_ms_count".to_string(),
+            "latency_ms_sum".to_string(),
+        ],
+    );
+
+    let latency_ms = name_to_sample.get("latency_ms").unwrap();
+    let Value::Histogram(latency_ms_value) = &latency_ms.value else {
+        panic!("{:#?}", latency_ms);
+    };
+    assert_eq!(
+        latency_ms_value,
+        &vec![
+            HistogramCount {
+                less_than: 10.0,
+                count: 1.0,
+            },
+            HistogramCount {
+                less_than: 15.0,
+                count: 3.0, // not 2, because cumulative, I guess.
+            },
+            HistogramCount {
+                less_than: 20.0,
+                count: 4.0,
+            },
+            HistogramCount {
+                less_than: f64::INFINITY,
+                count: 5.0,
+            },
+        ],
+    )
+}

--- a/rs/nervous_system/instruction_stats/BUILD.bazel
+++ b/rs/nervous_system/instruction_stats/BUILD.bazel
@@ -1,0 +1,35 @@
+load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test")
+
+# TODO: Move this library out of the nervous_system directory.
+# In the meantime, allow everyone to use this.
+package(default_visibility = ["//visibility:public"])
+
+DEPENDENCIES = [
+    "//rs/nervous_system/histogram",
+    "@crate_index//:ic-cdk",
+    "@crate_index//:ic-metrics-encoder",
+    "@crate_index//:itertools",
+    "@crate_index//:lazy_static",
+]
+
+DEV_DEPENDENCIES = [
+]
+
+LIB_SRCS = glob(
+    ["src/**/*.rs"],
+    exclude = ["**/*tests*/**"],
+)
+
+rust_library(
+    name = "instruction_stats",
+    srcs = LIB_SRCS,
+    crate_name = "ic_nervous_system_instruction_stats",
+    version = "0.0.1",
+    deps = DEPENDENCIES,
+)
+
+rust_test(
+    name = "instruction_stats_test",
+    srcs = glob(["src/**/*.rs"]),
+    deps = DEPENDENCIES + DEV_DEPENDENCIES,
+)

--- a/rs/nervous_system/instruction_stats/BUILD.bazel
+++ b/rs/nervous_system/instruction_stats/BUILD.bazel
@@ -8,7 +8,6 @@ DEPENDENCIES = [
     "//rs/nervous_system/histogram",
     "@crate_index//:ic-cdk",
     "@crate_index//:ic-metrics-encoder",
-    "@crate_index//:itertools",
     "@crate_index//:lazy_static",
 ]
 

--- a/rs/nervous_system/instruction_stats/Cargo.toml
+++ b/rs/nervous_system/instruction_stats/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "ic-nervous-system-instruction-stats"
+version = "0.0.1"
+edition = { workspace = true }
+
+[dependencies]
+ic-nervous-system-histogram = { path = "../histogram" }
+ic-cdk = { workspace = true }
+ic-metrics-encoder = "1"
+itertools = { workspace = true }
+lazy_static = { workspace = true }

--- a/rs/nervous_system/instruction_stats/Cargo.toml
+++ b/rs/nervous_system/instruction_stats/Cargo.toml
@@ -7,5 +7,4 @@ edition = { workspace = true }
 ic-nervous-system-histogram = { path = "../histogram" }
 ic-cdk = { workspace = true }
 ic-metrics-encoder = "1"
-itertools = { workspace = true }
 lazy_static = { workspace = true }

--- a/rs/nervous_system/instruction_stats/src/lib.rs
+++ b/rs/nervous_system/instruction_stats/src/lib.rs
@@ -15,7 +15,8 @@
 //!    &BasicRequest { method_name: "your_method_name" }
 //!    instead of &request.
 //!
-//! 2. Call encode_instruction_metrics.
+//! 2. Call encode_instruction_metrics. This writes a data for a metric named
+//!    `candid_call_instructions`.
 
 use ic_metrics_encoder::MetricsEncoder;
 use ic_nervous_system_histogram::{Histogram, STANDARD_POSITIVE_BIN_INCLUSIVE_UPPER_BOUNDS};

--- a/rs/nervous_system/instruction_stats/src/lib.rs
+++ b/rs/nervous_system/instruction_stats/src/lib.rs
@@ -104,6 +104,12 @@ pub struct BasicRequest {
     method_name: &'static str,
 }
 
+impl BasicRequest {
+    pub fn new(method_name: &'static str) -> Self {
+        Self { method_name }
+    }
+}
+
 impl Request for BasicRequest {
     fn method_name(&self) -> String {
         self.method_name.to_string()

--- a/rs/nervous_system/instruction_stats/src/lib.rs
+++ b/rs/nervous_system/instruction_stats/src/lib.rs
@@ -5,34 +5,21 @@
 //!
 //! Basic usage:
 //!
-//! 0. Optional. If you want to break out the request stream to a method using
-//!    labels (see https://prometheus.io/docs/concepts/data_model/) implement
-//!    the Request trait. Otherwise, just use BasicRequest.
-//!
-//! 1. At the beginning of a method implementation, add one line:
-//!    let _on_drop = UpdateInstructionStatsOnDrop::new(&request);
-//!    If you did not do step 0, pass
-//!    &BasicRequest { method_name: "your_method_name" }
-//!    instead of &request.
+//! 1. At the beginning of a canister method implementation, add one line:
+//!    let _on_drop = UpdateInstructionStatsOnDrop::new(method_name, additional_labels);
 //!
 //! 2. Call encode_instruction_metrics. This writes a data for a metric named
 //!    `candid_call_instructions`.
 
 use ic_metrics_encoder::MetricsEncoder;
 use ic_nervous_system_histogram::{Histogram, STANDARD_POSITIVE_BIN_INCLUSIVE_UPPER_BOUNDS};
-use itertools::Itertools;
 use lazy_static::lazy_static;
-use std::{
-    cell::RefCell,
-    collections::HashMap,
-    marker::PhantomData,
-};
-
-#[cfg(not(test))]
-use ic_cdk::api::call_context_instruction_counter;
+use std::{cell::RefCell, collections::BTreeMap};
 
 #[cfg(test)]
 use crate::tests::call_context_instruction_counter;
+#[cfg(not(test))]
+use ic_cdk::api::call_context_instruction_counter;
 
 #[cfg(test)]
 mod tests;
@@ -52,8 +39,9 @@ lazy_static! {
     };
 }
 
+type LabelSet = BTreeMap<String, String>;
 thread_local! {
-    static STATS: RefCell<HashMap<Vec<(String, String)>, Histogram>> = Default::default();
+    static STATS: RefCell<BTreeMap<LabelSet, Histogram>> = Default::default();
 }
 
 /// Adds statistics related to instructions used to service canister calls to `out`.
@@ -63,7 +51,9 @@ thread_local! {
 ///
 /// It is broken out by method_name (and possibly other custom labels, according
 /// to Request::request_labels).
-pub fn encode_instruction_metrics<MyWrite: std::io::Write>(out: &mut MetricsEncoder<MyWrite>) -> std::io::Result<()> {
+pub fn encode_instruction_metrics<MyWrite: std::io::Write>(
+    out: &mut MetricsEncoder<MyWrite>,
+) -> std::io::Result<()> {
     STATS.with(|stats| {
         let mut out = out.histogram_vec(
             "candid_call_instructions",
@@ -78,83 +68,40 @@ pub fn encode_instruction_metrics<MyWrite: std::io::Write>(out: &mut MetricsEnco
     })
 }
 
-/// The basic characteristics of a request (for the purposes of instruction
-/// stats gathering).
-///
-/// The resulting time series will have as its labels
-///
-/// { "method_name" => method_name } + request_labels.
-///
-/// If you do not need to break stats out beyond method_name, see BasicRequest.
-pub trait Request {
-    /// In general, the body of this would look like
-    /// "make_sandwhich".to_string(). This method could have instead been a
-    /// constant, but we wanted BasicRequest to be able to cover the common case
-    /// where people do not wish to further break out instruction stats for a
-    /// method.
-    fn method_name(&self) -> String;
-
-    /// If you do not want to further break out requests, just return an empty map.
-    fn request_labels(&self) -> HashMap<String, String>;
-}
-
-/// An implementation of Request for people who do not want/need custom request
-/// labels.
-pub struct BasicRequest {
-    method_name: &'static str,
-}
-
-impl BasicRequest {
-    pub fn new(method_name: &'static str) -> Self {
-        Self { method_name }
-    }
-}
-
-impl Request for BasicRequest {
-    fn method_name(&self) -> String {
-        self.method_name.to_string()
-    }
-
-    fn request_labels(&self) -> HashMap<String, String> {
-        Default::default()
-    }
-}
-
 /// Does what the name says.
 ///
-/// For now (and possibly forever), "update" just consists of incrementing the right counter.
+/// For now (and possibly forever), "update" just consists of incrementing the
+/// right counter (by 1), based on the amount of instructions.
 ///
-/// As statistics accumulate, they can be seen by calling encode_instruction_metrics.
-pub struct UpdateInstructionStatsOnDrop<MyRequest: Request> {
-    metric_labels: Vec<(String, String)>,
-
-    _phantom_data_my_metric_labels: PhantomData<MyRequest>
+/// As statistics accumulate, they can be seen by calling
+/// encode_instruction_metrics.
+pub struct UpdateInstructionStatsOnDrop {
+    metric_labels: BTreeMap<String, String>,
 }
 
-impl<MyRequest: Request> UpdateInstructionStatsOnDrop<MyRequest> {
-    pub fn new(request: &MyRequest) -> Self {
-        let mut metric_labels = request.request_labels();
-
-        metric_labels.insert("method_name".to_string(), request.method_name());
-
-        let metric_labels = metric_labels
-            .into_iter()
-            .sorted()
-            .collect();
-
-        Self {
-            metric_labels,
-            _phantom_data_my_metric_labels: Default::default(),
-        }
+impl UpdateInstructionStatsOnDrop {
+    /// What is a label: https://prometheus.io/docs/concepts/data_model/
+    ///
+    /// (In cases where there is no desire to break out stats, pass an empty vec to the
+    /// additional_labels parameter.)
+    ///
+    /// The resulting full set of labels includes "method_name" => method_name.
+    /// (If "method_name" is one of the keys in additional_labels, it gets
+    /// ignored.)
+    pub fn new(method_name: &str, additional_labels: BTreeMap<String, String>) -> Self {
+        let mut metric_labels = additional_labels;
+        metric_labels.insert("method_name".to_string(), method_name.to_string());
+        Self { metric_labels }
     }
 }
 
-impl<MyRequest: Request> Drop for UpdateInstructionStatsOnDrop<MyRequest> {
+impl Drop for UpdateInstructionStatsOnDrop {
     fn drop(&mut self) {
         let instruction_count = call_context_instruction_counter().min(i64::MAX as u64) as i64;
 
         STATS.with(|stats| {
-            stats.borrow_mut()
+            stats
+                .borrow_mut()
                 .entry(self.metric_labels.clone())
                 .or_insert_with(|| Histogram::new(INSTRUCTIONS_BIN_INCLUSIVE_UPPER_BOUNDS.clone()))
                 .add_event(instruction_count);

--- a/rs/nervous_system/instruction_stats/src/lib.rs
+++ b/rs/nervous_system/instruction_stats/src/lib.rs
@@ -1,0 +1,99 @@
+use ic_metrics_encoder::MetricsEncoder;
+use ic_nervous_system_histogram::{Histogram, STANDARD_POSITIVE_BIN_INCLUSIVE_UPPER_BOUNDS};
+use itertools::Itertools;
+use lazy_static::lazy_static;
+use std::{
+    cell::RefCell,
+    collections::HashMap,
+    marker::PhantomData,
+};
+
+#[cfg(not(test))]
+use ic_cdk::api::call_context_instruction_counter;
+
+#[cfg(test)]
+use crate::tests::call_context_instruction_counter;
+
+#[cfg(test)]
+mod tests;
+
+lazy_static! {
+    // Covers a wide range, yet is still fairly fine grained.
+    static ref INSTRUCTIONS_BIN_INCLUSIVE_UPPER_BOUNDS: Vec<i64> = {
+        // Drop values that are too small and too big.
+        STANDARD_POSITIVE_BIN_INCLUSIVE_UPPER_BOUNDS
+            .clone()
+            .into_iter()
+            // For instructions consumed, only values in this range make sense.
+            // For the upper bound, 40 billion was obtained from this page:
+            // https://internetcomputer.org/docs/current/developer-docs/smart-contracts/maintain/resource-limits
+            .filter(|b| 100_000 <= *b && *b <= 40_000_000_000)
+            .collect()
+    };
+}
+
+thread_local! {
+    static STATS: RefCell<HashMap<Vec<(String, String)>, Histogram>> = Default::default();
+}
+
+pub fn encode_instruction_metrics<MyWrite: std::io::Write>(out: &mut MetricsEncoder<MyWrite>) -> std::io::Result<()> {
+    STATS.with(|stats| {
+        let mut out = out.histogram_vec(
+            "candid_call_instructions",
+            "How many instructions were directly consumed to service requests. Useful numbers: https://internetcomputer.org/docs/current/developer-docs/smart-contracts/maintain/resource-limits",
+        )?;
+
+        for (metric_labels, histogram) in stats.borrow().iter() {
+            out = histogram.encode_metrics(metric_labels, out)?;
+        }
+
+        Ok(())
+    })
+}
+
+/// (The design of this assumes that each request type is associated with a
+/// unique Candid method. If you follow the very good convention where a method
+/// named foo takes FooRequest and returns FooResponse, then you are golden.)
+pub trait Request {
+    const METHOD_NAME: &'static str;
+
+    /// If you do not want to further break out requests, just return an empty map.
+    fn metric_labels(&self) -> HashMap<String, String>;
+}
+
+pub struct UpdateInstructionStatsOnDrop<MyRequest: Request> {
+    metric_labels: Vec<(String, String)>,
+
+    _phantom_data_my_metric_labels: PhantomData<MyRequest>
+}
+
+impl<MyRequest: Request> UpdateInstructionStatsOnDrop<MyRequest> {
+    pub fn new(metric_labels: &MyRequest) -> Self {
+        let mut metric_labels = metric_labels.metric_labels();
+
+        metric_labels.insert("method_name".to_string(), MyRequest::METHOD_NAME.to_string());
+
+        let metric_labels = metric_labels
+            .into_iter()
+            .sorted()
+            .collect();
+
+        Self {
+            metric_labels,
+            _phantom_data_my_metric_labels: Default::default(),
+        }
+    }
+}
+
+impl<MyRequest: Request> Drop for UpdateInstructionStatsOnDrop<MyRequest> {
+    fn drop(&mut self) {
+        let instruction_count = call_context_instruction_counter().min(i64::MAX as u64) as i64;
+
+        STATS.with(|stats| {
+            stats.borrow_mut()
+                .entry(self.metric_labels.clone())
+                .or_insert_with(|| Histogram::new(INSTRUCTIONS_BIN_INCLUSIVE_UPPER_BOUNDS.clone()))
+                .add_event(instruction_count);
+        });
+    }
+}

--- a/rs/nervous_system/instruction_stats/src/tests.rs
+++ b/rs/nervous_system/instruction_stats/src/tests.rs
@@ -1,0 +1,72 @@
+use super::*;
+
+thread_local! {
+    static CALL_CONTEXT_INSTRUCTION_COUNTER_RESULTS: RefCell<Vec<u64>> =
+        RefCell::new(vec![40_000_000_001, 2_760_000_000, 1_500_000, 123_456]);
+}
+
+pub(crate) fn call_context_instruction_counter() -> u64 {
+    CALL_CONTEXT_INSTRUCTION_COUNTER_RESULTS.with(|results| results.borrow_mut().pop().unwrap())
+}
+
+struct SomeRequest {
+    x: String,
+    y: String,
+}
+
+impl Request for SomeRequest {
+    const METHOD_NAME: &'static str = "make_sandwhich";
+
+    fn metric_labels(&self) -> HashMap<String, String> {
+        HashMap::from([
+            ("x".to_string(), self.x.clone()),
+            ("y".to_string(), self.y.clone()),
+        ])
+    }
+}
+
+#[test]
+fn test_on_drop() {
+    let request = SomeRequest {
+        x: "hello".to_string(),
+        y: "world".to_string(),
+    };
+
+    {
+        let _on_drop = UpdateInstructionStatsOnDrop::new(&request);
+    }
+
+    let stats = || {
+        STATS.with(|stats| stats.borrow().clone())
+    };
+
+    let expected_key = vec![
+        ("method_name".to_string(), "make_sandwhich".to_string()),
+        ("x".to_string(), "hello".to_string()),
+        ("y".to_string(), "world".to_string()),
+    ];
+    assert_eq!(
+        stats().keys().cloned().collect::<Vec<Vec<(String, String)>>>(),
+        vec![expected_key.clone()],
+    );
+
+    let observed_histogram = stats().get(&expected_key).unwrap().clone();
+    let mut expected_histogram = Histogram::new(INSTRUCTIONS_BIN_INCLUSIVE_UPPER_BOUNDS.clone());
+    expected_histogram.add_event(123_456);
+    assert_eq!(observed_histogram, expected_histogram);
+
+    for _ in 0..3 {
+        let _on_drop = UpdateInstructionStatsOnDrop::new(&request);
+    }
+
+    assert_eq!(
+        CALL_CONTEXT_INSTRUCTION_COUNTER_RESULTS.with(|results| results.borrow().clone()),
+        vec![],
+    );
+
+    let observed_histogram = stats().get(&expected_key).unwrap().clone();
+    for event in [1_500_000, 2_760_000_000, 40_000_000_001] {
+        expected_histogram.add_event(event);
+    }
+    assert_eq!(observed_histogram, expected_histogram);
+}

--- a/rs/nervous_system/instruction_stats_attribute/BUILD.bazel
+++ b/rs/nervous_system/instruction_stats_attribute/BUILD.bazel
@@ -10,6 +10,7 @@ DEPENDENCIES = [
 ]
 
 DEV_DEPENDENCIES = [
+    "//rs/nervous_system/instruction_stats",
     "@crate_index//:candid",
     "@crate_index//:ic-cdk",
 ]
@@ -28,7 +29,7 @@ rust_proc_macro(
 )
 
 rust_test(
-    name = "instruction_stats_test",
+    name = "instruction_stats_attribute_test",
     srcs = glob(["tests/*.rs"]),
     deps = DEPENDENCIES + DEV_DEPENDENCIES,
     proc_macro_deps = [

--- a/rs/nervous_system/instruction_stats_attribute/BUILD.bazel
+++ b/rs/nervous_system/instruction_stats_attribute/BUILD.bazel
@@ -10,7 +10,6 @@ DEPENDENCIES = [
 ]
 
 DEV_DEPENDENCIES = [
-    "//rs/nervous_system/instruction_stats",
     "@crate_index//:candid",
     "@crate_index//:ic-cdk",
 ]

--- a/rs/nervous_system/instruction_stats_attribute/BUILD.bazel
+++ b/rs/nervous_system/instruction_stats_attribute/BUILD.bazel
@@ -1,0 +1,37 @@
+load("@rules_rust//rust:defs.bzl", "rust_proc_macro", "rust_test")
+
+# TODO: Move this library out of the nervous_system directory.
+# In the meantime, allow everyone to use this.
+package(default_visibility = ["//visibility:public"])
+
+DEPENDENCIES = [
+    "@crate_index//:quote",
+    "@crate_index//:syn",
+]
+
+DEV_DEPENDENCIES = [
+    "@crate_index//:candid",
+    "@crate_index//:ic-cdk",
+]
+
+LIB_SRCS = glob(
+    ["src/**/*.rs"],
+    exclude = ["**/*tests*/**"],
+)
+
+rust_proc_macro(
+    name = "instruction_stats_attribute",
+    srcs = LIB_SRCS,
+    crate_name = "ic_nervous_system_instruction_stats_attribute",
+    version = "0.0.1",
+    deps = DEPENDENCIES,
+)
+
+rust_test(
+    name = "instruction_stats_test",
+    srcs = glob(["tests/*.rs"]),
+    deps = DEPENDENCIES + DEV_DEPENDENCIES,
+    proc_macro_deps = [
+        ":instruction_stats_attribute",
+    ],
+)

--- a/rs/nervous_system/instruction_stats_attribute/Cargo.toml
+++ b/rs/nervous_system/instruction_stats_attribute/Cargo.toml
@@ -13,4 +13,3 @@ syn = { workspace = true }
 [dev-dependencies]
 candid = { workspace = true }
 ic-cdk = { workspace = true }
-ic-nervous-system-instruction-stats = { path = "../instruction_stats" }

--- a/rs/nervous_system/instruction_stats_attribute/Cargo.toml
+++ b/rs/nervous_system/instruction_stats_attribute/Cargo.toml
@@ -13,3 +13,4 @@ syn = { workspace = true }
 [dev-dependencies]
 candid = { workspace = true }
 ic-cdk = { workspace = true }
+ic-nervous-system-instruction-stats = { path = "../instruction_stats" }

--- a/rs/nervous_system/instruction_stats_attribute/Cargo.toml
+++ b/rs/nervous_system/instruction_stats_attribute/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "ic-nervous-system-instruction-stats-attribute"
+version = "0.0.1"
+edition = "2021"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+quote = "1"
+syn = { workspace = true }
+
+[dev-dependencies]
+candid = { workspace = true }
+ic-cdk = { workspace = true }

--- a/rs/nervous_system/instruction_stats_attribute/src/lib.rs
+++ b/rs/nervous_system/instruction_stats_attribute/src/lib.rs
@@ -30,7 +30,7 @@ pub fn update(attr: TokenStream, item: TokenStream) -> TokenStream {
     // Create statement that we'll insert into the function.
     let new_stmt = quote! {
         let _on_drop = ic_nervous_system_instruction_stats::UpdateInstructionStatsOnDrop::new(
-            &ic_nervous_system_instruction_stats::BasicRequest::new(#function_name)
+            #function_name, std::collections::BTreeMap::new(),
         );
     };
     let new_stmt = TokenStream::from(new_stmt);

--- a/rs/nervous_system/instruction_stats_attribute/src/lib.rs
+++ b/rs/nervous_system/instruction_stats_attribute/src/lib.rs
@@ -15,7 +15,14 @@ use syn::{parse_macro_input, ItemFn, Stmt};
 /// this data, ic_nervous_system_instruction_stats::encode_instruction_metrics
 /// needs to be called.
 #[proc_macro_attribute]
-pub fn update(_attr: TokenStream, item: TokenStream) -> TokenStream {
+pub fn update(attr: TokenStream, item: TokenStream) -> TokenStream {
+    let attr = parse_macro_input!(attr as syn::AttributeArgs);
+    let update_attr = if attr.is_empty() {
+        quote! { #[ic_cdk::update] }
+    } else {
+        quote! { #[ic_cdk::update(#(#attr),*)] }
+    };
+
     let mut item_fn = parse_macro_input!(item as ItemFn);
 
     let function_name = item_fn.sig.ident.to_string();
@@ -32,7 +39,7 @@ pub fn update(_attr: TokenStream, item: TokenStream) -> TokenStream {
     item_fn.block.stmts.insert(0, new_stmt);
 
     let updated_item_fn = quote! {
-        #[ic_cdk::update]
+        #update_attr
         #item_fn
     };
 

--- a/rs/nervous_system/instruction_stats_attribute/src/lib.rs
+++ b/rs/nervous_system/instruction_stats_attribute/src/lib.rs
@@ -1,0 +1,40 @@
+use proc_macro::TokenStream;
+use quote::{quote, ToTokens};
+use syn::{parse_macro_input, ItemFn, Stmt};
+
+/// This does almost the same thing as ic_cdk::update. There is just one
+/// difference: This adds a statement to the beginning of the function. It looks
+/// something like this:
+///
+/// let _on_drop = foo(#function_name);
+///
+/// For this to work, you will need to depend on
+/// ic-nervous-system-instruction-stats, because foo is defined there.
+///
+/// More precisely, foo tracks instructions used by the call context. To expose
+/// this data, ic_nervous_system_instruction_stats::encode_instruction_metrics
+/// needs to be called.
+#[proc_macro_attribute]
+pub fn update(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    let mut item_fn = parse_macro_input!(item as ItemFn);
+
+    let function_name = item_fn.sig.ident.to_string();
+
+    // Create statement that we'll insert into the function.
+    let new_stmt = quote! {
+        let _on_drop = ic_nervous_system_instruction_stats::UpdateInstructionStatsOnDrop::new(
+            &ic_nervous_system_instruction_stats::BasicRequest{ name: #function_name}
+        );
+    };
+    let new_stmt = TokenStream::from(new_stmt);
+    let new_stmt = parse_macro_input!(new_stmt as Stmt);
+
+    item_fn.block.stmts.insert(0, new_stmt);
+
+    let updated_item_fn = quote! {
+        #[ic_cdk::update]
+        #item_fn
+    };
+
+    TokenStream::from(updated_item_fn.into_token_stream())
+}

--- a/rs/nervous_system/instruction_stats_attribute/src/lib.rs
+++ b/rs/nervous_system/instruction_stats_attribute/src/lib.rs
@@ -23,7 +23,7 @@ pub fn update(_attr: TokenStream, item: TokenStream) -> TokenStream {
     // Create statement that we'll insert into the function.
     let new_stmt = quote! {
         let _on_drop = ic_nervous_system_instruction_stats::UpdateInstructionStatsOnDrop::new(
-            &ic_nervous_system_instruction_stats::BasicRequest{ name: #function_name}
+            &ic_nervous_system_instruction_stats::BasicRequest::new(#function_name)
         );
     };
     let new_stmt = TokenStream::from(new_stmt);

--- a/rs/nervous_system/instruction_stats_attribute/tests/tests.rs
+++ b/rs/nervous_system/instruction_stats_attribute/tests/tests.rs
@@ -1,51 +1,40 @@
 use ic_nervous_system_instruction_stats_attribute::update;
-use std::cell::RefCell;
+use std::{cell::RefCell, collections::BTreeMap};
 
 thread_local! {
-    static NAME: RefCell<String> = Default::default();
-    static HELLO_WORLD_IMPL: RefCell<String> = Default::default();
+    static WAS_CALLED: RefCell<Vec<&'static str>> = Default::default();
 }
 
 mod ic_nervous_system_instruction_stats {
     use super::*;
-    use ::ic_nervous_system_instruction_stats::Request;
 
-    pub use ::ic_nervous_system_instruction_stats::BasicRequest;
-
-    pub struct UpdateInstructionStatsOnDrop {
-    }
+    pub struct UpdateInstructionStatsOnDrop {}
 
     impl UpdateInstructionStatsOnDrop {
-        pub fn new(request: &BasicRequest) {
-            NAME.with(|name| {
-                let mut name = name.borrow_mut();
-                *name = request.method_name();
-            })
+        pub fn new(method_name: &str, additional_labels: BTreeMap<String, String>) -> Self {
+            WAS_CALLED.with(|was_called| {
+                was_called.borrow_mut().push("new");
+            });
+
+            assert_eq!(method_name, "hello_world");
+            assert_eq!(additional_labels, BTreeMap::new());
+
+            Self {}
         }
     }
 }
 
 #[update]
 fn hello_world() {
-    HELLO_WORLD_IMPL.with(|impl_| {
-        let mut impl_ = impl_.borrow_mut();
-        *impl_ = "Daniel Wong deserves a fat raise.".to_string();
-    })
+    WAS_CALLED.with(|was_called| {
+        was_called.borrow_mut().push("hello_world");
+    });
 }
 
 #[test]
 fn test_update() {
     hello_world();
 
-    // Assert that UpdateInstructionStatsOnDrop::new was actually called.
-    assert_eq!(
-        NAME.with(|name| name.borrow().clone()),
-        "hello_world",
-    );
-
-    // Assert that the body of hello_world did NOT get blown away.
-    assert_eq!(
-        HELLO_WORLD_IMPL.with(|name| name.borrow().clone()),
-        "Daniel Wong deserves a fat raise.",
-    );
+    let observed_calls = WAS_CALLED.with(|was_called| was_called.borrow().clone());
+    assert_eq!(observed_calls, vec!["new", "hello_world"],);
 }

--- a/rs/nervous_system/instruction_stats_attribute/tests/tests.rs
+++ b/rs/nervous_system/instruction_stats_attribute/tests/tests.rs
@@ -8,6 +8,9 @@ thread_local! {
 
 mod ic_nervous_system_instruction_stats {
     use super::*;
+    use ::ic_nervous_system_instruction_stats::Request;
+
+    pub use ::ic_nervous_system_instruction_stats::BasicRequest;
 
     pub struct UpdateInstructionStatsOnDrop {
     }
@@ -16,13 +19,9 @@ mod ic_nervous_system_instruction_stats {
         pub fn new(request: &BasicRequest) {
             NAME.with(|name| {
                 let mut name = name.borrow_mut();
-                *name = request.name.to_string();
+                *name = request.method_name();
             })
         }
-    }
-
-    pub struct BasicRequest {
-        pub name: &'static str,
     }
 }
 

--- a/rs/nervous_system/instruction_stats_attribute/tests/tests.rs
+++ b/rs/nervous_system/instruction_stats_attribute/tests/tests.rs
@@ -1,0 +1,52 @@
+use ic_nervous_system_instruction_stats_attribute::update;
+use std::cell::RefCell;
+
+thread_local! {
+    static NAME: RefCell<String> = Default::default();
+    static HELLO_WORLD_IMPL: RefCell<String> = Default::default();
+}
+
+mod ic_nervous_system_instruction_stats {
+    use super::*;
+
+    pub struct UpdateInstructionStatsOnDrop {
+    }
+
+    impl UpdateInstructionStatsOnDrop {
+        pub fn new(request: &BasicRequest) {
+            NAME.with(|name| {
+                let mut name = name.borrow_mut();
+                *name = request.name.to_string();
+            })
+        }
+    }
+
+    pub struct BasicRequest {
+        pub name: &'static str,
+    }
+}
+
+#[update]
+fn hello_world() {
+    HELLO_WORLD_IMPL.with(|impl_| {
+        let mut impl_ = impl_.borrow_mut();
+        *impl_ = "Daniel Wong deserves a fat raise.".to_string();
+    })
+}
+
+#[test]
+fn test_update() {
+    hello_world();
+
+    // Assert that UpdateInstructionStatsOnDrop::new was actually called.
+    assert_eq!(
+        NAME.with(|name| name.borrow().clone()),
+        "hello_world",
+    );
+
+    // Assert that the body of hello_world did NOT get blown away.
+    assert_eq!(
+        HELLO_WORLD_IMPL.with(|name| name.borrow().clone()),
+        "Daniel Wong deserves a fat raise.",
+    );
+}


### PR DESCRIPTION
# So Far

Created a few libraries (all in rs/nervous_system, but they could go into a more general purpose dir):

1. histogram
2. instruction_stats (uses histogram)
3. instruction_stats_attribute - This defines an alternative `#[update]` attribute, similar to the one in `ic_cdk`. The only difference is that this adds instruction_stats tracking with just _one line_ of code 😁

This has been split out into a few PRs:

1. Histogram - https://github.com/dfinity/ic/pull/1828
2. Instruction Stats - https://github.com/dfinity/ic/pull/1829
3. Enhanced `#[update]` attribute - https://github.com/dfinity/ic/pull/1830

# Next

1. Apply this new `#[update]` attribute to some canisters 😈 Let's introduce this slowly/cautiously, because we do not want this to impact existing functionality.
    1. At first, maybe, we can apply it to just one method. Maybe it would only sample requests, which we would gradually increase.
    2. Later, it can spread to the whole canister.
    3. Later, all canisters.

2. Think about how to identify callers who are hammering us. Ofc, this does not help if an attacker creates tons of principals. Nevertheless this could be useful, because even with non malicious callers, we are having problems. I guess once we collect enough data points, we can get an idea of how much a "typical" call costs, and then request that takes more can be logged more, and inspected later.