### PR TITLE
feat(proposal-cli): FI-1520: Instructions to verify sha256sum of upgrade and install args

### DIFF
--- a/rs/cross-chain/proposal-cli/templates/install.md
+++ b/rs/cross-chain/proposal-cli/templates/install.md
@@ -18,7 +18,7 @@ TODO: THIS MUST BE FILLED OUT
 git fetch
 git checkout {{at}}
 cd {{canister.repo_dir().as_path().display()}}
-{{install_args.didc_encode_cmd()}}
+{{install_args.didc_encode_cmd()}} | xxd -r -p | sha256sum
 ```
 
 ## Wasm Verification

--- a/rs/cross-chain/proposal-cli/templates/upgrade.md
+++ b/rs/cross-chain/proposal-cli/templates/upgrade.md
@@ -20,7 +20,7 @@ TODO: THIS MUST BE FILLED OUT
 git fetch
 git checkout {{to}}
 cd {{canister.repo_dir().as_path().display()}}
-{{upgrade_args.didc_encode_cmd()}}
+{{upgrade_args.didc_encode_cmd()}} | xxd -r -p | sha256sum
 ```
 
 ## Release Notes


### PR DESCRIPTION
Due to a change in proposal types, the instructions to verify the install and upgrade arguments shall output the `sha256sum` of the candid-encoded arguments.