### PR TITLE
feat(ICP-Rosetta): FI-1603: implement refresh voting power endpoint

### DIFF
--- a/rs/rosetta-api/icp/client/src/lib.rs
+++ b/rs/rosetta-api/icp/client/src/lib.rs
@@ -559,6 +559,31 @@ impl RosettaClient {
         }])
     }
 
+    pub fn build_refresh_voting_power_operations(
+        signer_principal: Principal,
+        neuron_index: u64,
+    ) -> anyhow::Result<Vec<Operation>> {
+        Ok(vec![Operation {
+            operation_identifier: OperationIdentifier {
+                index: 0,
+                network_index: None,
+            },
+            related_operations: None,
+            type_: "REFRESH_VOTING_POWER".to_string(),
+            status: None,
+            account: Some(rosetta_core::identifiers::AccountIdentifier::from(
+                AccountIdentifier::new(PrincipalId(signer_principal), None),
+            )),
+            amount: None,
+            coin_change: None,
+            metadata: Some(
+                NeuronIdentifierMetadata { neuron_index }
+                    .try_into()
+                    .map_err(|e| anyhow::anyhow!("Failed to convert metadata: {:?}", e))?,
+            ),
+        }])
+    }
+
     pub async fn network_list(&self) -> anyhow::Result<NetworkListResponse> {
         self.call_endpoint("/network/list", &MetadataRequest { metadata: None })
             .await
@@ -1308,6 +1333,32 @@ impl RosettaClient {
             signer_keypair,
             network_identifier,
             list_neurons_operations,
+            None,
+            None,
+        )
+        .await
+    }
+
+    /// A neuron will lose its voting power over time when inactive
+    /// To refresh the voting power of a neuron, you can use this function
+    /// For reference see the proposal for peioric confirmation of following: https://dashboard.internetcomputer.org/proposal/132411
+    pub async fn refresh_voting_power<T>(
+        &self,
+        network_identifier: NetworkIdentifier,
+        signer_keypair: &T,
+        neuron_index: u64,
+    ) -> anyhow::Result<ConstructionSubmitResponse>
+    where
+        T: RosettaSupportedKeyPair,
+    {
+        let refresh_voting_power_operations = RosettaClient::build_refresh_voting_power_operations(
+            signer_keypair.generate_principal_id()?.0,
+            neuron_index,
+        )?;
+        self.make_submit_and_wait_for_transaction(
+            signer_keypair,
+            network_identifier,
+            refresh_voting_power_operations,
             None,
             None,
         )

--- a/rs/rosetta-api/icp/client/src/lib.rs
+++ b/rs/rosetta-api/icp/client/src/lib.rs
@@ -1341,7 +1341,7 @@ impl RosettaClient {
 
     /// A neuron will lose its voting power over time when inactive
     /// To refresh the voting power of a neuron, you can use this function
-    /// For reference see the proposal for peioric confirmation of following: https://dashboard.internetcomputer.org/proposal/132411
+    /// For reference see the proposal for periodic confirmation of following: https://dashboard.internetcomputer.org/proposal/132411
     pub async fn refresh_voting_power<T>(
         &self,
         network_identifier: NetworkIdentifier,

--- a/rs/rosetta-api/icp/src/convert.rs
+++ b/rs/rosetta-api/icp/src/convert.rs
@@ -292,6 +292,11 @@ pub fn operations_to_requests(
                 };
                 state.follow(account, pid, neuron_index, topic, followees)?;
             }
+            OperationType::RefreshVotingPower => {
+                let NeuronIdentifierMetadata { neuron_index } = o.metadata.clone().try_into()?;
+                validate_neuron_management_op()?;
+                state.refresh_voting_power(account, neuron_index)?;
+            }
         }
     }
 

--- a/rs/rosetta-api/icp/src/convert/state.rs
+++ b/rs/rosetta-api/icp/src/convert/state.rs
@@ -3,8 +3,8 @@ use crate::models::seconds::Seconds;
 use crate::request::Request;
 use crate::request_types::{
     AddHotKey, ChangeAutoStakeMaturity, Disburse, Follow, ListNeurons, MergeMaturity, NeuronInfo,
-    PublicKeyOrPrincipal, RegisterVote, RemoveHotKey, SetDissolveTimestamp, Spawn, Stake,
-    StakeMaturity, StartDissolve, StopDissolve,
+    PublicKeyOrPrincipal, RefreshVotingPower, RegisterVote, RemoveHotKey, SetDissolveTimestamp,
+    Spawn, Stake, StakeMaturity, StartDissolve, StopDissolve,
 };
 use ic_types::PrincipalId;
 use icp_ledger::{Operation, Tokens, DEFAULT_TRANSFER_FEE};
