### PR TITLE
Script that proposes to make neuron 28 ("Internet Computer Association") public.

### DIFF
--- a/rs/nns/propose_to_make_neuron_28_public
+++ b/rs/nns/propose_to_make_neuron_28_public
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+GOVERNANCE=rrkah-fqaaa-aaaaa-aaaaq-cai
+
+dfx --identity hsm \
+    canister \
+    --network ic \
+    call \
+    --candid rs/nns/governance/canister/governance.did \
+    $GOVERNANCE \
+    manage_neuron \
+    '(record {
+        neuron_id_or_subaccount = opt variant { NeuronId = record { id = 51 }} ;
+        command = opt variant { MakeProposal = record {
+            title = opt "Make Neuron 28 (\"Internet Computer Association\") Public";
+            url = "https://forum.dfinity.org/t/strengthening-governance-by-aligning-neuron-28s-voting-power-under-neuron-27/35957" ;
+            summary = "# Make Neuron 28 (\"Internet Computer Association\") Public" ;
+            action = opt variant { ManageNeuron = record {
+                neuron_id_or_subaccount = opt variant { NeuronId = record { id = 28 } } ;
+                command = opt variant { Configure = record {
+                    operation = opt variant { SetVisibility = record {
+                        visibility = opt 2 ; // Public
+                    } };
+                } } ;
+                id = null ;
+            } };
+        } } ;
+        id = null ;
+    })'


### PR DESCRIPTION
Since this is only going to be run once, I do not intend to merge this. To prevent merging, the title is intentionally not Conventional Commits compliant.

Only the followees of neuron 28 will be allowed to vote on this proposal. Therefore, this should be pretty low key.

Bjoern T. will probably run this. (I think only one of the followees of neuron 28 will be able to even submit this.)

# Related Work

[Make Neuron 27 a Known Neuron][1]

[1]: https://github.com/dfinity/ic/pull/2109