### PR TITLE
feat: allow specifying multiple bitcoin nodes in PocketIC instance configuration

### DIFF
--- a/packages/pocket-ic/src/common/rest.rs
+++ b/packages/pocket-ic/src/common/rest.rs
@@ -467,7 +467,7 @@ pub struct InstanceConfig {
     pub state_dir: Option<PathBuf>,
     pub nonmainnet_features: bool,
     pub log_level: Option<String>,
-    pub bitcoind_addr: Option<SocketAddr>,
+    pub bitcoind_addr: Option<Vec<SocketAddr>>,
 }
 
 #[derive(Debug, Clone, Eq, Hash, PartialEq, Serialize, Deserialize, Default, JsonSchema)]

--- a/packages/pocket-ic/src/lib.rs
+++ b/packages/pocket-ic/src/lib.rs
@@ -85,7 +85,7 @@ pub struct PocketIcBuilder {
     state_dir: Option<PathBuf>,
     nonmainnet_features: bool,
     log_level: Option<Level>,
-    bitcoind_addr: Option<SocketAddr>,
+    bitcoind_addr: Option<Vec<SocketAddr>>,
 }
 
 #[allow(clippy::new_without_default)]
@@ -162,7 +162,7 @@ impl PocketIcBuilder {
 
     pub fn with_bitcoind_addr(self, bitcoind_addr: SocketAddr) -> Self {
         Self {
-            bitcoind_addr: Some(bitcoind_addr),
+            bitcoind_addr: Some(vec![bitcoind_addr]),
             ..self
         }
     }
@@ -359,7 +359,7 @@ impl PocketIc {
         state_dir: Option<PathBuf>,
         nonmainnet_features: bool,
         log_level: Option<Level>,
-        bitcoind_addr: Option<SocketAddr>,
+        bitcoind_addr: Option<Vec<SocketAddr>>,
     ) -> Self {
         let (tx, rx) = channel();
         let thread = thread::spawn(move || {

--- a/packages/pocket-ic/src/nonblocking.rs
+++ b/packages/pocket-ic/src/nonblocking.rs
@@ -93,7 +93,7 @@ impl PocketIc {
         state_dir: Option<PathBuf>,
         nonmainnet_features: bool,
         log_level: Option<Level>,
-        bitcoind_addr: Option<SocketAddr>,
+        bitcoind_addr: Option<Vec<SocketAddr>>,
     ) -> Self {
         let subnet_config_set = subnet_config_set.into();
         if state_dir.is_none()

--- a/rs/pocket_ic_server/src/pocket_ic.rs
+++ b/rs/pocket_ic_server/src/pocket_ic.rs
@@ -173,7 +173,7 @@ struct BitcoinAdapterParts {
 
 impl BitcoinAdapterParts {
     fn new(
-        bitcoind_addr: SocketAddr,
+        bitcoind_addr: Vec<SocketAddr>,
         uds_path: PathBuf,
         log_level: Option<Level>,
         replica_logger: ReplicaLogger,
@@ -194,7 +194,7 @@ impl BitcoinAdapterParts {
         };
         let bitcoin_adapter_config = BitcoinAdapterConfig {
             network: Network::Regtest,
-            nodes: vec![bitcoind_addr],
+            nodes: bitcoind_addr,
             socks_proxy: None,
             ipv6_only: false,
             logger: logger_config,
@@ -234,7 +234,7 @@ pub struct PocketIc {
     runtime: Arc<Runtime>,
     nonmainnet_features: bool,
     log_level: Option<Level>,
-    bitcoind_addr: Option<SocketAddr>,
+    bitcoind_addr: Option<Vec<SocketAddr>>,
     _bitcoin_adapter_parts: Option<BitcoinAdapterParts>,
 }
 
@@ -388,7 +388,7 @@ impl PocketIc {
         state_dir: Option<PathBuf>,
         nonmainnet_features: bool,
         log_level: Option<Level>,
-        bitcoind_addr: Option<SocketAddr>,
+        bitcoind_addr: Option<Vec<SocketAddr>>,
     ) -> Self {
         let mut range_gen = RangeGen::new();
         let mut routing_table = RoutingTable::new();
@@ -572,7 +572,7 @@ impl PocketIc {
 
             if let Some(bitcoin_adapter_uds_path) = bitcoin_adapter_uds_path {
                 _bitcoin_adapter_parts = Some(BitcoinAdapterParts::new(
-                    bitcoind_addr.unwrap(),
+                    bitcoind_addr.clone().unwrap(),
                     bitcoin_adapter_uds_path,
                     log_level,
                     sm.replica_logger.clone(),
@@ -2366,7 +2366,7 @@ fn route(
                     // If applicable, we start a new bitcoin adapter.
                     if let Some(bitcoin_adapter_uds_path) = bitcoin_adapter_uds_path {
                         pic._bitcoin_adapter_parts = Some(BitcoinAdapterParts::new(
-                            pic.bitcoind_addr.unwrap(),
+                            pic.bitcoind_addr.clone().unwrap(),
                             bitcoin_adapter_uds_path,
                             pic.log_level,
                             sm.replica_logger.clone(),


### PR DESCRIPTION
This PR allows specifying multiple bitcoin nodes in PocketIC instance configuration which is required by DFX.