### PR TITLE
feat(sns): Populate upgrade journal

### DIFF
--- a/rs/nervous_system/integration_tests/tests/advance_target_version.rs
+++ b/rs/nervous_system/integration_tests/tests/advance_target_version.rs
@@ -1,3 +1,4 @@
+use ic_nervous_system_agent::sns::governance::GovernanceCanister;
 use ic_nervous_system_integration_tests::pocket_ic_helpers::sns;
 use ic_nervous_system_integration_tests::{
     create_service_nervous_system_builder::CreateServiceNervousSystemBuilder,
@@ -6,6 +7,7 @@ use ic_nervous_system_integration_tests::{
     },
 };
 use ic_nns_test_utils::sns_wasm::create_modified_sns_wasm;
+use ic_sns_governance::pb::v1::governance::Versions;
 use ic_sns_governance::{
     governance::UPGRADE_STEPS_INTERVAL_REFRESH_BACKOFF_SECONDS, pb::v1 as sns_pb,
 };
@@ -14,6 +16,34 @@ use ic_sns_wasm::pb::v1::SnsCanisterType;
 use pocket_ic::nonblocking::PocketIc;
 use pocket_ic::PocketIcBuilder;
 use std::time::Duration;
+
+/// Verifies that the upgrade journal has the expected entries.
+async fn assert_upgrade_journal(
+    pocket_ic: &PocketIc,
+    governance: GovernanceCanister,
+    expected_entries: &[sns_pb::upgrade_journal_entry::Event],
+) {
+    let sns_pb::GetUpgradeJournalResponse {
+        upgrade_journal, ..
+    } = sns::governance::get_upgrade_journal(pocket_ic, governance.canister_id).await;
+
+    let upgrade_journal = upgrade_journal.unwrap().entries;
+    assert_eq!(upgrade_journal.len(), expected_entries.len());
+
+    for (index, (actual, expected)) in upgrade_journal
+        .iter()
+        .zip(expected_entries.iter())
+        .enumerate()
+    {
+        assert!(actual.timestamp_seconds.is_some());
+        assert_eq!(
+            &actual.event,
+            &Some(expected.clone()),
+            "Upgrade journal entry at index {} does not match",
+            index
+        );
+    }
+}
 
 /// Advances time by up to `timeout_seconds` seconds and `timeout_seconds` tickets (1 tick = 1 second).
 /// Each tick, it observes the state using the provided `observe` function.
@@ -96,20 +126,28 @@ async fn test_get_upgrade_journal() {
         sns
     };
 
-    // State A: right after SNS creation.
+    // Step 1: right after SNS creation.
+    let mut expected_upgrade_journal_entries = vec![];
     {
-        let sns_pb::GetUpgradeJournalResponse {
-            upgrade_steps,
-            response_timestamp_seconds,
-            ..
-        } = sns::governance::get_upgrade_journal(&pocket_ic, sns.governance.canister_id).await;
-        let upgrade_steps = upgrade_steps
-            .expect("upgrade_steps should be Some")
-            .versions;
-        assert_eq!(upgrade_steps, vec![initial_sns_version.clone()]);
-        assert_eq!(response_timestamp_seconds, Some(1620501459));
+        expected_upgrade_journal_entries.push(
+            sns_pb::upgrade_journal_entry::Event::UpgradeStepsRefreshed(
+                sns_pb::upgrade_journal_entry::UpgradeStepsRefreshed {
+                    upgrade_steps: Some(Versions {
+                        versions: vec![initial_sns_version.clone()],
+                    }),
+                },
+            ),
+        );
+
+        assert_upgrade_journal(
+            &pocket_ic,
+            sns.governance,
+            &expected_upgrade_journal_entries,
+        )
+        .await;
     }
 
