### PR TITLE
chore: make PocketIc::new_from_existing_instance blocking

### DIFF
--- a/packages/pocket-ic/src/lib.rs
+++ b/packages/pocket-ic/src/lib.rs
@@ -367,10 +367,8 @@ impl PocketIc {
         });
         let runtime = rx.recv().unwrap();
 
-        let pocket_ic = runtime.block_on(async {
-            PocketIcAsync::new_from_existing_instance(server_url, instance_id, max_request_time_ms)
-                .await
-        });
+        let pocket_ic =
+            PocketIcAsync::new_from_existing_instance(server_url, instance_id, max_request_time_ms);
 
         Self {
             pocket_ic,

--- a/packages/pocket-ic/src/nonblocking.rs
+++ b/packages/pocket-ic/src/nonblocking.rs
@@ -97,7 +97,7 @@ impl PocketIc {
     /// Note that this handle does not extend the lifetime of the existing instance,
     /// i.e., the existing instance is deleted and this handle stops working
     /// when the PocketIC handle that created the existing instance is dropped.
-    pub async fn new_from_existing_instance(
+    pub fn new_from_existing_instance(
         server_url: Url,
         instance_id: InstanceId,
         max_request_time_ms: Option<u64>,


### PR DESCRIPTION
This PR makes the function `PocketIc::new_from_existing_instance` blocking since its implementation is already blocking and thus declaring it `async` is unnecessary and prevents its invocation in blocking code.