### PR TITLE
fix: remove the idle future

### DIFF
--- a/rs/bitcoin/adapter/src/lib.rs
+++ b/rs/bitcoin/adapter/src/lib.rs
@@ -208,6 +208,15 @@ impl AdapterState {
             })
             .await;
     }
+
+    /// Returns whether the adapter is idle.
+    pub fn is_idle(&self) -> bool {
+        match *self.last_received_rx.borrow() {
+            Some(last) => last.elapsed().as_secs() > self.idle_seconds,
+            // Nothing received yet still in idle from startup.
+            None => true,
+        }
+    }
 }
 
 /// Starts the gRPC server and the router for handling incoming requests.

--- a/rs/bitcoin/adapter/src/lib.rs
+++ b/rs/bitcoin/adapter/src/lib.rs
@@ -212,7 +212,7 @@ impl AdapterState {
     /// Returns whether the adapter is idle.
     pub fn is_idle(&self) -> bool {
         match *self.last_received_rx.borrow() {
-            Some(last) => last.elapsed().as_secs() > self.idle_seconds,
+            Some(last) => last.elapsed().as_secs() >= self.idle_seconds,
             // Nothing received yet still in idle from startup.
             None => true,
         }

--- a/rs/bitcoin/adapter/src/router.rs
+++ b/rs/bitcoin/adapter/src/router.rs
@@ -49,21 +49,19 @@ pub fn start_main_event_loop(
 
     tokio::task::spawn(async move {
         let mut tick_interval = interval(Duration::from_millis(100));
-        if adapter_state.is_idle() {
-            connection_manager.make_idle();
-            blockchain_manager.make_idle();
-        }
 
         loop {
-            adapter_state.active().await;
+            if adapter_state.is_idle() {
+                connection_manager.make_idle();
+                blockchain_manager.make_idle();
+                adapter_state.active().await;
+            }
 
             // We do a select over tokio::sync::mpsc::Receiver::recv, tokio::sync::mpsc::UnboundedReceiver::recv,
             // tokio::time::Interval::tick which are all cancellation safe.
             loop {
                 tokio::select! {
                     _ = adapter_state.idle() => {
-                        connection_manager.make_idle();
-                        blockchain_manager.make_idle();
                         break;
                     },
                     event = connection_manager.receive_stream_event() => {

--- a/rs/bitcoin/adapter/src/router.rs
+++ b/rs/bitcoin/adapter/src/router.rs
@@ -59,61 +59,56 @@ pub fn start_main_event_loop(
 
             // We do a select over tokio::sync::mpsc::Receiver::recv, tokio::sync::mpsc::UnboundedReceiver::recv,
             // tokio::time::Interval::tick which are all cancellation safe.
-            loop {
-                tokio::select! {
-                    _ = adapter_state.idle() => {
-                        break;
-                    },
-                    event = connection_manager.receive_stream_event() => {
-                        if let Err(ProcessBitcoinNetworkMessageError::InvalidMessage) =
-                            connection_manager.process_event(&event)
-                        {
-                            connection_manager.discard(&event.address);
-                        }
-                    },
-                    network_message = network_message_receiver.recv() => {
-                        let (address, message) = network_message.unwrap();
-                        router_metrics
-                            .bitcoin_messages_received
-                            .with_label_values(&[message.cmd()])
-                            .inc();
-                        if let Err(ProcessBitcoinNetworkMessageError::InvalidMessage) =
-                            connection_manager.process_bitcoin_network_message(address, &message) {
-                            connection_manager.discard(&address);
-                        }
+            tokio::select! {
+                event = connection_manager.receive_stream_event() => {
+                    if let Err(ProcessBitcoinNetworkMessageError::InvalidMessage) =
+                        connection_manager.process_event(&event)
+                    {
+                        connection_manager.discard(&event.address);
+                    }
+                },
+                network_message = network_message_receiver.recv() => {
+                    let (address, message) = network_message.unwrap();
+                    router_metrics
+                        .bitcoin_messages_received
+                        .with_label_values(&[message.cmd()])
+                        .inc();
+                    if let Err(ProcessBitcoinNetworkMessageError::InvalidMessage) =
+                        connection_manager.process_bitcoin_network_message(address, &message) {
+                        connection_manager.discard(&address);
+                    }
 
-                        if let Err(ProcessBitcoinNetworkMessageError::InvalidMessage) = blockchain_manager.process_bitcoin_network_message(&mut connection_manager, address, &message) {
-                            connection_manager.discard(&address);
-                        }
-                        if let Err(ProcessBitcoinNetworkMessageError::InvalidMessage) = transaction_manager.process_bitcoin_network_message(&mut connection_manager, address, &message) {
-                            connection_manager.discard(&address);
-                        }
-                    },
-                    result = blockchain_manager_rx.recv() => {
-                        let command = result.expect("Receiving should not fail because the sender part of the channel is never closed.");
-                        match command {
-                            BlockchainManagerRequest::EnqueueNewBlocksToDownload(next_headers) => {
-                                blockchain_manager.enqueue_new_blocks_to_download(next_headers);
-                            }
-                            BlockchainManagerRequest::PruneBlocks(anchor, processed_block_hashes) => {
-                                blockchain_manager.prune_blocks(anchor, processed_block_hashes);
-                            }
-                        };
+                    if let Err(ProcessBitcoinNetworkMessageError::InvalidMessage) = blockchain_manager.process_bitcoin_network_message(&mut connection_manager, address, &message) {
+                        connection_manager.discard(&address);
                     }
-                    transaction_manager_request = transaction_manager_rx.recv() => {
-                        match transaction_manager_request.unwrap() {
-                            TransactionManagerRequest::SendTransaction(transaction) => transaction_manager.enqueue_transaction(&transaction),
-                        }
-                    },
-                    _ = tick_interval.tick() => {
-                        // After an event is dispatched, the managers `tick` method is called to process possible
-                        // outgoing messages.
-                        connection_manager.tick(blockchain_manager.get_height(), handle_stream);
-                        blockchain_manager.tick(&mut connection_manager);
-                        transaction_manager.advertise_txids(&mut connection_manager);
+                    if let Err(ProcessBitcoinNetworkMessageError::InvalidMessage) = transaction_manager.process_bitcoin_network_message(&mut connection_manager, address, &message) {
+                        connection_manager.discard(&address);
                     }
-                };
-            }
+                },
+                result = blockchain_manager_rx.recv() => {
+                    let command = result.expect("Receiving should not fail because the sender part of the channel is never closed.");
+                    match command {
+                        BlockchainManagerRequest::EnqueueNewBlocksToDownload(next_headers) => {
+                            blockchain_manager.enqueue_new_blocks_to_download(next_headers);
+                        }
+                        BlockchainManagerRequest::PruneBlocks(anchor, processed_block_hashes) => {
+                            blockchain_manager.prune_blocks(anchor, processed_block_hashes);
+                        }
+                    };
+                }
+                transaction_manager_request = transaction_manager_rx.recv() => {
+                    match transaction_manager_request.unwrap() {
+                        TransactionManagerRequest::SendTransaction(transaction) => transaction_manager.enqueue_transaction(&transaction),
+                    }
+                },
+                _ = tick_interval.tick() => {
+                    // After an event is dispatched, the managers `tick` method is called to process possible
+                    // outgoing messages.
+                    connection_manager.tick(blockchain_manager.get_height(), handle_stream);
+                    blockchain_manager.tick(&mut connection_manager);
+                    transaction_manager.advertise_txids(&mut connection_manager);
+                }
+            };
         }
     });
 }

--- a/rs/bitcoin/adapter/src/router.rs
+++ b/rs/bitcoin/adapter/src/router.rs
@@ -50,7 +50,6 @@ pub fn start_main_event_loop(
     tokio::task::spawn(async move {
         let mut tick_interval = interval(Duration::from_millis(100));
 
-
         loop {
             if adapter_state.is_idle() {
                 connection_manager.make_idle();

--- a/rs/bitcoin/adapter/src/router.rs
+++ b/rs/bitcoin/adapter/src/router.rs
@@ -49,11 +49,12 @@ pub fn start_main_event_loop(
 
     tokio::task::spawn(async move {
         let mut tick_interval = interval(Duration::from_millis(100));
-        if adapter_state.is_idle() {
-            connection_manager.make_idle();
-            blockchain_manager.make_idle();
-        }
+
         loop {
+            if adapter_state.is_idle() {
+                connection_manager.make_idle();
+                blockchain_manager.make_idle();
+            }
             adapter_state.active().await;
 
             // We do a select over tokio::sync::mpsc::Receiver::recv, tokio::sync::mpsc::UnboundedReceiver::recv,
@@ -113,8 +114,6 @@ pub fn start_main_event_loop(
                     }
                 };
             }
-            connection_manager.make_idle();
-            blockchain_manager.make_idle();
         }
     });
 }

--- a/rs/bitcoin/adapter/src/router.rs
+++ b/rs/bitcoin/adapter/src/router.rs
@@ -49,6 +49,10 @@ pub fn start_main_event_loop(
 
     tokio::task::spawn(async move {
         let mut tick_interval = interval(Duration::from_millis(100));
+        if adapter_state.is_idle() {
+            connection_manager.make_idle();
+            blockchain_manager.make_idle();
+        }
         loop {
             adapter_state.active().await;
 

--- a/rs/bitcoin/adapter/src/router.rs
+++ b/rs/bitcoin/adapter/src/router.rs
@@ -56,11 +56,6 @@ pub fn start_main_event_loop(
                 blockchain_manager.make_idle();
                 adapter_state.active().await;
             }
-            if adapter_state.is_idle() {
-                connection_manager.make_idle();
-                blockchain_manager.make_idle();
-                adapter_state.active().await;
-            }
 
             // We do a select over tokio::sync::mpsc::Receiver::recv, tokio::sync::mpsc::UnboundedReceiver::recv,
             // tokio::time::Interval::tick which are all cancellation safe.


### PR DESCRIPTION
the "idle" method was fairly complex, and it had a few bugs:
- if it was called before any transactions happened, it would not return immediately, instead it would wait for "idle_sec" (because the last_time defaults to now()).
- If the last transaction time happened more than "idle_sec" ago, it would panic because the u64 subtraction would underflow.

It was used to notify the main loop that it needs to break. This can now be a simple check after each iteration. 

These are both very niche cases and almost impossible to happen, from the way the method is used; but leaving it increases the risk of misusing the method in the future.