### PR TITLE
perf(sns): Set up canbench

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11867,6 +11867,7 @@ dependencies = [
  "base64 0.13.1",
  "build-info",
  "build-info-build",
+ "canbench-rs",
  "candid",
  "candid_parser",
  "clap 4.5.20",

--- a/rs/sns/governance/BUILD.bazel
+++ b/rs/sns/governance/BUILD.bazel
@@ -1,5 +1,6 @@
 load("@rules_rust//cargo:defs.bzl", "cargo_build_script")
 load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test")
+load("//bazel:canbench.bzl", "rust_canbench")
 load("//bazel:canisters.bzl", "rust_canister")
 load("//bazel:defs.bzl", "rust_test_suite_with_extra_srcs")
 load("//bazel:prost.bzl", "generated_files_check")
@@ -128,6 +129,20 @@ rust_library(
     deps = DEPENDENCIES + [":build_script"],
 )
 
+rust_library(
+    name = "governance--canbench_feature",
+    srcs = LIB_SRCS,
+    aliases = ALIASES,
+    crate_features = ["canbench-rs"],
+    crate_name = "ic_sns_governance",
+    proc_macro_deps = MACRO_DEPENDENCIES,
+    version = "0.9.0",
+    deps = DEPENDENCIES + [
+        ":build_script",
+        "@crate_index//:canbench-rs",
+    ],
+)
+
 rust_canister(
     name = "sns-governance-canister",
     srcs = ["canister/canister.rs"],
@@ -227,5 +242,24 @@ generated_files_check(
         "//rs/sns/governance/protobuf_generator:lib",
         "//rs/test_utilities/compare_dirs",
         "@crate_index//:tempfile",
+    ],
+)
+
+# Usage:
+# bazel run //rs/sns/governance:governance-canbench for benchmarking (the output shoudl look like `canbench/canbench_results.yml`).
+# bazel run //rs/sns/governance:governance-canbench_update for updating the results file (see `canbench/canbench_results.yml`).
+# bazel test //rs/sns/governance:governance_canbench_test for checking if the results file is up to date.
+# Currently, updating the results file is not automated, and there are no tests to avoid
+# regression. For now, we can use it as an example for benchmarking as part of an
+# investigation of potential performance issues, or when we make a change that can affect
+# the performance measured in this benchmark.
+rust_canbench(
+    name = "governance-canbench",
+    srcs = ["canbench/main.rs"],
+    add_test = True,
+    results_file = "canbench/canbench_results.yml",
+    deps = [
+        # Keep sorted.
+        ":governance--canbench_feature",
     ],
 )

--- a/rs/sns/governance/Cargo.toml
+++ b/rs/sns/governance/Cargo.toml
@@ -81,6 +81,7 @@ serde_bytes = { workspace = true }
 strum = { workspace = true }
 strum_macros = { workspace = true }
 time = { workspace = true }
+canbench-rs = { version = "0.1.7", optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 ic-types = { path = "../../types/types" }
@@ -113,3 +114,4 @@ tokio-test = { workspace = true }
 
 [features]
 test = []
+canbench-rs = ["dep:canbench-rs"]

--- a/rs/sns/governance/canbench/canbench_results.yml
+++ b/rs/sns/governance/canbench/canbench_results.yml
@@ -1,0 +1,8 @@
+benches:
+  bench_example:
+    total:
+      instructions: 5638
+      heap_increase: 0
+      stable_memory_increase: 0
+    scopes: {}
+version: 0.1.7

--- a/rs/sns/governance/canbench/main.rs
+++ b/rs/sns/governance/canbench/main.rs
@@ -1,0 +1,4 @@
+#[allow(unused_imports, clippy::single_component_path_imports)]
+use ic_sns_governance;
+
+fn main() {}

--- a/rs/sns/governance/src/governance.rs
+++ b/rs/sns/governance/src/governance.rs
@@ -5933,3 +5933,6 @@ mod advance_target_sns_version_tests;
 
 #[cfg(test)]
 mod test_helpers;
+
+#[cfg(feature = "canbench-rs")]
+mod benches;

--- a/rs/sns/governance/src/governance/benches.rs
+++ b/rs/sns/governance/src/governance/benches.rs
@@ -1,0 +1,16 @@
+use canbench_rs::bench;
+
+#[bench(raw)]
+fn bench_example() -> canbench_rs::BenchResult {
+    fn example_function_to_benchmark(a: u64) {
+        for _ in 0..a {
+            // Use std::hint::black_box to prevent the compiler from optimizing out the loop.
+            std::hint::black_box(a);
+        }
+    }
+
+    let a = 1000;
+
+    // The argument to bench_fn is the code to benchmark.
+    canbench_rs::bench_fn(|| example_function_to_benchmark(a))
+}


### PR DESCRIPTION
This sets up canbench in the SNS with one simple example benchmark. Hopefully we can extend it in the future with benchmarks of our canister code, to identify performance regressions and bottlenecks.