### PR TITLE
chore: Replace better-toml extenstion with even-better-toml

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -57,7 +57,7 @@
         "vadimcn.vscode-lldb",
         "bazelbuild.vscode-bazel",
         "stackbuild.bazel-stack-vscode",
-        "bungcip.better-toml"
+        "tamasfe.even-better-toml"
       ]
     }
   }


### PR DESCRIPTION
The extension `better-toml` is deprecated and the maintainer recommends to switch to `even-better-toml`. See README https://github.com/bungcip/better-toml/blob/master/README.md.

This PR replaces `better-toml` with `even-better-toml` ast the installed extension in our dev containers.