### PR TITLE
chore(IDX): optimise the setup of the spec_compliance systests

### DIFF
--- a/rs/tests/driver/src/util.rs
+++ b/rs/tests/driver/src/util.rs
@@ -58,7 +58,7 @@ use icp_ledger::{
 };
 use itertools::Itertools;
 use on_wire::FromWire;
-use slog::{debug, info};
+use slog::{debug, info, Logger};
 use std::{
     collections::BTreeMap,
     convert::{TryFrom, TryInto},
@@ -1850,4 +1850,16 @@ pub fn expiry_time() -> Duration {
         .duration_since(SystemTime::UNIX_EPOCH)
         .unwrap()
         + Duration::from_secs(4 * 60)
+}
+
+/// Time the duration of the given closure and log it.
+pub fn timeit<F, R>(log: Logger, description: &str, f: F) -> R
+where
+    F: FnOnce() -> R,
+{
+    let start = Instant::now();
+    let result = f(); // Run the closure
+    let duration = start.elapsed();
+    info!(log, "Executed '{}' in: {:?}", description, duration);
+    result
 }

--- a/rs/tests/research/spec_compliance/spec_compliance.rs
+++ b/rs/tests/research/spec_compliance/spec_compliance.rs
@@ -12,6 +12,7 @@ use ic_system_test_driver::driver::test_env_api::{
     IcNodeContainer, NnsInstallationBuilder, SubnetSnapshot, TopologySnapshot,
 };
 use ic_system_test_driver::driver::universal_vm::UniversalVm;
+use ic_system_test_driver::util::timeit;
 use ic_types::SubnetId;
 use slog::{info, Logger};
 use std::path::PathBuf;
@@ -109,86 +110,122 @@ pub fn setup_impl(env: TestEnv, deploy_bn_and_nns_canisters: bool, http_requests
             canister_http::start_httpbin_on_uvm(&cloned_env);
         }))
     }
