### PR TITLE
feat(cketh/ckerc20): consolidate log scrapings

### DIFF
--- a/rs/ethereum/cketh/minter/cketh_minter.did
+++ b/rs/ethereum/cketh/minter/cketh_minter.did
@@ -201,6 +201,9 @@ type MinterInfo = record {
     // Last scraped block number for logs of the ERC20 helper contract.
     last_erc20_scraped_block_number: opt nat;
 
+    // Last scraped block number for logs of the deposit with subaccount helper contract.
+    last_deposit_with_subaccount_scraped_block_number: opt nat;
+
     // Canister ID of the ckETH ledger.
     cketh_ledger_id: opt principal;
 

--- a/rs/ethereum/cketh/minter/src/dashboard.rs
+++ b/rs/ethereum/cketh/minter/src/dashboard.rs
@@ -12,6 +12,7 @@ use ic_cketh_minter::lifecycle::EthereumNetwork;
 use ic_cketh_minter::numeric::{
     BlockNumber, Erc20Value, LedgerBurnIndex, LedgerMintIndex, LogIndex, TransactionNonce, Wei,
 };
+use ic_cketh_minter::state::eth_logs_scraping::LogScrapingId;
 use ic_cketh_minter::state::transactions::{
     ReimbursedError, ReimbursementIndex, TransactionCallData, WithdrawalRequest,
 };
@@ -325,22 +326,28 @@ impl DashboardTemplate {
                 .map(|addr| addr.to_string())
                 .unwrap_or_default(),
             eth_helper_contract_address: state
-                .eth_log_scraping
-                .contract_address()
+                .log_scrapings
+                .contract_address(LogScrapingId::EthDepositWithoutSubaccount)
                 .map_or("N/A".to_string(), |address| address.to_string()),
             erc20_helper_contract_address: state
-                .erc20_log_scraping
-                .contract_address()
+                .log_scrapings
+                .contract_address(LogScrapingId::Erc20DepositWithoutSubaccount)
                 .map_or("N/A".to_string(), |address| address.to_string()),
             cketh_ledger_id: state.cketh_ledger_id,
             next_transaction_nonce: state.eth_transactions.next_transaction_nonce(),
             minimum_withdrawal_amount: state.cketh_minimum_withdrawal_amount,
             first_synced_block: state.first_scraped_block_number,
-            last_eth_synced_block: state.eth_log_scraping.last_scraped_block_number(),
+            last_eth_synced_block: state
+                .log_scrapings
+                .last_scraped_block_number(LogScrapingId::EthDepositWithoutSubaccount),
             last_erc20_synced_block: state
-                .erc20_log_scraping
-                .contract_address()
-                .map(|_| state.erc20_log_scraping.last_scraped_block_number()),
+                .log_scrapings
+                .contract_address(LogScrapingId::Erc20DepositWithoutSubaccount)
+                .map(|_| {
+                    state
+                        .log_scrapings
+                        .last_scraped_block_number(LogScrapingId::Erc20DepositWithoutSubaccount)
+                }),
             last_observed_block: state.last_observed_block_number,
             minted_events,
             pending_deposits,

--- a/rs/ethereum/cketh/minter/src/dashboard/tests.rs
+++ b/rs/ethereum/cketh/minter/src/dashboard/tests.rs
@@ -12,6 +12,7 @@ use ic_cketh_minter::numeric::{
     TransactionNonce, Wei, WeiPerGas,
 };
 use ic_cketh_minter::state::audit::{apply_state_transition, EventType};
+use ic_cketh_minter::state::eth_logs_scraping::LogScrapingId;
 use ic_cketh_minter::state::transactions::{
     create_transaction, Erc20WithdrawalRequest, EthWithdrawalRequest, ReimbursementIndex,
     Subaccount, WithdrawalRequest,
@@ -27,9 +28,8 @@ use std::str::FromStr;
 
 #[test]
 fn should_display_metadata() {
-    let mut dashboard = DashboardTemplate {
+    let dashboard = DashboardTemplate {
         minter_address: "0x1789F79e95324A47c5Fd6693071188e82E9a3558".to_string(),
-        eth_helper_contract_address: "0xb44B5e756A894775FC32EDdf3314Bb1B1944dC34".to_string(),
         cketh_ledger_id: Principal::from_text("apia6-jaaaa-aaaar-qabma-cai")
             .expect("BUG: invalid principal"),
         ecdsa_key_name: "key_1".to_string(),
@@ -41,8 +41,6 @@ fn should_display_metadata() {
     DashboardAssert::assert_that(dashboard.clone())
         .has_ethereum_network("Ethereum Testnet Sepolia")
         .has_minter_address("0x1789F79e95324A47c5Fd6693071188e82E9a3558")
-        .has_eth_helper_contract_address("0xb44B5e756A894775FC32EDdf3314Bb1B1944dC34")
-        .has_erc20_helper_contract_address("N/A")
         .has_cketh_ledger_canister_id("apia6-jaaaa-aaaar-qabma-cai")
         .has_tecdsa_key_name("key_1")
         .has_next_transaction_nonce("42")
@@ -50,41 +48,30 @@ fn should_display_metadata() {
         .has_eth_balance("0")
         .has_total_effective_tx_fees("0")
         .has_total_unspent_tx_fees("0");
-
-    dashboard.erc20_helper_contract_address =
-        "0xE1788E4834c896F1932188645cc36c54d1b80AC1".to_string();
-    DashboardAssert::assert_that(dashboard.clone())
-        .has_erc20_helper_contract_address("0xE1788E4834c896F1932188645cc36c54d1b80AC1");
 }
 
 #[test]
 fn should_display_block_sync() {
     let dashboard = DashboardTemplate {
         last_observed_block: None,
-        last_eth_synced_block: BlockNumber::from(4552270_u32),
         ..initial_dashboard()
     };
     DashboardAssert::assert_that(dashboard)
         .has_no_elements_matching("#last-observed-block-number")
-        .has_no_elements_matching("#last-erc20-synced-block-number")
-        .has_last_eth_synced_block_href("https://sepolia.etherscan.io/block/4552270")
         .has_first_synced_block_href("https://sepolia.etherscan.io/block/3956207")
         .has_no_elements_matching("#skipped-blocks");
 
     let dashboard = DashboardTemplate {
         last_observed_block: Some(BlockNumber::from(4552271_u32)),
-        last_eth_synced_block: BlockNumber::from(4552270_u32),
-        last_erc20_synced_block: Some(BlockNumber::from(4552269_u32)),
         skipped_blocks: btreemap! {
             "0xb44B5e756A894775FC32EDdf3314Bb1B1944dC34".to_string() => btreeset! {BlockNumber::from(3552270_u32), BlockNumber::from(2552270_u32)},
             "0xE1788E4834c896F1932188645cc36c54d1b80AC1".to_string() => btreeset! {BlockNumber::from(3552370_u32), BlockNumber::from(2552370_u32)},
         },
         ..initial_dashboard()
     };
+
     DashboardAssert::assert_that(dashboard)
         .has_last_observed_block_href("https://sepolia.etherscan.io/block/4552271")
-        .has_last_eth_synced_block_href("https://sepolia.etherscan.io/block/4552270")
-        .has_last_erc20_synced_block_href("https://sepolia.etherscan.io/block/4552269")
         .has_first_synced_block_href("https://sepolia.etherscan.io/block/3956207")
         .has_skipped_blocks(
             "0xb44B5e756A894775FC32EDdf3314Bb1B1944dC34",
@@ -94,6 +81,78 @@ fn should_display_block_sync() {
             "0xE1788E4834c896F1932188645cc36c54d1b80AC1",
             &[2552370, 3552370],
         );
+}
+
+#[test]
+fn should_display_helper_smart_contracts() {
+    let dashboard = initial_dashboard();
+
+    DashboardAssert::assert_that(dashboard.clone())
+        .has_helper_contract(
+            LogScrapingId::EthDepositWithoutSubaccount,
+            "0xb44B5e756A894775FC32EDdf3314Bb1B1944dC34",
+            &format!("https://sepolia.etherscan.io/block/{INITIAL_LAST_SCRAPED_BLOCK_NUMBER}"),
+        )
+        .has_no_helper_contract(LogScrapingId::Erc20DepositWithoutSubaccount)
+        .has_no_helper_contract(LogScrapingId::EthOrErc20DepositWithSubaccount);
+
+    let mut dashboard = dashboard;
+    set_log_scraping(
+        &mut dashboard,
+        LogScrapingId::Erc20DepositWithoutSubaccount,
+        "0xE1788E4834c896F1932188645cc36c54d1b80AC1",
+        4552269,
+    );
+    DashboardAssert::assert_that(dashboard.clone())
+        .has_helper_contract(
+            LogScrapingId::EthDepositWithoutSubaccount,
+            "0xb44B5e756A894775FC32EDdf3314Bb1B1944dC34",
+            &format!("https://sepolia.etherscan.io/block/{INITIAL_LAST_SCRAPED_BLOCK_NUMBER}"),
+        )
+        .has_helper_contract(
+            LogScrapingId::Erc20DepositWithoutSubaccount,
+            "0xE1788E4834c896F1932188645cc36c54d1b80AC1",
+            "https://sepolia.etherscan.io/block/4552269",
+        )
+        .has_no_helper_contract(LogScrapingId::EthOrErc20DepositWithSubaccount);
+
+    set_log_scraping(
+        &mut dashboard,
+        LogScrapingId::EthOrErc20DepositWithSubaccount,
+        "0x2D39863d30716aaf2B7fFFd85Dd03Dda2BFC2E38",
+        4552270,
+    );
+    DashboardAssert::assert_that(dashboard.clone())
+        .has_helper_contract(
+            LogScrapingId::EthDepositWithoutSubaccount,
+            "0xb44B5e756A894775FC32EDdf3314Bb1B1944dC34",
+            &format!("https://sepolia.etherscan.io/block/{INITIAL_LAST_SCRAPED_BLOCK_NUMBER}"),
+        )
+        .has_helper_contract(
+            LogScrapingId::Erc20DepositWithoutSubaccount,
+            "0xE1788E4834c896F1932188645cc36c54d1b80AC1",
+            "https://sepolia.etherscan.io/block/4552269",
+        )
+        .has_helper_contract(
+            LogScrapingId::EthOrErc20DepositWithSubaccount,
+            "0x2D39863d30716aaf2B7fFFd85Dd03Dda2BFC2E38",
+            "https://sepolia.etherscan.io/block/4552270",
+        );
+
+    fn set_log_scraping(
+        dashboard: &mut DashboardTemplate,
+        id: LogScrapingId,
+        contract_address: &str,
+        last_scraped_block_number: u32,
+    ) {
+        dashboard
+            .log_scrapings
+            .set_contract_address(id, contract_address.parse().unwrap())
+            .unwrap();
+        dashboard
+            .log_scrapings
+            .set_last_scraped_block_number(id, BlockNumber::from(last_scraped_block_number));
+    }
 }
 
 #[test]
@@ -946,18 +1005,20 @@ fn initial_dashboard() -> DashboardTemplate {
     DashboardTemplate::from_state(&initial_state())
 }
 
+const INITIAL_LAST_SCRAPED_BLOCK_NUMBER: u32 = 3_956_206_u32;
+
 fn initial_state() -> State {
     use ic_cketh_minter::lifecycle::init::InitArg;
     State::try_from(InitArg {
         ethereum_network: Default::default(),
         ecdsa_key_name: "test_key_1".to_string(),
-        ethereum_contract_address: None,
+        ethereum_contract_address: Some("0xb44B5e756A894775FC32EDdf3314Bb1B1944dC34".to_string()),
         ledger_id: Principal::from_text("apia6-jaaaa-aaaar-qabma-cai")
             .expect("BUG: invalid principal"),
         ethereum_block_height: Default::default(),
         minimum_withdrawal_amount: Nat::from(10_000_000_000_000_000_u64),
         next_transaction_nonce: TransactionNonce::ZERO.into(),
-        last_scraped_block_number: candid::Nat::from(3_956_206_u32),
+        last_scraped_block_number: candid::Nat::from(INITIAL_LAST_SCRAPED_BLOCK_NUMBER),
     })
     .expect("valid init args")
 }
@@ -1181,11 +1242,13 @@ fn ckerc20_withdrawal_flow(
 }
 
 mod assertions {
+    use crate::dashboard::filters::lower_alphanumeric;
     use crate::dashboard::DashboardTemplate;
     use askama::Template;
     use ic_cketh_minter::erc20::CkErc20Token;
-    use scraper::Html;
+    use ic_cketh_minter::state::eth_logs_scraping::LogScrapingId;
     use scraper::Selector;
+    use scraper::{ElementRef, Html};
 
     pub struct DashboardAssert {
         rendered_html: String,
@@ -1227,19 +1290,14 @@ mod assertions {
             )
         }
 
-        pub fn has_last_eth_synced_block_href(&self, expected_href: &str) -> &Self {
+        pub fn has_last_synced_block_href(&self, id: LogScrapingId, expected_href: &str) -> &Self {
             self.has_href_value(
-                "#last-eth-synced-block-number > td > a",
+                &format!(
+                    "#helper-smart-contract-{} > td:nth-child(3) > code > a",
+                    lower_alphanumeric(id).unwrap()
+                ),
                 expected_href,
-                "wrong last ETH synced block href",
-            )
-        }
-
-        pub fn has_last_erc20_synced_block_href(&self, expected_href: &str) -> &Self {
-            self.has_href_value(
-                "#last-erc20-synced-block-number > td > a",
-                expected_href,
-                "wrong last ERC20 synced block href",
+                &format!("wrong last {} synced block href", id),
             )
         }
 
@@ -1296,19 +1354,35 @@ mod assertions {
             )
         }
 
-        pub fn has_eth_helper_contract_address(&self, expected_address: &str) -> &Self {
-            self.has_string_value(
-                "#eth-helper-contract-address > td",
-                expected_address,
-                "wrong ETH helper contract address",
-            )
+        pub fn has_helper_contract(
+            &self,
+            id: LogScrapingId,
+            expected_address: &str,
+            expected_last_synced_block_href: &str,
+        ) -> &Self {
+            self.has_helper_contract_address(id, expected_address)
+                .has_last_synced_block_href(id, expected_last_synced_block_href)
         }
 
-        pub fn has_erc20_helper_contract_address(&self, expected_address: &str) -> &Self {
+        pub fn has_no_helper_contract(&self, id: LogScrapingId) -> &Self {
+            self.has_no_elements_matching(&format!(
+                "#helper-smart-contract-{}",
+                lower_alphanumeric(id).unwrap()
+            ))
+        }
+
+        pub fn has_helper_contract_address(
+            &self,
+            id: LogScrapingId,
+            expected_address: &str,
+        ) -> &Self {
             self.has_string_value(
-                "#erc20-helper-contract-address > td",
+                &format!(
+                    "#helper-smart-contract-{} > td:nth-child(2)",
+                    lower_alphanumeric(id).unwrap()
+                ),
                 expected_address,
-                "wrong ERC20 helper contract address",
+                &format!("wrong {} helper contract address", id),
             )
         }
 
@@ -1463,8 +1537,7 @@ mod assertions {
             expected_value: &Vec<&str>,
             error_msg: &str,
         ) -> &Self {
-            let selector = Selector::parse(selector).unwrap();
-            let actual_value = only_one(&mut self.actual.select(&selector));
+            let actual_value = self.select_only_one(selector);
             let string_value = actual_value
                 .text()
                 .map(|s| s.trim())
@@ -1479,8 +1552,7 @@ mod assertions {
         }
 
         fn has_string_value(&self, selector: &str, expected_value: &str, error_msg: &str) -> &Self {
-            let selector = Selector::parse(selector).unwrap();
-            let actual_value = only_one(&mut self.actual.select(&selector));
+            let actual_value = self.select_only_one(selector);
             let string_value = actual_value.text().collect::<String>();
             assert_eq!(
                 string_value, expected_value,
@@ -1491,8 +1563,7 @@ mod assertions {
         }
 
         fn has_html_value(&self, selector: &str, expected_value: &str, error_msg: &str) -> &Self {
-            let selector = Selector::parse(selector).unwrap();
-            let actual_value = only_one(&mut self.actual.select(&selector));
+            let actual_value = self.select_only_one(selector);
             let string_value = actual_value.inner_html();
             assert_eq!(
                 string_value, expected_value,
@@ -1503,8 +1574,8 @@ mod assertions {
         }
 
         fn has_href_value(&self, selector: &str, expected_href: &str, error_msg: &str) -> &Self {
-            let selector = Selector::parse(selector).unwrap();
-            let actual_href = only_one(&mut self.actual.select(&selector))
+            let actual_href = self
+                .select_only_one(selector)
                 .value()
                 .attr("href")
                 .expect("href not found");
@@ -1515,14 +1586,23 @@ mod assertions {
             );
             self
         }
-    }
 
-    fn only_one<I, T>(iter: &mut I) -> T
-    where
-        I: Iterator<Item = T>,
-    {
-        let value = iter.next().expect("expected one element, got zero");
-        assert!(iter.next().is_none(), "expected one element, got more");
-        value
+        fn select_only_one(&self, selector: &str) -> ElementRef {
+            let css_selector = Selector::parse(selector).unwrap();
+            let mut iter = self.actual.select(&css_selector);
+            let value = iter.next().unwrap_or_else(|| {
+                panic!(
+                    "expected one element for selector '{}', got zero. Rendered html: {}",
+                    selector, self.rendered_html
+                )
+            });
+            assert!(
+                iter.next().is_none(),
+                "expected one element for selector '{}', got more. Rendered html: {}",
+                selector,
+                self.rendered_html
+            );
+            value
+        }
     }
 }

--- a/rs/ethereum/cketh/minter/src/deposit.rs
+++ b/rs/ethereum/cketh/minter/src/deposit.rs
@@ -7,6 +7,7 @@ use crate::eth_rpc_client::{EthRpcClient, MultiCallError};
 use crate::guard::TimerGuard;
 use crate::logs::{DEBUG, INFO};
 use crate::numeric::{BlockNumber, BlockRangeInclusive, LedgerMintIndex};
+use crate::state::eth_logs_scraping::LogScrapingId;
 use crate::state::{
     audit::process_event, event::EventType, mutate_state, read_state, State, TaskType,
 };
@@ -181,7 +182,7 @@ where
             log!(
                 DEBUG,
                 "[scrape_contract_logs]: skipping scraping {} logs: not active",
-                S::display_id()
+                S::ID
             );
             return;
         }
@@ -196,7 +197,7 @@ where
     log!(
         DEBUG,
         "[scrape_contract_logs]: Scraping {} logs in block range {block_range}",
-        S::display_id()
+        S::ID
     );
     let rpc_client = read_state(EthRpcClient::from_state);
     for block_range in block_range.into_chunks(max_block_spread) {
@@ -213,7 +214,7 @@ where
                 log!(
                     INFO,
                     "[scrape_contract_logs]: Failed to scrape {} logs in range {block_range}: {e:?}",
-                    S::display_id()
+                    S::ID
                 );
                 return;
             }
@@ -251,15 +252,11 @@ where
 
         match result {
             Ok((events, errors)) => {
-                register_deposit_events(S::display_id(), events, errors);
+                register_deposit_events(S::ID, events, errors);
                 mutate_state(|s| S::update_last_scraped_block_number(s, to_block));
             }
             Err(e) => {
-                log!(
-                    INFO,
-                    "Failed to get {} logs in range {range}: {e:?}",
-                    S::display_id()
-                );
+                log!(INFO, "Failed to get {} logs in range {range}: {e:?}", S::ID);
                 if e.has_http_outcall_error_matching(HttpOutcallError::is_response_too_large) {
                     if from_block == to_block {
                         mutate_state(|s| {
@@ -290,11 +287,7 @@ where
                         );
                     }
                 } else {
-                    log!(
-                        INFO,
-                        "Failed to get {} logs in range {range}: {e:?}",
-                        S::display_id()
-                    );
+                    log!(INFO, "Failed to get {} logs in range {range}: {e:?}", S::ID);
                     return Err(e);
                 }
             }
@@ -304,21 +297,21 @@ where
 }
 
 pub fn register_deposit_events(
-    scraping_display_name: &str,
+    scraping_id: LogScrapingId,
     transaction_events: Vec<ReceivedEvent>,
     errors: Vec<ReceivedEventError>,
 ) {
     for event in transaction_events {
         log!(
             INFO,
-            "Received event {event:?}; will mint {} {scraping_display_name} to {}",
+            "Received event {event:?}; will mint {} {scraping_id} to {}",
             event.value(),
             event.beneficiary()
         );
         if crate::blocklist::is_blocked(&event.from_address()) {
             log!(
                 INFO,
-                "Received event from a blocked address: {} for {} {scraping_display_name}",
+                "Received event from a blocked address: {} for {} {scraping_id}",
                 event.from_address(),
                 event.value(),
             );

--- a/rs/ethereum/cketh/minter/src/endpoints.rs
+++ b/rs/ethereum/cketh/minter/src/endpoints.rs
@@ -76,6 +76,7 @@ pub struct MinterInfo {
     pub erc20_balances: Option<Vec<Erc20Balance>>,
     pub last_eth_scraped_block_number: Option<Nat>,
     pub last_erc20_scraped_block_number: Option<Nat>,
+    pub last_deposit_with_subaccount_scraped_block_number: Option<Nat>,
     pub cketh_ledger_id: Option<Principal>,
     pub evm_rpc_id: Option<Principal>,
 }

--- a/rs/ethereum/cketh/minter/src/eth_logs/scraping.rs
+++ b/rs/ethereum/cketh/minter/src/eth_logs/scraping.rs
@@ -5,18 +5,34 @@ use crate::eth_logs::{
 };
 use crate::eth_rpc::{FixedSizeData, Topic};
 use crate::numeric::BlockNumber;
+use crate::state::eth_logs_scraping::LogScrapingId;
 use crate::state::State;
 use ic_ethereum_types::Address;
 use std::iter::once;
 
 /// Trait for managing log scraping.
 pub trait LogScraping {
+    /// The unique identifier for this log scraping.
+    const ID: LogScrapingId;
+
     /// The parser type that defines how to parse logs found by this log scraping.
     type Parser: LogParser;
 
     fn next_scrape(state: &State) -> Option<Scrape>;
-    fn update_last_scraped_block_number(state: &mut State, block_number: BlockNumber);
-    fn display_id() -> &'static str;
+
+    fn contract_address(state: &State) -> Option<&Address> {
+        state.log_scrapings.contract_address(Self::ID)
+    }
+
+    fn last_scraped_block_number(state: &State) -> BlockNumber {
+        state.log_scrapings.last_scraped_block_number(Self::ID)
+    }
+
+    fn update_last_scraped_block_number(state: &mut State, block_number: BlockNumber) {
+        state
+            .log_scrapings
+            .set_last_scraped_block_number(Self::ID, block_number);
+    }
 }
 
 #[derive(Clone, PartialEq, Eq, Debug)]
@@ -29,11 +45,12 @@ pub struct Scrape {
 pub enum ReceivedEthLogScraping {}
 
 impl LogScraping for ReceivedEthLogScraping {
+    const ID: LogScrapingId = LogScrapingId::EthDepositWithoutSubaccount;
     type Parser = ReceivedEthLogParser;
 
     fn next_scrape(state: &State) -> Option<Scrape> {
-        let contract_address = *state.eth_log_scraping.contract_address()?;
-        let last_scraped_block_number = state.eth_log_scraping.last_scraped_block_number();
+        let contract_address = *Self::contract_address(state)?;
+        let last_scraped_block_number = Self::last_scraped_block_number(state);
         let topics = vec![Topic::from(FixedSizeData(RECEIVED_ETH_EVENT_TOPIC))];
         Some(Scrape {
             contract_address,
@@ -41,29 +58,20 @@ impl LogScraping for ReceivedEthLogScraping {
             topics,
         })
     }
-
-    fn update_last_scraped_block_number(state: &mut State, block_number: BlockNumber) {
-        state
-            .eth_log_scraping
-            .set_last_scraped_block_number(block_number);
-    }
-
-    fn display_id() -> &'static str {
-        "ETH"
-    }
 }
 
 pub enum ReceivedErc20LogScraping {}
 
 impl LogScraping for ReceivedErc20LogScraping {
+    const ID: LogScrapingId = LogScrapingId::Erc20DepositWithoutSubaccount;
     type Parser = ReceivedErc20LogParser;
 
     fn next_scrape(state: &State) -> Option<Scrape> {
         if state.ckerc20_tokens.is_empty() {
             return None;
         }
-        let contract_address = *state.erc20_log_scraping.contract_address()?;
-        let last_scraped_block_number = state.erc20_log_scraping.last_scraped_block_number();
+        let contract_address = *Self::contract_address(state)?;
+        let last_scraped_block_number = Self::last_scraped_block_number(state);
 
         let mut topics: Vec<_> = vec![Topic::from(FixedSizeData(RECEIVED_ERC20_EVENT_TOPIC))];
         // We add token contract addresses as additional topics to match.
@@ -80,30 +88,17 @@ impl LogScraping for ReceivedErc20LogScraping {
             topics,
         })
     }
-
-    fn update_last_scraped_block_number(state: &mut State, block_number: BlockNumber) {
-        state
-            .erc20_log_scraping
-            .set_last_scraped_block_number(block_number);
-    }
-
-    fn display_id() -> &'static str {
-        "ERC-20"
-    }
 }
 
 pub enum ReceivedEthOrErc20LogScraping {}
 
 impl LogScraping for ReceivedEthOrErc20LogScraping {
+    const ID: LogScrapingId = LogScrapingId::EthOrErc20DepositWithSubaccount;
     type Parser = ReceivedEthOrErc20LogParser;
 
     fn next_scrape(state: &State) -> Option<Scrape> {
-        let contract_address = *state
-            .deposit_with_subaccount_log_scraping
-            .contract_address()?;
-        let last_scraped_block_number = state
-            .deposit_with_subaccount_log_scraping
-            .last_scraped_block_number();
+        let contract_address = *Self::contract_address(state)?;
+        let last_scraped_block_number = Self::last_scraped_block_number(state);
 
         let mut topics: Vec<_> = vec![Topic::from(FixedSizeData(
             RECEIVED_ETH_OR_ERC20_WITH_SUBACCOUNT_EVENT_TOPIC,
@@ -122,16 +117,6 @@ impl LogScraping for ReceivedEthOrErc20LogScraping {
             last_scraped_block_number,
             topics,
         })
-    }
-
-    fn update_last_scraped_block_number(state: &mut State, block_number: BlockNumber) {
-        state
-            .deposit_with_subaccount_log_scraping
-            .set_last_scraped_block_number(block_number);
-    }
-
-    fn display_id() -> &'static str {
-        "ETH or ERC-20 (with subaccount)"
     }
 }
 

--- a/rs/ethereum/cketh/minter/src/eth_logs/tests.rs
+++ b/rs/ethereum/cketh/minter/src/eth_logs/tests.rs
@@ -256,6 +256,7 @@ mod scraping {
         use crate::eth_rpc::{FixedSizeData, Topic};
         use crate::lifecycle::EthereumNetwork;
         use crate::numeric::BlockNumber;
+        use crate::state::eth_logs_scraping::LogScrapingId;
         use crate::test_fixtures::initial_state;
         use hex_literal::hex;
         use ic_ethereum_types::Address;
@@ -276,12 +277,16 @@ mod scraping {
             let state = {
                 let mut state = initial_state();
                 state
-                    .deposit_with_subaccount_log_scraping
-                    .set_contract_address(CONTRACT_ADDRESS)
+                    .log_scrapings
+                    .set_contract_address(
+                        LogScrapingId::EthOrErc20DepositWithSubaccount,
+                        CONTRACT_ADDRESS,
+                    )
                     .unwrap();
-                state
-                    .deposit_with_subaccount_log_scraping
-                    .set_last_scraped_block_number(last_scraped_block_number);
+                state.log_scrapings.set_last_scraped_block_number(
+                    LogScrapingId::EthOrErc20DepositWithSubaccount,
+                    last_scraped_block_number,
+                );
                 state
             };
 

--- a/rs/ethereum/cketh/minter/src/lifecycle/init.rs
+++ b/rs/ethereum/cketh/minter/src/lifecycle/init.rs
@@ -2,7 +2,7 @@ use crate::endpoints::CandidBlockTag;
 use crate::eth_rpc::BlockTag;
 use crate::lifecycle::EthereumNetwork;
 use crate::numeric::{BlockNumber, TransactionNonce, Wei};
-use crate::state::eth_logs_scraping::LogScrapingState;
+use crate::state::eth_logs_scraping::{LogScrapingId, LogScrapings};
 use crate::state::transactions::EthTransactions;
 use crate::state::{InvalidStateError, State};
 use candid::types::number::Nat;
@@ -70,16 +70,14 @@ impl TryFrom<InitArg> for State {
                         "ERROR: last_scraped_block_number is at maximum value".to_string(),
                     )
                 })?;
-        let mut eth_log_scraping = LogScrapingState::new(last_scraped_block_number);
+        let mut log_scrapings = LogScrapings::new(last_scraped_block_number);
         if let Some(contract_address) = eth_helper_contract_address {
-            eth_log_scraping
-                .set_contract_address(contract_address)
+            log_scrapings
+                .set_contract_address(LogScrapingId::EthDepositWithoutSubaccount, contract_address)
                 .map_err(|e| {
                     InvalidStateError::InvalidEthereumContractAddress(format!("ERROR: {:?}", e))
                 })?;
         }
-        let erc20_log_scraping = LogScrapingState::new(last_scraped_block_number);
-        let deposit_with_subaccount_log_scraping = LogScrapingState::new(last_scraped_block_number);
         let state = Self {
             ethereum_network,
             ecdsa_key_name,
@@ -103,9 +101,7 @@ impl TryFrom<InitArg> for State {
             evm_rpc_id: None,
             ckerc20_tokens: Default::default(),
             erc20_balances: Default::default(),
-            eth_log_scraping,
-            erc20_log_scraping,
-            deposit_with_subaccount_log_scraping,
+            log_scrapings,
         };
         state.validate_config()?;
         Ok(state)

--- a/rs/ethereum/cketh/minter/src/lifecycle/tests.rs
+++ b/rs/ethereum/cketh/minter/src/lifecycle/tests.rs
@@ -1,6 +1,7 @@
 mod init {
     use crate::lifecycle::init::InitArg;
     use crate::numeric::{TransactionNonce, Wei};
+    use crate::state::eth_logs_scraping::LogScrapingId;
     use crate::state::{InvalidStateError, State};
     use crate::test_fixtures::valid_init_arg;
     use assert_matches::assert_matches;
@@ -80,7 +81,12 @@ mod init {
 
         assert_eq!(state.ethereum_network, init_arg.ethereum_network);
         assert_eq!(state.ecdsa_key_name, init_arg.ecdsa_key_name);
-        assert_eq!(state.eth_log_scraping.contract_address(), None);
+        assert_eq!(
+            state
+                .log_scrapings
+                .contract_address(LogScrapingId::EthDepositWithoutSubaccount),
+            None
+        );
         assert_eq!(state.cketh_ledger_id, init_arg.ledger_id);
         assert_eq!(
             state.cketh_minimum_withdrawal_amount,

--- a/rs/ethereum/cketh/minter/src/main.rs
+++ b/rs/ethereum/cketh/minter/src/main.rs
@@ -24,6 +24,7 @@ use ic_cketh_minter::logs::INFO;
 use ic_cketh_minter::memo::BurnMemo;
 use ic_cketh_minter::numeric::{Erc20Value, LedgerBurnIndex, Wei};
 use ic_cketh_minter::state::audit::{process_event, Event, EventType};
+use ic_cketh_minter::state::eth_logs_scraping::LogScrapingId;
 use ic_cketh_minter::state::transactions::{
     Erc20WithdrawalRequest, EthWithdrawalRequest, Reimbursed, ReimbursementIndex,
     ReimbursementRequest,
@@ -104,17 +105,21 @@ fn init(arg: MinterArg) {
 
 fn emit_preupgrade_events() {
     read_state(|s| {
-        storage::record_event(EventType::SyncedToBlock {
-            block_number: s.eth_log_scraping.last_scraped_block_number(),
-        });
-        storage::record_event(EventType::SyncedErc20ToBlock {
-            block_number: s.erc20_log_scraping.last_scraped_block_number(),
-        });
-        storage::record_event(EventType::SyncedDepositWithSubaccountToBlock {
-            block_number: s
-                .deposit_with_subaccount_log_scraping
-                .last_scraped_block_number(),
-        });
+        for (id, scraping_state) in s.log_scrapings.iter() {
+            let block_number = scraping_state.last_scraped_block_number();
+            let event = match id {
+                LogScrapingId::EthDepositWithoutSubaccount => {
+                    EventType::SyncedToBlock { block_number }
+                }
+                LogScrapingId::Erc20DepositWithoutSubaccount => {
+                    EventType::SyncedErc20ToBlock { block_number }
+                }
+                LogScrapingId::EthOrErc20DepositWithSubaccount => {
+                    EventType::SyncedDepositWithSubaccountToBlock { block_number }
+                }
+            };
+            storage::record_event(event);
+        }
     });
 }
 
@@ -143,9 +148,13 @@ async fn minter_address() -> String {
 
 #[query]
 async fn smart_contract_address() -> String {
-    read_state(|s| s.eth_log_scraping.contract_address().cloned())
-        .map(|a| a.to_string())
-        .unwrap_or("N/A".to_string())
+    read_state(|s| {
+        s.log_scrapings
+            .contract_address(LogScrapingId::EthDepositWithoutSubaccount)
+            .cloned()
+    })
+    .map(|a| a.to_string())
+    .unwrap_or("N/A".to_string())
 }
 
 /// Estimate price of EIP-1559 transaction based on the
@@ -210,15 +219,17 @@ async fn get_minter_info() -> MinterInfo {
             (None, None)
         };
 
-        let eth_helper_contract_address =
-            s.eth_log_scraping.contract_address().map(|a| a.to_string());
+        let eth_helper_contract_address = s
+            .log_scrapings
+            .contract_address(LogScrapingId::EthDepositWithoutSubaccount)
+            .map(|a| a.to_string());
         MinterInfo {
             minter_address: s.minter_address().map(|a| a.to_string()),
             smart_contract_address: eth_helper_contract_address.clone(),
             eth_helper_contract_address,
             erc20_helper_contract_address: s
-                .erc20_log_scraping
-                .contract_address()
+                .log_scrapings
+                .contract_address(LogScrapingId::Erc20DepositWithoutSubaccount)
                 .map(|a| a.to_string()),
             supported_ckerc20_tokens,
             minimum_withdrawal_amount: Some(s.cketh_minimum_withdrawal_amount.into()),
@@ -234,10 +245,14 @@ async fn get_minter_info() -> MinterInfo {
             ),
             erc20_balances,
             last_eth_scraped_block_number: Some(
-                s.eth_log_scraping.last_scraped_block_number().into(),
+                s.log_scrapings
+                    .last_scraped_block_number(LogScrapingId::EthDepositWithoutSubaccount)
+                    .into(),
             ),
             last_erc20_scraped_block_number: Some(
-                s.erc20_log_scraping.last_scraped_block_number().into(),
+                s.log_scrapings
+                    .last_scraped_block_number(LogScrapingId::Erc20DepositWithoutSubaccount)
+                    .into(),
             ),
             cketh_ledger_id: Some(s.cketh_ledger_id),
             evm_rpc_id: s.evm_rpc_id,
@@ -855,6 +870,18 @@ fn http_request(req: HttpRequest) -> HttpResponse {
     if req.path() == "/metrics" {
         let mut writer = MetricsEncoder::new(vec![], ic_cdk::api::time() as i64 / 1_000_000);
 
+        fn last_processed_block_metric_name(id: &LogScrapingId) -> &'static str {
+            match *id {
+                LogScrapingId::EthDepositWithoutSubaccount => "cketh_minter_last_processed_block",
+                LogScrapingId::Erc20DepositWithoutSubaccount => {
+                    "ckerc20_minter_last_processed_block"
+                }
+                LogScrapingId::EthOrErc20DepositWithSubaccount => {
+                    "subaccount_minter_last_processed_block"
+                }
+            }
+        }
+
         fn encode_metrics(w: &mut MetricsEncoder<Vec<u8>>) -> std::io::Result<()> {
             const WASM_PAGE_SIZE_IN_BYTES: f64 = 65536.0;
 
@@ -885,17 +912,16 @@ fn http_request(req: HttpRequest) -> HttpResponse {
                     "The last Ethereum block the ckETH minter observed.",
                 )?;
 
-                w.encode_gauge(
-                    "cketh_minter_last_processed_block",
-                    s.eth_log_scraping.last_scraped_block_number().as_f64(),
-                    "The last Ethereum block the ckETH minter checked for ckETH deposits.",
-                )?;
-
-                w.encode_gauge(
-                    "ckerc20_minter_last_processed_block",
-                    s.erc20_log_scraping.last_scraped_block_number().as_f64(),
-                    "The last Ethereum block the ckETH minter checked for ckERC20 deposits.",
-                )?;
+                for (id, scraping_state) in s.log_scrapings.iter() {
+                    w.encode_gauge(
+                        last_processed_block_metric_name(id),
+                        scraping_state.last_scraped_block_number().as_f64(),
+                        &format!(
+                            "The last Ethereum block the ckETH minter checked for {} deposits.",
+                            id
+                        ),
+                    )?;
+                }
 
                 w.encode_counter(
                     "cketh_minter_skipped_blocks",

--- a/rs/ethereum/cketh/minter/src/main.rs
+++ b/rs/ethereum/cketh/minter/src/main.rs
@@ -254,6 +254,11 @@ async fn get_minter_info() -> MinterInfo {
                     .last_scraped_block_number(LogScrapingId::Erc20DepositWithoutSubaccount)
                     .into(),
             ),
+            last_deposit_with_subaccount_scraped_block_number: Some(
+                s.log_scrapings
+                    .last_scraped_block_number(LogScrapingId::EthOrErc20DepositWithSubaccount)
+                    .into(),
+            ),
             cketh_ledger_id: Some(s.cketh_ledger_id),
             evm_rpc_id: s.evm_rpc_id,
         }

--- a/rs/ethereum/cketh/minter/src/state/audit.rs
+++ b/rs/ethereum/cketh/minter/src/state/audit.rs
@@ -4,6 +4,8 @@ mod tests;
 pub use super::event::{Event, EventType};
 use super::State;
 use crate::erc20::CkTokenSymbol;
+use crate::state::eth_logs_scraping::LogScrapingId;
+use crate::state::eth_logs_scraping::LogScrapingId::Erc20DepositWithoutSubaccount;
 use crate::state::transactions::{Reimbursed, ReimbursementIndex};
 use crate::storage::{record_event, with_event_iter};
 
@@ -57,14 +59,15 @@ pub fn apply_state_transition(state: &mut State, payload: &EventType) {
             );
         }
         EventType::SyncedToBlock { block_number } => {
-            state
-                .eth_log_scraping
-                .set_last_scraped_block_number(*block_number);
+            state.log_scrapings.set_last_scraped_block_number(
+                LogScrapingId::EthDepositWithoutSubaccount,
+                *block_number,
+            );
         }
         EventType::SyncedErc20ToBlock { block_number } => {
             state
-                .erc20_log_scraping
-                .set_last_scraped_block_number(*block_number);
+                .log_scrapings
+                .set_last_scraped_block_number(Erc20DepositWithoutSubaccount, *block_number);
         }
         EventType::AcceptedEthWithdrawalRequest(request) => {
             state
@@ -157,9 +160,10 @@ pub fn apply_state_transition(state: &mut State, payload: &EventType) {
                 .record_quarantined_reimbursement(index.clone());
         }
         EventType::SyncedDepositWithSubaccountToBlock { block_number } => {
-            state
-                .deposit_with_subaccount_log_scraping
-                .set_last_scraped_block_number(*block_number);
+            state.log_scrapings.set_last_scraped_block_number(
+                LogScrapingId::EthOrErc20DepositWithSubaccount,
+                *block_number,
+            );
         }
     }
 }

--- a/rs/ethereum/cketh/minter/src/state/eth_logs_scraping/mod.rs
+++ b/rs/ethereum/cketh/minter/src/state/eth_logs_scraping/mod.rs
@@ -1,10 +1,11 @@
 use crate::numeric::BlockNumber;
 use ic_ethereum_types::Address;
 use std::collections::BTreeMap;
-use std::fmt::Debug;
+use std::fmt::{Debug, Display, Formatter};
 use strum::IntoEnumIterator;
 use strum_macros::EnumIter;
 
+/// A container to aggregate all log scrapings.
 #[derive(Clone, PartialEq, Debug)]
 pub struct LogScrapings {
     scrapings: BTreeMap<LogScrapingId, LogScrapingState>,
@@ -19,35 +20,39 @@ impl LogScrapings {
         Self { scrapings }
     }
 
+    pub fn iter(&self) -> impl Iterator<Item = (&LogScrapingId, &LogScrapingState)> {
+        self.scrapings.iter()
+    }
+
     pub fn set_contract_address(
         &mut self,
-        id: &LogScrapingId,
+        id: LogScrapingId,
         contract_address: Address,
     ) -> Result<(), LogScrapingStateError> {
         self.get_mut(id).set_contract_address(contract_address)
     }
 
-    pub fn set_last_scraped_block_number(&mut self, id: &LogScrapingId, block_number: BlockNumber) {
+    pub fn set_last_scraped_block_number(&mut self, id: LogScrapingId, block_number: BlockNumber) {
         self.get_mut(id).set_last_scraped_block_number(block_number)
     }
 
-    fn get_mut(&mut self, id: &LogScrapingId) -> &mut LogScrapingState {
+    fn get_mut(&mut self, id: LogScrapingId) -> &mut LogScrapingState {
         self.scrapings
-            .get_mut(id)
+            .get_mut(&id)
             .expect("BUG: LogScrapings should contain all LogScrapingId")
     }
 
-    pub fn last_scraped_block_number(&self, id: &LogScrapingId) -> BlockNumber {
+    pub fn last_scraped_block_number(&self, id: LogScrapingId) -> BlockNumber {
         self.get(id).last_scraped_block_number()
     }
 
-    pub fn contract_address(&self, id: &LogScrapingId) -> Option<&Address> {
+    pub fn contract_address(&self, id: LogScrapingId) -> Option<&Address> {
         self.get(id).contract_address()
     }
 
-    fn get(&self, id: &LogScrapingId) -> &LogScrapingState {
+    fn get(&self, id: LogScrapingId) -> &LogScrapingState {
         self.scrapings
-            .get(id)
+            .get(&id)
             .expect("BUG: LogScrapings should contain all LogScrapingId")
     }
 }
@@ -58,6 +63,18 @@ pub enum LogScrapingId {
     EthDepositWithoutSubaccount,
     Erc20DepositWithoutSubaccount,
     EthOrErc20DepositWithSubaccount,
+}
+
+impl Display for LogScrapingId {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            LogScrapingId::EthDepositWithoutSubaccount => write!(f, "ETH"),
+            LogScrapingId::Erc20DepositWithoutSubaccount => write!(f, "ERC-20"),
+            LogScrapingId::EthOrErc20DepositWithSubaccount => {
+                write!(f, "ETH or ERC-20 (with subaccount)")
+            }
+        }
+    }
 }
 
 #[derive(Clone, PartialEq, Debug)]

--- a/rs/ethereum/cketh/minter/src/state/eth_logs_scraping/mod.rs
+++ b/rs/ethereum/cketh/minter/src/state/eth_logs_scraping/mod.rs
@@ -1,6 +1,64 @@
 use crate::numeric::BlockNumber;
 use ic_ethereum_types::Address;
+use std::collections::BTreeMap;
 use std::fmt::Debug;
+use strum::IntoEnumIterator;
+use strum_macros::EnumIter;
+
+#[derive(Clone, PartialEq, Debug)]
+pub struct LogScrapings {
+    scrapings: BTreeMap<LogScrapingId, LogScrapingState>,
+}
+
+impl LogScrapings {
+    pub fn new(last_scraped_block_number: BlockNumber) -> Self {
+        let mut scrapings = BTreeMap::new();
+        for id in LogScrapingId::iter() {
+            scrapings.insert(id, LogScrapingState::new(last_scraped_block_number));
+        }
+        Self { scrapings }
+    }
+
+    pub fn set_contract_address(
+        &mut self,
+        id: &LogScrapingId,
+        contract_address: Address,
+    ) -> Result<(), LogScrapingStateError> {
+        self.get_mut(id).set_contract_address(contract_address)
+    }
+
+    pub fn set_last_scraped_block_number(&mut self, id: &LogScrapingId, block_number: BlockNumber) {
+        self.get_mut(id).set_last_scraped_block_number(block_number)
+    }
+
+    fn get_mut(&mut self, id: &LogScrapingId) -> &mut LogScrapingState {
+        self.scrapings
+            .get_mut(id)
+            .expect("BUG: LogScrapings should contain all LogScrapingId")
+    }
+
+    pub fn last_scraped_block_number(&self, id: &LogScrapingId) -> BlockNumber {
+        self.get(id).last_scraped_block_number()
+    }
+
+    pub fn contract_address(&self, id: &LogScrapingId) -> Option<&Address> {
+        self.get(id).contract_address()
+    }
+
+    fn get(&self, id: &LogScrapingId) -> &LogScrapingState {
+        self.scrapings
+            .get(id)
+            .expect("BUG: LogScrapings should contain all LogScrapingId")
+    }
+}
+
+#[derive(Clone, PartialEq, Copy, Debug, PartialOrd, Ord, Eq, EnumIter)]
+#[repr(u8)]
+pub enum LogScrapingId {
+    EthDepositWithoutSubaccount,
+    Erc20DepositWithoutSubaccount,
+    EthOrErc20DepositWithSubaccount,
+}
 
 #[derive(Clone, PartialEq, Debug)]
 pub enum LogScrapingStateError {

--- a/rs/ethereum/cketh/minter/templates/dashboard.html
+++ b/rs/ethereum/cketh/minter/templates/dashboard.html
@@ -111,14 +111,6 @@
                         <th>Minter address</th>
                         <td>{% call etherscan_address_link(minter_address) %}</td>
                     </tr>
-                    <tr id="eth-helper-contract-address">
-                        <th>ETH helper contract address</th>
-                        <td>{% call etherscan_address_link(eth_helper_contract_address) %}</td>
-                    </tr>
-                    <tr id="erc20-helper-contract-address">
-                        <th>ERC20 helper contract address</th>
-                        <td>{% call etherscan_address_link(erc20_helper_contract_address) %}</td>
-                    </tr>
                     <tr id="cketh-ledger-canister-id">
                         <th>ckETH ledger canister ID</th>
                         <td><code>{{ cketh_ledger_id }}</code></td>
@@ -166,16 +158,6 @@
                         <td>{% call etherscan_block_link(last_observed_block.unwrap()) %}</td>
                     </tr>
                     {%- endif %}
-                    <tr id="last-eth-synced-block-number">
-                        <th>Last ETH synced block number</th>
-                        <td>{% call etherscan_block_link(last_eth_synced_block) %}</td>
-                    </tr>
-                    {% if last_erc20_synced_block.is_some() -%}
-                    <tr id="last-erc20-synced-block-number">
-                        <th>Last ERC20 synced block number</th>
-                        <td>{% call etherscan_block_link(last_erc20_synced_block.unwrap()) %}</td>
-                    </tr>
-                    {%- endif %}
                     {% if !skipped_blocks.is_empty() -%}
                     {% for (contract_address, blocks) in skipped_blocks -%}
                     <tr id="skipped-blocks-{{ contract_address }}">
@@ -193,6 +175,27 @@
                 </tbody>
             </table>
 
+            <h3 id="helper-smart-contracts">Helper Smart Contracts</h3>
+            <table>
+                <thead>
+                <tr>
+                    <th>Deposit</th>
+                    <th>Address</th>
+                    <th>Last synced block number</th>
+                </tr>
+                </thead>
+                <tbody>
+                {% for (id, scraping_state) in log_scrapings.iter() -%}
+                {% if scraping_state.contract_address().is_some() %}
+                <tr id="helper-smart-contract-{{ id|lower_alphanumeric }}">
+                    <td>{{ id }}</td>
+                    <td>{% call etherscan_address_link(scraping_state.contract_address().unwrap()) %}</td>
+                    <td><code>{% call etherscan_block_link(scraping_state.last_scraped_block_number()) %}</code></td>
+                </tr>
+                {% endif %}
+                {%- endfor %}
+                </tbody>
+            </table>
 
             {% if !supported_ckerc20_tokens.is_empty() %}
             <h3 id="supported-ckerc20-tokens">Supported ckERC20 tokens</h3>

--- a/rs/ethereum/cketh/minter/tests/ckerc20.rs
+++ b/rs/ethereum/cketh/minter/tests/ckerc20.rs
@@ -1545,6 +1545,9 @@ fn should_retrieve_minter_info() {
             erc20_balances: Some(erc20_balances),
             last_eth_scraped_block_number: Some(LAST_SCRAPED_BLOCK_NUMBER_AT_INSTALL.into()),
             last_erc20_scraped_block_number: Some(LAST_SCRAPED_BLOCK_NUMBER_AT_INSTALL.into()),
+            last_deposit_with_subaccount_scraped_block_number: Some(
+                LAST_SCRAPED_BLOCK_NUMBER_AT_INSTALL.into()
+            ),
             cketh_ledger_id: Some(ckerc20.cketh_ledger_id()),
             evm_rpc_id: ckerc20.cketh.evm_rpc_id.map(Principal::from),
         }

--- a/rs/ethereum/cketh/minter/tests/cketh.rs
+++ b/rs/ethereum/cketh/minter/tests/cketh.rs
@@ -1070,6 +1070,9 @@ fn should_retrieve_minter_info() {
             erc20_balances: None,
             last_eth_scraped_block_number: Some(LAST_SCRAPED_BLOCK_NUMBER_AT_INSTALL.into()),
             last_erc20_scraped_block_number: Some(LAST_SCRAPED_BLOCK_NUMBER_AT_INSTALL.into()),
+            last_deposit_with_subaccount_scraped_block_number: Some(
+                LAST_SCRAPED_BLOCK_NUMBER_AT_INSTALL.into()
+            ),
             cketh_ledger_id: Some(cketh.ledger_id.into()),
             evm_rpc_id: cketh.evm_rpc_id.map(Principal::from),
         }


### PR DESCRIPTION
Follow-up on #2324 and #2369 to consolidate log scrapings done by the ckETH minter.

### Added

Information related to the state of the scraping of the new deposit with subaccount helper smart contract:

1. Last scraped block number to `MinterInfo`.
2. State of scraping (address and last scraped block number) to the minter dashboard.
3. Metric for the last scraped block number.

### Changed

Refactor `State` to have a container (`LogScrapings`) to aggregate all log scrapings. This allows to:

1. Automatically display the state of a new log scraping to the minter dashboard. Information related to helper smart contracts was moved to its own section.
2. Automatically add a metric for the last scraped block number.
3. Recall to add an event that is registered during `pre-upgrade` to save the last scraped block number to stable memory.