### PR TITLE
feat(ckbtc): Support regtest network in new KYT canister

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5869,6 +5869,7 @@ name = "ic-btc-kyt"
 version = "0.9.0"
 dependencies = [
  "askama",
+ "base64 0.13.1",
  "bitcoin 0.32.3",
  "candid",
  "candid_parser",
@@ -5889,6 +5890,7 @@ dependencies = [
  "serde_json",
  "time",
  "tokio",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5874,6 +5874,7 @@ dependencies = [
  "candid_parser",
  "ciborium",
  "futures",
+ "hex",
  "ic-base-types",
  "ic-btc-interface",
  "ic-canisters-http-types",
@@ -5885,6 +5886,7 @@ dependencies = [
  "pocket-ic",
  "scraper",
  "serde",
+ "serde_json",
  "time",
  "tokio",
 ]

--- a/rs/bitcoin/kyt/BUILD.bazel
+++ b/rs/bitcoin/kyt/BUILD.bazel
@@ -22,10 +22,12 @@ rust_library(
         "@crate_index//:candid",
         "@crate_index//:ciborium",
         "@crate_index//:futures",
+        "@crate_index//:hex",
         "@crate_index//:ic-btc-interface",
         "@crate_index//:ic-cdk",
         "@crate_index//:ic-stable-structures",
         "@crate_index//:serde",
+        "@crate_index//:serde_json",
         "@crate_index//:time",
     ],
 )

--- a/rs/bitcoin/kyt/BUILD.bazel
+++ b/rs/bitcoin/kyt/BUILD.bazel
@@ -18,6 +18,7 @@ rust_library(
         # Keep sorted.
         "//rs/rust_canisters/http_types",
         "@crate_index//:askama",
+        "@crate_index//:base64",
         "@crate_index//:bitcoin_0_32",
         "@crate_index//:candid",
         "@crate_index//:ciborium",
@@ -29,6 +30,7 @@ rust_library(
         "@crate_index//:serde",
         "@crate_index//:serde_json",
         "@crate_index//:time",
+        "@crate_index//:url",
     ],
 )
 

--- a/rs/bitcoin/kyt/Cargo.toml
+++ b/rs/bitcoin/kyt/Cargo.toml
@@ -12,6 +12,7 @@ path = "src/main.rs"
 
 [dependencies]
 askama = { workspace = true }
+base64 = { workspace = true }
 bitcoin = { version = "0.32.2", default-features = false }
 candid = { workspace = true }
 ciborium = { workspace = true }
@@ -24,6 +25,7 @@ ic-stable-structures = { workspace = true }
 serde = { workspace = true }
 serde_json = {workspace = true }
 time = { workspace = true }
+url = { workspace = true }
 
 [dev-dependencies]
 candid_parser = { workspace = true }

--- a/rs/bitcoin/kyt/Cargo.toml
+++ b/rs/bitcoin/kyt/Cargo.toml
@@ -16,11 +16,13 @@ bitcoin = { version = "0.32.2", default-features = false }
 candid = { workspace = true }
 ciborium = { workspace = true }
 futures = { workspace = true }
+hex = { workspace = true }
 ic-btc-interface = { workspace = true }
 ic-canisters-http-types = { path = "../../rust_canisters/http_types" }
 ic-cdk = { workspace = true }
 ic-stable-structures = { workspace = true }
 serde = { workspace = true }
+serde_json = {workspace = true }
 time = { workspace = true }
 
 [dev-dependencies]

--- a/rs/bitcoin/kyt/btc_kyt_canister.did
+++ b/rs/bitcoin/kyt/btc_kyt_canister.did
@@ -64,7 +64,8 @@ type KytArg = variant {
 
 type BtcNetwork = variant {
     mainnet;
-    testnet
+    testnet;
+    regtest: record { json_rpc_url: text };
 };
 
 type KytMode = variant {

--- a/rs/bitcoin/kyt/src/dashboard/tests.rs
+++ b/rs/bitcoin/kyt/src/dashboard/tests.rs
@@ -16,10 +16,7 @@ fn mock_txid(v: usize) -> Txid {
 
 #[test]
 fn should_display_metadata() {
-    let config = Config {
-        btc_network: BtcNetwork::Mainnet,
-        kyt_mode: KytMode::Normal,
-    };
+    let config = Config::new_and_validate(BtcNetwork::Mainnet, KytMode::Normal).unwrap();
     let outcall_capacity = 50;
     let cached_entries = 0;
     let oldest_entry_time = 0;
@@ -36,8 +33,8 @@ fn should_display_metadata() {
     };
 
     DashboardAssert::assert_that(dashboard)
-        .has_btc_network_in_title(config.btc_network)
-        .has_kyt_mode(config.kyt_mode)
+        .has_btc_network_in_title(config.btc_network())
+        .has_kyt_mode(config.kyt_mode())
         .has_outcall_capacity(outcall_capacity)
         .has_cached_entries(cached_entries)
         .has_oldest_entry_time(oldest_entry_time)
@@ -77,10 +74,7 @@ fn should_display_statuses() {
     });
 
     let dashboard = DashboardTemplate {
-        config: Config {
-            btc_network: BtcNetwork::Mainnet,
-            kyt_mode: KytMode::Normal,
-        },
+        config: Config::new_and_validate(BtcNetwork::Mainnet, KytMode::Normal).unwrap(),
         outcall_capacity: 50,
         cached_entries: 6,
         tx_table_page_size: 10,
@@ -120,10 +114,9 @@ fn test_pagination() {
     use askama::Template;
     use scraper::{Html, Selector};
 
-    state::set_config(state::Config {
-        btc_network: BtcNetwork::Mainnet,
-        kyt_mode: KytMode::Normal,
-    });
+    state::set_config(
+        state::Config::new_and_validate(BtcNetwork::Mainnet, KytMode::Normal).unwrap(),
+    );
     let mock_transaction = TransactionKytData::from_transaction(
         &BtcNetwork::Mainnet,
         Transaction {

--- a/rs/bitcoin/kyt/src/fetch.rs
+++ b/rs/bitcoin/kyt/src/fetch.rs
@@ -81,13 +81,13 @@ pub trait FetchEnv {
     ) -> TryFetchResult<impl futures::Future<Output = Result<FetchResult, Infallible>>> {
         let (provider, max_response_bytes) = match state::get_fetch_status(txid) {
             None => (
-                providers::next_provider(self.config().btc_network),
+                providers::next_provider(self.config().btc_network()),
                 INITIAL_MAX_RESPONSE_BYTES,
             ),
             Some(FetchTxStatus::PendingRetry {
                 max_response_bytes, ..
             }) => (
-                providers::next_provider(self.config().btc_network),
+                providers::next_provider(self.config().btc_network()),
                 max_response_bytes,
             ),
             Some(FetchTxStatus::PendingOutcall { .. }) => return TryFetchResult::Pending,

--- a/rs/bitcoin/kyt/src/fetch.rs
+++ b/rs/bitcoin/kyt/src/fetch.rs
@@ -63,7 +63,7 @@ pub trait FetchEnv {
 
     async fn http_get_tx(
         &self,
-        provider: providers::Provider,
+        provider: &providers::Provider,
         txid: Txid,
         max_response_bytes: u32,
     ) -> Result<Transaction, HttpGetTxError>;
@@ -127,7 +127,7 @@ pub trait FetchEnv {
         txid: Txid,
         max_response_bytes: u32,
     ) -> Result<FetchResult, Infallible> {
-        match self.http_get_tx(provider, txid, max_response_bytes).await {
+        match self.http_get_tx(&provider, txid, max_response_bytes).await {
             Ok(tx) => {
                 let input_addresses = tx.input.iter().map(|_| None).collect();
                 match TransactionKytData::from_transaction(provider.btc_network(), tx.clone()) {

--- a/rs/bitcoin/kyt/src/fetch/tests.rs
+++ b/rs/bitcoin/kyt/src/fetch/tests.rs
@@ -45,14 +45,14 @@ impl FetchEnv for MockEnv {
 
     async fn http_get_tx(
         &self,
-        provider: Provider,
+        provider: &Provider,
         txid: Txid,
         max_response_bytes: u32,
     ) -> Result<Transaction, HttpGetTxError> {
         self.calls
             .borrow_mut()
             .push_back((txid, max_response_bytes));
-        *self.called_provider.borrow_mut() = Some(provider);
+        *self.called_provider.borrow_mut() = Some(provider.clone());
         self.replies
             .borrow_mut()
             .pop_front()
@@ -192,7 +192,7 @@ async fn test_mock_env() {
     let txid = mock_txid(0);
     env.expect_get_tx_with_reply(Ok(mock_transaction()));
     let result = env
-        .http_get_tx(provider, txid, INITIAL_MAX_RESPONSE_BYTES)
+        .http_get_tx(&provider, txid, INITIAL_MAX_RESPONSE_BYTES)
         .await;
     assert!(result.is_ok());
     env.assert_get_tx_call(txid, INITIAL_MAX_RESPONSE_BYTES);
@@ -264,7 +264,7 @@ async fn test_fetch_tx() {
 
     env.expect_get_tx_with_reply(Ok(tx_0.clone()));
     let result = env
-        .fetch_tx((), provider, txid_0, INITIAL_MAX_RESPONSE_BYTES)
+        .fetch_tx((), provider.clone(), txid_0, INITIAL_MAX_RESPONSE_BYTES)
         .await;
     assert!(matches!(result, Ok(FetchResult::Fetched(_))));
     assert!(matches!(
@@ -281,7 +281,7 @@ async fn test_fetch_tx() {
     // case RetryWithBiggerBuffer
     env.expect_get_tx_with_reply(Err(HttpGetTxError::ResponseTooLarge));
     let result = env
-        .fetch_tx((), provider, txid_1, INITIAL_MAX_RESPONSE_BYTES)
+        .fetch_tx((), provider.clone(), txid_1, INITIAL_MAX_RESPONSE_BYTES)
         .await;
     assert!(matches!(result, Ok(FetchResult::RetryWithBiggerBuffer)));
     assert!(matches!(
@@ -293,7 +293,7 @@ async fn test_fetch_tx() {
         "failed to decode tx".to_string(),
     )));
     let result = env
-        .fetch_tx((), provider, txid_2, INITIAL_MAX_RESPONSE_BYTES)
+        .fetch_tx((), provider.clone(), txid_2, INITIAL_MAX_RESPONSE_BYTES)
         .await;
     assert!(matches!(
         result,
@@ -523,7 +523,7 @@ async fn test_check_fetched() {
     state::set_fetch_status(
         txid_2,
         FetchTxStatus::Error(FetchTxStatusError {
-            provider,
+            provider: provider.clone(),
             max_response_bytes: RETRY_MAX_RESPONSE_BYTES,
             error: HttpGetTxError::Rejected {
                 code: RejectionCode::SysTransient,

--- a/rs/bitcoin/kyt/src/lib.rs
+++ b/rs/bitcoin/kyt/src/lib.rs
@@ -151,7 +151,7 @@ impl FetchEnv for KytCanisterEnv {
 ///    in order to compute their corresponding addresses.
 pub async fn check_transaction_inputs(txid: Txid) -> CheckTransactionResponse {
     let env = &KytCanisterEnv;
-    match env.config().kyt_mode {
+    match env.config().kyt_mode() {
         KytMode::AcceptAll => CheckTransactionResponse::Passed,
         KytMode::RejectAll => CheckTransactionResponse::Failed(Vec::new()),
         KytMode::Normal => {

--- a/rs/bitcoin/kyt/src/lib.rs
+++ b/rs/bitcoin/kyt/src/lib.rs
@@ -60,7 +60,7 @@ impl FetchEnv for KytCanisterEnv {
 
     async fn http_get_tx(
         &self,
-        provider: providers::Provider,
+        provider: &providers::Provider,
         txid: Txid,
         max_response_bytes: u32,
     ) -> Result<Transaction, HttpGetTxError> {

--- a/rs/bitcoin/kyt/src/main.rs
+++ b/rs/bitcoin/kyt/src/main.rs
@@ -19,7 +19,7 @@ fn check_address(args: CheckAddressArgs) -> CheckAddressResponse {
     let btc_network = config.btc_network;
     let address = Address::from_str(args.address.trim())
         .unwrap_or_else(|err| ic_cdk::trap(&format!("Invalid bitcoin address: {}", err)))
-        .require_network(btc_network.into())
+        .require_network(btc_network.clone().into())
         .unwrap_or_else(|err| {
             ic_cdk::trap(&format!("Not a bitcoin {} address: {}", btc_network, err))
         });

--- a/rs/bitcoin/kyt/src/providers.rs
+++ b/rs/bitcoin/kyt/src/providers.rs
@@ -153,14 +153,21 @@ fn make_post_request(
     txid: Txid,
     max_response_bytes: u32,
 ) -> CanisterHttpRequestArgument {
-    let body = format!("{{\"jsonrpc\": \"1.0\", \"id\": \"curltest\", \"method\": \"getrawtransaction\", \"params\": [\"{}\", true]}}", txid);
+    let request_headers = vec![HttpHeader {
+        name: "Authorization".to_string(),
+        value: "Basic aWMtYnRjLWludGVncmF0aW9uOlFQUWlOYXBoMTlGcVVzQ3JCUk4wRklJN2x5TTI2QjUxZkFNZUJRekNiLUU9".to_string(),
+    }];
+    let body = format!(
+        "{{\"method\": \"gettransaction\", \"params\": [\"{}\"]}}",
+        txid
+    );
     CanisterHttpRequestArgument {
         url: json_rpc_url.to_string(),
         method: HttpMethod::POST,
         body: Some(body.as_bytes().to_vec()),
         max_response_bytes: Some(max_response_bytes as u64),
         transform: param_transform(),
-        headers: vec![],
+        headers: request_headers,
     }
 }
 

--- a/rs/bitcoin/kyt/src/providers/tests.rs
+++ b/rs/bitcoin/kyt/src/providers/tests.rs
@@ -1,0 +1,29 @@
+use super::*;
+
+#[test]
+fn test_parse_authorization_header_from_url() {
+    let result = parse_authorization_header_from_url("http://localhost:3030");
+    assert!(matches!(result, Err(err) if err.contains("Missing username")));
+
+    let result = parse_authorization_header_from_url("http://guest@localhost:3030");
+    assert!(matches!(result, Err(err) if err.contains("Missing password")));
+
+    let result = parse_authorization_header_from_url("http://guest:pass@localhost:3030");
+    assert!(result.is_ok());
+    let (url, header) = result.unwrap();
+    assert_eq!(url.to_string(), "http://localhost:3030/");
+    assert_eq!(
+        header.value,
+        format!("Basic {}", base64::encode("guest:pass"))
+    );
+
+    // The following would have failed if there was no url_decode
+    let result = parse_authorization_header_from_url("http://guest:pa=ss@localhost:3030");
+    assert!(result.is_ok());
+    let (url, header) = result.unwrap();
+    assert_eq!(url.to_string(), "http://localhost:3030/");
+    assert_eq!(
+        header.value,
+        format!("Basic {}", base64::encode("guest:pa=ss"))
+    );
+}

--- a/rs/bitcoin/kyt/src/state.rs
+++ b/rs/bitcoin/kyt/src/state.rs
@@ -92,8 +92,11 @@ impl TransactionKytData {
             // Some outputs do not have addresses. These outputs will never be
             // inputs of other transactions, so it is okay to treat them as `None`.
             outputs.push(
-                Address::from_script(&output.script_pubkey, bitcoin::Network::from(*btc_network))
-                    .ok(),
+                Address::from_script(
+                    &output.script_pubkey,
+                    bitcoin::Network::from(btc_network.clone()),
+                )
+                .ok(),
             )
         }
         Ok(Self { inputs, outputs })

--- a/rs/bitcoin/kyt/src/state.rs
+++ b/rs/bitcoin/kyt/src/state.rs
@@ -1,5 +1,5 @@
 use crate::{
-    providers::Provider,
+    providers::{parse_authorization_header_from_url, Provider},
     types::{BtcNetwork, KytMode},
 };
 use bitcoin::{Address, Transaction};
@@ -263,8 +263,28 @@ impl Drop for FetchGuard {
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Config {
-    pub btc_network: BtcNetwork,
-    pub kyt_mode: KytMode,
+    btc_network: BtcNetwork,
+    kyt_mode: KytMode,
+}
+
+impl Config {
+    pub fn new_and_validate(btc_network: BtcNetwork, kyt_mode: KytMode) -> Result<Self, String> {
+        if let BtcNetwork::Regtest { json_rpc_url } = &btc_network {
+            let _ = parse_authorization_header_from_url(json_rpc_url)?;
+        }
+        Ok(Self {
+            btc_network,
+            kyt_mode,
+        })
+    }
+
+    pub fn btc_network(&self) -> BtcNetwork {
+        self.btc_network.clone()
+    }
+
+    pub fn kyt_mode(&self) -> KytMode {
+        self.kyt_mode
+    }
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/rs/bitcoin/kyt/src/types.rs
+++ b/rs/bitcoin/kyt/src/types.rs
@@ -85,12 +85,14 @@ pub struct InitArg {
     pub kyt_mode: KytMode,
 }
 
-#[derive(CandidType, Clone, Copy, Deserialize, Debug, Eq, PartialEq, Serialize, Hash)]
+#[derive(CandidType, Clone, Deserialize, Debug, Eq, PartialEq, Serialize, Hash)]
 pub enum BtcNetwork {
     #[serde(rename = "mainnet")]
     Mainnet,
     #[serde(rename = "testnet")]
     Testnet,
+    #[serde(rename = "regtest")]
+    Regtest { json_rpc_url: String },
 }
 
 #[derive(CandidType, Clone, Copy, Deserialize, Debug, Eq, PartialEq, Serialize, Hash)]
@@ -115,6 +117,7 @@ impl From<BtcNetwork> for bitcoin::Network {
         match btc_network {
             BtcNetwork::Mainnet => Self::Bitcoin,
             BtcNetwork::Testnet => Self::Testnet,
+            BtcNetwork::Regtest { .. } => Self::Regtest,
         }
     }
 }
@@ -124,6 +127,7 @@ impl fmt::Display for BtcNetwork {
         match self {
             Self::Mainnet => write!(f, "mainnet"),
             Self::Testnet => write!(f, "testnet"),
+            Self::Regtest { .. } => write!(f, "regtest"),
         }
     }
 }

--- a/rs/bitcoin/kyt/templates/dashboard.html
+++ b/rs/bitcoin/kyt/templates/dashboard.html
@@ -12,6 +12,8 @@
             <a href="https://live.blockcypher.com/btc/tx/{{txid}}"><code>{{txid}}</code></a>
         {%- when crate::BtcNetwork::Testnet -%}
             <a href="https://live.blockcypher.com/btc-testnet/tx/{{txid}}"><code>{{txid}}</code></a>
+        {%- when _ -%}
+            <code>{{txid}}</code>
     {% endmatch %}
 {%- endmacro %}
 

--- a/rs/bitcoin/kyt/templates/dashboard.html
+++ b/rs/bitcoin/kyt/templates/dashboard.html
@@ -7,7 +7,7 @@
 {%- endmacro %}
 
 {% macro btc_tx_link(txid) -%}
-    {% match config.btc_network %}
+    {% match config.btc_network() %}
         {%- when crate::BtcNetwork::Mainnet -%}
             <a href="https://live.blockcypher.com/btc/tx/{{txid}}"><code>{{txid}}</code></a>
         {%- when crate::BtcNetwork::Testnet -%}
@@ -34,7 +34,7 @@
 <html lang="en">
 
 <head>
-    <title>KYT Canister Dashboard for Bitcoin ({{ config.btc_network }})</title>
+    <title>KYT Canister Dashboard for Bitcoin ({{ config.btc_network() }})</title>
     <style>
         details {
             margin-right: 1rem;
@@ -128,13 +128,13 @@
 <body>
     <div class="background">
         <div class="content">
-            <h2>KYT Canister Dashboard for Bitcoin ({{ config.btc_network }})</h2>
+            <h2>KYT Canister Dashboard for Bitcoin ({{ config.btc_network() }})</h2>
             <h3>Metadata</h3>
             <table>
                 <tbody>
                     <tr id="kyt-mode">
                         <th>KYT Mode</th>
-                        <td><code>{{ config.kyt_mode }}</code></td>
+                        <td><code>{{ config.kyt_mode() }}</code></td>
                     </tr>
                     <tr id="outcall-capacity">
                         <th>Outcall Capacity</th>


### PR DESCRIPTION
Support bitcoin regtest network for local testing by adding an option to specify bitcoind JSON RPC URL.

However, because bitcoind only supports HTTP protocol, one needs to find a workaround because by default canister HTTPs outcall will not work with plain HTTP. This can be achieved with one of the following methods:
 
1. Compile and use pocket-ic-server after enabling the "http" feature in the ic-https-outcalls-adapter crate, or
2. Set up reverse HTTPS proxy to connect to bitcoind.

The first approach has been tested manually and the second approach will be used in a followup PR that adapts ckbtc system tests after the new KYT canister is enabled.