### PR TITLE
fix(IDX): specify asset canister path via env

### DIFF
--- a/rs/tests/boundary_nodes/BUILD.bazel
+++ b/rs/tests/boundary_nodes/BUILD.bazel
@@ -17,6 +17,7 @@ system_test_nns(
     env = {
         "KV_STORE_WASM_PATH": "$(rootpath //rs/tests/test_canisters/kv_store)",
         "HTTP_COUNTER_WASM_PATH": "$(rootpath //rs/tests/test_canisters/http_counter)",
+        "ASSET_CANISTER_WASM_PATH": "$(rootpath @asset_canister//file)",
     },
     flaky = True,
     proc_macro_deps = MACRO_DEPENDENCIES,
@@ -40,6 +41,7 @@ system_test_nns(
     env = {
         "KV_STORE_WASM_PATH": "$(rootpath //rs/tests/test_canisters/kv_store)",
         "HTTP_COUNTER_WASM_PATH": "$(rootpath //rs/tests/test_canisters/http_counter)",
+        "ASSET_CANISTER_WASM_PATH": "$(rootpath @asset_canister//file)",
     },
     flaky = True,
     proc_macro_deps = MACRO_DEPENDENCIES,

--- a/rs/tests/driver/src/driver/asset_canister.rs
+++ b/rs/tests/driver/src/driver/asset_canister.rs
@@ -11,9 +11,8 @@ use candid::{CandidType, Decode, Deserialize, Encode, Nat, Principal};
 use ic_agent::Agent;
 use slog::{info, Logger};
 use std::collections::BTreeMap;
+use std::env;
 use tokio::task;
-
-const ASSET_CANISTER_WASM: &str = "external/asset_canister/file/assetstorage.wasm.gz";
 
 #[async_trait]
 pub trait DeployAssetCanister {
@@ -32,7 +31,13 @@ where
 
         let canister_id = task::spawn_blocking({
             let app_node = app_node.clone();
-            move || app_node.create_and_install_canister_with_arg(ASSET_CANISTER_WASM, None)
+            move || {
+                app_node.create_and_install_canister_with_arg(
+                    &env::var("ASSET_CANISTER_WASM_PATH")
+                        .expect("ASSET_CANISTER_WASM_PATH not set"),
+                    None,
+                )
+            }
         })
         .await
         .context("failed to deploy asset canister")?;


### PR DESCRIPTION
This updates some boundary node tests to use an asset canister provided through environment variable. This avoids the tests relying on bazel implementation details (`external/`).