### PR TITLE
feat(nns): Improve listing neuron ids performance by reading the main section only

### DIFF
--- a/rs/nns/governance/canbench/canbench_results.yml
+++ b/rs/nns/governance/canbench/canbench_results.yml
@@ -61,25 +61,25 @@ benches:
     scopes: {}
   list_neurons_ready_to_unstake_maturity_heap:
     total:
-      instructions: 470604
+      instructions: 471240
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   list_neurons_ready_to_unstake_maturity_stable:
     total:
-      instructions: 730635390
+      instructions: 36291394
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   list_ready_to_spawn_neuron_ids_heap:
     total:
-      instructions: 461375
+      instructions: 459353
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   list_ready_to_spawn_neuron_ids_stable:
     total:
-      instructions: 730625425
+      instructions: 36280095
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}

--- a/rs/nns/governance/src/neuron_store.rs
+++ b/rs/nns/governance/src/neuron_store.rs
@@ -901,8 +901,14 @@ impl NeuronStore {
 
     /// List all neuron ids whose neurons have staked maturity greater than 0.
     pub fn list_neurons_ready_to_unstake_maturity(&self, now_seconds: u64) -> Vec<NeuronId> {
-        let filter = |neuron: &Neuron| neuron.ready_to_unstake_maturity(now_seconds);
-        self.filter_map_active_neurons(filter, |neuron| neuron.id())
+        self.with_active_neurons_iter_sections(
+            |iter| {
+                iter.filter(|neuron| neuron.ready_to_unstake_maturity(now_seconds))
+                    .map(|neuron| neuron.id())
+                    .collect()
+            },
+            NeuronSections::NONE,
+        )
     }
 
     /// List all neuron ids of known neurons
@@ -912,7 +918,14 @@ impl NeuronStore {
 
     /// List all neurons that are spawning
     pub fn list_ready_to_spawn_neuron_ids(&self, now_seconds: u64) -> Vec<NeuronId> {
-        self.filter_map_active_neurons(|neuron| neuron.ready_to_spawn(now_seconds), |n| n.id())
+        self.with_active_neurons_iter_sections(
+            |iter| {
+                iter.filter(|neuron| neuron.ready_to_spawn(now_seconds))
+                    .map(|neuron| neuron.id())
+                    .collect()
+            },
+            NeuronSections::NONE,
+        )
     }
 
     pub fn create_ballots_for_standard_proposal(


### PR DESCRIPTION
# Why

As neurons will be moved to stable memory, listing neuron ids that are ready to spawn/unstake maturity will be more computationally intensive and we should optimize them.

# What

1. Only read the main section of the neuron for those 2 situations
2. Update benchmark results

[Prev](https://github.com/dfinity/ic/pull/2812)
