### PR TITLE
chore(fuzzing): Allow `no_op_logger` in StateMachine

### DIFF
--- a/rs/execution_environment/fuzz/BUILD.bazel
+++ b/rs/execution_environment/fuzz/BUILD.bazel
@@ -49,7 +49,6 @@ SYSTEM_API_FUZZ_DEPENDENCIES = [
     "//rs/types/management_canister_types",
     "//rs/types/types",
     "@crate_index//:libfuzzer-sys",
-    "@crate_index//:slog",
     "@crate_index//:wat",
 ]
 

--- a/rs/execution_environment/fuzz/fuzz_targets/execute_system_api_call.rs
+++ b/rs/execution_environment/fuzz/fuzz_targets/execute_system_api_call.rs
@@ -9,7 +9,6 @@ use ic_state_machine_tests::{StateMachine, StateMachineBuilder, StateMachineConf
 use ic_types::{CanisterId, Cycles, NumBytes};
 
 use libfuzzer_sys::fuzz_target;
-use slog::Level;
 use std::cell::RefCell;
 use wasm_fuzzers::ic_wasm::ICWasmModule;
 
@@ -77,7 +76,7 @@ fn setup_env() -> (StateMachine, CanisterId) {
         .with_config(Some(config))
         .with_subnet_type(subnet_type)
         .with_checkpoints_enabled(false)
-        .with_log_level(Some(Level::Critical))
+        .with_log_level(None)
         .build();
     let canister_id = env.create_canister_with_cycles(
         None,

--- a/rs/state_machine_tests/src/lib.rs
+++ b/rs/state_machine_tests/src/lib.rs
@@ -43,6 +43,7 @@ use ic_interfaces_certified_stream_store::{CertifiedStreamStore, EncodeStreamErr
 use ic_interfaces_registry::RegistryClient;
 use ic_interfaces_state_manager::{CertificationScope, StateHashError, StateManager, StateReader};
 use ic_limits::{MAX_INGRESS_TTL, PERMITTED_DRIFT, SMALL_APP_SUBNET_MAX_SIZE};
+use ic_logger::replica_logger::no_op_logger;
 use ic_logger::{error, ReplicaLogger};
 use ic_management_canister_types::{
     self as ic00, CanisterIdRecord, InstallCodeArgs, MasterPublicKeyId, Method, Payload,
@@ -463,24 +464,25 @@ fn into_cbor<R: Serialize>(r: &R) -> Vec<u8> {
 
 fn replica_logger(log_level: Option<Level>) -> ReplicaLogger {
     use slog::Drain;
-    let log_level = log_level
-        .or(std::env::var("RUST_LOG")
-            .ok()
-            .and_then(|level| Level::from_str(&level).ok()))
-        .unwrap_or(Level::Warning);
-
-    let writer: Box<dyn io::Write + Sync + Send> = if std::env::var("LOG_TO_STDERR").is_ok() {
-        Box::new(stderr())
+    if let Some(log_level) = log_level.or(std::env::var("RUST_LOG")
+        .ok()
+        .and_then(|level| Level::from_str(&level).ok()))
+    {
+        let writer: Box<dyn io::Write + Sync + Send> = if std::env::var("LOG_TO_STDERR").is_ok() {
+            Box::new(stderr())
+        } else {
+            Box::new(slog_term::TestStdoutWriter)
+        };
+        let decorator = slog_term::PlainSyncDecorator::new(writer);
+        let drain = slog_term::FullFormat::new(decorator)
+            .build()
+            .filter_level(log_level)
+            .fuse();
+        let logger = slog::Logger::root(drain, slog::o!());
+        logger.into()
     } else {
-        Box::new(slog_term::TestStdoutWriter)
-    };
-    let decorator = slog_term::PlainSyncDecorator::new(writer);
-    let drain = slog_term::FullFormat::new(decorator)
-        .build()
-        .filter_level(log_level)
-        .fuse();
-    let logger = slog::Logger::root(drain, slog::o!());
-    logger.into()
+        no_op_logger()
+    }
 }
 
 /// Bundles the configuration of a `StateMachine`.
@@ -955,7 +957,7 @@ impl StateMachineBuilder {
             is_root_subnet: false,
             seed: [42; 32],
             with_extra_canister_range: None,
-            log_level: None,
+            log_level: Some(Level::Warning),
             bitcoin_testnet_uds_path: None,
         }
     }

--- a/rs/state_machine_tests/src/lib.rs
+++ b/rs/state_machine_tests/src/lib.rs
@@ -464,9 +464,10 @@ fn into_cbor<R: Serialize>(r: &R) -> Vec<u8> {
 
 fn replica_logger(log_level: Option<Level>) -> ReplicaLogger {
     use slog::Drain;
-    if let Some(log_level) = log_level.or(std::env::var("RUST_LOG")
+    if let Some(log_level) = std::env::var("RUST_LOG")
         .ok()
-        .and_then(|level| Level::from_str(&level).ok()))
+        .and_then(|level| Level::from_str(&level).ok())
+        .or(log_level)
     {
         let writer: Box<dyn io::Write + Sync + Send> = if std::env::var("LOG_TO_STDERR").is_ok() {
             Box::new(stderr())


### PR DESCRIPTION
Currently, the StateMachine sets `log_level: None` by default and switches it to `Warning` in `fn replica_logger`, which is counterintuitive. The PR addresses it by setting the value default to `Some(Level::Warning)` and if `None` is passed, `no_op_logger` is used.

This is required for fuzzing, since we maintain a StateMachine invocation in a global state and would need to reduce it's memory footprint as much as possible for fuzzing long hours. 