### PR TITLE
chore: bump ic-bn-lib & ic-gateway

### DIFF
--- a/Cargo.Bazel.Fuzzing.json.lock
+++ b/Cargo.Bazel.Fuzzing.json.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "eefb27c751d3bf2734e9a74e2a61b07e5507dbe0f114772a131188c432b83c62",
+  "checksum": "2a09306f29a16c5a719d2a7bcc3ddb3ac2e4bbb17d14bf12140084fc72c1ac4c",
   "crates": {
     "abnf 0.12.0": {
       "name": "abnf",
@@ -19309,7 +19309,7 @@
               "target": "rustc_hash"
             },
             {
-              "id": "rustls 0.23.16",
+              "id": "rustls 0.23.17",
               "target": "rustls"
             },
             {
@@ -25082,7 +25082,7 @@
               "target": "futures_io"
             },
             {
-              "id": "rustls 0.23.16",
+              "id": "rustls 0.23.17",
               "target": "rustls"
             },
             {
@@ -29149,7 +29149,7 @@
               "target": "log"
             },
             {
-              "id": "rustls 0.23.16",
+              "id": "rustls 0.23.17",
               "target": "rustls"
             },
             {
@@ -30689,7 +30689,7 @@
         "Git": {
           "remote": "https://github.com/dfinity/ic-bn-lib",
           "commitish": {
-            "Rev": "526d34d15cfbf369d8baf2dae9932aa18d570a1d"
+            "Rev": "2496803db52d8182f578f098a3ffe4fcb9573fcd"
           }
         }
       },
@@ -30839,7 +30839,7 @@
               "target": "reqwest"
             },
             {
-              "id": "rustls 0.23.16",
+              "id": "rustls 0.23.17",
               "target": "rustls"
             },
             {
@@ -30883,7 +30883,7 @@
               "target": "systemstat"
             },
             {
-              "id": "thiserror 1.0.68",
+              "id": "thiserror 2.0.3",
               "target": "thiserror"
             },
             {
@@ -37382,7 +37382,7 @@
               "target": "pem"
             },
             {
-              "id": "rustls 0.23.16",
+              "id": "rustls 0.23.17",
               "target": "rustls"
             },
             {
@@ -53290,7 +53290,7 @@
               "target": "rustc_hash"
             },
             {
-              "id": "rustls 0.23.16",
+              "id": "rustls 0.23.17",
               "target": "rustls"
             },
             {
@@ -53378,7 +53378,7 @@
               "target": "rustc_hash"
             },
             {
-              "id": "rustls 0.23.16",
+              "id": "rustls 0.23.17",
               "target": "rustls"
             },
             {
@@ -57236,7 +57236,7 @@
                 "target": "hyper_rustls"
               },
               {
-                "id": "rustls 0.23.16",
+                "id": "rustls 0.23.17",
                 "target": "rustls"
               },
               {
@@ -57286,7 +57286,7 @@
                 "target": "hyper_rustls"
               },
               {
-                "id": "rustls 0.23.16",
+                "id": "rustls 0.23.17",
                 "target": "rustls"
               },
               {
@@ -57336,7 +57336,7 @@
                 "target": "hyper_rustls"
               },
               {
-                "id": "rustls 0.23.16",
+                "id": "rustls 0.23.17",
                 "target": "rustls"
               },
               {
@@ -57386,7 +57386,7 @@
                 "target": "hyper_rustls"
               },
               {
-                "id": "rustls 0.23.16",
+                "id": "rustls 0.23.17",
                 "target": "rustls"
               },
               {
@@ -57436,7 +57436,7 @@
                 "target": "hyper_rustls"
               },
               {
-                "id": "rustls 0.23.16",
+                "id": "rustls 0.23.17",
                 "target": "rustls"
               },
               {
@@ -57486,7 +57486,7 @@
                 "target": "hyper_rustls"
               },
               {
-                "id": "rustls 0.23.16",
+                "id": "rustls 0.23.17",
                 "target": "rustls"
               },
               {
@@ -57536,7 +57536,7 @@
                 "target": "hyper_rustls"
               },
               {
-                "id": "rustls 0.23.16",
+                "id": "rustls 0.23.17",
                 "target": "rustls"
               },
               {
@@ -57586,7 +57586,7 @@
                 "target": "hyper_rustls"
               },
               {
-                "id": "rustls 0.23.16",
+                "id": "rustls 0.23.17",
                 "target": "rustls"
               },
               {
@@ -57636,7 +57636,7 @@
                 "target": "hyper_rustls"
               },
               {
-                "id": "rustls 0.23.16",
+                "id": "rustls 0.23.17",
                 "target": "rustls"
               },
               {
@@ -57686,7 +57686,7 @@
                 "target": "hyper_rustls"
               },
               {
-                "id": "rustls 0.23.16",
+                "id": "rustls 0.23.17",
                 "target": "rustls"
               },
               {
@@ -57736,7 +57736,7 @@
                 "target": "hyper_rustls"
               },
               {
-                "id": "rustls 0.23.16",
+                "id": "rustls 0.23.17",
                 "target": "rustls"
               },
               {
@@ -57786,7 +57786,7 @@
                 "target": "hyper_rustls"
               },
               {
-                "id": "rustls 0.23.16",
+                "id": "rustls 0.23.17",
                 "target": "rustls"
               },
               {
@@ -57906,7 +57906,7 @@
                 "target": "hyper_rustls"
               },
               {
-                "id": "rustls 0.23.16",
+                "id": "rustls 0.23.17",
                 "target": "rustls"
               },
               {
@@ -57956,7 +57956,7 @@
                 "target": "hyper_rustls"
               },
               {
-                "id": "rustls 0.23.16",
+                "id": "rustls 0.23.17",
                 "target": "rustls"
               },
               {
@@ -58006,7 +58006,7 @@
                 "target": "hyper_rustls"
               },
               {
-                "id": "rustls 0.23.16",
+                "id": "rustls 0.23.17",
                 "target": "rustls"
               },
               {
@@ -58056,7 +58056,7 @@
                 "target": "hyper_rustls"
               },
               {
-                "id": "rustls 0.23.16",
+                "id": "rustls 0.23.17",
                 "target": "rustls"
               },
               {
@@ -58106,7 +58106,7 @@
                 "target": "hyper_rustls"
               },
               {
-                "id": "rustls 0.23.16",
+                "id": "rustls 0.23.17",
                 "target": "rustls"
               },
               {
@@ -58156,7 +58156,7 @@
                 "target": "hyper_rustls"
               },
               {
-                "id": "rustls 0.23.16",
+                "id": "rustls 0.23.17",
                 "target": "rustls"
               },
               {
@@ -58206,7 +58206,7 @@
                 "target": "hyper_rustls"
               },
               {
-                "id": "rustls 0.23.16",
+                "id": "rustls 0.23.17",
                 "target": "rustls"
               },
               {
@@ -58256,7 +58256,7 @@
                 "target": "hyper_rustls"
               },
               {
-                "id": "rustls 0.23.16",
+                "id": "rustls 0.23.17",
                 "target": "rustls"
               },
               {
@@ -58306,7 +58306,7 @@
                 "target": "hyper_rustls"
               },
               {
-                "id": "rustls 0.23.16",
+                "id": "rustls 0.23.17",
                 "target": "rustls"
               },
               {
@@ -58356,7 +58356,7 @@
                 "target": "hyper_rustls"
               },
               {
-                "id": "rustls 0.23.16",
+                "id": "rustls 0.23.17",
                 "target": "rustls"
               },
               {
@@ -58406,7 +58406,7 @@
                 "target": "hyper_rustls"
               },
               {
-                "id": "rustls 0.23.16",
+                "id": "rustls 0.23.17",
                 "target": "rustls"
               },
               {
@@ -58468,7 +58468,7 @@
                 "target": "hyper_rustls"
               },
               {
-                "id": "rustls 0.23.16",
+                "id": "rustls 0.23.17",
                 "target": "rustls"
               },
               {
@@ -58518,7 +58518,7 @@
                 "target": "hyper_rustls"
               },
               {
-                "id": "rustls 0.23.16",
+                "id": "rustls 0.23.17",
                 "target": "rustls"
               },
               {
@@ -58568,7 +58568,7 @@
                 "target": "hyper_rustls"
               },
               {
-                "id": "rustls 0.23.16",
+                "id": "rustls 0.23.17",
                 "target": "rustls"
               },
               {
@@ -58618,7 +58618,7 @@
                 "target": "hyper_rustls"
               },
               {
-                "id": "rustls 0.23.16",
+                "id": "rustls 0.23.17",
                 "target": "rustls"
               },
               {
@@ -58668,7 +58668,7 @@
                 "target": "hyper_rustls"
               },
               {
-                "id": "rustls 0.23.16",
+                "id": "rustls 0.23.17",
                 "target": "rustls"
               },
               {
@@ -58718,7 +58718,7 @@
                 "target": "hyper_rustls"
               },
               {
-                "id": "rustls 0.23.16",
+                "id": "rustls 0.23.17",
                 "target": "rustls"
               },
               {
@@ -58768,7 +58768,7 @@
                 "target": "hyper_rustls"
               },
               {
-                "id": "rustls 0.23.16",
+                "id": "rustls 0.23.17",
                 "target": "rustls"
               },
               {
@@ -58818,7 +58818,7 @@
                 "target": "hyper_rustls"
               },
               {
-                "id": "rustls 0.23.16",
+                "id": "rustls 0.23.17",
                 "target": "rustls"
               },
               {
@@ -58868,7 +58868,7 @@
                 "target": "hyper_rustls"
               },
               {
-                "id": "rustls 0.23.16",
+                "id": "rustls 0.23.17",
                 "target": "rustls"
               },
               {
@@ -61654,14 +61654,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "rustls 0.23.16": {
+    "rustls 0.23.17": {
       "name": "rustls",
-      "version": "0.23.16",
+      "version": "0.23.17",
       "package_url": "https://github.com/rustls/rustls",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/rustls/0.23.16/download",
-          "sha256": "eee87ff5d9b36712a58574e12e9f0ea80f915a5b0ac518d322b24a465617925e"
+          "url": "https://static.crates.io/crates/rustls/0.23.17/download",
+          "sha256": "7f1a745511c54ba6d4465e8d5dfbd81b45791756de28d4981af70d6dca128f1e"
         }
       },
       "targets": [
@@ -61729,7 +61729,7 @@
               "target": "ring"
             },
             {
-              "id": "rustls 0.23.16",
+              "id": "rustls 0.23.17",
               "target": "build_script_build"
             },
             {
@@ -61753,7 +61753,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.23.16"
+        "version": "0.23.17"
       },
       "build_script_attrs": {
         "compile_data_glob": [
@@ -62315,7 +62315,7 @@
               "target": "once_cell"
             },
             {
-              "id": "rustls 0.23.16",
+              "id": "rustls 0.23.17",
               "target": "rustls"
             }
           ],
@@ -73605,7 +73605,7 @@
         "deps": {
           "common": [
             {
-              "id": "rustls 0.23.16",
+              "id": "rustls 0.23.17",
               "target": "rustls"
             },
             {
@@ -87189,7 +87189,7 @@
     "rust_decimal_macros 1.36.0",
     "rustc-demangle 0.1.23",
     "rustc-hash 1.1.0",
-    "rustls 0.23.16",
+    "rustls 0.23.17",
     "rustls-pemfile 2.2.0",
     "rustversion 1.0.14",
     "rusty-fork 0.3.0",

--- a/Cargo.Bazel.Fuzzing.toml.lock
+++ b/Cargo.Bazel.Fuzzing.toml.lock
@@ -3214,7 +3214,7 @@ dependencies = [
  "rust_decimal_macros",
  "rustc-demangle",
  "rustc-hash 1.1.0",
- "rustls 0.23.16",
+ "rustls 0.23.17",
  "rustls-pemfile 2.2.0",
  "rustversion",
  "rusty-fork",
@@ -4139,7 +4139,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f2f12607f92c69b12ed746fabf9ca4f5c482cba46679c1a75b874ed7c26adb"
 dependencies = [
  "futures-io",
- "rustls 0.23.16",
+ "rustls 0.23.17",
  "rustls-pki-types",
 ]
 
@@ -4823,7 +4823,7 @@ dependencies = [
  "hyper 1.5.0",
  "hyper-util",
  "log",
- "rustls 0.23.16",
+ "rustls 0.23.17",
  "rustls-native-certs 0.8.0",
  "rustls-pki-types",
  "tokio",
@@ -4952,7 +4952,7 @@ dependencies = [
 [[package]]
 name = "ic-bn-lib"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic-bn-lib?rev=526d34d15cfbf369d8baf2dae9932aa18d570a1d#526d34d15cfbf369d8baf2dae9932aa18d570a1d"
+source = "git+https://github.com/dfinity/ic-bn-lib?rev=2496803db52d8182f578f098a3ffe4fcb9573fcd#2496803db52d8182f578f098a3ffe4fcb9573fcd"
 dependencies = [
  "ahash 0.8.11",
  "anyhow",
@@ -4988,7 +4988,7 @@ dependencies = [
  "rand 0.8.5",
  "rcgen",
  "reqwest 0.12.9",
- "rustls 0.23.16",
+ "rustls 0.23.17",
  "rustls-acme",
  "rustls-pemfile 2.2.0",
  "rustls-platform-verifier",
@@ -5000,7 +5000,7 @@ dependencies = [
  "strum_macros 0.26.4",
  "sync_wrapper 1.0.1",
  "systemstat",
- "thiserror 1.0.68",
+ "thiserror 2.0.3",
  "tokio",
  "tokio-io-timeout",
  "tokio-rustls 0.26.0",
@@ -6177,7 +6177,7 @@ dependencies = [
  "k8s-openapi",
  "kube-core",
  "pem 3.0.4",
- "rustls 0.23.16",
+ "rustls 0.23.17",
  "rustls-pemfile 2.2.0",
  "secrecy",
  "serde",
@@ -8703,7 +8703,7 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash 2.0.0",
- "rustls 0.23.16",
+ "rustls 0.23.17",
  "socket2 0.5.7",
  "thiserror 1.0.68",
  "tokio",
@@ -8720,7 +8720,7 @@ dependencies = [
  "rand 0.8.5",
  "ring 0.17.7",
  "rustc-hash 2.0.0",
- "rustls 0.23.16",
+ "rustls 0.23.17",
  "slab",
  "thiserror 1.0.68",
  "tinyvec",
@@ -9181,7 +9181,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.16",
+ "rustls 0.23.17",
  "rustls-native-certs 0.8.0",
  "rustls-pemfile 2.2.0",
  "rustls-pki-types",
@@ -9528,9 +9528,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.16"
+version = "0.23.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eee87ff5d9b36712a58574e12e9f0ea80f915a5b0ac518d322b24a465617925e"
+checksum = "7f1a745511c54ba6d4465e8d5dfbd81b45791756de28d4981af70d6dca128f1e"
 dependencies = [
  "brotli 7.0.0",
  "brotli-decompressor 4.0.1",
@@ -9642,7 +9642,7 @@ dependencies = [
  "jni",
  "log",
  "once_cell",
- "rustls 0.23.16",
+ "rustls 0.23.17",
  "rustls-native-certs 0.7.0",
  "rustls-platform-verifier-android",
  "rustls-webpki 0.102.8",
@@ -11311,7 +11311,7 @@ version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
 dependencies = [
- "rustls 0.23.16",
+ "rustls 0.23.17",
  "rustls-pki-types",
  "tokio",
 ]

--- a/Cargo.Bazel.json.lock
+++ b/Cargo.Bazel.json.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "d91089934a0754683996f85752037c2b7068be120a28b4ed4aed1483deed3fdc",
+  "checksum": "6e0d1102e47370e22a5da2034cd2281dbe6964d8dbbff85c2ed39139d88cac00",
   "crates": {
     "abnf 0.12.0": {
       "name": "abnf",
@@ -19137,7 +19137,7 @@
               "target": "rustc_hash"
             },
             {
-              "id": "rustls 0.23.16",
+              "id": "rustls 0.23.17",
               "target": "rustls"
             },
             {
@@ -24933,7 +24933,7 @@
               "target": "futures_io"
             },
             {
-              "id": "rustls 0.23.16",
+              "id": "rustls 0.23.17",
               "target": "rustls"
             },
             {
@@ -29004,7 +29004,7 @@
               "target": "log"
             },
             {
-              "id": "rustls 0.23.16",
+              "id": "rustls 0.23.17",
               "target": "rustls"
             },
             {
@@ -30544,7 +30544,7 @@
         "Git": {
           "remote": "https://github.com/dfinity/ic-bn-lib",
           "commitish": {
-            "Rev": "526d34d15cfbf369d8baf2dae9932aa18d570a1d"
+            "Rev": "2496803db52d8182f578f098a3ffe4fcb9573fcd"
           }
         }
       },
@@ -30694,7 +30694,7 @@
               "target": "reqwest"
             },
             {
-              "id": "rustls 0.23.16",
+              "id": "rustls 0.23.17",
               "target": "rustls"
             },
             {
@@ -30738,7 +30738,7 @@
               "target": "systemstat"
             },
             {
-              "id": "thiserror 1.0.68",
+              "id": "thiserror 2.0.3",
               "target": "thiserror"
             },
             {
@@ -37216,7 +37216,7 @@
               "target": "pem"
             },
             {
-              "id": "rustls 0.23.16",
+              "id": "rustls 0.23.17",
               "target": "rustls"
             },
             {
@@ -53092,7 +53092,7 @@
               "target": "rustc_hash"
             },
             {
-              "id": "rustls 0.23.16",
+              "id": "rustls 0.23.17",
               "target": "rustls"
             },
             {
@@ -53180,7 +53180,7 @@
               "target": "rustc_hash"
             },
             {
-              "id": "rustls 0.23.16",
+              "id": "rustls 0.23.17",
               "target": "rustls"
             },
             {
@@ -57082,7 +57082,7 @@
                 "target": "hyper_rustls"
               },
               {
-                "id": "rustls 0.23.16",
+                "id": "rustls 0.23.17",
                 "target": "rustls"
               },
               {
@@ -57132,7 +57132,7 @@
                 "target": "hyper_rustls"
               },
               {
-                "id": "rustls 0.23.16",
+                "id": "rustls 0.23.17",
                 "target": "rustls"
               },
               {
@@ -57182,7 +57182,7 @@
                 "target": "hyper_rustls"
               },
               {
-                "id": "rustls 0.23.16",
+                "id": "rustls 0.23.17",
                 "target": "rustls"
               },
               {
@@ -57232,7 +57232,7 @@
                 "target": "hyper_rustls"
               },
               {
-                "id": "rustls 0.23.16",
+                "id": "rustls 0.23.17",
                 "target": "rustls"
               },
               {
@@ -57282,7 +57282,7 @@
                 "target": "hyper_rustls"
               },
               {
-                "id": "rustls 0.23.16",
+                "id": "rustls 0.23.17",
                 "target": "rustls"
               },
               {
@@ -57332,7 +57332,7 @@
                 "target": "hyper_rustls"
               },
               {
-                "id": "rustls 0.23.16",
+                "id": "rustls 0.23.17",
                 "target": "rustls"
               },
               {
@@ -57382,7 +57382,7 @@
                 "target": "hyper_rustls"
               },
               {
-                "id": "rustls 0.23.16",
+                "id": "rustls 0.23.17",
                 "target": "rustls"
               },
               {
@@ -57432,7 +57432,7 @@
                 "target": "hyper_rustls"
               },
               {
-                "id": "rustls 0.23.16",
+                "id": "rustls 0.23.17",
                 "target": "rustls"
               },
               {
@@ -57482,7 +57482,7 @@
                 "target": "hyper_rustls"
               },
               {
-                "id": "rustls 0.23.16",
+                "id": "rustls 0.23.17",
                 "target": "rustls"
               },
               {
@@ -57532,7 +57532,7 @@
                 "target": "hyper_rustls"
               },
               {
-                "id": "rustls 0.23.16",
+                "id": "rustls 0.23.17",
                 "target": "rustls"
               },
               {
@@ -57582,7 +57582,7 @@
                 "target": "hyper_rustls"
               },
               {
-                "id": "rustls 0.23.16",
+                "id": "rustls 0.23.17",
                 "target": "rustls"
               },
               {
@@ -57632,7 +57632,7 @@
                 "target": "hyper_rustls"
               },
               {
-                "id": "rustls 0.23.16",
+                "id": "rustls 0.23.17",
                 "target": "rustls"
               },
               {
@@ -57752,7 +57752,7 @@
                 "target": "hyper_rustls"
               },
               {
-                "id": "rustls 0.23.16",
+                "id": "rustls 0.23.17",
                 "target": "rustls"
               },
               {
@@ -57802,7 +57802,7 @@
                 "target": "hyper_rustls"
               },
               {
-                "id": "rustls 0.23.16",
+                "id": "rustls 0.23.17",
                 "target": "rustls"
               },
               {
@@ -57852,7 +57852,7 @@
                 "target": "hyper_rustls"
               },
               {
-                "id": "rustls 0.23.16",
+                "id": "rustls 0.23.17",
                 "target": "rustls"
               },
               {
@@ -57902,7 +57902,7 @@
                 "target": "hyper_rustls"
               },
               {
-                "id": "rustls 0.23.16",
+                "id": "rustls 0.23.17",
                 "target": "rustls"
               },
               {
@@ -57952,7 +57952,7 @@
                 "target": "hyper_rustls"
               },
               {
-                "id": "rustls 0.23.16",
+                "id": "rustls 0.23.17",
                 "target": "rustls"
               },
               {
@@ -58002,7 +58002,7 @@
                 "target": "hyper_rustls"
               },
               {
-                "id": "rustls 0.23.16",
+                "id": "rustls 0.23.17",
                 "target": "rustls"
               },
               {
@@ -58052,7 +58052,7 @@
                 "target": "hyper_rustls"
               },
               {
-                "id": "rustls 0.23.16",
+                "id": "rustls 0.23.17",
                 "target": "rustls"
               },
               {
@@ -58102,7 +58102,7 @@
                 "target": "hyper_rustls"
               },
               {
-                "id": "rustls 0.23.16",
+                "id": "rustls 0.23.17",
                 "target": "rustls"
               },
               {
@@ -58152,7 +58152,7 @@
                 "target": "hyper_rustls"
               },
               {
-                "id": "rustls 0.23.16",
+                "id": "rustls 0.23.17",
                 "target": "rustls"
               },
               {
@@ -58202,7 +58202,7 @@
                 "target": "hyper_rustls"
               },
               {
-                "id": "rustls 0.23.16",
+                "id": "rustls 0.23.17",
                 "target": "rustls"
               },
               {
@@ -58252,7 +58252,7 @@
                 "target": "hyper_rustls"
               },
               {
-                "id": "rustls 0.23.16",
+                "id": "rustls 0.23.17",
                 "target": "rustls"
               },
               {
@@ -58314,7 +58314,7 @@
                 "target": "hyper_rustls"
               },
               {
-                "id": "rustls 0.23.16",
+                "id": "rustls 0.23.17",
                 "target": "rustls"
               },
               {
@@ -58364,7 +58364,7 @@
                 "target": "hyper_rustls"
               },
               {
-                "id": "rustls 0.23.16",
+                "id": "rustls 0.23.17",
                 "target": "rustls"
               },
               {
@@ -58414,7 +58414,7 @@
                 "target": "hyper_rustls"
               },
               {
-                "id": "rustls 0.23.16",
+                "id": "rustls 0.23.17",
                 "target": "rustls"
               },
               {
@@ -58464,7 +58464,7 @@
                 "target": "hyper_rustls"
               },
               {
-                "id": "rustls 0.23.16",
+                "id": "rustls 0.23.17",
                 "target": "rustls"
               },
               {
@@ -58514,7 +58514,7 @@
                 "target": "hyper_rustls"
               },
               {
-                "id": "rustls 0.23.16",
+                "id": "rustls 0.23.17",
                 "target": "rustls"
               },
               {
@@ -58564,7 +58564,7 @@
                 "target": "hyper_rustls"
               },
               {
-                "id": "rustls 0.23.16",
+                "id": "rustls 0.23.17",
                 "target": "rustls"
               },
               {
@@ -58614,7 +58614,7 @@
                 "target": "hyper_rustls"
               },
               {
-                "id": "rustls 0.23.16",
+                "id": "rustls 0.23.17",
                 "target": "rustls"
               },
               {
@@ -58664,7 +58664,7 @@
                 "target": "hyper_rustls"
               },
               {
-                "id": "rustls 0.23.16",
+                "id": "rustls 0.23.17",
                 "target": "rustls"
               },
               {
@@ -58714,7 +58714,7 @@
                 "target": "hyper_rustls"
               },
               {
-                "id": "rustls 0.23.16",
+                "id": "rustls 0.23.17",
                 "target": "rustls"
               },
               {
@@ -61500,14 +61500,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "rustls 0.23.16": {
+    "rustls 0.23.17": {
       "name": "rustls",
-      "version": "0.23.16",
+      "version": "0.23.17",
       "package_url": "https://github.com/rustls/rustls",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/rustls/0.23.16/download",
-          "sha256": "eee87ff5d9b36712a58574e12e9f0ea80f915a5b0ac518d322b24a465617925e"
+          "url": "https://static.crates.io/crates/rustls/0.23.17/download",
+          "sha256": "7f1a745511c54ba6d4465e8d5dfbd81b45791756de28d4981af70d6dca128f1e"
         }
       },
       "targets": [
@@ -61575,7 +61575,7 @@
               "target": "ring"
             },
             {
-              "id": "rustls 0.23.16",
+              "id": "rustls 0.23.17",
               "target": "build_script_build"
             },
             {
@@ -61599,7 +61599,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.23.16"
+        "version": "0.23.17"
       },
       "build_script_attrs": {
         "compile_data_glob": [
@@ -62161,7 +62161,7 @@
               "target": "once_cell"
             },
             {
-              "id": "rustls 0.23.16",
+              "id": "rustls 0.23.17",
               "target": "rustls"
             }
           ],
@@ -73451,7 +73451,7 @@
         "deps": {
           "common": [
             {
-              "id": "rustls 0.23.16",
+              "id": "rustls 0.23.17",
               "target": "rustls"
             },
             {
@@ -87069,7 +87069,7 @@
     "rust_decimal_macros 1.36.0",
     "rustc-demangle 0.1.23",
     "rustc-hash 1.1.0",
-    "rustls 0.23.16",
+    "rustls 0.23.17",
     "rustls-pemfile 2.2.0",
     "rustversion 1.0.14",
     "rusty-fork 0.3.0",

--- a/Cargo.Bazel.toml.lock
+++ b/Cargo.Bazel.toml.lock
@@ -3203,7 +3203,7 @@ dependencies = [
  "rust_decimal_macros",
  "rustc-demangle",
  "rustc-hash 1.1.0",
- "rustls 0.23.16",
+ "rustls 0.23.17",
  "rustls-pemfile 2.2.0",
  "rustversion",
  "rusty-fork",
@@ -4128,7 +4128,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f2f12607f92c69b12ed746fabf9ca4f5c482cba46679c1a75b874ed7c26adb"
 dependencies = [
  "futures-io",
- "rustls 0.23.16",
+ "rustls 0.23.17",
  "rustls-pki-types",
 ]
 
@@ -4813,7 +4813,7 @@ dependencies = [
  "hyper 1.5.0",
  "hyper-util",
  "log",
- "rustls 0.23.16",
+ "rustls 0.23.17",
  "rustls-native-certs 0.8.0",
  "rustls-pki-types",
  "tokio",
@@ -4942,7 +4942,7 @@ dependencies = [
 [[package]]
 name = "ic-bn-lib"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic-bn-lib?rev=526d34d15cfbf369d8baf2dae9932aa18d570a1d#526d34d15cfbf369d8baf2dae9932aa18d570a1d"
+source = "git+https://github.com/dfinity/ic-bn-lib?rev=2496803db52d8182f578f098a3ffe4fcb9573fcd#2496803db52d8182f578f098a3ffe4fcb9573fcd"
 dependencies = [
  "ahash 0.8.11",
  "anyhow",
@@ -4978,7 +4978,7 @@ dependencies = [
  "rand 0.8.5",
  "rcgen",
  "reqwest 0.12.9",
- "rustls 0.23.16",
+ "rustls 0.23.17",
  "rustls-acme",
  "rustls-pemfile 2.2.0",
  "rustls-platform-verifier",
@@ -4990,7 +4990,7 @@ dependencies = [
  "strum_macros 0.26.4",
  "sync_wrapper 1.0.1",
  "systemstat",
- "thiserror 1.0.68",
+ "thiserror 2.0.3",
  "tokio",
  "tokio-io-timeout",
  "tokio-rustls 0.26.0",
@@ -6167,7 +6167,7 @@ dependencies = [
  "k8s-openapi",
  "kube-core",
  "pem 3.0.3",
- "rustls 0.23.16",
+ "rustls 0.23.17",
  "rustls-pemfile 2.2.0",
  "secrecy",
  "serde",
@@ -8693,7 +8693,7 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash 2.0.0",
- "rustls 0.23.16",
+ "rustls 0.23.17",
  "socket2 0.5.7",
  "thiserror 1.0.68",
  "tokio",
@@ -8710,7 +8710,7 @@ dependencies = [
  "rand 0.8.5",
  "ring 0.17.7",
  "rustc-hash 2.0.0",
- "rustls 0.23.16",
+ "rustls 0.23.17",
  "slab",
  "thiserror 1.0.68",
  "tinyvec",
@@ -9177,7 +9177,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.16",
+ "rustls 0.23.17",
  "rustls-native-certs 0.8.0",
  "rustls-pemfile 2.2.0",
  "rustls-pki-types",
@@ -9524,9 +9524,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.16"
+version = "0.23.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eee87ff5d9b36712a58574e12e9f0ea80f915a5b0ac518d322b24a465617925e"
+checksum = "7f1a745511c54ba6d4465e8d5dfbd81b45791756de28d4981af70d6dca128f1e"
 dependencies = [
  "brotli 7.0.0",
  "brotli-decompressor 4.0.1",
@@ -9638,7 +9638,7 @@ dependencies = [
  "jni",
  "log",
  "once_cell",
- "rustls 0.23.16",
+ "rustls 0.23.17",
  "rustls-native-certs 0.7.0",
  "rustls-platform-verifier-android",
  "rustls-webpki 0.102.8",
@@ -11307,7 +11307,7 @@ version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
 dependencies = [
- "rustls 0.23.16",
+ "rustls 0.23.17",
  "rustls-pki-types",
  "tokio",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4433,7 +4433,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f2f12607f92c69b12ed746fabf9ca4f5c482cba46679c1a75b874ed7c26adb"
 dependencies = [
  "futures-io",
- "rustls 0.23.16",
+ "rustls 0.23.17",
  "rustls-pki-types",
 ]
 
@@ -5056,7 +5056,7 @@ dependencies = [
  "clap 4.5.20",
  "hyper 1.5.0",
  "hyper-util",
- "rustls 0.23.16",
+ "rustls 0.23.17",
  "rustls-pemfile 2.2.0",
  "serde_json",
  "tokio",
@@ -5185,7 +5185,7 @@ dependencies = [
  "hyper 1.5.0",
  "hyper-util",
  "log",
- "rustls 0.23.16",
+ "rustls 0.23.17",
  "rustls-native-certs 0.8.0",
  "rustls-pki-types",
  "tokio",
@@ -5629,7 +5629,7 @@ dependencies = [
 [[package]]
 name = "ic-bn-lib"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic-bn-lib?rev=526d34d15cfbf369d8baf2dae9932aa18d570a1d#526d34d15cfbf369d8baf2dae9932aa18d570a1d"
+source = "git+https://github.com/dfinity/ic-bn-lib?rev=2496803db52d8182f578f098a3ffe4fcb9573fcd#2496803db52d8182f578f098a3ffe4fcb9573fcd"
 dependencies = [
  "ahash 0.8.11",
  "anyhow",
@@ -5665,7 +5665,7 @@ dependencies = [
  "rand 0.8.5",
  "rcgen",
  "reqwest 0.12.9",
- "rustls 0.23.16",
+ "rustls 0.23.17",
  "rustls-acme",
  "rustls-pemfile 2.2.0",
  "rustls-platform-verifier",
@@ -5677,7 +5677,7 @@ dependencies = [
  "strum_macros",
  "sync_wrapper 1.0.1",
  "systemstat",
- "thiserror 1.0.68",
+ "thiserror 2.0.3",
  "tokio",
  "tokio-io-timeout",
  "tokio-rustls 0.26.0",
@@ -5750,7 +5750,7 @@ dependencies = [
  "rcgen",
  "regex",
  "reqwest 0.12.9",
- "rustls 0.23.16",
+ "rustls 0.23.17",
  "rustls-pemfile 2.2.0",
  "serde",
  "serde_bytes",
@@ -6084,7 +6084,7 @@ dependencies = [
  "prost 0.13.3",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
- "rustls 0.23.16",
+ "rustls 0.23.17",
  "serde",
  "serde_cbor",
  "tokio",
@@ -6973,7 +6973,7 @@ dependencies = [
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "rsa",
- "rustls 0.23.16",
+ "rustls 0.23.17",
  "serde",
  "sha2 0.10.8",
  "simple_asn1",
@@ -7731,7 +7731,7 @@ dependencies = [
  "ic-types-test-utils",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
- "rustls 0.23.16",
+ "rustls 0.23.17",
  "tempfile",
  "tokio",
 ]
@@ -7931,7 +7931,7 @@ dependencies = [
  "ic-types",
  "pkcs8",
  "rand 0.8.5",
- "rustls 0.23.16",
+ "rustls 0.23.17",
  "signature",
  "time",
  "tokio",
@@ -7967,7 +7967,7 @@ dependencies = [
  "ic-types",
  "json5",
  "maplit",
- "rustls 0.23.16",
+ "rustls 0.23.17",
  "serde",
  "thiserror 2.0.3",
  "x509-parser",
@@ -7980,7 +7980,7 @@ dependencies = [
  "ic-base-types",
  "ic-crypto-tls-interfaces",
  "mockall",
- "rustls 0.23.16",
+ "rustls 0.23.17",
 ]
 
 [[package]]
@@ -8492,7 +8492,7 @@ dependencies = [
  "rand 0.8.5",
  "reqwest 0.12.9",
  "rstest",
- "rustls 0.23.16",
+ "rustls 0.23.17",
  "serde",
  "serde_bytes",
  "serde_cbor",
@@ -8612,7 +8612,7 @@ dependencies = [
  "prometheus",
  "rand 0.8.5",
  "rstest",
- "rustls 0.23.16",
+ "rustls 0.23.17",
  "rustls-pemfile 2.2.0",
  "serde",
  "serde_json",
@@ -10725,7 +10725,7 @@ dependencies = [
  "quinn",
  "quinn-udp",
  "rcgen",
- "rustls 0.23.16",
+ "rustls 0.23.17",
  "serde",
  "slog",
  "tempfile",
@@ -10889,7 +10889,7 @@ dependencies = [
  "prost 0.13.3",
  "quinn",
  "rstest",
- "rustls 0.23.16",
+ "rustls 0.23.17",
  "slog",
  "socket2 0.5.7",
  "thiserror 2.0.3",
@@ -14698,7 +14698,7 @@ dependencies = [
  "k8s-openapi",
  "kube-core",
  "pem 3.0.4",
- "rustls 0.23.16",
+ "rustls 0.23.17",
  "rustls-pemfile 2.2.0",
  "secrecy",
  "serde",
@@ -17761,7 +17761,7 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash 2.0.0",
- "rustls 0.23.16",
+ "rustls 0.23.17",
  "socket2 0.5.7",
  "thiserror 1.0.68",
  "tokio",
@@ -17778,7 +17778,7 @@ dependencies = [
  "rand 0.8.5",
  "ring 0.17.8",
  "rustc-hash 2.0.0",
- "rustls 0.23.16",
+ "rustls 0.23.17",
  "slab",
  "thiserror 1.0.68",
  "tinyvec",
@@ -18396,7 +18396,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.16",
+ "rustls 0.23.17",
  "rustls-native-certs 0.8.0",
  "rustls-pemfile 2.2.0",
  "rustls-pki-types",
@@ -18811,9 +18811,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.16"
+version = "0.23.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eee87ff5d9b36712a58574e12e9f0ea80f915a5b0ac518d322b24a465617925e"
+checksum = "7f1a745511c54ba6d4465e8d5dfbd81b45791756de28d4981af70d6dca128f1e"
 dependencies = [
  "brotli 7.0.0",
  "brotli-decompressor",
@@ -18913,7 +18913,7 @@ dependencies = [
  "jni",
  "log",
  "once_cell",
- "rustls 0.23.16",
+ "rustls 0.23.17",
  "rustls-native-certs 0.7.3",
  "rustls-platform-verifier-android",
  "rustls-webpki 0.102.8",
@@ -21009,7 +21009,7 @@ version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
 dependencies = [
- "rustls 0.23.16",
+ "rustls 0.23.17",
  "rustls-pki-types",
  "tokio",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -671,7 +671,7 @@ rolling-file = "0.2.0"
 rsa = { version = "0.9.6", features = ["sha2"] }
 rstest = "0.19.0"
 rustc-demangle = { version = "0.1.16" }
-rustls = { version = "0.23.16", default-features = false, features = [
+rustls = { version = "0.23.17", default-features = false, features = [
     "ring",
     "std",
     "brotli",

--- a/bazel/external_crates.bzl
+++ b/bazel/external_crates.bzl
@@ -568,7 +568,7 @@ def external_crates_repository(name, cargo_lockfile, lockfile, sanitizers_enable
             ),
             "ic-bn-lib": crate.spec(
                 git = "https://github.com/dfinity/ic-bn-lib",
-                rev = "526d34d15cfbf369d8baf2dae9932aa18d570a1d",
+                rev = "2496803db52d8182f578f098a3ffe4fcb9573fcd",
             ),
             "ic-btc-interface": crate.spec(
                 version = "^0.2.2",
@@ -1081,7 +1081,7 @@ def external_crates_repository(name, cargo_lockfile, lockfile, sanitizers_enable
                 version = "^1.1.0",
             ),
             "rustls": crate.spec(
-                version = "^0.23.16",
+                version = "^0.23.17",
                 default_features = False,
                 features = [
                     "ring",

--- a/ic-os/boundary-guestos/context/Dockerfile
+++ b/ic-os/boundary-guestos/context/Dockerfile
@@ -25,8 +25,8 @@ WORKDIR /tmp
 
 # Download and verify ic-gateway
 RUN \
-    curl -L -O https://github.com/dfinity/ic-gateway/releases/download/v0.1.59/ic-gateway_0.1.59_amd64.deb && \
-    echo "2d57c4a6e77f974ce4674ebc631ba5f2c7de0bb4bf05069c5bcffb21ec274ea2  ic-gateway_0.1.59_amd64.deb" | sha256sum -c
+    curl -L -O https://github.com/dfinity/ic-gateway/releases/download/v0.1.60/ic-gateway_0.1.60_amd64.deb && \
+    echo "20abbe7a26da531ff459a905c92c3a9f01c6582cf2751bc63e46b11671f3f003  ic-gateway_0.1.60_amd64.deb" | sha256sum -c
 
 #
 # Second build stage:
@@ -56,9 +56,9 @@ FROM image-${BUILD_TYPE}
 
 USER root:root
 
-COPY --from=download /tmp/ic-gateway_0.1.59_amd64.deb /tmp/ic-gateway_0.1.59_amd64.deb
-RUN dpkg -i --force-confold /tmp/ic-gateway_0.1.59_amd64.deb && \
-    rm /tmp/ic-gateway_0.1.59_amd64.deb
+COPY --from=download /tmp/ic-gateway_0.1.60_amd64.deb /tmp/ic-gateway_0.1.60_amd64.deb
+RUN dpkg -i --force-confold /tmp/ic-gateway_0.1.60_amd64.deb && \
+    rm /tmp/ic-gateway_0.1.60_amd64.deb
 
 RUN mkdir -p /boot/config \
              /boot/efi \

--- a/rs/boundary_node/ic_boundary/Cargo.toml
+++ b/rs/boundary_node/ic_boundary/Cargo.toml
@@ -33,7 +33,7 @@ http = { workspace = true }
 http-body = { workspace = true }
 humantime = "2.1"
 ic-base-types = { path = "../../types/base_types" }
-ic-bn-lib = { git = "https://github.com/dfinity/ic-bn-lib", rev = "526d34d15cfbf369d8baf2dae9932aa18d570a1d" }
+ic-bn-lib = { git = "https://github.com/dfinity/ic-bn-lib", rev = "2496803db52d8182f578f098a3ffe4fcb9573fcd" }
 ic-certification-test-utils = { path = "../../certification/test-utils" }
 ic-config = { path = "../../config" }
 ic-crypto-ed25519 = { path = "../../crypto/ed25519" }


### PR DESCRIPTION
Also bump `rustls` minor as `ic-bn-lib` needs it.