### PR TITLE
test(sns): Add test that all SNS canisters can be upgraded using the advance-target-version mechanism

### DIFF
--- a/rs/nervous_system/agent/src/lib.rs
+++ b/rs/nervous_system/agent/src/lib.rs
@@ -1,6 +1,6 @@
-mod agent_impl;
+pub mod agent_impl;
 pub mod nns;
-mod pocketic_impl;
+pub mod pocketic_impl;
 pub mod sns;
 
 use candid::Principal;

--- a/rs/nervous_system/integration_tests/tests/advance_target_version.rs
+++ b/rs/nervous_system/integration_tests/tests/advance_target_version.rs
@@ -3,7 +3,8 @@ use ic_nervous_system_integration_tests::pocket_ic_helpers::sns;
 use ic_nervous_system_integration_tests::{
     create_service_nervous_system_builder::CreateServiceNervousSystemBuilder,
     pocket_ic_helpers::{
-        add_wasm_via_nns_proposal, add_wasms_to_sns_wasm, install_nns_canisters, nns,
+        add_wasm_via_nns_proposal, add_wasms_to_sns_wasm, hash_sns_wasms, install_nns_canisters,
+        nns,
     },
 };
 use ic_nns_test_utils::sns_wasm::create_modified_sns_wasm;
@@ -16,6 +17,7 @@ use ic_sns_swap::pb::v1::Lifecycle;
 use ic_sns_wasm::pb::v1::SnsCanisterType;
 use pocket_ic::nonblocking::PocketIc;
 use pocket_ic::PocketIcBuilder;
+use std::collections::BTreeMap;
 use std::time::Duration;
 
 /// Verifies that the upgrade journal has the expected entries.
