### PR TITLE
feat(sns): Add the upgrade_journal to the get_upgrade_journal SNS-Gov endpoint

### DIFF
--- a/rs/sns/governance/canister/governance.did
+++ b/rs/sns/governance/canister/governance.did
@@ -292,7 +292,7 @@ type Governance = record {
   genesis_timestamp_seconds : nat64;
   target_version : opt Version;
   timers : opt Timers;
-  upgrade_journal : opt UpgradeJournalEntries;
+  upgrade_journal : opt UpgradeJournal;
 };
 
 type Timers = record {
@@ -721,8 +721,8 @@ type WaitForQuietState = record {
 };
 
 type UpgradeJournalEntry = record {
-  entry : opt variant {
-    UpgradeStepsRefresh : UpgradeStepsRefresh;
+  event : opt variant {
+    UpgradeStepsRefreshed : UpgradeStepsRefreshed;
     TargetVersionSet : TargetVersionSet;
     UpgradeStarted : UpgradeStarted;
     UpgradeCompleted : UpgradeCompleted;
@@ -730,7 +730,7 @@ type UpgradeJournalEntry = record {
   timestamp_seconds : opt nat64;
 };
 
-type UpgradeStepsRefresh = record {
+type UpgradeStepsRefreshed = record {
   upgrade_steps : opt Versions;
 };
 
@@ -741,18 +741,23 @@ type TargetVersionSet = record {
 type UpgradeStarted = record {
   current_version : opt Version;
   expected_version : opt Version;
+  triggerer : opt variant {
+    UpgradeSnsToNextVersion : ProposalId;
+    BehindTargetVersion : record {};
+  }
 };
 
 type UpgradeCompleted = record {
+  human_readable : opt text;
   status : opt variant {
     Succeeded : record {};
     TimedOut : record {};
-    InvalidState : Version;
+    InvalidState : record { version : opt Version };
     CanisterCallFailure : record {};
   };
 };
 
-type UpgradeJournalEntries = record {
+type UpgradeJournal = record {
   entries : vec UpgradeJournalEntry;
 };
 
@@ -762,7 +767,7 @@ type GetUpgradeJournalResponse = record {
   upgrade_steps : opt Versions;
   response_timestamp_seconds : opt nat64;
   target_version : opt Version;
-  journal : opt UpgradeJournalEntries;
+  upgrade_journal : opt UpgradeJournal;
 };
 
 service : (Governance) -> {

--- a/rs/sns/governance/canister/governance.did
+++ b/rs/sns/governance/canister/governance.did
@@ -724,8 +724,9 @@ type UpgradeJournalEntry = record {
   event : opt variant {
     UpgradeStepsRefreshed : UpgradeStepsRefreshed;
     TargetVersionSet : TargetVersionSet;
+    TargetVersionReset : TargetVersionSet;
     UpgradeStarted : UpgradeStarted;
-    UpgradeCompleted : UpgradeCompleted;
+    UpgradeOutcome : UpgradeOutcome;
   };
   timestamp_seconds : opt nat64;
 };
@@ -735,25 +736,26 @@ type UpgradeStepsRefreshed = record {
 };
 
 type TargetVersionSet = record {
-  version : opt Version;
+  new_target_version : opt Version;
+  old_target_version : opt Version;
 };
 
 type UpgradeStarted = record {
   current_version : opt Version;
   expected_version : opt Version;
-  triggerer : opt variant {
-    UpgradeSnsToNextVersion : ProposalId;
+  reason : opt variant {
+    UpgradeSnsToNextVersionProposal : ProposalId;
     BehindTargetVersion : record {};
   }
 };
 
-type UpgradeCompleted = record {
+type UpgradeOutcome = record {
   human_readable : opt text;
   status : opt variant {
-    Succeeded : record {};
-    TimedOut : record {};
+    Success : record {};
+    Timeout : record {};
     InvalidState : record { version : opt Version };
-    CanisterCallFailure : record {};
+    ExternalFailure : record {};
   };
 };
 

--- a/rs/sns/governance/canister/governance.did
+++ b/rs/sns/governance/canister/governance.did
@@ -290,8 +290,9 @@ type Governance = record {
   sns_metadata : opt ManageSnsMetadata;
   neurons : vec record { text; Neuron };
   genesis_timestamp_seconds : nat64;
-  target_version: opt Version;
+  target_version : opt Version;
   timers : opt Timers;
+  upgrade_journal : opt UpgradeJournalEntries;
 };
 
 type Timers = record {
@@ -719,12 +720,49 @@ type WaitForQuietState = record {
   current_deadline_timestamp_seconds : nat64;
 };
 
+type UpgradeJournalEntry = record {
+  entry : opt variant {
+    UpgradeStepsRefresh : UpgradeStepsRefresh;
+    TargetVersionSet : TargetVersionSet;
+    UpgradeStarted : UpgradeStarted;
+    UpgradeCompleted : UpgradeCompleted;
+  };
+  timestamp_seconds : opt nat64;
+};
+
+type UpgradeStepsRefresh = record {
+  upgrade_steps : opt Versions;
+};
+
+type TargetVersionSet = record {
+  version : opt Version;
+};
+
+type UpgradeStarted = record {
+  current_version : opt Version;
+  expected_version : opt Version;
+};
+
+type UpgradeCompleted = record {
+  status : opt variant {
+    Succeeded : record {};
+    TimedOut : record {};
+    InvalidState : Version;
+    CanisterCallFailure : record {};
+  };
+};
+
+type UpgradeJournalEntries = record {
+  entries : vec UpgradeJournalEntry;
+};
+
 type GetUpgradeJournalRequest = record {};
 
 type GetUpgradeJournalResponse = record {
   upgrade_steps : opt Versions;
   response_timestamp_seconds : opt nat64;
   target_version : opt Version;
+  journal : opt UpgradeJournalEntries;
 };
 
 service : (Governance) -> {
@@ -740,13 +778,9 @@ service : (Governance) -> {
   get_proposal : (GetProposal) -> (GetProposalResponse) query;
   get_root_canister_status : (null) -> (CanisterStatusResultV2);
   get_running_sns_version : (record {}) -> (GetRunningSnsVersionResponse) query;
-  get_sns_initialization_parameters : (record {}) -> (
-      GetSnsInitializationParametersResponse,
-    ) query;
+  get_sns_initialization_parameters : (record {}) -> (GetSnsInitializationParametersResponse) query;
   get_upgrade_journal : (GetUpgradeJournalRequest) -> (GetUpgradeJournalResponse) query;
-  list_nervous_system_functions : () -> (
-      ListNervousSystemFunctionsResponse,
-    ) query;
+  list_nervous_system_functions : () -> (ListNervousSystemFunctionsResponse) query;
   list_neurons : (ListNeurons) -> (ListNeuronsResponse) query;
   list_proposals : (ListProposals) -> (ListProposalsResponse) query;
   manage_neuron : (ManageNeuron) -> (ManageNeuronResponse);

--- a/rs/sns/governance/canister/governance_test.did
+++ b/rs/sns/governance/canister/governance_test.did
@@ -301,6 +301,7 @@ type Governance = record {
   genesis_timestamp_seconds : nat64;
   target_version: opt Version;
   timers : opt Timers;
+  upgrade_journal : opt UpgradeJournalEntries;
 };
 
 type Timers = record {
@@ -733,12 +734,49 @@ type WaitForQuietState = record {
   current_deadline_timestamp_seconds : nat64;
 };
 
+type UpgradeJournalEntry = record {
+  entry : opt variant {
+    UpgradeStepsRefresh : UpgradeStepsRefresh;
+    TargetVersionSet : TargetVersionSet;
+    UpgradeStarted : UpgradeStarted;
+    UpgradeCompleted : UpgradeCompleted;
+  };
+  timestamp_seconds : opt nat64;
+};
+
+type UpgradeStepsRefresh = record {
+  upgrade_steps : opt Versions;
+};
+
+type TargetVersionSet = record {
+  version : opt Version;
+};
+
+type UpgradeStarted = record {
+  current_version : opt Version;
+  expected_version : opt Version;
+};
+
+type UpgradeCompleted = record {
+  status : opt variant {
+    Succeeded : record {};
+    TimedOut : record {};
+    InvalidState : Version;
+    CanisterCallFailure : record {};
+  };
+};
+
+type UpgradeJournalEntries = record {
+  entries : vec UpgradeJournalEntry;
+};
+
 type GetUpgradeJournalRequest = record {};
 
 type GetUpgradeJournalResponse = record {
   upgrade_steps : opt Versions;
   response_timestamp_seconds : opt nat64;
   target_version : opt Version;
+  journal : opt UpgradeJournalEntries;
 };
 
 type AdvanceTargetVersionRequest = record { target_version : opt Version; };

--- a/rs/sns/governance/canister/governance_test.did
+++ b/rs/sns/governance/canister/governance_test.did
@@ -738,8 +738,9 @@ type UpgradeJournalEntry = record {
   event : opt variant {
     UpgradeStepsRefreshed : UpgradeStepsRefreshed;
     TargetVersionSet : TargetVersionSet;
+    TargetVersionReset : TargetVersionSet;
     UpgradeStarted : UpgradeStarted;
-    UpgradeCompleted : UpgradeCompleted;
+    UpgradeOutcome : UpgradeOutcome;
   };
   timestamp_seconds : opt nat64;
 };
@@ -749,25 +750,26 @@ type UpgradeStepsRefreshed = record {
 };
 
 type TargetVersionSet = record {
-  version : opt Version;
+  new_target_version : opt Version;
+  old_target_version : opt Version;
 };
 
 type UpgradeStarted = record {
   current_version : opt Version;
   expected_version : opt Version;
-  triggerer : opt variant {
-    UpgradeSnsToNextVersion : ProposalId;
+  reason : opt variant {
+    UpgradeSnsToNextVersionProposal : ProposalId;
     BehindTargetVersion : record {};
   }
 };
 
-type UpgradeCompleted = record {
+type UpgradeOutcome = record {
   human_readable : opt text;
   status : opt variant {
-    Succeeded : record {};
-    TimedOut : record {};
+    Success : record {};
+    Timeout : record {};
     InvalidState : record { version : opt Version };
-    CanisterCallFailure : record {};
+    ExternalFailure : record {};
   };
 };
 

--- a/rs/sns/governance/canister/governance_test.did
+++ b/rs/sns/governance/canister/governance_test.did
@@ -301,7 +301,7 @@ type Governance = record {
   genesis_timestamp_seconds : nat64;
   target_version: opt Version;
   timers : opt Timers;
-  upgrade_journal : opt UpgradeJournalEntries;
+  upgrade_journal : opt UpgradeJournal;
 };
 
 type Timers = record {
@@ -735,8 +735,8 @@ type WaitForQuietState = record {
 };
 
 type UpgradeJournalEntry = record {
-  entry : opt variant {
-    UpgradeStepsRefresh : UpgradeStepsRefresh;
+  event : opt variant {
+    UpgradeStepsRefreshed : UpgradeStepsRefreshed;
     TargetVersionSet : TargetVersionSet;
     UpgradeStarted : UpgradeStarted;
     UpgradeCompleted : UpgradeCompleted;
@@ -744,7 +744,7 @@ type UpgradeJournalEntry = record {
   timestamp_seconds : opt nat64;
 };
 
-type UpgradeStepsRefresh = record {
+type UpgradeStepsRefreshed = record {
   upgrade_steps : opt Versions;
 };
 
@@ -755,18 +755,23 @@ type TargetVersionSet = record {
 type UpgradeStarted = record {
   current_version : opt Version;
   expected_version : opt Version;
+  triggerer : opt variant {
+    UpgradeSnsToNextVersion : ProposalId;
+    BehindTargetVersion : record {};
+  }
 };
 
 type UpgradeCompleted = record {
+  human_readable : opt text;
   status : opt variant {
     Succeeded : record {};
     TimedOut : record {};
-    InvalidState : Version;
+    InvalidState : record { version : opt Version };
     CanisterCallFailure : record {};
   };
 };
 
-type UpgradeJournalEntries = record {
+type UpgradeJournal = record {
   entries : vec UpgradeJournalEntry;
 };
 
@@ -776,7 +781,7 @@ type GetUpgradeJournalResponse = record {
   upgrade_steps : opt Versions;
   response_timestamp_seconds : opt nat64;
   target_version : opt Version;
-  journal : opt UpgradeJournalEntries;
+  upgrade_journal : opt UpgradeJournal;
 };
 
 type AdvanceTargetVersionRequest = record { target_version : opt Version; };

--- a/rs/sns/governance/proto/ic_sns_governance/pb/v1/governance.proto
+++ b/rs/sns/governance/proto/ic_sns_governance/pb/v1/governance.proto
@@ -2160,37 +2160,39 @@ message UpgradeJournalEntry {
   oneof event {
     UpgradeStepsRefreshed upgrade_steps_refreshed = 1;
     TargetVersionSet target_version_set = 2;
-    UpgradeStarted upgrade_started = 3;
-    UpgradeCompleted upgrade_completed = 4;
+    TargetVersionSet target_version_reset = 3;
+    UpgradeStarted upgrade_started = 4;
+    UpgradeOutcome upgrade_outcome = 5;
   }
-  optional uint64 timestamp_seconds = 5;
+  optional uint64 timestamp_seconds = 6;
 
   message UpgradeStepsRefreshed {
     optional Governance.Versions upgrade_steps = 2;
   }
 
   message TargetVersionSet {
-    optional Governance.Version version = 1;
+    optional Governance.Version old_target_version = 1;
+    optional Governance.Version new_target_version = 2;
   }
 
   message UpgradeStarted {
     optional Governance.Version current_version = 1;
     optional Governance.Version expected_version = 2;
-    oneof triggerer {
-      ProposalId upgrade_sns_to_next_version = 3;
+    oneof reason {
+      ProposalId upgrade_sns_to_next_version_proposal = 3;
       Empty behind_target_version = 4;
     }
   }
 
-  message UpgradeCompleted {
+  message UpgradeOutcome {
     optional string human_readable = 1;
 
     oneof status {
-      Empty succeeded = 2;
-      Empty timed_out = 3;
+      Empty success = 2;
+      Empty timeout = 3;
       // The SNS ended up being upgraded to a version that was not the expected one.
       InvalidState invalid_state = 4;
-      Empty canister_call_failure = 5;
+      Empty external_failure = 5;
     }
 
     message InvalidState {

--- a/rs/sns/governance/proto/ic_sns_governance/pb/v1/governance.proto
+++ b/rs/sns/governance/proto/ic_sns_governance/pb/v1/governance.proto
@@ -2189,8 +2189,7 @@ message UpgradeJournalEntry {
   }
 }
 
-// Needed to cause prost to generate a type isomorphic to
-// Option<Vec<UpgradeJournalEntry>>.
+// Needed to cause prost to generate a type isomorphic to Option<Vec<UpgradeJournalEntry>>.
 message UpgradeJournalEntries {
   // The entries in the upgrade journal.
   repeated UpgradeJournalEntry entries = 1;

--- a/rs/sns/governance/proto/ic_sns_governance/pb/v1/governance.proto
+++ b/rs/sns/governance/proto/ic_sns_governance/pb/v1/governance.proto
@@ -1473,6 +1473,21 @@ message Governance {
 
   // Information about the timers that perform periodic tasks of this Governance canister.
   optional ic_nervous_system.pb.v1.Timers timers = 31;
+
+  UpgradeJournalEntries upgrade_journal = 32;
+}
+
+message Timers {
+  optional uint64 last_reset_timestamp_seconds = 1;
+  optional uint64 last_spawned_timestamp_seconds = 2;
+}
+
+message ResetTimersRequest {}
+message ResetTimersResponse {}
+
+message GetTimersRequest {}
+message GetTimersResponse {
+  optional Timers timers = 1;
 }
 
 // Request message for 'get_metadata'.
@@ -2140,6 +2155,47 @@ message AdvanceTargetVersionRequest {
 // The response to a request to advance the target version of the SNS.
 message AdvanceTargetVersionResponse {}
 
+// Represents a single entry in the upgrade journal.
+message UpgradeJournalEntry {
+  oneof entry {
+    UpgradeStepsRefresh upgrade_steps_refresh = 1;
+    TargetVersionSet target_version_set = 2;
+    UpgradeStarted upgrade_started = 3;
+    UpgradeCompleted upgrade_completed = 4;
+  }
+  optional uint64 timestamp_seconds = 5;
+
+  message UpgradeStepsRefresh {
+    optional Governance.Versions upgrade_steps = 2;
+  }
+
+  message TargetVersionSet {
+    optional Governance.Version version = 2;
+  }
+
+  message UpgradeStarted {
+    optional Governance.Version current_version = 2;
+    optional Governance.Version expected_version = 3;
+  }
+
+  message UpgradeCompleted {
+    oneof status {
+      Empty succeeded = 1;
+      Empty timed_out = 2;
+      // The SNS ended up being upgraded to a version that was not the expected one.
+      Governance.Version invalid_state = 3;
+      Empty canister_call_failure = 4;
+    }
+  }
+}
+
+// Needed to cause prost to generate a type isomorphic to
+// Option<Vec<UpgradeJournalEntry>>.
+message UpgradeJournalEntries {
+  // The entries in the upgrade journal.
+  repeated UpgradeJournalEntry entries = 1;
+}
+
 // The upgrade journal contains all the information neede to audit previous SNS upgrades and understand its current state.
 // It is being implemented as part of the "effortless SNS upgrade" feature.
 message GetUpgradeJournalRequest {}
@@ -2151,6 +2207,8 @@ message GetUpgradeJournalResponse {
   // Currently, this field is always None, but in the "effortless SNS upgrade"
   // feature, it reflect the version of the SNS that the community has decided to upgrade to.
   Governance.Version target_version = 3;
+
+  UpgradeJournalEntries journal = 4;
 }
 
 // A request to mint tokens for a particular principal. The associated endpoint

--- a/rs/sns/governance/proto/ic_sns_governance/pb/v1/governance.proto
+++ b/rs/sns/governance/proto/ic_sns_governance/pb/v1/governance.proto
@@ -1474,7 +1474,7 @@ message Governance {
   // Information about the timers that perform periodic tasks of this Governance canister.
   optional ic_nervous_system.pb.v1.Timers timers = 31;
 
-  UpgradeJournalEntries upgrade_journal = 32;
+  UpgradeJournal upgrade_journal = 32;
 }
 
 message Timers {
@@ -2157,40 +2157,50 @@ message AdvanceTargetVersionResponse {}
 
 // Represents a single entry in the upgrade journal.
 message UpgradeJournalEntry {
-  oneof entry {
-    UpgradeStepsRefresh upgrade_steps_refresh = 1;
+  oneof event {
+    UpgradeStepsRefreshed upgrade_steps_refreshed = 1;
     TargetVersionSet target_version_set = 2;
     UpgradeStarted upgrade_started = 3;
     UpgradeCompleted upgrade_completed = 4;
   }
   optional uint64 timestamp_seconds = 5;
 
-  message UpgradeStepsRefresh {
+  message UpgradeStepsRefreshed {
     optional Governance.Versions upgrade_steps = 2;
   }
 
   message TargetVersionSet {
-    optional Governance.Version version = 2;
+    optional Governance.Version version = 1;
   }
 
   message UpgradeStarted {
-    optional Governance.Version current_version = 2;
-    optional Governance.Version expected_version = 3;
+    optional Governance.Version current_version = 1;
+    optional Governance.Version expected_version = 2;
+    oneof triggerer {
+      ProposalId upgrade_sns_to_next_version = 3;
+      Empty behind_target_version = 4;
+    }
   }
 
   message UpgradeCompleted {
+    optional string human_readable = 1;
+
     oneof status {
-      Empty succeeded = 1;
-      Empty timed_out = 2;
+      Empty succeeded = 2;
+      Empty timed_out = 3;
       // The SNS ended up being upgraded to a version that was not the expected one.
-      Governance.Version invalid_state = 3;
-      Empty canister_call_failure = 4;
+      InvalidState invalid_state = 4;
+      Empty canister_call_failure = 5;
+    }
+
+    message InvalidState {
+      Governance.Version version = 1;
     }
   }
 }
 
 // Needed to cause prost to generate a type isomorphic to Option<Vec<UpgradeJournalEntry>>.
-message UpgradeJournalEntries {
+message UpgradeJournal {
   // The entries in the upgrade journal.
   repeated UpgradeJournalEntry entries = 1;
 }
@@ -2207,7 +2217,7 @@ message GetUpgradeJournalResponse {
   // feature, it reflect the version of the SNS that the community has decided to upgrade to.
   Governance.Version target_version = 3;
 
-  UpgradeJournalEntries journal = 4;
+  UpgradeJournal upgrade_journal = 4;
 }
 
 // A request to mint tokens for a particular principal. The associated endpoint

--- a/rs/sns/governance/src/gen/ic_sns_governance.pb.v1.rs
+++ b/rs/sns/governance/src/gen/ic_sns_governance.pb.v1.rs
@@ -3404,9 +3404,9 @@ pub struct AdvanceTargetVersionResponse {}
     ::prost::Message,
 )]
 pub struct UpgradeJournalEntry {
-    #[prost(uint64, optional, tag = "5")]
+    #[prost(uint64, optional, tag = "6")]
     pub timestamp_seconds: ::core::option::Option<u64>,
-    #[prost(oneof = "upgrade_journal_entry::Event", tags = "1, 2, 3, 4")]
+    #[prost(oneof = "upgrade_journal_entry::Event", tags = "1, 2, 3, 4, 5")]
     pub event: ::core::option::Option<upgrade_journal_entry::Event>,
 }
 /// Nested message and enum types in `UpgradeJournalEntry`.
@@ -3433,7 +3433,9 @@ pub mod upgrade_journal_entry {
     )]
     pub struct TargetVersionSet {
         #[prost(message, optional, tag = "1")]
-        pub version: ::core::option::Option<super::governance::Version>,
+        pub old_target_version: ::core::option::Option<super::governance::Version>,
+        #[prost(message, optional, tag = "2")]
+        pub new_target_version: ::core::option::Option<super::governance::Version>,
     }
     #[derive(
         candid::CandidType,
@@ -3448,8 +3450,8 @@ pub mod upgrade_journal_entry {
         pub current_version: ::core::option::Option<super::governance::Version>,
         #[prost(message, optional, tag = "2")]
         pub expected_version: ::core::option::Option<super::governance::Version>,
-        #[prost(oneof = "upgrade_started::Triggerer", tags = "3, 4")]
-        pub triggerer: ::core::option::Option<upgrade_started::Triggerer>,
+        #[prost(oneof = "upgrade_started::Reason", tags = "3, 4")]
+        pub reason: ::core::option::Option<upgrade_started::Reason>,
     }
     /// Nested message and enum types in `UpgradeStarted`.
     pub mod upgrade_started {
@@ -3462,9 +3464,9 @@ pub mod upgrade_journal_entry {
             PartialEq,
             ::prost::Oneof,
         )]
-        pub enum Triggerer {
+        pub enum Reason {
             #[prost(message, tag = "3")]
-            UpgradeSnsToNextVersion(super::super::ProposalId),
+            UpgradeSnsToNextVersionProposal(super::super::ProposalId),
             #[prost(message, tag = "4")]
             BehindTargetVersion(super::super::Empty),
         }
@@ -3477,14 +3479,14 @@ pub mod upgrade_journal_entry {
         PartialEq,
         ::prost::Message,
     )]
-    pub struct UpgradeCompleted {
+    pub struct UpgradeOutcome {
         #[prost(string, optional, tag = "1")]
         pub human_readable: ::core::option::Option<::prost::alloc::string::String>,
-        #[prost(oneof = "upgrade_completed::Status", tags = "2, 3, 4, 5")]
-        pub status: ::core::option::Option<upgrade_completed::Status>,
+        #[prost(oneof = "upgrade_outcome::Status", tags = "2, 3, 4, 5")]
+        pub status: ::core::option::Option<upgrade_outcome::Status>,
     }
-    /// Nested message and enum types in `UpgradeCompleted`.
-    pub mod upgrade_completed {
+    /// Nested message and enum types in `UpgradeOutcome`.
+    pub mod upgrade_outcome {
         #[derive(
             candid::CandidType,
             candid::Deserialize,
@@ -3507,14 +3509,14 @@ pub mod upgrade_journal_entry {
         )]
         pub enum Status {
             #[prost(message, tag = "2")]
-            Succeeded(super::super::Empty),
+            Success(super::super::Empty),
             #[prost(message, tag = "3")]
-            TimedOut(super::super::Empty),
+            Timeout(super::super::Empty),
             /// The SNS ended up being upgraded to a version that was not the expected one.
             #[prost(message, tag = "4")]
             InvalidState(InvalidState),
             #[prost(message, tag = "5")]
-            CanisterCallFailure(super::super::Empty),
+            ExternalFailure(super::super::Empty),
         }
     }
     #[derive(
@@ -3531,9 +3533,11 @@ pub mod upgrade_journal_entry {
         #[prost(message, tag = "2")]
         TargetVersionSet(TargetVersionSet),
         #[prost(message, tag = "3")]
-        UpgradeStarted(UpgradeStarted),
+        TargetVersionReset(TargetVersionSet),
         #[prost(message, tag = "4")]
-        UpgradeCompleted(UpgradeCompleted),
+        UpgradeStarted(UpgradeStarted),
+        #[prost(message, tag = "5")]
+        UpgradeOutcome(UpgradeOutcome),
     }
 }
 /// Needed to cause prost to generate a type isomorphic to Option<Vec<UpgradeJournalEntry>>.

--- a/rs/sns/governance/src/gen/ic_sns_governance.pb.v1.rs
+++ b/rs/sns/governance/src/gen/ic_sns_governance.pb.v1.rs
@@ -1650,6 +1650,8 @@ pub struct Governance {
     /// Information about the timers that perform periodic tasks of this Governance canister.
     #[prost(message, optional, tag = "31")]
     pub timers: ::core::option::Option<::ic_nervous_system_proto::pb::v1::Timers>,
+    #[prost(message, optional, tag = "32")]
+    pub upgrade_journal: ::core::option::Option<UpgradeJournalEntries>,
 }
 /// Nested message and enum types in `Governance`.
 pub mod governance {
@@ -1995,6 +1997,64 @@ pub mod governance {
             }
         }
     }
+}
+#[derive(
+    candid::CandidType,
+    candid::Deserialize,
+    comparable::Comparable,
+    Clone,
+    Copy,
+    PartialEq,
+    ::prost::Message,
+)]
+pub struct Timers {
+    #[prost(uint64, optional, tag = "1")]
+    pub last_reset_timestamp_seconds: ::core::option::Option<u64>,
+    #[prost(uint64, optional, tag = "2")]
+    pub last_spawned_timestamp_seconds: ::core::option::Option<u64>,
+}
+#[derive(
+    candid::CandidType,
+    candid::Deserialize,
+    comparable::Comparable,
+    Clone,
+    Copy,
+    PartialEq,
+    ::prost::Message,
+)]
+pub struct ResetTimersRequest {}
+#[derive(
+    candid::CandidType,
+    candid::Deserialize,
+    comparable::Comparable,
+    Clone,
+    Copy,
+    PartialEq,
+    ::prost::Message,
+)]
+pub struct ResetTimersResponse {}
+#[derive(
+    candid::CandidType,
+    candid::Deserialize,
+    comparable::Comparable,
+    Clone,
+    Copy,
+    PartialEq,
+    ::prost::Message,
+)]
+pub struct GetTimersRequest {}
+#[derive(
+    candid::CandidType,
+    candid::Deserialize,
+    comparable::Comparable,
+    Clone,
+    Copy,
+    PartialEq,
+    ::prost::Message,
+)]
+pub struct GetTimersResponse {
+    #[prost(message, optional, tag = "1")]
+    pub timers: ::core::option::Option<Timers>,
 }
 /// Request message for 'get_metadata'.
 #[derive(
@@ -3334,6 +3394,129 @@ pub struct AdvanceTargetVersionRequest {
     ::prost::Message,
 )]
 pub struct AdvanceTargetVersionResponse {}
+/// Represents a single entry in the upgrade journal.
+#[derive(
+    candid::CandidType,
+    candid::Deserialize,
+    comparable::Comparable,
+    Clone,
+    PartialEq,
+    ::prost::Message,
+)]
+pub struct UpgradeJournalEntry {
+    #[prost(uint64, optional, tag = "5")]
+    pub timestamp_seconds: ::core::option::Option<u64>,
+    #[prost(oneof = "upgrade_journal_entry::Entry", tags = "1, 2, 3, 4")]
+    pub entry: ::core::option::Option<upgrade_journal_entry::Entry>,
+}
+/// Nested message and enum types in `UpgradeJournalEntry`.
+pub mod upgrade_journal_entry {
+    #[derive(
+        candid::CandidType,
+        candid::Deserialize,
+        comparable::Comparable,
+        Clone,
+        PartialEq,
+        ::prost::Message,
+    )]
+    pub struct UpgradeStepsRefresh {
+        #[prost(message, optional, tag = "2")]
+        pub upgrade_steps: ::core::option::Option<super::governance::Versions>,
+    }
+    #[derive(
+        candid::CandidType,
+        candid::Deserialize,
+        comparable::Comparable,
+        Clone,
+        PartialEq,
+        ::prost::Message,
+    )]
+    pub struct TargetVersionSet {
+        #[prost(message, optional, tag = "2")]
+        pub version: ::core::option::Option<super::governance::Version>,
+    }
+    #[derive(
+        candid::CandidType,
+        candid::Deserialize,
+        comparable::Comparable,
+        Clone,
+        PartialEq,
+        ::prost::Message,
+    )]
+    pub struct UpgradeStarted {
+        #[prost(message, optional, tag = "2")]
+        pub current_version: ::core::option::Option<super::governance::Version>,
+        #[prost(message, optional, tag = "3")]
+        pub expected_version: ::core::option::Option<super::governance::Version>,
+    }
+    #[derive(
+        candid::CandidType,
+        candid::Deserialize,
+        comparable::Comparable,
+        Clone,
+        PartialEq,
+        ::prost::Message,
+    )]
+    pub struct UpgradeCompleted {
+        #[prost(oneof = "upgrade_completed::Status", tags = "1, 2, 3, 4")]
+        pub status: ::core::option::Option<upgrade_completed::Status>,
+    }
+    /// Nested message and enum types in `UpgradeCompleted`.
+    pub mod upgrade_completed {
+        #[derive(
+            candid::CandidType,
+            candid::Deserialize,
+            comparable::Comparable,
+            Clone,
+            PartialEq,
+            ::prost::Oneof,
+        )]
+        pub enum Status {
+            #[prost(message, tag = "1")]
+            Succeeded(super::super::Empty),
+            #[prost(message, tag = "2")]
+            TimedOut(super::super::Empty),
+            /// The SNS ended up being upgraded to a version that was not the expected one.
+            #[prost(message, tag = "3")]
+            InvalidState(super::super::governance::Version),
+            #[prost(message, tag = "4")]
+            CanisterCallFailure(super::super::Empty),
+        }
+    }
+    #[derive(
+        candid::CandidType,
+        candid::Deserialize,
+        comparable::Comparable,
+        Clone,
+        PartialEq,
+        ::prost::Oneof,
+    )]
+    pub enum Entry {
+        #[prost(message, tag = "1")]
+        UpgradeStepsRefresh(UpgradeStepsRefresh),
+        #[prost(message, tag = "2")]
+        TargetVersionSet(TargetVersionSet),
+        #[prost(message, tag = "3")]
+        UpgradeStarted(UpgradeStarted),
+        #[prost(message, tag = "4")]
+        UpgradeCompleted(UpgradeCompleted),
+    }
+}
+/// Needed to cause prost to generate a type isomorphic to
+/// Option<Vec<UpgradeJournalEntry>>.
+#[derive(
+    candid::CandidType,
+    candid::Deserialize,
+    comparable::Comparable,
+    Clone,
+    PartialEq,
+    ::prost::Message,
+)]
+pub struct UpgradeJournalEntries {
+    /// The entries in the upgrade journal.
+    #[prost(message, repeated, tag = "1")]
+    pub entries: ::prost::alloc::vec::Vec<UpgradeJournalEntry>,
+}
 /// The upgrade journal contains all the information neede to audit previous SNS upgrades and understand its current state.
 /// It is being implemented as part of the "effortless SNS upgrade" feature.
 #[derive(
@@ -3364,6 +3547,8 @@ pub struct GetUpgradeJournalResponse {
     /// feature, it reflect the version of the SNS that the community has decided to upgrade to.
     #[prost(message, optional, tag = "3")]
     pub target_version: ::core::option::Option<governance::Version>,
+    #[prost(message, optional, tag = "4")]
+    pub journal: ::core::option::Option<UpgradeJournalEntries>,
 }
 /// A request to mint tokens for a particular principal. The associated endpoint
 /// is only available on SNS governance, and only then when SNS governance is

--- a/rs/sns/governance/src/gen/ic_sns_governance.pb.v1.rs
+++ b/rs/sns/governance/src/gen/ic_sns_governance.pb.v1.rs
@@ -3502,8 +3502,7 @@ pub mod upgrade_journal_entry {
         UpgradeCompleted(UpgradeCompleted),
     }
 }
