### PR TITLE
feat(sns): Make very old swaps not require periodic tasks

### DIFF
--- a/rs/sns/integration_tests/src/golden_state_swap_upgrade_twice.rs
+++ b/rs/sns/integration_tests/src/golden_state_swap_upgrade_twice.rs
@@ -1,8 +1,9 @@
+use assert_matches::assert_matches;
 use candid::{Decode, Encode};
 use ic_nns_test_utils::sns_wasm::{
     build_swap_sns_wasm, create_modified_sns_wasm, ensure_sns_wasm_gzipped,
 };
-use ic_sns_swap::pb::v1::{DerivedState, GetStateRequest, GetStateResponse, Swap};
+use ic_sns_swap::pb::v1::{DerivedState, GetStateRequest, GetStateResponse, Swap, Timers};
 use ic_sns_wasm::pb::v1::SnsWasm;
 use ic_state_machine_tests::StateMachine;
 use ic_types::{CanisterId, PrincipalId};
@@ -104,6 +105,18 @@ fn run_test_for_swap(state_machine: &StateMachine, swap_canister_id: &str, sns_n
     {
         let (mut swap_pre_state, mut swap_post_state) =
             run_upgrade_for_swap(state_machine, swap_canister_id, swap_wasm_1, sns_name);
+
+        // Ensure the timers are not going to be scheduled for this Swap.
+        assert_matches!(
+            swap_post_state.swap,
+            Some(Swap {
+                timers: Some(Timers {
+                    requires_periodic_tasks: Some(false),
+                    ..
+                }),
+                ..
+            })
+        );
 
         // Some fields need to be redacted as they were introduced after some Swaps were created.
         redact_unavailable_swap_fields(&mut swap_post_state);

--- a/rs/sns/swap/src/swap.rs
+++ b/rs/sns/swap/src/swap.rs
@@ -676,9 +676,10 @@ impl Swap {
     ///
     /// See also: `Swap.run_periodic_tasks`.
     pub fn requires_periodic_tasks(&self) -> bool {
-        // Practically, already_tried_to_auto_finalize should never be None, but we err towards
-        // caution, which in this case means to continue scheduling periodic tasks.
-        !self.lifecycle_is_terminal() || !self.already_tried_to_auto_finalize.unwrap_or(false)
+        // Practically, already_tried_to_auto_finalize should never be None, unless a Swap has not
+        // been updated since this field had been introduced. We default this field to `true` to
+        // capture those old Swaps (which were finalized manually).
+        !self.lifecycle_is_terminal() || !self.already_tried_to_auto_finalize.unwrap_or(true)
     }
 
     //


### PR DESCRIPTION
This PR ensures that very old swaps that were finalized manually (as opposed to automatically) do not require periodic tasks.

Regression testing included.