### PR TITLE
test(ICRC_ledger): FI-1522: Fix and tune golden state tests

### DIFF
--- a/rs/ledger_suite/icrc1/tests/golden_state_upgrade_downgrade.rs
+++ b/rs/ledger_suite/icrc1/tests/golden_state_upgrade_downgrade.rs
@@ -37,12 +37,20 @@ type Tokens = ic_icrc1_tokens_u256::U256;
 
 #[cfg(not(feature = "u256-tokens"))]
 lazy_static! {
-    pub static ref MAINNET_WASMS: Wasms = Wasms::new(
+    pub static ref MAINNET_CKBTC_WASMS: Wasms = Wasms::new(
         Wasm::from_bytes(load_wasm_using_env_var(
             "CKBTC_IC_ICRC1_INDEX_DEPLOYED_VERSION_WASM_PATH",
         )),
         Wasm::from_bytes(load_wasm_using_env_var(
             "CKBTC_IC_ICRC1_LEDGER_DEPLOYED_VERSION_WASM_PATH",
+        ))
+    );
+    pub static ref MAINNET_SNS_WASMS: Wasms = Wasms::new(
+        Wasm::from_bytes(load_wasm_using_env_var(
+            "IC_ICRC1_INDEX_DEPLOYED_VERSION_WASM_PATH",
+        )),
+        Wasm::from_bytes(load_wasm_using_env_var(
+            "IC_ICRC1_LEDGER_DEPLOYED_VERSION_WASM_PATH",
         ))
     );
     pub static ref MASTER_WASMS: Wasms = Wasms::new(
@@ -59,14 +67,6 @@ lazy_static! {
         )),
         Wasm::from_bytes(load_wasm_using_env_var(
             "CKETH_IC_ICRC1_LEDGER_DEPLOYED_VERSION_WASM_PATH",
-        ))
-    );
-    pub static ref MAINNET_U64_WASMS: Wasms = Wasms::new(
-        Wasm::from_bytes(load_wasm_using_env_var(
-            "IC_ICRC1_INDEX_DEPLOYED_VERSION_WASM_PATH",
-        )),
-        Wasm::from_bytes(load_wasm_using_env_var(
-            "IC_ICRC1_LEDGER_DEPLOYED_VERSION_WASM_PATH",
         ))
     );
     pub static ref MASTER_WASMS: Wasms = Wasms::new(
@@ -344,7 +344,7 @@ fn should_upgrade_icrc_ck_btc_canister_with_golden_state() {
             CK_BTC_INDEX_CANISTER_ID,
             CK_BTC_LEDGER_CANISTER_NAME,
         ),
-        &MAINNET_WASMS,
+        &MAINNET_CKBTC_WASMS,
         &MASTER_WASMS,
         Some(burns_without_spender),
         true,
@@ -485,7 +485,7 @@ fn should_upgrade_icrc_ck_u256_canisters_with_golden_state() {
     }
 }
 
-#[cfg(feature = "u256-tokens")]
+#[cfg(not(feature = "u256-tokens"))]
 #[test]
 fn should_upgrade_icrc_sns_canisters_with_golden_state() {
     // SNS canisters
@@ -637,7 +637,7 @@ fn should_upgrade_icrc_sns_canisters_with_golden_state() {
 
     let mut canister_configs = vec![LedgerSuiteConfig::new_with_params(
         OPENCHAT_LEDGER_SUITE,
-        &MAINNET_U64_WASMS,
+        &MAINNET_SNS_WASMS,
         &MASTER_WASMS,
         None,
         true,
@@ -674,7 +674,7 @@ fn should_upgrade_icrc_sns_canisters_with_golden_state() {
     ] {
         canister_configs.push(LedgerSuiteConfig::new(
             canister_id_and_name,
-            &MAINNET_U64_WASMS,
+            &MAINNET_SNS_WASMS,
             &MASTER_WASMS,
         ));
     }

--- a/rs/ledger_suite/tests/sm-tests/src/in_memory_ledger.rs
+++ b/rs/ledger_suite/tests/sm-tests/src/in_memory_ledger.rs
@@ -495,11 +495,13 @@ impl InMemoryLedger<ApprovalKey, Account, Tokens> {
                     TimeStamp::from_nanos_since_unix_epoch(block.timestamp),
                 ),
             }
-            self.validate_invariants();
         }
-        self.prune_expired_allowances(TimeStamp::from_nanos_since_unix_epoch(
-            blocks.last().unwrap().timestamp,
-        ));
+        if !blocks.is_empty() {
+            self.validate_invariants();
+            self.prune_expired_allowances(TimeStamp::from_nanos_since_unix_epoch(
+                blocks.last().unwrap().timestamp,
+            ));
+        }
     }
 
     pub fn apply_arg_with_caller(


### PR DESCRIPTION
Fix a bug and tune the performance in the ICRC golden state tests.

- The SNSs use canisters with `u64` tokens
- The verification of the invariants in the `InMemoryLedger` gets increasingly expensive with large amounts of balances (and allowances), to the point where verifying them after ingestion of each new block significantly slows down the tests. This PR proposes to only perform the invariant check once per batch of ingested blocks.