### PR TITLE
feat(boundary): add `inspect_message` hook to canister

### DIFF
--- a/rs/boundary_node/rate_limits/canister/canister.rs
+++ b/rs/boundary_node/rate_limits/canister/canister.rs
@@ -36,7 +36,7 @@ fn inspect_message() {
     } else {
         // For the update methods:
         // - Check if the canister's authorized principal is set
-        // - Check the caller_id matches authorized principal
+        // - Check caller_id matches the authorized principal
         with_canister_state(|state| {
             if let Some(authorized_principal) = state.get_authorized_principal() {
                 if caller_id == authorized_principal {

--- a/rs/boundary_node/rate_limits/canister_client/src/main.rs
+++ b/rs/boundary_node/rate_limits/canister_client/src/main.rs
@@ -236,9 +236,9 @@ async fn read_config(agent: &Agent, version: Version, canister_id: Principal) ->
     let args = Encode!(&Some(version)).unwrap();
 
     let response = agent
-        .update(&canister_id, "get_config")
+        .query(&canister_id, "get_config")
         .with_arg(args)
-        .call_and_wait()
+        .call()
         .await
         .expect("update call failed");
 
@@ -276,9 +276,9 @@ async fn read_rule(agent: &Agent, rule_id: &RuleId, canister_id: Principal) {
     let args = Encode!(rule_id).unwrap();
 
     let response = agent
-        .update(&canister_id, "get_rule_by_id")
+        .query(&canister_id, "get_rule_by_id")
         .with_arg(args)
-        .call_and_wait()
+        .call()
         .await
         .expect("update call failed");
 

--- a/rs/boundary_node/rate_limits/integration_tests/src/pocket_ic_helpers.rs
+++ b/rs/boundary_node/rate_limits/integration_tests/src/pocket_ic_helpers.rs
@@ -96,18 +96,26 @@ pub async fn get_installed_wasm_hash(pocket_ic: &PocketIc, canister_id: Principa
 pub async fn canister_call<R: DeserializeOwned + CandidType>(
     pocket_ic: &PocketIc,
     method: &str,
+    method_type: &str,
     canister_id: Principal,
     sender: Principal,
     payload: Vec<u8>,
 ) -> Result<R, String> {
-    let result = pocket_ic
-        .update_call(canister_id, sender, method, payload)
-        .await
-        .map_err(|err| err.to_string())?;
+    let result = match method_type {
+        "query" => pocket_ic
+            .query_call(canister_id, sender, method, payload)
+            .await
+            .map_err(|err| err.to_string())?,
+        "update" => pocket_ic
+            .update_call(canister_id, sender, method, payload)
+            .await
+            .map_err(|err| err.to_string())?,
+        _ => panic!("{method_type} is not allowed"),
+    };
 
     let result = match result {
         WasmResult::Reply(result) => result,
-        WasmResult::Reject(s) => panic!("Call to add_config failed: {:#?}", s),
+        WasmResult::Reject(s) => panic!("Call to {method} failed: {:#?}", s),
     };
 
     let decoded: R = Decode!(&result, R).unwrap();

--- a/rs/boundary_node/rate_limits/integration_tests/tests/rate_limit_canister_tests.rs
+++ b/rs/boundary_node/rate_limits/integration_tests/tests/rate_limit_canister_tests.rs
@@ -56,10 +56,11 @@ async fn main() {
         Principal::anonymous(),
         input_config.clone(),
     )
-    .await
-    .unwrap();
+    .await;
 
-    assert!(response.unwrap_err().contains("Unauthorized"));
+    let err_msg = response.unwrap_err();
+
+    assert!(err_msg.contains("inspect_message_failed: unauthorized caller"));
 
     // Try add config using authorized principal as sender, assert success
     let response: AddConfigResponse = canister_call(

--- a/rs/boundary_node/rate_limits/integration_tests/tests/rate_limit_canister_tests.rs
+++ b/rs/boundary_node/rate_limits/integration_tests/tests/rate_limit_canister_tests.rs
@@ -31,6 +31,7 @@ async fn main() {
     let response: GetConfigResponse = canister_call(
         &pocket_ic,
         "get_config",
+        "query",
         canister_id,
         Principal::anonymous(),
         input_version,
@@ -52,6 +53,7 @@ async fn main() {
     let response: AddConfigResponse = canister_call(
         &pocket_ic,
         "add_config",
+        "update",
         canister_id,
         Principal::anonymous(),
         input_config.clone(),
@@ -60,12 +62,13 @@ async fn main() {
 
     let err_msg = response.unwrap_err();
 
-    assert!(err_msg.contains("inspect_message_failed: unauthorized caller"));
+    assert!(err_msg.contains("message_inspection_failed: unauthorized caller"));
 
     // Try add config using authorized principal as sender, assert success
     let response: AddConfigResponse = canister_call(
         &pocket_ic,
         "add_config",
+        "update",
         canister_id,
         authorized_principal,
         input_config,
@@ -81,6 +84,7 @@ async fn main() {
     let response: GetConfigResponse = canister_call(
         &pocket_ic,
         "get_config",
+        "query",
         canister_id,
         Principal::anonymous(),
         input_version,

--- a/rs/tests/boundary_nodes/rate_limit_canister_test.rs
+++ b/rs/tests/boundary_nodes/rate_limit_canister_test.rs
@@ -325,9 +325,9 @@ async fn read_config(
     let args = Encode!(&Some(version)).unwrap();
 
     let response = agent
-        .update(&canister_id, "get_config")
+        .query(&canister_id, "get_config")
         .with_arg(args)
-        .call_and_wait()
+        .call()
         .await
         .expect("update call failed");
 
@@ -375,9 +375,9 @@ async fn read_rule(
     let args = Encode!(rule_id).unwrap();
 
     let response = agent
-        .update(&canister_id, "get_rule_by_id")
+        .query(&canister_id, "get_rule_by_id")
         .with_arg(args)
-        .call_and_wait()
+        .call()
         .await
         .expect("update call failed");
 


### PR DESCRIPTION
With this [inspect_message()](https://internetcomputer.org/docs/current/developer-docs/backend/rust/message-inspect)  hook, the canister rejects ingress messages in the pre-consensus phase if:
- Called method is neither one of the `update` canister methods nor `get_config` replicated query
- Method's authorization policy is not fulfilled

