### PR TITLE
fix: typo in `generate_swap_canister_upgrade_proposal_text`

### DIFF
--- a/testnet/tools/nns-tools/lib/proposals.sh
+++ b/testnet/tools/nns-tools/lib/proposals.sh
@@ -191,7 +191,7 @@ git checkout $NEXT_COMMIT
 ./ci/container/build-ic.sh -c
 
 # 3. Fingerprint the result.
-sha256sum ./artifacts/canisters/$(_canister_download_name_for_nns_canister_type "$CANISTER_NAME").wasm.gz
+sha256sum ./artifacts/canisters/$(_canister_download_name_for_sns_canister_type "$CANISTER_NAME").wasm.gz
 \`\`\`
 
 This should match \`wasm_module_hash\` field of this proposal.$(if [ ! -z "$CANDID_ARGS" ]; then


### PR DESCRIPTION
This PR fixes a typo in the verification instructions of the Swap upgrade proposal generation script.