### PR TITLE
test(sns): Add unit tests for automatic upgrades triggered when target version ahead of deployed version

### DIFF
--- a/rs/sns/governance/src/governance.rs
+++ b/rs/sns/governance/src/governance.rs
@@ -6132,3 +6132,6 @@ mod fail_stuck_upgrade_in_progress_tests;
 
 #[cfg(test)]
 mod advance_target_sns_version_tests;
+
+#[cfg(test)]
+mod test_helpers;

--- a/rs/sns/governance/src/governance/advance_target_sns_version_tests.rs
+++ b/rs/sns/governance/src/governance/advance_target_sns_version_tests.rs
@@ -1,11 +1,22 @@
-use super::assorted_governance_tests::{
-    basic_governance_proto, DoNothingLedger, TEST_GOVERNANCE_CANISTER_ID, TEST_ROOT_CANISTER_ID,
+use super::test_helpers::{
+    basic_governance_proto, canister_status_for_test,
+    canister_status_from_management_canister_for_test, DoNothingLedger, TEST_ARCHIVES_CANISTER_IDS,
+    TEST_GOVERNANCE_CANISTER_ID, TEST_INDEX_CANISTER_ID, TEST_LEDGER_CANISTER_ID,
+    TEST_ROOT_CANISTER_ID, TEST_SWAP_CANISTER_ID,
 };
 use super::*;
+use crate::sns_upgrade::CanisterSummary;
+use crate::sns_upgrade::GetWasmRequest;
+use crate::sns_upgrade::GetWasmResponse;
+use crate::sns_upgrade::SnsWasm;
+use crate::sns_upgrade::{GetSnsCanistersSummaryRequest, GetSnsCanistersSummaryResponse};
 use crate::{
     pb::v1::{ProposalData, Tally, UpgradeSnsToNextVersion},
     sns_upgrade::{ListUpgradeStep, ListUpgradeStepsRequest, ListUpgradeStepsResponse, SnsVersion},
     types::test_helpers::NativeEnvironment,
+};
+use ic_nervous_system_clients::{
+    canister_id_record::CanisterIdRecord, canister_status::CanisterStatusType,
 };
 use ic_nervous_system_common::cmc::FakeCmc;
 use ic_nns_constants::SNS_WASM_CANISTER_ID;
@@ -75,8 +86,8 @@ async fn test_initiate_upgrade_blocked_by_upgrade_proposal() {
     let mut governance = Governance::new(
         GovernanceProto {
             root_canister_id: Some(root_canister_id.get()),
-            deployed_version: Some(current_version.clone().into()),
-            target_version: Some(target_version.clone().into()),
+            deployed_version: Some(Version::from(current_version.clone())),
+            target_version: Some(Version::from(target_version.clone())),
             // Add an upgrade proposal that is adopted but not executed
             proposals: btreemap! {
                 proposal_id => proposal
@@ -125,6 +136,279 @@ async fn test_initiate_upgrade_blocked_by_upgrade_proposal() {
     // The target version should remain unchanged
     assert_eq!(
         governance.proto.target_version,
+        Some(Version::from(target_version))
+    );
+}
+
+#[tokio::test]
+async fn test_automatic_upgrade_when_behind_target_version_for_root() {
+    // Step 1: Prepare the world.
+    let root_canister_id = *TEST_ROOT_CANISTER_ID;
+    let governance_canister_id = *TEST_GOVERNANCE_CANISTER_ID;
+
+    let mut env = NativeEnvironment::new(Some(governance_canister_id));
+
+    let current_version = SnsVersion {
+        root_wasm_hash: vec![1, 2, 3],
+        governance_wasm_hash: vec![2, 3, 4],
+        ledger_wasm_hash: vec![3, 4, 5],
+        swap_wasm_hash: vec![4, 5, 6],
+        archive_wasm_hash: vec![5, 6, 7],
+        index_wasm_hash: vec![6, 7, 8],
+    };
+
+    let intermediate_version = {
+        let mut version = current_version.clone();
+        version.root_wasm_hash = vec![4, 4, 4];
+        version
+    };
+
+    let target_version = {
+        let mut version = intermediate_version.clone();
+        version.root_wasm_hash = vec![9, 9, 9];
+        version
+    };
+
+    // Set up environment to return upgrade steps that would allow an upgrade
+    env.set_call_canister_response(
+        SNS_WASM_CANISTER_ID,
+        "list_upgrade_steps",
+        Encode!(&ListUpgradeStepsRequest {
+            starting_at: Some(current_version.clone()),
+            sns_governance_canister_id: Some(governance_canister_id.into()),
+            limit: 0,
+        })
+        .unwrap(),
+        Ok(Encode!(&ListUpgradeStepsResponse {
+            steps: vec![
+                ListUpgradeStep {
+                    version: Some(current_version.clone())
+                },
+                ListUpgradeStep {
+                    version: Some(intermediate_version.clone())
+                },
+                ListUpgradeStep {
+                    version: Some(target_version.clone())
+                },
+            ]
+        })
+        .unwrap()),
+    );
+
+    let mut governance = Governance::new(
+        GovernanceProto {
+            root_canister_id: Some(root_canister_id.get()),
+            deployed_version: Some(Version::from(current_version.clone())),
+            ..basic_governance_proto()
+        }
+        .try_into()
+        .unwrap(),
+        Box::new(env),
+        Box::new(DoNothingLedger {}),
+        Box::new(DoNothingLedger {}),
+        Box::new(FakeCmc::new()),
+    );
+
+    // Step 2: Update the cached upgrade steps
+    assert_eq!(governance.proto.cached_upgrade_steps, None);
+    governance.run_periodic_tasks().await;
+    assert_eq!(
+        governance
+            .proto
+            .cached_upgrade_steps
+            .clone()
+            .unwrap()
+            .upgrade_steps
+            .unwrap()
+            .versions
+            .len(),
+        3
+    );
+
+    // Step 3: Set target version to latest version
+    governance.proto.target_version = Some(Version::from(target_version.clone()));
+
+    // Step 4: Run periodic tasks and observe upgrades
+
+    {
+        // The first periodic task initiates the upgrade
+        let mut env = NativeEnvironment::new(Some(governance_canister_id));
+        add_environment_mock_calls_for_initiate_upgrade(
+            &mut env,
+            vec![4, 4, 4],
+            SnsCanisterType::Root,
+            current_version.clone(),
+        );
+        governance.env = Box::new(env);
+        governance.run_periodic_tasks().await;
+    }
+    {
+        // The second periodic task marks the upgrade as completed, and starts the next one
+        let mut env = NativeEnvironment::new(Some(governance_canister_id));
+        add_environment_mock_get_sns_canisters_summary_call(&mut env, intermediate_version.clone());
+        add_environment_mock_calls_for_initiate_upgrade(
+            &mut env,
+            vec![9, 9, 9],
+            SnsCanisterType::Root,
+            intermediate_version.clone(),
+        );
+        governance.env = Box::new(env);
+        governance.run_periodic_tasks().await;
+    }
+
+    // Should now be at intermediate version
+    assert_eq!(
+        governance.proto.deployed_version,
+        Some(Version::from(intermediate_version.clone()))
+    );
+
+    {
+        // The third periodic task marks the upgrade as completed
+        let mut env = NativeEnvironment::new(Some(governance_canister_id));
+        add_environment_mock_get_sns_canisters_summary_call(&mut env, target_version.clone());
+        governance.env = Box::new(env);
+        governance.run_periodic_tasks().await;
+    }
+
+    // Should now be at target version
+    assert_eq!(
+        governance.proto.deployed_version,
+        Some(Version::from(target_version))
+    );
+}
+
+#[tokio::test]
+async fn test_automatic_upgrade_when_behind_target_version_for_governance() {
+    // Step 1: Prepare the world.
+    let root_canister_id = *TEST_ROOT_CANISTER_ID;
+    let governance_canister_id = *TEST_GOVERNANCE_CANISTER_ID;
+
+    let mut env = NativeEnvironment::new(Some(governance_canister_id));
+
+    let current_version = SnsVersion {
+        root_wasm_hash: vec![1, 2, 3],
+        governance_wasm_hash: vec![2, 3, 4],
+        ledger_wasm_hash: vec![3, 4, 5],
+        swap_wasm_hash: vec![4, 5, 6],
+        archive_wasm_hash: vec![5, 6, 7],
+        index_wasm_hash: vec![6, 7, 8],
+    };
+
+    let intermediate_version = {
+        let mut version = current_version.clone();
+        version.governance_wasm_hash = vec![4, 4, 4];
+        version
+    };
+
+    let target_version = {
+        let mut version = intermediate_version.clone();
+        version.governance_wasm_hash = vec![9, 9, 9];
+        version
+    };
+
+    // Set up environment to return upgrade steps that would allow an upgrade
+    env.set_call_canister_response(
+        SNS_WASM_CANISTER_ID,
+        "list_upgrade_steps",
+        Encode!(&ListUpgradeStepsRequest {
+            starting_at: Some(current_version.clone()),
+            sns_governance_canister_id: Some(governance_canister_id.into()),
+            limit: 0,
+        })
+        .unwrap(),
+        Ok(Encode!(&ListUpgradeStepsResponse {
+            steps: vec![
+                ListUpgradeStep {
+                    version: Some(current_version.clone())
+                },
+                ListUpgradeStep {
+                    version: Some(intermediate_version.clone())
+                },
+                ListUpgradeStep {
+                    version: Some(target_version.clone())
+                },
+            ]
+        })
+        .unwrap()),
+    );
+
+    let mut governance = Governance::new(
+        GovernanceProto {
+            root_canister_id: Some(root_canister_id.get()),
+            deployed_version: Some(current_version.clone().into()),
+            ..basic_governance_proto()
+        }
+        .try_into()
+        .unwrap(),
+        Box::new(env),
+        Box::new(DoNothingLedger {}),
+        Box::new(DoNothingLedger {}),
+        Box::new(FakeCmc::new()),
+    );
+
+    // Step 2: Update the cached upgrade steps
+    assert_eq!(governance.proto.cached_upgrade_steps, None);
+    governance.run_periodic_tasks().await;
+    assert_eq!(
+        governance
+            .proto
+            .cached_upgrade_steps
+            .clone()
+            .unwrap()
+            .upgrade_steps
+            .unwrap()
+            .versions
+            .len(),
+        3
+    );
+
+    // Step 3: Set target version to latest version
+    governance.proto.target_version = Some(Version::from(target_version.clone()));
+
+    // Step 4: Run periodic tasks and observe upgrades
+    {
+        // The first periodic task initiates the upgrade
+        let mut env = NativeEnvironment::new(Some(governance_canister_id));
+        add_environment_mock_calls_for_initiate_upgrade(
+            &mut env,
+            vec![4, 4, 4],
+            SnsCanisterType::Governance,
+            current_version.clone(),
+        );
+        governance.env = Box::new(env);
+        governance.run_periodic_tasks().await;
+    }
+    {
+        // The second periodic task marks the upgrade as completed, and starts the next one
+        let mut env = NativeEnvironment::new(Some(governance_canister_id));
+        add_environment_mock_get_sns_canisters_summary_call(&mut env, intermediate_version.clone());
+        add_environment_mock_calls_for_initiate_upgrade(
+            &mut env,
+            vec![9, 9, 9],
+            SnsCanisterType::Governance,
+            intermediate_version.clone(),
+        );
+        governance.env = Box::new(env);
+        governance.run_periodic_tasks().await;
+    }
+
+    // Should now be at intermediate version
+    assert_eq!(
+        governance.proto.deployed_version,
+        Some(Version::from(intermediate_version))
+    );
+
+    {
+        // The third periodic task marks the upgrade as completed
+        let mut env = NativeEnvironment::new(Some(governance_canister_id));
+        add_environment_mock_get_sns_canisters_summary_call(&mut env, target_version.clone());
+        governance.env = Box::new(env);
+        governance.run_periodic_tasks().await;
+    }
+
+    // Should now be at target version
+    assert_eq!(
+        governance.proto.deployed_version,
         Some(Version::from(target_version))
     );
 }
@@ -350,4 +634,181 @@ fn test_perform_advance_target_version() {
             .map_err(|err| err.to_string());
         assert_eq!(result, expected_result, "{}", label);
     }
+}
+
+fn add_environment_mock_calls_for_initiate_upgrade(
+    env: &mut NativeEnvironment,
+    expected_wasm_hash_requested: Vec<u8>,
+    expected_canister_to_be_upgraded: SnsCanisterType,
+    starting_version: SnsVersion,
+) {
+    let root_canister_id = *TEST_ROOT_CANISTER_ID;
+    let governance_canister_id = *TEST_GOVERNANCE_CANISTER_ID;
+    let ledger_canister_id = *TEST_LEDGER_CANISTER_ID;
+    let ledger_archive_ids = TEST_ARCHIVES_CANISTER_IDS.clone();
+    let index_canister_id = *TEST_INDEX_CANISTER_ID;
+
+    env.set_call_canister_response(
+        SNS_WASM_CANISTER_ID,
+        "get_wasm",
+        Encode!(&GetWasmRequest {
+            hash: expected_wasm_hash_requested
+        })
+        .unwrap(),
+        Ok(Encode!(&GetWasmResponse {
+            wasm: Some(SnsWasm {
+                wasm: vec![9, 8, 7, 6, 5, 4, 3, 2],
+                canister_type: expected_canister_to_be_upgraded.into(), // Governance
+                proposal_id: None,
+            })
+        })
+        .unwrap()),
+    );
+
+    let canisters_to_be_upgraded = match expected_canister_to_be_upgraded {
+        SnsCanisterType::Unspecified => {
+            panic!("Cannot be unspecified")
+        }
+        SnsCanisterType::Root => vec![root_canister_id],
+        SnsCanisterType::Governance => vec![governance_canister_id],
+        SnsCanisterType::Ledger => vec![ledger_canister_id],
+        SnsCanisterType::Archive => ledger_archive_ids,
+        SnsCanisterType::Swap => {
+            panic!("Swap upgrade not supported via SNS (ownership)")
+        }
+        SnsCanisterType::Index => vec![index_canister_id],
+    };
+
+    assert!(!canisters_to_be_upgraded.is_empty());
+
+    if expected_canister_to_be_upgraded != SnsCanisterType::Root {
+        add_environment_mock_get_sns_canisters_summary_call(&mut *env, starting_version);
+        for canister_id in canisters_to_be_upgraded {
+            env.require_call_canister_invocation(
+                root_canister_id,
+                "change_canister",
+                Encode!(&ChangeCanisterRequest::new(
+                    true,
+                    CanisterInstallMode::Upgrade,
+                    canister_id
+                )
+                .with_wasm(vec![9, 8, 7, 6, 5, 4, 3, 2])
+                .with_arg(Encode!().unwrap()))
+                .unwrap(),
+                // We don't actually look at the response from this call anywhere
+                Some(Ok(Encode!().unwrap())),
+            );
+        }
+    } else {
+        for canister_id in canisters_to_be_upgraded {
+            env.set_call_canister_response(
+                CanisterId::ic_00(),
+                "stop_canister",
+                Encode!(&CanisterIdRecord::from(canister_id)).unwrap(),
+                Ok(vec![]),
+            );
+            env.set_call_canister_response(
+                CanisterId::ic_00(),
+                "canister_status",
+                Encode!(&CanisterIdRecord::from(canister_id)).unwrap(),
+                Ok(Encode!(&canister_status_from_management_canister_for_test(
+                    vec![],
+                    CanisterStatusType::Stopped,
+                ))
+                .unwrap()),
+            );
+            env.set_call_canister_response(
+                CanisterId::ic_00(),
+                "start_canister",
+                Encode!(&CanisterIdRecord::from(canister_id)).unwrap(),
+                Ok(vec![]),
+            );
+            // For root canister, this is the required call that ensures our wiring was correct.
+            env.require_call_canister_invocation(
+                CanisterId::ic_00(),
+                "install_code",
+                Encode!(&ic_management_canister_types::InstallCodeArgs {
+                    mode: ic_management_canister_types::CanisterInstallMode::Upgrade,
+                    canister_id: canister_id.get(),
+                    wasm_module: vec![9, 8, 7, 6, 5, 4, 3, 2],
+                    arg: Encode!().unwrap(),
+                    compute_allocation: None,
+                    memory_allocation: None,
+                    sender_canister_version: None,
+                })
+                .unwrap(),
+                Some(Ok(vec![])),
+            );
+        }
+    }
+}
+
+fn add_environment_mock_get_sns_canisters_summary_call(
+    env: &mut NativeEnvironment,
+    version: SnsVersion,
+) {
+    let root_canister_id = *TEST_ROOT_CANISTER_ID;
+    let governance_canister_id = *TEST_GOVERNANCE_CANISTER_ID;
+    let ledger_canister_id = *TEST_LEDGER_CANISTER_ID;
+    let ledger_archive_ids = TEST_ARCHIVES_CANISTER_IDS.clone();
+    let index_canister_id = *TEST_INDEX_CANISTER_ID;
+    let swap_canister_id = *TEST_SWAP_CANISTER_ID;
+
+    env.set_call_canister_response(
+        *TEST_ROOT_CANISTER_ID,
+        "get_sns_canisters_summary",
+        Encode!(&GetSnsCanistersSummaryRequest {
+            update_canister_list: Some(true)
+        })
+        .unwrap(),
+        Ok(Encode!(&GetSnsCanistersSummaryResponse {
+            governance: Some(CanisterSummary {
+                canister_id: Some(PrincipalId::from(governance_canister_id)),
+                status: Some(canister_status_for_test(
+                    version.governance_wasm_hash,
+                    CanisterStatusType::Running,
+                ))
+            }),
+            swap: Some(CanisterSummary {
+                canister_id: Some(PrincipalId::from(swap_canister_id)),
+                status: Some(canister_status_for_test(
+                    version.swap_wasm_hash,
+                    CanisterStatusType::Running,
+                )),
+            }),
+            root: Some(CanisterSummary {
+                canister_id: Some(PrincipalId::from(root_canister_id)),
+                status: Some(canister_status_for_test(
+                    version.root_wasm_hash,
+                    CanisterStatusType::Running,
+                )),
+            }),
+            ledger: Some(CanisterSummary {
+                canister_id: Some(PrincipalId::from(ledger_canister_id)),
+                status: Some(canister_status_for_test(
+                    version.ledger_wasm_hash,
+                    CanisterStatusType::Running,
+                )),
+            }),
+            index: Some(CanisterSummary {
+                canister_id: Some(PrincipalId::from(index_canister_id)),
+                status: Some(canister_status_for_test(
+                    version.index_wasm_hash,
+                    CanisterStatusType::Running,
+                )),
+            }),
+            archives: ledger_archive_ids
+                .iter()
+                .map(|id| CanisterSummary {
+                    canister_id: Some(PrincipalId::from(*id)),
+                    status: Some(canister_status_for_test(
+                        version.archive_wasm_hash.clone(),
+                        CanisterStatusType::Running,
+                    )),
+                })
+                .collect(),
+            dapps: vec![],
+        })
+        .unwrap()),
+    );
 }

--- a/rs/sns/governance/src/governance/assorted_governance_tests.rs
+++ b/rs/sns/governance/src/governance/assorted_governance_tests.rs
@@ -3,10 +3,16 @@
 //! The name of this file is indeed too generic; feel free to factor specific tests out into
 //! more appropriate locations, or create new file modules for them, whatever makes more sense.
 
+use super::test_helpers::{
+    basic_governance_proto, canister_status_for_test,
+    canister_status_from_management_canister_for_test, DoNothingLedger, A_MOTION_PROPOSAL,
+    A_NEURON, A_NEURON_ID, A_NEURON_PRINCIPAL_ID, TEST_ARCHIVES_CANISTER_IDS,
+    TEST_DAPP_CANISTER_IDS, TEST_GOVERNANCE_CANISTER_ID, TEST_INDEX_CANISTER_ID,
+    TEST_LEDGER_CANISTER_ID, TEST_ROOT_CANISTER_ID, TEST_SWAP_CANISTER_ID,
+};
 use super::*;
 use crate::{
     pb::v1::{
-        governance::SnsMetadata,
         manage_neuron_response,
         nervous_system_function::{FunctionType, GenericNervousSystemFunction},
         neuron, Account as AccountProto, Motion, NeuronPermissionType, ProposalData, ProposalId,
@@ -28,10 +34,7 @@ use candid::Principal;
 use futures::{join, FutureExt};
 use ic_canister_client_sender::Sender;
 use ic_nervous_system_clients::{
-    canister_id_record::CanisterIdRecord,
-    canister_status::{
-        CanisterStatusResultFromManagementCanister, CanisterStatusResultV2, CanisterStatusType,
-    },
+    canister_id_record::CanisterIdRecord, canister_status::CanisterStatusType,
 };
 use ic_nervous_system_common::{
     assert_is_err, assert_is_ok, cmc::FakeCmc, ledger::compute_neuron_staking_subaccount_bytes, E8,
@@ -51,34 +54,6 @@ use std::{
     sync::{Arc, Mutex},
     time::{Duration, SystemTime},
 };
-
-pub(crate) struct DoNothingLedger {}
-
-#[async_trait]
-impl ICRC1Ledger for DoNothingLedger {
-    async fn transfer_funds(
-        &self,
-        _amount_e8s: u64,
-        _fee_e8s: u64,
-        _from_subaccount: Option<Subaccount>,
-        _to: Account,
-        _memo: u64,
-    ) -> Result<u64, NervousSystemError> {
-        unimplemented!();
-    }
-
-    async fn total_supply(&self) -> Result<Tokens, NervousSystemError> {
-        unimplemented!()
-    }
-
-    async fn account_balance(&self, _account: Account) -> Result<Tokens, NervousSystemError> {
-        unimplemented!()
-    }
-
-    fn canister_id(&self) -> CanisterId {
-        unimplemented!()
-    }
-}
 
 struct AlwaysSucceedingLedger {}
 
@@ -108,24 +83,6 @@ impl ICRC1Ledger for AlwaysSucceedingLedger {
     }
 }
 
-pub(crate) fn basic_governance_proto() -> GovernanceProto {
-    GovernanceProto {
-        root_canister_id: Some(PrincipalId::new_user_test_id(53)),
-        ledger_canister_id: Some(PrincipalId::new_user_test_id(228)),
-        swap_canister_id: Some(PrincipalId::new_user_test_id(15)),
-
-        parameters: Some(NervousSystemParameters::with_default_values()),
-        mode: governance::Mode::Normal as i32,
-        sns_metadata: Some(SnsMetadata {
-            logo: Some("data:image/png;base64,aGVsbG8gZnJvbSBkZmluaXR5IQ==".to_string()),
-            name: Some("ServiceNervousSystem-Test".to_string()),
-            description: Some("A project to spin up a ServiceNervousSystem".to_string()),
-            url: Some("https://internetcomputer.org".to_string()),
-        }),
-        ..Default::default()
-    }
-}
-
 const TRANSITION_ROUND_COUNT: u64 = 42;
 const BASE_VOTING_REWARDS_PARAMETERS: VotingRewardsParameters = VotingRewardsParameters {
     round_duration_seconds: Some(7 * 24 * 60 * 60), // 1 week
@@ -133,45 +90,6 @@ const BASE_VOTING_REWARDS_PARAMETERS: VotingRewardsParameters = VotingRewardsPar
     initial_reward_rate_basis_points: Some(200),                                              // 2%
     final_reward_rate_basis_points: Some(100),                                                // 1%
 };
-
-lazy_static! {
-    static ref A_NEURON_PRINCIPAL_ID: PrincipalId = PrincipalId::new_user_test_id(956560);
-
-    static ref A_NEURON_ID: NeuronId = NeuronId::from(
-        compute_neuron_staking_subaccount_bytes(*A_NEURON_PRINCIPAL_ID, /* nonce = */ 0),
-    );
-
-    static ref A_NEURON: Neuron = Neuron {
-        id: Some(A_NEURON_ID.clone()),
-        permissions: vec![NeuronPermission {
-            principal: Some(*A_NEURON_PRINCIPAL_ID),
-            permission_type: NeuronPermissionType::all(),
-        }],
-        cached_neuron_stake_e8s: 100 * E8,
-        aging_since_timestamp_seconds: START_OF_2022_TIMESTAMP_SECONDS,
-        dissolve_state: Some(DissolveState::DissolveDelaySeconds(365 * ONE_DAY_SECONDS)),
-        voting_power_percentage_multiplier: 100,
-        ..Default::default()
-    };
-
-    static ref A_MOTION_PROPOSAL: Proposal = Proposal {
-        title: "This Proposal is Wunderbar!".to_string(),
-        summary: "This will solve all of your problems.".to_string(),
-        url: "https://www.example.com/some/path".to_string(),
-        action: Some(Action::Motion(Motion {
-            motion_text: "See the summary.".to_string(),
-        }))
-    };
-
-    pub(crate) static ref TEST_ROOT_CANISTER_ID: CanisterId = CanisterId::from(500);
-    pub(crate) static ref TEST_GOVERNANCE_CANISTER_ID: CanisterId = CanisterId::from(501);
-    static ref TEST_LEDGER_CANISTER_ID: CanisterId = CanisterId::from(502);
-    static ref TEST_SWAP_CANISTER_ID: CanisterId = CanisterId::from(503);
-    static ref TEST_ARCHIVES_CANISTER_IDS: Vec<CanisterId> =
-        vec![CanisterId::from(504), CanisterId::from(505)];
-    static ref TEST_INDEX_CANISTER_ID: CanisterId = CanisterId::from(506);
-    static ref TEST_DAPP_CANISTER_IDS: Vec<CanisterId> = vec![CanisterId::from(600)];
-}
 
 #[test]
 fn fixtures_are_valid() {
@@ -800,29 +718,6 @@ fn execute_proposal(governance: &mut Governance, proposal_id: u64) -> ProposalDa
         }
 
         std::thread::sleep(std::time::Duration::from_millis(100));
-    }
-}
-
-fn canister_status_for_test(
-    module_hash: Vec<u8>,
-    status: CanisterStatusType,
-) -> CanisterStatusResultV2 {
-    CanisterStatusResultV2::from(canister_status_from_management_canister_for_test(
-        module_hash,
-        status,
-    ))
-}
-
-fn canister_status_from_management_canister_for_test(
-    module_hash: Vec<u8>,
-    status: CanisterStatusType,
-) -> CanisterStatusResultFromManagementCanister {
-    let module_hash = Some(module_hash);
-
-    CanisterStatusResultFromManagementCanister {
-        status,
-        module_hash,
-        ..Default::default()
     }
 }
 

--- a/rs/sns/governance/src/governance/fail_stuck_upgrade_in_progress_tests.rs
+++ b/rs/sns/governance/src/governance/fail_stuck_upgrade_in_progress_tests.rs
@@ -1,4 +1,4 @@
-use super::assorted_governance_tests::{
+use super::test_helpers::{
     basic_governance_proto, DoNothingLedger, TEST_GOVERNANCE_CANISTER_ID, TEST_ROOT_CANISTER_ID,
 };
 use crate::{

--- a/rs/sns/governance/src/governance/test_helpers.rs
+++ b/rs/sns/governance/src/governance/test_helpers.rs
@@ -1,0 +1,118 @@
+use super::*;
+use crate::pb::v1::{Motion, NeuronPermissionType};
+use async_trait::async_trait;
+use ic_nervous_system_clients::canister_status::{
+    CanisterStatusResultFromManagementCanister, CanisterStatusResultV2, CanisterStatusType,
+};
+use ic_nervous_system_common::{
+    ledger::compute_neuron_staking_subaccount_bytes, E8, ONE_DAY_SECONDS,
+    START_OF_2022_TIMESTAMP_SECONDS,
+};
+
+lazy_static! {
+    pub(crate) static ref A_NEURON_PRINCIPAL_ID: PrincipalId = PrincipalId::new_user_test_id(956560);
+
+    pub(crate) static ref A_NEURON_ID: NeuronId = NeuronId::from(
+        compute_neuron_staking_subaccount_bytes(*A_NEURON_PRINCIPAL_ID, /* nonce = */ 0),
+    );
+
+    pub(crate) static ref A_NEURON: Neuron = Neuron {
+        id: Some(A_NEURON_ID.clone()),
+        permissions: vec![NeuronPermission {
+            principal: Some(*A_NEURON_PRINCIPAL_ID),
+            permission_type: NeuronPermissionType::all(),
+        }],
+        cached_neuron_stake_e8s: 100 * E8,
+        aging_since_timestamp_seconds: START_OF_2022_TIMESTAMP_SECONDS,
+        dissolve_state: Some(DissolveState::DissolveDelaySeconds(365 * ONE_DAY_SECONDS)),
+        voting_power_percentage_multiplier: 100,
+        ..Default::default()
+    };
+
+    pub(crate) static ref A_MOTION_PROPOSAL: Proposal = Proposal {
+        title: "This Proposal is Wunderbar!".to_string(),
+        summary: "This will solve all of your problems.".to_string(),
+        url: "https://www.example.com/some/path".to_string(),
+        action: Some(Action::Motion(Motion {
+            motion_text: "See the summary.".to_string(),
+        }))
+    };
+
+    pub(crate) static ref TEST_ROOT_CANISTER_ID: CanisterId = CanisterId::from(500);
+    pub(crate) static ref TEST_GOVERNANCE_CANISTER_ID: CanisterId = CanisterId::from(501);
+    pub(crate) static ref TEST_LEDGER_CANISTER_ID: CanisterId = CanisterId::from(502);
+    pub(crate) static ref TEST_SWAP_CANISTER_ID: CanisterId = CanisterId::from(503);
+    pub(crate) static ref TEST_ARCHIVES_CANISTER_IDS: Vec<CanisterId> =
+        vec![CanisterId::from(504), CanisterId::from(505)];
+    pub(crate) static ref TEST_INDEX_CANISTER_ID: CanisterId = CanisterId::from(506);
+    pub(crate) static ref TEST_DAPP_CANISTER_IDS: Vec<CanisterId> = vec![CanisterId::from(600)];
+}
+
+pub(crate) fn basic_governance_proto() -> GovernanceProto {
+    GovernanceProto {
+        root_canister_id: Some(PrincipalId::new_user_test_id(53)),
+        ledger_canister_id: Some(PrincipalId::new_user_test_id(228)),
+        swap_canister_id: Some(PrincipalId::new_user_test_id(15)),
+
+        parameters: Some(NervousSystemParameters::with_default_values()),
+        mode: governance::Mode::Normal as i32,
+        sns_metadata: Some(SnsMetadata {
+            logo: Some("data:image/png;base64,aGVsbG8gZnJvbSBkZmluaXR5IQ==".to_string()),
+            name: Some("ServiceNervousSystem-Test".to_string()),
+            description: Some("A project to spin up a ServiceNervousSystem".to_string()),
+            url: Some("https://internetcomputer.org".to_string()),
+        }),
+        ..Default::default()
+    }
+}
+
+pub(crate) fn canister_status_from_management_canister_for_test(
+    module_hash: Vec<u8>,
+    status: CanisterStatusType,
+) -> CanisterStatusResultFromManagementCanister {
+    let module_hash = Some(module_hash);
+
+    CanisterStatusResultFromManagementCanister {
+        status,
+        module_hash,
+        ..Default::default()
+    }
+}
+
+pub(crate) fn canister_status_for_test(
+    module_hash: Vec<u8>,
+    status: CanisterStatusType,
+) -> CanisterStatusResultV2 {
+    CanisterStatusResultV2::from(canister_status_from_management_canister_for_test(
+        module_hash,
+        status,
+    ))
+}
+
+pub(crate) struct DoNothingLedger {}
+
+#[async_trait]
+impl ICRC1Ledger for DoNothingLedger {
+    async fn transfer_funds(
+        &self,
+        _amount_e8s: u64,
+        _fee_e8s: u64,
+        _from_subaccount: Option<Subaccount>,
+        _to: Account,
+        _memo: u64,
+    ) -> Result<u64, NervousSystemError> {
+        unimplemented!();
+    }
+
+    async fn total_supply(&self) -> Result<Tokens, NervousSystemError> {
+        unimplemented!()
+    }
+
+    async fn account_balance(&self, _account: Account) -> Result<Tokens, NervousSystemError> {
+        unimplemented!()
+    }
+
+    fn canister_id(&self) -> CanisterId {
+        unimplemented!()
+    }
+}


### PR DESCRIPTION
This PR contributes unit tests of the whole automatic-upgrade process (as triggered by target_version being set). It adds a test for Governance and Root.

## Why add unit tests when we already have integration tests?

Certain scenarios are much easier to test via unit testing. These tests lay the groundwork for a test I want to write which will exercise edge cases w.r.t. archive canisters, which are too hard to exercise in an integration test