### PR TITLE
fix: Drop duplicate responses in `induct_messages_to_self`

### DIFF
--- a/rs/replicated_state/src/canister_state/queues.rs
+++ b/rs/replicated_state/src/canister_state/queues.rs
@@ -1185,7 +1185,11 @@ impl CanisterQueues {
         dst_canister: &CanisterId,
     ) -> Option<RequestOrResponse> {
         let queue = &mut self.canister_queues.get_mut(dst_canister)?.1;
-        self.store.queue_pop_and_advance(queue)
+        let msg = self.store.queue_pop_and_advance(queue);
+
+        debug_assert_eq!(Ok(()), self.test_invariants());
+        debug_assert_eq!(Ok(()), self.schedules_ok(&|_| InputQueueType::RemoteSubnet));
+        msg
     }
 
     /// Tries to induct a message from the output queue to `own_canister_id`

--- a/rs/replicated_state/src/canister_state/queues.rs
+++ b/rs/replicated_state/src/canister_state/queues.rs
@@ -1179,6 +1179,15 @@ impl CanisterQueues {
         Some(self.store.get(output_queue.peek()?))
     }
 
+    /// Pops the next message from the output queue to `dst_canister`.
+    pub(super) fn pop_canister_output(
+        &mut self,
+        dst_canister: &CanisterId,
+    ) -> Option<RequestOrResponse> {
+        let queue = &mut self.canister_queues.get_mut(dst_canister)?.1;
+        self.store.queue_pop_and_advance(queue)
+    }
+
     /// Tries to induct a message from the output queue to `own_canister_id`
     /// into the input queue from `own_canister_id`. Returns `Err(())` if there
     /// was no message to induct or the input queue was full.
