### PR TITLE
refactor: CON-1434 Serialize current and next transcripts into `pb::NiDkgTranscript`

### DIFF
--- a/rs/types/types/src/consensus/dkg.rs
+++ b/rs/types/types/src/consensus/dkg.rs
@@ -293,19 +293,12 @@ impl Summary {
     }
 }
 
-fn build_tagged_transcripts_vec(
+fn build_transcripts_vec(
     transcripts: &BTreeMap<NiDkgTag, NiDkgTranscript>,
-) -> Vec<pb::TaggedNiDkgTranscript> {
+) -> Vec<pb::NiDkgTranscript> {
     transcripts
-        .iter()
-        .map(|(tag, transcript)| pb::TaggedNiDkgTranscript {
-            tag: pb::NiDkgTag::from(tag) as i32,
-            transcript: Some(pb::NiDkgTranscript::from(transcript)),
-            key_id: match tag {
-                NiDkgTag::HighThresholdForKey(k) => Some(pb::MasterPublicKeyId::from(k)),
-                _ => None,
-            },
-        })
+        .values()
+        .map(pb::NiDkgTranscript::from)
         .collect()
 }
 
@@ -355,12 +348,10 @@ impl From<&Summary> for pb::Summary {
                 .values()
                 .map(pb::NiDkgConfig::from)
                 .collect(),
-            current_transcripts_deprecated: build_tagged_transcripts_vec(
-                &summary.current_transcripts,
-            ),
-            current_transcripts_new: Vec::new(),
-            next_transcripts_deprecated: build_tagged_transcripts_vec(&summary.next_transcripts),
-            next_transcripts_new: Vec::new(),
+            current_transcripts_new: build_transcripts_vec(&summary.current_transcripts),
+            current_transcripts_deprecated: Vec::new(),
+            next_transcripts_new: build_transcripts_vec(&summary.next_transcripts),
+            next_transcripts_deprecated: Vec::new(),
             interval_length: summary.interval_length.get(),
             next_interval_length: summary.next_interval_length.get(),
             height: summary.height.get(),


### PR DESCRIPTION
As the `NiDkgId` (and therefore the `NiDkgTag`) is already part of the `NiDkgTranscript`, serializing the `NiDkgTag` separately as part of `pb::TaggedNiDkgTranscript` is redundant.

This PR instead serializes the current and next transcripts directly as `pb::NiDkgTranscript`.

https://github.com/dfinity/ic/pull/2838 introduced the new proto fields of type `pb::NiDkgTranscript`, and implemented the deserialization function to consider both new and old fields. This ensures the backwards/forwards compatibility of the change made by this PR.

Upgrade:
- The old summary still contains `pb::TaggedNiDkgTranscript`s, but they can still be read as the deserialization function supports both types.
- Newly created summary blocks will instead contain `pb::NiDkgTranscript`s directly.

Downgrade:
- As the deserialization function supporting both types already exists in the previous version, Summary blocks created by the version of this PR will be deserialized successfully.