### PR TITLE
feat(sns): Data migration that retrofits Swap.{direct_participation_icp_e8s, neurons_fund_participation_icp_e8s} + golden upgrade tests 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11759,6 +11759,7 @@ dependencies = [
  "ic-nns-constants",
  "ic-nns-governance-api",
  "ic-nns-test-utils",
+ "ic-nns-test-utils-golden-nns-state",
  "ic-protobuf",
  "ic-registry-subnet-type",
  "ic-sns-governance",

--- a/mainnet-canisters.json
+++ b/mainnet-canisters.json
@@ -20,24 +20,24 @@
     "sha256": "e6072806ae22868ee09c07923d093b1b0b687dba540d22cfc1e1a5392bfcca46"
   },
   "cycles-minting": {
-    "rev": "77f48ae63af09b6538b1bf33d3accc3bc74d14f8",
-    "sha256": "3260e795bd3e446a189539ce89d44cb29f7d196b92cdd2e2c75571c062ef1e50"
+    "rev": "ca8847547d327ce8a3bd81d25a590e01da1a3af5",
+    "sha256": "57f2cbbdbc2d8943173acc6ebd55aca9b9c12e2140b38ff5f20aea7b101ea570"
   },
   "genesis-token": {
     "rev": "cf237434877b39d0a94fb5ef84b13ea576a225ac",
     "sha256": "31d91cbdfa6e1aae4cc4fee4f611e25f33922bd3d336f4cdc97d511e03b264a7"
   },
   "governance": {
-    "rev": "87343a880050ca72b1361138535211f5770dd52e",
-    "sha256": "8665830c50c9a0dddd996008e537d060a380ac7b6c22237679bd0cecc4ee1044"
+    "rev": "c494c2af8bfc70a6501448dc73bf806477388738",
+    "sha256": "365411fcf8a925775e2111778ddda8f22ce828366c79b53b97ea78554dde381b"
   },
   "index": {
     "rev": "b43280208c32633a29657a1051660324e88a373d",
     "sha256": "62bbbada301838ad0f6e371415be990ce70e36c6f11267d4ba9fac8ff09aa32d"
   },
   "ledger": {
-    "rev": "b0ade55f7e8999e2842fe3f49df163ba224b71a2",
-    "sha256": "d0ec2cdeee48e2dbee07c59dfdc3928413de86930242fef0704ab7c1be6c7664"
+    "rev": "6dcfafb491092704d374317d9a72a7ad2475d7c9",
+    "sha256": "4fe38a91a3130e9d8b39e3413ae3b3f46c40d3fbd507df1b6092f962d970a7ea"
   },
   "lifeline": {
     "rev": "a0207146be211cdff83321c99e9e70baa62733c7",
@@ -48,20 +48,20 @@
     "sha256": "57c72469f01fd6ea8b5c5a962a1fed9b4ad550bbebdae38c29d5ad330c25c724"
   },
   "root": {
-    "rev": "a0207146be211cdff83321c99e9e70baa62733c7",
-    "sha256": "c280a25dc565f8a42429cb5b969906c4c5a789381e98f6e11c247c91c4dfaac5"
+    "rev": "c494c2af8bfc70a6501448dc73bf806477388738",
+    "sha256": "657010591182ce758c86f020d1eade5f7a188072cf0de9c41e2f9d577849c964"
   },
   "sns-wasm": {
-    "rev": "87343a880050ca72b1361138535211f5770dd52e",
-    "sha256": "6dd00ebe425ba360be161c880ce3a3b3cda5a3738d6b323a9fd0366debf590ce"
+    "rev": "c494c2af8bfc70a6501448dc73bf806477388738",
+    "sha256": "18fa2612dd51837d8f54769761b421627826fa1e19bb3a788ea6ffa8bd59f7b8"
   },
   "sns_archive": {
     "rev": "d4ee25b0865e89d3eaac13a60f0016d5e3296b31",
     "sha256": "9476aa71bcee621aba93a3d7c115c543f42c543de840da3224c5f70a32dbfe4d"
   },
   "sns_governance": {
-    "rev": "db5901a6e90b718918978ae5167b9c98d5aa7ab6",
-    "sha256": "b80737a35a19cd3e06af3b89eabaeeba901726afa84bc108117cff6f266d55b4"
+    "rev": "c494c2af8bfc70a6501448dc73bf806477388738",
+    "sha256": "62be1b74e8f8d1c51253035c91bc6f159c2885bcf653f79e9143b8edcd60ff9c"
   },
   "sns_index": {
     "rev": "d4ee25b0865e89d3eaac13a60f0016d5e3296b31",
@@ -76,7 +76,7 @@
     "sha256": "d93e219b1c7f50098da1e4b19dae3e803014f7450e4fb61de5a0dc46dd94d6e1"
   },
   "swap": {
-    "rev": "87343a880050ca72b1361138535211f5770dd52e",
-    "sha256": "4ea01d425cd9c6c0a2c4988af03710d7c2377527eb0375067c69a9baff9963f2"
+    "rev": "c494c2af8bfc70a6501448dc73bf806477388738",
+    "sha256": "a301ef4fd2c752cd96390a3d3b655e93c8efd8c0958962e3cf4d8deed02bdc1d"
   }
 }

