### PR TITLE
fix: Make regex for special address ranges more strict

### DIFF
--- a/ic-os/components/setupos-scripts/check-network.sh
+++ b/ic-os/components/setupos-scripts/check-network.sh
@@ -64,7 +64,7 @@ function get_network_settings() {
 
     # Full IPv6 address
     ipv6_address_system_full=$(eval_command_with_retries \
-        "ip -6 addr show | awk '(/inet6/) && (!/fe80|::1/) { print \$2 }'" \
+        "ip -6 addr show | awk '(/inet6/) && (!/^fe80|^::1$/) { print \$2 }'" \
         "Failed to get system's network configuration.")
 
     if [ -z "${ipv6_address_system_full}" ]; then

--- a/ic-os/components/setupos-scripts/check-network.sh
+++ b/ic-os/components/setupos-scripts/check-network.sh
@@ -64,7 +64,7 @@ function get_network_settings() {
 
     # Full IPv6 address
     ipv6_address_system_full=$(eval_command_with_retries \
-        "ip -6 addr show | awk '(/inet6/) && (!/^fe80|^::1$/) { print \$2 }'" \
+        "ip -6 addr show | awk '(/inet6/) && (!/\sfe80|\s::1/) { print \$2 }'" \
         "Failed to get system's network configuration.")
 
     if [ -z "${ipv6_address_system_full}" ]; then


### PR DESCRIPTION
Successfully filters out `::1` and `fe80...`, and lets `...fe80...` and `...::1...` through.
```
% cat demo
    inet6 ::1/128 scope host
       valid_lft forever preferred_lft forever
    inet6 fe80:a424:8eec:696f:de9a:532b:bbad:f0d7/64 scope link
       valid_lft forever preferred_lft forever
    inet6 a550:fe80:8eec:696f:de9a:532b:bbad:f0d7/64 scope global
       valid_lft forever preferred_lft forever
    inet6 a550:a424:8eec:696f:de9a:532b::1/64 scope global
       valid_lft forever preferred_lft forever
```

```
% cat demo | awk '(/inet6/) && (!/\sfe80|\s::1/) { print $2 }'
a550:fe80:8eec:696f:de9a:532b:bbad:f0d7/64
a550:a424:8eec:696f:de9a:532b::1/64
```