### PR TITLE
chore(api-boundary-node): close port 80 on the API BNs

### DIFF
--- a/ic-os/components/ic/ic.json5.template
+++ b/ic-os/components/ic/ic.json5.template
@@ -404,7 +404,7 @@ table ip6 filter {\n\
     icmp type { echo-reply, destination-unreachable, source-quench, echo-request, time-exceeded } accept\n\
     ct state invalid drop\n\
     ct state { established, related } accept\n\
-    ip saddr { 0.0.0.0-255.255.255.255 } ct state new tcp dport { 80, 443 } accept\n\
+    ip saddr { 0.0.0.0-255.255.255.255 } ct state new tcp dport 443 accept\n\
 \n\
     <<IPv4_TCP_RULES>>\n\
     <<IPv4_UDP_RULES>>\n\
@@ -458,7 +458,7 @@ table ip6 filter {\n\
     icmpv6 type { destination-unreachable, packet-too-big, time-exceeded, echo-request, echo-reply, nd-router-advert, nd-neighbor-solicit, nd-neighbor-advert } accept\n\
     ct state { invalid } drop\n\
     ct state { established, related } accept\n\
-    ip6 saddr { ::-ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff } ct state new tcp dport { 80, 443 } accept\n\
+    ip6 saddr { ::-ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff } ct state new tcp dport 443 accept\n\
 \n\
     <<IPv6_TCP_RULES>>\n\
     <<IPv6_UDP_RULES>>\n\

--- a/rs/orchestrator/testdata/nftables_boundary_node.conf.golden
+++ b/rs/orchestrator/testdata/nftables_boundary_node.conf.golden
@@ -31,7 +31,7 @@ table filter {
     icmp type { echo-reply, destination-unreachable, source-quench, echo-request, time-exceeded } accept
     ct state invalid drop
     ct state { established, related } accept
-    ip saddr { 0.0.0.0-255.255.255.255 } ct state new tcp dport { 80, 443 } accept
+    ip saddr { 0.0.0.0-255.255.255.255 } ct state new tcp dport 443 accept
 
     ip saddr {5.5.5.5} ct state { new } tcp dport {1005} accept # node_gwp4o-eaaaa-aaaaa-aaaap-2ai
 ip saddr {7.7.7.7} ct state { new } tcp dport {1007} accept # api_boundary_nodes
@@ -87,7 +87,7 @@ table ip6 filter {
     icmpv6 type { destination-unreachable, packet-too-big, time-exceeded, echo-request, echo-reply, nd-router-advert, nd-neighbor-solicit, nd-neighbor-advert } accept
     ct state { invalid } drop
     ct state { established, related } accept
-    ip6 saddr { ::-ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff } ct state new tcp dport { 80, 443 } accept
+    ip6 saddr { ::-ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff } ct state new tcp dport 443 accept
 
     ip6 saddr {::ffff:5.5.5.5} ct state { new } tcp dport {1005} accept # node_gwp4o-eaaaa-aaaaa-aaaap-2ai
 ip6 saddr {::ffff:7.7.7.7} ct state { new } tcp dport {1007} accept # api_boundary_nodes


### PR DESCRIPTION
Since we switched from the HTTP- to the ALPN-ACME-challenge, we don't need to have port 80 open anymore on the API boundary nodes.