### PR TITLE
chore(ICP-Rosetta): add release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11681,7 +11681,7 @@ dependencies = [
 
 [[package]]
 name = "ic-rosetta-api"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
  "actix-rt",
  "actix-web",

--- a/rs/rosetta-api/icp/BUILD.bazel
+++ b/rs/rosetta-api/icp/BUILD.bazel
@@ -99,7 +99,7 @@ MACRO_DEV_DEPENDENCIES = []
 ALIASES = {
 }
 
-ROSETTA_VERSION = "2.1.0"
+ROSETTA_VERSION = "2.1.1"
 
 rust_library(
     name = "rosetta-api",

--- a/rs/rosetta-api/icp/CHANGELOG.md
+++ b/rs/rosetta-api/icp/CHANGELOG.md
@@ -3,8 +3,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
-
 ## Unreleased
+
+## [2.1.1] - 2024-12-13
+### Added
+- added functionality to refresh voting power on the governance canister
 
 ## [2.1.0] - 2024-08-21
 ### Fixes

--- a/rs/rosetta-api/icp/Cargo.toml
+++ b/rs/rosetta-api/icp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic-rosetta-api"
-version = "2.1.0"
+version = "2.1.1"
 authors = ["The Internet Computer Project Developers"]
 description = "Build Once. Integrate Your Blockchain Everywhere. "
 edition = "2021"


### PR DESCRIPTION
This MR proposes the follwoing changes

1. Change ICP Rosetta to 2.1.1 for the upcoming release 