### PR TITLE
refactor: Do not clone in `ReplicatedState::get_ingress_status()`

### DIFF
--- a/rs/execution_environment/src/scheduler/test_utilities.rs
+++ b/rs/execution_environment/src/scheduler/test_utilities.rs
@@ -312,7 +312,11 @@ impl SchedulerTest {
     }
 
     pub fn ingress_status(&self, message_id: &MessageId) -> IngressStatus {
-        self.state.as_ref().unwrap().get_ingress_status(message_id)
+        self.state
+            .as_ref()
+            .unwrap()
+            .get_ingress_status(message_id)
+            .clone()
     }
 
     pub fn ingress_error(&self, message_id: &MessageId) -> UserError {

--- a/rs/execution_environment/tests/history.rs
+++ b/rs/execution_environment/tests/history.rs
@@ -185,7 +185,7 @@ fn test_valid_transitions() {
                     message_id.clone(),
                     next_state.clone(),
                 );
-                assert_eq!(state.get_ingress_status(&message_id), next_state);
+                assert_eq!(state.get_ingress_status(&message_id), &next_state);
             }
         }
     })

--- a/rs/messaging/src/scheduling/valid_set_rule.rs
+++ b/rs/messaging/src/scheduling/valid_set_rule.rs
@@ -195,7 +195,7 @@ impl ValidSetRuleImpl {
 
     /// Checks whether the given message has already been inducted.
     fn is_duplicate(&self, state: &ReplicatedState, msg: &SignedIngressContent) -> bool {
-        state.get_ingress_status(&msg.id()) != IngressStatus::Unknown
+        state.get_ingress_status(&msg.id()) != &IngressStatus::Unknown
     }
 
     /// Records the result of inducting an ingress message.

--- a/rs/messaging/src/scheduling/valid_set_rule/test.rs
+++ b/rs/messaging/src/scheduling/valid_set_rule/test.rs
@@ -352,7 +352,7 @@ fn update_history_if_induction_failed() {
         // ReplicatedState.
         valid_set_rule.induct_message(&mut state, msg.clone(), SMALL_APP_SUBNET_MAX_SIZE);
         assert!(state.canister_state(&canister_id).is_none());
-        assert_eq!(state.get_ingress_status(&msg.id()), status_clone);
+        assert_eq!(state.get_ingress_status(&msg.id()), &status_clone);
         assert_inducted_ingress_messages_eq(
             metric_vec(&[(&[(LABEL_STATUS, LABEL_VALUE_CANISTER_NOT_FOUND)], 1)]),
             &metrics_registry,

--- a/rs/replicated_state/src/replicated_state.rs
+++ b/rs/replicated_state/src/replicated_state.rs
@@ -525,12 +525,11 @@ impl ReplicatedState {
         &self.metadata
     }
 
-    pub fn get_ingress_status(&self, message_id: &MessageId) -> IngressStatus {
+    pub fn get_ingress_status(&self, message_id: &MessageId) -> &IngressStatus {
         self.metadata
             .ingress_history
             .get(message_id)
-            .cloned()
-            .unwrap_or(IngressStatus::Unknown)
+            .unwrap_or(&IngressStatus::Unknown)
     }
 
     pub fn get_ingress_history(&self) -> &IngressHistoryState {

--- a/rs/test_utilities/execution_environment/src/lib.rs
+++ b/rs/test_utilities/execution_environment/src/lib.rs
@@ -470,7 +470,7 @@ impl ExecutionTest {
     }
 
     pub fn ingress_status(&self, message_id: &MessageId) -> IngressStatus {
-        self.state().get_ingress_status(message_id)
+        self.state().get_ingress_status(message_id).clone()
     }
 
     pub fn ingress_state(&self, message_id: &MessageId) -> IngressState {


### PR DESCRIPTION
There is no need for it, an immutable reference will do.