### PR TITLE
chore(ckbtc): add Bitcoin Checker canister

### DIFF
--- a/rs/bitcoin/ckbtc/mainnet/canister_ids.json
+++ b/rs/bitcoin/ckbtc/mainnet/canister_ids.json
@@ -2,6 +2,9 @@
   "archive": {
     "ic": "nbsys-saaaa-aaaar-qaaga-cai"
   },
+  "btc_checker": {
+    "ic": "oltsj-fqaaa-aaaar-qal5q-cai"
+  },
   "index": {
     "ic": "n5wcd-faaaa-aaaar-qaaea-cai"
   },

--- a/rs/bitcoin/ckbtc/mainnet/dfx.json
+++ b/rs/bitcoin/ckbtc/mainnet/dfx.json
@@ -38,6 +38,15 @@
       "candid": "../../../ledger_suite/icrc1/index/index.did",
       "shrink": false
     },
+    "btc_checker": {
+      "type": "custom",
+      "build": [
+        "bazel build //rs/bitcoin/checker:btc_checker_canister"
+      ],
+      "wasm": "../../../../bazel-bin/rs/bitcoin/checker/btc_checker_canister.wasm",
+      "candid": "../../checker/btc_checker_canister.did",
+      "shrink": false
+    },
     "kyt": {
       "type": "custom",
       "build": [

--- a/rs/bitcoin/ckbtc/mainnet/dfx.json
+++ b/rs/bitcoin/ckbtc/mainnet/dfx.json
@@ -43,7 +43,7 @@
       "build": [
         "bazel build //rs/bitcoin/checker:btc_checker_canister"
       ],
-      "wasm": "../../../../bazel-bin/rs/bitcoin/checker/btc_checker_canister.wasm",
+      "wasm": "../../../../bazel-bin/rs/bitcoin/checker/btc_checker_canister.wasm.gz",
       "candid": "../../checker/btc_checker_canister.did",
       "shrink": false
     },

--- a/rs/bitcoin/ckbtc/testnet/canister_ids.json
+++ b/rs/bitcoin/ckbtc/testnet/canister_ids.json
@@ -2,6 +2,9 @@
   "archive": {
     "ic": "m62lf-ryaaa-aaaar-qaacq-cai"
   },
+  "btc_checker": {
+    "ic": "o6ude-eyaaa-aaaar-qal6a-cai"
+  },
   "index": {
     "ic": "mm444-5iaaa-aaaar-qaabq-cai"
   },

--- a/rs/bitcoin/ckbtc/testnet/dfx.json
+++ b/rs/bitcoin/ckbtc/testnet/dfx.json
@@ -37,6 +37,15 @@
       "candid": "../../../ledger_suite/icrc1/index-ng/index-ng.did",
       "shrink": false
     },
