### PR TITLE
chore(IDX): disable verbose rclone logs

### DIFF
--- a/ci/src/artifacts/upload.bash.template
+++ b/ci/src/artifacts/upload.bash.template
@@ -52,7 +52,7 @@ fi
     --s3-upload-cutoff=5G \
     copy \
     "$f" \
-    "public-s3:dfinity-download-public/ic/${VERSION}/@@REMOTE_SUBDIR@@/" -vv
+    "public-s3:dfinity-download-public/ic/${VERSION}/@@REMOTE_SUBDIR@@/"
 
 # Upload to Cloudflare's R2 (S3)
 unset RCLONE_S3_ENDPOINT
@@ -64,7 +64,7 @@ AWS_PROFILE=cf "@@RCLONE@@" \
     --s3-upload-cutoff=5G \
     copy \
     "$f" \
-    "public-s3-cf:dfinity-download-public/ic/${VERSION}/@@REMOTE_SUBDIR@@/" -vv
+    "public-s3-cf:dfinity-download-public/ic/${VERSION}/@@REMOTE_SUBDIR@@/"
 
 URL_PATH="ic/${VERSION}/@@REMOTE_SUBDIR@@/$(basename $f)"
 echo "https://download.dfinity.systems/${URL_PATH}" > "$2"


### PR DESCRIPTION
Disabling verbose logs as we don't have any issues with deterministic builds where logs benefit the root cause analysis.