### PR TITLE
feat(IDX): port rules_distroless to MODULE.bazel

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -214,6 +214,34 @@ oci.pull(
 )
 use_repo(oci, "alpine_openssl", "alpine_openssl_linux_amd64")
 
+# Ubuntu snapshots
+
+bazel_dep(name = "rules_distroless", version = "0.3.8")
+
+apt = use_extension("@rules_distroless//apt:extensions.bzl", "apt")
+
+## Packageset based on an Ubuntu focal snapshot, see manifest file
+## for details
+## To update, comment out the `lock` field below and run:
+##   bazel run @focal//:lock
+apt.install(
+    name = "focal",
+    lock = "//bazel:focal.lock.json",
+    manifest = "//bazel:focal.yaml",
+)
+use_repo(apt, "focal")
+
+# Packageset based on an Ubuntu noble snapshot, see manifest file
+# for details
+# To update, comment out the `lock` field below and run:
+#   bazel run @noble//:lock
+apt.install(
+    name = "noble",
+    lock = "//bazel:noble.lock.json",
+    manifest = "//bazel:noble.yaml",
+)
+use_repo(apt, "noble")
+
 # Haskell toolchain for spec_compliance tests
 
 bazel_dep(

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -3,53 +3,6 @@ workspace(
 )
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive", "http_file", "http_jar")
-
-# Rules used to build Ubuntu systems
-http_archive(
-    name = "rules_distroless",
-    sha256 = "8a3440067453ad211f3b34d4a8f68f65663dc5fd6d7834bf81eecf0526785381",
-    strip_prefix = "rules_distroless-0.3.6",
-    url = "https://github.com/GoogleContainerTools/rules_distroless/releases/download/v0.3.6/rules_distroless-v0.3.6.tar.gz",
-)
-
-load("@rules_distroless//distroless:dependencies.bzl", "distroless_dependencies")
-
-distroless_dependencies()
-
-load("@rules_distroless//distroless:toolchains.bzl", "distroless_register_toolchains")
-
-distroless_register_toolchains()
-
-load("@rules_distroless//apt:index.bzl", "deb_index")
-
-# Packageset based on an Ubuntu focal snapshot, see manifest file
-# for details
-# To update, comment out the `lock` field below and run:
-#   bazel run @focal//:lock
-deb_index(
-    name = "focal",
-    lock = "//bazel:focal.lock.json",
-    manifest = "//bazel:focal.yaml",
-)
-
-load("@focal//:packages.bzl", "focal_packages")
-
-focal_packages()
-
-# Packageset based on an Ubuntu noble snapshot, see manifest file
-# for details
-# To update, comment out the `lock` field below and run:
-#   bazel run @noble//:lock
-deb_index(
-    name = "noble",
-    lock = "//bazel:noble.lock.json",
-    manifest = "//bazel:noble.yaml",
-)
-
-load("@noble//:packages.bzl", "noble_packages")
-
-noble_packages()
-
 load("//bazel:mainnet-canisters.bzl", "canisters")
 load("//third_party/lmdb:repository.bzl", "lmdb_repository")
 


### PR DESCRIPTION
This bumps `rules_distroless` to a version contained in the [bazel central registry](https://registry.bazel.build/modules/rules_distroless) and ports them from our WORKSPACE to our MODULE.

This involves a slight change in the API (was `deb_index`, now `apt.install`) but overall very small change.