### PR TITLE
feat(repro-check): add support for component-specific verification flags

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -98,7 +98,7 @@ All built artifacts will be located in the top-level artifacts/ directory.
 
 Each https://dashboard.internetcomputer.org/releases[release proposal] includes instructions on how to verify the build reproducibility of IC-OS update images.
 
-To verify the build reproducibility of a specific `IC-OS Version Elect` proposal, you can just copy the one liner below to a fresh Ubuntu VM 22.04 or higher:
+To verify the build reproducibility of a specific `IC OS Version Election` proposal, you can just copy the one liner below to a fresh Ubuntu VM 22.04 or higher:
 
     $ sudo apt-get install -y curl && curl --proto '=https' --tlsv1.2 -sSLO https://raw.githubusercontent.com/dfinity/ic/master/ci/tools/repro-check.sh && chmod +x repro-check.sh && ./repro-check.sh -p <proposal>
 

--- a/README.adoc
+++ b/README.adoc
@@ -98,13 +98,18 @@ All built artifacts will be located in the top-level artifacts/ directory.
 
 Each https://dashboard.internetcomputer.org/releases[release proposal] includes instructions on how to verify the build reproducibility of IC-OS update images.
 
-To verify the build reproducibility of a specific `Elect Replica` proposal, you can just copy the one liner below to a fresh Ubuntu VM 22.04 or higher:
+To verify the build reproducibility of a specific `IC-OS Version Elect` proposal, you can just copy the one liner below to a fresh Ubuntu VM 22.04 or higher:
 
     $ sudo apt-get install -y curl && curl --proto '=https' --tlsv1.2 -sSLO https://raw.githubusercontent.com/dfinity/ic/master/ci/tools/repro-check.sh && chmod +x repro-check.sh && ./repro-check.sh -p <proposal>
 
 If you have the repository already cloned, you can just run:
 
     $ ./ci/tools/repro-check.sh -c <git revision>
+
+Verifying build reproducibility of GuestOS is sufficient for the `Revise Elected GuestOS Versions` NNS proposals.
+For the `Revise Elected HostOS Versions` NNS proposals, you should also verify the build reproducibility of HostOS or SetupOS images in addition to the regular GuestOS, and for that you can use the following command:
+
+    $ ./ci/tools/repro-check.sh -x -c <git revision>
 
 == Contributing
 

--- a/README.adoc
+++ b/README.adoc
@@ -106,10 +106,14 @@ If you have the repository already cloned, you can just run:
 
     $ ./ci/tools/repro-check.sh -c <git revision>
 
-Verifying build reproducibility of GuestOS is sufficient for the `Revise Elected GuestOS Versions` NNS proposals.
-For the `Revise Elected HostOS Versions` NNS proposals, you should also verify the build reproducibility of HostOS or SetupOS images in addition to the regular GuestOS, and for that you can use the following command:
+You can also verify only specific components, by specifying --guestos, --hostos, or --setupos flags:
 
-    $ ./ci/tools/repro-check.sh -x -c <git revision>
+    $ ./ci/tools/repro-check.sh -c <git revision> --guestos
+
+Verifying build reproducibility of GuestOS is sufficient for the `Revise Elected GuestOS Versions` NNS proposals.
+
+For the `Revise Elected HostOS Versions` NNS proposals, you should verify the build reproducibility of HostOS images.
+The default behavior of the script is to verify the build reproducibility of all components.
 
 == Contributing
 

--- a/ci/tools/repro-check.sh
+++ b/ci/tools/repro-check.sh
@@ -69,15 +69,52 @@ print_usage() {
     cat >&2 <<-USAGE
     This script builds and diffs the update image between CI and build-ic
     Pick one of the following options:
-    -h        this help message
-    --guestos   verify only build reproducibility of GuestOS images
-    --hostos    verify only build reproducibility of HostOS images
-    --setupos   verify only build reproducibility of SetupOS images
-    -p      proposal id to check - the proposal has to be for an Elect Replica proposal
-    -c      git revision/commit to use - the commit has to exist on master branch of
-            the IC repository on GitHub
-    <empty> no option - uses the commit at the tip of the branch this is run on
+    -h            this help message
+    --guestos     verify only build reproducibility of GuestOS images
+    --hostos      verify only build reproducibility of HostOS images
+    --setupos     verify only build reproducibility of SetupOS images
+    -p            proposal id to check - the proposal has to be for an Elect Replica proposal
+    -c            git revision/commit to use - the commit has to exist on master branch of
+                  the IC repository on GitHub
+    <empty>       no option - uses the commit at the tip of the branch this is run on
 USAGE
+}
+
+extract_field_json() {
+    jq_field="$1"
+    input="$2"
+
+    out=$(cat "$input" | jq --raw-output "$jq_field")
+    status="$?"
+
+    if [[ "$status" != 0 ]] || [[ "$out" == "null" ]]; then
+        error "Field $jq_field does not exist in $input"
+    fi
+
+    echo "$out"
+}
+
+check_git_repo() {
+    log_debug "Check we are inside a Git repository"
+    if [ "$(git rev-parse --is-inside-work-tree 2>/dev/null)" != "true" ]; then
+        error "Please run this script inside of a git repository"
+    else
+        log_debug "Inside git repository"
+    fi
+}
+
+check_ic_repo() {
+    git_remote="$(git config --get remote.origin.url)"
+
+    log_debug "Check the repository is an IC repository"
+    # Possible values of `git_remote` are listed below
+    # git@github.com:dfinity/ic.git
+    # https://github.com/dfinity/ic.git
+    if [[ "$git_remote" == */ic.git ]] || [[ "$git_remote" == */ic ]]; then
+        log_debug "Inside IC repository"
+    else
+        error "When not specifying any option please run this script inside an IC git repository"
+    fi
 }
 
 #################### Set-up
