### PR TITLE
fix: Update argument to start function of xnet canister in global reboot test

### DIFF
--- a/rs/tests/message_routing/global_reboot_test.rs
+++ b/rs/tests/message_routing/global_reboot_test.rs
@@ -48,7 +48,7 @@ use slog::{info, Logger};
 use std::env;
 use std::time::Duration;
 use tokio::time::sleep;
-use xnet_test::Metrics;
+use xnet_test::{Metrics, StartArgs};
 
 const SUBNETS_COUNT: usize = 2;
 const CANISTERS_PER_SUBNET: usize = 3;
@@ -186,9 +186,13 @@ pub fn start_all_canisters(
             .enumerate()
             .flat_map(|(x, v)| v.iter().enumerate().map(move |(y, v)| (x, y, v)))
         {
-            let input = (&topology, canister_to_subnet_rate, payload_size_bytes);
+            let input = StartArgs {
+                network_topology: topology.clone(),
+                canister_to_subnet_rate,
+                payload_size_bytes,
+            };
             let _: String = canister
-                .update_("start", candid, input)
+                .update_("start", candid, (input,))
                 .await
                 .unwrap_or_else(|_| {
                     panic!(


### PR DESCRIPTION
The changes in https://github.com/dfinity/ic/pull/806 missed updating the arguments to the start function of the xnet canister in a system test. This PR fixes the issue.