### PR TITLE
chore: drop run_until_completion from canister tests

### DIFF
--- a/rs/ethereum/ledger-suite-orchestrator/test_utils/src/flow.rs
+++ b/rs/ethereum/ledger-suite-orchestrator/test_utils/src/flow.rs
@@ -94,8 +94,6 @@ impl ManagedCanistersAssert {
             .expect("BUG: fail to make a transfer to trigger archive creation");
         }
 
-        self.setup.env.run_until_completion(/*max_ticks=*/ 10);
-
         let archive_ids_after: BTreeSet<_> = self
             .call_ledger_archives()
             .into_iter()

--- a/rs/ledger_suite/tests/sm-tests/src/lib.rs
+++ b/rs/ledger_suite/tests/sm-tests/src/lib.rs
@@ -1495,8 +1495,6 @@ fn test_controllers<T>(
         transfer(&env, ledger_id, p1.0, p2.0, 10_000 + i).expect("transfer failed");
     }
 
-    env.run_until_completion(/*max_ticks=*/ 10);
-
     let archive_info = list_archives(&env, ledger_id);
     assert_eq!(archive_info.len(), 1);
 
@@ -1632,7 +1630,6 @@ where
     for i in 0..ARCHIVE_TRIGGER_THRESHOLD {
         transfer(&env, ledger_id, p1.0, p2.0, 10_000 + i).expect("transfer failed");
     }
-    env.run_until_completion(/*max_ticks=*/ 10);
 
     let archive_info = list_archives(&env, ledger_id);
     let first_archive = ArchiveInfo {
@@ -1670,7 +1667,6 @@ where
     for i in 0..NUM_BLOCKS_TO_ARCHIVE {
         transfer(&env, ledger_id, p1.0, p2.0, 10_000 + i).expect("transfer failed");
     }
-    env.run_until_completion(/*max_ticks=*/ 10);
     let archive_info = list_archives(&env, ledger_id);
     let second_archive = ArchiveInfo {
         canister_id: "ryjl3-tyaaa-aaaaa-aaaba-cai".parse().unwrap(),
@@ -1713,8 +1709,6 @@ pub fn test_archiving<T>(
     for i in 0..ARCHIVE_TRIGGER_THRESHOLD {
         transfer(&env, canister_id, p1.0, p2.0, 10_000 + i).expect("transfer failed");
     }
-
-    env.run_until_completion(/*max_ticks=*/ 10);
 
     let archive_info = list_archives(&env, canister_id);
     assert_eq!(archive_info.len(), 1);
@@ -1839,8 +1833,6 @@ where
     for i in 0..ARCHIVE_TRIGGER_THRESHOLD {
         transfer(&env, canister_id, p1.0, p2.0, 10_000 + i * 10_000).expect("transfer failed");
     }
-
-    env.run_until_completion(/*max_ticks=*/ 10);
 
     let resp = get_blocks(&env, canister_id.get().0, 0, 1_000_000);
     assert_eq!(resp.first_index, Nat::from(NUM_BLOCKS_TO_ARCHIVE));

--- a/rs/ledger_suite/tests/sm-tests/src/metrics.rs
+++ b/rs/ledger_suite/tests/sm-tests/src/metrics.rs
@@ -92,8 +92,6 @@ pub fn assert_existence_of_ledger_total_transactions_metric<T>(
         transfer(&env, ledger_id, MINTER, p1.0, 10_000_000).expect("mint failed");
     }
 
-    env.run_until_completion(/*max_ticks=*/ 10);
-
     assert_eq!(
         NUM_MINT_TRANSACTIONS,
         parse_metric(

--- a/rs/nns/integration_tests/src/cycles_minting_canister_with_exchange_rate_canister.rs
+++ b/rs/nns/integration_tests/src/cycles_minting_canister_with_exchange_rate_canister.rs
@@ -177,8 +177,6 @@ fn test_enable_retrieving_rate_from_exchange_rate_canister() {
     // Start testing. Advance the state machine so the heartbeat triggers
     // at the new time.
     state_machine.tick();
-    // Wait to ensure that the call to the exchange rate canister completes.
-    state_machine.run_until_completion(10_000);
 
     // Step 3: Verify that the rate has been set by calling the cycles minting canister.
     let response = get_icp_xdr_conversion_rate(&state_machine);
@@ -207,8 +205,6 @@ fn test_enable_retrieving_rate_from_exchange_rate_canister() {
     state_machine.advance_time(Duration::from_secs(FIVE_MINUTES_SECONDS));
     // Trigger the heartbeat.
     state_machine.tick();
-    // Wait to ensure that the call to the exchange rate canister completes.
-    state_machine.run_until_completion(10_000);
 
     let response = get_icp_xdr_conversion_rate(&state_machine);
     // The rate's timestamp should be the CMC's first rate timestamp + 5 minutes + 10 secs.
@@ -380,8 +376,6 @@ fn test_disabling_and_reenabling_exchange_rate_canister_calling_via_exchange_rat
     // Start testing. Advance the state machine so the heartbeat triggers
     // at the new time.
     state_machine.tick();
-    // Wait to ensure that the call to the exchange rate canister completes.
-    state_machine.run_until_completion(10_000);
 
     // Step 3: Verify that the rate has been set by calling the cycles minting canister.
     let response = get_icp_xdr_conversion_rate(&state_machine);

--- a/rs/rosetta-api/tvl/tests/tests.rs
+++ b/rs/rosetta-api/tvl/tests/tests.rs
@@ -88,8 +88,6 @@ impl TvlSetup {
 #[test]
 fn test_tvl() {
     let tvl = TvlSetup::new();
-
-    tvl.env.run_until_completion(10_000);
     tvl.env
         .advance_time(std::time::Duration::from_secs(DEFAULT_UPDATE_PERIOD));
     tvl.env.tick();
@@ -115,7 +113,6 @@ fn test_tvl() {
 #[test]
 fn test_multiple_currencies() {
     let tvl = TvlSetup::new();
-    tvl.env.run_until_completion(100);
     tvl.env
         .advance_time(std::time::Duration::from_secs(24 * 60 * 60));
     tvl.env.tick();
@@ -211,7 +208,6 @@ fn test_multiple_currencies() {
 #[test]
 fn test_fiat_updates() {
     let tvl = TvlSetup::new();
-    tvl.env.run_until_completion(100);
     tvl.env
         .advance_time(std::time::Duration::from_secs(24 * 60 * 60));
     tvl.env.tick();


### PR DESCRIPTION
This PR removes `run_until_completion` from canister StateMachine tests since it is not required in the existing tests (this draft [PR](https://github.com/dfinity/ic/pull/1900) asserting that `run_until_completion` is a no-op is an empirical evidence of this claim). The motivation for removing `run_until_completion` from canister StateMachine tests is that this function is not supported in PocketIC and thus a blocker for migrating StateMachine tests to PocketIC.