### PR TITLE
chore: do not use time of next round in tests

### DIFF
--- a/rs/ethereum/cketh/minter/tests/cketh.rs
+++ b/rs/ethereum/cketh/minter/tests/cketh.rs
@@ -37,6 +37,7 @@ use icrc_ledger_types::icrc3::transactions::{Burn, Mint};
 use num_traits::cast::ToPrimitive;
 use serde_json::json;
 use std::str::FromStr;
+use std::time::Duration;
 
 #[test]
 fn should_deposit_and_withdraw() {
@@ -436,10 +437,9 @@ fn should_reimburse() {
     let balance_before_withdrawal = cketh.balance_of(caller);
     assert_eq!(balance_before_withdrawal, withdrawal_amount);
 
-    let time_at_withdrawal = cketh
-        .env
-        .get_time_of_next_round()
-        .as_nanos_since_unix_epoch();
+    // advance time so that time does not grow implicitly when executing a round
+    cketh.env.advance_time(Duration::from_secs(1));
+    let time_at_withdrawal = cketh.env.get_time().as_nanos_since_unix_epoch();
 
     let cketh = cketh
         .call_minter_withdraw_eth(caller, withdrawal_amount.clone(), destination.clone())

--- a/rs/execution_environment/src/execution_environment/tests/canister_task.rs
+++ b/rs/execution_environment/src/execution_environment/tests/canister_task.rs
@@ -226,12 +226,10 @@ fn global_timer_can_be_cancelled() {
         .install_canister(UNIVERSAL_CANISTER_WASM.to_vec(), vec![], None)
         .unwrap();
 
+    // advance time so that time does not grow implicitly when executing a round
+    env.advance_time(Duration::from_secs(1));
     // Setup global timer to increase a global counter
-    let now_nanos = env
-        .time_of_next_round()
-        .duration_since(UNIX_EPOCH)
-        .unwrap()
-        .as_nanos() as u64;
+    let now_nanos = env.time().duration_since(UNIX_EPOCH).unwrap().as_nanos() as u64;
     let set_global_timer = wasm()
         .set_global_timer_method(wasm().inc_global_counter())
         .api_global_timer_set(now_nanos + 3) // set the deadline in three rounds from now
@@ -309,12 +307,10 @@ fn global_timer_is_one_off() {
         .install_canister(UNIVERSAL_CANISTER_WASM.to_vec(), vec![], None)
         .unwrap();
 
+    // advance time so that time does not grow implicitly when executing a round
+    env.advance_time(Duration::from_secs(1));
     // Setup global timer to increase a global counter
-    let now_nanos = env
-        .time_of_next_round()
-        .duration_since(UNIX_EPOCH)
-        .unwrap()
-        .as_nanos() as u64;
+    let now_nanos = env.time().duration_since(UNIX_EPOCH).unwrap().as_nanos() as u64;
     let set_global_timer = wasm()
         .set_global_timer_method(wasm().inc_global_counter())
         .api_global_timer_set(now_nanos + 2) // set the deadline in two rounds from now

--- a/rs/execution_environment/tests/canister_logging.rs
+++ b/rs/execution_environment/tests/canister_logging.rs
@@ -317,7 +317,9 @@ fn test_appending_logs_in_replied_update_call(#[strategy("\\PC*")] message: Stri
             .update("test", wat_fn().debug_print(message.as_bytes()))
             .build_wasm(),
     );
-    let timestamp = system_time_to_nanos(env.time_of_next_round());
+    // advance time so that time does not grow implicitly when executing a round
+    env.advance_time(Duration::from_secs(1));
+    let timestamp = system_time_to_nanos(env.time());
     let _ = env.execute_ingress(canister_id, "test", vec![]);
     let result = fetch_canister_logs(&env, controller, canister_id);
     assert_eq!(
@@ -334,7 +336,9 @@ fn test_appending_logs_in_trapped_update_call(#[strategy("\\PC*")] message: Stri
             .update("test", wat_fn().debug_print(message.as_bytes()).trap())
             .build_wasm(),
     );
-    let timestamp = system_time_to_nanos(env.time_of_next_round());
+    // advance time so that time does not grow implicitly when executing a round
+    env.advance_time(Duration::from_secs(1));
+    let timestamp = system_time_to_nanos(env.time());
     let _ = env.execute_ingress(canister_id, "test", vec![]);
     let result = fetch_canister_logs(&env, controller, canister_id);
     assert_eq!(
@@ -354,7 +358,9 @@ fn test_appending_logs_in_replied_replicated_query_call(#[strategy("\\PC*")] mes
             .query("test", wat_fn().debug_print(message.as_bytes()))
             .build_wasm(),
     );
-    let timestamp = system_time_to_nanos(env.time_of_next_round());
+    // advance time so that time does not grow implicitly when executing a round
+    env.advance_time(Duration::from_secs(1));
+    let timestamp = system_time_to_nanos(env.time());
     let _ = env.execute_ingress(canister_id, "test", vec![]);
     let result = fetch_canister_logs(&env, controller, canister_id);
     assert_eq!(
@@ -371,7 +377,9 @@ fn test_appending_logs_in_trapped_replicated_query_call(#[strategy("\\PC*")] mes
             .query("test", wat_fn().debug_print(message.as_bytes()).trap())
             .build_wasm(),
     );
-    let timestamp = system_time_to_nanos(env.time_of_next_round());
+    // advance time so that time does not grow implicitly when executing a round
+    env.advance_time(Duration::from_secs(1));
+    let timestamp = system_time_to_nanos(env.time());
     let _ = env.execute_ingress(canister_id, "test", vec![]);
     let result = fetch_canister_logs(&env, controller, canister_id);
     assert_eq!(
@@ -400,13 +408,15 @@ fn test_canister_log_record_index_increment_for_different_calls() {
             .build_wasm(),
     );
 
+    // advance time so that time does not grow implicitly when executing a round
+    env.advance_time(Duration::from_secs(1));
     // First call.
-    let timestamp_01 = system_time_to_nanos(env.time_of_next_round());
+    let timestamp_01 = system_time_to_nanos(env.time());
     let _ = env.execute_ingress(canister_id, "test1", vec![]);
 
     // Second call.
     env.advance_time(Duration::from_nanos(123_456));
-    let timestamp_23 = system_time_to_nanos(env.time_of_next_round());
+    let timestamp_23 = system_time_to_nanos(env.time());
     let _ = env.execute_ingress(canister_id, "test2", vec![]);
 
     let result = fetch_canister_logs(&env, controller, canister_id);
@@ -439,8 +449,10 @@ fn test_canister_log_record_index_increment_after_node_restart() {
     );
     env.set_checkpoints_enabled(true);
 
+    // advance time so that time does not grow implicitly when executing a round
+    env.advance_time(Duration::from_secs(1));
     // First call.
-    let timestamp_01 = system_time_to_nanos(env.time_of_next_round());
+    let timestamp_01 = system_time_to_nanos(env.time());
     let _ = env.execute_ingress(canister_id, "test1", vec![]);
 
     // Node restart.
@@ -448,7 +460,7 @@ fn test_canister_log_record_index_increment_after_node_restart() {
     env.advance_time(Duration::from_nanos(123_456));
 
     // Second call.
-    let timestamp_23 = system_time_to_nanos(env.time_of_next_round());
+    let timestamp_23 = system_time_to_nanos(env.time());
     let _ = env.execute_ingress(canister_id, "test2", vec![]);
 
     let result = fetch_canister_logs(&env, controller, canister_id);
@@ -470,8 +482,10 @@ fn test_logging_in_trapped_wasm_execution() {
             .update("test", wat_fn().stable_grow(1).stable_read(0, 70_000))
             .build_wasm(),
     );
+    // advance time so that time does not grow implicitly when executing a round
+    env.advance_time(Duration::from_secs(1));
     // Grow stable memory by 1 page (64kb), reading outside of the page should trap.
-    let timestamp = system_time_to_nanos(env.time_of_next_round());
+    let timestamp = system_time_to_nanos(env.time());
     let _ = env.execute_ingress(canister_id, "test", vec![]);
     let result = fetch_canister_logs(&env, controller, canister_id);
     assert_eq!(
@@ -488,7 +502,9 @@ fn test_logging_in_trapped_wasm_execution() {
 fn test_logging_explicit_canister_trap_without_message() {
     let (env, canister_id, controller) =
         setup_with_controller(wat_canister().update("test", wat_fn().trap()).build_wasm());
-    let timestamp = system_time_to_nanos(env.time_of_next_round());
+    // advance time so that time does not grow implicitly when executing a round
+    env.advance_time(Duration::from_secs(1));
+    let timestamp = system_time_to_nanos(env.time());
     let _ = env.execute_ingress(canister_id, "test", vec![]);
     let result = fetch_canister_logs(&env, controller, canister_id);
     assert_eq!(
@@ -504,7 +520,9 @@ fn test_logging_explicit_canister_trap_with_message() {
             .update("test", wat_fn().trap_with_blob(b"some text"))
             .build_wasm(),
     );
-    let timestamp = system_time_to_nanos(env.time_of_next_round());
+    // advance time so that time does not grow implicitly when executing a round
+    env.advance_time(Duration::from_secs(1));
+    let timestamp = system_time_to_nanos(env.time());
     let _ = env.execute_ingress(canister_id, "test", vec![]);
     let result = fetch_canister_logs(&env, controller, canister_id);
     assert_eq!(
@@ -626,7 +644,7 @@ fn test_deleting_logs_on_reinstall() {
     env.advance_time(TIME_STEP);
 
     // Prepopulate log.
-    let timestamp_1_update = system_time_to_nanos(env.time_of_next_round());
+    let timestamp_1_update = system_time_to_nanos(env.time());
     let _ = env.execute_ingress(canister_id, "test_1", vec![]);
     env.advance_time(TIME_STEP);
 
@@ -656,7 +674,7 @@ fn test_deleting_logs_on_reinstall() {
     env.advance_time(TIME_STEP);
 
     // Populate log after reinstall.
-    let timestamp_2_update = system_time_to_nanos(env.time_of_next_round());
+    let timestamp_2_update = system_time_to_nanos(env.time());
     let _ = env.execute_ingress(canister_id, "test_2", vec![]);
     env.advance_time(TIME_STEP);
 
@@ -682,7 +700,7 @@ fn test_deleting_logs_on_uninstall() {
     env.advance_time(TIME_STEP);
 
     // Prepopulate log.
-    let timestamp_1_update = system_time_to_nanos(env.time_of_next_round());
+    let timestamp_1_update = system_time_to_nanos(env.time());
     let _ = env.execute_ingress(canister_id, "test_1", vec![]);
     env.advance_time(TIME_STEP);
 
@@ -732,12 +750,12 @@ fn test_logging_debug_print_persists_over_upgrade() {
     env.advance_time(TIME_STEP);
 
     // Pre-populate log.
-    let timestamp_before_upgrade = system_time_to_nanos(env.time_of_next_round());
+    let timestamp_before_upgrade = system_time_to_nanos(env.time());
     let _ = env.execute_ingress(canister_id, "test", vec![]);
     env.advance_time(TIME_STEP);
 
     // Upgrade canister.
-    let timestamp_upgrade = system_time_to_nanos(env.time_of_next_round());
+    let timestamp_upgrade = system_time_to_nanos(env.time());
     let _ = env.upgrade_canister(
         canister_id,
         wat_canister()
@@ -751,7 +769,7 @@ fn test_logging_debug_print_persists_over_upgrade() {
     );
     env.advance_time(TIME_STEP);
 
-    let timestamp_after_upgrade = system_time_to_nanos(env.time_of_next_round());
+    let timestamp_after_upgrade = system_time_to_nanos(env.time());
     let _ = env.execute_ingress(canister_id, "test", vec![]);
     env.advance_time(TIME_STEP);
 
@@ -781,7 +799,7 @@ fn test_logging_trap_at_install_start() {
     env.advance_time(TIME_STEP);
 
     // Install canister with a trap in the start function.
-    let timestamp_install = system_time_to_nanos(env.time_of_next_round());
+    let timestamp_install = system_time_to_nanos(env.time());
     let result = env.install_wasm_in_mode(
         canister_id,
         CanisterInstallMode::Install,
@@ -814,7 +832,7 @@ fn test_logging_trap_at_install_init() {
     env.advance_time(TIME_STEP);
 
     // Install canister with a trap in the init function.
-    let timestamp_install = system_time_to_nanos(env.time_of_next_round());
+    let timestamp_install = system_time_to_nanos(env.time());
     let result = env.install_wasm_in_mode(
         canister_id,
         CanisterInstallMode::Install,
@@ -857,12 +875,12 @@ fn test_logging_trap_in_pre_upgrade() {
     env.advance_time(TIME_STEP);
 
     // Pre-populate log.
-    let timestamp_before_upgrade = system_time_to_nanos(env.time_of_next_round());
+    let timestamp_before_upgrade = system_time_to_nanos(env.time());
     let _ = env.execute_ingress(canister_id, "test", vec![]);
     env.advance_time(TIME_STEP);
 
     // Upgrade canister.
-    let timestamp_upgrade = system_time_to_nanos(env.time_of_next_round());
+    let timestamp_upgrade = system_time_to_nanos(env.time());
     let result = env.upgrade_canister(
         canister_id,
         wat_canister()
@@ -879,7 +897,7 @@ fn test_logging_trap_in_pre_upgrade() {
     env.advance_time(TIME_STEP);
 
     // Populate log after failed upgrade.
-    let timestamp_after_upgrade = system_time_to_nanos(env.time_of_next_round());
+    let timestamp_after_upgrade = system_time_to_nanos(env.time());
     let _ = env.execute_ingress(canister_id, "test", vec![]);
     env.advance_time(TIME_STEP);
 
@@ -914,12 +932,12 @@ fn test_logging_trap_after_upgrade_in_start() {
     env.advance_time(TIME_STEP);
 
     // Pre-populate log.
-    let timestamp_before_upgrade = system_time_to_nanos(env.time_of_next_round());
+    let timestamp_before_upgrade = system_time_to_nanos(env.time());
     let _ = env.execute_ingress(canister_id, "test", vec![]);
     env.advance_time(TIME_STEP);
 
     // Upgrade canister.
-    let timestamp_upgrade = system_time_to_nanos(env.time_of_next_round());
+    let timestamp_upgrade = system_time_to_nanos(env.time());
     let result = env.upgrade_canister(
         canister_id,
         wat_canister()
@@ -936,7 +954,7 @@ fn test_logging_trap_after_upgrade_in_start() {
     env.advance_time(TIME_STEP);
 
     // Populate log after failed upgrade.
-    let timestamp_after_upgrade = system_time_to_nanos(env.time_of_next_round());
+    let timestamp_after_upgrade = system_time_to_nanos(env.time());
     let _ = env.execute_ingress(canister_id, "test", vec![]);
     env.advance_time(TIME_STEP);
 
@@ -972,12 +990,12 @@ fn test_logging_trap_after_upgrade_in_post_upgrade() {
     env.advance_time(TIME_STEP);
 
     // Pre-populate log.
-    let timestamp_before_upgrade = system_time_to_nanos(env.time_of_next_round());
+    let timestamp_before_upgrade = system_time_to_nanos(env.time());
     let _ = env.execute_ingress(canister_id, "test", vec![]);
     env.advance_time(TIME_STEP);
 
     // Upgrade canister.
-    let timestamp_upgrade = system_time_to_nanos(env.time_of_next_round());
+    let timestamp_upgrade = system_time_to_nanos(env.time());
     let result = env.upgrade_canister(
         canister_id,
         wat_canister()
@@ -998,7 +1016,7 @@ fn test_logging_trap_after_upgrade_in_post_upgrade() {
     env.advance_time(TIME_STEP);
 
     // Populate log after failed upgrade.
-    let timestamp_after_upgrade = system_time_to_nanos(env.time_of_next_round());
+    let timestamp_after_upgrade = system_time_to_nanos(env.time());
     let _ = env.execute_ingress(canister_id, "test", vec![]);
     env.advance_time(TIME_STEP);
 
@@ -1042,7 +1060,9 @@ fn test_logging_debug_print_over_dts() {
             .build_wasm(),
     );
 
-    let timestamp = system_time_to_nanos(env.time_of_next_round());
+    // advance time so that time does not grow implicitly when executing a round
+    env.advance_time(Duration::from_secs(1));
+    let timestamp = system_time_to_nanos(env.time());
     // Slice #0 is processed inside `send_ingress` in round #0.
     let _msg_id = env.send_ingress(PrincipalId::new_anonymous(), canister_id, "test", vec![]);
     // Since one slice was processed in `send_ingress` iterate over one slice less.
@@ -1093,7 +1113,9 @@ fn test_logging_trap_over_dts() {
             .build_wasm(),
     );
 
-    let timestamp = system_time_to_nanos(env.time_of_next_round());
+    // advance time so that time does not grow implicitly when executing a round
+    env.advance_time(Duration::from_secs(1));
+    let timestamp = system_time_to_nanos(env.time());
     // Slice #0 is processed inside `send_ingress` in round #0.
     let _msg_id = env.send_ingress(PrincipalId::new_anonymous(), canister_id, "test", vec![]);
     // Since one slice was processed in `send_ingress` iterate over one slice less.
@@ -1186,8 +1208,10 @@ fn test_logging_of_long_running_dts_over_checkpoint() {
         canister_log_response(vec![])
     );
 
+    // advance time so that time does not grow implicitly when executing a round
+    env.advance_time(Duration::from_secs(1));
     // Rounds #B0 and further: Afther the checkpoint process the message again through all the slices.
-    let timestamp_after_checkpoint = system_time_to_nanos(env.time_of_next_round());
+    let timestamp_after_checkpoint = system_time_to_nanos(env.time());
     for i in 0..number_of_slices {
         let result = fetch_canister_logs(&env, controller, canister_id);
         assert_eq!(
@@ -1200,7 +1224,7 @@ fn test_logging_of_long_running_dts_over_checkpoint() {
         env.advance_time(TIME_STEP);
     }
     // Round to process short message.
-    let timestamp_short = system_time_to_nanos(env.time_of_next_round());
+    let timestamp_short = system_time_to_nanos(env.time());
     env.tick();
     env.advance_time(TIME_STEP);
 
@@ -1248,7 +1272,9 @@ fn test_canister_log_on_reply() {
     let (env, canister_id, controller) = setup_with_controller(UNIVERSAL_CANISTER_WASM.to_vec());
 
     let instructions_per_slice = MAX_INSTRUCTIONS_PER_SLICE.get();
-    let timestamp_init = system_time_to_nanos(env.time_of_next_round());
+    // advance time so that time does not grow implicitly when executing a round
+    env.advance_time(Duration::from_secs(1));
+    let timestamp_init = system_time_to_nanos(env.time());
     let _ = env.execute_ingress(
         canister_id,
         "update",
@@ -1302,7 +1328,9 @@ fn test_canister_log_on_cleanup() {
     // Test that the log is recorded inside cleanup callback.
     let (env, canister_id, controller) = setup_with_controller(UNIVERSAL_CANISTER_WASM.to_vec());
 
-    let timestamp_init = system_time_to_nanos(env.time_of_next_round());
+    // advance time so that time does not grow implicitly when executing a round
+    env.advance_time(Duration::from_secs(1));
+    let timestamp_init = system_time_to_nanos(env.time());
     let instructions_per_slice = MAX_INSTRUCTIONS_PER_SLICE.get();
     let _ = env.execute_ingress(
         canister_id,

--- a/rs/execution_environment/tests/dts.rs
+++ b/rs/execution_environment/tests/dts.rs
@@ -1745,7 +1745,9 @@ fn dts_ingress_status_of_update_is_correct() {
         .install_canister_with_cycles(binary, vec![], None, INITIAL_CYCLES_BALANCE)
         .unwrap();
 
-    let original_time = env.time_of_next_round();
+    // advance time so that time does not grow implicitly when executing a round
+    env.advance_time(Duration::from_secs(1));
+    let original_time = env.time();
     let update = env.send_ingress(user_id, canister, "update", vec![]);
 
     env.tick();
@@ -1815,7 +1817,9 @@ fn dts_ingress_status_of_install_is_correct() {
         .install_canister_with_cycles(binary.clone(), vec![], None, INITIAL_CYCLES_BALANCE)
         .unwrap();
 
-    let original_time = env.time_of_next_round();
+    // advance time so that time does not grow implicitly when executing a round
+    env.advance_time(Duration::from_secs(1));
+    let original_time = env.time();
 
     let install = {
         let args = InstallCodeArgs::new(
@@ -1896,7 +1900,9 @@ fn dts_ingress_status_of_upgrade_is_correct() {
         .install_canister_with_cycles(binary.clone(), vec![], None, INITIAL_CYCLES_BALANCE)
         .unwrap();
 
-    let original_time = env.time_of_next_round();
+    // advance time so that time does not grow implicitly when executing a round
+    env.advance_time(Duration::from_secs(1));
+    let original_time = env.time();
 
     let install = {
         let args = InstallCodeArgs::new(
@@ -1996,7 +2002,9 @@ fn dts_ingress_status_of_update_with_call_is_correct() {
         .inter_update(b_id, call_args().other_side(b))
         .build();
 
-    let original_time = env.time_of_next_round();
+    // advance time so that time does not grow implicitly when executing a round
+    env.advance_time(Duration::from_secs(1));
+    let original_time = env.time();
     let update = env.send_ingress(user_id, a_id, "update", a);
 
     env.tick();

--- a/rs/ledger_suite/icp/index/tests/tests.rs
+++ b/rs/ledger_suite/icp/index/tests/tests.rs
@@ -592,7 +592,9 @@ fn test_ledger_index_icrc1_mint_parity() {
     let minter_account = Account::from(MINTER_PRINCIPAL.0);
     let recipient_account = account(4, 0);
     let recipient_account_identifier = AccountIdentifier::from(recipient_account);
-    let created_at_time = TimeStamp::from(setup.env.time_of_next_round());
+    // advance time so that time does not grow implicitly when executing a round
+    setup.env.advance_time(Duration::from_secs(1));
+    let created_at_time = TimeStamp::from(setup.env.time());
     let mint_block_index = icrc1_transfer(
         &setup.env,
         setup.ledger_id,
@@ -633,8 +635,10 @@ fn test_ledger_index_icrc1_mint_parity() {
 fn test_ledger_index_icrc1_transfer_parity() {
     // Set up an environment with a ledger, and index, and a single mint transaction
     let setup = ParitySetup::new();
+    // advance time so that time does not grow implicitly when executing a round
+    setup.env.advance_time(Duration::from_secs(1));
     // Create an ICRC1 Transfer transaction with all fields set
-    let tx_timestamp = TimeStamp::from(setup.env.time_of_next_round());
+    let tx_timestamp = TimeStamp::from(setup.env.time());
     let tx_block_index = icrc1_transfer(
         &setup.env,
         setup.ledger_id,
@@ -678,8 +682,10 @@ fn test_ledger_index_icrc1_transfer_parity() {
 fn test_ledger_index_icrc1_transfer_without_created_at_time_parity() {
     // Set up an environment with a ledger, and index, and a single mint transaction
     let setup = ParitySetup::new();
+    // advance time so that time does not grow implicitly when executing a round
+    setup.env.advance_time(Duration::from_secs(1));
     // Create an ICRC1 Transfer transaction with all fields set
-    let tx_timestamp = TimeStamp::from(setup.env.time_of_next_round());
+    let tx_timestamp = TimeStamp::from(setup.env.time());
     let tx_block_index = icrc1_transfer(
         &setup.env,
         setup.ledger_id,
@@ -723,8 +729,10 @@ fn test_ledger_index_icrc1_transfer_without_created_at_time_parity() {
 fn test_ledger_index_icrc1_approve_parity() {
     // Set up an environment with a ledger, and index, and a single mint transaction
     let setup = ParitySetup::new();
+    // advance time so that time does not grow implicitly when executing a round
+    setup.env.advance_time(Duration::from_secs(1));
     // Create an ICRC1 Approve transaction with all fields set
-    let tx_timestamp = TimeStamp::from(setup.env.time_of_next_round());
+    let tx_timestamp = TimeStamp::from(setup.env.time());
     let expires_at = tx_timestamp.as_nanos_since_unix_epoch() + 3600 * 1_000_000_000;
     let tx_block_index = approve(
         &setup.env,
@@ -775,8 +783,10 @@ fn test_ledger_index_icrc1_approve_parity() {
 fn test_ledger_index_icrc1_transfer_from_parity() {
     // Set up an environment with a ledger, and index, and a single mint transaction
     let setup = ParitySetup::new();
+    // advance time so that time does not grow implicitly when executing a round
+    setup.env.advance_time(Duration::from_secs(1));
     // Create an ICRC1 Approve transaction with all fields set
-    let tx_timestamp = TimeStamp::from(setup.env.time_of_next_round());
+    let tx_timestamp = TimeStamp::from(setup.env.time());
     let expires_at = tx_timestamp.as_nanos_since_unix_epoch() + 3600 * 1_000_000_000;
     let tx_block_index = approve(
         &setup.env,
@@ -794,9 +804,11 @@ fn test_ledger_index_icrc1_transfer_from_parity() {
         .expires_at(Some(expires_at)),
     );
     assert_eq!(tx_block_index, Nat::from(1u8));
+    // advance time so that time does not grow implicitly when executing a round
+    setup.env.advance_time(Duration::from_secs(1));
     // Create an ICRC2 TransferFrom transaction with all fields set, based on the previously
     // executed ICRC1 Approve transaction
-    let tx_timestamp = TimeStamp::from(setup.env.time_of_next_round());
+    let tx_timestamp = TimeStamp::from(setup.env.time());
     let tx_block_index = icrc2_transfer_from(
         &setup.env,
         setup.ledger_id,
@@ -1185,7 +1197,9 @@ fn test_get_account_transactions_start_length() {
     let env = &StateMachine::new();
     let ledger_id = install_ledger(env, initial_balances, default_archive_options());
     let index_id = install_index(env, ledger_id);
-    let time = env.time_of_next_round();
+    // advance time so that time does not grow implicitly when executing a round
+    env.advance_time(Duration::from_secs(1));
+    let time = env.time();
     for i in 0..10 {
         transfer(
             env,
@@ -1254,7 +1268,9 @@ fn test_get_account_identifier_transactions_pagination() {
     let env = &StateMachine::new();
     let ledger_id = install_ledger(env, initial_balances, default_archive_options());
     let index_id = install_index(env, ledger_id);
-    let time = env.time_of_next_round();
+    // advance time so that time does not grow implicitly when executing a round
+    env.advance_time(Duration::from_secs(1));
+    let time = env.time();
     for i in 0..10 {
         transfer(
             env,

--- a/rs/ledger_suite/icp/ledger/tests/tests.rs
+++ b/rs/ledger_suite/icp/ledger/tests/tests.rs
@@ -1588,17 +1588,25 @@ fn test_query_archived_blocks() {
     let user1 = Principal::from_slice(&[1]);
     let user2 = Principal::from_slice(&[2]);
 
+    // advance time so that time does not grow implicitly when executing a round
+    env.advance_time(Duration::from_secs(1));
     // mint block
-    let mint_time = system_time_to_nanos(env.time_of_next_round());
+    let mint_time = system_time_to_nanos(env.time());
     transfer(&env, ledger, MINTER, user1, 2_000_000_000).unwrap();
+    // advance time so that time does not grow implicitly when executing a round
+    env.advance_time(Duration::from_secs(1));
     // burn block
-    let burn_time = system_time_to_nanos(env.time_of_next_round());
+    let burn_time = system_time_to_nanos(env.time());
     transfer(&env, ledger, user1, MINTER, 1_000_000_000).unwrap();
+    // advance time so that time does not grow implicitly when executing a round
+    env.advance_time(Duration::from_secs(1));
     // xfer block
-    let xfer_time = system_time_to_nanos(env.time_of_next_round());
+    let xfer_time = system_time_to_nanos(env.time());
     transfer(&env, ledger, user1, user2, 100_000_000).unwrap();
+    // advance time so that time does not grow implicitly when executing a round
+    env.advance_time(Duration::from_secs(1));
     // approve block
-    let approve_time = system_time_to_nanos(env.time_of_next_round());
+    let approve_time = system_time_to_nanos(env.time());
     send_approval(
         &env,
         ledger,

--- a/rs/ledger_suite/tests/sm-tests/src/lib.rs
+++ b/rs/ledger_suite/tests/sm-tests/src/lib.rs
@@ -1443,7 +1443,9 @@ where
         vec![(Account::from(p1.0), 10_000_000)],
     );
 
-    let now = system_time_to_nanos(env.time_of_next_round());
+    // advance time so that time does not grow implicitly when executing a round
+    env.advance_time(Duration::from_secs(1));
+    let now = system_time_to_nanos(env.time());
     let tx_window = TX_WINDOW.as_nanos() as u64;
 
     assert_eq!(
@@ -1463,7 +1465,9 @@ where
         )
     );
 
-    let now = system_time_to_nanos(env.time_of_next_round());
+    // advance time so that time does not grow implicitly when executing a round
+    env.advance_time(Duration::from_secs(1));
+    let now = system_time_to_nanos(env.time());
 
     assert_eq!(
         Err(TransferError::CreatedInFuture { ledger_time: now }),

--- a/rs/state_machine_tests/src/lib.rs
+++ b/rs/state_machine_tests/src/lib.rs
@@ -2430,7 +2430,7 @@ impl StateMachine {
     /// Returns the state machine time at the beginning of next round
     /// under the assumption that time won't be advanced before that
     /// round is finalized.
-    pub fn time_of_next_round(&self) -> SystemTime {
+    fn time_of_next_round(&self) -> SystemTime {
         let time = self.time();
         if time == *self.time_of_last_round.read().unwrap() {
             time + Self::EXECUTE_ROUND_TIME_INCREMENT
@@ -2450,7 +2450,7 @@ impl StateMachine {
     }
 
     /// Returns the state machine time at the beginning of next round.
-    pub fn get_time_of_next_round(&self) -> Time {
+    fn get_time_of_next_round(&self) -> Time {
         Time::from_nanos_since_unix_epoch(
             self.time_of_next_round()
                 .duration_since(SystemTime::UNIX_EPOCH)

--- a/rs/state_machine_tests/src/lib.rs
+++ b/rs/state_machine_tests/src/lib.rs
@@ -2296,6 +2296,12 @@ impl StateMachine {
         let requires_full_state_hash =
             batch_number.get() % checkpoint_interval_length_plus_one == 0;
 
+        let time_of_next_round = Time::from_nanos_since_unix_epoch(
+            self.time_of_next_round()
+                .duration_since(SystemTime::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos() as u64,
+        );
         let batch = Batch {
             batch_number,
             batch_summary,
@@ -2313,7 +2319,7 @@ impl StateMachine {
             idkg_subnet_public_keys: self.idkg_subnet_public_keys.clone(),
             idkg_pre_signature_ids: BTreeMap::new(),
             registry_version: self.registry_client.get_latest_version(),
-            time: self.get_time_of_next_round(),
+            time: time_of_next_round,
             consensus_responses: payload.consensus_responses,
             blockmaker_metrics: BlockmakerMetrics::new_for_test(),
             replica_version: ReplicaVersion::default(),
@@ -2334,9 +2340,8 @@ impl StateMachine {
 
         self.check_critical_errors();
 
-        let time_of_next_round = self.time_of_next_round();
-        self.set_time(time_of_next_round);
-        *self.time_of_last_round.write().unwrap() = time_of_next_round;
+        self.set_time(time_of_next_round.into());
+        *self.time_of_last_round.write().unwrap() = time_of_next_round.into();
 
         batch_number
     }
@@ -2443,16 +2448,6 @@ impl StateMachine {
     pub fn get_time(&self) -> Time {
         Time::from_nanos_since_unix_epoch(
             self.time()
-                .duration_since(SystemTime::UNIX_EPOCH)
-                .unwrap()
-                .as_nanos() as u64,
-        )
-    }
-
-    /// Returns the state machine time at the beginning of next round.
-    fn get_time_of_next_round(&self) -> Time {
-        Time::from_nanos_since_unix_epoch(
-            self.time_of_next_round()
                 .duration_since(SystemTime::UNIX_EPOCH)
                 .unwrap()
                 .as_nanos() as u64,


### PR DESCRIPTION
This PR avoids querying the time of next round in tests by advancing time so that time does not grow implicitly when executing a round. The motivation for this change is to clean up the StateMachine test API.