### PR TITLE
chore(system-tests-k8s): always run hourly

### DIFF
--- a/.github/workflows/system-tests-k8s.yml
+++ b/.github/workflows/system-tests-k8s.yml
@@ -111,6 +111,7 @@ jobs:
         -v /cache:/cache -v /var/sysimage:/var/sysimage -v /var/tmp:/var/tmp
     timeout-minutes: 150
     needs: [system-tests-k8s]
+    # always run after 'system-tests-k8s' job but on schedule event only
     if: ${{ always() && github.event_name == 'schedule' }}
     steps:
       - name: Checkout

--- a/.github/workflows/system-tests-k8s.yml
+++ b/.github/workflows/system-tests-k8s.yml
@@ -111,7 +111,7 @@ jobs:
         -v /cache:/cache -v /var/sysimage:/var/sysimage -v /var/tmp:/var/tmp
     timeout-minutes: 150
     needs: [system-tests-k8s]
-    if: ${{ github.event_name == 'schedule' }}
+    if: ${{ always() && github.event_name == 'schedule' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Run hourly system tests always (we want to run this after PR related tests but we don't care if that CI job fails).