### PR TITLE
refactor(nervous-system): make the ic-nervous-system-integration-tests tests async

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9681,6 +9681,7 @@ dependencies = [
  "candid",
  "canister-test",
  "cycles-minting-canister",
+ "futures",
  "ic-base-types",
  "ic-crypto-sha2",
  "ic-error-types",
@@ -9733,6 +9734,7 @@ dependencies = [
  "rust_decimal_macros",
  "rustc-hash 1.1.0",
  "serde",
+ "tokio",
  "xrc-mock",
 ]
 

--- a/rs/nervous_system/agent/src/pocketic_impl.rs
+++ b/rs/nervous_system/agent/src/pocketic_impl.rs
@@ -1,6 +1,6 @@
 use candid::Principal;
 use ic_nervous_system_clients::Request;
-use pocket_ic::PocketIc;
+use pocket_ic::nonblocking::PocketIc;
 use thiserror::Error;
 
 use crate::CallCanisters;
@@ -36,6 +36,7 @@ impl CallCanisters for PocketIc {
                 R::METHOD,
                 request_bytes,
             )
+            .await
         } else {
             self.query_call(
                 canister_id,
@@ -43,6 +44,7 @@ impl CallCanisters for PocketIc {
                 R::METHOD,
                 request_bytes,
             )
+            .await
         }
         .map_err(PocketIcCallError::PocketIc)?;
 

--- a/rs/nervous_system/integration_tests/BUILD.bazel
+++ b/rs/nervous_system/integration_tests/BUILD.bazel
@@ -28,9 +28,11 @@ BASE_DEPENDENCIES = [
     "//rs/types/management_canister_types",
     "@crate_index//:assert_matches",
     "@crate_index//:candid",
+    "@crate_index//:futures",
     "@crate_index//:lazy_static",
     "@crate_index//:prost",
     "@crate_index//:rust_decimal",
+    "@crate_index//:tokio",
 ] + select({
     "@rules_rust//rust/platform:wasm32-unknown-unknown": [],
     "//conditions:default": [

--- a/rs/nervous_system/integration_tests/Cargo.toml
+++ b/rs/nervous_system/integration_tests/Cargo.toml
@@ -11,6 +11,7 @@ documentation.workspace = true
 assert_matches = { workspace = true }
 candid = { workspace = true }
 cycles-minting-canister = { path = "../../nns/cmc" }
+futures = { workspace = true }
 ic-base-types = { path = "../../types/base_types" }
 ic-ledger-core = { path = "../../ledger_suite/common/ledger_core" }
 ic-nervous-system-agent = { path = "../agent" }
@@ -33,6 +34,8 @@ pocket-ic = { path = "../../../packages/pocket-ic" }
 prost = { workspace = true }
 rust_decimal = "1.25"
 rust_decimal_macros = "1.25"
+tokio = { workspace = true }
+
 
 # Dependencies required to compile the tests.
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/rs/nervous_system/integration_tests/tests/advance_target_version.rs
+++ b/rs/nervous_system/integration_tests/tests/advance_target_version.rs
@@ -18,35 +18,42 @@ use std::time::Duration;
 
 const TICKS_PER_TASK: u64 = 2;
 
-#[test]
-fn test_get_upgrade_journal() {
+#[tokio::test]
+async fn test_get_upgrade_journal() {
     let pocket_ic = PocketIcBuilder::new()
         .with_nns_subnet()
         .with_sns_subnet()
-        .build();
+        .build_async()
+        .await;
 
     let wait_for_next_periodic_task = |sleep_duration_seconds| {
-        let now = pocket_ic.get_time();
-        pocket_ic.advance_time(Duration::from_secs(sleep_duration_seconds));
-        for _ in 0..TICKS_PER_TASK {
-            pocket_ic.tick();
+        let pocket_ic = &pocket_ic;
+        async move {
+            let now = pocket_ic.get_time().await;
+            pocket_ic
+                .advance_time(Duration::from_secs(sleep_duration_seconds))
+                .await;
+            for _ in 0..TICKS_PER_TASK {
+                pocket_ic.tick().await;
+            }
+            assert_eq!(
+                pocket_ic.get_time().await,
+                now + Duration::from_secs(sleep_duration_seconds)
+                    + Duration::from_nanos(TICKS_PER_TASK)
+            );
         }
-        assert_eq!(
-            pocket_ic.get_time(),
-            now + Duration::from_secs(sleep_duration_seconds)
-                + Duration::from_nanos(TICKS_PER_TASK)
-        );
     };
 
     // Install the (master) NNS canisters.
     let with_mainnet_nns_canisters = false;
-    install_nns_canisters(&pocket_ic, vec![], with_mainnet_nns_canisters, None, vec![]);
+    install_nns_canisters(&pocket_ic, vec![], with_mainnet_nns_canisters, None, vec![]).await;
 
     // Publish (master) SNS Wasms to SNS-W.
     let with_mainnet_sns_wasms = false;
-    let deployed_sns_starting_info =
-        add_wasms_to_sns_wasm(&pocket_ic, with_mainnet_sns_wasms).unwrap();
-    let initial_sns_version = nns::sns_wasm::get_lastest_sns_version(&pocket_ic);
+    let deployed_sns_starting_info = add_wasms_to_sns_wasm(&pocket_ic, with_mainnet_sns_wasms)
+        .await
+        .unwrap();
+    let initial_sns_version = nns::sns_wasm::get_latest_sns_version(&pocket_ic).await;
 
     // Deploy an SNS instance via proposal.
     let sns = {
@@ -69,14 +76,18 @@ fn test_get_upgrade_journal() {
             &pocket_ic,
             create_service_nervous_system,
             sns_instance_label,
-        );
+        )
+        .await;
 
-        sns::swap::await_swap_lifecycle(&pocket_ic, sns.swap.canister_id, Lifecycle::Open).unwrap();
+        sns::swap::await_swap_lifecycle(&pocket_ic, sns.swap.canister_id, Lifecycle::Open)
+            .await
+            .unwrap();
         sns::swap::smoke_test_participate_and_finalize(
             &pocket_ic,
             sns.swap.canister_id,
             swap_parameters,
-        );
+        )
+        .await;
         sns
     };
 
@@ -85,7 +96,7 @@ fn test_get_upgrade_journal() {
         let sns_pb::GetUpgradeJournalResponse {
             upgrade_steps,
             response_timestamp_seconds,
-        } = sns::governance::get_upgrade_journal(&pocket_ic, sns.governance.canister_id);
+        } = sns::governance::get_upgrade_journal(&pocket_ic, sns.governance.canister_id).await;
         let upgrade_steps = upgrade_steps
             .expect("upgrade_steps should be Some")
             .versions;
@@ -93,12 +104,12 @@ fn test_get_upgrade_journal() {
         assert_eq!(response_timestamp_seconds, Some(1620501459));
     }
 
-    wait_for_next_periodic_task(UPGRADE_STEPS_INTERVAL_REFRESH_BACKOFF_SECONDS);
+    wait_for_next_periodic_task(UPGRADE_STEPS_INTERVAL_REFRESH_BACKOFF_SECONDS).await;
 
     // State B: after the first periodic task's completion. No changes expected yet.
     {
         let sns_pb::GetUpgradeJournalResponse { upgrade_steps, .. } =
-            sns::governance::get_upgrade_journal(&pocket_ic, sns.governance.canister_id);
+            sns::governance::get_upgrade_journal(&pocket_ic, sns.governance.canister_id).await;
         let upgrade_steps = upgrade_steps
             .expect("upgrade_steps should be Some")
             .versions;
@@ -113,7 +124,9 @@ fn test_get_upgrade_journal() {
 
         let new_sns_version_1 = {
             let ledger_wasm = create_modified_sns_wasm(original_ledger_wasm, Some(1));
-            add_wasm_via_nns_proposal(&pocket_ic, ledger_wasm.clone()).unwrap();
+            add_wasm_via_nns_proposal(&pocket_ic, ledger_wasm.clone())
+                .await
+                .unwrap();
             let ledger_wasm_hash = ledger_wasm.sha256_hash().to_vec();
             sns_pb::governance::Version {
                 ledger_wasm_hash,
@@ -123,7 +136,9 @@ fn test_get_upgrade_journal() {
 
         let new_sns_version_2 = {
             let ledger_wasm = create_modified_sns_wasm(original_ledger_wasm, Some(2));
-            add_wasm_via_nns_proposal(&pocket_ic, ledger_wasm.clone()).unwrap();
+            add_wasm_via_nns_proposal(&pocket_ic, ledger_wasm.clone())
+                .await
+                .unwrap();
             let ledger_wasm_hash = ledger_wasm.sha256_hash().to_vec();
             sns_pb::governance::Version {
                 ledger_wasm_hash,
@@ -131,18 +146,18 @@ fn test_get_upgrade_journal() {
             }
         };
 
-        let sns_version = nns::sns_wasm::get_lastest_sns_version(&pocket_ic);
+        let sns_version = nns::sns_wasm::get_latest_sns_version(&pocket_ic).await;
         assert_ne!(sns_version, initial_sns_version);
 
         (new_sns_version_1, new_sns_version_2)
     };
 
-    wait_for_next_periodic_task(UPGRADE_STEPS_INTERVAL_REFRESH_BACKOFF_SECONDS);
+    wait_for_next_periodic_task(UPGRADE_STEPS_INTERVAL_REFRESH_BACKOFF_SECONDS).await;
 
     // State C: after the second periodic task's completion.
     {
         let sns_pb::GetUpgradeJournalResponse { upgrade_steps, .. } =
-            sns::governance::get_upgrade_journal(&pocket_ic, sns.governance.canister_id);
+            sns::governance::get_upgrade_journal(&pocket_ic, sns.governance.canister_id).await;
         let upgrade_steps = upgrade_steps.expect("cached_upgrade_steps should be Some");
 
         assert_eq!(

--- a/rs/nervous_system/integration_tests/tests/sns_release_qualification.rs
+++ b/rs/nervous_system/integration_tests/tests/sns_release_qualification.rs
@@ -31,8 +31,8 @@ use ic_sns_wasm::pb::v1::SnsCanisterType;
 /// Note: FI canisters are considered fully tested elsewhere, and have stable APIs.
 
 /// Deployment tests
-#[test]
-fn test_deployment_all_upgrades() {
+#[tokio::test]
+async fn test_deployment_all_upgrades() {
     test_sns_deployment(
         vec![GOVERNANCE_CANISTER_ID, SNS_WASM_CANISTER_ID],
         vec![
@@ -42,16 +42,17 @@ fn test_deployment_all_upgrades() {
             SnsCanisterType::Swap,
             SnsCanisterType::Index,
         ],
-    );
+    )
+    .await;
 }
 
-#[test]
-fn test_deployment_with_only_nns_upgrades() {
-    test_sns_deployment(vec![GOVERNANCE_CANISTER_ID, SNS_WASM_CANISTER_ID], vec![]);
+#[tokio::test]
+async fn test_deployment_with_only_nns_upgrades() {
+    test_sns_deployment(vec![GOVERNANCE_CANISTER_ID, SNS_WASM_CANISTER_ID], vec![]).await;
 }
 
-#[test]
-fn test_deployment_with_only_sns_upgrades() {
+#[tokio::test]
+async fn test_deployment_with_only_sns_upgrades() {
     test_sns_deployment(
         vec![],
         vec![
@@ -61,35 +62,37 @@ fn test_deployment_with_only_sns_upgrades() {
             SnsCanisterType::Swap,
             SnsCanisterType::Index,
         ],
-    );
+    )
+    .await;
 }
 
-#[test]
-fn test_deployment_with_sns_root_and_governance_upgrade() {
+#[tokio::test]
+async fn test_deployment_with_sns_root_and_governance_upgrade() {
     test_sns_deployment(
         vec![],
         vec![SnsCanisterType::Root, SnsCanisterType::Governance],
-    );
+    )
+    .await;
 }
 
-#[test]
-fn test_deployment_swap_upgrade() {
-    test_sns_deployment(vec![], vec![SnsCanisterType::Swap]);
+#[tokio::test]
+async fn test_deployment_swap_upgrade() {
+    test_sns_deployment(vec![], vec![SnsCanisterType::Swap]).await;
 }
 
 /// Upgrade Tests
-#[test]
-fn test_upgrade_sns_gov_root() {
-    test_sns_upgrade(vec![SnsCanisterType::Root, SnsCanisterType::Governance]);
+#[tokio::test]
+async fn test_upgrade_sns_gov_root() {
+    test_sns_upgrade(vec![SnsCanisterType::Root, SnsCanisterType::Governance]).await;
 }
 
-#[test]
-fn test_upgrade_upgrade_sns_gov_root() {
-    test_sns_upgrade(vec![SnsCanisterType::Governance, SnsCanisterType::Root]);
+#[tokio::test]
+async fn test_upgrade_upgrade_sns_gov_root() {
+    test_sns_upgrade(vec![SnsCanisterType::Governance, SnsCanisterType::Root]).await;
 }
 
-#[test]
-fn test_upgrade_everything() {
+#[tokio::test]
+async fn test_upgrade_everything() {
     test_sns_upgrade(vec![
         SnsCanisterType::Root,
         SnsCanisterType::Governance,
@@ -97,17 +100,18 @@ fn test_upgrade_everything() {
         SnsCanisterType::Index,
         SnsCanisterType::Ledger,
         SnsCanisterType::Archive,
-    ]);
+    ])
+    .await;
 }
 
 /// Tests a deployment of the SNS.
 /// Usually nns_canisters do not need to be upgraded, but sometimes they have to be due to dependencies
 /// or API changes to init arguments
-pub fn test_sns_deployment(
+pub async fn test_sns_deployment(
     nns_canisters_to_upgrade: Vec<CanisterId>, // should use constants from nns/constants to make this easy to track
     sns_canisters_to_upgrade: Vec<SnsCanisterType>,
 ) {
-    let pocket_ic = pocket_ic_helpers::pocket_ic_for_sns_tests_with_mainnet_versions();
+    let pocket_ic = pocket_ic_helpers::pocket_ic_for_sns_tests_with_mainnet_versions().await;
 
     let create_service_nervous_system = CreateServiceNervousSystemBuilder::default()
         .with_governance_parameters_neuron_minimum_dissolve_delay_to_vote(ONE_MONTH_SECONDS * 6)
@@ -124,7 +128,7 @@ pub fn test_sns_deployment(
         .unwrap();
 
     for canister_id in nns_canisters_to_upgrade {
-        upgrade_nns_canister_to_tip_of_master_or_panic(&pocket_ic, canister_id);
+        upgrade_nns_canister_to_tip_of_master_or_panic(&pocket_ic, canister_id).await;
     }
 
     for canister_type in sns_canisters_to_upgrade {
@@ -143,7 +147,7 @@ pub fn test_sns_deployment(
         };
 
         let wasm = ensure_sns_wasm_gzipped(wasm);
-        let proposal_info = add_wasm_via_nns_proposal(&pocket_ic, wasm).unwrap();
+        let proposal_info = add_wasm_via_nns_proposal(&pocket_ic, wasm).await.unwrap();
         assert_eq!(proposal_info.failure_reason, None);
     }
 
@@ -153,18 +157,22 @@ pub fn test_sns_deployment(
         &pocket_ic,
         create_service_nervous_system,
         sns_instance_label,
-    );
+    )
+    .await;
 
-    sns::swap::await_swap_lifecycle(&pocket_ic, sns.swap.canister_id, Lifecycle::Open).unwrap();
+    sns::swap::await_swap_lifecycle(&pocket_ic, sns.swap.canister_id, Lifecycle::Open)
+        .await
+        .unwrap();
     sns::swap::smoke_test_participate_and_finalize(
         &pocket_ic,
         sns.swap.canister_id,
         swap_parameters,
-    );
+    )
+    .await;
 }
 
-fn test_sns_upgrade(sns_canisters_to_upgrade: Vec<SnsCanisterType>) {
-    let pocket_ic = pocket_ic_helpers::pocket_ic_for_sns_tests_with_mainnet_versions();
+async fn test_sns_upgrade(sns_canisters_to_upgrade: Vec<SnsCanisterType>) {
+    let pocket_ic = pocket_ic_helpers::pocket_ic_for_sns_tests_with_mainnet_versions().await;
 
     let create_service_nervous_system = CreateServiceNervousSystemBuilder::default()
         .with_governance_parameters_neuron_minimum_dissolve_delay_to_vote(ONE_MONTH_SECONDS * 6)
@@ -186,7 +194,8 @@ fn test_sns_upgrade(sns_canisters_to_upgrade: Vec<SnsCanisterType>) {
         &pocket_ic,
         create_service_nervous_system,
         sns_instance_label,
-    );
+    )
+    .await;
 
     for canister_type in &sns_canisters_to_upgrade {
         let wasm = match canister_type {
@@ -202,7 +211,7 @@ fn test_sns_upgrade(sns_canisters_to_upgrade: Vec<SnsCanisterType>) {
         };
 
         let wasm = ensure_sns_wasm_gzipped(wasm);
-        let proposal_info = add_wasm_via_nns_proposal(&pocket_ic, wasm).unwrap();
+        let proposal_info = add_wasm_via_nns_proposal(&pocket_ic, wasm).await.unwrap();
         assert_eq!(proposal_info.failure_reason, None);
     }
 
@@ -227,7 +236,7 @@ fn test_sns_upgrade(sns_canisters_to_upgrade: Vec<SnsCanisterType>) {
         };
 
         let wasm = ensure_sns_wasm_gzipped(wasm);
-        let proposal_info = add_wasm_via_nns_proposal(&pocket_ic, wasm).unwrap();
+        let proposal_info = add_wasm_via_nns_proposal(&pocket_ic, wasm).await.unwrap();
         assert_eq!(proposal_info.failure_reason, None);
     }
 
@@ -238,25 +247,31 @@ fn test_sns_upgrade(sns_canisters_to_upgrade: Vec<SnsCanisterType>) {
             &pocket_ic,
             sns.governance.canister_id,
             sns.ledger.canister_id,
-        );
+        )
+        .await;
     }
 
-    sns::swap::await_swap_lifecycle(&pocket_ic, sns.swap.canister_id, Lifecycle::Open).unwrap();
+    sns::swap::await_swap_lifecycle(&pocket_ic, sns.swap.canister_id, Lifecycle::Open)
+        .await
+        .unwrap();
     sns::swap::smoke_test_participate_and_finalize(
         &pocket_ic,
         sns.swap.canister_id,
         swap_parameters,
-    );
+    )
+    .await;
 
     // Every canister we are testing has two upgrades.  We are just making sure the counts match
     for _ in sns_canisters_to_upgrade {
         sns::governance::propose_to_upgrade_sns_to_next_version_and_wait(
             &pocket_ic,
             sns.governance.canister_id,
-        );
+        )
+        .await;
         sns::governance::propose_to_upgrade_sns_to_next_version_and_wait(
             &pocket_ic,
             sns.governance.canister_id,
-        );
+        )
+        .await;
     }
 }

--- a/rs/registry/admin/tests/integration_tests.rs
+++ b/rs/registry/admin/tests/integration_tests.rs
@@ -1,19 +1,20 @@
 use candid::Principal;
 use ic_nervous_system_common_test_keys::{TEST_NEURON_1_ID, TEST_NEURON_1_OWNER_KEYPAIR};
 use ic_nervous_system_integration_tests::pocket_ic_helpers::install_nns_canisters;
-use pocket_ic::{PocketIc, PocketIcBuilder};
+use pocket_ic::{nonblocking::PocketIc, PocketIcBuilder};
 use std::{env, io::Write, process::Command};
 use tempfile::NamedTempFile;
 use url::Url;
 
-fn setup() -> (PocketIc, Url) {
+async fn setup() -> (PocketIc, Url) {
     let mut pocket_ic = PocketIcBuilder::new()
         .with_nns_subnet()
         .with_sns_subnet()
-        .build();
+        .build_async()
+        .await;
 
-    let _ = install_nns_canisters(&pocket_ic, vec![], false, None, vec![]);
-    let endpoint = pocket_ic.make_live(None);
+    let _ = install_nns_canisters(&pocket_ic, vec![], false, None, vec![]).await;
+    let endpoint = pocket_ic.make_live(None).await;
     (pocket_ic, endpoint)
 }
 
@@ -26,9 +27,9 @@ fn create_neuron_1_pem_file() -> NamedTempFile {
     pem_file
 }
 
-#[test]
-fn test_propose_to_rent_subnet_can_read_pem_file() {
-    let (_pocket_ic, url) = setup();
+#[tokio::test]
+async fn test_propose_to_rent_subnet_can_read_pem_file() {
+    let (_pocket_ic, url) = setup().await;
 
     let ic_admin_path = env::var("IC_ADMIN_BIN").expect("IC_ADMIN_BIN not set");
     let pem_file = create_neuron_1_pem_file();


### PR DESCRIPTION
## The problem

`block_on` in general is a bad practice imo - it constantly causes issues because it doesn't compose. A function called with block_on (or an async context) cannot call another function with block_on. This is not symmetrical with async - a sync function can call an async function using block_on, but an async function cannot call a sync function that uses block_on.

This is revelant to the the tests in ic-nervous-system-integration-tests because PocketIc in blocking mode (the default) uses block_on. This excludes the possibility of using it in an async context. 

For a concrete example, we can’t currently use sns-audit in integration tests since it must work with ic-agent (which is async). This means that any functions called from sns-audit must work in an async context. It would be very nice to be able to use sns-audit in integration tests, since it would mean that we could have a centralized place to do the checks for “did the SNS get deployed the way it was supposed to” that could be used on mainnet and in tests. Using sns-audit in tests that would also mean that we would not be able to make a change to how SNSes are deployed that is breaking w.r.t. sns-audit without also fixing sns-audit (which we currently basically do not test for IIUC)

## The solution

Use PocketIC in non-blocking mode. What this means generally is that you need to add `.await` and `async` everywhere. There are a lot of changes in this PR, but they almost all very mechanical. 

In some cases we had closures that called blocking pocket_ic functions. These generally could be fixed by using `async move`. 

The only non-mechanical change is that some places that used iterators had to be changed to use streams or just use traditional `for i in range` iteration.