### PR TITLE
chore(crypto): Reflect the message hash in signature verification errors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -675,7 +675,6 @@ rsa = { version = "0.9.6", features = ["sha2"] }
 rstest = "0.19.0"
 rustc-demangle = { version = "0.1.16" }
 rustls = { version = "0.23.18", default-features = false, features = [
-    "tls12",
     "ring",
     "std",
     "brotli",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -675,6 +675,7 @@ rsa = { version = "0.9.6", features = ["sha2"] }
 rstest = "0.19.0"
 rustc-demangle = { version = "0.1.16" }
 rustls = { version = "0.23.18", default-features = false, features = [
+    "tls12",
     "ring",
     "std",
     "brotli",

--- a/rs/crypto/internal/crypto_lib/basic_sig/ecdsa_secp256k1/src/api.rs
+++ b/rs/crypto/internal/crypto_lib/basic_sig/ecdsa_secp256k1/src/api.rs
@@ -156,6 +156,7 @@ pub fn verify(
             algorithm: AlgorithmId::EcdsaSecp256k1,
             public_key_bytes: pk.0.to_vec(),
             sig_bytes: sig.0.to_vec(),
+            msg_hash: Some(msg.to_vec()),
             internal_error: "verification failed".to_string(),
         }),
     }

--- a/rs/crypto/internal/crypto_lib/basic_sig/ecdsa_secp256k1/tests/api_tests.rs
+++ b/rs/crypto/internal/crypto_lib/basic_sig/ecdsa_secp256k1/tests/api_tests.rs
@@ -279,10 +279,11 @@ mod verify {
         invalid_signature.0[2] ^= 1;
 
         let result = verify(&invalid_signature, &msg, &pk);
-        assert_matches!(result, Err(CryptoError::SignatureVerification{algorithm, public_key_bytes, sig_bytes, internal_error: _})
+        assert_matches!(result, Err(CryptoError::SignatureVerification{algorithm, public_key_bytes, sig_bytes, msg_hash, internal_error: _})
                         if algorithm == AlgorithmId::EcdsaSecp256k1 &&
                         public_key_bytes == pk.0 &&
-                        sig_bytes == invalid_signature.0);
+                        sig_bytes == invalid_signature.0 &&
+                        msg_hash == Some(msg));
     }
 
     #[test]

--- a/rs/crypto/internal/crypto_lib/basic_sig/ecdsa_secp256r1/src/api.rs
+++ b/rs/crypto/internal/crypto_lib/basic_sig/ecdsa_secp256r1/src/api.rs
@@ -177,6 +177,7 @@ pub fn verify(
             algorithm: AlgorithmId::EcdsaP256,
             public_key_bytes: pk.0.to_vec(),
             sig_bytes: sig.0.to_vec(),
+            msg_hash: Some(msg.to_vec()),
             internal_error: "verification failed".to_string(),
         }),
     }

--- a/rs/crypto/internal/crypto_lib/basic_sig/ecdsa_secp256r1/tests/api_tests.rs
+++ b/rs/crypto/internal/crypto_lib/basic_sig/ecdsa_secp256r1/tests/api_tests.rs
@@ -177,10 +177,11 @@ mod verify {
         invalid_signature.0[2] ^= 1;
 
         let result = verify(&invalid_signature, &msg, &pk);
-        assert_matches!(result, Err(CryptoError::SignatureVerification{algorithm, public_key_bytes, sig_bytes, internal_error: _})
+        assert_matches!(result, Err(CryptoError::SignatureVerification{algorithm, public_key_bytes, sig_bytes, msg_hash, internal_error: _})
                         if algorithm == AlgorithmId::EcdsaP256 &&
                         public_key_bytes == pk.0 &&
-                        sig_bytes == invalid_signature.0);
+                        sig_bytes == invalid_signature.0 &&
+                        msg_hash == Some(msg));
     }
 }
 

--- a/rs/crypto/internal/crypto_lib/basic_sig/ed25519/src/api.rs
+++ b/rs/crypto/internal/crypto_lib/basic_sig/ed25519/src/api.rs
@@ -174,7 +174,11 @@ pub fn verify(
             algorithm: AlgorithmId::Ed25519,
             public_key_bytes: public_key.serialize_raw().to_vec(),
             sig_bytes: sig.0.to_vec(),
-            msg_hash: if msg.len() == 32 { Some(msg.to_vec()) } else { None },
+            msg_hash: if msg.len() == 32 {
+                Some(msg.to_vec())
+            } else {
+                None
+            },
             internal_error: e.to_string(),
         })
 }

