### PR TITLE
feat: PocketIC library functions for generic calls

### DIFF
--- a/packages/pocket-ic/CHANGELOG.md
+++ b/packages/pocket-ic/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - The function `PocketIcBuilder::with_bitcoind_addrs` to specify multiple addresses and ports at which `bitcoind` processes are listening.
+- The functions `PocketIc::update_call_with_effective_principal` and `PocketIc::query_call_with_effective_principal` for making generic calls (including management canister calls).
 
 
 

--- a/packages/pocket-ic/src/common/rest.rs
+++ b/packages/pocket-ic/src/common/rest.rs
@@ -98,6 +98,22 @@ pub enum RawEffectivePrincipal {
     ),
 }
 
+impl std::fmt::Display for RawEffectivePrincipal {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            RawEffectivePrincipal::None => write!(f, "None"),
+            RawEffectivePrincipal::SubnetId(subnet_id) => {
+                let principal = Principal::from_slice(subnet_id);
+                write!(f, "SubnetId({})", principal)
+            }
+            RawEffectivePrincipal::CanisterId(canister_id) => {
+                let principal = Principal::from_slice(canister_id);
+                write!(f, "CanisterId({})", principal)
+            }
+        }
+    }
+}
+
 #[derive(Clone, Serialize, Deserialize, Debug, JsonSchema)]
 pub struct RawMessageId {
     pub effective_principal: RawEffectivePrincipal,

--- a/packages/pocket-ic/src/lib.rs
+++ b/packages/pocket-ic/src/lib.rs
@@ -1073,7 +1073,11 @@ impl PocketIc {
         runtime.block_on(async { self.pocket_ic.get_subnet_metrics(subnet_id).await })
     }
 
-    fn update_call_with_effective_principal(
+    /// Execute an update call on a canister explicitly specifying an effective principal to route the request:
+    /// this API is useful for making generic calls (including management canister calls) without using dedicated functions from this library
+    /// (e.g., making generic calls in dfx to a PocketIC instance).
+    #[instrument(skip(self, payload), fields(instance_id=self.pocket_ic.instance_id, canister_id = %canister_id.to_string(), effective_principal = %effective_principal.to_string(), sender = %sender.to_string(), method = %method, payload_len = %payload.len()))]
+    pub fn update_call_with_effective_principal(
         &self,
         canister_id: CanisterId,
         effective_principal: RawEffectivePrincipal,
@@ -1085,6 +1089,32 @@ impl PocketIc {
         runtime.block_on(async {
             self.pocket_ic
                 .update_call_with_effective_principal(
+                    canister_id,
+                    effective_principal,
+                    sender,
+                    method,
+                    payload,
+                )
+                .await
+        })
+    }
+
+    /// Execute a query call on a canister explicitly specifying an effective principal to route the request:
+    /// this API is useful for making generic calls (including management canister calls) without using dedicated functions from this library
+    /// (e.g., making generic calls in dfx to a PocketIC instance).
+    #[instrument(skip(self, payload), fields(instance_id=self.pocket_ic.instance_id, canister_id = %canister_id.to_string(), effective_principal = %effective_principal.to_string(), sender = %sender.to_string(), method = %method, payload_len = %payload.len()))]
+    pub fn query_call_with_effective_principal(
+        &self,
+        canister_id: CanisterId,
+        effective_principal: RawEffectivePrincipal,
+        sender: Principal,
+        method: &str,
+        payload: Vec<u8>,
+    ) -> Result<WasmResult, UserError> {
+        let runtime = self.runtime.clone();
+        runtime.block_on(async {
+            self.pocket_ic
+                .query_call_with_effective_principal(
                     canister_id,
                     effective_principal,
                     sender,

--- a/packages/pocket-ic/src/nonblocking.rs
+++ b/packages/pocket-ic/src/nonblocking.rs
@@ -630,7 +630,11 @@ impl PocketIc {
         .await
     }
 
-    pub(crate) async fn query_call_with_effective_principal(
+    /// Execute a query call on a canister explicitly specifying an effective principal to route the request:
+    /// this API is useful for making generic calls (including management canister calls) without using dedicated functions from this library
+    /// (e.g., making generic calls in dfx to a PocketIC instance).
+    #[instrument(skip(self, payload), fields(instance_id=self.instance_id, canister_id = %canister_id.to_string(), effective_principal = %effective_principal.to_string(), sender = %sender.to_string(), method = %method, payload_len = %payload.len()))]
+    pub async fn query_call_with_effective_principal(
         &self,
         canister_id: CanisterId,
         effective_principal: RawEffectivePrincipal,
@@ -1425,7 +1429,11 @@ impl PocketIc {
         }
     }
 
-    pub(crate) async fn update_call_with_effective_principal(
+    /// Execute an update call on a canister explicitly specifying an effective principal to route the request:
+    /// this API is useful for making generic calls (including management canister calls) without using dedicated functions from this library
+    /// (e.g., making generic calls in dfx to a PocketIC instance).
+    #[instrument(skip(self, payload), fields(instance_id=self.instance_id, canister_id = %canister_id.to_string(), effective_principal = %effective_principal.to_string(), sender = %sender.to_string(), method = %method, payload_len = %payload.len()))]
+    pub async fn update_call_with_effective_principal(
         &self,
         canister_id: CanisterId,
         effective_principal: RawEffectivePrincipal,


### PR DESCRIPTION
This PR adds the PocketIC library functions `PocketIc::update_call_with_effective_principal` and `PocketIc::query_call_with_effective_principal` for making generic calls (including management canister calls).