### PR TITLE
test(IDX): disable //rs/pocket_ic_server:test on Apple Silicon

### DIFF
--- a/rs/pocket_ic_server/BUILD.bazel
+++ b/rs/pocket_ic_server/BUILD.bazel
@@ -189,7 +189,19 @@ rust_test(
     },
     tags = [
         "cpu:8",
-        "test_macos",
+        # TODO: enable "test_macos" again when we have fixed the following error on Apple Silicon:
+        #
+        #  ---- test_http_gateway stdout ----
+        #  thread 'test_http_gateway' panicked at rs/pocket_ic_server/tests/test.rs:383:48:
+        #  called `Result::unwrap()` on an `Err` value: reqwest::Error {
+        #    kind: Request, url: "http://7tjcv-pp777-77776-qaaaa-cai.raw.localhost:49380/",
+        #    source: hyper_util::client::legacy::Error(
+        #      Connect,
+        #      ConnectError("tcp connect error", Os { code: 1, kind: PermissionDenied, message: "Operation not permitted" })
+        #    )
+        #  }
+        #
+        #"test_macos",
     ],
     deps = TEST_DEPENDENCIES,
 )


### PR DESCRIPTION
This temporarily disables the `//rs/pocket_ic_server:test` on Apple Silicon because it occasionally runs into the following error:
```
---- test_http_gateway stdout ----
thread 'test_http_gateway' panicked at rs/pocket_ic_server/tests/test.rs:383:48:
called `Result::unwrap()` on an `Err` value: reqwest::Error {
  kind: Request, url: "http://7tjcv-pp777-77776-qaaaa-cai.raw.localhost:49380/",
  source: hyper_util::client::legacy::Error(
    Connect,
    ConnectError("tcp connect error", Os { code: 1, kind: PermissionDenied, message: "Operation not permitted" })
  )
}
```