### PR TITLE
test(IDX): move the global_reboot_test to long_tests

### DIFF
--- a/rs/tests/message_routing/BUILD.bazel
+++ b/rs/tests/message_routing/BUILD.bazel
@@ -14,6 +14,7 @@ system_test_nns(
     },
     tags = [
         "k8s",
+        "long_test",  # since it takes longer than 5 minutes.
     ],
     target_compatible_with = ["@platforms//os:linux"],  # requires libssh that does not build on Mac OS
     runtime_deps = GUESTOS_RUNTIME_DEPS + XNET_TEST_CANISTER_RUNTIME_DEPS,


### PR DESCRIPTION
The `global_reboot_test` has a P90 of 5m and 5s so it has to move off of PRs and into long_tests. See the 
[GitHub IC Bazel PR+MG Stats](https://superset.idx.dfinity.network/superset/dashboard/7/) dashboard:

![Screenshot 2024-10-21 at 09 37 56](https://github.com/user-attachments/assets/c8febac8-3490-4656-a8f4-cb09c285d283)
