### PR TITLE
test(ICRC_index_ng): FI-1519: Add test for ICRC index-ng sync with ledger with various intervals

### DIFF
--- a/rs/ledger_suite/icrc1/index-ng/tests/common/mod.rs
+++ b/rs/ledger_suite/icrc1/index-ng/tests/common/mod.rs
@@ -386,7 +386,7 @@ fn icrc3_get_blocks(
         .expect("Failed to decode GetBlocksResult")
 }
 
-fn status(env: &StateMachine, index_id: CanisterId) -> Status {
+pub fn status(env: &StateMachine, index_id: CanisterId) -> Status {
     let res = env
         .query(index_id, "status", Encode!(&()).unwrap())
         .expect("Failed to send status")

--- a/rs/ledger_suite/icrc1/index-ng/tests/retrieve_blocks_from_ledger_interval.rs
+++ b/rs/ledger_suite/icrc1/index-ng/tests/retrieve_blocks_from_ledger_interval.rs
@@ -2,13 +2,19 @@ use crate::common::{
     default_archive_options, index_ng_wasm, install_index_ng, install_ledger,
     wait_until_sync_is_completed, MAX_ATTEMPTS_FOR_INDEX_SYNC_WAIT, STARTING_CYCLES_PER_CANISTER,
 };
-use candid::{CandidType, Deserialize, Encode, Principal};
+use candid::{CandidType, Deserialize, Encode, Nat, Principal};
 use ic_agent::Identity;
 use ic_base_types::CanisterId;
 use ic_icrc1_index_ng::{IndexArg, InitArg, UpgradeArg};
-use ic_icrc1_test_utils::minter_identity;
+use ic_icrc1_test_utils::{arb_account, minter_identity};
+use ic_ledger_suite_state_machine_tests::send_transfer;
 use ic_registry_subnet_type::SubnetType;
 use ic_state_machine_tests::{ErrorCode, StateMachine, StateMachineBuilder, Time, UserError};
+use icrc_ledger_types::icrc1::account::Account;
+use icrc_ledger_types::icrc1::transfer::TransferArg;
+use num_traits::ToPrimitive;
+use proptest::prelude::Strategy;
+use proptest::test_runner::TestRunner;
 use std::time::{Duration, SystemTime};
 
 mod common;
@@ -110,6 +116,139 @@ fn should_install_and_upgrade_with_valid_values() {
             );
         }
     }
