### PR TITLE
feat(cketh/ckerc20): Deposit events with subaccounts

### DIFF
--- a/rs/ethereum/cketh/minter/DepositHelperWithSubaccount.sol
+++ b/rs/ethereum/cketh/minter/DepositHelperWithSubaccount.sol
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.20;
+
+import {SafeERC20, IERC20} from "https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v5.0.2/contracts/token/ERC20/utils/SafeERC20.sol";
+
+/**
+ * @title A helper smart contract for ETH <-> ckETH and ERC20 <-> ckERC20 conversions.
+ * @notice This smart contract deposits incoming funds to the ckETH minter account and emits deposit events.
+ */
+contract CkDeposit {
+    using SafeERC20 for IERC20;
+
+    address payable private immutable minterAddress;
+
+    event ReceivedEth(
+        address indexed from,
+        uint256 value,
+        bytes32 indexed principal,
+        bytes32 subaccount
+    );
+
+    event ReceivedErc20(
+        address indexed erc20ContractAddress,
+        address indexed owner,
+        uint256 amount,
+        bytes32 indexed principal,
+        bytes32 subaccount
+    );
+
+    /**
+     * @dev Set cketh_minter_main_address.
+     */
+    constructor(address _minterAddress) {
+        minterAddress = payable(_minterAddress);
+    }
+
+    /**
+     * @dev Return ckETH minter main address.
+     * @return address of ckETH minter main address.
+     */
+    function getMinterAddress() public view returns (address) {
+        return minterAddress;
+    }
+
+    /**
+     * @dev Emits the `ReceivedEth` event if the transfer succeeds.
+     */
+    function depositEth(bytes32 principal, bytes32 subaccount) public payable {
+        emit ReceivedEth(msg.sender, msg.value, principal, subaccount);
+        minterAddress.transfer(msg.value);
+    }
+
+    /**
+     * @dev Emits the `ReceivedErc20` event if the transfer succeeds.
+     */
+    function depositErc20(
+        address erc20Address,
+        uint256 amount,
+        bytes32 principal,
+        bytes32 subaccount
+    ) public {
+        IERC20 erc20Token = IERC20(erc20Address);
+        erc20Token.safeTransferFrom(
+            msg.sender,
+            minterAddress,
+            amount
+        );
+
+        emit ReceivedErc20(
+            erc20Address,
+            msg.sender,
+            amount,
+            principal,
+            subaccount
+        );
+    }
+}

--- a/rs/ethereum/cketh/minter/cketh_minter.did
+++ b/rs/ethereum/cketh/minter/cketh_minter.did
@@ -5,6 +5,8 @@ type EthereumNetwork = variant {
     Sepolia;
 };
 
