### PR TITLE
test(sns): Port old proposal integration tests to state machines

### DIFF
--- a/rs/sns/integration_tests/src/proposals.rs
+++ b/rs/sns/integration_tests/src/proposals.rs
@@ -23,9 +23,10 @@ use ic_sns_governance::{
     },
     reward,
 };
-use ic_sns_test_utils::itest_helpers::state_machine_test_on_sns_subnet;
 use ic_sns_test_utils::{
-    itest_helpers::{local_test_on_sns_subnet, SnsCanisters, SnsTestsInitPayloadBuilder, UserInfo},
+    itest_helpers::{
+        state_machine_test_on_sns_subnet, SnsCanisters, SnsTestsInitPayloadBuilder, UserInfo,
+    },
     now_seconds,
 };
 use icrc_ledger_types::icrc1::account::Account;
@@ -47,7 +48,7 @@ const VOTING_REWARDS_PARAMETERS: VotingRewardsParameters = VotingRewardsParamete
 /// Assert that Motion proposals can be submitted, voted on, and executed
 #[test]
 fn test_motion_proposal_execution() {
-    local_test_on_sns_subnet(|runtime| {
+    state_machine_test_on_sns_subnet(|runtime| {
         async move {
             // Initialize the ledger with an account for a user.
             let user = Sender::from_keypair(&TEST_USER1_KEYPAIR);
@@ -133,7 +134,7 @@ fn test_motion_proposal_execution() {
 /// Assert that ManageNervousSystemParameters proposals can be submitted, voted on, and executed
 #[test]
 fn test_manage_nervous_system_parameters_proposal_execution() {
-    local_test_on_sns_subnet(|runtime| {
+    state_machine_test_on_sns_subnet(|runtime| {
         async move {
             // Initialize the ledger with an account for a user.
             let user = Sender::from_keypair(&TEST_USER1_KEYPAIR);
@@ -230,7 +231,7 @@ fn test_voting_with_three_neurons_with_the_same_stake() {
             .as_secs_f64()
     }
 
-    local_test_on_sns_subnet(|runtime| {
+    state_machine_test_on_sns_subnet(|runtime| {
         async move {
             // Initialize the ledger with three users (each will create its own neuron).
             let user_1 = Sender::from_keypair(&TEST_USER1_KEYPAIR);
@@ -390,7 +391,7 @@ fn test_voting_with_three_neurons_with_the_same_stake() {
 
 #[test]
 fn test_bad_proposal_id_candid_type() {
-    local_test_on_sns_subnet(|runtime| {
+    state_machine_test_on_sns_subnet(|runtime| {
         async move {
             // Initialize the ledger with an account for a user.
             let user = Sender::from_keypair(&TEST_USER1_KEYPAIR);
@@ -420,7 +421,7 @@ fn test_bad_proposal_id_candid_type() {
 
 #[test]
 fn test_bad_proposal_id_candid_encoding() {
-    local_test_on_sns_subnet(|runtime| {
+    state_machine_test_on_sns_subnet(|runtime| {
         async move {
             // Initialize the ledger with an account for a user.
             let user = Sender::from_keypair(&TEST_USER1_KEYPAIR);
@@ -453,7 +454,7 @@ fn test_bad_proposal_id_candid_encoding() {
 
 #[test]
 fn test_non_existent_proposal_id_is_not_a_bad_input() {
-    local_test_on_sns_subnet(|runtime| {
+    state_machine_test_on_sns_subnet(|runtime| {
         async move {
             // Initialize the ledger with an account for a user.
             let user = Sender::from_keypair(&TEST_USER1_KEYPAIR);
@@ -488,7 +489,7 @@ fn test_non_existent_proposal_id_is_not_a_bad_input() {
 
 #[test]
 fn test_list_proposals_determinism() {
-    local_test_on_sns_subnet(|runtime| async move {
+    state_machine_test_on_sns_subnet(|runtime| async move {
         // Initialize the ledger with an account for a user.
         let user = Sender::from_keypair(&TEST_USER1_KEYPAIR);
         let alloc = Tokens::from_tokens(1000).unwrap();
@@ -601,7 +602,7 @@ async fn list_all_proposals_through_pagination(
 
 #[test]
 fn test_proposal_format_validation() {
-    local_test_on_sns_subnet(|runtime| async move {
+    state_machine_test_on_sns_subnet(|runtime| async move {
         // Initialize the ledger with an account for a user.
         let user = UserInfo::new(Sender::from_keypair(&TEST_USER1_KEYPAIR));
 
@@ -702,7 +703,7 @@ fn test_proposal_format_validation() {
 
 #[test]
 fn test_neuron_configuration_needed_for_proposals() {
-    local_test_on_sns_subnet(|runtime| async move {
+    state_machine_test_on_sns_subnet(|runtime| async move {
         // Initialize the ledger with an account for a user.
         let user = UserInfo::new(Sender::from_keypair(&TEST_USER1_KEYPAIR));
         let alloc = Tokens::from_tokens(1000).unwrap();
@@ -822,7 +823,7 @@ fn test_neuron_configuration_needed_for_proposals() {
 
 #[test]
 fn test_ballots_set_for_multiple_neurons() {
-    local_test_on_sns_subnet(|runtime| async move {
+    state_machine_test_on_sns_subnet(|runtime| async move {
         let alloc = Tokens::from_tokens(1000).unwrap();
 
         let params = NervousSystemParameters {
@@ -911,7 +912,7 @@ fn test_ballots_set_for_multiple_neurons() {
 
 #[test]
 fn test_vote_on_non_existent_proposal() {
-    local_test_on_sns_subnet(|runtime| async move {
+    state_machine_test_on_sns_subnet(|runtime| async move {
         // Initialize the ledger with an account for a user.
         let user = UserInfo::new(Sender::from_keypair(&TEST_USER1_KEYPAIR));
         let alloc = Tokens::from_tokens(1000).unwrap();
@@ -958,7 +959,7 @@ fn test_vote_on_non_existent_proposal() {
 
 #[test]
 fn test_ineligible_neuron_voting_fails() {
-    local_test_on_sns_subnet(|runtime| async move {
+    state_machine_test_on_sns_subnet(|runtime| async move {
         // Initialize the ledger with an account for a user who will propose and a user who will vote
         let proposer = UserInfo::new(Sender::from_keypair(&TEST_USER1_KEYPAIR));
         let voter = UserInfo::new(Sender::from_keypair(&TEST_USER2_KEYPAIR));
@@ -1014,7 +1015,7 @@ fn test_ineligible_neuron_voting_fails() {
 
 #[test]
 fn test_repeated_voting_fails() {
-    local_test_on_sns_subnet(|runtime| async move {
+    state_machine_test_on_sns_subnet(|runtime| async move {
         let yes_voter = UserInfo::new(Sender::from_keypair(&TEST_USER1_KEYPAIR));
         let no_voter = UserInfo::new(Sender::from_keypair(&TEST_USER2_KEYPAIR));
 
@@ -1114,7 +1115,7 @@ fn test_repeated_voting_fails() {
 //          D
 #[test]
 fn test_following_and_voting() {
-    local_test_on_sns_subnet(|runtime| async move {
+    state_machine_test_on_sns_subnet(|runtime| async move {
         let a = UserInfo::new(Sender::from_keypair(&TEST_USER1_KEYPAIR));
         let b = UserInfo::new(Sender::from_keypair(&TEST_USER2_KEYPAIR));
         let c = UserInfo::new(Sender::from_keypair(&TEST_USER3_KEYPAIR));
@@ -1242,7 +1243,7 @@ fn test_following_and_voting() {
 //   B <- C
 #[test]
 fn test_following_and_voting_from_non_proposer() {
-    local_test_on_sns_subnet(|runtime| async move {
+    state_machine_test_on_sns_subnet(|runtime| async move {
         let a = UserInfo::new(Sender::from_keypair(&TEST_USER1_KEYPAIR));
         let b = UserInfo::new(Sender::from_keypair(&TEST_USER2_KEYPAIR));
         let c = UserInfo::new(Sender::from_keypair(&TEST_USER3_KEYPAIR));
@@ -1333,7 +1334,7 @@ fn test_following_and_voting_from_non_proposer() {
 //   C
 #[test]
 fn test_following_multiple_neurons_reach_majority() {
-    local_test_on_sns_subnet(|runtime| async move {
+    state_machine_test_on_sns_subnet(|runtime| async move {
         let a = UserInfo::new(Sender::from_keypair(&TEST_USER1_KEYPAIR));
         let b = UserInfo::new(Sender::from_keypair(&TEST_USER2_KEYPAIR));
         let c = UserInfo::new(Sender::from_keypair(&TEST_USER3_KEYPAIR));
@@ -1444,7 +1445,7 @@ fn test_following_multiple_neurons_reach_majority() {
 
 #[test]
 fn test_proposal_rejection() {
-    local_test_on_sns_subnet(|runtime| async move {
+    state_machine_test_on_sns_subnet(|runtime| async move {
         // Initialize the ledger with an account for a user who will propose and a user who will vote
         let proposer = UserInfo::new(Sender::from_keypair(&TEST_USER1_KEYPAIR));
         let voter = UserInfo::new(Sender::from_keypair(&TEST_USER2_KEYPAIR));
@@ -1564,7 +1565,7 @@ fn assert_voting_error(
 
 #[test]
 fn test_proposal_garbage_collection() {
-    local_test_on_sns_subnet(|runtime| async move {
+    state_machine_test_on_sns_subnet(|runtime| async move {
         // Initialize the ledger with an account for a user who will make proposals
         let user = UserInfo::new(Sender::from_keypair(&TEST_USER1_KEYPAIR));
         let alloc = Tokens::from_tokens(1000).unwrap();
@@ -1667,7 +1668,7 @@ fn test_proposal_garbage_collection() {
 
 #[test]
 fn test_change_voting_rewards_round_duration() {
-    local_test_on_sns_subnet(|runtime| async move {
+    state_machine_test_on_sns_subnet(|runtime| async move {
         // Initialize the ledger with an account for a user who will make proposals
         let proposer = UserInfo::new(Sender::from_keypair(&TEST_USER1_KEYPAIR));
         // Initialize the ledger with an account for a user who will vote so we can control when

--- a/rs/sns/integration_tests/src/upgrade_canister.rs
+++ b/rs/sns/integration_tests/src/upgrade_canister.rs
@@ -25,8 +25,8 @@ use ic_sns_governance::pb::v1::{
 use ic_sns_test_utils::{
     itest_helpers::{
         install_governance_canister, install_ledger_canister, install_root_canister,
-        install_swap_canister, local_test_on_sns_subnet, state_machine_test_on_sns_subnet,
-        SnsCanisters, SnsTestsInitPayloadBuilder, UserInfo,
+        install_swap_canister, state_machine_test_on_sns_subnet, SnsCanisters,
+        SnsTestsInitPayloadBuilder, UserInfo,
     },
     state_test_helpers::{
         setup_sns_canisters, sns_root_register_dapp_canisters, state_machine_builder_for_sns_tests,
@@ -180,7 +180,7 @@ fn test_upgrade_canister_proposal_is_successful() {
 
 #[test]
 fn test_upgrade_canister_proposal_reinstall() {
-    local_test_on_sns_subnet(|runtime| async move {
+    state_machine_test_on_sns_subnet(|runtime| async move {
         // Step 1: Prepare
 
         // Step 1.a: Boot up SNS with one user.
@@ -327,7 +327,7 @@ fn test_upgrade_canister_proposal_reinstall() {
 
 #[test]
 fn test_upgrade_canister_proposal_execution_fail() {
-    local_test_on_sns_subnet(|runtime| async move {
+    state_machine_test_on_sns_subnet(|runtime| async move {
         // Step 1: Prepare
 
         // Step 1.a: Boot up SNS with one user.
@@ -587,7 +587,7 @@ fn governance_mem_test() {
 /// in a trap in post_upgrade.
 #[test]
 fn test_upgrade_after_state_shrink() {
-    local_test_on_sns_subnet(|runtime| async move {
+    state_machine_test_on_sns_subnet(|runtime| async move {
         // Initialize a User with a unique principal to claim a neuron
         let neuron_claimer = UserInfo::new(Sender::from_keypair(&TEST_USER1_KEYPAIR));
         // Initialize an extra user who's unique principal will be used to shrink the state
@@ -690,7 +690,7 @@ fn test_upgrade_after_state_shrink() {
 /// Test that SNS canisters can be installed in any order.
 #[test]
 fn test_install_canisters_in_any_order() {
-    local_test_on_sns_subnet(|runtime| async move {
+    state_machine_test_on_sns_subnet(|runtime| async move {
         let mut sns_init_payload = SnsTestsInitPayloadBuilder::new()
             .with_nervous_system_parameters(NervousSystemParameters::with_default_values())
             .build();

--- a/rs/sns/test_utils/src/itest_helpers.rs
+++ b/rs/sns/test_utils/src/itest_helpers.rs
@@ -1197,7 +1197,8 @@ impl SnsCanisters<'_> {
                 return proposal;
             }
 
-            tokio::time::sleep(Duration::from_millis(100)).await;
+            self.governance.runtime().tick().await;
+
             proposal = self.get_proposal(*proposal_id).await;
         }
 


### PR DESCRIPTION
This PR ports the old proposal integration tests to state machines' framework that is expected to be less flaky than `local_test` framework.

< [Previous PR](https://github.com/dfinity/ic/pull/2660) |