+    // Step 1.1: wait for the upgrade steps to be refreshed.
     await_with_timeout(
         &pocket_ic,
         UPGRADE_STEPS_INTERVAL_REFRESH_BACKOFF_SECONDS,
@@ -125,7 +163,7 @@ async fn test_get_upgrade_journal() {
     .await
     .unwrap();
 
-    // Publish a new SNS version.
+    // Step 2: Publish new SNS versions.
     let (new_sns_version_1, new_sns_version_2) = {
         let (_, original_root_wasm) = deployed_sns_starting_info
             .get(&SnsCanisterType::Root)
@@ -156,11 +194,12 @@ async fn test_get_upgrade_journal() {
         };
 
         let sns_version = nns::sns_wasm::get_latest_sns_version(&pocket_ic).await;
-        assert_ne!(sns_version, initial_sns_version);
+        assert_ne!(sns_version, initial_sns_version.clone());
 
         (new_sns_version_1, new_sns_version_2)
     };
 
+    // Step 2.1: wait for the upgrade steps to be refreshed.
     await_with_timeout(
         &pocket_ic,
         UPGRADE_STEPS_INTERVAL_REFRESH_BACKOFF_SECONDS,
@@ -172,27 +211,56 @@ async fn test_get_upgrade_journal() {
                 .versions
         },
         &vec![
-            initial_sns_version,
-            new_sns_version_1,
+            initial_sns_version.clone(),
+            new_sns_version_1.clone(),
             new_sns_version_2.clone(),
         ],
     )
     .await
     .unwrap();
 
-    // Advance the target version.
     {
-        sns::governance::advance_target_version(
+        expected_upgrade_journal_entries.push(
+            sns_pb::upgrade_journal_entry::Event::UpgradeStepsRefreshed(
+                sns_pb::upgrade_journal_entry::UpgradeStepsRefreshed {
+                    upgrade_steps: Some(Versions {
+                        versions: vec![
+                            initial_sns_version.clone(),
+                            new_sns_version_1.clone(),
+                            new_sns_version_2.clone(),
+                        ],
+                    }),
+                },
+            ),
+        );
+
+        assert_upgrade_journal(
             &pocket_ic,
-            sns.governance.canister_id,
-            new_sns_version_2.clone(),
+            sns.governance,
+            &expected_upgrade_journal_entries,
         )
         .await;
-
-        // Check that the target version is set to the new version.
-        let sns_pb::GetUpgradeJournalResponse { target_version, .. } =
-            sns::governance::get_upgrade_journal(&pocket_ic, sns.governance.canister_id).await;
-
-        assert_eq!(target_version, Some(new_sns_version_2.clone()));
     }
+
+    // State 3: Advance the target version.
+    sns::governance::advance_target_version(
+        &pocket_ic,
+        sns.governance.canister_id,
+        new_sns_version_2.clone(),
+    )
+    .await;
+
+    expected_upgrade_journal_entries.push(sns_pb::upgrade_journal_entry::Event::TargetVersionSet(
+        sns_pb::upgrade_journal_entry::TargetVersionSet {
+            old_target_version: None,
+            new_target_version: Some(new_sns_version_2),
+        },
+    ));
+
+    assert_upgrade_journal(
+        &pocket_ic,
+        sns.governance,
+        &expected_upgrade_journal_entries,
+    )
+    .await;
 }

--- a/rs/sns/governance/canister/canister.rs
+++ b/rs/sns/governance/canister/canister.rs
@@ -677,8 +677,7 @@ async fn mint_tokens(request: MintTokensRequest) -> MintTokensResponse {
 #[cfg(feature = "test")]
 #[update]
 fn advance_target_version(request: AdvanceTargetVersionRequest) -> AdvanceTargetVersionResponse {
-    governance_mut().proto.target_version = request.target_version;
-    AdvanceTargetVersionResponse {}
+    governance_mut().advance_target_version(request)
 }
 
 fn main() {

--- a/rs/sns/governance/canister/governance.did
+++ b/rs/sns/governance/canister/governance.did
@@ -724,7 +724,7 @@ type UpgradeJournalEntry = record {
   event : opt variant {
     UpgradeStepsRefreshed : UpgradeStepsRefreshed;
     TargetVersionSet : TargetVersionSet;
-    TargetVersionReset : TargetVersionSet;
+    TargetVersionReset : TargetVersionReset;
     UpgradeStarted : UpgradeStarted;
     UpgradeOutcome : UpgradeOutcome;
   };
@@ -736,6 +736,11 @@ type UpgradeStepsRefreshed = record {
 };
 
 type TargetVersionSet = record {
+  new_target_version : opt Version;
+  old_target_version : opt Version;
+};
+
+type TargetVersionReset = record {
   new_target_version : opt Version;
   old_target_version : opt Version;
 };

--- a/rs/sns/governance/canister/governance_test.did
+++ b/rs/sns/governance/canister/governance_test.did
@@ -738,7 +738,7 @@ type UpgradeJournalEntry = record {
   event : opt variant {
     UpgradeStepsRefreshed : UpgradeStepsRefreshed;
     TargetVersionSet : TargetVersionSet;
-    TargetVersionReset : TargetVersionSet;
+    TargetVersionReset : TargetVersionReset;
     UpgradeStarted : UpgradeStarted;
     UpgradeOutcome : UpgradeOutcome;
   };
@@ -750,6 +750,11 @@ type UpgradeStepsRefreshed = record {
 };
 
 type TargetVersionSet = record {
+  new_target_version : opt Version;
+  old_target_version : opt Version;
+};
+
+type TargetVersionReset = record {
   new_target_version : opt Version;
   old_target_version : opt Version;
 };

--- a/rs/sns/governance/proto/ic_sns_governance/pb/v1/governance.proto
+++ b/rs/sns/governance/proto/ic_sns_governance/pb/v1/governance.proto
@@ -2147,7 +2147,7 @@ message UpgradeJournalEntry {
   oneof event {
     UpgradeStepsRefreshed upgrade_steps_refreshed = 1;
     TargetVersionSet target_version_set = 2;
-    TargetVersionSet target_version_reset = 3;
+    TargetVersionReset target_version_reset = 3;
     UpgradeStarted upgrade_started = 4;
     UpgradeOutcome upgrade_outcome = 5;
   }
@@ -2158,6 +2158,11 @@ message UpgradeJournalEntry {
   }
 
   message TargetVersionSet {
+    optional Governance.Version old_target_version = 1;
+    optional Governance.Version new_target_version = 2;
+  }
+
+  message TargetVersionReset {
     optional Governance.Version old_target_version = 1;
     optional Governance.Version new_target_version = 2;
   }

--- a/rs/sns/governance/src/gen/ic_sns_governance.pb.v1.rs
+++ b/rs/sns/governance/src/gen/ic_sns_governance.pb.v1.rs
@@ -3387,6 +3387,20 @@ pub mod upgrade_journal_entry {
         PartialEq,
         ::prost::Message,
     )]
+    pub struct TargetVersionReset {
+        #[prost(message, optional, tag = "1")]
+        pub old_target_version: ::core::option::Option<super::governance::Version>,
+        #[prost(message, optional, tag = "2")]
+        pub new_target_version: ::core::option::Option<super::governance::Version>,
+    }
+    #[derive(
+        candid::CandidType,
+        candid::Deserialize,
+        comparable::Comparable,
+        Clone,
+        PartialEq,
+        ::prost::Message,
+    )]
     pub struct UpgradeStarted {
         #[prost(message, optional, tag = "1")]
         pub current_version: ::core::option::Option<super::governance::Version>,
@@ -3475,7 +3489,7 @@ pub mod upgrade_journal_entry {
         #[prost(message, tag = "2")]
         TargetVersionSet(TargetVersionSet),
         #[prost(message, tag = "3")]
-        TargetVersionReset(TargetVersionSet),
+        TargetVersionReset(TargetVersionReset),
         #[prost(message, tag = "4")]
         UpgradeStarted(UpgradeStarted),
         #[prost(message, tag = "5")]

--- a/rs/sns/governance/src/types.rs
+++ b/rs/sns/governance/src/types.rs
@@ -2755,24 +2755,18 @@ impl From<upgrade_journal_entry::UpgradeStepsRefreshed> for upgrade_journal_entr
         upgrade_journal_entry::Event::UpgradeStepsRefreshed(event)
     }
 }
-
-impl From<upgrade_journal_entry::TargetVersionSet> for upgrade_journal_entry::Event {
-    fn from(event: upgrade_journal_entry::TargetVersionSet) -> Self {
-        upgrade_journal_entry::Event::TargetVersionSet(event)
-    }
-}
-
 impl From<upgrade_journal_entry::UpgradeStarted> for upgrade_journal_entry::Event {
     fn from(event: upgrade_journal_entry::UpgradeStarted) -> Self {
         upgrade_journal_entry::Event::UpgradeStarted(event)
     }
 }
-
 impl From<upgrade_journal_entry::UpgradeOutcome> for upgrade_journal_entry::Event {
     fn from(event: upgrade_journal_entry::UpgradeOutcome) -> Self {
         upgrade_journal_entry::Event::UpgradeOutcome(event)
     }
 }
+// Note, we do not implement From<upgrade_journal_entry::TargetVersionSet> for upgrade_journal_entry::Event
+// because it is ambiguous which event variant to convert it to (TargetVersionSet vs TargetVersionReset).
 
 #[cfg(test)]
 pub(crate) mod tests {

--- a/rs/sns/governance/src/types.rs
+++ b/rs/sns/governance/src/types.rs
@@ -26,14 +26,14 @@ use crate::{
             nervous_system_function::FunctionType,
             neuron::Followees,
             proposal::Action,
-            ClaimSwapNeuronsError, ClaimSwapNeuronsResponse, ClaimedSwapNeuronStatus,
-            DefaultFollowees, DeregisterDappCanisters, Empty, ExecuteGenericNervousSystemFunction,
-            GovernanceError, ManageDappCanisterSettings, ManageLedgerParameters,
-            ManageNeuronResponse, ManageSnsMetadata, MintSnsTokens, Motion, NervousSystemFunction,
-            NervousSystemParameters, Neuron, NeuronId, NeuronIds, NeuronPermission,
-            NeuronPermissionList, NeuronPermissionType, ProposalId, RegisterDappCanisters,
-            RewardEvent, TransferSnsTreasuryFunds, UpgradeSnsControlledCanister,
-            UpgradeSnsToNextVersion, Vote, VotingRewardsParameters,
+            upgrade_journal_entry, ClaimSwapNeuronsError, ClaimSwapNeuronsResponse,
+            ClaimedSwapNeuronStatus, DefaultFollowees, DeregisterDappCanisters, Empty,
+            ExecuteGenericNervousSystemFunction, GovernanceError, ManageDappCanisterSettings,
+            ManageLedgerParameters, ManageNeuronResponse, ManageSnsMetadata, MintSnsTokens, Motion,
+            NervousSystemFunction, NervousSystemParameters, Neuron, NeuronId, NeuronIds,
+            NeuronPermission, NeuronPermissionList, NeuronPermissionType, ProposalId,
+            RegisterDappCanisters, RewardEvent, TransferSnsTreasuryFunds,
+            UpgradeSnsControlledCanister, UpgradeSnsToNextVersion, Vote, VotingRewardsParameters,
         },
     },
     proposal::ValidGenericNervousSystemFunction,
@@ -2747,6 +2747,30 @@ pub mod test_helpers {
         fn set_time_warp(&mut self, new_time_warp: TimeWarp) {
             self.now += new_time_warp.delta_s as u64
         }
+    }
+}
+
+impl From<upgrade_journal_entry::UpgradeStepsRefreshed> for upgrade_journal_entry::Event {
+    fn from(event: upgrade_journal_entry::UpgradeStepsRefreshed) -> Self {
+        upgrade_journal_entry::Event::UpgradeStepsRefreshed(event)
+    }
+}
+
+impl From<upgrade_journal_entry::TargetVersionSet> for upgrade_journal_entry::Event {
+    fn from(event: upgrade_journal_entry::TargetVersionSet) -> Self {
+        upgrade_journal_entry::Event::TargetVersionSet(event)
+    }
+}
+
+impl From<upgrade_journal_entry::UpgradeStarted> for upgrade_journal_entry::Event {
+    fn from(event: upgrade_journal_entry::UpgradeStarted) -> Self {
+        upgrade_journal_entry::Event::UpgradeStarted(event)
+    }
+}
+
+impl From<upgrade_journal_entry::UpgradeOutcome> for upgrade_journal_entry::Event {
+    fn from(event: upgrade_journal_entry::UpgradeOutcome) -> Self {
+        upgrade_journal_entry::Event::UpgradeOutcome(event)
     }
 }
 


### PR DESCRIPTION
This PR populates the upgrade journal when new events occur. The upgrade journal was first introduced in #2169

[← Previous PR](https://github.com/dfinity/ic/pull/2378) | [Next PR →](https://github.com/dfinity/ic/pull/2034)