### PR TITLE
chore(IDX): change rc schedule

### DIFF
--- a/.github/workflows/schedule-rc.yml
+++ b/.github/workflows/schedule-rc.yml
@@ -2,7 +2,7 @@ name: Schedule RC
 
 on:
   schedule:
-    - cron: "0 1 * * *"
+    - cron: "0 3 * * *"
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
To avoid running at the same time as the nightly tests, move the RC schedule two hours back.