### PR TITLE
chore(ckbtc): Upgrade ckBTC ledger suite

### DIFF
--- a/rs/bitcoin/ckbtc/mainnet/ckbtc_archive_upgrade_2024_12_09.md
+++ b/rs/bitcoin/ckbtc/mainnet/ckbtc_archive_upgrade_2024_12_09.md
@@ -1,0 +1,47 @@
+# Proposal to upgrade the ckBTC archive canister
+
+Repository: `https://github.com/dfinity/ic.git`
+
+Git hash: `2190613d3b5bcd9b74c382b22d151580b8ac271a`
+
+New compressed Wasm hash: `f94cf1db965b7042197e5894fef54f5f413bb2ebc607ff0fb59c9d4dfd3babea`
+
+Upgrade args hash: `0fee102bd16b053022b69f2c65fd5e2f41d150ce9c214ac8731cfaf496ebda4e`
+
+Target canister: `nbsys-saaaa-aaaar-qaaga-cai`
+
+Previous ckBTC archive proposal: https://dashboard.internetcomputer.org/proposal/133825
+
+---
+
+## Motivation
+TODO: THIS MUST BE FILLED OUT
+
+
+## Upgrade args
+
+```
+git fetch
+git checkout 2190613d3b5bcd9b74c382b22d151580b8ac271a
+cd rs/ledger_suite/icrc1/archive
+didc encode '()' | xxd -r -p | sha256sum
+```
+
+## Release Notes
+
+```
+git log --format='%C(auto) %h %s' e54d3fa34ded227c885d04e64505fa4b5d564743..2190613d3b5bcd9b74c382b22d151580b8ac271a -- rs/ledger_suite/icrc1/archive
+2b21236228 refactor(ICP_ledger): FI-1570: Rename ledger suite memory-related metrics (#2545)
+15d752c5dd chore: avoid reexports from StateMachine tests (#2370)
+ ```
+
+## Wasm Verification
+
+Verify that the hash of the gzipped WASM matches the proposed hash.
+
+```
+git fetch
+git checkout 2190613d3b5bcd9b74c382b22d151580b8ac271a
+"./ci/container/build-ic.sh" "--canisters"
+sha256sum ./artifacts/canisters/ic-icrc1-archive.wasm.gz
+```

--- a/rs/bitcoin/ckbtc/mainnet/ckbtc_archive_upgrade_2024_12_09.md
+++ b/rs/bitcoin/ckbtc/mainnet/ckbtc_archive_upgrade_2024_12_09.md
@@ -15,7 +15,7 @@ Previous ckBTC archive proposal: https://dashboard.internetcomputer.org/proposal
 ---
 
 ## Motivation
