### PR TITLE
fix(IDX): work around proc-macro2 non-determinism

### DIFF
--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -81,7 +81,9 @@ sol_register_toolchains(
 
 http_archive(
     name = "rules_rust",
-    integrity = "sha256-JLN47ZcAbx9wEr5Jiib4HduZATGLiDgK7oUi/fvotzU=",
+    patch_args = ["-p1"],
+    patches = ["//bazel:rules_rust.patch"],
+    sha256 = "24b378ed97006f1f7012be498a26f81ddb9901318b88380aee8522fdfbe8b735",
     urls = ["https://github.com/bazelbuild/rules_rust/releases/download/0.42.1/rules_rust-v0.42.1.tar.gz"],
 )
 

--- a/bazel/rules_rust.patch
+++ b/bazel/rules_rust.patch
@@ -1,0 +1,27 @@
+# workaround for proc-macro2 build determinism issues
+# https://github.com/dtolnay/proc-macro2/issues/473
+diff --git a/cargo/cargo_build_script_runner/bin.rs b/cargo/cargo_build_script_runner/bin.rs
+index 8730c809..f8eda5db 100644
+--- a/cargo/cargo_build_script_runner/bin.rs
++++ b/cargo/cargo_build_script_runner/bin.rs
+@@ -84,7 +84,7 @@ fn run_buildrs() -> Result<(), String> {
+     command
+         .current_dir(&working_directory)
+         .envs(target_env_vars)
+-        .env("OUT_DIR", out_dir_abs)
++        .env("OUT_DIR", out_dir_abs.clone())
+         .env("CARGO_MANIFEST_DIR", manifest_dir)
+         .env("RUSTC", rustc)
+         .env("RUST_BACKTRACE", "full");
+@@ -195,6 +195,11 @@ fn run_buildrs() -> Result<(), String> {
+         .unwrap_or_else(|_| panic!("Unable to write file {:?}", link_flags_file));
+     write(&link_search_paths_file, link_search_paths.as_bytes())
+         .unwrap_or_else(|_| panic!("Unable to write file {:?}", link_search_paths_file));
++
++    let proc_macro2_d = out_dir_abs.join("proc_macro2.d");
++    if Path::new(&proc_macro2_d).exists() {
++        std::fs::remove_file(proc_macro2_d).unwrap();
++    }
+     Ok(())
+ }
+


### PR DESCRIPTION
This is a patch for `rules_rust` to work around some build determinism issues in the `proc-macro2` Bazel build.

For more information, see:
* https://github.com/dtolnay/proc-macro2/issues/473
* https://github.com/bazelbuild/rules_rust/issues/2952