### PR TITLE
feat(sns): Add Swap.reset_timers

### DIFF
--- a/rs/sns/integration_tests/src/lib.rs
+++ b/rs/sns/integration_tests/src/lib.rs
@@ -54,3 +54,6 @@ mod manage_dapp_canister_settings;
 
 #[cfg(test)]
 mod http_request;
+
+#[cfg(test)]
+mod timers;

--- a/rs/sns/integration_tests/src/timers.rs
+++ b/rs/sns/integration_tests/src/timers.rs
@@ -47,7 +47,7 @@ fn swap_init(now: SystemTime) -> Init {
 }
 
 #[test]
-fn test_swap_disabled_eventually() {
+fn test_swap_periodic_tasks_disabled_eventually() {
     let state_machine = state_machine_builder_for_sns_tests().build();
 
     // Install the swap canister.

--- a/rs/sns/integration_tests/src/timers.rs
+++ b/rs/sns/integration_tests/src/timers.rs
@@ -1,0 +1,244 @@
+use assert_matches::assert_matches;
+use candid::{Decode, Encode, Principal};
+use ic_sns_swap::pb::v1::{
+    GetStateRequest, GetStateResponse, Init, Lifecycle, NeuronBasketConstructionParameters,
+    ResetTimersRequest, ResetTimersResponse, Timers,
+};
+use ic_sns_test_utils::state_test_helpers::state_machine_builder_for_sns_tests;
+use pretty_assertions::assert_eq;
+use std::time::{Duration, SystemTime};
+
+const TWO_WEEKS_SECONDS: u64 = 14 * 24 * 60 * 60;
+
+fn swap_init(now: SystemTime) -> Init {
+    let now = now.duration_since(SystemTime::UNIX_EPOCH).unwrap();
+    let swap_due_timestamp_seconds = Some((now + Duration::from_secs(TWO_WEEKS_SECONDS)).as_secs());
+
+    Init {
+        swap_due_timestamp_seconds,
+        nns_governance_canister_id: Principal::anonymous().to_string(),
+        sns_governance_canister_id: Principal::anonymous().to_string(),
+        sns_ledger_canister_id: Principal::anonymous().to_string(),
+        icp_ledger_canister_id: Principal::anonymous().to_string(),
+        sns_root_canister_id: Principal::anonymous().to_string(),
+        fallback_controller_principal_ids: vec![Principal::anonymous().to_string()],
+        transaction_fee_e8s: Some(10_000),
+        neuron_minimum_stake_e8s: Some(1_000_000),
+        confirmation_text: None,
+        restricted_countries: None,
+        min_participants: Some(5),
+        min_icp_e8s: None,
+        max_icp_e8s: None,
+        min_direct_participation_icp_e8s: Some(12_300_000_000),
+        max_direct_participation_icp_e8s: Some(65_000_000_000),
+        min_participant_icp_e8s: Some(6_500_000_000),
+        max_participant_icp_e8s: Some(65_000_000_000),
+        swap_start_timestamp_seconds: Some(0),
+        sns_token_e8s: Some(10_000_000),
+        neuron_basket_construction_parameters: Some(NeuronBasketConstructionParameters {
+            count: 5,
+            dissolve_delay_interval_seconds: 10_001,
+        }),
+        nns_proposal_id: Some(10),
+        should_auto_finalize: Some(true),
+        neurons_fund_participation_constraints: None,
+        neurons_fund_participation: Some(false),
+    }
+}
+
+#[test]
+fn test_swap_disabled_eventually() {
+    let state_machine = state_machine_builder_for_sns_tests().build();
+
+    // Install the swap canister.
+    let wasm = ic_test_utilities_load_wasm::load_wasm("../swap", "sns-swap-canister", &[]);
+    let args = Encode!(&swap_init(state_machine.time())).unwrap();
+    let canister_id = state_machine
+        .install_canister(wasm.clone(), args, None)
+        .unwrap();
+
+    state_machine.advance_time(Duration::from_secs(100));
+    state_machine.tick();
+
+    // Inspect the initial state.
+    {
+        let (timers, lifecycle, already_tried_to_auto_finalize) = {
+            let payload = Encode!(&GetStateRequest {}).unwrap();
+            let response = state_machine
+                .execute_ingress(canister_id, "get_state", payload)
+                .expect("Unable to call get_state on the Swap canister");
+            let response = Decode!(&response.bytes(), GetStateResponse).unwrap();
+            let swap_state = response.swap.unwrap();
+            (
+                swap_state.timers,
+                swap_state.lifecycle(),
+                swap_state.already_tried_to_auto_finalize,
+            )
+        };
+
+        assert_eq!(lifecycle, Lifecycle::Open);
+
+        assert_eq!(already_tried_to_auto_finalize, Some(false));
+
+        assert_matches!(
+            timers,
+            Some(Timers {
+                requires_periodic_tasks: Some(true),
+                last_reset_timestamp_seconds: Some(_),
+                last_spawned_timestamp_seconds: Some(_),
+            })
+        );
+    }
+
+    state_machine.advance_time(Duration::from_secs(TWO_WEEKS_SECONDS));
+    state_machine.tick();
+
+    // Inspect the final state.
+    {
+        let (timers, lifecycle, already_tried_to_auto_finalize) = {
+            let payload = Encode!(&GetStateRequest {}).unwrap();
+            let response = state_machine
+                .execute_ingress(canister_id, "get_state", payload)
+                .expect("Unable to call get_state on the Swap canister");
+            let response = Decode!(&response.bytes(), GetStateResponse).unwrap();
+            let swap_state = response.swap.unwrap();
+            (
+                swap_state.timers,
+                swap_state.lifecycle(),
+                swap_state.already_tried_to_auto_finalize,
+            )
+        };
+
+        assert_eq!(lifecycle, Lifecycle::Aborted);
+
+        assert_eq!(already_tried_to_auto_finalize, Some(true));
+
+        assert_matches!(
+            timers,
+            Some(Timers {
+                // This is the main postcondition of this test.
+                requires_periodic_tasks: Some(false),
+                last_reset_timestamp_seconds: Some(_),
+                last_spawned_timestamp_seconds: Some(_),
+            })
+        );
+    }
+}
+
+#[test]
+fn test_swap_reset_timers() {
+    let state_machine = state_machine_builder_for_sns_tests().build();
+
+    // Install the swap canister.
+    let wasm = ic_test_utilities_load_wasm::load_wasm("../swap", "sns-swap-canister", &[]);
+    let args = Encode!(&swap_init(state_machine.time())).unwrap();
+    let canister_id = state_machine
+        .install_canister(wasm.clone(), args, None)
+        .unwrap();
+
+    let last_spawned_timestamp_seconds = {
+        let timers_right_after_init = {
+            let payload = Encode!(&GetStateRequest {}).unwrap();
+            let response = state_machine
+                .execute_ingress(canister_id, "get_state", payload)
+                .expect("Unable to call get_state on the Swap canister");
+            let response = Decode!(&response.bytes(), GetStateResponse).unwrap();
+            response.swap.unwrap().timers
+        };
+
+        let last_reset_timestamp_seconds = assert_matches!(timers_right_after_init, Some(Timers {
+            requires_periodic_tasks: Some(true),
+            last_reset_timestamp_seconds: Some(last_reset_timestamp_seconds),
+            last_spawned_timestamp_seconds: None,
+        }) => last_reset_timestamp_seconds);
+
+        state_machine.advance_time(Duration::from_secs(100));
+        state_machine.tick();
+
+        let timers_before_reset = {
+            let payload = Encode!(&GetStateRequest {}).unwrap();
+            let response = state_machine
+                .execute_ingress(canister_id, "get_state", payload)
+                .expect("Unable to call get_state on the Swap canister");
+            let response = Decode!(&response.bytes(), GetStateResponse).unwrap();
+            response.swap.unwrap().timers
+        };
+
+        let last_spawned_timestamp_seconds = assert_matches!(timers_before_reset, Some(Timers {
+            requires_periodic_tasks: Some(true),
+            last_reset_timestamp_seconds: Some(last_reset_timestamp_seconds_1),
+            last_spawned_timestamp_seconds: Some(last_spawned_timestamp_seconds),
+        }) => {
+            assert_eq!(last_reset_timestamp_seconds_1, last_reset_timestamp_seconds);
+            last_spawned_timestamp_seconds
+        });
+
+        assert_eq!(
+            last_spawned_timestamp_seconds,
+            last_reset_timestamp_seconds + 100
+        );
+        last_spawned_timestamp_seconds
+    };
+
+    // Reset the timers.
+    {
+        let payload = Encode!(&ResetTimersRequest {}).unwrap();
+        let response = state_machine
+            .execute_ingress(canister_id, "reset_timers", payload)
+            .expect("Unable to call reset_timers on the Swap canister");
+        Decode!(&response.bytes(), ResetTimersResponse).unwrap();
+    }
+
+    // Inspect the sate after resetting the timers.
+    {
+        let last_spawned_before_reset_timestamp_seconds = last_spawned_timestamp_seconds;
+
+        let timers_right_after_reset = {
+            let payload = Encode!(&GetStateRequest {}).unwrap();
+            let response = state_machine
+                .execute_ingress(canister_id, "get_state", payload)
+                .expect("Unable to call get_state on the Swap canister");
+            let response = Decode!(&response.bytes(), GetStateResponse).unwrap();
+            response.swap.unwrap().timers
+        };
+
+        let last_reset_timestamp_seconds = assert_matches!(timers_right_after_reset, Some(Timers {
+            requires_periodic_tasks: Some(true),
+            last_reset_timestamp_seconds: Some(last_reset_timestamp_seconds),
+            last_spawned_timestamp_seconds: None,
+        }) => last_reset_timestamp_seconds);
+
+        // last_spawned_before_reset_timestamp_seconds is from before the reset, as time did not yet
+        // advance since the timers were reset.
+        assert_eq!(
+            last_reset_timestamp_seconds,
+            last_spawned_before_reset_timestamp_seconds
+        );
+
+        state_machine.advance_time(Duration::from_secs(100));
+        state_machine.tick();
+
+        let timers_a_while_after_reset = {
+            let payload = Encode!(&GetStateRequest {}).unwrap();
+            let response = state_machine
+                .execute_ingress(canister_id, "get_state", payload)
+                .expect("Unable to call get_state on the Swap canister");
+            let response = Decode!(&response.bytes(), GetStateResponse).unwrap();
+            response.swap.unwrap().timers
+        };
+
+        let last_spawned_timestamp_seconds = assert_matches!(timers_a_while_after_reset, Some(Timers {
+            requires_periodic_tasks: Some(true),
+            last_reset_timestamp_seconds: Some(last_reset_timestamp_seconds_1),
+            last_spawned_timestamp_seconds: Some(last_spawned_timestamp_seconds),
+        }) => {
+            assert_eq!(last_reset_timestamp_seconds_1, last_reset_timestamp_seconds);
+            last_spawned_timestamp_seconds
+        });
+
+        assert_eq!(
+            last_spawned_timestamp_seconds,
+            last_spawned_before_reset_timestamp_seconds + 100
+        );
+    }
+}

--- a/rs/sns/swap/canister/canister.rs
+++ b/rs/sns/swap/canister/canister.rs
@@ -301,7 +301,45 @@ fn init_timers() {
             let mut saved_timer_id = saved_timer_id.borrow_mut();
             *saved_timer_id = timer_id;
         });
+    } else {
+        log!(
+            INFO,
+            "Periodic tasks are not required for this Swap anymore."
+        );
     }
