### PR TITLE
feat: [UTP-242] [v1] Make subnet replica version available to canisters via management API

### DIFF
--- a/rs/consensus/src/consensus/batch_delivery.rs
+++ b/rs/consensus/src/consensus/batch_delivery.rs
@@ -233,6 +233,7 @@ pub fn deliver_batches(
             time: block.context.time,
             consensus_responses,
             blockmaker_metrics,
+            replica_version: current_replica_version,
         };
 
         debug!(

--- a/rs/consensus/src/consensus/batch_delivery.rs
+++ b/rs/consensus/src/consensus/batch_delivery.rs
@@ -233,7 +233,7 @@ pub fn deliver_batches(
             time: block.context.time,
             consensus_responses,
             blockmaker_metrics,
-            replica_version: current_replica_version.clone(),
+            replica_version: block.version().clone(),
         };
 
         debug!(

--- a/rs/consensus/src/consensus/batch_delivery.rs
+++ b/rs/consensus/src/consensus/batch_delivery.rs
@@ -233,7 +233,7 @@ pub fn deliver_batches(
             time: block.context.time,
             consensus_responses,
             blockmaker_metrics,
-            replica_version: current_replica_version,
+            replica_version: current_replica_version.clone(),
         };
 
         debug!(

--- a/rs/determinism_test/src/lib.rs
+++ b/rs/determinism_test/src/lib.rs
@@ -17,7 +17,7 @@ use ic_types::{
     ingress::{IngressState, IngressStatus, WasmResult},
     messages::{MessageId, SignedIngress},
     time::UNIX_EPOCH,
-    CanisterId, CryptoHashOfState, Randomness, RegistryVersion,
+    CanisterId, CryptoHashOfState, Randomness, RegistryVersion, ReplicaVersion,
 };
 use setup::setup;
 use std::{collections::BTreeMap, convert::TryFrom, sync::Arc, thread::sleep, time::Duration};

--- a/rs/determinism_test/src/lib.rs
+++ b/rs/determinism_test/src/lib.rs
@@ -38,6 +38,7 @@ fn build_batch(message_routing: &dyn MessageRouting, msgs: Vec<SignedIngress>) -
         time: UNIX_EPOCH,
         consensus_responses: vec![],
         blockmaker_metrics: BlockmakerMetrics::new_for_test(),
+        replica_version: ReplicaVersion::default(),
     }
 }
 
@@ -54,6 +55,7 @@ fn build_batch_with_full_state_hash(message_routing: &dyn MessageRouting) -> Bat
         time: UNIX_EPOCH,
         consensus_responses: vec![],
         blockmaker_metrics: BlockmakerMetrics::new_for_test(),
+        replica_version: ReplicaVersion::default(),
     }
 }
 

--- a/rs/drun/src/lib.rs
+++ b/rs/drun/src/lib.rs
@@ -386,6 +386,7 @@ fn build_batch(message_routing: &dyn MessageRouting, msgs: Vec<SignedIngress>) -
         time: time::current_time(),
         consensus_responses: vec![],
         blockmaker_metrics: BlockmakerMetrics::new_for_test(),
+        replica_version: ReplicaVersion::default(),
     }
 }
 /// Block till the given ingress message has finished executing and

--- a/rs/drun/src/lib.rs
+++ b/rs/drun/src/lib.rs
@@ -34,7 +34,6 @@ use ic_test_utilities_consensus::fake::FakeVerifier;
 use ic_test_utilities_registry::{
     add_subnet_record, insert_initial_dkg_transcript, SubnetRecordBuilder,
 };
