### PR TITLE
chore: EXC-1818: Upgrade wasmtime to 27.0.0

### DIFF
--- a/Cargo.Bazel.Fuzzing.json.lock
+++ b/Cargo.Bazel.Fuzzing.json.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "437e6f7903120517b815140fc45624e2c220aa4ef007dc6a066da451c97e90aa",
+  "checksum": "cb75bff2d9f6d8056d5a1b773fe08cd804f54831a43b9b23ed7da9d675a827c2",
   "crates": {
     "abnf 0.12.0": {
       "name": "abnf",
@@ -6268,7 +6268,7 @@
               "target": "clang_sys"
             },
             {
-              "id": "itertools 0.11.0",
+              "id": "itertools 0.12.0",
               "target": "itertools"
             },
             {
@@ -14228,14 +14228,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "cranelift-bforest 0.113.0": {
+    "cranelift-bforest 0.114.0": {
       "name": "cranelift-bforest",
-      "version": "0.113.0",
+      "version": "0.114.0",
       "package_url": "https://github.com/bytecodealliance/wasmtime",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/cranelift-bforest/0.113.0/download",
-          "sha256": "8ea5e7afe85cadb55c4c1176268a2ac046fdff8dfaeca39e18581b9dc319ca9e"
+          "url": "https://static.crates.io/crates/cranelift-bforest/0.114.0/download",
+          "sha256": "2ba4f80548f22dc9c43911907b5e322c5555544ee85f785115701e6a28c9abe1"
         }
       },
       "targets": [
@@ -14260,14 +14260,14 @@
         "deps": {
           "common": [
             {
-              "id": "cranelift-entity 0.113.0",
+              "id": "cranelift-entity 0.114.0",
               "target": "cranelift_entity"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.113.0"
+        "version": "0.114.0"
       },
       "license": "Apache-2.0 WITH LLVM-exception",
       "license_ids": [
@@ -14275,14 +14275,14 @@
       ],
       "license_file": "LICENSE"
     },
-    "cranelift-bitset 0.113.0": {
+    "cranelift-bitset 0.114.0": {
       "name": "cranelift-bitset",
-      "version": "0.113.0",
+      "version": "0.114.0",
       "package_url": "https://github.com/bytecodealliance/wasmtime",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/cranelift-bitset/0.113.0/download",
-          "sha256": "8ab25ef3be935a80680e393183e1f94ef507e93a24a8369494d2c6818aedb3e3"
+          "url": "https://static.crates.io/crates/cranelift-bitset/0.114.0/download",
+          "sha256": "005884e3649c3e5ff2dc79e8a94b138f11569cc08a91244a292714d2a86e9156"
         }
       },
       "targets": [
@@ -14329,7 +14329,7 @@
           ],
           "selects": {}
         },
-        "version": "0.113.0"
+        "version": "0.114.0"
       },
       "license": "Apache-2.0 WITH LLVM-exception",
       "license_ids": [
@@ -14337,14 +14337,14 @@
       ],
       "license_file": null
     },
-    "cranelift-codegen 0.113.0": {
+    "cranelift-codegen 0.114.0": {
       "name": "cranelift-codegen",
-      "version": "0.113.0",
+      "version": "0.114.0",
       "package_url": "https://github.com/bytecodealliance/wasmtime",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/cranelift-codegen/0.113.0/download",
-          "sha256": "900a19b84545924f1851cbfe386962edfc4ecbc3366a254825cf1ecbcda8ba08"
+          "url": "https://static.crates.io/crates/cranelift-codegen/0.114.0/download",
+          "sha256": "fe4036255ec33ce9a37495dfbcfc4e1118fd34e693eff9a1e106336b7cd16a9b"
         }
       },
       "targets": [
@@ -14395,27 +14395,27 @@
               "target": "bumpalo"
             },
             {
-              "id": "cranelift-bforest 0.113.0",
+              "id": "cranelift-bforest 0.114.0",
               "target": "cranelift_bforest"
             },
             {
-              "id": "cranelift-bitset 0.113.0",
+              "id": "cranelift-bitset 0.114.0",
               "target": "cranelift_bitset"
             },
             {
-              "id": "cranelift-codegen 0.113.0",
+              "id": "cranelift-codegen 0.114.0",
               "target": "build_script_build"
             },
             {
-              "id": "cranelift-codegen-shared 0.113.0",
+              "id": "cranelift-codegen-shared 0.114.0",
               "target": "cranelift_codegen_shared"
             },
             {
-              "id": "cranelift-control 0.113.0",
+              "id": "cranelift-control 0.114.0",
               "target": "cranelift_control"
             },
             {
-              "id": "cranelift-entity 0.113.0",
+              "id": "cranelift-entity 0.114.0",
               "target": "cranelift_entity"
             },
             {
@@ -14450,7 +14450,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.113.0"
+        "version": "0.114.0"
       },
       "build_script_attrs": {
         "compile_data_glob": [
@@ -14462,11 +14462,11 @@
         "deps": {
           "common": [
             {
-              "id": "cranelift-codegen-meta 0.113.0",
+              "id": "cranelift-codegen-meta 0.114.0",
               "target": "cranelift_codegen_meta"
             },
             {
-              "id": "cranelift-isle 0.113.0",
+              "id": "cranelift-isle 0.114.0",
               "target": "cranelift_isle"
             }
           ],
@@ -14479,14 +14479,14 @@
       ],
       "license_file": "LICENSE"
     },
-    "cranelift-codegen-meta 0.113.0": {
+    "cranelift-codegen-meta 0.114.0": {
       "name": "cranelift-codegen-meta",
-      "version": "0.113.0",
+      "version": "0.114.0",
       "package_url": "https://github.com/bytecodealliance/wasmtime",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/cranelift-codegen-meta/0.113.0/download",
-          "sha256": "08c73b2395ffe9e7b4fdf7e2ebc052e7e27af13f68a964985346be4da477a5fc",
+          "url": "https://static.crates.io/crates/cranelift-codegen-meta/0.114.0/download",
+          "sha256": "f7ca74f4b68319da11d39e894437cb6e20ec7c2e11fbbda823c3bf207beedff7",
           "patch_args": [
             "-p4"
           ],
@@ -14517,14 +14517,14 @@
         "deps": {
           "common": [
             {
-              "id": "cranelift-codegen-shared 0.113.0",
+              "id": "cranelift-codegen-shared 0.114.0",
               "target": "cranelift_codegen_shared"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.113.0"
+        "version": "0.114.0"
       },
       "license": "Apache-2.0 WITH LLVM-exception",
       "license_ids": [
@@ -14532,14 +14532,14 @@
       ],
       "license_file": "LICENSE"
     },
-    "cranelift-codegen-shared 0.113.0": {
+    "cranelift-codegen-shared 0.114.0": {
       "name": "cranelift-codegen-shared",
-      "version": "0.113.0",
+      "version": "0.114.0",
       "package_url": "https://github.com/bytecodealliance/wasmtime",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/cranelift-codegen-shared/0.113.0/download",
-          "sha256": "7d9ed0854e96a4ff0879bff39d078de8dea7f002721c9494c1fdb4e1baa86ccc"
+          "url": "https://static.crates.io/crates/cranelift-codegen-shared/0.114.0/download",
+          "sha256": "897e54f433a0269c4187871aa06d452214d5515d228d5bdc22219585e9eef895"
         }
       },
       "targets": [
@@ -14562,7 +14562,7 @@
           "**"
         ],
         "edition": "2021",
-        "version": "0.113.0"
+        "version": "0.114.0"
       },
       "license": "Apache-2.0 WITH LLVM-exception",
       "license_ids": [
@@ -14570,14 +14570,14 @@
       ],
       "license_file": "LICENSE"
     },
-    "cranelift-control 0.113.0": {
+    "cranelift-control 0.114.0": {
       "name": "cranelift-control",
-      "version": "0.113.0",
+      "version": "0.114.0",
       "package_url": "https://github.com/bytecodealliance/wasmtime",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/cranelift-control/0.113.0/download",
-          "sha256": "b4aca921dd422e781409de0129c255768fec5dec1dae83239b497fb9138abb89"
+          "url": "https://static.crates.io/crates/cranelift-control/0.114.0/download",
+          "sha256": "29cb4018f5bf59fb53f515fa9d80e6f8c5ce19f198dc538984ebd23ecf8965ec"
         }
       },
       "targets": [
@@ -14616,7 +14616,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.113.0"
+        "version": "0.114.0"
       },
       "license": "Apache-2.0 WITH LLVM-exception",
       "license_ids": [
@@ -14624,14 +14624,14 @@
       ],
       "license_file": "LICENSE"
     },
-    "cranelift-entity 0.113.0": {
+    "cranelift-entity 0.114.0": {
       "name": "cranelift-entity",
-      "version": "0.113.0",
+      "version": "0.114.0",
       "package_url": "https://github.com/bytecodealliance/wasmtime",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/cranelift-entity/0.113.0/download",
-          "sha256": "e2d770e6605eccee15b49decdd82cd26f2b6404767802471459ea49c57379a98"
+          "url": "https://static.crates.io/crates/cranelift-entity/0.114.0/download",
+          "sha256": "305399fd781a2953ac78c1396f02ff53144f39c33eb7fc7789cf4e8936d13a96"
         }
       },
       "targets": [
@@ -14664,7 +14664,7 @@
         "deps": {
           "common": [
             {
-              "id": "cranelift-bitset 0.113.0",
+              "id": "cranelift-bitset 0.114.0",
               "target": "cranelift_bitset"
             },
             {
@@ -14684,7 +14684,7 @@
           ],
           "selects": {}
         },
-        "version": "0.113.0"
+        "version": "0.114.0"
       },
       "license": "Apache-2.0 WITH LLVM-exception",
       "license_ids": [
@@ -14692,14 +14692,14 @@
       ],
       "license_file": "LICENSE"
     },
-    "cranelift-frontend 0.113.0": {
+    "cranelift-frontend 0.114.0": {
       "name": "cranelift-frontend",
-      "version": "0.113.0",
+      "version": "0.114.0",
       "package_url": "https://github.com/bytecodealliance/wasmtime",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/cranelift-frontend/0.113.0/download",
-          "sha256": "29268711cb889cb39215b10faf88b9087d4c9e1d2633581e4f722a2bf4bb4ef9"
+          "url": "https://static.crates.io/crates/cranelift-frontend/0.114.0/download",
+          "sha256": "9230b460a128d53653456137751d27baf567947a3ab8c0c4d6e31fd08036d81e"
         }
       },
       "targets": [
@@ -14731,7 +14731,7 @@
         "deps": {
           "common": [
             {
-              "id": "cranelift-codegen 0.113.0",
+              "id": "cranelift-codegen 0.114.0",
               "target": "cranelift_codegen"
             },
             {
@@ -14750,7 +14750,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.113.0"
+        "version": "0.114.0"
       },
       "license": "Apache-2.0 WITH LLVM-exception",
       "license_ids": [
@@ -14758,14 +14758,14 @@
       ],
       "license_file": "LICENSE"
     },
-    "cranelift-isle 0.113.0": {
+    "cranelift-isle 0.114.0": {
       "name": "cranelift-isle",
-      "version": "0.113.0",
+      "version": "0.114.0",
       "package_url": "https://github.com/bytecodealliance/wasmtime/tree/main/cranelift/isle",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/cranelift-isle/0.113.0/download",
-          "sha256": "dc65156f010aed1985767ad1bff0eb8d186743b7b03e23d0c17604a253e3f356",
+          "url": "https://static.crates.io/crates/cranelift-isle/0.114.0/download",
+          "sha256": "b961e24ae3ec9813a24a15ae64bbd2a42e4de4d79a7f3225a412e3b94e78d1c8",
           "patch_args": [
             "-p4"
           ],
@@ -14814,14 +14814,14 @@
         "deps": {
           "common": [
             {
-              "id": "cranelift-isle 0.113.0",
+              "id": "cranelift-isle 0.114.0",
               "target": "build_script_build"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.113.0"
+        "version": "0.114.0"
       },
       "build_script_attrs": {
         "compile_data_glob": [
@@ -14837,14 +14837,14 @@
       ],
       "license_file": null
     },
-    "cranelift-native 0.113.0": {
+    "cranelift-native 0.114.0": {
       "name": "cranelift-native",
-      "version": "0.113.0",
+      "version": "0.114.0",
       "package_url": "https://github.com/bytecodealliance/wasmtime",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/cranelift-native/0.113.0/download",
-          "sha256": "d8bf9b361eaf5a7627647270fabf1dc910d993edbeaf272a652c107861ebe9c2"
+          "url": "https://static.crates.io/crates/cranelift-native/0.114.0/download",
+          "sha256": "4d5bd76df6c9151188dfa428c863b33da5b34561b67f43c0cf3f24a794f9fa1f"
         }
       },
       "targets": [
@@ -14876,7 +14876,7 @@
         "deps": {
           "common": [
             {
-              "id": "cranelift-codegen 0.113.0",
+              "id": "cranelift-codegen 0.114.0",
               "target": "cranelift_codegen"
             },
             {
@@ -14894,7 +14894,7 @@
           }
         },
         "edition": "2021",
-        "version": "0.113.0"
+        "version": "0.114.0"
       },
       "license": "Apache-2.0 WITH LLVM-exception",
       "license_ids": [
@@ -19651,11 +19651,11 @@
               "target": "wasmprinter"
             },
             {
-              "id": "wasmtime 26.0.0",
+              "id": "wasmtime 27.0.0",
               "target": "wasmtime"
             },
             {
-              "id": "wasmtime-environ 26.0.0",
+              "id": "wasmtime-environ 27.0.0",
               "target": "wasmtime_environ"
             },
             {
@@ -52675,7 +52675,7 @@
               "target": "heck"
             },
             {
-              "id": "itertools 0.11.0",
+              "id": "itertools 0.12.0",
               "target": "itertools"
             },
             {
@@ -52829,7 +52829,7 @@
               "target": "anyhow"
             },
             {
-              "id": "itertools 0.11.0",
+              "id": "itertools 0.12.0",
               "target": "itertools"
             },
             {
@@ -53302,14 +53302,14 @@
       ],
       "license_file": "LICENSE"
     },
-    "pulley-interpreter 26.0.0": {
+    "pulley-interpreter 27.0.0": {
       "name": "pulley-interpreter",
-      "version": "26.0.0",
+      "version": "27.0.0",
       "package_url": "https://github.com/bytecodealliance/wasmtime/tree/main/pulley",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/pulley-interpreter/26.0.0/download",
-          "sha256": "d68c610ff29655a42eeef41a5b5346e714586971a7d927739477e552fe7e23e3"
+          "url": "https://static.crates.io/crates/pulley-interpreter/27.0.0/download",
+          "sha256": "a3b8d81cf799e20564931e9867ca32de545188c6ee4c2e0f6e41d32f0c7dc6fb"
         }
       },
       "targets": [
@@ -53334,7 +53334,7 @@
         "deps": {
           "common": [
             {
-              "id": "cranelift-bitset 0.113.0",
+              "id": "cranelift-bitset 0.114.0",
               "target": "cranelift_bitset"
             },
             {
@@ -53349,7 +53349,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "26.0.0"
+        "version": "27.0.0"
       },
       "license": "Apache-2.0 WITH LLVM-exception",
       "license_ids": [
@@ -79844,14 +79844,14 @@
       ],
       "license_file": null
     },
-    "wasm-encoder 0.218.0": {
+    "wasm-encoder 0.219.1": {
       "name": "wasm-encoder",
-      "version": "0.218.0",
+      "version": "0.219.1",
       "package_url": "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasm-encoder",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/wasm-encoder/0.218.0/download",
-          "sha256": "22b896fa8ceb71091ace9bcb81e853f54043183a1c9667cf93422c40252ffa0a"
+          "url": "https://static.crates.io/crates/wasm-encoder/0.219.1/download",
+          "sha256": "29cbbd772edcb8e7d524a82ee8cef8dd046fc14033796a754c3ad246d019fa54"
         }
       },
       "targets": [
@@ -79873,6 +79873,13 @@
         "compile_data_glob": [
           "**"
         ],
+        "crate_features": {
+          "common": [
+            "component-model",
+            "default"
+          ],
+          "selects": {}
+        },
         "deps": {
           "common": [
             {
@@ -79883,7 +79890,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.218.0"
+        "version": "0.219.1"
       },
       "license": "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT",
       "license_ids": [
@@ -80242,14 +80249,14 @@
       ],
       "license_file": null
     },
-    "wasmparser 0.218.0": {
+    "wasmparser 0.219.1": {
       "name": "wasmparser",
-      "version": "0.218.0",
+      "version": "0.219.1",
       "package_url": "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasmparser",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/wasmparser/0.218.0/download",
-          "sha256": "b09e46c7fceceaa72b2dd1a8a137ea7fd8f93dfaa69806010a709918e496c5dc"
+          "url": "https://static.crates.io/crates/wasmparser/0.219.1/download",
+          "sha256": "5c771866898879073c53b565a6c7b49953795159836714ac56a5befb581227c5"
         }
       },
       "targets": [
@@ -80273,6 +80280,7 @@
         ],
         "crate_features": {
           "common": [
+            "component-model",
             "features",
             "serde",
             "std",
@@ -80310,7 +80318,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.218.0"
+        "version": "0.219.1"
       },
       "license": "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT",
       "license_ids": [
@@ -80375,14 +80383,14 @@
       ],
       "license_file": null
     },
-    "wasmprinter 0.218.0": {
+    "wasmprinter 0.219.1": {
       "name": "wasmprinter",
-      "version": "0.218.0",
+      "version": "0.219.1",
       "package_url": "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasmprinter",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/wasmprinter/0.218.0/download",
-          "sha256": "0ace089155491837b75f474bf47c99073246d1b737393fe722d6dee311595ddc"
+          "url": "https://static.crates.io/crates/wasmprinter/0.219.1/download",
+          "sha256": "228cdc1f30c27816da225d239ce4231f28941147d34713dee8f1fff7cb330e54"
         }
       },
       "targets": [
@@ -80404,6 +80412,13 @@
         "compile_data_glob": [
           "**"
         ],
+        "crate_features": {
+          "common": [
+            "component-model",
+            "default"
+          ],
+          "selects": {}
+        },
         "deps": {
           "common": [
             {
@@ -80415,14 +80430,14 @@
               "target": "termcolor"
             },
             {
-              "id": "wasmparser 0.218.0",
+              "id": "wasmparser 0.219.1",
               "target": "wasmparser"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.218.0"
+        "version": "0.219.1"
       },
       "license": "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT",
       "license_ids": [
@@ -80431,14 +80446,14 @@
       ],
       "license_file": null
     },
-    "wasmtime 26.0.0": {
+    "wasmtime 27.0.0": {
       "name": "wasmtime",
-      "version": "26.0.0",
+      "version": "27.0.0",
       "package_url": "https://github.com/bytecodealliance/wasmtime",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/wasmtime/26.0.0/download",
-          "sha256": "5ffa3230b9ba1ab6568d116df21bf4ca55ed2bfac87723d910471d30d9656ea1"
+          "url": "https://static.crates.io/crates/wasmtime/27.0.0/download",
+          "sha256": "5b79302e3e084713249cc5622e8608e7410afdeeea8c8026d04f491d1fab0b4b"
         }
       },
       "targets": [
@@ -80476,6 +80491,8 @@
           "common": [
             "cranelift",
             "gc",
+            "gc-null",
+            "once_cell",
             "parallel-compilation",
             "runtime",
             "std"
@@ -80553,31 +80570,31 @@
               "target": "target_lexicon"
             },
             {
-              "id": "wasmparser 0.218.0",
+              "id": "wasmparser 0.219.1",
               "target": "wasmparser"
             },
             {
-              "id": "wasmtime 26.0.0",
+              "id": "wasmtime 27.0.0",
               "target": "build_script_build"
             },
             {
-              "id": "wasmtime-asm-macros 26.0.0",
+              "id": "wasmtime-asm-macros 27.0.0",
               "target": "wasmtime_asm_macros"
             },
             {
-              "id": "wasmtime-cranelift 26.0.0",
+              "id": "wasmtime-cranelift 27.0.0",
               "target": "wasmtime_cranelift"
             },
             {
-              "id": "wasmtime-environ 26.0.0",
+              "id": "wasmtime-environ 27.0.0",
               "target": "wasmtime_environ"
             },
             {
-              "id": "wasmtime-jit-icache-coherence 26.0.0",
+              "id": "wasmtime-jit-icache-coherence 27.0.0",
               "target": "wasmtime_jit_icache_coherence"
             },
             {
-              "id": "wasmtime-slab 26.0.0",
+              "id": "wasmtime-slab 27.0.0",
               "target": "wasmtime_slab"
             }
           ],
@@ -80810,7 +80827,7 @@
               "target": "serde_derive"
             },
             {
-              "id": "wasmtime-versioned-export-macros 26.0.0",
+              "id": "wasmtime-versioned-export-macros 27.0.0",
               "target": "wasmtime_versioned_export_macros"
             }
           ],
@@ -80837,7 +80854,7 @@
           ],
           "selects": {}
         },
-        "version": "26.0.0"
+        "version": "27.0.0"
       },
       "build_script_attrs": {
         "compile_data_glob": [
@@ -80858,7 +80875,7 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "wasmtime-versioned-export-macros 26.0.0",
+              "id": "wasmtime-versioned-export-macros 27.0.0",
               "target": "wasmtime_versioned_export_macros"
             }
           ],
@@ -80871,14 +80888,14 @@
       ],
       "license_file": "LICENSE"
     },
-    "wasmtime-asm-macros 26.0.0": {
+    "wasmtime-asm-macros 27.0.0": {
       "name": "wasmtime-asm-macros",
-      "version": "26.0.0",
+      "version": "27.0.0",
       "package_url": "https://github.com/bytecodealliance/wasmtime",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/wasmtime-asm-macros/26.0.0/download",
-          "sha256": "ef15fad08bbaa0e5c5539b76fa5965ca25e24f17a584f83a40b43ba9a2b36f44"
+          "url": "https://static.crates.io/crates/wasmtime-asm-macros/27.0.0/download",
+          "sha256": "fe53a24e7016a5222875d8ca3ad6024b464465985693c42098cd0bb710002c28"
         }
       },
       "targets": [
@@ -80910,7 +80927,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "26.0.0"
+        "version": "27.0.0"
       },
       "license": "Apache-2.0 WITH LLVM-exception",
       "license_ids": [
@@ -80918,14 +80935,14 @@
       ],
       "license_file": null
     },
-    "wasmtime-component-macro 26.0.0": {
+    "wasmtime-component-macro 27.0.0": {
       "name": "wasmtime-component-macro",
-      "version": "26.0.0",
+      "version": "27.0.0",
       "package_url": "https://github.com/bytecodealliance/wasmtime",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/wasmtime-component-macro/26.0.0/download",
-          "sha256": "23fb4e179f424260d0739c09d3bc83d34347a55d291d10dcb5244686a75c7733"
+          "url": "https://static.crates.io/crates/wasmtime-component-macro/27.0.0/download",
+          "sha256": "e118acbd2bc09b32ad8606bc7cef793bf5019c1b107772e64dc6c76b5055d40b"
         }
       },
       "targets": [
@@ -80978,26 +80995,26 @@
               "target": "syn"
             },
             {
-              "id": "wasmtime-component-macro 26.0.0",
+              "id": "wasmtime-component-macro 27.0.0",
               "target": "build_script_build"
             },
             {
-              "id": "wasmtime-component-util 26.0.0",
+              "id": "wasmtime-component-util 27.0.0",
               "target": "wasmtime_component_util"
             },
             {
-              "id": "wasmtime-wit-bindgen 26.0.0",
+              "id": "wasmtime-wit-bindgen 27.0.0",
               "target": "wasmtime_wit_bindgen"
             },
             {
-              "id": "wit-parser 0.218.0",
+              "id": "wit-parser 0.219.1",
               "target": "wit_parser"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "26.0.0"
+        "version": "27.0.0"
       },
       "build_script_attrs": {
         "compile_data_glob": [
@@ -81013,14 +81030,14 @@
       ],
       "license_file": null
     },
-    "wasmtime-component-util 26.0.0": {
+    "wasmtime-component-util 27.0.0": {
       "name": "wasmtime-component-util",
-      "version": "26.0.0",
+      "version": "27.0.0",
       "package_url": "https://github.com/bytecodealliance/wasmtime",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/wasmtime-component-util/26.0.0/download",
-          "sha256": "cfe3c27d64af5f584014db9381c081223d27a57e1dce2f6280bbafea37575619"
+          "url": "https://static.crates.io/crates/wasmtime-component-util/27.0.0/download",
+          "sha256": "4a6db4f3ee18c699629eabb9c64e77efe5a93a5137f098db7cab295037ba41c2"
         }
       },
       "targets": [
@@ -81043,7 +81060,7 @@
           "**"
         ],
         "edition": "2021",
-        "version": "26.0.0"
+        "version": "27.0.0"
       },
       "license": "Apache-2.0 WITH LLVM-exception",
       "license_ids": [
@@ -81051,14 +81068,14 @@
       ],
       "license_file": null
     },
-    "wasmtime-cranelift 26.0.0": {
+    "wasmtime-cranelift 27.0.0": {
       "name": "wasmtime-cranelift",
-      "version": "26.0.0",
+      "version": "27.0.0",
       "package_url": "https://github.com/bytecodealliance/wasmtime",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/wasmtime-cranelift/26.0.0/download",
-          "sha256": "eb56d9ee4a093509624bd0861888cd111f6530e16969a68bb12dc7dd7a2be27f"
+          "url": "https://static.crates.io/crates/wasmtime-cranelift/27.0.0/download",
+          "sha256": "8b87e6c78f562b50aff1afd87ff32a57e241424c846c1c8f3c5fd352d2d62906"
         }
       },
       "targets": [
@@ -81082,7 +81099,8 @@
         ],
         "crate_features": {
           "common": [
-            "gc"
+            "gc",
+            "gc-null"
           ],
           "selects": {}
         },
@@ -81097,23 +81115,23 @@
               "target": "cfg_if"
             },
             {
-              "id": "cranelift-codegen 0.113.0",
+              "id": "cranelift-codegen 0.114.0",
               "target": "cranelift_codegen"
             },
             {
-              "id": "cranelift-control 0.113.0",
+              "id": "cranelift-control 0.114.0",
               "target": "cranelift_control"
             },
             {
-              "id": "cranelift-entity 0.113.0",
+              "id": "cranelift-entity 0.114.0",
               "target": "cranelift_entity"
             },
             {
-              "id": "cranelift-frontend 0.113.0",
+              "id": "cranelift-frontend 0.114.0",
               "target": "cranelift_frontend"
             },
             {
-              "id": "cranelift-native 0.113.0",
+              "id": "cranelift-native 0.114.0",
               "target": "cranelift_native"
             },
             {
@@ -81145,11 +81163,11 @@
               "target": "thiserror"
             },
             {
-              "id": "wasmparser 0.218.0",
+              "id": "wasmparser 0.219.1",
               "target": "wasmparser"
             },
             {
-              "id": "wasmtime-environ 26.0.0",
+              "id": "wasmtime-environ 27.0.0",
               "target": "wasmtime_environ"
             }
           ],
@@ -81159,13 +81177,13 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "wasmtime-versioned-export-macros 26.0.0",
+              "id": "wasmtime-versioned-export-macros 27.0.0",
               "target": "wasmtime_versioned_export_macros"
             }
           ],
           "selects": {}
         },
