### PR TITLE
chore(IDX): notify for schedule hourly

### DIFF
--- a/.github/workflows/slack-workflow-run.yml
+++ b/.github/workflows/slack-workflow-run.yml
@@ -11,6 +11,7 @@ on:
       - release-*
     workflows:
       - Schedule Daily
+      - Schedule Hourly
       - Schedule RC
       - Schedule Rust Benchmarks
       - Schedule Weekly


### PR DESCRIPTION
Now that we are only notified of failures, we can add `Schedule Hourly` as well.