### PR TITLE
feat(ICP-Ledger): FI-1508 add test icp allowance getter endpoint

### DIFF
--- a/rs/ledger_suite/icp/ledger/BUILD.bazel
+++ b/rs/ledger_suite/icp/ledger/BUILD.bazel
@@ -1,6 +1,6 @@
 load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test")
-load("//bazel:canisters.bzl", "rust_canister")
 load("//bazel:defs.bzl", "rust_ic_test")
+load("ledger_canisters.bzl", "LEDGER_CANISTER_DATA", "LEDGER_CANISTER_RUSTC_ENV", "rust_ledger_canister")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -61,70 +61,21 @@ rust_test(
     },
 )
 
-LEDGER_CANISTER_DEPS = [
-    # Keep sorted.
-    ":ledger",
-    "//packages/ic-ledger-hash-of:ic_ledger_hash_of",
-    "//packages/icrc-ledger-types:icrc_ledger_types",
-    "//rs/ledger_suite/common/ledger_canister_core",
-    "//rs/ledger_suite/common/ledger_core",
-    "//rs/ledger_suite/icp:icp_ledger",
-    "//rs/ledger_suite/icrc1",
-    "//rs/rust_canisters/canister_log",
-    "//rs/rust_canisters/dfn_candid",
-    "//rs/rust_canisters/dfn_core",
-    "//rs/rust_canisters/dfn_http_metrics",
-    "//rs/rust_canisters/dfn_protobuf",
-    "//rs/rust_canisters/on_wire",
-    "//rs/types/base_types",
-    "@crate_index//:candid",
-    "@crate_index//:ciborium",
-    "@crate_index//:ic-cdk",
-    "@crate_index//:ic-metrics-encoder",
-    "@crate_index//:ic-stable-structures",
-    "@crate_index//:num-traits",
-    "@crate_index//:serde_bytes",
-]
+rust_ledger_canister(name = "ledger-canister-wasm")
 
