### PR TITLE
fix: ensure that StateMachine registry contains no special ipv6 addresses

### DIFF
--- a/rs/state_machine_tests/src/lib.rs
+++ b/rs/state_machine_tests/src/lib.rs
@@ -778,9 +778,9 @@ impl StateMachineNode {
             ic_crypto_ed25519::PrivateKey::deserialize_raw_32(&rng.gen());
         let mut http_ip_addr_bytes = rng.gen::<[u8; 16]>();
         http_ip_addr_bytes[0] = 0xe0; // make sure the ipv6 address has no special form
+        let http_ip_addr = Ipv6Addr::from(http_ip_addr_bytes);
         let mut xnet_ip_addr_bytes = rng.gen::<[u8; 16]>();
         xnet_ip_addr_bytes[0] = 0xe0; // make sure the ipv6 address has no special form
-        let http_ip_addr = Ipv6Addr::from(http_ip_addr_bytes);
         let xnet_ip_addr = Ipv6Addr::from(xnet_ip_addr_bytes);
         Self {
             node_id: PrincipalId::new_self_authenticating(

--- a/rs/state_machine_tests/src/lib.rs
+++ b/rs/state_machine_tests/src/lib.rs
@@ -776,8 +776,12 @@ impl StateMachineNode {
             ic_crypto_ed25519::PrivateKey::deserialize_raw_32(&rng.gen());
         let idkg_mega_encryption_key =
             ic_crypto_ed25519::PrivateKey::deserialize_raw_32(&rng.gen());
-        let http_ip_addr = Ipv6Addr::from(rng.gen::<[u16; 8]>());
-        let xnet_ip_addr = Ipv6Addr::from(rng.gen::<[u16; 8]>());
+        let mut http_ip_addr_bytes = rng.gen::<[u8; 16]>();
+        http_ip_addr_bytes[0] = 0xe0; // make sure the ipv6 address has no special form
+        let mut xnet_ip_addr_bytes = rng.gen::<[u8; 16]>();
+        xnet_ip_addr_bytes[0] = 0xe0; // make sure the ipv6 address has no special form
+        let http_ip_addr = Ipv6Addr::from(http_ip_addr_bytes);
+        let xnet_ip_addr = Ipv6Addr::from(xnet_ip_addr_bytes);
         Self {
             node_id: PrincipalId::new_self_authenticating(
                 &node_signing_key.public_key().serialize_rfc8410_der(),


### PR DESCRIPTION
This PR ensures that `StateMachine` registry contains no special ipv6 addresses by setting its first byte to `0xe0`. This guarantees that the ipv6 address satisfies the registry canister [check](https://github.com/dfinity/ic/blob/4a1c62f4c9ede0e888002931bdadbfd74878238f/rs/registry/canister/src/invariants/endpoint.rs#L124).