### PR TITLE
chore: Add stream limits to hypervisor config

### DIFF
--- a/rs/config/src/execution_environment.rs
+++ b/rs/config/src/execution_environment.rs
@@ -52,6 +52,18 @@ const SUBNET_WASM_CUSTOM_SECTIONS_MEMORY_CAPACITY: NumBytes = NumBytes::new(2 * 
 /// The number of bytes reserved for response callback executions.
 const SUBNET_MEMORY_RESERVATION: NumBytes = NumBytes::new(10 * GIB);
 
+/// Maximum number of messages in a stream.
+///
+/// At most `MAX_STREAM_MESSAGES` are enqueued into a stream; but only until its
+/// `count_bytes()` is greater than or equal to `TARGET_STREAM_SIZE_BYTES`.
+pub const MAX_STREAM_MESSAGES: usize = 10_000;
+
+/// Desired byte size of an outgoing stream.
+///
+/// At most `MAX_STREAM_MESSAGES` are enqueued into a stream; but only until its
+/// `count_bytes()` is greater than or equal to `TARGET_STREAM_SIZE_BYTES`.
+pub const TARGET_STREAM_SIZE_BYTES: NumBytes = NumBytes::new(10 * MIB);
+
 /// The soft limit on the subnet-wide number of callbacks.
 pub const SUBNET_CALLBACK_SOFT_LIMIT: usize = 1_000_000;
 
@@ -203,6 +215,12 @@ pub struct Config {
     /// The number of bytes reserved for response callback execution.
     pub subnet_memory_reservation: NumBytes,
 
+    /// Maximum number of messages in a stream.
+    pub max_stream_messages: usize,
+
+    /// Desired byte size of an outgoing stream.
+    pub target_stream_size_bytes: NumBytes,
+
     /// The maximum amount of memory that can be utilized by a single canister.
     pub max_canister_memory_size: NumBytes,
 
@@ -342,6 +360,8 @@ impl Default for Config {
             subnet_wasm_custom_sections_memory_capacity:
                 SUBNET_WASM_CUSTOM_SECTIONS_MEMORY_CAPACITY,
             subnet_memory_reservation: SUBNET_MEMORY_RESERVATION,
+            target_stream_size_bytes: TARGET_STREAM_SIZE_BYTES,
+            max_stream_messages: MAX_STREAM_MESSAGES,
             max_canister_memory_size: NumBytes::new(
                 MAX_STABLE_MEMORY_IN_BYTES + MAX_WASM_MEMORY_IN_BYTES,
             ),

--- a/rs/messaging/src/message_routing.rs
+++ b/rs/messaging/src/message_routing.rs
@@ -2,7 +2,9 @@ use crate::{
     routing, scheduling,
     state_machine::{StateMachine, StateMachineImpl},
 };
-use ic_config::execution_environment::{BitcoinConfig, Config as HypervisorConfig};
+use ic_config::execution_environment::{
+    BitcoinConfig, Config as HypervisorConfig, MAX_STREAM_MESSAGES, TARGET_STREAM_SIZE_BYTES,
+};
 use ic_cycles_account_manager::CyclesAccountManager;
 use ic_interfaces::{crypto::ErrorReproducibility, execution_environment::ChainKeySettings};
 use ic_interfaces::{
@@ -656,6 +658,8 @@ impl BatchProcessorImpl {
         ));
         let stream_builder = Box::new(routing::stream_builder::StreamBuilderImpl::new(
             subnet_id,
+            hypervisor_config.max_stream_messages,
+            hypervisor_config.target_stream_size_bytes.get() as usize,
             metrics_registry,
             &metrics,
             time_in_stream_metrics,
@@ -1508,6 +1512,8 @@ impl MessageRoutingImpl {
     ) -> Self {
         let stream_builder = Box::new(routing::stream_builder::StreamBuilderImpl::new(
             subnet_id,
+            MAX_STREAM_MESSAGES,
+            TARGET_STREAM_SIZE_BYTES.get() as usize,
             metrics_registry,
             &MessageRoutingMetrics::new(metrics_registry),
             Arc::new(Mutex::new(LatencyMetrics::new_time_in_stream(

--- a/rs/messaging/src/routing/stream_builder/tests.rs
+++ b/rs/messaging/src/routing/stream_builder/tests.rs
@@ -2,6 +2,7 @@ use crate::message_routing::MessageRoutingMetrics;
 
 use super::*;
 use ic_base_types::NumSeconds;
+use ic_config::execution_environment::{MAX_STREAM_MESSAGES, TARGET_STREAM_SIZE_BYTES};
 use ic_error_types::RejectCode;
 use ic_management_canister_types::Method;
 use ic_registry_routing_table::{CanisterIdRange, RoutingTable};
@@ -333,10 +334,13 @@ fn build_streams_local_canisters() {
     });
 }
 
-#[test]
-fn build_streams_impl_at_limit_leaves_state_untouched() {
+fn build_streams_impl_at_limit_leaves_state_untouched_impl(
+    max_stream_messages: usize,
+    target_stream_size_bytes: usize,
+) {
     with_test_replica_logger(|log| {
-        let (stream_builder, mut provided_state, metrics_registry) = new_fixture(&log);
+        let (stream_builder, mut provided_state, metrics_registry) =
+            new_fixture_with_limits(&log, max_stream_messages, target_stream_size_bytes);
         provided_state.metadata.network_topology.routing_table = Arc::new(RoutingTable::try_from(
             btreemap! {
                 CanisterIdRange{ start: CanisterId::from(0), end: CanisterId::from(0xfff) } => REMOTE_SUBNET,
@@ -358,10 +362,7 @@ fn build_streams_impl_at_limit_leaves_state_untouched() {
         let expected_state = provided_state.clone();
 
         // Act.
-        let result_state = stream_builder.build_streams_impl(provided_state.clone(), usize::MAX, 0);
-        assert_eq!(result_state, expected_state);
-
-        let result_state = stream_builder.build_streams_impl(provided_state, 0, usize::MAX);
+        let result_state = stream_builder.build_streams_impl(provided_state.clone());
         assert_eq!(result_state, expected_state);
 
         assert_eq!(
@@ -397,6 +398,22 @@ fn build_streams_impl_at_limit_leaves_state_untouched() {
     });
 }
 
+#[test]
+fn build_streams_impl_at_message_limit_leaves_state_untouched() {
+    build_streams_impl_at_limit_leaves_state_untouched_impl(
+        0,          // max_stream_messages
+        usize::MAX, // target_stream_size_bytes
+    );
+}
+
+#[test]
+fn build_streams_impl_at_bytes_limit_leaves_state_untouched() {
+    build_streams_impl_at_limit_leaves_state_untouched_impl(
+        usize::MAX, // max_stream_messages
+        0,          // target_stream_size_bytes
+    );
+}
+
 /// Helper for testing `build_streams_impl()` with various message or byte size
 /// limits.
 ///
@@ -411,13 +428,6 @@ fn build_streams_impl_respects_limits(
     expected_messages: u64,
 ) {
     with_test_replica_logger(|log| {
-        let (stream_builder, mut provided_state, metrics_registry) = new_fixture(&log);
-        provided_state.metadata.network_topology.routing_table = Arc::new(RoutingTable::try_from(
-            btreemap! {
-                CanisterIdRange{ start: CanisterId::from(0), end: CanisterId::from(0xfff) } => REMOTE_SUBNET,
-            },
-        ).unwrap());
-
         let msgs = generate_messages_for_test(/* senders = */ 2, /* receivers = */ 2);
         let msg_count = msgs.len();
         // All messages returned by `generate_messages_for_test` are of the same size
@@ -429,6 +439,21 @@ fn build_streams_impl_respects_limits(
             msg_count,
             expected_messages
         );
+
+        // Target stream size: stream struct plus `max_stream_messages_by_byte_size - 1`
+        // messages plus 1 byte. Since this is a target / soft limit, it should ensure
+        // that exactly `max_stream_messages_by_byte_size` messages (or
+        // `max_stream_messages_by_byte_size * msg_size` bytes) are routed.
+        let target_stream_size_bytes =
+            size_of::<Stream>() + (max_stream_messages_by_byte_size - 1) * msg_size as usize + 1;
+
+        let (stream_builder, mut provided_state, metrics_registry) =
+            new_fixture_with_limits(&log, max_stream_messages, target_stream_size_bytes);
+        provided_state.metadata.network_topology.routing_table = Arc::new(RoutingTable::try_from(
+            btreemap! {
+                CanisterIdRange{ start: CanisterId::from(0), end: CanisterId::from(0xfff) } => REMOTE_SUBNET,
+            },
+        ).unwrap());
 
         // Set up the provided_canister_states.
         let provided_canister_states = canister_states_with_outputs(msgs.clone());
@@ -457,19 +482,8 @@ fn build_streams_impl_respects_limits(
             streams.insert(REMOTE_SUBNET, expected_stream);
         });
 
-        // Target stream size: stream struct plus `max_stream_messages_by_byte_size - 1`
-        // messages plus 1 byte. Since this is a target / soft limit, it should ensure
-        // that exactly `max_stream_messages_by_byte_size` messages (or
-        // `max_stream_messages_by_byte_size * msg_size` bytes) are routed.
-        let target_stream_size_bytes =
-            size_of::<Stream>() + (max_stream_messages_by_byte_size - 1) * msg_size as usize + 1;
-
         // Act.
-        let result_state = stream_builder.build_streams_impl(
-            provided_state,
-            max_stream_messages,
-            target_stream_size_bytes,
-        );
+        let result_state = stream_builder.build_streams_impl(provided_state);
 
         assert_eq!(expected_state.canister_states, result_state.canister_states);
         assert_eq!(expected_state.metadata, result_state.metadata);
@@ -859,13 +873,19 @@ fn build_streams_with_oversized_payloads() {
 }
 
 /// Sets up the `StreamHandlerImpl`, `ReplicatedState` and `MetricsRegistry` to
-/// be used by a test.
-fn new_fixture(log: &ReplicaLogger) -> (StreamBuilderImpl, ReplicatedState, MetricsRegistry) {
+/// be used by a test including limits for streams.
+fn new_fixture_with_limits(
+    log: &ReplicaLogger,
+    max_stream_messages: usize,
+    target_stream_size_bytes: usize,
+) -> (StreamBuilderImpl, ReplicatedState, MetricsRegistry) {
     let mut state = ReplicatedState::new(LOCAL_SUBNET, SubnetType::Application);
     state.metadata.batch_time = Time::from_nanos_since_unix_epoch(5);
     let metrics_registry = MetricsRegistry::new();
     let stream_builder = StreamBuilderImpl::new(
         LOCAL_SUBNET,
+        max_stream_messages,
+        target_stream_size_bytes,
         &metrics_registry,
         &MessageRoutingMetrics::new(&metrics_registry),
         Arc::new(Mutex::new(LatencyMetrics::new_time_in_stream(
@@ -875,6 +895,16 @@ fn new_fixture(log: &ReplicaLogger) -> (StreamBuilderImpl, ReplicatedState, Metr
     );
 
     (stream_builder, state, metrics_registry)
+}
+
+/// Sets up the `StreamHandlerImpl`, `ReplicatedState` and `MetricsRegistry` to
+/// be used by a test.
+fn new_fixture(log: &ReplicaLogger) -> (StreamBuilderImpl, ReplicatedState, MetricsRegistry) {
+    new_fixture_with_limits(
+        log,
+        MAX_STREAM_MESSAGES,
+        TARGET_STREAM_SIZE_BYTES.get() as usize,
+    )
 }
 
 /// Simulates routing the given requests into a `StreamIndexedQueue` with the


### PR DESCRIPTION
The purpose of this change is to make these limits configurable for tests, especially proptests and state machine tests where it matters quite a bit that we don't have to produce 10k messages just to probe the behavior at the limit.

It is also a first step towards removing [this duplication](https://sourcegraph.com/github.com/dfinity/ic@52032b71c610476a06226c283df5a025f24a5094/-/blob/rs/xnet/payload_builder/src/lib.rs?L229) of the `MAX_STREAM_MESSAGES` constant. In an effort to keep the changes at a minimum, this should be moved into its own PR. However, it is clear that the `HypervisorConfig` is available both [here](https://sourcegraph.com/github.com/dfinity/ic@52032b71c610476a06226c283df5a025f24a5094/-/blob/rs/replica/src/setup_ic_stack.rs?L248), where the `PayloadBuilder` is initialized for the IC itself, and also [here](https://sourcegraph.com/github.com/dfinity/ic@52032b71c610476a06226c283df5a025f24a5094/-/blob/rs/state_machine_tests/src/lib.rs?L493) (and then [here](https://sourcegraph.com/github.com/dfinity/ic@52032b71c610476a06226c283df5a025f24a5094/-/blob/rs/state_machine_tests/src/lib.rs?L1229)) for state machine tests. For proptests most likely the changed constructor for `StreamBuilder` can be used directly (or the `PayloadBuilderImpl` on the next step).