### PR TITLE
test(nns): Add recent_ballots_next_entry_index to NeuronBuilder and let it be So…

### DIFF
--- a/rs/nns/governance/src/neuron/types.rs
+++ b/rs/nns/governance/src/neuron/types.rs
@@ -1600,6 +1600,8 @@ pub struct NeuronBuilder {
     #[cfg(test)]
     recent_ballots: Vec<BallotInfo>,
     #[cfg(test)]
+    recent_ballots_next_entry_index: Option<usize>,
+    #[cfg(test)]
     transfer: Option<NeuronStakeTransfer>,
     #[cfg(test)]
     staked_maturity_e8s_equivalent: Option<u64>,
@@ -1639,6 +1641,8 @@ impl NeuronBuilder {
             neuron_fees_e8s: 0,
             #[cfg(test)]
             recent_ballots: Vec::new(),
+            #[cfg(test)]
+            recent_ballots_next_entry_index: Some(0),
             #[cfg(test)]
             transfer: None,
             #[cfg(test)]
@@ -1730,7 +1734,10 @@ impl NeuronBuilder {
 
     #[cfg(test)]
     pub fn with_recent_ballots(mut self, recent_ballots: Vec<BallotInfo>) -> Self {
+        let recent_ballots_next_entry_index =
+            Some(recent_ballots.len() % MAX_NEURON_RECENT_BALLOTS);
         self.recent_ballots = recent_ballots;
+        self.recent_ballots_next_entry_index = recent_ballots_next_entry_index;
         self
     }
 
@@ -1783,6 +1790,8 @@ impl NeuronBuilder {
             #[cfg(test)]
             recent_ballots,
             #[cfg(test)]
+            recent_ballots_next_entry_index,
+            #[cfg(test)]
             transfer,
             #[cfg(test)]
             staked_maturity_e8s_equivalent,
@@ -1804,6 +1813,8 @@ impl NeuronBuilder {
         #[cfg(not(test))]
         let recent_ballots = Vec::new();
         #[cfg(not(test))]
+        let recent_ballots_next_entry_index = Some(0);
+        #[cfg(not(test))]
         let transfer = None;
         #[cfg(not(test))]
         let staked_maturity_e8s_equivalent = None;
@@ -1822,6 +1833,7 @@ impl NeuronBuilder {
             spawn_at_timestamp_seconds,
             followees,
             recent_ballots,
+            recent_ballots_next_entry_index,
             kyc_verified,
             transfer,
             maturity_e8s_equivalent,
@@ -1833,7 +1845,6 @@ impl NeuronBuilder {
             neuron_type,
             visibility,
             voting_power_refreshed_timestamp_seconds,
-            recent_ballots_next_entry_index: None,
         }
     }
 }

--- a/rs/nns/governance/tests/governance.rs
+++ b/rs/nns/governance/tests/governance.rs
@@ -4546,6 +4546,7 @@ fn create_mature_neuron(dissolved: bool) -> (fake::FakeDriver, Governance, Neuro
             voting_power_refreshed_timestamp_seconds: Some(START_TIMESTAMP_SECONDS),
             deciding_voting_power: Some(expected_voting_power),
             potential_voting_power: Some(expected_voting_power),
+            recent_ballots_next_entry_index: Some(0),
             ..Default::default()
         }
     );


### PR DESCRIPTION
Going forward, `recent_ballots_next_entry_index` should always be `Some(..)` except for neurons not migrated yet. Therefore tests, except for those specifically designed for testing the migration, should use `Some(..)`.