### PR TITLE
feat(ICRC-Rosetta): updated rosetta to support icrc3 standard

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9031,6 +9031,7 @@ dependencies = [
  "ic-canisters-http-types",
  "ic-cdk 0.16.0",
  "ic-cdk-macros 0.9.0",
+ "ic-certification 2.6.0",
  "ic-crypto-tree-hash",
  "ic-icrc1",
  "ic-icrc1-test-utils",
@@ -13906,7 +13907,9 @@ dependencies = [
  "ic-agent",
  "ic-cbor",
  "ic-certification 2.6.0",
+ "ic-crypto-tree-hash",
  "icrc-ledger-types",
+ "leb128",
 ]
 
 [[package]]

--- a/packages/icrc-ledger-agent/BUILD.bazel
+++ b/packages/icrc-ledger-agent/BUILD.bazel
@@ -10,11 +10,13 @@ rust_library(
     deps = [
         # Keep sorted.
         "//packages/icrc-ledger-types:icrc_ledger_types",
+        "//rs/crypto/tree_hash",
         "@crate_index//:candid",
         "@crate_index//:ciborium",
         "@crate_index//:hex",
         "@crate_index//:ic-agent",
         "@crate_index//:ic-cbor",
         "@crate_index//:ic-certification",
+        "@crate_index//:leb128",
     ],
 )

--- a/packages/icrc-ledger-agent/Cargo.toml
+++ b/packages/icrc-ledger-agent/Cargo.toml
@@ -20,3 +20,5 @@ ic-agent = { workspace = true }
 ic-cbor = { workspace = true }
 ic-certification = { workspace = true }
 icrc-ledger-types = { path = "../icrc-ledger-types", version = "0.1.2" }
+ic-crypto-tree-hash = { path = "../../rs/crypto/tree_hash" }
+leb128 = "0.2.5"

--- a/rs/ledger_suite/icrc1/ledger/BUILD.bazel
+++ b/rs/ledger_suite/icrc1/ledger/BUILD.bazel
@@ -36,8 +36,10 @@ package(default_visibility = ["//visibility:public"])
             "@crate_index//:ciborium",
             "@crate_index//:hex",
             "@crate_index//:ic-cdk",
+            "@crate_index//:ic-certification",
             "@crate_index//:ic-metrics-encoder",
             "@crate_index//:ic-stable-structures",
+            "@crate_index//:leb128",
             "@crate_index//:serde",
             "@crate_index//:serde_bytes",
         ] + extra_deps,
@@ -81,6 +83,15 @@ package(default_visibility = ["//visibility:public"])
             [
             ],
         ),
+        (
+            "_icrc3_compatible_data_certificate",
+            "",
+            [
+                "icrc3-compatible-data-certificate",
+            ],
+            [
+            ],
+        ),
     ]
 ]
 
@@ -108,6 +119,7 @@ package(default_visibility = ["//visibility:public"])
             "@crate_index//:candid",
             "@crate_index//:ciborium",
             "@crate_index//:ic-cdk",
+            "@crate_index//:ic-certification",
             "@crate_index//:ic-metrics-encoder",
             "@crate_index//:ic-stable-structures",
             "@crate_index//:num-traits",
@@ -189,6 +201,14 @@ package(default_visibility = ["//visibility:public"])
             [
                 ":ledger_u256_nextledgerversion",
                 "//rs/ledger_suite/icrc1/tokens_u256",
+            ],
+        ),
+        (
+            "_icrc3_compatible_data_certificate",
+            ["icrc3-compatible-data-certificate"],
+            [
+                ":ledger_icrc3_compatible_data_certificate",
+                "//rs/ledger_suite/icrc1/tokens_u64",
             ],
         ),
     ]

--- a/rs/ledger_suite/icrc1/ledger/Cargo.toml
+++ b/rs/ledger_suite/icrc1/ledger/Cargo.toml
@@ -22,6 +22,7 @@ ic-canister-log = { path = "../../../rust_canisters/canister_log" }
 ic-canisters-http-types = { path = "../../../rust_canisters/http_types" }
 ic-cdk = { workspace = true }
 ic-cdk-macros = { workspace = true }
+ic-certification = { workspace = true }
 ic-crypto-tree-hash = { path = "../../../crypto/tree_hash" }
 ic-icrc1 = { path = ".." }
 ic-icrc1-tokens-u256 = { path = "../tokens_u256", optional = true }
@@ -36,6 +37,7 @@ icrc-ledger-types = { path = "../../../../packages/icrc-ledger-types" }
 num-traits = { workspace = true }
 serde = { workspace = true }
 serde_bytes = { workspace = true }
+leb128 = "0.2.5"
 
 [dev-dependencies]
 assert_matches = { workspace = true }
@@ -56,3 +58,4 @@ get-blocks-disabled = []
 u256-tokens = ["dep:ic-icrc1-tokens-u256"]
 canbench-rs = ["dep:canbench-rs", "dep:assert_matches"]
 next-ledger-version = []
+icrc3-compatible-data-certificate = []

--- a/rs/rosetta-api/icrc1/BUILD.bazel
+++ b/rs/rosetta-api/icrc1/BUILD.bazel
@@ -120,7 +120,7 @@ LOCAL_REPLICA_DATA = [
     "//rs/canister_sandbox:sandbox_launcher",
     "//rs/replica",
     "//rs/ledger_suite/icrc1/archive:archive_canister",
-    "//rs/ledger_suite/icrc1/ledger:ledger_canister",
+    "//rs/ledger_suite/icrc1/ledger:ledger_canister_icrc3_compatible_data_certificate",
     "//rs/rosetta-api/icrc1:ic-icrc-rosetta-bin",
     "//rs/rosetta-api/icrc1/client:ic-icrc-rosetta-client-bin",
     "//rs/pocket_ic_server:pocket-ic-server",
@@ -129,7 +129,7 @@ LOCAL_REPLICA_DATA = [
 LOCAL_REPLICA_ENV = {
     "CANISTER_LAUNCHER": "$(rootpath //rs/canister_sandbox)",
     "IC_ICRC1_ARCHIVE_WASM_PATH": "$(rootpath //rs/ledger_suite/icrc1/archive:archive_canister)",
-    "IC_ICRC1_LEDGER_WASM_PATH": "$(rootpath //rs/ledger_suite/icrc1/ledger:ledger_canister)",
+    "IC_ICRC1_LEDGER_WASM_PATH": "$(rootpath //rs/ledger_suite/icrc1/ledger:ledger_canister_icrc3_compatible_data_certificate)",
     "POCKET_IC_BIN": "$(rootpath //rs/pocket_ic_server:pocket-ic-server)",
     "REPLICA_BIN": "$(rootpath //rs/replica)",
     "ROSETTA_BIN_PATH": "$(rootpath //rs/rosetta-api/icrc1:ic-icrc-rosetta-bin)",


### PR DESCRIPTION
This MR proposes the following changes:

1. Update ICRC-1 ledger to use `latest_block_hash` instead of `tip_hash` in the ICRC3 certificate
2. Update ICRC-1 ledger to use leb128 encoding for the `latest_block_index` in the ICRC3 certificate
3. Use the public crate for ic-certificates to construct the hash tree
4. Update icrc agent to support the changes made to the icrc1 ledger