### PR TITLE
feat: [MR-627] Time out messages in subnet queues

### DIFF
--- a/rs/replicated_state/src/replicated_state.rs
+++ b/rs/replicated_state/src/replicated_state.rs
@@ -953,6 +953,14 @@ impl ReplicatedState {
             self.canister_states.insert(canister_id, canister);
         }
 
+        if self.subnet_queues.has_expired_deadlines(current_time) {
+            timed_out_messages_count += self.subnet_queues.time_out_messages(
+                current_time,
+                &self.metadata.own_subnet_id.into(),
+                &self.canister_states,
+            );
+        }
+
         timed_out_messages_count
     }
 

--- a/rs/replicated_state/src/replicated_state.rs
+++ b/rs/replicated_state/src/replicated_state.rs
@@ -387,6 +387,16 @@ pub struct ReplicatedState {
     pub metadata: SystemMetadata,
 
     /// Queues for holding messages sent/received by the subnet.
+    ///
+    /// The Management Canister does not make outgoing calls as itself (it does so
+    /// on behalf of canisters, but those messages are enqueued in the canister's
+    /// output queue). Therefore, there's only a `push_subnet_output_response()`
+    /// method (no equivalent for requests) and an explicit check against inducting
+    /// responses into the subnet queues. This assumption is used in a number of
+    /// places (e.g. when shedding or timing out messages), so adding support for
+    /// outgoing calls in the future will likely require significant changes across
+    /// `ReplicatedState` and `SystemState`.
+    //
     // Must remain private.
     #[validate_eq(CompareWithValidateEq)]
     subnet_queues: CanisterQueues,


### PR DESCRIPTION
Time out best-effort requests in subnet input queues and responses in subnet output queues.

The management canister does not make outgoing calls as itself, so there are no requests in subnet output queues or responses in subnet input queues. Meaning that there are also no `SubnetCallContextManager` callbacks to time out.

We already shed messages from subnet queues, so this is the last missing piece of the puzzle in terms of best-effort message shedding and expiration.