### PR TITLE
chore(fuzzing): set `with_precompiled_universal_canister` to `false` for `execute_subnet_message_update_settings`

### DIFF
--- a/rs/execution_environment/fuzz/fuzz_targets/execute_subnet_message_update_settings.rs
+++ b/rs/execution_environment/fuzz/fuzz_targets/execute_subnet_message_update_settings.rs
@@ -12,7 +12,9 @@ fn main() {
 }
 
 fuzz_target!(|args: UpdateSettingsArgs| -> Corpus {
-    let mut test = ExecutionTestBuilder::new().build();
+    let mut test = ExecutionTestBuilder::new()
+        .with_precompiled_universal_canister(false)
+        .build();
 
     let wat = r#"(module)"#;
     let canister_id = test.canister_from_wat(wat).unwrap();


### PR DESCRIPTION
This is a regression from #2816 which broke `execute_subnet_message_update_settings`. The failure was caught on the hourly fuzzer [pipeline](https://github.com/dfinity/ic/actions/runs/12035541363) (CI for PRs don't run the fuzzers).