+}
+
+#[test]
+fn should_sync_according_to_interval() {
+    const INITIAL_BALANCE: u64 = 1_000_000_000;
+    const TRANSFER_AMOUNT: u64 = 1_000_000;
+    const DEFAULT_RETRIEVE_BLOCKS_FROM_LEDGER_INTERVAL: u64 = 1;
+
+    fn send_transaction_and_verify_index_sync(
+        env: &StateMachine,
+        ledger_id: CanisterId,
+        index_id: CanisterId,
+        a1: Account,
+        a2: Account,
+        install_interval: Option<u64>,
+        upgrade_interval: Option<u64>,
+    ) {
+        let ledger_chain_length = send_transfer(
+            env,
+            ledger_id,
+            a1.owner,
+            &TransferArg {
+                from_subaccount: a1.subaccount,
+                to: a2,
+                fee: None,
+                created_at_time: None,
+                memo: None,
+                amount: Nat::from(TRANSFER_AMOUNT),
+            },
+        )
+        .expect("send_transfer should succeed")
+        .checked_add(1)
+        .expect("should be able to add 1 to block index");
+        let mut index_num_blocks_synced = common::status(env, index_id)
+            .num_blocks_synced
+            .0
+            .to_u64()
+            .expect("should retrieve num_blocks_synced from index");
+        if index_num_blocks_synced != ledger_chain_length {
+            let time_to_advance = effective_retrieve_blocks_from_ledger_interval(
+                DEFAULT_RETRIEVE_BLOCKS_FROM_LEDGER_INTERVAL,
+                install_interval,
+                upgrade_interval,
+            );
+            if time_to_advance > 0 {
+                env.advance_time(Duration::from_secs(time_to_advance));
+                env.tick();
+            }
+            index_num_blocks_synced = common::status(env, index_id)
+                .num_blocks_synced
+                .0
+                .to_u64()
+                .expect("should retrieve num_blocks_synced from index");
+        }
+        assert_eq!(ledger_chain_length, index_num_blocks_synced);
+    }
+
+    let mut runner = TestRunner::new(proptest::test_runner::Config::with_cases(10));
+    runner
+        .run(
+            &(
+                proptest::option::of(0..(max_value_for_interval() / 2)),
+                proptest::option::of(0..(max_value_for_interval() / 2)),
+                arb_account(),
+                arb_account(),
+            )
+                .prop_filter("The accounts must be different", |(_, _, a1, a2)| a1 != a2)
+                .no_shrink(),
+            |(install_interval, upgrade_interval, a1, a2)| {
+                // Create a new environment with an application subnet
+                let env = &StateMachineBuilder::new()
+                    .with_subnet_type(SubnetType::Application)
+                    .with_subnet_size(28)
+                    .with_time(GENESIS)
+                    .build();
+                // Install a ledger with an initial balance for a1
+                let ledger_id = install_ledger(
+                    env,
+                    vec![(a1, INITIAL_BALANCE)],
+                    default_archive_options(),
+                    None,
+                    minter_identity().sender().unwrap(),
+                );
+                // Install an index with a specific interval
+                let args = IndexArg::Init(InitArg {
+                    ledger_id: Principal::from(ledger_id),
+                    retrieve_blocks_from_ledger_interval_seconds: install_interval,
+                });
+                let index_id = env.install_canister_with_cycles(
+                    index_ng_wasm(),
+                    Encode!(&args).unwrap(),
+                    None,
+                    ic_state_machine_tests::Cycles::new(STARTING_CYCLES_PER_CANISTER),
+                )?;
+
+                // Send a transaction and verify that the index is synced after the interval
+                // specified during the install, or the default value if the interval specified
+                // during the install was None.
+                send_transaction_and_verify_index_sync(
+                    env,
+                    ledger_id,
+                    index_id,
+                    a1,
+                    a2,
+                    install_interval,
+                    None,
+                );
+
+                // Upgrade the index with a specific interval
+                let upgrade_arg = IndexArg::Upgrade(UpgradeArg {
+                    ledger_id: None,
+                    retrieve_blocks_from_ledger_interval_seconds: upgrade_interval,
+                });
+                env.upgrade_canister(index_id, index_ng_wasm(), Encode!(&upgrade_arg).unwrap())?;
+
+                // Send a transaction and verify that the index is synced after the interval
+                // specified during the upgrade, or if it is None, the interval specified during
+                // the install, or the default value if the interval specified during the install
+                // was None.
+                send_transaction_and_verify_index_sync(
+                    env,
+                    ledger_id,
+                    index_id,
+                    a1,
+                    a2,
+                    install_interval,
+                    upgrade_interval,
+                );
+
+                Ok(())
+            },
+        )
+        .unwrap();
 }
 
 #[test]
@@ -308,6 +447,19 @@ struct CycleConsumption {
 
 fn abs_relative_difference(subject: i128, reference: i128) -> f64 {
     subject.abs_diff(reference) as f64 / (subject as f64)
+}
+
+fn effective_retrieve_blocks_from_ledger_interval(
+    default: u64,
+    install: Option<u64>,
+    upgrade: Option<u64>,
+) -> u64 {
+    match (install, upgrade) {
+        (Some(_install), Some(upgrade)) => upgrade,
+        (Some(install), None) => install,
+        (None, Some(upgrade)) => upgrade,
+        (None, None) => default,
+    }
 }
 
 fn idle_ledger_and_index_cycles_consumption(


### PR DESCRIPTION
Add a test that verifies that the ICRC `index-ng` syncs with the ledger with various values of the `retrieve_blocks_from_ledger_interval_seconds` configuration option.