-    InternetComputer::new()
-        .add_subnet(
-            Subnet::new(SubnetType::System)
-                .with_default_vm_resources(vm_resources)
-                .with_features(SubnetFeatures {
-                    http_requests,
-                    ..SubnetFeatures::default()
-                })
-                .add_nodes(REPLICATION_FACTOR),
-        )
-        .add_subnet(
-            Subnet::new(SubnetType::Application)
-                .with_default_vm_resources(vm_resources)
-                .with_features(SubnetFeatures {
-                    http_requests,
-                    ..SubnetFeatures::default()
-                })
-                .add_nodes(REPLICATION_FACTOR),
-        )
-        .setup_and_start(&env)
-        .expect("failed to setup IC under test");
-    if deploy_bn_and_nns_canisters {
-        let nns_node = env
-            .topology_snapshot()
-            .root_subnet()
-            .nodes()
-            .next()
-            .unwrap();
-        NnsInstallationBuilder::new()
-            .install(&nns_node, &env)
-            .expect("NNS canisters not installed");
-        info!(env.logger(), "NNS canisters are installed.");
-
-        let allocated_bn = deploy_bn_thread.unwrap().join().unwrap();
-        allocated_bn
-            .for_ic(&env, "")
-            .use_real_certs_and_dns()
-            .start(&env)
-            .expect("failed to setup BoundaryNode VM");
-    }
-    env.topology_snapshot().subnets().for_each(|subnet| {
-        subnet
-            .nodes()
-            .for_each(|node| node.await_status_is_healthy().unwrap())
+    let cloned_env = env.clone();
+    timeit(cloned_env.logger(), "deploying IC", move || {
+        InternetComputer::new()
+            .add_subnet(
+                Subnet::new(SubnetType::System)
+                    .with_default_vm_resources(vm_resources)
+                    .with_features(SubnetFeatures {
+                        http_requests,
+                        ..SubnetFeatures::default()
+                    })
+                    .add_nodes(REPLICATION_FACTOR),
+            )
+            .add_subnet(
+                Subnet::new(SubnetType::Application)
+                    .with_default_vm_resources(vm_resources)
+                    .with_features(SubnetFeatures {
+                        http_requests,
+                        ..SubnetFeatures::default()
+                    })
+                    .add_nodes(REPLICATION_FACTOR),
+            )
+            .setup_and_start(&cloned_env)
+            .expect("failed to setup IC under test");
     });
-
+    if deploy_bn_and_nns_canisters {
+        let cloned_env: TestEnv = env.clone();
+        timeit(
+            cloned_env.logger(),
+            "installing NNS & starting BN concurrently",
+            move || {
+                std::thread::scope(|s| {
+                    s.spawn(|| {
+                        let nns_node = cloned_env
+                            .topology_snapshot()
+                            .root_subnet()
+                            .nodes()
+                            .next()
+                            .unwrap();
+                        NnsInstallationBuilder::new()
+                            .install(&nns_node, &cloned_env)
+                            .expect("NNS canisters not installed");
+                        info!(cloned_env.logger(), "NNS canisters are installed.");
+                    });
+                    s.spawn(|| {
+                        let allocated_bn = deploy_bn_thread.unwrap().join().unwrap();
+                        allocated_bn
+                            .for_ic(&cloned_env, "")
+                            .use_real_certs_and_dns()
+                            .start(&cloned_env)
+                            .expect("failed to setup BoundaryNode VM");
+                    });
+                });
+            },
+        );
+    }
+    let cloned_env = env.clone();
+    timeit(
+        cloned_env.logger(),
+        "waiting until all IC nodes are healthy",
+        move || {
+            cloned_env.topology_snapshot().subnets().for_each(|subnet| {
+                subnet
+                    .nodes()
+                    .for_each(|node| node.await_status_is_healthy().unwrap())
+            });
+        },
+    );
     if http_requests {
-        deploy_httpbin_uvm_thread.unwrap().join().unwrap();
+        timeit(env.logger(), "waiting on httpbin deployment", move || {
+            deploy_httpbin_uvm_thread.unwrap().join().unwrap();
+        });
+        let cloned_env = env.clone();
+        timeit(
+            cloned_env.logger(),
+            "waiting until httpbin responds to requests",
+            move || {
+                let log = cloned_env.logger();
+                ic_system_test_driver::retry_with_msg!(
+                    "check if httpbin is responding to requests",
+                    log.clone(),
+                    secs(300),
+                    secs(10),
+                    || {
+                        block_on(async {
+                            let client = reqwest::Client::builder()
+                                .use_rustls_tls()
+                                .https_only(true)
+                                .http1_only()
+                                .build()?;
 
-        let log = env.logger();
-        ic_system_test_driver::retry_with_msg!(
-            "check if httpbin is responding to requests",
-            log.clone(),
-            secs(300),
-            secs(10),
-            || {
-                block_on(async {
-                    let client = reqwest::Client::builder()
-                        .use_rustls_tls()
-                        .https_only(true)
-                        .http1_only()
-                        .build()?;
+                            let webserver_ipv6 = get_universal_vm_address(&cloned_env);
+                            let httpbin = format!("https://[{webserver_ipv6}]:20443");
 
-                    let webserver_ipv6 = get_universal_vm_address(&env);
-                    let httpbin = format!("https://[{webserver_ipv6}]:20443");
+                            let resp = client.get(httpbin).send().await?;
 
-                    let resp = client.get(httpbin).send().await?;
+                            let body = String::from_utf8(resp.bytes().await?.to_vec()).unwrap();
 
-                    let body = String::from_utf8(resp.bytes().await?.to_vec()).unwrap();
+                            info!(log, "response body from httpbin: {}", body);
 
-                    info!(log, "response body from httpbin: {}", body);
-
-                    Ok(())
-                })
-            }
-        )
-        .expect("Httpbin server should respond to incoming requests!");
+                            Ok(())
+                        })
+                    }
+                )
+                .expect("Httpbin server should respond to incoming requests!");
+            },
+        );
     }
     if deploy_bn_and_nns_canisters {
-        await_boundary_node_healthy(&env, BOUNDARY_NODE_NAME);
+        let cloned_env = env.clone();
+        timeit(
+            cloned_env.logger(),
+            "waiting until Boundary Node is healthy",
+            move || {
+                await_boundary_node_healthy(&cloned_env, BOUNDARY_NODE_NAME);
+            },
+        );
     }
 }
 


### PR DESCRIPTION
This optimises the setup function of the spec_compliance system-tests by concurrently installing the NNS and starting the Boundary Node. This shaves off a minute from the setup and brings the total test time under 5 minutes.

Additionally the steps on the critical path of the setup function are now measured and logged so that we can monitor what takes up the time.