### PR TITLE
fix(IDX): read hostos URL directly

### DIFF
--- a/rs/tests/driver/src/driver/test_env_api.rs
+++ b/rs/tests/driver/src/driver/test_env_api.rs
@@ -1223,8 +1223,7 @@ pub fn get_mainnet_ic_os_update_img_url() -> Result<Url> {
 }
 
 pub fn get_hostos_update_img_test_url() -> Result<Url> {
-    let url =
-        read_dependency_from_env_to_string("ENV_DEPS__DEV_HOSTOS_UPDATE_IMG_TEST_TAR_ZST_CAS_URL")?;
+    let url = std::env::var("ENV_DEPS__DEV_HOSTOS_UPDATE_IMG_TEST_TAR_ZST_CAS_URL")?;
     Ok(Url::parse(&url)?)
 }
 


### PR DESCRIPTION
This fixes a hostos image lookup function. The function previously tried to read the URL as a local (run)file.