### PR TITLE
fix: [NODE-1500] Re-enable nested tests

### DIFF
--- a/rs/tests/nested/BUILD.bazel
+++ b/rs/tests/nested/BUILD.bazel
@@ -43,10 +43,6 @@ system_test_nns(
     flaky = True,
     proc_macro_deps = MACRO_DEPENDENCIES,
     tags = [
-        # TODO(https://dfinity.atlassian.net/browse/NODE-1500):
-        # The nested tests are very unstable and cause the "Schedule Hourly" workflow to fail often.
-        # So let's disable them to give us time to debug why they fail.
-        "manual",
         "system_test_hourly",
     ],
     target_compatible_with = ["@platforms//os:linux"],  # requires libssh that does not build on Mac OS
@@ -62,10 +58,6 @@ system_test_nns(
     flaky = True,
     proc_macro_deps = MACRO_DEPENDENCIES,
     tags = [
-        # TODO(https://dfinity.atlassian.net/browse/NODE-1500):
-        # The nested tests are very unstable and cause the "Schedule Hourly" workflow to fail often.
-        # So let's disable them to give us time to debug why they fail.
-        "manual",
         "system_test_hourly",
     ],
     target_compatible_with = ["@platforms//os:linux"],  # requires libssh that does not build on Mac OS


### PR DESCRIPTION
Since https://github.com/dfinity/ic/pull/2218, nested tests are back to running at a reasonable speed and passing tests.