### PR TITLE
chore(IDX): tag backup_manager_test with system_test_hourly

### DIFF
--- a/rs/tests/consensus/BUILD.bazel
+++ b/rs/tests/consensus/BUILD.bazel
@@ -12,6 +12,7 @@ system_test_nns(
     proc_macro_deps = MACRO_DEPENDENCIES,
     tags = [
         "experimental_system_test_colocation",
+        "system_test_hourly",
     ],
     target_compatible_with = ["@platforms//os:linux"],  # requires libssh that does not build on Mac OS
     runtime_deps =


### PR DESCRIPTION
Data shows this is the most frequent test on the critical path, hence moving it to hourly makes sense.
![image](https://github.com/user-attachments/assets/92bff221-c5ad-4cf5-b8c7-bf4f47da4154)