+}
+
+#[derive(
+    candid::CandidType,
+    candid::Deserialize,
+    serde::Serialize,
+    comparable::Comparable,
+    Clone,
+    Copy,
+    PartialEq,
+    ::prost::Message,
+)]
+struct ResetTimersRequest {}
+
+#[derive(
+    candid::CandidType,
+    candid::Deserialize,
+    serde::Serialize,
+    comparable::Comparable,
+    Clone,
+    Copy,
+    PartialEq,
+    ::prost::Message,
+)]
+struct ResetTimersResponse {}
+
+#[update]
+async fn reset_timers(_request: ResetTimersRequest) -> ResetTimersResponse {
+    let sns_governance_canister_id = &swap().init_or_panic().sns_governance_canister_id;
+    let sns_governance_canister_id = PrincipalId::from_str(sns_governance_canister_id).unwrap();
+    assert_eq!(caller_principal_id(), sns_governance_canister_id);
+    init_timers();
+    ResetTimersResponse {}
 }
 
 /// In contrast to canister_init(), this method does not do deserialization.

--- a/rs/sns/swap/canister/swap.did
+++ b/rs/sns/swap/canister/swap.did
@@ -466,4 +466,5 @@ service : (Init) -> {
   refresh_buyer_tokens : (RefreshBuyerTokensRequest) -> (
       RefreshBuyerTokensResponse,
     );
+  reset_timers : (record {}) -> (record {});
 }

