### PR TITLE
chore(consensus): remove unnecessary variable in ingress selector

### DIFF
--- a/rs/ingress_manager/src/ingress_selector.rs
+++ b/rs/ingress_manager/src/ingress_selector.rs
@@ -94,7 +94,6 @@ impl IngressSelector for IngressManager {
         // becomes greater than byte_limit.
         let mut accumulated_size = 0;
         let mut cycles_needed: BTreeMap<CanisterId, Cycles> = BTreeMap::new();
-        let mut num_messages = 0;
 
         let ingress_pool = self.ingress_pool.read().unwrap();
 
@@ -170,7 +169,7 @@ impl IngressSelector for IngressManager {
                         context,
                         &settings,
                         &past_ingress_set,
-                        num_messages,
+                        messages_in_payload.len(),
                         &mut cycles_needed,
                     );
                     // Any message that generates validation errors gets removed from
@@ -207,7 +206,6 @@ impl IngressSelector for IngressManager {
                         break;
                     }
 
-                    num_messages += 1;
                     accumulated_size += ingress_size;
                     queue.msgs_included += 1;
                     queue.bytes_included += ingress_size;


### PR DESCRIPTION
We can compute the number of ingress messages by calling `len` instead