### PR TITLE
feat(nns): Refresh voting power.

### DIFF
--- a/rs/nns/governance/src/governance.rs
+++ b/rs/nns/governance/src/governance.rs
@@ -5982,8 +5982,8 @@ impl Governance {
 
         if let Err(err) = result {
             println!(
-                "{}WARNING: Tried to update the voting power of {}, \
-                 but where neuron? {}",
+                "{}WARNING: Tried to refresh the voting power of neuron {}, \
+                 but was unable to find it: {}",
                 LOG_PREFIX, neuron_id.id, err,
             );
         }

--- a/rs/nns/governance/src/governance.rs
+++ b/rs/nns/governance/src/governance.rs
@@ -5584,6 +5584,8 @@ impl Governance {
         // Finally, add this proposal as an open proposal.
         self.insert_proposal(proposal_num, proposal_data);
 
+        self.refresh_voting_power(proposer_id);
+
         Ok(proposal_id)
     }
 
@@ -5966,7 +5968,25 @@ impl Governance {
 
         self.process_proposal(proposal_id.id);
 
+        self.refresh_voting_power(neuron_id);
+
         Ok(())
+    }
+
+    fn refresh_voting_power(&mut self, neuron_id: &NeuronId) {
+        let now_seconds = self.env.now();
+
+        let result = self.with_neuron_mut(neuron_id, |neuron| {
+            neuron.refresh_voting_power(now_seconds);
+        });
+
+        if let Err(err) = result {
+            println!(
+                "{}WARNING: Tried to update the voting power of {}, \
+                 but where neuron? {}",
+                LOG_PREFIX, neuron_id.id, err,
+            );
+        }
     }
 
     /// Add or remove followees for this neuron for a specified topic.
@@ -6031,17 +6051,20 @@ impl Governance {
             )
         })?;
 
+        let now_seconds = self.env.now();
         self.with_neuron_mut(id, |neuron| {
             if follow_request.followees.is_empty() {
-                neuron.followees.remove(&(topic as i32))
+                neuron.followees.remove(&(topic as i32));
             } else {
                 neuron.followees.insert(
                     topic as i32,
                     Followees {
                         followees: follow_request.followees.clone(),
                     },
-                )
+                );
             }
+
+            neuron.refresh_voting_power(now_seconds);
         })?;
 
         Ok(())

--- a/rs/nns/governance/src/lib.rs
+++ b/rs/nns/governance/src/lib.rs
@@ -175,6 +175,18 @@ mod subaccount_index;
 /// The value of 10_000 follows the Candid recommendation.
 const DEFAULT_SKIPPING_QUOTA: usize = 10_000;
 
+/// Value: one second after midnight, 2024-11-05 (UTC).
+///
+/// How this value was chosen: This is around the earliest time when
+/// "refreshing" a neuron's voting power might be released, (assuming the usual
+/// NNS release cycle). Significantly different values could also work, but this
+/// seems like a nice "neutral" value.
+///
+/// How this value is used: when a neuron does not have a value in the
+/// voting_power_refreshed_timestamp_seconds field (because it was created before
+/// this feature), we pretend as though this value is in that field.
+pub const DEFAULT_VOTING_POWER_REFRESHED_TIMESTAMP_SECONDS: u64 = 1731628801;
+
 // TODO(NNS1-3248): Delete this once the feature has made it through the
 // probation period. At that point, we will not need this "kill switch". We can
 // leave this here indefinitely, but it will just be clutter after a modest

--- a/rs/nns/governance/src/neuron/types.rs
+++ b/rs/nns/governance/src/neuron/types.rs
@@ -15,6 +15,7 @@ use crate::{
         Neuron as NeuronProto, NeuronInfo, NeuronStakeTransfer, NeuronState, NeuronType, Topic,
         Visibility, Vote,
     },
+    DEFAULT_VOTING_POWER_REFRESHED_TIMESTAMP_SECONDS,
 };
 use ic_base_types::PrincipalId;
 use ic_cdk::println;
