### PR TITLE
fix(IDX): disable lockfile for all bazel commands

### DIFF
--- a/bazel/conf/.bazelrc.build
+++ b/bazel/conf/.bazelrc.build
@@ -20,7 +20,7 @@ build --@rules_rust//:rustfmt.toml=//:rustfmt.toml
 
 # Until the lockfile format has settled, don't use a
 # lockfile for MODULE.bazel
-build --lockfile_mode=off
+common --lockfile_mode=off
 
 # Use hermetic JDK
 # See https://bazel.build/docs/bazel-and-java#hermetic-testing


### PR DESCRIPTION
Previously we disabled the lockfile on `build` commands. However `bazel query` commands will also try to generate a lockfile, so instead we disable the lockfile on `common`, which is inherited by all bazel commands, not just build commands.