### PR TITLE
feat(IDX): use env vars for embedders test deps

### DIFF
--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -328,11 +328,26 @@ filegroup(
 # To be used for testing libraries that handle canister Wasm code.
 http_archive(
     name = "wasm_spec_testsuite",
-    build_file_content = """filegroup(
-         name = "wast_files",
-         srcs = glob(["**/*.wast"]),
-         visibility = ["//visibility:public"]
-     )""",
+    build_file_content = """
+# Exports the various test suites that we use
+
+filegroup(
+    name = "base_wast_files",
+    srcs = glob(["*.wast"]),
+    visibility = ["//visibility:public"]
+)
+filegroup(
+    name = "multi_memory_wast_files",
+    srcs = glob(["proposals/multi-memory/*.wast"]),
+    visibility = ["//visibility:public"]
+)
+filegroup(
+    name = "memory64_wast_files",
+    srcs = glob(["proposals/memory64/*.wast"]),
+    visibility = ["//visibility:public"]
+)
+
+     """,
     sha256 = "9afc0e7c250b5f0dcf32e9a95860b99a392ab78a653fcf3705778e8a9357f3c4",
     strip_prefix = "testsuite-4f77306bb63151631d84f58dedf67958eb9911b9",
     url = "https://github.com/WebAssembly/testsuite/archive/4f77306bb63151631d84f58dedf67958eb9911b9.tar.gz",

--- a/rs/embedders/BUILD.bazel
+++ b/rs/embedders/BUILD.bazel
@@ -122,6 +122,12 @@ rust_test(
     deps = [":embedders"] + DEPENDENCIES + DEV_DEPENDENCIES,
 )
 
+# Run some tests using wasm spec files.
+# To add a test suite, see the `http_archive` pulling in the testsuite
+# and add a new target.
+#
+# To inspect the spec files, use this command:
+# $ ls $(bazel info output_base)/external/wasm_spec_testsuite
 rust_ic_test_suite_with_extra_srcs(
     name = "embedders_integration",
     srcs = glob(
@@ -133,13 +139,20 @@ rust_ic_test_suite_with_extra_srcs(
     ),
     aliases = ALIASES,
     compile_data = glob(["tests/instrumentation-test-data/*"]),
-    data = DATA + ["@wasm_spec_testsuite//:wast_files"] + glob([
+    data = DATA + [
+        "@wasm_spec_testsuite//:base_wast_files",
+        "@wasm_spec_testsuite//:memory64_wast_files",
+        "@wasm_spec_testsuite//:multi_memory_wast_files",
+    ] + glob([
         "tests/compressed/*",
         "tests/instrumentation-test-data/*",
         "tests/round-trip-test-data/*",
     ]),
     env = dict(ENV.items() + [
         ("CARGO_MANIFEST_DIR", "rs/embedders"),
+        ("WASM_SPEC_BASE", "$(locations @wasm_spec_testsuite//:base_wast_files)"),
+        ("WASM_SPEC_MULTI_MEMORY", "$(locations @wasm_spec_testsuite//:multi_memory_wast_files)"),
+        ("WASM_SPEC_MEMORY64", "$(locations @wasm_spec_testsuite//:memory64_wast_files)"),
     ]),
     extra_srcs = [
         "tests/wasmtime_simple.rs",

--- a/rs/embedders/tests/spec_tests.rs
+++ b/rs/embedders/tests/spec_tests.rs
@@ -800,7 +800,6 @@ fn error_to_string(e: anyhow::Error) -> String {
 /// rule in `WORKSPACE.bazel`.
 ///
 /// See BUILD.bazel for inspecting the `wast` files.
-/// `bazel-ic/external/wasm_spec_testsuite/` after building this test.
 #[test]
 fn spec_testsuite() {
     let test_files = parse_env_test_files("WASM_SPEC_BASE");

--- a/rs/embedders/tests/spec_tests.rs
+++ b/rs/embedders/tests/spec_tests.rs
@@ -1,4 +1,4 @@
-use std::{ffi::OsString, fmt::Write, fs, path::PathBuf};
+use std::{fmt::Write, fs, path::PathBuf};
 
 use ic_embedders::wasm_utils::validation::wasmtime_validation_config;
 use wasmtime::{
@@ -744,18 +744,10 @@ fn test_spec_file(
     }
 }
 
-fn run_testsuite(subdirectory: &str, config: &Config, parsing_multi_memory_enabled: bool) {
-    let dir_path = format!("./external/wasm_spec_testsuite/{}", subdirectory);
-    let directory = std::fs::read_dir(dir_path).unwrap();
-    let mut test_files = vec![];
-    for entry in directory {
-        let entry = entry.unwrap();
-        let path = entry.path();
-        if path.extension() == Some(&OsString::from("wast"))
-            && !FILES_TO_SKIP.contains(&path.file_name().unwrap().to_str().unwrap())
-        {
-            test_files.push(path);
-        }
+/// Run tests on the spec files and collect errors.
+fn run_testsuite(test_files: Vec<PathBuf>, config: &Config, parsing_multi_memory_enabled: bool) {
+    if test_files.is_empty() {
+        panic!("No test files");
     }
 
     println!("Running spec tests on {} files", test_files.len());
@@ -770,6 +762,19 @@ fn run_testsuite(subdirectory: &str, config: &Config, parsing_multi_memory_enabl
     if !errors.is_empty() {
         panic!("Errors from spec tests: {}", errors.join("\n"));
     }
+}
+
+/// Return the list of (wasm spec) test files pointed to by the environment variable (potentially
+/// filtered out, see below).
+fn parse_env_test_files(varname: &str) -> Vec<PathBuf> {
+    let files =
+        std::env::var(varname).unwrap_or_else(|_| panic!("Could not read env var '{varname}'"));
+    files
+        .split(" ") /* File names are space-separated */
+        .map(|f| f.into()) /* str -> PathBuf */
+        /* see FILES_TO_SKIP */
+        .filter(|f: &PathBuf| !FILES_TO_SKIP.contains(&f.file_name().unwrap().to_str().unwrap()))
+        .collect()
 }
 
 /// Returns the config that is as close as possible to the actual config used in
@@ -794,29 +799,24 @@ fn error_to_string(e: anyhow::Error) -> String {
 /// included in our repo, but is imported by Bazel using the `new_git_repository`
 /// rule in `WORKSPACE.bazel`.
 ///
-/// If you need to look at the test `wast` files directly they can be found in
+/// See BUILD.bazel for inspecting the `wast` files.
 /// `bazel-ic/external/wasm_spec_testsuite/` after building this test.
 #[test]
 fn spec_testsuite() {
-    run_testsuite("", &default_config(), false)
+    let test_files = parse_env_test_files("WASM_SPEC_BASE");
+    run_testsuite(test_files, &default_config(), false)
 }
 
 #[test]
 fn multi_memory_testsuite() {
-    run_testsuite(
-        "proposals/multi-memory",
-        default_config().wasm_multi_memory(true),
-        true,
-    )
+    let test_files = parse_env_test_files("WASM_SPEC_MULTI_MEMORY");
+    run_testsuite(test_files, default_config().wasm_multi_memory(true), true)
 }
 
 #[test]
 fn memory64_testsuite() {
     let mut config = Config::default();
     config.wasm_memory64(true);
-    run_testsuite(
-        "proposals/memory64",
-        default_config().wasm_memory64(true),
-        false,
-    )
+    let test_files = parse_env_test_files("WASM_SPEC_MEMORY64");
+    run_testsuite(test_files, default_config().wasm_memory64(true), false)
 }


### PR DESCRIPTION
This changes the embedders spec tests to use environment variables (set in `BUILD.bazel`) to specify the path to the wasm spec files.

This ensures that the tests do not depend on Bazel paths like `external/` and (more theoretically than practically) will make the tests run only if a file specifically depended on changes.