### PR TITLE
feat: add function Topology::get_subnet to PocketIC library

### DIFF
--- a/packages/pocket-ic/CHANGELOG.md
+++ b/packages/pocket-ic/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Functions `PocketIc::upload_chunk`, `PocketIc::stored_chunks`, and `PocketIc::clear_chunk_store` to manage the WASM chunk store of a canister.
 - The function `PocketIc::install_chunked_canister` to install a canister from WASM chunks in the WASM chunk store of a canister.
 - The function `PocketIc::fetch_canister_logs` to fetch canister logs via a query call to the management canister.
+- The function `Topology::get_subnet` to get a subnet to which a canister belongs independently of whether the canister exists.
 
 ### Removed
 - Functions `PocketIc::from_config`, `PocketIc::from_config_and_max_request_time`, and `PocketIc::from_config_and_server_url`.

--- a/packages/pocket-ic/tests/tests.rs
+++ b/packages/pocket-ic/tests/tests.rs
@@ -1813,7 +1813,7 @@ fn canister_logs() {
 }
 
 #[test]
-fn get_default_subnet() {
+fn get_subnet() {
     let pic = PocketIcBuilder::new()
         .with_nns_subnet()
         .with_application_subnet()

--- a/packages/pocket-ic/tests/tests.rs
+++ b/packages/pocket-ic/tests/tests.rs
@@ -1811,3 +1811,25 @@ fn canister_logs() {
         log_msg_multiple
     );
 }
+
+#[test]
+fn get_default_subnet() {
+    let pic = PocketIcBuilder::new()
+        .with_nns_subnet()
+        .with_application_subnet()
+        .build();
+
+    let topology = pic.topology();
+
+    let default_subnet = topology
+        .get_subnet(topology.default_effective_canister_id.clone().into())
+        .unwrap();
+    let default_subnet_config = topology.subnet_configs.get(&default_subnet).unwrap();
+    assert_eq!(default_subnet_config.subnet_kind, SubnetKind::Application);
+
+    let nns_subnet = topology
+        .get_subnet(Principal::from_text("rwlgt-iiaaa-aaaaa-aaaaa-cai").unwrap())
+        .unwrap();
+    let nns_subnet_config = topology.subnet_configs.get(&nns_subnet).unwrap();
+    assert_eq!(nns_subnet_config.subnet_kind, SubnetKind::NNS);
+}

--- a/rs/pocket_ic_server/src/pocket_ic.rs
+++ b/rs/pocket_ic_server/src/pocket_ic.rs
@@ -463,6 +463,11 @@ impl PocketIc {
         let mut subnet_configs = BTreeMap::new();
         for (subnet_seed, config) in self.topology.subnet_configs.iter() {
             // What will be returned to the client:
+            let mut canister_ranges: Vec<rest::CanisterIdRange> =
+                config.ranges.iter().map(from_range).collect();
+            if let Some(alloc_range) = config.alloc_range {
+                canister_ranges.push(from_range(&alloc_range));
+            }
             let subnet_config = pocket_ic::common::rest::SubnetConfig {
                 subnet_kind: config.subnet_kind,
                 subnet_seed: *subnet_seed,
@@ -474,7 +479,7 @@ impl PocketIc {
                     .iter()
                     .map(|n| n.node_id.get().0.into())
                     .collect(),
-                canister_ranges: config.ranges.iter().map(from_range).collect(),
+                canister_ranges,
                 instruction_config: config.instruction_config.clone(),
             };
             subnet_configs.insert(config.subnet_id.get().into(), subnet_config);


### PR DESCRIPTION
This PR adds the function `Topology::get_subnet` to the PocketIC library to get the subnet to which a canister belongs independently of whether the canister exists. Such a function is needed to migrate StateMachine tests to PocketIC since StateMachine test API exposes subnet IDs publicly independently of whether canisters are already deployed.