### PR TITLE
fix(PSEC-2202): Convert to lowercase before checking ignore list expressions

### DIFF
--- a/ci/src/dependencies/data_source/slack_findings_failover_data_store.py
+++ b/ci/src/dependencies/data_source/slack_findings_failover_data_store.py
@@ -133,7 +133,7 @@ class SlackFindingsFailoverDataStore(FindingsFailoverDataStore):
                     add_proj = True
                     if proj in ignore_list_by_project:
                         for expr in ignore_list_by_project[proj]:
-                            if expr in vi.vulnerability.description:
+                            if expr.lower() in vi.vulnerability.description.lower():
                                 add_proj = False
                                 break
                     if add_proj:

--- a/ci/src/dependencies/data_source/slack_findings_failover_data_store_test.py
+++ b/ci/src/dependencies/data_source/slack_findings_failover_data_store_test.py
@@ -146,7 +146,7 @@ def test_store_findings():
 
 
 def test_filter_findings():
-    v1 = Vulnerability("v1id", "v1 name", "v1 desc", 10)
+    v1 = Vulnerability("v1id", "v1 name", "V1 desc", 10)
     # filtered because only f1 is affected and ic/proj1 ignores it
     v2 = Vulnerability("v2id", "v2 name", "v2 desc", 10)
     v3 = Vulnerability("v3id", "v3 name", "v3 desc", 10)
@@ -172,7 +172,7 @@ def test_filter_findings():
         ["ic/proj1", "ic/proj2"],
         [],
     )
-    ignore_list_by_project = {"ic/proj1": {"v1 des", "v2"}}
+    ignore_list_by_project = {"ic/proj1": {"v1 DES", "v2"}}
     vuln_by_vuln_id = {
         v1.id: VulnerabilityInfo(v1, {f1.id(): deepcopy(f1), f2.id(): deepcopy(f2)}),
         v2.id: VulnerabilityInfo(v2, {f1.id(): deepcopy(f1)}),


### PR DESCRIPTION
Convert ignore list expressions and vuln descriptions to lowercase before comparing.