### PR TITLE
chore: Bump canbench and pocket ic mainnet version

### DIFF
--- a/Cargo.Bazel.Fuzzing.json.lock
+++ b/Cargo.Bazel.Fuzzing.json.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "3fbe6f0bc1150dc7e649e3be6d14ab3560751213130f5f2404d9e38092e2d002",
+  "checksum": "2afa4380416577e8ad0b8c3fe342e4dd718e3d617b3c81f8134ce7e0b9ba9f14",
   "crates": {
     "abnf 0.12.0": {
       "name": "abnf",
@@ -9948,14 +9948,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "canbench 0.1.7": {
+    "canbench 0.1.8": {
       "name": "canbench",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "package_url": "https://github.com/dfinity/canbench",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/canbench/0.1.7/download",
-          "sha256": "bf010ed5b327776525d545cef0fd17ffec73af71eb1b304ca11df3494ed65c31"
+          "url": "https://static.crates.io/crates/canbench/0.1.8/download",
+          "sha256": "cb548f9e006ad29b160d37e07435c499af7d2741918e18d95ddc87dfe97a0b8d"
         }
       },
       "targets": [
@@ -9992,7 +9992,7 @@
         "deps": {
           "common": [
             {
-              "id": "canbench-rs 0.1.7",
+              "id": "canbench-rs 0.1.8",
               "target": "canbench_rs"
             },
             {
@@ -10016,7 +10016,7 @@
               "target": "hex"
             },
             {
-              "id": "pocket-ic 5.0.0",
+              "id": "pocket-ic 6.0.0",
               "target": "pocket_ic"
             },
             {
@@ -10051,7 +10051,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.1.7"
+        "version": "0.1.8"
       },
       "license": "Apache-2.0",
       "license_ids": [
@@ -10059,14 +10059,14 @@
       ],
       "license_file": null
     },
-    "canbench-rs 0.1.7": {
+    "canbench-rs 0.1.8": {
       "name": "canbench-rs",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "package_url": "https://github.com/dfinity/canbench",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/canbench-rs/0.1.7/download",
-          "sha256": "e85a8f1ee95044a770b3d5166a12f55814283cb3aed71b81439dc59960ab76c1"
+          "url": "https://static.crates.io/crates/canbench-rs/0.1.8/download",
+          "sha256": "497d900e11ab1891dd9743dd45dbeaada540ce323aa1adc7fc0ce1da2c6e86ff"
         }
       },
       "targets": [
@@ -10109,13 +10109,13 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "canbench-rs-macros 0.1.7",
+              "id": "canbench-rs-macros 0.1.8",
               "target": "canbench_rs_macros"
             }
           ],
           "selects": {}
         },
-        "version": "0.1.7"
+        "version": "0.1.8"
       },
       "license": "Apache-2.0",
       "license_ids": [
@@ -10123,14 +10123,14 @@
       ],
       "license_file": null
     },
-    "canbench-rs-macros 0.1.7": {
+    "canbench-rs-macros 0.1.8": {
       "name": "canbench-rs-macros",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "package_url": "https://github.com/dfinity/canbench",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/canbench-rs-macros/0.1.7/download",
-          "sha256": "37aa9dbb190b03569ab14aadf669884a331712d54462c5a6c5b86c9867fe4e65"
+          "url": "https://static.crates.io/crates/canbench-rs-macros/0.1.8/download",
+          "sha256": "5a5509bcfe6eeb86f057d46fbf20a2ba6b6bf9a1099b053a8f491cd7a909dfa6"
         }
       },
       "targets": [
@@ -10170,7 +10170,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.1.7"
+        "version": "0.1.8"
       },
       "license": "Apache-2.0",
       "license_ids": [
@@ -18565,11 +18565,11 @@
               "target": "cached"
             },
             {
-              "id": "canbench 0.1.7",
+              "id": "canbench 0.1.8",
               "target": "canbench"
             },
             {
-              "id": "canbench-rs 0.1.7",
+              "id": "canbench-rs 0.1.8",
               "target": "canbench_rs"
             },
             {
@@ -31438,74 +31438,6 @@
       ],
       "license_file": "LICENSE"
     },
