### PR TITLE
fix(IDX): remove unused icmplib py dep

### DIFF
--- a/ic-os/dev-tools/bare_metal_deployment/tools.bzl
+++ b/ic-os/dev-tools/bare_metal_deployment/tools.bzl
@@ -12,7 +12,6 @@ def launch_bare_metal(name, image_zst_file):
         main = "//ic-os/dev-tools/bare_metal_deployment:deploy.py",
         deps = [
             requirement("fabric"),
-            requirement("icmplib"),
             requirement("idracredfishsupport"),
             requirement("invoke"),
             requirement("loguru"),

--- a/requirements.in
+++ b/requirements.in
@@ -5,7 +5,6 @@ cvss>=2.5
 fabric
 GitPython>=3.1.24
 https://github.com/rocklabs-io/ic-py/archive/53c375a1d6c1d09e8d24588142dece550b801cef.zip
-icmplib
 idracredfishsupport>=0.0.8
 invoke
 jira>=3.4.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -377,10 +377,6 @@ httpx==0.23.3 \
 ic-py @ https://github.com/rocklabs-io/ic-py/archive/53c375a1d6c1d09e8d24588142dece550b801cef.zip \
     --hash=sha256:a07b08e996d4be6749ba10934cc519daf08f20b8874551960274d8dc2c6260f4
     # via -r requirements.in
-icmplib==3.0.4 \
-    --hash=sha256:336b75c6c23c5ce99ddec33f718fab09661f6ad698e35b6f1fc7cc0ecf809398 \
-    --hash=sha256:57868f2cdb011418c0e1d5586b16d1fabd206569fe9652654c27b6b2d6a316de
-    # via -r requirements.in
 idna==3.4 \
     --hash=sha256:814f528e8dead7d329833b91c5faa87d60bf71824cd12a7530b5526063d02cb4 \
     --hash=sha256:90b77e79eaa3eba6de819a0c442c0b4ceefc341a7a2ab77d7562bf49f425c5c2


### PR DESCRIPTION
This python library has not been used in our repo since https://github.com/dfinity/ic/commit/d85f6e23095da708a0e606bde09e08d793e17054.