### PR TITLE
feat: Cache and evict sandboxes based on their memory usage

### DIFF
--- a/rs/canister_sandbox/src/replica_controller/sandboxed_execution_controller.rs
+++ b/rs/canister_sandbox/src/replica_controller/sandboxed_execution_controller.rs
@@ -57,7 +57,7 @@ use ic_replicated_state::{
 };
 use ic_types::ExecutionRound;
 
-const SANDBOX_PROCESS_UPDATE_INTERVAL: Duration = Duration::from_secs(10);
+const SANDBOX_PROCESS_UPDATE_INTERVAL: Duration = Duration::from_secs(1);
 
 // The percentage of sandbox processes to evict in one go in order to amortize
 // for the eviction cost.

--- a/rs/config/src/embedders.rs
+++ b/rs/config/src/embedders.rs
@@ -44,11 +44,11 @@ const DEFAULT_PAGE_ALLOCATOR_THREADS: usize = 8;
 
 /// Sandbox process eviction does not activate if the number of sandbox
 /// processes is below this threshold.
-pub(crate) const DEFAULT_MIN_SANDBOX_COUNT: usize = 15_000;
+pub(crate) const DEFAULT_MIN_SANDBOX_COUNT: usize = 2_000;
 
 /// Sandbox process eviction ensures that the number of sandbox processes is
 /// always below this threshold.
-pub(crate) const DEFAULT_MAX_SANDBOX_COUNT: usize = 20_000;
+pub(crate) const DEFAULT_MAX_SANDBOX_COUNT: usize = 10_000;
 
 /// A sandbox process may be evicted after it has been idle for this
 /// duration and sandbox process eviction is activated.

--- a/rs/config/src/embedders.rs
+++ b/rs/config/src/embedders.rs
@@ -44,11 +44,11 @@ const DEFAULT_PAGE_ALLOCATOR_THREADS: usize = 8;
 
 /// Sandbox process eviction does not activate if the number of sandbox
 /// processes is below this threshold.
-pub(crate) const DEFAULT_MIN_SANDBOX_COUNT: usize = 500;
+pub(crate) const DEFAULT_MIN_SANDBOX_COUNT: usize = 15_000;
 
 /// Sandbox process eviction ensures that the number of sandbox processes is
 /// always below this threshold.
-pub(crate) const DEFAULT_MAX_SANDBOX_COUNT: usize = 1_000;
+pub(crate) const DEFAULT_MAX_SANDBOX_COUNT: usize = 20_000;
 
 /// A sandbox process may be evicted after it has been idle for this
 /// duration and sandbox process eviction is activated.

--- a/rs/config/src/execution_environment.rs
+++ b/rs/config/src/execution_environment.rs
@@ -59,7 +59,7 @@ pub const STOP_CANISTER_TIMEOUT_DURATION: Duration = Duration::from_secs(5 * 60)
 /// potential fragmentation. This limit should be larger than the maximum
 /// canister memory size to guarantee that a message that overwrites the whole
 /// memory can succeed.
-pub(crate) const SUBNET_HEAP_DELTA_CAPACITY: NumBytes = NumBytes::new(140 * GIB);
+pub(crate) const SUBNET_HEAP_DELTA_CAPACITY: NumBytes = NumBytes::new(80 * GIB);
 
 /// The maximum number of instructions for inspect_message calls.
 const MAX_INSTRUCTIONS_FOR_MESSAGE_ACCEPTANCE_CALLS: NumInstructions =


### PR DESCRIPTION
In this PR we upgrade the sandbox eviction logic such that it doesn't only operate on the number of sandboxes, but also on their memory usage.

Some contention/discussion points:
1. Until this PR, the sandbox stat collection was done every 10s; we probably need to do this more often.
2. Until this PR, if adding one sandbox went over the number of sandboxes limit, a large eviction was triggered. We now remove this logic and leave eviction only on the metric collection thread, triggering decisions only when amount of memory goes beyond a threshold or the number of sandboxes reaches a maximum allowed value.
3. Overall page delta is reduced to 80 GiB. This constant and the max sandbox memory usage need to be thoroughly aligned.