### PR TITLE
refactor(node): rename use_nns_public_key and use_node_operator_private_key

### DIFF
--- a/rs/ic_os/config/src/generate_testnet_config.rs
+++ b/rs/ic_os/config/src/generate_testnet_config.rs
@@ -27,9 +27,7 @@ pub struct GenerateTestnetConfigArgs {
     pub deployment_environment: Option<String>,
     pub elasticsearch_hosts: Option<String>,
     pub elasticsearch_tags: Option<String>,
-    pub nns_public_key_exists: Option<bool>,
     pub nns_urls: Option<Vec<String>>,
-    pub node_operator_private_key_exists: Option<bool>,
     pub use_ssh_authorized_keys: Option<bool>,
 
     // GuestOSSettings arguments
@@ -75,9 +73,7 @@ fn create_guestos_config(config: GenerateTestnetConfigArgs) -> Result<GuestOSCon
         deployment_environment,
         elasticsearch_hosts,
         elasticsearch_tags,
-        nns_public_key_exists,
         nns_urls,
-        node_operator_private_key_exists,
         use_ssh_authorized_keys,
         inject_ic_crypto,
         inject_ic_state,
@@ -178,8 +174,6 @@ fn create_guestos_config(config: GenerateTestnetConfigArgs) -> Result<GuestOSCon
         elasticsearch_tags,
     };
 
-    let nns_public_key_exists = nns_public_key_exists.unwrap_or(true);
-
     let nns_urls = match nns_urls {
         Some(urls) => urls
             .iter()
@@ -188,8 +182,6 @@ fn create_guestos_config(config: GenerateTestnetConfigArgs) -> Result<GuestOSCon
         None => vec![Url::parse("https://wiki.internetcomputer.org")?],
     };
 
-    let node_operator_private_key_exists = node_operator_private_key_exists.unwrap_or(false);
-
     let use_ssh_authorized_keys = use_ssh_authorized_keys.unwrap_or(true);
 
     let icos_settings = ICOSSettings {
@@ -197,9 +189,7 @@ fn create_guestos_config(config: GenerateTestnetConfigArgs) -> Result<GuestOSCon
         mgmt_mac,
         deployment_environment,
         logging,
-        nns_public_key_exists,
         nns_urls,
-        node_operator_private_key_exists,
         use_ssh_authorized_keys,
         icos_dev_settings: ICOSDevSettings::default(),
     };

--- a/rs/ic_os/config/src/generate_testnet_config.rs
+++ b/rs/ic_os/config/src/generate_testnet_config.rs
@@ -27,7 +27,9 @@ pub struct GenerateTestnetConfigArgs {
     pub deployment_environment: Option<String>,
     pub elasticsearch_hosts: Option<String>,
     pub elasticsearch_tags: Option<String>,
+    pub nns_public_key_exists: Option<bool>,
     pub nns_urls: Option<Vec<String>>,
+    pub node_operator_private_key_exists: Option<bool>,
     pub use_ssh_authorized_keys: Option<bool>,
 
     // GuestOSSettings arguments
@@ -73,7 +75,9 @@ fn create_guestos_config(config: GenerateTestnetConfigArgs) -> Result<GuestOSCon
         deployment_environment,
         elasticsearch_hosts,
         elasticsearch_tags,
+        nns_public_key_exists,
         nns_urls,
+        node_operator_private_key_exists,
         use_ssh_authorized_keys,
         inject_ic_crypto,
         inject_ic_state,
@@ -174,6 +178,8 @@ fn create_guestos_config(config: GenerateTestnetConfigArgs) -> Result<GuestOSCon
         elasticsearch_tags,
     };
 
+    let nns_public_key_exists = nns_public_key_exists.unwrap_or(true);
+
     let nns_urls = match nns_urls {
         Some(urls) => urls
             .iter()
@@ -182,6 +188,8 @@ fn create_guestos_config(config: GenerateTestnetConfigArgs) -> Result<GuestOSCon
         None => vec![Url::parse("https://wiki.internetcomputer.org")?],
     };
 
