### PR TITLE
fix(BOUN-1308): use default shell and downgrade release action

### DIFF
--- a/.github/workflows/anonymization-backend-release.yml
+++ b/.github/workflows/anonymization-backend-release.yml
@@ -20,6 +20,10 @@ env:
   NAME: anonymization-backend
   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   build-and-release:
     name: Build and release the anonymization backend canister
@@ -37,7 +41,6 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: build
-        shell: bash
         run: |
           TARGET='//rs/boundary_node/anonymization/backend:anonymization_backend'
           bazel build --config=ci ${TARGET}
@@ -46,7 +49,6 @@ jobs:
           mv ${OUTPUT} anonymization_backend.wasm.gz
 
       - name: artifacts
-        shell: bash
         run: |
           ARTIFACTS=(
             anonymization_backend.wasm.gz
@@ -57,7 +59,6 @@ jobs:
           echo "EOF"                                           >> $GITHUB_ENV
 
       - name: checksums
-        shell: bash
         run: |
           CHECKSUMS=$(mktemp)
 
@@ -68,7 +69,6 @@ jobs:
           echo "CHECKSUMS=${CHECKSUMS}" >> "${GITHUB_ENV}"
 
       - name: tag
-        shell: bash
         run: |
           COMMIT_SHORT=$(git rev-parse --short HEAD)
           RELEASE_TAG="${{ env.NAME }}-${COMMIT_SHORT}"
@@ -76,7 +76,6 @@ jobs:
           echo "RELEASE_TAG=${RELEASE_TAG}" >> "${GITHUB_ENV}"
 
       - name: release notes
-        shell: bash
         run: |
           NOTES=$(mktemp)
 
@@ -103,7 +102,7 @@ jobs:
           echo "NOTES=${NOTES}" >> "${GITHUB_ENV}"
 
       - name: release
-        uses: softprops/action-gh-release@7b4da11513bf3f43f9999e90eabced41ab8bb048
+        uses: softprops/action-gh-release@e7a8f85e1c67a31e6ed99a94b41bd0b71bbee6b8
         with:
           tag_name: ${{ env.RELEASE_TAG }}
           name: ${{ inputs.title }}

--- a/.github/workflows/rate-limits-backend-release.yml
+++ b/.github/workflows/rate-limits-backend-release.yml
@@ -20,6 +20,10 @@ env:
   NAME: rate-limits
   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   build-and-release:
     name: Build and release the rate-limits backend canister
@@ -37,7 +41,6 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: build
-        shell: bash
         run: |
           TARGET='//rs/boundary_node/rate_limits:rate_limit_canister'
           bazel build --config=ci ${TARGET}
@@ -46,7 +49,6 @@ jobs:
           mv ${OUTPUT} rate_limit_canister.wasm.gz
 
       - name: artifacts
-        shell: bash
         run: |
           ARTIFACTS=(
             rate_limit_canister.wasm.gz
@@ -57,7 +59,6 @@ jobs:
           echo "EOF"                                           >> $GITHUB_ENV
 
       - name: checksums
-        shell: bash
         run: |
           CHECKSUMS=$(mktemp)
 
@@ -68,7 +69,6 @@ jobs:
           echo "CHECKSUMS=${CHECKSUMS}" >> "${GITHUB_ENV}"
 
       - name: tag
-        shell: bash
         run: |
           COMMIT_SHORT=$(git rev-parse --short HEAD)
           RELEASE_TAG="${{ env.NAME }}-${COMMIT_SHORT}"
@@ -76,7 +76,6 @@ jobs:
           echo "RELEASE_TAG=${RELEASE_TAG}" >> "${GITHUB_ENV}"
 
       - name: release notes
-        shell: bash
         run: |
           NOTES=$(mktemp)
 
@@ -103,7 +102,7 @@ jobs:
           echo "NOTES=${NOTES}" >> "${GITHUB_ENV}"
 
       - name: release
-        uses: softprops/action-gh-release@7b4da11513bf3f43f9999e90eabced41ab8bb048
+        uses: softprops/action-gh-release@e7a8f85e1c67a31e6ed99a94b41bd0b71bbee6b8
         with:
           tag_name: ${{ env.RELEASE_TAG }}
           name: ${{ inputs.title }}


### PR DESCRIPTION
This change applies @nmattia's suggestion about using a default shell. He also mentioned he believes that bash is the default but prior to this I had to set the shell to bash so I'm not confident if that is true.

It also downgrades the release action due to https://github.com/softprops/action-gh-release/issues/556