### PR TITLE
fix: use the registry instead of config for socks proxy in the https_outcalls adapter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8529,6 +8529,7 @@ dependencies = [
 name = "ic-https-outcalls-adapter"
 version = "0.1.0"
 dependencies = [
+ "arc-swap",
  "async-stream",
  "byte-unit",
  "bytes",

--- a/rs/bitcoin/adapter/src/connectionmanager.rs
+++ b/rs/bitcoin/adapter/src/connectionmanager.rs
@@ -428,7 +428,15 @@ impl ConnectionManager {
             .get_connection(address)
             .map_err(|_| ProcessBitcoinNetworkMessageError::InvalidMessage)?;
         if !conn.is_seed() && !self.validate_received_version(message) {
-            warn!(self.logger, "Received an invalid version from {}", address);
+            warn!(
+                self.logger,
+                "Received an invalid version from {}. Version: {}; Height: {}; Services: {}, while current height is: {}",
+                address,
+                message.version,
+                message.start_height,
+                message.services,
+                self.current_height,
+            );
             return Err(ProcessBitcoinNetworkMessageError::InvalidMessage);
         }
         self.send_verack(address).ok();

--- a/rs/https_outcalls/adapter/BUILD.bazel
+++ b/rs/https_outcalls/adapter/BUILD.bazel
@@ -9,6 +9,7 @@ DEPENDENCIES = [
     "//rs/https_outcalls/service",
     "//rs/monitoring/logger",
     "//rs/monitoring/metrics",
+    "@crate_index//:arc-swap",
     "@crate_index//:byte-unit",
     "@crate_index//:clap",
     "@crate_index//:futures",

--- a/rs/https_outcalls/adapter/Cargo.toml
+++ b/rs/https_outcalls/adapter/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+arc-swap = "1"
 byte-unit = "4.0.14"
 clap = { workspace = true }
 futures = { workspace = true }

--- a/rs/https_outcalls/adapter/src/rpc_server.rs
+++ b/rs/https_outcalls/adapter/src/rpc_server.rs
@@ -53,6 +53,12 @@ pub struct CanisterHttp {
 }
 
 impl CanisterHttp {
+
+    fn generate_socks_clients(&self, api_bn_ips: Vec<String>) -> Vec<Client<HttpsConnector<SocksConnector<HttpConnector>>, OutboundRequestBody>> {
+        //TODO(mihailjianu): implement this.
+        return vec![];
+    }
+
     pub fn new(config: Config, logger: ReplicaLogger, metrics: &MetricsRegistry) -> Self {
         // Socks client setup
         let mut http_connector = HttpConnector::new();
@@ -113,6 +119,10 @@ impl HttpsOutcallsService for CanisterHttp {
         self.metrics.requests.inc();
 
         let req = request.into_inner();
+
+        let api_bn_ips = req.api_bn_ips;
+
+        let socks_clients = self.generate_socks_clients(api_bn_ips);
 
         let uri = req.url.parse::<Uri>().map_err(|err| {
             debug!(self.logger, "Failed to parse URL: {}", err);

--- a/rs/https_outcalls/adapter/src/rpc_server.rs
+++ b/rs/https_outcalls/adapter/src/rpc_server.rs
@@ -134,11 +134,13 @@ impl CanisterHttp {
         }
     }
 
+    // This happens extremely rarely, only when there are changes to the api boundary nodes.
     fn update_socks_clients(&self, api_bn_ips: Vec<String>) {
-        let new_clients = self.generate_socks_clients(api_bn_ips);
+        let new_clients = self.generate_socks_clients(api_bn_ips.clone());
         self.socks_clients.store(Arc::new(new_clients));
+        self.current_socks_ips.store(Arc::new(api_bn_ips));
     }
-
+    
     fn get_next_socks_client(&self) -> Option<Client<HttpsConnector<SocksConnector<HttpConnector>>, OutboundRequestBody>> {
         let socks_clients = self.socks_clients.load();
         let socks_clients_ref = &*socks_clients;

--- a/rs/https_outcalls/adapter/tests/server_test.rs
+++ b/rs/https_outcalls/adapter/tests/server_test.rs
@@ -166,6 +166,7 @@ MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgob29X4H4m2XOkSZE
             body: "hello".to_string().as_bytes().to_vec(),
             max_response_size_bytes: 512,
             socks_proxy_allowed: false,
+            api_bn_ips: vec![],
         });
         let response = client.https_outcall(request).await;
         let http_response = response.unwrap().into_inner();
@@ -192,6 +193,7 @@ MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgob29X4H4m2XOkSZE
             body: "hello".to_string().as_bytes().to_vec(),
             max_response_size_bytes: 512,
             socks_proxy_allowed: false,
+            api_bn_ips: vec![],
         });
         let response = client.https_outcall(request).await;
         assert_eq!(
@@ -224,6 +226,7 @@ MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgob29X4H4m2XOkSZE
             body: "hello".to_string().as_bytes().to_vec(),
             max_response_size_bytes: 512,
             socks_proxy_allowed: false,
+            api_bn_ips: vec![],
         });
         let response = client.https_outcall(request).await;
         let http_response = response.unwrap().into_inner();
@@ -248,6 +251,7 @@ MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgob29X4H4m2XOkSZE
             body: "420".to_string().as_bytes().to_vec(),
             max_response_size_bytes: 512,
             socks_proxy_allowed: false,
+            api_bn_ips: vec![],
         });
 
         let response = client.https_outcall(request).await;
@@ -274,6 +278,7 @@ MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgob29X4H4m2XOkSZE
             body: "".to_string().as_bytes().to_vec(),
             max_response_size_bytes: 512,
             socks_proxy_allowed: false,
+            api_bn_ips: vec![],
         });
 
         let response = client.https_outcall(request).await;
