### PR TITLE
chore: Add sandbox cache hit dashboard to testnet grafana

### DIFF
--- a/rs/tests/dashboards/IC/execution-metrics.json
+++ b/rs/tests/dashboards/IC/execution-metrics.json
@@ -42,7 +42,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
-  "id": 143,
+  "id": 41,
   "links": [
     {
       "asDropdown": true,
@@ -84,7 +84,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 1
+            "y": 9
           },
           "hiddenSeries": false,
           "id": 45,
@@ -175,7 +175,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 1
+            "y": 9
           },
           "hiddenSeries": false,
           "id": 84,
@@ -262,7 +262,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 9
+            "y": 17
           },
           "hiddenSeries": false,
           "id": 85,
@@ -348,7 +348,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 9
+            "y": 17
           },
           "hiddenSeries": false,
           "id": 86,
@@ -434,7 +434,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 17
+            "y": 25
           },
           "hiddenSeries": false,
           "id": 43,
@@ -523,7 +523,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 17
+            "y": 25
           },
           "hiddenSeries": false,
           "id": 73,
@@ -619,7 +619,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 25
+            "y": 33
           },
           "hiddenSeries": false,
           "id": 126,
@@ -708,7 +708,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 25
+            "y": 33
           },
           "hiddenSeries": false,
           "id": 127,
@@ -804,7 +804,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 33
+            "y": 41
           },
           "hiddenSeries": false,
           "id": 41,
@@ -897,7 +897,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 33
+            "y": 41
           },
           "hiddenSeries": false,
           "id": 40,
@@ -984,7 +984,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 41
+            "y": 49
           },
           "hiddenSeries": false,
           "id": 102,
@@ -1076,7 +1076,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 41
+            "y": 49
           },
           "hiddenSeries": false,
           "id": 125,
@@ -1164,7 +1164,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 49
+            "y": 57
           },
           "hiddenSeries": false,
           "id": 103,
@@ -1250,7 +1250,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 49
+            "y": 57
           },
           "hiddenSeries": false,
           "id": 105,
@@ -1336,7 +1336,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 57
+            "y": 65
           },
           "hiddenSeries": false,
           "id": 109,
@@ -1429,7 +1429,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 57
+            "y": 65
           },
           "hiddenSeries": false,
           "id": 87,
@@ -1546,8 +1546,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -1563,7 +1562,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 65
+            "y": 73
           },
           "id": 108,
           "options": {
@@ -1610,7 +1609,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 65
+            "y": 73
           },
           "hiddenSeries": false,
           "id": 104,
@@ -1718,7 +1717,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 73
+            "y": 81
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -1814,7 +1813,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 73
+            "y": 81
           },
           "hiddenSeries": false,
           "id": 106,
@@ -1922,7 +1921,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 81
+            "y": 89
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -2064,7 +2063,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 81
+            "y": 89
           },
           "id": 107,
           "options": {
@@ -2133,7 +2132,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 89
+            "y": 97
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -2251,7 +2250,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 89
+            "y": 97
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -2347,7 +2346,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 97
+            "y": 105
           },
           "hiddenSeries": false,
           "id": 136,
@@ -2456,7 +2455,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 97
+            "y": 105
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -2558,7 +2557,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 105
+            "y": 113
           },
           "hiddenSeries": false,
           "id": 137,
@@ -2645,7 +2644,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 113
+            "y": 121
           },
           "hiddenSeries": false,
           "id": 139,
@@ -2797,7 +2796,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 2
+            "y": 10
           },
           "hiddenSeries": false,
           "id": 100,
@@ -2884,7 +2883,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 2
+            "y": 10
           },
           "hiddenSeries": false,
           "id": 311,
@@ -2977,7 +2976,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 10
+            "y": 18
           },
           "hiddenSeries": false,
           "id": 308,
@@ -3070,7 +3069,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 10
+            "y": 18
           },
           "hiddenSeries": false,
           "id": 312,
@@ -3185,7 +3184,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 18
+            "y": 26
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -3306,7 +3305,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 18
+            "y": 26
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -3433,7 +3432,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 26
+            "y": 34
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -3532,7 +3531,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 1
+        "y": 2
       },
       "id": 294,
       "panels": [
@@ -3558,7 +3557,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 2
+            "y": 10
           },
           "hiddenSeries": false,
           "id": 88,
@@ -3651,7 +3650,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 2
+            "y": 10
           },
           "hiddenSeries": false,
           "id": 288,
@@ -3738,7 +3737,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 10
+            "y": 18
           },
           "hiddenSeries": false,
           "id": 138,
@@ -3825,7 +3824,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 10
+            "y": 18
           },
           "hiddenSeries": false,
           "id": 142,
@@ -3906,7 +3905,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 2
+        "y": 3
       },
       "id": 165,
       "panels": [
@@ -3916,7 +3915,7 @@
             "h": 4,
             "w": 24,
             "x": 0,
-            "y": 3
+            "y": 11
           },
           "id": 167,
           "options": {
@@ -4033,7 +4032,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 7
+            "y": 15
           },
           "id": 162,
           "options": {
@@ -4333,7 +4332,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 7
+            "y": 15
           },
           "id": 163,
           "options": {
@@ -4543,7 +4542,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 3
+        "y": 4
       },
       "id": 300,
       "panels": [
@@ -4569,7 +4568,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 4
+            "y": 12
           },
           "hiddenSeries": false,
           "id": 63,
