### PR TITLE
chore(consensus): adjust dynamic block maker delay

### DIFF
--- a/rs/limits/src/lib.rs
+++ b/rs/limits/src/lib.rs
@@ -51,6 +51,13 @@ pub const LOG_CANISTER_OPERATION_CYCLES_THRESHOLD: u128 = 100_000_000_000;
 pub const KILOBYTE: u64 = 1024;
 pub const MEGABYTE: u64 = KILOBYTE * KILOBYTE;
 
+/// How long to wait before a block maker of higher rank can create a block. The value should be
+/// high enough to allow a lower rank block marker to broadcast their block to all their peers,
+/// before a higher rank block maker starts creating one. It should then depend on the size of the
+/// subnet and the maximum size of a block. For example, on an app subnet with 13 nodes and with
+/// maximum block size set to 4MB, assuming at least 300Mbit/s throughput for each node, a block
+/// maker will need roughly one second to broadcast their block. On the nns subnet with 40 nodes,
+/// it should take roughly three seconds on average.
 pub const UNIT_DELAY_APP_SUBNET: Duration = Duration::from_millis(1000);
 pub const UNIT_DELAY_NNS_SUBNET: Duration = Duration::from_millis(3000);
 pub const INITIAL_NOTARY_DELAY: Duration = Duration::from_millis(300);


### PR DESCRIPTION
The current value is constant and a bit too high. It should depend on the size of the subnet, because on a subnet with fewer nodes it should take less time to broadcast a block than on a subnet with many nodes. For example, on an app subnet it should take around 3x less time than on an nns subnet.

The unit delay setting in the subnet record encapsulates quite well what we need, thus instead of having the constant, we use the unit delay. This effectively means that when a subnet struggles to produce rank-0 blocks at acceptable (at the moment 66%) rate we double the time we allot to a rank-0 block maker for a creation and distribution of a block.