-use ic_types::batch::{BatchMessages, BlockmakerMetrics};
 use ic_types::malicious_flags::MaliciousFlags;
 use ic_types::{
     batch::Batch,
@@ -42,6 +41,10 @@ use ic_types::{
     messages::{MessageId, SignedIngress},
     replica_config::ReplicaConfig,
     time, CanisterId, NodeId, NumInstructions, PrincipalId, Randomness, RegistryVersion, SubnetId,
+};
+use ic_types::{
+    batch::{BatchMessages, BlockmakerMetrics},
+    ReplicaVersion,
 };
 use rand::distributions::{Distribution, Uniform};
 use rand::rngs::StdRng;

--- a/rs/execution_environment/src/canister_manager.rs
+++ b/rs/execution_environment/src/canister_manager.rs
@@ -476,7 +476,8 @@ impl CanisterManager {
             | Ok(Ic00Method::BitcoinSendTransaction)
             | Ok(Ic00Method::BitcoinSendTransactionInternal)
             | Ok(Ic00Method::BitcoinGetCurrentFeePercentiles)
-            | Ok(Ic00Method::NodeMetricsHistory) => Err(UserError::new(
+            | Ok(Ic00Method::NodeMetricsHistory)
+            | Ok(Ic00Method::SubnetStats) => Err(UserError::new(
                 ErrorCode::CanisterRejectedMessage,
                 format!("Only canisters can call ic00 method {}", method_name),
             )),

--- a/rs/execution_environment/src/execution_environment_metrics.rs
+++ b/rs/execution_environment/src/execution_environment_metrics.rs
@@ -193,6 +193,7 @@ impl ExecutionEnvironmentMetrics {
                     | ic00::Method::BitcoinSendTransaction
                     | ic00::Method::BitcoinGetCurrentFeePercentiles
                     | ic00::Method::NodeMetricsHistory
+                    | ic00::Method::SubnetStats
                     | ic00::Method::FetchCanisterLogs
                     | ic00::Method::ProvisionalCreateCanisterWithCycles
                     | ic00::Method::ProvisionalTopUpCanister

--- a/rs/execution_environment/src/ic00_permissions.rs
+++ b/rs/execution_environment/src/ic00_permissions.rs
@@ -153,6 +153,11 @@ impl Ic00MethodPermissions {
                 allow_remote_subnet_sender: true,
                 allow_only_nns_subnet_sender: false,
             },
+            Ic00Method::SubnetStats => Self {
+                method,
+                allow_remote_subnet_sender: true,
+                allow_only_nns_subnet_sender: false,
+            },
             Ic00Method::FetchCanisterLogs => Self {
                 method,
                 // `FetchCanisterLogs` method is only allowed for messages sent by users,

--- a/rs/execution_environment/src/scheduler.rs
+++ b/rs/execution_environment/src/scheduler.rs
@@ -2365,6 +2365,7 @@ fn can_execute_subnet_msg(
         | Ic00Method::BitcoinSendTransactionInternal
         | Ic00Method::BitcoinGetSuccessors
         | Ic00Method::NodeMetricsHistory
+        | Ic00Method::SubnetStats
         | Ic00Method::FetchCanisterLogs
         | Ic00Method::ProvisionalCreateCanisterWithCycles
         | Ic00Method::ProvisionalTopUpCanister
@@ -2428,6 +2429,7 @@ fn get_instructions_limits_for_subnet_message(
             | BitcoinGetCurrentFeePercentiles
             | BitcoinGetSuccessors
             | NodeMetricsHistory
+            | SubnetStats
             | FetchCanisterLogs
             | ProvisionalCreateCanisterWithCycles
             | ProvisionalTopUpCanister

--- a/rs/execution_environment/tests/dts.rs
+++ b/rs/execution_environment/tests/dts.rs
@@ -1165,6 +1165,7 @@ fn dts_aborted_execution_does_not_block_subnet_messages() {
             | Method::BitcoinSendTransactionInternal
             | Method::BitcoinGetSuccessors
             | Method::NodeMetricsHistory
+            | Method::SubnetStats
             | Method::ProvisionalCreateCanisterWithCycles
             | Method::ProvisionalTopUpCanister => {}
             // Unsupported methods accepting just one argument.

--- a/rs/messaging/src/message_routing/tests.rs
+++ b/rs/messaging/src/message_routing/tests.rs
@@ -37,6 +37,7 @@ use ic_test_utilities_types::{
 };
 use ic_types::batch::BlockmakerMetrics;
 use ic_types::xnet::{StreamIndexedQueue, StreamSlice};
+use ic_types::ReplicaVersion;
 use ic_types::{
     batch::{Batch, BatchMessages},
     crypto::threshold_sig::ni_dkg::{NiDkgTag, NiDkgTranscript},
@@ -1043,6 +1044,7 @@ fn try_read_registry_succeeds_with_fully_specified_registry_records() {
             time: Time::from_nanos_since_unix_epoch(0),
             consensus_responses: Vec::new(),
             blockmaker_metrics: BlockmakerMetrics::new_for_test(),
+            replica_version: ReplicaVersion::default(),
         });
         let latest_state = state_manager.get_latest_state().take();
         assert_eq!(network_topology, latest_state.metadata.network_topology);
@@ -1842,6 +1844,7 @@ fn process_batch_updates_subnet_metrics() {
             time: Time::from_nanos_since_unix_epoch(0),
             consensus_responses: Vec::new(),
             blockmaker_metrics: BlockmakerMetrics::new_for_test(),
+            replica_version: ReplicaVersion::default(),
         });
 
         let latest_state = state_manager.get_latest_state().take();

--- a/rs/protobuf/def/state/metadata/v1/metadata.proto
+++ b/rs/protobuf/def/state/metadata/v1/metadata.proto
@@ -339,6 +339,12 @@ message SystemMetadata {
   BlockmakerMetricsTimeSeries blockmaker_metrics_time_series = 20;
 
   repeated ApiBoundaryNodeEntry api_boundary_nodes = 21;
+
+  ReplicaVersion replica_version = 22;
+}
+
+message ReplicaVersion {
+  string version_id = 1;
 }
 
 message StableMemory {

--- a/rs/protobuf/src/gen/state/state.metadata.v1.rs
+++ b/rs/protobuf/src/gen/state/state.metadata.v1.rs
@@ -472,6 +472,13 @@ pub struct SystemMetadata {
     pub blockmaker_metrics_time_series: ::core::option::Option<BlockmakerMetricsTimeSeries>,
     #[prost(message, repeated, tag = "21")]
     pub api_boundary_nodes: ::prost::alloc::vec::Vec<ApiBoundaryNodeEntry>,
+    #[prost(message, optional, tag = "22")]
+    pub replica_version: ::core::option::Option<ReplicaVersion>,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ReplicaVersion {
+    #[prost(string, tag = "1")]
+    pub version_id: ::prost::alloc::string::String,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct StableMemory {

--- a/rs/replay/src/player.rs
+++ b/rs/replay/src/player.rs
@@ -766,6 +766,7 @@ impl Player {
             time,
             consensus_responses: Vec::new(),
             blockmaker_metrics: BlockmakerMetrics::new_for_test(),
+            replica_version: self.replica_version.clone(),
         };
         let context_time = extra_batch.time;
         let extra_msgs = extra(self, context_time);

--- a/rs/replicated_state/src/metadata_state.rs
+++ b/rs/replicated_state/src/metadata_state.rs
@@ -174,6 +174,9 @@ pub struct SystemMetadata {
     /// by aggregating them and storing a running total over multiple days by node id and
     /// timestamp. Observations of blockmaker stats are performed each time a batch is processed.
     pub blockmaker_metrics_time_series: BlockmakerMetricsTimeSeries,
+
+    /// The version of the replica binary as agreed on by consensus.
+    pub replica_version: ReplicaVersion,
 }
 
 /// Full description of the IC network toplogy.

--- a/rs/replicated_state/src/metadata_state.rs
+++ b/rs/replicated_state/src/metadata_state.rs
@@ -29,6 +29,7 @@ use ic_registry_routing_table::{
 };
 use ic_registry_subnet_features::SubnetFeatures;
 use ic_registry_subnet_type::SubnetType;
+use ic_types::ReplicaVersion;
 use ic_types::{
     batch::BlockmakerMetrics,
     crypto::CryptoHash,
@@ -634,6 +635,7 @@ impl From<&SystemMetadata> for pb_metadata::SystemMetadata {
                 )
                 .collect(),
             blockmaker_metrics_time_series: Some((&item.blockmaker_metrics_time_series).into()),
+            replica_version: Some((&item.replica_version).into()),
         }
     }
 }
@@ -763,6 +765,8 @@ impl TryFrom<(pb_metadata::SystemMetadata, &dyn CheckpointLoadingMetrics)> for S
                 Some(blockmaker_metrics) => (blockmaker_metrics, metrics).try_into()?,
                 None => BlockmakerMetricsTimeSeries::default(),
             },
+            // TODO: Review. This could be incorrect. Would that have consequences?
+            replica_version: ReplicaVersion::default(),
         })
     }
 }
@@ -800,6 +804,7 @@ impl SystemMetadata {
             expected_compiled_wasms: BTreeSet::new(),
             bitcoin_get_successors_follow_up_responses: BTreeMap::default(),
             blockmaker_metrics_time_series: BlockmakerMetricsTimeSeries::default(),
+            replica_version: ReplicaVersion::default(),
         }
     }
 
@@ -1069,6 +1074,7 @@ impl SystemMetadata {
             ref expected_compiled_wasms,
             bitcoin_get_successors_follow_up_responses: _,
             blockmaker_metrics_time_series: _,
+            replica_version: _,
         } = self;
 
         let split_from_subnet = split_from.expect("Not a state resulting from a subnet split");

--- a/rs/replicated_state/src/metadata_state.rs
+++ b/rs/replicated_state/src/metadata_state.rs
@@ -765,8 +765,7 @@ impl TryFrom<(pb_metadata::SystemMetadata, &dyn CheckpointLoadingMetrics)> for S
                 Some(blockmaker_metrics) => (blockmaker_metrics, metrics).try_into()?,
                 None => BlockmakerMetricsTimeSeries::default(),
             },
-            // TODO: Review. This could be incorrect. Would that have consequences?
-            replica_version: ReplicaVersion::default(),
+            replica_version: item.replica_version.map(|v| v.into()).unwrap_or_default(),
         })
     }
 }

