### PR TITLE
fix(PocketIC): fix deadlock

### DIFF
--- a/rs/pocket_ic_server/src/state_api/routes.rs
+++ b/rs/pocket_ic_server/src/state_api/routes.rs
@@ -864,9 +864,7 @@ pub async fn handler_read_graph(
     if let Ok(state_label) = StateLabel::try_from(vec) {
         let op_id = OpId(op_id_str.clone());
         // TODO: use new_state_label and return it to library
-        if let Some((_new_state_label, op_out)) =
-            ApiState::read_result(api_state.get_graph(), &state_label, &op_id)
-        {
+        if let Some((_new_state_label, op_out)) = api_state.read_graph(&state_label, &op_id) {
             op_out_to_response(op_out).await
         } else {
             (

--- a/rs/pocket_ic_server/src/state_api/state.rs
+++ b/rs/pocket_ic_server/src/state_api/state.rs
@@ -3,8 +3,8 @@
 /// Axum handlers operate on a global state of type ApiState, whose
 /// interface guarantees consistency and determinism.
 use crate::pocket_ic::{
-    AdvanceTimeAndTick, ApiResponse, CanisterHttpAdapters, EffectivePrincipal, GetCanisterHttp,
-    MockCanisterHttp, PocketIc,
+    AdvanceTimeAndTick, ApiResponse, EffectivePrincipal, GetCanisterHttp, MockCanisterHttp,
+    PocketIc,
 };
 use crate::state_api::canister_id::{self, DomainResolver, ResolvesDomain};
 use crate::state_api::routes::verify_cbor_content_header;
@@ -111,14 +111,23 @@ struct ProgressThread {
     sender: mpsc::Sender<()>,
 }
 
+struct Instance {
+    state: InstanceState,
+    progress_thread: Option<ProgressThread>,
+}
+
+impl std::fmt::Debug for Instance {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        writeln!(f, "{:?}", self.state)?;
+        Ok(())
+    }
+}
+
 /// The state of the PocketIC API.
 pub struct ApiState {
-    // impl note: If locks are acquired on multiple fields, acquire first on `instances`, then on `canister_http_adapters`, and then on `graph`.
-    instances: Arc<RwLock<Vec<Mutex<InstanceState>>>>,
-    canister_http_adapters: Arc<RwLock<HashMap<InstanceId, CanisterHttpAdapters>>>,
+    // impl note: If locks are acquired on both fields, acquire first on `instances` and then on `graph`.
+    instances: Arc<RwLock<Vec<Mutex<Instance>>>>,
     graph: Arc<RwLock<HashMap<StateLabel, Computations>>>,
-    // threads making IC instances progress automatically
-    progress_threads: RwLock<Vec<Mutex<Option<ProgressThread>>>>,
     sync_wait_time: Duration,
     // PocketIC server port
     port: Option<u16>,
@@ -166,33 +175,25 @@ impl PocketIcApiStateBuilder {
             .iter()
             .map(|i| (i.get_state_label(), Computations::default()))
             .collect();
-        let graph = RwLock::new(graph);
-
-        let canister_http_adapters = RwLock::new(
-            self.initial_instances
-                .iter()
-                .enumerate()
-                .map(|(instance_id, instance)| (instance_id, instance.canister_http_adapters()))
-                .collect(),
-        );
+        let graph = Arc::new(RwLock::new(graph));
 
         let instances: Vec<_> = self
             .initial_instances
             .into_iter()
-            .map(|inst| Mutex::new(InstanceState::Available(inst)))
+            .map(|instance| {
+                Mutex::new(Instance {
+                    progress_thread: None,
+                    state: InstanceState::Available(instance),
+                })
+            })
             .collect();
-        let instances_len = instances.len();
-        let instances = RwLock::new(instances);
-
-        let progress_threads = RwLock::new((0..instances_len).map(|_| Mutex::new(None)).collect());
+        let instances = Arc::new(RwLock::new(instances));
 
         let sync_wait_time = self.sync_wait_time.unwrap_or(DEFAULT_SYNC_WAIT_DURATION);
 
         Arc::new(ApiState {
-            instances: instances.into(),
-            canister_http_adapters: canister_http_adapters.into(),
-            graph: graph.into(),
-            progress_threads,
+            instances,
+            graph,
             sync_wait_time,
             port: self.port,
             http_gateways: Arc::new(RwLock::new(Vec::new())),
@@ -643,7 +644,7 @@ impl ApiState {
     // Executes an operation to completion and returns its `OpOut`
     // or `None` if the auto progress mode received a stop signal.
     async fn execute_operation(
-        instances: Arc<RwLock<Vec<Mutex<InstanceState>>>>,
+        instances: Arc<RwLock<Vec<Mutex<Instance>>>>,
         graph: Arc<RwLock<HashMap<StateLabel, Computations>>>,
         instance_id: InstanceId,
         op: impl Operation + Send + Sync + 'static,
@@ -689,7 +690,7 @@ impl ApiState {
     /// For polling:
     /// The client lib dispatches a long running operation and gets a Started {state_label, op_id}.
     /// It then polls on that via this state tree api function.
-    pub fn read_result(
+    fn read_result(
         graph: Arc<RwLock<HashMap<StateLabel, Computations>>>,
         state_label: &StateLabel,
         op_id: &OpId,
@@ -702,31 +703,32 @@ impl ApiState {
         }
     }
 
-    pub fn get_graph(&self) -> Arc<RwLock<HashMap<StateLabel, Computations>>> {
-        self.graph.clone()
+    pub fn read_graph(
+        &self,
+        state_label: &StateLabel,
+        op_id: &OpId,
+    ) -> Option<(StateLabel, OpOut)> {
+        Self::read_result(self.graph.clone(), state_label, op_id)
     }
 
     pub async fn add_instance(&self, instance: PocketIc) -> InstanceId {
         let mut instances = self.instances.write().await;
-        let mut canister_http_adapters = self.canister_http_adapters.write().await;
-        let mut progress_threads = self.progress_threads.write().await;
         let instance_id = instances.len();
-        canister_http_adapters.insert(instance_id, instance.canister_http_adapters().clone());
-        instances.push(Mutex::new(InstanceState::Available(instance)));
-        progress_threads.push(Mutex::new(None));
+        instances.push(Mutex::new(Instance {
+            state: InstanceState::Available(instance),
+            progress_thread: None,
+        }));
         instance_id
     }
 
     pub async fn delete_instance(&self, instance_id: InstanceId) {
         self.stop_progress(instance_id).await;
-        let instances = self.instances.read().await;
-        let mut canister_http_adapters = self.canister_http_adapters.write().await;
         loop {
-            let mut instance_state = instances[instance_id].lock().await;
-            match std::mem::replace(&mut *instance_state, InstanceState::Deleted) {
+            let instances = self.instances.read().await;
+            let mut instance = instances[instance_id].lock().await;
+            match std::mem::replace(&mut instance.state, InstanceState::Deleted) {
                 InstanceState::Available(pocket_ic) => {
                     std::mem::drop(pocket_ic);
-                    canister_http_adapters.remove(&instance_id);
                     break;
                 }
                 InstanceState::Deleted => {
@@ -734,14 +736,17 @@ impl ApiState {
                 }
                 InstanceState::Busy { .. } => {}
             }
-            drop(instance_state);
+            drop(instance);
+            drop(instances);
             tokio::time::sleep(Duration::from_secs(1)).await;
         }
     }
 
     pub async fn delete_all_instances(arc_self: Arc<ApiState>) {
         let mut tasks = JoinSet::new();
-        let num_instances = arc_self.instances.read().await.len();
+        let instances = arc_self.instances.read().await;
+        let num_instances = instances.len();
+        drop(instances);
         for instance_id in 0..num_instances {
             let arc_self_clone = arc_self.clone();
             tasks.spawn(async move { arc_self_clone.delete_instance(instance_id).await });
@@ -1119,8 +1124,7 @@ impl ApiState {
     }
 
     async fn process_canister_http_requests(
-        instances: Arc<RwLock<Vec<Mutex<InstanceState>>>>,
-        canister_http_adapters: Arc<RwLock<HashMap<InstanceId, CanisterHttpAdapters>>>,
+        instances: Arc<RwLock<Vec<Mutex<Instance>>>>,
         graph: Arc<RwLock<HashMap<StateLabel, Computations>>>,
         instance_id: InstanceId,
         rx: &mut Receiver<()>,
@@ -1142,25 +1146,34 @@ impl ApiState {
         for canister_http_request in canister_http_requests {
             let subnet_id = canister_http_request.subnet_id;
             let request_id = canister_http_request.request_id;
-            let canister_http_adapters = canister_http_adapters.read().await;
-            let canister_http_adapters = canister_http_adapters
-                .get(&instance_id)
-                .unwrap()
-                .lock()
-                .await;
-            let canister_http_adapter = canister_http_adapters
-                .get(&SubnetId::from(PrincipalId::from(subnet_id)))
-                .unwrap();
-            let response =
-                match Self::make_http_request(canister_http_request, canister_http_adapter).await {
-                    Ok(reply) => CanisterHttpResponse::CanisterHttpReply(reply),
-                    Err((reject_code, e)) => {
-                        CanisterHttpResponse::CanisterHttpReject(CanisterHttpReject {
-                            reject_code: reject_code as u64,
-                            message: e,
-                        })
-                    }
-                };
+            let response = loop {
+                let instances = instances.read().await;
+                let instance = instances[instance_id].lock().await;
+                if let InstanceState::Available(pocket_ic) = &instance.state {
+                    let canister_http_adapters = pocket_ic.canister_http_adapters();
+                    let canister_http_adapters = canister_http_adapters.lock().await;
+                    let canister_http_adapter = canister_http_adapters
+                        .get(&SubnetId::from(PrincipalId::from(subnet_id)))
+                        .unwrap();
+                    break match Self::make_http_request(
+                        canister_http_request,
+                        canister_http_adapter,
+                    )
+                    .await
+                    {
+                        Ok(reply) => CanisterHttpResponse::CanisterHttpReply(reply),
+                        Err((reject_code, e)) => {
+                            CanisterHttpResponse::CanisterHttpReject(CanisterHttpReject {
+                                reject_code: reject_code as u64,
+                                message: e,
+                            })
+                        }
+                    };
+                }
+                drop(instance);
+                drop(instances);
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            };
             let mock_canister_http_response = MockCanisterHttpResponse {
                 subnet_id,
                 request_id,
@@ -1191,12 +1204,11 @@ impl ApiState {
         artificial_delay_ms: Option<u64>,
     ) -> Result<(), String> {
         let artificial_delay = Duration::from_millis(artificial_delay_ms.unwrap_or_default());
-        let progress_threads = self.progress_threads.read().await;
-        let mut progress_thread = progress_threads[instance_id].lock().await;
-        let instances = self.instances.clone();
-        let canister_http_adapters = self.canister_http_adapters.clone();
+        let instances_clone = self.instances.clone();
         let graph = self.graph.clone();
-        if progress_thread.is_none() {
+        let instances = self.instances.read().await;
+        let mut instance = instances[instance_id].lock().await;
+        if instance.progress_thread.is_none() {
             let (tx, mut rx) = mpsc::channel::<()>(1);
             let handle = spawn(async move {
                 let mut now = Instant::now();
@@ -1205,7 +1217,7 @@ impl ApiState {
                     let old = std::mem::replace(&mut now, Instant::now());
                     let op = AdvanceTimeAndTick(now.duration_since(old));
                     if Self::execute_operation(
-                        instances.clone(),
+                        instances_clone.clone(),
                         graph.clone(),
                         instance_id,
                         op,
@@ -1217,8 +1229,7 @@ impl ApiState {
                         return;
                     }
                     if Self::process_canister_http_requests(
-                        instances.clone(),
-                        canister_http_adapters.clone(),
+                        instances_clone.clone(),
                         graph.clone(),
                         instance_id,
                         &mut rx,
@@ -1239,7 +1250,7 @@ impl ApiState {
                     }
                 }
             });
-            *progress_thread = Some(ProgressThread { handle, sender: tx });
+            instance.progress_thread = Some(ProgressThread { handle, sender: tx });
             Ok(())
         } else {
             Err("Auto progress mode has already been enabled.".to_string())
@@ -1247,9 +1258,9 @@ impl ApiState {
     }
 
     pub async fn stop_progress(&self, instance_id: InstanceId) {
-        let progress_threads = self.progress_threads.read().await;
-        let mut progress_thread = progress_threads[instance_id].lock().await;
-        if let Some(t) = progress_thread.take() {
+        let instances = self.instances.read().await;
+        let mut instance = instances[instance_id].lock().await;
+        if let Some(t) = instance.progress_thread.take() {
             t.sender.send(()).await.unwrap();
             t.handle.await.unwrap();
         }
@@ -1259,9 +1270,9 @@ impl ApiState {
         let instances = self.instances.read().await;
         let mut res = vec![];
 
-        for instance_state in &*instances {
-            let instance_state = &*instance_state.lock().await;
-            match instance_state {
+        for instance in &*instances {
+            let instance = &*instance.lock().await;
+            match &instance.state {
                 InstanceState::Busy { state_label, op_id } => {
                     res.push(format!("Busy({:?}, {:?})", state_label, op_id))
                 }
@@ -1330,7 +1341,7 @@ impl ApiState {
     /// Same as [Self::update] except that the timeout can be specified manually. This is useful in
     /// cases when clients want to enforce a long-running blocking call.
     async fn update_instances_with_timeout<O>(
-        instances: Arc<RwLock<Vec<Mutex<InstanceState>>>>,
+        instances: Arc<RwLock<Vec<Mutex<Instance>>>>,
         graph: Arc<RwLock<HashMap<StateLabel, Computations>>>,
         op: Arc<O>,
         instance_id: InstanceId,
@@ -1350,9 +1361,9 @@ impl ApiState {
         let (bg_task, busy_outcome) = if let Some(instance_mutex) =
             instances_locked.get(instance_id)
         {
-            let mut instance_state = instance_mutex.lock().await;
+            let mut instance = instance_mutex.lock().await;
             // If this instance is busy, return the running op and initial state
-            match &*instance_state {
+            match &instance.state {
                 InstanceState::Deleted => {
                     return Err(UpdateError {
                         message: "Instance was deleted".to_string(),
@@ -1375,7 +1386,7 @@ impl ApiState {
                         op_id: op_id.clone(),
                     };
                     let InstanceState::Available(mut pocket_ic) =
-                        std::mem::replace(&mut *instance_state, busy)
+                        std::mem::replace(&mut instance.state, busy)
                     else {
                         unreachable!()
                     };
@@ -1401,12 +1412,12 @@ impl ApiState {
                             cached_computations
                                 .insert(op_id.clone(), (new_state_label, result.clone()));
                             drop(graph_guard);
-                            let mut instance_state = instances[instance_id].blocking_lock();
-                            if let InstanceState::Deleted = &*instance_state {
+                            let mut instance = instances[instance_id].blocking_lock();
+                            if let InstanceState::Deleted = &instance.state {
                                 error!("The instance is deleted immediately after an operation. This is a bug!");
                                 std::mem::drop(pocket_ic);
                             } else {
-                                *instance_state = InstanceState::Available(pocket_ic);
+                                instance.state = InstanceState::Available(pocket_ic);
                             }
                             trace!("bg_task::end instance_id={} op_id={}", instance_id, op_id.0);
                             // also return old_state_label so we can prune graph if we return quickly

--- a/rs/pocket_ic_server/src/state_api/state.rs
+++ b/rs/pocket_ic_server/src/state_api/state.rs
@@ -1261,6 +1261,7 @@ impl ApiState {
         let instances = self.instances.read().await;
         let mut instance = instances[instance_id].lock().await;
         let progress_thread = instance.progress_thread.take();
+        // drop locks otherwise we might end up with a deadlock
         drop(instance);
         drop(instances);
         if let Some(t) = progress_thread {


### PR DESCRIPTION
This PR
- prevents deadlocks when acquiring locks in conflicting orders in `ApiState` by having a single lock for instances;
- makes sure locks are not leaked in the public API of `ApiState`;
- makes sure that no read lock to instances needs to be acquired while another read lock to instances is being held.

In particular, the last point prevents deadlocks of the following form:
- a read lock RL1 to instances is acquired;
- a write lock WL1 to instances is requested (at this point, `tokio::sync::RwLock` blocks every subsequent read lock request until this write lock can be acquired, at least until RL1 is released);
- a read lock RL2 to instances is requested (blocks due to WL1 being requested already) and RL1 is not released until RL2 is acquired => deadlock.