-LEDGER_CANISTER_DATA = [
-    "//rs/ledger_suite/icp:ledger.did",
-    "//rs/ledger_suite/icp/ledger:ledger_candid_backwards_compatible.did",
-]
-
-LEDGER_CANISTER_RUSTC_ENV = {
-    "LEDGER_DID_PATH": "$(execpath //rs/ledger_suite/icp:ledger.did)",
-}
-
-rust_canister(
-    name = "ledger-canister-wasm",
-    srcs = ["src/main.rs"],
-    compile_data = LEDGER_CANISTER_DATA,
-    data = LEDGER_CANISTER_DATA,
-    rustc_env = LEDGER_CANISTER_RUSTC_ENV,
-    service_file = "//rs/ledger_suite/icp:ledger.did",
-    deps = LEDGER_CANISTER_DEPS,
+rust_ledger_canister(
+    name = "ledger-canister-wasm-allowance-getter",
+    crate_features = ["icp-allowance-getter"],
 )
 
-rust_canister(
+rust_ledger_canister(
     name = "ledger-canister-wasm-notify-method",
-    srcs = ["src/main.rs"],
-    compile_data = LEDGER_CANISTER_DATA,
     crate_features = ["notify-method"],
-    data = LEDGER_CANISTER_DATA,
-    rustc_env = LEDGER_CANISTER_RUSTC_ENV,
-    service_file = "//rs/ledger_suite/icp:ledger.did",
-    deps = LEDGER_CANISTER_DEPS,
 )
 
-rust_canister(
+rust_ledger_canister(
     name = "ledger-canister-wasm-upgrade-to-memory-manager",
-    srcs = ["src/main.rs"],
-    compile_data = LEDGER_CANISTER_DATA,
     crate_features = ["upgrade-to-memory-manager"],
-    data = LEDGER_CANISTER_DATA,
-    rustc_env = LEDGER_CANISTER_RUSTC_ENV,
-    service_file = "//rs/ledger_suite/icp:ledger.did",
-    deps = LEDGER_CANISTER_DEPS,
 )
 
 rust_test(
@@ -144,6 +95,7 @@ rust_ic_test(
     srcs = ["tests/tests.rs"],
     data = [
         ":ledger-canister-wasm",
+        ":ledger-canister-wasm-allowance-getter",
         ":ledger-canister-wasm-upgrade-to-memory-manager",
         "@mainnet_icp_ledger_canister//file",
     ],
@@ -152,6 +104,7 @@ rust_ic_test(
         "ICP_LEDGER_DEPLOYED_VERSION_WASM_PATH": "$(rootpath @mainnet_icp_ledger_canister//file)",
         "LEDGER_CANISTER_WASM_PATH": "$(rootpath :ledger-canister-wasm)",
         "LEDGER_CANISTER_UPGRADE_TO_MEMORY_MANAGER_WASM_PATH": "$(rootpath :ledger-canister-wasm-upgrade-to-memory-manager)",
+        "LEDGER_CANISTER_ALLOWANCE_GETTER_WASM_PATH": "$(rootpath :ledger-canister-wasm-allowance-getter)",
     },
     flaky = True,
     deps = [

--- a/rs/ledger_suite/icp/ledger/Cargo.toml
+++ b/rs/ledger_suite/icp/ledger/Cargo.toml
@@ -51,4 +51,5 @@ ic-test-utilities-load-wasm = { path = "../../../test_utilities/load_wasm" }
 
 [features]
 notify-method = []
+icp-allowance-getter = []
 upgrade-to-memory-manager = []

--- a/rs/ledger_suite/icp/ledger/ledger_canisters.bzl
+++ b/rs/ledger_suite/icp/ledger/ledger_canisters.bzl
@@ -1,0 +1,61 @@
+"""
+This Bazel file defines the configuration for building the Ledger Canister in Rust.
+
+The `rust_ledger_canister` function is a wrapper around the `rust_canister` rule that 
+sets up the necessary dependencies, environment variables, and service files required 
+to build the Ledger Canister.
+
+Usage:
+- The `rust_ledger_canister` function is used to instantiate a Rust canister with the 
+  provided `name` and optional `crate_features`. It simplifies the configuration for 
+  building the Ledger Canister by predefining common settings such as source files, 
+  dependencies, and environment variables.
+"""
+
+load("//bazel:canisters.bzl", "rust_canister")
+
+LEDGER_CANISTER_DATA = [
+    "//rs/ledger_suite/icp:ledger.did",
+    "//rs/ledger_suite/icp/ledger:ledger_candid_backwards_compatible.did",
+]
+
+LEDGER_CANISTER_RUSTC_ENV = {
+    "LEDGER_DID_PATH": "$(execpath //rs/ledger_suite/icp:ledger.did)",
+}
+
+LEDGER_CANISTER_DEPS = [
+    # Keep sorted.
+    ":ledger",
+    "//packages/ic-ledger-hash-of:ic_ledger_hash_of",
+    "//packages/icrc-ledger-types:icrc_ledger_types",
+    "//rs/ledger_suite/common/ledger_canister_core",
+    "//rs/ledger_suite/common/ledger_core",
+    "//rs/ledger_suite/icp:icp_ledger",
+    "//rs/ledger_suite/icrc1",
+    "//rs/rust_canisters/canister_log",
+    "//rs/rust_canisters/dfn_candid",
+    "//rs/rust_canisters/dfn_core",
+    "//rs/rust_canisters/dfn_http_metrics",
+    "//rs/rust_canisters/dfn_protobuf",
+    "//rs/rust_canisters/on_wire",
+    "//rs/types/base_types",
+    "@crate_index//:candid",
+    "@crate_index//:ciborium",
+    "@crate_index//:ic-cdk",
+    "@crate_index//:ic-metrics-encoder",
+    "@crate_index//:ic-stable-structures",
+    "@crate_index//:num-traits",
+    "@crate_index//:serde_bytes",
+]
+
+def rust_ledger_canister(name, crate_features = None):
+    rust_canister(
+        name = name,
+        srcs = ["src/main.rs"],
+        compile_data = LEDGER_CANISTER_DATA,
+        data = LEDGER_CANISTER_DATA,
+        rustc_env = LEDGER_CANISTER_RUSTC_ENV,
+        service_file = "//rs/ledger_suite/icp:ledger.did",
+        deps = LEDGER_CANISTER_DEPS,
+        crate_features = crate_features if crate_features else [],
+    )

--- a/rs/ledger_suite/icp/ledger/tests/tests.rs
+++ b/rs/ledger_suite/icp/ledger/tests/tests.rs
@@ -16,16 +16,16 @@ use ic_state_machine_tests::{ErrorCode, PrincipalId, StateMachine, UserError};
 use icp_ledger::{
     AccountIdBlob, AccountIdentifier, ArchiveOptions, ArchivedBlocksRange, Block, CandidBlock,
     CandidOperation, CandidTransaction, FeatureFlags, GetBlocksArgs, GetBlocksRes, GetBlocksResult,
-    GetEncodedBlocksResult, InitArgs, IterBlocksArgs, IterBlocksRes, LedgerCanisterInitPayload,
-    LedgerCanisterPayload, LedgerCanisterUpgradePayload, Operation, QueryBlocksResponse,
-    QueryEncodedBlocksResponse, TimeStamp, UpgradeArgs, DEFAULT_TRANSFER_FEE,
+    GetEncodedBlocksResult, IcpAllowanceArgs, InitArgs, IterBlocksArgs, IterBlocksRes,
+    LedgerCanisterInitPayload, LedgerCanisterPayload, LedgerCanisterUpgradePayload, Operation,
+    QueryBlocksResponse, QueryEncodedBlocksResponse, TimeStamp, UpgradeArgs, DEFAULT_TRANSFER_FEE,
     MAX_BLOCKS_PER_INGRESS_REPLICATED_QUERY_REQUEST, MAX_BLOCKS_PER_REQUEST,
 };
 use icrc_ledger_types::icrc1::{
     account::Account,
     transfer::{Memo, TransferArg, TransferError},
 };
-use icrc_ledger_types::icrc2::allowance::AllowanceArgs;
+use icrc_ledger_types::icrc2::allowance::{Allowance, AllowanceArgs};
 use icrc_ledger_types::icrc2::approve::ApproveArgs;
 use num_traits::cast::ToPrimitive;
 use on_wire::{FromWire, IntoWire};
@@ -50,6 +50,14 @@ fn ledger_wasm_upgrade_to_memory_manager() -> Vec<u8> {
     ic_test_utilities_load_wasm::load_wasm(
         std::env::var("CARGO_MANIFEST_DIR").unwrap(),
         "ledger-canister-upgrade-to-memory-manager",
+        &[],
+    )
+}
+
+fn ledger_wasm_allowance_getter() -> Vec<u8> {
+    ic_test_utilities_load_wasm::load_wasm(
+        std::env::var("CARGO_MANIFEST_DIR").unwrap(),
+        "ledger-canister-allowance-getter",
         &[],
     )
 }
@@ -343,6 +351,78 @@ fn test_anonymous_approval() {
         string_from_bytes_result,
         Ok("Anonymous principal cannot approve token transfers on the ledger.".to_string())
     );
+}
+
+#[test]
+fn test_icp_allowance_getter_unavailable_in_prod() {
+    let p1 = PrincipalId::new_user_test_id(1);
+    let p2 = PrincipalId::new_user_test_id(2);
+    let (env, canister_id) = setup(ledger_wasm(), encode_init_args, vec![]);
+    let allowance_args = IcpAllowanceArgs {
+        account: AccountIdentifier::from(p1.0),
+        spender: AccountIdentifier::from(p2.0),
+    };
+
+    let response = env.execute_ingress_as(
+        p1,
+        canister_id,
+        "allowance",
+        Encode!(&allowance_args).unwrap(),
+    );
+    let error = response.unwrap_err();
+
+    assert_eq!(error.code(), ErrorCode::CanisterMethodNotFound);
+}
+
+#[test]
+fn test_get_icp_approval() {
+    const INITIAL_BALANCE: u64 = 10_000_000;
+    const APPROVE_AMOUNT: u64 = 1_000_000;
+    let p1 = PrincipalId::new_user_test_id(1);
+    let p2 = PrincipalId::new_user_test_id(2);
+    let (env, canister_id) = setup(
+        ledger_wasm_allowance_getter(),
+        encode_init_args,
+        vec![(Account::from(p1.0), INITIAL_BALANCE)],
+    );
+    assert_eq!(INITIAL_BALANCE, total_supply(&env, canister_id));
+    assert_eq!(INITIAL_BALANCE, balance_of(&env, canister_id, p1.0));
+    assert_eq!(0, balance_of(&env, canister_id, p2.0));
+    let approve_args = ApproveArgs {
+        from_subaccount: None,
+        spender: p2.0.into(),
+        amount: Nat::from(APPROVE_AMOUNT),
+        fee: None,
+        memo: None,
+        expires_at: None,
+        expected_allowance: None,
+        created_at_time: None,
+    };
+    let response = env.execute_ingress_as(
+        p1,
+        canister_id,
+        "icrc2_approve",
+        Encode!(&approve_args).unwrap(),
+    );
+    assert!(response.is_ok());
+    let allowance_args = IcpAllowanceArgs {
+        account: AccountIdentifier::from(p1.0),
+        spender: AccountIdentifier::from(p2.0),
+    };
+
+    let response = env.execute_ingress_as(
+        p1,
+        canister_id,
+        "allowance",
+        Encode!(&allowance_args).unwrap(),
+    );
+
+    let result = Decode!(
+        &response.expect("failed to get allowance").bytes(),
+        Allowance
+    )
+    .expect("failed to decode allowance response");
+    assert_eq!(result.allowance.0.to_u64(), Some(APPROVE_AMOUNT));
 }
 
 #[test]

--- a/rs/ledger_suite/icp/src/lib.rs
+++ b/rs/ledger_suite/icp/src/lib.rs
@@ -1038,6 +1038,12 @@ impl TryFrom<CandidBlock> for Block {
     }
 }
 
+#[derive(Clone, Eq, PartialEq, Hash, Debug, CandidType, Deserialize, Serialize)]
+pub struct IcpAllowanceArgs {
+    pub account: AccountIdentifier,
+    pub spender: AccountIdentifier,
+}
+
 /// Argument taken by the transfer fee endpoint
 ///
 /// The reason it is a struct is so that it can be extended -- e.g., to be able


### PR DESCRIPTION
- Introduced the `allowance` endpoint to the ICP ledger canister that fetches an allowance given `AccountIdentifier`s. It's only available in test wasm and not exposed through the candid interface.

- Refactored Bazel configuration by moving shared canister setup to `ledger_canisters.bzl`

- Added tests to make sure the new endpoint works if and only if it's running from a test wasm.