### PR TITLE
chore(MR): bump the XNet compatibility test failure threshold

### DIFF
--- a/rs/tests/src/message_routing/compatibility.rs
+++ b/rs/tests/src/message_routing/compatibility.rs
@@ -144,7 +144,7 @@ pub async fn test_async(env: TestEnv) {
         // Given that there are a couple of subnet upgrades happening
         // while the long running test is running we are generous
         // with error thresholds.
-        50.0,
+        75.0,
         40,
     );
 


### PR DESCRIPTION
For some reason the replica upgrades got very slow over the last week, which is making a lot more messages fail in the XNet compatibility test. Bump the threshold up until we can figure out what's causing the upgrade slowdown.