### PR TITLE
feat(cketh): threshold consensus strategy for HTTPs outcalls

### DIFF
--- a/rs/ethereum/cketh/minter/src/eth_rpc_client/mod.rs
+++ b/rs/ethereum/cketh/minter/src/eth_rpc_client/mod.rs
@@ -56,12 +56,13 @@ impl EthRpcClient {
     pub fn from_state(state: &State) -> Self {
         let mut client = Self::new(state.ethereum_network());
         if let Some(evm_rpc_id) = state.evm_rpc_id {
-            const MIN_ATTACHED_CYCLES: u128 = 400_000_000_000;
+            const MIN_ATTACHED_CYCLES: u128 = 500_000_000_000;
 
             let providers = match client.chain {
                 EthereumNetwork::Mainnet => EthereumProvider::evm_rpc_node_providers(),
                 EthereumNetwork::Sepolia => SepoliaProvider::evm_rpc_node_providers(),
             };
+            //TODO XC-207: min in threshold should be 2 for Sepolia and 3 for Mainnet
             let threshold_3_out_of_4 = EvmRpcConfig {
                 response_consensus: Some(ConsensusStrategy::Threshold {
                     total: Some(4),

--- a/rs/ethereum/cketh/minter/src/eth_rpc_client/mod.rs
+++ b/rs/ethereum/cketh/minter/src/eth_rpc_client/mod.rs
@@ -62,11 +62,14 @@ impl EthRpcClient {
                 EthereumNetwork::Mainnet => EthereumProvider::evm_rpc_node_providers(),
                 EthereumNetwork::Sepolia => SepoliaProvider::evm_rpc_node_providers(),
             };
-            //TODO XC-207: min in threshold should be 2 for Sepolia and 3 for Mainnet
-            let threshold_3_out_of_4 = EvmRpcConfig {
+            let min_threshold = match client.chain {
+                EthereumNetwork::Mainnet => 3_u8,
+                EthereumNetwork::Sepolia => 2_u8,
+            };
+            let threshold_strategy = EvmRpcConfig {
                 response_consensus: Some(ConsensusStrategy::Threshold {
-                    total: Some(4),
-                    min: 3,
+                    total: None,
+                    min: min_threshold,
                 }),
                 ..EvmRpcConfig::default()
             };
@@ -76,17 +79,17 @@ impl EthRpcClient {
                     .with_evm_canister_id(evm_rpc_id)
                     .with_min_attached_cycles(MIN_ATTACHED_CYCLES)
                     .with_override_rpc_config(OverrideRpcConfig {
-                        eth_get_block_by_number: Some(threshold_3_out_of_4.clone()),
+                        eth_get_block_by_number: Some(threshold_strategy.clone()),
                         eth_get_logs: Some(EvmRpcConfig {
                             response_size_estimate: Some(
                                 ETH_GET_LOGS_INITIAL_RESPONSE_SIZE_ESTIMATE + HEADER_SIZE_LIMIT,
                             ),
-                            ..threshold_3_out_of_4.clone()
+                            ..threshold_strategy.clone()
                         }),
-                        eth_fee_history: Some(threshold_3_out_of_4.clone()),
-                        eth_get_transaction_receipt: Some(threshold_3_out_of_4.clone()),
-                        eth_get_transaction_count: Some(threshold_3_out_of_4.clone()),
-                        eth_send_raw_transaction: Some(threshold_3_out_of_4),
+                        eth_fee_history: Some(threshold_strategy.clone()),
+                        eth_get_transaction_receipt: Some(threshold_strategy.clone()),
+                        eth_get_transaction_count: Some(threshold_strategy.clone()),
+                        eth_send_raw_transaction: Some(threshold_strategy),
                     })
                     .build(),
             );

--- a/rs/ethereum/cketh/minter/src/eth_rpc_client/mod.rs
+++ b/rs/ethereum/cketh/minter/src/eth_rpc_client/mod.rs
@@ -62,19 +62,30 @@ impl EthRpcClient {
                 EthereumNetwork::Mainnet => EthereumProvider::evm_rpc_node_providers(),
                 EthereumNetwork::Sepolia => SepoliaProvider::evm_rpc_node_providers(),
             };
+            let threshold_3_out_of_4 = EvmRpcConfig {
+                response_consensus: Some(ConsensusStrategy::Threshold {
+                    total: Some(4),
+                    min: 3,
+                }),
+                ..EvmRpcConfig::default()
+            };
             client.evm_rpc_client = Some(
                 EvmRpcClient::builder_for_ic(TRACE_HTTP)
                     .with_providers(providers)
                     .with_evm_canister_id(evm_rpc_id)
                     .with_min_attached_cycles(MIN_ATTACHED_CYCLES)
                     .with_override_rpc_config(OverrideRpcConfig {
+                        eth_get_block_by_number: Some(threshold_3_out_of_4.clone()),
                         eth_get_logs: Some(EvmRpcConfig {
                             response_size_estimate: Some(
                                 ETH_GET_LOGS_INITIAL_RESPONSE_SIZE_ESTIMATE + HEADER_SIZE_LIMIT,
                             ),
-                            response_consensus: Some(ConsensusStrategy::Equality),
+                            ..threshold_3_out_of_4.clone()
                         }),
-                        ..Default::default()
+                        eth_fee_history: Some(threshold_3_out_of_4.clone()),
+                        eth_get_transaction_receipt: Some(threshold_3_out_of_4.clone()),
+                        eth_get_transaction_count: Some(threshold_3_out_of_4.clone()),
+                        eth_send_raw_transaction: Some(threshold_3_out_of_4),
                     })
                     .build(),
             );

--- a/rs/ethereum/cketh/minter/src/eth_rpc_client/providers.rs
+++ b/rs/ethereum/cketh/minter/src/eth_rpc_client/providers.rs
@@ -1,15 +1,18 @@
 use crate::lifecycle::EthereumNetwork;
 use evm_rpc_client::{RpcService as EvmRpcService, RpcServices as EvmRpcServices};
 
-pub(crate) const MAINNET_PROVIDERS: [RpcNodeProvider; 3] = [
+pub(crate) const MAINNET_PROVIDERS: [RpcNodeProvider; 4] = [
     RpcNodeProvider::Ethereum(EthereumProvider::BlockPi),
     RpcNodeProvider::Ethereum(EthereumProvider::PublicNode),
     RpcNodeProvider::Ethereum(EthereumProvider::LlamaNodes),
+    RpcNodeProvider::Ethereum(EthereumProvider::Alchemy),
 ];
 
-pub(crate) const SEPOLIA_PROVIDERS: [RpcNodeProvider; 2] = [
+pub(crate) const SEPOLIA_PROVIDERS: [RpcNodeProvider; 4] = [
     RpcNodeProvider::Sepolia(SepoliaProvider::BlockPi),
     RpcNodeProvider::Sepolia(SepoliaProvider::PublicNode),
+    RpcNodeProvider::Sepolia(SepoliaProvider::Alchemy),
+    RpcNodeProvider::Sepolia(SepoliaProvider::RpcSepolia),
 ];
 
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Debug)]
@@ -40,6 +43,7 @@ pub(crate) enum EthereumProvider {
     PublicNode,
     // https://llamanodes.com/
     LlamaNodes,
+    Alchemy,
 }
 
 impl EthereumProvider {
@@ -48,6 +52,7 @@ impl EthereumProvider {
             EthereumProvider::BlockPi => "https://ethereum.blockpi.network/v1/rpc/public",
             EthereumProvider::PublicNode => "https://ethereum-rpc.publicnode.com",
             EthereumProvider::LlamaNodes => "https://eth.llamarpc.com",
+            EthereumProvider::Alchemy => "https://eth-mainnet.g.alchemy.com/v2",
         }
     }
 
@@ -64,6 +69,9 @@ pub(crate) enum SepoliaProvider {
     BlockPi,
     // https://publicnode.com/
     PublicNode,
+    // https://www.alchemy.com/chain-connect/endpoints/rpc-sepolia-sepolia
+    Alchemy,
+    RpcSepolia,
 }
 
 impl SepoliaProvider {
@@ -71,6 +79,8 @@ impl SepoliaProvider {
         match self {
             SepoliaProvider::BlockPi => "https://ethereum-sepolia.blockpi.network/v1/rpc/public",
             SepoliaProvider::PublicNode => "https://ethereum-sepolia-rpc.publicnode.com",
+            SepoliaProvider::Alchemy => "https://eth-sepolia.g.alchemy.com/v2/demo",
+            SepoliaProvider::RpcSepolia => "https://rpc.sepolia.org",
         }
     }
 

--- a/rs/ethereum/cketh/minter/src/eth_rpc_client/tests.rs
+++ b/rs/ethereum/cketh/minter/src/eth_rpc_client/tests.rs
@@ -19,7 +19,9 @@ mod eth_rpc_client {
             providers,
             &[
                 RpcNodeProvider::Sepolia(SepoliaProvider::BlockPi),
-                RpcNodeProvider::Sepolia(SepoliaProvider::PublicNode)
+                RpcNodeProvider::Sepolia(SepoliaProvider::PublicNode),
+                RpcNodeProvider::Sepolia(SepoliaProvider::Alchemy),
+                RpcNodeProvider::Sepolia(SepoliaProvider::RpcSepolia)
             ]
         );
     }
@@ -35,7 +37,8 @@ mod eth_rpc_client {
             &[
                 RpcNodeProvider::Ethereum(EthereumProvider::BlockPi),
                 RpcNodeProvider::Ethereum(EthereumProvider::PublicNode),
-                RpcNodeProvider::Ethereum(EthereumProvider::LlamaNodes)
+                RpcNodeProvider::Ethereum(EthereumProvider::LlamaNodes),
+                RpcNodeProvider::Ethereum(EthereumProvider::Alchemy)
             ]
         );
     }

--- a/rs/ethereum/cketh/minter/tests/cketh.rs
+++ b/rs/ethereum/cketh/minter/tests/cketh.rs
@@ -22,12 +22,12 @@ use ic_cketh_test_utils::response::{
     hash_transaction, multi_logs_for_single_transaction,
 };
 use ic_cketh_test_utils::{
-    CkEthSetup, CKETH_MINIMUM_WITHDRAWAL_AMOUNT, CKETH_TRANSFER_FEE, CKETH_WITHDRAWAL_AMOUNT,
-    DEFAULT_BLOCK_HASH, DEFAULT_BLOCK_NUMBER, DEFAULT_DEPOSIT_FROM_ADDRESS,
-    DEFAULT_DEPOSIT_LOG_INDEX, DEFAULT_DEPOSIT_TRANSACTION_HASH, DEFAULT_PRINCIPAL_ID,
-    DEFAULT_WITHDRAWAL_DESTINATION_ADDRESS, DEFAULT_WITHDRAWAL_TRANSACTION_HASH,
-    EFFECTIVE_GAS_PRICE, ETH_HELPER_CONTRACT_ADDRESS, EXPECTED_BALANCE, GAS_USED,
-    LAST_SCRAPED_BLOCK_NUMBER_AT_INSTALL, MINTER_ADDRESS,
+    use_evm_rpc_canister, CkEthSetup, CKETH_MINIMUM_WITHDRAWAL_AMOUNT, CKETH_TRANSFER_FEE,
+    CKETH_WITHDRAWAL_AMOUNT, DEFAULT_BLOCK_HASH, DEFAULT_BLOCK_NUMBER,
+    DEFAULT_DEPOSIT_FROM_ADDRESS, DEFAULT_DEPOSIT_LOG_INDEX, DEFAULT_DEPOSIT_TRANSACTION_HASH,
+    DEFAULT_PRINCIPAL_ID, DEFAULT_WITHDRAWAL_DESTINATION_ADDRESS,
+    DEFAULT_WITHDRAWAL_TRANSACTION_HASH, EFFECTIVE_GAS_PRICE, ETH_HELPER_CONTRACT_ADDRESS,
+    EXPECTED_BALANCE, GAS_USED, LAST_SCRAPED_BLOCK_NUMBER_AT_INSTALL, MINTER_ADDRESS,
 };
 use ic_ethereum_types::Address;
 use icrc_ledger_types::icrc1::account::Account;
@@ -206,7 +206,7 @@ fn should_block_deposit_from_blocked_address() {
 }
 
 #[test]
-fn should_not_mint_when_logs_inconsistent() {
+fn should_not_mint_when_logs_too_inconsistent() {
     let deposit_params = DepositParams::default();
     let (block_pi_logs, public_node_logs) = {
         let block_pi_log_entry = deposit_params.eth_log_entry();
@@ -224,8 +224,35 @@ fn should_not_mint_when_logs_inconsistent() {
             mock.respond_with(JsonRpcProvider::BlockPi, block_pi_logs.clone())
                 .respond_with(JsonRpcProvider::PublicNode, public_node_logs.clone())
                 .respond_with(JsonRpcProvider::LlamaNodes, block_pi_logs.clone())
+                .respond_with(JsonRpcProvider::Alchemy, public_node_logs.clone())
         }))
         .expect_no_mint();
+}
+
+#[test]
+fn should_mint_when_1_error_with_3_out_of_4_strategy() {
+    if use_evm_rpc_canister() {
+        let deposit_params = DepositParams::default();
+        let (block_pi_logs, public_node_logs) = {
+            let block_pi_log_entry = deposit_params.eth_log_entry();
+            let mut llama_nodes_log_entry = block_pi_log_entry.clone();
+            llama_nodes_log_entry.amount += 1;
+            (
+                vec![ethers_core::types::Log::from(block_pi_log_entry)],
+                vec![ethers_core::types::Log::from(llama_nodes_log_entry)],
+            )
+        };
+        assert_ne!(block_pi_logs, public_node_logs);
+
+        CkEthSetup::default_with_maybe_evm_rpc()
+            .deposit(deposit_params.with_mock_eth_get_logs(move |mock| {
+                mock.respond_with(JsonRpcProvider::BlockPi, block_pi_logs.clone())
+                    .respond_with(JsonRpcProvider::PublicNode, public_node_logs.clone())
+                    .respond_with(JsonRpcProvider::LlamaNodes, block_pi_logs.clone())
+                    .respond_with(JsonRpcProvider::Alchemy, block_pi_logs.clone())
+            }))
+            .expect_mint();
+    }
 }
 
 #[test]
@@ -712,7 +739,7 @@ fn should_retry_from_same_block_when_scrapping_fails() {
             "topics": [cketh.received_eth_event_topic()]
         }]))
         .respond_for_all_with(empty_logs())
-        .respond_with(JsonRpcProvider::PublicNode, json!({"error":{"code":-32000,"message":"max message response size exceed"},"id":74,"jsonrpc":"2.0"}))
+        .respond_for_providers_with([JsonRpcProvider::PublicNode, JsonRpcProvider::Alchemy], json!({"error":{"code":-32000,"message":"max message response size exceed"},"id":74,"jsonrpc":"2.0"}))
         .build()
         .expect_rpc_calls(&cketh);
 

--- a/rs/ethereum/cketh/test_utils/src/flow.rs
+++ b/rs/ethereum/cketh/test_utils/src/flow.rs
@@ -371,6 +371,12 @@ impl ProcessWithdrawalParams {
                 },
             )
             .modify_response(
+                JsonRpcProvider::Alchemy,
+                &mut |response: &mut ethers_core::types::TransactionReceipt| {
+                    response.status = Some(0.into())
+                },
+            )
+            .modify_response(
                 JsonRpcProvider::PublicNode,
                 &mut |response: &mut ethers_core::types::TransactionReceipt| {
                     response.status = Some(1.into())

--- a/rs/ethereum/cketh/test_utils/src/lib.rs
+++ b/rs/ethereum/cketh/test_utils/src/lib.rs
@@ -162,9 +162,10 @@ impl CkEthSetup {
     }
 
     pub fn maybe_evm_rpc(env: Arc<StateMachine>) -> Self {
-        match std::env::var("EVM_RPC_CANISTER_WASM_PATH") {
-            Ok(_) => CkEthSetup::new_with_evm_rpc(env),
-            Err(_) => CkEthSetup::new(env),
+        if use_evm_rpc_canister() {
+            CkEthSetup::new_with_evm_rpc(env)
+        } else {
+            CkEthSetup::new(env)
         }
     }
 
@@ -720,4 +721,8 @@ fn assert_reply(result: WasmResult) -> Vec<u8> {
             panic!("Expected a successful reply, got a reject: {}", reject)
         }
     }
+}
+
+pub fn use_evm_rpc_canister() -> bool {
+    std::env::var("EVM_RPC_CANISTER_WASM_PATH").is_ok()
 }


### PR DESCRIPTION
Use a 3-out-of 4 consensus strategy when querying the EVM RPC canister to avoid a provider being able to block the ckETH minter.