### PR TITLE
chore(IDX): lower parallelism of ic-ref-test in //rs/pocket_ic_server:spec_test

### DIFF
--- a/rs/pocket_ic_server/tests/spec_test.rs
+++ b/rs/pocket_ic_server/tests/spec_test.rs
@@ -196,7 +196,7 @@ fn setup_and_run_ic_ref_test(
         peer_subnet_config,
         excluded_tests,
         included_tests,
-        64,
+        32,
     );
 }
 


### PR DESCRIPTION
I noticed the `//rs/pocket_ic_server:spec_test` being a bit unstable after https://github.com/dfinity/ic/pull/2331 which I suspect comes from the high degree of parallelism. So let's halve this from 64 to 32 threads.