### PR TITLE
chore: remove obsolete ic-btc-test-utils dependency

### DIFF
--- a/Cargo.Bazel.Fuzzing.json.lock
+++ b/Cargo.Bazel.Fuzzing.json.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "61fa7882b7d8c8b66da348a9f5ed357bc146f15c3115297225877dc099b3dac3",
+  "checksum": "8f3c46ee2056590eb46190b4f135c020b34bee19b08d6ad3699cc3b5e3169366",
   "crates": {
     "abnf 0.12.0": {
       "name": "abnf",
@@ -18821,10 +18821,6 @@
               "target": "ic_btc_interface"
             },
             {
-              "id": "ic-btc-test-utils 0.1.0",
-              "target": "ic_btc_test_utils"
-            },
-            {
               "id": "ic-canister-log 0.2.0",
               "target": "ic_canister_log"
             },
@@ -31111,53 +31107,6 @@
         },
         "edition": "2021",
         "version": "0.2.2"
-      },
-      "license": "Apache-2.0",
-      "license_ids": [
-        "Apache-2.0"
-      ],
-      "license_file": null
-    },
-    "ic-btc-test-utils 0.1.0": {
-      "name": "ic-btc-test-utils",
-      "version": "0.1.0",
-      "package_url": "https://github.com/dfinity/bitcoin-canister",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/ic-btc-test-utils/0.1.0/download",
-          "sha256": "be8e0a43145188ba239150f8460d314b0dd6e0ddf7d753c0ef99296103c622dd"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "ic_btc_test_utils",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "ic_btc_test_utils",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "bitcoin 0.28.2",
-              "target": "bitcoin"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "version": "0.1.0"
       },
       "license": "Apache-2.0",
       "license_ids": [
@@ -87729,7 +87678,6 @@
     "ic-agent 0.37.1",
     "ic-bn-lib 0.1.0",
     "ic-btc-interface 0.2.2",
-    "ic-btc-test-utils 0.1.0",
     "ic-canister-log 0.2.0",
     "ic-canister-sig-creation 1.0.1",
     "ic-cbor 2.6.0",

--- a/Cargo.Bazel.Fuzzing.toml.lock
+++ b/Cargo.Bazel.Fuzzing.toml.lock
@@ -3086,7 +3086,6 @@ dependencies = [
  "ic-agent",
  "ic-bn-lib",
  "ic-btc-interface",
- "ic-btc-test-utils",
  "ic-canister-log",
  "ic-canister-sig-creation",
  "ic-cbor",
@@ -5038,15 +5037,6 @@ dependencies = [
  "candid",
  "serde",
  "serde_bytes",
-]
-
-[[package]]
-name = "ic-btc-test-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be8e0a43145188ba239150f8460d314b0dd6e0ddf7d753c0ef99296103c622dd"
-dependencies = [
- "bitcoin 0.28.2",
 ]
 
 [[package]]

--- a/Cargo.Bazel.json.lock
+++ b/Cargo.Bazel.json.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "2a190b1040f74ca71ac50027321981d70a28dd34237309ae5520350f0d84df63",
+  "checksum": "f858ef04dfd7375060841942bd3005d2ad41e9c7bb3b267c1a581c9bc587c2df",
   "crates": {
     "abnf 0.12.0": {
       "name": "abnf",
@@ -18649,10 +18649,6 @@
               "target": "ic_btc_interface"
             },
             {
-              "id": "ic-btc-test-utils 0.1.0",
-              "target": "ic_btc_test_utils"
-            },
-            {
               "id": "ic-canister-log 0.2.0",
               "target": "ic_canister_log"
             },
@@ -30966,53 +30962,6 @@
         },
         "edition": "2021",
         "version": "0.2.2"
-      },
-      "license": "Apache-2.0",
-      "license_ids": [
-        "Apache-2.0"
-      ],
-      "license_file": null
-    },
-    "ic-btc-test-utils 0.1.0": {
-      "name": "ic-btc-test-utils",
-      "version": "0.1.0",
-      "package_url": "https://github.com/dfinity/bitcoin-canister",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/ic-btc-test-utils/0.1.0/download",
-          "sha256": "be8e0a43145188ba239150f8460d314b0dd6e0ddf7d753c0ef99296103c622dd"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "ic_btc_test_utils",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "ic_btc_test_utils",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "bitcoin 0.28.2",
-              "target": "bitcoin"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "version": "0.1.0"
       },
       "license": "Apache-2.0",
       "license_ids": [
@@ -87609,7 +87558,6 @@
     "ic-agent 0.37.1",
     "ic-bn-lib 0.1.0",
     "ic-btc-interface 0.2.2",
-    "ic-btc-test-utils 0.1.0",
     "ic-canister-log 0.2.0",
     "ic-canister-sig-creation 1.0.1",
     "ic-cbor 2.6.0",

--- a/Cargo.Bazel.toml.lock
+++ b/Cargo.Bazel.toml.lock
@@ -3075,7 +3075,6 @@ dependencies = [
  "ic-agent",
  "ic-bn-lib",
  "ic-btc-interface",
- "ic-btc-test-utils",
  "ic-canister-log",
  "ic-canister-sig-creation",
  "ic-cbor",
@@ -5028,15 +5027,6 @@ dependencies = [
  "candid",
  "serde",
  "serde_bytes",
-]
-
-[[package]]
-name = "ic-btc-test-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be8e0a43145188ba239150f8460d314b0dd6e0ddf7d753c0ef99296103c622dd"
-dependencies = [
- "bitcoin 0.28.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6047,15 +6047,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ic-btc-test-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be8e0a43145188ba239150f8460d314b0dd6e0ddf7d753c0ef99296103c622dd"
-dependencies = [
- "bitcoin 0.28.2",
-]
-
-[[package]]
 name = "ic-btc-validation"
 version = "0.9.0"
 dependencies = [
@@ -8317,7 +8308,6 @@ dependencies = [
  "hex",
  "ic-base-types",
  "ic-btc-interface",
- "ic-btc-test-utils",
  "ic-canister-sandbox-backend-lib",
  "ic-config",
  "ic-crypto-prng",
@@ -11570,7 +11560,6 @@ dependencies = [
  "ic-base-types",
  "ic-btc-interface",
  "ic-btc-replica-types",
- "ic-btc-test-utils",
  "ic-certification-version",
  "ic-config",
  "ic-crypto-ed25519",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -568,7 +568,6 @@ ic-agent = { version = "0.37.1", features = [
 ] }
 ic-bn-lib = { git = "https://github.com/dfinity/ic-bn-lib", rev = "d74a6527fbaf8a2c1a7076983cc84f5c5a727923" }
 ic-btc-interface = "0.2.2"
-ic-btc-test-utils = "0.1.0"
 ic-cbor = "2.6.0"
 ic-cdk = "0.16.0"
 ic-cdk-macros = "0.9.0"

--- a/bazel/external_crates.bzl
+++ b/bazel/external_crates.bzl
@@ -579,9 +579,6 @@ def external_crates_repository(name, cargo_lockfile, lockfile, sanitizers_enable
             "ic-btc-interface": crate.spec(
                 version = "^0.2.2",
             ),
-            "ic-btc-test-utils": crate.spec(
-                version = "^0.1.0",
-            ),
             "ic-canister-log": crate.spec(
                 version = "^0.2.0",
             ),

--- a/rs/execution_environment/BUILD.bazel
+++ b/rs/execution_environment/BUILD.bazel
@@ -75,7 +75,6 @@ DEV_DEPENDENCIES = [
     "//rs/universal_canister/lib",
     "@crate_index//:assert_matches",
     "@crate_index//:criterion",
-    "@crate_index//:ic-btc-test-utils",
     "@crate_index//:insta",
     "@crate_index//:itertools",
     "@crate_index//:libflate",

--- a/rs/execution_environment/Cargo.toml
+++ b/rs/execution_environment/Cargo.toml
@@ -65,7 +65,6 @@ assert_matches = { workspace = true }
 canister-test = { path = "../rust_canisters/canister_test" }
 criterion = { workspace = true }
 execution-environment-bench = { path = "benches/lib" }
-ic-btc-test-utils = { workspace = true }
 ic-interfaces-state-manager-mocks = { path = "../interfaces/state_manager/mocks" }
 ic-management-canister-types = { path = "../types/management_canister_types" }
 ic-state-machine-tests = { path = "../state_machine_tests" }

--- a/rs/replicated_state/BUILD.bazel
+++ b/rs/replicated_state/BUILD.bazel
@@ -65,7 +65,6 @@ DEV_DEPENDENCIES = [
     "//rs/test_utilities/types",
     "@crate_index//:assert_matches",
     "@crate_index//:criterion",
-    "@crate_index//:ic-btc-test-utils",
     "@crate_index//:proptest",
     "@crate_index//:scoped_threadpool",
     "@crate_index//:serde_cbor",

--- a/rs/replicated_state/Cargo.toml
+++ b/rs/replicated_state/Cargo.toml
@@ -61,7 +61,6 @@ proptest = { workspace = true, optional = true }
 assert_matches = { workspace = true }
 criterion = { workspace = true }
 criterion-time = { path = "../criterion_time" }
-ic-btc-test-utils = { workspace = true }
 ic-crypto-ed25519 = { path = "../crypto/ed25519" }
 ic-crypto-test-utils-keys = { path = "../crypto/test_utils/keys" }
 ic-test-utilities-io = { path = "../test_utilities/io" }


### PR DESCRIPTION
This PR removes an obsolete dependency on `ic-btc-test-utils` from replica.

EXC-1813