### PR TITLE
perf(nns): Update canbench_results.yml for NNS Governance and turn on test

### DIFF
--- a/rs/nns/governance/BUILD.bazel
+++ b/rs/nns/governance/BUILD.bazel
@@ -197,6 +197,7 @@ rust_library(
 # Usage:
 # bazel run //rs/nns/governance:governance-canbench for benchmarking
 # bazel run //rs/nns/governance:governance-canbench_update for updating the results file.
+# bazel test //rs/nns/governance:governance_canbench_test for checking if the results file is up to date.
 # Currently, updating the results file is not automated, and there are no tests to avoid
 # regression. For now, we can use it as an example for benchmarking as part of an
 # investigation of potential performance issues, or when we make a change that can affect
@@ -205,6 +206,7 @@ rust_library(
 rust_canbench(
     name = "governance-canbench",
     srcs = ["canbench/main.rs"],
+    add_test = True,
     results_file = "canbench/canbench_results.yml",
     deps = [
         # Keep sorted.

--- a/rs/nns/governance/canbench/canbench_results.yml
+++ b/rs/nns/governance/canbench/canbench_results.yml
@@ -1,61 +1,61 @@
 benches:
   add_neuron_active_maximum:
     total:
-      instructions: 36185720
+      instructions: 36184650
       heap_increase: 1
       stable_memory_increase: 0
     scopes: {}
   add_neuron_active_typical:
     total:
-      instructions: 1835678
+      instructions: 1835617
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   add_neuron_inactive_maximum:
     total:
-      instructions: 96172531
+      instructions: 96171461
       heap_increase: 1
       stable_memory_increase: 0
     scopes: {}
   add_neuron_inactive_typical:
     total:
-      instructions: 7370935
+      instructions: 7370874
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   cascading_vote_all_heap:
     total:
-      instructions: 31928362
+      instructions: 31998643
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   cascading_vote_heap_neurons_stable_index:
     total:
-      instructions: 54231599
+      instructions: 54301880
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   cascading_vote_stable_everything:
     total:
-      instructions: 160353265
+      instructions: 160386757
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   cascading_vote_stable_neurons_with_heap_index:
     total:
-      instructions: 138159263
+      instructions: 138192755
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   centralized_following_all_stable:
     total:
-      instructions: 66001085
+      instructions: 66019738
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   compute_ballots_for_new_proposal_with_stable_neurons:
     total:
-      instructions: 1782808
+      instructions: 1787096
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
@@ -67,19 +67,19 @@ benches:
     scopes: {}
   list_neurons_ready_to_unstake_maturity_stable:
     total:
-      instructions: 712702017
+      instructions: 712831057
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   list_ready_to_spawn_neuron_ids_heap:
     total:
-      instructions: 462676
+      instructions: 461375
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   list_ready_to_spawn_neuron_ids_stable:
     total:
-      instructions: 712693035
+      instructions: 712821092
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
@@ -91,25 +91,25 @@ benches:
     scopes: {}
   neuron_metrics_calculation_stable:
     total:
-      instructions: 1817353
+      instructions: 1821353
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   range_neurons_performance:
     total:
-      instructions: 47337873
+      instructions: 47346463
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   single_vote_all_stable:
     total:
-      instructions: 363904
+      instructions: 363984
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   update_recent_ballots_stable_memory:
     total:
-      instructions: 13388351
+      instructions: 13388431
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}


### PR DESCRIPTION
# Why

Avoid performance regressions by adding a test which will fail if the benchmark results change (currently, by 2%)

# What

1. Run `bazel run //rs/nns/governance:governance-canbench_update` to update the results file
2. Add `add_test = True` for generating a test target to check if the results file is up to date
3. Add a comment about the new test target
