### PR TITLE
feat: [NODE-1509] Use 6.11 kernel on 24.04 for GuestOS

### DIFF
--- a/ic-os/guestos/context/Dockerfile.base
+++ b/ic-os/guestos/context/Dockerfile.base
@@ -41,6 +41,15 @@ RUN cd /tmp/ && \
     echo "fbadb376afa7c883f87f70795700a8a200f7fd45412532cc1938a24d41078011  node_exporter-1.8.1.linux-amd64.tar.gz" > node_exporter.sha256 && \
     shasum -c node_exporter.sha256
 
+# Download 6.11 kernel and modules
+RUN cd /tmp/ && \
+    curl -L -O http://mirrors.kernel.org/ubuntu/pool/main/l/linux/linux-modules-6.11.0-8-generic_6.11.0-8.8_amd64.deb && \
+    curl -L -O http://mirrors.kernel.org/ubuntu/pool/main/l/linux-signed/linux-image-6.11.0-8-generic_6.11.0-8.8_amd64.deb && \
+    curl -L -O http://mirrors.kernel.org/ubuntu/pool/main/l/linux-meta/linux-image-virtual-hwe-24.04_6.11.0-8.8_amd64.deb && \
+    echo "d4cd2d97fcca81b57bec947b0e8ca004d556afce1d13f5cebe5d677c0445c6a2  linux-modules-6.11.0-8-generic_6.11.0-8.8_amd64.deb" >> kernel.sha256 && \
+    echo "241811191691c68e0874519ee71bda9de39e23510dee5e5512150db874f5b285  linux-image-6.11.0-8-generic_6.11.0-8.8_amd64.deb" >> kernel.sha256 && \
+    echo "5c31c7e0d996ebc0928c5e1ad3b80fea047b56dfbbdaa759f7e7a70b1c42f10e  linux-image-virtual-hwe-24.04_6.11.0-8.8_amd64.deb" >> kernel.sha256 && \
+    shasum -c kernel.sha256
 
 #
 # Second build stage:
@@ -81,3 +90,16 @@ RUN cd /tmp/ && \
     mkdir -p /etc/node_exporter && \
     tar --strip-components=1 -C /usr/local/bin/ -zvxf node_exporter-1.8.1.linux-amd64.tar.gz node_exporter-1.8.1.linux-amd64/node_exporter && \
     rm /tmp/node_exporter-1.8.1.linux-amd64.tar.gz
+
+# Install 6.11 kernel
+COPY --from=download /tmp/linux-modules-6.11.0-8-generic_6.11.0-8.8_amd64.deb /tmp/linux-modules-6.11.0-8-generic_6.11.0-8.8_amd64.deb
+COPY --from=download /tmp/linux-image-6.11.0-8-generic_6.11.0-8.8_amd64.deb /tmp/linux-image-6.11.0-8-generic_6.11.0-8.8_amd64.deb
+COPY --from=download /tmp/linux-image-virtual-hwe-24.04_6.11.0-8.8_amd64.deb /tmp/linux-image-virtual-hwe-24.04_6.11.0-8.8_amd64.deb
+
+RUN cd /tmp/ && \
+    dpkg -i /tmp/linux-modules-6.11.0-8-generic_6.11.0-8.8_amd64.deb && \
+    dpkg -i /tmp/linux-image-6.11.0-8-generic_6.11.0-8.8_amd64.deb && \
+    dpkg -i /tmp/linux-image-virtual-hwe-24.04_6.11.0-8.8_amd64.deb && \
+    rm /tmp/linux-modules-6.11.0-8-generic_6.11.0-8.8_amd64.deb && \
+    rm /tmp/linux-image-6.11.0-8-generic_6.11.0-8.8_amd64.deb && \
+    rm /tmp/linux-image-virtual-hwe-24.04_6.11.0-8.8_amd64.deb

--- a/ic-os/guestos/context/docker-base.dev
+++ b/ic-os/guestos/context/docker-base.dev
@@ -1,1 +1,1 @@
-ghcr.io/dfinity/guestos-base-dev@sha256:a09de31389eded95279b455a4de31a4f718e7605fc491f03d209bae6841ac5c1
+ghcr.io/dfinity/guestos-base-dev@sha256:e5ed9b6e079e93ab6fafb1abdce6387d76f6a74331511817c98cfa93d3cf61d2

--- a/ic-os/guestos/context/docker-base.prod
+++ b/ic-os/guestos/context/docker-base.prod
@@ -1,1 +1,1 @@
-ghcr.io/dfinity/guestos-base@sha256:e7e968ad4df4606a7a4ed81fb248e8738f917ed5e54b5b8351b6f9ba620f4fa7
+ghcr.io/dfinity/guestos-base@sha256:50017277cd6363ec0dbe6d5ce44aff252598e7c303638a0bb0a5f612692c0dd4

--- a/ic-os/guestos/context/packages.common
+++ b/ic-os/guestos/context/packages.common
@@ -5,8 +5,12 @@
 # image only.
 
 # Need kernel to boot anything
-linux-image-virtual-hwe-24.04
 initramfs-tools
+
+# Resolve some dependencies manualy for 6.11
+kmod
+linux-base
+wireless-regdb
 
 # Need systemd for boot process
 systemd


### PR DESCRIPTION
This uses base images built with changes from: https://github.com/dfinity/ic/pull/2165 to run through CI.