--- a/rs/replicated_state/src/metadata_state.rs
+++ b/rs/replicated_state/src/metadata_state.rs
@@ -2447,6 +2447,7 @@ pub(crate) mod testing {
             expected_compiled_wasms: Default::default(),
             bitcoin_get_successors_follow_up_responses: Default::default(),
             blockmaker_metrics_time_series: BlockmakerMetricsTimeSeries::default(),
+            replica_version: ReplicaVersion::default(),
         };
     }
 }

--- a/rs/state_machine_tests/src/lib.rs
+++ b/rs/state_machine_tests/src/lib.rs
@@ -2351,6 +2351,7 @@ impl StateMachine {
             time: self.get_time_of_next_round(),
             consensus_responses: payload.consensus_responses,
             blockmaker_metrics: BlockmakerMetrics::new_for_test(),
+            replica_version: ReplicaVersion::default(),
         };
 
         self.message_routing

--- a/rs/system_api/src/routing.rs
+++ b/rs/system_api/src/routing.rs
@@ -11,8 +11,8 @@ use ic_management_canister_types::{
     ECDSAPublicKeyArgs, InstallChunkedCodeArgs, InstallCodeArgsV2, ListCanisterSnapshotArgs,
     LoadCanisterSnapshotArgs, MasterPublicKeyId, Method as Ic00Method, NodeMetricsHistoryArgs,
     Payload, ProvisionalTopUpCanisterArgs, SchnorrPublicKeyArgs, SignWithECDSAArgs,
-    SignWithSchnorrArgs, StoredChunksArgs, TakeCanisterSnapshotArgs, UninstallCodeArgs,
-    UpdateSettingsArgs, UploadChunkArgs,
+    SignWithSchnorrArgs, StoredChunksArgs, SubnetStatsArgs, TakeCanisterSnapshotArgs,
+    UninstallCodeArgs, UpdateSettingsArgs, UploadChunkArgs,
 };
 use ic_replicated_state::NetworkTopology;
 use itertools::Itertools;
