### PR TITLE
refactor(crypto): CRP-2596 rename VetKdArgs::encryption_key to encryption_public_key

### DIFF
--- a/rs/types/types/src/crypto/vetkd.rs
+++ b/rs/types/types/src/crypto/vetkd.rs
@@ -17,7 +17,7 @@ pub struct VetKdArgs {
     #[serde(with = "serde_bytes")]
     pub derivation_id: Vec<u8>,
     #[serde(with = "serde_bytes")]
-    pub encryption_key: Vec<u8>,
+    pub encryption_public_key: Vec<u8>,
 }
 
 impl fmt::Debug for VetKdArgs {
@@ -26,7 +26,10 @@ impl fmt::Debug for VetKdArgs {
             .field("ni_dkg_id", &self.ni_dkg_id)
             .field("derivation_path", &self.derivation_path)
             .field("derivation_id", &HexEncoding::from(&self.derivation_id))
-            .field("encryption_key", &HexEncoding::from(&self.encryption_key))
+            .field(
+                "encryption_public_key",
+                &HexEncoding::from(&self.encryption_public_key),
+            )
             .finish()
     }
 }

--- a/rs/types/types/src/crypto/vetkd/test.rs
+++ b/rs/types/types/src/crypto/vetkd/test.rs
@@ -24,7 +24,7 @@ mod display_and_debug {
                 derivation_path: vec![b"dp".to_vec()],
             },
             derivation_id: b"did".to_vec(),
-            encryption_key: b"ek".to_vec(),
+            encryption_public_key: b"ek".to_vec(),
         };
         let output = "VetKdArgs { \
             ni_dkg_id: NiDkgId { start_block_height: 7, dealer_subnet: ot5wk-sbkaa-aaaaa-aaaap-yai, dkg_tag: HighThreshold, target_subnet: Remote(0x2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a) }, \

--- a/rs/types/types/src/crypto/vetkd/test.rs
+++ b/rs/types/types/src/crypto/vetkd/test.rs
@@ -31,7 +31,7 @@ mod display_and_debug {
             derivation_path: ExtendedDerivationPath { caller: 7xzs3-rqraa-aaaaa-aaaap-2ai, \
             derivation_path: { 6470 } }, \
             derivation_id: 0x646964, \
-            encryption_key: 0x656b \
+            encryption_public_key: 0x656b \
         }"
         .to_string();
 


### PR DESCRIPTION
Renames `VetKdArgs::encryption_key` to `VetKdArgs::encryption_public_key` to avoid confusions as to whether this is the private or the public part of an asymmetric encryption key pair and thus to make clear that this is not sensitive information.