### PR TITLE
refactor(IDX): move node-name to step summary

### DIFF
--- a/.github/actions/bazel-test-all/action.yaml
+++ b/.github/actions/bazel-test-all/action.yaml
@@ -58,6 +58,9 @@ runs:
               rm "$exportout"
           fi
 
+          # output node name to gihub step summary
+          [ -n "${NODE_NAME:-}" ] && echo "Run on node: $NODE_NAME" >>$GITHUB_STEP_SUMMARY
+
           exit "$BAZEL_EXIT_CODE"
         env:
           BAZEL_COMMAND: ${{ inputs.BAZEL_COMMAND }}

--- a/.github/workflows-source/ci-main.yml
+++ b/.github/workflows-source/ci-main.yml
@@ -51,12 +51,6 @@ anchors:
     container:
       <<: *image
     timeout-minutes: 30
-  before-script: &before-script
-    name: Before script
-    id: before-script
-    shell: bash
-    run: |
-      [ -n "${NODE_NAME:-}" ] && echo "Node: $NODE_NAME"
   docker-login: &docker-login
     name: Login to Dockerhub
     shell: bash
@@ -107,7 +101,6 @@ jobs:
       labels: dind-large
     steps:
       - <<: *checkout
-      - <<: *before-script
       - <<: *docker-login
       - name: Set BAZEL_EXTRA_ARGS
         shell: bash
@@ -173,7 +166,6 @@ jobs:
     name: Bazel Build All Config Check
     steps:
       - <<: *checkout
-      - <<: *before-script
       - <<: *docker-login
       - name: Run bazel build --config=check //rs/...
         id: bazel-build-config-check
@@ -222,7 +214,6 @@ jobs:
     <<: *dind-large-setup
     steps:
       - <<: *checkout
-      - <<: *before-script
       - name: Run Bazel Build Fuzzers
         id: bazel-build-fuzzers
         uses:  ./.github/actions/bazel-test-all/
@@ -238,7 +229,6 @@ jobs:
     <<: *dind-large-setup
     steps:
       - <<: *checkout
-      - <<: *before-script
       - name: Run Bazel Build Fuzzers AFL
         id: bazel-build-fuzzers-afl
         uses:  ./.github/actions/bazel-test-all/
@@ -277,13 +267,13 @@ jobs:
     if: ${{ github.event_name != 'merge_group' }}
     steps:
       - <<: *checkout
-      - <<: *before-script
       - <<: *docker-login
       - name: Run Build IC
         id: build-ic
         shell: bash
         run: |
           set -eExuo pipefail
+          [ -n "${NODE_NAME:-}" ] && echo "Run on node: $NODE_NAME" >>$GITHUB_STEP_SUMMARY
           REPO_NAME="${GITHUB_REPOSITORY##*/}"
           rm -rf "/cache/job/${CI_JOB_NAME}/${CI_RUN_ID}"
           mkdir -p "/cache/job/${CI_JOB_NAME}/${CI_RUN_ID}/artifacts"

--- a/.github/workflows-source/ci-pr-only.yml
+++ b/.github/workflows-source/ci-pr-only.yml
@@ -34,12 +34,6 @@ anchors:
       <<: *image
       options: >-
         -e NODE_NAME
-  before-script: &before-script
-    name: Before script
-    id: before-script
-    shell: bash
-    run: |
-      [ -n "${NODE_NAME:-}" ] && echo "Node: $NODE_NAME"
   checkout: &checkout
     name: Checkout
     uses: actions/checkout@v4
@@ -50,7 +44,6 @@ jobs:
     <<: *dind-large-setup
     steps:
       - <<: *checkout
-      - <<: *before-script
       - name: Filter Relevant Files
         uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3
         id: filter
@@ -89,7 +82,6 @@ jobs:
         with:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.IDX_PUSH_TO_PR }}
-      - <<: *before-script
       - name: Filter Relevant Files
         uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3
         id: filter
@@ -130,7 +122,6 @@ jobs:
       - <<: *checkout
         with:
           fetch-depth: 256
-      - <<: *before-script
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -156,10 +147,10 @@ jobs:
     if: contains(github.event.pull_request.labels.*.name, 'CI_COVERAGE')
     steps:
       - <<: *checkout
-      - <<: *before-script
       - name: Run Bazel Test Coverage
         shell: bash
         run: |
+          [ -n "${NODE_NAME:-}" ] && echo "Node: $NODE_NAME"
           ./ci/scripts/bazel-coverage.sh
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows-source/release-testing.yml
+++ b/.github/workflows-source/release-testing.yml
@@ -42,12 +42,6 @@ anchors:
     uses: actions/checkout@v4
     with:
       ref: ${{ github.event.workflow_run.head_branch }}
