### PR TITLE
feat(BOUN-1236): add registry scraping for acls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -363,6 +363,7 @@ dependencies = [
  "candid",
  "ic-cdk 0.16.0",
  "ic-cdk-timers",
+ "ic-nns-constants",
  "ic-stable-structures",
  "lazy_static",
  "prometheus",

--- a/rs/boundary_node/anonymization/backend/Cargo.toml
+++ b/rs/boundary_node/anonymization/backend/Cargo.toml
@@ -14,6 +14,7 @@ candid = { workspace = true }
 ic-cdk = { workspace = true }
 ic-cdk-timers = { workspace = true }
 ic-stable-structures = { workspace = true }
+ic-nns-constants = { path = "../../../nns/constants" }
 lazy_static = { workspace = true }
 prometheus = { workspace = true }
 serde = { workspace = true, features = ["derive"] }

--- a/rs/boundary_node/anonymization/backend/Cargo.toml
+++ b/rs/boundary_node/anonymization/backend/Cargo.toml
@@ -3,8 +3,9 @@ name = "anonymization-backend"
 version = "0.1.0"
 edition = "2021"
 
-[lib]
-crate-type = ["cdylib"]
+[[bin]]
+name = "anonymization-backend"
+path = "src/lib.rs"
 
 [dependencies]
 anyhow = { workspace = true }

--- a/rs/boundary_node/anonymization/backend/src/lib.rs
+++ b/rs/boundary_node/anonymization/backend/src/lib.rs
@@ -30,7 +30,7 @@ const REGISTRY_CANISTER_ID: &str = "bnz7o-iuaaa-aaaaa-qaaaa-cai";
 const MEMORY_ID_ALLOWED_PRINCIPALS: u8 = 0;
 
 lazy_static! {
-    static ref REGISTRY_LISTER: Box<dyn List> = {
+    static ref API_BOUNDARY_NODES_LISTER: Box<dyn List> = {
         let cid =
             Principal::from_text(REGISTRY_CANISTER_ID).expect("failed to construct principal");
 
@@ -55,7 +55,7 @@ fn timers() {
         // Switch to async
         spawn(async {
             // List registry entries
-            let ids = match REGISTRY_LISTER.list().await {
+            let ids = match API_BOUNDARY_NODES_LISTER.list().await {
                 Ok(ids) => ids,
 
                 // Abort on failure

--- a/rs/boundary_node/anonymization/backend/src/lib.rs
+++ b/rs/boundary_node/anonymization/backend/src/lib.rs
@@ -1,2 +1,115 @@
-// I put this here for CI, will remove on the next PR
-pub const TMP: u32 = 0;
+use std::{cell::RefCell, time::Duration};
+
+use anonymization_interface::{
+    self as ifc, InitArg, QueryResponse, RegisterResponse, SubmitResponse,
+};
+use candid::Principal;
+use ic_cdk::{id, spawn};
+use ic_cdk_timers::set_timer_interval;
+use ic_stable_structures::{
+    memory_manager::{MemoryId, MemoryManager, VirtualMemory},
+    DefaultMemoryImpl, StableBTreeMap,
+};
+use lazy_static::lazy_static;
+use registry::{Client, List};
+
+mod registry;
+
+type Memory = VirtualMemory<DefaultMemoryImpl>;
+
+type StableMap<K, V> = StableBTreeMap<K, V, Memory>;
+type StableSet<T> = StableMap<T, ()>;
+
+thread_local! {
+    static MEMORY_MANAGER: RefCell<MemoryManager<DefaultMemoryImpl>> =
+        RefCell::new(MemoryManager::init(DefaultMemoryImpl::default()));
+}
+
+const REGISTRY_CANISTER_ID: &str = "bnz7o-iuaaa-aaaaa-qaaaa-cai";
+
+const MEMORY_ID_ALLOWED_PRINCIPALS: u8 = 0;
+
+lazy_static! {
+    static ref REGISTRY_LISTER: Box<dyn List> = {
+        let cid =
+            Principal::from_text(REGISTRY_CANISTER_ID).expect("failed to construct principal");
+
+        let v = Client::new(cid);
+        Box::new(v)
+    };
+}
+
+thread_local! {
+    static ALLOWED_PRINCIPALS: RefCell<StableSet<Principal>> = RefCell::new(
+        StableSet::init(
+            MEMORY_MANAGER.with(|m| m.borrow().get(MemoryId::new(MEMORY_ID_ALLOWED_PRINCIPALS))),
+        )
+    );
+}
+
+// Timers
+
+fn timers() {
+    // ACLs
+    set_timer_interval(Duration::from_secs(10), || {
+        // Switch to async
+        spawn(async {
+            // List registry entries
+            let ids = match REGISTRY_LISTER.list().await {
+                Ok(ids) => ids,
+
+                // Abort on failure
+                Err(_) => return,
+            };
+
+            // Update allowed principals
+            ALLOWED_PRINCIPALS.with(|ps| {
+                let mut ps = ps.borrow_mut();
+
+                // Clear allowed principals
+                ps.clear_new();
+
+                ids.iter().for_each(|p| {
+                    ps.insert(p.to_owned(), ());
+                });
+            });
+        });
+    });
+}
+
+// Service
+
+#[ic_cdk::init]
+fn init(_arg: InitArg) {
+    // Self-authorize
+    ALLOWED_PRINCIPALS.with(|m| {
+        m.borrow_mut().insert(
+            id(), // canister id
+            (),   // unit
+        )
+    });
+
+    // Start timers
+    timers();
+}
+
+#[ic_cdk::post_upgrade]
+fn post_upgrade() {
+    // Start timers
+    timers();
+}
+
+#[ic_cdk::update]
+fn register(_pubkey: Vec<u8>) -> RegisterResponse {
+    unimplemented!()
+}
+
+#[ic_cdk::query]
+fn query() -> QueryResponse {
+    unimplemented!()
+}
+
+#[ic_cdk::update]
+fn submit(_vs: Vec<ifc::Pair>) -> SubmitResponse {
+    unimplemented!()
+}

--- a/rs/boundary_node/anonymization/backend/src/lib.rs
+++ b/rs/boundary_node/anonymization/backend/src/lib.rs
@@ -6,6 +6,7 @@ use anonymization_interface::{
 use candid::Principal;
 use ic_cdk::{id, spawn};
 use ic_cdk_timers::set_timer_interval;
+use ic_nns_constants::REGISTRY_CANISTER_ID;
 use ic_stable_structures::{
     memory_manager::{MemoryId, MemoryManager, VirtualMemory},
     DefaultMemoryImpl, StableBTreeMap,
@@ -25,14 +26,11 @@ thread_local! {
         RefCell::new(MemoryManager::init(DefaultMemoryImpl::default()));
 }
 
-const REGISTRY_CANISTER_ID: &str = "bnz7o-iuaaa-aaaaa-qaaaa-cai";
-
 const MEMORY_ID_ALLOWED_PRINCIPALS: u8 = 0;
 
 lazy_static! {
     static ref API_BOUNDARY_NODES_LISTER: Box<dyn List> = {
-        let cid =
-            Principal::from_text(REGISTRY_CANISTER_ID).expect("failed to construct principal");
+        let cid = Principal::from(REGISTRY_CANISTER_ID);
 
         let v = Client::new(cid);
         Box::new(v)

--- a/rs/boundary_node/anonymization/backend/src/lib.rs
+++ b/rs/boundary_node/anonymization/backend/src/lib.rs
@@ -79,6 +79,8 @@ fn timers() {
 
 // Service
 
+fn main() {}
+
 #[ic_cdk::init]
 fn init(_arg: InitArg) {
     // Self-authorize

--- a/rs/boundary_node/anonymization/backend/src/lib.rs
+++ b/rs/boundary_node/anonymization/backend/src/lib.rs
@@ -79,6 +79,7 @@ fn timers() {
 
 // Service
 
+#[allow(dead_code)]
 fn main() {}
 
 #[ic_cdk::init]

--- a/rs/boundary_node/anonymization/backend/src/registry.rs
+++ b/rs/boundary_node/anonymization/backend/src/registry.rs
@@ -1,0 +1,55 @@
+use anyhow::anyhow;
+use async_trait::async_trait;
+use candid::{CandidType, Principal};
+use serde::Deserialize;
+
+#[derive(Debug, thiserror::Error)]
+pub enum ListError {
+    #[error(transparent)]
+    UnexpectedError(#[from] anyhow::Error),
+}
+
+#[async_trait]
+pub trait List: Sync + Send {
+    async fn list(&self) -> Result<Vec<Principal>, ListError>;
+}
+
+pub struct Client {
+    cid: Principal,
+}
+
+impl Client {
+    pub fn new(cid: Principal) -> Self {
+        Self { cid }
+    }
+}
+
+#[derive(CandidType)]
+pub struct EmptyStruct {}
+
+#[derive(Debug, CandidType, Deserialize)]
+pub struct IdRecord {
+    id: Option<Principal>,
+}
+
+type CallResult<T> = (Result<T, String>,);
+
+#[async_trait]
+impl List for Client {
+    async fn list(&self) -> Result<Vec<Principal>, ListError> {
+        // Fetch IDs
+        let r: CallResult<Vec<IdRecord>> =
+            ic_cdk::call(self.cid, "get_api_boundary_node_ids", (EmptyStruct {},))
+                .await
+                .map_err(|err| anyhow!("failed to call canister method: {err:?}"))?;
+
+        // Flatten IDs
+        let ids: Vec<Principal> =
+            r.0.map_err(|err| anyhow!("canister method returned error: {err}"))?
+                .into_iter()
+                .filter_map(|r| r.id)
+                .collect();
+
+        return Ok(ids);
+    }
+}


### PR DESCRIPTION
This PR makes the canister periodically poll the registry to list the principles of known API Boundary Nodes. These are then used in ACLs to only allow access to the canister by those principals (will be added in a follow-up PR).