### PR TITLE
fix(IDX): bump to thiserror v1.0.65 in Bazel

### DIFF
--- a/Cargo.Bazel.Fuzzing.json.lock
+++ b/Cargo.Bazel.Fuzzing.json.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "f8b4c5c79984a20a396e4fc13a32288840085a7d1a4e48cef5a5f312a57d464c",
+  "checksum": "753c222bd9690e54837729011cff67fc8e7e9af7fbb8af9e9fd2e48d08199936",
   "crates": {
     "abnf 0.12.0": {
       "name": "abnf",
@@ -1648,7 +1648,7 @@
               "target": "serde_json"
             },
             {
-              "id": "thiserror 1.0.64",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             },
             {
@@ -2863,7 +2863,7 @@
               "target": "rusticata_macros"
             },
             {
-              "id": "thiserror 1.0.64",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             },
             {
@@ -3788,7 +3788,7 @@
         "deps": {
           "common": [
             {
-              "id": "thiserror 1.0.64",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             },
             {
@@ -4096,7 +4096,7 @@
               "target": "rustls_pki_types"
             },
             {
-              "id": "thiserror 1.0.64",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             },
             {
@@ -9556,7 +9556,7 @@
               "target": "once_cell"
             },
             {
-              "id": "thiserror 1.0.64",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             }
           ],
@@ -9624,7 +9624,7 @@
               "target": "once_cell"
             },
             {
-              "id": "thiserror 1.0.64",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             }
           ],
@@ -9693,7 +9693,7 @@
               "target": "once_cell"
             },
             {
-              "id": "thiserror 1.0.64",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             }
           ],
@@ -10198,7 +10198,7 @@
               "target": "serde_bytes"
             },
             {
-              "id": "thiserror 1.0.64",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             }
           ],
@@ -10398,7 +10398,7 @@
               "target": "pretty"
             },
             {
-              "id": "thiserror 1.0.64",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             }
           ],
@@ -12237,7 +12237,7 @@
               "target": "serde_with"
             },
             {
-              "id": "thiserror 1.0.64",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             },
             {
@@ -18435,7 +18435,7 @@
               "target": "textplots"
             },
             {
-              "id": "thiserror 1.0.64",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             },
             {
@@ -19549,7 +19549,7 @@
               "target": "sha2"
             },
             {
-              "id": "thiserror 1.0.64",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             },
             {
@@ -20905,7 +20905,7 @@
               "target": "sha3"
             },
             {
-              "id": "thiserror 1.0.64",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             },
             {
@@ -21194,7 +21194,7 @@
               "target": "strum"
             },
             {
-              "id": "thiserror 1.0.64",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             },
             {
@@ -21584,7 +21584,7 @@
               "target": "strum"
             },
             {
-              "id": "thiserror 1.0.64",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             },
             {
@@ -22710,7 +22710,7 @@
               "target": "nonempty"
             },
             {
-              "id": "thiserror 1.0.64",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             }
           ],
@@ -25872,7 +25872,7 @@
               "target": "rustls_pemfile"
             },
             {
-              "id": "thiserror 1.0.64",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             },
             {
@@ -26017,7 +26017,7 @@
               "target": "smallvec"
             },
             {
-              "id": "thiserror 1.0.64",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             },
             {
@@ -27657,7 +27657,7 @@
               "target": "hyper_util"
             },
             {
-              "id": "thiserror 1.0.64",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             },
             {
@@ -28160,7 +28160,7 @@
               "target": "simple_asn1"
             },
             {
-              "id": "thiserror 1.0.64",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             },
             {
@@ -28389,7 +28389,7 @@
               "target": "sync_wrapper"
             },
             {
-              "id": "thiserror 1.0.64",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             },
             {
@@ -28680,7 +28680,7 @@
               "target": "sha2"
             },
             {
-              "id": "thiserror 1.0.64",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             }
           ],
@@ -28743,7 +28743,7 @@
               "target": "nom"
             },
             {
-              "id": "thiserror 1.0.64",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             }
           ],
@@ -29504,7 +29504,7 @@
               "target": "sha2"
             },
             {
-              "id": "thiserror 1.0.64",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             }
           ],
