### PR TITLE
refactor(crypto): CRP-2598 move ExtendedDerivationPath to ic_types::crypto

### DIFF
--- a/rs/consensus/src/idkg/payload_builder.rs
+++ b/rs/consensus/src/idkg/payload_builder.rs
@@ -711,9 +711,9 @@ mod tests {
         BlockPayload, BlockProposal, DataPayload, HashedBlock, Payload, Rank, SummaryPayload,
     };
     use ic_types::crypto::canister_threshold_sig::idkg::IDkgTranscript;
-    use ic_types::crypto::canister_threshold_sig::ExtendedDerivationPath;
     use ic_types::crypto::canister_threshold_sig::ThresholdEcdsaCombinedSignature;
     use ic_types::crypto::canister_threshold_sig::ThresholdSchnorrCombinedSignature;
+    use ic_types::crypto::ExtendedDerivationPath;
     use ic_types::crypto::{CryptoHash, CryptoHashOf};
     use ic_types::time::UNIX_EPOCH;
     use ic_types::Randomness;

--- a/rs/consensus/src/idkg/signer.rs
+++ b/rs/consensus/src/idkg/signer.rs
@@ -820,7 +820,7 @@ mod tests {
     };
     use ic_test_utilities_types::messages::RequestBuilder;
     use ic_types::consensus::idkg::*;
-    use ic_types::crypto::{canister_threshold_sig::ExtendedDerivationPath, AlgorithmId};
+    use ic_types::crypto::{AlgorithmId, ExtendedDerivationPath};
     use ic_types::time::UNIX_EPOCH;
     use ic_types::{Height, Randomness};
     use std::ops::Deref;

--- a/rs/consensus/src/idkg/test_utils.rs
+++ b/rs/consensus/src/idkg/test_utils.rs
@@ -51,10 +51,10 @@ use ic_types::crypto::canister_threshold_sig::idkg::{
     IDkgTranscriptType, IDkgUnmaskedTranscriptOrigin, SignedIDkgDealing,
 };
 use ic_types::crypto::canister_threshold_sig::{
-    ExtendedDerivationPath, ThresholdEcdsaSigInputs, ThresholdEcdsaSigShare,
-    ThresholdSchnorrSigInputs, ThresholdSchnorrSigShare,
+    ThresholdEcdsaSigInputs, ThresholdEcdsaSigShare, ThresholdSchnorrSigInputs,
+    ThresholdSchnorrSigShare,
 };
-use ic_types::crypto::AlgorithmId;
+use ic_types::crypto::{AlgorithmId, ExtendedDerivationPath};
 use ic_types::messages::CallbackId;
 use ic_types::time::UNIX_EPOCH;
 use ic_types::{signature::*, time};

