### PR TITLE
fix(IDX): fix the "Tag Team Reviewers" workflow when run in the private repo

### DIFF
--- a/.github/workflows/ci-pr-only-team-tags.yml
+++ b/.github/workflows/ci-pr-only-team-tags.yml
@@ -15,6 +15,7 @@ on:
 permissions:
   contents: read
   pull-requests: write
+  repository-projects: read
 
 env:
   REPO: "${{ github.repository }}"


### PR DESCRIPTION
The "Tag Team Reviewers" workflow was [failing](https://github.com/dfinity/ic-private/actions/runs/11152689696/job/30998779522?pr=39) in the private repo with:

```
+ gh pr edit 39 --add-label @ic-message-routing-owners
GraphQL: Resource not accessible by integration (repository.pullRequest.projectCards.nodes)
```

According to https://github.com/cli/cli/issues/6274 this will be fixed by adding the `repository-projects: read` permission.

Tested in: https://github.com/dfinity/ic-private/pull/41.