### PR TITLE
fix(ckbtc): Fix a problem with retrieve_btc_min_amount setting

### DIFF
--- a/rs/bitcoin/ckbtc/minter/ckbtc_minter.did
+++ b/rs/bitcoin/ckbtc/minter/ckbtc_minter.did
@@ -307,6 +307,8 @@ type BitcoinAddress = variant {
 
 type MinterInfo = record {
     min_confirmations : nat32;
+    // This fee is based on the `retrieve_btc_min_amount` setting during canister
+    // initialization or upgrades, but may vary according to current network fees.
     retrieve_btc_min_amount : nat64;
     kyt_fee : nat64;
 };

--- a/rs/bitcoin/ckbtc/minter/src/dashboard.rs
+++ b/rs/bitcoin/ckbtc/minter/src/dashboard.rs
@@ -296,6 +296,10 @@ pub fn build_metadata(s: &CkBtcMinterState) -> String {
                         <td>{}</td>
                     </tr>
                     <tr>
+                        <th>Min retrieve BTC amount (fee based)</th>
+                        <td>{}</td>
+                    </tr>
+                    <tr>
                         <th>Total BTC managed</th>
                         <td>{}</td>
                     </tr>
@@ -315,6 +319,7 @@ pub fn build_metadata(s: &CkBtcMinterState) -> String {
             .unwrap_or_else(|| "N/A".to_string()),
         DisplayAmount(s.kyt_fee),
         DisplayAmount(s.retrieve_btc_min_amount),
+        DisplayAmount(s.fee_based_retrieve_btc_min_amount),
         DisplayAmount(get_total_btc_managed(s))
     )
 }

--- a/rs/bitcoin/ckbtc/minter/src/lib.rs
+++ b/rs/bitcoin/ckbtc/minter/src/lib.rs
@@ -166,18 +166,13 @@ async fn fetch_main_utxos(main_account: &Account, main_address: &BitcoinAddress)
 /// Returns the minimum withdrawal amount based on the current median fee rate (in millisatoshi per byte).
 /// The returned amount is in satoshi.
 fn compute_min_withdrawal_amount(
-    btc_network: Network,
     median_fee_rate_e3s: MillisatoshiPerByte,
+    min_withdrawal_amount: u64,
 ) -> u64 {
     const PER_REQUEST_RBF_BOUND: u64 = 22_100;
     const PER_REQUEST_VSIZE_BOUND: u64 = 221;
     const PER_REQUEST_MINTER_FEE_BOUND: u64 = 305;
     const PER_REQUEST_KYT_FEE: u64 = 2_000;
-
-    let min_withdrawal_amount = match btc_network {
-        Network::Testnet | Network::Regtest => 10_000,
-        Network::Mainnet => 100_000,
-    };
 
     let median_fee_rate = median_fee_rate_e3s / 1_000;
     ((PER_REQUEST_RBF_BOUND
@@ -206,8 +201,8 @@ pub async fn estimate_fee_per_vbyte() -> Option<MillisatoshiPerByte> {
             if fees.len() >= 100 {
                 state::mutate_state(|s| {
                     s.last_fee_per_vbyte.clone_from(&fees);
-                    s.retrieve_btc_min_amount =
-                        compute_min_withdrawal_amount(s.btc_network, fees[50]);
+                    s.fee_based_retrieve_btc_min_amount =
+                        compute_min_withdrawal_amount(fees[50], s.retrieve_btc_min_amount);
                 });
                 Some(fees[50])
             } else {

--- a/rs/bitcoin/ckbtc/minter/src/lib.rs
+++ b/rs/bitcoin/ckbtc/minter/src/lib.rs
@@ -1198,6 +1198,10 @@ pub fn timer() {
         }
         TaskType::RefreshFeePercentiles => {
             ic_cdk::spawn(async {
+                let _guard = match crate::guard::TimerLogicGuard::new() {
+                    Some(guard) => guard,
+                    None => return,
+                };
                 const FEE_ESTIMATE_DELAY: Duration = Duration::from_secs(60 * 60);
                 let _ = estimate_fee_per_vbyte().await;
                 schedule_after(FEE_ESTIMATE_DELAY, TaskType::RefreshFeePercentiles);

--- a/rs/bitcoin/ckbtc/minter/src/main.rs
+++ b/rs/bitcoin/ckbtc/minter/src/main.rs
@@ -92,6 +92,14 @@ async fn distribute_kyt_fee() {
 #[cfg(feature = "self_check")]
 #[update]
 async fn refresh_fee_percentiles() {
+    // Use `TimerLogicGuard` here because:
+    // 1. `estimiate_fee_per_vbyte` could potentially change the state.
+    // 2. `estimiate_fee_per_vbyte` is also called from timer
+    //    `TaskType::ProcessLogic` and `TaskType::RefreshFeePercentiles`.
+    let _guard = match crate::guard::TimerLogicGuard::new() {
+        Some(guard) => guard,
+        None => return,
+    };
     let _ = ic_ckbtc_minter::estimate_fee_per_vbyte().await;
 }
 

--- a/rs/bitcoin/ckbtc/minter/src/main.rs
+++ b/rs/bitcoin/ckbtc/minter/src/main.rs
@@ -93,8 +93,8 @@ async fn distribute_kyt_fee() {
 #[update]
 async fn refresh_fee_percentiles() {
     // Use `TimerLogicGuard` here because:
-    // 1. `estimiate_fee_per_vbyte` could potentially change the state.
-    // 2. `estimiate_fee_per_vbyte` is also called from timer
+    // 1. `estimate_fee_per_vbyte` could potentially change the state.
+    // 2. `estimate_fee_per_vbyte` is also called from timer
     //    `TaskType::ProcessLogic` and `TaskType::RefreshFeePercentiles`.
     let _guard = match ic_ckbtc_minter::guard::TimerLogicGuard::new() {
         Some(guard) => guard,

--- a/rs/bitcoin/ckbtc/minter/src/main.rs
+++ b/rs/bitcoin/ckbtc/minter/src/main.rs
@@ -216,7 +216,7 @@ fn get_minter_info() -> MinterInfo {
     read_state(|s| MinterInfo {
         kyt_fee: s.kyt_fee,
         min_confirmations: s.min_confirmations,
-        retrieve_btc_min_amount: s.retrieve_btc_min_amount,
+        retrieve_btc_min_amount: s.fee_based_retrieve_btc_min_amount,
     })
 }
 

--- a/rs/bitcoin/ckbtc/minter/src/main.rs
+++ b/rs/bitcoin/ckbtc/minter/src/main.rs
@@ -96,7 +96,7 @@ async fn refresh_fee_percentiles() {
     // 1. `estimiate_fee_per_vbyte` could potentially change the state.
     // 2. `estimiate_fee_per_vbyte` is also called from timer
     //    `TaskType::ProcessLogic` and `TaskType::RefreshFeePercentiles`.
-    let _guard = match crate::guard::TimerLogicGuard::new() {
+    let _guard = match ic_ckbtc_minter::guard::TimerLogicGuard::new() {
         Some(guard) => guard,
         None => return,
     };

--- a/rs/bitcoin/ckbtc/minter/src/metrics.rs
+++ b/rs/bitcoin/ckbtc/minter/src/metrics.rs
@@ -123,6 +123,12 @@ pub fn encode_metrics(
     )?;
 
     metrics.encode_gauge(
+        "ckbtc_minter_fee_based_min_retrievable_amount",
+        state::read_state(|s| s.fee_based_retrieve_btc_min_amount) as f64,
+        "Minimum number of ckBTC a user can withdraw (fee based).",
+    )?;
+
+    metrics.encode_gauge(
         "ckbtc_minter_min_confirmations",
         state::read_state(|s| s.min_confirmations) as f64,
         "Min number of confirmations on BTC network",

--- a/rs/bitcoin/ckbtc/minter/src/state.rs
+++ b/rs/bitcoin/ckbtc/minter/src/state.rs
@@ -292,6 +292,9 @@ pub struct CkBtcMinterState {
     /// Minimum amount of bitcoin that can be retrieved
     pub retrieve_btc_min_amount: u64,
 
+    /// Minimum amount of bitcoin that can be retrieved based on recent fees
+    pub fee_based_retrieve_btc_min_amount: u64,
+
     /// Retrieve_btc requests that are waiting to be served, sorted by
     /// received_at.
     pub pending_retrieve_btc_requests: Vec<RetrieveBtcRequest>,
@@ -432,6 +435,7 @@ impl CkBtcMinterState {
         self.btc_network = btc_network.into();
         self.ecdsa_key_name = ecdsa_key_name;
         self.retrieve_btc_min_amount = retrieve_btc_min_amount;
+        self.fee_based_retrieve_btc_min_amount = retrieve_btc_min_amount;
         self.ledger_id = ledger_id;
         self.max_time_in_queue_nanos = max_time_in_queue_nanos;
         self.mode = mode;
@@ -457,6 +461,7 @@ impl CkBtcMinterState {
     ) {
         if let Some(retrieve_btc_min_amount) = retrieve_btc_min_amount {
             self.retrieve_btc_min_amount = retrieve_btc_min_amount;
+            self.fee_based_retrieve_btc_min_amount = retrieve_btc_min_amount;
         }
         if let Some(max_time_in_queue_nanos) = max_time_in_queue_nanos {
             self.max_time_in_queue_nanos = max_time_in_queue_nanos;
@@ -1236,6 +1241,7 @@ impl From<InitArgs> for CkBtcMinterState {
             update_balance_principals: Default::default(),
             retrieve_btc_principals: Default::default(),
             retrieve_btc_min_amount: args.retrieve_btc_min_amount,
+            fee_based_retrieve_btc_min_amount: args.retrieve_btc_min_amount,
             pending_retrieve_btc_requests: Default::default(),
             requests_in_flight: Default::default(),
             last_transaction_submission_time_ns: None,

--- a/rs/bitcoin/ckbtc/minter/src/updates/retrieve_btc.rs
+++ b/rs/bitcoin/ckbtc/minter/src/updates/retrieve_btc.rs
@@ -174,8 +174,13 @@ pub async fn retrieve_btc(args: RetrieveBtcArgs) -> Result<RetrieveBtcOk, Retrie
     }
 
     let _guard = retrieve_btc_guard(caller)?;
-    let (min_retrieve_amount, btc_network, kyt_fee) =
-        read_state(|s| (s.fee_based_retrieve_btc_min_amount, s.btc_network, s.kyt_fee));
+    let (min_retrieve_amount, btc_network, kyt_fee) = read_state(|s| {
+        (
+            s.fee_based_retrieve_btc_min_amount,
+            s.btc_network,
+            s.kyt_fee,
+        )
+    });
 
     let min_amount = max(min_retrieve_amount, kyt_fee);
     if args.amount < min_amount {
@@ -308,8 +313,13 @@ pub async fn retrieve_btc_with_approval(
     }
 
     let _guard = retrieve_btc_guard(caller)?;
-    let (min_retrieve_amount, btc_network, kyt_fee) =
-        read_state(|s| (s.fee_based_retrieve_btc_min_amount, s.btc_network, s.kyt_fee));
+    let (min_retrieve_amount, btc_network, kyt_fee) = read_state(|s| {
+        (
+            s.fee_based_retrieve_btc_min_amount,
+            s.btc_network,
+            s.kyt_fee,
+        )
+    });
     let min_amount = max(min_retrieve_amount, kyt_fee);
     if args.amount < min_amount {
         return Err(RetrieveBtcWithApprovalError::AmountTooLow(min_amount));

--- a/rs/bitcoin/ckbtc/minter/src/updates/retrieve_btc.rs
+++ b/rs/bitcoin/ckbtc/minter/src/updates/retrieve_btc.rs
@@ -175,7 +175,7 @@ pub async fn retrieve_btc(args: RetrieveBtcArgs) -> Result<RetrieveBtcOk, Retrie
 
     let _guard = retrieve_btc_guard(caller)?;
     let (min_retrieve_amount, btc_network, kyt_fee) =
-        read_state(|s| (s.retrieve_btc_min_amount, s.btc_network, s.kyt_fee));
+        read_state(|s| (s.fee_based_retrieve_btc_min_amount, s.btc_network, s.kyt_fee));
 
     let min_amount = max(min_retrieve_amount, kyt_fee);
     if args.amount < min_amount {
@@ -309,7 +309,7 @@ pub async fn retrieve_btc_with_approval(
 
     let _guard = retrieve_btc_guard(caller)?;
     let (min_retrieve_amount, btc_network, kyt_fee) =
-        read_state(|s| (s.retrieve_btc_min_amount, s.btc_network, s.kyt_fee));
+        read_state(|s| (s.fee_based_retrieve_btc_min_amount, s.btc_network, s.kyt_fee));
     let min_amount = max(min_retrieve_amount, kyt_fee);
     if args.amount < min_amount {
         return Err(RetrieveBtcWithApprovalError::AmountTooLow(min_amount));

--- a/rs/bitcoin/ckbtc/minter/tests/tests.rs
+++ b/rs/bitcoin/ckbtc/minter/tests/tests.rs
@@ -1329,7 +1329,7 @@ fn test_transaction_finalization() {
 }
 
 #[test]
-fn test_min_retrieval_amount_mainnet() {
+fn test_min_retrieval_amount_default() {
     let ckbtc = CkBtcSetup::new();
 
     ckbtc.refresh_fee_percentiles();
@@ -1359,7 +1359,7 @@ fn test_min_retrieval_amount_mainnet() {
 }
 
 #[test]
-fn test_min_retrieval_amount_testnet() {
+fn test_min_retrieval_amount_custom() {
     let min_amount = 12_345;
     let ckbtc = CkBtcSetup::new_with(Network::Testnet, min_amount);
 
@@ -1391,6 +1391,28 @@ fn test_min_retrieval_amount_testnet() {
     // When fee becomes 0 again, it goes back to the initial setting
     ckbtc.set_fee_percentiles(&vec![0; 100]);
     ckbtc.refresh_fee_percentiles();
+    let retrieve_btc_min_amount = ckbtc.get_minter_info().retrieve_btc_min_amount;
+    assert_eq!(retrieve_btc_min_amount, min_amount);
+
+    // Test changing min_retrieve_fee when upgrade
+    let min_amount = 123_456;
+    let upgrade_args = UpgradeArgs {
+        retrieve_btc_min_amount: Some(min_amount),
+        min_confirmations: None,
+        max_time_in_queue_nanos: None,
+        mode: None,
+        kyt_principal: None,
+        kyt_fee: None,
+    };
+    let minter_arg = MinterArg::Upgrade(Some(upgrade_args));
+    assert!(ckbtc
+        .env
+        .upgrade_canister(
+            ckbtc.minter_id,
+            minter_wasm(),
+            Encode!(&minter_arg).unwrap()
+        )
+        .is_ok());
     let retrieve_btc_min_amount = ckbtc.get_minter_info().retrieve_btc_min_amount;
     assert_eq!(retrieve_btc_min_amount, min_amount);
 }

--- a/rs/bitcoin/ckbtc/minter/tests/tests.rs
+++ b/rs/bitcoin/ckbtc/minter/tests/tests.rs
@@ -1398,11 +1398,7 @@ fn test_min_retrieval_amount_custom() {
     let min_amount = 123_456;
     let upgrade_args = UpgradeArgs {
         retrieve_btc_min_amount: Some(min_amount),
-        min_confirmations: None,
-        max_time_in_queue_nanos: None,
-        mode: None,
-        kyt_principal: None,
-        kyt_fee: None,
+        ..Default::default()
     };
     let minter_arg = MinterArg::Upgrade(Some(upgrade_args));
     assert!(ckbtc

--- a/rs/bitcoin/ckbtc/minter/tests/tests.rs
+++ b/rs/bitcoin/ckbtc/minter/tests/tests.rs
@@ -1388,7 +1388,7 @@ fn test_min_retrieval_amount_testnet() {
     let retrieve_btc_min_amount = ckbtc.get_minter_info().retrieve_btc_min_amount;
     assert_eq!(retrieve_btc_min_amount, 100_000 + min_amount);
 
-    // When fee is 0, it back to the original setting
+    // When fee becomes 0 again, it goes back to the initial setting
     ckbtc.set_fee_percentiles(&vec![0; 100]);
     ckbtc.refresh_fee_percentiles();
     let retrieve_btc_min_amount = ckbtc.get_minter_info().retrieve_btc_min_amount;


### PR DESCRIPTION
The `retrieve_btc_min_amount` setting was both used as a configuration and as a dynamically calculated value based on recent fees. This led to a problem that changing this setting through canister upgrades would be ineffective because it would be overwritten by the calculated value.

The fix is to introduce another `fee_based_retrieve_btc_min_amount` in the state to hold the calculated value, and let `retrieve_btc_min_amount` always retain its initial setting.