### PR TITLE
fix(node): add node-reward-type default to setupos-inject-config

### DIFF
--- a/rs/tests/driver/src/driver/bootstrap.rs
+++ b/rs/tests/driver/src/driver/bootstrap.rs
@@ -665,6 +665,8 @@ fn configure_setupos_image(
         .arg(nns_url.to_string())
         .arg("--nns-public-key")
         .arg(nns_public_key)
+        .arg("--node-reward-type")
+        .arg("type3.1")
         .env(path_key, &new_path);
 
     if !admin_keys.is_empty() {


### PR DESCRIPTION
node_reward_type is a required field in config.ini, so a default should be added to setupos-inject-config calls.