### PR TITLE
chore: Remove obsolete publish target sns-test-feature

### DIFF
--- a/publish/binaries/BUILD.bazel
+++ b/publish/binaries/BUILD.bazel
@@ -57,7 +57,6 @@ TESTONLY_BINARIES = [
     "ic-starter",
     "ic-test-state-machine",
     "pocket-ic",
-    "sns-test-feature",
     "types-test",
     "replicated-state-test",
 ]


### PR DESCRIPTION
The target sns-test-feature is not used anymore and is thus removed from the Bazel configurations.