### PR TITLE
ci: Fix `CODEOWNERS` for cross-chain team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -241,6 +241,7 @@ go_deps.bzl               @dfinity/idx
 /rs/tests/boundary_nodes/                               @dfinity/boundary-node @dfinity/idx
 /rs/tests/ckbtc/                                        @dfinity/cross-chain-team @dfinity/idx
 /rs/tests/consensus/                                    @dfinity/consensus @dfinity/idx
+/rs/tests/cross_chain/                                  @dfinity/cross-chain-team @dfinity/idx
 /rs/tests/crypto/                                       @dfinity/crypto-team @dfinity/idx
 /rs/tests/dre/                                          @dfinity/dre @dfinity/idx
 /rs/tests/execution/                                    @dfinity/execution @dfinity/idx


### PR DESCRIPTION
The cross-chain team should co-own (together with IDX) `/rs/tests/cross_chain/`, similarly to other system tests. Initially, those tests were in `/rs/tests/src/cross_chain/`, but were moved as part of the inlining in #1957 and the ownership of `/rs/tests/src/cross_chain/` was removed in #2260.