### PR TITLE
fix(node): setupos networking dependency

### DIFF
--- a/ic-os/components/setupos-scripts/setupos.service
+++ b/ic-os/components/setupos-scripts/setupos.service
@@ -1,6 +1,8 @@
 [Unit]
 Description=SetupOS install process
 After=generate-network-config.service
+After=systemd-networkd-wait-online.service
+Wants=systemd-networkd-wait-online.service
 
 [Service]
 Type=idle


### PR DESCRIPTION
Setting setupos.service to depend on systemd-networkd-wait-online.service prevents a timing issue where setupos.service runs before the networking has been set up.

If generate-network-config fails, setupos.service still runs. It just hangs for a minute after generate-network-config fails before starting setupos.service. 