### PR TITLE
chore(nervous-system): Fix cargo dependency tree

### DIFF
--- a/rs/nervous_system/long_message/Cargo.toml
+++ b/rs/nervous_system/long_message/Cargo.toml
@@ -19,9 +19,11 @@ ic-cdk-timers = { workspace = true }
 ic-registry-subnet-type = { path = "../../registry/subnet_type" }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+dfn_candid = { path = "../../rust_canisters/dfn_candid" }
 ic-nervous-system-temporary = { path = "../../nervous_system/temporary" }
+ic-config = { path = "../../config" }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 ic-state-machine-tests = { path = "../../state_machine_tests" }
 ic-nns-test-utils = { path = "../../nns/test_utils" }
 canister-test = { path = "../../rust_canisters/canister_test" }
-dfn_candid = { path = "../../rust_canisters/dfn_candid" }
-ic-config = { path = "../../config" }


### PR DESCRIPTION
This fixes miscategorization of types in cargo to match what's in the bazel configuration.