### PR TITLE
feat(sns): Add indication of whether a canister is frozen in `sns health`

### DIFF
--- a/rs/sns/cli/src/health.rs
+++ b/rs/sns/cli/src/health.rs
@@ -73,7 +73,7 @@ impl TableRow for SnsHealthInfo {
                 format!(
                     "{canister_type}: ({:.2} TC{frozen})",
                     cycles.cycles as f64 / TC,
-                    frozen = if (cycles.freezing_threshold as u128) > cycles.cycles {
+                    frozen = if cycles.cycles < cycles.freezing_threshold as u128 {
                         " 🥶".to_string()
                     } else {
                         "".to_string()


### PR DESCRIPTION
Example output:

| Name                    | Memory              | Cycles                                                                                                                         | Upgrades Remaining |
|-------------------------|---------------------|--------------------------------------------------------------------------------------------------------------------------------|--------------------|
| BOOM DAO                | 👍                   | ❌ governance: (6.96 TC), index: (0.00 TC 🥶) | 24                 |
| CYCLES-TRANSFER-STATION | 👍                   | 👍                                                                             | 8                  |
| Catalyze                | 👍                   | ❌ governance: (9.76 TC), swap: (8.83 TC), archive: (9.30 TC)                  | 1                  |

(This is using test data, BOOM DAO's index canister is fine)

The benefit of this is that it draws attention to the canisters that are really in trouble - the frozen ones.

The definition of frozen used by the tool is: the number of cycles is below the freezing threshold (as reported by the canister summary)