### PR TITLE
test(IDX): improve error message in xnet_slo_test

### DIFF
--- a/rs/tests/message_routing/common/common.rs
+++ b/rs/tests/message_routing/common/common.rs
@@ -34,10 +34,10 @@ pub async fn start_all_canisters(
             let _: String = canister
                 .update_("start", candid, input)
                 .await
-                .unwrap_or_else(|_| {
+                .unwrap_or_else(|e| {
                     panic!(
-                        "Starting canister_idx={} on subnet_idx={}",
-                        canister_idx, subnet_idx
+                        "Starting canister_idx={} on subnet_idx={} failed because of: {}",
+                        canister_idx, subnet_idx, e
                     )
                 });
         });


### PR DESCRIPTION
The `//rs/tests/message_routing/xnet:xnet_slo_3_subnets_test` is currently failing on master when starting canisters. This commit improves the error message we get in this case:
```
2024-12-05 09:42:53.985 INFO[test:StdErr] Starting canister_idx=0 on subnet_idx=1 failed because of: 
unexpected result: "rejected" - Some("Error from Canister 5v3p4-iyaaa-aaaaa-qaaaa-cai: 
Canister called `ic0.trap` with message: failed to decode call arguments: 
Custom(Fail to decode argument 0 from table0 to record 
{\n  payload_size_bytes : nat64;\n  
network_topology : vec vec principal;\n  
canister_to_subnet_rate : nat64;\n}\n\nCaused by:\n    
Subtyping error: Type mismatch at external/crate_index__candid-0.10.10/src/de.rs:994)\n
Canister Backtrace:\nunknown function at index 683\n
unknown function at index 50\nunknown function at index 451\n.\n
Consider gracefully handling failures from this canister or altering the canister to handle exceptions. 
See documentation: http://internetcomputer.org/docs/current/references/execution-errors#trapped-explicitly")
```