### PR TITLE
feat(crypto): CRP-2609 Introduce master key ID variant for vetKD

### DIFF
--- a/rs/consensus/src/idkg/payload_builder.rs
+++ b/rs/consensus/src/idkg/payload_builder.rs
@@ -1082,6 +1082,9 @@ mod tests {
                         signature: vec![2; 32],
                     })
                 }
+                MasterPublicKeyId::VetKd(_) => {
+                    todo!("CRP-XXXX Properly handle vetKD master key id in consensus tests")
+                }
             },
         );
 
@@ -1923,6 +1926,9 @@ mod tests {
                         algorithm,
                         &mut rng,
                     ))
+                }
+                MasterPublicKeyId::VetKd(_) => {
+                    todo!("CRP-XXXX Properly handle vetKD master key id in consensus tests")
                 }
             };
             payload_0.available_pre_signatures.insert(

--- a/rs/consensus/src/idkg/payload_builder.rs
+++ b/rs/consensus/src/idkg/payload_builder.rs
@@ -1082,9 +1082,7 @@ mod tests {
                         signature: vec![2; 32],
                     })
                 }
-                MasterPublicKeyId::VetKd(_) => {
-                    todo!("CRP-XXXX Properly handle vetKD master key id in consensus tests")
-                }
+                MasterPublicKeyId::VetKd(_) => panic!("not applicable to vetKD"),
             },
         );
 
@@ -1927,9 +1925,7 @@ mod tests {
                         &mut rng,
                     ))
                 }
-                MasterPublicKeyId::VetKd(_) => {
-                    todo!("CRP-XXXX Properly handle vetKD master key id in consensus tests")
-                }
+                MasterPublicKeyId::VetKd(_) => panic!("not applicable to vetKD"),
             };
             payload_0.available_pre_signatures.insert(
                 payload_0.uid_generator.next_pre_signature_id(),

--- a/rs/consensus/src/idkg/payload_builder/pre_signatures.rs
+++ b/rs/consensus/src/idkg/payload_builder/pre_signatures.rs
@@ -359,7 +359,12 @@ fn make_new_pre_signatures_if_needed_helper(
     let Some(pre_signatures_to_create) = chain_key_config
         .key_configs
         .iter()
-        .filter(|key_config| !matches!(&key_config.key_id, MasterPublicKeyId::VetKd(_)))
+        .filter(|key_config| {
+            matches!(
+                &key_config.key_id,
+                MasterPublicKeyId::Ecdsa(_) | MasterPublicKeyId::Schnorr(_)
+            )
+        })
         .find(|key_config| &key_config.key_id == key_id)
         .map(|key_config| key_config.pre_signatures_to_create_in_advance as usize)
     else {

--- a/rs/consensus/src/idkg/payload_builder/pre_signatures.rs
+++ b/rs/consensus/src/idkg/payload_builder/pre_signatures.rs
@@ -500,9 +500,7 @@ pub(super) mod test_utils {
                     blinder_config_ref,
                 ))
             }
-            MasterPublicKeyId::VetKd(_) => {
-                todo!("CRP-XXXX Properly handle vetKD master key id in consensus tests")
-            }
+            MasterPublicKeyId::VetKd(_) => panic!("not applicable to vetKD"),
         };
         let configs = pre_signature
             .iter_transcript_configs_in_creation()
@@ -717,9 +715,7 @@ pub(super) mod tests {
         let expected_transcript_ids = match key_id {
             MasterPublicKeyId::Ecdsa(_) => 2 * expected_pre_signatures_in_creation,
             MasterPublicKeyId::Schnorr(_) => expected_pre_signatures_in_creation,
-            MasterPublicKeyId::VetKd(_) => {
-                todo!("CRP-XXXX Properly handle vetKD master key id in consensus tests")
-            }
+            MasterPublicKeyId::VetKd(_) => panic!("not applicable to vetKD"),
         };
         assert_eq!(transcript_ids.len(), expected_transcript_ids);
         assert_eq!(

--- a/rs/consensus/src/idkg/payload_builder/signatures.rs
+++ b/rs/consensus/src/idkg/payload_builder/signatures.rs
@@ -311,6 +311,9 @@ mod tests {
                             signature: vec![i as u8; 32],
                         })
                     }
+                    MasterPublicKeyId::VetKd(_) => {
+                        todo!("CRP-XXXX Properly handle vetKD master key id in consensus tests")
+                    }
                 },
             );
         }

--- a/rs/consensus/src/idkg/payload_builder/signatures.rs
+++ b/rs/consensus/src/idkg/payload_builder/signatures.rs
@@ -311,9 +311,7 @@ mod tests {
                             signature: vec![i as u8; 32],
                         })
                     }
-                    MasterPublicKeyId::VetKd(_) => {
-                        todo!("CRP-XXXX Properly handle vetKD master key id in consensus tests")
-                    }
+                    MasterPublicKeyId::VetKd(_) => panic!("not applicable to vetKD"),
                 },
             );
         }

--- a/rs/consensus/src/idkg/payload_verifier.rs
+++ b/rs/consensus/src/idkg/payload_verifier.rs
@@ -1043,6 +1043,9 @@ mod test {
                     MasterPublicKeyId::Schnorr(_) => {
                         SignWithSchnorrReply { signature: vec![] }.encode()
                     }
+                    MasterPublicKeyId::VetKd(_) => {
+                        todo!("CRP-XXXX Properly handle vetKD master key id in consensus tests")
+                    }
                 }),
             ));
 
@@ -1076,6 +1079,9 @@ mod test {
                 fake_schnorr_master_public_key_id(SchnorrAlgorithm::Ed25519)
             }
             MasterPublicKeyId::Schnorr(_) => fake_ecdsa_master_public_key_id(),
+            MasterPublicKeyId::VetKd(_) => {
+                todo!("CRP-XXXX Properly handle vetKD master key id in consensus tests")
+            }
         };
         // Add a pre-signature for the "wrong_key_id"
         insert_test_sig_inputs(

--- a/rs/consensus/src/idkg/payload_verifier.rs
+++ b/rs/consensus/src/idkg/payload_verifier.rs
@@ -1043,9 +1043,7 @@ mod test {
                     MasterPublicKeyId::Schnorr(_) => {
                         SignWithSchnorrReply { signature: vec![] }.encode()
                     }
-                    MasterPublicKeyId::VetKd(_) => {
-                        todo!("CRP-XXXX Properly handle vetKD master key id in consensus tests")
-                    }
+                    MasterPublicKeyId::VetKd(_) => panic!("not applicable to vetKD"),
                 }),
             ));
 
@@ -1079,9 +1077,7 @@ mod test {
                 fake_schnorr_master_public_key_id(SchnorrAlgorithm::Ed25519)
             }
             MasterPublicKeyId::Schnorr(_) => fake_ecdsa_master_public_key_id(),
-            MasterPublicKeyId::VetKd(_) => {
-                todo!("CRP-XXXX Properly handle vetKD master key id in consensus tests")
-            }
+            MasterPublicKeyId::VetKd(_) => panic!("not applicable to vetKD"),
         };
         // Add a pre-signature for the "wrong_key_id"
         insert_test_sig_inputs(

--- a/rs/consensus/src/idkg/signer.rs
+++ b/rs/consensus/src/idkg/signer.rs
@@ -1101,6 +1101,9 @@ mod tests {
                 fake_schnorr_master_public_key_id(SchnorrAlgorithm::Ed25519)
             }
             MasterPublicKeyId::Schnorr(_) => fake_ecdsa_master_public_key_id(),
+            MasterPublicKeyId::VetKd(_) => {
+                todo!("CRP-XXXX Properly handle vetKD master key id in consensus tests")
+            }
         };
 
         // Set up the signature requests
@@ -1288,6 +1291,9 @@ mod tests {
                 let expected_complaints_count = match key_id {
                     MasterPublicKeyId::Ecdsa(_) => requested_signatures_count * 5,
                     MasterPublicKeyId::Schnorr(_) => requested_signatures_count * 2,
+                    MasterPublicKeyId::VetKd(_) => {
+                        todo!("CRP-XXXX Properly handle vetKD master key id in consensus tests")
+                    }
                 };
                 let complaints = transcript_loader.returned_complaints();
                 assert_eq!(change_set.len(), complaints.len());
@@ -1367,6 +1373,9 @@ mod tests {
                             inputs.receivers().clone(),
                             ThresholdSigInputs::Schnorr(inputs),
                         )
+                    }
+                    MasterPublicKeyId::VetKd(_) => {
+                        todo!("CRP-XXXX Properly handle vetKD master key id in consensus tests")
                     }
                 };
                 let crypto = env
