### PR TITLE
chore(BOUN): Add debugging endpoints to certificate-orchestrator

### DIFF
--- a/rs/boundary_node/certificate_issuance/certificate_orchestrator/interface.did
+++ b/rs/boundary_node/certificate_issuance/certificate_orchestrator/interface.did
@@ -88,6 +88,16 @@ type RemoveRegistrationResponse = variant {
     Err: RemoveRegistrationError;
 };
 
+type ListRegistrationsError = variant {
+    Unauthorized;
+    UnexpectedError: text;
+};
+
+type ListRegistrationsResponse = variant {
+    Ok;
+    Err: ListRegistrationsError;
+};
+
 type GetCertificateError = variant {
     NotFound;
     Unauthorized;
@@ -155,6 +165,16 @@ type PeekTaskResponse = variant {
     Err: PeekTaskError;
 };
 
+type ListTasksError = variant {
+    Unauthorized;
+    UnexpectedError: text;
+};
+
+type ListTasksResponse = variant {
+    Ok: Id;
+    Err: ListTasksError;
+};
+
 type DispenseTaskError = variant {
     NoTasksAvailable;
     Unauthorized;
@@ -207,6 +227,7 @@ service: (InitArg) -> {
     getRegistration: (Id) -> (GetRegistrationResponse) query;
     updateRegistration: (Id, UpdateType) -> (UpdateRegistrationResponse);
     removeRegistration: (Id) -> (RemoveRegistrationResponse);
+    listRegistrations: () -> (ListRegistrationsResponse) query;
 
     // Certificates
     getCertificate: (Id) -> (GetCertificateResponse) query;
@@ -219,6 +240,7 @@ service: (InitArg) -> {
     queueTask: (Id, Timestamp) -> (QueueTaskResponse);
     dispenseTask: () -> (DispenseTaskResponse);
     peekTask: () -> (PeekTaskResponse) query;
+    listTasks: () -> (ListTasksResponse) query;
 
     // Metrics (Http Interface)
     http_request: (HttpRequest) -> (HttpResponse) query;

--- a/rs/boundary_node/certificate_issuance/certificate_orchestrator/interface.did
+++ b/rs/boundary_node/certificate_issuance/certificate_orchestrator/interface.did
@@ -193,7 +193,7 @@ type RemoveTaskError = variant {
 };
 
 type RemoveTaskResponse = variant {
-    Ok: Id;
+    Ok;
     Err: RemoveTaskError;
 };
 

--- a/rs/boundary_node/certificate_issuance/certificate_orchestrator/interface.did
+++ b/rs/boundary_node/certificate_issuance/certificate_orchestrator/interface.did
@@ -186,6 +186,17 @@ type DispenseTaskResponse = variant {
     Err: DispenseTaskError;
 };
 
+type RemoveTaskError = variant {
+    NotFound;
+    Unauthorized;
+    UnexpectedError: text;
+};
+
+type RemoveTaskResponse = variant {
+    Ok: Id;
+    Err: RemoveTaskError;
+};
+
 type ModifyAllowedPrincipalError = variant {
     Unauthorized;
     UnexpectedError: text;
@@ -239,6 +250,7 @@ service: (InitArg) -> {
     // Tasks
     queueTask: (Id, Timestamp) -> (QueueTaskResponse);
     dispenseTask: () -> (DispenseTaskResponse);
+    removeTask: (Id) -> (RemoveTaskResponse);
     peekTask: () -> (PeekTaskResponse) query;
     listTasks: () -> (ListTasksResponse) query;
 

--- a/rs/boundary_node/certificate_issuance/certificate_orchestrator/interface.did
+++ b/rs/boundary_node/certificate_issuance/certificate_orchestrator/interface.did
@@ -171,7 +171,7 @@ type ListTasksError = variant {
 };
 
 type ListTasksResponse = variant {
-    Ok: Id;
+    Ok: vec record { text; nat64; Registration };
     Err: ListTasksError;
 };
 

--- a/rs/boundary_node/certificate_issuance/certificate_orchestrator/interface.did
+++ b/rs/boundary_node/certificate_issuance/certificate_orchestrator/interface.did
@@ -94,7 +94,7 @@ type ListRegistrationsError = variant {
 };
 
 type ListRegistrationsResponse = variant {
-    Ok;
+    Ok: vec record { text; Registration };
     Err: ListRegistrationsError;
 };
 

--- a/rs/boundary_node/certificate_issuance/certificate_orchestrator/src/main.rs
+++ b/rs/boundary_node/certificate_issuance/certificate_orchestrator/src/main.rs
@@ -2,7 +2,16 @@ use std::{cell::RefCell, cmp::Reverse, collections::BTreeMap, thread::LocalKey, 
 
 use candid::{candid_method, Principal};
 use certificate_orchestrator_interface::{
-    BoundedString, CreateRegistrationError, CreateRegistrationResponse, DispenseTaskError, DispenseTaskResponse, EncryptedPair, ExportCertificatesCertifiedResponse, ExportCertificatesError, ExportCertificatesResponse, ExportPackage, GetCertificateError, GetCertificateResponse, GetRegistrationError, GetRegistrationResponse, HeaderField, HttpRequest, HttpResponse, Id, InitArg, ListAllowedPrincipalsError, ListAllowedPrincipalsResponse, ListRegistrationsError, ListRegistrationsResponse, ListTasksError, ListTasksResponse, ModifyAllowedPrincipalError, ModifyAllowedPrincipalResponse, Name, PeekTaskError, PeekTaskResponse, QueueTaskError, QueueTaskResponse, Registration, RemoveRegistrationError, RemoveRegistrationResponse, State, UpdateRegistrationError, UpdateRegistrationResponse, UpdateType, UploadCertificateError, UploadCertificateResponse
+    BoundedString, CreateRegistrationError, CreateRegistrationResponse, DispenseTaskError,
+    DispenseTaskResponse, EncryptedPair, ExportCertificatesCertifiedResponse,
+    ExportCertificatesError, ExportCertificatesResponse, ExportPackage, GetCertificateError,
+    GetCertificateResponse, GetRegistrationError, GetRegistrationResponse, HeaderField,
+    HttpRequest, HttpResponse, Id, InitArg, ListAllowedPrincipalsError,
+    ListAllowedPrincipalsResponse, ListRegistrationsError, ListRegistrationsResponse,
+    ListTasksError, ListTasksResponse, ModifyAllowedPrincipalError, ModifyAllowedPrincipalResponse,
+    Name, PeekTaskError, PeekTaskResponse, QueueTaskError, QueueTaskResponse, Registration,
+    RemoveRegistrationError, RemoveRegistrationResponse, State, UpdateRegistrationError,
+    UpdateRegistrationResponse, UpdateType, UploadCertificateError, UploadCertificateResponse,
 };
 use ic_cdk::{
     api::{id, time},

--- a/rs/boundary_node/certificate_issuance/certificate_orchestrator/src/main.rs
+++ b/rs/boundary_node/certificate_issuance/certificate_orchestrator/src/main.rs
@@ -2,15 +2,7 @@ use std::{cell::RefCell, cmp::Reverse, collections::BTreeMap, thread::LocalKey, 
 
 use candid::{candid_method, Principal};
 use certificate_orchestrator_interface::{
-    BoundedString, CreateRegistrationError, CreateRegistrationResponse, DispenseTaskError,
-    DispenseTaskResponse, EncryptedPair, ExportCertificatesCertifiedResponse,
-    ExportCertificatesError, ExportCertificatesResponse, ExportPackage, GetCertificateError,
-    GetCertificateResponse, GetRegistrationError, GetRegistrationResponse, HeaderField,
-    HttpRequest, HttpResponse, Id, InitArg, ListAllowedPrincipalsError,
-    ListAllowedPrincipalsResponse, ModifyAllowedPrincipalError, ModifyAllowedPrincipalResponse,
-    Name, PeekTaskError, PeekTaskResponse, QueueTaskError, QueueTaskResponse, Registration,
-    RemoveRegistrationError, RemoveRegistrationResponse, State, UpdateRegistrationError,
-    UpdateRegistrationResponse, UpdateType, UploadCertificateError, UploadCertificateResponse,
+    BoundedString, CreateRegistrationError, CreateRegistrationResponse, DispenseTaskError, DispenseTaskResponse, EncryptedPair, ExportCertificatesCertifiedResponse, ExportCertificatesError, ExportCertificatesResponse, ExportPackage, GetCertificateError, GetCertificateResponse, GetRegistrationError, GetRegistrationResponse, HeaderField, HttpRequest, HttpResponse, Id, InitArg, ListAllowedPrincipalsError, ListAllowedPrincipalsResponse, ListRegistrationsResponse, ListTasksResponse, ModifyAllowedPrincipalError, ModifyAllowedPrincipalResponse, Name, PeekTaskError, PeekTaskResponse, QueueTaskError, QueueTaskResponse, Registration, RemoveRegistrationError, RemoveRegistrationResponse, State, UpdateRegistrationError, UpdateRegistrationResponse, UpdateType, UploadCertificateError, UploadCertificateResponse
 };
 use ic_cdk::{
     api::{id, time},
@@ -678,6 +670,12 @@ fn remove_registration(id: Id) -> RemoveRegistrationResponse {
     }
 }
 
+#[query(name = "listRegistrations")]
+#[candid_method(query, rename = "listRegistrations")]
+fn list_registrations() -> ListRegistrationsResponse {
+    ListRegistrationsResponse::Ok(())
+}
+
 // Certificates
 
 #[query(name = "getCertificate")]
@@ -796,6 +794,12 @@ fn dispense_task() -> DispenseTaskResponse {
             }
         }),
     }
+}
+
+#[query(name = "listTasks")]
+#[candid_method(query, rename = "listTasks")]
+fn list_tasks() -> ListTasksResponse {
+    ListTasksResponse::Ok(())
 }
 
 // Metrics

--- a/rs/boundary_node/certificate_issuance/certificate_orchestrator/src/main.rs
+++ b/rs/boundary_node/certificate_issuance/certificate_orchestrator/src/main.rs
@@ -847,7 +847,7 @@ fn dispense_task() -> DispenseTaskResponse {
 
 #[update(name = "removeTask")]
 #[candid_method(update, rename = "removeTask")]
-fn remove_task(id: String) -> RemoveTaskResponse {
+fn remove_task(id: Id) -> RemoveTaskResponse {
     match TASK_REMOVER.with(|v| v.borrow().remove(&id)) {
         Ok(()) => RemoveTaskResponse::Ok,
         Err(err) => RemoveTaskResponse::Err(match err {

--- a/rs/boundary_node/certificate_issuance/certificate_orchestrator/src/work.rs
+++ b/rs/boundary_node/certificate_issuance/certificate_orchestrator/src/work.rs
@@ -221,9 +221,10 @@ impl List for Lister {
                         .with(|rs| rs.borrow().get(&id.to_owned().into()))
                     {
                         Some(r) => Ok((id.to_owned(), timestamp.to_owned(), r)),
-                        None => {
-                            Err(anyhow!("invalid state: task id not found in registrations").into())
-                        }
+                        None => Err(anyhow!(
+                            "invalid state: task id {id} not found in registrations"
+                        )
+                        .into()),
                     }
                 })
                 .collect()

--- a/rs/boundary_node/certificate_issuance/certificate_orchestrator_interface/src/lib.rs
+++ b/rs/boundary_node/certificate_issuance/certificate_orchestrator_interface/src/lib.rs
@@ -288,7 +288,7 @@ pub enum ListRegistrationsError {
 
 #[derive(Clone, Debug, CandidType, Deserialize)]
 pub enum ListRegistrationsResponse {
-    Ok(()),
+    Ok(Vec<(String, Registration)>),
     Err(ListRegistrationsError),
 }
 

--- a/rs/boundary_node/certificate_issuance/certificate_orchestrator_interface/src/lib.rs
+++ b/rs/boundary_node/certificate_issuance/certificate_orchestrator_interface/src/lib.rs
@@ -391,7 +391,7 @@ pub enum ListTasksError {
 
 #[derive(Clone, Debug, CandidType, Deserialize)]
 pub enum ListTasksResponse {
-    Ok(()),
+    Ok(Vec<(String, u64, Registration)>),
     Err(ListTasksError),
 }
 

--- a/rs/boundary_node/certificate_issuance/certificate_orchestrator_interface/src/lib.rs
+++ b/rs/boundary_node/certificate_issuance/certificate_orchestrator_interface/src/lib.rs
@@ -281,6 +281,18 @@ pub enum RemoveRegistrationResponse {
 }
 
 #[derive(Clone, Debug, CandidType, Deserialize)]
+pub enum ListRegistrationsError {
+    Unauthorized,
+    UnexpectedError(String),
+}
+
+#[derive(Clone, Debug, CandidType, Deserialize)]
+pub enum ListRegistrationsResponse {
+    Ok(()),
+    Err(ListRegistrationsError),
+}
+
+#[derive(Clone, Debug, CandidType, Deserialize)]
 pub enum GetCertificateError {
     NotFound,
     Unauthorized,
@@ -369,6 +381,18 @@ pub enum DispenseTaskError {
 pub enum DispenseTaskResponse {
     Ok(Id),
     Err(DispenseTaskError),
+}
+
+#[derive(Clone, Debug, CandidType, Deserialize)]
+pub enum ListTasksError {
+    Unauthorized,
+    UnexpectedError(String),
+}
+
+#[derive(Clone, Debug, CandidType, Deserialize)]
+pub enum ListTasksResponse {
+    Ok(()),
+    Err(ListTasksError),
 }
 
 #[derive(Clone, Debug, CandidType, Deserialize)]

--- a/rs/boundary_node/certificate_issuance/certificate_orchestrator_interface/src/lib.rs
+++ b/rs/boundary_node/certificate_issuance/certificate_orchestrator_interface/src/lib.rs
@@ -384,6 +384,19 @@ pub enum DispenseTaskResponse {
 }
 
 #[derive(Clone, Debug, CandidType, Deserialize)]
+pub enum RemoveTaskError {
+    NotFound,
+    Unauthorized,
+    UnexpectedError(String),
+}
+
+#[derive(Clone, Debug, CandidType, Deserialize)]
+pub enum RemoveTaskResponse {
+    Ok,
+    Err(RemoveTaskError),
+}
+
+#[derive(Clone, Debug, CandidType, Deserialize)]
 pub enum ListTasksError {
     Unauthorized,
     UnexpectedError(String),


### PR DESCRIPTION
This change adds two canister methods:

- list_registrations
- list_tasks

which allow to examine the queue contents and the existing registrations.