### PR TITLE
chore(boundary): add flag to canister response

### DIFF
--- a/rs/boundary_node/rate_limits/api/src/lib.rs
+++ b/rs/boundary_node/rate_limits/api/src/lib.rs
@@ -34,6 +34,7 @@ pub struct ConfigResponse {
 #[derive(CandidType, Deserialize, Debug)]
 pub struct OutputConfig {
     pub schema_version: SchemaVersion,
+    pub is_redacted: bool,
     pub rules: Vec<OutputRule>,
 }
 
@@ -99,6 +100,7 @@ impl std::fmt::Display for ConfigResponse {
 impl std::fmt::Display for OutputConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         writeln!(f, "Schema version: {}", self.schema_version)?;
+        writeln!(f, "{INDENT}Is redacted: {}", self.is_redacted)?;
         for (i, rule) in self.rules.iter().enumerate() {
             writeln!(f, "{DOUBLE_INDENT}Rule {}:", i + 1)?;
             writeln!(f, "{DOUBLE_INDENT}ID: {}", rule.id)?;

--- a/rs/boundary_node/rate_limits/canister/fetcher.rs
+++ b/rs/boundary_node/rate_limits/canister/fetcher.rs
@@ -125,6 +125,7 @@ impl<R: CanisterApi, F: ConfidentialityFormatting<Input = OutputConfig>, A: Reso
 
         let mut config = OutputConfig {
             schema_version: stored_config.schema_version,
+            is_redacted: false,
             rules,
         };
 
@@ -134,6 +135,7 @@ impl<R: CanisterApi, F: ConfidentialityFormatting<Input = OutputConfig>, A: Reso
 
         if !is_authorized_viewer {
             config = self.formatter.format(&config);
+            config.is_redacted = true;
         }
 
         let config = rate_limits_api::ConfigResponse {
@@ -276,6 +278,7 @@ mod tests {
         mock_formatter.expect_format().returning(|_| OutputConfig {
             schema_version: 1,
             rules: vec![],
+            is_redacted: false,
         });
 
         let mut mock_canister_api = MockCanisterApi::new();

--- a/rs/boundary_node/rate_limits/canister/interface.did
+++ b/rs/boundary_node/rate_limits/canister/interface.did
@@ -24,6 +24,7 @@ type OutputRule = record {
 
 type OutputConfig = record {
   schema_version: SchemaVersion; // schema version needed to deserialize the rules
+  is_redacted: bool;             // when set to `true` indicates that the config contains some confidential rules, which are not fully exposed
   rules: vec OutputRule;
 };
 

--- a/rs/boundary_node/rate_limits/canister/types.rs
+++ b/rs/boundary_node/rate_limits/canister/types.rs
@@ -29,6 +29,7 @@ pub struct ConfigResponse {
 #[derive(Clone)]
 pub struct OutputConfig {
     pub schema_version: SchemaVersion,
+    pub is_redacted: bool,
     pub rules: Vec<OutputRule>,
 }
 
@@ -122,6 +123,7 @@ impl From<OutputConfig> for rate_limits_api::OutputConfig {
         rate_limits_api::OutputConfig {
             schema_version: value.schema_version,
             rules: value.rules.into_iter().map(|r| r.into()).collect(),
+            is_redacted: value.is_redacted,
         }
     }
 }


### PR DESCRIPTION
This `is_redacted` flag helps the `ic-boundary` service determine whether its call to the `rate-limit` canister succeeded with full reader privileges.
