### PR TITLE
refactor(nervous_system_agent): Make CallCanisters implementation slightly more generic

### DIFF
--- a/rs/nervous_system/agent/src/agent_impl.rs
+++ b/rs/nervous_system/agent/src/agent_impl.rs
@@ -1,6 +1,6 @@
+use crate::Request;
 use candid::Principal;
 use ic_agent::Agent;
-use ic_nervous_system_clients::Request;
 use thiserror::Error;
 
 use crate::CallCanisters;
@@ -25,10 +25,10 @@ impl CallCanisters for Agent {
         request: R,
     ) -> Result<R::Response, Self::Error> {
         let canister_id = canister_id.into();
-        let request_bytes = candid::encode_one(&request).map_err(AgentCallError::CandidEncode)?;
-        let response = if R::UPDATE {
+        let request_bytes = request.payload();
+        let response = if request.update() {
             let request = self
-                .update(&canister_id, R::METHOD)
+                .update(&canister_id, request.method())
                 .with_arg(request_bytes)
                 .call()
                 .await?;
@@ -39,7 +39,7 @@ impl CallCanisters for Agent {
                 }
             }
         } else {
-            self.query(&canister_id, R::METHOD)
+            self.query(&canister_id, request.method())
                 .with_arg(request_bytes)
                 .call()
                 .await?

--- a/rs/nervous_system/agent/src/lib.rs
+++ b/rs/nervous_system/agent/src/lib.rs
@@ -1,10 +1,11 @@
 pub mod agent_impl;
 pub mod nns;
+mod null_request;
 pub mod pocketic_impl;
 pub mod sns;
 
-use candid::Principal;
-use ic_nervous_system_clients::Request;
+use candid::{CandidType, Principal};
+use serde::de::DeserializeOwned;
 use std::fmt::Display;
 
 // This is used to "seal" the CallCanisters trait so that it cannot be implemented outside of this crate.
@@ -12,6 +13,31 @@ use std::fmt::Display;
 // breaking backwards compatibility with implementations outside of this crate.
 mod sealed {
     pub trait Sealed {}
+}
+
+/// An implementation of the request trait that is used internally by this crate.
+/// It is separate from the one in ic_nervous_system_clients because that one makes certain simplifying assumptions
+/// that are not valid for all requests made by this crate.
+/// When in doubt, prefer implementing the trait in ic_nervous_system_clients over this one.
+pub trait Request: Send {
+    fn method(&self) -> &'static str;
+    fn update(&self) -> bool;
+    fn payload(&self) -> Vec<u8>;
+    type Response: CandidType + DeserializeOwned;
+}
+
+impl<R: ic_nervous_system_clients::Request> Request for R {
+    fn method(&self) -> &'static str {
+        Self::METHOD
+    }
+    fn update(&self) -> bool {
+        Self::UPDATE
+    }
+    fn payload(&self) -> Vec<u8> {
+        candid::encode_one(self).unwrap()
+    }
+
+    type Response = <Self as ic_nervous_system_clients::Request>::Response;
 }
 
 pub trait CallCanisters: sealed::Sealed {

--- a/rs/nervous_system/agent/src/null_request.rs
+++ b/rs/nervous_system/agent/src/null_request.rs
@@ -1,0 +1,35 @@
+use candid::{CandidType, Encode};
+use serde::de::DeserializeOwned;
+
+use crate::Request;
+
+/// Implement a "null request" that can be used to call a canister method whose argument type is `null`.
+pub struct NullRequest<T> {
+    method_name: &'static str,
+    update: bool,
+    _phantom: std::marker::PhantomData<T>,
+}
+
+impl<T: CandidType + DeserializeOwned> NullRequest<T> {
+    pub fn new(method_name: &'static str, update: bool) -> Self {
+        Self {
+            method_name,
+            update,
+            _phantom: std::marker::PhantomData,
+        }
+    }
+}
+
+impl<T: CandidType + DeserializeOwned + Send> Request for NullRequest<T> {
+    fn method(&self) -> &'static str {
+        self.method_name
+    }
+    fn update(&self) -> bool {
+        self.update
+    }
+    fn payload(&self) -> Vec<u8> {
+        Encode!().unwrap()
+    }
+
+    type Response = T;
+}

--- a/rs/nervous_system/agent/src/pocketic_impl.rs
+++ b/rs/nervous_system/agent/src/pocketic_impl.rs
@@ -1,5 +1,5 @@
+use crate::Request;
 use candid::Principal;
-use ic_nervous_system_clients::Request;
 use pocket_ic::nonblocking::PocketIc;
 use thiserror::Error;
 
@@ -27,13 +27,12 @@ impl CallCanisters for PocketIc {
         request: R,
     ) -> Result<R::Response, Self::Error> {
         let canister_id = canister_id.into();
-        let request_bytes =
-            candid::encode_one(&request).map_err(PocketIcCallError::CandidEncode)?;
-        let response = if R::UPDATE {
+        let request_bytes = request.payload();
+        let response = if request.update() {
             self.update_call(
                 canister_id,
                 Principal::anonymous(),
-                R::METHOD,
+                request.method(),
                 request_bytes,
             )
             .await
@@ -41,7 +40,7 @@ impl CallCanisters for PocketIc {
             self.query_call(
                 canister_id,
                 Principal::anonymous(),
-                R::METHOD,
+                request.method(),
                 request_bytes,
             )
             .await

--- a/rs/nervous_system/agent/src/sns/governance.rs
+++ b/rs/nervous_system/agent/src/sns/governance.rs
@@ -1,8 +1,8 @@
-use crate::CallCanisters;
+use crate::{null_request::NullRequest, CallCanisters};
 use ic_base_types::PrincipalId;
 use ic_sns_governance::pb::v1::{
     GetMetadataRequest, GetMetadataResponse, GetMode, GetModeResponse, GetRunningSnsVersionRequest,
-    GetRunningSnsVersionResponse,
+    GetRunningSnsVersionResponse, NervousSystemParameters,
 };
 use serde::{Deserialize, Serialize};
 
@@ -30,6 +30,14 @@ impl GovernanceCanister {
 
     pub async fn get_mode<C: CallCanisters>(&self, agent: &C) -> Result<GetModeResponse, C::Error> {
         agent.call(self.canister_id, GetMode {}).await
+    }
+
+    pub async fn get_nervous_system_parameters<C: CallCanisters>(
+        &self,
+        agent: &C,
+    ) -> Result<NervousSystemParameters, C::Error> {
+        let request = NullRequest::new("get_nervous_system_parameters", false);
+        agent.call(self.canister_id, request).await
     }
 }
 

--- a/rs/nervous_system/integration_tests/src/pocket_ic_helpers.rs
+++ b/rs/nervous_system/integration_tests/src/pocket_ic_helpers.rs
@@ -1336,6 +1336,7 @@ pub mod sns {
     pub mod governance {
         use super::*;
         use ic_crypto_sha2::Sha256;
+        use ic_nervous_system_agent::sns::governance::GovernanceCanister;
         use ic_sns_governance::pb::v1::get_neuron_response;
         use pocket_ic::ErrorCode;
 
@@ -1545,29 +1546,15 @@ pub mod sns {
                 })
         }
 
+        /// This function is a wrapper around `GovernanceCanister::get_nervous_system_parameters`, kept here for convenience.
         pub async fn get_nervous_system_parameters(
             pocket_ic: &PocketIc,
             canister_id: PrincipalId,
         ) -> sns_pb::NervousSystemParameters {
-            let result = pocket_ic
-                .query_call(
-                    canister_id.into(),
-                    Principal::from(PrincipalId::new_anonymous()),
-                    "get_nervous_system_parameters",
-                    Encode!().unwrap(),
-                )
+            GovernanceCanister { canister_id }
+                .get_nervous_system_parameters(pocket_ic)
                 .await
-                .unwrap();
-            let result = match result {
-                WasmResult::Reply(reply) => reply,
-                WasmResult::Reject(reject) => {
-                    panic!(
-                        "get_nervous_system_parameters rejected by SNS governance: {:#?}",
-                        reject
-                    )
-                }
-            };
-            Decode!(&result, sns_pb::NervousSystemParameters).unwrap()
+                .unwrap()
         }
 
         pub async fn propose_to_advance_sns_target_version(

--- a/rs/nervous_system/integration_tests/tests/sns_lifecycle.rs
+++ b/rs/nervous_system/integration_tests/tests/sns_lifecycle.rs
@@ -419,9 +419,11 @@ async fn test_sns_lifecycle(
         swap_distribution_sns_e8s,
     );
 
-    let nervous_system_parameters =
-        sns::governance::get_nervous_system_parameters(&pocket_ic, sns.governance.canister_id)
-            .await;
+    let nervous_system_parameters = sns
+        .governance
+        .get_nervous_system_parameters(&pocket_ic)
+        .await
+        .unwrap();
     let swap_init = sns::swap::get_init(&pocket_ic, sns.swap.canister_id)
         .await
         .init


### PR DESCRIPTION
The `Request` trait in ic_nervous_system_clients is overly restrictive, as it assumes that all canister endpoints take exactly one argument. This is the case 99% of the time for our canisters, so it's nice to have, but for those cases where a canister endpoint takes 0 arguments, it's we need a more general option. This PR adds a trait that is flexible w.r.t. the number of argument, and makes use of it in ic_nervous_system_agent. There is also a blanket implementation, so anything that implements the old trait also implements the new trait.  

This adds a small amount of unfortunate complexity, but the benefit is large, because it means that we can now use CallCanisters for types which we could not implement `ic_nervous_system_clients::Request` for. I demonstrate this by adding a NullRequest type (which was the real motivation for this change), and using it to implement `get_nervous_system_parameters` as a proof of concept