### PR TITLE
perf(nns): Add benchmark for listing neurons fund neurons

### DIFF
--- a/rs/nns/governance/canbench/canbench_results.yml
+++ b/rs/nns/governance/canbench/canbench_results.yml
@@ -1,73 +1,85 @@
 benches:
   add_neuron_active_maximum:
     total:
-      instructions: 36184626
+      instructions: 36177920
       heap_increase: 1
       stable_memory_increase: 0
     scopes: {}
   add_neuron_active_typical:
     total:
-      instructions: 1835593
+      instructions: 1835389
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   add_neuron_inactive_maximum:
     total:
-      instructions: 96163372
+      instructions: 96156666
       heap_increase: 1
       stable_memory_increase: 0
     scopes: {}
   add_neuron_inactive_typical:
     total:
-      instructions: 7371198
+      instructions: 7370994
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   cascading_vote_all_heap:
     total:
-      instructions: 34443866
+      instructions: 34432365
       heap_increase: 0
       stable_memory_increase: 128
     scopes: {}
   cascading_vote_heap_neurons_stable_index:
     total:
-      instructions: 56578763
+      instructions: 56567262
       heap_increase: 0
       stable_memory_increase: 128
     scopes: {}
   cascading_vote_stable_everything:
     total:
-      instructions: 370858158
+      instructions: 372102159
       heap_increase: 0
       stable_memory_increase: 128
     scopes: {}
   cascading_vote_stable_neurons_with_heap_index:
     total:
-      instructions: 348673022
+      instructions: 349917023
       heap_increase: 0
       stable_memory_increase: 128
     scopes: {}
   centralized_following_all_stable:
     total:
-      instructions: 173332865
+      instructions: 173910217
       heap_increase: 0
       stable_memory_increase: 128
     scopes: {}
   compute_ballots_for_new_proposal_with_stable_neurons:
     total:
-      instructions: 1811023
+      instructions: 1815411
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   draw_maturity_from_neurons_fund_heap:
     total:
-      instructions: 7254719
+      instructions: 7252619
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   draw_maturity_from_neurons_fund_stable:
     total:
-      instructions: 10293400
+      instructions: 10301600
+      heap_increase: 0
+      stable_memory_increase: 0
+    scopes: {}
+  list_active_neurons_fund_neurons_heap:
+    total:
+      instructions: 438096
+      heap_increase: 0
+      stable_memory_increase: 0
+    scopes: {}
+  list_active_neurons_fund_neurons_stable:
+    total:
+      instructions: 24173103
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
@@ -79,7 +91,7 @@ benches:
     scopes: {}
   list_neurons_ready_to_unstake_maturity_stable:
     total:
-      instructions: 36814392
+      instructions: 36937433
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
@@ -91,37 +103,37 @@ benches:
     scopes: {}
   list_ready_to_spawn_neuron_ids_stable:
     total:
-      instructions: 36803093
+      instructions: 36926134
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   neuron_metrics_calculation_heap:
     total:
-      instructions: 528806
+      instructions: 536345
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   neuron_metrics_calculation_stable:
     total:
-      instructions: 1837632
+      instructions: 1841727
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   range_neurons_performance:
     total:
-      instructions: 47691642
+      instructions: 47700442
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   single_vote_all_stable:
     total:
-      instructions: 2474894
+      instructions: 2474981
       heap_increase: 0
       stable_memory_increase: 128
     scopes: {}
   update_recent_ballots_stable_memory:
     total:
-      instructions: 236883
+      instructions: 236963
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}