@@ -29693,7 +29693,7 @@
               "target": "serde"
             },
             {
-              "id": "thiserror 1.0.64",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             },
             {
@@ -29787,7 +29787,7 @@
               "target": "ic_utils"
             },
             {
-              "id": "thiserror 1.0.64",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             }
           ],
@@ -29979,7 +29979,7 @@
               "target": "sha2"
             },
             {
-              "id": "thiserror 1.0.64",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             },
             {
@@ -30233,7 +30233,7 @@
               "target": "sha2"
             },
             {
-              "id": "thiserror 1.0.64",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             }
           ],
@@ -30331,7 +30331,7 @@
               "target": "strum"
             },
             {
-              "id": "thiserror 1.0.64",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             },
             {
@@ -30597,7 +30597,7 @@
               "target": "serde_json"
             },
             {
-              "id": "thiserror 1.0.64",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             },
             {
@@ -30935,7 +30935,7 @@
               "target": "sha2"
             },
             {
-              "id": "thiserror 1.0.64",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             }
           ],
@@ -30997,7 +30997,7 @@
               "target": "serde"
             },
             {
-              "id": "thiserror 1.0.64",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             }
           ],
@@ -33024,7 +33024,7 @@
               "target": "serde_json"
             },
             {
-              "id": "thiserror 1.0.64",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             }
           ],
@@ -33436,7 +33436,7 @@
               "target": "serde"
             },
             {
-              "id": "thiserror 1.0.64",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             }
           ],
@@ -33932,7 +33932,7 @@
               "target": "serde_json"
             },
             {
-              "id": "thiserror 1.0.64",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             }
           ],
@@ -34541,7 +34541,7 @@
               "target": "serde_yaml"
             },
             {
-              "id": "thiserror 1.0.64",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             },
             {
@@ -34632,7 +34632,7 @@
               "target": "serde_json"
             },
             {
-              "id": "thiserror 1.0.64",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             }
           ],
@@ -36888,7 +36888,7 @@
         "deps": {
           "common": [
             {
-              "id": "thiserror 1.0.64",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             }
           ],
@@ -39700,7 +39700,7 @@
               "target": "tagptr"
             },
             {
-              "id": "thiserror 1.0.64",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             },
             {
@@ -40163,7 +40163,7 @@
               "target": "strum"
             },
             {
-              "id": "thiserror 1.0.64",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             }
           ],
@@ -42278,7 +42278,7 @@
               "target": "sha2"
             },
             {
-              "id": "thiserror 1.0.64",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             }
           ],
@@ -42596,7 +42596,7 @@
               "target": "pin_project_lite"
             },
             {
-              "id": "thiserror 1.0.64",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             },
             {
@@ -42680,7 +42680,7 @@
               "target": "pin_project_lite"
             },
             {
-              "id": "thiserror 1.0.64",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             }
           ],
@@ -42772,7 +42772,7 @@
               "target": "prost"
             },
             {
-              "id": "thiserror 1.0.64",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             },
             {
@@ -43114,7 +43114,7 @@
               "target": "pin_project_lite"
             },
             {
-              "id": "thiserror 1.0.64",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             }
           ],
@@ -43197,7 +43197,7 @@
               "target": "pin_project_lite"
             },
             {
-              "id": "thiserror 1.0.64",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             },
             {
@@ -43298,7 +43298,7 @@
               "target": "rand"
             },
             {
-              "id": "thiserror 1.0.64",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             }
           ],
@@ -43407,7 +43407,7 @@
               "target": "regex"
             },
             {
-              "id": "thiserror 1.0.64",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             }
           ],
@@ -43519,7 +43519,7 @@
               "target": "rand"
             },
             {
-              "id": "thiserror 1.0.64",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             },
             {
@@ -43636,7 +43636,7 @@
               "target": "serde_json"
             },
             {
-              "id": "thiserror 1.0.64",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             },
             {
@@ -45082,7 +45082,7 @@
               "target": "memchr"
             },
             {
-              "id": "thiserror 1.0.64",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             },
             {
@@ -46095,7 +46095,7 @@
               "target": "socket2"
             },
             {
-              "id": "thiserror 1.0.64",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             }
           ],
