### PR TITLE
fix: EXC-1775: Replace `delete_snapshots` functionality with `remove`

### DIFF
--- a/rs/replicated_state/src/canister_snapshots.rs
+++ b/rs/replicated_state/src/canister_snapshots.rs
@@ -126,12 +126,9 @@ impl CanisterSnapshots {
     /// Additionally, new items are added to the `unflushed_changes`,
     /// representing the deleted backups since the last flush to the disk.
     pub fn delete_snapshots(&mut self, canister_id: CanisterId) {
-        if let Some(snapshot_ids) = self.snapshot_ids.remove(&canister_id) {
+        if let Some(snapshot_ids) = self.snapshot_ids.get(&canister_id).cloned() {
             for snapshot_id in snapshot_ids {
-                debug_assert!(self.snapshots.contains_key(&snapshot_id));
-                self.snapshots.remove(&snapshot_id).unwrap();
-                self.unflushed_changes
-                    .push(SnapshotOperation::Delete(snapshot_id));
+                self.remove(snapshot_id);
             }
         }
     }


### PR DESCRIPTION
Eliminate code duplication by replacing `CanisterSnapshots::delete_snapshots` functionality with `CanisterSnapshots::remove`.