### PR TITLE
test(IDX): parallelise the spec_compliance setup functions

### DIFF
--- a/rs/tests/testing_verification/spec_compliance/spec_compliance.rs
+++ b/rs/tests/testing_verification/spec_compliance/spec_compliance.rs
@@ -2,7 +2,9 @@ use canister_http::get_universal_vm_address;
 use ic_registry_routing_table::canister_id_into_u64;
 use ic_registry_subnet_features::SubnetFeatures;
 use ic_registry_subnet_type::SubnetType;
-use ic_system_test_driver::driver::boundary_node::{BoundaryNode, BoundaryNodeVm};
+use ic_system_test_driver::driver::boundary_node::{
+    BoundaryNode, BoundaryNodeVm, BoundaryNodeWithVm,
+};
 use ic_system_test_driver::driver::ic::{InternetComputer, NrOfVCPUs, Subnet, VmResources};
 use ic_system_test_driver::driver::test_env::TestEnv;
 use ic_system_test_driver::driver::test_env_api::{
@@ -14,6 +16,7 @@ use ic_types::SubnetId;
 use slog::{info, Logger};
 use std::path::PathBuf;
 use std::process::{Command, Stdio};
+use std::thread::{spawn, JoinHandle};
 
 pub const UNIVERSAL_VM_NAME: &str = "httpbin";
 
@@ -32,10 +35,45 @@ const EXCLUDED: &[&str] = &[
     "$0 ~ /Call from query method traps (in query call)/",
 ];
 
-pub fn config_impl(env: TestEnv, deploy_bn_and_nns_canisters: bool, http_requests: bool) {
+pub fn setup_impl(env: TestEnv, deploy_bn_and_nns_canisters: bool, http_requests: bool) {
     use ic_system_test_driver::driver::test_env_api::secs;
     use ic_system_test_driver::util::block_on;
     use std::env;
+
+    // If requested, deploy a Boundary Node concurrently with deploying the rest of the testnet:
+    let mut deploy_bn_thread: Option<JoinHandle<BoundaryNodeWithVm>> = None;
+    let cloned_env = env.clone();
+    if deploy_bn_and_nns_canisters {
+        deploy_bn_thread = Some(spawn(move || {
+            BoundaryNode::new(String::from(BOUNDARY_NODE_NAME))
+                .allocate_vm(&cloned_env)
+                .expect("Allocation of BoundaryNode failed.")
+        }));
+    }
+
+    // If requested, deploy the httpbin UVM concurrently with deploying the rest of the testnet:
+    let mut deploy_httpbin_uvm_thread: Option<JoinHandle<()>> = None;
+    let cloned_env = env.clone();
+    if http_requests {
+        deploy_httpbin_uvm_thread = Some(spawn(move || {
+            env::set_var(
+                "SSL_CERT_FILE",
+                get_dependency_path(
+                    "ic-os/components/networking/dev-certs/canister_http_test_ca.cert",
+                ),
+            );
+            env::remove_var("NIX_SSL_CERT_FILE");
+
+            // Set up Universal VM for httpbin testing service
+            UniversalVm::new(String::from(UNIVERSAL_VM_NAME))
+                .with_config_img(get_dependency_path(
+                    "rs/tests/networking/canister_http/http_uvm_config_image.zst",
+                ))
+                .start(&cloned_env)
+                .expect("failed to set up universal VM");
+            canister_http::start_httpbin_on_uvm(&cloned_env);
+        }))
+    }
 
     let vm_resources = VmResources {
         vcpus: Some(NrOfVCPUs::new(16)),
@@ -74,9 +112,9 @@ pub fn config_impl(env: TestEnv, deploy_bn_and_nns_canisters: bool, http_request
             .install(&nns_node, &env)
             .expect("NNS canisters not installed");
         info!(env.logger(), "NNS canisters are installed.");
-        BoundaryNode::new(String::from(BOUNDARY_NODE_NAME))
-            .allocate_vm(&env)
-            .expect("Allocation of BoundaryNode failed.")
+
+        let allocated_bn = deploy_bn_thread.unwrap().join().unwrap();
+        allocated_bn
             .for_ic(&env, "")
             .use_real_certs_and_dns()
             .start(&env)
@@ -89,20 +127,8 @@ pub fn config_impl(env: TestEnv, deploy_bn_and_nns_canisters: bool, http_request
     });
 
     if http_requests {
-        env::set_var(
-            "SSL_CERT_FILE",
-            get_dependency_path("ic-os/components/networking/dev-certs/canister_http_test_ca.cert"),
-        );
-        env::remove_var("NIX_SSL_CERT_FILE");
+        deploy_httpbin_uvm_thread.unwrap().join().unwrap();
 
-        // Set up Universal VM for httpbin testing service
-        UniversalVm::new(String::from(UNIVERSAL_VM_NAME))
-            .with_config_img(get_dependency_path(
-                "rs/tests/networking/canister_http/http_uvm_config_image.zst",
-            ))
-            .start(&env)
-            .expect("failed to set up universal VM");
-        canister_http::start_httpbin_on_uvm(&env);
         let log = env.logger();
         ic_system_test_driver::retry_with_msg!(
             "check if httpbin is responding to requests",

--- a/rs/tests/testing_verification/spec_compliance_application_subnet_test.rs
+++ b/rs/tests/testing_verification/spec_compliance_application_subnet_test.rs
@@ -17,10 +17,10 @@ use ic_registry_subnet_type::SubnetType;
 use ic_system_test_driver::driver::group::SystemTestGroup;
 use ic_system_test_driver::driver::test_env::TestEnv;
 use ic_system_test_driver::systest;
-use spec_compliance::{config_impl, test_subnet};
+use spec_compliance::{setup_impl, test_subnet};
 
-pub fn config(env: TestEnv) {
-    config_impl(env, true, true);
+pub fn setup(env: TestEnv) {
+    setup_impl(env, true, true);
 }
 
 pub fn test(env: TestEnv) {
@@ -44,7 +44,7 @@ pub fn test(env: TestEnv) {
 
 fn main() -> Result<()> {
     SystemTestGroup::new()
-        .with_setup(config)
+        .with_setup(setup)
         .add_test(systest!(test))
         .execute_from_args()?;
 

--- a/rs/tests/testing_verification/spec_compliance_group_01_application_subnet_test.rs
+++ b/rs/tests/testing_verification/spec_compliance_group_01_application_subnet_test.rs
@@ -17,10 +17,10 @@ use ic_registry_subnet_type::SubnetType;
 use ic_system_test_driver::driver::group::SystemTestGroup;
 use ic_system_test_driver::driver::test_env::TestEnv;
 use ic_system_test_driver::systest;
-use spec_compliance::{config_impl, test_subnet};
+use spec_compliance::{setup_impl, test_subnet};
 
-pub fn config(env: TestEnv) {
-    config_impl(env, true, true);
+pub fn setup(env: TestEnv) {
+    setup_impl(env, true, true);
 }
 
 pub fn test(env: TestEnv) {
@@ -43,7 +43,7 @@ pub fn test(env: TestEnv) {
 
 fn main() -> Result<()> {
     SystemTestGroup::new()
-        .with_setup(config)
+        .with_setup(setup)
         .add_test(systest!(test))
         .execute_from_args()?;
 

--- a/rs/tests/testing_verification/spec_compliance_group_01_system_subnet_test.rs
+++ b/rs/tests/testing_verification/spec_compliance_group_01_system_subnet_test.rs
@@ -17,10 +17,10 @@ use ic_registry_subnet_type::SubnetType;
 use ic_system_test_driver::driver::group::SystemTestGroup;
 use ic_system_test_driver::driver::test_env::TestEnv;
 use ic_system_test_driver::systest;
-use spec_compliance::{config_impl, test_subnet};
+use spec_compliance::{setup_impl, test_subnet};
 
-pub fn config(env: TestEnv) {
-    config_impl(env, true, true);
+pub fn setup(env: TestEnv) {
+    setup_impl(env, true, true);
 }
 
 pub fn test(env: TestEnv) {
@@ -43,7 +43,7 @@ pub fn test(env: TestEnv) {
 
 fn main() -> Result<()> {
     SystemTestGroup::new()
-        .with_setup(config)
+        .with_setup(setup)
         .add_test(systest!(test))
         .execute_from_args()?;
 

--- a/rs/tests/testing_verification/spec_compliance_group_02_system_subnet_test.rs
+++ b/rs/tests/testing_verification/spec_compliance_group_02_system_subnet_test.rs
@@ -17,10 +17,10 @@ use ic_registry_subnet_type::SubnetType;
 use ic_system_test_driver::driver::group::SystemTestGroup;
 use ic_system_test_driver::driver::test_env::TestEnv;
 use ic_system_test_driver::systest;
-use spec_compliance::{config_impl, test_subnet};
+use spec_compliance::{setup_impl, test_subnet};
 
-pub fn config(env: TestEnv) {
-    config_impl(env, false, false);
+pub fn setup(env: TestEnv) {
+    setup_impl(env, false, false);
 }
 
 pub fn test(env: TestEnv) {
@@ -37,7 +37,7 @@ pub fn test(env: TestEnv) {
 
 fn main() -> Result<()> {
     SystemTestGroup::new()
-        .with_setup(config)
+        .with_setup(setup)
         .add_test(systest!(test))
         .execute_from_args()?;
 

--- a/rs/tests/testing_verification/spec_compliance_system_subnet_test.rs
+++ b/rs/tests/testing_verification/spec_compliance_system_subnet_test.rs
@@ -17,10 +17,10 @@ use ic_registry_subnet_type::SubnetType;
 use ic_system_test_driver::driver::group::SystemTestGroup;
 use ic_system_test_driver::driver::test_env::TestEnv;
 use ic_system_test_driver::systest;
-use spec_compliance::{config_impl, test_subnet};
+use spec_compliance::{setup_impl, test_subnet};
 
-pub fn config(env: TestEnv) {
-    config_impl(env, true, true);
+pub fn setup(env: TestEnv) {
+    setup_impl(env, true, true);
 }
 
 pub fn test(env: TestEnv) {
@@ -44,7 +44,7 @@ pub fn test(env: TestEnv) {
 
 fn main() -> Result<()> {
     SystemTestGroup::new()
-        .with_setup(config)
+        .with_setup(setup)
         .add_test(systest!(test))
         .execute_from_args()?;
 


### PR DESCRIPTION
This shaves of about 30 seconds from the `//rs/tests/testing_verification:spec_compliance_...` system-tests by deploying the Boundary Node, httpbin UVM and IC concurrently instead of in sequence.

spec_compliance test run: https://github.com/dfinity/ic/actions/runs/11498495840.