@@ -47033,7 +47033,7 @@
               "target": "tempfile"
             },
             {
-              "id": "thiserror 1.0.64",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             }
           ],
@@ -48577,7 +48577,7 @@
               "target": "protobuf"
             },
             {
-              "id": "thiserror 1.0.64",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             }
           ],
@@ -50155,7 +50155,7 @@
               "target": "socket2"
             },
             {
-              "id": "thiserror 1.0.64",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             },
             {
@@ -50243,7 +50243,7 @@
               "target": "slab"
             },
             {
-              "id": "thiserror 1.0.64",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             },
             {
@@ -51550,7 +51550,7 @@
               "target": "parking_lot"
             },
             {
-              "id": "thiserror 1.0.64",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             }
           ],
@@ -52046,7 +52046,7 @@
               "target": "syscall"
             },
             {
-              "id": "thiserror 1.0.64",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             }
           ],
@@ -55590,7 +55590,7 @@
               "target": "serde_json"
             },
             {
-              "id": "thiserror 1.0.64",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             },
             {
@@ -58656,7 +58656,7 @@
               "target": "serde"
             },
             {
-              "id": "thiserror 1.0.64",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             }
           ],
@@ -60211,7 +60211,7 @@
               "target": "num_traits"
             },
             {
-              "id": "thiserror 1.0.64",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             },
             {
@@ -63535,7 +63535,7 @@
               "target": "static_assertions"
             },
             {
-              "id": "thiserror 1.0.64",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             },
             {
@@ -64294,14 +64294,14 @@
       ],
       "license_file": "LICENSE"
     },
-    "thiserror 1.0.64": {
+    "thiserror 1.0.65": {
       "name": "thiserror",
-      "version": "1.0.64",
+      "version": "1.0.65",
       "package_url": "https://github.com/dtolnay/thiserror",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/thiserror/1.0.64/download",
-          "sha256": "d50af8abc119fb8bb6dbabcfa89656f46f84aa0ac7688088608076ad2b459a84"
+          "url": "https://static.crates.io/crates/thiserror/1.0.65/download",
+          "sha256": "5d11abd9594d9b38965ef50805c5e469ca9cc6f197f883f717e0269a3057b3d5"
         }
       },
       "targets": [
@@ -64338,7 +64338,7 @@
         "deps": {
           "common": [
             {
-              "id": "thiserror 1.0.64",
+              "id": "thiserror 1.0.65",
               "target": "build_script_build"
             }
           ],
@@ -64348,13 +64348,13 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "thiserror-impl 1.0.64",
+              "id": "thiserror-impl 1.0.65",
               "target": "thiserror_impl"
             }
           ],
           "selects": {}
         },
