### PR TITLE
fix(ICRC-Ledger): changed certificate version

### DIFF
--- a/rs/ledger_suite/icrc1/ledger/src/main.rs
+++ b/rs/ledger_suite/icrc1/ledger/src/main.rs
@@ -34,6 +34,7 @@ use icrc_ledger_types::icrc21::{
 use icrc_ledger_types::icrc3::blocks::DataCertificate;
 #[cfg(not(feature = "get-blocks-disabled"))]
 use icrc_ledger_types::icrc3::blocks::GetBlocksResponse;
+use icrc_ledger_types::icrc3::blocks::ICRC3DataCertificate;
 use icrc_ledger_types::{
     icrc::generic_metadata_value::MetadataValue as Value,
     icrc3::{
@@ -801,12 +802,12 @@ fn icrc3_get_archives(args: GetArchivesArgs) -> GetArchivesResult {
 
 #[query]
 #[candid_method(query)]
-fn icrc3_get_tip_certificate() -> Option<icrc_ledger_types::icrc3::blocks::ICRC3DataCertificate> {
+fn icrc3_get_tip_certificate() -> Option<ICRC3DataCertificate> {
     let certificate = ByteBuf::from(ic_cdk::api::data_certificate()?);
     let hash_tree = Access::with_ledger(|ledger| ledger.construct_hash_tree());
     let mut tree_buf = vec![];
     ciborium::ser::into_writer(&hash_tree, &mut tree_buf).unwrap();
-    Some(icrc_ledger_types::icrc3::blocks::ICRC3DataCertificate {
+    Some(ICRC3DataCertificate {
         certificate,
         hash_tree: ByteBuf::from(tree_buf),
     })

--- a/rs/ledger_suite/icrc1/ledger/tests/tests.rs
+++ b/rs/ledger_suite/icrc1/ledger/tests/tests.rs
@@ -27,7 +27,6 @@ use icrc_ledger_types::icrc2::allowance::Allowance;
 use icrc_ledger_types::icrc2::approve::{ApproveArgs, ApproveError};
 use icrc_ledger_types::icrc2::transfer_from::{TransferFromArgs, TransferFromError};
 use icrc_ledger_types::icrc3::archive::{GetArchivesArgs, GetArchivesResult, QueryArchiveFn};
-use icrc_ledger_types::icrc3::blocks::ICRC3DataCertificate;
 use icrc_ledger_types::icrc3::blocks::{
     ArchivedBlocks, BlockWithId, GetBlocksRequest, GetBlocksResponse, GetBlocksResult,
 };
@@ -1259,7 +1258,7 @@ fn test_icrc3_upgrade() {
         )
         .unwrap()
         .bytes(),
-        Option<ICRC3DataCertificate>
+        Option<icrc_ledger_types::icrc3::blocks::ICRC3DataCertificate>
     )
     .unwrap()
     .unwrap();
@@ -1293,7 +1292,7 @@ fn test_icrc3_upgrade() {
         )
         .unwrap()
         .bytes(),
-        Option<ICRC3DataCertificate>
+        Option<icrc_ledger_types::icrc3::blocks::ICRC3DataCertificate>
     )
     .unwrap()
     .unwrap();

--- a/rs/ledger_suite/icrc1/ledger/tests/tests.rs
+++ b/rs/ledger_suite/icrc1/ledger/tests/tests.rs
@@ -27,6 +27,7 @@ use icrc_ledger_types::icrc2::allowance::Allowance;
 use icrc_ledger_types::icrc2::approve::{ApproveArgs, ApproveError};
 use icrc_ledger_types::icrc2::transfer_from::{TransferFromArgs, TransferFromError};
 use icrc_ledger_types::icrc3::archive::{GetArchivesArgs, GetArchivesResult, QueryArchiveFn};
+use icrc_ledger_types::icrc3::blocks::ICRC3DataCertificate;
 use icrc_ledger_types::icrc3::blocks::{
     ArchivedBlocks, BlockWithId, GetBlocksRequest, GetBlocksResponse, GetBlocksResult,
 };
@@ -1258,7 +1259,7 @@ fn test_icrc3_upgrade() {
         )
         .unwrap()
         .bytes(),
-        Option<icrc_ledger_types::icrc3::blocks::ICRC3DataCertificate>
+        Option<ICRC3DataCertificate>
     )
     .unwrap()
     .unwrap();
@@ -1292,7 +1293,7 @@ fn test_icrc3_upgrade() {
         )
         .unwrap()
         .bytes(),
-        Option<icrc_ledger_types::icrc3::blocks::ICRC3DataCertificate>
+        Option<ICRC3DataCertificate>
     )
     .unwrap()
     .unwrap();

--- a/rs/tests/financial_integrations/icrc1_agent_test.rs
+++ b/rs/tests/financial_integrations/icrc1_agent_test.rs
@@ -294,7 +294,6 @@ pub fn test(env: TestEnv) {
         assert_eq!(Nat::from(1_u8), last_block_index);
 
         let data_certificate = agent.get_data_certificate().await.unwrap();
-        assert!(data_certificate.certificate.is_some());
 
         use LookupStatus::Found;
         let hash_tree: MixedHashTree = serde_cbor::from_slice(&data_certificate.hash_tree).unwrap();
@@ -309,7 +308,7 @@ pub fn test(env: TestEnv) {
             Found(&mleaf(archived_blocks.blocks[1].hash()))
         );
 
-        let cert = serde_cbor::from_slice(&data_certificate.certificate.unwrap()).unwrap();
+        let cert = serde_cbor::from_slice(&data_certificate.certificate).unwrap();
         assert_matches!(
             agent.verify_root_hash(&cert, &hash_tree.digest().0).await,
             Ok(_)

--- a/rs/tests/financial_integrations/icrc1_agent_test.rs
+++ b/rs/tests/financial_integrations/icrc1_agent_test.rs
@@ -293,7 +293,7 @@ pub fn test(env: TestEnv) {
         assert_eq!(archived_blocks.blocks[1].hash(), last_block_hash);
         assert_eq!(Nat::from(1_u8), last_block_index);
 
-        let data_certificate = agent.get_data_certificate().await.unwrap();
+        let data_certificate = agent.icrc3_get_tip_certificate().await.unwrap();
 
         use LookupStatus::Found;
         let hash_tree: MixedHashTree = serde_cbor::from_slice(&data_certificate.hash_tree).unwrap();


### PR DESCRIPTION
This MR proposes the following changes: 

1. Use the icrc3 certificate endpoint for the ICRC1 Agent library. 