### PR TITLE
feat(nns): Add voting_power_economics to NetworkEconomics.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10360,6 +10360,7 @@ dependencies = [
  "ic-base-types",
  "ic-crypto-sha2",
  "ic-nervous-system-clients",
+ "ic-nervous-system-common",
  "ic-nervous-system-common-validation",
  "ic-nervous-system-proto",
  "ic-nns-common",

--- a/rs/nns/governance/api/BUILD.bazel
+++ b/rs/nns/governance/api/BUILD.bazel
@@ -8,6 +8,7 @@ DEPENDENCIES = [
     "//rs/crypto/sha2",
     "//rs/ledger_suite/icp:icp_ledger",
     "//rs/nervous_system/clients",
+    "//rs/nervous_system/common",
     "//rs/nervous_system/common/validation",
     "//rs/nervous_system/proto",
     "//rs/nns/common",

--- a/rs/nns/governance/api/Cargo.toml
+++ b/rs/nns/governance/api/Cargo.toml
@@ -17,6 +17,7 @@ comparable = { version = "0.5", features = ["derive"] }
 ic-base-types = { path = "../../../types/base_types" }
 ic-crypto-sha2 = { path = "../../../crypto/sha2" }
 ic-nervous-system-clients = { path = "../../../nervous_system/clients" }
+ic-nervous-system-common = { path = "../../../nervous_system/common" }
 ic-nervous-system-common-validation = { path = "../../../nervous_system/common/validation" }
 ic-nervous-system-proto = { path = "../../../nervous_system/proto" }
 ic-nns-common = { path = "../../common" }

--- a/rs/nns/governance/api/src/ic_nns_governance.pb.v1.rs
+++ b/rs/nns/governance/api/src/ic_nns_governance.pb.v1.rs
@@ -2097,7 +2097,47 @@ pub struct NetworkEconomics {
     /// Global Neurons' Fund participation thresholds.
     #[prost(message, optional, tag = "11")]
     pub neurons_fund_economics: Option<NeuronsFundEconomics>,
+
+    /// Parameters that affect the voting power of neurons.
+    #[prost(message, optional, tag = "12")]
+    pub voting_power_economics: ::core::option::Option<VotingPowerEconomics>,
 }
+
+/// Parameters that affect the voting power of neurons.
+#[derive(
+    candid::CandidType,
+    candid::Deserialize,
+    serde::Serialize,
+    comparable::Comparable,
+    Clone,
+    Copy,
+    PartialEq,
+    ::prost::Message,
+)]
+pub struct VotingPowerEconomics {
+    /// If a neuron has not "refreshed" its voting power after this amount of time,
+    /// its deciding voting power starts decreasing linearly. See also
+    /// clear_following_after_seconds.
+    ///
+    /// For explanation of what "refresh" means in this context, see
+    /// <https://dashboard.internetcomputer.org/proposal/132411>
+    ///
+    /// Initially, set to 0.5 years. (The nominal length of a year is 365.25 days).
+    #[prost(uint64, optional, tag = "1")]
+    pub start_reducing_voting_power_after_seconds: ::core::option::Option<u64>,
+
+    /// After a neuron has experienced voting power reduction for this amount of
+    /// time, a couple of things happen:
+    ///
+    ///      1. Deciding voting power reaches 0.
+    ///
+    ///      2. Its following on topics other than NeuronManagement are cleared.
+    ///
+    /// Initially, set to 1/12 years.
+    #[prost(uint64, optional, tag = "2")]
+    pub clear_following_after_seconds: ::core::option::Option<u64>,
+}
+
 /// The thresholds specify the shape of the ideal matching function used by the Neurons' Fund to
 /// determine how much to contribute for a given direct participation amount. Note that the actual
 /// swap participation is in ICP, whereas these thresholds are specifid in XDR; the conversion rate

--- a/rs/nns/governance/api/src/pb.rs
+++ b/rs/nns/governance/api/src/pb.rs
@@ -105,11 +105,18 @@ impl NetworkEconomics {
 }
 
 impl VotingPowerEconomics {
+    pub const DEFAULT: Self = Self {
+        start_reducing_voting_power_after_seconds: Some(
+            Self::DEFAULT_START_REDUCING_VOTING_POWER_AFTER_SECONDS,
+        ),
+        clear_following_after_seconds: Some(Self::DEFAULT_CLEAR_FOLLOWING_AFTER_SECONDS),
+    };
+
+    pub const DEFAULT_START_REDUCING_VOTING_POWER_AFTER_SECONDS: u64 = 6 * ONE_MONTH_SECONDS;
+    pub const DEFAULT_CLEAR_FOLLOWING_AFTER_SECONDS: u64 = ONE_MONTH_SECONDS;
+
     pub fn with_default_values() -> Self {
-        Self {
-            start_reducing_voting_power_after_seconds: Some(6 * ONE_MONTH_SECONDS),
-            clear_following_after_seconds: Some(ONE_MONTH_SECONDS),
-        }
+        Self::DEFAULT
     }
 }
 

--- a/rs/nns/governance/api/src/pb.rs
+++ b/rs/nns/governance/api/src/pb.rs
@@ -2,8 +2,9 @@ use crate::pb::v1::{
     governance::migration::MigrationStatus, governance_error::ErrorType, manage_neuron_response,
     neuron::DissolveState, CreateServiceNervousSystem, GovernanceError, ManageNeuronResponse,
     NetworkEconomics, Neuron, NeuronState, NeuronsFundEconomics,
-    NeuronsFundMatchedFundingCurveCoefficients, XdrConversionRate,
+    NeuronsFundMatchedFundingCurveCoefficients, VotingPowerEconomics, XdrConversionRate,
 };
+use ic_nervous_system_common::{ONE_DAY_SECONDS, ONE_MONTH_SECONDS};
 use ic_nervous_system_proto::pb::v1::{Decimal, Duration, GlobalTimeOfDay, Percentage};
 use icp_ledger::{DEFAULT_TRANSFER_FEE, TOKEN_SUBDIVIDABLE_BY};
 use std::fmt;
@@ -14,8 +15,6 @@ pub mod v1;
 
 /// The number of e8s per ICP;
 const E8S_PER_ICP: u64 = TOKEN_SUBDIVIDABLE_BY;
-// TODO get this from nervous_system/common/consts after we migrate consts out of nervous_system/common
-pub const ONE_DAY_SECONDS: u64 = 24 * 60 * 60;
 
 impl ManageNeuronResponse {
     pub fn panic_if_error(self, msg: &str) -> Self {
@@ -100,6 +99,16 @@ impl NetworkEconomics {
             transaction_fee_e8s: DEFAULT_TRANSFER_FEE.get_e8s(),
             max_proposals_to_keep_per_topic: 100,
             neurons_fund_economics: Some(NeuronsFundEconomics::with_default_values()),
+            voting_power_economics: Some(VotingPowerEconomics::with_default_values()),
+        }
+    }
+}
+
+impl VotingPowerEconomics {
+    pub fn with_default_values() -> Self {
+        Self {
+            start_reducing_voting_power_after_seconds: Some(6 * ONE_MONTH_SECONDS),
+            clear_following_after_seconds: Some(ONE_MONTH_SECONDS),
         }
     }
 }

--- a/rs/nns/governance/canbench/canbench_results.yml
+++ b/rs/nns/governance/canbench/canbench_results.yml
@@ -109,7 +109,7 @@ benches:
     scopes: {}
   range_neurons_performance:
     total:
-      instructions: 48547417
+      instructions: 47978708
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}

--- a/rs/nns/governance/canbench/canbench_results.yml
+++ b/rs/nns/governance/canbench/canbench_results.yml
@@ -55,7 +55,7 @@ benches:
     scopes: {}
   compute_ballots_for_new_proposal_with_stable_neurons:
     total:
-      instructions: 1830966
+      instructions: 1798483
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}

--- a/rs/nns/governance/canister/canister.rs
+++ b/rs/nns/governance/canister/canister.rs
@@ -535,7 +535,7 @@ fn canister_post_upgrade() {
              CANISTER MIGHT HAVE BROKEN STATE!!!!.",
     );
 
-    // TODO(NNS1- DO NOT MERGE): This can be deleted after it has been released.
+    // TODO(NNS1-3446): This can be deleted after it has been released.
     set_initial_voting_power_economics(&mut restored_state);
 
     grow_upgrades_memory_to(WASM_PAGES_RESERVED_FOR_UPGRADES_MEMORY);

