### PR TITLE
refactor(tests): Attempt to upgrade root in test_get_upgrade_journal

### DIFF
--- a/rs/nervous_system/integration_tests/tests/advance_target_version.rs
+++ b/rs/nervous_system/integration_tests/tests/advance_target_version.rs
@@ -1,5 +1,3 @@
-use ic_base_types::PrincipalId;
-use ic_nervous_system_common::ONE_MONTH_SECONDS;
 use ic_nervous_system_integration_tests::pocket_ic_helpers::sns;
 use ic_nervous_system_integration_tests::{
     create_service_nervous_system_builder::CreateServiceNervousSystemBuilder,
@@ -49,23 +47,15 @@ async fn test_get_upgrade_journal() {
     install_nns_canisters(&pocket_ic, vec![], with_mainnet_nns_canisters, None, vec![]).await;
 
     // Publish (master) SNS Wasms to SNS-W.
-    let with_mainnet_sns_wasms = false;
-    let deployed_sns_starting_info = add_wasms_to_sns_wasm(&pocket_ic, with_mainnet_sns_wasms)
+    let with_mainnet_sns_canisters = false;
+    let deployed_sns_starting_info = add_wasms_to_sns_wasm(&pocket_ic, with_mainnet_sns_canisters)
         .await
         .unwrap();
     let initial_sns_version = nns::sns_wasm::get_latest_sns_version(&pocket_ic).await;
 
     // Deploy an SNS instance via proposal.
     let sns = {
-        let create_service_nervous_system = CreateServiceNervousSystemBuilder::default()
-            .with_governance_parameters_neuron_minimum_dissolve_delay_to_vote(ONE_MONTH_SECONDS * 6)
-            .with_one_developer_neuron(
-                PrincipalId::new_user_test_id(830947),
-                ONE_MONTH_SECONDS * 6,
-                756575,
-                0,
-            )
-            .build();
+        let create_service_nervous_system = CreateServiceNervousSystemBuilder::default().build();
         let swap_parameters = create_service_nervous_system
             .swap_parameters
             .clone()
@@ -118,30 +108,30 @@ async fn test_get_upgrade_journal() {
 
     // Publish a new SNS version.
     let (new_sns_version_1, new_sns_version_2) = {
-        let (_, original_ledger_wasm) = deployed_sns_starting_info
-            .get(&SnsCanisterType::Ledger)
+        let (_, original_root_wasm) = deployed_sns_starting_info
+            .get(&SnsCanisterType::Root)
             .unwrap();
 
         let new_sns_version_1 = {
-            let ledger_wasm = create_modified_sns_wasm(original_ledger_wasm, Some(1));
-            add_wasm_via_nns_proposal(&pocket_ic, ledger_wasm.clone())
+            let root_wasm = create_modified_sns_wasm(original_root_wasm, Some(1));
+            add_wasm_via_nns_proposal(&pocket_ic, root_wasm.clone())
                 .await
                 .unwrap();
-            let ledger_wasm_hash = ledger_wasm.sha256_hash().to_vec();
+            let root_wasm_hash = root_wasm.sha256_hash().to_vec();
             sns_pb::governance::Version {
-                ledger_wasm_hash,
+                root_wasm_hash,
                 ..initial_sns_version.clone()
             }
         };
 
         let new_sns_version_2 = {
-            let ledger_wasm = create_modified_sns_wasm(original_ledger_wasm, Some(2));
-            add_wasm_via_nns_proposal(&pocket_ic, ledger_wasm.clone())
+            let root_wasm = create_modified_sns_wasm(original_root_wasm, Some(2));
+            add_wasm_via_nns_proposal(&pocket_ic, root_wasm.clone())
                 .await
                 .unwrap();
-            let ledger_wasm_hash = ledger_wasm.sha256_hash().to_vec();
+            let root_wasm_hash = root_wasm.sha256_hash().to_vec();
             sns_pb::governance::Version {
-                ledger_wasm_hash,
+                root_wasm_hash,
                 ..new_sns_version_1.clone()
             }
         };


### PR DESCRIPTION
This PR changes the get_upgrade_journal test to simulate upgrades to root rather than Ledger. Root is a better candidate for testing against at this stage of the development of the effortless SNS upgrades feature, because it can be updated by Governance directly rather than needing to go through root like every other canister (except swap). Of course, it will need to be tested against all canisters eventually, but for now root seems like a good choice