### PR TITLE
refactor(nns): Use NeuronSections::none instead of default

### DIFF
--- a/rs/nns/governance/src/neuron_store.rs
+++ b/rs/nns/governance/src/neuron_store.rs
@@ -963,7 +963,7 @@ impl NeuronStore {
                     process_neuron(neuron.as_ref());
                 }
             },
-            NeuronSections::default(),
+            NeuronSections::none(),
         );
 
         (ballots, deciding_voting_power, potential_voting_power)
@@ -1006,7 +1006,7 @@ impl NeuronStore {
             &neuron_id,
             NeuronSections {
                 hot_keys: true,
-                ..Default::default()
+                ..NeuronSections::none()
             },
             |neuron| neuron.is_authorized_to_vote(&principal_id),
         )

--- a/rs/nns/governance/src/storage/neurons.rs
+++ b/rs/nns/governance/src/storage/neurons.rs
@@ -46,7 +46,7 @@ pub(crate) struct StableNeuronStoreBuilder<Memory> {
 
 /// A section of a neuron represents a part of neuron that can potentially be large, and when a
 /// neuron is read, the caller can specify which sections of the neuron they want to read.
-#[derive(Copy, Clone, Eq, PartialEq, Debug, Default)]
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
 pub(crate) struct NeuronSections {
     pub hot_keys: bool,
     pub recent_ballots: bool,
@@ -63,6 +63,16 @@ impl NeuronSections {
             followees: true,
             known_neuron_data: true,
             transfer: true,
+        }
+    }
+
+    pub fn none() -> Self {
+        Self {
+            hot_keys: false,
+            recent_ballots: false,
+            followees: false,
+            known_neuron_data: false,
+            transfer: false,
         }
     }
 }

--- a/rs/nns/governance/src/storage/neurons/neurons_tests.rs
+++ b/rs/nns/governance/src/storage/neurons/neurons_tests.rs
@@ -193,7 +193,7 @@ fn test_store_simplest_nontrivial_case() {
     );
 
     // 4. Bad read: Unknown NeuronId. This should result in a NotFound Err.
-    let bad_read_result = store.read(NeuronId { id: 0xDEAD_BEEF }, NeuronSections::default());
+    let bad_read_result = store.read(NeuronId { id: 0xDEAD_BEEF }, NeuronSections::none());
     match &bad_read_result {
         Err(err) => match err {
             NeuronStoreError::NeuronNotFound { neuron_id } => {
@@ -278,7 +278,7 @@ fn test_store_simplest_nontrivial_case() {
     assert_that_red_herring_neurons_are_untouched(&store);
 
     // 8. Read to verify bad update.
-    let read_result = store.read(NeuronId { id: 0xDEAD_BEEF }, NeuronSections::default());
+    let read_result = store.read(NeuronId { id: 0xDEAD_BEEF }, NeuronSections::none());
     match &read_result {
         // This is what we expected.
         Err(err) => {
@@ -330,7 +330,7 @@ fn test_store_simplest_nontrivial_case() {
     assert_that_red_herring_neurons_are_untouched(&store);
 
     // 13. Read to verify delete.
-    let read_result = store.read(NeuronId { id: 42 }, NeuronSections::default());
+    let read_result = store.read(NeuronId { id: 42 }, NeuronSections::none());
     match &read_result {
         // This is what we expected.
         Err(err) => {
@@ -455,27 +455,27 @@ fn test_partial_read() {
         }
     };
 
-    partial_read_test_helper(NeuronSections::default());
+    partial_read_test_helper(NeuronSections::none());
     partial_read_test_helper(NeuronSections::all());
     partial_read_test_helper(NeuronSections {
         hot_keys: true,
-        ..NeuronSections::default()
+        ..NeuronSections::none()
     });
     partial_read_test_helper(NeuronSections {
         followees: true,
-        ..NeuronSections::default()
+        ..NeuronSections::none()
     });
     partial_read_test_helper(NeuronSections {
         recent_ballots: true,
-        ..NeuronSections::default()
+        ..NeuronSections::none()
     });
     partial_read_test_helper(NeuronSections {
         known_neuron_data: true,
-        ..NeuronSections::default()
+        ..NeuronSections::none()
     });
     partial_read_test_helper(NeuronSections {
         transfer: true,
-        ..NeuronSections::default()
+        ..NeuronSections::none()
     });
 }
 


### PR DESCRIPTION
`NeuronSections::default()` doesn't seem to clearly suggest that it represents no sections, and `NeuronSections::none()` seems to be clearer.