### PR TITLE
fix(nns): Change the default voting power refreshed timestamp from Nov 15 to Sep 1.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10650,6 +10650,7 @@ dependencies = [
  "on_wire",
  "phantom_newtype",
  "pocket-ic",
+ "pretty_assertions",
  "prometheus-parse",
  "prost 0.13.3",
  "rand 0.8.5",

--- a/rs/nns/governance/canister/canister.rs
+++ b/rs/nns/governance/canister/canister.rs
@@ -177,7 +177,7 @@ fn schedule_timers() {
 const SEEDING_INTERVAL: Duration = Duration::from_secs(3600);
 const RETRY_SEEDING_INTERVAL: Duration = Duration::from_secs(30);
 const PRUNE_FOLLOWING_INTERVAL: Duration = Duration::from_secs(10);
-const BACKFILL_VOTING_POWER_REFRESHED_TIMESTAMPS_INTERVAL: Duration = Duration::from_secs(10);
+const BACKFILL_VOTING_POWER_REFRESHED_TIMESTAMPS_INTERVAL: Duration = Duration::from_secs(60);
 
 // Once this amount of instructions is used by the
 // Governance::prune_some_following, it stops, saves where it is, schedules more

--- a/rs/nns/governance/canister/canister.rs
+++ b/rs/nns/governance/canister/canister.rs
@@ -167,6 +167,9 @@ fn schedule_timers() {
     schedule_adjust_neurons_storage(Duration::from_nanos(0), NeuronIdProto { id: 0 });
     schedule_prune_following(Duration::from_secs(0));
     schedule_spawn_neurons();
+
+    // TODO(NNS1-3446): Delete. (This only needs to be run once, but can safely be run multiple times).
+    schedule_backfill_voting_power_refreshed_timestamps(Duration::from_secs(0));
 }
 
 // Seeding interval seeks to find a balance between the need for rng secrecy, and
@@ -174,6 +177,7 @@ fn schedule_timers() {
 const SEEDING_INTERVAL: Duration = Duration::from_secs(3600);
 const RETRY_SEEDING_INTERVAL: Duration = Duration::from_secs(30);
 const PRUNE_FOLLOWING_INTERVAL: Duration = Duration::from_secs(10);
+const BACKFILL_VOTING_POWER_REFRESHED_TIMESTAMPS_INTERVAL: Duration = Duration::from_secs(10);
 
 // Once this amount of instructions is used by the
 // Governance::prune_some_following, it stops, saves where it is, schedules more
@@ -193,6 +197,8 @@ const PRUNE_FOLLOWING_INTERVAL: Duration = Duration::from_secs(10);
 // prune_some_following. If we assume 1 terainstruction costs 1 XDR,
 // prune_some_following uses a couple of bucks worth of instructions each day.
 const MAX_PRUNE_SOME_FOLLOWING_INSTRUCTIONS: u64 = 50_000_000;
+
+const MAX_BACKFILL_VOTING_POWER_REFRESHED_TIMESTAMPS_INSTRUCTIONS: u64 = 50_000_000;
 
 fn schedule_seeding(delay: Duration) {
     ic_cdk_timers::set_timer(delay, || {
@@ -244,6 +250,40 @@ fn schedule_prune_following(delay: Duration) {
         });
 
         schedule_prune_following(PRUNE_FOLLOWING_INTERVAL);
+    });
+}
+
+thread_local! {
+    static BACKFILL_VOTING_POWER_REFRESHED_TIMESTAMPS_CHECKPOINT: RefCell<Bound<NeuronIdProto>> =
+        const { RefCell::new(Bound::Unbounded) };
+}
+
+fn schedule_backfill_voting_power_refreshed_timestamps(delay: Duration) {
+    ic_cdk_timers::set_timer(delay, || {
+        let original_checkpoint =
+            BACKFILL_VOTING_POWER_REFRESHED_TIMESTAMPS_CHECKPOINT.with(|p| *p.borrow());
+
+        let carry_on = || {
+            call_context_instruction_counter()
+                < MAX_BACKFILL_VOTING_POWER_REFRESHED_TIMESTAMPS_INSTRUCTIONS
+        };
+        let new_checkpoint = governance_mut()
+            .backfill_some_voting_power_refreshed_timestamps(original_checkpoint, carry_on);
+
+        BACKFILL_VOTING_POWER_REFRESHED_TIMESTAMPS_CHECKPOINT.with(|p| {
+            let mut borrow = p.borrow_mut();
+            *borrow = new_checkpoint;
+        });
+
+        let is_done = new_checkpoint == Bound::Unbounded;
+        if is_done {
+            return;
+        }
+
+        // Otherwise, continue later.
+        schedule_backfill_voting_power_refreshed_timestamps(
+            BACKFILL_VOTING_POWER_REFRESHED_TIMESTAMPS_INTERVAL,
+        );
     });
 }
 

--- a/rs/nns/governance/src/governance.rs
+++ b/rs/nns/governance/src/governance.rs
@@ -14,7 +14,8 @@ use crate::{
     neuron::{DissolveStateAndAge, Neuron, NeuronBuilder},
     neuron_data_validation::{NeuronDataValidationSummary, NeuronDataValidator},
     neuron_store::{
-        metrics::NeuronSubsetMetrics, prune_some_following, NeuronMetrics, NeuronStore,
+        backfill_some_voting_power_refreshed_timestamps, metrics::NeuronSubsetMetrics,
+        prune_some_following, NeuronMetrics, NeuronStore,
     },
     neurons_fund::{
         NeuronsFund, NeuronsFundNeuronPortion, NeuronsFundSnapshot,
@@ -6127,6 +6128,14 @@ impl Governance {
             begin,
             carry_on,
         )
+    }
+
+    pub fn backfill_some_voting_power_refreshed_timestamps(
+        &mut self,
+        begin: std::ops::Bound<NeuronId>,
+        carry_on: impl FnMut() -> bool,
+    ) -> std::ops::Bound<NeuronId> {
+        backfill_some_voting_power_refreshed_timestamps(&mut self.neuron_store, begin, carry_on)
     }
 
     /// Creates a new neuron or refreshes the stake of an existing

--- a/rs/nns/governance/src/neuron/types.rs
+++ b/rs/nns/governance/src/neuron/types.rs
@@ -588,7 +588,11 @@ impl Neuron {
     }
 
     pub(crate) fn backfill_voting_power_refreshed_timestamp(&mut self) {
-        if self.voting_power_refreshed_timestamp_seconds == 1731628801 {
+        // This used to be the default, but we later changed our minds.
+        // The old definition:
+        // https://sourcegraph.com/github.com/dfinity/ic@1956e438af82a5b4aa9713bcbbe385684bf0704f/-/blob/rs/nns/governance/src/lib.rs?L189
+        const EVIL_TIMESTAMP_SECONDS = 1731628801;
+        if self.voting_power_refreshed_timestamp_seconds == EVIL_TIMESTAMP_SECONDS {
             self.voting_power_refreshed_timestamp_seconds =
                 DEFAULT_VOTING_POWER_REFRESHED_TIMESTAMP_SECONDS;
         }

--- a/rs/nns/governance/src/neuron/types.rs
+++ b/rs/nns/governance/src/neuron/types.rs
@@ -587,6 +587,13 @@ impl Neuron {
         u64::try_from(result).unwrap()
     }
 
+    pub(crate) fn backfill_voting_power_refreshed_timestamp(&mut self) {
+        if self.voting_power_refreshed_timestamp_seconds == 1731628801 {
+            self.voting_power_refreshed_timestamp_seconds =
+                DEFAULT_VOTING_POWER_REFRESHED_TIMESTAMP_SECONDS;
+        }
+    }
+
     pub(crate) fn ready_to_unstake_maturity(&self, now_seconds: u64) -> bool {
         self.state(now_seconds) == NeuronState::Dissolved
             && self.staked_maturity_e8s_equivalent.unwrap_or(0) > 0

--- a/rs/nns/governance/src/neuron/types.rs
+++ b/rs/nns/governance/src/neuron/types.rs
@@ -591,7 +591,7 @@ impl Neuron {
         // This used to be the default, but we later changed our minds.
         // The old definition:
         // https://sourcegraph.com/github.com/dfinity/ic@1956e438af82a5b4aa9713bcbbe385684bf0704f/-/blob/rs/nns/governance/src/lib.rs?L189
-        const EVIL_TIMESTAMP_SECONDS = 1731628801;
+        const EVIL_TIMESTAMP_SECONDS: u64 = 1731628801;
         if self.voting_power_refreshed_timestamp_seconds == EVIL_TIMESTAMP_SECONDS {
             self.voting_power_refreshed_timestamp_seconds =
                 DEFAULT_VOTING_POWER_REFRESHED_TIMESTAMP_SECONDS;

--- a/rs/nns/governance/src/neuron_store.rs
+++ b/rs/nns/governance/src/neuron_store.rs
@@ -1397,7 +1397,7 @@ pub fn prune_some_following(
     groom_some_neurons(
         neuron_store,
         |neuron| {
-            neuron.prune_following(now_seconds);
+            neuron.prune_following(voting_power_economics, now_seconds);
         },
         next,
         carry_on,

--- a/rs/nns/governance/src/neuron_store.rs
+++ b/rs/nns/governance/src/neuron_store.rs
@@ -1410,6 +1410,10 @@ pub fn groom_some_neurons(
     mut next: Bound<NeuronId>,
     mut carry_on: impl FnMut() -> bool,
 ) -> Bound<NeuronId> {
+    // Here, do-while semantics is used, rather than while. I.e. carry_on is
+    // only called at the end of the loop, not the beginnin. This results in the
+    // nice property that (when there are more neurons), this ALWAYS makes SOME
+    // progress.
     loop {
         // Which neuron do we operate on next?
         let current_neuron_id = neuron_store.first_neuron_id(next);

--- a/rs/nns/integration_tests/BUILD.bazel
+++ b/rs/nns/integration_tests/BUILD.bazel
@@ -126,6 +126,7 @@ DEV_DEPENDENCIES = [
     "@crate_index//:ic-certificate-verification",
     "@crate_index//:ic-certification",
     "@crate_index//:itertools",
+    "@crate_index//:pretty_assertions",
     "@crate_index//:serde_cbor",
 ]
 

--- a/rs/nns/integration_tests/Cargo.toml
+++ b/rs/nns/integration_tests/Cargo.toml
@@ -117,3 +117,4 @@ xrc-mock = { path = "../../rosetta-api/tvl/xrc_mock" }
 ic-nervous-system-common-test-utils = { path = "../../nervous_system/common/test_utils" }
 ic-nervous-system-integration-tests = { path = "../../nervous_system/integration_tests" }
 ic-nns-test-utils-golden-nns-state = { path = "../test_utils/golden_nns_state" }
+pretty_assertions = { workspace = true }

--- a/rs/nns/integration_tests/src/neuron_following.rs
+++ b/rs/nns/integration_tests/src/neuron_following.rs
@@ -29,6 +29,7 @@ use ic_state_machine_tests::StateMachine;
 use itertools::Itertools;
 use maplit::hashmap;
 use pocket_ic::{nonblocking::PocketIc, PocketIcBuilder};
+use pretty_assertions::assert_eq;
 use prost::Message;
 use std::time::{Duration, SystemTime};
 
@@ -670,8 +671,6 @@ async fn test_backfill_voting_power_refreshed_timestamps() {
             EVIL_TIMESTAMP_SECONDS + 1,
             now_seconds,
         ],
-        "{:#?}",
-        neurons,
     );
 }
 

--- a/rs/nns/integration_tests/src/neuron_following.rs
+++ b/rs/nns/integration_tests/src/neuron_following.rs
@@ -485,9 +485,9 @@ async fn test_prune_some_following() {
         "NNS Governance",
         GOVERNANCE_CANISTER_ID,
         governance_proto.encode_to_vec(),
-        // TODO: Once following pruning is released, replace with vanilla
-        // build_governance_wasm(). For now, the feature is only enabled when
-        // built with feature = "test".
+        // TODO(NNS1-3446): Once following pruning is released, replace with
+        // vanilla build_governance_wasm(). For now, the feature is only enabled
+        // when built with feature = "test".
         build_test_governance_wasm(),
         Some(ROOT_CANISTER_ID.get()),
     )
@@ -635,9 +635,6 @@ async fn test_backfill_voting_power_refreshed_timestamps() {
         "NNS Governance",
         GOVERNANCE_CANISTER_ID,
         governance_proto.encode_to_vec(),
-        // TODO: Once following pruning is released, replace with vanilla
-        // build_governance_wasm(). For now, the feature is only enabled when
-        // built with feature = "test".
         build_test_governance_wasm(),
         Some(ROOT_CANISTER_ID.get()),
     )

--- a/rs/nns/integration_tests/src/neuron_following.rs
+++ b/rs/nns/integration_tests/src/neuron_following.rs
@@ -648,8 +648,7 @@ async fn test_backfill_voting_power_refreshed_timestamps() {
 
     // Step 3: Inspect results
 
-    let mut observed_neurons =
-        nns::governance::list_neurons(&pocket_ic, controller)
+    let mut observed_neurons = nns::governance::list_neurons(&pocket_ic, controller)
         .await
         .full_neurons;
     assert_eq!(observed_neurons.len(), 8);

--- a/rs/nns/integration_tests/src/neuron_following.rs
+++ b/rs/nns/integration_tests/src/neuron_following.rs
@@ -496,7 +496,7 @@ async fn test_prune_some_following() {
     // Step 2: Call the code under test.
 
     // Wait for pruning to occur in the background.
-    for _ in 0..100 {
+    for _ in 0..15 {
         pocket_ic.advance_time(Duration::from_secs(1)).await;
         pocket_ic.tick().await;
     }
@@ -643,7 +643,7 @@ async fn test_backfill_voting_power_refreshed_timestamps() {
     // Step 2: Call the code under test.
 
     // Wait for backfilling to complete.
-    for _ in 0..100 {
+    for _ in 0..15 {
         pocket_ic.advance_time(Duration::from_secs(1)).await;
         pocket_ic.tick().await;
     }


### PR DESCRIPTION
Originally, we decided to grandfather existing neurons so that they would be considered refreshed on Nov 15 (more precisely, [1731628801 seconds after UNIX epoch][used]), but later, we changed our minds, and said that the clock should start on Sep 1 (more precisely, 1725148800). We changed the value of the constant, but many neurons picked up the old value. This sets those neurons to the new value.

[used]: https://sourcegraph.com/github.com/dfinity/ic@1956e438af82a5b4aa9713bcbbe385684bf0704f/-/blob/rs/nns/governance/src/lib.rs?L189

# References

This is part of the "periodic confirmation" feature that was recently approved in proposal [132411][prop].

[prop]: https://dashboard.internetcomputer.org/proposal/132411

Closes [NNS1-3488][closes].

[closes]: https://dfinity.atlassian.net/browse/NNS1-3488

[NNS1-3488]: https://dfinity.atlassian.net/browse/NNS1-3488