### PR TITLE
feat(ckbtc): Support KytMode in new KYT canister

### DIFF
--- a/rs/bitcoin/kyt/btc_kyt_canister.did
+++ b/rs/bitcoin/kyt/btc_kyt_canister.did
@@ -49,10 +49,13 @@ type CheckTransactionIrrecoverableError = variant {
 };
 
 type InitArg = record {
-    btc_network : BtcNetwork
+    btc_network : BtcNetwork;
+    kyt_mode: KytMode;
 };
 
-type UpgradeArg = record {};
+type UpgradeArg = record {
+    kyt_mode: opt KytMode;
+};
 
 type KytArg = variant {
     InitArg : InitArg;
@@ -62,6 +65,12 @@ type KytArg = variant {
 type BtcNetwork = variant {
     mainnet;
     testnet
+};
+
+type KytMode = variant {
+    AcceptAll;
+    RejectAll;
+    Normal;
 };
 
 service : (KytArg) -> {

--- a/rs/bitcoin/kyt/src/dashboard.rs
+++ b/rs/bitcoin/kyt/src/dashboard.rs
@@ -1,7 +1,7 @@
-use crate::{state, BtcNetwork};
+use crate::state;
 use askama::Template;
 use ic_btc_interface::Txid;
-use state::{FetchTxStatus, Timestamp};
+use state::{Config, FetchTxStatus, Timestamp};
 use std::fmt;
 
 #[cfg(test)]
@@ -25,7 +25,7 @@ mod filters {
 #[derive(Template)]
 #[template(path = "dashboard.html", whitespace = "suppress")]
 pub struct DashboardTemplate {
-    btc_network: BtcNetwork,
+    config: Config,
     outcall_capacity: u32,
     cached_entries: usize,
     tx_table_page_size: usize,
@@ -80,7 +80,7 @@ const DEFAULT_TX_TABLE_PAGE_SIZE: usize = 500;
 pub fn dashboard(page_index: usize) -> DashboardTemplate {
     let tx_table_page_size = DEFAULT_TX_TABLE_PAGE_SIZE;
     DashboardTemplate {
-        btc_network: state::get_config().btc_network,
+        config: state::get_config(),
         outcall_capacity: state::OUTCALL_CAPACITY.with(|capacity| *capacity.borrow()),
         cached_entries: state::FETCH_TX_CACHE.with(|cache| cache.borrow().iter().count()),
         tx_table_page_size,

--- a/rs/bitcoin/kyt/src/dashboard/tests.rs
+++ b/rs/bitcoin/kyt/src/dashboard/tests.rs
@@ -1,7 +1,7 @@
 use crate::dashboard::tests::assertions::DashboardAssert;
 use crate::dashboard::{filters, DashboardTemplate, Fetched, Status, DEFAULT_TX_TABLE_PAGE_SIZE};
-use crate::state::{Timestamp, TransactionKytData};
-use crate::{blocklist::BTC_ADDRESS_BLOCKLIST, dashboard, state, BtcNetwork};
+use crate::state::{Config, Timestamp, TransactionKytData};
+use crate::{blocklist::BTC_ADDRESS_BLOCKLIST, dashboard, state, BtcNetwork, KytMode};
 use bitcoin::Address;
 use bitcoin::{absolute::LockTime, transaction::Version, Transaction};
 use ic_btc_interface::Txid;
@@ -16,13 +16,16 @@ fn mock_txid(v: usize) -> Txid {
 
 #[test]
 fn should_display_metadata() {
-    let btc_network = BtcNetwork::Mainnet;
+    let config = Config {
+        btc_network: BtcNetwork::Mainnet,
+        kyt_mode: KytMode::Normal,
+    };
     let outcall_capacity = 50;
     let cached_entries = 0;
     let oldest_entry_time = 0;
     let latest_entry_time = 1_000_000_000_000;
     let dashboard = DashboardTemplate {
-        btc_network,
+        config: config.clone(),
         outcall_capacity,
         cached_entries,
         tx_table_page_size: 10,
@@ -33,7 +36,8 @@ fn should_display_metadata() {
     };
 
     DashboardAssert::assert_that(dashboard)
-        .has_btc_network_in_title(btc_network)
+        .has_btc_network_in_title(config.btc_network)
+        .has_kyt_mode(config.kyt_mode)
         .has_outcall_capacity(outcall_capacity)
         .has_cached_entries(cached_entries)
         .has_oldest_entry_time(oldest_entry_time)
@@ -73,7 +77,10 @@ fn should_display_statuses() {
     });
 
     let dashboard = DashboardTemplate {
-        btc_network: BtcNetwork::Mainnet,
+        config: Config {
+            btc_network: BtcNetwork::Mainnet,
+            kyt_mode: KytMode::Normal,
+        },
         outcall_capacity: 50,
         cached_entries: 6,
         tx_table_page_size: 10,
@@ -115,6 +122,7 @@ fn test_pagination() {
 
     state::set_config(state::Config {
         btc_network: BtcNetwork::Mainnet,
+        kyt_mode: KytMode::Normal,
     });
     let mock_transaction = TransactionKytData::from_transaction(
         &BtcNetwork::Mainnet,
@@ -190,6 +198,14 @@ mod assertions {
                 "title",
                 &format!("KYT Canister Dashboard for Bitcoin ({})", btc_network),
                 "wrong btc_network",
+            )
+        }
+
+        pub fn has_kyt_mode(&self, kyt_mode: KytMode) -> &Self {
+            self.has_string_value(
+                "#kyt-mode > td > code",
+                &format!("{}", kyt_mode),
+                "wrong KYT mode",
             )
         }
 

--- a/rs/bitcoin/kyt/src/fetch.rs
+++ b/rs/bitcoin/kyt/src/fetch.rs
@@ -6,7 +6,7 @@ use crate::types::{
     CheckTransactionIrrecoverableError, CheckTransactionResponse, CheckTransactionRetriable,
     CheckTransactionStatus,
 };
-use crate::{blocklist_contains, providers, state, BtcNetwork};
+use crate::{blocklist_contains, providers, state, Config};
 use bitcoin::Transaction;
 use futures::future::try_join_all;
 use ic_btc_interface::Txid;
@@ -59,7 +59,7 @@ pub enum TryFetchResult<F> {
 pub trait FetchEnv {
     type FetchGuard;
     fn new_fetch_guard(&self, txid: Txid) -> Result<Self::FetchGuard, FetchGuardError>;
-    fn btc_network(&self) -> BtcNetwork;
+    fn config(&self) -> Config;
 
     async fn http_get_tx(
         &self,
@@ -81,13 +81,13 @@ pub trait FetchEnv {
     ) -> TryFetchResult<impl futures::Future<Output = Result<FetchResult, Infallible>>> {
         let (provider, max_response_bytes) = match state::get_fetch_status(txid) {
             None => (
-                providers::next_provider(self.btc_network()),
+                providers::next_provider(self.config().btc_network),
                 INITIAL_MAX_RESPONSE_BYTES,
             ),
             Some(FetchTxStatus::PendingRetry {
                 max_response_bytes, ..
             }) => (
-                providers::next_provider(self.btc_network()),
+                providers::next_provider(self.config().btc_network),
                 max_response_bytes,
             ),
             Some(FetchTxStatus::PendingOutcall { .. }) => return TryFetchResult::Pending,

--- a/rs/bitcoin/kyt/src/main.rs
+++ b/rs/bitcoin/kyt/src/main.rs
@@ -27,8 +27,12 @@ fn check_address(args: CheckAddressArgs) -> CheckAddressResponse {
     match config.kyt_mode {
         KytMode::AcceptAll => CheckAddressResponse::Passed,
         KytMode::RejectAll => CheckAddressResponse::Failed,
-        KytMode::Normal if blocklist_contains(&address) => CheckAddressResponse::Failed,
-        KytMode::Normal => CheckAddressResponse::Passed,
+        KytMode::Normal => {
+            if blocklist_contains(&address) {
+                return CheckAddressResponse::Failed;
+            }
+            CheckAddressResponse::Passed
+        }
     }
 }
 

--- a/rs/bitcoin/kyt/src/state.rs
+++ b/rs/bitcoin/kyt/src/state.rs
@@ -1,4 +1,7 @@
-use crate::{providers::Provider, types::BtcNetwork};
+use crate::{
+    providers::Provider,
+    types::{BtcNetwork, KytMode},
+};
 use bitcoin::{Address, Transaction};
 use ic_btc_interface::Txid;
 use ic_cdk::api::call::RejectionCode;
@@ -258,6 +261,7 @@ impl Drop for FetchGuard {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Config {
     pub btc_network: BtcNetwork,
+    pub kyt_mode: KytMode,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/rs/bitcoin/kyt/src/types.rs
+++ b/rs/bitcoin/kyt/src/types.rs
@@ -82,6 +82,7 @@ impl From<CheckTransactionStatus> for CheckTransactionResponse {
 #[derive(CandidType, Clone, Debug, Deserialize, Serialize)]
 pub struct InitArg {
     pub btc_network: BtcNetwork,
+    pub kyt_mode: KytMode,
 }
 
 #[derive(CandidType, Clone, Copy, Deserialize, Debug, Eq, PartialEq, Serialize, Hash)]
@@ -90,6 +91,23 @@ pub enum BtcNetwork {
     Mainnet,
     #[serde(rename = "testnet")]
     Testnet,
+}
+
+#[derive(CandidType, Clone, Copy, Deserialize, Debug, Eq, PartialEq, Serialize, Hash)]
+pub enum KytMode {
+    AcceptAll,
+    RejectAll,
+    Normal,
+}
+
+impl fmt::Display for KytMode {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Self::AcceptAll => write!(f, "AcceptAll"),
+            Self::RejectAll => write!(f, "RejectAll"),
+            Self::Normal => write!(f, "Normal"),
+        }
+    }
 }
 
 impl From<BtcNetwork> for bitcoin::Network {
@@ -111,7 +129,9 @@ impl fmt::Display for BtcNetwork {
 }
 
 #[derive(CandidType, Debug, Deserialize, Serialize)]
-pub struct UpgradeArg {}
+pub struct UpgradeArg {
+    pub kyt_mode: Option<KytMode>,
+}
 
 #[derive(CandidType, Debug, Deserialize, Serialize)]
 pub enum KytArg {

--- a/rs/bitcoin/kyt/templates/dashboard.html
+++ b/rs/bitcoin/kyt/templates/dashboard.html
@@ -7,10 +7,10 @@
 {%- endmacro %}
 
 {% macro btc_tx_link(txid) -%}
-    {% match btc_network %}
-        {%- when BtcNetwork::Mainnet -%}
+    {% match config.btc_network %}
+        {%- when crate::BtcNetwork::Mainnet -%}
             <a href="https://live.blockcypher.com/btc/tx/{{txid}}"><code>{{txid}}</code></a>
-        {%- when BtcNetwork::Testnet -%}
+        {%- when crate::BtcNetwork::Testnet -%}
             <a href="https://live.blockcypher.com/btc-testnet/tx/{{txid}}"><code>{{txid}}</code></a>
     {% endmatch %}
 {%- endmacro %}
@@ -32,7 +32,7 @@
 <html lang="en">
 
 <head>
-    <title>KYT Canister Dashboard for Bitcoin ({{ btc_network }})</title>
+    <title>KYT Canister Dashboard for Bitcoin ({{ config.btc_network }})</title>
     <style>
         details {
             margin-right: 1rem;
@@ -126,10 +126,14 @@
 <body>
     <div class="background">
         <div class="content">
-            <h2>KYT Canister Dashboard for Bitcoin ({{ btc_network }})</h2>
+            <h2>KYT Canister Dashboard for Bitcoin ({{ config.btc_network }})</h2>
             <h3>Metadata</h3>
             <table>
                 <tbody>
+                    <tr id="kyt-mode">
+                        <th>KYT Mode</th>
+                        <td><code>{{ config.kyt_mode }}</code></td>
+                    </tr>
                     <tr id="outcall-capacity">
                         <th>Outcall Capacity</th>
                         <td><code>{{ outcall_capacity }}</code></td>

--- a/rs/bitcoin/kyt/tests/tests.rs
+++ b/rs/bitcoin/kyt/tests/tests.rs
@@ -257,27 +257,30 @@ fn test_check_transaction_passed() {
 
     let txid =
         Txid::from_str("c80763842edc9a697a2114517cf0c138c5403a761ef63cfad1fa6993fa3475ed").unwrap();
-    let call_id = setup
-        .submit_kyt_call(
-            "check_transaction",
-            Encode!(&CheckTransactionArgs {
-                txid: txid.as_ref().to_vec()
-            })
-            .unwrap(),
-            CHECK_TRANSACTION_CYCLES_REQUIRED,
-        )
-        .expect("submit_call failed to return call id");
     let env = &setup.env;
 
-    // The response body used for testing below is generated from the output of
-    //
-    //   curl -H 'User-Agent: bitcoin-value-collector' https://btcscan.org/api/tx/{txid}/raw
-    //
-    // There wll be two outcalls because the canister will first fetch the above
-    // given txid, and then fetch the vout[0] from the returned transaction body.
+    // Normal operation requires making http outcalls.
+    // We'll run this again after testing other KytMode.
+    let test_normal_operation = || {
+        let call_id = setup
+            .submit_kyt_call(
+                "check_transaction",
+                Encode!(&CheckTransactionArgs {
+                    txid: txid.as_ref().to_vec()
+                })
+                .unwrap(),
+                CHECK_TRANSACTION_CYCLES_REQUIRED,
+            )
+            .expect("submit_call failed to return call id");
+        // The response body used for testing below is generated from the output of
+        //
+        //   curl -H 'User-Agent: bitcoin-value-collector' https://btcscan.org/api/tx/{txid}/raw
+        //
+        // There wll be two outcalls because the canister will first fetch the above
+        // given txid, and then fetch the vout[0] from the returned transaction body.
 
-    let canister_http_requests = tick_until_next_request(env);
-    let body = b"\
+        let canister_http_requests = tick_until_next_request(env);
+        let body = b"\
 \x02\x00\x00\x00\x01\x17\x34\x3a\xab\xa9\x67\x67\x2f\x17\xef\x0a\xbf\x4b\xb1\x14\xad\x19\x63\xe0\
 \x7d\xd2\xf2\x05\xaa\x25\xa4\xda\x50\x3e\xdb\x01\xab\x01\x00\x00\x00\x6a\x47\x30\x44\x02\x20\x21\
 \x81\xb5\x9c\xa7\xed\x7e\x2c\x8e\x06\x96\x52\xb0\x7e\xd2\x10\x24\x9e\x83\x37\xec\xc5\x35\xca\x6b\
@@ -288,20 +291,20 @@ fn test_check_transaction_passed() {
 \xed\xfc\x0a\x8b\x66\xfe\xeb\xae\x5c\x2e\x25\xa7\xb6\xa5\xd1\xcf\x31\x88\xac\x7c\x2e\x00\x00\x00\
 \x00\x00\x00\x19\x76\xa9\x14\xb9\x73\x68\xd8\xbf\x0a\x37\x69\x00\x85\x16\x57\xf3\x7f\xbe\x73\xa6\
 \x56\x61\x33\x88\xac\x14\xa4\x0c\x00"
-        .to_vec();
-    env.mock_canister_http_response(MockCanisterHttpResponse {
-        subnet_id: canister_http_requests[0].subnet_id,
-        request_id: canister_http_requests[0].request_id,
-        response: CanisterHttpResponse::CanisterHttpReply(CanisterHttpReply {
-            status: 200,
-            headers: vec![],
-            body,
-        }),
-        additional_responses: vec![],
-    });
+            .to_vec();
+        env.mock_canister_http_response(MockCanisterHttpResponse {
+            subnet_id: canister_http_requests[0].subnet_id,
+            request_id: canister_http_requests[0].request_id,
+            response: CanisterHttpResponse::CanisterHttpReply(CanisterHttpReply {
+                status: 200,
+                headers: vec![],
+                body,
+            }),
+            additional_responses: vec![],
+        });
 
-    let canister_http_requests = tick_until_next_request(env);
-    let body = b"\
+        let canister_http_requests = tick_until_next_request(env);
+        let body = b"\
 \x02\x00\x00\x00\x01\x82\xc8\x5d\xe7\x4d\x19\xbb\x36\x16\x2f\xca\xef\xc7\xe7\x70\x15\x65\xb0\x2d\
 \xf6\x06\x0f\x8e\xcf\x49\x64\x63\x37\xfc\xe8\x59\x37\x07\x00\x00\x00\x6a\x47\x30\x44\x02\x20\x15\
 \xf2\xc7\x7a\x3b\x95\x13\x73\x7a\xa2\x86\xb3\xe6\x06\xf9\xb6\x82\x1c\x6d\x5d\x35\xe5\xa9\x58\xe0\
@@ -312,46 +315,50 @@ fn test_check_transaction_passed() {
 \xb1\x5c\xbf\x27\xd5\x42\x53\x99\xeb\xf6\xf0\xfb\x50\xeb\xb8\x8f\x18\x88\xac\x00\x96\x00\x00\x00\
 \x00\x00\x00\x19\x76\xa9\x14\xb9\x73\x68\xd8\xbf\x0a\x37\x69\x00\x85\x16\x57\xf3\x7f\xbe\x73\xa6\
 \x56\x61\x33\x88\xac\xb3\xa3\x0c\x00"
-        .to_vec();
-    env.mock_canister_http_response(MockCanisterHttpResponse {
-        subnet_id: canister_http_requests[0].subnet_id,
-        request_id: canister_http_requests[0].request_id,
-        response: CanisterHttpResponse::CanisterHttpReply(CanisterHttpReply {
-            status: 200,
-            headers: vec![],
-            body: body.clone(),
-        }),
-        // Fill additional responses with different headers to test if the transform
-        // function does its job by clearing the headers.
-        additional_responses: (1..13)
-            .map(|i| {
-                CanisterHttpResponse::CanisterHttpReply(CanisterHttpReply {
-                    status: 200,
-                    headers: vec![CanisterHttpHeader {
-                        name: format!("name-{}", i),
-                        value: format!("{}", i),
-                    }],
-                    body: body.clone(),
+            .to_vec();
+        env.mock_canister_http_response(MockCanisterHttpResponse {
+            subnet_id: canister_http_requests[0].subnet_id,
+            request_id: canister_http_requests[0].request_id,
+            response: CanisterHttpResponse::CanisterHttpReply(CanisterHttpReply {
+                status: 200,
+                headers: vec![],
+                body: body.clone(),
+            }),
+            // Fill additional responses with different headers to test if the transform
+            // function does its job by clearing the headers.
+            additional_responses: (1..13)
+                .map(|i| {
+                    CanisterHttpResponse::CanisterHttpReply(CanisterHttpReply {
+                        status: 200,
+                        headers: vec![CanisterHttpHeader {
+                            name: format!("name-{}", i),
+                            value: format!("{}", i),
+                        }],
+                        body: body.clone(),
+                    })
                 })
-            })
-            .collect(),
-    });
+                .collect(),
+        });
 
-    let result = env
-        .await_call(call_id)
-        .expect("the fetch request didn't finish");
+        let result = env
+            .await_call(call_id)
+            .expect("the fetch request didn't finish");
 
-    assert!(matches!(
-        decode::<CheckTransactionResponse>(&result),
-        CheckTransactionResponse::Passed
-    ));
+        assert!(matches!(
+            decode::<CheckTransactionResponse>(&result),
+            CheckTransactionResponse::Passed
+        ));
 
-    let cycles_after = env.cycle_balance(setup.caller);
-    let expected_cost =
-        CHECK_TRANSACTION_CYCLES_SERVICE_FEE + 2 * get_tx_cycle_cost(INITIAL_MAX_RESPONSE_BYTES);
-    let actual_cost = cycles_before - cycles_after;
-    assert!(actual_cost > expected_cost);
-    assert!(actual_cost - expected_cost < UNIVERSAL_CANISTER_CYCLE_MARGIN);
+        let cycles_after = env.cycle_balance(setup.caller);
+        let expected_cost = CHECK_TRANSACTION_CYCLES_SERVICE_FEE
+            + 2 * get_tx_cycle_cost(INITIAL_MAX_RESPONSE_BYTES);
+        let actual_cost = cycles_before - cycles_after;
+        assert!(actual_cost > expected_cost);
+        assert!(actual_cost - expected_cost < UNIVERSAL_CANISTER_CYCLE_MARGIN);
+    };
+
+    // With default installation
+    test_normal_operation();
 
     // Test KytMode::RejectAll
     env.tick();
@@ -426,6 +433,21 @@ fn test_check_transaction_passed() {
     let actual_cost = cycles_before - cycles_after;
     assert!(actual_cost > expected_cost);
     assert!(actual_cost - expected_cost < UNIVERSAL_CANISTER_CYCLE_MARGIN);
+
+    // Test KytMode::Normal
+    env.tick();
+    env.upgrade_canister(
+        setup.kyt_canister,
+        kyt_wasm(),
+        Encode!(&KytArg::UpgradeArg(Some(UpgradeArg {
+            kyt_mode: Some(KytMode::Normal),
+        })))
+        .unwrap(),
+        Some(setup.controller),
+    )
+    .unwrap();
+
+    test_normal_operation();
 }
 
 #[test]

--- a/rs/bitcoin/kyt/tests/tests.rs
+++ b/rs/bitcoin/kyt/tests/tests.rs
@@ -253,8 +253,6 @@ fn test_check_address() {
 #[test]
 fn test_check_transaction_passed() {
     let setup = Setup::new(BtcNetwork::Mainnet);
-    let cycles_before = setup.env.cycle_balance(setup.caller);
-
     let txid =
         Txid::from_str("c80763842edc9a697a2114517cf0c138c5403a761ef63cfad1fa6993fa3475ed").unwrap();
     let env = &setup.env;
@@ -262,6 +260,7 @@ fn test_check_transaction_passed() {
     // Normal operation requires making http outcalls.
     // We'll run this again after testing other KytMode.
     let test_normal_operation = || {
+        let cycles_before = setup.env.cycle_balance(setup.caller);
         let call_id = setup
             .submit_kyt_call(
                 "check_transaction",
@@ -372,7 +371,7 @@ fn test_check_transaction_passed() {
         Some(setup.controller),
     )
     .unwrap();
-    let cycles_before = setup.env.cycle_balance(setup.caller);
+    let cycles_before = env.cycle_balance(setup.caller);
     let call_id = setup
         .submit_kyt_call(
             "check_transaction",
@@ -409,7 +408,7 @@ fn test_check_transaction_passed() {
         Some(setup.controller),
     )
     .unwrap();
-    let cycles_before = setup.env.cycle_balance(setup.caller);
+    let cycles_before = env.cycle_balance(setup.caller);
     let call_id = setup
         .submit_kyt_call(
             "check_transaction",


### PR DESCRIPTION
Support KytMode in the initialization and upgrade parameters  to the new KYT canister.
This simplifies work involved in testing with this canister, because the previous KYT canister had this feature and existing ckbtc minter tests are making use of it.