### PR TITLE
test(IDX): increase timeout to 15m for the ic_icp_index_test

### DIFF
--- a/rs/ledger_suite/icp/index/BUILD.bazel
+++ b/rs/ledger_suite/icp/index/BUILD.bazel
@@ -88,6 +88,7 @@ rust_test(
 
 rust_ic_test(
     name = "ic_icp_index_test",
+    timeout = "long",
     srcs = ["tests/tests.rs"],
     data = [
         ":ic-icp-index-canister.wasm",


### PR DESCRIPTION
The `//rs/ledger_suite/icp/index:ic_icp_index_test` is a bit flaky (~2%) because it occasionally times out after 5 minutes. So we increase the timeout to `long` which is 15 minutes.

If it turns out the P90 duration of this test will go over 5 minutes we should look into optimising it or tagging it as a `long_test` to no longer run this on PRs but only on pushes to `master`.