### PR TITLE
fix(IDX): use correct Range header when fetching logs from gatewayd from UVMs

### DIFF
--- a/rs/tests/driver/src/driver/group.rs
+++ b/rs/tests/driver/src/driver/group.rs
@@ -1117,7 +1117,7 @@ async fn stream_journald_from_cursor(
     unwrap_or_return!(
         cursor,
         stream
-            .write_all(format!("Range: entries={cursor}:0:\n\r\n\r").as_bytes())
+            .write_all(format!("Range: entries={cursor}\n\r\n\r").as_bytes())
             .await
     );
     let buf_reader = BufReader::new(stream);


### PR DESCRIPTION
https://github.com/dfinity/ic/pull/2855 changed the format of [systemd-journal-gatewayd's Range header](https://www.freedesktop.org/software/systemd/man/latest/systemd-journal-gatewayd.service.html#Range%20header) which broke fetching logs of UniversalVMs in system-tests. This PR fixes that.