### PR TITLE
feat(BOUN-1236): add core logic impl to canister, add leader election cron

### DIFF
--- a/rs/boundary_node/anonymization/backend/src/lib.rs
+++ b/rs/boundary_node/anonymization/backend/src/lib.rs
@@ -186,11 +186,11 @@ fn timers() {
 
     // Leader
     set_timer_interval(Duration::from_secs(30), || {
-        // Collect candidates
+        // Collect candidates that have registered a public-key
         let ps: Vec<Principal> =
             PUBLIC_KEYS.with(|ks| ks.borrow().iter().map(|(p, _)| p).collect());
 
-        // Clear assignment
+        // Clear previous assignment
         if ps.is_empty() {
             LEADER_ASSIGNMENT.with(|v| v.borrow_mut().remove(&()));
             return;

--- a/rs/boundary_node/anonymization/backend/src/lib.rs
+++ b/rs/boundary_node/anonymization/backend/src/lib.rs
@@ -264,7 +264,7 @@ fn query() -> QueryResponse {
         Err(err) => QueryResponse::Err(match err {
             QueryError::Unauthorized => ifc::QueryError::Unauthorized,
             QueryError::Unavailable => ifc::QueryError::Unavailable,
-            QueryError::LeaderMode(mode, ps) => ifc::QueryError::Leader(
+            QueryError::LeaderDuty(mode, ps) => ifc::QueryError::LeaderDuty(
                 (&mode).into(),                      // mode
                 ps.iter().map(Into::into).collect(), // pairs
             ),

--- a/rs/boundary_node/anonymization/backend/src/lib.rs
+++ b/rs/boundary_node/anonymization/backend/src/lib.rs
@@ -15,7 +15,7 @@ use ic_stable_structures::{
 use lazy_static::lazy_static;
 use queue::{
     Pair, Querier, Query, QueryError, Register, RegisterError, Registrator, Submit, SubmitError,
-    Submitter,
+    Submitter, WithDedupe, WithLeaderAssignment, WithLeaderCheck, WithUnassignLeader,
 };
 use registry::{Client, List};
 
@@ -28,6 +28,7 @@ type LocalRef<T> = &'static LocalKey<RefCell<T>>;
 
 type StableMap<K, V> = StableBTreeMap<K, V, Memory>;
 type StableSet<T> = StableMap<T, ()>;
+type StableValue<T> = StableMap<(), T>;
 
 thread_local! {
     static MEMORY_MANAGER: RefCell<MemoryManager<DefaultMemoryImpl>> =
@@ -38,6 +39,7 @@ const MEMORY_ID_ALLOWED_PRINCIPALS: u8 = 0;
 const MEMORY_ID_PUBLIC_KEYS: u8 = 1;
 const MEMORY_ID_QUEUE: u8 = 2;
 const MEMORY_ID_ENCRYPTTED_VALUES: u8 = 3;
+const MEMORY_ID_LEADER_ASSIGNMENT: u8 = 4;
 
 lazy_static! {
     static ref API_BOUNDARY_NODES_LISTER: Box<dyn List> = {
@@ -79,23 +81,33 @@ thread_local! {
             MEMORY_MANAGER.with(|m| m.borrow().get(MemoryId::new(MEMORY_ID_ENCRYPTTED_VALUES))),
         )
     );
+
+    static LEADER_ASSIGNMENT: RefCell<StableValue<Principal>> = RefCell::new(
+        StableValue::init(
+            MEMORY_MANAGER.with(|m| m.borrow().get(MemoryId::new(MEMORY_ID_LEADER_ASSIGNMENT))),
+        )
+    );
 }
 
 thread_local! {
     static REGISTRATOR: RefCell<Box<dyn Register>> = RefCell::new({
         let v = Registrator::new(&PUBLIC_KEYS, &QUEUE, &ENCRYPTED_VALUES);
+        let v = WithUnassignLeader(v, &LEADER_ASSIGNMENT);
+        let v = WithDedupe(v, &PUBLIC_KEYS);
         let v = WithAuthorize(v, &AUTHORIZER);
         Box::new(v)
     });
 
     static QUERIER: RefCell<Box<dyn Query>> = RefCell::new({
         let v = Querier::new(&ENCRYPTED_VALUES);
+        let v = WithLeaderAssignment(v, &LEADER_ASSIGNMENT, &QUEUE, &PUBLIC_KEYS, &ENCRYPTED_VALUES);
         let v = WithAuthorize(v, &AUTHORIZER);
         Box::new(v)
     });
 
     static SUBMITTER: RefCell<Box<dyn Submit>> = RefCell::new({
         let v = Submitter::new(&QUEUE, &ENCRYPTED_VALUES);
+        let v = WithLeaderCheck(v, &LEADER_ASSIGNMENT);
         let v = WithAuthorize(v, &AUTHORIZER);
         Box::new(v)
     });
@@ -127,7 +139,83 @@ fn timers() {
                     ps.insert(p.to_owned(), ());
                 });
             });
+
+            // Remove stale public-keys
+            PUBLIC_KEYS.with(|ks| {
+                let mut ks = ks.borrow_mut();
+
+                let stale: Vec<Principal> = ks
+                    .iter()
+                    .filter_map(|(p, _)| (!ids.contains(&p)).then_some(p))
+                    .collect();
+
+                for p in stale {
+                    ks.remove(&p);
+                }
+            });
+
+            // Remove stale encrypted values
+            ENCRYPTED_VALUES.with(|vs| {
+                let mut vs = vs.borrow_mut();
+
+                let stale: Vec<Principal> = vs
+                    .iter()
+                    .filter_map(|(p, _)| (!ids.contains(&p)).then_some(p))
+                    .collect();
+
+                for p in stale {
+                    vs.remove(&p);
+                }
+            });
+
+            // Remove stale queue entries
+            QUEUE.with(|q| {
+                let mut q = q.borrow_mut();
+
+                let stale: Vec<Principal> = q
+                    .iter()
+                    .filter_map(|(p, _)| (!ids.contains(&p)).then_some(p))
+                    .collect();
+
+                for p in stale {
+                    q.remove(&p);
+                }
+            });
         });
+    });
+
+    // Leader
+    set_timer_interval(Duration::from_secs(30), || {
+        // Collect candidates
+        let ps: Vec<Principal> =
+            PUBLIC_KEYS.with(|ks| ks.borrow().iter().map(|(p, _)| p).collect());
+
+        // Clear assignment
+        if ps.is_empty() {
+            LEADER_ASSIGNMENT.with(|v| v.borrow_mut().remove(&()));
+            return;
+        }
+
+        // Choose the next leader
+        let p = match LEADER_ASSIGNMENT
+            .with(|v| {
+                v.borrow().get(&()).map(|v| {
+                    ps.iter()
+                        .position(|&p| p == v)
+                        // Select next in line
+                        .map(|i| ps.get((i + 1) % ps.len()))
+                })
+            })
+            .flatten()
+            .flatten()
+        {
+            Some(p) => p,
+
+            // Assign first available
+            None => &ps[0],
+        };
+
+        LEADER_ASSIGNMENT.with(|v| v.borrow_mut().insert((), p.to_owned()));
     });
 }
 
@@ -175,6 +263,11 @@ fn query() -> QueryResponse {
         Ok(v) => QueryResponse::Ok(v),
         Err(err) => QueryResponse::Err(match err {
             QueryError::Unauthorized => ifc::QueryError::Unauthorized,
+            QueryError::Unavailable => ifc::QueryError::Unavailable,
+            QueryError::LeaderMode(mode, ps) => ifc::QueryError::Leader(
+                (&mode).into(),                      // mode
+                ps.iter().map(Into::into).collect(), // pairs
+            ),
             QueryError::UnexpectedError(err) => ifc::QueryError::UnexpectedError(err.to_string()),
         }),
     }

--- a/rs/boundary_node/anonymization/backend/src/queue.rs
+++ b/rs/boundary_node/anonymization/backend/src/queue.rs
@@ -168,8 +168,8 @@ pub enum QueryError {
     #[error("Unavailable")]
     Unavailable,
 
-    #[error("LeaderMode")]
-    LeaderMode(LeaderMode, Vec<Pair>),
+    #[error("LeaderDuty")]
+    LeaderDuty(LeaderMode, Vec<Pair>),
 
     #[error(transparent)]
     UnexpectedError(#[from] anyhow::Error),
@@ -242,7 +242,7 @@ impl<T: Query> Query for WithLeaderAssignment<T> {
             _ => LeaderMode::Refresh,
         };
 
-        Err(QueryError::LeaderMode(
+        Err(QueryError::LeaderDuty(
             mode, // mode
             ps,   // principal pubkey pairs
         ))

--- a/rs/boundary_node/anonymization/backend/src/queue.rs
+++ b/rs/boundary_node/anonymization/backend/src/queue.rs
@@ -4,7 +4,7 @@ use ic_cdk::caller;
 
 use crate::{
     acl::{Authorize, AuthorizeError, WithAuthorize},
-    LocalRef, StableMap, StableSet,
+    LocalRef, StableMap, StableSet, StableValue,
 };
 
 #[derive(Clone)]
@@ -47,9 +47,9 @@ pub trait Register {
 }
 
 pub struct Registrator {
-    _pubkeys: LocalRef<StableMap<Principal, Vec<u8>>>,
-    _queue: LocalRef<StableSet<Principal>>,
-    _encrypted_values: LocalRef<StableMap<Principal, Vec<u8>>>,
+    pubkeys: LocalRef<StableMap<Principal, Vec<u8>>>,
+    queue: LocalRef<StableSet<Principal>>,
+    encrypted_values: LocalRef<StableMap<Principal, Vec<u8>>>,
 }
 
 impl Registrator {
@@ -59,16 +59,74 @@ impl Registrator {
         encrypted_values: LocalRef<StableMap<Principal, Vec<u8>>>,
     ) -> Self {
         Self {
-            _pubkeys: pubkeys,
-            _queue: queue,
-            _encrypted_values: encrypted_values,
+            pubkeys,
+            queue,
+            encrypted_values,
         }
     }
 }
 
 impl Register for Registrator {
-    fn register(&self, _pubkey: &[u8]) -> Result<(), RegisterError> {
-        unimplemented!()
+    fn register(&self, pubkey: &[u8]) -> Result<(), RegisterError> {
+        // Register public-key
+        self.pubkeys.with(|ks| {
+            ks.borrow_mut().insert(
+                caller(),          // principal
+                pubkey.to_owned(), // pubkey
+            )
+        });
+
+        // Remove previous encrypted value, if any exist
+        self.encrypted_values
+            .with(|vs| vs.borrow_mut().remove(&caller()));
+
+        // Add to queue
+        self.queue.with(|q| {
+            q.borrow_mut().insert(
+                caller(), // principal
+                (),       // unit
+            )
+        });
+
+        Ok(())
+    }
+}
+
+pub struct WithDedupe<T>(pub T, pub LocalRef<StableMap<Principal, Vec<u8>>>);
+
+impl<T: Register> Register for WithDedupe<T> {
+    fn register(&self, pubkey: &[u8]) -> Result<(), RegisterError> {
+        // Ignore duplicate registrations
+        if let Some(v) = self.1.with(|ks| ks.borrow().get(&caller())) {
+            if v.eq(pubkey) {
+                return Ok(());
+            }
+        }
+
+        self.0.register(pubkey)
+    }
+}
+
+pub struct WithUnassignLeader<T>(
+    pub T,
+    pub LocalRef<StableValue<Principal>>, // LeaderAssignment
+);
+
+impl<T: Register> Register for WithUnassignLeader<T> {
+    fn register(&self, pubkey: &[u8]) -> Result<(), RegisterError> {
+        // Unassign if leader
+        self.1.with(|p| {
+            let mut p = p.borrow_mut();
+
+            if match p.get(&()) {
+                Some(p) => caller() == p,
+                None => false,
+            } {
+                p.remove(&());
+            }
+        });
+
+        self.0.register(pubkey)
     }
 }
 
@@ -107,6 +165,12 @@ pub enum QueryError {
     #[error("Unauthorized")]
     Unauthorized,
 
+    #[error("Unavailable")]
+    Unavailable,
+
+    #[error("LeaderMode")]
+    LeaderMode(LeaderMode, Vec<Pair>),
+
     #[error(transparent)]
     UnexpectedError(#[from] anyhow::Error),
 }
@@ -116,20 +180,72 @@ pub trait Query {
 }
 
 pub struct Querier {
-    _encrypted_values: LocalRef<StableMap<Principal, Vec<u8>>>,
+    encrypted_values: LocalRef<StableMap<Principal, Vec<u8>>>,
 }
 
 impl Querier {
     pub fn new(encrypted_values: LocalRef<StableMap<Principal, Vec<u8>>>) -> Self {
-        Self {
-            _encrypted_values: encrypted_values,
-        }
+        Self { encrypted_values }
     }
 }
 
 impl Query for Querier {
     fn query(&self) -> Result<Vec<u8>, QueryError> {
-        unimplemented!()
+        self.encrypted_values
+            .with(|vs| vs.borrow().get(&caller()))
+            .ok_or(QueryError::Unavailable)
+    }
+}
+
+pub struct WithLeaderAssignment<T>(
+    pub T,
+    pub LocalRef<StableValue<Principal>>, // LeaderAssignment
+    pub LocalRef<StableSet<Principal>>,   // Queue
+    pub LocalRef<StableMap<Principal, Vec<u8>>>, // PublicKeys
+    pub LocalRef<StableMap<Principal, Vec<u8>>>, // EncryptedValues
+);
+
+impl<T: Query> Query for WithLeaderAssignment<T> {
+    fn query(&self) -> Result<Vec<u8>, QueryError> {
+        // Check leader assignment
+        let is_leader = match self.1.with(|p| p.borrow().get(&())) {
+            Some(p) => caller() == p,
+            None => false,
+        };
+
+        if !is_leader {
+            return self.0.query();
+        }
+
+        // Check queue
+        let ps: Vec<Principal> = self.2.with(|q| q.borrow().iter().map(|(k, _)| k).collect());
+
+        // Ignore when queue is empty
+        if ps.is_empty() {
+            return self.0.query();
+        }
+
+        // Convert to principal public-key pairs
+        let ps: Vec<Pair> = ps
+            .into_iter()
+            .filter_map(|p| self.3.with(|ks| ks.borrow().get(&p).map(|k| Pair(p, k))))
+            .collect();
+
+        // Ignore if there are missing public-keys
+        if ps.is_empty() {
+            return self.0.query();
+        }
+
+        // Decide on mode
+        let mode = match self.4.with(|vs| vs.borrow().is_empty()) {
+            true => LeaderMode::Bootstrap,
+            _ => LeaderMode::Refresh,
+        };
+
+        Err(QueryError::LeaderMode(
+            mode, // mode
+            ps,   // principal pubkey pairs
+        ))
     }
 }
 
@@ -162,8 +278,8 @@ pub trait Submit {
 }
 
 pub struct Submitter {
-    _queue: LocalRef<StableSet<Principal>>,
-    _encrypted_values: LocalRef<StableMap<Principal, Vec<u8>>>,
+    queue: LocalRef<StableSet<Principal>>,
+    encrypted_values: LocalRef<StableMap<Principal, Vec<u8>>>,
 }
 
 impl Submitter {
@@ -172,15 +288,59 @@ impl Submitter {
         encrypted_values: LocalRef<StableMap<Principal, Vec<u8>>>,
     ) -> Self {
         Self {
-            _queue: queue,
-            _encrypted_values: encrypted_values,
+            queue,
+            encrypted_values,
         }
     }
 }
 
 impl Submit for Submitter {
-    fn submit(&self, _ps: &[Pair]) -> Result<(), SubmitError> {
-        unimplemented!()
+    fn submit(&self, ps: &[Pair]) -> Result<(), SubmitError> {
+        // Discard pairs that arent in the queue
+        let ps: Vec<&Pair> = ps
+            .iter()
+            .filter(|Pair(p, _)| self.queue.with(|q| q.borrow().contains_key(p)))
+            .collect();
+
+        ps.iter().for_each(|Pair(p, ct)| {
+            // Set encrypted values
+            self.encrypted_values.with(|vs| {
+                vs.borrow_mut().insert(
+                    p.to_owned(),  // principal
+                    ct.to_owned(), // ciphertext
+                )
+            });
+
+            // Remove from queue once complete
+            self.queue.with(|q| {
+                q.borrow_mut().remove(
+                    p, // principal
+                )
+            });
+        });
+
+        Ok(())
+    }
+}
+
+pub struct WithLeaderCheck<T>(
+    pub T,
+    pub LocalRef<StableValue<Principal>>, // LeaderAssignment
+);
+
+impl<T: Submit> Submit for WithLeaderCheck<T> {
+    fn submit(&self, ps: &[Pair]) -> Result<(), SubmitError> {
+        // Check leader assignment
+        let is_leader = match self.1.with(|p| p.borrow().get(&())) {
+            Some(p) => caller() == p,
+            None => false,
+        };
+
+        if !is_leader {
+            return Err(SubmitError::Unauthorized);
+        }
+
+        self.0.submit(ps)
     }
 }
 


### PR DESCRIPTION
This change adds the core logic of the `register`, `query` and `submit` canister methods. Additionally, it adds a cron job in the canister to elect a new leader.