### PR TITLE
fix: add a temporary measure to remove existing API BN certs

### DIFF
--- a/ic-os/components/init/bootstrap-ic-node/bootstrap-ic-node.sh
+++ b/ic-os/components/init/bootstrap-ic-node/bootstrap-ic-node.sh
@@ -190,3 +190,12 @@ write_metric "guestos_node_operator_private_key_exists" \
     "${node_operator_private_key_exists}" \
     "Existence of a Node Operator private key indicates the node deployment method" \
     "gauge"
+
+# temporary fix to remove existing certificates of the API BNs
+if [ -f /var/lib/ic/data/ic-boundary-tls.key ]; then
+    rm /var/lib/ic/data/ic-boundary-tls.key
+fi
+
+if [ -f /var/lib/ic/data/ic-boundary-tls.crt ]; then
+    rm /var/lib/ic/data/ic-boundary-tls.crt
+fi


### PR DESCRIPTION
With the switch from the HTTP- to the ALPN-ACME challenge, we need to cleanup the pre-existing certificates.