@@ -4705,7 +4704,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 4
+            "y": 12
           },
           "hiddenSeries": false,
           "id": 69,
@@ -4814,7 +4813,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 12
+            "y": 20
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -4946,7 +4945,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 12
+            "y": 20
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -5062,7 +5061,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 20
+            "y": 28
           },
           "hiddenSeries": false,
           "id": 91,
@@ -5163,7 +5162,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 20
+            "y": 28
           },
           "hiddenSeries": false,
           "id": 92,
@@ -5272,7 +5271,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 28
+            "y": 36
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -5404,7 +5403,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 28
+            "y": 36
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -5520,7 +5519,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 36
+            "y": 44
           },
           "hiddenSeries": false,
           "id": 81,
@@ -5613,7 +5612,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 36
+            "y": 44
           },
           "hiddenSeries": false,
           "id": 82,
@@ -5706,7 +5705,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 44
+            "y": 52
           },
           "hiddenSeries": false,
           "id": 93,
@@ -5799,7 +5798,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 44
+            "y": 52
           },
           "hiddenSeries": false,
           "id": 94,
@@ -5908,7 +5907,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 52
+            "y": 60
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -6050,7 +6049,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 52
+            "y": 60
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -6175,7 +6174,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 60
+            "y": 68
           },
           "hiddenSeries": false,
           "id": 89,
@@ -6274,7 +6273,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 60
+            "y": 68
           },
           "hiddenSeries": false,
           "id": 90,
@@ -6367,7 +6366,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 68
+            "y": 76
           },
           "hiddenSeries": false,
           "id": 95,
@@ -6460,7 +6459,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 68
+            "y": 76
           },
           "hiddenSeries": false,
           "id": 96,
@@ -6568,7 +6567,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 76
+            "y": 84
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -6690,7 +6689,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 76
+            "y": 84
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -6796,7 +6795,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 84
+            "y": 92
           },
           "hiddenSeries": false,
           "id": 170,
@@ -6895,7 +6894,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 84
+            "y": 92
           },
           "hiddenSeries": false,
           "id": 171,
@@ -6988,7 +6987,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 92
+            "y": 100
           },
           "hiddenSeries": false,
           "id": 174,
@@ -7087,7 +7086,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 92
+            "y": 100
           },
           "hiddenSeries": false,
           "id": 175,
@@ -7195,7 +7194,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 100
+            "y": 108
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -7317,7 +7316,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 100
+            "y": 108
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -7439,7 +7438,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 108
+            "y": 116
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -7560,7 +7559,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 108
+            "y": 116
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -7681,7 +7680,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 116
+            "y": 124
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -7827,7 +7826,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 43
+            "y": 51
           },
           "id": 148,
           "options": {
@@ -7873,7 +7872,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 4
+        "y": 5
       },
       "id": 296,
       "panels": [
@@ -7893,7 +7892,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 284
+            "y": 6
           },
           "hiddenSeries": false,
           "id": 132,
@@ -7913,7 +7912,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "9.2.5",
+          "pluginVersion": "10.4.8",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -7993,7 +7992,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 284
+            "y": 6
           },
           "hiddenSeries": false,
           "id": 133,
@@ -8013,7 +8012,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "9.2.5",
+          "pluginVersion": "10.4.8",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -8086,7 +8085,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 292
+            "y": 14
           },
           "hiddenSeries": false,
           "id": 134,
@@ -8106,7 +8105,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "9.2.5",
+          "pluginVersion": "10.4.8",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -8181,7 +8180,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 292
+            "y": 14
           },
           "hiddenSeries": false,
           "id": 135,
@@ -8201,7 +8200,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "9.2.5",
+          "pluginVersion": "10.4.8",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -8251,6 +8250,102 @@
           "yaxis": {
             "align": false
           }
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "000000001"
+          },
+          "description": "Sandbox cache hit ratio = hits / number_of_message_slices ",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 22
+          },
+          "id": 315,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "000000001"
+              },
+              "editorMode": "code",
+              "expr": "label_replace(\n    quantile by (ic_subnet) ( \n        0.5,\n        (\n            sum without(api_type, status)(\n                rate(\n                    sandboxed_execution_executed_message_slices_total{ic=\"$ic\",ic_subnet=~\"$ic_subnet\",job=\"replica\",instance=~\"$instance\",api_type!~\"non[ -]replicated.*|inspect message\"}[$__rate_interval]\n                )\n            ) \n            - \n            rate(sandboxed_execution_spawn_process_duration_seconds_count{ic=\"$ic\",ic_subnet=~\"$ic_subnet\",instance=~\"$instance\"}[$__rate_interval])\n        )\n        /\n        sum without(api_type, status)(\n            rate(\n                sandboxed_execution_executed_message_slices_total{ic=\"$ic\",ic_subnet=~\"$ic_subnet\",job=\"replica\",instance=~\"$instance\",api_type!~\"non[ -]replicated.*|inspect message\"}[$__rate_interval]\n            )\n        )\n    ),\n    \"ic_subnet\", \"$1\", \"ic_subnet\", \"([a-z0-9]+)-.*\"\n) * 100",
+              "instant": false,
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Sandbox cache hit ratio %",
+          "type": "timeseries"
         }
       ],
       "title": "Sandbox",
