### PR TITLE
feat(cketh/ckerc20): Deposit with subaccounts

### DIFF
--- a/rs/ethereum/cketh/minter/DepositHelperWithSubaccount.sol
+++ b/rs/ethereum/cketh/minter/DepositHelperWithSubaccount.sol
@@ -11,16 +11,11 @@ import {SafeERC20, IERC20} from "https://github.com/OpenZeppelin/openzeppelin-co
 contract CkDeposit {
     using SafeERC20 for IERC20;
 
+    address constant private ZERO_ADDRESS = address(0);
+
     address payable private immutable minterAddress;
 
-    event ReceivedEth(
-        address indexed from,
-        uint256 value,
-        bytes32 indexed principal,
-        bytes32 subaccount
-    );
-
-    event ReceivedErc20(
+    event ReceivedEthOrErc20(
         address indexed erc20ContractAddress,
         address indexed owner,
         uint256 amount,
@@ -44,10 +39,10 @@ contract CkDeposit {
     }
 
     /**
-     * @dev Emits the `ReceivedEth` event if the transfer succeeds.
+     * @dev Emits the `ReceivedEthOrErc20` event if the transfer succeeds.
      */
     function depositEth(bytes32 principal, bytes32 subaccount) public payable {
-        emit ReceivedEth(msg.sender, msg.value, principal, subaccount);
+        emit ReceivedEthOrErc20(ZERO_ADDRESS, msg.sender, msg.value, principal, subaccount);
         minterAddress.transfer(msg.value);
     }
 
@@ -60,6 +55,7 @@ contract CkDeposit {
         bytes32 principal,
         bytes32 subaccount
     ) public {
+        require(erc20Address != ZERO_ADDRESS, "ERC20: depositErc20 from the zero address");
         IERC20 erc20Token = IERC20(erc20Address);
         erc20Token.safeTransferFrom(
             msg.sender,
@@ -67,7 +63,7 @@ contract CkDeposit {
             amount
         );
 
-        emit ReceivedErc20(
+        emit ReceivedEthOrErc20(
             erc20Address,
             msg.sender,
             amount,

--- a/rs/ethereum/cketh/minter/cketh_minter.did
+++ b/rs/ethereum/cketh/minter/cketh_minter.did
@@ -110,6 +110,12 @@ type UpgradeArg = record {
     // The principal of the EVM RPC canister that handles the communication
     // with the Ethereum blockchain.
     evm_rpc_id : opt principal;
+
+    // Change the deposit with subaccount helper smart contract address.
+    deposit_with_subaccount_helper_contract_address : opt text;
+
+    // Change the last scraped block number of the deposit with subaccount helper smart contract.
+    last_deposit_with_subaccount_scraped_block_number : opt nat;
 };
 
 type MinterArg = variant { UpgradeArg : UpgradeArg; InitArg : InitArg };

--- a/rs/ethereum/cketh/minter/src/deposit.rs
+++ b/rs/ethereum/cketh/minter/src/deposit.rs
@@ -1,6 +1,6 @@
 use crate::eth_logs::{
     report_transaction_error, LogParser, LogScraping, ReceivedErc20LogScraping,
-    ReceivedEthLogScraping, ReceivedEvent, ReceivedEventError,
+    ReceivedEthLogScraping, ReceivedEthOrErc20LogScraping, ReceivedEvent, ReceivedEventError,
 };
 use crate::eth_rpc::{BlockSpec, GetLogsParam, HttpOutcallError, LogEntry, Topic};
 use crate::eth_rpc_client::{EthRpcClient, MultiCallError};
@@ -147,6 +147,7 @@ pub async fn scrape_logs() {
     let max_block_spread = read_state(|s| s.max_block_spread_for_logs_scraping());
     scrape_until_block::<ReceivedEthLogScraping>(last_block_number, max_block_spread).await;
     scrape_until_block::<ReceivedErc20LogScraping>(last_block_number, max_block_spread).await;
+    scrape_until_block::<ReceivedEthOrErc20LogScraping>(last_block_number, max_block_spread).await;
 }
 
 pub async fn update_last_observed_block_number() -> Option<BlockNumber> {

--- a/rs/ethereum/cketh/minter/src/eth_logs/mod.rs
+++ b/rs/ethereum/cketh/minter/src/eth_logs/mod.rs
@@ -19,7 +19,9 @@ use thiserror::Error;
 pub use parser::{
     LogParser, ReceivedErc20LogParser, ReceivedEthLogParser, ReceivedEthOrErc20LogParser,
 };
-pub use scraping::{LogScraping, ReceivedErc20LogScraping, ReceivedEthLogScraping};
+pub use scraping::{
+    LogScraping, ReceivedErc20LogScraping, ReceivedEthLogScraping, ReceivedEthOrErc20LogScraping,
+};
 
 // Keccak256("ReceivedEth(address,uint256,bytes32)")
 const RECEIVED_ETH_EVENT_TOPIC: [u8; 32] =

--- a/rs/ethereum/cketh/minter/src/eth_logs/mod.rs
+++ b/rs/ethereum/cketh/minter/src/eth_logs/mod.rs
@@ -97,6 +97,7 @@ impl fmt::Debug for ReceivedEthEvent {
             .field("from_address", &self.from_address)
             .field("value", &self.value)
             .field("principal", &format_args!("{}", self.principal))
+            .field("subaccount", &self.subaccount)
             .finish()
     }
 }
@@ -111,6 +112,7 @@ impl fmt::Debug for ReceivedErc20Event {
             .field("value", &self.value)
             .field("principal", &format_args!("{}", self.principal))
             .field("contract_address", &self.erc20_contract_address)
+            .field("subaccount", &self.subaccount)
             .finish()
     }
 }
@@ -286,7 +288,7 @@ type InternalLedgerSubaccount = CheckedAmountOf<InternalLedgerSubaccountTag>;
 ///
 /// Internally represented as a u256 to optimize cbor encoding for low values,
 /// which can be represented as a u32 or a u64.
-#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord, Decode, Encode)]
+#[derive(Clone, Eq, PartialEq, PartialOrd, Ord, Decode, Encode)]
 pub struct LedgerSubaccount(#[n(0)] InternalLedgerSubaccount);
 
 impl LedgerSubaccount {
@@ -300,5 +302,11 @@ impl LedgerSubaccount {
 
     pub fn to_bytes(self) -> [u8; 32] {
         self.0.to_be_bytes()
+    }
+}
+
+impl Debug for LedgerSubaccount {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "LedgerSubaccount({:x?})", self.0.to_be_bytes())
     }
 }

--- a/rs/ethereum/cketh/minter/src/eth_logs/mod.rs
+++ b/rs/ethereum/cketh/minter/src/eth_logs/mod.rs
@@ -13,10 +13,11 @@ use ic_canister_log::log;
 use ic_ethereum_types::Address;
 use minicbor::{Decode, Encode};
 use std::fmt;
+use std::fmt::{Debug, Formatter};
 use thiserror::Error;
 
 pub use parser::{
-    Erc20WithSubaccountLogParser, LogParser, ReceivedErc20LogParser, ReceivedEthLogParser,
+    LogParser, ReceivedErc20LogParser, ReceivedEthLogParser, ReceivedEthOrErc20LogParser,
 };
 pub use scraping::{LogScraping, ReceivedErc20LogScraping, ReceivedEthLogScraping};
 
@@ -28,9 +29,9 @@ const RECEIVED_ETH_EVENT_TOPIC: [u8; 32] =
 const RECEIVED_ERC20_EVENT_TOPIC: [u8; 32] =
     hex!("4d69d0bd4287b7f66c548f90154dc81bc98f65a1b362775df5ae171a2ccd262b");
 
-// Keccak256("ReceivedErc20(address,address,uint256,bytes32,bytes32)")
-const RECEIVED_ERC20_EVENT_WITH_SUBACCOUNT_TOPIC: [u8; 32] =
-    hex!("aef895090c2f5d6e81a70bef80dce496a0558487845aada57822159d5efae5cf");
+// Keccak256("ReceivedEthOrErc20(address,address,uint256,bytes32,bytes32)")
+const RECEIVED_ETH_OR_ERC20_WITH_SUBACCOUNT_EVENT_TOPIC: [u8; 32] =
+    hex!("918adbebdb8f3b36fc337ab76df10b147b2def5c9dd62cb3456d9aeca40e0b07");
 
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Decode, Encode)]
 pub struct ReceivedEthEvent {

--- a/rs/ethereum/cketh/minter/src/eth_logs/parser.rs
+++ b/rs/ethereum/cketh/minter/src/eth_logs/parser.rs
@@ -103,7 +103,7 @@ impl LogParser for ReceivedErc20LogParser {
     }
 }
 
-pub struct ReceivedEthOrErc20LogParser {}
+pub enum ReceivedEthOrErc20LogParser {}
 
 impl LogParser for ReceivedEthOrErc20LogParser {
     fn parse_log(entry: LogEntry) -> Result<ReceivedEvent, ReceivedEventError> {

--- a/rs/ethereum/cketh/minter/src/eth_logs/parser.rs
+++ b/rs/ethereum/cketh/minter/src/eth_logs/parser.rs
@@ -132,35 +132,32 @@ impl LogParser for ReceivedEthOrErc20LogParser {
             log_index,
         } = event_source;
 
-        match erc20_contract_address {
-            address if address == Address::ZERO => {
-                let value = Wei::from_be_bytes(value_bytes);
-                Ok(ReceivedEthEvent {
-                    transaction_hash,
-                    block_number,
-                    log_index,
-                    from_address,
-                    value,
-                    principal,
-                    subaccount,
-                }
-                .into())
+        if erc20_contract_address == Address::ZERO {
+            let value = Wei::from_be_bytes(value_bytes);
+            return Ok(ReceivedEthEvent {
+                transaction_hash,
+                block_number,
+                log_index,
+                from_address,
+                value,
+                principal,
+                subaccount,
             }
-            _ => {
-                let value = Erc20Value::from_be_bytes(value_bytes);
-                Ok(ReceivedErc20Event {
-                    transaction_hash,
-                    block_number,
-                    log_index,
-                    from_address,
-                    value,
-                    principal,
-                    erc20_contract_address,
-                    subaccount,
-                }
-                .into())
-            }
+            .into());
         }
+
+        let value = Erc20Value::from_be_bytes(value_bytes);
+        Ok(ReceivedErc20Event {
+            transaction_hash,
+            block_number,
+            log_index,
+            from_address,
+            value,
+            principal,
+            erc20_contract_address,
+            subaccount,
+        }
+        .into())
     }
 }
 

--- a/rs/ethereum/cketh/minter/src/eth_logs/scraping.rs
+++ b/rs/ethereum/cketh/minter/src/eth_logs/scraping.rs
@@ -19,6 +19,7 @@ pub trait LogScraping {
     fn display_id() -> &'static str;
 }
 
+#[derive(Clone, PartialEq, Eq, Debug)]
 pub struct Scrape {
     pub contract_address: Address,
     pub last_scraped_block_number: BlockNumber,

--- a/rs/ethereum/cketh/minter/src/eth_logs/tests.rs
+++ b/rs/ethereum/cketh/minter/src/eth_logs/tests.rs
@@ -1,7 +1,9 @@
 mod parser {
+    use crate::eth_logs::parser::ReceivedEthOrErc20LogParser;
     use crate::eth_logs::{
-        Erc20WithSubaccountLogParser, LedgerSubaccount, LogParser, ReceivedErc20Event,
-        ReceivedErc20LogParser, ReceivedEthEvent, ReceivedEthLogParser, RECEIVED_ETH_EVENT_TOPIC,
+        LedgerSubaccount, LogParser, ReceivedErc20Event, ReceivedErc20LogParser, ReceivedEthEvent,
+        ReceivedEthLogParser, RECEIVED_ERC20_EVENT_TOPIC, RECEIVED_ETH_EVENT_TOPIC,
+        RECEIVED_ETH_OR_ERC20_WITH_SUBACCOUNT_EVENT_TOPIC,
     };
     use crate::eth_rpc::LogEntry;
     use crate::numeric::{BlockNumber, Erc20Value, LogIndex, Wei};
@@ -11,10 +13,22 @@ mod parser {
 
     #[test]
     fn should_have_correct_topic() {
-        //must match event signature in minter.sol
-        let event_signature = "ReceivedEth(address,uint256,bytes32)";
-        let topic = Keccak256::hash(event_signature);
-        assert_eq!(topic, RECEIVED_ETH_EVENT_TOPIC)
+        for (event_signature, expected_topic) in [
+            (
+                "ReceivedEth(address,uint256,bytes32)",
+                RECEIVED_ETH_EVENT_TOPIC,
+            ),
+            (
+                "ReceivedErc20(address,address,uint256,bytes32)",
+                RECEIVED_ERC20_EVENT_TOPIC,
+            ),
+            (
+                "ReceivedEthOrErc20(address,address,uint256,bytes32,bytes32)",
+                RECEIVED_ETH_OR_ERC20_WITH_SUBACCOUNT_EVENT_TOPIC,
+            ),
+        ] {
+            assert_eq!(Keccak256::hash(event_signature), expected_topic)
+        }
     }
 
     #[test]
@@ -103,35 +117,35 @@ mod parser {
     #[test]
     fn should_parse_received_erc20_event_with_subaccount() {
         let event = r#"{
-            "address": "0x11d7c426eedc044b21066d2be9480d4b99e7cc1a",
+            "address": "0x2d39863d30716aaf2b7fffd85dd03dda2bfc2e38",
             "topics": [
-                "0xaef895090c2f5d6e81a70bef80dce496a0558487845aada57822159d5efae5cf",
+                "0x918adbebdb8f3b36fc337ab76df10b147b2def5c9dd62cb3456d9aeca40e0b07",
                 "0x0000000000000000000000001c7d4b196cb0c7b01d743fbc6116a902379c7238",
                 "0x000000000000000000000000dd2851cdd40ae6536831558dd46db62fac7a844d",
                 "0x1d9facb184cbe453de4841b6b9d9cc95bfc065344e485789b550544529020000"
             ],
-            "data": "0x000000000000000000000000000000000000000000000000000000000001869fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
-            "blockNumber": "0x698adb",
-            "transactionHash": "0xf353e17cbcfea236a8b03d2d800205074e1f5014a3ce0f6dedcf128addb6bea4",
-            "transactionIndex": "0x15",
-            "blockHash": "0xeee67434b62fe62182ee51cdaf2693f112994fd3aa4d043c7e4a16fe775c37e3",
-            "logIndex": "0x45",
+            "data": "0x000000000000000000000000000000000000000000000000000000000000000aff00000000000000000000000000000000000000000000000000000000000000",
+            "blockNumber": "0x6a5c7b",
+            "transactionHash": "0x89a5cd5304b8e210e1888862be09d6bb75ba0d1b9e741021223758f92f714a15",
+            "transactionIndex": "0x7",
+            "blockHash": "0x610b7733af90f0ddbcc15756e6de041c928804ad01a1bb036aeeec43e29a1a45",
+            "logIndex": "0x5",
             "removed": false
         }"#;
-        let parsed_event = Erc20WithSubaccountLogParser::parse_log(
+        let parsed_event = ReceivedEthOrErc20LogParser::parse_log(
             serde_json::from_str::<LogEntry>(event).unwrap(),
         )
         .unwrap();
         let expected_event = ReceivedErc20Event {
-            transaction_hash: "0xf353e17cbcfea236a8b03d2d800205074e1f5014a3ce0f6dedcf128addb6bea4"
+            transaction_hash: "0x89a5cd5304b8e210e1888862be09d6bb75ba0d1b9e741021223758f92f714a15"
                 .parse()
                 .unwrap(),
-            block_number: BlockNumber::new(6916827),
-            log_index: LogIndex::from(69_u8),
+            block_number: BlockNumber::new(6970491),
+            log_index: LogIndex::from(5_u8),
             from_address: "0xdd2851Cdd40aE6536831558DD46db62fAc7A844d"
                 .parse()
                 .unwrap(),
-            value: Erc20Value::from(99_999_u128),
+            value: Erc20Value::from(10_u8),
             principal: Principal::from_str(
                 "hkroy-sm7vs-yyjs7-ekppe-qqnwx-hm4zf-n7ybs-titsi-k6e3k-ucuiu-uqe",
             )
@@ -139,7 +153,55 @@ mod parser {
             erc20_contract_address: "0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238"
                 .parse()
                 .unwrap(),
-            subaccount: LedgerSubaccount::from_bytes([0xff; 32]),
+            subaccount: LedgerSubaccount::from_bytes([
+                0xff, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0,
+            ]),
+        }
+        .into();
+
+        assert_eq!(parsed_event, expected_event);
+    }
+    #[test]
+    fn should_parse_received_eth_event_with_subaccount() {
+        let event = r#"{
+            "address": "0x2d39863d30716aaf2b7fffd85dd03dda2bfc2e38",
+            "topics": [
+                "0x918adbebdb8f3b36fc337ab76df10b147b2def5c9dd62cb3456d9aeca40e0b07",
+                "0x0000000000000000000000000000000000000000000000000000000000000000",
+                "0x000000000000000000000000dd2851cdd40ae6536831558dd46db62fac7a844d",
+                "0x1d9facb184cbe453de4841b6b9d9cc95bfc065344e485789b550544529020000"
+            ],
+            "data": "0x00000000000000000000000000000000000000000000000000038d7ea4c68000ff00000000000000000000000000000000000000000000000000000000000000",
+            "blockNumber": "0x6a5c69",
+            "transactionHash": "0x5a258e23fa361d60dcee4cd1eac24473cc4391e1cb4022aea722c49ab26cadf8",
+            "transactionIndex": "0xc",
+            "blockHash": "0xc419283f22e6c6d33971837a01962c9688f291499971bd22b08e596db40b167a",
+            "logIndex": "0xa",
+            "removed": false
+        }"#;
+        let parsed_event = ReceivedEthOrErc20LogParser::parse_log(
+            serde_json::from_str::<LogEntry>(event).unwrap(),
+        )
+        .unwrap();
+        let expected_event = ReceivedEthEvent {
+            transaction_hash: "0x5a258e23fa361d60dcee4cd1eac24473cc4391e1cb4022aea722c49ab26cadf8"
+                .parse()
+                .unwrap(),
+            block_number: BlockNumber::new(6970473),
+            log_index: LogIndex::from(10_u8),
+            from_address: "0xdd2851Cdd40aE6536831558DD46db62fAc7A844d"
+                .parse()
+                .unwrap(),
+            value: Wei::from(1_000_000_000_000_000_u64),
+            principal: Principal::from_str(
+                "hkroy-sm7vs-yyjs7-ekppe-qqnwx-hm4zf-n7ybs-titsi-k6e3k-ucuiu-uqe",
+            )
+            .unwrap(),
+            subaccount: LedgerSubaccount::from_bytes([
+                0xff, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0,
+            ]),
         }
         .into();
 

--- a/rs/ethereum/cketh/minter/src/eth_rpc.rs
+++ b/rs/ethereum/cketh/minter/src/eth_rpc.rs
@@ -301,7 +301,7 @@ pub struct GetLogsParam {
 }
 
 /// A topic is either a 32 Bytes DATA, or an array of 32 Bytes DATA with "or" options.
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
 #[serde(untagged)]
 pub enum Topic {
     Single(FixedSizeData),

--- a/rs/ethereum/cketh/minter/src/eth_rpc.rs
+++ b/rs/ethereum/cketh/minter/src/eth_rpc.rs
@@ -75,6 +75,10 @@ impl AsRef<[u8]> for Data {
 #[serde(transparent)]
 pub struct FixedSizeData(#[serde(with = "ic_ethereum_types::serde_data")] pub [u8; 32]);
 
+impl FixedSizeData {
+    pub const ZERO: Self = Self([0u8; 32]);
+}
+
 impl AsRef<[u8]> for FixedSizeData {
     fn as_ref(&self) -> &[u8] {
         &self.0

--- a/rs/ethereum/cketh/minter/src/guard/tests.rs
+++ b/rs/ethereum/cketh/minter/src/guard/tests.rs
@@ -1,4 +1,4 @@
-use crate::numeric::wei_from_milli_ether;
+use crate::test_fixtures::initial_state;
 
 mod retrieve_eth_guard {
     use crate::guard::tests::init_state;
@@ -130,23 +130,7 @@ mod timer_guard {
 }
 
 fn init_state() {
-    use crate::lifecycle::init::InitArg;
-    use crate::state::State;
-    use candid::Principal;
     crate::state::STATE.with(|s| {
-        *s.borrow_mut() = Some(
-            State::try_from(InitArg {
-                ethereum_network: Default::default(),
-                ecdsa_key_name: "test_key_1".to_string(),
-                ethereum_contract_address: None,
-                ledger_id: Principal::from_text("apia6-jaaaa-aaaar-qabma-cai")
-                    .expect("BUG: invalid principal"),
-                ethereum_block_height: Default::default(),
-                minimum_withdrawal_amount: wei_from_milli_ether(10).into(),
-                next_transaction_nonce: Default::default(),
-                last_scraped_block_number: Default::default(),
-            })
-            .expect("init args should be valid"),
-        );
+        *s.borrow_mut() = Some(initial_state());
     });
 }

--- a/rs/ethereum/cketh/minter/src/lifecycle/init.rs
+++ b/rs/ethereum/cketh/minter/src/lifecycle/init.rs
@@ -79,6 +79,7 @@ impl TryFrom<InitArg> for State {
                 })?;
         }
         let erc20_log_scraping = LogScrapingState::new(last_scraped_block_number);
+        let deposit_with_subaccount_log_scraping = LogScrapingState::new(last_scraped_block_number);
         let state = Self {
             ethereum_network,
             ecdsa_key_name,
@@ -104,6 +105,7 @@ impl TryFrom<InitArg> for State {
             erc20_balances: Default::default(),
             eth_log_scraping,
             erc20_log_scraping,
+            deposit_with_subaccount_log_scraping,
         };
         state.validate_config()?;
         Ok(state)

--- a/rs/ethereum/cketh/minter/src/lifecycle/tests.rs
+++ b/rs/ethereum/cketh/minter/src/lifecycle/tests.rs
@@ -2,6 +2,7 @@ mod init {
     use crate::lifecycle::init::InitArg;
     use crate::numeric::{TransactionNonce, Wei};
     use crate::state::{InvalidStateError, State};
+    use crate::test_fixtures::valid_init_arg;
     use assert_matches::assert_matches;
     use candid::{Nat, Principal};
     use num_bigint::BigUint;
@@ -89,19 +90,5 @@ mod init {
             state.eth_transactions.next_transaction_nonce(),
             TransactionNonce::ZERO
         );
-    }
-
-    fn valid_init_arg() -> InitArg {
-        InitArg {
-            ethereum_network: Default::default(),
-            ecdsa_key_name: "test_key_1".to_string(),
-            ethereum_contract_address: None,
-            ledger_id: Principal::from_text("apia6-jaaaa-aaaar-qabma-cai")
-                .expect("BUG: invalid principal"),
-            ethereum_block_height: Default::default(),
-            minimum_withdrawal_amount: Nat::from(10_000_000_000_000_000_u64),
-            next_transaction_nonce: TransactionNonce::ZERO.into(),
-            last_scraped_block_number: Default::default(),
-        }
     }
 }

--- a/rs/ethereum/cketh/minter/src/lifecycle/upgrade.rs
+++ b/rs/ethereum/cketh/minter/src/lifecycle/upgrade.rs
@@ -26,6 +26,10 @@ pub struct UpgradeArg {
     pub last_erc20_scraped_block_number: Option<Nat>,
     #[cbor(n(7), with = "crate::cbor::principal::option")]
     pub evm_rpc_id: Option<Principal>,
+    #[n(8)]
+    pub deposit_with_subaccount_helper_contract_address: Option<String>,
+    #[cbor(n(9), with = "crate::cbor::nat::option")]
+    pub last_deposit_with_subaccount_scraped_block_number: Option<Nat>,
 }
 
 pub fn post_upgrade(upgrade_args: Option<UpgradeArg>) {

--- a/rs/ethereum/cketh/minter/src/state.rs
+++ b/rs/ethereum/cketh/minter/src/state.rs
@@ -57,6 +57,7 @@ pub struct State {
     pub cketh_ledger_id: Principal,
     pub eth_log_scraping: LogScrapingState,
     pub erc20_log_scraping: LogScrapingState,
+    pub deposit_with_subaccount_log_scraping: LogScrapingState,
     pub ecdsa_public_key: Option<EcdsaPublicKeyResponse>,
     pub cketh_minimum_withdrawal_amount: Wei,
     pub ethereum_block_height: BlockTag,
@@ -462,6 +463,8 @@ impl State {
             erc20_helper_contract_address,
             last_erc20_scraped_block_number,
             evm_rpc_id,
+            deposit_with_subaccount_helper_contract_address,
+            last_deposit_with_subaccount_scraped_block_number,
         } = upgrade_args;
         if let Some(nonce) = next_transaction_nonce {
             let nonce = TransactionNonce::try_from(nonce)
@@ -501,6 +504,27 @@ impl State {
                 })?,
             );
         }
+        if let Some(address) = deposit_with_subaccount_helper_contract_address {
+            let address = Address::from_str(&address).map_err(|e| {
+                InvalidStateError::InvalidErc20HelperContractAddress(format!("ERROR: {}", e))
+            })?;
+            self.deposit_with_subaccount_log_scraping
+                .set_contract_address(address)
+                .map_err(|e| {
+                    InvalidStateError::InvalidEthereumContractAddress(format!("ERROR: {:?}", e))
+                })?;
+        }
+        if let Some(block_number) = last_deposit_with_subaccount_scraped_block_number {
+            self.deposit_with_subaccount_log_scraping
+                .set_last_scraped_block_number(BlockNumber::try_from(block_number).map_err(
+                    |e| {
+                        InvalidStateError::InvalidLastErc20ScrapedBlockNumber(format!(
+                            "ERROR: {}",
+                            e
+                        ))
+                    },
+                )?);
+        }
         if let Some(block_height) = ethereum_block_height {
             self.ethereum_block_height = block_height.into();
         }
@@ -533,6 +557,10 @@ impl State {
         ensure_eq!(self.ecdsa_key_name, other.ecdsa_key_name);
         ensure_eq!(self.eth_log_scraping, other.eth_log_scraping);
         ensure_eq!(self.erc20_log_scraping, other.erc20_log_scraping);
+        ensure_eq!(
+            self.deposit_with_subaccount_log_scraping,
+            other.deposit_with_subaccount_log_scraping
+        );
         ensure_eq!(
             self.cketh_minimum_withdrawal_amount,
             other.cketh_minimum_withdrawal_amount

--- a/rs/ethereum/cketh/minter/src/state/tests.rs
+++ b/rs/ethereum/cketh/minter/src/state/tests.rs
@@ -235,7 +235,8 @@ mod mint_transaction {
           log_index: 29, \
           from_address: 0xdd2851Cdd40aE6536831558DD46db62fAc7A844d, \
           value: 10_000_000_000_000_000, \
-          principal: k2t6j-2nvnp-4zjm3-25dtz-6xhaa-c7boj-5gayf-oj3xs-i43lp-teztq-6ae \
+          principal: k2t6j-2nvnp-4zjm3-25dtz-6xhaa-c7boj-5gayf-oj3xs-i43lp-teztq-6ae, \
+          subaccount: None \
         }";
         assert_eq!(format!("{:?}", received_eth_event()), expected);
     }
@@ -249,7 +250,8 @@ mod mint_transaction {
           from_address: 0xdd2851Cdd40aE6536831558DD46db62fAc7A844d, \
           value: 5_000_000, \
           principal: hkroy-sm7vs-yyjs7-ekppe-qqnwx-hm4zf-n7ybs-titsi-k6e3k-ucuiu-uqe, \
-          contract_address: 0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238 \
+          contract_address: 0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238, \
+          subaccount: None \
         }";
         assert_eq!(format!("{:?}", received_erc20_event()), expected);
     }

--- a/rs/ethereum/cketh/minter/src/state/tests.rs
+++ b/rs/ethereum/cketh/minter/src/state/tests.rs
@@ -9,15 +9,18 @@ use crate::lifecycle::upgrade::UpgradeArg;
 use crate::lifecycle::EthereumNetwork;
 use crate::map::DedupMultiKeyMap;
 use crate::numeric::{
-    wei_from_milli_ether, BlockNumber, CkTokenAmount, Erc20Value, GasAmount, LedgerBurnIndex,
-    LedgerMintIndex, LogIndex, TransactionNonce, Wei, WeiPerGas,
+    BlockNumber, CkTokenAmount, Erc20Value, GasAmount, LedgerBurnIndex, LedgerMintIndex, LogIndex,
+    TransactionNonce, Wei, WeiPerGas,
 };
 use crate::state::audit::apply_state_transition;
 use crate::state::eth_logs_scraping::LogScrapingState;
 use crate::state::event::{Event, EventType};
 use crate::state::transactions::{Erc20WithdrawalRequest, ReimbursementIndex};
 use crate::state::{Erc20Balances, State};
-use crate::test_fixtures::arb::{arb_address, arb_checked_amount_of, arb_hash};
+use crate::test_fixtures::{
+    arb::{arb_address, arb_checked_amount_of, arb_hash},
+    initial_state,
+};
 use crate::tx::{
     AccessList, AccessListItem, Eip1559Signature, Eip1559TransactionRequest, GasFeeEstimate,
     ResubmissionStrategy, SignedEip1559TransactionRequest, StorageKey,
@@ -31,7 +34,7 @@ use proptest::prelude::*;
 use std::collections::BTreeMap;
 
 mod next_request_id {
-    use crate::state::tests::initial_state;
+    use super::*;
 
     #[test]
     fn should_retrieve_and_increment_counter() {
@@ -51,21 +54,6 @@ mod next_request_id {
         assert_eq!(state.next_request_id(), u64::MAX);
         assert_eq!(state.next_request_id(), 0);
     }
-}
-
-fn initial_state() -> State {
-    State::try_from(InitArg {
-        ethereum_network: Default::default(),
-        ecdsa_key_name: "test_key_1".to_string(),
-        ethereum_contract_address: None,
-        ledger_id: Principal::from_text("apia6-jaaaa-aaaar-qabma-cai")
-            .expect("BUG: invalid principal"),
-        ethereum_block_height: Default::default(),
-        minimum_withdrawal_amount: wei_from_milli_ether(10).into(),
-        next_transaction_nonce: Default::default(),
-        last_scraped_block_number: Default::default(),
-    })
-    .expect("init args should be valid")
 }
 
 mod mint_transaction {
@@ -1854,6 +1842,7 @@ mod erc20_balance {
         assert_eq!(balance_after, balance_before);
     }
 }
+
 fn initial_erc20_state() -> State {
     let mut state = initial_state();
     add_erc20_token(&mut state);

--- a/rs/ethereum/cketh/minter/src/test_fixtures.rs
+++ b/rs/ethereum/cketh/minter/src/test_fixtures.rs
@@ -1,3 +1,7 @@
+use crate::lifecycle::init::InitArg;
+use crate::state::State;
+use candid::{Nat, Principal};
+
 pub fn expect_panic_with_message<F: FnOnce() -> R, R: std::fmt::Debug>(
     f: F,
     expected_message: &str,
@@ -22,6 +26,24 @@ pub fn expect_panic_with_message<F: FnOnce() -> R, R: std::fmt::Debug>(
         expected_message,
         panic_message
     );
+}
+
+pub fn initial_state() -> State {
+    State::try_from(valid_init_arg()).expect("BUG: invalid init arg")
+}
+
+pub fn valid_init_arg() -> InitArg {
+    InitArg {
+        ethereum_network: Default::default(),
+        ecdsa_key_name: "test_key_1".to_string(),
+        ethereum_contract_address: None,
+        ledger_id: Principal::from_text("apia6-jaaaa-aaaar-qabma-cai")
+            .expect("BUG: invalid principal"),
+        ethereum_block_height: Default::default(),
+        minimum_withdrawal_amount: Nat::from(10_000_000_000_000_000_u64),
+        next_transaction_nonce: Default::default(),
+        last_scraped_block_number: Default::default(),
+    }
 }
 
 pub mod arb {


### PR DESCRIPTION
Support deposit of ETH or ERC-20 with subaccounts by scraping the logs of a new smart contract, currently deployed only on Sepolia at [0x2D39863d30716aaf2B7fFFd85Dd03Dda2BFC2E38](https://sepolia.etherscan.io/address/0x2d39863d30716aaf2b7fffd85dd03dda2bfc2e38). The smart contract offers 2 methods:

1. `depositEth`
2. `depositErc20`
that when successful emit the same type of event `ReceivedEthOrErc20`, which allows to retrieve the logs of that smart contract in a single request.
