### PR TITLE
test: CON-1440 Assert that a subnet state exists on the node before it is deleted

### DIFF
--- a/rs/tests/consensus/orchestrator/node_reassignment_test.rs
+++ b/rs/tests/consensus/orchestrator/node_reassignment_test.rs
@@ -26,7 +26,7 @@ Coverage::
 end::catalog[] */
 
 use anyhow::Result;
-use ic_consensus_system_test_utils::node::assert_node_is_unassigned;
+use ic_consensus_system_test_utils::node::{assert_node_is_assigned, assert_node_is_unassigned};
 use ic_consensus_system_test_utils::rw_message::{
     can_read_msg, can_read_msg_with_retries, install_nns_and_check_progress, store_message,
 };
@@ -130,6 +130,9 @@ fn test(env: TestEnv) {
     // Unassign 2 NNS nodes using remove_nodes_from_subnet operation
     node3.await_status_is_healthy().unwrap();
     node4.await_status_is_healthy().unwrap();
+    // Assert nodes are assigned before they are removed
+    assert_node_is_assigned(&node1, log);
+    assert_node_is_assigned(&node2, log);
     let node_ids: Vec<_> = vec![node1.node_id, node2.node_id];
     block_on(remove_nodes_via_endpoint(node3.get_public_url(), &node_ids)).unwrap();
     info!(log, "Removed node ids {:?} from the NNS subnet", node_ids);
@@ -237,6 +240,9 @@ fn test(env: TestEnv) {
     // APP: [node3, node4, <original-app-subnet-nodes>]
     node1.await_status_is_healthy().unwrap();
     node2.await_status_is_healthy().unwrap();
+    // Assert nodes are assigned before the are removed
+    assert_node_is_assigned(&node1, log);
+    assert_node_is_assigned(&node2, log);
     let nns_subnet_id = topo_snapshot.root_subnet().subnet_id;
     let app_subnet_id = app_subnet.subnet_id;
     let node_ids_remove: Vec<_> = vec![node1.node_id, node2.node_id];
@@ -259,6 +265,10 @@ fn test(env: TestEnv) {
     node2.await_status_is_unavailable().unwrap();
     assert_node_is_unassigned(&node1, log);
     assert_node_is_unassigned(&node2, log);
+
+    // Assert nodes are assigned before the are removed
+    assert_node_is_assigned(&node3, log);
+    assert_node_is_assigned(&node4, log);
 
     // Next, add node1 and node2 to the NNS subnet, and remove node3 and node4 at the same time
     let node_ids_add: Vec<_> = vec![node1.node_id, node2.node_id];

--- a/rs/tests/consensus/utils/src/node.rs
+++ b/rs/tests/consensus/utils/src/node.rs
@@ -54,16 +54,59 @@ pub fn get_node_certified_height(node: &IcNodeSnapshot, log: Logger) -> Height {
     .expect("Should be able to retrieve the certified height")
 }
 
+/// Assert that the given node has a state and local CUP within the next 5 minutes.
+pub fn assert_node_is_assigned(node: &IcNodeSnapshot, logger: &Logger) {
+    info!(
+        logger,
+        "Asserting that node {} has a state and local CUP.",
+        node.get_ip_addr()
+    );
+    // We consider the node to be assigned if it has both a subnet state
+    // and a local CUP
+    // We need to exclude the page_deltas/ directory, which is not deleted on state deletion.
+    // That is because deleting it would break SELinux assumptions.
+    let check = r#"
+        [ "$(ls -A /var/lib/ic/data/ic_state -I page_deltas)" ] && \
+        [ -f /var/lib/ic/data/cups/cup.types.v1.CatchUpPackage.pb ] && \
+        echo "assigned" || echo "unassigned"
+    "#;
+    let s = node
+        .block_on_ssh_session()
+        .expect("Failed to establish SSH session");
+
+    ic_system_test_driver::retry_with_msg!(
+        format!("check if node {} is assigned", node.node_id),
+        logger.clone(),
+        secs(300),
+        secs(10),
+        || match execute_bash_command(&s, check.to_string()) {
+            Ok(s) if s.trim() == "assigned" => Ok(()),
+            Ok(s) if s.trim() == "unassigned" => {
+                bail!("Node {} is unassigned.", node.get_ip_addr())
+            }
+            Ok(s) => bail!("Received unexpected output: {}", s),
+            Err(e) => bail!("Failed to read directory: {}", e),
+        }
+    )
+    .expect("Failed to detect that node has a state and local CUP.");
+}
+
 /// Assert that the given node has deleted its state within the next 5 minutes.
 pub fn assert_node_is_unassigned(node: &IcNodeSnapshot, logger: &Logger) {
     info!(
         logger,
-        "Asserting that node {} has deleted its state.",
+        "Asserting that node {} has deleted its state and local CUP.",
         node.get_ip_addr()
     );
+    // We consider the node to be unassigned once it deleted both the state directory and the
+    // local CUP.
     // We need to exclude the page_deltas/ directory, which is not deleted on state deletion.
     // That is because deleting it would break SELinux assumptions.
-    let check = r#"[ "$(ls -A /var/lib/ic/data/ic_state -I page_deltas)" ] && echo "assigned" || echo "unassigned""#;
+    let check = r#"
+        ([ "$(ls -A /var/lib/ic/data/ic_state -I page_deltas)" ] || \
+        [ -f /var/lib/ic/data/cups/cup.types.v1.CatchUpPackage.pb ]) && \
+        echo "assigned" || echo "unassigned"
+    "#;
     let s = node
         .block_on_ssh_session()
         .expect("Failed to establish SSH session");
@@ -82,7 +125,7 @@ pub fn assert_node_is_unassigned(node: &IcNodeSnapshot, logger: &Logger) {
             Err(e) => bail!("Failed to read directory: {}", e),
         }
     )
-    .expect("Failed to detect that node has deleted its state.");
+    .expect("Failed to detect that node has deleted its state and local CUP.");
 
     let state_removal_failed = "orchestrator_state_removal_failed_total".to_string();
     let fs_trim_duration = "orchestrator_fstrim_duration_milliseconds".to_string();


### PR DESCRIPTION
In the `node_reassignment_test` we want to verify that a node's state is correctly delete during unassignment. In https://github.com/dfinity/ic/pull/2720 we therefore added an assertion checking that the state of unassigned nodes is empty. Technically, this check would also succeed if the state never existed in the first place.

For that reason, this PR adds an assertion to make sure that the state exists before unassignment, and no longer exists afterwards. Additionally, we extend the assertion to not only check the node state, but also the orchestrator's local CUP file.