### PR TITLE
refactor(nns): Remove dfn_candid from test_utils, simplify method

### DIFF
--- a/rs/nns/handlers/root/impl/tests/test_change_canister_controllers.rs
+++ b/rs/nns/handlers/root/impl/tests/test_change_canister_controllers.rs
@@ -1,4 +1,3 @@
-use dfn_candid::candid_one;
 use ic_base_types::{CanisterId, PrincipalId};
 use ic_nervous_system_clients::{
     canister_id_record::CanisterIdRecord,
@@ -99,7 +98,6 @@ fn test_change_canister_controllers_integrates_with_management_canister() {
         &machine,
         ROOT_CANISTER_ID,
         "canister_status",
-        candid_one,
         CanisterIdRecord::from(universal),
         PrincipalId::new_anonymous(),
     )
@@ -111,11 +109,11 @@ fn test_change_canister_controllers_integrates_with_management_canister() {
 
     // calls to change_canister_controllers from unauthorized callers should fail
     let unauthorized_caller = CanisterId::from_u64(1000).get();
-    let err = update_with_sender(
+
+    let err = update_with_sender::<_, ChangeCanisterControllersResponse>(
         &machine,
         ROOT_CANISTER_ID,
         "change_canister_controllers",
-        candid_one::<ChangeCanisterControllersRequest, _>,
         ChangeCanisterControllersRequest {
             target_canister_id: universal.get(),
             new_controllers: vec![ROOT_CANISTER_ID.get(), test_canister_id.get()],
@@ -130,7 +128,6 @@ fn test_change_canister_controllers_integrates_with_management_canister() {
         &machine,
         ROOT_CANISTER_ID,
         "change_canister_controllers",
-        candid_one,
         ChangeCanisterControllersRequest {
             target_canister_id: universal.get(),
             new_controllers: vec![ROOT_CANISTER_ID.get(), test_canister_id.get()],
@@ -151,7 +148,6 @@ fn test_change_canister_controllers_integrates_with_management_canister() {
         &machine,
         ROOT_CANISTER_ID,
         "canister_status",
-        candid_one,
         CanisterIdRecord::from(universal),
         PrincipalId::new_anonymous(),
     )

--- a/rs/nns/handlers/root/impl/tests/test_open_calls_tracking.rs
+++ b/rs/nns/handlers/root/impl/tests/test_open_calls_tracking.rs
@@ -1,5 +1,4 @@
 use candid::{Decode, Encode};
-use dfn_candid::candid_one;
 use ic_base_types::PrincipalId;
 use ic_canisters_http_types::{HttpRequest, HttpResponse};
 use ic_nervous_system_clients::{
@@ -28,11 +27,10 @@ fn test_canister_status_call_tracking() {
     let universal = set_up_universal_canister(&machine, None);
 
     // Canister status call should fail as NNS Root is not a controller.
-    assert!(update_with_sender(
+    assert!(update_with_sender::<_, CanisterStatusResult>(
         &machine,
         ROOT_CANISTER_ID,
         "canister_status",
-        candid_one::<CanisterStatusResult, CanisterIdRecord>,
         CanisterIdRecord::from(universal),
         PrincipalId::new_anonymous(),
     )

--- a/rs/nns/integration_tests/src/canister_playground.rs
+++ b/rs/nns/integration_tests/src/canister_playground.rs
@@ -1,5 +1,4 @@
 use canister_test::Project;
-use dfn_candid::candid_one;
 use ic_base_types::PrincipalId;
 use ic_nns_test_utils::state_test_helpers::{
     create_canister, state_machine_builder_for_nns_tests, update_with_sender,
@@ -20,7 +19,6 @@ fn test_canister_playground() {
         &state_machine,
         playground_id,
         "test",
-        candid_one,
         (),
         PrincipalId::new_anonymous(),
     )

--- a/rs/nns/integration_tests/src/cycles_minting_canister.rs
+++ b/rs/nns/integration_tests/src/cycles_minting_canister.rs
@@ -303,8 +303,7 @@ fn canister_status(
         machine,
         CanisterId::ic_00(),
         "canister_status",
-        candid_one,
-        &CanisterIdRecord::from(target),
+        CanisterIdRecord::from(target),
         sender,
     )
 }

--- a/rs/nns/integration_tests/src/governance_upgrade.rs
+++ b/rs/nns/integration_tests/src/governance_upgrade.rs
@@ -136,7 +136,6 @@ fn test_root_restarts_canister_during_upgrade_canister_with_stop_canister_timeou
         &state_machine,
         ROOT_CANISTER_ID,
         "change_nns_canister",
-        candid_one,
         proposal,
         GOVERNANCE_CANISTER_ID.get(),
     )
@@ -153,7 +152,6 @@ fn test_root_restarts_canister_during_upgrade_canister_with_stop_canister_timeou
         &state_machine,
         ROOT_CANISTER_ID,
         "canister_status",
-        candid_one,
         CanisterIdRecord::from(GOVERNANCE_CANISTER_ID),
         PrincipalId::new_anonymous(),
     )
@@ -170,7 +168,6 @@ fn test_root_restarts_canister_during_upgrade_canister_with_stop_canister_timeou
         &state_machine,
         ROOT_CANISTER_ID,
         "canister_status",
-        candid_one,
         CanisterIdRecord::from(GOVERNANCE_CANISTER_ID),
         PrincipalId::new_anonymous(),
     )

--- a/rs/nns/integration_tests/src/lifeline.rs
+++ b/rs/nns/integration_tests/src/lifeline.rs
@@ -1,5 +1,4 @@
 use canister_test::Project;
-use dfn_candid::candid_one;
 use ic_base_types::CanisterId;
 use ic_management_canister_types::{CanisterInstallMode, CanisterStatusType};
 use ic_nervous_system_clients::canister_id_record::CanisterIdRecord;
@@ -253,7 +252,6 @@ fn test_lifeline_canister_restarts_root_on_stop_canister_timeout() {
         &state_machine,
         CanisterId::ic_00(),
         "uninstall_code",
-        candid_one,
         CanisterIdRecord::from(ROOT_CANISTER_ID),
         LIFELINE_CANISTER_ID.get(),
     )

--- a/rs/nns/integration_tests/src/node_provider_remuneration.rs
+++ b/rs/nns/integration_tests/src/node_provider_remuneration.rs
@@ -1,6 +1,5 @@
 use candid::{Decode, Encode};
 use cycles_minting_canister::IcpXdrConversionRateCertifiedResponse;
-use dfn_candid::candid_one;
 use ic_canister_client_sender::Sender;
 use ic_nervous_system_common::{ONE_DAY_SECONDS, ONE_MONTH_SECONDS};
 use ic_nervous_system_common_test_keys::{
@@ -764,7 +763,6 @@ fn set_icp_xdr_conversion_rate(
         state_machine,
         CYCLES_MINTING_CANISTER_ID,
         "set_icp_xdr_conversion_rate",
-        candid_one,
         payload,
         GOVERNANCE_CANISTER_ID.get(),
     )

--- a/rs/nns/integration_tests/src/reset_root.rs
+++ b/rs/nns/integration_tests/src/reset_root.rs
@@ -1,4 +1,3 @@
-use dfn_candid::candid_one;
 use ic_crypto_sha2::Sha256;
 use ic_nervous_system_common_test_keys::{TEST_NEURON_1_ID, TEST_NEURON_1_OWNER_PRINCIPAL};
 use ic_nns_common::pb::v1::NeuronId;
@@ -106,7 +105,6 @@ fn test_other_controllers_cannot_reset_root() {
         &state_machine,
         LIFELINE_CANISTER_ID,
         "hard_reset_root_to_version",
-        candid_one,
         payload,
         *TEST_NEURON_1_OWNER_PRINCIPAL,
     );

--- a/rs/nns/sns-wasm/tests/common/mod.rs
+++ b/rs/nns/sns-wasm/tests/common/mod.rs
@@ -1,6 +1,5 @@
 use candid::Encode;
 use canister_test::Project;
-use dfn_candid::candid_one;
 use ic_base_types::{CanisterId, PrincipalId};
 use ic_nervous_system_common::ONE_TRILLION;
 use ic_nns_constants::SNS_WASM_CANISTER_ID;
@@ -52,7 +51,6 @@ pub fn get_deployed_sns_by_proposal_id(
         machine,
         SNS_WASM_CANISTER_ID,
         "get_deployed_sns_by_proposal_id",
-        candid_one,
         GetDeployedSnsByProposalIdRequest { proposal_id },
         PrincipalId::new_anonymous(),
     )

--- a/rs/nns/sns-wasm/tests/deploy_new_sns.rs
+++ b/rs/nns/sns-wasm/tests/deploy_new_sns.rs
@@ -3,7 +3,6 @@ use crate::common::{
     EXPECTED_SNS_CREATION_FEE,
 };
 use canister_test::Wasm;
-use dfn_candid::candid_one;
 use ic_base_types::{CanisterId, PrincipalId};
 use ic_nervous_system_clients::canister_status::CanisterStatusType::Running;
 use ic_nervous_system_common::ONE_TRILLION;
@@ -63,7 +62,6 @@ fn test_canisters_are_created_and_installed() {
         &state_machine,
         CanisterId::unchecked_from_principal(root_canister_id),
         "get_sns_canisters_summary",
-        candid_one,
         GetSnsCanistersSummaryRequest {
             update_canister_list: None,
         },
@@ -386,7 +384,6 @@ fn test_deploy_sns_and_transfer_dapps() {
         &machine,
         CanisterId::unchecked_from_principal(root_canister_principal),
         "get_sns_canisters_summary",
-        candid_one,
         GetSnsCanistersSummaryRequest {
             update_canister_list: None,
         },

--- a/rs/nns/sns-wasm/tests/upgrade_sns_instance.rs
+++ b/rs/nns/sns-wasm/tests/upgrade_sns_instance.rs
@@ -1,7 +1,6 @@
 use crate::common::EXPECTED_SNS_CREATION_FEE;
 use candid::{Decode, Encode, Nat};
 use canister_test::Project;
-use dfn_candid::candid_one;
 use ic_base_types::{CanisterId, PrincipalId};
 use ic_icrc1_ledger::LedgerArgument;
 use ic_management_canister_types::{CanisterIdRecord, CanisterInstallMode};
@@ -187,7 +186,6 @@ fn test_governance_restarts_root_if_root_cannot_stop_during_upgrade() {
             &machine,
             CanisterId::ic_00(),
             "canister_status",
-            candid_one,
             CanisterIdRecord::from(root),
             governance.get(),
         )
@@ -645,7 +643,6 @@ fn upgrade_archive_sns_canister_via_sns_wasms() {
         &machine,
         ledger,
         "icrc1_transfer",
-        candid_one,
         TransferArg {
             from_subaccount: None,
             to: Account {
@@ -907,7 +904,6 @@ fn test_out_of_sync_version_still_allows_upgrade_to_succeed() {
         &machine,
         ledger,
         "icrc1_transfer",
-        candid_one,
         TransferArg {
             from_subaccount: None,
             to: Account {
@@ -1226,7 +1222,6 @@ fn insert_upgrade_path_entries_only_callable_by_governance_when_access_controls_
         &machine,
         SNS_WASM_CANISTER_ID,
         "insert_upgrade_path_entries",
-        candid_one,
         InsertUpgradePathEntriesRequest {
             upgrade_path: vec![],
             sns_governance_canister_id: None,
@@ -1261,7 +1256,6 @@ fn insert_upgrade_path_entries_callable_by_anyone_when_access_controls_disabled(
         &machine,
         SNS_WASM_CANISTER_ID,
         "insert_upgrade_path_entries",
-        candid_one,
         InsertUpgradePathEntriesRequest {
             upgrade_path: vec![],
             sns_governance_canister_id: None,

--- a/rs/nns/test_utils/src/sns_wasm.rs
+++ b/rs/nns/test_utils/src/sns_wasm.rs
@@ -4,7 +4,6 @@ use crate::{
 };
 use candid::{Decode, Encode};
 use canister_test::Project;
-use dfn_candid::candid_one;
 use ic_base_types::CanisterId;
 use ic_nervous_system_common_test_keys::{TEST_NEURON_1_ID, TEST_NEURON_1_OWNER_PRINCIPAL};
 use ic_nervous_system_common_test_utils::wasm_helpers;
@@ -186,7 +185,6 @@ fn make_proposal_with_test_neuron_1(env: &StateMachine, proposal: Proposal) -> P
         env,
         GOVERNANCE_CANISTER_ID,
         "manage_neuron",
-        candid_one,
         ManageNeuron {
             id: None,
             command: Some(Command::MakeProposal(Box::new(proposal))),
@@ -285,7 +283,6 @@ pub fn deploy_new_sns(
         env,
         sns_wasm_canister_id,
         "deploy_new_sns",
-        candid_one,
         DeployNewSnsRequest {
             sns_init_payload: Some(sns_init_payload),
         },

--- a/rs/nns/test_utils/src/state_test_helpers.rs
+++ b/rs/nns/test_utils/src/state_test_helpers.rs
@@ -8,7 +8,6 @@ use canister_test::Wasm;
 use cycles_minting_canister::{
     IcpXdrConversionRateCertifiedResponse, SetAuthorizedSubnetworkListArgs,
 };
-use dfn_candid::candid_one;
 use dfn_http::types::{HttpRequest, HttpResponse};
 use dfn_protobuf::ToProto;
 use ic_base_types::{CanisterId, PrincipalId, SubnetId};
@@ -76,7 +75,6 @@ use icrc_ledger_types::icrc1::{
     transfer::{TransferArg, TransferError},
 };
 use num_traits::ToPrimitive;
-use on_wire::{FromWire, IntoWire, NewType};
 use prost::Message;
 use serde::Serialize;
 use std::{convert::TryInto, env, time::Duration};
@@ -211,33 +209,30 @@ pub fn update(
     }
 }
 
-pub fn update_with_sender<Payload, ReturnType, Witness>(
+pub fn update_with_sender<Payload, ReturnType>(
     machine: &StateMachine,
     canister_target: CanisterId,
     method_name: &str,
-    _: Witness,
-    payload: Payload::Inner,
+    payload: Payload,
     sender: PrincipalId,
-) -> Result<ReturnType::Inner, String>
+) -> Result<ReturnType, String>
 where
-    Payload: IntoWire + NewType,
-    Witness: FnOnce(ReturnType, Payload::Inner) -> (ReturnType::Inner, Payload),
-    ReturnType: FromWire + NewType,
+    Payload: CandidType,
+    ReturnType: CandidType + for<'de> serde::Deserialize<'de>,
 {
     // move time forward
     machine.advance_time(Duration::from_secs(2));
-    let payload = Payload::from_inner(payload);
     let result = machine
         .execute_ingress_as(
             sender,
             canister_target,
             method_name,
-            payload.into_bytes().unwrap(),
+            Encode!(&payload).unwrap(),
         )
         .map_err(|e| e.to_string())?;
 
     match result {
-        WasmResult::Reply(v) => FromWire::from_bytes(v).map(|x: ReturnType| x.into_inner()),
+        WasmResult::Reply(v) => Decode!(&v, ReturnType).map_err(|e| e.to_string()),
         WasmResult::Reject(s) => Err(format!("Canister rejected with message: {}", s)),
     }
 }
@@ -341,7 +336,6 @@ pub fn set_controllers(
         machine,
         CanisterId::ic_00(),
         "update_settings",
-        candid_one,
         UpdateSettingsArgs {
             canister_id: target.into(),
             settings: CanisterSettingsArgsBuilder::new()
@@ -364,8 +358,7 @@ pub fn get_controllers(
         machine,
         CanisterId::ic_00(),
         "canister_status",
-        candid_one,
-        &CanisterIdRecord::from(target),
+        CanisterIdRecord::from(target),
         sender,
     )
     .unwrap();
@@ -383,8 +376,7 @@ pub fn get_canister_status(
         machine,
         canister_target,
         "canister_status",
-        candid_one,
-        &CanisterIdRecord::from(target),
+        CanisterIdRecord::from(target),
         sender,
     )
 }
@@ -403,8 +395,7 @@ pub fn get_canister_status_from_root(
         machine,
         ROOT_CANISTER_ID,
         "canister_status",
-        candid_one,
-        &CanisterIdRecord::from(target),
+        CanisterIdRecord::from(target),
         PrincipalId::new_anonymous(),
     )
     .unwrap()
@@ -1727,14 +1718,8 @@ pub fn icrc1_transfer(
     sender: PrincipalId,
     args: TransferArg,
 ) -> Result<BlockIndex, String> {
-    let result: Result<Result<Nat, TransferError>, String> = update_with_sender(
-        machine,
-        ledger_id,
-        "icrc1_transfer",
-        candid_one,
-        args,
-        sender,
-    );
+    let result: Result<Result<Nat, TransferError>, String> =
+        update_with_sender(machine, ledger_id, "icrc1_transfer", args, sender);
 
     let result = result.unwrap();
     match result {
@@ -1783,7 +1768,6 @@ pub fn sns_claim_staked_neuron(
         machine,
         governance_canister_id,
         "manage_neuron",
-        candid_one,
         sns_pb::ManageNeuron {
             subaccount: to_subaccount.to_vec(),
             command: Some(sns_pb::manage_neuron::Command::ClaimOrRefresh(
@@ -1860,7 +1844,6 @@ pub fn sns_increase_dissolve_delay(
         machine,
         governance_canister_id,
         "manage_neuron",
-        candid_one,
         payload,
         sender,
     )
@@ -1895,7 +1878,6 @@ pub fn sns_make_proposal(
         machine,
         sns_governance_canister_id,
         "manage_neuron",
-        candid_one,
         sns_pb::ManageNeuron {
             subaccount: sub_account.to_vec(),
             command: Some(sns_pb::manage_neuron::Command::MakeProposal(proposal)),

--- a/rs/sns/integration_tests/src/root.rs
+++ b/rs/sns/integration_tests/src/root.rs
@@ -1,6 +1,6 @@
 use candid::{Decode, Encode};
 use canister_test::Project;
-use dfn_candid::{candid, candid_one};
+use dfn_candid::candid;
 use ic_base_types::{CanisterId, PrincipalId};
 use ic_ledger_core::Tokens;
 use ic_management_canister_types::CanisterInstallMode;
@@ -285,7 +285,6 @@ fn test_root_restarts_governance_on_stop_canister_timeout() {
         &state_machine,
         CanisterId::ic_00(),
         "uninstall_code",
-        candid_one,
         CanisterIdRecord::from(scenario.governance_canister_id),
         scenario.root_canister_id.get(),
     )
@@ -323,7 +322,6 @@ fn test_root_restarts_governance_on_stop_canister_timeout() {
         &state_machine,
         scenario.root_canister_id,
         "change_canister",
-        candid_one,
         proposal,
         scenario.governance_canister_id.get(),
     )


### PR DESCRIPTION
This removes  simplifies the usage of a method to no longer require witnesses (but instead always just use candid encoders/decoders), as there are no instances of using it in any other way.  Moves us closer to removing dependency on dfn_candid.