### PR TITLE
chore: update ic-boundary README

### DIFF
--- a/rs/boundary_node/ic_boundary/README.md
+++ b/rs/boundary_node/ic_boundary/README.md
@@ -6,15 +6,21 @@ The `ic-boundary` is a service that handles all the responsibilities of the API 
 
 ## Usage
 
+To run a minimal `ic-boundary` instance, use the following command:
+
 ```sh
 ic-boundary                                                          \
     --nns-pub-key-pem                <NNS_KEY_PATH>                  \
-    --nns-url                        <NNS_URLS>                      \
+    --nns-urls                       <NNS_URLS>                      \
     --local-store-path               <LOCAL_STORE_PATH>              \
-    --nftables-system-replicas-path  <NFTABLES_SYSTEM_REPLICAS_PATH> \
-    --nftables-system-replicas-var   <NFTABLES_SYSTEM_REPLICAS_VAR>  \
-    --min_registry_version           <VERSION>                       \
-    --min_ok_count                   <OK_COUNT>                      \
-    --max_height_lag                 <LAG>                           \
-    --metrics-addr                   <METRICS_ADDR>
+    --http-port                      <HTTP_PORT>                     \
+    --log-stdout
 ```
+
+Where:
+* `<NNS_KEY_PATH>` points to a file containing the NNS root public key;
+* `<NNS_URLS>` consists of at least one URL pointing to a NNS-replica;
+* `<LOCAL_STORE_PATH>` points to a directory where `ic-boundary` will keep the local copy of the registry;
+* `<HTTP_PORT>` specifies the port `ic-boundary` is listening on (e.g., `80`);
+
+`ic-boundary` offers many more configuration options. For a full list, run `ic-boundary --help`.


### PR DESCRIPTION
The README was outdated and included some options that have been removed. Now, 