### PR TITLE
fix: Fix XNet end-to-end tests

### DIFF
--- a/rs/tests/message_routing/common/common.rs
+++ b/rs/tests/message_routing/common/common.rs
@@ -41,7 +41,7 @@ pub async fn start_all_canisters(
                 .await
                 .unwrap_or_else(|_| {
                     panic!(
-                        "Starting canister_idx={} on subnet_idx={} failed.",
+                        "Starting canister_idx={} on subnet_idx={}",
                         canister_idx, subnet_idx
                     )
                 });

--- a/rs/tests/message_routing/common/common.rs
+++ b/rs/tests/message_routing/common/common.rs
@@ -7,6 +7,7 @@ use ic_system_test_driver::driver::test_env::TestEnv;
 use ic_system_test_driver::driver::test_env_api::get_dependency_path;
 use slog::info;
 use std::{convert::TryFrom, env};
+use xnet_test::StartArgs;
 
 /// Concurrently calls `start` on all canisters in `canisters` with the
 /// given parameters.
@@ -29,14 +30,18 @@ pub async fn start_all_canisters(
         .enumerate()
         .flat_map(|(x, v)| v.iter().enumerate().map(move |(y, v)| (x, y, v)))
     {
-        let input = (&topology, canister_to_subnet_rate, payload_size_bytes);
+        let input = StartArgs {
+            network_topology: topology.clone(),
+            canister_to_subnet_rate,
+            payload_size_bytes,
+        };
         futures.push(async move {
             let _: String = canister
-                .update_("start", candid, input)
+                .update_("start", candid, (input,))
                 .await
                 .unwrap_or_else(|_| {
                     panic!(
-                        "Starting canister_idx={} on subnet_idx={}",
+                        "Starting canister_idx={} on subnet_idx={} failed.",
                         canister_idx, subnet_idx
                     )
                 });


### PR DESCRIPTION
Encode the arguments to the start method as the newly defined StartArgs struct instead of a tuple.