### PR TITLE
fix: update ic.json5 nns_urls references

### DIFF
--- a/rs/orchestrator/src/firewall.rs
+++ b/rs/orchestrator/src/firewall.rs
@@ -846,7 +846,7 @@ mod tests {
             .replace("{{ ipv6_address }}", "::")
             .replace("{{ backup_retention_time_secs }}", "0")
             .replace("{{ backup_purging_interval_secs }}", "0")
-            .replace("{{ nns_url }}", "http://www.fakeurl.com/")
+            .replace("{{ nns_urls }}", "http://www.fakeurl.com/")
             .replace("{{ malicious_behavior }}", "null")
             .replace("{{ query_stats_epoch_length }}", "600");
         let config_source = ConfigSource::Literal(cfg);

--- a/rs/tests/driver/src/util.rs
+++ b/rs/tests/driver/src/util.rs
@@ -1410,7 +1410,7 @@ pub fn get_config() -> ConfigOptional {
         .replace("{{ ipv6_address }}", "::")
         .replace("{{ backup_retention_time_secs }}", "0")
         .replace("{{ backup_purging_interval_secs }}", "0")
-        .replace("{{ nns_url }}", "http://www.fakeurl.com/")
+        .replace("{{ nns_urls }}", "http://www.fakeurl.com/")
         .replace("{{ malicious_behavior }}", "null")
         .replace("{{ query_stats_epoch_length }}", "600");
 


### PR DESCRIPTION
`nns_url` was updated to `nns_urls` in ic.json.template here: https://github.com/dfinity/ic/pull/1970

But these two references were missed.