### PR TITLE
feat(fuzzing): Duplicate STDERR to a separate file in AFL

### DIFF
--- a/bin/afl_wrapper.sh
+++ b/bin/afl_wrapper.sh
@@ -18,6 +18,11 @@ if [[ -z "$OUTPUT_DIR" ]]; then
     OUTPUT_DIR=$(mktemp -d)
 fi
 
+# stderr duplicate
+if [[ -z "$STDERR_DUPLICATE" ]]; then
+    STDERR_DUPLICATE=$(mktemp)
+fi
+
 cleanup() {
     echo "Input directory ${INPUT_DIR}"
     echo "Output directory ${OUTPUT_DIR}"
@@ -101,7 +106,9 @@ function afl_env() {
 if [[ ! -z "$AFL_PARALLEL" ]]; then
     trap cleanup EXIT
     # master fuzzer
-    afl_env -i $INPUT_DIR -o $OUTPUT_DIR -P exploit -p explore -M fuzzer1 ${@:2} -- $1 </dev/null &>/dev/null &
+    STDERR_DUPLICATE="$OUTPUT_DIR/stderr_1.txt"
+    touch $STDERR_DUPLICATE
+    AFL_DRIVER_STDERR_DUPLICATE_FILENAME=$STDERR_DUPLICATE afl_env -i $INPUT_DIR -o $OUTPUT_DIR -P exploit -p explore -M fuzzer1 ${@:2} -- $1 </dev/null &>/dev/null &
 
     for i in $(seq 2 $AFL_PARALLEL); do
         probability=$((100 * $i / $AFL_PARALLEL))
@@ -150,7 +157,9 @@ if [[ ! -z "$AFL_PARALLEL" ]]; then
             strategy="explore"
         fi
 
-        afl_env -i $INPUT_DIR -o $OUTPUT_DIR -P $strategy -p $power_schedule -S fuzzer$i ${@:2} -- $1 </dev/null &>/dev/null &
+        STDERR_DUPLICATE="$OUTPUT_DIR/stderr_$i.txt"
+        touch $STDERR_DUPLICATE
+        AFL_DRIVER_STDERR_DUPLICATE_FILENAME=$STDERR_DUPLICATE afl_env -i $INPUT_DIR -o $OUTPUT_DIR -P $strategy -p $power_schedule -S fuzzer$i ${@:2} -- $1 </dev/null &>/dev/null &
     done
 
     watch -n 5 --color "afl-whatsup -s -d $OUTPUT_DIR"
@@ -158,5 +167,5 @@ else
     # if AFL_PARALLEL is not set
     # run a single instance
     # single instance will mimic the master fuzzer
-    afl_env -i $INPUT_DIR -o $OUTPUT_DIR -P exploit -p explore ${@:2} -- $1
+    AFL_DRIVER_STDERR_DUPLICATE_FILENAME=$STDERR_DUPLICATE afl_env -i $INPUT_DIR -o $OUTPUT_DIR -P exploit -p explore ${@:2} -- $1
 fi

--- a/bin/afl_wrapper.sh
+++ b/bin/afl_wrapper.sh
@@ -18,11 +18,6 @@ if [[ -z "$OUTPUT_DIR" ]]; then
     OUTPUT_DIR=$(mktemp -d)
 fi
 
-# stderr duplicate
-if [[ -z "$STDERR_DUPLICATE" ]]; then
-    STDERR_DUPLICATE=$(mktemp)
-fi
-
 cleanup() {
     echo "Input directory ${INPUT_DIR}"
     echo "Output directory ${OUTPUT_DIR}"
@@ -99,6 +94,14 @@ function afl_env() {
         /usr/local/bin/afl-fuzz -t +20000 $@
 }
 
+# Usage: stderr_file 42
+# OUTPUT_DIR will always be set
+stderr_file() {
+    FILEPATH="$OUTPUT_DIR/stderr$1.txt"
+    touch "$FILEPATH"
+    echo $FILEPATH
+}
+
 # To run multiple fuzzers in parallel, use the AFL_PARALLEL env variable
 # export AFL_PARALLEL=4
 # Make sure you have enough cores, as each job occupies a core.
@@ -106,9 +109,7 @@ function afl_env() {
 if [[ ! -z "$AFL_PARALLEL" ]]; then
     trap cleanup EXIT
     # master fuzzer
-    STDERR_DUPLICATE="$OUTPUT_DIR/stderr_1.txt"
-    touch $STDERR_DUPLICATE
-    AFL_DRIVER_STDERR_DUPLICATE_FILENAME=$STDERR_DUPLICATE afl_env -i $INPUT_DIR -o $OUTPUT_DIR -P exploit -p explore -M fuzzer1 ${@:2} -- $1 </dev/null &>/dev/null &
+    AFL_DRIVER_STDERR_DUPLICATE_FILENAME=$(stderr_file 1) afl_env -i $INPUT_DIR -o $OUTPUT_DIR -P exploit -p explore -M fuzzer1 ${@:2} -- $1 </dev/null &>/dev/null &
 
     for i in $(seq 2 $AFL_PARALLEL); do
         probability=$((100 * $i / $AFL_PARALLEL))
@@ -157,9 +158,7 @@ if [[ ! -z "$AFL_PARALLEL" ]]; then
             strategy="explore"
         fi
 
-        STDERR_DUPLICATE="$OUTPUT_DIR/stderr_$i.txt"
-        touch $STDERR_DUPLICATE
-        AFL_DRIVER_STDERR_DUPLICATE_FILENAME=$STDERR_DUPLICATE afl_env -i $INPUT_DIR -o $OUTPUT_DIR -P $strategy -p $power_schedule -S fuzzer$i ${@:2} -- $1 </dev/null &>/dev/null &
+        AFL_DRIVER_STDERR_DUPLICATE_FILENAME=$(stderr_file $i) afl_env -i $INPUT_DIR -o $OUTPUT_DIR -P $strategy -p $power_schedule -S fuzzer$i ${@:2} -- $1 </dev/null &>/dev/null &
     done
 
     watch -n 5 --color "afl-whatsup -s -d $OUTPUT_DIR"
@@ -167,5 +166,5 @@ else
     # if AFL_PARALLEL is not set
     # run a single instance
     # single instance will mimic the master fuzzer
-    AFL_DRIVER_STDERR_DUPLICATE_FILENAME=$STDERR_DUPLICATE afl_env -i $INPUT_DIR -o $OUTPUT_DIR -P exploit -p explore ${@:2} -- $1
+    AFL_DRIVER_STDERR_DUPLICATE_FILENAME=$(stderr_file 1) afl_env -i $INPUT_DIR -o $OUTPUT_DIR -P exploit -p explore ${@:2} -- $1
 fi

--- a/rs/fuzzers/stable_structures/fuzz_targets/stable_structures_multiple_ops_persistent.rs
+++ b/rs/fuzzers/stable_structures/fuzz_targets/stable_structures_multiple_ops_persistent.rs
@@ -9,7 +9,7 @@ use std::cell::RefCell;
 use std::fs::File;
 use std::io::Write;
 use std::time::SystemTime;
-use tempfile::{tempdir, Builder, TempDir};
+use tempfile::{Builder, TempDir};
 
 mod data;
 use data::{BoundedFuzzStruct, UnboundedFuzzStruct, MAX_VALUE_SIZE};

--- a/rs/fuzzers/stable_structures/fuzz_targets/stable_structures_multiple_ops_persistent.rs
+++ b/rs/fuzzers/stable_structures/fuzz_targets/stable_structures_multiple_ops_persistent.rs
@@ -79,7 +79,7 @@ fuzz_target!(|ops: Vec<StableStructOperation>| {
     // crash, look into AFL_PERSISTENT_RECORD. (https://github.com/AFLplusplus/AFLplusplus/blob/stable/instrumentation/README.persistent_mode.md#6-persistent-record-and-replay)
 
     std::panic::set_hook(Box::new(move |panic_info| {
-        println!("{panic_info}");
+        eprintln!("{panic_info}");
 
         let duration_since_epoch = SystemTime::now()
             .duration_since(SystemTime::UNIX_EPOCH)
@@ -97,7 +97,7 @@ fuzz_target!(|ops: Vec<StableStructOperation>| {
             );
             DIR.with(|dir| {
                 let file_path = dir.path().join(file_name);
-                println!("Creating operations dump at {}", file_path.display());
+                eprintln!("Creating operations dump at {}", file_path.display());
 
                 let mut f = File::create(file_path).unwrap();
                 f.write_all(&buffer).unwrap();
@@ -117,7 +117,7 @@ fuzz_target!(|ops: Vec<StableStructOperation>| {
                 );
                 DIR.with(|dir| {
                     let file_path = dir.path().join(file_name);
-                    println!("Creating memory dump at {}", file_path.display());
+                    eprintln!("Creating memory dump at {}", file_path.display());
 
                     let mut f = File::create(file_path).unwrap();
                     f.write_all(&buffer).unwrap();


### PR DESCRIPTION
- When a crash occurs with AFL, the stacktrace of the crash is not preserved. Usually, it should be reproducible with the crash input (which is preserved). However, fuzzers with global state and OOM bugs are sometimes hard to recreate and it would be helpful to preserve the crash log. This PR achieves it by duplicating STDERR into a user controlled file. 
- Changes to the stable_structures fuzzer to sent panic info to STDERR.