### PR TITLE
docs(nns): Deleted comments that say Comand (and related) types are deprecated.

### DIFF
--- a/rs/nns/governance/api/src/ic_nns_governance.pb.v1.rs
+++ b/rs/nns/governance/api/src/ic_nns_governance.pb.v1.rs
@@ -711,8 +711,6 @@ pub mod proposal {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Empty {}
 
-/// DEPRECATED. USE ManageNeuronRequest INSTEAD!
-///
 /// All operations that modify the state of an existing neuron are
 /// represented by instances of `ManageNeuron`.
 ///
@@ -1085,8 +1083,6 @@ pub mod manage_neuron {
     }
 
     // KEEP THIS IN SYNC WITH ManageNeuronCommandRequest!
-    //
-    // Deprecated. Use ManageNeuronCommandRequest instead.
     #[derive(candid::CandidType, candid::Deserialize, serde::Serialize, comparable::Comparable)]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]

--- a/rs/nns/governance/canister/governance.did
+++ b/rs/nns/governance/canister/governance.did
@@ -123,8 +123,6 @@ type RefreshVotingPowerResponse = record {
 };
 
 // KEEP THIS IN SYNC WITH ManageNeuronCommandRequest!
-//
-// Deprecated. Use ManageNeuronCommandRequest instead. It is equivalent.
 type Command = variant {
   Spawn : Spawn;
   Split : Split;
@@ -495,10 +493,6 @@ type ManageNeuron = record {
 };
 
 // KEEP THIS IN SYNC WITH COMMAND!
-//
-// Command is deprecated, but people need time to migrate to this. Therefore, we
-// have not deleted Command yet. In the meantime, ManageNeuronCommandRequest
-// must be kept in sync with Command.
 type ManageNeuronCommandRequest = variant {
   Spawn : Spawn;
   Split : Split;


### PR DESCRIPTION
Those comments are incorrect. I wrote those comments in https://github.com/dfinity/ic/pull/3021, because I thought these types are deprecated, but I was confused.

However, it is still correct that the definition of analogous type need to be kept in sync.