### PR TITLE
chore(PocketIC): reduce PocketIC test network bandwidth

### DIFF
--- a/packages/pocket-ic/tests/tests.rs
+++ b/packages/pocket-ic/tests/tests.rs
@@ -601,11 +601,12 @@ fn test_too_large_call() {
     let counter_wasm = counter_wasm();
     pic.install_canister(canister_id, counter_wasm, vec![], None);
 
+    const MAX_INGRESS_MESSAGE_ARG_SIZE: usize = 2097152;
     pic.update_call(
         canister_id,
         Principal::anonymous(),
         "inc",
-        vec![42; 16_000_000],
+        vec![42; MAX_INGRESS_MESSAGE_ARG_SIZE + 1],
     )
     .unwrap_err();
 }


### PR DESCRIPTION
This PR optimizes the network bandwidth in PocketIC tests by reducing the size of an overly large update call from 16MB to a bit over 2MiB which already exceeds the limit.