### PR TITLE
chore: speed up searching in VScode

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -58,7 +58,16 @@
         "bazelbuild.vscode-bazel",
         "stackbuild.bazel-stack-vscode",
         "bungcip.better-toml"
-      ]
+      ],
+      "settings": {
+        // Exclude bazel output directories from search
+        "search.exclude": {
+          "bazel-bin/": true,
+          "bazel-ic/": true,
+          "bazel-out/": true,
+          "targets/": true
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
Using the global search function in VScode is quite slow, as it indexes order of gigabytes worth of files from the bazel output directories. This PR excludes bazel directories from search to make the search times tolerable.