### PR TITLE
fix(IDX): work around spurious rebuilds in rustix

### DIFF
--- a/Cargo.Bazel.Fuzzing.json.lock
+++ b/Cargo.Bazel.Fuzzing.json.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "f87bc097c5f4900250a6243a052dafcacb570cd5c8c8fbaaa38839acf498722b",
+  "checksum": "78f0da06c53d3fea869c6e8cac026c31871cde95bd6f583246b83cdd0b49f696",
   "crates": {
     "abnf 0.12.0": {
       "name": "abnf",
@@ -13536,14 +13536,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "cranelift-bforest 0.112.1": {
+    "cranelift-bforest 0.112.2": {
       "name": "cranelift-bforest",
-      "version": "0.112.1",
+      "version": "0.112.2",
       "package_url": "https://github.com/bytecodealliance/wasmtime",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/cranelift-bforest/0.112.1/download",
-          "sha256": "a6e376bd92bddd03dcfc443b14382611cae5d10012aa0b1628bbf18bb73f12f7"
+          "url": "https://static.crates.io/crates/cranelift-bforest/0.112.2/download",
+          "sha256": "7b765ed4349e66bedd9b88c7691da42e24c7f62067a6be17ddffa949367b6e17"
         }
       },
       "targets": [
@@ -13568,14 +13568,14 @@
         "deps": {
           "common": [
             {
-              "id": "cranelift-entity 0.112.1",
+              "id": "cranelift-entity 0.112.2",
               "target": "cranelift_entity"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.112.1"
+        "version": "0.112.2"
       },
       "license": "Apache-2.0 WITH LLVM-exception",
       "license_ids": [
@@ -13583,14 +13583,14 @@
       ],
       "license_file": "LICENSE"
     },
-    "cranelift-bitset 0.112.1": {
+    "cranelift-bitset 0.112.2": {
       "name": "cranelift-bitset",
-      "version": "0.112.1",
+      "version": "0.112.2",
       "package_url": "https://github.com/bytecodealliance/wasmtime",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/cranelift-bitset/0.112.1/download",
-          "sha256": "45ecbe07f25a8100e5077933516200e97808f1d7196b5a073edb85fa08fde32e"
+          "url": "https://static.crates.io/crates/cranelift-bitset/0.112.2/download",
+          "sha256": "9eaa2aece6237198afd32bff57699e08d4dccb8d3902c214fc1e6ba907247ca4"
         }
       },
       "targets": [
@@ -13637,7 +13637,7 @@
           ],
           "selects": {}
         },
-        "version": "0.112.1"
+        "version": "0.112.2"
       },
       "license": "Apache-2.0 WITH LLVM-exception",
       "license_ids": [
@@ -13645,14 +13645,14 @@
       ],
       "license_file": null
     },
-    "cranelift-codegen 0.112.1": {
+    "cranelift-codegen 0.112.2": {
       "name": "cranelift-codegen",
-      "version": "0.112.1",
+      "version": "0.112.2",
       "package_url": "https://github.com/bytecodealliance/wasmtime",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/cranelift-codegen/0.112.1/download",
-          "sha256": "bc60913f32c1de18538c28bef74b8c87cf16de7841a1b0956fcf01b23237853a"
+          "url": "https://static.crates.io/crates/cranelift-codegen/0.112.2/download",
+          "sha256": "351824439e59d42f0e4fa5aac1d13deded155120043565769e55cd4ad3ca8ed9"
         }
       },
       "targets": [
@@ -13702,27 +13702,27 @@
               "target": "bumpalo"
             },
             {
-              "id": "cranelift-bforest 0.112.1",
+              "id": "cranelift-bforest 0.112.2",
               "target": "cranelift_bforest"
             },
             {
-              "id": "cranelift-bitset 0.112.1",
+              "id": "cranelift-bitset 0.112.2",
               "target": "cranelift_bitset"
             },
             {
-              "id": "cranelift-codegen 0.112.1",
+              "id": "cranelift-codegen 0.112.2",
               "target": "build_script_build"
             },
             {
-              "id": "cranelift-codegen-shared 0.112.1",
+              "id": "cranelift-codegen-shared 0.112.2",
               "target": "cranelift_codegen_shared"
             },
             {
-              "id": "cranelift-control 0.112.1",
+              "id": "cranelift-control 0.112.2",
               "target": "cranelift_control"
             },
             {
-              "id": "cranelift-entity 0.112.1",
+              "id": "cranelift-entity 0.112.2",
               "target": "cranelift_entity"
             },
             {
@@ -13757,7 +13757,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.112.1"
+        "version": "0.112.2"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -13766,11 +13766,11 @@
         "deps": {
           "common": [
             {
-              "id": "cranelift-codegen-meta 0.112.1",
+              "id": "cranelift-codegen-meta 0.112.2",
               "target": "cranelift_codegen_meta"
             },
             {
-              "id": "cranelift-isle 0.112.1",
+              "id": "cranelift-isle 0.112.2",
               "target": "cranelift_isle"
             }
           ],
@@ -13783,14 +13783,14 @@
       ],
       "license_file": "LICENSE"
     },
-    "cranelift-codegen-meta 0.112.1": {
+    "cranelift-codegen-meta 0.112.2": {
       "name": "cranelift-codegen-meta",
-      "version": "0.112.1",
+      "version": "0.112.2",
       "package_url": "https://github.com/bytecodealliance/wasmtime",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/cranelift-codegen-meta/0.112.1/download",
-          "sha256": "bae009e7822f47aa55e7dcef846ccf3aa4eb102ca6b4bcb8a44b36f3f49aa85c"
+          "url": "https://static.crates.io/crates/cranelift-codegen-meta/0.112.2/download",
+          "sha256": "5a0ce0273d7a493ef8f31f606849a4e931c19187a4923f5f87fc1f2b13109981"
         }
       },
       "targets": [
@@ -13815,14 +13815,14 @@
         "deps": {
           "common": [
             {
-              "id": "cranelift-codegen-shared 0.112.1",
+              "id": "cranelift-codegen-shared 0.112.2",
               "target": "cranelift_codegen_shared"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.112.1"
+        "version": "0.112.2"
       },
       "license": "Apache-2.0 WITH LLVM-exception",
       "license_ids": [
@@ -13830,14 +13830,14 @@
       ],
       "license_file": "LICENSE"
     },
-    "cranelift-codegen-shared 0.112.1": {
+    "cranelift-codegen-shared 0.112.2": {
       "name": "cranelift-codegen-shared",
-      "version": "0.112.1",
+      "version": "0.112.2",
       "package_url": "https://github.com/bytecodealliance/wasmtime",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/cranelift-codegen-shared/0.112.1/download",
-          "sha256": "0c78f01a852536c68e34444450f845ed6e0782a1f047f85397fe460b8fbce8f1"
+          "url": "https://static.crates.io/crates/cranelift-codegen-shared/0.112.2/download",
+          "sha256": "0f72016ac35579051913f4f07f6b36c509ed69412d852fd44c8e1d7b7fa6d92a"
         }
       },
       "targets": [
@@ -13860,7 +13860,7 @@
           "**"
         ],
         "edition": "2021",
-        "version": "0.112.1"
+        "version": "0.112.2"
       },
       "license": "Apache-2.0 WITH LLVM-exception",
       "license_ids": [
@@ -13868,14 +13868,14 @@
       ],
       "license_file": "LICENSE"
     },
-    "cranelift-control 0.112.1": {
+    "cranelift-control 0.112.2": {
       "name": "cranelift-control",
-      "version": "0.112.1",
+      "version": "0.112.2",
       "package_url": "https://github.com/bytecodealliance/wasmtime",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/cranelift-control/0.112.1/download",
-          "sha256": "7a061b22e00a9e36b31f2660dfb05a9617b7775bd54b79754d3bb75a990dac06"
+          "url": "https://static.crates.io/crates/cranelift-control/0.112.2/download",
+          "sha256": "db28951d21512c4fd0554ef179bfb11e4eb6815062957a9173824eee5de0c46c"
         }
       },
       "targets": [
@@ -13914,7 +13914,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.112.1"
+        "version": "0.112.2"
       },
       "license": "Apache-2.0 WITH LLVM-exception",
       "license_ids": [
@@ -13922,14 +13922,14 @@
       ],
       "license_file": "LICENSE"
     },
-    "cranelift-entity 0.112.1": {
+    "cranelift-entity 0.112.2": {
       "name": "cranelift-entity",
-      "version": "0.112.1",
+      "version": "0.112.2",
       "package_url": "https://github.com/bytecodealliance/wasmtime",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/cranelift-entity/0.112.1/download",
-          "sha256": "95e2b261a3e74ae42f4e606906d5ffa44ee2684e8b1ae23bdf75d21908dc9233"
+          "url": "https://static.crates.io/crates/cranelift-entity/0.112.2/download",
+          "sha256": "14ebe592a2f81af9237cf9be29dd3854ecb72108cfffa59e85ef12389bf939e3"
         }
       },
       "targets": [
@@ -13962,7 +13962,7 @@
         "deps": {
           "common": [
             {
-              "id": "cranelift-bitset 0.112.1",
+              "id": "cranelift-bitset 0.112.2",
               "target": "cranelift_bitset"
             },
             {
@@ -13982,7 +13982,7 @@
           ],
           "selects": {}
         },
-        "version": "0.112.1"
+        "version": "0.112.2"
       },
       "license": "Apache-2.0 WITH LLVM-exception",
       "license_ids": [
@@ -13990,14 +13990,14 @@
       ],
       "license_file": "LICENSE"
     },
