### PR TITLE
chore: split and optimize spec compliance tests

### DIFF
--- a/hs/spec_compliance/src/IC/Test/Agent.hs
+++ b/hs/spec_compliance/src/IC/Test/Agent.hs
@@ -82,7 +82,6 @@ module IC.Test.Agent
     ic00as,
     ic00',
     ic00WithSubnetas',
-    ingressDelay,
     is2xx,
     isErr4xx,
     isErrOrReject,
@@ -764,11 +763,6 @@ isPendingOrProcessing r = assertFailure $ "Expected pending or processing, got "
 
 pollDelay :: IO ()
 pollDelay = threadDelay $ 10 * 1000 -- 10 milliseconds
-
--- How long to wait before checking if a request that should _not_ show up on
--- the system indeed did not show up
-ingressDelay :: IO ()
-ingressDelay = threadDelay $ 2 * 1000 * 1000 -- 2 seconds
 
 -- * HTTP Response predicates
 

--- a/rs/tests/research/BUILD.bazel
+++ b/rs/tests/research/BUILD.bazel
@@ -4,111 +4,38 @@ load("//rs/tests:system_tests.bzl", "system_test_nns")
 
 package(default_visibility = ["//rs:system-tests-pkg"])
 
-system_test_nns(
-    name = "spec_compliance_application_subnet_test",
-    extra_head_nns_tags = [],  # don't run the head_nns variant on nightly since it aleady runs on long_test.
-    flaky = True,
-    tags = [
-        "cpu:4",
-        "long_test",  # since it takes longer than 5 minutes.
-    ],
-    target_compatible_with = ["@platforms//os:linux"],  # requires libssh that does not build on Mac OS
-    runtime_deps = BOUNDARY_NODE_GUESTOS_RUNTIME_DEPS + GUESTOS_RUNTIME_DEPS + UNIVERSAL_VM_RUNTIME_DEPS + CANISTER_HTTP_RUNTIME_DEPS + [
-        ":ic-hs",
-        "//ic-os/components:networking/dev-certs/canister_http_test_ca.cert",
-    ],
-    deps = [
-        # Keep sorted.
-        "//rs/registry/subnet_type",
-        "//rs/tests/driver:ic-system-test-driver",
-        "//rs/tests/research/spec_compliance",
-        "@crate_index//:anyhow",
-    ],
-)
-
-system_test_nns(
-    name = "spec_compliance_system_subnet_test",
-    extra_head_nns_tags = [],  # don't run the head_nns variant on nightly since it aleady runs on long_test.
-    flaky = True,
-    tags = [
-        "cpu:4",
-        "long_test",
-    ],
-    target_compatible_with = ["@platforms//os:linux"],  # requires libssh that does not build on Mac OS
-    runtime_deps = BOUNDARY_NODE_GUESTOS_RUNTIME_DEPS + GUESTOS_RUNTIME_DEPS + UNIVERSAL_VM_RUNTIME_DEPS + CANISTER_HTTP_RUNTIME_DEPS + [
-        ":ic-hs",
-        "//ic-os/components:networking/dev-certs/canister_http_test_ca.cert",
-    ],
-    deps = [
-        # Keep sorted.
-        "//rs/registry/subnet_type",
-        "//rs/tests/driver:ic-system-test-driver",
-        "//rs/tests/research/spec_compliance",
-        "@crate_index//:anyhow",
-    ],
-)
-
-system_test_nns(
-    name = "spec_compliance_group_01_application_subnet_test",
-    extra_head_nns_tags = [],  # don't run the head_nns variant on nightly since it aleady runs on long_test.
-    flaky = True,
-    tags = [
-        "cpu:4",
-        "long_test",  # since it takes longer than 5 minutes.
-    ],
-    target_compatible_with = ["@platforms//os:linux"],  # requires libssh that does not build on Mac OS
-    runtime_deps = BOUNDARY_NODE_GUESTOS_RUNTIME_DEPS + GUESTOS_RUNTIME_DEPS + UNIVERSAL_VM_RUNTIME_DEPS + CANISTER_HTTP_RUNTIME_DEPS + [
-        ":ic-hs",
-        "//ic-os/components:networking/dev-certs/canister_http_test_ca.cert",
-    ],
-    deps = [
-        # Keep sorted.
-        "//rs/registry/subnet_type",
-        "//rs/tests/driver:ic-system-test-driver",
-        "//rs/tests/research/spec_compliance",
-        "@crate_index//:anyhow",
-    ],
-)
-
-system_test_nns(
-    name = "spec_compliance_group_01_system_subnet_test",
-    extra_head_nns_tags = [],  # don't run the head_nns variant on nightly since it aleady runs on long_test.
-    flaky = True,
-    tags = [
-        "cpu:4",
-        "long_test",
-    ],
-    target_compatible_with = ["@platforms//os:linux"],  # requires libssh that does not build on Mac OS
-    runtime_deps = BOUNDARY_NODE_GUESTOS_RUNTIME_DEPS + GUESTOS_RUNTIME_DEPS + UNIVERSAL_VM_RUNTIME_DEPS + CANISTER_HTTP_RUNTIME_DEPS + [
-        ":ic-hs",
-        "//ic-os/components:networking/dev-certs/canister_http_test_ca.cert",
-    ],
-    deps = [
-        # Keep sorted.
-        "//rs/registry/subnet_type",
-        "//rs/tests/driver:ic-system-test-driver",
-        "//rs/tests/research/spec_compliance",
-        "@crate_index//:anyhow",
-    ],
-)
-
-system_test_nns(
-    name = "spec_compliance_group_02_system_subnet_test",
-    flaky = True,
-    tags = ["cpu:4"],
-    target_compatible_with = ["@platforms//os:linux"],  # requires libssh that does not build on Mac OS
-    runtime_deps = BOUNDARY_NODE_GUESTOS_RUNTIME_DEPS + GUESTOS_RUNTIME_DEPS + UNIVERSAL_VM_RUNTIME_DEPS + CANISTER_HTTP_RUNTIME_DEPS + [
-        ":ic-hs",
-        "//ic-os/components:networking/dev-certs/canister_http_test_ca.cert",
-    ],
-    deps = [
-        # Keep sorted.
-        "//rs/registry/subnet_type",
-        "//rs/tests/driver:ic-system-test-driver",
-        "//rs/tests/research/spec_compliance",
-        "@crate_index//:anyhow",
-    ],
-)
+[
+    system_test_nns(
+        name = name,
+        extra_head_nns_tags = [],  # don't run the head_nns variant on nightly since it aleady runs on long_test.
+        flaky = True,
+        tags = [
+            "cpu:4",
+            "long_test",  # since it takes longer than 5 minutes.
+        ],
+        target_compatible_with = ["@platforms//os:linux"],  # requires libssh that does not build on Mac OS
+        runtime_deps = BOUNDARY_NODE_GUESTOS_RUNTIME_DEPS + GUESTOS_RUNTIME_DEPS + UNIVERSAL_VM_RUNTIME_DEPS + CANISTER_HTTP_RUNTIME_DEPS + [
+            ":ic-hs",
+            "//ic-os/components:networking/dev-certs/canister_http_test_ca.cert",
+        ],
+        deps = [
+            # Keep sorted.
+            "//rs/registry/subnet_type",
+            "//rs/tests/driver:ic-system-test-driver",
+            "//rs/tests/research/spec_compliance",
+            "@crate_index//:anyhow",
+        ],
+    )
+    for name in [
+        "spec_compliance_application_subnet_test",
+        "spec_compliance_group_01_application_subnet_test",
+        "spec_compliance_group_02_application_subnet_test",
+        "spec_compliance_system_subnet_test",
+        "spec_compliance_group_01_system_subnet_test",
+        "spec_compliance_group_02_system_subnet_test",
+        "spec_compliance_group_03_system_subnet_test",
+    ]
+]
 
 symlink_dirs(
     name = "ic-hs",

--- a/rs/tests/research/BUILD.bazel
+++ b/rs/tests/research/BUILD.bazel
@@ -7,12 +7,8 @@ package(default_visibility = ["//rs:system-tests-pkg"])
 [
     system_test_nns(
         name = name,
-        extra_head_nns_tags = [],  # don't run the head_nns variant on nightly since it aleady runs on long_test.
         flaky = True,
-        tags = [
-            "cpu:4",
-            "long_test",  # since it takes longer than 5 minutes.
-        ],
+        tags = ["cpu:4"],
         target_compatible_with = ["@platforms//os:linux"],  # requires libssh that does not build on Mac OS
         runtime_deps = BOUNDARY_NODE_GUESTOS_RUNTIME_DEPS + GUESTOS_RUNTIME_DEPS + UNIVERSAL_VM_RUNTIME_DEPS + CANISTER_HTTP_RUNTIME_DEPS + [
             ":ic-hs",

--- a/rs/tests/research/Cargo.toml
+++ b/rs/tests/research/Cargo.toml
@@ -29,5 +29,13 @@ name = "spec_compliance_group_01_system_subnet_test"
 path = "spec_compliance_group_01_system_subnet_test.rs"
 
 [[bin]]
+name = "spec_compliance_group_02_application_subnet_testt"
+path = "spec_compliance_group_02_application_subnet_test.rs"
+
+[[bin]]
 name = "spec_compliance_group_02_system_subnet_test"
 path = "spec_compliance_group_02_system_subnet_test.rs"
+
+[[bin]]
+name = "spec_compliance_group_03_system_subnet_test"
+path = "spec_compliance_group_03_system_subnet_test.rs"

--- a/rs/tests/research/spec_compliance/spec_compliance.rs
+++ b/rs/tests/research/spec_compliance/spec_compliance.rs
@@ -337,7 +337,7 @@ pub fn with_endpoint(
         peer_subnet_config,
         excluded_tests,
         included_tests,
-        64,
+        32,
     );
 }
 

--- a/rs/tests/research/spec_compliance/spec_compliance.rs
+++ b/rs/tests/research/spec_compliance/spec_compliance.rs
@@ -35,6 +35,28 @@ const EXCLUDED: &[&str] = &[
     "$0 ~ /Call from query method traps (in query call)/",
 ];
 
+pub fn group_all() -> Vec<&'static str> {
+    [group_01(), group_02(), group_03()].concat()
+}
+
+pub fn group_01() -> Vec<&'static str> {
+    vec![
+        "($0 ~ /canister history/)",
+        "($0 ~ /canister version/)",
+        "($0 ~ /canister global timer/)",
+        "($0 ~ /canister http/)",
+        "($0 ~ /WebAssembly module validation/)",
+    ]
+}
+
+pub fn group_02() -> Vec<&'static str> {
+    vec!["($0 ~ /stable memory/)", "($0 ~ /inter-canister calls/)"]
+}
+
+pub fn group_03() -> Vec<&'static str> {
+    vec!["($0 ~ /NNS canisters/)"]
+}
+
 pub fn setup_impl(env: TestEnv, deploy_bn_and_nns_canisters: bool, http_requests: bool) {
     use ic_system_test_driver::driver::test_env_api::secs;
     use ic_system_test_driver::util::block_on;

--- a/rs/tests/research/spec_compliance/spec_compliance.rs
+++ b/rs/tests/research/spec_compliance/spec_compliance.rs
@@ -50,7 +50,13 @@ pub fn group_01() -> Vec<&'static str> {
 }
 
 pub fn group_02() -> Vec<&'static str> {