@@ -1548,6 +1557,7 @@ mod tests {
                 fake_schnorr_master_public_key_id(SchnorrAlgorithm::Ed25519)
             }
             MasterPublicKeyId::Schnorr(_) => fake_ecdsa_master_public_key_id(),
+            MasterPublicKeyId::VetKd(_) => fake_vetkd_master_public_key_id(),
         };
         let message = create_signature_share(&key_id_wrong_scheme, NODE_2, id_2.clone());
         let msg_id_2 = message.message_id();

--- a/rs/consensus/src/idkg/signer.rs
+++ b/rs/consensus/src/idkg/signer.rs
@@ -1101,9 +1101,7 @@ mod tests {
                 fake_schnorr_master_public_key_id(SchnorrAlgorithm::Ed25519)
             }
             MasterPublicKeyId::Schnorr(_) => fake_ecdsa_master_public_key_id(),
-            MasterPublicKeyId::VetKd(_) => {
-                todo!("CRP-XXXX Properly handle vetKD master key id in consensus tests")
-            }
+            MasterPublicKeyId::VetKd(_) => panic!("not applicable to vetKD"),
         };
 
         // Set up the signature requests
@@ -1291,9 +1289,7 @@ mod tests {
                 let expected_complaints_count = match key_id {
                     MasterPublicKeyId::Ecdsa(_) => requested_signatures_count * 5,
                     MasterPublicKeyId::Schnorr(_) => requested_signatures_count * 2,
-                    MasterPublicKeyId::VetKd(_) => {
-                        todo!("CRP-XXXX Properly handle vetKD master key id in consensus tests")
-                    }
+                    MasterPublicKeyId::VetKd(_) => panic!("not applicable to vetKD"),
                 };
                 let complaints = transcript_loader.returned_complaints();
                 assert_eq!(change_set.len(), complaints.len());
@@ -1374,9 +1370,7 @@ mod tests {
                             ThresholdSigInputs::Schnorr(inputs),
                         )
                     }
-                    MasterPublicKeyId::VetKd(_) => {
-                        todo!("CRP-XXXX Properly handle vetKD master key id in consensus tests")
-                    }
+                    MasterPublicKeyId::VetKd(_) => panic!("not applicable to vetKD"),
                 };
                 let crypto = env
                     .nodes

--- a/rs/consensus/src/idkg/signer.rs
+++ b/rs/consensus/src/idkg/signer.rs
@@ -1551,7 +1551,7 @@ mod tests {
                 fake_schnorr_master_public_key_id(SchnorrAlgorithm::Ed25519)
             }
             MasterPublicKeyId::Schnorr(_) => fake_ecdsa_master_public_key_id(),
-            MasterPublicKeyId::VetKd(_) => fake_vetkd_master_public_key_id(),
+            MasterPublicKeyId::VetKd(_) => panic!("not applicable to vetKD"),
         };
         let message = create_signature_share(&key_id_wrong_scheme, NODE_2, id_2.clone());
         let msg_id_2 = message.message_id();

--- a/rs/consensus/src/idkg/test_utils.rs
+++ b/rs/consensus/src/idkg/test_utils.rs
@@ -99,9 +99,7 @@ fn fake_signature_request_args(key_id: MasterPublicKeyId) -> ThresholdArguments 
             key_id,
             message: Arc::new(vec![1; 48]),
         }),
-        MasterPublicKeyId::VetKd(_) => {
-            todo!("CRP-XXXX Properly handle vetKD master key id in consensus tests")
-        }
+        MasterPublicKeyId::VetKd(_) => panic!("not applicable to vetKD"),
     }
 }
 
@@ -1157,9 +1155,7 @@ pub(crate) fn create_sig_inputs_with_args(
         MasterPublicKeyId::Schnorr(key_id) => {
             create_schnorr_sig_inputs_with_args(caller, receivers, key_unmasked, height, key_id)
         }
-        MasterPublicKeyId::VetKd(_) => {
-            todo!("CRP-XXXX Properly handle vetKD master key id in consensus tests")
-        }
+        MasterPublicKeyId::VetKd(_) => panic!("not applicable to vetKD"),
     }
 }
 
@@ -1364,9 +1360,7 @@ pub(crate) fn create_signature_share_with_nonce(
                 sig_share_raw: vec![nonce],
             },
         }),
-        MasterPublicKeyId::VetKd(_) => {
-            todo!("CRP-XXXX Properly handle vetKD master key id in consensus tests")
-        }
+        MasterPublicKeyId::VetKd(_) => panic!("not applicable to vetKD"),
     }
 }
 
@@ -1678,13 +1672,6 @@ pub(crate) fn fake_master_public_key_ids_for_all_algorithms() -> Vec<MasterPubli
             AlgorithmId::ThresholdEd25519 => {
                 Some(fake_schnorr_master_public_key_id(SchnorrAlgorithm::Ed25519))
             }
-            ///////////////////////////////////
-            // TODO: Likely an algorihm for vetKD shall be added here, but
-            // first CRP-XXXX (Properly handle vetKD master key id in
-            // consensus tests) must be addressed.
-            //
-            // AlgorithmId::ThresBls12_381 => Some(fake_vetkd_master_public_key_id()),
-            ///////////////////////////////////
             _ => None,
         })
         .collect()

--- a/rs/consensus/src/idkg/test_utils.rs
+++ b/rs/consensus/src/idkg/test_utils.rs
@@ -17,9 +17,7 @@ use ic_crypto_tree_hash::{LabeledTree, MixedHashTree};
 use ic_interfaces::idkg::{IDkgChangeAction, IDkgPool};
 use ic_interfaces_state_manager::{CertifiedStateSnapshot, Labeled};
 use ic_logger::ReplicaLogger;
-use ic_management_canister_types::{
-    EcdsaKeyId, MasterPublicKeyId, SchnorrAlgorithm, SchnorrKeyId, VetKdKeyId,
-};
+use ic_management_canister_types::{EcdsaKeyId, MasterPublicKeyId, SchnorrAlgorithm, SchnorrKeyId};
 use ic_metrics::MetricsRegistry;
 use ic_replicated_state::metadata_state::subnet_call_context_manager::{
     EcdsaArguments, IDkgDealingsContext, SchnorrArguments, SignWithThresholdContext,
@@ -1652,14 +1650,6 @@ pub(crate) fn schnorr_algorithm(algorithm: AlgorithmId) -> SchnorrAlgorithm {
         AlgorithmId::ThresholdEd25519 => SchnorrAlgorithm::Ed25519,
         other => panic!("Unexpected algorithm: {other:?}"),
     }
-}
-
-pub(crate) fn fake_vetkd_key_id() -> VetKdKeyId {
-    VetKdKeyId::from_str("Bls12_381:some_key").unwrap()
-}
-
-pub(crate) fn fake_vetkd_master_public_key_id() -> MasterPublicKeyId {
-    MasterPublicKeyId::VetKd(fake_vetkd_key_id())
 }
 
 pub(crate) fn fake_master_public_key_ids_for_all_algorithms() -> Vec<MasterPublicKeyId> {

--- a/rs/consensus/src/idkg/utils.rs
+++ b/rs/consensus/src/idkg/utils.rs
@@ -8,7 +8,7 @@ use ic_interfaces::consensus_pool::ConsensusBlockChain;
 use ic_interfaces::idkg::{IDkgChangeAction, IDkgChangeSet, IDkgPool};
 use ic_interfaces_registry::RegistryClient;
 use ic_logger::{warn, ReplicaLogger};
-use ic_management_canister_types::{EcdsaCurve, MasterPublicKeyId, SchnorrAlgorithm};
+use ic_management_canister_types::{EcdsaCurve, MasterPublicKeyId, SchnorrAlgorithm, VetKdCurve};
 use ic_protobuf::registry::subnet::v1 as pb;
 use ic_registry_client_helpers::subnet::SubnetRegistry;
 use ic_registry_subnet_features::ChainKeyConfig;
@@ -443,18 +443,9 @@ pub(crate) fn algorithm_for_key_id(key_id: &MasterPublicKeyId) -> AlgorithmId {
             SchnorrAlgorithm::Bip340Secp256k1 => AlgorithmId::ThresholdSchnorrBip340,
             SchnorrAlgorithm::Ed25519 => AlgorithmId::ThresholdEd25519,
         },
-        MasterPublicKeyId::VetKd(_vetkd_key_id) => {
-            todo!(
-                "how to behave here: it seems `algorithm_for_key_id` is only
-                called once in production by fn update_next_key_transcript in
-                the iDKG payload builder. Seemingly all other of the many
-                usages usages are in test code.
-                "
-            )
-            // match vetkd_key_id.curve {
-            //     VetKdCurve::Bls12_381 => AlgorithmId::ThresBls12_381,
-            // },
-        }
+        MasterPublicKeyId::VetKd(vetkd_key_id) => match vetkd_key_id.curve {
+            VetKdCurve::Bls12_381 => AlgorithmId::ThresBls12_381,
+        },
     }
 }
 