-    "cranelift-frontend 0.112.1": {
+    "cranelift-frontend 0.112.2": {
       "name": "cranelift-frontend",
-      "version": "0.112.1",
+      "version": "0.112.2",
       "package_url": "https://github.com/bytecodealliance/wasmtime",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/cranelift-frontend/0.112.1/download",
-          "sha256": "fe14abba0e6bab42aca0f9ce757f96880f9187e88bc6cb975ed6acd8a42f7770"
+          "url": "https://static.crates.io/crates/cranelift-frontend/0.112.2/download",
+          "sha256": "4437db9d60c7053ac91ded0802740c2ccf123ee6d6898dd906c34f8c530cd119"
         }
       },
       "targets": [
@@ -14029,7 +14029,7 @@
         "deps": {
           "common": [
             {
-              "id": "cranelift-codegen 0.112.1",
+              "id": "cranelift-codegen 0.112.2",
               "target": "cranelift_codegen"
             },
             {
@@ -14048,7 +14048,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.112.1"
+        "version": "0.112.2"
       },
       "license": "Apache-2.0 WITH LLVM-exception",
       "license_ids": [
@@ -14056,14 +14056,14 @@
       ],
       "license_file": "LICENSE"
     },
-    "cranelift-isle 0.112.1": {
+    "cranelift-isle 0.112.2": {
       "name": "cranelift-isle",
-      "version": "0.112.1",
+      "version": "0.112.2",
       "package_url": "https://github.com/bytecodealliance/wasmtime/tree/main/cranelift/isle",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/cranelift-isle/0.112.1/download",
-          "sha256": "311d91ae72b37d4262b51217baf8c9e01f1afd5148931468da1fdb7e9d011347"
+          "url": "https://static.crates.io/crates/cranelift-isle/0.112.2/download",
+          "sha256": "230cb33572b9926e210f2ca28145f2bc87f389e1456560932168e2591feb65c1"
         }
       },
       "targets": [
@@ -14106,14 +14106,14 @@
         "deps": {
           "common": [
             {
-              "id": "cranelift-isle 0.112.1",
+              "id": "cranelift-isle 0.112.2",
               "target": "build_script_build"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.112.1"
+        "version": "0.112.2"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -14126,14 +14126,14 @@
       ],
       "license_file": null
     },
-    "cranelift-native 0.112.1": {
+    "cranelift-native 0.112.2": {
       "name": "cranelift-native",
-      "version": "0.112.1",
+      "version": "0.112.2",
       "package_url": "https://github.com/bytecodealliance/wasmtime",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/cranelift-native/0.112.1/download",
-          "sha256": "2a3f84c75e578189ff7a716c24ad83740b553bf583f2510b323bfe4c1a74bb93"
+          "url": "https://static.crates.io/crates/cranelift-native/0.112.2/download",
+          "sha256": "364524ac7aef7070b1141478724abebeec297d4ea1e87ad8b8986465e91146d9"
         }
       },
       "targets": [
@@ -14165,7 +14165,7 @@
         "deps": {
           "common": [
             {
-              "id": "cranelift-codegen 0.112.1",
+              "id": "cranelift-codegen 0.112.2",
               "target": "cranelift_codegen"
             },
             {
@@ -14183,7 +14183,7 @@
           }
         },
         "edition": "2021",
-        "version": "0.112.1"
+        "version": "0.112.2"
       },
       "license": "Apache-2.0 WITH LLVM-exception",
       "license_ids": [
@@ -14191,14 +14191,14 @@
       ],
       "license_file": "LICENSE"
     },
-    "cranelift-wasm 0.112.1": {
+    "cranelift-wasm 0.112.2": {
       "name": "cranelift-wasm",
-      "version": "0.112.1",
+      "version": "0.112.2",
       "package_url": "https://github.com/bytecodealliance/wasmtime",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/cranelift-wasm/0.112.1/download",
-          "sha256": "f56b7b2476c47b2091eee5a20bc54a80fbb29ca5313ae2bd0dea52621abcfca1"
+          "url": "https://static.crates.io/crates/cranelift-wasm/0.112.2/download",
+          "sha256": "0572cbd9d136a62c0f39837b6bce3b0978b96b8586794042bec0c214668fd6f5"
         }
       },
       "targets": [
@@ -14230,15 +14230,15 @@
         "deps": {
           "common": [
             {
-              "id": "cranelift-codegen 0.112.1",
+              "id": "cranelift-codegen 0.112.2",
               "target": "cranelift_codegen"
             },
             {
-              "id": "cranelift-entity 0.112.1",
+              "id": "cranelift-entity 0.112.2",
               "target": "cranelift_entity"
             },
             {
-              "id": "cranelift-frontend 0.112.1",
+              "id": "cranelift-frontend 0.112.2",
               "target": "cranelift_frontend"
             },
             {
@@ -14258,14 +14258,14 @@
               "target": "wasmparser"
             },
             {
-              "id": "wasmtime-types 25.0.1",
+              "id": "wasmtime-types 25.0.2",
               "target": "wasmtime_types"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.112.1"
+        "version": "0.112.2"
       },
       "license": "Apache-2.0 WITH LLVM-exception",
       "license_ids": [
@@ -18599,11 +18599,11 @@
               "target": "wasmprinter"
             },
             {
-              "id": "wasmtime 25.0.1",
+              "id": "wasmtime 25.0.2",
               "target": "wasmtime"
             },
             {
-              "id": "wasmtime-environ 25.0.1",
+              "id": "wasmtime-environ 25.0.2",
               "target": "wasmtime_environ"
             },
             {
@@ -54851,7 +54851,13 @@
       "repository": {
         "Http": {
           "url": "https://static.crates.io/crates/rustix/0.38.32/download",
-          "sha256": "65e04861e65f21776e67888bfbea442b3642beaa0138fdb1dd7a84a52dffdb89"
+          "sha256": "65e04861e65f21776e67888bfbea442b3642beaa0138fdb1dd7a84a52dffdb89",
+          "patch_args": [
+            "-p1"
+          ],
+          "patches": [
+            "@rustix-patch//file:downloaded"
+          ]
         }
       },
       "targets": [
@@ -71582,14 +71588,14 @@
       ],
       "license_file": null
     },
-    "wasmtime 25.0.1": {
+    "wasmtime 25.0.2": {
       "name": "wasmtime",
-      "version": "25.0.1",
+      "version": "25.0.2",
       "package_url": "https://github.com/bytecodealliance/wasmtime",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/wasmtime/25.0.1/download",
-          "sha256": "03601559991d459a228236a49135364eac85ac00dc07b65fb95ae61a957793af"
+          "url": "https://static.crates.io/crates/wasmtime/25.0.2/download",
+          "sha256": "ef01f9cb9636ed42a7ec5a09d785c0643590199dc7372dc22c7e2ba7a31a97d4"
         }
       },
       "targets": [
@@ -71708,27 +71714,27 @@
               "target": "wasmparser"
             },
             {
-              "id": "wasmtime 25.0.1",
+              "id": "wasmtime 25.0.2",
               "target": "build_script_build"
             },
             {
-              "id": "wasmtime-asm-macros 25.0.1",
+              "id": "wasmtime-asm-macros 25.0.2",
               "target": "wasmtime_asm_macros"
             },
             {
-              "id": "wasmtime-cranelift 25.0.1",
+              "id": "wasmtime-cranelift 25.0.2",
               "target": "wasmtime_cranelift"
             },
             {
-              "id": "wasmtime-environ 25.0.1",
+              "id": "wasmtime-environ 25.0.2",
               "target": "wasmtime_environ"
             },
             {
-              "id": "wasmtime-jit-icache-coherence 25.0.1",
+              "id": "wasmtime-jit-icache-coherence 25.0.2",
               "target": "wasmtime_jit_icache_coherence"
             },
             {
-              "id": "wasmtime-slab 25.0.1",
+              "id": "wasmtime-slab 25.0.2",
               "target": "wasmtime_slab"
             }
           ],
@@ -71777,7 +71783,7 @@
               "target": "serde_derive"
             },
             {
-              "id": "wasmtime-versioned-export-macros 25.0.1",
+              "id": "wasmtime-versioned-export-macros 25.0.2",
               "target": "wasmtime_versioned_export_macros"
             }
           ],
@@ -71805,7 +71811,7 @@
           ],
           "selects": {}
         },
-        "version": "25.0.1"
+        "version": "25.0.2"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -71823,7 +71829,7 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "wasmtime-versioned-export-macros 25.0.1",
+              "id": "wasmtime-versioned-export-macros 25.0.2",
               "target": "wasmtime_versioned_export_macros"
             }
           ],
@@ -71836,14 +71842,14 @@
       ],
       "license_file": "LICENSE"
     },
-    "wasmtime-asm-macros 25.0.1": {
+    "wasmtime-asm-macros 25.0.2": {
       "name": "wasmtime-asm-macros",
-      "version": "25.0.1",
+      "version": "25.0.2",
       "package_url": "https://github.com/bytecodealliance/wasmtime",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/wasmtime-asm-macros/25.0.1/download",
-          "sha256": "e453b3bde07312874c0c6703e2de9281daab46646172c1b71fa59a97226f858e"
+          "url": "https://static.crates.io/crates/wasmtime-asm-macros/25.0.2/download",
+          "sha256": "ba5b20797419d6baf2296db2354f864e8bb3447cacca9d151ce7700ae08b4460"
         }
       },
       "targets": [
@@ -71875,7 +71881,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "25.0.1"
+        "version": "25.0.2"
       },
       "license": "Apache-2.0 WITH LLVM-exception",
       "license_ids": [
@@ -71883,14 +71889,14 @@
       ],
       "license_file": null
     },
-    "wasmtime-component-macro 25.0.1": {
+    "wasmtime-component-macro 25.0.2": {
       "name": "wasmtime-component-macro",
-      "version": "25.0.1",
+      "version": "25.0.2",
       "package_url": "https://github.com/bytecodealliance/wasmtime",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/wasmtime-component-macro/25.0.1/download",
-          "sha256": "4a6faeabbdbfd27e24e8d5204207ba9c247a13cf84181ea721b5f209f281fe01"
+          "url": "https://static.crates.io/crates/wasmtime-component-macro/25.0.2/download",
+          "sha256": "26593c4b18c76ca3c3fbdd813d6692256537b639b851d8a6fe827e3d6966fc01"
         }
       },
       "targets": [
@@ -71943,15 +71949,15 @@
               "target": "syn"
             },
             {
-              "id": "wasmtime-component-macro 25.0.1",
+              "id": "wasmtime-component-macro 25.0.2",
               "target": "build_script_build"
             },
             {
-              "id": "wasmtime-component-util 25.0.1",
+              "id": "wasmtime-component-util 25.0.2",
               "target": "wasmtime_component_util"
             },
             {
-              "id": "wasmtime-wit-bindgen 25.0.1",
+              "id": "wasmtime-wit-bindgen 25.0.2",
               "target": "wasmtime_wit_bindgen"
             },
             {
@@ -71962,7 +71968,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "25.0.1"
+        "version": "25.0.2"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -71975,14 +71981,14 @@
       ],
       "license_file": null
     },
-    "wasmtime-component-util 25.0.1": {
+    "wasmtime-component-util 25.0.2": {
       "name": "wasmtime-component-util",
-      "version": "25.0.1",
+      "version": "25.0.2",
       "package_url": "https://github.com/bytecodealliance/wasmtime",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/wasmtime-component-util/25.0.1/download",
-          "sha256": "6b1b24db4aa3dc7c0d3181d1833b4fe9ec0cd3f08780b746415c84c0a9ec9011"
+          "url": "https://static.crates.io/crates/wasmtime-component-util/25.0.2/download",
+          "sha256": "a2ed562fbb0cbed20a56c369c8de146c1de06a48c19e26ed9aa45f073514ee60"
         }
       },
       "targets": [
@@ -72005,7 +72011,7 @@
           "**"
         ],
         "edition": "2021",
-        "version": "25.0.1"
+        "version": "25.0.2"
       },
       "license": "Apache-2.0 WITH LLVM-exception",
       "license_ids": [
@@ -72013,14 +72019,14 @@
       ],
       "license_file": null
     },
-    "wasmtime-cranelift 25.0.1": {
+    "wasmtime-cranelift 25.0.2": {
       "name": "wasmtime-cranelift",
-      "version": "25.0.1",
+      "version": "25.0.2",
       "package_url": "https://github.com/bytecodealliance/wasmtime",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/wasmtime-cranelift/25.0.1/download",
-          "sha256": "c737bef9ea94aab874e29ac6a8688b89ceb43c7b51f047079c43387972c07ee3"
+          "url": "https://static.crates.io/crates/wasmtime-cranelift/25.0.2/download",
+          "sha256": "f389b789cbcb53a8499131182135dea21d7d97ad77e7fb66830f69479ef0e68c"
         }
       },
       "targets": [
@@ -72059,27 +72065,27 @@
               "target": "cfg_if"
             },
             {
-              "id": "cranelift-codegen 0.112.1",
+              "id": "cranelift-codegen 0.112.2",
               "target": "cranelift_codegen"
             },
             {
-              "id": "cranelift-control 0.112.1",
+              "id": "cranelift-control 0.112.2",
               "target": "cranelift_control"
             },
             {
-              "id": "cranelift-entity 0.112.1",
+              "id": "cranelift-entity 0.112.2",
               "target": "cranelift_entity"
             },
             {
-              "id": "cranelift-frontend 0.112.1",
+              "id": "cranelift-frontend 0.112.2",
               "target": "cranelift_frontend"
             },
             {
-              "id": "cranelift-native 0.112.1",
+              "id": "cranelift-native 0.112.2",
               "target": "cranelift_native"
             },
             {
-              "id": "cranelift-wasm 0.112.1",
+              "id": "cranelift-wasm 0.112.2",
               "target": "cranelift_wasm"
             },
             {
@@ -72111,7 +72117,7 @@
               "target": "wasmparser"
             },
             {
-              "id": "wasmtime-environ 25.0.1",
+              "id": "wasmtime-environ 25.0.2",
               "target": "wasmtime_environ"
             }
           ],
@@ -72121,13 +72127,13 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "wasmtime-versioned-export-macros 25.0.1",
+              "id": "wasmtime-versioned-export-macros 25.0.2",
               "target": "wasmtime_versioned_export_macros"
             }
           ],
           "selects": {}
         },
-        "version": "25.0.1"
+        "version": "25.0.2"
       },
       "license": "Apache-2.0 WITH LLVM-exception",
       "license_ids": [
@@ -72135,14 +72141,14 @@
       ],
       "license_file": "LICENSE"
     },