--- a/rs/crypto/internal/crypto_lib/basic_sig/ed25519/src/api.rs
+++ b/rs/crypto/internal/crypto_lib/basic_sig/ed25519/src/api.rs
@@ -174,6 +174,7 @@ pub fn verify(
             algorithm: AlgorithmId::Ed25519,
             public_key_bytes: public_key.serialize_raw().to_vec(),
             sig_bytes: sig.0.to_vec(),
+            msg_hash: if msg.len() == 32 { Some(msg.to_vec()) } else { None },
             internal_error: e.to_string(),
         })
 }

--- a/rs/crypto/internal/crypto_lib/basic_sig/iccsa/src/api.rs
+++ b/rs/crypto/internal/crypto_lib/basic_sig/iccsa/src/api.rs
@@ -125,6 +125,7 @@ fn verify_certified_data(
             algorithm: AlgorithmId::IcCanisterSignature,
             public_key_bytes: pk.0.clone(),
             sig_bytes: sig.0.clone(),
+            msg_hash: Some(digest.to_vec()),
             internal_error: format!("certificate verification failed: {}", err),
         },
     })?;
@@ -159,6 +160,7 @@ fn lookup_path_in_tree(
                 algorithm: AlgorithmId::IcCanisterSignature,
                 public_key_bytes: pk.0.clone(),
                 sig_bytes: sig.0.clone(),
+                msg_hash: Some(msg_hash.to_vec()),
                 internal_error: format!(
                     "the signature tree doesn't contain sig/{}/{} path",
                     hex::encode(seed_hash),
@@ -171,6 +173,7 @@ fn lookup_path_in_tree(
             algorithm: AlgorithmId::IcCanisterSignature,
             public_key_bytes: pk.0.clone(),
             sig_bytes: sig.0.clone(),
+            msg_hash: Some(msg_hash.to_vec()),
             internal_error:
                 "The result of 'lookup_path' in the signature tree was not a leaf containing \"\""
                     .to_string(),

--- a/rs/crypto/internal/crypto_lib/basic_sig/iccsa/tests/api.rs
+++ b/rs/crypto/internal/crypto_lib/basic_sig/iccsa/tests/api.rs
@@ -98,7 +98,7 @@ fn should_fail_to_verify_on_wrong_message() {
 
         let result = verify(wrong_msg, sig_bytes, canister_pk_bytes, &root_pk);
 
-        assert_matches!(result, Err(CryptoError::SignatureVerification {  algorithm, public_key_bytes: _, sig_bytes: _, internal_error})
+        assert_matches!(result, Err(CryptoError::SignatureVerification {  algorithm, public_key_bytes: _, sig_bytes: _, msg_hash: _, internal_error})
             if internal_error.contains("the signature tree doesn't contain sig")
             && algorithm == AlgorithmId::IcCanisterSignature
         );
@@ -119,7 +119,7 @@ fn should_fail_to_verify_if_signature_certificate_verification_fails() {
 
         let result = verify(&msg, corrupted_sig, canister_pk_bytes, &root_pk);
 
-        assert_matches!(result, Err(CryptoError::SignatureVerification {  algorithm, public_key_bytes: _, sig_bytes: _, internal_error})
+        assert_matches!(result, Err(CryptoError::SignatureVerification {  algorithm, public_key_bytes: _, sig_bytes: _, msg_hash: _, internal_error})
             if internal_error.contains("certificate verification failed")
             && algorithm == AlgorithmId::IcCanisterSignature
         );
@@ -135,7 +135,7 @@ fn should_fail_to_verify_on_wrong_pubkey() {
 
         let result = verify(&msg, sig_bytes, canister_pk_bytes, &root_pk);
 
-        assert_matches!(result, Err(CryptoError::SignatureVerification {  algorithm, public_key_bytes: _, sig_bytes: _, internal_error})
+        assert_matches!(result, Err(CryptoError::SignatureVerification {  algorithm, public_key_bytes: _, sig_bytes: _, msg_hash: _, internal_error})
             if internal_error.contains("the signature tree doesn't contain sig")
             && algorithm == AlgorithmId::IcCanisterSignature
         );
@@ -172,7 +172,7 @@ fn should_fail_to_verify_on_invalid_root_pubkey() {
 
         println!("{:?}", result.clone().err());
 
-        assert_matches!(result, Err(CryptoError::SignatureVerification {  algorithm, public_key_bytes: _, sig_bytes: _, internal_error})
+        assert_matches!(result, Err(CryptoError::SignatureVerification {  algorithm, public_key_bytes: _, sig_bytes: _, msg_hash: _, internal_error})
             if internal_error.contains("Invalid public key")
             && internal_error.contains("certificate verification failed")
             && algorithm == AlgorithmId::IcCanisterSignature
@@ -198,7 +198,7 @@ fn should_fail_to_verify_on_wrong_root_pubkey() {
 
         let result = verify(&msg, sig_bytes, canister_pk_bytes, &wrong_root_pk);
 
-        assert_matches!(result, Err(CryptoError::SignatureVerification {  algorithm, public_key_bytes: _, sig_bytes: _, internal_error})
+        assert_matches!(result, Err(CryptoError::SignatureVerification {  algorithm, public_key_bytes: _, sig_bytes: _, msg_hash: _, internal_error})
             if internal_error.contains("Invalid combined threshold signature")
             && internal_error.contains("certificate verification failed")
             && algorithm == AlgorithmId::IcCanisterSignature

--- a/rs/crypto/internal/crypto_lib/basic_sig/rsa_pkcs1/src/lib.rs
+++ b/rs/crypto/internal/crypto_lib/basic_sig/rsa_pkcs1/src/lib.rs
@@ -173,6 +173,7 @@ impl RsaPublicKey {
                 algorithm: AlgorithmId::RsaSha256,
                 public_key_bytes: self.as_der().to_vec(),
                 sig_bytes: signature.to_vec(),
+                msg_hash: None,
                 internal_error: format!(
                     "Signature is {} bytes but public modulus only {}",
                     signature.len(),
@@ -187,6 +188,7 @@ impl RsaPublicKey {
                 algorithm: AlgorithmId::RsaSha256,
                 public_key_bytes: self.as_der().to_vec(),
                 sig_bytes: signature.to_vec(),
+                msg_hash: None,
                 internal_error: "Signature is larger than public modulus".to_string(),
             });
         }
@@ -202,6 +204,7 @@ impl RsaPublicKey {
                 algorithm: AlgorithmId::RsaSha256,
                 public_key_bytes: self.as_der().to_vec(),
                 sig_bytes: signature.to_vec(),
+                msg_hash: Some(digest.to_vec()),
                 internal_error: format!("{:?}", e),
             }),
         }

--- a/rs/crypto/internal/crypto_lib/multi_sig/bls12_381/src/api.rs
+++ b/rs/crypto/internal/crypto_lib/multi_sig/bls12_381/src/api.rs
@@ -115,6 +115,7 @@ pub fn verify_individual(
             algorithm: AlgorithmId::MultiBls12_381,
             public_key_bytes: public_key_bytes.0.to_vec(),
             sig_bytes: signature_bytes.0.to_vec(),
+            msg_hash: Some(message.to_vec()),
             internal_error: "Verification of individual contribution to multisignature failed"
                 .to_string(),
         })
@@ -149,6 +150,7 @@ pub fn verify_combined(
             algorithm: AlgorithmId::MultiBls12_381,
             public_key_bytes: Vec::new(),
             sig_bytes: signature.0.to_vec(),
+            msg_hash: Some(message.to_vec()),
             internal_error: "Verification of multisignature failed".to_string(),
         })
     }

--- a/rs/crypto/internal/crypto_lib/threshold_sig/bls12_381/src/crypto.rs
+++ b/rs/crypto/internal/crypto_lib/threshold_sig/bls12_381/src/crypto.rs
@@ -239,6 +239,7 @@ pub(crate) fn verify_individual_sig(
             algorithm: AlgorithmId::ThresBls12_381,
             public_key_bytes: PublicKeyBytes::from(public_key).0.to_vec(),
             sig_bytes: IndividualSignatureBytes::from(signature).0.to_vec(),
+            msg_hash: Some(message.to_vec()),
             internal_error: "Invalid individual threshold signature".to_string(),
         }),
     }
@@ -260,6 +261,7 @@ pub(crate) fn verify_combined_sig(
             algorithm: AlgorithmId::ThresBls12_381,
             public_key_bytes: PublicKeyBytes::from(public_key).0.to_vec(),
             sig_bytes: CombinedSignatureBytes::from(signature).0.to_vec(),
+            msg_hash: Some(message.to_vec()),
             internal_error: "Invalid combined threshold signature".to_string(),
         }),
     }

--- a/rs/crypto/internal/crypto_service_provider/csp_proptest_utils/src/lib.rs
+++ b/rs/crypto/internal/crypto_service_provider/csp_proptest_utils/src/lib.rs
@@ -388,7 +388,7 @@ mod crypto_error {
         MalformedPublicKey => {algorithm in arb_algorithm_id(), key_bytes in proptest::option::of(vec(any::<u8>(), 0..100)), internal_error in ".*"},
         MalformedSignature => {algorithm in arb_algorithm_id(), sig_bytes in vec(any::<u8>(), 0..100), internal_error in ".*"},
         MalformedPop => {algorithm in arb_algorithm_id(), pop_bytes in vec(any::<u8>(), 0..100), internal_error in ".*"},
-        SignatureVerification => {algorithm in arb_algorithm_id(), public_key_bytes in vec(any::<u8>(), 0..100), sig_bytes in vec(any::<u8>(), 0..100), internal_error in ".*"},
+        SignatureVerification => {algorithm in arb_algorithm_id(), public_key_bytes in vec(any::<u8>(), 0..100), sig_bytes in vec(any::<u8>(), 0..100), msg_hash in proptest::option::of(vec(any::<u8>(), 0..32)), internal_error in ".*"},
         PopVerification => {algorithm in arb_algorithm_id(), public_key_bytes in vec(any::<u8>(), 0..100), pop_bytes in vec(any::<u8>(), 0..100), internal_error in ".*"},
         InconsistentAlgorithms => {algorithms in btree_set(arb_algorithm_id(), 0..10), key_purpose in arb_key_purpose(), registry_version in arb_registry_version()},
         AlgorithmNotSupported => {algorithm in arb_algorithm_id(), reason in ".*"},

--- a/rs/crypto/internal/crypto_service_provider/src/signer/mod.rs
+++ b/rs/crypto/internal/crypto_service_provider/src/signer/mod.rs
@@ -116,6 +116,7 @@ impl CspSigner for Csp {
                 algorithm: algorithm_id,
                 public_key_bytes: signer.as_ref().to_vec(),
                 sig_bytes: sig.as_ref().to_vec(),
+                msg_hash: None,
                 internal_error: "Unsupported types".to_string(),
             }),
         }
@@ -193,6 +194,7 @@ impl CspSigner for Csp {
                             algorithm: algorithm_id,
                             public_key_bytes: signer.as_ref().to_vec(),
                             sig_bytes: signature.0.to_vec(),
+                            msg_hash: Some(msg.to_vec()),
                             internal_error: "Public key not of type MultiBls12_381".to_string(),
                         }),
                     })

--- a/rs/crypto/src/sign/basic_sig.rs
+++ b/rs/crypto/src/sign/basic_sig.rs
@@ -100,6 +100,7 @@ impl BasicSigVerifierInternal {
                 algorithm: AlgorithmId::Ed25519,
                 public_key_bytes: vec![],
                 sig_bytes: vec![],
+                msg_hash: None,
                 internal_error: e.to_string(),
             }
         })

