### PR TITLE
refactor(IDX): remove BAZEL_EXTRA_ARGS_RULES

### DIFF
--- a/.github/actions/bazel-test-all/action.yaml
+++ b/.github/actions/bazel-test-all/action.yaml
@@ -12,7 +12,7 @@ inputs:
     default: '--config=ci'
   BAZEL_EXTRA_ARGS:
     required: false
-    degault: ''
+    default: ''
   BAZEL_STARTUP_ARGS:
     required: false
     default: '--output_base=/var/tmp/bazel-output/'

--- a/.github/actions/bazel-test-all/action.yaml
+++ b/.github/actions/bazel-test-all/action.yaml
@@ -64,6 +64,7 @@ runs:
           BAZEL_TARGETS: ${{ inputs.BAZEL_TARGETS }}
           BAZEL_CI_CONFIG: ${{ inputs.BAZEL_CI_CONFIG }}
           BAZEL_EXTRA_ARGS: ${{ inputs.BAZEL_EXTRA_ARGS }}
+          BAZEL_STARTUP_ARGS: ${{ inputs.BAZEL_STARTUP_ARGS }}
           CI_PULL_REQUEST_TARGET_BRANCH_NAME: ${{ github.event.pull_request.base.ref }}
           MERGE_BASE_SHA: ${{ github.event.pull_request.base.sha }}
           BRANCH_HEAD_SHA: ${{ github.event.pull_request.head.sha }}

--- a/.github/actions/bazel-test-all/action.yaml
+++ b/.github/actions/bazel-test-all/action.yaml
@@ -12,6 +12,7 @@ inputs:
     default: '--config=ci'
   BAZEL_EXTRA_ARGS:
     required: false
+    degault: ''
   BAZEL_STARTUP_ARGS:
     required: false
     default: '--output_base=/var/tmp/bazel-output/'

--- a/.github/actions/bazel-test-all/action.yaml
+++ b/.github/actions/bazel-test-all/action.yaml
@@ -12,10 +12,6 @@ inputs:
     default: '--config=ci'
   BAZEL_EXTRA_ARGS:
     required: false
-    default: '--keep_going'
-  BAZEL_EXTRA_ARGS_RULES:
-    required: false
-    default: ''
   BAZEL_STARTUP_ARGS:
     required: false
     default: '--output_base=/var/tmp/bazel-output/'
@@ -66,8 +62,7 @@ runs:
           BAZEL_COMMAND: ${{ inputs.BAZEL_COMMAND }}
           BAZEL_TARGETS: ${{ inputs.BAZEL_TARGETS }}
           BAZEL_CI_CONFIG: ${{ inputs.BAZEL_CI_CONFIG }}
-          BAZEL_EXTRA_ARGS: "${{ inputs.BAZEL_EXTRA_ARGS }} ${{ inputs.BAZEL_EXTRA_ARGS_RULES }}"
-          BAZEL_STARTUP_ARGS: ${{ inputs.BAZEL_STARTUP_ARGS }}
+          BAZEL_EXTRA_ARGS: ${{ inputs.BAZEL_EXTRA_ARGS }}
           CI_PULL_REQUEST_TARGET_BRANCH_NAME: ${{ github.event.pull_request.base.ref }}
           MERGE_BASE_SHA: ${{ github.event.pull_request.base.sha }}
           BRANCH_HEAD_SHA: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows-source/ci-main.yml
+++ b/.github/workflows-source/ci-main.yml
@@ -109,15 +109,16 @@ jobs:
       - <<: *checkout
       - <<: *before-script
       - <<: *docker-login
-      - name: Set BAZEL_EXTRA_ARGS_RULES
+      - name: Set BAZEL_EXTRA_ARGS
         shell: bash
         run: |
           set -xeuo pipefail
           if [[ "${{ github.event_name }}" == 'merge_group' ]]; then
-            echo "BAZEL_EXTRA_ARGS_RULES=--test_timeout_filters=short,moderate --flaky_test_attempts=3" >> $GITHUB_ENV
-          fi
-          if [[ $BRANCH_NAME =~ ^hotfix-.* ]]; then
-            echo "BAZEL_EXTRA_ARGS_RULES=--test_timeout_filters=short,moderate" >> $GITHUB_ENV
+            echo "BAZEL_EXTRA_ARGS=--test_timeout_filters=short,moderate --flaky_test_attempts=3" >> $GITHUB_ENV
+          elif [[ $BRANCH_NAME =~ ^hotfix-.* ]]; then
+            echo "BAZEL_EXTRA_ARGS=--test_timeout_filters=short,moderate" >> $GITHUB_ENV
+          else
+            echo "BAZEL_EXTRA_ARGS=--keep_going" >> $GITHUB_ENV
           fi
       - name: Run Bazel Test All
         id: bazel-test-all
@@ -132,7 +133,7 @@ jobs:
           BAZEL_TARGETS: "//..."
           BAZEL_CI_CONFIG: "--config=ci --repository_cache=/cache/bazel"
           # check if PR title contains release and set timeout filters accordingly