+    "btc_checker": {
+      "type": "custom",
+      "build": [
+        "bazel build //rs/bitcoin/checker:btc_checker_canister"
+      ],
+      "wasm": "../../../../bazel-bin/rs/bitcoin/checker/btc_checker_canister.wasm.gz",
+      "candid": "../../checker/btc_checker_canister.did",
+      "shrink": false
+    },
     "kyt": {
       "type": "custom",
       "build": [

--- a/rs/cross-chain/proposal-cli/BUILD.bazel
+++ b/rs/cross-chain/proposal-cli/BUILD.bazel
@@ -46,7 +46,7 @@ rust_test(
     name = "unit_tests",
     crate = ":make_proposal",
     data = [
-        "//rs/bitcoin/ckbtc/kyt:kyt.did",
+        "//rs/bitcoin/checker:btc_checker_canister.did",
         "//rs/bitcoin/ckbtc/minter:ckbtc_minter.did",
         "//rs/ethereum/cketh/minter:cketh_minter.did",
         "//rs/ethereum/ledger-suite-orchestrator:ledger_suite_orchestrator.did",

--- a/rs/cross-chain/proposal-cli/src/candid/tests.rs
+++ b/rs/cross-chain/proposal-cli/src/candid/tests.rs
@@ -55,8 +55,8 @@ fn should_parse_constructor_parameters() {
             (
                 TargetCanister::CkBtcArchive,
                 "(principal, nat64, opt nat64, opt nat64)"
-            ) | (TargetCanister::CkBtcIndex, "(opt IndexArg)")
-                | (TargetCanister::CkBtcKyt, "(LifecycleArg)")
+            ) | (TargetCanister::BtcChecker, "(CheckArg)")
+                | (TargetCanister::CkBtcIndex, "(opt IndexArg)")
                 | (TargetCanister::CkBtcLedger, "(LedgerArg)")
                 | (TargetCanister::CkBtcMinter, "(MinterArg)")
                 | (

--- a/rs/cross-chain/proposal-cli/src/canister/mod.rs
+++ b/rs/cross-chain/proposal-cli/src/canister/mod.rs
@@ -10,9 +10,9 @@ use strum_macros::EnumIter;
 #[derive(Clone, Eq, PartialEq, Debug, Ord, PartialOrd, EnumIter)]
 #[allow(clippy::enum_variant_names)]
 pub enum TargetCanister {
+    BtcChecker,
     CkBtcArchive,
     CkBtcIndex,
-    CkBtcKyt,
     CkBtcLedger,
     CkBtcMinter,
     CkEthArchive,
@@ -33,9 +33,9 @@ pub enum TargetCanister {
 impl TargetCanister {
     pub fn canister_name(&self) -> &str {
         match self {
+            TargetCanister::BtcChecker => "btc_checker",
             TargetCanister::CkBtcArchive | TargetCanister::CkEthArchive => "archive",
             TargetCanister::CkBtcIndex | TargetCanister::CkEthIndex => "index",
-            TargetCanister::CkBtcKyt => "kyt",
             TargetCanister::CkBtcLedger | TargetCanister::CkEthLedger => "ledger",
             TargetCanister::CkBtcMinter | TargetCanister::CkEthMinter => "minter",
             TargetCanister::IcpArchive1 => "icp-archive1",
@@ -52,9 +52,9 @@ impl TargetCanister {
 
     pub fn git_repository_url(&self) -> &str {
         match &self {
-            TargetCanister::CkBtcArchive
+            TargetCanister::BtcChecker
+            | TargetCanister::CkBtcArchive
             | TargetCanister::CkBtcIndex
-            | TargetCanister::CkBtcKyt
             | TargetCanister::CkBtcLedger
             | TargetCanister::CkBtcMinter
             | TargetCanister::CkEthArchive
@@ -79,6 +79,9 @@ impl TargetCanister {
 
     pub fn candid_file(&self) -> PathBuf {
         match &self {
+            TargetCanister::BtcChecker => {
+                PathBuf::from("rs/bitcoin/checker/btc_checker_canister.did")
+            }
             TargetCanister::CkBtcArchive | TargetCanister::CkEthArchive => {
                 PathBuf::from("rs/ledger_suite/icrc1/archive/archive.did")
             }
@@ -88,7 +91,6 @@ impl TargetCanister {
             TargetCanister::CkBtcLedger | TargetCanister::CkEthLedger => {
                 PathBuf::from("rs/ledger_suite/icrc1/ledger/ledger.did")
             }
-            TargetCanister::CkBtcKyt => PathBuf::from("rs/bitcoin/ckbtc/kyt/kyt.did"),
             TargetCanister::CkBtcMinter => {
                 PathBuf::from("rs/bitcoin/ckbtc/minter/ckbtc_minter.did")
             }
@@ -113,9 +115,9 @@ impl TargetCanister {
 
     pub fn repo_dir(&self) -> Option<PathBuf> {
         match &self {
-            TargetCanister::CkBtcArchive
+            TargetCanister::BtcChecker
+            | TargetCanister::CkBtcArchive
             | TargetCanister::CkBtcIndex
-            | TargetCanister::CkBtcKyt
             | TargetCanister::CkBtcLedger
             | TargetCanister::CkBtcMinter
             | TargetCanister::CkEthArchive
@@ -169,9 +171,9 @@ impl TargetCanister {
                     PathBuf::from("rs/ledger_suite/common/ledger_core/src"),
                 ]
             }
-            TargetCanister::CkBtcArchive
+            TargetCanister::BtcChecker
+            | TargetCanister::CkBtcArchive
             | TargetCanister::CkBtcIndex
-            | TargetCanister::CkBtcKyt
             | TargetCanister::CkBtcLedger
             | TargetCanister::CkBtcMinter
             | TargetCanister::CkEthArchive
@@ -187,9 +189,9 @@ impl TargetCanister {
 
     pub fn artifact(&self) -> PathBuf {
         match &self {
-            TargetCanister::CkBtcArchive
+            TargetCanister::BtcChecker
+            | TargetCanister::CkBtcArchive
             | TargetCanister::CkBtcIndex
-            | TargetCanister::CkBtcKyt
             | TargetCanister::CkBtcLedger
             | TargetCanister::CkBtcMinter
             | TargetCanister::CkEthArchive
@@ -212,9 +214,9 @@ impl TargetCanister {
 
     pub fn artifact_file_name(&self) -> &str {
         match &self {
+            TargetCanister::BtcChecker => "ic-btc-checker.wasm.gz",
             TargetCanister::CkBtcArchive => "ic-icrc1-archive.wasm.gz",
             TargetCanister::CkBtcIndex => "ic-icrc1-index-ng.wasm.gz",
-            TargetCanister::CkBtcKyt => "ic-ckbtc-kyt.wasm.gz",
             TargetCanister::CkBtcLedger => "ic-icrc1-ledger.wasm.gz",
             TargetCanister::CkBtcMinter => "ic-ckbtc-minter.wasm.gz",
             TargetCanister::CkEthArchive => "ic-icrc1-archive-u256.wasm.gz",
@@ -237,9 +239,9 @@ impl TargetCanister {
 
     pub fn build_artifact(&self) -> Command {
         match &self {
-            TargetCanister::CkBtcArchive
+            TargetCanister::BtcChecker
+            | TargetCanister::CkBtcArchive
             | TargetCanister::CkBtcIndex
-            | TargetCanister::CkBtcKyt
             | TargetCanister::CkBtcLedger
             | TargetCanister::CkBtcMinter
             | TargetCanister::CkEthArchive
@@ -273,9 +275,9 @@ impl TargetCanister {
 
     pub fn canister_ids_json_file(&self) -> PathBuf {
         match self {
-            TargetCanister::CkBtcArchive
+            TargetCanister::BtcChecker
+            | TargetCanister::CkBtcArchive
             | TargetCanister::CkBtcIndex
-            | TargetCanister::CkBtcKyt
             | TargetCanister::CkBtcLedger
             | TargetCanister::CkBtcMinter => {
                 PathBuf::from("rs/bitcoin/ckbtc/mainnet/canister_ids.json")
@@ -311,9 +313,9 @@ impl FromStr for TargetCanister {
         let canonicalized_canister = canister.to_ascii_lowercase();
         let parts: Vec<&str> = canonicalized_canister.split('-').collect();
         match &parts.as_slice() {
+            ["btc", "checker"] => Ok(TargetCanister::BtcChecker),
             ["ckbtc", "archive"] => Ok(TargetCanister::CkBtcArchive),
             ["ckbtc", "index"] => Ok(TargetCanister::CkBtcIndex),
-            ["ckbtc", "kyt"] => Ok(TargetCanister::CkBtcKyt),
             ["ckbtc", "ledger"] => Ok(TargetCanister::CkBtcLedger),
             ["ckbtc", "minter"] => Ok(TargetCanister::CkBtcMinter),
             ["cketh", "archive"] => Ok(TargetCanister::CkEthArchive),
@@ -337,9 +339,9 @@ impl FromStr for TargetCanister {
 impl Display for TargetCanister {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
+            TargetCanister::BtcChecker => write!(f, "BTC Checker"),
             TargetCanister::CkBtcArchive => write!(f, "ckBTC archive"),
             TargetCanister::CkBtcIndex => write!(f, "ckBTC index"),
-            TargetCanister::CkBtcKyt => write!(f, "ckBTC KYT"),
             TargetCanister::CkBtcLedger => write!(f, "ckBTC ledger"),
             TargetCanister::CkBtcMinter => write!(f, "ckBTC minter"),
             TargetCanister::CkEthArchive => write!(f, "ckETH archive"),


### PR DESCRIPTION
Add Bitcoin Checker canister to both mainnet and testnet configurations with newly created canister ids.

Add support for Bitcoin Checker canister to proposal-cli, and remove KYT canister from it.