### PR TITLE
chore: Removes an exception in buf.yaml

### DIFF
--- a/buf.yaml
+++ b/buf.yaml
@@ -21,7 +21,6 @@ lint:
     - DEFAULT
 breaking:
   ignore:
-    - state/queues/v1/queues.proto
   use:
     - WIRE
   except:


### PR DESCRIPTION
The exception was added [here](https://github.com/dfinity/ic/pull/2622) to enable a specific change. After merging it, it should be removed.