### PR TITLE
chore: use mozilla root ca store in PocketIC tests on macOS

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -813,3 +813,11 @@ http_file(
     sha256 = "31d4654d60b364420a2e52f546f06b2255dc78ac8c2d768271f004b8946e92cb",
     url = "https://raw.githubusercontent.com/dfinity/portal/407ec5b92d06618c4df9f52e98514c5f4f44313e/docs/references/_attachments/ic.did",
 )
+
+# Mozilla CA certificate store in PEM format
+http_file(
+    name = "mozilla_root_ca_store",
+    downloaded_file_path = "cacert.pem",
+    sha256 = "bb1782d281fe60d4a2dcf41bc229abe3e46c280212597d4abcc25bddf667739b",
+    url = "https://curl.se/ca/cacert-2024-11-26.pem",
+)

--- a/packages/pocket-ic/BUILD.bazel
+++ b/packages/pocket-ic/BUILD.bazel
@@ -75,9 +75,11 @@ rust_test_suite(
     data = [
         "//packages/pocket-ic/test_canister:test_canister.wasm",
         "//rs/pocket_ic_server:pocket-ic-server",
+        "@mozilla_root_ca_store//file",
     ],
     env = {
         "POCKET_IC_BIN": "$(rootpath //rs/pocket_ic_server:pocket-ic-server)",
+        "SSL_CERT_FILE": "$(rootpath @mozilla_root_ca_store//file)",
         "TEST_WASM": "$(rootpath //packages/pocket-ic/test_canister:test_canister.wasm)",
     },
     flaky = False,
@@ -95,9 +97,11 @@ rust_test_suite(
     srcs = ["tests/restart.rs"],
     data = [
         "//rs/pocket_ic_server:pocket-ic-server",
+        "@mozilla_root_ca_store//file",
     ],
     env = {
         "POCKET_IC_BIN": "$(rootpath //rs/pocket_ic_server:pocket-ic-server)",
+        "SSL_CERT_FILE": "$(rootpath @mozilla_root_ca_store//file)",
     },
     flaky = False,
     proc_macro_deps = MACRO_DEPENDENCIES,
@@ -114,9 +118,11 @@ rust_test_suite(
     data = [
         "//packages/pocket-ic/test_canister:test_canister.wasm",
         "//rs/pocket_ic_server:pocket-ic-server",
+        "@mozilla_root_ca_store//file",
     ],
     env = {
         "POCKET_IC_BIN": "$(rootpath //rs/pocket_ic_server:pocket-ic-server)",
+        "SSL_CERT_FILE": "$(rootpath @mozilla_root_ca_store//file)",
         "TEST_WASM": "$(rootpath //packages/pocket-ic/test_canister:test_canister.wasm)",
     },
     flaky = False,

--- a/rs/pocket_ic_server/BUILD.bazel
+++ b/rs/pocket_ic_server/BUILD.bazel
@@ -176,11 +176,13 @@ rust_test(
         ":pocket-ic-server",
         "//rs/registry/canister:registry-canister",
         "@ii_dev_canister//file",
+        "@mozilla_root_ca_store//file",
     ],
     env = {
         "POCKET_IC_BIN": "$(rootpath :pocket-ic-server)",
         "REGISTRY_WASM": "$(rootpath //rs/registry/canister:registry-canister)",
         "II_WASM": "$(rootpath @ii_dev_canister//file)",
+        "SSL_CERT_FILE": "$(rootpath @mozilla_root_ca_store//file)",
     },
     tags = [
         "cpu:8",

--- a/rs/pocket_ic_server/BUILD.bazel
+++ b/rs/pocket_ic_server/BUILD.bazel
@@ -179,6 +179,7 @@ rust_test(
         "@mozilla_root_ca_store//file",
     ],
     env = {
+        "RUST_TEST_THREADS": "2",
         "POCKET_IC_BIN": "$(rootpath :pocket-ic-server)",
         "REGISTRY_WASM": "$(rootpath //rs/registry/canister:registry-canister)",
         "II_WASM": "$(rootpath @ii_dev_canister//file)",


### PR DESCRIPTION
This PR uses mozilla root ca store in PocketIC tests on macOS to mitigate their flakiness caused by loading the system-wide root ca store on macOS.