@@ -85,7 +122,7 @@ if [ "${DEBUG:-}" == "2" ]; then
     set -x
 fi
 
-# Default: Verify all OS components
+# Default behavior: Verify all OS components
 verify_guestos="true"
 verify_hostos="true"
 verify_setupos="true"
@@ -110,7 +147,8 @@ while [[ "$#" -gt 0 ]]; do
     shift
 done
 
-# Set default behavior if no flags are provided (i.e., verify all components)
+# Set default behavior if no flags are provided (verify all components)
+# OPTIND is a built-in variable in Bash that represents the index of the next argument to be processed by getopts during argument parsing.
 if [ "$OPTIND" -eq 1 ]; then
     verify_guestos="true"
     verify_hostos="true"
@@ -153,10 +191,16 @@ else
     log_warning "You need at least 100GB of free disk space on this machine"
 fi
 
-log "Update package registry"
-sudo apt-get update -y
-log "Install needed dependencies"
-sudo apt-get install git curl jq podman -y
+# Install dependencies if they are not available
+log "Check and install needed dependencies"
+for pkg in git curl jq podman; do
+    if ! command -v $pkg &>/dev/null; then
+        log "Installing missing package: $pkg"
+        sudo apt-get install -y $pkg
+    else
+        log_success "$pkg is already installed"
+    fi
+done
 
 # if no options have been chosen, we assume to check the latest commit of the
 # branch we are on.
@@ -167,7 +211,91 @@ if [ "$OPTIND" -eq 1 ]; then
     no_option="true"
 fi
 
