### PR TITLE
fix(nns): Fix incorrectly modified line from NeuronSections PR

### DIFF
--- a/rs/nns/governance/src/neuron_store.rs
+++ b/rs/nns/governance/src/neuron_store.rs
@@ -963,7 +963,7 @@ impl NeuronStore {
                     process_neuron(neuron.as_ref());
                 }
             },
-            NeuronSections::ALL,
+            NeuronSections::NONE,
         );
 
         (ballots, deciding_voting_power, potential_voting_power)


### PR DESCRIPTION
An incorrect line made it into a previous PR, which caused a 43x performance regression in calculating ballots: 

Previous PR: https://github.com/dfinity/ic/pull/2470/files