### PR TITLE
chore(nns): Bump mainnet canister revisions after the last Registry upgrade

### DIFF
--- a/mainnet-canisters.json
+++ b/mainnet-canisters.json
@@ -52,8 +52,8 @@
     "sha256": "76978515223287ece643bc7ca087eb310412b737e2382a73b8ae55fcb458da5b"
   },
   "registry": {
-    "rev": "d265b130647f04aa25909ec1fbb8294ce0139d1c",
-    "sha256": "2fabd44386a8af5a579a72af4a27c6b844a8a88aced49d16f286187e5660d771"
+    "rev": "86229594d61b433c39fc5331ab818ccb6c6aa6a7",
+    "sha256": "b0b2a7f37e76fcbab20a861fdf65c34d7ac2ca84a5190d204dfe5e1c50fb383e"
   },
   "root": {
     "rev": "c494c2af8bfc70a6501448dc73bf806477388738",


### PR DESCRIPTION
This PR bump the mainnet canister revisions file after the last Registry upgrade (https://dashboard.internetcomputer.org/proposal/134437).