-    "wasmtime-environ 25.0.1": {
+    "wasmtime-environ 25.0.2": {
       "name": "wasmtime-environ",
-      "version": "25.0.1",
+      "version": "25.0.2",
       "package_url": "https://github.com/bytecodealliance/wasmtime",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/wasmtime-environ/25.0.1/download",
-          "sha256": "817bfa9ea878ec37aa24f85fd6912844e8d87d321662824cf920d561b698cdfd"
+          "url": "https://static.crates.io/crates/wasmtime-environ/25.0.2/download",
+          "sha256": "84b72debe8899f19bedf66f7071310f06ef62de943a1369ba9b373613e77dd3d"
         }
       },
       "targets": [
@@ -72179,11 +72185,11 @@
               "target": "anyhow"
             },
             {
-              "id": "cranelift-bitset 0.112.1",
+              "id": "cranelift-bitset 0.112.2",
               "target": "cranelift_bitset"
             },
             {
-              "id": "cranelift-entity 0.112.1",
+              "id": "cranelift-entity 0.112.2",
               "target": "cranelift_entity"
             },
             {
@@ -72227,7 +72233,7 @@
               "target": "wasmprinter"
             },
             {
-              "id": "wasmtime-types 25.0.1",
+              "id": "wasmtime-types 25.0.2",
               "target": "wasmtime_types"
             }
           ],
@@ -72243,7 +72249,7 @@
           ],
           "selects": {}
         },
-        "version": "25.0.1"
+        "version": "25.0.2"
       },
       "license": "Apache-2.0 WITH LLVM-exception",
       "license_ids": [
@@ -72251,14 +72257,14 @@
       ],
       "license_file": "LICENSE"
     },
-    "wasmtime-jit-icache-coherence 25.0.1": {
+    "wasmtime-jit-icache-coherence 25.0.2": {
       "name": "wasmtime-jit-icache-coherence",
-      "version": "25.0.1",
+      "version": "25.0.2",
       "package_url": "https://github.com/bytecodealliance/wasmtime",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/wasmtime-jit-icache-coherence/25.0.1/download",
-          "sha256": "48011232c0da424f89c3752a378d0b7f512fae321ea414a43e1e7a302a6a1f7e"
+          "url": "https://static.crates.io/crates/wasmtime-jit-icache-coherence/25.0.2/download",
+          "sha256": "1d930bc1325bc0448be6a11754156d770f56f6c3a61f440e9567f36cd2ea3065"
         }
       },
       "targets": [
@@ -72307,7 +72313,7 @@
           }
         },
         "edition": "2021",
-        "version": "25.0.1"
+        "version": "25.0.2"
       },
       "license": "Apache-2.0 WITH LLVM-exception",
       "license_ids": [
@@ -72315,14 +72321,14 @@
       ],
       "license_file": null
     },
-    "wasmtime-slab 25.0.1": {
+    "wasmtime-slab 25.0.2": {
       "name": "wasmtime-slab",
-      "version": "25.0.1",
+      "version": "25.0.2",
       "package_url": "https://github.com/bytecodealliance/wasmtime",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/wasmtime-slab/25.0.1/download",
-          "sha256": "d9858a22e656ae8574631221b474b8bebf63f1367fcac3f179873833eabc2ced"
+          "url": "https://static.crates.io/crates/wasmtime-slab/25.0.2/download",
+          "sha256": "055a181b8d03998511294faea14798df436503f14d7fd20edcf7370ec583e80a"
         }
       },
       "targets": [
@@ -72345,7 +72351,7 @@
           "**"
         ],
         "edition": "2021",
-        "version": "25.0.1"
+        "version": "25.0.2"
       },
       "license": "Apache-2.0 WITH LLVM-exception",
       "license_ids": [
@@ -72353,14 +72359,14 @@
       ],
       "license_file": null
     },
-    "wasmtime-types 25.0.1": {
+    "wasmtime-types 25.0.2": {
       "name": "wasmtime-types",
-      "version": "25.0.1",
+      "version": "25.0.2",
       "package_url": "https://github.com/bytecodealliance/wasmtime",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/wasmtime-types/25.0.1/download",
-          "sha256": "4d14b8a9206fe94485a03edb1654cd530dbd2a859a85a43502cb4e99653a568c"
+          "url": "https://static.crates.io/crates/wasmtime-types/25.0.2/download",
+          "sha256": "c8340d976673ac3fdacac781f2afdc4933920c1adc738c3409e825dab3955399"
         }
       },
       "targets": [
@@ -72395,7 +72401,7 @@
               "target": "anyhow"
             },
             {
-              "id": "cranelift-entity 0.112.1",
+              "id": "cranelift-entity 0.112.2",
               "target": "cranelift_entity"
             },
             {
@@ -72423,7 +72429,7 @@
           ],
           "selects": {}
         },
-        "version": "25.0.1"
+        "version": "25.0.2"
       },
       "license": "Apache-2.0 WITH LLVM-exception",
       "license_ids": [
@@ -72431,14 +72437,14 @@
       ],
       "license_file": "LICENSE"
     },
-    "wasmtime-versioned-export-macros 25.0.1": {
+    "wasmtime-versioned-export-macros 25.0.2": {
       "name": "wasmtime-versioned-export-macros",
-      "version": "25.0.1",
+      "version": "25.0.2",
       "package_url": "https://github.com/bytecodealliance/wasmtime",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/wasmtime-versioned-export-macros/25.0.1/download",
-          "sha256": "e9bb1f01efb8b542eadfda511e8ea1cc54309451aba97b69969e5b1a59cb7ded"
+          "url": "https://static.crates.io/crates/wasmtime-versioned-export-macros/25.0.2/download",
+          "sha256": "a4b0c1f76891f778db9602ee3fbb4eb7e9a3f511847d1fb1b69eddbcea28303c"
         }
       },
       "targets": [
@@ -72478,7 +72484,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "25.0.1"
+        "version": "25.0.2"
       },
       "license": "Apache-2.0 WITH LLVM-exception",
       "license_ids": [
@@ -72486,14 +72492,14 @@
       ],
       "license_file": null
     },