-        "version": "1.0.64"
+        "version": "1.0.65"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -64368,14 +64368,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "thiserror-impl 1.0.64": {
+    "thiserror-impl 1.0.65": {
       "name": "thiserror-impl",
-      "version": "1.0.64",
+      "version": "1.0.65",
       "package_url": "https://github.com/dtolnay/thiserror",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/thiserror-impl/1.0.64/download",
-          "sha256": "08904e7672f5eb876eaaf87e0ce17857500934f4981c4a0ab2b4aa98baac7fc3"
+          "url": "https://static.crates.io/crates/thiserror-impl/1.0.65/download",
+          "sha256": "ae71770322cbd277e69d762a16c444af02aa0575ac0d174f0b9562d3b37f8602"
         }
       },
       "targets": [
@@ -64415,7 +64415,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "1.0.64"
+        "version": "1.0.65"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -66011,7 +66011,7 @@
               "target": "futures_util"
             },
             {
-              "id": "thiserror 1.0.64",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             },
             {
@@ -67325,7 +67325,7 @@
               "target": "pin_project"
             },
             {
-              "id": "thiserror 1.0.64",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             },
             {
@@ -67459,7 +67459,7 @@
               "target": "crossbeam_channel"
             },
             {
-              "id": "thiserror 1.0.64",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             },
             {
@@ -68287,7 +68287,7 @@
               "target": "smallvec"
             },
             {
-              "id": "thiserror 1.0.64",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             },
             {
@@ -68403,7 +68403,7 @@
               "target": "smallvec"
             },
             {
-              "id": "thiserror 1.0.64",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             },
             {
@@ -68551,7 +68551,7 @@
               "target": "sha1"
             },
             {
-              "id": "thiserror 1.0.64",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             },
             {
@@ -72109,7 +72109,7 @@
               "target": "target_lexicon"
             },
             {
-              "id": "thiserror 1.0.64",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             },
             {
@@ -76251,7 +76251,7 @@
               "target": "rusticata_macros"
             },
             {
-              "id": "thiserror 1.0.64",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             },
             {
@@ -78703,7 +78703,7 @@
     "test-strategy 0.3.1",
     "tester 0.7.0",
     "textplots 0.8.4",
-    "thiserror 1.0.64",
+    "thiserror 1.0.65",
     "thousands 0.2.0",
     "threadpool 1.8.1",
     "tikv-jemalloc-ctl 0.5.4",

--- a/Cargo.Bazel.Fuzzing.toml.lock
+++ b/Cargo.Bazel.Fuzzing.toml.lock
@@ -10867,18 +10867,18 @@ checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
 
 [[package]]
 name = "thiserror"
-version = "1.0.64"
+version = "1.0.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d50af8abc119fb8bb6dbabcfa89656f46f84aa0ac7688088608076ad2b459a84"
+checksum = "5d11abd9594d9b38965ef50805c5e469ca9cc6f197f883f717e0269a3057b3d5"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.64"
+version = "1.0.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08904e7672f5eb876eaaf87e0ce17857500934f4981c4a0ab2b4aa98baac7fc3"
+checksum = "ae71770322cbd277e69d762a16c444af02aa0575ac0d174f0b9562d3b37f8602"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.Bazel.json.lock
+++ b/Cargo.Bazel.json.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "7d6315901415b36b0e75876824e88368a8e546aa1b4aa4caa8c6bd5789443ec2",
+  "checksum": "d58c1f74bfe0c229a35606ef8239233712c7af0371c45bec85d1cffaf5705e5e",
   "crates": {
     "abnf 0.12.0": {
       "name": "abnf",
@@ -1652,7 +1652,7 @@
               "target": "serde_json"
             },
             {
-              "id": "thiserror 1.0.64",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             },
             {
@@ -2867,7 +2867,7 @@
               "target": "rusticata_macros"
             },
             {
-              "id": "thiserror 1.0.64",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             },
             {
@@ -3792,7 +3792,7 @@
         "deps": {
           "common": [
             {
-              "id": "thiserror 1.0.64",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             },
             {
@@ -4100,7 +4100,7 @@
               "target": "rustls_pki_types"
             },
             {
-              "id": "thiserror 1.0.64",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             },
             {
@@ -9469,7 +9469,7 @@
               "target": "once_cell"
             },
             {
-              "id": "thiserror 1.0.64",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             }
           ],
@@ -9537,7 +9537,7 @@
               "target": "once_cell"
             },
             {
-              "id": "thiserror 1.0.64",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             }
           ],
@@ -9606,7 +9606,7 @@
               "target": "once_cell"
             },
             {
-              "id": "thiserror 1.0.64",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             }
           ],
@@ -10111,7 +10111,7 @@
               "target": "serde_bytes"
             },
             {
-              "id": "thiserror 1.0.64",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             }
           ],
@@ -10289,7 +10289,7 @@
               "target": "pretty"
             },
             {
-              "id": "thiserror 1.0.64",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             }
           ],
@@ -12128,7 +12128,7 @@
               "target": "serde_with"
             },
             {
-              "id": "thiserror 1.0.64",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             },
             {
@@ -18258,7 +18258,7 @@
               "target": "textplots"
             },
             {
-              "id": "thiserror 1.0.64",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             },
             {
@@ -19372,7 +19372,7 @@
               "target": "sha2"
             },
             {
-              "id": "thiserror 1.0.64",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             },
             {
@@ -20749,7 +20749,7 @@
               "target": "sha3"
             },
             {
-              "id": "thiserror 1.0.64",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             },
             {
@@ -21037,7 +21037,7 @@
               "target": "strum"
             },
             {
-              "id": "thiserror 1.0.64",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             },
             {
@@ -21427,7 +21427,7 @@
               "target": "strum"
             },
             {
-              "id": "thiserror 1.0.64",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             },
             {
@@ -22553,7 +22553,7 @@
               "target": "nonempty"
             },
             {
-              "id": "thiserror 1.0.64",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             }
           ],
