### PR TITLE
chore(PocketIC): increase PocketIC library test resources

### DIFF
--- a/packages/pocket-ic/BUILD.bazel
+++ b/packages/pocket-ic/BUILD.bazel
@@ -73,7 +73,7 @@ rust_test(
 
 rust_test_suite(
     name = "test",
-    size = "small",
+    size = "medium",
     srcs = ["tests/tests.rs"],
     data = [
         "tests/counter.wasm",
@@ -89,6 +89,7 @@ rust_test_suite(
     },
     flaky = False,
     proc_macro_deps = MACRO_DEPENDENCIES,
+    tags = ["cpu:8"],
     deps = [":pocket-ic"] + DEPENDENCIES + TEST_DEPENDENCIES,
 )
 


### PR DESCRIPTION
This PR increases the PocketIC library test resources to address its timeouts:
- the size of the test is now medium;
- the CPU count of the test is 8.