### PR TITLE
feat(PocketIC): topology endpoint at /_/topology

### DIFF
--- a/rs/pocket_ic_server/BUILD.bazel
+++ b/rs/pocket_ic_server/BUILD.bazel
@@ -102,6 +102,7 @@ TEST_DEPENDENCIES = [
     "@crate_index//:rcgen",
     "@crate_index//:reqwest",
     "@crate_index//:serde",
+    "@crate_index//:serde_json",
     "@crate_index//:slog",
     "@crate_index//:tempfile",
     "@crate_index//:tokio",

--- a/rs/pocket_ic_server/CHANGELOG.md
+++ b/rs/pocket_ic_server/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (canister ID `g4xu7-jiaaa-aaaan-aaaaq-cai`) on the bitcoin subnet and configured with `Network::Regtest`
   and a `bitcoind` process is listening at an address and port specified in an additional argument
   of the endpoint `/instances/` to create a new PocketIC instance.
+- New endpoint `/instances/<instance_id>/_/topology` returning the topology of the PocketIC instance.
 
 ### Fixed
 - Renamed `dfx_test_key1` tECDSA and tSchnorr keys to `dfx_test_key`.

--- a/rs/pocket_ic_server/Cargo.toml
+++ b/rs/pocket_ic_server/Cargo.toml
@@ -88,5 +88,6 @@ ic-nns-constants = { path = "../nns/constants" }
 rcgen = { workspace = true }
 registry-canister = { path = "../registry/canister" }
 reqwest = { workspace = true }
+serde_json = { workspace = true }
 spec-compliance = { path = "../tests/testing_verification/spec_compliance" }
 slog = { workspace = true }

--- a/rs/pocket_ic_server/src/state_api/routes.rs
+++ b/rs/pocket_ic_server/src/state_api/routes.rs
@@ -192,6 +192,8 @@ where
         //
         // The instance dashboard
         .api_route("/:id/_/dashboard", get(handler_dashboard))
+        // The topology to be retrieved via an HTTP gateway that cannot route `/read/topology`.
+        .api_route("/:id/_/topology", get(handler_topology))
         // Configures an IC instance to make progress automatically,
         // i.e., periodically update the time of the IC instance
         // to the real time and execute rounds on the subnets.


### PR DESCRIPTION
This PR exposes the PocketIC topology at a new endpoint `/instances/<instance_id>/_/topology` so that the PocketIC topology can be retrieved via a PocketIC HTTP gateway that routes all requests starting with `/_/` to the PocketIC server directly, but could not route `/read/topology` to `/instances/<instance_id>/read/topology`.