--- a/rs/nns/governance/canister/canister.rs
+++ b/rs/nns/governance/canister/canister.rs
@@ -20,6 +20,7 @@ use ic_nns_common::{
 };
 use ic_nns_constants::LEDGER_CANISTER_ID;
 use ic_nns_governance::{
+    data_migration::set_initial_voting_power_economics,
     decoder_config, encode_metrics,
     governance::{Environment, Governance, HeapGrowthPotential, RngError, TimeWarp as GovTimeWarp},
     is_prune_following_enabled,
@@ -500,8 +501,11 @@ fn canister_init_(init_payload: ApiGovernanceProto) {
     );
 
     schedule_timers();
+
+    let mut governance_proto = InternalGovernanceProto::from(init_payload);
+    set_initial_voting_power_economics(&mut governance_proto);
     set_governance(Governance::new(
-        InternalGovernanceProto::from(init_payload),
+        governance_proto,
         Box::new(CanisterEnv::new()),
         Box::new(IcpLedgerCanister::<CdkRuntime>::new(LEDGER_CANISTER_ID)),
         Box::new(CMCCanister::<CdkRuntime>::new()),
@@ -522,7 +526,7 @@ fn canister_pre_upgrade() {
 fn canister_post_upgrade() {
     println!("{}Executing post upgrade", LOG_PREFIX);
 
-    let restored_state = with_upgrades_memory(|memory| {
+    let mut restored_state = with_upgrades_memory(|memory| {
         let result: Result<InternalGovernanceProto, _> = load_protobuf(memory);
         result
     })
@@ -530,6 +534,9 @@ fn canister_post_upgrade() {
         "Error deserializing canister state post-upgrade with MemoryManager memory segment. \
              CANISTER MIGHT HAVE BROKEN STATE!!!!.",
     );
+
+    // TODO(NNS1- DO NOT MERGE): This can be deleted after it has been released.
+    set_initial_voting_power_economics(&mut restored_state);
 
     grow_upgrades_memory_to(WASM_PAGES_RESERVED_FOR_UPGRADES_MEMORY);
 

--- a/rs/nns/governance/canister/governance.did
+++ b/rs/nns/governance/canister/governance.did
@@ -569,6 +569,32 @@ type NetworkEconomics = record {
   minimum_icp_xdr_rate : nat64;
   maximum_node_provider_rewards_e8s : nat64;
   neurons_fund_economics : opt NeuronsFundEconomics;
+
+  // Parameters that affect the voting power of neurons.
+  voting_power_economics : opt VotingPowerEconomics;
+};
+
+// Parameters that affect the voting power of neurons.
+type VotingPowerEconomics = record {
+  // If a neuron has not "refreshed" its voting power after this amount of time,
+  // its deciding voting power starts decreasing linearly. See also
+  // clear_following_after_seconds.
+  //
+  // For explanation of what "refresh" means in this context, see
+  // https://dashboard.internetcomputer.org/proposal/132411
+  //
+  // Initially, set to 0.5 years. (The nominal length of a year is 365.25 days).
+  start_reducing_voting_power_after_seconds : opt nat64;
+
+  // After a neuron has experienced voting power reduction for this amount of
+  // time, a couple of things happen:
+  //
+  //     1. Deciding voting power reaches 0.
+  //
+  //     2. Its following on topics other than NeuronManagement are cleared.
+  //
+  // Initially, set to 1/12 years.
+  clear_following_after_seconds : opt nat64;
 };
 
 type Neuron = record {

--- a/rs/nns/governance/canister/governance_test.did
+++ b/rs/nns/governance/canister/governance_test.did
@@ -571,6 +571,32 @@ type NetworkEconomics = record {
   minimum_icp_xdr_rate : nat64;
   maximum_node_provider_rewards_e8s : nat64;
   neurons_fund_economics : opt NeuronsFundEconomics;
+
+  // Parameters that affect the voting power of neurons.
+  voting_power_economics : opt VotingPowerEconomics;
+};
+
+// Parameters that affect the voting power of neurons.
+type VotingPowerEconomics = record {
+  // If a neuron has not "refreshed" its voting power after this amount of time,
+  // its deciding voting power starts decreasing linearly. See also
+  // clear_following_after_seconds.
+  //
+  // For explanation of what "refresh" means in this context, see
+  // https://dashboard.internetcomputer.org/proposal/132411
+  //
+  // Initially, set to 0.5 years. (The nominal length of a year is 365.25 days).
+  start_reducing_voting_power_after_seconds : opt nat64;
+
+  // After a neuron has experienced voting power reduction for this amount of
+  // time, a couple of things happen:
+  //
+  //     1. Deciding voting power reaches 0.
+  //
+  //     2. Its following on topics other than NeuronManagement are cleared.
+  //
+  // Initially, set to 1/12 years.
+  clear_following_after_seconds : opt nat64;
 };
 
 type Neuron = record {

--- a/rs/nns/governance/proto/ic_nns_governance/pb/v1/governance.proto
+++ b/rs/nns/governance/proto/ic_nns_governance/pb/v1/governance.proto
@@ -1896,6 +1896,32 @@ message NetworkEconomics {
 
   // Global Neurons' Fund participation thresholds.
   optional NeuronsFundEconomics neurons_fund_economics = 11;
+
+  // Parameters that affect the voting power of neurons.
+  VotingPowerEconomics voting_power_economics = 12;
+}
+
+// Parameters that affect the voting power of neurons.
+message VotingPowerEconomics {
+  // If a neuron has not "refreshed" its voting power after this amount of time,
+  // its deciding voting power starts decreasing linearly. See also
+  // clear_following_after_seconds.
+  //
+  // For explanation of what "refresh" means in this context, see
+  // https://dashboard.internetcomputer.org/proposal/132411
+  //
+  // Initially, set to 0.5 years. (The nominal length of a year is 365.25 days).
+  optional uint64 start_reducing_voting_power_after_seconds = 1;
+
+  // After a neuron has experienced voting power reduction for this amount of
+  // time, a couple of things happen:
+  //
+  //     1. Deciding voting power reaches 0.
+  //
+  //     2. Its following on topics other than NeuronManagement are cleared.
+  //
+  // Initially, set to 1/12 years.
+  optional uint64 clear_following_after_seconds = 2;
 }
 
 // The thresholds specify the shape of the ideal matching function used by the Neurons' Fund to

--- a/rs/nns/governance/src/data_migration.rs
+++ b/rs/nns/governance/src/data_migration.rs
@@ -1,0 +1,66 @@
+//! This module is the home of code that you call from post_upgrade and/or init,
+//! and only has an effect once.
+//!
+//! Ideally, once such code is released, it gets deleted. At the same time,
+//! ideally, it is safe for the same code to be in multiple releases.
+//!
+//! A typical use case is that you add some field, and you want to give it some
+//! initial value, but thereafter, it can be changed as the result of requests
+//! (e.g. create a proposal followed by many votes in favor).
+
+use crate::pb::v1::{Governance, VotingPowerEconomics};
+
+#[path = "data_migration_tests.rs"]
+#[cfg(test)]
+mod tests;
+
+/// This ensures that the fields in voting_power_economics are set.
+///
+/// If they already have Some value, the existing values are left alone.
+///
+/// Whereas, if values are missing (or voting_power_economics itself is None),
+/// they get set according to DEFAULT_VOTING_POWER_ECONOMICS.
+///
+/// What we expect in production is that when governance is upgraded,
+/// voting_power_economics will default to None, and during post_ugprade, this
+/// gets called, causing voting_power_economics to be set to
+/// DEFAULT_VOTING_POWER_ECONOMICS.
+///
+/// In testing, when a new governance canister is created,
+/// voting_power_economics gets set in init, which also calls this.
+pub fn set_initial_voting_power_economics(governance: &mut Governance) {
+    let economics = governance.economics.as_mut();
+
+    let Some(economics) = economics else {
+        // DO NOT MERGE - Log.
+        return;
+    };
+
+    let voting_power_economics = economics.voting_power_economics.as_mut();
+    let default = VotingPowerEconomics::with_default_values();
+
+    let Some(voting_power_economics) = voting_power_economics else {
+        // DO NOT MERGE - Log.
+        economics.voting_power_economics = Some(default);
+        return;
+    };
+
+    // This is weird, but we handle it anyway instead of freaking out.
+    // DO NOT MERGE - Log.
+
+    let VotingPowerEconomics {
+        start_reducing_voting_power_after_seconds,
+        clear_following_after_seconds,
+    } = voting_power_economics;
+
+    if start_reducing_voting_power_after_seconds.is_none() {
+        // DO NOT MERGE - Log.
+        *start_reducing_voting_power_after_seconds =
+            default.start_reducing_voting_power_after_seconds;
+    }
+
+    if clear_following_after_seconds.is_none() {
+        // DO NOT MERGE - Log.
+        *clear_following_after_seconds = default.clear_following_after_seconds;
+    }
+}

--- a/rs/nns/governance/src/data_migration.rs
+++ b/rs/nns/governance/src/data_migration.rs
@@ -8,7 +8,10 @@
 //! initial value, but thereafter, it can be changed as the result of requests
 //! (e.g. create a proposal followed by many votes in favor).
 
-use crate::pb::v1::{Governance, VotingPowerEconomics};
+use crate::{
+    governance::LOG_PREFIX,
+    pb::v1::{Governance, VotingPowerEconomics},
+};
 
 #[path = "data_migration_tests.rs"]
 #[cfg(test)]
@@ -32,7 +35,7 @@ pub fn set_initial_voting_power_economics(governance: &mut Governance) {
     let economics = governance.economics.as_mut();
 
     let Some(economics) = economics else {
-        // DO NOT MERGE - Log.
+        println!("{}ERROR: No NetworkEconomics!", LOG_PREFIX);
         return;
     };
 
@@ -40,13 +43,10 @@ pub fn set_initial_voting_power_economics(governance: &mut Governance) {
     let default = VotingPowerEconomics::with_default_values();
 
     let Some(voting_power_economics) = voting_power_economics else {
-        // DO NOT MERGE - Log.
+        println!("{}Setting voting_power_economics to default.", LOG_PREFIX);
         economics.voting_power_economics = Some(default);
         return;
     };
-
-    // This is weird, but we handle it anyway instead of freaking out.
-    // DO NOT MERGE - Log.
 
     let VotingPowerEconomics {
         start_reducing_voting_power_after_seconds,
@@ -54,13 +54,23 @@ pub fn set_initial_voting_power_economics(governance: &mut Governance) {
     } = voting_power_economics;
 
     if start_reducing_voting_power_after_seconds.is_none() {
-        // DO NOT MERGE - Log.
+        println!(
+            "{}WARNING: voting_power_economics was set, but not its \
+             start_reducing_voting_power_after_seconds field. This is weird. \
+             Nevertheless, setting the field to the default.",
+            LOG_PREFIX,
+        );
         *start_reducing_voting_power_after_seconds =
             default.start_reducing_voting_power_after_seconds;
     }
 
     if clear_following_after_seconds.is_none() {
-        // DO NOT MERGE - Log.
+        println!(
+            "{}WARNING: voting_power_economics was set, but not its \
+             clear_following_after_seconds field. This is weird. \
+             Nevertheless, setting the field to the default.",
+            LOG_PREFIX,
+        );
         *clear_following_after_seconds = default.clear_following_after_seconds;
     }
 }

--- a/rs/nns/governance/src/data_migration_tests.rs
+++ b/rs/nns/governance/src/data_migration_tests.rs
@@ -1,0 +1,61 @@
+use super::*;
+use crate::pb::v1::{Governance as GovernanceProto, NetworkEconomics, VotingPowerEconomics};
+use lazy_static::lazy_static;
+
+mod set_initial_voting_power_economics {
+    use super::*;
+
+    lazy_static! {
+        static ref GOVERNANCE_PROTO: GovernanceProto = GovernanceProto {
+            economics: Some(NetworkEconomics::with_default_values()),
+            ..Default::default()
+        };
+    }
+
+    #[test]
+    fn test_typical() {
+        let mut governance_proto = GOVERNANCE_PROTO.clone();
+        governance_proto
+            .economics
+            .as_mut()
+            .unwrap()
+            .voting_power_economics = None;
+
+        set_initial_voting_power_economics(&mut governance_proto);
+
+        assert_eq!(
+            governance_proto.economics.unwrap().voting_power_economics,
+            Some(VotingPowerEconomics {
+                start_reducing_voting_power_after_seconds: Some(15_778_800), // 0.5 * 365.25 days.
+                clear_following_after_seconds: Some(2_629_800),              // 1/12 * 365.25 days
+            }),
+        );
+    }
+
+    #[test]
+    fn test_weird() {
+        let mut governance_proto = GOVERNANCE_PROTO.clone();
+        {
+            let voting_power_economics = governance_proto
+                .economics
+                .as_mut()
+                .unwrap()
+                .voting_power_economics
+                .as_mut()
+                .unwrap();
+
+            voting_power_economics.start_reducing_voting_power_after_seconds = Some(42);
+            voting_power_economics.clear_following_after_seconds = None;
+        }
+
+        set_initial_voting_power_economics(&mut governance_proto);
+
+        assert_eq!(
+            governance_proto.economics.unwrap().voting_power_economics,
+            Some(VotingPowerEconomics {
+                start_reducing_voting_power_after_seconds: Some(42), // Do not touch.
+                clear_following_after_seconds: Some(2_629_800),      // 1/12 * 365.25 days
+            }),
+        );
+    }
+} // mod set_initial_voting_power_economics

--- a/rs/nns/governance/src/gen/ic_nns_governance.pb.v1.rs
+++ b/rs/nns/governance/src/gen/ic_nns_governance.pb.v1.rs
@@ -2546,6 +2546,42 @@ pub struct NetworkEconomics {
     /// Global Neurons' Fund participation thresholds.
     #[prost(message, optional, tag = "11")]
     pub neurons_fund_economics: ::core::option::Option<NeuronsFundEconomics>,
+    /// Parameters that affect the voting power of neurons.
+    #[prost(message, optional, tag = "12")]
+    pub voting_power_economics: ::core::option::Option<VotingPowerEconomics>,
+}
+/// Parameters that affect the voting power of neurons.
+#[derive(
+    candid::CandidType,
+    candid::Deserialize,
+    serde::Serialize,
+    comparable::Comparable,
+    Clone,
+    Copy,
+    PartialEq,
+    ::prost::Message,
+)]
+pub struct VotingPowerEconomics {
+    /// If a neuron has not "refreshed" its voting power after this amount of time,
+    /// its deciding voting power starts decreasing linearly. See also
+    /// clear_following_after_seconds.
+    ///
+    /// For explanation of what "refresh" means in this context, see
+    /// <https://dashboard.internetcomputer.org/proposal/132411>
+    ///
+    /// Initially, set to 0.5 years. (The nominal length of a year is 365.25 days).
+    #[prost(uint64, optional, tag = "1")]
+    pub start_reducing_voting_power_after_seconds: ::core::option::Option<u64>,
+    /// After a neuron has experienced voting power reduction for this amount of
+    /// time, a couple of things happen:
+    ///
+    ///      1. Deciding voting power reaches 0.
+    ///
+    ///      2. Its following on topics other than NeuronManagement are cleared.
+    ///
+    /// Initially, set to 1/12 years.
+    #[prost(uint64, optional, tag = "2")]
+    pub clear_following_after_seconds: ::core::option::Option<u64>,
 }
 /// The thresholds specify the shape of the ideal matching function used by the Neurons' Fund to
 /// determine how much to contribute for a given direct participation amount. Note that the actual

--- a/rs/nns/governance/src/governance.rs
+++ b/rs/nns/governance/src/governance.rs
@@ -6121,7 +6121,12 @@ impl Governance {
                 &VotingPowerEconomics::DEFAULT
             });
 
-        prune_some_following(voting_power_economics, &mut self.neuron_store, begin, carry_on)
+        prune_some_following(
+            voting_power_economics,
+            &mut self.neuron_store,
+            begin,
+            carry_on,
+        )
     }
 
     /// Creates a new neuron or refreshes the stake of an existing

--- a/rs/nns/governance/src/governance.rs
+++ b/rs/nns/governance/src/governance.rs
@@ -63,7 +63,7 @@ use crate::{
         RewardEvent, RewardNodeProvider, RewardNodeProviders,
         SettleNeuronsFundParticipationRequest, SettleNeuronsFundParticipationResponse,
         StopOrStartCanister, Tally, Topic, UpdateCanisterSettings, UpdateNodeProvider, Visibility,
-        Vote, WaitForQuietState, XdrConversionRate as XdrConversionRatePb,
+        Vote, VotingPowerEconomics, WaitForQuietState, XdrConversionRate as XdrConversionRatePb,
     },
     proposals::{call_canister::CallCanister, sum_weighted_voting_power},
 };
@@ -270,6 +270,16 @@ impl NetworkEconomics {
             transaction_fee_e8s: DEFAULT_TRANSFER_FEE.get_e8s(),
             max_proposals_to_keep_per_topic: 100,
             neurons_fund_economics: Some(NeuronsFundNetworkEconomicsPb::with_default_values()),
+            voting_power_economics: Some(VotingPowerEconomics::with_default_values()),
+        }
+    }
+}
+
+impl VotingPowerEconomics {
+    pub fn with_default_values() -> Self {
+        Self {
+            start_reducing_voting_power_after_seconds: Some(6 * ONE_MONTH_SECONDS),
+            clear_following_after_seconds: Some(ONE_MONTH_SECONDS),
         }
     }
 }

--- a/rs/nns/governance/src/governance.rs
+++ b/rs/nns/governance/src/governance.rs
@@ -283,19 +283,24 @@ impl Default for &'_ VotingPowerEconomics { // DO NOT MERGE: Move.
 
 use std::time::Duration; use ic_nervous_system_linear_map::LinearMap; // DO NOT MERGE
 impl VotingPowerEconomics {
-    const DEFAULT: Self = Self {
-        start_reducing_voting_power_after_seconds: Some(Self::DEFAULT_START_REDUCING_VOTING_POWER_AFTER_SECONDS),
+    pub const DEFAULT: Self = Self {
+        start_reducing_voting_power_after_seconds: Some(
+            Self::DEFAULT_START_REDUCING_VOTING_POWER_AFTER_SECONDS,
+        ),
         clear_following_after_seconds: Some(Self::DEFAULT_CLEAR_FOLLOWING_AFTER_SECONDS),
     };
 
-    const DEFAULT_START_REDUCING_VOTING_POWER_AFTER_SECONDS: u64 = 6 * ONE_MONTH_SECONDS;
-    const DEFAULT_CLEAR_FOLLOWING_AFTER_SECONDS: u64 = ONE_MONTH_SECONDS;
+    pub const DEFAULT_START_REDUCING_VOTING_POWER_AFTER_SECONDS: u64 = 6 * ONE_MONTH_SECONDS;
+    pub const DEFAULT_CLEAR_FOLLOWING_AFTER_SECONDS: u64 = ONE_MONTH_SECONDS;
 
     pub fn with_default_values() -> Self {
         Self::DEFAULT.clone()
     }
 
-    pub fn deciding_voting_power_adjustment_factor(&self, time_since_last_voting_power_refreshed: Duration) -> Decimal {
+    pub fn deciding_voting_power_adjustment_factor(
+        &self,
+        time_since_last_voting_power_refreshed: Duration,
+    ) -> Decimal {
         self.deciding_voting_power_adjustment_factor_function()
             .apply(time_since_last_voting_power_refreshed.as_secs())
             .clamp(Decimal::from(0), Decimal::from(1))
@@ -320,7 +325,8 @@ impl VotingPowerEconomics {
     }
 
     fn get_clear_following_after_seconds(&self) -> u64 {
-        self.clear_following_after_seconds.unwrap_or(Self::DEFAULT_CLEAR_FOLLOWING_AFTER_SECONDS)
+        self.clear_following_after_seconds
+            .unwrap_or(Self::DEFAULT_CLEAR_FOLLOWING_AFTER_SECONDS)
     }
 }
 
@@ -1974,7 +1980,7 @@ impl Governance {
         )
     }
 
-    fn get_voting_power_economics<'a>(&'a self) -> &'a VotingPowerEconomics {
+    fn get_voting_power_economics(&self) -> &VotingPowerEconomics {
         let economics = match &self.heap_data.economics {
             Some(ok) => ok,
             None => {
@@ -5782,9 +5788,8 @@ impl Governance {
             // vote, with a voting power determined at the
             // time of the proposal (i.e., now).
             _ => {
-                let (ballots, total_deciding_power, potential_voting_power) = self
-                    .neuron_store
-                    .create_ballots_for_standard_proposal(
+                let (ballots, total_deciding_power, potential_voting_power) =
+                    self.neuron_store.create_ballots_for_standard_proposal(
                         self.get_voting_power_economics(),
                         now_seconds,
                     );

--- a/rs/nns/governance/src/governance.rs
+++ b/rs/nns/governance/src/governance.rs
@@ -289,7 +289,7 @@ impl VotingPowerEconomics {
     pub const DEFAULT_CLEAR_FOLLOWING_AFTER_SECONDS: u64 = ONE_MONTH_SECONDS;
 
     pub fn with_default_values() -> Self {
-        Self::DEFAULT.clone()
+        Self::DEFAULT
     }
 
     pub fn deciding_voting_power_adjustment_factor(
@@ -1980,14 +1980,13 @@ impl Governance {
         let economics = match &self.heap_data.economics {
             Some(ok) => ok,
             None => {
-                return VotingPowerEconomics::with_default_values();
+                return VotingPowerEconomics::DEFAULT;
             }
         };
 
         economics
             .voting_power_economics
-            .clone()
-            .unwrap_or_else(VotingPowerEconomics::with_default_values)
+            .unwrap_or(VotingPowerEconomics::DEFAULT)
     }
 
     pub fn __get_state_for_test(&self) -> GovernanceProto {

--- a/rs/nns/governance/src/governance.rs
+++ b/rs/nns/governance/src/governance.rs
@@ -3069,7 +3069,13 @@ impl Governance {
 
         // Step 7: builds the response.
         Ok(ManageNeuronResponse::merge_response(
-            build_merge_neurons_response(&source_neuron, &target_neuron, self.voting_power_economics(), now, *caller),
+            build_merge_neurons_response(
+                &source_neuron,
+                &target_neuron,
+                self.voting_power_economics(),
+                now,
+                *caller,
+            ),
         ))
     }
 
@@ -3137,7 +3143,13 @@ impl Governance {
 
         // Step 4: builds the response.
         Ok(ManageNeuronResponse::merge_response(
-            build_merge_neurons_response(&source_neuron, &target_neuron, self.voting_power_economics(), now, *caller),
+            build_merge_neurons_response(
+                &source_neuron,
+                &target_neuron,
+                self.voting_power_economics(),
+                now,
+                *caller,
+            ),
         ))
     }
 
@@ -3681,7 +3693,9 @@ impl Governance {
         requester: PrincipalId,
     ) -> Result<NeuronInfo, GovernanceError> {
         let now = self.env.now();
-        self.with_neuron(id, |neuron| neuron.get_neuron_info(self.voting_power_economics(), now, requester))
+        self.with_neuron(id, |neuron| {
+            neuron.get_neuron_info(self.voting_power_economics(), now, requester)
+        })
     }
 
     /// Returns the neuron info for a neuron identified by id or subaccount.
@@ -5155,7 +5169,8 @@ impl Governance {
     }
 
     pub fn voting_power_economics(&self) -> &VotingPowerEconomics {
-        let result = self.heap_data
+        let result = self
+            .heap_data
             .economics
             .as_ref()
             .and_then(|economics| economics.voting_power_economics.as_ref());
@@ -5163,7 +5178,10 @@ impl Governance {
         match result {
             Some(ok) => ok,
             None => {
-                println!("{}ERROR: Falling back to default VotingPowerEconomics.", LOG_PREFIX);
+                println!(
+                    "{}ERROR: Falling back to default VotingPowerEconomics.",
+                    LOG_PREFIX
+                );
                 &VotingPowerEconomics::DEFAULT
             }
         }

--- a/rs/nns/governance/src/governance/benches.rs
+++ b/rs/nns/governance/src/governance/benches.rs
@@ -4,7 +4,7 @@ use crate::{
     neuron_store::NeuronStore,
     pb::v1::{
         neuron::Followees, proposal::Action, Ballot, BallotInfo, Governance as GovernanceProto,
-        KnownNeuron, Neuron as NeuronProto, ProposalData, Topic, Vote,
+        KnownNeuron, Neuron as NeuronProto, ProposalData, Topic, Vote, VotingPowerEconomics,
     },
     temporarily_disable_active_neurons_in_stable_memory,
     temporarily_disable_stable_memory_following_index,
@@ -497,7 +497,7 @@ fn compute_ballots_for_new_proposal_with_stable_neurons() -> BenchResult {
                     1_000_000_000,
                     hashmap! {}, // get the default followees
                 )
-                .into_proto(now_seconds),
+                .into_proto(&VotingPowerEconomics::DEFAULT, now_seconds),
             )
         })
         .collect::<BTreeMap<u64, NeuronProto>>();

--- a/rs/nns/governance/src/governance/merge_neurons.rs
+++ b/rs/nns/governance/src/governance/merge_neurons.rs
@@ -349,10 +349,20 @@ pub fn build_merge_neurons_response(
     now_seconds: u64,
     requester: PrincipalId,
 ) -> MergeResponse {
-    let source_neuron = Some(source.clone().into_proto(voting_power_economics, now_seconds));
-    let target_neuron = Some(target.clone().into_proto(voting_power_economics, now_seconds));
-    let source_neuron_info = Some(source.get_neuron_info(voting_power_economics, now_seconds, requester));
-    let target_neuron_info = Some(target.get_neuron_info(voting_power_economics, now_seconds, requester));
+    let source_neuron = Some(
+        source
+            .clone()
+            .into_proto(voting_power_economics, now_seconds),
+    );
+    let target_neuron = Some(
+        target
+            .clone()
+            .into_proto(voting_power_economics, now_seconds),
+    );
+    let source_neuron_info =
+        Some(source.get_neuron_info(voting_power_economics, now_seconds, requester));
+    let target_neuron_info =
+        Some(target.get_neuron_info(voting_power_economics, now_seconds, requester));
     MergeResponse {
         source_neuron,
         target_neuron,

--- a/rs/nns/governance/src/governance/merge_neurons.rs
+++ b/rs/nns/governance/src/governance/merge_neurons.rs
@@ -6,7 +6,7 @@ use crate::{
         governance_error::ErrorType,
         manage_neuron::{Merge, NeuronIdOrSubaccount},
         manage_neuron_response::MergeResponse,
-        GovernanceError, NeuronState, ProposalData, ProposalStatus,
+        GovernanceError, NeuronState, ProposalData, ProposalStatus, VotingPowerEconomics,
     },
 };
 use ic_base_types::PrincipalId;
@@ -345,13 +345,14 @@ pub fn validate_merge_neurons_before_commit(
 pub fn build_merge_neurons_response(
     source: &Neuron,
     target: &Neuron,
+    voting_power_economics: &VotingPowerEconomics,
     now_seconds: u64,
     requester: PrincipalId,
 ) -> MergeResponse {
-    let source_neuron = Some(source.clone().into_proto(now_seconds));
-    let target_neuron = Some(target.clone().into_proto(now_seconds));
-    let source_neuron_info = Some(source.get_neuron_info(now_seconds, requester));
-    let target_neuron_info = Some(target.get_neuron_info(now_seconds, requester));
+    let source_neuron = Some(source.clone().into_proto(voting_power_economics, now_seconds));
+    let target_neuron = Some(target.clone().into_proto(voting_power_economics, now_seconds));
+    let source_neuron_info = Some(source.get_neuron_info(voting_power_economics, now_seconds, requester));
+    let target_neuron_info = Some(target.get_neuron_info(voting_power_economics, now_seconds, requester));
     MergeResponse {
         source_neuron,
         target_neuron,

--- a/rs/nns/governance/src/governance/tests/mod.rs
+++ b/rs/nns/governance/src/governance/tests/mod.rs
@@ -1604,7 +1604,9 @@ fn test_compute_ballots_for_new_proposal() {
 
     let deciding_vote = |g: &Governance, id, now| {
         g.neuron_store
-            .with_neuron(&NeuronId { id }, |n| n.deciding_voting_power(now))
+            .with_neuron(&NeuronId { id }, |n| {
+                n.deciding_voting_power(&VotingPowerEconomics::DEFAULT, now)
+            })
             .unwrap()
     };
     assert_eq!(tot_potential_voting_power, expected_potential_voting_power);

--- a/rs/nns/governance/src/governance/tests/mod.rs
+++ b/rs/nns/governance/src/governance/tests/mod.rs
@@ -1461,6 +1461,43 @@ fn test_validate_execute_nns_function() {
 }
 
 #[test]
+fn test_deciding_voting_power_adjustment_factor() {
+    let voting_power_economics = VotingPowerEconomics {
+        start_reducing_voting_power_after_seconds: Some(60),
+        clear_following_after_seconds: Some(30),
+    };
+
+    let deciding_voting_power = |seconds_since_refresh| {
+        let time_since_refresh = Duration::from_secs(seconds_since_refresh);
+        voting_power_economics.deciding_voting_power_adjustment_factor(time_since_refresh)
+    };
+
+    // 100% at first.
+    for seconds_since_refresh in 0..=60 {
+        assert_eq!(
+            deciding_voting_power(seconds_since_refresh),
+            Decimal::from(1),
+        );
+    }
+
+    // Slowly ramp down.
+    for seconds_since_refresh in 60..=90 {
+        let expected_value = Decimal::from(90 - seconds_since_refresh) / Decimal::from(30);
+
+        assert_eq!(deciding_voting_power(seconds_since_refresh), expected_value);
+    }
+    assert_eq!(deciding_voting_power(75), Decimal::try_from(0.5).unwrap());
+
+    // Stuck at 0% after a "very" long time.
+    for seconds_since_refresh in 90..200 {
+        assert_eq!(
+            deciding_voting_power(seconds_since_refresh),
+            Decimal::from(0),
+        );
+    }
+}
+
+#[test]
 fn topic_min_max_test() {
     use strum::IntoEnumIterator;
 

--- a/rs/nns/governance/src/governance/tests/mod.rs
+++ b/rs/nns/governance/src/governance/tests/mod.rs
@@ -1574,7 +1574,7 @@ fn test_compute_ballots_for_new_proposal() {
         )
         .with_cached_neuron_stake_e8s(i * E8)
         .build()
-        .into_proto(CREATED_TIMESTAMP_SECONDS + 999)
+        .into_proto(&VotingPowerEconomics::DEFAULT, CREATED_TIMESTAMP_SECONDS + 999)
     }
 
     let mut neuron_10 = new_neuron(10);

--- a/rs/nns/governance/src/governance/tests/mod.rs
+++ b/rs/nns/governance/src/governance/tests/mod.rs
@@ -1574,7 +1574,10 @@ fn test_compute_ballots_for_new_proposal() {
         )
         .with_cached_neuron_stake_e8s(i * E8)
         .build()
-        .into_proto(&VotingPowerEconomics::DEFAULT, CREATED_TIMESTAMP_SECONDS + 999)
+        .into_proto(
+            &VotingPowerEconomics::DEFAULT,
+            CREATED_TIMESTAMP_SECONDS + 999,
+        )
     }
 
     let mut neuron_10 = new_neuron(10);

--- a/rs/nns/governance/src/lib.rs
+++ b/rs/nns/governance/src/lib.rs
@@ -146,6 +146,7 @@ pub mod test_utils;
 
 mod account_id_index;
 mod audit_event;
+pub mod data_migration;
 mod garbage_collection;
 /// The 'governance' module contains the canister (smart contract)
 /// that manages neurons, proposals, voting, voter following, voting

--- a/rs/nns/governance/src/neuron/types.rs
+++ b/rs/nns/governance/src/neuron/types.rs
@@ -928,7 +928,12 @@ impl Neuron {
     }
 
     /// Get the 'public' information associated with this neuron.
-    pub fn get_neuron_info(&self, voting_power_economics: &VotingPowerEconomics, now_seconds: u64, requester: PrincipalId) -> NeuronInfo {
+    pub fn get_neuron_info(
+        &self,
+        voting_power_economics: &VotingPowerEconomics,
+        now_seconds: u64,
+        requester: PrincipalId,
+    ) -> NeuronInfo {
         let mut recent_ballots = vec![];
         let mut joined_community_fund_timestamp_seconds = None;
 
@@ -1159,9 +1164,14 @@ impl Neuron {
 }
 
 impl Neuron {
-    pub fn into_proto(self, voting_power_economics: &VotingPowerEconomics, now_seconds: u64) -> NeuronProto {
+    pub fn into_proto(
+        self,
+        voting_power_economics: &VotingPowerEconomics,
+        now_seconds: u64,
+    ) -> NeuronProto {
         let visibility = self.visibility().map(|visibility| visibility as i32);
-        let deciding_voting_power = Some(self.deciding_voting_power(voting_power_economics, now_seconds));
+        let deciding_voting_power =
+            Some(self.deciding_voting_power(voting_power_economics, now_seconds));
         let potential_voting_power = Some(self.potential_voting_power(now_seconds));
 
         let Neuron {

--- a/rs/nns/governance/src/neuron/types.rs
+++ b/rs/nns/governance/src/neuron/types.rs
@@ -19,7 +19,7 @@ use crate::{
 };
 use ic_base_types::PrincipalId;
 use ic_cdk::println;
-use ic_nervous_system_common::ONE_DAY_SECONDS;
+use ic_nervous_system_common::{ONE_DAY_SECONDS, ONE_MONTH_SECONDS};
 use ic_nns_common::pb::v1::{NeuronId, ProposalId};
 use icp_ledger::Subaccount;
 use rust_decimal::Decimal;
@@ -928,7 +928,7 @@ impl Neuron {
     }
 
     /// Get the 'public' information associated with this neuron.
-    pub fn get_neuron_info(&self, now_seconds: u64, requester: PrincipalId) -> NeuronInfo {
+    pub fn get_neuron_info(&self, voting_power_economics: &VotingPowerEconomics, now_seconds: u64, requester: PrincipalId) -> NeuronInfo {
         let mut recent_ballots = vec![];
         let mut joined_community_fund_timestamp_seconds = None;
 
@@ -941,7 +941,7 @@ impl Neuron {
         }
 
         let visibility = self.visibility().map(|visibility| visibility as i32);
-        let deciding_voting_power = self.deciding_voting_power(now_seconds);
+        let deciding_voting_power = self.deciding_voting_power(voting_power_economics, now_seconds);
         let potential_voting_power = self.potential_voting_power(now_seconds);
 
         NeuronInfo {
@@ -1159,9 +1159,9 @@ impl Neuron {
 }
 
 impl Neuron {
-    pub fn into_proto(self, now_seconds: u64) -> NeuronProto {
+    pub fn into_proto(self, voting_power_economics: &VotingPowerEconomics, now_seconds: u64) -> NeuronProto {
         let visibility = self.visibility().map(|visibility| visibility as i32);
-        let deciding_voting_power = Some(self.deciding_voting_power(now_seconds));
+        let deciding_voting_power = Some(self.deciding_voting_power(voting_power_economics, now_seconds));
         let potential_voting_power = Some(self.potential_voting_power(now_seconds));
 
         let Neuron {

--- a/rs/nns/governance/src/neuron/types.rs
+++ b/rs/nns/governance/src/neuron/types.rs
@@ -19,7 +19,7 @@ use crate::{
 };
 use ic_base_types::PrincipalId;
 use ic_cdk::println;
-use ic_nervous_system_common::{ONE_DAY_SECONDS};
+use ic_nervous_system_common::ONE_DAY_SECONDS;
 use ic_nns_common::pb::v1::{NeuronId, ProposalId};
 use icp_ledger::Subaccount;
 use rust_decimal::Decimal;
@@ -359,7 +359,11 @@ impl Neuron {
     }
 
     /// How much swap this neuron has when it casts its vote on proposals.
-    pub fn deciding_voting_power(&self, voting_power_economics: &VotingPowerEconomics, now_seconds: u64) -> u64 {
+    pub fn deciding_voting_power(
+        &self,
+        voting_power_economics: &VotingPowerEconomics,
+        now_seconds: u64,
+    ) -> u64 {
         // Main inputs to main calculation.
 
         let adjustment_factor: Decimal = if is_voting_power_adjustment_enabled() {

--- a/rs/nns/governance/src/neuron/types.rs
+++ b/rs/nns/governance/src/neuron/types.rs
@@ -19,7 +19,7 @@ use crate::{
 };
 use ic_base_types::PrincipalId;
 use ic_cdk::println;
-use ic_nervous_system_common::{ONE_DAY_SECONDS, ONE_MONTH_SECONDS};
+use ic_nervous_system_common::ONE_DAY_SECONDS;
 use ic_nns_common::pb::v1::{NeuronId, ProposalId};
 use icp_ledger::Subaccount;
 use rust_decimal::Decimal;
@@ -556,9 +556,15 @@ impl Neuron {
     ///
     /// If the neuron refreshed recently, no followee neuron IDs are removed
     /// (and returns 0).
-    pub(crate) fn prune_following(&mut self, now_seconds: u64) -> u64 {
-        let is_fresh =
-            self.voting_power_refreshed_timestamp_seconds >= now_seconds - 7 * ONE_MONTH_SECONDS;
+    pub(crate) fn prune_following(
+        &mut self,
+        voting_power_economics: &VotingPowerEconomics,
+        now_seconds: u64,
+    ) -> u64 {
+        let is_fresh = self.voting_power_refreshed_timestamp_seconds
+            >= now_seconds
+                - voting_power_economics.get_start_reducing_voting_power_after_seconds()
+                - voting_power_economics.get_clear_following_after_seconds();
         if is_fresh {
             return 0;
         }

--- a/rs/nns/governance/src/neuron/types/tests.rs
+++ b/rs/nns/governance/src/neuron/types/tests.rs
@@ -1,13 +1,16 @@
 use super::*;
 use crate::{
     neuron::{DissolveStateAndAge, NeuronBuilder},
-    pb::v1::manage_neuron::{SetDissolveTimestamp, StartDissolving},
+    pb::v1::{
+        manage_neuron::{SetDissolveTimestamp, StartDissolving},
+        VotingPowerEconomics,
+    },
     temporarily_disable_private_neuron_enforcement, temporarily_disable_voting_power_adjustment,
     temporarily_enable_private_neuron_enforcement, temporarily_enable_voting_power_adjustment,
 };
 use ic_cdk::println;
 
-use ic_nervous_system_common::{E8, ONE_YEAR_SECONDS};
+use ic_nervous_system_common::{E8, ONE_MONTH_SECONDS, ONE_YEAR_SECONDS};
 use icp_ledger::Subaccount;
 
 const NOW: u64 = 123_456_789;
@@ -526,7 +529,7 @@ fn test_adjust_voting_power_enabled() {
     // At first, there is no difference between deciding and potential voting
     // power. The neuron is considered "current".
     assert_eq!(
-        neuron.deciding_voting_power(created_timestamp_seconds),
+        neuron.deciding_voting_power(&VotingPowerEconomics::DEFAULT, created_timestamp_seconds),
         original_potential_voting_power,
     );
 
@@ -537,7 +540,7 @@ fn test_adjust_voting_power_enabled() {
         let current_potential_voting_power = neuron.potential_voting_power(now_seconds);
 
         assert_eq!(
-            neuron.deciding_voting_power(now_seconds),
+            neuron.deciding_voting_power(&VotingPowerEconomics::DEFAULT, now_seconds),
             current_potential_voting_power,
         );
 
@@ -567,7 +570,7 @@ fn test_adjust_voting_power_enabled() {
             (observed_value - expected_value) / expected_value
         }
 
-        let observed = neuron.deciding_voting_power(now_seconds);
+        let observed = neuron.deciding_voting_power(&VotingPowerEconomics::DEFAULT, now_seconds);
         let current_potential_voting_power = neuron.potential_voting_power(now_seconds);
         let expected = (1.0 - months) * current_potential_voting_power as f64;
         let err = relative_error(
@@ -590,7 +593,10 @@ fn test_adjust_voting_power_enabled() {
     // goes all the way down to 0.
     for months in 7..=10 {
         let now_seconds = created_timestamp_seconds + months * ONE_MONTH_SECONDS;
-        assert_eq!(neuron.deciding_voting_power(now_seconds), 0,);
+        assert_eq!(
+            neuron.deciding_voting_power(&VotingPowerEconomics::DEFAULT, now_seconds),
+            0
+        );
     }
 }
 
@@ -626,7 +632,7 @@ fn test_adjust_voting_power_disabled() {
         let current_potential_voting_power = neuron.potential_voting_power(now_seconds);
 
         assert_eq!(
-            neuron.deciding_voting_power(now_seconds),
+            neuron.deciding_voting_power(&VotingPowerEconomics::DEFAULT, now_seconds),
             current_potential_voting_power,
         );
     }

--- a/rs/nns/governance/src/neuron/types/tests.rs
+++ b/rs/nns/governance/src/neuron/types/tests.rs
@@ -448,10 +448,10 @@ fn test_visibility_when_converting_neuron_to_neuron_info_and_neuron_proto() {
 
             assert_eq!(neuron.visibility(), Some(visibility),);
 
-            let neuron_info = neuron.get_neuron_info(timestamp_seconds, principal_id);
+            let neuron_info = neuron.get_neuron_info(&VotingPowerEconomics::DEFAULT, timestamp_seconds, principal_id);
             assert_eq!(neuron_info.visibility, Some(visibility as i32),);
 
-            let neuron_proto = neuron.into_proto(timestamp_seconds);
+            let neuron_proto = neuron.into_proto(&VotingPowerEconomics::DEFAULT, timestamp_seconds);
             assert_eq!(neuron_proto.visibility, Some(visibility as i32),);
         }
     }
@@ -463,10 +463,10 @@ fn test_visibility_when_converting_neuron_to_neuron_info_and_neuron_proto() {
 
         assert_eq!(neuron.visibility(), None,);
 
-        let neuron_info = neuron.get_neuron_info(timestamp_seconds, principal_id);
+        let neuron_info = neuron.get_neuron_info(&VotingPowerEconomics::DEFAULT, timestamp_seconds, principal_id);
         assert_eq!(neuron_info.visibility, None,);
 
-        let neuron_proto = neuron.clone().into_proto(timestamp_seconds);
+        let neuron_proto = neuron.clone().into_proto(&VotingPowerEconomics::DEFAULT, timestamp_seconds);
         assert_eq!(neuron_proto.visibility, None,);
     }
     {
@@ -474,10 +474,10 @@ fn test_visibility_when_converting_neuron_to_neuron_info_and_neuron_proto() {
 
         assert_eq!(neuron.visibility(), Some(Visibility::Private),);
 
-        let neuron_info = neuron.get_neuron_info(timestamp_seconds, principal_id);
+        let neuron_info = neuron.get_neuron_info(&VotingPowerEconomics::DEFAULT, timestamp_seconds, principal_id);
         assert_eq!(neuron_info.visibility, Some(Visibility::Private as i32),);
 
-        let neuron_proto = neuron.into_proto(timestamp_seconds);
+        let neuron_proto = neuron.into_proto(&VotingPowerEconomics::DEFAULT, timestamp_seconds);
         assert_eq!(neuron_proto.visibility, Some(Visibility::Private as i32),);
     }
 
@@ -496,10 +496,10 @@ fn test_visibility_when_converting_neuron_to_neuron_info_and_neuron_proto() {
 
         assert_eq!(neuron.visibility(), Some(Visibility::Public),);
 
-        let neuron_info = neuron.get_neuron_info(timestamp_seconds, principal_id);
+        let neuron_info = neuron.get_neuron_info(&VotingPowerEconomics::DEFAULT, timestamp_seconds, principal_id);
         assert_eq!(neuron_info.visibility, Some(Visibility::Public as i32),);
 
-        let neuron_proto = neuron.clone().into_proto(timestamp_seconds);
+        let neuron_proto = neuron.clone().into_proto(&VotingPowerEconomics::DEFAULT, timestamp_seconds);
         assert_eq!(neuron_proto.visibility, Some(Visibility::Public as i32),);
     }
 }

--- a/rs/nns/governance/src/neuron/types/tests.rs
+++ b/rs/nns/governance/src/neuron/types/tests.rs
@@ -448,7 +448,11 @@ fn test_visibility_when_converting_neuron_to_neuron_info_and_neuron_proto() {
 
             assert_eq!(neuron.visibility(), Some(visibility),);
 
-            let neuron_info = neuron.get_neuron_info(&VotingPowerEconomics::DEFAULT, timestamp_seconds, principal_id);
+            let neuron_info = neuron.get_neuron_info(
+                &VotingPowerEconomics::DEFAULT,
+                timestamp_seconds,
+                principal_id,
+            );
             assert_eq!(neuron_info.visibility, Some(visibility as i32),);
 
             let neuron_proto = neuron.into_proto(&VotingPowerEconomics::DEFAULT, timestamp_seconds);
@@ -463,10 +467,16 @@ fn test_visibility_when_converting_neuron_to_neuron_info_and_neuron_proto() {
 
         assert_eq!(neuron.visibility(), None,);
 
-        let neuron_info = neuron.get_neuron_info(&VotingPowerEconomics::DEFAULT, timestamp_seconds, principal_id);
+        let neuron_info = neuron.get_neuron_info(
+            &VotingPowerEconomics::DEFAULT,
+            timestamp_seconds,
+            principal_id,
+        );
         assert_eq!(neuron_info.visibility, None,);
 
-        let neuron_proto = neuron.clone().into_proto(&VotingPowerEconomics::DEFAULT, timestamp_seconds);
+        let neuron_proto = neuron
+            .clone()
+            .into_proto(&VotingPowerEconomics::DEFAULT, timestamp_seconds);
         assert_eq!(neuron_proto.visibility, None,);
     }
     {
@@ -474,7 +484,11 @@ fn test_visibility_when_converting_neuron_to_neuron_info_and_neuron_proto() {
 
         assert_eq!(neuron.visibility(), Some(Visibility::Private),);
 
-        let neuron_info = neuron.get_neuron_info(&VotingPowerEconomics::DEFAULT, timestamp_seconds, principal_id);
+        let neuron_info = neuron.get_neuron_info(
+            &VotingPowerEconomics::DEFAULT,
+            timestamp_seconds,
+            principal_id,
+        );
         assert_eq!(neuron_info.visibility, Some(Visibility::Private as i32),);
 
         let neuron_proto = neuron.into_proto(&VotingPowerEconomics::DEFAULT, timestamp_seconds);
@@ -496,10 +510,16 @@ fn test_visibility_when_converting_neuron_to_neuron_info_and_neuron_proto() {
 
         assert_eq!(neuron.visibility(), Some(Visibility::Public),);
 
-        let neuron_info = neuron.get_neuron_info(&VotingPowerEconomics::DEFAULT, timestamp_seconds, principal_id);
+        let neuron_info = neuron.get_neuron_info(
+            &VotingPowerEconomics::DEFAULT,
+            timestamp_seconds,
+            principal_id,
+        );
         assert_eq!(neuron_info.visibility, Some(Visibility::Public as i32),);
 
-        let neuron_proto = neuron.clone().into_proto(&VotingPowerEconomics::DEFAULT, timestamp_seconds);
+        let neuron_proto = neuron
+            .clone()
+            .into_proto(&VotingPowerEconomics::DEFAULT, timestamp_seconds);
         assert_eq!(neuron_proto.visibility, Some(Visibility::Public as i32),);
     }
 }

--- a/rs/nns/governance/src/neuron_store.rs
+++ b/rs/nns/governance/src/neuron_store.rs
@@ -8,7 +8,7 @@ use crate::{
     pb::v1::{
         governance::{followers_map::Followers, FollowersMap},
         governance_error::ErrorType,
-        GovernanceError, Neuron as NeuronProto, Topic,
+        GovernanceError, Neuron as NeuronProto, NeuronState, Topic, VotingPowerEconomics,
     },
     storage::{
         neuron_indexes::{CorruptedNeuronIndexes, NeuronIndex},
@@ -980,6 +980,7 @@ impl NeuronStore {
 
     pub fn create_ballots_for_standard_proposal(
         &self,
+        voting_power_economics: &VotingPowerEconomics,
         now_seconds: u64,
     ) -> (
         HashMap<u64, Ballot>,
@@ -998,7 +999,7 @@ impl NeuronStore {
                 return;
             }
 
-            let voting_power = neuron.deciding_voting_power(now_seconds);
+            let voting_power = neuron.deciding_voting_power(voting_power_economics, now_seconds);
             deciding_voting_power += voting_power as u128;
             potential_voting_power += neuron.potential_voting_power(now_seconds) as u128;
             ballots.insert(

--- a/rs/nns/governance/src/neuron_store.rs
+++ b/rs/nns/governance/src/neuron_store.rs
@@ -8,7 +8,7 @@ use crate::{
     pb::v1::{
         governance::{followers_map::Followers, FollowersMap},
         governance_error::ErrorType,
-        GovernanceError, Neuron as NeuronProto, NeuronState, Topic, VotingPowerEconomics,
+        GovernanceError, Neuron as NeuronProto, Topic, VotingPowerEconomics,
     },
     storage::{
         neuron_indexes::{CorruptedNeuronIndexes, NeuronIndex},
@@ -411,7 +411,7 @@ impl NeuronStore {
         (
             self.heap_neurons
                 .into_iter()
-                .map(|(id, neuron)| (id, neuron.into_proto(now_seconds)))
+                .map(|(id, neuron)| (id, neuron.into_proto(&VotingPowerEconomics::DEFAULT, now_seconds)))
                 .collect(),
             heap_topic_followee_index_to_proto(self.topic_followee_index),
         )
@@ -460,13 +460,13 @@ impl NeuronStore {
         let mut stable_neurons = with_stable_neuron_store(|stable_store| {
             stable_store
                 .range_neurons(..)
-                .map(|neuron| (neuron.id().id, neuron.into_proto(now_seconds)))
+                .map(|neuron| (neuron.id().id, neuron.into_proto(&VotingPowerEconomics::DEFAULT, now_seconds)))
                 .collect::<BTreeMap<u64, NeuronProto>>()
         });
         let heap_neurons = self
             .heap_neurons
             .iter()
-            .map(|(id, neuron)| (*id, neuron.clone().into_proto(now_seconds)))
+            .map(|(id, neuron)| (*id, neuron.clone().into_proto(&VotingPowerEconomics::DEFAULT, now_seconds)))
             .collect::<BTreeMap<u64, NeuronProto>>();
 
         stable_neurons.extend(heap_neurons);

--- a/rs/nns/governance/src/neuron_store.rs
+++ b/rs/nns/governance/src/neuron_store.rs
@@ -1387,8 +1387,9 @@ impl NeuronStore {
 ///
 /// Returns where the scan should pick up from next time. I.e. the return value
 /// should be passed via start next time.
-#[allow(unused)] // This line will be removed soon...
+#[allow(unused)]
 pub fn prune_some_following(
+    voting_power_economics: &VotingPowerEconomics,
     neuron_store: &mut NeuronStore,
     mut next: Bound<NeuronId>,
     mut carry_on: impl FnMut() -> bool,
@@ -1415,7 +1416,7 @@ pub fn prune_some_following(
         let result = neuron_store.with_neuron_mut(&current_neuron_id, |neuron| {
             // This is where the "real work" takes place. Everything else is to
             // keep the scan going.
-            neuron.prune_following(now_seconds);
+            neuron.prune_following(voting_power_economics, now_seconds);
         });
 
         // Log if somehow with_neuron_mut returns Err. This should not be

--- a/rs/nns/governance/src/neuron_store.rs
+++ b/rs/nns/governance/src/neuron_store.rs
@@ -411,7 +411,12 @@ impl NeuronStore {
         (
             self.heap_neurons
                 .into_iter()
-                .map(|(id, neuron)| (id, neuron.into_proto(&VotingPowerEconomics::DEFAULT, now_seconds)))
+                .map(|(id, neuron)| {
+                    (
+                        id,
+                        neuron.into_proto(&VotingPowerEconomics::DEFAULT, now_seconds),
+                    )
+                })
                 .collect(),
             heap_topic_followee_index_to_proto(self.topic_followee_index),
         )
@@ -460,13 +465,25 @@ impl NeuronStore {
         let mut stable_neurons = with_stable_neuron_store(|stable_store| {
             stable_store
                 .range_neurons(..)
-                .map(|neuron| (neuron.id().id, neuron.into_proto(&VotingPowerEconomics::DEFAULT, now_seconds)))
+                .map(|neuron| {
+                    (
+                        neuron.id().id,
+                        neuron.into_proto(&VotingPowerEconomics::DEFAULT, now_seconds),
+                    )
+                })
                 .collect::<BTreeMap<u64, NeuronProto>>()
         });
         let heap_neurons = self
             .heap_neurons
             .iter()
-            .map(|(id, neuron)| (*id, neuron.clone().into_proto(&VotingPowerEconomics::DEFAULT, now_seconds)))
+            .map(|(id, neuron)| {
+                (
+                    *id,
+                    neuron
+                        .clone()
+                        .into_proto(&VotingPowerEconomics::DEFAULT, now_seconds),
+                )
+            })
             .collect::<BTreeMap<u64, NeuronProto>>();
 
         stable_neurons.extend(heap_neurons);

--- a/rs/nns/governance/src/neuron_store.rs
+++ b/rs/nns/governance/src/neuron_store.rs
@@ -1387,7 +1387,6 @@ impl NeuronStore {
 ///
 /// Returns where the scan should pick up from next time. I.e. the return value
 /// should be passed via start next time.
-#[allow(unused)]
 pub fn prune_some_following(
     voting_power_economics: &VotingPowerEconomics,
     neuron_store: &mut NeuronStore,
@@ -1424,8 +1423,8 @@ pub fn prune_some_following(
         // this line to be reached.
         if let Err(err) = result {
             println!(
-                "{}ERROR: Unable to find neuron {} while pruning following.",
-                LOG_PREFIX, current_neuron_id.id,
+                "{}ERROR: Unable to find neuron {} while pruning following: {:?}",
+                LOG_PREFIX, current_neuron_id.id, err,
             );
         }
 

--- a/rs/nns/governance/src/neuron_store/neuron_store_tests.rs
+++ b/rs/nns/governance/src/neuron_store/neuron_store_tests.rs
@@ -696,7 +696,7 @@ fn test_prune_some_following() {
     };
 
     assert_eq!(
-        prune_some_following(&mut neuron_store, Bound::Unbounded, carry_on),
+        prune_some_following(&VotingPowerEconomics::DEFAULT, &mut neuron_store, Bound::Unbounded, carry_on),
         Bound::Excluded(stale_neuron.id()),
     );
     assert_eq!(neuron_count, 2);
@@ -708,6 +708,7 @@ fn test_prune_some_following() {
     };
     assert_eq!(
         prune_some_following(
+            &VotingPowerEconomics::DEFAULT,
             &mut neuron_store,
             Bound::Excluded(stale_neuron.id()),
             carry_on,

--- a/rs/nns/governance/src/neuron_store/neuron_store_tests.rs
+++ b/rs/nns/governance/src/neuron_store/neuron_store_tests.rs
@@ -641,7 +641,7 @@ fn test_get_neuron_ids_readable_by_caller() {
 }
 
 #[test]
-fn test_prune_some_following() {
+fn test_prune_some_following_standard_voting_power_refresh_requirements() {
     // Step 1: Prepare the world.
 
     let followees = hashmap! {
@@ -706,6 +706,9 @@ fn test_prune_some_following() {
     );
     assert_eq!(neuron_count, 2);
 
+    // Do the next batch (which is empty). What we want to see is that
+    // prune_some_following "loops back around". More concretely, it should
+    // return Bound::Unbounded.
     let mut call_count = 0;
     let carry_on = || {
         call_count += 1;
@@ -741,6 +744,7 @@ fn test_prune_some_following() {
                 hashmap! {
                     // Governance got wiped out.
 
+                    // NeuronManagement did not get touched.
                     Topic::NeuronManagement as i32 => Followees {
                         followees: vec![NeuronId { id: 101 }],
                     },
@@ -748,6 +752,96 @@ fn test_prune_some_following() {
             );
         })
         .unwrap();
+
+    assert_eq!(neuron_store.len(), 2);
+}
+
+#[test]
+fn test_prune_some_following_super_strict_voting_power_refresh() {
+    // Step 1: Prepare the world. (This is exactly the same as the previous test.)
+
+    let followees = hashmap! {
+        Topic::Governance as i32 => Followees {
+            followees: vec![NeuronId { id: 99 }],
+        },
+        Topic::NeuronManagement as i32 => Followees {
+            followees: vec![NeuronId { id: 101 }],
+        },
+    };
+
+    let mut fresh_neuron = simple_neuron_builder(1)
+        .with_followees(followees.clone())
+        .build();
+    fresh_neuron.refresh_voting_power(CREATED_TIMESTAMP_SECONDS - 7 * ONE_MONTH_SECONDS + 1);
+
+    // Similar to fresh_neuron, except voting power was refrshed a "long" time
+    // ago.
+    let mut stale_neuron = simple_neuron_builder(3)
+        .with_followees(followees.clone())
+        .build();
+    stale_neuron.refresh_voting_power(CREATED_TIMESTAMP_SECONDS - 7 * ONE_MONTH_SECONDS - 1);
+
+    let mut neuron_store = NeuronStore::new(btreemap! {
+        fresh_neuron.id().id => fresh_neuron.clone(),
+        stale_neuron.id().id => stale_neuron.clone(),
+    });
+
+    // Control the perception of time by neuron_store.
+    #[derive(Debug, Clone)]
+    struct DummyClock {}
+    impl Clock for DummyClock {
+        fn now(&self) -> u64 {
+            CREATED_TIMESTAMP_SECONDS
+        }
+
+        fn set_time_warp(&mut self, _: TimeWarp) {
+            unimplemented!();
+        }
+    }
+    impl PracticalClock for DummyClock {}
+    let clock = DummyClock {};
+    neuron_store.clock = Box::new(clock);
+
+    // Step 2: Call code under test. (This is where things start looking
+    // different, compared to the previous test.)
+
+    assert_eq!(
+        prune_some_following(
+            &VotingPowerEconomics {
+                // These are much smaller than the normal values. As a result, all
+                // neurons suddenly look stale. As a result, all following is
+                // supposed to be cleared.
+                start_reducing_voting_power_after_seconds: Some(42),
+                clear_following_after_seconds: Some(58),
+            },
+            &mut neuron_store,
+            Bound::Unbounded, // Start new cycle.
+            || true, // Do a full cycle.
+        ),
+        Bound::Unbounded,
+    );
+
+    // Step 3: Inspect results.
+
+    // Assert that everyone's following got cleared, due to super strict
+    // VotingPowerEconomics.
+    for neuron_id in [fresh_neuron.id(), stale_neuron.id()] {
+        neuron_store
+            .with_neuron(&neuron_id, |observed_neuron| {
+                assert_eq!(
+                    observed_neuron.followees,
+                    hashmap! {
+                        // Governance got wiped out.
+
+                        // NeuronManagement did not get touched.
+                        Topic::NeuronManagement as i32 => Followees {
+                            followees: vec![NeuronId { id: 101 }],
+                        },
+                    },
+                );
+            })
+            .unwrap();
+    }
 
     assert_eq!(neuron_store.len(), 2);
 }

--- a/rs/nns/governance/src/neuron_store/neuron_store_tests.rs
+++ b/rs/nns/governance/src/neuron_store/neuron_store_tests.rs
@@ -696,7 +696,12 @@ fn test_prune_some_following() {
     };
 
     assert_eq!(
-        prune_some_following(&VotingPowerEconomics::DEFAULT, &mut neuron_store, Bound::Unbounded, carry_on),
+        prune_some_following(
+            &VotingPowerEconomics::DEFAULT,
+            &mut neuron_store,
+            Bound::Unbounded,
+            carry_on
+        ),
         Bound::Excluded(stale_neuron.id()),
     );
     assert_eq!(neuron_count, 2);

--- a/rs/nns/governance/src/neuron_store/neuron_store_tests.rs
+++ b/rs/nns/governance/src/neuron_store/neuron_store_tests.rs
@@ -756,6 +756,8 @@ fn test_prune_some_following_standard_voting_power_refresh_requirements() {
     assert_eq!(neuron_store.len(), 2);
 }
 
+/// This shows that VotingPowerEconomics is used when pruning following, not the
+/// old constant(s).
 #[test]
 fn test_prune_some_following_super_strict_voting_power_refresh() {
     // Step 1: Prepare the world. (This is exactly the same as the previous test.)

--- a/rs/nns/governance/src/neuron_store/neuron_store_tests.rs
+++ b/rs/nns/governance/src/neuron_store/neuron_store_tests.rs
@@ -816,7 +816,7 @@ fn test_prune_some_following_super_strict_voting_power_refresh() {
             },
             &mut neuron_store,
             Bound::Unbounded, // Start new cycle.
-            || true, // Do a full cycle.
+            || true,          // Do a full cycle.
         ),
         Bound::Unbounded,
     );

--- a/rs/nns/governance/src/pb/conversions.rs
+++ b/rs/nns/governance/src/pb/conversions.rs
@@ -2405,9 +2405,11 @@ impl From<pb::NetworkEconomics> for pb_api::NetworkEconomics {
             transaction_fee_e8s: item.transaction_fee_e8s,
             max_proposals_to_keep_per_topic: item.max_proposals_to_keep_per_topic,
             neurons_fund_economics: item.neurons_fund_economics.map(|x| x.into()),
+            voting_power_economics: item.voting_power_economics.map(|x| x.into()),
         }
     }
 }
+
 impl From<pb_api::NetworkEconomics> for pb::NetworkEconomics {
     fn from(item: pb_api::NetworkEconomics) -> Self {
         Self {
@@ -2420,6 +2422,27 @@ impl From<pb_api::NetworkEconomics> for pb::NetworkEconomics {
             transaction_fee_e8s: item.transaction_fee_e8s,
             max_proposals_to_keep_per_topic: item.max_proposals_to_keep_per_topic,
             neurons_fund_economics: item.neurons_fund_economics.map(|x| x.into()),
+            voting_power_economics: item.voting_power_economics.map(|x| x.into()),
+        }
+    }
+}
+
+impl From<pb_api::VotingPowerEconomics> for pb::VotingPowerEconomics {
+    fn from(item: pb_api::VotingPowerEconomics) -> Self {
+        Self {
+            start_reducing_voting_power_after_seconds: item
+                .start_reducing_voting_power_after_seconds,
+            clear_following_after_seconds: item.clear_following_after_seconds,
+        }
+    }
+}
+
+impl From<pb::VotingPowerEconomics> for pb_api::VotingPowerEconomics {
+    fn from(item: pb::VotingPowerEconomics) -> Self {
+        Self {
+            start_reducing_voting_power_after_seconds: item
+                .start_reducing_voting_power_after_seconds,
+            clear_following_after_seconds: item.clear_following_after_seconds,
         }
     }
 }

--- a/rs/nns/governance/src/voting.rs
+++ b/rs/nns/governance/src/voting.rs
@@ -253,12 +253,11 @@ fn retain_neurons_with_castable_ballots(
 
 #[cfg(test)]
 mod test {
-
     use crate::{
         governance::{Governance, MIN_DISSOLVE_DELAY_FOR_VOTE_ELIGIBILITY_SECONDS},
         neuron::{DissolveStateAndAge, Neuron, NeuronBuilder},
         neuron_store::NeuronStore,
-        pb::v1::{neuron::Followees, Ballot, ProposalData, Tally, Topic, Vote},
+        pb::v1::{neuron::Followees, Ballot, ProposalData, Tally, Topic, Vote, VotingPowerEconomics},
         test_utils::{MockEnvironment, StubCMC, StubIcpLedger},
         voting::ProposalVotingStateMachine,
     };
@@ -326,7 +325,7 @@ mod test {
                                       followees: Vec<u64>,
                                       vote: Vote| {
             let neuron = make_neuron(id, followees);
-            let deciding_voting_power = neuron.deciding_voting_power(now);
+            let deciding_voting_power = neuron.deciding_voting_power(&VotingPowerEconomics::DEFAULT, now);
             neuron_map.insert(id, neuron);
             ballots.insert(id, make_ballot(deciding_voting_power, vote));
         };
@@ -366,7 +365,7 @@ mod test {
         let governance_proto = crate::pb::v1::Governance {
             neurons: heap_neurons
                 .into_iter()
-                .map(|(id, neuron)| (id, neuron.into_proto(now)))
+                .map(|(id, neuron)| (id, neuron.into_proto(&VotingPowerEconomics::DEFAULT, now)))
                 .collect(),
             proposals: btreemap! {
                 1 => ProposalData {
@@ -397,7 +396,7 @@ mod test {
         let deciding_voting_power = |neuron_id| {
             governance
                 .neuron_store
-                .with_neuron(&neuron_id, |n| n.deciding_voting_power(now))
+                .with_neuron(&neuron_id, |n| n.deciding_voting_power(&VotingPowerEconomics::DEFAULT, now))
                 .unwrap()
         };
         assert_eq!(
@@ -434,7 +433,7 @@ mod test {
                                       followees: Vec<u64>,
                                       vote: Vote| {
             let neuron = make_neuron(id, followees);
-            let deciding_voting_power = neuron.deciding_voting_power(now);
+            let deciding_voting_power = neuron.deciding_voting_power(&VotingPowerEconomics::DEFAULT, now);
             neuron_map.insert(id, neuron);
             ballots.insert(id, make_ballot(deciding_voting_power, vote));
         };
@@ -462,7 +461,7 @@ mod test {
         let governance_proto = crate::pb::v1::Governance {
             neurons: neurons
                 .into_iter()
-                .map(|(id, neuron)| (id, neuron.into_proto(now)))
+                .map(|(id, neuron)| (id, neuron.into_proto(&VotingPowerEconomics::DEFAULT, now)))
                 .collect(),
             proposals: btreemap! {
                 1 => ProposalData {
@@ -493,7 +492,7 @@ mod test {
         let deciding_voting_power = |neuron_id| {
             governance
                 .neuron_store
-                .with_neuron(&neuron_id, |n| n.deciding_voting_power(now))
+                .with_neuron(&neuron_id, |n| n.deciding_voting_power(&VotingPowerEconomics::DEFAULT, now))
                 .unwrap()
         };
         assert_eq!(

--- a/rs/nns/governance/src/voting.rs
+++ b/rs/nns/governance/src/voting.rs
@@ -257,7 +257,9 @@ mod test {
         governance::{Governance, MIN_DISSOLVE_DELAY_FOR_VOTE_ELIGIBILITY_SECONDS},
         neuron::{DissolveStateAndAge, Neuron, NeuronBuilder},
         neuron_store::NeuronStore,
-        pb::v1::{neuron::Followees, Ballot, ProposalData, Tally, Topic, Vote, VotingPowerEconomics},
+        pb::v1::{
+            neuron::Followees, Ballot, ProposalData, Tally, Topic, Vote, VotingPowerEconomics,
+        },
         test_utils::{MockEnvironment, StubCMC, StubIcpLedger},
         voting::ProposalVotingStateMachine,
     };

--- a/rs/nns/governance/src/voting.rs
+++ b/rs/nns/governance/src/voting.rs
@@ -325,7 +325,8 @@ mod test {
                                       followees: Vec<u64>,
                                       vote: Vote| {
             let neuron = make_neuron(id, followees);
-            let deciding_voting_power = neuron.deciding_voting_power(&VotingPowerEconomics::DEFAULT, now);
+            let deciding_voting_power =
+                neuron.deciding_voting_power(&VotingPowerEconomics::DEFAULT, now);
             neuron_map.insert(id, neuron);
             ballots.insert(id, make_ballot(deciding_voting_power, vote));
         };
@@ -396,7 +397,9 @@ mod test {
         let deciding_voting_power = |neuron_id| {
             governance
                 .neuron_store
-                .with_neuron(&neuron_id, |n| n.deciding_voting_power(&VotingPowerEconomics::DEFAULT, now))
+                .with_neuron(&neuron_id, |n| {
+                    n.deciding_voting_power(&VotingPowerEconomics::DEFAULT, now)
+                })
                 .unwrap()
         };
         assert_eq!(
@@ -433,7 +436,8 @@ mod test {
                                       followees: Vec<u64>,
                                       vote: Vote| {
             let neuron = make_neuron(id, followees);
-            let deciding_voting_power = neuron.deciding_voting_power(&VotingPowerEconomics::DEFAULT, now);
+            let deciding_voting_power =
+                neuron.deciding_voting_power(&VotingPowerEconomics::DEFAULT, now);
             neuron_map.insert(id, neuron);
             ballots.insert(id, make_ballot(deciding_voting_power, vote));
         };
@@ -492,7 +496,9 @@ mod test {
         let deciding_voting_power = |neuron_id| {
             governance
                 .neuron_store
-                .with_neuron(&neuron_id, |n| n.deciding_voting_power(&VotingPowerEconomics::DEFAULT, now))
+                .with_neuron(&neuron_id, |n| {
+                    n.deciding_voting_power(&VotingPowerEconomics::DEFAULT, now)
+                })
                 .unwrap()
         };
         assert_eq!(

--- a/rs/nns/governance/tests/fixtures/mod.rs
+++ b/rs/nns/governance/tests/fixtures/mod.rs
@@ -928,7 +928,10 @@ impl NNS {
     pub fn get_neuron(&self, ident: &NeuronId) -> Neuron {
         self.governance
             .neuron_store
-            .with_neuron(ident, |n| n.clone().into_proto(self.governance.voting_power_economics(), self.now()))
+            .with_neuron(ident, |n| {
+                n.clone()
+                    .into_proto(self.governance.voting_power_economics(), self.now())
+            })
             .unwrap()
     }
 

--- a/rs/nns/governance/tests/fixtures/mod.rs
+++ b/rs/nns/governance/tests/fixtures/mod.rs
@@ -928,7 +928,7 @@ impl NNS {
     pub fn get_neuron(&self, ident: &NeuronId) -> Neuron {
         self.governance
             .neuron_store
-            .with_neuron(ident, |n| n.clone().into_proto(self.now()))
+            .with_neuron(ident, |n| n.clone().into_proto(self.governance.voting_power_economics(), self.now()))
             .unwrap()
     }
 

--- a/rs/nns/governance/tests/governance.rs
+++ b/rs/nns/governance/tests/governance.rs
@@ -4559,7 +4559,11 @@ fn create_mature_neuron(dissolved: bool) -> (fake::FakeDriver, Governance, Neuro
             .expect("Neuron not found");
         assert_eq!(
             neuron
-                .get_neuron_info(gov.voting_power_economics(), driver.now(), *RANDOM_PRINCIPAL_ID)
+                .get_neuron_info(
+                    gov.voting_power_economics(),
+                    driver.now(),
+                    *RANDOM_PRINCIPAL_ID
+                )
                 .state(),
             NeuronState::Dissolved
         );
@@ -5454,7 +5458,11 @@ fn test_neuron_split_fails() {
 
     assert_eq!(
         neuron
-            .get_neuron_info(gov.voting_power_economics(), driver.now(), *RANDOM_PRINCIPAL_ID)
+            .get_neuron_info(
+                gov.voting_power_economics(),
+                driver.now(),
+                *RANDOM_PRINCIPAL_ID
+            )
             .state(),
         NeuronState::NotDissolving
     );
@@ -5576,7 +5584,11 @@ fn test_neuron_split() {
             })
             .expect("Neuron not found");
         neuron
-            .get_neuron_info(governance.voting_power_economics(), driver.now(), *RANDOM_PRINCIPAL_ID)
+            .get_neuron_info(
+                governance.voting_power_economics(),
+                driver.now(),
+                *RANDOM_PRINCIPAL_ID,
+            )
             .state()
     };
 
@@ -5701,7 +5713,11 @@ fn test_seed_neuron_split() {
 
     assert_eq!(
         neuron
-            .get_neuron_info(gov.voting_power_economics(), driver.now(), *RANDOM_PRINCIPAL_ID)
+            .get_neuron_info(
+                gov.voting_power_economics(),
+                driver.now(),
+                *RANDOM_PRINCIPAL_ID
+            )
             .state(),
         NeuronState::NotDissolving
     );
@@ -6149,7 +6165,11 @@ fn assert_neuron_spawn_partial(
         .expect("Neuron did not exist");
     assert_eq!(
         neuron
-            .get_neuron_info(gov.voting_power_economics(), driver.now(), *RANDOM_PRINCIPAL_ID)
+            .get_neuron_info(
+                gov.voting_power_economics(),
+                driver.now(),
+                *RANDOM_PRINCIPAL_ID
+            )
             .state(),
         NeuronState::NotDissolving
     );
@@ -6521,7 +6541,11 @@ fn test_disburse_to_neuron() {
     // now disburse the neuron.
     assert_eq!(
         parent_neuron
-            .get_neuron_info(gov.voting_power_economics(), driver.now(), *RANDOM_PRINCIPAL_ID)
+            .get_neuron_info(
+                gov.voting_power_economics(),
+                driver.now(),
+                *RANDOM_PRINCIPAL_ID
+            )
             .state(),
         NeuronState::Dissolved
     );

--- a/rs/nns/governance/tests/merge_neurons.rs
+++ b/rs/nns/governance/tests/merge_neurons.rs
@@ -139,14 +139,14 @@ fn do_test_merge_neurons(
                 source_neuron,
                 nns.governance
                     .neuron_store
-                    .with_neuron(&source_neuron_id, |n| n.clone().into_proto(now_seconds))
+                    .with_neuron(&source_neuron_id, |n| n.clone().into_proto(nns.governance.voting_power_economics(), now_seconds))
                     .unwrap()
             );
             pretty_assertions::assert_eq!(
                 target_neuron,
                 nns.governance
                     .neuron_store
-                    .with_neuron(&target_neuron_id, |n| n.clone().into_proto(now_seconds))
+                    .with_neuron(&target_neuron_id, |n| n.clone().into_proto(nns.governance.voting_power_economics(), now_seconds))
                     .unwrap()
             );
             pretty_assertions::assert_eq!(

--- a/rs/nns/governance/tests/merge_neurons.rs
+++ b/rs/nns/governance/tests/merge_neurons.rs
@@ -139,14 +139,18 @@ fn do_test_merge_neurons(
                 source_neuron,
                 nns.governance
                     .neuron_store
-                    .with_neuron(&source_neuron_id, |n| n.clone().into_proto(nns.governance.voting_power_economics(), now_seconds))
+                    .with_neuron(&source_neuron_id, |n| n
+                        .clone()
+                        .into_proto(nns.governance.voting_power_economics(), now_seconds))
                     .unwrap()
             );
             pretty_assertions::assert_eq!(
                 target_neuron,
                 nns.governance
                     .neuron_store
-                    .with_neuron(&target_neuron_id, |n| n.clone().into_proto(nns.governance.voting_power_economics(), now_seconds))
+                    .with_neuron(&target_neuron_id, |n| n
+                        .clone()
+                        .into_proto(nns.governance.voting_power_economics(), now_seconds))
                     .unwrap()
             );
             pretty_assertions::assert_eq!(

--- a/rs/nns/integration_tests/src/network_economics.rs
+++ b/rs/nns/integration_tests/src/network_economics.rs
@@ -1,5 +1,5 @@
 use dfn_candid::candid_one;
-use ic_nns_governance_api::pb::v1::NetworkEconomics;
+use ic_nns_governance_api::pb::v1::{NetworkEconomics, VotingPowerEconomics};
 use ic_nns_test_utils::{
     common::NnsInitPayloadsBuilder,
     itest_helpers::{state_machine_test_on_nns_subnet, NnsCanisters},
@@ -10,6 +10,7 @@ fn test_get_network_economics() {
     state_machine_test_on_nns_subnet(|runtime| async move {
         let network_economics = NetworkEconomics {
             neuron_minimum_stake_e8s: 100 * 100_000_000,
+            voting_power_economics: Some(VotingPowerEconomics::DEFAULT),
             ..Default::default()
         };
 


### PR DESCRIPTION
With this in place, a future change will make it possible to change these values via ManageNetworkEconomics proposals.

Initially, the fields are set as follows:

1. start_reducing_voting_power_after_seconds = 0.5 years.
2. clear_following_after_seconds = 1/12 years.

(Nominally, 1 year = 365.25 days in NNS.)

# References

This is part of the "periodic confirmation" feature that was recently approved in proposal [132411][prop].

[prop]: https://dashboard.internetcomputer.org/proposal/132411

[Next PR 👉][next]

[next]: https://github.com/dfinity/ic/pull/2997