### PR TITLE
feat(nns): Increase the neurons limit to 380K

### DIFF
--- a/rs/nns/governance/src/governance.rs
+++ b/rs/nns/governance/src/governance.rs
@@ -190,7 +190,7 @@ pub const MAX_NEURON_RECENT_BALLOTS: usize = 100;
 pub const REWARD_DISTRIBUTION_PERIOD_SECONDS: u64 = ONE_DAY_SECONDS;
 
 /// The maximum number of neurons supported.
-pub const MAX_NUMBER_OF_NEURONS: usize = 350_000;
+pub const MAX_NUMBER_OF_NEURONS: usize = 380_000;
 
 // Spawning is exempted from rate limiting, so we don't need large of a limit here.
 pub const MAX_SUSTAINED_NEURONS_PER_HOUR: u64 = 15;


### PR DESCRIPTION
The number of neurons keeps growing. Some analysis showed that we would be able to increase the limit to 420K. However, given that we are actively working on moving all neurons to stable storage, we would like to increase the limit in a more conservative way. The 380K limit should give us ~18 weeks.