-# Download CI artifacts based on selected components
+# set the `git_hash` from the `proposal_id` or from the environment
+if [ -n "$proposal_id" ]; then
+    # format the proposal
+    proposal_url="https://ic-api.internetcomputer.org/api/v3/proposals/$proposal_id"
+    proposal_body="proposal-body.json"
+
+    log_debug "Fetch the proposal json body"
+    proposal_body_status=$(curl --silent --show-error -w %{http_code} --location --retry 5 --retry-delay 10 "$proposal_url" -o "$proposal_body")
+
+    # check for error
+    if ! [[ "$proposal_body_status" =~ ^2 ]]; then
+        error "Could not fetch $proposal_id, please make sure you have a valid internet connection or that the proposal #$proposal_id exists"
+    fi
+    log_debug "Extract the package_url"
+    proposal_package_url=$(extract_field_json ".payload.release_package_urls[0]" "$proposal_body")
+
+    log_debug "Extract the sha256 sums hex for the artifacts from the proposal"
+    proposal_package_sha256_hex=$(extract_field_json ".payload.release_package_sha256_hex" "$proposal_body")
+
+    log_debug "Extract git_hash out of the proposal"
+    if grep -q "replica_version_to_elect" "$proposal_body"; then
+        guestos_proposal=true
+        git_hash=$(extract_field_json ".payload.replica_version_to_elect" "$proposal_body")
+    elif grep -q "hostos_version_to_elect" "$proposal_body"; then
+        hostos_proposal=true
+        git_hash=$(extract_field_json ".payload.hostos_version_to_elect" "$proposal_body")
+    else
+        error "Proposal #$proposal_id is missing replica_version_to_elect or hostos_version_to_elect"
+    fi
+else
+    log_debug "Extract git_hash from CLI arguments or directory's HEAD"
+    git_hash=${git_commit:-$(git rev-parse HEAD)}
+fi
+
+tmpdir="$(mktemp -d)"
+log "Set our working directory to a temporary one - $tmpdir"
+
+# if we are in debug mode we keep the directories to debug any issues
+if [ -z "${DEBUG:-}" ]; then
+    trap 'rm -rf "$tmpdir"' EXIT
+fi
+
+pushd "$tmpdir"
+
+log "Set and create output directories for the different images"
+out="$tmpdir/disk-images/$git_hash"
+log "Images will be saved in $out"
+
+ci_out="$out/ci-img"
+dev_out="$out/dev-img"
+proposal_out="$out/proposal-img"
+
+mkdir -p "$ci_out/guestos" "$ci_out/hostos" "$ci_out/setupos"
+mkdir -p "$dev_out/guestos" "$dev_out/hostos" "$dev_out/setupos"
+mkdir -p "$proposal_out"
+
+#################### Check Proposal Hash
+# download and check the hash matches
+if [ -n "$proposal_id" ]; then
+
+    log "Check the proposal url is correctly formatted"
+    if [ "${guestos_proposal:-}" == "true" ]; then
+        expected_url="https://download.dfinity.systems/ic/$git_hash/guest-os/update-img/update-img.tar.zst"
+    else
+        expected_url="https://download.dfinity.systems/ic/$git_hash/host-os/update-img/update-img.tar.zst"
+    fi
+
+    if [ "$proposal_package_url" != "$expected_url" ]; then
+        error "The artifact's URL is wrongly formatted, please report this to DFINITY\n\t\tcurrent  = $proposal_package_url\n\t\texpected = $expected_url"
+    fi
+
+    log "Download the proposal artifacts"
+    curl --silent --show-error --location --retry 5 --retry-delay 10 \
+        --remote-name --output-dir "$proposal_out" "$proposal_package_url"
+
+    pushd "$proposal_out"
+
+    log "Check the hash of the artifacts is the correct one"
+    echo "$proposal_package_sha256_hex  update-img.tar.zst" | shasum -a256 -c- >/dev/null
+
+    log_success "The proposal's artifacts and hash match"
+    popd
+fi
+
+# Download CI artifacts for the selected component
 download_ci_files() {
     BASE_URL="https://download.dfinity.systems/ic/$git_hash"
 
@@ -200,7 +328,6 @@ if [ "$verify_setupos" == "true" ]; then
     download_ci_files "setup-os" "$ci_out/setupos"
 fi
 
-# Check hashes, verify based on the flags
 check_ci_hash() {
     local os_dir="$1"
     local target_file="$2"
@@ -208,8 +335,10 @@ check_ci_hash() {
 
     pushd "$ci_out/$os_dir"
 
+    # Validate that the computed hash of the target file matches the hash in the SHA256SUMS file
     grep "$target_file" SHA256SUMS | shasum -a256 -c- >/dev/null || error "The hash for $target_file in $os_dir doesn't match the published artifact for git hash: $git_hash"
 
+    # Extract the hash value from the SHA256SUMS file and assign it to the given output variable
     local extracted_hash="$(grep "$target_file" SHA256SUMS | cut -d' ' -f 1)"
     declare -g "$output_var=$extracted_hash"
 
@@ -229,3 +358,114 @@ if [ "$verify_setupos" == "true" ]; then
 fi
 
 log_success "The CI's artifacts and hash match"
+
+#################### Verify Proposal Image == CI Image
+log "Check the shasum that was set in the proposal matches the one we download from CDN"
+if [ -n "$proposal_id" ]; then
+    if [ "${guestos_proposal:-}" == "true" ]; then
+        if [ "$proposal_package_sha256_hex" != "$ci_package_guestos_sha256_hex" ]; then
+            error "The sha256 sum from the proposal does not match the one from the CDN storage for guestOS update-img.tar.zst. The guestos sha256 sum from the proposal: $proposal_package_sha256_hex The guestos sha256 sum from the CDN storage: $ci_package_guestos_sha256_hex."
+        else
+            log_success "The guestos shasum from the proposal and CDN match"
+        fi
+    else
+        if [ "$verify_hostos" == "true" ]; then
+            if [ "$proposal_package_sha256_hex" != "$ci_package_hostos_sha256_hex" ]; then
+                error "The sha256 sum from the proposal does not match the one from the CDN storage for hostOS update-img.tar.zst. The hostos sha256 sum from the proposal: $proposal_package_sha256_hex The hostos sha256 sum from the CDN storage: $ci_package_hostos_sha256_hex."
+            else
+                log_success "The guestos shasum from the proposal and CDN match"
+            fi
+        fi
+    fi
+fi
+
+################### Verify CI Image == Dev Image
+pushd "$tmpdir"
+# Copy if we are in CI, if there wasn't an option specified or if it was `git_commit`
+if [ -n "${CI:-}" ] || [ -n "$no_option" ]; then
+    log "Copy IC repository from $pwd to temporary directory"
+    git clone "$pwd" ic
+else
+    log "Clone IC repository"
+    git clone https://github.com/dfinity/ic
+fi
+
+pushd ic
+
+# Check `git_commit` exists on the master branch of the IC repository on GitHub
+if [ -n "$git_commit" ]; then
+    check_git_repo
+    check_ic_repo
+
+    if ! git cat-file -e "$git_commit^{commit}"; then
+        error "When specifying the -c option please specify a git hash which exists as a commit on a branch of the IC repository"
+    fi
+fi
+
+log "Checkout $git_hash commit"
+git fetch --quiet origin "$git_hash"
+git checkout --quiet "$git_hash"
+
+log "Build IC-OS"
+./ci/container/build-ic.sh --icos
+log_success "Built IC-OS successfully"
+
+if [ "$verify_guestos" == "true" ]; then
+mv artifacts/icos/guestos/update-img.tar.zst "$dev_out/guestos"
+fi
+if [ "$verify_hostos" == "true" ]; then
+mv artifacts/icos/hostos/update-img.tar.zst "$dev_out/hostos"
+fi
+if [ "$verify_setupos" == "true" ]; then
+mv artifacts/icos/setupos/disk-img.tar.zst "$dev_out/setupos"
+fi
+
+compute_dev_hash() {
+    local os_dir="$1"
+    local local_file="$2"
+    local output_var_name="$3"
+
+    pushd "$dev_out/$os_dir"
+    local computed_hash="$(shasum -a 256 "$local_file" | cut -d' ' -f1)"
+    popd
+
+    declare -g "$output_var_name=$computed_hash"
+}
+
+compute_dev_hash "guestos" "update-img.tar.zst" "dev_package_guestos_sha256_hex"
+if [ "$verify_hostos_setupos" == "true" ]; then
+compute_dev_hash "hostos" "update-img.tar.zst" "dev_package_hostos_sha256_hex"
+compute_dev_hash "setupos" "disk-img.tar.zst" "dev_package_setupos_sha256_hex"
+fi
+
+compare_hashes() {
+    local local_hash_var="$1"
+    local ci_hash_var="$2"
+    local os_type="$3"
+
+    local local_hash_value=${!local_hash_var}
+    local ci_hash_value=${!ci_hash_var}
+
+    if [ "$local_hash_value" != "$ci_hash_value" ]; then
+        log_stderr "Error! The sha256 sum from the proposal/CDN does not match the one we just built for $os_type. \n\tThe sha256 sum we just built:\t\t$local_hash_value\n\tThe sha256 sum from the CDN:\t\t$ci_hash_value."
+    else
+        log_success "Verification successful for $os_type!"
+        log_success "The shasum for $os_type from the artifact built locally and the one fetched from the proposal/CDN match:\n\t\t\t\t\t\tLocal = $local_hash_value\n\t\t\t\t\t\tCDN   = $ci_hash_value\n\n"
+    fi
+}
+
+log "Check hash of locally built artifact matches the one fetched from the proposal/CDN"
+
+if [ "$verify_guestos" == "true" ]; then
+compare_hashes "dev_package_guestos_sha256_hex" "ci_package_guestos_sha256_hex" "GuestOS"
+fi
+if [ "$verify_hostos" == "true" ]; then
+compare_hashes "dev_package_hostos_sha256_hex" "ci_package_hostos_sha256_hex" "HostOS"
+fi
+if [ "$verify_setupos" == "true" ]; then
+compare_hashes "dev_package_setupos_sha256_hex" "ci_package_setupos_sha256_hex" "SetupOS"
+fi
+
+log "Total time: $(($SECONDS / 3600))h $((($SECONDS / 60) % 60))m $(($SECONDS % 60))s"
+
+exit 0

--- a/ci/tools/repro-check.sh
+++ b/ci/tools/repro-check.sh
@@ -69,50 +69,15 @@ print_usage() {
     cat >&2 <<-USAGE
     This script builds and diffs the update image between CI and build-ic
     Pick one of the following options:
-    -h	    this help message
+    -h        this help message
+    --guestos   verify only build reproducibility of GuestOS images
+    --hostos    verify only build reproducibility of HostOS images
+    --setupos   verify only build reproducibility of SetupOS images
     -p      proposal id to check - the proposal has to be for an Elect Replica proposal
-    -c	    git revision/commit to use - the commit has to exist on master branch of
+    -c      git revision/commit to use - the commit has to exist on master branch of
             the IC repository on GitHub
-    -x      verify HostOS and SetupOS images as well (default is to verify only GuestOS)
     <empty> no option - uses the commit at the tip of the branch this is run on
 USAGE
-}
-
-extract_field_json() {
-    jq_field="$1"
-    input="$2"
-
-    out=$(cat "$input" | jq --raw-output "$jq_field")
-    status="$?"
-
-    if [[ "$status" != 0 ]] || [[ "$out" == "null" ]]; then
-        error "Field $jq_field does not exist in $input"
-    fi
-
-    echo "$out"
-}
-
-check_git_repo() {
-    log_debug "Check we are inside a Git repository"
-    if [ "$(git rev-parse --is-inside-work-tree 2>/dev/null)" != "true" ]; then
-        error "Please run this script inside of a git repository"
-    else
-        log_debug "Inside git repository"
-    fi
-}
-
-check_ic_repo() {
-    git_remote="$(git config --get remote.origin.url)"
-
-    log_debug "Check the repository is an IC repository"
-    # Possible values of `git_remote` are listed below
-    # git@github.com:dfinity/ic.git
-    # https://github.com/dfinity/ic.git
-    if [[ "$git_remote" == */ic.git ]] || [[ "$git_remote" == */ic ]]; then
-        log_debug "Inside IC repository"
-    else
-        error "When not specifying any option please run this script inside an IC git repository"
-    fi
 }
 
 #################### Set-up
@@ -120,7 +85,11 @@ if [ "${DEBUG:-}" == "2" ]; then
     set -x
 fi
 
-verify_hostos_setupos=""
+# Default: Verify all OS components
+verify_guestos="true"
+verify_hostos="true"
+verify_setupos="true"
+
 proposal_id=""
 git_commit=""
 no_option=""
@@ -128,17 +97,26 @@ SECONDS=0
 pwd="$(pwd)"
 
 # Parse arguments
-while getopts ':i:h:c:p:d:x:' flag; do
-    case "${flag}" in
-        c) git_commit="${OPTARG}" ;;
-        p) proposal_id="${OPTARG}" ;;
-        x) verify_hostos_setupos="true" ;;
-        *)
-            print_usage
-            exit 1
-            ;;
+while [[ "$#" -gt 0 ]]; do
+    case "$1" in
+        --guestos) verify_hostos="false"; verify_setupos="false" ;;  # Only verify build reproducibility of GuestOS
+        --hostos) verify_guestos="false"; verify_setupos="false" ;;  # Only verify build reproducibility of HostOS
+        --setupos) verify_guestos="false"; verify_hostos="false" ;;  # Only verify build reproducibility of SetupOS
+        -p) proposal_id="$2"; shift ;;
+        -c) git_commit="$2"; shift ;;
+        -h) print_usage; exit 0 ;;
+        *) print_usage; exit 1 ;;
     esac