+    let node_operator_private_key_exists = node_operator_private_key_exists.unwrap_or(false);
+
     let use_ssh_authorized_keys = use_ssh_authorized_keys.unwrap_or(true);
 
     let icos_settings = ICOSSettings {
@@ -189,7 +197,9 @@ fn create_guestos_config(config: GenerateTestnetConfigArgs) -> Result<GuestOSCon
         mgmt_mac,
         deployment_environment,
         logging,
+        nns_public_key_exists,
         nns_urls,
+        node_operator_private_key_exists,
         use_ssh_authorized_keys,
         icos_dev_settings: ICOSDevSettings::default(),
     };

--- a/rs/ic_os/config/src/generate_testnet_config.rs
+++ b/rs/ic_os/config/src/generate_testnet_config.rs
@@ -27,9 +27,9 @@ pub struct GenerateTestnetConfigArgs {
     pub deployment_environment: Option<String>,
     pub elasticsearch_hosts: Option<String>,
     pub elasticsearch_tags: Option<String>,
-    pub nns_public_key_exists: Option<bool>,
+    pub use_nns_public_key: Option<bool>,
     pub nns_urls: Option<Vec<String>>,
-    pub node_operator_private_key_exists: Option<bool>,
+    pub use_node_operator_private_key: Option<bool>,
     pub use_ssh_authorized_keys: Option<bool>,
 
     // GuestOSSettings arguments
@@ -75,9 +75,9 @@ fn create_guestos_config(config: GenerateTestnetConfigArgs) -> Result<GuestOSCon
         deployment_environment,
         elasticsearch_hosts,
         elasticsearch_tags,
-        nns_public_key_exists,
+        use_nns_public_key,
         nns_urls,
-        node_operator_private_key_exists,
+        use_node_operator_private_key,
         use_ssh_authorized_keys,
         inject_ic_crypto,
         inject_ic_state,
@@ -178,7 +178,7 @@ fn create_guestos_config(config: GenerateTestnetConfigArgs) -> Result<GuestOSCon
         elasticsearch_tags,
     };
 
-    let nns_public_key_exists = nns_public_key_exists.unwrap_or(true);
+    let use_nns_public_key = use_nns_public_key.unwrap_or(true);
 
     let nns_urls = match nns_urls {
         Some(urls) => urls
@@ -188,7 +188,7 @@ fn create_guestos_config(config: GenerateTestnetConfigArgs) -> Result<GuestOSCon
         None => vec![Url::parse("https://wiki.internetcomputer.org")?],
     };
 
-    let node_operator_private_key_exists = node_operator_private_key_exists.unwrap_or(false);
+    let use_node_operator_private_key = use_node_operator_private_key.unwrap_or(false);
 
     let use_ssh_authorized_keys = use_ssh_authorized_keys.unwrap_or(true);
 
@@ -197,9 +197,9 @@ fn create_guestos_config(config: GenerateTestnetConfigArgs) -> Result<GuestOSCon
         mgmt_mac,
         deployment_environment,
         logging,
-        nns_public_key_exists,
+        use_nns_public_key,
         nns_urls,
-        node_operator_private_key_exists,
+        use_node_operator_private_key,
         use_ssh_authorized_keys,
         icos_dev_settings: ICOSDevSettings::default(),
     };

--- a/rs/ic_os/config/src/lib.rs
+++ b/rs/ic_os/config/src/lib.rs
@@ -77,9 +77,9 @@ mod tests {
             mgmt_mac: FormattedMacAddress::try_from("ec:2a:72:31:a2:0c")?,
             deployment_environment: "Mainnet".to_string(),
             logging,
-            nns_public_key_exists: true,
+            use_nns_public_key: true,
             nns_urls: vec!["http://localhost".parse().unwrap()],
-            node_operator_private_key_exists: true,
+            use_node_operator_private_key: true,
             use_ssh_authorized_keys: false,
             icos_dev_settings,
         };
@@ -169,11 +169,11 @@ mod tests {
                 "elasticsearch_hosts": "elasticsearch-node-0.mercury.dfinity.systems:443 elasticsearch-node-1.mercury.dfinity.systems:443",
                 "elasticsearch_tags": "tag1 tag2"
             },
