### PR TITLE
fix(IDX): override mainnet_revisions.json

### DIFF
--- a/testnet/mainnet_revisions.json
+++ b/testnet/mainnet_revisions.json
@@ -1,6 +1,6 @@
 {
   "subnets": {
-    "tdb26-jop6k-aogll-7ltgs-eruif-6kk7m-qpktf-gdiqx-mxtrf-vb5e6-eqe": "2d8611eb4efa8e69c4dd567546c1c353a545e0a6",
+    "tdb26-jop6k-aogll-7ltgs-eruif-6kk7m-qpktf-gdiqx-mxtrf-vb5e6-eqe": "a88b490e10831ae42aea8d16c686fd46d9b1894f",
     "io67a-2jmkw-zup3h-snbwi-g6a5n-rm5dn-b6png-lvdpl-nqnto-yih6l-gqe": "d9fe2076f677a08734bed90c67b1c3f4056ed621"
   }
 }


### PR DESCRIPTION
The replica release `2d8611eb4efa8e69c4dd567546c1c353a545e0a6` was built with Ubuntu-24.04 which means that it expects a newer version of libc to be available in the environment where its binaries run. After deploying this release we had to downgrade to Ubuntu 20.04 again. This means that the binaries from the latest replica release don't work in our tests since the latest libc is not available there. This effects the `//rs/tests/consensus/backup:backup_manager_upgrade_test` for example. We therefor temporarily override the mainnet revision to the commit just before the Ubuntu 24.04 upgrade.