### PR TITLE
chore(IDX): remove read-all permissions

### DIFF
--- a/.github/workflows-source/ci-main.yml
+++ b/.github/workflows-source/ci-main.yml
@@ -20,8 +20,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
-permissions: read-all
-
 env:
   CI_COMMIT_SHA: ${{ github.sha }}
   CI_JOB_NAME: ${{ github.job }}

--- a/.github/workflows-source/ci-pr-only.yml
+++ b/.github/workflows-source/ci-pr-only.yml
@@ -5,8 +5,6 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
-permissions: read-all
-
 concurrency:
   # only triggered on PR, so head_ref will always be set
   group: ${{ github.workflow }}-${{ github.head_ref }}

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -17,7 +17,6 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
-permissions: read-all
 env:
   CI_COMMIT_SHA: ${{ github.sha }}
   CI_JOB_NAME: ${{ github.job }}

--- a/.github/workflows/ci-pr-only.yml
+++ b/.github/workflows/ci-pr-only.yml
@@ -4,7 +4,6 @@ name: CI PR Only
 on:
   pull_request:
     types: [opened, synchronize, reopened]
-permissions: read-all
 concurrency:
   # only triggered on PR, so head_ref will always be set
   group: ${{ github.workflow }}-${{ github.head_ref }}


### PR DESCRIPTION
Permissions are set to `read-all` by default, so this is unnecessary and only causes confusion.