### PR TITLE
refactor(cketh/ckerc20): mark older helper smart contracts as deprecated

### DIFF
--- a/rs/ethereum/cketh/minter/cketh_minter.did
+++ b/rs/ethereum/cketh/minter/cketh_minter.did
@@ -201,9 +201,6 @@ type MinterInfo = record {
     // Last scraped block number for logs of the ERC20 helper contract.
     last_erc20_scraped_block_number: opt nat;
 
-    // Last scraped block number for logs of the deposit with subaccount helper contract.
-    last_deposit_with_subaccount_scraped_block_number: opt nat;
-
     // Canister ID of the ckETH ledger.
     cketh_ledger_id: opt principal;
 

--- a/rs/ethereum/cketh/minter/src/dashboard/tests.rs
+++ b/rs/ethereum/cketh/minter/src/dashboard/tests.rs
@@ -1293,7 +1293,7 @@ mod assertions {
         pub fn has_last_synced_block_href(&self, id: LogScrapingId, expected_href: &str) -> &Self {
             self.has_href_value(
                 &format!(
-                    "#helper-smart-contract-{} > td:nth-child(3) > code > a",
+                    "#helper-smart-contract-{} > td:nth-child(4) > code > a",
                     lower_alphanumeric(id).unwrap()
                 ),
                 expected_href,

--- a/rs/ethereum/cketh/minter/src/endpoints.rs
+++ b/rs/ethereum/cketh/minter/src/endpoints.rs
@@ -76,7 +76,6 @@ pub struct MinterInfo {
     pub erc20_balances: Option<Vec<Erc20Balance>>,
     pub last_eth_scraped_block_number: Option<Nat>,
     pub last_erc20_scraped_block_number: Option<Nat>,
-    pub last_deposit_with_subaccount_scraped_block_number: Option<Nat>,
     pub cketh_ledger_id: Option<Principal>,
     pub evm_rpc_id: Option<Principal>,
 }

--- a/rs/ethereum/cketh/minter/src/main.rs
+++ b/rs/ethereum/cketh/minter/src/main.rs
@@ -249,7 +249,6 @@ async fn get_minter_info() -> MinterInfo {
             erc20_balances,
             last_eth_scraped_block_number,
             last_erc20_scraped_block_number,
-            last_deposit_with_subaccount_scraped_block_number,
             cketh_ledger_id: Some(s.cketh_ledger_id),
             evm_rpc_id: s.evm_rpc_id,
         }

--- a/rs/ethereum/cketh/minter/src/state/eth_logs_scraping/mod.rs
+++ b/rs/ethereum/cketh/minter/src/state/eth_logs_scraping/mod.rs
@@ -1,3 +1,6 @@
+#[cfg(test)]
+mod tests;
+
 use crate::numeric::BlockNumber;
 use candid::Nat;
 use ic_ethereum_types::Address;
@@ -193,7 +196,7 @@ impl LogScrapingState {
     }
 }
 
-#[derive(Clone, PartialEq, Debug)]
+#[derive(Clone, PartialEq, Debug, Default)]
 pub struct LogScrapingInfo {
     pub eth_helper_contract_address: Option<String>,
     pub last_eth_scraped_block_number: Option<Nat>,

--- a/rs/ethereum/cketh/minter/src/state/eth_logs_scraping/mod.rs
+++ b/rs/ethereum/cketh/minter/src/state/eth_logs_scraping/mod.rs
@@ -95,10 +95,24 @@ pub enum LogScrapingStateError {
     InvalidContractAddress(String),
 }
 
-#[derive(Clone, PartialEq, Debug)]
+#[derive(Clone, Copy, PartialEq, Debug)]
+#[repr(u8)]
 pub enum LogScrapingStatus {
     Active,
     Deprecated,
+}
+
+impl Display for LogScrapingStatus {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            LogScrapingStatus::Active => {
+                write!(f, "active 🟢")
+            }
+            LogScrapingStatus::Deprecated => {
+                write!(f, "deprecated 🟠")
+            }
+        }
+    }
 }
 
 #[derive(Clone, PartialEq, Debug)]
@@ -140,5 +154,9 @@ impl LogScrapingState {
 
     pub fn contract_address(&self) -> Option<&Address> {
         self.contract_address.as_ref()
+    }
+
+    pub fn status(&self) -> LogScrapingStatus {
+        self.status
     }
 }

--- a/rs/ethereum/cketh/minter/src/state/eth_logs_scraping/tests.rs
+++ b/rs/ethereum/cketh/minter/src/state/eth_logs_scraping/tests.rs
@@ -1,0 +1,71 @@
+use crate::state::eth_logs_scraping::{LogScrapingId, LogScrapingInfo, LogScrapings};
+
+#[test]
+fn should_use_info_from_deposit_with_subaccount_when_contract_address_present() {
+    const LAST_SCRAPED_BLOCK_NUMBER: u32 = 21_235_426_u32;
+    const ETH_HELPER_SMART_CONTRACT: &str = "0x7574eB42cA208A4f6960ECCAfDF186D627dCC175";
+    const ERC20_HELPER_SMART_CONTRACT: &str = "0x6abDA0438307733FC299e9C229FD3cc074bD8cC0";
+    const DEPOSIT_WITH_SUBACCOUNT_HELPER_SMART_CONTRACT: &str =
+        "0x2D39863d30716aaf2B7fFFd85Dd03Dda2BFC2E38";
+
+    let mut scrapings = LogScrapings::new(LAST_SCRAPED_BLOCK_NUMBER.into());
+
+    assert_eq!(
+        scrapings.info(),
+        LogScrapingInfo {
+            last_eth_scraped_block_number: Some(LAST_SCRAPED_BLOCK_NUMBER.into()),
+            last_erc20_scraped_block_number: Some(LAST_SCRAPED_BLOCK_NUMBER.into()),
+            ..Default::default()
+        }
+    );
+
+    scrapings
+        .set_contract_address(
+            LogScrapingId::EthDepositWithoutSubaccount,
+            ETH_HELPER_SMART_CONTRACT.parse().unwrap(),
+        )
+        .unwrap();
+    scrapings
+        .set_contract_address(
+            LogScrapingId::Erc20DepositWithoutSubaccount,
+            ERC20_HELPER_SMART_CONTRACT.parse().unwrap(),
+        )
+        .unwrap();
+
+    assert_eq!(
+        scrapings.info(),
+        LogScrapingInfo {
+            eth_helper_contract_address: Some(ETH_HELPER_SMART_CONTRACT.to_string()),
+            last_eth_scraped_block_number: Some(LAST_SCRAPED_BLOCK_NUMBER.into()),
+            erc20_helper_contract_address: Some(ERC20_HELPER_SMART_CONTRACT.to_string()),
+            last_erc20_scraped_block_number: Some(LAST_SCRAPED_BLOCK_NUMBER.into()),
+        }
+    );
+
+    scrapings
+        .set_contract_address(
+            LogScrapingId::EthOrErc20DepositWithSubaccount,
+            DEPOSIT_WITH_SUBACCOUNT_HELPER_SMART_CONTRACT
+                .parse()
+                .unwrap(),
+        )
+        .unwrap();
+    scrapings.set_last_scraped_block_number(
+        LogScrapingId::EthOrErc20DepositWithSubaccount,
+        (LAST_SCRAPED_BLOCK_NUMBER + 1).into(),
+    );
+
+    assert_eq!(
+        scrapings.info(),
+        LogScrapingInfo {
+            eth_helper_contract_address: Some(
+                DEPOSIT_WITH_SUBACCOUNT_HELPER_SMART_CONTRACT.to_string()
+            ),
+            last_eth_scraped_block_number: Some((LAST_SCRAPED_BLOCK_NUMBER + 1).into()),
+            erc20_helper_contract_address: Some(
+                DEPOSIT_WITH_SUBACCOUNT_HELPER_SMART_CONTRACT.to_string()
+            ),
+            last_erc20_scraped_block_number: Some((LAST_SCRAPED_BLOCK_NUMBER + 1).into()),
+        }
+    );
+}

--- a/rs/ethereum/cketh/minter/templates/dashboard.html
+++ b/rs/ethereum/cketh/minter/templates/dashboard.html
@@ -181,6 +181,7 @@
                 <tr>
                     <th>Deposit</th>
                     <th>Address</th>
+                    <th>Status</th>
                     <th>Last synced block number</th>
                 </tr>
                 </thead>
@@ -190,6 +191,7 @@
                 <tr id="helper-smart-contract-{{ id|lower_alphanumeric }}">
                     <td>{{ id }}</td>
                     <td>{% call etherscan_address_link(scraping_state.contract_address().unwrap()) %}</td>
+                    <td>{{ scraping_state.status() }}</td>
                     <td><code>{% call etherscan_block_link(scraping_state.last_scraped_block_number()) %}</code></td>
                 </tr>
                 {% endif %}

--- a/rs/ethereum/cketh/minter/tests/ckerc20.rs
+++ b/rs/ethereum/cketh/minter/tests/ckerc20.rs
@@ -1690,9 +1690,6 @@ fn should_retrieve_minter_info() {
             erc20_balances: Some(erc20_balances),
             last_eth_scraped_block_number: Some(LAST_SCRAPED_BLOCK_NUMBER_AT_INSTALL.into()),
             last_erc20_scraped_block_number: Some(LAST_SCRAPED_BLOCK_NUMBER_AT_INSTALL.into()),
-            last_deposit_with_subaccount_scraped_block_number: Some(
-                LAST_SCRAPED_BLOCK_NUMBER_AT_INSTALL.into()
-            ),
             cketh_ledger_id: Some(ckerc20.cketh_ledger_id()),
             evm_rpc_id: ckerc20.cketh.evm_rpc_id.map(Principal::from),
         }

--- a/rs/ethereum/cketh/minter/tests/cketh.rs
+++ b/rs/ethereum/cketh/minter/tests/cketh.rs
@@ -1096,9 +1096,6 @@ fn should_retrieve_minter_info() {
             erc20_balances: None,
             last_eth_scraped_block_number: Some(LAST_SCRAPED_BLOCK_NUMBER_AT_INSTALL.into()),
             last_erc20_scraped_block_number: Some(LAST_SCRAPED_BLOCK_NUMBER_AT_INSTALL.into()),
-            last_deposit_with_subaccount_scraped_block_number: Some(
-                LAST_SCRAPED_BLOCK_NUMBER_AT_INSTALL.into()
-            ),
             cketh_ledger_id: Some(cketh.ledger_id.into()),
             evm_rpc_id: cketh.evm_rpc_id.map(Principal::from),
         }


### PR DESCRIPTION
The helper smart contract supporting subaccount is the new preferred way to do deposit, both of ETH and ERC-20. The 2 previous helper smart contracts are therefore deprecated. Concretely,

1. The status (active or deprecated) of a helper smart contract is added to the minter dashboard.
2. In case the address of the helper smart contract supporting subaccount is set, the minter endpoints to retrieve the state of a scraping (contract address and last scraped block number) for deposit of ETH and ERC-20 will be that of the new helper smart contract supporting subaccount. 
3. The field `last_deposit_with_subaccount_scraped_block_number` was removed. This is not a breaking change since it was never deployed in production.