### PR TITLE
feat(proposal-cli): Support canisters outside the IC repository

### DIFF
--- a/rs/cross-chain/proposal-cli/src/candid/tests.rs
+++ b/rs/cross-chain/proposal-cli/src/candid/tests.rs
@@ -38,6 +38,8 @@ fn should_parse_constructor_parameters() {
         if canister == TargetCanister::IcpArchive1
             || canister == TargetCanister::IcpArchive2
             || canister == TargetCanister::IcpArchive3
+            //canister lives outside the monorepo
+            || canister == TargetCanister::EvmRpc
         {
             continue;
         }

--- a/rs/cross-chain/proposal-cli/src/canister/mod.rs
+++ b/rs/cross-chain/proposal-cli/src/canister/mod.rs
@@ -242,6 +242,10 @@ impl TargetCanister {
         }
     }
 
+    pub fn build_artifact_as_str(&self) -> String {
+        format!("{:?}", self.build_artifact())
+    }
+
     pub fn canister_ids_json_file(&self) -> PathBuf {
         match self {
             TargetCanister::CkBtcArchive

--- a/rs/cross-chain/proposal-cli/src/canister/mod.rs
+++ b/rs/cross-chain/proposal-cli/src/canister/mod.rs
@@ -3,6 +3,7 @@ mod tests;
 
 use std::fmt::Display;
 use std::path::PathBuf;
+use std::process::Command;
 use std::str::FromStr;
 use strum_macros::EnumIter;
 
@@ -186,6 +187,31 @@ impl TargetCanister {
                 "ic-ledger-suite-orchestrator-canister.wasm.gz"
             }
             TargetCanister::EvmRpc => "evm_rpc.wasm.gz",
+        }
+    }
+
+    pub fn build_artifact(&self) -> Command {
+        match &self {
+            TargetCanister::CkBtcArchive
+            | TargetCanister::CkBtcIndex
+            | TargetCanister::CkBtcKyt
+            | TargetCanister::CkBtcLedger
+            | TargetCanister::CkBtcMinter
+            | TargetCanister::CkEthArchive
+            | TargetCanister::CkEthIndex
+            | TargetCanister::CkEthLedger
+            | TargetCanister::CkEthMinter
+            | TargetCanister::IcpArchive1
+            | TargetCanister::IcpArchive2
+            | TargetCanister::IcpArchive3
+            | TargetCanister::IcpIndex
+            | TargetCanister::IcpLedger
+            | TargetCanister::LedgerSuiteOrchestrator => {
+                let mut cmd = Command::new("./ci/container/build-ic.sh");
+                cmd.arg("--canisters");
+                cmd
+            }
+            TargetCanister::EvmRpc => Command::new("./scripts/docker-build"),
         }
     }
 

--- a/rs/cross-chain/proposal-cli/src/canister/mod.rs
+++ b/rs/cross-chain/proposal-cli/src/canister/mod.rs
@@ -24,6 +24,7 @@ pub enum TargetCanister {
     IcpIndex,
     IcpLedger,
     LedgerSuiteOrchestrator,
+    EvmRpc,
 }
 
 impl TargetCanister {
@@ -40,6 +41,7 @@ impl TargetCanister {
             TargetCanister::IcpIndex => "icp-index",
             TargetCanister::IcpLedger => "icp-ledger",
             TargetCanister::LedgerSuiteOrchestrator => "orchestrator",
+            TargetCanister::EvmRpc => "evm_rpc",
         }
     }
 
@@ -60,6 +62,9 @@ impl TargetCanister {
             | TargetCanister::IcpIndex
             | TargetCanister::IcpLedger
             | TargetCanister::LedgerSuiteOrchestrator => "https://github.com/dfinity/ic.git",
+            TargetCanister::EvmRpc => {
+                "https://github.com/internet-computer-protocol/evm-rpc-canister.git"
+            }
         }
     }
 
@@ -91,6 +96,7 @@ impl TargetCanister {
             TargetCanister::LedgerSuiteOrchestrator => {
                 PathBuf::from("rs/ethereum/ledger-suite-orchestrator/ledger_suite_orchestrator.did")
             }
+            TargetCanister::EvmRpc => PathBuf::from("candid/evm_rpc.did"),
         }
     }
 
