### PR TITLE
chore(fuzzing): enable canister sandboxing for fuzzers

### DIFF
--- a/rs/canister_sandbox/src/replica_controller/process_exe_and_args.rs
+++ b/rs/canister_sandbox/src/replica_controller/process_exe_and_args.rs
@@ -31,6 +31,7 @@ const RUNNABLE_AS_SANDBOX: &[&str] = &[
     // need a different approach to enable multiple fuzzers use this
     // approach. The logic can be gated with #[cfg(feature = "fuzzing_code")]
     "execute_with_wasm_executor_system_api_call",
+    "execute_subnet_message_update_settings",
 ];
 
 enum SandboxCrate {

--- a/rs/execution_environment/fuzz/BUILD.bazel
+++ b/rs/execution_environment/fuzz/BUILD.bazel
@@ -1,26 +1,47 @@
-load("//bazel:fuzz_testing.bzl", "rust_fuzz_test_binary")
+load("@rules_rust//rust:defs.bzl", "rust_library")
+load("//bazel:fuzz_testing.bzl", "DEFAULT_RUSTC_FLAGS_FOR_FUZZING", "rust_fuzz_test_binary")
 
 package(default_visibility = ["//visibility:private"])
 
 MACRO_DEPENDENCIES = []
+
+rust_library(
+    name = "fuzzer_sandbox",
+    testonly = True,
+    srcs = glob(["src/*.rs"]),
+    crate_features = select({
+        "//bazel:fuzzing_code_enabled": ["fuzzing_code"],
+        "//conditions:default": [],
+    }),
+    proc_macro_deps = MACRO_DEPENDENCIES,
+    rustc_flags = select({
+        "//bazel:fuzzing_code_enabled": DEFAULT_RUSTC_FLAGS_FOR_FUZZING,
+        "//conditions:default": [],
+    }),
+    version = "0.1.0",
+    deps = [
+        "//rs/canister_sandbox:backend_lib",
+        "@crate_index//:libfuzzer-sys",
+    ],
+)
 
 rust_fuzz_test_binary(
     name = "execute_subnet_message_update_settings",
     srcs = [
         "fuzz_targets/execute_subnet_message_update_settings.rs",
     ],
+    allow_main = True,  # To allow the fuzzer to export it's own main fn
     proc_macro_deps = MACRO_DEPENDENCIES,
     deps = [
         # Keep sorted.
         "//rs/test_utilities/execution_environment",
         "//rs/types/management_canister_types",
         "@crate_index//:libfuzzer-sys",
-    ],
+    ] + [":fuzzer_sandbox"],
 )
 
 SYSTEM_API_FUZZ_DEPENDENCIES = [
     # Keep sorted.
-    "//rs/canister_sandbox:backend_lib",
     "//rs/config",
     "//rs/embedders/fuzz:wasm_fuzzers",
     "//rs/registry/subnet_type",
@@ -40,5 +61,5 @@ rust_fuzz_test_binary(
     ],
     allow_main = True,  # To allow the fuzzer to export it's own main fn
     proc_macro_deps = MACRO_DEPENDENCIES,
-    deps = SYSTEM_API_FUZZ_DEPENDENCIES,
+    deps = SYSTEM_API_FUZZ_DEPENDENCIES + [":fuzzer_sandbox"],
 )

--- a/rs/execution_environment/fuzz/fuzz_targets/execute_subnet_message_update_settings.rs
+++ b/rs/execution_environment/fuzz/fuzz_targets/execute_subnet_message_update_settings.rs
@@ -1,4 +1,3 @@
-#![no_main]
 use ic_management_canister_types::{Method, Payload, UpdateSettingsArgs};
 use ic_test_utilities_execution_environment::ExecutionTestBuilder;
 use libfuzzer_sys::{fuzz_target, Corpus};
@@ -7,14 +6,16 @@ use libfuzzer_sys::{fuzz_target, Corpus};
 //
 // The fuzz test is only compiled but not executed by CI.
 //
