### PR TITLE
fix(IDX): open up more rosetta ports in the k8s-based UVM to fix the rosetta systests

### DIFF
--- a/rs/tests/driver/src/k8s/virtualmachine.rs
+++ b/rs/tests/driver/src/k8s/virtualmachine.rs
@@ -50,6 +50,17 @@ spec:
             ports:
             - port: 22
             - port: 8100
+            - port: 8101
+            - port: 8102
+            - port: 8103
+            - port: 8104
+            - port: 8105
+            - port: 8106
+            - port: 8107
+            - port: 8108
+            - port: 8109
+            - port: 8110
+            - port: 8111
             - port: 8332
             - port: 18444
             - port: 20443


### PR DESCRIPTION
The rosetta system-tests need [ports 8100-8111](https://sourcegraph.com/search?q=repo:%5Egithub%5C.com/dfinity/ic%24+file:rs/tests/src/rosetta+PORT.*8&patternType=regexp&sm=0) open on the UVM running rosetta. So this PR opens them up on the k8s-based UVM.
