### PR TITLE
fix: Correctly observe block maker to induction latency

### DIFF
--- a/rs/execution_environment/src/scheduler/scheduler_metrics.rs
+++ b/rs/execution_environment/src/scheduler/scheduler_metrics.rs
@@ -201,7 +201,7 @@ impl SchedulerMetrics {
             ),
             canister_ingress_queue_latencies: metrics_registry.histogram(
                 "scheduler_canister_ingress_queue_latencies_seconds",
-                "Per-canister mean time spent by messages in the ingress queue.",
+                "Per-canister mean IC clock duration spent by messages in the ingress queue.",
                 // 10ms, 20ms, 50ms, …, 100s, 200s, 500s
                 decimal_buckets(-2, 2),
             ),


### PR DESCRIPTION
I fell into the trap of trying too hard to factor out common functionality: unfortunately, when a new ingress message is inducted, we don't yet have a `received_time` entry for it (we only add one a few lines below). Use the current block time directly instead.

Also update the metric descriptions, to clearly state exactly what is being measured (including, as I just found out, the first message execution, in the "time to Processing" metrics(.