### PR TITLE
fix(PocketIC): retry topology operation if the instance is busy

### DIFF
--- a/rs/pocket_ic_server/src/pocket_ic.rs
+++ b/rs/pocket_ic_server/src/pocket_ic.rs
@@ -994,6 +994,10 @@ impl Operation for GetTopology {
         OpOut::Topology(pic.topology().clone())
     }
 
+    fn retry_if_busy(&self) -> bool {
+        true
+    }
+
     fn id(&self) -> OpId {
         OpId("get_topology".into())
     }


### PR DESCRIPTION
Because the PocketIC operation to fetch topology is also expected to be called by IC agents that don't expect to retry the operation if the PocketIC instance is busy, we need to retry in PocketIC.