-  before-script: &before-script
-    name: Before script
-    id: before-script
-    shell: bash
-    run: |
-      [ -n "${NODE_NAME:-}" ] && echo "Node: $NODE_NAME"
   docker-login: &docker-login
     name: Login to Dockerhub
     shell: bash
@@ -81,7 +75,6 @@ jobs:
     <<: *dind-large-setup
     steps:
       - <<: *checkout
-      - <<: *before-script
       - <<: *docker-login
       - name: Run Bazel System Test Nightly
         id: bazel-test-all
@@ -99,7 +92,6 @@ jobs:
     <<: *dind-large-setup
     steps:
       - <<: *checkout
-      - <<: *before-script
       - <<: *docker-login
       - name: Run Bazel System Test Staging
         id: bazel-test-all
@@ -118,7 +110,6 @@ jobs:
     timeout-minutes: 90
     steps:
       - <<: *checkout
-      - <<: *before-script
       - <<: *docker-login
       - name: Run Bazel Test All
         id: bazel-test-all
@@ -146,7 +137,6 @@ jobs:
       REPO_NAME: ${{ github.repository }}
     steps:
       - <<: *checkout
-      - <<: *before-script
       - <<: *docker-login
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -193,7 +183,6 @@ jobs:
     <<: *dind-large-setup
     steps:
       - <<: *checkout
-      - <<: *before-script
       - <<: *docker-login
       - name: Run qualification for version ${{ matrix.version }} from the tip of the branch
         uses: ./.github/actions/bazel-test-all/

--- a/.github/workflows-source/schedule-daily.yml
+++ b/.github/workflows-source/schedule-daily.yml
@@ -33,12 +33,6 @@ anchors:
   checkout: &checkout
     name: Checkout
     uses: actions/checkout@v4
-  before-script: &before-script
-    name: Before script
-    id: before-script
-    shell: bash
-    run: |
-      [ -n "${NODE_NAME:-}" ] && echo "Node: $NODE_NAME"
   docker-login: &docker-login
     name: Login to Dockerhub
     shell: bash
@@ -72,13 +66,13 @@ jobs:
       labels: dind-large
     steps:
       - <<: *checkout
-      - <<: *before-script
       - <<: *docker-login
       - name: Run Bazel Launch Bare Metal
         shell: bash
         run: |
           echo "$ZH2_DLL01_CSV_SECRETS" > file1
           echo "$ZH2_FILE_SHARE_KEY" > file2 && chmod 400 file2
+          [ -n "${NODE_NAME:-}" ] && echo "Node: $NODE_NAME"
 
           # Run bare metal installation test
           # shellcheck disable=SC2046,SC2086
@@ -115,7 +109,6 @@ jobs:
     timeout-minutes: 720 # 12 hours
     steps:
       - <<: *checkout
-      - <<: *before-script
       - <<: *docker-login
       - name: Run FI Tests Nightly
         id: bazel-test-all
@@ -135,7 +128,6 @@ jobs:
     timeout-minutes: 20
     steps:
       - <<: *checkout
-      - <<: *before-script
       - <<: *docker-login
       - name: Run NNS Tests Nightly
         id: bazel-test-all
@@ -155,7 +147,6 @@ jobs:
     timeout-minutes: 480
     steps:
       - <<: *checkout
-      - <<: *before-script
       - <<: *docker-login
       - name: Set Benchmark Targets
         shell: bash
@@ -193,7 +184,6 @@ jobs:
       REPO_NAME: ${{ github.repository }}
     steps:
       - <<: *checkout
-      - <<: *before-script
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -225,10 +215,10 @@ jobs:
     <<: *dind-large-setup
     steps:
       - <<: *checkout
-      - <<: *before-script
       - name: Run Bazel Test Coverage
         shell: bash
         run: |
+          [ -n "${NODE_NAME:-}" ] && echo "Node: $NODE_NAME"
           ./ci/scripts/bazel-coverage.sh
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows-source/schedule-hourly.yml
+++ b/.github/workflows-source/schedule-hourly.yml
@@ -32,12 +32,6 @@ anchors:
   checkout: &checkout
     name: Checkout
     uses: actions/checkout@v4
-  before-script: &before-script
-    name: Before script
-    id: before-script
-    shell: bash
-    run: |
-      [ -n "${NODE_NAME:-}" ] && echo "Node: $NODE_NAME"
   docker-login: &docker-login
     name: Login to Dockerhub
     shell: bash
@@ -66,7 +60,6 @@ jobs:
     <<: *dind-large-setup
     steps:
       - <<: *checkout
-      - <<: *before-script
       - <<: *docker-login
       - name: Run Bazel Build All No Cache
         uses:  ./.github/actions/bazel-test-all/
