### PR TITLE
test(sns): Do release-qualification for swap upgrades

### DIFF
--- a/rs/nervous_system/integration_tests/tests/sns_release_qualification.rs
+++ b/rs/nervous_system/integration_tests/tests/sns_release_qualification.rs
@@ -84,8 +84,6 @@ async fn test_deployment_swap_upgrade() {
 }
 
 /// Upgrade Tests
-
-#[ignore]
 #[tokio::test]
 async fn test_upgrade_swap() {
     test_sns_upgrade(vec![SnsCanisterType::Swap]).await;

--- a/rs/nervous_system/integration_tests/tests/sns_release_qualification_legacy.rs
+++ b/rs/nervous_system/integration_tests/tests/sns_release_qualification_legacy.rs
@@ -1,10 +1,10 @@
+//! Legacy upgrade release-qualification tests
+
 use ic_sns_wasm::pb::v1::SnsCanisterType;
 
 mod sns_upgrade_test_utils_legacy;
 use sns_upgrade_test_utils_legacy::test_sns_upgrade_legacy;
 
-/// Legacy upgrade Tests
-///
 #[tokio::test]
 async fn test_upgrade_swap() {
     test_sns_upgrade_legacy(vec![SnsCanisterType::Swap]).await;


### PR DESCRIPTION
This was disabled until we updated SNS Gov on mainnet (as previously SNS Swap did not upgrade).

Closes [NNS1-3433](https://dfinity.atlassian.net/browse/NNS1-3433)

#2981 already did this for the legacy (UpgradeSnsToNextVersion) upgrade qualifications, this PR does it for AvanceSnsTargetVersion upgrade qualifications as well.

[NNS1-3433]: https://dfinity.atlassian.net/browse/NNS1-3433?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Note: This PR also cleans up a comment in `sns_release_qualification_legacy.rs`