### PR TITLE
fix: Depend on .git/index in commit_timestamp_txt

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -7,6 +7,7 @@ package(default_visibility = ["//visibility:public"])
 # WARNING! .git is the directory, not a regular file! only consume it in your rules if you know how exactly bazel works and understand implications!
 exports_files([
     ".git",
+    ".git/index",
     ".rclone.conf",
     ".rclone-anon.conf",
     "buf.yaml",

--- a/ic-os/components/BUILD.bazel
+++ b/ic-os/components/BUILD.bazel
@@ -30,6 +30,9 @@ exports_files(
 
 genrule(
     name = "commit_timestamp_txt",
+    # Depend on .git/index so that the commit timestamp is regenerated whenever
+    # a new branch is checked out.
+    srcs = ["//:.git/index"],
     outs = ["commit_timestamp.txt"],
     cmd = select({
         "//bazel:is_release_build": "git show -s --format=%ct > $@",
@@ -38,7 +41,6 @@ genrule(
     }),
     tags = [
         "local",
-        "no-cache",
     ],
 )
 


### PR DESCRIPTION
This way the commit timestamp is regenerated whenever a new branch is checked out.