### PR TITLE
chore(IDX): bump timeout for macos tests

### DIFF
--- a/.github/workflows-source/ci-main.yml
+++ b/.github/workflows-source/ci-main.yml
@@ -157,7 +157,7 @@ jobs:
 
   bazel-test-macos-intel:
     name: Bazel Test macOS Intel
-    timeout-minutes: 120
+    timeout-minutes: 130
     runs-on:
       labels: macOS
     # Run on protected branches, but only on public repo

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -149,7 +149,7 @@ jobs:
             profile.json
   bazel-test-macos-intel:
     name: Bazel Test macOS Intel
-    timeout-minutes: 120
+    timeout-minutes: 130
     runs-on:
       labels: macOS
     # Run on protected branches, but only on public repo


### PR DESCRIPTION
We see occasional timeouts for `bazel-test-macos-intel` so bump by 10 min.