### PR TITLE
chore: Reduce optimization for NNS Governance rust_canbench

### DIFF
--- a/bazel/canbench.bzl
+++ b/bazel/canbench.bzl
@@ -26,7 +26,7 @@ def rust_canbench(name, results_file, add_test = False, **kwargs):
     wasm_rust_binary_rule(
         name = name + "_wasm",
         binary = ":{name}_bin".format(name = name),
-        opt = "3",
+        opt = "s",
     )
 
     canbench_bin = "$(location @crate_index//:canbench__canbench)"

--- a/bazel/canbench.bzl
+++ b/bazel/canbench.bzl
@@ -5,7 +5,7 @@ This module defines functions to run benchmarks using canbench.
 load("@rules_rust//rust:defs.bzl", "rust_binary")
 load("//bazel:canisters.bzl", "wasm_rust_binary_rule")
 
-def rust_canbench(name, results_file, add_test = False, **kwargs):
+def rust_canbench(name, results_file, add_test = False, opt = "3", **kwargs):
     """ Run a Rust benchmark using canbench. 
 
     This creates 2 executable rules: :${name} for running the benchmark and :${name}_update for
@@ -26,7 +26,7 @@ def rust_canbench(name, results_file, add_test = False, **kwargs):
     wasm_rust_binary_rule(
         name = name + "_wasm",
         binary = ":{name}_bin".format(name = name),
-        opt = "s",
+        opt = opt,
     )
 
     canbench_bin = "$(location @crate_index//:canbench__canbench)"

--- a/bazel/canbench.bzl
+++ b/bazel/canbench.bzl
@@ -15,6 +15,7 @@ def rust_canbench(name, results_file, add_test = False, opt = "3", **kwargs):
         name: The name of the rule.
         results_file: The file used store the benchmark results for future comparison.
         add_test: If True add an additional :${name}_test rule that fails if canbench benchmark fails.
+        opt: The optimization level to use for the rust_binary compilation.
         **kwargs: Additional arguments to pass to rust_binary.
     """
 