@@ -138,7 +144,26 @@ impl TargetCanister {
     }
 
     pub fn artifact(&self) -> PathBuf {
-        PathBuf::from("artifacts/canisters").join(self.artifact_file_name())
+        match &self {
+            TargetCanister::CkBtcArchive
+            | TargetCanister::CkBtcIndex
+            | TargetCanister::CkBtcKyt
+            | TargetCanister::CkBtcLedger
+            | TargetCanister::CkBtcMinter
+            | TargetCanister::CkEthArchive
+            | TargetCanister::CkEthIndex
+            | TargetCanister::CkEthLedger
+            | TargetCanister::CkEthMinter
+            | TargetCanister::IcpArchive1
+            | TargetCanister::IcpArchive2
+            | TargetCanister::IcpArchive3
+            | TargetCanister::IcpIndex
+            | TargetCanister::IcpLedger
+            | TargetCanister::LedgerSuiteOrchestrator => {
+                PathBuf::from("artifacts/canisters").join(self.artifact_file_name())
+            }
+            TargetCanister::EvmRpc => PathBuf::from(self.artifact_file_name()),
+        }
     }
 
     pub fn artifact_file_name(&self) -> &str {
@@ -160,6 +185,7 @@ impl TargetCanister {
             TargetCanister::LedgerSuiteOrchestrator => {
                 "ic-ledger-suite-orchestrator-canister.wasm.gz"
             }
+            TargetCanister::EvmRpc => "evm_rpc.wasm.gz",
         }
     }
 
@@ -184,6 +210,7 @@ impl TargetCanister {
             | TargetCanister::IcpArchive3
             | TargetCanister::IcpIndex
             | TargetCanister::IcpLedger => PathBuf::from("rs/ledger_suite/icp/canister_ids.json"),
+            TargetCanister::EvmRpc => PathBuf::from("canister_ids.json"),
         }
     }
 
@@ -215,6 +242,7 @@ impl FromStr for TargetCanister {
             ["icp", "archive3"] => Ok(TargetCanister::IcpArchive3),
             ["icp", "index"] => Ok(TargetCanister::IcpIndex),
             ["icp", "ledger"] => Ok(TargetCanister::IcpLedger),
+            ["evm", "rpc"] => Ok(TargetCanister::EvmRpc),
             _ => Err(format!("Unknown canister name: {}", canister)),
         }
     }
@@ -238,6 +266,7 @@ impl Display for TargetCanister {
             TargetCanister::IcpIndex => write!(f, "ICP index"),
             TargetCanister::IcpLedger => write!(f, "ICP ledger"),
             TargetCanister::LedgerSuiteOrchestrator => write!(f, "ledger suite orchestrator"),
+            TargetCanister::EvmRpc => write!(f, "EVM RPC"),
         }
     }
 }

--- a/rs/cross-chain/proposal-cli/src/canister/mod.rs
+++ b/rs/cross-chain/proposal-cli/src/canister/mod.rs
@@ -157,8 +157,20 @@ impl TargetCanister {
                     PathBuf::from("rs/ledger_suite/common/ledger_core/src"),
                 ]
             }
-            _ => {
+            TargetCanister::CkBtcArchive
+            | TargetCanister::CkBtcIndex
+            | TargetCanister::CkBtcKyt
+            | TargetCanister::CkBtcLedger
+            | TargetCanister::CkBtcMinter
+            | TargetCanister::CkEthArchive
+            | TargetCanister::CkEthIndex
+            | TargetCanister::CkEthLedger
+            | TargetCanister::CkEthMinter
+            | TargetCanister::LedgerSuiteOrchestrator => {
                 vec![self.repo_dir()]
+            }
+            TargetCanister::EvmRpc => {
+                vec![]
             }
         }
     }

