### PR TITLE
feat(sns): Make SNS-W create new Swaps with SNS Root as a controller (in addition to NNS Root)

### DIFF
--- a/rs/nns/sns-wasm/src/sns_wasm.rs
+++ b/rs/nns/sns-wasm/src/sns_wasm.rs
@@ -996,7 +996,9 @@ where
     }
 
     /// Sets the controllers of the SNS canisters so that Root controls Governance + Ledger, and
-    /// Governance controls Root
+    /// Governance controls Root.
+    ///
+    /// WARNING: This function should be kept in sync with `remove_self_as_controller`.
     async fn add_controllers(
         canister_api: &impl CanisterApi,
         canisters: &SnsCanisterIds,
@@ -1075,7 +1077,7 @@ where
         canisters: &SnsCanisterIds,
     ) -> Result<(), String> {
         let set_controllers_results = vec![
-            // Removing self, leaving root.
+            // Removing self, leaving SNS Root.
             canister_api
                 .set_controllers(
                     CanisterId::unchecked_from_principal(canisters.governance.unwrap()),
@@ -1088,7 +1090,7 @@ where
                         e
                     )
                 }),
-            // Removing self, leaving root.
+            // Removing self, leaving SNS Root.
             canister_api
                 .set_controllers(
                     CanisterId::unchecked_from_principal(canisters.ledger.unwrap()),
@@ -1096,7 +1098,7 @@ where
                 )
                 .await
                 .map_err(|e| format!("Unable to remove SNS-WASM as Ledger's controller: {}", e)),
-            // Removing self, leaving governance.
+            // Removing self, leaving SNS Governance.
             canister_api
                 .set_controllers(
                     CanisterId::unchecked_from_principal(canisters.root.unwrap()),
@@ -1104,11 +1106,11 @@ where
                 )
                 .await
                 .map_err(|e| format!("Unable to remove SNS-WASM as Root's controller: {}", e)),
-            // Removing self, leaving NNS-Root
+            // Removing self, leaving SNS Root and NNS Root.
             canister_api
                 .set_controllers(
                     CanisterId::unchecked_from_principal(canisters.swap.unwrap()),
-                    vec![ROOT_CANISTER_ID.get()],
+                    vec![canisters.root.unwrap(), ROOT_CANISTER_ID.get()],
                 )
                 .await
                 .map_err(|e| format!("Unable to remove SNS-WASM as Swap's controller: {}", e)),
@@ -3717,7 +3719,7 @@ mod test {
                 (governance_id, vec![root_id.get()]),
                 (ledger_id, vec![root_id.get()]),
                 (root_id, vec![governance_id.get()]),
-                (swap_id, vec![ROOT_CANISTER_ID.get()]),
+                (swap_id, vec![root_id.get(), ROOT_CANISTER_ID.get()]),
                 (index_id, vec![root_id.get()]),
             ],
             vec![],
@@ -3831,7 +3833,7 @@ mod test {
                 (governance_id, vec![root_id.get()]),
                 (ledger_id, vec![root_id.get()]),
                 (root_id, vec![governance_id.get()]),
-                (swap_id, vec![ROOT_CANISTER_ID.get()]),
+                (swap_id, vec![root_id.get(), ROOT_CANISTER_ID.get()]),
                 (index_id, vec![root_id.get()]),
             ],
             vec![
@@ -4000,7 +4002,7 @@ mod test {
                 (governance_id, vec![root_id.get()]),
                 (ledger_id, vec![root_id.get()]),
                 (root_id, vec![governance_id.get()]),
-                (swap_id, vec![ROOT_CANISTER_ID.get()]),
+                (swap_id, vec![root_id.get(), ROOT_CANISTER_ID.get()]),
                 (index_id, vec![root_id.get()]),
             ],
             vec![],
@@ -4584,7 +4586,7 @@ mod test {
                 (governance_id, vec![root_id.get()]),
                 (ledger_id, vec![root_id.get()]),
                 (root_id, vec![governance_id.get()]),
-                (swap_id, vec![ROOT_CANISTER_ID.get()]),
+                (swap_id, vec![root_id.get(), ROOT_CANISTER_ID.get()]),
                 (index_id, vec![root_id.get()]),
             ],
             vec![
@@ -4965,7 +4967,7 @@ mod test {
                 (governance_id, vec![root_id.get()]),
                 (ledger_id, vec![root_id.get()]),
                 (root_id, vec![governance_id.get()]),
-                (swap_id, vec![ROOT_CANISTER_ID.get()]),
+                (swap_id, vec![root_id.get(), ROOT_CANISTER_ID.get()]),
                 (index_id, vec![root_id.get()]),
             ],
             vec![

--- a/rs/nns/sns-wasm/src/sns_wasm.rs
+++ b/rs/nns/sns-wasm/src/sns_wasm.rs
@@ -1046,17 +1046,21 @@ where
                         e
                     )
                 }),
