### PR TITLE
feat(sns): Refactor API types related to managing timers

### DIFF
--- a/rs/nervous_system/proto/proto/ic_nervous_system/pb/v1/nervous_system.proto
+++ b/rs/nervous_system/proto/proto/ic_nervous_system/pb/v1/nervous_system.proto
@@ -62,6 +62,9 @@ message ResetTimersRequest {}
 message ResetTimersResponse {}
 
 message Timers {
+  // Indicates whether this canister (still) requires (timer-based) periodic tasks.
+  //
+  // May be ignored by canisters that never cancel their periodic tasks.
   optional bool requires_periodic_tasks = 1;
   optional uint64 last_reset_timestamp_seconds = 2;
   optional uint64 last_spawned_timestamp_seconds = 3;

--- a/rs/nervous_system/proto/proto/ic_nervous_system/pb/v1/nervous_system.proto
+++ b/rs/nervous_system/proto/proto/ic_nervous_system/pb/v1/nervous_system.proto
@@ -55,3 +55,19 @@ message Decimal {
   // E.g. "3.14".
   optional string human_readable = 1;
 }
+
+// API types related to managing canister timers.
+
+message ResetTimersRequest {}
+message ResetTimersResponse {}
+
+message Timers {
+  optional bool requires_periodic_tasks = 1;
+  optional uint64 last_reset_timestamp_seconds = 2;
+  optional uint64 last_spawned_timestamp_seconds = 3;
+}
+
+message GetTimersRequest {}
+message GetTimersResponse {
+  optional Timers timers = 1;
+}

--- a/rs/nervous_system/proto/src/gen/ic_nervous_system.pb.v1.rs
+++ b/rs/nervous_system/proto/src/gen/ic_nervous_system.pb.v1.rs
@@ -186,6 +186,9 @@ pub struct ResetTimersResponse {}
     ::prost::Message,
 )]
 pub struct Timers {
+    /// Indicates whether this canister (still) requires (timer-based) periodic tasks.
+    ///
+    /// May be ignored by canisters that never cancel their periodic tasks.
     #[prost(bool, optional, tag = "1")]
     pub requires_periodic_tasks: ::core::option::Option<bool>,
     #[prost(uint64, optional, tag = "2")]

--- a/rs/nervous_system/proto/src/gen/ic_nervous_system.pb.v1.rs
+++ b/rs/nervous_system/proto/src/gen/ic_nervous_system.pb.v1.rs
@@ -150,3 +150,73 @@ pub struct Decimal {
     #[prost(string, optional, tag = "1")]
     pub human_readable: ::core::option::Option<::prost::alloc::string::String>,
 }
+#[derive(
+    Eq,
+    candid::CandidType,
+    candid::Deserialize,
+    comparable::Comparable,
+    serde::Serialize,
+    Clone,
+    Copy,
+    PartialEq,
+    ::prost::Message,
+)]
+pub struct ResetTimersRequest {}
+#[derive(
+    Eq,
+    candid::CandidType,
+    candid::Deserialize,
+    comparable::Comparable,
+    serde::Serialize,
+    Clone,
+    Copy,
+    PartialEq,
+    ::prost::Message,
+)]
+pub struct ResetTimersResponse {}
+#[derive(
+    Eq,
+    candid::CandidType,
+    candid::Deserialize,
+    comparable::Comparable,
+    serde::Serialize,
+    Clone,
+    Copy,
+    PartialEq,
+    ::prost::Message,
+)]
+pub struct Timers {
+    #[prost(bool, optional, tag = "1")]
+    pub requires_periodic_tasks: ::core::option::Option<bool>,
+    #[prost(uint64, optional, tag = "2")]
+    pub last_reset_timestamp_seconds: ::core::option::Option<u64>,
+    #[prost(uint64, optional, tag = "3")]
+    pub last_spawned_timestamp_seconds: ::core::option::Option<u64>,
+}
+#[derive(
+    Eq,
+    candid::CandidType,
+    candid::Deserialize,
+    comparable::Comparable,
+    serde::Serialize,
+    Clone,
+    Copy,
+    PartialEq,
+    ::prost::Message,
+)]
+pub struct GetTimersRequest {}
+#[derive(
+    Eq,
+    candid::CandidType,
+    candid::Deserialize,
+    comparable::Comparable,
+    serde::Serialize,
+    Clone,
+    Copy,
+    PartialEq,
+    ::prost::Message,
+)]
+pub struct GetTimersResponse {
+    #[prost(message, optional, tag = "1")]
+    pub timers: ::core::option::Option<Timers>,
+}