--- a/rs/consensus/src/idkg/utils.rs
+++ b/rs/consensus/src/idkg/utils.rs
@@ -30,8 +30,8 @@ use ic_types::consensus::{
 use ic_types::crypto::canister_threshold_sig::idkg::{
     IDkgTranscript, IDkgTranscriptOperation, InitialIDkgDealings,
 };
-use ic_types::crypto::canister_threshold_sig::{ExtendedDerivationPath, MasterPublicKey};
-use ic_types::crypto::AlgorithmId;
+use ic_types::crypto::canister_threshold_sig::MasterPublicKey;
+use ic_types::crypto::{AlgorithmId, ExtendedDerivationPath};
 use ic_types::messages::CallbackId;
 use ic_types::registry::RegistryClientError;
 use ic_types::{Height, RegistryVersion, SubnetId};

--- a/rs/crypto/benches/tecdsa.rs
+++ b/rs/crypto/benches/tecdsa.rs
@@ -12,10 +12,9 @@ use ic_crypto_test_utils_canister_threshold_sigs::{
 use ic_crypto_test_utils_reproducible_rng::ReproducibleRng;
 use ic_interfaces::crypto::{ThresholdEcdsaSigVerifier, ThresholdEcdsaSigner};
 use ic_types::crypto::canister_threshold_sig::{
-    ExtendedDerivationPath, ThresholdEcdsaCombinedSignature, ThresholdEcdsaSigInputs,
-    ThresholdEcdsaSigShare,
+    ThresholdEcdsaCombinedSignature, ThresholdEcdsaSigInputs, ThresholdEcdsaSigShare,
 };
-use ic_types::crypto::AlgorithmId;
+use ic_types::crypto::{AlgorithmId, ExtendedDerivationPath};
 use ic_types::Randomness;
 use rand::{CryptoRng, Rng, RngCore};
 use std::collections::BTreeMap;

--- a/rs/crypto/benches/tschnorr.rs
+++ b/rs/crypto/benches/tschnorr.rs
@@ -9,8 +9,8 @@ use ic_crypto_test_utils_canister_threshold_sigs::{
 };
 use ic_crypto_test_utils_reproducible_rng::ReproducibleRng;
 use ic_interfaces::crypto::{ThresholdSchnorrSigVerifier, ThresholdSchnorrSigner};
-use ic_types::crypto::canister_threshold_sig::ExtendedDerivationPath;
 use ic_types::crypto::AlgorithmId;
+use ic_types::crypto::ExtendedDerivationPath;
 use ic_types::Randomness;
 use rand::{CryptoRng, Rng, RngCore};
 use strum::IntoEnumIterator;

--- a/rs/crypto/internal/crypto_lib/threshold_sig/canister_threshold_sig/src/lib.rs
+++ b/rs/crypto/internal/crypto_lib/threshold_sig/canister_threshold_sig/src/lib.rs
@@ -187,8 +187,8 @@
 #![forbid(unsafe_code)]
 
 use ic_crypto_internal_seed::XmdError;
-use ic_types::crypto::canister_threshold_sig::{ExtendedDerivationPath, MasterPublicKey};
-use ic_types::crypto::AlgorithmId;
+use ic_types::crypto::canister_threshold_sig::MasterPublicKey;
+use ic_types::crypto::{AlgorithmId, ExtendedDerivationPath};
 use ic_types::{NumberOfNodes, Randomness};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;

--- a/rs/crypto/internal/crypto_service_provider/src/vault/api.rs
+++ b/rs/crypto/internal/crypto_service_provider/src/vault/api.rs
@@ -22,10 +22,10 @@ use ic_types::crypto::canister_threshold_sig::error::{
     IDkgLoadTranscriptError, IDkgOpenTranscriptError, IDkgRetainKeysError,
     IDkgVerifyDealingPrivateError, ThresholdEcdsaCreateSigShareError,
 };
-use ic_types::crypto::canister_threshold_sig::{
-    idkg::{BatchSignedIDkgDealing, IDkgTranscriptOperation},
-    ExtendedDerivationPath,
+use ic_types::crypto::canister_threshold_sig::idkg::{
+    BatchSignedIDkgDealing, IDkgTranscriptOperation,
 };
+use ic_types::crypto::ExtendedDerivationPath;
 use ic_types::crypto::{AlgorithmId, CryptoError, CurrentNodePublicKeys};
 use ic_types::{NodeId, NodeIndex, NumberOfNodes, Randomness};
 use serde::{Deserialize, Serialize};

--- a/rs/crypto/internal/crypto_service_provider/src/vault/local_csp_vault/tecdsa/mod.rs
+++ b/rs/crypto/internal/crypto_service_provider/src/vault/local_csp_vault/tecdsa/mod.rs
@@ -8,8 +8,8 @@ use ic_crypto_internal_threshold_sig_canister_threshold_sig::{
     ThresholdEcdsaSigShareInternal,
 };
 use ic_types::crypto::canister_threshold_sig::error::ThresholdEcdsaCreateSigShareError;
-use ic_types::crypto::canister_threshold_sig::ExtendedDerivationPath;
 use ic_types::crypto::AlgorithmId;
+use ic_types::crypto::ExtendedDerivationPath;
 use ic_types::Randomness;
 use rand::{CryptoRng, Rng};
 

--- a/rs/crypto/internal/crypto_service_provider/src/vault/local_csp_vault/tecdsa/tests.rs
+++ b/rs/crypto/internal/crypto_service_provider/src/vault/local_csp_vault/tecdsa/tests.rs
@@ -11,8 +11,8 @@ mod ecdsa_sign_share {
         ThresholdEcdsaSigShareInternal,
     };
     use ic_types::crypto::canister_threshold_sig::error::ThresholdEcdsaCreateSigShareError;
-    use ic_types::crypto::canister_threshold_sig::ExtendedDerivationPath;
     use ic_types::crypto::AlgorithmId;
+    use ic_types::crypto::ExtendedDerivationPath;
     use ic_types::Randomness;
     use proptest::collection::vec;
     use proptest::prelude::any;

--- a/rs/crypto/internal/crypto_service_provider/src/vault/local_csp_vault/tschnorr/mod.rs
+++ b/rs/crypto/internal/crypto_service_provider/src/vault/local_csp_vault/tschnorr/mod.rs
@@ -11,8 +11,8 @@ use ic_crypto_internal_threshold_sig_canister_threshold_sig::{
     IDkgTranscriptInternal, ThresholdBip340GenerateSigShareInternalError,
     ThresholdEd25519GenerateSigShareInternalError,
 };
-use ic_types::crypto::canister_threshold_sig::ExtendedDerivationPath;
 use ic_types::crypto::AlgorithmId;
+use ic_types::crypto::ExtendedDerivationPath;
 use ic_types::Randomness;
 use rand::{CryptoRng, Rng};
 

--- a/rs/crypto/internal/crypto_service_provider/src/vault/local_csp_vault/tschnorr/tests.rs
+++ b/rs/crypto/internal/crypto_service_provider/src/vault/local_csp_vault/tschnorr/tests.rs
@@ -14,7 +14,7 @@ use ic_crypto_internal_threshold_sig_canister_threshold_sig::{
 };
 use ic_crypto_test_utils_reproducible_rng::reproducible_rng;
 use ic_types::{
-    crypto::{canister_threshold_sig::ExtendedDerivationPath, AlgorithmId},
+    crypto::{AlgorithmId, ExtendedDerivationPath},
     Randomness,
 };
 use proptest::{

--- a/rs/crypto/internal/crypto_service_provider/src/vault/remote_csp_vault/mod.rs
+++ b/rs/crypto/internal/crypto_service_provider/src/vault/remote_csp_vault/mod.rs
@@ -25,10 +25,10 @@ use ic_types::crypto::canister_threshold_sig::error::{
     IDkgLoadTranscriptError, IDkgOpenTranscriptError, IDkgRetainKeysError,
     IDkgVerifyDealingPrivateError, ThresholdEcdsaCreateSigShareError,
 };
-use ic_types::crypto::canister_threshold_sig::{
-    idkg::{BatchSignedIDkgDealing, IDkgTranscriptOperation},
-    ExtendedDerivationPath,
+use ic_types::crypto::canister_threshold_sig::idkg::{
+    BatchSignedIDkgDealing, IDkgTranscriptOperation,
 };
+use ic_types::crypto::ExtendedDerivationPath;
 use ic_types::crypto::{AlgorithmId, CurrentNodePublicKeys};
 use ic_types::{NodeId, NodeIndex, NumberOfNodes, Randomness};
 use serde_bytes::ByteBuf;

--- a/rs/crypto/internal/crypto_service_provider/src/vault/remote_csp_vault/tarpc_csp_vault_client.rs
+++ b/rs/crypto/internal/crypto_service_provider/src/vault/remote_csp_vault/tarpc_csp_vault_client.rs
@@ -42,10 +42,10 @@ use ic_types::crypto::canister_threshold_sig::error::{
     IDkgLoadTranscriptError, IDkgOpenTranscriptError, IDkgRetainKeysError,
     IDkgVerifyDealingPrivateError, ThresholdEcdsaCreateSigShareError,
 };
-use ic_types::crypto::canister_threshold_sig::{
-    idkg::{BatchSignedIDkgDealing, IDkgTranscriptOperation},
-    ExtendedDerivationPath,
+use ic_types::crypto::canister_threshold_sig::idkg::{
+    BatchSignedIDkgDealing, IDkgTranscriptOperation,
 };
+use ic_types::crypto::ExtendedDerivationPath;
 use ic_types::crypto::{AlgorithmId, CurrentNodePublicKeys};
 use ic_types::{NodeId, NumberOfNodes, Randomness};
 use serde::{Deserialize, Serialize};

--- a/rs/crypto/internal/crypto_service_provider/src/vault/remote_csp_vault/tarpc_csp_vault_server.rs
+++ b/rs/crypto/internal/crypto_service_provider/src/vault/remote_csp_vault/tarpc_csp_vault_server.rs
@@ -41,10 +41,10 @@ use ic_types::crypto::canister_threshold_sig::error::{
     IDkgLoadTranscriptError, IDkgOpenTranscriptError, IDkgRetainKeysError,
     IDkgVerifyDealingPrivateError, ThresholdEcdsaCreateSigShareError,
 };
-use ic_types::crypto::canister_threshold_sig::{
-    idkg::{BatchSignedIDkgDealing, IDkgTranscriptOperation},
-    ExtendedDerivationPath,
+use ic_types::crypto::canister_threshold_sig::idkg::{
+    BatchSignedIDkgDealing, IDkgTranscriptOperation,
 };
+use ic_types::crypto::ExtendedDerivationPath;
 use ic_types::crypto::{AlgorithmId, CurrentNodePublicKeys};
 use ic_types::{NodeId, NumberOfNodes, Randomness};
 use rayon::{ThreadPool, ThreadPoolBuilder};

--- a/rs/crypto/test_utils/canister_threshold_sigs/src/lib.rs
+++ b/rs/crypto/test_utils/canister_threshold_sigs/src/lib.rs
@@ -23,11 +23,13 @@ use ic_types::crypto::canister_threshold_sig::idkg::{
     IDkgUnmaskedTranscriptOrigin, SignedIDkgDealing,
 };
 use ic_types::crypto::canister_threshold_sig::{
-    EcdsaPreSignatureQuadruple, ExtendedDerivationPath, SchnorrPreSignatureTranscript,
-    ThresholdEcdsaCombinedSignature, ThresholdEcdsaSigInputs, ThresholdEcdsaSigShare,
-    ThresholdSchnorrCombinedSignature, ThresholdSchnorrSigInputs, ThresholdSchnorrSigShare,
+    EcdsaPreSignatureQuadruple, SchnorrPreSignatureTranscript, ThresholdEcdsaCombinedSignature,
+    ThresholdEcdsaSigInputs, ThresholdEcdsaSigShare, ThresholdSchnorrCombinedSignature,
+    ThresholdSchnorrSigInputs, ThresholdSchnorrSigShare,
 };
-use ic_types::crypto::{AlgorithmId, BasicSig, BasicSigOf, KeyPurpose, Signed};
+use ic_types::crypto::{
+    AlgorithmId, BasicSig, BasicSigOf, ExtendedDerivationPath, KeyPurpose, Signed,
+};
 use ic_types::signature::{BasicSignature, BasicSignatureBatch};
 use ic_types::{Height, NodeId, PrincipalId, Randomness, RegistryVersion, SubnetId};
 use rand::prelude::*;
@@ -2885,10 +2887,8 @@ pub mod ecdsa {
         CanisterThresholdSigTestEnvironment, IDkgParticipants,
     };
     use ic_types::crypto::canister_threshold_sig::idkg::{IDkgDealers, IDkgReceivers};
-    use ic_types::crypto::canister_threshold_sig::{
-        ExtendedDerivationPath, ThresholdEcdsaSigInputs,
-    };
-    use ic_types::crypto::AlgorithmId;
+    use ic_types::crypto::canister_threshold_sig::ThresholdEcdsaSigInputs;
+    use ic_types::crypto::{AlgorithmId, ExtendedDerivationPath};
     use ic_types::PrincipalId;
     use ic_types::Randomness;
     use rand::distributions::uniform::SampleRange;
@@ -2941,10 +2941,8 @@ pub mod schnorr {
         CanisterThresholdSigTestEnvironment, IDkgParticipants,
     };
     use ic_types::crypto::canister_threshold_sig::idkg::{IDkgDealers, IDkgReceivers};
-    use ic_types::crypto::canister_threshold_sig::{
-        ExtendedDerivationPath, ThresholdSchnorrSigInputs,
-    };
-    use ic_types::crypto::AlgorithmId;
+    use ic_types::crypto::canister_threshold_sig::ThresholdSchnorrSigInputs;
+    use ic_types::crypto::{AlgorithmId, ExtendedDerivationPath};
     use ic_types::PrincipalId;
     use ic_types::Randomness;
     use rand::distributions::uniform::SampleRange;

--- a/rs/crypto/test_utils/local_csp_vault/src/lib.rs
+++ b/rs/crypto/test_utils/local_csp_vault/src/lib.rs
@@ -47,10 +47,10 @@ use ic_types::crypto::canister_threshold_sig::error::{
     IDkgLoadTranscriptError, IDkgOpenTranscriptError, IDkgRetainKeysError,
     IDkgVerifyDealingPrivateError, ThresholdEcdsaCreateSigShareError,
 };
-use ic_types::crypto::canister_threshold_sig::{
-    idkg::{BatchSignedIDkgDealing, IDkgTranscriptOperation},
-    ExtendedDerivationPath,
+use ic_types::crypto::canister_threshold_sig::idkg::{
+    BatchSignedIDkgDealing, IDkgTranscriptOperation,
 };
+use ic_types::crypto::ExtendedDerivationPath;
 use ic_types::crypto::{AlgorithmId, CurrentNodePublicKeys};
 use ic_types::{NodeId, NodeIndex, NumberOfNodes, Randomness};
 use mockall::mock;

--- a/rs/crypto/tests/canister_threshold_ecdsa.rs
+++ b/rs/crypto/tests/canister_threshold_ecdsa.rs
@@ -16,8 +16,8 @@ use ic_types::crypto::canister_threshold_sig::error::{
     ThresholdEcdsaCombineSigSharesError, ThresholdEcdsaCreateSigShareError,
 };
 use ic_types::crypto::canister_threshold_sig::idkg::IDkgTranscript;
-use ic_types::crypto::canister_threshold_sig::{ExtendedDerivationPath, ThresholdEcdsaSigInputs};
-use ic_types::crypto::AlgorithmId;
+use ic_types::crypto::canister_threshold_sig::ThresholdEcdsaSigInputs;
+use ic_types::crypto::{AlgorithmId, ExtendedDerivationPath};
 use ic_types::{NodeId, Randomness};
 use maplit::hashset;
 use rand::prelude::*;

--- a/rs/crypto/tests/canister_threshold_idkg.rs
+++ b/rs/crypto/tests/canister_threshold_idkg.rs
@@ -33,8 +33,8 @@ use ic_types::crypto::canister_threshold_sig::idkg::{
     IDkgDealers, IDkgReceivers, IDkgTranscript, IDkgTranscriptOperation, IDkgTranscriptParams,
     InitialIDkgDealings, SignedIDkgDealing,
 };
-use ic_types::crypto::canister_threshold_sig::{ExtendedDerivationPath, ThresholdEcdsaSigInputs};
-use ic_types::crypto::{AlgorithmId, CryptoError};
+use ic_types::crypto::canister_threshold_sig::ThresholdEcdsaSigInputs;
+use ic_types::crypto::{AlgorithmId, CryptoError, ExtendedDerivationPath};
 use ic_types::{NodeId, Randomness};
 use maplit::hashset;
 use rand::prelude::*;

--- a/rs/crypto/utils/canister_threshold_sig/src/lib.rs
+++ b/rs/crypto/utils/canister_threshold_sig/src/lib.rs
@@ -1,8 +1,7 @@
 use ic_crypto_internal_threshold_sig_canister_threshold_sig::DeriveThresholdPublicKeyError;
 use ic_types::crypto::canister_threshold_sig::error::CanisterThresholdGetPublicKeyError;
-use ic_types::crypto::canister_threshold_sig::{
-    ExtendedDerivationPath, MasterPublicKey, PublicKey,
-};
+use ic_types::crypto::canister_threshold_sig::{MasterPublicKey, PublicKey};
+use ic_types::crypto::ExtendedDerivationPath;
 
 /// Derives the threshold public key from the specified `master_public_key` for
 /// the given `extended_derivation_path`.

--- a/rs/execution_environment/src/execution_environment.rs
+++ b/rs/execution_environment/src/execution_environment.rs
@@ -60,8 +60,9 @@ use ic_system_api::{ExecutionParameters, InstructionLimits};
 use ic_types::{
     canister_http::CanisterHttpRequestContext,
     crypto::{
-        canister_threshold_sig::{ExtendedDerivationPath, MasterPublicKey, PublicKey},
+        canister_threshold_sig::{MasterPublicKey, PublicKey},
         threshold_sig::ni_dkg::NiDkgTargetId,
+        ExtendedDerivationPath,
     },
     ingress::{IngressState, IngressStatus, WasmResult},
     messages::{

--- a/rs/types/types/src/consensus/idkg/ecdsa.rs
+++ b/rs/types/types/src/consensus/idkg/ecdsa.rs
@@ -1,11 +1,10 @@
 //! Threshold ECDSA transcripts and references related definitions.
+use crate::crypto::ExtendedDerivationPath;
 use crate::crypto::{
     canister_threshold_sig::error::{
         EcdsaPresignatureQuadrupleCreationError, ThresholdEcdsaSigInputsCreationError,
     },
-    canister_threshold_sig::{
-        EcdsaPreSignatureQuadruple, ExtendedDerivationPath, ThresholdEcdsaSigInputs,
-    },
+    canister_threshold_sig::{EcdsaPreSignatureQuadruple, ThresholdEcdsaSigInputs},
 };
 use crate::{Height, Randomness};
 #[cfg(test)]

--- a/rs/types/types/src/consensus/idkg/schnorr.rs
+++ b/rs/types/types/src/consensus/idkg/schnorr.rs
@@ -1,7 +1,8 @@
 //! Threshold Schnorr transcripts and references related definitions.
 use crate::crypto::canister_threshold_sig::{
-    ExtendedDerivationPath, SchnorrPreSignatureTranscript, ThresholdSchnorrSigInputs,
+    SchnorrPreSignatureTranscript, ThresholdSchnorrSigInputs,
 };
+use crate::crypto::ExtendedDerivationPath;
 use crate::{Height, Randomness};
 #[cfg(test)]
 use ic_exhaustive_derive::ExhaustiveSet;

--- a/rs/types/types/src/crypto.rs
+++ b/rs/types/types/src/crypto.rs
@@ -22,6 +22,7 @@ use crate::crypto::threshold_sig::ni_dkg::NiDkgId;
 use crate::registry::RegistryClientError;
 use crate::{CountBytes, NodeId, RegistryVersion, SubnetId};
 use core::fmt::Formatter;
+use ic_base_types::PrincipalId;
 use ic_crypto_internal_types::sign::threshold_sig::public_coefficients::CspPublicCoefficients;
 use ic_crypto_internal_types::sign::threshold_sig::public_key::bls12_381::ThresholdSigPublicKeyBytesConversionError;
 use ic_crypto_internal_types::sign::threshold_sig::public_key::CspThresholdSigPublicKey;
@@ -798,5 +799,33 @@ impl CurrentNodePublicKeys {
             count += 1;
         }
         count
+    }
+}
+
+/// Metadata used to derive keys for tECDSA, tSchnorr, and vetKD.
+#[serde_with::serde_as]
+#[derive(Clone, Eq, PartialEq, Hash, Deserialize, Serialize)]
+#[cfg_attr(test, derive(ExhaustiveSet))]
+pub struct ExtendedDerivationPath {
+    pub caller: PrincipalId,
+    #[serde_as(as = "Vec<serde_with::Bytes>")]
+    pub derivation_path: Vec<Vec<u8>>,
+}
+
+impl fmt::Debug for ExtendedDerivationPath {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "ExtendedDerivationPath {{ caller: {:?}", self.caller)?;
+        write!(f, ", derivation_path: {{ ")?;
+        let mut first_path = true;
+        for path in &self.derivation_path {
+            if !first_path {
+                write!(f, ", ")?;
+                first_path = false;
+            }
+            write!(f, "{}", hex::encode(path))?;
+        }
+        write!(f, " }}")?;
+        write!(f, " }}")?;
+        Ok(())
     }
 }

--- a/rs/types/types/src/crypto/canister_threshold_sig.rs
+++ b/rs/types/types/src/crypto/canister_threshold_sig.rs
@@ -5,12 +5,11 @@ use crate::crypto::canister_threshold_sig::idkg::{
 };
 use crate::crypto::impl_display_using_debug;
 use crate::crypto::AlgorithmId;
+use crate::crypto::ExtendedDerivationPath;
 use crate::{NumberOfNodes, Randomness};
 use core::fmt;
-use ic_base_types::{NodeId, PrincipalId};
+use ic_base_types::NodeId;
 use ic_crypto_internal_types::NodeIndex;
-#[cfg(test)]
-use ic_exhaustive_derive::ExhaustiveSet;
 use serde::{Deserialize, Serialize};
 use std::fmt::Formatter;
 
@@ -271,34 +270,6 @@ impl EcdsaPreSignatureQuadruple {
                 format!("`key_times_lambda` transcript expected to have type `Masked` with origin of type `UnmaskedTimesMasked(_,{:?})`, but found transcript of type {:?}", lambda_masked.transcript_id, key_times_lambda.transcript_type))
             ),
         }
-    }
-}
-
-/// Metadata used to derive a specific ECDSA keypair.
-#[serde_with::serde_as]
-#[derive(Clone, Eq, PartialEq, Hash, Deserialize, Serialize)]
-#[cfg_attr(test, derive(ExhaustiveSet))]
-pub struct ExtendedDerivationPath {
-    pub caller: PrincipalId,
-    #[serde_as(as = "Vec<serde_with::Bytes>")]
-    pub derivation_path: Vec<Vec<u8>>,
-}
-
-impl fmt::Debug for ExtendedDerivationPath {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(f, "ExtendedDerivationPath {{ caller: {:?}", self.caller)?;
-        write!(f, ", derivation_path: {{ ")?;
-        let mut first_path = true;
-        for path in &self.derivation_path {
-            if !first_path {
-                write!(f, ", ")?;
-                first_path = false;
-            }
-            write!(f, "{}", hex::encode(path))?;
-        }
-        write!(f, " }}")?;
-        write!(f, " }}")?;
-        Ok(())
     }
 }
 

--- a/rs/types/types/src/crypto/canister_threshold_sig/idkg/proto_conversions.rs
+++ b/rs/types/types/src/crypto/canister_threshold_sig/idkg/proto_conversions.rs
@@ -4,7 +4,7 @@ use crate::crypto::canister_threshold_sig::idkg::{
     IDkgTranscriptOperation, IDkgTranscriptParams, IDkgTranscriptType, InitialIDkgDealings,
     SignedIDkgDealing,
 };
-use crate::crypto::canister_threshold_sig::ExtendedDerivationPath;
+use crate::crypto::ExtendedDerivationPath;
 use crate::crypto::{AlgorithmId, BasicSig, BasicSigOf, CryptoHashOf};
 use crate::signature::{BasicSignature, BasicSignatureBatch};
 use crate::{node_id_into_protobuf, node_id_try_from_option, Height, NodeIndex};

--- a/rs/types/types/src/crypto/canister_threshold_sig/idkg/tests/proto_conversions.rs
+++ b/rs/types/types/src/crypto/canister_threshold_sig/idkg/tests/proto_conversions.rs
@@ -2,7 +2,7 @@ use crate::crypto::canister_threshold_sig::idkg::{
     IDkgComplaint, IDkgDealing, IDkgOpening, IDkgTranscriptId, IDkgTranscriptOperation,
     InitialIDkgDealings, SignedIDkgDealing,
 };
-use crate::crypto::canister_threshold_sig::ExtendedDerivationPath;
+use crate::crypto::ExtendedDerivationPath;
 use crate::{Height, NodeId, PrincipalId};
 
 use crate::crypto::canister_threshold_sig::idkg::tests::test_utils::{

--- a/rs/types/types/src/crypto/canister_threshold_sig/tests.rs
+++ b/rs/types/types/src/crypto/canister_threshold_sig/tests.rs
@@ -5,6 +5,7 @@ use crate::crypto::canister_threshold_sig::error::{
 use crate::crypto::canister_threshold_sig::idkg::IDkgTranscriptId;
 use crate::{Height, NodeId, RegistryVersion, SubnetId};
 use assert_matches::assert_matches;
+use ic_base_types::PrincipalId;
 use ic_crypto_test_utils_canister_threshold_sigs::{ordered_node_id, set_of_nodes};
 use ic_crypto_test_utils_reproducible_rng::reproducible_rng;
 use rand::{CryptoRng, Rng};

--- a/rs/types/types/src/crypto/vetkd.rs
+++ b/rs/types/types/src/crypto/vetkd.rs
@@ -1,7 +1,7 @@
-use crate::crypto::canister_threshold_sig::ExtendedDerivationPath;
 use crate::crypto::impl_display_using_debug;
 use crate::crypto::threshold_sig::errors::threshold_sig_data_not_found_error::ThresholdSigDataNotFoundError;
 use crate::crypto::threshold_sig::ni_dkg::NiDkgId;
+use crate::crypto::ExtendedDerivationPath;
 use crate::crypto::HexEncoding;
 use crate::NodeId;
 use serde::{Deserialize, Serialize};

--- a/rs/types/types/src/crypto/vetkd/test.rs
+++ b/rs/types/types/src/crypto/vetkd/test.rs
@@ -1,6 +1,6 @@
-use crate::crypto::canister_threshold_sig::ExtendedDerivationPath;
 use crate::crypto::threshold_sig::ni_dkg::{NiDkgId, NiDkgTag, NiDkgTargetId, NiDkgTargetSubnet};
 use crate::crypto::vetkd::{VetKdArgs, VetKdEncryptedKey, VetKdEncryptedKeyShare};
+use crate::crypto::ExtendedDerivationPath;
 use crate::Height;
 use ic_base_types::PrincipalId;
 use ic_base_types::SubnetId;


### PR DESCRIPTION
Moves the `ExtendedDerivationPath` from `ic_types::crypto::canister_threshold_sig` up one level to `ic_types::crypto`, because with the vetKeys feature, the type will no longer be used just for canister threshold signatures. 