-            "nns_public_key_exists": true,
+            "use_nns_public_key": true,
             "nns_urls": [
                 "http://localhost"
             ],
-            "node_operator_private_key_exists": true,
+            "use_node_operator_private_key": true,
             "use_ssh_authorized_keys": false,
             "icos_dev_settings": {}
         },
@@ -229,11 +229,11 @@ mod tests {
                 "elasticsearch_hosts": "elasticsearch-node-0.mercury.dfinity.systems:443 elasticsearch-node-1.mercury.dfinity.systems:443",
                 "elasticsearch_tags": "tag1 tag2"
             },
-            "nns_public_key_exists": true,
+            "use_nns_public_key": true,
             "nns_urls": [
                 "http://localhost"
             ],
-            "node_operator_private_key_exists": true,
+            "use_node_operator_private_key": true,
             "use_ssh_authorized_keys": false,
             "icos_dev_settings": {}
         },

--- a/rs/ic_os/config/src/lib.rs
+++ b/rs/ic_os/config/src/lib.rs
@@ -77,9 +77,7 @@ mod tests {
             mgmt_mac: FormattedMacAddress::try_from("ec:2a:72:31:a2:0c")?,
             deployment_environment: "Mainnet".to_string(),
             logging,
-            nns_public_key_exists: true,
             nns_urls: vec!["http://localhost".parse().unwrap()],
-            node_operator_private_key_exists: true,
             use_ssh_authorized_keys: false,
             icos_dev_settings,
         };
@@ -169,11 +167,9 @@ mod tests {
                 "elasticsearch_hosts": "elasticsearch-node-0.mercury.dfinity.systems:443 elasticsearch-node-1.mercury.dfinity.systems:443",
                 "elasticsearch_tags": "tag1 tag2"
             },
-            "nns_public_key_exists": true,
             "nns_urls": [
                 "http://localhost"
             ],
-            "node_operator_private_key_exists": true,
             "use_ssh_authorized_keys": false,
             "icos_dev_settings": {}
         },
@@ -229,11 +225,9 @@ mod tests {
                 "elasticsearch_hosts": "elasticsearch-node-0.mercury.dfinity.systems:443 elasticsearch-node-1.mercury.dfinity.systems:443",
                 "elasticsearch_tags": "tag1 tag2"
             },
-            "nns_public_key_exists": true,
             "nns_urls": [
                 "http://localhost"
             ],
-            "node_operator_private_key_exists": true,
             "use_ssh_authorized_keys": false,
             "icos_dev_settings": {}
         },

--- a/rs/ic_os/config/src/lib.rs
+++ b/rs/ic_os/config/src/lib.rs
@@ -77,7 +77,9 @@ mod tests {
             mgmt_mac: FormattedMacAddress::try_from("ec:2a:72:31:a2:0c")?,
             deployment_environment: "Mainnet".to_string(),
             logging,
+            nns_public_key_exists: true,
             nns_urls: vec!["http://localhost".parse().unwrap()],
+            node_operator_private_key_exists: true,
             use_ssh_authorized_keys: false,
             icos_dev_settings,
         };
@@ -167,9 +169,11 @@ mod tests {
                 "elasticsearch_hosts": "elasticsearch-node-0.mercury.dfinity.systems:443 elasticsearch-node-1.mercury.dfinity.systems:443",
                 "elasticsearch_tags": "tag1 tag2"
             },
+            "nns_public_key_exists": true,
             "nns_urls": [
                 "http://localhost"
             ],
+            "node_operator_private_key_exists": true,
             "use_ssh_authorized_keys": false,
             "icos_dev_settings": {}
         },
@@ -225,9 +229,11 @@ mod tests {
                 "elasticsearch_hosts": "elasticsearch-node-0.mercury.dfinity.systems:443 elasticsearch-node-1.mercury.dfinity.systems:443",
                 "elasticsearch_tags": "tag1 tag2"
             },
+            "nns_public_key_exists": true,
             "nns_urls": [
                 "http://localhost"
             ],
+            "node_operator_private_key_exists": true,
             "use_ssh_authorized_keys": false,
             "icos_dev_settings": {}
         },

