### PR TITLE
feat(cketh/ckerc20): add helper smart contract supporting Subaccounts

### DIFF
--- a/rs/ethereum/cketh/minter/DepositHelperWithSubaccount.sol
+++ b/rs/ethereum/cketh/minter/DepositHelperWithSubaccount.sol
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.20;
+
+import {SafeERC20, IERC20} from "https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v5.0.2/contracts/token/ERC20/utils/SafeERC20.sol";
+
+/**
+ * @title A helper smart contract for ETH <-> ckETH and ERC20 <-> ckERC20 conversions.
+ * @notice This smart contract deposits incoming funds to the ckETH minter account and emits deposit events.
+ */
+contract CkDeposit {
+    using SafeERC20 for IERC20;
+
+    address payable private immutable minterAddress;
+
+    event ReceivedEth(
+        address indexed from,
+        uint256 value,
+        bytes32 indexed principal,
+        bytes32 subaccount
+    );
+
+    event ReceivedErc20(
+        address indexed erc20ContractAddress,
+        address indexed owner,
+        uint256 amount,
+        bytes32 indexed principal,
+        bytes32 subaccount
+    );
+
+    /**
+     * @dev Set cketh_minter_main_address.
+     */
+    constructor(address _minterAddress) {
+        minterAddress = payable(_minterAddress);
+    }
+
+    /**
+     * @dev Return ckETH minter main address.
+     * @return address of ckETH minter main address.
+     */
+    function getMinterAddress() public view returns (address) {
+        return minterAddress;
+    }
+
+    /**
+     * @dev Emits the `ReceivedEth` event if the transfer succeeds.
+     */
+    function depositEth(bytes32 principal, bytes32 subaccount) public payable {
+        emit ReceivedEth(msg.sender, msg.value, principal, subaccount);
+        minterAddress.transfer(msg.value);
+    }
+
+    /**
+     * @dev Emits the `ReceivedErc20` event if the transfer succeeds.
+     */
+    function depositErc20(
+        address erc20Address,
+        uint256 amount,
+        bytes32 principal,
+        bytes32 subaccount
+    ) public {
+        IERC20 erc20Token = IERC20(erc20Address);
+        erc20Token.safeTransferFrom(
+            msg.sender,
+            minterAddress,
+            amount
+        );
+
+        emit ReceivedErc20(
+            erc20Address,
+            msg.sender,
+            amount,
+            principal,
+            subaccount
+        );
+    }
+}


### PR DESCRIPTION
([XC-218](https://dfinity.atlassian.net/browse/XC-218)): Add a new Solidity helper smart contract for both ETH and ERC-20 deposits to support subaccounts. The contract is deployed on Sepolia at [`0x11d7c426EEdC044b21066d2BE9480D4b99E7cC1a`](https://sepolia.etherscan.io/address/0x11d7c426eedc044b21066d2be9480d4b99e7cc1a).

Examples of events:

1. [Example](https://sepolia.etherscan.io/tx/0x12213b78a743d45a868f0eca5da62a28ed8e6578cd63b1986a23f63e6089a5c3#eventlog) of ReceivedEth event with subaccount. 
2. [Example](https://sepolia.etherscan.io/tx/0x54b59e673d03d2313f77fbe3837e599cf47d51de007e08a18494189a2243f5dd#eventlog) of ReceivedErc20 with subaccount

[XC-218]: https://dfinity.atlassian.net/browse/XC-218?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