### PR TITLE
feat(BOUN-1308): build and publish anonymization canister

### DIFF
--- a/.github/workflows/anonymization-backend-release.yml
+++ b/.github/workflows/anonymization-backend-release.yml
@@ -13,13 +13,8 @@ on:
         required: true
         type: string
 
-      ref:
-        description: 'Commit to base the release on (defaults to `HEAD`)'
-        required: false
-        type: string
-
       tag:
-        description: 'Tag for the release (defaults to `anonymization-backend-<COMMIT>`)'
+        description: 'Tag for the release (required format `anonymization-backend-*`)'
         required: false
         type: string
 
@@ -72,17 +67,9 @@ jobs:
 
       - name: tag
         run: |
-          REF='${{ inputs.ref }}'
-          if [[ -z "${REF}" ]]; then
-            REF='HEAD'
-          fi
-
-          COMMIT=$(git rev-parse ${REF})
-          git checkout ${COMMIT}
-
           RELEASE_TAG='${{ inputs.tag }}'
           if [[ -z "${RELEASE_TAG}" ]]; then
-            COMMIT_SHORT=$(git rev-parse --short ${COMMIT})
+            COMMIT_SHORT=$(git rev-parse --short HEAD)
             RELEASE_TAG="${{ env.NAME }}-${COMMIT_SHORT}"
           fi
 

--- a/.github/workflows/anonymization-backend-release.yml
+++ b/.github/workflows/anonymization-backend-release.yml
@@ -1,4 +1,4 @@
-name: release
+name: anonymization-backend-release
 
 on:
   workflow_dispatch:
@@ -31,13 +31,20 @@ env:
   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
-  ok:
-    runs-on: ubuntu-latest
+  build-and-release:
+    name: Build and release the anonymization backend canister
+
+    runs-on:
+      group: zh1
+      labels: dind-large
+
+    container:
+      image: ghcr.io/dfinity/ic-build@sha256:4fd13b47285e783c3a6f35aadd9559d097c0de162a1cf221ead66ab1598d5d45
+      options: >-
+        -e NODE_NAME --privileged --cgroupns host -v /cache:/cache -v /var/sysimage:/var/sysimage -v /var/tmp:/var/tmp -v /ceph-s3-info:/ceph-s3-info
+
     steps:
       - uses: actions/checkout@v4
-
-      - name: Setup Bazel environment
-        uses: bazel-contrib/setup-bazel@0.9.1
 
       - name: build
         run: |

--- a/.github/workflows/anonymization-backend-release.yml
+++ b/.github/workflows/anonymization-backend-release.yml
@@ -1,0 +1,120 @@
+name: release
+
+on:
+  workflow_dispatch:
+    inputs:
+      title:
+        description: 'Title for the release'
+        required: true
+        type: string
+
+      description:
+        description: 'Human-readable description of the release'
+        required: true
+        type: string
+
+      ref:
+        description: 'Commit to base the release on (defaults to `HEAD`)'
+        required: false
+        type: string
+
+      tag:
+        description: 'Tag for the release (defaults to `anonymization-backend-<COMMIT>`)'
+        required: false
+        type: string
+
+permissions:
+  contents: write
+
+env:
+  NAME: anonymization-backend
+  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+jobs:
+  ok:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Bazel environment
+        uses: bazel-contrib/setup-bazel@0.9.1
+
+      - name: build
+        run: |
+          TARGET='//rs/boundary_node/anonymization/backend:anonymization_backend'
+          bazel build ${TARGET}
+
+          OUTPUT='bazel-bin/rs/boundary_node/anonymization/backend/anonymization_backend.wasm.gz'
+          mv ${OUTPUT} anonymization_backend.wasm.gz
+
+          ARTIFACTS=(
+            anonymization_backend.wasm.gz
+          )
+
+          echo "ARTIFACTS=${ARTIFACTS[@]}" >> "${GITHUB_ENV}"
+
+      - name: checksums
+        run: |
+          CHECKSUMS=$(mktemp)
+
+          for ARTIFACT in ${ARTIFACTS[@]}; do
+              shasum -a256 ${ARTIFACT} >> ${CHECKSUMS}
+          done
+
+          echo "CHECKSUMS=${CHECKSUMS}" >> "${GITHUB_ENV}"
+
+      - name: tag
+        run: |
+          REF='${{ inputs.ref }}'
+          if [[ -z "${REF}" ]]; then
+            REF='HEAD'
+          fi
+
+          COMMIT=$(git rev-parse ${REF})
+          git checkout ${COMMIT}
+
+          RELEASE_TAG='${{ inputs.tag }}'
+          if [[ -z "${RELEASE_TAG}" ]]; then
+            COMMIT_SHORT=$(git rev-parse --short ${COMMIT})
+            RELEASE_TAG="${{ env.NAME }}-${COMMIT_SHORT}"
+          fi
+
+          git tag ${RELEASE_TAG}
+          git push origin tag ${RELEASE_TAG}
+
+          echo "RELEASE_TAG=${RELEASE_TAG}" >> "${GITHUB_ENV}"
+
+      - name: release notes
+        run: |
+          NOTES=$(mktemp)
+
+          CODE_BLOCK='```'
+
+          cat > ${NOTES} <<EOF
+          ${{ inputs.description }}
+
+          ## Verification
+
+          To reproduce the artifacts of this release:
+
+          ${CODE_BLOCK}
+          bazel build //rs/boundary_node/anonymization/backend:anonymization_backend
+          ${CODE_BLOCK}
+
+          ## Checksums
+
+          ${CODE_BLOCK}
+          $(cat ${CHECKSUMS})
+          ${CODE_BLOCK}
+          EOF
+
+          echo "NOTES=${NOTES}" >> "${GITHUB_ENV}"
+
+      - name: release
+        run: |
+          gh release create \
+            ${RELEASE_TAG} ${ARTIFACTS[@]} \
+                --title '${{ inputs.title }}' \
+                --verify-tag \
+                --latest=false \
+                --notes-file ${NOTES}

