### PR TITLE
feat(sns): Automatically trigger upgrades when target_version is ahead of the current version

### DIFF
--- a/rs/nervous_system/common/src/lib.rs
+++ b/rs/nervous_system/common/src/lib.rs
@@ -778,6 +778,16 @@ fn checked_div_mod(dividend: usize, divisor: usize) -> Option<(usize, usize)> {
     Some((quotient, remainder))
 }
 
+/// Converts a sha256 hash into a hex string representation
+pub fn hash_to_hex_string(hash: &[u8]) -> String {
+    use std::fmt::Write;
+    let mut result_hash = String::new();
+    for b in hash {
+        let _ = write!(result_hash, "{:02x}", b);
+    }
+    result_hash
+}
+
 #[cfg(test)]
 mod serve_logs_tests;
 

--- a/rs/nervous_system/common/src/tests.rs
+++ b/rs/nervous_system/common/src/tests.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-use crate::ledger::compute_neuron_staking_subaccount_bytes;
+use crate::{hash_to_hex_string, ledger::compute_neuron_staking_subaccount_bytes};
 use ic_base_types::PrincipalId;
 use ic_crypto_sha2::Sha256;
 
@@ -45,4 +45,22 @@ fn test_compute_neuron_staking_subaccount_bytes() {
         compute_neuron_staking_subaccount_bytes(principal_id, nonce),
         hash
     );
+}
+
+#[test]
+fn test_hash_to_hex_string_empty() {
+    let empty: [u8; 0] = [];
+    assert_eq!(hash_to_hex_string(&empty), "");
+}
+
+#[test]
+fn test_hash_to_hex_string_single_byte() {
+    let single = [0xAB];
+    assert_eq!(hash_to_hex_string(&single), "ab");
+}
+
+#[test]
+fn test_hash_to_hex_string_multiple_bytes() {
+    let bytes = [0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC, 0xDE, 0xF0];
+    assert_eq!(hash_to_hex_string(&bytes), "123456789abcdef0");
 }

