### PR TITLE
fix(IDX): Add default directory for lint script

### DIFF
--- a/ci/scripts/rust-lint.sh
+++ b/ci/scripts/rust-lint.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -xeuo pipefail
 
-cd "$CI_PROJECT_DIR"
+cd "${CI_PROJECT_DIR:-$(git rev-parse --show-toplevel)}"
 cargo fmt -- --check
 cargo clippy --locked --all-features --workspace --all-targets -- \
     -D warnings \


### PR DESCRIPTION
This defaults the working directory of the lint script to the root of the git repo, in case `CI_PROJECT_DIR` is not set.

Before this, the variable `CI_PROJECT_DIR` would be read, which is only set on CI. By adding a default, the script can be run locally.