### PR TITLE
chore(IDX): update darwin workflow

### DIFF
--- a/.github/workflows/test-namespace-darwin.yaml
+++ b/.github/workflows/test-namespace-darwin.yaml
@@ -21,6 +21,7 @@ jobs:
     name: Bazel Test macOS Apple Silicon
     timeout-minutes: 120
     runs-on: namespace-profile-darwin # profile created in namespace console
+    if: ${{ github.repository == 'dfinity/ic' }} # only run on public repo, not private
     steps:
       - name: Set up Bazel cache
         run: |

--- a/.github/workflows/test-namespace-darwin.yaml
+++ b/.github/workflows/test-namespace-darwin.yaml
@@ -21,7 +21,7 @@ jobs:
     name: Bazel Test macOS Apple Silicon
     timeout-minutes: 120
     runs-on: namespace-profile-darwin # profile created in namespace console
-    if: ${{ github.repository == 'dfinity/ic' }} # only run on public repo, not private
+    if: ${{ github.repository == 'dfinity/ic' }} # only run on public repo, not private since Namespace runners are not configured there, so these CI jobs get stuck otherwise.
     steps:
       - name: Set up Bazel cache
         run: |


### PR DESCRIPTION
Namespace runners are not configured for our private repo, so these CI jobs get stuck otherwise.