--- a/mainnet-canisters.json
+++ b/mainnet-canisters.json
@@ -20,24 +20,24 @@
     "sha256": "e6072806ae22868ee09c07923d093b1b0b687dba540d22cfc1e1a5392bfcca46"
   },
   "cycles-minting": {
-    "rev": "ca8847547d327ce8a3bd81d25a590e01da1a3af5",
-    "sha256": "57f2cbbdbc2d8943173acc6ebd55aca9b9c12e2140b38ff5f20aea7b101ea570"
+    "rev": "77f48ae63af09b6538b1bf33d3accc3bc74d14f8",
+    "sha256": "3260e795bd3e446a189539ce89d44cb29f7d196b92cdd2e2c75571c062ef1e50"
   },
   "genesis-token": {
     "rev": "cf237434877b39d0a94fb5ef84b13ea576a225ac",
     "sha256": "31d91cbdfa6e1aae4cc4fee4f611e25f33922bd3d336f4cdc97d511e03b264a7"
   },
   "governance": {
-    "rev": "c494c2af8bfc70a6501448dc73bf806477388738",
-    "sha256": "365411fcf8a925775e2111778ddda8f22ce828366c79b53b97ea78554dde381b"
+    "rev": "87343a880050ca72b1361138535211f5770dd52e",
+    "sha256": "8665830c50c9a0dddd996008e537d060a380ac7b6c22237679bd0cecc4ee1044"
   },
   "index": {
     "rev": "b43280208c32633a29657a1051660324e88a373d",
     "sha256": "62bbbada301838ad0f6e371415be990ce70e36c6f11267d4ba9fac8ff09aa32d"
   },
   "ledger": {
-    "rev": "6dcfafb491092704d374317d9a72a7ad2475d7c9",
-    "sha256": "4fe38a91a3130e9d8b39e3413ae3b3f46c40d3fbd507df1b6092f962d970a7ea"
+    "rev": "b0ade55f7e8999e2842fe3f49df163ba224b71a2",
+    "sha256": "d0ec2cdeee48e2dbee07c59dfdc3928413de86930242fef0704ab7c1be6c7664"
   },
   "lifeline": {
     "rev": "a0207146be211cdff83321c99e9e70baa62733c7",
@@ -48,20 +48,20 @@
     "sha256": "57c72469f01fd6ea8b5c5a962a1fed9b4ad550bbebdae38c29d5ad330c25c724"
   },
   "root": {
-    "rev": "c494c2af8bfc70a6501448dc73bf806477388738",
-    "sha256": "657010591182ce758c86f020d1eade5f7a188072cf0de9c41e2f9d577849c964"
+    "rev": "a0207146be211cdff83321c99e9e70baa62733c7",
+    "sha256": "c280a25dc565f8a42429cb5b969906c4c5a789381e98f6e11c247c91c4dfaac5"
   },
   "sns-wasm": {
-    "rev": "c494c2af8bfc70a6501448dc73bf806477388738",
-    "sha256": "18fa2612dd51837d8f54769761b421627826fa1e19bb3a788ea6ffa8bd59f7b8"
+    "rev": "87343a880050ca72b1361138535211f5770dd52e",
+    "sha256": "6dd00ebe425ba360be161c880ce3a3b3cda5a3738d6b323a9fd0366debf590ce"
   },
   "sns_archive": {
     "rev": "d4ee25b0865e89d3eaac13a60f0016d5e3296b31",
     "sha256": "9476aa71bcee621aba93a3d7c115c543f42c543de840da3224c5f70a32dbfe4d"
   },
   "sns_governance": {
-    "rev": "c494c2af8bfc70a6501448dc73bf806477388738",
-    "sha256": "62be1b74e8f8d1c51253035c91bc6f159c2885bcf653f79e9143b8edcd60ff9c"
+    "rev": "db5901a6e90b718918978ae5167b9c98d5aa7ab6",
+    "sha256": "b80737a35a19cd3e06af3b89eabaeeba901726afa84bc108117cff6f266d55b4"
   },
   "sns_index": {
     "rev": "d4ee25b0865e89d3eaac13a60f0016d5e3296b31",
@@ -76,7 +76,7 @@
     "sha256": "d93e219b1c7f50098da1e4b19dae3e803014f7450e4fb61de5a0dc46dd94d6e1"
   },
   "swap": {
-    "rev": "c494c2af8bfc70a6501448dc73bf806477388738",
-    "sha256": "a301ef4fd2c752cd96390a3d3b655e93c8efd8c0958962e3cf4d8deed02bdc1d"
+    "rev": "87343a880050ca72b1361138535211f5770dd52e",
+    "sha256": "4ea01d425cd9c6c0a2c4988af03710d7c2377527eb0375067c69a9baff9963f2"
   }
 }

