### PR TITLE
refactor(nns): Spin out sum_weighted_voting_power.

### DIFF
--- a/rs/nns/governance/src/governance.rs
+++ b/rs/nns/governance/src/governance.rs
@@ -63,7 +63,7 @@ use crate::{
         StopOrStartCanister, Tally, Topic, UpdateCanisterSettings, UpdateNodeProvider, Visibility,
         Vote, WaitForQuietState, XdrConversionRate as XdrConversionRatePb,
     },
-    proposals::call_canister::CallCanister,
+    proposals::{call_canister::CallCanister, sum_weighted_voting_power},
 };
 use async_trait::async_trait;
 use candid::{Decode, Encode};
@@ -7028,57 +7028,19 @@ impl Governance {
         // reward weight of proposals being voted on.
         let mut actually_distributed_e8s_equivalent = 0_u64;
 
-        // Sum up "voting rights", which determine the share of the pot earned
-        // by a neuron.
-        //
-        // Construct map voters -> total _used_ voting rights for
-        // considered proposals as well as the overall total voting
-        // power on considered proposals, whether or not this voting
-        // power was used to vote (yes or no).
-        let (voters_to_used_voting_right, total_voting_rights) = {
-            let mut voters_to_used_voting_right: HashMap<NeuronId, f64> = HashMap::new();
-            let mut total_voting_rights = 0f64;
-
-            for pid in considered_proposals.iter() {
-                if let Some(proposal) = self.get_proposal_data(*pid) {
-                    let reward_weight = proposal.topic().reward_weight();
-
-                    let weighted_total_potential_voting_power = proposal
-                        .total_potential_voting_power
-                        .map(|total_potential_voting_power| {
-                            reward_weight * (total_potential_voting_power as f64)
-                        });
-
-                    let mut proposal_total_deciding_voting_rights = 0_f64;
-                    for (voter, ballot) in proposal.ballots.iter() {
-                        let voting_rights = (ballot.voting_power as f64) * reward_weight;
-                        proposal_total_deciding_voting_rights += voting_rights;
-                        #[allow(clippy::blocks_in_conditions)]
-                        if Vote::try_from(ballot.vote)
-                            .unwrap_or_else(|_| {
-                                println!(
-                                    "{}Vote::from invoked with unexpected value {}.",
-                                    LOG_PREFIX, ballot.vote
-                                );
-                                Vote::Unspecified
-                            })
-                            .eligible_for_rewards()
-                        {
-                            *voters_to_used_voting_right
-                                .entry(NeuronId { id: *voter })
-                                .or_insert(0f64) += voting_rights;
-                        }
-                    }
-
-                    total_voting_rights += weighted_total_potential_voting_power
-                        // This is to handle legacy proposals, which were
-                        // created before there was a distinction between
-                        // *deciding* voting power vs. *potential* voting power.
-                        .unwrap_or(proposal_total_deciding_voting_rights);
-                }
+        let proposals = considered_proposals.iter().filter_map(|proposal_id| {
+            let result = self.heap_data.proposals.get(&proposal_id.id);
+            if result.is_none() {
+                println!(
+                    "{}ERROR: Trying to give voting rewards for proposal {}, \
+                         but it was not found.",
+                    LOG_PREFIX, proposal_id.id,
+                );
             }
-            (voters_to_used_voting_right, total_voting_rights)
-        };
+            result
+        });
+        let (voters_to_used_voting_right, total_voting_rights) =
+            sum_weighted_voting_power(proposals);
 
         // Increment neuron maturities (and actually_distributed_e8s_equivalent).
         //

--- a/rs/nns/governance/src/proposals/mod.rs
+++ b/rs/nns/governance/src/proposals/mod.rs
@@ -1,5 +1,9 @@
-use crate::pb::v1::{governance_error::ErrorType, GovernanceError, Topic};
+use crate::{
+    governance::LOG_PREFIX,
+    pb::v1::{governance_error::ErrorType, GovernanceError, ProposalData, Topic, Vote},
+};
 use ic_base_types::CanisterId;
+use ic_nns_common::pb::v1::NeuronId;
 use ic_nns_constants::{
     BITCOIN_MAINNET_CANISTER_ID, BITCOIN_TESTNET_CANISTER_ID, CYCLES_LEDGER_CANISTER_ID,
     CYCLES_LEDGER_INDEX_CANISTER_ID, CYCLES_MINTING_CANISTER_ID, EXCHANGE_RATE_CANISTER_ID,
@@ -8,6 +12,7 @@ use ic_nns_constants::{
     LEDGER_INDEX_CANISTER_ID, LIFELINE_CANISTER_ID, REGISTRY_CANISTER_ID, ROOT_CANISTER_ID,
     SNS_AGGREGATOR_CANISTER_ID, SNS_WASM_CANISTER_ID, SUBNET_RENTAL_CANISTER_ID,
 };
+use std::collections::HashMap;
 
 pub mod call_canister;
 pub mod create_service_nervous_system;
@@ -52,5 +57,79 @@ pub(crate) fn invalid_proposal_error(reason: &str) -> GovernanceError {
     GovernanceError::new_with_message(
         ErrorType::InvalidProposal,
         format!("Proposal invalid because of {}", reason),
+    )
+}
+
+/// Weighted voting power is just voting power * the proposal's (topic's) weight.
+///
+/// For example, suppose this returns ({42 => 3.14}, 99.9). This means that
+/// neuron 42 should get 3.14/99.9 of today's reward purse.
+///
+/// Non-essential fact: Typically, result.1 is strictly greater than the sum of
+/// the values in result.0. The main reason they are usually not equal is that
+/// some neurons didn't vote. Another reason is that some neurons did not
+/// "refresh" their voting power recently enough. Probably the former has more
+/// of an impact on the sum of values in result.1.
+pub fn sum_weighted_voting_power<'a>(
+    proposals: impl Iterator<Item = &'a ProposalData>,
+) -> (
+    HashMap<
+        NeuronId,
+        f64, // exercised
+    >,
+    f64, // total
+) {
+    // Results.
+    let mut neuron_id_to_exercised_weighted_voting_power: HashMap<NeuronId, f64> = HashMap::new();
+    let mut total_weighted_voting_power = 0.0;
+
+    for proposal in proposals {
+        let reward_weight = proposal.topic().reward_weight();
+
+        // This is used in lieu of total_potential_voting_power. That is, this
+        // gets used if proposal does not have total_potential_voting_power.
+        // This fall back will only be used during a short transition period
+        // when there is a backlog of "old" proposals that were created without
+        // total_potential_voting_power, but all new proposals have it. In the
+        // case of such legacy proposals, their total potential voting power
+        // would have been equal to this anyway, so this is a sound substitute
+        // for total_potential_voting_power.
+        let mut total_ballots_voting_power = 0;
+
+        for (neuron_id, ballot) in &proposal.ballots {
+            total_ballots_voting_power += ballot.voting_power;
+
+            // Don't reward neurons that did not actually vote. (Whereas, ALL
+            // eligible neurons get an "empty" ballot when the proposal is first
+            // created. An "empty" ballot is one where the vote field is set to
+            // Unspecified.)
+            let vote = Vote::try_from(ballot.vote).unwrap_or_else(|err| {
+                println!(
+                    "{}ERROR: Unrecognized Vote {} in ballot by neuron {} \
+                     on proposal {:?}: {:?}",
+                    LOG_PREFIX, ballot.vote, neuron_id, proposal.id, err,
+                );
+                Vote::Unspecified
+            });
+            if !vote.eligible_for_rewards() {
+                continue;
+            }
+
+            // Increment neuron.
+            *neuron_id_to_exercised_weighted_voting_power
+                .entry(NeuronId { id: *neuron_id })
+                .or_insert(0.0) += (ballot.voting_power as f64) * reward_weight;
+        }
+
+        // Increment global total.
+        total_weighted_voting_power += reward_weight
+            * proposal
+                .total_potential_voting_power
+                .unwrap_or(total_ballots_voting_power) as f64;
+    }
+
+    (
+        neuron_id_to_exercised_weighted_voting_power,
+        total_weighted_voting_power,
     )
 }

--- a/rs/nns/governance/tests/proposals.rs
+++ b/rs/nns/governance/tests/proposals.rs
@@ -190,17 +190,17 @@ fn test_sum_weighted_voting_power() {
                 // value has no entry for this neuron.
 
                 // Voted (Yes) twice on 1x weight proposals and once on a 20x weight proposal.
-                NeuronId { id: 1043 } => (2 * 2_000 + 20 * 2_000) as f64,
+                NeuronId { id: 1043 } => ((2_000 + 1_000 + 20 * 2_000) * E8) as f64,
 
                 // Similar to previous, but voted No, and has different (more) voting power.
                 // In voting rewards, Yes and No are treated the same.
-                NeuronId { id: 1044 } => (2 * 30_000 + 20 * 30_000) as f64,
+                NeuronId { id: 1044 } => ((30_000 + 20_000 + 20 * 30_000) * E8) as f64,
             },
-            (
+            ((
                 (100 + 2_000 + 30_000) // First proposal.
-                + 40_000               // Second proposal
-                + 20 * 40_000          // Third proposal
-            ) as f64
+                + 80_000               // Second proposal
+                + 20 * 80_000          // Third proposal
+            ) * E8) as f64
         ),
     );
 }

