### PR TITLE
fix: always enable canister sandboxing in SM tests

### DIFF
--- a/rs/state_machine_tests/src/lib.rs
+++ b/rs/state_machine_tests/src/lib.rs
@@ -1554,7 +1554,6 @@ impl StateMachine {
         }
 
         if !dts {
-            hypervisor_config.canister_sandboxing_flag = FlagStatus::Disabled;
             hypervisor_config.deterministic_time_slicing = FlagStatus::Disabled;
         }
 


### PR DESCRIPTION
In production, canister sandboxing is always enabled. Moreover, without canister sandboxing, the error message for instruction limit exceeded reports a limit of 0 instructions for single message execution which is confusing.