### PR TITLE
chore: Align test canister naming

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -209,6 +209,7 @@ go_deps.bzl               @dfinity/idx
 /rs/rust_canisters/response_payload_test/               @dfinity/execution
 /rs/rust_canisters/stable_structures/                   @dfinity/execution
 /rs/rust_canisters/stable_memory_integrity              @dfinity/execution
+/rs/rust_canisters/statesync_test                       @dfinity/ic-message-routing-owners
 /rs/rust_canisters/canister_creator                     @dfinity/execution
 /rs/rust_canisters/load_simulator                       @dfinity/execution
 /rs/rust_canisters/xnet_test/                           @dfinity/ic-message-routing-owners

--- a/rs/rust_canisters/statesync_test/BUILD.bazel
+++ b/rs/rust_canisters/statesync_test/BUILD.bazel
@@ -37,7 +37,7 @@ rust_binary(
 )
 
 rust_canister(
-    name = "statesync_test_canister",
+    name = "statesync-test-canister",
     srcs = ["src/main.rs"],
     proc_macro_deps = MACRO_DEPENDENCIES,
     service_file = ":statesync_test.did",
@@ -54,11 +54,11 @@ rust_ic_test(
     name = "statesync_test_integration_test",
     srcs = ["test/test.rs"],
     data = [
-        ":statesync_test_canister",
+        ":statesync-test-canister",
     ],
     env = {
         "CARGO_MANIFEST_DIR": "rs/rust_canisters/statesync_test",
-        "STATESYNC_TEST_CANISTER_WASM_PATH": "$(rootpath :statesync_test_canister)",
+        "STATESYNC_TEST_CANISTER_WASM_PATH": "$(rootpath :statesync-test-canister)",
     },
     proc_macro_deps = MACRO_DEPENDENCIES,
     deps = DEPENDENCIES + DEV_DEPENDENCIES,

--- a/rs/tests/common.bzl
+++ b/rs/tests/common.bzl
@@ -325,7 +325,7 @@ CANISTER_HTTP_RUNTIME_DEPS = [
 
 XNET_TEST_CANISTER_RUNTIME_DEPS = ["//rs/rust_canisters/xnet_test:xnet-test-canister"]
 
-STATESYNC_TEST_CANISTER_RUNTIME_DEPS = ["//rs/rust_canisters/statesync_test:statesync_test_canister"]
+STATESYNC_TEST_CANISTER_RUNTIME_DEPS = ["//rs/rust_canisters/statesync_test:statesync-test-canister"]
 
 IC_MAINNET_NNS_RECOVERY_RUNTIME_DEPS = GUESTOS_RUNTIME_DEPS + \
                                        NNS_CANISTER_RUNTIME_DEPS + \

--- a/rs/tests/message_routing/BUILD.bazel
+++ b/rs/tests/message_routing/BUILD.bazel
@@ -60,9 +60,7 @@ system_test(
 
 system_test_nns(
     name = "rejoin_test",
-    env = UNIVERSAL_CANISTER_ENV | {
-        "STATESYNC_TEST_CANISTER_WASM_PATH": "$(rootpath //rs/rust_canisters/statesync_test:statesync-test-canister)",
-    },
+    env = UNIVERSAL_CANISTER_ENV,
     tags = [
         "k8s",
         "system_test_hourly",
@@ -71,7 +69,6 @@ system_test_nns(
     runtime_deps =
         GUESTOS_RUNTIME_DEPS +
         GRAFANA_RUNTIME_DEPS +
-        STATESYNC_TEST_CANISTER_RUNTIME_DEPS +
         UNIVERSAL_CANISTER_RUNTIME_DEPS,
     deps = [
         "//rs/registry/subnet_type",

--- a/rs/tests/message_routing/BUILD.bazel
+++ b/rs/tests/message_routing/BUILD.bazel
@@ -61,7 +61,7 @@ system_test(
 system_test_nns(
     name = "rejoin_test",
     env = UNIVERSAL_CANISTER_ENV | {
-        "STATESYNC_TEST_CANISTER_WASM_PATH": "$(rootpath //rs/rust_canisters/statesync_test:statesync_test_canister)",
+        "STATESYNC_TEST_CANISTER_WASM_PATH": "$(rootpath //rs/rust_canisters/statesync_test:statesync-test-canister)",
     },
     tags = [
         "k8s",
@@ -85,7 +85,7 @@ system_test_nns(
 system_test_nns(
     name = "rejoin_test_large_state",
     env = UNIVERSAL_CANISTER_ENV | {
-        "STATESYNC_TEST_CANISTER_WASM_PATH": "$(rootpath //rs/rust_canisters/statesync_test:statesync_test_canister)",
+        "STATESYNC_TEST_CANISTER_WASM_PATH": "$(rootpath //rs/rust_canisters/statesync_test:statesync-test-canister)",
     },
     extra_head_nns_tags = ["manual"],  # only run this test with the mainnet NNS canisters.
     tags = [
@@ -111,7 +111,7 @@ system_test_nns(
 system_test_nns(
     name = "state_sync_malicious_chunk_test",
     env = UNIVERSAL_CANISTER_ENV | {
-        "STATESYNC_TEST_CANISTER_WASM_PATH": "$(rootpath //rs/rust_canisters/statesync_test:statesync_test_canister)",
+        "STATESYNC_TEST_CANISTER_WASM_PATH": "$(rootpath //rs/rust_canisters/statesync_test:statesync-test-canister)",
     },
     extra_head_nns_tags = ["manual"],  # only run this test with the mainnet NNS canisters.
     malicious = True,


### PR DESCRIPTION
This commit changes the naming scheme of the statsync test canister to be analogous to the xnet test canister.

This commit also moves the code ownership of that canister to the message routing team.