-        "version": "26.0.0"
+        "version": "27.0.0"
       },
       "license": "Apache-2.0 WITH LLVM-exception",
       "license_ids": [
@@ -81173,14 +81191,14 @@
       ],
       "license_file": "LICENSE"
     },
-    "wasmtime-environ 26.0.0": {
+    "wasmtime-environ 27.0.0": {
       "name": "wasmtime-environ",
-      "version": "26.0.0",
+      "version": "27.0.0",
       "package_url": "https://github.com/bytecodealliance/wasmtime",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/wasmtime-environ/26.0.0/download",
-          "sha256": "f3444c1759d5b906ff76a3cab073dd92135bdd06e5d1f46635ec40a58207d314"
+          "url": "https://static.crates.io/crates/wasmtime-environ/27.0.0/download",
+          "sha256": "c25bfeaa16432d59a0706e2463d315ef4c9ebcfaf5605670b99d46373bdf9f27"
         }
       },
       "targets": [
@@ -81206,6 +81224,7 @@
           "common": [
             "compile",
             "gc",
+            "gc-null",
             "std"
           ],
           "selects": {}
@@ -81217,11 +81236,11 @@
               "target": "anyhow"
             },
             {
-              "id": "cranelift-bitset 0.113.0",
+              "id": "cranelift-bitset 0.114.0",
               "target": "cranelift_bitset"
             },
             {
-              "id": "cranelift-entity 0.113.0",
+              "id": "cranelift-entity 0.114.0",
               "target": "cranelift_entity"
             },
             {
@@ -81257,15 +81276,15 @@
               "target": "target_lexicon"
             },
             {
-              "id": "wasm-encoder 0.218.0",
+              "id": "wasm-encoder 0.219.1",
               "target": "wasm_encoder"
             },
             {
-              "id": "wasmparser 0.218.0",
+              "id": "wasmparser 0.219.1",
               "target": "wasmparser"
             },
             {
-              "id": "wasmprinter 0.218.0",
+              "id": "wasmprinter 0.219.1",
               "target": "wasmprinter"
             }
           ],
