### PR TITLE
refactor(governance): NeuronSections no longer implements default.

### DIFF
--- a/rs/nns/governance/src/neuron_store.rs
+++ b/rs/nns/governance/src/neuron_store.rs
@@ -963,7 +963,7 @@ impl NeuronStore {
                     process_neuron(neuron.as_ref());
                 }
             },
-            NeuronSections::default(),
+            NeuronSections::ALL,
         );
 
         (ballots, deciding_voting_power, potential_voting_power)

--- a/rs/nns/governance/src/neuron_store.rs
+++ b/rs/nns/governance/src/neuron_store.rs
@@ -722,7 +722,7 @@ impl NeuronStore {
         &self,
         neuron_id: NeuronId,
     ) -> Result<(Cow<Neuron>, StorageLocation), NeuronStoreError> {
-        self.load_neuron_with_sections(neuron_id, NeuronSections::all())
+        self.load_neuron_with_sections(neuron_id, NeuronSections::ALL)
     }
 
     fn update_neuron(
@@ -809,7 +809,7 @@ impl NeuronStore {
         &self,
         callback: impl for<'b> FnOnce(Box<dyn Iterator<Item = Cow<Neuron>> + 'b>) -> R,
     ) -> R {
-        self.with_active_neurons_iter_sections(callback, NeuronSections::all())
+        self.with_active_neurons_iter_sections(callback, NeuronSections::ALL)
     }
 
     fn with_active_neurons_iter_sections<R>(
@@ -1006,7 +1006,7 @@ impl NeuronStore {
             &neuron_id,
             NeuronSections {
                 hot_keys: true,
-                ..Default::default()
+                ..NeuronSections::NONE
             },
             |neuron| neuron.is_authorized_to_vote(&principal_id),
         )

--- a/rs/nns/governance/src/storage/neurons.rs
+++ b/rs/nns/governance/src/storage/neurons.rs
@@ -46,7 +46,7 @@ pub(crate) struct StableNeuronStoreBuilder<Memory> {
 
 /// A section of a neuron represents a part of neuron that can potentially be large, and when a
 /// neuron is read, the caller can specify which sections of the neuron they want to read.
-#[derive(Copy, Clone, Eq, PartialEq, Debug, Default)]
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
 pub(crate) struct NeuronSections {
     pub hot_keys: bool,
     pub recent_ballots: bool,

--- a/rs/nns/governance/src/storage/neurons.rs
+++ b/rs/nns/governance/src/storage/neurons.rs
@@ -56,15 +56,21 @@ pub(crate) struct NeuronSections {
 }
 
 impl NeuronSections {
-    pub fn all() -> Self {
-        Self {
-            hot_keys: true,
-            recent_ballots: true,
-            followees: true,
-            known_neuron_data: true,
-            transfer: true,
-        }
-    }
+    pub const NONE: Self = Self {
+        hot_keys: false,
+        recent_ballots: false,
+        followees: false,
+        known_neuron_data: false,
+        transfer: false,
+    };
+
+    pub const ALL: Self = Self {
+        hot_keys: true,
+        recent_ballots: true,
+        followees: true,
+        known_neuron_data: true,
+        transfer: true,
+    };
 }
 
 impl<Memory> StableNeuronStoreBuilder<Memory>
@@ -397,7 +403,7 @@ where
     where
         R: RangeBounds<NeuronId> + Clone,
     {
-        self.range_neurons_sections(range, NeuronSections::all())
+        self.range_neurons_sections(range, NeuronSections::ALL)
     }
 
     /// Returns the next neuron_id equal to or higher than the provided neuron_id

--- a/rs/nns/governance/src/storage/neurons/neurons_tests.rs
+++ b/rs/nns/governance/src/storage/neurons/neurons_tests.rs
@@ -720,7 +720,7 @@ fn test_register_recent_neuron_ballot_migration_full() {
 
     store.create(neuron.clone()).unwrap();
 
-    let retrieved_neuron = store.read(neuron.id(), NeuronSections::all()).unwrap();
+    let retrieved_neuron = store.read(neuron.id(), NeuronSections::ALL).unwrap();
     assert_eq!(retrieved_neuron, neuron);
 
     store
@@ -742,7 +742,7 @@ fn test_register_recent_neuron_ballot_migration_full() {
         recent_ballots
     };
 
-    let retrieved_neuron = store.read(neuron.id(), NeuronSections::all()).unwrap();
+    let retrieved_neuron = store.read(neuron.id(), NeuronSections::ALL).unwrap();
     assert_eq!(retrieved_neuron.recent_ballots, expected_updated_ballots);
     assert_eq!(retrieved_neuron.recent_ballots_next_entry_index, Some(1));
 
@@ -760,7 +760,7 @@ fn test_register_recent_neuron_ballot_migration_full() {
         proposal_id: Some(ProposalId { id: 101 }),
         vote: Vote::Yes as i32,
     };
-    let retrieved_neuron = store.read(neuron.id(), NeuronSections::all()).unwrap();
+    let retrieved_neuron = store.read(neuron.id(), NeuronSections::ALL).unwrap();
     assert_eq!(retrieved_neuron.recent_ballots, expected_updated_ballots);
     assert_eq!(retrieved_neuron.recent_ballots_next_entry_index, Some(2));
 }
@@ -783,7 +783,7 @@ fn test_register_recent_neuron_ballot_migration_notfull() {
 
     store.create(neuron.clone()).unwrap();
 
-    let retrieved_neuron = store.read(neuron.id(), NeuronSections::all()).unwrap();
+    let retrieved_neuron = store.read(neuron.id(), NeuronSections::ALL).unwrap();
     assert_eq!(retrieved_neuron, neuron);
 
     store
@@ -805,7 +805,7 @@ fn test_register_recent_neuron_ballot_migration_notfull() {
         recent_ballots
     };
 
-    let retrieved_neuron = store.read(neuron.id(), NeuronSections::all()).unwrap();
+    let retrieved_neuron = store.read(neuron.id(), NeuronSections::ALL).unwrap();
     assert_eq!(retrieved_neuron.recent_ballots, expected_updated_ballots);
     assert_eq!(retrieved_neuron.recent_ballots_next_entry_index, Some(21));
 
@@ -823,7 +823,7 @@ fn test_register_recent_neuron_ballot_migration_notfull() {
         proposal_id: Some(ProposalId { id: 101 }),
         vote: Vote::Yes as i32,
     });
-    let retrieved_neuron = store.read(neuron.id(), NeuronSections::all()).unwrap();
+    let retrieved_neuron = store.read(neuron.id(), NeuronSections::ALL).unwrap();
     assert_eq!(retrieved_neuron.recent_ballots, expected_updated_ballots);
     assert_eq!(retrieved_neuron.recent_ballots_next_entry_index, Some(22));
 }

--- a/rs/nns/governance/src/storage/neurons/neurons_tests.rs
+++ b/rs/nns/governance/src/storage/neurons/neurons_tests.rs
@@ -193,7 +193,7 @@ fn test_store_simplest_nontrivial_case() {
     );
 
     // 4. Bad read: Unknown NeuronId. This should result in a NotFound Err.
-    let bad_read_result = store.read(NeuronId { id: 0xDEAD_BEEF }, NeuronSections::default());
+    let bad_read_result = store.read(NeuronId { id: 0xDEAD_BEEF }, NeuronSections::NONE);
     match &bad_read_result {
         Err(err) => match err {
             NeuronStoreError::NeuronNotFound { neuron_id } => {
@@ -278,7 +278,7 @@ fn test_store_simplest_nontrivial_case() {
     assert_that_red_herring_neurons_are_untouched(&store);
 
     // 8. Read to verify bad update.
-    let read_result = store.read(NeuronId { id: 0xDEAD_BEEF }, NeuronSections::default());
+    let read_result = store.read(NeuronId { id: 0xDEAD_BEEF }, NeuronSections::NONE);
     match &read_result {
         // This is what we expected.
         Err(err) => {
@@ -330,7 +330,7 @@ fn test_store_simplest_nontrivial_case() {
     assert_that_red_herring_neurons_are_untouched(&store);
 
     // 13. Read to verify delete.
-    let read_result = store.read(NeuronId { id: 42 }, NeuronSections::default());
+    let read_result = store.read(NeuronId { id: 42 }, NeuronSections::NONE);
     match &read_result {
         // This is what we expected.
         Err(err) => {
@@ -455,27 +455,27 @@ fn test_partial_read() {
         }
     };
 
-    partial_read_test_helper(NeuronSections::default());
+    partial_read_test_helper(NeuronSections::NONE);
     partial_read_test_helper(NeuronSections::ALL);
     partial_read_test_helper(NeuronSections {
         hot_keys: true,
-        ..NeuronSections::default()
+        ..NeuronSections::NONE
     });
     partial_read_test_helper(NeuronSections {
         followees: true,
-        ..NeuronSections::default()
+        ..NeuronSections::NONE
     });
     partial_read_test_helper(NeuronSections {
         recent_ballots: true,
-        ..NeuronSections::default()
+        ..NeuronSections::NONE
     });
     partial_read_test_helper(NeuronSections {
         known_neuron_data: true,
-        ..NeuronSections::default()
+        ..NeuronSections::NONE
     });
     partial_read_test_helper(NeuronSections {
         transfer: true,
-        ..NeuronSections::default()
+        ..NeuronSections::NONE
     });
 }
 


### PR DESCRIPTION
Instead, callers should use either NeruonSections::ALL or NeuronSections::NONE. It is very easy for a caller to think NeuronSections::default() is equivalent to ALL, when **_actually_**, it's equivalent to NONE. Whereas, it is basically impossible to misunderstand what ALL and NONE do.

# History of This Pull Request

Earlier, this PR tried to add support for sections to neuron range. But Max developed that independently/concurrently, and he was able to merge first. Therefore, the main change that I was originally trying to do has been removed from this PR. What remains is

1. Additional tests
2. `NeuronSections::ALL`, a constant that replaces `NeuronsSections::all` (an `fn`).
3. Added `NeuronSections::NONE`.

In terms of interface, the difference between what I did vs. what Max merged is that I figured that there should be one range_neurons method, which should additionally take NeuronSections; whereas, he created range_neurons_sections.

His interface also seems reasonable. I think my "1 range_neurons to rule them all" approach has various advantages, the main one being that it minimizes API surface area.

# References

[👈 Previous PR][prev] | [Next PR 👉][next]

[prev]: https://github.com/dfinity/ic/pull/2385
[next]: https://github.com/dfinity/ic/pull/2471