### PR TITLE
refactor(nns): Improve range neurons performance for stable store

### DIFF
--- a/rs/nns/governance/canbench/canbench_results.yml
+++ b/rs/nns/governance/canbench/canbench_results.yml
@@ -1,31 +1,31 @@
 benches:
   add_neuron_active_maximum:
     total:
-      instructions: 35958957
+      instructions: 35991301
       heap_increase: 1
       stable_memory_increase: 0
     scopes: {}
   add_neuron_active_typical:
     total:
-      instructions: 1834893
+      instructions: 1836362
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   add_neuron_inactive_maximum:
     total:
-      instructions: 98377518
+      instructions: 98457016
       heap_increase: 1
       stable_memory_increase: 0
     scopes: {}
   add_neuron_inactive_typical:
     total:
-      instructions: 7568470
+      instructions: 7574043
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   range_neurons_performance:
     total:
-      instructions: 31991
+      instructions: 47070657
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}

--- a/rs/nns/governance/canbench/canbench_results.yml
+++ b/rs/nns/governance/canbench/canbench_results.yml
@@ -1,26 +1,32 @@
 benches:
   add_neuron_active_maximum:
     total:
-      instructions: 45003037
+      instructions: 35958957
       heap_increase: 1
       stable_memory_increase: 0
     scopes: {}
   add_neuron_active_typical:
     total:
-      instructions: 2703302
+      instructions: 1834893
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   add_neuron_inactive_maximum:
     total:
-      instructions: 122465697
+      instructions: 98377518
       heap_increase: 1
       stable_memory_increase: 0
     scopes: {}
   add_neuron_inactive_typical:
     total:
-      instructions: 10581822
+      instructions: 7568470
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
-version: 0.1.3
+  range_neurons_performance:
+    total:
+      instructions: 31991
+      heap_increase: 0
+      stable_memory_increase: 0
+    scopes: {}
+version: 0.1.7