--- a/rs/sns/integration_tests/BUILD.bazel
+++ b/rs/sns/integration_tests/BUILD.bazel
@@ -180,7 +180,6 @@ ENV = {
     "SNS_TEST_DAPP_CANISTER_WASM_PATH": "$(rootpath //rs/sns/integration_tests:sns-test-dapp-canister)",
     "SNS_WASM_CANISTER_WASM_PATH": "$(rootpath //rs/nns/sns-wasm:sns-wasm-canister)",
     "UNSTOPPABLE_CANISTER_WASM_PATH": "$(rootpath //rs/nns/integration_tests:unstoppable-canister)",
-    "MAINNET_SNS_SWAP_CANISTER_WASM_PATH": "$(rootpath @mainnet_sns-swap-canister//file)",
 }
 
 rust_ic_test_suite_with_extra_srcs(
@@ -247,7 +246,9 @@ rust_ic_test_suite_with_extra_srcs(
     data = DATA_DEPS + [
         "@mainnet_sns-swap-canister//file",
     ],
-    env = ENV,
+    env = dict(ENV.items() + [
+        ("MAINNET_SNS_SWAP_CANISTER_WASM_PATH", "$(rootpath @mainnet_sns-swap-canister//file)"),
+    ]),
     extra_srcs = [],
     proc_macro_deps = MACRO_DEPENDENCIES + MACRO_DEV_DEPENDENCIES,
     tags = [

--- a/rs/sns/integration_tests/BUILD.bazel
+++ b/rs/sns/integration_tests/BUILD.bazel
@@ -252,10 +252,9 @@ rust_ic_test_suite_with_extra_srcs(
     proc_macro_deps = MACRO_DEPENDENCIES + MACRO_DEV_DEPENDENCIES,
     tags = [
         "cpu:8",
+        "manual",  # TODO: Enable on CI
         "no-sandbox",  # such that the test can access the file $SSH_AUTH_SOCK.
         "requires-network",  # Because mainnet state is downloaded (and used).
-        "manual", # TODO: Enable on CI
     ],
-    deps = DEPENDENCIES_WITH_TEST_FEATURES + TEST_DEV_DEPENDENCIES + ["//rs/nns/test_utils/golden_nns_state",],
-
+    deps = DEPENDENCIES_WITH_TEST_FEATURES + TEST_DEV_DEPENDENCIES + ["//rs/nns/test_utils/golden_nns_state"],
 )

--- a/rs/sns/integration_tests/BUILD.bazel
+++ b/rs/sns/integration_tests/BUILD.bazel
@@ -180,6 +180,7 @@ ENV = {
     "SNS_TEST_DAPP_CANISTER_WASM_PATH": "$(rootpath //rs/sns/integration_tests:sns-test-dapp-canister)",
     "SNS_WASM_CANISTER_WASM_PATH": "$(rootpath //rs/nns/sns-wasm:sns-wasm-canister)",
     "UNSTOPPABLE_CANISTER_WASM_PATH": "$(rootpath //rs/nns/integration_tests:unstoppable-canister)",
+    "MAINNET_SNS_SWAP_CANISTER_WASM_PATH": "$(rootpath @mainnet_sns-swap-canister//file)",
 }
 
 rust_ic_test_suite_with_extra_srcs(
@@ -189,6 +190,7 @@ rust_ic_test_suite_with_extra_srcs(
         ["src/*.rs"],
         exclude = [
             "src/lib.rs",
+            "src/golden_state_swap_upgrade_twice.rs",
         ],
     ),
     aliases = ALIASES,
@@ -203,4 +205,57 @@ rust_ic_test_suite_with_extra_srcs(
     proc_macro_deps = MACRO_DEPENDENCIES + MACRO_DEV_DEPENDENCIES,
     tags = ["cpu:8"],
     deps = DEPENDENCIES_WITH_TEST_FEATURES + TEST_DEV_DEPENDENCIES,
+)
+
+# To run this test,
+#
+#     bazel \
+#         test \
+#         --test_env=SSH_AUTH_SOCK \
+#         --test_timeout=43200 \
+#         //rs/sns/integration_tests:golden_state_swap_upgrade_twice
+#
+# The unusual things in this command are:
+#  - `--test_env=SSH_AUTH_SOCK`: This causes the SSH_AUTH_SOCK environment variable to be
+#    "forwarded" from your shell to the sandbox where the test is run. This authorizes the test
+#    to download the test data.
+#  - `--test_timeout=43200`: This sets the test timeout to 12 hours (more than currently required).
+#
+# Additionally, the following flags are recommended (but not required):
+#
+# --test_output=streamed
+# --test_arg=--nocapture
+#
+# These let you watch the progress of the test, rather than only being able to see the output only
+# at the end.
+#
+# See the .bazelrc for more configuration information.
+rust_ic_test_suite_with_extra_srcs(
+    name = "golden_state_swap_upgrade_twice",
+    # This uses on the order of 50 GB of disk space.
+    # Therefore, size = "large" is not large enough.
+    size = "enormous",
+    srcs = [
+        "src/golden_state_swap_upgrade_twice.rs",
+    ],
+    aliases = ALIASES,
+    args = [
+        "--test-threads",
+        "7",
+    ],
+    crate_features = ["test"],
+    data = DATA_DEPS + [
+        "@mainnet_sns-swap-canister//file",
+    ],
+    env = ENV,
+    extra_srcs = [],
+    proc_macro_deps = MACRO_DEPENDENCIES + MACRO_DEV_DEPENDENCIES,
+    tags = [
+        "cpu:8",
+        "no-sandbox",  # such that the test can access the file $SSH_AUTH_SOCK.
+        "requires-network",  # Because mainnet state is downloaded (and used).
+        "manual", # TODO: Enable on CI
+    ],
+    deps = DEPENDENCIES_WITH_TEST_FEATURES + TEST_DEV_DEPENDENCIES + ["//rs/nns/test_utils/golden_nns_state",],
+
 )

--- a/rs/sns/integration_tests/Cargo.toml
+++ b/rs/sns/integration_tests/Cargo.toml
@@ -38,6 +38,7 @@ ic-registry-subnet-type = { path = "../../registry/subnet_type" }
 ic-sns-governance = { path = "../governance" }
 ic-sns-init = { path = "../init" }
 ic-sns-root = { path = "../root" }
+ic-nns-test-utils-golden-nns-state = { path = "../../nns/test_utils/golden_nns_state" }
 ic-universal-canister = { path = "../../universal_canister/lib" }
 icrc-ledger-types = { path = "../../../packages/icrc-ledger-types" }
 maplit = "1.0.2"

--- a/rs/sns/integration_tests/src/golden_state_swap_upgrade_twice.rs
+++ b/rs/sns/integration_tests/src/golden_state_swap_upgrade_twice.rs
@@ -6,6 +6,7 @@ use ic_sns_swap::pb::v1::{DerivedState, GetStateRequest, GetStateResponse, Swap}
 use ic_sns_wasm::pb::v1::SnsWasm;
 use ic_state_machine_tests::StateMachine;
 use ic_types::{CanisterId, PrincipalId};
+use pretty_assertions::assert_eq;
 use std::str::FromStr;
 
 // TODO[NNS1-3386]: Remove this function once all existing Swaps are upgraded.
@@ -135,7 +136,7 @@ fn run_test_for_swap(state_machine: &StateMachine, swap_canister_id: &str, sns_n
 }
 
 #[test]
-fn upgrade_downgrade_swap_boom_dao() {
+fn golden_state_swap_upgrade_twice() {
     let snses_under_test = [
         ("vuqiy-liaaa-aaaaq-aabiq-cai", "BOOM DAO"),
         ("iuhw5-siaaa-aaaaq-aadoq-cai", "CYCLES-TRANSFER-STATION"),
@@ -146,8 +147,7 @@ fn upgrade_downgrade_swap_boom_dao() {
         ("grlys-pqaaa-aaaaq-aacoa-cai", "ELNA AI"),
         ("bcl3g-3aaaa-aaaaq-aac5a-cai", "EstateDAO"),
         ("t7z6p-ryaaa-aaaaq-aab7q-cai", "Gold DAO"),
-        // TODO: Uncomment once ICGhost has enough cycles to make it through two upgrades.
-        // ("4f5dx-pyaaa-aaaaq-aaa3q-cai", "ICGhost"),
+        ("4f5dx-pyaaa-aaaaq-aaa3q-cai", "ICGhost"),
         ("habgn-xyaaa-aaaaq-aaclq-cai", "ICLighthouse DAO"),
         ("lwslc-cyaaa-aaaaq-aadfq-cai", "ICPCC DAO LLC"),
         ("ch7an-giaaa-aaaaq-aacwq-cai", "ICPSwap"),

--- a/rs/sns/integration_tests/src/golden_state_swap_upgrade_twice.rs
+++ b/rs/sns/integration_tests/src/golden_state_swap_upgrade_twice.rs
@@ -169,7 +169,8 @@ fn upgrade_downgrade_swap_boom_dao() {
         ("a2cof-vaaaa-aaaaq-aacza-cai", "Yuku DAO"),
     ];
 
-    let state_machine = ic_nns_test_utils_golden_nns_state::new_state_machine_or_panic();
+    let state_machine =
+        ic_nns_test_utils_golden_nns_state::new_state_machine_with_golden_sns_state_or_panic();
 
     for (swap_canister_id, sns_name) in snses_under_test {
         run_test_for_swap(&state_machine, swap_canister_id, sns_name);

--- a/rs/sns/integration_tests/src/golden_state_swap_upgrade_twice.rs
+++ b/rs/sns/integration_tests/src/golden_state_swap_upgrade_twice.rs
@@ -1,0 +1,279 @@
+use candid::{Decode, Encode};
+use ic_nns_test_utils::sns_wasm::{
+    build_swap_sns_wasm, create_modified_sns_wasm, ensure_sns_wasm_gzipped,
+};
+use ic_sns_swap::pb::v1::{DerivedState, GetStateRequest, GetStateResponse, Swap};
+use ic_sns_wasm::pb::v1::SnsWasm;
+use ic_state_machine_tests::StateMachine;
+use ic_types::{CanisterId, PrincipalId};
+use std::str::FromStr;
+
+// TODO[NNS1-3386]: Remove this function once all existing Swaps are upgraded.
+fn redact_unavailable_swap_fields(swap_state: &mut GetStateResponse) {
+    // The following fields were added to the swap state later than some of the Swap canisters'
+    // last upgrade. These fields will become available after those canisters are upgraded.
+    {
+        let swap = swap_state.swap.clone().unwrap();
+        swap_state.swap = Some(Swap {
+            timers: None,
+            direct_participation_icp_e8s: None,
+            neurons_fund_participation_icp_e8s: None,
+            ..swap
+        });
+    }
+
+    // The following fields were added to the derived state later than some of the Swap canisters'
+    // last upgrade. These fields will become available after those canisters are upgraded.
+    {
+        let derived = swap_state.derived.clone().unwrap();
+        swap_state.derived = Some(DerivedState {
+            direct_participant_count: None,
+            cf_participant_count: None,
+            cf_neuron_count: None,
+            direct_participation_icp_e8s: None,
+            neurons_fund_participation_icp_e8s: None,
+            ..derived
+        });
+    }
+}
+
+fn get_state(
+    state_machine: &StateMachine,
+    swap_canister_id: CanisterId,
+    sns_name: &str,
+) -> GetStateResponse {
+    let args = Encode!(&GetStateRequest {}).unwrap();
+    let state_before_upgrade = state_machine
+        .execute_ingress(swap_canister_id, "get_state", args)
+        .expect(&format!(
+            "Unable to get state of {}'s Swap canister",
+            sns_name
+        ));
+    Decode!(&state_before_upgrade.bytes(), GetStateResponse).unwrap()
+}
+
+fn upgrade_swap_to_tip_of_master(
+    state_machine: &StateMachine,
+    swap_canister_id: CanisterId,
+    swap_wasm: SnsWasm,
+    sns_name: &str,
+) {
+    let swap_upgrade_arg = Encode!().unwrap();
+
+    state_machine
+        .upgrade_canister(swap_canister_id, swap_wasm.wasm, swap_upgrade_arg)
+        .expect(&format!("Cannot upgrade {}'s Swap canister", sns_name));
+}
+
+/// Returns the pre-upgrade and post-upgrade states of the Swap.
+fn run_upgrade_for_swap(
+    state_machine: &StateMachine,
+    swap_canister_id: CanisterId,
+    swap_wasm: SnsWasm,
+    sns_name: &str,
+) -> (GetStateResponse, GetStateResponse) {
+    let swap_pre_state = get_state(&state_machine, swap_canister_id, sns_name);
+
+    upgrade_swap_to_tip_of_master(&state_machine, swap_canister_id, swap_wasm, sns_name);
+
+    let swap_post_state = get_state(&state_machine, swap_canister_id, sns_name);
+
+    (swap_pre_state, swap_post_state)
+}
+
+fn run_test_for_swap(swap_canister_id: &str, sns_name: &str) {
+    let swap_canister_id =
+        CanisterId::unchecked_from_principal(PrincipalId::from_str(swap_canister_id).unwrap());
+
+    let state_machine =
+        ic_nns_test_utils_golden_nns_state::new_state_machine_with_golden_sns_state_or_panic();
+
+    let swap_wasm_1 = ensure_sns_wasm_gzipped(build_swap_sns_wasm());
+    let swap_wasm_2 = create_modified_sns_wasm(&swap_wasm_1, Some(42));
+    assert_ne!(swap_wasm_1, swap_wasm_2);
+
+    // Experiment I: Upgrade from golden version to the tip of this branch.
+    {
+        let (swap_pre_state, mut swap_post_state) =
+            run_upgrade_for_swap(&state_machine, swap_canister_id, swap_wasm_1, sns_name);
+
+        // Some fields need to be redacted as they were introduced after some Swaps were created.
+        redact_unavailable_swap_fields(&mut swap_post_state);
+
+        // Otherwise, the states before and after the migration should match.
+        assert_eq!(
+            swap_pre_state, swap_post_state,
+            "Experiment I: Swap state mismatch detected for {} ",
+            sns_name
+        );
+    }
+
+    // Experiment II: Upgrade again to test the pre-upgrade hook.
+    {
+        let (swap_pre_state, swap_post_state) =
+            run_upgrade_for_swap(&state_machine, swap_canister_id, swap_wasm_2, sns_name);
+
+        // Nothing to redact in this case; we've just upgraded a recent version to its modified version.
+
+        assert_eq!(
+            swap_pre_state, swap_post_state,
+            "Experiment II: Swap state mismatch detected for {}",
+            sns_name
+        );
+    }
+}
+
+#[test]
+fn upgrade_downgrade_swap_boom_dao() {
+    run_test_for_swap("vuqiy-liaaa-aaaaq-aabiq-cai", "BOOM DAO");
+}
+
+#[test]
+fn upgrade_downgrade_swap_cycles_transfer_station() {
+    run_test_for_swap("iuhw5-siaaa-aaaaq-aadoq-cai", "CYCLES-TRANSFER-STATION");
+}
+
+#[test]
+fn upgrade_downgrade_swap_catalyze() {
+    run_test_for_swap("uc3qt-6yaaa-aaaaq-aabnq-cai", "Catalyze");
+}
+
+#[test]
+fn upgrade_downgrade_swap_dogmi() {
+    run_test_for_swap("n223b-vqaaa-aaaaq-aadsa-cai", "DOGMI");
+}
+
+#[test]
+fn upgrade_downgrade_swap_decideai_dao() {
+    run_test_for_swap("xhply-dqaaa-aaaaq-aabga-cai", "DecideAI DAO");
+}
+
+#[test]
+fn upgrade_downgrade_swap_dragginz() {
+    run_test_for_swap("zcdfx-6iaaa-aaaaq-aaagq-cai", "Dragginz");
+}
+
+#[test]
+fn upgrade_downgrade_swap_elna_ai() {
+    run_test_for_swap("grlys-pqaaa-aaaaq-aacoa-cai", "ELNA AI");
+}
+
+#[test]
+fn upgrade_downgrade_swap_estatedao() {
+    run_test_for_swap("bcl3g-3aaaa-aaaaq-aac5a-cai", "EstateDAO");
+}
+
+#[test]
+fn upgrade_downgrade_swap_gold_dao() {
+    run_test_for_swap("t7z6p-ryaaa-aaaaq-aab7q-cai", "Gold DAO");
+}
+
+#[test]
+fn upgrade_downgrade_swap_icghost() {
+    run_test_for_swap("4f5dx-pyaaa-aaaaq-aaa3q-cai", "ICGhost");
+}
+
+#[test]
+fn upgrade_downgrade_swap_iclighthouse_dao() {
+    run_test_for_swap("habgn-xyaaa-aaaaq-aaclq-cai", "ICLighthouse DAO");
+    
+}
+#[test]
+fn upgrade_downgrade_swap_icpcc_dao_llc() {
+    run_test_for_swap("lwslc-cyaaa-aaaaq-aadfq-cai", "ICPCC DAO LLC");
+}
+
+#[test]
+fn upgrade_downgrade_swap_icpswap() {
+    run_test_for_swap("ch7an-giaaa-aaaaq-aacwq-cai", "ICPSwap");
+}
+
+#[test]
+fn upgrade_downgrade_swap_icpanda_dao() {
+    run_test_for_swap("c424i-4qaaa-aaaaq-aacua-cai", "ICPanda DAO");
+}
+
+#[test]
+fn upgrade_downgrade_swap_icvc() {
+    run_test_for_swap("mzwsh-biaaa-aaaaq-aaduq-cai", "ICVC");
+}
+
+#[test]
+fn upgrade_downgrade_swap_juno_build() {
+    run_test_for_swap("mlqf6-nyaaa-aaaaq-aadxq-cai", "Juno Build");
+}
+
+#[test]
+fn upgrade_downgrade_swap_kinic() {
+    run_test_for_swap("7sppf-6aaaa-aaaaq-aaata-cai", "Kinic");
+}
+
+#[test]
+fn upgrade_downgrade_swap_mora_dao() {
+    run_test_for_swap("khyv5-2qaaa-aaaaq-aadaa-cai", "MORA DAO");
+}
+
+#[test]
+fn upgrade_downgrade_swap_motoko() {
+    run_test_for_swap("kv6ce-waaaa-aaaaq-aadda-cai", "Motoko");
+}
+
+#[test]
+fn upgrade_downgrade_swap_neutrinite() {
+    run_test_for_swap("f25or-jiaaa-aaaaq-aaceq-cai", "Neutrinite");
+}
+
+#[test]
+fn upgrade_downgrade_swap_nuance() {
+    run_test_for_swap("q2nfe-mqaaa-aaaaq-aabua-cai", "Nuance");
+}
+
+#[test]
+fn upgrade_downgrade_swap_origyn() {
+    run_test_for_swap("jxl73-gqaaa-aaaaq-aadia-cai", "ORIGYN");
+}
+
+#[test]
+fn upgrade_downgrade_swap_openchat() {
+    run_test_for_swap("2hx64-daaaa-aaaaq-aaana-cai", "OpenChat");
+}
+
+#[test]
+fn upgrade_downgrade_swap_openfpl() {
+    run_test_for_swap("dkred-jaaaa-aaaaq-aacra-cai", "OpenFPL");
+}
+
+#[test]
+fn upgrade_downgrade_swap_sonic() {
+    run_test_for_swap("qils5-aaaaa-aaaaq-aabxa-cai", "SONIC");
+}
+
+#[test]
+fn upgrade_downgrade_swap_seers() {
+    run_test_for_swap("rmg5p-zaaaa-aaaaq-aabra-cai", "Seers");
+}
+
+#[test]
+fn upgrade_downgrade_swap_sneed() {
+    run_test_for_swap("hshru-3iaaa-aaaaq-aaciq-cai", "Sneed");
+}
+
+#[test]
+fn upgrade_downgrade_swap_trax() {
+    run_test_for_swap("ezrhx-5qaaa-aaaaq-aacca-cai", "TRAX");
+}
+
+#[test]
+fn upgrade_downgrade_swap_waterneuron() {
+    run_test_for_swap("ipcky-iqaaa-aaaaq-aadma-cai", "WaterNeuron");
+}
+
+#[test]
+fn upgrade_downgrade_swap_yral() {
+    run_test_for_swap("6eexo-lqaaa-aaaaq-aaawa-cai", "YRAL");
+}
+
+#[test]
+fn upgrade_downgrade_swap_yuku_dao() {
+    run_test_for_swap("a2cof-vaaaa-aaaaq-aacza-cai", "Yuku DAO");
+}

--- a/rs/sns/integration_tests/src/lib.rs
+++ b/rs/sns/integration_tests/src/lib.rs
@@ -59,4 +59,4 @@ mod http_request;
 mod timers;
 
 #[cfg(test)]
-mod golden_state_upgrade_downgrade;
+mod golden_state_swap_upgrade_twice;

--- a/rs/sns/integration_tests/src/lib.rs
+++ b/rs/sns/integration_tests/src/lib.rs
@@ -57,3 +57,6 @@ mod http_request;
 
 #[cfg(test)]
 mod timers;
+
+#[cfg(test)]
+mod golden_state_upgrade_downgrade;

--- a/rs/sns/swap/canister/canister.rs
+++ b/rs/sns/swap/canister/canister.rs
@@ -455,7 +455,7 @@ fn canister_post_upgrade() {
 
     init_timers();
 
-    // TODO[NNS1-3386]: Remove this line.
+    // TODO[NNS1-3386]: Remove once all Swaps are migrated to have these fields populated.
     swap_mut().migrate_state();
 }
 

--- a/rs/sns/swap/canister/canister.rs
+++ b/rs/sns/swap/canister/canister.rs
@@ -454,6 +454,9 @@ fn canister_post_upgrade() {
     });
 
     init_timers();
+
+    // TODO[NNS1-3386]: Remove this line.
+    swap_mut().migrate_state();
 }
 
 /// Serve an HttpRequest made to this canister

--- a/rs/sns/swap/src/swap.rs
+++ b/rs/sns/swap/src/swap.rs
@@ -1013,6 +1013,32 @@ impl Swap {
     // --- state modifying methods ---------------------------------------------
     //
 
+    // TODO[NNS1-3386]: Remove this function.
+    pub fn migrate_state(&mut self) {
+        if self.direct_participation_icp_e8s.is_none() {
+            let direct_participation_icp_e8s =
+                self.buyers
+                    .values()
+                    .fold(0_u64, |sum_icp_e8s, buyer_state| {
+                        let amount_icp_e8s = buyer_state.amount_icp_e8s();
+                        sum_icp_e8s.saturating_add(amount_icp_e8s)
+                    });
+            self.direct_participation_icp_e8s = Some(direct_participation_icp_e8s);
+        }
+
+        if self.neurons_fund_participation_icp_e8s.is_none() {
+            let neurons_fund_participation_icp_e8s =
+                self.cf_participants
+                    .iter()
+                    .fold(0_u64, |sum_icp_e8s, neurons_fund_participant| {
+                        let participant_total_icp_e8s =
+                            neurons_fund_participant.participant_total_icp_e8s();
+                        sum_icp_e8s.saturating_add(participant_total_icp_e8s)
+                    });
+            self.neurons_fund_participation_icp_e8s = Some(neurons_fund_participation_icp_e8s);
+        }
+    }
+
     /// Runs those tasks that should be run periodically.
     ///
     /// The argument 'now_fn' is a function that returns the current time for bookkeeping

--- a/rs/sns/swap/src/swap.rs
+++ b/rs/sns/swap/src/swap.rs
@@ -427,8 +427,8 @@ impl Swap {
             purge_old_tickets_next_principal: Some(FIRST_PRINCIPAL_BYTES.to_vec()),
             already_tried_to_auto_finalize: Some(false),
             auto_finalize_swap_response: None,
-            direct_participation_icp_e8s: None,
-            neurons_fund_participation_icp_e8s: None,
+            direct_participation_icp_e8s: Some(0),
+            neurons_fund_participation_icp_e8s: Some(0),
             timers: None,
         };
         if init.validate_swap_init_for_one_proposal_flow().is_ok() {


### PR DESCRIPTION
The PR adds a simple data migration for old Swap canisters that still don't have the fields direct_participation_icp_e8s, neurons_fund_participation_icp_e8s. Additionally, we add golden upgrade tests to check that this migration works as expected in production.