--- a/rs/cross-chain/proposal-cli/src/canister/mod.rs
+++ b/rs/cross-chain/proposal-cli/src/canister/mod.rs
@@ -102,7 +102,26 @@ impl TargetCanister {
     }
 
     pub fn repo_dir(&self) -> PathBuf {
-        self.candid_file().parent().unwrap().to_path_buf()
+        match &self {
+            TargetCanister::CkBtcArchive
+            | TargetCanister::CkBtcIndex
+            | TargetCanister::CkBtcKyt
+            | TargetCanister::CkBtcLedger
+            | TargetCanister::CkBtcMinter
+            | TargetCanister::CkEthArchive
+            | TargetCanister::CkEthIndex
+            | TargetCanister::CkEthLedger
+            | TargetCanister::CkEthMinter
+            | TargetCanister::IcpArchive1
+            | TargetCanister::IcpArchive2
+            | TargetCanister::IcpArchive3
+            | TargetCanister::IcpIndex
+            | TargetCanister::IcpLedger
+            | TargetCanister::LedgerSuiteOrchestrator => {
+                self.candid_file().parent().unwrap().to_path_buf()
+            }
+            TargetCanister::EvmRpc => PathBuf::new(),
+        }
     }
 
     pub fn git_log_dirs(&self) -> Vec<PathBuf> {

--- a/rs/cross-chain/proposal-cli/src/canister/mod.rs
+++ b/rs/cross-chain/proposal-cli/src/canister/mod.rs
@@ -6,7 +6,7 @@ use std::path::PathBuf;
 use std::str::FromStr;
 use strum_macros::EnumIter;
 
-#[derive(Clone, Eq, PartialEq, Debug, EnumIter)]
+#[derive(Clone, Eq, PartialEq, Debug, Ord, PartialOrd, EnumIter)]
 #[allow(clippy::enum_variant_names)]
 pub enum TargetCanister {
     CkBtcArchive,
@@ -40,6 +40,26 @@ impl TargetCanister {
             TargetCanister::IcpIndex => "icp-index",
             TargetCanister::IcpLedger => "icp-ledger",
             TargetCanister::LedgerSuiteOrchestrator => "orchestrator",
+        }
+    }
+
+    pub fn git_repository_url(&self) -> &str {
+        match &self {
+            TargetCanister::CkBtcArchive
+            | TargetCanister::CkBtcIndex
+            | TargetCanister::CkBtcKyt
+            | TargetCanister::CkBtcLedger
+            | TargetCanister::CkBtcMinter
+            | TargetCanister::CkEthArchive
+            | TargetCanister::CkEthIndex
+            | TargetCanister::CkEthLedger
+            | TargetCanister::CkEthMinter
+            | TargetCanister::IcpArchive1
+            | TargetCanister::IcpArchive2
+            | TargetCanister::IcpArchive3
+            | TargetCanister::IcpIndex
+            | TargetCanister::IcpLedger
+            | TargetCanister::LedgerSuiteOrchestrator => "https://github.com/dfinity/ic.git",
         }
     }
 

--- a/rs/cross-chain/proposal-cli/src/canister/mod.rs
+++ b/rs/cross-chain/proposal-cli/src/canister/mod.rs
@@ -101,7 +101,7 @@ impl TargetCanister {
         }
     }
 
