### PR TITLE
chore(IDX): use stable bazel flags for remote cache

### DIFF
--- a/bazel/conf/.bazelrc.internal
+++ b/bazel/conf/.bazelrc.internal
@@ -15,13 +15,13 @@ build:ci --build_event_binary_file=bazel-bep.pb --profile=profile.json
 
 # DFINITY internal remote cache setup
 build --remote_cache=bazel-remote.idx.dfinity.network
-build --experimental_remote_cache_async
-build --experimental_remote_cache_compression # If enabled, compress/decompress cache blobs with zstd.
+build --remote_cache_async
+build --remote_cache_compression # If enabled, compress/decompress cache blobs with zstd.
 build --remote_timeout=60s # Default is also 60s but we set it explicitly to remind ourselves of this timeout.
 build:ci --remote_timeout=5m # Default is 60s.
 # TODO: re-enable after fixing the error like this:
 # `Failed to fetch file with hash 'xxx' because it does not exist remotely. --remote_download_outputs=minimal does not work if your remote cache evicts files during builds.`
-# Probably disabling `--experimental_remote_cache_async` will help
+# Probably disabling `--remote_cache_async` will help
 #build --remote_download_minimal # https://bazel.build/reference/command-line-reference#flag--remote_download_minimal
 #build --remote_download_outputs=toplevel # Still download outputs from top level targets.
 


### PR DESCRIPTION
The `--remote_cache_async` and `--remote_cache_compression` are now stable.