### PR TITLE
fix: stop doing u32 subtraction in bitcoin headers validation

### DIFF
--- a/rs/bitcoin/validation/BUILD.bazel
+++ b/rs/bitcoin/validation/BUILD.bazel
@@ -5,6 +5,7 @@ package(default_visibility = ["//visibility:public"])
 DEPENDENCIES = [
     # Keep sorted.
     "@crate_index//:bitcoin",
+    "@crate_index//:thiserror",
 ]
 
 MACRO_DEPENDENCIES = []

--- a/rs/bitcoin/validation/BUILD.bazel
+++ b/rs/bitcoin/validation/BUILD.bazel
@@ -5,7 +5,6 @@ package(default_visibility = ["//visibility:public"])
 DEPENDENCIES = [
     # Keep sorted.
     "@crate_index//:bitcoin",
-    "@crate_index//:thiserror",
 ]
 
 MACRO_DEPENDENCIES = []


### PR DESCRIPTION
<img width="960" alt="Screenshot 2024-11-15 at 17 09 00" src="https://github.com/user-attachments/assets/94430a8e-fc29-44d7-a7b2-fa4aecfbe614">

The bitcoin adapter has been stuck on the testnet on height `3229631` since November 4th. The reason was that because of a u32 subtraction underflow (see changes), it thought that the next correct block was invalid (because of insufficient PoW), hence it was rejecting all headers messages coming from all the peers. 

The reason it was underflowing was that the timestamp of [block `3229631`](https://blockstream.info/testnet/block/000000000000005ca13d4fc8bebb498e46dd764ec5f727ffff7ac9c90da8ed28) is actually smaller than the timestamp of [block `3227616`](https://blockstream.info/testnet/block/00000000084e1bbf6a418ef356f62ad38fdab345afe69baead9146fc41c65141), even if `3227616` comes 2015 blocks before `3229631`. 

2015 blocks is on average 2 weeks worth of mining, so these two blocks having a "reversed" timestamp order is actually really extraordinary, and it would **_absolutely_** never happen on the mainnet. The reason it occurred was due to the "block storm" on the testnet on November 3rd 2024 (see image).