@@ -382,6 +382,20 @@ impl State {
             controller,
             neuron_index,
         }));
+        Ok(())
+    }
+
+    pub fn refresh_voting_power(
+        &mut self,
+        account: icp_ledger::AccountIdentifier,
+        neuron_index: u64,
+    ) -> Result<(), ApiError> {
+        self.flush()?;
+        self.actions
+            .push(Request::RefreshVotingPower(RefreshVotingPower {
+                account,
+                neuron_index,
+            }));
         Ok(())
     }
 }

--- a/rs/rosetta-api/icp/src/ledger_client.rs
+++ b/rs/rosetta-api/icp/src/ledger_client.rs
@@ -5,6 +5,7 @@ mod handle_follow;
 mod handle_list_neurons;
 mod handle_merge_maturity;
 mod handle_neuron_info;
+mod handle_refresh_voting_power;
 mod handle_register_vote;
 mod handle_remove_hotkey;
 mod handle_send;
@@ -62,6 +63,7 @@ use crate::{
         handle_change_auto_stake_maturity::handle_change_auto_stake_maturity,
         handle_disburse::handle_disburse, handle_follow::handle_follow,
         handle_merge_maturity::handle_merge_maturity, handle_neuron_info::handle_neuron_info,
+        handle_refresh_voting_power::handle_refresh_voting_power,
         handle_register_vote::handle_register_vote, handle_remove_hotkey::handle_remove_hotkey,
         handle_send::handle_send, handle_set_dissolve_timestamp::handle_set_dissolve_timestamp,
         handle_spawn::handle_spawn, handle_stake::handle_stake,
@@ -852,6 +854,7 @@ impl LedgerClient {
             RequestType::Stake { .. } => handle_stake(bytes),
             RequestType::StartDissolve { .. } => handle_start_dissolve(bytes, request_type),
             RequestType::StopDissolve { .. } => handle_stop_dissolve(bytes, request_type),
+            RequestType::RefreshVotingPower { .. } => handle_refresh_voting_power(bytes),
         }
     }
 }

--- a/rs/rosetta-api/icp/src/ledger_client/handle_refresh_voting_power.rs
+++ b/rs/rosetta-api/icp/src/ledger_client/handle_refresh_voting_power.rs
@@ -1,0 +1,20 @@
+use crate::{errors::ApiError, ledger_client::OperationOutput};
+use ic_nns_governance_api::pb::v1::{
+    manage_neuron_response::{Command, RefreshVotingPowerResponse},
+    ManageNeuronResponse,
+};
+
+pub fn handle_refresh_voting_power(
+    bytes: Vec<u8>,
+) -> Result<Result<Option<OperationOutput>, ApiError>, String> {
+    let response: ManageNeuronResponse = candid::decode_one(bytes.as_ref())
+        .map_err(|err| format!("Could not decode REFRESH_VOTING_POWER response: {}", err))?;
+    match &response.command {
+        Some(Command::RefreshVotingPower(RefreshVotingPowerResponse { .. })) => Ok(Ok(None)),
+        Some(Command::Error(err)) => Ok(Err(ApiError::TransactionRejected(
+            false,
+            format!("Could not register vote: {}", err).into(),
+        ))),
+        _ => panic!("Unexpected register vote result: {:?}", response.command),
+    }
+}

--- a/rs/rosetta-api/icp/src/models/operation.rs
+++ b/rs/rosetta-api/icp/src/models/operation.rs
@@ -25,4 +25,5 @@ pub enum OperationType {
     NeuronInfo,
     ListNeurons,
     Follow,
+    RefreshVotingPower,
 }

--- a/rs/rosetta-api/icp/src/request.rs
+++ b/rs/rosetta-api/icp/src/request.rs
@@ -215,6 +215,7 @@ impl Request {
                 | Request::StakeMaturity(_)
                 | Request::ListNeurons(_) // not neuron management but we need it signed.
                 | Request::NeuronInfo(_) // not neuron management but we need it signed.
+                | Request::RefreshVotingPower(_)
                 | Request::Follow(_)
         )
     }

--- a/rs/rosetta-api/icp/src/request.rs
+++ b/rs/rosetta-api/icp/src/request.rs
@@ -59,6 +59,8 @@ pub enum Request {
     ListNeurons(ListNeurons),
     #[serde(rename = "FOLLOW")]
     Follow(Follow),
+    #[serde(rename = "REFRESH_VOTING_POWER")]
+    RefreshVotingPower(RefreshVotingPower),
 }
 
 impl Request {
@@ -151,6 +153,11 @@ impl Request {
                 neuron_index: *neuron_index,
                 controller: controller.map(PublicKeyOrPrincipal::Principal),
             }),
