### PR TITLE
fix(IDX): update bazel lockfile

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -155,6 +155,23 @@
   },
   "selectedYankedVersions": {},
   "moduleExtensions": {
+    "//rs/tests:kubeconfig_extension.bzl%kubeconfig_extension": {
+      "general": {
+        "bzlTransitiveDigest": "xEGrJHac1Q0AeSsq47wmCUw9/QuvIsSjn2H4zlg7RgM=",
+        "usagesDigest": "nx/HYUUCtKW9bl/h/wrK069HawIvbPlJo+fUzOBVDlQ=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "kubeconfig": {
+            "bzlFile": "@@//rs/tests:kubeconfig.bzl",
+            "ruleClassName": "kubeconfig_rule",
+            "attributes": {}
+          }
+        },
+        "recordedRepoMappingEntries": []
+      }
+    },
     "@@apple_support~//crosstool:setup.bzl%apple_cc_configure_extension": {
       "general": {
         "bzlTransitiveDigest": "Co35oEwSoYZFy42IHjYfE7VkKR1WykyxhRlbUGSa3XA=",


### PR DESCRIPTION
An entry for the k8s config was missing from the lockfile. This fixes the lockfile. A fix for the automated update logic will come separately.