@@ -81281,7 +81300,7 @@
           ],
           "selects": {}
         },
-        "version": "26.0.0"
+        "version": "27.0.0"
       },
       "license": "Apache-2.0 WITH LLVM-exception",
       "license_ids": [
@@ -81289,14 +81308,14 @@
       ],
       "license_file": "LICENSE"
     },
-    "wasmtime-jit-icache-coherence 26.0.0": {
+    "wasmtime-jit-icache-coherence 27.0.0": {
       "name": "wasmtime-jit-icache-coherence",
-      "version": "26.0.0",
+      "version": "27.0.0",
       "package_url": "https://github.com/bytecodealliance/wasmtime",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/wasmtime-jit-icache-coherence/26.0.0/download",
-          "sha256": "6e458e6a1a010a53f86ac8d75837c0c6b2ce3e54b7503b2f1dc5629a4a541f5a"
+          "url": "https://static.crates.io/crates/wasmtime-jit-icache-coherence/27.0.0/download",
+          "sha256": "91b218a92866f74f35162f5d03a4e0f62cd0e1cc624285b1014275e5d4575fad"
         }
       },
       "targets": [
@@ -81345,7 +81364,7 @@
           }
         },
         "edition": "2021",
-        "version": "26.0.0"
+        "version": "27.0.0"
       },
       "license": "Apache-2.0 WITH LLVM-exception",
       "license_ids": [
@@ -81353,14 +81372,14 @@
       ],
       "license_file": null
     },
-    "wasmtime-slab 26.0.0": {
+    "wasmtime-slab 27.0.0": {
       "name": "wasmtime-slab",
-      "version": "26.0.0",
+      "version": "27.0.0",
       "package_url": "https://github.com/bytecodealliance/wasmtime",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/wasmtime-slab/26.0.0/download",
-          "sha256": "339c9a2a62b989a3184baff31be3a5b5256ad52629634eb432f9ccf0ab251f83"
+          "url": "https://static.crates.io/crates/wasmtime-slab/27.0.0/download",
+          "sha256": "4d5f8acf677ee6b3b8ba400dd9753ea4769e56a95c4b30b045ac6d2d54b2f8ea"
         }
       },
       "targets": [
@@ -81383,7 +81402,7 @@
           "**"
         ],
         "edition": "2021",
-        "version": "26.0.0"
+        "version": "27.0.0"
       },
       "license": "Apache-2.0 WITH LLVM-exception",
       "license_ids": [
@@ -81391,14 +81410,14 @@
       ],
       "license_file": null
     },
-    "wasmtime-versioned-export-macros 26.0.0": {
+    "wasmtime-versioned-export-macros 27.0.0": {
       "name": "wasmtime-versioned-export-macros",
-      "version": "26.0.0",
+      "version": "27.0.0",
       "package_url": "https://github.com/bytecodealliance/wasmtime",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/wasmtime-versioned-export-macros/26.0.0/download",
-          "sha256": "abe01058e422966659e1af00af833147d54658b07c7e74606d73ca9af3f1690a"
+          "url": "https://static.crates.io/crates/wasmtime-versioned-export-macros/27.0.0/download",
+          "sha256": "df09be00c38f49172ca9936998938476e3f2df782673a39ae2ef9fb0838341b6"
         }
       },
       "targets": [
@@ -81438,7 +81457,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "26.0.0"
+        "version": "27.0.0"
       },
       "license": "Apache-2.0 WITH LLVM-exception",
       "license_ids": [
@@ -81446,14 +81465,14 @@
       ],
       "license_file": null
     },
-    "wasmtime-wit-bindgen 26.0.0": {
+    "wasmtime-wit-bindgen 27.0.0": {
       "name": "wasmtime-wit-bindgen",
-      "version": "26.0.0",
+      "version": "27.0.0",
       "package_url": "https://github.com/bytecodealliance/wasmtime",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/wasmtime-wit-bindgen/26.0.0/download",
-          "sha256": "1c9e85935a1199e96b73e7fcd27a127035d2082265720a67d59268a24892d567"
+          "url": "https://static.crates.io/crates/wasmtime-wit-bindgen/27.0.0/download",
+          "sha256": "bf3963c9c29df91564d8bd181eb00d0dbaeafa1b2a01e15952bb7391166b704e"
         }
       },
       "targets": [
@@ -81490,14 +81509,14 @@
               "target": "indexmap"
             },
             {
-              "id": "wit-parser 0.218.0",
+              "id": "wit-parser 0.219.1",
               "target": "wit_parser"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "26.0.0"
+        "version": "27.0.0"
       },
       "license": "Apache-2.0 WITH LLVM-exception",
       "license_ids": [
@@ -84920,14 +84939,14 @@
       ],
       "license_file": "LICENSE"
     },
-    "wit-parser 0.218.0": {
+    "wit-parser 0.219.1": {
       "name": "wit-parser",
-      "version": "0.218.0",
+      "version": "0.219.1",
       "package_url": "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wit-parser",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/wit-parser/0.218.0/download",
-          "sha256": "0d3d1066ab761b115f97fef2b191090faabcb0f37b555b758d3caf42d4ed9e55"
+          "url": "https://static.crates.io/crates/wit-parser/0.219.1/download",
+          "sha256": "4a86f669283257e8e424b9a4fc3518e3ade0b95deb9fbc0f93a1876be3eda598"
         }
       },
       "targets": [
@@ -84993,7 +85012,7 @@
               "target": "unicode_xid"
             },
             {
-              "id": "wasmparser 0.218.0",
+              "id": "wasmparser 0.219.1",
               "target": "wasmparser"
             }
           ],
@@ -85009,7 +85028,7 @@
           ],
           "selects": {}
         },
