### PR TITLE
chore(nns): Clarify the purpose of loading the known neuron section when calculating metrics

### DIFF
--- a/rs/nns/governance/src/neuron_store/metrics.rs
+++ b/rs/nns/governance/src/neuron_store/metrics.rs
@@ -219,11 +219,9 @@ impl NeuronStore {
     ) {
         with_stable_neuron_store(|stable_neuron_store| {
             let neuron_sections = NeuronSections {
-                hot_keys: false,
-                recent_ballots: false,
-                followees: false,
+                // This is needed for `Neuron::visibility``
                 known_neuron_data: true,
-                transfer: false,
+                ..NeuronSections::NONE
             };
 
             for neuron in stable_neuron_store.range_neurons_sections(.., neuron_sections) {


### PR DESCRIPTION
The purpose of loading the `known_neuron_data` section isn't very obvious. Adding a comment as well as using `..NeuronSections::NONE` for simplification.