### PR TITLE
feat(nns): Voting rewards are now in proportion to total *potential* voting power.

### DIFF
--- a/rs/nns/governance/src/governance.rs
+++ b/rs/nns/governance/src/governance.rs
@@ -7028,9 +7028,17 @@ impl Governance {
         // reward weight of proposals being voted on.
         let mut actually_distributed_e8s_equivalent = 0_u64;
 
-        let proposals = considered_proposals
-            .iter()
-            .map(|proposal_id| (*proposal_id, self.heap_data.proposals.get(&proposal_id.id)));
+        let proposals = considered_proposals.iter().filter_map(|proposal_id| {
+            let result = self.heap_data.proposals.get(&proposal_id.id);
+            if result.is_none() {
+                println!(
+                    "{}ERROR: Trying to give voting rewards for proposal {}, \
+                         but it was not found.",
+                    LOG_PREFIX, proposal_id.id,
+                );
+            }
+            result
+        });
         let (voters_to_used_voting_right, total_voting_rights) =
             sum_weighted_voting_power(proposals);
 

--- a/rs/nns/governance/src/governance.rs
+++ b/rs/nns/governance/src/governance.rs
@@ -7043,12 +7043,11 @@ impl Governance {
                 if let Some(proposal) = self.get_proposal_data(*pid) {
                     let reward_weight = proposal.topic().reward_weight();
 
-                    let total_potential_voting_power =
-                        proposal
-                            .total_potential_voting_power
-                            .map(|total_potential_voting_power| {
-                                reward_weight * (total_potential_voting_power as f64)
-                            });
+                    let weighted_total_potential_voting_power = proposal
+                        .total_potential_voting_power
+                        .map(|total_potential_voting_power| {
+                            reward_weight * (total_potential_voting_power as f64)
+                        });
 
                     let mut proposal_total_deciding_voting_rights = 0_f64;
                     for (voter, ballot) in proposal.ballots.iter() {
@@ -7071,7 +7070,7 @@ impl Governance {
                         }
                     }
 
-                    total_voting_rights = total_potential_voting_power
+                    total_voting_rights += weighted_total_potential_voting_power
                         // This is to handle legacy proposals, which were
                         // created before there was a distinction between
                         // *deciding* voting power vs. *potential* voting power.

--- a/rs/nns/governance/src/proposals/mod.rs
+++ b/rs/nns/governance/src/proposals/mod.rs
@@ -65,10 +65,11 @@ pub(crate) fn invalid_proposal_error(reason: &str) -> GovernanceError {
 /// For example, suppose this returns ({42 => 3.14}, 99.9). This means that
 /// neuron 42 should get 3.14/99.9 of today's reward purse.
 ///
-/// Non-essential fact: It is highly unusual for result.1 to be the sum of the
-/// values in result.0. The main reason they would not be equal is that not all
-/// neurons vote. Another (less imporant reason) is that some neurons lose
-/// voting power due to inactivity.
+/// Non-essential fact: Typically, result.1 is strictly greater than the sum of
+/// the values in result.0. The main reason they are usually not equal is that
+/// some neurons didn't vote. Another reason is that some neurons did not
+/// "refresh" their voting power recently enough. Probably the former has more
+/// of an impact on the sum of values in result.1.
 pub fn sum_weighted_voting_power<'a>(
     proposals: impl Iterator<Item = &'a ProposalData>,
 ) -> (
@@ -99,7 +100,7 @@ pub fn sum_weighted_voting_power<'a>(
             total_ballots_voting_power += ballot.voting_power;
 
             // Don't reward neurons that did not actually vote. (Whereas, ALL
-            // eligible neuron gets an "empty" ballot when the proposal is first
+            // eligible neurons get an "empty" ballot when the proposal is first
             // created. An "empty" ballot is one where the vote field is set to
             // Unspecified.)
             let vote = Vote::try_from(ballot.vote).unwrap_or_else(|err| {

--- a/rs/nns/governance/src/proposals/mod.rs
+++ b/rs/nns/governance/src/proposals/mod.rs
@@ -1,9 +1,5 @@
-use crate::{
-    governance::LOG_PREFIX,
-    pb::v1::{governance_error::ErrorType, GovernanceError, ProposalData, Topic, Vote},
-};
+use crate::pb::v1::{governance_error::ErrorType, GovernanceError, Topic};
 use ic_base_types::CanisterId;
-use ic_nns_common::pb::v1::NeuronId;
 use ic_nns_constants::{
     BITCOIN_MAINNET_CANISTER_ID, BITCOIN_TESTNET_CANISTER_ID, CYCLES_LEDGER_CANISTER_ID,
     CYCLES_LEDGER_INDEX_CANISTER_ID, CYCLES_MINTING_CANISTER_ID, EXCHANGE_RATE_CANISTER_ID,
@@ -12,7 +8,6 @@ use ic_nns_constants::{
     LEDGER_INDEX_CANISTER_ID, LIFELINE_CANISTER_ID, REGISTRY_CANISTER_ID, ROOT_CANISTER_ID,
     SNS_AGGREGATOR_CANISTER_ID, SNS_WASM_CANISTER_ID, SUBNET_RENTAL_CANISTER_ID,
 };
-use std::collections::HashMap;
 
 pub mod call_canister;
 pub mod create_service_nervous_system;
@@ -57,79 +52,5 @@ pub(crate) fn invalid_proposal_error(reason: &str) -> GovernanceError {
     GovernanceError::new_with_message(
         ErrorType::InvalidProposal,
         format!("Proposal invalid because of {}", reason),
-    )
-}
-
-/// Weighted voting power is just voting power * the proposal's (topic's) weight.
-///
-/// For example, suppose this returns ({42 => 3.14}, 99.9). This means that
-/// neuron 42 should get 3.14/99.9 of today's reward purse.
-///
-/// Non-essential fact: Typically, result.1 is strictly greater than the sum of
-/// the values in result.0. The main reason they are usually not equal is that
-/// some neurons didn't vote. Another reason is that some neurons did not
-/// "refresh" their voting power recently enough. Probably the former has more
-/// of an impact on the sum of values in result.1.
-pub fn sum_weighted_voting_power<'a>(
-    proposals: impl Iterator<Item = &'a ProposalData>,
-) -> (
-    HashMap<
-        NeuronId,
-        f64, // exercised
-    >,
-    f64, // total
-) {
-    // Results.
-    let mut neuron_id_to_exercised_weighted_voting_power: HashMap<NeuronId, f64> = HashMap::new();
-    let mut total_weighted_voting_power = 0.0;
-
-    for proposal in proposals {
-        let reward_weight = proposal.topic().reward_weight();
-
-        // This is used in lieu of total_potential_voting_power. That is, this
-        // gets used if proposal does not have total_potential_voting_power.
-        // This fall back will only be used during a short transition period
-        // when there is a backlog of "old" proposals that were created without
-        // total_potential_voting_power, but all new proposals have it. In the
-        // case of such legacy proposals, their total potential voting power
-        // would have been equal to this anyway, so this is a sound substitute
-        // for total_potential_voting_power.
-        let mut total_ballots_voting_power = 0;
-
-        for (neuron_id, ballot) in &proposal.ballots {
-            total_ballots_voting_power += ballot.voting_power;
-
-            // Don't reward neurons that did not actually vote. (Whereas, ALL
-            // eligible neurons get an "empty" ballot when the proposal is first
-            // created. An "empty" ballot is one where the vote field is set to
-            // Unspecified.)
-            let vote = Vote::try_from(ballot.vote).unwrap_or_else(|err| {
-                println!(
-                    "{}ERROR: Unrecognized Vote {} in ballot by neuron {} \
-                     on proposal {:?}: {:?}",
-                    LOG_PREFIX, ballot.vote, neuron_id, proposal.id, err,
-                );
-                Vote::Unspecified
-            });
-            if !vote.eligible_for_rewards() {
-                continue;
-            }
-
-            // Increment neuron.
-            *neuron_id_to_exercised_weighted_voting_power
-                .entry(NeuronId { id: *neuron_id })
-                .or_insert(0.0) += (ballot.voting_power as f64) * reward_weight;
-        }
-
-        // Increment global total.
-        total_weighted_voting_power += reward_weight
-            * proposal
-                .total_potential_voting_power
-                .unwrap_or(total_ballots_voting_power) as f64;
-    }
-
-    (
-        neuron_id_to_exercised_weighted_voting_power,
-        total_weighted_voting_power,
     )
 }

--- a/rs/nns/governance/src/proposals/mod.rs
+++ b/rs/nns/governance/src/proposals/mod.rs
@@ -1,5 +1,9 @@
-use crate::pb::v1::{governance_error::ErrorType, GovernanceError, Topic};
+use crate::{
+    governance::LOG_PREFIX,
+    pb::v1::{governance_error::ErrorType, GovernanceError, ProposalData, Topic, Vote},
+};
 use ic_base_types::CanisterId;
+use ic_nns_common::pb::v1::{NeuronId, ProposalId};
 use ic_nns_constants::{
     BITCOIN_MAINNET_CANISTER_ID, BITCOIN_TESTNET_CANISTER_ID, CYCLES_LEDGER_CANISTER_ID,
     CYCLES_LEDGER_INDEX_CANISTER_ID, CYCLES_MINTING_CANISTER_ID, EXCHANGE_RATE_CANISTER_ID,
@@ -8,6 +12,7 @@ use ic_nns_constants::{
     LEDGER_INDEX_CANISTER_ID, LIFELINE_CANISTER_ID, REGISTRY_CANISTER_ID, ROOT_CANISTER_ID,
     SNS_AGGREGATOR_CANISTER_ID, SNS_WASM_CANISTER_ID, SUBNET_RENTAL_CANISTER_ID,
 };
+use std::collections::HashMap;
 
 pub mod call_canister;
 pub mod create_service_nervous_system;
@@ -52,5 +57,84 @@ pub(crate) fn invalid_proposal_error(reason: &str) -> GovernanceError {
     GovernanceError::new_with_message(
         ErrorType::InvalidProposal,
         format!("Proposal invalid because of {}", reason),
+    )
+}
+
+/// Weighted voting power is just voting power * the proposal's (topic's) weight.
+///
+/// For example, suppose this returns ({42 => 3.14}, 99.9). This means that
+/// neuron 42 should get 3.14/99.9 of today's reward purse.
+///
+/// Non-essential fact: It is highly unusual for result.1 to be the sum of the
+/// values in result.0. The main reason they would not be equal is that not all
+/// neurons vote. Another (less imporant reason) is that some neurons lose
+/// voting power due to inactivity.
+pub fn sum_weighted_voting_power<'a>(
+    proposals: impl Iterator<Item = (ProposalId, Option<&'a ProposalData>)>,
+) -> (HashMap<NeuronId, /* exercised */ f64>, /* total */ f64) {
+    // Results.
+    let mut neuron_id_to_exercised_weighted_voting_power: HashMap<NeuronId, f64> = HashMap::new();
+    let mut total_weighted_voting_power = 0.0;
+
+    for (proposal_id, proposal) in proposals {
+        let proposal = match proposal {
+            Some(ok) => ok,
+            None => {
+                println!(
+                    "{}ERROR: Trying to give voting rewards for proposal {}, \
+                     but it was not found.",
+                    LOG_PREFIX, proposal_id.id,
+                );
+                continue;
+            }
+        };
+
+        let reward_weight = proposal.topic().reward_weight();
+
+        // This is used in lieu of total_potential_voting_power. That is, this
+        // gets used if proposal does not have total_potential_voting_power.
+        // This fall back will only be used during a short transition period
+        // when there is a backlog of "old" proposals that were created without
+        // total_potential_voting_power, but all new proposals have it. In the
+        // case of such legacy proposals, their total potential voting power
+        // would have been equal to this anyway, so this is a sound substitute
+        // for total_potential_voting_power.
+        let mut total_ballots_voting_power = 0;
+
+        for (neuron_id, ballot) in &proposal.ballots {
+            total_ballots_voting_power += ballot.voting_power;
+
+            // Don't reward neurons that did not actually vote. (Whereas, ALL
+            // eligible neuron gets an "empty" ballot when the proposal is first
+            // created. An "empty" ballot is one where the vote field is set to
+            // Unspecified.)
+            let vote = Vote::try_from(ballot.vote).unwrap_or_else(|err| {
+                println!(
+                    "{}ERROR: Unrecognized Vote {} in ballot by \
+                         neuron {} on proposal {:?}: {:?}",
+                    LOG_PREFIX, ballot.vote, neuron_id, proposal.id, err,
+                );
+                Vote::Unspecified
+            });
+            if !vote.eligible_for_rewards() {
+                continue;
+            }
+
+            // Increment neuron.
+            *neuron_id_to_exercised_weighted_voting_power
+                .entry(NeuronId { id: *neuron_id })
+                .or_insert(0.0) += (ballot.voting_power as f64) * reward_weight;
+        }
+
+        // Increment global total.
+        total_weighted_voting_power += reward_weight
+            * proposal
+                .total_potential_voting_power
+                .unwrap_or(total_ballots_voting_power) as f64;
+    }
+
+    (
+        neuron_id_to_exercised_weighted_voting_power,
+        total_weighted_voting_power,
     )
 }

--- a/rs/nns/governance/tests/proposals.rs
+++ b/rs/nns/governance/tests/proposals.rs
@@ -1,0 +1,102 @@
+use ic_nns_common::pb::v1::{NeuronId, ProposalId};
+use ic_nns_governance::{
+    pb::v1::{proposal::Action, Ballot, Proposal, ProposalData, Vote},
+    proposals::sum_weighted_voting_power,
+};
+use maplit::hashmap;
+
+#[test]
+fn test_sum_weighted_voting_power() {
+    let proposal = Some(Proposal {
+        action: Some(Action::AddOrRemoveNodeProvider(Default::default())),
+        ..Default::default()
+    });
+
+    let ballots = hashmap! {
+        1042 => Ballot {
+            vote: Vote::Unspecified as i32,
+            voting_power: 100,
+        },
+        1043 => Ballot {
+            vote: Vote::Yes as i32,
+            voting_power: 2_000,
+        },
+        1044 => Ballot {
+            vote: Vote::No as i32,
+            voting_power: 30_000,
+        },
+    };
+
+    let proposal_data = ProposalData {
+        proposal,
+        ballots,
+        total_potential_voting_power: Some(40_000),
+        ..Default::default()
+    };
+
+    // Scenario: Three proposals, three neurons. They always vote the same:
+    //
+    //   * 1042 - never votes, and has 100 voting_power
+    //   * 1043 - Always votes Yes, and has 2_000 voting_power
+    //   * 1044 - Always votes No, and has 30_000 voting_power
+    //
+    // The proposals:
+    //
+    //   * 57 - Has no total_potential_voting_power. Thus, 100 + 2_000 + 30_000
+    //     is used in lieu of total_potential_voting_power.
+    //   * 58 - Actually has total_potential_voting_power.
+    //   * 59 - Also has total_potential_voting_power, but its reward weight is
+    //          20x, not 1x.
+    let proposals = vec![
+        (
+            ProposalId { id: 57 },
+            ProposalData {
+                total_potential_voting_power: None,
+                ..proposal_data.clone()
+            },
+        ),
+        (ProposalId { id: 58 }, proposal_data.clone()),
+        (ProposalId { id: 59 }, {
+            let mut proposal_data = proposal_data;
+            let proposal = proposal_data.proposal.as_mut().unwrap();
+            proposal.action = Some(Action::Motion(Default::default()));
+            proposal_data
+        }),
+    ];
+
+    // Make sure our input has the reward weights as described in the scenario.
+    assert_eq!(
+        proposals
+            .iter()
+            .map(|(_, proposal): &(_, ProposalData)| proposal.topic().reward_weight())
+            .collect::<Vec<f64>>(),
+        [1.0, 1.0, 20.0]
+    );
+
+    // Step 2: Call code under test.
+    let proposals = proposals
+        .iter()
+        .map(|(id, proposal_data)| (*id, Some(proposal_data)));
+    let result = sum_weighted_voting_power(proposals);
+
+    // Step 3: Inspect result(s).
+    assert_eq!(
+        result,
+        (
+            hashmap! {
+                // Neuron 1042 never voted, and as a result, has no entry in the result.
+
+                // Voted (Yes) twice on 1x weight proposals and once on a 20x weight proposal.
+                NeuronId { id: 1043 } => (2 * 2_000 + 20 * 2_000) as f64,
+
+                // Similar to previous, but voted No, and has different (more) voting power.
+                NeuronId { id: 1044 } => (2 * 30_000 + 20 * 30_000) as f64,
+            },
+            (
+                (100 + 2_000 + 30_000) // First proposal.
+                + 40_000               // Second proposal
+                + 20 * 40_000          // Third proposal
+            ) as f64
+        ),
+    );
+}

--- a/rs/nns/governance/tests/proposals.rs
+++ b/rs/nns/governance/tests/proposals.rs
@@ -80,6 +80,7 @@ fn test_sum_weighted_voting_power() {
     let result = sum_weighted_voting_power(proposals);
 
     // Step 3: Inspect result(s).
+    #[rustfmt::skip]
     assert_eq!(
         result,
         (
@@ -92,7 +93,6 @@ fn test_sum_weighted_voting_power() {
                 // Similar to previous, but voted No, and has different (more) voting power.
                 NeuronId { id: 1044 } => (2 * 30_000 + 20 * 30_000) as f64,
             },
-            #[rustfmt::skip]
             (
                 (100 + 2_000 + 30_000) // First proposal.
                 + 40_000               // Second proposal

--- a/rs/nns/governance/tests/proposals.rs
+++ b/rs/nns/governance/tests/proposals.rs
@@ -92,6 +92,7 @@ fn test_sum_weighted_voting_power() {
                 // Similar to previous, but voted No, and has different (more) voting power.
                 NeuronId { id: 1044 } => (2 * 30_000 + 20 * 30_000) as f64,
             },
+            #[rustfmt::skip]
             (
                 (100 + 2_000 + 30_000) // First proposal.
                 + 40_000               // Second proposal

--- a/rs/nns/governance/tests/proposals.rs
+++ b/rs/nns/governance/tests/proposals.rs
@@ -1,14 +1,55 @@
-use ic_nns_common::pb::v1::NeuronId;
+use ic_base_types::PrincipalId;
+use ic_nervous_system_common::ONE_DAY_SECONDS;
+use ic_nns_common::pb::v1::{NeuronId, ProposalId};
 use ic_nns_governance::{
-    pb::v1::{proposal::Action, Ballot, Proposal, ProposalData, Vote},
-    proposals::sum_weighted_voting_power,
+    governance::{Governance, REWARD_DISTRIBUTION_PERIOD_SECONDS},
+    pb::v1::{
+        neuron::DissolveState, proposal::Action, Ballot, Governance as GovernanceProto,
+        NetworkEconomics, Neuron, Proposal, ProposalData, ProposalRewardStatus, Vote,
+        WaitForQuietState,
+    },
 };
-use maplit::hashmap;
+use icp_ledger::Tokens;
+use lazy_static::lazy_static;
+use maplit::{btreemap, hashmap};
+use std::collections::BTreeMap;
 
-#[test]
-fn test_sum_weighted_voting_power() {
-    // Step 1: Prepare the world. Basically, we come up with some proposal that
-    // have ballots in them. More precisely, there are three proposals here:
+pub mod fake;
+
+// Jan 1, 2025 (midnight UTC). There is nothing really special about this value; it's just realistic.
+const NOW_SECONDS: u64 = 1735689600;
+
+lazy_static! {
+    static ref NEURONS: BTreeMap<u64, Neuron> = {
+        let base = Neuron {
+            controller: Some(PrincipalId::new_user_test_id(783_068_996)),
+            dissolve_state: Some(DissolveState::WhenDissolvedTimestampSeconds(NOW_SECONDS)),
+            aging_since_timestamp_seconds: u64::MAX,
+            ..Default::default()
+        };
+
+        let result = btreemap! {
+            1042 => Neuron {
+                id: Some(NeuronId { id: 1042 }),
+                account: vec![42; 32],
+                ..base.clone()
+            },
+            1043 => Neuron {
+                id: Some(NeuronId { id: 1043 }),
+                account: vec![43; 32],
+                ..base.clone()
+            },
+            1044 => Neuron {
+                id: Some(NeuronId { id: 1044 }),
+                account: vec![44; 32],
+                ..base.clone()
+            },
+        };
+
+        result
+    };
+
+    // There are three proposals here:
     //
     //   * Has no total_potential_voting_power. Thus, 100 + 2_000 + 30_000
     //     is used in lieu of total_potential_voting_power.
@@ -16,86 +57,151 @@ fn test_sum_weighted_voting_power() {
     //   * Also has total_potential_voting_power, but its reward weight is
     //     20x, not the usual 1x.
     //
-    // And three neurons that vote the same way on all of the above proposals:
+    // And three neurons that vote the same way on all of the above
+    // proposals:
     //
     //   * 1042 - never votes, and has 100 voting_power
     //   * 1043 - Always votes Yes, and has 2_000 voting_power
     //   * 1044 - Always votes No, and has 30_000 voting_power
+    static ref PROPOSALS: BTreeMap<u64, ProposalData> = {
+        let ballots = hashmap! {
+            1042 => Ballot {
+                vote: Vote::Unspecified as i32,
+                voting_power: 100,
+            },
+            1043 => Ballot {
+                vote: Vote::Yes as i32,
+                voting_power: 2_000,
+            },
+            1044 => Ballot {
+                vote: Vote::No as i32,
+                voting_power: 30_000,
+            },
+        };
 
-    let proposal = Some(Proposal {
-        action: Some(Action::AddOrRemoveNodeProvider(Default::default())),
-        ..Default::default()
-    });
+        let proposal = Some(Proposal {
+            action: Some(Action::AddOrRemoveNodeProvider(Default::default())),
+            ..Default::default()
+        });
 
-    let ballots = hashmap! {
-        1042 => Ballot {
-            vote: Vote::Unspecified as i32,
-            voting_power: 100,
-        },
-        1043 => Ballot {
-            vote: Vote::Yes as i32,
-            voting_power: 2_000,
-        },
-        1044 => Ballot {
-            vote: Vote::No as i32,
-            voting_power: 30_000,
-        },
-    };
+        // This is used as a base. All proposals are ReadyToSettle, because,
+        // they have no associated reward event, and the voting period is over.
+        let proposal_data = ProposalData {
+            proposal,
+            ballots,
+            total_potential_voting_power: Some(40_000),
+            wait_for_quiet_state: Some(WaitForQuietState {
+                current_deadline_timestamp_seconds: NOW_SECONDS - 5 * ONE_DAY_SECONDS,
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
 
-    let proposal_data = ProposalData {
-        proposal,
-        ballots,
-        total_potential_voting_power: Some(40_000),
-        ..Default::default()
-    };
+        let proposals = btreemap! {
+            // A "legacy" proposal. I.e. has no total_potential_voting_power. Has 1x reward weight.
+            77 => ProposalData {
+                id: Some(ProposalId { id: 77 }),
+                total_potential_voting_power: None,
+                ..proposal_data.clone()
+            },
 
-    let proposals = vec![
-        ProposalData {
-            total_potential_voting_power: None,
-            ..proposal_data.clone()
-        },
-        proposal_data.clone(),
-        {
-            let mut proposal_data = proposal_data;
-            let proposal = proposal_data.proposal.as_mut().unwrap();
-            proposal.action = Some(Action::Motion(Default::default()));
-            proposal_data
-        },
-    ];
+            // A new proposal (i.e. with total_potential_voting_power, and 1x
+            // reward weight.). Has 1x reward weight.
+            78 => ProposalData {
+                id: Some(ProposalId { id: 78 }),
+                ..proposal_data.clone()
+            },
 
-    // Make sure our input has the reward weights as described in the scenario.
-    assert_eq!(
+            // A new proposal, but with 20x reward weight.
+            79 => {
+                let mut proposal_data = proposal_data;
+                proposal_data.id = Some(ProposalId { id: 79 });
+
+                let proposal = proposal_data.proposal.as_mut().unwrap();
+                proposal.action = Some(Action::Motion(Default::default()));
+                proposal_data
+            },
+        };
+
+        // Verify all ReadyToSettle.
+        assert_eq!(
+            proposals
+                .iter()
+                .map(|(_, proposal): (_, &ProposalData)| proposal.reward_status(NOW_SECONDS, 4 * ONE_DAY_SECONDS))
+                .collect::<Vec<_>>(),
+            // Using all is more concise, but if the assert fails, assert! gives
+            // less diagnostic information than assert_eq!.
+            vec![
+                ProposalRewardStatus::ReadyToSettle,
+                ProposalRewardStatus::ReadyToSettle,
+                ProposalRewardStatus::ReadyToSettle,
+            ],
+        );
+
+        // Verify reward weights.
+        assert_eq!(
+            proposals
+                .iter()
+                .map(|(_, proposal): (_, &ProposalData)| proposal.topic().reward_weight())
+                .collect::<Vec<f64>>(),
+            [1.0, 1.0, 20.0]
+        );
+
         proposals
-            .iter()
-            .map(|proposal: &ProposalData| proposal.topic().reward_weight())
-            .collect::<Vec<f64>>(),
-        [1.0, 1.0, 20.0]
+    };
+
+    static ref GOVERNANCE_PROTO: GovernanceProto = GovernanceProto {
+        neurons: NEURONS.clone(),
+        proposals: PROPOSALS.clone(),
+        genesis_timestamp_seconds: NOW_SECONDS - REWARD_DISTRIBUTION_PERIOD_SECONDS,
+        economics: Some(NetworkEconomics::with_default_values()),
+        ..Default::default()
+    };
+}
+
+#[tokio::test]
+async fn test_distribute_rewards_with_total_potential_voting_power() {
+    // Step 1: Prepare the world.
+
+    let fake_driver = fake::FakeDriver::default()
+        .at(NOW_SECONDS)
+        // This ensures that the rewards purse is exactly equal to 2x the total
+        // weighted voting power. That way, the amount of rewards that each
+        // neuron gets is equal to its voting power (times the reward weight of
+        // the proposal).
+        .with_supply(Tokens::from_e8s(5844002454));
+
+    let mut governance = Governance::new(
+        GOVERNANCE_PROTO.clone(),
+        fake_driver.get_fake_env(),
+        fake_driver.get_fake_ledger(),
+        fake_driver.get_fake_cmc(),
     );
 
     // Step 2: Call code under test.
-    let result = sum_weighted_voting_power(proposals.iter());
+    governance.run_periodic_tasks().await;
 
     // Step 3: Inspect result(s).
-    #[rustfmt::skip]
-    assert_eq!(
-        result,
-        (
-            hashmap! {
-                // Neuron 1042 never voted, and because of this, the return
-                // value has no entry for this neuron.
+    let get_neuron_rewards = |neuron_id| {
+        governance
+            .with_neuron(&NeuronId { id: neuron_id }, |neuron| {
+                neuron.maturity_e8s_equivalent
+            })
+            .unwrap()
+    };
 
-                // Voted (Yes) twice on 1x weight proposals and once on a 20x weight proposal.
-                NeuronId { id: 1043 } => (2 * 2_000 + 20 * 2_000) as f64,
+    assert_eq!(get_neuron_rewards(1042), 0); // Didn't vote -> no rewards.
 
-                // Similar to previous, but voted No, and has different (more) voting power.
-                // In voting rewards, Yes and No are treated the same.
-                NeuronId { id: 1044 } => (2 * 30_000 + 20 * 30_000) as f64,
-            },
-            (
-                (100 + 2_000 + 30_000) // First proposal.
-                + 40_000               // Second proposal
-                + 20 * 40_000          // Third proposal
-            ) as f64
-        ),
+    let reward_ratio = get_neuron_rewards(1043) as f64 / get_neuron_rewards(1044) as f64;
+
+    let weighted_voting_power_ratio = (2 * 2_000 + 20 * 2_000) as f64 /   // neuron 1043
+        (2 * 30_000 + 20 * 30_000) as f64; // neuron 1044
+
+    let error = (reward_ratio - weighted_voting_power_ratio) / weighted_voting_power_ratio;
+    assert!(
+        error < 1e-8,
+        "{:?} vs {:?}",
+        [get_neuron_rewards(1043), get_neuron_rewards(1044)],
+        [2 * 2_000 + 20 * 2_000, 2 * 30_000 + 20 * 30_000],
     );
 }

--- a/rs/nns/governance/tests/proposals.rs
+++ b/rs/nns/governance/tests/proposals.rs
@@ -7,6 +7,21 @@ use maplit::hashmap;
 
 #[test]
 fn test_sum_weighted_voting_power() {
+    // Step 1: Prepare the world. Basically, we come up with some proposal that
+    // have ballots in them. More precisely, there are three proposals here:
+    //
+    //   * Has no total_potential_voting_power. Thus, 100 + 2_000 + 30_000
+    //     is used in lieu of total_potential_voting_power.
+    //   * Actually has total_potential_voting_power.
+    //   * Also has total_potential_voting_power, but its reward weight is
+    //     20x, not the usual 1x.
+    //
+    // And three neurons that vote the same way on all of the above proposals:
+    //
+    //   * 1042 - never votes, and has 100 voting_power
+    //   * 1043 - Always votes Yes, and has 2_000 voting_power
+    //   * 1044 - Always votes No, and has 30_000 voting_power
+
     let proposal = Some(Proposal {
         action: Some(Action::AddOrRemoveNodeProvider(Default::default())),
         ..Default::default()
@@ -34,19 +49,6 @@ fn test_sum_weighted_voting_power() {
         ..Default::default()
     };
 
-    // Scenario: Three proposals, three neurons. They always vote the same:
-    //
-    //   * 1042 - never votes, and has 100 voting_power
-    //   * 1043 - Always votes Yes, and has 2_000 voting_power
-    //   * 1044 - Always votes No, and has 30_000 voting_power
-    //
-    // The proposals:
-    //
-    //   * 57 - Has no total_potential_voting_power. Thus, 100 + 2_000 + 30_000
-    //     is used in lieu of total_potential_voting_power.
-    //   * 58 - Actually has total_potential_voting_power.
-    //   * 59 - Also has total_potential_voting_power, but its reward weight is
-    //          20x, not 1x.
     let proposals = vec![
         ProposalData {
             total_potential_voting_power: None,
@@ -79,12 +81,14 @@ fn test_sum_weighted_voting_power() {
         result,
         (
             hashmap! {
-                // Neuron 1042 never voted, and as a result, has no entry in the result.
+                // Neuron 1042 never voted, and because of this, the return
+                // value has no entry for this neuron.
 
                 // Voted (Yes) twice on 1x weight proposals and once on a 20x weight proposal.
                 NeuronId { id: 1043 } => (2 * 2_000 + 20 * 2_000) as f64,
 
                 // Similar to previous, but voted No, and has different (more) voting power.
+                // In voting rewards, Yes and No are treated the same.
                 NeuronId { id: 1044 } => (2 * 30_000 + 20 * 30_000) as f64,
             },
             (

--- a/rs/nns/governance/tests/proposals.rs
+++ b/rs/nns/governance/tests/proposals.rs
@@ -204,24 +204,18 @@ async fn test_distribute_rewards_with_total_potential_voting_power() {
     let rewards = (get_neuron_rewards(1043), get_neuron_rewards(1044));
 
     let weighted_voting_powers = (
-        // 2nd neuron (id = 1043)
-        (
-            2_000 +       // First proposal
-            1_000 +       // Second proposal
-            20 * 2_000  // Third proposal
-        ),
-
-        // 3rd neuron (id = 1044)
-        (
-            30_000 +
-            20_000 +
-            20 * 30_000
-        )
+        2_000 + 1_000 + 20 * 2_000,    // 2nd neuron (id = 1043)
+        30_000 + 20_000 + 20 * 30_000, // 3rd neuron (id = 1044)
     );
 
     // Remember, this can return NEGATIVE. Most of the time, you want to do
     // assert!(e.abs() < EPSILON, ...). Do NOT forget the .abs() !
-    fn assert_ratio_relative_error_close(observed: (u64, u64), expected: (u64, u64), epsilon: f64, msg: &str) {
+    fn assert_ratio_relative_error_close(
+        observed: (u64, u64),
+        expected: (u64, u64),
+        epsilon: f64,
+        msg: &str,
+    ) {
         let ob = observed.0 as f64 / observed.1 as f64;
         let ex = expected.0 as f64 / expected.1 as f64;
 
@@ -230,7 +224,10 @@ async fn test_distribute_rewards_with_total_potential_voting_power() {
         assert!(
             relative_error.abs() < epsilon,
             "{}: {:?} vs. {:?} (relative error = {})",
-            msg, observed, expected, relative_error,
+            msg,
+            observed,
+            expected,
+            relative_error,
         );
     }
 
@@ -245,6 +242,12 @@ async fn test_distribute_rewards_with_total_potential_voting_power() {
     assert_ratio_relative_error_close(
         (rewards.0, reward_event.total_available_e8s_equivalent),
         (weighted_voting_powers.0, (32_100 + 80_000 + 20 * 80_000)),
+        2e-6,
+        "2nd neuron (ID = 1043)",
+    );
+    assert_ratio_relative_error_close(
+        (rewards.1, reward_event.total_available_e8s_equivalent),
+        (weighted_voting_powers.1, (32_100 + 80_000 + 20 * 80_000)),
         2e-6,
         "2nd neuron (ID = 1043)",
     );

--- a/rs/nns/governance/tests/proposals.rs
+++ b/rs/nns/governance/tests/proposals.rs
@@ -92,7 +92,6 @@ lazy_static! {
             total_potential_voting_power: Some(40_000),
             wait_for_quiet_state: Some(WaitForQuietState {
                 current_deadline_timestamp_seconds: NOW_SECONDS - 5 * ONE_DAY_SECONDS,
-                ..Default::default()
             }),
             ..Default::default()
         };
@@ -126,8 +125,8 @@ lazy_static! {
         // Verify all ReadyToSettle.
         assert_eq!(
             proposals
-                .iter()
-                .map(|(_, proposal): (_, &ProposalData)| proposal.reward_status(NOW_SECONDS, 4 * ONE_DAY_SECONDS))
+                .values()
+                .map(|proposal| proposal.reward_status(NOW_SECONDS, 4 * ONE_DAY_SECONDS))
                 .collect::<Vec<_>>(),
             // Using all is more concise, but if the assert fails, assert! gives
             // less diagnostic information than assert_eq!.
@@ -141,8 +140,8 @@ lazy_static! {
         // Verify reward weights.
         assert_eq!(
             proposals
-                .iter()
-                .map(|(_, proposal): (_, &ProposalData)| proposal.topic().reward_weight())
+                .values()
+                .map(|proposal| proposal.topic().reward_weight())
                 .collect::<Vec<f64>>(),
             [1.0, 1.0, 20.0]
         );


### PR DESCRIPTION
Whereas, before, we did not have a distinction between **potential** voting power vs. **deciding** voting power. When neurons refresh themselves, there is no difference between these. Whereas, when a neuron does not refresh itself recently enough, the amount of voting power in its ballots (its "deciding" voting power) is less than its potential voting power.

# Example

Suppose there are two neurons:

* A has 100 potential voting power, and refreshed recently, and as a result, its deciding voting power is also 100.
* B has 1000 potential voting power, but has not refreshed in a long time, and as a result, it's deciding voting power is just 500.

Then, the total potential voting power is 1100. If both neurons vote, then A gets 100 / 1100 of the reward purse, while B gets only 500 / 1100 of the reward purse, not 1000 / 1100.

You might also intuitively guess that the neurons get 100 / 600 and 500 / 600 of the reward purse, but this is (also) incorrect. The reason for this design is to keep the amount of rewards to refreshed neurons the same as before, not more. In other words, it should not be that some other neuron goes to sleep, and as a result, you get more rewards. It should only be that the sleeper neuron gets less.

# References

This is part of the "periodic confirmation" feature that was recently approved in proposal [132411][prop].

[prop]: https://dashboard.internetcomputer.org/proposal/132411

Closes https://dfinity.atlassian.net/browse/NNS1-3411.

[👈 Previous PR][prev] | [Next PR (tangent) 👉][next]

[prev]: https://github.com/dfinity/ic/pull/2375
[next]: https://github.com/dfinity/ic/pull/2470