### PR TITLE
feat(nns): Propose voting power economics.

### DIFF
--- a/rs/nns/governance/api/src/ic_nns_governance.pb.v1.rs
+++ b/rs/nns/governance/api/src/ic_nns_governance.pb.v1.rs
@@ -2035,15 +2035,13 @@ pub struct ProposalInfo {
     #[prost(uint64, optional, tag = "21")]
     pub total_potential_voting_power: ::core::option::Option<u64>,
 }
+
 /// Network economics contains the parameters for several operations related
 /// to the economy of the network. When submitting a NetworkEconomics proposal
 /// default values (0) are considered unchanged, so a valid proposal only needs
 /// to set the parameters that it wishes to change.
 /// In other words, it's not possible to set any of the values of
 /// NetworkEconomics to 0.
-///
-/// NOTE: If adding a value to this proto, make sure there is a corresponding
-/// `if` in Governance::perform_action().
 #[derive(candid::CandidType, candid::Deserialize, serde::Serialize, comparable::Comparable)]
 #[self_describing]
 #[allow(clippy::derive_partial_eq_without_eq)]

--- a/rs/nns/governance/proto/ic_nns_governance/pb/v1/governance.proto
+++ b/rs/nns/governance/proto/ic_nns_governance/pb/v1/governance.proto
@@ -1844,9 +1844,6 @@ message ProposalInfo {
 // to set the parameters that it wishes to change.
 // In other words, it's not possible to set any of the values of
 // NetworkEconomics to 0.
-//
-// NOTE: If adding a value to this proto, make sure there is a corresponding
-// `if` in Governance::perform_action().
 message NetworkEconomics {
   reserved 3, 7;
   // The number of E8s (10E-8 of an ICP token) that a rejected

--- a/rs/nns/governance/src/gen/ic_nns_governance.pb.v1.rs
+++ b/rs/nns/governance/src/gen/ic_nns_governance.pb.v1.rs
@@ -2491,9 +2491,6 @@ pub struct ProposalInfo {
 /// to set the parameters that it wishes to change.
 /// In other words, it's not possible to set any of the values of
 /// NetworkEconomics to 0.
-///
-/// NOTE: If adding a value to this proto, make sure there is a corresponding
-/// `if` in Governance::perform_action().
 #[derive(candid::CandidType, candid::Deserialize, serde::Serialize, comparable::Comparable)]
 #[self_describing]
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/rs/nns/governance/src/governance.rs
+++ b/rs/nns/governance/src/governance.rs
@@ -4833,6 +4833,8 @@ impl Governance {
 
     fn perform_manage_network_economics(&mut self, new_network_economics: NetworkEconomics) {
         let Some(original_network_economics) = &self.heap_data.economics else {
+            // This wouldn't happen in production, but if it does, we try to do
+            // the best we can, because doing nothing seems more catastrophic.
             println!(
                 "{}ERROR: NetworkEconomics was not set. Setting to proposed NetworkEconomics:\n{:#?}",
                 LOG_PREFIX, new_network_economics,
@@ -4842,7 +4844,7 @@ impl Governance {
         };
 
         self.heap_data.economics =
-            Some(new_network_economics.inherit_from(&original_network_economics));
+            Some(new_network_economics.inherit_from(original_network_economics));
     }
 
     async fn perform_install_code(&mut self, proposal_id: u64, install_code: InstallCode) {

--- a/rs/nns/governance/src/governance.rs
+++ b/rs/nns/governance/src/governance.rs
@@ -283,8 +283,7 @@ impl NetworkEconomics {
         /// Returns ours if it is nonzero. Otherwise, returns default.
         fn inherit_from<Primitive>(ours: Primitive, default: Primitive) -> Primitive
         where
-            Primitive:
-                Default
+            Primitive: Default
                 + Eq
                 // Not actually used. This is just to make sure we only support numbers.
                 // This could be relaxed (i.e. deleted) later.
@@ -299,13 +298,34 @@ impl NetworkEconomics {
 
         Self {
             reject_cost_e8s: inherit_from(self.reject_cost_e8s, defaults.reject_cost_e8s),
-            neuron_minimum_stake_e8s: inherit_from(self.neuron_minimum_stake_e8s, defaults.neuron_minimum_stake_e8s),
-            neuron_management_fee_per_proposal_e8s: inherit_from(self.neuron_management_fee_per_proposal_e8s, defaults.neuron_management_fee_per_proposal_e8s),
-            minimum_icp_xdr_rate: inherit_from(self.minimum_icp_xdr_rate, defaults.minimum_icp_xdr_rate),
-            neuron_spawn_dissolve_delay_seconds: inherit_from(self.neuron_spawn_dissolve_delay_seconds, defaults.neuron_spawn_dissolve_delay_seconds),
-            maximum_node_provider_rewards_e8s: inherit_from(self.maximum_node_provider_rewards_e8s, defaults.maximum_node_provider_rewards_e8s),
-            transaction_fee_e8s: inherit_from(self.transaction_fee_e8s, defaults.transaction_fee_e8s),
-            max_proposals_to_keep_per_topic: inherit_from(self.max_proposals_to_keep_per_topic, defaults.max_proposals_to_keep_per_topic),
+            neuron_minimum_stake_e8s: inherit_from(
+                self.neuron_minimum_stake_e8s,
+                defaults.neuron_minimum_stake_e8s,
+            ),
+            neuron_management_fee_per_proposal_e8s: inherit_from(
+                self.neuron_management_fee_per_proposal_e8s,
+                defaults.neuron_management_fee_per_proposal_e8s,
+            ),
+            minimum_icp_xdr_rate: inherit_from(
+                self.minimum_icp_xdr_rate,
+                defaults.minimum_icp_xdr_rate,
+            ),
+            neuron_spawn_dissolve_delay_seconds: inherit_from(
+                self.neuron_spawn_dissolve_delay_seconds,
+                defaults.neuron_spawn_dissolve_delay_seconds,
+            ),
+            maximum_node_provider_rewards_e8s: inherit_from(
+                self.maximum_node_provider_rewards_e8s,
+                defaults.maximum_node_provider_rewards_e8s,
+            ),
+            transaction_fee_e8s: inherit_from(
+                self.transaction_fee_e8s,
+                defaults.transaction_fee_e8s,
+            ),
+            max_proposals_to_keep_per_topic: inherit_from(
+                self.max_proposals_to_keep_per_topic,
+                defaults.max_proposals_to_keep_per_topic,
+            ),
 
             // TODO(NNS1-3499): Ideally, we would recurse into T, because
             // otherwise, you have to set a bundle of parameters all at once. In

--- a/rs/nns/governance/src/governance.rs
+++ b/rs/nns/governance/src/governance.rs
@@ -297,22 +297,6 @@ impl NetworkEconomics {
             ours
         }
 
-        // Ideally, we would recurse into T, because otherwise, you have to set
-        // a bundle of parameters all at once. In other words, the current
-        // implementation does not support setting individual subfields, a la
-        // carte.
-        fn inherit_from_option<T>(ours: &Option<T>, defaults: &Option<T>) -> T
-        where
-            T: Clone,
-        {
-            if ours.is_none() {
-                ours
-            } else {
-                defaults
-            }
-            .clone()
-        }
-
         Self {
             reject_cost_e8s: inherit_from(self.reject_cost_e8s, defaults.reject_cost_e8s),
             neuron_minimum_stake_e8s: inherit_from(self.neuron_minimum_stake_e8s, defaults.neuron_minimum_stake_e8s),
@@ -323,8 +307,20 @@ impl NetworkEconomics {
             transaction_fee_e8s: inherit_from(self.transaction_fee_e8s, defaults.transaction_fee_e8s),
             max_proposals_to_keep_per_topic: inherit_from(self.max_proposals_to_keep_per_topic, defaults.max_proposals_to_keep_per_topic),
 
-            neurons_fund_economics: inherit_from_option(&self.neurons_fund_economics, &defaults.neurons_fund_economics),
-            voting_power_economics: inherit_from_option(&self.voting_power_economics, &defaults.voting_power_economics),
+            // Ideally, we would recurse into T, because otherwise, you have to
+            // set a bundle of parameters all at once. In other words, the
+            // current implementation does not support setting individual
+            // subfields, a la carte.
+            neurons_fund_economics: self
+                .neurons_fund_economics
+                .as_ref()
+                .or(defaults.neurons_fund_economics.as_ref())
+                .cloned(),
+            voting_power_economics: self
+                .voting_power_economics
+                .as_ref()
+                .or(defaults.voting_power_economics.as_ref())
+                .cloned(),
         }
     }
 }

--- a/rs/nns/governance/src/governance.rs
+++ b/rs/nns/governance/src/governance.rs
@@ -283,7 +283,7 @@ impl NetworkEconomics {
         /// Returns ours if it is the default (for its type). Otherwise, returns default.
         fn inherit_from<T>(ours: T, default: T) -> T
         where
-            T: Default + PartialEq
+            T: Default + PartialEq,
         {
             if ours == T::default() {
                 return default;

--- a/rs/nns/governance/src/governance.rs
+++ b/rs/nns/governance/src/governance.rs
@@ -307,10 +307,10 @@ impl NetworkEconomics {
             transaction_fee_e8s: inherit_from(self.transaction_fee_e8s, defaults.transaction_fee_e8s),
             max_proposals_to_keep_per_topic: inherit_from(self.max_proposals_to_keep_per_topic, defaults.max_proposals_to_keep_per_topic),
 
-            // Ideally, we would recurse into T, because otherwise, you have to
-            // set a bundle of parameters all at once. In other words, the
-            // current implementation does not support setting individual
-            // subfields, a la carte.
+            // TODO(NNS1-3499): Ideally, we would recurse into T, because
+            // otherwise, you have to set a bundle of parameters all at once. In
+            // other words, the current implementation does not support setting
+            // individual subfields, a la carte.
             neurons_fund_economics: self
                 .neurons_fund_economics
                 .as_ref()

--- a/rs/nns/governance/src/governance.rs
+++ b/rs/nns/governance/src/governance.rs
@@ -280,16 +280,12 @@ impl NetworkEconomics {
     /// value are replaced with the value from defaults. In particular, 0 and
     /// None are replaced.
     fn inherit_from(&self, defaults: &Self) -> Self {
-        /// Returns ours if it is nonzero. Otherwise, returns default.
-        fn inherit_from<Primitive>(ours: Primitive, default: Primitive) -> Primitive
+        /// Returns ours if it is the default (for its type). Otherwise, returns default.
+        fn inherit_from<T>(ours: T, default: T) -> T
         where
-            Primitive: Default
-                + Eq
-                // Not actually used. This is just to make sure we only support numbers.
-                // This could be relaxed (i.e. deleted) later.
-                + std::ops::Add,
+            T: Default + PartialEq
         {
-            if ours == Primitive::default() {
+            if ours == T::default() {
                 return default;
             }
 
@@ -331,16 +327,16 @@ impl NetworkEconomics {
             // otherwise, you have to set a bundle of parameters all at once. In
             // other words, the current implementation does not support setting
             // individual subfields, a la carte.
-            neurons_fund_economics: self
-                .neurons_fund_economics
-                .as_ref()
-                .or(defaults.neurons_fund_economics.as_ref())
-                .cloned(),
-            voting_power_economics: self
-                .voting_power_economics
-                .as_ref()
-                .or(defaults.voting_power_economics.as_ref())
-                .cloned(),
+            neurons_fund_economics: inherit_from(
+                self.neurons_fund_economics.as_ref(),
+                defaults.neurons_fund_economics.as_ref(),
+            )
+            .cloned(),
+            voting_power_economics: inherit_from(
+                self.voting_power_economics.as_ref(),
+                defaults.voting_power_economics.as_ref(),
+            )
+            .cloned(),
         }
     }
 }

--- a/rs/nns/governance/tests/governance.rs
+++ b/rs/nns/governance/tests/governance.rs
@@ -7787,8 +7787,7 @@ fn test_network_economics_proposal() {
         .unwrap()
         .neuron_minimum_stake_e8s = 1234;
 
-    // Making a proposal to change 'reject_cost_e8s' should only change
-    // that value.
+    // Propose to change some, NetworkEconomics parameters.
     let pid = match gov
         .manage_neuron(
             &voter_pid,
@@ -7826,16 +7825,18 @@ fn test_network_economics_proposal() {
         ProposalStatus::Executed
     );
 
-    // Make sure only that value changed.
+    // Verify that only the two fields specified by the proposal are changed.
     assert_eq!(
         gov.heap_data.economics.as_ref().unwrap(),
-        NetworkEconomics {
+        &NetworkEconomics {
             reject_cost_e8s: 56789,
-            neuron_minimum_stake_e8s: 1234,
             voting_power_economics: Some(VotingPowerEconomics {
                 start_reducing_voting_power_after_seconds: Some(42),
                 clear_following_after_seconds: Some(4242),
-            },
+            }),
+
+            // No changes to the rest.
+            neuron_minimum_stake_e8s: 1234,
             ..NetworkEconomics::with_default_values()
         },
     );

--- a/rs/nns/governance/tests/governance.rs
+++ b/rs/nns/governance/tests/governance.rs
@@ -7801,6 +7801,10 @@ fn test_network_economics_proposal() {
                     url: "".to_string(),
                     action: Some(proposal::Action::ManageNetworkEconomics(NetworkEconomics {
                         reject_cost_e8s: 56789,
+                        voting_power_economics: Some(VotingPowerEconomics {
+                            start_reducing_voting_power_after_seconds: Some(42),
+                            clear_following_after_seconds: Some(4242),
+                        }),
                         ..Default::default()
                     })),
                 }))),
@@ -7824,16 +7828,16 @@ fn test_network_economics_proposal() {
 
     // Make sure only that value changed.
     assert_eq!(
-        gov.heap_data.economics.as_ref().unwrap().reject_cost_e8s,
-        56789
-    );
-    assert_eq!(
-        gov.heap_data
-            .economics
-            .as_ref()
-            .unwrap()
-            .neuron_minimum_stake_e8s,
-        1234
+        gov.heap_data.economics.as_ref().unwrap(),
+        NetworkEconomics {
+            reject_cost_e8s: 56789,
+            neuron_minimum_stake_e8s: 1234,
+            voting_power_economics: Some(VotingPowerEconomics {
+                start_reducing_voting_power_after_seconds: Some(42),
+                clear_following_after_seconds: Some(4242),
+            },
+            ..NetworkEconomics::with_default_values()
+        },
     );
 }
 


### PR DESCRIPTION
In a previous change, we added VotingPowerEconomics to NetworkEconomics. But it wasn't possible to actually change VPE via proposal. This adds the ability to make such proposals.

# References

This is part of the "periodic confirmation" feature that was recently approved in proposal [132411][prop].

[prop]: https://dashboard.internetcomputer.org/proposal/132411

Closes https://dfinity.atlassian.net/browse/NNS1-3437.

[👈 Previous PR][prev]

[prev]: https://github.com/dfinity/ic/pull/2580