### PR TITLE
feat(IDX): Force static link of lmdb

### DIFF
--- a/Cargo.Bazel.Fuzzing.json.lock
+++ b/Cargo.Bazel.Fuzzing.json.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "1771e8a5f1fdb0c8cf153411c37a9a8aab8ff03252dbb22817a79363ad197c9b",
+  "checksum": "7bcec2471ca519d384af77a30627d62d307fdd8866c9a3e46e62820c75795be5",
   "crates": {
     "abnf 0.12.0": {
       "name": "abnf",
@@ -40066,7 +40066,13 @@
           "commitish": {
             "Rev": "4d952c8f1dca79de855af892b444d7112567b58d"
           },
-          "strip_prefix": "lmdb-sys"
+          "strip_prefix": "lmdb-sys",
+          "patch_args": [
+            "-p1"
+          ],
+          "patches": [
+            "@@//bazel:lmdb_rkv_sys.patch"
+          ]
         }
       },
       "targets": [
@@ -40119,12 +40125,6 @@
           ],
           "selects": {}
         },
-        "extra_deps": {
-          "common": [
-            "@lmdb//:lmdb"
-          ],
-          "selects": {}
-        },
         "edition": "2015",
         "version": "0.11.99"
       },
@@ -40134,6 +40134,7 @@
         ],
         "data": {
           "common": [
+            "@lmdb//:liblmdb",
             "@lmdb//:lmdb.h"
           ],
           "selects": {}
@@ -40157,7 +40158,7 @@
         "build_script_env": {
           "common": {
             "LMDB_H_PATH": "$(location @lmdb//:lmdb.h)",
-            "LMDB_NO_BUILD": "1"
+            "LMDB_OVERRIDE": "$(location @lmdb//:liblmdb)"
           },
           "selects": {}
         }

--- a/Cargo.Bazel.json.lock
+++ b/Cargo.Bazel.json.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "8a0463c997697666d544fe6b2e5aae9ebf90ceb2daaaaca94f6e0664819e9af0",
+  "checksum": "4096d5d405db9ca6279818b7093039a7c9ee0571354bc184745a2a6c9e085447",
   "crates": {
     "abnf 0.12.0": {
       "name": "abnf",
@@ -39903,7 +39903,13 @@
           "commitish": {
             "Rev": "4d952c8f1dca79de855af892b444d7112567b58d"
           },
-          "strip_prefix": "lmdb-sys"
+          "strip_prefix": "lmdb-sys",
+          "patch_args": [
+            "-p1"
+          ],
+          "patches": [
+            "@@//bazel:lmdb_rkv_sys.patch"
+          ]
         }
       },
       "targets": [
@@ -39956,12 +39962,6 @@
           ],
           "selects": {}
         },
-        "extra_deps": {
-          "common": [
-            "@lmdb//:lmdb"
-          ],
-          "selects": {}
-        },
         "edition": "2015",
         "version": "0.11.99"
       },
@@ -39971,6 +39971,7 @@
         ],
         "data": {
           "common": [
+            "@lmdb//:liblmdb",
             "@lmdb//:lmdb.h"
           ],
           "selects": {}
@@ -39994,7 +39995,7 @@
         "build_script_env": {
           "common": {
             "LMDB_H_PATH": "$(location @lmdb//:lmdb.h)",
-            "LMDB_NO_BUILD": "1"
+            "LMDB_OVERRIDE": "$(location @lmdb//:liblmdb)"
           },
           "selects": {}
         }

--- a/bazel/external_crates.bzl
+++ b/bazel/external_crates.bzl
@@ -52,15 +52,18 @@ def external_crates_repository(name, cargo_lockfile, lockfile, sanitizers_enable
             ],
         )],
         "lmdb-rkv-sys": [crate.annotation(
+            # patch our fork of the lmdb-rkv-sys to allow specifying the path
+            # to the built static archive
+            patch_args = ["-p1"],
+            patches = ["@@//bazel:lmdb_rkv_sys.patch"],
             build_script_data = [
+                "@lmdb//:liblmdb",
                 "@lmdb//:lmdb.h",
             ],
             build_script_env = {
-                "LMDB_NO_BUILD": "1",
+                "LMDB_OVERRIDE": "$(location @lmdb//:liblmdb)",
                 "LMDB_H_PATH": "$(location @lmdb//:lmdb.h)",
             },
-            # ensure LMDB lib is available at runtime
-            deps = ["@lmdb"],
         )],
         "p256": [crate.annotation(
             rustc_flags = [

--- a/bazel/lmdb_rkv_sys.patch
+++ b/bazel/lmdb_rkv_sys.patch
@@ -1,0 +1,29 @@
+# patch our fork of the lmdb-rkv-sys to allow specifying the path
+# to the built static archive
+diff --git a/build.rs b/build.rs
+index c422d52..b779ee0 100644
+--- a/build.rs
++++ b/build.rs
+@@ -57,7 +57,21 @@ fn main() {
+         warn!("Building with `-fsanitize=fuzzer`.");
+     }
+
+-    if let Err(_) = std::env::var("LMDB_NO_BUILD") {
++    if let Ok(lmdb) = std::env::var("LMDB_OVERRIDE") {
++        let lmdb = PathBuf::from(lmdb);
++        assert!(
++            lmdb.exists(),
++            "Path to `lmdb` '{}' does not exist",
++            lmdb.display()
++        );
++        println!(
++            "cargo:rustc-link-search=native={}",
++            lmdb.parent().unwrap().display()
++        );
++        let stem = lmdb.file_stem().unwrap().to_str().unwrap();
++        println!("cargo:rustc-link-lib=static={}", &stem[3..]);
++        return;
++    } else {
+         if pkg_config::probe_library("lmdb").is_err() {
+             let mut lmdb = PathBuf::from(&env::var("CARGO_MANIFEST_DIR").unwrap());
+             lmdb.push("lmdb");

--- a/third_party/lmdb/BUILD.lmdb.bazel
+++ b/third_party/lmdb/BUILD.lmdb.bazel
@@ -2,6 +2,25 @@ package(default_visibility = ["//visibility:public"])
 
 exports_files(["lmdb.h"])
 
+# A copy of just the static archive, which can be used with `$(location ...)` in
+# builds that need it.
+genrule(
+    name = "liblmdb",
+    srcs = [":lmdb"],
+    outs = ["single/liblmdb.a"],
+
+    # Just iterate over the outputs of `cc_library` until we find the lib we want
+    cmd = """
+    for src in $(SRCS); do
+        if [[ $$src =~ liblmdb.a$$ ]]; then
+            cp "$$src" "$@"
+            break
+        fi
+    done
+    """,
+    visibility = ["//visibility:public"],
+)
+
 cc_library(
     name = "lmdb",
     srcs = [
@@ -10,4 +29,5 @@ cc_library(
         "midl.h",
     ],
     hdrs = ["lmdb.h"],
+    linkstatic = True,
 )


### PR DESCRIPTION
This ensures that lmdb is linked in statically in the Bazel build, and that the specified archive is used.

Before this, lmdb was linked statically somewhat by chance, and only at the end of the build. Now lmdb is linked in when the `lmdb-rkv-sys` crate is built and doesn't need to be linked when final executables are built.