### PR TITLE
fix: use appropriate backoff term

### DIFF
--- a/rs/tests/driver/src/driver/test_env_api.rs
+++ b/rs/tests/driver/src/driver/test_env_api.rs
@@ -2048,7 +2048,7 @@ where
     let start = Instant::now();
     debug!(
         log,
-        "Func=\"{msg}\" is being retried for the maximum of {timeout:?} with a linear backoff of {backoff:?}"
+        "Func=\"{msg}\" is being retried for the maximum of {timeout:?} with a constant backoff of {backoff:?}"
     );
     loop {
         match f().await {


### PR DESCRIPTION
The backoff used in the test driver is constant, not linear:

```
exponential: |.|..|....|.........|
linear:      |.|..|...|....|.....|
constant:    |.|.|.|.|.|.|.|.|.|.|
```