### PR TITLE
fix(PocketIC): do not prune OpOut in graph

### DIFF
--- a/rs/pocket_ic_server/src/state_api/routes.rs
+++ b/rs/pocket_ic_server/src/state_api/routes.rs
@@ -768,14 +768,6 @@ async fn handle_raw<T: Operation + Send + Sync + 'static>(
 /// the return type.
 async fn op_out_to_response(op_out: OpOut) -> Response {
     match op_out {
-        OpOut::Pruned => (
-            StatusCode::GONE,
-            Json(ApiResponse::<()>::Error {
-                message: "Pruned".to_owned(),
-            })
-            .into_response(),
-        )
-            .into_response(),
         opout @ OpOut::MessageId(_) => (
             StatusCode::OK,
             Json(ApiResponse::Success(


### PR DESCRIPTION
Pruning OpOut values in the PocketIC state graph could lead to test timeouts because a different operation might depend on the pruned OpOut:
- instance 0 starts op_id OP from state label SL
- instance 0 times out op_id OP from state label SL
- instance 1 starts op_id OP from state label SL
- library polls for the result of op_id OP from state label SL (instance 0) and gets NOT FOUND
- instance 1 finishes op_id OP from state label SL and writes result to graph
- instance 0 finishes op_id OP from state label SL and writes result to graph (computations are deterministic and thus the same result is written)
- instance 1 prunes the result of op_id OP from state label SL in the graph (because instance 1 finished the operation quickly)
- library polls for the result of op_id OP from state label SL (instance 0) and gets Pruned (forever at this point)

I could also _empirically_ confirm to see that `OpOut::Pruned` was returned indefinitely for some computations (but could not confirm if the scenario was exactly as described above).