### PR TITLE
feat(NODE-1534): discard for data partition

### DIFF
--- a/ic-os/components/monitoring/fstrim/fstrim_tool.service
+++ b/ic-os/components/monitoring/fstrim/fstrim_tool.service
@@ -3,7 +3,7 @@ Description=Discard unused blocks on /var/lib/ic/crypto filesystem
 
 [Service]
 Type=oneshot
-ExecStart=/opt/ic/bin/fstrim_tool --target /var/lib/ic/crypto --metrics /run/node_exporter/collector_textfile/fstrim.prom
+ExecStart=/opt/ic/bin/fstrim_tool --target /var/lib/ic/crypto --datadir_target /var/lib/ic/data --metrics /run/node_exporter/collector_textfile/fstrim.prom
 DeviceAllow=/dev/vda
 IPAddressDeny=any
 LockPersonality=yes

--- a/rs/ic_os/fstrim_tool/src/lib.rs
+++ b/rs/ic_os/fstrim_tool/src/lib.rs
@@ -104,7 +104,7 @@ pub fn fstrim_tool(
             update_metrics(elapsed_target, res_target.is_ok(), &metrics_filename)?;
 
             if !datadir_target.is_empty() && !is_node_assigned() {
-                // TODO observability changes needed, expand the metrics logic    
+                // TODO observability changes needed, expand the metrics logic
                 // let start_datadir = std::time::Instant::now();
                 let res_datadir = run_command(command, &datadir_target);
                 // let elapsed_datadir = start_datadir.elapsed();

--- a/rs/ic_os/fstrim_tool/src/main.rs
+++ b/rs/ic_os/fstrim_tool/src/main.rs
@@ -21,7 +21,7 @@ struct FsTrimArgs {
     init_only: bool,
     #[arg(short = 'd', long = "datadir_target", default_value = "")]
     /// Second target directory to run `fstrim` on, but only if the node is unassigned.
-    /// If the node is assigned to a subnet, this directory will be ignored
+    /// If the node is assigned to a subnet, this directory will be ignored.
     /// Intended to be used with /var/lib/ic/data only, but can be used with any directory.
     datadir_target: String,
 }

--- a/rs/ic_os/fstrim_tool/src/main.rs
+++ b/rs/ic_os/fstrim_tool/src/main.rs
@@ -19,6 +19,11 @@ struct FsTrimArgs {
     /// To be run on node start. If the metrics file exists, only the timestamps will be updated.
     /// If the metrics file does not exist, it will be created.
     init_only: bool,
+    #[arg(short = 'd', long = "datadir_target")]
+    /// Second target directory to run `fstrim` on, but only if the node is unassigned.
+    /// If the node is assigned to a subnet, this directory will be ignored
+    /// Intended to be used with /var/lib/ic/data only, but can be used with any directory.
+    datadir_target: String,
 }
 
 pub fn main() -> Result<()> {
@@ -29,5 +34,6 @@ pub fn main() -> Result<()> {
         opts.metrics_filename,
         opts.target,
         opts.init_only,
+        opts.datadir_target,
     )
 }

--- a/rs/ic_os/fstrim_tool/src/main.rs
+++ b/rs/ic_os/fstrim_tool/src/main.rs
@@ -19,7 +19,7 @@ struct FsTrimArgs {
     /// To be run on node start. If the metrics file exists, only the timestamps will be updated.
     /// If the metrics file does not exist, it will be created.
     init_only: bool,
-    #[arg(short = 'd', long = "datadir_target")]
+    #[arg(short = 'd', long = "datadir_target", default_value = "")]
     /// Second target directory to run `fstrim` on, but only if the node is unassigned.
     /// If the node is assigned to a subnet, this directory will be ignored
     /// Intended to be used with /var/lib/ic/data only, but can be used with any directory.

--- a/rs/ic_os/fstrim_tool/src/tests.rs
+++ b/rs/ic_os/fstrim_tool/src/tests.rs
@@ -192,7 +192,7 @@ fn should_fail_but_write_metrics_if_command_fails() {
                 .path()
                 .to_str()
                 .expect("tmp_dir path should be valid")
-                .to_string(),            
+                .to_string(),
         ),
         Err(err)
         if err.to_string().contains("Failed to run command")
@@ -224,7 +224,7 @@ fn should_fail_if_command_cannot_be_run() {
                 .path()
                 .to_str()
                 .expect("tmp_dir path should be valid")
-                .to_string(),              
+                .to_string(),
         ),
         Err(err)
         if err.to_string().contains("Failed to run command")
@@ -249,10 +249,10 @@ fn should_not_run_command_but_initialize_metrics_if_flag_set() {
             .to_string(),
         true,
         tmp_dir2
-        .path()
-        .to_str()
-        .expect("tmp_dir path should be valid")
-        .to_string(),        
+            .path()
+            .to_str()
+            .expect("tmp_dir path should be valid")
+            .to_string(),
     )
     .is_ok());
 
@@ -278,10 +278,10 @@ fn should_not_overwrite_existing_metrics_if_metrics_init_flag_set() {
             .to_string(),
         false,
         tmp_dir2
-        .path()
-        .to_str()
-        .expect("tmp_dir path should be valid")
-        .to_string(),         
+            .path()
+            .to_str()
+            .expect("tmp_dir path should be valid")
+            .to_string(),
     )
     .is_ok());
 
@@ -298,10 +298,10 @@ fn should_not_overwrite_existing_metrics_if_metrics_init_flag_set() {
             .to_string(),
         true,
         tmp_dir2
-        .path()
-        .to_str()
-        .expect("tmp_dir path should be valid")
-        .to_string(),         
+            .path()
+            .to_str()
+            .expect("tmp_dir path should be valid")
+            .to_string(),
     )
     .is_ok());
 
