### PR TITLE
chore(boundary): adapt rate-limit rule definition

### DIFF
--- a/rs/boundary_node/rate_limits/api/src/schema_versions/v1.rs
+++ b/rs/boundary_node/rate_limits/api/src/schema_versions/v1.rs
@@ -16,7 +16,7 @@ pub struct RateLimitRule {
     pub canister_id: Option<Principal>,
     pub subnet_id: Option<Principal>,
     pub methods_regex: Option<String>,
-    pub request_type: Option<RequestType>,
+    pub request_types: Option<Vec<RequestType>>,
     pub limit: String,
 }
 

--- a/rs/boundary_node/rate_limits/canister_client/src/main.rs
+++ b/rs/boundary_node/rate_limits/canister_client/src/main.rs
@@ -82,7 +82,7 @@ async fn add_config_1(agent: &Agent, canister_id: Principal) {
         canister_id: Some(canister_id),
         subnet_id: None,
         methods_regex: Some(r"^(method_1)$".to_string()),
-        request_type: Some(RequestType::Call),
+        request_types: Some(vec![RequestType::Call]),
         limit: "1req/s".to_string(),
     };
 
@@ -90,7 +90,7 @@ async fn add_config_1(agent: &Agent, canister_id: Principal) {
         canister_id: Some(canister_id),
         subnet_id: None,
         methods_regex: Some(r"^(method_2)$".to_string()),
-        request_type: Some(RequestType::Query),
+        request_types: Some(vec![RequestType::Query]),
         limit: "2req/s".to_string(),
     };
 
@@ -98,7 +98,7 @@ async fn add_config_1(agent: &Agent, canister_id: Principal) {
         canister_id: Some(canister_id),
         subnet_id: None,
         methods_regex: Some(r"^(method_3)$".to_string()),
-        request_type: None,
+        request_types: None,
         limit: "3req/s".to_string(),
     };
 
@@ -106,7 +106,7 @@ async fn add_config_1(agent: &Agent, canister_id: Principal) {
         canister_id: Some(canister_id),
         subnet_id: None,
         methods_regex: Some(r"^(method_4)$".to_string()),
-        request_type: Some(RequestType::ReadState),
+        request_types: Some(vec![RequestType::ReadState]),
         limit: "4req/s".to_string(),
     };
 
@@ -160,7 +160,7 @@ async fn add_config_2(agent: &Agent, canister_id: Principal) {
         canister_id: Some(canister_id),
         subnet_id: None,
         methods_regex: Some(r"^(method_1)$".to_string()),
-        request_type: Some(RequestType::Call),
+        request_types: Some(vec![RequestType::Call]),
         limit: "1req/s".to_string(),
     };
 
@@ -168,7 +168,7 @@ async fn add_config_2(agent: &Agent, canister_id: Principal) {
         canister_id: Some(canister_id),
         subnet_id: None,
         methods_regex: Some(r"^(method_2)$".to_string()),
-        request_type: Some(RequestType::Query),
+        request_types: Some(vec![RequestType::Query]),
         limit: "2req/s".to_string(),
     };
 
@@ -177,7 +177,7 @@ async fn add_config_2(agent: &Agent, canister_id: Principal) {
         canister_id: Some(canister_id),
         subnet_id: None,
         methods_regex: Some(r"^(method_33)$".to_string()),
-        request_type: None,
+        request_types: None,
         limit: "33req/s".to_string(),
     };
 
@@ -185,7 +185,7 @@ async fn add_config_2(agent: &Agent, canister_id: Principal) {
         canister_id: Some(canister_id),
         subnet_id: None,
         methods_regex: Some(r"^(method_4)$".to_string()),
-        request_type: Some(RequestType::ReadState),
+        request_types: Some(vec![RequestType::ReadState]),
         limit: "4req/s".to_string(),
     };
 

--- a/rs/tests/boundary_nodes/rate_limit_canister_test.rs
+++ b/rs/tests/boundary_nodes/rate_limit_canister_test.rs
@@ -167,7 +167,7 @@ async fn add_config_1(logger: Logger, agent: &Agent, canister_id: Principal) {
         canister_id: Some(canister_id),
         subnet_id: None,
         methods_regex: Some(r"^(method_1)$".to_string()),
-        request_type: Some(RequestType::Call),
+        request_types: Some(vec![RequestType::Call]),
         limit: "1req/s".to_string(),
     };
 
@@ -175,7 +175,7 @@ async fn add_config_1(logger: Logger, agent: &Agent, canister_id: Principal) {
         canister_id: Some(canister_id),
         subnet_id: None,
         methods_regex: Some(r"^(method_2)$".to_string()),
-        request_type: Some(RequestType::Query),
+        request_types: Some(vec![RequestType::Query]),
         limit: "2req/s".to_string(),
     };
 
@@ -183,7 +183,7 @@ async fn add_config_1(logger: Logger, agent: &Agent, canister_id: Principal) {
         canister_id: Some(canister_id),
         subnet_id: None,
         methods_regex: Some(r"^(method_3)$".to_string()),
-        request_type: None,
+        request_types: None,
         limit: "3req/s".to_string(),
     };
 
@@ -191,7 +191,7 @@ async fn add_config_1(logger: Logger, agent: &Agent, canister_id: Principal) {
         canister_id: Some(canister_id),
         subnet_id: None,
         methods_regex: Some(r"^(method_4)$".to_string()),
-        request_type: Some(RequestType::ReadState),
+        request_types: Some(vec![RequestType::ReadState]),
         limit: "4req/s".to_string(),
     };
 
@@ -244,7 +244,7 @@ async fn add_config_2(logger: Logger, agent: &Agent, canister_id: Principal) {
         canister_id: Some(canister_id),
         subnet_id: None,
         methods_regex: Some(r"^(method_1)$".to_string()),
-        request_type: Some(RequestType::Call),
+        request_types: Some(vec![RequestType::Call]),
         limit: "1req/s".to_string(),
     };
 
@@ -252,7 +252,7 @@ async fn add_config_2(logger: Logger, agent: &Agent, canister_id: Principal) {
         canister_id: Some(canister_id),
         subnet_id: None,
         methods_regex: Some(r"^(method_2)$".to_string()),
-        request_type: Some(RequestType::Query),
+        request_types: Some(vec![RequestType::Query]),
         limit: "2req/s".to_string(),
     };
 
@@ -261,7 +261,7 @@ async fn add_config_2(logger: Logger, agent: &Agent, canister_id: Principal) {
         canister_id: Some(canister_id),
         subnet_id: None,
         methods_regex: Some(r"^(method_33)$".to_string()),
-        request_type: None,
+        request_types: None,
         limit: "33req/s".to_string(),
     };
 
@@ -269,7 +269,7 @@ async fn add_config_2(logger: Logger, agent: &Agent, canister_id: Principal) {
         canister_id: Some(canister_id),
         subnet_id: None,
         methods_regex: Some(r"^(method_4)$".to_string()),
-        request_type: Some(RequestType::ReadState),
+        request_types: Some(vec![RequestType::ReadState]),
         limit: "4req/s".to_string(),
     };
 


### PR DESCRIPTION
This definition would allow to `rate-limit` on multiple request types:
```
pub struct RateLimitRule {
   ...
    pub request_types: Option<Vec<RequestType>>,
   ...
}
```