-/// Needed to cause prost to generate a type isomorphic to
-/// Option<Vec<UpgradeJournalEntry>>.
+/// Needed to cause prost to generate a type isomorphic to Option<Vec<UpgradeJournalEntry>>.
 #[derive(
     candid::CandidType,
     candid::Deserialize,

--- a/rs/sns/governance/src/proposal.rs
+++ b/rs/sns/governance/src/proposal.rs
@@ -2490,6 +2490,7 @@ mod tests {
             cached_upgrade_steps: None,
             target_version: None,
             timers: None,
+            upgrade_journal: None,
         }
     }
 

--- a/rs/sns/governance/src/sns_upgrade.rs
+++ b/rs/sns/governance/src/sns_upgrade.rs
@@ -653,7 +653,7 @@ pub struct ListUpgradeStepsRequest {
 pub struct ListUpgradeStepsResponse {
     pub steps: ::prost::alloc::vec::Vec<ListUpgradeStep>,
 }
-#[derive(candid::CandidType, candid::Deserialize, Debug)]
+#[derive(candid::CandidType, candid::Deserialize, Debug, Clone)]
 pub struct ListUpgradeStep {
     pub version: ::core::option::Option<SnsVersion>,
 }

--- a/rs/sns/governance/tests/governance.rs
+++ b/rs/sns/governance/tests/governance.rs
@@ -26,7 +26,7 @@ use ic_sns_governance::{
                 NeuronRecipe, NeuronRecipes,
             },
             claim_swap_neurons_response::{ClaimSwapNeuronsResult, ClaimedSwapNeurons, SwapNeuron},
-            governance::Version,
+            governance::{Version, Versions},
             governance_error::ErrorType,
             manage_neuron::{
                 self, claim_or_refresh, configure::Operation, AddNeuronPermissions, ClaimOrRefresh,
@@ -39,12 +39,13 @@ use ic_sns_governance::{
             },
             neuron::{self, DissolveState, Followees},
             proposal::Action,
-            Account as AccountProto, AddMaturityRequest, Ballot, ClaimSwapNeuronsError,
-            ClaimSwapNeuronsRequest, ClaimSwapNeuronsResponse, ClaimedSwapNeuronStatus,
-            DeregisterDappCanisters, Empty, GovernanceError, ManageNeuronResponse,
-            MintTokensRequest, MintTokensResponse, Motion, NervousSystemParameters, Neuron,
-            NeuronId, NeuronIds, NeuronPermission, NeuronPermissionList, NeuronPermissionType,
-            Proposal, ProposalData, ProposalId, RegisterDappCanisters, Vote, WaitForQuietState,
+            upgrade_journal_entry, Account as AccountProto, AddMaturityRequest, Ballot,
+            ClaimSwapNeuronsError, ClaimSwapNeuronsRequest, ClaimSwapNeuronsResponse,
+            ClaimedSwapNeuronStatus, DeregisterDappCanisters, Empty, GovernanceError,
+            ManageNeuronResponse, MintTokensRequest, MintTokensResponse, Motion,
+            NervousSystemParameters, Neuron, NeuronId, NeuronIds, NeuronPermission,
+            NeuronPermissionList, NeuronPermissionType, Proposal, ProposalData, ProposalId,
+            RegisterDappCanisters, UpgradeJournalEntry, Vote, WaitForQuietState,
         },
     },
     sns_upgrade::{ListUpgradeStep, ListUpgradeStepsResponse, SnsVersion},