--- a/rs/sns/swap/canister/swap.did
+++ b/rs/sns/swap/canister/swap.did
@@ -412,6 +412,13 @@ type Swap = record {
   buyers : vec record { text; BuyerState };
   params : opt Params;
   open_sns_token_swap_proposal_id : opt nat64;
+  timers : opt Timers;
+};
+
+type Timers = record {
+  requires_periodic_tasks : opt bool;
+  last_reset_timestamp_seconds : opt nat64;
+  last_spawned_timestamp_seconds : opt nat64;
 };
 
 type SweepResult = record {

--- a/rs/sns/swap/proto/ic_sns_swap/pb/v1/swap.proto
+++ b/rs/sns/swap/proto/ic_sns_swap/pb/v1/swap.proto
@@ -275,6 +275,15 @@ message Swap {
 
   // Amount of contributions from the Neurons' Fund committed to this SNS so far.
   optional uint64 neurons_fund_participation_icp_e8s = 20;
+
+  // Information about the timers that perform periodic tasks of this Swap canister.
+  optional Timers timers = 22;
+}
+
+message Timers {
+  optional bool requires_periodic_tasks = 1;
+  optional uint64 last_reset_timestamp_seconds = 2;
+  optional uint64 last_spawned_timestamp_seconds = 3;
 }
 
 // The initialisation data of the canister. Always specified on
@@ -784,6 +793,9 @@ message GetStateResponse {
   Swap swap = 1;
   DerivedState derived = 2;
 }
+
+message ResetTimersRequest {}
+message ResetTimersResponse {}
 
 message GetBuyerStateRequest {
   // The principal_id of the user who's buyer state is being queried for.

--- a/rs/sns/swap/src/gen/ic_sns_swap.pb.v1.rs
+++ b/rs/sns/swap/src/gen/ic_sns_swap.pb.v1.rs
@@ -236,6 +236,27 @@ pub struct Swap {
     /// Amount of contributions from the Neurons' Fund committed to this SNS so far.
     #[prost(uint64, optional, tag = "20")]
     pub neurons_fund_participation_icp_e8s: ::core::option::Option<u64>,
+    /// Information about the timers that perform periodic tasks of this Swap canister.
+    #[prost(message, optional, tag = "22")]
+    pub timers: ::core::option::Option<Timers>,
+}
+#[derive(
+    candid::CandidType,
+    candid::Deserialize,
+    serde::Serialize,
+    comparable::Comparable,
+    Clone,
+    Copy,
+    PartialEq,
+    ::prost::Message,
+)]
+pub struct Timers {
+    #[prost(bool, optional, tag = "1")]
+    pub requires_periodic_tasks: ::core::option::Option<bool>,
+    #[prost(uint64, optional, tag = "2")]
+    pub last_reset_timestamp_seconds: ::core::option::Option<u64>,
+    #[prost(uint64, optional, tag = "3")]
+    pub last_spawned_timestamp_seconds: ::core::option::Option<u64>,
 }
 /// The initialisation data of the canister. Always specified on
 /// canister creation, and cannot be modified afterwards.
