### PR TITLE
fix(node): update-config in testnet environment

### DIFF
--- a/rs/ic_os/config/src/update_config.rs
+++ b/rs/ic_os/config/src/update_config.rs
@@ -10,7 +10,7 @@ use macaddr::MacAddr6;
 
 use crate::config_ini::{get_config_ini_settings, ConfigIniSettings};
 use crate::deployment_json::get_deployment_settings;
-use crate::serialize_and_write_config;
+use crate::{deserialize_config, serialize_and_write_config};
 use config_types::*;
 use network::resolve_mgmt_mac;
 
@@ -25,6 +25,18 @@ pub fn update_guestos_config() -> Result<()> {
 
     let network_conf_path = config_dir.join("network.conf");
     let config_json_path = config_dir.join("config.json");
+
+    // If a config already exists and is Testnet, do not update.
+    if config_json_path.exists() {
+        if let Ok(existing_config) = deserialize_config::<GuestOSConfig, _>(&config_json_path) {
+            if existing_config.icos_settings.deployment_environment
+                == DeploymentEnvironment::Testnet
+            {
+                println!("A new GuestOSConfig already exists and the environment is Testnet. Skipping update.");
+                return Ok(());
+            }
+        }
+    }
 
     let old_config_exists = network_conf_path.exists();
 
@@ -243,6 +255,19 @@ pub fn update_hostos_config(
     deployment_json_path: &Path,
     hostos_config_json_path: &PathBuf,
 ) -> Result<()> {
+    // If a config already exists and is Testnet, do not update.
+    if hostos_config_json_path.exists() {
+        if let Ok(existing_config) = deserialize_config::<HostOSConfig, _>(&hostos_config_json_path)
+        {
+            if existing_config.icos_settings.deployment_environment
+                == DeploymentEnvironment::Testnet
+            {
+                println!("A new HostOSConfig already exists and the environment is Testnet. Skipping update.");
+                return Ok(());
+            }
+        }
+    }
+
     let old_config_exists = config_ini_path.exists();
 
     if old_config_exists {

--- a/rs/ic_os/config/src/update_config.rs
+++ b/rs/ic_os/config/src/update_config.rs
@@ -187,19 +187,14 @@ fn read_nns_conf(config_dir: &Path) -> Result<Vec<Url>> {
 }
 
 fn derive_mgmt_mac_from_hostname(hostname: Option<&str>) -> Result<MacAddr6> {
-    if let Some(hostname) = hostname {
-        if let Some(unformatted_mac) = hostname.strip_prefix("guest-") {
-            unformatted_mac
-                .parse()
-                .map_err(|_| anyhow!("Unable to parse mac address: {}", unformatted_mac))
-        } else {
-            Err(anyhow::anyhow!(
-                "Hostname does not start with 'guest-': {}",
-                hostname
-            ))
-        }
+    if let Some(unformatted_mac) = hostname.and_then(|h| h.strip_prefix("guest-")) {
+        unformatted_mac
+            .parse()
+            .map_err(|_| anyhow!("Unable to parse mac address: {}", unformatted_mac))
     } else {
-        Err(anyhow::anyhow!("Hostname is not specified"))
+        "00:00:00:00:00:00"
+            .parse()
+            .map_err(|_| anyhow!("Unable to parse dummy mac address"))
     }
 }
 
@@ -381,19 +376,10 @@ mod tests {
         let mac = derive_mgmt_mac_from_hostname(hostname)?;
         assert_eq!(mac, expected_mac);
 
-        // Test with invalid hostname (wrong prefix)
-        let invalid_hostname = Some("host-001122334455");
-        let result = derive_mgmt_mac_from_hostname(invalid_hostname);
-        assert!(result.is_err());
-
-        // Test with invalid hostname (wrong length)
-        let invalid_hostname_length = Some("guest-00112233");
-        let result = derive_mgmt_mac_from_hostname(invalid_hostname_length);
-        assert!(result.is_err());
-
-        // Test with None
-        let result = derive_mgmt_mac_from_hostname(None);
-        assert!(result.is_err());
+        // Test empty hostname
+        let expected_mac: MacAddr6 = "00:00:00:00:00:00".parse().unwrap();
+        let mac = derive_mgmt_mac_from_hostname(None)?;
+        assert_eq!(mac, expected_mac);
 
         Ok(())
     }

--- a/rs/ic_os/dev_test_tools/setupos-inject-configuration/src/main.rs
+++ b/rs/ic_os/dev_test_tools/setupos-inject-configuration/src/main.rs
@@ -80,6 +80,9 @@ struct DeploymentConfig {
 
     #[arg(long)]
     mgmt_mac: Option<String>,
+
+    #[arg(long)]
+    deployment_environment: Option<String>,
 }
 
 #[tokio::main]
@@ -254,6 +257,10 @@ async fn update_deployment(path: &Path, cfg: &DeploymentConfig) -> Result<(), Er
 
     if let Some(cpu) = &cfg.cpu {
         deployment_json.resources.cpu = Some(cpu.to_owned());
+    }
+
+    if let Some(deployment_environment) = &cfg.deployment_environment {
+        deployment_json.deployment.name = deployment_environment.to_owned();
     }
 
     let mut f = File::create(path).context("failed to open deployment config file")?;

--- a/rs/tests/driver/src/driver/bootstrap.rs
+++ b/rs/tests/driver/src/driver/bootstrap.rs
@@ -651,6 +651,8 @@ fn configure_setupos_image(
     let mut cmd = Command::new(setupos_inject_configs);
     cmd.arg("--image-path")
         .arg(&uncompressed_image)
+        .arg("--deployment-environment")
+        .arg("Testnet")
         .arg("--mgmt-mac")
         .arg(&mac)
         .arg("--ipv6-prefix")

--- a/rs/tests/driver/src/driver/nested.rs
+++ b/rs/tests/driver/src/driver/nested.rs
@@ -140,13 +140,13 @@ impl NestedVms for TestEnv {
 
         let host_mac = calculate_deterministic_mac(
             &seed_mac,
-            DeploymentEnvironment::Mainnet,
+            DeploymentEnvironment::Testnet,
             IpVariant::V6,
             NodeType::HostOS,
         );
         let guest_mac = calculate_deterministic_mac(
             &seed_mac,
-            DeploymentEnvironment::Mainnet,
+            DeploymentEnvironment::Testnet,
             IpVariant::V6,
             NodeType::GuestOS,
         );


### PR DESCRIPTION
- Add a check in update-config preventing a "new" testnet config from being overwritten. This check fixes errors in the [config revamp](https://github.com/dfinity/ic/pull/1563) caused by update-config erroneously overriding development config fields. This change will have no impact on mainnet: cf825d2c08bc7b26a6dc2a1b16ea7e646f053482

- Allowing an empty hostname field in GuestOS fixes update-config errors in the nested tests. 
Example: https://github.com/dfinity/ic/actions/runs/12244488249
The hostname field will always be populated on mainnet, so this will only impact testing: 764230f49edaef0f9149bfd6fe0da1d6789e6774

- Switching nested testing to run with a "testnet" deployment environment (54cde2eeed7c7616b887e18aae3bb1b4820e7db7, 23d8824c61fc4e3f79d377e290f029df59568eaf) fixes issues with deployment configs being overwritten.