@@ -91,18 +93,18 @@ async fn test_get_upgrade_journal() {
         .build_async()
         .await;
 
-    // Install the (master) NNS canisters.
+    // Step 0: Install the (master) NNS canisters.
     let with_mainnet_nns_canisters = false;
     install_nns_canisters(&pocket_ic, vec![], with_mainnet_nns_canisters, None, vec![]).await;
 
-    // Publish (master) SNS Wasms to SNS-W.
+    // Step 0.1: Publish (master) SNS Wasms to SNS-W.
     let with_mainnet_sns_canisters = false;
     let deployed_sns_starting_info = add_wasms_to_sns_wasm(&pocket_ic, with_mainnet_sns_canisters)
         .await
         .unwrap();
     let initial_sns_version = nns::sns_wasm::get_latest_sns_version(&pocket_ic).await;
 
-    // Deploy an SNS instance via proposal.
+    // Step 0.2: Deploy an SNS instance via proposal.
     let sns = {
         let create_service_nervous_system = CreateServiceNervousSystemBuilder::default().build();
         let swap_parameters = create_service_nervous_system
@@ -130,7 +132,7 @@ async fn test_get_upgrade_journal() {
         sns
     };
 
-    // Step 1: right after SNS creation.
+    // Step 1: Check that the upgrade journal contains the initial version right after SNS creation.
     let mut expected_upgrade_journal_entries = vec![];
     {
         expected_upgrade_journal_entries.push(Event::UpgradeStepsRefreshed(
@@ -323,4 +325,131 @@ async fn test_get_upgrade_journal() {
         )
         .await;
     }
+}
+
+#[tokio::test]
+async fn test_advance_target_version_upgrades_all_canisters() {
+    // Step 0: Setup the test environment.
+    let pocket_ic = PocketIcBuilder::new()
+        .with_nns_subnet()
+        .with_sns_subnet()
+        .build_async()
+        .await;
+
+    // Install the (master) NNS canisters.
+    let with_mainnet_nns_canisters = false;
+    install_nns_canisters(&pocket_ic, vec![], with_mainnet_nns_canisters, None, vec![]).await;
+
+    // Step 0.1: Publish (master) SNS Wasms to SNS-W.
+    let with_mainnet_sns_canisters = false;
+    let initial_sns_version = {
+        let deployed_sns_starting_info =
+            add_wasms_to_sns_wasm(&pocket_ic, with_mainnet_sns_canisters)
+                .await
+                .unwrap();
+        deployed_sns_starting_info
+            .into_iter()
+            .map(|(canister_type, (_, wasm))| (canister_type, wasm))
+            .collect::<BTreeMap<_, _>>()
+    };
+
+    // Step 0.2: Deploy an SNS instance via proposal.
+    let sns = {
+        let create_service_nervous_system = CreateServiceNervousSystemBuilder::default().build();
+        let swap_parameters = create_service_nervous_system
+            .swap_parameters
+            .clone()
+            .unwrap();
+
+        let sns_instance_label = "1";
+        let (sns, _) = nns::governance::propose_to_deploy_sns_and_wait(
+            &pocket_ic,
+            create_service_nervous_system,
+            sns_instance_label,
+        )
+        .await;
+
+        sns::swap::await_swap_lifecycle(&pocket_ic, sns.swap.canister_id, Lifecycle::Open)
+            .await
+            .unwrap();
+        sns::swap::smoke_test_participate_and_finalize(
+            &pocket_ic,
+            sns.swap.canister_id,
+            swap_parameters,
+        )
+        .await;
+        sns
+    };
+
+    // Step 0.3: Ensure an archive canister is spawned.
+    sns::ensure_archive_canister_is_spawned_or_panic(
+        &pocket_ic,
+        sns.governance.canister_id,
+        sns.ledger.canister_id,
+    )
+    .await;
+
+    // Step 2: Publish new SNS versions.
+    let latest_sns_version = {
+        let canister_types = vec![
+            SnsCanisterType::Governance,
+            SnsCanisterType::Root,
+            SnsCanisterType::Swap,
+            SnsCanisterType::Ledger,
+            SnsCanisterType::Index,
+            SnsCanisterType::Archive,
+        ];
+
+        let mut latest_version = initial_sns_version;
+
+        for canister_type in canister_types {
+            latest_version =
+                nns::sns_wasm::modify_and_add_wasm(&pocket_ic, latest_version, canister_type, 1)
+                    .await;
+        }
+
+        latest_version
+    };
+
+    // Step 3: Wait for the upgrade steps to be refreshed.
+    await_with_timeout(
+        &pocket_ic,
+        UPGRADE_STEPS_INTERVAL_REFRESH_BACKOFF_SECONDS,
+        |pocket_ic| async {
+            sns::governance::try_get_upgrade_journal(pocket_ic, sns.governance.canister_id)
+                .await
+                .ok()
+                .and_then(|journal| journal.upgrade_steps)
+                .map(|upgrade_steps| upgrade_steps.versions)
+                .map(|versions| versions.len())
+        },
+        // Hopefully there are 7 upgrade steps - 1 initial version, then another for each of the 6 canisters.
+        &Some(7usize),
+    )
+    .await
+    .unwrap();
+
+    // Step 4: advance the target version to the latest version.
+    let latest_sns_version_hash = hash_sns_wasms(&latest_sns_version);
+    sns::governance::advance_target_version(
+        &pocket_ic,
+        sns.governance.canister_id,
+        latest_sns_version_hash.clone(),
+    )
+    .await;
+
+    // Step 5: Wait for the upgrade to happen
+    await_with_timeout(
+        &pocket_ic,
+        UPGRADE_STEPS_INTERVAL_REFRESH_BACKOFF_SECONDS,
+        |pocket_ic| async {
+            let journal =
+                sns::governance::try_get_upgrade_journal(pocket_ic, sns.governance.canister_id)
+                    .await;
+            journal.ok().and_then(|journal| journal.deployed_version)
+        },
+        &Some(latest_sns_version_hash),
+    )
+    .await
+    .unwrap();
 }


### PR DESCRIPTION
The test is simple - we deploy an SNS, add upgrade steps for all 6 canisters, then advance the target version, then check that the SNS eventually gets to the desired version.

This tests that advance-target-version's upgrade logic is capable of working for all 6 canisters, at least in a normal happy scenario.