### PR TITLE
fix(release-scripts): Remove deprecated `--use-explicit-action-type` from ic-admin command in submit-mainnet-nns-upgrade-proposal.sh

### DIFF
--- a/testnet/tools/nns-tools/submit-mainnet-nns-upgrade-proposal.sh
+++ b/testnet/tools/nns-tools/submit-mainnet-nns-upgrade-proposal.sh
@@ -104,7 +104,6 @@ submit_nns_upgrade_proposal_mainnet() {
         --wasm-module-path="$WASM_GZ"
 
         # Misc
-        --use-explicit-action-type true
         --wasm-module-sha256="$WASM_SHA"
         --proposer="$NEURON_ID"
     )


### PR DESCRIPTION
This PR removes the `--use-explicit-action-type` option from the ic-admin command in submit-mainnet-nns-upgrade-proposal.sh as it has been deprecated.