-// To execute the fuzzer run
-// bazel run --config=fuzzing //rs/execution_environment/fuzz:execute_subnet_message_update_settings
+// ASAN_OPTIONS="detect_leaks=0:allow_user_segv_handler=1:handle_segv=1:handle_sigfpe=1:handle_sigill=0:quarantine_size_mb=16"
+// LSAN_OPTIONS="handle_sigill=0"
+// ASAN_OPTIONS=$ASAN_OPTIONS LSAN_OPTIONS=$LSAN_OPTIONS bazel run --config=fuzzing //rs/execution_environment/fuzz:execute_subnet_message_update_settings
+
+fn main() {
+    fuzzer_sandbox::fuzzer_main();
+}
 
 fuzz_target!(|args: UpdateSettingsArgs| -> Corpus {
-    let mut test = ExecutionTestBuilder::new()
-        .with_deterministic_time_slicing_disabled()
-        .with_canister_sandboxing_disabled()
-        .build();
+    let mut test = ExecutionTestBuilder::new().build();
 
     let wat = r#"(module)"#;
     let canister_id = test.canister_from_wat(wat).unwrap();

--- a/rs/execution_environment/fuzz/fuzz_targets/execute_system_api_call.rs
+++ b/rs/execution_environment/fuzz/fuzz_targets/execute_system_api_call.rs
@@ -1,8 +1,3 @@
-use ic_canister_sandbox_backend_lib::{
-    canister_sandbox_main, compiler_sandbox::compiler_sandbox_main,
-    launcher::sandbox_launcher_main, RUN_AS_CANISTER_SANDBOX_FLAG, RUN_AS_COMPILER_SANDBOX_FLAG,
-    RUN_AS_SANDBOX_LAUNCHER_FLAG,
-};
 use ic_config::{
     embedders::Config as EmbeddersConfig, embedders::FeatureFlags,
     execution_environment::Config as ExecutionConfig, flag_status::FlagStatus,
@@ -13,11 +8,9 @@ use ic_registry_subnet_type::SubnetType;
 use ic_state_machine_tests::{StateMachine, StateMachineBuilder, StateMachineConfig};
 use ic_types::{CanisterId, Cycles, NumBytes};
 
-use libfuzzer_sys::{fuzz_target, test_input_wrap};
+use libfuzzer_sys::fuzz_target;
 use slog::Level;
 use std::cell::RefCell;
-use std::ffi::CString;
-use std::os::raw::c_char;
 use wasm_fuzzers::ic_wasm::ICWasmModule;
 
 thread_local! {
@@ -30,61 +23,13 @@ const HELLO_WORLD_WAT: &str = r#"
     (export "canister_query hi" (func $hi))
 )"#;
 
-#[allow(improper_ctypes)]
-extern "C" {
-    fn LLVMFuzzerRunDriver(
-        argc: *const isize,
-        argv: *const *const *const u8,
-        UserCb: fn(data: *const u8, size: usize) -> i32,
-    ) -> i32;
-}
-
-// In general, fuzzers don't include `main()` and the initialisation logic is deferred to libfuzzer.
-// However, to enable canister sandboxing, we override the initialisation by providing our own `main()`
-// which acts as a dispatcher for different sandboxed under certain arguments.
-//
-// The default case invokes `LLVMFuzzerRunDriver` which invokes a callback with similar signature as
-// `LLVMFuzzerTestOneInput`. For more details, see https://llvm.org/docs/LibFuzzer.html#using-libfuzzer-as-a-library
-//
-// We provide `libfuzzer_sys::test_input_wrap` as callback for `LLVMFuzzerRunDriver` since libfuzzer_sys
-// already exports `LLVMFuzzerTestOneInput` and we can't override it. `test_input_wrap` internally calls
-// `rust_fuzzer_test_input`, which is generated via the macro `fuzz_target!`.
-// See https://github.com/rust-fuzz/libfuzzer/blob/c8275d1517933765b56a6de61a371bb1cc4268cb/src/lib.rs#L62
-
 // To run the fuzzer,
-// ASAN_OPTIONS="detect_leaks=0:allow_user_segv_handler=1:handle_segv=1:handle_sigfpe=1:handle_sigill=0"
+// ASAN_OPTIONS="detect_leaks=0:allow_user_segv_handler=1:handle_segv=1:handle_sigfpe=1:handle_sigill=0:quarantine_size_mb=16"
 // LSAN_OPTIONS="handle_sigill=0"
 // ASAN_OPTIONS=$ASAN_OPTIONS LSAN_OPTIONS=$LSAN_OPTIONS bazel run --config=fuzzing //rs/execution_environment/fuzz:execute_with_wasm_executor_system_api_call
 
 fn main() {
-    if std::env::args().any(|arg| arg == RUN_AS_CANISTER_SANDBOX_FLAG) {
-        #[cfg(not(fuzzing))]
-        canister_sandbox_main();
-    } else if std::env::args().any(|arg| arg == RUN_AS_SANDBOX_LAUNCHER_FLAG) {
-        #[cfg(not(fuzzing))]
-        sandbox_launcher_main();
-    } else if std::env::args().any(|arg| arg == RUN_AS_COMPILER_SANDBOX_FLAG) {
-        #[cfg(not(fuzzing))]
-        compiler_sandbox_main();
-    } else {
-        // Collect command-line arguments
-        let args: Vec<CString> = std::env::args()
-            .map(|arg| CString::new(arg).unwrap())
-            .collect();
-
-        // Prepare argc as *const isize
-        let argc = args.len() as isize;
-        let argc: *const isize = &argc;
-
-        // Prepare argv as *const *const *const u8
-        let argv: Vec<*const c_char> = args.iter().map(|arg| arg.as_ptr()).collect();
-        let argv_ptr: *const *const u8 = argv.as_ptr() as *const *const u8;
-        let argv: *const *const *const u8 = &argv_ptr;
-
-        unsafe {
-            LLVMFuzzerRunDriver(argc, argv, test_input_wrap);
-        }
-    }
+    fuzzer_sandbox::fuzzer_main();
 }
 
 fuzz_target!(|data: ICWasmModule| {

--- a/rs/execution_environment/fuzz/src/lib.rs
+++ b/rs/execution_environment/fuzz/src/lib.rs
@@ -1,0 +1,61 @@
+use ic_canister_sandbox_backend_lib::{
+    canister_sandbox_main, compiler_sandbox::compiler_sandbox_main,
+    launcher::sandbox_launcher_main, RUN_AS_CANISTER_SANDBOX_FLAG, RUN_AS_COMPILER_SANDBOX_FLAG,
+    RUN_AS_SANDBOX_LAUNCHER_FLAG,
+};
+use libfuzzer_sys::test_input_wrap;
+use std::ffi::CString;
+use std::os::raw::c_char;
+
+#[allow(improper_ctypes)]
+extern "C" {
+    fn LLVMFuzzerRunDriver(
+        argc: *const isize,
+        argv: *const *const *const u8,
+        UserCb: fn(data: *const u8, size: usize) -> i32,
+    ) -> i32;
+
+}
+
+// In general, fuzzers don't include `main()` and the initialisation logic is deferred to libfuzzer.
+// However, to enable canister sandboxing, we override the initialisation by providing our own `main()`
+// which acts as a dispatcher for different sandboxed under certain arguments.
+//
+// The default case invokes `LLVMFuzzerRunDriver` which invokes a callback with similar signature as
+// `LLVMFuzzerTestOneInput`. For more details, see https://llvm.org/docs/LibFuzzer.html#using-libfuzzer-as-a-library
+//
+// We provide `libfuzzer_sys::test_input_wrap` as callback for `LLVMFuzzerRunDriver` since libfuzzer_sys
+// already exports `LLVMFuzzerTestOneInput` and we can't override it. `test_input_wrap` internally calls
+// `rust_fuzzer_test_input`, which is generated via the macro `fuzz_target!`.
+// See https://github.com/rust-fuzz/libfuzzer/blob/c8275d1517933765b56a6de61a371bb1cc4268cb/src/lib.rs#L62
+
+pub fn fuzzer_main() {
+    if std::env::args().any(|arg| arg == RUN_AS_CANISTER_SANDBOX_FLAG) {
+        #[cfg(not(fuzzing))]
+        canister_sandbox_main();
+    } else if std::env::args().any(|arg| arg == RUN_AS_SANDBOX_LAUNCHER_FLAG) {
+        #[cfg(not(fuzzing))]
+        sandbox_launcher_main();
+    } else if std::env::args().any(|arg| arg == RUN_AS_COMPILER_SANDBOX_FLAG) {
+        #[cfg(not(fuzzing))]
+        compiler_sandbox_main();
+    } else {
+        // Collect command-line arguments
+        let args: Vec<CString> = std::env::args()
+            .map(|arg| CString::new(arg).unwrap())
+            .collect();
+
+        // Prepare argc as *const isize
+        let argc = args.len() as isize;
+        let argc: *const isize = &argc;
+
+        // Prepare argv as *const *const *const u8
+        let argv: Vec<*const c_char> = args.iter().map(|arg| arg.as_ptr()).collect();
+        let argv_ptr: *const *const u8 = argv.as_ptr() as *const *const u8;
+        let argv: *const *const *const u8 = &argv_ptr;
+
+        unsafe {
+            LLVMFuzzerRunDriver(argc, argv, test_input_wrap);
+        }
+    }
+}


### PR DESCRIPTION
- Add a new helper lib for fuzzers to invoke canister sandbox `//rs/execution_environment/fuzz:fuzzer_sandbox`
- Adapt existing fuzzers to use the `fuzzer_sandbox`