### PR TITLE
fix(consensus): Use correct malicious flags in equivocation integration test

### DIFF
--- a/rs/consensus/tests/integration.rs
+++ b/rs/consensus/tests/integration.rs
@@ -356,8 +356,12 @@ fn equivocating_block_maker_test(
         .and_then(|config| config.parse_extra_config())
         .map(|config| {
             let mut malicious: Vec<ComponentModifier> = Vec::new();
+            let malicious_flags = MaliciousFlags {
+                maliciously_propose_equivocating_blocks: true,
+                ..MaliciousFlags::default()
+            };
             for _ in 0..num_nodes_equivocating {
-                malicious.push(malicious::absent_notary_share());
+                malicious.push(malicious::with_malicious_flags(malicious_flags.clone()));
             }
             run_n_rounds_and_collect_hashes(config, malicious, finish);
         })


### PR DESCRIPTION
The integration test mistakenly used the `absent_notary_share` modifier, instead of the equivocation flag.