### PR TITLE
feat(PocketIC): make PocketIC library run on Windows seamlessly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16662,6 +16662,7 @@ dependencies = [
  "tracing-appender",
  "tracing-subscriber",
  "wat",
+ "wslpath",
 ]
 
 [[package]]
@@ -21952,6 +21953,12 @@ name = "wsl"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dab7ac864710bdea6594becbea5b5050333cf34fefb0dc319567eb347950d4"
+
+[[package]]
+name = "wslpath"
+version = "0.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04a2ecdf2cc4d33a6a93d71bcfbc00bb1f635cdb8029a2cc0709204a045ec7a3"
 
 [[package]]
 name = "wycheproof"

--- a/packages/pocket-ic/Cargo.toml
+++ b/packages/pocket-ic/Cargo.toml
@@ -19,6 +19,9 @@ include = [
 authors.workspace = true
 edition.workspace = true
 
+[lib]
+doctest = false
+
 [dependencies]
 base64 = { workspace = true }
 candid = "^0.10.2"

--- a/packages/pocket-ic/Cargo.toml
+++ b/packages/pocket-ic/Cargo.toml
@@ -40,6 +40,9 @@ tracing = { workspace = true }
 tracing-appender = { workspace = true }
 tracing-subscriber = { workspace = true }
 
+[target.'cfg(windows)'.dependencies]
+wslpath = "0.0.2"
+
 [dev-dependencies]
 candid_parser = { workspace = true }
 ed25519-dalek = { workspace = true }

--- a/packages/pocket-ic/tests/tests.rs
+++ b/packages/pocket-ic/tests/tests.rs
@@ -12,6 +12,7 @@ use pocket_ic::{
     update_candid, DefaultEffectiveCanisterIdError, ErrorCode, PocketIc, PocketIcBuilder,
     WasmResult,
 };
+#[cfg(unix)]
 use reqwest::blocking::Client;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};

--- a/packages/pocket-ic/tests/tests.rs
+++ b/packages/pocket-ic/tests/tests.rs
@@ -1354,6 +1354,7 @@ fn subnet_metrics() {
     assert!((1 << 16) < metrics.canister_state_bytes && metrics.canister_state_bytes < (1 << 17));
 }
 
+#[cfg(unix)]
 #[test]
 fn test_raw_gateway() {
     // We create a PocketIC instance consisting of the NNS and one application subnet.

--- a/rs/pocket_ic_server/CHANGELOG.md
+++ b/rs/pocket_ic_server/CHANGELOG.md
@@ -27,6 +27,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   of whether a canister ID could be found).
 - Subnet ids can be specified in `SubnetSpec`s for all subnet kinds.
 
+### Removed
+- The CLI option `--pid`: use the CLI option `--port-file` instead.
+
 
 
 ## 6.0.0 - 2024-09-12

--- a/rs/pocket_ic_server/src/main.rs
+++ b/rs/pocket_ic_server/src/main.rs
@@ -59,10 +59,10 @@ struct Args {
     #[clap(long, short)]
     ip_addr: Option<String>,
     /// The port at which the PocketIC server should listen
-    #[clap(long, short)]
-    port: Option<u16>,
+    #[clap(long, short, default_value_t = 0)]
+    port: u16,
     /// The file to which the PocketIC server port should be written
-    #[clap(long, conflicts_with = "port")]
+    #[clap(long)]
     port_file: Option<PathBuf>,
     /// The time-to-live of the PocketIC server in seconds
     #[clap(long, default_value_t = TTL_SEC)]
@@ -119,8 +119,7 @@ async fn start(runtime: Arc<Runtime>) {
     };
 
     let ip_addr = args.ip_addr.unwrap_or("127.0.0.1".to_string());
-    let port = args.port.unwrap_or_default();
-    let addr = format!("{}:{}", ip_addr, port);
+    let addr = format!("{}:{}", ip_addr, args.port);
     let listener = std::net::TcpListener::bind(addr.clone())
         .unwrap_or_else(|_| panic!("Failed to bind PocketIC server to address {}", addr));
     let real_port = listener.local_addr().unwrap().port();

--- a/rs/pocket_ic_server/tests/test.rs
+++ b/rs/pocket_ic_server/tests/test.rs
@@ -45,11 +45,7 @@ fn start_server_helper(
         NamedTempFile::new().unwrap().into_temp_path().to_path_buf()
     };
     let mut cmd = Command::new(PathBuf::from(bin_path));
-    if let Some(test_driver_pid) = test_driver_pid {
-        cmd.arg("--pid").arg(test_driver_pid.to_string());
-    } else {
-        cmd.arg("--port-file").arg(port_file_path.clone());
-    }
+    cmd.arg("--port-file").arg(port_file_path.clone());
     // use a long TTL of 5 mins (the bazel test timeout for medium tests)
     // so that the server doesn't die during the test if the runner
     // is overloaded


### PR DESCRIPTION
This PR makes canister tests using the PocketIC library run seamlessly on Windows:
- this PR removes the CLI option `--pid` of the PocketIC server and makes the CLI option `--port-file` behave like `--pid`: only one PocketIC server process listens at a port and writes that port to the specified port file. This change was necessary because the (implicit) port file created using `--pid` in a WSL temporary directory cannot be read from a native Windows `cargo test` invokation;
- this PR disables doc tests of the PocketIC library since they fail on both Linux and Windows at the moment.

This PR has been tested manually by running `cargo test -p pocket-ic` on a Windows laptop. It is not possible to have a CI test on a Windows runner because they only support WSLv1, but WSLv2 is required (see [forum post](https://forum.dfinity.org/t/mr-batch-processor-panicked-at-mmappageapplicator-failed-to-mmap-bytes-to-memory-file/23659)).