--- a/rs/sns/integration_tests/src/golden_state_swap_upgrade_twice.rs
+++ b/rs/sns/integration_tests/src/golden_state_swap_upgrade_twice.rs
@@ -1,9 +1,10 @@
 use assert_matches::assert_matches;
 use candid::{Decode, Encode};
+use ic_nervous_system_proto::pb::v1::Timers;
 use ic_nns_test_utils::sns_wasm::{
     build_swap_sns_wasm, create_modified_sns_wasm, ensure_sns_wasm_gzipped,
 };
-use ic_sns_swap::pb::v1::{DerivedState, GetStateRequest, GetStateResponse, Swap, Timers};
+use ic_sns_swap::pb::v1::{DerivedState, GetStateRequest, GetStateResponse, Swap};
 use ic_sns_wasm::pb::v1::SnsWasm;
 use ic_state_machine_tests::StateMachine;
 use ic_types::{CanisterId, PrincipalId};

--- a/rs/sns/integration_tests/src/timers.rs
+++ b/rs/sns/integration_tests/src/timers.rs
@@ -1,9 +1,10 @@
 use assert_matches::assert_matches;
 use candid::{Decode, Encode, Principal};
+use ic_nervous_system_proto::pb::v1::{ResetTimersRequest, ResetTimersResponse, Timers};
 use ic_nns_test_utils::sns_wasm::build_governance_sns_wasm;
 use ic_sns_governance::{init::GovernanceCanisterInitPayloadBuilder, pb::v1 as governance_pb};
 use ic_sns_swap::pb::v1::{
-    self as swap_pb, GetStateRequest, Init, Lifecycle, NeuronBasketConstructionParameters,
+    GetStateRequest, GetStateResponse, Init, Lifecycle, NeuronBasketConstructionParameters,
 };
 use ic_sns_test_utils::state_test_helpers::state_machine_builder_for_sns_tests;
 use ic_types::PrincipalId;
