### PR TITLE
fix(IDX): remove continue-on-error

### DIFF
--- a/.github/workflows-source/release-testing.yml
+++ b/.github/workflows-source/release-testing.yml
@@ -96,7 +96,6 @@ jobs:
 
   bazel-system-test-staging:
     name: Bazel System Test Staging
-    continue-on-error: True
     <<: *dind-large-setup
     steps:
       - <<: *checkout

--- a/.github/workflows/release-testing.yml
+++ b/.github/workflows/release-testing.yml
@@ -74,7 +74,6 @@ jobs:
             profile.json
   bazel-system-test-staging:
     name: Bazel System Test Staging
-    continue-on-error: True
     runs-on:
       group: zh1
       labels: dind-large


### PR DESCRIPTION
It's unclear why we set it in the first place, but it falsely shows the release pipeline as green.