### PR TITLE
test(IDX): tag tecdsa_key_rotation_test as a long_test

### DIFF
--- a/rs/tests/consensus/tecdsa/BUILD.bazel
+++ b/rs/tests/consensus/tecdsa/BUILD.bazel
@@ -116,6 +116,7 @@ system_test_nns(
     proc_macro_deps = MACRO_DEPENDENCIES,
     tags = [
         "k8s",
+        "long_test",  # since it takes longer than 5 minutes.
     ],
     target_compatible_with = ["@platforms//os:linux"],  # requires libssh that does not build on Mac OS
     runtime_deps = GUESTOS_RUNTIME_DEPS,


### PR DESCRIPTION
The P90 duration of `//rs/tests/consensus/tecdsa:tecdsa_key_rotation_test` is [5m 13s](https://superset.idx.dfinity.network/explore/?form_data_key=L-xruYuVU55b2GcEj-nkSn9Hi7_DgNzUqhqScHYiuV4rSfyPaw_ak0pkH5hnlDHw&dashboard_page_id=_HteHI2SXP&slice_id=48) which is longer than our maximum allowed 5 minutes.

This tests uses the setup function: `setup_without_ecdsa_on_nns()` which can take quite some time to finish. All the other system-tests, that use this setup function, have already been tagged as `long_test` such that they no longer run on PRs but just on pushes to master.

This commit does the same for `//rs/tests/consensus/tecdsa:tecdsa_key_rotation_test`.

Unfortunately, I don't see an easy way to optimise the setup. It just appears that creating 12 nodes takes quite some time. Especially when they're allocated overseas in se1 or ch1. Although I have seen slow runs in fr1 as well.

Once, we migrate to k8s-based system-tests all tests will run colocated in the same cluster as where the artifacts have been built. Let's reavaulate the P90 of this test then.