--- a/rs/nns/governance/tests/proposals.rs
+++ b/rs/nns/governance/tests/proposals.rs
@@ -8,6 +8,7 @@ use ic_nns_governance::{
         NetworkEconomics, Neuron, Proposal, ProposalData, ProposalRewardStatus, Vote,
         WaitForQuietState,
     },
+    proposals::sum_weighted_voting_power,
 };
 use icp_ledger::Tokens;
 use lazy_static::lazy_static;
@@ -170,6 +171,38 @@ lazy_static! {
         economics: Some(NetworkEconomics::with_default_values()),
         ..Default::default()
     };
+}
+
+#[test]
+fn test_sum_weighted_voting_power() {
+    // Step 1: Prepare the world.
+
+    // Step 2: Call code under test.
+    let result = sum_weighted_voting_power(PROPOSALS.iter().map(|(_id, proposal)| proposal));
+
+    // Step 3: Inspect result(s).
+    #[rustfmt::skip]
+    assert_eq!(
+        result,
+        (
+            hashmap! {
+                // Neuron 1042 never voted, and because of this, the return
+                // value has no entry for this neuron.
+
+                // Voted (Yes) twice on 1x weight proposals and once on a 20x weight proposal.
+                NeuronId { id: 1043 } => (2 * 2_000 + 20 * 2_000) as f64,
+
+                // Similar to previous, but voted No, and has different (more) voting power.
+                // In voting rewards, Yes and No are treated the same.
+                NeuronId { id: 1044 } => (2 * 30_000 + 20 * 30_000) as f64,
+            },
+            (
+                (100 + 2_000 + 30_000) // First proposal.
+                + 40_000               // Second proposal
+                + 20 * 40_000          // Third proposal
+            ) as f64
+        ),
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
This used to be part of https://github.com/dfinity/ic/pull/2385, but I was asked to not spin out sum_weighted_voting_power from distribute_rewards.