### PR TITLE
fix(NODE-1522): fix permissions for nftables and systemd-journald

### DIFF
--- a/ic-os/components/selinux/ic-node/ic-node.te
+++ b/ic-os/components/selinux/ic-node/ic-node.te
@@ -370,6 +370,7 @@ allow unconfined_domain_type ic_canister_sandbox_t : process *;
 require { type syslogd_t; }
 allow syslogd_t ic_canister_sandbox_t : dir { getattr open read search };
 allow syslogd_t ic_canister_sandbox_t : file { open read getattr ioctl};
+allow syslogd_t ic_canister_sandbox_t : lnk_file { open read getattr ioctl};
 allow syslogd_t ic_canister_sandbox_t : process { getattr };
 
 # Allow interacting with our own executable.

--- a/ic-os/components/selinux/misc-fixes/misc-fixes.te
+++ b/ic-os/components/selinux/misc-fixes/misc-fixes.te
@@ -84,3 +84,9 @@ search_dirs_pattern(ssh_keygen_t, locale_t, locale_t)
 # go to a different policy module.
 search_dirs_pattern(ssh_keygen_t, tmp_t, tmp_t)
 manage_files_pattern(ssh_keygen_t, initrc_tmp_t, initrc_tmp_t)
+
+###############################################################################
+# nftables
+# allow reading from /dev/urandom
+require { type iptables_t }
+dev_read_urand(iptables_t)

--- a/ic-os/components/selinux/misc-fixes/misc-fixes.te
+++ b/ic-os/components/selinux/misc-fixes/misc-fixes.te
@@ -88,5 +88,5 @@ manage_files_pattern(ssh_keygen_t, initrc_tmp_t, initrc_tmp_t)
 ###############################################################################
 # nftables
 # allow reading from /dev/urandom
-require { type iptables_t }
+require { type iptables_t; }
 dev_read_urand(iptables_t)


### PR DESCRIPTION
- Allow `nftables` (`nft`) to read from `/dev/urandom`
- Allow `systemd-journald` to access procfs symlinks of the canister sandbox process (it is already allowed to access the actual process to log its errors, etc.)
