### PR TITLE
test(IDX): run //rs/tests/consensus:dual_workload_test in colocated mode to reduce flakiness

### DIFF
--- a/rs/tests/consensus/BUILD.bazel
+++ b/rs/tests/consensus/BUILD.bazel
@@ -72,6 +72,7 @@ system_test(
     proc_macro_deps = MACRO_DEPENDENCIES,
     tags = [
         "k8s",
+        "experimental_system_test_colocation",
     ],
     target_compatible_with = ["@platforms//os:linux"],  # requires libssh that does not build on Mac OS
     runtime_deps = GUESTOS_RUNTIME_DEPS,

--- a/rs/tests/consensus/BUILD.bazel
+++ b/rs/tests/consensus/BUILD.bazel
@@ -71,8 +71,8 @@ system_test(
     flaky = True,
     proc_macro_deps = MACRO_DEPENDENCIES,
     tags = [
-        "k8s",
         "experimental_system_test_colocation",
+        "k8s",
     ],
     target_compatible_with = ["@platforms//os:linux"],  # requires libssh that does not build on Mac OS
     runtime_deps = GUESTOS_RUNTIME_DEPS,


### PR DESCRIPTION
`//rs/tests/consensus:dual_workload_test` is currently our most flaky test on PRs. What all flakes have in common is that the testnet is deployed in `se1` while the driver is running in `zh1` causing cross Atlantic traffic. What we then see is that some calls the `http://[$ip]:8080/api/v3/canister/$id/call` time out.

We can potentially fix this by running the test in colocated mode such that the driver and testnet are located on the same host or DC.