### PR TITLE
fix: call make_idle if the adapter is idle initially

### DIFF
--- a/rs/bitcoin/adapter/src/lib.rs
+++ b/rs/bitcoin/adapter/src/lib.rs
@@ -208,6 +208,15 @@ impl AdapterState {
             })
             .await;
     }
+
+    /// Returns whether the adapter is idle.
+    pub fn is_idle(&self) -> bool {
+        match *self.last_received_rx.borrow() {
+            Some(last) => last.elapsed().as_secs() > self.idle_seconds,
+            // Nothing received yet still in idle from startup.
+            None => true,
+        }
+    }
 }
 
 /// Starts the gRPC server and the router for handling incoming requests.

--- a/rs/bitcoin/adapter/src/lib.rs
+++ b/rs/bitcoin/adapter/src/lib.rs
@@ -212,7 +212,7 @@ impl AdapterState {
     /// Returns whether the adapter is idle.
     pub fn is_idle(&self) -> bool {
         match *self.last_received_rx.borrow() {
-            Some(last) => last.elapsed().as_secs() > self.idle_seconds,
+            Some(last) => last.elapsed().as_secs() >= self.idle_seconds,
             // Nothing received yet still in idle from startup.
             None => true,
         }

--- a/rs/bitcoin/adapter/src/router.rs
+++ b/rs/bitcoin/adapter/src/router.rs
@@ -49,21 +49,19 @@ pub fn start_main_event_loop(
 
     tokio::task::spawn(async move {
         let mut tick_interval = interval(Duration::from_millis(100));
-        if adapter_state.is_idle() {
-            connection_manager.make_idle();
-            blockchain_manager.make_idle();
-        }
 
         loop {
-            adapter_state.active().await;
+            if adapter_state.is_idle() {
+                connection_manager.make_idle();
+                blockchain_manager.make_idle();
+                adapter_state.active().await;
+            }
 
             // We do a select over tokio::sync::mpsc::Receiver::recv, tokio::sync::mpsc::UnboundedReceiver::recv,
             // tokio::time::Interval::tick which are all cancellation safe.
             loop {
                 tokio::select! {
                     _ = adapter_state.idle() => {
-                        connection_manager.make_idle();
-                        blockchain_manager.make_idle();
                         break;
                     },
                     event = connection_manager.receive_stream_event() => {

--- a/rs/bitcoin/adapter/src/router.rs
+++ b/rs/bitcoin/adapter/src/router.rs
@@ -49,11 +49,12 @@ pub fn start_main_event_loop(
 
     tokio::task::spawn(async move {
         let mut tick_interval = interval(Duration::from_millis(100));
-        if adapter_state.is_idle() {
-            connection_manager.make_idle();
-            blockchain_manager.make_idle();
-        }
+
         loop {
+            if adapter_state.is_idle() {
+                connection_manager.make_idle();
+                blockchain_manager.make_idle();
+            }
             adapter_state.active().await;
 
             // We do a select over tokio::sync::mpsc::Receiver::recv, tokio::sync::mpsc::UnboundedReceiver::recv,
@@ -113,8 +114,6 @@ pub fn start_main_event_loop(
                     }
                 };
             }
-            connection_manager.make_idle();
-            blockchain_manager.make_idle();
         }
     });
 }

--- a/rs/bitcoin/adapter/src/router.rs
+++ b/rs/bitcoin/adapter/src/router.rs
@@ -49,6 +49,10 @@ pub fn start_main_event_loop(
 
     tokio::task::spawn(async move {
         let mut tick_interval = interval(Duration::from_millis(100));
+        if adapter_state.is_idle() {
+            connection_manager.make_idle();
+            blockchain_manager.make_idle();
+        }
         loop {
             adapter_state.active().await;
 


### PR DESCRIPTION
Before https://github.com/dfinity/ic/pull/2178, make_idle was called at server startup if there have been no relevant transactions. 

After https://github.com/dfinity/ic/pull/2178, make_idle is not called anymore, meaning that the blockchain_manager and the connection_manager will stay in a "non idle" state forever for subnets that don't run the bitcoin adapter.