### PR TITLE
test(nns): Fix flakiness in two nns integration tests

### DIFF
--- a/rs/nns/integration_tests/src/node_assignment.rs
+++ b/rs/nns/integration_tests/src/node_assignment.rs
@@ -1,3 +1,4 @@
+use canister_test::Runtime;
 use dfn_candid::candid_one;
 use ic_base_types::NodeId;
 use ic_canister_client_sender::Sender;
@@ -23,7 +24,7 @@ use registry_canister::mutations::{
     do_add_node_operator::AddNodeOperatorPayload,
     node_management::do_remove_nodes::RemoveNodesPayload,
 };
-use std::collections::BTreeMap;
+use std::{collections::BTreeMap, time::Duration};
 
 /// Test that nodes can be added and removed from the Registry correctly via
 /// Governance's `manage_neuron` method. The test first adds a node provider and
@@ -116,6 +117,16 @@ fn test_add_and_remove_nodes_from_registry() {
         .await;
 
         let (payload, _) = prepare_add_node_payload(1);
+        // To fix occasional flakiness similar to this error:
+        // invalid TLS certificate: notBefore date (=ASN1Time(2024-12-12 13:17:08.0 +00:00:00)) \
+        //      is in the future compared to current time (=ASN1Time(2024-12-12 13:16:39.0 +00:00:00))\"
+        // we advance time on the state machine by 5 minutes.
+        // The theory is that resource contention is causing the system time to advance while the time
+        // set for the state machine does not, causing the key's time to be in the future.
+        if let Runtime::StateMachine(sm) = &runtime {
+            sm.advance_time(Duration::from_secs(300));
+            sm.tick();
+        };
         let node_id: NodeId = nns_canisters
             .registry
             .update_from_sender(


### PR DESCRIPTION
This attempts to fix a time discrepancy between system time and StateMachine time causing test flakiness when dealing with cryptographic keys in some tests using the Registry.