@@ -22,18 +23,6 @@ use ic_nervous_system_common::ONE_DAY_SECONDS;
 use ic_nns_common::pb::v1::{NeuronId, ProposalId};
 use icp_ledger::Subaccount;
 use std::collections::{BTreeSet, HashMap};
-
-/// Value: one second after midnight, 2024-11-05 (UTC).
-///
-/// How this value was chosen: This is around the earliest time when
-/// "refreshing" a neuron's voting power might be released, (assuming the usual
-/// NNS release cycle). Significantly different values could also work, but this
-/// seems like a nice "neutral" value.
-///
-/// How this value is used: when a neuron does not have a value in the
-/// voting_power_refreshed_timestamp_seconds field (because it was created before
-/// this feature), we pretend as though this value is in that field.
-const DEFAULT_VOTING_POWER_REFRESHED_TIMESTAMP_SECONDS: u64 = 1731628801;
 
 /// A neuron type internal to the governance crate. Currently, this type is identical to the
 /// prost-generated Neuron type (except for derivations for prost). Gradually, this type will evolve
@@ -478,6 +467,10 @@ impl Neuron {
         while self.recent_ballots.len() > MAX_NEURON_RECENT_BALLOTS {
             self.recent_ballots.pop();
         }
+    }
+
+    pub(crate) fn refresh_voting_power(&mut self, now_seconds: u64) {
+        self.voting_power_refreshed_timestamp_seconds = now_seconds;
     }
 
     pub(crate) fn ready_to_unstake_maturity(&self, now_seconds: u64) -> bool {

--- a/rs/nns/governance/tests/governance.rs
+++ b/rs/nns/governance/tests/governance.rs
@@ -1740,6 +1740,18 @@ async fn test_all_follow_proposer() {
         driver.get_fake_ledger(),
         driver.get_fake_cmc(),
     );
+
+    // Later, we'll inspect the same field again to verify that voting power
+    // refresh actually took place. This is just to make sure that the later
+    // value is different from this earlier one.
+    assert_eq!(
+        gov.with_neuron(&NeuronId { id: 5 }, |neuron| {
+            neuron.voting_power_refreshed_timestamp_seconds()
+        })
+        .unwrap(),
+        DEFAULT_VOTING_POWER_REFRESHED_TIMESTAMP_SECONDS,
+    );
+
     // Add following for 5 and 6 for 1.
     gov.manage_neuron(
         // Must match neuron 5's serialized_id.
@@ -1756,6 +1768,22 @@ async fn test_all_follow_proposer() {
     .now_or_never()
     .unwrap()
     .panic_if_error("Manage neuron failed");
+
+    // Assert that neuron 5's voting power was refreshed. More concretely,
+    // verifying that neuron 5's voting_power_refreshed_timestamp_seconds
+    // changed from before. (Earlier, we saw that this field had a different
+    // value, to wit, DEFAULT_VOTING_POWER_REFRESHED_TIMESTAMP_SECONDS)
+    assert_ne!(
+        DEFAULT_TEST_START_TIMESTAMP_SECONDS,
+        DEFAULT_VOTING_POWER_REFRESHED_TIMESTAMP_SECONDS,
+    );
+    assert_eq!(
+        gov.with_neuron(&NeuronId { id: 5 }, |neuron| {
+            neuron.voting_power_refreshed_timestamp_seconds()
+        })
+        .unwrap(),
+        DEFAULT_TEST_START_TIMESTAMP_SECONDS,
+    );
 
     gov.manage_neuron(
         // Must match neuron 6's serialized_id.


### PR DESCRIPTION
This occurs when a neuron is modified in the following ways:

1. vote (directly, not indirectly)
2. change follow

# Background

This is part of the "periodic confirmation" feature that was recently approved in proposal [132411][prop].

[prop]: https://dashboard.internetcomputer.org/proposal/132411

# Future Work

This will be used to reduce the voting power in ballots when a neuron has not refreshed for a long time.

# References

Closes https://dfinity.atlassian.net/browse/NNS1-3405.

[👈 Previous PR][prev] | [Next PR 👉][next]

[prev]: https://github.com/dfinity/ic/pull/2268
[next]: https://github.com/dfinity/ic/pull/2338