### PR TITLE
feat: EXC-1787: Penalize canisters at the end of the round

### DIFF
--- a/rs/execution_environment/src/scheduler/tests.rs
+++ b/rs/execution_environment/src/scheduler/tests.rs
@@ -1884,7 +1884,11 @@ fn scheduler_long_execution_progress_across_checkpoints() {
     // Penalize canister for a long execution.
     let message_id = test.send_ingress(penalized_long_id, ingress(message_instructions));
     assert_eq!(test.ingress_status(&message_id), IngressStatus::Unknown);
-    for _ in 0..message_instructions / slice_instructions {
+    for i in 0..message_instructions / slice_instructions {
+        // Without short executions, all idle canister will be equally executed.
+        if let Some(canister_id) = canister_ids.get(i as usize % num_canisters) {
+            test.send_ingress(*canister_id, ingress(slice_instructions));
+        }
         test.execute_round(ExecutionRoundType::OrdinaryRound);
     }
     assert_matches!(

--- a/rs/execution_environment/src/scheduler/tests.rs
+++ b/rs/execution_environment/src/scheduler/tests.rs
@@ -4543,7 +4543,7 @@ fn scheduler_respects_compute_allocation(
     let replicated_state = test.state();
     let number_of_canisters = replicated_state.canister_states.len();
     let total_compute_allocation = replicated_state.total_compute_allocation();
-    assert!(total_compute_allocation <= 100 * scheduler_cores as u64);
+    prop_assert!(total_compute_allocation <= 100 * scheduler_cores as u64);
 
     // Count, for each canister, how many times it is the first canister
     // to be executed by a thread.
@@ -4556,7 +4556,8 @@ fn scheduler_respects_compute_allocation(
 
     let canister_ids: Vec<_> = test.state().canister_states.iter().map(|x| *x.0).collect();
 
-    for _ in 0..number_of_rounds {
+    // Add one more round as we update the accumulated priorities at the end of the round now.
+    for _ in 0..=number_of_rounds {
         for canister_id in canister_ids.iter() {
             test.expect_heartbeat(*canister_id, instructions(B as u64));
         }
@@ -4584,7 +4585,7 @@ fn scheduler_respects_compute_allocation(
             number_of_rounds / 100 * compute_allocation + 1
         };
 
-        assert!(
+        prop_assert!(
             *count >= expected_count,
             "Canister {} (allocation {}) should have been scheduled \
                     {} out of {} rounds, was scheduled only {} rounds instead.",


### PR DESCRIPTION
The logic of penalizing canisters for full execution and distributing the priority across the subnet has been moved to the end of the round. This change is necessary for priority-based eviction.
    
Newly created canisters join the first execution round with an accumulated priority of zero, which breaks two existing tests, but is not a practical issue. To compensate for this, during the reset round, we set the accumulated priority to the canister's compute allocation instead of the default zero priority.

There are also a few minor optimizations.