### PR TITLE
fix(tests): Reduce timeout in `tecdsa_signature_timeout_test`

### DIFF
--- a/rs/tests/consensus/tecdsa/tecdsa_signature_timeout_test.rs
+++ b/rs/tests/consensus/tecdsa/tecdsa_signature_timeout_test.rs
@@ -42,7 +42,7 @@ fn test(env: TestEnv) {
             &governance,
             app_subnet.subnet_id,
             key_ids.clone(),
-            Some(Duration::from_secs(1)),
+            Some(Duration::from_millis(1)),
             &log,
         )
         .await;


### PR DESCRIPTION
This test makes sure that signature requests fail after the configured timeout. It turns out that we occasionally manage to create signatures in less than 1 second, making this test flaky. This PR reduces the timeout to 1 millisecond instead.