### PR TITLE
feat(nns): Added total_potential_voting_power to proposals.

### DIFF
--- a/rs/nns/governance/api/src/ic_nns_governance.pb.v1.rs
+++ b/rs/nns/governance/api/src/ic_nns_governance.pb.v1.rs
@@ -1535,6 +1535,13 @@ pub struct ProposalData {
     /// `cf_participants` and use only this field for managing the Neurons' Fund swap participation.
     #[prost(message, optional, tag = "21")]
     pub neurons_fund_data: Option<NeuronsFundData>,
+    /// This is the amount of voting power that would be available if all neurons
+    /// kept themselves "refreshed". This is used as the baseline for voting
+    /// rewards. That is, the amount of maturity that a neuron receives is the
+    /// amount of voting power that it exercised (so called "deciding" voting
+    /// power) in proportion to this.
+    #[prost(uint64, optional, tag = "22")]
+    pub total_potential_voting_power: ::core::option::Option<u64>,
 }
 /// This structure contains data for settling the Neurons' Fund participation in an SNS token swap.
 #[derive(candid::CandidType, candid::Deserialize, serde::Serialize, comparable::Comparable)]
@@ -1929,6 +1936,8 @@ pub struct ProposalInfo {
     pub deadline_timestamp_seconds: Option<u64>,
     #[prost(message, optional, tag = "20")]
     pub derived_proposal_information: Option<DerivedProposalInformation>,
+    #[prost(uint64, optional, tag = "21")]
+    pub total_potential_voting_power: ::core::option::Option<u64>,
 }
 /// Network economics contains the parameters for several operations related
 /// to the economy of the network. When submitting a NetworkEconomics proposal

