### PR TITLE
chore: Change how the build time is calculated

### DIFF
--- a/bazel/BUILD.bazel
+++ b/bazel/BUILD.bazel
@@ -79,6 +79,17 @@ ic_version_or_git_sha(
     visibility = ["//visibility:public"],
 )
 
+genrule(
+    name = "commit_timestamp_txt",
+    outs = ["commit_timestamp.txt"],
+    cmd = "git show -s --format=%ct > $@",
+    tags = [
+        "local",
+        "no-cache",
+    ],
+    visibility = ["//visibility:public"],
+)
+
 sh_binary(
     name = "ic_version_or_git_sha_sh",
     srcs = ["ic_version_or_git_sha.sh"],

--- a/bazel/BUILD.bazel
+++ b/bazel/BUILD.bazel
@@ -50,6 +50,18 @@ string_flag(
     build_setting_default = FAKE_IC_VERSION,
 )
 
+bool_flag(
+    name = "release_build",
+    build_setting_default = False,
+)
+
+config_setting(
+    name = "is_release_build",
+    flag_values = {
+        ":release_build": "True",
+    },
+)
+
 string_flag(
     name = "timeout_value",
     build_setting_default = "10m",
@@ -76,17 +88,6 @@ ic_version_or_git_sha(
     name = "rc_only_version.txt",
     ic_version = ":ic_version_rc_only",
     tags = ["no-cache"],
-    visibility = ["//visibility:public"],
-)
-
-genrule(
-    name = "commit_timestamp_txt",
-    outs = ["commit_timestamp.txt"],
-    cmd = "git show -s --format=%ct > $@",
-    tags = [
-        "local",
-        "no-cache",
-    ],
     visibility = ["//visibility:public"],
 )
 

--- a/bazel/conf/.bazelrc.build
+++ b/bazel/conf/.bazelrc.build
@@ -41,6 +41,7 @@ build --experimental_repository_downloader_retries=3 # https://bazel.build/refer
 
 build --flag_alias=ic_version=//bazel:ic_version
 build --flag_alias=ic_version_rc_only=//bazel:ic_version_rc_only
+build --flag_alias=release_build=//bazel:release_build
 build --flag_alias=s3_endpoint=//ci/src/artifacts:s3_endpoint
 build --flag_alias=s3_upload=//ci/src/artifacts:s3_upload
 build --flag_alias=k8s=//rs/tests:k8s

--- a/ci/container/build-ic.sh
+++ b/ci/container/build-ic.sh
@@ -113,7 +113,8 @@ rm -rf "$CANISTERS_DIR_FULL"
 rm -rf "$DISK_DIR_FULL"
 
 echo_green "Building selected IC artifacts"
-BAZEL_CMD="bazel build --config=local --ic_version='$VERSION' --ic_version_rc_only='$IC_VERSION_RC_ONLY'"
+BAZEL_CMD="bazel build --config=local --ic_version='$VERSION' --ic_version_rc_only='$IC_VERSION_RC_ONLY' " \
+          "--release_build=$RELEASE"
 BUILD_BINARIES_CMD=$(
     cat <<-END
     # build binaries

--- a/ci/container/build-ic.sh
+++ b/ci/container/build-ic.sh
@@ -113,8 +113,8 @@ rm -rf "$CANISTERS_DIR_FULL"
 rm -rf "$DISK_DIR_FULL"
 
 echo_green "Building selected IC artifacts"
-BAZEL_CMD="bazel build --config=local --ic_version='$VERSION' --ic_version_rc_only='$IC_VERSION_RC_ONLY' " \
-          "--release_build=$RELEASE"
+BAZEL_CMD="bazel build --config=local --ic_version='$VERSION' --ic_version_rc_only='$IC_VERSION_RC_ONLY' "\
+"--release_build=$RELEASE"
 BUILD_BINARIES_CMD=$(
     cat <<-END
     # build binaries

--- a/ci/container/build-ic.sh
+++ b/ci/container/build-ic.sh
@@ -113,8 +113,8 @@ rm -rf "$CANISTERS_DIR_FULL"
 rm -rf "$DISK_DIR_FULL"
 
 echo_green "Building selected IC artifacts"
-BAZEL_CMD="bazel build --config=local --ic_version='$VERSION' --ic_version_rc_only='$IC_VERSION_RC_ONLY' "\
-"--release_build=$RELEASE"
+BAZEL_CMD="bazel build --config=local --ic_version='$VERSION' --ic_version_rc_only='$IC_VERSION_RC_ONLY' \
+           --release_build=$RELEASE"
 BUILD_BINARIES_CMD=$(
     cat <<-END
     # build binaries

--- a/ic-os/components/BUILD.bazel
+++ b/ic-os/components/BUILD.bazel
@@ -4,6 +4,8 @@ load("guestos.bzl", guestos_component_files = "component_files")
 load("hostos.bzl", hostos_component_files = "component_files")
 load("setupos.bzl", setupos_component_files = "component_files")
 
+package(default_visibility = ["//ic-os:__subpackages__"])
+
 PUBLIC_GUESTOS_EXPORTS = [
     "ic/ic.json5.template",
     "networking/dev-certs/canister_http_test_ca.cert",
@@ -23,6 +25,20 @@ exports_files(
         "//ic-os/guestos:__subpackages__",
         "//ic-os/hostos:__subpackages__",
         "//ic-os/setupos:__subpackages__",
+    ],
+)
+
+genrule(
+    name = "commit_timestamp_txt",
+    outs = ["commit_timestamp.txt"],
+    cmd = select({
+        "//bazel:is_release_build": "git show -s --format=%ct > $@",
+        # Use a constant in non-release builds to improve caching.
+        "//conditions:default": "echo 4000000000 > $@",
+    }),
+    tags = [
+        "local",
+        "no-cache",
     ],
 )
 

--- a/ic-os/components/setupos-scripts/check-setupos-age.sh
+++ b/ic-os/components/setupos-scripts/check-setupos-age.sh
@@ -9,9 +9,9 @@ PATH="/sbin:/bin:/usr/sbin:/usr/bin"
 source /opt/ic/bin/functions.sh
 
 function check_setupos_age() {
-    if [ -f "/build-time" ]; then
+    if [ -f "/commit-time" ]; then
         six_weeks_ago=$(date -u -d '6 weeks ago' +%s)
-        build_time=$(cat /build-time)
+        build_time=$(cat /commit-time)
         if [[ ${build_time} -lt ${six_weeks_ago} ]]; then
             echo -e "\n\n\n\n\n\n"
             echo -e "\033[1;31mWARNING: IC-OS installation image is more than six weeks out of date!\033[0m"

--- a/ic-os/components/setupos.bzl
+++ b/ic-os/components/setupos.bzl
@@ -3,6 +3,9 @@ Enumerate every component file dependency for SetupOS
 """
 
 component_files = {
+    # build-time is checked in the setupOS installation to verify that images are not too old.
+    Label("//bazel:commit_timestamp_txt"): "/build-time",
+
     # setupos-scripts
     Label("setupos-scripts/check-setupos-age.sh"): "/opt/ic/bin/check-setupos-age.sh",
     Label("setupos-scripts/config.sh"): "/opt/ic/bin/config.sh",

--- a/ic-os/components/setupos.bzl
+++ b/ic-os/components/setupos.bzl
@@ -3,8 +3,8 @@ Enumerate every component file dependency for SetupOS
 """
 
 component_files = {
-    # build-time is checked in the setupOS installation to verify that images are not too old.
-    Label("//bazel:commit_timestamp_txt"): "/build-time",
+    # commit-time is checked in the setupOS installation to verify that images are not too old.
+    Label("//ic-os/components:commit_timestamp_txt"): "/commit-time",
 
     # setupos-scripts
     Label("setupos-scripts/check-setupos-age.sh"): "/opt/ic/bin/check-setupos-age.sh",

--- a/ic-os/setupos/context/Dockerfile
+++ b/ic-os/setupos/context/Dockerfile
@@ -81,9 +81,9 @@ RUN systemctl disable \
 
 # ------ SETUPOS WORK --------------------------------------------
 
-# build-time is checked in the setupOS installation to verify that images
+# commit-time is checked in the setupOS installation to verify that images
 # are < six weeks old.
-COPY build-time /build-time
+COPY commit-time /commit-time
 
 # Clear additional files that may lead to indeterministic build.
 RUN rm -rf \

--- a/ic-os/setupos/context/Dockerfile
+++ b/ic-os/setupos/context/Dockerfile
@@ -81,6 +81,10 @@ RUN systemctl disable \
 
 # ------ SETUPOS WORK --------------------------------------------
 
+# build-time is checked in the setupOS installation to verify that images
+# are < six weeks old.
+COPY build-time /build-time
+
 # Clear additional files that may lead to indeterministic build.
 RUN rm -rf \
     /var/cache/fontconfig/* /var/cache/ldconfig/aux-cache \

--- a/ic-os/setupos/context/Dockerfile.base
+++ b/ic-os/setupos/context/Dockerfile.base
@@ -54,6 +54,3 @@ RUN curl -LsSf --remote-name https://github.com/dfinity/AMDSEV/releases/download
     -o -name "System*generic" \
     | xargs rm \
     && find /usr/lib/modules -maxdepth 1 -type d -name "*generic" | xargs rm -rf
-
-# build-time checked in setupOS installation to verify images < six weeks old
-RUN date +%s > build-time


### PR DESCRIPTION
Previously, we computed the build time when building the SetupOS base image. We're trying to move away from base images and want to be able to build the entire OS directly from source, therefore a new solution is required for reproducibility which does not take the current time into account. The new approach uses the commit timestamp.

In order to allow better caching of non-release builds, a new build flag `release_build` is introduced. Non-release builds use a constant commit time.

This approach assumes/requires that commits are fairly regular. We currently check that the build time (or commit time after this change) is not older than 6 weeks.