### PR TITLE
fix: bare_metal_deployment timeout

### DIFF
--- a/ic-os/dev-tools/bare_metal_deployment/deploy.py
+++ b/ic-os/dev-tools/bare_metal_deployment/deploy.py
@@ -25,8 +25,7 @@ DEFAULT_IDRAC_SCRIPT_DIR = f"{site.getuserbase()}/bin"
 # IDRAC versions after 6 use different REST API endpoints.
 NEWER_IDRAC_VERSION_THRESHOLD = 6000000
 
-# May vary depending on network or other conditions!
-DEFAULT_SETUPOS_WAIT_TIME_MINS = 25
+DEFAULT_SETUPOS_WAIT_TIME_MINS = 20
 
 BMC_INFO_ENV_VAR = "BMC_INFO_CSV_FILENAME"
 
@@ -212,10 +211,6 @@ def parse_from_row(row: List[str], network_image_url: str) -> BMCInfo:
     assert False, f"Invalid csv row found. Must be 3 or 4 items: {row}"
 
 
-def parse_from_rows(rows: List[List[str]], network_image_url: str) -> List["BMCInfo"]:
-    return [parse_from_row(row, network_image_url) for row in rows]
-
-
 def parse_from_csv_file(csv_filename: str, network_image_url: str) -> List["BMCInfo"]:
     with open(csv_filename, "r") as csv_file:
         rows = [line.strip().split(",") for line in csv_file]
@@ -391,11 +386,13 @@ def deploy_server(bmc_info: BMCInfo, wait_time_mins: int, idrac_script_dir: Path
         iterate_func = check_connectivity_func if bmc_info.guestos_ipv6_address else wait_func
 
         log.info(f"Machine booting. Checking on SetupOS completion periodically. Timeout (mins): {wait_time_mins}")
-        for i in tqdm.tqdm(range(int(60 * (wait_time_mins / timeout_secs))), disable=DISABLE_PROGRESS_BAR):
+        start_time = time.time()
+        end_time = start_time + wait_time_mins * 60
+        while time.time() < end_time:
             if iterate_func():
                 log.info("*** Deployment SUCCESS!")
                 return OperationResult(bmc_info, success=True)
-
+            time.sleep(timeout_secs)
         raise Exception("Could not successfully verify connectivity to node.")
 
     except DeploymentError as e:


### PR DESCRIPTION
deploy.py incorrectly determines the number of times to call iterate_func. The for loop assumes iterate_func will take 5 seconds, but the connectivity check actually fails faster than 5 seconds, causing the whole loop to typically run for just ~15 minutes.

Summary of changes:
* Change the success-check loop to run for the desired wait time
* I also *lowered* the DEFAULT_SETUPOS_WAIT_TIME_MINS to 20 minutes. 
    * SetupOS is pretty reliably installing in less than 15 minutes. I only hit this issue by chance, which is why we didn’t see it until now. So I figured we could lower the labeled wait time from 25 to 20 minutes
* Remove unused parse_from_rows function