-    "wasmtime-wit-bindgen 25.0.1": {
+    "wasmtime-wit-bindgen 25.0.2": {
       "name": "wasmtime-wit-bindgen",
-      "version": "25.0.1",
+      "version": "25.0.2",
       "package_url": "https://github.com/bytecodealliance/wasmtime",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/wasmtime-wit-bindgen/25.0.1/download",
-          "sha256": "eb1596caa67b31ac675fd3da61685c4260f8b10832021db42c85d227b7ba8133"
+          "url": "https://static.crates.io/crates/wasmtime-wit-bindgen/25.0.2/download",
+          "sha256": "b2fca2cbb5bb390f65d4434c19bf8d9873dfc60f10802918ebcd6f819a38d703"
         }
       },
       "targets": [
@@ -72537,7 +72543,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "25.0.1"
+        "version": "25.0.2"
       },
       "license": "Apache-2.0 WITH LLVM-exception",
       "license_ids": [
@@ -78738,8 +78744,8 @@
     "wasm-smith 0.212.0",
     "wasmparser 0.217.0",
     "wasmprinter 0.217.0",
-    "wasmtime 25.0.1",
-    "wasmtime-environ 25.0.1",
+    "wasmtime 25.0.2",
+    "wasmtime-environ 25.0.2",
     "wast 212.0.0",
     "wat 1.212.0",
     "wee_alloc 0.4.5",

--- a/Cargo.Bazel.Fuzzing.toml.lock
+++ b/Cargo.Bazel.Fuzzing.toml.lock
@@ -2330,18 +2330,18 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.112.1"
+version = "0.112.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6e376bd92bddd03dcfc443b14382611cae5d10012aa0b1628bbf18bb73f12f7"
+checksum = "7b765ed4349e66bedd9b88c7691da42e24c7f62067a6be17ddffa949367b6e17"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-bitset"
-version = "0.112.1"
+version = "0.112.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45ecbe07f25a8100e5077933516200e97808f1d7196b5a073edb85fa08fde32e"
+checksum = "9eaa2aece6237198afd32bff57699e08d4dccb8d3902c214fc1e6ba907247ca4"
 dependencies = [
  "serde",
  "serde_derive",
@@ -2349,9 +2349,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.112.1"
+version = "0.112.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc60913f32c1de18538c28bef74b8c87cf16de7841a1b0956fcf01b23237853a"
+checksum = "351824439e59d42f0e4fa5aac1d13deded155120043565769e55cd4ad3ca8ed9"
 dependencies = [
  "bumpalo",
  "cranelift-bforest",
@@ -2372,33 +2372,33 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.112.1"
+version = "0.112.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bae009e7822f47aa55e7dcef846ccf3aa4eb102ca6b4bcb8a44b36f3f49aa85c"
+checksum = "5a0ce0273d7a493ef8f31f606849a4e931c19187a4923f5f87fc1f2b13109981"
 dependencies = [
  "cranelift-codegen-shared",
 ]
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.112.1"
+version = "0.112.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c78f01a852536c68e34444450f845ed6e0782a1f047f85397fe460b8fbce8f1"
+checksum = "0f72016ac35579051913f4f07f6b36c509ed69412d852fd44c8e1d7b7fa6d92a"
 
 [[package]]
 name = "cranelift-control"
-version = "0.112.1"
+version = "0.112.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a061b22e00a9e36b31f2660dfb05a9617b7775bd54b79754d3bb75a990dac06"
+checksum = "db28951d21512c4fd0554ef179bfb11e4eb6815062957a9173824eee5de0c46c"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.112.1"
+version = "0.112.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95e2b261a3e74ae42f4e606906d5ffa44ee2684e8b1ae23bdf75d21908dc9233"
+checksum = "14ebe592a2f81af9237cf9be29dd3854ecb72108cfffa59e85ef12389bf939e3"
 dependencies = [
  "cranelift-bitset",
  "serde",
@@ -2407,9 +2407,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.112.1"
+version = "0.112.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe14abba0e6bab42aca0f9ce757f96880f9187e88bc6cb975ed6acd8a42f7770"
+checksum = "4437db9d60c7053ac91ded0802740c2ccf123ee6d6898dd906c34f8c530cd119"
 dependencies = [
  "cranelift-codegen",
  "log",
@@ -2419,15 +2419,15 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.112.1"
+version = "0.112.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "311d91ae72b37d4262b51217baf8c9e01f1afd5148931468da1fdb7e9d011347"
+checksum = "230cb33572b9926e210f2ca28145f2bc87f389e1456560932168e2591feb65c1"
 
 [[package]]
 name = "cranelift-native"
-version = "0.112.1"
+version = "0.112.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a3f84c75e578189ff7a716c24ad83740b553bf583f2510b323bfe4c1a74bb93"
+checksum = "364524ac7aef7070b1141478724abebeec297d4ea1e87ad8b8986465e91146d9"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -2436,9 +2436,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-wasm"
-version = "0.112.1"
+version = "0.112.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f56b7b2476c47b2091eee5a20bc54a80fbb29ca5313ae2bd0dea52621abcfca1"
+checksum = "0572cbd9d136a62c0f39837b6bce3b0978b96b8586794042bec0c214668fd6f5"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -12117,9 +12117,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime"
-version = "25.0.1"
+version = "25.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03601559991d459a228236a49135364eac85ac00dc07b65fb95ae61a957793af"
+checksum = "ef01f9cb9636ed42a7ec5a09d785c0643590199dc7372dc22c7e2ba7a31a97d4"
 dependencies = [
  "anyhow",
  "bitflags 2.4.1",
@@ -12158,18 +12158,18 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-asm-macros"
-version = "25.0.1"
+version = "25.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e453b3bde07312874c0c6703e2de9281daab46646172c1b71fa59a97226f858e"
+checksum = "ba5b20797419d6baf2296db2354f864e8bb3447cacca9d151ce7700ae08b4460"
 dependencies = [
  "cfg-if 1.0.0",
 ]
 
 [[package]]
 name = "wasmtime-component-macro"
-version = "25.0.1"
+version = "25.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a6faeabbdbfd27e24e8d5204207ba9c247a13cf84181ea721b5f209f281fe01"
+checksum = "26593c4b18c76ca3c3fbdd813d6692256537b639b851d8a6fe827e3d6966fc01"
 dependencies = [
  "anyhow",
  "proc-macro2",
@@ -12182,15 +12182,15 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-component-util"
-version = "25.0.1"
+version = "25.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b1b24db4aa3dc7c0d3181d1833b4fe9ec0cd3f08780b746415c84c0a9ec9011"
+checksum = "a2ed562fbb0cbed20a56c369c8de146c1de06a48c19e26ed9aa45f073514ee60"
 
 [[package]]
 name = "wasmtime-cranelift"
-version = "25.0.1"
+version = "25.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c737bef9ea94aab874e29ac6a8688b89ceb43c7b51f047079c43387972c07ee3"
+checksum = "f389b789cbcb53a8499131182135dea21d7d97ad77e7fb66830f69479ef0e68c"
 dependencies = [
  "anyhow",
  "cfg-if 1.0.0",
@@ -12213,9 +12213,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-environ"
-version = "25.0.1"
+version = "25.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "817bfa9ea878ec37aa24f85fd6912844e8d87d321662824cf920d561b698cdfd"
+checksum = "84b72debe8899f19bedf66f7071310f06ef62de943a1369ba9b373613e77dd3d"
 dependencies = [
  "anyhow",
  "cranelift-bitset",
@@ -12236,9 +12236,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit-icache-coherence"
-version = "25.0.1"
+version = "25.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48011232c0da424f89c3752a378d0b7f512fae321ea414a43e1e7a302a6a1f7e"
+checksum = "1d930bc1325bc0448be6a11754156d770f56f6c3a61f440e9567f36cd2ea3065"
 dependencies = [
  "anyhow",
  "cfg-if 1.0.0",
@@ -12248,15 +12248,15 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-slab"
-version = "25.0.1"
+version = "25.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9858a22e656ae8574631221b474b8bebf63f1367fcac3f179873833eabc2ced"
+checksum = "055a181b8d03998511294faea14798df436503f14d7fd20edcf7370ec583e80a"
 
 [[package]]
 name = "wasmtime-types"
-version = "25.0.1"
+version = "25.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d14b8a9206fe94485a03edb1654cd530dbd2a859a85a43502cb4e99653a568c"
+checksum = "c8340d976673ac3fdacac781f2afdc4933920c1adc738c3409e825dab3955399"
 dependencies = [
  "anyhow",
  "cranelift-entity",
@@ -12268,9 +12268,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-versioned-export-macros"
-version = "25.0.1"
+version = "25.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9bb1f01efb8b542eadfda511e8ea1cc54309451aba97b69969e5b1a59cb7ded"
+checksum = "a4b0c1f76891f778db9602ee3fbb4eb7e9a3f511847d1fb1b69eddbcea28303c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12279,9 +12279,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wit-bindgen"
-version = "25.0.1"
+version = "25.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb1596caa67b31ac675fd3da61685c4260f8b10832021db42c85d227b7ba8133"
+checksum = "b2fca2cbb5bb390f65d4434c19bf8d9873dfc60f10802918ebcd6f819a38d703"
 dependencies = [
  "anyhow",
  "heck 0.4.1",

--- a/Cargo.Bazel.json.lock
+++ b/Cargo.Bazel.json.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "1af0a1c776d32823a68c85613fc4dc21dc84e38bda584a3058b479f58c588eaf",
+  "checksum": "064a13c0359982d947a7c1993ad892be8a541f816ab527f4c04db07118bb1530",
   "crates": {
     "abnf 0.12.0": {
       "name": "abnf",
@@ -13359,14 +13359,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "cranelift-bforest 0.112.1": {
+    "cranelift-bforest 0.112.2": {
       "name": "cranelift-bforest",
-      "version": "0.112.1",
+      "version": "0.112.2",
       "package_url": "https://github.com/bytecodealliance/wasmtime",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/cranelift-bforest/0.112.1/download",
-          "sha256": "a6e376bd92bddd03dcfc443b14382611cae5d10012aa0b1628bbf18bb73f12f7"
+          "url": "https://static.crates.io/crates/cranelift-bforest/0.112.2/download",
+          "sha256": "7b765ed4349e66bedd9b88c7691da42e24c7f62067a6be17ddffa949367b6e17"
         }
       },
       "targets": [
@@ -13391,14 +13391,14 @@
         "deps": {
           "common": [
             {
-              "id": "cranelift-entity 0.112.1",
+              "id": "cranelift-entity 0.112.2",
               "target": "cranelift_entity"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.112.1"
+        "version": "0.112.2"
       },
       "license": "Apache-2.0 WITH LLVM-exception",
       "license_ids": [
@@ -13406,14 +13406,14 @@
       ],
       "license_file": "LICENSE"
     },
-    "cranelift-bitset 0.112.1": {
+    "cranelift-bitset 0.112.2": {
       "name": "cranelift-bitset",
-      "version": "0.112.1",
+      "version": "0.112.2",
       "package_url": "https://github.com/bytecodealliance/wasmtime",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/cranelift-bitset/0.112.1/download",
-          "sha256": "45ecbe07f25a8100e5077933516200e97808f1d7196b5a073edb85fa08fde32e"
+          "url": "https://static.crates.io/crates/cranelift-bitset/0.112.2/download",
+          "sha256": "9eaa2aece6237198afd32bff57699e08d4dccb8d3902c214fc1e6ba907247ca4"
         }
       },
       "targets": [
@@ -13460,7 +13460,7 @@
           ],
           "selects": {}
         },
-        "version": "0.112.1"
+        "version": "0.112.2"
       },
       "license": "Apache-2.0 WITH LLVM-exception",
       "license_ids": [
@@ -13468,14 +13468,14 @@
       ],
       "license_file": null
     },
-    "cranelift-codegen 0.112.1": {
+    "cranelift-codegen 0.112.2": {
       "name": "cranelift-codegen",
-      "version": "0.112.1",
+      "version": "0.112.2",
       "package_url": "https://github.com/bytecodealliance/wasmtime",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/cranelift-codegen/0.112.1/download",
-          "sha256": "bc60913f32c1de18538c28bef74b8c87cf16de7841a1b0956fcf01b23237853a"
+          "url": "https://static.crates.io/crates/cranelift-codegen/0.112.2/download",
+          "sha256": "351824439e59d42f0e4fa5aac1d13deded155120043565769e55cd4ad3ca8ed9"
         }
       },
       "targets": [
@@ -13525,27 +13525,27 @@
               "target": "bumpalo"
             },
             {
-              "id": "cranelift-bforest 0.112.1",
+              "id": "cranelift-bforest 0.112.2",
               "target": "cranelift_bforest"
             },
             {
-              "id": "cranelift-bitset 0.112.1",
+              "id": "cranelift-bitset 0.112.2",
               "target": "cranelift_bitset"
             },
             {
-              "id": "cranelift-codegen 0.112.1",
+              "id": "cranelift-codegen 0.112.2",
               "target": "build_script_build"
             },
             {
-              "id": "cranelift-codegen-shared 0.112.1",
+              "id": "cranelift-codegen-shared 0.112.2",
               "target": "cranelift_codegen_shared"
             },
             {
-              "id": "cranelift-control 0.112.1",
+              "id": "cranelift-control 0.112.2",
               "target": "cranelift_control"
             },
             {
-              "id": "cranelift-entity 0.112.1",
+              "id": "cranelift-entity 0.112.2",
               "target": "cranelift_entity"
             },
             {
@@ -13580,7 +13580,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.112.1"
+        "version": "0.112.2"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -13589,11 +13589,11 @@
         "deps": {
           "common": [
             {
-              "id": "cranelift-codegen-meta 0.112.1",
+              "id": "cranelift-codegen-meta 0.112.2",
               "target": "cranelift_codegen_meta"
             },
             {
-              "id": "cranelift-isle 0.112.1",
+              "id": "cranelift-isle 0.112.2",
               "target": "cranelift_isle"
             }
           ],
@@ -13606,14 +13606,14 @@
       ],
       "license_file": "LICENSE"
     },
-    "cranelift-codegen-meta 0.112.1": {
+    "cranelift-codegen-meta 0.112.2": {
       "name": "cranelift-codegen-meta",
-      "version": "0.112.1",
+      "version": "0.112.2",
       "package_url": "https://github.com/bytecodealliance/wasmtime",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/cranelift-codegen-meta/0.112.1/download",
-          "sha256": "bae009e7822f47aa55e7dcef846ccf3aa4eb102ca6b4bcb8a44b36f3f49aa85c"
+          "url": "https://static.crates.io/crates/cranelift-codegen-meta/0.112.2/download",
+          "sha256": "5a0ce0273d7a493ef8f31f606849a4e931c19187a4923f5f87fc1f2b13109981"
         }
       },
       "targets": [
@@ -13638,14 +13638,14 @@
         "deps": {
           "common": [
             {
-              "id": "cranelift-codegen-shared 0.112.1",
+              "id": "cranelift-codegen-shared 0.112.2",
               "target": "cranelift_codegen_shared"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.112.1"
+        "version": "0.112.2"
       },
       "license": "Apache-2.0 WITH LLVM-exception",
       "license_ids": [
@@ -13653,14 +13653,14 @@
       ],
       "license_file": "LICENSE"
     },
-    "cranelift-codegen-shared 0.112.1": {
+    "cranelift-codegen-shared 0.112.2": {
       "name": "cranelift-codegen-shared",
-      "version": "0.112.1",
+      "version": "0.112.2",
       "package_url": "https://github.com/bytecodealliance/wasmtime",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/cranelift-codegen-shared/0.112.1/download",
-          "sha256": "0c78f01a852536c68e34444450f845ed6e0782a1f047f85397fe460b8fbce8f1"
+          "url": "https://static.crates.io/crates/cranelift-codegen-shared/0.112.2/download",
+          "sha256": "0f72016ac35579051913f4f07f6b36c509ed69412d852fd44c8e1d7b7fa6d92a"
         }
       },
       "targets": [
@@ -13683,7 +13683,7 @@
           "**"
         ],
         "edition": "2021",
-        "version": "0.112.1"
+        "version": "0.112.2"
       },
       "license": "Apache-2.0 WITH LLVM-exception",
       "license_ids": [
@@ -13691,14 +13691,14 @@
       ],
       "license_file": "LICENSE"
     },
-    "cranelift-control 0.112.1": {
+    "cranelift-control 0.112.2": {
       "name": "cranelift-control",
-      "version": "0.112.1",
+      "version": "0.112.2",
       "package_url": "https://github.com/bytecodealliance/wasmtime",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/cranelift-control/0.112.1/download",
-          "sha256": "7a061b22e00a9e36b31f2660dfb05a9617b7775bd54b79754d3bb75a990dac06"
+          "url": "https://static.crates.io/crates/cranelift-control/0.112.2/download",
+          "sha256": "db28951d21512c4fd0554ef179bfb11e4eb6815062957a9173824eee5de0c46c"
         }
       },
       "targets": [
@@ -13737,7 +13737,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.112.1"
+        "version": "0.112.2"
       },
       "license": "Apache-2.0 WITH LLVM-exception",
       "license_ids": [
@@ -13745,14 +13745,14 @@
       ],
       "license_file": "LICENSE"
     },
-    "cranelift-entity 0.112.1": {
+    "cranelift-entity 0.112.2": {
       "name": "cranelift-entity",
-      "version": "0.112.1",
+      "version": "0.112.2",
       "package_url": "https://github.com/bytecodealliance/wasmtime",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/cranelift-entity/0.112.1/download",
-          "sha256": "95e2b261a3e74ae42f4e606906d5ffa44ee2684e8b1ae23bdf75d21908dc9233"
+          "url": "https://static.crates.io/crates/cranelift-entity/0.112.2/download",
+          "sha256": "14ebe592a2f81af9237cf9be29dd3854ecb72108cfffa59e85ef12389bf939e3"
         }
       },
       "targets": [
@@ -13785,7 +13785,7 @@
         "deps": {
           "common": [
             {
-              "id": "cranelift-bitset 0.112.1",
+              "id": "cranelift-bitset 0.112.2",
               "target": "cranelift_bitset"
             },
             {
@@ -13805,7 +13805,7 @@
           ],
           "selects": {}
         },
-        "version": "0.112.1"
+        "version": "0.112.2"
       },
       "license": "Apache-2.0 WITH LLVM-exception",
       "license_ids": [
@@ -13813,14 +13813,14 @@
       ],
       "license_file": "LICENSE"
     },
-    "cranelift-frontend 0.112.1": {
+    "cranelift-frontend 0.112.2": {
       "name": "cranelift-frontend",
-      "version": "0.112.1",
+      "version": "0.112.2",
       "package_url": "https://github.com/bytecodealliance/wasmtime",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/cranelift-frontend/0.112.1/download",
-          "sha256": "fe14abba0e6bab42aca0f9ce757f96880f9187e88bc6cb975ed6acd8a42f7770"
+          "url": "https://static.crates.io/crates/cranelift-frontend/0.112.2/download",
+          "sha256": "4437db9d60c7053ac91ded0802740c2ccf123ee6d6898dd906c34f8c530cd119"
         }
       },
       "targets": [
@@ -13852,7 +13852,7 @@
         "deps": {
           "common": [
             {
-              "id": "cranelift-codegen 0.112.1",
+              "id": "cranelift-codegen 0.112.2",
               "target": "cranelift_codegen"
             },
             {
@@ -13871,7 +13871,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.112.1"
+        "version": "0.112.2"
       },
       "license": "Apache-2.0 WITH LLVM-exception",
       "license_ids": [
@@ -13879,14 +13879,14 @@
       ],
       "license_file": "LICENSE"
     },
-    "cranelift-isle 0.112.1": {
+    "cranelift-isle 0.112.2": {
       "name": "cranelift-isle",
-      "version": "0.112.1",
+      "version": "0.112.2",
       "package_url": "https://github.com/bytecodealliance/wasmtime/tree/main/cranelift/isle",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/cranelift-isle/0.112.1/download",
-          "sha256": "311d91ae72b37d4262b51217baf8c9e01f1afd5148931468da1fdb7e9d011347"
+          "url": "https://static.crates.io/crates/cranelift-isle/0.112.2/download",
+          "sha256": "230cb33572b9926e210f2ca28145f2bc87f389e1456560932168e2591feb65c1"
         }
       },
       "targets": [
@@ -13929,14 +13929,14 @@
         "deps": {
           "common": [
             {
-              "id": "cranelift-isle 0.112.1",
+              "id": "cranelift-isle 0.112.2",
               "target": "build_script_build"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.112.1"
+        "version": "0.112.2"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -13949,14 +13949,14 @@
       ],
       "license_file": null
     },
-    "cranelift-native 0.112.1": {
+    "cranelift-native 0.112.2": {
       "name": "cranelift-native",
-      "version": "0.112.1",
+      "version": "0.112.2",
       "package_url": "https://github.com/bytecodealliance/wasmtime",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/cranelift-native/0.112.1/download",
-          "sha256": "2a3f84c75e578189ff7a716c24ad83740b553bf583f2510b323bfe4c1a74bb93"
+          "url": "https://static.crates.io/crates/cranelift-native/0.112.2/download",
+          "sha256": "364524ac7aef7070b1141478724abebeec297d4ea1e87ad8b8986465e91146d9"
         }
       },
       "targets": [
@@ -13988,7 +13988,7 @@
         "deps": {
           "common": [
             {
-              "id": "cranelift-codegen 0.112.1",
+              "id": "cranelift-codegen 0.112.2",
               "target": "cranelift_codegen"
             },
             {
@@ -14006,7 +14006,7 @@
           }
         },
         "edition": "2021",
-        "version": "0.112.1"
+        "version": "0.112.2"
       },
       "license": "Apache-2.0 WITH LLVM-exception",
       "license_ids": [
@@ -14014,14 +14014,14 @@
       ],
       "license_file": "LICENSE"
     },
-    "cranelift-wasm 0.112.1": {
+    "cranelift-wasm 0.112.2": {
       "name": "cranelift-wasm",
-      "version": "0.112.1",
+      "version": "0.112.2",
       "package_url": "https://github.com/bytecodealliance/wasmtime",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/cranelift-wasm/0.112.1/download",
-          "sha256": "f56b7b2476c47b2091eee5a20bc54a80fbb29ca5313ae2bd0dea52621abcfca1"
+          "url": "https://static.crates.io/crates/cranelift-wasm/0.112.2/download",
+          "sha256": "0572cbd9d136a62c0f39837b6bce3b0978b96b8586794042bec0c214668fd6f5"
         }
       },
       "targets": [
@@ -14053,15 +14053,15 @@
         "deps": {
           "common": [
             {
-              "id": "cranelift-codegen 0.112.1",
+              "id": "cranelift-codegen 0.112.2",
               "target": "cranelift_codegen"
             },
             {
-              "id": "cranelift-entity 0.112.1",
+              "id": "cranelift-entity 0.112.2",
               "target": "cranelift_entity"
             },
             {
-              "id": "cranelift-frontend 0.112.1",
+              "id": "cranelift-frontend 0.112.2",
               "target": "cranelift_frontend"
             },
             {
@@ -14081,14 +14081,14 @@
               "target": "wasmparser"
             },
             {
-              "id": "wasmtime-types 25.0.1",
+              "id": "wasmtime-types 25.0.2",
               "target": "wasmtime_types"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.112.1"
+        "version": "0.112.2"
       },
       "license": "Apache-2.0 WITH LLVM-exception",
       "license_ids": [
@@ -18422,11 +18422,11 @@
               "target": "wasmprinter"
             },
             {
-              "id": "wasmtime 25.0.1",
+              "id": "wasmtime 25.0.2",
               "target": "wasmtime"
             },
             {
-              "id": "wasmtime-environ 25.0.1",
+              "id": "wasmtime-environ 25.0.2",
               "target": "wasmtime_environ"
             },
             {
@@ -32926,99 +32926,6 @@
       ],
       "license_file": "LICENSE-MIT"
     },
-    "io-lifetimes 1.0.11": {
-      "name": "io-lifetimes",
-      "version": "1.0.11",
-      "package_url": "https://github.com/sunfishcode/io-lifetimes",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/io-lifetimes/1.0.11/download",
-          "sha256": "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "io_lifetimes",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": false,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        },
-        {
-          "BuildScript": {
-            "crate_name": "build_script_build",
-            "crate_root": "build.rs",
-            "srcs": {
-              "allow_empty": false,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "io_lifetimes",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "close",
-            "hermit-abi",
-            "libc",
-            "windows-sys"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "io-lifetimes 1.0.11",
-              "target": "build_script_build"
-            }
-          ],
-          "selects": {
-            "cfg(not(windows))": [
-              {
-                "id": "libc 0.2.158",
-                "target": "libc"
-              }
-            ],
-            "cfg(target_os = \"hermit\")": [
-              {
-                "id": "hermit-abi 0.3.9",
-                "target": "hermit_abi"
-              }
-            ],
-            "cfg(windows)": [
-              {
-                "id": "windows-sys 0.48.0",
-                "target": "windows_sys"
-              }
-            ]
-          }
-        },
-        "edition": "2018",
-        "version": "1.0.11"
-      },
-      "build_script_attrs": {
-        "data_glob": [
-          "**"
-        ]
-      },
-      "license": "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT",
-      "license_ids": [
-        "Apache-2.0",
-        "MIT"
-      ],
-      "license_file": "LICENSE-APACHE"
-    },
     "ipconfig 0.3.2": {
       "name": "ipconfig",
       "version": "0.3.2",
@@ -36301,75 +36208,6 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "linux-raw-sys 0.3.8": {
-      "name": "linux-raw-sys",
-      "version": "0.3.8",
-      "package_url": "https://github.com/sunfishcode/linux-raw-sys",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/linux-raw-sys/0.3.8/download",
-          "sha256": "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "linux_raw_sys",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": false,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "linux_raw_sys",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "general",
-            "ioctl",
-            "no_std"
-          ],
-          "selects": {
-            "aarch64-unknown-linux-gnu": [
-              "errno"
-            ],
-            "aarch64-unknown-nixos-gnu": [
-              "errno"
-            ],
-            "arm-unknown-linux-gnueabi": [
-              "errno"
-            ],
-            "armv7-unknown-linux-gnueabi": [
-              "errno"
-            ],
-            "i686-unknown-linux-gnu": [
-              "errno"
-            ],
-            "x86_64-unknown-linux-gnu": [
-              "errno"
-            ],
-            "x86_64-unknown-nixos-gnu": [
-              "errno"
-            ]
-          }
-        },
-        "edition": "2018",
-        "version": "0.3.8"
-      },
-      "license": "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT",
-      "license_ids": [
-        "Apache-2.0",
-        "MIT"
-      ],
-      "license_file": "LICENSE-APACHE"
-    },
     "linux-raw-sys 0.4.13": {
       "name": "linux-raw-sys",
       "version": "0.4.13",
@@ -38009,14 +37847,14 @@
       ],
       "license_file": "LICENSE-MIT"
     },
-    "memfd 0.6.3": {
+    "memfd 0.6.4": {
       "name": "memfd",
-      "version": "0.6.3",
+      "version": "0.6.4",
       "package_url": "https://github.com/lucab/memfd-rs",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/memfd/0.6.3/download",
-          "sha256": "ffc89ccdc6e10d6907450f753537ebc5c5d3460d2e4e62ea74bd571db62c0f9e"
+          "url": "https://static.crates.io/crates/memfd/0.6.4/download",
+          "sha256": "b2cffa4ad52c6f791f4f8b15f0c05f9824b2ced1160e88cc393d64fff9a8ac64"
         }
       },
       "targets": [
@@ -38041,14 +37879,14 @@
         "deps": {
           "common": [
             {
-              "id": "rustix 0.37.23",
+              "id": "rustix 0.38.32",
               "target": "rustix"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.6.3"
+        "version": "0.6.4"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -54846,129 +54684,6 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "rustix 0.37.23": {
-      "name": "rustix",
-      "version": "0.37.23",
-      "package_url": "https://github.com/bytecodealliance/rustix",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/rustix/0.37.23/download",
-          "sha256": "4d69718bf81c6127a49dc64e44a742e8bb9213c0ff8869a22c308f84c1d4ab06"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "rustix",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": false,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        },
-        {
-          "BuildScript": {
-            "crate_name": "build_script_build",
-            "crate_root": "build.rs",
-            "srcs": {
-              "allow_empty": false,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "rustix",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "default",
-            "fs",
-            "io-lifetimes",
-            "libc",
-            "std",
-            "use-libc-auxv"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "bitflags 1.3.2",
-              "target": "bitflags"
-            },
-            {
-              "id": "io-lifetimes 1.0.11",
-              "target": "io_lifetimes"
-            },
-            {
-              "id": "rustix 0.37.23",
-              "target": "build_script_build"
-            }
-          ],
-          "selects": {
-            "cfg(all(any(target_os = \"android\", target_os = \"linux\"), any(rustix_use_libc, miri, not(all(target_os = \"linux\", any(target_arch = \"x86\", all(target_arch = \"x86_64\", target_pointer_width = \"64\"), all(target_endian = \"little\", any(target_arch = \"arm\", all(target_arch = \"aarch64\", target_pointer_width = \"64\"), target_arch = \"powerpc64\", target_arch = \"riscv64\", target_arch = \"mips\", target_arch = \"mips64\"))))))))": [
-              {
-                "id": "linux-raw-sys 0.3.8",
-                "target": "linux_raw_sys"
-              }
-            ],
-            "cfg(all(not(rustix_use_libc), not(miri), target_os = \"linux\", any(target_arch = \"x86\", all(target_arch = \"x86_64\", target_pointer_width = \"64\"), all(target_endian = \"little\", any(target_arch = \"arm\", all(target_arch = \"aarch64\", target_pointer_width = \"64\"), target_arch = \"powerpc64\", target_arch = \"riscv64\", target_arch = \"mips\", target_arch = \"mips64\")))))": [
-              {
-                "id": "libc 0.2.158",
-                "target": "libc"
-              },
-              {
-                "id": "linux-raw-sys 0.3.8",
-                "target": "linux_raw_sys"
-              }
-            ],
-            "cfg(all(not(windows), any(rustix_use_libc, miri, not(all(target_os = \"linux\", any(target_arch = \"x86\", all(target_arch = \"x86_64\", target_pointer_width = \"64\"), all(target_endian = \"little\", any(target_arch = \"arm\", all(target_arch = \"aarch64\", target_pointer_width = \"64\"), target_arch = \"powerpc64\", target_arch = \"riscv64\", target_arch = \"mips\", target_arch = \"mips64\"))))))))": [
-              {
-                "id": "errno 0.3.8",
-                "target": "errno",
-                "alias": "libc_errno"
-              },
-              {
-                "id": "libc 0.2.158",
-                "target": "libc"
-              }
-            ],
-            "cfg(windows)": [
-              {
-                "id": "errno 0.3.8",
-                "target": "errno",
-                "alias": "libc_errno"
-              },
-              {
-                "id": "windows-sys 0.48.0",
-                "target": "windows_sys"
-              }
-            ]
-          }
-        },
-        "edition": "2018",
-        "version": "0.37.23"
-      },
-      "build_script_attrs": {
-        "data_glob": [
-          "**"
-        ]
-      },
-      "license": "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT",
-      "license_ids": [
-        "Apache-2.0",
-        "MIT"
-      ],
-      "license_file": "LICENSE-APACHE"
-    },
     "rustix 0.38.32": {
       "name": "rustix",
       "version": "0.38.32",
@@ -54976,7 +54691,13 @@
       "repository": {
         "Http": {
           "url": "https://static.crates.io/crates/rustix/0.38.32/download",
-          "sha256": "65e04861e65f21776e67888bfbea442b3642beaa0138fdb1dd7a84a52dffdb89"
+          "sha256": "65e04861e65f21776e67888bfbea442b3642beaa0138fdb1dd7a84a52dffdb89",
+          "patch_args": [
+            "-p1"
+          ],
+          "patches": [
+            "@rustix-patch//file:downloaded"
+          ]
         }
       },
       "targets": [
@@ -71707,14 +71428,14 @@
       ],
       "license_file": null
     },
-    "wasmtime 25.0.1": {
+    "wasmtime 25.0.2": {
       "name": "wasmtime",
-      "version": "25.0.1",
+      "version": "25.0.2",
       "package_url": "https://github.com/bytecodealliance/wasmtime",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/wasmtime/25.0.1/download",
-          "sha256": "03601559991d459a228236a49135364eac85ac00dc07b65fb95ae61a957793af"
+          "url": "https://static.crates.io/crates/wasmtime/25.0.2/download",
+          "sha256": "ef01f9cb9636ed42a7ec5a09d785c0643590199dc7372dc22c7e2ba7a31a97d4"
         }
       },
       "targets": [
@@ -71833,27 +71554,27 @@
               "target": "wasmparser"
             },
             {
-              "id": "wasmtime 25.0.1",
+              "id": "wasmtime 25.0.2",
               "target": "build_script_build"
             },
             {
-              "id": "wasmtime-asm-macros 25.0.1",
+              "id": "wasmtime-asm-macros 25.0.2",
               "target": "wasmtime_asm_macros"
             },
             {
-              "id": "wasmtime-cranelift 25.0.1",
+              "id": "wasmtime-cranelift 25.0.2",
               "target": "wasmtime_cranelift"
             },
             {
-              "id": "wasmtime-environ 25.0.1",
+              "id": "wasmtime-environ 25.0.2",
               "target": "wasmtime_environ"
             },
             {
-              "id": "wasmtime-jit-icache-coherence 25.0.1",
+              "id": "wasmtime-jit-icache-coherence 25.0.2",
               "target": "wasmtime_jit_icache_coherence"
             },
             {
-              "id": "wasmtime-slab 25.0.1",
+              "id": "wasmtime-slab 25.0.2",
               "target": "wasmtime_slab"
             }
           ],
@@ -71866,7 +71587,7 @@
             ],
             "cfg(target_os = \"linux\")": [
               {
-                "id": "memfd 0.6.3",
+                "id": "memfd 0.6.4",
                 "target": "memfd"
               }
             ],
@@ -71902,13 +71623,13 @@
               "target": "serde_derive"
             },
             {
-              "id": "wasmtime-versioned-export-macros 25.0.1",
+              "id": "wasmtime-versioned-export-macros 25.0.2",
               "target": "wasmtime_versioned_export_macros"
             }
           ],
           "selects": {}
         },
-        "version": "25.0.1"
+        "version": "25.0.2"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -71926,7 +71647,7 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "wasmtime-versioned-export-macros 25.0.1",
+              "id": "wasmtime-versioned-export-macros 25.0.2",
               "target": "wasmtime_versioned_export_macros"
             }
           ],
@@ -71939,14 +71660,14 @@
       ],
       "license_file": "LICENSE"
     },
-    "wasmtime-asm-macros 25.0.1": {
+    "wasmtime-asm-macros 25.0.2": {
       "name": "wasmtime-asm-macros",
-      "version": "25.0.1",
+      "version": "25.0.2",
       "package_url": "https://github.com/bytecodealliance/wasmtime",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/wasmtime-asm-macros/25.0.1/download",
-          "sha256": "e453b3bde07312874c0c6703e2de9281daab46646172c1b71fa59a97226f858e"
+          "url": "https://static.crates.io/crates/wasmtime-asm-macros/25.0.2/download",
+          "sha256": "ba5b20797419d6baf2296db2354f864e8bb3447cacca9d151ce7700ae08b4460"
         }
       },
       "targets": [
@@ -71978,7 +71699,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "25.0.1"
+        "version": "25.0.2"
       },
       "license": "Apache-2.0 WITH LLVM-exception",
       "license_ids": [
@@ -71986,14 +71707,14 @@
       ],
       "license_file": null
     },
-    "wasmtime-component-macro 25.0.1": {
+    "wasmtime-component-macro 25.0.2": {
       "name": "wasmtime-component-macro",
-      "version": "25.0.1",
+      "version": "25.0.2",
       "package_url": "https://github.com/bytecodealliance/wasmtime",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/wasmtime-component-macro/25.0.1/download",
-          "sha256": "4a6faeabbdbfd27e24e8d5204207ba9c247a13cf84181ea721b5f209f281fe01"
+          "url": "https://static.crates.io/crates/wasmtime-component-macro/25.0.2/download",
+          "sha256": "26593c4b18c76ca3c3fbdd813d6692256537b639b851d8a6fe827e3d6966fc01"
         }
       },
       "targets": [
@@ -72046,15 +71767,15 @@
               "target": "syn"
             },
             {
-              "id": "wasmtime-component-macro 25.0.1",
+              "id": "wasmtime-component-macro 25.0.2",
               "target": "build_script_build"
             },
             {
-              "id": "wasmtime-component-util 25.0.1",
+              "id": "wasmtime-component-util 25.0.2",
               "target": "wasmtime_component_util"
             },
             {
-              "id": "wasmtime-wit-bindgen 25.0.1",
+              "id": "wasmtime-wit-bindgen 25.0.2",
               "target": "wasmtime_wit_bindgen"
             },
             {
@@ -72065,7 +71786,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "25.0.1"
+        "version": "25.0.2"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -72078,14 +71799,14 @@
       ],
       "license_file": null
     },
-    "wasmtime-component-util 25.0.1": {
+    "wasmtime-component-util 25.0.2": {
       "name": "wasmtime-component-util",
-      "version": "25.0.1",
+      "version": "25.0.2",
       "package_url": "https://github.com/bytecodealliance/wasmtime",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/wasmtime-component-util/25.0.1/download",
-          "sha256": "6b1b24db4aa3dc7c0d3181d1833b4fe9ec0cd3f08780b746415c84c0a9ec9011"
+          "url": "https://static.crates.io/crates/wasmtime-component-util/25.0.2/download",
+          "sha256": "a2ed562fbb0cbed20a56c369c8de146c1de06a48c19e26ed9aa45f073514ee60"
         }
       },
       "targets": [
@@ -72108,7 +71829,7 @@
           "**"
         ],
         "edition": "2021",
-        "version": "25.0.1"
+        "version": "25.0.2"
       },
       "license": "Apache-2.0 WITH LLVM-exception",
       "license_ids": [
@@ -72116,14 +71837,14 @@
       ],
       "license_file": null
     },
-    "wasmtime-cranelift 25.0.1": {
+    "wasmtime-cranelift 25.0.2": {
       "name": "wasmtime-cranelift",
-      "version": "25.0.1",
+      "version": "25.0.2",
       "package_url": "https://github.com/bytecodealliance/wasmtime",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/wasmtime-cranelift/25.0.1/download",
-          "sha256": "c737bef9ea94aab874e29ac6a8688b89ceb43c7b51f047079c43387972c07ee3"
+          "url": "https://static.crates.io/crates/wasmtime-cranelift/25.0.2/download",
+          "sha256": "f389b789cbcb53a8499131182135dea21d7d97ad77e7fb66830f69479ef0e68c"
         }
       },
       "targets": [
@@ -72162,27 +71883,27 @@
               "target": "cfg_if"
             },
             {
-              "id": "cranelift-codegen 0.112.1",
+              "id": "cranelift-codegen 0.112.2",
               "target": "cranelift_codegen"
             },
             {
-              "id": "cranelift-control 0.112.1",
+              "id": "cranelift-control 0.112.2",
               "target": "cranelift_control"
             },
             {
-              "id": "cranelift-entity 0.112.1",
+              "id": "cranelift-entity 0.112.2",
               "target": "cranelift_entity"
             },
             {
-              "id": "cranelift-frontend 0.112.1",
+              "id": "cranelift-frontend 0.112.2",
               "target": "cranelift_frontend"
             },
             {
-              "id": "cranelift-native 0.112.1",
+              "id": "cranelift-native 0.112.2",
               "target": "cranelift_native"
             },
             {
-              "id": "cranelift-wasm 0.112.1",
+              "id": "cranelift-wasm 0.112.2",
               "target": "cranelift_wasm"
             },
             {
@@ -72214,7 +71935,7 @@
               "target": "wasmparser"
             },
             {
-              "id": "wasmtime-environ 25.0.1",
+              "id": "wasmtime-environ 25.0.2",
               "target": "wasmtime_environ"
             }
           ],
@@ -72224,13 +71945,13 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "wasmtime-versioned-export-macros 25.0.1",
+              "id": "wasmtime-versioned-export-macros 25.0.2",
               "target": "wasmtime_versioned_export_macros"
             }
           ],
           "selects": {}
         },
