### PR TITLE
chore: remove redundant words in comment

### DIFF
--- a/rs/execution_environment/src/canister_manager.rs
+++ b/rs/execution_environment/src/canister_manager.rs
@@ -1365,7 +1365,7 @@ impl CanisterManager {
 
     /// Validates specified ID is available for use.
     ///
-    /// It must be used in in the context of provisional create canister flow when a specified ID is provided.
+    /// It must be used in the context of provisional create canister flow when a specified ID is provided.
     ///
     /// Returns `Err` iff the `specified_id` is not valid.
     fn validate_specified_id(

--- a/rs/recovery/src/steps.rs
+++ b/rs/recovery/src/steps.rs
@@ -205,7 +205,7 @@ impl Step for MergeCertificationPoolsStep {
             .map(|range| range.min.get())
             .min();
 
-        // Find the min and max height of certification shares higher than than the highest full certification
+        // Find the min and max height of certification shares higher than the highest full certification
         let (min, max) = match (max_full_cert, max_cert_share) {
             (None, None) => {
                 return Err(RecoveryError::UnexpectedError(

--- a/rs/state_manager/src/lib.rs
+++ b/rs/state_manager/src/lib.rs
@@ -767,7 +767,7 @@ struct SharedState {
     snapshots: VecDeque<Snapshot>,
     /// The last checkpoint that was advertised.
     last_advertised: Height,
-    /// The state we are are trying to fetch.
+    /// The state we are trying to fetch.
     fetch_state: Option<(Height, CryptoHashOfState, Height)>,
     /// State representing the on disk mutable state
     tip: Option<(Height, ReplicatedState)>,


### PR DESCRIPTION
remove redundant words in comment