### PR TITLE
chore: decrease max request time in PocketIC tests

### DIFF
--- a/packages/pocket-ic/src/lib.rs
+++ b/packages/pocket-ic/src/lib.rs
@@ -79,7 +79,7 @@ pub mod nonblocking;
 const EXPECTED_SERVER_VERSION: &str = "pocket-ic-server 7.0.0";
 
 // the default timeout of a PocketIC operation
-const DEFAULT_MAX_REQUEST_TIME_MS: u64 = 300_000;
+const DEFAULT_MAX_REQUEST_TIME_MS: u64 = 60_000;
 
 const LOCALHOST: &str = "127.0.0.1";
 


### PR DESCRIPTION
This PR decreases the default maximum amount of time the PocketIC library waits for a pending request to the server. With the current high default, PocketIC tests time out upon bazel timeout and we don't see any error output then, e.g., [here](https://dash.zh1-idx1.dfinity.network/invocation/ca49d089-4dc1-469e-9d9e-b79062964c12?target=%2F%2Frs%2Fpocket_ic_server%3Atest&targetStatus=7#@139).