### PR TITLE
feat(sns): Enable AdvanceSnsTargetVersion proposals in mainnet

### DIFF
--- a/rs/sns/governance/src/governance.rs
+++ b/rs/sns/governance/src/governance.rs
@@ -3034,9 +3034,6 @@ impl Governance {
         &mut self,
         new_target: Version,
     ) -> Result<(), GovernanceError> {
-        // TODO[NNS1-3365]: Enable the AdvanceSnsTargetVersionFeature.
-        self.check_test_features_enabled();
-
         let (_, target_version) = self
             .proto
             .validate_new_target_version(Some(new_target))


### PR DESCRIPTION
This PR removes the restriction for the new AdvanceSnsTargetVersion proposals to be only allowed in testing, thereby activating the new feature on mainnet.