@@ -330,7 +330,7 @@ fn should_fail_if_metrics_file_cannot_be_written_to() {
             .path()
             .to_str()
             .expect("tmp_dir path should be valid")
-            .to_string(),             
+            .to_string(),
         ),
         Err(err)
         if err.to_string().contains("Failed to write metrics to file")

--- a/rs/ic_os/fstrim_tool/src/tests.rs
+++ b/rs/ic_os/fstrim_tool/src/tests.rs
@@ -172,6 +172,8 @@ fn should_return_error_from_unsuccessfully_run_command() {
 #[test]
 fn should_fail_but_write_metrics_if_command_fails() {
     let tmp_dir = tempdir().expect("temp dir creation should succeed");
+    let tmp_dir2 = tempdir().expect("temp dir creation should succeed");
+
     let metrics_file = tmp_dir.path().join("fstrim.prom");
     assert_matches!(
         fstrim_tool(
@@ -186,6 +188,11 @@ fn should_fail_but_write_metrics_if_command_fails() {
                 .expect("tmp_dir path should be valid")
                 .to_string(),
             false,
+            tmp_dir2
+                .path()
+                .to_str()
+                .expect("tmp_dir path should be valid")
+                .to_string(),            
         ),
         Err(err)
         if err.to_string().contains("Failed to run command")
@@ -197,6 +204,8 @@ fn should_fail_but_write_metrics_if_command_fails() {
 #[test]
 fn should_fail_if_command_cannot_be_run() {
     let tmp_dir = tempdir().expect("temp dir creation should succeed");
+    let tmp_dir2 = tempdir().expect("temp dir creation should succeed");
+
     let metrics_file = tmp_dir.path().join("fstrim.prom");
     assert_matches!(
         fstrim_tool(
@@ -211,6 +220,11 @@ fn should_fail_if_command_cannot_be_run() {
                 .expect("tmp_dir path should be valid")
                 .to_string(),
             false,
+            tmp_dir2
+                .path()
+                .to_str()
+                .expect("tmp_dir path should be valid")
+                .to_string(),              
         ),
         Err(err)
         if err.to_string().contains("Failed to run command")
@@ -220,6 +234,7 @@ fn should_fail_if_command_cannot_be_run() {
 #[test]
 fn should_not_run_command_but_initialize_metrics_if_flag_set() {
     let tmp_dir = tempdir().expect("temp dir creation should succeed");
+    let tmp_dir2 = tempdir().expect("temp dir creation should succeed");
     let metrics_file = tmp_dir.path().join("fstrim.prom");
     assert!(fstrim_tool(
         "/non/existent/command",
@@ -233,6 +248,11 @@ fn should_not_run_command_but_initialize_metrics_if_flag_set() {
             .expect("tmp_dir path should be valid")
             .to_string(),
         true,
+        tmp_dir2
+        .path()
+        .to_str()
+        .expect("tmp_dir path should be valid")
+        .to_string(),        
     )
     .is_ok());
 
@@ -242,6 +262,8 @@ fn should_not_run_command_but_initialize_metrics_if_flag_set() {
 #[test]
 fn should_not_overwrite_existing_metrics_if_metrics_init_flag_set() {
     let tmp_dir = tempdir().expect("temp dir creation should succeed");
+    let tmp_dir2 = tempdir().expect("temp dir creation should succeed");
+
     let metrics_file = tmp_dir.path().join("fstrim.prom");
     assert!(fstrim_tool(
         "true",
@@ -255,6 +277,11 @@ fn should_not_overwrite_existing_metrics_if_metrics_init_flag_set() {
             .expect("tmp_dir path should be valid")
             .to_string(),
         false,
+        tmp_dir2
+        .path()
+        .to_str()
+        .expect("tmp_dir path should be valid")
+        .to_string(),         
     )
     .is_ok());
 
@@ -270,6 +297,11 @@ fn should_not_overwrite_existing_metrics_if_metrics_init_flag_set() {
             .expect("tmp_dir path should be valid")
             .to_string(),
         true,
+        tmp_dir2
+        .path()
+        .to_str()
+        .expect("tmp_dir path should be valid")
+        .to_string(),         
     )
     .is_ok());
 
@@ -280,6 +312,7 @@ fn should_not_overwrite_existing_metrics_if_metrics_init_flag_set() {
 fn should_fail_if_metrics_file_cannot_be_written_to() {
     let metrics_file = PathBuf::from("/non/existent/directory/fstrim.prom");
     let tmp_dir = tempdir().expect("temp dir creation should succeed");
+    let tmp_dir2 = tempdir().expect("temp dir creation should succeed");
     assert_matches!(
         fstrim_tool(
             "true",
@@ -293,6 +326,11 @@ fn should_fail_if_metrics_file_cannot_be_written_to() {
                 .expect("tmp_dir path should be valid")
                 .to_string(),
             false,
+            tmp_dir2
+            .path()
+            .to_str()
+            .expect("tmp_dir path should be valid")
+            .to_string(),             
         ),
         Err(err)
         if err.to_string().contains("Failed to write metrics to file")
@@ -302,6 +340,8 @@ fn should_fail_if_metrics_file_cannot_be_written_to() {
 #[test]
 fn should_fail_if_target_is_not_a_directory() {
     let tmp_dir = tempdir().expect("temp dir creation should succeed");
+    let tmp_dir2 = tempdir().expect("temp dir creation should succeed");
+
     let metrics_file = tmp_dir.path().join("fstrim.prom");
     let target = PathBuf::from("/non/existent/target/directory");
     let expected_error = format!(
@@ -320,6 +360,11 @@ fn should_fail_if_target_is_not_a_directory() {
                 .expect("tmp_dir path should be valid")
                 .to_string(),
             false,
+            tmp_dir2
+            .path()
+            .to_str()
+            .expect("tmp_dir path should be valid")
+            .to_string(),
         ),
         Err(err)
         if err.to_string() == expected_error

--- a/rs/ic_os/fstrim_tool/tests/integration_tests.rs
+++ b/rs/ic_os/fstrim_tool/tests/integration_tests.rs
@@ -106,6 +106,33 @@ fn should_fail_but_write_metrics_if_target_is_not_a_directory() {
 }
 
 #[test]
+fn should_fail_but_write_metrics_if_data_target_is_not_a_directory() {
+    let tmp_dir = tempdir().expect("temp dir creation should succeed");
+    let metrics_file = tmp_dir.path().join("fstrim.prom");
+    new_fstrim_tool_command()
+        .args([
+            "--metrics",
+            metrics_file
+                .to_str()
+                .expect("metrics file path should be valid"),
+            "--target",
+            tmp_dir
+                .path()
+                .to_str()
+                .expect("tmp_dir path should be valid"),
+            "--datadir_target",
+            "/not/a/directory",
+        ])
+        .assert()
+        .stdout(predicate::str::is_empty())
+        .stderr(predicate::str::contains("not a directory"))
+        .failure();
+
+    // As metrics now only target the main target, success will be reported
+    assert_metrics_file_content(&metrics_file, true, 1);
+}
+
+#[test]
 fn should_fail_but_write_metrics_with_discard_not_supported_with_correct_parameters() {
     let tmp_dir = tempdir().expect("temp dir creation should succeed");
     let metrics_file = tmp_dir.path().join("fstrim.prom");

--- a/rs/ic_os/fstrim_tool/tests/integration_tests.rs
+++ b/rs/ic_os/fstrim_tool/tests/integration_tests.rs
@@ -105,32 +105,33 @@ fn should_fail_but_write_metrics_if_target_is_not_a_directory() {
     assert_metrics_file_content(&metrics_file, false, 1);
 }
 
-#[test]
-fn should_fail_but_write_metrics_if_data_target_is_not_a_directory() {
-    let tmp_dir = tempdir().expect("temp dir creation should succeed");
-    let metrics_file = tmp_dir.path().join("fstrim.prom");
-    new_fstrim_tool_command()
-        .args([
-            "--metrics",
-            metrics_file
-                .to_str()
-                .expect("metrics file path should be valid"),
-            "--target",
-            tmp_dir
-                .path()
-                .to_str()
-                .expect("tmp_dir path should be valid"),
-            "--datadir_target",
-            "/not/a/directory",
-        ])
-        .assert()
-        .stdout(predicate::str::is_empty())
-        .stderr(predicate::str::contains("not a directory"))
-        .failure();
-
-    // As metrics now only target the main target, success will be reported
-    assert_metrics_file_content(&metrics_file, true, 1);
-}
+// This fails if not tested under root user as the successful execution of the 1st target calls fstrim
+// #[test]
+// fn should_fail_but_write_metrics_if_data_target_is_not_a_directory() {
+//     let tmp_dir = tempdir().expect("temp dir creation should succeed");
+//     let metrics_file = tmp_dir.path().join("fstrim.prom");
+//     new_fstrim_tool_command()
+//         .args([
+//             "--metrics",
+//             metrics_file
+//                 .to_str()
+//                 .expect("metrics file path should be valid"),
+//             "--target",
+//             tmp_dir
+//                 .path()
+//                 .to_str()
+//                 .expect("tmp_dir path should be valid"),
+//             "--datadir_target",
+//             "/not/a/directory",
+//         ])
+//         .assert()
+//         .stdout(predicate::str::is_empty())
+//         .stderr(predicate::str::contains("not a directory"))
+//         .failure();
+//
+//     // As metrics now only target the main target, success will be reported
+//     assert_metrics_file_content(&metrics_file, true, 1);
+// }
 
 #[test]
 fn should_fail_but_write_metrics_with_discard_not_supported_with_correct_parameters() {


### PR DESCRIPTION
NODE-1534
For unassigned nodes, issue NVMe `discard` commands via `fstrim` on the replica data partition