### PR TITLE
fix(ckbtc): btc-checker charges service fee before checking txid

### DIFF
--- a/rs/bitcoin/checker/src/main.rs
+++ b/rs/bitcoin/checker/src/main.rs
@@ -88,7 +88,12 @@ fn check_address(args: CheckAddressArgs) -> CheckAddressResponse {
 /// fails to decode or its transaction id does not match, then `Error` is returned
 /// together with a text description.
 async fn check_transaction(args: CheckTransactionArgs) -> CheckTransactionResponse {
-    ic_cdk::api::call::msg_cycles_accept128(CHECK_TRANSACTION_CYCLES_SERVICE_FEE);
+    if ic_cdk::api::call::msg_cycles_accept128(CHECK_TRANSACTION_CYCLES_SERVICE_FEE)
+        < CHECK_TRANSACTION_CYCLES_SERVICE_FEE
+    {
+        return CheckTransactionStatus::NotEnoughCycles.into();
+    }
+
     match Txid::try_from(args.txid.as_ref()) {
         Ok(txid) => {
             STATS.with(|s| s.borrow_mut().check_transaction_count += 1);

--- a/rs/bitcoin/checker/tests/tests.rs
+++ b/rs/bitcoin/checker/tests/tests.rs
@@ -486,7 +486,7 @@ fn test_check_transaction_error() {
     let call_id = setup
         .submit_btc_checker_call(
             "check_transaction",
-            Encode!(&CheckTransactionArgs { txid: vec![0;31] }).unwrap(),
+            Encode!(&CheckTransactionArgs { txid: vec![0; 31] }).unwrap(),
             CHECK_TRANSACTION_CYCLES_SERVICE_FEE - 1,
         )
         .expect("submit_call failed to return call id");

--- a/rs/bitcoin/checker/tests/tests.rs
+++ b/rs/bitcoin/checker/tests/tests.rs
@@ -476,14 +476,31 @@ fn test_check_transaction_passed() {
 #[test]
 fn test_check_transaction_error() {
     let setup = Setup::new(BtcNetwork::Mainnet);
-    let cycles_before = setup.env.cycle_balance(setup.caller);
     let mut txid =
         Txid::from_str("a80763842edc9a697a2114517cf0c138c5403a761ef63cfad1fa6993fa3475ed")
             .unwrap()
             .as_ref()
             .to_vec();
 
+    // Test should return NotEnoughCycles error, not InvalidTransactionId
+    let call_id = setup
+        .submit_btc_checker_call(
+            "check_transaction",
+            Encode!(&CheckTransactionArgs { txid: vec![0;31] }).unwrap(),
+            CHECK_TRANSACTION_CYCLES_SERVICE_FEE - 1,
+        )
+        .expect("submit_call failed to return call id");
+    let result = setup
+        .env
+        .await_call(call_id)
+        .expect("the fetch request didn't finish");
+    assert!(matches!(
+        decode::<CheckTransactionResponse>(&result),
+        CheckTransactionResponse::Unknown(CheckTransactionStatus::NotEnoughCycles),
+    ));
+
     // Test for cycles not enough
+    let cycles_before = setup.env.cycle_balance(setup.caller);
     let call_id = setup
         .submit_btc_checker_call(
             "check_transaction",


### PR DESCRIPTION
Make sure service fee is fully charged before checking the validity of txid.