### PR TITLE
chore(IDX): remove token from tag-release workflow

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -13,13 +13,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-      - name: Create GitHub App Token
-        uses: actions/create-github-app-token@v1
-        id: app-token
-        with:
-          app-id: ${{ vars.PR_AUTOMATION_BOT_PUBLIC_APP_ID }}
-          private-key: ${{ secrets.PR_AUTOMATION_BOT_PUBLIC_PRIVATE_KEY }}
-
       - name: Checkout
         uses: actions/checkout@v4
 
@@ -84,7 +77,6 @@ jobs:
         # v0.1.15
         uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844
         with:
-          token: ${{ steps.app-token.outputs.token }}
           body: "IC ${{github.ref_name}}"
           files: |
             canisters.tar


### PR DESCRIPTION
After reviewing the code and testing this out in a separate repo, I've determined the token is not actually needed here - we already enable write permissions in this workflow.