### PR TITLE
feat: enable the hashes-in-blocks feature everywhere

### DIFF
--- a/rs/replica/setup_ic_network/src/lib.rs
+++ b/rs/replica/setup_ic_network/src/lib.rs
@@ -65,7 +65,7 @@ use tower_http::trace::TraceLayer;
 /// we will reconstruct the blocks by looking up the referenced ingress messages in the ingress
 /// pool or, if they are not there, by fetching missing ingress messages from peers who are
 /// advertising the blocks.
-const HASHES_IN_BLOCKS_FEATURE_ENABLED: bool = false;
+const HASHES_IN_BLOCKS_FEATURE_ENABLED: bool = true;
 
 pub const MAX_ADVERT_BUFFER: usize = 100_000;
 /// This limit is used to protect against a malicious peer advertising many ingress messages.


### PR DESCRIPTION
The feature has been already enabled for all subnets (for some subnets already over a month ago) except the NNS subnet and no issues have been observed.