### PR TITLE
chore(system-tests): adding API BNs to ic-prep and creating a testnet with API BNs

### DIFF
--- a/ic-os/components/hostos-scripts/build-bootstrap-config-image.sh
+++ b/ic-os/components/hostos-scripts/build-bootstrap-config-image.sh
@@ -106,6 +106,10 @@ options may be specified:
   --socks_proxy url
     The URL of the socks proxy to use. To be used in
     systems tests only.
+
+  --generate_ic_boundary_tls_cert domain_name
+    Generate and inject a self-signed TLS certificate and key for ic-boundary
+    for the given domain name. To be used in system tests only.
 EOF
 }
 
@@ -199,6 +203,9 @@ function build_ic_bootstrap_tar() {
             --socks_proxy)
                 SOCKS_PROXY="$2"
                 ;;
+            --generate_ic_boundary_tls_cert)
+                IC_BOUNDARY_TLS_CERT_DOMAIN_NAME="$2"
+                ;;
             *)
                 echo "Unrecognized option: $1"
                 usage
@@ -269,6 +276,12 @@ EOF
     fi
     if [ "${NODE_OPERATOR_PRIVATE_KEY}" != "" ]; then
         cp "${NODE_OPERATOR_PRIVATE_KEY}" "${BOOTSTRAP_TMPDIR}/node_operator_private_key.pem"
+    fi
+    if [[ -n "$IC_BOUNDARY_TLS_CERT_DOMAIN_NAME" ]]; then
+        openssl req -x509 -newkey rsa:2048 \
+            -keyout ${BOOTSTRAP_TMPDIR}/ic-boundary-tls.key \
+            -out ${BOOTSTRAP_TMPDIR}/ic-boundary-tls.crt -sha256 -days 3650 -nodes \
+            -subj /C=CH/ST=Zurich/L=Zurich/O=InternetComputer/OU=ApiBoundaryNodes/CN=${IC_BOUNDARY_TLS_CERT_DOMAIN_NAME}
     fi
 
     tar cf "${OUT_FILE}" \

--- a/ic-os/components/init/bootstrap-ic-node/bootstrap-ic-node.sh
+++ b/ic-os/components/init/bootstrap-ic-node/bootstrap-ic-node.sh
@@ -101,6 +101,12 @@ function process_bootstrap() {
             cp -rL -T "${TMPDIR}/${ITEM}" "${STATE_ROOT}/data/${ITEM}"
         fi
     done
+    if [ -e "${TMPDIR}/ic-boundary-tls.key" ]; then
+        echo "Setting up self-signed certificate of ic-boundary"
+        cp -L "${TMPDIR}/ic-boundary-tls.key" "${STATE_ROOT}/data/ic-boundary-tls.key"
+        cp -L "${TMPDIR}/ic-boundary-tls.crt" "${STATE_ROOT}/data/ic-boundary-tls.crt"
+        sudo chmod +r ${STATE_ROOT}/data/ic-boundary-tls.key
+    fi
 
     # stash the following configuration files to config store
     # note: keep this list in sync with configurations supported in build-bootstrap-config-image.sh

--- a/rs/ic_os/dev_test_tools/launch-single-vm/src/main.rs
+++ b/rs/ic_os/dev_test_tools/launch-single-vm/src/main.rs
@@ -157,6 +157,7 @@ fn main() {
             public_api: SocketAddr::new(ipv6_addr, 8080),
             node_operator_principal_id: None,
             secret_key_store: None,
+            domain: None,
         },
     )]);
 

--- a/rs/prep/src/bin/prep.rs
+++ b/rs/prep/src/bin/prep.rs
@@ -508,6 +508,7 @@ mod test_flag_node_parser {
                 public_api: "3.4.5.6:82".parse().unwrap(),
                 node_operator_principal_id: None,
                 secret_key_store: None,
+                domain: None,
             },
         };
 

