### PR TITLE
chore: add bazel profile.json to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -118,6 +118,9 @@ bazel-bep.txt
 bazel-timestamp.txt
 user.bazelrc
 
+# Bazel profile
+profile.json
+
 # Visual Studio Code
 .vscode
 


### PR DESCRIPTION
Exclude bazel's `profile.json` from version control. The profiling dump is generated by bazel when profiling is explicitly enabled in `.bazelrc` or on-demand. We enable it when improving the build system from time to time.