-        "version": "25.0.1"
+        "version": "25.0.2"
       },
       "license": "Apache-2.0 WITH LLVM-exception",
       "license_ids": [
@@ -72238,14 +71959,14 @@
       ],
       "license_file": "LICENSE"
     },
-    "wasmtime-environ 25.0.1": {
+    "wasmtime-environ 25.0.2": {
       "name": "wasmtime-environ",
-      "version": "25.0.1",
+      "version": "25.0.2",
       "package_url": "https://github.com/bytecodealliance/wasmtime",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/wasmtime-environ/25.0.1/download",
-          "sha256": "817bfa9ea878ec37aa24f85fd6912844e8d87d321662824cf920d561b698cdfd"
+          "url": "https://static.crates.io/crates/wasmtime-environ/25.0.2/download",
+          "sha256": "84b72debe8899f19bedf66f7071310f06ef62de943a1369ba9b373613e77dd3d"
         }
       },
       "targets": [
@@ -72282,11 +72003,11 @@
               "target": "anyhow"
             },
             {
-              "id": "cranelift-bitset 0.112.1",
+              "id": "cranelift-bitset 0.112.2",
               "target": "cranelift_bitset"
             },
             {
-              "id": "cranelift-entity 0.112.1",
+              "id": "cranelift-entity 0.112.2",
               "target": "cranelift_entity"
             },
             {
@@ -72330,7 +72051,7 @@
               "target": "wasmprinter"
             },
             {
-              "id": "wasmtime-types 25.0.1",
+              "id": "wasmtime-types 25.0.2",
               "target": "wasmtime_types"
             }
           ],
