### PR TITLE
test(sns): Re-enable SNS qualification tests after the next SNS-W release

### DIFF
--- a/rs/nervous_system/integration_tests/tests/sns_ledger_upgrade.rs
+++ b/rs/nervous_system/integration_tests/tests/sns_ledger_upgrade.rs
@@ -111,8 +111,6 @@ async fn test_deploy_fresh_sns() {
     // TODO eventually we need to test a swap
 }
 
-// TODO[NNS1-3429]: Re-enable this test after the next SNS-W release.
-#[ignore]
 #[tokio::test]
 async fn test_upgrade_existing_sns() {
     let create_service_nervous_system = CreateServiceNervousSystemBuilder::default()

--- a/rs/nervous_system/integration_tests/tests/sns_release_qualification.rs
+++ b/rs/nervous_system/integration_tests/tests/sns_release_qualification.rs
@@ -32,8 +32,6 @@ use ic_sns_wasm::pb::v1::SnsCanisterType;
 
 /// Deployment tests
 //
-// TODO[NNS1-3429]: Re-enable this test after the next SNS-W release.
-#[ignore]
 #[tokio::test]
 async fn test_deployment_all_upgrades() {
     test_sns_deployment(
@@ -49,15 +47,11 @@ async fn test_deployment_all_upgrades() {
     .await;
 }
 
-// TODO[NNS1-3429]: Re-enable this test after the next SNS-W release.
-#[ignore]
 #[tokio::test]
 async fn test_deployment_with_only_nns_upgrades() {
     test_sns_deployment(vec![GOVERNANCE_CANISTER_ID, SNS_WASM_CANISTER_ID], vec![]).await;
 }
 
-// TODO[NNS1-3429]: Re-enable this test after the next SNS-W release.
-#[ignore]
 #[tokio::test]
 async fn test_deployment_with_only_sns_upgrades() {
     test_sns_deployment(
@@ -73,8 +67,6 @@ async fn test_deployment_with_only_sns_upgrades() {
     .await;
 }
 
-// TODO[NNS1-3429]: Re-enable this test after the next SNS-W release.
-#[ignore]
 #[tokio::test]
 async fn test_deployment_with_sns_root_and_governance_upgrade() {
     test_sns_deployment(
@@ -84,30 +76,22 @@ async fn test_deployment_with_sns_root_and_governance_upgrade() {
     .await;
 }
 
-// TODO[NNS1-3429]: Re-enable this test after the next SNS-W release.
-#[ignore]
 #[tokio::test]
 async fn test_deployment_swap_upgrade() {
     test_sns_deployment(vec![], vec![SnsCanisterType::Swap]).await;
 }
 
-// TODO[NNS1-3429]: Re-enable this test after the next SNS-W release.
-#[ignore]
 /// Upgrade Tests
 #[tokio::test]
 async fn test_upgrade_sns_gov_root() {
     test_sns_upgrade(vec![SnsCanisterType::Root, SnsCanisterType::Governance]).await;
 }
 
-// TODO[NNS1-3429]: Re-enable this test after the next SNS-W release.
-#[ignore]
 #[tokio::test]
 async fn test_upgrade_upgrade_sns_gov_root() {
     test_sns_upgrade(vec![SnsCanisterType::Governance, SnsCanisterType::Root]).await;
 }
 
-// TODO[NNS1-3429]: Re-enable this test after the next SNS-W release.
-#[ignore]
 #[tokio::test]
 async fn test_upgrade_everything() {
     test_sns_upgrade(vec![


### PR DESCRIPTION
These SNS qualification tests were disabled last week due to the mainnet SNS-W canister not providing enough cycles upfront while deploying an SNS. With https://dashboard.internetcomputer.org/proposal/133906 being adopted, we now have the adjusted SNS-W canister on mainnet, so the previously disabled qualification tests can now be enabled again.