### PR TITLE
feat(nns): Periodic confirmation metrics.

### DIFF
--- a/rs/nns/governance/api/src/ic_nns_governance.pb.v1.rs
+++ b/rs/nns/governance/api/src/ic_nns_governance.pb.v1.rs
@@ -3058,27 +3058,46 @@ pub mod governance {
             /// example, count = count_buckets.values().sum().
             #[prost(uint64, optional, tag = "1")]
             pub count: Option<u64>,
+
             #[prost(uint64, optional, tag = "2")]
             pub total_staked_e8s: Option<u64>,
             #[prost(uint64, optional, tag = "3")]
             pub total_staked_maturity_e8s_equivalent: Option<u64>,
             #[prost(uint64, optional, tag = "4")]
             pub total_maturity_e8s_equivalent: Option<u64>,
+
+            /// Deprecated. Use one of the following instead.
             #[prost(uint64, optional, tag = "5")]
             pub total_voting_power: Option<u64>,
+            /// Used to decide proposals. If all neurons refresh their voting
+            /// power/following frequently enough, this will be equal to potential
+            /// voting power. If not, this will be less.
+            #[prost(uint64, optional, tag = "11")]
+            pub total_deciding_voting_power: ::core::option::Option<u64>,
+            /// Used for voting rewards.
+            #[prost(uint64, optional, tag = "12")]
+            pub total_potential_voting_power: ::core::option::Option<u64>,
+
             /// These fields are keyed by floor(dissolve delay / 0.5 years). These are
             /// analogous to the (singular) fields above. Here, the usual definition of
             /// year for the IC is used: exactly 365.25 days.
             #[prost(map = "uint64, uint64", tag = "6")]
             pub count_buckets: ::std::collections::HashMap<u64, u64>,
+
             #[prost(map = "uint64, uint64", tag = "7")]
             pub staked_e8s_buckets: ::std::collections::HashMap<u64, u64>,
             #[prost(map = "uint64, uint64", tag = "8")]
             pub staked_maturity_e8s_equivalent_buckets: ::std::collections::HashMap<u64, u64>,
             #[prost(map = "uint64, uint64", tag = "9")]
             pub maturity_e8s_equivalent_buckets: ::std::collections::HashMap<u64, u64>,
+
+            /// Deprecated. Use one of the following instead.
             #[prost(map = "uint64, uint64", tag = "10")]
             pub voting_power_buckets: ::std::collections::HashMap<u64, u64>,
+            #[prost(map = "uint64, uint64", tag = "13")]
+            pub deciding_voting_power_buckets: ::std::collections::HashMap<u64, u64>,
+            #[prost(map = "uint64, uint64", tag = "14")]
+            pub potential_voting_power_buckets: ::std::collections::HashMap<u64, u64>,
         }
     }
     /// Records that making an OpenSnsTokenSwap (OSTS) or CreateServiceNervousSystem (CSNS)

