### PR TITLE
test(IC-1579): Isolate TLA tests in Rust-based (non-canister) tests

### DIFF
--- a/rs/nns/governance/src/governance.rs
+++ b/rs/nns/governance/src/governance.rs
@@ -135,7 +135,7 @@ pub mod tla;
 #[cfg(feature = "tla")]
 pub use tla::{
     claim_neuron_desc, split_neuron_desc, tla_update_method, InstrumentationState, ToTla,
-    TLA_INSTRUMENTATION_STATE, TLA_TRACES,
+    TLA_INSTRUMENTATION_STATE, TLA_TRACES_LKEY, TLA_TRACES_MUTEX,
 };
 
 // 70 KB (for executing NNS functions that are not canister upgrades)

--- a/rs/nns/governance/src/governance/tla/mod.rs
+++ b/rs/nns/governance/src/governance/tla/mod.rs
@@ -221,7 +221,7 @@ pub fn check_traces() {
         println!("Checking {} traces with TLA/Apalache", traces.len());
         for t in traces {
             let total_len = t.state_pairs.len();
-            let under_limit_len = t.state_pairs.iter().filter(|p| is_under_limit(*p)).count();
+            let under_limit_len = t.state_pairs.iter().filter(|p| is_under_limit(p)).count();
             println!(
                 "TLA/Apalache checks: keeping {}/{} states for update {}",
                 under_limit_len, total_len, t.update.process_id

--- a/rs/nns/governance/src/governance/tla/mod.rs
+++ b/rs/nns/governance/src/governance/tla/mod.rs
@@ -21,7 +21,7 @@ mod store;
 
 pub use common::{account_to_tla, opt_subaccount_to_tla, subaccount_to_tla};
 use common::{function_domain_union, governance_account_id};
-pub use store::{TLA_INSTRUMENTATION_STATE, TLA_TRACES};
+pub use store::{TLA_INSTRUMENTATION_STATE, TLA_TRACES_LKEY, TLA_TRACES_MUTEX};
 
 mod split_neuron;
 pub use split_neuron::split_neuron_desc;
@@ -213,10 +213,25 @@ pub fn check_traces() {
     // improving that later, for now we introduce a hard limit on the state size, and
     // skip checking states larger than the limit
     const STATE_SIZE_LIMIT: u64 = 500;
+    fn is_under_limit(p: &ResolvedStatePair) -> bool {
+        p.start.size() < STATE_SIZE_LIMIT && p.end.size() < STATE_SIZE_LIMIT
+    }
+
+    fn print_stats(traces: &Vec<UpdateTrace>) {
+        println!("Checking {} traces with TLA/Apalache", traces.len());
+        for t in traces {
+            let total_len = t.state_pairs.len();
+            let under_limit_len = t.state_pairs.iter().filter(|p| is_under_limit(*p)).count();
+            println!(
+                "TLA/Apalache checks: keeping {}/{} states for update {}",
+                under_limit_len, total_len, t.update.process_id
+            );
+        }
+    }
+
     let traces = {
-        // Introduce a scope to drop the write lock immediately, in order
-        // not to poison the lock if we panic later
-        let mut t = TLA_TRACES.write().unwrap();
+        let t = TLA_TRACES_LKEY.get();
+        let mut t = t.borrow_mut();
         std::mem::take(&mut (*t))
     };
 
@@ -230,11 +245,13 @@ pub fn check_traces() {
         panic!("bad apalache bin from 'TLA_APALACHE_BIN': '{:?}'", apalache);
     }
 
+    print_stats(&traces);
+
     let chunk_size = 20;
     let all_pairs = traces.into_iter().flat_map(|t| {
         t.state_pairs
             .into_iter()
-            .filter(|p| p.start.size() < STATE_SIZE_LIMIT && p.end.size() < STATE_SIZE_LIMIT)
+            .filter(is_under_limit)
             .map(move |p| (t.update.clone(), t.constants.clone(), p))
     });
     let chunks = all_pairs.chunks(chunk_size);
@@ -267,7 +284,7 @@ pub fn check_traces() {
                 println!("Possible divergence from the TLA model detected when interacting with the ledger!");
                 println!("If you did not expect to change the interaction between governance and the ledger, reconsider whether your change is safe. You can find additional data on the step that triggered the error below.");
                 println!("If you are confident that your change is correct, please contact the #formal-models Slack channel and describe the problem.");
-                println!("You can edit nervous_system/tla/feature_flags.bzl to disable TLA checks in the CI and get on with your business.");
+                println!("You can edit nns/governance/feature_flags.bzl to disable TLA checks in the CI and get on with your business.");
                 println!("-------------------");
                 println!("Error occured while checking the state pair:\n{:#?}\nwith constants:\n{:#?}", e.pair, e.constants);
                 println!("Apalache returned:\n{:#?}", e.apalache_error);

--- a/rs/nns/governance/src/governance/tla/store.rs
+++ b/rs/nns/governance/src/governance/tla/store.rs
@@ -1,4 +1,5 @@
 use local_key::task_local;
+use std::cell::RefCell;
 use std::sync::RwLock;
 pub use tla_instrumentation::{InstrumentationState, UpdateTrace};
 
@@ -8,7 +9,8 @@ pub use tla_instrumentation::{InstrumentationState, UpdateTrace};
 #[cfg(feature = "tla")]
 task_local! {
     pub static TLA_INSTRUMENTATION_STATE: InstrumentationState;
+    pub static TLA_TRACES_LKEY: RefCell<Vec<UpdateTrace>>;
 }
 
 #[cfg(feature = "tla")]
-pub static TLA_TRACES: RwLock<Vec<UpdateTrace>> = RwLock::new(Vec::new());
+pub static TLA_TRACES_MUTEX: RwLock<Vec<UpdateTrace>> = RwLock::new(Vec::new());

--- a/rs/tla_instrumentation/tla_instrumentation/src/lib.rs
+++ b/rs/tla_instrumentation/tla_instrumentation/src/lib.rs
@@ -41,7 +41,7 @@ pub struct Update {
     pub post_process: fn(&mut Vec<ResolvedStatePair>) -> TlaConstantAssignment,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct UpdateTrace {
     pub update: Update,
     pub state_pairs: Vec<ResolvedStatePair>,

--- a/rs/tla_instrumentation/tla_instrumentation/tests/multiple_calls.rs
+++ b/rs/tla_instrumentation/tla_instrumentation/tests/multiple_calls.rs
@@ -35,9 +35,10 @@ mod tla_stuff {
 
     task_local! {
         pub static TLA_INSTRUMENTATION_STATE: InstrumentationState;
+        pub static TLA_TRACES_LKEY: std::cell::RefCell<Vec<UpdateTrace>>;
     }
 
-    pub static TLA_TRACES: RwLock<Vec<UpdateTrace>> = RwLock::new(Vec::new());
+    pub static TLA_TRACES_MUTEX: RwLock<Vec<UpdateTrace>> = RwLock::new(Vec::new());
 
     pub fn tla_get_globals(c: &StructCanister) -> GlobalState {
         let mut state = GlobalState::new();
@@ -110,7 +111,9 @@ mod tla_stuff {
     }
 }
 
-use tla_stuff::{my_f_desc, CAN_NAME, PID, TLA_INSTRUMENTATION_STATE, TLA_TRACES};
+use tla_stuff::{
+    my_f_desc, CAN_NAME, PID, TLA_INSTRUMENTATION_STATE, TLA_TRACES_LKEY, TLA_TRACES_MUTEX,
+};
 
 struct StructCanister {
     pub counter: u64,
@@ -162,7 +165,7 @@ fn multiple_calls_test() {
         let canister = &mut *addr_of_mut!(GLOBAL);
         tokio_test::block_on(canister.my_method());
     }
-    let trace = &TLA_TRACES.read().unwrap()[0];
+    let trace = &TLA_TRACES_MUTEX.read().unwrap()[0];
     assert_eq!(
         trace.constants.to_map().get("MAX_COUNTER"),
         Some(&3_u64.to_string())

--- a/rs/tla_instrumentation/tla_instrumentation/tests/structs.rs
+++ b/rs/tla_instrumentation/tla_instrumentation/tests/structs.rs
@@ -271,7 +271,7 @@ fn tla_check_traces() {
     let traces = TLA_TRACES_LKEY.get();
     let traces = traces.borrow();
     for t in &*traces {
-        check_tla_trace(&t)
+        check_tla_trace(t)
     }
 }
 

--- a/rs/tla_instrumentation/tla_instrumentation/tests/structs.rs
+++ b/rs/tla_instrumentation/tla_instrumentation/tests/structs.rs
@@ -10,7 +10,7 @@ use tla_instrumentation::{
     tla_value::{TlaValue, ToTla},
     Destination, InstrumentationState,
 };
-use tla_instrumentation_proc_macros::tla_update_method;
+use tla_instrumentation_proc_macros::{tla_update_method, with_tla_trace_check};
 
 mod common;
 use common::check_tla_trace;
@@ -35,9 +35,10 @@ mod tla_stuff {
 
     task_local! {
         pub static TLA_INSTRUMENTATION_STATE: InstrumentationState;
+        pub static TLA_TRACES_LKEY: std::cell::RefCell<Vec<UpdateTrace>>;
     }
 
-    pub static TLA_TRACES: RwLock<Vec<UpdateTrace>> = RwLock::new(Vec::new());
+    pub static TLA_TRACES_MUTEX: RwLock<Vec<UpdateTrace>> = RwLock::new(Vec::new());
 
     pub fn tla_get_globals(c: &StructCanister) -> GlobalState {
         let mut state = GlobalState::new();
@@ -110,7 +111,9 @@ mod tla_stuff {
     }
 }
 
-use tla_stuff::{my_f_desc, CAN_NAME, PID, TLA_INSTRUMENTATION_STATE, TLA_TRACES};
+use tla_stuff::{
+    my_f_desc, CAN_NAME, PID, TLA_INSTRUMENTATION_STATE, TLA_TRACES_LKEY, TLA_TRACES_MUTEX,
+};
 
 struct StructCanister {
     pub counter: u64,
@@ -155,7 +158,7 @@ fn struct_test() {
         let canister = &mut *addr_of_mut!(GLOBAL);
         tokio_test::block_on(canister.my_method());
     }
-    let trace = &TLA_TRACES.read().unwrap()[0];
+    let trace = &TLA_TRACES_MUTEX.read().unwrap()[0];
     assert_eq!(
         trace.constants.to_map().get("MAX_COUNTER"),
         Some(&2_u64.to_string())
@@ -262,4 +265,19 @@ fn struct_test() {
     );
 
     check_tla_trace(trace);
+}
+
+fn tla_check_traces() {
+    let traces = TLA_TRACES_LKEY.get();
+    let traces = traces.borrow();
+    for t in &*traces {
+        check_tla_trace(&t)
+    }
+}
+
+#[test]
+#[with_tla_trace_check]
+fn annotated_test() {
+    let canister = &mut StructCanister { counter: 0 };
+    tokio_test::block_on(canister.my_method());
 }

--- a/rs/tla_instrumentation/tla_instrumentation_proc_macros/src/lib.rs
+++ b/rs/tla_instrumentation/tla_instrumentation_proc_macros/src/lib.rs
@@ -76,6 +76,16 @@ pub fn tla_update(attr: TokenStream, item: TokenStream) -> TokenStream {
     output.into()
 }
 
+/// Marks the method as the starting point of a TLA transition (or more concretely, a PlusCal process).
+/// Assumes that the following are in scope:
+/// 1. TLA_INSTRUMENTATION_STATE LocalKey storing a Rc<RefCell<InstrumentationState>>
+/// 2. TLA_TRACES_MUTEX RwLock storing a Vec<UpdateTrace>
+/// 3. TLA_TRACES_LKEY LocalKey storing a RefCell<Vec<UpdateTrace>>
+/// 4. tla_get_globals! a macro which takes a self parameter iff this is a method
+/// 5. tla_instrumentation crate
+///
+/// It records the trace (sequence of states) resulting from `tla_log_request!` and `tla_log_response!`
+/// macro calls in either the
 #[proc_macro_attribute]
 pub fn tla_update_method(attr: TokenStream, item: TokenStream) -> TokenStream {
     // Parse the input tokens of the attribute and the function
@@ -259,6 +269,10 @@ pub fn tla_function(_attr: TokenStream, item: TokenStream) -> TokenStream {
     output.into()
 }
 
+/// An annotation for tests whose TLA traces should be checked.
+/// Assumes that the following are in scope:
+/// 1. a LocalKey variable `TLA_TRACES_LKEY` of type Vec<UpdateTrace>,and
+/// 2. a function tla_check_traces() (presumably looking at the `TLA_TRACES_LKEY`
 #[proc_macro_attribute]
 pub fn with_tla_trace_check(_attr: TokenStream, item: TokenStream) -> TokenStream {
     // Parse the input tokens of the attribute and the function


### PR DESCRIPTION
Switch to a `LocalKey`-based approach for Rust-based tests, and add an annotation (proc macro) that scopes the `LocalKey` to the test. 

Previously, we used only a global `RwLock`, which would cause traces of one test to be picked up by other tests. In contract, a `LocalKey` is task-local, eliminating the interference. We still use the `RwLock` as a fallback to store traces if the `LocalKey` is not present (i.e., no scope has been opened). This means that, first, tests that aren't annotated still collect the traces, but they aren't checked, which is a bit wasteful but should be OK as these aren't extremely heavy operations. Second, and more importantly, this means that the instrumentation will still work in canister-based tests, allowing a separate query method to pick the traces up from the global variable.