@@ -301,6 +306,7 @@ MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgob29X4H4m2XOkSZE
             body: format!("{}", response_limit + 1).as_bytes().to_vec(),
             max_response_size_bytes: response_limit,
             socks_proxy_allowed: false,
+            api_bn_ips: vec![],
         });
 
         let response = client.https_outcall(request).await;
@@ -333,6 +339,7 @@ MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgob29X4H4m2XOkSZE
             body: format!("{}", response_size).as_bytes().to_vec(),
             max_response_size_bytes: response_size * 2,
             socks_proxy_allowed: false,
+            api_bn_ips: vec![],
         });
 
         let response = client.https_outcall(request).await;
@@ -360,6 +367,7 @@ MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgob29X4H4m2XOkSZE
             body: format!("{}", delay).as_bytes().to_vec(),
             max_response_size_bytes: 512,
             socks_proxy_allowed: false,
+            api_bn_ips: vec![],
         });
 
         let response = client.https_outcall(request).await;
@@ -396,6 +404,7 @@ MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgob29X4H4m2XOkSZE
             body: "hello".to_string().as_bytes().to_vec(),
             max_response_size_bytes: 64,
             socks_proxy_allowed: false,
+            api_bn_ips: vec![],
         });
         let response = client.https_outcall(request).await;
         assert_eq!(
@@ -435,6 +444,7 @@ MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgob29X4H4m2XOkSZE
             body: "hello".as_bytes().to_vec(),
             max_response_size_bytes: response_limit,
             socks_proxy_allowed: false,
+            api_bn_ips: vec![],
         });
 
         let response = client.https_outcall(request).await;
@@ -460,6 +470,7 @@ MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgob29X4H4m2XOkSZE
             body: "hello".to_string().as_bytes().to_vec(),
             max_response_size_bytes: 512,
             socks_proxy_allowed: false,
+            api_bn_ips: vec![],
         });
         let response = client.https_outcall(request).await;
         let _ = response.unwrap_err();
@@ -563,6 +574,7 @@ MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgob29X4H4m2XOkSZE
                     body: "hello".to_string().as_bytes().to_vec(),
                     max_response_size_bytes: 512,
                     socks_proxy_allowed: false,
+                    api_bn_ips: vec![],
                 });
 
                 let response = client.https_outcall(request).await;

--- a/rs/https_outcalls/client/src/client.rs
+++ b/rs/https_outcalls/client/src/client.rs
@@ -147,6 +147,7 @@ impl NonBlockingChannel<CanisterHttpRequest> for CanisterHttpAdapterClientImpl {
                         transform: request_transform,
                         ..
                     },
+                api_bn_ips,
             } = canister_http_request;
 
             let adapter_req_timer = Instant::now();
@@ -169,7 +170,8 @@ impl NonBlockingChannel<CanisterHttpRequest> for CanisterHttpAdapterClientImpl {
                         .collect(),
                     body: request_body.unwrap_or_default(),
                     // Socks proxy is only enabled on system subnets.
-                    socks_proxy_allowed: matches!(subnet_type, SubnetType::System)
+                    socks_proxy_allowed: matches!(subnet_type, SubnetType::System),
+                    api_bn_ips,
                 })
                 .map_err(|grpc_status| {
                     (
@@ -448,6 +450,7 @@ mod tests {
                 }),
                 time: UNIX_EPOCH,
             },
+            api_bn_ips: vec![],
         }
     }
 

