### PR TITLE
test: Log GuestOS and HostOS IP address in nested tests

### DIFF
--- a/rs/tests/driver/src/driver/nested.rs
+++ b/rs/tests/driver/src/driver/nested.rs
@@ -16,6 +16,7 @@ use anyhow::{bail, Result};
 use async_trait::async_trait;
 use deterministic_ips::{calculate_deterministic_mac, Deployment, HwAddr, IpVariant};
 use serde::{Deserialize, Serialize};
+use slog::info;
 use ssh2::Session;
 use url::Url;
 
@@ -143,6 +144,10 @@ impl NestedVms for TestEnv {
         let guest_ip = guest_mac.calculate_slaac(&prefix).unwrap();
 
         let nested_network = NestedNetwork { guest_ip, host_ip };
+        info!(
+            self.logger(),
+            "Nested network Host IP: {host_ip}, Guest IP: {guest_ip}"
+        );
         let mapped_vm = AllocatedVm {
             ipv6: host_ip,
             ..vm.clone()


### PR DESCRIPTION
We already write the addresses to a log file but not to the console. We should improve discoverability of this information by printing it to the console (IP addresses of other nodes are logged to the console during the test run).