### PR TITLE
feat: Per-canister mean ingress queue latency metric

### DIFF
--- a/rs/execution_environment/src/execution_environment.rs
+++ b/rs/execution_environment/src/execution_environment.rs
@@ -3305,7 +3305,7 @@ impl ExecutionEnvironment {
                         time,
                         state: ingress_state,
                     },
-                )
+                );
             }
             StopCanisterContext::Canister {
                 sender,

--- a/rs/execution_environment/src/history.rs
+++ b/rs/execution_environment/src/history.rs
@@ -145,7 +145,12 @@ impl IngressHistoryWriterImpl {
 impl IngressHistoryWriter for IngressHistoryWriterImpl {
     type State = ReplicatedState;
 
-    fn set_status(&self, state: &mut Self::State, message_id: MessageId, status: IngressStatus) {
+    fn set_status(
+        &self,
+        state: &mut Self::State,
+        message_id: MessageId,
+        status: IngressStatus,
+    ) -> Arc<IngressStatus> {
         let time = state.time();
         let current_status = state.get_ingress_status(&message_id);
 
@@ -232,7 +237,7 @@ impl IngressHistoryWriter for IngressHistoryWriterImpl {
             message_id,
             status,
             self.config.ingress_history_memory_capacity,
-        );
+        )
     }
 }
 

--- a/rs/execution_environment/src/scheduler.rs
+++ b/rs/execution_environment/src/scheduler.rs
@@ -37,11 +37,12 @@ use ic_types::{
     ingress::{IngressState, IngressStatus},
     messages::{CanisterMessage, Ingress, MessageId, Response, NO_DEADLINE},
     CanisterId, ComputeAllocation, Cycles, ExecutionRound, MemoryAllocation, NumBytes,
-    NumInstructions, NumSlices, Randomness, ReplicaVersion, SubnetId, Time,
+    NumInstructions, NumSlices, PrincipalId, Randomness, ReplicaVersion, SubnetId, Time,
     MAX_WASM_MEMORY_IN_BYTES,
 };
 use ic_types::{nominal_cycles::NominalCycles, NumMessages};
 use num_rational::Ratio;
+use prometheus::Histogram;
 use std::{
     cell::RefCell,
     collections::{BTreeMap, BTreeSet},
@@ -401,6 +402,7 @@ impl SchedulerImpl {
         round_schedule: &RoundSchedule,
         current_round: ExecutionRound,
         root_measurement_scope: &MeasurementScope<'a>,
+        canister_ingress_latencies: &mut CanisterIngressQueueLatencies,
         scheduler_round_limits: &mut SchedulerRoundLimits,
         registry_settings: &RegistryExecutionSettings,
         replica_version: &ReplicaVersion,
@@ -608,8 +610,10 @@ impl SchedulerImpl {
         }
 
         for (message_id, status) in ingress_execution_results {
-            self.ingress_history_writer
+            let old_status = self
+                .ingress_history_writer
                 .set_status(&mut state, message_id, status);
+            canister_ingress_latencies.on_ingress_status_changed(old_status);
         }
         self.metrics
             .executable_canisters_per_round
@@ -779,7 +783,11 @@ impl SchedulerImpl {
         )
     }
 
-    fn purge_expired_ingress_messages(&self, state: &mut ReplicatedState) {
+    fn purge_expired_ingress_messages(
+        &self,
+        state: &mut ReplicatedState,
+        canister_ingress_latencies: &mut CanisterIngressQueueLatencies,
+    ) {
         let current_time = state.time();
         let not_expired_yet = |ingress: &Arc<Ingress>| ingress.expiry_time >= current_time;
         let mut expired_ingress_messages =
@@ -801,7 +809,7 @@ impl SchedulerImpl {
                     ingress.message_id
                 ),
             );
-            self.ingress_history_writer.set_status(
+            let old_status = self.ingress_history_writer.set_status(
                 state,
                 ingress.message_id.clone(),
                 IngressStatus::Known {
@@ -811,6 +819,7 @@ impl SchedulerImpl {
                     state: IngressState::Failed(error),
                 },
             );
+            canister_ingress_latencies.on_ingress_status_changed(old_status);
         }
         state.put_canister_states(canisters);
     }
@@ -1184,6 +1193,10 @@ impl Scheduler for SchedulerImpl {
         let round_log;
         let mut csprng;
         let long_running_canister_ids: BTreeSet<_>;
+        let mut canister_ingress_latencies = CanisterIngressQueueLatencies::new(
+            state.time(),
+            self.metrics.canister_ingress_queue_latencies.clone(),
+        );
 
         // Round preparation.
         let mut scheduler_round_limits = {
@@ -1240,7 +1253,7 @@ impl Scheduler for SchedulerImpl {
 
             {
                 let _timer = self.metrics.round_preparation_ingress.start_timer();
-                self.purge_expired_ingress_messages(&mut state);
+                self.purge_expired_ingress_messages(&mut state, &mut canister_ingress_latencies);
             }
 
             // In the future, subnet messages might be executed in threads. In
@@ -1444,6 +1457,7 @@ impl Scheduler for SchedulerImpl {
             &round_schedule,
             current_round,
             &root_measurement_scope,
+            &mut canister_ingress_latencies,
             &mut scheduler_round_limits,
             registry_settings,
             replica_version,
@@ -2375,4 +2389,53 @@ fn scheduled_heap_delta_limit(
         .get()
         .saturating_sub(remaining_heap_delta_reserve)
         .into()
+}
+
+/// Aggregator and observer of per-canister ingress queue latencies.
+struct CanisterIngressQueueLatencies {
+    /// Per canister observed ingress message latency sum and count.
+    latencies: BTreeMap<PrincipalId, (f64, usize)>,
+    /// Current block time.
+    time: Time,
+    /// Histogram to observe the latencies.
+    histogram: Histogram,
+}
+
+impl CanisterIngressQueueLatencies {
+    fn new(time: Time, histogram: Histogram) -> Self {
+        Self {
+            latencies: BTreeMap::new(),
+            time,
+            histogram,
+        }
+    }
+
+    /// Records the ingress queue latency of a message iff it is transitioning from
+    /// `Received` to some other state (i.e. when popped from the ingress queue).
+    fn on_ingress_status_changed(&mut self, old_status: Arc<IngressStatus>) {
+        match &*old_status {
+            IngressStatus::Known {
+                receiver,
+                user_id: _,
+                time,
+                state: IngressState::Received,
+            } => {
+                let (latency, count) = self.latencies.entry(*receiver).or_default();
+                *latency += self.time.saturating_duration_since(*time).as_secs_f64();
+                *count += 1;
+            }
+
+            _ => {}
+        }
+    }
+}
+
+impl Drop for CanisterIngressQueueLatencies {
+    /// Observes the average ingress queue latency of each canister at the end of
+    /// the round.
+    fn drop(&mut self) {
+        for (latency, count) in self.latencies.values() {
+            self.histogram.observe(*latency / *count as f64);
+        }
+    }
 }

--- a/rs/execution_environment/src/scheduler/scheduler_metrics.rs
+++ b/rs/execution_environment/src/scheduler/scheduler_metrics.rs
@@ -33,6 +33,7 @@ pub(super) struct SchedulerMetrics {
     pub(super) canister_stable_memory_usage: Histogram,
     pub(super) canister_memory_allocation: Histogram,
     pub(super) canister_compute_allocation: Histogram,
+    pub(super) canister_ingress_queue_latencies: Histogram,
     pub(super) compute_utilization_per_core: Histogram,
     pub(super) instructions_consumed_per_message: Histogram,
     pub(super) instructions_consumed_per_round: Histogram,
@@ -197,6 +198,12 @@ impl SchedulerMetrics {
                 "canister_compute_allocation_ratio",
                 "Canisters compute allocation distribution ratio (0-1).",
                 linear_buckets(0.0, 0.1, 11),
+            ),
+            canister_ingress_queue_latencies: metrics_registry.histogram(
+                "scheduler_canister_ingress_queue_latencies_seconds",
+                "Per-canister mean time spent by messages in the ingress queue.",
+                // 10ms, 20ms, 50ms, …, 100s, 200s, 500s
+                decimal_buckets(-2, 2),
             ),
             compute_utilization_per_core: metrics_registry.histogram(
                 "scheduler_compute_utilization_per_core",

--- a/rs/interfaces/src/execution_environment.rs
+++ b/rs/interfaces/src/execution_environment.rs
@@ -21,6 +21,7 @@ use std::{
     collections::{BTreeMap, BTreeSet},
     convert::{Infallible, TryFrom},
     fmt, ops,
+    sync::Arc,
 };
 use strum_macros::EnumIter;
 use thiserror::Error;
@@ -511,13 +512,18 @@ pub trait IngressHistoryWriter: Send + Sync {
     // Note [Associated Types in Interfaces]
     type State;
 
-    /// Allows to set status on a message.
+    /// Sets the status of a message. Returns the message's previous status.
     ///
     /// The allowed status transitions are:
     /// * "None" -> {"Received", "Processing", "Completed", "Failed"}
     /// * "Received" -> {"Processing", "Completed", "Failed"}
     /// * "Processing" -> {"Processing", "Completed", "Failed"}
-    fn set_status(&self, state: &mut Self::State, message_id: MessageId, status: IngressStatus);
+    fn set_status(
+        &self,
+        state: &mut Self::State,
+        message_id: MessageId,
+        status: IngressStatus,
+    ) -> Arc<IngressStatus>;
 }
 
 /// A trait for handling `out_of_instructions()` calls from the Wasm module.

--- a/rs/messaging/src/scheduling/valid_set_rule/test.rs
+++ b/rs/messaging/src/scheduling/valid_set_rule/test.rs
@@ -40,7 +40,8 @@ impl IngressHistoryWriter for NoopIngressHistoryWriter {
         _state: &mut ReplicatedState,
         _message_id: MessageId,
         _status: IngressStatus,
-    ) {
+    ) -> Arc<IngressStatus> {
+        IngressStatus::Unknown.into()
     }
 }
 
@@ -117,6 +118,7 @@ fn induct_message_with_successful_history_update() {
                     },
                     NumBytes::from(u64::MAX),
                 );
+                IngressStatus::Unknown.into()
             });
 
         let ingress_history_writer = Arc::new(ingress_history_writer);
@@ -183,6 +185,7 @@ fn induct_message_fails_for_stopping_canister() {
             .times(1)
             .returning(move |state, _, status| {
                 state.set_ingress_status(msg_id.clone(), status, NumBytes::from(u64::MAX));
+                IngressStatus::Unknown.into()
             });
         let ingress_history_writer = Arc::new(ingress_history_writer);
         let metrics_registry = MetricsRegistry::new();
@@ -239,6 +242,7 @@ fn induct_message_fails_for_stopped_canister() {
             .times(1)
             .returning(move |state, _, status| {
                 state.set_ingress_status(msg_id.clone(), status, NumBytes::from(u64::MAX));
+                IngressStatus::Unknown.into()
             });
 
         let ingress_history_writer = Arc::new(ingress_history_writer);
@@ -335,6 +339,7 @@ fn update_history_if_induction_failed() {
             .times(1)
             .returning(move |state, _, _| {
                 state.set_ingress_status(msg_id.clone(), status.clone(), NumBytes::from(u64::MAX));
+                IngressStatus::Unknown.into()
             });
 
         let ingress_history_writer = Arc::new(ingress_history_writer);
@@ -406,6 +411,7 @@ fn dont_induct_duplicate_messages() {
                     },
                     NumBytes::from(u64::MAX),
                 );
+                IngressStatus::Unknown.into()
             });
 
         let ingress_history_writer = Arc::new(ingress_history_writer);
@@ -647,7 +653,7 @@ fn running_canister_on_application_subnet_accepts_and_charges_for_ingress() {
         ingress_history_writer
             .expect_set_status()
             .times(1)
-            .return_const(());
+            .return_const(Arc::new(IngressStatus::Unknown));
         let metrics_registry = MetricsRegistry::new();
 
         let valid_set_rule = ValidSetRuleImpl::new(
@@ -689,7 +695,7 @@ fn running_canister_on_system_subnet_accepts_and_does_not_charge_for_ingress() {
         ingress_history_writer
             .expect_set_status()
             .times(1)
-            .return_const(());
+            .return_const(Arc::new(IngressStatus::Unknown));
         let metrics_registry = MetricsRegistry::new();
         let valid_set_rule = ValidSetRuleImpl::new(
             Arc::new(ingress_history_writer),
@@ -872,6 +878,7 @@ fn ingress_history_max_messages_impl(subnet_type: SubnetType) {
             .times(4)
             .returning(move |state, msg_id, status| {
                 state.set_ingress_status(msg_id, status, NumBytes::from(u64::MAX));
+                IngressStatus::Unknown.into()
             });
 
         let mut state = ReplicatedState::new(subnet_test_id(1), subnet_type);

--- a/rs/replicated_state/src/replicated_state.rs
+++ b/rs/replicated_state/src/replicated_state.rs
@@ -543,18 +543,20 @@ impl ReplicatedState {
     /// by transitioning `Completed` and `Failed` statuses to `Done` from
     /// oldest to newest in case inserting `status` pushes the memory
     /// consumption over the bound.
+    ///
+    /// Returns the previous status associated with `message_id`.
     pub fn set_ingress_status(
         &mut self,
         message_id: MessageId,
         status: IngressStatus,
         ingress_memory_capacity: NumBytes,
-    ) {
+    ) -> Arc<IngressStatus> {
         self.metadata.ingress_history.insert(
             message_id,
             status,
             self.time(),
             ingress_memory_capacity,
-        );
+        )
     }
 
     /// Prunes ingress history statuses with a pruning time older than

--- a/rs/test_utilities/state/src/history.rs
+++ b/rs/test_utilities/state/src/history.rs
@@ -4,6 +4,7 @@ use ic_interfaces::execution_environment::{
 use ic_replicated_state::ReplicatedState;
 use ic_types::{ingress::IngressStatus, messages::MessageId, Height};
 use mockall::*;
+use std::sync::Arc;
 
 mock! {
     pub IngressHistory {}
@@ -16,7 +17,7 @@ mock! {
             state: &mut ReplicatedState,
             message_id: MessageId,
             status: IngressStatus,
-        );
+        ) -> Arc<IngressStatus>;
     }
 
     impl IngressHistoryReader for  IngressHistory {


### PR DESCRIPTION
For the duration of the scheduler round, aggregate per-canister sum and count of ingress message latencies (delta between current block time and induction block time). At the end of the scheduler round, make one observation per canister with the resulting mean obserevd ingress queue latency.