### PR TITLE
chore(ci): Make `CI PR Only` mandatory for PRs

### DIFF
--- a/.github/workflows-source/ci-pr-only.yml
+++ b/.github/workflows-source/ci-pr-only.yml
@@ -2,6 +2,7 @@ name: CI PR Only
 # Jobs that run on PRs, but no other pipelines
 
 on:
+  merge_group:
   pull_request:
     types: [opened, synchronize, reopened]
 
@@ -37,11 +38,14 @@ anchors:
   checkout: &checkout
     name: Checkout
     uses: actions/checkout@v4
+  skip-merge-group: &skip-merge-group
+    if: ${{ github.event_name != 'merge_group' }}
 
 jobs:
   bazel-build-fuzzers-archives:
     name: Bazel Build Fuzzers Archives
     <<: *dind-large-setup
+    <<: *skip-merge-group
     steps:
       - <<: *checkout
       - name: Filter Relevant Files
@@ -76,6 +80,7 @@ jobs:
   lock-generate:
     name: Lock Generate
     <<: *dind-small-setup
+    <<: *skip-merge-group
     steps:
       - name: Create GitHub App Token
         uses: actions/create-github-app-token@v1
@@ -110,6 +115,7 @@ jobs:
   dependencies-check:
     name: Dependency Scan for PR
     <<: *dind-small-setup
+    <<: *skip-merge-group
     timeout-minutes: 60
     permissions:
       contents: read
@@ -150,6 +156,7 @@ jobs:
   bazel-test-coverage:
     name: Bazel Test Coverage
     <<: *dind-large-setup
+    <<: *skip-merge-group
     if: contains(github.event.pull_request.labels.*.name, 'CI_COVERAGE')
     steps:
       - <<: *checkout

--- a/.github/workflows/ci-pr-only.yml
+++ b/.github/workflows/ci-pr-only.yml
@@ -2,6 +2,7 @@ name: CI PR Only
 # Jobs that run on PRs, but no other pipelines
 
 on:
+  merge_group:
   pull_request:
     types: [opened, synchronize, reopened]
 concurrency:
@@ -23,6 +24,7 @@ jobs:
       image: ghcr.io/dfinity/ic-build@sha256:1d775e6d161dee883d10f082ab7fdde3e3d26061e1209255fb6514f8b62b206b
       options: >-
         -e NODE_NAME
+    if: ${{ github.event_name != 'merge_group' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -63,6 +65,7 @@ jobs:
       image: ghcr.io/dfinity/ic-build@sha256:1d775e6d161dee883d10f082ab7fdde3e3d26061e1209255fb6514f8b62b206b
       options: >-
         -e NODE_NAME
+    if: ${{ github.event_name != 'merge_group' }}
     steps:
       - name: Create GitHub App Token
         uses: actions/create-github-app-token@v1
@@ -101,6 +104,7 @@ jobs:
       image: ghcr.io/dfinity/ic-build@sha256:1d775e6d161dee883d10f082ab7fdde3e3d26061e1209255fb6514f8b62b206b
       options: >-
         -e NODE_NAME
+    if: ${{ github.event_name != 'merge_group' }}
     timeout-minutes: 60
     permissions:
       contents: read


### PR DESCRIPTION
This PR is a necessary step before making `CI PR Only` required / mandatory on PRs. 

Currently, when a workflow is marked as required for PR, it is also enforced on the merge queue as well which can block the queue. However, these jobs are only needed to gate the merge. Hence, we allow the workflow to run on `merge_group` but each individual job is not run by adding ` if: ${{ github.event_name != 'merge_group' }}`