### PR TITLE
feat(nervous-system-tools): Reintroduce verification instructions.

### DIFF
--- a/testnet/tools/nns-tools/lib/proposals.sh
+++ b/testnet/tools/nns-tools/lib/proposals.sh
@@ -95,10 +95,6 @@ __Source Code__: [$NEXT_COMMIT][new-commit]
 
 [new-commit]: https://github.com/dfinity/ic/tree/$NEXT_COMMIT
 
-[How to verify] this proposal (and others like it).
-
-[How to verify]: https://github.com/dfinity/ic/tree/master/rs/nervous_system/docs/proposal_verification.md
-
 ## New Commits
 
 \`\`\`
@@ -123,7 +119,15 @@ $CANDID_ARGS
 - Current Wasm Hash: $LAST_WASM_HASH
 
 
-## WASM Verification
+## Verification
+
+See the general instructions on [how to verify] proposals like this. A "quick
+start" guide is provided here.
+
+[how to verify]: https://github.com/dfinity/ic/tree/${NEXT_COMMIT}/rs/nervous_system/docs/proposal_verification.md
+
+
+### WASM Verification
 
 See ["Building the code"][prereqs] for prerequisites.
 
@@ -148,7 +152,7 @@ This should match \`wasm_module_hash\` field of this proposal.$(if [ ! -z "$CAND
             echo "
 
 
-## Upgrade Arguments Verification
+### Upgrade Arguments Verification
 
 [\`didc\`][latest-didc] is required.
 
@@ -203,10 +207,6 @@ __Source Code__: [$NEXT_COMMIT][new-commit]
 
 [new-commit]: https://github.com/dfinity/ic/tree/$NEXT_COMMIT
 
-[How to verify] this proposal (and others like it).
-
-[How to verify]: https://github.com/dfinity/ic/tree/master/rs/nervous_system/docs/proposal_verification.md
-
 
 ## New Commits
 
@@ -217,6 +217,11 @@ $(git log --format="%C(auto) %h %s" "$LAST_COMMIT".."$NEXT_COMMIT" -- $CANISTER_
 
 
 ## Wasm Verification
+
+See the general instructions on [how to verify] proposals like this. A "quick
+start" guide is provided here.
+
+[how to verify]: https://github.com/dfinity/ic/tree/${NEXT_COMMIT}/rs/nervous_system/docs/proposal_verification.md
 
 See ["Building the code"][prereqs] for prerequisites.
 

--- a/testnet/tools/nns-tools/lib/proposals.sh
+++ b/testnet/tools/nns-tools/lib/proposals.sh
@@ -121,6 +121,47 @@ $CANDID_ARGS
 
 - Current Git Hash: $LAST_COMMIT
 - Current Wasm Hash: $LAST_WASM_HASH
+
+
+## WASM Verification
+
+See ["Building the code"][prereqs] for prerequisites.
+
+[prereqs]: https://github.com/dfinity/ic?tab=readme-ov-file#building-the-code
+
+\`\`\`
+# 1. Get a copy of the code.
+git clone git@github.com:dfinity/ic.git
+cd ic
+# Or, if you already have a copy of the ic repo,
+git fetch
+git checkout $NEXT_COMMIT
+
+# 2. Build canisters.
+./ci/container/build-ic.sh -c
+
+# 3. Fingerprint the result.
+sha256sum ./artifacts/canisters/$(_canister_download_name_for_nns_canister_type "$CANISTER_NAME").wasm.gz
+\`\`\`
+
+This should match \`wasm_module_hash\` field of this proposal.$(if [ ! -z "$CANDID_ARGS" ]; then
+            echo "
+
+
+## Upgrade Arguments Verification
+
+[\`didc\`][latest-didc] is required.
+
+[latest-didc]: https://github.com/dfinity/candid/releases/latest
+
+\`\`\`
+didc encode '$CANDID_ARGS' | xxd -r -p | sha256sum
+
+\`\`\`
+
+This should match the \`arg_hash\` field of this proposal.
+"
+        fi)
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
     )
 
@@ -173,6 +214,30 @@ __Source Code__: [$NEXT_COMMIT][new-commit]
 \$ git log --format="%C(auto) %h %s" $LAST_COMMIT..$NEXT_COMMIT --  $RELATIVE_CODE_LOCATION
 $(git log --format="%C(auto) %h %s" "$LAST_COMMIT".."$NEXT_COMMIT" -- $CANISTER_CODE_LOCATION)
 \`\`\`
+
+
+## Wasm Verification
+
+See ["Building the code"][prereqs] for prerequisites.
+
+[prereqs]: https://github.com/dfinity/ic?tab=readme-ov-file#building-the-code
+
+\`\`\`
+# 1. Get a copy of the code.
+git clone git@github.com:dfinity/ic.git
+cd ic
+# Or, if you already have a copy of the ic repo,
+git fetch
+git checkout $NEXT_COMMIT
+
+# 2. Build canisters.
+./ci/container/build-ic.sh -c
+
+# 3. Fingerprint the result.
+sha256sum ./artifacts/canisters/$(_canister_download_name_for_sns_canister_type "$CANISTER_TYPE").wasm.gz
+\`\`\`
+
+This should match \`wasm\` field of this proposal.
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
     )
 


### PR DESCRIPTION
This implements what I said in [this forum post]. Specifically, where I said

[this forum post]: https://forum.dfinity.org/t/nns-updates-2024-10-04/35846/8?u=daniel-wong

> I can re-introduce instructions into future proposal summaries.

# Motivation

Multiple people (in DFINITY and outside) complained about the removal of instructions, so I'm putting them back.

# Changes

This partially reverts [pull request 1657]. Basically, this change just gets rid of the deletions in that PR.

[pull request 1657]: https://github.com/dfinity/ic/pull/1657

Minor change: link to separate detailed instructions is now locked to the same commit as the proposal itself.

# Example Output

Example output files are attached below. I plugged those files into a Markdown viewer, and it seemed alright to me.

[nns.md](https://github.com/user-attachments/files/17279466/nns.md)
[sns.md](https://github.com/user-attachments/files/17279467/sns.md)