### PR TITLE
fix(crypto): Fix a flaky test introduced by PR 1803

### DIFF
--- a/rs/crypto/tests/canister_threshold_schnorr_verify_combined_sig.rs
+++ b/rs/crypto/tests/canister_threshold_schnorr_verify_combined_sig.rs
@@ -2,6 +2,7 @@ use assert_matches::assert_matches;
 use ic_crypto::get_master_public_key_from_transcript;
 use ic_crypto_internal_threshold_sig_canister_threshold_sig_test_utils::{
     verify_bip340_signature_using_third_party, verify_ed25519_signature_using_third_party,
+    verify_taproot_signature_using_third_party,
 };
 use ic_crypto_test_utils_canister_threshold_sigs::{
     generate_key_transcript, random_crypto_component_not_in_receivers, run_tschnorr_protocol,
@@ -50,11 +51,20 @@ fn should_verify_combined_signature_with_usual_basic_sig_verification() {
 
         match alg {
             AlgorithmId::ThresholdSchnorrBip340 => {
-                assert!(verify_bip340_signature_using_third_party(
-                    &canister_public_key.public_key,
-                    &combined_sig.signature,
-                    inputs.message()
-                ))
+                if let Some(ttr) = inputs.taproot_tree_root() {
+                    assert!(verify_taproot_signature_using_third_party(
+                        &canister_public_key.public_key,
+                        &combined_sig.signature,
+                        inputs.message(),
+                        ttr,
+                    ))
+                } else {
+                    assert!(verify_bip340_signature_using_third_party(
+                        &canister_public_key.public_key,
+                        &combined_sig.signature,
+                        inputs.message()
+                    ))
+                }
             }
             AlgorithmId::ThresholdEd25519 => {
                 assert!(verify_ed25519_signature_using_third_party(


### PR DESCRIPTION
The test generates BIP340 signatures, sometimes with and sometimes without using the Taproot option. However the validation check was never updated to handle Taproot. We got "lucky" in CI in 1803, and the test just happened to succeed at every point.