### PR TITLE
fix(ckETH): update readme

### DIFF
--- a/rs/ethereum/cketh/playground/README.adoc
+++ b/rs/ethereum/cketh/playground/README.adoc
@@ -88,15 +88,15 @@ dfx canister --network ic start minter
 If you deploy locally, you need to find out the compressed wasm hashes of the ledger and the index canisters for the desired git revision, e.g. `5553ee5f7586290a59ed372a2b7aca847520af82`:
 [source,shell]
 ----
-git checkout 5553ee5f7586290a59ed372a2b7aca847520af82
-openssl sha256 bazel-bin/rs/rosetta-api/icrc1/ledger/ledger_canister_u256.wasm.gz
-openssl sha256 bazel-bin/rs/rosetta-api/icrc1/index-ng/index_ng_canister_u256.wasm.gz
+git checkout ca8847547d327ce8a3bd81d25a590e01da1a3af5
+openssl sha256 bazel-bin/rs/ledger_suite/icrc1/ledger/ledger_canister_u256.wasm.gz
+openssl sha256 bazel-bin/rs/ledger_suite/icrc1/index-ng/index_ng_canister_u256.wasm.gz
 ----
 
 If you deploy from a dev env,
 [source,shell]
 ----
-git checkout 5553ee5f7586290a59ed372a2b7aca847520af82
+git checkout ca8847547d327ce8a3bd81d25a590e01da1a3af5
 ./gitlab-ci/container/build-ic.sh -c
 ----
 


### PR DESCRIPTION
This MR proposes the following changes:

1. Fix the git hash and subdirectory path of the icrc1 ledger of the README for ckETH