-          BAZEL_EXTRA_ARGS_RULES: ${{ env.BAZEL_EXTRA_ARGS_RULES || '' }}
+          BAZEL_EXTRA_ARGS: ${{ env.BAZEL_EXTRA_ARGS }}
           BUILDEVENT_APIKEY: ${{ secrets.HONEYCOMB_API_TOKEN }}
       - <<: *bazel-bep
       - <<: *bazel-upload

--- a/.github/workflows-source/release-testing.yml
+++ b/.github/workflows-source/release-testing.yml
@@ -127,7 +127,7 @@ jobs:
           BAZEL_COMMAND: "test"
           BAZEL_TARGETS: "//rs/tests/..."
           BAZEL_CI_CONFIG: "--config=ci --repository_cache=/cache/bazel"
-          BAZEL_EXTRA_ARGS_RULES: "--test_tag_filters=system_test_hotfix"
+          BAZEL_EXTRA_ARGS: "--keep-going --test_tag_filters=system_test_hotfix"
           BUILDEVENT_APIKEY: ${{ secrets.HONEYCOMB_API_TOKEN }}
       - <<: *bazel-bep
 
@@ -197,7 +197,7 @@ jobs:
           BAZEL_COMMAND: "test"
           BAZEL_TARGETS: "//rs/tests/dre:guest_os_qualification"
           BAZEL_CI_CONFIG: "--config=systest --repository_cache=/cache/bazel"
-          BAZEL_EXTRA_ARGS_RULES: "--test_timeout=7200 --test_env=OLD_VERSION=${{ matrix.version }}"
+          BAZEL_EXTRA_ARGS: "--keep_going --test_timeout=7200 --test_env=OLD_VERSION=${{ matrix.version }}"
           BUILDEVENT_APIKEY: ${{ secrets.HONEYCOMB_API_TOKEN }}
       - <<: *bazel-bep
         name: Upload bazel bep for version ${{ matrix.version }}

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -54,15 +54,15 @@ jobs:
         env:
           DOCKER_HUB_USER: ${{ vars.DOCKER_HUB_USER }}
           DOCKER_HUB_PASSWORD_RO: ${{ secrets.DOCKER_HUB_PASSWORD_RO }}
-      - name: Set BAZEL_EXTRA_ARGS_RULES
+      - name: Set BAZEL_EXTRA_ARGS
         shell: bash
         run: |
           set -xeuo pipefail
           if [[ "${{ github.event_name }}" == 'merge_group' ]]; then
-            echo "BAZEL_EXTRA_ARGS_RULES=--test_timeout_filters=short,moderate --flaky_test_attempts=3" >> $GITHUB_ENV
+            echo "BAZEL_EXTRA_ARGS=--keep_going --test_timeout_filters=short,moderate --flaky_test_attempts=3" >> $GITHUB_ENV
           fi
           if [[ $BRANCH_NAME =~ ^hotfix-.* ]]; then
-            echo "BAZEL_EXTRA_ARGS_RULES=--test_timeout_filters=short,moderate" >> $GITHUB_ENV
+            echo "BAZEL_EXTRA_ARGS=--keep_going --test_timeout_filters=short,moderate" >> $GITHUB_ENV
           fi
       - name: Run Bazel Test All
         id: bazel-test-all
@@ -77,7 +77,7 @@ jobs:
           BAZEL_TARGETS: "//..."
           BAZEL_CI_CONFIG: "--config=ci --repository_cache=/cache/bazel"
           # check if PR title contains release and set timeout filters accordingly
-          BAZEL_EXTRA_ARGS_RULES: ${{ env.BAZEL_EXTRA_ARGS_RULES || '' }}
+          BAZEL_EXTRA_ARGS: ${{ env.BAZEL_EXTRA_ARGS || '--keep_going' }}
           BUILDEVENT_APIKEY: ${{ secrets.HONEYCOMB_API_TOKEN }}
       - name: Upload bazel-bep
         # runs only if previous step succeeded or failed;
@@ -175,8 +175,7 @@ jobs:
         with:
           BAZEL_CI_CONFIG: "--config=ci --config macos_ci"
           BAZEL_COMMAND: test
-          BAZEL_EXTRA_ARGS: '--test_tag_filters=test_macos'
-          BAZEL_STARTUP_ARGS: "--output_base /var/tmp/bazel-output/${CI_RUN_ID}"
+          BAZEL_EXTRA_ARGS: '--test_tag_filters=test_macos --output_base /var/tmp/bazel-output/${CI_RUN_ID}'
           BAZEL_TARGETS: "//rs/... //publish/binaries/..."
           BUILDEVENT_APIKEY: ${{ secrets.HONEYCOMB_API_TOKEN }}
       - name: Upload bazel-bep

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -59,10 +59,11 @@ jobs:
         run: |
           set -xeuo pipefail
           if [[ "${{ github.event_name }}" == 'merge_group' ]]; then