@@ -2911,12 +2912,17 @@ async fn test_refresh_cached_upgrade_steps() {
 
     // Set up the fixture state
     {
-        let steps = expected_upgrade_steps
+        let steps: Vec<_> = expected_upgrade_steps
             .iter()
             .map(|v| ListUpgradeStep {
                 version: Some(SnsVersion::from(v.clone())),
             })
             .collect();
+        canister_fixture
+            .environment_fixture
+            .push_mocked_canister_reply(ListUpgradeStepsResponse {
+                steps: steps.clone(),
+            });
         canister_fixture
             .environment_fixture
             .push_mocked_canister_reply(ListUpgradeStepsResponse { steps });
@@ -3005,13 +3011,46 @@ async fn test_refresh_cached_upgrade_steps() {
         assert!(!should_refresh);
     }
 
-    // Check that the canister wants to refresh the cached_upgrade_steps after a while
+    // Check that the canister wants to refresh the cached_upgrade_steps after another second
     {
         canister_fixture.advance_time_by(1);
         let should_refresh = canister_fixture
             .governance
             .should_refresh_cached_upgrade_steps();
         assert!(should_refresh);
+    }
+
+    // Refresh the cached upgrade steps again
+    {
+        canister_fixture
+            .governance
+            .refresh_cached_upgrade_steps()
+            .await;
+    }
+
+    // Check that only one refresh has been recorded in the upgrade journal
+    {
+        let upgrade_journal = canister_fixture
+            .governance
+            .proto
+            .upgrade_journal
+            .clone()
+            .unwrap();
+        assert_eq!(
+            upgrade_journal.entries,
+            vec![UpgradeJournalEntry {
+                // we advanced time by one second after the first refresh
+                timestamp_seconds: Some(DEFAULT_TEST_START_TIMESTAMP_SECONDS + 1),
+                // the event contains the upgrade steps
+                event: Some(upgrade_journal_entry::Event::UpgradeStepsRefreshed(
+                    upgrade_journal_entry::UpgradeStepsRefreshed {
+                        upgrade_steps: Some(Versions {
+                            versions: expected_upgrade_steps
+                        }),
+                    }
+                )),
+            }]
+        );
     }
 }
 


### PR DESCRIPTION
The idea is for the upgrade journal to have all the information necessary to understand when and why the SNS got to its current version. This PR adds the journal to the API (but doesn't yet populate the journal, generally).

A follow-up PR will use the new endpoint in tests, and populate it in more places. As a proof of concept, I've made refreshing the upgrade steps add an entry to the journal, although the purpose of this PR is just to implement the API.