### PR TITLE
feat(IDX): update container tag on dev branches

### DIFF
--- a/.github/workflows/container-autobuild.yml
+++ b/.github/workflows/container-autobuild.yml
@@ -7,6 +7,14 @@ on:
       - '.bazelversion'
       - 'rust-toolchain.toml'
       - 'ci/container/**'
+  push:
+    branches:
+      - 'dev-gh-*'
+    paths:
+      - '.github/workflows/container-autobuild.yml'
+      - '.bazelversion'
+      - 'rust-toolchain.toml'
+      - 'ci/container/**'
   workflow_dispatch:
 
 concurrency:
@@ -111,7 +119,7 @@ jobs:
 
       - name: Add PR Comment
         uses: actions/github-script@v7
-        if: ${{ steps.check.outputs.build == 'true' }}
+        if: ${{ steps.check.outputs.build == 'true' && github.event_name == 'pull_request' }}
         with:
           script: |
             let message = 'Run URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}\n\n'


### PR DESCRIPTION
This ports the container tag autoupdate to work on `dev-gh-*` development branches, and adapts the workflow to work on non-PR runs (which happens to also fix the workflow when dispatches manually).