-    "ic-cdk 0.13.5": {
-      "name": "ic-cdk",
-      "version": "0.13.5",
-      "package_url": "https://github.com/dfinity/cdk-rs",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/ic-cdk/0.13.5/download",
-          "sha256": "3b1da6a25b045f9da3c9459c0cb2b0700ac368ee16382975a17185a23b9c18ab"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "ic_cdk",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "ic_cdk",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "candid 0.10.10",
-              "target": "candid"
-            },
-            {
-              "id": "ic0 0.21.1",
-              "target": "ic0"
-            },
-            {
-              "id": "serde 1.0.214",
-              "target": "serde"
-            },
-            {
-              "id": "serde_bytes 0.11.15",
-              "target": "serde_bytes"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "proc_macro_deps": {
-          "common": [
-            {
-              "id": "ic-cdk-macros 0.13.2",
-              "target": "ic_cdk_macros"
-            }
-          ],
-          "selects": {}
-        },
-        "version": "0.13.5"
-      },
-      "license": "Apache-2.0",
-      "license_ids": [
-        "Apache-2.0"
-      ],
-      "license_file": "LICENSE"
-    },
     "ic-cdk 0.14.1": {
       "name": "ic-cdk",
       "version": "0.14.1",
@@ -31837,73 +31769,6 @@
         },
         "edition": "2021",
         "version": "0.9.0"
-      },
-      "license": "Apache-2.0",
-      "license_ids": [
-        "Apache-2.0"
-      ],
-      "license_file": "LICENSE"
-    },
-    "ic-cdk-macros 0.13.2": {
-      "name": "ic-cdk-macros",
-      "version": "0.13.2",
-      "package_url": "https://github.com/dfinity/cdk-rs",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/ic-cdk-macros/0.13.2/download",
-          "sha256": "a45800053d80a6df839a71aaea5797e723188c0b992618208ca3b941350c7355"
-        }
-      },
-      "targets": [
-        {
-          "ProcMacro": {
-            "crate_name": "ic_cdk_macros",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "ic_cdk_macros",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "candid 0.10.10",
-              "target": "candid"
-            },
-            {
-              "id": "proc-macro2 1.0.89",
-              "target": "proc_macro2"
-            },
-            {
-              "id": "quote 1.0.37",
-              "target": "quote"
-            },
-            {
-              "id": "serde 1.0.214",
-              "target": "serde"
-            },
-            {
-              "id": "serde_tokenstream 0.1.7",
-              "target": "serde_tokenstream"
-            },
-            {
-              "id": "syn 1.0.109",
-              "target": "syn"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "version": "0.13.2"
       },
       "license": "Apache-2.0",
       "license_ids": [
@@ -50139,14 +50004,14 @@
       ],
       "license_file": "LICENSE"
     },
-    "pocket-ic 5.0.0": {
+    "pocket-ic 6.0.0": {
       "name": "pocket-ic",
-      "version": "5.0.0",
+      "version": "6.0.0",
       "package_url": "https://github.com/dfinity/ic",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/pocket-ic/5.0.0/download",
-          "sha256": "beff607d4dbebff8d003453ced669d2645e905de496ca93713f3d47633357e6c"
+          "url": "https://static.crates.io/crates/pocket-ic/6.0.0/download",
+          "sha256": "124a2380ca6f557adf8b02517cbfd2f564113230e14cda6f6aadd3dfe156293c"
         }
       },
       "targets": [
@@ -50183,8 +50048,12 @@
               "target": "hex"
             },
             {
-              "id": "ic-cdk 0.13.5",
-              "target": "ic_cdk"
+              "id": "ic-certification 2.6.0",
+              "target": "ic_certification"
+            },
+            {
+              "id": "ic-transport-types 0.37.1",
+              "target": "ic_transport_types"
             },
             {
               "id": "reqwest 0.12.9",
@@ -50203,6 +50072,10 @@
               "target": "serde_bytes"
             },
             {
+              "id": "serde_cbor 0.11.2",
+              "target": "serde_cbor"
+            },
+            {
               "id": "serde_json 1.0.132",
               "target": "serde_json"
             },
@@ -50213,6 +50086,14 @@
             {
               "id": "slog 2.7.0",
               "target": "slog"
+            },
+            {
+              "id": "strum 0.26.3",
+              "target": "strum"
+            },
+            {
+              "id": "thiserror 1.0.68",
+              "target": "thiserror"
             },
             {
               "id": "tokio 1.41.1",
@@ -50231,10 +50112,26 @@
               "target": "tracing_subscriber"
             }
           ],
