### PR TITLE
chore(consensus): remove some unnecessary validator metrics

### DIFF
--- a/rs/consensus/src/consensus/metrics.rs
+++ b/rs/consensus/src/consensus/metrics.rs
@@ -468,8 +468,6 @@ pub struct ValidatorMetrics {
     // Used to sum the values within a single validator run
     dkg_time_per_validator_run: RwLock<f64>,
     pub(crate) idkg_validation_duration: HistogramVec,
-    pub(crate) validation_random_tape_shares_count: IntGauge,
-    pub(crate) validation_random_beacon_shares_count: IntGauge,
     pub(crate) validation_share_batch_size: HistogramVec,
     // Payload metrics
     pub(crate) ingress_messages: Histogram,
@@ -518,14 +516,6 @@ impl ValidatorMetrics {
                 // 1s, 2s, 5s, 10s, 20s, 50s, 100s, 200s, 500s
                 decimal_buckets(-4, 2),
                 &["type"],
-            ),
-            validation_random_tape_shares_count: metrics_registry.int_gauge(
-                "consensus_validation_tape_shares",
-                "Number of random tape shares being validated every block",
-            ),
-            validation_random_beacon_shares_count: metrics_registry.int_gauge(
-                "consensus_validation_beacon_shares",
-                "Number of random beacon shares being validated every block",
             ),
             validation_share_batch_size: metrics_registry.histogram_vec(
                 "consensus_validation_share_batch_size",

--- a/rs/consensus/src/consensus/validator.rs
+++ b/rs/consensus/src/consensus/validator.rs
@@ -1381,7 +1381,6 @@ impl Validator {
             .random_beacon_share()
             .get_by_height(next_height)
             .filter_map(|beacon| {
-                self.metrics.validation_random_beacon_shares_count.add(1);
                 let verification = self.verify_artifact(pool_reader, &beacon);
                 if verification.is_ok() && last_hash != beacon.content.parent {
                     Some(ChangeAction::HandleInvalid(
@@ -1493,7 +1492,6 @@ impl Validator {
                     // Remove if we already have a validated tape at this height
                     Some(ChangeAction::RemoveFromUnvalidated(tape.into_message()))
                 } else {
-                    self.metrics.validation_random_tape_shares_count.add(1);
                     let verification = self.verify_artifact(pool_reader, &tape);
                     self.compute_action_from_artifact_verification(
                         pool_reader,

--- a/rs/consensus/src/consensus/validator.rs
+++ b/rs/consensus/src/consensus/validator.rs
@@ -1345,13 +1345,13 @@ impl Validator {
             .random_beacon()
             .get_by_height(last_beacon.content.height().increment())
             .filter_map(|beacon| {
-                if last_hash != beacon.content.parent {
+                let verification = self.verify_artifact(pool_reader, &beacon);
+                if verification.is_ok() && last_hash != beacon.content.parent {
                     Some(ChangeAction::HandleInvalid(
                         beacon.into_message(),
                         "The parent hash of the beacon is not correct".to_string(),
                     ))
                 } else {
-                    let verification = self.verify_artifact(pool_reader, &beacon);
                     self.compute_action_from_artifact_verification(
                         pool_reader,
                         verification,
@@ -1381,14 +1381,14 @@ impl Validator {
             .random_beacon_share()
             .get_by_height(next_height)
             .filter_map(|beacon| {
-                if last_hash != beacon.content.parent {
+                self.metrics.validation_random_beacon_shares_count.add(1);
+                let verification = self.verify_artifact(pool_reader, &beacon);
+                if verification.is_ok() && last_hash != beacon.content.parent {
                     Some(ChangeAction::HandleInvalid(
                         beacon.into_message(),
-                        "The parent hash of the beacon was not correct".to_string(),
+                        "The parent hash of the beacon share is not correct".to_string(),
                     ))
                 } else {
-                    self.metrics.validation_random_beacon_shares_count.add(1);
-                    let verification = self.verify_artifact(pool_reader, &beacon);
                     self.compute_action_from_artifact_verification(
                         pool_reader,
                         verification,


### PR DESCRIPTION
1. These metrics are unused 
2. They don't track what they are supposed to: the description says `Number of (...) shares being validated every block` but we never reset the counter so in reality it counts the total number of validated shares
3. They are not accurate: we don't increment the counter when some validations fail (e.g. parent hash mismatch or when random tape height = 0) or we double count some shares when the validation failed due to some transient error 