--- a/rs/nns/governance/canister/governance.did
+++ b/rs/nns/governance/canister/governance.did
@@ -811,6 +811,7 @@ type ProposalData = record {
   wait_for_quiet_state : opt WaitForQuietState;
   executed_timestamp_seconds : nat64;
   original_total_community_fund_maturity_e8s_equivalent : opt nat64;
+  total_potential_voting_power : opt nat64;
 };
 
 type ProposalInfo = record {
@@ -831,6 +832,7 @@ type ProposalInfo = record {
   proposal : opt Proposal;
   proposer : opt NeuronId;
   executed_timestamp_seconds : nat64;
+  total_potential_voting_power : opt nat64;
 };
 
 type RegisterVote = record {

--- a/rs/nns/governance/canister/governance_test.did
+++ b/rs/nns/governance/canister/governance_test.did
@@ -813,6 +813,7 @@ type ProposalData = record {
   wait_for_quiet_state : opt WaitForQuietState;
   executed_timestamp_seconds : nat64;
   original_total_community_fund_maturity_e8s_equivalent : opt nat64;
+  total_potential_voting_power : opt nat64;
 };
 
 type ProposalInfo = record {
@@ -833,6 +834,7 @@ type ProposalInfo = record {
   proposal : opt Proposal;
   proposer : opt NeuronId;
   executed_timestamp_seconds : nat64;
+  total_potential_voting_power : opt nat64;
 };
 
 type RegisterVote = record {

--- a/rs/nns/governance/proto/ic_nns_governance/pb/v1/governance.proto
+++ b/rs/nns/governance/proto/ic_nns_governance/pb/v1/governance.proto
@@ -1447,6 +1447,13 @@ message ProposalData {
   // TODO[NNS1-2566]: deprecate `original_total_community_fund_maturity_e8s_equivalent` and
   // `cf_participants` and use only this field for managing the Neurons' Fund swap participation.
   optional NeuronsFundData neurons_fund_data = 21;
+
+  // This is the amount of voting power that would be available if all neurons
+  // kept themselves "refreshed". This is used as the baseline for voting
+  // rewards. That is, the amount of maturity that a neuron receives is the
+  // amount of voting power that it exercised (so called "deciding" voting
+  // power) in proportion to this.
+  optional uint64 total_potential_voting_power = 22;
 }
 
 // This structure contains data for settling the Neurons' Fund participation in an SNS token swap.
@@ -1750,6 +1757,9 @@ message ProposalInfo {
   optional uint64 deadline_timestamp_seconds = 19;
 
   DerivedProposalInformation derived_proposal_information = 20;
+
+  // See [ProposalData::total_potential_voting_power].
+  optional uint64 total_potential_voting_power = 21;
 }
 
 // Network economics contains the parameters for several operations related

--- a/rs/nns/governance/src/gen/ic_nns_governance.pb.v1.rs
+++ b/rs/nns/governance/src/gen/ic_nns_governance.pb.v1.rs
@@ -1873,6 +1873,13 @@ pub struct ProposalData {
     /// `cf_participants` and use only this field for managing the Neurons' Fund swap participation.
     #[prost(message, optional, tag = "21")]
     pub neurons_fund_data: ::core::option::Option<NeuronsFundData>,
+    /// This is the amount of voting power that would be available if all neurons
+    /// kept themselves "refreshed". This is used as the baseline for voting
+    /// rewards. That is, the amount of maturity that a neuron receives is the
+    /// amount of voting power that it exercised (so called "deciding" voting
+    /// power) in proportion to this.
+    #[prost(uint64, optional, tag = "22")]
+    pub total_potential_voting_power: ::core::option::Option<u64>,
 }
 /// This structure contains data for settling the Neurons' Fund participation in an SNS token swap.
 #[derive(
@@ -2375,6 +2382,9 @@ pub struct ProposalInfo {
     pub deadline_timestamp_seconds: ::core::option::Option<u64>,
     #[prost(message, optional, tag = "20")]
     pub derived_proposal_information: ::core::option::Option<DerivedProposalInformation>,
+    /// See \[ProposalData::total_potential_voting_power\].
+    #[prost(uint64, optional, tag = "21")]
+    pub total_potential_voting_power: ::core::option::Option<u64>,
 }
 /// Network economics contains the parameters for several operations related
 /// to the economy of the network. When submitting a NetworkEconomics proposal

--- a/rs/nns/governance/src/governance.rs
+++ b/rs/nns/governance/src/governance.rs
@@ -11,7 +11,7 @@ use crate::{
         reassemble_governance_proto, split_governance_proto, HeapGovernanceData, XdrConversionRate,
     },
     migrations::maybe_run_migrations,
-    neuron::{DissolveStateAndAge, Neuron, NeuronBuilder},
+    neuron::{types::total_potential_voting_power, DissolveStateAndAge, Neuron, NeuronBuilder},
     neuron_data_validation::{NeuronDataValidationSummary, NeuronDataValidator},
     neuron_store::{metrics::NeuronSubsetMetrics, NeuronMetrics, NeuronStore},
     neurons_fund::{
@@ -3846,6 +3846,7 @@ impl Governance {
                 data.get_deadline_timestamp_seconds(voting_period_seconds),
             ),
             derived_proposal_information: data.derived_proposal_information.clone(),
+            total_potential_voting_power: data.total_potential_voting_power,
         }
     }
 
@@ -5521,6 +5522,13 @@ impl Governance {
             ));
         }
 
+        let total_potential_voting_power = Some(total_potential_voting_power(
+            self.neuron_store.voting_eligible_neurons(now_seconds),
+            now_seconds,
+            &action,
+            ballots.len(),
+        )?);
+
         // In some cases we want to customize some aspects of the proposal
         let proposal = if let Action::ManageNeuron(ref manage_neuron) = action {
             // We want to customize the title for manage neuron proposals, to
@@ -5559,7 +5567,6 @@ impl Governance {
         let proposal_num = self.next_proposal_id();
         let proposal_id = ProposalId { id: proposal_num };
 
-        // Create the proposal.
         let wait_for_quiet_state = if wait_for_quiet_enabled {
             Some(WaitForQuietState {
                 current_deadline_timestamp_seconds: now_seconds
@@ -5568,6 +5575,8 @@ impl Governance {
         } else {
             None
         };
+
+        // Create the proposal.
         let mut proposal_data = ProposalData {
             id: Some(proposal_id),
             proposer: Some(*proposer_id),
@@ -5576,6 +5585,7 @@ impl Governance {
             proposal_timestamp_seconds: now_seconds,
             ballots,
             wait_for_quiet_state,
+            total_potential_voting_power,
             ..Default::default()
         };
 

--- a/rs/nns/governance/src/pb/conversions.rs
+++ b/rs/nns/governance/src/pb/conversions.rs
@@ -1825,6 +1825,7 @@ impl From<pb::ProposalData> for pb_api::ProposalData {
             sns_token_swap_lifecycle: item.sns_token_swap_lifecycle,
             derived_proposal_information: item.derived_proposal_information.map(|x| x.into()),
             neurons_fund_data: item.neurons_fund_data.map(|x| x.into()),
+            total_potential_voting_power: item.total_potential_voting_power,
         }
     }
 }
@@ -1853,6 +1854,7 @@ impl From<pb_api::ProposalData> for pb::ProposalData {
             sns_token_swap_lifecycle: item.sns_token_swap_lifecycle,
             derived_proposal_information: item.derived_proposal_information.map(|x| x.into()),
             neurons_fund_data: item.neurons_fund_data.map(|x| x.into()),
+            total_potential_voting_power: item.total_potential_voting_power,
         }
     }
 }
@@ -2309,9 +2311,11 @@ impl From<pb::ProposalInfo> for pb_api::ProposalInfo {
             reward_status: item.reward_status,
             deadline_timestamp_seconds: item.deadline_timestamp_seconds,
             derived_proposal_information: item.derived_proposal_information.map(|x| x.into()),
+            total_potential_voting_power: item.total_potential_voting_power,
         }
     }
 }
+
 impl From<pb_api::ProposalInfo> for pb::ProposalInfo {
     fn from(item: pb_api::ProposalInfo) -> Self {
         Self {
@@ -2336,6 +2340,7 @@ impl From<pb_api::ProposalInfo> for pb::ProposalInfo {
             reward_status: item.reward_status,
             deadline_timestamp_seconds: item.deadline_timestamp_seconds,
             derived_proposal_information: item.derived_proposal_information.map(|x| x.into()),
+            total_potential_voting_power: item.total_potential_voting_power,
         }
     }
 }

--- a/rs/nns/governance/tests/governance.rs
+++ b/rs/nns/governance/tests/governance.rs
@@ -346,6 +346,10 @@ fn test_single_neuron_proposal_new() {
                                 current_deadline_timestamp_seconds: 999111017,
                             }),
                         )),
