### PR TITLE
feat(cketh): add EVM RPC canister ID to the minter info endpoint

### DIFF
--- a/rs/ethereum/cketh/minter/cketh_minter.did
+++ b/rs/ethereum/cketh/minter/cketh_minter.did
@@ -195,6 +195,10 @@ type MinterInfo = record {
 
     // Canister ID of the ckETH ledger.
     cketh_ledger_id: opt principal;
+
+    // Canister ID of the EVM RPC canister that handles the communication
+    // with the Ethereum blockchain.
+    evm_rpc_id : opt principal;
 };
 
 

--- a/rs/ethereum/cketh/minter/src/endpoints.rs
+++ b/rs/ethereum/cketh/minter/src/endpoints.rs
@@ -77,6 +77,7 @@ pub struct MinterInfo {
     pub last_eth_scraped_block_number: Option<Nat>,
     pub last_erc20_scraped_block_number: Option<Nat>,
     pub cketh_ledger_id: Option<Principal>,
+    pub evm_rpc_id: Option<Principal>,
 }
 
 #[derive(Clone, Eq, PartialEq, Debug, CandidType, Deserialize)]

--- a/rs/ethereum/cketh/minter/src/main.rs
+++ b/rs/ethereum/cketh/minter/src/main.rs
@@ -226,6 +226,7 @@ async fn get_minter_info() -> MinterInfo {
             last_eth_scraped_block_number: Some(s.last_scraped_block_number.into()),
             last_erc20_scraped_block_number: Some(s.last_erc20_scraped_block_number.into()),
             cketh_ledger_id: Some(s.cketh_ledger_id),
+            evm_rpc_id: s.evm_rpc_id,
         }
     })
 }

--- a/rs/ethereum/cketh/minter/tests/ckerc20.rs
+++ b/rs/ethereum/cketh/minter/tests/ckerc20.rs
@@ -1546,6 +1546,7 @@ fn should_retrieve_minter_info() {
             last_eth_scraped_block_number: Some(LAST_SCRAPED_BLOCK_NUMBER_AT_INSTALL.into()),
             last_erc20_scraped_block_number: Some(LAST_SCRAPED_BLOCK_NUMBER_AT_INSTALL.into()),
             cketh_ledger_id: Some(ckerc20.cketh_ledger_id()),
+            evm_rpc_id: ckerc20.cketh.evm_rpc_id.map(Principal::from),
         }
     );
 }

--- a/rs/ethereum/cketh/minter/tests/cketh.rs
+++ b/rs/ethereum/cketh/minter/tests/cketh.rs
@@ -1070,6 +1070,7 @@ fn should_retrieve_minter_info() {
             last_eth_scraped_block_number: Some(LAST_SCRAPED_BLOCK_NUMBER_AT_INSTALL.into()),
             last_erc20_scraped_block_number: Some(LAST_SCRAPED_BLOCK_NUMBER_AT_INSTALL.into()),
             cketh_ledger_id: Some(cketh.ledger_id.into()),
+            evm_rpc_id: cketh.evm_rpc_id.map(Principal::from),
         }
     );
 


### PR DESCRIPTION
For debugging purposes and transparency reasons, returns the canister ID of the EVM RPC canister used to interact with Ethereum as part of `MinterInfo`, in case the minter does not issue the HTTPs outcalls itself.