-
-            // Set NNS-Root as controller of Swap
+            // Set SNS Root and NNS Root as controllers of Swap.
             canister_api
                 .set_controllers(
                     CanisterId::unchecked_from_principal(canisters.swap.unwrap()),
-                    vec![this_canister_id, ROOT_CANISTER_ID.get()],
+                    vec![
+                        this_canister_id,
+                        canisters.root.unwrap(),
+                        ROOT_CANISTER_ID.get(),
+                    ],
                 )
                 .await
                 .map_err(|e| {
                     format!(
-                        "Unable to set NNS-Root and Swap canister (itself) as Swap canister controller: {}",
+                        "Unable to set SNS Root and NNS Root and Swap canister (itself) \
+                         as Swap canister controller: {}",
                         e
                     )
                 }),
@@ -3526,7 +3530,10 @@ mod test {
                 (ledger_id, vec![this_id.get(), root_id.get()]),
                 (index_id, vec![this_id.get(), root_id.get()]),
                 (root_id, vec![this_id.get(), governance_id.get()]),
-                (swap_id, vec![this_id.get(), ROOT_CANISTER_ID.get()]),
+                (
+                    swap_id,
+                    vec![this_id.get(), root_id.get(), ROOT_CANISTER_ID.get()],
+                ),
             ],
             vec![],
             vec![],
