### PR TITLE
chore: Fix http server used by system tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15450,6 +15450,7 @@ name = "networking-system-tests"
 version = "0.9.0"
 dependencies = [
  "anyhow",
+ "assert_matches",
  "candid",
  "canister-test",
  "canister_http",

--- a/rs/tests/httpbin-rs/src/main.rs
+++ b/rs/tests/httpbin-rs/src/main.rs
@@ -10,7 +10,7 @@ use std::{
 use axum::{
     body::Body,
     extract::{Path, Request},
-    http::{HeaderMap, HeaderName, Method, StatusCode, Uri},
+    http::{HeaderMap, HeaderName, Method, StatusCode},
     middleware::map_response,
     response::{Html, IntoResponse, Redirect, Response},
     routing::{get, post},
@@ -85,8 +85,7 @@ async fn redirect_handler(Path(n): Path<u64>) -> impl IntoResponse {
 }
 
 /// Builds the response body using the request
-async fn anything_handler(method: Method, uri: Uri, headers: HeaderMap, body: String) -> Vec<u8> {
-    let host = headers.get("host").unwrap().to_str().unwrap_or("");
+async fn anything_handler(method: Method, headers: HeaderMap, body: String) -> Vec<u8> {
     let headers = headers
         .iter()
         .map(|h| (h.0.to_string(), h.1.to_str().unwrap().to_string()))
@@ -96,7 +95,6 @@ async fn anything_handler(method: Method, uri: Uri, headers: HeaderMap, body: St
         "method": method.to_string(),
         "headers": headers,
         "data": body,
-        "url": format!("https://{}{}", host, uri),
     })
     .to_string();
 

--- a/rs/tests/networking/BUILD.bazel
+++ b/rs/tests/networking/BUILD.bazel
@@ -88,6 +88,7 @@ system_test_nns(
         "//rs/test_utilities/types",
         "//rs/types/base_types",
         "//rs/types/types",
+        "@crate_index//:assert_matches",
         "@crate_index//:tokio",
     ],
 )

--- a/rs/tests/networking/Cargo.toml
+++ b/rs/tests/networking/Cargo.toml
@@ -8,6 +8,7 @@ documentation.workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
+assert_matches = { workspace = true }
 candid = { workspace = true }
 canister-test = { path = "../../rust_canisters/canister_test" }
 canister_http = { path = "./canister_http" }

--- a/rs/tests/networking/canister_http_correctness_test.rs
+++ b/rs/tests/networking/canister_http_correctness_test.rs
@@ -15,8 +15,8 @@ Success::
 
 end::catalog[] */
 
-use anyhow::bail;
 use anyhow::Result;
+use assert_matches::assert_matches;
 use canister_http::*;
 use canister_test::{Canister, Runtime};
 use dfn_candid::candid_one;
@@ -28,7 +28,7 @@ use ic_management_canister_types::{
 };
 use ic_system_test_driver::driver::group::SystemTestGroup;
 use ic_system_test_driver::driver::group::SystemTestSubGroup;
-use ic_system_test_driver::driver::{test_env::TestEnv, test_env_api::RETRY_BACKOFF};
+use ic_system_test_driver::driver::test_env::TestEnv;
 use ic_system_test_driver::systest;
 use ic_system_test_driver::util::block_on;
 use ic_test_utilities::cycles_account_manager::CyclesAccountManagerBuilder;
@@ -36,12 +36,9 @@ use ic_test_utilities_types::messages::RequestBuilder;
 use ic_types::canister_http::{CanisterHttpRequestContext, MAX_CANISTER_HTTP_REQUEST_BYTES};
 use ic_types::time::UNIX_EPOCH;
 use proxy_canister::{RemoteHttpRequest, RemoteHttpResponse};
-use slog::Logger;
 use std::convert::TryFrom;
-use std::time::Duration;
 
 struct Handlers<'a> {
-    logger: Logger,
     subnet_size: usize,
     runtime: Runtime,
     env: &'a TestEnv,
@@ -49,7 +46,6 @@ struct Handlers<'a> {
 
 impl<'a> Handlers<'a> {
     fn new(env: &'a TestEnv) -> Handlers<'a> {
-        let logger = env.logger();
         let subnet_size = get_node_snapshots(env).count();
 
         let runtime = {
@@ -59,7 +55,6 @@ impl<'a> Handlers<'a> {
         };
 
         Handlers {
-            logger,
             runtime,
             subnet_size,
             env,
@@ -108,228 +103,202 @@ pub fn test_enforce_https(env: TestEnv) {
     let handlers = Handlers::new(&env);
     let webserver_ipv6 = get_universal_vm_address(&env);
 
-    block_on(async {
-        assert!(
-            test_canister_http_property(
-                &handlers.logger,
-                &handlers.proxy_canister(),
-                RemoteHttpRequest {
-                    request: CanisterHttpRequestArgs {
-                        url: format!("http://[{webserver_ipv6}]:20443"),
-                        headers: BoundedHttpHeaders::new(vec![]),
-                        method: HttpMethod::GET,
-                        body: Some("".as_bytes().to_vec()),
-                        transform: Some(TransformContext {
-                            function: TransformFunc(candid::Func {
-                                principal: get_proxy_canister_id(&env).into(),
-                                method: "transform".to_string(),
-                            }),
-                            context: vec![0, 1, 2],
-                        }),
-                        max_response_bytes: None,
-                    },
-                    cycles: 500_000_000_000,
-                },
-                |response| matches!(response, Err((RejectionCode::SysFatal, _))),
-            )
-            .await
-        )
-    });
+    let response = block_on(submit_outcall(
+        &handlers.proxy_canister(),
+        RemoteHttpRequest {
+            request: CanisterHttpRequestArgs {
+                url: format!("http://[{webserver_ipv6}]:20443"),
+                headers: BoundedHttpHeaders::new(vec![]),
+                method: HttpMethod::GET,
+                body: Some("".as_bytes().to_vec()),
+                transform: Some(TransformContext {
+                    function: TransformFunc(candid::Func {
+                        principal: get_proxy_canister_id(&env).into(),
+                        method: "transform".to_string(),
+                    }),
+                    context: vec![0, 1, 2],
+                }),
+                max_response_bytes: None,
+            },
+            cycles: 500_000_000_000,
+        },
+    ));
+
+    assert_matches!(response, Err((RejectionCode::SysFatal, _)));
 }
 
 pub fn test_transform_function_is_executed(env: TestEnv) {
     let handlers = Handlers::new(&env);
     let webserver_ipv6 = get_universal_vm_address(&env);
 
-    block_on(async {
-        assert!(
-            test_canister_http_property(
-                &handlers.logger,
-                &handlers.proxy_canister(),
-                RemoteHttpRequest {
-                    request: CanisterHttpRequestArgs {
-                        url: format!("https://[{webserver_ipv6}]:20443"),
-                        headers: BoundedHttpHeaders::new(vec![]),
-                        method: HttpMethod::GET,
-                        body: Some("".as_bytes().to_vec()),
-                        transform: Some(TransformContext {
-                            function: TransformFunc(candid::Func {
-                                principal: get_proxy_canister_id(&env).into(),
-                                method: "test_transform".to_string(),
-                            }),
-                            context: vec![0, 1, 2],
-                        }),
-                        max_response_bytes: None,
-                    },
-                    cycles: 500_000_000_000,
-                },
-                |response| {
-                    let r = response.clone().expect("Http call should succeed");
-                    r.headers.len() == 2
-                        && r.headers[0].0 == "hello"
-                        && r.headers[0].1 == "bonjour"
-                        && r.headers[1].0 == "caller"
-                        && r.headers[1].1 == "aaaaa-aa"
-                },
-            )
-            .await
-        )
-    });
+    let response = block_on(submit_outcall(
+        &handlers.proxy_canister(),
+        RemoteHttpRequest {
+            request: CanisterHttpRequestArgs {
+                url: format!("https://[{webserver_ipv6}]:20443"),
+                headers: BoundedHttpHeaders::new(vec![]),
+                method: HttpMethod::GET,
+                body: Some("".as_bytes().to_vec()),
+                transform: Some(TransformContext {
+                    function: TransformFunc(candid::Func {
+                        principal: get_proxy_canister_id(&env).into(),
+                        method: "test_transform".to_string(),
+                    }),
+                    context: vec![0, 1, 2],
+                }),
+                max_response_bytes: None,
+            },
+            cycles: 500_000_000_000,
+        },
+    ));
+
+    let response = response.expect("Http call should succeed");
+
+    assert_eq!(response.headers.len(), 2, "Headers: {:?}", response.headers);
+    assert_eq!(response.headers[0].0, "hello");
+    assert_eq!(response.headers[0].1, "bonjour");
+    assert_eq!(response.headers[1].0, "caller");
+    assert_eq!(response.headers[1].1, "aaaaa-aa");
 }
 
 pub fn test_composite_transform_function_is_executed(env: TestEnv) {
     let handlers = Handlers::new(&env);
     let webserver_ipv6 = get_universal_vm_address(&env);
 
-    block_on(async {
-        assert!(
-            test_canister_http_property(
-                &handlers.logger,
-                &handlers.proxy_canister(),
-                RemoteHttpRequest {
-                    request: CanisterHttpRequestArgs {
-                        url: format!("https://[{webserver_ipv6}]:20443"),
-                        headers: BoundedHttpHeaders::new(vec![]),
-                        method: HttpMethod::GET,
-                        body: Some("".as_bytes().to_vec()),
-                        transform: Some(TransformContext {
-                            function: TransformFunc(candid::Func {
-                                principal: get_proxy_canister_id(&env).into(),
-                                method: "test_composite_transform".to_string(),
-                            }),
-                            context: vec![0, 1, 2],
-                        }),
-                        max_response_bytes: None,
-                    },
-                    cycles: 500_000_000_000,
-                },
-                |response| {
-                    let r = response.clone().expect("Http call should succeed");
-                    r.headers.len() == 2
-                        && r.headers[0].0 == "hello"
-                        && r.headers[0].1 == "bonjour"
-                        && r.headers[1].0 == "caller"
-                        && r.headers[1].1 == "aaaaa-aa"
-                },
-            )
-            .await,
-        )
-    });
+    let response = block_on(submit_outcall(
+        &handlers.proxy_canister(),
+        RemoteHttpRequest {
+            request: CanisterHttpRequestArgs {
+                url: format!("https://[{webserver_ipv6}]:20443"),
+                headers: BoundedHttpHeaders::new(vec![]),
+                method: HttpMethod::GET,
+                body: Some("".as_bytes().to_vec()),
+                transform: Some(TransformContext {
+                    function: TransformFunc(candid::Func {
+                        principal: get_proxy_canister_id(&env).into(),
+                        method: "test_composite_transform".to_string(),
+                    }),
+                    context: vec![0, 1, 2],
+                }),
+                max_response_bytes: None,
+            },
+            cycles: 500_000_000_000,
+        },
+    ));
+
+    let response = response.expect("Http call should succeed");
+
+    assert_eq!(response.headers.len(), 2, "Headers: {:?}", response.headers);
+    assert_eq!(response.headers[0].0, "hello");
+    assert_eq!(response.headers[0].1, "bonjour");
+    assert_eq!(response.headers[1].0, "caller");
+    assert_eq!(response.headers[1].1, "aaaaa-aa");
 }
 
 pub fn test_no_cycles_attached(env: TestEnv) {
     let handlers = Handlers::new(&env);
     let webserver_ipv6 = get_universal_vm_address(&env);
 
-    block_on(async {
-        assert!(
-            test_canister_http_property(
-                &handlers.logger,
-                &handlers.proxy_canister(),
-                RemoteHttpRequest {
-                    request: CanisterHttpRequestArgs {
-                        url: format!("http://[{webserver_ipv6}]:20443"),
-                        headers: BoundedHttpHeaders::new(vec![]),
-                        method: HttpMethod::GET,
-                        body: Some("".as_bytes().to_vec()),
-                        transform: Some(TransformContext {
-                            function: TransformFunc(candid::Func {
-                                principal: get_proxy_canister_id(&env).into(),
-                                method: "transform".to_string(),
-                            }),
-                            context: vec![0, 1, 2],
-                        }),
-                        max_response_bytes: None,
-                    },
-                    cycles: 0,
-                },
-                |response| matches!(response, Err((RejectionCode::CanisterReject, _))),
-            )
-            .await,
-        )
-    });
+    let response = block_on(submit_outcall(
+        &handlers.proxy_canister(),
+        RemoteHttpRequest {
+            request: CanisterHttpRequestArgs {
+                url: format!("http://[{webserver_ipv6}]:20443"),
+                headers: BoundedHttpHeaders::new(vec![]),
+                method: HttpMethod::GET,
+                body: Some("".as_bytes().to_vec()),
+                transform: Some(TransformContext {
+                    function: TransformFunc(candid::Func {
+                        principal: get_proxy_canister_id(&env).into(),
+                        method: "transform".to_string(),
+                    }),
+                    context: vec![0, 1, 2],
+                }),
+                max_response_bytes: None,
+            },
+            cycles: 0,
+        },
+    ));
+
+    assert_matches!(response, Err((RejectionCode::CanisterReject, _)));
 }
 
 pub fn test_2mb_response_cycle_for_success_path(env: TestEnv) {
     let handlers = Handlers::new(&env);
     let webserver_ipv6 = get_universal_vm_address(&env);
 
-    block_on(async {
-        // Test: Pricing without max_response specified
-        // Formula: 400M + (2*response_size_limit + 2*request_size) * 50000
-        let request = CanisterHttpRequestArgs {
-            url: format!("https://[{webserver_ipv6}]:20443"),
-            headers: BoundedHttpHeaders::new(vec![]),
-            method: HttpMethod::GET,
-            body: Some("".as_bytes().to_vec()),
-            transform: Some(TransformContext {
-                function: TransformFunc(candid::Func {
-                    principal: get_proxy_canister_id(&env).into(),
-                    method: "transform".to_string(),
-                }),
-                context: vec![0, 1, 2],
+    // Test: Pricing without max_response specified
+    // Formula: 400M + (2*response_size_limit + 2*request_size) * 50000
+    let request = CanisterHttpRequestArgs {
+        url: format!("https://[{webserver_ipv6}]:20443"),
+        headers: BoundedHttpHeaders::new(vec![]),
+        method: HttpMethod::GET,
+        body: Some("".as_bytes().to_vec()),
+        transform: Some(TransformContext {
+            function: TransformFunc(candid::Func {
+                principal: get_proxy_canister_id(&env).into(),
+                method: "transform".to_string(),
             }),
-            max_response_bytes: None,
-        };
+            context: vec![0, 1, 2],
+        }),
+        max_response_bytes: None,
+    };
 
-        assert!(
-            test_canister_http_property(
-                &handlers.logger,
-                &handlers.proxy_canister(),
-                RemoteHttpRequest {
-                    request: request.clone(),
-                    cycles: expected_cycle_cost(
-                        handlers.proxy_canister().canister_id(),
-                        request,
-                        handlers.subnet_size,
-                    ),
-                },
-                |response| matches!(response, Ok(r) if r.status==200),
-            )
-            .await,
+    let response = block_on(async move {
+        submit_outcall(
+            &handlers.proxy_canister(),
+            RemoteHttpRequest {
+                request: request.clone(),
+                cycles: expected_cycle_cost(
+                    handlers.proxy_canister().canister_id(),
+                    request,
+                    handlers.subnet_size,
+                ),
+            },
         )
+        .await
     });
+
+    assert_matches!(response, Ok(r) if r.status==200);
 }
 
 pub fn test_2mb_response_cycle_for_rejection_path(env: TestEnv) {
     let handlers = Handlers::new(&env);
     let webserver_ipv6 = get_universal_vm_address(&env);
 
-    block_on(async {
-        // Test: Pricing without max_response specified
-        // Formula: 400M + (2*response_size_limit + 2*request_size) * 50000
-        let request = CanisterHttpRequestArgs {
-            url: format!("https://[{webserver_ipv6}]:20443"),
-            headers: BoundedHttpHeaders::new(vec![]),
-            method: HttpMethod::GET,
-            body: Some("".as_bytes().to_vec()),
-            transform: Some(TransformContext {
-                function: TransformFunc(candid::Func {
-                    principal: get_proxy_canister_id(&env).into(),
-                    method: "transform".to_string(),
-                }),
-                context: vec![0, 1, 2],
+    // Test: Pricing without max_response specified
+    // Formula: 400M + (2*response_size_limit + 2*request_size) * 50000
+    let request = CanisterHttpRequestArgs {
+        url: format!("https://[{webserver_ipv6}]:20443"),
+        headers: BoundedHttpHeaders::new(vec![]),
+        method: HttpMethod::GET,
+        body: Some("".as_bytes().to_vec()),
+        transform: Some(TransformContext {
+            function: TransformFunc(candid::Func {
+                principal: get_proxy_canister_id(&env).into(),
+                method: "transform".to_string(),
             }),
-            max_response_bytes: None,
-        };
+            context: vec![0, 1, 2],
+        }),
+        max_response_bytes: None,
+    };
 
-        assert!(
-            test_canister_http_property(
-                &handlers.logger,
-                &handlers.proxy_canister(),
-                RemoteHttpRequest {
-                    request: request.clone(),
-                    cycles: expected_cycle_cost(
-                        handlers.proxy_canister().canister_id(),
-                        request,
-                        handlers.subnet_size,
-                    ) - 1,
-                },
-                |response| matches!(response, Err((RejectionCode::CanisterReject, _))),
-            )
-            .await,
+    let response = block_on(async move {
+        submit_outcall(
+            &handlers.proxy_canister(),
+            RemoteHttpRequest {
+                request: request.clone(),
+                cycles: expected_cycle_cost(
+                    handlers.proxy_canister().canister_id(),
+                    request,
+                    handlers.subnet_size,
+                ) - 1,
+            },
         )
+        .await
     });
+
+    assert_matches!(response, Err((RejectionCode::CanisterReject, _)));
 }
 
 pub fn test_4096_max_response_cycle_case_1(env: TestEnv) {
@@ -353,27 +322,24 @@ pub fn test_4096_max_response_cycle_case_1(env: TestEnv) {
         max_response_bytes: Some(16384),
     };
 
-    block_on(async {
+    let response = block_on(async move {
         // Test: Pricing without max_response specified
         // Formula: 400M + (2*response_size_limit + 2*request_size) * 50000
-
-        assert!(
-            test_canister_http_property(
-                &handlers.logger,
-                &handlers.proxy_canister(),
-                RemoteHttpRequest {
-                    request: request.clone(),
-                    cycles: expected_cycle_cost(
-                        handlers.proxy_canister().canister_id(),
-                        request.clone(),
-                        handlers.subnet_size,
-                    ),
-                },
-                |response| matches!(response, Ok(r) if r.status==200),
-            )
-            .await,
+        submit_outcall(
+            &handlers.proxy_canister(),
+            RemoteHttpRequest {
+                request: request.clone(),
+                cycles: expected_cycle_cost(
+                    handlers.proxy_canister().canister_id(),
+                    request.clone(),
+                    handlers.subnet_size,
+                ),
+            },
         )
+        .await
     });
+
+    assert_matches!(response, Ok(r) if r.status==200);
 }
 
 pub fn test_4096_max_response_cycle_case_2(env: TestEnv) {
@@ -397,228 +363,194 @@ pub fn test_4096_max_response_cycle_case_2(env: TestEnv) {
         max_response_bytes: Some(16384),
     };
 
-    block_on(async {
+    let response = block_on(async move {
         // Test: Pricing without max_response specified
         // Formula: 400M + (2*response_size_limit + 2*request_size) * 50000
-
-        assert!(
-            test_canister_http_property(
-                &handlers.logger,
-                &handlers.proxy_canister(),
-                RemoteHttpRequest {
-                    request: request.clone(),
-                    cycles: expected_cycle_cost(
-                        handlers.proxy_canister().canister_id(),
-                        request.clone(),
-                        handlers.subnet_size,
-                    ) - 1,
-                },
-                |response| matches!(response, Err((RejectionCode::CanisterReject, _))),
-            )
-            .await,
+        submit_outcall(
+            &handlers.proxy_canister(),
+            RemoteHttpRequest {
+                request: request.clone(),
+                cycles: expected_cycle_cost(
+                    handlers.proxy_canister().canister_id(),
+                    request.clone(),
+                    handlers.subnet_size,
+                ) - 1,
+            },
         )
+        .await
     });
+    assert_matches!(response, Err((RejectionCode::CanisterReject, _)));
 }
 
 pub fn test_max_response_limit_too_large(env: TestEnv) {
     let handlers = Handlers::new(&env);
     let webserver_ipv6 = get_universal_vm_address(&env);
 
-    block_on(async {
-        assert!(
-            test_canister_http_property(
-                &handlers.logger,
-                &handlers.proxy_canister(),
-                RemoteHttpRequest {
-                    request: CanisterHttpRequestArgs {
-                        url: format!("https://[{webserver_ipv6}]:20443"),
-                        headers: BoundedHttpHeaders::new(vec![]),
-                        method: HttpMethod::GET,
-                        body: Some("".as_bytes().to_vec()),
-                        transform: Some(TransformContext {
-                            function: TransformFunc(candid::Func {
-                                principal: get_proxy_canister_id(&env).into(),
-                                method: "transform".to_string(),
-                            }),
-                            context: vec![0, 1, 2],
-                        }),
-                        max_response_bytes: Some(4 * 1024 * 1024),
-                    },
-                    cycles: 0,
-                },
-                |response| matches!(response, Err((RejectionCode::CanisterReject, _))),
-            )
-            .await,
-        )
-    });
+    let response = block_on(submit_outcall(
+        &handlers.proxy_canister(),
+        RemoteHttpRequest {
+            request: CanisterHttpRequestArgs {
+                url: format!("https://[{webserver_ipv6}]:20443"),
+                headers: BoundedHttpHeaders::new(vec![]),
+                method: HttpMethod::GET,
+                body: Some("".as_bytes().to_vec()),
+                transform: Some(TransformContext {
+                    function: TransformFunc(candid::Func {
+                        principal: get_proxy_canister_id(&env).into(),
+                        method: "transform".to_string(),
+                    }),
+                    context: vec![0, 1, 2],
+                }),
+                max_response_bytes: Some(4 * 1024 * 1024),
+            },
+            cycles: 0,
+        },
+    ));
+
+    assert_matches!(response, Err((RejectionCode::CanisterReject, _)));
 }
 
 pub fn test_transform_that_bloats_response_above_2mb_limit(env: TestEnv) {
     let handlers = Handlers::new(&env);
     let webserver_ipv6 = get_universal_vm_address(&env);
 
-    block_on(async {
-        assert!(
-            test_canister_http_property(
-                &handlers.logger,
-                &handlers.proxy_canister(),
-                RemoteHttpRequest {
-                    request: CanisterHttpRequestArgs {
-                        url: format!("https://[{webserver_ipv6}]:20443"),
-                        headers: BoundedHttpHeaders::new(vec![]),
-                        method: HttpMethod::GET,
-                        body: Some("".as_bytes().to_vec()),
-                        transform: Some(TransformContext {
-                            function: TransformFunc(candid::Func {
-                                principal: get_proxy_canister_id(&env).into(),
-                                method: "bloat_transform".to_string(),
-                            }),
-                            context: vec![0, 1, 2],
-                        }),
-                        max_response_bytes: None,
-                    },
-                    cycles: 500_000_000_000,
-                },
-                |response| matches!(response, Err((RejectionCode::SysFatal, _))),
-            )
-            .await,
-        )
-    });
+    let response = block_on(submit_outcall(
+        &handlers.proxy_canister(),
+        RemoteHttpRequest {
+            request: CanisterHttpRequestArgs {
+                url: format!("https://[{webserver_ipv6}]:20443"),
+                headers: BoundedHttpHeaders::new(vec![]),
+                method: HttpMethod::GET,
+                body: Some("".as_bytes().to_vec()),
+                transform: Some(TransformContext {
+                    function: TransformFunc(candid::Func {
+                        principal: get_proxy_canister_id(&env).into(),
+                        method: "bloat_transform".to_string(),
+                    }),
+                    context: vec![0, 1, 2],
+                }),
+                max_response_bytes: None,
+            },
+            cycles: 500_000_000_000,
+        },
+    ));
+
+    assert_matches!(response, Err((RejectionCode::SysFatal, _)));
 }
 
 pub fn test_non_existing_transform_function(env: TestEnv) {
     let handlers = Handlers::new(&env);
     let webserver_ipv6 = get_universal_vm_address(&env);
 
-    block_on(async {
-        assert!(
-            test_canister_http_property(
-                &handlers.logger,
-                &handlers.proxy_canister(),
-                RemoteHttpRequest {
-                    request: CanisterHttpRequestArgs {
-                        url: format!("https://[{webserver_ipv6}]:20443"),
-                        headers: BoundedHttpHeaders::new(vec![]),
-                        method: HttpMethod::GET,
-                        body: Some("".as_bytes().to_vec()),
-                        transform: Some(TransformContext {
-                            function: TransformFunc(candid::Func {
-                                principal: get_proxy_canister_id(&env).into(),
-                                method: "idontexist".to_string(),
-                            }),
-                            context: vec![0, 1, 2],
-                        }),
-                        max_response_bytes: None,
-                    },
-                    cycles: 500_000_000_000,
-                },
-                |response| matches!(response, Err((RejectionCode::CanisterError, _))),
-            )
-            .await,
-        )
-    });
+    let response = block_on(submit_outcall(
+        &handlers.proxy_canister(),
+        RemoteHttpRequest {
+            request: CanisterHttpRequestArgs {
+                url: format!("https://[{webserver_ipv6}]:20443"),
+                headers: BoundedHttpHeaders::new(vec![]),
+                method: HttpMethod::GET,
+                body: Some("".as_bytes().to_vec()),
+                transform: Some(TransformContext {
+                    function: TransformFunc(candid::Func {
+                        principal: get_proxy_canister_id(&env).into(),
+                        method: "idontexist".to_string(),
+                    }),
+                    context: vec![0, 1, 2],
+                }),
+                max_response_bytes: None,
+            },
+            cycles: 500_000_000_000,
+        },
+    ));
+
+    assert_matches!(response, Err((RejectionCode::CanisterError, _)))
 }
 
 pub fn test_post_request(env: TestEnv) {
     let handlers = Handlers::new(&env);
     let webserver_ipv6 = get_universal_vm_address(&env);
 
-    block_on(async {
-        assert!(
-            test_canister_http_property(
-                &handlers.logger,
-                &handlers.proxy_canister(),
-                RemoteHttpRequest {
-                    request: CanisterHttpRequestArgs {
-                        url: format!("https://[{webserver_ipv6}]:20443/post"),
-                        headers: BoundedHttpHeaders::new(vec![HttpHeader {
-                            name: "Content-Type".to_string(),
-                            value: "application/x-www-form-urlencoded".to_string(),
-                        }]),
-                        method: HttpMethod::POST,
-                        body: Some("satoshi=me".as_bytes().to_vec()),
-                        transform: Some(TransformContext {
-                            function: TransformFunc(candid::Func {
-                                principal: get_proxy_canister_id(&env).into(),
-                                method: "transform".to_string(),
-                            }),
-                            context: vec![0, 1, 2],
-                        }),
-                        max_response_bytes: None,
-                    },
-                    cycles: 500_000_000_000,
-                },
-                |response| matches!(response, Ok(r) if r.body.contains("satoshi")),
-            )
-            .await,
-        )
-    });
+    let response = block_on(submit_outcall(
+        &handlers.proxy_canister(),
+        RemoteHttpRequest {
+            request: CanisterHttpRequestArgs {
+                url: format!("https://[{webserver_ipv6}]:20443/post"),
+                headers: BoundedHttpHeaders::new(vec![HttpHeader {
+                    name: "content-type".to_string(),
+                    value: "application/x-www-form-urlencoded".to_string(),
+                }]),
+                method: HttpMethod::POST,
+                body: Some("satoshi".as_bytes().to_vec()),
+                transform: Some(TransformContext {
+                    function: TransformFunc(candid::Func {
+                        principal: get_proxy_canister_id(&env).into(),
+                        method: "transform".to_string(),
+                    }),
+                    context: vec![0, 1, 2],
+                }),
+                max_response_bytes: None,
+            },
+            cycles: 500_000_000_000,
+        },
+    ));
+
+    assert_matches!(response, Ok(r) if r.body.contains("satoshi"));
 }
 
 pub fn test_http_endpoint_response_is_too_large(env: TestEnv) {
     let handlers = Handlers::new(&env);
     let webserver_ipv6 = get_universal_vm_address(&env);
 
-    block_on(async {
-        assert!(
-            test_canister_http_property(
-                &handlers.logger,
-                &handlers.proxy_canister(),
-                RemoteHttpRequest {
-                    request: CanisterHttpRequestArgs {
-                        url: format!("https://[{webserver_ipv6}]:20443/bytes/100000"),
-                        headers: BoundedHttpHeaders::new(vec![]),
-                        method: HttpMethod::GET,
-                        body: Some("".as_bytes().to_vec()),
-                        transform: Some(TransformContext {
-                            function: TransformFunc(candid::Func {
-                                principal: get_proxy_canister_id(&env).into(),
-                                method: "transform".to_string(),
-                            }),
-                            context: vec![0, 1, 2],
-                        }),
-                        max_response_bytes: Some(8 * 1024),
-                    },
-                    cycles: 500_000_000_000,
-                },
-                |response| matches!(response, Err((RejectionCode::SysFatal, _))),
-            )
-            .await,
-        )
-    });
+    let response = block_on(submit_outcall(
+        &handlers.proxy_canister(),
+        RemoteHttpRequest {
+            request: CanisterHttpRequestArgs {
+                url: format!("https://[{webserver_ipv6}]:20443/bytes/100000"),
+                headers: BoundedHttpHeaders::new(vec![]),
+                method: HttpMethod::GET,
+                body: Some("".as_bytes().to_vec()),
+                transform: Some(TransformContext {
+                    function: TransformFunc(candid::Func {
+                        principal: get_proxy_canister_id(&env).into(),
+                        method: "transform".to_string(),
+                    }),
+                    context: vec![0, 1, 2],
+                }),
+                max_response_bytes: Some(8 * 1024),
+            },
+            cycles: 500_000_000_000,
+        },
+    ));
+
+    assert_matches!(response, Err((RejectionCode::SysFatal, _)));
 }
 
 pub fn test_http_endpoint_with_delayed_response_is_rejected(env: TestEnv) {
     let handlers = Handlers::new(&env);
     let webserver_ipv6 = get_universal_vm_address(&env);
 
-    block_on(async {
-        assert!(
-            test_canister_http_property(
-                &handlers.logger,
-                &handlers.proxy_canister(),
-                RemoteHttpRequest {
-                    request: CanisterHttpRequestArgs {
-                        url: format!("https://[{webserver_ipv6}]:20443/delay/40"),
-                        headers: BoundedHttpHeaders::new(vec![]),
-                        method: HttpMethod::GET,
-                        body: Some("".as_bytes().to_vec()),
-                        transform: Some(TransformContext {
-                            function: TransformFunc(candid::Func {
-                                principal: get_proxy_canister_id(&env).into(),
-                                method: "transform".to_string(),
-                            }),
-                            context: vec![0, 1, 2],
-                        }),
-                        max_response_bytes: None,
-                    },
-                    cycles: 500_000_000_000,
-                },
-                |response| matches!(response, Err((RejectionCode::SysFatal, _))),
-            )
-            .await,
-        )
-    });
+    let response = block_on(submit_outcall(
+        &handlers.proxy_canister(),
+        RemoteHttpRequest {
+            request: CanisterHttpRequestArgs {
+                url: format!("https://[{webserver_ipv6}]:20443/delay/40"),
+                headers: BoundedHttpHeaders::new(vec![]),
+                method: HttpMethod::GET,
+                body: Some("".as_bytes().to_vec()),
+                transform: Some(TransformContext {
+                    function: TransformFunc(candid::Func {
+                        principal: get_proxy_canister_id(&env).into(),
+                        method: "transform".to_string(),
+                    }),
+                    context: vec![0, 1, 2],
+                }),
+                max_response_bytes: None,
+            },
+            cycles: 500_000_000_000,
+        },
+    ));
+
+    assert_matches!(response, Err((RejectionCode::SysFatal, _)));
 }
 
 /// The adapter should not follow HTTP redirects.
@@ -626,111 +558,79 @@ pub fn test_that_redirects_are_not_followed(env: TestEnv) {
     let handlers = Handlers::new(&env);
     let webserver_ipv6 = get_universal_vm_address(&env);
 
-    block_on(async {
-        assert!(
-            test_canister_http_property(
-                &handlers.logger,
-                &handlers.proxy_canister(),
-                RemoteHttpRequest {
-                    request: CanisterHttpRequestArgs {
-                        url: format!("https://[{webserver_ipv6}]:20443/redirect/10"),
-                        headers: BoundedHttpHeaders::new(vec![]),
-                        method: HttpMethod::GET,
-                        body: Some("".as_bytes().to_vec()),
-                        transform: Some(TransformContext {
-                            function: TransformFunc(candid::Func {
-                                principal: get_proxy_canister_id(&env).into(),
-                                method: "transform".to_string(),
-                            }),
-                            context: vec![0, 1, 2],
-                        }),
-                        max_response_bytes: None,
-                    },
-                    cycles: 500_000_000_000,
-                },
-                |response| matches!(response, Ok(r) if r.status == 303),
-            )
-            .await,
-        )
-    });
+    let response = block_on(submit_outcall(
+        &handlers.proxy_canister(),
+        RemoteHttpRequest {
+            request: CanisterHttpRequestArgs {
+                url: format!("https://[{webserver_ipv6}]:20443/redirect/10"),
+                headers: BoundedHttpHeaders::new(vec![]),
+                method: HttpMethod::GET,
+                body: Some("".as_bytes().to_vec()),
+                transform: Some(TransformContext {
+                    function: TransformFunc(candid::Func {
+                        principal: get_proxy_canister_id(&env).into(),
+                        method: "transform".to_string(),
+                    }),
+                    context: vec![0, 1, 2],
+                }),
+                max_response_bytes: None,
+            },
+            cycles: 500_000_000_000,
+        },
+    ));
+
+    assert_matches!(response, Ok(r) if r.status == 303);
 }
 
-/// The adapter should not reject HTTP calls that are made to other IC replicas' HTTPS endpoints.
+/// The adapter should reject HTTP calls that are made to other IC replicas' HTTPS endpoints.
 pub fn test_http_calls_to_ic_fails(env: TestEnv) {
     let handlers = Handlers::new(&env);
     let webserver_ipv6 = get_universal_vm_address(&env);
 
-    block_on(async {
-        assert!(
-            test_canister_http_property(
-                &handlers.logger,
-                &handlers.proxy_canister(),
-                RemoteHttpRequest {
-                    request: CanisterHttpRequestArgs {
-                        url: format!("https://[{}]:9090", webserver_ipv6),
-                        headers: BoundedHttpHeaders::new(vec![]),
-                        method: HttpMethod::GET,
-                        body: Some("".as_bytes().to_vec()),
-                        transform: Some(TransformContext {
-                            function: TransformFunc(candid::Func {
-                                principal: get_proxy_canister_id(&env).into(),
-                                method: "transform".to_string(),
-                            }),
-                            context: vec![0, 1, 2],
-                        }),
-                        max_response_bytes: None,
-                    },
-                    cycles: 500_000_000_000,
-                },
-                |response| {
-                    let err_response = response.clone().unwrap_err();
-                    matches!(err_response.0, RejectionCode::SysTransient)
-                        && err_response.1.contains("client error (Connect)")
-                },
-            )
-            .await,
-        )
-    });
+    let response = block_on(submit_outcall(
+        &handlers.proxy_canister(),
+        RemoteHttpRequest {
+            request: CanisterHttpRequestArgs {
+                url: format!("https://[{}]:9090", webserver_ipv6),
+                headers: BoundedHttpHeaders::new(vec![]),
+                method: HttpMethod::GET,
+                body: Some("".as_bytes().to_vec()),
+                transform: Some(TransformContext {
+                    function: TransformFunc(candid::Func {
+                        principal: get_proxy_canister_id(&env).into(),
+                        method: "transform".to_string(),
+                    }),
+                    context: vec![0, 1, 2],
+                }),
+                max_response_bytes: None,
+            },
+            cycles: 500_000_000_000,
+        },
+    ));
+
+    let err_response = response.clone().unwrap_err();
+    assert_matches!(err_response.0, RejectionCode::SysTransient);
+    assert!(
+        err_response.1.contains("client error (Connect)"),
+        "Response did not container client error: {}",
+        err_response.1
+    );
 }
 
-async fn test_canister_http_property<F>(
-    logger: &Logger,
+type OutcallsResponse = Result<RemoteHttpResponse, (RejectionCode, String)>;
+
+async fn submit_outcall(
     proxy_canister: &Canister<'_>,
     request: RemoteHttpRequest,
-    response_check: F,
-) -> bool
-where
-    F: Fn(&Result<RemoteHttpResponse, (RejectionCode, String)>) -> bool,
-{
-    let test_result = ic_system_test_driver::retry_with_msg_async!(
-        format!(
-            "checking send_request of proxy canister {}",
-            proxy_canister.canister_id()
-        ),
-        logger,
-        Duration::from_secs(60),
-        RETRY_BACKOFF,
-        || async {
-            let res = proxy_canister
-                .update_(
-                    "send_request",
-                    candid_one::<
-                        Result<RemoteHttpResponse, (RejectionCode, String)>,
-                        RemoteHttpRequest,
-                    >,
-                    request.clone(),
-                )
-                .await
-                .expect("Update call to proxy canister failed");
-            if !response_check(&res) {
-                bail!("Http request didn't pass check: {:?}", &res);
-            }
-            Ok(())
-        }
-    )
-    .await;
-
-    test_result.is_ok()
+) -> OutcallsResponse {
+    proxy_canister
+        .update_(
+            "send_request",
+            candid_one::<OutcallsResponse, RemoteHttpRequest>,
+            request.clone(),
+        )
+        .await
+        .expect("Request completes.")
 }
 
 /// Pricing function of canister http requests.


### PR DESCRIPTION
This PR:
- Refactors all https correctness tests to give diagnostics on what failed for each test case.
- Removes an unsafe unwrap of host name in teh http bin server, used for testing. The host name header is not used in http/2, causing the server to crash, which failed the system tests when we enable http/2 for outcalls