### PR TITLE
fix(recovery): Set up empty recovery directory in guestOS

### DIFF
--- a/ic-os/components/ic/setup-permissions/setup-permissions.sh
+++ b/ic-os/components/ic/setup-permissions/setup-permissions.sh
@@ -37,6 +37,7 @@ make_group_owned_and_sticky /var/lib/ic/data/cups ic-replica nonconfidential
 make_group_owned_and_sticky /var/lib/ic/data/orchestrator ic-replica nonconfidential
 make_group_owned_and_sticky /var/lib/ic/data/ic_registry_local_store ic-replica ic-registry-local-store
 make_group_owned_and_sticky /var/lib/ic/data/ic_state/page_deltas ic-replica nonconfidential
+make_group_owned_and_sticky /var/lib/ic/data/recovery admin nonconfidential
 
 # Fix up security labels for everything.
 echo "Restoring SELinux security contexts in /var/lib/ic"


### PR DESCRIPTION
During recoveries, we are logged in as admin and operate in a working directory (by default we pick `/var/lib/ic/data/recovery`). Right now we need to create that manually with sudo mkdir & chown before starting the recovery tool.


Having an existing directory at `/var/lib/ic/data/recovery` with `admin` permissions helps simplify recovery, because the operator doesn't need to remember to create the directory beforehand.