--- a/rs/nns/governance/canister/governance.did
+++ b/rs/nns/governance/canister/governance.did
@@ -767,16 +767,25 @@ type NeuronStakeTransfer = record {
 };
 
 type NeuronSubsetMetrics = record {
-  total_maturity_e8s_equivalent : opt nat64;
-  maturity_e8s_equivalent_buckets : vec record { nat64; nat64 };
-  voting_power_buckets : vec record { nat64; nat64 };
-  total_staked_e8s : opt nat64;
   count : opt nat64;
+
+  total_staked_e8s : opt nat64;
+  total_maturity_e8s_equivalent : opt nat64;
   total_staked_maturity_e8s_equivalent : opt nat64;
-  staked_maturity_e8s_equivalent_buckets : vec record { nat64; nat64 };
-  staked_e8s_buckets : vec record { nat64; nat64 };
+
   total_voting_power : opt nat64;
+  total_deciding_voting_power : opt nat64;
+  total_potential_voting_power : opt nat64;
+
   count_buckets : vec record { nat64; nat64 };
+
+  staked_e8s_buckets : vec record { nat64; nat64 };
+  maturity_e8s_equivalent_buckets : vec record { nat64; nat64 };
+  staked_maturity_e8s_equivalent_buckets : vec record { nat64; nat64 };
+
+  voting_power_buckets : vec record { nat64; nat64 };
+  deciding_voting_power_buckets : vec record { nat64; nat64 };
+  potential_voting_power_buckets : vec record { nat64; nat64 };
 };
 
 type NeuronsFundAuditInfo = record {

--- a/rs/nns/governance/canister/governance_test.did
+++ b/rs/nns/governance/canister/governance_test.did
@@ -693,16 +693,25 @@ type NeuronStakeTransfer = record {
 };
 
 type NeuronSubsetMetrics = record {
-  total_maturity_e8s_equivalent : opt nat64;
-  maturity_e8s_equivalent_buckets : vec record { nat64; nat64 };
-  voting_power_buckets : vec record { nat64; nat64 };
-  total_staked_e8s : opt nat64;
   count : opt nat64;
+
+  total_staked_e8s : opt nat64;
+  total_maturity_e8s_equivalent : opt nat64;
   total_staked_maturity_e8s_equivalent : opt nat64;
-  staked_maturity_e8s_equivalent_buckets : vec record { nat64; nat64 };
-  staked_e8s_buckets : vec record { nat64; nat64 };
+
   total_voting_power : opt nat64;
+  total_deciding_voting_power : opt nat64;
+  total_potential_voting_power : opt nat64;
+
   count_buckets : vec record { nat64; nat64 };
+
+  staked_e8s_buckets : vec record { nat64; nat64 };
+  maturity_e8s_equivalent_buckets : vec record { nat64; nat64 };
+  staked_maturity_e8s_equivalent_buckets : vec record { nat64; nat64 };
+
+  voting_power_buckets : vec record { nat64; nat64 };
+  deciding_voting_power_buckets : vec record { nat64; nat64 };
+  potential_voting_power_buckets : vec record { nat64; nat64 };
 };
 
 type NeuronsFundAuditInfo = record {

--- a/rs/nns/governance/proto/ic_nns_governance/pb/v1/governance.proto
+++ b/rs/nns/governance/proto/ic_nns_governance/pb/v1/governance.proto
@@ -2432,19 +2432,33 @@ message Governance {
       // analogous fields (declared a little lower in this message). For
       // example, count = count_buckets.values().sum().
       optional uint64 count = 1;
+
       optional uint64 total_staked_e8s = 2;
       optional uint64 total_staked_maturity_e8s_equivalent = 3;
       optional uint64 total_maturity_e8s_equivalent = 4;
+
+      // Deprecated. Use one of the following instead.
       optional uint64 total_voting_power = 5;
+      // Used to decide proposals. If all neurons refresh their voting
+      // power/following frequently enough, this will be equal to potential
+      // voting power. If not, this will be less.
+      optional uint64 total_deciding_voting_power = 11;
+      // Used for voting rewards.
+      optional uint64 total_potential_voting_power = 12;
 
       // These fields are keyed by floor(dissolve delay / 0.5 years). These are
       // analogous to the (singular) fields above. Here, the usual definition of
       // year for the IC is used: exactly 365.25 days.
       map<uint64, uint64> count_buckets = 6;
+
       map<uint64, uint64> staked_e8s_buckets = 7;
       map<uint64, uint64> staked_maturity_e8s_equivalent_buckets = 8;
       map<uint64, uint64> maturity_e8s_equivalent_buckets = 9;
+
+      // Deprecated. Use one of the following instead.
       map<uint64, uint64> voting_power_buckets = 10;
+      map<uint64, uint64> deciding_voting_power_buckets = 13;
+      map<uint64, uint64> potential_voting_power_buckets = 14;
     }
 
     NeuronSubsetMetrics non_self_authenticating_controller_neuron_subset_metrics = 38;

--- a/rs/nns/governance/src/gen/ic_nns_governance.pb.v1.rs
+++ b/rs/nns/governance/src/gen/ic_nns_governance.pb.v1.rs
@@ -3629,8 +3629,17 @@ pub mod governance {
             pub total_staked_maturity_e8s_equivalent: ::core::option::Option<u64>,
             #[prost(uint64, optional, tag = "4")]
             pub total_maturity_e8s_equivalent: ::core::option::Option<u64>,
+            /// Deprecated. Use one of the following instead.
             #[prost(uint64, optional, tag = "5")]
             pub total_voting_power: ::core::option::Option<u64>,
+            /// Used to decide proposals. If all neurons refresh their voting
+            /// power/following frequently enough, this will be equal to potential
+            /// voting power. If not, this will be less.
+            #[prost(uint64, optional, tag = "11")]
+            pub total_deciding_voting_power: ::core::option::Option<u64>,
+            /// Used for voting rewards.
+            #[prost(uint64, optional, tag = "12")]
+            pub total_potential_voting_power: ::core::option::Option<u64>,
             /// These fields are keyed by floor(dissolve delay / 0.5 years). These are
             /// analogous to the (singular) fields above. Here, the usual definition of
             /// year for the IC is used: exactly 365.25 days.
@@ -3642,8 +3651,13 @@ pub mod governance {
             pub staked_maturity_e8s_equivalent_buckets: ::std::collections::HashMap<u64, u64>,
             #[prost(map = "uint64, uint64", tag = "9")]
             pub maturity_e8s_equivalent_buckets: ::std::collections::HashMap<u64, u64>,
+            /// Deprecated. Use one of the following instead.
             #[prost(map = "uint64, uint64", tag = "10")]
             pub voting_power_buckets: ::std::collections::HashMap<u64, u64>,
+            #[prost(map = "uint64, uint64", tag = "13")]
+            pub deciding_voting_power_buckets: ::std::collections::HashMap<u64, u64>,
+            #[prost(map = "uint64, uint64", tag = "14")]
+            pub potential_voting_power_buckets: ::std::collections::HashMap<u64, u64>,
         }
     }
     /// Records that making an OpenSnsTokenSwap (OSTS) or CreateServiceNervousSystem (CSNS)

--- a/rs/nns/governance/src/lib.rs
+++ b/rs/nns/governance/src/lib.rs
@@ -215,6 +215,8 @@ thread_local! {
 }
 
 thread_local! {
+    // This gets set to the current time when it detects that a new cycle has
+    // begun. (This occurs in one of the prune_some_following functions.)
     static CURRENT_PRUNE_FOLLOWING_FULL_CYCLE_START_TIMESTAMP_SECONDS: Cell<u64> =
         const { Cell::new(0) };
 }

--- a/rs/nns/governance/src/lib.rs
+++ b/rs/nns/governance/src/lib.rs
@@ -566,7 +566,7 @@ pub fn encode_metrics(
 
     w.encode_gauge(
         "governance_voting_power_total",
-        total_deciding_voting_power,
+        total_potential_voting_power,
         "Deprecated. Use governance_deciding_voting_power_total instead.",
     )?;
     w.encode_gauge(

--- a/rs/nns/governance/src/lib.rs
+++ b/rs/nns/governance/src/lib.rs
@@ -415,7 +415,12 @@ fn encode_dissolve_delay_buckets<W, T>(
     }
 }
 
-/// Encodes
+/// Outputs many statistics about neurons, proposals, etc in Prometheus format
+/// (via the w output parameter).
+///
+/// Some of these statistics are useful to operators (these could be called
+/// health metrics). Others are of interest to the general public, and help
+/// promote transparency of the Internet Computer (especially its governance).
 pub fn encode_metrics(
     governance: &Governance,
     w: &mut ic_metrics_encoder::MetricsEncoder<Vec<u8>>,
@@ -432,6 +437,9 @@ pub fn encode_metrics(
         ic_nervous_system_common::total_memory_size_bytes() as f64,
         "Size of the total memory allocated by this canister measured in bytes.",
     )?;
+
+    // Background Work
+
     w.encode_gauge(
         "governance_latest_gc_timestamp_seconds",
         governance.latest_gc_timestamp_seconds as f64,

--- a/rs/nns/governance/src/lib.rs
+++ b/rs/nns/governance/src/lib.rs
@@ -214,6 +214,11 @@ thread_local! {
     static USE_STABLE_MEMORY_FOLLOWING_INDEX: Cell<bool> = const { Cell::new(cfg!(feature = "test")) };
 }
 
+thread_local! {
+    static CURRENT_PRUNE_FOLLOWING_FULL_CYCLE_START_TIMESTAMP_SECONDS: Cell<u64> =
+        const { Cell::new(0) };
+}
+
 pub fn is_voting_power_adjustment_enabled() -> bool {
     IS_VOTING_POWER_ADJUSTMENT_ENABLED.with(|ok| ok.get())
 }
@@ -444,6 +449,12 @@ pub fn encode_metrics(
         "governance_latest_gc_timestamp_seconds",
         governance.latest_gc_timestamp_seconds as f64,
         "Timestamp of the last proposal garbage collection event, in seconds since the Unix epoch.",
+    )?;
+    w.encode_gauge(
+        "governance_current_prune_following_full_cycle_start_timestamp_seconds",
+        CURRENT_PRUNE_FOLLOWING_FULL_CYCLE_START_TIMESTAMP_SECONDS
+            .with(|timestamp_seconds| timestamp_seconds.get()) as f64,
+        "When the current full cycle of follow pruning started.",
     )?;
 
     // Proposals (more detailed breakdowns later).

--- a/rs/nns/governance/src/neuron/types.rs
+++ b/rs/nns/governance/src/neuron/types.rs
@@ -1761,6 +1761,15 @@ impl NeuronBuilder {
         self
     }
 
+    #[cfg(test)] // To satisfy clippy. Feel free to use in production code.
+    pub fn with_voting_power_refreshed_timestamp_seconds(
+        mut self,
+        voting_power_refreshed_timestamp_seconds: u64,
+    ) -> Self {
+        self.voting_power_refreshed_timestamp_seconds = voting_power_refreshed_timestamp_seconds;
+        self
+    }
+
     pub fn build(self) -> Neuron {
         let NeuronBuilder {
             id,

--- a/rs/nns/governance/src/neuron_store.rs
+++ b/rs/nns/governance/src/neuron_store.rs
@@ -17,6 +17,7 @@ use crate::{
         with_stable_neuron_store_mut,
     },
     use_stable_memory_following_index, Clock, IcClock,
+    CURRENT_PRUNE_FOLLOWING_FULL_CYCLE_START_TIMESTAMP_SECONDS,
 };
 use dyn_clone::DynClone;
 use ic_base_types::PrincipalId;
@@ -1394,6 +1395,15 @@ pub fn prune_some_following(
     carry_on: impl FnMut() -> bool,
 ) -> Bound<NeuronId> {
     let now_seconds = neuron_store.now();
+
+    if next == Bound::Unbounded {
+        CURRENT_PRUNE_FOLLOWING_FULL_CYCLE_START_TIMESTAMP_SECONDS.with(
+            |start_timestamp_seconds| {
+                start_timestamp_seconds.set(now_seconds);
+            },
+        );
+    }
+
     groom_some_neurons(
         neuron_store,
         |neuron| {

--- a/rs/nns/governance/src/neuron_store/benches.rs
+++ b/rs/nns/governance/src/neuron_store/benches.rs
@@ -242,7 +242,9 @@ fn neuron_metrics_calculation_heap() -> BenchResult {
     let mut rng = new_rng();
     let neuron_store = set_up_neuron_store(&mut rng, 100, 0);
 
-    bench_fn(|| neuron_store.compute_neuron_metrics(now_seconds(), E8))
+    bench_fn(|| {
+        neuron_store.compute_neuron_metrics(E8, &VotingPowerEconomics::DEFAULT, now_seconds())
+    })
 }
 
 #[bench(raw)]
@@ -252,7 +254,9 @@ fn neuron_metrics_calculation_stable() -> BenchResult {
     let mut rng = new_rng();
     let neuron_store = set_up_neuron_store(&mut rng, 100, 0);
 
-    bench_fn(|| neuron_store.compute_neuron_metrics(now_seconds(), E8))
+    bench_fn(|| {
+        neuron_store.compute_neuron_metrics(E8, &VotingPowerEconomics::DEFAULT, now_seconds())
+    })
 }
 
 fn add_neuron_ready_to_spawn(

--- a/rs/nns/governance/src/neuron_store/metrics.rs
+++ b/rs/nns/governance/src/neuron_store/metrics.rs
@@ -145,8 +145,6 @@ impl NeuronSubsetMetrics {
             neuron.staked_maturity_e8s_equivalent.unwrap_or_default();
         let maturity_e8s_equivalent = neuron.maturity_e8s_equivalent;
 
-        // TODO: Also provide deciding voting power. Ideally, we'd rename the metrics to
-        // potential_voting_power, but that's probably not worth it.
         let potential_voting_power = neuron.potential_voting_power(now_seconds);
         let deciding_voting_power =
             neuron.deciding_voting_power(voting_power_economics, now_seconds);

--- a/rs/nns/governance/src/neuron_store/metrics.rs
+++ b/rs/nns/governance/src/neuron_store/metrics.rs
@@ -167,7 +167,7 @@ impl NeuronSubsetMetrics {
             maturity_e8s_equivalent,
         );
 
-        increment(&mut self.total_voting_power, deciding_voting_power);
+        increment(&mut self.total_voting_power, potential_voting_power);
         increment(&mut self.total_deciding_voting_power, deciding_voting_power);
         increment(
             &mut self.total_potential_voting_power,
@@ -195,7 +195,7 @@ impl NeuronSubsetMetrics {
             maturity_e8s_equivalent,
         );
 
-        increment(&mut self.voting_power_buckets, deciding_voting_power);
+        increment(&mut self.voting_power_buckets, potential_voting_power);
         increment(
             &mut self.deciding_voting_power_buckets,
             deciding_voting_power,

--- a/rs/nns/governance/src/neuron_store/metrics.rs
+++ b/rs/nns/governance/src/neuron_store/metrics.rs
@@ -1,7 +1,7 @@
 use super::NeuronStore;
 use crate::{
     neuron_store::Neuron,
-    pb::v1::{NeuronState, Visibility},
+    pb::v1::{NeuronState, Visibility, VotingPowerEconomics},
     storage::{neurons::NeuronSections, with_stable_neuron_store},
 };
 use ic_base_types::PrincipalId;
@@ -65,6 +65,7 @@ pub(crate) struct NeuronMetrics {
 impl NeuronMetrics {
     fn increment_non_self_authenticating_controller_neuron_subset_metrics(
         &mut self,
+        voting_power_economics: &VotingPowerEconomics,
         now_seconds: u64,
         neuron: &Neuron,
     ) {
@@ -80,17 +81,22 @@ impl NeuronMetrics {
         }
 
         self.non_self_authenticating_controller_neuron_subset_metrics
-            .increment(now_seconds, neuron);
+            .increment(voting_power_economics, now_seconds, neuron);
     }
 
-    fn increment_public_neuron_subset_metrics(&mut self, now_seconds: u64, neuron: &Neuron) {
+    fn increment_public_neuron_subset_metrics(
+        &mut self,
+        voting_power_economics: &VotingPowerEconomics,
+        now_seconds: u64,
+        neuron: &Neuron,
+    ) {
         let is_public = neuron.visibility() == Some(Visibility::Public);
         if !is_public {
             return;
         }
 
         self.public_neuron_subset_metrics
-            .increment(now_seconds, neuron);
+            .increment(voting_power_economics, now_seconds, neuron);
     }
 }
 
@@ -104,7 +110,9 @@ pub(crate) struct NeuronSubsetMetrics {
     pub total_maturity_e8s_equivalent: u64,
 
     // Voting power.
-    pub total_voting_power: u64,
+    pub total_voting_power: u64, // Deprecated. Use one of the following instead.
+    pub total_deciding_voting_power: u64, // Used to decide proposals.
+    pub total_potential_voting_power: u64, // Used for voting rewards.
 
     // Broken out by dissolve delay (rounded down to the nearest multiple of 0.5
     // years). For example, if the current dissolve delay of a neuron is 7
@@ -120,11 +128,18 @@ pub(crate) struct NeuronSubsetMetrics {
     pub maturity_e8s_equivalent_buckets: HashMap<u64, u64>,
 
     // Analogous to total_voting_power.
-    pub voting_power_buckets: HashMap<u64, u64>,
+    pub voting_power_buckets: HashMap<u64, u64>, // Deprecated. Use one of the following instead.
+    pub deciding_voting_power_buckets: HashMap<u64, u64>, // See earlier comments.
+    pub potential_voting_power_buckets: HashMap<u64, u64>, // See earlier comments.
 }
 
 impl NeuronSubsetMetrics {
-    fn increment(&mut self, now_seconds: u64, neuron: &Neuron) {
+    fn increment(
+        &mut self,
+        voting_power_economics: &VotingPowerEconomics,
+        now_seconds: u64,
+        neuron: &Neuron,
+    ) {
         let staked_e8s = neuron.minted_stake_e8s();
         let staked_maturity_e8s_equivalent =
             neuron.staked_maturity_e8s_equivalent.unwrap_or_default();
@@ -132,7 +147,9 @@ impl NeuronSubsetMetrics {
 
         // TODO: Also provide deciding voting power. Ideally, we'd rename the metrics to
         // potential_voting_power, but that's probably not worth it.
-        let voting_power = neuron.potential_voting_power(now_seconds);
+        let potential_voting_power = neuron.potential_voting_power(now_seconds);
+        let deciding_voting_power =
+            neuron.deciding_voting_power(voting_power_economics, now_seconds);
 
         let increment = |total: &mut u64, additional_amount| {
             *total = total.saturating_add(additional_amount);
@@ -150,7 +167,12 @@ impl NeuronSubsetMetrics {
             maturity_e8s_equivalent,
         );
 
-        increment(&mut self.total_voting_power, voting_power);
+        increment(&mut self.total_voting_power, deciding_voting_power);
+        increment(&mut self.total_deciding_voting_power, deciding_voting_power);
+        increment(
+            &mut self.total_potential_voting_power,
+            potential_voting_power,
+        );
 
         // Increment metrics broken out by dissolve delay.
         let dissolve_delay_bucket = neuron
@@ -173,7 +195,15 @@ impl NeuronSubsetMetrics {
             maturity_e8s_equivalent,
         );
 
-        increment(&mut self.voting_power_buckets, voting_power);
+        increment(&mut self.voting_power_buckets, deciding_voting_power);
+        increment(
+            &mut self.deciding_voting_power_buckets,
+            deciding_voting_power,
+        );
+        increment(
+            &mut self.potential_voting_power_buckets,
+            potential_voting_power,
+        );
     }
 }
 
@@ -181,8 +211,9 @@ impl NeuronStore {
     /// Computes neuron metrics.
     pub(crate) fn compute_neuron_metrics(
         &self,
+        neuron_minimum_stake_e8s: u64,
+        voting_power_economics: &VotingPowerEconomics,
         now_seconds: u64,
-        minimum_stake_e8s: u64,
     ) -> NeuronMetrics {
         let mut metrics = if self.use_stable_memory_for_all_neurons {
             NeuronMetrics {
@@ -202,11 +233,21 @@ impl NeuronStore {
         };
 
         if self.use_stable_memory_for_all_neurons {
-            self.compute_neuron_metrics_all_stable(&mut metrics, now_seconds, minimum_stake_e8s);
+            self.compute_neuron_metrics_all_stable(
+                &mut metrics,
+                neuron_minimum_stake_e8s,
+                voting_power_economics,
+                now_seconds,
+            );
         }
         // During migration, some neurons may be in the heap, so we need to compute
         // metrics for them as well.
-        self.compute_neuron_metrics_current(&mut metrics, now_seconds, minimum_stake_e8s);
+        self.compute_neuron_metrics_current(
+            &mut metrics,
+            neuron_minimum_stake_e8s,
+            voting_power_economics,
+            now_seconds,
+        );
 
         metrics
     }
@@ -214,8 +255,9 @@ impl NeuronStore {
     pub(crate) fn compute_neuron_metrics_all_stable(
         &self,
         metrics: &mut NeuronMetrics,
+        neuron_minimum_stake_e8s: u64,
+        voting_power_economics: &VotingPowerEconomics,
         now_seconds: u64,
-        minimum_stake_e8s: u64,
     ) {
         with_stable_neuron_store(|stable_neuron_store| {
             let neuron_sections = NeuronSections {
@@ -229,10 +271,15 @@ impl NeuronStore {
             for neuron in stable_neuron_store.range_neurons_sections(.., neuron_sections) {
                 let neuron = &neuron;
                 metrics.increment_non_self_authenticating_controller_neuron_subset_metrics(
+                    voting_power_economics,
                     now_seconds,
                     neuron,
                 );
-                metrics.increment_public_neuron_subset_metrics(now_seconds, neuron);
+                metrics.increment_public_neuron_subset_metrics(
+                    voting_power_economics,
+                    now_seconds,
+                    neuron,
+                );
 
                 metrics.total_staked_e8s += neuron.minted_stake_e8s();
                 metrics.total_staked_maturity_e8s_equivalent +=
@@ -254,7 +301,7 @@ impl NeuronStore {
                 }
 
                 if 0 < neuron.cached_neuron_stake_e8s
-                    && neuron.cached_neuron_stake_e8s < minimum_stake_e8s
+                    && neuron.cached_neuron_stake_e8s < neuron_minimum_stake_e8s
                 {
                     metrics.neurons_with_invalid_stake_count += 1;
                 }
@@ -388,15 +435,21 @@ impl NeuronStore {
     pub(crate) fn compute_neuron_metrics_current(
         &self,
         metrics: &mut NeuronMetrics,
+        neuron_minimum_stake_e8s: u64,
+        voting_power_economics: &VotingPowerEconomics,
         now_seconds: u64,
-        minimum_stake_e8s: u64,
     ) {
         for neuron in self.heap_neurons.values() {
             metrics.increment_non_self_authenticating_controller_neuron_subset_metrics(
+                voting_power_economics,
                 now_seconds,
                 neuron,
             );
-            metrics.increment_public_neuron_subset_metrics(now_seconds, neuron);
+            metrics.increment_public_neuron_subset_metrics(
+                voting_power_economics,
+                now_seconds,
+                neuron,
+            );
 
             metrics.total_staked_e8s += neuron.minted_stake_e8s();
             metrics.total_staked_maturity_e8s_equivalent +=
@@ -414,7 +467,7 @@ impl NeuronStore {
             }
 
             if 0 < neuron.cached_neuron_stake_e8s
-                && neuron.cached_neuron_stake_e8s < minimum_stake_e8s
+                && neuron.cached_neuron_stake_e8s < neuron_minimum_stake_e8s
             {
                 metrics.neurons_with_invalid_stake_count += 1;
             }

--- a/rs/nns/governance/src/neuron_store/metrics/tests.rs
+++ b/rs/nns/governance/src/neuron_store/metrics/tests.rs
@@ -227,7 +227,7 @@ fn test_compute_metrics() {
         )
         .unwrap();
 
-    let metrics = neuron_store.compute_neuron_metrics(now, 100_000_000);
+    let metrics = neuron_store.compute_neuron_metrics(E8, &VotingPowerEconomics::DEFAULT, now);
 
     let expected_metrics = NeuronMetrics {
         dissolving_neurons_count: 5,
@@ -345,12 +345,14 @@ fn test_compute_metrics_inactive_neuron_in_heap() {
         .unwrap();
 
     // Step 2: verify that 1 neuron (3) are inactive.
-    let actual_metrics = neuron_store.compute_neuron_metrics(now, 100_000_000);
+    let actual_metrics =
+        neuron_store.compute_neuron_metrics(E8, &VotingPowerEconomics::DEFAULT, now);
     assert_eq!(actual_metrics.garbage_collectable_neurons_count, 1);
 
     // Step 3: 2 days pass, and now neuron (2) is dissolved 15 days ago, and becomes inactive.
     let now = now + 2 * ONE_DAY_SECONDS;
-    let actual_metrics = neuron_store.compute_neuron_metrics(now, 100_000_000);
+    let actual_metrics =
+        neuron_store.compute_neuron_metrics(E8, &VotingPowerEconomics::DEFAULT, now);
     assert_eq!(actual_metrics.garbage_collectable_neurons_count, 2);
 }
 
@@ -482,7 +484,7 @@ fn test_compute_neuron_metrics_non_self_authenticating() {
     let NeuronMetrics {
         non_self_authenticating_controller_neuron_subset_metrics,
         ..
-    } = neuron_store.compute_neuron_metrics(now_seconds, E8);
+    } = neuron_store.compute_neuron_metrics(E8, &VotingPowerEconomics::DEFAULT, now_seconds);
 
     // Step 3: Inspect results.
     assert_eq!(
@@ -496,6 +498,8 @@ fn test_compute_neuron_metrics_non_self_authenticating() {
 
             // Voting power.
             total_voting_power: voting_power_1 + voting_power_3,
+            total_deciding_voting_power: voting_power_1 + voting_power_3,
+            total_potential_voting_power: voting_power_1 + voting_power_3,
 
             // Broken out by dissolve delay (rounded down to the nearest multiple of 6
             // months).
@@ -522,6 +526,14 @@ fn test_compute_neuron_metrics_non_self_authenticating() {
 
             // Analogous to total_voting_power.
             voting_power_buckets: hashmap! {
+                8  => voting_power_3,
+                16 => voting_power_1,
+            },
+            deciding_voting_power_buckets: hashmap! {
+                8  => voting_power_3,
+                16 => voting_power_1,
+            },
+            potential_voting_power_buckets: hashmap! {
                 8  => voting_power_3,
                 16 => voting_power_1,
             },
@@ -559,6 +571,7 @@ fn test_compute_neuron_metrics_public_neurons() {
     .with_staked_maturity_e8s_equivalent(101)
     .with_maturity_e8s_equivalent(110)
     .with_visibility(Some(Visibility::Public))
+    // DO NOT MERGE - Set refreshed_voting_power_timestamp_seconds
     .build();
 
     let neuron_2 = NeuronBuilder::new(
@@ -629,7 +642,7 @@ fn test_compute_neuron_metrics_public_neurons() {
     let NeuronMetrics {
         public_neuron_subset_metrics,
         ..
-    } = neuron_store.compute_neuron_metrics(now_seconds, E8);
+    } = neuron_store.compute_neuron_metrics(E8, &VotingPowerEconomics::DEFAULT, now_seconds);
 
     // Step 3: Inspect results.
     assert_eq!(
@@ -643,6 +656,8 @@ fn test_compute_neuron_metrics_public_neurons() {
 
             // Voting power.
             total_voting_power: voting_power_1 + voting_power_3,
+            total_deciding_voting_power: voting_power_1 + voting_power_3,
+            total_potential_voting_power: voting_power_1 + voting_power_3,
 
             // Broken out by dissolve delay (rounded down to the nearest multiple of 6
             // months).
@@ -669,6 +684,14 @@ fn test_compute_neuron_metrics_public_neurons() {
 
             // Analogous to total_voting_power.
             voting_power_buckets: hashmap! {
+                8  => voting_power_3,
+                16 => voting_power_1,
+            },
+            deciding_voting_power_buckets: hashmap! {
+                8  => voting_power_3,
+                16 => voting_power_1,
+            },
+            potential_voting_power_buckets: hashmap! {
                 8  => voting_power_3,
                 16 => voting_power_1,
             },

--- a/rs/nns/governance/src/neuron_store/metrics/tests.rs
+++ b/rs/nns/governance/src/neuron_store/metrics/tests.rs
@@ -571,7 +571,7 @@ fn test_compute_neuron_metrics_public_neurons() {
     .with_staked_maturity_e8s_equivalent(101)
     .with_maturity_e8s_equivalent(110)
     .with_visibility(Some(Visibility::Public))
-    // DO NOT MERGE - Set refreshed_voting_power_timestamp_seconds
+    .with_voting_power_refreshed_timestamp_seconds(now_seconds)
     .build();
 
     let neuron_2 = NeuronBuilder::new(
@@ -588,6 +588,7 @@ fn test_compute_neuron_metrics_public_neurons() {
     .with_cached_neuron_stake_e8s(200_000)
     .with_staked_maturity_e8s_equivalent(202_000)
     .with_maturity_e8s_equivalent(220_000)
+    .with_voting_power_refreshed_timestamp_seconds(now_seconds)
     .build();
 
     let neuron_3 = NeuronBuilder::new(
@@ -609,6 +610,7 @@ fn test_compute_neuron_metrics_public_neurons() {
         name: "Daniel Wong".to_string(),
         description: Some("Best engineer of all time. Of all time.".to_string()),
     }))
+    .with_voting_power_refreshed_timestamp_seconds(now_seconds)
     .build();
 
     let voting_power_1 = neuron_1.potential_voting_power(now_seconds);
@@ -626,6 +628,7 @@ fn test_compute_neuron_metrics_public_neurons() {
         2 => neuron_2,
         3 => neuron_3,
     });
+
     neuron_store
         .with_neuron(&NeuronId { id: 3 }, |neuron| {
             assert_eq!(

--- a/rs/nns/governance/src/pb/conversions.rs
+++ b/rs/nns/governance/src/pb/conversions.rs
@@ -3476,15 +3476,24 @@ impl From<pb::governance::governance_cached_metrics::NeuronSubsetMetrics>
     fn from(item: pb::governance::governance_cached_metrics::NeuronSubsetMetrics) -> Self {
         Self {
             count: item.count,
+
             total_staked_e8s: item.total_staked_e8s,
             total_staked_maturity_e8s_equivalent: item.total_staked_maturity_e8s_equivalent,
             total_maturity_e8s_equivalent: item.total_maturity_e8s_equivalent,
+
             total_voting_power: item.total_voting_power,
+            total_deciding_voting_power: item.total_deciding_voting_power,
+            total_potential_voting_power: item.total_potential_voting_power,
+
             count_buckets: item.count_buckets,
+
             staked_e8s_buckets: item.staked_e8s_buckets,
             staked_maturity_e8s_equivalent_buckets: item.staked_maturity_e8s_equivalent_buckets,
             maturity_e8s_equivalent_buckets: item.maturity_e8s_equivalent_buckets,
+
             voting_power_buckets: item.voting_power_buckets,
+            deciding_voting_power_buckets: item.deciding_voting_power_buckets,
+            potential_voting_power_buckets: item.potential_voting_power_buckets,
         }
     }
 }
@@ -3494,15 +3503,24 @@ impl From<pb_api::governance::governance_cached_metrics::NeuronSubsetMetrics>
     fn from(item: pb_api::governance::governance_cached_metrics::NeuronSubsetMetrics) -> Self {
         Self {
             count: item.count,
+
             total_staked_e8s: item.total_staked_e8s,
             total_staked_maturity_e8s_equivalent: item.total_staked_maturity_e8s_equivalent,
             total_maturity_e8s_equivalent: item.total_maturity_e8s_equivalent,
+
             total_voting_power: item.total_voting_power,
+            total_deciding_voting_power: item.total_deciding_voting_power,
+            total_potential_voting_power: item.total_potential_voting_power,
+
             count_buckets: item.count_buckets,
+
             staked_e8s_buckets: item.staked_e8s_buckets,
             staked_maturity_e8s_equivalent_buckets: item.staked_maturity_e8s_equivalent_buckets,
             maturity_e8s_equivalent_buckets: item.maturity_e8s_equivalent_buckets,
+
             voting_power_buckets: item.voting_power_buckets,
+            deciding_voting_power_buckets: item.deciding_voting_power_buckets,
+            potential_voting_power_buckets: item.potential_voting_power_buckets,
         }
     }
 }

--- a/rs/nns/governance/src/tests.rs
+++ b/rs/nns/governance/src/tests.rs
@@ -35,10 +35,14 @@ fn test_neuron_subset_metrics_pb_encode() {
     // Step 2: Call the code under test.
     let subject = NeuronSubsetMetricsPb {
         count: Some(42),
+
         total_staked_e8s: Some(43_000),
         total_staked_maturity_e8s_equivalent: Some(44_000_000),
         total_maturity_e8s_equivalent: Some(45_000_000_000),
+
         total_voting_power: Some(46_000_000_000_000),
+        total_deciding_voting_power: Some(46_000_000_000_000),
+        total_potential_voting_power: Some(47_000_000_000_000),
 
         count_buckets: hashmap! {
             3 => 3,
@@ -53,6 +57,14 @@ fn test_neuron_subset_metrics_pb_encode() {
             6 => 6_000,
         },
         voting_power_buckets: hashmap! {
+            7 =>  70_000,
+            8 => 800_000,
+        },
+        deciding_voting_power_buckets: hashmap! {
+            7 =>  70_000,
+            8 => 800_000,
+        },
+        potential_voting_power_buckets: hashmap! {
             7 =>  70_000,
             8 => 800_000,
         },

--- a/rs/nns/governance/src/tests.rs
+++ b/rs/nns/governance/src/tests.rs
@@ -41,12 +41,13 @@ fn test_neuron_subset_metrics_pb_encode() {
         total_maturity_e8s_equivalent: Some(45_000_000_000),
 
         total_voting_power: Some(46_000_000_000_000),
-        total_deciding_voting_power: Some(46_000_000_000_000),
-        total_potential_voting_power: Some(47_000_000_000_000),
+        total_deciding_voting_power: Some(47_000_000_000_000_000),
+        total_potential_voting_power: Some(717_568_738),
 
         count_buckets: hashmap! {
             3 => 3,
         },
+
         staked_e8s_buckets: hashmap! {
             4 => 40,
         },
@@ -56,17 +57,18 @@ fn test_neuron_subset_metrics_pb_encode() {
         maturity_e8s_equivalent_buckets: hashmap! {
             6 => 6_000,
         },
+
         voting_power_buckets: hashmap! {
             7 =>  70_000,
             8 => 800_000,
         },
         deciding_voting_power_buckets: hashmap! {
-            7 =>  70_000,
-            8 => 800_000,
+            9 => 9_000_000,
+            10 => 110_000_000,
         },
         potential_voting_power_buckets: hashmap! {
-            7 =>  70_000,
-            8 => 800_000,
+            11 => 12_000_000_000,
+            12 => 1_300_000_000_000,
         },
     };
     assert_is_ok!(subject.encode("smart", "has IQ > 120", &mut metrics_encoder));
@@ -81,6 +83,7 @@ fn test_neuron_subset_metrics_pb_encode() {
     let result = prometheus_parse::Scrape::parse(result).unwrap();
 
     assert_eq!(get_gauge(&result, "governance_smart_neurons_count"), 42.0);
+
     assert_eq!(
         get_gauge(&result, "governance_total_staked_e8s_smart"),
         43_000.0
@@ -96,9 +99,18 @@ fn test_neuron_subset_metrics_pb_encode() {
         get_gauge(&result, "governance_total_maturity_e8s_equivalent_smart"),
         45_000_000_000.0
     );
+
     assert_eq!(
         get_gauge(&result, "governance_total_voting_power_smart"),
         46_000_000_000_000.0
+    );
+    assert_eq!(
+        get_gauge(&result, "governance_total_deciding_voting_power_smart"),
+        47_000_000_000_000_000.0
+    );
+    assert_eq!(
+        get_gauge(&result, "governance_total_potential_voting_power_smart"),
+        717_568_738.0
     );
 
     assert_eq!(
@@ -123,6 +135,7 @@ fn test_neuron_subset_metrics_pb_encode() {
         ),
         hashmap! { "[36, 42)".to_string() => 6_000.0 },
     );
+
     assert_eq!(
         get_metric_broken_out_by_dissolve_delay(
             &result,
@@ -131,6 +144,26 @@ fn test_neuron_subset_metrics_pb_encode() {
         hashmap! {
             "[42, 48)".to_string() =>  70_000.0,
             "[48, 54)".to_string() => 800_000.0,
+        },
+    );
+    assert_eq!(
+        get_metric_broken_out_by_dissolve_delay(
+            &result,
+            "governance_smart_deciding_voting_power_buckets",
+        ),
+        hashmap! {
+            "[54, 60)".to_string() =>  9e6,
+            "[60, 66)".to_string() => 11e7,
+        },
+    );
+    assert_eq!(
+        get_metric_broken_out_by_dissolve_delay(
+            &result,
+            "governance_smart_potential_voting_power_buckets",
+        ),
+        hashmap! {
+            "[66, 72)".to_string() => 12e9,
+            "[72, 78)".to_string() => 13e11,
         },
     );
 }

--- a/rs/nns/governance/tests/governance.rs
+++ b/rs/nns/governance/tests/governance.rs
@@ -416,6 +416,12 @@ fn test_single_neuron_proposal_new() {
                                         total_voting_power: Some(
                                             1,
                                         ),
+                                        total_deciding_voting_power: Some(
+                                            1,
+                                        ),
+                                        total_potential_voting_power: Some(
+                                            1,
+                                        ),
                                         count_buckets: btreemap! {
                                             1 => 1,
                                         },
@@ -429,6 +435,12 @@ fn test_single_neuron_proposal_new() {
                                             1 => 0,
                                         },
                                         voting_power_buckets: btreemap! {
+                                            1 => 1,
+                                        },
+                                        deciding_voting_power_buckets: btreemap! {
+                                            1 => 1,
+                                        },
+                                        potential_voting_power_buckets: btreemap! {
                                             1 => 1,
                                         },
                                     },
@@ -455,11 +467,19 @@ fn test_single_neuron_proposal_new() {
                                         total_voting_power: Some(
                                             0,
                                         ),
+                                        total_deciding_voting_power: Some(
+                                            0,
+                                        ),
+                                        total_potential_voting_power: Some(
+                                            0,
+                                        ),
                                         count_buckets: btreemap! {},
                                         staked_e8s_buckets: btreemap! {},
                                         staked_maturity_e8s_equivalent_buckets: btreemap! {},
                                         maturity_e8s_equivalent_buckets: btreemap! {},
                                         voting_power_buckets: btreemap! {},
+                                        deciding_voting_power_buckets: btreemap! {},
+                                        potential_voting_power_buckets: btreemap! {},
                                     },
                                 ),
                             ),


### PR DESCRIPTION
Most of the changes here are for breaking out voting power into deciding vs. potential, and copying those around, because of duplicate types.

Another metric in this PR: When the current prune following cycle began.

# References

This is part of the "periodic confirmation" feature that was recently approved in proposal [132411][prop].

[prop]: https://dashboard.internetcomputer.org/proposal/132411

[Next PR 👉][next]

[next]: https://github.com/dfinity/ic/pull/3090