### PR TITLE
feat: EXC-1659: Enable storage reservation mechanism on verified application subnets

### DIFF
--- a/rs/config/src/subnet_config.rs
+++ b/rs/config/src/subnet_config.rs
@@ -422,13 +422,6 @@ pub struct CyclesAccountManagerConfig {
 impl CyclesAccountManagerConfig {
     pub fn application_subnet() -> Self {
         Self {
-            max_storage_reservation_period: Duration::from_secs(300_000_000),
-            ..Self::verified_application_subnet()
-        }
-    }
-
-    pub fn verified_application_subnet() -> Self {
-        Self {
             reference_subnet_size: DEFAULT_REFERENCE_SUBNET_SIZE,
             canister_creation_fee: Cycles::new(100_000_000_000),
             compute_percent_allocated_per_second_fee: Cycles::new(10_000_000),
@@ -451,11 +444,13 @@ impl CyclesAccountManagerConfig {
             http_request_quadratic_baseline_fee: Cycles::new(60_000),
             http_request_per_byte_fee: Cycles::new(400),
             http_response_per_byte_fee: Cycles::new(800),
-            // This effectively disables the storage reservation mechanism on
-            // verified application subnets.
-            max_storage_reservation_period: Duration::from_secs(0),
+            max_storage_reservation_period: Duration::from_secs(300_000_000),
             default_reserved_balance_limit: DEFAULT_RESERVED_BALANCE_LIMIT,
         }
+    }
+
+    pub fn verified_application_subnet() -> Self {
+        Self::application_subnet()
     }
 
     /// All processing is free on system subnets

--- a/rs/execution_environment/src/canister_manager/tests.rs
+++ b/rs/execution_environment/src/canister_manager/tests.rs
@@ -54,8 +54,9 @@ use ic_test_utilities::{
     universal_canister::{call_args, wasm, UNIVERSAL_CANISTER_WASM},
 };
 use ic_test_utilities_execution_environment::{
-    assert_delta, get_reply, get_routing_table_with_specified_ids_allocation_range,
-    wasm_compilation_cost, wat_compilation_cost, ExecutionTest, ExecutionTestBuilder,
+    assert_delta, cycles_reserved_for_app_and_verified_app_subnets, get_reply,
+    get_routing_table_with_specified_ids_allocation_range, wasm_compilation_cost,
+    wat_compilation_cost, ExecutionTest, ExecutionTestBuilder,
 };
 use ic_test_utilities_state::{
     get_running_canister, get_running_canister_with_args, get_stopped_canister,
@@ -5956,262 +5957,273 @@ fn system_subnet_does_not_check_for_freezing_threshold_on_allocation_changes() {
 
 #[test]
 fn install_reserves_cycles_on_memory_allocation() {
-    const CYCLES: Cycles = Cycles::new(1_000_000_000_000_000);
-    const CAPACITY: u64 = 20_000_000_000;
-    const THRESHOLD: u64 = CAPACITY / 2;
-    const USAGE: u64 = CAPACITY - THRESHOLD;
+    cycles_reserved_for_app_and_verified_app_subnets(|subnet_type| {
+        const CYCLES: Cycles = Cycles::new(1_000_000_000_000_000);
+        const CAPACITY: u64 = 20_000_000_000;
+        const THRESHOLD: u64 = CAPACITY / 2;
+        const USAGE: u64 = CAPACITY - THRESHOLD;
 
-    let mut test = ExecutionTestBuilder::new()
-        .with_subnet_execution_memory(CAPACITY as i64)
-        .with_subnet_memory_reservation(0)
-        .with_subnet_memory_threshold(THRESHOLD as i64)
-        .build();
+        let mut test = ExecutionTestBuilder::new()
+            .with_subnet_type(subnet_type)
+            .with_subnet_execution_memory(CAPACITY as i64)
+            .with_subnet_memory_reservation(0)
+            .with_subnet_memory_threshold(THRESHOLD as i64)
+            .build();
 
-    test.create_canister_with_allocation(CYCLES, None, Some(THRESHOLD))
-        .unwrap();
+        test.create_canister_with_allocation(CYCLES, None, Some(THRESHOLD))
+            .unwrap();
 
-    let canister_id = test
-        .create_canister_with_settings(
-            CYCLES,
-            CanisterSettingsArgsBuilder::new()
-                .with_reserved_cycles_limit(CYCLES.get())
-                .build(),
-        )
-        .unwrap();
-
-    let subnet_memory_usage =
-        CAPACITY - test.subnet_available_memory().get_execution_memory() as u64;
-
-    // TODO(RUN-745): This should be `execution_memory_usage()`.
-    let memory_usage_before = test.canister_state(canister_id).memory_usage();
-    let balance_before = test.canister_state(canister_id).system_state.balance();
-    test.install_canister_with_allocation(
-        canister_id,
-        UNIVERSAL_CANISTER_WASM.into(),
-        None,
-        Some(USAGE),
-    )
-    .unwrap();
-    let balance_after = test.canister_state(canister_id).system_state.balance();
-    let memory_usage_after = NumBytes::from(USAGE);
-
-    let reserved_cycles = test
-        .canister_state(canister_id)
-        .system_state
-        .reserved_balance();
-
-    assert_eq!(
-        reserved_cycles,
-        test.cycles_account_manager().storage_reservation_cycles(
-            memory_usage_after - memory_usage_before,
-            &ResourceSaturation::new(subnet_memory_usage, THRESHOLD, CAPACITY),
-            test.subnet_size(),
-        )
-    );
-
-    assert_ge!(
-        balance_before - balance_after,
-        reserved_cycles,
-        "Unexpected balance change: {} >= {}",
-        balance_before - balance_after,
-        reserved_cycles,
-    );
-
-    let wat = r#"
-        (module
-            (import "ic0" "stable64_grow" (func $stable64_grow (param i64) (result i64)))
-            (func (export "canister_post_upgrade")
-                (if (i64.eq (call $stable64_grow (i64.const 150000)) (i64.const -1))
-                  (then (unreachable))
-                )
+        let canister_id = test
+            .create_canister_with_settings(
+                CYCLES,
+                CanisterSettingsArgsBuilder::new()
+                    .with_reserved_cycles_limit(CYCLES.get())
+                    .build(),
             )
-            (memory 0)
-        )"#;
+            .unwrap();
 
-    let wasm_binary = wat::parse_str(wat).unwrap();
+        let subnet_memory_usage =
+            CAPACITY - test.subnet_available_memory().get_execution_memory() as u64;
 
-    let balance_before = test.canister_state(canister_id).system_state.balance();
-    test.upgrade_canister(canister_id, wasm_binary).unwrap();
-    let balance_after = test.canister_state(canister_id).system_state.balance();
+        // TODO(RUN-745): This should be `execution_memory_usage()`.
+        let memory_usage_before = test.canister_state(canister_id).memory_usage();
+        let balance_before = test.canister_state(canister_id).system_state.balance();
+        test.install_canister_with_allocation(
+            canister_id,
+            UNIVERSAL_CANISTER_WASM.into(),
+            None,
+            Some(USAGE),
+        )
+        .unwrap();
+        let balance_after = test.canister_state(canister_id).system_state.balance();
+        let memory_usage_after = NumBytes::from(USAGE);
 
-    let new_reserved_cycles = test
-        .canister_state(canister_id)
-        .system_state
-        .reserved_balance();
+        let reserved_cycles = test
+            .canister_state(canister_id)
+            .system_state
+            .reserved_balance();
 
-    // The reserved balance shouldn't change because the canister has already
-    // reserved memory allocation.
-    assert_eq!(reserved_cycles, new_reserved_cycles);
+        assert_eq!(
+            reserved_cycles,
+            test.cycles_account_manager().storage_reservation_cycles(
+                memory_usage_after - memory_usage_before,
+                &ResourceSaturation::new(subnet_memory_usage, THRESHOLD, CAPACITY),
+                test.subnet_size(),
+            )
+        );
 
-    // Message execution fee is an order of a few million cycles.
-    assert_lt!(balance_before - balance_after, Cycles::new(1_000_000_000));
+        assert_ge!(
+            balance_before - balance_after,
+            reserved_cycles,
+            "Unexpected balance change: {} >= {}",
+            balance_before - balance_after,
+            reserved_cycles,
+        );
+
+        let wat = r#"
+            (module
+                (import "ic0" "stable64_grow" (func $stable64_grow (param i64) (result i64)))
+                (func (export "canister_post_upgrade")
+                    (if (i64.eq (call $stable64_grow (i64.const 150000)) (i64.const -1))
+                      (then (unreachable))
+                    )
+                )
+                (memory 0)
+            )"#;
+
+        let wasm_binary = wat::parse_str(wat).unwrap();
+
+        let balance_before = test.canister_state(canister_id).system_state.balance();
+        test.upgrade_canister(canister_id, wasm_binary).unwrap();
+        let balance_after = test.canister_state(canister_id).system_state.balance();
+
+        let new_reserved_cycles = test
+            .canister_state(canister_id)
+            .system_state
+            .reserved_balance();
+
+        // The reserved balance shouldn't change because the canister has already
+        // reserved memory allocation.
+        assert_eq!(reserved_cycles, new_reserved_cycles);
+
+        // Message execution fee is an order of a few million cycles.
+        assert_lt!(balance_before - balance_after, Cycles::new(1_000_000_000));
+    });
 }
 
 #[test]
 fn install_reserves_cycles_on_memory_grow() {
-    const CYCLES: Cycles = Cycles::new(1_000_000_000_000_000);
-    const CAPACITY: u64 = 20_000_000_000;
-    const THRESHOLD: u64 = CAPACITY / 2;
+    cycles_reserved_for_app_and_verified_app_subnets(|subnet_type| {
+        const CYCLES: Cycles = Cycles::new(1_000_000_000_000_000);
+        const CAPACITY: u64 = 20_000_000_000;
+        const THRESHOLD: u64 = CAPACITY / 2;
 
-    let mut test = ExecutionTestBuilder::new()
-        .with_subnet_execution_memory(CAPACITY as i64)
-        .with_subnet_memory_reservation(0)
-        .with_subnet_memory_threshold(THRESHOLD as i64)
-        .build();
+        let mut test = ExecutionTestBuilder::new()
+            .with_subnet_type(subnet_type)
+            .with_subnet_execution_memory(CAPACITY as i64)
+            .with_subnet_memory_reservation(0)
+            .with_subnet_memory_threshold(THRESHOLD as i64)
+            .build();
 
-    test.create_canister_with_allocation(CYCLES, None, Some(THRESHOLD))
-        .unwrap();
+        test.create_canister_with_allocation(CYCLES, None, Some(THRESHOLD))
+            .unwrap();
 
-    let canister_id = test
-        .create_canister_with_settings(
-            CYCLES,
-            CanisterSettingsArgsBuilder::new()
-                .with_reserved_cycles_limit(CYCLES.get())
-                .build(),
-        )
-        .unwrap();
-
-    let wat = r#"
-        (module
-            (import "ic0" "stable64_grow" (func $stable64_grow (param i64) (result i64)))
-            (func (export "canister_init")
-                (if (i64.eq (call $stable64_grow (i64.const 150000)) (i64.const -1))
-                  (then (unreachable))
-                )
+        let canister_id = test
+            .create_canister_with_settings(
+                CYCLES,
+                CanisterSettingsArgsBuilder::new()
+                    .with_reserved_cycles_limit(CYCLES.get())
+                    .build(),
             )
-            (memory 0)
-        )"#;
+            .unwrap();
 
-    let wasm_binary = wat::parse_str(wat).unwrap();
+        let wat = r#"
+            (module
+                (import "ic0" "stable64_grow" (func $stable64_grow (param i64) (result i64)))
+                (func (export "canister_init")
+                    (if (i64.eq (call $stable64_grow (i64.const 150000)) (i64.const -1))
+                      (then (unreachable))
+                    )
+                )
+                (memory 0)
+            )"#;
 
-    let subnet_memory_usage =
-        CAPACITY - test.subnet_available_memory().get_execution_memory() as u64;
-    let memory_usage_before = test.canister_state(canister_id).execution_memory_usage();
-    let balance_before = test.canister_state(canister_id).system_state.balance();
-    test.install_canister(canister_id, wasm_binary).unwrap();
-    let balance_after = test.canister_state(canister_id).system_state.balance();
-    let memory_usage_after = test.canister_state(canister_id).execution_memory_usage();
+        let wasm_binary = wat::parse_str(wat).unwrap();
 
-    let reserved_cycles = test
-        .canister_state(canister_id)
-        .system_state
-        .reserved_balance();
+        let subnet_memory_usage =
+            CAPACITY - test.subnet_available_memory().get_execution_memory() as u64;
+        let memory_usage_before = test.canister_state(canister_id).execution_memory_usage();
+        let balance_before = test.canister_state(canister_id).system_state.balance();
+        test.install_canister(canister_id, wasm_binary).unwrap();
+        let balance_after = test.canister_state(canister_id).system_state.balance();
+        let memory_usage_after = test.canister_state(canister_id).execution_memory_usage();
 
-    assert_eq!(
-        reserved_cycles,
-        test.cycles_account_manager().storage_reservation_cycles(
-            memory_usage_after - memory_usage_before,
-            &ResourceSaturation::new(subnet_memory_usage, THRESHOLD, CAPACITY),
-            test.subnet_size(),
-        )
-    );
+        let reserved_cycles = test
+            .canister_state(canister_id)
+            .system_state
+            .reserved_balance();
 
-    assert_ge!(
-        balance_before - balance_after,
-        reserved_cycles,
-        "Unexpected balance change: {} >= {}",
-        balance_before - balance_after,
-        reserved_cycles,
-    );
+        assert_eq!(
+            reserved_cycles,
+            test.cycles_account_manager().storage_reservation_cycles(
+                memory_usage_after - memory_usage_before,
+                &ResourceSaturation::new(subnet_memory_usage, THRESHOLD, CAPACITY),
+                test.subnet_size(),
+            )
+        );
+
+        assert_ge!(
+            balance_before - balance_after,
+            reserved_cycles,
+            "Unexpected balance change: {} >= {}",
+            balance_before - balance_after,
+            reserved_cycles,
+        );
+    });
 }
 
 #[test]
 fn upgrade_reserves_cycles_on_memory_allocation() {
-    const CYCLES: Cycles = Cycles::new(1_000_000_000_000_000);
-    const CAPACITY: u64 = 20_000_000_000;
-    const THRESHOLD: u64 = CAPACITY / 2;
-    const USAGE: u64 = CAPACITY - THRESHOLD;
+    cycles_reserved_for_app_and_verified_app_subnets(|subnet_type| {
+        const CYCLES: Cycles = Cycles::new(1_000_000_000_000_000);
+        const CAPACITY: u64 = 20_000_000_000;
+        const THRESHOLD: u64 = CAPACITY / 2;
+        const USAGE: u64 = CAPACITY - THRESHOLD;
 
-    let mut test = ExecutionTestBuilder::new()
-        .with_subnet_execution_memory(CAPACITY as i64)
-        .with_subnet_memory_reservation(0)
-        .with_subnet_memory_threshold(THRESHOLD as i64)
-        .build();
+        let mut test = ExecutionTestBuilder::new()
+            .with_subnet_type(subnet_type)
+            .with_subnet_execution_memory(CAPACITY as i64)
+            .with_subnet_memory_reservation(0)
+            .with_subnet_memory_threshold(THRESHOLD as i64)
+            .build();
 
-    test.create_canister_with_allocation(CYCLES, None, Some(THRESHOLD))
-        .unwrap();
+        test.create_canister_with_allocation(CYCLES, None, Some(THRESHOLD))
+            .unwrap();
 
-    let canister_id = test
-        .create_canister_with_settings(
-            CYCLES,
-            CanisterSettingsArgsBuilder::new()
-                .with_reserved_cycles_limit(CYCLES.get())
-                .build(),
+        let canister_id = test
+            .create_canister_with_settings(
+                CYCLES,
+                CanisterSettingsArgsBuilder::new()
+                    .with_reserved_cycles_limit(CYCLES.get())
+                    .build(),
+            )
+            .unwrap();
+
+        test.install_canister(canister_id, UNIVERSAL_CANISTER_WASM.to_vec())
+            .unwrap();
+
+        let subnet_memory_usage =
+            CAPACITY - test.subnet_available_memory().get_execution_memory() as u64;
+
+        // TODO(RUN-745): This should be `execution_memory_usage()`.
+        let memory_usage_before = test.canister_state(canister_id).memory_usage();
+        let balance_before = test.canister_state(canister_id).system_state.balance();
+        let reserved_cycles_before = test
+            .canister_state(canister_id)
+            .system_state
+            .reserved_balance();
+
+        test.upgrade_canister_with_allocation(
+            canister_id,
+            UNIVERSAL_CANISTER_WASM.to_vec(),
+            None,
+            Some(USAGE),
         )
         .unwrap();
+        let balance_after = test.canister_state(canister_id).system_state.balance();
+        let memory_usage_after = NumBytes::new(USAGE);
 
-    test.install_canister(canister_id, UNIVERSAL_CANISTER_WASM.to_vec())
-        .unwrap();
+        let reserved_cycles = test
+            .canister_state(canister_id)
+            .system_state
+            .reserved_balance();
 
-    let subnet_memory_usage =
-        CAPACITY - test.subnet_available_memory().get_execution_memory() as u64;
+        assert_eq!(
+            reserved_cycles - reserved_cycles_before,
+            test.cycles_account_manager().storage_reservation_cycles(
+                memory_usage_after - memory_usage_before,
+                &ResourceSaturation::new(subnet_memory_usage, THRESHOLD, CAPACITY),
+                test.subnet_size(),
+            )
+        );
 
-    // TODO(RUN-745): This should be `execution_memory_usage()`.
-    let memory_usage_before = test.canister_state(canister_id).memory_usage();
-    let balance_before = test.canister_state(canister_id).system_state.balance();
-    let reserved_cycles_before = test
-        .canister_state(canister_id)
-        .system_state
-        .reserved_balance();
-
-    test.upgrade_canister_with_allocation(
-        canister_id,
-        UNIVERSAL_CANISTER_WASM.to_vec(),
-        None,
-        Some(USAGE),
-    )
-    .unwrap();
-    let balance_after = test.canister_state(canister_id).system_state.balance();
-    let memory_usage_after = NumBytes::new(USAGE);
-
-    let reserved_cycles = test
-        .canister_state(canister_id)
-        .system_state
-        .reserved_balance();
-
-    assert_eq!(
-        reserved_cycles - reserved_cycles_before,
-        test.cycles_account_manager().storage_reservation_cycles(
-            memory_usage_after - memory_usage_before,
-            &ResourceSaturation::new(subnet_memory_usage, THRESHOLD, CAPACITY),
-            test.subnet_size(),
-        )
-    );
-
-    assert_ge!(
-        balance_before - balance_after,
-        reserved_cycles,
-        "Unexpected balance change: {} >= {}",
-        balance_before - balance_after,
-        reserved_cycles,
-    );
+        assert_ge!(
+            balance_before - balance_after,
+            reserved_cycles,
+            "Unexpected balance change: {} >= {}",
+            balance_before - balance_after,
+            reserved_cycles,
+        );
+    });
 }
 
 #[test]
 fn upgrade_reserves_cycles_on_memory_grow() {
-    const CYCLES: Cycles = Cycles::new(1_000_000_000_000_000);
-    const CAPACITY: u64 = 20_000_000_000;
-    const THRESHOLD: u64 = CAPACITY / 2;
+    cycles_reserved_for_app_and_verified_app_subnets(|subnet_type| {
+        const CYCLES: Cycles = Cycles::new(1_000_000_000_000_000);
+        const CAPACITY: u64 = 20_000_000_000;
+        const THRESHOLD: u64 = CAPACITY / 2;
 
-    let mut test = ExecutionTestBuilder::new()
-        .with_subnet_execution_memory(CAPACITY as i64)
-        .with_subnet_memory_reservation(0)
-        .with_subnet_memory_threshold(THRESHOLD as i64)
-        .build();
+        let mut test = ExecutionTestBuilder::new()
+            .with_subnet_type(subnet_type)
+            .with_subnet_execution_memory(CAPACITY as i64)
+            .with_subnet_memory_reservation(0)
+            .with_subnet_memory_threshold(THRESHOLD as i64)
+            .build();
 
-    test.create_canister_with_allocation(CYCLES, None, Some(THRESHOLD))
-        .unwrap();
+        test.create_canister_with_allocation(CYCLES, None, Some(THRESHOLD))
+            .unwrap();
 
-    let canister_id = test
-        .create_canister_with_settings(
-            CYCLES,
-            CanisterSettingsArgsBuilder::new()
-                .with_reserved_cycles_limit(CYCLES.get())
-                .build(),
-        )
-        .unwrap();
+        let canister_id = test
+            .create_canister_with_settings(
+                CYCLES,
+                CanisterSettingsArgsBuilder::new()
+                    .with_reserved_cycles_limit(CYCLES.get())
+                    .build(),
+            )
+            .unwrap();
 
-    let wat = r#"
+        let wat = r#"
         (module
             (import "ic0" "stable64_grow" (func $stable64_grow (param i64) (result i64)))
             (func (export "canister_post_upgrade")
@@ -6222,44 +6234,45 @@ fn upgrade_reserves_cycles_on_memory_grow() {
             (memory 0)
         )"#;
 
-    let wasm_binary = wat::parse_str(wat).unwrap();
+        let wasm_binary = wat::parse_str(wat).unwrap();
 
-    test.install_canister(canister_id, wasm_binary.clone())
-        .unwrap();
+        test.install_canister(canister_id, wasm_binary.clone())
+            .unwrap();
 
-    let subnet_memory_usage =
-        CAPACITY - test.subnet_available_memory().get_execution_memory() as u64;
-    let memory_usage_before = test.canister_state(canister_id).execution_memory_usage();
-    let balance_before = test.canister_state(canister_id).system_state.balance();
-    let reserved_cycles_before = test
-        .canister_state(canister_id)
-        .system_state
-        .reserved_balance();
-    test.upgrade_canister(canister_id, wasm_binary).unwrap();
-    let balance_after = test.canister_state(canister_id).system_state.balance();
-    let memory_usage_after = test.canister_state(canister_id).execution_memory_usage();
+        let subnet_memory_usage =
+            CAPACITY - test.subnet_available_memory().get_execution_memory() as u64;
+        let memory_usage_before = test.canister_state(canister_id).execution_memory_usage();
+        let balance_before = test.canister_state(canister_id).system_state.balance();
+        let reserved_cycles_before = test
+            .canister_state(canister_id)
+            .system_state
+            .reserved_balance();
+        test.upgrade_canister(canister_id, wasm_binary).unwrap();
+        let balance_after = test.canister_state(canister_id).system_state.balance();
+        let memory_usage_after = test.canister_state(canister_id).execution_memory_usage();
 
-    let reserved_cycles = test
-        .canister_state(canister_id)
-        .system_state
-        .reserved_balance();
+        let reserved_cycles = test
+            .canister_state(canister_id)
+            .system_state
+            .reserved_balance();
 
-    assert_eq!(
-        reserved_cycles - reserved_cycles_before,
-        test.cycles_account_manager().storage_reservation_cycles(
-            memory_usage_after - memory_usage_before,
-            &ResourceSaturation::new(subnet_memory_usage, THRESHOLD, CAPACITY),
-            test.subnet_size(),
-        )
-    );
+        assert_eq!(
+            reserved_cycles - reserved_cycles_before,
+            test.cycles_account_manager().storage_reservation_cycles(
+                memory_usage_after - memory_usage_before,
+                &ResourceSaturation::new(subnet_memory_usage, THRESHOLD, CAPACITY),
+                test.subnet_size(),
+            )
+        );
 
-    assert_ge!(
-        balance_before - balance_after,
-        reserved_cycles,
-        "Unexpected balance change: {} >= {}",
-        balance_before - balance_after,
-        reserved_cycles,
-    );
+        assert_ge!(
+            balance_before - balance_after,
+            reserved_cycles,
+            "Unexpected balance change: {} >= {}",
+            balance_before - balance_after,
+            reserved_cycles,
+        );
+    });
 }
 
 #[test]
@@ -6309,178 +6322,138 @@ fn install_does_not_reserve_cycles_on_system_subnet() {
 }
 
 #[test]
-fn install_does_not_reserve_cycles_on_verified_application_subnet() {
-    const CYCLES: Cycles = Cycles::new(1_000_000_000_000_000);
-    const CAPACITY: u64 = 20_000_000_000;
-    const THRESHOLD: u64 = CAPACITY / 2;
-    const USAGE: u64 = CAPACITY - THRESHOLD;
-
-    let mut test = ExecutionTestBuilder::new()
-        .with_subnet_type(SubnetType::VerifiedApplication)
-        .with_subnet_execution_memory(CAPACITY as i64)
-        .with_subnet_memory_reservation(0)
-        .with_subnet_memory_threshold(THRESHOLD as i64)
-        .build();
-
-    let canister_id = test.create_canister(CYCLES);
-
-    test.install_canister_with_allocation(
-        canister_id,
-        UNIVERSAL_CANISTER_WASM.into(),
-        None,
-        Some(THRESHOLD),
-    )
-    .unwrap();
-
-    let canister_id = test.create_canister(CYCLES);
-
-    let balance_before = test.canister_state(canister_id).system_state.balance();
-    test.install_canister_with_allocation(
-        canister_id,
-        UNIVERSAL_CANISTER_WASM.into(),
-        None,
-        Some(USAGE),
-    )
-    .unwrap();
-    let balance_after = test.canister_state(canister_id).system_state.balance();
-
-    // Message execution fee is an order of a few million cycles.
-    assert_lt!(balance_before - balance_after, Cycles::new(1_000_000_000));
-
-    let reserved_cycles = test
-        .canister_state(canister_id)
-        .system_state
-        .reserved_balance();
-    assert_eq!(reserved_cycles, Cycles::zero());
-}
-
-#[test]
 fn create_canister_reserves_cycles_for_memory_allocation() {
-    const CYCLES: Cycles = Cycles::new(1_000_000_000_000_000);
-    const CAPACITY: u64 = 20_000_000_000;
-    const THRESHOLD: u64 = CAPACITY / 2;
-    const USAGE: u64 = CAPACITY - THRESHOLD;
+    cycles_reserved_for_app_and_verified_app_subnets(|subnet_type| {
+        const CYCLES: Cycles = Cycles::new(1_000_000_000_000_000);
+        const CAPACITY: u64 = 20_000_000_000;
+        const THRESHOLD: u64 = CAPACITY / 2;
+        const USAGE: u64 = CAPACITY - THRESHOLD;
 
-    let mut test = ExecutionTestBuilder::new()
-        .with_subnet_execution_memory(CAPACITY as i64)
-        .with_subnet_memory_reservation(0)
-        .with_subnet_memory_threshold(THRESHOLD as i64)
-        .build();
+        let mut test = ExecutionTestBuilder::new()
+            .with_subnet_type(subnet_type)
+            .with_subnet_execution_memory(CAPACITY as i64)
+            .with_subnet_memory_reservation(0)
+            .with_subnet_memory_threshold(THRESHOLD as i64)
+            .build();
 
-    test.create_canister_with_allocation(CYCLES, None, Some(USAGE))
-        .unwrap();
+        test.create_canister_with_allocation(CYCLES, None, Some(USAGE))
+            .unwrap();
 
-    let subnet_memory_usage =
-        CAPACITY - test.subnet_available_memory().get_execution_memory() as u64;
+        let subnet_memory_usage =
+            CAPACITY - test.subnet_available_memory().get_execution_memory() as u64;
 
-    let balance_before = CYCLES;
-    let canister_id = test
-        .create_canister_with_settings(
-            balance_before,
-            CanisterSettingsArgsBuilder::new()
-                .with_memory_allocation(USAGE)
-                .with_reserved_cycles_limit(CYCLES.get())
-                .build(),
-        )
-        .unwrap();
-    let balance_after = test.canister_state(canister_id).system_state.balance();
+        let balance_before = CYCLES;
+        let canister_id = test
+            .create_canister_with_settings(
+                balance_before,
+                CanisterSettingsArgsBuilder::new()
+                    .with_memory_allocation(USAGE)
+                    .with_reserved_cycles_limit(CYCLES.get())
+                    .build(),
+            )
+            .unwrap();
+        let balance_after = test.canister_state(canister_id).system_state.balance();
 
-    assert_eq!(
-        test.canister_state(canister_id)
-            .memory_allocation()
-            .bytes()
-            .get(),
-        USAGE,
-    );
+        assert_eq!(
+            test.canister_state(canister_id)
+                .memory_allocation()
+                .bytes()
+                .get(),
+            USAGE,
+        );
 
-    let reserved_cycles = test
-        .canister_state(canister_id)
-        .system_state
-        .reserved_balance();
+        let reserved_cycles = test
+            .canister_state(canister_id)
+            .system_state
+            .reserved_balance();
 
-    assert_eq!(
-        reserved_cycles,
-        test.cycles_account_manager().storage_reservation_cycles(
-            NumBytes::new(USAGE),
-            &ResourceSaturation::new(subnet_memory_usage, THRESHOLD, CAPACITY),
-            test.subnet_size(),
-        )
-    );
+        assert_eq!(
+            reserved_cycles,
+            test.cycles_account_manager().storage_reservation_cycles(
+                NumBytes::new(USAGE),
+                &ResourceSaturation::new(subnet_memory_usage, THRESHOLD, CAPACITY),
+                test.subnet_size(),
+            )
+        );
 
-    assert_ge!(
-        balance_before - balance_after,
-        reserved_cycles,
-        "Unexpected balance change: {} >= {}",
-        balance_before - balance_after,
-        reserved_cycles,
-    );
+        assert_ge!(
+            balance_before - balance_after,
+            reserved_cycles,
+            "Unexpected balance change: {} >= {}",
+            balance_before - balance_after,
+            reserved_cycles,
+        );
+    });
 }
 
 #[test]
 fn update_settings_reserves_cycles_for_memory_allocation() {
-    const CYCLES: Cycles = Cycles::new(1_000_000_000_000_000);
-    const CAPACITY: u64 = 20_000_000_000;
-    const THRESHOLD: u64 = CAPACITY / 2;
-    const USAGE: u64 = CAPACITY - THRESHOLD;
+    cycles_reserved_for_app_and_verified_app_subnets(|subnet_type| {
+        const CYCLES: Cycles = Cycles::new(1_000_000_000_000_000);
+        const CAPACITY: u64 = 20_000_000_000;
+        const THRESHOLD: u64 = CAPACITY / 2;
+        const USAGE: u64 = CAPACITY - THRESHOLD;
 
-    let mut test = ExecutionTestBuilder::new()
-        .with_subnet_execution_memory(CAPACITY as i64)
-        .with_subnet_memory_reservation(0)
-        .with_subnet_memory_threshold(THRESHOLD as i64)
-        .build();
+        let mut test = ExecutionTestBuilder::new()
+            .with_subnet_type(subnet_type)
+            .with_subnet_execution_memory(CAPACITY as i64)
+            .with_subnet_memory_reservation(0)
+            .with_subnet_memory_threshold(THRESHOLD as i64)
+            .build();
 
-    test.create_canister_with_allocation(CYCLES, None, Some(THRESHOLD))
-        .unwrap();
+        test.create_canister_with_allocation(CYCLES, None, Some(THRESHOLD))
+            .unwrap();
 
-    let canister_id = test
-        .create_canister_with_settings(
-            CYCLES,
-            CanisterSettingsArgsBuilder::new()
-                .with_reserved_cycles_limit(CYCLES.get())
-                .build(),
-        )
-        .unwrap();
+        let canister_id = test
+            .create_canister_with_settings(
+                CYCLES,
+                CanisterSettingsArgsBuilder::new()
+                    .with_reserved_cycles_limit(CYCLES.get())
+                    .build(),
+            )
+            .unwrap();
 
-    let subnet_memory_usage =
-        CAPACITY - test.subnet_available_memory().get_execution_memory() as u64;
+        let subnet_memory_usage =
+            CAPACITY - test.subnet_available_memory().get_execution_memory() as u64;
 
-    // TODO(RUN-745): This should be `execution_memory_usage()`.
-    let memory_usage_before = test.canister_state(canister_id).memory_usage();
-    let balance_before = test.canister_state(canister_id).system_state.balance();
-    test.canister_update_allocations_settings(canister_id, None, Some(USAGE))
-        .unwrap();
-    let balance_after = test.canister_state(canister_id).system_state.balance();
-    let memory_usage_after = NumBytes::new(USAGE);
+        // TODO(RUN-745): This should be `execution_memory_usage()`.
+        let memory_usage_before = test.canister_state(canister_id).memory_usage();
+        let balance_before = test.canister_state(canister_id).system_state.balance();
+        test.canister_update_allocations_settings(canister_id, None, Some(USAGE))
+            .unwrap();
+        let balance_after = test.canister_state(canister_id).system_state.balance();
+        let memory_usage_after = NumBytes::new(USAGE);
 
-    assert_eq!(
-        test.canister_state(canister_id)
-            .memory_allocation()
-            .bytes()
-            .get(),
-        USAGE
-    );
+        assert_eq!(
+            test.canister_state(canister_id)
+                .memory_allocation()
+                .bytes()
+                .get(),
+            USAGE
+        );
 
-    let reserved_cycles = test
-        .canister_state(canister_id)
-        .system_state
-        .reserved_balance();
+        let reserved_cycles = test
+            .canister_state(canister_id)
+            .system_state
+            .reserved_balance();
 
-    assert_eq!(
-        reserved_cycles,
-        test.cycles_account_manager().storage_reservation_cycles(
-            memory_usage_after - memory_usage_before,
-            &ResourceSaturation::new(subnet_memory_usage, THRESHOLD, CAPACITY),
-            test.subnet_size(),
-        )
-    );
+        assert_eq!(
+            reserved_cycles,
+            test.cycles_account_manager().storage_reservation_cycles(
+                memory_usage_after - memory_usage_before,
+                &ResourceSaturation::new(subnet_memory_usage, THRESHOLD, CAPACITY),
+                test.subnet_size(),
+            )
+        );
 
-    assert_ge!(
-        balance_before - balance_after,
-        reserved_cycles,
-        "Unexpected balance change: {} >= {}",
-        balance_before - balance_after,
-        reserved_cycles,
-    );
+        assert_ge!(
+            balance_before - balance_after,
+            reserved_cycles,
+            "Unexpected balance change: {} >= {}",
+            balance_before - balance_after,
+            reserved_cycles,
+        );
+    });
 }
 
 #[test]
@@ -7442,76 +7415,79 @@ fn upload_chunk_fails_when_it_exceeds_chunk_size() {
 
 #[test]
 fn upload_chunk_reserves_cycles() {
-    const CYCLES: Cycles = Cycles::new(1_000_000_000_000_000);
+    cycles_reserved_for_app_and_verified_app_subnets(|subnet_type| {
+        const CYCLES: Cycles = Cycles::new(1_000_000_000_000_000);
 
-    let memory_usage_after_uploading_one_chunk = {
-        const CAPACITY: i64 = 1_000_000_000;
+        let memory_usage_after_uploading_one_chunk = {
+            const CAPACITY: i64 = 1_000_000_000;
+
+            let mut test = ExecutionTestBuilder::new()
+                .with_subnet_type(subnet_type)
+                .with_subnet_execution_memory(CAPACITY)
+                .with_subnet_memory_reservation(0)
+                .with_subnet_memory_threshold(0)
+                .build();
+            let canister_id = test.create_canister(CYCLES);
+
+            let upload_args = UploadChunkArgs {
+                canister_id: canister_id.into(),
+                chunk: vec![42; 10],
+            };
+
+            let _hash = test
+                .subnet_message("upload_chunk", upload_args.encode())
+                .unwrap();
+
+            CAPACITY - test.subnet_available_memory().get_execution_memory()
+        };
 
         let mut test = ExecutionTestBuilder::new()
-            .with_subnet_execution_memory(CAPACITY)
             .with_subnet_memory_reservation(0)
-            .with_subnet_memory_threshold(0)
+            .with_subnet_memory_threshold(memory_usage_after_uploading_one_chunk + 1)
             .build();
         let canister_id = test.create_canister(CYCLES);
+        assert_eq!(
+            test.canister_state(canister_id)
+                .system_state
+                .reserved_balance(),
+            Cycles::from(0_u128)
+        );
 
+        // Upload a chunk
         let upload_args = UploadChunkArgs {
             canister_id: canister_id.into(),
             chunk: vec![42; 10],
         };
-
         let _hash = test
             .subnet_message("upload_chunk", upload_args.encode())
             .unwrap();
+        assert_eq!(
+            test.canister_state(canister_id)
+                .system_state
+                .reserved_balance(),
+            Cycles::from(0_u128)
+        );
 
-        CAPACITY - test.subnet_available_memory().get_execution_memory()
-    };
-
-    let mut test = ExecutionTestBuilder::new()
-        .with_subnet_memory_reservation(0)
-        .with_subnet_memory_threshold(memory_usage_after_uploading_one_chunk + 1)
-        .build();
-    let canister_id = test.create_canister(CYCLES);
-    assert_eq!(
-        test.canister_state(canister_id)
+        // Upload a second chunk which should reserve some cycles.
+        let upload_args = UploadChunkArgs {
+            canister_id: canister_id.into(),
+            chunk: vec![43; 10],
+        };
+        let _hash = test
+            .subnet_message("upload_chunk", upload_args.encode())
+            .unwrap();
+        let reserved_balance = test
+            .canister_state(canister_id)
             .system_state
-            .reserved_balance(),
-        Cycles::from(0_u128)
-    );
-
-    // Upload a chunk
-    let upload_args = UploadChunkArgs {
-        canister_id: canister_id.into(),
-        chunk: vec![42; 10],
-    };
-    let _hash = test
-        .subnet_message("upload_chunk", upload_args.encode())
-        .unwrap();
-    assert_eq!(
-        test.canister_state(canister_id)
-            .system_state
-            .reserved_balance(),
-        Cycles::from(0_u128)
-    );
-
-    // Upload a second chunk which should reserve some cycles.
-    let upload_args = UploadChunkArgs {
-        canister_id: canister_id.into(),
-        chunk: vec![43; 10],
-    };
-    let _hash = test
-        .subnet_message("upload_chunk", upload_args.encode())
-        .unwrap();
-    let reserved_balance = test
-        .canister_state(canister_id)
-        .system_state
-        .reserved_balance()
-        .get();
-    assert_lt!(
-        0,
-        reserved_balance,
-        "Reserved balance {} should be positive",
-        reserved_balance
-    );
+            .reserved_balance()
+            .get();
+        assert_lt!(
+            0,
+            reserved_balance,
+            "Reserved balance {} should be positive",
+            reserved_balance
+        );
+    });
 }
 
 #[test]

--- a/rs/test_utilities/execution_environment/src/lib.rs
+++ b/rs/test_utilities/execution_environment/src/lib.rs
@@ -156,6 +156,17 @@ pub fn universal_canister_compilation_cost_correction() -> NumInstructions {
     cost - CompilationCostHandling::CountReducedAmount.adjusted_compilation_cost(cost)
 }
 
+/// Helper function to test that cycles are reserved for both
+/// application and verified application subnets.
+///
+/// Expects a test function that takes a `SubnetType` as an argument
+/// so it can be tested over the desired subnet types.
+pub fn cycles_reserved_for_app_and_verified_app_subnets<T: Fn(SubnetType)>(test: T) {
+    for subnet_type in vec![SubnetType::Application, SubnetType::VerifiedApplication] {
+        test(subnet_type);
+    }
+}
+
 /// A helper for execution tests.
 ///
 /// Example usage:

--- a/rs/test_utilities/execution_environment/src/lib.rs
+++ b/rs/test_utilities/execution_environment/src/lib.rs
@@ -162,7 +162,7 @@ pub fn universal_canister_compilation_cost_correction() -> NumInstructions {
 /// Expects a test function that takes a `SubnetType` as an argument
 /// so it can be tested over the desired subnet types.
 pub fn cycles_reserved_for_app_and_verified_app_subnets<T: Fn(SubnetType)>(test: T) {
-    for subnet_type in vec![SubnetType::Application, SubnetType::VerifiedApplication] {
+    for subnet_type in [SubnetType::Application, SubnetType::VerifiedApplication] {
         test(subnet_type);
     }
 }


### PR DESCRIPTION
This enables the storage reservation mechanism on verified application subnets. The storage reservation mechanism has been enabled for a while on application subnets and so it's time that this is enabled for verified application subnets as well. This helps bring closer the configuration between application and verified application subnets.