@@ -168,6 +168,7 @@ pub(super) fn resolve_destination(
         Ok(Ic00Method::NodeMetricsHistory) => {
             Ok(NodeMetricsHistoryArgs::decode(payload)?.subnet_id)
         }
+        Ok(Ic00Method::SubnetStats) => Ok(SubnetStatsArgs::decode(payload)?.subnet_id),
         Ok(Ic00Method::FetchCanisterLogs) => {
             Err(ResolveDestinationError::UserError(UserError::new(
                 ic_error_types::ErrorCode::CanisterRejectedMessage,

--- a/rs/system_api/src/sandbox_safe_system_state.rs
+++ b/rs/system_api/src/sandbox_safe_system_state.rs
@@ -255,6 +255,7 @@ impl SystemStateChanges {
             | Ok(Ic00Method::BitcoinSendTransaction)
             | Ok(Ic00Method::BitcoinGetCurrentFeePercentiles)
             | Ok(Ic00Method::NodeMetricsHistory)
+            | Ok(Ic00Method::SubnetStats)
             | Ok(Ic00Method::FetchCanisterLogs)
             | Ok(Ic00Method::UploadChunk)
             | Ok(Ic00Method::StoredChunks)

--- a/rs/test_utilities/types/src/batch/batch_builder.rs
+++ b/rs/test_utilities/types/src/batch/batch_builder.rs
@@ -26,6 +26,7 @@ impl Default for BatchBuilder {
                 time: UNIX_EPOCH,
                 consensus_responses: vec![],
                 blockmaker_metrics: BlockmakerMetrics::new_for_test(),
+                replica_version: ReplicaVersion::default(),
             },
         }
     }

--- a/rs/test_utilities/types/src/batch/batch_builder.rs
+++ b/rs/test_utilities/types/src/batch/batch_builder.rs
@@ -3,7 +3,7 @@ use std::collections::BTreeMap;
 use ic_types::{
     batch::{Batch, BatchMessages, BlockmakerMetrics},
     time::UNIX_EPOCH,
-    Height, Randomness, RegistryVersion, Time,
+    Height, Randomness, RegistryVersion, ReplicaVersion, Time,
 };
 
 pub struct BatchBuilder {

--- a/rs/types/management_canister_types/src/lib.rs
+++ b/rs/types/management_canister_types/src/lib.rs
@@ -97,7 +97,9 @@ pub enum Method {
     BitcoinSendTransactionInternal, // API for sending transactions to the network.
     BitcoinGetSuccessors,           // API for fetching blocks from the network.
 
+    // Subnet information
     NodeMetricsHistory,
+    SubnetStats,
 
     FetchCanisterLogs,
 
@@ -2585,6 +2587,32 @@ impl Payload<'_> for BitcoinSendTransactionInternalArgs {}
 pub enum QueryMethod {
     FetchCanisterLogs,
 }
+
+/// `CandidType` for `SubnetStatsArgs`
+/// ```text
+/// record {
+///     subnet_id: principal;
+/// }
+/// ```
+#[derive(Clone, Debug, Default, CandidType, Deserialize)]
+pub struct SubnetStatsArgs {
+    pub subnet_id: PrincipalId,
+}
+
+impl Payload<'_> for SubnetStatsArgs {}
+
+/// `CandidType` for `SubnetStatsResponse`
+/// ```text
+/// record {
+///     replica_version: text;
+/// }
+/// ```
+#[derive(Clone, Debug, Default, CandidType, Deserialize)]
+pub struct SubnetStatsResponse {
+    replica_version: String,
+}
+
+impl Payload<'_> for SubnetStatsResponse {}
 
 /// `CandidType` for `NodeMetricsHistoryArgs`
 /// ```text

--- a/rs/types/management_canister_types/src/lib.rs
+++ b/rs/types/management_canister_types/src/lib.rs
@@ -2609,7 +2609,7 @@ impl Payload<'_> for SubnetStatsArgs {}
 /// ```
 #[derive(Clone, Debug, Default, CandidType, Deserialize)]
 pub struct SubnetStatsResponse {
-    replica_version: String,
+    pub replica_version: String,
 }
 
 impl Payload<'_> for SubnetStatsResponse {}

--- a/rs/types/types/src/batch.rs
+++ b/rs/types/types/src/batch.rs
@@ -22,7 +22,7 @@ use crate::{
     crypto::canister_threshold_sig::MasterPublicKey,
     messages::{CallbackId, Payload, SignedIngress},
     xnet::CertifiedStreamSlice,
-    Height, Randomness, RegistryVersion, SubnetId, Time,
+    Height, Randomness, RegistryVersion, ReplicaVersion, SubnetId, Time,
 };
 use ic_base_types::NodeId;
 use ic_btc_replica_types::BitcoinAdapterResponse;
@@ -64,6 +64,8 @@ pub struct Batch {
     pub consensus_responses: Vec<ConsensusResponse>,
     /// Information about block makers
     pub blockmaker_metrics: BlockmakerMetrics,
+    /// The current replica version.
+    pub replica_version: ReplicaVersion,
 }
 
 /// The context built by Consensus for deterministic processing. Captures all

--- a/rs/types/types/src/messages/ingress_messages.rs
+++ b/rs/types/types/src/messages/ingress_messages.rs
@@ -570,6 +570,7 @@ pub fn extract_effective_canister_id(
         | Ok(Method::BitcoinGetSuccessors)
         | Ok(Method::BitcoinGetCurrentFeePercentiles)
         | Ok(Method::NodeMetricsHistory)
+        | Ok(Method::SubnetStats)
         | Ok(Method::FetchCanisterLogs) => {
             // Subnet method not allowed for ingress.
             Err(ParseIngressError::SubnetMethodNotAllowed)

--- a/rs/types/types/src/messages/inter_canister.rs
+++ b/rs/types/types/src/messages/inter_canister.rs
@@ -220,7 +220,8 @@ impl Request {
             | Ok(Method::BitcoinSendTransactionInternal)
             | Ok(Method::BitcoinGetSuccessors)
             | Ok(Method::BitcoinGetCurrentFeePercentiles)
-            | Ok(Method::NodeMetricsHistory) => {
+            | Ok(Method::NodeMetricsHistory)
+            | Ok(Method::SubnetStats) => {
                 // No effective canister id.
                 None
             }

--- a/rs/types/types/src/replica_version.rs
+++ b/rs/types/types/src/replica_version.rs
@@ -107,6 +107,14 @@ impl fmt::Display for ReplicaVersionParseError {
 
 impl Error for ReplicaVersionParseError {}
 
+impl From<&ReplicaVersion> for ic_protobuf::state::system_metadata::v1::ReplicaVersion {
+    fn from(value: &ReplicaVersion) -> Self {
+        Self {
+            version_id: value.version_id.clone(),
+        }
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;

--- a/rs/types/types/src/replica_version.rs
+++ b/rs/types/types/src/replica_version.rs
@@ -115,6 +115,22 @@ impl From<&ReplicaVersion> for ic_protobuf::state::system_metadata::v1::ReplicaV
     }
 }
 
+impl From<ReplicaVersion> for ic_protobuf::state::system_metadata::v1::ReplicaVersion {
+    fn from(value: ReplicaVersion) -> Self {
+        Self {
+            version_id: value.version_id,
+        }
+    }
+}
+
+impl From<ic_protobuf::state::system_metadata::v1::ReplicaVersion> for ReplicaVersion {
+    fn from(value: ic_protobuf::state::system_metadata::v1::ReplicaVersion) -> Self {
+        Self {
+            version_id: value.version_id,
+        }
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;


### PR DESCRIPTION
This PR introduces a new IC management canister method `blah(blah) -> blah` which exposes the replica version a subnet is currently running. The method is callable by canisters only, and might in the future expose more information that is interesting to canisters, like the number of canisters or the amount of memory taken on the subnet. 