### PR TITLE
fix(registry): Do not ignore the error field in get_changes_since response.

### DIFF
--- a/rs/registry/transport/src/lib.rs
+++ b/rs/registry/transport/src/lib.rs
@@ -5,7 +5,7 @@ use std::{fmt, str};
 
 use crate::pb::v1::{
     registry_error::Code, registry_mutation::Type, Precondition, RegistryDelta, RegistryError,
-    RegistryMutation,
+    RegistryGetChangesSinceResponse, RegistryMutation,
 };
 use prost::Message;
 use serde::{Deserialize, Serialize};
@@ -69,7 +69,7 @@ impl From<RegistryError> for Error {
             1 => Error::KeyNotPresent(error.key),
             2 => Error::KeyAlreadyPresent(error.key),
             3 => Error::VersionNotLatest(error.key),
-            _ => Error::UnknownError(error.reason),
+            _ => Error::UnknownError(format!("{}: {}", error.code, error.reason)),
         }
     }
 }
@@ -239,10 +239,22 @@ pub fn serialize_get_changes_since_request(version: u64) -> Result<Vec<u8>, Erro
 pub fn deserialize_get_changes_since_response(
     response: Vec<u8>,
 ) -> Result<(Vec<RegistryDelta>, u64), Error> {
-    match pb::v1::RegistryGetChangesSinceResponse::decode(&response[..]) {
-        Ok(response) => Ok((response.deltas, response.version)),
-        Err(error) => Err(Error::MalformedMessage(error.to_string())),
+    let response = match pb::v1::RegistryGetChangesSinceResponse::decode(&response[..]) {
+        Ok(ok) => ok,
+        Err(error) => return Err(Error::MalformedMessage(error.to_string())),
+    };
+
+    let RegistryGetChangesSinceResponse {
+        error,
+        version,
+        deltas,
+    } = response;
+
+    if let Some(error) = error {
+        return Err(Error::from(error));
     }
+
+    Ok((deltas, version))
 }
 
 /// Serializes the arguments for a request to the insert() function in the
@@ -445,5 +457,29 @@ mod tests {
             RegistryMutation { mutation_type: delete, key: someone is going to get offended if i put a real country here, value:  }], \
             preconditions on keys: [africa, asia] }"
         )
+    }
+
+    #[test]
+    fn test_deserialize_get_changes_since_response_with_error() {
+        let response = RegistryGetChangesSinceResponse {
+            error: Some(RegistryError {
+                code: Code::Authorization as i32,
+                reason: "You are not welcome here.".to_string(),
+                key: vec![],
+            }),
+            deltas: vec![],
+            version: 0,
+        };
+
+        let response = response.encode_to_vec();
+
+        let result = deserialize_get_changes_since_response(response);
+
+        assert_eq!(
+            result,
+            Err(Error::UnknownError(
+                "5: You are not welcome here.".to_string()
+            )),
+        );
     }
 }


### PR DESCRIPTION
When the error field is populated, deserialize_get_changes_since_response now returns Err.

Whereas, before, the only time it returned Err is when deserialization itself failed, not when the message is properly encoded, but bears information about an error (such as authorization fail).