### PR TITLE
fix: Depend on //:bazel-timestamp instead of //:.git/index when calculating commit_timestamp_txt

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -7,7 +7,6 @@ package(default_visibility = ["//visibility:public"])
 # WARNING! .git is the directory, not a regular file! only consume it in your rules if you know how exactly bazel works and understand implications!
 exports_files([
     ".git",
-    ".git/index",
     ".rclone.conf",
     ".rclone-anon.conf",
     "buf.yaml",

--- a/ic-os/components/BUILD.bazel
+++ b/ic-os/components/BUILD.bazel
@@ -32,7 +32,7 @@ genrule(
     name = "commit_timestamp_txt",
     # Depend on .git/index so that the commit timestamp is regenerated whenever
     # a new branch is checked out.
-    srcs = ["//:.git/index"],
+    srcs = ["//:bazel-timestamp"],
     outs = ["commit_timestamp.txt"],
     cmd = select({
         "//bazel:is_release_build": "git show -s --format=%ct > $@",

--- a/ic-os/components/BUILD.bazel
+++ b/ic-os/components/BUILD.bazel
@@ -30,8 +30,7 @@ exports_files(
 
 genrule(
     name = "commit_timestamp_txt",
-    # Depend on .git/index so that the commit timestamp is regenerated whenever
-    # a new branch is checked out.
+    # Depend on //:bazel-timestamp so that the commit timestamp is not cached.
     srcs = ["//:bazel-timestamp"],
     outs = ["commit_timestamp.txt"],
     cmd = select({


### PR DESCRIPTION
This change will hopefully resolve the issues people were having with this target (the target was recomputed or not recomputed unexpectedly).