### PR TITLE
fix(node): HSM onboarding

### DIFF
--- a/ic-os/components/guestos.bzl
+++ b/ic-os/components/guestos.bzl
@@ -60,6 +60,7 @@ component_files = {
     Label("misc/guestos/sysctl.d/dfn-max-map-count.conf"): "/etc/sysctl.d/dfn-max-map-count.conf",
     Label("misc/guestos/sysctl.d/privileged-ports.conf"): "/etc/sysctl.d/privileged-ports.conf",
     Label("misc/guestos/sysfs.d/hugepage.conf"): "/etc/sysfs.d/hugepage.conf",
+    Label("misc/hsm/pcscd"): "/etc/default/pcscd",
 
     # monitoring
     Label("monitoring/filebeat/setup-filebeat-permissions.sh"): "/opt/ic/bin/setup-filebeat-permissions.sh",

--- a/ic-os/components/guestos.bzl
+++ b/ic-os/components/guestos.bzl
@@ -60,7 +60,7 @@ component_files = {
     Label("misc/guestos/sysctl.d/dfn-max-map-count.conf"): "/etc/sysctl.d/dfn-max-map-count.conf",
     Label("misc/guestos/sysctl.d/privileged-ports.conf"): "/etc/sysctl.d/privileged-ports.conf",
     Label("misc/guestos/sysfs.d/hugepage.conf"): "/etc/sysfs.d/hugepage.conf",
-    Label("misc/hsm/pcscd"): "/etc/default/pcscd",
+    Label("misc/guestos/hsm/pcscd"): "/etc/default/pcscd",
 
     # monitoring
     Label("monitoring/filebeat/setup-filebeat-permissions.sh"): "/opt/ic/bin/setup-filebeat-permissions.sh",

--- a/ic-os/components/misc/guestos/hsm/pcscd
+++ b/ic-os/components/misc/guestos/hsm/pcscd
@@ -1,0 +1,1 @@
+PCSCD_ARGS=--disable-polkit

--- a/ic-os/components/misc/hsm/pcscd
+++ b/ic-os/components/misc/hsm/pcscd
@@ -1,0 +1,1 @@
+PCSCD_ARGS=--disable-polkit

--- a/ic-os/components/misc/hsm/pcscd
+++ b/ic-os/components/misc/hsm/pcscd
@@ -1,1 +1,0 @@
-PCSCD_ARGS=--disable-polkit

--- a/ic-os/components/selinux/misc-fixes/misc-fixes.te
+++ b/ic-os/components/selinux/misc-fixes/misc-fixes.te
@@ -90,3 +90,8 @@ manage_files_pattern(ssh_keygen_t, initrc_tmp_t, initrc_tmp_t)
 # allow reading from /dev/urandom
 require { type iptables_t; }
 dev_read_urand(iptables_t)
+
+###############################################################################
+# pcscd_t policy breaks HSM deployments, setting persmissive for now
+require { type pcscd_t; }
+permissive pcscd_t;


### PR DESCRIPTION
NODE-1526

After the Ubuntu 20.04 --> 24.04 upgrade, we started getting pcscd errors that broke HSM onboardings:
![Pasted Graphic 3](https://github.com/user-attachments/assets/7cb69148-e816-442d-acab-5770d4eaaef5)

We learned that the upgraded pcscd switched from using D-bus to polkit. We tried [adding the necessary rules to polkit to fix the permission issue](https://support.nitrokey.com/t/unpriviledged-service-account/6369), but were unable to resolve it.

As a quick fix, by disabling polkit, HSM onboardings are fixed.


With fix, successfully deployed node to production using HSM!