-TODO: THIS MUST BE FILLED OUT
+Upgrade the ckBTC archive canister to the same version ([ledger-suite-icrc-2024-11-28](https://github.com/dfinity/ic/releases/tag/ledger-suite-icrc-2024-11-28)) as the ckBTC ledger canister to maintain a consistent versioning across the ckBTC ledger suite.
 
 
 ## Upgrade args

--- a/rs/bitcoin/ckbtc/mainnet/ckbtc_index_upgrade_2024_12_09.md
+++ b/rs/bitcoin/ckbtc/mainnet/ckbtc_index_upgrade_2024_12_09.md
@@ -15,8 +15,8 @@ Previous ckBTC index proposal: https://dashboard.internetcomputer.org/proposal/1
 ---
 
 ## Motivation
-TODO: THIS MUST BE FILLED OUT
 
+Upgrade the ckBTC index canister to the same version ([ledger-suite-icrc-2024-11-28](https://github.com/dfinity/ic/releases/tag/ledger-suite-icrc-2024-11-28)) as the ckBTC ledger canister to maintain a consistent versioning across the ckBTC ledger suite.
 
 ## Upgrade args
 

--- a/rs/bitcoin/ckbtc/mainnet/ckbtc_index_upgrade_2024_12_09.md
+++ b/rs/bitcoin/ckbtc/mainnet/ckbtc_index_upgrade_2024_12_09.md
@@ -1,0 +1,51 @@
+# Proposal to upgrade the ckBTC index canister
+
+Repository: `https://github.com/dfinity/ic.git`
+
+Git hash: `2190613d3b5bcd9b74c382b22d151580b8ac271a`
+
+New compressed Wasm hash: `2adc74fe5667f26ea4c4006309d99b1dfa71787aa43a5c168cb08ec725677996`
+
+Upgrade args hash: `0fee102bd16b053022b69f2c65fd5e2f41d150ce9c214ac8731cfaf496ebda4e`
+
+Target canister: `n5wcd-faaaa-aaaar-qaaea-cai`
+
+Previous ckBTC index proposal: https://dashboard.internetcomputer.org/proposal/133823
+
+---
+
+## Motivation
+TODO: THIS MUST BE FILLED OUT
+
+
+## Upgrade args
+
+```
+git fetch
+git checkout 2190613d3b5bcd9b74c382b22d151580b8ac271a
+cd rs/ledger_suite/icrc1/index-ng
+didc encode '()' | xxd -r -p | sha256sum
+```
+
+## Release Notes
+
+```
+git log --format='%C(auto) %h %s' e54d3fa34ded227c885d04e64505fa4b5d564743..2190613d3b5bcd9b74c382b22d151580b8ac271a -- rs/ledger_suite/icrc1/index-ng
+2b21236228 refactor(ICP_ledger): FI-1570: Rename ledger suite memory-related metrics (#2545)
+ee1006503b test(ICRC_index_ng): FI-1519: Add test for ICRC index-ng sync with ledger with various intervals (#2313)
+15d752c5dd chore: avoid reexports from StateMachine tests (#2370)
+d361dd6923 feat: Update cycles cost for compute (#2308)
+07cf5773d4 feat(Index-ng): FI-1389: Disallow upgrading ICRC index-ng from u64 to u256 or vice versa (#1987)
+03dd6ee6de fix(Ledger-Suite): renamed state machine tests (#2014)
+ ```
+
+## Wasm Verification
+
+Verify that the hash of the gzipped WASM matches the proposed hash.
+
+```
+git fetch
+git checkout 2190613d3b5bcd9b74c382b22d151580b8ac271a
+"./ci/container/build-ic.sh" "--canisters"
+sha256sum ./artifacts/canisters/ic-icrc1-index-ng.wasm.gz
+```

--- a/rs/bitcoin/ckbtc/mainnet/ckbtc_ledger_upgrade_2024_12_09.md
+++ b/rs/bitcoin/ckbtc/mainnet/ckbtc_ledger_upgrade_2024_12_09.md
@@ -15,7 +15,8 @@ Previous ckBTC ledger proposal: https://dashboard.internetcomputer.org/proposal/
 ---
 
 ## Motivation
-TODO: THIS MUST BE FILLED OUT
+
+Upgrade the ckBTC ledger canister to the latest version ([ledger-suite-icrc-2024-11-28](https://github.com/dfinity/ic/releases/tag/ledger-suite-icrc-2024-11-28)) to continue the migration towards stable memory.
 
 
 ## Upgrade args

--- a/rs/bitcoin/ckbtc/mainnet/ckbtc_ledger_upgrade_2024_12_09.md
+++ b/rs/bitcoin/ckbtc/mainnet/ckbtc_ledger_upgrade_2024_12_09.md
@@ -1,0 +1,56 @@
+# Proposal to upgrade the ckBTC ledger canister
+
+Repository: `https://github.com/dfinity/ic.git`
+
+Git hash: `2190613d3b5bcd9b74c382b22d151580b8ac271a`
+
+New compressed Wasm hash: `25071c2c55ad4571293e00d8e277f442aec7aed88109743ac52df3125209ff45`
+
+Upgrade args hash: `0fee102bd16b053022b69f2c65fd5e2f41d150ce9c214ac8731cfaf496ebda4e`
+
+Target canister: `mxzaz-hqaaa-aaaar-qaada-cai`
+
+Previous ckBTC ledger proposal: https://dashboard.internetcomputer.org/proposal/133824
+
+---
+
+## Motivation
+TODO: THIS MUST BE FILLED OUT
+
+
+## Upgrade args
+
+```
+git fetch
+git checkout 2190613d3b5bcd9b74c382b22d151580b8ac271a
+cd rs/ledger_suite/icrc1/ledger
+didc encode '()' | xxd -r -p | sha256sum
+```
+
+## Release Notes
+
+```
+git log --format='%C(auto) %h %s' e54d3fa34ded227c885d04e64505fa4b5d564743..2190613d3b5bcd9b74c382b22d151580b8ac271a -- rs/ledger_suite/icrc1/ledger
+8d726cc67a feat(ICRC-ledger): FI-1437: Implement V3 for ICRC ledger - migrate allowances to stable structures (#1513)
+f68da752b5 feat(ICRC-Rosetta): updated rosetta to support icrc3 standard (#2607)
+7c718f95a4 chore(Ledger_suite): FI-1573: Update the ledger suite canister git revs and module hashes (#2547)
+593f0cd19c chore(FI): Cleanup unused dependencies (#2628)
+6da35b9432 refactor: [FI-1531] Support ICP blocks and accounts in InMemoryLedger (#2497)
+2b21236228 refactor(ICP_ledger): FI-1570: Rename ledger suite memory-related metrics (#2545)
+3e0cf89b23 test(IDX): depend on the universal canister at run-time instead of at build-time (#2502)
+b811de98a7 feat(ICP-Ledger): FI-1436: Implement V2 for ICP ledger - use memory manager during upgrade (#1969)
+6971fee041 test(ICRC_ledger): FI-1542: Add fee collector test for icrc3_get_blocks (#2181)
+588ad7a46b chore: upgrade rust version to 1.82 (#2137)
+03dd6ee6de fix(Ledger-Suite): renamed state machine tests (#2014)
+ ```
+
+## Wasm Verification
+
+Verify that the hash of the gzipped WASM matches the proposed hash.
+
+```
+git fetch
+git checkout 2190613d3b5bcd9b74c382b22d151580b8ac271a
+"./ci/container/build-ic.sh" "--canisters"
+sha256sum ./artifacts/canisters/ic-icrc1-ledger.wasm.gz
+```


### PR DESCRIPTION
Proposals to upgrade the ckBTC ledger suite (index, ledger and archive canisters) to [ledger-suite-icrc-2024-11-28](https://github.com/dfinity/ic/releases/tag/ledger-suite-icrc-2024-11-28).