### PR TITLE
feat(nns): Move neuron validation to timer

### DIFF
--- a/rs/nns/governance/canister/canister.rs
+++ b/rs/nns/governance/canister/canister.rs
@@ -168,6 +168,7 @@ fn schedule_timers() {
     schedule_prune_following(Duration::from_secs(0), Bound::Unbounded);
     schedule_spawn_neurons();
     schedule_unstake_maturity_of_dissolved_neurons();
+    schedule_neuron_data_validation();
     schedule_vote_processing();
 
     // TODO(NNS1-3446): Delete. (This only needs to be run once, but can safely be run multiple times).
@@ -311,6 +312,13 @@ const UNSTAKE_MATURITY_OF_DISSOLVED_NEURONS_INTERVAL: Duration = Duration::from_
 fn schedule_unstake_maturity_of_dissolved_neurons() {
     ic_cdk_timers::set_timer_interval(UNSTAKE_MATURITY_OF_DISSOLVED_NEURONS_INTERVAL, || {
         governance_mut().unstake_maturity_of_dissolved_neurons();
+    });
+}
+
+const NEURON_DATA_VALIDATION_INTERNVAL: Duration = Duration::from_secs(5);
+fn schedule_neuron_data_validation() {
+    ic_cdk_timers::set_timer_interval(NEURON_DATA_VALIDATION_INTERNVAL, || {
+        governance_mut().maybe_run_validations();
     });
 }
 

--- a/rs/nns/governance/src/governance.rs
+++ b/rs/nns/governance/src/governance.rs
@@ -6632,15 +6632,6 @@ impl Governance {
         ));
     }
 
-    fn maybe_run_validations(&mut self) {
-        // Running validations might increase heap size. Do not run it when heap should not grow.
-        if self.check_heap_can_grow().is_err() {
-            return;
-        }
-        self.neuron_data_validator
-            .maybe_validate(self.env.now(), &self.neuron_store);
-    }
-
     /// Increment neuron allowances if enough time has passed.
     fn maybe_increase_neuron_allowances(&mut self) {
         // We  increase the allowance over the maximum per hour to account
@@ -6739,7 +6730,6 @@ impl Governance {
 
         self.maybe_gc();
         self.maybe_run_migrations();
-        self.maybe_run_validations();
         self.maybe_increase_neuron_allowances();
     }
 
@@ -6808,6 +6798,15 @@ impl Governance {
         };
 
         Ok(())
+    }
+
+    pub fn maybe_run_validations(&mut self) {
+        // Running validations might increase heap size. Do not run it when heap should not grow.
+        if self.check_heap_can_grow().is_err() {
+            return;
+        }
+        self.neuron_data_validator
+            .maybe_validate(self.env.now(), &self.neuron_store);
     }
 
     /// Returns the 30-day average of the ICP/XDR conversion rate.


### PR DESCRIPTION
We prefer timer to heartbeat in general, and the neuron validation can be scheduled in a fixed interval. Therefore we should just move it to timer as a low hanging fruit.