### PR TITLE
feat(PocketIC): configurable server log levels and optimized tests

### DIFF
--- a/packages/pocket-ic/BUILD.bazel
+++ b/packages/pocket-ic/BUILD.bazel
@@ -94,10 +94,12 @@ rust_test_suite(
     size = "medium",
     srcs = ["tests/slow.rs"],
     data = [
+        "//packages/pocket-ic/test_canister:test_canister.wasm",
         "//rs/pocket_ic_server:pocket-ic-server",
     ],
     env = {
         "POCKET_IC_BIN": "$(rootpath //rs/pocket_ic_server:pocket-ic-server)",
+        "TEST_WASM": "$(rootpath //packages/pocket-ic/test_canister:test_canister.wasm)",
     },
     flaky = False,
     proc_macro_deps = MACRO_DEPENDENCIES,

--- a/packages/pocket-ic/test_canister/canister.did
+++ b/packages/pocket-ic/test_canister/canister.did
@@ -111,4 +111,5 @@ service : {
   whois : (principal) -> (text);
   blob_len : (blob) -> (nat64);
   call_with_large_blob : (principal, nat64) -> (nat64);
+  execute_many_instructions : (nat64) -> ();
 }

--- a/packages/pocket-ic/test_canister/src/canister.rs
+++ b/packages/pocket-ic/test_canister/src/canister.rs
@@ -1,5 +1,6 @@
 use candid::{define_function, CandidType, Principal};
 use ic_cdk::api::call::RejectionCode;
+use ic_cdk::api::instruction_counter;
 use ic_cdk::api::management_canister::ecdsa::{
     ecdsa_public_key as ic_cdk_ecdsa_public_key, sign_with_ecdsa as ic_cdk_sign_with_ecdsa,
     EcdsaCurve, EcdsaKeyId, EcdsaPublicKeyArgument, EcdsaPublicKeyResponse, SignWithEcdsaArgument,
@@ -276,6 +277,13 @@ async fn call_with_large_blob(canister: Principal, blob_len: usize) -> usize {
         .await
         .unwrap()
         .0
+}
+
+// executing many instructions
+
+#[update]
+async fn execute_many_instructions(n: u64) {
+    while instruction_counter() < n {}
 }
 
 fn main() {}

--- a/packages/pocket-ic/tests/slow.rs
+++ b/packages/pocket-ic/tests/slow.rs
@@ -1,69 +1,20 @@
-use candid::Principal;
+use candid::{Encode, Principal};
 use pocket_ic::{common::rest::DtsFlag, PocketIc, PocketIcBuilder, UserError, WasmResult};
 use std::time::Duration;
 
 // 200T cycles
 const INIT_CYCLES: u128 = 200_000_000_000_000;
 
-// Canister code with a very slow method.
-fn very_slow_wasm(n: u64) -> Vec<u8> {
-    let wat = format!(
-        r#"
-    (module
-        (import "ic0" "msg_reply" (func $msg_reply))
-        (import "ic0" "msg_reply_data_append"
-            (func $msg_reply_data_append (param i32 i32)))
-        (func $inc
-            ;; Increment a counter.
-            (i32.store
-                (i32.const 0)
-                (i32.add (i32.load (i32.const 0)) (i32.const 1))))
-        (func $run
-            ;; create a local variable and initialize it to 0
-            (local $i i32)
-            (local $j i32)
-            (loop $my_loop
-                i32.const 0
-                local.set $j
-                (loop $my_inner_loop
-                    ;; add one to $j
-                    local.get $j
-                    i32.const 1
-                    i32.add
-                    local.set $j
-                    ;; if $j is less than ... branch to loop
-                    local.get $j
-                    i32.const {}
-                    i32.lt_s
-                    br_if $my_inner_loop
-                )
-                ;; add one to $i
-                local.get $i
-                i32.const 1
-                i32.add
-                local.set $i
-                ;; if $i is less than ... branch to loop
-                local.get $i
-                i32.const {}
-                i32.lt_s
-                br_if $my_loop
-            )
-            (call $msg_reply))
-        (memory $memory 1)
-        (export "canister_update run" (func $run))
-        (export "canister_heartbeat" (func $inc))
-    )
-"#,
-        n, n
-    );
-    wat::parse_str(wat).unwrap()
+fn test_canister_wasm() -> Vec<u8> {
+    let wasm_path = std::env::var_os("TEST_WASM").expect("Missing test canister wasm file");
+    std::fs::read(wasm_path).unwrap()
 }
 
-fn run_very_slow_method(
+fn execute_many_instructions(
     pic: &PocketIc,
-    loop_iterations: u64,
-    dts_flag: DtsFlag,
-    arg_size: usize,
+    instructions: u64,
+    dts_rounds: u64,
+    system_subnet: bool,
 ) -> Result<WasmResult, UserError> {
     // Create a canister.
     let t0 = pic.get_time();
@@ -74,16 +25,25 @@ fn run_very_slow_method(
     // Charge the canister with 200T cycles.
     pic.add_cycles(can_id, INIT_CYCLES);
 
-    // Install the very slow canister wasm on the canister.
-    pic.install_canister(can_id, very_slow_wasm(loop_iterations), vec![], None);
+    let initial_cycles = pic.cycle_balance(can_id);
+    assert_eq!(initial_cycles, INIT_CYCLES);
+
+    // Install the test canister wasm on the canister.
+    pic.install_canister(can_id, test_canister_wasm(), vec![], None);
 
     let t0 = pic.get_time();
-    let res = pic.update_call(can_id, Principal::anonymous(), "run", vec![42u8; arg_size]);
+    let res = pic.update_call(
+        can_id,
+        Principal::anonymous(),
+        "execute_many_instructions",
+        Encode!(&instructions).unwrap(),
+    );
     let t1 = pic.get_time();
-    if let DtsFlag::Enabled = dts_flag {
-        assert!(t1 >= t0 + Duration::from_nanos(10)); // DTS takes at least 10 rounds
-    } else {
-        assert_eq!(t1, t0 + Duration::from_nanos(1)); // update call should take one round, i.e., 1ns without DTS
+    assert!(t1 >= t0 + Duration::from_nanos(dts_rounds));
+
+    if system_subnet {
+        let cycles = pic.cycle_balance(can_id);
+        assert_eq!(cycles, initial_cycles);
     }
 
     res
@@ -94,7 +54,10 @@ fn test_benchmarking_app_subnet() {
     let pic = PocketIcBuilder::new()
         .with_benchmarking_application_subnet()
         .build();
-    run_very_slow_method(&pic, 200_000, DtsFlag::Disabled, 0).unwrap();
+
+    let instructions = 42_000_000_000_u64;
+    let dts_rounds = 1; // DTS is disabled on benchmarking subnets
+    execute_many_instructions(&pic, instructions, dts_rounds, false).unwrap();
 }
 
 #[test]
@@ -102,13 +65,10 @@ fn test_benchmarking_system_subnet() {
     let pic = PocketIcBuilder::new()
         .with_benchmarking_system_subnet()
         .build();
-    run_very_slow_method(&pic, 200_000, DtsFlag::Disabled, 3_000_000).unwrap();
-}
 
-#[test]
-fn very_slow_method_on_application_subnet() {
-    let pic = PocketIcBuilder::new().with_application_subnet().build();
-    run_very_slow_method(&pic, 200_000, DtsFlag::Enabled, 0).unwrap_err();
+    let instructions = 42_000_000_000_u64;
+    let dts_rounds = 1; // DTS is disabled on benchmarking subnets
+    execute_many_instructions(&pic, instructions, dts_rounds, true).unwrap();
 }
 
 fn test_dts(dts_flag: DtsFlag) {
@@ -116,7 +76,14 @@ fn test_dts(dts_flag: DtsFlag) {
         .with_application_subnet()
         .with_dts_flag(dts_flag)
         .build();
-    run_very_slow_method(&pic, 60_000, dts_flag, 0).unwrap();
+
+    let instructions = 4_000_000_000_u64;
+    let dts_rounds = if let DtsFlag::Enabled = dts_flag {
+        instructions / 2_000_000_000
+    } else {
+        1
+    };
+    execute_many_instructions(&pic, instructions, dts_rounds, false).unwrap();
 }
 
 #[test]
@@ -135,29 +102,24 @@ fn instruction_limit_exceeded(dts_flag: DtsFlag) {
         .with_dts_flag(dts_flag)
         .build();
 
-    // Create a canister.
-    let can_id = pic.create_canister();
-
-    // Charge the canister with 200T cycles.
-    pic.add_cycles(can_id, INIT_CYCLES);
-
-    // Install the very slow canister wasm on the canister.
-    pic.install_canister(can_id, very_slow_wasm(200_000), vec![], None);
-
-    let res = pic
-        .update_call(can_id, Principal::anonymous(), "run", vec![])
-        .unwrap_err();
+    let instructions = 42_000_000_000_u64;
+    let dts_rounds = if let DtsFlag::Enabled = dts_flag {
+        20 // instruction limit exceeded after 20 rounds
+    } else {
+        1
+    };
+    let res = execute_many_instructions(&pic, instructions, dts_rounds, false).unwrap_err();
     assert!(res.description.contains(
         "Canister exceeded the limit of 40000000000 instructions for single message execution."
     ));
 }
 
 #[test]
-fn test_instruction_limit_exceeded_no_dts() {
-    instruction_limit_exceeded(DtsFlag::Disabled);
+fn test_instruction_limit_exceeded_dts_enabled() {
+    instruction_limit_exceeded(DtsFlag::Enabled);
 }
 
 #[test]
-fn test_instruction_limit_exceeded_dts() {
-    instruction_limit_exceeded(DtsFlag::Enabled);
+fn test_instruction_limit_exceeded_dts_disabled() {
+    instruction_limit_exceeded(DtsFlag::Disabled);
 }

--- a/packages/pocket-ic/tests/slow.rs
+++ b/packages/pocket-ic/tests/slow.rs
@@ -1,91 +1,9 @@
 use candid::Principal;
 use pocket_ic::{common::rest::DtsFlag, PocketIc, PocketIcBuilder, UserError, WasmResult};
-use std::{thread, time::Duration};
+use std::time::Duration;
 
 // 200T cycles
 const INIT_CYCLES: u128 = 200_000_000_000_000;
-
-// Canister code incrementing a counter in every heartbeat
-// and exporting a query method to read the counter.
-const AUTO_PROGRESS_WAT: &str = r#"
-    (module
-        (import "ic0" "msg_reply" (func $msg_reply))
-        (import "ic0" "msg_reply_data_append"
-            (func $msg_reply_data_append (param i32 i32)))
-        (func $inc
-            ;; Increment a counter.
-            (i32.store
-                (i32.const 0)
-                (i32.add (i32.load (i32.const 0)) (i32.const 1))))
-        (func $read
-            (call $msg_reply_data_append
-                (i32.const 0) ;; the counter from heap[0]
-                (i32.const 4)) ;; length
-            (call $msg_reply))
-        (memory $memory 1)
-        (export "canister_query read" (func $read))
-        (export "canister_heartbeat" (func $inc))
-    )
-"#;
-
-#[test]
-fn test_auto_progress() {
-    let pic = PocketIc::new();
-
-    // Create a canister and charge it with 200T cycles.
-    let can_id = pic.create_canister();
-    pic.add_cycles(can_id, INIT_CYCLES);
-
-    // Install the auto progress canister wasm on the canister.
-    let auto_progress_wasm = wat::parse_str(AUTO_PROGRESS_WAT).unwrap();
-    pic.install_canister(can_id, auto_progress_wasm, vec![], None);
-
-    // Capture the original value of the counter.
-    let old_counter = match pic.query_call(can_id, Principal::anonymous(), "read", vec![]) {
-        Ok(WasmResult::Reply(data)) => u32::from_le_bytes(data.try_into().unwrap()),
-        _ => panic!("could not read counter"),
-    };
-
-    // Starting auto progress on the IC.
-    // Consequently, heartbeats should be executed on the auto progress canister automatically
-    // and its counter should increase.
-    pic.auto_progress();
-
-    let mut ok = false;
-    for _ in 0..100 {
-        let counter = match pic.query_call(can_id, Principal::anonymous(), "read", vec![]) {
-            Ok(WasmResult::Reply(data)) => u32::from_le_bytes(data.try_into().unwrap()),
-            _ => panic!("could not read counter"),
-        };
-        if counter > old_counter {
-            ok = true;
-            break;
-        }
-        thread::sleep(Duration::from_millis(100));
-    }
-    if !ok {
-        panic!("did not observe a counter increase")
-    }
-
-    // Stopping auto progress on the IC.
-    // The counter should not increase anymore.
-    pic.stop_progress();
-
-    // Capture the current value of the counter.
-    let cur_counter = match pic.query_call(can_id, Principal::anonymous(), "read", vec![]) {
-        Ok(WasmResult::Reply(data)) => u32::from_le_bytes(data.try_into().unwrap()),
-        _ => panic!("could not read counter"),
-    };
-
-    for _ in 0..100 {
-        let counter = match pic.query_call(can_id, Principal::anonymous(), "read", vec![]) {
-            Ok(WasmResult::Reply(data)) => u32::from_le_bytes(data.try_into().unwrap()),
-            _ => panic!("could not read counter"),
-        };
-        assert_eq!(counter, cur_counter);
-        thread::sleep(Duration::from_millis(100));
-    }
-}
 
 // Canister code with a very slow method.
 fn very_slow_wasm(n: u64) -> Vec<u8> {

--- a/rs/pocket_ic_server/CHANGELOG.md
+++ b/rs/pocket_ic_server/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and a `bitcoind` process is listening at an address and port specified in an additional argument
   of the endpoint `/instances/` to create a new PocketIC instance.
 - New endpoint `/instances/<instance_id>/_/topology` returning the topology of the PocketIC instance.
+- New CLI option `--log-levels` to specify the log levels for PocketIC server logs (defaults to `pocket_ic_server=info,tower_http=info,axum::rejection=trace`).
 
 ### Fixed
 - Renamed `dfx_test_key1` tECDSA and tSchnorr keys to `dfx_test_key`.
@@ -35,7 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## 6.0.0 - 2024-09-12
 
 ### Added
-- New CLI option `--ip_addr` to specify the IP address at which the PocketIC server should listen (defaults to `127.0.0.1`).
+- New CLI option `--ip-addr` to specify the IP address at which the PocketIC server should listen (defaults to `127.0.0.1`).
 - New argument `ip_addr` of the endpoint `/http_gateway` to specify the IP address at which the HTTP gateway should listen (defaults to `127.0.0.1`).
 - New GET endpoint `/http_gateway` listing all HTTP gateways and their details.
 - Support for query statistics in the management canister.

--- a/rs/pocket_ic_server/tests/test.rs
+++ b/rs/pocket_ic_server/tests/test.rs
@@ -1390,6 +1390,7 @@ fn auto_progress() {
         std::thread::sleep(Duration::from_millis(10));
     }
 
+    // Since the time increased by now, we know that the log should have been recorded.
     let mut bytes = [0; 1000];
     let _ = out.stdout.as_mut().unwrap().read(&mut bytes).unwrap();
     let stdout = String::from_utf8(bytes.to_vec()).unwrap();

--- a/rs/pocket_ic_server/tests/test.rs
+++ b/rs/pocket_ic_server/tests/test.rs
@@ -35,6 +35,7 @@ pub const LOCALHOST: &str = "127.0.0.1";
 
 fn start_server_helper(
     test_driver_pid: Option<u32>,
+    log_levels: Option<String>,
     capture_stdout: bool,
     capture_stderr: bool,
 ) -> (Url, Child) {
@@ -46,6 +47,9 @@ fn start_server_helper(
     };
     let mut cmd = Command::new(PathBuf::from(bin_path));
     cmd.arg("--port-file").arg(port_file_path.clone());
+    if let Some(log_levels) = log_levels {
+        cmd.arg("--log-levels").arg(log_levels);
+    }
     // use a long TTL of 5 mins (the bazel test timeout for medium tests)
     // so that the server doesn't die during the test if the runner
     // is overloaded
@@ -74,7 +78,7 @@ fn start_server_helper(
 
 pub fn start_server() -> Url {
     let test_driver_pid = std::process::id();
-    start_server_helper(Some(test_driver_pid), false, false).0
+    start_server_helper(Some(test_driver_pid), None, false, false).0
 }
 
 #[test]
@@ -200,7 +204,7 @@ fn test_blob_store_wrong_encoding() {
 #[test]
 fn test_port_file() {
     // tests the port file by setting the parent PID to None in start_server_helper
-    start_server_helper(None, false, false);
+    start_server_helper(None, None, false, false);
 }
 
 async fn test_gateway(server_url: Url, https: bool) {
@@ -450,7 +454,7 @@ fn test_specified_id() {
 
 #[test]
 fn test_dashboard() {
-    let (server_url, _) = start_server_helper(None, false, false);
+    let (server_url, _) = start_server_helper(None, None, false, false);
     let mut pic = PocketIcBuilder::new()
         .with_nns_subnet()
         .with_application_subnet()
@@ -517,7 +521,7 @@ const CANISTER_LOGS_WAT: &str = r#"
 #[test]
 fn canister_and_replica_logs() {
     const INIT_CYCLES: u128 = 2_000_000_000_000;
-    let (server_url, mut out) = start_server_helper(None, true, true);
+    let (server_url, mut out) = start_server_helper(None, None, true, true);
     let pic = PocketIcBuilder::new()
         .with_application_subnet()
         .with_server_url(server_url)
@@ -554,7 +558,7 @@ fn canister_and_replica_logs() {
 #[test]
 fn canister_and_no_replica_logs() {
     const INIT_CYCLES: u128 = 2_000_000_000_000;
-    let (server_url, mut out) = start_server_helper(None, true, true);
+    let (server_url, mut out) = start_server_helper(None, None, true, true);
     let pic = PocketIcBuilder::new()
         .with_application_subnet()
         .with_server_url(server_url)
@@ -693,7 +697,7 @@ fn canister_state_dir(shutdown_signal: Option<Signal>) {
     let state_dir_path_buf = state_dir.path().to_path_buf();
 
     // Create a PocketIC instance with NNS and app subnets.
-    let (server_url, child) = start_server_helper(None, false, false);
+    let (server_url, child) = start_server_helper(None, None, false, false);
     let pic = PocketIcBuilder::new()
         .with_state_dir(state_dir_path_buf.clone())
         .with_server_url(server_url)
@@ -769,7 +773,7 @@ fn canister_state_dir(shutdown_signal: Option<Signal>) {
     send_signal_to_pic(pic, child, shutdown_signal);
 
     // Start a new PocketIC server.
-    let (new_server_url, child) = start_server_helper(None, false, false);
+    let (new_server_url, child) = start_server_helper(None, None, false, false);
 
     // Create a PocketIC instance mounting the state created so far.
     let pic = PocketIcBuilder::new()
@@ -810,7 +814,7 @@ fn canister_state_dir(shutdown_signal: Option<Signal>) {
     send_signal_to_pic(pic, child, shutdown_signal);
 
     // Start a new PocketIC server.
-    let (newest_server_url, _) = start_server_helper(None, false, false);
+    let (newest_server_url, _) = start_server_helper(None, None, false, false);
 
     // Create a PocketIC instance mounting the NNS and app state created so far.
     let nns_subnet_seed = topology
@@ -1122,7 +1126,7 @@ fn test_unresponsive_gateway_backend() {
     let client = Client::new();
 
     // Create PocketIC instance with one NNS subnet and one app subnet.
-    let (backend_server_url, mut backend_process) = start_server_helper(None, false, false);
+    let (backend_server_url, mut backend_process) = start_server_helper(None, None, false, false);
     let pic = PocketIcBuilder::new()
         .with_nns_subnet()
         .with_application_subnet()
@@ -1130,7 +1134,7 @@ fn test_unresponsive_gateway_backend() {
         .build();
 
     // Create HTTP gateway on a different gateway server.
-    let (gateway_server_url, _) = start_server_helper(None, false, false);
+    let (gateway_server_url, _) = start_server_helper(None, None, false, false);
     let create_gateway_endpoint = gateway_server_url.join("http_gateway").unwrap();
     let backend_instance_url = backend_server_url
         .join(&format!("instances/{}/", pic.instance_id()))
@@ -1184,7 +1188,7 @@ fn test_unresponsive_gateway_backend() {
 #[test]
 fn test_invalid_gateway_backend() {
     // Create HTTP gateway with an invalid backend URL
-    let (gateway_server_url, _) = start_server_helper(None, false, false);
+    let (gateway_server_url, _) = start_server_helper(None, None, false, false);
     let create_gateway_endpoint = gateway_server_url.join("http_gateway").unwrap();
     let backend_url = "http://240.0.0.0";
     let http_gateway_config = HttpGatewayConfig {
@@ -1358,4 +1362,45 @@ fn http_gateway_route_underscore() {
     assert_eq!(error_page.status(), StatusCode::BAD_REQUEST);
     let page = String::from_utf8(error_page.bytes().unwrap().to_vec()).unwrap();
     assert!(page.contains("canister_id_not_found"));
+}
+
+#[test]
+fn auto_progress() {
+    let (server_url, mut out) = start_server_helper(
+        None,
+        Some("pocket_ic_server=debug,tower_http=info,axum::rejection=trace".to_string()),
+        true,
+        true,
+    );
+    let pic = PocketIcBuilder::new()
+        .with_application_subnet()
+        .with_server_url(server_url)
+        .build();
+
+    let t0 = pic.get_time();
+
+    // Starting auto progress on the IC => a corresponding log should be made and time should start incresing automatically now.
+    pic.auto_progress();
+
+    loop {
+        let t = pic.get_time();
+        if t > t0 {
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(10));
+    }
+
+    let mut bytes = [0; 1000];
+    let _ = out.stdout.as_mut().unwrap().read(&mut bytes).unwrap();
+    let stdout = String::from_utf8(bytes.to_vec()).unwrap();
+    assert!(stdout.contains("Starting auto progress for instance 0."));
+    assert!(!stdout.contains("Stopping auto progress for instance 0."));
+
+    // Stopping auto progress on the IC => a corresponding log should be made.
+    pic.stop_progress();
+
+    let mut bytes = [0; 1000];
+    let _ = out.stdout.as_mut().unwrap().read(&mut bytes).unwrap();
+    let stdout = String::from_utf8(bytes.to_vec()).unwrap();
+    assert!(stdout.contains("Stopping auto progress for instance 0."));
 }


### PR DESCRIPTION
This PR contains the following changes:
- the log levels for PocketIC server logs are configurable via a new CLI option `--log-levels`;
- auto progress mode produces a debug log when starting and stopping;
- PocketIC library tests are simplified by using the test canister and optimized by better controlling the number of executed instructions.