-    vec!["($0 ~ /stable memory/)", "($0 ~ /inter-canister calls/)"]
+    vec![
+        "($0 ~ /stable memory/)",
+        "($0 ~ /inter-canister calls/)",
+        "($0 ~ /uninstall/)",
+        "($0 ~ /read state/)",
+        "($0 ~ /cycles/)",
+    ]
 }
 
 pub fn group_03() -> Vec<&'static str> {

--- a/rs/tests/research/spec_compliance_application_subnet_test.rs
+++ b/rs/tests/research/spec_compliance_application_subnet_test.rs
@@ -16,7 +16,7 @@ use ic_registry_subnet_type::SubnetType;
 use ic_system_test_driver::driver::group::SystemTestGroup;
 use ic_system_test_driver::driver::test_env::TestEnv;
 use ic_system_test_driver::systest;
-use spec_compliance::{setup_impl, test_subnet};
+use spec_compliance::{group_all, setup_impl, test_subnet};
 
 pub fn setup(env: TestEnv) {
     setup_impl(env, true, false);
@@ -29,16 +29,7 @@ pub fn test(env: TestEnv) {
         false,
         Some(SubnetType::Application),
         None,
-        vec![
-            "($0 ~ /NNS canisters/)",
-            "($0 ~ /canister history/)",
-            "($0 ~ /canister version/)",
-            "($0 ~ /canister global timer/)",
-            "($0 ~ /canister http/)",
-            "($0 ~ /WebAssembly module validation/)",
-            "($0 ~ /stable memory/)",
-            "($0 ~ /inter-canister calls/)",
-        ],
+        group_all(),
         vec![],
     );
 }

