### PR TITLE
test(ICP_ledger): FI-1568: Assume yes for apt install in ICP ledger suite qualification script

### DIFF
--- a/rs/rosetta-api/scripts/run_upgrade_test.sh
+++ b/rs/rosetta-api/scripts/run_upgrade_test.sh
@@ -44,7 +44,7 @@ function check_index() {
     set -e
 }
 
-sudo apt update && sudo apt install sqlite3 containernetworking-plugins
+sudo apt update && sudo apt install -y sqlite3 containernetworking-plugins
 
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
 COMMIT_ID="$1"


### PR DESCRIPTION
Assume yes, i.e., do not wait for user input when installing dependencies using `apt install` in the ICP ledger qualification script.