### PR TITLE
test(NNS): isolate upgrade_everything_test to its own bazel target

### DIFF
--- a/rs/nervous_system/integration_tests/BUILD.bazel
+++ b/rs/nervous_system/integration_tests/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_rust//rust:defs.bzl", "rust_library")
+load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test")
 load("//bazel:defs.bzl", "rust_test_suite_with_extra_srcs")
 
 package(default_visibility = ["//visibility:public"])
@@ -166,11 +166,33 @@ rust_test_suite_with_extra_srcs(
     name = "integration_tests_test",
     srcs = glob(
         ["tests/**/*.rs"],
+        exclude = [
+            "tests/sns_upgrade_test_utils.rs",
+            "tests/upgrade_everything_test.rs",
+        ],
     ),
     aliases = ALIASES,
     data = DEV_DATA,
     env = DEV_ENV,
-    extra_srcs = [],
+    extra_srcs = ["tests/sns_upgrade_test_utils.rs"],
+    flaky = True,
+    proc_macro_deps = MACRO_DEPENDENCIES + MACRO_DEV_DEPENDENCIES,
+    tags = [
+        "cpu:6",
+    ],
+    deps = [":nervous_system_integration_tests"] + DEPENDENCIES_WITH_TEST_FEATURES + DEV_DEPENDENCIES,
+)
+
+rust_test(
+    name = "upgrade_everything_test",
+    srcs = [
+        "tests/sns_upgrade_test_utils.rs",
+        "tests/upgrade_everything_test.rs",
+    ],
+    aliases = ALIASES,
+    crate_root = "tests/upgrade_everything_test.rs",
+    data = DEV_DATA,
+    env = DEV_ENV,
     flaky = True,
     proc_macro_deps = MACRO_DEPENDENCIES + MACRO_DEV_DEPENDENCIES,
     tags = [

--- a/rs/nervous_system/integration_tests/tests/sns_release_qualification.rs
+++ b/rs/nervous_system/integration_tests/tests/sns_release_qualification.rs
@@ -9,12 +9,14 @@ use ic_nervous_system_integration_tests::{
 };
 use ic_nns_constants::{GOVERNANCE_CANISTER_ID, SNS_WASM_CANISTER_ID};
 use ic_nns_test_utils::sns_wasm::{
-    build_archive_sns_wasm, build_governance_sns_wasm, build_index_ng_sns_wasm,
-    build_ledger_sns_wasm, build_root_sns_wasm, build_swap_sns_wasm, create_modified_sns_wasm,
-    ensure_sns_wasm_gzipped,
+    build_governance_sns_wasm, build_index_ng_sns_wasm, build_ledger_sns_wasm, build_root_sns_wasm,
+    build_swap_sns_wasm, ensure_sns_wasm_gzipped,
 };
 use ic_sns_swap::pb::v1::Lifecycle;
 use ic_sns_wasm::pb::v1::SnsCanisterType;
+
+mod sns_upgrade_test_utils;
+use sns_upgrade_test_utils::test_sns_upgrade;
 
 /// In order to ensure that creating an SNS still works, we need to test the following:
 /// We test new SNS canisters with mainnet NNS canisters
@@ -101,19 +103,6 @@ async fn test_upgrade_upgrade_sns_gov_root() {
     test_sns_upgrade(vec![SnsCanisterType::Governance, SnsCanisterType::Root]).await;
 }
 
-#[tokio::test]
-async fn test_upgrade_everything() {
-    test_sns_upgrade(vec![
-        SnsCanisterType::Root,
-        SnsCanisterType::Governance,
-        SnsCanisterType::Swap,
-        SnsCanisterType::Index,
-        SnsCanisterType::Ledger,
-        SnsCanisterType::Archive,
-    ])
-    .await;
-}
-
 /// Tests a deployment of the SNS.
 /// Usually nns_canisters do not need to be upgraded, but sometimes they have to be due to dependencies
 /// or API changes to init arguments
@@ -179,103 +168,4 @@ pub async fn test_sns_deployment(
         swap_parameters,
     )
     .await;
-}
-
-async fn test_sns_upgrade(sns_canisters_to_upgrade: Vec<SnsCanisterType>) {
-    let pocket_ic = pocket_ic_helpers::pocket_ic_for_sns_tests_with_mainnet_versions().await;
-
-    let create_service_nervous_system = CreateServiceNervousSystemBuilder::default()
-        .with_governance_parameters_neuron_minimum_dissolve_delay_to_vote(ONE_MONTH_SECONDS * 6)
-        .with_one_developer_neuron(
-            PrincipalId::new_user_test_id(830947),
-            ONE_MONTH_SECONDS * 6,
-            756575,
-            0,
-        )
-        .build();
-    let swap_parameters = create_service_nervous_system
-        .swap_parameters
-        .clone()
-        .unwrap();
-
-    // Deploy an SNS instance via proposal.
-    let sns_instance_label = "1";
-    let (sns, _) = nns::governance::propose_to_deploy_sns_and_wait(
-        &pocket_ic,
-        create_service_nervous_system,
-        sns_instance_label,
-    )
-    .await;
-
-    for canister_type in &sns_canisters_to_upgrade {
-        let wasm = match canister_type {
-            SnsCanisterType::Root => build_root_sns_wasm(),
-            SnsCanisterType::Governance => build_governance_sns_wasm(),
-            SnsCanisterType::Ledger => build_ledger_sns_wasm(),
-            SnsCanisterType::Swap => build_swap_sns_wasm(),
-            SnsCanisterType::Index => build_index_ng_sns_wasm(),
-            SnsCanisterType::Unspecified => {
-                panic!("Where did you get this canister type from?")
-            }
-            SnsCanisterType::Archive => build_archive_sns_wasm(),
-        };
-
-        let wasm = ensure_sns_wasm_gzipped(wasm);
-        let proposal_info = add_wasm_via_nns_proposal(&pocket_ic, wasm).await.unwrap();
-        assert_eq!(proposal_info.failure_reason, None);
-    }
-
-    for canister_type in &sns_canisters_to_upgrade {
-        let wasm = match canister_type {
-            // Second upgrade with modified wasms
-            SnsCanisterType::Root => create_modified_sns_wasm(&build_root_sns_wasm(), Some(42)),
-            SnsCanisterType::Governance => {
-                create_modified_sns_wasm(&build_governance_sns_wasm(), Some(42))
-            }
-            SnsCanisterType::Ledger => create_modified_sns_wasm(&build_ledger_sns_wasm(), Some(42)),
-            SnsCanisterType::Swap => create_modified_sns_wasm(&build_swap_sns_wasm(), Some(42)),
-            SnsCanisterType::Index => {
-                create_modified_sns_wasm(&build_index_ng_sns_wasm(), Some(42))
-            }
-            SnsCanisterType::Unspecified => {
-                panic!("Where did you get this canister type from?")
-            }
-            SnsCanisterType::Archive => {
-                create_modified_sns_wasm(&build_archive_sns_wasm(), Some(42))
-            }
-        };
-
-        let wasm = ensure_sns_wasm_gzipped(wasm);
-        let proposal_info = add_wasm_via_nns_proposal(&pocket_ic, wasm).await.unwrap();
-        assert_eq!(proposal_info.failure_reason, None);
-    }
-
-    // Only spawn an archive if we're testing it
-    if sns_canisters_to_upgrade.contains(&SnsCanisterType::Archive) {
-        // Testing the Archive canister requires that it can be spawned.
-        sns::ensure_archive_canister_is_spawned_or_panic(
-            &pocket_ic,
-            sns.governance.canister_id,
-            sns.ledger.canister_id,
-        )
-        .await;
-    }
-
-    sns::swap::await_swap_lifecycle(&pocket_ic, sns.swap.canister_id, Lifecycle::Open)
-        .await
-        .unwrap();
-    sns::swap::smoke_test_participate_and_finalize(
-        &pocket_ic,
-        sns.swap.canister_id,
-        swap_parameters,
-    )
-    .await;
-
-    // Every canister we are testing has two upgrades.  We are just making sure the counts match
-    for canister_type in &sns_canisters_to_upgrade {
-        sns::upgrade_sns_to_next_version_and_assert_change(&pocket_ic, &sns, *canister_type).await;
-    }
-    for canister_type in sns_canisters_to_upgrade {
-        sns::upgrade_sns_to_next_version_and_assert_change(&pocket_ic, &sns, canister_type).await;
-    }
 }

--- a/rs/nervous_system/integration_tests/tests/sns_upgrade_test_utils.rs
+++ b/rs/nervous_system/integration_tests/tests/sns_upgrade_test_utils.rs
@@ -1,0 +1,127 @@
+use ic_base_types::PrincipalId;
+use ic_nervous_system_common::ONE_MONTH_SECONDS;
+use ic_nervous_system_integration_tests::{
+    create_service_nervous_system_builder::CreateServiceNervousSystemBuilder,
+    pocket_ic_helpers,
+    pocket_ic_helpers::{add_wasm_via_nns_proposal, nns, sns},
+};
+use ic_nns_test_utils::sns_wasm::{
+    build_archive_sns_wasm, build_governance_sns_wasm, build_index_ng_sns_wasm,
+    build_ledger_sns_wasm, build_root_sns_wasm, build_swap_sns_wasm, create_modified_sns_wasm,
+    ensure_sns_wasm_gzipped,
+};
+use ic_sns_swap::pb::v1::Lifecycle;
+use ic_sns_wasm::pb::v1::SnsCanisterType;
+
+pub async fn test_sns_upgrade(sns_canisters_to_upgrade: Vec<SnsCanisterType>) {
+    let pocket_ic = pocket_ic_helpers::pocket_ic_for_sns_tests_with_mainnet_versions().await;
+
+    eprintln!("Creating SNS ...");
+    let create_service_nervous_system = CreateServiceNervousSystemBuilder::default()
+        .with_governance_parameters_neuron_minimum_dissolve_delay_to_vote(ONE_MONTH_SECONDS * 6)
+        .with_one_developer_neuron(
+            PrincipalId::new_user_test_id(830947),
+            ONE_MONTH_SECONDS * 6,
+            756575,
+            0,
+        )
+        .build();
+    let swap_parameters = create_service_nervous_system
+        .swap_parameters
+        .clone()
+        .unwrap();
+
+    eprintln!("Deploying an SNS instance via proposal ...");
+    let sns_instance_label = "1";
+    let (sns, _) = nns::governance::propose_to_deploy_sns_and_wait(
+        &pocket_ic,
+        create_service_nervous_system,
+        sns_instance_label,
+    )
+    .await;
+
+    eprintln!("Adding all WASMs ...");
+    for canister_type in &sns_canisters_to_upgrade {
+        let wasm = match canister_type {
+            SnsCanisterType::Root => build_root_sns_wasm(),
+            SnsCanisterType::Governance => build_governance_sns_wasm(),
+            SnsCanisterType::Ledger => build_ledger_sns_wasm(),
+            SnsCanisterType::Swap => build_swap_sns_wasm(),
+            SnsCanisterType::Index => build_index_ng_sns_wasm(),
+            SnsCanisterType::Unspecified => {
+                panic!("Where did you get this canister type from?")
+            }
+            SnsCanisterType::Archive => build_archive_sns_wasm(),
+        };
+
+        let wasm = ensure_sns_wasm_gzipped(wasm);
+        let proposal_info = add_wasm_via_nns_proposal(&pocket_ic, wasm).await.unwrap();
+        assert_eq!(proposal_info.failure_reason, None);
+    }
+
+    eprintln!("Adding all WASMs with custom metadata ...");
+    for canister_type in &sns_canisters_to_upgrade {
+        let wasm = match canister_type {
+            // Second upgrade with modified wasms
+            SnsCanisterType::Root => create_modified_sns_wasm(&build_root_sns_wasm(), Some(42)),
+            SnsCanisterType::Governance => {
+                create_modified_sns_wasm(&build_governance_sns_wasm(), Some(42))
+            }
+            SnsCanisterType::Ledger => create_modified_sns_wasm(&build_ledger_sns_wasm(), Some(42)),
+            SnsCanisterType::Swap => create_modified_sns_wasm(&build_swap_sns_wasm(), Some(42)),
+            SnsCanisterType::Index => {
+                create_modified_sns_wasm(&build_index_ng_sns_wasm(), Some(42))
+            }
+            SnsCanisterType::Unspecified => {
+                panic!("Where did you get this canister type from?")
+            }
+            SnsCanisterType::Archive => {
+                create_modified_sns_wasm(&build_archive_sns_wasm(), Some(42))
+            }
+        };
+
+        let wasm = ensure_sns_wasm_gzipped(wasm);
+        let proposal_info = add_wasm_via_nns_proposal(&pocket_ic, wasm).await.unwrap();
+        assert_eq!(proposal_info.failure_reason, None);
+    }
+
+    // Only spawn an archive if we're testing it
+    if sns_canisters_to_upgrade.contains(&SnsCanisterType::Archive) {
+        eprintln!("Testing if the Archive canister is spawned ...");
+        sns::ensure_archive_canister_is_spawned_or_panic(
+            &pocket_ic,
+            sns.governance.canister_id,
+            sns.ledger.canister_id,
+        )
+        .await;
+    }
+
+    eprintln!("Await the swap lifecycle ...");
+    sns::swap::await_swap_lifecycle(&pocket_ic, sns.swap.canister_id, Lifecycle::Open)
+        .await
+        .unwrap();
+
+    eprintln!("smoke_test_participate_and_finalize ...");
+    sns::swap::smoke_test_participate_and_finalize(
+        &pocket_ic,
+        sns.swap.canister_id,
+        swap_parameters,
+    )
+    .await;
+
+    // Every canister we are testing has two upgrades.  We are just making sure the counts match
+    for canister_type in &sns_canisters_to_upgrade {
+        eprintln!(
+            "1st upgrade_sns_to_next_version_and_assert_change {:?} ...",
+            canister_type
+        );
+        sns::upgrade_sns_to_next_version_and_assert_change(&pocket_ic, &sns, *canister_type).await;
+    }
+    for canister_type in sns_canisters_to_upgrade {
+        eprintln!(
+            "2nd upgrade_sns_to_next_version_and_assert_change {:?} ...",
+            canister_type
+        );
+        sns::upgrade_sns_to_next_version_and_assert_change(&pocket_ic, &sns, canister_type).await;
+    }
+}

--- a/rs/nervous_system/integration_tests/tests/upgrade_everything_test.rs
+++ b/rs/nervous_system/integration_tests/tests/upgrade_everything_test.rs
@@ -1,0 +1,16 @@
+use ic_sns_wasm::pb::v1::SnsCanisterType;
+mod sns_upgrade_test_utils;
+use sns_upgrade_test_utils::test_sns_upgrade;
+
+#[tokio::test]
+async fn test_upgrade_everything() {
+    test_sns_upgrade(vec![
+        SnsCanisterType::Root,
+        SnsCanisterType::Governance,
+        SnsCanisterType::Swap,
+        SnsCanisterType::Index,
+        SnsCanisterType::Ledger,
+        SnsCanisterType::Archive,
+    ])
+    .await;
+}


### PR DESCRIPTION
The `//rs/nervous_system/integration_tests:integration_tests_test_tests/sns_release_qualification` is currently our most flaky test because the `test_upgrade_everything` test is often timing out.

To debug why this is happening we isolate this test to its own bazel target and add some logs to see where it's timing out.