### PR TITLE
feat(sns): Unify validation of `AdvanceTargetVersion.new_target` at proposal submission and execution times

### DIFF
--- a/rs/sns/governance/src/governance.rs
+++ b/rs/sns/governance/src/governance.rs
@@ -462,6 +462,55 @@ impl GovernanceProto {
             .expect("GovernanceProto.deployed_version must be set.")
     }
 
+    pub(crate) fn validate_new_target_version<V>(
+        &self,
+        new_target: Option<V>,
+    ) -> Result<
+        (
+            /* pending_upgrade_steps */ CachedUpgradeSteps,
+            /* valid_target_version */ Version,
+        ),
+        String,
+    >
+    where
+        Version: TryFrom<V>,
+        <Version as TryFrom<V>>::Error: ToString,
+    {
+        let deployed_version = self.deployed_version_or_err()?;
+
+        let upgrade_steps = {
+            let cached_upgrade_steps = self.cached_upgrade_steps_or_err()?;
+            cached_upgrade_steps.take_from(&deployed_version)?
+        };
+
+        if upgrade_steps.is_empty() {
+            return Err(
+                "Cannot advance SNS target version: there are no pending upgrades.".to_string(),
+            );
+        }
+
+        let new_target = if let Some(new_target) = new_target {
+            let new_target = Version::try_from(new_target).map_err(|err| err.to_string())?;
+            upgrade_steps.validate_new_target_version(&new_target)?;
+            new_target
+        } else {
+            upgrade_steps.last().clone()
+        };
+
+        if let Some(current_target_version) = &self.target_version {
+            let new_target_is_not_ahead_of_current_target =
+                upgrade_steps.contains_in_order(&new_target, current_target_version)?;
+            if new_target_is_not_ahead_of_current_target {
+                return Err(format!(
+                    "SNS target already set to {}.",
+                    current_target_version
+                ));
+            }
+        }
+
+        Ok((upgrade_steps, new_target))
+    }
+
     /// Returns 0 if maturity modulation is disabled (per
     /// nervous_system_parameters.maturity_modulation_disabled). Otherwise,
     /// returns the value in self.maturity_modulation.current_basis_points. If
@@ -3054,21 +3103,17 @@ impl Governance {
         // TODO[NNS1-3365]: Enable the AdvanceSnsTargetVersionFeature.
         self.check_test_features_enabled();
 
-        let cached_upgrade_steps = self
+        let (_, target_version) = self
             .proto
-            .cached_upgrade_steps_or_err()
-            .map_err(|err| GovernanceError::new_with_message(ErrorType::NotFound, err))?;
-
-        cached_upgrade_steps
-            .validate_new_target_version(&new_target)
+            .validate_new_target_version(Some(new_target))
             .map_err(|err| GovernanceError::new_with_message(ErrorType::InvalidProposal, err))?;
 
         self.push_to_upgrade_journal(upgrade_journal_entry::TargetVersionSet::new(
             self.proto.target_version.clone(),
-            Some(new_target.clone()),
+            Some(target_version.clone()),
         ));
 
-        self.proto.target_version = Some(new_target);
+        self.proto.target_version = Some(target_version);
 
         Ok(())
     }

