### PR TITLE
test(IDX): increase the number of ic-ref-test jobs in the spec_compliance tests

### DIFF
--- a/rs/tests/research/spec_compliance/spec_compliance.rs
+++ b/rs/tests/research/spec_compliance/spec_compliance.rs
@@ -337,7 +337,7 @@ pub fn with_endpoint(
         peer_subnet_config,
         excluded_tests,
         included_tests,
-        16,
+        64,
     );
 }
 


### PR DESCRIPTION
https://github.com/dfinity/ic/pull/2251 optimised ic-ref-test such that instead of uploading the WASM of the universal canister for every test it's only uploaded once to the WASM chunk store and then installed from there.

This should reduce the load on the IC and so we should be able to support a higher level of parallelism. So like #2251 we bump the number of ic-ref-test jobs from 16 to 64.

The following are [the results](https://dash.zh1-idx1.dfinity.network/invocation/ccf672c1-5f7b-40da-bc73-8d1b4a511b47?targetFilter=%2F%2Frs%2Ftests%2Fresearch%3Aspec_compliance_#targets) where I list [the P90 from last week onwards](https://superset.idx.dfinity.network/explore/?form_data_key=8dXXZ6F633bRVs9tnki-0djzUkDwtjFAjeYJ_7nQBtbbdsmDpSSC1k0-0wG-V8s5&dashboard_page_id=jkkuHpdTs&slice_id=60) and the new duration with 64 jobs:

| Test | P90 duration from last week onwards | new duration |
| --- | --- | --- |
| `spec_compliance_application_subnet_test` | 9m 7s | 7m 6s |
| `spec_compliance_group_01_application_subnet_test`| 7m 1s | 3m 44s |
| `spec_compliance_group_01_system_subnet_test`| 6m 49s | 3m 35s |
| `spec_compliance_group_02_system_subnet_test`| 2m 27s | 2m 9s |
| `spec_compliance_system_subnet_test`| 7m 48s | 3m 43s |

This has the risk of overloading the IC and thus of increasing flakiness of the spec_compliance tests so let's do an evaluation after a week by taking a look at [the flakiness chart](https://superset.idx.dfinity.network/explore/?form_data_key=-2qZh5uOWuQZBubB22MyJxow_u_zlQ1THOMOoe_gUnYMTqscHHiK0CaUruqdZlya&dashboard_page_id=fe3x8oUs8&slice_id=31).