@@ -3606,7 +3613,10 @@ mod test {
                 (ledger_id, vec![this_id.get(), root_id.get()]),
                 (index_id, vec![this_id.get(), root_id.get()]),
                 (root_id, vec![this_id.get(), governance_id.get()]),
-                (swap_id, vec![this_id.get(), ROOT_CANISTER_ID.get()]),
+                (
+                    swap_id,
+                    vec![this_id.get(), root_id.get(), ROOT_CANISTER_ID.get()],
+                ),
             ],
             vec![
                 (dapp_id, vec![ROOT_CANISTER_ID.get()]),
@@ -3700,7 +3710,10 @@ mod test {
                 (ledger_id, vec![this_id.get(), root_id.get()]),
                 (index_id, vec![this_id.get(), root_id.get()]),
                 (root_id, vec![this_id.get(), governance_id.get()]),
-                (swap_id, vec![this_id.get(), ROOT_CANISTER_ID.get()]),
+                (
+                    swap_id,
+                    vec![this_id.get(), root_id.get(), ROOT_CANISTER_ID.get()],
+                ),
                 (governance_id, vec![root_id.get()]),
                 (ledger_id, vec![root_id.get()]),
                 (root_id, vec![governance_id.get()]),
@@ -3811,7 +3824,10 @@ mod test {
                 (ledger_id, vec![this_id.get(), root_id.get()]),
                 (index_id, vec![this_id.get(), root_id.get()]),
                 (root_id, vec![this_id.get(), governance_id.get()]),
-                (swap_id, vec![this_id.get(), ROOT_CANISTER_ID.get()]),
+                (
+                    swap_id,
+                    vec![this_id.get(), root_id.get(), ROOT_CANISTER_ID.get()],
+                ),
                 (governance_id, vec![root_id.get()]),
                 (ledger_id, vec![root_id.get()]),
                 (root_id, vec![governance_id.get()]),
@@ -3977,7 +3993,10 @@ mod test {
                 (ledger_id, vec![this_id.get(), root_id.get()]),
                 (index_id, vec![this_id.get(), root_id.get()]),
                 (root_id, vec![this_id.get(), governance_id.get()]),
-                (swap_id, vec![this_id.get(), ROOT_CANISTER_ID.get()]),
+                (
+                    swap_id,
+                    vec![this_id.get(), root_id.get(), ROOT_CANISTER_ID.get()],
+                ),
                 (governance_id, vec![root_id.get()]),
                 (ledger_id, vec![root_id.get()]),
                 (root_id, vec![governance_id.get()]),
@@ -4558,7 +4577,10 @@ mod test {
                 (ledger_id, vec![this_id.get(), root_id.get()]),
                 (index_id, vec![this_id.get(), root_id.get()]),
                 (root_id, vec![this_id.get(), governance_id.get()]),
-                (swap_id, vec![this_id.get(), ROOT_CANISTER_ID.get()]),
+                (
+                    swap_id,
+                    vec![this_id.get(), root_id.get(), ROOT_CANISTER_ID.get()],
+                ),
                 (governance_id, vec![root_id.get()]),
                 (ledger_id, vec![root_id.get()]),
                 (root_id, vec![governance_id.get()]),
@@ -4939,7 +4961,7 @@ mod test {
                 (ledger_id, vec![this_id.get(), root_id.get()]),
                 (index_id, vec![this_id.get(), root_id.get()]),
                 (root_id, vec![this_id.get(), governance_id.get()]),
-                (swap_id, vec![this_id.get(), ROOT_CANISTER_ID.get()]),
+                (swap_id, vec![this_id.get(), root_id.get(), ROOT_CANISTER_ID.get()]),
                 (governance_id, vec![root_id.get()]),
                 (ledger_id, vec![root_id.get()]),
                 (root_id, vec![governance_id.get()]),

--- a/rs/nns/sns-wasm/tests/deploy_new_sns.rs
+++ b/rs/nns/sns-wasm/tests/deploy_new_sns.rs
@@ -26,6 +26,8 @@ use ic_sns_wasm::{
 };
 use ic_test_utilities::universal_canister::UNIVERSAL_CANISTER_WASM;
 use ic_test_utilities_types::ids::canister_test_id;
+use maplit::btreeset;
+use std::collections::BTreeSet;
 
 pub mod common;
 
@@ -128,9 +130,15 @@ fn test_canisters_are_created_and_installed() {
     let swap_canister_summary = get_sns_canisters_summary_response.swap_canister_summary();
     assert_eq!(swap_canister_summary.canister_id(), swap_canister_id);
     assert_eq!(swap_canister_summary.status().status(), Running);
+    // https://internetcomputer.org/docs/current/references/ic-interface-spec#ic-canister_info:
+    // The order of controllers stored in the canister history may vary depending on the implementation.
     assert_eq!(
-        swap_canister_summary.status().controllers(),
-        vec![ROOT_CANISTER_ID.get()]
+        swap_canister_summary
+            .status()
+            .controllers()
+            .into_iter()
+            .collect::<BTreeSet<_>>(),
+        btreeset! { root_canister_id, ROOT_CANISTER_ID.get() }
     );
     assert_eq!(
         swap_canister_summary.status().module_hash().unwrap(),


### PR DESCRIPTION
This PR implements the first step towards making Swap a proper SNS canister. To that end, SNS-W now adds SNS Root as a controller of a newly created Swap canister, in addition to NNS Root. (In the future, only SNS Root would need to be its controller.)

| [Next PR](https://github.com/dfinity/ic/pull/2300) >