--- a/rs/nns/governance/src/neuron_store/benches.rs
+++ b/rs/nns/governance/src/neuron_store/benches.rs
@@ -186,11 +186,14 @@ fn add_neuron_inactive_maximum() -> BenchResult {
 #[bench(raw)]
 fn range_neurons_performance() -> BenchResult {
     let mut rng = new_rng();
-    let neuron_store = set_up_neuron_store(&mut rng, 100, 200);
+    let _neuron_store = set_up_neuron_store(&mut rng, 100, 200);
 
     bench_fn(|| {
-        for _ in 0..100 {
-            let _ = neuron_store.range_neurons(0..100);
-        }
+        let _ = with_stable_neuron_store(|stable_store| {
+            let iter = stable_store.range_neurons(NeuronId::from_u64(0)..NeuronId::from_u64(100));
+            for n in iter {
+                let n = n.id();
+            }
+        });
     })
 }

--- a/rs/nns/governance/src/neuron_store/benches.rs
+++ b/rs/nns/governance/src/neuron_store/benches.rs
@@ -117,13 +117,17 @@ fn build_neuron(rng: &mut impl RngCore, location: NeuronLocation, size: NeuronSi
     neuron
 }
 
-fn set_up_neuron_store(rng: &mut impl RngCore) -> NeuronStore {
+fn set_up_neuron_store(
+    rng: &mut impl RngCore,
+    active_count: u64,
+    inactive_count: u64,
+) -> NeuronStore {
     // We insert 200 inactive neurons and 100 active neurons. They are not very realistic sizes, but
     // it would take too long to prepare those neurons for each benchmark.
-    let inactive_neurons: Vec<_> = (0..200)
+    let inactive_neurons: Vec<_> = (0..inactive_count)
         .map(|_| build_neuron(rng, NeuronLocation::Stable, NeuronSize::Typical))
         .collect();
-    let active_neurons: Vec<_> = (0..100)
+    let active_neurons: Vec<_> = (0..active_count)
         .map(|_| build_neuron(rng, NeuronLocation::Heap, NeuronSize::Typical))
         .collect();
     let neurons: BTreeMap<u64, Neuron> = inactive_neurons
@@ -138,7 +142,7 @@ fn set_up_neuron_store(rng: &mut impl RngCore) -> NeuronStore {
 #[bench(raw)]
 fn add_neuron_active_typical() -> BenchResult {
     let mut rng = new_rng();
-    let mut neuron_store = set_up_neuron_store(&mut rng);
+    let mut neuron_store = set_up_neuron_store(&mut rng, 100, 200);
     let neuron = build_neuron(&mut rng, NeuronLocation::Heap, NeuronSize::Typical);
 
     bench_fn(|| {
@@ -149,7 +153,7 @@ fn add_neuron_active_typical() -> BenchResult {
 #[bench(raw)]
 fn add_neuron_active_maximum() -> BenchResult {
     let mut rng = new_rng();
-    let mut neuron_store = set_up_neuron_store(&mut rng);
+    let mut neuron_store = set_up_neuron_store(&mut rng, 100, 200);
     let neuron = build_neuron(&mut rng, NeuronLocation::Heap, NeuronSize::Maximum);
 
     bench_fn(|| {
@@ -160,7 +164,7 @@ fn add_neuron_active_maximum() -> BenchResult {
 #[bench(raw)]
 fn add_neuron_inactive_typical() -> BenchResult {
     let mut rng = new_rng();
-    let mut neuron_store = set_up_neuron_store(&mut rng);
+    let mut neuron_store = set_up_neuron_store(&mut rng, 100, 200);
     let neuron = build_neuron(&mut rng, NeuronLocation::Stable, NeuronSize::Typical);
 
     bench_fn(|| {
@@ -171,10 +175,22 @@ fn add_neuron_inactive_typical() -> BenchResult {
 #[bench(raw)]
 fn add_neuron_inactive_maximum() -> BenchResult {
     let mut rng = new_rng();
-    let mut neuron_store = set_up_neuron_store(&mut rng);
+    let mut neuron_store = set_up_neuron_store(&mut rng, 100, 200);
     let neuron = build_neuron(&mut rng, NeuronLocation::Stable, NeuronSize::Maximum);
 
     bench_fn(|| {
         neuron_store.add_neuron(neuron).unwrap();
+    })
+}
+
+#[bench(raw)]
+fn range_neurons_performance() -> BenchResult {
+    let mut rng = new_rng();
+    let neuron_store = set_up_neuron_store(&mut rng, 100, 200);
+
+    bench_fn(|| {
+        for _ in 0..100 {
+            let _ = neuron_store.range_neurons(0..100);
+        }
     })
 }

--- a/rs/nns/governance/src/neuron_store/benches.rs
+++ b/rs/nns/governance/src/neuron_store/benches.rs
@@ -190,7 +190,7 @@ fn range_neurons_performance() -> BenchResult {
 
     bench_fn(|| {
         let _ = with_stable_neuron_store(|stable_store| {
-            let iter = stable_store.range_neurons(NeuronId::from_u64(0)..NeuronId::from_u64(100));
+            let iter = stable_store.range_neurons(..);
             for n in iter {
                 let n = n.id();
             }

--- a/rs/nns/governance/src/neuron_store/benches.rs
+++ b/rs/nns/governance/src/neuron_store/benches.rs
@@ -189,10 +189,10 @@ fn range_neurons_performance() -> BenchResult {
     let _neuron_store = set_up_neuron_store(&mut rng, 100, 200);
 
     bench_fn(|| {
-        let _ = with_stable_neuron_store(|stable_store| {
+        with_stable_neuron_store(|stable_store| {
             let iter = stable_store.range_neurons(..);
             for n in iter {
-                let n = n.id();
+                n.id();
             }
         });
     })

--- a/rs/nns/governance/src/storage/neurons.rs
+++ b/rs/nns/governance/src/storage/neurons.rs
@@ -359,7 +359,7 @@ where
             ..FolloweesKey::MAX
         };
 
-        let mut main_range = self.main.range(range.clone());
+        let main_range = self.main.range(range.clone());
         let mut hot_keys_iter = self.hot_keys_map.range(hotkeys_range).peekable();
         let mut recent_ballots_iter = self.recent_ballots_map.range(ballots_range).peekable();
         let mut followees_iter = self.followees_map.range(followees_range).peekable();
@@ -372,25 +372,20 @@ where
             let hot_keys = collect_for_neuron_id(
                 &mut hot_keys_iter,
                 main_neuron_id,
-                |((neuron_id, _index), principal)| {
-                    (*neuron_id, PrincipalId::from(principal.clone()))
-                },
+                |((neuron_id, _index), principal)| (*neuron_id, PrincipalId::from(*principal)),
             );
 
             let ballots = collect_for_neuron_id(
                 &mut recent_ballots_iter,
                 main_neuron_id,
-                |((neuron_id, _index), ballot_info)| (*neuron_id, ballot_info.clone()),
+                |((neuron_id, _index), ballot_info)| (*neuron_id, *ballot_info),
             );
 
             let followees = collect_for_neuron_id(
                 &mut followees_iter,
                 main_neuron_id,
                 |(followees_key, followee_id)| {
-                    (
-                        followees_key.follower_id,
-                        (followees_key.clone(), *followee_id),
-                    )
+                    (followees_key.follower_id, (*followees_key, *followee_id))
                 },
             );
 
@@ -696,13 +691,13 @@ where
     R: RangeBounds<NeuronId>,
 {
     let start = match range_bound.start_bound() {
-        RangeBound::Included(start) => start.clone(),
-        RangeBound::Excluded(start) => start.clone(),
+        RangeBound::Included(start) => *start,
+        RangeBound::Excluded(start) => *start,
         RangeBound::Unbounded => NeuronId::MIN,
     };
     let end = match range_bound.end_bound() {
-        RangeBound::Included(start) => start.clone(),
-        RangeBound::Excluded(start) => start.clone(),
+        RangeBound::Included(end) => *end,
+        RangeBound::Excluded(end) => *end,
         RangeBound::Unbounded => NeuronId::MAX,
     };
 

--- a/rs/nns/governance/src/storage/neurons/neurons_tests.rs
+++ b/rs/nns/governance/src/storage/neurons/neurons_tests.rs
@@ -530,3 +530,36 @@ fn test_range_neurons_reconstitutes_fully() {
 
     assert_eq!(result, neurons);
 }
+
+#[test]
+fn test_range_neurons_ranges_work_correctly() {
+    // This test is here to ensure that the conversions that happen inside range_neurons are correct.
+    let mut store = new_heap_based();
+    let neurons = {
+        let mut neurons = vec![];
+        for i in 1..=10 {
+            let neuron = create_model_neuron(i);
+            store.create(neuron.clone()).unwrap();
+            neurons.push(neuron);
+        }
+        neurons
+    };
+
+    let result = store
+        .range_neurons(NeuronId::from_u64(2)..NeuronId::from_u64(9))
+        .collect::<Vec<_>>();
+    assert_eq!(result, neurons[1..8]);
+
+    let result = store
+        .range_neurons(NeuronId::from_u64(2)..=NeuronId::from_u64(3))
+        .collect::<Vec<_>>();
+    assert_eq!(result, neurons[1..3]);
+
+    let result = store
+        .range_neurons((
+            std::ops::Bound::Excluded(NeuronId::from_u64(2)),
+            std::ops::Bound::Included(NeuronId::from_u64(3)),
+        ))
+        .collect::<Vec<_>>();
+    assert_eq!(result, neurons[2..3]);
+}

--- a/rs/nns/governance/src/storage/neurons/neurons_tests.rs
+++ b/rs/nns/governance/src/storage/neurons/neurons_tests.rs
@@ -3,7 +3,6 @@ use super::*;
 use crate::{
     neuron::{DissolveStateAndAge, NeuronBuilder},
     pb::v1::{abridged_neuron::DissolveState, Vote},
-    storage::with_stable_neuron_store,
 };
 use ic_base_types::PrincipalId;
 use ic_nns_common::pb::v1::ProposalId;

--- a/rs/nns/governance/src/storage/neurons/neurons_tests.rs
+++ b/rs/nns/governance/src/storage/neurons/neurons_tests.rs
@@ -3,6 +3,7 @@ use super::*;
 use crate::{
     neuron::{DissolveStateAndAge, NeuronBuilder},
     pb::v1::{abridged_neuron::DissolveState, Vote},
+    storage::with_stable_neuron_store,
 };
 use ic_base_types::PrincipalId;
 use ic_nns_common::pb::v1::ProposalId;
@@ -526,7 +527,8 @@ fn test_range_neurons_reconstitutes_fully() {
         neurons
     };
 
-    let result = store.range_neurons(..).collect::<Vec<_>>();
+    let result =
+        with_stable_neuron_store(|stable_store| stable_store.range_neurons(..).collect::<Vec<_>>());
 
     assert_eq!(result, neurons);
     assert_ne!(result, neurons);

--- a/rs/nns/governance/src/storage/neurons/neurons_tests.rs
+++ b/rs/nns/governance/src/storage/neurons/neurons_tests.rs
@@ -527,9 +527,7 @@ fn test_range_neurons_reconstitutes_fully() {
         neurons
     };
 
-    let result =
-        with_stable_neuron_store(|stable_store| stable_store.range_neurons(..).collect::<Vec<_>>());
+    let result = store.range_neurons(..).collect::<Vec<_>>();
 
     assert_eq!(result, neurons);
-    assert_ne!(result, neurons);
 }

--- a/rs/nns/governance/src/storage/neurons/neurons_tests.rs
+++ b/rs/nns/governance/src/storage/neurons/neurons_tests.rs
@@ -512,3 +512,22 @@ fn test_abridged_neuron_size() {
     // headroom.
     assert_eq!(abridged_neuron.encoded_len(), 184);
 }
+
+#[test]
+fn test_range_neurons_reconstitutes_fully() {
+    let mut store = new_heap_based();
+    let neurons = {
+        let mut neurons = vec![];
+        for i in 1..10 {
+            let neuron = create_model_neuron(i);
+            store.create(neuron.clone()).unwrap();
+            neurons.push(neuron);
+        }
+        neurons
+    };
+
+    let result = store.range_neurons(..).collect::<Vec<_>>();
+
+    assert_eq!(result, neurons);
+    assert_ne!(result, neurons);
+}


### PR DESCRIPTION
When scanning neurons in the main StableBTreeMap, instead of doing a separate traversal of the auxiliary StableBTreeMaps for EACH neuron in the result set, ranges of each auxiliary StableBTreeMap are used (and scanned in parallel).

This gets around a 40% performance improvement.

This method, while not currently extensively used, will be used more after the migration of neurons to stable storage.

Benchmark results before the change:

```
// Output from benchmark test
Benchmark: range_neurons_performance
  total:
    instructions: 47.07 M (improved by 41.47%)
    heap_increase: 0 pages (no change)
    stable_memory_increase: 0 pages (no change)

```

```
range_neurons_performance:
  total:
    instructions: 80415437
    heap_increase: 0
    stable_memory_increase: 0
  scopes: {}
```

After the change (what's in PR):

```
  range_neurons_performance:
    total:
      instructions: 47070657
      heap_increase: 0
      stable_memory_increase: 0
    scopes: {}
```