### PR TITLE
feat(release-scripts): Output all commits to be released with colors

### DIFF
--- a/testnet/tools/lib.sh
+++ b/testnet/tools/lib.sh
@@ -2,6 +2,7 @@ repo_root() {
     git rev-parse --show-toplevel
 }
 
+LIGHT_GRAY_TEXT='\033[0;37m'
 RED_TEXT='\033[0;31m'
 GREEN_TEXT='\033[0;32m'
 YELLOW_TEXT='\033[0;33m'
@@ -9,6 +10,10 @@ BLUE_TEXT='\033[0;34m'
 PURPLE_TEXT='\033[0;35m'
 CYAN_TEXT='\033[0;36m'
 NO_COLOR='\033[0m'
+
+print_light_gray() {
+    echo -e "${LIGHT_GRAY_TEXT}$*${NO_COLOR}"
+}
 
 print_red() {
     echo -e "${RED_TEXT}$*${NO_COLOR}" 1>&2

--- a/testnet/tools/nns-tools/list-new-commits.sh
+++ b/testnet/tools/nns-tools/list-new-commits.sh
@@ -78,10 +78,15 @@ list_new_canister_commits() {
         print_cyan "${HEADING}"
     fi
 
-    # Print commits.
-    if [[ "${INTERESTING_COMMITS}" != "" ]]; then
-        echo "${INTERESTING_COMMITS}"
-    fi
+    while IFS= read -r COMMIT_MSG; do
+        if [[ $(echo "$COMMIT_MSG" | grep -v -E ' .{10} (chore|refactor|test)\b' | wc -l) -gt 0 ]];
+        then
+            print_blue "${COMMIT_MSG}"
+        else
+            print_light_gray "${COMMIT_MSG}"
+        fi
+    done <<<  "${NEW_COMMITS}"
+
 }
 
 # Begin main.

--- a/testnet/tools/nns-tools/list-new-commits.sh
+++ b/testnet/tools/nns-tools/list-new-commits.sh
@@ -78,11 +78,11 @@ list_new_canister_commits() {
         print_cyan "${HEADING}"
     fi
 
-    while IFS= read -r COMMIT_MSG; do
-        if [[ $(echo "$COMMIT_MSG" | grep -v -E ' .{10} (chore|refactor|test)\b' | wc -l) -gt 0 ]]; then
-            print_blue "${COMMIT_MSG}"
+    while IFS= read -r COMMIT_MESSAGE; do
+        if [[ $(echo "$COMMIT_MESSAGE" | grep -v -E ' .{10} (chore|refactor|test)\b' | wc -l) -gt 0 ]]; then
+            print_blue "${COMMIT_MESSAGE}"
         else
-            print_light_gray "${COMMIT_MSG}"
+            print_light_gray "${COMMIT_MESSAGE}"
         fi
     done <<<"${NEW_COMMITS}"
 

--- a/testnet/tools/nns-tools/list-new-commits.sh
+++ b/testnet/tools/nns-tools/list-new-commits.sh
@@ -79,13 +79,12 @@ list_new_canister_commits() {
     fi
 
     while IFS= read -r COMMIT_MSG; do
-        if [[ $(echo "$COMMIT_MSG" | grep -v -E ' .{10} (chore|refactor|test)\b' | wc -l) -gt 0 ]];
-        then
+        if [[ $(echo "$COMMIT_MSG" | grep -v -E ' .{10} (chore|refactor|test)\b' | wc -l) -gt 0 ]]; then
             print_blue "${COMMIT_MSG}"
         else
             print_light_gray "${COMMIT_MSG}"
         fi
-    done <<<  "${NEW_COMMITS}"
+    done <<<"${NEW_COMMITS}"
 
 }
 

--- a/testnet/tools/nns-tools/submit-mainnet-nns-upgrade-proposal.sh
+++ b/testnet/tools/nns-tools/submit-mainnet-nns-upgrade-proposal.sh
@@ -104,7 +104,7 @@ submit_nns_upgrade_proposal_mainnet() {
         --wasm-module-path="$WASM_GZ"
 
         # Misc
-        --use-explicit-action-type
+        --use-explicit-action-type true
         --wasm-module-sha256="$WASM_SHA"
         --proposer="$NEURON_ID"
     )


### PR DESCRIPTION
Instead of hiding uninteresting commits, simply color codes interesting versus non-interesting, as shown below:

![image](https://github.com/user-attachments/assets/e4895c16-fc9d-4961-ac2e-14e74a583b44)