-          "selects": {}
+          "selects": {
+            "cfg(windows)": [
+              {
+                "id": "wslpath 0.0.2",
+                "target": "wslpath"
+              }
+            ]
+          }
         },
         "edition": "2021",
-        "version": "5.0.0"
+        "proc_macro_deps": {
+          "common": [
+            {
+              "id": "strum_macros 0.26.4",
+              "target": "strum_macros"
+            }
+          ],
+          "selects": {}
+        },
+        "version": "6.0.0"
       },
       "license": "Apache-2.0",
       "license_ids": [
@@ -85242,6 +85139,44 @@
       ],
       "license_file": "LICENSE"
     },
+    "wslpath 0.0.2": {
+      "name": "wslpath",
+      "version": "0.0.2",
+      "package_url": "https://github.com/pratikpc/wsl-path-rust",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/wslpath/0.0.2/download",
+          "sha256": "04a2ecdf2cc4d33a6a93d71bcfbc00bb1f635cdb8029a2cc0709204a045ec7a3"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "wslpath",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "wslpath",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "edition": "2018",
+        "version": "0.0.2"
+      },
+      "license": "MIT",
+      "license_ids": [
+        "MIT"
+      ],
+      "license_file": "LICENSE"
+    },
     "wycheproof 0.6.0": {
       "name": "wycheproof",
       "version": "0.6.0",
@@ -86578,7 +86513,7 @@
     }
   },
   "binary_crates": [
-    "canbench 0.1.7",
+    "canbench 0.1.8",
     "ic-wasm 0.8.4",
     "metrics-proxy 0.1.0"
   ],
@@ -87686,8 +87621,8 @@
     "byteorder 1.5.0",
     "bytes 1.8.0",
     "cached 0.49.2",
-    "canbench 0.1.7",
-    "canbench-rs 0.1.7",
+    "canbench 0.1.8",
+    "canbench-rs 0.1.8",
     "candid 0.10.10",
     "candid_parser 0.1.2",
     "cargo_metadata 0.14.2",

