### PR TITLE
test(IDX): isolate the advance_target_version_upgrades_all_canisters_test

### DIFF
--- a/rs/nervous_system/integration_tests/BUILD.bazel
+++ b/rs/nervous_system/integration_tests/BUILD.bazel
@@ -168,8 +168,8 @@ rust_test_suite_with_extra_srcs(
         ["tests/**/*.rs"],
         exclude = [
             # The following tests are flaky when run as part of this test suite.
-            # So they have been moved to dedicated bazel targets below such that we can
-            # different CPU reservations and better logging.
+            # So they have been moved to dedicated bazel targets below
+            # such that we can have different CPU reservations and better logging.
             "tests/sns_upgrade_test_utils.rs",
             "tests/upgrade_everything_test.rs",
             "tests/advance_target_version_upgrades_all_canisters_test.rs",

--- a/rs/nervous_system/integration_tests/BUILD.bazel
+++ b/rs/nervous_system/integration_tests/BUILD.bazel
@@ -167,8 +167,12 @@ rust_test_suite_with_extra_srcs(
     srcs = glob(
         ["tests/**/*.rs"],
         exclude = [
+            # The following tests are flaky when run as part of this test suite.
+            # So they have been moved to dedicated bazel targets below such that we can
+            # different CPU reservations and better logging.
             "tests/sns_upgrade_test_utils.rs",
             "tests/upgrade_everything_test.rs",
+            "tests/advance_target_version_upgrades_all_canisters_test.rs",
         ],
     ),
     aliases = ALIASES,
@@ -197,6 +201,22 @@ rust_test(
     proc_macro_deps = MACRO_DEPENDENCIES + MACRO_DEV_DEPENDENCIES,
     tags = [
         "cpu:6",
+    ],
+    deps = [":nervous_system_integration_tests"] + DEPENDENCIES_WITH_TEST_FEATURES + DEV_DEPENDENCIES,
+)
+
+rust_test(
+    name = "advance_target_version_upgrades_all_canisters_test",
+    srcs = [
+        "tests/advance_target_version_upgrades_all_canisters_test.rs",
+    ],
+    aliases = ALIASES,
+    data = DEV_DATA,
+    env = DEV_ENV,
+    flaky = True,
+    proc_macro_deps = MACRO_DEPENDENCIES + MACRO_DEV_DEPENDENCIES,
+    tags = [
+        "cpu:4",
     ],
     deps = [":nervous_system_integration_tests"] + DEPENDENCIES_WITH_TEST_FEATURES + DEV_DEPENDENCIES,
 )

--- a/rs/nervous_system/integration_tests/tests/advance_sns_target_version.rs
+++ b/rs/nervous_system/integration_tests/tests/advance_sns_target_version.rs
@@ -2,8 +2,7 @@ use ic_nervous_system_integration_tests::pocket_ic_helpers::{await_with_timeout,
 use ic_nervous_system_integration_tests::{
     create_service_nervous_system_builder::CreateServiceNervousSystemBuilder,
     pocket_ic_helpers::{
-        add_wasm_via_nns_proposal, add_wasms_to_sns_wasm, hash_sns_wasms, install_nns_canisters,
-        nns,
+        add_wasm_via_nns_proposal, add_wasms_to_sns_wasm, install_nns_canisters, nns,
     },
 };
 use ic_nns_test_utils::sns_wasm::create_modified_sns_wasm;
@@ -16,7 +15,6 @@ use ic_sns_governance::{
 use ic_sns_swap::pb::v1::Lifecycle;
 use ic_sns_wasm::pb::v1::SnsCanisterType;
 use pocket_ic::PocketIcBuilder;
-use std::collections::BTreeMap;
 
 #[tokio::test]
 async fn test_get_upgrade_journal() {
@@ -260,131 +258,4 @@ async fn test_get_upgrade_journal() {
         )
         .await;
     }
-}
-
-#[tokio::test]
-async fn test_advance_target_version_upgrades_all_canisters() {
-    // Step 0: Setup the test environment.
-    let pocket_ic = PocketIcBuilder::new()
-        .with_nns_subnet()
-        .with_sns_subnet()
-        .build_async()
-        .await;
-
-    // Install the (master) NNS canisters.
-    let with_mainnet_nns_canisters = false;
-    install_nns_canisters(&pocket_ic, vec![], with_mainnet_nns_canisters, None, vec![]).await;
-
-    // Step 0.1: Publish (master) SNS Wasms to SNS-W.
-    let with_mainnet_sns_canisters = false;
-    let initial_sns_version = {
-        let deployed_sns_starting_info =
-            add_wasms_to_sns_wasm(&pocket_ic, with_mainnet_sns_canisters)
-                .await
-                .unwrap();
-        deployed_sns_starting_info
-            .into_iter()
-            .map(|(canister_type, (_, wasm))| (canister_type, wasm))
-            .collect::<BTreeMap<_, _>>()
-    };
-
-    // Step 0.2: Deploy an SNS instance via proposal.
-    let sns = {
-        let create_service_nervous_system = CreateServiceNervousSystemBuilder::default().build();
-        let swap_parameters = create_service_nervous_system
-            .swap_parameters
-            .clone()
-            .unwrap();
-
-        let sns_instance_label = "1";
-        let (sns, _) = nns::governance::propose_to_deploy_sns_and_wait(
-            &pocket_ic,
-            create_service_nervous_system,
-            sns_instance_label,
-        )
-        .await;
-
-        sns::swap::await_swap_lifecycle(&pocket_ic, sns.swap.canister_id, Lifecycle::Open)
-            .await
-            .unwrap();
-        sns::swap::smoke_test_participate_and_finalize(
-            &pocket_ic,
-            sns.swap.canister_id,
-            swap_parameters,
-        )
-        .await;
-        sns
-    };
-
-    // Step 0.3: Ensure an archive canister is spawned.
-    sns::ensure_archive_canister_is_spawned_or_panic(
-        &pocket_ic,
-        sns.governance.canister_id,
-        sns.ledger.canister_id,
-    )
-    .await;
-
-    // Step 2: Publish new SNS versions.
-    let latest_sns_version = {
-        let canister_types = vec![
-            SnsCanisterType::Governance,
-            SnsCanisterType::Root,
-            SnsCanisterType::Swap,
-            SnsCanisterType::Ledger,
-            SnsCanisterType::Index,
-            SnsCanisterType::Archive,
-        ];
-
-        let mut latest_version = initial_sns_version;
-
-        for canister_type in canister_types {
-            latest_version =
-                nns::sns_wasm::modify_and_add_wasm(&pocket_ic, latest_version, canister_type, 1)
-                    .await;
-        }
-
-        latest_version
-    };
-
-    // Step 3: Wait for the upgrade steps to be refreshed.
-    await_with_timeout(
-        &pocket_ic,
-        UPGRADE_STEPS_INTERVAL_REFRESH_BACKOFF_SECONDS,
-        |pocket_ic| async {
-            sns::governance::try_get_upgrade_journal(pocket_ic, sns.governance.canister_id)
-                .await
-                .ok()
-                .and_then(|journal| journal.upgrade_steps)
-                .map(|upgrade_steps| upgrade_steps.versions)
-                .map(|versions| versions.len())
-        },
-        // Hopefully there are 7 upgrade steps - 1 initial version, then another for each of the 6 canisters.
-        &Some(7usize),
-    )
-    .await
-    .unwrap();
-
-    // Step 4: advance the target version to the latest version.
-    let latest_sns_version_hash = hash_sns_wasms(&latest_sns_version);
-    sns::governance::advance_target_version(
-        &pocket_ic,
-        sns.governance.canister_id,
-        latest_sns_version_hash.clone(),
-    )
-    .await;
-
-    // Step 5: Wait for the upgrade to happen
-    await_with_timeout(
-        &pocket_ic,
-        UPGRADE_STEPS_INTERVAL_REFRESH_BACKOFF_SECONDS,
-        |pocket_ic| async {
-            let journal =
-                sns::governance::try_get_upgrade_journal(pocket_ic, sns.governance.canister_id)
-                    .await;
-            journal.ok().and_then(|journal| journal.deployed_version)
-        },
-        &Some(latest_sns_version_hash),
-    )
-    .await
-    .unwrap();
 }

--- a/rs/nervous_system/integration_tests/tests/advance_target_version_upgrades_all_canisters_test.rs
+++ b/rs/nervous_system/integration_tests/tests/advance_target_version_upgrades_all_canisters_test.rs
@@ -85,6 +85,7 @@ async fn test_advance_target_version_upgrades_all_canisters() {
         let mut latest_version = initial_sns_version;
 
         for canister_type in canister_types {
+            eprintln!("modify_and_add_wasm for {:?} ...", canister_type);
             latest_version =
                 nns::sns_wasm::modify_and_add_wasm(&pocket_ic, latest_version, canister_type, 1)
                     .await;

--- a/rs/nervous_system/integration_tests/tests/advance_target_version_upgrades_all_canisters_test.rs
+++ b/rs/nervous_system/integration_tests/tests/advance_target_version_upgrades_all_canisters_test.rs
@@ -1,0 +1,137 @@
+use ic_nervous_system_integration_tests::pocket_ic_helpers::{await_with_timeout, sns};
+use ic_nervous_system_integration_tests::{
+    create_service_nervous_system_builder::CreateServiceNervousSystemBuilder,
+    pocket_ic_helpers::{add_wasms_to_sns_wasm, hash_sns_wasms, install_nns_canisters, nns},
+};
+use ic_sns_governance::governance::UPGRADE_STEPS_INTERVAL_REFRESH_BACKOFF_SECONDS;
+use ic_sns_swap::pb::v1::Lifecycle;
+use ic_sns_wasm::pb::v1::SnsCanisterType;
+use pocket_ic::PocketIcBuilder;
+use std::collections::BTreeMap;
+
+#[tokio::test]
+async fn test_advance_target_version_upgrades_all_canisters() {
+    eprintln!("Step 0: Setup the test environment ...");
+    let pocket_ic = PocketIcBuilder::new()
+        .with_nns_subnet()
+        .with_sns_subnet()
+        .build_async()
+        .await;
+
+    eprintln!("Install the (master) NNS canisters ...");
+    let with_mainnet_nns_canisters = false;
+    install_nns_canisters(&pocket_ic, vec![], with_mainnet_nns_canisters, None, vec![]).await;
+
+    eprintln!("Step 0.1: Publish (master) SNS Wasms to SNS-W ...");
+    let with_mainnet_sns_canisters = false;
+    let initial_sns_version = {
+        let deployed_sns_starting_info =
+            add_wasms_to_sns_wasm(&pocket_ic, with_mainnet_sns_canisters)
+                .await
+                .unwrap();
+        deployed_sns_starting_info
+            .into_iter()
+            .map(|(canister_type, (_, wasm))| (canister_type, wasm))
+            .collect::<BTreeMap<_, _>>()
+    };
+
+    eprintln!("Step 0.2: Deploy an SNS instance via proposal ...");
+    let sns = {
+        let create_service_nervous_system = CreateServiceNervousSystemBuilder::default().build();
+        let swap_parameters = create_service_nervous_system
+            .swap_parameters
+            .clone()
+            .unwrap();
+
+        let sns_instance_label = "1";
+        let (sns, _) = nns::governance::propose_to_deploy_sns_and_wait(
+            &pocket_ic,
+            create_service_nervous_system,
+            sns_instance_label,
+        )
+        .await;
+
+        sns::swap::await_swap_lifecycle(&pocket_ic, sns.swap.canister_id, Lifecycle::Open)
+            .await
+            .unwrap();
+        sns::swap::smoke_test_participate_and_finalize(
+            &pocket_ic,
+            sns.swap.canister_id,
+            swap_parameters,
+        )
+        .await;
+        sns
+    };
+
+    eprintln!("Step 0.3: Ensure an archive canister is spawned ...");
+    sns::ensure_archive_canister_is_spawned_or_panic(
+        &pocket_ic,
+        sns.governance.canister_id,
+        sns.ledger.canister_id,
+    )
+    .await;
+
+    eprintln!("Step 2: Publish new SNS versions ...");
+    let latest_sns_version = {
+        let canister_types = vec![
+            SnsCanisterType::Governance,
+            SnsCanisterType::Root,
+            SnsCanisterType::Swap,
+            SnsCanisterType::Ledger,
+            SnsCanisterType::Index,
+            SnsCanisterType::Archive,
+        ];
+
+        let mut latest_version = initial_sns_version;
+
+        for canister_type in canister_types {
+            latest_version =
+                nns::sns_wasm::modify_and_add_wasm(&pocket_ic, latest_version, canister_type, 1)
+                    .await;
+        }
+
+        latest_version
+    };
+
+    eprintln!("Step 3: Wait for the upgrade steps to be refreshed ...");
+    await_with_timeout(
+        &pocket_ic,
+        UPGRADE_STEPS_INTERVAL_REFRESH_BACKOFF_SECONDS,
+        |pocket_ic| async {
+            sns::governance::try_get_upgrade_journal(pocket_ic, sns.governance.canister_id)
+                .await
+                .ok()
+                .and_then(|journal| journal.upgrade_steps)
+                .map(|upgrade_steps| upgrade_steps.versions)
+                .map(|versions| versions.len())
+        },
+        // Hopefully there are 7 upgrade steps - 1 initial version, then another for each of the 6 canisters.
+        &Some(7usize),
+    )
+    .await
+    .unwrap();
+
+    eprintln!("Step 4: advance the target version to the latest version. ...");
+    let latest_sns_version_hash = hash_sns_wasms(&latest_sns_version);
+    sns::governance::advance_target_version(
+        &pocket_ic,
+        sns.governance.canister_id,
+        latest_sns_version_hash.clone(),
+    )
+    .await;
+
+    eprintln!("Step 5: Wait for the upgrade to happen ...");
+    await_with_timeout(
+        &pocket_ic,
+        UPGRADE_STEPS_INTERVAL_REFRESH_BACKOFF_SECONDS,
+        |pocket_ic| async {
+            let journal =
+                sns::governance::try_get_upgrade_journal(pocket_ic, sns.governance.canister_id)
+                    .await;
+            journal.ok().and_then(|journal| journal.deployed_version)
+        },
+        &Some(latest_sns_version_hash),
+    )
+    .await
+    .unwrap();
+}


### PR DESCRIPTION
The `//rs/nervous_system/integration_tests:integration_tests_test_tests/advance_sns_target_version` is currently the most flaky system-test. It flakes because the `advance_target_version_upgrades_all_canisters_test` is timing out. So this commit isolates this test into its own bazel target and adds some logging such that we know which part is timing out.