### PR TITLE
chore: CON-1415 Rename `transcripts_for_new_subnets_with_callback_ids`

### DIFF
--- a/rs/consensus/src/consensus/batch_delivery.rs
+++ b/rs/consensus/src/consensus/batch_delivery.rs
@@ -276,7 +276,7 @@ pub fn generate_responses_to_subnet_calls(
             summary.dkg.configs.keys().collect::<Vec<_>>()
         );
         consensus_responses.append(&mut generate_responses_to_setup_initial_dkg_calls(
-            &summary.dkg.transcripts_for_new_subnets_with_callback_ids,
+            &summary.dkg.transcripts_for_remote_subnets,
             log,
         ))
     } else {
@@ -304,14 +304,14 @@ struct TranscriptResults {
 /// This function creates responses to the SetupInitialDKG system calls with the
 /// computed DKG key material for remote subnets, without needing values from the state.
 pub fn generate_responses_to_setup_initial_dkg_calls(
-    transcripts_for_new_subnets: &[(NiDkgId, CallbackId, Result<NiDkgTranscript, String>)],
+    transcripts_for_remote_subnets: &[(NiDkgId, CallbackId, Result<NiDkgTranscript, String>)],
     log: &ReplicaLogger,
 ) -> Vec<ConsensusResponse> {
     let mut consensus_responses = Vec::new();
 
     let mut transcripts: BTreeMap<CallbackId, TranscriptResults> = BTreeMap::new();
 
-    for (id, callback_id, transcript) in transcripts_for_new_subnets.iter() {
+    for (id, callback_id, transcript) in transcripts_for_remote_subnets.iter() {
         let add_transcript = |transcript_results: &mut TranscriptResults| {
             let value = Some(transcript.clone());
             match id.dkg_tag {

--- a/rs/consensus/src/consensus/finalizer.rs
+++ b/rs/consensus/src/consensus/finalizer.rs
@@ -493,7 +493,7 @@ mod tests {
         .collect::<BTreeMap<_, _>>();
 
         // Build some transcipts with matching ids and tags
-        let transcripts_for_new_subnets = vec![
+        let transcripts_for_remote_subnets = vec![
             (
                 NiDkgId {
                     start_block_height: Height::from(0),
@@ -520,7 +520,7 @@ mod tests {
 
         // Run the
         let result = generate_responses_to_setup_initial_dkg_calls(
-            &transcripts_for_new_subnets[..],
+            &transcripts_for_remote_subnets[..],
             &no_op_logger(),
         );
         assert_eq!(result.len(), 1);

--- a/rs/consensus/src/dkg.rs
+++ b/rs/consensus/src/dkg.rs
@@ -1027,18 +1027,8 @@ mod tests {
                 for (dkg_id, _) in summary.dkg.configs.iter() {
                     assert_eq!(dkg_id.target_subnet, NiDkgTargetSubnet::Local);
                 }
-                assert_eq!(
-                    summary
-                        .dkg
-                        .transcripts_for_new_subnets_with_callback_ids
-                        .len(),
-                    2
-                );
-                for (dkg_id, _, result) in summary
-                    .dkg
-                    .transcripts_for_new_subnets_with_callback_ids
-                    .iter()
-                {
+                assert_eq!(summary.dkg.transcripts_for_remote_subnets.len(), 2);
+                for (dkg_id, _, result) in summary.dkg.transcripts_for_remote_subnets.iter() {
                     assert_eq!(dkg_id.target_subnet, NiDkgTargetSubnet::Remote(target_id));
                     assert!(result.is_err());
                 }
@@ -1664,7 +1654,7 @@ mod tests {
     }
 
     #[test]
-    fn test_dkg_payload_has_transcripts_for_new_subnets() {
+    fn test_dkg_payload_has_transcripts_for_remote_subnets() {
         ic_test_utilities::artifact_pool_config::with_test_pool_config(|pool_config| {
             let node_ids = vec![node_test_id(0), node_test_id(1)];
             let dkg_interval_length = 99;
@@ -1714,9 +1704,7 @@ mod tests {
                         .count(),
                     2
                 );
-                assert!(dkg_summary
-                    .transcripts_for_new_subnets_with_callback_ids
-                    .is_empty());
+                assert!(dkg_summary.transcripts_for_remote_subnets.is_empty());
             } else {
                 panic!(
                     "block at height {} is not a summary block",
@@ -1747,7 +1735,7 @@ mod tests {
                 );
                 assert_eq!(
                     dkg_summary
-                        .transcripts_for_new_subnets_with_callback_ids
+                        .transcripts_for_remote_subnets
                         .iter()
                         .filter(
                             |(id, _, _)| id.target_subnet == NiDkgTargetSubnet::Remote(target_id)

--- a/rs/protobuf/def/types/v1/dkg.proto
+++ b/rs/protobuf/def/types/v1/dkg.proto
@@ -35,7 +35,7 @@ message Summary {
   repeated TaggedNiDkgTranscript next_transcripts = 6;
   repeated NiDkgConfig configs = 7;
   repeated InitialDkgAttemptCount initial_dkg_attempts = 9;
-  repeated CallbackIdedNiDkgTranscript transcripts_for_new_subnets_with_callback_ids = 10;
+  repeated CallbackIdedNiDkgTranscript transcripts_for_remote_subnets = 10;
 }
 
 message TaggedNiDkgTranscript {

--- a/rs/protobuf/src/gen/types/types.v1.rs
+++ b/rs/protobuf/src/gen/types/types.v1.rs
@@ -214,8 +214,7 @@ pub struct Summary {
     #[prost(message, repeated, tag = "9")]
     pub initial_dkg_attempts: ::prost::alloc::vec::Vec<InitialDkgAttemptCount>,
     #[prost(message, repeated, tag = "10")]
-    pub transcripts_for_new_subnets_with_callback_ids:
-        ::prost::alloc::vec::Vec<CallbackIdedNiDkgTranscript>,
+    pub transcripts_for_remote_subnets: ::prost::alloc::vec::Vec<CallbackIdedNiDkgTranscript>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TaggedNiDkgTranscript {


### PR DESCRIPTION
This field is not only used to store NiDKG transcripts for *new* subnets that are being created, but also existing subnets that are being recovered. In the future it will additionally be used to hold transcripts for subnets requesting a vet Key resharing.