### PR TITLE
feat: syncing dashboards from k8s repo

### DIFF
--- a/rs/tests/driver/src/driver/prometheus_vm.rs
+++ b/rs/tests/driver/src/driver/prometheus_vm.rs
@@ -181,7 +181,7 @@ impl PrometheusVm {
             .arg("main")
             .current_dir(&k8s_repo)
             .output()?;
-        info!(logger, "Pulled from origin");
+        info!(logger, "Pulled dashboards from dfinity-ops/k8s repo");
 
         let dashboards_root = k8s_repo.join("bases").join("apps").join("ic-dashboards");
         let k8s_dashboards = k8s_repo.join("k8s-dashboards");


### PR DESCRIPTION
As pointed out previously, there were some issues with the fact that prometheus dashboards need to be kept in sync manually between two repositories. Since all developers have access to [k8s](https://github.com/dfinity-ops/k8s) repo this PR adds automatic pulling of dashboards when the testnet is being provisioned. 