### PR TITLE
docs(governance): More streamlined procedure for generating and submitting proposals.

### DIFF
--- a/testnet/tools/nns-tools/README.md
+++ b/testnet/tools/nns-tools/README.md
@@ -492,15 +492,9 @@ You can look up your neuron ID [here in Notion][neuron-id]. For example, Daniel 
 
 [neuron-id]: https://www.notion.so/dfinityorg/3a1856c603704d51a6fcd2a57c98f92f?v=fc597afede904e499744f3528cad6682
 
-For example:
 
-```bash
-./testnet/tools/nns-tools/submit-mainnet-nns-upgrade-proposal.sh \
-    /tmp/registry-upgrade-proposal-2023-09-29.md \
-    51
-```
-
-The script validates your proposal text. Specifically, it enforces the following requirements:
+The submission scripts validate your proposal texts. Specifically, it enforces
+the following requirements:
 
 1. There are no TODO items left in the proposal text.
 

--- a/testnet/tools/nns-tools/README.md
+++ b/testnet/tools/nns-tools/README.md
@@ -467,7 +467,9 @@ Finally, run
 ```bash
 # In addition to the following, we assume that you still have the environment
 # variables from the previous section...
-SUBMITTING_NEURON_ID=51 # e.g. for Daniel Wong, 51
+
+# e.g. for Daniel Wong, 51
+SUBMITTING_NEURON_ID=51
 
 # NNS:
 for CANISTER in "${NNS_CANISTERS[@]}"

--- a/testnet/tools/nns-tools/README.md
+++ b/testnet/tools/nns-tools/README.md
@@ -410,17 +410,19 @@ Generate a mostly pre-populated proposal text file:
 ```bash
 # Fill these in.
 RC=FAKE
-# Space separated names. E.g. governance sns-wasm
-NNS_CANISTERS=
+# In case you aren't familiar, this is bash array.
+NNS_CANISTERS=(
+)
 # Similar to NNS_CANISTERS
-SNS_CANISTERS=
+SNS_CANISTERS=(
+)
 # Path to an empty dir where the proposal files will be saved.
 PROPOSALS_DIR=/tmp/release-$(date --iso)
 
 mkdir $PROPOSALS_DIR
 
 # NNS:
-for CANISTER in $NNS_CANISTERS
+for CANISTER in "${NNS_CANISTERS[@]}"
 do
     ./testnet/tools/nns-tools/prepare-nns-upgrade-proposal-text.sh \
         $CANISTER \
@@ -429,7 +431,7 @@ do
 done
 
 # SNS:
-for CANISTER in $SNS_CANISTERS
+for CANISTER in "${SNS_CANISTERS[@]}"
 do
     ./testnet/tools/nns-tools/prepare-publish-sns-wasm-proposal-text.sh \
         $CANISTER \
@@ -468,14 +470,14 @@ Finally, run
 SUBMITTING_NEURON_ID=51 # e.g. for Daniel Wong, 51
 
 # NNS:
-for CANISTER in $NNS_CANISTERS
+for CANISTER in "${NNS_CANISTERS[@]}"
 do
     ./testnet/tools/nns-tools/submit-mainnet-nns-upgrade-proposal.sh \
         $PROPOSALS_DIR/nns-$CANISTER.md \
         $SUBMITTING_NEURON_ID
 
 # SNS:
-for CANISTER in $SNS_CANISTERS
+for CANISTER in "${SNS_CANISTERS[@]}"
 do
     ./testnet/tools/nns-tools/submit-mainnet-publish-sns-wasm-proposal.sh \
         $PROPOSALS_DIR/sns-$CANISTER.md \

--- a/testnet/tools/nns-tools/README.md
+++ b/testnet/tools/nns-tools/README.md
@@ -475,6 +475,7 @@ do
     ./testnet/tools/nns-tools/submit-mainnet-nns-upgrade-proposal.sh \
         $PROPOSALS_DIR/nns-$CANISTER.md \
         $SUBMITTING_NEURON_ID
+done
 
 # SNS:
 for CANISTER in "${SNS_CANISTERS[@]}"


### PR DESCRIPTION
In particular, the instructions are now more amenable to copy n' paste. At the top of each chunk of commands, there are some variables that the user (i.e. release tsar) fills in. Then, the rest of the commands in the chunk can be run **_without modification._**

# Future Work

Now that no manual work is needed to generate a complete proposal summary file, we could merge the steps where proposal texts are created vs. when they are submitted. Both could be done from a single script. All it would have to know is

1. What is the release candidate commit ID.
2. Which canisters.
3. The ID of the neuron that will submit the proposals.

This could further be merged with list-new-commits, but we would only want to do that if we trust list-new-commits to decide which canisters to release.

At this point, I would say that the most tedious part of the process is copying the proposal texts and URLs to various places. In particular,

1. The forum.
2. The #eng-nns-releases Slack channel.
3. The Calendar event.

I suspect 2 is the easiest to automate. It would just be an "extra" thing that the submission script does after a successful submission.