### PR TITLE
test(IDX): do not capture logs in //rs/nervous_system/integration_tests:... tests

### DIFF
--- a/rs/nervous_system/integration_tests/BUILD.bazel
+++ b/rs/nervous_system/integration_tests/BUILD.bazel
@@ -197,7 +197,7 @@ rust_test(
     aliases = ALIASES,
     crate_root = "tests/upgrade_everything_test.rs",
     data = DEV_DATA,
-    env = DEV_ENV,
+    env = DEV_ENV | {"RUST_TEST_NOCAPTURE": "1"},
     flaky = True,
     proc_macro_deps = MACRO_DEPENDENCIES + MACRO_DEV_DEPENDENCIES,
     tags = [
@@ -213,7 +213,7 @@ rust_test(
     ],
     aliases = ALIASES,
     data = DEV_DATA,
-    env = DEV_ENV,
+    env = DEV_ENV | {"RUST_TEST_NOCAPTURE": "1"},
     flaky = True,
     proc_macro_deps = MACRO_DEPENDENCIES + MACRO_DEV_DEPENDENCIES,
     tags = [
@@ -229,7 +229,7 @@ rust_test(
     ],
     aliases = ALIASES,
     data = DEV_DATA,
-    env = DEV_ENV,
+    env = DEV_ENV | {"RUST_TEST_NOCAPTURE": "1"},
     flaky = True,
     proc_macro_deps = MACRO_DEPENDENCIES + MACRO_DEV_DEPENDENCIES,
     tags = [


### PR DESCRIPTION
We got our first flakes for these tests ([example](https://dash.zh1-idx1.dfinity.network/invocation/af13b004-7600-4a70-bd98-3f4265e75bb4)) but because the rust test driver captures logs we can't see where they flaked.

So this commit disables capturing of logs for the `//rs/nervous_system/integration_tests:...` tests.