@@ -8262,7 +8357,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 5
+        "y": 6
       },
       "id": 298,
       "panels": [
@@ -8288,7 +8383,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 6
+            "y": 14
           },
           "hiddenSeries": false,
           "id": 77,
@@ -8381,7 +8476,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 6
+            "y": 14
           },
           "hiddenSeries": false,
           "id": 79,
@@ -8490,7 +8585,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 14
+            "y": 22
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -8611,7 +8706,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 14
+            "y": 22
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -8716,7 +8811,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 22
+            "y": 30
           },
           "hiddenSeries": false,
           "id": 97,
@@ -8809,7 +8904,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 22
+            "y": 30
           },
           "hiddenSeries": false,
           "id": 98,
@@ -8902,7 +8997,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 30
+            "y": 38
           },
           "hiddenSeries": false,
           "id": 78,
@@ -8995,7 +9090,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 30
+            "y": 38
           },
           "hiddenSeries": false,
           "id": 80,
@@ -9082,7 +9177,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 38
+            "y": 46
           },
           "hiddenSeries": false,
           "id": 59,
@@ -9162,7 +9257,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 6
+        "y": 7
       },
       "id": 143,
       "panels": [
@@ -9224,7 +9319,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 35
+            "y": 43
           },
           "id": 145,
           "options": {
@@ -9322,7 +9417,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 35
+            "y": 43
           },
           "id": 146,
           "options": {
@@ -9420,7 +9515,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 43
+            "y": 51
           },
           "id": 147,
           "options": {
@@ -9518,9 +9613,9 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 43
+            "y": 51
           },
-          "id": 148,
+          "id": 314,
           "options": {
             "legend": {
               "calcs": [],
@@ -9616,7 +9711,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 51
+            "y": 59
           },
           "id": 149,
           "options": {
@@ -9677,7 +9772,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 51
+            "y": 59
           },
           "id": 152,
           "options": {
@@ -9801,7 +9896,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 59
+            "y": 67
           },
           "id": 150,
           "options": {
@@ -9862,7 +9957,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 59
+            "y": 67
           },
           "id": 153,
           "options": {
@@ -9986,7 +10081,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 67
+            "y": 75
           },
           "id": 157,
           "options": {
@@ -10108,7 +10203,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 67
+            "y": 75
           },
           "id": 160,
           "options": {
@@ -10206,7 +10301,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 75
+            "y": 83
           },
           "id": 154,
           "options": {
@@ -10304,7 +10399,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 75
+            "y": 83
           },
           "id": 155,
           "options": {
@@ -10402,7 +10497,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 83
+            "y": 91
           },
           "id": 156,
           "options": {
@@ -10448,7 +10543,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 7
+        "y": 8
       },
       "id": 291,
       "panels": [
@@ -10474,7 +10569,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 8
+            "y": 16
           },
           "hiddenSeries": false,
           "id": 289,
@@ -10593,8 +10688,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -10610,7 +10704,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 8
+            "y": 16
           },
           "id": 304,
           "options": {
@@ -10689,8 +10783,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -10706,7 +10799,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 16
+            "y": 24
           },
           "id": 306,
           "options": {
@@ -10776,7 +10869,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 16
+            "y": 24
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -10866,8 +10959,7 @@
     }
   ],
   "refresh": false,
-  "schemaVersion": 37,
-  "style": "dark",
+  "schemaVersion": 39,
   "tags": [
     "production"
   ],
@@ -10876,8 +10968,8 @@
       {
         "current": {
           "selected": false,
-          "text": "IC Metrics (cluster local)",
-          "value": "IC Metrics (cluster local)"
+          "text": "No data sources found",
+          "value": ""
         },
         "hide": 0,
         "includeAll": false,
@@ -10893,8 +10985,8 @@
       {
         "current": {
           "selected": false,
-          "text": "mercury",
-          "value": "mercury"
+          "text": "small-high-perf--1730291540947",
+          "value": "small-high-perf--1730291540947"
         },
         "datasource": {
           "type": "prometheus",
@@ -11130,6 +11222,6 @@
   "timezone": "utc",
   "title": "Execution Metrics",
   "uid": "execution-metrics",
-  "version": 8,
+  "version": 1,
   "weekStart": ""
 }


### PR DESCRIPTION
Problem:
Dashboard that is recently added to k8s repo, is not shown when running testnet.

Solution:
Add it in `/rs/tests/dashboards`.
<img width="2048" alt="Screenshot 2024-10-30 at 15 06 45" src="https://github.com/user-attachments/assets/2c0e922a-1de7-4e03-87aa-ce117e8b9690">