--- a/rs/consensus/src/idkg/utils.rs
+++ b/rs/consensus/src/idkg/utils.rs
@@ -8,7 +8,7 @@ use ic_interfaces::consensus_pool::ConsensusBlockChain;
 use ic_interfaces::idkg::{IDkgChangeAction, IDkgChangeSet, IDkgPool};
 use ic_interfaces_registry::RegistryClient;
 use ic_logger::{warn, ReplicaLogger};
-use ic_management_canister_types::{EcdsaCurve, MasterPublicKeyId, SchnorrAlgorithm, VetKdCurve};
+use ic_management_canister_types::{EcdsaCurve, MasterPublicKeyId, SchnorrAlgorithm};
 use ic_protobuf::registry::subnet::v1 as pb;
 use ic_registry_client_helpers::subnet::SubnetRegistry;
 use ic_registry_subnet_features::ChainKeyConfig;

--- a/rs/consensus/src/idkg/utils.rs
+++ b/rs/consensus/src/idkg/utils.rs
@@ -8,7 +8,7 @@ use ic_interfaces::consensus_pool::ConsensusBlockChain;
 use ic_interfaces::idkg::{IDkgChangeAction, IDkgChangeSet, IDkgPool};
 use ic_interfaces_registry::RegistryClient;
 use ic_logger::{warn, ReplicaLogger};
-use ic_management_canister_types::{EcdsaCurve, MasterPublicKeyId, SchnorrAlgorithm};
+use ic_management_canister_types::{EcdsaCurve, MasterPublicKeyId, SchnorrAlgorithm, VetKdCurve};
 use ic_protobuf::registry::subnet::v1 as pb;
 use ic_registry_client_helpers::subnet::SubnetRegistry;
 use ic_registry_subnet_features::ChainKeyConfig;
@@ -443,6 +443,18 @@ pub(crate) fn algorithm_for_key_id(key_id: &MasterPublicKeyId) -> AlgorithmId {
             SchnorrAlgorithm::Bip340Secp256k1 => AlgorithmId::ThresholdSchnorrBip340,
             SchnorrAlgorithm::Ed25519 => AlgorithmId::ThresholdEd25519,
         },
+        MasterPublicKeyId::VetKd(_vetkd_key_id) => {
+            todo!(
+                "how to behave here: it seems `algorithm_for_key_id` is only
+                called once in production by fn update_next_key_transcript in
+                the iDKG payload builder. Seemingly all other of the many
+                usages usages are in test code.
+                "
+            )
+            // match vetkd_key_id.curve {
+            //     VetKdCurve::Bls12_381 => AlgorithmId::ThresBls12_381,
+            // },
+        }
     }
 }
 

--- a/rs/consensus/src/idkg/utils.rs
+++ b/rs/consensus/src/idkg/utils.rs
@@ -444,7 +444,7 @@ pub(crate) fn algorithm_for_key_id(key_id: &MasterPublicKeyId) -> AlgorithmId {
             SchnorrAlgorithm::Ed25519 => AlgorithmId::ThresholdEd25519,
         },
         MasterPublicKeyId::VetKd(vetkd_key_id) => match vetkd_key_id.curve {
-            VetKdCurve::Bls12_381 => AlgorithmId::ThresBls12_381,
+            VetKdCurve::Bls12_381 => AlgorithmId::Placeholder,
         },
     }
 }

--- a/rs/consensus/src/idkg/utils.rs
+++ b/rs/consensus/src/idkg/utils.rs
@@ -444,7 +444,7 @@ pub(crate) fn algorithm_for_key_id(key_id: &MasterPublicKeyId) -> AlgorithmId {
             SchnorrAlgorithm::Ed25519 => AlgorithmId::ThresholdEd25519,
         },
         MasterPublicKeyId::VetKd(vetkd_key_id) => match vetkd_key_id.curve {
-            VetKdCurve::Bls12_381 => AlgorithmId::Placeholder,
+            VetKdCurve::Bls12_381_G2 => AlgorithmId::Placeholder,
         },
     }
 }

--- a/rs/consensus/utils/src/lib.rs
+++ b/rs/consensus/utils/src/lib.rs
@@ -860,6 +860,9 @@ mod tests {
             MasterPublicKeyId::Schnorr(key_id) => {
                 PreSignatureRef::Schnorr(fake_schnorr_transcript(id, key_id.clone()))
             }
+            MasterPublicKeyId::VetKd(_) => {
+                todo!("CRP-XXXX Properly handle vetKD master key id in consensus tests")
+            }
         }
     }
 
@@ -879,6 +882,9 @@ mod tests {
                         message: Arc::new(vec![1; 64]),
                         key_id: key_id.clone(),
                     })
+                }
+                MasterPublicKeyId::VetKd(_) => {
+                    todo!("CRP-XXXX Properly handle vetKD master key id in consensus tests")
                 }
             },
             derivation_path: vec![],

--- a/rs/consensus/utils/src/lib.rs
+++ b/rs/consensus/utils/src/lib.rs
@@ -860,9 +860,7 @@ mod tests {
             MasterPublicKeyId::Schnorr(key_id) => {
                 PreSignatureRef::Schnorr(fake_schnorr_transcript(id, key_id.clone()))
             }
-            MasterPublicKeyId::VetKd(_) => {
-                todo!("CRP-XXXX Properly handle vetKD master key id in consensus tests")
-            }
+            MasterPublicKeyId::VetKd(_) => panic!("not applicable to vetKD"),
         }
     }
 
@@ -883,9 +881,7 @@ mod tests {
                         key_id: key_id.clone(),
                     })
                 }
-                MasterPublicKeyId::VetKd(_) => {
-                    todo!("CRP-XXXX Properly handle vetKD master key id in consensus tests")
-                }
+                MasterPublicKeyId::VetKd(_) => panic!("not applicable to vetKD"),
             },
             derivation_path: vec![],
             pseudo_random_id: [0; 32],

--- a/rs/execution_environment/src/scheduler/threshold_signatures.rs
+++ b/rs/execution_environment/src/scheduler/threshold_signatures.rs
@@ -140,6 +140,7 @@ mod tests {
                 key_id: key_id.clone(),
                 message: Arc::new(vec![1; 64]),
             }),
