### PR TITLE
feat(sns): Recover SNS from not knowing its deployed version

### DIFF
--- a/rs/sns/governance/BUILD.bazel
+++ b/rs/sns/governance/BUILD.bazel
@@ -245,13 +245,27 @@ generated_files_check(
     ],
 )
 
-# Usage:
-# bazel run //rs/sns/governance:governance-canbench for benchmarking (the output shoudl look like `canbench/canbench_results.yml`).
-# bazel run //rs/sns/governance:governance-canbench_update for updating the results file (see `canbench/canbench_results.yml`).
-# bazel test //rs/sns/governance:governance_canbench_test for checking if the results file is up to date.
+# Usage
+# =====
+#
+# For benchmarking (see `canbench/canbench_results.yml`):
+# ```
+# bazel run //rs/sns/governance:governance-canbench
+# ```
+#
+# For updating the results file:
+# ```
+# bazel run //rs/sns/governance:governance-canbench_update
+# ```
+#
+# To run the test:
+# ```
+# bazel test //rs/sns/governance:governance_canbench_test
+# ```
+#
 # Currently, updating the results file is not automated, and there are no tests to avoid
-# regression. For now, we can use it as an example for benchmarking as part of an
-# investigation of potential performance issues, or when we make a change that can affect
+# regression. For now, we can use it as an example for benchmarking as part
+# of an investigation of potential performance issues, or when we make a change that can affect
 # the performance measured in this benchmark.
 rust_canbench(
     name = "governance-canbench",

--- a/rs/sns/governance/canbench/canbench_results.yml
+++ b/rs/sns/governance/canbench/canbench_results.yml
@@ -1,8 +1,8 @@
 benches:
   bench_example:
     total:
-      instructions: 5638
+      instructions: 4738
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
-version: 0.1.7
+version: 0.1.8

--- a/rs/sns/governance/src/governance.rs
+++ b/rs/sns/governance/src/governance.rs
@@ -2614,13 +2614,18 @@ impl Governance {
 
         let root_canister_id = self.proto.root_canister_id_or_panic();
 
-        let deployed_version = get_running_version(&*self.env, root_canister_id).await?;
+        let new_deployed_version = get_running_version(&*self.env, root_canister_id).await?;
+
+        // Re-check that a reentrant call to this function did not yet update the state.
+        if let Some(deployed_version) = self.proto.deployed_version.clone() {
+            return Ok(deployed_version);
+        }
 
         self.proto
             .deployed_version
-            .replace(deployed_version.clone());
+            .replace(new_deployed_version.clone());
 
-        Ok(deployed_version)
+        Ok(new_deployed_version)
     }
 
     /// Return `Ok(true)` if the upgrade was completed successfully, return `Ok(false)` if an

--- a/rs/sns/governance/src/governance.rs
+++ b/rs/sns/governance/src/governance.rs
@@ -441,12 +441,6 @@ impl GovernanceProto {
         }
     }
 
-    /// Gets the current deployed version of the SNS or panics.
-    pub fn deployed_version_or_panic(&self) -> Version {
-        self.deployed_version_or_err()
-            .expect("GovernanceProto.deployed_version must be set.")
-    }
-
     /// Returns 0 if maturity modulation is disabled (per
     /// nervous_system_parameters.maturity_modulation_disabled). Otherwise,
     /// returns the value in self.maturity_modulation.current_basis_points. If
@@ -2603,6 +2597,32 @@ impl Governance {
         Ok(())
     }
 
