### PR TITLE
feat(fuzzing): Introduce `--config=sandbox_fuzzing` bazel flag

### DIFF
--- a/bazel/conf/.bazelrc.build
+++ b/bazel/conf/.bazelrc.build
@@ -120,6 +120,12 @@ build:afl --config=fuzzing
 build:afl --build_tag_filters=afl
 build:afl --run_under="/ic/bin/afl_wrapper.sh"
 
+# Fuzzing w/ Canister Sandbox configuration
+# NOTE: This is only for --config=fuzzing
+# AFL handles this differently in afl_wrapper.sh
+build:sandbox_fuzzing --config=fuzzing
+run:sandbox_fuzzing --run_under="ASAN_OPTIONS=detect_leaks=0:allow_user_segv_handler=1:handle_segv=1:handle_sigfpe=1:handle_sigill=0:quarantine_size_mb=16 LSAN_OPTIONS=handle_sigill=0 RUST_MIN_STACK=8192000"
+
 # Suppress all additional output to make it more convenient in scripts
 query --ui_event_filters=-info,-debug --noshow_progress
 cquery --ui_event_filters=-info,-debug --noshow_progress

--- a/rs/execution_environment/fuzz/fuzz_targets/execute_subnet_message_update_settings.rs
+++ b/rs/execution_environment/fuzz/fuzz_targets/execute_subnet_message_update_settings.rs
@@ -5,10 +5,7 @@ use libfuzzer_sys::{fuzz_target, Corpus};
 // This fuzz tries to execute the UpdateSettings management canister method
 //
 // The fuzz test is only compiled but not executed by CI.
-//
-// ASAN_OPTIONS="detect_leaks=0:allow_user_segv_handler=1:handle_segv=1:handle_sigfpe=1:handle_sigill=0:quarantine_size_mb=16"
-// LSAN_OPTIONS="handle_sigill=0"
-// ASAN_OPTIONS=$ASAN_OPTIONS LSAN_OPTIONS=$LSAN_OPTIONS bazel run --config=fuzzing //rs/execution_environment/fuzz:execute_subnet_message_update_settings
+// bazel run --config=sandbox_fuzzing //rs/execution_environment/fuzz:execute_subnet_message_update_settings
 
 fn main() {
     fuzzer_sandbox::fuzzer_main();

--- a/rs/execution_environment/fuzz/fuzz_targets/execute_system_api_call.rs
+++ b/rs/execution_environment/fuzz/fuzz_targets/execute_system_api_call.rs
@@ -24,9 +24,7 @@ const HELLO_WORLD_WAT: &str = r#"
 )"#;
 
 // To run the fuzzer,
-// ASAN_OPTIONS="detect_leaks=0:allow_user_segv_handler=1:handle_segv=1:handle_sigfpe=1:handle_sigill=0:quarantine_size_mb=16"
-// LSAN_OPTIONS="handle_sigill=0"
-// ASAN_OPTIONS=$ASAN_OPTIONS LSAN_OPTIONS=$LSAN_OPTIONS bazel run --config=fuzzing //rs/execution_environment/fuzz:execute_with_wasm_executor_system_api_call
+// bazel run --config=sandbox_fuzzing //rs/execution_environment/fuzz:execute_with_wasm_executor_system_api_call
 
 fn main() {
     fuzzer_sandbox::fuzzer_main();


### PR DESCRIPTION
This PR introduces a new `--config=sandbox_fuzzing` bazel flag to capture unique runtime env vars for fuzzers using canister sandboxing.

All env_vars will be now added in the `.bazelrc.build` file and sandbox fuzzers can be invoked with `--config=sandbox_fuzzing`.