+            MasterPublicKeyId::VetKd(_) => panic!("vetKD does not have pre-signatures"),
         };
         let context = SignWithThresholdContext {
             request: RequestBuilder::new().build(),

--- a/rs/protobuf/def/registry/crypto/v1/crypto.proto
+++ b/rs/protobuf/def/registry/crypto/v1/crypto.proto
@@ -80,9 +80,20 @@ message SchnorrKeyId {
   string name = 2;
 }
 
+enum VetKdCurve {
+  VETKD_CURVE_UNSPECIFIED = 0;
+  VETKD_CURVE_BLS12381 = 1;
+}
+
+message VetKdKeyId {
+  VetKdCurve curve = 1;
+  string name = 2;
+}
+
 message MasterPublicKeyId {
   oneof key_id {
     EcdsaKeyId ecdsa = 1;
     SchnorrKeyId schnorr = 2;
+    VetKdKeyId vetkd = 3;
   }
 }

--- a/rs/protobuf/def/registry/crypto/v1/crypto.proto
+++ b/rs/protobuf/def/registry/crypto/v1/crypto.proto
@@ -81,8 +81,8 @@ message SchnorrKeyId {
 }
 
 enum VetKdCurve {
-  VETKD_CURVE_UNSPECIFIED = 0;
-  VETKD_CURVE_BLS12_381_G2 = 1;
+  VET_KD_CURVE_UNSPECIFIED = 0;
+  VET_KD_CURVE_BLS12_381_G2 = 1;
 }
 
 message VetKdKeyId {

--- a/rs/protobuf/def/registry/crypto/v1/crypto.proto
+++ b/rs/protobuf/def/registry/crypto/v1/crypto.proto
@@ -82,7 +82,7 @@ message SchnorrKeyId {
 
 enum VetKdCurve {
   VETKD_CURVE_UNSPECIFIED = 0;
-  VETKD_CURVE_BLS12381 = 1;
+  VETKD_CURVE_BLS12_381_G2 = 1;
 }
 
 message VetKdKeyId {

--- a/rs/protobuf/src/gen/crypto/registry.crypto.v1.rs
+++ b/rs/protobuf/src/gen/crypto/registry.crypto.v1.rs
@@ -49,8 +49,15 @@ pub struct SchnorrKeyId {
     pub name: ::prost::alloc::string::String,
 }
 #[derive(serde::Serialize, serde::Deserialize, Clone, PartialEq, ::prost::Message)]
+pub struct VetKdKeyId {
+    #[prost(enumeration = "VetKdCurve", tag = "1")]
+    pub curve: i32,
+    #[prost(string, tag = "2")]
+    pub name: ::prost::alloc::string::String,
+}
+#[derive(serde::Serialize, serde::Deserialize, Clone, PartialEq, ::prost::Message)]
 pub struct MasterPublicKeyId {
-    #[prost(oneof = "master_public_key_id::KeyId", tags = "1, 2")]
+    #[prost(oneof = "master_public_key_id::KeyId", tags = "1, 2, 3")]
     pub key_id: ::core::option::Option<master_public_key_id::KeyId>,
 }
 /// Nested message and enum types in `MasterPublicKeyId`.
@@ -61,6 +68,8 @@ pub mod master_public_key_id {
         Ecdsa(super::EcdsaKeyId),
         #[prost(message, tag = "2")]
         Schnorr(super::SchnorrKeyId),
+        #[prost(message, tag = "3")]
+        Vetkd(super::VetKdKeyId),
     }
 }
 /// An algorithm ID. This is used to specify the signature algorithm associated with a public key.
@@ -233,6 +242,44 @@ impl SchnorrAlgorithm {
             "SCHNORR_ALGORITHM_UNSPECIFIED" => Some(Self::Unspecified),
             "SCHNORR_ALGORITHM_BIP340SECP256K1" => Some(Self::Bip340secp256k1),
             "SCHNORR_ALGORITHM_ED25519" => Some(Self::Ed25519),
+            _ => None,
+        }
+    }
+}
+#[derive(
+    serde::Serialize,
+    serde::Deserialize,
+    Clone,
+    Copy,
+    Debug,
+    PartialEq,
+    Eq,
+    Hash,
+    PartialOrd,
+    Ord,
+    ::prost::Enumeration,
+)]
+#[repr(i32)]
+pub enum VetKdCurve {
+    VetkdCurveUnspecified = 0,
+    VetkdCurveBls12381 = 1,
+}
+impl VetKdCurve {
+    /// String value of the enum field names used in the ProtoBuf definition.
+    ///
+    /// The values are not transformed in any way and thus are considered stable
+    /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+    pub fn as_str_name(&self) -> &'static str {
+        match self {
+            Self::VetkdCurveUnspecified => "VETKD_CURVE_UNSPECIFIED",
+            Self::VetkdCurveBls12381 => "VETKD_CURVE_BLS12381",
+        }
+    }
+    /// Creates an enum from field names used in the ProtoBuf definition.
+    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+        match value {
+            "VETKD_CURVE_UNSPECIFIED" => Some(Self::VetkdCurveUnspecified),
+            "VETKD_CURVE_BLS12381" => Some(Self::VetkdCurveBls12381),
             _ => None,
         }
     }

--- a/rs/protobuf/src/gen/crypto/registry.crypto.v1.rs
+++ b/rs/protobuf/src/gen/crypto/registry.crypto.v1.rs
@@ -261,8 +261,8 @@ impl SchnorrAlgorithm {
 )]
 #[repr(i32)]
 pub enum VetKdCurve {
-    VetkdCurveUnspecified = 0,
-    VetkdCurveBls12381G2 = 1,
+    Unspecified = 0,
+    Bls12381G2 = 1,
 }
 impl VetKdCurve {
     /// String value of the enum field names used in the ProtoBuf definition.
@@ -271,15 +271,15 @@ impl VetKdCurve {
     /// (if the ProtoBuf definition does not change) and safe for programmatic use.
     pub fn as_str_name(&self) -> &'static str {
         match self {
-            Self::VetkdCurveUnspecified => "VETKD_CURVE_UNSPECIFIED",
-            Self::VetkdCurveBls12381G2 => "VETKD_CURVE_BLS12_381_G2",
+            Self::Unspecified => "VET_KD_CURVE_UNSPECIFIED",
+            Self::Bls12381G2 => "VET_KD_CURVE_BLS12_381_G2",
         }
     }
     /// Creates an enum from field names used in the ProtoBuf definition.
     pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
         match value {
-            "VETKD_CURVE_UNSPECIFIED" => Some(Self::VetkdCurveUnspecified),
-            "VETKD_CURVE_BLS12_381_G2" => Some(Self::VetkdCurveBls12381G2),
+            "VET_KD_CURVE_UNSPECIFIED" => Some(Self::Unspecified),
+            "VET_KD_CURVE_BLS12_381_G2" => Some(Self::Bls12381G2),
             _ => None,
         }
     }

--- a/rs/protobuf/src/gen/crypto/registry.crypto.v1.rs
+++ b/rs/protobuf/src/gen/crypto/registry.crypto.v1.rs
@@ -262,7 +262,7 @@ impl SchnorrAlgorithm {
 #[repr(i32)]
 pub enum VetKdCurve {
     VetkdCurveUnspecified = 0,
-    VetkdCurveBls12381 = 1,
+    VetkdCurveBls12381G2 = 1,
 }
 impl VetKdCurve {
     /// String value of the enum field names used in the ProtoBuf definition.
@@ -272,14 +272,14 @@ impl VetKdCurve {
     pub fn as_str_name(&self) -> &'static str {
         match self {
             Self::VetkdCurveUnspecified => "VETKD_CURVE_UNSPECIFIED",
-            Self::VetkdCurveBls12381 => "VETKD_CURVE_BLS12381",
+            Self::VetkdCurveBls12381G2 => "VETKD_CURVE_BLS12_381_G2",
         }
     }
     /// Creates an enum from field names used in the ProtoBuf definition.
     pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
         match value {
             "VETKD_CURVE_UNSPECIFIED" => Some(Self::VetkdCurveUnspecified),
-            "VETKD_CURVE_BLS12381" => Some(Self::VetkdCurveBls12381),
+            "VETKD_CURVE_BLS12_381_G2" => Some(Self::VetkdCurveBls12381G2),
             _ => None,
         }
     }

--- a/rs/protobuf/src/gen/registry/registry.crypto.v1.rs
+++ b/rs/protobuf/src/gen/registry/registry.crypto.v1.rs
@@ -71,8 +71,15 @@ pub struct SchnorrKeyId {
     pub name: ::prost::alloc::string::String,
 }
 #[derive(serde::Serialize, serde::Deserialize, Clone, PartialEq, ::prost::Message)]
+pub struct VetKdKeyId {
+    #[prost(enumeration = "VetKdCurve", tag = "1")]
+    pub curve: i32,
+    #[prost(string, tag = "2")]
+    pub name: ::prost::alloc::string::String,
+}
+#[derive(serde::Serialize, serde::Deserialize, Clone, PartialEq, ::prost::Message)]
 pub struct MasterPublicKeyId {
-    #[prost(oneof = "master_public_key_id::KeyId", tags = "1, 2")]
+    #[prost(oneof = "master_public_key_id::KeyId", tags = "1, 2, 3")]
     pub key_id: ::core::option::Option<master_public_key_id::KeyId>,
 }
 /// Nested message and enum types in `MasterPublicKeyId`.
@@ -83,6 +90,8 @@ pub mod master_public_key_id {
         Ecdsa(super::EcdsaKeyId),
         #[prost(message, tag = "2")]
         Schnorr(super::SchnorrKeyId),
+        #[prost(message, tag = "3")]
+        Vetkd(super::VetKdKeyId),
     }
 }
 /// An algorithm ID. This is used to specify the signature algorithm associated with a public key.
@@ -256,6 +265,44 @@ impl SchnorrAlgorithm {
             "SCHNORR_ALGORITHM_UNSPECIFIED" => Some(Self::Unspecified),
             "SCHNORR_ALGORITHM_BIP340SECP256K1" => Some(Self::Bip340secp256k1),
             "SCHNORR_ALGORITHM_ED25519" => Some(Self::Ed25519),
+            _ => None,
+        }
+    }
+}
+#[derive(
+    serde::Serialize,
+    serde::Deserialize,
+    Clone,
+    Copy,
+    Debug,
+    PartialEq,
+    Eq,
+    Hash,
+    PartialOrd,
+    Ord,
+    ::prost::Enumeration,
+)]
+#[repr(i32)]
+pub enum VetKdCurve {
+    VetkdCurveUnspecified = 0,
+    VetkdCurveBls12381 = 1,
+}
+impl VetKdCurve {
+    /// String value of the enum field names used in the ProtoBuf definition.
+    ///
+    /// The values are not transformed in any way and thus are considered stable
+    /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+    pub fn as_str_name(&self) -> &'static str {
+        match self {
+            Self::VetkdCurveUnspecified => "VETKD_CURVE_UNSPECIFIED",
+            Self::VetkdCurveBls12381 => "VETKD_CURVE_BLS12381",
+        }
+    }
+    /// Creates an enum from field names used in the ProtoBuf definition.
+    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+        match value {
+            "VETKD_CURVE_UNSPECIFIED" => Some(Self::VetkdCurveUnspecified),
+            "VETKD_CURVE_BLS12381" => Some(Self::VetkdCurveBls12381),
             _ => None,
         }
     }

