### PR TITLE
test: CON-1434 Prepare `cup_compatibility_test` for removal of `pb::TaggedNiDkgTranscript`

### DIFF
--- a/rs/types/types/src/exhaustive.rs
+++ b/rs/types/types/src/exhaustive.rs
@@ -2,12 +2,12 @@
 
 use crate::consensus::hashed::Hashed;
 use crate::consensus::idkg::common::{PreSignatureInCreation, PreSignatureRef};
-use crate::consensus::idkg::ecdsa::{QuadrupleInCreation, ThresholdEcdsaSigInputsRef};
+use crate::consensus::idkg::ecdsa::QuadrupleInCreation;
 use crate::consensus::idkg::{
     CompletedReshareRequest, CompletedSignature, HasMasterPublicKeyId, IDkgPayload,
     IDkgReshareRequest, IDkgUIDGenerator, MaskedTranscript, MasterKeyTranscript, PreSigId,
-    PseudoRandomId, RandomTranscriptParams, RandomUnmaskedTranscriptParams, RequestId,
-    ReshareOfMaskedParams, ReshareOfUnmaskedParams, UnmaskedTimesMaskedParams, UnmaskedTranscript,
+    PseudoRandomId, RandomTranscriptParams, RandomUnmaskedTranscriptParams, ReshareOfMaskedParams,
+    ReshareOfUnmaskedParams, UnmaskedTimesMaskedParams, UnmaskedTranscript,
 };
 use crate::consensus::{
     Block, BlockPayload, CatchUpShareContent, ConsensusMessageHashable, Payload, SummaryPayload,
@@ -921,27 +921,33 @@ impl HasId<NiDkgId> for NiDkgConfig {
         Some(self.dkg_id().clone())
     }
 }
+
 impl HasId<IDkgTranscriptId> for IDkgTranscript {
     fn get_id(&self) -> Option<IDkgTranscriptId> {
         Some(self.transcript_id)
     }
 }
-impl HasId<IDkgReshareRequest> for ReshareOfUnmaskedParams {}
-impl HasId<PseudoRandomId> for CompletedSignature {}
-impl HasId<IDkgReshareRequest> for CompletedReshareRequest {}
-impl HasId<NodeIndex> for BatchSignedIDkgDealing {}
-impl HasId<SubnetId> for CertifiedStreamSlice {}
-impl HasId<NiDkgTag> for NiDkgTranscript {}
-impl HasId<NiDkgTargetId> for u32 {}
-impl HasId<RequestId> for ThresholdEcdsaSigInputsRef {}
-impl HasId<PreSigId> for PreSignatureInCreation {}
-impl HasId<PreSigId> for PreSignatureRef {}
+
+impl HasId<NiDkgTag> for NiDkgTranscript {
+    fn get_id(&self) -> Option<NiDkgTag> {
+        Some(self.dkg_id.dkg_tag.clone())
+    }
+}
 
 impl HasId<MasterPublicKeyId> for MasterKeyTranscript {
     fn get_id(&self) -> Option<MasterPublicKeyId> {
         Some(self.key_id())
     }
 }
+
+impl HasId<IDkgReshareRequest> for ReshareOfUnmaskedParams {}
+impl HasId<PseudoRandomId> for CompletedSignature {}
+impl HasId<IDkgReshareRequest> for CompletedReshareRequest {}
+impl HasId<NodeIndex> for BatchSignedIDkgDealing {}
+impl HasId<SubnetId> for CertifiedStreamSlice {}
+impl HasId<NiDkgTargetId> for u32 {}
+impl HasId<PreSigId> for PreSignatureInCreation {}
+impl HasId<PreSigId> for PreSignatureRef {}
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
Currently, NiDkg transcripts are stored in the summary using `pb::TaggedNiDkgTranscript`, which contains the `pb::NiDkgTranscript` and the NiDkg tag. The latter data is redundant, as the NiDkg tag is also already part of `pb::NiDkgTranscript`. Therefore we should be able to replace `pb::TaggedNiDkgTranscript` with `pb::NiDkgTranscript` entirely.

To do this, we first need to tell the `cup_compatibility_test` that the current replica version only creates instances of `pb::TaggedNiDkgTranscript`, where `tagged_transcript.tag == tagged_transcript.transcript.tag`. Otherwise, the test would continue to create instances where this isn't the case. These instances of `pb::TaggedNiDkgTranscript` would not be correctly deserialized as `pb::NiDkgTranscript` once we make the switch in a future version.

This is achieved by implementing the `HasId<NiDkgTag>` trait for `NiDkgTranscript`.