### PR TITLE
refactor(ICP_ledger): FI-1570: Rename ledger suite memory-related metrics

### DIFF
--- a/rs/ledger_suite/common/ledger_canister_core/src/runtime.rs
+++ b/rs/ledger_suite/common/ledger_canister_core/src/runtime.rs
@@ -22,14 +22,14 @@ pub trait Runtime {
         Out: for<'a> ArgumentDecoder<'a>;
 }
 
-/// Returns the total amount of memory (heap, stable memory, etc) that has been allocated.
+/// Returns the amount of heap memory in bytes that has been allocated.
 #[cfg(target_arch = "wasm32")]
-pub fn total_memory_size_bytes() -> usize {
+pub fn heap_memory_size_bytes() -> usize {
     const WASM_PAGE_SIZE_BYTES: usize = 65536;
     core::arch::wasm32::memory_size(0) * WASM_PAGE_SIZE_BYTES
 }
 
 #[cfg(not(any(target_arch = "wasm32")))]
-pub fn total_memory_size_bytes() -> usize {
+pub fn heap_memory_size_bytes() -> usize {
     0
 }

--- a/rs/ledger_suite/icp/archive/src/main.rs
+++ b/rs/ledger_suite/icp/archive/src/main.rs
@@ -251,14 +251,14 @@ fn encode_metrics(w: &mut MetricsEncoder<Vec<u8>>) -> std::io::Result<()> {
         "Size of the stable memory allocated by this canister measured in 64K Wasm pages.",
     )?;
     w.encode_gauge(
-        "archive_node_stable_memory_bytes",
+        "stable_memory_bytes",
         (stable_memory_size_in_pages() * 64 * 1024) as f64,
         "Size of the stable memory allocated by this canister measured in bytes.",
     )?;
     w.encode_gauge(
-        "archive_node_total_memory_bytes",
+        "heap_memory_bytes",
         total_memory_size_bytes() as f64,
-        "Total amount of memory (heap, stable memory, etc) that has been allocated by this canister.",
+        "Size of the heap memory allocated by this canister measured in bytes.",
     )?;
     w.encode_gauge(
         "archive_node_last_upgrade_time_seconds",

--- a/rs/ledger_suite/icp/archive/src/main.rs
+++ b/rs/ledger_suite/icp/archive/src/main.rs
@@ -4,7 +4,7 @@ use dfn_core::api::{caller, print, stable_memory_size_in_pages};
 use dfn_core::{over_init, stable, BytesS};
 use dfn_protobuf::protobuf;
 use ic_ledger_canister_core::range_utils;
-use ic_ledger_canister_core::runtime::total_memory_size_bytes;
+use ic_ledger_canister_core::runtime::heap_memory_size_bytes;
 use ic_ledger_core::block::{BlockIndex, BlockType, EncodedBlock};
 use ic_metrics_encoder::MetricsEncoder;
 use icp_ledger::{
@@ -257,7 +257,7 @@ fn encode_metrics(w: &mut MetricsEncoder<Vec<u8>>) -> std::io::Result<()> {
     )?;
     w.encode_gauge(
         "heap_memory_bytes",
-        total_memory_size_bytes() as f64,
+        heap_memory_size_bytes() as f64,
         "Size of the heap memory allocated by this canister measured in bytes.",
     )?;
     w.encode_gauge(

--- a/rs/ledger_suite/icp/index/src/main.rs
+++ b/rs/ledger_suite/icp/index/src/main.rs
@@ -536,14 +536,14 @@ pub fn encode_metrics(w: &mut ic_metrics_encoder::MetricsEncoder<Vec<u8>>) -> st
         "Size of the stable memory allocated by this canister measured in 64K Wasm pages.",
     )?;
     w.encode_gauge(
-        "index_stable_memory_bytes",
+        "stable_memory_bytes",
         (ic_cdk::api::stable::stable_size() * 64 * 1024) as f64,
-        "Size of the stable memory allocated by this canister.",
+        "Size of the stable memory allocated by this canister measured in bytes.",
     )?;
     w.encode_gauge(
-        "index_total_memory_bytes",
+        "heap_memory_bytes",
         total_memory_size_bytes() as f64,
-        "Total amount of memory (heap, stable memory, etc) that has been allocated by this canister.",
+        "Size of the heap memory allocated by this canister measured in bytes.",
     )?;
 
     let cycle_balance = ic_cdk::api::canister_balance128() as f64;

--- a/rs/ledger_suite/icp/index/src/main.rs
+++ b/rs/ledger_suite/icp/index/src/main.rs
@@ -11,7 +11,7 @@ use ic_icp_index::{
     Priority, SettledTransaction, SettledTransactionWithId, Status,
 };
 use ic_icrc1_index_ng::GetAccountTransactionsArgs;
-use ic_ledger_canister_core::runtime::total_memory_size_bytes;
+use ic_ledger_canister_core::runtime::heap_memory_size_bytes;
 use ic_ledger_core::block::{BlockType, EncodedBlock};
 use ic_stable_structures::memory_manager::{MemoryId, VirtualMemory};
 use ic_stable_structures::StableBTreeMap;
@@ -542,7 +542,7 @@ pub fn encode_metrics(w: &mut ic_metrics_encoder::MetricsEncoder<Vec<u8>>) -> st
     )?;
     w.encode_gauge(
         "heap_memory_bytes",
-        total_memory_size_bytes() as f64,
+        heap_memory_size_bytes() as f64,
         "Size of the heap memory allocated by this canister measured in bytes.",
     )?;
 

--- a/rs/ledger_suite/icp/index/tests/tests.rs
+++ b/rs/ledger_suite/icp/index/tests/tests.rs
@@ -1700,8 +1700,8 @@ mod metrics {
     use ic_icp_index::InitArg;
 
     #[test]
-    fn should_export_total_memory_usage_bytes_metrics() {
-        ic_ledger_suite_state_machine_tests::metrics::assert_existence_of_index_total_memory_bytes_metric(
+    fn should_export_heap_memory_usage_bytes_metrics() {
+        ic_ledger_suite_state_machine_tests::metrics::assert_existence_of_index_heap_memory_bytes_metric(
             index_wasm(),
             encode_init_args,
         );

--- a/rs/ledger_suite/icp/ledger/src/main.rs
+++ b/rs/ledger_suite/icp/ledger/src/main.rs
@@ -11,7 +11,7 @@ use dfn_protobuf::protobuf;
 use ic_base_types::CanisterId;
 use ic_canister_log::{LogEntry, Sink};
 use ic_icrc1::endpoints::{convert_transfer_error, StandardRecord};
-use ic_ledger_canister_core::runtime::total_memory_size_bytes;
+use ic_ledger_canister_core::runtime::heap_memory_size_bytes;
 use ic_ledger_canister_core::{
     archive::{Archive, ArchiveOptions},
     ledger::{
@@ -1371,7 +1371,7 @@ fn encode_metrics(w: &mut ic_metrics_encoder::MetricsEncoder<Vec<u8>>) -> std::i
     )?;
     w.encode_gauge(
         "heap_memory_bytes",
-        total_memory_size_bytes() as f64,
+        heap_memory_size_bytes() as f64,
         "Size of the stable memory allocated by this canister measured in bytes.",
     )?;
     w.encode_gauge(

--- a/rs/ledger_suite/icp/ledger/src/main.rs
+++ b/rs/ledger_suite/icp/ledger/src/main.rs
@@ -1365,14 +1365,14 @@ fn encode_metrics(w: &mut ic_metrics_encoder::MetricsEncoder<Vec<u8>>) -> std::i
         "Size of the stable memory allocated by this canister measured in 64K Wasm pages.",
     )?;
     w.encode_gauge(
-        "ledger_stable_memory_bytes",
+        "stable_memory_bytes",
         (dfn_core::api::stable_memory_size_in_pages() * 64 * 1024) as f64,
-        "Size of the stable memory allocated by this canister.",
+        "Size of the stable memory allocated by this canister measured in bytes.",
     )?;
     w.encode_gauge(
-        "ledger_total_memory_bytes",
+        "heap_memory_bytes",
         total_memory_size_bytes() as f64,
-        "Total amount of memory (heap, stable memory, etc) that has been allocated by this canister.",
+        "Size of the stable memory allocated by this canister measured in bytes.",
     )?;
     w.encode_gauge(
         "ledger_transactions_by_hash_cache_entries",

--- a/rs/ledger_suite/icp/ledger/tests/tests.rs
+++ b/rs/ledger_suite/icp/ledger/tests/tests.rs
@@ -1724,8 +1724,8 @@ mod metrics {
     }
 
     #[test]
-    fn should_export_total_memory_usage_metrics() {
-        ic_ledger_suite_state_machine_tests::metrics::assert_existence_of_ledger_total_memory_bytes_metric(
+    fn should_export_ledger_heap_memory_usage_metrics() {
+        ic_ledger_suite_state_machine_tests::metrics::assert_existence_of_heap_memory_bytes_metric(
             ledger_wasm(),
             encode_init_args,
         );

--- a/rs/ledger_suite/icrc1/archive/src/main.rs
+++ b/rs/ledger_suite/icrc1/archive/src/main.rs
@@ -2,7 +2,7 @@ use candid::{candid_method, Principal};
 use ic_canisters_http_types::{HttpRequest, HttpResponse, HttpResponseBuilder};
 use ic_cdk_macros::{init, post_upgrade, query, update};
 use ic_icrc1::{blocks::encoded_block_to_generic_block, Block};
-use ic_ledger_canister_core::runtime::total_memory_size_bytes;
+use ic_ledger_canister_core::runtime::heap_memory_size_bytes;
 use ic_ledger_core::block::{BlockIndex, BlockType, EncodedBlock};
 use ic_stable_structures::memory_manager::{MemoryId, VirtualMemory};
 use ic_stable_structures::{
@@ -370,7 +370,7 @@ fn encode_metrics(w: &mut ic_metrics_encoder::MetricsEncoder<Vec<u8>>) -> std::i
     )?;
     w.encode_gauge(
         "heap_memory_bytes",
-        total_memory_size_bytes() as f64,
+        heap_memory_size_bytes() as f64,
         "Size of the heap memory allocated by this canister measured in bytes.",
     )?;
 

--- a/rs/ledger_suite/icrc1/archive/src/main.rs
+++ b/rs/ledger_suite/icrc1/archive/src/main.rs
@@ -364,14 +364,14 @@ fn encode_metrics(w: &mut ic_metrics_encoder::MetricsEncoder<Vec<u8>>) -> std::i
         "Size of the stable memory allocated by this canister measured in 64K Wasm pages.",
     )?;
     w.encode_gauge(
-        "archive_stable_memory_bytes",
+        "stable_memory_bytes",
         ic_cdk::api::stable::stable_size() as f64 * 65536f64,
-        "Size of the stable memory allocated by this canister.",
+        "Size of the stable memory allocated by this canister measured in bytes.",
     )?;
     w.encode_gauge(
-        "archive_total_memory_bytes",
+        "heap_memory_bytes",
         total_memory_size_bytes() as f64,
-        "Total amount of memory (heap, stable memory, etc) that has been allocated by this canister.",
+        "Size of the heap memory allocated by this canister measured in bytes.",
     )?;
 
     let cycle_balance = ic_cdk::api::canister_balance128() as f64;

--- a/rs/ledger_suite/icrc1/index-ng/src/main.rs
+++ b/rs/ledger_suite/icrc1/index-ng/src/main.rs
@@ -1121,14 +1121,14 @@ pub fn encode_metrics(w: &mut ic_metrics_encoder::MetricsEncoder<Vec<u8>>) -> st
         "Size of the stable memory allocated by this canister measured in 64K Wasm pages.",
     )?;
     w.encode_gauge(
-        "index_stable_memory_bytes",
+        "stable_memory_bytes",
         (ic_cdk::api::stable::stable_size() * 64 * 1024) as f64,
-        "Size of the stable memory allocated by this canister.",
+        "Size of the stable memory allocated by this canister measured in bytes.",
     )?;
     w.encode_gauge(
-        "index_total_memory_bytes",
+        "heap_memory_bytes",
         total_memory_size_bytes() as f64,
-        "Total amount of memory (heap, stable memory, etc) that has been allocated by this canister.",
+        "Size of the heap memory allocated by this canister measured in bytes.",
     )?;
 
     let cycle_balance = ic_cdk::api::canister_balance128() as f64;

--- a/rs/ledger_suite/icrc1/index-ng/src/main.rs
+++ b/rs/ledger_suite/icrc1/index-ng/src/main.rs
@@ -14,7 +14,7 @@ use ic_icrc1_index_ng::{
     GetAccountTransactionsResult, GetBlocksMethod, IndexArg, InitArg, ListSubaccountsArgs, Log,
     LogEntry, Status, TransactionWithId, UpgradeArg, DEFAULT_MAX_BLOCKS_PER_RESPONSE,
 };
-use ic_ledger_canister_core::runtime::total_memory_size_bytes;
+use ic_ledger_canister_core::runtime::heap_memory_size_bytes;
 use ic_ledger_core::block::{BlockIndex as BlockIndex64, BlockType, EncodedBlock};
 use ic_ledger_core::tokens::{CheckedAdd, CheckedSub, Zero};
 use ic_stable_structures::memory_manager::{MemoryId, VirtualMemory};
@@ -1127,7 +1127,7 @@ pub fn encode_metrics(w: &mut ic_metrics_encoder::MetricsEncoder<Vec<u8>>) -> st
     )?;
     w.encode_gauge(
         "heap_memory_bytes",
-        total_memory_size_bytes() as f64,
+        heap_memory_size_bytes() as f64,
         "Size of the heap memory allocated by this canister measured in bytes.",
     )?;
 

--- a/rs/ledger_suite/icrc1/index-ng/tests/tests.rs
+++ b/rs/ledger_suite/icrc1/index-ng/tests/tests.rs
@@ -1352,8 +1352,8 @@ mod metrics {
     use ic_icrc1_index_ng::InitArg;
 
     #[test]
-    fn should_export_total_memory_usage_bytes_metrics() {
-        ic_ledger_suite_state_machine_tests::metrics::assert_existence_of_index_total_memory_bytes_metric(
+    fn should_export_heap_memory_usage_bytes_metrics() {
+        ic_ledger_suite_state_machine_tests::metrics::assert_existence_of_index_heap_memory_bytes_metric(
             index_wasm(),
             encode_init_args,
         );

--- a/rs/ledger_suite/icrc1/index/src/lib.rs
+++ b/rs/ledger_suite/icrc1/index/src/lib.rs
@@ -451,14 +451,14 @@ pub fn encode_metrics(w: &mut ic_metrics_encoder::MetricsEncoder<Vec<u8>>) -> st
         "Size of the stable memory allocated by this canister measured in 64K Wasm pages.",
     )?;
     w.encode_gauge(
-        "index_stable_memory_bytes",
+        "stable_memory_bytes",
         (ic_cdk::api::stable::stable_size() * 64 * 1024) as f64,
-        "Size of the stable memory allocated by this canister.",
+        "Size of the stable memory allocated by this canister measured in bytes.",
     )?;
     w.encode_gauge(
-        "index_total_memory_bytes",
+        "heap_memory_bytes",
         total_memory_size_bytes() as f64,
-        "Total amount of memory (heap, stable memory, etc) that has been allocated by this canister.",
+        "Size of the heap memory allocated by this canister measured in bytes.",
     )?;
 
     let cycle_balance = ic_cdk::api::canister_balance128() as f64;

--- a/rs/ledger_suite/icrc1/index/src/lib.rs
+++ b/rs/ledger_suite/icrc1/index/src/lib.rs
@@ -2,7 +2,7 @@ use candid::{CandidType, Nat};
 use ic_base_types::{CanisterId, PrincipalId};
 use ic_canister_profiler::{measure_span, SpanStats};
 use ic_cdk::api::stable::{StableReader, StableWriter};
-use ic_ledger_canister_core::runtime::total_memory_size_bytes;
+use ic_ledger_canister_core::runtime::heap_memory_size_bytes;
 use icrc_ledger_types::icrc1::transfer::BlockIndex;
 use icrc_ledger_types::icrc3::archive::QueryTxArchiveFn;
 use icrc_ledger_types::icrc3::transactions::{
@@ -457,7 +457,7 @@ pub fn encode_metrics(w: &mut ic_metrics_encoder::MetricsEncoder<Vec<u8>>) -> st
     )?;
     w.encode_gauge(
         "heap_memory_bytes",
-        total_memory_size_bytes() as f64,
+        heap_memory_size_bytes() as f64,
         "Size of the heap memory allocated by this canister measured in bytes.",
     )?;
 

--- a/rs/ledger_suite/icrc1/index/tests/tests.rs
+++ b/rs/ledger_suite/icrc1/index/tests/tests.rs
@@ -673,8 +673,8 @@ mod metrics {
     use ic_icrc1_index::InitArgs;
 
     #[test]
-    fn should_export_total_memory_usage_bytes_metrics() {
-        ic_ledger_suite_state_machine_tests::metrics::assert_existence_of_index_total_memory_bytes_metric(
+    fn should_export_heap_memory_usage_bytes_metrics() {
+        ic_ledger_suite_state_machine_tests::metrics::assert_existence_of_index_heap_memory_bytes_metric(
             index_wasm(),
             encode_init_args,
         );

--- a/rs/ledger_suite/icrc1/ledger/src/main.rs
+++ b/rs/ledger_suite/icrc1/ledger/src/main.rs
@@ -20,7 +20,7 @@ use ic_ledger_canister_core::ledger::{
     apply_transaction, archive_blocks, LedgerAccess, LedgerContext, LedgerData,
     TransferError as CoreTransferError,
 };
-use ic_ledger_canister_core::runtime::total_memory_size_bytes;
+use ic_ledger_canister_core::runtime::heap_memory_size_bytes;
 use ic_ledger_core::block::BlockIndex;
 use ic_ledger_core::timestamp::TimeStamp;
 use ic_ledger_core::tokens::Zero;
@@ -243,7 +243,7 @@ fn encode_metrics(w: &mut ic_metrics_encoder::MetricsEncoder<Vec<u8>>) -> std::i
     )?;
     w.encode_gauge(
         "heap_memory_bytes",
-        total_memory_size_bytes() as f64,
+        heap_memory_size_bytes() as f64,
         "Size of the heap memory allocated by this canister measured in bytes.",
     )?;
 

--- a/rs/ledger_suite/icrc1/ledger/src/main.rs
+++ b/rs/ledger_suite/icrc1/ledger/src/main.rs
@@ -237,14 +237,14 @@ fn encode_metrics(w: &mut ic_metrics_encoder::MetricsEncoder<Vec<u8>>) -> std::i
         "Size of the stable memory allocated by this canister measured in 64K Wasm pages.",
     )?;
     w.encode_gauge(
-        "ledger_stable_memory_bytes",
+        "stable_memory_bytes",
         (ic_cdk::api::stable::stable_size() * 64 * 1024) as f64,
-        "Size of the stable memory allocated by this canister.",
+        "Size of the stable memory allocated by this canister measured in bytes.",
     )?;
     w.encode_gauge(
-        "ledger_total_memory_bytes",
+        "heap_memory_bytes",
         total_memory_size_bytes() as f64,
-        "Total amount of memory (heap, stable memory, etc) that has been allocated by this canister.",
+        "Size of the heap memory allocated by this canister measured in bytes.",
     )?;
 
     let cycle_balance = ic_cdk::api::canister_balance128() as f64;

--- a/rs/ledger_suite/icrc1/ledger/tests/tests.rs
+++ b/rs/ledger_suite/icrc1/ledger/tests/tests.rs
@@ -479,8 +479,8 @@ mod metrics {
     }
 
     #[test]
-    fn should_export_total_memory_usage_metrics() {
-        ic_ledger_suite_state_machine_tests::metrics::assert_existence_of_ledger_total_memory_bytes_metric(
+    fn should_export_heap_memory_usage_metrics() {
+        ic_ledger_suite_state_machine_tests::metrics::assert_existence_of_heap_memory_bytes_metric(
             ledger_wasm(),
             encode_init_args,
         );

--- a/rs/ledger_suite/tests/sm-tests/src/metrics.rs
+++ b/rs/ledger_suite/tests/sm-tests/src/metrics.rs
@@ -10,13 +10,13 @@ pub enum LedgerSuiteType {
     ICRC,
 }
 
-pub fn assert_existence_of_index_total_memory_bytes_metric<T>(
+pub fn assert_existence_of_index_heap_memory_bytes_metric<T>(
     index_wasm: Vec<u8>,
     encode_init_args: fn(Principal) -> T,
 ) where
     T: CandidType,
 {
-    const METRIC: &str = "index_total_memory_bytes";
+    const METRIC: &str = "heap_memory_bytes";
 
     let env = StateMachine::new();
     let ledger_id = CanisterId::from_u64(100);
@@ -42,13 +42,13 @@ pub fn assert_existence_of_ledger_num_archives_metric<T>(
     assert_existence_of_metric(&env, canister_id, METRIC);
 }
 
-pub fn assert_existence_of_ledger_total_memory_bytes_metric<T>(
+pub fn assert_existence_of_heap_memory_bytes_metric<T>(
     ledger_wasm: Vec<u8>,
     encode_init_args: fn(InitArgs) -> T,
 ) where
     T: CandidType,
 {
-    const METRIC: &str = "ledger_total_memory_bytes";
+    const METRIC: &str = "heap_memory_bytes";
 
     let (env, canister_id) = setup(ledger_wasm, encode_init_args, vec![]);
 


### PR DESCRIPTION
Rename the heap- and stable memory-related metrics for the ICP and ICRC ledger suite canisters. This will facilitate the alerting, since a general alert for canisters can be used for all canisters exporting the same metrics under the same names.