### PR TITLE
fix: increase the keep alive probes.

### DIFF
--- a/rs/p2p/quic_transport/src/connection_manager.rs
+++ b/rs/p2p/quic_transport/src/connection_manager.rs
@@ -77,8 +77,8 @@ const STREAM_RECEIVE_WINDOW: VarInt = VarInt::from_u32(4_000_000);
 const MAX_CONCURRENT_BIDI_STREAMS: VarInt = VarInt::from_u32(1_000);
 const MAX_CONCURRENT_UNI_STREAMS: VarInt = VarInt::from_u32(1_000);
 
-/// Interval of quic heartbeats. They are only sent if the connection is idle for more than 200ms.
-const KEEP_ALIVE_INTERVAL: Duration = Duration::from_millis(200);
+/// Interval of quic heartbeats. They are only sent if the connection is idle for more than 1sec.
+const KEEP_ALIVE_INTERVAL: Duration = Duration::from_secs(1);
 /// Timeout after which quic marks connections as broken. This timeout is used to detect connections
 /// that were not explicitly closed. I.e replica crash
 const IDLE_TIMEOUT: Duration = Duration::from_secs(5);

--- a/rs/p2p/quic_transport/src/metrics.rs
+++ b/rs/p2p/quic_transport/src/metrics.rs
@@ -21,7 +21,7 @@ const ERROR_CLOSED_STREAM: &str = "closed_stream";
 const ERROR_RESET_STREAM: &str = "reset_stream";
 const ERROR_STOPPED_STREAM: &str = "stopped_stream";
 const ERROR_APP_CLOSED_CONN: &str = "app_closed_conn";
-const ERROR_TIMEDOUT_CONN: &str = "timedout_conn";
+const ERROR_TIMED_OUT_CONN: &str = "timed_out_conn";
 const ERROR_LOCALLY_CLOSED_CONN: &str = "locally_closed_conn";
 const ERROR_QUIC_CLOSED_CONN: &str = "quic_closed_conn";
 
@@ -212,7 +212,7 @@ pub fn observe_conn_error(err: &ConnectionError, op: &str, counter: &IntCounterV
             .with_label_values(&[op, ERROR_APP_CLOSED_CONN])
             .inc(),
         // Can happen if peer crashes or there are connectivity problems.
-        ConnectionError::TimedOut => counter.with_label_values(&[op, ERROR_TIMEDOUT_CONN]).inc(),
+        ConnectionError::TimedOut => counter.with_label_values(&[op, ERROR_TIMED_OUT_CONN]).inc(),
         // A connection was closed by the QUIC protocol.
         _ => counter
             .with_label_values(&[op, ERROR_QUIC_CLOSED_CONN])

--- a/rs/p2p/quic_transport/src/metrics.rs
+++ b/rs/p2p/quic_transport/src/metrics.rs
@@ -21,7 +21,7 @@ const ERROR_CLOSED_STREAM: &str = "closed_stream";
 const ERROR_RESET_STREAM: &str = "reset_stream";
 const ERROR_STOPPED_STREAM: &str = "stopped_stream";
 const ERROR_APP_CLOSED_CONN: &str = "app_closed_conn";
-const ERROR_TIMEOUT_CONN: &str = "timeout_conn";
+const ERROR_TIMEDOUT_CONN: &str = "timedout_conn";
 const ERROR_LOCALLY_CLOSED_CONN: &str = "locally_closed_conn";
 const ERROR_QUIC_CLOSED_CONN: &str = "quic_closed_conn";
 
@@ -212,7 +212,7 @@ pub fn observe_conn_error(err: &ConnectionError, op: &str, counter: &IntCounterV
             .with_label_values(&[op, ERROR_APP_CLOSED_CONN])
             .inc(),
         // Can happen if peer crashes or there are connectivity problems.
-        ConnectionError::Timeout => counter.with_label_values(&[op, ERROR_TIMEOUT_CONN]).inc(),
+        ConnectionError::TimedOut => counter.with_label_values(&[op, ERROR_TIMEDOUT_CONN]).inc(),
         // A connection was closed by the QUIC protocol.
         _ => counter
             .with_label_values(&[op, ERROR_QUIC_CLOSED_CONN])


### PR DESCRIPTION
200 ms way to aggressive given we have 5 seconds to timeout the connection due to inactivity. Also the expectation is that transport is used continuously, so there won't be any periods of more than 1 second of inactivity.