--- a/rs/prep/src/internet_computer.rs
+++ b/rs/prep/src/internet_computer.rs
@@ -14,6 +14,8 @@ use std::{
     str::FromStr,
 };
 
+use anyhow::{anyhow, Result};
+
 use prost::Message;
 use serde_json::Value;
 use thiserror::Error;
@@ -28,6 +30,7 @@ use ic_protobuf::registry::firewall::v1::{
     FirewallAction, FirewallRule, FirewallRuleDirection, FirewallRuleSet,
 };
 use ic_protobuf::registry::{
+    api_boundary_node::v1::ApiBoundaryNodeRecord,
     node_operator::v1::NodeOperatorRecord,
     provisional_whitelist::v1::ProvisionalWhitelist as PbProvisionalWhitelist,
     replica_version::v1::{BlessedReplicaVersions, ReplicaVersionRecord},
@@ -38,10 +41,11 @@ use ic_protobuf::registry::{
 use ic_protobuf::types::v1::{PrincipalId as PrincipalIdProto, SubnetId as SubnetIdProto};
 use ic_registry_client::client::RegistryDataProviderError;
 use ic_registry_keys::{
-    make_blessed_replica_versions_key, make_firewall_rules_record_key,
-    make_node_operator_record_key, make_provisional_whitelist_record_key, make_replica_version_key,
-    make_routing_table_record_key, make_subnet_list_record_key,
-    make_unassigned_nodes_config_record_key, FirewallRulesScope, ROOT_SUBNET_ID_KEY,
+    make_api_boundary_node_record_key, make_blessed_replica_versions_key,
+    make_firewall_rules_record_key, make_node_operator_record_key,
+    make_provisional_whitelist_record_key, make_replica_version_key, make_routing_table_record_key,
+    make_subnet_list_record_key, make_unassigned_nodes_config_record_key, FirewallRulesScope,
+    ROOT_SUBNET_ID_KEY,
 };
 use ic_registry_local_store::{Changelog, KeyMutation, LocalStoreImpl, LocalStoreWriter};
 use ic_registry_proto_data_provider::ProtoRegistryDataProvider;
@@ -86,6 +90,7 @@ pub struct TopologyConfig {
     subnets: BTreeMap<SubnetIndex, SubnetConfig>,
     subnet_ids: BTreeMap<SubnetIndex, SubnetId>,
     unassigned_nodes: BTreeMap<NodeIndex, NodeConfiguration>,
+    api_boundary_nodes: BTreeMap<NodeIndex, NodeConfiguration>,
 }
 
 impl TopologyConfig {
@@ -143,6 +148,21 @@ impl TopologyConfig {
             }
         }
         routing_table
+    }
+
+    pub fn insert_api_boundary_node(
+        &mut self,
+        idx: NodeIndex,
+        config: NodeConfiguration,
+    ) -> Result<()> {
+        if config.domain.is_none() {
+            return Err(anyhow!(
+                "Missing domain name: an API boundary node requires a domain name."
+            ));
+        }
+
+        self.api_boundary_nodes.insert(idx, config);
+        Ok(())
     }
 
     pub fn insert_unassigned_node(&mut self, idx: NodeIndex, nc: NodeConfiguration) {
@@ -204,6 +224,7 @@ impl From<NodeOperatorEntry> for NodeOperatorRecord {
 
 pub type InitializedTopology = BTreeMap<SubnetIndex, InitializedSubnet>;
 pub type UnassignedNodes = BTreeMap<NodeIndex, InitializedNode>;
+pub type ApiBoundaryNodes = BTreeMap<NodeIndex, InitializedNode>;
 
 #[derive(Clone, Debug)]
 pub struct IcConfig {
@@ -463,6 +484,27 @@ impl IcConfig {
             unassigned_nodes.insert(*n_idx, init_node);
         }
 
+        let mut api_boundary_nodes = BTreeMap::new();
+        for (n_idx, nc) in self.topology_config.api_boundary_nodes.iter() {
+            // create all the registry entries for the node
+            let node_path = InitializedSubnet::build_node_path(self.target_dir.as_path(), *n_idx);
+            let init_node = nc.clone().initialize(node_path)?;
+            init_node.write_registry_entries(&data_provider, version)?;
+            api_boundary_nodes.insert(*n_idx, init_node.clone());
+
+            // create the API boundary node registry entry
+            let api_bn_record = ApiBoundaryNodeRecord {
+                version: self.initial_replica_version_id.to_string(),
+            };
+            write_registry_entry(
+                &data_provider,
+                self.target_dir.as_path(),
+                &make_api_boundary_node_record_key(init_node.node_id),
+                version,
+                api_bn_record,
+            );
+        }
+
         // Set the routing table after initializing the subnet ids
         let routing_table_record = if self.generate_subnet_records {
             PbRoutingTable::from(if self.use_specified_ids_allocation_range {
@@ -643,6 +685,7 @@ impl IcConfig {
             target_dir: self.target_dir,
             initialized_topology,
             unassigned_nodes,
+            api_boundary_nodes,
         })
     }
 
@@ -810,6 +853,7 @@ pub struct InitializedIc {
     pub target_dir: PathBuf,
     pub initialized_topology: InitializedTopology,
     pub unassigned_nodes: UnassignedNodes,
+    pub api_boundary_nodes: ApiBoundaryNodes,
 }
 
 impl InitializedIc {

--- a/rs/prep/src/node.rs
+++ b/rs/prep/src/node.rs
@@ -302,6 +302,10 @@ pub struct NodeConfiguration {
     /// directory chosen by ic-prep.
     #[serde(skip_serializing, skip_deserializing)]
     pub secret_key_store: Option<NodeSecretKeyStore>,
+
+    /// The domain name of the node
+    #[serde(skip_serializing, skip_deserializing)]
+    pub domain: Option<String>,
 }
 
 impl From<NodeConfiguration> for pbNodeRecord {
@@ -319,6 +323,7 @@ impl From<NodeConfiguration> for pbNodeRecord {
                 .node_operator_principal_id
                 .map(|id| id.to_vec())
                 .unwrap_or_default(),
+            domain: node_configuration.domain,
             ..Default::default()
         }
     }
@@ -434,6 +439,7 @@ mod node_configuration {
             public_api: SocketAddr::from_str("1.2.3.4:8081").unwrap(),
             node_operator_principal_id: None,
             secret_key_store: None,
+            domain: None,
         };
 
         let got = pbNodeRecord::from(node_configuration);

--- a/rs/prep/src/prep_state_directory.rs
+++ b/rs/prep/src/prep_state_directory.rs
@@ -128,6 +128,7 @@ mod tests {
                 public_api: SocketAddr::from_str("1.2.3.4:8081").unwrap(),
                 node_operator_principal_id: None,
                 secret_key_store: None,
+                domain: None,
             },
         );
 

--- a/rs/registry/regedit/src/tests.rs
+++ b/rs/registry/regedit/src/tests.rs
@@ -134,6 +134,7 @@ pub fn run_ic_prep() -> (TempDir, IcPrepStateDir) {
             public_api: SocketAddr::from_str("0.0.0.0:8080").unwrap(),
             node_operator_principal_id: None,
             secret_key_store: None,
+            domain: None,
         },
     );
 

--- a/rs/replica_tests/src/lib.rs
+++ b/rs/replica_tests/src/lib.rs
@@ -218,6 +218,7 @@ pub fn get_ic_config() -> IcConfig {
             public_api: SocketAddr::from_str("128.0.0.1:1").expect("can't fail"),
             node_operator_principal_id: None,
             secret_key_store: Some(node_sks),
+            domain: None,
         },
     );
 

--- a/rs/starter/src/main.rs
+++ b/rs/starter/src/main.rs
@@ -100,6 +100,7 @@ fn main() -> Result<()> {
                 public_api,
                 node_operator_principal_id: None,
                 secret_key_store: None,
+                domain: None,
             },
         );
 

--- a/rs/tests/driver/src/driver/bootstrap.rs
+++ b/rs/tests/driver/src/driver/bootstrap.rs
@@ -172,6 +172,12 @@ pub fn init_ic(
         ic_topology.insert_unassigned_node(node_index as NodeIndex, node_to_config(node));
     }
 
+    for node in &ic.api_boundary_nodes {
+        let node_index = next_node_index;
+        next_node_index += 1;
+        ic_topology.insert_api_boundary_node(node_index as NodeIndex, node_to_config(node));
+    }
+
     let whitelist = ProvisionalWhitelist::All;
     let (ic_os_update_img_sha256, ic_os_update_img_url) = {
         if ic.has_malicious_behaviours() {
@@ -232,6 +238,9 @@ pub fn setup_and_start_vms(
         }
     }
     for node in initialized_ic.unassigned_nodes.values() {
+        nodes.push(node.clone());
+    }
+    for node in initialized_ic.api_boundary_nodes.values() {
         nodes.push(node.clone());
     }
 
@@ -565,6 +574,7 @@ fn node_to_config(node: &Node) -> NodeConfiguration {
         // this value will be overridden by IcConfig::with_node_operator()
         node_operator_principal_id: None,
         secret_key_store: node.secret_key_store.clone(),
+        domain: node.domain.clone(),
     }
 }
 

--- a/rs/tests/driver/src/driver/bootstrap.rs
+++ b/rs/tests/driver/src/driver/bootstrap.rs
@@ -175,7 +175,7 @@ pub fn init_ic(
     for node in &ic.api_boundary_nodes {
         let node_index = next_node_index;
         next_node_index += 1;
-        ic_topology.insert_api_boundary_node(node_index as NodeIndex, node_to_config(node));
+        ic_topology.insert_api_boundary_node(node_index as NodeIndex, node_to_config(node))?;
     }
 
     let whitelist = ProvisionalWhitelist::All;
@@ -490,6 +490,12 @@ fn create_config_disk_image(
             ipv4_config.prefix_length()
         ));
         cmd.arg("--ipv4_gateway").arg(ipv4_config.gateway_ip_addr());
+    }
+
+    // if the node has a domain name, generate a certificate to be used
+    // when the node is an API boundary node.
+    if let Some(domain_name) = &node.node_config.domain {
+        cmd.arg("--generate_ic_boundary_tls_cert").arg(domain_name);
     }
 
     if let Some(domain) = domain {

--- a/rs/tests/driver/src/driver/ic.rs
+++ b/rs/tests/driver/src/driver/ic.rs
@@ -225,27 +225,13 @@ impl InternetComputer {
     pub fn setup_and_start(&mut self, env: &TestEnv) -> Result<()> {
         // propagate required host features and resource settings to all vms
         let farm = Farm::from_test_env(env, "Internet Computer");
-        for subnet in self.subnets.iter_mut() {
-            for node in subnet.nodes.iter_mut() {
-                node.required_host_features = node
-                    .required_host_features
-                    .iter()
-                    .chain(self.required_host_features.iter())
-                    .cloned()
-                    .collect();
-                node.vm_resources = node.vm_resources.or(&self.default_vm_resources);
-            }
-        }
-        for node in self.unassigned_nodes.iter_mut() {
-            node.required_host_features = node
-                .required_host_features
-                .iter()
-                .chain(self.required_host_features.iter())
-                .cloned()
-                .collect();
-            node.vm_resources = node.vm_resources.or(&self.default_vm_resources);
-        }
-        for node in self.api_boundary_nodes.iter_mut() {
+        for node in self
+            .subnets
+            .iter_mut()
+            .flat_map(|subnet| subnet.nodes.iter_mut())
+            .chain(self.unassigned_nodes.iter_mut())
+            .chain(self.api_boundary_nodes.iter_mut())
+        {
             node.required_host_features = node
                 .required_host_features
                 .iter()

--- a/rs/tests/driver/src/driver/resource.rs
+++ b/rs/tests/driver/src/driver/resource.rs
@@ -195,6 +195,9 @@ pub fn get_resource_request(
     for n in &config.unassigned_nodes {
         res_req.add_vm_request(vm_spec_from_node(n, default_vm_resources));
     }
+    for n in &config.api_boundary_nodes {
+        res_req.add_vm_request(vm_spec_from_node(n, default_vm_resources));
+    }
     Ok(res_req)
 }
 

--- a/rs/tests/driver/src/driver/test_env_api.rs
+++ b/rs/tests/driver/src/driver/test_env_api.rs
@@ -304,6 +304,21 @@ impl std::fmt::Display for TopologySnapshot {
                 .unwrap();
             });
         });
+        if self.api_boundary_nodes().count() > 0 {
+            writeln!(f, "API boundary nodes:").unwrap();
+        }
+        self.api_boundary_nodes().enumerate().for_each(|(idx, n)| {
+            writeln!(
+                f,
+                "\tNode id={}, ipv6={:<width$}, domain_name={}, index={}",
+                n.node_id,
+                n.get_ip_addr(),
+                n.get_domain().map_or("n/a".to_string(), |domain| domain),
+                idx,
+                width = max_length_ipv6,
+            )
+            .unwrap()
+        });
         if self.unassigned_nodes().count() > 0 {
             writeln!(f, "Unassigned nodes:").unwrap();
         }

--- a/rs/tests/testing_verification/testnets/BUILD.bazel
+++ b/rs/tests/testing_verification/testnets/BUILD.bazel
@@ -146,6 +146,31 @@ system_test_nns(
 )
 
 system_test_nns(
+    name = "small_with_api_bn",
+    flaky = False,
+    proc_macro_deps = MACRO_DEPENDENCIES,
+    tags = [
+        "dynamic_testnet",
+        "manual",
+    ],
+    target_compatible_with = ["@platforms//os:linux"],  # requires libssh that does not build on Mac OS
+    runtime_deps = GUESTOS_RUNTIME_DEPS + BOUNDARY_NODE_GUESTOS_RUNTIME_DEPS + GRAFANA_RUNTIME_DEPS + [
+        "//rs/ledger_suite/icrc1/ledger:ledger_canister.wasm.gz",
+        "@ii_dev_canister//file",
+        "@nns_dapp_canister//file",
+        "@subnet_rental_canister//file",
+    ],
+    deps = [
+        # Keep sorted.
+        "//rs/registry/subnet_type",
+        "//rs/tests/consensus/utils",
+        "//rs/tests/driver:ic-system-test-driver",
+        "//rs/tests/nns/nns_dapp",
+        "@crate_index//:anyhow",
+    ],
+)
+
+system_test_nns(
     name = "small_with_query_stats",
     env = {
         "IC_ICRC1_LEDGER_WASM_PATH": "$(rootpath //rs/ledger_suite/icrc1/ledger:ledger_canister)",

--- a/rs/tests/testing_verification/testnets/small_with_api_bn.rs
+++ b/rs/tests/testing_verification/testnets/small_with_api_bn.rs
@@ -41,7 +41,7 @@ use ic_registry_subnet_type::SubnetType;
 use ic_system_test_driver::driver::{
     boundary_node::BoundaryNode,
     group::SystemTestGroup,
-    ic::{InternetComputer, Subnet},
+    ic::{InternetComputer, Node, Subnet},
     prometheus_vm::{HasPrometheus, PrometheusVm},
     test_env::TestEnv,
     test_env_api::{await_boundary_node_healthy, HasTopologySnapshot, NnsCustomizations},
@@ -63,8 +63,8 @@ pub fn setup(env: TestEnv) {
     InternetComputer::new()
         .add_subnet(Subnet::new(SubnetType::System).add_nodes(1))
         .add_subnet(Subnet::new(SubnetType::Application).add_nodes(1))
-        .with_unassigned_nodes(2)
-        .with_api_boundary_nodes(2)
+        .with_unassigned_node(Node::new().with_domain("api-bn.icp.app".to_string()))
+        .with_api_boundary_nodes(1)
         .setup_and_start(&env)
         .expect("Failed to setup IC under test");
     install_nns_with_customizations_and_check_progress(

--- a/rs/tests/testing_verification/testnets/small_with_api_bn.rs
+++ b/rs/tests/testing_verification/testnets/small_with_api_bn.rs
@@ -1,17 +1,20 @@
 // Set up a testnet containing:
-//   one 1-node System and one 1-node Application subnets, one unassigned node, single boundary node, and a p8s (with grafana) VM.
+//   one 1-node System and one 1-node Application subnets, one unassigned node with a domain
+//   (which could be turned into an API boundary node through a proposal), one API boundary node,
+//   a single boundary node (for HTTP gateway protocol support),
+//   and a p8s (with grafana) VM.
 // All replica nodes use the following resources: 6 vCPUs, 24GiB of RAM, and 50 GiB disk.
 //
 // You can setup this testnet with a lifetime of 180 mins by executing the following commands:
 //
 //   $ ./gitlab-ci/tools/docker-run
-//   $ ict testnet create small --lifetime-mins=180 --output-dir=./small -- --test_tmpdir=./small
+//   $ ict testnet create small_with_api_bns --lifetime-mins=180 --output-dir=./small -- --test_tmpdir=./small
 //
-// The --output-dir=./small will store the debug output of the test driver in the specified directory.
-// The --test_tmpdir=./small will store the remaining test output in the specified directory.
+// The --output-dir=./small_with_api_bns will store the debug output of the test driver in the specified directory.
+// The --test_tmpdir=./small_with_api_bns will store the remaining test output in the specified directory.
 // This is useful to have access to in case you need to SSH into an IC node for example like:
 //
-//   $ ssh -i small/_tmp/*/setup/ssh/authorized_priv_keys/admin admin@
+//   $ ssh -i small_with_api_bns/_tmp/*/setup/ssh/authorized_priv_keys/admin admin@
 //
 // Note that you can get the  address of the IC node from the ict console output:
 //
@@ -28,9 +31,9 @@
 //
 // To get access to P8s and Grafana look for the following lines in the ict console output:
 //
-//     prometheus: Prometheus Web UI at http://prometheus.small--1692597750709.testnet.farm.dfinity.systems,
-//     grafana: Grafana at http://grafana.small--1692597750709.testnet.farm.dfinity.systems,
-//     progress_clock: IC Progress Clock at http://grafana.small--1692597750709.testnet.farm.dfinity.systems/d/ic-progress-clock/ic-progress-clock?refresh=10su0026from=now-5mu0026to=now,
+//     prometheus: Prometheus Web UI at http://prometheus.small_with_api_bns--1692597750709.testnet.farm.dfinity.systems,
+//     grafana: Grafana at http://grafana.small_with_api_bns--1692597750709.testnet.farm.dfinity.systems,
+//     progress_clock: IC Progress Clock at http://grafana.small_with_api_bns--1692597750709.testnet.farm.dfinity.systems/d/ic-progress-clock/ic-progress-clock?refresh=10su0026from=now-5mu0026to=now,
 //
 // Happy testing!
 

--- a/rs/tests/testing_verification/testnets/small_with_api_bn.rs
+++ b/rs/tests/testing_verification/testnets/small_with_api_bn.rs
@@ -1,0 +1,83 @@
+// Set up a testnet containing:
+//   one 1-node System and one 1-node Application subnets, one unassigned node, single boundary node, and a p8s (with grafana) VM.
+// All replica nodes use the following resources: 6 vCPUs, 24GiB of RAM, and 50 GiB disk.
+//
+// You can setup this testnet with a lifetime of 180 mins by executing the following commands:
+//
+//   $ ./gitlab-ci/tools/docker-run
+//   $ ict testnet create small --lifetime-mins=180 --output-dir=./small -- --test_tmpdir=./small
+//
+// The --output-dir=./small will store the debug output of the test driver in the specified directory.
+// The --test_tmpdir=./small will store the remaining test output in the specified directory.
+// This is useful to have access to in case you need to SSH into an IC node for example like:
+//
+//   $ ssh -i small/_tmp/*/setup/ssh/authorized_priv_keys/admin admin@
+//
+// Note that you can get the  address of the IC node from the ict console output:
+//
+//   {
+//     nodes: [
+//       {
+//         id: y4g5e-dpl4n-swwhv-la7ec-32ngk-w7f3f-pr5bt-kqw67-2lmfy-agipc-zae,
+//         ipv6: 2a0b:21c0:4003:2:5034:46ff:fe3c:e76f
+//       }
+//     ],
+//     subnet_id: 5hv4k-srndq-xgw53-r6ldt-wtv4x-6xvbj-6lvpf-sbu5n-sqied-63bgv-eqe,
+//     subnet_type: application
+//   },
+//
+// To get access to P8s and Grafana look for the following lines in the ict console output:
+//
+//     prometheus: Prometheus Web UI at http://prometheus.small--1692597750709.testnet.farm.dfinity.systems,
+//     grafana: Grafana at http://grafana.small--1692597750709.testnet.farm.dfinity.systems,
+//     progress_clock: IC Progress Clock at http://grafana.small--1692597750709.testnet.farm.dfinity.systems/d/ic-progress-clock/ic-progress-clock?refresh=10su0026from=now-5mu0026to=now,
+//
+// Happy testing!
+
+use anyhow::Result;
+
+use ic_consensus_system_test_utils::rw_message::install_nns_with_customizations_and_check_progress;
+use ic_registry_subnet_type::SubnetType;
+use ic_system_test_driver::driver::{
+    boundary_node::BoundaryNode,
+    group::SystemTestGroup,
+    ic::{InternetComputer, Subnet},
+    prometheus_vm::{HasPrometheus, PrometheusVm},
+    test_env::TestEnv,
+    test_env_api::{await_boundary_node_healthy, HasTopologySnapshot, NnsCustomizations},
+};
+
+const BOUNDARY_NODE_NAME: &str = "boundary-node-1";
+
+fn main() -> Result<()> {
+    SystemTestGroup::new()
+        .with_setup(setup)
+        .execute_from_args()?;
+    Ok(())
+}
+
+pub fn setup(env: TestEnv) {
+    PrometheusVm::default()
+        .start(&env)
+        .expect("Failed to start prometheus VM");
+    InternetComputer::new()
+        .add_subnet(Subnet::new(SubnetType::System).add_nodes(1))
+        .add_subnet(Subnet::new(SubnetType::Application).add_nodes(1))
+        .with_unassigned_nodes(2)
+        .with_api_boundary_nodes(2)
+        .setup_and_start(&env)
+        .expect("Failed to setup IC under test");
+    install_nns_with_customizations_and_check_progress(
+        env.topology_snapshot(),
+        NnsCustomizations::default(),
+    );
+    BoundaryNode::new(String::from(BOUNDARY_NODE_NAME))
+        .allocate_vm(&env)
+        .expect("Allocation of BoundaryNode failed.")
+        .for_ic(&env, "")
+        .use_real_certs_and_dns()
+        .start(&env)
+        .expect("failed to setup BoundaryNode VM");
+    env.sync_with_prometheus();
+    await_boundary_node_healthy(&env, BOUNDARY_NODE_NAME);
+}


### PR DESCRIPTION
This PR adds the API BNs to the system test infrastructure such that one can spin up an IC with API boundary nodes. To this end, `ic-prep` has been extended (e.g., domain name in the node structs and the notion of API boundary nodes). In addition, the test driver has been extended to allow the addition of API boundary nodes. Finally, a small testnet with API BNs has been added to serve as an example.

In follow-up MRs, we can move some of the system tests (e.g., the API BN decentralization test).