### PR TITLE
chore(IDX): dont post success messages to slack

### DIFF
--- a/.github/workflows/slack-workflow-run.yml
+++ b/.github/workflows/slack-workflow-run.yml
@@ -31,26 +31,38 @@ jobs:
           CHANNEL="eng-idx-alerts"
           FULL_MESSAGE="nothing"
 
-          if [[ "${{ github.event.workflow_run.conclusion }}" =~ ^(success)$ ]]; then
-            FULL_MESSAGE=":white_check_mark: ${MESSAGE} :relaxed:"
+          # if a job was cancelled, never post it to slack
+          if [[ "${{ github.event.workflow_run.conclusion }}" =~ ^(cancelled)$ ]]; then
+            POST_TO_SLACK="false"
+            echo "post_to_slack=${POST_TO_SLACK}" >> $GITHUB_OUTPUT
+            exit 0
+          # if a job was successful, don't post it to slack, unless it was a release testing job (see below)
+          elif [[ "${{ github.event.workflow_run.conclusion }}" =~ ^(success)$ ]]; then
+            FULL_MESSAGE=":white_check_mark: ${MESSAGE} :relaxed:
+            POST_TO_SLACK="false"
+          # if a job failed or timed out, always post it to slack
           elif [[ "${{ github.event.workflow_run.conclusion }}" =~ ^(failure|timed_out)$ ]]; then
             FULL_MESSAGE=":fire: ${MESSAGE} :disappointed:"
+            POST_TO_SLACK="true"
           fi
 
+          # If the job was release testing, modify the message and channel and post it to slack
           if [[ "$TRIGGERING_WORKFLOW_NAME" == "Release Testing" ]]; then
             CHANNEL="release-management-alerts"
             COMMIT="${{ github.event.workflow_run.head_sha }}"
             FULL_MESSAGE="${FULL_MESSAGE} commit: ${COMMIT}"
+            POST_TO_SLACK="true"
           fi
 
           echo "channel=${CHANNEL}" >> $GITHUB_OUTPUT
           echo "message=${FULL_MESSAGE}" >> $GITHUB_OUTPUT
+          echo "post_to_slack=${POST_TO_SLACK}" >> $GITHUB_OUTPUT
         env:
           MESSAGE: "*${{github.event.workflow_run.name}}* ${{github.event.workflow_run.conclusion}} on ${{github.event.workflow_run.head_branch}} - <${{github.server_url}}/${{github.repository}}/actions/runs/${{github.event.workflow_run.id}}|Run#${{github.event.workflow_run.id}}>"
 
       - name: Post Slack Notification
         uses: slackapi/slack-github-action@6c661ce58804a1a20f6dc5fbee7f0381b469e001 # v1.25.0
-        if: ${{ github.event.workflow_run.conclusion != 'cancelled' }}
+        if: ${{ steps.setup.outputs.post_to_slack == 'true' }}
         with:
           channel-id: ${{ steps.setup.outputs.channel }}
           slack-message: "${{ steps.setup.outputs.message }}"


### PR DESCRIPTION
In an effort to reduce the noise on our slack channels, this changes the logic to stop posting success messages to slack, since they are not actionable. However, I needed to update the logic a little to get it to work and keep it clear.