--- a/rs/protobuf/src/gen/registry/registry.crypto.v1.rs
+++ b/rs/protobuf/src/gen/registry/registry.crypto.v1.rs
@@ -285,7 +285,7 @@ impl SchnorrAlgorithm {
 #[repr(i32)]
 pub enum VetKdCurve {
     VetkdCurveUnspecified = 0,
-    VetkdCurveBls12381 = 1,
+    VetkdCurveBls12381G2 = 1,
 }
 impl VetKdCurve {
     /// String value of the enum field names used in the ProtoBuf definition.
@@ -295,14 +295,14 @@ impl VetKdCurve {
     pub fn as_str_name(&self) -> &'static str {
         match self {
             Self::VetkdCurveUnspecified => "VETKD_CURVE_UNSPECIFIED",
-            Self::VetkdCurveBls12381 => "VETKD_CURVE_BLS12381",
+            Self::VetkdCurveBls12381G2 => "VETKD_CURVE_BLS12_381_G2",
         }
     }
     /// Creates an enum from field names used in the ProtoBuf definition.
     pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
         match value {
             "VETKD_CURVE_UNSPECIFIED" => Some(Self::VetkdCurveUnspecified),
-            "VETKD_CURVE_BLS12381" => Some(Self::VetkdCurveBls12381),
+            "VETKD_CURVE_BLS12_381_G2" => Some(Self::VetkdCurveBls12381G2),
             _ => None,
         }
     }

--- a/rs/protobuf/src/gen/registry/registry.crypto.v1.rs
+++ b/rs/protobuf/src/gen/registry/registry.crypto.v1.rs
@@ -284,8 +284,8 @@ impl SchnorrAlgorithm {
 )]
 #[repr(i32)]
 pub enum VetKdCurve {
-    VetkdCurveUnspecified = 0,
-    VetkdCurveBls12381G2 = 1,
+    Unspecified = 0,
+    Bls12381G2 = 1,
 }
 impl VetKdCurve {
     /// String value of the enum field names used in the ProtoBuf definition.
@@ -294,15 +294,15 @@ impl VetKdCurve {
     /// (if the ProtoBuf definition does not change) and safe for programmatic use.
     pub fn as_str_name(&self) -> &'static str {
         match self {
-            Self::VetkdCurveUnspecified => "VETKD_CURVE_UNSPECIFIED",
-            Self::VetkdCurveBls12381G2 => "VETKD_CURVE_BLS12_381_G2",
+            Self::Unspecified => "VET_KD_CURVE_UNSPECIFIED",
+            Self::Bls12381G2 => "VET_KD_CURVE_BLS12_381_G2",
         }
     }
     /// Creates an enum from field names used in the ProtoBuf definition.
     pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
         match value {
-            "VETKD_CURVE_UNSPECIFIED" => Some(Self::VetkdCurveUnspecified),
-            "VETKD_CURVE_BLS12_381_G2" => Some(Self::VetkdCurveBls12381G2),
+            "VET_KD_CURVE_UNSPECIFIED" => Some(Self::Unspecified),
+            "VET_KD_CURVE_BLS12_381_G2" => Some(Self::Bls12381G2),
             _ => None,
         }
     }

--- a/rs/protobuf/src/gen/state/registry.crypto.v1.rs
+++ b/rs/protobuf/src/gen/state/registry.crypto.v1.rs
@@ -49,8 +49,15 @@ pub struct SchnorrKeyId {
     pub name: ::prost::alloc::string::String,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
+pub struct VetKdKeyId {
+    #[prost(enumeration = "VetKdCurve", tag = "1")]
+    pub curve: i32,
+    #[prost(string, tag = "2")]
+    pub name: ::prost::alloc::string::String,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MasterPublicKeyId {
-    #[prost(oneof = "master_public_key_id::KeyId", tags = "1, 2")]
+    #[prost(oneof = "master_public_key_id::KeyId", tags = "1, 2, 3")]
     pub key_id: ::core::option::Option<master_public_key_id::KeyId>,
 }
 /// Nested message and enum types in `MasterPublicKeyId`.
@@ -61,6 +68,8 @@ pub mod master_public_key_id {
         Ecdsa(super::EcdsaKeyId),
         #[prost(message, tag = "2")]
         Schnorr(super::SchnorrKeyId),
+        #[prost(message, tag = "3")]
+        Vetkd(super::VetKdKeyId),
     }
 }
 /// An algorithm ID. This is used to specify the signature algorithm associated with a public key.
@@ -197,6 +206,32 @@ impl SchnorrAlgorithm {
             "SCHNORR_ALGORITHM_UNSPECIFIED" => Some(Self::Unspecified),
             "SCHNORR_ALGORITHM_BIP340SECP256K1" => Some(Self::Bip340secp256k1),
             "SCHNORR_ALGORITHM_ED25519" => Some(Self::Ed25519),
+            _ => None,
+        }
+    }
+}
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[repr(i32)]
+pub enum VetKdCurve {
+    VetkdCurveUnspecified = 0,
+    VetkdCurveBls12381 = 1,
+}
+impl VetKdCurve {
+    /// String value of the enum field names used in the ProtoBuf definition.
+    ///
+    /// The values are not transformed in any way and thus are considered stable
+    /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+    pub fn as_str_name(&self) -> &'static str {
+        match self {
+            Self::VetkdCurveUnspecified => "VETKD_CURVE_UNSPECIFIED",
+            Self::VetkdCurveBls12381 => "VETKD_CURVE_BLS12381",
+        }
+    }
+    /// Creates an enum from field names used in the ProtoBuf definition.
+    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+        match value {
+            "VETKD_CURVE_UNSPECIFIED" => Some(Self::VetkdCurveUnspecified),
+            "VETKD_CURVE_BLS12381" => Some(Self::VetkdCurveBls12381),
             _ => None,
         }
     }

