### PR TITLE
refactor(sns): Introduce internal CachedUpgradeSteps type and use its instances instead of deployed_version

### DIFF
--- a/rs/sns/governance/proto/ic_sns_governance/pb/v1/governance.proto
+++ b/rs/sns/governance/proto/ic_sns_governance/pb/v1/governance.proto
@@ -2160,6 +2160,7 @@ message AdvanceTargetVersionResponse {}
 message UpgradeJournalEntry {
   oneof event {
     UpgradeStepsRefreshed upgrade_steps_refreshed = 1;
+    UpgradeStepsReset upgrade_steps_reset = 7;
     TargetVersionSet target_version_set = 2;
     TargetVersionReset target_version_reset = 3;
     UpgradeStarted upgrade_started = 4;
@@ -2168,6 +2169,11 @@ message UpgradeJournalEntry {
   optional uint64 timestamp_seconds = 6;
 
   message UpgradeStepsRefreshed {
+    optional Governance.Versions upgrade_steps = 2;
+  }
+
+  message UpgradeStepsReset {
+    optional string human_readable = 1;
     optional Governance.Versions upgrade_steps = 2;
   }
 

--- a/rs/sns/governance/protobuf_generator/src/lib.rs
+++ b/rs/sns/governance/protobuf_generator/src/lib.rs
@@ -64,6 +64,7 @@ pub fn generate_prost_files(proto: ProtoPaths<'_>, out: &Path) {
             "Governance.Versions",
             "UpgradeJournalEntry",
             "UpgradeJournalEntry.event",
+            "UpgradeJournalEntry.UpgradeStepsReset",
             "UpgradeJournalEntry.UpgradeStepsRefreshed",
             "UpgradeJournalEntry.TargetVersionSet",
             "UpgradeJournalEntry.TargetVersionReset",

--- a/rs/sns/governance/src/gen/ic_sns_governance.pb.v1.rs
+++ b/rs/sns/governance/src/gen/ic_sns_governance.pb.v1.rs
@@ -3381,7 +3381,7 @@ pub struct AdvanceTargetVersionResponse {}
 pub struct UpgradeJournalEntry {
     #[prost(uint64, optional, tag = "6")]
     pub timestamp_seconds: ::core::option::Option<u64>,
-    #[prost(oneof = "upgrade_journal_entry::Event", tags = "1, 2, 3, 4, 5")]
+    #[prost(oneof = "upgrade_journal_entry::Event", tags = "1, 7, 2, 3, 4, 5")]
     pub event: ::core::option::Option<upgrade_journal_entry::Event>,
 }
 /// Nested message and enum types in `UpgradeJournalEntry`.
@@ -3396,6 +3396,21 @@ pub mod upgrade_journal_entry {
         ::prost::Message,
     )]
     pub struct UpgradeStepsRefreshed {
+        #[prost(message, optional, tag = "2")]
+        pub upgrade_steps: ::core::option::Option<super::governance::Versions>,
+    }
+    #[derive(
+        candid::CandidType,
+        candid::Deserialize,
+        comparable::Comparable,
+        serde::Serialize,
+        Clone,
+        PartialEq,
+        ::prost::Message,
+    )]
+    pub struct UpgradeStepsReset {
+        #[prost(string, optional, tag = "1")]
+        pub human_readable: ::core::option::Option<::prost::alloc::string::String>,
         #[prost(message, optional, tag = "2")]
         pub upgrade_steps: ::core::option::Option<super::governance::Versions>,
     }
@@ -3528,6 +3543,8 @@ pub mod upgrade_journal_entry {
     pub enum Event {
         #[prost(message, tag = "1")]
         UpgradeStepsRefreshed(UpgradeStepsRefreshed),
+        #[prost(message, tag = "7")]
+        UpgradeStepsReset(UpgradeStepsReset),
         #[prost(message, tag = "2")]
         TargetVersionSet(TargetVersionSet),
         #[prost(message, tag = "3")]

--- a/rs/sns/governance/src/governance.rs
+++ b/rs/sns/governance/src/governance.rs
@@ -4821,7 +4821,7 @@ impl Governance {
         };
 
         let original_cached_upgrade_steps =
-            cached_upgrade_steps("refresh_cached_upgrade_steps (before await)")?;
+            cached_upgrade_steps("refresh_cached_upgrade_steps (before awaiting SNS-W response)")?;
 
         let current_version = original_cached_upgrade_steps.current();
 
@@ -4873,7 +4873,7 @@ impl Governance {
             // This might not be the case if another task has consumed some upgrade steps while this
             // function was refreshing them.
             let cached_upgrade_steps =
-                cached_upgrade_steps("refresh_cached_upgrade_steps (after await)")?;
+                cached_upgrade_steps("refresh_cached_upgrade_steps (after awaiting SNS-W response)")?;
             if cached_upgrade_steps != original_cached_upgrade_steps {
                 log!(
                     INFO,

--- a/rs/sns/governance/src/governance.rs
+++ b/rs/sns/governance/src/governance.rs
@@ -7828,7 +7828,9 @@ mod tests {
                 timestamp_seconds: _,
                 event: Some(upgrade_journal_entry::Event::UpgradeOutcome(
                     upgrade_journal_entry::UpgradeOutcome {
-                        human_readable: None,
+                        human_readable: Some(
+                            format!("Marking upgrade SUCCESS at {}} seconds.", governance.env.now())
+                        ),
                         status: Some(upgrade_journal_entry::upgrade_outcome::Status::Success(
                             Empty {}
                         )),

--- a/rs/sns/governance/src/lib.rs
+++ b/rs/sns/governance/src/lib.rs
@@ -12,6 +12,7 @@ mod request_impls;
 pub mod reward;
 pub mod sns_upgrade;
 pub mod types;
+pub(crate) mod upgrading;
 
 mod treasury;
 

--- a/rs/sns/governance/src/proposal.rs
+++ b/rs/sns/governance/src/proposal.rs
@@ -2457,7 +2457,7 @@ mod tests {
     use super::*;
     use crate::{
         pb::v1::{
-            governance::{self, Version},
+            governance::{self, CachedUpgradeSteps, Version, Versions},
             Ballot, Empty, Governance as GovernanceProto, NeuronId, Proposal, ProposalId,
             Subaccount, WaitForQuietState,
         },
@@ -2515,14 +2515,22 @@ mod tests {
             genesis_timestamp_seconds: 0,
             metrics: None,
             mode: governance::Mode::Normal.into(),
-            deployed_version,
+            cached_upgrade_steps: deployed_version.map(|deployed_version| CachedUpgradeSteps {
+                upgrade_steps: Some(Versions {
+                    versions: vec![Version::from(deployed_version)],
+                }),
+                requested_timestamp_seconds: Some(123),
+                response_timestamp_seconds: Some(456),
+            }),
             pending_version: None,
             is_finalizing_disburse_maturity: None,
             maturity_modulation: None,
-            cached_upgrade_steps: None,
             target_version: None,
             timers: None,
             upgrade_journal: None,
+
+            // Deprecated field.
+            deployed_version: None,
         }
     }
 

--- a/rs/sns/governance/src/proposal.rs
+++ b/rs/sns/governance/src/proposal.rs
@@ -372,8 +372,16 @@ pub(crate) async fn validate_and_render_action(
             validate_and_render_upgrade_sns_controlled_canister(upgrade)
         }
         Action::UpgradeSnsToNextVersion(upgrade_sns) => {
-            let current_version = governance_proto.deployed_version_or_panic();
-
+            let current_version = match governance_proto.cached_upgrade_steps_or_err() {
+                Err(err) => {
+                    return Err(format!(
+                        "Cannot identify current_version required for validating \
+                             and rendering an UpgradeSnsToNextVersion: {}",
+                        err
+                    ));
+                }
+                Ok(cached_upgrade_steps) => cached_upgrade_steps.current(),
+            };
             validate_and_render_upgrade_sns_to_next_version(
                 upgrade_sns,
                 env,

--- a/rs/sns/governance/src/sns_upgrade.rs
+++ b/rs/sns/governance/src/sns_upgrade.rs
@@ -416,54 +416,6 @@ impl Version {
 
         differences
     }
-    pub(crate) fn version_has_expected_hashes(
-        &self,
-        expected_hashes: &[(SnsCanisterType, Vec<u8> /* wasm hash*/)],
-    ) -> Result<(), Vec<String>> {
-        let results = expected_hashes
-            .iter()
-            .map(|(canister_type, expected_hash)| {
-                let actual_hash = self.get_hash_for_type(canister_type);
-                if &actual_hash == expected_hash {
-                    Ok(())
-                } else {
-                    Err(format!(
-                        "Expected hash for {:?} to be: '{}', but it was '{}'",
-                        canister_type,
-                        hex::encode(expected_hash),
-                        hex::encode(actual_hash)
-                    ))
-                }
-            })
-            .collect::<Vec<Result<(), String>>>();
-
-        if results.iter().any(|r| r.is_err()) {
-            Err(results
-                .into_iter()
-                .flat_map(|result| match result {
-                    Ok(_) => None,
-                    Err(e) => Some(e),
-                })
-                .collect::<Vec<_>>())
-        } else {
-            Ok(())
-        }
-    }
-
-    fn get_hash_for_type(&self, canister_type: &SnsCanisterType) -> Vec<u8> {
-        match canister_type {
-            // Unspecified should be impossible given we create the diff we are using,
-            // but we must not panic in a heartbeat, so  we use a value that won't match a
-            // real hash so downstream check will fail.
-            SnsCanisterType::Unspecified => vec![0; 3],
-            SnsCanisterType::Root => self.root_wasm_hash.clone(),
-            SnsCanisterType::Governance => self.governance_wasm_hash.clone(),
-            SnsCanisterType::Ledger => self.ledger_wasm_hash.clone(),
-            SnsCanisterType::Swap => self.swap_wasm_hash.clone(),
-            SnsCanisterType::Archive => self.archive_wasm_hash.clone(),
-            SnsCanisterType::Index => self.index_wasm_hash.clone(),
-        }
-    }
 }
 
 impl From<Version> for SnsVersion {

--- a/rs/sns/governance/src/types.rs
+++ b/rs/sns/governance/src/types.rs
@@ -2752,17 +2752,25 @@ pub mod test_helpers {
 
 impl From<upgrade_journal_entry::UpgradeStepsRefreshed> for upgrade_journal_entry::Event {
     fn from(event: upgrade_journal_entry::UpgradeStepsRefreshed) -> Self {
-        upgrade_journal_entry::Event::UpgradeStepsRefreshed(event)
+        Self::UpgradeStepsRefreshed(event)
     }
 }
+
+impl From<upgrade_journal_entry::UpgradeStepsReset> for upgrade_journal_entry::Event {
+    fn from(event: upgrade_journal_entry::UpgradeStepsReset) -> Self {
+        Self::UpgradeStepsReset(event)
+    }
+}
+
 impl From<upgrade_journal_entry::UpgradeStarted> for upgrade_journal_entry::Event {
     fn from(event: upgrade_journal_entry::UpgradeStarted) -> Self {
-        upgrade_journal_entry::Event::UpgradeStarted(event)
+        Self::UpgradeStarted(event)
     }
 }
+
 impl From<upgrade_journal_entry::UpgradeOutcome> for upgrade_journal_entry::Event {
     fn from(event: upgrade_journal_entry::UpgradeOutcome) -> Self {
-        upgrade_journal_entry::Event::UpgradeOutcome(event)
+        Self::UpgradeOutcome(event)
     }
 }
 // Note, we do not implement From<upgrade_journal_entry::TargetVersionSet> for upgrade_journal_entry::Event

--- a/rs/sns/governance/src/upgrading.rs
+++ b/rs/sns/governance/src/upgrading.rs
@@ -49,9 +49,8 @@ impl TryFrom<&CachedUpgradeStepsPb> for CachedUpgradeSteps {
         else {
             return Err(
                 "Cannot interpret CachedUpgradeSteps; please specify all the required fields: \
-                 upgrade_steps, requested_timestamp_seconds, response_timestamp_seconds.
-                 "
-                .to_string(),
+                 upgrade_steps, requested_timestamp_seconds, response_timestamp_seconds."
+                    .to_string(),
             );
         };
 
@@ -95,6 +94,7 @@ impl CachedUpgradeSteps {
         }
     }
 
+    #[allow(unused)]
     pub fn last(&self) -> Version {
         let Some(last) = self.subsequent_versions.last() else {
             return self.current_version.clone();
@@ -102,10 +102,12 @@ impl CachedUpgradeSteps {
         last.clone()
     }
 
+    #[allow(unused)]
     pub fn contains(&self, version: &Version) -> bool {
         &self.current_version == version || self.subsequent_versions.contains(version)
     }
 
+    #[allow(unused)]
     pub fn is_current(&self, version: &Version) -> bool {
         version == &self.current_version
     }
@@ -115,6 +117,7 @@ impl CachedUpgradeSteps {
     }
 
     /// Approximate time at which this cache was valid.
+    #[allow(unused)]
     pub fn approximate_time_of_validity_timestamp_seconds(&self) -> u64 {
         self.response_timestamp_seconds
     }
@@ -122,6 +125,7 @@ impl CachedUpgradeSteps {
     // Clippy wants us to implement `Iterator for CachedUpgradeSteps`, but that would require adding
     // iterator-specific state to this type, which is an overkill for the purpose of having a simple
     // self-consuming method with an intuitive name.
+    #[allow(unused)]
     #[allow(clippy::should_implement_trait)]
     pub fn into_iter(self) -> impl Iterator<Item = Version> {
         Iterator::chain(
@@ -130,6 +134,7 @@ impl CachedUpgradeSteps {
         )
     }
 
+    #[allow(unused)]
     pub fn validate_new_target_version(&self, new_target: &Version) -> Result<(), String> {
         if !self.contains(new_target) {
             return Err("new_target_version must be among the upgrade steps.".to_string());

--- a/rs/sns/governance/src/upgrading.rs
+++ b/rs/sns/governance/src/upgrading.rs
@@ -1,0 +1,174 @@
+use crate::pb::v1::governance::CachedUpgradeSteps as CachedUpgradeStepsPb;
+use crate::pb::v1::governance::Version;
+use crate::pb::v1::governance::Versions;
+
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) struct CachedUpgradeSteps {
+    current_version: Version,
+    subsequent_versions: Vec<Version>,
+
+    response_timestamp_seconds: u64,
+    requested_timestamp_seconds: u64,
+}
+
+impl From<CachedUpgradeSteps> for CachedUpgradeStepsPb {
+    fn from(src: CachedUpgradeSteps) -> Self {
+        let CachedUpgradeSteps {
+            current_version,
+            subsequent_versions,
+            requested_timestamp_seconds,
+            response_timestamp_seconds,
+        } = src;
+
+        let upgrade_steps = {
+            let mut versions = vec![current_version];
+            versions.extend(subsequent_versions);
+            Some(Versions { versions })
+        };
+
+        Self {
+            upgrade_steps,
+            requested_timestamp_seconds: Some(requested_timestamp_seconds),
+            response_timestamp_seconds: Some(response_timestamp_seconds),
+        }
+    }
+}
+
+impl TryFrom<&CachedUpgradeStepsPb> for CachedUpgradeSteps {
+    type Error = String;
+
+    fn try_from(src: &CachedUpgradeStepsPb) -> Result<Self, Self::Error> {
+        let CachedUpgradeStepsPb {
+            upgrade_steps: Some(upgrade_steps),
+            // requested_timestamp_seconds is not guaranteed to be <= response_timestamp_seconds,
+            // when requested_timestamp_seconds > response_timestamp_seconds it indicates a request
+            // for upgrade steps is in-flight. Thus we don't validate the relationship between them.
+            requested_timestamp_seconds: Some(requested_timestamp_seconds),
+            response_timestamp_seconds: Some(response_timestamp_seconds),
+        } = src
+        else {
+            return Err(
+                "Cannot interpret CachedUpgradeSteps; please specify all the required fields: \
+                 upgrade_steps, requested_timestamp_seconds, response_timestamp_seconds.
+                 "
+                .to_string(),
+            );
+        };
+
+        let Some((current_version, subsequent_versions)) = upgrade_steps.versions.split_first()
+        else {
+            return Err(
+                "Cannot interpret CachedUpgradeSteps: upgrade_steps must not be empty.".to_string(),
+            );
+        };
+
+        Ok(Self {
+            current_version: current_version.clone(),
+            subsequent_versions: subsequent_versions.to_vec(),
+            requested_timestamp_seconds: *requested_timestamp_seconds,
+            response_timestamp_seconds: *response_timestamp_seconds,
+        })
+    }
+}
+
+impl CachedUpgradeSteps {
+    pub fn empty(current_version: Version, now_timestamp_seconds: u64) -> Self {
+        Self {
+            current_version: current_version,
+            subsequent_versions: vec![],
+            requested_timestamp_seconds: 0,
+            response_timestamp_seconds: now_timestamp_seconds,
+        }
+    }
+
+    pub fn new(
+        current_version: Version,
+        subsequent_versions: Vec<Version>,
+        requested_timestamp_seconds: u64,
+        response_timestamp_seconds: u64,
+    ) -> Self {
+        Self {
+            current_version,
+            subsequent_versions,
+            requested_timestamp_seconds,
+            response_timestamp_seconds,
+        }
+    }
+
+    pub fn last(&self) -> Version {
+        let Some(last) = self.subsequent_versions.last() else {
+            return self.current_version.clone();
+        };
+        last.clone()
+    }
+
+    pub fn contains(&self, version: &Version) -> bool {
+        &self.current_version == version || self.subsequent_versions.contains(version)
+    }
+
+    pub fn is_current(&self, version: &Version) -> bool {
+        version == &self.current_version
+    }
+
+    pub fn current(&self) -> Version {
+        self.current_version.clone()
+    }
+
+    /// Approximate time at which this cache was valid.
+    pub fn approximate_time_of_validity_timestamp_seconds(&self) -> u64 {
+        self.response_timestamp_seconds
+    }
+
+    // Clippy wants us to implement `Iterator for CachedUpgradeSteps`, but that would require adding
+    // iterator-specific state to this type, which is an overkill for the purpose of having a simple
+    // self-consuming method with an intuitive name.
+    #[allow(clippy::should_implement_trait)]
+    pub fn into_iter(self) -> impl Iterator<Item = Version> {
+        Iterator::chain(
+            std::iter::once(self.current_version),
+            self.subsequent_versions,
+        )
+    }
+
+    pub fn validate_new_target_version(&self, new_target: &Version) -> Result<(), String> {
+        if !self.contains(new_target) {
+            return Err("new_target_version must be among the upgrade steps.".to_string());
+        }
+        if self.is_current(new_target) {
+            return Err("new_target_version must differ from the current version.".to_string());
+        }
+        Ok(())
+    }
+
+    /// Consume self, returning the previous SNS version and a new CachedUpgradeSteps instance
+    /// containing *all but the current* SNS versions in the Ok result.
+    ///
+    /// Returns `Err` if the current version is the only one (i.e., there are no pending upgrades).
+    pub fn consume(self) -> Result<(Version, CachedUpgradeSteps), String> {
+        let Self {
+            current_version: previous_version,
+            subsequent_versions: previous_subsequent_versions,
+            requested_timestamp_seconds,
+            response_timestamp_seconds,
+        } = self;
+
+        let Some((current_version, subsequent_versions)) =
+            previous_subsequent_versions.split_first()
+        else {
+            return Err(format!(
+                "Cannot consume an upgrade step: only the current version {:?} is available.",
+                previous_version
+            ));
+        };
+
+        Ok((
+            previous_version,
+            Self {
+                current_version: current_version.clone(),
+                subsequent_versions: subsequent_versions.to_vec(),
+                requested_timestamp_seconds,
+                response_timestamp_seconds,
+            },
+        ))
+    }
+}

--- a/rs/sns/governance/src/upgrading.rs
+++ b/rs/sns/governance/src/upgrading.rs
@@ -43,13 +43,13 @@ impl TryFrom<&CachedUpgradeStepsPb> for CachedUpgradeSteps {
             // requested_timestamp_seconds is not guaranteed to be <= response_timestamp_seconds,
             // when requested_timestamp_seconds > response_timestamp_seconds it indicates a request
             // for upgrade steps is in-flight. Thus we don't validate the relationship between them.
-            requested_timestamp_seconds: Some(requested_timestamp_seconds),
-            response_timestamp_seconds: Some(response_timestamp_seconds),
+            requested_timestamp_seconds,
+            response_timestamp_seconds,
         } = src
         else {
             return Err(
-                "Cannot interpret CachedUpgradeSteps; please specify all the required fields: \
-                 upgrade_steps, requested_timestamp_seconds, response_timestamp_seconds."
+                "Cannot interpret CachedUpgradeSteps; \
+                 please specify the required field upgrade_steps"
                     .to_string(),
             );
         };
@@ -61,11 +61,15 @@ impl TryFrom<&CachedUpgradeStepsPb> for CachedUpgradeSteps {
             );
         };
 
+        let requested_timestamp_seconds = requested_timestamp_seconds.unwrap_or_default();
+
+        let response_timestamp_seconds = response_timestamp_seconds.unwrap_or_default();
+
         Ok(Self {
             current_version: current_version.clone(),
             subsequent_versions: subsequent_versions.to_vec(),
-            requested_timestamp_seconds: *requested_timestamp_seconds,
-            response_timestamp_seconds: *response_timestamp_seconds,
+            requested_timestamp_seconds,
+            response_timestamp_seconds,
         })
     }
 }

--- a/rs/sns/governance/src/upgrading.rs
+++ b/rs/sns/governance/src/upgrading.rs
@@ -8,7 +8,7 @@ pub(crate) struct CachedUpgradeSteps {
     subsequent_versions: Vec<Version>,
 
     response_timestamp_seconds: u64,
-    requested_timestamp_seconds: u64,
+    pub requested_timestamp_seconds: u64,
 }
 
 impl From<CachedUpgradeSteps> for CachedUpgradeStepsPb {
@@ -47,11 +47,9 @@ impl TryFrom<&CachedUpgradeStepsPb> for CachedUpgradeSteps {
             response_timestamp_seconds,
         } = src
         else {
-            return Err(
-                "Cannot interpret CachedUpgradeSteps; \
+            return Err("Cannot interpret CachedUpgradeSteps; \
                  please specify the required field upgrade_steps"
-                    .to_string(),
-            );
+                .to_string());
         };
 
         let Some((current_version, subsequent_versions)) = upgrade_steps.versions.split_first()
@@ -179,5 +177,10 @@ impl CachedUpgradeSteps {
                 response_timestamp_seconds,
             },
         ))
+    }
+
+    pub fn is_equivalent_to(&self, other: &Self) -> bool {
+        self.current_version == other.current_version
+            && self.subsequent_versions == other.subsequent_versions
     }
 }

--- a/rs/sns/governance/tests/governance.rs
+++ b/rs/sns/governance/tests/governance.rs
@@ -10,6 +10,7 @@ use ic_nervous_system_common_test_keys::{
     TEST_NEURON_1_OWNER_PRINCIPAL, TEST_NEURON_2_OWNER_PRINCIPAL,
 };
 use ic_nervous_system_proto::pb::v1::{Percentage, Principals};
+use ic_sns_governance::pb::v1::governance::CachedUpgradeSteps;
 use ic_sns_governance::{
     governance::{
         MATURITY_DISBURSEMENT_DELAY_SECONDS, UPGRADE_STEPS_INTERVAL_REFRESH_BACKOFF_SECONDS,
@@ -55,7 +56,6 @@ use maplit::btreemap;
 use pretty_assertions::assert_eq;
 use std::collections::{BTreeMap, HashSet};
 use strum::IntoEnumIterator;
-use ic_sns_governance::pb::v1::governance::CachedUpgradeSteps;
 
 pub mod fixtures;
 

--- a/rs/sns/governance/tests/governance.rs
+++ b/rs/sns/governance/tests/governance.rs
@@ -55,6 +55,7 @@ use maplit::btreemap;
 use pretty_assertions::assert_eq;
 use std::collections::{BTreeMap, HashSet};
 use strum::IntoEnumIterator;
+use ic_sns_governance::pb::v1::governance::CachedUpgradeSteps;
 
 pub mod fixtures;
 
@@ -2864,7 +2865,7 @@ async fn test_mint_tokens() {
 }
 
 #[tokio::test]
-async fn test_refresh_cached_upgrade_steps_noop_if_deployed_version_none() {
+async fn test_refresh_cached_upgrade_steps_noop_if_cached_upgrade_steps_none() {
     let mut canister_fixture = GovernanceCanisterFixtureBuilder::new().create();
 
     // Check that the initial state is None
@@ -2886,7 +2887,7 @@ async fn test_refresh_cached_upgrade_steps_noop_if_deployed_version_none() {
     }
 
     {
-        canister_fixture.governance.proto.deployed_version = None;
+        canister_fixture.governance.proto.cached_upgrade_steps = None;
         canister_fixture
             .governance
             .refresh_cached_upgrade_steps()
@@ -2926,17 +2927,13 @@ async fn test_refresh_cached_upgrade_steps() {
         canister_fixture
             .environment_fixture
             .push_mocked_canister_reply(ListUpgradeStepsResponse { steps });
-        canister_fixture.governance.proto.deployed_version = Some(Version::default());
-    }
-
-    // Check that the initial state is None
-    {
-        let original_cached_upgrade_steps = canister_fixture
-            .governance
-            .proto
-            .cached_upgrade_steps
-            .clone();
-        assert_eq!(original_cached_upgrade_steps, None);
+        canister_fixture.governance.proto.cached_upgrade_steps = Some(CachedUpgradeSteps {
+            upgrade_steps: Some(Versions {
+                versions: vec![Version::default()],
+            }),
+            requested_timestamp_seconds: Some(123),
+            response_timestamp_seconds: Some(456),
+        });
     }
 
     // Check that the canister wants to refresh the cached_upgrade_steps


### PR DESCRIPTION
This PR introduce an internal `CachedUpgradeSteps` type in SNS Governance that holds pre-validated data from the canisters `cached_upgrade_steps` field. Additionally, we make this field represent the sequence `current_version` .. `latest_verison`, so instead of reading a separate field `deployed_version`, the canister now always reads from and updates the data in just one structure (`cached_upgrade_steps`).