### PR TITLE
fix(IDX): revert "fix(IDX): add branch head sha (#1821)"

### DIFF
--- a/.github/actions/bazel-test-all/action.yaml
+++ b/.github/actions/bazel-test-all/action.yaml
@@ -70,6 +70,5 @@ runs:
           BAZEL_STARTUP_ARGS: ${{ inputs.BAZEL_STARTUP_ARGS }}
           CI_PULL_REQUEST_TARGET_BRANCH_NAME: ${{ github.event.pull_request.base.ref }}
           MERGE_BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          BRANCH_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           BUILDEVENT_APIKEY: ${{ inputs.BUILDEVENT_APIKEY }}
           SSH_PRIVATE_KEY: ${{ inputs.SSH_PRIVATE_KEY }}

--- a/.github/workflows-source/ci-main.yml
+++ b/.github/workflows-source/ci-main.yml
@@ -264,7 +264,6 @@ jobs:
           RUN_ON_DIFF_ONLY: ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'CI_ALL_BAZEL_TARGETS') }}
           MERGE_BASE_SHA: ${{ github.event.pull_request.base.sha }}
           BUILDEVENT_APIKEY: ${{ secrets.HONEYCOMB_API_TOKEN }}
-          BRANCH_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
       - name: Upload build-ic.tar
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -350,7 +350,6 @@ jobs:
           RUN_ON_DIFF_ONLY: ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'CI_ALL_BAZEL_TARGETS') }}
           MERGE_BASE_SHA: ${{ github.event.pull_request.base.sha }}
           BUILDEVENT_APIKEY: ${{ secrets.HONEYCOMB_API_TOKEN }}
-          BRANCH_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
       - name: Upload build-ic.tar
         uses: actions/upload-artifact@v4
         with:

--- a/ci/bazel-scripts/diff.sh
+++ b/ci/bazel-scripts/diff.sh
@@ -14,8 +14,7 @@ set -x
 cd "$(git rev-parse --show-toplevel)"
 
 MERGE_BASE="${MERGE_BASE_SHA:-HEAD}"
-# we can't use HEAD here because that is the merge commit which contains the changes of the current HEAD of master
-COMMIT_RANGE="$MERGE_BASE..${BRANCH_HEAD_SHA:-}"
+COMMIT_RANGE=${COMMIT_RANGE:-$MERGE_BASE".."}
 DIFF_FILES=$(git diff --name-only "${COMMIT_RANGE}")
 
 if grep -qE "(.*\.bazel|.*\.bzl|\.bazelrc|\.bazelversion)" <<<"$DIFF_FILES"; then


### PR DESCRIPTION
This reverts commit 4e5f7466d70059ceb9137298bba91f0dc6f0513e.

I realise https://github.com/dfinity/ic/pull/1821 was not fully correct. I noticed that https://github.com/dfinity/ic/actions/runs/11179592069/job/31079559670?pr=1720 contained DIFF_FILES that I didn't touch. The reason is that we now run `DIFF_FILES=$(git diff --name-only $MERGE_BASE..$BRANCH_HEAD_SHA)`. Where `$MERGE_BASE` is the latest commit on master and `$BRANCH_HEAD_SHA` is the HEAD of my PR. The problem with this is that if master has advanced after I forked of my PR branch the DIFF_FILES will include all changed files on master between my PR fork off commit and `$MERGE_BASE`. Before we had:
`DIFF_FILES=$(git diff --name-only $MERGE_BASE..)` or more explicitly: `DIFF_FILES=$(git diff --name-only $MERGE_BASE..HEAD)` where `HEAD` is the merge commit of the latest master with the PR branch. That actually results in the right diff since it won't include any commits in master since the latest master is included in both `$MERGE_BASE` and `HEAD`.