### PR TITLE
fix: add timeout when fetching root key in PocketIC HTTP gateway

### DIFF
--- a/rs/pocket_ic_server/src/state_api/state.rs
+++ b/rs/pocket_ic_server/src/state_api/state.rs
@@ -830,7 +830,11 @@ impl ApiState {
             .with_url(replica_url.clone())
             .build()
             .unwrap();
-        agent.fetch_root_key().await.map_err(|e| e.to_string())?;
+        time::timeout(DEFAULT_SYNC_WAIT_DURATION, async {
+            agent.fetch_root_key().await.map_err(|e| e.to_string())
+        })
+        .await
+        .map_err(|_| format!("Timed out fetching root key from {}", replica_url))??;
 
         let replica_url = replica_url.trim_end_matches('/').to_string();
 

--- a/rs/pocket_ic_server/src/state_api/state.rs
+++ b/rs/pocket_ic_server/src/state_api/state.rs
@@ -830,11 +830,10 @@ impl ApiState {
             .with_url(replica_url.clone())
             .build()
             .unwrap();
-        time::timeout(DEFAULT_SYNC_WAIT_DURATION, async {
-            agent.fetch_root_key().await.map_err(|e| e.to_string())
-        })
-        .await
-        .map_err(|_| format!("Timed out fetching root key from {}", replica_url))??;
+        time::timeout(DEFAULT_SYNC_WAIT_DURATION, agent.fetch_root_key())
+            .await
+            .map_err(|_| format!("Timed out fetching root key from {}", replica_url))?
+            .map_err(|e| e.to_string())?;
 
         let replica_url = replica_url.trim_end_matches('/').to_string();
 

--- a/rs/pocket_ic_server/tests/test.rs
+++ b/rs/pocket_ic_server/tests/test.rs
@@ -1233,7 +1233,7 @@ fn test_invalid_gateway_backend() {
             panic!("Suceeded to create http gateway!")
         }
         CreateHttpGatewayResponse::Error { message } => {
-            assert!(message.contains("An error happened during communication with the replica: error sending request for url"));
+            assert!(message.contains("Timed out fetching root key from http://240.0.0.0"));
         }
     };
 }

--- a/rs/pocket_ic_server/tests/test.rs
+++ b/rs/pocket_ic_server/tests/test.rs
@@ -1233,7 +1233,7 @@ fn test_invalid_gateway_backend() {
             panic!("Suceeded to create http gateway!")
         }
         CreateHttpGatewayResponse::Error { message } => {
-            assert!(message.contains("Timed out fetching root key from http://240.0.0.0"));
+            assert!(message.contains(&format!("Timed out fetching root key from {}", backend_url)));
         }
     };
 }

--- a/rs/pocket_ic_server/tests/test.rs
+++ b/rs/pocket_ic_server/tests/test.rs
@@ -1233,7 +1233,8 @@ fn test_invalid_gateway_backend() {
             panic!("Suceeded to create http gateway!")
         }
         CreateHttpGatewayResponse::Error { message } => {
-            assert!(message.contains(&format!("Timed out fetching root key from {}", backend_url)));
+            assert!(message.contains(&format!("Timed out fetching root key from {}", backend_url))
+            || message.contains(&format!("An error happened during communication with the replica: error sending request for url ({}/api/v2/status)", backend_url)));
         }
     };
 }


### PR DESCRIPTION
This PR adds a timeout when fetching the root key in PocketIC HTTP gateway. This way, passing an invalid backend URL would result into a comprehensible error message that fetching the root key from this URL timed out instead of the HTTP gateway creation timing out as a whole.