### PR TITLE
fix: retry bad gateway errors in spec compliance tests

### DIFF
--- a/hs/spec_compliance/src/IC/Test/Agent.hs
+++ b/hs/spec_compliance/src/IC/Test/Agent.hs
@@ -460,7 +460,7 @@ postCBOR' ep path gr = do
         }
   waitFor $ do
     res <- httpLbs request agentManager
-    if responseStatus res == tooManyRequests429
+    if responseStatus res == tooManyRequests429 || responseStatus res == badGateway502
       then return Nothing
       else return $ Just res
 


### PR DESCRIPTION
This PR retries HTTP errors with status code 502 (bad gateway) in spec compliance tests: if the HTTP gateway is overloaded in PocketIC, then this error code is sometimes produced leading to spurious test failures.