### PR TITLE
chore(nns): add feature flag for stable following index

### DIFF
--- a/rs/nns/governance/src/lib.rs
+++ b/rs/nns/governance/src/lib.rs
@@ -131,6 +131,7 @@ use crate::{
     },
 };
 use candid::DecoderConfig;
+#[cfg(any(test, feature = "canbench-rs", feature = "test"))]
 use ic_nervous_system_temporary::Temporary;
 use mockall::automock;
 use std::{
@@ -140,7 +141,7 @@ use std::{
     time::{Duration, SystemTime},
 };
 
-#[cfg(test)]
+#[cfg(any(test, feature = "canbench-rs"))]
 pub mod test_utils;
 
 mod account_id_index;
@@ -203,7 +204,9 @@ thread_local! {
 
     static ARE_SET_VISIBILITY_PROPOSALS_ENABLED: Cell<bool> = const { Cell::new(true) };
 
-    static ACTIVE_NEURONS_IN_STABLE_MEMORY_ENABLED: Cell<bool> = const { Cell::new(false) };
+    static ACTIVE_NEURONS_IN_STABLE_MEMORY_ENABLED: Cell<bool> = const { Cell::new(cfg!(feature = "test")) };
+
+    static USE_STABLE_MEMORY_FOLLOWING_INDEX: Cell<bool> = const { Cell::new(cfg!(feature = "test")) };
 }
 
 pub fn is_voting_power_adjustment_enabled() -> bool {
@@ -211,11 +214,13 @@ pub fn is_voting_power_adjustment_enabled() -> bool {
 }
 
 /// Only integration tests should use this.
+#[cfg(any(test, feature = "canbench-rs", feature = "test"))]
 pub fn temporarily_enable_voting_power_adjustment() -> Temporary {
     Temporary::new(&IS_VOTING_POWER_ADJUSTMENT_ENABLED, true)
 }
 
 /// Only integration tests should use this.
+#[cfg(any(test, feature = "canbench-rs", feature = "test"))]
 pub fn temporarily_disable_voting_power_adjustment() -> Temporary {
     Temporary::new(&IS_VOTING_POWER_ADJUSTMENT_ENABLED, false)
 }
@@ -225,11 +230,13 @@ pub fn is_private_neuron_enforcement_enabled() -> bool {
 }
 
 /// Only integration tests should use this.
+#[cfg(any(test, feature = "canbench-rs", feature = "test"))]
 pub fn temporarily_enable_private_neuron_enforcement() -> Temporary {
     Temporary::new(&IS_PRIVATE_NEURON_ENFORCEMENT_ENABLED, true)
 }
 
 /// Only integration tests should use this.
+#[cfg(any(test, feature = "canbench-rs", feature = "test"))]
 pub fn temporarily_disable_private_neuron_enforcement() -> Temporary {
     Temporary::new(&IS_PRIVATE_NEURON_ENFORCEMENT_ENABLED, false)
 }
@@ -239,11 +246,13 @@ pub fn are_set_visibility_proposals_enabled() -> bool {
 }
 
 /// Only integration tests should use this.
+#[cfg(any(test, feature = "canbench-rs", feature = "test"))]
 pub fn temporarily_enable_set_visibility_proposals() -> Temporary {
     Temporary::new(&ARE_SET_VISIBILITY_PROPOSALS_ENABLED, true)
 }
 
 /// Only integration tests should use this.
+#[cfg(any(test, feature = "canbench-rs", feature = "test"))]
 pub fn temporarily_disable_set_visibility_proposals() -> Temporary {
     Temporary::new(&ARE_SET_VISIBILITY_PROPOSALS_ENABLED, false)
 }
@@ -253,13 +262,31 @@ pub fn is_active_neurons_in_stable_memory_enabled() -> bool {
 }
 
 /// Only integration tests should use this.
+#[cfg(any(test, feature = "canbench-rs", feature = "test"))]
 pub fn temporarily_enable_active_neurons_in_stable_memory() -> Temporary {
     Temporary::new(&ACTIVE_NEURONS_IN_STABLE_MEMORY_ENABLED, true)
 }
 
 /// Only integration tests should use this.
+#[cfg(any(test, feature = "canbench-rs", feature = "test"))]
 pub fn temporarily_disable_active_neurons_in_stable_memory() -> Temporary {
     Temporary::new(&ACTIVE_NEURONS_IN_STABLE_MEMORY_ENABLED, false)
+}
+
+pub fn use_stable_memory_following_index() -> bool {
+    USE_STABLE_MEMORY_FOLLOWING_INDEX.with(|ok| ok.get())
+}
+
+/// Only integration tests should use this.
+#[cfg(any(test, feature = "canbench-rs", feature = "test"))]
+pub fn temporarily_enable_stable_memory_following_index() -> Temporary {
+    Temporary::new(&USE_STABLE_MEMORY_FOLLOWING_INDEX, true)
+}
+
+/// Only integration tests should use this.
+#[cfg(any(test, feature = "canbench-rs", feature = "test"))]
+pub fn temporarily_disable_stable_memory_following_index() -> Temporary {
+    Temporary::new(&USE_STABLE_MEMORY_FOLLOWING_INDEX, false)
 }
 
 pub fn decoder_config() -> DecoderConfig {

--- a/rs/nns/governance/src/test_utils.rs
+++ b/rs/nns/governance/src/test_utils.rs
@@ -1,3 +1,6 @@
+// This allow(dead_code) is necessary because some parts of this file
+// are not used in canbench-rs, but are used elsewhere.  Otherwise we get annoying clippy warnings.
+#![allow(dead_code)]
 use crate::{
     governance::{Environment, HeapGrowthPotential, RngError},
     pb::v1::{ExecuteNnsFunction, GovernanceError, OpenSnsTokenSwap},


### PR DESCRIPTION
This PR adds a new feature flag that will be used to keep stable neurons support behind a feature flag until it is completed and the migration is ready to proceed.

Next PR: https://github.com/dfinity/ic/pull/2473