### PR TITLE
chore(IDX): enable bitcoind tests on macos

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -98,6 +98,17 @@ test_suite(
     tests = ["//rs/tests/testing_verification/testnets:single_large_node"],
 )
 
+### Bitcoind
+
+alias(
+    name = "bitcoind",
+    actual = select({
+        "@bazel_tools//src/conditions:darwin_arm64": "@bitcoin_core_darwin_arm64//:bitcoind",
+        "@bazel_tools//src/conditions:darwin_x86_64": "@bitcoin_core_darwin_x86//:bitcoind",
+        "@bazel_tools//src/conditions:linux_x86_64": "@bitcoin_core_linux//:bitcoind",
+    }),
+)
+
 ### Pocket IC
 
 # The pocket-ic server binary. Use this as a test dependency if the test

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -768,7 +768,7 @@ cc_library(
 )
 
 http_archive(
-    name = "bitcoin_core",
+    name = "bitcoin_core_linux",
     build_file_content = """
 package(default_visibility = ["//visibility:public"])
 filegroup(
@@ -781,6 +781,40 @@ filegroup(
     urls = [
         "https://bitcoin.org/bin/bitcoin-core-27.0/bitcoin-27.0-x86_64-linux-gnu.tar.gz",
         "https://bitcoincore.org/bin/bitcoin-core-27.0/bitcoin-27.0-x86_64-linux-gnu.tar.gz",
+    ],
+)
+
+http_archive(
+    name = "bitcoin_core_darwin_x86",
+    build_file_content = """
+package(default_visibility = ["//visibility:public"])
+filegroup(
+    name = "bitcoind",
+    srcs = ["bin/bitcoind"],
+)
+""",
+    sha256 = "e1efd8c4605b2aabc876da93b6eee2bedd868ce7d1f02b0220c1001f903b3e2c",
+    strip_prefix = "bitcoin-27.0",
+    urls = [
+        "https://bitcoin.org/bin/bitcoin-core-27.0/bitcoin-27.0-x86_64-apple-darwin.tar.gz",
+        "https://bitcoincore.org/bin/bitcoin-core-27.0/bitcoin-27.0-x86_64-apple-darwin.tar.gz",
+    ],
+)
+
+http_archive(
+    name = "bitcoin_core_darwin_arm64",
+    build_file_content = """
+package(default_visibility = ["//visibility:public"])
+filegroup(
+    name = "bitcoind",
+    srcs = ["bin/bitcoind"],
+)
+""",
+    sha256 = "1d9d9b837297a73fc7a3b1cfed376644e3fa25c4e1672fbc143d5946cb52431d",
+    strip_prefix = "bitcoin-27.0",
+    urls = [
+        "https://bitcoin.org/bin/bitcoin-core-27.0/bitcoin-27.0-arm64-apple-darwin.tar.gz",
+        "https://bitcoincore.org/bin/bitcoin-core-27.0/bitcoin-27.0-arm64-apple-darwin.tar.gz",
     ],
 )
 

--- a/rs/bitcoin/adapter/BUILD.bazel
+++ b/rs/bitcoin/adapter/BUILD.bazel
@@ -105,14 +105,14 @@ rust_test_suite(
     aliases = ALIASES,
     data = [
         # Keep sorted.
+        "//:bitcoind",
         "@bitcoin_adapter_mainnet_blocks//file",
         "@bitcoin_adapter_mainnet_headers//file",
         "@bitcoin_adapter_testnet_blocks//file",
         "@bitcoin_adapter_testnet_headers//file",
-        "@bitcoin_core//:bitcoind",
     ],
     env = {
-        "BITCOIN_CORE_PATH": "$(rootpath @bitcoin_core//:bitcoind)",
+        "BITCOIN_CORE_PATH": "$(rootpath //:bitcoind)",
         "HEADERS_DATA_PATH": "$(rootpath @bitcoin_adapter_mainnet_headers//file)",
         "BLOCKS_DATA_PATH": "$(rootpath @bitcoin_adapter_mainnet_blocks//file)",
         "TESTNET_HEADERS_DATA_PATH": "$(rootpath @bitcoin_adapter_testnet_headers//file)",

--- a/rs/pocket_ic_server/BUILD.bazel
+++ b/rs/pocket_ic_server/BUILD.bazel
@@ -223,15 +223,16 @@ rust_test(
     aliases = {},
     data = [
         ":pocket-ic-server",
-        "@bitcoin_core//:bitcoind",
+        "//:bitcoind",
         "@bitcoin_example_canister//file",
         "@btc_canister//file",
     ],
     env = {
         "POCKET_IC_BIN": "$(rootpath :pocket-ic-server)",
         "BASIC_BITCOIN_WASM": "$(rootpath @bitcoin_example_canister//file)",
-        "BITCOIND_BIN": "$(rootpath @bitcoin_core//:bitcoind)",
+        "BITCOIND_BIN": "$(rootpath //:bitcoind)",
         "BTC_WASM": "$(rootpath @btc_canister//file)",
     },
+    tags = ["test_macos"],
     deps = TEST_DEPENDENCIES,
 )


### PR DESCRIPTION
This adds two new prebuilt `bitcoind` executables and a new target, `//:bitcoind`, which points to the (platform) correct executable. This allows us to mark `bitcoind` tests as `test_macos`.