### PR TITLE
revert: "feat(RUN-1013): Adjust max number of cached sandboxes"

### DIFF
--- a/rs/config/src/embedders.rs
+++ b/rs/config/src/embedders.rs
@@ -48,7 +48,7 @@ pub(crate) const DEFAULT_MIN_SANDBOX_COUNT: usize = 500;
 
 /// Sandbox process eviction ensures that the number of sandbox processes is
 /// always below this threshold.
-pub(crate) const DEFAULT_MAX_SANDBOX_COUNT: usize = 1_000;
+pub(crate) const DEFAULT_MAX_SANDBOX_COUNT: usize = 2_000;
 
 /// A sandbox process may be evicted after it has been idle for this
 /// duration and sandbox process eviction is activated.


### PR DESCRIPTION
This reverts commit 75c57bc48ef317ce5ded8c68bdb0296d63fd6008.

As canister executions increase, it's essential to maintain more spawned sandboxes to accelerate sandbox executions. While the original change reduced memory usage to switch to the memory-based allocator, production metrics indicate minimal risk.