### PR TITLE
fix(ckbtc): ensure tasks are always rescheduled

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6579,6 +6579,7 @@ dependencies = [
  "lazy_static",
  "minicbor",
  "minicbor-derive",
+ "mockall",
  "num-traits",
  "proptest",
  "ripemd",

--- a/rs/bitcoin/ckbtc/minter/BUILD.bazel
+++ b/rs/bitcoin/ckbtc/minter/BUILD.bazel
@@ -111,8 +111,10 @@ rust_test(
     deps = [
         # Keep sorted.
         "@crate_index//:bitcoin",
+        "@crate_index//:mockall",
         "@crate_index//:proptest",
         "@crate_index//:simple_asn1",
+        "@crate_index//:tokio",
     ],
 )
 

--- a/rs/bitcoin/ckbtc/minter/Cargo.toml
+++ b/rs/bitcoin/ckbtc/minter/Cargo.toml
@@ -60,6 +60,7 @@ ic-icrc1-ledger = { path = "../../../ledger_suite/icrc1/ledger" }
 ic-state-machine-tests = { path = "../../../state_machine_tests" }
 ic-test-utilities-load-wasm = { path = "../../../test_utilities/load_wasm" }
 ic-types = { path = "../../../types/types" }
+mockall = { workspace = true }
 proptest = { workspace = true }
 simple_asn1 = { workspace = true }
 tokio = { workspace = true }

--- a/rs/bitcoin/ckbtc/minter/src/lib.rs
+++ b/rs/bitcoin/ckbtc/minter/src/lib.rs
@@ -34,6 +34,8 @@ pub mod tx;
 pub mod updates;
 
 #[cfg(test)]
+pub mod test_fixtures;
+#[cfg(test)]
 mod tests;
 
 /// Time constants

--- a/rs/bitcoin/ckbtc/minter/src/tasks.rs
+++ b/rs/bitcoin/ckbtc/minter/src/tasks.rs
@@ -1,3 +1,5 @@
+#[cfg(test)]
+mod tests;
 use crate::{
     distribute_kyt_fees, estimate_fee_per_vbyte, finalize_requests, reimburse_failed_kyt,
     submit_pending_requests, CanisterRuntime,
@@ -130,52 +132,57 @@ pub fn global_timer() -> u64 {
 }
 
 pub(crate) async fn run_task<R: CanisterRuntime>(task: Task, runtime: R) {
-    const INTERVAL_PROCESSING: Duration = Duration::from_secs(5);
-
     match task.task_type {
         TaskType::ProcessLogic => {
-            let _guard = match crate::guard::TimerLogicGuard::new() {
-                Some(guard) => guard,
-                None => return,
-            };
+            const INTERVAL_PROCESSING: Duration = Duration::from_secs(5);
 
             let _enqueue_followup_guard = guard((), |_| {
                 schedule_after(INTERVAL_PROCESSING, TaskType::ProcessLogic, &runtime)
             });
+
+            let _guard = match crate::guard::TimerLogicGuard::new() {
+                Some(guard) => guard,
+                None => return,
+            };
 
             submit_pending_requests().await;
             finalize_requests().await;
             reimburse_failed_kyt().await;
         }
         TaskType::RefreshFeePercentiles => {
+            const FEE_ESTIMATE_DELAY: Duration = Duration::from_secs(60 * 60);
+            let _enqueue_followup_guard = guard((), |_| {
+                schedule_after(
+                    FEE_ESTIMATE_DELAY,
+                    TaskType::RefreshFeePercentiles,
+                    &runtime,
+                )
+            });
+
             let _guard = match crate::guard::TimerLogicGuard::new() {
                 Some(guard) => guard,
                 None => return,
             };
-            const FEE_ESTIMATE_DELAY: Duration = Duration::from_secs(60 * 60);
             let _ = estimate_fee_per_vbyte().await;
-            schedule_after(
-                FEE_ESTIMATE_DELAY,
-                TaskType::RefreshFeePercentiles,
-                &runtime,
-            );
         }
         TaskType::DistributeKytFee => {
+            const MAINNET_KYT_FEE_DISTRIBUTION_PERIOD: Duration = Duration::from_secs(24 * 60 * 60);
+
+            let _enqueue_followup_guard = guard((), |_| {
+                schedule_after(
+                    MAINNET_KYT_FEE_DISTRIBUTION_PERIOD,
+                    TaskType::DistributeKytFee,
+                    &runtime,
+                );
+            });
             let _guard = match crate::guard::DistributeKytFeeGuard::new() {
                 Some(guard) => guard,
                 None => return,
             };
 
-            const MAINNET_KYT_FEE_DISTRIBUTION_PERIOD: Duration = Duration::from_secs(24 * 60 * 60);
-
             match crate::state::read_state(|s| s.btc_network) {
                 Network::Mainnet | Network::Testnet => {
                     distribute_kyt_fees().await;
-                    schedule_after(
-                        MAINNET_KYT_FEE_DISTRIBUTION_PERIOD,
-                        TaskType::DistributeKytFee,
-                        &runtime,
-                    );
                 }
                 // We use a debug canister build exposing an endpoint
                 // triggering the fee distribution in tests.

--- a/rs/bitcoin/ckbtc/minter/src/tasks/tests.rs
+++ b/rs/bitcoin/ckbtc/minter/src/tasks/tests.rs
@@ -1,0 +1,87 @@
+use crate::tasks::tests::mock::MockCanisterRuntime;
+use crate::tasks::{pop_if_ready, run_task, schedule_now, Task, TaskType, TASKS};
+use std::time::Duration;
+
+#[tokio::test]
+async fn should_reschedule_process_logic() {
+    test_reschedule(
+        TaskType::ProcessLogic,
+        || crate::guard::TimerLogicGuard::new().unwrap(),
+        Duration::from_secs(5),
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn should_reschedule_refresh_fees() {
+    test_reschedule(
+        TaskType::RefreshFeePercentiles,
+        || crate::guard::TimerLogicGuard::new().unwrap(),
+        Duration::from_secs(60 * 60),
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn should_reschedule_distribute_kyt_fee() {
+    test_reschedule(
+        TaskType::DistributeKytFee,
+        || crate::guard::DistributeKytFeeGuard::new().unwrap(),
+        Duration::from_secs(24 * 60 * 60),
+    )
+    .await;
+}
+
+async fn test_reschedule<T, G: FnOnce() -> T>(
+    task_type: TaskType,
+    guard: G,
+    expected_deadline: Duration,
+) {
+    init_state();
+    let mut runtime = MockCanisterRuntime::new();
+    runtime.expect_time().return_const(0_u64);
+    runtime.expect_global_timer_set().return_const(());
+    schedule_now(task_type.clone(), &runtime);
+
+    let _guard_mocking_already_running_task = guard();
+    let task = pop_if_ready(&runtime).unwrap();
+    assert_eq!(
+        task,
+        Task {
+            execute_at: 0,
+            task_type: task_type.clone(),
+        }
+    );
+    assert_eq!(task_deadline_from_state(&task_type), None);
+
+    run_task(task, runtime).await;
+
+    assert_eq!(
+        task_deadline_from_state(&task_type),
+        Some(expected_deadline.as_nanos() as u64)
+    );
+}
+
+fn task_deadline_from_state(task: &TaskType) -> Option<u64> {
+    TASKS.with(|t| t.borrow().deadline_by_task.get(task).cloned())
+}
+
+fn init_state() {
+    crate::test_fixtures::init_state(crate::test_fixtures::init_args());
+}
+
+mod mock {
+    use crate::CanisterRuntime;
+    use async_trait::async_trait;
+    use mockall::mock;
+
+    mock! {
+        pub CanisterRuntime {}
+
+        #[async_trait]
+        impl CanisterRuntime for CanisterRuntime {
+            fn time(&self) -> u64;
+            fn global_timer_set(&self, timestamp: u64);
+        }
+    }
+}

--- a/rs/bitcoin/ckbtc/minter/src/tasks/tests.rs
+++ b/rs/bitcoin/ckbtc/minter/src/tasks/tests.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 
 proptest! {
     #[test]
-    fn queue_holds_one_copy_of_each_task(
+    fn should_hold_one_copy_of_each_task(
         timestamps in pvec(1_000_000_u64..1_000_000_000, 2..100),
     ) {
         let mut task_queue: TaskQueue = Default::default();

--- a/rs/bitcoin/ckbtc/minter/src/test_fixtures.rs
+++ b/rs/bitcoin/ckbtc/minter/src/test_fixtures.rs
@@ -1,0 +1,27 @@
+use crate::lifecycle;
+use crate::lifecycle::init::{BtcNetwork, InitArgs};
+use candid::Principal;
+use ic_base_types::CanisterId;
+
+pub fn init_args() -> InitArgs {
+    InitArgs {
+        btc_network: BtcNetwork::Mainnet,
+        ecdsa_key_name: "key_1".to_string(),
+        retrieve_btc_min_amount: 10_000,
+        ledger_id: CanisterId::unchecked_from_principal(
+            Principal::from_text("mxzaz-hqaaa-aaaar-qaada-cai")
+                .unwrap()
+                .into(),
+        ),
+        max_time_in_queue_nanos: 600_000_000_000,
+        min_confirmations: Some(72),
+        mode: crate::state::Mode::GeneralAvailability,
+        new_kyt_principal: Some(CanisterId::from(0)),
+        kyt_principal: Some(CanisterId::from(0)),
+        kyt_fee: None,
+    }
+}
+
+pub fn init_state(args: InitArgs) {
+    lifecycle::init::init(args)
+}

--- a/rs/bitcoin/ckbtc/minter/src/test_fixtures.rs
+++ b/rs/bitcoin/ckbtc/minter/src/test_fixtures.rs
@@ -14,7 +14,7 @@ pub fn init_args() -> InitArgs {
                 .into(),
         ),
         max_time_in_queue_nanos: 600_000_000_000,
-        min_confirmations: Some(72),
+        min_confirmations: Some(6),
         mode: crate::state::Mode::GeneralAvailability,
         new_kyt_principal: Some(CanisterId::from(0)),
         kyt_principal: Some(CanisterId::from(0)),

--- a/rs/bitcoin/ckbtc/minter/src/tests.rs
+++ b/rs/bitcoin/ckbtc/minter/src/tests.rs
@@ -491,32 +491,6 @@ fn arb_retrieve_btc_requests(
 
 proptest! {
     #[test]
-    fn queue_holds_one_copy_of_each_task(
-        timestamps in pvec(1_000_000_u64..1_000_000_000, 2..100),
-    ) {
-        use crate::tasks::{Task, TaskQueue, TaskType};
-
-        let mut task_queue: TaskQueue = Default::default();
-        for (i, ts) in timestamps.iter().enumerate() {
-            task_queue.schedule_at(*ts, TaskType::ProcessLogic);
-            prop_assert_eq!(task_queue.len(), 1, "queue: {:?}", task_queue);
-
-            let task = task_queue.pop_if_ready(u64::MAX).unwrap();
-
-            prop_assert_eq!(task_queue.len(), 0);
-
-            prop_assert_eq!(&task, &Task{
-                execute_at: timestamps[0..=i].iter().cloned().min().unwrap(),
-                task_type: TaskType::ProcessLogic
-            });
-            task_queue.schedule_at(task.execute_at, task.task_type);
-
-            prop_assert_eq!(task_queue.len(), 1);
-        }
-    }
-
-
-    #[test]
     fn greedy_solution_properties(
         values in pvec(1u64..1_000_000_000, 1..10),
         target in 1u64..1_000_000_000,

--- a/rs/bitcoin/ckbtc/minter/src/updates/retrieve_btc.rs
+++ b/rs/bitcoin/ckbtc/minter/src/updates/retrieve_btc.rs
@@ -8,6 +8,7 @@ use crate::{
     address::{account_to_bitcoin_address, BitcoinAddress, ParseAddressError},
     guard::{retrieve_btc_guard, GuardError},
     state::{self, mutate_state, read_state, RetrieveBtcRequest},
+    IC_CANISTER_RUNTIME,
 };
 use candid::{CandidType, Deserialize, Nat, Principal};
 use ic_base_types::PrincipalId;
@@ -243,7 +244,7 @@ pub async fn retrieve_btc(args: RetrieveBtcArgs) -> Result<RetrieveBtcOk, Retrie
         read_state(|s| s.retrieve_btc_status(block_index))
     );
 
-    schedule_now(TaskType::ProcessLogic);
+    schedule_now(TaskType::ProcessLogic, &IC_CANISTER_RUNTIME);
 
     Ok(RetrieveBtcOk { block_index })
 }
@@ -344,7 +345,7 @@ pub async fn retrieve_btc_with_approval(
         read_state(|s| s.retrieve_btc_status(block_index))
     );
 
-    schedule_now(TaskType::ProcessLogic);
+    schedule_now(TaskType::ProcessLogic, &IC_CANISTER_RUNTIME);
 
     Ok(RetrieveBtcOk { block_index })
 }

--- a/rs/bitcoin/ckbtc/minter/src/updates/update_balance.rs
+++ b/rs/bitcoin/ckbtc/minter/src/updates/update_balance.rs
@@ -21,6 +21,7 @@ use crate::{
     state,
     tx::{DisplayAmount, DisplayOutpoint},
     updates::get_btc_address,
+    IC_CANISTER_RUNTIME,
 };
 
 /// The argument of the [update_balance] endpoint.
@@ -279,7 +280,7 @@ pub async fn update_balance(
         }
     }
 
-    schedule_now(TaskType::ProcessLogic);
+    schedule_now(TaskType::ProcessLogic, &IC_CANISTER_RUNTIME);
     Ok(utxo_statuses)
 }
 


### PR DESCRIPTION
The tasks `ProcessLogic` and `RefreshFeePercentiles` are executed on a timer at different frequencies. Since #2435, the second task is also guarded by a `TimerLogicGuard`, which is the same type of guard used by `ProcessLogic`, meaning it could be the case that a task of type `RefreshFeePercentiles` prevents a task of type `ProcessLogic` from being executed, which is particularly the case upon canister initialization or upgrade as all tasks are scheduled at the same time.

This is problematic because the re-scheduling of a task of type `ProcessLogic` only happened _after_ having tried to obtain a `TimerLogicGuard`, meaning that in case this failed, due to for example the running of a `RefreshFeePercentiles`, the task `ProcessLogic`  would not be rescheduled.

The fix simply consists of having the rescheduling of each task as a scope guard that is declared _before_ trying to retrieve the concurrency guard for the given task type. To be able to unit test this, some refactoring was needed to abstract away some canister specific methods related to time management to be able to mock those.