+            Request::RefreshVotingPower(RefreshVotingPower { neuron_index, .. }) => {
+                Ok(RequestType::RefreshVotingPower {
+                    neuron_index: *neuron_index,
+                })
+            }
         }
     }
 
@@ -181,6 +188,7 @@ impl Request {
                 Request::NeuronInfo(o) => builder.neuron_info(o),
                 Request::ListNeurons(o) => builder.list_neurons(o),
                 Request::Follow(o) => builder.follow(o),
+                Request::RefreshVotingPower(o) => builder.refresh_voting_power(o),
             }?;
         }
         Ok(builder.build())
@@ -500,6 +508,20 @@ impl TryFrom<&models::Request> for Request {
                     }
                 } else {
                     Err(ApiError::invalid_request("Invalid follow request."))
+                }
+            }
+            RequestType::RefreshVotingPower { neuron_index } => {
+                if let Some(Command::RefreshVotingPower(manage_neuron::RefreshVotingPower {})) =
+                    manage_neuron()?
+                {
+                    Ok(Request::RefreshVotingPower(RefreshVotingPower {
+                        neuron_index: *neuron_index,
+                        account,
+                    }))
+                } else {
+                    Err(ApiError::invalid_request(
+                        "Invalid refresh voting power request.",
+                    ))
                 }
             }
         }

--- a/rs/rosetta-api/icp/src/request_handler/construction_preprocess.rs
+++ b/rs/rosetta-api/icp/src/request_handler/construction_preprocess.rs
@@ -8,8 +8,8 @@ use crate::request::Request;
 use crate::request_handler::{verify_network_id, RosettaRequestHandler};
 use crate::request_types::{
     AddHotKey, ChangeAutoStakeMaturity, Disburse, Follow, ListNeurons, MergeMaturity, NeuronInfo,
-    RegisterVote, RemoveHotKey, SetDissolveTimestamp, Spawn, Stake, StakeMaturity, StartDissolve,
-    StopDissolve,
+    RefreshVotingPower, RegisterVote, RemoveHotKey, SetDissolveTimestamp, Spawn, Stake,
+    StakeMaturity, StartDissolve, StopDissolve,
 };
 use icp_ledger::Operation;
 use std::collections::HashSet;
@@ -80,6 +80,7 @@ fn required_public_key(request: Request) -> Result<icp_ledger::AccountIdentifier
         | Request::StakeMaturity(StakeMaturity { account, .. })
         | Request::NeuronInfo(NeuronInfo { account, .. })
         | Request::ListNeurons(ListNeurons { account, .. })
-        | Request::Follow(Follow { account, .. }) => Ok(account),
+        | Request::Follow(Follow { account, .. })
+        | Request::RefreshVotingPower(RefreshVotingPower { account, .. }) => Ok(account),
     }
 }

