### PR TITLE
fix(ckbtc): compute min_withdrawal_amount using check_fee from state

### DIFF
--- a/rs/bitcoin/ckbtc/minter/src/lib.rs
+++ b/rs/bitcoin/ckbtc/minter/src/lib.rs
@@ -187,17 +187,17 @@ async fn fetch_main_utxos<R: CanisterRuntime>(
 fn compute_min_withdrawal_amount(
     median_fee_rate_e3s: MillisatoshiPerByte,
     min_withdrawal_amount: u64,
+    check_fee: u64,
 ) -> u64 {
     const PER_REQUEST_RBF_BOUND: u64 = 22_100;
     const PER_REQUEST_VSIZE_BOUND: u64 = 221;
     const PER_REQUEST_MINTER_FEE_BOUND: u64 = 305;
-    const PER_REQUEST_CHECK_FEE: u64 = 2_000;
 
     let median_fee_rate = median_fee_rate_e3s / 1_000;
     ((PER_REQUEST_RBF_BOUND
         + PER_REQUEST_VSIZE_BOUND * median_fee_rate
         + PER_REQUEST_MINTER_FEE_BOUND
-        + PER_REQUEST_CHECK_FEE)
+        + check_fee)
         / 50_000)
         * 50_000
         + min_withdrawal_amount
@@ -220,8 +220,11 @@ pub async fn estimate_fee_per_vbyte() -> Option<MillisatoshiPerByte> {
             if fees.len() >= 100 {
                 state::mutate_state(|s| {
                     s.last_fee_per_vbyte.clone_from(&fees);
-                    s.fee_based_retrieve_btc_min_amount =
-                        compute_min_withdrawal_amount(fees[50], s.retrieve_btc_min_amount);
+                    s.fee_based_retrieve_btc_min_amount = compute_min_withdrawal_amount(
+                        fees[50],
+                        s.retrieve_btc_min_amount,
+                        s.check_fee,
+                    );
                 });
                 Some(fees[50])
             } else {


### PR DESCRIPTION
Instead of using a built-in default value, use check_fee from state to compute min_withdrawal_amount.