### PR TITLE
chore(node): add HostOS console message clarifying onboarding success

### DIFF
--- a/rs/orchestrator/src/orchestrator.rs
+++ b/rs/orchestrator/src/orchestrator.rs
@@ -123,6 +123,8 @@ impl Orchestrator {
             1,
         );
 
+        UtilityCommand::notify_host("Please wait for a 'Join request successful!' message confirming a successful onboarding.", 3);
+
         let version = replica_version.clone();
         thread::spawn(move || loop {
             // Sleep early because IPv4 takes several minutes to configure


### PR DESCRIPTION
Node providers have mistaken the initial logging-nodeID-and-version message as a 'successful onboarding' message. It is not. This log helps better clarify that confusion.

![image](https://github.com/user-attachments/assets/28026028-dac0-4892-bfc0-89d501ed022a)
