### PR TITLE
fix(EXC): Make expensive debug assert conditional

### DIFF
--- a/rs/utils/lru_cache/src/lib.rs
+++ b/rs/utils/lru_cache/src/lib.rs
@@ -138,13 +138,18 @@ where
     }
 
     fn check_invariants(&self) {
-        // debug_assert_eq!(
-        //     self.size,
-        //     self.cache
-        //         .iter()
-        //         .map(|(key, value)| key.count_bytes() + value.count_bytes())
-        //         .sum::<usize>()
-        // );
+        // Iterating over random memory locations is expensive and slows down some tests,
+        // so the debug assert is limited to 1k cache entries.
+        #[cfg(debug_assertions)]
+        if self.len() < 1_000 {
+            debug_assert_eq!(
+                self.size,
+                self.cache
+                    .iter()
+                    .map(|(key, value)| key.count_bytes() + value.count_bytes())
+                    .sum::<usize>()
+            );
+        }
         debug_assert!(self.size <= self.capacity);
     }
 }


### PR DESCRIPTION
This fix accelerates tests with many unique queries.