### PR TITLE
fix(ckbtc): fix bitcoin checker cycle cost calculation

### DIFF
--- a/rs/bitcoin/checker/btc_checker_canister.did
+++ b/rs/bitcoin/checker/btc_checker_canister.did
@@ -55,6 +55,7 @@ type InitArg = record {
 
 type UpgradeArg = record {
     check_mode: opt CheckMode;
+    num_subnet_nodes: opt nat16;
 };
 
 type CheckArg = variant {

--- a/rs/bitcoin/checker/src/dashboard/tests.rs
+++ b/rs/bitcoin/checker/src/dashboard/tests.rs
@@ -15,9 +15,13 @@ fn mock_txid(v: usize) -> Txid {
     Txid::from(bytes)
 }
 
+const TEST_SUBNET_NODES: u16 = 13;
+
 #[test]
 fn should_display_metadata() {
-    let config = Config::new_and_validate(BtcNetwork::Mainnet, CheckMode::Normal).unwrap();
+    let config =
+        Config::new_and_validate(BtcNetwork::Mainnet, CheckMode::Normal, TEST_SUBNET_NODES)
+            .unwrap();
     let outcall_capacity = 50;
     let cached_entries = 0;
     let oldest_entry_time = 0;
@@ -35,7 +39,7 @@ fn should_display_metadata() {
 
     DashboardAssert::assert_that(dashboard)
         .has_btc_network_in_title(config.btc_network())
-        .has_check_mode(config.check_mode())
+        .has_check_mode(config.check_mode)
         .has_outcall_capacity(outcall_capacity)
         .has_cached_entries(cached_entries)
         .has_oldest_entry_time(oldest_entry_time)
@@ -75,7 +79,8 @@ fn should_display_statuses() {
     });
 
     let dashboard = DashboardTemplate {
-        config: Config::new_and_validate(BtcNetwork::Mainnet, CheckMode::Normal).unwrap(),
+        config: Config::new_and_validate(BtcNetwork::Mainnet, CheckMode::Normal, TEST_SUBNET_NODES)
+            .unwrap(),
         outcall_capacity: 50,
         cached_entries: 6,
         tx_table_page_size: 10,
@@ -116,7 +121,8 @@ fn test_pagination() {
     use scraper::{Html, Selector};
 
     state::set_config(
-        state::Config::new_and_validate(BtcNetwork::Mainnet, CheckMode::Normal).unwrap(),
+        state::Config::new_and_validate(BtcNetwork::Mainnet, CheckMode::Normal, TEST_SUBNET_NODES)
+            .unwrap(),
     );
     let mock_transaction = TransactionCheckData::from_transaction(
         &BtcNetwork::Mainnet,

--- a/rs/bitcoin/checker/src/fetch.rs
+++ b/rs/bitcoin/checker/src/fetch.rs
@@ -94,7 +94,8 @@ pub trait FetchEnv {
             Ok(guard) => guard,
             Err(_) => return TryFetchResult::HighLoad,
         };
-        let cycle_cost = get_tx_cycle_cost(max_response_bytes);
+        let num_subnet_nodes = self.config().num_subnet_nodes;
+        let cycle_cost = get_tx_cycle_cost(max_response_bytes, num_subnet_nodes);
         if self.cycles_accept(cycle_cost) < cycle_cost {
             TryFetchResult::NotEnoughCycles
         } else {

--- a/rs/bitcoin/checker/src/lib.rs
+++ b/rs/bitcoin/checker/src/lib.rs
@@ -26,9 +26,11 @@ pub const INITIAL_MAX_RESPONSE_BYTES: u32 = 4 * 1024;
 /// Retry max response bytes is 400kB
 pub const RETRY_MAX_RESPONSE_BYTES: u32 = 400 * 1024;
 
-pub fn get_tx_cycle_cost(max_response_bytes: u32) -> u128 {
+pub fn get_tx_cycle_cost(max_response_bytes: u32, num_subnet_nodes: u16) -> u128 {
+    let n = num_subnet_nodes as u128;
+    let m = max_response_bytes as u128;
     // 1 KiB for request, max_response_bytes for response
-    49_140_000 + 1024 * 5_200 + 10_400 * (max_response_bytes as u128)
+    (3_000_000 + 60_000 * n) * n + 400 * n * 1024 + 800 * n * m
 }
 
 pub fn blocklist_contains(address: &Address) -> bool {

--- a/rs/bitcoin/checker/src/main.rs
+++ b/rs/bitcoin/checker/src/main.rs
@@ -57,7 +57,7 @@ fn check_address(args: CheckAddressArgs) -> CheckAddressResponse {
         });
 
     STATS.with(|s| s.borrow_mut().check_transaction_count += 1);
-    match config.check_mode() {
+    match config.check_mode {
         CheckMode::AcceptAll => CheckAddressResponse::Passed,
         CheckMode::RejectAll => CheckAddressResponse::Failed,
         CheckMode::Normal => {
@@ -119,10 +119,15 @@ fn transform(raw: TransformArgs) -> HttpResponse {
 
 #[ic_cdk::init]
 fn init(arg: CheckArg) {
+    const DEFAULT_NUM_SUBNET_NODES: u16 = 13;
     match arg {
         CheckArg::InitArg(init_arg) => set_config(
-            Config::new_and_validate(init_arg.btc_network, init_arg.check_mode)
-                .unwrap_or_else(|err| ic_cdk::trap(&format!("error creating config: {}", err))),
+            Config::new_and_validate(
+                init_arg.btc_network,
+                init_arg.check_mode,
+                DEFAULT_NUM_SUBNET_NODES,
+            )
+            .unwrap_or_else(|err| ic_cdk::trap(&format!("error creating config: {}", err))),
         ),
         CheckArg::UpgradeArg(_) => {
             ic_cdk::trap("cannot init canister state without init args");
@@ -134,11 +139,19 @@ fn init(arg: CheckArg) {
 fn post_upgrade(arg: CheckArg) {
     match arg {
         CheckArg::UpgradeArg(arg) => {
-            if let Some(check_mode) = arg.and_then(|arg| arg.check_mode) {
-                let config = Config::new_and_validate(get_config().btc_network(), check_mode)
+            let old_config = get_config();
+            let num_subnet_nodes = arg
+                .as_ref()
+                .and_then(|arg| arg.num_subnet_nodes)
+                .unwrap_or(old_config.num_subnet_nodes);
+            let check_mode = arg
+                .as_ref()
+                .and_then(|arg| arg.check_mode)
+                .unwrap_or(old_config.check_mode);
+            let config =
+                Config::new_and_validate(get_config().btc_network(), check_mode, num_subnet_nodes)
                     .unwrap_or_else(|err| ic_cdk::trap(&format!("error creating config: {}", err)));
-                set_config(config);
-            }
+            set_config(config);
         }
         CheckArg::InitArg(_) => ic_cdk::trap("cannot upgrade canister state without upgrade args"),
     }
@@ -335,7 +348,8 @@ impl FetchEnv for BtcCheckerCanisterEnv {
                 message: err,
             })?;
         let url = request.url.clone();
-        let cycles = get_tx_cycle_cost(max_response_bytes);
+        let num_subnet_nodes = self.config().num_subnet_nodes;
+        let cycles = get_tx_cycle_cost(max_response_bytes, num_subnet_nodes);
         match http_request(request.clone(), cycles).await {
             Ok((response,)) => {
                 STATS.with(|s| {
@@ -426,7 +440,7 @@ impl FetchEnv for BtcCheckerCanisterEnv {
 ///    in order to compute their corresponding addresses.
 pub async fn check_transaction_inputs(txid: Txid) -> CheckTransactionResponse {
     let env = &BtcCheckerCanisterEnv;
-    match env.config().check_mode() {
+    match env.config().check_mode {
         CheckMode::AcceptAll => CheckTransactionResponse::Passed,
         CheckMode::RejectAll => CheckTransactionResponse::Failed(Vec::new()),
         CheckMode::Normal => {

--- a/rs/bitcoin/checker/src/state.rs
+++ b/rs/bitcoin/checker/src/state.rs
@@ -281,13 +281,15 @@ impl Drop for FetchGuard {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Config {
     btc_network: BtcNetwork,
-    check_mode: CheckMode,
+    pub check_mode: CheckMode,
+    pub num_subnet_nodes: u16,
 }
 
 impl Config {
     pub fn new_and_validate(
         btc_network: BtcNetwork,
         check_mode: CheckMode,
+        num_subnet_nodes: u16,
     ) -> Result<Self, String> {
         if let BtcNetwork::Regtest { json_rpc_url } = &btc_network {
             let _ = parse_authorization_header_from_url(json_rpc_url)?;
@@ -295,15 +297,12 @@ impl Config {
         Ok(Self {
             btc_network,
             check_mode,
+            num_subnet_nodes,
         })
     }
 
     pub fn btc_network(&self) -> BtcNetwork {
         self.btc_network.clone()
-    }
-
-    pub fn check_mode(&self) -> CheckMode {
-        self.check_mode
     }
 }
 

--- a/rs/bitcoin/checker/src/types.rs
+++ b/rs/bitcoin/checker/src/types.rs
@@ -132,9 +132,10 @@ impl fmt::Display for BtcNetwork {
     }
 }
 
-#[derive(CandidType, Debug, Deserialize, Serialize)]
+#[derive(CandidType, Debug, Default, Deserialize, Serialize)]
 pub struct UpgradeArg {
     pub check_mode: Option<CheckMode>,
+    pub num_subnet_nodes: Option<u16>,
 }
 
 #[derive(CandidType, Debug, Deserialize, Serialize)]

--- a/rs/bitcoin/checker/templates/dashboard.html
+++ b/rs/bitcoin/checker/templates/dashboard.html
@@ -134,7 +134,7 @@
                 <tbody>
                     <tr id="check-mode">
                         <th>Check Mode</th>
-                        <td><code>{{ config.check_mode() }}</code></td>
+                        <td><code>{{ config.check_mode }}</code></td>
                     </tr>
                     <tr id="outcall-capacity">
                         <th>Outcall Capacity</th>

--- a/rs/bitcoin/checker/tests/tests.rs
+++ b/rs/bitcoin/checker/tests/tests.rs
@@ -22,6 +22,8 @@ use std::str::FromStr;
 
 const MAX_TICKS: usize = 10;
 
+const TEST_SUBNET_NODES: u16 = 13;
+
 // Because we use universal_canister to make calls with attached cycles to
 // `check_transaction`, the actual_cost would be greater than expected_cost
 // by a small margin. Namely, the universal_canister itself would consume
@@ -119,6 +121,12 @@ fn decode<'a, T: CandidType + Deserialize<'a>>(result: &'a WasmResult) -> T {
 }
 
 #[test]
+fn test_get_tx_cycle_cost() {
+    assert_eq!(get_tx_cycle_cost(INITIAL_MAX_RESPONSE_BYTES, 13), 97_063_200); 
+    assert_eq!(get_tx_cycle_cost(INITIAL_MAX_RESPONSE_BYTES, 34), 296_697_600); 
+}
+
+#[test]
 fn test_check_address() {
     let blocklist_len = blocklist::BTC_ADDRESS_BLOCKLIST.len();
     let blocked_address = blocklist::BTC_ADDRESS_BLOCKLIST[blocklist_len / 2].to_string();
@@ -188,6 +196,7 @@ fn test_check_address() {
         btc_checker_wasm(),
         Encode!(&CheckArg::UpgradeArg(Some(UpgradeArg {
             check_mode: Some(CheckMode::AcceptAll),
+            ..UpgradeArg::default()
         })))
         .unwrap(),
         Some(controller),
@@ -231,6 +240,7 @@ fn test_check_address() {
         btc_checker_wasm(),
         Encode!(&CheckArg::UpgradeArg(Some(UpgradeArg {
             check_mode: Some(CheckMode::RejectAll),
+            ..UpgradeArg::default()
         })))
         .unwrap(),
         Some(controller),
@@ -352,7 +362,7 @@ fn test_check_transaction_passed() {
 
         let cycles_after = env.cycle_balance(setup.caller);
         let expected_cost = CHECK_TRANSACTION_CYCLES_SERVICE_FEE
-            + 2 * get_tx_cycle_cost(INITIAL_MAX_RESPONSE_BYTES);
+            + 2 * get_tx_cycle_cost(INITIAL_MAX_RESPONSE_BYTES, TEST_SUBNET_NODES);
         let actual_cost = cycles_before - cycles_after;
         assert!(actual_cost > expected_cost);
         assert!(actual_cost - expected_cost < UNIVERSAL_CANISTER_CYCLE_MARGIN);
@@ -368,6 +378,7 @@ fn test_check_transaction_passed() {
         btc_checker_wasm(),
         Encode!(&CheckArg::UpgradeArg(Some(UpgradeArg {
             check_mode: Some(CheckMode::RejectAll),
+            ..UpgradeArg::default()
         })))
         .unwrap(),
         Some(setup.controller),
@@ -405,6 +416,7 @@ fn test_check_transaction_passed() {
         btc_checker_wasm(),
         Encode!(&CheckArg::UpgradeArg(Some(UpgradeArg {
             check_mode: Some(CheckMode::AcceptAll),
+            ..UpgradeArg::default()
         })))
         .unwrap(),
         Some(setup.controller),
@@ -445,6 +457,7 @@ fn test_check_transaction_passed() {
         btc_checker_wasm(),
         Encode!(&CheckArg::UpgradeArg(Some(UpgradeArg {
             check_mode: Some(CheckMode::Normal),
+            ..UpgradeArg::default()
         })))
         .unwrap(),
         Some(setup.controller),
@@ -521,8 +534,8 @@ fn test_check_transaction_error() {
         )) if msg.contains("received code 500")
     ));
     let cycles_after = setup.env.cycle_balance(setup.caller);
-    let expected_cost =
-        CHECK_TRANSACTION_CYCLES_SERVICE_FEE + get_tx_cycle_cost(INITIAL_MAX_RESPONSE_BYTES);
+    let expected_cost = CHECK_TRANSACTION_CYCLES_SERVICE_FEE
+        + get_tx_cycle_cost(INITIAL_MAX_RESPONSE_BYTES, TEST_SUBNET_NODES);
     let actual_cost = cycles_before - cycles_after;
     assert!(actual_cost > expected_cost);
     assert!(actual_cost - expected_cost < UNIVERSAL_CANISTER_CYCLE_MARGIN);
@@ -561,8 +574,8 @@ fn test_check_transaction_error() {
         )) if msg.contains("received code 404")
     ));
     let cycles_after = setup.env.cycle_balance(setup.caller);
-    let expected_cost =
-        CHECK_TRANSACTION_CYCLES_SERVICE_FEE + get_tx_cycle_cost(INITIAL_MAX_RESPONSE_BYTES);
+    let expected_cost = CHECK_TRANSACTION_CYCLES_SERVICE_FEE
+        + get_tx_cycle_cost(INITIAL_MAX_RESPONSE_BYTES, TEST_SUBNET_NODES);
     let actual_cost = cycles_before - cycles_after;
     assert!(actual_cost > expected_cost);
     assert!(actual_cost - expected_cost < UNIVERSAL_CANISTER_CYCLE_MARGIN);
@@ -601,8 +614,8 @@ fn test_check_transaction_error() {
         )) if msg.contains("TxEncoding")
     ));
     let cycles_after = setup.env.cycle_balance(setup.caller);
-    let expected_cost =
-        CHECK_TRANSACTION_CYCLES_SERVICE_FEE + get_tx_cycle_cost(INITIAL_MAX_RESPONSE_BYTES);
+    let expected_cost = CHECK_TRANSACTION_CYCLES_SERVICE_FEE
+        + get_tx_cycle_cost(INITIAL_MAX_RESPONSE_BYTES, TEST_SUBNET_NODES);
     let actual_cost = cycles_before - cycles_after;
     assert!(actual_cost > expected_cost);
     assert!(actual_cost - expected_cost < UNIVERSAL_CANISTER_CYCLE_MARGIN);


### PR DESCRIPTION
Fix the https outcall cycle cost calculation to consider the number of nodes in a subnet.
Also make `num_subnet_nodes` an upgrade option.