### PR TITLE
chore: Create oci tarball for nginx-proxy

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -169,6 +169,16 @@ oci.pull(
     ],
 )
 use_repo(oci, "bitcoind", "bitcoind_linux_amd64")
+
+# nginx-proxy container used in test
+oci.pull(
+    name = "nginx-proxy",
+    image = "ghcr.io/dfinity/nginxproxy/nginx-proxy@sha256:c9ba1ba8a93223305a8bce2ae09024060797698121cd01a48e5cd7462b22faa1",
+    platforms = [
+        "linux/amd64",
+    ],
+use_repo(oci, "nginx_proxy", "nginx_proxy_linux_amd64")
+
 oci.pull(
     name = "jaeger",
     image = "ghcr.io/dfinity/jaegertracing/all-in-one@sha256:836e9b69c88afbedf7683ea7162e179de63b1f981662e83f5ebb68badadc710f",

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -180,6 +180,7 @@ oci.pull(
 )
 use_repo(oci, "nginx-proxy", "nginx-proxy_linux_amd64")
 
+# Used by tests
 oci.pull(
     name = "jaeger",
     image = "ghcr.io/dfinity/jaegertracing/all-in-one@sha256:836e9b69c88afbedf7683ea7162e179de63b1f981662e83f5ebb68badadc710f",

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -177,6 +177,7 @@ oci.pull(
     platforms = [
         "linux/amd64",
     ],
+)
 use_repo(oci, "nginx-proxy", "nginx-proxy_linux_amd64")
 
 oci.pull(

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -177,7 +177,7 @@ oci.pull(
     platforms = [
         "linux/amd64",
     ],
-use_repo(oci, "nginx_proxy", "nginx_proxy_linux_amd64")
+use_repo(oci, "nginx-proxy", "nginx-proxy_linux_amd64")
 
 oci.pull(
     name = "jaeger",


### PR DESCRIPTION
This will be used by #2304 to setup a SSL reverse proxy to connect to a local bitcoind, because https-outcalls require https.
