### PR TITLE
fix: revert "feat: [NODE-1521] Move bootloader off dockerhub (#2475)"

### DIFF
--- a/.github/workflows/container-mirror-images.json
+++ b/.github/workflows/container-mirror-images.json
@@ -6,11 +6,6 @@
       "sha256": "965fbcae990b0467ed5657caceaec165018ef44a4d2d46c7cdea80a9dff0d1ea"
     },
     {
-      "image": "library/ubuntu",
-      "repo": "docker.io",
-      "sha256": "5d070ad5f7fe63623cbb99b4fc0fd997f5591303d4b03ccce50f403957d0ddc4"
-    },
-    {
       "image": "ryantk/minica",
       "repo": "docker.io",
       "sha256": "c67e2c1885d438b5927176295d41aaab8a72dd9e1272ba85054bfc78191d05b0"

--- a/ic-os/bootloader/build-bootloader-tree.sh
+++ b/ic-os/bootloader/build-bootloader-tree.sh
@@ -25,12 +25,11 @@ sudo mount -t tmpfs tmpfs-podman "${TMPFS}"
 trap 'rm -rf "${TMPDIR}"; sudo podman --root "${TMPFS}" rm -f "${CONTAINER}"' exit
 TMPDIR=$(mktemp -d -t build-image-XXXXXXXXXXXX)
 
-BASE_IMAGE="ghcr.io/dfinity/library/ubuntu@sha256:5d070ad5f7fe63623cbb99b4fc0fd997f5591303d4b03ccce50f403957d0ddc4"
+BASE_IMAGE="docker.io/dfinity/ic-build-bazel@sha256:1978886cfda51b09057bffd60f2e5edb588c6c0b74de87696cd4e964335dba87"
 
 sudo podman --root "${TMPFS}" build --iidfile ${TMPDIR}/iidfile - <<<"
     FROM $BASE_IMAGE
     USER root:root
-    RUN apt-get -y update && apt-get -y --no-install-recommends install grub-efi faketime
     RUN mkdir -p /build/boot/grub
     RUN cp -r /usr/lib/grub/x86_64-efi /build/boot/grub
     RUN mkdir -p /build/boot/efi/EFI/Boot

--- a/ic-os/bootloader/grub.cfg
+++ b/ic-os/bootloader/grub.cfg
@@ -1,4 +1,4 @@
-regexp -s boot_disk '^\(([a-z0-9]*),[a-z0-9]*\)/EFI/BOOT' $fw_path
+regexp -s boot_disk '^\(([a-z0-9]*),[a-z0-9]*\)/EFI/BOOT' $cmdpath
 
 set prefix=($boot_disk,gpt2)
 


### PR DESCRIPTION
This reverts commit c582bfe2cc97e2dc2d49a55d050dd452dda9dbfc because it breaks the hourly `//rs/tests/nested:...` system-tests since the `host-1` VM gets stuck on grub:

https://farm.dfinity.systems/group/registration--1731006619504/vm/host-1/console/
![Screenshot 2024-11-08 at 11 05 52](https://github.com/user-attachments/assets/e03ecb7a-39f4-4149-83a9-03213e90390d)

This is likely caused by [using](https://github.com/dfinity/ic/commit/c582bfe2cc97e2dc2d49a55d050dd452dda9dbfc#diff-6580a63795796c85f6d7ac9b194b7543ce61bed207dad770e648fa53bef72ad1R1) `$fw_path` in `grub.cfg`.

Schedule Hourly on this branch: https://github.com/dfinity/ic/actions/runs/11739921391