### PR TITLE
feat: create PocketIC handle for existing PocketIC instance

### DIFF
--- a/packages/pocket-ic/CHANGELOG.md
+++ b/packages/pocket-ic/CHANGELOG.md
@@ -26,6 +26,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The function `PocketIc::install_chunked_canister` to install a canister from WASM chunks in the WASM chunk store of a canister.
 - The function `PocketIc::fetch_canister_logs` to fetch canister logs via a query call to the management canister.
 - The function `Topology::get_subnet` to get a subnet to which a canister belongs independently of whether the canister exists.
+- The function `PocketIc::new_from_existing_instance` to create a PocketIC handle to an existing instance on a running server.
+- The function `PocketIc::get_server_url` returning the URL of the PocketIC server on which the PocketIC instance is running.
 
 ### Removed
 - Functions `PocketIc::from_config`, `PocketIc::from_config_and_max_request_time`, and `PocketIc::from_config_and_server_url`.

--- a/packages/pocket-ic/src/lib.rs
+++ b/packages/pocket-ic/src/lib.rs
@@ -349,6 +349,9 @@ impl PocketIc {
     }
 
     /// Creates a PocketIC handle to an existing instance on a running server.
+    /// Note that this handle does not extend the lifetime of the existing instance,
+    /// i.e., the existing instance is deleted and this handle stops working
+    /// when the PocketIC handle that created the existing instance is dropped.
     pub fn new_from_existing_instance(
         server_url: Url,
         instance_id: InstanceId,

--- a/packages/pocket-ic/src/lib.rs
+++ b/packages/pocket-ic/src/lib.rs
@@ -348,9 +348,32 @@ impl PocketIc {
         PocketIcBuilder::new().with_application_subnet().build()
     }
 
-    /// Returns the instance ID.
-    pub fn instance_id(&self) -> InstanceId {
-        self.pocket_ic.instance_id
+    /// Creates a PocketIC handle to an existing instance on a running server.
+    pub fn new_from_existing_instance(
+        server_url: Url,
+        instance_id: InstanceId,
+        max_request_time_ms: Option<u64>,
+    ) -> Self {
+        let (tx, rx) = channel();
+        let thread = thread::spawn(move || {
+            let rt = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .unwrap();
+            tx.send(rt).unwrap();
+        });
+        let runtime = rx.recv().unwrap();
+
+        let pocket_ic = runtime.block_on(async {
+            PocketIcAsync::new_from_existing_instance(server_url, instance_id, max_request_time_ms)
+                .await
+        });
+
+        Self {
+            pocket_ic,
+            runtime: Arc::new(runtime),
+            thread: Some(thread),
+        }
     }
 
     pub(crate) fn from_components(
@@ -390,6 +413,16 @@ impl PocketIc {
             runtime: Arc::new(runtime),
             thread: Some(thread),
         }
+    }
+
+    /// Returns the URL of the PocketIC server on which this PocketIC instance is running.
+    pub fn get_server_url(&self) -> Url {
+        self.pocket_ic.get_server_url()
+    }
+
+    /// Returns the instance ID.
+    pub fn instance_id(&self) -> InstanceId {
+        self.pocket_ic.instance_id
     }
 
     /// Returns the topology of the different subnets of this PocketIC instance.

--- a/packages/pocket-ic/src/nonblocking.rs
+++ b/packages/pocket-ic/src/nonblocking.rs
@@ -94,6 +94,9 @@ impl PocketIc {
     }
 
     /// Creates a PocketIC handle to an existing instance on a running server.
+    /// Note that this handle does not extend the lifetime of the existing instance,
+    /// i.e., the existing instance is deleted and this handle stops working
+    /// when the PocketIC handle that created the existing instance is dropped.
     pub async fn new_from_existing_instance(
         server_url: Url,
         instance_id: InstanceId,

--- a/packages/pocket-ic/src/nonblocking.rs
+++ b/packages/pocket-ic/src/nonblocking.rs
@@ -78,6 +78,8 @@ pub struct PocketIc {
     http_gateway: Option<HttpGatewayInfo>,
     server_url: Url,
     reqwest_client: reqwest::Client,
+    // do not delete the instance when dropping this handle if this handle was created for an existing instance
+    keep: bool,
     _log_guard: Option<WorkerGuard>,
 }
 
@@ -89,6 +91,29 @@ impl PocketIc {
             .with_application_subnet()
             .build_async()
             .await
+    }
+
+    /// Creates a PocketIC handle to an existing instance on a running server.
+    pub async fn new_from_existing_instance(
+        server_url: Url,
+        instance_id: InstanceId,
+        max_request_time_ms: Option<u64>,
+    ) -> Self {
+        let test_driver_pid = std::process::id();
+        let log_guard = setup_tracing(test_driver_pid);
+
+        let reqwest_client = reqwest::Client::new();
+        debug!("instance_id={} Reusing existing instance.", instance_id);
+
+        Self {
+            instance_id,
+            max_request_time_ms,
+            http_gateway: None,
+            server_url,
+            reqwest_client,
+            keep: true,
+            _log_guard: log_guard,
+        }
     }
 
     pub(crate) async fn from_components(
@@ -139,8 +164,14 @@ impl PocketIc {
             http_gateway: None,
             server_url,
             reqwest_client,
+            keep: false,
             _log_guard: log_guard,
         }
+    }
+
+    /// Returns the URL of the PocketIC server on which this PocketIC instance is running.
+    pub fn get_server_url(&self) -> Url {
+        self.server_url.clone()
     }
 
     /// Returns the topology of the different subnets of this PocketIC instance.
@@ -1266,11 +1297,13 @@ impl PocketIc {
 
     pub(crate) async fn do_drop(&mut self) {
         self.stop_http_gateway().await;
-        self.reqwest_client
-            .delete(self.instance_url())
-            .send()
-            .await
-            .expect("Failed to send delete request");
+        if !self.keep {
+            self.reqwest_client
+                .delete(self.instance_url())
+                .send()
+                .await
+                .expect("Failed to send delete request");
+        }
     }
 
     async fn get<T: DeserializeOwned>(&self, endpoint: &str) -> T {

--- a/packages/pocket-ic/src/nonblocking.rs
+++ b/packages/pocket-ic/src/nonblocking.rs
@@ -79,7 +79,7 @@ pub struct PocketIc {
     server_url: Url,
     reqwest_client: reqwest::Client,
     // do not delete the instance when dropping this handle if this handle was created for an existing instance
-    keep: bool,
+    owns_instance: bool,
     _log_guard: Option<WorkerGuard>,
 }
 
@@ -114,7 +114,7 @@ impl PocketIc {
             http_gateway: None,
             server_url,
             reqwest_client,
-            keep: true,
+            owns_instance: true,
             _log_guard: log_guard,
         }
     }
@@ -167,7 +167,7 @@ impl PocketIc {
             http_gateway: None,
             server_url,
             reqwest_client,
-            keep: false,
+            owns_instance: false,
             _log_guard: log_guard,
         }
     }
@@ -1300,7 +1300,7 @@ impl PocketIc {
 
     pub(crate) async fn do_drop(&mut self) {
         self.stop_http_gateway().await;
-        if !self.keep {
+        if !self.owns_instance {
             self.reqwest_client
                 .delete(self.instance_url())
                 .send()


### PR DESCRIPTION
This PR supports PocketIC handle creation for an existing PocketIC instance. This is necessary for using the PocketIC library in dfx since dfx creates a PocketIC instance in a separate process than the process making a request to the PocketIC instance.