### PR TITLE
fix(IDX): remove unused Cargo.toml cloudflare key

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -493,9 +493,8 @@ clap = { version = "4.5.18", features = ["derive", "string"] }
 # see:
 # - https://github.com/cloudflare/cloudflare-rs/issues/222
 # - https://github.com/cloudflare/cloudflare-rs/issues/236
-cloudflare = { git = "https://github.com/dfinity/cloudflare-rs.git", rev = "a6538a036926bd756986c9c0a5de356daef48881", default-features = false, feature = [
-    "rustls-tls",
-] }
+cloudflare = { git = "https://github.com/dfinity/cloudflare-rs.git", rev = "a6538a036926bd756986c9c0a5de356daef48881", default-features = false }
+
 criterion = { version = "0.5.1", features = ["html_reports", "async_tokio"] }
 crossbeam-channel = "0.5.13"
 curve25519-dalek = { version = "4.1.3", features = [


### PR DESCRIPTION
This removes the `feature` (without `s`) specified for the `cloudflare` crate. `feature` is not a valid key. The `rustls-tls` feature does not seem to be necessary.