--- a/rs/https_outcalls/consensus/src/pool_manager.rs
+++ b/rs/https_outcalls/consensus/src/pool_manager.rs
@@ -184,11 +184,20 @@ impl CanisterHttpPoolManagerImpl {
             .collect();
 
         //TODO(mihailjianu): handle errors.
-        let api_bn_ids = self.registry_client.get_api_boundary_node_ids(self.registry_client.get_latest_version()).unwrap();
-        let api_bn_ips = api_bn_ids.iter().map(|id| {
-            let record = self.registry_client.get_node_record(*id, self.registry_client.get_latest_version()).unwrap();
-            record.unwrap().http.unwrap().ip_addr
-        }).collect::<Vec<String>>();
+        let api_bn_ids = self
+            .registry_client
+            .get_api_boundary_node_ids(self.registry_client.get_latest_version())
+            .unwrap();
+        let api_bn_ips = api_bn_ids
+            .iter()
+            .map(|id| {
+                let record = self
+                    .registry_client
+                    .get_node_record(*id, self.registry_client.get_latest_version())
+                    .unwrap();
+                record.unwrap().http.unwrap().ip_addr
+            })
+            .collect::<Vec<String>>();
 
         for (id, context) in http_requests {
             if !request_ids_already_made.contains(&id) {

--- a/rs/https_outcalls/service/proto/https_outcalls_service/v1/proto.proto
+++ b/rs/https_outcalls/service/proto/https_outcalls_service/v1/proto.proto
@@ -21,6 +21,7 @@ message HttpsOutcallRequest {
   HttpMethod method = 4;
   uint64 max_response_size_bytes = 5;
   bool socks_proxy_allowed = 6;
+  repeated string api_bn_ips = 7;
 }
 
 message HttpsOutcallResponse {

--- a/rs/pocket_ic_server/src/pocket_ic.rs
+++ b/rs/pocket_ic_server/src/pocket_ic.rs
@@ -1248,6 +1248,7 @@ impl Operation for ProcessCanisterHttpInternal {
                     timeout: context.time + Duration::from_secs(5 * 60),
                     id,
                     context,
+                    api_bn_ips: vec![],
                 }) {
                     canister_http.pending.insert(id);
                 }
@@ -1401,6 +1402,7 @@ fn process_mock_canister_https_response(
                     timeout,
                     id: canister_http_request_id,
                     context: context.clone(),
+                    api_bn_ips: vec![],
                 })
                 .unwrap();
             let response = loop {

--- a/rs/types/types/src/canister_http.rs
+++ b/rs/types/types/src/canister_http.rs
@@ -457,7 +457,8 @@ pub struct CanisterHttpRequest {
     pub id: CanisterHttpRequestId,
     /// The context of the request which captures all the metadata about this request
     pub context: CanisterHttpRequestContext,
-    /// The api boundary nodes that should be used as a socks proxy in the case of a request to an IPv4 address.
+    /// The most up to date api boundary nodes that should be used as a socks proxy in the case of a request to an IPv4 address.
+    /// The adapter does not guarantee that the request will be sent through these nodes.
     pub api_bn_ips: Vec<String>,
 }
 

--- a/rs/types/types/src/canister_http.rs
+++ b/rs/types/types/src/canister_http.rs
@@ -457,6 +457,8 @@ pub struct CanisterHttpRequest {
     pub id: CanisterHttpRequestId,
     /// The context of the request which captures all the metadata about this request
     pub context: CanisterHttpRequestContext,
+    /// The api boundary nodes that should be used as a socks proxy in the case of a request to an IPv4 address.
+    pub api_bn_ips: Vec<String>,
 }
 
 /// The content of a response after the transformation


### PR DESCRIPTION
This change introduces the use of the registry in order to fetch API boundary node IPs to be used as a socks proxy.

The IPs are fetched in the replica at every request batch and sent as part of the request to the adapter. The adapter then processes the request, using the proxy's in a round-robin fashion when needed.

Because the actual API_BN IPs _should_ change very rarely, the adapter keeps a local cache of IPs and hyper clients which are only updated when needed.

I have decided against properly synchronizing on the cache (currently it's implemented using an arc_swap), as that would introduce a lot of complexity (mutexes / locks / waiting on other threads etc). This however can lead to scenarios such as the adapter sending the outcalls through different socks proxies than the ones specified in the request (which is fine). Hence, the `api_bn_ips` field should be viewed more like a suggestion to the adapter, and not as a strong enforcement on the request.