### PR TITLE
perf(nns): Improve listing neurons fund neurons

### DIFF
--- a/rs/nns/governance/canbench/canbench_results.yml
+++ b/rs/nns/governance/canbench/canbench_results.yml
@@ -37,25 +37,25 @@ benches:
     scopes: {}
   cascading_vote_stable_everything:
     total:
-      instructions: 162936090
+      instructions: 162934518
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   cascading_vote_stable_neurons_with_heap_index:
     total:
-      instructions: 140737573
+      instructions: 140736001
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   centralized_following_all_stable:
     total:
-      instructions: 68400404
+      instructions: 68399951
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   compute_ballots_for_new_proposal_with_stable_neurons:
     total:
-      instructions: 1817258
+      instructions: 1816970
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
@@ -73,13 +73,13 @@ benches:
     scopes: {}
   list_active_neurons_fund_neurons_heap:
     total:
-      instructions: 438096
+      instructions: 440982
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   list_active_neurons_fund_neurons_stable:
     total:
-      instructions: 24026434
+      instructions: 2457798
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
@@ -109,7 +109,7 @@ benches:
     scopes: {}
   neuron_metrics_calculation_heap:
     total:
-      instructions: 536345
+      instructions: 536231
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
@@ -121,7 +121,7 @@ benches:
     scopes: {}
   range_neurons_performance:
     total:
-      instructions: 47410663
+      instructions: 47410063
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}

--- a/rs/nns/governance/src/neuron_store.rs
+++ b/rs/nns/governance/src/neuron_store.rs
@@ -933,19 +933,6 @@ impl NeuronStore {
         self.heap_neurons.range(range).map(|(_, neuron)| neuron)
     }
 
-    /// Internal - map over neurons after filtering
-    fn filter_map_active_neurons<R>(
-        &self,
-        filter: impl Fn(&Neuron) -> bool,
-        f: impl Fn(&Neuron) -> R,
-    ) -> Vec<R> {
-        self.with_active_neurons_iter(|iter| {
-            iter.filter(|n| filter(n.as_ref()))
-                .map(|n| f(n.as_ref()))
-                .collect()
-        })
-    }
-
     fn is_active_neurons_fund_neuron(neuron: &Neuron, now: u64) -> bool {
         !neuron.is_inactive(now) && neuron.is_a_neurons_fund_member()
     }
@@ -953,17 +940,22 @@ impl NeuronStore {
     /// List all neuron ids that are in the Neurons' Fund.
     pub fn list_active_neurons_fund_neurons(&self) -> Vec<NeuronsFundNeuron> {
         let now = self.now();
-        self.filter_map_active_neurons(
-            |n| Self::is_active_neurons_fund_neuron(n, now),
-            |n| NeuronsFundNeuron {
-                id: n.id(),
-                controller: n.controller(),
-                hotkeys: pick_most_important_hotkeys(&n.hot_keys),
-                maturity_equivalent_icp_e8s: n.maturity_e8s_equivalent,
+        self.with_active_neurons_iter_sections(
+            |iter| {
+                iter.filter(|neuron| Self::is_active_neurons_fund_neuron(neuron, now))
+                    .map(|neuron| NeuronsFundNeuron {
+                        id: neuron.id(),
+                        controller: neuron.controller(),
+                        hotkeys: pick_most_important_hotkeys(&neuron.hot_keys),
+                        maturity_equivalent_icp_e8s: neuron.maturity_e8s_equivalent,
+                    })
+                    .collect()
+            },
+            NeuronSections {
+                hot_keys: true,
+                ..NeuronSections::NONE
             },
         )
-        .into_iter()
-        .collect()
     }
 
     /// List all neuron ids whose neurons have staked maturity greater than 0.


### PR DESCRIPTION
Improving listing neurons fund neurons by 90% (24026434 -> 2457798), through only reading the hot keys section.

[Prev](https://github.com/dfinity/ic/pull/3019)