### PR TITLE
fix: Small change in how we enable systemd services

### DIFF
--- a/ic-os/boundary-guestos/context/Dockerfile
+++ b/ic-os/boundary-guestos/context/Dockerfile
@@ -115,7 +115,9 @@ RUN if [ "${ROOT_PASSWORD}" != "" ]; then \
 # to node operation.
 
 RUN for SERVICE in /etc/systemd/system/*; do \
-    if [ -f "$SERVICE" -a ! -L "$SERVICE" ] && grep -q '^.Install.' "$SERVICE" ; then systemctl enable "${SERVICE#/etc/systemd/system/}" ; fi ; \
+        if [ -f "$SERVICE" ] && [ ! -L "$SERVICE" ] && ! echo "$SERVICE" | grep -Eq "@\.service$"; then \
+            systemctl enable "${SERVICE#/etc/systemd/system/}"; \
+        fi ; \
     done && \
     systemctl enable \
     chrony \

--- a/ic-os/guestos/context/Dockerfile
+++ b/ic-os/guestos/context/Dockerfile
@@ -88,9 +88,10 @@ RUN rm /etc/ssh/ssh*key*
 # strictly necessary to be explicit here.
 RUN sed -e "s/.*PermitRootLogin.*/PermitRootLogin prohibit-password/" -i /etc/ssh/sshd_config
 
-RUN \
-    for SERVICE in /etc/systemd/system/*; do \
-    if [ -f "$SERVICE" -a ! -L "$SERVICE" ] && grep -q '^.Install.' "$SERVICE" ; then systemctl enable "${SERVICE#/etc/systemd/system/}" ; fi ; \
+RUN for SERVICE in /etc/systemd/system/*; do \
+        if [ -f "$SERVICE" ] && [ ! -L "$SERVICE" ] && ! echo "$SERVICE" | grep -Eq "@\.service$"; then \
+            systemctl enable "${SERVICE#/etc/systemd/system/}"; \
+        fi ; \
     done
 
 RUN systemctl enable \

--- a/ic-os/hostos/context/Dockerfile
+++ b/ic-os/hostos/context/Dockerfile
@@ -82,9 +82,10 @@ RUN rm /etc/ssh/ssh*key*
 # strictly necessary to be explicit here.
 RUN sed -e "s/.*PermitRootLogin.*/PermitRootLogin prohibit-password/" -i /etc/ssh/sshd_config
 
-RUN \
-    for SERVICE in /etc/systemd/system/*; do \
-    if [ -f "$SERVICE" -a ! -L "$SERVICE" ] && grep -q '^.Install.' "$SERVICE" ; then systemctl enable "${SERVICE#/etc/systemd/system/}" ; fi ; \
+RUN for SERVICE in /etc/systemd/system/*; do \
+        if [ -f "$SERVICE" ] && [ ! -L "$SERVICE" ] && ! echo "$SERVICE" | grep -Eq "@\.service$"; then \
+            systemctl enable "${SERVICE#/etc/systemd/system/}"; \
+        fi ; \
     done
 
 RUN systemctl enable \

--- a/ic-os/setupos/context/Dockerfile
+++ b/ic-os/setupos/context/Dockerfile
@@ -64,9 +64,10 @@ RUN find /etc -type d -exec chmod 0755 {} \+ && \
 # Regenerate initramfs (config changed after copying in /etc)
 RUN RESUME=none update-initramfs -c -k all
 
-RUN \
-    for SERVICE in /etc/systemd/system/*; do \
-    if [ -f "$SERVICE" -a ! -L "$SERVICE" ] && grep -q '^.Install.' "$SERVICE" ; then systemctl enable "${SERVICE#/etc/systemd/system/}" ; fi ; \
+RUN for SERVICE in /etc/systemd/system/*; do \
+        if [ -f "$SERVICE" ] && [ ! -L "$SERVICE" ] && ! echo "$SERVICE" | grep -Eq "@\.service$"; then \
+            systemctl enable "${SERVICE#/etc/systemd/system/}"; \
+        fi ; \
     done
 
 RUN systemctl enable \


### PR DESCRIPTION
- Don't enable template units (these will fail without the instance variable)
- Remove unnecessary check whether the definition contains an [Install] directive