### PR TITLE
fix(IDX): no diff with build-all-config-check

### DIFF
--- a/.github/workflows-source/ci-main.yml
+++ b/.github/workflows-source/ci-main.yml
@@ -176,6 +176,7 @@ jobs:
         id: bazel-build-config-check
         uses: ./.github/actions/bazel-test-all/
         with:
+          RUN_ON_DIFF_ONLY: false
           BAZEL_COMMAND: "build"
           BAZEL_TARGETS: "//rs/..."
           BAZEL_CI_CONFIG: "--config=check --config=ci --keep_going"

--- a/.github/workflows-source/ci-main.yml
+++ b/.github/workflows-source/ci-main.yml
@@ -176,6 +176,8 @@ jobs:
         id: bazel-build-config-check
         uses: ./.github/actions/bazel-test-all/
         with:
+          # Diff logic is problematic for this CI job
+          # https://github.com/dfinity/ic/actions/runs/11528673458/job/32096105251
           RUN_ON_DIFF_ONLY: false
           BAZEL_COMMAND: "build"
           BAZEL_TARGETS: "//rs/..."

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -158,6 +158,8 @@ jobs:
         id: bazel-build-config-check
         uses: ./.github/actions/bazel-test-all/
         with:
+          # Diff logic is problematic for this CI job
+          # https://github.com/dfinity/ic/actions/runs/11528673458/job/32096105251
           RUN_ON_DIFF_ONLY: false
           BAZEL_COMMAND: "build"
           BAZEL_TARGETS: "//rs/..."

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -158,6 +158,7 @@ jobs:
         id: bazel-build-config-check
         uses: ./.github/actions/bazel-test-all/
         with:
+          RUN_ON_DIFF_ONLY: false
           BAZEL_COMMAND: "build"
           BAZEL_TARGETS: "//rs/..."
           BAZEL_CI_CONFIG: "--config=check --config=ci --keep_going"


### PR DESCRIPTION
Disabling bazel diff logic. https://github.com/dfinity/ic/pull/2266 introduced a bug and allowed the logic to work in this CI job.