--- a/rs/tests/research/spec_compliance_application_subnet_test.rs
+++ b/rs/tests/research/spec_compliance_application_subnet_test.rs
@@ -36,6 +36,8 @@ pub fn test(env: TestEnv) {
             "($0 ~ /canister global timer/)",
             "($0 ~ /canister http/)",
             "($0 ~ /WebAssembly module validation/)",
+            "($0 ~ /stable memory/)",
+            "($0 ~ /inter-canister calls/)",
         ],
         vec![],
     );

--- a/rs/tests/research/spec_compliance_application_subnet_test.rs
+++ b/rs/tests/research/spec_compliance_application_subnet_test.rs
@@ -19,7 +19,7 @@ use ic_system_test_driver::systest;
 use spec_compliance::{setup_impl, test_subnet};
 
 pub fn setup(env: TestEnv) {
-    setup_impl(env, true, true);
+    setup_impl(env, true, false);
 }
 
 pub fn test(env: TestEnv) {
@@ -34,7 +34,7 @@ pub fn test(env: TestEnv) {
             "($0 ~ /canister history/)",
             "($0 ~ /canister version/)",
             "($0 ~ /canister global timer/)",
-            "($0 ~ /canister http outcalls/)",
+            "($0 ~ /canister http/)",
             "($0 ~ /WebAssembly module validation/)",
         ],
         vec![],

--- a/rs/tests/research/spec_compliance_application_subnet_test.rs
+++ b/rs/tests/research/spec_compliance_application_subnet_test.rs
@@ -5,7 +5,7 @@ Goal:: Ensure that the replica implementation is compliant with the formal speci
 
 Runbook::
 . Set up system and application subnet containing two nodes each
-. Run ic-ref-test against system subnet
+. Run ic-ref-test against application subnet
 
 Success:: The ic-ref-test binary does not return an error.
 

--- a/rs/tests/research/spec_compliance_group_01_application_subnet_test.rs
+++ b/rs/tests/research/spec_compliance_group_01_application_subnet_test.rs
@@ -34,7 +34,7 @@ pub fn test(env: TestEnv) {
             "($0 ~ /canister history/)",
             "($0 ~ /canister version/)",
             "($0 ~ /canister global timer/)",
-            "($0 ~ /canister http outcalls/)",
+            "($0 ~ /canister http/)",
             "($0 ~ /WebAssembly module validation/)",
         ],
     );

