### PR TITLE
chore(nns): remove governance api--test-feature bazel target

### DIFF
--- a/rs/nns/governance/api/BUILD.bazel
+++ b/rs/nns/governance/api/BUILD.bazel
@@ -46,17 +46,3 @@ rust_library(
     version = "0.9.0",
     deps = DEPENDENCIES,
 )
-
-rust_library(
-    name = "api--test_feature",
-    srcs = glob(
-        ["src/**/*.rs"],
-        exclude = ["**/*tests.rs"],
-    ),
-    aliases = ALIASES,
-    crate_features = ["test"],
-    crate_name = "ic_nns_governance_api",
-    proc_macro_deps = MACRO_DEPENDENCIES,
-    version = "0.9.0",
-    deps = DEPENDENCIES,
-)


### PR DESCRIPTION
Remove a library we no longer need.