### PR TITLE
fix: nns_urls reference in dev-generate-guestos-config

### DIFF
--- a/ic-os/components/hostos-scripts/generate-guestos-config/dev-generate-guestos-config.sh
+++ b/ic-os/components/hostos-scripts/generate-guestos-config/dev-generate-guestos-config.sh
@@ -91,7 +91,7 @@ function assemble_config_media() {
         cmd+=(--domain "${domain}")
     fi
     cmd+=(--hostname "guest-$(/opt/ic/bin/hostos_tool fetch-mac-address | sed 's/://g')")
-    cmd+=(--nns_url "$(/opt/ic/bin/fetch-property.sh --key=.nns.url --metric=hostos_nns_url --config=${DEPLOYMENT})")
+    cmd+=(--nns_urls "$(/opt/ic/bin/fetch-property.sh --key=.nns.url --metric=hostos_nns_url --config=${DEPLOYMENT})")
     if [ -f "/boot/config/node_operator_private_key.pem" ]; then
         cmd+=(--node_operator_private_key "/boot/config/node_operator_private_key.pem")
     fi


### PR DESCRIPTION
In this commit (https://github.com/dfinity/ic/pull/1970) we updated the nns_urls references but missed dev-generate-guestos-config, causing test bare-metal-deployments to fail