--- a/rs/nns/governance/BUILD.bazel
+++ b/rs/nns/governance/BUILD.bazel
@@ -211,6 +211,7 @@ rust_canbench(
     # We would like to figure out why and fix it, but for now, we are reducing the optimization 
     # level so that tests against the optimization level can be added.
     opt = "s",
+    add_test = True,
     deps = [
         # Keep sorted.
         ":governance--canbench_feature",

--- a/rs/nns/governance/BUILD.bazel
+++ b/rs/nns/governance/BUILD.bazel
@@ -207,6 +207,10 @@ rust_canbench(
     name = "governance-canbench",
     srcs = ["canbench/main.rs"],
     results_file = "canbench/canbench_results.yml",
+    # For some reason, the NNS Governance benchmarks are sensitive to the optimization level.
+    # We would like to figure out why and fix it, but for now, we are reducing the optimization 
+    # level so that tests against the optimization level can be added.
+    opt = "s",
     deps = [
         # Keep sorted.
         ":governance--canbench_feature",

--- a/rs/nns/governance/BUILD.bazel
+++ b/rs/nns/governance/BUILD.bazel
@@ -206,12 +206,12 @@ rust_library(
 rust_canbench(
     name = "governance-canbench",
     srcs = ["canbench/main.rs"],
-    results_file = "canbench/canbench_results.yml",
+    add_test = True,
     # For some reason, the NNS Governance benchmarks are sensitive to the optimization level.
-    # We would like to figure out why and fix it, but for now, we are reducing the optimization 
+    # We would like to figure out why and fix it, but for now, we are reducing the optimization
     # level so that tests against the optimization level can be added.
     opt = "s",
-    add_test = True,
+    results_file = "canbench/canbench_results.yml",
     deps = [
         # Keep sorted.
         ":governance--canbench_feature",

--- a/rs/nns/governance/canbench/canbench_results.yml
+++ b/rs/nns/governance/canbench/canbench_results.yml
@@ -1,67 +1,111 @@
 benches:
   add_neuron_active_maximum:
     total:
+<<<<<<< HEAD
       instructions: 42559874
+=======
+      instructions: 42556630
+>>>>>>> 0ca7abc289 (Add test)
       heap_increase: 1
       stable_memory_increase: 0
     scopes: {}
   add_neuron_active_typical:
     total:
+<<<<<<< HEAD
       instructions: 2160611
+=======
+      instructions: 2160475
+>>>>>>> 0ca7abc289 (Add test)
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   add_neuron_inactive_maximum:
     total:
+<<<<<<< HEAD
       instructions: 112126649
+=======
+      instructions: 112123405
+>>>>>>> 0ca7abc289 (Add test)
       heap_increase: 1
       stable_memory_increase: 0
     scopes: {}
   add_neuron_inactive_typical:
     total:
+<<<<<<< HEAD
       instructions: 8465215
+=======
+      instructions: 8465079
+>>>>>>> 0ca7abc289 (Add test)
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   cascading_vote_all_heap:
     total:
+<<<<<<< HEAD
       instructions: 35565672
+=======
+      instructions: 35529187
+>>>>>>> 0ca7abc289 (Add test)
       heap_increase: 0
       stable_memory_increase: 128
     scopes: {}
   cascading_vote_heap_neurons_stable_index:
     total:
+<<<<<<< HEAD
       instructions: 61721390
+=======
+      instructions: 61684905
+>>>>>>> 0ca7abc289 (Add test)
       heap_increase: 0
       stable_memory_increase: 128
     scopes: {}
   cascading_vote_stable_everything:
     total:
+<<<<<<< HEAD
       instructions: 188861073
+=======
+      instructions: 456063730
+>>>>>>> 0ca7abc289 (Add test)
       heap_increase: 0
       stable_memory_increase: 128
     scopes: {}
   cascading_vote_stable_neurons_with_heap_index:
     total:
+<<<<<<< HEAD
       instructions: 162571959
+=======
+      instructions: 429859109
+>>>>>>> 0ca7abc289 (Add test)
       heap_increase: 0
       stable_memory_increase: 128
     scopes: {}
   centralized_following_all_stable:
     total:
+<<<<<<< HEAD
       instructions: 78285442
+=======
+      instructions: 236106246
+>>>>>>> 0ca7abc289 (Add test)
       heap_increase: 0
       stable_memory_increase: 128
     scopes: {}
   compute_ballots_for_new_proposal_with_stable_neurons:
     total:
+<<<<<<< HEAD
       instructions: 2019526
+=======
+      instructions: 1965583
+>>>>>>> 0ca7abc289 (Add test)
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   draw_maturity_from_neurons_fund_heap:
     total:
+<<<<<<< HEAD
       instructions: 7549569
+=======
+      instructions: 7535969
+>>>>>>> 0ca7abc289 (Add test)
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
@@ -79,7 +123,11 @@ benches:
     scopes: {}
   list_active_neurons_fund_neurons_stable:
     total:
+<<<<<<< HEAD
       instructions: 2755320
+=======
+      instructions: 2752320
+>>>>>>> 0ca7abc289 (Add test)
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
@@ -97,13 +145,21 @@ benches:
     scopes: {}
   list_neurons_ready_to_unstake_maturity_stable:
     total:
+<<<<<<< HEAD
       instructions: 41326673
+=======
+      instructions: 41326666
+>>>>>>> 0ca7abc289 (Add test)
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   list_neurons_stable:
     total:
+<<<<<<< HEAD
       instructions: 113166221
+=======
+      instructions: 113166821
+>>>>>>> 0ca7abc289 (Add test)
       heap_increase: 5
       stable_memory_increase: 0
     scopes: {}
@@ -121,13 +177,21 @@ benches:
     scopes: {}
   neuron_data_validation_heap:
     total:
+<<<<<<< HEAD
       instructions: 407871691
+=======
+      instructions: 407858091
+>>>>>>> 0ca7abc289 (Add test)
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   neuron_data_validation_stable:
     total:
+<<<<<<< HEAD
       instructions: 363603468
+=======
+      instructions: 363593268
+>>>>>>> 0ca7abc289 (Add test)
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
@@ -139,13 +203,21 @@ benches:
     scopes: {}
   neuron_metrics_calculation_stable:
     total:
+<<<<<<< HEAD
       instructions: 2479136
+=======
+      instructions: 2478536
+>>>>>>> 0ca7abc289 (Add test)
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   range_neurons_performance:
     total:
+<<<<<<< HEAD
       instructions: 56494134
+=======
+      instructions: 56492334
+>>>>>>> 0ca7abc289 (Add test)
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}

--- a/rs/nns/governance/canbench/canbench_results.yml
+++ b/rs/nns/governance/canbench/canbench_results.yml
@@ -1,163 +1,163 @@
 benches:
   add_neuron_active_maximum:
     total:
-      instructions: 36155076
+      instructions: 42559874
       heap_increase: 1
       stable_memory_increase: 0
     scopes: {}
   add_neuron_active_typical:
     total:
-      instructions: 1834230
+      instructions: 2160611
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   add_neuron_inactive_maximum:
     total:
-      instructions: 96097938
+      instructions: 112126649
       heap_increase: 1
       stable_memory_increase: 0
     scopes: {}
   add_neuron_inactive_typical:
     total:
-      instructions: 7366914
+      instructions: 8465215
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   cascading_vote_all_heap:
     total:
-      instructions: 34431941
+      instructions: 35565672
       heap_increase: 0
       stable_memory_increase: 128
     scopes: {}
   cascading_vote_heap_neurons_stable_index:
     total:
-      instructions: 56566838
+      instructions: 61721390
       heap_increase: 0
       stable_memory_increase: 128
     scopes: {}
   cascading_vote_stable_everything:
     total:
-      instructions: 163131819
+      instructions: 188861073
       heap_increase: 0
       stable_memory_increase: 128
     scopes: {}
   cascading_vote_stable_neurons_with_heap_index:
     total:
-      instructions: 140864617
+      instructions: 162571959
       heap_increase: 0
       stable_memory_increase: 128
     scopes: {}
   centralized_following_all_stable:
     total:
-      instructions: 68259968
+      instructions: 78285442
       heap_increase: 0
       stable_memory_increase: 128
     scopes: {}
   compute_ballots_for_new_proposal_with_stable_neurons:
     total:
-      instructions: 1815411
+      instructions: 2019526
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   draw_maturity_from_neurons_fund_heap:
     total:
-      instructions: 7248219
+      instructions: 7549569
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   draw_maturity_from_neurons_fund_stable:
     total:
-      instructions: 10293728
+      instructions: 12303773
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   list_active_neurons_fund_neurons_heap:
     total:
-      instructions: 440980
+      instructions: 436248
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   list_active_neurons_fund_neurons_stable:
     total:
-      instructions: 2450275
+      instructions: 2755320
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   list_neurons_heap:
     total:
-      instructions: 3900688
+      instructions: 4345595
       heap_increase: 9
       stable_memory_increase: 0
     scopes: {}
   list_neurons_ready_to_unstake_maturity_heap:
     total:
-      instructions: 471240
+      instructions: 158257
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   list_neurons_ready_to_unstake_maturity_stable:
     total:
-      instructions: 36937653
+      instructions: 41326673
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   list_neurons_stable:
     total:
-      instructions: 97962451
+      instructions: 113166221
       heap_increase: 5
       stable_memory_increase: 0
     scopes: {}
   list_ready_to_spawn_neuron_ids_heap:
     total:
-      instructions: 459353
+      instructions: 132847
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   list_ready_to_spawn_neuron_ids_stable:
     total:
-      instructions: 36926354
+      instructions: 41298569
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   neuron_data_validation_heap:
     total:
-      instructions: 349668956
+      instructions: 407871691
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   neuron_data_validation_stable:
     total:
-      instructions: 312681996
+      instructions: 363603468
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   neuron_metrics_calculation_heap:
     total:
-      instructions: 1077651
+      instructions: 954474
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   neuron_metrics_calculation_stable:
     total:
-      instructions: 2476865
+      instructions: 2479136
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   range_neurons_performance:
     total:
-      instructions: 47700442
+      instructions: 56494134
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   single_vote_all_stable:
     total:
-      instructions: 2731286
+      instructions: 2802680
       heap_increase: 0
       stable_memory_increase: 128
     scopes: {}
   update_recent_ballots_stable_memory:
     total:
-      instructions: 236846
+      instructions: 273777
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}

--- a/rs/nns/governance/canbench/canbench_results.yml
+++ b/rs/nns/governance/canbench/canbench_results.yml
@@ -1,111 +1,67 @@
 benches:
   add_neuron_active_maximum:
     total:
-<<<<<<< HEAD
       instructions: 42559874
-=======
-      instructions: 42556630
->>>>>>> 0ca7abc289 (Add test)
       heap_increase: 1
       stable_memory_increase: 0
     scopes: {}
   add_neuron_active_typical:
     total:
-<<<<<<< HEAD
       instructions: 2160611
-=======
-      instructions: 2160475
->>>>>>> 0ca7abc289 (Add test)
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   add_neuron_inactive_maximum:
     total:
-<<<<<<< HEAD
       instructions: 112126649
-=======
-      instructions: 112123405
->>>>>>> 0ca7abc289 (Add test)
       heap_increase: 1
       stable_memory_increase: 0
     scopes: {}
   add_neuron_inactive_typical:
     total:
-<<<<<<< HEAD
       instructions: 8465215
-=======
-      instructions: 8465079
->>>>>>> 0ca7abc289 (Add test)
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   cascading_vote_all_heap:
     total:
-<<<<<<< HEAD
       instructions: 35565672
-=======
-      instructions: 35529187
->>>>>>> 0ca7abc289 (Add test)
       heap_increase: 0
       stable_memory_increase: 128
     scopes: {}
   cascading_vote_heap_neurons_stable_index:
     total:
-<<<<<<< HEAD
       instructions: 61721390
-=======
-      instructions: 61684905
->>>>>>> 0ca7abc289 (Add test)
       heap_increase: 0
       stable_memory_increase: 128
     scopes: {}
   cascading_vote_stable_everything:
     total:
-<<<<<<< HEAD
       instructions: 188861073
-=======
-      instructions: 456063730
->>>>>>> 0ca7abc289 (Add test)
       heap_increase: 0
       stable_memory_increase: 128
     scopes: {}
   cascading_vote_stable_neurons_with_heap_index:
     total:
-<<<<<<< HEAD
       instructions: 162571959
-=======
-      instructions: 429859109
->>>>>>> 0ca7abc289 (Add test)
       heap_increase: 0
       stable_memory_increase: 128
     scopes: {}
   centralized_following_all_stable:
     total:
-<<<<<<< HEAD
       instructions: 78285442
-=======
-      instructions: 236106246
->>>>>>> 0ca7abc289 (Add test)
       heap_increase: 0
       stable_memory_increase: 128
     scopes: {}
   compute_ballots_for_new_proposal_with_stable_neurons:
     total:
-<<<<<<< HEAD
       instructions: 2019526
-=======
-      instructions: 1965583
->>>>>>> 0ca7abc289 (Add test)
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   draw_maturity_from_neurons_fund_heap:
     total:
-<<<<<<< HEAD
       instructions: 7549569
-=======
-      instructions: 7535969
->>>>>>> 0ca7abc289 (Add test)
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
@@ -123,11 +79,7 @@ benches:
     scopes: {}
   list_active_neurons_fund_neurons_stable:
     total:
-<<<<<<< HEAD
       instructions: 2755320
-=======
-      instructions: 2752320
->>>>>>> 0ca7abc289 (Add test)
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
@@ -145,21 +97,13 @@ benches:
     scopes: {}
   list_neurons_ready_to_unstake_maturity_stable:
     total:
-<<<<<<< HEAD
       instructions: 41326673
-=======
-      instructions: 41326666
->>>>>>> 0ca7abc289 (Add test)
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   list_neurons_stable:
     total:
-<<<<<<< HEAD
       instructions: 113166221
-=======
-      instructions: 113166821
->>>>>>> 0ca7abc289 (Add test)
       heap_increase: 5
       stable_memory_increase: 0
     scopes: {}
@@ -177,21 +121,13 @@ benches:
     scopes: {}
   neuron_data_validation_heap:
     total:
-<<<<<<< HEAD
       instructions: 407871691
-=======
-      instructions: 407858091
->>>>>>> 0ca7abc289 (Add test)
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   neuron_data_validation_stable:
     total:
-<<<<<<< HEAD
       instructions: 363603468
-=======
-      instructions: 363593268
->>>>>>> 0ca7abc289 (Add test)
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
@@ -203,21 +139,13 @@ benches:
     scopes: {}
   neuron_metrics_calculation_stable:
     total:
-<<<<<<< HEAD
       instructions: 2479136
-=======
-      instructions: 2478536
->>>>>>> 0ca7abc289 (Add test)
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   range_neurons_performance:
     total:
-<<<<<<< HEAD
       instructions: 56494134
-=======
-      instructions: 56492334
->>>>>>> 0ca7abc289 (Add test)
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}


### PR DESCRIPTION
Compiler optimizations like loop unrolling can make benchmarks more sensitive to unrelated changes. In this PR we effectively disable such optimizations for benchmarks using `canbench`.