### PR TITLE
refactor(sns): Add `Copy` implementation to ic-nervous-system-agent SNS canister wrappers

### DIFF
--- a/rs/nervous_system/agent/src/sns/governance.rs
+++ b/rs/nervous_system/agent/src/sns/governance.rs
@@ -6,7 +6,7 @@ use ic_sns_governance::pb::v1::{
 };
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Copy, Clone, Debug, Deserialize, Serialize)]
 pub struct GovernanceCanister {
     pub canister_id: PrincipalId,
 }

--- a/rs/nervous_system/agent/src/sns/index.rs
+++ b/rs/nervous_system/agent/src/sns/index.rs
@@ -1,7 +1,7 @@
 use ic_base_types::PrincipalId;
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Copy, Clone, Debug, Deserialize, Serialize)]
 pub struct IndexCanister {
     pub canister_id: PrincipalId,
 }

--- a/rs/nervous_system/agent/src/sns/ledger.rs
+++ b/rs/nervous_system/agent/src/sns/ledger.rs
@@ -1,7 +1,7 @@
 use ic_base_types::PrincipalId;
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Copy, Clone, Debug, Deserialize, Serialize)]
 pub struct LedgerCanister {
     pub canister_id: PrincipalId,
 }

--- a/rs/nervous_system/agent/src/sns/root.rs
+++ b/rs/nervous_system/agent/src/sns/root.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::CallCanisters;
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Copy, Clone, Debug, Deserialize, Serialize)]
 pub struct RootCanister {
     pub canister_id: PrincipalId,
 }

--- a/rs/nervous_system/agent/src/sns/swap.rs
+++ b/rs/nervous_system/agent/src/sns/swap.rs
@@ -8,7 +8,7 @@ use thiserror::Error;
 
 use crate::CallCanisters;
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Copy, Clone, Debug, Deserialize, Serialize)]
 pub struct SwapCanister {
     pub canister_id: PrincipalId,
 }


### PR DESCRIPTION
They are just wrappers for `Principald`s, which are `Copy`, and it's more convenient not to have to write `.clone()`

[← Prevous PR](https://github.com/dfinity/ic/pull/2377) | [Next PR →](https://github.com/dfinity/ic/pull/2321)