### PR TITLE
chore: EXC: Reduce stable grow test cases to 10

### DIFF
--- a/rs/embedders/tests/stable_grow.rs
+++ b/rs/embedders/tests/stable_grow.rs
@@ -58,8 +58,7 @@ fn run_memory_grows(grows: &[GrowCommand]) {
 
 #[test]
 fn random_stable_grows() {
-    // The default is 256 cases, but we do half of that to reduce the test time.
-    let config = Config::with_cases(128);
+    let config = Config::with_cases(10);
     let algorithm = config.rng_algorithm;
     let mut runner = TestRunner::new_with_rng(config, TestRng::deterministic_rng(algorithm));
     runner


### PR DESCRIPTION
This reduces the overall test time from ~40s down to ~3s.