### PR TITLE
chore(IDX): disable closure tests

### DIFF
--- a/rs/ethereum/cketh/minter/BUILD.bazel
+++ b/rs/ethereum/cketh/minter/BUILD.bazel
@@ -237,6 +237,8 @@ rust_binary(
 closure_js_library(
     name = "principal_to_bytes",
     srcs = ["templates/principal_to_bytes.js"],
+    # We don't automatically build this because the build is unreliable.
+    tags = ["manual"],
     # the test doesn't need to run on macOS; just linux is enough
     target_compatible_with = [
         "@platforms//os:linux",
@@ -246,6 +248,8 @@ closure_js_library(
 closure_js_test(
     name = "principal_to_bytes_test",
     srcs = ["tests/principal_to_bytes_test.js"],
+    # We don't automatically build this because the build is unreliable.
+    tags = ["manual"],
     # the test doesn't need to run on macOS; just linux is enough
     target_compatible_with = [
         "@platforms//os:linux",


### PR DESCRIPTION
The `principal_to_bytes` test uses the deprecated
[closure](https://github.com/google/closure-library) framework. The `rules_closure` are causing flakiness in our Bazel build.

Because the `principal_to_bytes` code is rarely (if ever) changed we temporarily disable the tests, until a better solution is found.