### PR TITLE
chore: remove the INITIAL_NOTARY_DELAY_NNS_SUBNET constant

### DIFF
--- a/rs/limits/src/lib.rs
+++ b/rs/limits/src/lib.rs
@@ -54,7 +54,6 @@ pub const MEGABYTE: u64 = KILOBYTE * KILOBYTE;
 pub const UNIT_DELAY_APP_SUBNET: Duration = Duration::from_millis(1000);
 pub const UNIT_DELAY_NNS_SUBNET: Duration = Duration::from_millis(3000);
 pub const INITIAL_NOTARY_DELAY: Duration = Duration::from_millis(300);
-pub const INITIAL_NOTARY_DELAY_NNS_SUBNET: Duration = Duration::from_millis(1000);
 pub const MAX_INGRESS_MESSAGES_PER_BLOCK: u64 = 1000;
 pub const MAX_BLOCK_PAYLOAD_SIZE: u64 = 4 * MEGABYTE;
 /// This sets the upper bound on how big a single ingress message can be, as

--- a/rs/prep/src/subnet_configuration.rs
+++ b/rs/prep/src/subnet_configuration.rs
@@ -191,7 +191,7 @@ pub fn get_default_config_params(subnet_type: SubnetType, nodes_num: usize) -> S
     } else {
         DynamicConfig {
             unit_delay: ic_limits::UNIT_DELAY_NNS_SUBNET,
-            initial_notary_delay: ic_limits::INITIAL_NOTARY_DELAY_NNS_SUBNET,
+            initial_notary_delay: ic_limits::INITIAL_NOTARY_DELAY,
             dkg_interval_length: ic_limits::DKG_INTERVAL_HEIGHT.into(),
             max_ingress_bytes_per_message: ic_limits::MAX_INGRESS_BYTES_PER_MESSAGE_NNS_SUBNET,
         }


### PR DESCRIPTION
This constant is used only in system tests. In production the initial notary delay will be updated to the new value for the NNS subnet in few weeks. Let's start running our tests with the new value before that.