--- a/rs/tests/research/spec_compliance_group_01_application_subnet_test.rs
+++ b/rs/tests/research/spec_compliance_group_01_application_subnet_test.rs
@@ -16,7 +16,7 @@ use ic_registry_subnet_type::SubnetType;
 use ic_system_test_driver::driver::group::SystemTestGroup;
 use ic_system_test_driver::driver::test_env::TestEnv;
 use ic_system_test_driver::systest;
-use spec_compliance::{setup_impl, test_subnet};
+use spec_compliance::{group_01, setup_impl, test_subnet};
 
 pub fn setup(env: TestEnv) {
     setup_impl(env, true, true);
@@ -30,13 +30,7 @@ pub fn test(env: TestEnv) {
         Some(SubnetType::Application),
         None,
         vec![],
-        vec![
-            "($0 ~ /canister history/)",
-            "($0 ~ /canister version/)",
-            "($0 ~ /canister global timer/)",
-            "($0 ~ /canister http/)",
-            "($0 ~ /WebAssembly module validation/)",
-        ],
+        group_01(),
     );
 }
 

--- a/rs/tests/research/spec_compliance_group_01_application_subnet_test.rs
+++ b/rs/tests/research/spec_compliance_group_01_application_subnet_test.rs
@@ -5,7 +5,7 @@ Goal:: Ensure that the replica implementation is compliant with the formal speci
 
 Runbook::
 . Set up system and application subnet containing two nodes each
