### PR TITLE
feat(nns): Count stale and expired voting power neurons.

### DIFF
--- a/rs/nns/governance/api/src/ic_nns_governance.pb.v1.rs
+++ b/rs/nns/governance/api/src/ic_nns_governance.pb.v1.rs
@@ -3038,6 +3038,12 @@ pub mod governance {
             Option<governance_cached_metrics::NeuronSubsetMetrics>,
         #[prost(message, optional, tag = "39")]
         pub public_neuron_subset_metrics: Option<governance_cached_metrics::NeuronSubsetMetrics>,
+        #[prost(message, optional, tag = "40")]
+        pub still_losing_voting_power_neuron_subset_metrics:
+            ::core::option::Option<governance_cached_metrics::NeuronSubsetMetrics>,
+        #[prost(message, optional, tag = "41")]
+        pub done_losing_voting_power_neuron_subset_metrics:
+            ::core::option::Option<governance_cached_metrics::NeuronSubsetMetrics>,
     }
     /// Nested message and enum types in `GovernanceCachedMetrics`.
     pub mod governance_cached_metrics {

--- a/rs/nns/governance/api/src/ic_nns_governance.pb.v1.rs
+++ b/rs/nns/governance/api/src/ic_nns_governance.pb.v1.rs
@@ -3042,7 +3042,7 @@ pub mod governance {
         pub still_losing_voting_power_neuron_subset_metrics:
             ::core::option::Option<governance_cached_metrics::NeuronSubsetMetrics>,
         #[prost(message, optional, tag = "41")]
-        pub done_losing_voting_power_neuron_subset_metrics:
+        pub fully_lost_voting_power_neuron_subset_metrics:
             ::core::option::Option<governance_cached_metrics::NeuronSubsetMetrics>,
     }
     /// Nested message and enum types in `GovernanceCachedMetrics`.

--- a/rs/nns/governance/api/src/ic_nns_governance.pb.v1.rs
+++ b/rs/nns/governance/api/src/ic_nns_governance.pb.v1.rs
@@ -3039,7 +3039,7 @@ pub mod governance {
         #[prost(message, optional, tag = "39")]
         pub public_neuron_subset_metrics: Option<governance_cached_metrics::NeuronSubsetMetrics>,
         #[prost(message, optional, tag = "40")]
-        pub still_losing_voting_power_neuron_subset_metrics:
+        pub declining_voting_power_neuron_subset_metrics:
             ::core::option::Option<governance_cached_metrics::NeuronSubsetMetrics>,
         #[prost(message, optional, tag = "41")]
         pub fully_lost_voting_power_neuron_subset_metrics:

--- a/rs/nns/governance/canister/governance.did
+++ b/rs/nns/governance/canister/governance.did
@@ -357,7 +357,7 @@ type GovernanceCachedMetrics = record {
   non_self_authenticating_controller_neuron_subset_metrics : opt NeuronSubsetMetrics;
   public_neuron_subset_metrics : opt NeuronSubsetMetrics;
   still_losing_voting_power_neuron_subset_metrics : opt NeuronSubsetMetrics;
-  done_losing_voting_power_neuron_subset_metrics : opt NeuronSubsetMetrics;
+  fully_lost_voting_power_neuron_subset_metrics : opt NeuronSubsetMetrics;
 };
 
 type GovernanceError = record {

--- a/rs/nns/governance/canister/governance.did
+++ b/rs/nns/governance/canister/governance.did
@@ -356,7 +356,7 @@ type GovernanceCachedMetrics = record {
 
   non_self_authenticating_controller_neuron_subset_metrics : opt NeuronSubsetMetrics;
   public_neuron_subset_metrics : opt NeuronSubsetMetrics;
-  still_losing_voting_power_neuron_subset_metrics : opt NeuronSubsetMetrics;
+  declining_voting_power_neuron_subset_metrics : opt NeuronSubsetMetrics;
   fully_lost_voting_power_neuron_subset_metrics : opt NeuronSubsetMetrics;
 };
 

--- a/rs/nns/governance/canister/governance.did
+++ b/rs/nns/governance/canister/governance.did
@@ -346,15 +346,18 @@ type GovernanceCachedMetrics = record {
   };
   dissolving_neurons_count_buckets : vec record { nat64; nat64 };
   dissolving_neurons_e8s_buckets_ect : vec record { nat64; float64 };
-  non_self_authenticating_controller_neuron_subset_metrics : opt NeuronSubsetMetrics;
   dissolving_neurons_count : nat64;
   dissolving_neurons_e8s_buckets : vec record { nat64; float64 };
   total_staked_maturity_e8s_equivalent_seed : nat64;
   community_fund_total_staked_e8s : nat64;
   not_dissolving_neurons_e8s_buckets_seed : vec record { nat64; float64 };
-  public_neuron_subset_metrics : opt NeuronSubsetMetrics;
   timestamp_seconds : nat64;
   seed_neuron_count : nat64;
+
+  non_self_authenticating_controller_neuron_subset_metrics : opt NeuronSubsetMetrics;
+  public_neuron_subset_metrics : opt NeuronSubsetMetrics;
+  still_losing_voting_power_neuron_subset_metrics : opt NeuronSubsetMetrics;
+  done_losing_voting_power_neuron_subset_metrics : opt NeuronSubsetMetrics;
 };
 
 type GovernanceError = record {

--- a/rs/nns/governance/canister/governance_test.did
+++ b/rs/nns/governance/canister/governance_test.did
@@ -345,15 +345,18 @@ type GovernanceCachedMetrics = record {
   };
   dissolving_neurons_count_buckets : vec record { nat64; nat64 };
   dissolving_neurons_e8s_buckets_ect : vec record { nat64; float64 };
-  non_self_authenticating_controller_neuron_subset_metrics : opt NeuronSubsetMetrics;
   dissolving_neurons_count : nat64;
   dissolving_neurons_e8s_buckets : vec record { nat64; float64 };
   total_staked_maturity_e8s_equivalent_seed : nat64;
   community_fund_total_staked_e8s : nat64;
   not_dissolving_neurons_e8s_buckets_seed : vec record { nat64; float64 };
-  public_neuron_subset_metrics : opt NeuronSubsetMetrics;
   timestamp_seconds : nat64;
   seed_neuron_count : nat64;
+
+  non_self_authenticating_controller_neuron_subset_metrics : opt NeuronSubsetMetrics;
+  public_neuron_subset_metrics : opt NeuronSubsetMetrics;
+  still_losing_voting_power_neuron_subset_metrics : opt NeuronSubsetMetrics;
+  done_losing_voting_power_neuron_subset_metrics : opt NeuronSubsetMetrics;
 };
 
 type GovernanceError = record {

--- a/rs/nns/governance/canister/governance_test.did
+++ b/rs/nns/governance/canister/governance_test.did
@@ -356,7 +356,7 @@ type GovernanceCachedMetrics = record {
   non_self_authenticating_controller_neuron_subset_metrics : opt NeuronSubsetMetrics;
   public_neuron_subset_metrics : opt NeuronSubsetMetrics;
   still_losing_voting_power_neuron_subset_metrics : opt NeuronSubsetMetrics;
-  done_losing_voting_power_neuron_subset_metrics : opt NeuronSubsetMetrics;
+  fully_lost_voting_power_neuron_subset_metrics : opt NeuronSubsetMetrics;
 };
 
 type GovernanceError = record {

--- a/rs/nns/governance/canister/governance_test.did
+++ b/rs/nns/governance/canister/governance_test.did
@@ -355,7 +355,7 @@ type GovernanceCachedMetrics = record {
 
   non_self_authenticating_controller_neuron_subset_metrics : opt NeuronSubsetMetrics;
   public_neuron_subset_metrics : opt NeuronSubsetMetrics;
-  still_losing_voting_power_neuron_subset_metrics : opt NeuronSubsetMetrics;
+  declining_voting_power_neuron_subset_metrics : opt NeuronSubsetMetrics;
   fully_lost_voting_power_neuron_subset_metrics : opt NeuronSubsetMetrics;
 };
 

--- a/rs/nns/governance/proto/ic_nns_governance/pb/v1/governance.proto
+++ b/rs/nns/governance/proto/ic_nns_governance/pb/v1/governance.proto
@@ -2464,7 +2464,7 @@ message Governance {
     NeuronSubsetMetrics non_self_authenticating_controller_neuron_subset_metrics = 38;
     NeuronSubsetMetrics public_neuron_subset_metrics = 39;
     NeuronSubsetMetrics still_losing_voting_power_neuron_subset_metrics = 40;
-    NeuronSubsetMetrics done_losing_voting_power_neuron_subset_metrics = 41;
+    NeuronSubsetMetrics fully_lost_voting_power_neuron_subset_metrics = 41;
   }
 
   GovernanceCachedMetrics metrics = 15;

--- a/rs/nns/governance/proto/ic_nns_governance/pb/v1/governance.proto
+++ b/rs/nns/governance/proto/ic_nns_governance/pb/v1/governance.proto
@@ -2463,7 +2463,7 @@ message Governance {
 
     NeuronSubsetMetrics non_self_authenticating_controller_neuron_subset_metrics = 38;
     NeuronSubsetMetrics public_neuron_subset_metrics = 39;
-    NeuronSubsetMetrics still_losing_voting_power_neuron_subset_metrics = 40;
+    NeuronSubsetMetrics declining_voting_power_neuron_subset_metrics = 40;
     NeuronSubsetMetrics fully_lost_voting_power_neuron_subset_metrics = 41;
   }
 

--- a/rs/nns/governance/proto/ic_nns_governance/pb/v1/governance.proto
+++ b/rs/nns/governance/proto/ic_nns_governance/pb/v1/governance.proto
@@ -2463,6 +2463,8 @@ message Governance {
 
     NeuronSubsetMetrics non_self_authenticating_controller_neuron_subset_metrics = 38;
     NeuronSubsetMetrics public_neuron_subset_metrics = 39;
+    NeuronSubsetMetrics still_losing_voting_power_neuron_subset_metrics = 40;
+    NeuronSubsetMetrics done_losing_voting_power_neuron_subset_metrics = 41;
   }
 
   GovernanceCachedMetrics metrics = 15;

--- a/rs/nns/governance/src/gen/ic_nns_governance.pb.v1.rs
+++ b/rs/nns/governance/src/gen/ic_nns_governance.pb.v1.rs
@@ -3604,7 +3604,7 @@ pub mod governance {
         pub public_neuron_subset_metrics:
             ::core::option::Option<governance_cached_metrics::NeuronSubsetMetrics>,
         #[prost(message, optional, tag = "40")]
-        pub still_losing_voting_power_neuron_subset_metrics:
+        pub declining_voting_power_neuron_subset_metrics:
             ::core::option::Option<governance_cached_metrics::NeuronSubsetMetrics>,
         #[prost(message, optional, tag = "41")]
         pub fully_lost_voting_power_neuron_subset_metrics:

--- a/rs/nns/governance/src/gen/ic_nns_governance.pb.v1.rs
+++ b/rs/nns/governance/src/gen/ic_nns_governance.pb.v1.rs
@@ -3603,6 +3603,12 @@ pub mod governance {
         #[prost(message, optional, tag = "39")]
         pub public_neuron_subset_metrics:
             ::core::option::Option<governance_cached_metrics::NeuronSubsetMetrics>,
+        #[prost(message, optional, tag = "40")]
+        pub still_losing_voting_power_neuron_subset_metrics:
+            ::core::option::Option<governance_cached_metrics::NeuronSubsetMetrics>,
+        #[prost(message, optional, tag = "41")]
+        pub done_losing_voting_power_neuron_subset_metrics:
+            ::core::option::Option<governance_cached_metrics::NeuronSubsetMetrics>,
     }
     /// Nested message and enum types in `GovernanceCachedMetrics`.
     pub mod governance_cached_metrics {

--- a/rs/nns/governance/src/gen/ic_nns_governance.pb.v1.rs
+++ b/rs/nns/governance/src/gen/ic_nns_governance.pb.v1.rs
@@ -3607,7 +3607,7 @@ pub mod governance {
         pub still_losing_voting_power_neuron_subset_metrics:
             ::core::option::Option<governance_cached_metrics::NeuronSubsetMetrics>,
         #[prost(message, optional, tag = "41")]
-        pub done_losing_voting_power_neuron_subset_metrics:
+        pub fully_lost_voting_power_neuron_subset_metrics:
             ::core::option::Option<governance_cached_metrics::NeuronSubsetMetrics>,
     }
     /// Nested message and enum types in `GovernanceCachedMetrics`.

--- a/rs/nns/governance/src/governance.rs
+++ b/rs/nns/governance/src/governance.rs
@@ -8151,10 +8151,12 @@ impl Governance {
         );
         let public_neuron_subset_metrics =
             Some(NeuronSubsetMetricsPb::from(public_neuron_subset_metrics));
-        let still_losing_voting_power_neuron_subset_metrics =
-            Some(NeuronSubsetMetricsPb::from(still_losing_voting_power_neuron_subset_metrics));
-        let done_losing_voting_power_neuron_subset_metrics =
-            Some(NeuronSubsetMetricsPb::from(done_losing_voting_power_neuron_subset_metrics));
+        let still_losing_voting_power_neuron_subset_metrics = Some(NeuronSubsetMetricsPb::from(
+            still_losing_voting_power_neuron_subset_metrics,
+        ));
+        let done_losing_voting_power_neuron_subset_metrics = Some(NeuronSubsetMetricsPb::from(
+            done_losing_voting_power_neuron_subset_metrics,
+        ));
 
         GovernanceCachedMetrics {
             timestamp_seconds: now,

--- a/rs/nns/governance/src/governance.rs
+++ b/rs/nns/governance/src/governance.rs
@@ -8134,7 +8134,7 @@ impl Governance {
             non_self_authenticating_controller_neuron_subset_metrics,
             public_neuron_subset_metrics,
             still_losing_voting_power_neuron_subset_metrics,
-            done_losing_voting_power_neuron_subset_metrics,
+            fully_lost_voting_power_neuron_subset_metrics,
         } = self.neuron_store.compute_neuron_metrics(
             neuron_minimum_stake_e8s,
             voting_power_economics,
@@ -8154,8 +8154,8 @@ impl Governance {
         let still_losing_voting_power_neuron_subset_metrics = Some(NeuronSubsetMetricsPb::from(
             still_losing_voting_power_neuron_subset_metrics,
         ));
-        let done_losing_voting_power_neuron_subset_metrics = Some(NeuronSubsetMetricsPb::from(
-            done_losing_voting_power_neuron_subset_metrics,
+        let fully_lost_voting_power_neuron_subset_metrics = Some(NeuronSubsetMetricsPb::from(
+            fully_lost_voting_power_neuron_subset_metrics,
         ));
 
         GovernanceCachedMetrics {
@@ -8200,7 +8200,7 @@ impl Governance {
             non_self_authenticating_controller_neuron_subset_metrics,
             public_neuron_subset_metrics,
             still_losing_voting_power_neuron_subset_metrics,
-            done_losing_voting_power_neuron_subset_metrics,
+            fully_lost_voting_power_neuron_subset_metrics,
         }
     }
 

--- a/rs/nns/governance/src/governance.rs
+++ b/rs/nns/governance/src/governance.rs
@@ -8133,7 +8133,7 @@ impl Governance {
             not_dissolving_neurons_e8s_buckets_ect,
             non_self_authenticating_controller_neuron_subset_metrics,
             public_neuron_subset_metrics,
-            still_losing_voting_power_neuron_subset_metrics,
+            declining_voting_power_neuron_subset_metrics,
             fully_lost_voting_power_neuron_subset_metrics,
         } = self.neuron_store.compute_neuron_metrics(
             neuron_minimum_stake_e8s,
@@ -8151,8 +8151,8 @@ impl Governance {
         );
         let public_neuron_subset_metrics =
             Some(NeuronSubsetMetricsPb::from(public_neuron_subset_metrics));
-        let still_losing_voting_power_neuron_subset_metrics = Some(NeuronSubsetMetricsPb::from(
-            still_losing_voting_power_neuron_subset_metrics,
+        let declining_voting_power_neuron_subset_metrics = Some(NeuronSubsetMetricsPb::from(
+            declining_voting_power_neuron_subset_metrics,
         ));
         let fully_lost_voting_power_neuron_subset_metrics = Some(NeuronSubsetMetricsPb::from(
             fully_lost_voting_power_neuron_subset_metrics,
@@ -8199,7 +8199,7 @@ impl Governance {
 
             non_self_authenticating_controller_neuron_subset_metrics,
             public_neuron_subset_metrics,
-            still_losing_voting_power_neuron_subset_metrics,
+            declining_voting_power_neuron_subset_metrics,
             fully_lost_voting_power_neuron_subset_metrics,
         }
     }

--- a/rs/nns/governance/src/governance.rs
+++ b/rs/nns/governance/src/governance.rs
@@ -8133,6 +8133,8 @@ impl Governance {
             not_dissolving_neurons_e8s_buckets_ect,
             non_self_authenticating_controller_neuron_subset_metrics,
             public_neuron_subset_metrics,
+            still_losing_voting_power_neuron_subset_metrics,
+            done_losing_voting_power_neuron_subset_metrics,
         } = self.neuron_store.compute_neuron_metrics(
             neuron_minimum_stake_e8s,
             voting_power_economics,
@@ -8149,6 +8151,10 @@ impl Governance {
         );
         let public_neuron_subset_metrics =
             Some(NeuronSubsetMetricsPb::from(public_neuron_subset_metrics));
+        let still_losing_voting_power_neuron_subset_metrics =
+            Some(NeuronSubsetMetricsPb::from(still_losing_voting_power_neuron_subset_metrics));
+        let done_losing_voting_power_neuron_subset_metrics =
+            Some(NeuronSubsetMetricsPb::from(done_losing_voting_power_neuron_subset_metrics));
 
         GovernanceCachedMetrics {
             timestamp_seconds: now,
@@ -8191,6 +8197,8 @@ impl Governance {
 
             non_self_authenticating_controller_neuron_subset_metrics,
             public_neuron_subset_metrics,
+            still_losing_voting_power_neuron_subset_metrics,
+            done_losing_voting_power_neuron_subset_metrics,
         }
     }
 

--- a/rs/nns/governance/src/lib.rs
+++ b/rs/nns/governance/src/lib.rs
@@ -943,7 +943,9 @@ pub fn encode_metrics(
             public_neuron_subset_metrics.encode("public", "have visibility set to public", w)?;
         }
 
-        if let Some(still_losing_voting_power_neuron_subset_metrics) = still_losing_voting_power_neuron_subset_metrics {
+        if let Some(still_losing_voting_power_neuron_subset_metrics) =
+            still_losing_voting_power_neuron_subset_metrics
+        {
             still_losing_voting_power_neuron_subset_metrics.encode(
                 "still_losing_voting_power",
                 "have deciding voting power < potential voting power (but still positive) due \
@@ -952,7 +954,9 @@ pub fn encode_metrics(
             )?;
         }
 
-        if let Some(done_losing_voting_power_neuron_subset_metrics) = done_losing_voting_power_neuron_subset_metrics {
+        if let Some(done_losing_voting_power_neuron_subset_metrics) =
+            done_losing_voting_power_neuron_subset_metrics
+        {
             done_losing_voting_power_neuron_subset_metrics.encode(
                 "done_losing_voting_power",
                 "have 0 deciding voting power due to not refreshing recently enough.",

--- a/rs/nns/governance/src/lib.rs
+++ b/rs/nns/governance/src/lib.rs
@@ -707,6 +707,8 @@ pub fn encode_metrics(
             total_staked_e8s_non_self_authenticating_controller: _,
             non_self_authenticating_controller_neuron_subset_metrics,
             public_neuron_subset_metrics,
+            still_losing_voting_power_neuron_subset_metrics,
+            done_losing_voting_power_neuron_subset_metrics,
         } = metrics;
 
         // ICP
@@ -939,6 +941,23 @@ pub fn encode_metrics(
 
         if let Some(public_neuron_subset_metrics) = public_neuron_subset_metrics {
             public_neuron_subset_metrics.encode("public", "have visibility set to public", w)?;
+        }
+
+        if let Some(still_losing_voting_power_neuron_subset_metrics) = still_losing_voting_power_neuron_subset_metrics {
+            still_losing_voting_power_neuron_subset_metrics.encode(
+                "still_losing_voting_power",
+                "have deciding voting power < potential voting power (but still positive) due \
+                 to not refreshing recently enough.",
+                w,
+            )?;
+        }
+
+        if let Some(done_losing_voting_power_neuron_subset_metrics) = done_losing_voting_power_neuron_subset_metrics {
+            done_losing_voting_power_neuron_subset_metrics.encode(
+                "done_losing_voting_power",
+                "have 0 deciding voting power due to not refreshing recently enough.",
+                w,
+            )?;
         }
     }
 

--- a/rs/nns/governance/src/lib.rs
+++ b/rs/nns/governance/src/lib.rs
@@ -708,7 +708,7 @@ pub fn encode_metrics(
             non_self_authenticating_controller_neuron_subset_metrics,
             public_neuron_subset_metrics,
             still_losing_voting_power_neuron_subset_metrics,
-            done_losing_voting_power_neuron_subset_metrics,
+            fully_lost_voting_power_neuron_subset_metrics,
         } = metrics;
 
         // ICP
@@ -954,11 +954,11 @@ pub fn encode_metrics(
             )?;
         }
 
-        if let Some(done_losing_voting_power_neuron_subset_metrics) =
-            done_losing_voting_power_neuron_subset_metrics
+        if let Some(fully_lost_voting_power_neuron_subset_metrics) =
+            fully_lost_voting_power_neuron_subset_metrics
         {
-            done_losing_voting_power_neuron_subset_metrics.encode(
-                "done_losing_voting_power",
+            fully_lost_voting_power_neuron_subset_metrics.encode(
+                "fully_lost_voting_power",
                 "have 0 deciding voting power due to not refreshing recently enough.",
                 w,
             )?;

--- a/rs/nns/governance/src/lib.rs
+++ b/rs/nns/governance/src/lib.rs
@@ -707,7 +707,7 @@ pub fn encode_metrics(
             total_staked_e8s_non_self_authenticating_controller: _,
             non_self_authenticating_controller_neuron_subset_metrics,
             public_neuron_subset_metrics,
-            still_losing_voting_power_neuron_subset_metrics,
+            declining_voting_power_neuron_subset_metrics,
             fully_lost_voting_power_neuron_subset_metrics,
         } = metrics;
 
@@ -943,11 +943,11 @@ pub fn encode_metrics(
             public_neuron_subset_metrics.encode("public", "have visibility set to public", w)?;
         }
 
-        if let Some(still_losing_voting_power_neuron_subset_metrics) =
-            still_losing_voting_power_neuron_subset_metrics
+        if let Some(declining_voting_power_neuron_subset_metrics) =
+            declining_voting_power_neuron_subset_metrics
         {
-            still_losing_voting_power_neuron_subset_metrics.encode(
-                "still_losing_voting_power",
+            declining_voting_power_neuron_subset_metrics.encode(
+                "declining_voting_power",
                 "have deciding voting power < potential voting power (but still positive) due \
                  to not refreshing recently enough.",
                 w,

--- a/rs/nns/governance/src/neuron_store/metrics.rs
+++ b/rs/nns/governance/src/neuron_store/metrics.rs
@@ -61,7 +61,7 @@ pub(crate) struct NeuronMetrics {
     pub(crate) non_self_authenticating_controller_neuron_subset_metrics: NeuronSubsetMetrics,
     pub(crate) public_neuron_subset_metrics: NeuronSubsetMetrics,
     pub(crate) still_losing_voting_power_neuron_subset_metrics: NeuronSubsetMetrics,
-    pub(crate) done_losing_voting_power_neuron_subset_metrics: NeuronSubsetMetrics,
+    pub(crate) fully_lost_voting_power_neuron_subset_metrics: NeuronSubsetMetrics,
 }
 
 impl NeuronMetrics {
@@ -102,9 +102,9 @@ impl NeuronMetrics {
     }
 
     /// This could modify either still_losing_voting_power_neuron_subset_metrics, or
-    /// done_losing_voting_power_neuron_subset_metrics (but not both), since
+    /// fully_lost_voting_power_neuron_subset_metrics (but not both), since
     /// they are very closely related. In particular,
-    fn increment_still_losing_voting_power_or_done_losing_voting_power_neuron_subset_metrics(
+    fn increment_still_losing_voting_power_or_fully_lost_voting_power_neuron_subset_metrics(
         &mut self,
         voting_power_economics: &VotingPowerEconomics,
         now_seconds: u64,
@@ -126,7 +126,7 @@ impl NeuronMetrics {
             self.still_losing_voting_power_neuron_subset_metrics
                 .increment(voting_power_economics, now_seconds, neuron);
         } else {
-            self.done_losing_voting_power_neuron_subset_metrics
+            self.fully_lost_voting_power_neuron_subset_metrics
                 .increment(voting_power_economics, now_seconds, neuron);
         }
     }
@@ -308,7 +308,7 @@ impl NeuronStore {
                     now_seconds,
                     neuron,
                 );
-                metrics.increment_still_losing_voting_power_or_done_losing_voting_power_neuron_subset_metrics(
+                metrics.increment_still_losing_voting_power_or_fully_lost_voting_power_neuron_subset_metrics(
                     voting_power_economics,
                     now_seconds,
                     neuron,
@@ -483,7 +483,7 @@ impl NeuronStore {
                 now_seconds,
                 neuron,
             );
-            metrics.increment_still_losing_voting_power_or_done_losing_voting_power_neuron_subset_metrics(
+            metrics.increment_still_losing_voting_power_or_fully_lost_voting_power_neuron_subset_metrics(
                 voting_power_economics,
                 now_seconds,
                 neuron,

--- a/rs/nns/governance/src/neuron_store/metrics.rs
+++ b/rs/nns/governance/src/neuron_store/metrics.rs
@@ -60,6 +60,8 @@ pub(crate) struct NeuronMetrics {
     // to the reader.
     pub(crate) non_self_authenticating_controller_neuron_subset_metrics: NeuronSubsetMetrics,
     pub(crate) public_neuron_subset_metrics: NeuronSubsetMetrics,
+    pub(crate) still_losing_voting_power_neuron_subset_metrics: NeuronSubsetMetrics,
+    pub(crate) done_losing_voting_power_neuron_subset_metrics: NeuronSubsetMetrics,
 }
 
 impl NeuronMetrics {
@@ -97,6 +99,33 @@ impl NeuronMetrics {
 
         self.public_neuron_subset_metrics
             .increment(voting_power_economics, now_seconds, neuron);
+    }
+
+    /// This could modify either still_losing_voting_power_neuron_subset_metrics, or
+    /// done_losing_voting_power_neuron_subset_metrics (but not both), since
+    /// they are very closely related. In particular,
+    fn increment_still_losing_voting_power_or_done_losing_voting_power_neuron_subset_metrics(
+        &mut self,
+        voting_power_economics: &VotingPowerEconomics,
+        now_seconds: u64,
+        neuron: &Neuron,
+    ) {
+        let seconds_since_voting_power_refreshed =
+            now_seconds - neuron.voting_power_refreshed_timestamp_seconds();
+        let Some(seconds_losing_voting_power) =
+            seconds_since_voting_power_refreshed
+            .checked_sub(voting_power_economics.get_start_reducing_voting_power_after_seconds())
+        else {
+            return;
+        };
+
+        if seconds_losing_voting_power < voting_power_economics.get_clear_following_after_seconds() {
+            self.still_losing_voting_power_neuron_subset_metrics
+                .increment(voting_power_economics, now_seconds, neuron);
+        } else {
+            self.done_losing_voting_power_neuron_subset_metrics
+                .increment(voting_power_economics, now_seconds, neuron);
+        }
     }
 }
 
@@ -276,6 +305,11 @@ impl NeuronStore {
                     now_seconds,
                     neuron,
                 );
+                metrics.increment_still_losing_voting_power_or_done_losing_voting_power_neuron_subset_metrics(
+                    voting_power_economics,
+                    now_seconds,
+                    neuron,
+                );
 
                 metrics.total_staked_e8s += neuron.minted_stake_e8s();
                 metrics.total_staked_maturity_e8s_equivalent +=
@@ -442,6 +476,11 @@ impl NeuronStore {
                 neuron,
             );
             metrics.increment_public_neuron_subset_metrics(
+                voting_power_economics,
+                now_seconds,
+                neuron,
+            );
+            metrics.increment_still_losing_voting_power_or_done_losing_voting_power_neuron_subset_metrics(
                 voting_power_economics,
                 now_seconds,
                 neuron,

--- a/rs/nns/governance/src/neuron_store/metrics.rs
+++ b/rs/nns/governance/src/neuron_store/metrics.rs
@@ -112,14 +112,14 @@ impl NeuronMetrics {
     ) {
         let seconds_since_voting_power_refreshed =
             now_seconds - neuron.voting_power_refreshed_timestamp_seconds();
-        let Some(seconds_losing_voting_power) =
-            seconds_since_voting_power_refreshed
+        let Some(seconds_losing_voting_power) = seconds_since_voting_power_refreshed
             .checked_sub(voting_power_economics.get_start_reducing_voting_power_after_seconds())
         else {
             return;
         };
 
-        if seconds_losing_voting_power < voting_power_economics.get_clear_following_after_seconds() {
+        if seconds_losing_voting_power < voting_power_economics.get_clear_following_after_seconds()
+        {
             self.still_losing_voting_power_neuron_subset_metrics
                 .increment(voting_power_economics, now_seconds, neuron);
         } else {

--- a/rs/nns/governance/src/neuron_store/metrics.rs
+++ b/rs/nns/governance/src/neuron_store/metrics.rs
@@ -111,7 +111,10 @@ impl NeuronMetrics {
         neuron: &Neuron,
     ) {
         let seconds_since_voting_power_refreshed =
-            now_seconds - neuron.voting_power_refreshed_timestamp_seconds();
+            // Here, we assume that the neuron was not refreshed in the future.
+            // This doesn't always hold in tests though, due to the difficulty
+            // of constructing realistic data/scenarios.
+            now_seconds.saturating_sub(neuron.voting_power_refreshed_timestamp_seconds());
         let Some(seconds_losing_voting_power) = seconds_since_voting_power_refreshed
             .checked_sub(voting_power_economics.get_start_reducing_voting_power_after_seconds())
         else {

--- a/rs/nns/governance/src/neuron_store/metrics.rs
+++ b/rs/nns/governance/src/neuron_store/metrics.rs
@@ -103,7 +103,7 @@ impl NeuronMetrics {
 
     /// This could modify either declining_voting_power_neuron_subset_metrics, or
     /// fully_lost_voting_power_neuron_subset_metrics (but not both), since
-    /// they are very closely related. In particular,
+    /// those categories are mutually exclusive.
     fn increment_declining_voting_power_or_fully_lost_voting_power_neuron_subset_metrics(
         &mut self,
         voting_power_economics: &VotingPowerEconomics,

--- a/rs/nns/governance/src/neuron_store/metrics/tests.rs
+++ b/rs/nns/governance/src/neuron_store/metrics/tests.rs
@@ -286,7 +286,7 @@ fn test_compute_metrics() {
         // Some garbage values, because this test was written before this feature.
         non_self_authenticating_controller_neuron_subset_metrics: NeuronSubsetMetrics::default(),
         public_neuron_subset_metrics: NeuronSubsetMetrics::default(),
-        still_losing_voting_power_neuron_subset_metrics: NeuronSubsetMetrics::default(),
+        declining_voting_power_neuron_subset_metrics: NeuronSubsetMetrics::default(),
         fully_lost_voting_power_neuron_subset_metrics: NeuronSubsetMetrics::default(),
     };
     assert_eq!(
@@ -295,7 +295,7 @@ fn test_compute_metrics() {
             non_self_authenticating_controller_neuron_subset_metrics: NeuronSubsetMetrics::default(
             ),
             public_neuron_subset_metrics: NeuronSubsetMetrics::default(),
-            still_losing_voting_power_neuron_subset_metrics: NeuronSubsetMetrics::default(),
+            declining_voting_power_neuron_subset_metrics: NeuronSubsetMetrics::default(),
             fully_lost_voting_power_neuron_subset_metrics: NeuronSubsetMetrics::default(),
 
             ..metrics
@@ -801,7 +801,7 @@ fn test_compute_neuron_metrics_stale_and_expired_voting_power_neurons() {
     // Step 2: Call code under test.
 
     let NeuronMetrics {
-        still_losing_voting_power_neuron_subset_metrics,
+        declining_voting_power_neuron_subset_metrics,
         fully_lost_voting_power_neuron_subset_metrics,
         ..
     } = neuron_store.compute_neuron_metrics(E8, &VotingPowerEconomics::DEFAULT, now_seconds);
@@ -809,7 +809,7 @@ fn test_compute_neuron_metrics_stale_and_expired_voting_power_neurons() {
     // Step 3: Inspect results.
 
     assert_eq!(
-        still_losing_voting_power_neuron_subset_metrics,
+        declining_voting_power_neuron_subset_metrics,
         NeuronSubsetMetrics {
             count: 1,
 

--- a/rs/nns/governance/src/neuron_store/metrics/tests.rs
+++ b/rs/nns/governance/src/neuron_store/metrics/tests.rs
@@ -286,6 +286,8 @@ fn test_compute_metrics() {
         // Some garbage values, because this test was written before this feature.
         non_self_authenticating_controller_neuron_subset_metrics: NeuronSubsetMetrics::default(),
         public_neuron_subset_metrics: NeuronSubsetMetrics::default(),
+        still_losing_voting_power_neuron_subset_metrics: NeuronSubsetMetrics::default(),
+        done_losing_voting_power_neuron_subset_metrics: NeuronSubsetMetrics::default(),
     };
     assert_eq!(
         NeuronMetrics {
@@ -293,6 +295,8 @@ fn test_compute_metrics() {
             non_self_authenticating_controller_neuron_subset_metrics: NeuronSubsetMetrics::default(
             ),
             public_neuron_subset_metrics: NeuronSubsetMetrics::default(),
+            still_losing_voting_power_neuron_subset_metrics: NeuronSubsetMetrics::default(),
+            done_losing_voting_power_neuron_subset_metrics: NeuronSubsetMetrics::default(),
 
             ..metrics
         },
@@ -554,7 +558,7 @@ fn test_compute_neuron_metrics_public_neurons() {
 
     let now_seconds = 1718213756;
 
-    // Step 1.2: Construct neurons (as described in the docstring).
+    // Step 1.1: Construct neurons (as described in the docstring).
 
     let neuron_1 = NeuronBuilder::new(
         NeuronId { id: 1 },
@@ -621,7 +625,7 @@ fn test_compute_neuron_metrics_public_neurons() {
         (1.875 * (300.0 + 303.0) * 1_000_000.0) as u64
     );
 
-    // Step 1.3: Assemble neurons into collection.
+    // Step 1.2: Assemble neurons into collection.
 
     let neuron_store = NeuronStore::new(btreemap! {
         1 => neuron_1,
@@ -697,6 +701,193 @@ fn test_compute_neuron_metrics_public_neurons() {
             potential_voting_power_buckets: hashmap! {
                 8  => voting_power_3,
                 16 => voting_power_1,
+            },
+        },
+    );
+}
+
+/// Tests rollups related to periodic refresh of neurons.
+///
+/// There are three neurons in this test:
+///
+///     1. Refreshed recently.
+///
+///     2. Refreshed 6.5 months ago. Thus, its deciding voting power is half of
+///        its potential voting power.
+///
+///     3. Refreshed 8 months ago. Thus, deciding voting power is 0.
+#[test]
+fn test_compute_neuron_metrics_stale_and_expired_voting_power_neurons() {
+    // Step 1: Prepare the world.
+
+    let _reset_on_drop = crate::temporarily_enable_voting_power_adjustment();
+    let now_seconds = 1718213756;
+
+    // Step 1.1: Construct neurons (as described in the docstring).
+
+    // Total voting power bonus: 2x * 1.125x = 2.25x
+    let dissolve_state_and_age = DissolveStateAndAge::NotDissolving {
+        dissolve_delay_seconds: 8 * ONE_YEAR_SECONDS, // 100% (equivlanetly, 2x) dissolve delay bonus
+        aging_since_timestamp_seconds: now_seconds - 2 * ONE_YEAR_SECONDS, // 12.5% (equivalently 1.125x) age bonus
+    };
+    let total_bonus_multiplier = 2.25;
+
+    let fresh_neuron = NeuronBuilder::new(
+        NeuronId { id: 1 },
+        Subaccount::try_from([1_u8; 32].as_ref()).unwrap(),
+        PrincipalId::new_user_test_id(1),
+        dissolve_state_and_age,
+        now_seconds - 10 * ONE_YEAR_SECONDS,
+    )
+    .with_cached_neuron_stake_e8s(100)
+    .with_staked_maturity_e8s_equivalent(101)
+    .with_maturity_e8s_equivalent(110)
+    .with_visibility(Some(Visibility::Public))
+    .with_voting_power_refreshed_timestamp_seconds(now_seconds)
+    .build();
+
+    let stale_neuron = NeuronBuilder::new(
+        NeuronId { id: 2 },
+        Subaccount::try_from([2_u8; 32].as_ref()).unwrap(),
+        PrincipalId::new_user_test_id(2),
+        dissolve_state_and_age,
+        now_seconds - 10 * ONE_YEAR_SECONDS,
+    )
+    .with_cached_neuron_stake_e8s(200_000)
+    .with_staked_maturity_e8s_equivalent(202_000)
+    .with_maturity_e8s_equivalent(220_000)
+    .with_voting_power_refreshed_timestamp_seconds(now_seconds - 6 * ONE_MONTH_SECONDS - ONE_MONTH_SECONDS / 2)
+    .build();
+
+    let expired_neuron = NeuronBuilder::new(
+        NeuronId { id: 3 },
+        Subaccount::try_from([3_u8; 32].as_ref()).unwrap(),
+        PrincipalId::new_user_test_id(3),
+        dissolve_state_and_age,
+        now_seconds - 10 * ONE_YEAR_SECONDS,
+    )
+    .with_cached_neuron_stake_e8s(300_000_000)
+    .with_staked_maturity_e8s_equivalent(303_000_000)
+    .with_maturity_e8s_equivalent(330_000_000)
+    .with_voting_power_refreshed_timestamp_seconds(now_seconds - 8 * ONE_MONTH_SECONDS)
+    .build();
+
+    let fresh_potential_voting_power = fresh_neuron.potential_voting_power(now_seconds);
+    let stale_potential_voting_power = stale_neuron.potential_voting_power(now_seconds);
+    let expired_potential_voting_power = expired_neuron.potential_voting_power(now_seconds);
+    assert_eq!(fresh_potential_voting_power, (total_bonus_multiplier * (100.0 + 101.0)) as u64);
+    assert_eq!(stale_potential_voting_power, (total_bonus_multiplier * (200.0e3 + 202.0e3)) as u64);
+    assert_eq!(
+        expired_potential_voting_power,
+        (total_bonus_multiplier * (300.0 + 303.0) * 1e6) as u64
+    );
+
+    // Step 1.2: Assemble neurons into collection.
+
+    let neuron_store = NeuronStore::new(btreemap! {
+        fresh_neuron.id().id => fresh_neuron,
+        stale_neuron.id().id => stale_neuron,
+        expired_neuron.id().id => expired_neuron,
+    });
+
+    // Step 2: Call code under test.
+
+    let NeuronMetrics {
+        still_losing_voting_power_neuron_subset_metrics,
+        done_losing_voting_power_neuron_subset_metrics,
+        ..
+    } = neuron_store.compute_neuron_metrics(E8, &VotingPowerEconomics::DEFAULT, now_seconds);
+
+    // Step 3: Inspect results.
+
+    assert_eq!(
+        still_losing_voting_power_neuron_subset_metrics,
+        NeuronSubsetMetrics {
+            count: 1,
+
+            total_staked_e8s: 200_000,
+            total_staked_maturity_e8s_equivalent: 202_000,
+            total_maturity_e8s_equivalent: 220_000,
+
+            // Voting power.
+            total_voting_power: stale_potential_voting_power,
+            total_deciding_voting_power: stale_potential_voting_power / 2,
+            total_potential_voting_power: stale_potential_voting_power,
+
+            // Broken out by dissolve delay (rounded down to the nearest multiple of 6
+            // months).
+
+            // Analogous to the vanilla count field.
+            count_buckets: hashmap! {
+                16 => 1, // 1 neuron with 4 year dissolve delay.
+            },
+
+            // ICP-like resources.
+            staked_e8s_buckets: hashmap! {
+                16 => 200_000,
+            },
+            staked_maturity_e8s_equivalent_buckets: hashmap! {
+                16 => 202_000,
+            },
+            maturity_e8s_equivalent_buckets: hashmap! {
+                16 => 220_000,
+            },
+
+            // Analogous to total_voting_power.
+            voting_power_buckets: hashmap! {
+                16 => stale_potential_voting_power,
+            },
+            deciding_voting_power_buckets: hashmap! {
+                16 => stale_potential_voting_power / 2,
+            },
+            potential_voting_power_buckets: hashmap! {
+                16 => stale_potential_voting_power,
+            },
+        },
+    );
+
+    assert_eq!(
+        done_losing_voting_power_neuron_subset_metrics,
+        NeuronSubsetMetrics {
+            count: 1,
+
+            total_staked_e8s: 300_000_000,
+            total_staked_maturity_e8s_equivalent: 303_000_000,
+            total_maturity_e8s_equivalent: 330_000_000,
+
+            // Voting power.
+            total_voting_power: expired_potential_voting_power,
+            total_deciding_voting_power: 0,
+            total_potential_voting_power: expired_potential_voting_power,
+
+            // Broken out by dissolve delay (rounded down to the nearest multiple of 6
+            // months).
+
+            // Analogous to the vanilla count field.
+            count_buckets: hashmap! {
+                16 => 1, // 1 neuron with 4 year dissolve delay.
+            },
+
+            // ICP-like resources.
+            staked_e8s_buckets: hashmap! {
+                16 => 300_000_000,
+            },
+            staked_maturity_e8s_equivalent_buckets: hashmap! {
+                16 => 303_000_000,
+            },
+            maturity_e8s_equivalent_buckets: hashmap! {
+                16 => 330_000_000,
+            },
+
+            // Analogous to total_voting_power.
+            voting_power_buckets: hashmap! {
+                16 => expired_potential_voting_power,
+            },
+            deciding_voting_power_buckets: hashmap! {
+                16 => 0,
+            },
+            potential_voting_power_buckets: hashmap! {
+                16 => expired_potential_voting_power,
             },
         },
     );

--- a/rs/nns/governance/src/neuron_store/metrics/tests.rs
+++ b/rs/nns/governance/src/neuron_store/metrics/tests.rs
@@ -756,7 +756,9 @@ fn test_compute_neuron_metrics_stale_and_expired_voting_power_neurons() {
     .with_cached_neuron_stake_e8s(200_000)
     .with_staked_maturity_e8s_equivalent(202_000)
     .with_maturity_e8s_equivalent(220_000)
-    .with_voting_power_refreshed_timestamp_seconds(now_seconds - 6 * ONE_MONTH_SECONDS - ONE_MONTH_SECONDS / 2)
+    .with_voting_power_refreshed_timestamp_seconds(
+        now_seconds - 6 * ONE_MONTH_SECONDS - ONE_MONTH_SECONDS / 2,
+    )
     .build();
 
     let expired_neuron = NeuronBuilder::new(
@@ -775,8 +777,14 @@ fn test_compute_neuron_metrics_stale_and_expired_voting_power_neurons() {
     let fresh_potential_voting_power = fresh_neuron.potential_voting_power(now_seconds);
     let stale_potential_voting_power = stale_neuron.potential_voting_power(now_seconds);
     let expired_potential_voting_power = expired_neuron.potential_voting_power(now_seconds);
-    assert_eq!(fresh_potential_voting_power, (total_bonus_multiplier * (100.0 + 101.0)) as u64);
-    assert_eq!(stale_potential_voting_power, (total_bonus_multiplier * (200.0e3 + 202.0e3)) as u64);
+    assert_eq!(
+        fresh_potential_voting_power,
+        (total_bonus_multiplier * (100.0 + 101.0)) as u64
+    );
+    assert_eq!(
+        stale_potential_voting_power,
+        (total_bonus_multiplier * (200.0e3 + 202.0e3)) as u64
+    );
     assert_eq!(
         expired_potential_voting_power,
         (total_bonus_multiplier * (300.0 + 303.0) * 1e6) as u64

--- a/rs/nns/governance/src/neuron_store/metrics/tests.rs
+++ b/rs/nns/governance/src/neuron_store/metrics/tests.rs
@@ -813,11 +813,18 @@ fn test_compute_neuron_metrics_stale_and_expired_voting_power_neurons() {
         NeuronSubsetMetrics {
             count: 1,
 
+            // Here, we are seeing a pretty good indicator that stale neuron
+            // detection is working, because there isn't a plausible alternative
+            // explanation for how these values can be achieved from the numbers
+            // that we fed into the stats compiler. Ofc, other fields also
+            // indicate that stale neuron detection works.
             total_staked_e8s: 200_000,
             total_staked_maturity_e8s_equivalent: 202_000,
             total_maturity_e8s_equivalent: 220_000,
 
-            // Voting power.
+            // Voting power. Here, we see "good" evidence that the "right"
+            // voting power (deciding vs. voting) is used to populate these
+            // fields.
             total_voting_power: stale_potential_voting_power,
             total_deciding_voting_power: stale_potential_voting_power / 2,
             total_potential_voting_power: stale_potential_voting_power,
@@ -845,6 +852,7 @@ fn test_compute_neuron_metrics_stale_and_expired_voting_power_neurons() {
             voting_power_buckets: hashmap! {
                 16 => stale_potential_voting_power,
             },
+            // Ditto earlier comments about "right" voting power.
             deciding_voting_power_buckets: hashmap! {
                 16 => stale_potential_voting_power / 2,
             },
@@ -859,12 +867,16 @@ fn test_compute_neuron_metrics_stale_and_expired_voting_power_neurons() {
         NeuronSubsetMetrics {
             count: 1,
 
+            // Similar to the previous assert, this indicates that expired
+            // neuron detection works.
             total_staked_e8s: 300_000_000,
             total_staked_maturity_e8s_equivalent: 303_000_000,
             total_maturity_e8s_equivalent: 330_000_000,
 
             // Voting power.
             total_voting_power: expired_potential_voting_power,
+            // Similar to the previous assert, this indicates that the "right"
+            // (deciding vs. potential) voting power is being used.
             total_deciding_voting_power: 0,
             total_potential_voting_power: expired_potential_voting_power,
 
@@ -891,6 +903,7 @@ fn test_compute_neuron_metrics_stale_and_expired_voting_power_neurons() {
             voting_power_buckets: hashmap! {
                 16 => expired_potential_voting_power,
             },
+            // Ditto earlier comment about "right" voting power.
             deciding_voting_power_buckets: hashmap! {
                 16 => 0,
             },

--- a/rs/nns/governance/src/neuron_store/metrics/tests.rs
+++ b/rs/nns/governance/src/neuron_store/metrics/tests.rs
@@ -287,7 +287,7 @@ fn test_compute_metrics() {
         non_self_authenticating_controller_neuron_subset_metrics: NeuronSubsetMetrics::default(),
         public_neuron_subset_metrics: NeuronSubsetMetrics::default(),
         still_losing_voting_power_neuron_subset_metrics: NeuronSubsetMetrics::default(),
-        done_losing_voting_power_neuron_subset_metrics: NeuronSubsetMetrics::default(),
+        fully_lost_voting_power_neuron_subset_metrics: NeuronSubsetMetrics::default(),
     };
     assert_eq!(
         NeuronMetrics {
@@ -296,7 +296,7 @@ fn test_compute_metrics() {
             ),
             public_neuron_subset_metrics: NeuronSubsetMetrics::default(),
             still_losing_voting_power_neuron_subset_metrics: NeuronSubsetMetrics::default(),
-            done_losing_voting_power_neuron_subset_metrics: NeuronSubsetMetrics::default(),
+            fully_lost_voting_power_neuron_subset_metrics: NeuronSubsetMetrics::default(),
 
             ..metrics
         },
@@ -802,7 +802,7 @@ fn test_compute_neuron_metrics_stale_and_expired_voting_power_neurons() {
 
     let NeuronMetrics {
         still_losing_voting_power_neuron_subset_metrics,
-        done_losing_voting_power_neuron_subset_metrics,
+        fully_lost_voting_power_neuron_subset_metrics,
         ..
     } = neuron_store.compute_neuron_metrics(E8, &VotingPowerEconomics::DEFAULT, now_seconds);
 
@@ -863,7 +863,7 @@ fn test_compute_neuron_metrics_stale_and_expired_voting_power_neurons() {
     );
 
     assert_eq!(
-        done_losing_voting_power_neuron_subset_metrics,
+        fully_lost_voting_power_neuron_subset_metrics,
         NeuronSubsetMetrics {
             count: 1,
 

--- a/rs/nns/governance/src/pb/conversions.rs
+++ b/rs/nns/governance/src/pb/conversions.rs
@@ -3409,8 +3409,8 @@ impl From<pb::governance::GovernanceCachedMetrics> for pb_api::governance::Gover
                 .non_self_authenticating_controller_neuron_subset_metrics
                 .map(|x| x.into()),
             public_neuron_subset_metrics: item.public_neuron_subset_metrics.map(|x| x.into()),
-            still_losing_voting_power_neuron_subset_metrics: item
-                .still_losing_voting_power_neuron_subset_metrics
+            declining_voting_power_neuron_subset_metrics: item
+                .declining_voting_power_neuron_subset_metrics
                 .map(|x| x.into()),
             fully_lost_voting_power_neuron_subset_metrics: item
                 .fully_lost_voting_power_neuron_subset_metrics
@@ -3472,8 +3472,8 @@ impl From<pb_api::governance::GovernanceCachedMetrics> for pb::governance::Gover
                 .non_self_authenticating_controller_neuron_subset_metrics
                 .map(|x| x.into()),
             public_neuron_subset_metrics: item.public_neuron_subset_metrics.map(|x| x.into()),
-            still_losing_voting_power_neuron_subset_metrics: item
-                .still_losing_voting_power_neuron_subset_metrics
+            declining_voting_power_neuron_subset_metrics: item
+                .declining_voting_power_neuron_subset_metrics
                 .map(|x| x.into()),
             fully_lost_voting_power_neuron_subset_metrics: item
                 .fully_lost_voting_power_neuron_subset_metrics

--- a/rs/nns/governance/src/pb/conversions.rs
+++ b/rs/nns/governance/src/pb/conversions.rs
@@ -3409,8 +3409,12 @@ impl From<pb::governance::GovernanceCachedMetrics> for pb_api::governance::Gover
                 .non_self_authenticating_controller_neuron_subset_metrics
                 .map(|x| x.into()),
             public_neuron_subset_metrics: item.public_neuron_subset_metrics.map(|x| x.into()),
-            still_losing_voting_power_neuron_subset_metrics: item.still_losing_voting_power_neuron_subset_metrics.map(|x| x.into()),
-            done_losing_voting_power_neuron_subset_metrics: item.done_losing_voting_power_neuron_subset_metrics.map(|x| x.into()),
+            still_losing_voting_power_neuron_subset_metrics: item
+                .still_losing_voting_power_neuron_subset_metrics
+                .map(|x| x.into()),
+            done_losing_voting_power_neuron_subset_metrics: item
+                .done_losing_voting_power_neuron_subset_metrics
+                .map(|x| x.into()),
         }
     }
 }
@@ -3468,8 +3472,12 @@ impl From<pb_api::governance::GovernanceCachedMetrics> for pb::governance::Gover
                 .non_self_authenticating_controller_neuron_subset_metrics
                 .map(|x| x.into()),
             public_neuron_subset_metrics: item.public_neuron_subset_metrics.map(|x| x.into()),
-            still_losing_voting_power_neuron_subset_metrics: item.still_losing_voting_power_neuron_subset_metrics.map(|x| x.into()),
-            done_losing_voting_power_neuron_subset_metrics: item.done_losing_voting_power_neuron_subset_metrics.map(|x| x.into()),
+            still_losing_voting_power_neuron_subset_metrics: item
+                .still_losing_voting_power_neuron_subset_metrics
+                .map(|x| x.into()),
+            done_losing_voting_power_neuron_subset_metrics: item
+                .done_losing_voting_power_neuron_subset_metrics
+                .map(|x| x.into()),
         }
     }
 }

--- a/rs/nns/governance/src/pb/conversions.rs
+++ b/rs/nns/governance/src/pb/conversions.rs
@@ -3409,6 +3409,8 @@ impl From<pb::governance::GovernanceCachedMetrics> for pb_api::governance::Gover
                 .non_self_authenticating_controller_neuron_subset_metrics
                 .map(|x| x.into()),
             public_neuron_subset_metrics: item.public_neuron_subset_metrics.map(|x| x.into()),
+            still_losing_voting_power_neuron_subset_metrics: item.still_losing_voting_power_neuron_subset_metrics.map(|x| x.into()),
+            done_losing_voting_power_neuron_subset_metrics: item.done_losing_voting_power_neuron_subset_metrics.map(|x| x.into()),
         }
     }
 }
@@ -3466,6 +3468,8 @@ impl From<pb_api::governance::GovernanceCachedMetrics> for pb::governance::Gover
                 .non_self_authenticating_controller_neuron_subset_metrics
                 .map(|x| x.into()),
             public_neuron_subset_metrics: item.public_neuron_subset_metrics.map(|x| x.into()),
+            still_losing_voting_power_neuron_subset_metrics: item.still_losing_voting_power_neuron_subset_metrics.map(|x| x.into()),
+            done_losing_voting_power_neuron_subset_metrics: item.done_losing_voting_power_neuron_subset_metrics.map(|x| x.into()),
         }
     }
 }

--- a/rs/nns/governance/src/pb/conversions.rs
+++ b/rs/nns/governance/src/pb/conversions.rs
@@ -3412,8 +3412,8 @@ impl From<pb::governance::GovernanceCachedMetrics> for pb_api::governance::Gover
             still_losing_voting_power_neuron_subset_metrics: item
                 .still_losing_voting_power_neuron_subset_metrics
                 .map(|x| x.into()),
-            done_losing_voting_power_neuron_subset_metrics: item
-                .done_losing_voting_power_neuron_subset_metrics
+            fully_lost_voting_power_neuron_subset_metrics: item
+                .fully_lost_voting_power_neuron_subset_metrics
                 .map(|x| x.into()),
         }
     }
@@ -3475,8 +3475,8 @@ impl From<pb_api::governance::GovernanceCachedMetrics> for pb::governance::Gover
             still_losing_voting_power_neuron_subset_metrics: item
                 .still_losing_voting_power_neuron_subset_metrics
                 .map(|x| x.into()),
-            done_losing_voting_power_neuron_subset_metrics: item
-                .done_losing_voting_power_neuron_subset_metrics
+            fully_lost_voting_power_neuron_subset_metrics: item
+                .fully_lost_voting_power_neuron_subset_metrics
                 .map(|x| x.into()),
         }
     }

--- a/rs/nns/governance/tests/governance.rs
+++ b/rs/nns/governance/tests/governance.rs
@@ -521,7 +521,7 @@ fn test_single_neuron_proposal_new() {
                                 ),
                             ),
                         ),
-                        GovernanceCachedMetricsChange::DoneLosingVotingPowerNeuronSubsetMetrics(
+                        GovernanceCachedMetricsChange::FullyLostVotingPowerNeuronSubsetMetrics(
                             comparable::OptionChange::Different(
                                 None,
                                 Some(
@@ -14197,7 +14197,7 @@ async fn test_metrics() {
         non_self_authenticating_controller_neuron_subset_metrics: None,
         public_neuron_subset_metrics: None,
         still_losing_voting_power_neuron_subset_metrics: None,
-        done_losing_voting_power_neuron_subset_metrics: None,
+        fully_lost_voting_power_neuron_subset_metrics: None,
     };
 
     let driver = fake::FakeDriver::default().at(60 * 60 * 24 * 30);
@@ -14218,7 +14218,7 @@ async fn test_metrics() {
             non_self_authenticating_controller_neuron_subset_metrics: None,
             public_neuron_subset_metrics: None,
             still_losing_voting_power_neuron_subset_metrics: None,
-            done_losing_voting_power_neuron_subset_metrics: None,
+            fully_lost_voting_power_neuron_subset_metrics: None,
 
             ..actual_metrics
         },
@@ -14238,7 +14238,7 @@ async fn test_metrics() {
             non_self_authenticating_controller_neuron_subset_metrics: None,
             public_neuron_subset_metrics: None,
             still_losing_voting_power_neuron_subset_metrics: None,
-            done_losing_voting_power_neuron_subset_metrics: None,
+            fully_lost_voting_power_neuron_subset_metrics: None,
 
             ..actual_metrics
         },
@@ -14295,7 +14295,7 @@ async fn test_metrics() {
         non_self_authenticating_controller_neuron_subset_metrics: None,
         public_neuron_subset_metrics: None,
         still_losing_voting_power_neuron_subset_metrics: None,
-        done_losing_voting_power_neuron_subset_metrics: None,
+        fully_lost_voting_power_neuron_subset_metrics: None,
     };
     let metrics = gov.get_metrics().expect("Error while querying metrics.");
     assert_eq!(
@@ -14307,7 +14307,7 @@ async fn test_metrics() {
             non_self_authenticating_controller_neuron_subset_metrics: None,
             public_neuron_subset_metrics: None,
             still_losing_voting_power_neuron_subset_metrics: None,
-            done_losing_voting_power_neuron_subset_metrics: None,
+            fully_lost_voting_power_neuron_subset_metrics: None,
 
             ..metrics
         },

--- a/rs/nns/governance/tests/governance.rs
+++ b/rs/nns/governance/tests/governance.rs
@@ -14122,6 +14122,8 @@ async fn test_metrics() {
         total_staked_e8s_non_self_authenticating_controller: Some(0xBEEF),
         non_self_authenticating_controller_neuron_subset_metrics: None,
         public_neuron_subset_metrics: None,
+        still_losing_voting_power_neuron_subset_metrics: None,
+        done_losing_voting_power_neuron_subset_metrics: None,
     };
 
     let driver = fake::FakeDriver::default().at(60 * 60 * 24 * 30);
@@ -14141,6 +14143,8 @@ async fn test_metrics() {
             total_staked_e8s_non_self_authenticating_controller: Some(0xBEEF),
             non_self_authenticating_controller_neuron_subset_metrics: None,
             public_neuron_subset_metrics: None,
+            still_losing_voting_power_neuron_subset_metrics: None,
+            done_losing_voting_power_neuron_subset_metrics: None,
 
             ..actual_metrics
         },
@@ -14159,6 +14163,8 @@ async fn test_metrics() {
             total_staked_e8s_non_self_authenticating_controller: Some(0xBEEF),
             non_self_authenticating_controller_neuron_subset_metrics: None,
             public_neuron_subset_metrics: None,
+            still_losing_voting_power_neuron_subset_metrics: None,
+            done_losing_voting_power_neuron_subset_metrics: None,
 
             ..actual_metrics
         },
@@ -14214,6 +14220,8 @@ async fn test_metrics() {
         total_staked_e8s_non_self_authenticating_controller: Some(0xBEEF),
         non_self_authenticating_controller_neuron_subset_metrics: None,
         public_neuron_subset_metrics: None,
+        still_losing_voting_power_neuron_subset_metrics: None,
+        done_losing_voting_power_neuron_subset_metrics: None,
     };
     let metrics = gov.get_metrics().expect("Error while querying metrics.");
     assert_eq!(
@@ -14224,6 +14232,8 @@ async fn test_metrics() {
             total_staked_e8s_non_self_authenticating_controller: Some(0xBEEF),
             non_self_authenticating_controller_neuron_subset_metrics: None,
             public_neuron_subset_metrics: None,
+            still_losing_voting_power_neuron_subset_metrics: None,
+            done_losing_voting_power_neuron_subset_metrics: None,
 
             ..metrics
         },

--- a/rs/nns/governance/tests/governance.rs
+++ b/rs/nns/governance/tests/governance.rs
@@ -484,6 +484,80 @@ fn test_single_neuron_proposal_new() {
                                 ),
                             ),
                         ),
+                        GovernanceCachedMetricsChange::StillLosingVotingPowerNeuronSubsetMetrics(
+                            comparable::OptionChange::Different(
+                                None,
+                                Some(
+                                    ic_nns_governance::pb::v1::governance::governance_cached_metrics::NeuronSubsetMetricsDesc {
+                                        count: Some(
+                                            0,
+                                        ),
+                                        total_staked_e8s: Some(
+                                            0,
+                                        ),
+                                        total_staked_maturity_e8s_equivalent: Some(
+                                            0,
+                                        ),
+                                        total_maturity_e8s_equivalent: Some(
+                                            0,
+                                        ),
+                                        total_voting_power: Some(
+                                            0,
+                                        ),
+                                        total_deciding_voting_power: Some(
+                                            0,
+                                        ),
+                                        total_potential_voting_power: Some(
+                                            0,
+                                        ),
+                                        count_buckets: btreemap! {},
+                                        staked_e8s_buckets: btreemap! {},
+                                        staked_maturity_e8s_equivalent_buckets: btreemap! {},
+                                        maturity_e8s_equivalent_buckets: btreemap! {},
+                                        voting_power_buckets: btreemap! {},
+                                        deciding_voting_power_buckets: btreemap! {},
+                                        potential_voting_power_buckets: btreemap! {},
+                                    },
+                                ),
+                            ),
+                        ),
+                        GovernanceCachedMetricsChange::DoneLosingVotingPowerNeuronSubsetMetrics(
+                            comparable::OptionChange::Different(
+                                None,
+                                Some(
+                                    ic_nns_governance::pb::v1::governance::governance_cached_metrics::NeuronSubsetMetricsDesc {
+                                        count: Some(
+                                            0,
+                                        ),
+                                        total_staked_e8s: Some(
+                                            0,
+                                        ),
+                                        total_staked_maturity_e8s_equivalent: Some(
+                                            0,
+                                        ),
+                                        total_maturity_e8s_equivalent: Some(
+                                            0,
+                                        ),
+                                        total_voting_power: Some(
+                                            0,
+                                        ),
+                                        total_deciding_voting_power: Some(
+                                            0,
+                                        ),
+                                        total_potential_voting_power: Some(
+                                            0,
+                                        ),
+                                        count_buckets: btreemap! {},
+                                        staked_e8s_buckets: btreemap! {},
+                                        staked_maturity_e8s_equivalent_buckets: btreemap! {},
+                                        maturity_e8s_equivalent_buckets: btreemap! {},
+                                        voting_power_buckets: btreemap! {},
+                                        deciding_voting_power_buckets: btreemap! {},
+                                        potential_voting_power_buckets: btreemap! {},
+                                    },
+                                ),
+                            ),
+                        ),
                     ]),
                 )),
                 GovernanceChange::CachedDailyMaturityModulationBasisPoints(

--- a/rs/nns/governance/tests/governance.rs
+++ b/rs/nns/governance/tests/governance.rs
@@ -484,7 +484,7 @@ fn test_single_neuron_proposal_new() {
                                 ),
                             ),
                         ),
-                        GovernanceCachedMetricsChange::StillLosingVotingPowerNeuronSubsetMetrics(
+                        GovernanceCachedMetricsChange::DecliningVotingPowerNeuronSubsetMetrics(
                             comparable::OptionChange::Different(
                                 None,
                                 Some(
@@ -14196,7 +14196,7 @@ async fn test_metrics() {
         total_staked_e8s_non_self_authenticating_controller: Some(0xBEEF),
         non_self_authenticating_controller_neuron_subset_metrics: None,
         public_neuron_subset_metrics: None,
-        still_losing_voting_power_neuron_subset_metrics: None,
+        declining_voting_power_neuron_subset_metrics: None,
         fully_lost_voting_power_neuron_subset_metrics: None,
     };
 
@@ -14217,7 +14217,7 @@ async fn test_metrics() {
             total_staked_e8s_non_self_authenticating_controller: Some(0xBEEF),
             non_self_authenticating_controller_neuron_subset_metrics: None,
             public_neuron_subset_metrics: None,
-            still_losing_voting_power_neuron_subset_metrics: None,
+            declining_voting_power_neuron_subset_metrics: None,
             fully_lost_voting_power_neuron_subset_metrics: None,
 
             ..actual_metrics
@@ -14237,7 +14237,7 @@ async fn test_metrics() {
             total_staked_e8s_non_self_authenticating_controller: Some(0xBEEF),
             non_self_authenticating_controller_neuron_subset_metrics: None,
             public_neuron_subset_metrics: None,
-            still_losing_voting_power_neuron_subset_metrics: None,
+            declining_voting_power_neuron_subset_metrics: None,
             fully_lost_voting_power_neuron_subset_metrics: None,
 
             ..actual_metrics
@@ -14294,7 +14294,7 @@ async fn test_metrics() {
         total_staked_e8s_non_self_authenticating_controller: Some(0xBEEF),
         non_self_authenticating_controller_neuron_subset_metrics: None,
         public_neuron_subset_metrics: None,
-        still_losing_voting_power_neuron_subset_metrics: None,
+        declining_voting_power_neuron_subset_metrics: None,
         fully_lost_voting_power_neuron_subset_metrics: None,
     };
     let metrics = gov.get_metrics().expect("Error while querying metrics.");
@@ -14306,7 +14306,7 @@ async fn test_metrics() {
             total_staked_e8s_non_self_authenticating_controller: Some(0xBEEF),
             non_self_authenticating_controller_neuron_subset_metrics: None,
             public_neuron_subset_metrics: None,
-            still_losing_voting_power_neuron_subset_metrics: None,
+            declining_voting_power_neuron_subset_metrics: None,
             fully_lost_voting_power_neuron_subset_metrics: None,
 
             ..metrics


### PR DESCRIPTION
Here,

* stale = time since voting power was refreshed is between strictly 6 and 7 months (or whatever VotingPowerEconomics dictates).
* expired = time since voting power was refreshed is >= 7 months (again, per VotingPowerEconomics).

I think the main thing we really care about here is the number of such neurons in those two (sub)categories. However, it is not much harder to gather additional statistics (thanks to existing code for compiling statistics for arbitrary neuron (sub)categories). Therefore, a whole bunch of other stats about these two subcategories of neurons is also exported.

FWIW, if you strip away the highly repetitive code (and don't count test code), this change is actually pretty small.

# References

This is part of the "periodic confirmation" feature that was recently approved in proposal [132411][prop].

[prop]: https://dashboard.internetcomputer.org/proposal/132411

Closes [NNS1-3418].

[NNS1-3418]: https://dfinity.atlassian.net/browse/NNS1-3418

[👈 Previous PR][prev]

[prev]: https://github.com/dfinity/ic/pull/3070