### PR TITLE
feat: awaiting calls in PocketIC without triggering round execution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17060,6 +17060,7 @@ dependencies = [
 name = "pocket-ic"
 version = "6.0.0"
 dependencies = [
+ "backoff",
  "base64 0.13.1",
  "candid",
  "candid_parser",

--- a/packages/pocket-ic/BUILD.bazel
+++ b/packages/pocket-ic/BUILD.bazel
@@ -4,6 +4,7 @@ package(default_visibility = ["//visibility:public"])
 
 DEPENDENCIES = [
     # Keep sorted.
+    "@crate_index//:backoff",
     "@crate_index//:base64",
     "@crate_index//:candid",
     "@crate_index//:hex",

--- a/packages/pocket-ic/CHANGELOG.md
+++ b/packages/pocket-ic/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - The function `PocketIcBuilder::with_bitcoind_addrs` to specify multiple addresses and ports at which `bitcoind` processes are listening.
 - The functions `PocketIc::update_call_with_effective_principal` and `PocketIc::query_call_with_effective_principal` for making generic calls (including management canister calls).
+- The function `PocketIc::ingress_status` to fetch the status of an update call submitted through an ingress message (`None` means that the status is unknown yet).
 
 
 

--- a/packages/pocket-ic/CHANGELOG.md
+++ b/packages/pocket-ic/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The function `PocketIcBuilder::with_bitcoind_addrs` to specify multiple addresses and ports at which `bitcoind` processes are listening.
 - The functions `PocketIc::update_call_with_effective_principal` and `PocketIc::query_call_with_effective_principal` for making generic calls (including management canister calls).
 - The function `PocketIc::ingress_status` to fetch the status of an update call submitted through an ingress message (`None` means that the status is unknown yet).
+- The function `PocketIc::await_call_no_ticks` to await the status of an update call (submitted through an ingress message) becoming known without triggering round execution
+  (round execution must be triggered separarely, e.g., on a "live" instance or by separate PocketIC library calls).
 
 
 

--- a/packages/pocket-ic/Cargo.toml
+++ b/packages/pocket-ic/Cargo.toml
@@ -20,6 +20,7 @@ authors.workspace = true
 edition.workspace = true
 
 [dependencies]
+backoff = { workspace = true }
 base64 = { workspace = true }
 candid = { workspace = true }
 hex = { workspace = true }

--- a/packages/pocket-ic/src/lib.rs
+++ b/packages/pocket-ic/src/lib.rs
@@ -685,6 +685,14 @@ impl PocketIc {
         runtime.block_on(async { self.pocket_ic.ingress_status(message_id).await })
     }
 
+    /// Await an update call submitted previously by `submit_call_with_effective_principal`.
+    /// This function does not execute rounds and thus should only be called on a "live" PocketIC instance
+    /// or if rounds are executed due to separate PocketIC library calls.
+    pub fn await_call_no_ticks(&self, message_id: RawMessageId) -> Result<WasmResult, UserError> {
+        let runtime = self.runtime.clone();
+        runtime.block_on(async { self.pocket_ic.await_call_no_ticks(message_id).await })
+    }
+
     /// Execute an update call on a canister.
     #[instrument(skip(self, payload), fields(instance_id=self.pocket_ic.instance_id, canister_id = %canister_id.to_string(), sender = %sender.to_string(), method = %method, payload_len = %payload.len()))]
     pub fn update_call(

--- a/packages/pocket-ic/src/lib.rs
+++ b/packages/pocket-ic/src/lib.rs
@@ -674,6 +674,17 @@ impl PocketIc {
         runtime.block_on(async { self.pocket_ic.await_call(message_id).await })
     }
 
+    /// Fetch the status of an update call submitted previously by `submit_call_with_effective_principal`.
+    /// Note that the status of the update call can only change if the PocketIC instance is in live mode
+    /// or a round has been executed due to a separate PocketIC library call.
+    pub fn ingress_status(
+        &self,
+        message_id: RawMessageId,
+    ) -> Option<Result<WasmResult, UserError>> {
+        let runtime = self.runtime.clone();
+        runtime.block_on(async { self.pocket_ic.ingress_status(message_id).await })
+    }
+
     /// Execute an update call on a canister.
     #[instrument(skip(self, payload), fields(instance_id=self.pocket_ic.instance_id, canister_id = %canister_id.to_string(), sender = %sender.to_string(), method = %method, payload_len = %payload.len()))]
     pub fn update_call(

--- a/packages/pocket-ic/tests/tests.rs
+++ b/packages/pocket-ic/tests/tests.rs
@@ -2006,3 +2006,32 @@ fn create_instance_from_existing() {
     let reply = call_counter_can(&pic, can_id, "read");
     assert_eq!(reply, WasmResult::Reply(vec![3, 0, 0, 0]));
 }
+
+#[test]
+fn await_call_no_ticks() {
+    let mut pic = PocketIcBuilder::new()
+        .with_nns_subnet()
+        .with_application_subnet()
+        .build();
+    let canister_id = pic.create_canister();
+    pic.add_cycles(canister_id, INIT_CYCLES);
+    pic.install_canister(canister_id, test_canister_wasm(), vec![], None);
+
+    pic.make_live(None);
+
+    let msg_id = pic
+        .submit_call(
+            canister_id,
+            Principal::anonymous(),
+            "whoami",
+            encode_one(()).unwrap(),
+        )
+        .unwrap();
+
+    let result = pic.await_call_no_ticks(msg_id).unwrap();
+    let principal = match result {
+        WasmResult::Reply(data) => Decode!(&data, String).unwrap(),
+        WasmResult::Reject(err) => panic!("Unexpected reject: {}", err),
+    };
+    assert_eq!(principal, canister_id.to_string());
+}

--- a/rs/pocket_ic_server/CHANGELOG.md
+++ b/rs/pocket_ic_server/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+- New endpoint `/instances/<instance_id>/read/ingress_status` to fetch the status of an update call submitted through an ingress message.
+
 
 
 ## 7.0.0 - 2024-11-13


### PR DESCRIPTION
This PR adds support for awaiting calls in PocketIC without triggering round execution (round execution must be triggered separarely, e.g., on a "live" instance or by separate PocketIC library calls). The motivation is awaiting calls on "live" PocketIC instances, e.g., in dfx.