### PR TITLE
refactor: miscellaneous icos refactoring and clean-up

### DIFF
--- a/ic-os/components/early-boot/setup-hostname/hostos/setup-hostname.sh
+++ b/ic-os/components/early-boot/setup-hostname/hostos/setup-hostname.sh
@@ -60,32 +60,27 @@ function read_variables() {
         case "$key" in
             "ipv6_prefix") ipv6_prefix="${value}" ;;
             "ipv6_gateway") ipv6_gateway="${value}" ;;
-            "hostname") hostname="${value}" ;;
         esac
     done <"${CONFIG}"
 }
 
 function construct_hostname() {
-    if [ -z "${hostname}" ]; then
-        local mac=$(/opt/ic/bin/hostos_tool fetch-mac-address | sed 's/://g')
+    local mac=$(/opt/ic/bin/hostos_tool fetch-mac-address | sed 's/://g')
 
-        if [[ -r ${FILE} && $(cat ${FILE}) != "" ]]; then
-            HOSTNAME=$(echo ${TYPE}-${mac}-$(cat ${FILE}))
-            write_log "Using hostname: ${HOSTNAME}"
-            write_metric "hostos_setup_hostname" \
-                "1" \
-                "HostOS setup hostname" \
-                "gauge"
-        else
-            HOSTNAME=$(echo ${TYPE}-${mac})
-            write_log "Using hostname: ${HOSTNAME}"
-            write_metric "hostos_setup_hostname" \
-                "0" \
-                "HostOS setup hostname" \
-                "gauge"
-        fi
+    if [[ -r ${FILE} && $(cat ${FILE}) != "" ]]; then
+        HOSTNAME=$(echo ${TYPE}-${mac}-$(cat ${FILE}))
+        write_log "Using hostname: ${HOSTNAME}"
+        write_metric "hostos_setup_hostname" \
+            "1" \
+            "HostOS setup hostname" \
+            "gauge"
     else
-        HOSTNAME="${hostname}"
+        HOSTNAME=$(echo ${TYPE}-${mac})
+        write_log "Using hostname: ${HOSTNAME}"
+        write_metric "hostos_setup_hostname" \
+            "0" \
+            "HostOS setup hostname" \
+            "gauge"
     fi
 }
 

--- a/ic-os/docs/Configuration.adoc
+++ b/ic-os/docs/Configuration.adoc
@@ -72,8 +72,6 @@ Consider that values may be controlled by an attacker on boot. Bootstrapping a n
 
 *Interpretation of configuration bits*: Any script or service in the system may pull configuration bits out of /boot/config to customize its behavior. E.g. if adding parameter-driven customization of ic.json5, then augment the generate-replica-config.sh script to pull the configuration values and substitute them into the generated configuration.
 
-*Documentation*: Please keep documentation up-to-date (link:ConfigStore-SetupOSHostOS.adoc[SetupOS/HostOS config store], link:../guestos/docs/ConfigStore.adoc[GuestOS config store])
-
 === Testing
 
 * *bootstrap-ic-node.sh* can be temporarily tweaked (internally adapt paths, then run the process_bootstrap function):

--- a/ic-os/docs/README.adoc
+++ b/ic-os/docs/README.adoc
@@ -7,4 +7,3 @@ Refer to detailed documentation on:
 * link:Components{outfilesuffix}[Components]
 * link:SELinux{outfilesuffix}[SELinux security policy]
 * link:Configuration{outfilesuffix}[Configuration]
-* link:ConfigStore-SetupOSHostOS{outfilesuffix}[SetupOS and HostOS config store]

--- a/rs/ic_os/network/src/interfaces.rs
+++ b/rs/ic_os/network/src/interfaces.rs
@@ -22,11 +22,11 @@ pub struct Interface {
 pub fn has_ipv6_connectivity(
     interface: &Interface,
     generated_ipv6: &Ipv6Addr,
-    ipv6_subnet: u8,
+    ipv6_prefix_length: u8,
     ping_target: &str,
 ) -> Result<bool> {
     // Format with the prefix length
-    let ip = format!("{}/{}", generated_ipv6, ipv6_subnet);
+    let ip = format!("{}/{}", generated_ipv6, ipv6_prefix_length);
     let interface_down_func = || {
         eprintln!("Removing ip address and bringing interface down");
         get_command_stdout("ip", ["addr", "del", &ip, "dev", &interface.name])?;

--- a/rs/ic_os/network/src/mac_address.rs
+++ b/rs/ic_os/network/src/mac_address.rs
@@ -124,6 +124,10 @@ pub fn generate_mac_address(
 /// Retrieves the MAC address from the IPMI LAN interface
 pub fn get_ipmi_mac() -> Result<FormattedMacAddress> {
     let output = Command::new("ipmitool").arg("lan").arg("print").output()?;
+
+    // A bug in our version of ipmitool causes it to exit with an error
+    // status, but we have enough output to work with anyway.
+    // https://github.com/ipmitool/ipmitool/issues/388
     if !output.status.success() {
         eprintln!(
             "Error running ipmitool: {}",


### PR DESCRIPTION
A few minor refactoring changes pulled out of the new [icos config integration](https://github.com/dfinity/ic/pull/1563/files):

- [Update has_ipv6_connectivity ipv6_prefix_length reference](https://github.com/dfinity/ic/commit/403dfd2399cf10b1fa5dd96e5e6ff76506e8d6c0)
- [Remove unused hostname field from setup-hostname.sh](https://github.com/dfinity/ic/commit/12a9ea1938b9a3455743ae12865018185506a390)
- [Remove references to deleted ConfigStore-SetupOSHostOS documentation](https://github.com/dfinity/ic/commit/40030e65e5ef69c3b24b32a470d2117625ace345)
- [Add comment to get_ipmi_mac](https://github.com/dfinity/ic/pull/1937/commits/afbe77d9e5066cf5071420f072073d35d20bdd44)