### PR TITLE
test(sns): Add more unit tests for the internal `CachedUpgradeSteps` type

### DIFF
--- a/rs/sns/governance/src/cached_upgrade_steps.rs
+++ b/rs/sns/governance/src/cached_upgrade_steps.rs
@@ -283,6 +283,9 @@ impl CachedUpgradeSteps {
         &self.current_version == version || self.subsequent_versions.contains(version)
     }
 
+    /// Returns whether `left` is strictly before `right` in `self.into_iter()` in the `Ok` result.
+    ///
+    /// Returns `Err` if at least one of the versions `left` and `right` are not in `self`.
     pub fn contains_in_order(&self, left: &Version, right: &Version) -> Result<bool, String> {
         if !self.contains(left) {
             return Err(format!("{:?} does not contain {:?}", self, left));

--- a/rs/sns/governance/src/cached_upgrade_steps.rs
+++ b/rs/sns/governance/src/cached_upgrade_steps.rs
@@ -283,9 +283,9 @@ impl CachedUpgradeSteps {
         &self.current_version == version || self.subsequent_versions.contains(version)
     }
 
-    /// Returns whether `left` is strictly before `right` in `self.into_iter()` in the `Ok` result.
+    /// Returns whether `left` is before or equal to `right` in `self`, in the `Ok` result.
     ///
-    /// Returns `Err` if at least one of the versions `left` and `right` are not in `self`.
+    /// Returns `Err` if at least one of the versions `left` or `right` are not in `self`.
     pub fn contains_in_order(&self, left: &Version, right: &Version) -> Result<bool, String> {
         if !self.contains(left) {
             return Err(format!("{:?} does not contain {:?}", self, left));
@@ -364,6 +364,8 @@ impl CachedUpgradeSteps {
         self.response_timestamp_seconds
     }
 
+    /// Returns `Ok` if `new_target` is in `self` but different from `self.current()`.
+    /// Otherwise, returns `Err`.
     pub fn validate_new_target_version(&self, new_target: &Version) -> Result<(), String> {
         if !self.contains(new_target) {
             return Err("new_target_version must be among the upgrade steps.".to_string());

--- a/rs/sns/governance/src/cached_upgrade_steps/tests.rs
+++ b/rs/sns/governance/src/cached_upgrade_steps/tests.rs
@@ -197,3 +197,161 @@ fn cached_upgrade_steps_without_pending_upgrades() {
         vec![v]
     );
 }
+
+#[test]
+fn cached_upgrade_steps_with_pending_upgrades() {
+    let v0 = Version {
+        root_wasm_hash: vec![0, 0, 0],
+        governance_wasm_hash: vec![0, 0, 0],
+        ledger_wasm_hash: vec![0, 0, 0],
+        swap_wasm_hash: vec![0, 0, 0],
+        archive_wasm_hash: vec![0, 0, 0],
+        index_wasm_hash: vec![0, 0, 0],
+    };
+
+    let v1 = {
+        let mut v = v0.clone();
+        v.root_wasm_hash = vec![1, 1, 1];
+        v
+    };
+
+    let v2 = {
+        let mut v = v0.clone();
+        v.root_wasm_hash = vec![2, 2, 2];
+        v
+    };
+
+    let v3 = {
+        let mut v = v0.clone();
+        v.root_wasm_hash = vec![3, 3, 3];
+        v
+    };
+
+    let cached_upgrade_steps = CachedUpgradeSteps {
+        current_version: v0.clone(),
+        subsequent_versions: vec![v1.clone(), v2.clone()],
+        response_timestamp_seconds: 0,
+        requested_timestamp_seconds: 0,
+    };
+
+    // .last
+    assert_eq!(cached_upgrade_steps.last(), &v2);
+
+    // .contains
+    assert!(cached_upgrade_steps.contains(&v0));
+    assert!(cached_upgrade_steps.contains(&v1));
+    assert!(cached_upgrade_steps.contains(&v2));
+    assert!(!cached_upgrade_steps.contains(&v3));
+
+    // .current, .is_current
+    assert_eq!(cached_upgrade_steps.current(), &v0);
+    assert!(cached_upgrade_steps.is_current(&v0));
+    assert!(!cached_upgrade_steps.is_current(&v1));
+    assert!(!cached_upgrade_steps.is_current(&v2));
+    assert!(!cached_upgrade_steps.is_current(&v3));
+
+    // .next, .has_pending_upgrades
+    assert_eq!(cached_upgrade_steps.next(), Some(&v1));
+    assert!(cached_upgrade_steps.has_pending_upgrades());
+
+    // .contains_in_order
+    let expected_err = Err(format!(
+        "{:?} does not contain {:?}",
+        cached_upgrade_steps, v3
+    ));
+    assert_eq!(cached_upgrade_steps.contains_in_order(&v0, &v0), Ok(true));
+    assert_eq!(cached_upgrade_steps.contains_in_order(&v0, &v1), Ok(true));
+    assert_eq!(cached_upgrade_steps.contains_in_order(&v0, &v2), Ok(true));
+    assert_eq!(
+        cached_upgrade_steps.contains_in_order(&v0, &v3),
+        expected_err
+    );
+
+    assert_eq!(cached_upgrade_steps.contains_in_order(&v1, &v0), Ok(false));
+    assert_eq!(cached_upgrade_steps.contains_in_order(&v1, &v1), Ok(true));
+    assert_eq!(cached_upgrade_steps.contains_in_order(&v1, &v2), Ok(true));
+    assert_eq!(
+        cached_upgrade_steps.contains_in_order(&v1, &v3),
+        expected_err
+    );
+
+    assert_eq!(cached_upgrade_steps.contains_in_order(&v2, &v0), Ok(false));
+    assert_eq!(cached_upgrade_steps.contains_in_order(&v2, &v1), Ok(false));
+    assert_eq!(cached_upgrade_steps.contains_in_order(&v2, &v2), Ok(true));
+    assert_eq!(
+        cached_upgrade_steps.contains_in_order(&v2, &v3),
+        expected_err
+    );
+
+    assert_eq!(
+        cached_upgrade_steps.contains_in_order(&v3, &v0),
+        expected_err
+    );
+    assert_eq!(
+        cached_upgrade_steps.contains_in_order(&v3, &v1),
+        expected_err
+    );
+    assert_eq!(
+        cached_upgrade_steps.contains_in_order(&v3, &v2),
+        expected_err
+    );
+    assert_eq!(
+        cached_upgrade_steps.contains_in_order(&v3, &v3),
+        expected_err
+    );
+
+    // .validate_new_target_version
+    assert_eq!(
+        cached_upgrade_steps.validate_new_target_version(&v0),
+        Err("new_target_version must differ from the current version.".to_string())
+    );
+    assert_eq!(
+        cached_upgrade_steps.validate_new_target_version(&v1),
+        Ok(())
+    );
+    assert_eq!(
+        cached_upgrade_steps.validate_new_target_version(&v2),
+        Ok(())
+    );
+    assert_eq!(
+        cached_upgrade_steps.validate_new_target_version(&v3),
+        Err("new_target_version must be among the upgrade steps.".to_string())
+    );
+
+    // .take_from
+    assert_eq!(
+        cached_upgrade_steps.clone().take_from(&v0),
+        Ok(cached_upgrade_steps.clone())
+    );
+    assert_eq!(
+        cached_upgrade_steps.clone().take_from(&v1),
+        Ok(CachedUpgradeSteps {
+            current_version: v1.clone(),
+            subsequent_versions: vec![v2.clone()],
+            response_timestamp_seconds: 0,
+            requested_timestamp_seconds: 0,
+        })
+    );
+    assert_eq!(
+        cached_upgrade_steps.clone().take_from(&v2),
+        Ok(CachedUpgradeSteps {
+            current_version: v2.clone(),
+            subsequent_versions: vec![],
+            response_timestamp_seconds: 0,
+            requested_timestamp_seconds: 0,
+        })
+    );
+    assert_eq!(
+        cached_upgrade_steps.clone().take_from(&v3),
+        Err(format!(
+            "Cannot take_from {} that is not one of the cached upgrade steps.",
+            v3
+        ))
+    );
+
+    // .into_iter
+    assert_eq!(
+        cached_upgrade_steps.into_iter().collect::<Vec<_>>(),
+        vec![v0, v1, v2]
+    );
+}


### PR DESCRIPTION
This PR adds more unit tests to cover the methods of `CachedUpgradeSteps` for more complex instances.