--- a/rs/nervous_system/integration_tests/tests/advance_target_version.rs
+++ b/rs/nervous_system/integration_tests/tests/advance_target_version.rs
@@ -285,55 +285,31 @@ async fn test_get_upgrade_journal() {
     {
         expected_upgrade_journal_entries.push(
             sns_pb::upgrade_journal_entry::Event::UpgradeStarted(
-                sns_pb::upgrade_journal_entry::UpgradeStarted {
-                    current_version: Some(initial_sns_version.clone()),
-                    expected_version: Some(new_sns_version_1.clone()),
-                    reason: Some(
-                        sns_pb::upgrade_journal_entry::upgrade_started::Reason::BehindTargetVersion(
-                            sns_pb::Empty {},
-                        ),
-                    ),
-                },
+                sns_pb::upgrade_journal_entry::UpgradeStarted::from_behind_target(
+                    initial_sns_version.clone(),
+                    new_sns_version_1.clone(),
+                ),
             ),
         );
 
         expected_upgrade_journal_entries.push(
             sns_pb::upgrade_journal_entry::Event::UpgradeOutcome(
-                sns_pb::upgrade_journal_entry::UpgradeOutcome {
-                    status: Some(
-                        sns_pb::upgrade_journal_entry::upgrade_outcome::Status::Success(
-                            sns_pb::Empty {},
-                        ),
-                    ),
-                    human_readable: None,
-                },
+                sns_pb::upgrade_journal_entry::UpgradeOutcome::success(None),
             ),
         );
 
         expected_upgrade_journal_entries.push(
             sns_pb::upgrade_journal_entry::Event::UpgradeStarted(
-                sns_pb::upgrade_journal_entry::UpgradeStarted {
-                    current_version: Some(new_sns_version_1.clone()),
-                    expected_version: Some(new_sns_version_2.clone()),
-                    reason: Some(
-                        sns_pb::upgrade_journal_entry::upgrade_started::Reason::BehindTargetVersion(
-                            sns_pb::Empty {},
-                        ),
-                    ),
-                },
+                sns_pb::upgrade_journal_entry::UpgradeStarted::from_behind_target(
+                    new_sns_version_1.clone(),
+                    new_sns_version_2.clone(),
+                ),
             ),
         );
 
         expected_upgrade_journal_entries.push(
             sns_pb::upgrade_journal_entry::Event::UpgradeOutcome(
-                sns_pb::upgrade_journal_entry::UpgradeOutcome {
-                    status: Some(
-                        sns_pb::upgrade_journal_entry::upgrade_outcome::Status::Success(
-                            sns_pb::Empty {},
-                        ),
-                    ),
-                    human_readable: None,
-                },
+                sns_pb::upgrade_journal_entry::UpgradeOutcome::success(None),
             ),
         );
 

--- a/rs/nns/sns-wasm/src/pb/mod.rs
+++ b/rs/nns/sns-wasm/src/pb/mod.rs
@@ -13,25 +13,12 @@ use crate::{
 use ic_base_types::CanisterId;
 use ic_cdk::api::stable::StableMemory;
 use ic_crypto_sha2::Sha256;
-use std::{
-    collections::HashMap,
-    convert::TryFrom,
-    fmt::{Display, Write},
-    str::FromStr,
-};
+use ic_nervous_system_common::hash_to_hex_string;
+use std::{collections::HashMap, convert::TryFrom, str::FromStr};
 
 #[allow(clippy::all)]
 #[path = "../gen/ic_sns_wasm.pb.v1.rs"]
 pub mod v1;
-
-/// Converts a sha256 hash into a hex string representation
-pub fn hash_to_hex_string(hash: &[u8; 32]) -> String {
-    let mut result_hash = String::new();
-    for b in hash {
-        let _ = write!(result_hash, "{:02X}", b);
-    }
-    result_hash
-}
 
 impl AddWasmResponse {
     pub fn error(message: String) -> Self {
@@ -123,7 +110,7 @@ impl From<SnsVersion> for GetNextSnsVersionResponse {
     }
 }
 
-impl Display for SnsVersion {
+impl std::fmt::Display for SnsVersion {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut versions_str = HashMap::<&str, String>::new();
 

--- a/rs/nns/sns-wasm/src/sns_wasm.rs
+++ b/rs/nns/sns-wasm/src/sns_wasm.rs
@@ -1,22 +1,18 @@
 use crate::{
     canister_api::CanisterApi,
-    pb::{
-        hash_to_hex_string,
-        v1::{
-            add_wasm_response, AddWasmRequest, AddWasmResponse, DappCanistersTransferResult,
-            DeployNewSnsRequest, DeployNewSnsResponse, DeployedSns,
-            GetDeployedSnsByProposalIdRequest, GetDeployedSnsByProposalIdResponse,
-            GetNextSnsVersionRequest, GetNextSnsVersionResponse, GetProposalIdThatAddedWasmRequest,
-            GetProposalIdThatAddedWasmResponse, GetSnsSubnetIdsResponse,
-            GetWasmMetadataRequest as GetWasmMetadataRequestPb,
-            GetWasmMetadataResponse as GetWasmMetadataResponsePb, GetWasmRequest, GetWasmResponse,
-            InsertUpgradePathEntriesRequest, InsertUpgradePathEntriesResponse,
-            ListDeployedSnsesRequest, ListDeployedSnsesResponse, ListUpgradeStep,
-            ListUpgradeStepsRequest, ListUpgradeStepsResponse,
-            MetadataSection as MetadataSectionPb, SnsCanisterIds, SnsCanisterType, SnsUpgrade,
-            SnsVersion, SnsWasm, SnsWasmError, SnsWasmStableIndex, StableCanisterState,
-            UpdateSnsSubnetListRequest, UpdateSnsSubnetListResponse,
-        },
+    pb::v1::{
+        add_wasm_response, AddWasmRequest, AddWasmResponse, DappCanistersTransferResult,
+        DeployNewSnsRequest, DeployNewSnsResponse, DeployedSns, GetDeployedSnsByProposalIdRequest,
+        GetDeployedSnsByProposalIdResponse, GetNextSnsVersionRequest, GetNextSnsVersionResponse,
+        GetProposalIdThatAddedWasmRequest, GetProposalIdThatAddedWasmResponse,
+        GetSnsSubnetIdsResponse, GetWasmMetadataRequest as GetWasmMetadataRequestPb,
+        GetWasmMetadataResponse as GetWasmMetadataResponsePb, GetWasmRequest, GetWasmResponse,
+        InsertUpgradePathEntriesRequest, InsertUpgradePathEntriesResponse,
+        ListDeployedSnsesRequest, ListDeployedSnsesResponse, ListUpgradeStep,
+        ListUpgradeStepsRequest, ListUpgradeStepsResponse, MetadataSection as MetadataSectionPb,
+        SnsCanisterIds, SnsCanisterType, SnsUpgrade, SnsVersion, SnsWasm, SnsWasmError,
+        SnsWasmStableIndex, StableCanisterState, UpdateSnsSubnetListRequest,
+        UpdateSnsSubnetListResponse,
     },
     stable_memory::SnsWasmStableMemory,
     wasm_metadata::MetadataSection,
@@ -25,7 +21,7 @@ use candid::Encode;
 use ic_base_types::{CanisterId, PrincipalId};
 use ic_cdk::api::stable::StableMemory;
 use ic_nervous_system_clients::canister_id_record::CanisterIdRecord;
-use ic_nervous_system_common::{ONE_TRILLION, SNS_CREATION_FEE};
+use ic_nervous_system_common::{hash_to_hex_string, ONE_TRILLION, SNS_CREATION_FEE};
 use ic_nervous_system_proto::pb::v1::Canister;
 use ic_nns_constants::{
     DEFAULT_SNS_GOVERNANCE_CANISTER_WASM_MEMORY_LIMIT,

--- a/rs/sns/governance/canister/canister.rs
+++ b/rs/sns/governance/canister/canister.rs
@@ -473,7 +473,7 @@ fn get_running_sns_version(_: GetRunningSnsVersionRequest) -> GetRunningSnsVersi
         target_version: upgrade_in_progress.target_version.clone(),
         mark_failed_at_seconds: upgrade_in_progress.mark_failed_at_seconds,
         checking_upgrade_lock: upgrade_in_progress.checking_upgrade_lock,
-        proposal_id: upgrade_in_progress.proposal_id,
+        proposal_id: upgrade_in_progress.proposal_id.unwrap_or(0),
     });
     GetRunningSnsVersionResponse {
         deployed_version: governance().proto.deployed_version.clone(),

--- a/rs/sns/governance/canister/governance.did
+++ b/rs/sns/governance/canister/governance.did
@@ -761,6 +761,7 @@ type TargetVersionSet = record {
 type TargetVersionReset = record {
   new_target_version : opt Version;
   old_target_version : opt Version;
+  human_readable : opt text;
 };
 
 type UpgradeStarted = record {

--- a/rs/sns/governance/canister/governance.did
+++ b/rs/sns/governance/canister/governance.did
@@ -257,7 +257,12 @@ type GetProposalResponse = record {
 
 type GetRunningSnsVersionResponse = record {
   deployed_version : opt Version;
-  pending_version : opt UpgradeInProgress;
+  pending_version : opt record {
+    mark_failed_at_seconds : nat64;
+    checking_upgrade_lock : nat64;
+    proposal_id : nat64;
+    target_version : opt Version;
+  };
 };
 
 type GetSnsInitializationParametersResponse = record {
@@ -674,14 +679,14 @@ type TransferSnsTreasuryFunds = record {
 type UpgradeInProgress = record {
   mark_failed_at_seconds : nat64;
   checking_upgrade_lock : nat64;
-  proposal_id : nat64;
+  proposal_id : opt nat64;
   target_version : opt Version;
 };
 
 type PendingVersion = record {
   mark_failed_at_seconds : nat64;
   checking_upgrade_lock : nat64;
-  proposal_id : nat64;
+  proposal_id : opt nat64;
   target_version : opt Version;
 };
 
@@ -787,6 +792,7 @@ type GetUpgradeJournalResponse = record {
   upgrade_steps : opt Versions;
   response_timestamp_seconds : opt nat64;
   target_version : opt Version;
+  deployed_version : opt Version;
   upgrade_journal : opt UpgradeJournal;
 };
 

--- a/rs/sns/governance/canister/governance_test.did
+++ b/rs/sns/governance/canister/governance_test.did
@@ -775,6 +775,7 @@ type TargetVersionSet = record {
 type TargetVersionReset = record {
   new_target_version : opt Version;
   old_target_version : opt Version;
+  human_readable : opt text;
 };
 
 type UpgradeStarted = record {

--- a/rs/sns/governance/canister/governance_test.did
+++ b/rs/sns/governance/canister/governance_test.did
@@ -266,7 +266,12 @@ type GetProposalResponse = record {
 
 type GetRunningSnsVersionResponse = record {
   deployed_version : opt Version;
-  pending_version : opt UpgradeInProgress;
+  pending_version : opt record {
+    mark_failed_at_seconds : nat64;
+    checking_upgrade_lock : nat64;
+    proposal_id : nat64;
+    target_version : opt Version;
+  };
 };
 
 type GetSnsInitializationParametersResponse = record {
@@ -688,14 +693,14 @@ type TransferSnsTreasuryFunds = record {
 type UpgradeInProgress = record {
   mark_failed_at_seconds : nat64;
   checking_upgrade_lock : nat64;
-  proposal_id : nat64;
+  proposal_id : opt nat64;
   target_version : opt Version;
 };
 
 type PendingVersion = record {
   mark_failed_at_seconds : nat64;
   checking_upgrade_lock : nat64;
-  proposal_id : nat64;
+  proposal_id : opt nat64;
   target_version : opt Version;
 };
 
@@ -801,6 +806,7 @@ type GetUpgradeJournalResponse = record {
   upgrade_steps : opt Versions;
   response_timestamp_seconds : opt nat64;
   target_version : opt Version;
+  deployed_version : opt Version;
   upgrade_journal : opt UpgradeJournal;
 };
 

--- a/rs/sns/governance/proto/ic_sns_governance/pb/v1/governance.proto
+++ b/rs/sns/governance/proto/ic_sns_governance/pb/v1/governance.proto
@@ -1424,7 +1424,7 @@ message Governance {
     // allowing us to fail in case we otherwise have gotten stuck.
     uint64 checking_upgrade_lock = 3;
     // The proposal that initiated this upgrade
-    uint64 proposal_id = 4;
+    optional uint64 proposal_id = 4;
   }
 
   // Version SNS is in process of upgrading to.
@@ -2230,6 +2230,7 @@ message GetUpgradeJournalResponse {
   // Currently, this field is always None, but in the "effortless SNS upgrade"
   // feature, it reflect the version of the SNS that the community has decided to upgrade to.
   Governance.Version target_version = 3;
+  Governance.Version deployed_version = 5;
 
   UpgradeJournal upgrade_journal = 4;
 }

--- a/rs/sns/governance/proto/ic_sns_governance/pb/v1/governance.proto
+++ b/rs/sns/governance/proto/ic_sns_governance/pb/v1/governance.proto
@@ -2185,6 +2185,7 @@ message UpgradeJournalEntry {
   message TargetVersionReset {
     optional Governance.Version old_target_version = 1;
     optional Governance.Version new_target_version = 2;
+    optional string human_readable = 3;
   }
 
   message UpgradeStarted {

--- a/rs/sns/governance/src/gen/ic_sns_governance.pb.v1.rs
+++ b/rs/sns/governance/src/gen/ic_sns_governance.pb.v1.rs
@@ -3443,6 +3443,8 @@ pub mod upgrade_journal_entry {
         pub old_target_version: ::core::option::Option<super::governance::Version>,
         #[prost(message, optional, tag = "2")]
         pub new_target_version: ::core::option::Option<super::governance::Version>,
+        #[prost(string, optional, tag = "3")]
+        pub human_readable: ::core::option::Option<::prost::alloc::string::String>,
     }
     #[derive(
         candid::CandidType,

--- a/rs/sns/governance/src/gen/ic_sns_governance.pb.v1.rs
+++ b/rs/sns/governance/src/gen/ic_sns_governance.pb.v1.rs
@@ -1900,8 +1900,8 @@ pub mod governance {
         #[prost(uint64, tag = "3")]
         pub checking_upgrade_lock: u64,
         /// The proposal that initiated this upgrade
-        #[prost(uint64, tag = "4")]
-        pub proposal_id: u64,
+        #[prost(uint64, optional, tag = "4")]
+        pub proposal_id: ::core::option::Option<u64>,
     }
     #[derive(
         candid::CandidType,
@@ -3600,6 +3600,8 @@ pub struct GetUpgradeJournalResponse {
     /// feature, it reflect the version of the SNS that the community has decided to upgrade to.
     #[prost(message, optional, tag = "3")]
     pub target_version: ::core::option::Option<governance::Version>,
+    #[prost(message, optional, tag = "5")]
+    pub deployed_version: ::core::option::Option<governance::Version>,
     #[prost(message, optional, tag = "4")]
     pub upgrade_journal: ::core::option::Option<UpgradeJournal>,
 }

--- a/rs/sns/governance/src/governance.rs
+++ b/rs/sns/governance/src/governance.rs
@@ -65,8 +65,8 @@ use crate::{
         MAX_NUMBER_OF_PROPOSALS_WITH_BALLOTS,
     },
     sns_upgrade::{
-        get_all_sns_canisters, get_running_version, get_upgrade_params, get_wasm, SnsCanisterType,
-        UpgradeSnsParams,
+        canister_type_and_wasm_hash_for_upgrade, get_all_sns_canisters, get_canisters_to_upgrade,
+        get_running_version, get_upgrade_params, get_wasm, SnsCanisterType, UpgradeSnsParams,
     },
     types::{
         function_id_to_proposal_criticality, is_registered_function_id, Environment,
@@ -2063,8 +2063,9 @@ impl Governance {
             }
             Action::UpgradeSnsToNextVersion(_) => {
                 log!(INFO, "Executing UpgradeSnsToNextVersion action",);
-                let upgrade_sns_result =
-                    self.perform_upgrade_to_next_sns_version(proposal_id).await;
+                let upgrade_sns_result = self
+                    .perform_upgrade_to_next_sns_version_legacy(proposal_id)
+                    .await;
 
                 // If the upgrade returned `Ok(true)` that means the upgrade completed successfully
                 // and the proposal can be marked as "executed". If the upgrade returned `Ok(false)`
@@ -2458,7 +2459,7 @@ impl Governance {
         proposal_id: u64,
         upgrade: UpgradeSnsControlledCanister,
     ) -> Result<(), GovernanceError> {
-        self.check_no_other_upgrades_in_progress(proposal_id)?;
+        self.check_no_upgrades_in_progress(Some(proposal_id))?;
 
         let sns_canisters =
             get_all_sns_canisters(&*self.env, self.proto.root_canister_id_or_panic())
@@ -2545,12 +2546,14 @@ impl Governance {
             })
     }
 
-    pub fn check_no_other_upgrades_in_progress(
+
+    /// Used for checking that no upgrades are in progress. Also checks that there are no upgrade proposals in progress except, optionally, one that you pass in as `proposal_id`
+    pub fn check_no_upgrades_in_progress(
         &self,
-        proposal_id: u64,
+        proposal_id: Option<u64>,
     ) -> Result<(), GovernanceError> {
         let upgrade_proposals_in_progress = self.upgrade_proposals_in_progress();
-        if upgrade_proposals_in_progress != BTreeSet::from([proposal_id]) {
+        if upgrade_proposals_in_progress != proposal_id.into_iter().collect() {
             return Err(GovernanceError::new_with_message(
                 ErrorType::ResourceExhausted,
                 format!(
@@ -2577,11 +2580,11 @@ impl Governance {
 
     /// Return `Ok(true)` if the upgrade was completed successfully, return `Ok(false)` if an
     /// upgrade was successfully kicked-off, but its completion is pending.
-    async fn perform_upgrade_to_next_sns_version(
+    async fn perform_upgrade_to_next_sns_version_legacy(
         &mut self,
         proposal_id: u64,
     ) -> Result<bool, GovernanceError> {
-        self.check_no_other_upgrades_in_progress(proposal_id)?;
+        self.check_no_upgrades_in_progress(Some(proposal_id))?;
 
         let current_version = self.proto.deployed_version_or_panic();
         let root_canister_id = self.proto.root_canister_id_or_panic();
@@ -2645,7 +2648,7 @@ impl Governance {
             target_version: Some(next_version),
             mark_failed_at_seconds: self.env.now() + 5 * 60,
             checking_upgrade_lock: 0,
-            proposal_id,
+            proposal_id: Some(proposal_id),
         });
 
         log!(
@@ -2655,6 +2658,63 @@ impl Governance {
         );
 
         Ok(false)
+    }
+
+    async fn upgrade_sns_framework_canister(
+        &mut self,
+        new_wasm_hash: Vec<u8>,
+        canister_type_to_upgrade: SnsCanisterType,
+    ) -> Result<(), GovernanceError> {
+        let root_canister_id = self.proto.root_canister_id_or_panic();
+
+        let target_wasm = get_wasm(&*self.env, new_wasm_hash.to_vec(), canister_type_to_upgrade)
+            .await
+            .map_err(|e| {
+                GovernanceError::new_with_message(
+                    ErrorType::External,
+                    format!("Could not get wasm for upgrade: {}", e),
+                )
+            })?
+            .wasm;
+
+        let target_is_root = canister_type_to_upgrade == SnsCanisterType::Root;
+
+        if target_is_root {
+            upgrade_canister_directly(
+                &*self.env,
+                root_canister_id,
+                target_wasm,
+                Encode!().unwrap(),
+            )
+            .await?;
+        } else {
+            let canister_ids_to_upgrade =
+                get_canisters_to_upgrade(&*self.env, root_canister_id, canister_type_to_upgrade)
+                    .await
+                    .map_err(|e| {
+                        GovernanceError::new_with_message(
+                            ErrorType::External,
+                            format!("Could not get list of SNS canisters from root: {}", e),
+                        )
+                    })?;
+            for target_canister_id in canister_ids_to_upgrade {
+                self.upgrade_non_root_canister(
+                    target_canister_id,
+                    target_wasm.clone(),
+                    Encode!().unwrap(),
+                    CanisterInstallMode::Upgrade,
+                )
+                .await?;
+            }
+        }
+
+        log!(
+            INFO,
+            "Successfully kicked off upgrade for SNS canister {:?}",
+            canister_type_to_upgrade,
+        );
+
+        Ok(())
     }
 
     async fn perform_transfer_sns_treasury_funds(
@@ -2777,7 +2837,7 @@ impl Governance {
         proposal_id: u64,
         manage_ledger_parameters: ManageLedgerParameters,
     ) -> Result<(), GovernanceError> {
-        self.check_no_other_upgrades_in_progress(proposal_id)?;
+        self.check_no_upgrades_in_progress(Some(proposal_id))?;
 
         let current_version = self.proto.deployed_version_or_panic();
         let ledger_canister_id = self.proto.ledger_canister_id_or_panic();
@@ -4695,6 +4755,8 @@ impl Governance {
                 self.refresh_cached_upgrade_steps().await;
             }
 
+            self.initiate_upgrade_if_behind_target_version().await;
+
             self.release_upgrade_periodic_task_lock();
         }
 
@@ -4747,6 +4809,97 @@ impl Governance {
                 true
             }
         }
+    }
+    /// Checks if an automatic upgrade is needed and initiates it.
+    /// An automatic upgrade is needed if `target_version` is set to a future version on the upgrade path
+    async fn initiate_upgrade_if_behind_target_version(&mut self) {
+        // Check that no upgrades are in progress
+        if self.check_no_upgrades_in_progress(None).is_err() {
+            // An upgrade is already in progress
+            return;
+        }
+
+        let Some(deployed_version) = self.proto.deployed_version.clone() else {
+            return;
+        };
+
+        let Some(target_version) = self.proto.target_version.clone() else {
+            return;
+        };
+
+        let Some(CachedUpgradeSteps {
+            upgrade_steps: Some(Versions {
+                versions: upgrade_steps,
+            }),
+            ..
+        }) = &self.proto.cached_upgrade_steps
+        else {
+            log!(ERROR, "Cached upgrade steps set to None");
+            return;
+        };
+
+        // Find the current position of the deployed version
+        let Some(deployed_position) = upgrade_steps.iter().position(|v| v == &deployed_version)
+        else {
+            log!(ERROR, "Deployed version is not on the upgrade path");
+            self.invalidate_cached_upgrade_steps();
+            return;
+        };
+
+        // Find the target position of the target version
+        let Some(target_position) = upgrade_steps.iter().position(|v| v == &target_version) else {
+            log!(ERROR, "Target version is not on the upgrade path");
+            return;
+        };
+
+        if target_position <= deployed_position {
+            // Target version is not after the deployed version
+            return;
+        }
+
+        // since `target_position > deployed_position`, `deployed_position + 1 < upgrade_steps.len()`
+        let next_version = upgrade_steps[deployed_position + 1].clone();
+
+        let (canister_type, wasm_hash) =
+            match canister_type_and_wasm_hash_for_upgrade(&deployed_version, &next_version) {
+                Ok((canister_type, wasm_hash)) => (canister_type, wasm_hash),
+
+                Err(err) => {
+                    log!(ERROR, "Upgrade attempt failed: {}", err);
+                    self.proto.target_version = None;
+                    return;
+                }
+            };
+
+        self.push_to_upgrade_journal(upgrade_journal_entry::UpgradeStarted {
+            current_version: self.proto.deployed_version.clone(),
+            expected_version: Some(next_version.clone()),
+            reason: Some(
+                upgrade_journal_entry::upgrade_started::Reason::BehindTargetVersion(Empty {}),
+            ),
+        });
+
+        self.proto.pending_version = Some(PendingVersion {
+            target_version: Some(next_version.clone()),
+            mark_failed_at_seconds: self.env.now() + 5 * 60,
+            checking_upgrade_lock: 0,
+            proposal_id: None,
+        });
+
+        println!("Initiating upgrade to version: {:?}", next_version);
+        let upgrade_attempt = self
+            .upgrade_sns_framework_canister(wasm_hash, canister_type)
+            .await;
+        if let Err(err) = upgrade_attempt {
+            log!(ERROR, "Upgrade attempt failed: {}", err);
+            self.proto.pending_version = None;
+            self.proto.target_version = None;
+        }
+    }
+
+    /// Invalidates the cached upgrade steps.
+    fn invalidate_cached_upgrade_steps(&mut self) {
+        self.proto.cached_upgrade_steps = None;
     }
 
     fn release_upgrade_periodic_task_lock(&mut self) {
@@ -4837,6 +4990,7 @@ impl Governance {
                 upgrade_steps: cached_upgrade_steps.upgrade_steps,
                 response_timestamp_seconds: cached_upgrade_steps.response_timestamp_seconds,
                 target_version: self.proto.target_version.clone(),
+                deployed_version: self.proto.deployed_version.clone(),
                 // TODO(NNS1-3416): Bound the size of the response.
                 upgrade_journal: self.proto.upgrade_journal.clone(),
             },
@@ -4844,6 +4998,7 @@ impl Governance {
                 upgrade_steps: None,
                 response_timestamp_seconds: None,
                 target_version: None,
+                deployed_version: self.proto.deployed_version.clone(),
                 // TODO(NNS1-3416): Bound the size of the response.
                 upgrade_journal: self.proto.upgrade_journal.clone(),
             },
@@ -5459,7 +5614,9 @@ impl Governance {
                     target_version
                 );
                 self.push_to_upgrade_journal(upgrade_journal_entry::UpgradeOutcome::success(None));
-                self.set_proposal_execution_status(proposal_id, Ok(()));
+                if let Some(proposal_id) = proposal_id {
+                    self.set_proposal_execution_status(proposal_id, Ok(()));
+                }
                 self.proto.deployed_version = Some(target_version);
                 self.proto.pending_version = None;
             }
@@ -5489,12 +5646,14 @@ impl Governance {
     // an error for an UpgradeSnsToNextVersion actions failure.  This unblocks further upgrade proposals.
     fn fail_sns_upgrade_to_next_version_proposal(
         &mut self,
-        proposal_id: u64,
+        proposal_id: Option<u64>,
         error: GovernanceError,
     ) {
         log!(ERROR, "{}", error.error_message);
         let result = Err(error);
-        self.set_proposal_execution_status(proposal_id, result);
+        if let Some(proposal_id) = proposal_id {
+            self.set_proposal_execution_status(proposal_id, result);
+        }
         self.proto.pending_version = None;
     }
 
@@ -5535,7 +5694,7 @@ impl Governance {
             self.fail_sns_upgrade_to_next_version_proposal(
                 pending_version.proposal_id,
                 GovernanceError::new_with_message(ErrorType::External, error),
-            );
+            )
         }
 
         FailStuckUpgradeInProgressResponse {}
@@ -7275,7 +7434,7 @@ mod tests {
                 target_version: Some(next_version.into()),
                 mark_failed_at_seconds: now + 5 * 60,
                 checking_upgrade_lock: 0,
-                proposal_id,
+                proposal_id: Some(proposal_id),
             }
         );
         // We do not check the upgrade completion in this test because of limitations
@@ -7590,7 +7749,7 @@ mod tests {
             target_version: Some(next_version.clone().into()),
             mark_failed_at_seconds,
             checking_upgrade_lock: 0,
-            proposal_id: 0,
+            proposal_id: Some(0),
         });
 
         // Make sure Governance state is correctly set
@@ -7600,7 +7759,7 @@ mod tests {
                 target_version: Some(next_version.clone().into()),
                 mark_failed_at_seconds,
                 checking_upgrade_lock: 0,
-                proposal_id: 0,
+                proposal_id: Some(0),
             }
         );
         assert_eq!(
@@ -7688,7 +7847,7 @@ mod tests {
                     target_version: Some(next_version.clone().into()),
                     mark_failed_at_seconds: now - 1,
                     checking_upgrade_lock: 0,
-                    proposal_id: 0,
+                    proposal_id: Some(0),
                 }),
                 ..basic_governance_proto()
             }
@@ -7706,7 +7865,7 @@ mod tests {
                 target_version: Some(next_version.into()),
                 mark_failed_at_seconds: now - 1,
                 checking_upgrade_lock: 0,
-                proposal_id: 0,
+                proposal_id: Some(0),
             }
         );
         assert_eq!(
@@ -7783,7 +7942,7 @@ mod tests {
                     target_version: Some(next_version.clone().into()),
                     mark_failed_at_seconds: now + 5 * 60,
                     checking_upgrade_lock: 0,
-                    proposal_id,
+                    proposal_id: Some(proposal_id),
                 }),
                 // we make a proposal that is already decided so that it won't execute again because
                 // proposals to upgrade SNS's cannot execute if there's no deployed_version set on Governance state
@@ -7829,7 +7988,7 @@ mod tests {
                 target_version: Some(next_version.clone().into()),
                 mark_failed_at_seconds: now + 5 * 60,
                 checking_upgrade_lock: 0,
-                proposal_id,
+                proposal_id: Some(proposal_id),
             }
         );
         assert_eq!(
@@ -7924,7 +8083,7 @@ mod tests {
                     target_version: Some(next_version.clone().into()),
                     mark_failed_at_seconds: now + 1,
                     checking_upgrade_lock: 0,
-                    proposal_id,
+                    proposal_id: Some(proposal_id),
                 }),
                 // we make a proposal that is already decided so that it won't execute again because
                 // proposals to upgrade SNS's cannot execute if there's no deployed_version set on Governance state
@@ -7970,7 +8129,7 @@ mod tests {
                 target_version: Some(next_version.clone().into()),
                 mark_failed_at_seconds: now + 1,
                 checking_upgrade_lock: 0,
-                proposal_id,
+                proposal_id: Some(proposal_id),
             }
         );
         assert_eq!(
@@ -7987,7 +8146,7 @@ mod tests {
                 target_version: Some(next_version.into()),
                 mark_failed_at_seconds: now + 1,
                 checking_upgrade_lock: 0,
-                proposal_id,
+                proposal_id: Some(proposal_id),
             }
         );
 
@@ -8060,7 +8219,7 @@ mod tests {
                     target_version: Some(next_version.clone().into()),
                     mark_failed_at_seconds: now - 1,
                     checking_upgrade_lock: 0,
-                    proposal_id,
+                    proposal_id: Some(proposal_id),
                 }),
                 // we make a proposal that is already decided so that it won't execute again because
                 // proposals to upgrade SNS's cannot execute if there's no deployed_version set on Governance state
@@ -8106,7 +8265,7 @@ mod tests {
                 target_version: Some(next_version.clone().into()),
                 mark_failed_at_seconds: now - 1,
                 checking_upgrade_lock: 0,
-                proposal_id,
+                proposal_id: Some(proposal_id),
             }
         );
         assert_eq!(
@@ -8208,7 +8367,7 @@ mod tests {
                     target_version: None,
                     mark_failed_at_seconds: now - 1,
                     checking_upgrade_lock: 0,
-                    proposal_id,
+                    proposal_id: Some(proposal_id),
                 }),
                 // we make a proposal that is already decided so that it won't execute again because
                 // proposals to upgrade SNS's cannot execute if there's no deployed_version set on Governance state
@@ -8343,7 +8502,7 @@ mod tests {
                     target_version: Some(next_version.clone().into()),
                     mark_failed_at_seconds: now + 5 * 60,
                     checking_upgrade_lock: 0,
-                    proposal_id,
+                    proposal_id: Some(proposal_id),
                 }),
                 // we make a proposal that is already decided so that it won't execute again because
                 // proposals to upgrade SNS's cannot execute if there's no deployed_version set on Governance state
@@ -8389,7 +8548,7 @@ mod tests {
                 target_version: Some(next_version.into()),
                 mark_failed_at_seconds: now + 5 * 60,
                 checking_upgrade_lock: 0,
-                proposal_id,
+                proposal_id: Some(proposal_id),
             }
         );
 
@@ -8550,7 +8709,7 @@ mod tests {
                     target_version: Some(next_version.clone().into()),
                     mark_failed_at_seconds: now + 5 * 60,
                     checking_upgrade_lock: 0,
-                    proposal_id,
+                    proposal_id: Some(proposal_id),
                 }),
                 ..basic_governance_proto()
             }
@@ -8568,7 +8727,7 @@ mod tests {
                 target_version: Some(next_version.clone().into()),
                 mark_failed_at_seconds: now + 5 * 60,
                 checking_upgrade_lock: 0,
-                proposal_id,
+                proposal_id: Some(proposal_id),
             }
         );
         assert_eq!(
@@ -8628,7 +8787,7 @@ mod tests {
                     target_version: Some(next_version.clone().into()),
                     mark_failed_at_seconds: now + 5 * 60,
                     checking_upgrade_lock: 0,
-                    proposal_id,
+                    proposal_id: Some(proposal_id),
                 }),
                 ..basic_governance_proto()
             }
@@ -8646,7 +8805,7 @@ mod tests {
                 target_version: Some(next_version.clone().into()),
                 mark_failed_at_seconds: now + 5 * 60,
                 checking_upgrade_lock: 0,
-                proposal_id,
+                proposal_id: Some(proposal_id),
             }
         );
         assert_eq!(
@@ -8842,7 +9001,7 @@ mod tests {
         );
 
         // Step 2: Run code under test.
-        let result = governance.check_no_other_upgrades_in_progress(upgrade_proposal_id);
+        let result = governance.check_no_upgrades_in_progress(Some(upgrade_proposal_id));
 
         // Step 3: Inspect result.
         assert!(result.is_ok(), "{:#?}", result);
@@ -8902,7 +9061,7 @@ mod tests {
         );
 
         // Step 2: Run code under test.
-        let result = governance.check_no_other_upgrades_in_progress(executing_upgrade_proposal_id);
+        let result = governance.check_no_upgrades_in_progress(Some(executing_upgrade_proposal_id));
 
         // Step 3: Inspect result.
         assert!(result.is_ok(), "{:#?}", result);
@@ -8963,7 +9122,7 @@ mod tests {
         );
 
         // Step 2: Run code under test.
-        let result = governance.check_no_other_upgrades_in_progress(upgrade_proposal_id);
+        let result = governance.check_no_upgrades_in_progress(Some(upgrade_proposal_id));
 
         // Step 3: Inspect result.
         assert!(result.is_ok(), "{:#?}", result);
@@ -9008,12 +9167,12 @@ mod tests {
         );
 
         // Step 2 & 3: Run code under test, and inspect results.
-        let result = governance.check_no_other_upgrades_in_progress(proposal_id);
+        let result = governance.check_no_upgrades_in_progress(Some(proposal_id));
         assert!(result.is_ok(), "{:#?}", result);
 
         // Other upgrades should be blocked by proposal 1 though.
         let some_other_proposal_id = 99_u64;
-        match governance.check_no_other_upgrades_in_progress(some_other_proposal_id) {
+        match governance.check_no_upgrades_in_progress(Some(some_other_proposal_id)) {
             Ok(_) => panic!("Some other upgrade proposal was not blocked."),
             Err(err) => assert_eq!(
                 err.error_type,
@@ -9067,7 +9226,7 @@ mod tests {
         );
 
         // Step 2 & 3: Run code under test, and inspect results.
-        match governance.check_no_other_upgrades_in_progress(proposal_id) {
+        match governance.check_no_upgrades_in_progress(Some(proposal_id)) {
             Ok(_) => panic!("Some other upgrade proposal was not blocked."),
             Err(err) => assert_eq!(
                 err.error_type,
@@ -9078,7 +9237,7 @@ mod tests {
         }
 
         let some_other_proposal_id = 99_u64;
-        match governance.check_no_other_upgrades_in_progress(some_other_proposal_id) {
+        match governance.check_no_upgrades_in_progress(Some(some_other_proposal_id)) {
             Ok(_) => panic!("Some other upgrade proposal was not blocked."),
             Err(err) => assert_eq!(
                 err.error_type,

--- a/rs/sns/governance/src/governance/tests/fail_stuck_upgrade_in_progress_tests.rs
+++ b/rs/sns/governance/src/governance/tests/fail_stuck_upgrade_in_progress_tests.rs
@@ -79,7 +79,7 @@ lazy_static! {
                 target_version: Some(SNS_VERSION_2.clone()),
                 mark_failed_at_seconds: UPGRADE_DEADLINE_TIMESTAMP_SECONDS,
                 checking_upgrade_lock: 10,
-                proposal_id: UPGRADE_PROPOSAL_ID,
+                proposal_id: Some(UPGRADE_PROPOSAL_ID),
             }),
             // we make a proposal that is already decided so that it won't execute again because
             // proposals to upgrade SNS's cannot execute if there's no deployed_version set on Governance state
@@ -173,7 +173,7 @@ fn test_does_nothing_if_upgrade_attempt_not_expired() {
         target_version: Some(SNS_VERSION_2.clone()),
         mark_failed_at_seconds: UPGRADE_DEADLINE_TIMESTAMP_SECONDS,
         checking_upgrade_lock: 10,
-        proposal_id: UPGRADE_PROPOSAL_ID,
+        proposal_id: Some(UPGRADE_PROPOSAL_ID),
     };
     assert_eq!(
         governance.proto.pending_version.clone().unwrap(),
@@ -252,7 +252,7 @@ fn test_fails_proposal_and_removes_upgrade_if_upgrade_attempt_is_expired() {
             target_version: Some(SNS_VERSION_2.clone()),
             mark_failed_at_seconds: UPGRADE_DEADLINE_TIMESTAMP_SECONDS,
             checking_upgrade_lock: 10,
-            proposal_id: UPGRADE_PROPOSAL_ID,
+            proposal_id: Some(UPGRADE_PROPOSAL_ID),
         }
     );
     assert_eq!(

--- a/rs/sns/governance/src/sns_upgrade.rs
+++ b/rs/sns/governance/src/sns_upgrade.rs
@@ -137,7 +137,7 @@ pub(crate) async fn get_proposal_id_that_added_wasm(
     Ok(proposal_id)
 }
 
-async fn get_canisters_to_upgrade(
+pub(crate) async fn get_canisters_to_upgrade(
     env: &dyn Environment,
     root_canister_id: CanisterId,
     canister_type: SnsCanisterType,
@@ -174,7 +174,7 @@ async fn get_canisters_to_upgrade(
         .collect()
 }
 
-fn canister_type_and_wasm_hash_for_upgrade(
+pub(crate) fn canister_type_and_wasm_hash_for_upgrade(
     current_version: &Version,
     next_version: &Version,
 ) -> Result<(SnsCanisterType, Vec<u8>), String> {

--- a/rs/sns/governance/src/types.rs
+++ b/rs/sns/governance/src/types.rs
@@ -16,7 +16,7 @@ use crate::{
             governance::{
                 self,
                 neuron_in_flight_command::{self, SyncCommand},
-                SnsMetadata,
+                SnsMetadata, Version,
             },
             governance_error::ErrorType,
             manage_neuron,
@@ -46,8 +46,8 @@ use ic_icrc1_ledger::UpgradeArgs as LedgerUpgradeArgs;
 use ic_ledger_core::tokens::TOKEN_SUBDIVIDABLE_BY;
 use ic_management_canister_types::CanisterInstallModeError;
 use ic_nervous_system_common::{
-    ledger_validation::MAX_LOGO_LENGTH, NervousSystemError, DEFAULT_TRANSFER_FEE, ONE_DAY_SECONDS,
-    ONE_MONTH_SECONDS, ONE_YEAR_SECONDS,
+    hash_to_hex_string, ledger_validation::MAX_LOGO_LENGTH, NervousSystemError,
+    DEFAULT_TRANSFER_FEE, ONE_DAY_SECONDS, ONE_MONTH_SECONDS, ONE_YEAR_SECONDS,
 };
 use ic_nervous_system_common_validation::validate_proposal_url;
 use ic_nervous_system_proto::pb::v1::{Duration as PbDuration, Percentage};
@@ -2528,6 +2528,21 @@ impl From<Vec<NeuronRecipe>> for NeuronRecipes {
 impl From<NeuronRecipes> for Vec<NeuronRecipe> {
     fn from(neuron_recipes: NeuronRecipes) -> Self {
         neuron_recipes.neuron_recipes
+    }
+}
+
+impl std::fmt::Display for Version {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "SnsVersion {{ root:{}, governance:{}, swap:{}, index:{}, ledger:{}, archive:{} }}",
+            hash_to_hex_string(&self.root_wasm_hash),
+            hash_to_hex_string(&self.governance_wasm_hash),
+            hash_to_hex_string(&self.swap_wasm_hash),
+            hash_to_hex_string(&self.index_wasm_hash),
+            hash_to_hex_string(&self.ledger_wasm_hash),
+            hash_to_hex_string(&self.archive_wasm_hash)
+        )
     }
 }
 

--- a/rs/sns/governance/src/upgrade_journal.rs
+++ b/rs/sns/governance/src/upgrade_journal.rs
@@ -14,6 +14,16 @@ impl upgrade_journal_entry::UpgradeStepsRefreshed {
     }
 }
 
+impl upgrade_journal_entry::UpgradeStepsReset {
+    /// Creates a new UpgradeStepsReset event with the given versions and message
+    pub fn new(human_readable: String, versions: Vec<Version>) -> Self {
+        Self {
+            human_readable: Some(human_readable),
+            upgrade_steps: Some(Versions { versions }),
+        }
+    }
+}
+
 impl upgrade_journal_entry::TargetVersionSet {
     /// Creates a new TargetVersionSet event with old and new versions
     pub fn new(old_version: Option<Version>, new_version: Option<Version>) -> Self {
@@ -26,10 +36,15 @@ impl upgrade_journal_entry::TargetVersionSet {
 
 impl upgrade_journal_entry::TargetVersionReset {
     /// Creates a new TargetVersionReset event with old and new versions
-    pub fn new(old_version: Option<Version>, new_version: Option<Version>) -> Self {
+    pub fn new(
+        old_version: Option<Version>,
+        new_version: Option<Version>,
+        human_readable: String,
+    ) -> Self {
         Self {
             old_target_version: old_version,
             new_target_version: new_version,
+            human_readable: Some(human_readable),
         }
     }
 }
@@ -118,6 +133,11 @@ impl Governance {
 impl From<upgrade_journal_entry::UpgradeStepsRefreshed> for upgrade_journal_entry::Event {
     fn from(event: upgrade_journal_entry::UpgradeStepsRefreshed) -> Self {
         upgrade_journal_entry::Event::UpgradeStepsRefreshed(event)
+    }
+}
+impl From<upgrade_journal_entry::UpgradeStepsReset> for upgrade_journal_entry::Event {
+    fn from(event: upgrade_journal_entry::UpgradeStepsReset) -> Self {
+        upgrade_journal_entry::Event::UpgradeStepsReset(event)
     }
 }
 impl From<upgrade_journal_entry::UpgradeStarted> for upgrade_journal_entry::Event {


### PR DESCRIPTION
This PR adds a new periodic task (or rather, a new thing to be called from our existing periodic task) that will initiate an upgrade when one is necessary.

At the time of writing the proto backwards compatibility checker is complaining about this:

```
ic_sns_governance/pb/v1/governance.proto:1427:5:Field "4" with name "proposal_id" on message "PendingVersion" changed cardinality from "optional with implicit presence" to "optional with explicit presence".
```

Which I don't really think is a real issue, so I'm tagging the PR with CI_OVERRIDE_BUF_BREAKING

[← Previous PR](https://github.com/dfinity/ic/pull/2453)