### PR TITLE
chore: Add limits constant for upper bound of validated consensus pool size

### DIFF
--- a/rs/consensus/src/consensus/bounds.rs
+++ b/rs/consensus/src/consensus/bounds.rs
@@ -35,6 +35,39 @@ pub struct ArtifactCounts {
     equivocation_proofs: usize,
 }
 
+impl ArtifactCounts {
+    /// Computes a sum of all individual artifact counts.
+    pub fn sum(&self) -> usize {
+        // Do not ignore any field, include all of them in the sum
+        let ArtifactCounts {
+            block_proposals,
+            notarizations,
+            finalization,
+            random_beacon,
+            random_tape,
+            notarization_shares,
+            finalization_shares,
+            random_beacon_shares,
+            random_tape_shares,
+            cup_shares,
+            cups,
+            equivocation_proofs,
+        } = self;
+        block_proposals
+            + notarizations
+            + finalization
+            + random_beacon
+            + random_tape
+            + notarization_shares
+            + finalization_shares
+            + random_beacon_shares
+            + random_tape_shares
+            + cup_shares
+            + cups
+            + equivocation_proofs
+    }
+}
+
 /// Returns the upper limit on the artifact counts a validated pool is allowed
 /// to have. NOTE: This bound is tied to the implementation. If we move towards
 /// a more aggressive purging strategy, this bound can be lowered.
@@ -197,6 +230,8 @@ mod tests {
             equivocation_proofs: 980,
         };
         assert_eq!(get_maximum_validated_artifacts(40, 499), max_counts);
+        // Make sure limits.rs is kept in sync
+        assert_eq!(ic_limits::MAX_VALIDATED_ARTIFACTS, max_counts.sum());
 
         // Simple check: advance pool without purging, until we have too many
         // finalized blocks.

--- a/rs/consensus/src/consensus/bounds.rs
+++ b/rs/consensus/src/consensus/bounds.rs
@@ -231,7 +231,10 @@ mod tests {
         };
         assert_eq!(get_maximum_validated_artifacts(40, 499), max_counts);
         // Make sure limits.rs is kept in sync
-        assert_eq!(ic_limits::MAX_VALIDATED_ARTIFACTS, max_counts.sum());
+        assert_eq!(
+            ic_limits::MAX_VALIDATED_CONSENSUS_ARTIFACTS,
+            max_counts.sum()
+        );
 
         // Simple check: advance pool without purging, until we have too many
         // finalized blocks.

--- a/rs/limits/src/lib.rs
+++ b/rs/limits/src/lib.rs
@@ -78,3 +78,9 @@ pub const DKG_INTERVAL_HEIGHT: u64 = 499;
 /// The default upper bound for the number of allowed dkg dealings in a
 /// block.
 pub const DKG_DEALINGS_PER_BLOCK: usize = 1;
+/// The maximum number of artifacts we must support in the validated pool.
+/// This number is based on the function [`get_maximum_validated_artifacts`]
+/// in the consensus component, which is kept in sync with the implementation.
+/// The calculation is done for a 40-node subnet with a DKG interval of 499,
+/// a minimum chain length of 50, and a notarization notarization-CUP gap of 70.
+pub const MAX_VALIDATED_ARTIFACTS: usize = 97750;

--- a/rs/limits/src/lib.rs
+++ b/rs/limits/src/lib.rs
@@ -78,9 +78,9 @@ pub const DKG_INTERVAL_HEIGHT: u64 = 499;
 /// The default upper bound for the number of allowed dkg dealings in a
 /// block.
 pub const DKG_DEALINGS_PER_BLOCK: usize = 1;
-/// The maximum number of artifacts we must support in the validated pool.
-/// This number is based on the function [`get_maximum_validated_artifacts`]
-/// in the consensus component, which is kept in sync with the implementation.
-/// The calculation is done for a 40-node subnet with a DKG interval of 499,
-/// a minimum chain length of 50, and a notarization notarization-CUP gap of 70.
-pub const MAX_VALIDATED_ARTIFACTS: usize = 97750;
+/// The maximum number of artifacts we must support in the validated consensus pool. This
+/// number is based on the function [`get_maximum_validated_artifacts`] in the consensus
+/// component, which is kept in sync with the implementation. The calculation is done
+/// for a 40-node subnet with a DKG interval of 499, a minimum chain length of 50, and a
+/// notarization notarization-CUP gap of 70.
+pub const MAX_VALIDATED_CONSENSUS_ARTIFACTS: usize = 97750;


### PR DESCRIPTION
Follow-up from the discussion in https://github.com/dfinity/ic/pull/2340#discussion_r1824887388 This PR also adds a check to make sure the test calculation in `bounds.rs` is consistent with the new constant.