### PR TITLE
fix: verbose logging service file failure

### DIFF
--- a/ic-os/components/hostos-scripts/verbose-logging/verbose-logging.service
+++ b/ic-os/components/hostos-scripts/verbose-logging/verbose-logging.service
@@ -4,7 +4,7 @@ Requires=guestos.service
 After=guestos.service
 
 [Service]
-ExecStart=/opt/ic/bin/verbose-logging.sh 
+ExecStart=/opt/ic/bin/verbose-logging.sh
 Restart=on-failure
 
 [Install]

--- a/ic-os/components/hostos-scripts/verbose-logging/verbose-logging.service
+++ b/ic-os/components/hostos-scripts/verbose-logging/verbose-logging.service
@@ -4,9 +4,8 @@ Requires=guestos.service
 After=guestos.service
 
 [Service]
-Type=oneshot
 ExecStart=/opt/ic/bin/verbose-logging.sh 
-RemainAfterExit=true
+Restart=on-failure
 
 [Install]
 WantedBy=multi-user.target

--- a/ic-os/components/hostos-scripts/verbose-logging/verbose-logging.service
+++ b/ic-os/components/hostos-scripts/verbose-logging/verbose-logging.service
@@ -4,8 +4,9 @@ Requires=guestos.service
 After=guestos.service
 
 [Service]
-ExecStart=/opt/ic/bin/verbose-logging.sh
-Restart=always
+Type=oneshot
+ExecStart=/opt/ic/bin/verbose-logging.sh 
+RemainAfterExit=true
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
When the verbose flag is not enabled, verbose-logging.sh exits immediately, but the service file was set to restart causing it to restart over and over again. After several rapid restarts, systemd marks the service as failed to prevent a restart loop.

<img width="1308" alt="Pasted Graphic 6" src="https://github.com/user-attachments/assets/e255a6ac-745e-425c-94c6-3b47a4a75c7a">

This changes the service to only restart on failure