+    shift
 done
+
+# Set default behavior if no flags are provided (i.e., verify all components)
+if [ "$OPTIND" -eq 1 ]; then
+    verify_guestos="true"
+    verify_hostos="true"
+    verify_setupos="true"
+    no_option="true"
+fi
 
 log "Check the environment"
 # either of those files should exist
@@ -189,91 +167,7 @@ if [ "$OPTIND" -eq 1 ]; then
     no_option="true"
 fi
 
-# set the `git_hash` from the `proposal_id` or from the environment
-if [ -n "$proposal_id" ]; then
-    # format the proposal
-    proposal_url="https://ic-api.internetcomputer.org/api/v3/proposals/$proposal_id"
-    proposal_body="proposal-body.json"
-
-    log_debug "Fetch the proposal json body"
-    proposal_body_status=$(curl --silent --show-error -w %{http_code} --location --retry 5 --retry-delay 10 "$proposal_url" -o "$proposal_body")
-
-    # check for error
-    if ! [[ "$proposal_body_status" =~ ^2 ]]; then
-        error "Could not fetch $proposal_id, please make sure you have a valid internet connection or that the proposal #$proposal_id exists"
-    fi
-    log_debug "Extract the package_url"
-    proposal_package_url=$(extract_field_json ".payload.release_package_urls[0]" "$proposal_body")
-
-    log_debug "Extract the sha256 sums hex for the artifacts from the proposal"
-    proposal_package_sha256_hex=$(extract_field_json ".payload.release_package_sha256_hex" "$proposal_body")
-
-    log_debug "Extract git_hash out of the proposal"
-    if grep -q "replica_version_to_elect" "$proposal_body"; then
-        guestos_proposal=true
-        git_hash=$(extract_field_json ".payload.replica_version_to_elect" "$proposal_body")
-    elif grep -q "hostos_version_to_elect" "$proposal_body"; then
-        hostos_proposal=true
-        git_hash=$(extract_field_json ".payload.hostos_version_to_elect" "$proposal_body")
-    else
-        error "Proposal #$proposal_id is missing replica_version_to_elect or hostos_version_to_elect"
-    fi
-else
-    log_debug "Extract git_hash from CLI arguments or directory's HEAD"
-    git_hash=${git_commit:-$(git rev-parse HEAD)}
-fi
-
-tmpdir="$(mktemp -d)"
-log "Set our working directory to a temporary one - $tmpdir"
-
-# if we are in debug mode we keep the directories to debug any issues
-if [ -z "${DEBUG:-}" ]; then
-    trap 'rm -rf "$tmpdir"' EXIT
-fi
-
-pushd "$tmpdir"
-
-log "Set and create output directories for the different images"
-out="$tmpdir/disk-images/$git_hash"
-log "Images will be saved in $out"
-
-ci_out="$out/ci-img"
-dev_out="$out/dev-img"
-proposal_out="$out/proposal-img"
-
-mkdir -p "$ci_out/guestos" "$ci_out/hostos" "$ci_out/setupos"
-mkdir -p "$dev_out/guestos" "$dev_out/hostos" "$dev_out/setupos"
-mkdir -p "$proposal_out"
-
-#################### Check Proposal Hash
-# download and check the hash matches
-if [ -n "$proposal_id" ]; then
-
-    log "Check the proposal url is correctly formatted"
-    if [ "${guestos_proposal:-}" == "true" ]; then
-        expected_url="https://download.dfinity.systems/ic/$git_hash/guest-os/update-img/update-img.tar.zst"
-    else
-        expected_url="https://download.dfinity.systems/ic/$git_hash/host-os/update-img/update-img.tar.zst"
-    fi
-
-    if [ "$proposal_package_url" != "$expected_url" ]; then
-        error "The artifact's URL is wrongly formatted, please report this to DFINITY\n\t\tcurrent  = $proposal_package_url\n\t\texpected = $expected_url"
-    fi
-
-    log "Download the proposal artifacts"
-    curl --silent --show-error --location --retry 5 --retry-delay 10 \
-        --remote-name --output-dir "$proposal_out" "$proposal_package_url"
-
-    pushd "$proposal_out"
-
-    log "Check the hash of the artifacts is the correct one"
-    echo "$proposal_package_sha256_hex  update-img.tar.zst" | shasum -a256 -c- >/dev/null
-
-    log_success "The proposal's artifacts and hash match"
-    popd
-fi
-
-#################### Check CI Hash
+# Download CI artifacts based on selected components
 download_ci_files() {
     BASE_URL="https://download.dfinity.systems/ic/$git_hash"
 
@@ -282,11 +176,6 @@ download_ci_files() {
 
     local os_url="${BASE_URL}/${os_type}/update-img/update-img.tar.zst"
     local sha_url="${BASE_URL}/${os_type}/update-img/SHA256SUMS"
-
-    if [ "$os_type" == "host-os" ]; then
-        os_url="${BASE_URL}/${os_type}/update-img/update-img.tar.zst"
-        sha_url="${BASE_URL}/${os_type}/update-img/SHA256SUMS"
-    fi
 
     if [ "$os_type" == "setup-os" ]; then
         os_url="${BASE_URL}/${os_type}/disk-img/disk-img.tar.zst"
@@ -300,12 +189,18 @@ download_ci_files() {
     curl $DOWNLOAD_OPTIONS --output-dir "$output_dir" "$sha_url"
 }
 
-download_ci_files "guest-os" "$ci_out/guestos"
-if [ "$verify_hostos_setupos" == "true" ]; then
-download_ci_files "host-os" "$ci_out/hostos"
-download_ci_files "setup-os" "$ci_out/setupos"
+# Download the requested OS images
+if [ "$verify_guestos" == "true" ]; then
+    download_ci_files "guest-os" "$ci_out/guestos"
+fi
+if [ "$verify_hostos" == "true" ]; then
+    download_ci_files "host-os" "$ci_out/hostos"
+fi
+if [ "$verify_setupos" == "true" ]; then
+    download_ci_files "setup-os" "$ci_out/setupos"
 fi
 
+# Check hashes, verify based on the flags
 check_ci_hash() {
     local os_dir="$1"
     local target_file="$2"
@@ -313,10 +208,8 @@ check_ci_hash() {
 
     pushd "$ci_out/$os_dir"
 
-    # Validate that the computed hash of the target file matches the hash in the SHA256SUMS file
     grep "$target_file" SHA256SUMS | shasum -a256 -c- >/dev/null || error "The hash for $target_file in $os_dir doesn't match the published artifact for git hash: $git_hash"
 
-    # Extract the hash value from the SHA256SUMS file and assign it to the given output variable
     local extracted_hash="$(grep "$target_file" SHA256SUMS | cut -d' ' -f 1)"
     declare -g "$output_var=$extracted_hash"
 
@@ -325,113 +218,14 @@ check_ci_hash() {
 
 log "Validating that uploaded image hashes match the provided proposal hashes"
 
-check_ci_hash "guestos" "update-img.tar.zst" "ci_package_guestos_sha256_hex"
-if [ "$verify_hostos_setupos" == "true" ]; then
-check_ci_hash "hostos" "update-img.tar.zst" "ci_package_hostos_sha256_hex"
-check_ci_hash "setupos" "disk-img.tar.zst" "ci_package_setupos_sha256_hex"
+if [ "$verify_guestos" == "true" ]; then
+    check_ci_hash "guestos" "update-img.tar.zst" "ci_package_guestos_sha256_hex"
+fi
+if [ "$verify_hostos" == "true" ]; then
+    check_ci_hash "hostos" "update-img.tar.zst" "ci_package_hostos_sha256_hex"
+fi
+if [ "$verify_setupos" == "true" ]; then
+    check_ci_hash "setupos" "disk-img.tar.zst" "ci_package_setupos_sha256_hex"
 fi
 
 log_success "The CI's artifacts and hash match"
-
-#################### Verify Proposal Image == CI Image
-log "Check the shasum that was set in the proposal matches the one we download from CDN"
-if [ -n "$proposal_id" ]; then
-    if [ "${guestos_proposal:-}" == "true" ]; then
-        if [ "$proposal_package_sha256_hex" != "$ci_package_guestos_sha256_hex" ]; then
-            error "The sha256 sum from the proposal does not match the one from the CDN storage for guestOS update-img.tar.zst. The guestos sha256 sum from the proposal: $proposal_package_sha256_hex The guestos sha256 sum from the CDN storage: $ci_package_guestos_sha256_hex."
-        else
-            log_success "The guestos shasum from the proposal and CDN match"
-        fi
-    else
-        if [ "$verify_hostos_setupos" == "true" ]; then
-            if [ "$proposal_package_sha256_hex" != "$ci_package_hostos_sha256_hex" ]; then
-                error "The sha256 sum from the proposal does not match the one from the CDN storage for hostOS update-img.tar.zst. The hostos sha256 sum from the proposal: $proposal_package_sha256_hex The hostos sha256 sum from the CDN storage: $ci_package_hostos_sha256_hex."
-            else
-                log_success "The guestos shasum from the proposal and CDN match"
-            fi
-        fi
-    fi
-fi
-
-################### Verify CI Image == Dev Image
-pushd "$tmpdir"
-# Copy if we are in CI, if there wasn't an option specified or if it was `git_commit`
-if [ -n "${CI:-}" ] || [ -n "$no_option" ]; then
-    log "Copy IC repository from $pwd to temporary directory"
-    git clone "$pwd" ic
-else
-    log "Clone IC repository"
-    git clone https://github.com/dfinity/ic
-fi
-
-pushd ic
-
-# Check `git_commit` exists on the master branch of the IC repository on GitHub
-if [ -n "$git_commit" ]; then
-    check_git_repo
-    check_ic_repo
-
-    if ! git cat-file -e "$git_commit^{commit}"; then
-        error "When specifying the -c option please specify a git hash which exists as a commit on a branch of the IC repository"
-    fi
-fi
-
-log "Checkout $git_hash commit"
-git fetch --quiet origin "$git_hash"
-git checkout --quiet "$git_hash"
-
-log "Build IC-OS"
-./ci/container/build-ic.sh --icos
-log_success "Built IC-OS successfully"
-
-mv artifacts/icos/guestos/update-img.tar.zst "$dev_out/guestos"
-if [ "$verify_hostos_setupos" == "true" ]; then
-mv artifacts/icos/hostos/update-img.tar.zst "$dev_out/hostos"
-mv artifacts/icos/setupos/disk-img.tar.zst "$dev_out/setupos"
-fi
-
-compute_dev_hash() {
-    local os_dir="$1"
-    local local_file="$2"
-    local output_var_name="$3"
-
-    pushd "$dev_out/$os_dir"
-    local computed_hash="$(shasum -a 256 "$local_file" | cut -d' ' -f1)"
-    popd
-
-    declare -g "$output_var_name=$computed_hash"
-}
-
-compute_dev_hash "guestos" "update-img.tar.zst" "dev_package_guestos_sha256_hex"
-if [ "$verify_hostos_setupos" == "true" ]; then
-compute_dev_hash "hostos" "update-img.tar.zst" "dev_package_hostos_sha256_hex"
-compute_dev_hash "setupos" "disk-img.tar.zst" "dev_package_setupos_sha256_hex"
-fi
-
-compare_hashes() {
-    local local_hash_var="$1"
-    local ci_hash_var="$2"
-    local os_type="$3"
-
-    local local_hash_value=${!local_hash_var}
-    local ci_hash_value=${!ci_hash_var}
-
-    if [ "$local_hash_value" != "$ci_hash_value" ]; then
-        log_stderr "Error! The sha256 sum from the proposal/CDN does not match the one we just built for $os_type. \n\tThe sha256 sum we just built:\t\t$local_hash_value\n\tThe sha256 sum from the CDN:\t\t$ci_hash_value."
-    else
-        log_success "Verification successful for $os_type!"
-        log_success "The shasum for $os_type from the artifact built locally and the one fetched from the proposal/CDN match:\n\t\t\t\t\t\tLocal = $local_hash_value\n\t\t\t\t\t\tCDN   = $ci_hash_value\n\n"
-    fi
-}
-
-log "Check hash of locally built artifact matches the one fetched from the proposal/CDN"
-
-compare_hashes "dev_package_guestos_sha256_hex" "ci_package_guestos_sha256_hex" "GuestOS"
-if [ "$verify_hostos_setupos" == "true" ]; then
-compare_hashes "dev_package_hostos_sha256_hex" "ci_package_hostos_sha256_hex" "HostOS"
-compare_hashes "dev_package_setupos_sha256_hex" "ci_package_setupos_sha256_hex" "SetupOS"
-fi
-
-log "Total time: $(($SECONDS / 3600))h $((($SECONDS / 60) % 60))m $(($SECONDS % 60))s"
-
-exit 0

--- a/ci/tools/repro-check.sh
+++ b/ci/tools/repro-check.sh
@@ -168,15 +168,6 @@ while [[ "$#" -gt 0 ]]; do
     shift
 done
 
-# Set default behavior if no flags are provided (verify all components)
-# OPTIND is a built-in variable in Bash that represents the index of the next argument to be processed by getopts during argument parsing.
-if [ "$OPTIND" -eq 1 ]; then
-    verify_guestos="true"
-    verify_hostos="true"
-    verify_setupos="true"
-    no_option="true"
-fi
-
 log "Check the environment"
 # either of those files should exist
 source /usr/lib/os-release 2>/dev/null
@@ -223,13 +214,18 @@ for pkg in git curl jq podman; do
     fi
 done
 
-# if no options have been chosen, we assume to check the latest commit of the
-# branch we are on.
+# Set default behavior if no flags are provided
+# OPTIND is a built-in variable in Bash that represents the index of the
+# next argument to be processed by getopts during argument parsing.
+# - check the latest commit of the branch we are on
+# - verify all OS components
 if [ "$OPTIND" -eq 1 ]; then
+    verify_guestos="true"
+    verify_hostos="true"
+    verify_setupos="true"
+    no_option="true"
     check_git_repo
     check_ic_repo
-
-    no_option="true"
 fi
 
 # set the `git_hash` from the `proposal_id` or from the environment

--- a/ci/tools/repro-check.sh
+++ b/ci/tools/repro-check.sh
@@ -136,13 +136,34 @@ pwd="$(pwd)"
 # Parse arguments
 while [[ "$#" -gt 0 ]]; do
     case "$1" in
-        --guestos) verify_hostos="false"; verify_setupos="false" ;;  # Only verify build reproducibility of GuestOS
-        --hostos) verify_guestos="false"; verify_setupos="false" ;;  # Only verify build reproducibility of HostOS
-        --setupos) verify_guestos="false"; verify_hostos="false" ;;  # Only verify build reproducibility of SetupOS
-        -p) proposal_id="$2"; shift ;;
-        -c) git_commit="$2"; shift ;;
-        -h) print_usage; exit 0 ;;
-        *) print_usage; exit 1 ;;
+        --guestos)
+            verify_hostos="false"
+            verify_setupos="false"
+            ;; # Only verify build reproducibility of GuestOS
+        --hostos)
+            verify_guestos="false"
+            verify_setupos="false"
+            ;; # Only verify build reproducibility of HostOS
+        --setupos)
+            verify_guestos="false"
+            verify_hostos="false"
+            ;; # Only verify build reproducibility of SetupOS
+        -p)
+            proposal_id="$2"
+            shift
+            ;;
+        -c)
+            git_commit="$2"
+            shift
+            ;;
+        -h)
+            print_usage
+            exit 0
+            ;;
+        *)
+            print_usage
+            exit 1
+            ;;
     esac
     shift
 done
