### PR TITLE
chore: revert removal of old API BN certificates

### DIFF
--- a/ic-os/components/init/bootstrap-ic-node/bootstrap-ic-node.sh
+++ b/ic-os/components/init/bootstrap-ic-node/bootstrap-ic-node.sh
@@ -190,12 +190,3 @@ write_metric "guestos_node_operator_private_key_exists" \
     "${node_operator_private_key_exists}" \
     "Existence of a Node Operator private key indicates the node deployment method" \
     "gauge"
-
-# temporary fix to remove existing certificates of the API BNs
-if [ -f /var/lib/ic/data/ic-boundary-tls.key ]; then
-    rm /var/lib/ic/data/ic-boundary-tls.key
-fi
-
-if [ -f /var/lib/ic/data/ic-boundary-tls.crt ]; then
-    rm /var/lib/ic/data/ic-boundary-tls.crt
-fi


### PR DESCRIPTION
Due to a change in how API BNs provision their certificates, we had to remove the existing certificates. Since this has been done in the previous release, we can now revert that change (see PR #2146 ).