### PR TITLE
fix(IDX): work around GHC install timeouts

### DIFF
--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -702,9 +702,11 @@ http_file(
 )
 
 # Haskell toolchain for spec_compliance tests
-
+# (patched to work around https://github.com/tweag/rules_haskell/issues/2254)
 http_archive(
     name = "rules_haskell",
+    patch_args = ["-p1"],
+    patches = ["//bazel:rules_haskell.patch"],
     sha256 = "4cae22bc84f327bf3cb7605021c3663160ff6bc8a0b7b6266062366bcbd19e79",
     strip_prefix = "rules_haskell-1.0",
     urls = ["https://github.com/tweag/rules_haskell/releases/download/v1.0/rules_haskell-1.0.tar.gz"],

--- a/bazel/rules_haskell.patch
+++ b/bazel/rules_haskell.patch
@@ -1,0 +1,14 @@
+# workaround for https://github.com/tweag/rules_haskell/issues/2254
+diff --git a/haskell/private/workspace_utils.bzl b/haskell/private/workspace_utils.bzl
+index df851329..980b3e16 100644
+--- a/haskell/private/workspace_utils.bzl
++++ b/haskell/private/workspace_utils.bzl
+@@ -19,6 +19,8 @@ def execute_or_fail_loudly(
+         environment = environment,
+         quiet = True,
+         working_directory = working_directory,
++        # triple the default timeout because e.g. copying GHC is slow (1.5G)
++        timeout = 3 * 600,
+     )
+     if exec_result.return_code != 0:
+         arguments = [_as_string(x) for x in arguments]


### PR DESCRIPTION
This patches our rules_haskell version to increase the timeout for the `make install` command installing GHC. The default of 10 minutes seems to be too short in some scenarios, though this has to be confirmed after the workaround has been in use for a couple of days. We will also need to investigate ways to avoid burning 10+minutes installing GHC.

See also: https://github.com/tweag/rules_haskell/issues/2254