### PR TITLE
refactor(ckbtc): minor refactor of FetchEnv

### DIFF
--- a/rs/bitcoin/kyt/src/fetch/tests.rs
+++ b/rs/bitcoin/kyt/src/fetch/tests.rs
@@ -65,9 +65,6 @@ impl FetchEnv for MockEnv {
         *available -= cycles;
         cycles
     }
-    fn cycles_available(&self) -> u128 {
-        *self.available_cycles.borrow()
-    }
 }
 
 impl MockEnv {
@@ -98,6 +95,9 @@ impl MockEnv {
     }
     fn cycles_accepted(&self) -> u128 {
         *self.accepted_cycles.borrow()
+    }
+    fn cycles_available(&self) -> u128 {
+        *self.available_cycles.borrow()
     }
 }
 

--- a/rs/bitcoin/kyt/src/main.rs
+++ b/rs/bitcoin/kyt/src/main.rs
@@ -237,9 +237,6 @@ impl FetchEnv for KytCanisterEnv {
     fn cycles_accept(&self, cycles: u128) -> u128 {
         ic_cdk::api::call::msg_cycles_accept128(cycles)
     }
-    fn cycles_available(&self) -> u128 {
-        ic_cdk::api::call::msg_cycles_available128()
-    }
 }
 
 /// Check the input addresses of a transaction given its txid.


### PR DESCRIPTION
Remove the `cycles_available` method from `FetchEnv` and make the return result of `check_fetched` slightly more accurate.