### PR TITLE
refactor(sns): Reset cached upgrade steps upon detecting inconsistencies

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,4 +9,7 @@
         "editor.formatOnSave": true
     },
     "bazel.buildifierExecutable": "@buildifier",
+    "cSpell.words": [
+        "recieved"
+    ],
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,7 +9,4 @@
         "editor.formatOnSave": true
     },
     "bazel.buildifierExecutable": "@buildifier",
-    "cSpell.words": [
-        "recieved"
-    ],
 }

--- a/rs/nervous_system/integration_tests/src/pocket_ic_helpers.rs
+++ b/rs/nervous_system/integration_tests/src/pocket_ic_helpers.rs
@@ -1343,6 +1343,7 @@ pub mod sns {
 
     pub mod governance {
         use super::*;
+        use assert_matches::assert_matches;
         use ic_crypto_sha2::Sha256;
         use ic_nervous_system_agent::sns::governance::GovernanceCanister;
         use ic_sns_governance::pb::v1::get_neuron_response;
@@ -1719,13 +1720,21 @@ pub mod sns {
             sns_governance_canister_id: PrincipalId,
             expected_entries: &[sns_pb::upgrade_journal_entry::Event],
         ) {
-            let sns_pb::GetUpgradeJournalResponse {
-                upgrade_journal, ..
-            } = sns::governance::get_upgrade_journal(pocket_ic, sns_governance_canister_id).await;
+            let response =
+                sns::governance::get_upgrade_journal(pocket_ic, sns_governance_canister_id).await;
 
-            let upgrade_journal = upgrade_journal.unwrap().entries;
+            let journal_entries = assert_matches!(
+                response,
+                sns_pb::GetUpgradeJournalResponse {
+                    upgrade_journal: Some(sns_pb::UpgradeJournal {
+                        entries,
+                        ..
+                    }),
+                    ..
+                } => entries
+            );
 
-            for (index, either_or_both) in upgrade_journal
+            for (index, either_or_both) in journal_entries
                 .iter()
                 .zip_longest(expected_entries.iter())
                 .enumerate()

--- a/rs/nervous_system/integration_tests/tests/advance_sns_target_version.rs
+++ b/rs/nervous_system/integration_tests/tests/advance_sns_target_version.rs
@@ -7,6 +7,7 @@ use ic_nervous_system_integration_tests::{
     },
 };
 use ic_nns_test_utils::sns_wasm::create_modified_sns_wasm;
+use ic_sns_governance::pb::v1::upgrade_journal_entry::UpgradeStepsReset;
 use ic_sns_governance::{
     governance::UPGRADE_STEPS_INTERVAL_REFRESH_BACKOFF_SECONDS,
     pb::v1 as sns_pb,
@@ -67,9 +68,10 @@ async fn test_get_upgrade_journal() {
     // Step 1: Check that the upgrade journal contains the initial version right after SNS creation.
     let mut expected_upgrade_journal_entries = vec![];
     {
-        expected_upgrade_journal_entries.push(Event::UpgradeStepsRefreshed(
-            UpgradeStepsRefreshed::new(vec![initial_sns_version.clone()]),
-        ));
+        expected_upgrade_journal_entries.push(Event::UpgradeStepsReset(UpgradeStepsReset::new(
+            "redacted".to_string(),
+            vec![initial_sns_version.clone()],
+        )));
 
         sns::governance::assert_upgrade_journal(
             &pocket_ic,

--- a/rs/nervous_system/integration_tests/tests/advance_sns_target_version.rs
+++ b/rs/nervous_system/integration_tests/tests/advance_sns_target_version.rs
@@ -69,7 +69,7 @@ async fn test_get_upgrade_journal() {
     let mut expected_upgrade_journal_entries = vec![];
     {
         expected_upgrade_journal_entries.push(Event::UpgradeStepsReset(UpgradeStepsReset::new(
-            "redacted".to_string(),
+            "this message will be redacted to keep the test spec more abstract".to_string(),
             vec![initial_sns_version.clone()],
         )));
 
@@ -230,7 +230,9 @@ async fn test_get_upgrade_journal() {
 
         expected_upgrade_journal_entries.push(
             sns_pb::upgrade_journal_entry::Event::UpgradeOutcome(
-                sns_pb::upgrade_journal_entry::UpgradeOutcome::success("redacted".to_string()),
+                sns_pb::upgrade_journal_entry::UpgradeOutcome::success(
+                    "this message will be redacted to keep the test spec more abstract".to_string(),
+                ),
             ),
         );
 
@@ -245,7 +247,9 @@ async fn test_get_upgrade_journal() {
 
         expected_upgrade_journal_entries.push(
             sns_pb::upgrade_journal_entry::Event::UpgradeOutcome(
-                sns_pb::upgrade_journal_entry::UpgradeOutcome::success("redacted".to_string()),
+                sns_pb::upgrade_journal_entry::UpgradeOutcome::success(
+                    "this message will be redacted to keep the test spec more abstract".to_string(),
+                ),
             ),
         );
 

--- a/rs/sns/governance/canister/canister.rs
+++ b/rs/sns/governance/canister/canister.rs
@@ -693,7 +693,13 @@ fn advance_target_version(request: AdvanceTargetVersionRequest) -> AdvanceTarget
 async fn refresh_cached_upgrade_steps(
     _: RefreshCachedUpgradeStepsRequest,
 ) -> RefreshCachedUpgradeStepsResponse {
-    governance_mut().refresh_cached_upgrade_steps().await;
+    let goverance = governance_mut();
+    let deployed_version = goverance
+        .try_temporarily_lock_refresh_cached_upgrade_steps()
+        .unwrap();
+    goverance
+        .refresh_cached_upgrade_steps(deployed_version)
+        .await;
     RefreshCachedUpgradeStepsResponse {}
 }
 

--- a/rs/sns/governance/src/cached_upgrade_steps.rs
+++ b/rs/sns/governance/src/cached_upgrade_steps.rs
@@ -396,7 +396,7 @@ impl Governance {
     /// Additionally, invalidates the target version, if it was set.
     ///
     /// Returns the new instance.
-    fn reset_cached_upgrade_steps(
+    pub(crate) fn reset_cached_upgrade_steps(
         &mut self,
         current_version: &Version,
         reason: String,

--- a/rs/sns/governance/src/cached_upgrade_steps.rs
+++ b/rs/sns/governance/src/cached_upgrade_steps.rs
@@ -328,7 +328,7 @@ impl CachedUpgradeSteps {
 
     /// Returns whether there are no pending upgrades.
     pub fn has_pending_upgrades(&self) -> bool {
-        self.next().is_none()
+        self.next().is_some()
     }
 
     /// Returns a new instance of `Self` starting with `version` in the `Ok` result

--- a/rs/sns/governance/src/cached_upgrade_steps.rs
+++ b/rs/sns/governance/src/cached_upgrade_steps.rs
@@ -306,12 +306,12 @@ impl CachedUpgradeSteps {
         Ok(contains_in_order)
     }
 
-    pub fn current(&self) -> &Version {
-        &self.current_version
-    }
-
     pub fn next(&self) -> Option<&Version> {
         self.subsequent_versions.first()
+    }
+
+    pub fn current(&self) -> &Version {
+        &self.current_version
     }
 
     pub fn is_current(&self, version: &Version) -> bool {
@@ -320,7 +320,7 @@ impl CachedUpgradeSteps {
 
     /// Returns whether there are no pending upgrades.
     pub fn has_pending_upgrades(&self) -> bool {
-        !self.subsequent_versions.is_empty()
+        self.next().is_none()
     }
 
     /// Returns a new instance of `Self` starting with `version` in the `Ok` result
@@ -461,7 +461,9 @@ impl Governance {
             let requested_timestamp_seconds = cached_upgrade_steps
                 .requested_timestamp_seconds
                 .unwrap_or(0);
-            if now - requested_timestamp_seconds < UPGRADE_STEPS_INTERVAL_REFRESH_BACKOFF_SECONDS {
+            if now.saturating_sub(requested_timestamp_seconds)
+                < UPGRADE_STEPS_INTERVAL_REFRESH_BACKOFF_SECONDS
+            {
                 return false;
             }
         }
@@ -575,3 +577,6 @@ impl GovernancePb {
         Ok((upgrade_steps, new_target))
     }
 }
+
+#[cfg(test)]
+mod tests;

--- a/rs/sns/governance/src/cached_upgrade_steps/tests.rs
+++ b/rs/sns/governance/src/cached_upgrade_steps/tests.rs
@@ -1,0 +1,189 @@
+use super::*;
+
+#[test]
+fn cache_upgrade_steps_proto_conversions() {
+    let pb = CachedUpgradeStepsPb {
+        upgrade_steps: Some(Versions {
+            versions: vec![Version {
+                root_wasm_hash: vec![0, 0, 0],
+                governance_wasm_hash: vec![1, 1, 1],
+                ledger_wasm_hash: vec![2, 2, 2],
+                swap_wasm_hash: vec![3, 3, 3],
+                archive_wasm_hash: vec![4, 4, 4],
+                index_wasm_hash: vec![5, 5, 5],
+            }],
+        }),
+        requested_timestamp_seconds: Some(111),
+        response_timestamp_seconds: Some(222),
+    };
+
+    // Scenario A: Round trip conversions work for a valid structure.
+    {
+        let cached_upgrade_steps = CachedUpgradeSteps::try_from(&pb).unwrap();
+        assert_eq!(CachedUpgradeStepsPb::from(cached_upgrade_steps), pb);
+    }
+
+    // Scenario B: Conversion fails for a structure with missing `upgrade_steps` fields.
+    {
+        let mut pb = pb.clone();
+        pb.upgrade_steps = None;
+        let err = CachedUpgradeSteps::try_from(&pb).unwrap_err();
+        assert_eq!(err, "CachedUpgradeSteps.upgrade_steps must be specified.");
+    }
+
+    // Scenario C: Conversion fails if there are no versions.
+    {
+        let mut pb = pb.clone();
+        pb.upgrade_steps = Some(Versions { versions: vec![] });
+        let err = CachedUpgradeSteps::try_from(&pb).unwrap_err();
+        assert_eq!(err, "CachedUpgradeSteps.upgrade_steps must not be empty.");
+    }
+
+    // Scenario D: Conversion fails if there are duplicate versions.
+    {
+        let mut pb = pb.clone();
+        let mut versions = pb.upgrade_steps.clone().unwrap().versions;
+        versions.extend(versions.clone().into_iter());
+        pb.upgrade_steps = Some(Versions { versions });
+        let err = CachedUpgradeSteps::try_from(&pb).unwrap_err();
+        assert_eq!(
+            err,
+            "CachedUpgradeSteps.upgrade_steps must not contain duplicates: SnsVersion { \
+                root:000000, governance:010101, swap:030303, \
+                index:050505, ledger:020202, archive:040404 \
+             } occurres more than once.",
+        );
+    }
+}
+
+#[test]
+fn cache_upgrade_steps_sns_w_response_conversions() {
+    let requested_timestamp_seconds = 111;
+    let response_timestamp_seconds = 222;
+    let sns_w_response = ListUpgradeStepsResponse {
+        steps: vec![ListUpgradeStep {
+            version: Some(
+                Version {
+                    root_wasm_hash: vec![0, 0, 0],
+                    governance_wasm_hash: vec![1, 1, 1],
+                    ledger_wasm_hash: vec![2, 2, 2],
+                    swap_wasm_hash: vec![3, 3, 3],
+                    archive_wasm_hash: vec![4, 4, 4],
+                    index_wasm_hash: vec![5, 5, 5],
+                }
+                .into(),
+            ),
+        }],
+    };
+    let expected_pb = CachedUpgradeStepsPb {
+        upgrade_steps: Some(Versions {
+            versions: vec![Version {
+                root_wasm_hash: vec![0, 0, 0],
+                governance_wasm_hash: vec![1, 1, 1],
+                ledger_wasm_hash: vec![2, 2, 2],
+                swap_wasm_hash: vec![3, 3, 3],
+                archive_wasm_hash: vec![4, 4, 4],
+                index_wasm_hash: vec![5, 5, 5],
+            }],
+        }),
+        requested_timestamp_seconds: Some(111),
+        response_timestamp_seconds: Some(222),
+    };
+
+    // Scenario A: Round trip conversions work for a valid structure.
+    {
+        let cached_upgrade_steps = CachedUpgradeSteps::try_from_sns_w_response(
+            sns_w_response.clone(),
+            requested_timestamp_seconds,
+            response_timestamp_seconds,
+        )
+        .unwrap();
+
+        assert_eq!(
+            CachedUpgradeStepsPb::from(cached_upgrade_steps),
+            expected_pb
+        );
+    }
+
+    // Scenario B: Conversion fails for a structure with missing `version` fields.
+    {
+        let mut sns_w_response = sns_w_response.clone();
+        sns_w_response.steps.push(ListUpgradeStep { version: None });
+
+        let err = CachedUpgradeSteps::try_from_sns_w_response(
+            sns_w_response,
+            requested_timestamp_seconds,
+            response_timestamp_seconds,
+        )
+        .unwrap_err();
+
+        assert_eq!(err, "CachedUpgradeSteps.upgrade_steps must be specified.");
+    }
+
+    // Scenario C: Conversion fails if there are no versions.
+    {
+        let err = CachedUpgradeSteps::try_from_sns_w_response(
+            ListUpgradeStepsResponse { steps: vec![] },
+            requested_timestamp_seconds,
+            response_timestamp_seconds,
+        )
+        .unwrap_err();
+
+        assert_eq!(err, "CachedUpgradeSteps.upgrade_steps must be specified.");
+    }
+
+    // Scenario D: Conversion fails if there are duplicate versions.
+    {
+        let mut sns_w_response = sns_w_response.clone();
+        sns_w_response.steps.push(sns_w_response.steps[0].clone());
+
+        let err = CachedUpgradeSteps::try_from_sns_w_response(
+            sns_w_response,
+            requested_timestamp_seconds,
+            response_timestamp_seconds,
+        )
+        .unwrap_err();
+
+        assert_eq!(err, "CachedUpgradeSteps.upgrade_steps must be specified.");
+    }
+}
+
+#[test]
+fn cached_upgrade_steps_without_pending_upgrades() {
+    let v = Version {
+        root_wasm_hash: vec![0, 0, 0],
+        governance_wasm_hash: vec![1, 1, 1],
+        ledger_wasm_hash: vec![2, 2, 2],
+        swap_wasm_hash: vec![3, 3, 3],
+        archive_wasm_hash: vec![4, 4, 4],
+        index_wasm_hash: vec![5, 5, 5],
+    };
+
+    // A: It validates.
+    let cached_upgrade_steps = CachedUpgradeSteps::without_pending_upgrades(v.clone(), 111);
+    assert_eq!(
+        CachedUpgradeSteps::try_from(&CachedUpgradeStepsPb::from(cached_upgrade_steps.clone()))
+            .unwrap(),
+        cached_upgrade_steps
+    );
+
+    // B. It's methods work as expected.
+    assert_eq!(cached_upgrade_steps.last(), &v);
+    assert!(cached_upgrade_steps.contains(&v));
+    assert!(cached_upgrade_steps.is_current(&v));
+    assert_eq!(cached_upgrade_steps.current(), &v);
+    assert_eq!(cached_upgrade_steps.next(), None);
+    assert!(!cached_upgrade_steps.has_pending_upgrades());
+    assert_eq!(
+        cached_upgrade_steps.clone().take_from(&v),
+        Ok(cached_upgrade_steps.clone())
+    );
+    assert_eq!(
+        cached_upgrade_steps.approximate_time_of_validity_timestamp_seconds(),
+        111
+    );
+    assert_eq!(
+        cached_upgrade_steps.validate_new_target_version(&v),
+        Err("new_target_version must differ from the current version.".to_string())
+    );
+}

--- a/rs/sns/governance/src/cached_upgrade_steps/tests.rs
+++ b/rs/sns/governance/src/cached_upgrade_steps/tests.rs
@@ -186,5 +186,8 @@ fn cached_upgrade_steps_without_pending_upgrades() {
         cached_upgrade_steps.validate_new_target_version(&v),
         Err("new_target_version must differ from the current version.".to_string())
     );
-    assert_eq!(cached_upgrade_steps.into_iter().collect(), vec![v]);
+    assert_eq!(
+        cached_upgrade_steps.into_iter().collect::<Vec<_>>(),
+        vec![v]
+    );
 }

--- a/rs/sns/governance/src/cached_upgrade_steps/tests.rs
+++ b/rs/sns/governance/src/cached_upgrade_steps/tests.rs
@@ -117,7 +117,7 @@ fn cache_upgrade_steps_sns_w_response_conversions() {
         )
         .unwrap_err();
 
-        assert_eq!(err, "CachedUpgradeSteps.upgrade_steps must be specified.");
+        assert!(err.contains("SnsW.list_upgrade_steps response had invalid fields"));
     }
 
     // Scenario C: Conversion fails if there are no versions.
@@ -129,7 +129,7 @@ fn cache_upgrade_steps_sns_w_response_conversions() {
         )
         .unwrap_err();
 
-        assert_eq!(err, "CachedUpgradeSteps.upgrade_steps must be specified.");
+        assert_eq!(err, "ListUpgradeStepsResponse.steps must not be empty.");
     }
 
     // Scenario D: Conversion fails if there are duplicate versions.
@@ -144,7 +144,13 @@ fn cache_upgrade_steps_sns_w_response_conversions() {
         )
         .unwrap_err();
 
-        assert_eq!(err, "CachedUpgradeSteps.upgrade_steps must be specified.");
+        assert_eq!(
+            err,
+            "ListUpgradeStepsResponse.steps must not contain duplicates: SnsVersion { \
+                root:000000, governance:010101, swap:030303, \
+                index:050505, ledger:020202, archive:040404 \
+             } occurres more than once.",
+        );
     }
 }
 

--- a/rs/sns/governance/src/cached_upgrade_steps/tests.rs
+++ b/rs/sns/governance/src/cached_upgrade_steps/tests.rs
@@ -43,7 +43,7 @@ fn cache_upgrade_steps_proto_conversions() {
     {
         let mut pb = pb.clone();
         let mut versions = pb.upgrade_steps.clone().unwrap().versions;
-        versions.extend(versions.clone().into_iter());
+        versions.extend(versions.clone());
         pb.upgrade_steps = Some(Versions { versions });
         let err = CachedUpgradeSteps::try_from(&pb).unwrap_err();
         assert_eq!(
@@ -186,4 +186,5 @@ fn cached_upgrade_steps_without_pending_upgrades() {
         cached_upgrade_steps.validate_new_target_version(&v),
         Err("new_target_version must differ from the current version.".to_string())
     );
+    assert_eq!(cached_upgrade_steps.into_iter().collect(), vec![v]);
 }

--- a/rs/sns/governance/src/governance.rs
+++ b/rs/sns/governance/src/governance.rs
@@ -5535,10 +5535,7 @@ impl Governance {
                     self.env.now(),
                     running_version,
                 );
-                self.push_to_upgrade_journal(upgrade_journal_entry::UpgradeStepsReset::new(
-                    message,
-                    vec![running_version.clone()],
-                ));
+                self.reset_cached_upgrade_steps(&running_version, message);
 
                 self.proto.deployed_version = Some(running_version.clone());
 

--- a/rs/sns/governance/src/governance/advance_target_sns_version_tests.rs
+++ b/rs/sns/governance/src/governance/advance_target_sns_version_tests.rs
@@ -565,7 +565,6 @@ async fn test_initiate_upgrade_blocked_by_pending_upgrade() {
         GovernanceProto {
             root_canister_id: Some(root_canister_id.get()),
             deployed_version: Some(Version::from(current_version.clone())),
-            target_version: Some(Version::from(target_version.clone())),
             // There's already an upgrade pending
             pending_version: Some(PendingVersion {
                 target_version: Some(pending_version.clone()),
@@ -603,6 +602,8 @@ async fn test_initiate_upgrade_blocked_by_pending_upgrade() {
             .len(),
         2
     );
+
+    governance.proto.target_version = Some(Version::from(target_version.clone()));
 
     governance
         .initiate_upgrade_if_sns_behind_target_version()

--- a/rs/sns/governance/src/governance/advance_target_sns_version_tests.rs
+++ b/rs/sns/governance/src/governance/advance_target_sns_version_tests.rs
@@ -72,7 +72,6 @@ async fn test_initiate_upgrade_blocked_by_upgrade_proposal() {
         GovernanceProto {
             root_canister_id: Some(root_canister_id.get()),
             deployed_version: Some(Version::from(current_version.clone())),
-            target_version: Some(Version::from(target_version.clone())),
             // Add an upgrade proposal that is adopted but not executed
             proposals: btreemap! {
                 proposal_id => proposal
@@ -107,6 +106,8 @@ async fn test_initiate_upgrade_blocked_by_upgrade_proposal() {
             .len(),
         2
     );
+
+    governance.proto.target_version = Some(Version::from(target_version.clone()));
 
     governance
         .initiate_upgrade_if_sns_behind_target_version()

--- a/rs/sns/governance/src/governance/advance_target_sns_version_tests.rs
+++ b/rs/sns/governance/src/governance/advance_target_sns_version_tests.rs
@@ -879,7 +879,7 @@ fn get_or_reset_upgrade_steps_leads_to_should_refresh_cached_upgrade_steps() {
             deployed_version: Some(version_a.clone()),
             cached_upgrade_steps: Some(CachedUpgradeStepsPb {
                 upgrade_steps: Some(Versions {
-                    versions: vec![version_a],
+                    versions: vec![version_a.clone()],
                 }),
                 requested_timestamp_seconds: Some(env.now()),
                 response_timestamp_seconds: Some(env.now()),
@@ -901,7 +901,7 @@ fn get_or_reset_upgrade_steps_leads_to_should_refresh_cached_upgrade_steps() {
     // Run code under test and assert intermediate conditions
     {
         let cached_upgrade_steps = gov.get_or_reset_upgrade_steps(&version_b);
-        let cached_upgrade_steps = CachedUpgradeStepsPb::try_from(cached_upgrade_steps).unwrap();
+        let cached_upgrade_steps = CachedUpgradeStepsPb::from(cached_upgrade_steps);
         assert_eq!(
             gov.proto.cached_upgrade_steps,
             Some(cached_upgrade_steps.clone())

--- a/rs/sns/governance/src/governance/advance_target_sns_version_tests.rs
+++ b/rs/sns/governance/src/governance/advance_target_sns_version_tests.rs
@@ -11,7 +11,7 @@ use crate::sns_upgrade::GetWasmResponse;
 use crate::sns_upgrade::SnsWasm;
 use crate::sns_upgrade::{GetSnsCanistersSummaryRequest, GetSnsCanistersSummaryResponse};
 use crate::{
-    pb::v1::{ProposalData, Tally, UpgradeSnsToNextVersion},
+    pb::v1::{governance::Versions, ProposalData, Tally, UpgradeSnsToNextVersion},
     sns_upgrade::{ListUpgradeStep, ListUpgradeStepsRequest, ListUpgradeStepsResponse, SnsVersion},
     types::test_helpers::NativeEnvironment,
 };
@@ -86,8 +86,12 @@ async fn test_initiate_upgrade_blocked_by_upgrade_proposal() {
 
     // Step 2: Run code under test.
     assert_eq!(governance.proto.cached_upgrade_steps, None);
-    governance.temporarily_lock_refresh_cached_upgrade_steps();
-    governance.refresh_cached_upgrade_steps().await;
+    let deployed_version = governance
+        .try_temporarily_lock_refresh_cached_upgrade_steps()
+        .unwrap();
+    governance
+        .refresh_cached_upgrade_steps(deployed_version)
+        .await;
     assert_eq!(
         governance
             .proto
@@ -578,8 +582,12 @@ async fn test_initiate_upgrade_blocked_by_pending_upgrade() {
 
     // Step 2: Run code under test.
     assert_eq!(governance.proto.cached_upgrade_steps, None);
-    governance.temporarily_lock_refresh_cached_upgrade_steps();
-    governance.refresh_cached_upgrade_steps().await;
+    let deployed_version = governance
+        .try_temporarily_lock_refresh_cached_upgrade_steps()
+        .unwrap();
+    governance
+        .refresh_cached_upgrade_steps(deployed_version)
+        .await;
     assert_eq!(
         governance
             .proto

--- a/rs/sns/governance/src/governance/assorted_governance_tests.rs
+++ b/rs/sns/governance/src/governance/assorted_governance_tests.rs
@@ -2463,11 +2463,11 @@ fn test_no_target_version_fails_check_upgrade_status() {
                 )),
             },
             UpgradeJournalEntry {
-                timestamp_seconds: Some(now),
+                timestamp_seconds: Some(_),
                 event: Some(upgrade_journal_entry::Event::UpgradeStepsReset(
                     upgrade_journal_entry::UpgradeStepsReset {
                         human_readable: Some(_),
-                        upgrade_steps: Some(Versions { versions }),
+                        upgrade_steps: Some(Versions { versions: _ }),
                     }
                 )),
             },

--- a/rs/sns/governance/src/governance/assorted_governance_tests.rs
+++ b/rs/sns/governance/src/governance/assorted_governance_tests.rs
@@ -2274,17 +2274,28 @@ fn test_check_upgrade_fails_if_canister_summary_errs_and_past_mark_failed_at_tim
     // Check that the upgrade journal reflects the timed-out upgrade attempt
     assert_matches!(
         &governance.proto.upgrade_journal.clone().unwrap().entries[..],
-        [UpgradeJournalEntry {
-            timestamp_seconds: _,
-            event: Some(upgrade_journal_entry::Event::UpgradeOutcome(
-                upgrade_journal_entry::UpgradeOutcome {
-                    human_readable: Some(_),
-                    status: Some(upgrade_journal_entry::upgrade_outcome::Status::Timeout(
-                        Empty {}
-                    )),
-                }
-            )),
-        }]
+        [
+            UpgradeJournalEntry {
+                timestamp_seconds: _,
+                event: Some(upgrade_journal_entry::Event::UpgradeOutcome(
+                    upgrade_journal_entry::UpgradeOutcome {
+                        human_readable: Some(_),
+                        status: Some(upgrade_journal_entry::upgrade_outcome::Status::Timeout(
+                            Empty {}
+                        )),
+                    }
+                )),
+            },
+            UpgradeJournalEntry {
+                timestamp_seconds: _,
+                event: Some(upgrade_journal_entry::Event::UpgradeStepsReset(
+                    upgrade_journal_entry::UpgradeStepsReset {
+                        human_readable: Some(_),
+                        upgrade_steps: Some(_),
+                    },
+                )),
+            },
+        ]
     )
 }
 

--- a/rs/sns/governance/src/governance/assorted_governance_tests.rs
+++ b/rs/sns/governance/src/governance/assorted_governance_tests.rs
@@ -1986,21 +1986,34 @@ fn test_check_upgrade_status_succeeds() {
     // Check that the upgrade journal reflects the succeeded upgrade
     assert_eq!(
         governance.proto.upgrade_journal.clone().unwrap().entries,
-        vec![UpgradeJournalEntry {
-            timestamp_seconds: Some(now),
-            event: Some(upgrade_journal_entry::Event::UpgradeOutcome(
-                upgrade_journal_entry::UpgradeOutcome {
-                    human_readable: Some(format!(
-                        "Upgrade marked successful at timestamp {} seconds, new {:?}",
-                        governance.env.now(),
-                        Version::from(next_version),
-                    )),
-                    status: Some(upgrade_journal_entry::upgrade_outcome::Status::Success(
-                        Empty {}
-                    )),
-                }
-            )),
-        }]
+        vec![
+            UpgradeJournalEntry {
+                timestamp_seconds: Some(now),
+                event: Some(upgrade_journal_entry::Event::UpgradeOutcome(
+                    upgrade_journal_entry::UpgradeOutcome {
+                        human_readable: Some(format!(
+                            "Upgrade marked successful at timestamp {} seconds, new {:?}",
+                            governance.env.now(),
+                            Version::from(next_version.clone()),
+                        )),
+                        status: Some(upgrade_journal_entry::upgrade_outcome::Status::Success(
+                            Empty {}
+                        )),
+                    }
+                )),
+            },
+            UpgradeJournalEntry {
+                timestamp_seconds: Some(now),
+                event: Some(upgrade_journal_entry::Event::UpgradeStepsReset(
+                    upgrade_journal_entry::UpgradeStepsReset {
+                        human_readable: Some("Initializing the cache".to_string()),
+                        upgrade_steps: Some(Versions {
+                            versions: vec![Version::from(next_version)],
+                        }),
+                    }
+                )),
+            },
+        ]
     )
 }
 
@@ -2146,7 +2159,7 @@ fn test_check_upgrade_not_yet_failed_if_canister_summary_errs_and_before_mark_fa
                     human_readable: Some("Initializing the cache".to_string(),),
                     upgrade_steps: Some(Versions {
                         versions: vec![current_version.into()],
-                    },),
+                    }),
                 },
             ),),
         }],

--- a/rs/sns/governance/src/governance/assorted_governance_tests.rs
+++ b/rs/sns/governance/src/governance/assorted_governance_tests.rs
@@ -2414,7 +2414,6 @@ fn test_no_target_version_fails_check_upgrade_status() {
         Box::new(FakeCmc::new()),
     );
 
-    // After we run our periodic tasks, the version should be marked as successful
     governance.run_periodic_tasks().now_or_never();
 
     assert!(governance.proto.pending_version.is_none());
@@ -2447,20 +2446,33 @@ fn test_no_target_version_fails_check_upgrade_status() {
     // Check that the upgrade journal reflects the failed upgrade attempt
     assert_matches!(
         &governance.proto.upgrade_journal.clone().unwrap().entries[..],
-        [UpgradeJournalEntry {
-            timestamp_seconds: _,
-            event: Some(upgrade_journal_entry::Event::UpgradeOutcome(
-                upgrade_journal_entry::UpgradeOutcome {
-                    human_readable: Some(_),
-                    status: Some(
-                        upgrade_journal_entry::upgrade_outcome::Status::InvalidState(
-                            upgrade_journal_entry::upgrade_outcome::InvalidState { version: None }
-                        )
-                    ),
-                }
-            )),
-        }]
-    )
+        [
+            UpgradeJournalEntry {
+                timestamp_seconds: _,
+                event: Some(upgrade_journal_entry::Event::UpgradeOutcome(
+                    upgrade_journal_entry::UpgradeOutcome {
+                        human_readable: Some(_),
+                        status: Some(
+                            upgrade_journal_entry::upgrade_outcome::Status::InvalidState(
+                                upgrade_journal_entry::upgrade_outcome::InvalidState {
+                                    version: None
+                                }
+                            )
+                        ),
+                    }
+                )),
+            },
+            UpgradeJournalEntry {
+                timestamp_seconds: Some(now),
+                event: Some(upgrade_journal_entry::Event::UpgradeStepsReset(
+                    upgrade_journal_entry::UpgradeStepsReset {
+                        human_readable: Some(_),
+                        upgrade_steps: Some(Versions { versions }),
+                    }
+                )),
+            },
+        ]
+    );
 }
 
 #[test]

--- a/rs/sns/governance/src/governance/assorted_governance_tests.rs
+++ b/rs/sns/governance/src/governance/assorted_governance_tests.rs
@@ -2599,8 +2599,6 @@ fn test_check_upgrade_fails_and_sets_deployed_version_if_deployed_version_missin
     // Check that the upgrade journal reflects the succeeded upgrade.
     let upgrade_journal = governance.proto.upgrade_journal.clone().unwrap();
 
-    println!("upgrade_journal.entries = {:#?}", upgrade_journal.entries);
-
     let (reset_upgrade_steps, refreshed_versions) = assert_matches!(
         &upgrade_journal.entries[..],
         [
@@ -3855,10 +3853,6 @@ fn test_disburse_maturity_succeeds_with_multiple_disbursals() {
         let expected_disbursing_maturity =
             remaining_maturity.saturating_mul(*percentage_to_disburse as u64) / 100;
         let in_progress = &neuron.disburse_maturity_in_progress[i];
-        println!(
-            "i: {}, {}, {}",
-            i, percentage_to_disburse, in_progress.amount_e8s
-        );
         assert_eq!(
             in_progress.amount_e8s, expected_disbursing_maturity,
             "unexpected disbursing maturity for percentage {}",

--- a/rs/sns/governance/src/proposal/advance_sns_target_version.rs
+++ b/rs/sns/governance/src/proposal/advance_sns_target_version.rs
@@ -239,8 +239,8 @@ fn test_no_pending_upgrades() {
         // Inspect the observed results.
         assert_eq!(
             err,
-            "The currently deployed SNS version is not in the cached_upgrade_steps. You may need to wait for the upgrade steps to be refreshed. \
-            This shouldn't take more than 3600 seconds."
+            "Currently, the SNS does not have pending upgrades. You may need to wait for \
+             the upgrade steps to be refreshed. This shouldn't take more than 3600 seconds.",
         );
     }
 }
@@ -299,8 +299,8 @@ fn test_deployed_version_not_in_cached_upgrade_steps() {
         // Inspect the observed results.
         assert_eq!(
             err,
-            "The currently deployed SNS version is not in the cached_upgrade_steps. You may need to wait for the upgrade steps to be refreshed. \
-            This shouldn't take more than 3600 seconds."
+            "Currently, the SNS does not have pending upgrades. You may need to wait for \
+             the upgrade steps to be refreshed. This shouldn't take more than 3600 seconds.",
         );
     }
 }

--- a/rs/sns/governance/src/sns_upgrade.rs
+++ b/rs/sns/governance/src/sns_upgrade.rs
@@ -1,3 +1,4 @@
+use crate::cached_upgrade_steps::CachedUpgradeSteps;
 use crate::{pb::v1::governance::Version, proposal::render_version, types::Environment};
 use candid::{Decode, Encode};
 use ic_base_types::{CanisterId, PrincipalId};
@@ -297,37 +298,36 @@ pub(crate) async fn get_upgrade_steps(
     env: &dyn Environment,
     current_version: Version,
     sns_governance_canister_id: PrincipalId,
-) -> Result<Vec<Version>, String> {
+) -> Result<CachedUpgradeSteps, String> {
     let request = ListUpgradeStepsRequest {
         starting_at: Some(current_version.into()),
         sns_governance_canister_id: Some(sns_governance_canister_id),
         limit: 0,
     };
     let arg = Encode!(&request)
-        .map_err(|e| format!("Could not encode ListUpgradeStepsRequest: {:?}", e))?;
+        .map_err(|err| format!("Could not encode ListUpgradeStepsRequest: {:?}", err))?;
+
+    let requested_timestamp_seconds = env.now();
 
     let response = env
         .call_canister(SNS_WASM_CANISTER_ID, "list_upgrade_steps", arg)
         .await
-        .map_err(|e| format!("Request failed for get_next_sns_version: {:?}", e))?;
+        .map_err(|err| format!("Request failed for get_next_sns_version: {:?}", err))?;
 
-    let response = Decode!(&response, ListUpgradeStepsResponse)
-        .map_err(|e| format!("Could not decode response to get_next_sns_version: {:?}", e))?;
-    let response_str = format!("{:?}", response);
+    let response = Decode!(&response, ListUpgradeStepsResponse).map_err(|err| {
+        format!(
+            "Could not decode the response from SnsW.list_upgrade_steps: {}",
+            err
+        )
+    })?;
 
-    response
-        .steps
-        .into_iter()
-        .map(|list_upgrade_step| match list_upgrade_step {
-            ListUpgradeStep {
-                version: Some(version),
-            } => Ok(version.into()),
-            _ => Err(format!(
-                "list_upgrade_steps response had invalid fields: {}",
-                response_str
-            )),
-        })
-        .collect()
+    let response_timestamp_seconds = env.now();
+
+    CachedUpgradeSteps::try_from_sns_w_response(
+        response,
+        requested_timestamp_seconds,
+        response_timestamp_seconds,
+    )
 }
 
 /// Returns all SNS canisters known by the Root canister.

--- a/rs/sns/governance/src/sns_upgrade.rs
+++ b/rs/sns/governance/src/sns_upgrade.rs
@@ -650,11 +650,11 @@ pub struct ListUpgradeStepsRequest {
     /// Limit to number of entries (for paging)
     pub limit: u32,
 }
-#[derive(candid::CandidType, candid::Deserialize, Debug)]
+#[derive(candid::CandidType, candid::Deserialize, Clone, Debug)]
 pub struct ListUpgradeStepsResponse {
     pub steps: ::prost::alloc::vec::Vec<ListUpgradeStep>,
 }
-#[derive(candid::CandidType, candid::Deserialize, Debug, Clone)]
+#[derive(candid::CandidType, candid::Deserialize, Clone, Debug)]
 pub struct ListUpgradeStep {
     pub version: ::core::option::Option<SnsVersion>,
 }

--- a/rs/sns/governance/tests/governance.rs
+++ b/rs/sns/governance/tests/governance.rs
@@ -2865,47 +2865,6 @@ async fn test_mint_tokens() {
 }
 
 #[tokio::test]
-async fn test_refresh_cached_upgrade_steps_noop_if_deployed_version_none() {
-    let mut canister_fixture = GovernanceCanisterFixtureBuilder::new().create();
-
-    // Check that the initial state is None
-    {
-        let original_cached_upgrade_steps = canister_fixture
-            .governance
-            .proto
-            .cached_upgrade_steps
-            .clone();
-        assert_eq!(original_cached_upgrade_steps, None);
-    }
-
-    // Check that the canister wants to refresh the cached_upgrade_steps
-    {
-        let should_refresh = canister_fixture
-            .governance
-            .should_refresh_cached_upgrade_steps();
-        assert!(should_refresh);
-    }
-
-    {
-        canister_fixture.governance.proto.deployed_version = None;
-        canister_fixture
-            .governance
-            .refresh_cached_upgrade_steps()
-            .await;
-    }
-
-    // Check that the state is still None
-    {
-        let original_cached_upgrade_steps = canister_fixture
-            .governance
-            .proto
-            .cached_upgrade_steps
-            .clone();
-        assert_eq!(original_cached_upgrade_steps, None);
-    }
-}
-
-#[tokio::test]
 async fn test_refresh_cached_upgrade_steps() {
     let mut canister_fixture = GovernanceCanisterFixtureBuilder::new().create();
 
@@ -2958,9 +2917,10 @@ async fn test_refresh_cached_upgrade_steps() {
         assert!(should_refresh);
     }
 
-    canister_fixture
+    let deployed_version = canister_fixture
         .governance
-        .temporarily_lock_refresh_cached_upgrade_steps();
+        .try_temporarily_lock_refresh_cached_upgrade_steps()
+        .unwrap();
 
     // Check that the lock has been set
     {
@@ -2976,11 +2936,10 @@ async fn test_refresh_cached_upgrade_steps() {
         );
     }
 
-    canister_fixture.advance_time_by(1);
     // Refresh the upgrade steps
     canister_fixture
         .governance
-        .refresh_cached_upgrade_steps()
+        .refresh_cached_upgrade_steps(deployed_version)
         .await;
 
     // Check that the state has been updated
@@ -2999,9 +2958,11 @@ async fn test_refresh_cached_upgrade_steps() {
             cached_upgrade_steps.requested_timestamp_seconds,
             Some(DEFAULT_TEST_START_TIMESTAMP_SECONDS),
         );
+        // In practice, we would expect `response_timestamp_seconds` > `requested_timestamp_seconds`
+        // but in this test we don't model how time flows inside `refresh_cached_upgrade_steps`.
         assert_eq!(
             cached_upgrade_steps.response_timestamp_seconds,
-            Some(DEFAULT_TEST_START_TIMESTAMP_SECONDS + 1),
+            Some(DEFAULT_TEST_START_TIMESTAMP_SECONDS),
         )
     }
 
@@ -3015,7 +2976,7 @@ async fn test_refresh_cached_upgrade_steps() {
 
     // It still should not want to after less than UPGRADE_STEPS_INTERVAL_REFRESH_BACKOFF_SECONDS
     {
-        canister_fixture.advance_time_by(UPGRADE_STEPS_INTERVAL_REFRESH_BACKOFF_SECONDS - 2);
+        canister_fixture.advance_time_by(UPGRADE_STEPS_INTERVAL_REFRESH_BACKOFF_SECONDS - 1);
         let should_refresh = canister_fixture
             .governance
             .should_refresh_cached_upgrade_steps();
@@ -3033,13 +2994,18 @@ async fn test_refresh_cached_upgrade_steps() {
 
     // Refresh the cached upgrade steps again
     {
+        let deployed_version = canister_fixture
+            .governance
+            .try_temporarily_lock_refresh_cached_upgrade_steps()
+            .unwrap();
         canister_fixture
             .governance
-            .refresh_cached_upgrade_steps()
+            .refresh_cached_upgrade_steps(deployed_version)
             .await;
     }
 
-    // Check that only one refresh has been recorded in the upgrade journal
+    // Check that only one refresh has been recorded in the upgrade journal (because the 2nd one
+    // is identical to the 1st).
     {
         let upgrade_journal = canister_fixture
             .governance
@@ -3051,7 +3017,7 @@ async fn test_refresh_cached_upgrade_steps() {
             upgrade_journal.entries,
             vec![UpgradeJournalEntry {
                 // we advanced time by one second after the first refresh
-                timestamp_seconds: Some(DEFAULT_TEST_START_TIMESTAMP_SECONDS + 1),
+                timestamp_seconds: Some(DEFAULT_TEST_START_TIMESTAMP_SECONDS),
                 // the event contains the upgrade steps
                 event: Some(upgrade_journal_entry::Event::UpgradeStepsRefreshed(
                     upgrade_journal_entry::UpgradeStepsRefreshed {
@@ -3082,16 +3048,17 @@ async fn test_refresh_cached_upgrade_steps_doesnt_panic_on_invalid_response() {
 
     // Refresh should not panic on empty response
     let now = canister_fixture.governance.env.now();
+    let deployed_version = canister_fixture
+        .governance
+        .try_temporarily_lock_refresh_cached_upgrade_steps()
+        .unwrap();
     canister_fixture
         .governance
-        .temporarily_lock_refresh_cached_upgrade_steps();
-    canister_fixture
-        .governance
-        .refresh_cached_upgrade_steps()
+        .refresh_cached_upgrade_steps(deployed_version)
         .await;
     let expected_upgrade_steps = Some(CachedUpgradeSteps {
         upgrade_steps: Some(Versions {
-            versions: Vec::new(),
+            versions: vec![Version::default()],
         }),
         requested_timestamp_seconds: Some(now),
         response_timestamp_seconds: Some(now),
@@ -3117,17 +3084,22 @@ async fn test_refresh_cached_upgrade_steps_handles_sns_w_error() {
     let now = canister_fixture.governance.env.now();
     let expected_upgrade_steps = Some(CachedUpgradeSteps {
         upgrade_steps: Some(Versions {
-            versions: Vec::new(),
+            versions: vec![Version::default()],
         }),
         requested_timestamp_seconds: Some(now),
         response_timestamp_seconds: Some(now),
     });
     canister_fixture.governance.proto.cached_upgrade_steps = expected_upgrade_steps.clone();
 
+    let deployed_version = canister_fixture
+        .governance
+        .try_temporarily_lock_refresh_cached_upgrade_steps()
+        .unwrap();
+
     // Refresh should not panic on error response
     canister_fixture
         .governance
-        .refresh_cached_upgrade_steps()
+        .refresh_cached_upgrade_steps(deployed_version)
         .await;
 
     // State should remain None after error


### PR DESCRIPTION
This PR refactors the SNS Governance to reset cached upgrade steps earlier, as soon as an inconsistency or missing data is detected. This simplifies the implementation of a few periodic functions since they can rely on the data being available.

The behavior is slightly affected, as the first upgrade journal entry for a newly deployed SNS is expected to be a cache _reset_ rather than a cache refresh.