@@ -86,7 +79,6 @@ jobs:
       labels: dind-large
     steps:
       - <<: *checkout
-      - <<: *before-script
       - <<: *docker-login
       - name: Run Bazel System Test Hourly
         id: bazel-test-all

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -44,11 +44,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: ${{ github.event_name == 'pull_request' && 256 || 0 }}
-      - name: Before script
-        id: before-script
-        shell: bash
-        run: |
-          [ -n "${NODE_NAME:-}" ] && echo "Node: $NODE_NAME"
       - name: Login to Dockerhub
         shell: bash
         run: ./ci/scripts/docker-login.sh
@@ -146,11 +141,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: ${{ github.event_name == 'pull_request' && 256 || 0 }}
-      - name: Before script
-        id: before-script
-        shell: bash
-        run: |
-          [ -n "${NODE_NAME:-}" ] && echo "Node: $NODE_NAME"
       - name: Login to Dockerhub
         shell: bash
         run: ./ci/scripts/docker-login.sh
@@ -243,11 +233,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: ${{ github.event_name == 'pull_request' && 256 || 0 }}
-      - name: Before script
-        id: before-script
-        shell: bash
-        run: |
-          [ -n "${NODE_NAME:-}" ] && echo "Node: $NODE_NAME"
       - name: Run Bazel Build Fuzzers
         id: bazel-build-fuzzers
         uses: ./.github/actions/bazel-test-all/
@@ -283,11 +268,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: ${{ github.event_name == 'pull_request' && 256 || 0 }}
-      - name: Before script
-        id: before-script
-        shell: bash
-        run: |
-          [ -n "${NODE_NAME:-}" ] && echo "Node: $NODE_NAME"
       - name: Run Bazel Build Fuzzers AFL
         id: bazel-build-fuzzers-afl
         uses: ./.github/actions/bazel-test-all/
@@ -355,11 +335,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: ${{ github.event_name == 'pull_request' && 256 || 0 }}
-      - name: Before script
-        id: before-script
-        shell: bash
-        run: |
-          [ -n "${NODE_NAME:-}" ] && echo "Node: $NODE_NAME"
       - name: Login to Dockerhub
         shell: bash
         run: ./ci/scripts/docker-login.sh
@@ -371,6 +346,7 @@ jobs:
         shell: bash
         run: |
           set -eExuo pipefail
+          [ -n "${NODE_NAME:-}" ] && echo "Run on node: $NODE_NAME" >>$GITHUB_STEP_SUMMARY
           REPO_NAME="${GITHUB_REPOSITORY##*/}"
           rm -rf "/cache/job/${CI_JOB_NAME}/${CI_RUN_ID}"
           mkdir -p "/cache/job/${CI_JOB_NAME}/${CI_RUN_ID}/artifacts"

--- a/.github/workflows/ci-pr-only.yml
+++ b/.github/workflows/ci-pr-only.yml
@@ -26,11 +26,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Before script
-        id: before-script
-        shell: bash
-        run: |
-          [ -n "${NODE_NAME:-}" ] && echo "Node: $NODE_NAME"
       - name: Filter Relevant Files
         uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3
         id: filter
@@ -74,11 +69,6 @@ jobs:
         with:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.IDX_PUSH_TO_PR }}
-      - name: Before script
-        id: before-script
-        shell: bash
-        run: |
-          [ -n "${NODE_NAME:-}" ] && echo "Node: $NODE_NAME"
       - name: Filter Relevant Files
         uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3
         id: filter
@@ -124,11 +114,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 256
-      - name: Before script
-        id: before-script
-        shell: bash
-        run: |
-          [ -n "${NODE_NAME:-}" ] && echo "Node: $NODE_NAME"
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -160,14 +145,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Before script
-        id: before-script
-        shell: bash
-        run: |
-          [ -n "${NODE_NAME:-}" ] && echo "Node: $NODE_NAME"
       - name: Run Bazel Test Coverage
         shell: bash
         run: |
+          [ -n "${NODE_NAME:-}" ] && echo "Node: $NODE_NAME"
           ./ci/scripts/bazel-coverage.sh
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/release-testing.yml
+++ b/.github/workflows/release-testing.yml
@@ -39,11 +39,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.workflow_run.head_branch }}
-      - name: Before script
-        id: before-script
-        shell: bash
-        run: |
-          [ -n "${NODE_NAME:-}" ] && echo "Node: $NODE_NAME"
       - name: Login to Dockerhub
         shell: bash
         run: ./ci/scripts/docker-login.sh
@@ -87,11 +82,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.workflow_run.head_branch }}
-      - name: Before script
-        id: before-script
-        shell: bash
-        run: |
-          [ -n "${NODE_NAME:-}" ] && echo "Node: $NODE_NAME"
       - name: Login to Dockerhub
         shell: bash
         run: ./ci/scripts/docker-login.sh
