### PR TITLE
chore: Add log_and_halt_installation_on_error sleep

### DIFF
--- a/ic-os/components/setupos-scripts/functions.sh
+++ b/ic-os/components/setupos-scripts/functions.sh
@@ -12,6 +12,11 @@ function log_and_halt_installation_on_error() {
 
     if [ "${exit_code}" -ne 0 ]; then
         {
+            # Sleep before printing error log to ensure previous log messages
+            # have time to display on console (helpful for screen recordings).
+            echo "ERROR DETECTED..."
+            sleep 5
+
             echo -e "\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n"
             echo "--------------------------------------------------------------------------------"
             echo "                       INTERNET COMPUTER - SETUP - FAILED"


### PR DESCRIPTION
When we get installation screen recordings from node providers, the error log often comes so fast that the previous logs don't show up on the console for a single frame. Adding a sleep helps ensure that the logs show up on the console before the error log comes and wipes it.