### PR TITLE
fix(nns): Neuron conversion did not transcribe visibility correctly.

### DIFF
--- a/rs/nns/governance/src/neuron/types.rs
+++ b/rs/nns/governance/src/neuron/types.rs
@@ -811,13 +811,7 @@ impl Neuron {
             joined_community_fund_timestamp_seconds = self.joined_community_fund_timestamp_seconds;
         }
 
-        let visibility = if !is_private_neuron_enforcement_enabled() {
-            None
-        } else if self.known_neuron_data.is_some() {
-            Some(Visibility::Public as i32)
-        } else {
-            Some(self.visibility.unwrap_or(Visibility::Private) as i32)
-        };
+        let visibility = self.visibility().map(|visibility| visibility as i32);
 
         NeuronInfo {
             retrieved_at_timestamp_seconds: now_seconds,
@@ -1026,6 +1020,8 @@ impl Neuron {
 
 impl From<Neuron> for NeuronProto {
     fn from(neuron: Neuron) -> Self {
+        let visibility = neuron.visibility().map(|visibility| visibility as i32);
+
         let Neuron {
             id,
             subaccount,
@@ -1047,7 +1043,7 @@ impl From<Neuron> for NeuronProto {
             joined_community_fund_timestamp_seconds,
             known_neuron_data,
             neuron_type,
-            visibility,
+            visibility: _,
         } = neuron;
 
         let id = Some(id);
@@ -1057,11 +1053,6 @@ impl From<Neuron> for NeuronProto {
             dissolve_state,
             aging_since_timestamp_seconds,
         } = StoredDissolveStateAndAge::from(dissolve_state_and_age);
-        let mut visibility = visibility.map(|visibility| visibility as i32);
-
-        if is_private_neuron_enforcement_enabled() {
-            visibility = visibility.or(Some(Visibility::Private as i32));
-        }
 
         NeuronProto {
             id,

--- a/rs/nns/governance/src/neuron/types/tests.rs
+++ b/rs/nns/governance/src/neuron/types/tests.rs
@@ -467,36 +467,26 @@ fn test_visibility_when_converting_neuron_to_neuron_info_and_neuron_proto() {
             dissolve_delay_seconds: 1_000_000,
             aging_since_timestamp_seconds: timestamp_seconds,
         },
-        timestamp_seconds // created
+        timestamp_seconds, // created
     );
 
     // Case 1: visibility is explicitly set.
-    for set_enforcement in [temporarily_enable_private_neuron_enforcement, temporarily_disable_private_neuron_enforcement] {
+    for set_enforcement in [
+        temporarily_enable_private_neuron_enforcement,
+        temporarily_disable_private_neuron_enforcement,
+    ] {
         let _restore_on_drop = set_enforcement();
 
         for visibility in [Visibility::Public, Visibility::Private] {
-            let neuron = builder
-                .clone()
-                .with_visibility(Some(visibility))
-                .build();
+            let neuron = builder.clone().with_visibility(Some(visibility)).build();
 
-            assert_eq!(
-                neuron.visibility(),
-                Some(visibility),
-            );
+            assert_eq!(neuron.visibility(), Some(visibility),);
 
-            let neuron_info =
-                neuron.get_neuron_info(timestamp_seconds, principal_id);
-            assert_eq!(
-                neuron_info.visibility,
-                Some(visibility as i32),
-            );
+            let neuron_info = neuron.get_neuron_info(timestamp_seconds, principal_id);
+            assert_eq!(neuron_info.visibility, Some(visibility as i32),);
 
             let neuron_proto = NeuronProto::from(neuron);
-            assert_eq!(
-                neuron_proto.visibility,
-                Some(visibility as i32),
-            );
+            assert_eq!(neuron_proto.visibility, Some(visibility as i32),);
         }
     }
 
@@ -505,42 +495,24 @@ fn test_visibility_when_converting_neuron_to_neuron_info_and_neuron_proto() {
     {
         let _restore_on_drop = temporarily_disable_private_neuron_enforcement();
 
-        assert_eq!(
-            neuron.visibility(),
-            None,
-        );
+        assert_eq!(neuron.visibility(), None,);
 
         let neuron_info = neuron.get_neuron_info(timestamp_seconds, principal_id);
-        assert_eq!(
-            neuron_info.visibility,
-            None,
-        );
+        assert_eq!(neuron_info.visibility, None,);
 
         let neuron_proto = NeuronProto::from(neuron.clone());
-        assert_eq!(
-            neuron_proto.visibility,
-            None,
-        );
+        assert_eq!(neuron_proto.visibility, None,);
     }
     {
         let _restore_on_drop = temporarily_enable_private_neuron_enforcement();
 
-        assert_eq!(
-            neuron.visibility(),
-            Some(Visibility::Private),
-        );
+        assert_eq!(neuron.visibility(), Some(Visibility::Private),);
 
         let neuron_info = neuron.get_neuron_info(timestamp_seconds, principal_id);
-        assert_eq!(
-            neuron_info.visibility,
-            Some(Visibility::Private as i32),
-        );
+        assert_eq!(neuron_info.visibility, Some(Visibility::Private as i32),);
 
         let neuron_proto = NeuronProto::from(neuron);
-        assert_eq!(
-            neuron_proto.visibility,
-            Some(Visibility::Private as i32),
-        );
+        assert_eq!(neuron_proto.visibility, Some(Visibility::Private as i32),);
     }
 
     // Case 3: Known neurons are always public.
@@ -550,24 +522,18 @@ fn test_visibility_when_converting_neuron_to_neuron_info_and_neuron_proto() {
             description: Some("neuron description".to_string()),
         }))
         .build();
-    for set_enforcement in [temporarily_enable_private_neuron_enforcement, temporarily_disable_private_neuron_enforcement] {
+    for set_enforcement in [
+        temporarily_enable_private_neuron_enforcement,
+        temporarily_disable_private_neuron_enforcement,
+    ] {
         let _restore_on_drop = set_enforcement();
 
-        assert_eq!(
-            neuron.visibility(),
-            Some(Visibility::Public),
-        );
+        assert_eq!(neuron.visibility(), Some(Visibility::Public),);
 
         let neuron_info = neuron.get_neuron_info(timestamp_seconds, principal_id);
-        assert_eq!(
-            neuron_info.visibility,
-            Some(Visibility::Public as i32),
-        );
+        assert_eq!(neuron_info.visibility, Some(Visibility::Public as i32),);
 
         let neuron_proto = NeuronProto::from(neuron.clone());
-        assert_eq!(
-            neuron_proto.visibility,
-            Some(Visibility::Public as i32),
-        );
+        assert_eq!(neuron_proto.visibility, Some(Visibility::Public as i32),);
     }
 }

--- a/rs/nns/governance/src/neuron/types/tests.rs
+++ b/rs/nns/governance/src/neuron/types/tests.rs
@@ -2,6 +2,7 @@ use super::*;
 use crate::{
     neuron::{DissolveStateAndAge, NeuronBuilder},
     pb::v1::manage_neuron::{SetDissolveTimestamp, StartDissolving},
+    temporarily_disable_private_neuron_enforcement, temporarily_enable_private_neuron_enforcement,
 };
 use ic_cdk::println;
 
@@ -450,4 +451,123 @@ fn test_neuron_configure_dissolve_delay() {
     // Step 8: advance the time by 1 second and see that the neuron is now dissolved.
     let now = now + 1;
     assert_eq!(neuron.state(now), NeuronState::Dissolved);
+}
+
+#[test]
+fn test_visibility_when_converting_neuron_to_neuron_info_and_neuron_proto() {
+    // (These are not actually used by code under test.)
+    let principal_id = PrincipalId::new_user_test_id(42);
+    let timestamp_seconds = 1729791574;
+
+    let builder = NeuronBuilder::new(
+        NeuronId { id: 42 },
+        Subaccount::try_from(vec![42u8; 32].as_slice()).unwrap(),
+        principal_id,
+        DissolveStateAndAge::NotDissolving {
+            dissolve_delay_seconds: 1_000_000,
+            aging_since_timestamp_seconds: timestamp_seconds,
+        },
+        timestamp_seconds // created
+    );
+
+    // Case 1: visibility is explicitly set.
+    for set_enforcement in [temporarily_enable_private_neuron_enforcement, temporarily_disable_private_neuron_enforcement] {
+        let _restore_on_drop = set_enforcement();
+
+        for visibility in [Visibility::Public, Visibility::Private] {
+            let neuron = builder
+                .clone()
+                .with_visibility(Some(visibility))
+                .build();
+
+            assert_eq!(
+                neuron.visibility(),
+                Some(visibility),
+            );
+
+            let neuron_info =
+                neuron.get_neuron_info(timestamp_seconds, principal_id);
+            assert_eq!(
+                neuron_info.visibility,
+                Some(visibility as i32),
+            );
+
+            let neuron_proto = NeuronProto::from(neuron);
+            assert_eq!(
+                neuron_proto.visibility,
+                Some(visibility as i32),
+            );
+        }
+    }
+
+    // Case 2: visibility is not set.
+    let neuron = builder.clone().build();
+    {
+        let _restore_on_drop = temporarily_disable_private_neuron_enforcement();
+
+        assert_eq!(
+            neuron.visibility(),
+            None,
+        );
+
+        let neuron_info = neuron.get_neuron_info(timestamp_seconds, principal_id);
+        assert_eq!(
+            neuron_info.visibility,
+            None,
+        );
+
+        let neuron_proto = NeuronProto::from(neuron.clone());
+        assert_eq!(
+            neuron_proto.visibility,
+            None,
+        );
+    }
+    {
+        let _restore_on_drop = temporarily_enable_private_neuron_enforcement();
+
+        assert_eq!(
+            neuron.visibility(),
+            Some(Visibility::Private),
+        );
+
+        let neuron_info = neuron.get_neuron_info(timestamp_seconds, principal_id);
+        assert_eq!(
+            neuron_info.visibility,
+            Some(Visibility::Private as i32),
+        );
+
+        let neuron_proto = NeuronProto::from(neuron);
+        assert_eq!(
+            neuron_proto.visibility,
+            Some(Visibility::Private as i32),
+        );
+    }
+
+    // Case 3: Known neurons are always public.
+    let neuron = builder
+        .with_known_neuron_data(Some(KnownNeuronData {
+            name: "neuron name".to_string(),
+            description: Some("neuron description".to_string()),
+        }))
+        .build();
+    for set_enforcement in [temporarily_enable_private_neuron_enforcement, temporarily_disable_private_neuron_enforcement] {
+        let _restore_on_drop = set_enforcement();
+
+        assert_eq!(
+            neuron.visibility(),
+            Some(Visibility::Public),
+        );
+
+        let neuron_info = neuron.get_neuron_info(timestamp_seconds, principal_id);
+        assert_eq!(
+            neuron_info.visibility,
+            Some(Visibility::Public as i32),
+        );
+
+        let neuron_proto = NeuronProto::from(neuron.clone());
+        assert_eq!(
+            neuron_proto.visibility,
+            Some(Visibility::Public as i32),
+        );
+    }
 }

--- a/rs/nns/governance/tests/governance.rs
+++ b/rs/nns/governance/tests/governance.rs
@@ -10135,6 +10135,9 @@ fn test_include_public_neurons_in_full_neurons() {
 
     if is_private_neuron_enforcement_enabled() {
         for neuron in &mut expected_full_neurons {
+            if neuron.known_neuron_data.is_some() {
+                neuron.visibility = Some(Visibility::Public as i32);
+            }
             let visibility = &mut neuron.visibility;
             if visibility.is_none() {
                 *visibility = Some(Visibility::Private as i32);
@@ -10142,7 +10145,7 @@ fn test_include_public_neurons_in_full_neurons() {
         }
     }
 
-    assert_eq!(list_neurons_response.full_neurons, expected_full_neurons,);
+    assert_eq!(list_neurons_response.full_neurons, expected_full_neurons);
 }
 
 /// Struct to help with the wait for quiet tests.
@@ -14151,15 +14154,20 @@ fn test_neuron_info_private_enforcement() {
         ];
         main(neuron_id_to_expect_redact);
 
-        // Insepct visibility. This time, it should always be None.
-        for neuron_id in [
-            no_explicit_visibility_neuron.id.unwrap(),
-            private_neuron.id.unwrap(),
-            public_neuron.id.unwrap(),
-            known_neuron.id.unwrap(),
+        // Insepct visibility. This time, the no explicit visibility guy is shown as such.
+        for (neuron_id, expected_visibility) in [
+            (no_explicit_visibility_neuron.id.unwrap(), None),
+            (private_neuron.id.unwrap(), Some(Visibility::Private)),
+            (public_neuron.id.unwrap(), Some(Visibility::Public)),
+            (known_neuron.id.unwrap(), Some(Visibility::Public)),
         ] {
             let neuron_info = governance.get_neuron_info(&neuron_id, controller).unwrap();
-            assert_eq!(neuron_info.visibility, None, "{:?}", neuron_info,);
+            assert_eq!(
+                neuron_info.visibility,
+                expected_visibility.map(|visibility| visibility as i32),
+                "{:?}",
+                neuron_info,
+            );
         }
     }
 }

--- a/rs/nns/governance/tests/governance.rs
+++ b/rs/nns/governance/tests/governance.rs
@@ -14154,7 +14154,7 @@ fn test_neuron_info_private_enforcement() {
         ];
         main(neuron_id_to_expect_redact);
 
-        // Insepct visibility. This time, the no explicit visibility guy is shown as such.
+        // Insepct visibility. This time, the no explicit visibility neuron is shown as such.
         for (neuron_id, expected_visibility) in [
             (no_explicit_visibility_neuron.id.unwrap(), None),
             (private_neuron.id.unwrap(), Some(Visibility::Private)),


### PR DESCRIPTION
What we should have done was call Neuron::visibility. That's how it works now. Whereas, previously, similar (but not actually equivalent) code existed in a couple other places. Those have now been replaced with a call to Neuron::visibility, ensuring consistent behavior in our conversions.