### PR TITLE
feat(sns): Use human readable date-time in AdvanceSnsTargetVersion proposal rendering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11793,7 +11793,6 @@ dependencies = [
  "build-info-build",
  "candid",
  "candid_parser",
- "chrono",
  "clap 4.5.20",
  "comparable",
  "futures",
@@ -11857,6 +11856,7 @@ dependencies = [
  "strum",
  "strum_macros",
  "tempfile",
+ "time",
  "tokio",
  "tokio-test",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14763,7 +14763,7 @@ dependencies = [
  "regex",
  "regex-syntax 0.6.29",
  "string_cache",
- "term 0.7.0",
+ "term",
  "tiny-keccak",
  "unicode-xid",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11793,6 +11793,7 @@ dependencies = [
  "build-info-build",
  "candid",
  "candid_parser",
+ "chrono",
  "clap 4.5.20",
  "comparable",
  "futures",

--- a/rs/sns/governance/BUILD.bazel
+++ b/rs/sns/governance/BUILD.bazel
@@ -44,6 +44,7 @@ DEPENDENCIES = [
     "@crate_index//:base64",
     "@crate_index//:build-info",
     "@crate_index//:candid",
+    "@crate_index//:chrono",
     "@crate_index//:clap",
     "@crate_index//:comparable",
     "@crate_index//:futures",

--- a/rs/sns/governance/BUILD.bazel
+++ b/rs/sns/governance/BUILD.bazel
@@ -44,7 +44,6 @@ DEPENDENCIES = [
     "@crate_index//:base64",
     "@crate_index//:build-info",
     "@crate_index//:candid",
-    "@crate_index//:chrono",
     "@crate_index//:clap",
     "@crate_index//:comparable",
     "@crate_index//:futures",
@@ -62,6 +61,7 @@ DEPENDENCIES = [
     "@crate_index//:serde",
     "@crate_index//:serde_bytes",
     "@crate_index//:strum",
+    "@crate_index//:time",
 ]
 
 MACRO_DEPENDENCIES = [

--- a/rs/sns/governance/Cargo.toml
+++ b/rs/sns/governance/Cargo.toml
@@ -30,7 +30,6 @@ build-info = { workspace = true }
 async-trait = { workspace = true }
 base64 = { workspace = true }
 candid = { workspace = true }
-chrono = { workspace = true }
 clap = { workspace = true }
 comparable = { version = "0.5", features = ["derive"] }
 hex = { workspace = true }
@@ -81,6 +80,7 @@ serde = { workspace = true }
 serde_bytes = { workspace = true }
 strum = { workspace = true }
 strum_macros = { workspace = true }
+time = { workspace = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 ic-types = { path = "../../types/types" }

--- a/rs/sns/governance/Cargo.toml
+++ b/rs/sns/governance/Cargo.toml
@@ -27,10 +27,10 @@ path = "tests/proposal.rs"
 
 [dependencies]
 build-info = { workspace = true }
-
 async-trait = { workspace = true }
 base64 = { workspace = true }
 candid = { workspace = true }
+chrono = { workspace = true }
 clap = { workspace = true }
 comparable = { version = "0.5", features = ["derive"] }
 hex = { workspace = true }

--- a/rs/sns/governance/src/proposal.rs
+++ b/rs/sns/governance/src/proposal.rs
@@ -1765,7 +1765,7 @@ fn validate_and_render_advance_sns_target_version_proposal(
          ### Upgrade steps\n\n\
          {upgrade_steps}\n\n\
          ### Monitoring the upgrade process\n\n\
-         Please note: the upgrade steps above (valid around {time_of_validity}) \
+         Please note: the upgrade steps mentioned above (valid around {time_of_validity}) \
          might change during this proposal's voting period.\n\n\
          The **upgrade journal** provides up-to-date information on this SNS's upgrade process:\n\n\
          {upgrade_journal_url_render}"

--- a/rs/sns/governance/src/proposal.rs
+++ b/rs/sns/governance/src/proposal.rs
@@ -1742,9 +1742,8 @@ fn validate_and_render_advance_sns_target_version_proposal(
         let timestamp_seconds = upgrade_steps.approximate_time_of_validity_timestamp_seconds();
         i64::try_from(timestamp_seconds)
             .ok()
-            .map(|timestamp_seconds| DateTime::from_timestamp(timestamp_seconds, 0))
-            .flatten()
-            .map(|datetime| format!("{}", datetime))
+            .and_then(|timestamp_seconds| DateTime::from_timestamp(timestamp_seconds, 0))
+            .map(|datetime| datetime.to_string())
             // This fallback should not occur unless `timestamp_seconds` is outside of the range
             // from +  1970-01-01 00:00:00 UTC (0)
             // till +262142-12-31 23:59:59 UTC (8210266876799).

--- a/rs/sns/governance/src/proposal/advance_sns_target_version.rs
+++ b/rs/sns/governance/src/proposal/advance_sns_target_version.rs
@@ -5,6 +5,7 @@ use crate::pb::v1::Governance as GovernancePb;
 use crate::types::test_helpers::NativeEnvironment;
 use futures::FutureExt;
 use ic_test_utilities_types::ids::canister_test_id;
+use pretty_assertions::assert_eq;
 
 fn sns_version_for_tests() -> Version {
     Version {

--- a/rs/sns/governance/src/proposal/advance_sns_target_version.rs
+++ b/rs/sns/governance/src/proposal/advance_sns_target_version.rs
@@ -176,7 +176,7 @@ fn test_validate_and_render_advance_target_version_action() {
 
 ### Monitoring the upgrade process
 
-Please note: the upgrade steps above (valid around timestamp 0 seconds) might change during this proposal's voting period. Such changes are unlikely and are subject to NNS community's approval.
+Please note: the upgrade steps above (valid around 1970-01-01 00:00:00 UTC) might change during this proposal's voting period.
 
 The **upgrade journal** provides up-to-date information on this SNS's upgrade process:
 

--- a/rs/sns/governance/src/proposal/advance_sns_target_version.rs
+++ b/rs/sns/governance/src/proposal/advance_sns_target_version.rs
@@ -176,7 +176,7 @@ fn test_validate_and_render_advance_target_version_action() {
 
 ### Monitoring the upgrade process
 
-Please note: the upgrade steps above (valid around 1970-01-01 00:00:00 UTC) might change during this proposal's voting period.
+Please note: the upgrade steps mentioned above (valid around 1970-01-01 00:00:00 UTC) might change during this proposal's voting period.
 
 The **upgrade journal** provides up-to-date information on this SNS's upgrade process:
 

--- a/rs/sns/governance/src/proposal/advance_sns_target_version.rs
+++ b/rs/sns/governance/src/proposal/advance_sns_target_version.rs
@@ -67,6 +67,28 @@ fn standard_governance_proto_for_tests(deployed_version: Option<Version>) -> Gov
 }
 
 #[test]
+fn test_format_timestamp() {
+    for (expected, timestamp_seconds) in [
+        (Some("1970-01-01 00:00:00 UTC"), 0),
+        (Some("2024-11-29 16:14:10 UTC"), 1732896850),
+        (Some("2038-01-19 03:14:07 UTC"), i32::MAX as u64),
+        (Some("4571-09-24 08:52:47 UTC"), 82102668767),
+        (Some("9999-12-31 23:59:59 UTC"), 253402300799),
+        (None, 253402300800),
+        (None, i64::MAX as u64),
+        (None, u64::MAX),
+    ] {
+        let observed = format_timestamp(timestamp_seconds);
+        assert_eq!(
+            observed,
+            expected.map(|s| s.to_string()),
+            "unexpected result from format_timestamp({})",
+            timestamp_seconds,
+        );
+    }
+}
+
+#[test]
 fn test_validate_and_render_advance_target_version_action() {
     // Prepare the world.
     let pre_deployed_version = sns_version_for_tests();


### PR DESCRIPTION
This PR improves the rendering of AdvanceSnsTargetVersion proposals by using a human-readable date-time format rather than raw Unix timestamps. Also, a potentially confusing remark is dropped from the disclaimer. 