### PR TITLE
test(IDX): lower parallelism and reserve more CPUs for the //rs/rosetta-api/icp:icp_rosetta_system_tests_tests

### DIFF
--- a/rs/rosetta-api/icp/BUILD.bazel
+++ b/rs/rosetta-api/icp/BUILD.bazel
@@ -179,6 +179,7 @@ rust_test_suite_with_extra_srcs(
         "@mainnet_icp_ledger_canister//file",
     ],
     env = {
+        "RUST_TEST_THREADS": "4",
         "CANISTER_LAUNCHER": "$(rootpath //rs/canister_sandbox)",
         "LEDGER_CANISTER_NOTIFY_METHOD_WASM_PATH": "$(rootpath //rs/ledger_suite/icp/ledger:ledger-canister-wasm-notify-method)",
         "POCKET_IC_BIN": "$(rootpath //rs/pocket_ic_server:pocket-ic-server)",
@@ -197,6 +198,7 @@ rust_test_suite_with_extra_srcs(
     ]),
     flaky = True,
     proc_macro_deps = MACRO_DEV_DEPENDENCIES,
+    tags = ["cpu:4"],
     deps = DEV_DEPENDENCIES + DEPENDENCIES,
 )
 


### PR DESCRIPTION
On 2024-11-15 the `//rs/rosetta-api/icp:icp_rosetta_system_tests_tests` was marked as flaky in  https://github.com/dfinity/ic/pull/2615 and then became our most flaky test.

See: https://superset.idx.dfinity.network/explore/?slice_id=83

This is an experiment to see if lowering parallelism and increasing its CPU reservation lowers the flakiness of this test.