### PR TITLE
perf(nns): Add benchmarks for periodic tasks

### DIFF
--- a/rs/nns/governance/canbench/canbench_results.yml
+++ b/rs/nns/governance/canbench/canbench_results.yml
@@ -1,91 +1,115 @@
 benches:
   add_neuron_active_maximum:
     total:
-      instructions: 35887686
+      instructions: 35992698
       heap_increase: 1
       stable_memory_increase: 0
     scopes: {}
   add_neuron_active_typical:
     total:
-      instructions: 1833590
+      instructions: 1838632
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   add_neuron_inactive_maximum:
     total:
-      instructions: 98494555
+      instructions: 98666560
       heap_increase: 1
       stable_memory_increase: 0
     scopes: {}
   add_neuron_inactive_typical:
     total:
-      instructions: 7593880
+      instructions: 7577551
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   cascading_vote_all_heap:
     total:
-      instructions: 32187827
+      instructions: 32302982
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   cascading_vote_heap_neurons_stable_index:
     total:
-      instructions: 54527506
+      instructions: 54494918
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   cascading_vote_stable_everything:
     total:
-      instructions: 1978888007
+      instructions: 1969690886
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   cascading_vote_stable_neurons_with_heap_index:
     total:
-      instructions: 1956237656
+      instructions: 1947188278
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   centralized_following_all_stable:
     total:
-      instructions: 2057421983
+      instructions: 2047356165
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   compute_ballots_for_new_proposal_with_stable_neurons:
     total:
-      instructions: 1685116
+      instructions: 1743731
+      heap_increase: 0
+      stable_memory_increase: 0
+    scopes: {}
+  list_neurons_ready_to_unstake_maturity_heap:
+    total:
+      instructions: 3441869
+      heap_increase: 0
+      stable_memory_increase: 0
+    scopes: {}
+  list_neurons_ready_to_unstake_maturity_stable:
+    total:
+      instructions: 710546759
+      heap_increase: 0
+      stable_memory_increase: 0
+    scopes: {}
+  list_ready_to_spawn_neuron_ids_heap:
+    total:
+      instructions: 3438794
+      heap_increase: 0
+      stable_memory_increase: 0
+    scopes: {}
+  list_ready_to_spawn_neuron_ids_stable:
+    total:
+      instructions: 710543948
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   neuron_metrics_calculation_heap:
     total:
-      instructions: 840837
+      instructions: 845137
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   neuron_metrics_calculation_stable:
     total:
-      instructions: 1834053
+      instructions: 1835769
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   range_neurons_performance:
     total:
-      instructions: 48615662
+      instructions: 47339494
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   single_vote_all_stable:
     total:
-      instructions: 13224969
+      instructions: 13161102
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   update_recent_ballots:
     total:
-      instructions: 16275553
+      instructions: 16208293
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}

--- a/rs/nns/governance/src/neuron_store/benches.rs
+++ b/rs/nns/governance/src/neuron_store/benches.rs
@@ -82,15 +82,19 @@ fn new_rng() -> StdRng {
     StdRng::seed_from_u64(42)
 }
 