--- a/rs/protobuf/src/gen/state/registry.crypto.v1.rs
+++ b/rs/protobuf/src/gen/state/registry.crypto.v1.rs
@@ -214,7 +214,7 @@ impl SchnorrAlgorithm {
 #[repr(i32)]
 pub enum VetKdCurve {
     VetkdCurveUnspecified = 0,
-    VetkdCurveBls12381 = 1,
+    VetkdCurveBls12381G2 = 1,
 }
 impl VetKdCurve {
     /// String value of the enum field names used in the ProtoBuf definition.
@@ -224,14 +224,14 @@ impl VetKdCurve {
     pub fn as_str_name(&self) -> &'static str {
         match self {
             Self::VetkdCurveUnspecified => "VETKD_CURVE_UNSPECIFIED",
-            Self::VetkdCurveBls12381 => "VETKD_CURVE_BLS12381",
+            Self::VetkdCurveBls12381G2 => "VETKD_CURVE_BLS12_381_G2",
         }
     }
     /// Creates an enum from field names used in the ProtoBuf definition.
     pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
         match value {
             "VETKD_CURVE_UNSPECIFIED" => Some(Self::VetkdCurveUnspecified),
-            "VETKD_CURVE_BLS12381" => Some(Self::VetkdCurveBls12381),
+            "VETKD_CURVE_BLS12_381_G2" => Some(Self::VetkdCurveBls12381G2),
             _ => None,
         }
     }

--- a/rs/protobuf/src/gen/state/registry.crypto.v1.rs
+++ b/rs/protobuf/src/gen/state/registry.crypto.v1.rs
@@ -213,8 +213,8 @@ impl SchnorrAlgorithm {
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]
 pub enum VetKdCurve {
-    VetkdCurveUnspecified = 0,
-    VetkdCurveBls12381G2 = 1,
+    Unspecified = 0,
+    Bls12381G2 = 1,
 }
 impl VetKdCurve {
     /// String value of the enum field names used in the ProtoBuf definition.
@@ -223,15 +223,15 @@ impl VetKdCurve {
     /// (if the ProtoBuf definition does not change) and safe for programmatic use.
     pub fn as_str_name(&self) -> &'static str {
         match self {
-            Self::VetkdCurveUnspecified => "VETKD_CURVE_UNSPECIFIED",
-            Self::VetkdCurveBls12381G2 => "VETKD_CURVE_BLS12_381_G2",
+            Self::Unspecified => "VET_KD_CURVE_UNSPECIFIED",
+            Self::Bls12381G2 => "VET_KD_CURVE_BLS12_381_G2",
         }
     }
     /// Creates an enum from field names used in the ProtoBuf definition.
     pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
         match value {
-            "VETKD_CURVE_UNSPECIFIED" => Some(Self::VetkdCurveUnspecified),
-            "VETKD_CURVE_BLS12_381_G2" => Some(Self::VetkdCurveBls12381G2),
+            "VET_KD_CURVE_UNSPECIFIED" => Some(Self::Unspecified),
+            "VET_KD_CURVE_BLS12_381_G2" => Some(Self::Bls12381G2),
             _ => None,
         }
     }

--- a/rs/protobuf/src/gen/types/registry.crypto.v1.rs
+++ b/rs/protobuf/src/gen/types/registry.crypto.v1.rs
@@ -49,8 +49,15 @@ pub struct SchnorrKeyId {
     pub name: ::prost::alloc::string::String,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
+pub struct VetKdKeyId {
+    #[prost(enumeration = "VetKdCurve", tag = "1")]
+    pub curve: i32,
+    #[prost(string, tag = "2")]
+    pub name: ::prost::alloc::string::String,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MasterPublicKeyId {
-    #[prost(oneof = "master_public_key_id::KeyId", tags = "1, 2")]
+    #[prost(oneof = "master_public_key_id::KeyId", tags = "1, 2, 3")]
     pub key_id: ::core::option::Option<master_public_key_id::KeyId>,
 }
 /// Nested message and enum types in `MasterPublicKeyId`.
@@ -61,6 +68,8 @@ pub mod master_public_key_id {
         Ecdsa(super::EcdsaKeyId),
         #[prost(message, tag = "2")]
         Schnorr(super::SchnorrKeyId),
+        #[prost(message, tag = "3")]
+        Vetkd(super::VetKdKeyId),
     }
 }
 /// An algorithm ID. This is used to specify the signature algorithm associated with a public key.
@@ -197,6 +206,32 @@ impl SchnorrAlgorithm {
             "SCHNORR_ALGORITHM_UNSPECIFIED" => Some(Self::Unspecified),
             "SCHNORR_ALGORITHM_BIP340SECP256K1" => Some(Self::Bip340secp256k1),
             "SCHNORR_ALGORITHM_ED25519" => Some(Self::Ed25519),
+            _ => None,
+        }
+    }
+}
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[repr(i32)]
+pub enum VetKdCurve {
+    VetkdCurveUnspecified = 0,
+    VetkdCurveBls12381 = 1,
+}
+impl VetKdCurve {
+    /// String value of the enum field names used in the ProtoBuf definition.
+    ///
+    /// The values are not transformed in any way and thus are considered stable
+    /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+    pub fn as_str_name(&self) -> &'static str {
+        match self {
+            Self::VetkdCurveUnspecified => "VETKD_CURVE_UNSPECIFIED",
+            Self::VetkdCurveBls12381 => "VETKD_CURVE_BLS12381",
+        }
+    }
+    /// Creates an enum from field names used in the ProtoBuf definition.
+    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+        match value {
+            "VETKD_CURVE_UNSPECIFIED" => Some(Self::VetkdCurveUnspecified),
+            "VETKD_CURVE_BLS12381" => Some(Self::VetkdCurveBls12381),
             _ => None,
         }
     }

--- a/rs/protobuf/src/gen/types/registry.crypto.v1.rs
+++ b/rs/protobuf/src/gen/types/registry.crypto.v1.rs
@@ -214,7 +214,7 @@ impl SchnorrAlgorithm {
 #[repr(i32)]
 pub enum VetKdCurve {
     VetkdCurveUnspecified = 0,
-    VetkdCurveBls12381 = 1,
+    VetkdCurveBls12381G2 = 1,
 }
 impl VetKdCurve {
     /// String value of the enum field names used in the ProtoBuf definition.
@@ -224,14 +224,14 @@ impl VetKdCurve {
     pub fn as_str_name(&self) -> &'static str {
         match self {
             Self::VetkdCurveUnspecified => "VETKD_CURVE_UNSPECIFIED",
-            Self::VetkdCurveBls12381 => "VETKD_CURVE_BLS12381",
+            Self::VetkdCurveBls12381G2 => "VETKD_CURVE_BLS12_381_G2",
         }
     }
     /// Creates an enum from field names used in the ProtoBuf definition.
     pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
         match value {
             "VETKD_CURVE_UNSPECIFIED" => Some(Self::VetkdCurveUnspecified),
-            "VETKD_CURVE_BLS12381" => Some(Self::VetkdCurveBls12381),
+            "VETKD_CURVE_BLS12_381_G2" => Some(Self::VetkdCurveBls12381G2),
             _ => None,
         }
     }

--- a/rs/protobuf/src/gen/types/registry.crypto.v1.rs
+++ b/rs/protobuf/src/gen/types/registry.crypto.v1.rs
@@ -213,8 +213,8 @@ impl SchnorrAlgorithm {
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]
 pub enum VetKdCurve {
-    VetkdCurveUnspecified = 0,
-    VetkdCurveBls12381G2 = 1,
+    Unspecified = 0,
+    Bls12381G2 = 1,
 }
 impl VetKdCurve {
     /// String value of the enum field names used in the ProtoBuf definition.
@@ -223,15 +223,15 @@ impl VetKdCurve {
     /// (if the ProtoBuf definition does not change) and safe for programmatic use.
     pub fn as_str_name(&self) -> &'static str {
         match self {
-            Self::VetkdCurveUnspecified => "VETKD_CURVE_UNSPECIFIED",
-            Self::VetkdCurveBls12381G2 => "VETKD_CURVE_BLS12_381_G2",
+            Self::Unspecified => "VET_KD_CURVE_UNSPECIFIED",
+            Self::Bls12381G2 => "VET_KD_CURVE_BLS12_381_G2",
         }
     }
     /// Creates an enum from field names used in the ProtoBuf definition.
     pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
         match value {
-            "VETKD_CURVE_UNSPECIFIED" => Some(Self::VetkdCurveUnspecified),
-            "VETKD_CURVE_BLS12_381_G2" => Some(Self::VetkdCurveBls12381G2),
+            "VET_KD_CURVE_UNSPECIFIED" => Some(Self::Unspecified),
+            "VET_KD_CURVE_BLS12_381_G2" => Some(Self::Bls12381G2),
             _ => None,
         }
     }

--- a/rs/registry/canister/canister/registry.did
+++ b/rs/registry/canister/canister/registry.did
@@ -132,13 +132,13 @@ type KeyConfig = record {
   max_queue_size : opt nat32;
 };
 
-type MasterPublicKeyId = variant { Schnorr : SchnorrKeyId; Ecdsa : EcdsaKeyId; Vetkd : VetKdKeyId };
+type MasterPublicKeyId = variant { Schnorr : SchnorrKeyId; Ecdsa : EcdsaKeyId; VetKd : VetKdKeyId };
 
 type SchnorrKeyId = record { algorithm : SchnorrAlgorithm; name : text };
 
 type SchnorrAlgorithm = variant { ed25519; bip340secp256k1 };
 
-type VetKdKeyId = record { curve: VetKdCurve; name: String };
+type VetKdKeyId = record { curve: VetKdCurve; name: text };
 
 type VetKdCurve = variant { bls12_381 };
 

--- a/rs/registry/canister/canister/registry.did
+++ b/rs/registry/canister/canister/registry.did
@@ -132,11 +132,15 @@ type KeyConfig = record {
   max_queue_size : opt nat32;
 };
 
-type MasterPublicKeyId = variant { Schnorr : SchnorrKeyId; Ecdsa : EcdsaKeyId };
+type MasterPublicKeyId = variant { Schnorr : SchnorrKeyId; Ecdsa : EcdsaKeyId; Vetkd : VetKdKeyId };
 
 type SchnorrKeyId = record { algorithm : SchnorrAlgorithm; name : text };
 
 type SchnorrAlgorithm = variant { ed25519; bip340secp256k1 };
+
+type VetKdKeyId = record { curve: VetKdCurve; name: String };
+
+type VetKdCurve = variant { bls12_381 };
 
 type EcdsaConfig = record {
   quadruples_to_create_in_advance : nat32;

--- a/rs/registry/canister/canister/registry.did
+++ b/rs/registry/canister/canister/registry.did
@@ -140,7 +140,7 @@ type SchnorrAlgorithm = variant { ed25519; bip340secp256k1 };
 
 type VetKdKeyId = record { curve: VetKdCurve; name: text };
 
-type VetKdCurve = variant { bls12_381 };
+type VetKdCurve = variant { bls12_381_g2 };
 
 type EcdsaConfig = record {
   quadruples_to_create_in_advance : nat32;

--- a/rs/registry/canister/tests/common/test_helpers.rs
+++ b/rs/registry/canister/tests/common/test_helpers.rs
@@ -346,6 +346,9 @@ pub async fn wait_for_chain_key_setup(
         MasterPublicKeyId::Schnorr(key_id) => {
             wait_for_schnorr_setup(runtime, calling_canister, key_id).await;
         }
+        MasterPublicKeyId::VetKd(_key_id) => {
+            todo!("CRP-YYYY Extend registry canister tests")
+        }
     }
 }
 

--- a/rs/registry/canister/tests/common/test_helpers.rs
+++ b/rs/registry/canister/tests/common/test_helpers.rs
@@ -347,7 +347,7 @@ pub async fn wait_for_chain_key_setup(
             wait_for_schnorr_setup(runtime, calling_canister, key_id).await;
         }
         MasterPublicKeyId::VetKd(_key_id) => {
-            todo!("CRP-YYYY Extend registry canister tests")
+            todo!("CRP-2632 Extend registry canister tests")
         }
     }
 }

