### PR TITLE
chore: drop dependency on ic-agent in PocketIC library

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16809,7 +16809,7 @@ dependencies = [
  "ed25519-dalek",
  "flate2",
  "hex",
- "ic-agent",
+ "ic-certification 2.6.0",
  "ic-transport-types",
  "k256",
  "lazy_static",

--- a/packages/pocket-ic/BUILD.bazel
+++ b/packages/pocket-ic/BUILD.bazel
@@ -7,7 +7,7 @@ DEPENDENCIES = [
     "@crate_index//:base64",
     "@crate_index//:candid",
     "@crate_index//:hex",
-    "@crate_index//:ic-agent",
+    "@crate_index//:ic-certification",
     "@crate_index//:ic-transport-types",
     "@crate_index//:reqwest",
     "@crate_index//:schemars",

--- a/packages/pocket-ic/Cargo.toml
+++ b/packages/pocket-ic/Cargo.toml
@@ -26,7 +26,7 @@ doctest = false
 base64 = { workspace = true }
 candid = { workspace = true }
 hex = { workspace = true }
-ic-agent = { workspace = true }
+ic-certification = { workspace = true }
 ic-transport-types = { workspace = true }
 reqwest = { workspace = true }
 schemars = "0.8.16"

--- a/packages/pocket-ic/src/nonblocking.rs
+++ b/packages/pocket-ic/src/nonblocking.rs
@@ -20,6 +20,9 @@ use candid::{
     utils::{ArgumentDecoder, ArgumentEncoder},
     Principal,
 };
+use ic_certification::{Certificate, Label, LookupResult};
+use ic_transport_types::Envelope;
+use ic_transport_types::EnvelopeContent::ReadState;
 use ic_transport_types::{ReadStateResponse, SubnetMetrics};
 use reqwest::{StatusCode, Url};
 use serde::{de::DeserializeOwned, Serialize};
@@ -1005,11 +1008,11 @@ impl PocketIc {
     pub async fn get_subnet_metrics(&self, subnet_id: Principal) -> Option<SubnetMetrics> {
         let path = vec![
             "subnet".into(),
-            ic_agent::hash_tree::Label::from_bytes(subnet_id.as_slice()),
+            Label::from_bytes(subnet_id.as_slice()),
             "metrics".into(),
         ];
         let paths = vec![path.clone()];
-        let content = ic_agent::agent::EnvelopeContent::ReadState {
+        let content = ReadState {
             ingress_expiry: self
                 .get_time()
                 .await
@@ -1020,7 +1023,7 @@ impl PocketIc {
             sender: Principal::anonymous(),
             paths,
         };
-        let envelope = ic_agent::agent::Envelope {
+        let envelope = Envelope {
             content: std::borrow::Cow::Borrowed(&content),
             sender_pubkey: None,
             sender_sig: None,
@@ -1043,10 +1046,12 @@ impl PocketIc {
             .unwrap();
         let read_state_response: ReadStateResponse =
             serde_cbor::from_slice(&resp.bytes().await.unwrap()).ok()?;
-        let cert: ic_agent::Certificate =
-            serde_cbor::from_slice(&read_state_response.certificate).unwrap();
+        let cert: Certificate = serde_cbor::from_slice(&read_state_response.certificate).unwrap();
 
-        let metrics = ic_agent::lookup_value(&cert, path).ok()?;
+        let metrics = match cert.tree.lookup_path(path) {
+            LookupResult::Found(value) => Some(value),
+            _ => None,
+        }?;
         serde_cbor::from_slice(metrics).unwrap()
     }
 


### PR DESCRIPTION
This PR drops a dependency on `ic-agent` in the PocketIC library so that this library can be used in `ic-agent`.