-. Run ic-ref-test against system subnet
+. Run ic-ref-test against application subnet
 
 Success:: The ic-ref-test binary does not return an error.
 

--- a/rs/tests/research/spec_compliance_group_01_system_subnet_test.rs
+++ b/rs/tests/research/spec_compliance_group_01_system_subnet_test.rs
@@ -4,7 +4,7 @@ Title:: Specification compliance test
 Goal:: Ensure that the replica implementation is compliant with the formal specification.
 
 Runbook::
-. Set up system system and application subnet containing two nodes each
+. Set up system and application subnet containing two nodes each
 . Run ic-ref-test against application subnet
 
 Success:: The ic-ref-test binary does not return an error.
@@ -34,7 +34,7 @@ pub fn test(env: TestEnv) {
             "($0 ~ /canister history/)",
             "($0 ~ /canister version/)",
             "($0 ~ /canister global timer/)",
-            "($0 ~ /canister http outcalls/)",
+            "($0 ~ /canister http/)",
             "($0 ~ /WebAssembly module validation/)",
         ],
     );

--- a/rs/tests/research/spec_compliance_group_01_system_subnet_test.rs
+++ b/rs/tests/research/spec_compliance_group_01_system_subnet_test.rs
@@ -16,7 +16,7 @@ use ic_registry_subnet_type::SubnetType;
 use ic_system_test_driver::driver::group::SystemTestGroup;
 use ic_system_test_driver::driver::test_env::TestEnv;
 use ic_system_test_driver::systest;
-use spec_compliance::{setup_impl, test_subnet};
+use spec_compliance::{group_01, setup_impl, test_subnet};
 
 pub fn setup(env: TestEnv) {
     setup_impl(env, true, true);
@@ -30,13 +30,7 @@ pub fn test(env: TestEnv) {
         None,
         Some(SubnetType::Application),
         vec![],
-        vec![
-            "($0 ~ /canister history/)",
-            "($0 ~ /canister version/)",
-            "($0 ~ /canister global timer/)",
-            "($0 ~ /canister http/)",
-            "($0 ~ /WebAssembly module validation/)",
-        ],
+        group_01(),
     );
 }
 

--- a/rs/tests/research/spec_compliance_group_02_application_subnet_test.rs
+++ b/rs/tests/research/spec_compliance_group_02_application_subnet_test.rs
@@ -5,7 +5,7 @@ Goal:: Ensure that the replica implementation is compliant with the formal speci
 
 Runbook::
 . Set up system and application subnet containing two nodes each
-. Run ic-ref-test against system subnet
+. Run ic-ref-test against application subnet
 
 Success:: The ic-ref-test binary does not return an error.
 
