### PR TITLE
fix(sns): Don't permanently get the upgrade lock stuck in the event of overflow

### DIFF
--- a/rs/sns/governance/src/governance.rs
+++ b/rs/sns/governance/src/governance.rs
@@ -4909,7 +4909,10 @@ impl Governance {
         match self.upgrade_periodic_task_lock {
             Some(time_acquired)
                 if now
-                    > time_acquired.saturating_add(UPGRADE_PERIODIC_TASK_LOCK_TIMEOUT_SECONDS) =>
+                    >= time_acquired
+                        .checked_add(UPGRADE_PERIODIC_TASK_LOCK_TIMEOUT_SECONDS)
+                        // In case of overflow, we'll unwrap to 0, which should always cause this to evaluate to true
+                        .unwrap_or(0) =>
             {
                 self.upgrade_periodic_task_lock = Some(now);
                 true

--- a/rs/sns/governance/src/governance/advance_target_sns_version_tests.rs
+++ b/rs/sns/governance/src/governance/advance_target_sns_version_tests.rs
@@ -636,6 +636,44 @@ fn test_perform_advance_target_version() {
     }
 }
 
+#[test]
+fn test_upgrade_periodic_task_lock_times_out() {
+    let env = NativeEnvironment::new(Some(*TEST_GOVERNANCE_CANISTER_ID));
+    let mut gov = Governance::new(
+        basic_governance_proto().try_into().unwrap(),
+        Box::new(env),
+        Box::new(DoNothingLedger {}),
+        Box::new(DoNothingLedger {}),
+        Box::new(FakeCmc::new()),
+    );
+
+    assert!(gov.acquire_upgrade_periodic_task_lock());
+    assert!(!gov.acquire_upgrade_periodic_task_lock());
+    assert!(gov.upgrade_periodic_task_lock.is_some());
+
+    // advance time
+    gov.env.set_time_warp(TimeWarp {
+        delta_s: UPGRADE_PERIODIC_TASK_LOCK_TIMEOUT_SECONDS as i64 + 1,
+    });
+    assert!(gov.acquire_upgrade_periodic_task_lock()); // The lock should successfully be acquired, since the previous one timed out
+    assert!(!gov.acquire_upgrade_periodic_task_lock());
+}
+
+#[test]
+fn test_upgrade_periodic_task_lock_doesnt_get_stuck_during_overflow() {
+    let env = NativeEnvironment::new(Some(*TEST_GOVERNANCE_CANISTER_ID));
+    let mut gov = Governance::new(
+        basic_governance_proto().try_into().unwrap(),
+        Box::new(env),
+        Box::new(DoNothingLedger {}),
+        Box::new(DoNothingLedger {}),
+        Box::new(FakeCmc::new()),
+    );
+
+    gov.upgrade_periodic_task_lock = Some(u64::MAX);
+    assert!(gov.acquire_upgrade_periodic_task_lock());
+}
+
 fn add_environment_mock_calls_for_initiate_upgrade(
     env: &mut NativeEnvironment,
     expected_wasm_hash_requested: Vec<u8>,

--- a/rs/sns/governance/src/governance/assorted_governance_tests.rs
+++ b/rs/sns/governance/src/governance/assorted_governance_tests.rs
@@ -2669,29 +2669,6 @@ fn test_upgrade_periodic_task_lock() {
 }
 
 #[test]
-fn test_upgrade_periodic_task_lock_times_out() {
-    let env = NativeEnvironment::new(Some(*TEST_GOVERNANCE_CANISTER_ID));
-    let mut gov = Governance::new(
-        basic_governance_proto().try_into().unwrap(),
-        Box::new(env),
-        Box::new(DoNothingLedger {}),
-        Box::new(DoNothingLedger {}),
-        Box::new(FakeCmc::new()),
-    );
-
-    assert!(gov.acquire_upgrade_periodic_task_lock());
-    assert!(!gov.acquire_upgrade_periodic_task_lock());
-    assert!(gov.upgrade_periodic_task_lock.is_some());
-
-    // advance time
-    gov.env.set_time_warp(TimeWarp {
-        delta_s: UPGRADE_PERIODIC_TASK_LOCK_TIMEOUT_SECONDS as i64 + 1,
-    });
-    assert!(gov.acquire_upgrade_periodic_task_lock()); // The lock should successfully be acquired, since the previous one timed out
-    assert!(!gov.acquire_upgrade_periodic_task_lock());
-}
-
-#[test]
 fn test_check_upgrade_can_succeed_if_archives_out_of_sync() {
     let root_canister_id = *TEST_ROOT_CANISTER_ID;
     let governance_canister_id = *TEST_GOVERNANCE_CANISTER_ID;


### PR DESCRIPTION
In the very unlikely event of the time being close to u64::max, the upgrade lock would get permanently stuck. This PR changes it so that it is instead permanently un-stuck and adds a test for this edge case. 