--- a/rs/ic_os/config/src/main.rs
+++ b/rs/ic_os/config/src/main.rs
@@ -24,14 +24,8 @@ pub enum Commands {
         #[arg(long, default_value = config::DEFAULT_SETUPOS_DEPLOYMENT_JSON_PATH, value_name = "deployment.json")]
         deployment_json_path: PathBuf,
 
-        #[arg(long, default_value_t = true)]
-        nns_public_key_exists: bool,
-
         #[arg(long, default_value_t = false)]
         use_ssh_authorized_keys: bool,
-
-        #[arg(long, default_value_t = true)]
-        node_operator_private_key_exists: bool,
 
         #[arg(long, default_value = config::DEFAULT_SETUPOS_CONFIG_OBJECT_PATH, value_name = "config.json")]
         setupos_config_json_path: PathBuf,
@@ -98,11 +92,7 @@ pub struct GenerateTestnetConfigClapArgs {
     #[arg(long)]
     pub elasticsearch_tags: Option<String>,
     #[arg(long)]
-    pub nns_public_key_exists: Option<bool>,
-    #[arg(long)]
     pub nns_urls: Option<Vec<String>>,
-    #[arg(long)]
-    pub node_operator_private_key_exists: Option<bool>,
     #[arg(long)]
     pub use_ssh_authorized_keys: Option<bool>,
 
@@ -146,9 +136,7 @@ pub fn main() -> Result<()> {
         Some(Commands::CreateSetuposConfig {
             config_ini_path,
             deployment_json_path,
-            nns_public_key_exists,
             use_ssh_authorized_keys,
-            node_operator_private_key_exists,
             setupos_config_json_path,
         }) => {
             // get config.ini settings
@@ -225,9 +213,7 @@ pub fn main() -> Result<()> {
                 mgmt_mac,
                 deployment_environment: deployment_json_settings.deployment.name,
                 logging,
-                nns_public_key_exists,
                 nns_urls: deployment_json_settings.nns.url.clone(),
-                node_operator_private_key_exists,
                 use_ssh_authorized_keys,
                 icos_dev_settings: ICOSDevSettings::default(),
             };
@@ -356,9 +342,7 @@ pub fn main() -> Result<()> {
                 deployment_environment: clap_args.deployment_environment,
                 elasticsearch_hosts: clap_args.elasticsearch_hosts,
                 elasticsearch_tags: clap_args.elasticsearch_tags,
-                nns_public_key_exists: clap_args.nns_public_key_exists,
                 nns_urls: clap_args.nns_urls,
-                node_operator_private_key_exists: clap_args.node_operator_private_key_exists,
                 use_ssh_authorized_keys: clap_args.use_ssh_authorized_keys,
                 inject_ic_crypto: clap_args.inject_ic_crypto,
                 inject_ic_state: clap_args.inject_ic_state,

--- a/rs/ic_os/config/src/main.rs
+++ b/rs/ic_os/config/src/main.rs
@@ -24,8 +24,14 @@ pub enum Commands {
         #[arg(long, default_value = config::DEFAULT_SETUPOS_DEPLOYMENT_JSON_PATH, value_name = "deployment.json")]
         deployment_json_path: PathBuf,
 
+        #[arg(long, default_value_t = true)]
+        nns_public_key_exists: bool,
+
         #[arg(long, default_value_t = false)]
         use_ssh_authorized_keys: bool,
+
+        #[arg(long, default_value_t = true)]
+        node_operator_private_key_exists: bool,
 
         #[arg(long, default_value = config::DEFAULT_SETUPOS_CONFIG_OBJECT_PATH, value_name = "config.json")]
         setupos_config_json_path: PathBuf,
@@ -92,7 +98,11 @@ pub struct GenerateTestnetConfigClapArgs {
     #[arg(long)]
     pub elasticsearch_tags: Option<String>,
     #[arg(long)]
+    pub nns_public_key_exists: Option<bool>,
+    #[arg(long)]
     pub nns_urls: Option<Vec<String>>,
+    #[arg(long)]
+    pub node_operator_private_key_exists: Option<bool>,
     #[arg(long)]
     pub use_ssh_authorized_keys: Option<bool>,
 
@@ -136,7 +146,9 @@ pub fn main() -> Result<()> {
         Some(Commands::CreateSetuposConfig {
             config_ini_path,
             deployment_json_path,
+            nns_public_key_exists,
             use_ssh_authorized_keys,
+            node_operator_private_key_exists,
             setupos_config_json_path,
         }) => {
             // get config.ini settings
@@ -213,7 +225,9 @@ pub fn main() -> Result<()> {
                 mgmt_mac,
                 deployment_environment: deployment_json_settings.deployment.name,
                 logging,
+                nns_public_key_exists,
                 nns_urls: deployment_json_settings.nns.url.clone(),
+                node_operator_private_key_exists,
                 use_ssh_authorized_keys,
                 icos_dev_settings: ICOSDevSettings::default(),
             };
@@ -342,7 +356,9 @@ pub fn main() -> Result<()> {
                 deployment_environment: clap_args.deployment_environment,
                 elasticsearch_hosts: clap_args.elasticsearch_hosts,
                 elasticsearch_tags: clap_args.elasticsearch_tags,
+                nns_public_key_exists: clap_args.nns_public_key_exists,
                 nns_urls: clap_args.nns_urls,
+                node_operator_private_key_exists: clap_args.node_operator_private_key_exists,
                 use_ssh_authorized_keys: clap_args.use_ssh_authorized_keys,
                 inject_ic_crypto: clap_args.inject_ic_crypto,
                 inject_ic_state: clap_args.inject_ic_state,

--- a/rs/ic_os/config/src/main.rs
+++ b/rs/ic_os/config/src/main.rs
@@ -25,13 +25,13 @@ pub enum Commands {
         deployment_json_path: PathBuf,
 
         #[arg(long, default_value_t = true)]
-        nns_public_key_exists: bool,
+        use_nns_public_key: bool,
 
         #[arg(long, default_value_t = false)]
         use_ssh_authorized_keys: bool,
 
         #[arg(long, default_value_t = true)]
-        node_operator_private_key_exists: bool,
+        use_node_operator_private_key: bool,
 
         #[arg(long, default_value = config::DEFAULT_SETUPOS_CONFIG_OBJECT_PATH, value_name = "config.json")]
         setupos_config_json_path: PathBuf,
@@ -98,11 +98,11 @@ pub struct GenerateTestnetConfigClapArgs {
     #[arg(long)]
     pub elasticsearch_tags: Option<String>,
     #[arg(long)]
-    pub nns_public_key_exists: Option<bool>,
+    pub use_nns_public_key: Option<bool>,
     #[arg(long)]
     pub nns_urls: Option<Vec<String>>,
     #[arg(long)]
-    pub node_operator_private_key_exists: Option<bool>,
+    pub use_node_operator_private_key: Option<bool>,
     #[arg(long)]
     pub use_ssh_authorized_keys: Option<bool>,
 
@@ -146,9 +146,9 @@ pub fn main() -> Result<()> {
         Some(Commands::CreateSetuposConfig {
             config_ini_path,
             deployment_json_path,
-            nns_public_key_exists,
+            use_nns_public_key,
             use_ssh_authorized_keys,
-            node_operator_private_key_exists,
+            use_node_operator_private_key,
             setupos_config_json_path,
         }) => {
             // get config.ini settings
@@ -225,9 +225,9 @@ pub fn main() -> Result<()> {
                 mgmt_mac,
                 deployment_environment: deployment_json_settings.deployment.name,
                 logging,
-                nns_public_key_exists,
+                use_nns_public_key,
                 nns_urls: deployment_json_settings.nns.url.clone(),
-                node_operator_private_key_exists,
+                use_node_operator_private_key,
                 use_ssh_authorized_keys,
                 icos_dev_settings: ICOSDevSettings::default(),
             };
@@ -356,9 +356,9 @@ pub fn main() -> Result<()> {
                 deployment_environment: clap_args.deployment_environment,
                 elasticsearch_hosts: clap_args.elasticsearch_hosts,
                 elasticsearch_tags: clap_args.elasticsearch_tags,
-                nns_public_key_exists: clap_args.nns_public_key_exists,
+                use_nns_public_key: clap_args.use_nns_public_key,
                 nns_urls: clap_args.nns_urls,
-                node_operator_private_key_exists: clap_args.node_operator_private_key_exists,
+                use_node_operator_private_key: clap_args.use_node_operator_private_key,
                 use_ssh_authorized_keys: clap_args.use_ssh_authorized_keys,
                 inject_ic_crypto: clap_args.inject_ic_crypto,
                 inject_ic_state: clap_args.inject_ic_state,

--- a/rs/ic_os/config/src/types.rs
+++ b/rs/ic_os/config/src/types.rs
@@ -69,10 +69,10 @@ pub struct ICOSSettings {
     /// "mainnet" or "testnet"
     pub deployment_environment: String,
     pub logging: Logging,
-    pub nns_public_key_exists: bool,
+    pub use_nns_public_key: bool,
     /// The URL (HTTP) of the NNS node(s).
     pub nns_urls: Vec<Url>,
-    pub node_operator_private_key_exists: bool,
+    pub use_node_operator_private_key: bool,
     /// This ssh keys directory contains individual files named `admin`, `backup`, `readonly`.
     /// The contents of these files serve as `authorized_keys` for their respective role account.
     /// This means that, for example, `accounts_ssh_authorized_keys/admin`
@@ -209,9 +209,9 @@ mod tests {
                     elasticsearch_hosts: String::new(),
                     elasticsearch_tags: None,
                 },
-                nns_public_key_exists: false,
+                use_nns_public_key: false,
                 nns_urls: vec![],
-                node_operator_private_key_exists: false,
+                use_node_operator_private_key: false,
                 use_ssh_authorized_keys: false,
                 icos_dev_settings: ICOSDevSettings::default(),
             },

--- a/rs/ic_os/config/src/types.rs
+++ b/rs/ic_os/config/src/types.rs
@@ -69,10 +69,8 @@ pub struct ICOSSettings {
     /// "mainnet" or "testnet"
     pub deployment_environment: String,
     pub logging: Logging,
-    pub nns_public_key_exists: bool,
     /// The URL (HTTP) of the NNS node(s).
     pub nns_urls: Vec<Url>,
-    pub node_operator_private_key_exists: bool,
     /// This ssh keys directory contains individual files named `admin`, `backup`, `readonly`.
     /// The contents of these files serve as `authorized_keys` for their respective role account.
     /// This means that, for example, `accounts_ssh_authorized_keys/admin`
@@ -209,9 +207,7 @@ mod tests {
                     elasticsearch_hosts: String::new(),
                     elasticsearch_tags: None,
                 },
-                nns_public_key_exists: false,
                 nns_urls: vec![],
-                node_operator_private_key_exists: false,
                 use_ssh_authorized_keys: false,
                 icos_dev_settings: ICOSDevSettings::default(),
             },

--- a/rs/ic_os/config/src/types.rs
+++ b/rs/ic_os/config/src/types.rs
@@ -69,8 +69,10 @@ pub struct ICOSSettings {
     /// "mainnet" or "testnet"
     pub deployment_environment: String,
     pub logging: Logging,
+    pub nns_public_key_exists: bool,
     /// The URL (HTTP) of the NNS node(s).
     pub nns_urls: Vec<Url>,
+    pub node_operator_private_key_exists: bool,
     /// This ssh keys directory contains individual files named `admin`, `backup`, `readonly`.
     /// The contents of these files serve as `authorized_keys` for their respective role account.
     /// This means that, for example, `accounts_ssh_authorized_keys/admin`
@@ -207,7 +209,9 @@ mod tests {
                     elasticsearch_hosts: String::new(),
                     elasticsearch_tags: None,
                 },
+                nns_public_key_exists: false,
                 nns_urls: vec![],
+                node_operator_private_key_exists: false,
                 use_ssh_authorized_keys: false,
                 icos_dev_settings: ICOSDevSettings::default(),
             },


### PR DESCRIPTION
Renaming use_nns_public_key and use_node_operator_private_key to because 'exists' variables add a layer of indirection from the truth (which is whether the keys actually exist) but 'use' emphasizes that we are using these variable as access controls.