### PR TITLE
fix(recovery): [CON-1405] Print example of expected ssh key format during recovery

### DIFF
--- a/rs/recovery/src/app_subnet_recovery.rs
+++ b/rs/recovery/src/app_subnet_recovery.rs
@@ -210,7 +210,10 @@ impl RecoveryIterator<StepType, StepTypeIter> for AppSubnetRecovery {
                 if self.params.pub_key.is_none() {
                     self.params.pub_key = read_optional(
                         &self.logger,
-                        "Enter public key to add readonly SSH access to subnet: ",
+                        "Enter public key to add readonly SSH access to subnet. Ensure the right format.\n\
+                        Format:   ssh-ed25519 <pubkey> <identity>\n\
+                        Example:  ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPwS/0S6xH0g/xLDV0Tz7VeMZE9AKPeSbLmCsq9bY3F1 foo@dfinity.org\n\
+                        Enter your key: ",
                     );
                 }
             }

--- a/rs/recovery/src/file_sync_helper.rs
+++ b/rs/recovery/src/file_sync_helper.rs
@@ -85,9 +85,7 @@ pub fn rsync_with_retries(
             require_confirmation,
             key_file,
         ) {
-            Err(e) => {
-                warn!(logger, "Rsync failed: {:?}, retrying...", e);
-            }
+            Err(e) => warn!(logger, "Rsync failed: {:?}, retrying...", e),
             success => return success,
         }
         thread::sleep(time::Duration::from_secs(10));

--- a/rs/recovery/subnet_splitting/src/subnet_splitting.rs
+++ b/rs/recovery/subnet_splitting/src/subnet_splitting.rs
@@ -433,7 +433,10 @@ impl RecoveryIterator<StepType, StepTypeIter> for SubnetSplitting {
                 if self.params.pub_key.is_none() {
                     self.params.pub_key = read_optional(
                         &self.logger,
-                        "Enter public key to add readonly SSH access to subnet: ",
+                        "Enter public key to add readonly SSH access to subnet. Ensure the right format.\n\
+                        Format:   ssh-ed25519 <pubkey> <identity>\n\
+                        Example:  ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPwS/0S6xH0g/xLDV0Tz7VeMZE9AKPeSbLmCsq9bY3F1 foo@dfinity.org\n\
+                        Enter your key: ",
                     )
                 }
             }


### PR DESCRIPTION
To avoid confusion during recovery, we now print the expected key format. 

![image](https://github.com/user-attachments/assets/5c7f4425-fb8f-4e5d-b34d-0a4be3a4d5fc)