@@ -25719,7 +25719,7 @@
               "target": "rustls_pemfile"
             },
             {
-              "id": "thiserror 1.0.64",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             },
             {
@@ -25864,7 +25864,7 @@
               "target": "smallvec"
             },
             {
-              "id": "thiserror 1.0.64",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             },
             {
@@ -27504,7 +27504,7 @@
               "target": "hyper_util"
             },
             {
-              "id": "thiserror 1.0.64",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             },
             {
@@ -28007,7 +28007,7 @@
               "target": "simple_asn1"
             },
             {
-              "id": "thiserror 1.0.64",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             },
             {
@@ -28236,7 +28236,7 @@
               "target": "sync_wrapper"
             },
             {
-              "id": "thiserror 1.0.64",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             },
             {
@@ -28527,7 +28527,7 @@
               "target": "sha2"
             },
             {
-              "id": "thiserror 1.0.64",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             }
           ],
@@ -28590,7 +28590,7 @@
               "target": "nom"
             },
             {
-              "id": "thiserror 1.0.64",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             }
           ],
@@ -29351,7 +29351,7 @@
               "target": "sha2"
             },
             {
-              "id": "thiserror 1.0.64",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             }
           ],
@@ -29540,7 +29540,7 @@
               "target": "serde"
             },
             {
-              "id": "thiserror 1.0.64",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             },
             {
@@ -29634,7 +29634,7 @@
               "target": "ic_utils"
             },
             {
-              "id": "thiserror 1.0.64",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             }
           ],
@@ -29826,7 +29826,7 @@
               "target": "sha2"
             },
             {
-              "id": "thiserror 1.0.64",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             },
             {
@@ -30058,7 +30058,7 @@
               "target": "sha2"
             },
             {
-              "id": "thiserror 1.0.64",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             }
           ],
@@ -30156,7 +30156,7 @@
               "target": "strum"
             },
             {
-              "id": "thiserror 1.0.64",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             },
             {
@@ -30422,7 +30422,7 @@
               "target": "serde_json"
             },
             {
-              "id": "thiserror 1.0.64",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             },
             {
@@ -30760,7 +30760,7 @@
               "target": "sha2"
             },
             {
-              "id": "thiserror 1.0.64",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             }
           ],
@@ -30822,7 +30822,7 @@
               "target": "serde"
             },
             {
-              "id": "thiserror 1.0.64",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             }
           ],
@@ -32849,7 +32849,7 @@
               "target": "serde_json"
             },
             {
-              "id": "thiserror 1.0.64",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             }
           ],
@@ -33261,7 +33261,7 @@
               "target": "serde"
             },
             {
-              "id": "thiserror 1.0.64",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             }
           ],
@@ -33757,7 +33757,7 @@
               "target": "serde_json"
             },
             {
-              "id": "thiserror 1.0.64",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             }
           ],
@@ -34366,7 +34366,7 @@
               "target": "serde_yaml"
             },
             {
-              "id": "thiserror 1.0.64",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             },
             {
@@ -34457,7 +34457,7 @@
               "target": "serde_json"
             },
             {
-              "id": "thiserror 1.0.64",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             }
           ],
@@ -36720,7 +36720,7 @@
         "deps": {
           "common": [
             {
-              "id": "thiserror 1.0.64",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             }
           ],
@@ -39531,7 +39531,7 @@
               "target": "tagptr"
             },
             {
-              "id": "thiserror 1.0.64",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             },
             {
@@ -39994,7 +39994,7 @@
               "target": "strum"
             },
             {
-              "id": "thiserror 1.0.64",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             }
           ],
