### PR TITLE
chore: do not pin to crate versions

### DIFF
--- a/Cargo.Bazel.Fuzzing.json.lock
+++ b/Cargo.Bazel.Fuzzing.json.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "e17415520832a0f5581780f5ba12c8d37034d68fcde8debc17b3710d56731791",
+  "checksum": "b3b5db49424c27c83478feea1d5a1b1d579662600d5a0074abd4c02ccfc9be4e",
   "crates": {
     "abnf 0.12.0": {
       "name": "abnf",
@@ -17695,10 +17695,6 @@
             {
               "id": "assert_matches 1.5.0",
               "target": "assert_matches"
-            },
-            {
-              "id": "async-channel 2.3.1",
-              "target": "async_channel"
             },
             {
               "id": "async-scoped 0.8.0",
@@ -79433,7 +79429,6 @@
     "assert-json-diff 2.0.2",
     "assert_cmd 2.0.16",
     "assert_matches 1.5.0",
-    "async-channel 2.3.1",
     "async-recursion 1.0.5",
     "async-scoped 0.8.0",
     "async-stream 0.3.5",

--- a/Cargo.Bazel.Fuzzing.toml.lock
+++ b/Cargo.Bazel.Fuzzing.toml.lock
@@ -3032,7 +3032,6 @@ dependencies = [
  "assert-json-diff",
  "assert_cmd",
  "assert_matches",
- "async-channel",
  "async-recursion",
  "async-scoped",
  "async-stream",

--- a/Cargo.Bazel.json.lock
+++ b/Cargo.Bazel.json.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "f1d446e2f51f5523ef34b14dc52d390645bd8bf6796eb37472bd66e892f0a910",
+  "checksum": "9ab5779ad70c5b45a9834dcfe75c463fc6eda77068374293ca0cade10a91d9c1",
   "crates": {
     "abnf 0.12.0": {
       "name": "abnf",
@@ -17496,10 +17496,6 @@
             {
               "id": "assert_matches 1.5.0",
               "target": "assert_matches"
-            },
-            {
-              "id": "async-channel 2.3.1",
-              "target": "async_channel"
             },
             {
               "id": "async-scoped 0.8.0",
@@ -79609,7 +79605,6 @@
     "assert-json-diff 2.0.2",
     "assert_cmd 2.0.16",
     "assert_matches 1.5.0",
-    "async-channel 2.3.1",
     "async-recursion 1.0.5",
     "async-scoped 0.8.0",
     "async-stream 0.3.5",

--- a/Cargo.Bazel.toml.lock
+++ b/Cargo.Bazel.toml.lock
@@ -3021,7 +3021,6 @@ dependencies = [
  "assert-json-diff",
  "assert_cmd",
  "assert_matches",
- "async-channel",
  "async-recursion",
  "async-scoped",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -551,7 +551,7 @@ ic-response-verification = "2.6.0"
 ic-stable-structures = "0.6.5"
 ic-transport-types = { version = "0.37.1" }
 ic-utils = { version = "0.37.0", features = ["raw"] }
-ic_bls12_381 = { version = "=0.10.0", default-features = false, features = [
+ic_bls12_381 = { version = "0.10.0", default-features = false, features = [
     "groups",
     "pairings",
     "alloc",
@@ -595,7 +595,7 @@ p256 = { version = "0.13.2", default-features = false, features = [
     "pem",
     "pkcs8",
 ] }
-pairing = "=0.23"
+pairing = "0.23"
 parking_lot = "0.12.3"
 ping = "0.5.0"
 pkcs8 = "0.10.2"
@@ -666,7 +666,7 @@ strum = { version = "0.26.3", features = [ "derive" ] }
 strum_macros = "0.26.4"
 syn = { version = "1.0.109", features = ["fold", "full"] }
 sync_wrapper = "1.0.1"
-tar = "=0.4.39"
+tar = "0.4.39"
 tempfile = "3.12.0"
 thiserror = "1.0.62"
 threadpool = "1.8.1"
@@ -700,13 +700,13 @@ tracing-subscriber = { version = "0.3.18", features = [
 turmoil = "0.6.3"
 url = { version = "2.5.2", features = ["serde"] }
 uuid = { version = "1.10.0", features = ["v4", "serde"] }
-walkdir = "=2.3.3"
+walkdir = "2.3.3"
 walrus = "0.21.1"
 wasm-encoder = { version = "0.217.0", features = ["wasmparser"] }
 wasmparser = "0.217.0"
 wasmprinter = "0.217.0"
 wast = "212.0.0"
-wat = "=1.212.0"
+wat = "1.212.0"
 x509-cert = { version = "0.2.5", features = ["builder", "hazmat"] }
 x509-parser = { version = "0.16.0" }
 zeroize = { version = "1.8.1", features = ["zeroize_derive"] }

--- a/bazel/external_crates.bzl
+++ b/bazel/external_crates.bzl
@@ -168,9 +168,6 @@ def external_crates_repository(name, cargo_lockfile, lockfile, sanitizers_enable
             "assert_matches": crate.spec(
                 version = "^1.5.0",
             ),
-            "async-channel": crate.spec(
-                version = "2.3.1",
-            ),
             "async-recursion": crate.spec(
                 version = "^1.0.5",
             ),
@@ -257,7 +254,7 @@ def external_crates_repository(name, cargo_lockfile, lockfile, sanitizers_enable
                 version = "^0.5.0",
             ),
             "ic_bls12_381": crate.spec(
-                version = "=0.10.0",
+                version = "0.10.0",
                 features = [
                     "alloc",
                     "experimental",
@@ -1423,7 +1420,7 @@ def external_crates_repository(name, cargo_lockfile, lockfile, sanitizers_enable
                 version = "^212.0.0",
             ),
             "wat": crate.spec(
-                version = "=1.212.0",
+                version = "1.212.0",
             ),
             "wee_alloc": crate.spec(
                 version = "^0.4.3",

--- a/rs/bitcoin/ckbtc/minter/Cargo.toml
+++ b/rs/bitcoin/ckbtc/minter/Cargo.toml
@@ -13,7 +13,7 @@ path = "src/main.rs"
 [dependencies]
 async-trait = { workspace = true }
 bech32 = "0.9.0"
-bs58 = "=0.5.0"
+bs58 = "0.5.0"
 candid = { workspace = true }
 ciborium = { workspace = true }
 hex = { workspace = true }


### PR DESCRIPTION
It is fairly discouraged to pin to particular version.

> Multiple versions within the same compatibility range are not allowed and will result in a resolver error if it is constrained to two different versions within a compatibility range. For example, if there are two packages in the resolve graph with the following requirements:

https://doc.rust-lang.org/cargo/reference/resolver.html