### PR TITLE
refactor: remove default query_stats_aggregation field

### DIFF
--- a/ic-os/components/ic/generate-replica-config.sh
+++ b/ic-os/components/ic/generate-replica-config.sh
@@ -133,9 +133,7 @@ function read_query_stats_variables() {
     while IFS="=" read -r key value; do
         case "$key" in
             "query_stats_epoch_length")
-                query_stats_epoch_length="${value}"
-                query_stats_aggregation="\"Enabled\""
-                ;;
+                query_stats_epoch_length="${value}" ;;
         esac
     done <"$1"
 }
@@ -225,8 +223,6 @@ BACKUP_RETENTION_TIME_SECS="${backup_retention_time_secs:-86400}"
 BACKUP_PURGING_INTERVAL_SECS="${backup_purging_interval_secs:-3600}"
 # Default is null (None)
 MALICIOUS_BEHAVIOR="${malicious_behavior:-null}"
-# Defaults to enabled
-QUERY_STATS_AGGREGATION="${query_stats_aggregation:-\"Enabled\"}"
 # Default is 600 blocks i.e. around 10min
 QUERY_STATS_EPOCH_LENGTH="${query_stats_epoch_length:-600}"
 # TODO: If the Jaeger address is not specified the config file will contain Some(""). This needs to be fixed.
@@ -262,7 +258,6 @@ sed -e "s@{{ ipv6_address }}@${IPV6_ADDRESS}@" \
     -e "s@{{ backup_retention_time_secs }}@${BACKUP_RETENTION_TIME_SECS}@" \
     -e "s@{{ backup_purging_interval_secs }}@${BACKUP_PURGING_INTERVAL_SECS}@" \
     -e "s@{{ malicious_behavior }}@${MALICIOUS_BEHAVIOR}@" \
-    -e "s@{{ query_stats_aggregation }}@${QUERY_STATS_AGGREGATION}@" \
     -e "s@{{ query_stats_epoch_length }}@${QUERY_STATS_EPOCH_LENGTH}@" \
     -e "s@{{ jaeger_addr }}@${JAEGER_ADDR}@" \
     "${IN_FILE}" >"${OUT_FILE}"

--- a/ic-os/components/ic/generate-replica-config.sh
+++ b/ic-os/components/ic/generate-replica-config.sh
@@ -133,7 +133,8 @@ function read_query_stats_variables() {
     while IFS="=" read -r key value; do
         case "$key" in
             "query_stats_epoch_length")
-                query_stats_epoch_length="${value}" ;;
+                query_stats_epoch_length="${value}"
+                ;;
         esac
     done <"$1"
 }

--- a/ic-os/components/ic/ic.json5.template
+++ b/ic-os/components/ic/ic.json5.template
@@ -100,7 +100,7 @@
         create_funds_whitelist: "5o66h-77qch-43oup-7aaui-kz5ty-tww4j-t2wmx-e3lym-cbtct-l3gpw-wae",
 
         // Enable Query Stats
-        query_stats_aggregation: {{ query_stats_aggregation }},
+        query_stats_aggregation: "Enabled",
 
         // Length of an epoch for query stats collection.
         query_stats_epoch_length: {{ query_stats_epoch_length }},

--- a/rs/orchestrator/src/firewall.rs
+++ b/rs/orchestrator/src/firewall.rs
@@ -848,7 +848,6 @@ mod tests {
             .replace("{{ backup_purging_interval_secs }}", "0")
             .replace("{{ nns_url }}", "http://www.fakeurl.com/")
             .replace("{{ malicious_behavior }}", "null")
-            .replace("{{ query_stats_aggregation }}", "\"Enabled\"")
             .replace("{{ query_stats_epoch_length }}", "600");
         let config_source = ConfigSource::Literal(cfg);
 

--- a/rs/tests/driver/src/util.rs
+++ b/rs/tests/driver/src/util.rs
@@ -1412,7 +1412,6 @@ pub fn get_config() -> ConfigOptional {
         .replace("{{ backup_purging_interval_secs }}", "0")
         .replace("{{ nns_url }}", "http://www.fakeurl.com/")
         .replace("{{ malicious_behavior }}", "null")
-        .replace("{{ query_stats_aggregation }}", "\"Enabled\"")
         .replace("{{ query_stats_epoch_length }}", "600");
 
     json5::from_str::<ConfigOptional>(&cfg).expect("Could not parse json5")


### PR DESCRIPTION
move default query_stats_aggregation field from generate-replica-config.sh to ic.json.template (where hard-coded values should be)