### PR TITLE
chore(IDX): update concurrency logic

### DIFF
--- a/.github/workflows-source/ci-main.yml
+++ b/.github/workflows-source/ci-main.yml
@@ -16,7 +16,7 @@ on:
 
 # runs for the same workflow are cancelled on PRs but not on master
 concurrency:
-  group: ${{ github.head_ref || github.ref }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 permissions: read-all

--- a/.github/workflows-source/ci-main.yml
+++ b/.github/workflows-source/ci-main.yml
@@ -16,7 +16,7 @@ on:
 
 # runs for the same workflow are cancelled on PRs but not on master
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref && github.ref || github.run_id }}
+  group: ${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 permissions: read-all

--- a/.github/workflows-source/ci-pr-only.yml
+++ b/.github/workflows-source/ci-pr-only.yml
@@ -8,7 +8,7 @@ on:
 permissions: read-all
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref && github.ref || github.run_id }}
+  group: ${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 env:
   CI_PIPELINE_SOURCE: ${{ github.event_name }}

--- a/.github/workflows-source/ci-pr-only.yml
+++ b/.github/workflows-source/ci-pr-only.yml
@@ -8,7 +8,7 @@ on:
 permissions: read-all
 
 concurrency:
-  group: ${{ github.head_ref || github.ref }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 env:
   CI_PIPELINE_SOURCE: ${{ github.event_name }}

--- a/.github/workflows-source/release-testing.yml
+++ b/.github/workflows-source/release-testing.yml
@@ -9,7 +9,7 @@ on:
 
 # new commits interrupt any running workflow on the same branch
 concurrency:
-  group: ${{ github.ref }}
+  group: ${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows-source/release-testing.yml
+++ b/.github/workflows-source/release-testing.yml
@@ -9,7 +9,7 @@ on:
 
 # new commits interrupt any running workflow on the same branch
 concurrency:
-  group: ${{ github.head_ref || github.ref }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -14,7 +14,7 @@ on:
   workflow_call:
 # runs for the same workflow are cancelled on PRs but not on master
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref && github.ref || github.run_id }}
+  group: ${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 permissions: read-all
 env:

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -14,7 +14,7 @@ on:
   workflow_call:
 # runs for the same workflow are cancelled on PRs but not on master
 concurrency:
-  group: ${{ github.head_ref || github.ref }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 permissions: read-all
 env:

--- a/.github/workflows/ci-pr-only.yml
+++ b/.github/workflows/ci-pr-only.yml
@@ -6,7 +6,7 @@ on:
     types: [opened, synchronize, reopened]
 permissions: read-all
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref && github.ref || github.run_id }}
+  group: ${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 env:
   CI_PIPELINE_SOURCE: ${{ github.event_name }}

--- a/.github/workflows/ci-pr-only.yml
+++ b/.github/workflows/ci-pr-only.yml
@@ -6,7 +6,7 @@ on:
     types: [opened, synchronize, reopened]
 permissions: read-all
 concurrency:
-  group: ${{ github.head_ref || github.ref }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 env:
   CI_PIPELINE_SOURCE: ${{ github.event_name }}

--- a/.github/workflows/container-autobuild.yml
+++ b/.github/workflows/container-autobuild.yml
@@ -10,7 +10,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: group: ${{ github.head_ref || github.ref }}
+  group: group: $${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/container-autobuild.yml
+++ b/.github/workflows/container-autobuild.yml
@@ -10,7 +10,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref && github.ref || github.run_id }}
+  group: group: ${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/container-autobuild.yml
+++ b/.github/workflows/container-autobuild.yml
@@ -10,7 +10,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: group: $${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  group: $${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/container-base-images.yml
+++ b/.github/workflows/container-base-images.yml
@@ -15,7 +15,7 @@ on:
       - '**/packages.dev'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref && github.ref || github.run_id }}
+  group: ${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/container-base-images.yml
+++ b/.github/workflows/container-base-images.yml
@@ -15,7 +15,7 @@ on:
       - '**/packages.dev'
 
 concurrency:
-  group: ${{ github.head_ref || github.ref }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/release-testing.yml
+++ b/.github/workflows/release-testing.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 # new commits interrupt any running workflow on the same branch
 concurrency:
-  group: ${{ github.ref }}
+  group: ${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 env:
   CI_COMMIT_SHA: ${{ github.sha }}

--- a/.github/workflows/release-testing.yml
+++ b/.github/workflows/release-testing.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 # new commits interrupt any running workflow on the same branch
 concurrency:
-  group: ${{ github.head_ref || github.ref }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 env:
   CI_COMMIT_SHA: ${{ github.sha }}


### PR DESCRIPTION
This simplifies the concurrency logic. The fallback to `github.run_id` is not really needed - the only scenarios where this would happen is for scheduled jobs or manually triggered jobs and concurrency rules shouldn't be necessary there.