### PR TITLE
chore: assorted ic-os bash script clean-ups and tweaks

### DIFF
--- a/ic-os/components/boundary-guestos/opt/ic/bin/firewall-counter-check.sh
+++ b/ic-os/components/boundary-guestos/opt/ic/bin/firewall-counter-check.sh
@@ -3,7 +3,6 @@
 set -o nounset
 set -o pipefail
 
-# Source the functions required for writing metrics
 source /opt/ic/bin/metrics.sh
 METRICS_FILE="${METRICS_DIR}/firewall_counters.prom"
 

--- a/ic-os/components/early-boot/setup-hostname/hostos/setup-hostname.sh
+++ b/ic-os/components/early-boot/setup-hostname/hostos/setup-hostname.sh
@@ -5,7 +5,6 @@ set -e
 # Set the transient or persistent hostname.
 
 source /opt/ic/bin/logging.sh
-# Source the functions required for writing metrics
 source /opt/ic/bin/metrics.sh
 
 SCRIPT="$(basename $0)[$$]"

--- a/ic-os/components/hostos-scripts/generate-guestos-config/dev-generate-guestos-config.sh
+++ b/ic-os/components/hostos-scripts/generate-guestos-config/dev-generate-guestos-config.sh
@@ -4,10 +4,8 @@ set -e
 
 # Generate the GuestOS configuration.
 
-# Source the functions required for writing metrics
+source /opt/ic/bin/logging.sh
 source /opt/ic/bin/metrics.sh
-
-SCRIPT="$(basename $0)[$$]"
 
 # Get keyword arguments
 for argument in "${@}"; do
@@ -65,16 +63,6 @@ DEPLOYMENT="${DEPLOYMENT:=/boot/config/deployment.json}"
 INPUT="${INPUT:=/opt/ic/share/guestos.xml.template}"
 MEDIA="${MEDIA:=/run/ic-node/config.img}"
 OUTPUT="${OUTPUT:=/var/lib/libvirt/guestos.xml}"
