### PR TITLE
fix: test flakiness due to auto progress logs

### DIFF
--- a/rs/pocket_ic_server/tests/test.rs
+++ b/rs/pocket_ic_server/tests/test.rs
@@ -1383,6 +1383,16 @@ fn auto_progress() {
     pic.auto_progress();
 
     loop {
+        let mut bytes = [0; 1000];
+        let _ = out.stdout.as_mut().unwrap().read(&mut bytes).unwrap();
+        let stdout = String::from_utf8(bytes.to_vec()).unwrap();
+        assert!(!stdout.contains("Stopping auto progress for instance 0."));
+        if stdout.contains("Starting auto progress for instance 0.") {
+            break;
+        }
+    }
+
+    loop {
         let t = pic.get_time();
         if t > t0 {
             break;
@@ -1390,18 +1400,15 @@ fn auto_progress() {
         std::thread::sleep(Duration::from_millis(10));
     }
 
-    // Since the time increased by now, we know that the log should have been recorded.
-    let mut bytes = [0; 1000];
-    let _ = out.stdout.as_mut().unwrap().read(&mut bytes).unwrap();
-    let stdout = String::from_utf8(bytes.to_vec()).unwrap();
-    assert!(stdout.contains("Starting auto progress for instance 0."));
-    assert!(!stdout.contains("Stopping auto progress for instance 0."));
-
     // Stopping auto progress on the IC => a corresponding log should be made.
     pic.stop_progress();
 
-    let mut bytes = [0; 1000];
-    let _ = out.stdout.as_mut().unwrap().read(&mut bytes).unwrap();
-    let stdout = String::from_utf8(bytes.to_vec()).unwrap();
-    assert!(stdout.contains("Stopping auto progress for instance 0."));
+    loop {
+        let mut bytes = [0; 1000];
+        let _ = out.stdout.as_mut().unwrap().read(&mut bytes).unwrap();
+        let stdout = String::from_utf8(bytes.to_vec()).unwrap();
+        if stdout.contains("Stopping auto progress for instance 0.") {
+            break;
+        }
+    }
 }


### PR DESCRIPTION
This PR fixes PocketIC test [flakiness](https://dash.zh1-idx1.dfinity.network/invocation/3afbf11a-8204-4602-86f5-22bfe8452b55?target=%2F%2Frs%2Fpocket_ic_server%3Atest&targetStatus=6#@228) due to auto progress logs.