### PR TITLE
feat: Add various subnet info metrics

### DIFF
--- a/rs/messaging/src/message_routing.rs
+++ b/rs/messaging/src/message_routing.rs
@@ -44,17 +44,17 @@ use ic_types::{
 use ic_utils_thread::JoinOnDrop;
 #[cfg(test)]
 use mockall::automock;
-use prometheus::{Histogram, HistogramVec, IntCounter, IntCounterVec, IntGauge, IntGaugeVec};
+use prometheus::{
+    Gauge, Histogram, HistogramVec, IntCounter, IntCounterVec, IntGauge, IntGaugeVec,
+};
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
+use std::convert::{AsRef, TryFrom};
+use std::net::{Ipv4Addr, Ipv6Addr};
 use std::ops::Range;
 use std::sync::mpsc::{sync_channel, TrySendError};
 use std::sync::{Arc, Mutex, RwLock};
 use std::thread::sleep;
-use std::{
-    collections::{BTreeMap, BTreeSet, VecDeque},
-    convert::TryFrom,
-    net::{Ipv4Addr, Ipv6Addr},
-    time::Instant,
-};
+use std::time::Instant;
 use tracing::instrument;
 
 #[cfg(test)]
@@ -97,6 +97,13 @@ const METRIC_WASM_CUSTOM_SECTIONS_MEMORY_USAGE_BYTES: &str =
     "mr_wasm_custom_sections_memory_usage_bytes";
 const METRIC_CANISTER_HISTORY_MEMORY_USAGE_BYTES: &str = "mr_canister_history_memory_usage_bytes";
 const METRIC_CANISTER_HISTORY_TOTAL_NUM_CHANGES: &str = "mr_canister_history_total_num_changes";
+
+const METRIC_SUBNET_INFO: &str = "mr_subnet_info";
+const METRIC_SUBNET_SIZE: &str = "mr_subnet_size";
+const METRIC_MAX_CANISTERS: &str = "mr_subnet_max_canisters";
+const METRIC_INITIAL_NOTARY_DELAY: &str = "mr_subnet_initial_notary_delay_seconds";
+const METRIC_MAX_BLOCK_PAYLOAD_SIZE: &str = "mr_subnet_max_block_payload_size_bytes";
+const METRIC_SUBNET_FEATURES: &str = "mr_subnet_features";
 
 const CRITICAL_ERROR_MISSING_SUBNET_SIZE: &str = "cycles_account_manager_missing_subnet_size_error";
 const CRITICAL_ERROR_MISSING_OR_INVALID_NODE_PUBLIC_KEYS: &str =
@@ -311,6 +318,13 @@ pub(crate) struct MessageRoutingMetrics {
     /// The total number of changes in canister history per canister on this subnet.
     canister_history_total_num_changes: Histogram,
 
+    subnet_info: IntGaugeVec,
+    subnet_size: IntGauge,
+    max_canisters: IntGauge,
+    initial_notary_delay: Gauge,
+    max_block_payload_size: IntGauge,
+    subnet_features: IntGaugeVec,
+
     /// Critical error for not being able to calculate a subnet size.
     critical_error_missing_subnet_size: IntCounter,
     /// Critical error: public keys of own subnet nodes are missing
@@ -427,6 +441,33 @@ impl MessageRoutingMetrics {
                 "Total number of changes in canister history per canister on this subnet.",
                 // 0, 1, 2, 5, …, 1000, 2000, 5000
                 decimal_buckets_with_zero(0, 3),
+            ),
+
+            subnet_info: metrics_registry.int_gauge_vec(
+                METRIC_SUBNET_INFO,
+                "Subnet ID and type, from the subnet record in the registry.",
+                &["subnet_id", "subnet_type"],
+            ),
+            subnet_size: metrics_registry.int_gauge(
+                METRIC_SUBNET_SIZE,
+                "Number of nodes in the subnet, per the subnet record in the registry.",
+            ),
+            max_canisters: metrics_registry.int_gauge(
+                METRIC_MAX_CANISTERS,
+                "Maximum number of canisters that can be created on this subnet.",
+            ),
+            initial_notary_delay: metrics_registry.gauge(
+                METRIC_INITIAL_NOTARY_DELAY,
+                "Initial delay for notarization, in seconds.",
+            ),
+            max_block_payload_size: metrics_registry.int_gauge(
+                METRIC_MAX_BLOCK_PAYLOAD_SIZE,
+                "Maximum size of a block payload, in bytes.",
+            ),
+            subnet_features: metrics_registry.int_gauge_vec(
+                METRIC_SUBNET_FEATURES,
+                "Subnet features and their status (enabled or disabled).",
+                &["feature"],
             ),
 
             critical_error_missing_subnet_size: metrics_registry
@@ -814,6 +855,40 @@ impl BatchProcessorImpl {
                 .collect::<BTreeSet<_>>()
                 .len()
         };
+
+        let own_subnet_type: SubnetType = subnet_record.subnet_type.try_into().unwrap_or_default();
+        self.metrics
+            .subnet_info
+            .with_label_values(&[&own_subnet_id.to_string(), own_subnet_type.as_ref()])
+            .set(1);
+        self.metrics.subnet_size.set(subnet_size as i64);
+        self.metrics
+            .max_canisters
+            .set(max_number_of_canisters as i64);
+        self.metrics
+            .initial_notary_delay
+            .set(subnet_record.initial_notary_delay_millis as f64 * 1e-3);
+        self.metrics
+            .max_block_payload_size
+            .set(subnet_record.max_block_payload_size as i64);
+        // Please export any new features via the `subnet_features` metric below.
+        let SubnetFeatures {
+            canister_sandboxing,
+            http_requests,
+            sev_enabled,
+        } = &subnet_features;
+        self.metrics
+            .subnet_features
+            .with_label_values(&["canister_sandboxing"])
+            .set(*canister_sandboxing as i64);
+        self.metrics
+            .subnet_features
+            .with_label_values(&["http_requests"])
+            .set(*http_requests as i64);
+        self.metrics
+            .subnet_features
+            .with_label_values(&["sev_enabled"])
+            .set(*sev_enabled as i64);
 
         Ok((
             network_topology,


### PR DESCRIPTION
Export information about subnet type, size, features, initial notary delay, max block payload size when reading the registry at the top of the round.