### PR TITLE
feat: EXC-1758: Evict sandboxes based on their RSS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5989,6 +5989,7 @@ dependencies = [
  "memory_tracker",
  "mockall 0.13.0",
  "nix 0.24.3",
+ "num-traits",
  "once_cell",
  "prometheus",
  "rayon",

--- a/rs/canister_sandbox/BUILD.bazel
+++ b/rs/canister_sandbox/BUILD.bazel
@@ -28,6 +28,7 @@ DEPENDENCIES = [
     "@crate_index//:libc",
     "@crate_index//:libflate",
     "@crate_index//:nix",
+    "@crate_index//:num-traits",
     "@crate_index//:once_cell",
     "@crate_index//:prometheus",
     "@crate_index//:rayon",

--- a/rs/canister_sandbox/Cargo.toml
+++ b/rs/canister_sandbox/Cargo.toml
@@ -32,6 +32,7 @@ libc = { workspace = true }
 libflate = { workspace = true }
 memory_tracker = { path = "../memory_tracker" }
 nix = { workspace = true }
+num-traits = { workspace = true }
 once_cell = "1.8"
 prometheus = { workspace = true }
 rayon = { workspace = true }

--- a/rs/canister_sandbox/src/replica_controller/sandbox_process_eviction.rs
+++ b/rs/canister_sandbox/src/replica_controller/sandbox_process_eviction.rs
@@ -1,11 +1,13 @@
+use num_traits::ops::saturating::SaturatingSub;
 use std::time::Instant;
 
-use ic_types::CanisterId;
+use ic_types::{CanisterId, NumBytes};
 
 #[derive(Clone, Eq, PartialEq, Debug)]
 pub(crate) struct EvictionCandidate {
     pub id: CanisterId,
     pub last_used: Instant,
+    pub rss: NumBytes,
 }
 
 /// Evicts the least recently used candidates in order to bring the number of
@@ -26,30 +28,29 @@ pub(crate) struct EvictionCandidate {
 /// 4. Return the evicted candidates.
 pub(crate) fn evict(
     mut candidates: Vec<EvictionCandidate>,
-    min_count_threshold: usize,
+    mut total_rss: NumBytes,
     max_count_threshold: usize,
     last_used_threshold: Instant,
+    max_sandboxes_rss_size: NumBytes,
 ) -> Vec<EvictionCandidate> {
     candidates.sort_by_key(|x| x.last_used);
 
     let evict_at_least = candidates.len().saturating_sub(max_count_threshold);
-    let evict_at_most = candidates.len().saturating_sub(min_count_threshold);
 
     let mut evicted = vec![];
 
     for candidate in candidates.into_iter() {
-        if evicted.len() >= evict_at_most {
-            // Cannot evict anymore because at least `min_count_threshold`
-            // should remain not evicted.
-            break;
-        }
-        if candidate.last_used >= last_used_threshold && evicted.len() >= evict_at_least {
+        if candidate.last_used >= last_used_threshold
+            && evicted.len() >= evict_at_least
+            && total_rss <= max_sandboxes_rss_size
+        {
             // We have already evicted the minimum required number of candidates
             // and all the remaining candidates were not idle the recent
             // `last_used_threshold` time window. No need to evict more.
             break;
         }
-        evicted.push(candidate)
+        total_rss = total_rss.saturating_sub(&candidate.rss);
+        evicted.push(candidate);
     }
 
     evicted
@@ -60,12 +61,13 @@ mod tests {
     use std::time::{Duration, Instant};
 
     use ic_test_utilities_types::ids::canister_test_id;
+    use ic_types::NumBytes;
 
     use super::{evict, EvictionCandidate};
 
     #[test]
     fn evict_empty() {
-        assert_eq!(evict(vec![], 0, 0, Instant::now()), vec![],);
+        assert_eq!(evict(vec![], 0.into(), 0, Instant::now(), 0.into()), vec![],);
     }
 
     #[test]
@@ -76,9 +78,10 @@ mod tests {
             candidates.push(EvictionCandidate {
                 id: canister_test_id(i),
                 last_used: now,
+                rss: 0.into(),
             });
         }
-        assert_eq!(evict(candidates, 0, 10, now,), vec![],);
+        assert_eq!(evict(candidates, 0.into(), 10, now, 0.into()), vec![],);
     }
 
     #[test]
@@ -89,10 +92,11 @@ mod tests {
             candidates.push(EvictionCandidate {
                 id: canister_test_id(i),
                 last_used: now + Duration::from_secs(100 - i),
+                rss: 0.into(),
             });
         }
         assert_eq!(
-            evict(candidates.clone(), 0, 90, now,),
+            evict(candidates.clone(), 0.into(), 90, now, 0.into()),
             candidates.into_iter().rev().take(10).collect::<Vec<_>>()
         );
     }
@@ -105,10 +109,17 @@ mod tests {
             candidates.push(EvictionCandidate {
                 id: canister_test_id(i),
                 last_used: now - Duration::from_secs(i),
+                rss: 0.into(),
             });
         }
         assert_eq!(
-            evict(candidates.clone(), 0, 100, now - Duration::from_secs(50)),
+            evict(
+                candidates.clone(),
+                0.into(),
+                100,
+                now - Duration::from_secs(50),
+                0.into()
+            ),
             candidates.into_iter().rev().take(49).collect::<Vec<_>>()
         );
     }
@@ -120,12 +131,70 @@ mod tests {
         for i in 0..100 {
             candidates.push(EvictionCandidate {
                 id: canister_test_id(i),
-                last_used: now - Duration::from_secs(i + 1),
+                last_used: now - Duration::from_secs(i + 1) + Duration::from_secs(10),
+                rss: 0.into(),
             });
         }
         assert_eq!(
-            evict(candidates.clone(), 10, 100, now),
+            evict(candidates.clone(), 0.into(), 100, now, 0.into()),
             candidates.into_iter().rev().take(90).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn evict_none_due_to_rss() {
+        let mut candidates = vec![];
+        let now = Instant::now();
+        let mut total_rss = NumBytes::new(0);
+        for i in 0..100 {
+            candidates.push(EvictionCandidate {
+                id: canister_test_id(i),
+                last_used: now,
+                rss: 50.into(),
+            });
+            total_rss += 50.into();
+        }
+        assert_eq!(
+            evict(candidates.clone(), total_rss, 100, now, total_rss),
+            vec![]
+        );
+    }
+
+    #[test]
+    fn evict_some_due_to_rss() {
+        let mut candidates = vec![];
+        let now = Instant::now();
+        let mut total_rss = NumBytes::new(0);
+        for i in 0..100 {
+            candidates.push(EvictionCandidate {
+                id: canister_test_id(i),
+                last_used: now,
+                rss: 50.into(),
+            });
+            total_rss += 50.into();
+        }
+        assert_eq!(
+            evict(candidates.clone(), total_rss, 100, now, total_rss / 2),
+            candidates.into_iter().take(50).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn evict_all_due_to_rss() {
+        let mut candidates = vec![];
+        let now = Instant::now();
+        let mut total_rss = NumBytes::new(0);
+        for i in 0..100 {
+            candidates.push(EvictionCandidate {
+                id: canister_test_id(i),
+                last_used: now,
+                rss: 50.into(),
+            });
+            total_rss += 50.into();
+        }
+        assert_eq!(
+            evict(candidates.clone(), total_rss, 100, now, 0.into()),
+            candidates
         );
     }
 
@@ -137,8 +206,12 @@ mod tests {
             candidates.push(EvictionCandidate {
                 id: canister_test_id(i),
                 last_used: now - Duration::from_secs(i + 1),
+                rss: 0.into(),
             });
         }
-        assert_eq!(evict(candidates.clone(), 0, 100, now).len(), 100);
+        assert_eq!(
+            evict(candidates.clone(), 0.into(), 100, now, 0.into()).len(),
+            100
+        );
     }
 }

--- a/rs/canister_sandbox/src/replica_controller/sandboxed_execution_controller.rs
+++ b/rs/canister_sandbox/src/replica_controller/sandboxed_execution_controller.rs
@@ -1141,6 +1141,7 @@ impl SandboxedExecutionController {
     ) {
         loop {
             let sandbox_processes = get_sandbox_process_stats(&backends);
+            #[allow(unused_mut)] // for MacOS
             let mut sandbox_processes_rss = HashMap::with_capacity(sandbox_processes.len());
 
             #[cfg(target_os = "linux")]
@@ -1213,7 +1214,7 @@ impl SandboxedExecutionController {
                 let now = std::time::Instant::now();
                 // For all processes requested, get their memory usage and report
                 // it keyed by pid. Ignore processes failures to get
-                for (_sandbox_process, stats, status) in &sandbox_processes {
+                for (_canister_id, _sandbox_process, stats, status) in &sandbox_processes {
                     let time_since_last_usage = now
                         .checked_duration_since(stats.last_used)
                         .unwrap_or_else(|| std::time::Duration::from_secs(0));

--- a/rs/config/src/embedders.rs
+++ b/rs/config/src/embedders.rs
@@ -50,9 +50,8 @@ pub(crate) const DEFAULT_MAX_SANDBOX_COUNT: usize = 5_000;
 /// duration and sandbox process eviction is activated.
 pub(crate) const DEFAULT_MAX_SANDBOX_IDLE_TIME: Duration = Duration::from_secs(30 * 60);
 
-/// Sandbox processes may be evicted if their total RSS memory size
-/// exceeds 100 GiB.
-pub(crate) const DEFAULT_MAX_SANDBOXES_RSS_SIZE: NumBytes = NumBytes::new(100 * 1024 * 1024 * 1024);
+/// Sandbox processes may be evicted if their total RSS exceeds 100 GiB.
+pub(crate) const DEFAULT_MAX_SANDBOXES_RSS: NumBytes = NumBytes::new(100 * 1024 * 1024 * 1024);
 
 /// The maximum number of pages that a message dirties without optimizing dirty
 /// page copying by triggering a new execution slice for copying pages.
@@ -205,9 +204,9 @@ pub struct Config {
     /// duration and sandbox process eviction is activated.
     pub max_sandbox_idle_time: Duration,
 
-    /// Sandbox processes may be evicted if their total RSS memory size
-    /// exceeds the specified amount in bytes.
-    pub max_sandboxes_rss_size: NumBytes,
+    /// Sandbox processes may be evicted if their total RSS exceeds
+    /// the specified amount in bytes.
+    pub max_sandboxes_rss: NumBytes,
 
     /// The type of the local subnet. The default value here should be replaced
     /// with the correct value at runtime when the hypervisor is created.
@@ -267,7 +266,7 @@ impl Config {
             },
             max_sandbox_count: DEFAULT_MAX_SANDBOX_COUNT,
             max_sandbox_idle_time: DEFAULT_MAX_SANDBOX_IDLE_TIME,
-            max_sandboxes_rss_size: DEFAULT_MAX_SANDBOXES_RSS_SIZE,
+            max_sandboxes_rss: DEFAULT_MAX_SANDBOXES_RSS,
             subnet_type: SubnetType::Application,
             dirty_page_overhead: NumInstructions::new(0),
             trace_execution: FlagStatus::Disabled,

--- a/rs/config/src/embedders.rs
+++ b/rs/config/src/embedders.rs
@@ -50,8 +50,8 @@ pub(crate) const DEFAULT_MAX_SANDBOX_COUNT: usize = 5_000;
 /// duration and sandbox process eviction is activated.
 pub(crate) const DEFAULT_MAX_SANDBOX_IDLE_TIME: Duration = Duration::from_secs(30 * 60);
 
-/// Sandbox processes may be evicted if their total RSS exceeds 100 GiB.
-pub(crate) const DEFAULT_MAX_SANDBOXES_RSS: NumBytes = NumBytes::new(100 * 1024 * 1024 * 1024);
+/// Sandbox processes may be evicted if their total RSS exceeds 50 GiB.
+pub(crate) const DEFAULT_MAX_SANDBOXES_RSS: NumBytes = NumBytes::new(50 * 1024 * 1024 * 1024);
 
 /// The maximum number of pages that a message dirties without optimizing dirty
 /// page copying by triggering a new execution slice for copying pages.

--- a/rs/pocket_ic_server/src/pocket_ic.rs
+++ b/rs/pocket_ic_server/src/pocket_ic.rs
@@ -51,6 +51,7 @@ use ic_state_machine_tests::{
     StateMachineConfig, StateMachineStateDir, SubmitIngressError, Time,
 };
 use ic_test_utilities_registry::add_subnet_list_record;
+use ic_types::NumBytes;
 use ic_types::{
     artifact::UnvalidatedArtifactMutation,
     canister_http::{CanisterHttpReject, CanisterHttpRequestId, CanisterHttpResponseContent},
@@ -356,9 +357,10 @@ impl PocketIc {
             hypervisor_config.max_query_call_graph_instructions = instruction_limit;
         }
         // bound PocketIc resource consumption
-        hypervisor_config.embedders_config.min_sandbox_count = 0;
         hypervisor_config.embedders_config.max_sandbox_count = 64;
         hypervisor_config.embedders_config.max_sandbox_idle_time = Duration::from_secs(30);
+        hypervisor_config.embedders_config.max_sandboxes_rss_size =
+            NumBytes::new(2 * 1024 * 1024 * 1024);
         // shorter query stats epoch length for faster query stats aggregation
         hypervisor_config.query_stats_epoch_length = 60;
         // enable canister debug prints

--- a/rs/pocket_ic_server/src/pocket_ic.rs
+++ b/rs/pocket_ic_server/src/pocket_ic.rs
@@ -359,7 +359,7 @@ impl PocketIc {
         // bound PocketIc resource consumption
         hypervisor_config.embedders_config.max_sandbox_count = 64;
         hypervisor_config.embedders_config.max_sandbox_idle_time = Duration::from_secs(30);
-        hypervisor_config.embedders_config.max_sandboxes_rss_size =
+        hypervisor_config.embedders_config.max_sandboxes_rss =
             NumBytes::new(2 * 1024 * 1024 * 1024);
         // shorter query stats epoch length for faster query stats aggregation
         hypervisor_config.query_stats_epoch_length = 60;


### PR DESCRIPTION
This allows to increase the number of sandbox processes without risking the OOM as the total RSS size of sandboxes is still limited.

This PR also increases the number of sandbox processes to 5k.