--- a/Cargo.Bazel.Fuzzing.toml.lock
+++ b/Cargo.Bazel.Fuzzing.toml.lock
@@ -1677,9 +1677,9 @@ dependencies = [
 
 [[package]]
 name = "canbench"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf010ed5b327776525d545cef0fd17ffec73af71eb1b304ca11df3494ed65c31"
+checksum = "cb548f9e006ad29b160d37e07435c499af7d2741918e18d95ddc87dfe97a0b8d"
 dependencies = [
  "canbench-rs",
  "candid",
@@ -1699,9 +1699,9 @@ dependencies = [
 
 [[package]]
 name = "canbench-rs"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e85a8f1ee95044a770b3d5166a12f55814283cb3aed71b81439dc59960ab76c1"
+checksum = "497d900e11ab1891dd9743dd45dbeaada540ce323aa1adc7fc0ce1da2c6e86ff"
 dependencies = [
  "canbench-rs-macros",
  "candid",
@@ -1711,9 +1711,9 @@ dependencies = [
 
 [[package]]
 name = "canbench-rs-macros"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37aa9dbb190b03569ab14aadf669884a331712d54462c5a6c5b86c9867fe4e65"
+checksum = "5a5509bcfe6eeb86f057d46fbf20a2ba6b6bf9a1099b053a8f491cd7a909dfa6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5107,19 +5107,6 @@ dependencies = [
 
 [[package]]
 name = "ic-cdk"
-version = "0.13.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b1da6a25b045f9da3c9459c0cb2b0700ac368ee16382975a17185a23b9c18ab"
-dependencies = [
- "candid",
- "ic-cdk-macros 0.13.2",
- "ic0 0.21.1",
- "serde",
- "serde_bytes",
-]
-
-[[package]]
-name = "ic-cdk"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cff1a3c3db565e3384c9c9d6d676b0a3f89a0886f4f787294d9c946d844369f"
@@ -5176,20 +5163,6 @@ name = "ic-cdk-macros"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fde5ca6ef1e69825c68916ff1bf7256b8f7ed69ac5ea3f1756f6e57f1503e27"
-dependencies = [
- "candid",
- "proc-macro2",
- "quote",
- "serde",
- "serde_tokenstream 0.1.7",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "ic-cdk-macros"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a45800053d80a6df839a71aaea5797e723188c0b992618208ca3b941350c7355"
 dependencies = [
  "candid",
  "proc-macro2",
@@ -8168,25 +8141,31 @@ dependencies = [
 
 [[package]]
 name = "pocket-ic"
-version = "5.0.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "beff607d4dbebff8d003453ced669d2645e905de496ca93713f3d47633357e6c"
+checksum = "124a2380ca6f557adf8b02517cbfd2f564113230e14cda6f6aadd3dfe156293c"
 dependencies = [
  "base64 0.13.1",
  "candid",
  "hex",
- "ic-cdk 0.13.5",
+ "ic-certification",
+ "ic-transport-types",
  "reqwest 0.12.9",
  "schemars",
  "serde",
  "serde_bytes",
+ "serde_cbor",
  "serde_json",
  "sha2 0.10.8",
  "slog",
+ "strum 0.26.3",
+ "strum_macros 0.26.4",
+ "thiserror 1.0.68",
  "tokio",
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
+ "wslpath",
 ]
 
 [[package]]
@@ -13097,6 +13076,12 @@ name = "wsl"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dab7ac864710bdea6594becbea5b5050333cf34fefb0dc319567eb347950d4"
+
+[[package]]
+name = "wslpath"
+version = "0.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04a2ecdf2cc4d33a6a93d71bcfbc00bb1f635cdb8029a2cc0709204a045ec7a3"
 
 [[package]]
 name = "wycheproof"

--- a/Cargo.Bazel.json.lock
+++ b/Cargo.Bazel.json.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "a3824c6dae08a250d31e5907e2eff62575b38fd163dbb7e1c0f0ba342d66dc29",
+  "checksum": "9504732445804a8b57396f4c87d76da0f2cd5c9d2a16e0a13b9f08cc4dd54070",
   "crates": {
     "abnf 0.12.0": {
       "name": "abnf",
@@ -9865,14 +9865,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "canbench 0.1.7": {
+    "canbench 0.1.8": {
       "name": "canbench",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "package_url": "https://github.com/dfinity/canbench",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/canbench/0.1.7/download",
-          "sha256": "bf010ed5b327776525d545cef0fd17ffec73af71eb1b304ca11df3494ed65c31"
+          "url": "https://static.crates.io/crates/canbench/0.1.8/download",
+          "sha256": "cb548f9e006ad29b160d37e07435c499af7d2741918e18d95ddc87dfe97a0b8d"
         }
       },
       "targets": [
@@ -9909,7 +9909,7 @@
         "deps": {
           "common": [
             {
-              "id": "canbench-rs 0.1.7",
+              "id": "canbench-rs 0.1.8",
               "target": "canbench_rs"
             },
             {
@@ -9933,7 +9933,7 @@
               "target": "hex"
             },
             {
-              "id": "pocket-ic 5.0.0",
+              "id": "pocket-ic 6.0.0",
               "target": "pocket_ic"
             },
             {
@@ -9968,7 +9968,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.1.7"
+        "version": "0.1.8"
       },
       "license": "Apache-2.0",
       "license_ids": [
@@ -9976,14 +9976,14 @@
       ],
       "license_file": null
     },
-    "canbench-rs 0.1.7": {
+    "canbench-rs 0.1.8": {
       "name": "canbench-rs",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "package_url": "https://github.com/dfinity/canbench",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/canbench-rs/0.1.7/download",
-          "sha256": "e85a8f1ee95044a770b3d5166a12f55814283cb3aed71b81439dc59960ab76c1"
+          "url": "https://static.crates.io/crates/canbench-rs/0.1.8/download",
+          "sha256": "497d900e11ab1891dd9743dd45dbeaada540ce323aa1adc7fc0ce1da2c6e86ff"
         }
       },
       "targets": [
@@ -10026,13 +10026,13 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "canbench-rs-macros 0.1.7",
+              "id": "canbench-rs-macros 0.1.8",
               "target": "canbench_rs_macros"
             }
           ],
           "selects": {}
         },
-        "version": "0.1.7"
+        "version": "0.1.8"
       },
       "license": "Apache-2.0",
       "license_ids": [
@@ -10040,14 +10040,14 @@
       ],
       "license_file": null
     },
-    "canbench-rs-macros 0.1.7": {
+    "canbench-rs-macros 0.1.8": {
       "name": "canbench-rs-macros",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "package_url": "https://github.com/dfinity/canbench",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/canbench-rs-macros/0.1.7/download",
-          "sha256": "37aa9dbb190b03569ab14aadf669884a331712d54462c5a6c5b86c9867fe4e65"
+          "url": "https://static.crates.io/crates/canbench-rs-macros/0.1.8/download",
+          "sha256": "5a5509bcfe6eeb86f057d46fbf20a2ba6b6bf9a1099b053a8f491cd7a909dfa6"
         }
       },
       "targets": [
@@ -10087,7 +10087,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.1.7"
+        "version": "0.1.8"
       },
       "license": "Apache-2.0",
       "license_ids": [
@@ -18393,11 +18393,11 @@
               "target": "cached"
             },
             {
-              "id": "canbench 0.1.7",
+              "id": "canbench 0.1.8",
               "target": "canbench"
             },
             {
-              "id": "canbench-rs 0.1.7",
+              "id": "canbench-rs 0.1.8",
               "target": "canbench_rs"
             },
             {
@@ -31293,74 +31293,6 @@
       ],
       "license_file": "LICENSE"
     },
-    "ic-cdk 0.13.5": {
-      "name": "ic-cdk",
-      "version": "0.13.5",
-      "package_url": "https://github.com/dfinity/cdk-rs",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/ic-cdk/0.13.5/download",
-          "sha256": "3b1da6a25b045f9da3c9459c0cb2b0700ac368ee16382975a17185a23b9c18ab"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "ic_cdk",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "ic_cdk",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "candid 0.10.10",
-              "target": "candid"
-            },
-            {
-              "id": "ic0 0.21.1",
-              "target": "ic0"
-            },
-            {
-              "id": "serde 1.0.214",
-              "target": "serde"
-            },
-            {
-              "id": "serde_bytes 0.11.15",
-              "target": "serde_bytes"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "proc_macro_deps": {
-          "common": [
-            {
-              "id": "ic-cdk-macros 0.13.2",
-              "target": "ic_cdk_macros"
-            }
-          ],
-          "selects": {}
-        },
-        "version": "0.13.5"
-      },
-      "license": "Apache-2.0",
-      "license_ids": [
-        "Apache-2.0"
-      ],
-      "license_file": "LICENSE"
-    },
     "ic-cdk 0.14.1": {
       "name": "ic-cdk",
       "version": "0.14.1",
@@ -31692,73 +31624,6 @@
         },
         "edition": "2021",
         "version": "0.9.0"
-      },
-      "license": "Apache-2.0",
-      "license_ids": [
-        "Apache-2.0"
-      ],
-      "license_file": "LICENSE"
-    },
-    "ic-cdk-macros 0.13.2": {
-      "name": "ic-cdk-macros",
-      "version": "0.13.2",
-      "package_url": "https://github.com/dfinity/cdk-rs",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/ic-cdk-macros/0.13.2/download",
-          "sha256": "a45800053d80a6df839a71aaea5797e723188c0b992618208ca3b941350c7355"
-        }
-      },
-      "targets": [
-        {
-          "ProcMacro": {
-            "crate_name": "ic_cdk_macros",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "ic_cdk_macros",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "candid 0.10.10",
-              "target": "candid"
-            },
-            {
-              "id": "proc-macro2 1.0.89",
-              "target": "proc_macro2"
-            },
-            {
-              "id": "quote 1.0.37",
-              "target": "quote"
-            },
-            {
-              "id": "serde 1.0.214",
-              "target": "serde"
-            },
-            {
-              "id": "serde_tokenstream 0.1.7",
-              "target": "serde_tokenstream"
-            },
-            {
-              "id": "syn 1.0.109",
-              "target": "syn"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "version": "0.13.2"
       },
       "license": "Apache-2.0",
       "license_ids": [
@@ -49941,14 +49806,14 @@
       ],
       "license_file": "LICENSE"
     },
-    "pocket-ic 5.0.0": {
+    "pocket-ic 6.0.0": {
       "name": "pocket-ic",
-      "version": "5.0.0",
+      "version": "6.0.0",
       "package_url": "https://github.com/dfinity/ic",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/pocket-ic/5.0.0/download",
-          "sha256": "beff607d4dbebff8d003453ced669d2645e905de496ca93713f3d47633357e6c"
+          "url": "https://static.crates.io/crates/pocket-ic/6.0.0/download",
+          "sha256": "124a2380ca6f557adf8b02517cbfd2f564113230e14cda6f6aadd3dfe156293c"
         }
       },
       "targets": [
@@ -49985,8 +49850,12 @@
               "target": "hex"
             },
             {
-              "id": "ic-cdk 0.13.5",
-              "target": "ic_cdk"
+              "id": "ic-certification 2.6.0",
+              "target": "ic_certification"
+            },
+            {
+              "id": "ic-transport-types 0.37.1",
+              "target": "ic_transport_types"
             },
             {
               "id": "reqwest 0.12.9",
@@ -50005,6 +49874,10 @@
               "target": "serde_bytes"
             },
             {
+              "id": "serde_cbor 0.11.2",
+              "target": "serde_cbor"
+            },
+            {
               "id": "serde_json 1.0.132",
               "target": "serde_json"
             },
@@ -50015,6 +49888,14 @@
             {
               "id": "slog 2.7.0",
               "target": "slog"
+            },
+            {
+              "id": "strum 0.26.3",
+              "target": "strum"
+            },
+            {
+              "id": "thiserror 1.0.68",
+              "target": "thiserror"
             },
             {
               "id": "tokio 1.41.1",
@@ -50033,10 +49914,26 @@
               "target": "tracing_subscriber"
             }
           ],
-          "selects": {}
+          "selects": {
+            "cfg(windows)": [
+              {
+                "id": "wslpath 0.0.2",
+                "target": "wslpath"
+              }
+            ]
+          }
         },
         "edition": "2021",
-        "version": "5.0.0"
+        "proc_macro_deps": {
+          "common": [
+            {
+              "id": "strum_macros 0.26.4",
+              "target": "strum_macros"
+            }
+          ],
+          "selects": {}
+        },
+        "version": "6.0.0"
       },
       "license": "Apache-2.0",
       "license_ids": [
@@ -85062,6 +84959,44 @@
       ],
       "license_file": "LICENSE"
     },