--- a/.github/workflows/anonymization-backend-release.yml
+++ b/.github/workflows/anonymization-backend-release.yml
@@ -79,6 +79,11 @@ jobs:
             RELEASE_TAG="${{ env.NAME }}-${COMMIT_SHORT}"
           fi
 
+          if [[ ! "${RELEASE_TAG}" =~ "^${{ env.NAME }}" ]]; then
+            echo "ERROR: Required tag prefix: ${{ env.NAME }}"
+            exit 1
+          fi
+
           git tag ${RELEASE_TAG}
           git push origin tag ${RELEASE_TAG}
 

--- a/.github/workflows/anonymization-backend-release.yml
+++ b/.github/workflows/anonymization-backend-release.yml
@@ -42,7 +42,7 @@ jobs:
       - name: build
         run: |
           TARGET='//rs/boundary_node/anonymization/backend:anonymization_backend'
-          bazel build ${TARGET}
+          bazel build --config=ci ${TARGET}
 
           OUTPUT='bazel-bin/rs/boundary_node/anonymization/backend/anonymization_backend.wasm.gz'
           mv ${OUTPUT} anonymization_backend.wasm.gz

--- a/rs/boundary_node/anonymization/backend/BUILD.bazel
+++ b/rs/boundary_node/anonymization/backend/BUILD.bazel
@@ -1,0 +1,32 @@
+load("//bazel:canisters.bzl", "rust_canister")
+
+package(default_visibility = ["//visibility:public"])
+
+DEPENDENCIES = [
+    # Keep sorted.
+    "//rs/boundary_node/anonymization/interface",
+    "//rs/nns/constants",
+    "@crate_index//:anyhow",
+    "@crate_index//:candid",
+    "@crate_index//:ic-cdk",
+    "@crate_index//:ic-cdk-timers",
+    "@crate_index//:ic-stable-structures",
+    "@crate_index//:lazy_static",
+    "@crate_index//:prometheus",
+    "@crate_index//:serde",
+    "@crate_index//:thiserror",
+]
+
+MACRO_DEPENDENCIES = [
+    # Keep sorted.
+    "@crate_index//:async-trait",
+]
+
+rust_canister(
+    name = "anonymization_backend",
+    srcs = glob(["src/**/*.rs"]),
+    crate_name = "anonymization_backend",
+    proc_macro_deps = MACRO_DEPENDENCIES,
+    service_file = ":interface.did",
+    deps = DEPENDENCIES,
+)

--- a/rs/boundary_node/anonymization/backend/build.sh
+++ b/rs/boundary_node/anonymization/backend/build.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+NAME="anonymization_backend"
+OUTPUT="target/wasm32-unknown-unknown/release/${NAME}.wasm"
+
+# Build
+cargo build \
+    --release \
+    --target wasm32-unknown-unknown \
+    --target-dir target \
+    -p "${NAME}" \
+    --locked
+
+# Shrink
+ic-wasm "${OUTPUT}" -o "${OUTPUT}" shrink
+
+# Compress
+gzip -f "${OUTPUT}"

--- a/rs/boundary_node/anonymization/backend/dfx.json
+++ b/rs/boundary_node/anonymization/backend/dfx.json
@@ -1,0 +1,11 @@
+{
+  "version": 1,
+  "canisters": {
+    "anonymization_backend": {
+      "type": "custom",
+      "candid": "interface.did",
+      "build": "build.sh",
+      "wasm": "target/wasm32-unknown-unknown/release/anonymization_backend.wasm.gz"
+    }
+  }
+}


### PR DESCRIPTION
This adds a github workflow to manually trigger a build/release of the anonymization canister. We plan to add a similar workflow for another new rate-limiting canister.

I tested this on a small temporary repo but without the bazel portion, so am not entirely sure if this would require another runner or also installing ic-wasm? cc @basvandijk 