@@ -2021,8 +2030,7 @@ pub mod testing {
         /// Returns the number of messages in `ingress_queue`.
         fn ingress_queue_size(&self) -> usize;
 
-        /// Pops the next message from the output queue associated with
-        /// `dst_canister`.
+        /// Pops the next message from the output queue to `dst_canister`.
         fn pop_canister_output(&mut self, dst_canister: &CanisterId) -> Option<RequestOrResponse>;
 
         /// Returns the number of output queues, empty or not.
@@ -2058,8 +2066,7 @@ pub mod testing {
         }
 
         fn pop_canister_output(&mut self, dst_canister: &CanisterId) -> Option<RequestOrResponse> {
-            let queue = &mut self.canister_queues.get_mut(dst_canister).unwrap().1;
-            self.store.queue_pop_and_advance(queue)
+            self.pop_canister_output(dst_canister)
         }
 
         fn output_queues_len(&self) -> usize {

--- a/rs/replicated_state/src/canister_state/system_state.rs
+++ b/rs/replicated_state/src/canister_state/system_state.rs
@@ -1951,10 +1951,12 @@ impl SystemState {
         own_subnet_type: SubnetType,
     ) {
         // Bail out if the canister is not running.
-        match self.status {
-            CanisterStatus::Running { .. } => (),
+        let call_context_manager = match &self.status {
+            CanisterStatus::Running {
+                call_context_manager,
+            } => call_context_manager,
             CanisterStatus::Stopped | CanisterStatus::Stopping { .. } => return,
-        }
+        };
 
         let mut memory_usage = self.queues.guaranteed_response_memory_usage() as i64;
 
@@ -1966,16 +1968,26 @@ impl SystemState {
                 return;
             }
 
-            // Protect against enqueuing a second response for the currently executing
-            // (aborted or paused) callback.
+            // Protect against enqueuing duplicate responses.
             if let RequestOrResponse::Response(response) = &msg {
-                if let Some(aborted_or_paused_response) = self.aborted_or_paused_response() {
-                    if response.originator_reply_callback
-                        == aborted_or_paused_response.originator_reply_callback
-                    {
-                        // The callback is already executing, don't enqueue a second response for it.
-                        return;
+                match should_enqueue_input(
+                    response,
+                    call_context_manager,
+                    self.aborted_or_paused_response(),
+                ) {
+                    // Safe to induct.
+                    Ok(true) => {}
+
+                    // Best effort response whose callback is gone. Silently drop it.
+                    Ok(false) => {
+                        self.queues
+                            .pop_canister_output(&self.canister_id)
+                            .expect("Message peeked above so pop should not fail.");
+                        continue;
                     }
+
+                    // This should not happen. Bail out and let Message Routing deal with it.
+                    Err(_) => return,
                 }
             }
 

--- a/rs/replicated_state/src/canister_state/tests.rs
+++ b/rs/replicated_state/src/canister_state/tests.rs
@@ -416,21 +416,30 @@ fn canister_state_push_input_best_effort_response_duplicate_of_paused_response()
 
 #[test]
 fn canister_state_induct_messages_to_self_guaranteed_response_duplicate_of_paused_response() {
+    canister_state_induct_messages_to_self_duplicate_of_paused_response(NO_DEADLINE);
+}
+
+#[test]
+fn canister_state_induct_messages_to_self_best_effort_duplicate_of_paused_response() {
+    canister_state_induct_messages_to_self_duplicate_of_paused_response(SOME_DEADLINE);
+}
+
+fn canister_state_induct_messages_to_self_duplicate_of_paused_response(deadline: CoarseTime) {
     let mut fixture = CanisterStateFixture::new();
 
     // Pair of request and response to self.
-    let callback_id = fixture.make_callback_to(CANISTER_ID, SOME_DEADLINE);
+    let callback_id = fixture.make_callback_to(CANISTER_ID, deadline);
     let request = RequestBuilder::default()
         .sender(CANISTER_ID)
         .receiver(CANISTER_ID)
         .sender_reply_callback(callback_id)
-        .deadline(SOME_DEADLINE)
+        .deadline(deadline)
         .build();
     let response = ResponseBuilder::default()
         .originator(CANISTER_ID)
         .respondent(CANISTER_ID)
         .originator_reply_callback(callback_id)
-        .deadline(SOME_DEADLINE)
+        .deadline(deadline)
         .build();
 
     // Make an input queue slot reservation.
@@ -483,10 +492,12 @@ fn canister_state_induct_messages_to_self_guaranteed_response_duplicate_of_pause
         &mut SUBNET_AVAILABLE_MEMORY.clone(),
         SubnetType::Application,
     );
+
     // Nothing was enqueued.
     assert!(!fixture.canister_state.has_input());
-    // And the response is gone from the output queue.
-    assert!(!fixture.canister_state.has_output());
+    // And the response should be silently consumed if best-effort; retained if
+    // guaranteed response.
+    assert_eq!(deadline == NO_DEADLINE, fixture.canister_state.has_output());
 }
 
 #[test]

--- a/rs/replicated_state/src/canister_state/tests.rs
+++ b/rs/replicated_state/src/canister_state/tests.rs
@@ -485,8 +485,8 @@ fn canister_state_induct_messages_to_self_guaranteed_response_duplicate_of_pause
     );
     // Nothing was enqueued.
     assert!(!fixture.canister_state.has_input());
-    // And the response is still in the output queue.
-    assert!(fixture.canister_state.has_output());
+    // And the response is gone from the output queue.
+    assert!(!fixture.canister_state.has_output());
 }
 
 #[test]

--- a/rs/replicated_state/tests/system_state.rs
+++ b/rs/replicated_state/tests/system_state.rs
@@ -434,10 +434,7 @@ fn induct_messages_to_self_callback_gone() {
 
     // Pop and start executing it (pretend it's waiting for multiple rounds for
     // downstream calls).
-    assert_eq!(
-        Some(CanisterMessage::Request(request.clone().into())),
-        fixture.pop_input()
-    );
+    assert_eq!(Some(CanisterMessage::Request(request)), fixture.pop_input());
 
     // Expire the callback.
     fixture.time_out_callbacks(CoarseTime::from_secs_since_unix_epoch(u32::MAX));


### PR DESCRIPTION
`CanisterQueues` checks against duplicate responses for a given callback, but relies on `SystemState` to ensure that these are existent callbacks (other than the potential paused or aborted execution). `SystemState` already made this check this in `push_input()`. Also do the check in `induct_messages_to_self()`.