@@ -135,11 +125,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.workflow_run.head_branch }}
-      - name: Before script
-        id: before-script
-        shell: bash
-        run: |
-          [ -n "${NODE_NAME:-}" ] && echo "Node: $NODE_NAME"
       - name: Login to Dockerhub
         shell: bash
         run: ./ci/scripts/docker-login.sh
@@ -192,11 +177,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.workflow_run.head_branch }}
-      - name: Before script
-        id: before-script
-        shell: bash
-        run: |
-          [ -n "${NODE_NAME:-}" ] && echo "Node: $NODE_NAME"
       - name: Login to Dockerhub
         shell: bash
         run: ./ci/scripts/docker-login.sh
@@ -263,11 +243,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.workflow_run.head_branch }}
-      - name: Before script
-        id: before-script
-        shell: bash
-        run: |
-          [ -n "${NODE_NAME:-}" ] && echo "Node: $NODE_NAME"
       - name: Login to Dockerhub
         shell: bash
         run: ./ci/scripts/docker-login.sh

--- a/.github/workflows/schedule-daily.yml
+++ b/.github/workflows/schedule-daily.yml
@@ -27,11 +27,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Before script
-        id: before-script
-        shell: bash
-        run: |
-          [ -n "${NODE_NAME:-}" ] && echo "Node: $NODE_NAME"
       - name: Login to Dockerhub
         shell: bash
         run: ./ci/scripts/docker-login.sh
@@ -43,6 +38,7 @@ jobs:
         run: |
           echo "$ZH2_DLL01_CSV_SECRETS" > file1
           echo "$ZH2_FILE_SHARE_KEY" > file2 && chmod 400 file2
+          [ -n "${NODE_NAME:-}" ] && echo "Node: $NODE_NAME"
 
           # Run bare metal installation test
           # shellcheck disable=SC2046,SC2086
@@ -85,11 +81,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Before script
-        id: before-script
-        shell: bash
-        run: |
-          [ -n "${NODE_NAME:-}" ] && echo "Node: $NODE_NAME"
       - name: Login to Dockerhub
         shell: bash
         run: ./ci/scripts/docker-login.sh
@@ -132,11 +123,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Before script
-        id: before-script
-        shell: bash
-        run: |
-          [ -n "${NODE_NAME:-}" ] && echo "Node: $NODE_NAME"
       - name: Login to Dockerhub
         shell: bash
         run: ./ci/scripts/docker-login.sh
@@ -179,11 +165,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Before script
-        id: before-script
-        shell: bash
-        run: |
-          [ -n "${NODE_NAME:-}" ] && echo "Node: $NODE_NAME"
       - name: Login to Dockerhub
         shell: bash
         run: ./ci/scripts/docker-login.sh
@@ -244,11 +225,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Before script
-        id: before-script
-        shell: bash
-        run: |
-          [ -n "${NODE_NAME:-}" ] && echo "Node: $NODE_NAME"
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -287,14 +263,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Before script
-        id: before-script
-        shell: bash
-        run: |
-          [ -n "${NODE_NAME:-}" ] && echo "Node: $NODE_NAME"
       - name: Run Bazel Test Coverage
         shell: bash
         run: |
+          [ -n "${NODE_NAME:-}" ] && echo "Node: $NODE_NAME"
           ./ci/scripts/bazel-coverage.sh
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/schedule-hourly.yml
+++ b/.github/workflows/schedule-hourly.yml
@@ -26,11 +26,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Before script
-        id: before-script
-        shell: bash
-        run: |
-          [ -n "${NODE_NAME:-}" ] && echo "Node: $NODE_NAME"
       - name: Login to Dockerhub
         shell: bash
         run: ./ci/scripts/docker-login.sh
@@ -71,11 +66,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Before script
-        id: before-script
-        shell: bash
-        run: |
-          [ -n "${NODE_NAME:-}" ] && echo "Node: $NODE_NAME"
       - name: Login to Dockerhub
         shell: bash
         run: ./ci/scripts/docker-login.sh

--- a/.github/workflows/system-tests-k8s.yml
+++ b/.github/workflows/system-tests-k8s.yml
@@ -59,12 +59,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Before script
-        id: before-script
-        shell: bash
-        run: |
-          [ -n "${NODE_NAME:-}" ] && echo "Node: $NODE_NAME"
-
       - name: Login to Dockerhub
         shell: bash
         run: ./ci/scripts/docker-login.sh


### PR DESCRIPTION
This PR moves the node name to the step summary as part of the `bazel-test-all` action instead of `before-script`. I then removed `before-script` completely as it's not needed.