-fn build_neuron(rng: &mut impl RngCore, location: NeuronLocation, size: NeuronSize) -> Neuron {
-    let id = rng.next_u64();
-
+fn subaccount_from_id(id: u64) -> Subaccount {
     let mut account = vec![0; 32];
     // Populate account so that it's not all zeros.
     for (destination, data) in account.iter_mut().zip(id.to_le_bytes().iter().cycle()) {
         *destination = *data;
     }
-    let subaccount = Subaccount::try_from(account.as_slice()).unwrap();
+    Subaccount::try_from(account.as_slice()).unwrap()
+}
+
+fn build_neuron(rng: &mut impl RngCore, location: NeuronLocation, size: NeuronSize) -> Neuron {
+    let id = rng.next_u64();
+
+    let subaccount = subaccount_from_id(id);
     let hot_keys = (0..size.num_hot_keys())
         .map(|_| PrincipalId::new_user_test_id(rng.next_u64()))
         .collect();
@@ -231,7 +235,7 @@ fn range_neurons_performance() -> BenchResult {
 
 #[bench(raw)]
 fn neuron_metrics_calculation_heap() -> BenchResult {
-    let _ = temporarily_disable_active_neurons_in_stable_memory();
+    let _f = temporarily_disable_active_neurons_in_stable_memory();
     let mut rng = new_rng();
     let neuron_store = set_up_neuron_store(&mut rng, 100, 0);
 
@@ -245,8 +249,92 @@ fn neuron_metrics_calculation_stable() -> BenchResult {
     let mut rng = new_rng();
     let neuron_store = set_up_neuron_store(&mut rng, 100, 0);
 
+    bench_fn(|| neuron_store.compute_neuron_metrics(now_seconds(), E8))
+}
+
+fn add_neuron_ready_to_spawn(
+    now_seconds: u64,
+    rng: &mut impl RngCore,
+    neuron_store: &mut NeuronStore,
+) {
+    let id = rng.next_u64();
+    let subaccount = subaccount_from_id(id);
+    let neuron = NeuronBuilder::new(
+        NeuronId { id: rng.next_u64() },
+        subaccount,
+        PrincipalId::new_user_test_id(id),
+        DissolveStateAndAge::DissolvingOrDissolved {
+            when_dissolved_timestamp_seconds: now_seconds,
+        },
+        123_456_789,
+    )
+    .with_spawn_at_timestamp_seconds(now_seconds)
+    .with_maturity_e8s_equivalent(1_000_000_000)
+    .build();
+    neuron_store.add_neuron(neuron).unwrap();
+}
+
+#[bench(raw)]
+fn list_ready_to_spawn_neuron_ids_heap() -> BenchResult {
+    let _t = temporarily_disable_active_neurons_in_stable_memory();
+    let mut rng = new_rng();
+    let mut neuron_store = set_up_neuron_store(&mut rng, 1_000, 2_000);
+    add_neuron_ready_to_spawn(now_seconds(), &mut rng, &mut neuron_store);
+
+    bench_fn(|| neuron_store.list_ready_to_spawn_neuron_ids(now_seconds()))
+}
+
+#[bench(raw)]
+fn list_ready_to_spawn_neuron_ids_stable() -> BenchResult {
+    let _t = temporarily_enable_active_neurons_in_stable_memory();
+    let mut rng = new_rng();
+    let mut neuron_store = set_up_neuron_store(&mut rng, 1_000, 2_000);
+    add_neuron_ready_to_spawn(now_seconds(), &mut rng, &mut neuron_store);
+
     bench_fn(|| {
-        let _ = temporarily_enable_active_neurons_in_stable_memory();
-        neuron_store.compute_neuron_metrics(now_seconds(), E8)
+        neuron_store.list_ready_to_spawn_neuron_ids(now_seconds());
+    })
+}
+
+fn add_neuron_ready_to_unstake_maturity(
+    now_seconds: u64,
+    rng: &mut impl RngCore,
+    neuron_store: &mut NeuronStore,
+) {
+    let id = rng.next_u64();
+    let subaccount = subaccount_from_id(id);
+    let mut neuron = NeuronBuilder::new(
+        NeuronId { id: rng.next_u64() },
+        subaccount,
+        PrincipalId::new_user_test_id(id),
+        DissolveStateAndAge::DissolvingOrDissolved {
+            when_dissolved_timestamp_seconds: now_seconds,
+        },
+        123_456_789,
+    )
+    .build();
+    neuron.staked_maturity_e8s_equivalent = Some(1_000_000_000);
+    neuron_store.add_neuron(neuron).unwrap();
+}
+
+#[bench(raw)]
+fn list_neurons_ready_to_unstake_maturity_heap() -> BenchResult {
+    let _t = temporarily_disable_active_neurons_in_stable_memory();
+    let mut rng = new_rng();
+    let mut neuron_store = set_up_neuron_store(&mut rng, 1_000, 2_000);
+    add_neuron_ready_to_unstake_maturity(now_seconds(), &mut rng, &mut neuron_store);
+
+    bench_fn(|| neuron_store.list_neurons_ready_to_unstake_maturity(now_seconds()))
+}
+
+#[bench(raw)]
+fn list_neurons_ready_to_unstake_maturity_stable() -> BenchResult {
+    let _t = temporarily_enable_active_neurons_in_stable_memory();
+    let mut rng = new_rng();
+    let mut neuron_store = set_up_neuron_store(&mut rng, 1_000, 2_000);
+    add_neuron_ready_to_unstake_maturity(now_seconds(), &mut rng, &mut neuron_store);
+
+    bench_fn(|| {
+        neuron_store.list_neurons_ready_to_unstake_maturity(now_seconds());
     })
 }


### PR DESCRIPTION
# Why

There was a recent regression on how we list neurons ready to unstake maturity or spawn. Adding benchmarks for those will help prevent them in the future (although, currently they are not enabled in CI yet).

# What

Adding benchmarks for `list_ready_to_spawn_neuron_ids` and `list_neurons_ready_to_unstake_maturity`. Additional dimensions are: (1) whether the "active neuron in stable memory" is enabled (2) whether there are actually meaningful return value.

# Testing

When running against changes in https://github.com/dfinity/ic/pull/2726 , we get the following results:

---------------------------------------------------
Benchmark: list_ready_to_spawn_neuron_ids_heap
  total:
    instructions: 455.22 K (improved by 86.76%)
    heap_increase: 0 pages (no change)
    stable_memory_increase: 0 pages (no change)

---------------------------------------------------

Benchmark: list_ready_to_spawn_neuron_ids_stable
  total:
    instructions: 710.56 M (0.00%) (change within noise threshold)
    heap_increase: 0 pages (no change)
    stable_memory_increase: 0 pages (no change)

---------------------------------------------------

Benchmark: list_neurons_ready_to_unstake_maturity_heap
  total:
    instructions: 463.15 K (improved by 86.54%)
    heap_increase: 0 pages (no change)
    stable_memory_increase: 0 pages (no change)

---------------------------------------------------

Benchmark: list_neurons_ready_to_unstake_maturity_stable
  total:
    instructions: 710.57 M (0.00%) (change within noise threshold)
    heap_increase: 0 pages (no change)
    stable_memory_increase: 0 pages (no change)

---------------------------------------------------