--- a/rs/rosetta-api/icp/src/transaction_id.rs
+++ b/rs/rosetta-api/icp/src/transaction_id.rs
@@ -66,6 +66,7 @@ impl TransactionIdentifier {
             | RequestType::StakeMaturity { .. }
             | RequestType::NeuronInfo { .. }
             | RequestType::ListNeurons { .. }
+            | RequestType::RefreshVotingPower { .. }
             | RequestType::Follow { .. } => {
                 // Unfortunately, staking operations don't really have a transaction ID
                 Ok(TransactionIdentifier::from(

--- a/rs/rosetta-api/icp/test_utils/src/lib.rs
+++ b/rs/rosetta-api/icp/test_utils/src/lib.rs
@@ -19,8 +19,8 @@ use ic_rosetta_api::request::transaction_results::TransactionResults;
 use ic_rosetta_api::request::Request;
 use ic_rosetta_api::request_types::{
     AddHotKey, ChangeAutoStakeMaturity, Disburse, Follow, ListNeurons, MergeMaturity, NeuronInfo,
-    RegisterVote, RemoveHotKey, SetDissolveTimestamp, Spawn, Stake, StakeMaturity, StartDissolve,
-    StopDissolve,
+    RefreshVotingPower, RegisterVote, RemoveHotKey, SetDissolveTimestamp, Spawn, Stake,
+    StakeMaturity, StartDissolve, StopDissolve,
 };
 use ic_rosetta_api::transaction_id::TransactionIdentifier;
 use ic_rosetta_api::{convert, errors, errors::ApiError, DEFAULT_TOKEN_SYMBOL};
@@ -133,6 +133,7 @@ where
             | Request::StakeMaturity(StakeMaturity { account, .. })
             | Request::NeuronInfo(NeuronInfo { account, .. })
             | Request::ListNeurons(ListNeurons { account, .. })
+            | Request::RefreshVotingPower(RefreshVotingPower { account, .. })
             | Request::Follow(Follow { account, .. }) => {
                 all_sender_account_ids.push(to_model_account_identifier(&account));
             }

--- a/rs/rosetta-api/icp/tests/system_tests/test_cases/neuron_management.rs
+++ b/rs/rosetta-api/icp/tests/system_tests/test_cases/neuron_management.rs
@@ -1369,3 +1369,61 @@ fn test_list_neurons() {
         );
     });
 }
+
+#[test]
+fn test_refresh_voting_power() {
+    let rt = Runtime::new().unwrap();
+    rt.block_on(async {
+        let env = RosettaTestingEnvironment::builder()
+            .with_initial_balances(
+                vec![(
+                    AccountIdentifier::from(TEST_IDENTITY.sender().unwrap()),
+                    // A hundred million ICP should be enough
+                    icp_ledger::Tokens::from_tokens(100_000_000).unwrap(),
+                )]
+                .into_iter()
+                .collect(),
+            )
+            .with_governance_canister()
+            .build()
+            .await;
+
+        // Stake the minimum amount 100 million e8s
+        let staked_amount = 100_000_000u64;
+        let neuron_index = 0;
+        let from_subaccount = [0; 32];
+
+        env.rosetta_client
+            .create_neuron(
+                env.network_identifier.clone(),
+                &(*TEST_IDENTITY).clone(),
+                RosettaCreateNeuronArgs::builder(staked_amount.into())
+                    .with_from_subaccount(from_subaccount)
+                    .with_neuron_index(neuron_index)
+                    .build(),
+            )
+            .await
+            .unwrap();
+
+        let agent = get_test_agent(env.pocket_ic.url().unwrap().port().unwrap()).await;
+        let neuron = list_neurons(&agent).await.full_neurons[0].to_owned();
+        let refresh_timestamp = neuron.voting_power_refreshed_timestamp_seconds.unwrap();
+        std::thread::sleep(std::time::Duration::from_secs(1));
+        TransactionOperationResults::try_from(
+            env.rosetta_client
+                .refresh_voting_power(
+                    env.network_identifier.clone(),
+                    &(*TEST_IDENTITY).clone(),
+                    neuron_index,
+                )
+                .await
+                .unwrap()
+                .metadata,
+        )
+        .unwrap();
+
+        let neuron = list_neurons(&agent).await.full_neurons[0].to_owned();
+        // The voting power should have been refreshed
+        assert!(neuron.voting_power_refreshed_timestamp_seconds.unwrap() > refresh_timestamp);
+    });
+}

--- a/rs/rosetta-api/icp/tests/system_tests/test_cases/neuron_management.rs
+++ b/rs/rosetta-api/icp/tests/system_tests/test_cases/neuron_management.rs
@@ -1408,6 +1408,8 @@ fn test_refresh_voting_power() {
         let agent = get_test_agent(env.pocket_ic.url().unwrap().port().unwrap()).await;
         let neuron = list_neurons(&agent).await.full_neurons[0].to_owned();
         let refresh_timestamp = neuron.voting_power_refreshed_timestamp_seconds.unwrap();
+
+        // Wait for a second before updating the voting power. This is done so the timestamp is sure to have a different value when refreshed
         std::thread::sleep(std::time::Duration::from_secs(1));
         TransactionOperationResults::try_from(
             env.rosetta_client

--- a/rs/tests/src/rosetta_tests/lib.rs
+++ b/rs/tests/src/rosetta_tests/lib.rs
@@ -32,8 +32,8 @@ use ic_rosetta_api::{
     },
     request_types::{
         AddHotKey, ChangeAutoStakeMaturity, Disburse, Follow, ListNeurons, MergeMaturity,
-        NeuronInfo, RegisterVote, RemoveHotKey, SetDissolveTimestamp, Spawn, Stake, StakeMaturity,
-        StartDissolve, StopDissolve,
+        NeuronInfo, RefreshVotingPower, RegisterVote, RemoveHotKey, SetDissolveTimestamp, Spawn,
+        Stake, StakeMaturity, StartDissolve, StopDissolve,
     },
     transaction_id::TransactionIdentifier,
     DEFAULT_TOKEN_SYMBOL,
@@ -378,6 +378,7 @@ where
             | Request::StakeMaturity(StakeMaturity { account, .. })
             | Request::NeuronInfo(NeuronInfo { account, .. })
             | Request::ListNeurons(ListNeurons { account, .. })
+            | Request::RefreshVotingPower(RefreshVotingPower { account, .. })
             | Request::Follow(Follow { account, .. }) => {
                 all_sender_account_ids.push(to_model_account_identifier(&account));
             }


### PR DESCRIPTION
This MR proposes the following changes:

1. Add the refresh voting power functionality to ICP Rosetta
2. Add the refresh voting power functionality to the ICP Rosetta Client