@@ -42079,7 +42079,7 @@
               "target": "sha2"
             },
             {
-              "id": "thiserror 1.0.64",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             }
           ],
@@ -42397,7 +42397,7 @@
               "target": "pin_project_lite"
             },
             {
-              "id": "thiserror 1.0.64",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             },
             {
@@ -42481,7 +42481,7 @@
               "target": "pin_project_lite"
             },
             {
-              "id": "thiserror 1.0.64",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             }
           ],
@@ -42573,7 +42573,7 @@
               "target": "prost"
             },
             {
-              "id": "thiserror 1.0.64",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             },
             {
@@ -42915,7 +42915,7 @@
               "target": "pin_project_lite"
             },
             {
-              "id": "thiserror 1.0.64",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             }
           ],
@@ -42998,7 +42998,7 @@
               "target": "pin_project_lite"
             },
             {
-              "id": "thiserror 1.0.64",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             },
             {
@@ -43099,7 +43099,7 @@
               "target": "rand"
             },
             {
-              "id": "thiserror 1.0.64",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             }
           ],
@@ -43208,7 +43208,7 @@
               "target": "regex"
             },
             {
-              "id": "thiserror 1.0.64",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             }
           ],
@@ -43320,7 +43320,7 @@
               "target": "rand"
             },
             {
-              "id": "thiserror 1.0.64",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             },
             {
@@ -43437,7 +43437,7 @@
               "target": "serde_json"
             },
             {
-              "id": "thiserror 1.0.64",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             },
             {
@@ -44878,7 +44878,7 @@
         "deps": {
           "common": [
             {
-              "id": "thiserror 1.0.64",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             },
             {
@@ -45891,7 +45891,7 @@
               "target": "socket2"
             },
             {
-              "id": "thiserror 1.0.64",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             }
           ],
@@ -46829,7 +46829,7 @@
               "target": "tempfile"
             },
             {
-              "id": "thiserror 1.0.64",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             }
           ],
@@ -48373,7 +48373,7 @@
               "target": "protobuf"
             },
             {
-              "id": "thiserror 1.0.64",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             }
           ],
@@ -49951,7 +49951,7 @@
               "target": "socket2"
             },
             {
-              "id": "thiserror 1.0.64",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             },
             {
@@ -50039,7 +50039,7 @@
               "target": "slab"
             },
             {
-              "id": "thiserror 1.0.64",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             },
             {
@@ -51346,7 +51346,7 @@
               "target": "parking_lot"
             },
             {
-              "id": "thiserror 1.0.64",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             }
           ],
@@ -51842,7 +51842,7 @@
               "target": "syscall"
             },
             {
-              "id": "thiserror 1.0.64",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             }
           ],
@@ -55430,7 +55430,7 @@
               "target": "serde_json"
             },
             {
-              "id": "thiserror 1.0.64",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             },
             {
@@ -58496,7 +58496,7 @@
               "target": "serde"
             },
             {
-              "id": "thiserror 1.0.64",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             }
           ],
@@ -60051,7 +60051,7 @@
               "target": "num_traits"
             },
             {
-              "id": "thiserror 1.0.64",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             },
             {
@@ -63375,7 +63375,7 @@
               "target": "static_assertions"
             },
             {
-              "id": "thiserror 1.0.64",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             },
             {
@@ -64134,14 +64134,14 @@
       ],
       "license_file": "LICENSE"
     },
-    "thiserror 1.0.64": {
+    "thiserror 1.0.65": {
       "name": "thiserror",
-      "version": "1.0.64",
+      "version": "1.0.65",
       "package_url": "https://github.com/dtolnay/thiserror",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/thiserror/1.0.64/download",
-          "sha256": "d50af8abc119fb8bb6dbabcfa89656f46f84aa0ac7688088608076ad2b459a84"
+          "url": "https://static.crates.io/crates/thiserror/1.0.65/download",
+          "sha256": "5d11abd9594d9b38965ef50805c5e469ca9cc6f197f883f717e0269a3057b3d5"
         }
       },
       "targets": [
@@ -64178,7 +64178,7 @@
         "deps": {
           "common": [
             {
-              "id": "thiserror 1.0.64",
+              "id": "thiserror 1.0.65",
               "target": "build_script_build"
             }
           ],
@@ -64188,13 +64188,13 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "thiserror-impl 1.0.64",
+              "id": "thiserror-impl 1.0.65",
               "target": "thiserror_impl"
             }
           ],
           "selects": {}
         },
