### PR TITLE
Periodic confirmation api changes daniel wong

### DIFF
--- a/rs/nns/governance/canister/governance.did
+++ b/rs/nns/governance/canister/governance.did
@@ -746,7 +746,14 @@ type NeuronInfo = record {
   visibility : opt int32;
   known_neuron_data : opt KnownNeuronData;
 
-  // Deprecated. Use either deciding_voting_power or potential_voting_power instead.
+  // Deprecated. Use either deciding_voting_power or potential_voting_power
+  // instead. Has the same value as deciding_voting_power.
+  //
+  // Previously, if a neuron had < 6 months dissolve delay (making it ineligible
+  // to vote), this would not get zeroed out. That was pretty confusing. At the
+  // same time this field became deprecated, it started being set to 0 when the
+  // neuron became ineligible to vote, due to inheriting the behavior of
+  // deciding_voting_power (which is derived from potential_voting_power).
   voting_power : nat64;
 
   age_seconds : nat64;

--- a/rs/nns/governance/canister/governance.did
+++ b/rs/nns/governance/canister/governance.did
@@ -505,10 +505,21 @@ type ManageNeuronRequest = record {
   id : opt NeuronId;
   command : opt ManageNeuronCommandRequest;
   neuron_id_or_subaccount : opt NeuronIdOrSubaccount;
+
+  // Controls how the resulting_neuron field in the response is populated.
+  // Possible values here and how the response will be populated:
+  //
+  //     * null - Not populated.
+  //     * 1 - NeuronInfo
+  //     * 2 - NueronInfo, but "big" fields are cleared. To wit,
+  //         * recent_ballots
+  //         * known_neuron_data
+  resulting_neuron_info : opt int32;
 };
 
 type ManageNeuronResponse = record {
   command : opt Command_1;
+  resulting_neuron_info : opt NeuronInfo;
 };
 
 type Merge = record {

--- a/rs/nns/governance/canister/governance.did
+++ b/rs/nns/governance/canister/governance.did
@@ -107,6 +107,18 @@ type ClaimOrRefreshResponse = record {
   refreshed_neuron_id : opt NeuronId;
 };
 
+type RefreshVotingPower = record {
+  // Intentionally left blank.
+};
+
+type RefreshVotingPowerResponse = record {
+  // Intentionally left blank.
+  //
+  // We could add information such as the value in the neuron's
+  // voting_power_refreshed_timestamp_second's field, but let's keep things
+  // minimal until we discover there is a "real need". YAGNI.
+};
+
 type Command = variant {
   Spawn : Spawn;
   Split : Split;
@@ -120,6 +132,7 @@ type Command = variant {
   StakeMaturity : StakeMaturity;
   MergeMaturity : MergeMaturity;
   Disburse : Disburse;
+  RefreshVotingPower : RefreshVotingPower;
 };
 
 type Command_1 = variant {
@@ -136,6 +149,7 @@ type Command_1 = variant {
   StakeMaturity : StakeMaturityResponse;
   MergeMaturity : MergeMaturityResponse;
   Disburse : DisburseResponse;
+  RefreshVotingPower : RefreshVotingPowerResponse;
 };
 
 type Command_2 = variant {

--- a/rs/nns/governance/canister/governance.did
+++ b/rs/nns/governance/canister/governance.did
@@ -505,21 +505,10 @@ type ManageNeuronRequest = record {
   id : opt NeuronId;
   command : opt ManageNeuronCommandRequest;
   neuron_id_or_subaccount : opt NeuronIdOrSubaccount;
-
-  // Controls how the resulting_neuron field in the response is populated.
-  // Possible values here and how the response will be populated:
-  //
-  //     * null - Not populated.
-  //     * 1 - NeuronInfo
-  //     * 2 - NueronInfo, but "big" fields are cleared. To wit,
-  //         * recent_ballots
-  //         * known_neuron_data
-  resulting_neuron_info : opt int32;
 };
 
 type ManageNeuronResponse = record {
   command : opt Command_1;
-  resulting_neuron_info : opt NeuronInfo;
 };
 
 type Merge = record {

--- a/rs/nns/governance/canister/governance.did
+++ b/rs/nns/governance/canister/governance.did
@@ -942,16 +942,20 @@ type ProposalData = record {
   executed_timestamp_seconds : nat64;
   original_total_community_fund_maturity_e8s_equivalent : opt nat64;
 
+  // The total of potential voting power of neurons when this proposal was
+  // created.
+  //
   // This is the baseline that determines the amount of voting rewards (in the
   // form of additional maturity) that voting neurons receive.
   //
   // For example, suppose neuron N has 42 voting power in ballot B for this
-  // proposl. The amount of voting power in B is determined by the neuron's
+  // proposal. The amount of voting power in B is determined by the neuron's
   // deciding voting power when the proposal was created. If this field has 99,
   // then, neuron N receives 42 / 99 of the rewards purse for this proposal.
   //
   // Note that this is NOT used to determine whether the proposal is adopted or
-  // rejected.
+  // rejected. Instead, the total subfield in the latest_tally field is used as
+  // the baseline when deciding proposals.
   total_potential_voting_power : opt nat64;
 };
 

--- a/rs/nns/governance/canister/governance.did
+++ b/rs/nns/governance/canister/governance.did
@@ -676,16 +676,14 @@ type Neuron = record {
   // Per NNS policy, this is opt. Nevertheless, it will never be null.
   deciding_voting_power : opt nat64;
 
-  // The amount of "sway" this neuron has when voting on proposals, assuming
-  // that it has refreshed recently enough.
+  // The amount of "sway" this neuron can have if it refreshes its voting power
+  // frequently enough.
   //
   // Unlike deciding_voting_power, this does NOT take refreshing into account.
   // Rather, this only takes three factors into account:
   //
   //     1. (Net) staked amount - This is the "base" of a neuron's voting power.
-  //        This primarily consists of the balance in the neuron's NNS
-  //        Governance subaccount, but also includes (unburned) fees, and staked
-  //        maturity.
+  //        This primarily consists of the neuron's ICP balance.
   //
   //     2. Age - Neurons with more age have more voting power (all else being
   //        equal).
@@ -695,8 +693,7 @@ type Neuron = record {
   //        than six months are not eligible to vote. Therefore, such neurons
   //        are considered to have 0 voting power.
   //
-  // Per NNS policy, this is opt. Nevertheless, it will never be null (unless we
-  // later deprecate this feature).
+  // Per NNS policy, this is opt. Nevertheless, it will never be null.
   potential_voting_power : opt nat64;
 };
 

--- a/rs/nns/governance/canister/governance.did
+++ b/rs/nns/governance/canister/governance.did
@@ -566,6 +566,30 @@ type NetworkEconomics = record {
   minimum_icp_xdr_rate : nat64;
   maximum_node_provider_rewards_e8s : nat64;
   neurons_fund_economics : opt NeuronsFundEconomics;
+
+  voting_power_economics : opt VotingPowerEconomics;
+};
+
+type VotingPowerEconomics = record {
+  // If a neuron has not "refreshed" its voting power after this amount of time,
+  // its deciding voting power starts decreasing linearly. See also
+  // clear_following_after_seconds.
+  //
+  // For explanation of what "refresh" means in this context, see
+  // https://dashboard.internetcomputer.org/proposal/132411
+  //
+  // Initially, set to 0.5 years. (The nominal length of a year is 365.25 days).
+  start_reducing_voting_power_after_seconds : opt nat64;
+
+  // After a neuron has experienced voting power reduction for this amount of
+  // time, a couple of things happen:
+  //
+  //     1. Deciding voting power reaches 0.
+  //
+  //     2. Its following on topics other than NeuronManagement are cleared.
+  //
+  // Initially, set to 1/12 years.
+  clear_following_after_seconds : opt nat64;
 };
 
 type Neuron = record {

--- a/rs/nns/governance/canister/governance.did
+++ b/rs/nns/governance/canister/governance.did
@@ -593,6 +593,46 @@ type Neuron = record {
   // Per NNS policy, this is opt. Nevertheless, it will never be null (unless we
   // later deprecate this feature).
   voting_power_refreshed_timestamp_seconds : opt nat64;
+
+  // The amount of "sway" this neuron has when voting on proposals.
+  //
+  // If a neuron regularly refreshes its voting power, this value is the same as
+  // potential_voting_power.
+  //
+  // However, if a neuron has not refreshed in more than six months, this will
+  // be less than potential voting power.
+  //
+  // As a further secondary consequence, the neuron receives less voting rewards
+  // (when it votes indirectly via following).
+  //
+  // For details, see https://dashboard.internetcomputer.org/proposal/132411.
+  //
+  // Per NNS policy, this is opt. Nevertheless, it will never be null (unless we
+  // later deprecate this feature).
+  deciding_voting_power : opt nat64;
+
+  // The amount of "sway" this neuron has when voting on proposals, assuming
+  // that it has refreshed recently enough.
+  //
+  // Unlike deciding_voting_power, this does NOT take refreshing into account.
+  // Rather, this only takes three factors into account:
+  //
+  //     1. (Net) staked amount - This is the "base" of a neuron's voting power.
+  //        This primarily consists of the balance in the neuron's NNS
+  //        Governance subaccount, but also includes (unburned) fees, and staked
+  //        maturity.
+  //
+  //     2. Age - Neurons with more age have more voting power (all else being
+  //        equal).
+  //
+  //     3. Dissolve delay - Neurons with longer dissolve delay have more voting
+  //        power (all else being equal). Neurons with a dissolve delay of less
+  //        than six months are not eligible to vote. Therefore, such neurons
+  //        are considered to have 0 voting power.
+  //
+  // Per NNS policy, this is opt. Nevertheless, it will never be null (unless we
+  // later deprecate this feature).
+  potential_voting_power : opt nat64;
 };
 
 type NeuronBasketConstructionParameters = record {
@@ -631,6 +671,7 @@ type NeuronInFlightCommand = record {
   timestamp : nat64;
 };
 
+// In general, this is a subset of Neuron.
 type NeuronInfo = record {
   dissolve_delay_seconds : nat64;
   recent_ballots : vec BallotInfo;
@@ -642,9 +683,14 @@ type NeuronInfo = record {
   retrieved_at_timestamp_seconds : nat64;
   visibility : opt int32;
   known_neuron_data : opt KnownNeuronData;
+
+  // Deprecated. Use either deciding_voting_power or potential_voting_power instead.
   voting_power : nat64;
+
   age_seconds : nat64;
   voting_power_refreshed_timestamp_seconds : opt nat64;
+  deciding_voting_power : opt nat64;
+  potential_voting_power : opt nat64;
 };
 
 type NeuronStakeTransfer = record {

--- a/rs/nns/governance/canister/governance.did
+++ b/rs/nns/governance/canister/governance.did
@@ -627,20 +627,31 @@ type Neuron = record {
   known_neuron_data : opt KnownNeuronData;
   spawn_at_timestamp_seconds : opt nat64;
 
+  // The last time voting power was "refreshed".
+  //
+  // This gets updated to the current time when the user performs one of the
+  // following:
+  //
+  //     1. voting directly (not via following)
+  //     2. set following
+  //     3. refresh voting power
+  //
+  // (All of these actions are performed via the manage_neuron method.)
+  //
   // When a neuron is first created, this is set to create_timestamp_seconds.
-  //
-  // This is part of the "periodic confirmation" feature, which was proposed and
-  // (overwhelmingly) adopted in NNS motion proposal 132411:
-  // https://dashboard.internetcomputer.org/proposal/132411
-  //
-  // This gets updated to the current time when the user performs related
-  // actions, as described in the aforementioned proposal.
   //
   // For neurons created prior to this feature, this field will be set to
   // 2024-09-01T00:00:00 UTC.
   //
-  // Per NNS policy, this is opt. Nevertheless, it will never be null (unless we
-  // later deprecate this feature).
+  // When a neuron has not refreshed for a long time a couple of things happen:
+  //
+  //   1. Deciding voting power becomes less than potential voting power.
+  //   2. Following on most topics is cleared.
+  //
+  // The exact behavior is described here:
+  // https://dashboard.internetcomputer.org/proposal/132411
+  //
+  // Per NNS policy, this is opt. Nevertheless, it will never be null.
   voting_power_refreshed_timestamp_seconds : opt nat64;
 
   // The amount of "sway" this neuron has when voting on proposals.

--- a/rs/nns/governance/canister/governance.did
+++ b/rs/nns/governance/canister/governance.did
@@ -656,19 +656,24 @@ type Neuron = record {
 
   // The amount of "sway" this neuron has when voting on proposals.
   //
-  // If a neuron regularly refreshes its voting power, this value is the same as
-  // potential_voting_power.
+  // If a neuron regularly refreshes its voting power, this has the same value
+  // as potential_voting_power. Actions that cause a refresh are as follows:
   //
-  // However, if a neuron has not refreshed in more than six months, this will
-  // be less than potential voting power.
+  //     1. voting directly (not via following)
+  //     2. set following
+  //     3. refresh voting power
   //
-  // As a further secondary consequence, the neuron receives less voting rewards
-  // (when it votes indirectly via following).
+  // (All of these actions are performed via the manage_neuron method.)
+  //
+  // However, if a neuron has not refreshed in a "long" time, this will be less
+  // than potential voting power. See VotingPowerEconomics. As a further result
+  // of less deciding voting power, not only does it have less influence on the
+  // outcome of proposals, the neuron receives less voting rewards (when it
+  // votes indirectly via following).
   //
   // For details, see https://dashboard.internetcomputer.org/proposal/132411.
   //
-  // Per NNS policy, this is opt. Nevertheless, it will never be null (unless we
-  // later deprecate this feature).
+  // Per NNS policy, this is opt. Nevertheless, it will never be null.
   deciding_voting_power : opt nat64;
 
   // The amount of "sway" this neuron has when voting on proposals, assuming

--- a/rs/nns/governance/canister/governance.did
+++ b/rs/nns/governance/canister/governance.did
@@ -577,6 +577,22 @@ type Neuron = record {
   transfer : opt NeuronStakeTransfer;
   known_neuron_data : opt KnownNeuronData;
   spawn_at_timestamp_seconds : opt nat64;
+
+  // When a neuron is first created, this is set to create_timestamp_seconds.
+  //
+  // This is part of the "periodic confirmation" feature, which was proposed and
+  // (overwhelmingly) adopted in NNS motion proposal 132411:
+  // https://dashboard.internetcomputer.org/proposal/132411
+  //
+  // This gets updated to the current time when the user performs related
+  // actions, as described in the aforementioned proposal.
+  //
+  // For neurons created prior to this feature, this field will be set to
+  // 2024-09-01T00:00:00 UTC.
+  //
+  // Per NNS policy, this is opt. Nevertheless, it will never be null (unless we
+  // later deprecate this feature).
+  voting_power_refreshed_timestamp_seconds : opt nat64;
 };
 
 type NeuronBasketConstructionParameters = record {
@@ -628,6 +644,7 @@ type NeuronInfo = record {
   known_neuron_data : opt KnownNeuronData;
   voting_power : nat64;
   age_seconds : nat64;
+  voting_power_refreshed_timestamp_seconds : opt nat64;
 };
 
 type NeuronStakeTransfer = record {

--- a/rs/nns/governance/canister/governance.did
+++ b/rs/nns/governance/canister/governance.did
@@ -741,10 +741,9 @@ type NeuronInfo = record {
   // instead. Has the same value as deciding_voting_power.
   //
   // Previously, if a neuron had < 6 months dissolve delay (making it ineligible
-  // to vote), this would not get zeroed out. That was pretty confusing. At the
-  // same time this field became deprecated, it started being set to 0 when the
-  // neuron became ineligible to vote, due to inheriting the behavior of
-  // deciding_voting_power (which is derived from potential_voting_power).
+  // to vote), this would not get set to 0 (zero). That was pretty confusing.
+  // Now that this is set to deciding_voting_power, this actually does get
+  // zeroed out.
   voting_power : nat64;
 
   age_seconds : nat64;

--- a/rs/nns/governance/canister/governance.did
+++ b/rs/nns/governance/canister/governance.did
@@ -648,6 +648,8 @@ type Neuron = record {
   //   1. Deciding voting power becomes less than potential voting power.
   //   2. Following on most topics is cleared.
   //
+  // See also VotingPowerEconomics.
+  //
   // The exact behavior is described here:
   // https://dashboard.internetcomputer.org/proposal/132411
   //

--- a/rs/nns/governance/canister/governance.did
+++ b/rs/nns/governance/canister/governance.did
@@ -872,6 +872,18 @@ type ProposalData = record {
   wait_for_quiet_state : opt WaitForQuietState;
   executed_timestamp_seconds : nat64;
   original_total_community_fund_maturity_e8s_equivalent : opt nat64;
+
+  // This is the baseline that determines the amount of voting rewards (in the
+  // form of additional maturity) that voting neurons receive.
+  //
+  // For example, suppose neuron N has 42 voting power in ballot B for this
+  // proposl. The amount of voting power in B is determined by the neuron's
+  // deciding voting power when the proposal was created. If this field has 99,
+  // then, neuron N receives 42 / 99 of the rewards purse for this proposal.
+  //
+  // Note that this is NOT used to determine whether the proposal is adopted or
+  // rejected.
+  total_potential_voting_power : opt nat64;
 };
 
 type ProposalInfo = record {
@@ -892,6 +904,7 @@ type ProposalInfo = record {
   proposal : opt Proposal;
   proposer : opt NeuronId;
   executed_timestamp_seconds : nat64;
+  total_potential_voting_power : opt nat64;
 };
 
 type RegisterVote = record {


### PR DESCRIPTION
We share these changes publicly for feedback via a ["clean" PR][clean-pr]. The code there is the same, but is "clean" in the sense that it does not show all of our internal discussions.

[clean-pr]: https://github.com/dfinity/ic/pull/2568