### PR TITLE
chore: reshare status handle from ic-boundary

### DIFF
--- a/rs/pocket_ic_server/src/pocket_ic.rs
+++ b/rs/pocket_ic_server/src/pocket_ic.rs
@@ -13,7 +13,7 @@ use futures::FutureExt;
 use hyper::body::Bytes;
 use hyper::header::{HeaderValue, CONTENT_TYPE};
 use hyper::{Method, StatusCode};
-use ic_boundary::{Health, RootKey};
+use ic_boundary::{status, Health, RootKey};
 use ic_btc_adapter::config::{Config as BitcoinAdapterConfig, IncomingSource};
 use ic_btc_adapter::start_server;
 use ic_config::{
@@ -95,6 +95,12 @@ use tower::{service_fn, util::ServiceExt};
 
 // See build.rs
 include!(concat!(env!("OUT_DIR"), "/dashboard.rs"));
+
+// Clippy complains that these are interior-mutable.
+// We don't mutate them, so silence it.
+// https://rust-lang.github.io/rust-clippy/master/index.html#/declare_interior_mutable_const
+#[allow(clippy::declare_interior_mutable_const)]
+const CONTENT_TYPE_CBOR: HeaderValue = HeaderValue::from_static("application/cbor");
 
 /// The response type for `/api/v2` and `/api/v3` IC endpoint operations.
 pub(crate) type ApiResponse = BoxFuture<'static, (u16, BTreeMap<String, Vec<u8>>, Vec<u8>)>;
@@ -1558,51 +1564,6 @@ impl RootKey for PocketRootKey {
         self.0.clone()
     }
 }
-
-// START COPY from rs/boundary_node/ic_boundary/src/routes.rs
-// TODO: reshare once ic_boundary upgrades to axum 0.7.
-
-const IC_API_VERSION: &str = "0.18.0";
-// Clippy complains that these are interior-mutable.
-// We don't mutate them, so silence it.
-// https://rust-lang.github.io/rust-clippy/master/index.html#/declare_interior_mutable_const
-#[allow(clippy::declare_interior_mutable_const)]
-const CONTENT_TYPE_CBOR: HeaderValue = HeaderValue::from_static("application/cbor");
-
-pub async fn status(
-    State((rk, h)): State<(Arc<dyn RootKey>, Arc<dyn Health>)>,
-) -> impl IntoResponse {
-    use ic_types::messages::HttpStatusResponse;
-
-    let health = h.health().await;
-
-    let status = HttpStatusResponse {
-        ic_api_version: IC_API_VERSION.to_string(),
-        root_key: rk.root_key().await.map(|x| x.into()),
-        impl_version: None,
-        impl_hash: None,
-        replica_health_status: Some(health),
-        certified_height: None,
-    };
-
-    // Serialize to CBOR
-    let mut ser = serde_cbor::Serializer::new(Vec::new());
-    // These should not really fail, better to panic if something in serde changes which would cause them to fail
-    ser.self_describe().unwrap();
-    status.serialize(&mut ser).unwrap();
-    let cbor = ser.into_inner();
-
-    // Construct response and inject health status for middleware
-    let mut response = cbor.into_response();
-    response.extensions_mut().insert(health);
-    response
-        .headers_mut()
-        .insert(CONTENT_TYPE, CONTENT_TYPE_CBOR);
-
-    response
-}
-
-// END COPY
 
 impl Operation for StatusRequest {
     fn compute(&self, pic: &mut PocketIc) -> OpOut {


### PR DESCRIPTION
This PR reshares code of the status HTTP handler from `ic-boundary`. That code used to be copied because `ic-boundary` used to depend on an incompatible axum version.