### PR TITLE
chore(EXC): Remove IPC calls for compliation in canister sandbox

### DIFF
--- a/rs/canister_sandbox/bin/test_controller.rs
+++ b/rs/canister_sandbox/bin/test_controller.rs
@@ -4,6 +4,7 @@ use ic_canister_sandbox_backend_lib::{
     protocol::{ctlsvc, id::WasmId, logging::LogRequest, sbxsvc},
     rpc,
 };
+use ic_embedders::SerializedModuleBytes;
 use std::sync::{atomic::AtomicBool, Arc};
 
 struct DummyControllerService {}
@@ -44,9 +45,9 @@ fn main() {
 
     println!("Controller: Sending 'open_wasm' request");
     let wasm_id = WasmId::new();
-    sbx.open_wasm(sbxsvc::OpenWasmRequest {
+    sbx.open_wasm_serialized(sbxsvc::OpenWasmSerializedRequest {
         wasm_id,
-        wasm_src: Vec::new(),
+        serialized_module: Arc::new(SerializedModuleBytes::empty()),
     })
     .sync()
     .unwrap();

--- a/rs/canister_sandbox/bin/test_sandbox.rs
+++ b/rs/canister_sandbox/bin/test_sandbox.rs
@@ -1,14 +1,7 @@
 use ic_canister_sandbox_backend_lib::{
     protocol, protocol::sbxsvc, rpc, sandbox_service, transport, transport::SocketReaderConfig,
 };
-use ic_embedders::{
-    wasm_utils::{Segments, WasmImportsDetails},
-    CompilationResult, SerializedModule, SerializedModuleBytes,
-};
-use ic_replicated_state::canister_state::execution_state::WasmMetadata;
-use ic_types::NumInstructions;
 
-use std::collections::BTreeSet;
 use std::os::unix::io::FromRawFd;
 use std::sync::Arc;
 
@@ -31,7 +24,8 @@ impl sandbox_service::SandboxService for DummySandboxService {
         &self,
         _req: sbxsvc::OpenWasmSerializedRequest,
     ) -> rpc::Call<sbxsvc::OpenWasmSerializedReply> {
-        unimplemented!();
+        println!("Sandbox: Received 'open_wasm_serialized' request");
+        rpc::Call::new_resolved(Ok(sbxsvc::OpenWasmSerializedReply(Ok(()))))
     }
 
     fn close_wasm(&self, _req: sbxsvc::CloseWasmRequest) -> rpc::Call<sbxsvc::CloseWasmReply> {

--- a/rs/canister_sandbox/bin/test_sandbox.rs
+++ b/rs/canister_sandbox/bin/test_sandbox.rs
@@ -27,23 +27,6 @@ impl sandbox_service::SandboxService for DummySandboxService {
         rpc::Call::new_resolved(Ok(sbxsvc::TerminateReply {}))
     }
 
-    fn open_wasm(&self, _req: sbxsvc::OpenWasmRequest) -> rpc::Call<sbxsvc::OpenWasmReply> {
-        println!("Sandbox: Received 'open_wasm' request");
-        rpc::Call::new_resolved(Ok(sbxsvc::OpenWasmReply(Ok((
-            CompilationResult::empty_for_testing(),
-            SerializedModule {
-                bytes: Arc::new(SerializedModuleBytes::empty()),
-                exported_functions: BTreeSet::new(),
-                data_segments: Segments::default(),
-                wasm_metadata: WasmMetadata::default(),
-                compilation_cost: NumInstructions::from(0),
-                imports_details: WasmImportsDetails::default(),
-                // For these tests, it doesn't matter if it's wasm64 or not.
-                is_wasm64: false,
-            },
-        )))))
-    }
-
     fn open_wasm_serialized(
         &self,
         _req: sbxsvc::OpenWasmSerializedRequest,
@@ -84,13 +67,6 @@ impl sandbox_service::SandboxService for DummySandboxService {
         &self,
         _req: sbxsvc::AbortExecutionRequest,
     ) -> rpc::Call<sbxsvc::AbortExecutionReply> {
-        unimplemented!()
-    }
-
-    fn create_execution_state(
-        &self,
-        _req: sbxsvc::CreateExecutionStateRequest,
-    ) -> rpc::Call<sbxsvc::CreateExecutionStateReply> {
         unimplemented!()
     }
 

--- a/rs/canister_sandbox/src/protocol/sbxsvc.rs
+++ b/rs/canister_sandbox/src/protocol/sbxsvc.rs
@@ -348,11 +348,9 @@ mod tests {
         id::{ExecId, MemoryId, WasmId},
         sbxsvc::{
             AbortExecutionReply, AbortExecutionRequest, CloseMemoryReply, CloseMemoryRequest,
-            CloseWasmReply, CloseWasmRequest, CreateExecutionStateReply,
-            CreateExecutionStateRequest, CreateExecutionStateSerializedReply,
+            CloseWasmReply, CloseWasmRequest, CreateExecutionStateSerializedReply,
             CreateExecutionStateSerializedRequest, CreateExecutionStateSerializedSuccessReply,
-            CreateExecutionStateSuccessReply, MemorySerialization, OpenMemoryReply,
-            OpenMemoryRequest, OpenWasmReply, OpenWasmRequest, OpenWasmSerializedReply,
+            MemorySerialization, OpenMemoryReply, OpenMemoryRequest, OpenWasmSerializedReply,
             OpenWasmSerializedRequest, ResumeExecutionReply, ResumeExecutionRequest,
             StartExecutionReply, StartExecutionRequest, TerminateReply,
         },
@@ -398,21 +396,6 @@ mod tests {
     #[test]
     fn round_trip_terminate_reply() {
         let msg = Reply::Terminate(TerminateReply {});
-        assert_eq!(round_trip_reply(&msg), msg);
-    }
-
-    #[test]
-    fn round_trip_open_wasm_request() {
-        let msg = Request::OpenWasm(OpenWasmRequest {
-            wasm_id: WasmId::new(),
-            wasm_src: vec![1, 2, 3],
-        });
-        assert_eq!(round_trip_request(&msg), msg);
-    }
-
-    #[test]
-    fn round_trip_open_wasm_reply() {
-        let msg = Reply::OpenWasm(OpenWasmReply(Ok(wasm_module())));
         assert_eq!(round_trip_reply(&msg), msg);
     }
 
@@ -581,41 +564,6 @@ mod tests {
     #[test]
     fn round_trip_abort_execution_reply() {
         let msg = Reply::AbortExecution(AbortExecutionReply { success: true });
-        assert_eq!(round_trip_reply(&msg), msg);
-    }
-
-    #[test]
-    fn round_trip_create_execution_state_request() {
-        let msg = Request::CreateExecutionState(CreateExecutionStateRequest {
-            wasm_id: WasmId::new(),
-            wasm_binary: vec![1, 2, 3],
-            wasm_page_map: PageMap::new_for_testing().serialize(),
-            next_wasm_memory_id: MemoryId::new(),
-            canister_id: canister_test_id(1),
-            stable_memory_page_map: PageMap::new_for_testing().serialize(),
-        });
-        assert_eq!(round_trip_request(&msg), msg);
-    }
-
-    #[test]
-    fn round_trip_create_execution_state_reply() {
-        let compilation = wasm_module();
-        let reply = CreateExecutionStateSuccessReply {
-            wasm_memory_modifications: MemoryModifications {
-                page_delta: PageMap::new_for_testing().serialize_delta(&[]),
-                size: NumWasmPages::new(10),
-            },
-            exported_globals: vec![
-                Global::I32(10),
-                Global::I64(32),
-                Global::F32(10.5),
-                Global::F64(12.3),
-                Global::V128(123),
-            ],
-            compilation_result: compilation.0,
-            serialized_module: compilation.1,
-        };
-        let msg = Reply::CreateExecutionState(CreateExecutionStateReply(Ok(reply)));
         assert_eq!(round_trip_reply(&msg), msg);
     }
 

--- a/rs/canister_sandbox/src/sandbox_client_stub.rs
+++ b/rs/canister_sandbox/src/sandbox_client_stub.rs
@@ -24,14 +24,6 @@ impl SandboxService for SandboxClientStub {
         Call::new(cell)
     }
 
-    fn open_wasm(&self, req: OpenWasmRequest) -> Call<OpenWasmReply> {
-        let cell = self.channel.call(Request::OpenWasm(req), |rep| match rep {
-            Reply::OpenWasm(rep) => Ok(rep),
-            _ => Err(Error::ServerError),
-        });
-        Call::new(cell)
-    }
-
     fn open_wasm_serialized(
         &self,
         req: OpenWasmSerializedRequest,
@@ -98,19 +90,6 @@ impl SandboxService for SandboxClientStub {
             .channel
             .call(Request::AbortExecution(req), |rep| match rep {
                 Reply::AbortExecution(rep) => Ok(rep),
-                _ => Err(Error::ServerError),
-            });
-        Call::new(cell)
-    }
-
-    fn create_execution_state(
-        &self,
-        req: CreateExecutionStateRequest,
-    ) -> Call<CreateExecutionStateReply> {
-        let cell = self
-            .channel
-            .call(Request::CreateExecutionState(req), |rep| match rep {
-                Reply::CreateExecutionState(rep) => Ok(rep),
                 _ => Err(Error::ServerError),
             });
         Call::new(cell)

--- a/rs/canister_sandbox/src/sandbox_server.rs
+++ b/rs/canister_sandbox/src/sandbox_server.rs
@@ -126,6 +126,7 @@ mod tests {
     use ic_config::subnet_config::{CyclesAccountManagerConfig, SchedulerConfig};
     use ic_config::{embedders::Config as EmbeddersConfig, flag_status::FlagStatus};
     use ic_cycles_account_manager::{CyclesAccountManager, ResourceSaturation};
+    use ic_embedders::{wasm_utils, SerializedModuleBytes, WasmtimeEmbedder};
     use ic_interfaces::execution_environment::{ExecutionMode, SubnetAvailableMemory};
     use ic_limits::SMALL_APP_SUBNET_MAX_SIZE;
     use ic_logger::replica_logger::no_op_logger;
@@ -143,6 +144,7 @@ mod tests {
         time::Time,
         CanisterTimer, ComputeAllocation, Cycles, MemoryAllocation, NumBytes, NumInstructions,
     };
+    use ic_wasm_types::BinaryEncodedWasm;
     use mockall::*;
     use std::collections::{BTreeMap, BTreeSet};
     use std::convert::TryFrom;
@@ -553,6 +555,15 @@ mod tests {
         assert!(rep.success);
     }
 
+    fn compile_module(wasm: Vec<u8>) -> Arc<SerializedModuleBytes> {
+        let embedder = WasmtimeEmbedder::new(EmbeddersConfig::default(), no_op_logger());
+        wasm_utils::compile(&embedder, &BinaryEncodedWasm::new(wasm))
+            .1
+            .unwrap()
+            .1
+            .bytes
+    }
+
     /// Verifies that we can create a simple canister and run something on
     /// it.
     #[test]
@@ -567,10 +578,11 @@ mod tests {
         ));
 
         let wasm_id = WasmId::new();
+        let serialized_module = compile_module(make_counter_canister_wasm());
         let rep = srv
-            .open_wasm(OpenWasmRequest {
+            .open_wasm_serialized(OpenWasmSerializedRequest {
                 wasm_id,
-                wasm_src: make_counter_canister_wasm(),
+                serialized_module,
             })
             .sync()
             .unwrap();
@@ -648,10 +660,11 @@ mod tests {
         ));
 
         let wasm_id = WasmId::new();
+        let serialized_module = compile_module(make_memory_canister_wasm());
         let rep = srv
-            .open_wasm(OpenWasmRequest {
+            .open_wasm_serialized(OpenWasmSerializedRequest {
                 wasm_id,
-                wasm_src: make_memory_canister_wasm(),
+                serialized_module,
             })
             .sync()
             .unwrap();
@@ -708,10 +721,11 @@ mod tests {
         ));
 
         let wasm_id = WasmId::new();
+        let serialized_module = compile_module(make_memory_canister_wasm());
         let rep = srv
-            .open_wasm(OpenWasmRequest {
+            .open_wasm_serialized(OpenWasmSerializedRequest {
                 wasm_id,
-                wasm_src: make_memory_canister_wasm(),
+                serialized_module,
             })
             .sync()
             .unwrap();
@@ -797,10 +811,11 @@ mod tests {
         ));
 
         let wasm_id = WasmId::new();
+        let serialized_module = compile_module(make_counter_canister_wasm());
         let rep = srv
-            .open_wasm(OpenWasmRequest {
+            .open_wasm_serialized(OpenWasmSerializedRequest {
                 wasm_id,
-                wasm_src: make_counter_canister_wasm(),
+                serialized_module,
             })
             .sync()
             .unwrap();
@@ -917,10 +932,11 @@ mod tests {
         ));
 
         let wasm_id = WasmId::new();
+        let serialized_module = compile_module(make_memory_canister_wasm());
         let rep = srv
-            .open_wasm(OpenWasmRequest {
+            .open_wasm_serialized(OpenWasmSerializedRequest {
                 wasm_id,
-                wasm_src: make_memory_canister_wasm(),
+                serialized_module,
             })
             .sync()
             .unwrap();
@@ -977,10 +993,11 @@ mod tests {
         ));
 
         let wasm_id = WasmId::new();
+        let serialized_module = compile_module(make_memory_canister_wasm());
         let rep = srv
-            .open_wasm(OpenWasmRequest {
+            .open_wasm_serialized(OpenWasmSerializedRequest {
                 wasm_id,
-                wasm_src: make_memory_canister_wasm(),
+                serialized_module,
             })
             .sync()
             .unwrap();
@@ -1050,10 +1067,11 @@ mod tests {
         ));
 
         let wasm_id = WasmId::new();
+        let serialized_module = compile_module(make_memory_canister_wasm());
         let rep = srv
-            .open_wasm(OpenWasmRequest {
+            .open_wasm_serialized(OpenWasmSerializedRequest {
                 wasm_id,
-                wasm_src: make_memory_canister_wasm(),
+                serialized_module,
             })
             .sync()
             .unwrap();
@@ -1151,10 +1169,11 @@ mod tests {
         ));
 
         let wasm_id = WasmId::new();
+        let serialized_module = compile_module(make_memory_canister_wasm());
         let rep = srv
-            .open_wasm(OpenWasmRequest {
+            .open_wasm_serialized(OpenWasmSerializedRequest {
                 wasm_id,
-                wasm_src: make_memory_canister_wasm(),
+                serialized_module,
             })
             .sync()
             .unwrap();
@@ -1277,10 +1296,11 @@ mod tests {
 
         // Compile the wasm code.
         let wasm_id = WasmId::new();
+        let serialized_module = compile_module(make_long_running_canister_wasm());
         let rep = srv
-            .open_wasm(OpenWasmRequest {
+            .open_wasm_serialized(OpenWasmSerializedRequest {
                 wasm_id,
-                wasm_src: make_long_running_canister_wasm(),
+                serialized_module,
             })
             .sync()
             .unwrap();
@@ -1397,10 +1417,11 @@ mod tests {
 
         // Compile the wasm code.
         let wasm_id = WasmId::new();
+        let serialized_module = compile_module(make_long_running_canister_wasm());
         let rep = srv
-            .open_wasm(OpenWasmRequest {
+            .open_wasm_serialized(OpenWasmSerializedRequest {
                 wasm_id,
-                wasm_src: make_long_running_canister_wasm(),
+                serialized_module,
             })
             .sync()
             .unwrap();

--- a/rs/canister_sandbox/src/sandbox_server.rs
+++ b/rs/canister_sandbox/src/sandbox_server.rs
@@ -32,14 +32,6 @@ impl SandboxService for SandboxServer {
         std::process::exit(0);
     }
 
-    fn open_wasm(&self, req: OpenWasmRequest) -> rpc::Call<OpenWasmReply> {
-        let result = self
-            .manager
-            .open_wasm(req.wasm_id, req.wasm_src)
-            .map(|(_cache, result, serialized_module)| (result, serialized_module));
-        rpc::Call::new_resolved(Ok(OpenWasmReply(result)))
-    }
-
     fn open_wasm_serialized(
         &self,
         req: OpenWasmSerializedRequest,
@@ -99,21 +91,6 @@ impl SandboxService for SandboxServer {
             SandboxManager::abort_execution(&self.manager, req.exec_id);
             Ok(AbortExecutionReply { success: true })
         })
-    }
-
-    fn create_execution_state(
-        &self,
-        req: CreateExecutionStateRequest,
-    ) -> rpc::Call<CreateExecutionStateReply> {
-        let result = self.manager.create_execution_state(
-            req.wasm_id,
-            req.wasm_binary,
-            req.wasm_page_map,
-            req.next_wasm_memory_id,
-            req.canister_id,
-            req.stable_memory_page_map,
-        );
-        rpc::Call::new_resolved(Ok(CreateExecutionStateReply(result)))
     }
 
     fn create_execution_state_serialized(

--- a/rs/canister_sandbox/src/sandbox_service.rs
+++ b/rs/canister_sandbox/src/sandbox_service.rs
@@ -6,10 +6,8 @@ pub trait SandboxService: Send + Sync {
     /// Terminate the sandbox.
     fn terminate(&self, req: TerminateRequest) -> Call<TerminateReply>;
 
-    /// Creates a canister Wasm code object. The wasm code itself or
-    /// the path to it is passed as the RPC payload.
-    fn open_wasm(&self, req: OpenWasmRequest) -> Call<OpenWasmReply>;
-
+    /// Creates a canister Wasm code object. The already compiled Wasm module is
+    /// passed in the request.
     fn open_wasm_serialized(&self, req: OpenWasmSerializedRequest)
         -> Call<OpenWasmSerializedReply>;
 
@@ -39,13 +37,6 @@ pub trait SandboxService: Send + Sync {
     /// Abort Wasm execution that was previously paused.
     fn abort_execution(&self, req: AbortExecutionRequest) -> Call<AbortExecutionReply>;
 
-    /// Perform initial parsing and evaluation needed to create the starting
-    /// execution state.
-    fn create_execution_state(
-        &self,
-        req: CreateExecutionStateRequest,
-    ) -> Call<CreateExecutionStateReply>;
-
     /// Perform deserialization of a serialized module needed to create the
     /// starting execution state.
     fn create_execution_state_serialized(
@@ -60,7 +51,6 @@ impl<Svc: SandboxService + Send + Sync> DemuxServer<Request, Reply> for Svc {
     fn dispatch(&self, req: Request) -> Call<Reply> {
         match req {
             Request::Terminate(req) => Call::new_wrap(self.terminate(req), Reply::Terminate),
-            Request::OpenWasm(req) => Call::new_wrap(self.open_wasm(req), Reply::OpenWasm),
             Request::OpenWasmSerialized(req) => {
                 Call::new_wrap(self.open_wasm_serialized(req), Reply::OpenWasmSerialized)
             }
@@ -76,10 +66,6 @@ impl<Svc: SandboxService + Send + Sync> DemuxServer<Request, Reply> for Svc {
             Request::AbortExecution(req) => {
                 Call::new_wrap(self.abort_execution(req), Reply::AbortExecution)
             }
-            Request::CreateExecutionState(req) => Call::new_wrap(
-                self.create_execution_state(req),
-                Reply::CreateExecutionState,
-            ),
             Request::CreateExecutionStateSerialized(req) => Call::new_wrap(
                 self.create_execution_state_serialized(req),
                 Reply::CreateExecutionStateSerialized,


### PR DESCRIPTION
Now that we have a separate compilation sandbox, we can deprecate the IPC requests for compiling in the canister sandbox.