### PR TITLE
feat(BOUN-1215) fix(BOUN-1282): update ic-gateway, enable shedding

### DIFF
--- a/ic-os/boundary-guestos/context/Dockerfile
+++ b/ic-os/boundary-guestos/context/Dockerfile
@@ -25,8 +25,8 @@ WORKDIR /tmp
 
 # Download and verify ic-gateway
 RUN \
-    curl -L -O https://github.com/dfinity/ic-gateway/releases/download/v0.1.57/ic-gateway_0.1.57_amd64.deb && \
-    echo "991a3f4aff97ec0a7422e7806ce298c277e2fc38eae37fbe2f4f24527dcd688d  ic-gateway_0.1.57_amd64.deb" | sha256sum -c
+    curl -L -O https://github.com/dfinity/ic-gateway/releases/download/v0.1.58/ic-gateway_0.1.58_amd64.deb && \
+    echo "d6939a8e4c473cf5af8f63e3ce577d7685ec2bb89428d925f8a55dc87d7a10c1  ic-gateway_0.1.58_amd64.deb" | sha256sum -c
 
 #
 # Second build stage:
@@ -56,9 +56,9 @@ FROM image-${BUILD_TYPE}
 
 USER root:root
 
-COPY --from=download /tmp/ic-gateway_0.1.57_amd64.deb /tmp/ic-gateway_0.1.57_amd64.deb
-RUN dpkg -i --force-confold /tmp/ic-gateway_0.1.57_amd64.deb && \
-    rm /tmp/ic-gateway_0.1.57_amd64.deb
+COPY --from=download /tmp/ic-gateway_0.1.58_amd64.deb /tmp/ic-gateway_0.1.58_amd64.deb
+RUN dpkg -i --force-confold /tmp/ic-gateway_0.1.58_amd64.deb && \
+    rm /tmp/ic-gateway_0.1.58_amd64.deb
 
 RUN mkdir -p /boot/config \
              /boot/efi \

--- a/ic-os/components/boundary-guestos/opt/ic/bin/setup-ic-gateway.sh
+++ b/ic-os/components/boundary-guestos/opt/ic/bin/setup-ic-gateway.sh
@@ -145,9 +145,12 @@ CACHE_MAX_ITEM_SIZE="20MB"
 CACHE_TTL="10s"
 CACHE_LOCK_TIMEOUT="10s"
 CACHE_XFETCH_BETA="3.0"
+SHED_SYSTEM_EWMA="0.9"
 SHED_SYSTEM_CPU="0.95"
 SHED_SYSTEM_MEMORY="0.95"
-SHED_SHARDED_LATENCY="query:600ms,call:300ms,sync_call:13s,read_state:600ms,read_state_subnet:600ms,status:20ms,health:20ms,registrations:5s,http:800ms"
+SHED_SHARDED_EWMA="0.6"
+SHED_SHARDED_PASSTHROUGH="20000"
+SHED_SHARDED_LATENCY="query:1s,call:1s,sync_call:13s,read_state:1s,read_state_subnet:1s,status:100ms,health:100ms,registrations:5s,http:5s"
 EOF
 
     if [ ! -z "${DENYLIST_URL}" ]; then

--- a/ic-os/components/boundary-guestos/opt/ic/bin/setup-ic-gateway.sh
+++ b/ic-os/components/boundary-guestos/opt/ic/bin/setup-ic-gateway.sh
@@ -147,7 +147,7 @@ CACHE_LOCK_TIMEOUT="10s"
 CACHE_XFETCH_BETA="3.0"
 SHED_SYSTEM_CPU="0.95"
 SHED_SYSTEM_MEMORY="0.95"
-SHED_SHARDED_LATENCY="query:600ms,call:300ms,sync_call:13s,read_state:600ms,read_state_subnet:600ms,status:20ms,health:20ms,registrations:600ms,http:800ms"
+SHED_SHARDED_LATENCY="query:600ms,call:300ms,sync_call:13s,read_state:600ms,read_state_subnet:600ms,status:20ms,health:20ms,registrations:5s,http:800ms"
 EOF
 
     if [ ! -z "${DENYLIST_URL}" ]; then

--- a/ic-os/components/boundary-guestos/opt/ic/bin/setup-ic-gateway.sh
+++ b/ic-os/components/boundary-guestos/opt/ic/bin/setup-ic-gateway.sh
@@ -145,6 +145,9 @@ CACHE_MAX_ITEM_SIZE="20MB"
 CACHE_TTL="10s"
 CACHE_LOCK_TIMEOUT="10s"
 CACHE_XFETCH_BETA="3.0"
+SHED_SYSTEM_CPU="0.95"
+SHED_SYSTEM_MEMORY="0.95"
+SHED_SHARDED_LATENCY="query:600ms,call:300ms,sync_call:13s,read_state:600ms,read_state_subnet:600ms,status:20ms,health:20ms,registrations:600ms,http:800ms"
 EOF
 
     if [ ! -z "${DENYLIST_URL}" ]; then


### PR DESCRIPTION
* Update `ic-gateway` to v0.1.58 with new shedding & timeouts
* Enable shedding based on Clickhouse statistics (target latency set to roughly x2 of 95% percentile)
