### PR TITLE
refactor: remove dead code in generate-replica-config.sh

### DIFF
--- a/ic-os/components/ic/generate-replica-config.sh
+++ b/ic-os/components/ic/generate-replica-config.sh
@@ -237,22 +237,6 @@ if [ "${IPV6_ADDRESS}" == "" ]; then
     exit 1
 fi
 
-# HACK: host names set on mercury deployment are invalid. Fix this up
-# by resetting the host name to be derived from IPv6 address.
-if [ "${hostname}" == "" ]; then
-    if [ -e "${NETWORK_CONFIG_FILE}" ]; then
-        # Derive new hostname.
-        # Hostname must start with a letter, not have two consecutive hyphens and end with an alphanumeric.
-        NEW_HOST_NAME=ip6$(echo "${IPV6_ADDRESS}" | sed -e 's/::/x/g;s/:/-/g')
-        echo "Set new hostname: ${NEW_HOST_NAME}"
-        # Substitute hostname in master config file so it persists
-        # across reboots and upgrades.
-        sed -i "${NETWORK_CONFIG_FILE}" -e "s/hostname=.*/hostname=$NEW_HOST_NAME/"
-        # Force set current hostname from master config file.
-        /opt/ic/bin/setup-hostname.sh
-    fi
-fi
-
 sed -e "s@{{ ipv6_address }}@${IPV6_ADDRESS}@" \
     -e "s@{{ ipv4_address }}@${IPV4_ADDRESS}@" \
     -e "s@{{ ipv4_gateway }}@${IPV4_GATEWAY}@" \


### PR DESCRIPTION
This code is never triggered. A hostname is required for build-bootstrap-config-image.sh to succeed, which is what is used to generate the GuestOS config.