### PR TITLE
feat(consensus): reduce consensus bouncer function refresh period from 3 seconds to 1 second.

### DIFF
--- a/rs/consensus/src/consensus.rs
+++ b/rs/consensus/src/consensus.rs
@@ -602,7 +602,7 @@ impl<Pool: ConsensusPool> BouncerFactory<ConsensusMessageId, Pool> for Consensus
     }
 
     fn refresh_period(&self) -> Duration {
-        Duration::from_secs(3)
+        Duration::from_secs(1)
     }
 }
 


### PR DESCRIPTION
The combination of 3 seconds refresh period and [LOOK_AHEAD](https://sourcegraph.com/github.com/dfinity/ic/-/blob/rs/consensus/src/idkg.rs?L236) being set to 10 heights, means that a node which is lagging behind the other nodes, will catch up at the rate at most `LOOK_AHEAD / REFRESH_PERIOD = 10 / 3 = 3.(3)` blocks per second. Since the notary delay is now set to `0.3s`, some subnets achieve up to `2.5` blocks per second finalization rate, which is not that far away from the maximum achievable catch up rate.

Reducing the refresh period to `1s` means that in theory we could catch up 10 blocks per second.

Note that computing the bouncer function is very fast- 0.0002s on average according to `consensus_bouncer_update_duration` metric.