### PR TITLE
chore(PocketIC): use test driver's pid instead of parent pid

### DIFF
--- a/packages/pocket-ic/src/lib.rs
+++ b/packages/pocket-ic/src/lib.rs
@@ -1345,11 +1345,12 @@ To download the binary, please visit https://github.com/dfinity/pocketic."
         );
     }
 
-    // Use the parent process ID to find the PocketIC server port for this `cargo test` run.
-    let parent_pid = std::os::unix::process::parent_id();
-    let port_file_path = std::env::temp_dir().join(format!("pocket_ic_{}.port", parent_pid));
+    // We use the test driver's process ID to share the PocketIC server between multiple tests
+    // launched by the same test driver.
+    let test_driver_pid = std::process::id();
+    let port_file_path = std::env::temp_dir().join(format!("pocket_ic_{}.port", test_driver_pid));
     let mut cmd = Command::new(PathBuf::from(bin_path.clone()));
-    cmd.arg("--pid").arg(parent_pid.to_string());
+    cmd.arg("--pid").arg(test_driver_pid.to_string());
     if std::env::var("POCKET_IC_MUTE_SERVER").is_ok() {
         cmd.stdout(std::process::Stdio::null());
         cmd.stderr(std::process::Stdio::null());

--- a/packages/pocket-ic/src/nonblocking.rs
+++ b/packages/pocket-ic/src/nonblocking.rs
@@ -103,8 +103,8 @@ impl PocketIc {
             bitcoind_addr,
         };
 
-        let parent_pid = std::os::unix::process::parent_id();
-        let log_guard = setup_tracing(parent_pid);
+        let test_driver_pid = std::process::id();
+        let log_guard = setup_tracing(test_driver_pid);
 
         let reqwest_client = reqwest::Client::new();
         let instance_id = match reqwest_client

--- a/packages/pocket-ic/tests/tests.rs
+++ b/packages/pocket-ic/tests/tests.rs
@@ -1800,8 +1800,8 @@ fn test_get_default_effective_canister_id_invalid_url() {
         .with_application_subnet()
         .build();
 
-    let parent_pid = std::os::unix::process::parent_id();
-    let port_file_path = std::env::temp_dir().join(format!("pocket_ic_{}.port", parent_pid));
+    let test_driver_pid = std::process::id();
+    let port_file_path = std::env::temp_dir().join(format!("pocket_ic_{}.port", test_driver_pid));
     let port = std::fs::read_to_string(port_file_path).unwrap();
 
     let server_url = format!("http://localhost:{}", port);

--- a/rs/pocket_ic_server/tests/test.rs
+++ b/rs/pocket_ic_server/tests/test.rs
@@ -33,19 +33,19 @@ use tempfile::{NamedTempFile, TempDir};
 pub const LOCALHOST: &str = "127.0.0.1";
 
 fn start_server_helper(
-    parent_pid: Option<u32>,
+    test_driver_pid: Option<u32>,
     capture_stdout: bool,
     capture_stderr: bool,
 ) -> (Url, Child) {
     let bin_path = std::env::var_os("POCKET_IC_BIN").expect("Missing PocketIC binary");
-    let port_file_path = if let Some(parent_pid) = parent_pid {
-        std::env::temp_dir().join(format!("pocket_ic_{}.port", parent_pid))
+    let port_file_path = if let Some(test_driver_pid) = test_driver_pid {
+        std::env::temp_dir().join(format!("pocket_ic_{}.port", test_driver_pid))
     } else {
         NamedTempFile::new().unwrap().into_temp_path().to_path_buf()
     };
     let mut cmd = Command::new(PathBuf::from(bin_path));
-    if let Some(parent_pid) = parent_pid {
-        cmd.arg("--pid").arg(parent_pid.to_string());
+    if let Some(test_driver_pid) = test_driver_pid {
+        cmd.arg("--pid").arg(test_driver_pid.to_string());
     } else {
         cmd.arg("--port-file").arg(port_file_path.clone());
     }
@@ -76,8 +76,8 @@ fn start_server_helper(
 }
 
 pub fn start_server() -> Url {
-    let parent_pid = std::os::unix::process::parent_id();
-    start_server_helper(Some(parent_pid), false, false).0
+    let test_driver_pid = std::process::id();
+    start_server_helper(Some(test_driver_pid), false, false).0
 }
 
 #[test]


### PR DESCRIPTION
This PR makes the PocketIC library build on Windows by using the test driver's process ID instead of its parent process ID.