### PR TITLE
chore(pocket-ic): bazel test requires-network

### DIFF
--- a/rs/pocket_ic_server/BUILD.bazel
+++ b/rs/pocket_ic_server/BUILD.bazel
@@ -189,9 +189,7 @@ rust_test(
     },
     tags = [
         "cpu:8",
-        "requires-network",
-        # TODO: enable "test_macos" again when we have fixed the following error on Apple Silicon:
-        #
+        # TODO: remove 'requires-network' tag when the root cause for sporadic error below on Apple Silicon is identified and fixed.
         #  ---- test_http_gateway stdout ----
         #  thread 'test_http_gateway' panicked at rs/pocket_ic_server/tests/test.rs:383:48:
         #  called `Result::unwrap()` on an `Err` value: reqwest::Error {
@@ -201,8 +199,8 @@ rust_test(
         #      ConnectError("tcp connect error", Os { code: 1, kind: PermissionDenied, message: "Operation not permitted" })
         #    )
         #  }
-        #
-        #"test_macos",
+        "requires-network",
+        "test_macos",
     ],
     deps = TEST_DEPENDENCIES,
 )

--- a/rs/pocket_ic_server/BUILD.bazel
+++ b/rs/pocket_ic_server/BUILD.bazel
@@ -189,6 +189,7 @@ rust_test(
     },
     tags = [
         "cpu:8",
+        "requires-network",
         # TODO: enable "test_macos" again when we have fixed the following error on Apple Silicon:
         #
         #  ---- test_http_gateway stdout ----


### PR DESCRIPTION
Adding `requires-network` tag to overcome the issue of sporadic failures (seen [here](https://github.com/dfinity/ic/actions/runs/12320821672), attempt 1 & 2):
```
 Failed to get result: reqwest::Error { kind: Request, url: "http://127.0.0.1:49325/instances", source: hyper_util::client::legacy::Error(Connect, ConnectError("tcp connect error", Os { code: 1, kind: PermissionDenied, message: "Operation not permitted" })) }
```