### PR TITLE
feat: EXC-1757: Make sandbox lock more granular

### DIFF
--- a/rs/canister_sandbox/src/replica_controller/sandboxed_execution_controller.rs
+++ b/rs/canister_sandbox/src/replica_controller/sandboxed_execution_controller.rs
@@ -1244,50 +1244,52 @@ impl SandboxedExecutionController {
     }
 
     fn get_sandbox_process(&self, canister_id: CanisterId) -> Arc<SandboxProcess> {
-        let mut guard = self.backends.lock().unwrap();
+        {
+            let mut guard = self.backends.lock().unwrap();
 
-        if let Some(backend) = (*guard).get_mut(&canister_id) {
-            let old = std::mem::replace(backend, Backend::Empty);
-            let sandbox_process_and_stats = match old {
-                Backend::Active {
-                    sandbox_process,
-                    stats,
-                } => Some((sandbox_process, stats)),
-                Backend::Evicted {
-                    sandbox_process,
-                    stats,
-                } => sandbox_process.upgrade().map(|p| (p, stats)),
-                Backend::Empty => None,
-            };
-            if let Some((sandbox_process, _stats)) = sandbox_process_and_stats {
-                let now = std::time::Instant::now();
-                if self.max_sandbox_count > 0 {
-                    *backend = Backend::Active {
-                        sandbox_process: Arc::clone(&sandbox_process),
-                        stats: SandboxProcessStats { last_used: now },
-                    };
-                } else {
-                    *backend = Backend::Evicted {
-                        sandbox_process: Arc::downgrade(&sandbox_process),
-                        stats: SandboxProcessStats { last_used: now },
-                    };
+            if let Some(backend) = (*guard).get_mut(&canister_id) {
+                let old = std::mem::replace(backend, Backend::Empty);
+                let sandbox_process_and_stats = match old {
+                    Backend::Active {
+                        sandbox_process,
+                        stats,
+                    } => Some((sandbox_process, stats)),
+                    Backend::Evicted {
+                        sandbox_process,
+                        stats,
+                    } => sandbox_process.upgrade().map(|p| (p, stats)),
+                    Backend::Empty => None,
+                };
+                if let Some((sandbox_process, _stats)) = sandbox_process_and_stats {
+                    let now = std::time::Instant::now();
+                    if self.max_sandbox_count > 0 {
+                        *backend = Backend::Active {
+                            sandbox_process: Arc::clone(&sandbox_process),
+                            stats: SandboxProcessStats { last_used: now },
+                        };
+                    } else {
+                        *backend = Backend::Evicted {
+                            sandbox_process: Arc::downgrade(&sandbox_process),
+                            stats: SandboxProcessStats { last_used: now },
+                        };
+                    }
+                    return sandbox_process;
                 }
-                return sandbox_process;
+            }
+
+            if guard.len() > self.max_sandbox_count {
+                let to_evict = self.max_sandbox_count * SANDBOX_PROCESS_EVICTION_PERCENT / 100;
+                let max_active_sandboxes = self.max_sandbox_count.saturating_sub(to_evict);
+                evict_sandbox_processes(
+                    &mut guard,
+                    self.min_sandbox_count,
+                    max_active_sandboxes,
+                    self.max_sandbox_idle_time,
+                );
             }
         }
 
         let _timer = self.metrics.sandboxed_execution_spawn_process.start_timer();
-        if guard.len() > self.max_sandbox_count {
-            let to_evict = self.max_sandbox_count * SANDBOX_PROCESS_EVICTION_PERCENT / 100;
-            let max_active_sandboxes = self.max_sandbox_count.saturating_sub(to_evict);
-            evict_sandbox_processes(
-                &mut guard,
-                self.min_sandbox_count,
-                max_active_sandboxes,
-                self.max_sandbox_idle_time,
-            );
-        }
-
         // No sandbox process found for this canister. Start a new one and register it.
         let reg = Arc::new(ActiveExecutionStateRegistry::new());
         let controller_service = ControllerServiceImpl::new(Arc::clone(&reg), self.logger.clone());
@@ -1312,7 +1314,10 @@ impl SandboxedExecutionController {
             sandbox_process: Arc::clone(&sandbox_process),
             stats: SandboxProcessStats { last_used: now },
         };
-        (*guard).insert(canister_id, backend);
+        {
+            let mut guard = self.backends.lock().unwrap();
+            (*guard).insert(canister_id, backend);
+        }
 
         sandbox_process
     }


### PR DESCRIPTION
This change allows spawning sandboxes concurrently on the replica side. However, it doesn't significantly improve performance because sandbox launcher communication and the launcher's main thread still serialize requests.

We will address these shortcomings in future PRs.

This change also fixes the sandbox spawning metric to exclude sandbox eviction.