### PR TITLE
chore: Fix checkpointing of TaskQueue

### DIFF
--- a/rs/state_layout/src/state_layout.rs
+++ b/rs/state_layout/src/state_layout.rs
@@ -2393,9 +2393,9 @@ impl TryFrom<pb_canister_state_bits::CanisterStateBits> for CanisterStateBits {
             .into_iter()
             .map(|v| v.try_into())
             .collect::<Result<_, _>>()?;
-        if task_queue.len() > 1 {
+        if task_queue.len() > 2 {
             return Err(ProxyDecodeError::Other(format!(
-                "Expecting at most one task queue entry. Found {:?}",
+                "Expecting at most two task queue entry. Found {:?}",
                 task_queue
             )));
         }

--- a/rs/state_layout/src/state_layout.rs
+++ b/rs/state_layout/src/state_layout.rs
@@ -2395,7 +2395,7 @@ impl TryFrom<pb_canister_state_bits::CanisterStateBits> for CanisterStateBits {
             .collect::<Result<_, _>>()?;
         if task_queue.len() > 2 {
             return Err(ProxyDecodeError::Other(format!(
-                "Expecting at most two task queue entry. Found {:?}",
+                "At most, two tasks are expected in the task queue. Found {:?}",
                 task_queue
             )));
         }


### PR DESCRIPTION
After adding OnLowWasmMemoryHook, it will be possible to have 2 tasks in the queue on the checkpointing. This will not create a problem if it is merged today, since the PR wich sets OnLowWasmMemoryHook is merged on Monday.

CanisterStateBits version of TaskQueue will be added in the follow-up, and conversion will become implicit.