### PR TITLE
perf(nns): Avoid running `StableNeuronStoreValidator` after migration

### DIFF
--- a/rs/nns/governance/canbench/canbench_results.yml
+++ b/rs/nns/governance/canbench/canbench_results.yml
@@ -109,13 +109,13 @@ benches:
     scopes: {}
   neuron_data_validation_heap:
     total:
-      instructions: 531626627
+      instructions: 531626630
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   neuron_data_validation_stable:
     total:
-      instructions: 667651110
+      instructions: 588485678
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}


### PR DESCRIPTION
# Why

The `StableNeuronStoreValidator` validates that no neurons in the stable storage is active. However, that fact won't be true anymore, and such validation is unnecessary.

# What

Stop adding the validation task when the neuron migration is enabled, and update benchmark results