### PR TITLE
fix: set ports to 0 in BN system tests

### DIFF
--- a/rs/tests/boundary_nodes/integration_test_common/src/lib.rs
+++ b/rs/tests/boundary_nodes/integration_test_common/src/lib.rs
@@ -257,7 +257,7 @@ pub fn asset_canister_test(env: TestEnv) {
             )
         } else {
             let host = format!("{0}.ic0.app", asset_canister.canister_id);
-            let bn_addr = SocketAddrV6::new(boundary_node.ipv6(), 443, 0, 0).into();
+            let bn_addr = SocketAddrV6::new(boundary_node.ipv6(), 0, 0, 0).into();
             let client_builder = http_client_builder
                 .danger_accept_invalid_certs(true)
                 .resolve(&host, bn_addr);
@@ -673,7 +673,7 @@ pub fn http_canister_test(env: TestEnv) {
             } else {
                 let host = format!("{canister_id}.raw.ic0.app");
                 let invalid_host = "invalid-canister-id.raw.ic0.app".to_string();
-                let bn_addr = SocketAddrV6::new(boundary_node.ipv6(), 443, 0, 0).into();
+                let bn_addr = SocketAddrV6::new(boundary_node.ipv6(), 0, 0, 0).into();
                 let client_builder = client_builder
                     .danger_accept_invalid_certs(true)
                     .resolve(&host, bn_addr)
@@ -867,7 +867,7 @@ pub fn prefix_canister_id_test(env: TestEnv) {
             )
         } else {
             let host = format!("ignored-prefix--{canister_id}.raw.ic0.app");
-            let bn_addr = SocketAddrV6::new(boundary_node.ipv6(), 443, 0, 0).into();
+            let bn_addr = SocketAddrV6::new(boundary_node.ipv6(), 0, 0, 0).into();
             let client_builder = client_builder
                 .danger_accept_invalid_certs(true)
                 .resolve(&host, bn_addr);
@@ -1026,7 +1026,7 @@ pub fn proxy_http_canister_test(env: TestEnv) {
             } else {
                 let host = format!("{canister_id}.raw.ic0.app");
                 let invalid_host = "invalid-canister-id.raw.ic0.app".to_string();
-                let bn_addr = SocketAddrV6::new(boundary_node.ipv6(), 443, 0, 0).into();
+                let bn_addr = SocketAddrV6::new(boundary_node.ipv6(), 0, 0, 0).into();
                 let client_builder = client_builder
                     .danger_accept_invalid_certs(true)
                     .resolve(&host, bn_addr)
@@ -1231,7 +1231,7 @@ pub fn denylist_test(env: TestEnv) {
             (client_builder, playnet)
         } else {
             let host = "ic0.app";
-            let bn_addr = SocketAddrV6::new(boundary_node.ipv6(), 443, 0, 0);
+            let bn_addr = SocketAddrV6::new(boundary_node.ipv6(), 0, 0, 0);
             let client_builder = client_builder
                 .danger_accept_invalid_certs(true)
                 .resolve(&format!("{canister_id}.raw.{host}"),bn_addr.into());
@@ -1329,7 +1329,7 @@ pub fn canister_allowlist_test(env: TestEnv) {
             (client_builder, playnet)
         } else {
             let host = "ic0.app";
-            let bn_addr = SocketAddrV6::new(boundary_node.ipv6(), 443, 0, 0);
+            let bn_addr = SocketAddrV6::new(boundary_node.ipv6(), 0, 0, 0);
             let client_builder = client_builder
                 .danger_accept_invalid_certs(true)
                 .resolve(&format!("{canister_id}.raw.{host}"), bn_addr.into());
@@ -1446,7 +1446,7 @@ pub fn redirect_http_to_https_test(env: TestEnv) {
         (client_builder, playnet)
     } else {
         let host = "ic0.app";
-        let bn_addr = SocketAddrV6::new(boundary_node.ipv6(), 80, 0, 0);
+        let bn_addr = SocketAddrV6::new(boundary_node.ipv6(), 0, 0, 0);
         let client_builder = client_builder
             .danger_accept_invalid_certs(true)
             .resolve(host, bn_addr.into())
@@ -1545,7 +1545,7 @@ pub fn redirect_to_dashboard_test(env: TestEnv) {
         (client_builder, playnet)
     } else {
         let host = "ic0.app";
-        let bn_addr = SocketAddrV6::new(boundary_node.ipv6(), 443, 0, 0);
+        let bn_addr = SocketAddrV6::new(boundary_node.ipv6(), 0, 0, 0);
         let client_builder = client_builder
             .resolve(host, bn_addr.into())
             .resolve(&format!("raw.{host}"), bn_addr.into());
@@ -1646,7 +1646,7 @@ pub fn http_endpoint_test(env: TestEnv) {
         (client_builder, playnet)
     } else {
         let host = "ic0.app";
-        let bn_addr = SocketAddrV6::new(boundary_node.ipv6(), 443, 0, 0);
+        let bn_addr = SocketAddrV6::new(boundary_node.ipv6(), 0, 0, 0);
         let client_builder = client_builder.danger_accept_invalid_certs(true).resolve(
             &format!("{0}.{host}", asset_canister_orig.canister_id),
             bn_addr.into(),
@@ -1842,7 +1842,7 @@ pub fn ic_gateway_test(env: TestEnv) {
         (client_builder, playnet)
     } else {
         let host = "ic0.app";
-        let bn_addr = SocketAddrV6::new(boundary_node.ipv6(), 443, 0, 0);
+        let bn_addr = SocketAddrV6::new(boundary_node.ipv6(), 0, 0, 0);
         let client_builder = client_builder
             .danger_accept_invalid_certs(true)
             .resolve(&format!("{canister_id}.{host}"), bn_addr.into())
@@ -1947,7 +1947,7 @@ pub fn direct_to_replica_test(env: TestEnv) {
         (client_builder, playnet)
     } else {
         let host = "ic0.app";
-        let bn_addr = SocketAddrV6::new(boundary_node.ipv6(), 443, 0, 0);
+        let bn_addr = SocketAddrV6::new(boundary_node.ipv6(), 0, 0, 0);
         let client_builder = client_builder
             .danger_accept_invalid_certs(true)
             .resolve(host, bn_addr.into());
@@ -2164,7 +2164,7 @@ pub fn direct_to_replica_options_test(env: TestEnv) {
         (client_builder, playnet)
     } else {
         let host = "ic0.app";
-        let bn_addr = SocketAddrV6::new(boundary_node.ipv6(), 443, 0, 0);
+        let bn_addr = SocketAddrV6::new(boundary_node.ipv6(), 0, 0, 0);
         let client_builder = client_builder
             .danger_accept_invalid_certs(true)
             .resolve(host, bn_addr.into());
@@ -2377,7 +2377,7 @@ pub fn direct_to_replica_rosetta_test(env: TestEnv) {
         .get_snapshot()
         .expect("failed to get BN snapshot");
 
-    let bn_addr = SocketAddrV6::new(boundary_node.ipv6(), 443, 0, 0);
+    let bn_addr = SocketAddrV6::new(boundary_node.ipv6(), 0, 0, 0);
 
     let client = ClientBuilder::new()
         .danger_accept_invalid_certs(true)
@@ -2598,7 +2598,7 @@ pub fn seo_test(env: TestEnv) {
         (client_builder, playnet)
     } else {
         let host = "ic0.app";
-        let bn_addr = SocketAddrV6::new(boundary_node.ipv6(), 443, 0, 0);
+        let bn_addr = SocketAddrV6::new(boundary_node.ipv6(), 0, 0, 0);
         let client_builder = client_builder.danger_accept_invalid_certs(true).resolve(
             &format!("{0}.{host}", asset_canister_orig.canister_id),
             bn_addr.into(),
@@ -2851,7 +2851,7 @@ pub fn headers_test(env: TestEnv) {
             (http_client_builder, playnet)
         } else {
             let host = "ic0.app";
-            let bn_addr = SocketAddrV6::new(boundary_node.ipv6(), 443, 0, 0).into();
+            let bn_addr = SocketAddrV6::new(boundary_node.ipv6(), 0, 0, 0).into();
             let client_builder = http_client_builder
                 .danger_accept_invalid_certs(true)
                 .resolve(host, bn_addr);

--- a/rs/tests/boundary_nodes/performance_test_common/src/lib.rs
+++ b/rs/tests/boundary_nodes/performance_test_common/src/lib.rs
@@ -381,7 +381,7 @@ pub fn mainnet_query_calls_ic_gateway_test(env: TestEnv, bn_ipv6: Ipv6Addr) {
         .unwrap();
     let logger = env.logger();
 
-    let bn_addr = SocketAddrV6::new(bn_ipv6, 443, 0, 0).into();
+    let bn_addr = SocketAddrV6::new(bn_ipv6, 0, 0, 0).into();
 
     let mut http_clients = vec![];
     for _ in 0..NUM_AGENTS {


### PR DESCRIPTION
This PR addresses the [changed behavior of `hyper-util`](https://github.com/hyperium/hyper-util/commit/2639193e9134a235db42cca16c8cff7f21f61661) of using the port number if a non-zero number is specified instead of inferring it from the URL.