### PR TITLE
fix: avoid panics in PocketIC HTTP gateway flows

### DIFF
--- a/packages/pocket-ic/tests/tests.rs
+++ b/packages/pocket-ic/tests/tests.rs
@@ -1944,3 +1944,18 @@ fn get_subnet() {
     let nns_subnet_config = topology.subnet_configs.get(&nns_subnet).unwrap();
     assert_eq!(nns_subnet_config.subnet_kind, SubnetKind::NNS);
 }
+
+#[test]
+fn make_live_twice() {
+    // create PocketIC instance
+    let mut pic = PocketIcBuilder::new()
+        .with_nns_subnet()
+        .with_application_subnet()
+        .build();
+
+    // create HTTP gateway
+    let url = pic.make_live(None);
+
+    let same_url = pic.make_live(None);
+    assert_eq!(same_url, url);
+}

--- a/rs/pocket_ic_server/src/state_api/state.rs
+++ b/rs/pocket_ic_server/src/state_api/state.rs
@@ -911,7 +911,7 @@ impl ApiState {
         let port = http_gateway_config.port.unwrap_or_default();
         let addr = format!("{}:{}", ip_addr, port);
         let listener = std::net::TcpListener::bind(&addr)
-            .unwrap_or_else(|_| panic!("Failed to start HTTP gateway on port {}", port));
+            .map_err(|e| format!("Failed to bind to address {}: {}", addr, e))?;
         let real_port = listener.local_addr().unwrap().port();
 
         let pocket_ic_server_port = self.port.unwrap();


### PR DESCRIPTION
This PR fixes two sources of panics in PocketIC HTTP gateway flows:
- calling `PocketIc::make_live` twice in a row should not panic, but return the same URL of the gateway;
- making a POST request to the `/http_gateway` endpoint on the server specifying a port that is already in use should not crash the server.