### PR TITLE
fix(IDX): Ensure upload_systest_dep variables are defined

### DIFF
--- a/bazel/upload_systest_dep.sh
+++ b/bazel/upload_systest_dep.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
-#
+
+set -euo pipefail
+
 # Uploads a dependency to shared storage and returns the download URL.
 #
 # The path to the dependency should be specified as the first (and only) argument.
@@ -43,6 +45,7 @@ lookup_dep_url() {
 }
 
 dep_filename="${1:?Dependency not specified}"
+dep_sha256=$(sha256sum "$dep_filename" | cut -d' ' -f1)
 
 echo "Found dep to upload $dep_filename ($dep_sha256)" >&2
 result_url=$(lookup_dep_url "$dep_sha256")
@@ -52,14 +55,13 @@ result_url=$(lookup_dep_url "$dep_sha256")
 if [ -n "$result_url" ]; then
     echo "dep '$dep_filename': already uploaded" >&2
 else
-    echo "dep '$dep_filename': not uploaded yet, uploading to $dep_upload_url" >&2
+    echo "dep '$dep_filename': not uploaded yet" >&2
 
     # We use bazel-remote as a CAS storage
     UPLOAD_URL="http://server.bazel-remote.svc.cluster.local:8080/cas"
     echo "Using upload URL: '$UPLOAD_URL'" >&2
 
     # Upload the dep
-    dep_sha256=$(sha256sum "$dep_filename" | cut -d' ' -f1)
     dep_upload_url="$UPLOAD_URL/$dep_sha256"
     # read & pretty print 3 metrics: upload size, upload time & upload speed
     read -ra metrics < <(curl --silent --fail "$dep_upload_url" --upload-file "$dep_filename" -w '%{size_upload} %{time_total} %{speed_upload}')


### PR DESCRIPTION
This defines all variables in `upload_systest_dep`. Two variables were not defined at the first use site due to a last minute refactoring.

This PR also enables `set -u` which will ensure that bash fails if a variable is used before being defined. This should have been enabled when the changes were first introduced; this was an oversight.