### PR TITLE
chore: increase PocketIC test size and cpu

### DIFF
--- a/packages/pocket-ic/BUILD.bazel
+++ b/packages/pocket-ic/BUILD.bazel
@@ -70,7 +70,7 @@ rust_test(
 
 rust_test_suite(
     name = "test",
-    size = "small",
+    size = "medium",
     srcs = ["tests/tests.rs"],
     data = [
         "//packages/pocket-ic/test_canister:test_canister.wasm",
@@ -83,7 +83,7 @@ rust_test_suite(
     flaky = False,
     proc_macro_deps = MACRO_DEPENDENCIES,
     tags = [
-        "cpu:8",
+        "cpu:16",
         "test_macos",
     ],
     deps = [":pocket-ic"] + DEPENDENCIES + TEST_DEPENDENCIES,


### PR DESCRIPTION
The test `//packages/pocket-ic:test_tests/tests` has been timing out quite often on CI recently so this PR increases its size (and thus timeout) and cpu count.