--- a/rs/state_machine_tests/src/lib.rs
+++ b/rs/state_machine_tests/src/lib.rs
@@ -1763,6 +1763,9 @@ impl StateMachine {
                         (public_key, private_key)
                     }
                 },
+                MasterPublicKeyId::VetKd(_vetkd_key_id) => {
+                    todo!("CRP-2629: Support vetKD in state machine tests")
+                }
             };
 
             idkg_subnet_secret_keys.insert(key_id.clone(), private_key);

--- a/rs/test_utilities/execution_environment/src/lib.rs
+++ b/rs/test_utilities/execution_environment/src/lib.rs
@@ -2155,7 +2155,7 @@ impl ExecutionTestBuilder {
                         algorithm_id: AlgorithmId::ThresBls12_381,
                         public_key: b"efefefef".to_vec(),
                     },
-                )
+                ),
             })
             .collect();
 

--- a/rs/test_utilities/execution_environment/src/lib.rs
+++ b/rs/test_utilities/execution_environment/src/lib.rs
@@ -2149,6 +2149,13 @@ impl ExecutionTestBuilder {
                         public_key: b"cdcdcdcd".to_vec(),
                     },
                 ),
+                MasterPublicKeyId::VetKd(_) => (
+                    key_id,
+                    MasterPublicKey {
+                        algorithm_id: AlgorithmId::ThresBls12_381,
+                        public_key: b"efefefef".to_vec(),
+                    },
+                )
             })
             .collect();
 

--- a/rs/tests/consensus/tecdsa/tecdsa_signature_fails_without_cycles_test.rs
+++ b/rs/tests/consensus/tecdsa/tecdsa_signature_fails_without_cycles_test.rs
@@ -67,6 +67,7 @@ fn test(env: TestEnv) {
             let method_name = match key_id {
                 MasterPublicKeyId::Ecdsa(_) => "sign_with_ecdsa",
                 MasterPublicKeyId::Schnorr(_) => "sign_with_schnorr",
+                MasterPublicKeyId::VetKd(_) => panic!("not applicable to vetKD"),
             };
             assert_eq!(
                 error,

--- a/rs/tests/consensus/tecdsa/tecdsa_signature_life_cycle_test.rs
+++ b/rs/tests/consensus/tecdsa/tecdsa_signature_life_cycle_test.rs
@@ -215,6 +215,7 @@ fn test(env: TestEnv) {
                 let method_name = match key_id {
                     MasterPublicKeyId::Ecdsa(_) => "sign_with_ecdsa",
                     MasterPublicKeyId::Schnorr(_) => "sign_with_schnorr",
+                    MasterPublicKeyId::VetKd(_) => panic!("not applicable to vetKD"),
                 };
                 if let Err(sig_err) = sig_result {
                     assert_eq!(

--- a/rs/tests/consensus/tecdsa/utils/src/lib.rs
+++ b/rs/tests/consensus/tecdsa/utils/src/lib.rs
@@ -301,6 +301,7 @@ pub async fn get_public_key_with_retries(
         MasterPublicKeyId::Schnorr(key_id) => {
             get_schnorr_public_key_with_retries(key_id, msg_can, logger, retries).await
         }
+        MasterPublicKeyId::VetKd(_) => panic!("not applicable to vetKD"),
     }
 }
 
@@ -507,6 +508,7 @@ pub async fn get_signature_with_logger(
         MasterPublicKeyId::Schnorr(key_id) => {
             get_schnorr_signature_with_logger(message, cycles, key_id, msg_can, logger).await
         }
+        MasterPublicKeyId::VetKd(_) => panic!("not applicable to vetKD"),
     }
 }
 
@@ -809,6 +811,7 @@ pub fn verify_signature(key_id: &MasterPublicKeyId, msg: &[u8], pk: &[u8], sig: 
             SchnorrAlgorithm::Bip340Secp256k1 => verify_bip340_signature(pk, sig, msg),
             SchnorrAlgorithm::Ed25519 => verify_ed25519_signature(pk, sig, msg),
         },
+        MasterPublicKeyId::VetKd(_) => panic!("not applicable to vetKD"),
     };
     assert!(res);
 }
@@ -837,6 +840,7 @@ impl ChainSignatureRequest {
             MasterPublicKeyId::Schnorr(schnorr_key_id) => {
                 Self::schnorr_params(schnorr_key_id, schnorr_message_size)
             }
+            MasterPublicKeyId::VetKd(_) => panic!("not applicable to vetKD"),
         };
         let payload = Encode!(&params).unwrap();
 
@@ -901,6 +905,7 @@ impl Request<SignWithChainKeyReply> for ChainSignatureRequest {
             MasterPublicKeyId::Schnorr(_) => {
                 SignWithChainKeyReply::Schnorr(SignWithSchnorrReply::decode(raw_response)?)
             }
+            MasterPublicKeyId::VetKd(_) => panic!("not applicable to vetKD"),
         })
     }
 }

--- a/rs/types/management_canister_types/src/lib.rs
+++ b/rs/types/management_canister_types/src/lib.rs
@@ -2224,7 +2224,7 @@ impl TryFrom<pb_registry_crypto::SchnorrKeyId> for SchnorrKeyId {
             pb_registry_crypto::SchnorrAlgorithm::try_from(algorithm).map_err(|_| {
                 ProxyDecodeError::ValueOutOfRange {
                     typ: "SchnorrKeyId",
-                    err: format!("Unable to convert {} to a SchnorrKeyId", algorithm),
+                    err: format!("Unable to convert {} to a SchnorrAlgorithm", algorithm),
                 }
             })?,
         )?;
@@ -2347,7 +2347,7 @@ impl TryFrom<pb_registry_crypto::VetKdKeyId> for VetKdKeyId {
                 pb_registry_crypto::VetKdCurve::try_from(item.curve).map_err(|_| {
                     ProxyDecodeError::ValueOutOfRange {
                         typ: "VetKdKeyId",
-                        err: format!("Unable to convert {} to a VetKdKeyId", item.curve),
+                        err: format!("Unable to convert {} to a VetKdCurve", item.curve),
                     }
                 })?,
             )?,

--- a/rs/types/management_canister_types/src/lib.rs
+++ b/rs/types/management_canister_types/src/lib.rs
@@ -2253,7 +2253,7 @@ impl FromStr for SchnorrKeyId {
 
 /// Types of curves that can be used for threshold key derivation (vetKD).
 /// ```text
-/// (variant { bls12_381; })
+/// (variant { bls12_381_g2; })
 /// ```
 #[derive(
     Copy,
@@ -2270,14 +2270,15 @@ impl FromStr for SchnorrKeyId {
     Serialize,
 )]
 pub enum VetKdCurve {
-    #[serde(rename = "bls12_381")]
-    Bls12_381,
+    #[serde(rename = "bls12_381_g2")]
+    #[allow(non_camel_case_types)]
+    Bls12_381_G2,
 }
 
 impl From<&VetKdCurve> for pb_registry_crypto::VetKdCurve {
     fn from(item: &VetKdCurve) -> Self {
         match item {
-            VetKdCurve::Bls12_381 => pb_registry_crypto::VetKdCurve::VetkdCurveBls12381,
+            VetKdCurve::Bls12_381_G2 => pb_registry_crypto::VetKdCurve::VetkdCurveBls12381G2,
         }
     }
 }
