### PR TITLE
fix(nns): Fix benchmark by simulating proper behavior in canbench-rs build

### DIFF
--- a/rs/nns/governance/canbench/canbench_results.yml
+++ b/rs/nns/governance/canbench/canbench_results.yml
@@ -1,73 +1,73 @@
 benches:
   add_neuron_active_maximum:
     total:
-      instructions: 36164619
+      instructions: 36155076
       heap_increase: 1
       stable_memory_increase: 0
     scopes: {}
   add_neuron_active_typical:
     total:
-      instructions: 1834736
+      instructions: 1834230
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   add_neuron_inactive_maximum:
     total:
-      instructions: 96124805
+      instructions: 96097938
       heap_increase: 1
       stable_memory_increase: 0
     scopes: {}
   add_neuron_inactive_typical:
     total:
-      instructions: 7369666
+      instructions: 7366914
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   cascading_vote_all_heap:
     total:
-      instructions: 34418252
+      instructions: 34431941
       heap_increase: 0
       stable_memory_increase: 128
     scopes: {}
   cascading_vote_heap_neurons_stable_index:
     total:
-      instructions: 56553893
+      instructions: 56566838
       heap_increase: 0
       stable_memory_increase: 128
     scopes: {}
   cascading_vote_stable_everything:
     total:
-      instructions: 371815016
+      instructions: 163131819
       heap_increase: 0
       stable_memory_increase: 128
     scopes: {}
   cascading_vote_stable_neurons_with_heap_index:
     total:
-      instructions: 349629136
+      instructions: 140864617
       heap_increase: 0
       stable_memory_increase: 128
     scopes: {}
   centralized_following_all_stable:
     total:
-      instructions: 174310560
+      instructions: 68259968
       heap_increase: 0
       stable_memory_increase: 128
     scopes: {}
   compute_ballots_for_new_proposal_with_stable_neurons:
     total:
-      instructions: 1815415
+      instructions: 1815411
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   draw_maturity_from_neurons_fund_heap:
     total:
-      instructions: 7242119
+      instructions: 7248219
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   draw_maturity_from_neurons_fund_stable:
     total:
-      instructions: 10300850
+      instructions: 10293728
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
@@ -79,13 +79,13 @@ benches:
     scopes: {}
   list_active_neurons_fund_neurons_stable:
     total:
-      instructions: 2450279
+      instructions: 2450275
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   list_neurons_heap:
     total:
-      instructions: 3900350
+      instructions: 3900688
       heap_increase: 9
       stable_memory_increase: 0
     scopes: {}
@@ -97,13 +97,13 @@ benches:
     scopes: {}
   list_neurons_ready_to_unstake_maturity_stable:
     total:
-      instructions: 36937657
+      instructions: 36937653
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   list_neurons_stable:
     total:
-      instructions: 97878941
+      instructions: 97962451
       heap_increase: 5
       stable_memory_increase: 0
     scopes: {}
@@ -115,19 +115,19 @@ benches:
     scopes: {}
   list_ready_to_spawn_neuron_ids_stable:
     total:
-      instructions: 36926358
+      instructions: 36926354
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   neuron_data_validation_heap:
     total:
-      instructions: 349808709
+      instructions: 349668956
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   neuron_data_validation_stable:
     total:
-      instructions: 312718406
+      instructions: 312681996
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
@@ -139,25 +139,25 @@ benches:
     scopes: {}
   neuron_metrics_calculation_stable:
     total:
-      instructions: 2476869
+      instructions: 2476865
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   range_neurons_performance:
     total:
-      instructions: 47700446
+      instructions: 47700442
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   single_vote_all_stable:
     total:
-      instructions: 2477911
+      instructions: 2731286
       heap_increase: 0
       stable_memory_increase: 128
     scopes: {}
   update_recent_ballots_stable_memory:
     total:
-      instructions: 236980
+      instructions: 236846
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}


### PR DESCRIPTION
In order to get approximately the same number of read/writes in stable for the VotingStateMachine, it is required to count accurately.  Canbench doesn't allow queries, which means the instruction_counter never gives a different result, which means the benchmark thinks it runs out of cycles on every iteration, and thus saves and restores the ProposalVotingStateMachine over and over, leading to an inaccurate benchmark compared to production.

This adds code to approximately simulate behavior in canbench-rs build.