+    "wslpath 0.0.2": {
+      "name": "wslpath",
+      "version": "0.0.2",
+      "package_url": "https://github.com/pratikpc/wsl-path-rust",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/wslpath/0.0.2/download",
+          "sha256": "04a2ecdf2cc4d33a6a93d71bcfbc00bb1f635cdb8029a2cc0709204a045ec7a3"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "wslpath",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "wslpath",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "edition": "2018",
+        "version": "0.0.2"
+      },
+      "license": "MIT",
+      "license_ids": [
+        "MIT"
+      ],
+      "license_file": "LICENSE"
+    },
     "wycheproof 0.6.0": {
       "name": "wycheproof",
       "version": "0.6.0",
@@ -86536,7 +86471,7 @@
     }
   },
   "binary_crates": [
-    "canbench 0.1.7",
+    "canbench 0.1.8",
     "ic-wasm 0.8.4",
     "metrics-proxy 0.1.0"
   ],
@@ -87566,8 +87501,8 @@
     "byteorder 1.5.0",
     "bytes 1.8.0",
     "cached 0.49.2",
-    "canbench 0.1.7",
-    "canbench-rs 0.1.7",
+    "canbench 0.1.8",
+    "canbench-rs 0.1.8",
     "candid 0.10.10",
     "candid_parser 0.1.2",
     "cargo_metadata 0.14.2",

