### PR TITLE
fix(CON-1332): Handle ChainKeyInitializations conversion errors

### DIFF
--- a/rs/consensus/src/dkg.rs
+++ b/rs/consensus/src/dkg.rs
@@ -490,10 +490,10 @@ pub fn make_registry_cup_from_cup_contents(
         Err(err) => {
             warn!(
                 logger,
-                "Failed constructing IDKG summary block from CUP contents: {}", err
+                "Failed constructing IDKG summary block from CUP contents: {}.", err
             );
 
-            None
+            return None;
         }
     };
 

--- a/rs/consensus/src/idkg/utils.rs
+++ b/rs/consensus/src/idkg/utils.rs
@@ -369,31 +369,20 @@ pub(crate) fn inspect_idkg_chain_key_initializations(
             .to_string());
     }
 
-    // TODO(CON-1332): Do not panic if fields are missing
     for ecdsa_init in ecdsa_initializations {
         let ecdsa_key_id = ecdsa_init
             .key_id
             .clone()
-            .expect("Error: Failed to find key_id in ecdsa_initializations")
+            .ok_or("Failed to find key_id in ecdsa_initializations")?
             .try_into()
-            .map_err(|err| {
-                format!(
-                    "Error reading ECDSA key_id: {:?}. Setting idkg_summary to None.",
-                    err
-                )
-            })?;
+            .map_err(|err| format!("Error reading ECDSA key_id: {:?}", err))?;
 
         let dealings = ecdsa_init
             .dealings
             .as_ref()
-            .expect("Error: Failed to find dealings in ecdsa_initializations")
+            .ok_or("Failed to find dealings in ecdsa_initializations")?
             .try_into()
-            .map_err(|err| {
-                format!(
-                    "Error reading ECDSA dealings: {:?}. Setting idkg_summary to None.",
-                    err
-                )
-            })?;
+            .map_err(|err| format!("Error reading ECDSA dealings: {:?}", err))?;
 
         initial_dealings_per_key_id.insert(
             MasterPublicKeyId::Ecdsa(ecdsa_key_id).try_into().unwrap(),
@@ -401,19 +390,13 @@ pub(crate) fn inspect_idkg_chain_key_initializations(
         );
     }
 
-    // TODO(CON-1332): Do not panic if fields are missing
     for chain_key_init in chain_key_initializations {
         let key_id: MasterPublicKeyId = chain_key_init
             .key_id
             .clone()
-            .expect("Error: Failed to find key_id in chain_key_initializations")
+            .ok_or("Failed to find key_id in chain_key_initializations")?
             .try_into()
-            .map_err(|err| {
-                format!(
-                    "Error reading Master public key_id: {:?}. Setting idkg_summary to None.",
-                    err
-                )
-            })?;
+            .map_err(|err| format!("Error reading Master public key_id: {:?}", err))?;
 
         // Skip non-idkg keys
         let key_id = match key_id.try_into() {
@@ -423,20 +406,16 @@ pub(crate) fn inspect_idkg_chain_key_initializations(
 
         let dealings = match &chain_key_init.initialization {
             Some(pb::chain_key_initialization::Initialization::Dealings(dealings)) => dealings,
-            Some(pb::chain_key_initialization::Initialization::TranscriptRecord(_)) => continue,
-            None => {
+            Some(pb::chain_key_initialization::Initialization::TranscriptRecord(_)) | None => {
                 return Err(
                     "Error: Failed to find dealings in chain_key_initializations".to_string(),
                 )
             }
         };
 
-        let dealings = dealings.try_into().map_err(|err| {
-            format!(
-                "Error reading initial IDkg dealings: {:?}. Setting idkg_summary to None.",
-                err
-            )
-        })?;
+        let dealings = dealings
+            .try_into()
+            .map_err(|err| format!("Error reading initial IDkg dealings: {:?}", err))?;
 
         initial_dealings_per_key_id.insert(key_id, dealings);
     }


### PR DESCRIPTION
This PR changes changes how to handle protobuf conversion errors in `inspect_idkg_chain_key_initializations`.

Initially, we would return an error on some occasions, while on others, we would panic via `expect`.
We would also simply ignore the `ChainKeyInitialization`, if there was a `Transcript` variant.

Now, we will always return an Error, if something unexpected happens.