### PR TITLE
feat(proposal_cli): FI-1571: Do not write the args.hex file from proposal-cli

### DIFF
--- a/rs/cross-chain/proposal-cli/src/candid/mod.rs
+++ b/rs/cross-chain/proposal-cli/src/candid/mod.rs
@@ -22,10 +22,6 @@ impl UpgradeArgs {
         &self.encoded_upgrade_args
     }
 
-    pub fn upgrade_args_hex(&self) -> String {
-        hex::encode(&self.encoded_upgrade_args)
-    }
-
     pub fn args_sha256_hex(&self) -> String {
         self.args_sha256.to_string()
     }

--- a/rs/cross-chain/proposal-cli/src/candid/tests.rs
+++ b/rs/cross-chain/proposal-cli/src/candid/tests.rs
@@ -14,7 +14,7 @@ fn should_encode_default_upgrade_args() {
         let upgrade_args = encode_upgrade_args(&path, canister.default_upgrade_args());
 
         assert_eq!(
-            upgrade_args.upgrade_args_hex(),
+            hex::encode(upgrade_args.upgrade_args_bin()),
             expected,
             "failed to encode default upgrade args for: {:?}",
             canister
@@ -29,7 +29,10 @@ fn should_encode_non_empty_ledger_upgrade_args() {
 
     let upgrade_args = encode_upgrade_args(&path, "(variant {Upgrade})");
 
-    assert_matches!(upgrade_args.upgrade_args_hex(), _string);
+    assert_matches!(
+        hex::encode(upgrade_args.upgrade_args_bin()).as_str(),
+        "4449444c1e6b02fcb88b840301b0ced18403186e026c0992cdb6f902039efeb9a40309f2c794ae030aefcee780040b8484d5c0070585f199f40710b0d7c3920b1591c9aafe0d09bea3d1c30f166e046c089ea581d20105b2a7c2d20305a495a5e90605ffb08aab0806e0ab86ef0805e4d8cce80b0593c8e6c70c05dec5d8ae0e086e786e076d686e686e716e7d6e0c6d0d6c020071010e6b04cf89df017cc189ee017dfdd2c9df020fcdf1cbbe03716d7b6e116b029d83f46a12c9c5f1d0037f6c02b3b0dac30368ad86ca8305136e146d7b6e7a6e176c01c7bfe7b60b7e6c0dc295a99301199efeb9a40371f2c794ae037defcee780040caecbeb880412b2a4dab2051a97aabdbb06058484d5c0070582babe82081ca1e5f7a10a1db0d7c3920b1591c9aafe0d71bea3d1c30f166e7b6d1b6c020012017d6e126c089ea581d20178b2a7c2d20305a495a5e90678ffb08aab0806e0ab86ef0805e4d8cce80b0593c8e6c70c05dec5d8ae0e6801000000"
+    );
 }
 
 #[test]

--- a/rs/cross-chain/proposal-cli/src/candid/tests.rs
+++ b/rs/cross-chain/proposal-cli/src/candid/tests.rs
@@ -29,10 +29,7 @@ fn should_encode_non_empty_ledger_upgrade_args() {
 
     let upgrade_args = encode_upgrade_args(&path, "(variant {Upgrade})");
 
-    assert_matches!(
-        hex::encode(upgrade_args.upgrade_args_bin()).as_str(),
-        "4449444c1e6b02fcb88b840301b0ced18403186e026c0992cdb6f902039efeb9a40309f2c794ae030aefcee780040b8484d5c0070585f199f40710b0d7c3920b1591c9aafe0d09bea3d1c30f166e046c089ea581d20105b2a7c2d20305a495a5e90605ffb08aab0806e0ab86ef0805e4d8cce80b0593c8e6c70c05dec5d8ae0e086e786e076d686e686e716e7d6e0c6d0d6c020071010e6b04cf89df017cc189ee017dfdd2c9df020fcdf1cbbe03716d7b6e116b029d83f46a12c9c5f1d0037f6c02b3b0dac30368ad86ca8305136e146d7b6e7a6e176c01c7bfe7b60b7e6c0dc295a99301199efeb9a40371f2c794ae037defcee780040caecbeb880412b2a4dab2051a97aabdbb06058484d5c0070582babe82081ca1e5f7a10a1db0d7c3920b1591c9aafe0d71bea3d1c30f166e7b6d1b6c020012017d6e126c089ea581d20178b2a7c2d20305a495a5e90678ffb08aab0806e0ab86ef0805e4d8cce80b0593c8e6c70c05dec5d8ae0e6801000000"
-    );
+    assert!(hex::encode(upgrade_args.upgrade_args_bin()).starts_with("4449444c"));
 }
 
 #[test]

--- a/rs/cross-chain/proposal-cli/src/main.rs
+++ b/rs/cross-chain/proposal-cli/src/main.rs
@@ -214,15 +214,6 @@ fn write_to_disk<P: Into<ProposalTemplate>>(
         bin_args_file_path.display()
     );
 
-    let hex_args_file_path = output_dir.join("args.hex");
-    let mut args_file = fs::File::create(&hex_args_file_path)
-        .unwrap_or_else(|_| panic!("failed to create {:?}", hex_args_file_path));
-    proposal.write_hex_args(&mut args_file);
-    println!(
-        "Hexadecimal upgrade args written to '{}'",
-        hex_args_file_path.display()
-    );
-
     let artifact = output_dir.join(proposal.target_canister().artifact_file_name());
     ic_repo.copy_file(&proposal.target_canister().artifact(), &artifact);
     println!("Artifact written to '{}'", artifact.display());

--- a/rs/cross-chain/proposal-cli/src/proposal/mod.rs
+++ b/rs/cross-chain/proposal-cli/src/proposal/mod.rs
@@ -53,16 +53,6 @@ impl ProposalTemplate {
             .expect("failed to write binary args");
     }
 
-    pub fn write_hex_args<W: Write>(&self, writer: &mut W) {
-        let hex_args = match self {
-            ProposalTemplate::Upgrade(template) => template.upgrade_args.upgrade_args_hex(),
-            ProposalTemplate::Install(template) => template.install_args.upgrade_args_hex(),
-        };
-        writer
-            .write_all(hex_args.as_bytes())
-            .expect("failed to write hex args");
-    }
-
     pub fn args_sha256_hex(&self) -> String {
         match self {
             ProposalTemplate::Upgrade(template) => template.upgrade_args.args_sha256_hex(),


### PR DESCRIPTION
To avoid potential confusion for reviewers of proposals generated using the `proposal-cli` before they are submitted, do not write the `args.hex` file to disk.