### PR TITLE
refactor(nns): Refactor neuron spawn timestamp check to Neuron::ready_to_spawn

### DIFF
--- a/rs/nns/governance/src/neuron/types.rs
+++ b/rs/nns/governance/src/neuron/types.rs
@@ -554,6 +554,11 @@ impl Neuron {
         self.voting_power_refreshed_timestamp_seconds = now_seconds;
     }
 
+    pub(crate) fn ready_to_spawn(&self, now_seconds: u64) -> bool {
+        self.spawn_at_timestamp_seconds
+            .is_some_and(|spawn_at_timestamp_seconds| now_seconds >= spawn_at_timestamp_seconds)
+    }
+
     pub(crate) fn ready_to_unstake_maturity(&self, now_seconds: u64) -> bool {
         self.state(now_seconds) == NeuronState::Dissolved
             && self.staked_maturity_e8s_equivalent.unwrap_or(0) > 0

--- a/rs/nns/governance/src/neuron_store.rs
+++ b/rs/nns/governance/src/neuron_store.rs
@@ -8,7 +8,7 @@ use crate::{
     pb::v1::{
         governance::{followers_map::Followers, FollowersMap},
         governance_error::ErrorType,
-        GovernanceError, Neuron as NeuronProto, NeuronState, Topic,
+        GovernanceError, Neuron as NeuronProto, Topic,
     },
     storage::{
         neuron_indexes::{CorruptedNeuronIndexes, NeuronIndex},
@@ -912,16 +912,7 @@ impl NeuronStore {
 
     /// List all neurons that are spawning
     pub fn list_ready_to_spawn_neuron_ids(&self, now_seconds: u64) -> Vec<NeuronId> {
-        let filter = |n: &Neuron| {
-            let spawning_state = n.state(now_seconds) == NeuronState::Spawning;
-            if !spawning_state {
-                return false;
-            }
-            // spawning_state is calculated based on presence of spawn_at_timestamp_seconds
-            // so it would be quite surprising if it is missing here (impossible in fact)
-            now_seconds >= n.spawn_at_timestamp_seconds.unwrap_or(u64::MAX)
-        };
-        self.filter_map_active_neurons(filter, |n| n.id())
+        self.filter_map_active_neurons(|neuron| neuron.ready_to_spawn(now_seconds), |n| n.id())
     }
 
     pub fn create_ballots_for_standard_proposal(


### PR DESCRIPTION
# Why

The `list_ready_to_spawn_neuron_ids` implementation is unnecessarily complex.

# What

* Refactor neuron spawn timestamp check logic into a `Neuron` method
* Add unit tests for `Neuron::ready_to_spawn`
* Add unit tests for `Neuron::ready_to_unstake_maturity` while we are at it