### PR TITLE
chore: release PocketIC server v7 and PocketIC library v6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16998,7 +16998,7 @@ dependencies = [
 
 [[package]]
 name = "pocket-ic-server"
-version = "6.0.0"
+version = "7.0.0"
 dependencies = [
  "aide",
  "askama",

--- a/packages/pocket-ic/CHANGELOG.md
+++ b/packages/pocket-ic/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+
+
+## 6.0.0 - 2024-11-13
+
 ### Added
 - The function `PocketIc::get_subnet_metrics` to retrieve metrics of a given subnet.
 - The function `PocketIcBuilder::with_bitcoind_addr` to specify the address and port at which a `bitcoind` process is listening.

--- a/packages/pocket-ic/src/lib.rs
+++ b/packages/pocket-ic/src/lib.rs
@@ -76,7 +76,7 @@ pub mod common;
 pub mod management_canister;
 pub mod nonblocking;
 
-const EXPECTED_SERVER_VERSION: &str = "pocket-ic-server 6.0.0";
+const EXPECTED_SERVER_VERSION: &str = "pocket-ic-server 7.0.0";
 
 // the default timeout of a PocketIC operation
 const DEFAULT_MAX_REQUEST_TIME_MS: u64 = 300_000;

--- a/rs/pocket_ic_server/BUILD.bazel
+++ b/rs/pocket_ic_server/BUILD.bazel
@@ -153,7 +153,7 @@ rust_library(
     ]),
     crate_name = "pocket_ic_server",
     proc_macro_deps = MACRO_DEPENDENCIES,
-    version = "6.0.0",
+    version = "7.0.0",
     deps = LIB_DEPENDENCIES + [":build_script"],
 )
 

--- a/rs/pocket_ic_server/CHANGELOG.md
+++ b/rs/pocket_ic_server/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+
+
+## 7.0.0 - 2024-11-13
+
 ### Added
 - Support for IC Bitcoin API via the management canister if the bitcoin canister is installed as the bitcoin testnet canister
   (canister ID `g4xu7-jiaaa-aaaan-aaaaq-cai`) on the bitcoin subnet and configured with `Network::Regtest`

--- a/rs/pocket_ic_server/Cargo.toml
+++ b/rs/pocket_ic_server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pocket-ic-server"
-version = "6.0.0"
+version = "7.0.0"
 edition = "2021"
 
 [dependencies]

--- a/rs/pocket_ic_server/src/main.rs
+++ b/rs/pocket_ic_server/src/main.rs
@@ -54,7 +54,7 @@ const LOG_DIR_PATH_ENV_NAME: &str = "POCKET_IC_LOG_DIR";
 const LOG_DIR_LEVELS_ENV_NAME: &str = "POCKET_IC_LOG_DIR_LEVELS";
 
 #[derive(Parser)]
-#[clap(version = "6.0.0")]
+#[clap(version = "7.0.0")]
 struct Args {
     /// The IP address to which the PocketIC server should bind (defaults to 127.0.0.1)
     #[clap(long, short)]


### PR DESCRIPTION
This PR releases PocketIC server v7 and PocketIC library v6.