### PR TITLE
fix: Update Elasticsearch URLs and index patterns for testnet environment

### DIFF
--- a/ci/scripts/rust-benchmarks.sh
+++ b/ci/scripts/rust-benchmarks.sh
@@ -25,5 +25,5 @@ while IFS= read -r bench_dir; do
     .revCount = 1' \
         >report.json
     curl --fail --retry 2 -sS -o /dev/null -X POST -H 'Content-Type: application/json' --data @report.json \
-        "https://elasticsearch.testnet.dfinity.network/ci-performance-test/_doc"
+        "https://elasticsearch.ch1-obsdev1.dfinity.network/ci-performance-test/_doc"
 done < <(find -L ./bazel-out -type d -path '*/new')

--- a/ic-os/components/monitoring/filebeat/filebeat.yml.template
+++ b/ic-os/components/monitoring/filebeat/filebeat.yml.template
@@ -60,7 +60,7 @@ output.elasticsearch:
 
   # Optional data stream or index name. The default is "filebeat-%{[agent.version]}".
   # In case you modify this pattern you must update setup.template.name and setup.template.pattern accordingly.
-  index: "ic-logs-%{+yyyy.MM.dd}"
+  index: "testnet-ic-logs-%{+yyyy-MM-dd}"
 
   # Optional ingest pipeline. By default no pipeline will be used.
   #pipeline: ""
@@ -85,13 +85,13 @@ output.console:
 
 setup:
   template:
-    name: ic-logs
-    pattern: ic-logs-%{+yyyy.MM.dd}
+    name: testnet-ic-logs
+    pattern: testnet-ic-logs-%{+yyyy-MM-dd}
     settings:
       index:
         codec: best_compression
         number_of_replicas: 1
-        number_of_shards: 6
+        number_of_shards: 3
 
 # ====================== Index Lifecycle Management (ILM) ======================
 

--- a/rs/tests/consensus/tecdsa/tecdsa_performance_test_template.rs
+++ b/rs/tests/consensus/tecdsa/tecdsa_performance_test_template.rs
@@ -356,7 +356,7 @@ pub fn tecdsa_performance_test(
         if cfg!(feature = "upload_perf_systest_results") {
             // elastic search url
             const ES_URL: &str =
-                "https://elasticsearch.testnet.dfinity.network/ci-performance-test/_doc";
+                "https://elasticsearch.ch1-obsdev1.dfinity.network/ci-performance-test/_doc";
             const NUM_UPLOAD_ATTEMPS: usize = 3;
             info!(
                 log,

--- a/rs/tests/consensus/utils/src/performance.rs
+++ b/rs/tests/consensus/utils/src/performance.rs
@@ -342,7 +342,7 @@ pub async fn persist_metrics(
 ) {
     // elastic search url
     const ES_URL: &str =
-        "https://elasticsearch.testnet.dfinity.network/ci-consensus-performance-test/_doc";
+        "https://elasticsearch.ch1-obsdev1.dfinity.network/ci-consensus-performance-test/_doc";
 
     let timestamp =
         chrono::DateTime::<chrono::Utc>::from(std::time::SystemTime::now()).to_rfc3339();

--- a/rs/tests/driver/src/driver/test_env_api.rs
+++ b/rs/tests/driver/src/driver/test_env_api.rs
@@ -1134,7 +1134,7 @@ impl<T: HasTestEnv> HasIcDependencies for T {
 pub fn get_elasticsearch_hosts() -> Result<Vec<String>> {
     let dep_rel_path = "elasticsearch_hosts";
     let hosts = read_dependency_to_string(dep_rel_path)
-        .unwrap_or_else(|_| "elasticsearch.testnet.dfinity.network:443".to_string());
+        .unwrap_or_else(|_| "elasticsearch.ch1-obsdev1.dfinity.network:443".to_string());
     parse_elasticsearch_hosts(Some(hosts))
 }
 

--- a/testnet/env/shared-config.yml
+++ b/testnet/env/shared-config.yml
@@ -68,7 +68,7 @@ nodes:
     orchestrator_metrics_listen_addr: "[{{ orchestrator_metrics_listen_ip }}]:{{ orchestrator_metrics_listen_port }}"
 
     elasticsearch_hosts:
-      - "elasticsearch.testnet.dfinity.network:443"
+      - "elasticsearch.ch1-obsdev1.dfinity.network:443"
 
 api:
   vars:
@@ -87,7 +87,7 @@ boundary:
   vars:
     api_listen_port: 443
     api_listen_protocol: https
-    elasticsearch_url: "https://elasticsearch.testnet.dfinity.network"
+    elasticsearch_url: "https://elasticsearch.ch1-obsdev1.dfinity.network"
     ipv4_http_ips: # See: https://www.cloudflare.com/ips-v4
       - "103.21.244.0/22" # Cloudflare: https://www.cloudflare.com/ips/
       - "103.22.200.0/22" # Cloudflare: https://www.cloudflare.com/ips/


### PR DESCRIPTION
This needs to be done due to the deprecation of the SF1 DC where the current elasticsearch clusters are. The new ES clusters will be brought up in a few weeks, in DM1 DC.