-            echo "BAZEL_EXTRA_ARGS=--keep_going --test_timeout_filters=short,moderate --flaky_test_attempts=3" >> $GITHUB_ENV
-          fi
-          if [[ $BRANCH_NAME =~ ^hotfix-.* ]]; then
-            echo "BAZEL_EXTRA_ARGS=--keep_going --test_timeout_filters=short,moderate" >> $GITHUB_ENV
+            echo "BAZEL_EXTRA_ARGS=--test_timeout_filters=short,moderate --flaky_test_attempts=3" >> $GITHUB_ENV
+          elif [[ $BRANCH_NAME =~ ^hotfix-.* ]]; then
+            echo "BAZEL_EXTRA_ARGS=--test_timeout_filters=short,moderate" >> $GITHUB_ENV
+          else
+            echo "BAZEL_EXTRA_ARGS=--keep_going" >> $GITHUB_ENV
           fi
       - name: Run Bazel Test All
         id: bazel-test-all
@@ -77,7 +78,7 @@ jobs:
           BAZEL_TARGETS: "//..."
           BAZEL_CI_CONFIG: "--config=ci --repository_cache=/cache/bazel"
           # check if PR title contains release and set timeout filters accordingly
-          BAZEL_EXTRA_ARGS: ${{ env.BAZEL_EXTRA_ARGS || '--keep_going' }}
+          BAZEL_EXTRA_ARGS: ${{ env.BAZEL_EXTRA_ARGS }}
           BUILDEVENT_APIKEY: ${{ secrets.HONEYCOMB_API_TOKEN }}
       - name: Upload bazel-bep
         # runs only if previous step succeeded or failed;
@@ -175,7 +176,8 @@ jobs:
         with:
           BAZEL_CI_CONFIG: "--config=ci --config macos_ci"
           BAZEL_COMMAND: test
-          BAZEL_EXTRA_ARGS: '--test_tag_filters=test_macos --output_base /var/tmp/bazel-output/${CI_RUN_ID}'
+          BAZEL_EXTRA_ARGS: '--test_tag_filters=test_macos'
+          BAZEL_STARTUP_ARGS: "--output_base /var/tmp/bazel-output/${CI_RUN_ID}"
           BAZEL_TARGETS: "//rs/... //publish/binaries/..."
           BUILDEVENT_APIKEY: ${{ secrets.HONEYCOMB_API_TOKEN }}
       - name: Upload bazel-bep

--- a/.github/workflows/release-testing.yml
+++ b/.github/workflows/release-testing.yml
@@ -153,7 +153,7 @@ jobs:
           BAZEL_COMMAND: "test"
           BAZEL_TARGETS: "//rs/tests/..."
           BAZEL_CI_CONFIG: "--config=ci --repository_cache=/cache/bazel"
-          BAZEL_EXTRA_ARGS_RULES: "--keep going --test_tag_filters=system_test_hotfix"
+          BAZEL_EXTRA_ARGS: "--keep-going --test_tag_filters=system_test_hotfix"
           BUILDEVENT_APIKEY: ${{ secrets.HONEYCOMB_API_TOKEN }}
       - name: Upload bazel-bep
         # runs only if previous step succeeded or failed;
@@ -276,7 +276,7 @@ jobs:
           BAZEL_COMMAND: "test"
           BAZEL_TARGETS: "//rs/tests/dre:guest_os_qualification"
           BAZEL_CI_CONFIG: "--config=systest --repository_cache=/cache/bazel"
-          BAZEL_EXTRA_ARGS_RULES: "--test_timeout=7200 --test_env=OLD_VERSION=${{ matrix.version }}"
+          BAZEL_EXTRA_ARGS: "--keep_going --test_timeout=7200 --test_env=OLD_VERSION=${{ matrix.version }}"
           BUILDEVENT_APIKEY: ${{ secrets.HONEYCOMB_API_TOKEN }}
       - # runs only if previous step succeeded or failed;
         # we avoid collecting artifacts of jobs that were cancelled

--- a/.github/workflows/release-testing.yml
+++ b/.github/workflows/release-testing.yml
@@ -153,7 +153,7 @@ jobs:
           BAZEL_COMMAND: "test"
           BAZEL_TARGETS: "//rs/tests/..."
           BAZEL_CI_CONFIG: "--config=ci --repository_cache=/cache/bazel"
-          BAZEL_EXTRA_ARGS_RULES: "--test_tag_filters=system_test_hotfix"
+          BAZEL_EXTRA_ARGS_RULES: "--keep going --test_tag_filters=system_test_hotfix"
           BUILDEVENT_APIKEY: ${{ secrets.HONEYCOMB_API_TOKEN }}
       - name: Upload bazel-bep
         # runs only if previous step succeeded or failed;


### PR DESCRIPTION
Reduce complexity by removing `BAZEL_EXTRA_ARGS_RULES`. We also change the default of `BAZEL_EXTRA_ARGS`, so that we only explicitly mark tests with `--keep_going`.