### PR TITLE
fix: [NODE-1519] Fixup colliding permission services

### DIFF
--- a/ic-os/components/upgrade/shared-resources/upgrade-shared-data-store/upgrade-shared-data-store.service
+++ b/ic-os/components/upgrade/shared-resources/upgrade-shared-data-store/upgrade-shared-data-store.service
@@ -3,6 +3,7 @@ Description=Initialize node data storage
 DefaultDependencies=no
 Requires=var-lib-ic-data.mount
 After=var-lib-ic-data.mount
+Before=setup-permissions.service
 
 [Install]
 WantedBy=local-fs.target

--- a/ic-os/components/upgrade/shared-resources/upgrade-shared-data-store/upgrade-shared-data-store.sh
+++ b/ic-os/components/upgrade/shared-resources/upgrade-shared-data-store/upgrade-shared-data-store.sh
@@ -8,6 +8,6 @@ set -e
 
 # Fix up ownership -- should be owned by the ic replica service user.
 USER=$(stat -c %U /var/lib/ic/data)
-if [ "${USER}" != replica ]; then
+if [ "${USER}" != ic-replica ]; then
     chown -R ic-replica /var/lib/ic/data
 fi


### PR DESCRIPTION
A bad check in `upgrade-shared-data-store.sh` was causing a `chown -R` to run across all of `/var/lib/ic/data`. This would then also create additional work for `setup-permissions.sh`.

With this fix, the broad `upgrade-shared-data-store.sh` should only run rarely. Though `setup-permissions.sh` will still scan parts of `/var/lib/ic/data`, it will need to change less permissions which should hopefully be an improvement as well.