### PR TITLE
refactor(test): Move some helpers from `pocket_ic_helpers.rs` to `ic-nervous-system-agent`

### DIFF
--- a/rs/nervous_system/agent/src/nns/sns_wasm.rs
+++ b/rs/nervous_system/agent/src/nns/sns_wasm.rs
@@ -26,6 +26,9 @@ pub async fn query_mainline_sns_upgrade_steps<C: CallCanisters>(
     agent.call(SNS_WASM_CANISTER_ID, request).await
 }
 
+/// Queries SNS-W to get the deployed SNSes. The returned SNSes are not guaranteed to be
+/// fully initialized (they may have ongoing or failed swaps). Archive canisters are not
+/// included in the response (as SNS-W doesn't know about them).
 pub async fn list_deployed_snses<C: CallCanisters>(agent: &C) -> Result<Vec<Sns>, C::Error> {
     let response = agent
         .call(SNS_WASM_CANISTER_ID, ListDeployedSnsesRequest {})

--- a/rs/nervous_system/agent/src/sns/archive.rs
+++ b/rs/nervous_system/agent/src/sns/archive.rs
@@ -1,0 +1,14 @@
+use ic_base_types::PrincipalId;
+use serde::{Deserialize, Serialize};
+
+#[derive(Copy, Clone, Debug, Deserialize, Serialize)]
+pub struct ArchiveCanister {
+    pub canister_id: PrincipalId,
+}
+
+impl ArchiveCanister {
+    pub fn new(canister_id: impl Into<PrincipalId>) -> Self {
+        let canister_id = canister_id.into();
+        Self { canister_id }
+    }
+}

--- a/rs/nervous_system/agent/src/sns/governance.rs
+++ b/rs/nervous_system/agent/src/sns/governance.rs
@@ -1,7 +1,7 @@
 use crate::CallCanisters;
 use ic_base_types::PrincipalId;
 use ic_sns_governance::pb::v1::{
-    GetMetadataRequest, GetMetadataResponse, GetRunningSnsVersionRequest,
+    GetMetadataRequest, GetMetadataResponse, GetMode, GetModeResponse, GetRunningSnsVersionRequest,
     GetRunningSnsVersionResponse,
 };
 use serde::{Deserialize, Serialize};
@@ -26,6 +26,10 @@ impl GovernanceCanister {
         agent
             .call(self.canister_id, GetRunningSnsVersionRequest {})
             .await
+    }
+
+    pub async fn get_mode<C: CallCanisters>(&self, agent: &C) -> Result<GetModeResponse, C::Error> {
+        agent.call(self.canister_id, GetMode {}).await
     }
 }
 

--- a/rs/nervous_system/agent/src/sns/mod.rs
+++ b/rs/nervous_system/agent/src/sns/mod.rs
@@ -1,3 +1,4 @@
+pub mod archive;
 pub mod governance;
 pub mod index;
 pub mod ledger;
@@ -18,6 +19,7 @@ pub struct Sns {
     pub index: index::IndexCanister,
     pub swap: swap::SwapCanister,
     pub root: root::RootCanister,
+    pub archive: Vec<archive::ArchiveCanister>,
 }
 
 impl Sns {
@@ -67,6 +69,7 @@ impl TryFrom<ic_sns_wasm::pb::v1::DeployedSns> for Sns {
                     .root_canister_id
                     .ok_or("ledger_canister_id not found")?,
             },
+            archive: Vec::new(),
         })
     }
 }

--- a/rs/nervous_system/agent/src/sns/root.rs
+++ b/rs/nervous_system/agent/src/sns/root.rs
@@ -15,6 +15,15 @@ pub struct RootCanister {
     pub canister_id: PrincipalId,
 }
 
