### PR TITLE
chore: increase read state retry delay in spec compliance tests

### DIFF
--- a/hs/spec_compliance/src/IC/Test/Agent.hs
+++ b/hs/spec_compliance/src/IC/Test/Agent.hs
@@ -762,7 +762,7 @@ isPendingOrProcessing Processing = return ()
 isPendingOrProcessing r = assertFailure $ "Expected pending or processing, got " <> show r
 
 pollDelay :: IO ()
-pollDelay = threadDelay $ 10 * 1000 -- 10 milliseconds
+pollDelay = threadDelay $ 500 * 1000 -- 500 milliseconds
 
 -- * HTTP Response predicates
 

--- a/rs/tests/research/spec_compliance/spec_compliance.rs
+++ b/rs/tests/research/spec_compliance/spec_compliance.rs
@@ -365,7 +365,7 @@ pub fn with_endpoint(
         peer_subnet_config,
         excluded_tests,
         included_tests,
-        64,
+        32,
     );
 }
 

--- a/rs/tests/research/spec_compliance/spec_compliance.rs
+++ b/rs/tests/research/spec_compliance/spec_compliance.rs
@@ -365,7 +365,7 @@ pub fn with_endpoint(
         peer_subnet_config,
         excluded_tests,
         included_tests,
-        32,
+        64,
     );
 }
 


### PR DESCRIPTION
This PR sets the read state retry delay in spec compliance tests to match the Rust agent's [initial retry delay](https://github.com/dfinity/agent-rs/blob/705f23f83dc1360d2de62fbf62a56757d6ba26cf/ic-agent/src/agent/mod.rs#L622) of 500 ms. Retry delays shorter than a round duration are not useful and only create network traffic.