### PR TITLE
chore(consensus): remove a no longer needed metric

### DIFF
--- a/rs/consensus/src/consensus.rs
+++ b/rs/consensus/src/consensus.rs
@@ -259,7 +259,6 @@ impl ConsensusImpl {
                 logger.clone(),
                 ValidatorMetrics::new(metrics_registry.clone()),
                 Arc::clone(&time_source),
-                Some(ingress_selector.clone()),
             ),
             aggregator: ShareAggregator::new(
                 membership,

--- a/rs/consensus/src/consensus/validator.rs
+++ b/rs/consensus/src/consensus/validator.rs
@@ -23,7 +23,6 @@ use ic_interfaces::{
     consensus::{InvalidPayloadReason, PayloadBuilder, PayloadValidationFailure},
     consensus_pool::*,
     dkg::DkgPool,
-    ingress_manager::IngressSelector,
     messaging::MessageRouting,
     time_source::TimeSource,
     validation::{ValidationError, ValidationResult},
@@ -687,7 +686,6 @@ pub struct Validator {
     metrics: ValidatorMetrics,
     schedule: RoundRobin,
     time_source: Arc<dyn TimeSource>,
-    ingress_selector: Option<Arc<dyn IngressSelector>>,
 }
 
 impl Validator {
@@ -705,7 +703,6 @@ impl Validator {
         log: ReplicaLogger,
         metrics: ValidatorMetrics,
         time_source: Arc<dyn TimeSource>,
-        ingress_selector: Option<Arc<dyn IngressSelector>>,
     ) -> Validator {
         Validator {
             replica_config,
@@ -720,7 +717,6 @@ impl Validator {
             metrics,
             schedule: RoundRobin::default(),
             time_source,
-            ingress_selector,
         }
     }
 
@@ -1143,8 +1139,7 @@ impl Validator {
         for action in &change_set {
             if let ChangeAction::MoveToValidated(ConsensusMessage::BlockProposal(proposal)) = action
             {
-                self.metrics
-                    .observe_data_payload(proposal, self.ingress_selector.as_deref());
+                self.metrics.observe_data_payload(proposal);
                 self.metrics.observe_block(pool_reader, proposal);
             }
         }
@@ -1997,7 +1992,6 @@ pub mod test {
                 no_op_logger(),
                 ValidatorMetrics::new(MetricsRegistry::new()),
                 Arc::clone(&dependencies.time_source) as Arc<_>,
-                /*ingress_selector=*/ None,
             );
             Self {
                 validator,

--- a/rs/ingress_manager/src/ingress_selector.rs
+++ b/rs/ingress_manager/src/ingress_selector.rs
@@ -413,16 +413,6 @@ impl IngressSelector for IngressManager {
     fn request_purge_finalized_messages(&self, message_ids: Vec<IngressMessageId>) {
         self.messages_to_purge.write().unwrap().push(message_ids)
     }
-
-    fn has_message(&self, message_id: &IngressMessageId) -> bool {
-        self.ingress_pool
-            .as_ref()
-            .read()
-            .unwrap()
-            .validated()
-            .get(message_id)
-            .is_some()
-    }
 }
 
 impl IngressManager {

--- a/rs/interfaces/src/ingress_manager.rs
+++ b/rs/interfaces/src/ingress_manager.rs
@@ -153,10 +153,6 @@ pub trait IngressSelector: Send + Sync {
     ///
     /// The actual purge is not required to happen immediately.
     fn request_purge_finalized_messages(&self, message_ids: Vec<IngressMessageId>);
-
-    /// Returns true if and only if the pool has an ingress message with the given id.
-    // TODO(CON-1312): Remove this when no longer necessary
-    fn has_message(&self, message_id: &IngressMessageId) -> bool;
 }
 
 /*

--- a/rs/replay/src/validator.rs
+++ b/rs/replay/src/validator.rs
@@ -133,7 +133,6 @@ impl ReplayValidator {
             log.clone(),
             ValidatorMetrics::new(metrics_registry.clone()),
             time_source.clone(),
-            /*ingress_selector=*/ None,
         );
 
         Self {

--- a/rs/test_utilities/src/ingress_selector.rs
+++ b/rs/test_utilities/src/ingress_selector.rs
@@ -102,8 +102,4 @@ impl IngressSelector for FakeIngressSelector {
     }
 
     fn request_purge_finalized_messages(&self, _message_ids: Vec<IngressMessageId>) {}
-
-    fn has_message(&self, _message_id: &IngressMessageId) -> bool {
-        true
-    }
 }


### PR DESCRIPTION
I added it a couple of weeks ago to gather some data. We no longer need this metric