+#[allow(clippy::large_enum_variant)]
+#[derive(Debug, thiserror::Error)]
+pub enum ListSnsCanistersError<E> {
+    #[error("SNS root canister did not return canister IDs for all canisters - this should never happen")]
+    SnsRootDidNotReturnAllCanisterIds(ListSnsCanistersResponse),
+    #[error("Failed to call SNS root canister")]
+    CallFailed(#[from] E),
+}
+
 impl RootCanister {
     pub fn new(canister_id: impl Into<PrincipalId>) -> Self {
         let canister_id = canister_id.into();
@@ -35,24 +44,30 @@ impl RootCanister {
             .await
     }
 
-    pub async fn list_sns_canisters<C: CallCanisters>(&self, agent: &C) -> Result<Sns, C::Error> {
+    pub async fn list_sns_canisters<C: CallCanisters>(
+        &self,
+        agent: &C,
+    ) -> Result<Sns, ListSnsCanistersError<C::Error>> {
+        let response = agent
+            .call(self.canister_id, ListSnsCanistersRequest {})
+            .await?;
         let ListSnsCanistersResponse {
-            root: Some(sns_root_canister_id_1),
+            root: Some(sns_root_canister_id),
             governance: Some(sns_governance_canister_id),
             ledger: Some(sns_ledger_canister_id),
             swap: Some(swap_canister_id),
             index: Some(index_canister_id),
             archives,
             dapps: _,
-        } = agent
-            .call(self.canister_id, ListSnsCanistersRequest {})
-            .await?
+        } = response
         else {
-            panic!("SNS root canister did not return canister IDs for all canisters - this should never happen");
+            return Err(ListSnsCanistersError::SnsRootDidNotReturnAllCanisterIds(
+                response,
+            ));
         };
 
         Ok(Sns {
-            root: RootCanister::new(sns_root_canister_id_1),
+            root: RootCanister::new(sns_root_canister_id),
             governance: GovernanceCanister::new(sns_governance_canister_id),
             ledger: LedgerCanister::new(sns_ledger_canister_id),
             swap: SwapCanister::new(swap_canister_id),

--- a/rs/nervous_system/integration_tests/src/pocket_ic_helpers.rs
+++ b/rs/nervous_system/integration_tests/src/pocket_ic_helpers.rs
@@ -1277,26 +1277,6 @@ pub mod sns {
         use ic_sns_governance::pb::v1::{get_neuron_response, GetRunningSnsVersionResponse};
         use pocket_ic::ErrorCode;
 
-        pub async fn get_mode(
-            pocket_ic: &PocketIc,
-            canister_id: PrincipalId,
-        ) -> sns_pb::GetModeResponse {
-            let result = pocket_ic
-                .query_call(
-                    canister_id.into(),
-                    Principal::anonymous(),
-                    "get_mode",
-                    Encode!(&sns_pb::GetMode {}).unwrap(),
-                )
-                .await
-                .unwrap();
-            let result = match result {
-                WasmResult::Reply(result) => result,
-                WasmResult::Reject(s) => panic!("Call to get_mode failed: {:#?}", s),
-            };
-            Decode!(&result, sns_pb::GetModeResponse).unwrap()
-        }
-
         pub async fn get_running_sns_version(
             pocket_ic: &PocketIc,
             sns_governance_canister_id: PrincipalId,

--- a/rs/nervous_system/integration_tests/tests/sns_ledger_upgrade.rs
+++ b/rs/nervous_system/integration_tests/tests/sns_ledger_upgrade.rs
@@ -215,7 +215,7 @@ async fn test_upgrade_existing_sns() {
     {
         sns::upgrade_sns_to_next_version_and_assert_change(
             &pocket_ic,
-            sns.root.canister_id,
+            &sns,
             SnsCanisterType::Index,
         )
         .await;
@@ -257,7 +257,7 @@ async fn test_upgrade_existing_sns() {
 
         sns::upgrade_sns_to_next_version_and_assert_change(
             &pocket_ic,
-            sns.root.canister_id,
+            &sns,
             SnsCanisterType::Ledger,
         )
         .await;
@@ -372,7 +372,7 @@ async fn test_upgrade_existing_sns() {
 
         sns::upgrade_sns_to_next_version_and_assert_change(
             &pocket_ic,
-            sns.root.canister_id,
+            &sns,
             SnsCanisterType::Archive,
         )
         .await;
@@ -403,11 +403,7 @@ async fn test_upgrade_existing_sns() {
         SnsCanisterType::Ledger,
         SnsCanisterType::Archive,
     ] {
-        sns::upgrade_sns_to_next_version_and_assert_change(
-            &pocket_ic,
-            sns.root.canister_id,
-            sns_canister_type,
-        )
-        .await;
+        sns::upgrade_sns_to_next_version_and_assert_change(&pocket_ic, &sns, sns_canister_type)
+            .await;
     }
 }

--- a/rs/nervous_system/integration_tests/tests/sns_lifecycle.rs
+++ b/rs/nervous_system/integration_tests/tests/sns_lifecycle.rs
@@ -443,8 +443,10 @@ async fn test_sns_lifecycle(
 
     // Assert that the mode of SNS Governance is `PreInitializationSwap`.
     assert_eq!(
-        sns::governance::get_mode(&pocket_ic, sns.governance.canister_id)
+        sns.governance
+            .get_mode(&pocket_ic)
             .await
+            .unwrap()
             .mode
             .unwrap(),
         sns_pb::governance::Mode::PreInitializationSwap as i32
@@ -1111,16 +1113,20 @@ async fn test_sns_lifecycle(
     // Assert that the mode of SNS Governance is correct
     if swap_finalization_status == SwapFinalizationStatus::Aborted {
         assert_eq!(
-            sns::governance::get_mode(&pocket_ic, sns.governance.canister_id)
+            sns.governance
+                .get_mode(&pocket_ic)
                 .await
+                .unwrap()
                 .mode
                 .unwrap(),
             sns_pb::governance::Mode::PreInitializationSwap as i32,
         );
     } else {
         assert_eq!(
-            sns::governance::get_mode(&pocket_ic, sns.governance.canister_id)
+            sns.governance
+                .get_mode(&pocket_ic)
                 .await
+                .unwrap()
                 .mode
                 .unwrap(),
             sns_pb::governance::Mode::Normal as i32

--- a/rs/nervous_system/integration_tests/tests/sns_release_qualification.rs
+++ b/rs/nervous_system/integration_tests/tests/sns_release_qualification.rs
@@ -273,19 +273,9 @@ async fn test_sns_upgrade(sns_canisters_to_upgrade: Vec<SnsCanisterType>) {
 
     // Every canister we are testing has two upgrades.  We are just making sure the counts match
     for canister_type in &sns_canisters_to_upgrade {
-        sns::upgrade_sns_to_next_version_and_assert_change(
-            &pocket_ic,
-            sns.root.canister_id,
-            *canister_type,
-        )
-        .await;
+        sns::upgrade_sns_to_next_version_and_assert_change(&pocket_ic, &sns, *canister_type).await;
     }
     for canister_type in sns_canisters_to_upgrade {
-        sns::upgrade_sns_to_next_version_and_assert_change(
-            &pocket_ic,
-            sns.root.canister_id,
-            canister_type,
-        )
-        .await;
+        sns::upgrade_sns_to_next_version_and_assert_change(&pocket_ic, &sns, canister_type).await;
     }
 }

--- a/rs/sns/root/src/request_impls.rs
+++ b/rs/sns/root/src/request_impls.rs
@@ -1,8 +1,17 @@
-use crate::{GetSnsCanistersSummaryRequest, GetSnsCanistersSummaryResponse};
+use crate::{
+    pb::v1::{ListSnsCanistersRequest, ListSnsCanistersResponse},
+    GetSnsCanistersSummaryRequest, GetSnsCanistersSummaryResponse,
+};
 use ic_nervous_system_clients::Request;
 
 impl Request for GetSnsCanistersSummaryRequest {
     type Response = GetSnsCanistersSummaryResponse;
     const METHOD: &'static str = "get_sns_canisters_summary";
     const UPDATE: bool = true;
+}
+
+impl Request for ListSnsCanistersRequest {
+    type Response = ListSnsCanistersResponse;
+    const METHOD: &'static str = "list_sns_canisters";
+    const UPDATE: bool = false;
 }


### PR DESCRIPTION
Advantages of this change:

1. It's less code to implement in ic-nervous-system-agent than it was in pocket_ic_helpers.
2. It's also more compact to call - you can do `sns.governance.get_mode(&pocket_ic)` rather than `sns::governance::get_mode(&pocket_ic, sns.governance.canister_id)`. (Notice how the pocket_ic_helpers implementation required writing `governance` twice, as well as saying `.canister_id`.)
3. The new implementation is more general - the type argument means that you can call it with anything that implements CallCanisters. Currently this is pocket_ic as well as ic-agent. This means that the method can be used in CLI tooling as well as in tests - facilitating code reuse.

Some of the changes in this PR are due to ic-nervous-system-agent previously not having a concept of archive canisters, which had to be added to support root's `list_sns_canisters` endpoint

More helpers will be moved in a future PR. Currently I've been doing this incrementally as I wait for CI to get back to me during my primary tasks.