### PR TITLE
chore(sns): Remove completed data migration from Swap

### DIFF
--- a/rs/sns/integration_tests/src/golden_state_swap_upgrade_twice.rs
+++ b/rs/sns/integration_tests/src/golden_state_swap_upgrade_twice.rs
@@ -17,7 +17,9 @@ use std::str::FromStr;
 /// in particular, the last time timers were initialized, reset, and executed. Or course, this is
 /// time-sensitive and upgrade-sensitive.
 fn redact_timers(swap_state: &mut GetStateResponse) {
-    swap_state.swap.as_mut().map(|swap| swap.timers = None);
+    if let Some(swap) = swap_state.swap.as_mut() {
+        swap.timers = None
+    }
 }
 
 fn get_state(

--- a/rs/sns/swap/canister/canister.rs
+++ b/rs/sns/swap/canister/canister.rs
@@ -463,9 +463,6 @@ fn canister_post_upgrade() {
     });
 
     init_timers();
-
-    // TODO[NNS1-3386]: Remove once all Swaps are migrated to have these fields populated.
-    swap_mut().migrate_state();
 }
 
 /// Serve an HttpRequest made to this canister

--- a/rs/sns/swap/src/swap.rs
+++ b/rs/sns/swap/src/swap.rs
@@ -1014,32 +1014,6 @@ impl Swap {
     // --- state modifying methods ---------------------------------------------
     //
 
-    // TODO[NNS1-3386]: Remove this function.
-    pub fn migrate_state(&mut self) {
-        if self.direct_participation_icp_e8s.is_none() {
-            let direct_participation_icp_e8s =
-                self.buyers
-                    .values()
-                    .fold(0_u64, |sum_icp_e8s, buyer_state| {
-                        let amount_icp_e8s = buyer_state.amount_icp_e8s();
-                        sum_icp_e8s.saturating_add(amount_icp_e8s)
-                    });
-            self.direct_participation_icp_e8s = Some(direct_participation_icp_e8s);
-        }
-
-        if self.neurons_fund_participation_icp_e8s.is_none() {
-            let neurons_fund_participation_icp_e8s =
-                self.cf_participants
-                    .iter()
-                    .fold(0_u64, |sum_icp_e8s, neurons_fund_participant| {
-                        let participant_total_icp_e8s =
-                            neurons_fund_participant.participant_total_icp_e8s();
-                        sum_icp_e8s.saturating_add(participant_total_icp_e8s)
-                    });
-            self.neurons_fund_participation_icp_e8s = Some(neurons_fund_participation_icp_e8s);
-        }
-    }
-
     /// Runs those tasks that should be run periodically.
     ///
     /// The argument 'now_fn' is a function that returns the current time for bookkeeping


### PR DESCRIPTION
This PR removes the data migration from Swap's post-upgrade, namely, the code that defined `direct_participation_icp_e8s` and `neurons_fund_participation_icp_e8s` based on priorly available data. This migration has been applied to all Swaps existing in production, see https://forum.dfinity.org/t/proposal-to-upgrade-the-oldest-swap-canisters/36318#p-143615-planned-upgrade-order-of-existing-swap-canisters-4