-    pub fn repo_dir(&self) -> PathBuf {
+    pub fn repo_dir(&self) -> Option<PathBuf> {
         match &self {
             TargetCanister::CkBtcArchive
             | TargetCanister::CkBtcIndex
@@ -118,9 +118,9 @@ impl TargetCanister {
             | TargetCanister::IcpIndex
             | TargetCanister::IcpLedger
             | TargetCanister::LedgerSuiteOrchestrator => {
-                self.candid_file().parent().unwrap().to_path_buf()
+                Some(self.candid_file().parent().unwrap().to_path_buf())
             }
-            TargetCanister::EvmRpc => PathBuf::new(),
+            TargetCanister::EvmRpc => None,
         }
     }
 
@@ -166,12 +166,8 @@ impl TargetCanister {
             | TargetCanister::CkEthIndex
             | TargetCanister::CkEthLedger
             | TargetCanister::CkEthMinter
-            | TargetCanister::LedgerSuiteOrchestrator => {
-                vec![self.repo_dir()]
-            }
-            TargetCanister::EvmRpc => {
-                vec![]
-            }
+            | TargetCanister::LedgerSuiteOrchestrator
+            | TargetCanister::EvmRpc => self.repo_dir().into_iter().collect(),
         }
     }
 

--- a/rs/cross-chain/proposal-cli/src/git/mod.rs
+++ b/rs/cross-chain/proposal-cli/src/git/mod.rs
@@ -183,16 +183,21 @@ impl GitRepository {
         &mut self,
         canister: &[TargetCanister],
     ) -> Vec<CompressedWasmHash> {
-        self.build_canisters();
-        canister.iter().map(|c| self.sha256_artifact(c)).collect()
+        canister
+            .iter()
+            .map(|c| {
+                self.build_canister_artifact(c);
+                self.sha256_artifact(c)
+            })
+            .collect()
     }
 
-    fn build_canisters(&mut self) {
-        let build = Command::new("./ci/container/build-ic.sh")
-            .arg("--canisters")
+    fn build_canister_artifact(&mut self, canister: &TargetCanister) {
+        let build = canister
+            .build_artifact()
             .current_dir(self.dir.path())
             .status()
-            .expect("failed to build canister artifacts");
+            .expect("failed to build canister artifact");
         assert!(build.success());
     }
 

--- a/rs/cross-chain/proposal-cli/src/git/mod.rs
+++ b/rs/cross-chain/proposal-cli/src/git/mod.rs
@@ -57,17 +57,17 @@ pub struct GitRepository {
 }
 
 impl GitRepository {
-    pub fn clone_ic() -> Self {
+    pub fn clone(url: &str) -> Self {
         let repo = TempDir::new().expect("failed to create a temporary directory");
         // Blobless clone
         // see https://github.blog/2020-12-21-get-up-to-speed-with-partial-clone-and-shallow-clone/
         let git_clone = Command::new("git")
             .arg("clone")
             .arg("--filter=blob:none")
-            .arg("https://github.com/dfinity/ic.git")
+            .arg(url)
             .arg(repo.path())
             .status()
-            .expect("failed to clone the IC repository");
+            .expect("failed to clone the repository");
         assert!(git_clone.success());
 
         GitRepository { dir: repo }

--- a/rs/cross-chain/proposal-cli/src/git/mod.rs
+++ b/rs/cross-chain/proposal-cli/src/git/mod.rs
@@ -159,7 +159,7 @@ impl GitRepository {
             git_log.arg(repo_dir);
         }
         let log = git_log.output().expect("failed to run git log");
-        assert!(log.status.success());
+        assert!(log.status.success(), "failed to run git log: {:?}", log);
 
         let executed_command = iter::once(git_log.get_program())
             .chain(git_log.get_args())

--- a/rs/cross-chain/proposal-cli/src/main.rs
+++ b/rs/cross-chain/proposal-cli/src/main.rs
@@ -140,6 +140,7 @@ async fn main() {
                         last_upgrade_proposal_id: last_upgrade_proposal_ids[index],
                         upgrade_args: upgrade_args[index].clone(),
                         release_notes: release_notes[index].clone(),
+                        build_artifact_command: canister.build_artifact_as_str(),
                     };
 
                     write_to_disk(output_dir, proposal, submit.clone(), &git_repo);
@@ -173,11 +174,12 @@ async fn main() {
                     let output_dir = output_dir.join(canister.to_string()).join(at.to_string());
 
                     let proposal = InstallProposalTemplate {
-                        canister,
+                        canister: canister.clone(),
                         at: at.clone(),
                         compressed_wasm_hash: compressed_wasm_hashes[index].clone(),
                         canister_id: canister_ids[index],
                         install_args: install_args[index].clone(),
+                        build_artifact_command: canister.build_artifact_as_str(),
                     };
 
                     write_to_disk(output_dir, proposal, submit.clone(), &git_repo);

--- a/rs/cross-chain/proposal-cli/src/proposal/mod.rs
+++ b/rs/cross-chain/proposal-cli/src/proposal/mod.rs
@@ -15,6 +15,7 @@ pub struct UpgradeProposalTemplate {
     pub last_upgrade_proposal_id: Option<u64>,
     pub upgrade_args: UpgradeArgs,
     pub release_notes: ReleaseNotes,
+    pub build_artifact_command: String,
 }
 
 impl UpgradeProposalTemplate {
@@ -33,6 +34,7 @@ pub struct InstallProposalTemplate {
     pub compressed_wasm_hash: CompressedWasmHash,
     pub canister_id: Principal,
     pub install_args: UpgradeArgs,
+    pub build_artifact_command: String,
 }
 
 pub enum ProposalTemplate {

--- a/rs/cross-chain/proposal-cli/templates/install.md
+++ b/rs/cross-chain/proposal-cli/templates/install.md
@@ -1,5 +1,7 @@
 # Proposal to install the {{canister}} canister
 
+Repository: `{{canister.git_repository_url()}}`
+
 Git hash: `{{at}}`
 
 New compressed Wasm hash: `{{compressed_wasm_hash}}`

--- a/rs/cross-chain/proposal-cli/templates/install.md
+++ b/rs/cross-chain/proposal-cli/templates/install.md
@@ -17,7 +17,9 @@ TODO: THIS MUST BE FILLED OUT
 ```
 git fetch
 git checkout {{at}}
-cd {{canister.repo_dir().as_path().display()}}
+{% if let Some(dir) = canister.repo_dir() -%}
+cd {{dir.as_path().display()}} \
+{% endif -%}
 {{install_args.didc_encode_cmd()}} | xxd -r -p | sha256sum
 ```
 

--- a/rs/cross-chain/proposal-cli/templates/install.md
+++ b/rs/cross-chain/proposal-cli/templates/install.md
@@ -32,6 +32,6 @@ Verify that the hash of the gzipped WASM matches the proposed hash.
 ```
 git fetch
 git checkout {{at}}
-./ci/container/build-ic.sh -c
+{{build_artifact_command}}
 sha256sum ./{{canister.artifact().as_path().display()}}
 ```

--- a/rs/cross-chain/proposal-cli/templates/install.md
+++ b/rs/cross-chain/proposal-cli/templates/install.md
@@ -20,7 +20,7 @@ TODO: THIS MUST BE FILLED OUT
 git fetch
 git checkout {{at}}
 {% if let Some(dir) = canister.repo_dir() -%}
-cd {{dir.as_path().display()}} \
+cd {{dir.as_path().display()}}
 {% endif -%}
 {{install_args.didc_encode_cmd()}} | xxd -r -p | sha256sum
 ```

--- a/rs/cross-chain/proposal-cli/templates/upgrade.md
+++ b/rs/cross-chain/proposal-cli/templates/upgrade.md
@@ -40,6 +40,6 @@ Verify that the hash of the gzipped WASM matches the proposed hash.
 ```
 git fetch
 git checkout {{to}}
-./ci/container/build-ic.sh -c
+{{build_artifact_command}}
 sha256sum ./{{canister.artifact().as_path().display()}}
 ```

--- a/rs/cross-chain/proposal-cli/templates/upgrade.md
+++ b/rs/cross-chain/proposal-cli/templates/upgrade.md
@@ -1,5 +1,7 @@
 # Proposal to upgrade the {{canister}} canister
 
+Repository: `{{canister.git_repository_url()}}`
+
 Git hash: `{{to}}`
 
 New compressed Wasm hash: `{{compressed_wasm_hash}}`

--- a/rs/cross-chain/proposal-cli/templates/upgrade.md
+++ b/rs/cross-chain/proposal-cli/templates/upgrade.md
@@ -19,7 +19,9 @@ TODO: THIS MUST BE FILLED OUT
 ```
 git fetch
 git checkout {{to}}
-cd {{canister.repo_dir().as_path().display()}}
+{% if let Some(dir) = canister.repo_dir() -%}
+cd {{dir.as_path().display()}} \
+{% endif -%}
 {{upgrade_args.didc_encode_cmd()}} | xxd -r -p | sha256sum
 ```
 

--- a/rs/cross-chain/proposal-cli/templates/upgrade.md
+++ b/rs/cross-chain/proposal-cli/templates/upgrade.md
@@ -22,7 +22,7 @@ TODO: THIS MUST BE FILLED OUT
 git fetch
 git checkout {{to}}
 {% if let Some(dir) = canister.repo_dir() -%}
-cd {{dir.as_path().display()}} \
+cd {{dir.as_path().display()}}
 {% endif -%}
 {{upgrade_args.didc_encode_cmd()}} | xxd -r -p | sha256sum
 ```


### PR DESCRIPTION
Add support to the `proposal-cli` CLI tool for canisters outside the IC repository, such as the EVM RPC canister.