### PR TITLE
fix: [NODE-1510] Clean cache in repro script

### DIFF
--- a/ci/container/build-ic.sh
+++ b/ci/container/build-ic.sh
@@ -115,6 +115,14 @@ rm -rf "$DISK_DIR_FULL"
 echo_green "Building selected IC artifacts"
 BAZEL_CMD="bazel build --config=local --ic_version='$VERSION' --ic_version_rc_only='$IC_VERSION_RC_ONLY' \
            --release_build=$RELEASE"
+
+BAZEL_CLEAN_CMD=$(
+    cat <<-END
+    # clear bazel cache
+    bazel clean
+END
+)
+
 BUILD_BINARIES_CMD=$(
     cat <<-END
     # build binaries
@@ -149,7 +157,7 @@ BUILD_IMAGES_CMD=$(
     bazel cquery --config=local --output=files //ic-os/setupos/envs/prod | xargs -I {} cp {} "${DISK_DIR}/setupos"
 END
 )
-BUILD_CMD=""
+BUILD_CMD="${BAZEL_CLEAN_CMD}"
 
 if "$BUILD_BIN"; then BUILD_CMD="${BUILD_CMD}${BUILD_BINARIES_CMD}"; fi
 if "$BUILD_CAN"; then BUILD_CMD="${BUILD_CMD}${BUILD_CANISTERS_CMD}"; fi


### PR DESCRIPTION
This will avoid https://dfinity.atlassian.net/browse/NODE-1510 when reproducing builds, until we have a better solution to avoid caching this commit time.