### PR TITLE
refactor(sns): Move human-readable timestamp formatter into its own crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10183,6 +10183,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "ic-nervous-system-timestamp"
+version = "0.0.1"
+dependencies = [
+ "time",
+]
+
+[[package]]
 name = "ic-networking-subnet-update-workload"
 version = "0.9.0"
 dependencies = [
@@ -11924,6 +11931,7 @@ dependencies = [
  "ic-nervous-system-proto",
  "ic-nervous-system-root",
  "ic-nervous-system-runtime",
+ "ic-nervous-system-timestamp",
  "ic-nns-constants",
  "ic-protobuf",
  "ic-sns-governance",
@@ -11956,7 +11964,6 @@ dependencies = [
  "strum",
  "strum_macros",
  "tempfile",
- "time",
  "tokio",
  "tokio-test",
 ]

--- a/rs/nervous_system/timestamp/BUILD.bazel
+++ b/rs/nervous_system/timestamp/BUILD.bazel
@@ -1,0 +1,38 @@
+load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test")
+
+package(default_visibility = ["//visibility:public"])
+
+DEPENDENCIES = [
+    "@crate_index//:time",
+]
+
+MACRO_DEPENDENCIES = [
+]
+
+DEV_DEPENDENCIES = [
+]
+
+MACRO_DEV_DEPENDENCIES = [
+]
+
+LIB_SRCS = glob(
+    ["src/**/*.rs"],
+    # Ensures that we do not need to rebuild just because a _test.rs file changed.
+    exclude = ["**/*tests.rs"],
+)
+
+rust_library(
+    name = "timestamp",
+    srcs = LIB_SRCS,
+    crate_name = "ic_nervous_system_string",
+    proc_macro_deps = MACRO_DEPENDENCIES,
+    version = "0.0.1",
+    deps = DEPENDENCIES,
+)
+
+rust_test(
+    name = "timestamp_test",
+    srcs = glob(["src/**/*.rs"]),
+    proc_macro_deps = MACRO_DEPENDENCIES + MACRO_DEV_DEPENDENCIES,
+    deps = DEPENDENCIES + DEV_DEPENDENCIES,
+)

--- a/rs/nervous_system/timestamp/BUILD.bazel
+++ b/rs/nervous_system/timestamp/BUILD.bazel
@@ -24,7 +24,7 @@ LIB_SRCS = glob(
 rust_library(
     name = "timestamp",
     srcs = LIB_SRCS,
-    crate_name = "ic_nervous_system_string",
+    crate_name = "ic_nervous_system_timestamp",
     proc_macro_deps = MACRO_DEPENDENCIES,
     version = "0.0.1",
     deps = DEPENDENCIES,

--- a/rs/nervous_system/timestamp/Cargo.toml
+++ b/rs/nervous_system/timestamp/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "ic-nervous-system-timestamp"
+version = "0.0.1"
+edition = "2021"
+
+[dependencies]
+time = { workspace = true }

--- a/rs/nervous_system/timestamp/src/lib.rs
+++ b/rs/nervous_system/timestamp/src/lib.rs
@@ -1,0 +1,29 @@
+//! A library for working with timestamps used in canister code.
+//!
+//! While existing Rust libraries (e.g., chrono) may also provide similar (or richer) functions,
+//! those libraries cannot be used by Rust canisters built in this repo, as that requires enabling
+//! Rust compiler features that are not available in this repo.
+
+/// Attempts to format `` as a human-readable string.
+///
+/// For example:
+/// ```
+/// assert_eq!(format_timestamp(1732896850), Some("2024-11-29 16:14:10 UTC".to_string()));
+/// ```
+pub fn format_timestamp(timestamp_seconds: u64) -> Option<String> {
+    let timestamp_seconds = i64::try_from(timestamp_seconds).ok()?;
+    let dt_offset = time::OffsetDateTime::from_unix_timestamp(timestamp_seconds).ok()?;
+    let format =
+        time::format_description::parse("[year]-[month]-[day] [hour]:[minute]:[second] UTC")
+            .ok()?;
+    dt_offset.format(&format).ok()
+}
+
+/// Formats `timestamp_seconds` as a human-readable string, unless it is outside of the range
+/// from +1970-01-01 00:00:00 UTC (0)
+/// till +9999-12-31 23:59:59 UTC (253402300799),
+/// in which case falls back to a string containing the literal `timestamp_seconds`.
+pub fn format_timestamp_for_humans(timestamp_seconds: u64) -> String {
+    format_timestamp(timestamp_seconds)
+        .unwrap_or_else(|| format!("timestamp {} seconds", timestamp_seconds))
+}

--- a/rs/nervous_system/timestamp/src/tests.rs
+++ b/rs/nervous_system/timestamp/src/tests.rs
@@ -1,0 +1,40 @@
+use super::*;
+
+#[test]
+fn test_format_timestamp() {
+    for (expected, timestamp_seconds) in [
+        (Some("1970-01-01 00:00:00 UTC"), 0),
+        (Some("2024-11-29 16:14:10 UTC"), 1732896850),
+        (Some("2038-01-19 03:14:07 UTC"), i32::MAX as u64),
+        (Some("4571-09-24 08:52:47 UTC"), 82102668767),
+        (Some("9999-12-31 23:59:59 UTC"), 253402300799),
+        (None, 253402300800),
+        (None, i64::MAX as u64),
+        (None, u64::MAX),
+    ] {
+        let observed_opt = format_timestamp(timestamp_seconds);
+        assert_eq!(
+            observed_opt,
+            expected.map(|s| s.to_string()),
+            "unexpected result from format_timestamp({})",
+            timestamp_seconds,
+        );
+
+        let observed_str = format_timestamp_for_humans(timestamp_seconds);
+        if let Some(expected) = expected {
+            assert_eq!(
+                observed_str,
+                expected.to_string(),
+                "unexpected result from format_timestamp_for_humans({})",
+                timestamp_seconds,
+            );
+        } else {
+            let expected_fallback = format!("timestamp {} seconds", timestamp_seconds);
+            assert_eq!(
+                observed_str, expected_fallback,
+                "unexpected result from format_timestamp_for_humans({})",
+                timestamp_seconds,
+            );
+        }
+    }
+}

--- a/rs/sns/governance/BUILD.bazel
+++ b/rs/sns/governance/BUILD.bazel
@@ -30,6 +30,7 @@ DEPENDENCIES = [
     "//rs/nervous_system/proto",
     "//rs/nervous_system/root",
     "//rs/nervous_system/runtime",
+    "//rs/nervous_system/timestamp",
     "//rs/nns/constants",
     "//rs/protobuf",
     "//rs/rust_canisters/canister_log",
@@ -62,7 +63,6 @@ DEPENDENCIES = [
     "@crate_index//:serde",
     "@crate_index//:serde_bytes",
     "@crate_index//:strum",
-    "@crate_index//:time",
 ]
 
 MACRO_DEPENDENCIES = [

--- a/rs/sns/governance/Cargo.toml
+++ b/rs/sns/governance/Cargo.toml
@@ -59,6 +59,7 @@ ic-nervous-system-lock = { path = "../../nervous_system/lock" }
 ic-nervous-system-proto = { path = "../../nervous_system/proto" }
 ic-nervous-system-root = { path = "../../nervous_system/root" }
 ic-nervous-system-runtime = { path = "../../nervous_system/runtime" }
+ic-nervous-system-timestamp = { path = "../../nervous_system/timestamp" }
 ic-nns-constants = { path = "../../nns/constants" }
 ic-sns-governance-api = { path = "./api" }
 ic-sns-governance-proposal-criticality = { path = "./proposal_criticality" }
@@ -80,7 +81,6 @@ serde = { workspace = true }
 serde_bytes = { workspace = true }
 strum = { workspace = true }
 strum_macros = { workspace = true }
-time = { workspace = true }
 canbench-rs = { version = "0.1.7", optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]

--- a/rs/sns/governance/src/proposal.rs
+++ b/rs/sns/governance/src/proposal.rs
@@ -38,6 +38,7 @@ use ic_nervous_system_common::{
     DEFAULT_TRANSFER_FEE, E8, ONE_DAY_SECONDS,
 };
 use ic_nervous_system_proto::pb::v1::Percentage;
+use ic_nervous_system_string::format_timestamp_for_humans;
 use ic_protobuf::types::v1::CanisterInstallMode;
 use ic_sns_governance_proposals_amount_total_limit::{
     // TODO(NNS1-2982): Uncomment. mint_sns_tokens_7_day_total_upper_bound_tokens,
@@ -52,7 +53,6 @@ use std::{
     convert::TryFrom,
     fmt::Write,
 };
-use time;
 
 /// The maximum number of bytes in an SNS proposal's title.
 pub const PROPOSAL_TITLE_BYTES_MAX: usize = 256;
@@ -1716,21 +1716,6 @@ fn validate_and_render_manage_dapp_canister_settings(
     }
 }
 
-/// Attempts to format `` as a human-readable string.
-///
-/// For example:
-/// ```
-/// assert_eq!(format_timestamp(1732896850), Some("2024-11-29 16:14:10 UTC".to_string()));
-/// ```
-fn format_timestamp(timestamp_seconds: u64) -> Option<String> {
-    let timestamp_seconds = i64::try_from(timestamp_seconds).ok()?;
-    let dt_offset = time::OffsetDateTime::from_unix_timestamp(timestamp_seconds).ok()?;
-    let format =
-        time::format_description::parse("[year]-[month]-[day] [hour]:[minute]:[second] UTC")
-            .ok()?;
-    dt_offset.format(&format).ok()
-}
-
 /// Attempts to validate an `AdvanceSnsTargetVersion` action and render its human-readable text.
 /// Invalidates the action in the following cases:
 /// - There are no pending upgrades.
@@ -1754,11 +1739,7 @@ fn validate_and_render_advance_sns_target_version_proposal(
 
     let time_of_validity = {
         let timestamp_seconds = upgrade_steps.approximate_time_of_validity_timestamp_seconds();
-        // This fallback should not occur unless `timestamp_seconds` is outside of the range
-        // from +1970-01-01 00:00:00 UTC (0)
-        // till +9999-12-31 23:59:59 UTC (253402300799).
-        format_timestamp(timestamp_seconds)
-            .unwrap_or_else(|| format!("timestamp {} seconds", timestamp_seconds))
+        format_timestamp_for_humans(timestamp_seconds)
     };
 
     let current_target_versions_render =

--- a/rs/sns/governance/src/proposal.rs
+++ b/rs/sns/governance/src/proposal.rs
@@ -38,7 +38,7 @@ use ic_nervous_system_common::{
     DEFAULT_TRANSFER_FEE, E8, ONE_DAY_SECONDS,
 };
 use ic_nervous_system_proto::pb::v1::Percentage;
-use ic_nervous_system_string::format_timestamp_for_humans;
+use ic_nervous_system_timestamp::format_timestamp_for_humans;
 use ic_protobuf::types::v1::CanisterInstallMode;
 use ic_sns_governance_proposals_amount_total_limit::{
     // TODO(NNS1-2982): Uncomment. mint_sns_tokens_7_day_total_upper_bound_tokens,

--- a/rs/sns/governance/src/proposal/advance_sns_target_version.rs
+++ b/rs/sns/governance/src/proposal/advance_sns_target_version.rs
@@ -67,28 +67,6 @@ fn standard_governance_proto_for_tests(deployed_version: Option<Version>) -> Gov
 }
 
 #[test]
-fn test_format_timestamp() {
-    for (expected, timestamp_seconds) in [
-        (Some("1970-01-01 00:00:00 UTC"), 0),
-        (Some("2024-11-29 16:14:10 UTC"), 1732896850),
-        (Some("2038-01-19 03:14:07 UTC"), i32::MAX as u64),
-        (Some("4571-09-24 08:52:47 UTC"), 82102668767),
-        (Some("9999-12-31 23:59:59 UTC"), 253402300799),
-        (None, 253402300800),
-        (None, i64::MAX as u64),
-        (None, u64::MAX),
-    ] {
-        let observed = format_timestamp(timestamp_seconds);
-        assert_eq!(
-            observed,
-            expected.map(|s| s.to_string()),
-            "unexpected result from format_timestamp({})",
-            timestamp_seconds,
-        );
-    }
-}
-
-#[test]
 fn test_validate_and_render_advance_target_version_action() {
     // Prepare the world.
     let pre_deployed_version = sns_version_for_tests();


### PR DESCRIPTION
This PR factors the human-readable timestamp formatter out into its own crate.