@@ -72346,7 +72067,7 @@
           ],
           "selects": {}
         },
-        "version": "25.0.1"
+        "version": "25.0.2"
       },
       "license": "Apache-2.0 WITH LLVM-exception",
       "license_ids": [
@@ -72354,14 +72075,14 @@
       ],
       "license_file": "LICENSE"
     },
-    "wasmtime-jit-icache-coherence 25.0.1": {
+    "wasmtime-jit-icache-coherence 25.0.2": {
       "name": "wasmtime-jit-icache-coherence",
-      "version": "25.0.1",
+      "version": "25.0.2",
       "package_url": "https://github.com/bytecodealliance/wasmtime",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/wasmtime-jit-icache-coherence/25.0.1/download",
-          "sha256": "48011232c0da424f89c3752a378d0b7f512fae321ea414a43e1e7a302a6a1f7e"
+          "url": "https://static.crates.io/crates/wasmtime-jit-icache-coherence/25.0.2/download",
+          "sha256": "1d930bc1325bc0448be6a11754156d770f56f6c3a61f440e9567f36cd2ea3065"
         }
       },
       "targets": [
@@ -72410,7 +72131,7 @@
           }
         },
         "edition": "2021",
-        "version": "25.0.1"
+        "version": "25.0.2"
       },
       "license": "Apache-2.0 WITH LLVM-exception",
       "license_ids": [
@@ -72418,14 +72139,14 @@
       ],
       "license_file": null
     },