@@ -977,6 +998,28 @@ pub struct GetStateResponse {
     #[prost(message, optional, tag = "2")]
     pub derived: ::core::option::Option<DerivedState>,
 }
+#[derive(
+    candid::CandidType,
+    candid::Deserialize,
+    serde::Serialize,
+    comparable::Comparable,
+    Clone,
+    Copy,
+    PartialEq,
+    ::prost::Message,
+)]
+pub struct ResetTimersRequest {}
+#[derive(
+    candid::CandidType,
+    candid::Deserialize,
+    serde::Serialize,
+    comparable::Comparable,
+    Clone,
+    Copy,
+    PartialEq,
+    ::prost::Message,
+)]
+pub struct ResetTimersResponse {}
 #[derive(
     candid::CandidType,
     candid::Deserialize,

--- a/rs/sns/swap/src/swap.rs
+++ b/rs/sns/swap/src/swap.rs
@@ -429,6 +429,7 @@ impl Swap {
             auto_finalize_swap_response: None,
             direct_participation_icp_e8s: None,
             neurons_fund_participation_icp_e8s: None,
+            timers: None,
         };
         if init.validate_swap_init_for_one_proposal_flow().is_ok() {
             // Automatically fill out the fields that the (legacy) open request
@@ -3771,6 +3772,7 @@ impl<'a> fmt::Debug for SwapDigest<'a> {
             purge_old_tickets_next_principal,
             already_tried_to_auto_finalize,
             auto_finalize_swap_response,
+            timers,
 
             // These are (potentially large) collections. To avoid an
             // overwhelmingly large log message, we need summarize and/or
@@ -3829,6 +3831,7 @@ impl<'a> fmt::Debug for SwapDigest<'a> {
                 "neurons_fund_participation_icp_e8s",
                 neurons_fund_participation_icp_e8s,
             )
+            .field("timers", timers)
             .finish()
     }
 }

--- a/rs/sns/swap/tests/swap.rs
+++ b/rs/sns/swap/tests/swap.rs
@@ -209,6 +209,7 @@ fn create_generic_committed_swap() -> Swap {
         auto_finalize_swap_response: None,
         direct_participation_icp_e8s: Some(50 * E8),
         neurons_fund_participation_icp_e8s: None,
+        timers: None,
     }
 }
 


### PR DESCRIPTION
Now that the Swap canister's periodic tasks are migrated from heartbeats to timers, a theoretical risk can arise if a panic occurs during one of the timers' setup process. This could occur, e.g., if the Swap runs out of cycles during that code's execution. To be able to recover from such a situation, the NNS could already pass two proposals (one to publish a new Swap WASM, potentially identical to the one already installed, thereby creating a new step in the upgrade order; another one for triggering the Swap upgrade). However, it would be better if the SNS could recover itself. To that end, we add a new function for resetting Swap's timers, only callable by the SNS Governance. A follow-up PR will add an SNS proposal for calling this new function. 

< [Previous PR](https://github.com/dfinity/ic/pull/1932) |