### PR TITLE
test(IDX): skip some tests using the HEAD NNS canisters to save resources

### DIFF
--- a/rs/tests/consensus/subnet_recovery/BUILD.bazel
+++ b/rs/tests/consensus/subnet_recovery/BUILD.bazel
@@ -228,6 +228,7 @@ system_test_nns(
 
 system_test_nns(
     name = "sr_app_large_with_tecdsa_test",
+    extra_head_nns_tags = ["manual"],  # Let's not run this expensive test against the HEAD NNS canisters to save resources.
     flaky = True,
     proc_macro_deps = MACRO_DEPENDENCIES,
     tags = [

--- a/rs/tests/message_routing/xnet/BUILD.bazel
+++ b/rs/tests/message_routing/xnet/BUILD.bazel
@@ -8,6 +8,7 @@ system_test_nns(
     env = {
         "XNET_TEST_CANISTER_WASM_PATH": "$(rootpath //rs/rust_canisters/xnet_test:xnet-test-canister)",
     },
+    extra_head_nns_tags = ["manual"],  # Let's not run this expensive test against the HEAD NNS canisters to save resources.
     flaky = False,
     proc_macro_deps = MACRO_DEPENDENCIES,
     tags = [


### PR DESCRIPTION
The release-testing workflow is very expensive in terms of vCPUs needed for testnet VMs:
![Screenshot 2024-10-16 at 14 15 32](https://github.com/user-attachments/assets/9a9e7b31-3193-4fa7-80b7-bc75295518e8)

This actually prevents us from running concurrent release-testing workflows. To help reduce resources a bit we disable a few test variants that run the test against the HEAD NNS canisters, namely:

* `//rs/tests/consensus/subnet_recovery:sr_app_large_with_tecdsa_test_head_nns`
* `//rs/tests/message_routing/xnet:xnet_slo_120_subnets_staging_test_head_nns`

They will now only be tested using the mainnet NNS canisters.