### PR TITLE
feat: Enable jemalloc profiling

### DIFF
--- a/Cargo.Bazel.Fuzzing.json.lock
+++ b/Cargo.Bazel.Fuzzing.json.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "775d8ca395cdeaa7395617336d62b7b70032dc5510f0b8239a9f3f1e44d70174",
+  "checksum": "4dd212649298c61f95106ea5524eef15ab37238264f92bba2e434a43d4d9f73f",
   "crates": {
     "abnf 0.12.0": {
       "name": "abnf",
@@ -70421,7 +70421,8 @@
         "crate_features": {
           "common": [
             "background_threads_runtime_support",
-            "default"
+            "default",
+            "profiling"
           ],
           "selects": {}
         },
@@ -70439,20 +70440,19 @@
           "selects": {}
         },
         "edition": "2018",
+        "rustc_flags": {
+          "common": [
+            "-C",
+            "opt-level=3"
+          ],
+          "selects": {}
+        },
         "version": "0.5.4+5.3.0-patched"
       },
       "build_script_attrs": {
         "compile_data_glob": [
           "**"
         ],
-        "data": {
-          "common": [],
-          "selects": {
-            "x86_64-unknown-linux-gnu": [
-              "@jemalloc//:libjemalloc"
-            ]
-          }
-        },
         "data_glob": [
           "**"
         ],
@@ -70464,14 +70464,6 @@
             }
           ],
           "selects": {}
-        },
-        "build_script_env": {
-          "common": {},
-          "selects": {
-            "x86_64-unknown-linux-gnu": {
-              "JEMALLOC_OVERRIDE": "$(location @jemalloc//:libjemalloc)"
-            }
-          }
         },
         "links": "jemalloc"
       },
@@ -70514,7 +70506,8 @@
         "crate_features": {
           "common": [
             "background_threads_runtime_support",
-            "default"
+            "default",
+            "profiling"
           ],
           "selects": {}
         },

--- a/Cargo.Bazel.json.lock
+++ b/Cargo.Bazel.json.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "80f4762a2f8fe99bbbf2a4741de304e024aa81ac195a1164df382c19ce84922e",
+  "checksum": "ae961338f1b205cababb2a8d36e79184f40160eb1fc0a8b069c97f8901dd587a",
   "crates": {
     "abnf 0.12.0": {
       "name": "abnf",
@@ -70267,7 +70267,8 @@
         "crate_features": {
           "common": [
             "background_threads_runtime_support",
-            "default"
+            "default",
+            "profiling"
           ],
           "selects": {}
         },
@@ -70285,20 +70286,19 @@
           "selects": {}
         },
         "edition": "2018",
+        "rustc_flags": {
+          "common": [
+            "-C",
+            "opt-level=3"
+          ],
+          "selects": {}
+        },
         "version": "0.5.4+5.3.0-patched"
       },
       "build_script_attrs": {
         "compile_data_glob": [
           "**"
         ],
-        "data": {
-          "common": [],
-          "selects": {
-            "x86_64-unknown-linux-gnu": [
-              "@jemalloc//:libjemalloc"
-            ]
-          }
-        },
         "data_glob": [
           "**"
         ],
@@ -70310,14 +70310,6 @@
             }
           ],
           "selects": {}
-        },
-        "build_script_env": {
-          "common": {},
-          "selects": {
-            "x86_64-unknown-linux-gnu": {
-              "JEMALLOC_OVERRIDE": "$(location @jemalloc//:libjemalloc)"
-            }
-          }
         },
         "links": "jemalloc"
       },
@@ -70360,7 +70352,8 @@
         "crate_features": {
           "common": [
             "background_threads_runtime_support",
-            "default"
+            "default",
+            "profiling"
           ],
           "selects": {}
         },

--- a/bazel/external_crates.bzl
+++ b/bazel/external_crates.bzl
@@ -75,18 +75,10 @@ def external_crates_repository(name, cargo_lockfile, lockfile, sanitizers_enable
             patches = ["@rustix-patch//file:downloaded"],
         )],
         "tikv-jemalloc-sys": [crate.annotation(
-            # Avoid building jemalloc from rust (in part bc it creates builder-specific config files)
-            build_script_data = crate.select([], {
-                "x86_64-unknown-linux-gnu": [
-                    "@jemalloc//:libjemalloc",
-                ],
-            }),
-            build_script_env = crate.select(
-                {},
-                {
-                    "x86_64-unknown-linux-gnu": {"JEMALLOC_OVERRIDE": "$(location @jemalloc//:libjemalloc)"},
-                },
-            ),
+            rustc_flags = [
+                "-C",
+                "opt-level=3",
+            ],
         )],
         "cranelift-isle": [crate.annotation(
             # Patch for determinism issues
@@ -1268,6 +1260,9 @@ def external_crates_repository(name, cargo_lockfile, lockfile, sanitizers_enable
             ),
             "tikv-jemallocator": crate.spec(
                 version = "^0.5",
+                features = [
+                    "profiling",
+                ],
             ),
             "time": crate.spec(
                 version = "^0.3.36",


### PR DESCRIPTION
This builds jemalloc with support for profiling enabled. A bit more work is required for something like a `/pprpf/heap` replica endpoint. And IDX will probably not like whatever it is that building jemalloc from scratch does.

In order to check that this works, run (with `CARGO_BAZEL_REPIN=true` prepended first time around):

```
_RJEM_MALLOC_CONF=prof:true,prof_final:true,prof_leak:true,prof_gdump:true,lg_prof_interval:32,prof_prefix:/tmp/jeprof bazel run //rs/replica:replica
```

You should end up with a bunch of `/tmp/jeprof*` files that can be viewed with the `jeprof` tool.

For more context see https://www.magiroux.com/rust-jemalloc-profiling/