### PR TITLE
chore(node): remove setupos/hostos network bonding and clean up docs

### DIFF
--- a/ic-os/docs/Network-Configuration.adoc
+++ b/ic-os/docs/Network-Configuration.adoc
@@ -13,64 +13,9 @@ Network configuration details for each IC-OS:
 
 == Deterministic MAC Address
 
-Each IC-OS node must have a unique but deterministic MAC address. To solve this, a schema has been devised.
+Each IC-OS node must have a unique but deterministic MAC address derived from its BMC MAC address, deployment type (mainnet vs testnet), and variant type (SetupOS, HostOS, GuestOS, BoundaryGuestOS). This MAC address is then utilized to generate the node's network configuration.
 
-=== Schema
-
-* *The first 8-bits: 6a*
-** Indicates an IPv6 interface.
-
-* *The second 8-bits:*
-** We reserve the following hexadecimal numbers for each IC-OS:
-*** SetupOS: 0f
-*** HostOS: 00
-*** GuestOS: 01
-*** Boundary-GuestOS: 02
-
-* *The remaining 32-bits:*
-** Deterministically generated
-
-=== Example MAC addresses
-
-* SetupOS: `6a:0f:<deterministically-generated-part>`
-* HostOS: `6a:00:<deterministically-generated-part>`
-* GuestOS: `6a:01:<deterministically-generated-part>`
-* BoundaryOS: `6a:02:<deterministically-generated-part>`
-
-=== Deterministically Generated Part
-
-The deterministically generated part is generated using the following inputs:
-
-1. IPMI MAC address (the MAC address of the BMC)
-a. Obtained via `$ ipmitool lan print | grep 'MAC Address'``
-2. Deployment name
-a. Ex: `mainnet`
-
-The concatenation of the IPMI MAC address and deployment name is hashed:
-
-  $ sha256sum "<IPMI MAC ADDRESS><DEPLOYMENT NAME>"
-    # Example:
-    $ sha256sum "3c:ec:ef:6b:37:99mainnet"
-
-The first 32-bits of the sha256 checksum are then used as the deterministically generated part of the MAC address.
-
-  # Checksum
-  f409d72aa8c98ea40a82ea5a0a437798a67d36e587b2cc49f9dabf2de1cedeeb
-
-  # Deterministically Generated Part
-  f409d72a
-
-==== Deployment name
-
-The deployment name is added to the MAC address generation to further increase its uniqueness. The deployment name *mainnet* is reserved for production. Testnets must use other names to avoid any chance of a MAC address collision in the same data center.
-
-The deployment name is retrieved from the +deployment.json+ configuration file, generated as part of the SetupOS:
-
-  {
-    "deployment": {
-      "name": "mainnet"
-    }
-  }
+For details, see the link:../../rs/ic_os/network/mac_address/README.md[mac_address README].
 
 == Hostname
 

--- a/ic-os/docs/Network-Configuration.adoc
+++ b/ic-os/docs/Network-Configuration.adoc
@@ -17,9 +17,8 @@ Each IC-OS node must have a unique but deterministic MAC address. To solve this,
 
 === Schema
 
-* *The first 8-bits:*
-** IPv4 interfaces: 4a
-** IPv6 interfaces: 6a
+* *The first 8-bits: 6a*
+** Indicates an IPv6 interface.
 
 * *The second 8-bits:*
 ** We reserve the following hexadecimal numbers for each IC-OS:
@@ -28,20 +27,15 @@ Each IC-OS node must have a unique but deterministic MAC address. To solve this,
 *** GuestOS: 01
 *** Boundary-GuestOS: 02
 
-** Note: any additional virtual machine on the same physical machine gets the next higher hexadecimal number.
-
 * *The remaining 32-bits:*
 ** Deterministically generated
 
 === Example MAC addresses
 
-* SetupOS: `{4a,6a}:0f:<deterministically-generated-part>`
-* HostOS: `{4a,6a}:00:<deterministically-generated-part>`
-* GuestOS: `{4a,6a}:01:<deterministically-generated-part>`
-* BoundaryOS: `{4a,6a}:02:<deterministically-generated-part>`
-* Next Virtual Machine: `{4a,6a}:03:<deterministically-generated-part>`
-
-Note that the MAC address is expected to be lower-case and to contain colons between the octets.
+* SetupOS: `6a:0f:<deterministically-generated-part>`
+* HostOS: `6a:00:<deterministically-generated-part>`
+* GuestOS: `6a:01:<deterministically-generated-part>`
+* BoundaryOS: `6a:02:<deterministically-generated-part>`
 
 === Deterministically Generated Part
 

--- a/rs/ic_os/network/mac_address/README.md
+++ b/rs/ic_os/network/mac_address/README.md
@@ -1,0 +1,69 @@
+# MAC Address
+
+Each IC-OS node must have a unique but deterministic MAC address derived from its BMC MAC address, deployment type (mainnet vs testnet), and variant type (SetupOS, HostOS, GuestOS, BoundaryGuestOS). This MAC address is then utilized to generate the node’s network configuration. To solve this, a schema has been devised.
+
+## Schema
+
+- **The first 8-bits: `6a`**
+  - Indicates an IPv6 interface.
+
+- **The second 8-bits:**
+  - Reserved hexadecimal numbers for each IC-OS:
+    - SetupOS: `0f`
+    - HostOS: `00`
+    - GuestOS: `01`
+    - Boundary-GuestOS: `02`
+
+- **The remaining 32-bits:**
+  - Deterministically generated.
+
+## Example MAC Addresses
+
+- SetupOS: `6a:0f:<deterministically-generated-part>`
+- HostOS: `6a:00:<deterministically-generated-part>`
+- GuestOS: `6a:01:<deterministically-generated-part>`
+- BoundaryOS: `6a:02:<deterministically-generated-part>`
+
+## Deterministically Generated Part
+
+The deterministically generated part is generated using the following inputs:
+
+1. **IPMI MAC address** (the MAC address of the BMC):
+   - Obtained via:
+     ```bash
+     ipmitool lan print | grep 'MAC Address'
+     ```
+
+2. **Deployment name**:
+   - Example: `mainnet`
+
+The concatenation of the IPMI MAC address and deployment name is hashed:
+
+```bash
+sha256sum "<IPMI MAC ADDRESS><DEPLOYMENT NAME>"
+# Example:
+sha256sum "3c:ec:ef:6b:37:99mainnet"
+```
+
+The first 32 bits of the SHA-256 checksum are then used as the deterministically generated part of the MAC address:
+
+```bash
+Checksum: 
+f409d72aa8c98ea40a82ea5a0a437798a67d36e587b2cc49f9dabf2de1cedeeb
+
+Deterministically Generated Part:
+f409d72a
+```
+
+## Deployment Name
+The deployment name is added to the MAC address generation to further increase its uniqueness. The deployment name mainnet is reserved for production. Testnets must use other names to avoid any chance of a MAC address collision in the same data center.
+
+The deployment name is retrieved from the deployment.json configuration file, generated as part of the SetupOS:
+
+json
+Copy code
+{
+  "deployment": {
+    "name": "mainnet"
+  }
+}

--- a/rs/ic_os/network/mac_address/README.md
+++ b/rs/ic_os/network/mac_address/README.md
@@ -4,8 +4,9 @@ Each IC-OS node must have a unique but deterministic MAC address derived from it
 
 ## Schema
 
-- **The first 8-bits: `6a`**
-  - Indicates an IPv6 interface.
+- **The first 8-bits:**
+  - IPv4 interfaces: 4a
+  - IPv6 interfaces: 6a
 
 - **The second 8-bits:**
   - Reserved hexadecimal numbers for each IC-OS:

--- a/rs/ic_os/network/src/lib.rs
+++ b/rs/ic_os/network/src/lib.rs
@@ -5,7 +5,7 @@ use anyhow::Result;
 use crate::systemd::generate_systemd_config_files;
 use info::NetworkInfo;
 use ipv6::generate_ipv6_address;
-use mac_address::mac_address::UnformattedMacAddress;
+use mac_address::mac_address::{FormattedMacAddress, UnformattedMacAddress};
 
 pub mod info;
 pub mod interfaces;
@@ -23,5 +23,11 @@ pub fn generate_network_config(
     let ipv6_address = generate_ipv6_address(&network_info.ipv6_prefix, &generated_mac)?;
     eprintln!("Using ipv6 address: {}", ipv6_address);
 
-    generate_systemd_config_files(output_directory, network_info, &ipv6_address)
+    let formatted_mac = FormattedMacAddress::from(&generated_mac);
+    generate_systemd_config_files(
+        output_directory,
+        network_info,
+        Some(&formatted_mac),
+        &ipv6_address,
+    )
 }

--- a/rs/ic_os/network/src/lib.rs
+++ b/rs/ic_os/network/src/lib.rs
@@ -5,7 +5,7 @@ use anyhow::Result;
 use crate::systemd::generate_systemd_config_files;
 use info::NetworkInfo;
 use ipv6::generate_ipv6_address;
-use mac_address::mac_address::{FormattedMacAddress, UnformattedMacAddress};
+use mac_address::mac_address::UnformattedMacAddress;
 
 pub mod info;
 pub mod interfaces;
@@ -13,7 +13,7 @@ pub mod ipv6;
 pub mod systemd;
 
 /// Write SetupOS or HostOS systemd network configuration.
-/// Requires superuser permissions to run `ipmitool` and write to the systemd directory
+/// Requires superuser permissions to run ipmitool and write to the systemd directory
 pub fn generate_network_config(
     network_info: &NetworkInfo,
     generated_mac: UnformattedMacAddress,
@@ -23,11 +23,5 @@ pub fn generate_network_config(
     let ipv6_address = generate_ipv6_address(&network_info.ipv6_prefix, &generated_mac)?;
     eprintln!("Using ipv6 address: {}", ipv6_address);
 
-    let formatted_mac = FormattedMacAddress::from(&generated_mac);
-    generate_systemd_config_files(
-        output_directory,
-        network_info,
-        Some(&formatted_mac),
-        &ipv6_address,
-    )
+    generate_systemd_config_files(output_directory, network_info, &ipv6_address)
 }

--- a/rs/ic_os/network/src/lib.rs
+++ b/rs/ic_os/network/src/lib.rs
@@ -5,7 +5,7 @@ use anyhow::Result;
 use crate::systemd::generate_systemd_config_files;
 use info::NetworkInfo;
 use ipv6::generate_ipv6_address;
-use mac_address::mac_address::{FormattedMacAddress, UnformattedMacAddress};
+use mac_address::mac_address::UnformattedMacAddress;
 
 pub mod info;
 pub mod interfaces;
@@ -23,11 +23,5 @@ pub fn generate_network_config(
     let ipv6_address = generate_ipv6_address(&network_info.ipv6_prefix, &generated_mac)?;
     eprintln!("Using ipv6 address: {}", ipv6_address);
 
-    let formatted_mac = FormattedMacAddress::from(&generated_mac);
-    generate_systemd_config_files(
-        output_directory,
-        network_info,
-        Some(&formatted_mac),
-        &ipv6_address,
-    )
+    generate_systemd_config_files(output_directory, network_info, &ipv6_address)
 }

--- a/rs/ic_os/network/src/lib.rs
+++ b/rs/ic_os/network/src/lib.rs
@@ -5,7 +5,7 @@ use anyhow::Result;
 use crate::systemd::generate_systemd_config_files;
 use info::NetworkInfo;
 use ipv6::generate_ipv6_address;
-use mac_address::mac_address::UnformattedMacAddress;
+use mac_address::mac_address::{FormattedMacAddress, UnformattedMacAddress};
 
 pub mod info;
 pub mod interfaces;
@@ -13,7 +13,7 @@ pub mod ipv6;
 pub mod systemd;
 
 /// Write SetupOS or HostOS systemd network configuration.
-/// Requires superuser permissions to run ipmitool and write to the systemd directory
+/// Requires superuser permissions to run `ipmitool` and write to the systemd directory
 pub fn generate_network_config(
     network_info: &NetworkInfo,
     generated_mac: UnformattedMacAddress,
@@ -23,5 +23,11 @@ pub fn generate_network_config(
     let ipv6_address = generate_ipv6_address(&network_info.ipv6_prefix, &generated_mac)?;
     eprintln!("Using ipv6 address: {}", ipv6_address);
 
-    generate_systemd_config_files(output_directory, network_info, &ipv6_address)
+    let formatted_mac = FormattedMacAddress::from(&generated_mac);
+    generate_systemd_config_files(
+        output_directory,
+        network_info,
+        Some(&formatted_mac),
+        &ipv6_address,
+    )
 }

--- a/rs/ic_os/network/src/systemd.rs
+++ b/rs/ic_os/network/src/systemd.rs
@@ -7,7 +7,6 @@ use anyhow::{Context, Result};
 
 use crate::info::NetworkInfo;
 use crate::interfaces::{get_interfaces, has_ipv6_connectivity, Interface};
-use mac_address::mac_address::FormattedMacAddress;
 
 pub static DEFAULT_SYSTEMD_NETWORK_DIR: &str = "/run/systemd/network";
 
@@ -76,7 +75,6 @@ pub fn restart_systemd_networkd() {
 fn generate_and_write_systemd_files(
     output_directory: &Path,
     interface: &Interface,
-    generated_mac: Option<&FormattedMacAddress>,
     ipv6_address: &str,
     ipv6_gateway: &str,
 ) -> Result<()> {
@@ -111,7 +109,6 @@ fn generate_and_write_systemd_files(
 pub fn generate_systemd_config_files(
     output_directory: &Path,
     network_info: &NetworkInfo,
-    generated_mac: Option<&FormattedMacAddress>,
     ipv6_address: &Ipv6Addr,
 ) -> Result<()> {
     let mut interfaces = get_interfaces()?;
@@ -146,7 +143,6 @@ pub fn generate_systemd_config_files(
     generate_and_write_systemd_files(
         output_directory,
         fastest_interface,
-        generated_mac,
         &ipv6_address,
         &network_info.ipv6_gateway.to_string(),
     )?;

--- a/rs/ic_os/network/src/systemd.rs
+++ b/rs/ic_os/network/src/systemd.rs
@@ -7,7 +7,6 @@ use anyhow::{Context, Result};
 
 use crate::info::NetworkInfo;
 use crate::interfaces::{get_interfaces, has_ipv6_connectivity, Interface};
-use mac_address::mac_address::FormattedMacAddress;
 
 pub static DEFAULT_SYSTEMD_NETWORK_DIR: &str = "/run/systemd/network";
 
@@ -18,58 +17,8 @@ DNS=2001:4860:4860::8888
 DNS=2001:4860:4860::8844
 "#;
 
-fn generate_network_interface_content(interface_name: &str) -> String {
-    format!(
-        "
-[Match]
-Name={interface_name}
-
-[Link]
-RequiredForOnline=no
-MTUBytes=1500
-
-[Network]
-LLDP=true
-EmitLLDP=true
-Bond=bond6
-"
-    )
-}
-
-// `mac_line` - Must be in format: "MACAddress=ff:ff:ff:ff:ff:ff". Potentially unnecessary.
-fn generate_bond6_netdev_content(mac_line: &str) -> String {
-    format!(
-        "
-[NetDev]
-Name=bond6
-Kind=bond
-{mac_line}
-
-[Bond]
-Mode=active-backup
-MIIMonitorSec=5
-UpDelaySec=10
-DownDelaySec=10"
-    )
-}
-
-static BOND6_NETWORK_CONTENT: &str = "
-[Match]
-Name=bond6
-
-[Network]
-Bridge=br6";
-
-static BRIDGE6_NETDEV_CONTENT: &str = "
-[NetDev]
-Name=br6
-Kind=bridge
-
-[Bridge]
-ForwardDelaySec=0
-STP=false";
-
-fn generate_bridge6_network_content(
+fn generate_network_interface_content(
+    interface_name: &str,
     ipv6_address: &str,
     ipv6_gateway: &str,
     nameserver_content: &str,
@@ -77,7 +26,7 @@ fn generate_bridge6_network_content(
     format!(
         "
 [Match]
-Name=br6
+Name={interface_name}
 
 [Network]
 DHCP=no
@@ -86,6 +35,12 @@ LinkLocalAddressing=ipv6
 Address={ipv6_address}
 Gateway={ipv6_gateway}
 {nameserver_content}
+LLDP=true
+EmitLLDP=true
+
+[Link]
+RequiredForOnline=no
+MTUBytes=1500
 "
     )
 }
@@ -100,7 +55,6 @@ pub fn restart_systemd_networkd() {
 fn generate_and_write_systemd_files(
     output_directory: &Path,
     interface: &Interface,
-    generated_mac: Option<&FormattedMacAddress>,
     ipv6_address: &str,
     ipv6_gateway: &str,
 ) -> Result<()> {
@@ -109,40 +63,15 @@ fn generate_and_write_systemd_files(
 
     let interface_filename = format!("20-{}.network", interface.name);
     let interface_path = output_directory.join(interface_filename);
-    let interface_content = generate_network_interface_content(&interface.name);
-    eprintln!("Writing {}", interface_path.to_string_lossy());
-    write(interface_path, interface_content)?;
 
-    let bond6_filename = "20-bond6.network";
-    let bond6_path = output_directory.join(bond6_filename);
-    eprintln!("Writing {}", bond6_path.to_string_lossy());
-    write(bond6_path, BOND6_NETWORK_CONTENT)?;
-
-    let bond6_netdev_filename = "20-bond6.netdev";
-    let bond6_netdev_path = output_directory.join(bond6_netdev_filename);
-    let mac_line = match generated_mac {
-        Some(mac) => format!("MACAddress={}", mac.get()),
-        None => String::new(),
-    };
-    let bond6_netdev_content = generate_bond6_netdev_content(&mac_line);
-    eprintln!("Writing {}", bond6_netdev_path.to_string_lossy());
-    write(bond6_netdev_path, bond6_netdev_content)?;
-
-    let bridge6_netdev_filename = "20-br6.netdev";
-    let bridge6_netdev_path = output_directory.join(bridge6_netdev_filename);
-    eprintln!("Writing {}", bridge6_netdev_path.to_string_lossy());
-    write(bridge6_netdev_path, BRIDGE6_NETDEV_CONTENT)?;
-
-    let bridge6_filename = "20-br6.network";
-    let bridge6_path = output_directory.join(bridge6_filename);
-
-    let bridge6_content = generate_bridge6_network_content(
+    let interface_content = generate_network_interface_content(
+        &interface.name,
         ipv6_address,
         ipv6_gateway,
         IPV6_NAME_SERVER_NETWORKD_CONTENTS,
     );
-    eprintln!("Writing {}", bridge6_path.to_string_lossy());
-    write(bridge6_path, bridge6_content)?;
+    eprintln!("Writing {}", interface_path.to_string_lossy());
+    write(interface_path, interface_content)?;
 
     Ok(())
 }
@@ -150,7 +79,6 @@ fn generate_and_write_systemd_files(
 pub fn generate_systemd_config_files(
     output_directory: &Path,
     network_info: &NetworkInfo,
-    generated_mac: Option<&FormattedMacAddress>,
     ipv6_address: &Ipv6Addr,
 ) -> Result<()> {
     let mut interfaces = get_interfaces()?;
@@ -187,7 +115,6 @@ pub fn generate_systemd_config_files(
     generate_and_write_systemd_files(
         output_directory,
         fastest_interface,
-        generated_mac,
         &ipv6_address,
         &network_info.ipv6_gateway.to_string(),
     )?;

--- a/rs/ic_os/network/src/systemd.rs
+++ b/rs/ic_os/network/src/systemd.rs
@@ -31,34 +31,10 @@ MTUBytes=1500
 [Network]
 LLDP=true
 EmitLLDP=true
-Bond=bond6
+Bridge=br6
 "
     )
 }
-
-// `mac_line` - Must be in format: "MACAddress=ff:ff:ff:ff:ff:ff". Potentially unnecessary.
-fn generate_bond6_netdev_content(mac_line: &str) -> String {
-    format!(
-        "
-[NetDev]
-Name=bond6
-Kind=bond
-{mac_line}
-
-[Bond]
-Mode=active-backup
-MIIMonitorSec=5
-UpDelaySec=10
-DownDelaySec=10"
-    )
-}
-
-static BOND6_NETWORK_CONTENT: &str = "
-[Match]
-Name=bond6
-
-[Network]
-Bridge=br6";
 
 static BRIDGE6_NETDEV_CONTENT: &str = "
 [NetDev]
@@ -113,21 +89,6 @@ fn generate_and_write_systemd_files(
     eprintln!("Writing {}", interface_path.to_string_lossy());
     write(interface_path, interface_content)?;
 
-    let bond6_filename = "20-bond6.network";
-    let bond6_path = output_directory.join(bond6_filename);
-    eprintln!("Writing {}", bond6_path.to_string_lossy());
-    write(bond6_path, BOND6_NETWORK_CONTENT)?;
-
-    let bond6_netdev_filename = "20-bond6.netdev";
-    let bond6_netdev_path = output_directory.join(bond6_netdev_filename);
-    let mac_line = match generated_mac {
-        Some(mac) => format!("MACAddress={}", mac.get()),
-        None => String::new(),
-    };
-    let bond6_netdev_content = generate_bond6_netdev_content(&mac_line);
-    eprintln!("Writing {}", bond6_netdev_path.to_string_lossy());
-    write(bond6_netdev_path, bond6_netdev_content)?;
-
     let bridge6_netdev_filename = "20-br6.netdev";
     let bridge6_netdev_path = output_directory.join(bridge6_netdev_filename);
     eprintln!("Writing {}", bridge6_netdev_path.to_string_lossy());
@@ -158,8 +119,8 @@ pub fn generate_systemd_config_files(
     eprintln!("Interfaces sorted by speed: {:?}", interfaces);
 
     let ping_target = network_info.ipv6_gateway.to_string();
-    // old nodes are still configured with a local IPv4 interface connection
-    // local IPv4 interfaces must be filtered out
+    // Old nodes are still configured with a local IPv4 interface connection
+    // Local IPv4 interfaces must be filtered out
     let ipv6_interfaces: Vec<&Interface> = interfaces
         .iter()
         .filter(|i| {
@@ -173,9 +134,7 @@ pub fn generate_systemd_config_files(
         })
         .collect();
 
-    // For now only assign the fastest interface to ipv6.
-    // TODO - probe to make sure the interfaces are on the same network before doing active-backup bonding.
-    // TODO - Ensure ipv6 connectivity exists
+    // Only assign the fastest interface to ipv6.
     let fastest_interface = ipv6_interfaces
         .first()
         .context("Could not find any network interfaces")?;


### PR DESCRIPTION
NODE-1527

Remove bonding. It's added complexity that we don't need.

I successfully testing on bare metal and networking still works 👍 

zh2-dll01 on master:
![Pasted Graphic 19](https://github.com/user-attachments/assets/af3b9972-ba91-48e8-8bb5-db89c23666cf)

On branch:
<img width="1209" alt="image" src="https://github.com/user-attachments/assets/fae924ee-8c32-4b1f-8c6a-a5bf566bbc35">

----

GuestOS `$ ip a` output is unchanged