### PR TITLE
feat: [UTP-242] [v2] Make subnet replica version of latest block available to execution environment

### DIFF
--- a/rs/consensus/src/consensus/batch_delivery.rs
+++ b/rs/consensus/src/consensus/batch_delivery.rs
@@ -233,6 +233,7 @@ pub fn deliver_batches(
             time: block.context.time,
             consensus_responses,
             blockmaker_metrics,
+            replica_version: block.version.clone(),
         };
 
         debug!(

--- a/rs/determinism_test/src/lib.rs
+++ b/rs/determinism_test/src/lib.rs
@@ -17,7 +17,7 @@ use ic_types::{
     ingress::{IngressState, IngressStatus, WasmResult},
     messages::{MessageId, SignedIngress},
     time::UNIX_EPOCH,
-    CanisterId, CryptoHashOfState, Randomness, RegistryVersion,
+    CanisterId, CryptoHashOfState, Randomness, RegistryVersion, ReplicaVersion,
 };
 use setup::setup;
 use std::{collections::BTreeMap, convert::TryFrom, sync::Arc, thread::sleep, time::Duration};
@@ -38,6 +38,7 @@ fn build_batch(message_routing: &dyn MessageRouting, msgs: Vec<SignedIngress>) -
         time: UNIX_EPOCH,
         consensus_responses: vec![],
         blockmaker_metrics: BlockmakerMetrics::new_for_test(),
+        replica_version: ReplicaVersion::default(),
     }
 }
 
@@ -54,6 +55,7 @@ fn build_batch_with_full_state_hash(message_routing: &dyn MessageRouting) -> Bat
         time: UNIX_EPOCH,
         consensus_responses: vec![],
         blockmaker_metrics: BlockmakerMetrics::new_for_test(),
+        replica_version: ReplicaVersion::default(),
     }
 }
 

--- a/rs/drun/src/lib.rs
+++ b/rs/drun/src/lib.rs
@@ -34,7 +34,6 @@ use ic_test_utilities_consensus::fake::FakeVerifier;
 use ic_test_utilities_registry::{
     add_subnet_record, insert_initial_dkg_transcript, SubnetRecordBuilder,
 };
-use ic_types::batch::{BatchMessages, BlockmakerMetrics};
 use ic_types::malicious_flags::MaliciousFlags;
 use ic_types::{
     batch::Batch,
@@ -42,6 +41,10 @@ use ic_types::{
     messages::{MessageId, SignedIngress},
     replica_config::ReplicaConfig,
     time, CanisterId, NodeId, NumInstructions, PrincipalId, Randomness, RegistryVersion, SubnetId,
+};
+use ic_types::{
+    batch::{BatchMessages, BlockmakerMetrics},
+    ReplicaVersion,
 };
 use rand::distributions::{Distribution, Uniform};
 use rand::rngs::StdRng;
@@ -386,6 +389,7 @@ fn build_batch(message_routing: &dyn MessageRouting, msgs: Vec<SignedIngress>) -
         time: time::current_time(),
         consensus_responses: vec![],
         blockmaker_metrics: BlockmakerMetrics::new_for_test(),
+        replica_version: ReplicaVersion::default(),
     }
 }
 /// Block till the given ingress message has finished executing and

--- a/rs/interfaces/src/execution_environment.rs
+++ b/rs/interfaces/src/execution_environment.rs
@@ -13,7 +13,8 @@ use ic_types::{
     crypto::canister_threshold_sig::MasterPublicKey,
     ingress::{IngressStatus, WasmResult},
     messages::{CertificateDelegation, MessageId, Query, SignedIngressContent},
-    CanisterLog, Cycles, ExecutionRound, Height, NumInstructions, NumOsPages, Randomness, Time,
+    CanisterLog, Cycles, ExecutionRound, Height, NumInstructions, NumOsPages, Randomness,
+    ReplicaVersion, Time,
 };
 use serde::{Deserialize, Serialize};
 use std::{
@@ -1184,6 +1185,8 @@ pub struct RegistryExecutionSettings {
     pub provisional_whitelist: ProvisionalWhitelist,
     pub chain_key_settings: BTreeMap<MasterPublicKeyId, ChainKeySettings>,
     pub subnet_size: usize,
+    /// This field is not from the registry, but from the most recent block.
+    pub replica_version: ReplicaVersion,
 }
 
 /// Chain key configuration of execution that comes from the registry.

--- a/rs/messaging/src/message_routing/tests.rs
+++ b/rs/messaging/src/message_routing/tests.rs
@@ -37,6 +37,7 @@ use ic_test_utilities_types::{
 };
 use ic_types::batch::BlockmakerMetrics;
 use ic_types::xnet::{StreamIndexedQueue, StreamSlice};
+use ic_types::ReplicaVersion;
 use ic_types::{
     batch::{Batch, BatchMessages},
     crypto::threshold_sig::ni_dkg::{NiDkgTag, NiDkgTranscript},
@@ -1043,6 +1044,7 @@ fn try_read_registry_succeeds_with_fully_specified_registry_records() {
             time: Time::from_nanos_since_unix_epoch(0),
             consensus_responses: Vec::new(),
             blockmaker_metrics: BlockmakerMetrics::new_for_test(),
+            replica_version: ReplicaVersion::default(),
         });
         let latest_state = state_manager.get_latest_state().take();
         assert_eq!(network_topology, latest_state.metadata.network_topology);
@@ -1842,6 +1844,7 @@ fn process_batch_updates_subnet_metrics() {
             time: Time::from_nanos_since_unix_epoch(0),
             consensus_responses: Vec::new(),
             blockmaker_metrics: BlockmakerMetrics::new_for_test(),
+            replica_version: ReplicaVersion::default(),
         });
 
         let latest_state = state_manager.get_latest_state().take();

