### PR TITLE
chore(sns): Set `INITIAL_CANISTER_CREATION_CYCLES` to 3T

### DIFF
--- a/rs/nns/sns-wasm/src/sns_wasm.rs
+++ b/rs/nns/sns-wasm/src/sns_wasm.rs
@@ -55,7 +55,7 @@ use dfn_core::println;
 
 const LOG_PREFIX: &str = "[SNS-WASM] ";
 
-const INITIAL_CANISTER_CREATION_CYCLES: u64 = 2 * ONE_TRILLION;
+const INITIAL_CANISTER_CREATION_CYCLES: u64 = 3 * ONE_TRILLION;
 
 /// The number of canisters that the SNS-WASM canister will install when deploying
 /// an SNS. This constant is different than `SNS_CANISTER_COUNT` due to the Archive

--- a/rs/nns/sns-wasm/src/sns_wasm.rs
+++ b/rs/nns/sns-wasm/src/sns_wasm.rs
@@ -55,7 +55,7 @@ use dfn_core::println;
 
 const LOG_PREFIX: &str = "[SNS-WASM] ";
 
-const INITIAL_CANISTER_CREATION_CYCLES: u64 = ONE_TRILLION;
+const INITIAL_CANISTER_CREATION_CYCLES: u64 = 2 * ONE_TRILLION;
 
 /// The number of canisters that the SNS-WASM canister will install when deploying
 /// an SNS. This constant is different than `SNS_CANISTER_COUNT` due to the Archive

--- a/rs/nns/sns-wasm/tests/deploy_new_sns.rs
+++ b/rs/nns/sns-wasm/tests/deploy_new_sns.rs
@@ -243,10 +243,12 @@ fn test_deploy_cleanup_on_wasm_install_failure() {
         );
     }
 
-    // 5_000_000_000_000 cycles are burned creating the canisters before the failure
+    // 15_000_000_000_000 cycles are burned creating the canisters before the failure
+    let initial_canister_creation_cycles = 3 * ONE_TRILLION as u128;
     assert_eq!(
         machine.cycle_balance(SNS_WASM_CANISTER_ID),
-        EXPECTED_SNS_CREATION_FEE - SNS_CANISTER_COUNT_AT_INSTALL as u128 * (ONE_TRILLION as u128)
+        EXPECTED_SNS_CREATION_FEE
+            - SNS_CANISTER_COUNT_AT_INSTALL as u128 * initial_canister_creation_cycles,
     );
 }
 


### PR DESCRIPTION
This PR prepares the SNS-W canister to an upcoming replica change (https://github.com/dfinity/ic/pull/2308).

The previous value for `INITIAL_CANISTER_CREATION_CYCLES` was 1T.

With that amount, I experimentally observed the following error during SNS deployment, more specifically, when the SNS Root was being installed:

```
Error installing Root WASM: 
  Failed to install WASM on canister 7tjcv-pp777-77776-qaaaa-cai: 
    error code 2: 
      Canister installation failed with 
      `Canister 7tjcv-pp777-77776-qaaaa-cai is out of cycles: 
       please top up the canister with at least 46_167_036_896 additional cycles`.
```

Thus, setting `INITIAL_CANISTER_CREATION_CYCLES` to 2T would suffice to cover the increased deployment costs. 

However, another fee increase planned in two weeks from now will be `canister_creation_fee`, which is planned be increase from 0.1T to 0.5T. The adjustment in this PR takes that upcoming change into account. With just 2T for canister creation, an SNS deployment would fail with: 

```
Error installing Root WASM: 
  Failed to install WASM on canister 7tjcv-pp777-77776-qaaaa-cai:
    error code 2:
      Canister installation failed with 
        `Canister 7tjcv-pp777-77776-qaaaa-cai is out of cycles: 
          please top up the canister with at least 92_320_883_050 additional cycles`.
```

Thus, setting `INITIAL_CANISTER_CREATION_CYCLES` to 3T would suffice to cover the increased creation _and_ deployment costs. 