+                        ProposalDataChange::TotalPotentialVotingPower(OptionChange::Different(
+                            None,
+                            Some(1),
+                        )),
                     ],
                 )]),
                 GovernanceChange::Metrics(OptionChange::Different(
@@ -1067,6 +1071,10 @@ async fn test_cascade_following_new() {
                         Some(WaitForQuietStateDesc {
                             current_deadline_timestamp_seconds: 999111001,
                         }),
+                    )),
+                    ProposalDataChange::TotalPotentialVotingPower(OptionChange::Different(
+                        None,
+                        Some(10_125_000_000)
                     )),
                 ],
             )]),


### PR DESCRIPTION
# Background

This is part of the "periodic confirmation" feature that was recently approved in proposal [132411][prop].

[prop]: https://dashboard.internetcomputer.org/proposal/132411

# Future Work

This will be used in the calculation of voting rewards. Whereas, before, the total voting power in ballots (i.e. "deciding" voting power) was used as the baseline to determine each neuron's share of the reward purse. With the distinction between potential voting power vs. deciding voting power (implemented in an earlier PR in this series), if we continued to do it the old way, the pie would be sliced into a smaller number of pieces. When this new field is used, the pie will continue to be sliced into the same number of pieces today. This way, neurons that stay refreshed will keep getting the same amount of rewards (not more), while those who do not stay refreshed will get less.

# References

Closes https://dfinity.atlassian.net/browse/NNS1-3411.

[👈 Previous PR][prev] | [Next PR 👉][next]

[prev]: https://github.com/dfinity/ic/pull/2339
[next]: https://github.com/dfinity/ic/pull/2385