### PR TITLE
chore(IDX): exclude problematic target

### DIFF
--- a/ci/scripts/bazel-coverage.sh
+++ b/ci/scripts/bazel-coverage.sh
@@ -5,6 +5,8 @@ bazel query --universe_scope=//... \
     "kind(test, //rs/...) except kind(test, allrdeps(attr('tags', 'canister', //rs/...)))" \
     >cov_targets.txt
 
+# exclude the target blelow because of flaky builds - https://github.com/dfinity/ic/pull/2103
+sed -i '/minter:principal_to_bytes_test/d' cov_targets.txt
 # shellcheck disable=SC2046,SC2086
 bazel --output_base=/var/tmp/bazel-output/ coverage --config=ci --combined_report=lcov \
     --test_timeout=3000 --combined_report=lcov $(<cov_targets.txt) || true


### PR DESCRIPTION
Excluding problematic target (see https://github.com/dfinity/ic/pull/2103) to not degrade success rate of hourly workflow.