@@ -2287,7 +2288,7 @@ impl TryFrom<pb_registry_crypto::VetKdCurve> for VetKdCurve {
 
     fn try_from(item: pb_registry_crypto::VetKdCurve) -> Result<Self, Self::Error> {
         match item {
-            pb_registry_crypto::VetKdCurve::VetkdCurveBls12381 => Ok(VetKdCurve::Bls12_381),
+            pb_registry_crypto::VetKdCurve::VetkdCurveBls12381G2 => Ok(VetKdCurve::Bls12_381_G2),
             pb_registry_crypto::VetKdCurve::VetkdCurveUnspecified => {
                 Err(ProxyDecodeError::ValueOutOfRange {
                     typ: "VetKdCurve",
@@ -2309,7 +2310,7 @@ impl FromStr for VetKdCurve {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s.to_lowercase().as_str() {
-            "bls12_381" => Ok(Self::Bls12_381),
+            "bls12_381_g2" => Ok(Self::Bls12_381_G2),
             _ => Err(format!("{} is not a recognized vetKD curve", s)),
         }
     }

--- a/rs/types/management_canister_types/src/lib.rs
+++ b/rs/types/management_canister_types/src/lib.rs
@@ -2321,7 +2321,7 @@ impl FromStr for VetKdCurve {
 /// some information about the key (e.g. that the key is meant to be used for
 /// testing purposes).
 /// ```text
-/// (record { curve: ecdsa_curve; name: text})
+/// (record { curve: vetkd_curve; name: text})
 /// ```
 #[derive(
     Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, CandidType, Deserialize, Serialize,

--- a/rs/types/management_canister_types/src/lib.rs
+++ b/rs/types/management_canister_types/src/lib.rs
@@ -2278,7 +2278,7 @@ pub enum VetKdCurve {
 impl From<&VetKdCurve> for pb_registry_crypto::VetKdCurve {
     fn from(item: &VetKdCurve) -> Self {
         match item {
-            VetKdCurve::Bls12_381_G2 => pb_registry_crypto::VetKdCurve::VetkdCurveBls12381G2,
+            VetKdCurve::Bls12_381_G2 => pb_registry_crypto::VetKdCurve::Bls12381G2,
         }
     }
 }
@@ -2288,13 +2288,11 @@ impl TryFrom<pb_registry_crypto::VetKdCurve> for VetKdCurve {
 
     fn try_from(item: pb_registry_crypto::VetKdCurve) -> Result<Self, Self::Error> {
         match item {
-            pb_registry_crypto::VetKdCurve::VetkdCurveBls12381G2 => Ok(VetKdCurve::Bls12_381_G2),
-            pb_registry_crypto::VetKdCurve::VetkdCurveUnspecified => {
-                Err(ProxyDecodeError::ValueOutOfRange {
-                    typ: "VetKdCurve",
-                    err: format!("Unable to convert {:?} to a VetKdCurve", item),
-                })
-            }
+            pb_registry_crypto::VetKdCurve::Bls12381G2 => Ok(VetKdCurve::Bls12_381_G2),
+            pb_registry_crypto::VetKdCurve::Unspecified => Err(ProxyDecodeError::ValueOutOfRange {
+                typ: "VetKdCurve",
+                err: format!("Unable to convert {:?} to a VetKdCurve", item),
+            }),
         }
     }
 }

--- a/rs/types/management_canister_types/src/lib.rs
+++ b/rs/types/management_canister_types/src/lib.rs
@@ -3480,6 +3480,26 @@ mod tests {
     }
 
     #[test]
+    fn vetkd_curve_round_trip() {
+        for curve in VetKdCurve::iter() {
+            assert_eq!(format!("{}", curve).parse::<VetKdCurve>().unwrap(), curve);
+        }
+    }
+
+    #[test]
+    fn vetkd_key_id_round_trip() {
+        for curve in VetKdCurve::iter() {
+            for name in ["bls12_381_g2", "", "other_key", "other key", "other:key"] {
+                let key = VetKdKeyId {
+                    curve,
+                    name: name.to_string(),
+                };
+                assert_eq!(format!("{}", key).parse::<VetKdKeyId>().unwrap(), key);
+            }
+        }
+    }
+
+    #[test]
     fn master_public_key_id_round_trip() {
         for algorithm in SchnorrAlgorithm::iter() {
             for name in ["Ed25519", "", "other_key", "other key", "other:key"] {
@@ -3497,6 +3517,19 @@ mod tests {
         for curve in EcdsaCurve::iter() {
             for name in ["secp256k1", "", "other_key", "other key", "other:key"] {
                 let key = MasterPublicKeyId::Ecdsa(EcdsaKeyId {
+                    curve,
+                    name: name.to_string(),
+                });
+                assert_eq!(
+                    format!("{}", key).parse::<MasterPublicKeyId>().unwrap(),
+                    key
+                );
+            }
+        }
+
+        for curve in VetKdCurve::iter() {
+            for name in ["bls12_381_g2", "", "other_key", "other key", "other:key"] {
+                let key = MasterPublicKeyId::VetKd(VetKdKeyId {
                     curve,
                     name: name.to_string(),
                 });


### PR DESCRIPTION
Adds a variant for vetKD in the `MasterPublicKeyId` in the
1. registry protobuf definitions,
   
   where it is used in the `KeyConfig` (which is used in the `ChainKeyConfig`, which is used in the `SubnetRecord`).
2. management canister types,

   where it is used in the `ComputeInitialIDkgDealingsArgs` (which will be generalized in a later step, e.g., to `ReshareChainKeyArgs`).
3. registry canister API (registry.did),

   where it is used in the `KeyConfig` (which is used in the `KeyConfigRequest`, which is used in the `InitialChainKeyConfig`, which is used in `CreateSubnetPayload` and `RecoverSubnetPayload`), and in the `UpdateSubnetPayload`'s `chain_key_signing_enable`/`chain_key_signing_disable`.

This is the very first step for the vetKeys feature.

As discussed with the Consensus team, various consensus tests related to pre-signatures are adapted so that the tests panic if the vetKD variant is used, because vetKD doesn't have pre-signatures.

### Registry API backwards-compatibility

The changes in the registry canister API should be safe/backwards-compatible based on the following argumentation (see [Can I add a variant alternative?](https://mmapped.blog/posts/20-candid-for-engineers#faq-remove-alternative)):

The `MasterPublicKeyId` variant in `registry.did` is extended with a new alternative as follows:
```
- type MasterPublicKeyId = variant { Schnorr : SchnorrKeyId; Ecdsa : EcdsaKeyId };
+ type MasterPublicKeyId = variant { Schnorr : SchnorrKeyId; Ecdsa : EcdsaKeyId; VetKd : VetKdKeyId };
```
This variant is used in two places:
1. ```
   type KeyConfig = record {
      key_id : opt MasterPublicKeyId;
      [...]
   };
   ```
   Here, adding the alternative is safe, given that the variant field `key_id` is optional.
2. ```
   type UpdateSubnetPayload = record {
      [...]
      chain_key_signing_enable : opt vec MasterPublicKeyId;
      chain_key_signing_disable : opt vec MasterPublicKeyId;
      [...]
   }
   ```
   Although `chain_key_signing_enable` and `chain_key_signing_disable` are not (directly) optional variant fields (because they are contained in a `vec`), adding the alternative is safe, given that the `MasterPublicKeyId` variant is only ever used (as part of `UpdateSubnetPayload`) in method arguments but never as method result.

This argumentation is also supported by the fact that the `//rs/registry/canister:registry-canister_did_git_test` test passes.

### Registry protobuf backwards-compatibility

The changes in the registry protocol buffer definitions is backwards-compatible. On the one hand, adding a new field to a `oneof` is generally backward-compatible in Protocol Buffers (with some [nuances](https://protobuf.dev/programming-guides/proto3/#backward) that are not relevant here). On the other hand, the new field/variant in the `MasterPublicKeyId` is not yet written by any code, and this new variant won't be written for many weeks to come. In particular, it will only be written to the registry once subnets will actually hold master public keys for vetKD, which will only happen in 2025.

### Crypto Algorithm ID

For the time being, we don't need a particular `AlgorithmId` for vetKD, so we use the `AlgorithmId::Placeholder`. In any case, the exact algorithm also doesn't matter for now because neither the intended Crypto APIs will use an algorithm ID nor will this algorithm be persisted anywhere (e.g., in the registry or in a key store).