### PR TITLE
fix: Make NNS init .csv parser recognize `dissolve_delay_s` and `maturity_e8s_equivalent` values again

### DIFF
--- a/rs/nns/governance/init/src/lib.rs
+++ b/rs/nns/governance/init/src/lib.rs
@@ -251,6 +251,7 @@ impl GovernanceCanisterInitPayloadBuilder {
                     "neuron_id",
                     "owner_id",
                     "created_ts_ns",
+                    "dissolve_delay_s",
                     "staked_icpt",
                     "follows",
                     "not_for_profit",
@@ -275,10 +276,13 @@ impl GovernanceCanisterInitPayloadBuilder {
             let creation_ts_ns = record[2]
                 .parse::<u64>()
                 .expect("couldn't read the neuron's creation time");
-            let staked_icpt = record[3]
+            let dissolve_delay_seconds = record[3]
+                .parse::<u64>()
+                .expect("couldn't read the neuron's dissolve delay");
+            let staked_icpt = record[4]
                 .parse::<u64>()
                 .expect("couldn't read the neuron's staked icpt amount");
-            let followees: Vec<NeuronIdProto> = record[4]
+            let followees: Vec<NeuronIdProto> = record[5]
                 .split_terminator(',')
                 .map(|x| NeuronIdProto {
                     id: x.parse::<u64>().expect("could not parse followee"),
@@ -290,19 +294,15 @@ impl GovernanceCanisterInitPayloadBuilder {
 
             let neuron_id = NeuronIdProto::from(neuron_id);
 
-            let not_for_profit = record[5]
+            let not_for_profit = record[6]
                 .parse::<bool>()
                 .expect("couldn't read the neuron's not-for-profit flag");
 
             let memo = self.rng.next_u64();
 
-            let maturity_e8s_equivalent = if record.len() < 7 {
-                0
-            } else {
-                record[6]
-                    .parse::<u64>()
-                    .expect("could not parse maturity_e8s_equivalent")
-            };
+            let maturity_e8s_equivalent = record[7]
+                .parse::<u64>()
+                .expect("could not parse maturity_e8s_equivalent");
 
             let kyc_verified = false;
 
@@ -317,7 +317,7 @@ impl GovernanceCanisterInitPayloadBuilder {
                 kyc_verified,
                 maturity_e8s_equivalent,
                 not_for_profit,
-                dissolve_state: Some(DissolveState::DissolveDelaySeconds(1)),
+                dissolve_state: Some(DissolveState::DissolveDelaySeconds(dissolve_delay_seconds)),
                 followees: [(Topic::Unspecified as i32, Followees { followees })]
                     .iter()
                     .cloned()

--- a/rs/nns/governance/init/src/lib.rs
+++ b/rs/nns/governance/init/src/lib.rs
@@ -253,7 +253,8 @@ impl GovernanceCanisterInitPayloadBuilder {
                     "created_ts_ns",
                     "staked_icpt",
                     "follows",
-                    "not_for_profit"
+                    "not_for_profit",
+                    "maturity_e8s_equivalent",
                 ]
             );
         }
@@ -293,25 +294,17 @@ impl GovernanceCanisterInitPayloadBuilder {
                 .parse::<bool>()
                 .expect("couldn't read the neuron's not-for-profit flag");
 
-            let memo = if record.len() < 9 {
-                self.rng.next_u64()
-            } else {
-                record[6].parse::<u64>().expect("could not parse memo")
-            };
+            let memo = self.rng.next_u64();
 
-            let maturity_e8s_equivalent = if record.len() < 10 {
+            let maturity_e8s_equivalent = if record.len() < 7 {
                 0
             } else {
-                record[7].parse::<u64>().expect("could not parse maturity")
+                record[6]
+                    .parse::<u64>()
+                    .expect("could not parse maturity_e8s_equivalent")
             };
 
-            let kyc_verified = if record.len() < 11 {
-                false
-            } else {
-                record[8]
-                    .parse::<bool>()
-                    .expect("could not parse kyc_verified")
-            };
+            let kyc_verified = false;
 
             let neuron = Neuron {
                 id: Some(neuron_id),

--- a/rs/nns/governance/tests/neurons.csv
+++ b/rs/nns/governance/tests/neurons.csv
@@ -1,4 +1,4 @@
-neuron_id;owner_id;created_ts_ns;staked_icpt;follows;not_for_profit
-25;zcwir-6stv5-xj4ap-gsl5i-r7dg5-w5prz-fedwa-knbyj-o4tlv-5sbo7-6qe;0;1000000000;42;true
-42;2q5kv-5vcol-eh2je-udy6s-j74gx-djqza-siucy-2jxyq-u5kw6-imugq-uae;1;10000000000;;false
-100;sma3p-ivkif-hz7nu-ngmvq-ibnjg-nubke-zf6gh-wbnfc-2dlng-l3die-zqe;1;0;25,42;false
+neuron_id;owner_id;created_ts_ns;staked_icpt;follows;not_for_profit;maturity_e8s_equivalent
+25;zcwir-6stv5-xj4ap-gsl5i-r7dg5-w5prz-fedwa-knbyj-o4tlv-5sbo7-6qe;0;1000000000;42;true;100000000
+42;2q5kv-5vcol-eh2je-udy6s-j74gx-djqza-siucy-2jxyq-u5kw6-imugq-uae;1;10000000000;;false;200000000
+100;sma3p-ivkif-hz7nu-ngmvq-ibnjg-nubke-zf6gh-wbnfc-2dlng-l3die-zqe;1;0;25,42;false;300000000

--- a/rs/nns/governance/tests/neurons.csv
+++ b/rs/nns/governance/tests/neurons.csv
@@ -1,4 +1,4 @@
 neuron_id;owner_id;created_ts_ns;dissolve_delay_s;staked_icpt;follows;not_for_profit;maturity_e8s_equivalent
-25;zcwir-6stv5-xj4ap-gsl5i-r7dg5-w5prz-fedwa-knbyj-o4tlv-5sbo7-6qe;0;0;1000000000;42;true;100000000
-42;2q5kv-5vcol-eh2je-udy6s-j74gx-djqza-siucy-2jxyq-u5kw6-imugq-uae;1;0;10000000000;;false;200000000
-100;sma3p-ivkif-hz7nu-ngmvq-ibnjg-nubke-zf6gh-wbnfc-2dlng-l3die-zqe;1;0;0;25,42;false;300000000
+25;zcwir-6stv5-xj4ap-gsl5i-r7dg5-w5prz-fedwa-knbyj-o4tlv-5sbo7-6qe;0;1;1000000000;42;true;100000000
+42;2q5kv-5vcol-eh2je-udy6s-j74gx-djqza-siucy-2jxyq-u5kw6-imugq-uae;1;1;10000000000;;false;200000000
+100;sma3p-ivkif-hz7nu-ngmvq-ibnjg-nubke-zf6gh-wbnfc-2dlng-l3die-zqe;1;1;0;25,42;false;300000000

--- a/rs/nns/governance/tests/neurons.csv
+++ b/rs/nns/governance/tests/neurons.csv
@@ -1,4 +1,4 @@
-neuron_id;owner_id;created_ts_ns;staked_icpt;follows;not_for_profit;maturity_e8s_equivalent
-25;zcwir-6stv5-xj4ap-gsl5i-r7dg5-w5prz-fedwa-knbyj-o4tlv-5sbo7-6qe;0;1000000000;42;true;100000000
-42;2q5kv-5vcol-eh2je-udy6s-j74gx-djqza-siucy-2jxyq-u5kw6-imugq-uae;1;10000000000;;false;200000000
-100;sma3p-ivkif-hz7nu-ngmvq-ibnjg-nubke-zf6gh-wbnfc-2dlng-l3die-zqe;1;0;25,42;false;300000000
+neuron_id;owner_id;created_ts_ns;dissolve_delay_s;staked_icpt;follows;not_for_profit;maturity_e8s_equivalent
+25;zcwir-6stv5-xj4ap-gsl5i-r7dg5-w5prz-fedwa-knbyj-o4tlv-5sbo7-6qe;0;0;1000000000;42;true;100000000
+42;2q5kv-5vcol-eh2je-udy6s-j74gx-djqza-siucy-2jxyq-u5kw6-imugq-uae;1;0;10000000000;;false;200000000
+100;sma3p-ivkif-hz7nu-ngmvq-ibnjg-nubke-zf6gh-wbnfc-2dlng-l3die-zqe;1;0;0;25,42;false;300000000

--- a/rs/nns/integration_tests/src/neurons.csv
+++ b/rs/nns/integration_tests/src/neurons.csv
@@ -1,4 +1,4 @@
-neuron_id;owner_id;created_ts_ns;staked_icpt;follows;not_for_profit
-25;zcwir-6stv5-xj4ap-gsl5i-r7dg5-w5prz-fedwa-knbyj-o4tlv-5sbo7-6qe;0;1000000000;42;true
-42;2q5kv-5vcol-eh2je-udy6s-j74gx-djqza-siucy-2jxyq-u5kw6-imugq-uae;1;10000000000;;false
-100;sma3p-ivkif-hz7nu-ngmvq-ibnjg-nubke-zf6gh-wbnfc-2dlng-l3die-zqe;1;0;25,42;false
+neuron_id;owner_id;created_ts_ns;staked_icpt;follows;not_for_profit;maturity_e8s_equivalent
+25;zcwir-6stv5-xj4ap-gsl5i-r7dg5-w5prz-fedwa-knbyj-o4tlv-5sbo7-6qe;0;1000000000;42;true;500000000
+42;2q5kv-5vcol-eh2je-udy6s-j74gx-djqza-siucy-2jxyq-u5kw6-imugq-uae;1;10000000000;;false;5000000000
+100;sma3p-ivkif-hz7nu-ngmvq-ibnjg-nubke-zf6gh-wbnfc-2dlng-l3die-zqe;1;0;25,42;false;0

--- a/rs/nns/integration_tests/src/neurons.csv
+++ b/rs/nns/integration_tests/src/neurons.csv
@@ -1,4 +1,4 @@
-neuron_id;owner_id;created_ts_ns;staked_icpt;follows;not_for_profit;maturity_e8s_equivalent
-25;zcwir-6stv5-xj4ap-gsl5i-r7dg5-w5prz-fedwa-knbyj-o4tlv-5sbo7-6qe;0;1000000000;42;true;500000000
-42;2q5kv-5vcol-eh2je-udy6s-j74gx-djqza-siucy-2jxyq-u5kw6-imugq-uae;1;10000000000;;false;5000000000
-100;sma3p-ivkif-hz7nu-ngmvq-ibnjg-nubke-zf6gh-wbnfc-2dlng-l3die-zqe;1;0;25,42;false;0
+neuron_id;owner_id;created_ts_ns;dissolve_delay_s;staked_icpt;follows;not_for_profit;maturity_e8s_equivalent
+25;zcwir-6stv5-xj4ap-gsl5i-r7dg5-w5prz-fedwa-knbyj-o4tlv-5sbo7-6qe;0;1;1000000000;42;true;500000000
+42;2q5kv-5vcol-eh2je-udy6s-j74gx-djqza-siucy-2jxyq-u5kw6-imugq-uae;1;1;10000000000;;false;5000000000
+100;sma3p-ivkif-hz7nu-ngmvq-ibnjg-nubke-zf6gh-wbnfc-2dlng-l3die-zqe;1;1;0;25,42;false;0


### PR DESCRIPTION
This PR fixes the NNS init .csv parser to enable it to recognize `dissolve_delay_s` and `maturity_e8s_equivalent` values for initial neurons again.