### PR TITLE
fix(IDX): Clean up WORKSPACE

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -149,9 +149,9 @@ use_repo(oci, "bitcoind", "bitcoind_linux_amd64")
 # we can't use the official image: https://github.com/bazel-contrib/rules_oci/issues/695
 #
 # Instead we copy the official image to our repository:
-# $ docker pull halverneus/static-file-server
-# $ docker tag halverneus/static-file-server dfinitydev/halverneus-static-file-server:latest
-# $ docker push dfinitydev/halverneus-static-file-server:latest
+# $ docker pull jaegertracing/all-in-one
+# $ docker tag jaegertracing/all-in-one dfinitydev/jaegertracing-all-in-one:latest
+# $ docker push jaegertracing-all-in-one:latest
 # > latest: digest: sha256:...
 oci.pull(
     name = "jaeger",

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -50,23 +50,6 @@ load("@noble//:packages.bzl", "noble_packages")
 
 noble_packages()
 
-# OCI (docker, podman) container support
-http_archive(
-    name = "rules_oci",
-    sha256 = "79e7f80df2840d14d7bc79099b5ed4553398cce8cff1f0df97289a07f7fd213c",
-    strip_prefix = "rules_oci-2.0.0-rc0",
-    url = "https://github.com/bazel-contrib/rules_oci/releases/download/v2.0.0-rc0/rules_oci-v2.0.0-rc0.tar.gz",
-)
-
-load("@rules_oci//oci:dependencies.bzl", "rules_oci_dependencies")
-
-rules_oci_dependencies()
-
-load("@rules_oci//oci:repositories.bzl", "oci_register_toolchains")
-
-oci_register_toolchains(name = "oci")
-
-load("@rules_oci//oci:pull.bzl", "oci_pull")
 load("//bazel:mainnet-canisters.bzl", "canisters")
 load("//third_party/lmdb:repository.bzl", "lmdb_repository")
 
@@ -126,95 +109,6 @@ canisters(
 load("@canisters//:defs.bzl", "canister_deps")
 
 canister_deps()
-
-# file server used in tests
-oci_pull(
-    name = "static-file-server",
-    # $ docker pull halverneus/static-file-server
-    # $ docker tag halverneus/static-file-server dfinitydev/halverneus-static-file-server:latest
-    # $ docker push dfinitydev/halverneus-static-file-server:latest
-    #latest: digest: sha256:...
-    image = "docker.io/dfinitydev/halverneus-static-file-server@sha256:80eb204716e0928e27e378ed817056c1167b2b1a878b1ac4ce496964dd9a3ccd",
-    platforms = [
-        "linux/amd64",
-    ],
-)
-
-# bitcoin container used in test
-oci_pull(
-    name = "bitcoind",
-    image = "docker.io/kylemanna/bitcoind@sha256:17c7dd21690f3be34630db7389d2f0bff14649e27a964afef03806a6d631e0f1",
-)
-
-# Tracing image used in tests
-# we can't use the official image: https://github.com/bazel-contrib/rules_oci/issues/695
-#
-# Instead we copy the official image to our repository:
-# $ docker pull halverneus/static-file-server
-# $ docker tag halverneus/static-file-server dfinitydev/halverneus-static-file-server:latest
-# $ docker push dfinitydev/halverneus-static-file-server:latest
-# > latest: digest: sha256:...
-oci_pull(
-    name = "jaeger",
-    image = "docker.io/dfinitydev/jaegertracing-all-in-one@sha256:b85a6bbb949a62377010b8418d7a860c9d0ea7058d83e7cb5ade4fba046c4a76",
-    platforms = [
-        "linux/amd64",
-    ],
-)
-
-# Used by tests
-oci_pull(
-    name = "minica",
-    image = "docker.io/ryantk/minica@sha256:c67e2c1885d438b5927176295d41aaab8a72dd9e1272ba85054bfc78191d05b0",
-    platforms = ["linux/amd64"],
-)
-
-# used by rosetta image
-oci_pull(
-    name = "rust_base",
-    image = "gcr.io/distroless/cc-debian11@sha256:8e94f031353596c3fc9db6a2499bcc82dacc40cb71e0703476f9fad41677efdf",
-    platforms = ["linux/amd64"],
-)
-
-# used in various places as base
-oci_pull(
-    name = "ubuntu_base",
-    image = "docker.io/library/ubuntu@sha256:965fbcae990b0467ed5657caceaec165018ef44a4d2d46c7cdea80a9dff0d1ea",
-    platforms = ["linux/amd64"],
-)
-
-# used in various places as base
-oci_pull(
-    name = "ubuntu_noble_base",
-    image = "docker.io/library/ubuntu@sha256:77d57fd89366f7d16615794a5b53e124d742404e20f035c22032233f1826bd6a",
-    platforms = ["linux/amd64"],
-)
-
-# used by boundary node tests
-oci_pull(
-    name = "coredns",
-    image = "docker.io/coredns/coredns@sha256:be7652ce0b43b1339f3d14d9b14af9f588578011092c1f7893bd55432d83a378",
-    platforms = ["linux/amd64"],
-)
-
-# used by custom domains tests
-oci_pull(
-    name = "pebble",
-    image = "docker.io/letsencrypt/pebble@sha256:fc5a537bf8fbc7cc63aa24ec3142283aa9b6ba54529f86eb8ff31fbde7c5b258",
-    platforms = ["linux/amd64"],
-)
-
-oci_pull(
-    name = "python3",
-    image = "docker.io/library/python@sha256:0a56f24afa1fc7f518aa690cb8c7be661225e40b157d9bb8c6ef402164d9faa7",
-    platforms = ["linux/amd64"],
-)
-
-oci_pull(
-    name = "alpine_openssl",
-    image = "docker.io/alpine/openssl@sha256:cf89651f07a33d2faf4499f72e6f8b0ee2542cd40735d51c7e75b8965c17af0e",
-    platforms = ["linux/amd64"],
-)
 
 http_archive(
     name = "aspect_rules_sol",
@@ -915,10 +809,6 @@ http_file(
     sha256 = "bf3987bd483cf710ff0c54134350ca188c29ff0fdd38567aa4df5e74131543e4",
     url = "https://raw.githubusercontent.com/dfinity/interface-spec/a82220c1156f5e3e80ea65be6a4f69b766cbe6d1/spec/_attachments/ic.did",
 )
-
-load("//rs/tests:kubeconfig.bzl", "kubeconfig")
-
-kubeconfig()
 
 http_archive(
     name = "bitcoin_core",


### PR DESCRIPTION
This removes a couple of Bazel dependencies that were duplicated between the WORKSPACE and the MODULE bazel files. These slipped through during rebase. There was also a bit of copypasta in a comment.