### PR TITLE
fix(ICP_Ledger): FI-1590: Change length type in GetBlocksArgs

### DIFF
--- a/rs/ledger_suite/icp/index/src/main.rs
+++ b/rs/ledger_suite/icp/index/src/main.rs
@@ -252,7 +252,7 @@ async fn get_blocks_from_ledger(start: u64) -> Result<QueryEncodedBlocksResponse
     let ledger_id = with_state(|state| state.ledger_id);
     let req = GetBlocksArgs {
         start,
-        length: DEFAULT_MAX_BLOCKS_PER_RESPONSE,
+        length: DEFAULT_MAX_BLOCKS_PER_RESPONSE as u64,
     };
     let (res,): (QueryEncodedBlocksResponse,) =
         ic_cdk::call(ledger_id, "query_encoded_blocks", (req,))
@@ -266,7 +266,7 @@ async fn get_blocks_from_archive(
 ) -> Result<Vec<EncodedBlock>, String> {
     let req = GetBlocksArgs {
         start: block_range.start,
-        length: block_range.length as usize,
+        length: block_range.length,
     };
     let (blocks_res,): (GetEncodedBlocksResult,) = ic_cdk::call(
         block_range.callback.canister_id,

--- a/rs/ledger_suite/icp/ledger/src/main.rs
+++ b/rs/ledger_suite/icp/ledger/src/main.rs
@@ -1237,10 +1237,10 @@ fn iter_blocks_() {
 #[export_name = "canister_query get_blocks_pb"]
 fn get_blocks_() {
     over(protobuf, |GetBlocksArgs { start, length }| {
-        let length = std::cmp::min(length, max_blocks_per_request(&caller()));
+        let length = std::cmp::min(length, max_blocks_per_request(&caller()) as u64);
         let blockchain = &LEDGER.read().unwrap().blockchain;
         let start_offset = blockchain.num_archived_blocks();
-        icp_ledger::get_blocks(&blockchain.blocks, start_offset, start, length)
+        icp_ledger::get_blocks(&blockchain.blocks, start_offset, start, length as usize)
     });
 }
 
@@ -1252,7 +1252,7 @@ fn icrc1_supported_standards_candid() {
 #[candid_method(query, rename = "query_blocks")]
 fn query_blocks(GetBlocksArgs { start, length }: GetBlocksArgs) -> QueryBlocksResponse {
     let ledger = LEDGER.read().unwrap();
-    let locations = block_locations(&*ledger, start, length);
+    let locations = block_locations(&*ledger, start, length.min(usize::MAX as u64) as usize);
 
     let local_blocks =
         range_utils::take(&locations.local_blocks, max_blocks_per_request(&caller()));
@@ -1463,7 +1463,7 @@ fn query_encoded_blocks(
     GetBlocksArgs { start, length }: GetBlocksArgs,
 ) -> QueryEncodedBlocksResponse {
     let ledger = LEDGER.read().unwrap();
-    let locations = block_locations(&*ledger, start, length);
+    let locations = block_locations(&*ledger, start, length.min(usize::MAX as u64) as usize);
 
     let local_blocks =
         range_utils::take(&locations.local_blocks, max_blocks_per_request(&caller()));

--- a/rs/ledger_suite/icp/ledger/tests/tests.rs
+++ b/rs/ledger_suite/icp/ledger/tests/tests.rs
@@ -1751,11 +1751,14 @@ fn test_query_blocks_large_length() {
     .expect("should successfully decode QueryBlocksResponse");
     // Verify that we have more blocks in the ledger than can be returned in a single query.
     assert_eq!(res.chain_length, (MAX_BLOCKS_PER_REQUEST + 1) as u64);
-    // Verify that the number of blocks in the response is limited to MAX_BLOCKS_PER_REQUEST, and
-    // that it is also larger than 0 (which would be the case if the length in the request was
-    // incorrectly cast to a wasm32 `usize` (`u32`)).
+    // Verify that the number of blocks in the response is limited to MAX_BLOCKS_PER_REQUEST.
     assert_eq!(res.blocks.len(), MAX_BLOCKS_PER_REQUEST);
-    assert!(MAX_BLOCKS_PER_REQUEST > 0);
+    // Also verify that the maximum number of blocks per request is larger than 0, in case the
+    // length `(u32::MAX as u64) + 1` in the request was incorrectly cast to a wasm32 `usize`
+    // (`u32`)).
+    if MAX_BLOCKS_PER_REQUEST == 0 {
+        panic!("MAX_BLOCKS_PER_REQUEST should be larger than 0");
+    }
 }
 
 mod metrics {

--- a/rs/ledger_suite/icp/ledger/tests/tests.rs
+++ b/rs/ledger_suite/icp/ledger/tests/tests.rs
@@ -104,11 +104,7 @@ fn query_blocks(
             PrincipalId(caller),
             ledger,
             "query_blocks",
-            Encode!(&GetBlocksArgs {
-                start,
-                length: length as usize
-            })
-            .unwrap()
+            Encode!(&GetBlocksArgs { start, length }).unwrap()
         )
         .expect("failed to query blocks")
         .bytes(),
@@ -129,11 +125,7 @@ fn query_encoded_blocks(
             PrincipalId(caller),
             ledger,
             "query_encoded_blocks",
-            Encode!(&GetBlocksArgs {
-                start,
-                length: length as usize
-            })
-            .unwrap()
+            Encode!(&GetBlocksArgs { start, length }).unwrap()
         )
         .expect("failed to query blocks")
         .bytes(),
@@ -154,9 +146,12 @@ fn get_blocks_pb(
             PrincipalId(caller),
             ledger,
             "get_blocks_pb",
-            ProtoBuf(GetBlocksArgs { start, length })
-                .into_bytes()
-                .unwrap(),
+            ProtoBuf(GetBlocksArgs {
+                start,
+                length: length as u64,
+            })
+            .into_bytes()
+            .unwrap(),
         )
         .expect("failed to query blocks")
         .bytes();
@@ -744,7 +739,7 @@ fn check_block_endpoint_limits() {
 
     let get_blocks_args = Encode!(&GetBlocksArgs {
         start: 0,
-        length: MAX_BLOCKS_PER_REQUEST + 1
+        length: (MAX_BLOCKS_PER_REQUEST + 1) as u64
     })
     .unwrap();
 
@@ -799,7 +794,7 @@ fn check_block_endpoint_limits() {
     // get_blocks_pb
     let get_blocks_pb_args = ProtoBuf(GetBlocksArgs {
         start: 0,
-        length: MAX_BLOCKS_PER_REQUEST + 1,
+        length: (MAX_BLOCKS_PER_REQUEST + 1) as u64,
     })
     .into_bytes()
     .unwrap();
@@ -953,7 +948,7 @@ fn check_archive_block_endpoint_limits() {
 
     let get_blocks_args = Encode!(&GetBlocksArgs {
         start: 0,
-        length: MAX_BLOCKS_PER_REQUEST + 1
+        length: (MAX_BLOCKS_PER_REQUEST + 1) as u64
     })
     .unwrap();
 
@@ -1046,7 +1041,7 @@ fn check_archive_block_endpoint_limits() {
     // get_blocks_pb
     let get_blocks_pb_args = ProtoBuf(GetBlocksArgs {
         start: 0,
-        length: MAX_BLOCKS_PER_REQUEST + 1,
+        length: (MAX_BLOCKS_PER_REQUEST + 1) as u64,
     })
     .into_bytes()
     .unwrap();
@@ -1649,7 +1644,7 @@ fn test_query_archived_blocks() {
             callback.method.to_owned(),
             Encode!(&GetBlocksArgs {
                 start: *start,
-                length: *length as usize
+                length: *length
             })
             .unwrap()
         )
@@ -1732,7 +1727,7 @@ fn test_query_blocks_large_length() {
         .expect("Unable to install the Ledger canister with the new init");
 
     // query_blocks
-    match Decode!(
+    let res = Decode!(
         &env.execute_ingress(
             canister_id,
             "query_blocks",
@@ -1745,18 +1740,9 @@ fn test_query_blocks_large_length() {
         .expect("failed to query blocks")
         .bytes(),
         QueryBlocksResponse
-    ) {
-        Ok(query_blocks_response) => {
-            panic!("Expected an error, but got: {:?}", query_blocks_response);
-        }
-        Err(err) => {
-            println!("query_blocks returned an error: {:?}", err);
-            assert!(err.to_string().contains(&hex::encode(
-                "Fail to decode argument 0 from table0 to record { start : nat64; length : nat64 }"
-                    .as_bytes()
-            )));
-        }
-    }
+    )
+    .expect("should successfully decode QueryBlocksResponse");
+    assert_eq!(res.chain_length, 0);
 }
 
 mod metrics {

--- a/rs/ledger_suite/icp/src/lib.rs
+++ b/rs/ledger_suite/icp/src/lib.rs
@@ -1096,7 +1096,7 @@ pub struct TipOfChainRes {
 #[derive(Clone, Debug, CandidType, Deserialize, Serialize)]
 pub struct GetBlocksArgs {
     pub start: BlockIndex,
-    pub length: usize,
+    pub length: u64,
 }
 
 #[derive(Clone, Debug, CandidType, Deserialize, Serialize)]

--- a/rs/ledger_suite/icp/src/validate_endpoints.rs
+++ b/rs/ledger_suite/icp/src/validate_endpoints.rs
@@ -147,20 +147,16 @@ impl ToProto for GetBlocksArgs {
     type Proto = protobuf::GetBlocksRequest;
 
     fn from_proto(pb: Self::Proto) -> Result<Self, String> {
-        let length = pb
-            .length
-            .try_into()
-            .map_err(|_| format!("{} count not be converted to a usize", pb.length))?;
         Ok(GetBlocksArgs {
             start: pb.start,
-            length,
+            length: pb.length,
         })
     }
 
     fn into_proto(self) -> Self::Proto {
         protobuf::GetBlocksRequest {
             start: self.start,
-            length: self.length as u64,
+            length: self.length,
         }
     }
 }

--- a/rs/ledger_suite/icp/test_utils/src/pocket_ic_helpers/ledger.rs
+++ b/rs/ledger_suite/icp/test_utils/src/pocket_ic_helpers/ledger.rs
@@ -25,7 +25,7 @@ pub fn account_balance(pocket_ic: &PocketIc, account: &AccountIdentifier) -> Tok
     )
 }
 
-pub fn query_blocks(pocket_ic: &PocketIc, start: BlockIndex, length: usize) -> QueryBlocksResponse {
+pub fn query_blocks(pocket_ic: &PocketIc, start: BlockIndex, length: u64) -> QueryBlocksResponse {
     super::query_or_panic(
         pocket_ic,
         candid::Principal::from(LEDGER_CANISTER_ID),
@@ -41,7 +41,7 @@ pub fn query_encoded_blocks(
 ) -> Vec<Block> {
     let get_blocks_args = GetBlocksArgs {
         start: 0u64,
-        length: MAX_BLOCKS_PER_REQUEST,
+        length: MAX_BLOCKS_PER_REQUEST as u64,
     };
     let query_encoded_blocks_response: QueryEncodedBlocksResponse = super::query_or_panic(
         pocket_ic,
@@ -55,7 +55,7 @@ pub fn query_encoded_blocks(
         for archived in query_encoded_blocks_response.archived_blocks {
             let req = GetBlocksArgs {
                 start: archived.start,
-                length: archived.length as usize,
+                length: archived.length,
             };
             let canister_id = archived.callback.canister_id;
             let query_encoded_blocks_response: icp_ledger::GetEncodedBlocksResult =

--- a/rs/ledger_suite/icp/test_utils/src/state_machine_helpers/ledger.rs
+++ b/rs/ledger_suite/icp/test_utils/src/state_machine_helpers/ledger.rs
@@ -15,7 +15,7 @@ pub fn icp_get_blocks(
 ) -> Vec<icp_ledger::Block> {
     let req = GetBlocksArgs {
         start: start_index.unwrap_or(0u64),
-        length: num_blocks.unwrap_or(u32::MAX as usize),
+        length: num_blocks.unwrap_or(u32::MAX as usize) as u64,
     };
     let req = Encode!(&req).expect("Failed to encode GetBlocksArgs");
     let res = env
@@ -39,7 +39,7 @@ pub fn icp_get_blocks(
         for i in 0..=archived.length / MAX_BLOCKS_PER_REQUEST as u64 {
             let req = GetBlocksArgs {
                 start: archived.start + i * MAX_BLOCKS_PER_REQUEST as u64,
-                length: MAX_BLOCKS_PER_REQUEST,
+                length: MAX_BLOCKS_PER_REQUEST as u64,
             };
             let req = Encode!(&req).expect("Failed to encode GetBlocksArgs for archive node");
             let canister_id = archived.callback.canister_id;
@@ -68,7 +68,7 @@ pub fn icp_get_blocks(
 pub fn icp_query_blocks(env: &StateMachine, ledger_id: CanisterId) -> Vec<icp_ledger::Block> {
     let req = GetBlocksArgs {
         start: 0u64,
-        length: u32::MAX as usize,
+        length: u32::MAX as u64,
     };
     let req = Encode!(&req).expect("Failed to encode GetBlocksArgs");
     let res = env
@@ -81,7 +81,7 @@ pub fn icp_query_blocks(env: &StateMachine, ledger_id: CanisterId) -> Vec<icp_le
         for i in 0..=archived.length / MAX_BLOCKS_PER_REQUEST as u64 {
             let req = GetBlocksArgs {
                 start: archived.start + i * MAX_BLOCKS_PER_REQUEST as u64,
-                length: MAX_BLOCKS_PER_REQUEST,
+                length: MAX_BLOCKS_PER_REQUEST as u64,
             };
             let req = Encode!(&req).expect("Failed to encode GetBlocksArgs for archive node");
             let canister_id = archived.callback.canister_id;

--- a/rs/ledger_suite/icp/tests/tests.rs
+++ b/rs/ledger_suite/icp/tests/tests.rs
@@ -145,7 +145,7 @@ async fn get_blocks_pb(
             protobuf,
             GetBlocksArgs {
                 start: range.start,
-                length: range.end.saturating_sub(range.start) as usize,
+                length: range.end.saturating_sub(range.start),
             },
         )
         .await
@@ -158,7 +158,7 @@ async fn get_blocks_candid(archive: &Canister<'_>, range: std::ops::Range<u64>) 
             candid_one,
             GetBlocksArgs {
                 start: range.start,
-                length: range.end.saturating_sub(range.start) as usize,
+                length: range.end.saturating_sub(range.start),
             },
         )
         .await
@@ -175,14 +175,14 @@ async fn get_encoded_blocks_candid(
             candid_one,
             GetBlocksArgs {
                 start: range.start,
-                length: range.end.saturating_sub(range.start) as usize,
+                length: range.end.saturating_sub(range.start),
             },
         )
         .await
         .expect("get_encoded_blocks call trapped")
 }
 
-async fn query_blocks(ledger: &Canister<'_>, start: u64, length: usize) -> QueryBlocksResponse {
+async fn query_blocks(ledger: &Canister<'_>, start: u64, length: u64) -> QueryBlocksResponse {
     ledger
         .query_("query_blocks", candid_one, GetBlocksArgs { start, length })
         .await
@@ -192,7 +192,7 @@ async fn query_blocks(ledger: &Canister<'_>, start: u64, length: usize) -> Query
 async fn query_encoded_blocks(
     ledger: &Canister<'_>,
     start: u64,
-    length: usize,
+    length: u64,
 ) -> QueryEncodedBlocksResponse {
     ledger
         .query_(
@@ -479,7 +479,7 @@ fn archive_blocks_small_test() {
                     ledger: ledger.canister_id().into(),
                     arg: GetBlocksArgs {
                         start: 0,
-                        length: all_blocks.len(),
+                        length: all_blocks.len() as u64,
                     },
                     result: all_blocks
                         .iter()
@@ -673,12 +673,11 @@ fn archived_blocks_ranges() {
 
         for start in 0..10 {
             for length in 1..=10 - start {
-                let response = query_blocks(&ledger, start, length as usize).await;
+                let response = query_blocks(&ledger, start, length).await;
                 assert_eq!(response.archived_blocks.len(), 1);
                 assert_eq!(response.archived_blocks[0].start, start);
                 assert_eq!(response.archived_blocks[0].length, length);
-                let response_encoded_blocks =
-                    query_encoded_blocks(&ledger, start, length as usize).await;
+                let response_encoded_blocks = query_encoded_blocks(&ledger, start, length).await;
                 assert_eq!(
                     response.archived_blocks.len(),
                     response_encoded_blocks.archived_blocks.len()

--- a/rs/rosetta-api/icp/ledger_canister_blocks_synchronizer/src/canister_access.rs
+++ b/rs/rosetta-api/icp/ledger_canister_blocks_synchronizer/src/canister_access.rs
@@ -150,7 +150,7 @@ impl CanisterAccess {
                 "get_blocks_pb",
                 GetBlocksArgs {
                     start,
-                    length: (end - start) as usize,
+                    length: (end - start),
                 },
             )
             .await

--- a/rs/rosetta-api/icp/tests/system_tests/common/utils.rs
+++ b/rs/rosetta-api/icp/tests/system_tests/common/utils.rs
@@ -157,7 +157,7 @@ pub async fn query_encoded_blocks(
     let current_chain_tip_index = response.chain_length.saturating_sub(1);
     let block_request = GetBlocksArgs {
         start: std::cmp::min(min_block_height, current_chain_tip_index),
-        length: std::cmp::min(num_blocks, response.chain_length) as usize,
+        length: std::cmp::min(num_blocks, response.chain_length),
     };
     Decode!(
         &agent


### PR DESCRIPTION
Change the type of the `length` field in the ledger `GetBlocksArgs` struct from `usize` to `u64`. The field in the candid interface is of type `Nat64`, but if a value larger than what fit into a `u32` was passed in as the `length` in a `query_blocks` query, this would lead to a `Fail to decode argument 0 from table0 to record { start : nat64; length : nat64 }` error.