--- a/rs/crypto/src/sign/threshold_sig/tests.rs
+++ b/rs/crypto/src/sign/threshold_sig/tests.rs
@@ -1560,6 +1560,7 @@ fn sig_verification_error() -> CryptoError {
         algorithm: AlgorithmId::ThresBls12_381,
         public_key_bytes: vec![],
         sig_bytes: vec![],
+        msg_hash: None,
         internal_error: "".to_string(),
     }
 }

--- a/rs/crypto/tests/canister_signatures.rs
+++ b/rs/crypto/tests/canister_signatures.rs
@@ -100,7 +100,7 @@ fn should_fail_to_verify_on_wrong_signature() {
             &data.root_of_trust,
         );
 
-        assert_matches!(result, Err(CryptoError::SignatureVerification {  algorithm, public_key_bytes: _, sig_bytes: _, internal_error})
+        assert_matches!(result, Err(CryptoError::SignatureVerification {  algorithm, public_key_bytes: _, sig_bytes: _, msg_hash: _, internal_error})
                 if internal_error.contains("certificate verification failed")
                 && algorithm == AlgorithmId::IcCanisterSignature
         );
@@ -122,7 +122,7 @@ fn should_fail_to_verify_on_wrong_message() {
             &data.root_of_trust,
         );
 
-        assert_matches!(result, Err(CryptoError::SignatureVerification {  algorithm, public_key_bytes: _, sig_bytes: _, internal_error})
+        assert_matches!(result, Err(CryptoError::SignatureVerification {  algorithm, public_key_bytes: _, sig_bytes: _, msg_hash: _, internal_error})
                 if internal_error.contains("the signature tree doesn't contain sig")
                 && algorithm == AlgorithmId::IcCanisterSignature
         );
@@ -147,7 +147,7 @@ fn should_fail_to_verify_on_wrong_public_key() {
             &data.root_of_trust,
         );
 
-        assert_matches!(result, Err(CryptoError::SignatureVerification {  algorithm, public_key_bytes: _, sig_bytes: _, internal_error})
+        assert_matches!(result, Err(CryptoError::SignatureVerification {  algorithm, public_key_bytes: _, sig_bytes: _, msg_hash: _, internal_error})
                 if internal_error.contains("the signature tree doesn't contain sig")
                 && algorithm == AlgorithmId::IcCanisterSignature
         );
@@ -170,7 +170,7 @@ fn should_fail_to_verify_on_invalid_root_public_key() {
             &invalid_root_pk,
         );
 
-        assert_matches!(result, Err(CryptoError::SignatureVerification {  algorithm, public_key_bytes: _, sig_bytes: _, internal_error})
+        assert_matches!(result, Err(CryptoError::SignatureVerification {  algorithm, public_key_bytes: _, sig_bytes: _, msg_hash: _, internal_error})
                 if internal_error.contains("Invalid public key")
                 && internal_error.contains("certificate verification failed")
                 && algorithm == AlgorithmId::IcCanisterSignature
@@ -202,7 +202,7 @@ fn should_fail_to_verify_on_wrong_root_public_key() {
             &wrong_root_pk,
         );
 
-        assert_matches!(result, Err(CryptoError::SignatureVerification {  algorithm, public_key_bytes: _, sig_bytes: _, internal_error})
+        assert_matches!(result, Err(CryptoError::SignatureVerification {  algorithm, public_key_bytes: _, sig_bytes: _, msg_hash: _, internal_error})
                 if internal_error.contains("Invalid combined threshold signature")
                 && internal_error.contains("certificate verification failed")
                 && algorithm == AlgorithmId::IcCanisterSignature

--- a/rs/types/types/src/crypto.rs
+++ b/rs/types/types/src/crypto.rs
@@ -341,6 +341,7 @@ pub enum CryptoError {
         algorithm: AlgorithmId,
         public_key_bytes: Vec<u8>,
         sig_bytes: Vec<u8>,
+        msg_hash: Option<Vec<u8>>,
         internal_error: String,
     },
     /// Pop could not be verified.
@@ -550,13 +551,15 @@ impl fmt::Debug for CryptoError {
                 algorithm,
                 public_key_bytes,
                 sig_bytes,
+                msg_hash,
                 internal_error,
             } => write!(
                 f,
-                "{:?} signature could not be verified: public key {}, signature {}, error: {}",
+                "{:?} signature could not be verified: public key {}, signature {}, message hash {} error: {}",
                 algorithm,
                 hex::encode(public_key_bytes),
                 hex::encode(sig_bytes),
+                if let Some(h) = msg_hash { hex::encode(h) } else { "unavailable".to_string() },
                 internal_error,
             ),
             CryptoError::PopVerification {


### PR DESCRIPTION
This makes it easier to diagnose signature verification issues from logs or user-provided error messages.