@@ -19,23 +19,20 @@ use ic_system_test_driver::systest;
 use spec_compliance::{setup_impl, test_subnet};
 
 pub fn setup(env: TestEnv) {
-    setup_impl(env, true, true);
+    setup_impl(env, true, false);
 }
 
 pub fn test(env: TestEnv) {
     test_subnet(
         env,
         true,
-        true,
-        None,
+        false,
         Some(SubnetType::Application),
+        None,
         vec![],
         vec![
-            "($0 ~ /canister history/)",
-            "($0 ~ /canister version/)",
-            "($0 ~ /canister global timer/)",
-            "($0 ~ /canister http/)",
-            "($0 ~ /WebAssembly module validation/)",
+            "($0 ~ /stable memory/)",
+            "($0 ~ /inter-canister calls/)",
         ],
     );
 }

--- a/rs/tests/research/spec_compliance_group_02_application_subnet_test.rs
+++ b/rs/tests/research/spec_compliance_group_02_application_subnet_test.rs
@@ -16,7 +16,7 @@ use ic_registry_subnet_type::SubnetType;
 use ic_system_test_driver::driver::group::SystemTestGroup;
 use ic_system_test_driver::driver::test_env::TestEnv;
 use ic_system_test_driver::systest;
-use spec_compliance::{setup_impl, test_subnet, group_02};
+use spec_compliance::{group_02, setup_impl, test_subnet};
 
 pub fn setup(env: TestEnv) {
     setup_impl(env, true, false);

--- a/rs/tests/research/spec_compliance_group_02_application_subnet_test.rs
+++ b/rs/tests/research/spec_compliance_group_02_application_subnet_test.rs
@@ -16,7 +16,7 @@ use ic_registry_subnet_type::SubnetType;
 use ic_system_test_driver::driver::group::SystemTestGroup;
 use ic_system_test_driver::driver::test_env::TestEnv;
 use ic_system_test_driver::systest;
-use spec_compliance::{setup_impl, test_subnet};
+use spec_compliance::{setup_impl, test_subnet, group_02};
 
 pub fn setup(env: TestEnv) {
     setup_impl(env, true, false);
@@ -30,10 +30,7 @@ pub fn test(env: TestEnv) {
         Some(SubnetType::Application),
         None,
         vec![],
-        vec![
-            "($0 ~ /stable memory/)",
-            "($0 ~ /inter-canister calls/)",
-        ],
+        group_02(),
     );
 }
 

--- a/rs/tests/research/spec_compliance_group_02_system_subnet_test.rs
+++ b/rs/tests/research/spec_compliance_group_02_system_subnet_test.rs
@@ -16,7 +16,7 @@ use ic_registry_subnet_type::SubnetType;
 use ic_system_test_driver::driver::group::SystemTestGroup;
 use ic_system_test_driver::driver::test_env::TestEnv;
 use ic_system_test_driver::systest;
-use spec_compliance::{setup_impl, test_subnet};
+use spec_compliance::{group_02, setup_impl, test_subnet};
 
 pub fn setup(env: TestEnv) {
     setup_impl(env, true, false);
@@ -30,10 +30,7 @@ pub fn test(env: TestEnv) {
         None,
         Some(SubnetType::Application),
         vec![],
-        vec![
-            "($0 ~ /stable memory/)",
-            "($0 ~ /inter-canister calls/)",
-        ],
+        group_02(),
     );
 }
 

--- a/rs/tests/research/spec_compliance_group_02_system_subnet_test.rs
+++ b/rs/tests/research/spec_compliance_group_02_system_subnet_test.rs
@@ -4,8 +4,8 @@ Title:: Specification compliance test
 Goal:: Ensure that the replica implementation is compliant with the formal specification.
 
 Runbook::
-. Set up system system and application subnet containing two nodes each
-. Run ic-ref-test against application subnet
+. Set up system and application subnet containing two nodes each
+. Run ic-ref-test against system subnet
 
 Success:: The ic-ref-test binary does not return an error.
 
@@ -19,18 +19,21 @@ use ic_system_test_driver::systest;
 use spec_compliance::{setup_impl, test_subnet};
 
 pub fn setup(env: TestEnv) {
-    setup_impl(env, false, false);
+    setup_impl(env, true, false);
 }
 
 pub fn test(env: TestEnv) {
     test_subnet(
         env,
-        false,
+        true,
         false,
         None,
         Some(SubnetType::Application),
         vec![],
-        vec!["($0 ~ /NNS canisters/)"],
+        vec![
+            "($0 ~ /stable memory/)",
+            "($0 ~ /inter-canister calls/)",
+        ],
     );
 }
 

--- a/rs/tests/research/spec_compliance_group_03_system_subnet_test.rs
+++ b/rs/tests/research/spec_compliance_group_03_system_subnet_test.rs
@@ -16,7 +16,7 @@ use ic_registry_subnet_type::SubnetType;
 use ic_system_test_driver::driver::group::SystemTestGroup;
 use ic_system_test_driver::driver::test_env::TestEnv;
 use ic_system_test_driver::systest;
-use spec_compliance::{setup_impl, test_subnet, group_03};
+use spec_compliance::{group_03, setup_impl, test_subnet};
 
 pub fn setup(env: TestEnv) {
     setup_impl(env, false, false);

--- a/rs/tests/research/spec_compliance_group_03_system_subnet_test.rs
+++ b/rs/tests/research/spec_compliance_group_03_system_subnet_test.rs
@@ -19,24 +19,18 @@ use ic_system_test_driver::systest;
 use spec_compliance::{setup_impl, test_subnet};
 
 pub fn setup(env: TestEnv) {
-    setup_impl(env, true, true);
+    setup_impl(env, false, false);
 }
 
 pub fn test(env: TestEnv) {
     test_subnet(
         env,
-        true,
-        true,
+        false,
+        false,
         None,
         Some(SubnetType::Application),
         vec![],
-        vec![
-            "($0 ~ /canister history/)",
-            "($0 ~ /canister version/)",
-            "($0 ~ /canister global timer/)",
-            "($0 ~ /canister http/)",
-            "($0 ~ /WebAssembly module validation/)",
-        ],
+        vec!["($0 ~ /NNS canisters/)"],
     );
 }
 

--- a/rs/tests/research/spec_compliance_group_03_system_subnet_test.rs
+++ b/rs/tests/research/spec_compliance_group_03_system_subnet_test.rs
@@ -16,7 +16,7 @@ use ic_registry_subnet_type::SubnetType;
 use ic_system_test_driver::driver::group::SystemTestGroup;
 use ic_system_test_driver::driver::test_env::TestEnv;
 use ic_system_test_driver::systest;
-use spec_compliance::{setup_impl, test_subnet};
+use spec_compliance::{setup_impl, test_subnet, group_03};
 
 pub fn setup(env: TestEnv) {
     setup_impl(env, false, false);
@@ -30,7 +30,7 @@ pub fn test(env: TestEnv) {
         None,
         Some(SubnetType::Application),
         vec![],
-        vec!["($0 ~ /NNS canisters/)"],
+        group_03(),
     );
 }
 

--- a/rs/tests/research/spec_compliance_system_subnet_test.rs
+++ b/rs/tests/research/spec_compliance_system_subnet_test.rs
@@ -5,7 +5,7 @@ Goal:: Ensure that the replica implementation is compliant with the formal speci
 
 Runbook::
 . Set up system and application subnet containing two nodes each
-. Run ic-ref-test against application subnet
+. Run ic-ref-test against system subnet
 
 Success:: The ic-ref-test binary does not return an error.
 

--- a/rs/tests/research/spec_compliance_system_subnet_test.rs
+++ b/rs/tests/research/spec_compliance_system_subnet_test.rs
@@ -36,6 +36,8 @@ pub fn test(env: TestEnv) {
             "($0 ~ /canister global timer/)",
             "($0 ~ /canister http/)",
             "($0 ~ /WebAssembly module validation/)",
+            "($0 ~ /stable memory/)",
+            "($0 ~ /inter-canister calls/)",
         ],
         vec![],
     );

--- a/rs/tests/research/spec_compliance_system_subnet_test.rs
+++ b/rs/tests/research/spec_compliance_system_subnet_test.rs
@@ -16,7 +16,7 @@ use ic_registry_subnet_type::SubnetType;
 use ic_system_test_driver::driver::group::SystemTestGroup;
 use ic_system_test_driver::driver::test_env::TestEnv;
 use ic_system_test_driver::systest;
-use spec_compliance::{setup_impl, test_subnet};
+use spec_compliance::{group_all, setup_impl, test_subnet};
 
 pub fn setup(env: TestEnv) {
     setup_impl(env, true, false);
@@ -29,16 +29,7 @@ pub fn test(env: TestEnv) {
         false,
         None,
         Some(SubnetType::Application),
-        vec![
-            "($0 ~ /NNS canisters/)",
-            "($0 ~ /canister history/)",
-            "($0 ~ /canister version/)",
-            "($0 ~ /canister global timer/)",
-            "($0 ~ /canister http/)",
-            "($0 ~ /WebAssembly module validation/)",
-            "($0 ~ /stable memory/)",
-            "($0 ~ /inter-canister calls/)",
-        ],
+        group_all(),
         vec![],
     );
 }

--- a/rs/tests/research/spec_compliance_system_subnet_test.rs
+++ b/rs/tests/research/spec_compliance_system_subnet_test.rs
@@ -4,7 +4,7 @@ Title:: Specification compliance test
 Goal:: Ensure that the replica implementation is compliant with the formal specification.
 
 Runbook::
-. Set up system system and application subnet containing two nodes each
+. Set up system and application subnet containing two nodes each
 . Run ic-ref-test against application subnet
 
 Success:: The ic-ref-test binary does not return an error.
@@ -19,14 +19,14 @@ use ic_system_test_driver::systest;
 use spec_compliance::{setup_impl, test_subnet};
 
 pub fn setup(env: TestEnv) {
-    setup_impl(env, true, true);
+    setup_impl(env, true, false);
 }
 
 pub fn test(env: TestEnv) {
     test_subnet(
         env,
         true,
-        true,
+        false,
         None,
         Some(SubnetType::Application),
         vec![
@@ -34,7 +34,7 @@ pub fn test(env: TestEnv) {
             "($0 ~ /canister history/)",
             "($0 ~ /canister version/)",
             "($0 ~ /canister global timer/)",
-            "($0 ~ /canister http outcalls/)",
+            "($0 ~ /canister http/)",
             "($0 ~ /WebAssembly module validation/)",
         ],
         vec![],


### PR DESCRIPTION
This PR splits and optimizes the spec compliance tests:
- avoid artificial delays
- reuse the same universal canister in selected tests that do not update the universal canister's state
- decreases the number of jobs from 64 to 32 (reducing flakiness)
- no httpbin webserver is started if not needed
- a new group of test cases is introduced as a separate system test

All spec compliance tests are labeled as pre-master since they finish well below 5mins:
```
//rs/tests/research:spec_compliance_application_subnet_test              PASSED in 226.4s
//rs/tests/research:spec_compliance_group_01_application_subnet_test     PASSED in 232.9s
//rs/tests/research:spec_compliance_group_01_system_subnet_test          PASSED in 238.6s
//rs/tests/research:spec_compliance_group_02_application_subnet_test     PASSED in 215.9s
//rs/tests/research:spec_compliance_group_02_system_subnet_test          PASSED in 197.5s
//rs/tests/research:spec_compliance_group_03_system_subnet_test          PASSED in 90.1s
//rs/tests/research:spec_compliance_system_subnet_test                   PASSED in 207.0s
```