### PR TITLE
refactor(nns): Switch NNS Governance global state from static to thread_local

### DIFF
--- a/rs/nns/governance/src/governance.rs
+++ b/rs/nns/governance/src/governance.rs
@@ -117,7 +117,7 @@ use rust_decimal_macros::dec;
 use std::{
     borrow::Cow,
     cmp::{max, Ordering},
-    collections::{HashMap, HashSet},
+    collections::{BTreeMap, HashMap, HashSet},
     convert::{TryFrom, TryInto},
     fmt,
     future::Future,
@@ -1935,6 +1935,30 @@ fn spawn_in_canister_env(future: impl Future<Output = ()> + Sized + 'static) {
 }
 
 impl Governance {
+    /// Creates a new Governance instance with uninitialized fields. The canister should only have
+    /// such state before the state is recovered from the stable memory in post_upgrade or
+    /// initialized in init. In any other case, the `Governance` object should be initialized with
+    /// either `new` or `new_restored`.
+    pub fn new_uninitialized(
+        env: Box<dyn Environment>,
+        ledger: Box<dyn IcpLedger>,
+        cmc: Box<dyn CMC>,
+    ) -> Self {
+        Self {
+            heap_data: HeapGovernanceData::default(),
+            neuron_store: NeuronStore::new(BTreeMap::new()),
+            env,
+            ledger,
+            cmc,
+            closest_proposal_deadline_timestamp_seconds: 0,
+            latest_gc_timestamp_seconds: 0,
+            latest_gc_num_proposals: 0,
+            neuron_data_validator: NeuronDataValidator::new(),
+            minting_node_provider_rewards: false,
+            neuron_rate_limits: NeuronRateLimits::default(),
+        }
+    }
+
     /// Initializes Governance for the first time from init payload. When restoring after an upgrade
     /// with its persisted state, `Governance::new_restored` should be called instead.
     pub fn new(


### PR DESCRIPTION
# Why `governance()` and `governance_mut()` are bad

Representing the canister global state with `thread_local!` avoids using unsafe blocks to access it. When using unsafe blocks to access it, one can easily write code with undefined behavior by retaining references across await boundary (more precisely, after an inter-canister call). 

# Why this PR

The NNS Governance heavily depends on the accessing the global state as `static`, and there will be a lot of refactoring needed in order to get away with the current pattern. This PR is the first step towards getting rid of those bad access patterns - with this change, we can gradually migrate from using `governance()`/`governance_mut()` to using `GOVERNANCE.with()`. When all the usage of `governance()`/`governance_mut()` are replaced, we can delete them and declare victory.

# What

Define the global state with `thread_local!` (`LocalKey<RefCell<Governance>>`) while returning the raw pointer for the existing access pattern.

# Why it is safe

The `LocalKey<RefCell<T>>` is set once and only once during `post_upgrade` or `init`, so the pointer should remain constant, given that the canister code is single threaded. When accessing through `governance()` or `governance_mut()` one can still write code with undefined behavior, but it is the same danger as what we have now.

# Why `Governance::new_uninitialized`

This is needed in order for the `thread_local!` state to be `Governance` instead of `Option<Governance>`. We know the "uninitialized" version won't be used except for the code in the init/post_upgrade before the "initialized" state is set. However, there doesn't seem to be a good way to express that understanding. An alternative is to still use `Option<Governance>` and `unwrap()` every time, but it seems more cumbersome.