### PR TITLE
fix(nns): Avoid cloning heap_neurons to avoid performance penalty (HOTFIX; DO NOT MERGE)

### DIFF
--- a/mainnet-canisters.json
+++ b/mainnet-canisters.json
@@ -36,8 +36,8 @@
     "sha256": "fd25a4e2e283b498c3be1aaf63cc9b2726264d78a12b12f43ad453ceeb575e7c"
   },
   "governance": {
-    "rev": "aa91ecacdf3824e193e21b70e0127e8d3edab51a",
-    "sha256": "18ca5b86271c76459f249c87d80c9e0172e09f64e18c04cf1c28d95f3489de4e"
+    "rev": "f5a63fd41933eee24ab3a6c71e43c67c1048e0db",
+    "sha256": "c7cd011d711edadc024d2673c090cea17688eca1748648d04c0c0afbdaebdbdc"
   },
   "index": {
     "rev": "b43280208c32633a29657a1051660324e88a373d",
@@ -60,16 +60,16 @@
     "sha256": "657010591182ce758c86f020d1eade5f7a188072cf0de9c41e2f9d577849c964"
   },
   "sns-wasm": {
-    "rev": "d265b130647f04aa25909ec1fbb8294ce0139d1c",
-    "sha256": "3760ee699c5b61fcec2fb5662924dbe3198062ae075e950f494f496185de232e"
+    "rev": "f5a63fd41933eee24ab3a6c71e43c67c1048e0db",
+    "sha256": "54a1274e04355fab3a10ec6b351735abf16ebf939b477e8863b6673a44fcf538"
   },
   "sns_archive": {
     "rev": "e54d3fa34ded227c885d04e64505fa4b5d564743",
     "sha256": "317771544f0e828a60ad6efc97694c425c169c4d75d911ba592546912dba3116"
   },
   "sns_governance": {
-    "rev": "aa91ecacdf3824e193e21b70e0127e8d3edab51a",
-    "sha256": "bc91fd7bc4d6c01ea814b12510a1ff8f4f74fcac9ab16248ad4af7cb98d9c69d"
+    "rev": "f5a63fd41933eee24ab3a6c71e43c67c1048e0db",
+    "sha256": "831f6cfdc355d1324ed93bb1a8d4b1f6a3eda5070e59e470cdfd0f2d35de8a88"
   },
   "sns_index": {
     "rev": "e54d3fa34ded227c885d04e64505fa4b5d564743",

--- a/rs/nns/governance/src/governance/tla/mod.rs
+++ b/rs/nns/governance/src/governance/tla/mod.rs
@@ -1,6 +1,7 @@
 use itertools::Itertools;
 use std::{
     collections::{BTreeMap, BTreeSet},
+    ops::Deref,
     thread,
 };
 
@@ -33,7 +34,8 @@ pub use claim_neuron::claim_neuron_desc;
 fn neuron_global(gov: &Governance) -> TlaValue {
     let neuron_map: BTreeMap<u64, TlaValue> = with_stable_neuron_store(|store| {
         gov.neuron_store.with_active_neurons_iter(|iter| {
-            iter.chain(store.range_neurons(std::ops::RangeFull))
+            iter.map(|n| n.deref().clone())
+                .chain(store.range_neurons(std::ops::RangeFull))
                 .map(|neuron| {
                     (
                         neuron.id().id,

--- a/rs/nns/governance/src/neuron_store.rs
+++ b/rs/nns/governance/src/neuron_store.rs
@@ -733,14 +733,14 @@ impl NeuronStore {
     }
     pub fn with_active_neurons_iter<R>(
         &self,
-        callback: impl for<'b> FnOnce(Box<dyn Iterator<Item = Neuron> + 'b>) -> R,
+        callback: impl for<'b> FnOnce(Box<dyn Iterator<Item = Cow<Neuron>> + 'b>) -> R,
     ) -> R {
         self.with_active_neurons_iter_sections(callback, NeuronSections::all())
     }
 
     fn with_active_neurons_iter_sections<R>(
         &self,
-        callback: impl for<'b> FnOnce(Box<dyn Iterator<Item = Neuron> + 'b>) -> R,
+        callback: impl for<'b> FnOnce(Box<dyn Iterator<Item = Cow<Neuron>> + 'b>) -> R,
         sections: NeuronSections,
     ) -> R {
         if self.use_stable_memory_for_all_neurons {
@@ -751,13 +751,13 @@ impl NeuronStore {
                     stable_store
                         .range_neurons_sections(.., sections)
                         .filter(|n| !n.is_inactive(now))
-                        .chain(self.heap_neurons.values().cloned()),
-                ) as Box<dyn Iterator<Item = Neuron>>;
+                        .map(Cow::Owned)
+                        .chain(self.heap_neurons.values().map(Cow::Borrowed)),
+                );
                 callback(iter)
             })
         } else {
-            let iter =
-                Box::new(self.heap_neurons.values().cloned()) as Box<dyn Iterator<Item = Neuron>>;
+            let iter = Box::new(self.heap_neurons.values().map(Cow::Borrowed));
             callback(iter)
         }
     }
@@ -796,9 +796,13 @@ impl NeuronStore {
     fn filter_map_active_neurons<R>(
         &self,
         filter: impl Fn(&Neuron) -> bool,
-        f: impl FnMut(Neuron) -> R,
+        f: impl Fn(&Neuron) -> R,
     ) -> Vec<R> {
-        self.with_active_neurons_iter(|iter| iter.filter(|n| filter(n)).map(f).collect())
+        self.with_active_neurons_iter(|iter| {
+            iter.filter(|n| filter(n.as_ref()))
+                .map(|n| f(n.as_ref()))
+                .collect()
+        })
     }
 
     fn is_active_neurons_fund_neuron(neuron: &Neuron, now: u64) -> bool {
@@ -858,7 +862,7 @@ impl NeuronStore {
         let mut deciding_voting_power: u128 = 0;
         let mut potential_voting_power: u128 = 0;
 
-        let mut process_neuron = |neuron: Neuron| {
+        let mut process_neuron = |neuron: &Neuron| {
             if neuron.is_inactive(now_seconds)
                 || neuron.dissolve_delay_seconds(now_seconds)
                     < MIN_DISSOLVE_DELAY_FOR_VOTE_ELIGIBILITY_SECONDS
@@ -882,7 +886,7 @@ impl NeuronStore {
         self.with_active_neurons_iter_sections(
             |iter| {
                 for neuron in iter {
-                    process_neuron(neuron);
+                    process_neuron(neuron.as_ref());
                 }
             },
             NeuronSections::default(),

--- a/rs/nns/governance/tests/governance.rs
+++ b/rs/nns/governance/tests/governance.rs
@@ -126,7 +126,7 @@ use std::{
     collections::{BTreeMap, HashSet, VecDeque},
     convert::{TryFrom, TryInto},
     iter::{self, once},
-    ops::Div,
+    ops::{Deref, Div},
     path::PathBuf,
     sync::{Arc, Mutex},
 };
@@ -7166,9 +7166,11 @@ fn test_manage_and_reward_node_providers() {
         ProposalStatus::Executed
     );
     // Find the neuron...
-    let neuron = gov
-        .neuron_store
-        .with_active_neurons_iter(|mut iter| iter.find(|x| x.controller() == np_pid).unwrap());
+    let neuron = gov.neuron_store.with_active_neurons_iter(|mut iter| {
+        iter.find(|x| x.controller() == np_pid)
+            .map(|n| n.deref().clone())
+            .unwrap()
+    });
     assert_eq!(neuron.stake_e8s(), 99_999_999);
     // Find the transaction in the ledger...
     driver.assert_account_contains(
@@ -7474,9 +7476,11 @@ fn test_manage_and_reward_multiple_node_providers() {
 
     // Check third reward
     // Find the neuron...
-    let neuron = gov
-        .neuron_store
-        .with_active_neurons_iter(|mut iter| iter.find(|x| x.controller() == np_pid_2).unwrap());
+    let neuron = gov.neuron_store.with_active_neurons_iter(|mut iter| {
+        iter.find(|x| x.controller() == np_pid_2)
+            .map(|n| n.deref().clone())
+            .unwrap()
+    });
     assert_eq!(neuron.stake_e8s(), 99_999_999);
     // Find the transaction in the ledger...
     driver.assert_account_contains(


### PR DESCRIPTION
This hotfix is based on the latest deployed NNS Governance code (https://dashboard.internetcomputer.org/proposal/134193) with two cherry-picks: 

1. The actual hotfix: https://github.com/dfinity/ic/pull/2726/commits/babfa674d2e249d38d548a38fa9bb5cc3219a881
2. Repin mainnet canister versions after last release ([PR 2751][repin])

[repin]: https://github.com/dfinity/ic/pull/2751