@@ -74,7 +75,7 @@ fn test_swap_periodic_tasks_disabled_eventually() {
         let response = state_machine
             .execute_ingress(canister_id, "get_state", payload)
             .expect("Unable to call get_state on the Swap canister");
-        let response = Decode!(&response.bytes(), swap_pb::GetStateResponse).unwrap();
+        let response = Decode!(&response.bytes(), GetStateResponse).unwrap();
         let swap_state = response.swap.unwrap();
         (
             swap_state.timers,
@@ -91,7 +92,7 @@ fn test_swap_periodic_tasks_disabled_eventually() {
     assert_matches!(
         get_relevant_state_components(),
         (
-            Some(swap_pb::Timers {
+            Some(Timers {
                 requires_periodic_tasks: Some(true),
                 last_reset_timestamp_seconds: Some(_),
                 last_spawned_timestamp_seconds: Some(_),
@@ -117,7 +118,7 @@ fn test_swap_periodic_tasks_disabled_eventually() {
     assert_matches!(
         get_relevant_state_components(),
         (
-            Some(swap_pb::Timers {
+            Some(Timers {
                 requires_periodic_tasks: Some(false),
                 last_reset_timestamp_seconds: Some(_),
                 last_spawned_timestamp_seconds: Some(_),
@@ -145,12 +146,12 @@ fn test_swap_reset_timers() {
         let response = state_machine
             .execute_ingress(canister_id, "get_state", payload)
             .expect("Unable to call get_state on the Swap canister");
-        let response = Decode!(&response.bytes(), swap_pb::GetStateResponse).unwrap();
+        let response = Decode!(&response.bytes(), GetStateResponse).unwrap();
         response.swap.unwrap().timers
     };
 
     let last_spawned_timestamp_seconds = {
-        let last_reset_timestamp_seconds = assert_matches!(get_timers(), Some(swap_pb::Timers {
+        let last_reset_timestamp_seconds = assert_matches!(get_timers(), Some(Timers {
             requires_periodic_tasks: Some(true),
             last_reset_timestamp_seconds: Some(last_reset_timestamp_seconds),
             last_spawned_timestamp_seconds: None,
@@ -161,7 +162,7 @@ fn test_swap_reset_timers() {
         state_machine.advance_time(Duration::from_secs(1000));
         state_machine.tick();
 
-        let last_spawned_timestamp_seconds = assert_matches!(get_timers(), Some(swap_pb::Timers {
+        let last_spawned_timestamp_seconds = assert_matches!(get_timers(), Some(Timers {
             requires_periodic_tasks: Some(true),
             last_reset_timestamp_seconds: Some(last_reset_timestamp_seconds_1),
             last_spawned_timestamp_seconds: Some(last_spawned_timestamp_seconds),
@@ -179,18 +180,18 @@ fn test_swap_reset_timers() {
 
     // Reset the timers.
     {
-        let payload = Encode!(&swap_pb::ResetTimersRequest {}).unwrap();
+        let payload = Encode!(&ResetTimersRequest {}).unwrap();
         let response = state_machine
             .execute_ingress(canister_id, "reset_timers", payload)
             .expect("Unable to call reset_timers on the Swap canister");
-        Decode!(&response.bytes(), swap_pb::ResetTimersResponse).unwrap();
+        Decode!(&response.bytes(), ResetTimersResponse).unwrap();
     }
 
     // Inspect the sate after resetting the timers.
     {
         let last_spawned_before_reset_timestamp_seconds = last_spawned_timestamp_seconds;
 
-        let last_reset_timestamp_seconds = assert_matches!(get_timers(), Some(swap_pb::Timers {
+        let last_reset_timestamp_seconds = assert_matches!(get_timers(), Some(Timers {
             requires_periodic_tasks: Some(true),
             last_reset_timestamp_seconds: Some(last_reset_timestamp_seconds),
             last_spawned_timestamp_seconds: None,
@@ -206,7 +207,7 @@ fn test_swap_reset_timers() {
         state_machine.advance_time(Duration::from_secs(100));
         state_machine.tick();
 
-        let last_spawned_timestamp_seconds = assert_matches!(get_timers(), Some(swap_pb::Timers {
+        let last_spawned_timestamp_seconds = assert_matches!(get_timers(), Some(Timers {
             requires_periodic_tasks: Some(true),
             last_reset_timestamp_seconds: Some(last_reset_timestamp_seconds_1),
             last_spawned_timestamp_seconds: Some(last_spawned_timestamp_seconds),
@@ -272,11 +273,11 @@ fn test_governance_reset_timers() {
 
     // Reset the timers.
     {
-        let payload = Encode!(&swap_pb::ResetTimersRequest {}).unwrap();
+        let payload = Encode!(&ResetTimersRequest {}).unwrap();
         let response = state_machine
             .execute_ingress(canister_id, "reset_timers", payload)
             .expect("Unable to call reset_timers on the Governance canister");
-        Decode!(&response.bytes(), swap_pb::ResetTimersResponse).unwrap();
+        Decode!(&response.bytes(), ResetTimersResponse).unwrap();
     }
 
     // Inspect the sate after resetting the timers.
@@ -325,11 +326,11 @@ fn test_swap_reset_timers_cannot_be_spammed() {
         .unwrap();
 
     // Helpers.
-    let try_reset_timers = || -> Result<swap_pb::ResetTimersResponse, String> {
-        let payload = Encode!(&swap_pb::ResetTimersRequest {}).unwrap();
+    let try_reset_timers = || -> Result<ResetTimersResponse, String> {
+        let payload = Encode!(&ResetTimersRequest {}).unwrap();
         let response = state_machine.execute_ingress(canister_id, "reset_timers", payload);
         match response {
-            Ok(response) => Ok(Decode!(&response.bytes(), swap_pb::ResetTimersResponse).unwrap()),
+            Ok(response) => Ok(Decode!(&response.bytes(), ResetTimersResponse).unwrap()),
             Err(err) => Err(err.to_string()),
         }
     };
@@ -343,11 +344,11 @@ fn test_swap_reset_timers_cannot_be_spammed() {
             let response = state_machine
                 .execute_ingress(canister_id, "get_state", payload)
                 .expect("Unable to call get_state on the Swap canister");
-            let response = Decode!(&response.bytes(), swap_pb::GetStateResponse).unwrap();
+            let response = Decode!(&response.bytes(), GetStateResponse).unwrap();
             response.swap.unwrap().timers
         };
 
-        let last_reset_timestamp_seconds = assert_matches!(timers, Some(swap_pb::Timers {
+        let last_reset_timestamp_seconds = assert_matches!(timers, Some(Timers {
             last_reset_timestamp_seconds: Some(last_reset_timestamp_seconds),
             ..
         }) => last_reset_timestamp_seconds);

--- a/rs/sns/integration_tests/src/timers.rs
+++ b/rs/sns/integration_tests/src/timers.rs
@@ -57,9 +57,6 @@ fn governance_proto() -> governance_pb::Governance {
         .build()
 }
 
-/// Assumes `canister_id` is installed and has an endpoint called "reset_timers".
-fn run_canister_reset_timers_cannot_be_spammed_test()
-
 #[test]
 fn test_swap_periodic_tasks_disabled_eventually() {
     let state_machine = state_machine_builder_for_sns_tests().build();

--- a/rs/sns/integration_tests/src/timers.rs
+++ b/rs/sns/integration_tests/src/timers.rs
@@ -57,6 +57,9 @@ fn governance_proto() -> governance_pb::Governance {
         .build()
 }
 
+/// Assumes `canister_id` is installed and has an endpoint called "reset_timers".
+fn run_canister_reset_timers_cannot_be_spammed_test()
+
 #[test]
 fn test_swap_periodic_tasks_disabled_eventually() {
     let state_machine = state_machine_builder_for_sns_tests().build();

--- a/rs/sns/swap/canister/canister.rs
+++ b/rs/sns/swap/canister/canister.rs
@@ -10,13 +10,25 @@ use ic_nervous_system_clients::{
     management_canister_client::{ManagementCanisterClient, ManagementCanisterClientImpl},
 };
 use ic_nervous_system_common::{serve_logs, serve_logs_v2, serve_metrics};
-use ic_nervous_system_proto::pb::v1::{GetTimersRequest, GetTimersResponse, ResetTimersRequest, ResetTimersResponse, Timers};
+use ic_nervous_system_proto::pb::v1::{
+    GetTimersRequest, GetTimersResponse, ResetTimersRequest, ResetTimersResponse, Timers,
+};
 use ic_nervous_system_runtime::CdkRuntime;
 use ic_sns_swap::{
     logs::{ERROR, INFO},
     memory::UPGRADES_MEMORY,
     pb::v1::{
-        ErrorRefundIcpRequest, ErrorRefundIcpResponse, FinalizeSwapRequest, FinalizeSwapResponse, GetAutoFinalizationStatusRequest, GetAutoFinalizationStatusResponse, GetBuyerStateRequest, GetBuyerStateResponse, GetBuyersTotalRequest, GetBuyersTotalResponse, GetCanisterStatusRequest, GetDerivedStateRequest, GetDerivedStateResponse, GetInitRequest, GetInitResponse, GetLifecycleRequest, GetLifecycleResponse, GetOpenTicketRequest, GetOpenTicketResponse, GetSaleParametersRequest, GetSaleParametersResponse, GetStateRequest, GetStateResponse, Init, ListCommunityFundParticipantsRequest, ListCommunityFundParticipantsResponse, ListDirectParticipantsRequest, ListDirectParticipantsResponse, ListSnsNeuronRecipesRequest, ListSnsNeuronRecipesResponse, NewSaleTicketRequest, NewSaleTicketResponse, NotifyPaymentFailureRequest, NotifyPaymentFailureResponse, RefreshBuyerTokensRequest, RefreshBuyerTokensResponse, Swap
+        ErrorRefundIcpRequest, ErrorRefundIcpResponse, FinalizeSwapRequest, FinalizeSwapResponse,
+        GetAutoFinalizationStatusRequest, GetAutoFinalizationStatusResponse, GetBuyerStateRequest,
+        GetBuyerStateResponse, GetBuyersTotalRequest, GetBuyersTotalResponse,
+        GetCanisterStatusRequest, GetDerivedStateRequest, GetDerivedStateResponse, GetInitRequest,
+        GetInitResponse, GetLifecycleRequest, GetLifecycleResponse, GetOpenTicketRequest,
+        GetOpenTicketResponse, GetSaleParametersRequest, GetSaleParametersResponse,
+        GetStateRequest, GetStateResponse, Init, ListCommunityFundParticipantsRequest,
+        ListCommunityFundParticipantsResponse, ListDirectParticipantsRequest,
+        ListDirectParticipantsResponse, ListSnsNeuronRecipesRequest, ListSnsNeuronRecipesResponse,
+        NewSaleTicketRequest, NewSaleTicketResponse, NotifyPaymentFailureRequest,
+        NotifyPaymentFailureResponse, RefreshBuyerTokensRequest, RefreshBuyerTokensResponse, Swap,
     },
 };
 use ic_stable_structures::{writer::Writer, Memory};

--- a/rs/sns/swap/canister/canister.rs
+++ b/rs/sns/swap/canister/canister.rs
@@ -10,23 +10,13 @@ use ic_nervous_system_clients::{
     management_canister_client::{ManagementCanisterClient, ManagementCanisterClientImpl},
 };
 use ic_nervous_system_common::{serve_logs, serve_logs_v2, serve_metrics};
+use ic_nervous_system_proto::pb::v1::{GetTimersRequest, GetTimersResponse, ResetTimersRequest, ResetTimersResponse, Timers};
 use ic_nervous_system_runtime::CdkRuntime;
 use ic_sns_swap::{
     logs::{ERROR, INFO},
     memory::UPGRADES_MEMORY,
     pb::v1::{
-        ErrorRefundIcpRequest, ErrorRefundIcpResponse, FinalizeSwapRequest, FinalizeSwapResponse,
-        GetAutoFinalizationStatusRequest, GetAutoFinalizationStatusResponse, GetBuyerStateRequest,
-        GetBuyerStateResponse, GetBuyersTotalRequest, GetBuyersTotalResponse,
-        GetCanisterStatusRequest, GetDerivedStateRequest, GetDerivedStateResponse, GetInitRequest,
-        GetInitResponse, GetLifecycleRequest, GetLifecycleResponse, GetOpenTicketRequest,
-        GetOpenTicketResponse, GetSaleParametersRequest, GetSaleParametersResponse,
-        GetStateRequest, GetStateResponse, Init, ListCommunityFundParticipantsRequest,
-        ListCommunityFundParticipantsResponse, ListDirectParticipantsRequest,
-        ListDirectParticipantsResponse, ListSnsNeuronRecipesRequest, ListSnsNeuronRecipesResponse,
-        NewSaleTicketRequest, NewSaleTicketResponse, NotifyPaymentFailureRequest,
-        NotifyPaymentFailureResponse, RefreshBuyerTokensRequest, RefreshBuyerTokensResponse,
-        ResetTimersRequest, ResetTimersResponse, Swap, Timers,
+        ErrorRefundIcpRequest, ErrorRefundIcpResponse, FinalizeSwapRequest, FinalizeSwapResponse, GetAutoFinalizationStatusRequest, GetAutoFinalizationStatusResponse, GetBuyerStateRequest, GetBuyerStateResponse, GetBuyersTotalRequest, GetBuyersTotalResponse, GetCanisterStatusRequest, GetDerivedStateRequest, GetDerivedStateResponse, GetInitRequest, GetInitResponse, GetLifecycleRequest, GetLifecycleResponse, GetOpenTicketRequest, GetOpenTicketResponse, GetSaleParametersRequest, GetSaleParametersResponse, GetStateRequest, GetStateResponse, Init, ListCommunityFundParticipantsRequest, ListCommunityFundParticipantsResponse, ListDirectParticipantsRequest, ListDirectParticipantsResponse, ListSnsNeuronRecipesRequest, ListSnsNeuronRecipesResponse, NewSaleTicketRequest, NewSaleTicketResponse, NotifyPaymentFailureRequest, NotifyPaymentFailureResponse, RefreshBuyerTokensRequest, RefreshBuyerTokensResponse, Swap
     },
 };
 use ic_stable_structures::{writer::Writer, Memory};
@@ -303,6 +293,13 @@ async fn run_periodic_tasks() {
              Stop scheduling new periodic tasks."
         );
     }
+}
+
+#[query]
+fn get_timers(arg: GetTimersRequest) -> GetTimersResponse {
+    let GetTimersRequest {} = arg;
+    let timers = swap().timers;
+    GetTimersResponse { timers }
 }
 
 fn init_timers() {

--- a/rs/sns/swap/canister/swap.did
+++ b/rs/sns/swap/canister/swap.did
@@ -421,6 +421,10 @@ type Timers = record {
   last_spawned_timestamp_seconds : opt nat64;
 };
 
+type GetTimersResponse = record {
+  timers : opt Timers;
+};
+
 type SweepResult = record {
   failure : nat32;
   skipped : nat32;
@@ -474,4 +478,5 @@ service : (Init) -> {
       RefreshBuyerTokensResponse,
     );
   reset_timers : (record {}) -> (record {});
+  get_timers : (record {}) -> (GetTimersResponse) query;
 }

--- a/rs/sns/swap/proto/ic_sns_swap/pb/v1/swap.proto
+++ b/rs/sns/swap/proto/ic_sns_swap/pb/v1/swap.proto
@@ -277,13 +277,7 @@ message Swap {
   optional uint64 neurons_fund_participation_icp_e8s = 20;
 
   // Information about the timers that perform periodic tasks of this Swap canister.
-  optional Timers timers = 22;
-}
-
-message Timers {
-  optional bool requires_periodic_tasks = 1;
-  optional uint64 last_reset_timestamp_seconds = 2;
-  optional uint64 last_spawned_timestamp_seconds = 3;
+  optional ic_nervous_system.pb.v1.Timers timers = 22;
 }
 
 // The initialisation data of the canister. Always specified on
@@ -793,9 +787,6 @@ message GetStateResponse {
   Swap swap = 1;
   DerivedState derived = 2;
 }
-
-message ResetTimersRequest {}
-message ResetTimersResponse {}
 
 message GetBuyerStateRequest {
   // The principal_id of the user who's buyer state is being queried for.

--- a/rs/sns/swap/src/gen/ic_sns_swap.pb.v1.rs
+++ b/rs/sns/swap/src/gen/ic_sns_swap.pb.v1.rs
@@ -238,25 +238,7 @@ pub struct Swap {
     pub neurons_fund_participation_icp_e8s: ::core::option::Option<u64>,
     /// Information about the timers that perform periodic tasks of this Swap canister.
     #[prost(message, optional, tag = "22")]
-    pub timers: ::core::option::Option<Timers>,
-}
-#[derive(
-    candid::CandidType,
-    candid::Deserialize,
-    serde::Serialize,
-    comparable::Comparable,
-    Clone,
-    Copy,
-    PartialEq,
-    ::prost::Message,
-)]
-pub struct Timers {
-    #[prost(bool, optional, tag = "1")]
-    pub requires_periodic_tasks: ::core::option::Option<bool>,
-    #[prost(uint64, optional, tag = "2")]
-    pub last_reset_timestamp_seconds: ::core::option::Option<u64>,
-    #[prost(uint64, optional, tag = "3")]
-    pub last_spawned_timestamp_seconds: ::core::option::Option<u64>,
+    pub timers: ::core::option::Option<::ic_nervous_system_proto::pb::v1::Timers>,
 }
 /// The initialisation data of the canister. Always specified on
 /// canister creation, and cannot be modified afterwards.
@@ -998,28 +980,6 @@ pub struct GetStateResponse {
     #[prost(message, optional, tag = "2")]
     pub derived: ::core::option::Option<DerivedState>,
 }
-#[derive(
-    candid::CandidType,
-    candid::Deserialize,
-    serde::Serialize,
-    comparable::Comparable,
-    Clone,
-    Copy,
-    PartialEq,
-    ::prost::Message,
-)]
-pub struct ResetTimersRequest {}
-#[derive(
-    candid::CandidType,
-    candid::Deserialize,
-    serde::Serialize,
-    comparable::Comparable,
-    Clone,
-    Copy,
-    PartialEq,
-    ::prost::Message,
-)]
-pub struct ResetTimersResponse {}
 #[derive(
     candid::CandidType,
     candid::Deserialize,


### PR DESCRIPTION
This PR moves some timer-related API types into the `ic_nervous_system` crate, as three different SNS canisters would benefit from using the same types to reset their timers and read timer-related metadata. As the first step, only Swap is adjusted to refer to the common types in this PR. To make the timer-related APIs uniform, we add `Swap.get_timers`, despite this information also being available via `Swap.get_state`.

| [Next PR](https://github.com/dfinity/ic/pull/2211) >