### PR TITLE
feat(cketh): use EVM RPC canister v2.2.0

### DIFF
--- a/Cargo.Bazel.Fuzzing.json.lock
+++ b/Cargo.Bazel.Fuzzing.json.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "57de8d576f7cdd3ae771b5a508038e567c284557846f4bd8523cea6c36756b6a",
+  "checksum": "dee1c8591387e179356044d1973b6e3fc16e62ce42c6ac47fefd1f61ca9ad54d",
   "crates": {
     "abnf 0.12.0": {
       "name": "abnf",
@@ -17927,7 +17927,7 @@
               "target": "ethnum"
             },
             {
-              "id": "evm_rpc_types 1.1.0",
+              "id": "evm_rpc_types 1.2.0",
               "target": "evm_rpc_types"
             },
             {
@@ -21806,14 +21806,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "evm_rpc_types 1.1.0": {
+    "evm_rpc_types 1.2.0": {
       "name": "evm_rpc_types",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "package_url": "https://github.com/internet-computer-protocol/evm-rpc-canister",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/evm_rpc_types/1.1.0/download",
-          "sha256": "e7ff4b02fde6e377b397b54fd011dccb41b16ebc606fc8e34a7885510fa408d6"
+          "url": "https://static.crates.io/crates/evm_rpc_types/1.2.0/download",
+          "sha256": "29ed9ee7b89726f4a343208e9a89e9ad22fe7b4518b0d722973cc83274e7bf7f"
         }
       },
       "targets": [
@@ -21873,7 +21873,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "1.1.0"
+        "version": "1.2.0"
       },
       "license": "Apache-2.0",
       "license_ids": [
@@ -78760,7 +78760,7 @@
     "escargot 0.5.8",
     "ethers-core 2.0.10",
     "ethnum 1.4.0",
-    "evm_rpc_types 1.1.0",
+    "evm_rpc_types 1.2.0",
     "exec 0.3.1",
     "eyre 0.6.8",
     "ff 0.12.1",

--- a/Cargo.Bazel.Fuzzing.json.lock
+++ b/Cargo.Bazel.Fuzzing.json.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "23b8c4c80ca99d2cb874403f59f756788b97b830a3dd2f48826f239b0028a3c3",
+  "checksum": "4fe82831a028ca3a4394f2810b1a2bc468d70e5b7b3e77c5ea07cfd075a5e079",
   "crates": {
     "abnf 0.12.0": {
       "name": "abnf",
@@ -17927,7 +17927,7 @@
               "target": "ethnum"
             },
             {
-              "id": "evm_rpc_types 1.1.0",
+              "id": "evm_rpc_types 1.2.0",
               "target": "evm_rpc_types"
             },
             {
@@ -21806,14 +21806,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "evm_rpc_types 1.1.0": {
+    "evm_rpc_types 1.2.0": {
       "name": "evm_rpc_types",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "package_url": "https://github.com/internet-computer-protocol/evm-rpc-canister",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/evm_rpc_types/1.1.0/download",
-          "sha256": "e7ff4b02fde6e377b397b54fd011dccb41b16ebc606fc8e34a7885510fa408d6"
+          "url": "https://static.crates.io/crates/evm_rpc_types/1.2.0/download",
+          "sha256": "29ed9ee7b89726f4a343208e9a89e9ad22fe7b4518b0d722973cc83274e7bf7f"
         }
       },
       "targets": [
@@ -21873,7 +21873,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "1.1.0"
+        "version": "1.2.0"
       },
       "license": "Apache-2.0",
       "license_ids": [
@@ -78772,7 +78772,7 @@
     "escargot 0.5.8",
     "ethers-core 2.0.10",
     "ethnum 1.4.0",
-    "evm_rpc_types 1.1.0",
+    "evm_rpc_types 1.2.0",
     "exec 0.3.1",
     "eyre 0.6.8",
     "ff 0.12.1",

--- a/Cargo.Bazel.Fuzzing.toml.lock
+++ b/Cargo.Bazel.Fuzzing.toml.lock
@@ -3831,9 +3831,9 @@ dependencies = [
 
 [[package]]
 name = "evm_rpc_types"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7ff4b02fde6e377b397b54fd011dccb41b16ebc606fc8e34a7885510fa408d6"
+checksum = "29ed9ee7b89726f4a343208e9a89e9ad22fe7b4518b0d722973cc83274e7bf7f"
 dependencies = [
  "candid",
  "hex",

--- a/Cargo.Bazel.json.lock
+++ b/Cargo.Bazel.json.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "976a58bb35194d733b45f9f9c879351718b30cfad161a2ddbfa4f733adf31e9a",
+  "checksum": "1861efa48e121e05f9daa65d6cd8f5f731aa0244d71351971411b6fdce43fb9a",
   "crates": {
     "abnf 0.12.0": {
       "name": "abnf",
@@ -17750,7 +17750,7 @@
               "target": "ethnum"
             },
             {
-              "id": "evm_rpc_types 1.1.0",
+              "id": "evm_rpc_types 1.2.0",
               "target": "evm_rpc_types"
             },
             {
@@ -21649,14 +21649,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "evm_rpc_types 1.1.0": {
+    "evm_rpc_types 1.2.0": {
       "name": "evm_rpc_types",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "package_url": "https://github.com/internet-computer-protocol/evm-rpc-canister",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/evm_rpc_types/1.1.0/download",
-          "sha256": "e7ff4b02fde6e377b397b54fd011dccb41b16ebc606fc8e34a7885510fa408d6"
+          "url": "https://static.crates.io/crates/evm_rpc_types/1.2.0/download",
+          "sha256": "29ed9ee7b89726f4a343208e9a89e9ad22fe7b4518b0d722973cc83274e7bf7f"
         }
       },
       "targets": [
@@ -21716,7 +21716,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "1.1.0"
+        "version": "1.2.0"
       },
       "license": "Apache-2.0",
       "license_ids": [
@@ -78958,7 +78958,7 @@
     "escargot 0.5.7",
     "ethers-core 2.0.8",
     "ethnum 1.3.2",
-    "evm_rpc_types 1.1.0",
+    "evm_rpc_types 1.2.0",
     "exec 0.3.1",
     "eyre 0.6.8",
     "ff 0.12.1",

--- a/Cargo.Bazel.json.lock
+++ b/Cargo.Bazel.json.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "c9bc3e509f30589e67fba9a2ead972a72a8bfa503afedd11da725d8a1e931269",
+  "checksum": "64cc94ae39a731c31d16f4f97eeda650924ad931a63b2d2b8eef564db363d926",
   "crates": {
     "abnf 0.12.0": {
       "name": "abnf",
@@ -17750,7 +17750,7 @@
               "target": "ethnum"
             },
             {
-              "id": "evm_rpc_types 1.1.0",
+              "id": "evm_rpc_types 1.2.0",
               "target": "evm_rpc_types"
             },
             {
@@ -21649,14 +21649,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "evm_rpc_types 1.1.0": {
+    "evm_rpc_types 1.2.0": {
       "name": "evm_rpc_types",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "package_url": "https://github.com/internet-computer-protocol/evm-rpc-canister",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/evm_rpc_types/1.1.0/download",
-          "sha256": "e7ff4b02fde6e377b397b54fd011dccb41b16ebc606fc8e34a7885510fa408d6"
+          "url": "https://static.crates.io/crates/evm_rpc_types/1.2.0/download",
+          "sha256": "29ed9ee7b89726f4a343208e9a89e9ad22fe7b4518b0d722973cc83274e7bf7f"
         }
       },
       "targets": [
@@ -21716,7 +21716,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "1.1.0"
+        "version": "1.2.0"
       },
       "license": "Apache-2.0",
       "license_ids": [
@@ -78970,7 +78970,7 @@
     "escargot 0.5.7",
     "ethers-core 2.0.8",
     "ethnum 1.3.2",
-    "evm_rpc_types 1.1.0",
+    "evm_rpc_types 1.2.0",
     "exec 0.3.1",
     "eyre 0.6.8",
     "ff 0.12.1",

--- a/Cargo.Bazel.toml.lock
+++ b/Cargo.Bazel.toml.lock
@@ -3820,9 +3820,9 @@ dependencies = [
 
 [[package]]
 name = "evm_rpc_types"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7ff4b02fde6e377b397b54fd011dccb41b16ebc606fc8e34a7885510fa408d6"
+checksum = "29ed9ee7b89726f4a343208e9a89e9ad22fe7b4518b0d722973cc83274e7bf7f"
 dependencies = [
  "candid",
  "hex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3905,9 +3905,9 @@ dependencies = [
 
 [[package]]
 name = "evm_rpc_types"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7ff4b02fde6e377b397b54fd011dccb41b16ebc606fc8e34a7885510fa408d6"
+checksum = "29ed9ee7b89726f4a343208e9a89e9ad22fe7b4518b0d722973cc83274e7bf7f"
 dependencies = [
  "candid",
  "hex",

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -483,8 +483,8 @@ http_file(
 
 http_file(
     name = "evm_rpc.wasm.gz",
-    sha256 = "5f4a871b2369768fb7e69b08d367ac0288b95dcdfda9bd2c37283aa84e6b58b4",
-    url = "https://github.com/internet-computer-protocol/evm-rpc-canister/releases/download/v2.1.0/evm_rpc.wasm.gz",
+    sha256 = "636442e4349a007316dcc1452d9a256d22203186181d2534f33bd264162305b3",
+    url = "https://github.com/internet-computer-protocol/evm-rpc-canister/releases/download/v2.2.0/evm_rpc.wasm.gz",
 )
 
 http_archive(

--- a/bazel/external_crates.bzl
+++ b/bazel/external_crates.bzl
@@ -424,7 +424,7 @@ def external_crates_repository(name, cargo_lockfile, lockfile, sanitizers_enable
                 features = ["serde"],
             ),
             "evm_rpc_types": crate.spec(
-                version = "^1.1.0",
+                version = "^1.2.0",
             ),
             "exec": crate.spec(
                 version = "^0.3.1",

--- a/rs/ethereum/cketh/test_utils/Cargo.toml
+++ b/rs/ethereum/cketh/test_utils/Cargo.toml
@@ -10,7 +10,7 @@ documentation.workspace = true
 assert_matches = { workspace = true }
 candid = { workspace = true }
 ethers-core = "2.0.8"
-evm_rpc_types = "1.0.0"
+evm_rpc_types = "1.2.0"
 hex = { workspace = true }
 ic-base-types = { path = "../../../types/base_types" }
 ic-canisters-http-types = { path = "../../../rust_canisters/http_types" }

--- a/rs/ethereum/cketh/test_utils/src/evm_rpc_provider.rs
+++ b/rs/ethereum/cketh/test_utils/src/evm_rpc_provider.rs
@@ -13,7 +13,7 @@ impl JsonRpcProvider {
             JsonRpcProvider::Provider1 => "https://ethereum.blockpi.network/v1/rpc/public",
             JsonRpcProvider::Provider2 => "https://ethereum-rpc.publicnode.com",
             JsonRpcProvider::Provider3 => "https://cloudflare-eth.com/v1/mainnet",
-            JsonRpcProvider::Provider4 => "https://eth-mainnet.g.alchemy.com/v2/demo",
+            JsonRpcProvider::Provider4 => "https://eth.llamarpc.com",
         }
     }
 }

--- a/rs/ethereum/evm-rpc-client/Cargo.toml
+++ b/rs/ethereum/evm-rpc-client/Cargo.toml
@@ -9,7 +9,7 @@ documentation.workspace = true
 [dependencies]
 async-trait = { workspace = true }
 candid = { workspace = true }
-evm_rpc_types = "1.1.0"
+evm_rpc_types = "1.2.0"
 ic-canister-log = "0.2.0"
 ic-cdk = { workspace = true }
 serde = { workspace = true }


### PR DESCRIPTION
Update the EVM RPC client to use [v2.2.0](https://github.com/internet-computer-protocol/evm-rpc-canister/releases/tag/v2.2.0).