-    "wasmtime-slab 25.0.1": {
+    "wasmtime-slab 25.0.2": {
       "name": "wasmtime-slab",
-      "version": "25.0.1",
+      "version": "25.0.2",
       "package_url": "https://github.com/bytecodealliance/wasmtime",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/wasmtime-slab/25.0.1/download",
-          "sha256": "d9858a22e656ae8574631221b474b8bebf63f1367fcac3f179873833eabc2ced"
+          "url": "https://static.crates.io/crates/wasmtime-slab/25.0.2/download",
+          "sha256": "055a181b8d03998511294faea14798df436503f14d7fd20edcf7370ec583e80a"
         }
       },
       "targets": [
@@ -72448,7 +72169,7 @@
           "**"
         ],
         "edition": "2021",
-        "version": "25.0.1"
+        "version": "25.0.2"
       },
       "license": "Apache-2.0 WITH LLVM-exception",
       "license_ids": [
@@ -72456,14 +72177,14 @@
       ],
       "license_file": null
     },
-    "wasmtime-types 25.0.1": {
+    "wasmtime-types 25.0.2": {
       "name": "wasmtime-types",
-      "version": "25.0.1",
+      "version": "25.0.2",
       "package_url": "https://github.com/bytecodealliance/wasmtime",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/wasmtime-types/25.0.1/download",
-          "sha256": "4d14b8a9206fe94485a03edb1654cd530dbd2a859a85a43502cb4e99653a568c"
+          "url": "https://static.crates.io/crates/wasmtime-types/25.0.2/download",
+          "sha256": "c8340d976673ac3fdacac781f2afdc4933920c1adc738c3409e825dab3955399"
         }
       },
       "targets": [
@@ -72498,7 +72219,7 @@
               "target": "anyhow"
             },
             {
-              "id": "cranelift-entity 0.112.1",
+              "id": "cranelift-entity 0.112.2",
               "target": "cranelift_entity"
             },
             {
@@ -72526,7 +72247,7 @@
           ],
           "selects": {}
         },
-        "version": "25.0.1"
+        "version": "25.0.2"
       },
       "license": "Apache-2.0 WITH LLVM-exception",
       "license_ids": [
@@ -72534,14 +72255,14 @@
       ],
       "license_file": "LICENSE"
     },
-    "wasmtime-versioned-export-macros 25.0.1": {
+    "wasmtime-versioned-export-macros 25.0.2": {
       "name": "wasmtime-versioned-export-macros",
-      "version": "25.0.1",
+      "version": "25.0.2",
       "package_url": "https://github.com/bytecodealliance/wasmtime",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/wasmtime-versioned-export-macros/25.0.1/download",
-          "sha256": "e9bb1f01efb8b542eadfda511e8ea1cc54309451aba97b69969e5b1a59cb7ded"
+          "url": "https://static.crates.io/crates/wasmtime-versioned-export-macros/25.0.2/download",
+          "sha256": "a4b0c1f76891f778db9602ee3fbb4eb7e9a3f511847d1fb1b69eddbcea28303c"
         }
       },
       "targets": [
@@ -72581,7 +72302,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "25.0.1"
+        "version": "25.0.2"
       },
       "license": "Apache-2.0 WITH LLVM-exception",
       "license_ids": [
@@ -72589,14 +72310,14 @@
       ],
       "license_file": null
     },
