### PR TITLE
test: set flaky to True for //rs/sns/integration_tests

### DIFF
--- a/rs/sns/integration_tests/BUILD.bazel
+++ b/rs/sns/integration_tests/BUILD.bazel
@@ -203,6 +203,7 @@ rust_ic_test_suite_with_extra_srcs(
     data = DATA_DEPS,
     env = ENV,
     extra_srcs = [],
+    flaky = True,
     proc_macro_deps = MACRO_DEPENDENCIES + MACRO_DEV_DEPENDENCIES,
     tags = ["cpu:8"],
     deps = DEPENDENCIES_WITH_TEST_FEATURES + TEST_DEV_DEPENDENCIES,


### PR DESCRIPTION
The `//rs/sns/integration_tests:...` fail a lot on PRs and master so we set `flaky = True` so the test gets a chance to pass. If the flakiness turns out too high the NNS team should look into fixing it.