--- a/rs/nns/governance/src/neuron/types.rs
+++ b/rs/nns/governance/src/neuron/types.rs
@@ -1600,7 +1600,7 @@ pub struct NeuronBuilder {
     neuron_fees_e8s: u64,
     #[cfg(any(test, feature = "canbench-rs"))]
     recent_ballots: Vec<BallotInfo>,
-    #[cfg(test)]
+    #[cfg(any(test, feature = "canbench-rs"))]
     recent_ballots_next_entry_index: Option<usize>,
     #[cfg(test)]
     transfer: Option<NeuronStakeTransfer>,
@@ -1636,14 +1636,13 @@ impl NeuronBuilder {
             joined_community_fund_timestamp_seconds: None,
             neuron_type: None,
             visibility: None,
-            recent_ballots_next_entry_index: None,
             voting_power_refreshed_timestamp_seconds: created_timestamp_seconds,
 
             #[cfg(test)]
             neuron_fees_e8s: 0,
             #[cfg(any(test, feature = "canbench-rs"))]
             recent_ballots: Vec::new(),
-            #[cfg(test)]
+            #[cfg(any(test, feature = "canbench-rs"))]
             recent_ballots_next_entry_index: Some(0),
             #[cfg(test)]
             transfer: None,

--- a/rs/nns/governance/src/neuron/types.rs
+++ b/rs/nns/governance/src/neuron/types.rs
@@ -1593,7 +1593,6 @@ pub struct NeuronBuilder {
     neuron_type: Option<i32>,
     visibility: Option<Visibility>,
     voting_power_refreshed_timestamp_seconds: u64,
-    recent_ballots_next_entry_index: Option<usize>,
 
     // Fields that don't exist when a neuron is first built. We allow them to be set in tests.
     #[cfg(test)]

--- a/rs/nns/governance/src/neuron/types.rs
+++ b/rs/nns/governance/src/neuron/types.rs
@@ -221,7 +221,7 @@ impl PartialEq for Neuron {
                     voting_power_refreshed_timestamp_seconds,
 
                     visibility,
-                    recent_ballots_next_entry_index,
+                    recent_ballots_next_entry_index: *recent_ballots_next_entry_index,
                 }
             }
         }

--- a/rs/nns/governance/src/neuron/types.rs
+++ b/rs/nns/governance/src/neuron/types.rs
@@ -221,7 +221,7 @@ impl PartialEq for Neuron {
                     voting_power_refreshed_timestamp_seconds,
 
                     visibility,
-                    recent_ballots_next_entry_index: *recent_ballots_next_entry_index,
+                    recent_ballots_next_entry_index,
                 }
             }
         }