-    "wasmtime-wit-bindgen 25.0.1": {
+    "wasmtime-wit-bindgen 25.0.2": {
       "name": "wasmtime-wit-bindgen",
-      "version": "25.0.1",
+      "version": "25.0.2",
       "package_url": "https://github.com/bytecodealliance/wasmtime",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/wasmtime-wit-bindgen/25.0.1/download",
-          "sha256": "eb1596caa67b31ac675fd3da61685c4260f8b10832021db42c85d227b7ba8133"
+          "url": "https://static.crates.io/crates/wasmtime-wit-bindgen/25.0.2/download",
+          "sha256": "b2fca2cbb5bb390f65d4434c19bf8d9873dfc60f10802918ebcd6f819a38d703"
         }
       },
       "targets": [
@@ -72640,7 +72361,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "25.0.1"
+        "version": "25.0.2"
       },
       "license": "Apache-2.0 WITH LLVM-exception",
       "license_ids": [
@@ -77603,14 +77324,6 @@
     "cfg(all(any(target_arch = \"x86_64\", target_arch = \"arm64ec\"), target_env = \"msvc\", not(windows_raw_dylib)))": [
       "x86_64-pc-windows-msvc"
     ],
-    "cfg(all(any(target_os = \"android\", target_os = \"linux\"), any(rustix_use_libc, miri, not(all(target_os = \"linux\", any(target_arch = \"x86\", all(target_arch = \"x86_64\", target_pointer_width = \"64\"), all(target_endian = \"little\", any(target_arch = \"arm\", all(target_arch = \"aarch64\", target_pointer_width = \"64\"), target_arch = \"powerpc64\", target_arch = \"riscv64\", target_arch = \"mips\", target_arch = \"mips64\"))))))))": [
-      "aarch64-linux-android",
-      "armv7-linux-androideabi",
-      "i686-linux-android",
-      "powerpc-unknown-linux-gnu",
-      "s390x-unknown-linux-gnu",
-      "x86_64-linux-android"
-    ],
     "cfg(all(any(target_os = \"android\", target_os = \"linux\"), any(rustix_use_libc, miri, not(all(target_os = \"linux\", target_endian = \"little\", any(target_arch = \"arm\", all(target_arch = \"aarch64\", target_pointer_width = \"64\"), target_arch = \"riscv64\", all(rustix_use_experimental_asm, target_arch = \"powerpc64\"), all(rustix_use_experimental_asm, target_arch = \"mips\"), all(rustix_use_experimental_asm, target_arch = \"mips32r6\"), all(rustix_use_experimental_asm, target_arch = \"mips64\"), all(rustix_use_experimental_asm, target_arch = \"mips64r6\"), target_arch = \"x86\", all(target_arch = \"x86_64\", target_pointer_width = \"64\")))))))": [
       "aarch64-linux-android",
       "armv7-linux-androideabi",
@@ -77638,15 +77351,6 @@
       "x86_64-unknown-nixos-gnu",
       "x86_64-unknown-none"
     ],
-    "cfg(all(not(rustix_use_libc), not(miri), target_os = \"linux\", any(target_arch = \"x86\", all(target_arch = \"x86_64\", target_pointer_width = \"64\"), all(target_endian = \"little\", any(target_arch = \"arm\", all(target_arch = \"aarch64\", target_pointer_width = \"64\"), target_arch = \"powerpc64\", target_arch = \"riscv64\", target_arch = \"mips\", target_arch = \"mips64\")))))": [
-      "aarch64-unknown-linux-gnu",
-      "aarch64-unknown-nixos-gnu",
-      "arm-unknown-linux-gnueabi",
-      "armv7-unknown-linux-gnueabi",
-      "i686-unknown-linux-gnu",
-      "x86_64-unknown-linux-gnu",
-      "x86_64-unknown-nixos-gnu"
-    ],
     "cfg(all(not(rustix_use_libc), not(miri), target_os = \"linux\", target_endian = \"little\", any(target_arch = \"arm\", all(target_arch = \"aarch64\", target_pointer_width = \"64\"), target_arch = \"riscv64\", all(rustix_use_experimental_asm, target_arch = \"powerpc64\"), all(rustix_use_experimental_asm, target_arch = \"mips\"), all(rustix_use_experimental_asm, target_arch = \"mips32r6\"), all(rustix_use_experimental_asm, target_arch = \"mips64\"), all(rustix_use_experimental_asm, target_arch = \"mips64r6\"), target_arch = \"x86\", all(target_arch = \"x86_64\", target_pointer_width = \"64\"))))": [
       "aarch64-unknown-linux-gnu",
       "aarch64-unknown-nixos-gnu",
@@ -77655,32 +77359,6 @@
       "i686-unknown-linux-gnu",
       "x86_64-unknown-linux-gnu",
       "x86_64-unknown-nixos-gnu"
-    ],
-    "cfg(all(not(windows), any(rustix_use_libc, miri, not(all(target_os = \"linux\", any(target_arch = \"x86\", all(target_arch = \"x86_64\", target_pointer_width = \"64\"), all(target_endian = \"little\", any(target_arch = \"arm\", all(target_arch = \"aarch64\", target_pointer_width = \"64\"), target_arch = \"powerpc64\", target_arch = \"riscv64\", target_arch = \"mips\", target_arch = \"mips64\"))))))))": [
-      "aarch64-apple-darwin",
-      "aarch64-apple-ios",
-      "aarch64-apple-ios-sim",
-      "aarch64-fuchsia",
-      "aarch64-linux-android",
-      "aarch64-unknown-nto-qnx710",
-      "armv7-linux-androideabi",
-      "i686-apple-darwin",
-      "i686-linux-android",
-      "i686-unknown-freebsd",
-      "powerpc-unknown-linux-gnu",
-      "riscv32imc-unknown-none-elf",
-      "riscv64gc-unknown-none-elf",
-      "s390x-unknown-linux-gnu",
-      "thumbv7em-none-eabi",
-      "thumbv8m.main-none-eabi",
-      "wasm32-unknown-unknown",
-      "wasm32-wasi",
-      "x86_64-apple-darwin",
-      "x86_64-apple-ios",
-      "x86_64-fuchsia",
-      "x86_64-linux-android",
-      "x86_64-unknown-freebsd",
-      "x86_64-unknown-none"
     ],
     "cfg(all(not(windows), any(rustix_use_libc, miri, not(all(target_os = \"linux\", target_endian = \"little\", any(target_arch = \"arm\", all(target_arch = \"aarch64\", target_pointer_width = \"64\"), target_arch = \"riscv64\", all(rustix_use_experimental_asm, target_arch = \"powerpc64\"), all(rustix_use_experimental_asm, target_arch = \"mips\"), all(rustix_use_experimental_asm, target_arch = \"mips32r6\"), all(rustix_use_experimental_asm, target_arch = \"mips64\"), all(rustix_use_experimental_asm, target_arch = \"mips64r6\"), target_arch = \"x86\", all(target_arch = \"x86_64\", target_pointer_width = \"64\")))))))": [
       "aarch64-apple-darwin",
@@ -78936,8 +78614,8 @@
     "wasm-smith 0.212.0",
     "wasmparser 0.217.0",
     "wasmprinter 0.217.0",
-    "wasmtime 25.0.1",
-    "wasmtime-environ 25.0.1",
+    "wasmtime 25.0.2",
+    "wasmtime-environ 25.0.2",
     "wast 212.0.0",
     "wat 1.212.0",
     "wee_alloc 0.4.5",

--- a/Cargo.Bazel.toml.lock
+++ b/Cargo.Bazel.toml.lock
@@ -616,7 +616,7 @@ dependencies = [
  "futures-lite",
  "parking",
  "polling",
- "rustix 0.38.32",
+ "rustix",
  "slab",
  "tracing",
  "windows-sys 0.59.0",
@@ -2319,18 +2319,18 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.112.1"
+version = "0.112.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6e376bd92bddd03dcfc443b14382611cae5d10012aa0b1628bbf18bb73f12f7"
+checksum = "7b765ed4349e66bedd9b88c7691da42e24c7f62067a6be17ddffa949367b6e17"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-bitset"
-version = "0.112.1"
+version = "0.112.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45ecbe07f25a8100e5077933516200e97808f1d7196b5a073edb85fa08fde32e"
+checksum = "9eaa2aece6237198afd32bff57699e08d4dccb8d3902c214fc1e6ba907247ca4"
 dependencies = [
  "serde",
  "serde_derive",
@@ -2338,9 +2338,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.112.1"
+version = "0.112.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc60913f32c1de18538c28bef74b8c87cf16de7841a1b0956fcf01b23237853a"
+checksum = "351824439e59d42f0e4fa5aac1d13deded155120043565769e55cd4ad3ca8ed9"
 dependencies = [
  "bumpalo",
  "cranelift-bforest",
@@ -2361,33 +2361,33 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.112.1"
+version = "0.112.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bae009e7822f47aa55e7dcef846ccf3aa4eb102ca6b4bcb8a44b36f3f49aa85c"
+checksum = "5a0ce0273d7a493ef8f31f606849a4e931c19187a4923f5f87fc1f2b13109981"
 dependencies = [
  "cranelift-codegen-shared",
 ]
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.112.1"
+version = "0.112.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c78f01a852536c68e34444450f845ed6e0782a1f047f85397fe460b8fbce8f1"
+checksum = "0f72016ac35579051913f4f07f6b36c509ed69412d852fd44c8e1d7b7fa6d92a"
 
 [[package]]
 name = "cranelift-control"
-version = "0.112.1"
+version = "0.112.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a061b22e00a9e36b31f2660dfb05a9617b7775bd54b79754d3bb75a990dac06"
+checksum = "db28951d21512c4fd0554ef179bfb11e4eb6815062957a9173824eee5de0c46c"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.112.1"
+version = "0.112.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95e2b261a3e74ae42f4e606906d5ffa44ee2684e8b1ae23bdf75d21908dc9233"
+checksum = "14ebe592a2f81af9237cf9be29dd3854ecb72108cfffa59e85ef12389bf939e3"
 dependencies = [
  "cranelift-bitset",
  "serde",
@@ -2396,9 +2396,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.112.1"
+version = "0.112.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe14abba0e6bab42aca0f9ce757f96880f9187e88bc6cb975ed6acd8a42f7770"
+checksum = "4437db9d60c7053ac91ded0802740c2ccf123ee6d6898dd906c34f8c530cd119"
 dependencies = [
  "cranelift-codegen",
  "log",
@@ -2408,15 +2408,15 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.112.1"
+version = "0.112.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "311d91ae72b37d4262b51217baf8c9e01f1afd5148931468da1fdb7e9d011347"
+checksum = "230cb33572b9926e210f2ca28145f2bc87f389e1456560932168e2591feb65c1"
 
 [[package]]
 name = "cranelift-native"
-version = "0.112.1"
+version = "0.112.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a3f84c75e578189ff7a716c24ad83740b553bf583f2510b323bfe4c1a74bb93"
+checksum = "364524ac7aef7070b1141478724abebeec297d4ea1e87ad8b8986465e91146d9"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -2425,9 +2425,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-wasm"
-version = "0.112.1"
+version = "0.112.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f56b7b2476c47b2091eee5a20bc54a80fbb29ca5313ae2bd0dea52621abcfca1"
+checksum = "0572cbd9d136a62c0f39837b6bce3b0978b96b8586794042bec0c214668fd6f5"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -5824,17 +5824,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "io-lifetimes"
-version = "1.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
-dependencies = [
- "hermit-abi 0.3.9",
- "libc",
- "windows-sys 0.48.0",
-]
-
-[[package]]
 name = "ipconfig"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5868,7 +5857,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
 dependencies = [
  "hermit-abi 0.3.9",
- "rustix 0.38.32",
+ "rustix",
  "windows-sys 0.48.0",
 ]
 
@@ -6359,12 +6348,6 @@ checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
-
-[[package]]
-name = "linux-raw-sys"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
@@ -6603,11 +6586,11 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "memfd"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffc89ccdc6e10d6907450f753537ebc5c5d3460d2e4e62ea74bd571db62c0f9e"
+checksum = "b2cffa4ad52c6f791f4f8b15f0c05f9824b2ced1160e88cc393d64fff9a8ac64"
 dependencies = [
- "rustix 0.37.23",
+ "rustix",
 ]
 
 [[package]]
@@ -8023,7 +8006,7 @@ dependencies = [
  "concurrent-queue",
  "hermit-abi 0.4.0",
  "pin-project-lite",
- "rustix 0.38.32",
+ "rustix",
  "tracing",
  "windows-sys 0.59.0",
 ]
@@ -8299,7 +8282,7 @@ dependencies = [
  "hex",
  "lazy_static",
  "procfs-core",
- "rustix 0.38.32",
+ "rustix",
 ]
 
 [[package]]
@@ -9392,20 +9375,6 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.37.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d69718bf81c6127a49dc64e44a742e8bb9213c0ff8869a22c308f84c1d4ab06"
-dependencies = [
- "bitflags 1.3.2",
- "errno 0.3.8",
- "io-lifetimes",
- "libc",
- "linux-raw-sys 0.3.8",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "rustix"
 version = "0.38.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "65e04861e65f21776e67888bfbea442b3642beaa0138fdb1dd7a84a52dffdb89"
@@ -9413,7 +9382,7 @@ dependencies = [
  "bitflags 2.4.1",
  "errno 0.3.8",
  "libc",
- "linux-raw-sys 0.4.13",
+ "linux-raw-sys",
  "windows-sys 0.52.0",
 ]
 
@@ -10785,7 +10754,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "fastrand 2.1.0",
  "once_cell",
- "rustix 0.38.32",
+ "rustix",
  "windows-sys 0.59.0",
 ]
 
@@ -12146,9 +12115,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime"
-version = "25.0.1"
+version = "25.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03601559991d459a228236a49135364eac85ac00dc07b65fb95ae61a957793af"
+checksum = "ef01f9cb9636ed42a7ec5a09d785c0643590199dc7372dc22c7e2ba7a31a97d4"
 dependencies = [
  "anyhow",
  "bitflags 2.4.1",
@@ -12168,7 +12137,7 @@ dependencies = [
  "postcard",
  "psm",
  "rayon",
- "rustix 0.38.32",
+ "rustix",
  "serde",
  "serde_derive",
  "smallvec",
@@ -12187,18 +12156,18 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-asm-macros"
-version = "25.0.1"
+version = "25.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e453b3bde07312874c0c6703e2de9281daab46646172c1b71fa59a97226f858e"
+checksum = "ba5b20797419d6baf2296db2354f864e8bb3447cacca9d151ce7700ae08b4460"
 dependencies = [
  "cfg-if 1.0.0",
 ]
 
 [[package]]
 name = "wasmtime-component-macro"
-version = "25.0.1"
+version = "25.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a6faeabbdbfd27e24e8d5204207ba9c247a13cf84181ea721b5f209f281fe01"
+checksum = "26593c4b18c76ca3c3fbdd813d6692256537b639b851d8a6fe827e3d6966fc01"
 dependencies = [
  "anyhow",
  "proc-macro2",
@@ -12211,15 +12180,15 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-component-util"
-version = "25.0.1"
+version = "25.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b1b24db4aa3dc7c0d3181d1833b4fe9ec0cd3f08780b746415c84c0a9ec9011"
+checksum = "a2ed562fbb0cbed20a56c369c8de146c1de06a48c19e26ed9aa45f073514ee60"
 
 [[package]]
 name = "wasmtime-cranelift"
-version = "25.0.1"
+version = "25.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c737bef9ea94aab874e29ac6a8688b89ceb43c7b51f047079c43387972c07ee3"
+checksum = "f389b789cbcb53a8499131182135dea21d7d97ad77e7fb66830f69479ef0e68c"
 dependencies = [
  "anyhow",
  "cfg-if 1.0.0",
@@ -12242,9 +12211,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-environ"
-version = "25.0.1"
+version = "25.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "817bfa9ea878ec37aa24f85fd6912844e8d87d321662824cf920d561b698cdfd"
+checksum = "84b72debe8899f19bedf66f7071310f06ef62de943a1369ba9b373613e77dd3d"
 dependencies = [
  "anyhow",
  "cranelift-bitset",
@@ -12265,9 +12234,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit-icache-coherence"
-version = "25.0.1"
+version = "25.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48011232c0da424f89c3752a378d0b7f512fae321ea414a43e1e7a302a6a1f7e"
+checksum = "1d930bc1325bc0448be6a11754156d770f56f6c3a61f440e9567f36cd2ea3065"
 dependencies = [
  "anyhow",
  "cfg-if 1.0.0",
@@ -12277,15 +12246,15 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-slab"
-version = "25.0.1"
+version = "25.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9858a22e656ae8574631221b474b8bebf63f1367fcac3f179873833eabc2ced"
+checksum = "055a181b8d03998511294faea14798df436503f14d7fd20edcf7370ec583e80a"
 
 [[package]]
 name = "wasmtime-types"
-version = "25.0.1"
+version = "25.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d14b8a9206fe94485a03edb1654cd530dbd2a859a85a43502cb4e99653a568c"
+checksum = "c8340d976673ac3fdacac781f2afdc4933920c1adc738c3409e825dab3955399"
 dependencies = [
  "anyhow",
  "cranelift-entity",
@@ -12297,9 +12266,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-versioned-export-macros"
-version = "25.0.1"
+version = "25.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9bb1f01efb8b542eadfda511e8ea1cc54309451aba97b69969e5b1a59cb7ded"
+checksum = "a4b0c1f76891f778db9602ee3fbb4eb7e9a3f511847d1fb1b69eddbcea28303c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12308,9 +12277,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wit-bindgen"
-version = "25.0.1"
+version = "25.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb1596caa67b31ac675fd3da61685c4260f8b10832021db42c85d227b7ba8133"
+checksum = "b2fca2cbb5bb390f65d4434c19bf8d9873dfc60f10802918ebcd6f819a38d703"
 dependencies = [
  "anyhow",
  "heck 0.4.1",

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -804,3 +804,11 @@ http_file(
     sha256 = "454891cac2421f3f894759ec5e6b6e48fbb544d79197bc29b88d34b93d78a4f1",
     url = "https://download.dfinity.systems/ic/52ebccfba8855e23dcad9657a8d6e6be01df71f9/binaries/x86_64-linux/pocket-ic.gz",
 )
+
+# Patches
+
+http_file(
+    name = "rustix-patch",
+    sha256 = "ffe807170f06b579098f948eca42ba1ea1fd2cb7b8290c9d41101efe976337f7",
+    url = "https://github.com/nmattia/rustix/commit/330bcc07796f4b8e6443987fbb1b9be79c446bd2.diff",
+)

--- a/bazel/external_crates.bzl
+++ b/bazel/external_crates.bzl
@@ -62,6 +62,12 @@ def external_crates_repository(name, cargo_lockfile, lockfile, sanitizers_enable
                 "opt-level=3",
             ],
         )],
+        "rustix": [crate.annotation(
+            # Patch for determinism issues
+            # https://github.com/bytecodealliance/rustix/issues/1199
+            patch_args = ["-p1"],
+            patches = ["@rustix-patch//file:downloaded"],
+        )],
         "secp256k1-sys": [crate.annotation(
             # This specific version is used by ic-btc-kyt canister, which
             # requires an extra cfg flag to avoid linking issues.
@@ -1382,7 +1388,7 @@ def external_crates_repository(name, cargo_lockfile, lockfile, sanitizers_enable
                 version = "^0.217.0",
             ),
             "wasmtime": crate.spec(
-                version = "^25.0.0",
+                version = "=25.0.2",
                 default_features = False,
                 features = [
                     "cranelift",


### PR DESCRIPTION
This includes a patch that fixes rebuild issues in `rustix`. Without the patch the `rustix` crate creates a (seemingly non-deterministic) `.rmeta` file that causes cache misses in our bazel build.

For more info see: https://github.com/bytecodealliance/rustix/issues/1199

Some dependencies are also updated to match the `cargo` version and ensure we only depend on one `rustix` version -- more importantly, that we don't depend on `rustix v0.37.X` for which the patch doesn't work.