### PR TITLE
feat(test): Add test-only endpoint to refresh cached upgrade steps

### DIFF
--- a/rs/sns/governance/canister/canister.rs
+++ b/rs/sns/governance/canister/canister.rs
@@ -22,6 +22,7 @@ use ic_nns_constants::LEDGER_CANISTER_ID as NNS_LEDGER_CANISTER_ID;
 use ic_sns_governance::pb::v1::{
     AddMaturityRequest, AddMaturityResponse, AdvanceTargetVersionRequest,
     AdvanceTargetVersionResponse, GovernanceError, MintTokensRequest, MintTokensResponse, Neuron,
+    RefreshCachedUpgradeStepsRequest, RefreshCachedUpgradeStepsResponse,
 };
 use ic_sns_governance::{
     governance::{
@@ -684,6 +685,16 @@ async fn mint_tokens(request: MintTokensRequest) -> MintTokensResponse {
 #[update]
 fn advance_target_version(request: AdvanceTargetVersionRequest) -> AdvanceTargetVersionResponse {
     governance_mut().advance_target_version(request)
+}
+
+/// Test only feature. Immediately refreshes the cached upgrade steps.
+#[cfg(feature = "test")]
+#[update]
+async fn refresh_cached_upgrade_steps(
+    _: RefreshCachedUpgradeStepsRequest,
+) -> RefreshCachedUpgradeStepsResponse {
+    governance_mut().refresh_cached_upgrade_steps().await;
+    RefreshCachedUpgradeStepsResponse {}
 }
 
 fn main() {

--- a/rs/sns/governance/canister/governance_test.did
+++ b/rs/sns/governance/canister/governance_test.did
@@ -859,4 +859,5 @@ service : (Governance) -> {
   advance_target_version : (AdvanceTargetVersionRequest) -> (AdvanceTargetVersionResponse);
   reset_timers : (record {}) -> (record {});
   get_timers : (record {}) -> (GetTimersResponse) query;
+  refresh_cached_upgrade_steps : (record {}) -> (record {});
 }

--- a/rs/sns/governance/proto/ic_sns_governance/pb/v1/governance.proto
+++ b/rs/sns/governance/proto/ic_sns_governance/pb/v1/governance.proto
@@ -2199,6 +2199,12 @@ message AdvanceTargetVersionRequest {
 // The response to a request to advance the target version of the SNS.
 message AdvanceTargetVersionResponse {}
 
+// A test-only API that refreshes the cached upgrade steps.
+message RefreshCachedUpgradeStepsRequest {}
+
+// The response to a request to refresh the cached upgrade steps.
+message RefreshCachedUpgradeStepsResponse {}
+
 // Represents a single entry in the upgrade journal.
 message UpgradeJournalEntry {
   oneof event {

--- a/rs/sns/governance/src/gen/ic_sns_governance.pb.v1.rs
+++ b/rs/sns/governance/src/gen/ic_sns_governance.pb.v1.rs
@@ -3438,6 +3438,28 @@ pub struct AdvanceTargetVersionRequest {
     ::prost::Message,
 )]
 pub struct AdvanceTargetVersionResponse {}
+/// A test-only API that refreshes the cached upgrade steps.
+#[derive(
+    candid::CandidType,
+    candid::Deserialize,
+    comparable::Comparable,
+    Clone,
+    Copy,
+    PartialEq,
+    ::prost::Message,
+)]
+pub struct RefreshCachedUpgradeStepsRequest {}
+/// The response to a request to refresh the cached upgrade steps.
+#[derive(
+    candid::CandidType,
+    candid::Deserialize,
+    comparable::Comparable,
+    Clone,
+    Copy,
+    PartialEq,
+    ::prost::Message,
+)]
+pub struct RefreshCachedUpgradeStepsResponse {}
 /// Represents a single entry in the upgrade journal.
 #[derive(
     candid::CandidType,


### PR DESCRIPTION
Needed for easy testing of the AdvanceSnsTargetVersion feature