### PR TITLE
refactor(cross-chain): rename metrics related to memory

### DIFF
--- a/rs/bitcoin/ckbtc/minter/src/metrics.rs
+++ b/rs/bitcoin/ckbtc/minter/src/metrics.rs
@@ -12,13 +12,13 @@ pub fn encode_metrics(
     const WASM_PAGE_SIZE_IN_BYTES: f64 = 65536.0;
 
     metrics.encode_gauge(
-        "ckbtc_minter_stable_memory_bytes",
+        "stable_memory_bytes",
         ic_cdk::api::stable::stable_size() as f64 * WASM_PAGE_SIZE_IN_BYTES,
         "Size of the stable memory allocated by this canister.",
     )?;
 
     metrics.encode_gauge(
-        "ckbtc_minter_heap_memory_bytes",
+        "heap_memory_bytes",
         heap_memory_size_bytes() as f64,
         "Size of the heap memory allocated by this canister.",
     )?;

--- a/rs/ethereum/cketh/minter/src/main.rs
+++ b/rs/ethereum/cketh/minter/src/main.rs
@@ -850,13 +850,13 @@ fn http_request(req: HttpRequest) -> HttpResponse {
 
             read_state(|s| {
                 w.encode_gauge(
-                    "cketh_minter_stable_memory_bytes",
+                    "stable_memory_bytes",
                     ic_cdk::api::stable::stable_size() as f64 * WASM_PAGE_SIZE_IN_BYTES,
                     "Size of the stable memory allocated by this canister.",
                 )?;
 
                 w.encode_gauge(
-                    "cketh_minter_heap_memory_bytes",
+                    "heap_memory_bytes",
                     heap_memory_size_bytes() as f64,
                     "Size of the heap memory allocated by this canister.",
                 )?;

--- a/rs/ethereum/ledger-suite-orchestrator/src/main.rs
+++ b/rs/ethereum/ledger-suite-orchestrator/src/main.rs
@@ -196,13 +196,13 @@ fn http_request(
                 const WASM_PAGE_SIZE_IN_BYTES: f64 = 65536.0;
 
                 w.encode_gauge(
-                    "ledger_suite_orchestrator_stable_memory_bytes",
+                    "stable_memory_bytes",
                     ic_cdk::api::stable::stable_size() as f64 * WASM_PAGE_SIZE_IN_BYTES,
                     "Size of the stable memory allocated by this canister.",
                 )?;
 
                 w.encode_gauge(
-                    "ledger_suite_orchestrator_heap_memory_bytes",
+                    "heap_memory_bytes",
                     heap_memory_size_bytes() as f64,
                     "Size of the heap memory allocated by this canister.",
                 )?;


### PR DESCRIPTION
Rename the following metrics published by canisters owned by the cross-chain team:

1. `canister_stable_memory_bytes` -> `stable_memory_bytes`
2. `canister_ heap_memory_bytes` -> `heap_memory_bytes`