+    /// Best effort to return the deployed version of this SNS.
+    ///
+    /// Normally, the SNS should always have a deployed version, in which case it is returned.
+    /// If this is not the case for whatever reason, this function tries to fetch the running
+    /// version, initialize deployed version with it, and return a copy.
+    pub async fn get_or_reset_deployed_version(&mut self) -> Result<Version, String> {
+        if let Some(deployed_version) = self.proto.deployed_version.clone() {
+            return Ok(deployed_version);
+        }
+
+        log!(
+            ERROR,
+            "The SNS does not have a deployed version. Attempting to reset it ..."
+        );
+
+        let root_canister_id = self.proto.root_canister_id_or_panic();
+
+        let deployed_version = get_running_version(&*self.env, root_canister_id).await?;
+
+        self.proto
+            .deployed_version
+            .replace(deployed_version.clone());
+
+        Ok(deployed_version)
+    }
+
     /// Return `Ok(true)` if the upgrade was completed successfully, return `Ok(false)` if an
     /// upgrade was successfully kicked-off, but its completion is pending.
     async fn perform_upgrade_to_next_sns_version_legacy(
@@ -2611,7 +2631,13 @@ impl Governance {
     ) -> Result<bool, GovernanceError> {
         self.check_no_upgrades_in_progress(Some(proposal_id))?;
 
-        let current_version = self.proto.deployed_version_or_panic();
+        let current_version = self.get_or_reset_deployed_version().await.map_err(|err| {
+            GovernanceError::new_with_message(
+                ErrorType::External,
+                format!("Could not execute proposal: {}", err),
+            )
+        })?;
+
         let root_canister_id = self.proto.root_canister_id_or_panic();
 
         let UpgradeSnsParams {
@@ -2621,10 +2647,10 @@ impl Governance {
             canister_ids_to_upgrade,
         } = get_upgrade_params(&*self.env, root_canister_id, &current_version)
             .await
-            .map_err(|e| {
+            .map_err(|err| {
                 GovernanceError::new_with_message(
                     ErrorType::InvalidProposal,
-                    format!("Could not execute proposal: {}", e),
+                    format!("Could not execute proposal: {}", err),
                 )
             })?;
 
@@ -2864,7 +2890,13 @@ impl Governance {
     ) -> Result<(), GovernanceError> {
         self.check_no_upgrades_in_progress(Some(proposal_id))?;
 
-        let current_version = self.proto.deployed_version_or_panic();
+        let current_version = self.get_or_reset_deployed_version().await.map_err(|err| {
+            GovernanceError::new_with_message(
+                ErrorType::External,
+                format!("Could not execute proposal: {}", err),
+            )
+        })?;
+
         let ledger_canister_id = self.proto.ledger_canister_id_or_panic();
 
         let ledger_canister_info = self.env
@@ -4839,9 +4871,17 @@ impl Governance {
         self.maybe_gc();
     }
 
-    // Acquires the "upgrade periodic task lock" (a lock shared between all periodic tasks that relate to upgrades)
-    // if it is currently released or was last acquired over UPGRADE_PERIODIC_TASK_LOCK_TIMEOUT_SECONDS ago.
-    fn acquire_upgrade_periodic_task_lock(&mut self) -> bool {
+    /// Attempts to acquire the lock over SNS upgrade-related periodic tasks.
+    ///
+    /// Succeeds if the lock is currently released or was last acquired
+    /// over `UPGRADE_PERIODIC_TASK_LOCK_TIMEOUT_SECONDS` ago.
+    ///
+    /// Returns whether the lock was acquired.
+    ///
+    /// This function is made public so that it can be called from
+    /// rs/sns/governance/tests/governance.rs where we need to disable upgrade-related periodic
+    /// tasks while testing a orthogonal SNS features (e.g., disburse maturity).
+    pub fn acquire_upgrade_periodic_task_lock(&mut self) -> bool {
         let now = self.env.now();
         match self.upgrade_periodic_task_lock {
             Some(time_acquired)
@@ -4871,10 +4911,12 @@ impl Governance {
             return;
         }
 
-        let Some(deployed_version) = self.proto.deployed_version.clone() else {
-            // TODO(NNS1-3445): there should be some way to recover from this state.
-            log!(ERROR, "No deployed version! This is an internal bug");
-            return;
+        let deployed_version = match self.get_or_reset_deployed_version().await {
+            Ok(deployed_version) => deployed_version,
+            Err(err) => {
+                log!(ERROR, "Cannot get or reset deployed version: {}", err);
+                return;
+            }
         };
 
         let upgrade_steps = self.get_or_reset_upgrade_steps(&deployed_version);

--- a/rs/sns/governance/src/proposal.rs
+++ b/rs/sns/governance/src/proposal.rs
@@ -414,15 +414,18 @@ pub(crate) async fn validate_and_render_action(
             validate_and_render_upgrade_sns_controlled_canister(upgrade)
         }
         Action::UpgradeSnsToNextVersion(upgrade_sns) => {
-            let current_version = governance_proto.deployed_version_or_panic();
-
-            validate_and_render_upgrade_sns_to_next_version(
-                upgrade_sns,
-                env,
-                root_canister_id,
-                current_version,
-            )
-            .await
+            match governance_proto.deployed_version_or_err() {
+                Ok(current_version) => {
+                    validate_and_render_upgrade_sns_to_next_version(
+                        upgrade_sns,
+                        env,
+                        root_canister_id,
+                        current_version,
+                    )
+                    .await
+                }
+                Err(err) => Err(err),
+            }
         }
         proposal::Action::AddGenericNervousSystemFunction(function_to_add) => {
             validate_and_render_add_generic_nervous_system_function(

--- a/rs/sns/governance/tests/fixtures/mod.rs
+++ b/rs/sns/governance/tests/fixtures/mod.rs
@@ -9,10 +9,9 @@ use ic_sns_governance::{
     governance::{Governance, ValidGovernanceProto},
     pb::v1::{
         get_neuron_response, get_proposal_response,
-        governance::{MaturityModulation, Mode, SnsMetadata},
-        manage_neuron,
+        governance::{MaturityModulation, Mode, SnsMetadata, Version},
         manage_neuron::{
-            AddNeuronPermissions, MergeMaturity, RegisterVote, RemoveNeuronPermissions,
+            self, AddNeuronPermissions, MergeMaturity, RegisterVote, RemoveNeuronPermissions,
         },
         manage_neuron_response::{
             self, AddNeuronPermissionsResponse, FollowResponse, MergeMaturityResponse,
@@ -430,6 +429,13 @@ impl GovernanceCanisterFixture {
             .lock()
             .unwrap()
             .now += delta_seconds;
+        self
+    }
+
+    /// Ensures that SNS upgrade features are not going to produce any external calls that are
+    /// orthogonal to this test scenario, as they would require setting up mock responses.
+    pub fn temporarily_disable_sns_upgrades(&mut self) -> &mut Self {
+        assert!(self.governance.acquire_upgrade_periodic_task_lock());
         self
     }
 
@@ -854,6 +860,7 @@ impl Default for GovernanceCanisterFixtureBuilder {
                     current_basis_points: Some(0),
                     updated_at_timestamp_seconds: Some(1),
                 }),
+                deployed_version: Some(Version::default()),
                 ..Default::default()
             },
             sns_ledger_transforms: Vec::default(),

--- a/rs/sns/governance/tests/governance.rs
+++ b/rs/sns/governance/tests/governance.rs
@@ -304,14 +304,20 @@ fn test_disburse_maturity_succeeds_to_self() {
     assert_eq!(account_balance_before_disbursal, account_balance);
 
     // Advance time by a few days, but without triggering disbursal finalization.
-    env.gov_fixture.advance_time_by(6 * ONE_DAY_SECONDS);
-    env.gov_fixture.run_periodic_tasks_now();
+    env.gov_fixture
+        .advance_time_by(6 * ONE_DAY_SECONDS)
+        .temporarily_disable_sns_upgrades()
+        .run_periodic_tasks_now();
+
     let neuron = env.gov_fixture.get_neuron(&env.neuron_id);
     assert_eq!(neuron.disburse_maturity_in_progress.len(), 1);
 
     // Advance more, to hit 7-day period, and to trigger disbursal finalization.
-    env.gov_fixture.advance_time_by(ONE_DAY_SECONDS + 10);
-    env.gov_fixture.run_periodic_tasks_now();
+    env.gov_fixture
+        .advance_time_by(ONE_DAY_SECONDS + 10)
+        .temporarily_disable_sns_upgrades()
+        .run_periodic_tasks_now();
+
     let neuron = env.gov_fixture.get_neuron(&env.neuron_id);
     assert_eq!(neuron.disburse_maturity_in_progress.len(), 0);
 
@@ -409,14 +415,20 @@ fn test_disburse_maturity_succeeds_to_other() {
     assert_eq!(receiver_balance_before_disbursal, account_balance);
 
     // Advance time by a few days, but without triggering disbursal finalization.
-    env.gov_fixture.advance_time_by(6 * ONE_DAY_SECONDS);
-    env.gov_fixture.run_periodic_tasks_now();
+    env.gov_fixture
+        .advance_time_by(6 * ONE_DAY_SECONDS)
+        .temporarily_disable_sns_upgrades()
+        .run_periodic_tasks_now();
+
     let neuron = env.gov_fixture.get_neuron(&env.neuron_id);
     assert_eq!(neuron.disburse_maturity_in_progress.len(), 1);
 
     // Advance more, to hit 7-day period, and to trigger disbursal finalization.
-    env.gov_fixture.advance_time_by(ONE_DAY_SECONDS + 10);
-    env.gov_fixture.run_periodic_tasks_now();
+    env.gov_fixture
+        .advance_time_by(ONE_DAY_SECONDS + 10)
+        .temporarily_disable_sns_upgrades()
+        .run_periodic_tasks_now();
+
     let neuron = env.gov_fixture.get_neuron(&env.neuron_id);
     assert_eq!(neuron.disburse_maturity_in_progress.len(), 0);
 
@@ -498,7 +510,10 @@ fn test_disburse_maturity_succeeds_with_multiple_operations() {
     }
 
     // Advance time, to trigger disbursal finalization.
-    env.gov_fixture.advance_time_by(7 * ONE_DAY_SECONDS + 10);
+    env.gov_fixture
+        .advance_time_by(7 * ONE_DAY_SECONDS + 10)
+        .temporarily_disable_sns_upgrades();
+
     let mut remaining_maturity_e8s = earned_maturity_e8s;
     for (i, (percentage, destination)) in percentage_and_destination.iter().enumerate() {
         let destination_account = icrc_ledger_types::icrc1::account::Account {
@@ -2628,7 +2643,9 @@ async fn assert_disburse_maturity_with_modulation_disburses_correctly(
         .create();
 
     // This is supposed to cause Governance to poll CMC for the maturity modulation.
-    canister_fixture.run_periodic_tasks_now();
+    canister_fixture
+        .temporarily_disable_sns_upgrades()
+        .run_periodic_tasks_now();
 
     // Get the Neuron and assert its maturity is set as expected
     let neuron = canister_fixture.get_neuron(&neuron_id);
@@ -2675,8 +2692,10 @@ async fn assert_disburse_maturity_with_modulation_disburses_correctly(
     let neuron = canister_fixture.get_neuron(&neuron_id);
     assert_eq!(neuron.maturity_e8s_equivalent, 0);
 
-    canister_fixture.advance_time_by(7 * ONE_DAY_SECONDS + 1);
-    canister_fixture.run_periodic_tasks_now();
+    canister_fixture
+        .advance_time_by(7 * ONE_DAY_SECONDS + 1)
+        .temporarily_disable_sns_upgrades()
+        .run_periodic_tasks_now();
 
     // Assert that the Neuron owner's account balance has increased the expected amount
     let account_balance_after_disbursal =
@@ -2714,7 +2733,9 @@ async fn test_disburse_maturity_applied_modulation_at_end_of_window() {
         .create();
 
     // This is supposed to cause Governance to poll CMC for the maturity modulation.
-    canister_fixture.run_periodic_tasks_now();
+    canister_fixture
+        .temporarily_disable_sns_upgrades()
+        .run_periodic_tasks_now();
 
     let current_basis_points = canister_fixture
         .get_maturity_modulation()
@@ -2782,8 +2803,11 @@ async fn test_disburse_maturity_applied_modulation_at_end_of_window() {
         .unwrap() = time_of_disbursement_maturity_modulation_basis_points;
 
     // Advancing time and triggering periodic tasks should force a query of the new modulation.
-    canister_fixture.advance_time_by(2 * ONE_DAY_SECONDS);
-    canister_fixture.run_periodic_tasks_now();
+    canister_fixture
+        .advance_time_by(2 * ONE_DAY_SECONDS)
+        .temporarily_disable_sns_upgrades()
+        .run_periodic_tasks_now();
+
     let current_basis_points = canister_fixture
         .get_maturity_modulation()
         .maturity_modulation
@@ -2802,8 +2826,10 @@ async fn test_disburse_maturity_applied_modulation_at_end_of_window() {
     assert_eq!(account_balance_before_disbursal, 0);
 
     // Advancing time and triggering periodic tasks should trigger the final disbursal.
-    canister_fixture.advance_time_by(5 * ONE_DAY_SECONDS + 1);
-    canister_fixture.run_periodic_tasks_now();
+    canister_fixture
+        .advance_time_by(5 * ONE_DAY_SECONDS + 1)
+        .temporarily_disable_sns_upgrades()
+        .run_periodic_tasks_now();
 
     // Assert that the Neuron owner's account balance has increased the expected amount
     let account_balance_after_disbursal =


### PR DESCRIPTION
This PR enables SNS Governance to recover from a corrupted state in which a deployed version is not specified. The recovery is a best-effort attempt, currently done via calling SNS Root's `get_sns_canisters_summary` function.