### PR TITLE
feat(IDX): show buildbuddy link as step summary

### DIFF
--- a/ci/bazel-scripts/main.sh
+++ b/ci/bazel-scripts/main.sh
@@ -106,7 +106,10 @@ buildevents cmd "${CI_RUN_ID}" "${CI_JOB_NAME}" "${CI_JOB_NAME}-bazel-cmd" -- ba
     ${BAZEL_TARGETS} \
     2>&1 | awk -v url_out="$url_out" "$stream_awk_program"
 
-# Write the bes link & GitHub notice
+# Write the bes link & summary
 echo "Build results uploaded to $(<"$url_out")"
-echo "::notice title=Build Events for $CI_JOB_NAME::$(<"$url_out")"
+if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+    invocation=$(sed <"$url_out" 's;.*/;;') # grab invocation ID (last url part)
+    echo "BuildBuddy [$invocation]($(<"$url_out"))" >>$GITHUB_STEP_SUMMARY
+fi
 rm "$url_out"


### PR DESCRIPTION
This replaces the previous GitHub notice/annotation with a GitHub step summary, which supports Markdown and hence links. This makes it easier to find and open BuildBuddy links.

<img width="546" alt="Screenshot 2024-10-11 at 15 35 33" src="https://github.com/user-attachments/assets/2cb611ec-b549-4d8c-99ff-ab4313d1c224">
