### PR TITLE
[DO NOT MERGE] 2 MB pages for the wasm heap

### DIFF
--- a/rs/config/src/execution_environment.rs
+++ b/rs/config/src/execution_environment.rs
@@ -145,7 +145,7 @@ pub const MAX_CANISTER_HTTP_REQUESTS_IN_FLIGHT: usize = 3000;
 /// - existing canisters will get their field initialized as follows:
 ///   - let `halfway_to_max = (memory_usage + 4GiB) / 2`
 ///   - use the maximum of `default_wasm_memory_limit` and `halfway_to_max`.
-pub const DEFAULT_WASM_MEMORY_LIMIT: NumBytes = NumBytes::new(3 * GIB);
+pub const DEFAULT_WASM_MEMORY_LIMIT: NumBytes = NumBytes::new(12 * GIB);
 
 #[derive(Clone, Eq, PartialEq, Debug, Deserialize, Serialize)]
 #[serde(default)]

--- a/rs/embedders/src/wasm_executor.rs
+++ b/rs/embedders/src/wasm_executor.rs
@@ -647,7 +647,9 @@ pub fn process(
     // Execute Wasm code until it finishes or exceeds the message instruction
     // limit. With deterministic time slicing, this call may execute multiple
     // slices before it returns.
+    let time_now = std::time::Instant::now();
     let run_result = instance.run(func_ref);
+    println!("Execution time: {:?}", time_now.elapsed());
 
     // Get the executed/remaining instructions for the message and the slice.
     let instruction_counter = instance.instruction_counter();
@@ -670,6 +672,7 @@ pub fn process(
         .min(message_instruction_limit);
     let message_instructions_left = message_instruction_limit - message_instructions_executed;
 
+    let copy_time = std::time::Instant::now();
     // In case the message dirtied too many pages, as a performance optimization we will
     // yield the control to the replica and then resume copying dirty pages in a new execution slice.
     let num_dirty_pages = if let Ok(ref res) = run_result {
@@ -805,6 +808,7 @@ pub fn process(
             None
         }
     };
+    println!("Dirty page copy time: {:?}", copy_time.elapsed());
 
     // If the dirty page optimization slicing has been performed, we know the dirty page copying
     // was a heavy operation, therefore we take into account its overhead in number of instructions

--- a/rs/embedders/src/wasmtime_embedder/host_memory.rs
+++ b/rs/embedders/src/wasmtime_embedder/host_memory.rs
@@ -12,8 +12,8 @@ use ic_sys::PAGE_SIZE;
 use ic_types::MAX_STABLE_MEMORY_IN_BYTES;
 use libc::c_void;
 use libc::MAP_FAILED;
-use libc::{mmap, munmap};
-use libc::{MAP_ANON, MAP_PRIVATE, PROT_NONE};
+use libc::{madvise, mmap, munmap};
+use libc::{MADV_HUGEPAGE, MAP_ANON, MAP_PRIVATE, PROT_NONE};
 use wasmtime::{LinearMemory, MemoryType};
 use wasmtime_environ::WASM32_MAX_SIZE;
 
@@ -177,6 +177,10 @@ impl MmapMemory {
         let wasm_memory =
             unsafe { (start as *mut u8).add(prologue_guard_size_in_bytes) as *mut c_void };
 
+        unsafe {
+            madvise(start, size_in_bytes, MADV_HUGEPAGE);
+        }
+        //println!("we madvised {} bytes", size_in_bytes);
         Self {
             start,
             size_in_bytes,

--- a/rs/memory_tracker/src/lib.rs
+++ b/rs/memory_tracker/src/lib.rs
@@ -231,7 +231,7 @@ impl SigsegvMemoryTracker {
         dirty_page_tracking: DirtyPageTracking,
         page_map: PageMap,
     ) -> nix::Result<Self> {
-        assert_eq!(ic_sys::sysconf_page_size(), PAGE_SIZE);
+        //assert_eq!(ic_sys::sysconf_page_size(), PAGE_SIZE);
         let num_pages = size / PAGE_SIZE;
         debug!(
             log,

--- a/rs/sys/src/lib.rs
+++ b/rs/sys/src/lib.rs
@@ -14,7 +14,7 @@ lazy_static! {
 pub const PAGE_SIZE: usize = 16384;
 
 #[cfg(not(all(target_arch = "aarch64", target_vendor = "apple")))]
-pub const PAGE_SIZE: usize = 4096;
+pub const PAGE_SIZE: usize = 2 * 1024 * 1024; //65_536 ;//4096;
 
 /// The size of a huge page on x86_64 on Linux.
 /// Used for a huge page allocation as a memory optimization as


### PR DESCRIPTION
simple infra and changes to set up 2 MiB transparent huge pages for the wasm heap. Run on SPM22 machine using:

`bazel test //rs/execution_environment:all --config=check --config=lint --test_verbose_timeout_warnings --test_output=streamed --test_arg=--nocapture --cache_test_results=no --test_arg=large_canister_test`