### PR TITLE
fix: Try to address spurious `unresolved import` errors

### DIFF
--- a/rs/nns/governance/Cargo.toml
+++ b/rs/nns/governance/Cargo.toml
@@ -113,6 +113,7 @@ criterion = { workspace = true }
 cycles-minting-canister = { path = "../cmc" }
 ic-config = { path = "../../config" }
 ic-nervous-system-common-test-utils = { path = "../../nervous_system/common/test_utils" }
+ic-nns-governance = { path = ".", features = ["test"] }
 ic-nns-governance-protobuf-generator = { path = "./protobuf_generator" }
 ic-test-utilities-compare-dirs = { path = "../../test_utilities/compare_dirs" }
 local_key = { path = "../../tla_instrumentation/local_key" }


### PR DESCRIPTION
`cargo check` randomly complains of the `ic_nns_governance::storage::reset_stable_memory` import being gated out. Try having `ic-nns-governance` tests explicitly depend on the crate with the `test` feature enabled.