-        "version": "0.218.0"
+        "version": "0.219.1"
       },
       "license": "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT",
       "license_ids": [
@@ -87900,8 +87919,8 @@
     "wasm-smith 0.212.0",
     "wasmparser 0.217.0",
     "wasmprinter 0.217.0",
-    "wasmtime 26.0.0",
-    "wasmtime-environ 26.0.0",
+    "wasmtime 27.0.0",
+    "wasmtime-environ 27.0.0",
     "wast 212.0.0",
     "wat 1.212.0",
     "wee_alloc 0.4.5",

--- a/Cargo.Bazel.Fuzzing.toml.lock
+++ b/Cargo.Bazel.Fuzzing.toml.lock
@@ -1091,7 +1091,7 @@ dependencies = [
  "bitflags 2.6.0",
  "cexpr",
  "clang-sys",
- "itertools 0.11.0",
+ "itertools 0.12.0",
  "lazy_static",
  "lazycell",
  "proc-macro2",
@@ -2341,18 +2341,18 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.113.0"
+version = "0.114.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5e7afe85cadb55c4c1176268a2ac046fdff8dfaeca39e18581b9dc319ca9e"
+checksum = "2ba4f80548f22dc9c43911907b5e322c5555544ee85f785115701e6a28c9abe1"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-bitset"
-version = "0.113.0"
+version = "0.114.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ab25ef3be935a80680e393183e1f94ef507e93a24a8369494d2c6818aedb3e3"
+checksum = "005884e3649c3e5ff2dc79e8a94b138f11569cc08a91244a292714d2a86e9156"
 dependencies = [
  "serde",
  "serde_derive",
@@ -2360,9 +2360,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.113.0"
+version = "0.114.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "900a19b84545924f1851cbfe386962edfc4ecbc3366a254825cf1ecbcda8ba08"
+checksum = "fe4036255ec33ce9a37495dfbcfc4e1118fd34e693eff9a1e106336b7cd16a9b"
 dependencies = [
  "bumpalo",
  "cranelift-bforest",
@@ -2377,39 +2377,40 @@ dependencies = [
  "log",
  "regalloc2",
  "rustc-hash 2.0.0",
+ "serde",
  "smallvec",
  "target-lexicon",
 ]
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.113.0"
+version = "0.114.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08c73b2395ffe9e7b4fdf7e2ebc052e7e27af13f68a964985346be4da477a5fc"
+checksum = "f7ca74f4b68319da11d39e894437cb6e20ec7c2e11fbbda823c3bf207beedff7"
 dependencies = [
  "cranelift-codegen-shared",
 ]
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.113.0"
+version = "0.114.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d9ed0854e96a4ff0879bff39d078de8dea7f002721c9494c1fdb4e1baa86ccc"
+checksum = "897e54f433a0269c4187871aa06d452214d5515d228d5bdc22219585e9eef895"
 
 [[package]]
 name = "cranelift-control"
-version = "0.113.0"
+version = "0.114.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4aca921dd422e781409de0129c255768fec5dec1dae83239b497fb9138abb89"
+checksum = "29cb4018f5bf59fb53f515fa9d80e6f8c5ce19f198dc538984ebd23ecf8965ec"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.113.0"
+version = "0.114.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2d770e6605eccee15b49decdd82cd26f2b6404767802471459ea49c57379a98"
+checksum = "305399fd781a2953ac78c1396f02ff53144f39c33eb7fc7789cf4e8936d13a96"
 dependencies = [
  "cranelift-bitset",
  "serde",
@@ -2418,9 +2419,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.113.0"
+version = "0.114.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29268711cb889cb39215b10faf88b9087d4c9e1d2633581e4f722a2bf4bb4ef9"
+checksum = "9230b460a128d53653456137751d27baf567947a3ab8c0c4d6e31fd08036d81e"
 dependencies = [
  "cranelift-codegen",
  "log",
@@ -2430,15 +2431,15 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.113.0"
+version = "0.114.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc65156f010aed1985767ad1bff0eb8d186743b7b03e23d0c17604a253e3f356"
+checksum = "b961e24ae3ec9813a24a15ae64bbd2a42e4de4d79a7f3225a412e3b94e78d1c8"
 
 [[package]]
 name = "cranelift-native"
-version = "0.113.0"
+version = "0.114.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8bf9b361eaf5a7627647270fabf1dc910d993edbeaf272a652c107861ebe9c2"
+checksum = "4d5bd76df6c9151188dfa428c863b33da5b34561b67f43c0cf3f24a794f9fa1f"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -8566,7 +8567,7 @@ checksum = "0c1318b19085f08681016926435853bbf7858f9c082d0999b80550ff5d9abe15"
 dependencies = [
  "bytes",
  "heck 0.5.0",
- "itertools 0.11.0",
+ "itertools 0.12.0",
  "log",
  "multimap",
  "once_cell",
@@ -8599,7 +8600,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9552f850d5f0964a4e4d0bf306459ac29323ddfbae05e35a7c0d35cb0803cc5"
 dependencies = [
  "anyhow",
- "itertools 0.11.0",
+ "itertools 0.12.0",
  "proc-macro2",
  "quote",
  "syn 2.0.87",
@@ -8676,9 +8677,9 @@ dependencies = [
 
 [[package]]
 name = "pulley-interpreter"
-version = "26.0.0"
+version = "27.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d68c610ff29655a42eeef41a5b5346e714586971a7d927739477e552fe7e23e3"
+checksum = "a3b8d81cf799e20564931e9867ca32de545188c6ee4c2e0f6e41d32f0c7dc6fb"
 dependencies = [
  "cranelift-bitset",
  "log",
@@ -12354,11 +12355,12 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.218.0"
+version = "0.219.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22b896fa8ceb71091ace9bcb81e853f54043183a1c9667cf93422c40252ffa0a"
+checksum = "29cbbd772edcb8e7d524a82ee8cef8dd046fc14033796a754c3ad246d019fa54"
 dependencies = [
  "leb128",
+ "wasmparser 0.219.1",
 ]
 
 [[package]]
@@ -12430,9 +12432,9 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.218.0"
+version = "0.219.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b09e46c7fceceaa72b2dd1a8a137ea7fd8f93dfaa69806010a709918e496c5dc"
+checksum = "5c771866898879073c53b565a6c7b49953795159836714ac56a5befb581227c5"
 dependencies = [
  "ahash 0.8.11",
  "bitflags 2.6.0",
@@ -12455,20 +12457,20 @@ dependencies = [
 
 [[package]]
 name = "wasmprinter"
-version = "0.218.0"
+version = "0.219.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ace089155491837b75f474bf47c99073246d1b737393fe722d6dee311595ddc"
+checksum = "228cdc1f30c27816da225d239ce4231f28941147d34713dee8f1fff7cb330e54"
 dependencies = [
  "anyhow",
  "termcolor",
- "wasmparser 0.218.0",
+ "wasmparser 0.219.1",
 ]
 
 [[package]]
 name = "wasmtime"
-version = "26.0.0"
+version = "27.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ffa3230b9ba1ab6568d116df21bf4ca55ed2bfac87723d910471d30d9656ea1"
+checksum = "5b79302e3e084713249cc5622e8608e7410afdeeea8c8026d04f491d1fab0b4b"
 dependencies = [
  "anyhow",
  "bitflags 2.6.0",
@@ -12495,7 +12497,7 @@ dependencies = [
  "smallvec",
  "sptr",
  "target-lexicon",
- "wasmparser 0.218.0",
+ "wasmparser 0.219.1",
  "wasmtime-asm-macros",
  "wasmtime-component-macro",
  "wasmtime-cranelift",
@@ -12508,18 +12510,18 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-asm-macros"
-version = "26.0.0"
+version = "27.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef15fad08bbaa0e5c5539b76fa5965ca25e24f17a584f83a40b43ba9a2b36f44"
+checksum = "fe53a24e7016a5222875d8ca3ad6024b464465985693c42098cd0bb710002c28"
 dependencies = [
  "cfg-if 1.0.0",
 ]
 
 [[package]]
 name = "wasmtime-component-macro"
-version = "26.0.0"
+version = "27.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23fb4e179f424260d0739c09d3bc83d34347a55d291d10dcb5244686a75c7733"
+checksum = "e118acbd2bc09b32ad8606bc7cef793bf5019c1b107772e64dc6c76b5055d40b"
 dependencies = [
  "anyhow",
  "proc-macro2",
@@ -12532,15 +12534,15 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-component-util"
-version = "26.0.0"
+version = "27.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfe3c27d64af5f584014db9381c081223d27a57e1dce2f6280bbafea37575619"
+checksum = "4a6db4f3ee18c699629eabb9c64e77efe5a93a5137f098db7cab295037ba41c2"
 
 [[package]]
 name = "wasmtime-cranelift"
-version = "26.0.0"
+version = "27.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb56d9ee4a093509624bd0861888cd111f6530e16969a68bb12dc7dd7a2be27f"
+checksum = "8b87e6c78f562b50aff1afd87ff32a57e241424c846c1c8f3c5fd352d2d62906"
 dependencies = [
  "anyhow",
  "cfg-if 1.0.0",
@@ -12556,16 +12558,16 @@ dependencies = [
  "smallvec",
  "target-lexicon",
  "thiserror 1.0.68",
- "wasmparser 0.218.0",
+ "wasmparser 0.219.1",
  "wasmtime-environ",
  "wasmtime-versioned-export-macros",
 ]
 
 [[package]]
 name = "wasmtime-environ"
-version = "26.0.0"
+version = "27.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3444c1759d5b906ff76a3cab073dd92135bdd06e5d1f46635ec40a58207d314"
+checksum = "c25bfeaa16432d59a0706e2463d315ef4c9ebcfaf5605670b99d46373bdf9f27"
 dependencies = [
  "anyhow",
  "cranelift-bitset",
@@ -12579,16 +12581,16 @@ dependencies = [
  "serde_derive",
  "smallvec",
  "target-lexicon",
- "wasm-encoder 0.218.0",
- "wasmparser 0.218.0",
- "wasmprinter 0.218.0",
+ "wasm-encoder 0.219.1",
+ "wasmparser 0.219.1",
+ "wasmprinter 0.219.1",
 ]
 
 [[package]]
 name = "wasmtime-jit-icache-coherence"
-version = "26.0.0"
+version = "27.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e458e6a1a010a53f86ac8d75837c0c6b2ce3e54b7503b2f1dc5629a4a541f5a"
+checksum = "91b218a92866f74f35162f5d03a4e0f62cd0e1cc624285b1014275e5d4575fad"
 dependencies = [
  "anyhow",
  "cfg-if 1.0.0",
@@ -12598,15 +12600,15 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-slab"
-version = "26.0.0"
+version = "27.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "339c9a2a62b989a3184baff31be3a5b5256ad52629634eb432f9ccf0ab251f83"
+checksum = "4d5f8acf677ee6b3b8ba400dd9753ea4769e56a95c4b30b045ac6d2d54b2f8ea"
 
 [[package]]
 name = "wasmtime-versioned-export-macros"
-version = "26.0.0"
+version = "27.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abe01058e422966659e1af00af833147d54658b07c7e74606d73ca9af3f1690a"
+checksum = "df09be00c38f49172ca9936998938476e3f2df782673a39ae2ef9fb0838341b6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12615,9 +12617,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wit-bindgen"
-version = "26.0.0"
+version = "27.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c9e85935a1199e96b73e7fcd27a127035d2082265720a67d59268a24892d567"
+checksum = "bf3963c9c29df91564d8bd181eb00d0dbaeafa1b2a01e15952bb7391166b704e"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
@@ -13041,9 +13043,9 @@ dependencies = [
 
 [[package]]
 name = "wit-parser"
-version = "0.218.0"
+version = "0.219.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d3d1066ab761b115f97fef2b191090faabcb0f37b555b758d3caf42d4ed9e55"
+checksum = "4a86f669283257e8e424b9a4fc3518e3ade0b95deb9fbc0f93a1876be3eda598"
 dependencies = [
  "anyhow",
  "id-arena",
@@ -13054,7 +13056,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "unicode-xid",
- "wasmparser 0.218.0",
+ "wasmparser 0.219.1",
 ]
 
 [[package]]

--- a/Cargo.Bazel.json.lock
+++ b/Cargo.Bazel.json.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "7e7fc08d04386a15716037351beec07fdfb1567d38a6b187ad38bb0a0f5412d1",
+  "checksum": "6fe3acd7d34fb9438b36f7ec483d8e3f6f4e0a9ba130dc790a394422c002a555",
   "crates": {
     "abnf 0.12.0": {
       "name": "abnf",
@@ -6248,7 +6248,7 @@
               "target": "clang_sys"
             },
             {
-              "id": "itertools 0.11.0",
+              "id": "itertools 0.12.0",
               "target": "itertools"
             },
             {
@@ -14056,14 +14056,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "cranelift-bforest 0.113.0": {
+    "cranelift-bforest 0.114.0": {
       "name": "cranelift-bforest",
-      "version": "0.113.0",
+      "version": "0.114.0",
       "package_url": "https://github.com/bytecodealliance/wasmtime",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/cranelift-bforest/0.113.0/download",
-          "sha256": "8ea5e7afe85cadb55c4c1176268a2ac046fdff8dfaeca39e18581b9dc319ca9e"
+          "url": "https://static.crates.io/crates/cranelift-bforest/0.114.0/download",
+          "sha256": "2ba4f80548f22dc9c43911907b5e322c5555544ee85f785115701e6a28c9abe1"
         }
       },
       "targets": [
@@ -14088,14 +14088,14 @@
         "deps": {
           "common": [
             {
-              "id": "cranelift-entity 0.113.0",
+              "id": "cranelift-entity 0.114.0",
               "target": "cranelift_entity"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.113.0"
+        "version": "0.114.0"
       },
       "license": "Apache-2.0 WITH LLVM-exception",
       "license_ids": [
@@ -14103,14 +14103,14 @@
       ],
       "license_file": "LICENSE"
     },
-    "cranelift-bitset 0.113.0": {
+    "cranelift-bitset 0.114.0": {
       "name": "cranelift-bitset",
-      "version": "0.113.0",
+      "version": "0.114.0",
       "package_url": "https://github.com/bytecodealliance/wasmtime",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/cranelift-bitset/0.113.0/download",
-          "sha256": "8ab25ef3be935a80680e393183e1f94ef507e93a24a8369494d2c6818aedb3e3"
+          "url": "https://static.crates.io/crates/cranelift-bitset/0.114.0/download",
+          "sha256": "005884e3649c3e5ff2dc79e8a94b138f11569cc08a91244a292714d2a86e9156"
         }
       },
       "targets": [
@@ -14157,7 +14157,7 @@
           ],
           "selects": {}
         },
-        "version": "0.113.0"
+        "version": "0.114.0"
       },
       "license": "Apache-2.0 WITH LLVM-exception",
       "license_ids": [
@@ -14165,14 +14165,14 @@
       ],
       "license_file": null
     },
-    "cranelift-codegen 0.113.0": {
+    "cranelift-codegen 0.114.0": {
       "name": "cranelift-codegen",
-      "version": "0.113.0",
+      "version": "0.114.0",
       "package_url": "https://github.com/bytecodealliance/wasmtime",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/cranelift-codegen/0.113.0/download",
-          "sha256": "900a19b84545924f1851cbfe386962edfc4ecbc3366a254825cf1ecbcda8ba08"
+          "url": "https://static.crates.io/crates/cranelift-codegen/0.114.0/download",
+          "sha256": "fe4036255ec33ce9a37495dfbcfc4e1118fd34e693eff9a1e106336b7cd16a9b"
         }
       },
       "targets": [
@@ -14223,27 +14223,27 @@
               "target": "bumpalo"
             },
             {
-              "id": "cranelift-bforest 0.113.0",
+              "id": "cranelift-bforest 0.114.0",
               "target": "cranelift_bforest"
             },
             {
-              "id": "cranelift-bitset 0.113.0",
+              "id": "cranelift-bitset 0.114.0",
               "target": "cranelift_bitset"
             },
             {
-              "id": "cranelift-codegen 0.113.0",
+              "id": "cranelift-codegen 0.114.0",
               "target": "build_script_build"
             },
             {
-              "id": "cranelift-codegen-shared 0.113.0",
+              "id": "cranelift-codegen-shared 0.114.0",
               "target": "cranelift_codegen_shared"
             },
             {
-              "id": "cranelift-control 0.113.0",
+              "id": "cranelift-control 0.114.0",
               "target": "cranelift_control"
             },
             {
-              "id": "cranelift-entity 0.113.0",
+              "id": "cranelift-entity 0.114.0",
               "target": "cranelift_entity"
             },
             {
@@ -14278,7 +14278,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.113.0"
+        "version": "0.114.0"
       },
       "build_script_attrs": {
         "compile_data_glob": [
@@ -14290,11 +14290,11 @@
         "deps": {
           "common": [
             {
-              "id": "cranelift-codegen-meta 0.113.0",
+              "id": "cranelift-codegen-meta 0.114.0",
               "target": "cranelift_codegen_meta"
             },
             {
-              "id": "cranelift-isle 0.113.0",
+              "id": "cranelift-isle 0.114.0",
               "target": "cranelift_isle"
             }
           ],
@@ -14307,14 +14307,14 @@
       ],
       "license_file": "LICENSE"
     },
-    "cranelift-codegen-meta 0.113.0": {
+    "cranelift-codegen-meta 0.114.0": {
       "name": "cranelift-codegen-meta",
-      "version": "0.113.0",
+      "version": "0.114.0",
       "package_url": "https://github.com/bytecodealliance/wasmtime",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/cranelift-codegen-meta/0.113.0/download",
-          "sha256": "08c73b2395ffe9e7b4fdf7e2ebc052e7e27af13f68a964985346be4da477a5fc",
+          "url": "https://static.crates.io/crates/cranelift-codegen-meta/0.114.0/download",
+          "sha256": "f7ca74f4b68319da11d39e894437cb6e20ec7c2e11fbbda823c3bf207beedff7",
           "patch_args": [
             "-p4"
           ],
@@ -14345,14 +14345,14 @@
         "deps": {
           "common": [
             {
-              "id": "cranelift-codegen-shared 0.113.0",
+              "id": "cranelift-codegen-shared 0.114.0",
               "target": "cranelift_codegen_shared"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.113.0"
+        "version": "0.114.0"
       },
       "license": "Apache-2.0 WITH LLVM-exception",
       "license_ids": [
@@ -14360,14 +14360,14 @@
       ],
       "license_file": "LICENSE"
     },
-    "cranelift-codegen-shared 0.113.0": {
+    "cranelift-codegen-shared 0.114.0": {
       "name": "cranelift-codegen-shared",
-      "version": "0.113.0",
+      "version": "0.114.0",
       "package_url": "https://github.com/bytecodealliance/wasmtime",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/cranelift-codegen-shared/0.113.0/download",
-          "sha256": "7d9ed0854e96a4ff0879bff39d078de8dea7f002721c9494c1fdb4e1baa86ccc"
+          "url": "https://static.crates.io/crates/cranelift-codegen-shared/0.114.0/download",
+          "sha256": "897e54f433a0269c4187871aa06d452214d5515d228d5bdc22219585e9eef895"
         }
       },
       "targets": [
@@ -14390,7 +14390,7 @@
           "**"
         ],
         "edition": "2021",
-        "version": "0.113.0"
+        "version": "0.114.0"
       },
       "license": "Apache-2.0 WITH LLVM-exception",
       "license_ids": [
@@ -14398,14 +14398,14 @@
       ],
       "license_file": "LICENSE"
     },
-    "cranelift-control 0.113.0": {
+    "cranelift-control 0.114.0": {
       "name": "cranelift-control",
-      "version": "0.113.0",
+      "version": "0.114.0",
       "package_url": "https://github.com/bytecodealliance/wasmtime",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/cranelift-control/0.113.0/download",
-          "sha256": "b4aca921dd422e781409de0129c255768fec5dec1dae83239b497fb9138abb89"
+          "url": "https://static.crates.io/crates/cranelift-control/0.114.0/download",
+          "sha256": "29cb4018f5bf59fb53f515fa9d80e6f8c5ce19f198dc538984ebd23ecf8965ec"
         }
       },
       "targets": [
@@ -14444,7 +14444,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.113.0"
+        "version": "0.114.0"
       },
       "license": "Apache-2.0 WITH LLVM-exception",
       "license_ids": [
@@ -14452,14 +14452,14 @@
       ],
       "license_file": "LICENSE"
     },
-    "cranelift-entity 0.113.0": {
+    "cranelift-entity 0.114.0": {
       "name": "cranelift-entity",
-      "version": "0.113.0",
+      "version": "0.114.0",
       "package_url": "https://github.com/bytecodealliance/wasmtime",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/cranelift-entity/0.113.0/download",
-          "sha256": "e2d770e6605eccee15b49decdd82cd26f2b6404767802471459ea49c57379a98"
+          "url": "https://static.crates.io/crates/cranelift-entity/0.114.0/download",
+          "sha256": "305399fd781a2953ac78c1396f02ff53144f39c33eb7fc7789cf4e8936d13a96"
         }
       },
       "targets": [
@@ -14492,7 +14492,7 @@
         "deps": {
           "common": [
             {
-              "id": "cranelift-bitset 0.113.0",
+              "id": "cranelift-bitset 0.114.0",
               "target": "cranelift_bitset"
             },
             {
@@ -14512,7 +14512,7 @@
           ],
           "selects": {}
         },
-        "version": "0.113.0"
+        "version": "0.114.0"
       },
       "license": "Apache-2.0 WITH LLVM-exception",
       "license_ids": [
@@ -14520,14 +14520,14 @@
       ],
       "license_file": "LICENSE"
     },
-    "cranelift-frontend 0.113.0": {
+    "cranelift-frontend 0.114.0": {
       "name": "cranelift-frontend",
-      "version": "0.113.0",
+      "version": "0.114.0",
       "package_url": "https://github.com/bytecodealliance/wasmtime",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/cranelift-frontend/0.113.0/download",
-          "sha256": "29268711cb889cb39215b10faf88b9087d4c9e1d2633581e4f722a2bf4bb4ef9"
+          "url": "https://static.crates.io/crates/cranelift-frontend/0.114.0/download",
+          "sha256": "9230b460a128d53653456137751d27baf567947a3ab8c0c4d6e31fd08036d81e"
         }
       },
       "targets": [
@@ -14559,7 +14559,7 @@
         "deps": {
           "common": [
             {
-              "id": "cranelift-codegen 0.113.0",
+              "id": "cranelift-codegen 0.114.0",
               "target": "cranelift_codegen"
             },
             {
@@ -14578,7 +14578,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.113.0"
+        "version": "0.114.0"
       },
       "license": "Apache-2.0 WITH LLVM-exception",
       "license_ids": [
@@ -14586,14 +14586,14 @@
       ],
       "license_file": "LICENSE"
     },
-    "cranelift-isle 0.113.0": {
+    "cranelift-isle 0.114.0": {
       "name": "cranelift-isle",
-      "version": "0.113.0",
+      "version": "0.114.0",
       "package_url": "https://github.com/bytecodealliance/wasmtime/tree/main/cranelift/isle",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/cranelift-isle/0.113.0/download",
-          "sha256": "dc65156f010aed1985767ad1bff0eb8d186743b7b03e23d0c17604a253e3f356",
+          "url": "https://static.crates.io/crates/cranelift-isle/0.114.0/download",
+          "sha256": "b961e24ae3ec9813a24a15ae64bbd2a42e4de4d79a7f3225a412e3b94e78d1c8",
           "patch_args": [
             "-p4"
           ],
@@ -14642,14 +14642,14 @@
         "deps": {
           "common": [
             {
-              "id": "cranelift-isle 0.113.0",
+              "id": "cranelift-isle 0.114.0",
               "target": "build_script_build"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.113.0"
+        "version": "0.114.0"
       },
       "build_script_attrs": {
         "compile_data_glob": [
@@ -14665,14 +14665,14 @@
       ],
       "license_file": null
     },
-    "cranelift-native 0.113.0": {
+    "cranelift-native 0.114.0": {
       "name": "cranelift-native",
-      "version": "0.113.0",
+      "version": "0.114.0",
       "package_url": "https://github.com/bytecodealliance/wasmtime",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/cranelift-native/0.113.0/download",
-          "sha256": "d8bf9b361eaf5a7627647270fabf1dc910d993edbeaf272a652c107861ebe9c2"
+          "url": "https://static.crates.io/crates/cranelift-native/0.114.0/download",
+          "sha256": "4d5bd76df6c9151188dfa428c863b33da5b34561b67f43c0cf3f24a794f9fa1f"
         }
       },
       "targets": [
@@ -14704,7 +14704,7 @@
         "deps": {
           "common": [
             {
-              "id": "cranelift-codegen 0.113.0",
+              "id": "cranelift-codegen 0.114.0",
               "target": "cranelift_codegen"
             },
             {
@@ -14722,7 +14722,7 @@
           }
         },
         "edition": "2021",
-        "version": "0.113.0"
+        "version": "0.114.0"
       },
       "license": "Apache-2.0 WITH LLVM-exception",
       "license_ids": [
@@ -19479,11 +19479,11 @@
               "target": "wasmprinter"
             },
             {
-              "id": "wasmtime 26.0.0",
+              "id": "wasmtime 27.0.0",
               "target": "wasmtime"
             },
             {
-              "id": "wasmtime-environ 26.0.0",
+              "id": "wasmtime-environ 27.0.0",
               "target": "wasmtime_environ"
             },
             {
@@ -52477,7 +52477,7 @@
               "target": "heck"
             },
             {
-              "id": "itertools 0.11.0",
+              "id": "itertools 0.12.0",
               "target": "itertools"
             },
             {
@@ -52631,7 +52631,7 @@
               "target": "anyhow"
             },
             {
-              "id": "itertools 0.11.0",
+              "id": "itertools 0.12.0",
               "target": "itertools"
             },
             {
@@ -53104,14 +53104,14 @@
       ],
       "license_file": "LICENSE"
     },
-    "pulley-interpreter 26.0.0": {
+    "pulley-interpreter 27.0.0": {
       "name": "pulley-interpreter",
-      "version": "26.0.0",
+      "version": "27.0.0",
       "package_url": "https://github.com/bytecodealliance/wasmtime/tree/main/pulley",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/pulley-interpreter/26.0.0/download",
-          "sha256": "d68c610ff29655a42eeef41a5b5346e714586971a7d927739477e552fe7e23e3"
+          "url": "https://static.crates.io/crates/pulley-interpreter/27.0.0/download",
+          "sha256": "a3b8d81cf799e20564931e9867ca32de545188c6ee4c2e0f6e41d32f0c7dc6fb"
         }
       },
       "targets": [
@@ -53136,7 +53136,7 @@
         "deps": {
           "common": [
             {
-              "id": "cranelift-bitset 0.113.0",
+              "id": "cranelift-bitset 0.114.0",
               "target": "cranelift_bitset"
             },
             {
@@ -53151,7 +53151,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "26.0.0"
+        "version": "27.0.0"
       },
       "license": "Apache-2.0 WITH LLVM-exception",
       "license_ids": [
@@ -79690,14 +79690,14 @@
       ],
       "license_file": null
     },
-    "wasm-encoder 0.218.0": {
+    "wasm-encoder 0.219.1": {
       "name": "wasm-encoder",
-      "version": "0.218.0",
+      "version": "0.219.1",
       "package_url": "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasm-encoder",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/wasm-encoder/0.218.0/download",
-          "sha256": "22b896fa8ceb71091ace9bcb81e853f54043183a1c9667cf93422c40252ffa0a"
+          "url": "https://static.crates.io/crates/wasm-encoder/0.219.1/download",
+          "sha256": "29cbbd772edcb8e7d524a82ee8cef8dd046fc14033796a754c3ad246d019fa54"
         }
       },
       "targets": [
@@ -79719,6 +79719,13 @@
         "compile_data_glob": [
           "**"
         ],
+        "crate_features": {
+          "common": [
+            "component-model",
+            "default"
+          ],
+          "selects": {}
+        },
         "deps": {
           "common": [
             {
@@ -79729,7 +79736,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.218.0"
+        "version": "0.219.1"
       },
       "license": "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT",
       "license_ids": [
@@ -80088,14 +80095,14 @@
       ],
       "license_file": null
     },
-    "wasmparser 0.218.0": {
+    "wasmparser 0.219.1": {
       "name": "wasmparser",
-      "version": "0.218.0",
+      "version": "0.219.1",
       "package_url": "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasmparser",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/wasmparser/0.218.0/download",
-          "sha256": "b09e46c7fceceaa72b2dd1a8a137ea7fd8f93dfaa69806010a709918e496c5dc"
+          "url": "https://static.crates.io/crates/wasmparser/0.219.1/download",
+          "sha256": "5c771866898879073c53b565a6c7b49953795159836714ac56a5befb581227c5"
         }
       },
       "targets": [
@@ -80119,6 +80126,7 @@
         ],
         "crate_features": {
           "common": [
+            "component-model",
             "features",
             "serde",
             "std",
@@ -80156,7 +80164,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.218.0"
+        "version": "0.219.1"
       },
       "license": "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT",
       "license_ids": [
@@ -80221,14 +80229,14 @@
       ],
       "license_file": null
     },
-    "wasmprinter 0.218.0": {
+    "wasmprinter 0.219.1": {
       "name": "wasmprinter",
-      "version": "0.218.0",
+      "version": "0.219.1",
       "package_url": "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasmprinter",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/wasmprinter/0.218.0/download",
-          "sha256": "0ace089155491837b75f474bf47c99073246d1b737393fe722d6dee311595ddc"
+          "url": "https://static.crates.io/crates/wasmprinter/0.219.1/download",
+          "sha256": "228cdc1f30c27816da225d239ce4231f28941147d34713dee8f1fff7cb330e54"
         }
       },
       "targets": [
@@ -80250,6 +80258,13 @@
         "compile_data_glob": [
           "**"
         ],
+        "crate_features": {
+          "common": [
+            "component-model",
+            "default"
+          ],
+          "selects": {}
+        },
         "deps": {
           "common": [
             {
@@ -80261,14 +80276,14 @@
               "target": "termcolor"
             },
             {
-              "id": "wasmparser 0.218.0",
+              "id": "wasmparser 0.219.1",
               "target": "wasmparser"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.218.0"
+        "version": "0.219.1"
       },
       "license": "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT",
       "license_ids": [
@@ -80277,14 +80292,14 @@
       ],
       "license_file": null
     },
-    "wasmtime 26.0.0": {
+    "wasmtime 27.0.0": {
       "name": "wasmtime",
-      "version": "26.0.0",
+      "version": "27.0.0",
       "package_url": "https://github.com/bytecodealliance/wasmtime",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/wasmtime/26.0.0/download",
-          "sha256": "5ffa3230b9ba1ab6568d116df21bf4ca55ed2bfac87723d910471d30d9656ea1"
+          "url": "https://static.crates.io/crates/wasmtime/27.0.0/download",
+          "sha256": "5b79302e3e084713249cc5622e8608e7410afdeeea8c8026d04f491d1fab0b4b"
         }
       },
       "targets": [
@@ -80322,6 +80337,8 @@
           "common": [
             "cranelift",
             "gc",
+            "gc-null",
+            "once_cell",
             "parallel-compilation",
             "runtime",
             "std"
@@ -80399,31 +80416,31 @@
               "target": "target_lexicon"
             },
             {
-              "id": "wasmparser 0.218.0",
+              "id": "wasmparser 0.219.1",
               "target": "wasmparser"
             },
             {
-              "id": "wasmtime 26.0.0",
+              "id": "wasmtime 27.0.0",
               "target": "build_script_build"
             },
             {
-              "id": "wasmtime-asm-macros 26.0.0",
+              "id": "wasmtime-asm-macros 27.0.0",
               "target": "wasmtime_asm_macros"
             },
             {
-              "id": "wasmtime-cranelift 26.0.0",
+              "id": "wasmtime-cranelift 27.0.0",
               "target": "wasmtime_cranelift"
             },
             {
-              "id": "wasmtime-environ 26.0.0",
+              "id": "wasmtime-environ 27.0.0",
               "target": "wasmtime_environ"
             },
             {
-              "id": "wasmtime-jit-icache-coherence 26.0.0",
+              "id": "wasmtime-jit-icache-coherence 27.0.0",
               "target": "wasmtime_jit_icache_coherence"
             },
             {
-              "id": "wasmtime-slab 26.0.0",
+              "id": "wasmtime-slab 27.0.0",
               "target": "wasmtime_slab"
             }
           ],
@@ -80656,13 +80673,13 @@
               "target": "serde_derive"
             },
             {
-              "id": "wasmtime-versioned-export-macros 26.0.0",
+              "id": "wasmtime-versioned-export-macros 27.0.0",
               "target": "wasmtime_versioned_export_macros"
             }
           ],
           "selects": {}
         },
-        "version": "26.0.0"
+        "version": "27.0.0"
       },
       "build_script_attrs": {
         "compile_data_glob": [
@@ -80683,7 +80700,7 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "wasmtime-versioned-export-macros 26.0.0",
+              "id": "wasmtime-versioned-export-macros 27.0.0",
               "target": "wasmtime_versioned_export_macros"
             }
           ],
@@ -80696,14 +80713,14 @@
       ],
       "license_file": "LICENSE"
     },
-    "wasmtime-asm-macros 26.0.0": {
+    "wasmtime-asm-macros 27.0.0": {
       "name": "wasmtime-asm-macros",
-      "version": "26.0.0",
+      "version": "27.0.0",
       "package_url": "https://github.com/bytecodealliance/wasmtime",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/wasmtime-asm-macros/26.0.0/download",
-          "sha256": "ef15fad08bbaa0e5c5539b76fa5965ca25e24f17a584f83a40b43ba9a2b36f44"
+          "url": "https://static.crates.io/crates/wasmtime-asm-macros/27.0.0/download",
+          "sha256": "fe53a24e7016a5222875d8ca3ad6024b464465985693c42098cd0bb710002c28"
         }
       },
       "targets": [
@@ -80735,7 +80752,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "26.0.0"
+        "version": "27.0.0"
       },
       "license": "Apache-2.0 WITH LLVM-exception",
       "license_ids": [
@@ -80743,14 +80760,14 @@
       ],
       "license_file": null
     },
-    "wasmtime-component-macro 26.0.0": {
+    "wasmtime-component-macro 27.0.0": {
       "name": "wasmtime-component-macro",
-      "version": "26.0.0",
+      "version": "27.0.0",
       "package_url": "https://github.com/bytecodealliance/wasmtime",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/wasmtime-component-macro/26.0.0/download",
-          "sha256": "23fb4e179f424260d0739c09d3bc83d34347a55d291d10dcb5244686a75c7733"
+          "url": "https://static.crates.io/crates/wasmtime-component-macro/27.0.0/download",
+          "sha256": "e118acbd2bc09b32ad8606bc7cef793bf5019c1b107772e64dc6c76b5055d40b"
         }
       },
       "targets": [
@@ -80803,26 +80820,26 @@
               "target": "syn"
             },
             {
-              "id": "wasmtime-component-macro 26.0.0",
+              "id": "wasmtime-component-macro 27.0.0",
               "target": "build_script_build"
             },
             {
-              "id": "wasmtime-component-util 26.0.0",
+              "id": "wasmtime-component-util 27.0.0",
               "target": "wasmtime_component_util"
             },
             {
-              "id": "wasmtime-wit-bindgen 26.0.0",
+              "id": "wasmtime-wit-bindgen 27.0.0",
               "target": "wasmtime_wit_bindgen"
             },
             {
-              "id": "wit-parser 0.218.0",
+              "id": "wit-parser 0.219.1",
               "target": "wit_parser"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "26.0.0"
+        "version": "27.0.0"
       },
       "build_script_attrs": {
         "compile_data_glob": [
@@ -80838,14 +80855,14 @@
       ],
       "license_file": null
     },
-    "wasmtime-component-util 26.0.0": {
+    "wasmtime-component-util 27.0.0": {
       "name": "wasmtime-component-util",
-      "version": "26.0.0",
+      "version": "27.0.0",
       "package_url": "https://github.com/bytecodealliance/wasmtime",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/wasmtime-component-util/26.0.0/download",
-          "sha256": "cfe3c27d64af5f584014db9381c081223d27a57e1dce2f6280bbafea37575619"
+          "url": "https://static.crates.io/crates/wasmtime-component-util/27.0.0/download",
+          "sha256": "4a6db4f3ee18c699629eabb9c64e77efe5a93a5137f098db7cab295037ba41c2"
         }
       },
       "targets": [
@@ -80868,7 +80885,7 @@
           "**"
         ],
         "edition": "2021",
-        "version": "26.0.0"
+        "version": "27.0.0"
       },
       "license": "Apache-2.0 WITH LLVM-exception",
       "license_ids": [
@@ -80876,14 +80893,14 @@
       ],
       "license_file": null
     },
-    "wasmtime-cranelift 26.0.0": {
+    "wasmtime-cranelift 27.0.0": {
       "name": "wasmtime-cranelift",
-      "version": "26.0.0",
+      "version": "27.0.0",
       "package_url": "https://github.com/bytecodealliance/wasmtime",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/wasmtime-cranelift/26.0.0/download",
-          "sha256": "eb56d9ee4a093509624bd0861888cd111f6530e16969a68bb12dc7dd7a2be27f"
+          "url": "https://static.crates.io/crates/wasmtime-cranelift/27.0.0/download",
+          "sha256": "8b87e6c78f562b50aff1afd87ff32a57e241424c846c1c8f3c5fd352d2d62906"
         }
       },
       "targets": [
@@ -80907,7 +80924,8 @@
         ],
         "crate_features": {
           "common": [
-            "gc"
+            "gc",
+            "gc-null"
           ],
           "selects": {}
         },
@@ -80922,23 +80940,23 @@
               "target": "cfg_if"
             },
             {
-              "id": "cranelift-codegen 0.113.0",
+              "id": "cranelift-codegen 0.114.0",
               "target": "cranelift_codegen"
             },
             {
-              "id": "cranelift-control 0.113.0",
+              "id": "cranelift-control 0.114.0",
               "target": "cranelift_control"
             },
             {
-              "id": "cranelift-entity 0.113.0",
+              "id": "cranelift-entity 0.114.0",
               "target": "cranelift_entity"
             },
             {
-              "id": "cranelift-frontend 0.113.0",
+              "id": "cranelift-frontend 0.114.0",
               "target": "cranelift_frontend"
             },
             {
-              "id": "cranelift-native 0.113.0",
+              "id": "cranelift-native 0.114.0",
               "target": "cranelift_native"
             },
             {
@@ -80970,11 +80988,11 @@
               "target": "thiserror"
             },
             {
-              "id": "wasmparser 0.218.0",
+              "id": "wasmparser 0.219.1",
               "target": "wasmparser"
             },
             {
-              "id": "wasmtime-environ 26.0.0",
+              "id": "wasmtime-environ 27.0.0",
               "target": "wasmtime_environ"
             }
           ],
@@ -80984,13 +81002,13 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "wasmtime-versioned-export-macros 26.0.0",
+              "id": "wasmtime-versioned-export-macros 27.0.0",
               "target": "wasmtime_versioned_export_macros"
             }
           ],
           "selects": {}
         },
-        "version": "26.0.0"
+        "version": "27.0.0"
       },
       "license": "Apache-2.0 WITH LLVM-exception",
       "license_ids": [
@@ -80998,14 +81016,14 @@
       ],
       "license_file": "LICENSE"
     },
-    "wasmtime-environ 26.0.0": {
+    "wasmtime-environ 27.0.0": {
       "name": "wasmtime-environ",
-      "version": "26.0.0",
+      "version": "27.0.0",
       "package_url": "https://github.com/bytecodealliance/wasmtime",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/wasmtime-environ/26.0.0/download",
-          "sha256": "f3444c1759d5b906ff76a3cab073dd92135bdd06e5d1f46635ec40a58207d314"
+          "url": "https://static.crates.io/crates/wasmtime-environ/27.0.0/download",
+          "sha256": "c25bfeaa16432d59a0706e2463d315ef4c9ebcfaf5605670b99d46373bdf9f27"
         }
       },
       "targets": [
@@ -81031,6 +81049,7 @@
           "common": [
             "compile",
             "gc",
+            "gc-null",
             "std"
           ],
           "selects": {}
@@ -81042,11 +81061,11 @@
               "target": "anyhow"
             },
             {
-              "id": "cranelift-bitset 0.113.0",
+              "id": "cranelift-bitset 0.114.0",
               "target": "cranelift_bitset"
             },
             {
-              "id": "cranelift-entity 0.113.0",
+              "id": "cranelift-entity 0.114.0",
               "target": "cranelift_entity"
             },
             {
@@ -81082,15 +81101,15 @@
               "target": "target_lexicon"
             },
             {
-              "id": "wasm-encoder 0.218.0",
+              "id": "wasm-encoder 0.219.1",
               "target": "wasm_encoder"
             },
             {
-              "id": "wasmparser 0.218.0",
+              "id": "wasmparser 0.219.1",
               "target": "wasmparser"
             },
             {
-              "id": "wasmprinter 0.218.0",
+              "id": "wasmprinter 0.219.1",
               "target": "wasmprinter"
             }
           ],
@@ -81106,7 +81125,7 @@
           ],
           "selects": {}
         },
-        "version": "26.0.0"
+        "version": "27.0.0"
       },
       "license": "Apache-2.0 WITH LLVM-exception",
       "license_ids": [
@@ -81114,14 +81133,14 @@
       ],
       "license_file": "LICENSE"
     },
-    "wasmtime-jit-icache-coherence 26.0.0": {
+    "wasmtime-jit-icache-coherence 27.0.0": {
       "name": "wasmtime-jit-icache-coherence",
-      "version": "26.0.0",
+      "version": "27.0.0",
       "package_url": "https://github.com/bytecodealliance/wasmtime",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/wasmtime-jit-icache-coherence/26.0.0/download",
-          "sha256": "6e458e6a1a010a53f86ac8d75837c0c6b2ce3e54b7503b2f1dc5629a4a541f5a"
+          "url": "https://static.crates.io/crates/wasmtime-jit-icache-coherence/27.0.0/download",
+          "sha256": "91b218a92866f74f35162f5d03a4e0f62cd0e1cc624285b1014275e5d4575fad"
         }
       },
       "targets": [
@@ -81170,7 +81189,7 @@
           }
         },
         "edition": "2021",
-        "version": "26.0.0"
+        "version": "27.0.0"
       },
       "license": "Apache-2.0 WITH LLVM-exception",
       "license_ids": [
@@ -81178,14 +81197,14 @@
       ],
       "license_file": null
     },
-    "wasmtime-slab 26.0.0": {
+    "wasmtime-slab 27.0.0": {
       "name": "wasmtime-slab",
-      "version": "26.0.0",
+      "version": "27.0.0",
       "package_url": "https://github.com/bytecodealliance/wasmtime",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/wasmtime-slab/26.0.0/download",
-          "sha256": "339c9a2a62b989a3184baff31be3a5b5256ad52629634eb432f9ccf0ab251f83"
+          "url": "https://static.crates.io/crates/wasmtime-slab/27.0.0/download",
+          "sha256": "4d5f8acf677ee6b3b8ba400dd9753ea4769e56a95c4b30b045ac6d2d54b2f8ea"
         }
       },
       "targets": [
@@ -81208,7 +81227,7 @@
           "**"
         ],
         "edition": "2021",
-        "version": "26.0.0"
+        "version": "27.0.0"
       },
       "license": "Apache-2.0 WITH LLVM-exception",
       "license_ids": [
@@ -81216,14 +81235,14 @@
       ],
       "license_file": null
     },
-    "wasmtime-versioned-export-macros 26.0.0": {
+    "wasmtime-versioned-export-macros 27.0.0": {
       "name": "wasmtime-versioned-export-macros",
-      "version": "26.0.0",
+      "version": "27.0.0",
       "package_url": "https://github.com/bytecodealliance/wasmtime",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/wasmtime-versioned-export-macros/26.0.0/download",
-          "sha256": "abe01058e422966659e1af00af833147d54658b07c7e74606d73ca9af3f1690a"
+          "url": "https://static.crates.io/crates/wasmtime-versioned-export-macros/27.0.0/download",
+          "sha256": "df09be00c38f49172ca9936998938476e3f2df782673a39ae2ef9fb0838341b6"
         }
       },
       "targets": [
@@ -81263,7 +81282,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "26.0.0"
+        "version": "27.0.0"
       },
       "license": "Apache-2.0 WITH LLVM-exception",
       "license_ids": [
@@ -81271,14 +81290,14 @@
       ],
       "license_file": null
     },
-    "wasmtime-wit-bindgen 26.0.0": {
+    "wasmtime-wit-bindgen 27.0.0": {
       "name": "wasmtime-wit-bindgen",
-      "version": "26.0.0",
+      "version": "27.0.0",
       "package_url": "https://github.com/bytecodealliance/wasmtime",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/wasmtime-wit-bindgen/26.0.0/download",
-          "sha256": "1c9e85935a1199e96b73e7fcd27a127035d2082265720a67d59268a24892d567"
+          "url": "https://static.crates.io/crates/wasmtime-wit-bindgen/27.0.0/download",
+          "sha256": "bf3963c9c29df91564d8bd181eb00d0dbaeafa1b2a01e15952bb7391166b704e"
         }
       },
       "targets": [
@@ -81315,14 +81334,14 @@
               "target": "indexmap"
             },
             {
-              "id": "wit-parser 0.218.0",
+              "id": "wit-parser 0.219.1",
               "target": "wit_parser"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "26.0.0"
+        "version": "27.0.0"
       },
       "license": "Apache-2.0 WITH LLVM-exception",
       "license_ids": [
@@ -84740,14 +84759,14 @@
       ],
       "license_file": "LICENSE"
     },
-    "wit-parser 0.218.0": {
+    "wit-parser 0.219.1": {
       "name": "wit-parser",
-      "version": "0.218.0",
+      "version": "0.219.1",
       "package_url": "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wit-parser",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/wit-parser/0.218.0/download",
-          "sha256": "0d3d1066ab761b115f97fef2b191090faabcb0f37b555b758d3caf42d4ed9e55"
+          "url": "https://static.crates.io/crates/wit-parser/0.219.1/download",
+          "sha256": "4a86f669283257e8e424b9a4fc3518e3ade0b95deb9fbc0f93a1876be3eda598"
         }
       },
       "targets": [
@@ -84813,7 +84832,7 @@
               "target": "unicode_xid"
             },
             {
-              "id": "wasmparser 0.218.0",
+              "id": "wasmparser 0.219.1",
               "target": "wasmparser"
             }
           ],
@@ -84829,7 +84848,7 @@
           ],
           "selects": {}
         },
-        "version": "0.218.0"
+        "version": "0.219.1"
       },
       "license": "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT",
       "license_ids": [
@@ -87780,8 +87799,8 @@
     "wasm-smith 0.212.0",
     "wasmparser 0.217.0",
     "wasmprinter 0.217.0",
-    "wasmtime 26.0.0",
-    "wasmtime-environ 26.0.0",
+    "wasmtime 27.0.0",
+    "wasmtime-environ 27.0.0",
     "wast 212.0.0",
     "wat 1.212.0",
     "wee_alloc 0.4.5",

--- a/Cargo.Bazel.toml.lock
+++ b/Cargo.Bazel.toml.lock
@@ -1092,7 +1092,7 @@ dependencies = [
  "bitflags 2.6.0",
  "cexpr",
  "clang-sys",
- "itertools 0.11.0",
+ "itertools 0.12.0",
  "lazy_static",
  "lazycell",
  "proc-macro2",
@@ -2330,18 +2330,18 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.113.0"
+version = "0.114.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5e7afe85cadb55c4c1176268a2ac046fdff8dfaeca39e18581b9dc319ca9e"
+checksum = "2ba4f80548f22dc9c43911907b5e322c5555544ee85f785115701e6a28c9abe1"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-bitset"
-version = "0.113.0"
+version = "0.114.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ab25ef3be935a80680e393183e1f94ef507e93a24a8369494d2c6818aedb3e3"
+checksum = "005884e3649c3e5ff2dc79e8a94b138f11569cc08a91244a292714d2a86e9156"
 dependencies = [
  "serde",
  "serde_derive",
@@ -2349,9 +2349,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.113.0"
+version = "0.114.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "900a19b84545924f1851cbfe386962edfc4ecbc3366a254825cf1ecbcda8ba08"
+checksum = "fe4036255ec33ce9a37495dfbcfc4e1118fd34e693eff9a1e106336b7cd16a9b"
 dependencies = [
  "bumpalo",
  "cranelift-bforest",
@@ -2366,39 +2366,40 @@ dependencies = [
  "log",
  "regalloc2",
  "rustc-hash 2.0.0",
+ "serde",
  "smallvec",
  "target-lexicon",
 ]
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.113.0"
+version = "0.114.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08c73b2395ffe9e7b4fdf7e2ebc052e7e27af13f68a964985346be4da477a5fc"
+checksum = "f7ca74f4b68319da11d39e894437cb6e20ec7c2e11fbbda823c3bf207beedff7"
 dependencies = [
  "cranelift-codegen-shared",
 ]
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.113.0"
+version = "0.114.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d9ed0854e96a4ff0879bff39d078de8dea7f002721c9494c1fdb4e1baa86ccc"
+checksum = "897e54f433a0269c4187871aa06d452214d5515d228d5bdc22219585e9eef895"
 
 [[package]]
 name = "cranelift-control"
-version = "0.113.0"
+version = "0.114.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4aca921dd422e781409de0129c255768fec5dec1dae83239b497fb9138abb89"
+checksum = "29cb4018f5bf59fb53f515fa9d80e6f8c5ce19f198dc538984ebd23ecf8965ec"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.113.0"
+version = "0.114.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2d770e6605eccee15b49decdd82cd26f2b6404767802471459ea49c57379a98"
+checksum = "305399fd781a2953ac78c1396f02ff53144f39c33eb7fc7789cf4e8936d13a96"
 dependencies = [
  "cranelift-bitset",
  "serde",
@@ -2407,9 +2408,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.113.0"
+version = "0.114.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29268711cb889cb39215b10faf88b9087d4c9e1d2633581e4f722a2bf4bb4ef9"
+checksum = "9230b460a128d53653456137751d27baf567947a3ab8c0c4d6e31fd08036d81e"
 dependencies = [
  "cranelift-codegen",
  "log",
@@ -2419,15 +2420,15 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.113.0"
+version = "0.114.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc65156f010aed1985767ad1bff0eb8d186743b7b03e23d0c17604a253e3f356"
+checksum = "b961e24ae3ec9813a24a15ae64bbd2a42e4de4d79a7f3225a412e3b94e78d1c8"
 
 [[package]]
 name = "cranelift-native"
-version = "0.113.0"
+version = "0.114.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8bf9b361eaf5a7627647270fabf1dc910d993edbeaf272a652c107861ebe9c2"
+checksum = "4d5bd76df6c9151188dfa428c863b33da5b34561b67f43c0cf3f24a794f9fa1f"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -8556,7 +8557,7 @@ checksum = "0c1318b19085f08681016926435853bbf7858f9c082d0999b80550ff5d9abe15"
 dependencies = [
  "bytes",
  "heck 0.5.0",
- "itertools 0.11.0",
+ "itertools 0.12.0",
  "log",
  "multimap",
  "once_cell",
@@ -8589,7 +8590,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9552f850d5f0964a4e4d0bf306459ac29323ddfbae05e35a7c0d35cb0803cc5"
 dependencies = [
  "anyhow",
- "itertools 0.11.0",
+ "itertools 0.12.0",
  "proc-macro2",
  "quote",
  "syn 2.0.87",
@@ -8666,9 +8667,9 @@ dependencies = [
 
 [[package]]
 name = "pulley-interpreter"
-version = "26.0.0"
+version = "27.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d68c610ff29655a42eeef41a5b5346e714586971a7d927739477e552fe7e23e3"
+checksum = "a3b8d81cf799e20564931e9867ca32de545188c6ee4c2e0f6e41d32f0c7dc6fb"
 dependencies = [
  "cranelift-bitset",
  "log",
@@ -12350,11 +12351,12 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.218.0"
+version = "0.219.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22b896fa8ceb71091ace9bcb81e853f54043183a1c9667cf93422c40252ffa0a"
+checksum = "29cbbd772edcb8e7d524a82ee8cef8dd046fc14033796a754c3ad246d019fa54"
 dependencies = [
  "leb128",
+ "wasmparser 0.219.1",
 ]
 
 [[package]]
@@ -12426,9 +12428,9 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.218.0"
+version = "0.219.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b09e46c7fceceaa72b2dd1a8a137ea7fd8f93dfaa69806010a709918e496c5dc"
+checksum = "5c771866898879073c53b565a6c7b49953795159836714ac56a5befb581227c5"
 dependencies = [
  "ahash 0.8.11",
  "bitflags 2.6.0",
@@ -12451,20 +12453,20 @@ dependencies = [
 
 [[package]]
 name = "wasmprinter"
-version = "0.218.0"
+version = "0.219.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ace089155491837b75f474bf47c99073246d1b737393fe722d6dee311595ddc"
+checksum = "228cdc1f30c27816da225d239ce4231f28941147d34713dee8f1fff7cb330e54"
 dependencies = [
  "anyhow",
  "termcolor",
- "wasmparser 0.218.0",
+ "wasmparser 0.219.1",
 ]
 
 [[package]]
 name = "wasmtime"
-version = "26.0.0"
+version = "27.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ffa3230b9ba1ab6568d116df21bf4ca55ed2bfac87723d910471d30d9656ea1"
+checksum = "5b79302e3e084713249cc5622e8608e7410afdeeea8c8026d04f491d1fab0b4b"
 dependencies = [
  "anyhow",
  "bitflags 2.6.0",
@@ -12491,7 +12493,7 @@ dependencies = [
  "smallvec",
  "sptr",
  "target-lexicon",
- "wasmparser 0.218.0",
+ "wasmparser 0.219.1",
  "wasmtime-asm-macros",
  "wasmtime-component-macro",
  "wasmtime-cranelift",
@@ -12504,18 +12506,18 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-asm-macros"
-version = "26.0.0"
+version = "27.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef15fad08bbaa0e5c5539b76fa5965ca25e24f17a584f83a40b43ba9a2b36f44"
+checksum = "fe53a24e7016a5222875d8ca3ad6024b464465985693c42098cd0bb710002c28"
 dependencies = [
  "cfg-if 1.0.0",
 ]
 
 [[package]]
 name = "wasmtime-component-macro"
-version = "26.0.0"
+version = "27.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23fb4e179f424260d0739c09d3bc83d34347a55d291d10dcb5244686a75c7733"
+checksum = "e118acbd2bc09b32ad8606bc7cef793bf5019c1b107772e64dc6c76b5055d40b"
 dependencies = [
  "anyhow",
  "proc-macro2",
@@ -12528,15 +12530,15 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-component-util"
-version = "26.0.0"
+version = "27.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfe3c27d64af5f584014db9381c081223d27a57e1dce2f6280bbafea37575619"
+checksum = "4a6db4f3ee18c699629eabb9c64e77efe5a93a5137f098db7cab295037ba41c2"
 
 [[package]]
 name = "wasmtime-cranelift"
-version = "26.0.0"
+version = "27.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb56d9ee4a093509624bd0861888cd111f6530e16969a68bb12dc7dd7a2be27f"
+checksum = "8b87e6c78f562b50aff1afd87ff32a57e241424c846c1c8f3c5fd352d2d62906"
 dependencies = [
  "anyhow",
  "cfg-if 1.0.0",
@@ -12552,16 +12554,16 @@ dependencies = [
  "smallvec",
  "target-lexicon",
  "thiserror 1.0.68",
- "wasmparser 0.218.0",
+ "wasmparser 0.219.1",
  "wasmtime-environ",
  "wasmtime-versioned-export-macros",
 ]
 
 [[package]]
 name = "wasmtime-environ"
-version = "26.0.0"
+version = "27.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3444c1759d5b906ff76a3cab073dd92135bdd06e5d1f46635ec40a58207d314"
+checksum = "c25bfeaa16432d59a0706e2463d315ef4c9ebcfaf5605670b99d46373bdf9f27"
 dependencies = [
  "anyhow",
  "cranelift-bitset",
@@ -12575,16 +12577,16 @@ dependencies = [
  "serde_derive",
  "smallvec",
  "target-lexicon",
- "wasm-encoder 0.218.0",
- "wasmparser 0.218.0",
- "wasmprinter 0.218.0",
+ "wasm-encoder 0.219.1",
+ "wasmparser 0.219.1",
+ "wasmprinter 0.219.1",
 ]
 
 [[package]]
 name = "wasmtime-jit-icache-coherence"
-version = "26.0.0"
+version = "27.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e458e6a1a010a53f86ac8d75837c0c6b2ce3e54b7503b2f1dc5629a4a541f5a"
+checksum = "91b218a92866f74f35162f5d03a4e0f62cd0e1cc624285b1014275e5d4575fad"
 dependencies = [
  "anyhow",
  "cfg-if 1.0.0",
@@ -12594,15 +12596,15 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-slab"
-version = "26.0.0"
+version = "27.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "339c9a2a62b989a3184baff31be3a5b5256ad52629634eb432f9ccf0ab251f83"
+checksum = "4d5f8acf677ee6b3b8ba400dd9753ea4769e56a95c4b30b045ac6d2d54b2f8ea"
 
 [[package]]
 name = "wasmtime-versioned-export-macros"
-version = "26.0.0"
+version = "27.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abe01058e422966659e1af00af833147d54658b07c7e74606d73ca9af3f1690a"
+checksum = "df09be00c38f49172ca9936998938476e3f2df782673a39ae2ef9fb0838341b6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12611,9 +12613,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wit-bindgen"
-version = "26.0.0"
+version = "27.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c9e85935a1199e96b73e7fcd27a127035d2082265720a67d59268a24892d567"
+checksum = "bf3963c9c29df91564d8bd181eb00d0dbaeafa1b2a01e15952bb7391166b704e"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
@@ -13036,9 +13038,9 @@ dependencies = [
 
 [[package]]
 name = "wit-parser"
-version = "0.218.0"
+version = "0.219.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d3d1066ab761b115f97fef2b191090faabcb0f37b555b758d3caf42d4ed9e55"
+checksum = "4a86f669283257e8e424b9a4fc3518e3ade0b95deb9fbc0f93a1876be3eda598"
 dependencies = [
  "anyhow",
  "id-arena",
@@ -13049,7 +13051,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "unicode-xid",
- "wasmparser 0.218.0",
+ "wasmparser 0.219.1",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2655,18 +2655,18 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.113.0"
+version = "0.114.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5e7afe85cadb55c4c1176268a2ac046fdff8dfaeca39e18581b9dc319ca9e"
+checksum = "2ba4f80548f22dc9c43911907b5e322c5555544ee85f785115701e6a28c9abe1"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-bitset"
-version = "0.113.0"
+version = "0.114.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ab25ef3be935a80680e393183e1f94ef507e93a24a8369494d2c6818aedb3e3"
+checksum = "005884e3649c3e5ff2dc79e8a94b138f11569cc08a91244a292714d2a86e9156"
 dependencies = [
  "serde",
  "serde_derive",
@@ -2674,9 +2674,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.113.0"
+version = "0.114.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "900a19b84545924f1851cbfe386962edfc4ecbc3366a254825cf1ecbcda8ba08"
+checksum = "fe4036255ec33ce9a37495dfbcfc4e1118fd34e693eff9a1e106336b7cd16a9b"
 dependencies = [
  "bumpalo",
  "cranelift-bforest",
@@ -2691,39 +2691,40 @@ dependencies = [
  "log",
  "regalloc2",
  "rustc-hash 2.0.0",
+ "serde",
  "smallvec",
  "target-lexicon",
 ]
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.113.0"
+version = "0.114.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08c73b2395ffe9e7b4fdf7e2ebc052e7e27af13f68a964985346be4da477a5fc"
+checksum = "f7ca74f4b68319da11d39e894437cb6e20ec7c2e11fbbda823c3bf207beedff7"
 dependencies = [
  "cranelift-codegen-shared",
 ]
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.113.0"
+version = "0.114.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d9ed0854e96a4ff0879bff39d078de8dea7f002721c9494c1fdb4e1baa86ccc"
+checksum = "897e54f433a0269c4187871aa06d452214d5515d228d5bdc22219585e9eef895"
 
 [[package]]
 name = "cranelift-control"
-version = "0.113.0"
+version = "0.114.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4aca921dd422e781409de0129c255768fec5dec1dae83239b497fb9138abb89"
+checksum = "29cb4018f5bf59fb53f515fa9d80e6f8c5ce19f198dc538984ebd23ecf8965ec"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.113.0"
+version = "0.114.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2d770e6605eccee15b49decdd82cd26f2b6404767802471459ea49c57379a98"
+checksum = "305399fd781a2953ac78c1396f02ff53144f39c33eb7fc7789cf4e8936d13a96"
 dependencies = [
  "cranelift-bitset",
  "serde",
@@ -2732,9 +2733,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.113.0"
+version = "0.114.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29268711cb889cb39215b10faf88b9087d4c9e1d2633581e4f722a2bf4bb4ef9"
+checksum = "9230b460a128d53653456137751d27baf567947a3ab8c0c4d6e31fd08036d81e"
 dependencies = [
  "cranelift-codegen",
  "log",
@@ -2744,15 +2745,15 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.113.0"
+version = "0.114.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc65156f010aed1985767ad1bff0eb8d186743b7b03e23d0c17604a253e3f356"
+checksum = "b961e24ae3ec9813a24a15ae64bbd2a42e4de4d79a7f3225a412e3b94e78d1c8"
 
 [[package]]
 name = "cranelift-native"
-version = "0.113.0"
+version = "0.114.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8bf9b361eaf5a7627647270fabf1dc910d993edbeaf272a652c107861ebe9c2"
+checksum = "4d5bd76df6c9151188dfa428c863b33da5b34561b67f43c0cf3f24a794f9fa1f"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -17824,9 +17825,9 @@ dependencies = [
 
 [[package]]
 name = "pulley-interpreter"
-version = "26.0.0"
+version = "27.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d68c610ff29655a42eeef41a5b5346e714586971a7d927739477e552fe7e23e3"
+checksum = "a3b8d81cf799e20564931e9867ca32de545188c6ee4c2e0f6e41d32f0c7dc6fb"
 dependencies = [
  "cranelift-bitset",
  "log",
@@ -22062,15 +22063,6 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.218.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22b896fa8ceb71091ace9bcb81e853f54043183a1c9667cf93422c40252ffa0a"
-dependencies = [
- "leb128",
-]
-
-[[package]]
-name = "wasm-encoder"
 version = "0.219.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29cbbd772edcb8e7d524a82ee8cef8dd046fc14033796a754c3ad246d019fa54"
@@ -22122,9 +22114,9 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.218.0"
+version = "0.219.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b09e46c7fceceaa72b2dd1a8a137ea7fd8f93dfaa69806010a709918e496c5dc"
+checksum = "5c771866898879073c53b565a6c7b49953795159836714ac56a5befb581227c5"
 dependencies = [
  "ahash 0.8.11",
  "bitflags 2.6.0",
@@ -22132,16 +22124,6 @@ dependencies = [
  "indexmap 2.6.0",
  "semver",
  "serde",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.219.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c771866898879073c53b565a6c7b49953795159836714ac56a5befb581227c5"
-dependencies = [
- "bitflags 2.6.0",
- "indexmap 2.6.0",
 ]
 
 [[package]]
@@ -22157,20 +22139,20 @@ dependencies = [
 
 [[package]]
 name = "wasmprinter"
-version = "0.218.0"
+version = "0.219.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ace089155491837b75f474bf47c99073246d1b737393fe722d6dee311595ddc"
+checksum = "228cdc1f30c27816da225d239ce4231f28941147d34713dee8f1fff7cb330e54"
 dependencies = [
  "anyhow",
  "termcolor",
- "wasmparser 0.218.0",
+ "wasmparser 0.219.1",
 ]
 
 [[package]]
 name = "wasmtime"
-version = "26.0.0"
+version = "27.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ffa3230b9ba1ab6568d116df21bf4ca55ed2bfac87723d910471d30d9656ea1"
+checksum = "5b79302e3e084713249cc5622e8608e7410afdeeea8c8026d04f491d1fab0b4b"
 dependencies = [
  "anyhow",
  "bitflags 2.6.0",
@@ -22197,7 +22179,7 @@ dependencies = [
  "smallvec",
  "sptr",
  "target-lexicon",
- "wasmparser 0.218.0",
+ "wasmparser 0.219.1",
  "wasmtime-asm-macros",
  "wasmtime-component-macro",
  "wasmtime-cranelift",
@@ -22210,18 +22192,18 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-asm-macros"
-version = "26.0.0"
+version = "27.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef15fad08bbaa0e5c5539b76fa5965ca25e24f17a584f83a40b43ba9a2b36f44"
+checksum = "fe53a24e7016a5222875d8ca3ad6024b464465985693c42098cd0bb710002c28"
 dependencies = [
  "cfg-if 1.0.0",
 ]
 
 [[package]]
 name = "wasmtime-component-macro"
-version = "26.0.0"
+version = "27.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23fb4e179f424260d0739c09d3bc83d34347a55d291d10dcb5244686a75c7733"
+checksum = "e118acbd2bc09b32ad8606bc7cef793bf5019c1b107772e64dc6c76b5055d40b"
 dependencies = [
  "anyhow",
  "proc-macro2",
@@ -22234,15 +22216,15 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-component-util"
-version = "26.0.0"
+version = "27.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfe3c27d64af5f584014db9381c081223d27a57e1dce2f6280bbafea37575619"
+checksum = "4a6db4f3ee18c699629eabb9c64e77efe5a93a5137f098db7cab295037ba41c2"
 
 [[package]]
 name = "wasmtime-cranelift"
-version = "26.0.0"
+version = "27.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb56d9ee4a093509624bd0861888cd111f6530e16969a68bb12dc7dd7a2be27f"
+checksum = "8b87e6c78f562b50aff1afd87ff32a57e241424c846c1c8f3c5fd352d2d62906"
 dependencies = [
  "anyhow",
  "cfg-if 1.0.0",
@@ -22258,16 +22240,16 @@ dependencies = [
  "smallvec",
  "target-lexicon",
  "thiserror 1.0.68",
- "wasmparser 0.218.0",
+ "wasmparser 0.219.1",
  "wasmtime-environ",
  "wasmtime-versioned-export-macros",
 ]
 
 [[package]]
 name = "wasmtime-environ"
-version = "26.0.0"
+version = "27.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3444c1759d5b906ff76a3cab073dd92135bdd06e5d1f46635ec40a58207d314"
+checksum = "c25bfeaa16432d59a0706e2463d315ef4c9ebcfaf5605670b99d46373bdf9f27"
 dependencies = [
  "anyhow",
  "cranelift-bitset",
@@ -22281,16 +22263,16 @@ dependencies = [
  "serde_derive",
  "smallvec",
  "target-lexicon",
- "wasm-encoder 0.218.0",
- "wasmparser 0.218.0",
- "wasmprinter 0.218.0",
+ "wasm-encoder 0.219.1",
+ "wasmparser 0.219.1",
+ "wasmprinter 0.219.1",
 ]
 
 [[package]]
 name = "wasmtime-jit-icache-coherence"
-version = "26.0.0"
+version = "27.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e458e6a1a010a53f86ac8d75837c0c6b2ce3e54b7503b2f1dc5629a4a541f5a"
+checksum = "91b218a92866f74f35162f5d03a4e0f62cd0e1cc624285b1014275e5d4575fad"
 dependencies = [
  "anyhow",
  "cfg-if 1.0.0",
@@ -22300,15 +22282,15 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-slab"
-version = "26.0.0"
+version = "27.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "339c9a2a62b989a3184baff31be3a5b5256ad52629634eb432f9ccf0ab251f83"
+checksum = "4d5f8acf677ee6b3b8ba400dd9753ea4769e56a95c4b30b045ac6d2d54b2f8ea"
 
 [[package]]
 name = "wasmtime-versioned-export-macros"
-version = "26.0.0"
+version = "27.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abe01058e422966659e1af00af833147d54658b07c7e74606d73ca9af3f1690a"
+checksum = "df09be00c38f49172ca9936998938476e3f2df782673a39ae2ef9fb0838341b6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -22317,9 +22299,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wit-bindgen"
-version = "26.0.0"
+version = "27.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c9e85935a1199e96b73e7fcd27a127035d2082265720a67d59268a24892d567"
+checksum = "bf3963c9c29df91564d8bd181eb00d0dbaeafa1b2a01e15952bb7391166b704e"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
@@ -22699,9 +22681,9 @@ checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
 name = "wit-parser"
-version = "0.218.0"
+version = "0.219.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d3d1066ab761b115f97fef2b191090faabcb0f37b555b758d3caf42d4ed9e55"
+checksum = "4a86f669283257e8e424b9a4fc3518e3ade0b95deb9fbc0f93a1876be3eda598"
 dependencies = [
  "anyhow",
  "id-arena",
@@ -22712,7 +22694,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "unicode-xid",
- "wasmparser 0.218.0",
+ "wasmparser 0.219.1",
 ]
 
 [[package]]

--- a/bazel/external_crates.bzl
+++ b/bazel/external_crates.bzl
@@ -1434,17 +1434,18 @@ def external_crates_repository(name, cargo_lockfile, lockfile, sanitizers_enable
                 version = "^0.217.0",
             ),
             "wasmtime": crate.spec(
-                version = "^26.0.0",
+                version = "^27.0.0",
                 default_features = False,
                 features = [
                     "cranelift",
                     "gc",
+                    "gc-null",
                     "parallel-compilation",
                     "runtime",
                 ],
             ),
             "wasmtime-environ": crate.spec(
-                version = "^26.0.0",
+                version = "^27.0.0",
             ),
             "wast": crate.spec(
                 version = "^212.0.0",

--- a/rs/embedders/Cargo.toml
+++ b/rs/embedders/Cargo.toml
@@ -39,13 +39,14 @@ slog-term = { workspace = true }
 tempfile = { workspace = true }
 wasm-encoder = { workspace = true }
 wasmparser = { workspace = true }
-wasmtime = { version = "26.0.0", default-features = false, features = [
+wasmtime = { version = "27.0.0", default-features = false, features = [
     'cranelift',
     'gc',
+    'gc-null',
     'parallel-compilation',
     'runtime',
 ] }
-wasmtime-environ = "26.0.0"
+wasmtime-environ = "27.0.0"
 
 # Wasmtime depends on 0.4.2 but specifies 0.4.1 in the toml file.
 # Enforce 0.4.2 using a dummy dependency until the upstream issue

--- a/rs/embedders/README.adoc
+++ b/rs/embedders/README.adoc
@@ -8,5 +8,4 @@ See [Nondeterminism in WebAssembly](https://github.com/WebAssembly/design/blob/m
 We use the following config flags to ensure deterministic execution in Wasmtime:
 
 - Threads: `wasmtime::Config::wasm_threads(false)`.
-- SIMD: `wasmtime::Config::wasm_simd(false)`.
 - NaN values: `wasmtime::Config::cranelift_nan_canonicalization(true)`.

--- a/rs/embedders/src/wasm_utils/validation.rs
+++ b/rs/embedders/src/wasm_utils/validation.rs
@@ -1474,7 +1474,7 @@ pub fn wasmtime_validation_config(embedders_config: &EmbeddersConfig) -> wasmtim
         // of `wasmtime::MemoryCreator`.
         .static_memory_maximum_size(MAX_STABLE_MEMORY_IN_BYTES)
         .guard_before_linear_memory(true)
-        .static_memory_guard_size(MIN_GUARD_REGION_SIZE as u64)
+        .memory_guard_size(MIN_GUARD_REGION_SIZE as u64)
         .max_wasm_stack(MAX_WASM_STACK_SIZE);
     config
 }

--- a/rs/embedders/tests/spec_tests.rs
+++ b/rs/embedders/tests/spec_tests.rs
@@ -223,7 +223,12 @@ mod convert {
             (V::ExternRef(None), C(R::RefExtern(_))) => false,
             // `WastArgCore::RefExtern` always stores a `u32`.
             (V::ExternRef(Some(l)), C(R::RefExtern(Some(r)))) => {
-                let l = l.data(store).unwrap().downcast_ref::<u32>().unwrap();
+                let l = l
+                    .data(store)
+                    .expect("reference to be rooted")
+                    .unwrap()
+                    .downcast_ref::<u32>()
+                    .unwrap();
                 l == r
             }
             (V::ExternRef(l), C(R::RefNull(_))) => l.is_none(),


### PR DESCRIPTION
Release notes: https://github.com/bytecodealliance/wasmtime/releases/tag/v27.0.0

* enabled `gc-null` feature as the GC dependency
* minor changes in spec tests
