### PR TITLE
docs(nervous-system): Add a comment for the `Timers` message in nervous_system.proto

### DIFF
--- a/rs/nervous_system/proto/proto/ic_nervous_system/pb/v1/nervous_system.proto
+++ b/rs/nervous_system/proto/proto/ic_nervous_system/pb/v1/nervous_system.proto
@@ -61,6 +61,10 @@ message Decimal {
 message ResetTimersRequest {}
 message ResetTimersResponse {}
 
+// TODO[NNS1-3420] This type can be refined into different internal API types, depending on
+// TODO[NNS1-3420] the needs of a particular canister. The fields of this type represent
+// TODO[NNS1-3420] over-approximation of the fields that might be relevant for observing and
+// TODO[NNS1-3420] managing timers in nervous system-related canisters.
 message Timers {
   // Indicates whether this canister (still) requires (timer-based) periodic tasks.
   //

--- a/rs/nervous_system/proto/src/gen/ic_nervous_system.pb.v1.rs
+++ b/rs/nervous_system/proto/src/gen/ic_nervous_system.pb.v1.rs
@@ -174,6 +174,10 @@ pub struct ResetTimersRequest {}
     ::prost::Message,
 )]
 pub struct ResetTimersResponse {}
+/// TODO\[NNS1-3420\] This type can be refined into different internal API types, depending on
+/// TODO\[NNS1-3420\] the needs of a particular canister. The fields of this type represent
+/// TODO\[NNS1-3420\] over-approximation of the fields that might be relevant for observing and
+/// TODO\[NNS1-3420\] managing timers in nervous system-related canisters.
 #[derive(
     Eq,
     candid::CandidType,

--- a/rs/sns/root/proto/ic_sns_root/pb/v1/root.proto
+++ b/rs/sns/root/proto/ic_sns_root/pb/v1/root.proto
@@ -48,7 +48,7 @@ message SnsRootCanister {
   reserved "latest_ledger_archive_poll_timestamp_seconds";
   reserved 6;
 
-  // Information about the timers that perform periodic tasks of this Swap canister.
+  // Information about the timers that perform periodic tasks of this Root canister.
   optional ic_nervous_system.pb.v1.Timers timers = 10;
 }
 

--- a/rs/sns/root/src/gen/ic_sns_root.pb.v1.rs
+++ b/rs/sns/root/src/gen/ic_sns_root.pb.v1.rs
@@ -45,7 +45,7 @@ pub struct SnsRootCanister {
     /// controllers beyond SNS root are allowed when registering a dapp.
     #[prost(bool, tag = "8")]
     pub testflight: bool,
-    /// Information about the timers that perform periodic tasks of this Swap canister.
+    /// Information about the timers that perform periodic tasks of this Root canister.
     #[prost(message, optional, tag = "10")]
     pub timers: ::core::option::Option<::ic_nervous_system_proto::pb::v1::Timers>,
 }


### PR DESCRIPTION
This PR adds some information about the applicability of `Timers` message in nervous_system.proto. 

Additionally, some typos are fixed in other proto comments.