### PR TITLE
feat(nns): Add new ProposalRewardStatus to handle async vote processing

### DIFF
--- a/rs/nns/governance/api/src/ic_nns_governance.pb.v1.rs
+++ b/rs/nns/governance/api/src/ic_nns_governance.pb.v1.rs
@@ -4727,6 +4727,8 @@ pub enum ProposalRewardStatus {
     Settled = 3,
     /// The proposal is not eligible to be taken into account in a reward event.
     Ineligible = 4,
+    /// The proposal is not accepting votes, but some voting is still being processed
+    VotesProcessing = 5,
 }
 impl ProposalRewardStatus {
     /// String value of the enum field names used in the ProtoBuf definition.
@@ -4735,21 +4737,23 @@ impl ProposalRewardStatus {
     /// (if the ProtoBuf definition does not change) and safe for programmatic use.
     pub fn as_str_name(&self) -> &'static str {
         match self {
-            ProposalRewardStatus::Unspecified => "PROPOSAL_REWARD_STATUS_UNSPECIFIED",
-            ProposalRewardStatus::AcceptVotes => "PROPOSAL_REWARD_STATUS_ACCEPT_VOTES",
-            ProposalRewardStatus::ReadyToSettle => "PROPOSAL_REWARD_STATUS_READY_TO_SETTLE",
-            ProposalRewardStatus::Settled => "PROPOSAL_REWARD_STATUS_SETTLED",
-            ProposalRewardStatus::Ineligible => "PROPOSAL_REWARD_STATUS_INELIGIBLE",
+            Self::Unspecified => "PROPOSAL_REWARD_STATUS_UNSPECIFIED",
+            Self::AcceptVotes => "PROPOSAL_REWARD_STATUS_ACCEPT_VOTES",
+            Self::ReadyToSettle => "PROPOSAL_REWARD_STATUS_READY_TO_SETTLE",
+            Self::Settled => "PROPOSAL_REWARD_STATUS_SETTLED",
+            Self::Ineligible => "PROPOSAL_REWARD_STATUS_INELIGIBLE",
+            Self::VotesProcessing => "PROPOSAL_REWARD_STATUS_VOTES_PROCESSING",
         }
     }
     /// Creates an enum from field names used in the ProtoBuf definition.
-    pub fn from_str_name(value: &str) -> Option<Self> {
+    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
         match value {
             "PROPOSAL_REWARD_STATUS_UNSPECIFIED" => Some(Self::Unspecified),
             "PROPOSAL_REWARD_STATUS_ACCEPT_VOTES" => Some(Self::AcceptVotes),
             "PROPOSAL_REWARD_STATUS_READY_TO_SETTLE" => Some(Self::ReadyToSettle),
             "PROPOSAL_REWARD_STATUS_SETTLED" => Some(Self::Settled),
             "PROPOSAL_REWARD_STATUS_INELIGIBLE" => Some(Self::Ineligible),
+            "PROPOSAL_REWARD_STATUS_VOTES_PROCESSING" => Some(Self::VotesProcessing),
             _ => None,
         }
     }

--- a/rs/nns/governance/proto/ic_nns_governance/pb/v1/governance.proto
+++ b/rs/nns/governance/proto/ic_nns_governance/pb/v1/governance.proto
@@ -1418,6 +1418,9 @@ enum ProposalRewardStatus {
 
   // The proposal is not eligible to be taken into account in a reward event.
   PROPOSAL_REWARD_STATUS_INELIGIBLE = 4;
+
+  // The proposal is not accepting votes, but some voting is still being processed
+  PROPOSAL_REWARD_STATUS_VOTES_PROCESSING = 5;
 }
 
 // A tally of votes.

--- a/rs/nns/governance/src/gen/ic_nns_governance.pb.v1.rs
+++ b/rs/nns/governance/src/gen/ic_nns_governance.pb.v1.rs
@@ -5563,6 +5563,8 @@ pub enum ProposalRewardStatus {
     Settled = 3,
     /// The proposal is not eligible to be taken into account in a reward event.
     Ineligible = 4,
+    /// The proposal is not accepting votes, but some voting is still being processed
+    VotesProcessing = 5,
 }
 impl ProposalRewardStatus {
     /// String value of the enum field names used in the ProtoBuf definition.
@@ -5576,6 +5578,7 @@ impl ProposalRewardStatus {
             Self::ReadyToSettle => "PROPOSAL_REWARD_STATUS_READY_TO_SETTLE",
             Self::Settled => "PROPOSAL_REWARD_STATUS_SETTLED",
             Self::Ineligible => "PROPOSAL_REWARD_STATUS_INELIGIBLE",
+            Self::VotesProcessing => "PROPOSAL_REWARD_STATUS_VOTES_PROCESSING",
         }
     }
     /// Creates an enum from field names used in the ProtoBuf definition.
@@ -5586,6 +5589,7 @@ impl ProposalRewardStatus {
             "PROPOSAL_REWARD_STATUS_READY_TO_SETTLE" => Some(Self::ReadyToSettle),
             "PROPOSAL_REWARD_STATUS_SETTLED" => Some(Self::Settled),
             "PROPOSAL_REWARD_STATUS_INELIGIBLE" => Some(Self::Ineligible),
+            "PROPOSAL_REWARD_STATUS_VOTES_PROCESSING" => Some(Self::VotesProcessing),
             _ => None,
         }
     }

--- a/rs/nns/governance/src/pb/conversions.rs
+++ b/rs/nns/governance/src/pb/conversions.rs
@@ -4794,6 +4794,9 @@ impl From<pb::ProposalRewardStatus> for pb_api::ProposalRewardStatus {
             pb::ProposalRewardStatus::ReadyToSettle => pb_api::ProposalRewardStatus::ReadyToSettle,
             pb::ProposalRewardStatus::Settled => pb_api::ProposalRewardStatus::Settled,
             pb::ProposalRewardStatus::Ineligible => pb_api::ProposalRewardStatus::Ineligible,
+            pb::ProposalRewardStatus::VotesProcessing => {
+                pb_api::ProposalRewardStatus::VotesProcessing
+            }
         }
     }
 }
@@ -4805,6 +4808,9 @@ impl From<pb_api::ProposalRewardStatus> for pb::ProposalRewardStatus {
             pb_api::ProposalRewardStatus::ReadyToSettle => pb::ProposalRewardStatus::ReadyToSettle,
             pb_api::ProposalRewardStatus::Settled => pb::ProposalRewardStatus::Settled,
             pb_api::ProposalRewardStatus::Ineligible => pb::ProposalRewardStatus::Ineligible,
+            pb_api::ProposalRewardStatus::VotesProcessing => {
+                pb::ProposalRewardStatus::VotesProcessing
+            }
         }
     }
 }


### PR DESCRIPTION
This adds a new status that will be used with async rewards processing (i.e. being able to have following happen after the voting deadline in a message, while still not being able to register new votes).