### PR TITLE
chore: run spec compliance tests without heartbeat

### DIFF
--- a/hs/spec_compliance/src/IC/Test/Spec/CanisterVersion.hs
+++ b/hs/spec_compliance/src/IC/Test/Spec/CanisterVersion.hs
@@ -89,15 +89,6 @@ canister_version_tests ecid =
                               ctr1 @?= 1
                               ctr2 @?= 2
                               ctr3 @?= 2,
-                            testCase "in heartbeat" $ do
-                              cid <-
-                                install ecid $
-                                  onHeartbeat (callback $ trapIfNeq canister_version (i64tob $ int64 1) "" >>> setGlobal canister_version)
-                              wait_for_global cid (1 :: Int)
-                              ctr1 <- query cid (replyData getGlobal) >>= asWord64
-                              ctr2 <- query cid (replyData canister_version) >>= asWord64
-                              ctr1 @?= 1
-                              ctr2 @?= 2,
                             testCase "in global timer" $ do
                               cid <-
                                 install ecid $

--- a/hs/spec_compliance/src/IC/Test/Spec/Utils.hs
+++ b/hs/spec_compliance/src/IC/Test/Spec/Utils.hs
@@ -351,7 +351,11 @@ isRelay =
 
 -- Shortcut for test cases that just need one canister.
 simpleTestCase :: (HasCallStack, HasAgentConfig) => String -> Blob -> (Blob -> IO ()) -> TestTree
-simpleTestCase name ecid act = testCase name $ install ecid noop >>= act
+simpleTestCase name ecid act = testCase name $ do
+  cid <- install ecid noop
+  act cid
+  ic_stop_canister ic00 cid
+  ic_delete_canister ic00 cid
 
 -- * Programmatic test generation
 

--- a/rs/tests/research/BUILD.bazel
+++ b/rs/tests/research/BUILD.bazel
@@ -115,7 +115,7 @@ symlink_dirs(
     target_compatible_with = ["@platforms//os:linux"],
     targets = {
         "//hs/spec_compliance:ic-ref-test": "bin",
-        "//rs/universal_canister/impl:universal_canister.wasm.gz": "test-data",
+        "//rs/universal_canister/impl:universal_canister_no_heartbeat.wasm.gz": "test-data",
         "//rs/tests:wabt-tests": "test-data",
     },
     visibility = [

--- a/rs/universal_canister/impl/BUILD.bazel
+++ b/rs/universal_canister/impl/BUILD.bazel
@@ -37,6 +37,16 @@ rust_canister(
     name = "universal_canister",
     srcs = glob(["src/*.rs"]),
     aliases = ALIASES,
+    crate_features = ["heartbeat"],
+    proc_macro_deps = MACRO_DEPENDENCIES,
+    service_file = ":interface.did",
+    deps = LIB_DEPENDENCIES + DEPENDENCIES,
+)
+
+rust_canister(
+    name = "universal_canister_no_heartbeat",
+    srcs = glob(["src/*.rs"]),
+    aliases = ALIASES,
     proc_macro_deps = MACRO_DEPENDENCIES,
     service_file = ":interface.did",
     deps = LIB_DEPENDENCIES + DEPENDENCIES,

--- a/rs/universal_canister/impl/Cargo.toml
+++ b/rs/universal_canister/impl/Cargo.toml
@@ -11,3 +11,6 @@ candid = { workspace = true }
 lazy_static = { workspace = true }
 serde = { workspace = true }
 wee_alloc = "0.4.3"
+
+[features]
+heartbeat = []

--- a/rs/universal_canister/impl/src/main.rs
+++ b/rs/universal_canister/impl/src/main.rs
@@ -475,6 +475,7 @@ fn pre_upgrade() {
     eval(&get_pre_upgrade());
 }
 
+#[cfg(feature = "heartbeat")]
 #[export_name = "canister_heartbeat"]
 fn heartbeat() {
     setup();
@@ -536,6 +537,7 @@ lazy_static! {
 fn set_heartbeat(data: Vec<u8>) {
     *HEARTBEAT.lock().unwrap() = data;
 }
+#[cfg(feature = "heartbeat")]
 fn get_heartbeat() -> Vec<u8> {
     HEARTBEAT.lock().unwrap().clone()
 }


### PR DESCRIPTION
This PR speeds up spec compliance tests by
- deleting universal canister at the end of simple tests using only one canister;
- using a universal canister without heartbeats in all tests.

This prevents the following tests:
- test that heartbeat is executed (tested sufficiently in canister tests relying on heartbeat functionality and in execution environment tests);
- test that replying in heartbeats traps (tested sufficiently in system API tests);
- check canister version in heartbeat (only mild test coverage reduction as there is still an analogous test for global timer which is a system task, too).