--- a/rs/replay/src/player.rs
+++ b/rs/replay/src/player.rs
@@ -728,11 +728,12 @@ impl Player {
         pool: Option<&ConsensusPoolImpl>,
         mut extra: F,
     ) -> (Time, Option<(Height, Vec<IngressWithPrinter>)>) {
-        let (registry_version, time, randomness) = match pool {
+        let (registry_version, time, randomness, replica_version) = match pool {
             None => (
                 self.registry.get_latest_version(),
                 ic_types::time::current_time(),
                 Randomness::from([0; 32]),
+                ReplicaVersion::default(),
             ),
             Some(pool) => {
                 let pool = PoolReader::new(pool);
@@ -750,6 +751,7 @@ impl Player {
                     last_block.context.registry_version,
                     last_block.context.time + Duration::from_nanos(1),
                     Randomness::from(crypto_hashable_to_seed(&last_block)),
+                    last_block.version.clone(),
                 )
             }
         };
@@ -766,6 +768,7 @@ impl Player {
             time,
             consensus_responses: Vec::new(),
             blockmaker_metrics: BlockmakerMetrics::new_for_test(),
+            replica_version,
         };
         let context_time = extra_batch.time;
         let extra_msgs = extra(self, context_time);

--- a/rs/state_machine_tests/src/lib.rs
+++ b/rs/state_machine_tests/src/lib.rs
@@ -2338,6 +2338,7 @@ impl StateMachine {
             time: self.get_time_of_next_round(),
             consensus_responses: payload.consensus_responses,
             blockmaker_metrics: BlockmakerMetrics::new_for_test(),
+            replica_version: ReplicaVersion::default(),
         };
 
         self.message_routing

--- a/rs/test_utilities/execution_environment/src/lib.rs
+++ b/rs/test_utilities/execution_environment/src/lib.rs
@@ -61,7 +61,7 @@ use ic_types::{
         RequestOrResponse, Response, MAX_INTER_CANISTER_PAYLOAD_IN_BYTES,
     },
     time::UNIX_EPOCH,
-    CanisterId, Cycles, Height, NumInstructions, QueryStatsEpoch, Time, UserId,
+    CanisterId, Cycles, Height, NumInstructions, QueryStatsEpoch, ReplicaVersion, Time, UserId,
 };
 use ic_types_test_utils::ids::{node_test_id, subnet_test_id, user_test_id};
 use ic_universal_canister::UNIVERSAL_CANISTER_WASM;
@@ -142,6 +142,7 @@ pub fn test_registry_settings() -> RegistryExecutionSettings {
         provisional_whitelist: ProvisionalWhitelist::Set(BTreeSet::new()),
         chain_key_settings: BTreeMap::new(),
         subnet_size: SMALL_APP_SUBNET_MAX_SIZE,
+        replica_version: ReplicaVersion::default(),
     }
 }
 

--- a/rs/test_utilities/types/src/batch/batch_builder.rs
+++ b/rs/test_utilities/types/src/batch/batch_builder.rs
@@ -3,7 +3,7 @@ use std::collections::BTreeMap;
 use ic_types::{
     batch::{Batch, BatchMessages, BlockmakerMetrics},
     time::UNIX_EPOCH,
-    Height, Randomness, RegistryVersion, Time,
+    Height, Randomness, RegistryVersion, ReplicaVersion, Time,
 };
 
 pub struct BatchBuilder {
@@ -26,6 +26,7 @@ impl Default for BatchBuilder {
                 time: UNIX_EPOCH,
                 consensus_responses: vec![],
                 blockmaker_metrics: BlockmakerMetrics::new_for_test(),
+                replica_version: ReplicaVersion::default(),
             },
         }
     }

--- a/rs/types/types/src/batch.rs
+++ b/rs/types/types/src/batch.rs
@@ -22,7 +22,7 @@ use crate::{
     crypto::canister_threshold_sig::MasterPublicKey,
     messages::{CallbackId, Payload, SignedIngress},
     xnet::CertifiedStreamSlice,
-    Height, Randomness, RegistryVersion, SubnetId, Time,
+    Height, Randomness, RegistryVersion, ReplicaVersion, SubnetId, Time,
 };
 use ic_base_types::NodeId;
 use ic_btc_replica_types::BitcoinAdapterResponse;
@@ -64,6 +64,8 @@ pub struct Batch {
     pub consensus_responses: Vec<ConsensusResponse>,
     /// Information about block makers
     pub blockmaker_metrics: BlockmakerMetrics,
+    /// The current replica version.
+    pub replica_version: ReplicaVersion,
 }
 
 /// The context built by Consensus for deterministic processing. Captures all


### PR DESCRIPTION
Alternative to https://github.com/dfinity/ic/pull/2082

This PR makes the `replica_version` part of `RegistryExecutionSettings` so that the execution environment has access to it when processing messages. 

This PR will have a follow-up to make replica_version available via a management canister call as specified [here](https://github.com/dfinity/interface-spec/pull/351). 
