### PR TITLE
fix(node): Add node reward type update-config parsing

### DIFF
--- a/rs/ic_os/config/src/generate_testnet_config.rs
+++ b/rs/ic_os/config/src/generate_testnet_config.rs
@@ -161,8 +161,6 @@ fn create_guestos_config(config: GenerateTestnetConfigArgs) -> Result<GuestOSCon
     };
 
     // Construct ICOSSettings
-    let node_reward_type = node_reward_type.unwrap_or_else(|| "type3.1".to_string());
-
     let mgmt_mac = match mgmt_mac {
         Some(mac) => mac,
         // Use a dummy MAC address
@@ -191,7 +189,7 @@ fn create_guestos_config(config: GenerateTestnetConfigArgs) -> Result<GuestOSCon
     let use_ssh_authorized_keys = use_ssh_authorized_keys.unwrap_or(true);
 
     let icos_settings = ICOSSettings {
-        node_reward_type: Some(node_reward_type),
+        node_reward_type,
         mgmt_mac,
         deployment_environment,
         logging,

--- a/rs/ic_os/config/src/update_config.rs
+++ b/rs/ic_os/config/src/update_config.rs
@@ -35,6 +35,7 @@ pub fn update_guestos_config() -> Result<()> {
         let hostname = network_config_result.hostname.clone();
 
         let nns_urls = read_nns_conf(config_dir)?;
+        let node_reward_type = read_reward_conf(config_dir)?;
 
         let use_nns_public_key = state_root.join("nns_public_key.pem").exists();
         let use_node_operator_private_key =
@@ -45,7 +46,7 @@ pub fn update_guestos_config() -> Result<()> {
         let deployment_environment = DeploymentEnvironment::Mainnet;
 
         let icos_settings = ICOSSettings {
-            node_reward_type: None,
+            node_reward_type,
             mgmt_mac,
             deployment_environment,
             logging: Logging::default(),
@@ -172,6 +173,15 @@ fn read_nns_conf(config_dir: &Path) -> Result<Vec<Url>> {
     }
 
     Ok(nns_urls)
+}
+
+fn read_reward_conf(config_dir: &Path) -> Result<Option<String>> {
+    let reward_conf_path = config_dir.join("reward.conf");
+    let conf_map = read_conf_file(&reward_conf_path)?;
+
+    let node_reward_type = conf_map.get("node_reward_type").cloned();
+
+    Ok(node_reward_type)
 }
 
 fn derive_mgmt_mac_from_hostname(hostname: Option<&str>) -> Result<MacAddr6> {

--- a/rs/ic_os/config_types/src/lib.rs
+++ b/rs/ic_os/config_types/src/lib.rs
@@ -247,7 +247,7 @@ mod tests {
                 domain_name: None,
             },
             icos_settings: ICOSSettings {
-                node_reward_type: Some(String::new()),
+                node_reward_type: None,
                 mgmt_mac: "00:00:00:00:00:00".parse()?,
                 deployment_environment: DeploymentEnvironment::Testnet,
                 logging: Logging::default(),


### PR DESCRIPTION
A few small updates to update-config. Most notably: [Add node reward type update-config parsing](https://github.com/dfinity/ic/pull/3132/commits/f297cee67edf46f1975e1dd803116edf8838f3c0)