@@ -411,13 +432,13 @@ log "Build IC-OS"
 log_success "Built IC-OS successfully"
 
 if [ "$verify_guestos" == "true" ]; then
-mv artifacts/icos/guestos/update-img.tar.zst "$dev_out/guestos"
+    mv artifacts/icos/guestos/update-img.tar.zst "$dev_out/guestos"
 fi
 if [ "$verify_hostos" == "true" ]; then
-mv artifacts/icos/hostos/update-img.tar.zst "$dev_out/hostos"
+    mv artifacts/icos/hostos/update-img.tar.zst "$dev_out/hostos"
 fi
 if [ "$verify_setupos" == "true" ]; then
-mv artifacts/icos/setupos/disk-img.tar.zst "$dev_out/setupos"
+    mv artifacts/icos/setupos/disk-img.tar.zst "$dev_out/setupos"
 fi
 
 compute_dev_hash() {
@@ -433,13 +454,13 @@ compute_dev_hash() {
 }
 
 if [ "$verify_guestos" == "true" ]; then
-compute_dev_hash "guestos" "update-img.tar.zst" "dev_package_guestos_sha256_hex"
+    compute_dev_hash "guestos" "update-img.tar.zst" "dev_package_guestos_sha256_hex"
 fi
 if [ "$verify_hostos" == "true" ]; then
-compute_dev_hash "hostos" "update-img.tar.zst" "dev_package_hostos_sha256_hex"
+    compute_dev_hash "hostos" "update-img.tar.zst" "dev_package_hostos_sha256_hex"
 fi
 if [ "$verify_setupos" == "true" ]; then
-compute_dev_hash "setupos" "disk-img.tar.zst" "dev_package_setupos_sha256_hex"
+    compute_dev_hash "setupos" "disk-img.tar.zst" "dev_package_setupos_sha256_hex"
 fi
 
 compare_hashes() {
@@ -461,13 +482,13 @@ compare_hashes() {
 log "Check hash of locally built artifact matches the one fetched from the proposal/CDN"
 
 if [ "$verify_guestos" == "true" ]; then
-compare_hashes "dev_package_guestos_sha256_hex" "ci_package_guestos_sha256_hex" "GuestOS"
+    compare_hashes "dev_package_guestos_sha256_hex" "ci_package_guestos_sha256_hex" "GuestOS"
 fi
 if [ "$verify_hostos" == "true" ]; then
-compare_hashes "dev_package_hostos_sha256_hex" "ci_package_hostos_sha256_hex" "HostOS"
+    compare_hashes "dev_package_hostos_sha256_hex" "ci_package_hostos_sha256_hex" "HostOS"
 fi
 if [ "$verify_setupos" == "true" ]; then
-compare_hashes "dev_package_setupos_sha256_hex" "ci_package_setupos_sha256_hex" "SetupOS"
+    compare_hashes "dev_package_setupos_sha256_hex" "ci_package_setupos_sha256_hex" "SetupOS"
 fi
 
 log "Total time: $(($SECONDS / 3600))h $((($SECONDS / 60) % 60))m $(($SECONDS % 60))s"

--- a/ci/tools/repro-check.sh
+++ b/ci/tools/repro-check.sh
@@ -432,9 +432,13 @@ compute_dev_hash() {
     declare -g "$output_var_name=$computed_hash"
 }
 
+if [ "$verify_guestos" == "true" ]; then
 compute_dev_hash "guestos" "update-img.tar.zst" "dev_package_guestos_sha256_hex"
-if [ "$verify_hostos_setupos" == "true" ]; then
+fi
+if [ "$verify_hostos" == "true" ]; then
 compute_dev_hash "hostos" "update-img.tar.zst" "dev_package_hostos_sha256_hex"
+fi
+if [ "$verify_setupos" == "true" ]; then
 compute_dev_hash "setupos" "disk-img.tar.zst" "dev_package_setupos_sha256_hex"
 fi
 


### PR DESCRIPTION
- Introduce `--guestos`, `--hostos`, and `--setupos` flags to allow selective verification of specific OS components.
- By default, the script verifies all components (GuestOS, HostOS, SetupOS), maintaining the original behavior.
- Adjusted download and verification logic to check only the selected OS components based on the provided flags.
- Updated the `print_usage` instructions to reflect the new flag options.
- Updated `README.adoc` to clarify the verification process for `IC-OS Version Elect` proposals and add instructions for verifying HostOS and SetupOS images.
- Adjusted RAM check logic in `repro-check.sh` to ensure accurate reporting of system memory.
