### PR TITLE
feat(boundary): add rate-limit canister post_upgrade

### DIFF
--- a/rs/boundary_node/rate_limits/canister/add_config.rs
+++ b/rs/boundary_node/rate_limits/canister/add_config.rs
@@ -1,4 +1,7 @@
-use crate::{storage::StorableIncidentMetadata, types::Timestamp};
+use crate::{
+    storage::StorableIncidentMetadata,
+    types::{SchemaVersion, Timestamp},
+};
 use anyhow::Context;
 use getrandom::getrandom;
 use rate_limits_api::IncidentId;
@@ -15,6 +18,7 @@ use crate::{
 };
 
 pub const INIT_VERSION: Version = 1;
+pub const INIT_SCHEMA_VERSION: SchemaVersion = 1;
 
 pub trait AddsConfig {
     fn add_config(&self, config: InputConfig, time: Timestamp) -> Result<(), AddConfigError>;


### PR DESCRIPTION
This `post_upgrade` hook serves the following purposes:
- Allows changing the authorized principal during canister upgrade phase (upgrades will be done via nns proposals)
- Resets periodic timer task of polling API boundary nodes, otherwise this task remains stopped after upgrade