+type Subaccount = blob;
+
 type CanisterStatusResponse = record {
   query_stats : QueryStats;
   status : CanisterStatusType;
@@ -427,6 +429,7 @@ type Event = record {
             from_address : text;
             value : nat;
             "principal" : principal;
+            subaccount : opt Subaccount;
         };
         InvalidDeposit : record {
             event_source : EventSource;
@@ -498,6 +501,7 @@ type Event = record {
             value : nat;
             "principal" : principal;
             erc20_contract_address : text;
+            subaccount : opt Subaccount;
         };
         AcceptedErc20WithdrawalRequest : record {
             max_transaction_fee : nat;

--- a/rs/ethereum/cketh/minter/src/dashboard/tests.rs
+++ b/rs/ethereum/cketh/minter/src/dashboard/tests.rs
@@ -966,6 +966,7 @@ fn initial_state_with_usdc_support() -> State {
     state
 }
 
+// TODO XC-222: add subaccounts to dashboard
 fn received_eth_event() -> ReceivedEthEvent {
     ReceivedEthEvent {
         transaction_hash: "0xf1ac37d920fa57d9caeebc7136fea591191250309ffca95ae0e8a7739de89cc2"
@@ -980,6 +981,7 @@ fn received_eth_event() -> ReceivedEthEvent {
         principal: "k2t6j-2nvnp-4zjm3-25dtz-6xhaa-c7boj-5gayf-oj3xs-i43lp-teztq-6ae"
             .parse()
             .unwrap(),
+        subaccount: None,
     }
 }
 
@@ -1000,6 +1002,7 @@ fn received_erc20_event() -> ReceivedErc20Event {
         erc20_contract_address: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
             .parse()
             .unwrap(),
+        subaccount: None,
     }
 }
 

--- a/rs/ethereum/cketh/minter/src/deposit.rs
+++ b/rs/ethereum/cketh/minter/src/deposit.rs
@@ -15,11 +15,21 @@ use scopeguard::ScopeGuard;
 use std::cmp::{min, Ordering};
 use std::time::Duration;
 
+// Keccak256("ReceivedEth(address,uint256,bytes32)")
 pub(crate) const RECEIVED_ETH_EVENT_TOPIC: [u8; 32] =
     hex!("257e057bb61920d8d0ed2cb7b720ac7f9c513cd1110bc9fa543079154f45f435");
 
+// Keccak256("ReceivedEth(address,uint256,bytes32,bytes32)")
+pub(crate) const RECEIVED_ETH_EVENT_WITH_SUBACCOUNT_TOPIC: [u8; 32] =
+    hex!("5cf3eb7dcd092fdae9eb9a8bee8249f871222400db54ff78e64b809d723a02bf");
+
+// Keccak256("ReceivedErc20(address,address,uint256,bytes32)")
 pub(crate) const RECEIVED_ERC20_EVENT_TOPIC: [u8; 32] =
     hex!("4d69d0bd4287b7f66c548f90154dc81bc98f65a1b362775df5ae171a2ccd262b");
+
+// Keccak256("ReceivedErc20(address,address,uint256,bytes32,bytes32)")
+pub(crate) const RECEIVED_ERC20_EVENT_WITH_SUBACCOUNT_TOPIC: [u8; 32] =
+    hex!("aef895090c2f5d6e81a70bef80dce496a0558487845aada57822159d5efae5cf");
 
 async fn mint() {
     use icrc_ledger_client_cdk::{CdkRuntime, ICRC1Client};

--- a/rs/ethereum/cketh/minter/src/endpoints.rs
+++ b/rs/ethereum/cketh/minter/src/endpoints.rs
@@ -366,7 +366,7 @@ pub mod events {
             from_address: String,
             value: Nat,
             principal: Principal,
-            subaccount: Option<String>,
+            subaccount: Option<[u8; 32]>,
         },
         AcceptedErc20Deposit {
             transaction_hash: String,
@@ -376,7 +376,7 @@ pub mod events {
             value: Nat,
             principal: Principal,
             erc20_contract_address: String,
-            subaccount: Option<String>,
+            subaccount: Option<[u8; 32]>,
         },
         InvalidDeposit {
             event_source: EventSource,

--- a/rs/ethereum/cketh/minter/src/endpoints.rs
+++ b/rs/ethereum/cketh/minter/src/endpoints.rs
@@ -366,6 +366,7 @@ pub mod events {
             from_address: String,
             value: Nat,
             principal: Principal,
+            subaccount: Option<String>,
         },
         AcceptedErc20Deposit {
             transaction_hash: String,
@@ -375,6 +376,7 @@ pub mod events {
             value: Nat,
             principal: Principal,
             erc20_contract_address: String,
+            subaccount: Option<String>,
         },
         InvalidDeposit {
             event_source: EventSource,

--- a/rs/ethereum/cketh/minter/src/eth_logs/mod.rs
+++ b/rs/ethereum/cketh/minter/src/eth_logs/mod.rs
@@ -12,9 +12,6 @@ use ic_canister_log::log;
 use ic_ethereum_types::Address;
 use minicbor::{Decode, Encode};
 use std::fmt;
-use std::fmt::{Display, Formatter};
-use std::num::ParseIntError;
-use std::str::FromStr;
 use thiserror::Error;
 
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Decode, Encode)]
@@ -453,19 +450,5 @@ impl LedgerSubaccount {
 
     pub fn to_bytes(self) -> [u8; 32] {
         self.0.to_be_bytes()
-    }
-}
-
-impl Display for LedgerSubaccount {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(f, "{:x}", self.0)
-    }
-}
-
-impl FromStr for LedgerSubaccount {
-    type Err = ParseIntError;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        InternalLedgerSubaccount::from_str_hex(s).map(LedgerSubaccount)
     }
 }

--- a/rs/ethereum/cketh/minter/src/eth_logs/mod.rs
+++ b/rs/ethereum/cketh/minter/src/eth_logs/mod.rs
@@ -333,7 +333,7 @@ impl TryFrom<LogEntry> for ReceivedEvent {
                 };
                 let from_address = parse_address(&entry.topics[1])?;
                 let principal = parse_principal(&entry.topics[2])?;
-                let [value_bytes] = parse_data_into_32_bytes_words(entry.data, event_source)?;
+                let [value_bytes] = parse_data_into_32_byte_words(entry.data, event_source)?;
                 Ok(ReceivedEthEvent {
                     transaction_hash,
                     block_number,
@@ -359,7 +359,7 @@ impl TryFrom<LogEntry> for ReceivedEvent {
                 let from_address = parse_address(&entry.topics[1])?;
                 let principal = parse_principal(&entry.topics[2])?;
                 let [value_bytes, subaccount_bytes] =
-                    parse_data_into_32_bytes_words(entry.data, event_source)?;
+                    parse_data_into_32_byte_words(entry.data, event_source)?;
                 let value = Wei::from_be_bytes(value_bytes);
                 let subaccount = LedgerSubaccount::from_bytes(subaccount_bytes);
                 Ok(ReceivedEthEvent {
@@ -387,7 +387,7 @@ impl TryFrom<LogEntry> for ReceivedEvent {
                 let erc20_contract_address = parse_address(&entry.topics[1])?;
                 let from_address = parse_address(&entry.topics[2])?;
                 let principal = parse_principal(&entry.topics[3])?;
-                let [value_bytes] = parse_data_into_32_bytes_words(entry.data, event_source)?;
+                let [value_bytes] = parse_data_into_32_byte_words(entry.data, event_source)?;
                 Ok(ReceivedErc20Event {
                     transaction_hash,
                     block_number,
@@ -415,7 +415,7 @@ impl TryFrom<LogEntry> for ReceivedEvent {
                 let from_address = parse_address(&entry.topics[2])?;
                 let principal = parse_principal(&entry.topics[3])?;
                 let [value_bytes, subaccount_bytes] =
-                    parse_data_into_32_bytes_words(entry.data, event_source)?;
+                    parse_data_into_32_byte_words(entry.data, event_source)?;
                 let value = Erc20Value::from_be_bytes(value_bytes);
                 let subaccount = LedgerSubaccount::from_bytes(subaccount_bytes);
                 Ok(ReceivedErc20Event {
@@ -441,7 +441,7 @@ impl TryFrom<LogEntry> for ReceivedEvent {
     }
 }
 
-fn parse_data_into_32_bytes_words<const N: usize>(
+fn parse_data_into_32_byte_words<const N: usize>(
     data: Data,
     event_source: EventSource,
 ) -> Result<[[u8; 32]; N], ReceivedEventError> {

--- a/rs/ethereum/cketh/minter/src/eth_logs/tests.rs
+++ b/rs/ethereum/cketh/minter/src/eth_logs/tests.rs
@@ -119,16 +119,25 @@ mod parse_principal_from_slice {
 }
 
 mod subaccount {
-    use crate::eth_logs::Subaccount;
+    use crate::eth_logs::LedgerSubaccount;
     use proptest::{array::uniform32, prelude::any, prop_assert_eq, proptest};
 
     proptest! {
         #[test]
         fn should_preserve_bytes_representation(bytes in uniform32(any::<u8>())) {
-            let subaccount = Subaccount::from_bytes(bytes);
+            let subaccount = LedgerSubaccount::from_bytes(bytes);
             let actual_bytes = subaccount.to_bytes();
 
             prop_assert_eq!(bytes, actual_bytes);
+        }
+
+        #[test]
+        fn should_decode_string_representation(bytes in uniform32(any::<u8>())) {
+            let subaccount = LedgerSubaccount::from_bytes(bytes);
+            let hex_subaccount = subaccount.to_string();
+            let decoded_subaccount = hex_subaccount.parse::<LedgerSubaccount>().unwrap();
+
+            prop_assert_eq!(subaccount, decoded_subaccount);
         }
     }
 }

--- a/rs/ethereum/cketh/minter/src/eth_logs/tests.rs
+++ b/rs/ethereum/cketh/minter/src/eth_logs/tests.rs
@@ -117,3 +117,18 @@ mod parse_principal_from_slice {
         principal_bytes
     }
 }
+
+mod subaccount {
+    use crate::eth_logs::Subaccount;
+    use proptest::{array::uniform32, prelude::any, prop_assert_eq, proptest};
+
+    proptest! {
+        #[test]
+        fn should_preserve_bytes_representation(bytes in uniform32(any::<u8>())) {
+            let subaccount = Subaccount::from_bytes(bytes);
+            let actual_bytes = subaccount.to_bytes();
+
+            prop_assert_eq!(bytes, actual_bytes);
+        }
+    }
+}

--- a/rs/ethereum/cketh/minter/src/eth_logs/tests.rs
+++ b/rs/ethereum/cketh/minter/src/eth_logs/tests.rs
@@ -120,12 +120,13 @@ mod parse_principal_from_slice {
 
 mod subaccount {
     use crate::eth_logs::LedgerSubaccount;
-    use proptest::{array::uniform32, prelude::any, prop_assert_eq, proptest};
+    use proptest::{array::uniform32, prelude::any, prop_assert_eq, prop_assume, proptest};
 
     proptest! {
         #[test]
         fn should_preserve_bytes_representation(bytes in uniform32(any::<u8>())) {
-            let subaccount = LedgerSubaccount::from_bytes(bytes);
+            prop_assume!(bytes != [0_u8; 32]);
+            let subaccount = LedgerSubaccount::from_bytes(bytes).unwrap();
             let actual_bytes = subaccount.to_bytes();
 
             prop_assert_eq!(bytes, actual_bytes);

--- a/rs/ethereum/cketh/minter/src/eth_logs/tests.rs
+++ b/rs/ethereum/cketh/minter/src/eth_logs/tests.rs
@@ -130,14 +130,5 @@ mod subaccount {
 
             prop_assert_eq!(bytes, actual_bytes);
         }
-
-        #[test]
-        fn should_decode_string_representation(bytes in uniform32(any::<u8>())) {
-            let subaccount = LedgerSubaccount::from_bytes(bytes);
-            let hex_subaccount = subaccount.to_string();
-            let decoded_subaccount = hex_subaccount.parse::<LedgerSubaccount>().unwrap();
-
-            prop_assert_eq!(subaccount, decoded_subaccount);
-        }
     }
 }

--- a/rs/ethereum/cketh/minter/src/main.rs
+++ b/rs/ethereum/cketh/minter/src/main.rs
@@ -635,7 +635,7 @@ fn get_events(arg: GetEventsArg) -> GetEventsResult {
                     from_address: from_address.to_string(),
                     value: value.into(),
                     principal,
-                    subaccount: subaccount.map(|s| s.to_string()),
+                    subaccount: subaccount.map(|s| s.to_bytes()),
                 },
                 EventType::AcceptedErc20Deposit(ReceivedErc20Event {
                     transaction_hash,
@@ -654,7 +654,7 @@ fn get_events(arg: GetEventsArg) -> GetEventsResult {
                     value: value.into(),
                     principal,
                     erc20_contract_address: erc20_contract_address.to_string(),
-                    subaccount: subaccount.map(|s| s.to_string()),
+                    subaccount: subaccount.map(|s| s.to_bytes()),
                 },
                 EventType::InvalidDeposit {
                     event_source,

--- a/rs/ethereum/cketh/minter/src/main.rs
+++ b/rs/ethereum/cketh/minter/src/main.rs
@@ -627,6 +627,7 @@ fn get_events(arg: GetEventsArg) -> GetEventsResult {
                     from_address,
                     value,
                     principal,
+                    subaccount,
                 }) => EP::AcceptedDeposit {
                     transaction_hash: transaction_hash.to_string(),
                     block_number: block_number.into(),
@@ -634,6 +635,7 @@ fn get_events(arg: GetEventsArg) -> GetEventsResult {
                     from_address: from_address.to_string(),
                     value: value.into(),
                     principal,
+                    subaccount: subaccount.map(|s| s.to_string()),
                 },
                 EventType::AcceptedErc20Deposit(ReceivedErc20Event {
                     transaction_hash,
@@ -643,6 +645,7 @@ fn get_events(arg: GetEventsArg) -> GetEventsResult {
                     value,
                     principal,
                     erc20_contract_address,
+                    subaccount,
                 }) => EP::AcceptedErc20Deposit {
                     transaction_hash: transaction_hash.to_string(),
                     block_number: block_number.into(),
@@ -651,6 +654,7 @@ fn get_events(arg: GetEventsArg) -> GetEventsResult {
                     value: value.into(),
                     principal,
                     erc20_contract_address: erc20_contract_address.to_string(),
+                    subaccount: subaccount.map(|s| s.to_string()),
                 },
                 EventType::InvalidDeposit {
                     event_source,

--- a/rs/ethereum/cketh/minter/src/memo/tests.rs
+++ b/rs/ethereum/cketh/minter/src/memo/tests.rs
@@ -65,6 +65,7 @@ fn encode_mint_convert_memo_is_stable() {
         from_address,
         value: Wei::from(10_000_000_000_000_000_u128),
         principal: Principal::from_str("2chl6-4hpzw-vqaaa-aaaaa-c").unwrap(),
+        subaccount: None,
     };
     let memo: Memo = (&ReceivedEvent::from(event)).into();
 

--- a/rs/ethereum/cketh/minter/src/state/audit/tests.rs
+++ b/rs/ethereum/cketh/minter/src/state/audit/tests.rs
@@ -257,7 +257,7 @@ impl GetEventsFile {
                     from_address: from_address.parse().unwrap(),
                     value: value.try_into().unwrap(),
                     principal,
-                    subaccount: subaccount.map(LedgerSubaccount::from_bytes),
+                    subaccount: subaccount.and_then(LedgerSubaccount::from_bytes),
                 }),
                 EventPayload::AcceptedErc20Deposit {
                     transaction_hash,
@@ -276,7 +276,7 @@ impl GetEventsFile {
                     value: value.try_into().unwrap(),
                     principal,
                     erc20_contract_address: erc20_contract_address.parse().unwrap(),
-                    subaccount: subaccount.map(LedgerSubaccount::from_bytes),
+                    subaccount: subaccount.and_then(LedgerSubaccount::from_bytes),
                 }),
                 EventPayload::InvalidDeposit {
                     event_source,

--- a/rs/ethereum/cketh/minter/src/state/audit/tests.rs
+++ b/rs/ethereum/cketh/minter/src/state/audit/tests.rs
@@ -1,7 +1,7 @@
 use crate::checked_amount::CheckedAmountOf;
 use crate::endpoints::events::{Event as CandidEvent, EventPayload, UnsignedTransaction};
 use crate::erc20::CkErc20Token;
-use crate::eth_logs::{ReceivedErc20Event, ReceivedEthEvent};
+use crate::eth_logs::{LedgerSubaccount, ReceivedErc20Event, ReceivedEthEvent};
 use crate::eth_rpc_client::responses::TransactionReceipt;
 use crate::lifecycle::EthereumNetwork;
 use crate::numeric::Wei;
@@ -257,7 +257,7 @@ impl GetEventsFile {
                     from_address: from_address.parse().unwrap(),
                     value: value.try_into().unwrap(),
                     principal,
-                    subaccount: subaccount.map(|s| s.parse().unwrap()),
+                    subaccount: subaccount.map(LedgerSubaccount::from_bytes),
                 }),
                 EventPayload::AcceptedErc20Deposit {
                     transaction_hash,
@@ -276,7 +276,7 @@ impl GetEventsFile {
                     value: value.try_into().unwrap(),
                     principal,
                     erc20_contract_address: erc20_contract_address.parse().unwrap(),
-                    subaccount: subaccount.map(|s| s.parse().unwrap()),
+                    subaccount: subaccount.map(LedgerSubaccount::from_bytes),
                 }),
                 EventPayload::InvalidDeposit {
                     event_source,

--- a/rs/ethereum/cketh/minter/src/state/audit/tests.rs
+++ b/rs/ethereum/cketh/minter/src/state/audit/tests.rs
@@ -249,6 +249,7 @@ impl GetEventsFile {
                     from_address,
                     value,
                     principal,
+                    subaccount,
                 } => ET::AcceptedDeposit(ReceivedEthEvent {
                     transaction_hash: transaction_hash.parse().unwrap(),
                     block_number: block_number.try_into().unwrap(),
@@ -256,6 +257,7 @@ impl GetEventsFile {
                     from_address: from_address.parse().unwrap(),
                     value: value.try_into().unwrap(),
                     principal,
+                    subaccount: subaccount.map(|s| s.parse().unwrap()),
                 }),
                 EventPayload::AcceptedErc20Deposit {
                     transaction_hash,
@@ -265,6 +267,7 @@ impl GetEventsFile {
                     value,
                     principal,
                     erc20_contract_address,
+                    subaccount,
                 } => ET::AcceptedErc20Deposit(ReceivedErc20Event {
                     transaction_hash: transaction_hash.parse().unwrap(),
                     block_number: block_number.try_into().unwrap(),
@@ -273,6 +276,7 @@ impl GetEventsFile {
                     value: value.try_into().unwrap(),
                     principal,
                     erc20_contract_address: erc20_contract_address.parse().unwrap(),
+                    subaccount: subaccount.map(|s| s.parse().unwrap()),
                 }),
                 EventPayload::InvalidDeposit {
                     event_source,

--- a/rs/ethereum/cketh/minter/src/state/tests.rs
+++ b/rs/ethereum/cketh/minter/src/state/tests.rs
@@ -26,7 +26,6 @@ use ethnum::u256;
 use ic_ethereum_types::Address;
 use proptest::array::uniform32;
 use proptest::collection::vec as pvec;
-use proptest::option;
 use proptest::prelude::*;
 use std::collections::BTreeMap;
 
@@ -536,7 +535,7 @@ fn arb_principal() -> impl Strategy<Value = Principal> {
     pvec(any::<u8>(), 0..=29).prop_map(|bytes| Principal::from_slice(&bytes))
 }
 
-fn arb_ledger_subaccount() -> impl Strategy<Value = LedgerSubaccount> {
+fn arb_ledger_subaccount() -> impl Strategy<Value = Option<LedgerSubaccount>> {
     uniform32(any::<u8>()).prop_map(LedgerSubaccount::from_bytes)
 }
 
@@ -635,7 +634,7 @@ prop_compose! {
         from_address in arb_address(),
         value in arb_checked_amount_of(),
         principal in arb_principal(),
-        subaccount in option::of(arb_ledger_subaccount()),
+        subaccount in arb_ledger_subaccount(),
     ) -> ReceivedEthEvent {
         ReceivedEthEvent {
             transaction_hash,
@@ -658,7 +657,7 @@ prop_compose! {
         value in arb_checked_amount_of(),
         principal in arb_principal(),
         erc20_contract_address in arb_address(),
-        subaccount in option::of(arb_ledger_subaccount()),
+        subaccount in arb_ledger_subaccount(),
     ) -> ReceivedErc20Event {
         ReceivedErc20Event {
             transaction_hash,

--- a/rs/ethereum/cketh/minter/src/tests.rs
+++ b/rs/ethereum/cketh/minter/src/tests.rs
@@ -136,6 +136,7 @@ mod eth_get_logs {
                 .unwrap(),
             value: Wei::from(10_000_000_000_000_000_u128),
             principal: Principal::from_str("2chl6-4hpzw-vqaaa-aaaaa-c").unwrap(),
+            subaccount: None,
         }
         .into();
 
@@ -179,6 +180,7 @@ mod eth_get_logs {
             erc20_contract_address: "0x7439e9bb6d8a84dd3a23fe621a30f95403f87fb9"
                 .parse()
                 .unwrap(),
+            subaccount: None,
         }
         .into();
 

--- a/rs/ethereum/cketh/minter/tests/ckerc20.rs
+++ b/rs/ethereum/cketh/minter/tests/ckerc20.rs
@@ -1355,6 +1355,7 @@ fn should_deposit_cketh_and_ckerc20_when_ledger_temporary_offline() {
                 from_address: format_ethereum_address_to_eip_55(DEFAULT_DEPOSIT_FROM_ADDRESS),
                 value: CKETH_MINIMUM_WITHDRAWAL_AMOUNT.into(),
                 principal: caller,
+                subaccount: None,
             },
             EventPayload::AcceptedErc20Deposit {
                 transaction_hash: DEFAULT_ERC20_DEPOSIT_TRANSACTION_HASH.to_string(),
@@ -1364,6 +1365,7 @@ fn should_deposit_cketh_and_ckerc20_when_ledger_temporary_offline() {
                 value: ONE_USDC.into(),
                 principal: caller,
                 erc20_contract_address: ckusdc.erc20_contract_address.clone(),
+                subaccount: None,
             },
         ])
         .check_events()

--- a/rs/ethereum/cketh/test_utils/src/ckerc20.rs
+++ b/rs/ethereum/cketh/test_utils/src/ckerc20.rs
@@ -484,6 +484,7 @@ impl CkErc20DepositFlow {
                         ),
                         value: amount.into(),
                         principal: self.params.recipient,
+                        subaccount: None,
                     },
                     EventPayload::MintedCkEth {
                         event_source: EventSource {
@@ -505,6 +506,7 @@ impl CkErc20DepositFlow {
                 value: self.params.ckerc20_amount.into(),
                 principal: self.params.recipient,
                 erc20_contract_address: self.params.token.erc20_contract_address.clone(),
+                subaccount: None,
             },
             EventPayload::MintedCkErc20 {
                 event_source: EventSource {

--- a/rs/ethereum/cketh/test_utils/src/flow.rs
+++ b/rs/ethereum/cketh/test_utils/src/flow.rs
@@ -116,6 +116,7 @@ impl DepositFlow {
                 from_address: self.params.from_address.to_string(),
                 value: Nat::from(self.params.amount),
                 principal: self.params.recipient,
+                subaccount: None,
             },
         );
         assert_contains_unique_event(


### PR DESCRIPTION
Parse deposit events originating from the smart contract introduced in #2143, which additionally contain an optional ledger subaccount. The events from that smart contract are not yet scraped, which will be done in a follow-up PR.