--- a/Cargo.Bazel.toml.lock
+++ b/Cargo.Bazel.toml.lock
@@ -1678,9 +1678,9 @@ dependencies = [
 
 [[package]]
 name = "canbench"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf010ed5b327776525d545cef0fd17ffec73af71eb1b304ca11df3494ed65c31"
+checksum = "cb548f9e006ad29b160d37e07435c499af7d2741918e18d95ddc87dfe97a0b8d"
 dependencies = [
  "canbench-rs",
  "candid",
@@ -1700,9 +1700,9 @@ dependencies = [
 
 [[package]]
 name = "canbench-rs"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e85a8f1ee95044a770b3d5166a12f55814283cb3aed71b81439dc59960ab76c1"
+checksum = "497d900e11ab1891dd9743dd45dbeaada540ce323aa1adc7fc0ce1da2c6e86ff"
 dependencies = [
  "canbench-rs-macros",
  "candid",
@@ -1712,9 +1712,9 @@ dependencies = [
 
 [[package]]
 name = "canbench-rs-macros"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37aa9dbb190b03569ab14aadf669884a331712d54462c5a6c5b86c9867fe4e65"
+checksum = "5a5509bcfe6eeb86f057d46fbf20a2ba6b6bf9a1099b053a8f491cd7a909dfa6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5097,19 +5097,6 @@ dependencies = [
 
 [[package]]
 name = "ic-cdk"
-version = "0.13.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b1da6a25b045f9da3c9459c0cb2b0700ac368ee16382975a17185a23b9c18ab"
-dependencies = [
- "candid",
- "ic-cdk-macros 0.13.2",
- "ic0 0.21.1",
- "serde",
- "serde_bytes",
-]
-
-[[package]]
-name = "ic-cdk"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cff1a3c3db565e3384c9c9d6d676b0a3f89a0886f4f787294d9c946d844369f"
@@ -5166,20 +5153,6 @@ name = "ic-cdk-macros"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fde5ca6ef1e69825c68916ff1bf7256b8f7ed69ac5ea3f1756f6e57f1503e27"
-dependencies = [
- "candid",
- "proc-macro2",
- "quote",
- "serde",
- "serde_tokenstream 0.1.7",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "ic-cdk-macros"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a45800053d80a6df839a71aaea5797e723188c0b992618208ca3b941350c7355"
 dependencies = [
  "candid",
  "proc-macro2",
@@ -8158,25 +8131,31 @@ dependencies = [
 
 [[package]]
 name = "pocket-ic"
-version = "5.0.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "beff607d4dbebff8d003453ced669d2645e905de496ca93713f3d47633357e6c"
+checksum = "124a2380ca6f557adf8b02517cbfd2f564113230e14cda6f6aadd3dfe156293c"
 dependencies = [
  "base64 0.13.1",
  "candid",
  "hex",
- "ic-cdk 0.13.5",
+ "ic-certification",
+ "ic-transport-types",
  "reqwest 0.12.9",
  "schemars",
  "serde",
  "serde_bytes",
+ "serde_cbor",
  "serde_json",
  "sha2 0.10.8",
  "slog",
+ "strum 0.26.3",
+ "strum_macros 0.26.4",
+ "thiserror 1.0.68",
  "tokio",
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
+ "wslpath",
 ]
 
 [[package]]
@@ -13092,6 +13071,12 @@ name = "wsl"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dab7ac864710bdea6594becbea5b5050333cf34fefb0dc319567eb347950d4"
+
+[[package]]
+name = "wslpath"
+version = "0.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04a2ecdf2cc4d33a6a93d71bcfbc00bb1f635cdb8029a2cc0709204a045ec7a3"
 
 [[package]]
 name = "wycheproof"

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -782,8 +782,8 @@ http_file(
 
 http_file(
     name = "pocket-ic-mainnet-gz",
-    sha256 = "454891cac2421f3f894759ec5e6b6e48fbb544d79197bc29b88d34b93d78a4f1",
-    url = "https://download.dfinity.systems/ic/52ebccfba8855e23dcad9657a8d6e6be01df71f9/binaries/x86_64-linux/pocket-ic.gz",
+    sha256 = "0935ee6ece312719aae4eabddec2dfc6af34d5edbddf4d3af53bccd1b3636044",
+    url = "https://download.dfinity.systems/ic/172f8c78653c93ad101af75b94251439b4ccf098/binaries/x86_64-linux/pocket-ic.gz",
 )
 
 # Patches

--- a/bazel/external_crates.bzl
+++ b/bazel/external_crates.bzl
@@ -329,10 +329,10 @@ def external_crates_repository(name, cargo_lockfile, lockfile, sanitizers_enable
                 default_features = False,
             ),
             "canbench": crate.spec(
-                version = "^0.1.7",
+                version = "^0.1.8",
             ),
             "canbench-rs": crate.spec(
-                version = "^0.1.7",
+                version = "^0.1.8",
             ),
             "candid": crate.spec(
                 version = "^0.10.6",


### PR DESCRIPTION
Bumping canbench and the pocket-ic-mainnet versions so that the performance tests based on canbench can be run successfully.