### PR TITLE
chore(IDX): IDX no longer co-owns system-tests

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -236,26 +236,25 @@ go_deps.bzl               @dfinity/idx
 /rs/test_utilities/state/                               @dfinity/execution @dfinity/ic-message-routing-owners
 /rs/test_utilities/types/src/batch/                     @dfinity/consensus
 /rs/tests/                                              @dfinity/idx
-/rs/tests/research                                      @dfinity/research @dfinity/idx
-/rs/tests/driver/src/driver/simulate_network.rs         @dfinity/networking
-/rs/tests/boundary_nodes/                               @dfinity/boundary-node @dfinity/idx
-/rs/tests/ckbtc/                                        @dfinity/cross-chain-team @dfinity/idx
-/rs/tests/consensus/                                    @dfinity/consensus @dfinity/idx
-/rs/tests/cross_chain/                                  @dfinity/cross-chain-team @dfinity/idx
-/rs/tests/crypto/                                       @dfinity/crypto-team @dfinity/idx
-/rs/tests/dre/                                          @dfinity/dre @dfinity/idx
-/rs/tests/execution/                                    @dfinity/execution @dfinity/idx
-/rs/tests/financial_integrations/                       @dfinity/finint @dfinity/idx
-/rs/tests/message_routing/                              @dfinity/ic-message-routing-owners @dfinity/idx
-/rs/tests/networking/                                   @dfinity/networking @dfinity/idx
-/rs/tests/nns/                                          @dfinity/nns-team @dfinity/idx
-/rs/tests/node/                                         @dfinity/node @dfinity/idx
-/rs/tests/query_stats/                                  @dfinity/execution @dfinity/consensus @dfinity/idx
-/rs/tests/sdk/                                          @dfinity/sdk @dfinity/idx
-/rs/tests/src/ledger_tests/                             @dfinity/finint  @dfinity/idx
-/rs/tests/src/nns_tests/                                @dfinity/nns-team @dfinity/idx
-/rs/tests/src/rosetta_test.rs                           @dfinity/finint @dfinity/idx
-/rs/tests/src/rosetta_tests/                            @dfinity/finint @dfinity/idx
+/rs/tests/research                                      @dfinity/research
+/rs/tests/driver/src/driver/simulate_network.rs         @dfinity/networking @dfinity/idx
+/rs/tests/boundary_nodes/                               @dfinity/boundary-node
+/rs/tests/ckbtc/                                        @dfinity/cross-chain-team
+/rs/tests/consensus/                                    @dfinity/consensus
+/rs/tests/cross_chain/                                  @dfinity/cross-chain-team
+/rs/tests/crypto/                                       @dfinity/crypto-team
+/rs/tests/dre/                                          @dfinity/dre
+/rs/tests/execution/                                    @dfinity/execution
+/rs/tests/financial_integrations/                       @dfinity/finint
+/rs/tests/message_routing/                              @dfinity/ic-message-routing-owners
+/rs/tests/networking/                                   @dfinity/networking
+/rs/tests/nns/                                          @dfinity/nns-team
+/rs/tests/node/                                         @dfinity/node
+/rs/tests/query_stats/                                  @dfinity/execution @dfinity/consensus
+/rs/tests/sdk/                                          @dfinity/sdk
+/rs/tests/src/ledger_tests/                             @dfinity/finint
+/rs/tests/src/rosetta_test.rs                           @dfinity/finint
+/rs/tests/src/rosetta_tests/                            @dfinity/finint
 /rs/tests/k8s/                                          @dfinity/idx @dfinity/node
 /rs/tla_instrumentation/                                @dfinity/research @dfinity/formal-models
 /rs/tools/                                              @dfinity/ic-interface-owners


### PR DESCRIPTION
IDX used to co-own system-tests such that we could quickly make sweeping changes to all system-tests. However, system-tests have really stabilised and no longer receive sweeping changes frequently anymore. So to reduce code-review notifications for the IDX team, component teams will solely own their system-tests.