### PR TITLE
feat(PocketIC): management canister types module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16644,7 +16644,6 @@ dependencies = [
  "flate2",
  "hex",
  "ic-agent",
- "ic-cdk 0.16.0",
  "ic-transport-types",
  "k256",
  "lazy_static",

--- a/packages/pocket-ic/BUILD.bazel
+++ b/packages/pocket-ic/BUILD.bazel
@@ -8,7 +8,6 @@ DEPENDENCIES = [
     "@crate_index//:candid",
     "@crate_index//:hex",
     "@crate_index//:ic-agent",
-    "@crate_index//:ic-cdk",
     "@crate_index//:ic-transport-types",
     "@crate_index//:reqwest",
     "@crate_index//:schemars",

--- a/packages/pocket-ic/CHANGELOG.md
+++ b/packages/pocket-ic/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - The type `Topology` becomes a struct with two fields: `subnet_configs` contains an association of subnet ids to their configurations
   and `default_effective_canister_id` contains a default effective canister id for canister creation.
+- Management canister types are defined in a new `management_canister` module to avoid a dependency on `ic-cdk`.
 
 
 

--- a/packages/pocket-ic/Cargo.toml
+++ b/packages/pocket-ic/Cargo.toml
@@ -24,7 +24,6 @@ base64 = { workspace = true }
 candid = "^0.10.2"
 hex = { workspace = true }
 ic-agent = { workspace = true }
-ic-cdk = { workspace = true }
 ic-transport-types = { workspace = true }
 reqwest = { workspace = true }
 schemars = "0.8.16"

--- a/packages/pocket-ic/Cargo.toml
+++ b/packages/pocket-ic/Cargo.toml
@@ -21,7 +21,7 @@ edition.workspace = true
 
 [dependencies]
 base64 = { workspace = true }
-candid = "^0.10.2"
+candid = { workspace = true }
 hex = { workspace = true }
 ic-agent = { workspace = true }
 ic-transport-types = { workspace = true }

--- a/packages/pocket-ic/HOWTO.md
+++ b/packages/pocket-ic/HOWTO.md
@@ -355,7 +355,7 @@ Here is a sketch of a test for a canister making canister HTTP outcalls in the l
 #[tokio::test]
 async fn test_canister_http_live() {
     use candid::{Decode, Encode, Principal};
-    use ic_cdk::api::management_canister::http_request::HttpResponse;
+    use pocket_ic::management_canister::HttpRequestResult;
     use ic_utils::interfaces::ManagementCanister;
 
     let mut pic = PocketIcBuilder::new()

--- a/packages/pocket-ic/src/lib.rs
+++ b/packages/pocket-ic/src/lib.rs
@@ -38,14 +38,14 @@ use crate::common::rest::{
     InstanceId, MockCanisterHttpResponse, RawEffectivePrincipal, RawMessageId, SubnetId,
     SubnetKind, SubnetSpec, Topology,
 };
+pub use crate::management_canister::CanisterSettings;
+use crate::management_canister::{CanisterId, CanisterStatusResult};
 use crate::nonblocking::PocketIc as PocketIcAsync;
 use candid::{
     decode_args, encode_args,
     utils::{ArgumentDecoder, ArgumentEncoder},
     Principal,
 };
-pub use ic_cdk::api::management_canister::main::CanisterSettings;
-use ic_cdk::api::management_canister::main::{CanisterId, CanisterStatusResponse};
 use ic_transport_types::SubnetMetrics;
 use reqwest::Url;
 use schemars::JsonSchema;
@@ -66,6 +66,7 @@ use tokio::runtime::Runtime;
 use tracing::{instrument, warn};
 
 pub mod common;
+pub mod management_canister;
 pub mod nonblocking;
 
 const EXPECTED_SERVER_VERSION: &str = "pocket-ic-server 6.0.0";
@@ -668,7 +669,7 @@ impl PocketIc {
         &self,
         canister_id: CanisterId,
         sender: Option<Principal>,
-    ) -> Result<CanisterStatusResponse, CallError> {
+    ) -> Result<CanisterStatusResult, CallError> {
         let runtime = self.runtime.clone();
         runtime.block_on(async { self.pocket_ic.canister_status(canister_id, sender).await })
     }

--- a/packages/pocket-ic/src/management_canister.rs
+++ b/packages/pocket-ic/src/management_canister.rs
@@ -1,0 +1,357 @@
+use candid::{CandidType, Deserialize, Principal};
+
+pub type CanisterId = Principal;
+
+#[derive(CandidType, Deserialize, Debug, Clone)]
+pub struct CanisterIdRecord {
+    pub canister_id: CanisterId,
+}
+
+// canister settings
+
+#[derive(CandidType, Deserialize, Debug, Clone)]
+pub enum LogVisibility {
+    #[serde(rename = "controllers")]
+    Controllers,
+    #[serde(rename = "public")]
+    Public,
+}
+
+#[derive(CandidType, Deserialize, Debug, Clone)]
+pub struct DefiniteCanisterSettings {
+    pub freezing_threshold: candid::Nat,
+    pub controllers: Vec<Principal>,
+    pub reserved_cycles_limit: candid::Nat,
+    pub log_visibility: LogVisibility,
+    pub wasm_memory_limit: candid::Nat,
+    pub memory_allocation: candid::Nat,
+    pub compute_allocation: candid::Nat,
+}
+
+#[derive(CandidType, Deserialize, Debug, Clone, Default)]
+pub struct CanisterSettings {
+    pub freezing_threshold: Option<candid::Nat>,
+    pub controllers: Option<Vec<Principal>>,
+    pub reserved_cycles_limit: Option<candid::Nat>,
+    pub log_visibility: Option<LogVisibility>,
+    pub wasm_memory_limit: Option<candid::Nat>,
+    pub memory_allocation: Option<candid::Nat>,
+    pub compute_allocation: Option<candid::Nat>,
+}
+
+#[derive(CandidType, Deserialize, Debug, Clone)]
+pub struct UpdateSettingsArgs {
+    pub canister_id: CanisterId,
+    pub settings: CanisterSettings,
+    pub sender_canister_version: Option<u64>,
+}
+
+// canister status
+
+#[derive(CandidType, Deserialize, Debug, Clone)]
+pub enum CanisterStatusResultStatus {
+    #[serde(rename = "stopped")]
+    Stopped,
+    #[serde(rename = "stopping")]
+    Stopping,
+    #[serde(rename = "running")]
+    Running,
+}
+
+#[derive(CandidType, Deserialize, Debug, Clone)]
+pub struct CanisterStatusResultQueryStats {
+    pub response_payload_bytes_total: candid::Nat,
+    pub num_instructions_total: candid::Nat,
+    pub num_calls_total: candid::Nat,
+    pub request_payload_bytes_total: candid::Nat,
+}
+
+#[derive(CandidType, Deserialize, Debug, Clone)]
+pub struct CanisterStatusResult {
+    pub status: CanisterStatusResultStatus,
+    pub memory_size: candid::Nat,
+    pub cycles: candid::Nat,
+    pub settings: DefiniteCanisterSettings,
+    pub query_stats: CanisterStatusResultQueryStats,
+    pub idle_cycles_burned_per_day: candid::Nat,
+    pub module_hash: Option<Vec<u8>>,
+    pub reserved_cycles: candid::Nat,
+}
+
+// canister creation
+
+#[derive(CandidType, Deserialize, Debug, Clone)]
+pub struct CreateCanisterArgs {
+    pub settings: Option<CanisterSettings>,
+    pub sender_canister_version: Option<u64>,
+}
+
+#[derive(CandidType, Deserialize, Debug, Clone)]
+pub struct ProvisionalCreateCanisterWithCyclesArgs {
+    pub settings: Option<CanisterSettings>,
+    pub specified_id: Option<CanisterId>,
+    pub amount: Option<candid::Nat>,
+    pub sender_canister_version: Option<u64>,
+}
+
+// canister code installation
+
+#[derive(CandidType, Deserialize, Debug, Clone)]
+pub enum CanisterInstallModeUpgradeInnerWasmMemoryPersistenceInner {
+    #[serde(rename = "keep")]
+    Keep,
+    #[serde(rename = "replace")]
+    Replace,
+}
+
+#[derive(CandidType, Deserialize, Debug, Clone)]
+pub struct CanisterInstallModeUpgradeInner {
+    pub wasm_memory_persistence: Option<CanisterInstallModeUpgradeInnerWasmMemoryPersistenceInner>,
+    pub skip_pre_upgrade: Option<bool>,
+}
+
+#[derive(CandidType, Deserialize, Debug, Clone)]
+pub enum CanisterInstallMode {
+    #[serde(rename = "reinstall")]
+    Reinstall,
+    #[serde(rename = "upgrade")]
+    Upgrade(Option<CanisterInstallModeUpgradeInner>),
+    #[serde(rename = "install")]
+    Install,
+}
+
+#[derive(CandidType, Deserialize, Debug, Clone)]
+pub struct InstallCodeArgs {
+    pub arg: Vec<u8>,
+    pub wasm_module: Vec<u8>,
+    pub mode: CanisterInstallMode,
+    pub canister_id: CanisterId,
+    pub sender_canister_version: Option<u64>,
+}
+
+// canister code uninstallation
+
+#[derive(CandidType, Deserialize, Debug, Clone)]
+pub struct UninstallCodeArgs {
+    pub canister_id: CanisterId,
+    pub sender_canister_version: Option<u64>,
+}
+
+// canister chunks
+
+#[derive(CandidType, Deserialize, Debug, Clone)]
+pub struct ChunkHash {
+    pub hash: Vec<u8>,
+}
+
+pub type StoredChunksResult = Vec<ChunkHash>;
+
+#[derive(CandidType, Deserialize, Debug, Clone)]
+pub struct UploadChunkArgs {
+    pub canister_id: CanisterId,
+    pub chunk: Vec<u8>,
+}
+
+pub type UploadChunkResult = ChunkHash;
+
+#[derive(CandidType, Deserialize, Debug, Clone)]
+pub struct InstallChunkedCodeArgs {
+    pub arg: Vec<u8>,
+    pub wasm_module_hash: Vec<u8>,
+    pub mode: CanisterInstallMode,
+    pub chunk_hashes_list: Vec<ChunkHash>,
+    pub target_canister: CanisterId,
+    pub store_canister: Option<CanisterId>,
+    pub sender_canister_version: Option<u64>,
+}
+
+// canister snapshots
+
+pub type SnapshotId = Vec<u8>;
+
+#[derive(CandidType, Deserialize, Debug, Clone)]
+pub struct Snapshot {
+    pub id: SnapshotId,
+    pub total_size: u64,
+    pub taken_at_timestamp: u64,
+}
+
+#[derive(CandidType, Deserialize, Debug, Clone)]
+pub struct DeleteCanisterSnapshotArgs {
+    pub canister_id: CanisterId,
+    pub snapshot_id: SnapshotId,
+}
+
+pub type ListCanisterSnapshotsResult = Vec<Snapshot>;
+
+#[derive(CandidType, Deserialize, Debug, Clone)]
+pub struct LoadCanisterSnapshotArgs {
+    pub canister_id: CanisterId,
+    pub sender_canister_version: Option<u64>,
+    pub snapshot_id: SnapshotId,
+}
+
+#[derive(CandidType, Deserialize, Debug, Clone)]
+pub struct TakeCanisterSnapshotArgs {
+    pub replace_snapshot: Option<SnapshotId>,
+    pub canister_id: CanisterId,
+}
+
+pub type TakeCanisterSnapshotResult = Snapshot;
+
+// canister logs
+
+#[derive(CandidType, Deserialize, Debug, Clone)]
+pub struct CanisterLogRecord {
+    pub idx: u64,
+    pub timestamp_nanos: u64,
+    pub content: Vec<u8>,
+}
+
+#[derive(CandidType, Deserialize, Debug, Clone)]
+pub struct FetchCanisterLogsResult {
+    pub canister_log_records: Vec<CanisterLogRecord>,
+}
+
+// canister http
+
+#[derive(CandidType, Deserialize, Debug, Clone)]
+pub enum HttpRequestArgsMethod {
+    #[serde(rename = "get")]
+    Get,
+    #[serde(rename = "head")]
+    Head,
+    #[serde(rename = "post")]
+    Post,
+}
+
+#[derive(CandidType, Deserialize, Debug, Clone)]
+pub struct HttpHeader {
+    pub value: String,
+    pub name: String,
+}
+
+#[derive(CandidType, Deserialize, Debug, Clone)]
+pub struct HttpRequestArgsTransformInnerFunctionArg {
+    pub context: Vec<u8>,
+    pub response: HttpRequestResult,
+}
+
+candid::define_function!(pub HttpRequestArgsTransformInnerFunction : (
+    HttpRequestArgsTransformInnerFunctionArg,
+  ) -> (HttpRequestResult) query);
+
+#[derive(CandidType, Deserialize, Debug, Clone)]
+pub struct HttpRequestArgsTransformInner {
+    pub function: HttpRequestArgsTransformInnerFunction,
+    pub context: Vec<u8>,
+}
+
+#[derive(CandidType, Deserialize, Debug, Clone)]
+pub struct HttpRequestArgs {
+    pub url: String,
+    pub method: HttpRequestArgsMethod,
+    pub max_response_bytes: Option<u64>,
+    pub body: Option<Vec<u8>>,
+    pub transform: Option<HttpRequestArgsTransformInner>,
+    pub headers: Vec<HttpHeader>,
+}
+
+#[derive(CandidType, Deserialize, Debug, Clone)]
+pub struct HttpRequestResult {
+    pub status: candid::Nat,
+    pub body: Vec<u8>,
+    pub headers: Vec<HttpHeader>,
+}
+
+// ecdsa
+
+#[derive(CandidType, Deserialize, Debug, Clone)]
+pub enum EcdsaCurve {
+    #[serde(rename = "secp256k1")]
+    Secp256K1,
+}
+
+#[derive(CandidType, Deserialize, Debug, Clone)]
+pub struct EcdsaPublicKeyArgsKeyId {
+    pub name: String,
+    pub curve: EcdsaCurve,
+}
+
+#[derive(CandidType, Deserialize, Debug, Clone)]
+pub struct EcdsaPublicKeyArgs {
+    pub key_id: EcdsaPublicKeyArgsKeyId,
+    pub canister_id: Option<CanisterId>,
+    pub derivation_path: Vec<Vec<u8>>,
+}
+
+#[derive(CandidType, Deserialize, Debug, Clone)]
+pub struct EcdsaPublicKeyResult {
+    pub public_key: Vec<u8>,
+    pub chain_code: Vec<u8>,
+}
+
+#[derive(CandidType, Deserialize, Debug, Clone)]
+pub struct SignWithEcdsaArgsKeyId {
+    pub name: String,
+    pub curve: EcdsaCurve,
+}
+
+#[derive(CandidType, Deserialize, Debug, Clone)]
+pub struct SignWithEcdsaArgs {
+    pub key_id: SignWithEcdsaArgsKeyId,
+    pub derivation_path: Vec<Vec<u8>>,
+    pub message_hash: Vec<u8>,
+}
+
+#[derive(CandidType, Deserialize, Debug, Clone)]
+pub struct SignWithEcdsaResult {
+    pub signature: Vec<u8>,
+}
+
+// schnorr
+
+#[derive(CandidType, Deserialize, Debug, Clone)]
+pub enum SchnorrAlgorithm {
+    #[serde(rename = "ed25519")]
+    Ed25519,
+    #[serde(rename = "bip340secp256k1")]
+    Bip340Secp256K1,
+}
+
+#[derive(CandidType, Deserialize, Debug, Clone)]
+pub struct SchnorrPublicKeyArgsKeyId {
+    pub algorithm: SchnorrAlgorithm,
+    pub name: String,
+}
+
+#[derive(CandidType, Deserialize, Debug, Clone)]
+pub struct SchnorrPublicKeyArgs {
+    pub key_id: SchnorrPublicKeyArgsKeyId,
+    pub canister_id: Option<CanisterId>,
+    pub derivation_path: Vec<Vec<u8>>,
+}
+
+#[derive(CandidType, Deserialize, Debug, Clone)]
+pub struct SchnorrPublicKeyResult {
+    pub public_key: Vec<u8>,
+    pub chain_code: Vec<u8>,
+}
+
+#[derive(CandidType, Deserialize, Debug, Clone)]
+pub struct SignWithSchnorrArgsKeyId {
+    pub algorithm: SchnorrAlgorithm,
+    pub name: String,
+}
+
+#[derive(CandidType, Deserialize, Debug, Clone)]
+pub struct SignWithSchnorrArgs {
+    pub key_id: SignWithSchnorrArgsKeyId,
+    pub derivation_path: Vec<Vec<u8>>,
+    pub message: Vec<u8>,
+}
+
+#[derive(CandidType, Deserialize, Debug, Clone)]
+pub struct SignWithSchnorrResult {
+    pub signature: Vec<u8>,
+}

--- a/packages/pocket-ic/tests/tests.rs
+++ b/packages/pocket-ic/tests/tests.rs
@@ -1,9 +1,9 @@
-use candid::{decode_one, encode_one, CandidType, Decode, Encode, Principal};
-use ic_cdk::api::call::RejectionCode;
-use ic_cdk::api::management_canister::ecdsa::EcdsaPublicKeyResponse;
-use ic_cdk::api::management_canister::http_request::HttpResponse;
-use ic_cdk::api::management_canister::main::{CanisterId, CanisterIdRecord, CanisterSettings};
-use ic_cdk::api::management_canister::provisional::ProvisionalCreateCanisterWithCyclesArgument;
+use candid::{decode_one, encode_one, CandidType, Decode, Deserialize, Encode, Principal};
+use pocket_ic::management_canister::{
+    CanisterId, CanisterIdRecord, CanisterSettings, EcdsaPublicKeyResult, HttpRequestResult,
+    ProvisionalCreateCanisterWithCyclesArgs, SchnorrAlgorithm, SchnorrPublicKeyArgsKeyId,
+    SchnorrPublicKeyResult,
+};
 use pocket_ic::{
     common::rest::{
         BlobCompression, CanisterHttpReply, CanisterHttpResponse, MockCanisterHttpResponse,
@@ -13,12 +13,22 @@ use pocket_ic::{
     WasmResult,
 };
 use reqwest::blocking::Client;
-use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::{io::Read, time::SystemTime};
 
 // 2T cycles
 const INIT_CYCLES: u128 = 2_000_000_000_000;
+
+#[derive(CandidType, Deserialize, Debug)]
+enum RejectionCode {
+    NoError,
+    SysFatal,
+    SysTransient,
+    DestinationInvalid,
+    CanisterReject,
+    CanisterError,
+    Unknown,
+}
 
 #[test]
 fn test_counter_canister() {
@@ -852,26 +862,6 @@ fn test_canister_wasm() -> Vec<u8> {
     std::fs::read(wasm_path).unwrap()
 }
 
-#[derive(CandidType, Serialize, Deserialize, Debug, Copy, Clone)]
-pub enum SchnorrAlgorithm {
-    #[serde(rename = "bip340secp256k1")]
-    Bip340Secp256k1,
-    #[serde(rename = "ed25519")]
-    Ed25519,
-}
-
-#[derive(CandidType, Serialize, Deserialize, Debug, Clone)]
-struct SchnorrKeyId {
-    pub algorithm: SchnorrAlgorithm,
-    pub name: String,
-}
-
-#[derive(CandidType, Deserialize, Debug)]
-struct SchnorrPublicKeyResponse {
-    pub public_key: Vec<u8>,
-    pub chain_code: Vec<u8>,
-}
-
 #[test]
 fn test_schnorr() {
     // We create a PocketIC instance consisting of the NNS, II, and one application subnet.
@@ -896,17 +886,17 @@ fn test_schnorr() {
     // We define the message, derivation path, and ECDSA key ID to use in this test.
     let message = b"Hello, world!==================="; // must be of length 32 bytes for BIP340
     let derivation_path = vec!["my message".as_bytes().to_vec()];
-    for algorithm in [SchnorrAlgorithm::Bip340Secp256k1, SchnorrAlgorithm::Ed25519] {
+    for algorithm in [SchnorrAlgorithm::Bip340Secp256K1, SchnorrAlgorithm::Ed25519] {
         for name in ["key_1", "test_key_1", "dfx_test_key"] {
-            let key_id = SchnorrKeyId {
-                algorithm,
+            let key_id = SchnorrPublicKeyArgsKeyId {
+                algorithm: algorithm.clone(),
                 name: name.to_string(),
             };
 
             // We get the Schnorr public key and signature via update calls to the test canister.
             let schnorr_public_key = update_candid::<
                 (Option<Principal>, _, _),
-                (Result<SchnorrPublicKeyResponse, String>,),
+                (Result<SchnorrPublicKeyResult, String>,),
             >(
                 &pic,
                 canister,
@@ -928,7 +918,7 @@ fn test_schnorr() {
 
             // We verify the Schnorr signature.
             match key_id.algorithm {
-                SchnorrAlgorithm::Bip340Secp256k1 => {
+                SchnorrAlgorithm::Bip340Secp256K1 => {
                     use k256::ecdsa::signature::hazmat::PrehashVerifier;
                     use k256::schnorr::{Signature, VerifyingKey};
                     let vk = VerifyingKey::from_bytes(&schnorr_public_key.public_key[1..]).unwrap();
@@ -983,7 +973,7 @@ fn test_ecdsa() {
         // We get the ECDSA public key and signature via update calls to the test canister.
         let ecsda_public_key = update_candid::<
             (Option<Principal>, Vec<Vec<u8>>, String),
-            (Result<EcdsaPublicKeyResponse, String>,),
+            (Result<EcdsaPublicKeyResult, String>,),
         >(
             &pic,
             canister,
@@ -1043,7 +1033,7 @@ fn test_ecdsa_disabled() {
     // We attempt to get the ECDSA public key and signature via update calls to the test canister.
     let ecsda_public_key_error = update_candid::<
         (Option<Principal>, Vec<Vec<u8>>, String),
-        (Result<EcdsaPublicKeyResponse, String>,),
+        (Result<EcdsaPublicKeyResult, String>,),
     >(
         &pic,
         canister,
@@ -1119,7 +1109,7 @@ fn test_canister_http() {
     let reply = pic.await_call(call_id).unwrap();
     match reply {
         WasmResult::Reply(data) => {
-            let http_response: Result<HttpResponse, (RejectionCode, String)> =
+            let http_response: Result<HttpRequestResult, (RejectionCode, String)> =
                 decode_one(&data).unwrap();
             assert_eq!(http_response.unwrap().body, body);
         }
@@ -1181,7 +1171,7 @@ fn test_canister_http_with_transform() {
     let reply = pic.await_call(call_id).unwrap();
     match reply {
         WasmResult::Reply(data) => {
-            let http_response: HttpResponse = decode_one(&data).unwrap();
+            let http_response: HttpRequestResult = decode_one(&data).unwrap();
             // http response headers are cleared by the transform function
             assert!(http_response.headers.is_empty());
             // mocked non-empty response body is transformed to the transform context
@@ -1248,10 +1238,10 @@ fn test_canister_http_with_diverging_responses() {
     let reply = pic.await_call(call_id).unwrap();
     match reply {
         WasmResult::Reply(data) => {
-            let http_response: Result<HttpResponse, (RejectionCode, String)> =
+            let http_response: Result<HttpRequestResult, (RejectionCode, String)> =
                 decode_one(&data).unwrap();
             let (reject_code, err) = http_response.unwrap_err();
-            assert_eq!(reject_code, RejectionCode::SysTransient);
+            assert!(matches!(reject_code, RejectionCode::SysTransient));
             let expected = "No consensus could be reached. Replicas had different responses. Details: request_id: 0, timeout: 1620328930000000005, hashes: [98387cc077af9cff2ef439132854e91cb074035bb76e2afb266960d8e3beaf11: 2], [6a2fa8e54fb4bbe62cde29f7531223d9fcf52c21c03500c1060a5f893ed32d2e: 2], [3e9ec98abf56ef680bebb14309858ede38f6fde771cd4c04cda8f066dc2810db: 2], [2c14e77f18cd990676ae6ce0d7eb89c0af9e1a66e17294b5f0efa68422bba4cb: 2], [2843e4133f673571ff919808d3ca542cc54aaf288c702944e291f0e4fafffc69: 2], [1c4ad84926c36f1fbc634a0dc0535709706f7c48f0c6ebd814fe514022b90671: 2], [7bf80e2f02011ab0a7836b526546e75203b94e856d767c9df4cb0c19baf34059: 1]";
             assert_eq!(err, expected);
         }
@@ -1410,9 +1400,11 @@ fn create_canister_with_effective_canister_id(
         RawEffectivePrincipal::CanisterId(effective_canister_id.as_slice().to_vec()),
         Principal::anonymous(),
         "provisional_create_canister_with_cycles",
-        (ProvisionalCreateCanisterWithCyclesArgument {
+        (ProvisionalCreateCanisterWithCyclesArgs {
             settings: None,
+            specified_id: None,
             amount: None,
+            sender_canister_version: None,
         },),
     )
     .map(|(x,)| x)
@@ -1430,9 +1422,11 @@ async fn create_canister_with_effective_canister_id_nonblocking(
         RawEffectivePrincipal::CanisterId(effective_canister_id.as_slice().to_vec()),
         Principal::anonymous(),
         "provisional_create_canister_with_cycles",
-        (ProvisionalCreateCanisterWithCyclesArgument {
+        (ProvisionalCreateCanisterWithCyclesArgs {
             settings: None,
+            specified_id: None,
             amount: None,
+            sender_canister_version: None,
         },),
     )
     .await


### PR DESCRIPTION
This PR introduces a PocketIC library module containing management canister types to avoid a dependency on the Rust CDK. This is useful to allow canister developers bump their Rust CDK version independently of their PocketIC library version. The names of the management canister types follow the names in the management canister candid interface.