-
-write_log() {
-    local message=$1
-
-    if [ -t 1 ]; then
-        echo "${SCRIPT} ${message}" >/dev/stdout
-    fi
-
-    logger -t ${SCRIPT} "${message}"
-}
 
 function read_variables() {
     # Read limited set of keys. Be extra-careful quoting values as it could

--- a/ic-os/components/hostos-scripts/generate-guestos-config/generate-guestos-config.sh
+++ b/ic-os/components/hostos-scripts/generate-guestos-config/generate-guestos-config.sh
@@ -5,10 +5,7 @@ set -e
 # Generate the GuestOS configuration.
 
 source /opt/ic/bin/logging.sh
-# Source the functions required for writing metrics
 source /opt/ic/bin/metrics.sh
-
-SCRIPT="$(basename $0)[$$]"
 
 # Get keyword arguments
 for argument in "${@}"; do

--- a/ic-os/components/hostos-scripts/guestos/start-guestos.sh
+++ b/ic-os/components/hostos-scripts/guestos/start-guestos.sh
@@ -5,7 +5,6 @@ set -e
 # Start the GuestOS virtual machine.
 
 source /opt/ic/bin/logging.sh
-# Source the functions required for writing metrics
 source /opt/ic/bin/metrics.sh
 
 SCRIPT="$(basename $0)[$$]"

--- a/ic-os/components/hostos-scripts/guestos/stop-guestos.sh
+++ b/ic-os/components/hostos-scripts/guestos/stop-guestos.sh
@@ -5,7 +5,6 @@ set -e
 # Stop the GuestOS virtual machine.
 
 source /opt/ic/bin/logging.sh
-# Source the functions required for writing metrics
 source /opt/ic/bin/metrics.sh
 
 SCRIPT="$(basename $0)[$$]"

--- a/ic-os/components/hostos-scripts/misc/detect-first-boot.sh
+++ b/ic-os/components/hostos-scripts/misc/detect-first-boot.sh
@@ -7,7 +7,6 @@ set -e
 # This script is executed by HostOS right before booting GuestOS VM.
 
 source /opt/ic/bin/logging.sh
-# Source the functions required for writing metrics
 source /opt/ic/bin/metrics.sh
 
 SCRIPT="$(basename "$0")[$$]"

--- a/ic-os/components/hostos-scripts/misc/fetch-mgmt-mac.sh
+++ b/ic-os/components/hostos-scripts/misc/fetch-mgmt-mac.sh
@@ -5,7 +5,6 @@ set -e
 # Fetch the management MAC address of the physical machine.
 
 source /opt/ic/bin/logging.sh
-# Source the functions required for writing metrics
 source /opt/ic/bin/metrics.sh
 
 SCRIPT="$(basename $0)[$$]"

--- a/ic-os/components/hostos-scripts/monitoring/monitor-guestos.sh
+++ b/ic-os/components/hostos-scripts/monitoring/monitor-guestos.sh
@@ -5,7 +5,6 @@ set -e
 # Monitor the GuestOS virtual machine.
 
 source /opt/ic/bin/logging.sh
-# Source the functions required for writing metrics
 source /opt/ic/bin/metrics.sh
 
 SCRIPT="$(basename $0)[$$]"

--- a/ic-os/components/init/bootstrap-ic-node/guestos/bootstrap-ic-node.sh
+++ b/ic-os/components/init/bootstrap-ic-node/guestos/bootstrap-ic-node.sh
@@ -14,7 +14,6 @@
 set -eo pipefail
 
 source /opt/ic/bin/logging.sh
-# Source the functions required for writing metrics
 source /opt/ic/bin/metrics.sh
 
 SCRIPT="$(basename $0)[$$]"

--- a/ic-os/components/monitoring/ipv4-connectivity-check/ipv4-connectivity-check.sh
+++ b/ic-os/components/monitoring/ipv4-connectivity-check/ipv4-connectivity-check.sh
@@ -3,7 +3,6 @@
 set -o nounset
 set -o pipefail
 
-# Source the functions required for writing metrics
 source /opt/ic/bin/metrics.sh
 
 endpoints=("1.1.1.1" "ic0.app" "httpbin.org")

--- a/ic-os/components/setupos-scripts/check-hardware.sh
+++ b/ic-os/components/setupos-scripts/check-hardware.sh
@@ -6,6 +6,8 @@ set -o pipefail
 SHELL="/bin/bash"
 PATH="/sbin:/bin:/usr/sbin:/usr/bin"
 
+source /opt/ic/bin/functions.sh
+
 GENERATION=
 
 MINIMUM_CPU_SOCKETS=2
@@ -261,7 +263,6 @@ function verify_deployment_path() {
 
 # Establish run order
 main() {
-    source /opt/ic/bin/functions.sh
     log_start "$(basename $0)"
     check_generation
     verify_cpu

--- a/ic-os/components/setupos-scripts/check-network.sh
+++ b/ic-os/components/setupos-scripts/check-network.sh
@@ -6,6 +6,8 @@ set -o pipefail
 SHELL="/bin/bash"
 PATH="/sbin:/bin:/usr/sbin:/usr/bin"
 
+source /opt/ic/bin/functions.sh
+
 CONFIG="${CONFIG:=/var/ic/config/config.ini}"
 DEPLOYMENT="${DEPLOYMENT:=/data/deployment.json}"
 
@@ -200,7 +202,6 @@ function query_nns_nodes() {
 
 # Establish run order
 main() {
-    source /opt/ic/bin/functions.sh
     log_start "$(basename $0)"
     read_variables
     get_network_settings

--- a/ic-os/components/setupos-scripts/check-network.sh
+++ b/ic-os/components/setupos-scripts/check-network.sh
@@ -123,20 +123,20 @@ function validate_domain_name() {
     IFS='.' read -ra domain_parts <<<"${domain}"
 
     if [ ${#domain_parts[@]} -lt 2 ]; then
-        log_and_halt_installation_on_error 1 "Domain validation error: less than two domain parts in domain"
+        log_and_halt_installation_on_error 1 "Domain validation error: less than two domain parts in domain: ${domain}"
     fi
 
     for domain_part in "${domain_parts[@]}"; do
         if [ -z "$domain_part" ] || [ ${#domain_part} -gt 63 ]; then
-            log_and_halt_installation_on_error 1 "Domain validation error: domain part length violation"
+            log_and_halt_installation_on_error 1 "Domain validation error: domain part length violation: ${domain_part}"
         fi
 
         if [[ $domain_part == -* ]] || [[ $domain_part == *- ]]; then
-            log_and_halt_installation_on_error 1 "Domain validation error: domain part starts or ends with a hyphen"
+            log_and_halt_installation_on_error 1 "Domain validation error: domain part starts or ends with a hyphen: ${domain_part}"
         fi
 
         if ! [[ $domain_part =~ ^[a-zA-Z0-9-]+$ ]]; then
-            log_and_halt_installation_on_error 1 "Domain validation error: invalid characters in domain part"
+            log_and_halt_installation_on_error 1 "Domain validation error: invalid characters in domain part: ${domain_part}"
         fi
     done
 }

--- a/ic-os/components/setupos-scripts/check-setupos-age.sh
+++ b/ic-os/components/setupos-scripts/check-setupos-age.sh
@@ -6,6 +6,8 @@ set -o pipefail
 SHELL="/bin/bash"
 PATH="/sbin:/bin:/usr/sbin:/usr/bin"
 
+source /opt/ic/bin/functions.sh
+
 function check_setupos_age() {
     if [ -f "/build-time" ]; then
         six_weeks_ago=$(date -u -d '6 weeks ago' +%s)
@@ -22,7 +24,9 @@ function check_setupos_age() {
 }
 
 main() {
+    log_start "$(basename $0)"
     check_setupos_age
+    log_end "$(basename $0)"
 }
 
 main

--- a/ic-os/components/setupos-scripts/config.sh
+++ b/ic-os/components/setupos-scripts/config.sh
@@ -13,6 +13,8 @@ CONFIG_INI_CLONE="${CONFIG_TMP}/config.ini"
 SSH_AUTHORIZED_KEYS="${CONFIG_DIR}/ssh_authorized_keys"
 SSH_AUTHORIZED_KEYS_CLONE="${CONFIG_TMP}/ssh_authorized_keys"
 
+source /opt/ic/bin/functions.sh
+
 # Define empty variables so they are not unset
 ipv6_prefix=""
 ipv6_gateway=""
@@ -106,7 +108,6 @@ function verify_variables() {
 
 # Establish run order
 main() {
-    source /opt/ic/bin/functions.sh
     log_start "$(basename $0)"
     print_config_file
     create_config_tmp

--- a/ic-os/components/setupos-scripts/functions.sh
+++ b/ic-os/components/setupos-scripts/functions.sh
@@ -23,7 +23,7 @@ function log_and_halt_installation_on_error() {
             echo "                                     ERROR"
             echo "--------------------------------------------------------------------------------"
             echo -e "\n\n"
-            echo "${log_message}"
+            echo -e "${log_message}"
             echo -e "\n\n"
             echo "--------------------------------------------------------------------------------"
             echo "                                     ERROR"

--- a/ic-os/components/setupos-scripts/install-guestos.sh
+++ b/ic-os/components/setupos-scripts/install-guestos.sh
@@ -6,6 +6,8 @@ set -o pipefail
 SHELL="/bin/bash"
 PATH="/sbin:/bin:/usr/sbin:/usr/bin"
 
+source /opt/ic/bin/functions.sh
+
 LV="/dev/mapper/hostlvm-guestos"
 
 function install_guestos() {
@@ -34,7 +36,6 @@ function install_guestos() {
 
 # Establish run order
 main() {
-    source /opt/ic/bin/functions.sh
     log_start "$(basename $0)"
     install_guestos
     log_end "$(basename $0)"

--- a/ic-os/components/setupos-scripts/install-hostos.sh
+++ b/ic-os/components/setupos-scripts/install-hostos.sh
@@ -6,6 +6,8 @@ set -o pipefail
 SHELL="/bin/bash"
 PATH="/sbin:/bin:/usr/sbin:/usr/bin"
 
+source /opt/ic/bin/functions.sh
+
 function install_hostos() {
     echo "* Installing HostOS disk-image..."
 
@@ -101,7 +103,6 @@ function resize_partition() {
 
 # Establish run order
 main() {
-    source /opt/ic/bin/functions.sh
     log_start "$(basename $0)"
     install_hostos
     configure_efi

--- a/ic-os/components/setupos-scripts/setup-disk.sh
+++ b/ic-os/components/setupos-scripts/setup-disk.sh
@@ -6,6 +6,8 @@ set -o pipefail
 SHELL="/bin/bash"
 PATH="/sbin:/bin:/usr/sbin:/usr/bin"
 
+source /opt/ic/bin/functions.sh
+
 function purge_partitions() {
     echo "* Purging partitions..."
 
@@ -60,7 +62,6 @@ function setup_storage() {
 
 # Establish run order
 main() {
-    source /opt/ic/bin/functions.sh
     log_start "$(basename $0)"
     purge_partitions
     setup_storage

--- a/ic-os/components/setupos-scripts/setup-hostos-config.sh
+++ b/ic-os/components/setupos-scripts/setup-hostos-config.sh
@@ -7,6 +7,8 @@ SHELL="/bin/bash"
 PATH="/sbin:/bin:/usr/sbin:/usr/bin"
 CONFIG_DIR="/var/ic/config"
 
+source /opt/ic/bin/functions.sh
+
 function mount_config_partition() {
     echo "* Mounting hostOS config partition..."
 
@@ -82,7 +84,6 @@ function unmount_config_partition() {
 
 # Establish run order
 main() {
-    source /opt/ic/bin/functions.sh
     log_start "$(basename $0)"
     mount_config_partition
     copy_config_files

--- a/ic-os/components/setupos-scripts/setupos.sh
+++ b/ic-os/components/setupos-scripts/setupos.sh
@@ -6,6 +6,8 @@ set -o pipefail
 SHELL="/bin/bash"
 PATH="/sbin:/bin:/usr/sbin:/usr/bin"
 
+source /opt/ic/bin/functions.sh
+
 function start_setupos() {
     # Wait until login prompt appears
     sleep 5
@@ -34,7 +36,6 @@ function reboot_setupos() {
 
 # Establish run order
 main() {
-    source /opt/ic/bin/functions.sh
     log_start "$(basename $0)"
     start_setupos
     /opt/ic/bin/check-setupos-age.sh

--- a/ic-os/components/upgrade/manageboot/manageboot.sh
+++ b/ic-os/components/upgrade/manageboot/manageboot.sh
@@ -3,7 +3,6 @@
 set -e
 
 source /opt/ic/bin/logging.sh
-# Source the functions required for writing metrics
 source /opt/ic/bin/metrics.sh
 
 SCRIPT="$(basename "$0")[$$]"


### PR DESCRIPTION
Easier to review by commits:

- [Remove variation in generate-guestos-config scripts except for what's necessary](https://github.com/dfinity/ic/pull/1857/commits/5593cce57e3925795468631852421f3f0b778051)
- [Add -e to log_and_halt_installation_on_error echo](https://github.com/dfinity/ic/pull/1857/commits/5a66aa42e72d52c4720701bef23c5ee955bd564e)
- [Organize sourcing in bash scripts](https://github.com/dfinity/ic/pull/1857/commits/7e6e3b8866af1c77feaac07945d7d5c635ee68b6)
- [Log domain in check-network.sh error](https://github.com/dfinity/ic/pull/1857/commits/c9d4e99ed428c93d5538fb5cfc043cfc6dcac3a2)