### PR TITLE
fix(crypto): Fix the management canister interface for Schnorr aux inputs

### DIFF
--- a/rs/execution_environment/src/execution_environment.rs
+++ b/rs/execution_environment/src/execution_environment.rs
@@ -41,7 +41,7 @@ use ic_management_canister_types::{
     LoadCanisterSnapshotArgs, MasterPublicKeyId, Method as Ic00Method, NodeMetricsHistoryArgs,
     Payload as Ic00Payload, ProvisionalCreateCanisterWithCyclesArgs, ProvisionalTopUpCanisterArgs,
     SchnorrPublicKeyArgs, SchnorrPublicKeyResponse, SetupInitialDKGArgs, SignWithECDSAArgs,
-    SignWithSchnorrArgs, StoredChunksArgs, SubnetInfoArgs, SubnetInfoResponse,
+    SignWithSchnorrArgs, SignWithSchnorrAux, StoredChunksArgs, SubnetInfoArgs, SubnetInfoResponse,
     TakeCanisterSnapshotArgs, UninstallCodeArgs, UpdateSettingsArgs, UploadChunkArgs,
     VetKdPublicKeyArgs, VetKdPublicKeyResult, IC_00,
 };
@@ -1212,9 +1212,11 @@ impl ExecutionEnvironment {
                                     ThresholdArguments::Schnorr(SchnorrArguments {
                                         key_id: args.key_id,
                                         message: Arc::new(args.message),
-                                        taproot_tree_root: args
-                                            .taproot_tree_root
-                                            .map(|v| Arc::new(v.into_vec())),
+                                        taproot_tree_root: args.aux.map(|v| {
+                                            match v {
+                                                SignWithSchnorrAux::Bip341(v) => Arc::new(v.merkle_root_hash.into_vec()),
+                                            }
+                                        }),
                                     }),
                                     args.derivation_path.into_inner(),
                                     registry_settings

--- a/rs/tests/consensus/tecdsa/utils/src/lib.rs
+++ b/rs/tests/consensus/tecdsa/utils/src/lib.rs
@@ -577,7 +577,7 @@ pub async fn get_schnorr_signature_with_logger(
         message,
         derivation_path: DerivationPath::new(Vec::new()),
         key_id: key_id.clone(),
-        taproot_tree_root: None,
+        aux: None,
     };
     info!(
         logger,
@@ -871,7 +871,7 @@ impl ChainSignatureRequest {
             message: vec![1; message_size],
             derivation_path: DerivationPath::new(Vec::new()),
             key_id: schnorr_key_id,
-            taproot_tree_root: None,
+            aux: None,
         };
         ForwardParams {
             receiver: Principal::management_canister(),

--- a/rs/types/management_canister_types/src/lib.rs
+++ b/rs/types/management_canister_types/src/lib.rs
@@ -2711,12 +2711,38 @@ impl ReshareChainKeyResponse {
     }
 }
 
+/// Represents the BIP341 aux argument of the sign_with_schnorr API.
+/// ```text
+/// (record {
+///   merkle_root_hash: blob;
+/// })
+/// ```
+#[derive(Eq, PartialEq, Debug, CandidType, Deserialize)]
+pub struct SignWithBip341Aux {
+    pub merkle_root_hash: ByteBuf,
+}
+
+/// Represents the aux argument of the sign_with_schnorr API.
+/// ```text
+/// (record {
+///    bip341: record {
+///      merkle_root_hash: blob;
+///   }
+/// })
+/// ```
+#[derive(Eq, PartialEq, Debug, CandidType, Deserialize)]
+pub enum SignWithSchnorrAux {
+    #[serde(rename = "bip341")]
+    Bip341(SignWithBip341Aux),
+}
+
 /// Represents the argument of the sign_with_schnorr API.
 /// ```text
 /// (record {
 ///   message : blob;
 ///   derivation_path : vec blob;
 ///   key_id : schnorr_key_id;
+///   aux: opt schnorr_aux;
 /// })
 /// ```
 #[derive(Eq, PartialEq, Debug, CandidType, Deserialize)]
@@ -2725,7 +2751,7 @@ pub struct SignWithSchnorrArgs {
     pub message: Vec<u8>,
     pub derivation_path: DerivationPath,
     pub key_id: SchnorrKeyId,
-    pub taproot_tree_root: Option<ByteBuf>,
+    pub aux: Option<SignWithSchnorrAux>,
 }
 
 impl Payload<'_> for SignWithSchnorrArgs {}


### PR DESCRIPTION
PR 2523 implemented a management canister interface which does not match the finalized interface change (https://github.com/dfinity/portal/pull/3758)