### PR TITLE
chore(IDX): Don't specify sha256 twice

### DIFF
--- a/rs/tests/driver/src/driver/test_env_api.rs
+++ b/rs/tests/driver/src/driver/test_env_api.rs
@@ -1138,15 +1138,25 @@ pub fn get_elasticsearch_hosts() -> Result<Vec<String>> {
     parse_elasticsearch_hosts(Some(hosts))
 }
 
+/// Helper function to figure out SHA256 from a CAS url
+pub fn get_sha256_from_cas_url(img_name: &str, url: &Url) -> Result<String> {
+    // Since this is a CAS url, we assume the last URL path part is the sha256.
+    let (_prefix, sha256) = url
+        .path()
+        .rsplit_once('/')
+        .ok_or(anyhow!("failed to extract sha256 from CAS url '{url}'"))?;
+    let sha256 = sha256.to_string();
+    bail_if_sha256_invalid(&sha256, img_name)?;
+    Ok(sha256.to_string())
+}
+
 pub fn get_ic_os_img_url() -> Result<Url> {
     let url = read_dependency_from_env_to_string("ENV_DEPS__DEV_DISK_IMG_TAR_ZST_CAS_URL")?;
     Ok(Url::parse(&url)?)
 }
 
 pub fn get_ic_os_img_sha256() -> Result<String> {
-    let sha256 = read_dependency_from_env_to_string("ENV_DEPS__DEV_DISK_IMG_TAR_ZST_SHA256")?;
-    bail_if_sha256_invalid(&sha256, "ic_os_img_sha256")?;
-    Ok(sha256)
+    get_sha256_from_cas_url("ic_os_img_sha256", &get_ic_os_img_url()?)
 }
 
 pub fn get_malicious_ic_os_img_url() -> Result<Url> {
@@ -1156,10 +1166,7 @@ pub fn get_malicious_ic_os_img_url() -> Result<Url> {
 }
 
 pub fn get_malicious_ic_os_img_sha256() -> Result<String> {
-    let sha256 =
-        read_dependency_from_env_to_string("ENV_DEPS__DEV_MALICIOUS_DISK_IMG_TAR_ZST_SHA256")?;
-    bail_if_sha256_invalid(&sha256, "ic_os_img_sha256")?;
-    Ok(sha256)
+    get_sha256_from_cas_url("ic_os_img_sha256", &get_malicious_ic_os_img_url()?)
 }
 
 pub fn get_ic_os_update_img_url() -> Result<Url> {
@@ -1168,9 +1175,7 @@ pub fn get_ic_os_update_img_url() -> Result<Url> {
 }
 
 pub fn get_ic_os_update_img_sha256() -> Result<String> {
-    let sha256 = read_dependency_from_env_to_string("ENV_DEPS__DEV_UPDATE_IMG_TAR_ZST_SHA256")?;
-    bail_if_sha256_invalid(&sha256, "ic_os_update_img_sha256")?;
-    Ok(sha256)
+    get_sha256_from_cas_url("ic_os_update_img_sha256", &get_ic_os_update_img_url()?)
 }
 
 pub fn get_ic_os_update_img_test_url() -> Result<Url> {
@@ -1179,10 +1184,7 @@ pub fn get_ic_os_update_img_test_url() -> Result<Url> {
 }
 
 pub fn get_ic_os_update_img_test_sha256() -> Result<String> {
-    let sha256 =
-        read_dependency_from_env_to_string("ENV_DEPS__DEV_UPDATE_IMG_TEST_TAR_ZST_SHA256")?;
-    bail_if_sha256_invalid(&sha256, "ic_os_update_img_sha256")?;
-    Ok(sha256)
+    get_sha256_from_cas_url("ic_os_update_img_sha256", &get_ic_os_update_img_test_url()?)
 }
 
 pub fn get_malicious_ic_os_update_img_url() -> Result<Url> {
@@ -1192,10 +1194,10 @@ pub fn get_malicious_ic_os_update_img_url() -> Result<Url> {
 }
 
 pub fn get_malicious_ic_os_update_img_sha256() -> Result<String> {
-    let sha256 =
-        read_dependency_from_env_to_string("ENV_DEPS__DEV_MALICIOUS_UPDATE_IMG_TAR_ZST_SHA256")?;
-    bail_if_sha256_invalid(&sha256, "ic_os_update_img_sha256")?;
-    Ok(sha256)
+    get_sha256_from_cas_url(
+        "ic_os_update_img_sha256",
+        &get_malicious_ic_os_update_img_url()?,
+    )
 }
 
 pub fn get_boundary_node_img_url() -> Result<Url> {
@@ -1230,10 +1232,10 @@ pub fn get_hostos_update_img_test_url() -> Result<Url> {
 }
 
 pub fn get_hostos_update_img_test_sha256() -> Result<String> {
-    let sha256 =
-        read_dependency_from_env_to_string("ENV_DEPS__DEV_HOSTOS_UPDATE_IMG_TEST_TAR_ZST_SHA256")?;
-    bail_if_sha256_invalid(&sha256, "hostos_update_img_sha256")?;
-    Ok(sha256)
+    get_sha256_from_cas_url(
+        "hostos_update_img_sha256",
+        &get_hostos_update_img_test_url()?,
+    )
 }
 
 pub const FETCH_SHA256SUMS_RETRY_TIMEOUT: Duration = Duration::from_secs(120);

--- a/rs/tests/system_tests.bzl
+++ b/rs/tests/system_tests.bzl
@@ -197,13 +197,10 @@ def system_test(
 
     if uses_guestos_dev:
         _env_deps[_guestos + "disk-img.tar.zst.cas-url"] = "ENV_DEPS__DEV_DISK_IMG_TAR_ZST_CAS_URL"
-        _env_deps[_guestos + "disk-img.tar.zst.sha256"] = "ENV_DEPS__DEV_DISK_IMG_TAR_ZST_SHA256"
         _env_deps[_guestos + "update-img.tar.zst.cas-url"] = "ENV_DEPS__DEV_UPDATE_IMG_TAR_ZST_CAS_URL"
-        _env_deps[_guestos + "update-img.tar.zst.sha256"] = "ENV_DEPS__DEV_UPDATE_IMG_TAR_ZST_SHA256"
 
     if uses_hostos_dev_test:
         _env_deps[_hostos + "update-img-test.tar.zst.cas-url"] = "ENV_DEPS__DEV_HOSTOS_UPDATE_IMG_TEST_TAR_ZST_CAS_URL"
-        _env_deps[_hostos + "update-img-test.tar.zst.sha256"] = "ENV_DEPS__DEV_HOSTOS_UPDATE_IMG_TEST_TAR_ZST_SHA256"
 
     if uses_setupos_dev:
         _env_deps[_setupos + "disk-img.tar.zst"] = "ENV_DEPS__DEV_SETUPOS_IMG_TAR_ZST"
@@ -212,15 +209,12 @@ def system_test(
 
     if uses_guestos_dev_test:
         _env_deps[_guestos + "update-img-test.tar.zst.cas-url"] = "ENV_DEPS__DEV_UPDATE_IMG_TEST_TAR_ZST_CAS_URL"
-        _env_deps[_guestos + "update-img-test.tar.zst.sha256"] = "ENV_DEPS__DEV_UPDATE_IMG_TEST_TAR_ZST_SHA256"
 
     if malicious:
         _guestos_malicous = "//ic-os/guestos/envs/dev-malicious:"
 
         _env_deps[_guestos_malicous + "disk-img.tar.zst.cas-url"] = "ENV_DEPS__DEV_MALICIOUS_DISK_IMG_TAR_ZST_CAS_URL"
-        _env_deps[_guestos_malicous + "disk-img.tar.zst.sha256"] = "ENV_DEPS__DEV_MALICIOUS_DISK_IMG_TAR_ZST_SHA256"
         _env_deps[_guestos_malicous + "update-img.tar.zst.cas-url"] = "ENV_DEPS__DEV_MALICIOUS_UPDATE_IMG_TAR_ZST_CAS_URL"
-        _env_deps[_guestos_malicous + "update-img.tar.zst.sha256"] = "ENV_DEPS__DEV_MALICIOUS_UPDATE_IMG_TAR_ZST_SHA256"
 
     run_system_test(
         name = name,


### PR DESCRIPTION
This stops supplying the sha256 of ic-os images to system tests. The sha256 is already included in the CAS URLs.

This simplifies the runtime environment setup for the tests.