### PR TITLE
feat: Restrict legacy ICQC code to one subnet

### DIFF
--- a/rs/execution_environment/src/lib.rs
+++ b/rs/execution_environment/src/lib.rs
@@ -147,6 +147,7 @@ impl ExecutionServices {
         let sync_query_handler = Arc::new(InternalHttpQueryHandler::new(
             logger.clone(),
             hypervisor,
+            own_subnet_id,
             own_subnet_type,
             config.clone(),
             metrics_registry,

--- a/rs/execution_environment/src/query_handler.rs
+++ b/rs/execution_environment/src/query_handler.rs
@@ -33,7 +33,7 @@ use ic_types::QueryStatsEpoch;
 use ic_types::{
     ingress::WasmResult,
     messages::{Blob, Certificate, CertificateDelegation, Query},
-    CanisterId, NumInstructions, PrincipalId,
+    CanisterId, NumInstructions, PrincipalId, SubnetId,
 };
 use prometheus::Histogram;
 use serde::Serialize;
@@ -53,6 +53,9 @@ pub(crate) use self::query_scheduler::{QueryScheduler, QuerySchedulerFlag};
 use ic_management_canister_types::{
     FetchCanisterLogsRequest, FetchCanisterLogsResponse, LogVisibilityV2, Payload, QueryMethod,
 };
+
+const DISTRIKT_SUBNET_PRINCIPAL: &str =
+    "shefu-t3kr5-t5q3w-mqmdq-jabyv-vyvtf-cyyey-3kmo4-toyln-emubw-4qe";
 
 /// Convert an object into CBOR binary.
 fn into_cbor<R: Serialize>(r: &R) -> Vec<u8> {
@@ -100,6 +103,7 @@ fn label<T: Into<Label>>(t: T) -> Label {
 pub struct InternalHttpQueryHandler {
     log: ReplicaLogger,
     hypervisor: Arc<Hypervisor>,
+    own_subnet_id: SubnetId,
     own_subnet_type: SubnetType,
     config: Config,
     metrics: QueryHandlerMetrics,
@@ -139,6 +143,7 @@ impl InternalHttpQueryHandler {
     pub fn new(
         log: ReplicaLogger,
         hypervisor: Arc<Hypervisor>,
+        own_subnet_id: SubnetId,
         own_subnet_type: SubnetType,
         config: Config,
         metrics_registry: &MetricsRegistry,
@@ -152,6 +157,7 @@ impl InternalHttpQueryHandler {
         Self {
             log,
             hypervisor,
+            own_subnet_id,
             own_subnet_type,
             config,
             metrics: QueryHandlerMetrics::new(metrics_registry),
@@ -257,6 +263,7 @@ impl InternalHttpQueryHandler {
         let mut context = query_context::QueryContext::new(
             &self.log,
             self.hypervisor.as_ref(),
+            self.own_subnet_id,
             self.own_subnet_type,
             // For composite queries, the set of evaluated canisters is not known in advance,
             // so the whole state is needed to capture later the state of the call graph.

--- a/rs/execution_environment/src/query_handler/tests.rs
+++ b/rs/execution_environment/src/query_handler/tests.rs
@@ -1,17 +1,16 @@
-use crate::InternalHttpQueryHandler;
+use crate::{query_handler::DISTRIKT_SUBNET_PRINCIPAL, InternalHttpQueryHandler};
 use ic_base_types::{CanisterId, NumSeconds};
 use ic_config::execution_environment::INSTRUCTION_OVERHEAD_PER_QUERY_CALL;
 use ic_error_types::{ErrorCode, UserError};
-use ic_registry_subnet_type::SubnetType;
 use ic_test_utilities::universal_canister::{call_args, wasm};
 use ic_test_utilities_execution_environment::{ExecutionTest, ExecutionTestBuilder};
 use ic_test_utilities_types::ids::user_test_id;
 use ic_types::{
     ingress::WasmResult,
     messages::{Query, QuerySource},
-    Cycles, NumInstructions,
+    Cycles, NumInstructions, PrincipalId,
 };
-use std::sync::Arc;
+use std::{str::FromStr, sync::Arc};
 
 const CYCLES_BALANCE: Cycles = Cycles::new(100_000_000_000_000);
 
@@ -42,7 +41,7 @@ fn query_metrics_are_reported() {
     // Canister A handles the user query by calling canister B.
 
     let mut test = ExecutionTestBuilder::new()
-        .with_subnet_type(SubnetType::VerifiedApplication)
+        .with_subnet_id(PrincipalId::from_str(DISTRIKT_SUBNET_PRINCIPAL).unwrap())
         .build();
 
     let canister_a = test.universal_canister_with_cycles(CYCLES_BALANCE).unwrap();
@@ -193,13 +192,14 @@ fn query_metrics_are_reported() {
 }
 
 #[test]
-fn query_call_with_side_effects() {
+fn legacy_query_call_with_side_effects() {
     // In this test we have two canisters A and B.
     // Canister A does a side-effectful operation (stable_grow) and then
     // calls canister B. The side effect must happen once and only once.
 
     let mut test = ExecutionTestBuilder::new()
-        .with_subnet_type(SubnetType::System)
+        // Legacy ICQC only enabled on Distrikt's subnet.
+        .with_subnet_id(PrincipalId::from_str(DISTRIKT_SUBNET_PRINCIPAL).unwrap())
         .build();
 
     let canister_a = test.universal_canister_with_cycles(CYCLES_BALANCE).unwrap();
@@ -270,9 +270,10 @@ fn query_calls_disabled_for_application_subnet() {
 }
 
 #[test]
-fn query_callgraph_depth_is_enforced() {
+fn legacy_query_callgraph_depth_is_enforced() {
     let mut test = ExecutionTestBuilder::new()
-        .with_subnet_type(SubnetType::System) // For now, query calls are only allowed in system subnets
+        // Legacy ICQC only enabled on Distrikt's subnet.
+        .with_subnet_id(PrincipalId::from_str(DISTRIKT_SUBNET_PRINCIPAL).unwrap())
         .build();
 
     const NUM_CANISTERS: usize = 20;
@@ -354,12 +355,13 @@ fn query_callgraph_depth_is_enforced() {
 }
 
 #[test]
-fn query_callgraph_max_instructions_is_enforced() {
+fn legacy_query_callgraph_max_instructions_is_enforced() {
     const NUM_CANISTERS: u64 = 20;
     const NUM_SUCCESSFUL_QUERIES: u64 = 5; // Number of calls expected to succeed
 
     let mut test = ExecutionTestBuilder::new()
-        .with_subnet_type(SubnetType::System) // For now, query calls are only allowed in system subnets
+        // Legacy ICQC only enabled on Distrikt's subnet.
+        .with_subnet_id(PrincipalId::from_str(DISTRIKT_SUBNET_PRINCIPAL).unwrap())
         .with_max_query_call_graph_instructions(NumInstructions::from(
             NUM_SUCCESSFUL_QUERIES * INSTRUCTION_OVERHEAD_PER_QUERY_CALL,
         ))
@@ -1473,9 +1475,7 @@ fn test_incorrect_query_name() {
 
 #[test]
 fn test_call_context_performance_counter_correctly_reported_on_query() {
-    let mut test = ExecutionTestBuilder::new()
-        .with_subnet_type(SubnetType::System)
-        .build();
+    let mut test = ExecutionTestBuilder::new().with_composite_queries().build();
     let a_id = test.universal_canister().unwrap();
     let b_id = test.universal_canister().unwrap();
 
@@ -1510,7 +1510,9 @@ fn test_call_context_performance_counter_correctly_reported_on_query() {
         .int64_to_blob()
         .append_to_global_data()
         .build();
-    let result = test.non_replicated_query(a_id, "query", a).unwrap();
+    let result = test
+        .non_replicated_query(a_id, "composite_query", a)
+        .unwrap();
 
     let counters = result
         .bytes()

--- a/rs/test_utilities/execution_environment/src/lib.rs
+++ b/rs/test_utilities/execution_environment/src/lib.rs
@@ -1821,6 +1821,13 @@ impl ExecutionTestBuilder {
         }
     }
 
+    pub fn with_subnet_id(self, principal_id: PrincipalId) -> Self {
+        Self {
+            own_subnet_id: SubnetId::new(principal_id),
+            ..self
+        }
+    }
+
     pub fn with_max_query_call_graph_instructions(
         mut self,
         max_query_call_graph_instructions: NumInstructions,
@@ -2327,6 +2334,7 @@ impl ExecutionTestBuilder {
         let query_handler = InternalHttpQueryHandler::new(
             self.log.clone(),
             hypervisor,
+            self.own_subnet_id,
             self.subnet_type,
             config.clone(),
             &metrics_registry,

--- a/rs/tests/execution/inter_canister_queries_tests/call_on_cleanup.rs
+++ b/rs/tests/execution/inter_canister_queries_tests/call_on_cleanup.rs
@@ -234,10 +234,10 @@ pub fn is_called_in_query(env: TestEnv) {
 
             assert_eq!(
                 canister_a
-                    .query(
+                    .composite_query(
                         wasm()
-                            .inter_query(canister_b.canister_id(), query_call_args.clone(),)
-                            .inter_query(canister_b.canister_id(), query_call_args,),
+                            .composite_query(canister_b.canister_id(), query_call_args.clone(),)
+                            .composite_query(canister_b.canister_id(), query_call_args,),
                     )
                     .await
                     .unwrap(),


### PR DESCRIPTION
The legacy code for ICQC (inter-canister query calls), aka predecessor of composite queries, is still enabled in system and verified application subnets. There's only one actual user of this legacy feature and it's Distrikt. The new team that took over is going to migrate off of this legacy feature but some extra time is required. When this is done we can completely remove this legacy feature.

On the IC side, given the recent load issues we experienced on mainnet, we would like to open up some of the (currently) unused verified application subnets. However, we wouldn't want to open the door to this legacy feature (only composite queries should be used). To satisfy all requirements, the proposed change in this PR is to restrict the legacy feature only on Distrikt's subnet until the team can complete the migration.