### PR TITLE
fix(sns): Remove accidentally-included timer type definitions

### DIFF
--- a/rs/sns/governance/proto/ic_sns_governance/pb/v1/governance.proto
+++ b/rs/sns/governance/proto/ic_sns_governance/pb/v1/governance.proto
@@ -1477,19 +1477,6 @@ message Governance {
   UpgradeJournal upgrade_journal = 32;
 }
 
-message Timers {
-  optional uint64 last_reset_timestamp_seconds = 1;
-  optional uint64 last_spawned_timestamp_seconds = 2;
-}
-
-message ResetTimersRequest {}
-message ResetTimersResponse {}
-
-message GetTimersRequest {}
-message GetTimersResponse {
-  optional Timers timers = 1;
-}
-
 // Request message for 'get_metadata'.
 message GetMetadataRequest {}
 

--- a/rs/sns/governance/src/gen/ic_sns_governance.pb.v1.rs
+++ b/rs/sns/governance/src/gen/ic_sns_governance.pb.v1.rs
@@ -1998,64 +1998,6 @@ pub mod governance {
         }
     }
 }
-#[derive(
-    candid::CandidType,
-    candid::Deserialize,
-    comparable::Comparable,
-    Clone,
-    Copy,
-    PartialEq,
-    ::prost::Message,
-)]
-pub struct Timers {
-    #[prost(uint64, optional, tag = "1")]
-    pub last_reset_timestamp_seconds: ::core::option::Option<u64>,
-    #[prost(uint64, optional, tag = "2")]
-    pub last_spawned_timestamp_seconds: ::core::option::Option<u64>,
-}
-#[derive(
-    candid::CandidType,
-    candid::Deserialize,
-    comparable::Comparable,
-    Clone,
-    Copy,
-    PartialEq,
-    ::prost::Message,
-)]
-pub struct ResetTimersRequest {}
-#[derive(
-    candid::CandidType,
-    candid::Deserialize,
-    comparable::Comparable,
-    Clone,
-    Copy,
-    PartialEq,
-    ::prost::Message,
-)]
-pub struct ResetTimersResponse {}
-#[derive(
-    candid::CandidType,
-    candid::Deserialize,
-    comparable::Comparable,
-    Clone,
-    Copy,
-    PartialEq,
-    ::prost::Message,
-)]
-pub struct GetTimersRequest {}
-#[derive(
-    candid::CandidType,
-    candid::Deserialize,
-    comparable::Comparable,
-    Clone,
-    Copy,
-    PartialEq,
-    ::prost::Message,
-)]
-pub struct GetTimersResponse {
-    #[prost(message, optional, tag = "1")]
-    pub timers: ::core::option::Option<Timers>,
-}
 /// Request message for 'get_metadata'.
 #[derive(
     candid::CandidType,


### PR DESCRIPTION
This was accidentally included in #2169 as pointed out by @aterga. This PR just removes it.