--- a/rs/sns/governance/src/governance/advance_target_sns_version_tests.rs
+++ b/rs/sns/governance/src/governance/advance_target_sns_version_tests.rs
@@ -282,8 +282,7 @@ fn test_perform_advance_target_version() {
 
     let make_governance = |versions: Vec<Version>, current_target| {
         let mut governance_proto = basic_governance_proto();
-        let deployed_version: Version = versions.get(0).unwrap().clone();
-        governance_proto.deployed_version = Some(deployed_version);
+        governance_proto.deployed_version = versions.first().cloned();
         governance_proto.target_version = current_target;
         governance_proto.cached_upgrade_steps = Some(CachedUpgradeStepsPb {
             upgrade_steps: Some(Versions { versions }),

--- a/rs/sns/governance/src/governance/advance_target_sns_version_tests.rs
+++ b/rs/sns/governance/src/governance/advance_target_sns_version_tests.rs
@@ -250,3 +250,105 @@ async fn test_initiate_upgrade_blocked_by_pending_upgrade() {
         Some(Version::from(target_version))
     );
 }
+
+#[test]
+fn test_perform_advance_target_version() {
+    let deployed_version = Version {
+        root_wasm_hash: vec![1, 0, 1],
+        governance_wasm_hash: vec![1, 0, 2],
+        swap_wasm_hash: vec![1, 0, 3],
+        index_wasm_hash: vec![1, 0, 4],
+        ledger_wasm_hash: vec![1, 0, 5],
+        archive_wasm_hash: vec![1, 0, 6],
+    };
+    let next_version = Version {
+        root_wasm_hash: vec![2, 0, 1],
+        ..deployed_version.clone()
+    };
+    let next_next_version = Version {
+        index_wasm_hash: vec![2, 0, 4],
+        ..deployed_version.clone()
+    };
+    // Smoke check: Make sure all versions are different
+    let versions = vec![
+        deployed_version.clone(),
+        next_version.clone(),
+        next_next_version.clone(),
+    ];
+    assert!(
+        versions.iter().collect::<HashSet::<_>>().len() == versions.len(),
+        "Duplicates!"
+    );
+
+    let make_governance = |versions: Vec<Version>, current_target| {
+        let mut governance_proto = basic_governance_proto();
+        let deployed_version: Version = versions.get(0).unwrap().clone();
+        governance_proto.deployed_version = Some(deployed_version);
+        governance_proto.target_version = current_target;
+        governance_proto.cached_upgrade_steps = Some(CachedUpgradeStepsPb {
+            upgrade_steps: Some(Versions { versions }),
+            ..Default::default()
+        });
+        let env = NativeEnvironment::new(Some(*TEST_GOVERNANCE_CANISTER_ID));
+        let mut governance = crate::governance::Governance::new(
+            governance_proto.try_into().unwrap(),
+            Box::new(env),
+            Box::new(DoNothingLedger {}),
+            Box::new(DoNothingLedger {}),
+            Box::new(FakeCmc::new()),
+        );
+        // TODO[NNS1-3365]: Enable the AdvanceSnsTargetVersionFeature.
+        governance.test_features_enabled = true;
+        governance
+    };
+
+    for (label, current_target, new_target, expected_result) in [
+        (
+            "Scenario A. Cannot advance SNS target to deployed version.",
+            None,
+            deployed_version,
+            Err(
+                "InvalidProposal: new_target_version must differ from the current version."
+                    .to_string(),
+            ),
+        ),
+        (
+            "Scenario B. Can advance SNS target to next version.",
+            None,
+            next_version.clone(),
+            Ok(()),
+        ),
+        (
+            "Scenario C. Can advance SNS target to next next version (current target is not set).",
+            None,
+            next_next_version.clone(),
+            Ok(()),
+        ),
+        (
+            "Scenario D. Can advance SNS target to next next version (current target is set).",
+            Some(next_version.clone()),
+            next_next_version.clone(),
+            Ok(()),
+        ),
+        (
+            "Scenario E. Cannot advance SNS target to next version since current target is ahead.",
+            Some(next_next_version),
+            next_version.clone(),
+            Err("InvalidProposal: SNS target already set to SnsVersion { \
+                    root:010001, \
+                    governance:010002, \
+                    swap:010003, \
+                    index:020004, \
+                    ledger:010005, \
+                    archive:010006 \
+                }."
+            .to_string()),
+        ),
+    ] {
+        let mut governance = make_governance(versions.clone(), current_target);
+        let result = governance
+            .perform_advance_target_version(new_target)
+            .map_err(|err| err.to_string());
+        assert_eq!(result, expected_result, "{}", label);
+    }
+}

--- a/rs/sns/governance/src/proposal/advance_sns_target_version.rs
+++ b/rs/sns/governance/src/proposal/advance_sns_target_version.rs
@@ -306,10 +306,7 @@ fn test_invalid_new_targets() {
             Action::AdvanceSnsTargetVersion(AdvanceSnsTargetVersion {
                 new_target: Some(SnsVersion::from(next_version.clone())),
             }),
-            Err(format!(
-                "SNS target already set to version {}.",
-                next_version
-            )),
+            Err(format!("SNS target already set to {}.", next_version)),
         ),
         (
             "Scenario D: `new_target` is behind `current_target_version`.",
@@ -317,10 +314,7 @@ fn test_invalid_new_targets() {
             Action::AdvanceSnsTargetVersion(AdvanceSnsTargetVersion {
                 new_target: Some(SnsVersion::from(next_version.clone())),
             }),
-            Err(format!(
-                "SNS target already set to version {}.",
-                next_next_version
-            )),
+            Err(format!("SNS target already set to {}.", next_next_version)),
         ),
         (
             "Scenario E: `new_target` is ahead of `current_target_version`.",


### PR DESCRIPTION
This PR slightly refactors the validation logic at `AdvanceTargetVersion.new_target` proposal submission time, and uses the same validation at execution times. The state of the SNS can change between those two time points, therefore re-validation is required.