### PR TITLE
chore: stop all HTTP gateways in PocketIC signal handler

### DIFF
--- a/rs/pocket_ic_server/src/main.rs
+++ b/rs/pocket_ic_server/src/main.rs
@@ -254,6 +254,7 @@ async fn terminate(
 ) {
     debug!("The PocketIC server will terminate");
 
+    app_state.api_state.stop_all_http_gateways().await;
     ApiState::delete_all_instances(app_state.api_state).await;
 
     if let Some(port_file_path) = port_file_path {

--- a/rs/pocket_ic_server/src/state_api/state.rs
+++ b/rs/pocket_ic_server/src/state_api/state.rs
@@ -1063,6 +1063,13 @@ impl ApiState {
         }
     }
 
+    pub async fn stop_all_http_gateways(&self) {
+        let mut http_gateways = self.http_gateways.write().await;
+        for i in 0..http_gateways.len() {
+            http_gateways[i] = None;
+        }
+    }
+
     pub async fn auto_progress(
         &self,
         instance_id: InstanceId,

--- a/rs/pocket_ic_server/tests/test.rs
+++ b/rs/pocket_ic_server/tests/test.rs
@@ -689,6 +689,28 @@ fn send_signal_to_pic(pic: PocketIc, mut child: Child, shutdown_signal: Option<S
     }
 }
 
+fn kill_gateway_with_signal(shutdown_signal: Signal) {
+    let (server_url, child) = start_server_helper(None, None, false, false);
+    let mut pic = PocketIcBuilder::new()
+        .with_server_url(server_url)
+        .with_nns_subnet()
+        .with_application_subnet()
+        .build();
+    let _ = pic.make_live(None);
+
+    send_signal_to_pic(pic, child, Some(shutdown_signal));
+}
+
+#[test]
+fn kill_gateway_with_sigint() {
+    kill_gateway_with_signal(Signal::SIGINT);
+}
+
+#[test]
+fn kill_gateway_with_sigterm() {
+    kill_gateway_with_signal(Signal::SIGTERM);
+}
+
 fn canister_state_dir(shutdown_signal: Option<Signal>) {
     const INIT_CYCLES: u128 = 2_000_000_000_000;
 


### PR DESCRIPTION
This PR stops all HTTP gateways in its signal handler before exiting.