### PR TITLE
feat(pocket-ic): POCKET_IC_MUTE_SERVER only mutes output when set to non-empty string

### DIFF
--- a/packages/pocket-ic/CHANGELOG.md
+++ b/packages/pocket-ic/CHANGELOG.md
@@ -22,7 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The type `Topology` becomes a struct with two fields: `subnet_configs` contains an association of subnet ids to their configurations
   and `default_effective_canister_id` contains a default effective canister id for canister creation.
 - Management canister types are defined in a new `management_canister` module to avoid a dependency on `ic-cdk`.
-
+- Environment variable `POCKET_IC_MUTE_SERVER` now only mutes output when set to non-empty string (previously any value muted server).
 
 
 ## 5.0.0 - 2024-09-12

--- a/packages/pocket-ic/src/lib.rs
+++ b/packages/pocket-ic/src/lib.rs
@@ -1384,7 +1384,7 @@ To download the binary, please visit https://github.com/dfinity/pocketic."
     #[cfg(not(windows))]
     cmd.arg(port_file_path.clone());
     if let Ok(mute_server) = std::env::var("POCKET_IC_MUTE_SERVER") {
-        if mute_server != "" {
+        if !mute_server.is_empty() {
             cmd.stdout(std::process::Stdio::null());
             cmd.stderr(std::process::Stdio::null());
         }

--- a/packages/pocket-ic/src/lib.rs
+++ b/packages/pocket-ic/src/lib.rs
@@ -33,14 +33,16 @@
 //! ```
 //! For more information, see the [README](https://crates.io/crates/pocket-ic).
 //!
-use crate::common::rest::{
-    BlobCompression, BlobId, CanisterHttpRequest, DtsFlag, ExtendedSubnetConfigSet, HttpsConfig,
-    InstanceId, MockCanisterHttpResponse, RawEffectivePrincipal, RawMessageId, SubnetId,
-    SubnetKind, SubnetSpec, Topology,
-};
 pub use crate::management_canister::CanisterSettings;
-use crate::management_canister::{CanisterId, CanisterStatusResult};
-use crate::nonblocking::PocketIc as PocketIcAsync;
+use crate::{
+    common::rest::{
+        BlobCompression, BlobId, CanisterHttpRequest, DtsFlag, ExtendedSubnetConfigSet,
+        HttpsConfig, InstanceId, MockCanisterHttpResponse, RawEffectivePrincipal, RawMessageId,
+        SubnetId, SubnetKind, SubnetSpec, Topology,
+    },
+    management_canister::{CanisterId, CanisterStatusResult},
+    nonblocking::PocketIc as PocketIcAsync,
+};
 use candid::{
     decode_args, encode_args,
     utils::{ArgumentDecoder, ArgumentEncoder},
@@ -51,14 +53,13 @@ use reqwest::Url;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use slog::Level;
-use std::sync::mpsc::channel;
-use std::thread;
-use std::thread::JoinHandle;
 use std::{
     net::SocketAddr,
     path::{Path, PathBuf},
     process::Command,
-    sync::Arc,
+    sync::{mpsc::channel, Arc},
+    thread,
+    thread::JoinHandle,
     time::{Duration, SystemTime},
 };
 use thiserror::Error;
@@ -1382,9 +1383,11 @@ To download the binary, please visit https://github.com/dfinity/pocketic."
     ));
     #[cfg(not(windows))]
     cmd.arg(port_file_path.clone());
-    if std::env::var("POCKET_IC_MUTE_SERVER").is_ok() {
-        cmd.stdout(std::process::Stdio::null());
-        cmd.stderr(std::process::Stdio::null());
+    if let Ok(mute_server) = std::env::var("POCKET_IC_MUTE_SERVER") {
+        if mute_server.as_str() == "1" {
+            cmd.stdout(std::process::Stdio::null());
+            cmd.stderr(std::process::Stdio::null());
+        }
     }
     cmd.spawn()
         .unwrap_or_else(|_| panic!("Failed to start PocketIC binary ({:?})", bin_path));

--- a/packages/pocket-ic/src/lib.rs
+++ b/packages/pocket-ic/src/lib.rs
@@ -1384,7 +1384,7 @@ To download the binary, please visit https://github.com/dfinity/pocketic."
     #[cfg(not(windows))]
     cmd.arg(port_file_path.clone());
     if let Ok(mute_server) = std::env::var("POCKET_IC_MUTE_SERVER") {
-        if mute_server.as_str() == "1" {
+        if mute_server != "" {
             cmd.stdout(std::process::Stdio::null());
             cmd.stderr(std::process::Stdio::null());
         }


### PR DESCRIPTION
This allows an override that explicitly unmutes the server, which is needed when debugging canbench tests.

See: https://github.com/dfinity/canbench/pull/73/files