### PR TITLE
test(IDX): increae timeout of the NNS integration_tests_test

### DIFF
--- a/rs/nns/integration_tests/BUILD.bazel
+++ b/rs/nns/integration_tests/BUILD.bazel
@@ -268,6 +268,7 @@ rust_canister(
 
 rust_ic_test_suite_with_extra_srcs(
     name = "integration_tests_test",
+    timeout = "long",
     srcs = glob(
         ["src/**/*.rs"],
         exclude = [


### PR DESCRIPTION
The `//rs/nns/integration_tests:integration_tests_test_src/...` tests are slightly flaky (> 1%) because they sometimes time out after 5 minutes. So we increase the timeout to `long` which is 15 minutes.

If it turns out the P90 duration of these tests will go over 5 minutes we should look into optimising them or tagging them as `long_test` to no longer run them on PRs but only on pushes to `master`.