### PR TITLE
chore(nns): Disable canbench test for NNS Governance

### DIFF
--- a/rs/nns/governance/BUILD.bazel
+++ b/rs/nns/governance/BUILD.bazel
@@ -197,7 +197,6 @@ rust_library(
 # Usage:
 # bazel run //rs/nns/governance:governance-canbench for benchmarking
 # bazel run //rs/nns/governance:governance-canbench_update for updating the results file.
-# bazel test //rs/nns/governance:governance_canbench_test for checking if the results file is up to date.
 # Currently, updating the results file is not automated, and there are no tests to avoid
 # regression. For now, we can use it as an example for benchmarking as part of an
 # investigation of potential performance issues, or when we make a change that can affect
@@ -206,7 +205,6 @@ rust_library(
 rust_canbench(
     name = "governance-canbench",
     srcs = ["canbench/main.rs"],
-    add_test = True,
     results_file = "canbench/canbench_results.yml",
     deps = [
         # Keep sorted.


### PR DESCRIPTION
# Why

Currently, the benchmarks in NNS Governance aren't very stable. Sometimes they go over 2% noise threshold, and currently the noise threshold is still hard-coded in canbench.

# What

Disable the canbench test in the NNS Governance until we can either make the benchmarks more stable or increase the noise threshold.