### PR TITLE
feat: enable allowed_viewers feature for canister log visibility

### DIFF
--- a/rs/config/src/execution_environment.rs
+++ b/rs/config/src/execution_environment.rs
@@ -360,7 +360,7 @@ impl Default for Config {
             dirty_page_logging: FlagStatus::Disabled,
             max_canister_http_requests_in_flight: MAX_CANISTER_HTTP_REQUESTS_IN_FLIGHT,
             default_wasm_memory_limit: DEFAULT_WASM_MEMORY_LIMIT,
-            allowed_viewers_feature: FlagStatus::Disabled,
+            allowed_viewers_feature: FlagStatus::Enabled,
         }
     }
 }

--- a/rs/execution_environment/tests/canister_logging.rs
+++ b/rs/execution_environment/tests/canister_logging.rs
@@ -280,8 +280,7 @@ fn test_log_visibility_of_fetch_canister_logs() {
         (
             LogVisibilityV2::AllowedViewers(allowed_viewers.clone()),
             allowed_viewer,
-            // TODO(EXC-1675): when disabled works as for controllers, change to ok when enabled.
-            not_allowed_error(&allowed_viewer),
+            ok.clone(),
         ),
         (
             LogVisibilityV2::AllowedViewers(allowed_viewers.clone()),


### PR DESCRIPTION
This PR enables `allowed_viewers` for canister log visibility.

EXC-1697