### PR TITLE
fix(ICRC_Rosetta): Set the ICRC Rosetta version correctly in the docker tag

### DIFF
--- a/.github/workflows/rosetta-release.yml
+++ b/.github/workflows/rosetta-release.yml
@@ -86,7 +86,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          for tag in "v${ROSETTA_RELEASE_VERSION}" latest; do
+          for tag in "v${ICRC_ROSETTA_RELEASE_VERSION}" latest; do
             bazel run --stamp --embed_label="$tag" //rs/rosetta-api/icrc1:push_ic_icrc_rosetta_image
           done
           git tag "icrc-rosetta-release-$ICRC_ROSETTA_RELEASE_VERSION" "${{ github.sha }}"


### PR DESCRIPTION
The wrong variable was being read in the ICRC Rosetta release workflow, leading to a docker release with a tag "v" being [created](https://hub.docker.com/layers/dfinity/ic-icrc-rosetta-api/v/images/sha256-d6c959f579d7827c53abd5c3d4d3a32c73046f312033a4146541b8e2e5256f26?context=explore). This PR proposes reading the `ICRC_ROSETTA_RELEASE_VERSION` variable in the case of ICRC Rosetta.