### PR TITLE
refactor(ckbtc): refactor the ic-btc-kyt crate

### DIFF
--- a/rs/bitcoin/kyt/BUILD.bazel
+++ b/rs/bitcoin/kyt/BUILD.bazel
@@ -16,6 +16,7 @@ rust_library(
     crate_name = "ic_btc_kyt",
     deps = [
         # Keep sorted.
+        "@crate_index//:bitcoin_0_32",
         "@crate_index//:candid",
         "@crate_index//:serde",
     ],

--- a/rs/bitcoin/kyt/BUILD.bazel
+++ b/rs/bitcoin/kyt/BUILD.bazel
@@ -6,10 +6,12 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "btc_kyt_lib",
-    srcs = glob(
-        ["src/**"],
-        exclude = ["src/main.rs"],
-    ),
+    srcs = [
+      "src/lib.rs",
+      "src/blocklist.rs",
+      "src/providers.rs",
+      "src/types.rs",
+    ],
     compile_data = [
         "templates/dashboard.html",
     ],
@@ -64,7 +66,13 @@ rust_test(
 rust_canister(
     name = "btc_kyt_canister",
     srcs = [
+        "src/dashboard.rs",
+        "src/dashboard/tests.rs",
+        "src/fetch.rs",
+        "src/fetch/tests.rs",
         "src/main.rs",
+        "src/state.rs",
+        "src/state/tests.rs",
     ],
     proc_macro_deps = ["@crate_index//:ic-cdk-macros"],
     service_file = "btc_kyt_canister.did",

--- a/rs/bitcoin/kyt/BUILD.bazel
+++ b/rs/bitcoin/kyt/BUILD.bazel
@@ -7,31 +7,21 @@ package(default_visibility = ["//visibility:public"])
 rust_library(
     name = "btc_kyt_lib",
     srcs = [
-      "src/lib.rs",
-      "src/blocklist.rs",
-      "src/providers.rs",
-      "src/types.rs",
-    ],
-    compile_data = [
-        "templates/dashboard.html",
+        "src/blocklist.rs",
+        "src/lib.rs",
+        "src/providers.rs",
+        "src/types.rs",
     ],
     crate_name = "ic_btc_kyt",
     deps = [
         # Keep sorted.
         "//rs/rust_canisters/http_types",
-        "@crate_index//:askama",
         "@crate_index//:base64",
         "@crate_index//:bitcoin_0_32",
         "@crate_index//:candid",
-        "@crate_index//:ciborium",
-        "@crate_index//:futures",
-        "@crate_index//:hex",
         "@crate_index//:ic-btc-interface",
         "@crate_index//:ic-cdk",
-        "@crate_index//:ic-stable-structures",
         "@crate_index//:serde",
-        "@crate_index//:serde_json",
-        "@crate_index//:time",
         "@crate_index//:url",
     ],
 )
@@ -39,14 +29,6 @@ rust_library(
 rust_test(
     name = "unit_tests",
     crate = ":btc_kyt_lib",
-    deps = [
-        # Keep sorted.
-        "@crate_index//:bitcoin_0_32",
-        "@crate_index//:candid_parser",
-        "@crate_index//:ic-btc-interface",
-        "@crate_index//:scraper",
-        "@crate_index//:tokio",
-    ],
 )
 
 rust_test(
@@ -60,6 +42,8 @@ rust_test(
         # Keep sorted.
         "@crate_index//:candid_parser",
         "@crate_index//:ic-btc-interface",
+        "@crate_index//:scraper",
+        "@crate_index//:tokio",
     ],
 )
 
@@ -74,6 +58,9 @@ rust_canister(
         "src/state.rs",
         "src/state/tests.rs",
     ],
+    compile_data = [
+        "templates/dashboard.html",
+    ],
     proc_macro_deps = ["@crate_index//:ic-cdk-macros"],
     service_file = "btc_kyt_canister.did",
     deps = [
@@ -84,9 +71,15 @@ rust_canister(
         "@crate_index//:bitcoin_0_32",
         "@crate_index//:candid",
         "@crate_index//:candid_parser",
+        "@crate_index//:ciborium",
         "@crate_index//:futures",
+        "@crate_index//:hex",
         "@crate_index//:ic-btc-interface",
         "@crate_index//:ic-cdk",
+        "@crate_index//:ic-stable-structures",
+        "@crate_index//:serde",
+        "@crate_index//:serde_json",
+        "@crate_index//:time",
     ],
 )
 

--- a/rs/bitcoin/kyt/BUILD.bazel
+++ b/rs/bitcoin/kyt/BUILD.bazel
@@ -4,25 +4,20 @@ load("//bazel:defs.bzl", "rust_ic_test")
 
 package(default_visibility = ["//visibility:public"])
 
+LIB_SRCS = [
+    "src/blocklist.rs",
+    "src/lib.rs",
+    "src/types.rs",
+]
+
 rust_library(
     name = "btc_kyt_lib",
-    srcs = [
-        "src/blocklist.rs",
-        "src/lib.rs",
-        "src/providers.rs",
-        "src/types.rs",
-    ],
+    srcs = LIB_SRCS,
     crate_name = "ic_btc_kyt",
     deps = [
         # Keep sorted.
-        "//rs/rust_canisters/http_types",
-        "@crate_index//:base64",
-        "@crate_index//:bitcoin_0_32",
         "@crate_index//:candid",
-        "@crate_index//:ic-btc-interface",
-        "@crate_index//:ic-cdk",
         "@crate_index//:serde",
-        "@crate_index//:url",
     ],
 )
 
@@ -49,15 +44,10 @@ rust_test(
 
 rust_canister(
     name = "btc_kyt_canister",
-    srcs = [
-        "src/dashboard.rs",
-        "src/dashboard/tests.rs",
-        "src/fetch.rs",
-        "src/fetch/tests.rs",
-        "src/main.rs",
-        "src/state.rs",
-        "src/state/tests.rs",
-    ],
+    srcs = glob(
+        ["src/**"],
+        exclude = LIB_SRCS,
+    ),
     compile_data = [
         "templates/dashboard.html",
     ],
@@ -68,6 +58,7 @@ rust_canister(
         ":btc_kyt_lib",
         "//rs/rust_canisters/http_types",
         "@crate_index//:askama",
+        "@crate_index//:base64",
         "@crate_index//:bitcoin_0_32",
         "@crate_index//:candid",
         "@crate_index//:candid_parser",
@@ -80,6 +71,7 @@ rust_canister(
         "@crate_index//:serde",
         "@crate_index//:serde_json",
         "@crate_index//:time",
+        "@crate_index//:url",
     ],
 )
 

--- a/rs/bitcoin/kyt/src/dashboard/tests.rs
+++ b/rs/bitcoin/kyt/src/dashboard/tests.rs
@@ -1,10 +1,11 @@
 use crate::dashboard::tests::assertions::DashboardAssert;
 use crate::dashboard::{filters, DashboardTemplate, Fetched, Status, DEFAULT_TX_TABLE_PAGE_SIZE};
 use crate::state::{Config, Timestamp, TransactionKytData};
-use crate::{blocklist::BTC_ADDRESS_BLOCKLIST, dashboard, state, BtcNetwork, KytMode};
+use crate::{dashboard, state};
 use bitcoin::Address;
 use bitcoin::{absolute::LockTime, transaction::Version, Transaction};
 use ic_btc_interface::Txid;
+use ic_btc_kyt::{blocklist::BTC_ADDRESS_BLOCKLIST, BtcNetwork, KytMode};
 use std::str::FromStr;
 
 fn mock_txid(v: usize) -> Txid {

--- a/rs/bitcoin/kyt/src/fetch.rs
+++ b/rs/bitcoin/kyt/src/fetch.rs
@@ -26,7 +26,7 @@ impl HttpGetTxError {
             HttpGetTxError::ResponseTooLarge => {
                 (CheckTransactionIrrecoverableError::ResponseTooLarge { txid }).into()
             }
-            _ => CheckTransactionRetriable::TransientInternalError(format!("{:?}", self)).into(),
+            _ => CheckTransactionRetriable::TransientInternalError(self.to_string()).into(),
         }
     }
 }

--- a/rs/bitcoin/kyt/src/fetch.rs
+++ b/rs/bitcoin/kyt/src/fetch.rs
@@ -17,7 +17,7 @@ use std::convert::Infallible;
 mod tests;
 
 impl HttpGetTxError {
-    pub(crate) fn to_response(self, txid: Txid) -> CheckTransactionResponse {
+    pub(crate) fn into_response(self, txid: Txid) -> CheckTransactionResponse {
         let txid = txid.as_ref().to_vec();
         match self {
             HttpGetTxError::Rejected { message, .. } => {
@@ -263,7 +263,7 @@ pub trait FetchEnv {
                         );
                     }
                 }
-                FetchResult::Error(err) => error = Some(err.to_response(input_txid)),
+                FetchResult::Error(err) => error = Some(err.into_response(input_txid)),
                 FetchResult::RetryWithBiggerBuffer => (),
             }
         }

--- a/rs/bitcoin/kyt/src/fetch/tests.rs
+++ b/rs/bitcoin/kyt/src/fetch/tests.rs
@@ -1,13 +1,12 @@
 use super::*;
-use crate::{
-    blocklist,
-    providers::Provider,
-    types::{BtcNetwork, KytMode},
-    CheckTransactionIrrecoverableError,
-};
+use crate::{providers::Provider, CheckTransactionIrrecoverableError};
 use bitcoin::{
     absolute::LockTime, address::Address, hashes::Hash, transaction::Version, Amount, OutPoint,
     PubkeyHash, ScriptBuf, Sequence, Transaction, TxIn, TxOut, Witness,
+};
+use ic_btc_kyt::{
+    blocklist, BtcNetwork, KytMode, CHECK_TRANSACTION_CYCLES_REQUIRED,
+    CHECK_TRANSACTION_CYCLES_SERVICE_FEE,
 };
 use ic_cdk::api::call::RejectionCode;
 use std::cell::RefCell;

--- a/rs/bitcoin/kyt/src/lib.rs
+++ b/rs/bitcoin/kyt/src/lib.rs
@@ -1,180 +1,41 @@
-use bitcoin::{consensus::Decodable, Address, Transaction};
-use ic_btc_interface::Txid;
-use ic_cdk::api::call::RejectionCode;
-use ic_cdk::api::management_canister::http_request::http_request;
+use bitcoin::Address;
 
 pub mod blocklist;
-pub mod dashboard;
-mod fetch;
-mod providers;
-mod state;
+pub mod providers;
 mod types;
 
-pub use fetch::{
-    get_tx_cycle_cost, CHECK_TRANSACTION_CYCLES_REQUIRED, CHECK_TRANSACTION_CYCLES_SERVICE_FEE,
-    INITIAL_MAX_RESPONSE_BYTES,
-};
-use fetch::{FetchEnv, FetchResult, TryFetchResult};
-pub use state::{get_config, set_config, Config};
-use state::{FetchGuardError, HttpGetTxError};
 pub use types::*;
 
-impl From<(Txid, HttpGetTxError)> for CheckTransactionResponse {
-    fn from((txid, err): (Txid, HttpGetTxError)) -> CheckTransactionResponse {
-        let txid = txid.as_ref().to_vec();
-        match err {
-            HttpGetTxError::Rejected { message, .. } => {
-                CheckTransactionRetriable::TransientInternalError(message).into()
-            }
-            HttpGetTxError::ResponseTooLarge => {
-                (CheckTransactionIrrecoverableError::ResponseTooLarge { txid }).into()
-            }
-            _ => CheckTransactionRetriable::TransientInternalError(format!("{:?}", err)).into(),
-        }
-    }
+/// Caller of check_transaction must attach this amount of cycles with the call.
+pub const CHECK_TRANSACTION_CYCLES_REQUIRED: u128 = 40_000_000_000;
+
+/// One-time charge for every check_transaction call.
+pub const CHECK_TRANSACTION_CYCLES_SERVICE_FEE: u128 = 100_000_000;
+
+// The max_response_bytes is initially set to 4kB, and then
+// increased to 400kB if the initial size isn't enough.
+// - The maximum size of a standard non-taproot transaction is 400k vBytes.
+// - Taproot transactions could be as big as full block size (4MiB).
+// - Currently a subnet's maximum response size is only 2MiB.
+// - Transaction size between 400kB and 2MiB are also uncommon, we could
+//   handle them in the future if required.
+// - Transactions bigger than 2MiB are very rare, and we can't handle them.
+
+/// Initial max response bytes is 4kB
+pub const INITIAL_MAX_RESPONSE_BYTES: u32 = 4 * 1024;
+
+/// Retry max response bytes is 400kB
+pub const RETRY_MAX_RESPONSE_BYTES: u32 = 400 * 1024;
+
+pub fn get_tx_cycle_cost(max_response_bytes: u32) -> u128 {
+    // 1 KiB for request, max_response_bytes for response
+    49_140_000 + 1024 * 5_200 + 10_400 * (max_response_bytes as u128)
 }
 
 pub fn blocklist_contains(address: &Address) -> bool {
     blocklist::BTC_ADDRESS_BLOCKLIST
         .binary_search(&address.to_string().as_ref())
         .is_ok()
-}
-
-pub fn is_response_too_large(code: &RejectionCode, message: &str) -> bool {
-    code == &RejectionCode::SysFatal
-        && (message.contains("size limit") || message.contains("length limit"))
-}
-
-struct KytCanisterEnv;
-
-impl FetchEnv for KytCanisterEnv {
-    type FetchGuard = state::FetchGuard;
-
-    fn new_fetch_guard(&self, txid: Txid) -> Result<Self::FetchGuard, FetchGuardError> {
-        state::FetchGuard::new(txid)
-    }
-
-    fn config(&self) -> Config {
-        get_config()
-    }
-
-    async fn http_get_tx(
-        &self,
-        provider: &providers::Provider,
-        txid: Txid,
-        max_response_bytes: u32,
-    ) -> Result<Transaction, HttpGetTxError> {
-        let request = provider
-            .create_request(txid, max_response_bytes)
-            .map_err(|err| HttpGetTxError::Rejected {
-                code: RejectionCode::SysFatal,
-                message: err,
-            })?;
-        let url = request.url.clone();
-        let cycles = get_tx_cycle_cost(max_response_bytes);
-        match http_request(request.clone(), cycles).await {
-            Ok((response,)) => {
-                // Ensure response is 200 before decoding
-                if response.status != 200u32 {
-                    // All non-200 status are treated as transient errors
-                    return Err(HttpGetTxError::Rejected {
-                        code: RejectionCode::SysTransient,
-                        message: format!("HTTP call {} received code {}", url, response.status),
-                    });
-                }
-                let tx = match provider.btc_network() {
-                    BtcNetwork::Regtest { .. } => {
-                        use serde_json::{from_slice, from_value, Value};
-                        let json: Value = from_slice(response.body.as_slice()).map_err(|err| {
-                            HttpGetTxError::TxEncoding(format!("JSON parsing error {}", err))
-                        })?;
-                        let hex: String =
-                            from_value(json["result"]["hex"].clone()).map_err(|_| {
-                                HttpGetTxError::TxEncoding(
-                                    "Missing result.hex field in JSON response".to_string(),
-                                )
-                            })?;
-                        let raw = hex::decode(&hex).map_err(|err| {
-                            HttpGetTxError::TxEncoding(format!("decode hex error: {}", err))
-                        })?;
-                        Transaction::consensus_decode(&mut raw.as_slice()).map_err(|err| {
-                            HttpGetTxError::TxEncoding(format!("decode tx error: {}", err))
-                        })?
-                    }
-                    _ => Transaction::consensus_decode(&mut response.body.as_slice())
-                        .map_err(|err| HttpGetTxError::TxEncoding(err.to_string()))?,
-                };
-                // Verify the correctness of the transaction by recomputing the transaction ID.
-                let decoded_txid = tx.compute_txid();
-                if decoded_txid.as_ref() as &[u8; 32] != txid.as_ref() {
-                    return Err(HttpGetTxError::TxidMismatch {
-                        expected: txid,
-                        decoded: Txid::from(*(decoded_txid.as_ref() as &[u8; 32])),
-                    });
-                }
-                Ok(tx)
-            }
-            Err((r, m)) if is_response_too_large(&r, &m) => Err(HttpGetTxError::ResponseTooLarge),
-            Err((r, m)) => {
-                // TODO(XC-158): maybe try other providers and also log the error.
-                println!("The http_request resulted into error. RejectionCode: {r:?}, Error: {m}");
-                Err(HttpGetTxError::Rejected {
-                    code: r,
-                    message: m,
-                })
-            }
-        }
-    }
-
-    fn cycles_accept(&self, cycles: u128) -> u128 {
-        ic_cdk::api::call::msg_cycles_accept128(cycles)
-    }
-    fn cycles_available(&self) -> u128 {
-        ic_cdk::api::call::msg_cycles_available128()
-    }
-}
-
-/// Check the input addresses of a transaction given its txid.
-/// It consists of the following steps:
-///
-/// 1. Call `try_fetch_tx` to find if the transaction has already
-///    been fetched, or if another fetch is already pending, or
-///    if we are experiencing high load, or we need to retry the
-///    fetch (when the previous max_response_bytes setting wasn't
-///    enough).
-///
-/// 2. If we need to fetch this tranction, call the function `do_fetch`.
-///
-/// 3. For fetched transaction, call `check_fetched`, which further
-///    checks if the input addresses of this transaction are available.
-///    If not, we need to additionally fetch those input transactions
-///    in order to compute their corresponding addresses.
-pub async fn check_transaction_inputs(txid: Txid) -> CheckTransactionResponse {
-    let env = &KytCanisterEnv;
-    match env.config().kyt_mode() {
-        KytMode::AcceptAll => CheckTransactionResponse::Passed,
-        KytMode::RejectAll => CheckTransactionResponse::Failed(Vec::new()),
-        KytMode::Normal => {
-            match env.try_fetch_tx(txid) {
-                TryFetchResult::Pending => CheckTransactionRetriable::Pending.into(),
-                TryFetchResult::HighLoad => CheckTransactionRetriable::HighLoad.into(),
-                TryFetchResult::NotEnoughCycles => CheckTransactionStatus::NotEnoughCycles.into(),
-                TryFetchResult::Fetched(fetched) => env.check_fetched(txid, &fetched).await,
-                TryFetchResult::ToFetch(do_fetch) => {
-                    match do_fetch.await {
-                        Ok(FetchResult::Fetched(fetched)) => {
-                            env.check_fetched(txid, &fetched).await
-                        }
-                        Ok(FetchResult::Error(err)) => (txid, err).into(),
-                        Ok(FetchResult::RetryWithBiggerBuffer) => {
-                            CheckTransactionRetriable::Pending.into()
-                        }
-                        Err(_) => unreachable!(), // should never happen
-                    }
-                }
-            }
-        }
-    }
 }
 
 mod test {

--- a/rs/bitcoin/kyt/src/lib.rs
+++ b/rs/bitcoin/kyt/src/lib.rs
@@ -1,7 +1,6 @@
 use bitcoin::Address;
 
 pub mod blocklist;
-pub mod providers;
 mod types;
 
 pub use types::*;

--- a/rs/bitcoin/kyt/src/main.rs
+++ b/rs/bitcoin/kyt/src/main.rs
@@ -1,14 +1,27 @@
-use bitcoin::Address;
+use bitcoin::{consensus::Decodable, Address, Transaction};
 use ic_btc_interface::Txid;
 use ic_btc_kyt::{
-    blocklist_contains, check_transaction_inputs, dashboard, get_config, set_config,
-    CheckAddressArgs, CheckAddressResponse, CheckTransactionArgs,
-    CheckTransactionIrrecoverableError, CheckTransactionResponse, CheckTransactionStatus, Config,
-    KytArg, KytMode, CHECK_TRANSACTION_CYCLES_REQUIRED, CHECK_TRANSACTION_CYCLES_SERVICE_FEE,
+    blocklist_contains, get_tx_cycle_cost, providers, BtcNetwork, CheckAddressArgs,
+    CheckAddressResponse, CheckTransactionArgs, CheckTransactionIrrecoverableError,
+    CheckTransactionResponse, CheckTransactionRetriable, CheckTransactionStatus, KytArg, KytMode,
+    CHECK_TRANSACTION_CYCLES_REQUIRED, CHECK_TRANSACTION_CYCLES_SERVICE_FEE,
 };
 use ic_canisters_http_types as http;
+use ic_cdk::api::call::RejectionCode;
 use ic_cdk::api::management_canister::http_request::{HttpResponse, TransformArgs};
 use std::str::FromStr;
+
+mod dashboard;
+mod fetch;
+mod state;
+
+use fetch::{FetchEnv, FetchResult, TryFetchResult};
+use state::{get_config, set_config, Config, FetchGuardError, HttpGetTxError};
+
+pub fn is_response_too_large(code: &RejectionCode, message: &str) -> bool {
+    code == &RejectionCode::SysFatal
+        && (message.contains("size limit") || message.contains("length limit"))
+}
 
 #[ic_cdk::query]
 /// Return `Passed` if the given bitcion address passed the KYT check, or
@@ -135,6 +148,138 @@ fn http_request(req: http::HttpRequest) -> http::HttpResponse {
             .build()
     } else {
         http::HttpResponseBuilder::not_found().build()
+    }
+}
+
+struct KytCanisterEnv;
+
+impl FetchEnv for KytCanisterEnv {
+    type FetchGuard = state::FetchGuard;
+
+    fn new_fetch_guard(&self, txid: Txid) -> Result<Self::FetchGuard, FetchGuardError> {
+        state::FetchGuard::new(txid)
+    }
+
+    fn config(&self) -> Config {
+        get_config()
+    }
+
+    async fn http_get_tx(
+        &self,
+        provider: &providers::Provider,
+        txid: Txid,
+        max_response_bytes: u32,
+    ) -> Result<Transaction, HttpGetTxError> {
+        let request = provider
+            .create_request(txid, max_response_bytes)
+            .map_err(|err| HttpGetTxError::Rejected {
+                code: RejectionCode::SysFatal,
+                message: err,
+            })?;
+        let url = request.url.clone();
+        let cycles = get_tx_cycle_cost(max_response_bytes);
+        match http_request(request.clone(), cycles).await {
+            Ok((response,)) => {
+                // Ensure response is 200 before decoding
+                if response.status != 200u32 {
+                    // All non-200 status are treated as transient errors
+                    return Err(HttpGetTxError::Rejected {
+                        code: RejectionCode::SysTransient,
+                        message: format!("HTTP call {} received code {}", url, response.status),
+                    });
+                }
+                let tx = match provider.btc_network() {
+                    BtcNetwork::Regtest { .. } => {
+                        use serde_json::{from_slice, from_value, Value};
+                        let json: Value = from_slice(response.body.as_slice()).map_err(|err| {
+                            HttpGetTxError::TxEncoding(format!("JSON parsing error {}", err))
+                        })?;
+                        let hex: String =
+                            from_value(json["result"]["hex"].clone()).map_err(|_| {
+                                HttpGetTxError::TxEncoding(
+                                    "Missing result.hex field in JSON response".to_string(),
+                                )
+                            })?;
+                        let raw = hex::decode(&hex).map_err(|err| {
+                            HttpGetTxError::TxEncoding(format!("decode hex error: {}", err))
+                        })?;
+                        Transaction::consensus_decode(&mut raw.as_slice()).map_err(|err| {
+                            HttpGetTxError::TxEncoding(format!("decode tx error: {}", err))
+                        })?
+                    }
+                    _ => Transaction::consensus_decode(&mut response.body.as_slice())
+                        .map_err(|err| HttpGetTxError::TxEncoding(err.to_string()))?,
+                };
+                // Verify the correctness of the transaction by recomputing the transaction ID.
+                let decoded_txid = tx.compute_txid();
+                if decoded_txid.as_ref() as &[u8; 32] != txid.as_ref() {
+                    return Err(HttpGetTxError::TxidMismatch {
+                        expected: txid,
+                        decoded: Txid::from(*(decoded_txid.as_ref() as &[u8; 32])),
+                    });
+                }
+                Ok(tx)
+            }
+            Err((r, m)) if is_response_too_large(&r, &m) => Err(HttpGetTxError::ResponseTooLarge),
+            Err((r, m)) => {
+                // TODO(XC-158): maybe try other providers and also log the error.
+                println!("The http_request resulted into error. RejectionCode: {r:?}, Error: {m}");
+                Err(HttpGetTxError::Rejected {
+                    code: r,
+                    message: m,
+                })
+            }
+        }
+    }
+
+    fn cycles_accept(&self, cycles: u128) -> u128 {
+        ic_cdk::api::call::msg_cycles_accept128(cycles)
+    }
+    fn cycles_available(&self) -> u128 {
+        ic_cdk::api::call::msg_cycles_available128()
+    }
+}
+
+/// Check the input addresses of a transaction given its txid.
+/// It consists of the following steps:
+///
+/// 1. Call `try_fetch_tx` to find if the transaction has already
+///    been fetched, or if another fetch is already pending, or
+///    if we are experiencing high load, or we need to retry the
+///    fetch (when the previous max_response_bytes setting wasn't
+///    enough).
+///
+/// 2. If we need to fetch this tranction, call the function `do_fetch`.
+///
+/// 3. For fetched transaction, call `check_fetched`, which further
+///    checks if the input addresses of this transaction are available.
+///    If not, we need to additionally fetch those input transactions
+///    in order to compute their corresponding addresses.
+pub async fn check_transaction_inputs(txid: Txid) -> CheckTransactionResponse {
+    let env = &KytCanisterEnv;
+    match env.config().kyt_mode() {
+        KytMode::AcceptAll => CheckTransactionResponse::Passed,
+        KytMode::RejectAll => CheckTransactionResponse::Failed(Vec::new()),
+        KytMode::Normal => {
+            match env.try_fetch_tx(txid) {
+                TryFetchResult::Pending => CheckTransactionRetriable::Pending.into(),
+                TryFetchResult::HighLoad => CheckTransactionRetriable::HighLoad.into(),
+                TryFetchResult::NotEnoughCycles => CheckTransactionStatus::NotEnoughCycles.into(),
+                TryFetchResult::Fetched(fetched) => env.check_fetched(txid, &fetched).await,
+                TryFetchResult::ToFetch(do_fetch) => {
+                    match do_fetch.await {
+                        Ok(FetchResult::Fetched(fetched)) => {
+                            env.check_fetched(txid, &fetched).await
+                        }
+                        Ok(FetchResult::Error(err)) => (txid, err).into(),
+                        Ok(FetchResult::RetryWithBiggerBuffer) => {
+                            CheckTransactionRetriable::Pending.into()
+                        }
+                        Err(_) => unreachable!(), // should never happen
+                    }
+                }
+            }
+        }
     }
 }
 

--- a/rs/bitcoin/kyt/src/main.rs
+++ b/rs/bitcoin/kyt/src/main.rs
@@ -1,9 +1,9 @@
 use bitcoin::{consensus::Decodable, Address, Transaction};
 use ic_btc_interface::Txid;
 use ic_btc_kyt::{
-    blocklist_contains, get_tx_cycle_cost, providers, BtcNetwork, CheckAddressArgs,
-    CheckAddressResponse, CheckTransactionArgs, CheckTransactionIrrecoverableError,
-    CheckTransactionResponse, CheckTransactionRetriable, CheckTransactionStatus, KytArg, KytMode,
+    blocklist_contains, get_tx_cycle_cost, BtcNetwork, CheckAddressArgs, CheckAddressResponse,
+    CheckTransactionArgs, CheckTransactionIrrecoverableError, CheckTransactionResponse,
+    CheckTransactionRetriable, CheckTransactionStatus, KytArg, KytMode,
     CHECK_TRANSACTION_CYCLES_REQUIRED, CHECK_TRANSACTION_CYCLES_SERVICE_FEE,
 };
 use ic_canisters_http_types as http;
@@ -13,6 +13,7 @@ use std::str::FromStr;
 
 mod dashboard;
 mod fetch;
+mod providers;
 mod state;
 
 use fetch::{FetchEnv, FetchResult, TryFetchResult};

--- a/rs/bitcoin/kyt/src/main.rs
+++ b/rs/bitcoin/kyt/src/main.rs
@@ -271,7 +271,7 @@ pub async fn check_transaction_inputs(txid: Txid) -> CheckTransactionResponse {
                         Ok(FetchResult::Fetched(fetched)) => {
                             env.check_fetched(txid, &fetched).await
                         }
-                        Ok(FetchResult::Error(err)) => (txid, err).into(),
+                        Ok(FetchResult::Error(err)) => err.into_response(txid),
                         Ok(FetchResult::RetryWithBiggerBuffer) => {
                             CheckTransactionRetriable::Pending.into()
                         }

--- a/rs/bitcoin/kyt/src/main.rs
+++ b/rs/bitcoin/kyt/src/main.rs
@@ -171,6 +171,7 @@ impl FetchEnv for KytCanisterEnv {
         txid: Txid,
         max_response_bytes: u32,
     ) -> Result<Transaction, HttpGetTxError> {
+        use ic_cdk::api::management_canister::http_request::http_request;
         let request = provider
             .create_request(txid, max_response_bytes)
             .map_err(|err| HttpGetTxError::Rejected {

--- a/rs/bitcoin/kyt/src/state.rs
+++ b/rs/bitcoin/kyt/src/state.rs
@@ -1,6 +1,6 @@
 use crate::{
     providers::{parse_authorization_header_from_url, Provider},
-    types::{BtcNetwork, KytMode},
+    BtcNetwork, KytMode,
 };
 use bitcoin::{Address, Transaction};
 use ic_btc_interface::Txid;
@@ -11,6 +11,7 @@ use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
 use std::cell::RefCell;
 use std::collections::{BTreeMap, VecDeque};
+use std::fmt;
 
 #[cfg(test)]
 mod tests;
@@ -28,6 +29,22 @@ pub enum HttpGetTxError {
         code: RejectionCode,
         message: String,
     },
+}
+
+impl fmt::Display for HttpGetTxError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use HttpGetTxError::*;
+        match self {
+            TxEncoding(s) => write!(f, "TxEncoding: {}", s),
+            TxidMismatch { expected, decoded } => write!(
+                f,
+                "TxidMismatch: expected {} but decoded {}",
+                expected, decoded
+            ),
+            ResponseTooLarge => write!(f, "ResponseTooLarge"),
+            Rejected { code, message } => write!(f, "Rejected: code {:?}, {}", code, message),
+        }
+    }
 }
 
 /// We store in state the `FetchStatus` for every `Txid` we fetch.


### PR DESCRIPTION
Refactor the ic-btc-kyt crate to only keep necessary functions in the library and move the rest to build together with the Wasm binary.

This is a necessary move in order to resolve a bizarre problem with CI when ic-btc-kyt is made a dependency of ic-ckbtc-minter. More specifically, our CI job "Bazel Build All Config Check" (which is essentially running clippy) would fail unless askama template is moved out of the ic-btc-kyt lib. Refactoring this crate avoids the problem.