### PR TITLE
chore: Fix intermittent `cargo check` errors

### DIFF
--- a/rs/types/types/src/lib.rs
+++ b/rs/types/types/src/lib.rs
@@ -106,7 +106,7 @@ use serde::{Deserialize, Serialize};
 use std::convert::TryFrom;
 use std::fmt;
 use std::sync::Arc;
-use strum::EnumIter;
+use strum_macros::EnumIter;
 use thousands::Separable;
 
 pub struct UserTag {}

--- a/rs/types/types/src/state_sync.rs
+++ b/rs/types/types/src/state_sync.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 use std::fmt;
 use std::fmt::Display;
-use strum::EnumIter;
+use strum_macros::EnumIter;
 
 #[derive(
     Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Deserialize, EnumIter, Serialize,


### PR DESCRIPTION
`cargo check` intermittently fails to build with `strum::EnumIter` as a derive macro, switch to `strum_derive::EnumIter`.