### PR TITLE
fix(node): silence libunwind denials and allow systemd NoNewPrivileges for fstrim_tool

### DIFF
--- a/ic-os/components/selinux/ic-node/ic-node.te
+++ b/ic-os/components/selinux/ic-node/ic-node.te
@@ -346,6 +346,11 @@ dontaudit ic_canister_sandbox_t proc_t : dir { search };
 dontaudit ic_canister_sandbox_t proc_t : lnk_file { read };
 dontaudit ic_canister_sandbox_t ic_canister_sandbox_t : lnk_file { read };
 
+# There is a pipe used by libunwind to probe memory when generating stack traces.
+# The `anyhow` crate since 1.0.77 is generating stack traces for all errors, not only panics.
+# For now, we silently deny this, until RUST_LIB_BACKTRACE=0 is rolled out and reduces the noise.
+dontaudit ic_canister_sandbox_t ic_canister_sandbox_t : fifo_file { read write };
+
 # Deny accessing system information (tries to access "/proc/sys/kernel/osrelease" for unspecified reasons).
 dontaudit ic_canister_sandbox_t sysctl_kernel_t : dir { search };
 dontaudit ic_canister_sandbox_t sysctl_kernel_t : file { getattr open read };

--- a/ic-os/components/selinux/systemd-fixes/systemd-fixes.te
+++ b/ic-os/components/selinux/systemd-fixes/systemd-fixes.te
@@ -10,6 +10,10 @@ policy_module(systemd-fixes, 1.0.0)
 require { type init_t, initrc_t; }
 allow init_t initrc_t : process2 { nnp_transition };
 
+# Allow the NoNewPrivileges transition for fstrim_tool service that will call fstrim
+require { type fsadm_t; }
+allow initrc_t fsadm_t : process2 { nnp_transition };
+
 ###############################################################################
 # systemd-journal
 


### PR DESCRIPTION
NODE-1522

- Silence libunwind-related SELinux denials (pipe access)
- allow fstrim_tool systemd service to perform NoNewPrivileges transition

Created from: https://github.com/dfinity/ic/pull/2990