-        "version": "1.0.64"
+        "version": "1.0.65"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -64208,14 +64208,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "thiserror-impl 1.0.64": {
+    "thiserror-impl 1.0.65": {
       "name": "thiserror-impl",
-      "version": "1.0.64",
+      "version": "1.0.65",
       "package_url": "https://github.com/dtolnay/thiserror",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/thiserror-impl/1.0.64/download",
-          "sha256": "08904e7672f5eb876eaaf87e0ce17857500934f4981c4a0ab2b4aa98baac7fc3"
+          "url": "https://static.crates.io/crates/thiserror-impl/1.0.65/download",
+          "sha256": "ae71770322cbd277e69d762a16c444af02aa0575ac0d174f0b9562d3b37f8602"
         }
       },
       "targets": [
@@ -64255,7 +64255,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "1.0.64"
+        "version": "1.0.65"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -65851,7 +65851,7 @@
               "target": "futures_util"
             },
             {
-              "id": "thiserror 1.0.64",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             },
             {
@@ -67165,7 +67165,7 @@
               "target": "pin_project"
             },
             {
-              "id": "thiserror 1.0.64",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             },
             {
@@ -67299,7 +67299,7 @@
               "target": "crossbeam_channel"
             },
             {
-              "id": "thiserror 1.0.64",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             },
             {
@@ -68127,7 +68127,7 @@
               "target": "smallvec"
             },
             {
-              "id": "thiserror 1.0.64",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             },
             {
@@ -68243,7 +68243,7 @@
               "target": "smallvec"
             },
             {
-              "id": "thiserror 1.0.64",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             },
             {
@@ -68391,7 +68391,7 @@
               "target": "sha1"
             },
             {
-              "id": "thiserror 1.0.64",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             },
             {
@@ -71927,7 +71927,7 @@
               "target": "target_lexicon"
             },
             {
-              "id": "thiserror 1.0.64",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             },
             {
@@ -76064,7 +76064,7 @@
               "target": "rusticata_macros"
             },
             {
-              "id": "thiserror 1.0.64",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             },
             {
@@ -78573,7 +78573,7 @@
     "test-strategy 0.3.1",
     "tester 0.7.0",
     "textplots 0.8.4",
-    "thiserror 1.0.64",
+    "thiserror 1.0.65",
     "thousands 0.2.0",
     "threadpool 1.8.1",
     "tikv-jemalloc-ctl 0.5.4",

--- a/Cargo.Bazel.toml.lock
+++ b/Cargo.Bazel.toml.lock
@@ -10865,18 +10865,18 @@ checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
 
 [[package]]
 name = "thiserror"
-version = "1.0.64"
+version = "1.0.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d50af8abc119fb8bb6dbabcfa89656f46f84aa0ac7688088608076ad2b459a84"
+checksum = "5d11abd9594d9b38965ef50805c5e469ca9cc6f197f883f717e0269a3057b3d5"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.64"
+version = "1.0.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08904e7672f5eb876eaaf87e0ce17857500934f4981c4a0ab2b4aa98baac7fc3"
+checksum = "ae71770322cbd277e69d762a16c444af02aa0575ac0d174f0b9562d3b37f8602"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/bazel/external_crates.bzl
+++ b/bazel/external_crates.bzl
@@ -1221,7 +1221,7 @@ def external_crates_repository(name, cargo_lockfile, lockfile, sanitizers_enable
                 version = "^0.8",
             ),
             "thiserror": crate.spec(
-                version = "^1.0.62",
+                version = "^1.0.65",
             ),
             "thousands": crate.spec(
                 version = "^0.2.0",


### PR DESCRIPTION
The previous `thiserror` version included dep-info files in the bazel build output, which included the (changing) build directory and threw off Bazel.

This was fixed in https://github.com/dtolnay/thiserror/pull/325