### PR TITLE
chore(IDX): mark flaky tests as flaky

### DIFF
--- a/packages/pocket-ic/BUILD.bazel
+++ b/packages/pocket-ic/BUILD.bazel
@@ -69,7 +69,7 @@ rust_test(
 
 rust_test_suite(
     name = "test",
-    size = "medium",
+    size = "small",
     srcs = ["tests/tests.rs"],
     data = [
         ":test_canister.wasm",
@@ -79,9 +79,8 @@ rust_test_suite(
         "POCKET_IC_BIN": "$(rootpath //rs/pocket_ic_server:pocket-ic-server)",
         "TEST_WASM": "$(rootpath :test_canister.wasm)",
     },
-    flaky = False,
+    flaky = True,
     proc_macro_deps = MACRO_DEPENDENCIES,
-    tags = ["cpu:8"],
     deps = [":pocket-ic"] + DEPENDENCIES + TEST_DEPENDENCIES,
 )
 

--- a/rs/pocket_ic_server/BUILD.bazel
+++ b/rs/pocket_ic_server/BUILD.bazel
@@ -178,6 +178,7 @@ rust_test(
         "REGISTRY_WASM": "$(rootpath //rs/registry/canister:registry-canister)",
         "II_WASM": "external/ii_dev_canister/file/internet_identity_dev.wasm.gz",
     },
+    flaky = True,
     tags = ["cpu:8"],
     deps = TEST_DEPENDENCIES,
 )

--- a/rs/rust_canisters/stable_memory_integrity/BUILD.bazel
+++ b/rs/rust_canisters/stable_memory_integrity/BUILD.bazel
@@ -43,6 +43,7 @@ rust_ic_test(
     env = {
         "STABLE_MEMORY_INTEGRITY_CANISTER_WASM_PATH": "$(rootpath :stable_memory_integrity_canister.wasm)",
     },
+    flaky = True,
     proc_macro_deps = [],
     deps = [
         # Keep sorted.

--- a/rs/tests/message_routing/xnet/BUILD.bazel
+++ b/rs/tests/message_routing/xnet/BUILD.bazel
@@ -99,6 +99,7 @@ system_test_nns(
         "XNET_TEST_CANISTER_WASM_PATH": "$(rootpath //rs/rust_canisters/xnet_test:xnet-test-canister)",
     },
     extra_head_nns_tags = ["manual"],  # only run this test with the mainnet NNS canisters.
+    flaky = True,
     proc_macro_deps = MACRO_DEPENDENCIES,
     tags = [
         "system_test_nightly",


### PR DESCRIPTION
Until these tests can be made more stable, we need to mark them as flaky so they don't cause failures on the master pipeline.