@@ -1593,11 +1593,12 @@ pub struct NeuronBuilder {
     neuron_type: Option<i32>,
     visibility: Option<Visibility>,
     voting_power_refreshed_timestamp_seconds: u64,
+    recent_ballots_next_entry_index: Option<usize>,
 
     // Fields that don't exist when a neuron is first built. We allow them to be set in tests.
     #[cfg(test)]
     neuron_fees_e8s: u64,
-    #[cfg(test)]
+    #[cfg(any(test, feature = "canbench-rs"))]
     recent_ballots: Vec<BallotInfo>,
     #[cfg(test)]
     recent_ballots_next_entry_index: Option<usize>,
@@ -1635,11 +1636,12 @@ impl NeuronBuilder {
             joined_community_fund_timestamp_seconds: None,
             neuron_type: None,
             visibility: None,
+            recent_ballots_next_entry_index: None,
             voting_power_refreshed_timestamp_seconds: created_timestamp_seconds,
 
             #[cfg(test)]
             neuron_fees_e8s: 0,
-            #[cfg(test)]
+            #[cfg(any(test, feature = "canbench-rs"))]
             recent_ballots: Vec::new(),
             #[cfg(test)]
             recent_ballots_next_entry_index: Some(0),
@@ -1732,7 +1734,7 @@ impl NeuronBuilder {
         self
     }
 
-    #[cfg(test)]
+    #[cfg(any(test, feature = "canbench-rs"))]
     pub fn with_recent_ballots(mut self, recent_ballots: Vec<BallotInfo>) -> Self {
         let recent_ballots_next_entry_index =
             Some(recent_ballots.len() % MAX_NEURON_RECENT_BALLOTS);
@@ -1787,9 +1789,9 @@ impl NeuronBuilder {
             neuron_type,
             #[cfg(test)]
             neuron_fees_e8s,
-            #[cfg(test)]
+            #[cfg(any(test, feature = "canbench-rs"))]
             recent_ballots,
-            #[cfg(test)]
+            #[cfg(any(test, feature = "canbench-rs"))]
             recent_ballots_next_entry_index,
             #[cfg(test)]
             transfer,
@@ -1810,9 +1812,9 @@ impl NeuronBuilder {
         // The below fields are always the default values for a new neuron.
         #[cfg(not(test))]
         let neuron_fees_e8s = 0;
-        #[cfg(not(test))]
+        #[cfg(not(any(test, feature = "canbench-rs")))]
         let recent_ballots = Vec::new();
-        #[cfg(not(test))]
+        #[cfg(not(any(test, feature = "canbench-rs")))]
         let recent_ballots_next_entry_index = Some(0);
         #[cfg(not(test))]
         let transfer = None;

--- a/rs/nns/governance/src/neuron_store/benches.rs
+++ b/rs/nns/governance/src/neuron_store/benches.rs
@@ -93,7 +93,11 @@ fn subaccount_from_id(id: u64) -> Subaccount {
     Subaccount::try_from(account.as_slice()).unwrap()
 }
 
-fn build_neuron(rng: &mut impl RngCore, location: NeuronLocation, size: NeuronSize) -> Neuron {
+fn new_neuron_builder(
+    rng: &mut impl RngCore,
+    location: NeuronLocation,
+    size: NeuronSize,
+) -> NeuronBuilder {
     let id = rng.next_u64();
 
     let subaccount = subaccount_from_id(id);
@@ -105,8 +109,14 @@ fn build_neuron(rng: &mut impl RngCore, location: NeuronLocation, size: NeuronSi
             followees: (0..size.num_followees()).map(|_| NeuronId { id: rng.next_u64() }).collect(),
         },
     };
+    let recent_ballots = (0..size.num_recent_ballots())
+        .map(|_| BallotInfo {
+            proposal_id: Some(ProposalId { id: rng.next_u64() }),
+            vote: Vote::Yes as i32,
+        })
+        .collect();
 
-    let mut neuron = NeuronBuilder::new(
+    NeuronBuilder::new(
         NeuronId { id },
         subaccount,
         PrincipalId::new_user_test_id(id),
@@ -116,17 +126,7 @@ fn build_neuron(rng: &mut impl RngCore, location: NeuronLocation, size: NeuronSi
     .with_cached_neuron_stake_e8s(location.cached_neuron_stake_e8s())
     .with_hot_keys(hot_keys)
     .with_followees(followees)
-    .build();
-
-    neuron.recent_ballots = (0..size.num_recent_ballots())
-        .map(|_| BallotInfo {
-            proposal_id: Some(ProposalId { id: rng.next_u64() }),
-            vote: Vote::Yes as i32,
-        })
-        .collect();
-    neuron.recent_ballots_next_entry_index = Some(0);
-
-    neuron
+    .with_recent_ballots(recent_ballots)
 }
 
 fn set_up_neuron_store(
@@ -137,10 +137,10 @@ fn set_up_neuron_store(
     // We insert 200 inactive neurons and 100 active neurons. They are not very realistic sizes, but
     // it would take too long to prepare those neurons for each benchmark.
     let inactive_neurons: Vec<_> = (0..inactive_count)
-        .map(|_| build_neuron(rng, NeuronLocation::Stable, NeuronSize::Typical))
+        .map(|_| new_neuron_builder(rng, NeuronLocation::Stable, NeuronSize::Typical).build())
         .collect();
     let active_neurons: Vec<_> = (0..active_count)
-        .map(|_| build_neuron(rng, NeuronLocation::Heap, NeuronSize::Typical))
+        .map(|_| new_neuron_builder(rng, NeuronLocation::Heap, NeuronSize::Typical).build())
         .collect();
     let neurons: BTreeMap<u64, Neuron> = inactive_neurons
         .into_iter()
@@ -155,7 +155,7 @@ fn set_up_neuron_store(
 fn add_neuron_active_typical() -> BenchResult {
     let mut rng = new_rng();
     let mut neuron_store = set_up_neuron_store(&mut rng, 100, 200);
-    let neuron = build_neuron(&mut rng, NeuronLocation::Heap, NeuronSize::Typical);
+    let neuron = new_neuron_builder(&mut rng, NeuronLocation::Heap, NeuronSize::Typical).build();
 
     bench_fn(|| {
         neuron_store.add_neuron(neuron).unwrap();
@@ -166,7 +166,7 @@ fn add_neuron_active_typical() -> BenchResult {
 fn add_neuron_active_maximum() -> BenchResult {
     let mut rng = new_rng();
     let mut neuron_store = set_up_neuron_store(&mut rng, 100, 200);
-    let neuron = build_neuron(&mut rng, NeuronLocation::Heap, NeuronSize::Maximum);
+    let neuron = new_neuron_builder(&mut rng, NeuronLocation::Heap, NeuronSize::Maximum).build();
 
     bench_fn(|| {
         neuron_store.add_neuron(neuron).unwrap();
@@ -177,7 +177,18 @@ fn add_neuron_active_maximum() -> BenchResult {
 fn add_neuron_inactive_typical() -> BenchResult {
     let mut rng = new_rng();
     let mut neuron_store = set_up_neuron_store(&mut rng, 100, 200);
-    let neuron = build_neuron(&mut rng, NeuronLocation::Stable, NeuronSize::Typical);
+    let neuron = new_neuron_builder(&mut rng, NeuronLocation::Stable, NeuronSize::Typical).build();
+
+    bench_fn(|| {
+        neuron_store.add_neuron(neuron).unwrap();
+    })
+}
+
+#[bench(raw)]
+fn add_neuron_inactive_maximum() -> BenchResult {
+    let mut rng = new_rng();
+    let mut neuron_store = set_up_neuron_store(&mut rng, 100, 200);
+    let neuron = new_neuron_builder(&mut rng, NeuronLocation::Stable, NeuronSize::Maximum).build();
 
     bench_fn(|| {
         neuron_store.add_neuron(neuron).unwrap();
@@ -190,7 +201,7 @@ fn update_recent_ballots_stable_memory() -> BenchResult {
     let _b = temporarily_enable_stable_memory_following_index();
     let mut rng = new_rng();
     let mut neuron_store = set_up_neuron_store(&mut rng, 100, 200);
-    let neuron = build_neuron(&mut rng, NeuronLocation::Heap, NeuronSize::Maximum);
+    let neuron = new_neuron_builder(&mut rng, NeuronLocation::Heap, NeuronSize::Maximum).build();
 
     let id = neuron.id();
 
@@ -207,17 +218,6 @@ fn update_recent_ballots_stable_memory() -> BenchResult {
                 Vote::Yes,
             )
             .unwrap();
-    })
-}
-
-#[bench(raw)]
-fn add_neuron_inactive_maximum() -> BenchResult {
-    let mut rng = new_rng();
-    let mut neuron_store = set_up_neuron_store(&mut rng, 100, 200);
-    let neuron = build_neuron(&mut rng, NeuronLocation::Stable, NeuronSize::Maximum);
-
-    bench_fn(|| {
-        neuron_store.add_neuron(neuron).unwrap();
     })
 }
 
@@ -367,8 +367,9 @@ fn draw_maturity_from_neurons_fund_heap() -> BenchResult {
     let mut neuron_store = NeuronStore::new(BTreeMap::new());
     let mut neurons_fund_neurons = BTreeSet::new();
     for _ in 0..100 {
-        let mut neuron = build_neuron(&mut rng, NeuronLocation::Heap, NeuronSize::Typical);
-        neuron.maturity_e8s_equivalent = 2_000_000_000;
+        let neuron = new_neuron_builder(&mut rng, NeuronLocation::Heap, NeuronSize::Typical)
+            .with_maturity_e8s_equivalent(2_000_000_000)
+            .build();
         neurons_fund_neurons.insert(build_neurons_fund_portion(&neuron, 1_000_000_000));
         neuron_store.add_neuron(neuron).unwrap();
     }
@@ -388,8 +389,9 @@ fn draw_maturity_from_neurons_fund_stable() -> BenchResult {
     let mut neuron_store = NeuronStore::new(BTreeMap::new());
     let mut neurons_fund_neurons = BTreeSet::new();
     for _ in 0..100 {
-        let mut neuron = build_neuron(&mut rng, NeuronLocation::Heap, NeuronSize::Typical);
-        neuron.maturity_e8s_equivalent = 2_000_000_000;
+        let neuron = new_neuron_builder(&mut rng, NeuronLocation::Heap, NeuronSize::Typical)
+            .with_maturity_e8s_equivalent(2_000_000_000)
+            .build();
         neurons_fund_neurons.insert(build_neurons_fund_portion(&neuron, 1_000_000_000));
         neuron_store.add_neuron(neuron).unwrap();
     }
@@ -400,4 +402,34 @@ fn draw_maturity_from_neurons_fund_stable() -> BenchResult {
             .draw_maturity_from_neurons_fund(&neurons_fund_snapshot)
             .unwrap();
     })
+}
+
+#[bench(raw)]
+fn list_active_neurons_fund_neurons_heap() -> BenchResult {
+    let _t = temporarily_disable_active_neurons_in_stable_memory();
+    let mut rng = new_rng();
+    let mut neuron_store = NeuronStore::new(BTreeMap::new());
+    for _ in 0..100 {
+        let neuron = new_neuron_builder(&mut rng, NeuronLocation::Heap, NeuronSize::Typical)
+            .with_joined_community_fund_timestamp_seconds(Some(now_seconds()))
+            .build();
+        neuron_store.add_neuron(neuron).unwrap();
+    }
+
+    bench_fn(|| std::hint::black_box(neuron_store.list_active_neurons_fund_neurons()))
+}
+
+#[bench(raw)]
+fn list_active_neurons_fund_neurons_stable() -> BenchResult {
+    let _t = temporarily_enable_active_neurons_in_stable_memory();
+    let mut rng = new_rng();
+    let mut neuron_store = NeuronStore::new(BTreeMap::new());
+    for _ in 0..100 {
+        let neuron = new_neuron_builder(&mut rng, NeuronLocation::Heap, NeuronSize::Typical)
+            .with_joined_community_fund_timestamp_seconds(Some(now_seconds()))
+            .build();
+        neuron_store.add_neuron(neuron).unwrap();
+    }
+
+    bench_fn(|| std::hint::black_box(neuron_store.list_active_neurons_fund_neurons()))
 }


### PR DESCRIPTION
# Why

Listing neurons could get more expensive when neurons are moved to stable structures. Adding a benchmark so that future improvements can be measured, and regressions can be detected.

# What

* Some small refactoring on neuron building for benchmarks so that each benchmark can customize neuron builder before building it
* Add benchmarks for listing neurons fund neurons with and without the "neurons in stable memory" feature

[Next](https://github.com/dfinity/ic/pull/3020)