### PR TITLE
fix(nervous-system): Ensure clamp_string works on arbitrary unicode inputs

### DIFF
--- a/rs/nervous_system/string/src/lib.rs
+++ b/rs/nervous_system/string/src/lib.rs
@@ -1,25 +1,40 @@
 use std::fmt::Debug;
 
-/// Returns a possibly modified version of s that fits within the specified bounds.
+/// Returns a possibly modified version of `s` that fits within the specified bounds (in terms of
+/// the number of UTF-8 characters).
 ///
-/// More precisely, middle characters are removed such that the return value is at most max_len.
+/// More precisely, middle characters are removed such that the return value has at most `max_len`
+/// characters. Some examples:
+/// ```
+/// println!("{}", clamp_string_len("abcdef", 5));  // a...f
+/// println!("{}", clamp_string_len("abcde", 5));   // abcde
+/// println!("{}", clamp_string_len("abcd", 5));    // abcd
+/// ```
 ///
 /// This is analogous clamp method on numeric types in that this makes the value bounded.
 pub fn clamp_string_len(s: &str, max_len: usize) -> String {
-    if s.len() <= max_len {
+    // Collect into a vector so that we can safely index the input.
+    let chars: Vec<_> = s.chars().collect();
+    if max_len <= 3 {
+        return chars.into_iter().take(max_len).collect();
+    }
+
+    if chars.len() <= max_len {
         return s.to_string();
     }
 
-    if max_len <= 3 {
-        return s[0..max_len].to_string();
-    }
-
-    let content_len = max_len - 3;
+    let ellipsis = "...";
+    let content_len = max_len - ellipsis.len();
     let tail_len = content_len / 2;
     let head_len = content_len - tail_len;
+    let tail_begin = chars.len() - tail_len;
 
-    let tail_begin = s.len() - tail_len;
-    format!("{}...{}", &s[0..head_len], &s[tail_begin..s.len()])
+    format!(
+        "{}{}{}",
+        chars[..head_len].iter().collect::<String>(),
+        ellipsis,
+        chars[tail_begin..].iter().collect::<String>(),
+    )
 }
 
 pub fn clamp_debug_len(object: &impl Debug, max_len: usize) -> String {

--- a/rs/nervous_system/string/src/tests.rs
+++ b/rs/nervous_system/string/src/tests.rs
@@ -12,9 +12,41 @@ fn test_clamp_string_len() {
     assert_eq!(&clamp_string_len("123456789", 7), "12...89");
     assert_eq!(&clamp_string_len("123456789", 8), "123...89");
     assert_eq!(&clamp_string_len("123456789", 9), "123456789");
-
     assert_eq!(&clamp_string_len("123456789", 10), "123456789");
     assert_eq!(&clamp_string_len("123456789", 11), "123456789");
+}
+
+#[test]
+fn test_clamp_string_corner_cases() {
+    for (s, max_len, expected) in [
+        ("abcdef", usize::MAX, "abcdef"),
+        ("abcdef", 10, "abcdef"),
+        ("abcdef", 5, "a...f"),
+        ("abcde", 5, "abcde"),
+        ("abcd", 5, "abcd"),
+        ("abcde", 4, "a..."),
+        ("abcd", 4, "abcd"),
+        ("abcd", 3, "abc"),
+        ("abcd", 2, "ab"),
+        ("abcd", 1, "a"),
+        ("abcd", 0, ""),
+        ("", 5, ""),
+        ("", 0, ""),
+        ("\u{200D}\u{200D}\u{200D}", 2, "\u{200d}\u{200d}"),
+        ("🙂🗜🌟🚀", 4, "🙂🗜🌟🚀"),
+        ("🙂🗜🌟🚀", 3, "🙂🗜🌟"),
+        ("🙂🗜🌟🚀", 2, "🙂🗜"),
+        ("🙂🗜🌟🚀", 1, "🙂"),
+        ("你好, 世界", 5, "你...界"),
+    ] {
+        assert_eq!(
+            clamp_string_len(s, max_len),
+            expected.to_string(),
+            "clamp_string_len({}, {}) returned an unexpected value.",
+            s,
+            max_len,
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
This PR fixes a potential panic in `clamp_string` that could occur due to string indices not being mapped 1:1 to Rust `char`s.