### PR TITLE
perf(nns): Add benchmarks for neuron data validator

### DIFF
--- a/rs/nns/governance/canbench/canbench_results.yml
+++ b/rs/nns/governance/canbench/canbench_results.yml
@@ -1,55 +1,55 @@
 benches:
   add_neuron_active_maximum:
     total:
-      instructions: 36176826
+      instructions: 36179013
       heap_increase: 1
       stable_memory_increase: 0
     scopes: {}
   add_neuron_active_typical:
     total:
-      instructions: 1835322
+      instructions: 1835446
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   add_neuron_inactive_maximum:
     total:
-      instructions: 96155572
+      instructions: 96157759
       heap_increase: 1
       stable_memory_increase: 0
     scopes: {}
   add_neuron_inactive_typical:
     total:
-      instructions: 7370927
+      instructions: 7371051
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   cascading_vote_all_heap:
     total:
-      instructions: 34422494
+      instructions: 34547039
       heap_increase: 0
       stable_memory_increase: 128
     scopes: {}
   cascading_vote_heap_neurons_stable_index:
     total:
-      instructions: 56557391
+      instructions: 56681936
       heap_increase: 0
       stable_memory_increase: 128
     scopes: {}
   cascading_vote_stable_everything:
     total:
-      instructions: 371631388
+      instructions: 371913075
       heap_increase: 0
       stable_memory_increase: 128
     scopes: {}
   cascading_vote_stable_neurons_with_heap_index:
     total:
-      instructions: 349446252
+      instructions: 349727939
       heap_increase: 0
       stable_memory_increase: 128
     scopes: {}
   centralized_following_all_stable:
     total:
-      instructions: 173749742
+      instructions: 173821479
       heap_increase: 0
       stable_memory_increase: 128
     scopes: {}
@@ -61,7 +61,7 @@ benches:
     scopes: {}
   draw_maturity_from_neurons_fund_heap:
     total:
-      instructions: 7245419
+      instructions: 7336319
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
@@ -103,7 +103,7 @@ benches:
     scopes: {}
   list_neurons_stable:
     total:
-      instructions: 97867451
+      instructions: 97962451
       heap_increase: 5
       stable_memory_increase: 0
     scopes: {}
@@ -116,6 +116,18 @@ benches:
   list_ready_to_spawn_neuron_ids_stable:
     total:
       instructions: 36926354
+      heap_increase: 0
+      stable_memory_increase: 0
+    scopes: {}
+  neuron_data_validation_heap:
+    total:
+      instructions: 531679423
+      heap_increase: 0
+      stable_memory_increase: 0
+    scopes: {}
+  neuron_data_validation_stable:
+    total:
+      instructions: 883798615
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
@@ -139,7 +151,7 @@ benches:
     scopes: {}
   single_vote_all_stable:
     total:
-      instructions: 2474974
+      instructions: 2474986
       heap_increase: 0
       stable_memory_increase: 128
     scopes: {}

--- a/rs/nns/governance/src/neuron_store/benches.rs
+++ b/rs/nns/governance/src/neuron_store/benches.rs
@@ -2,6 +2,7 @@ use super::*;
 use crate::{
     governance::{MAX_FOLLOWEES_PER_TOPIC, MAX_NEURON_RECENT_BALLOTS, MAX_NUM_HOT_KEYS_PER_NEURON},
     neuron::{DissolveStateAndAge, NeuronBuilder},
+    neuron_data_validation::NeuronDataValidator,
     neurons_fund::{NeuronsFund, NeuronsFundNeuronPortion, NeuronsFundSnapshot},
     now_seconds,
     pb::v1::{neuron::Followees, BallotInfo, Vote},
@@ -436,4 +437,44 @@ fn list_active_neurons_fund_neurons_stable() -> BenchResult {
     }
 
     bench_fn(|| std::hint::black_box(neuron_store.list_active_neurons_fund_neurons()))
+}
+
+fn validate_all_neurons(neuron_store: &NeuronStore, validator: &mut NeuronDataValidator) {
+    let mut now = now_seconds();
+    loop {
+        validator.maybe_validate(now, neuron_store);
+
+        let still_validating = validator
+            .summary()
+            .current_validation_started_time_seconds
+            .is_some();
+        if !still_validating {
+            break;
+        }
+        now += 1;
+    }
+}
+
+#[bench(raw)]
+fn neuron_data_validation_heap() -> BenchResult {
+    let _t = temporarily_disable_active_neurons_in_stable_memory();
+    let mut rng = new_rng();
+    let neuron_store = set_up_neuron_store(&mut rng, 100, 200);
+    let mut validator = NeuronDataValidator::new();
+
+    bench_fn(|| {
+        validate_all_neurons(&neuron_store, &mut validator);
+    })
+}
+
+#[bench(raw)]
+fn neuron_data_validation_stable() -> BenchResult {
+    let _t = temporarily_enable_active_neurons_in_stable_memory();
+    let mut rng = new_rng();
+    let neuron_store = set_up_neuron_store(&mut rng, 100, 200);
+    let mut validator = NeuronDataValidator::new();
+
+    bench_fn(|| {
+        validate_all_neurons(&neuron_store, &mut validator);
+    })
 }


### PR DESCRIPTION
# Why

Neuron data validator goes through batches of neurons in order to make sure neurons and its indexes are in a consistent state, and such operations will get more expensive after neurons are migrated to stable structures. Adding benchmarks makes it easier to optimize the performance, and help prevent regressions.

# What

Add benchmarks for neuron data validator for 2 cases - whether the neuron migration to stable structures is enabled or not.

