### PR TITLE
chore: [MR-610] Revert custom `impl ExhaustiveSet for RejectCode`

### DIFF
--- a/rs/types/types/src/exhaustive.rs
+++ b/rs/types/types/src/exhaustive.rs
@@ -284,10 +284,7 @@ impl<K: ExhaustiveSet + std::cmp::Ord> ExhaustiveSet for BTreeSet<K> {
 
 impl ExhaustiveSet for RejectCode {
     fn exhaustive_set<R: RngCore + CryptoRng>(_: &mut R) -> Vec<Self> {
-        RejectCode::iter()
-            // TODO(MR-610): Drop this after `SysUnknown` is supported on mainnet.
-            .filter(|code| *code != RejectCode::SysUnknown)
-            .collect()
+        RejectCode::iter().collect()
     }
 }
 


### PR DESCRIPTION
This was introduced along with `SysUnknown`, for backwards compatibility. Now that `SysUnknown` is supported by mainnet replicas, the filter can be dropped.