### PR TITLE
feat: EXC - Memory-size based sandbox eviction

### DIFF
--- a/rs/canister_sandbox/src/replica_controller/sandbox_process_eviction.rs
+++ b/rs/canister_sandbox/src/replica_controller/sandbox_process_eviction.rs
@@ -24,6 +24,7 @@ pub(crate) struct EvictionCandidate {
 ///    - if there multiple possible values for `K`, then choose the one that
 ///      evicts the most candidates with `last_used < last_used_threshold`.
 /// 4. Return the evicted candidates.
+#[allow(dead_code)]
 pub(crate) fn evict(
     mut candidates: Vec<EvictionCandidate>,
     min_count_threshold: usize,
@@ -54,6 +55,24 @@ pub(crate) fn evict(
 
     println!("Evicted {} canisters", evicted.len());
 
+    evicted
+}
+
+pub(crate) fn evict_at_most(
+    mut candidates: Vec<EvictionCandidate>,
+    at_most: usize,
+) -> Vec<EvictionCandidate> {
+    candidates.sort_by_key(|x| x.last_used);
+
+    let mut evicted = vec![];
+
+    for candidate in candidates.into_iter().rev() {
+        if evicted.len() >= at_most {
+            break;
+        }
+        evicted.push(candidate)
+    }
+    println!("[evict_at_most:] Evicted {} canisters", evicted.len());
     evicted
 }
 

--- a/rs/canister_sandbox/src/replica_controller/sandbox_process_eviction.rs
+++ b/rs/canister_sandbox/src/replica_controller/sandbox_process_eviction.rs
@@ -52,6 +52,8 @@ pub(crate) fn evict(
         evicted.push(candidate)
     }
 
+    println!("Evicted {} canisters", evicted.len());
+
     evicted
 }
 

--- a/rs/config/src/embedders.rs
+++ b/rs/config/src/embedders.rs
@@ -44,11 +44,11 @@ const DEFAULT_PAGE_ALLOCATOR_THREADS: usize = 8;
 
 /// Sandbox process eviction does not activate if the number of sandbox
 /// processes is below this threshold.
-pub(crate) const DEFAULT_MIN_SANDBOX_COUNT: usize = 500;
+pub(crate) const DEFAULT_MIN_SANDBOX_COUNT: usize = 2_000;
 
 /// Sandbox process eviction ensures that the number of sandbox processes is
 /// always below this threshold.
-pub(crate) const DEFAULT_MAX_SANDBOX_COUNT: usize = 2_000;
+pub(crate) const DEFAULT_MAX_SANDBOX_COUNT: usize = 20_000;
 
 /// A sandbox process may be evicted after it has been idle for this
 /// duration and sandbox process eviction is activated.

--- a/rs/config/src/execution_environment.rs
+++ b/rs/config/src/execution_environment.rs
@@ -59,7 +59,7 @@ pub const STOP_CANISTER_TIMEOUT_DURATION: Duration = Duration::from_secs(5 * 60)
 /// potential fragmentation. This limit should be larger than the maximum
 /// canister memory size to guarantee that a message that overwrites the whole
 /// memory can succeed.
-pub(crate) const SUBNET_HEAP_DELTA_CAPACITY: NumBytes = NumBytes::new(140 * GIB);
+pub(crate) const SUBNET_HEAP_DELTA_CAPACITY: NumBytes = NumBytes::new(80 * GIB);
 
 /// The maximum number of instructions for inspect_message calls.
 const MAX_INSTRUCTIONS_FOR_MESSAGE_ACCEPTANCE_CALLS: NumInstructions =


### PR DESCRIPTION
In this PR we upgrade the sandbox eviction logic such that it doesn't only operate on the number of sandboxes, but also on their memory usage.

Some contention/discussion points:

* Until this PR, the sandbox stat collection was done every 10s; we probably need to do this more often.
* Overall page delta is reduced to 80 GiB. This constant and the max sandbox memory usage need to be thoroughly aligned.