### PR TITLE
test(ICP_Ledger): FI-1506: Increase CPU reservation for flaky ICP ledger and index tests

### DIFF
--- a/rs/ledger_suite/icp/index/BUILD.bazel
+++ b/rs/ledger_suite/icp/index/BUILD.bazel
@@ -105,5 +105,6 @@ rust_ic_test(
         "LEDGER_CANISTER_WASM_PATH": "$(rootpath //rs/ledger_suite/icp/ledger:ledger-canister-wasm)",
     },
     flaky = True,
+    tags = ["cpu:4"],
     deps = [":ic-icp-index"] + DEPENDENCIES + DEV_DEPENDENCIES,
 )

--- a/rs/ledger_suite/icp/ledger/BUILD.bazel
+++ b/rs/ledger_suite/icp/ledger/BUILD.bazel
@@ -118,6 +118,7 @@ rust_ic_test(
         "LEDGER_CANISTER_NEXT_VERSION_WASM_PATH": "$(rootpath :ledger-canister-wasm-next-version)",
     },
     flaky = True,
+    tags = ["cpu:4"],
     deps = [
         # Keep sorted.
         ":ledger",


### PR DESCRIPTION
[This earlier PR](https://github.com/dfinity/ic/pull/2208) limited the parallelism for the affected tests to 4 threads, but unfortunately that didn't seem to help. However, when combined with CPU reservations in [this PR](https://github.com/dfinity/ic/pull/2914) (for a somewhat related test), the flakiness of the latter test went down from 9% to 0.9%. Since both tests are similar (the tests in this PR use `StateMachine`, whereas the ones in the other use `PocketIC`, which in turn uses `StateMachine` under the hood), the hope is that increasing the CPU reservation would also reduce the flakiness of the ICP ledger and index tests covered by this PR.