### PR TITLE
fix(BOUN-1255): ratelimiter: separate update/query fetchers

### DIFF
--- a/rs/boundary_node/ic_boundary/src/core.rs
+++ b/rs/boundary_node/ic_boundary/src/core.rs
@@ -287,10 +287,11 @@ pub async fn main(cli: Cli) -> Result<(), Error> {
         Some(Arc::new(generic::Limiter::new_from_file(v.clone())))
     } else {
         cli.rate_limiting.rate_limit_generic_canister_id.map(|x| {
-            Arc::new(generic::Limiter::new_from_canister(
-                x,
-                agent.clone().unwrap(),
-            ))
+            Arc::new(if cli.misc.crypto_config.is_some() {
+                generic::Limiter::new_from_canister_update(x, agent.clone().unwrap())
+            } else {
+                generic::Limiter::new_from_canister_query(x, agent.clone().unwrap())
+            })
         })
     };
 

--- a/rs/boundary_node/ic_boundary/src/rate_limiting/fetcher.rs
+++ b/rs/boundary_node/ic_boundary/src/rate_limiting/fetcher.rs
@@ -1,4 +1,4 @@
-use std::{path::PathBuf, sync::Arc};
+use std::{path::PathBuf, sync::Arc, time::SystemTime};
 
 use anyhow::{anyhow, Context as _, Error};
 use async_trait::async_trait;
@@ -9,6 +9,15 @@ use rate_limits_api::{v1::RateLimitRule, GetConfigResponse, Version};
 use tokio::fs;
 
 const SCHEMA_VERSION: u64 = 1;
+
+fn nonce() -> Vec<u8> {
+    SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos()
+        .to_le_bytes()
+        .to_vec()
+}
 
 #[async_trait]
 pub trait FetchesRules: Send + Sync {
@@ -41,16 +50,35 @@ impl FetchesRules for FileFetcher {
     }
 }
 
-pub struct CanisterConfigFetcher(pub Agent, pub CanisterId);
+pub struct CanisterConfigFetcherQuery(pub Agent, pub CanisterId);
 
 #[async_trait]
-impl FetchesConfig for CanisterConfigFetcher {
+impl FetchesConfig for CanisterConfigFetcherQuery {
     async fn fetch_config(&self) -> Result<Vec<u8>, Error> {
         self.0
             .execute_query(
+                &self.1,                            // canister_id
+                "get_config",                       // method
+                Encode!(&None::<Version>).unwrap(), // arguments
+            )
+            .await
+            .map_err(|e| anyhow!("failed to fetch config from the canister: {e:#}"))?
+            .ok_or_else(|| anyhow!("got empty response from the canister"))
+    }
+}
+
+pub struct CanisterConfigFetcherUpdate(pub Agent, pub CanisterId);
+
+#[async_trait]
+impl FetchesConfig for CanisterConfigFetcherUpdate {
+    async fn fetch_config(&self) -> Result<Vec<u8>, Error> {
+        self.0
+            .execute_update(
+                &self.1,                            // canister_id
                 &self.1,                            // effective_canister_id
                 "get_config",                       // method
                 Encode!(&None::<Version>).unwrap(), // arguments
+                nonce(),                            // nonce
             )
             .await
             .map_err(|e| anyhow!("failed to fetch config from the canister: {e:#}"))?


### PR DESCRIPTION
use update for authenticated calls, query otherwise.