### PR TITLE
feat(EXC-1795): Limit cache disk space

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13279,6 +13279,7 @@ version = "0.9.0"
 dependencies = [
  "ic-types",
  "lru",
+ "proptest",
 ]
 
 [[package]]

--- a/rs/artifact_pool/src/ingress_pool/peer_counter.rs
+++ b/rs/artifact_pool/src/ingress_pool/peer_counter.rs
@@ -41,15 +41,19 @@ impl PeerCounters {
 
     pub(super) fn observe(&mut self, ingress_message: &IngressPoolObject) {
         self.message_counters.add(ingress_message.originator_id, 1);
-        self.bytes_counters
-            .add(ingress_message.originator_id, ingress_message.count_bytes());
+        self.bytes_counters.add(
+            ingress_message.originator_id,
+            ingress_message.memory_count_bytes(),
+        );
     }
 
     pub(super) fn forget(&mut self, ingress_message: &IngressPoolObject) {
         self.message_counters
             .subtract(ingress_message.originator_id, 1);
-        self.bytes_counters
-            .subtract(ingress_message.originator_id, ingress_message.count_bytes());
+        self.bytes_counters.subtract(
+            ingress_message.originator_id,
+            ingress_message.memory_count_bytes(),
+        );
     }
 
     pub(super) fn count_total_bytes(&self) -> usize {
@@ -140,7 +144,7 @@ mod tests {
         let ingress_message_1 = fake_ingress_pool_object(NODE_1, 1);
         let ingress_message_2 = fake_ingress_pool_object(NODE_2, 2);
         let ingress_message_3 = fake_ingress_pool_object(NODE_2, 3);
-        let message_size = ingress_message_1.count_bytes();
+        let message_size = ingress_message_1.memory_count_bytes();
 
         peer_counters.observe(&ingress_message_1);
         peer_counters.observe(&ingress_message_2);
@@ -162,7 +166,7 @@ mod tests {
         let ingress_message_1 = fake_ingress_pool_object(NODE_1, 1);
         let ingress_message_2 = fake_ingress_pool_object(NODE_2, 2);
         let ingress_message_3 = fake_ingress_pool_object(NODE_2, 3);
-        let message_size = ingress_message_1.count_bytes();
+        let message_size = ingress_message_1.memory_count_bytes();
 
         peer_counters.observe(&ingress_message_1);
         peer_counters.observe(&ingress_message_2);

--- a/rs/bitcoin/consensus/src/payload_builder.rs
+++ b/rs/bitcoin/consensus/src/payload_builder.rs
@@ -253,7 +253,7 @@ impl BitcoinPayloadBuilder {
 
         self.metrics
             .observe_validate_duration(VALIDATION_STATUS_VALID, since);
-        let size = NumBytes::new(payload.count_bytes() as u64);
+        let size = NumBytes::new(payload.memory_count_bytes() as u64);
 
         Ok(size)
     }
@@ -295,7 +295,7 @@ impl SelfValidatingPayloadBuilder for BitcoinPayloadBuilder {
             }
         };
 
-        let size = NumBytes::new(payload.count_bytes() as u64);
+        let size = NumBytes::new(payload.memory_count_bytes() as u64);
         (payload, size.min(byte_limit))
     }
 

--- a/rs/canister_sandbox/src/replica_controller/sandboxed_execution_controller.rs
+++ b/rs/canister_sandbox/src/replica_controller/sandboxed_execution_controller.rs
@@ -2053,7 +2053,8 @@ mod tests {
 
     use super::*;
     use ic_config::{
-        execution_environment::MAX_COMPILATION_CACHE_SIZE, logger::Config as LoggerConfig,
+        execution_environment::{MAX_COMPILATION_CACHE_DISK_SIZE, MAX_COMPILATION_CACHE_SIZE},
+        logger::Config as LoggerConfig,
     };
     use ic_logger::{new_replica_logger, replica_logger::no_op_logger};
     use ic_test_utilities::state_manager::FakeStateManager;
@@ -2131,7 +2132,11 @@ mod tests {
                 canister_module,
                 PathBuf::new(),
                 canister_id,
-                Arc::new(CompilationCache::new(MAX_COMPILATION_CACHE_SIZE)),
+                Arc::new(CompilationCache::new(
+                    MAX_COMPILATION_CACHE_SIZE,
+                    MAX_COMPILATION_CACHE_DISK_SIZE,
+                    tempfile::tempdir().unwrap(),
+                )),
             )
             .unwrap();
         let sandbox_pid = match controller

--- a/rs/config/src/execution_environment.rs
+++ b/rs/config/src/execution_environment.rs
@@ -141,8 +141,11 @@ pub const BITCOIN_MAINNET_CANISTER_ID: &str = "ghsi2-tqaaa-aaaan-aaaca-cai";
 // TODO(EXC-1298): Uninstall this canister once the bitcoin mainnet canister is live.
 const BITCOIN_MAINNET_SOFT_LAUNCH_CANISTER_ID: &str = "gsvzx-syaaa-aaaan-aaabq-cai";
 
-/// The capacity of the Wasm compilation cache.
+/// The capacity in memory of the Wasm compilation cache.
 pub const MAX_COMPILATION_CACHE_SIZE: NumBytes = NumBytes::new(10 * GIB);
+
+/// The capacity on disk for the Wasm compilation cache.
+pub const MAX_COMPILATION_CACHE_DISK_SIZE: NumBytes = NumBytes::new(100 * GIB);
 
 /// Maximum number of controllers allowed in a request (specified in the interface spec).
 pub const MAX_ALLOWED_CONTROLLERS_COUNT: usize = 10;
@@ -288,8 +291,11 @@ pub struct Config {
     /// The upper limit on how long the data certificate stays valid in the query cache.
     pub query_cache_data_certificate_expiry_time: Duration,
 
-    /// The capacity of the Wasm compilation cache.
+    /// The capacity of the Wasm compilation cache in memory.
     pub max_compilation_cache_size: NumBytes,
+
+    /// The capacity of the Wasm compilation cache on disk.
+    pub max_compilation_cache_disk_size: NumBytes,
 
     /// Indicate whether query stats should be collected or not.
     pub query_stats_aggregation: FlagStatus,
@@ -383,6 +389,7 @@ impl Default for Config {
             query_cache_max_expiry_time: QUERY_CACHE_MAX_EXPIRY_TIME,
             query_cache_data_certificate_expiry_time: QUERY_CACHE_DATA_CERTIFICATE_EXPIRY_TIME,
             max_compilation_cache_size: MAX_COMPILATION_CACHE_SIZE,
+            max_compilation_cache_disk_size: MAX_COMPILATION_CACHE_DISK_SIZE,
             query_stats_aggregation: FlagStatus::Enabled,
             query_stats_epoch_length: QUERY_STATS_EPOCH_LENGTH,
             stop_canister_timeout_duration: STOP_CANISTER_TIMEOUT_DURATION,

--- a/rs/consensus/src/consensus/block_maker.rs
+++ b/rs/consensus/src/consensus/block_maker.rs
@@ -388,7 +388,7 @@ impl BlockMaker {
 
                     self.metrics.report_byte_estimate_metrics(
                         batch_payload.xnet.size_bytes(),
-                        batch_payload.ingress.count_bytes(),
+                        batch_payload.ingress.memory_count_bytes(),
                     );
 
                     BlockPayload::Data(DataPayload {

--- a/rs/consensus/src/consensus/metrics.rs
+++ b/rs/consensus/src/consensus/metrics.rs
@@ -154,7 +154,7 @@ impl BatchStats {
 
     pub(crate) fn add_from_payload(&mut self, payload: &BatchPayload) {
         self.ingress_messages_delivered += payload.ingress.message_count();
-        self.ingress_message_bytes_delivered += payload.ingress.count_bytes();
+        self.ingress_message_bytes_delivered += payload.ingress.memory_count_bytes();
         self.xnet_bytes_delivered += payload.xnet.size_bytes();
         self.ingress_ids
             .extend_from_slice(&payload.ingress.message_ids());

--- a/rs/consensus/src/consensus/payload.rs
+++ b/rs/consensus/src/consensus/payload.rs
@@ -117,7 +117,7 @@ impl BatchPayloadSectionBuilder {
                     proposal_context.validation_context,
                     max_size,
                 );
-                let size = NumBytes::new(ingress.count_bytes() as u64);
+                let size = NumBytes::new(ingress.memory_count_bytes() as u64);
 
                 // Validate the ingress payload as a safety measure
                 if let Err(err) = builder.validate_ingress_payload(
@@ -349,7 +349,7 @@ impl BatchPayloadSectionBuilder {
                     &past_payloads,
                     proposal_context.validation_context,
                 )?;
-                Ok(NumBytes::new(payload.ingress.count_bytes() as u64))
+                Ok(NumBytes::new(payload.ingress.memory_count_bytes() as u64))
             }
             Self::XNet(builder) => {
                 let past_payloads = builder.filter_past_payloads(past_payloads);

--- a/rs/embedders/src/compilation_cache.rs
+++ b/rs/embedders/src/compilation_cache.rs
@@ -37,9 +37,11 @@ pub enum CompilationCache {
 }
 
 impl CompilationCache {
-    pub fn new(capacity: NumBytes) -> Self {
-        Self::Memory {
-            cache: Mutex::new(LruCache::new(capacity, NumBytes::from(1024 * 1024 * 1024))),
+    pub fn new(memory_capacity: NumBytes, disk_capacity: NumBytes, dir: TempDir) -> Self {
+        Self::Disk {
+            cache: Mutex::new(LruCache::new(memory_capacity, disk_capacity)),
+            dir,
+            counter: AtomicU64::new(0),
         }
     }
 
@@ -190,7 +192,11 @@ impl StoredCompilation {
 /// each other if they all try to insert in the cache at the same time.
 #[test]
 fn concurrent_insertions() {
-    let cache = CompilationCache::new(NumBytes::from(30 * 1024 * 1024));
+    let cache = CompilationCache::new(
+        NumBytes::from(30 * 1024 * 1024),
+        NumBytes::from(30 * 1024 * 1024),
+        tempfile::tempdir().unwrap(),
+    );
     let wasm = wat::parse_str("(module)").unwrap();
     let canister_module = CanisterModule::new(wasm.clone());
     let binary = ic_wasm_types::BinaryEncodedWasm::new(wasm.clone());

--- a/rs/embedders/src/compilation_cache.rs
+++ b/rs/embedders/src/compilation_cache.rs
@@ -39,7 +39,7 @@ pub enum CompilationCache {
 impl CompilationCache {
     pub fn new(capacity: NumBytes) -> Self {
         Self::Memory {
-            cache: Mutex::new(LruCache::new(capacity)),
+            cache: Mutex::new(LruCache::new(capacity, NumBytes::from(1024 * 1024 * 1024))),
         }
     }
 

--- a/rs/embedders/src/serialized_module.rs
+++ b/rs/embedders/src/serialized_module.rs
@@ -83,7 +83,7 @@ pub struct SerializedModule {
 }
 
 impl CountBytes for SerializedModule {
-    fn count_bytes(&self) -> usize {
+    fn memory_count_bytes(&self) -> usize {
         self.bytes.0.len()
     }
 }
@@ -148,7 +148,7 @@ pub struct OnDiskSerializedModule {
 }
 
 impl CountBytes for OnDiskSerializedModule {
-    fn count_bytes(&self) -> usize {
+    fn memory_count_bytes(&self) -> usize {
         std::mem::size_of::<Self>()
     }
 }

--- a/rs/execution_environment/src/query_handler/query_cache.rs
+++ b/rs/execution_environment/src/query_handler/query_cache.rs
@@ -392,7 +392,7 @@ impl QueryCache {
         data_certificate_expiry_time: Duration,
     ) -> Self {
         QueryCache {
-            cache: Mutex::new(LruCache::new(capacity)),
+            cache: Mutex::new(LruCache::new(capacity, NumBytes::from(0))),
             max_expiry_time,
             data_certificate_expiry_time,
             metrics: QueryCacheMetrics::new(metrics_registry),

--- a/rs/execution_environment/src/query_handler/query_cache.rs
+++ b/rs/execution_environment/src/query_handler/query_cache.rs
@@ -141,7 +141,7 @@ pub(crate) struct EntryKey {
 }
 
 impl CountBytes for EntryKey {
-    fn count_bytes(&self) -> usize {
+    fn memory_count_bytes(&self) -> usize {
         size_of_val(self) + self.method_name.len() + self.method_payload.len()
     }
 }
@@ -212,8 +212,8 @@ pub(crate) struct EntryValue {
 }
 
 impl CountBytes for EntryValue {
-    fn count_bytes(&self) -> usize {
-        size_of_val(self) + self.result.count_bytes()
+    fn memory_count_bytes(&self) -> usize {
+        size_of_val(self) + self.result.memory_count_bytes()
     }
 }
 
@@ -378,8 +378,8 @@ pub(crate) struct QueryCache {
 }
 
 impl CountBytes for QueryCache {
-    fn count_bytes(&self) -> usize {
-        size_of_val(self) + self.cache.lock().unwrap().count_bytes()
+    fn memory_count_bytes(&self) -> usize {
+        size_of_val(self) + self.cache.lock().unwrap().memory_count_bytes()
     }
 }
 
@@ -422,7 +422,9 @@ impl QueryCache {
                 // The cache entry is no longer valid, remove it.
                 cache.pop(key);
                 // Update the `count_bytes` metric.
-                self.metrics.count_bytes.set(cache.count_bytes() as i64);
+                self.metrics
+                    .count_bytes
+                    .set(cache.memory_count_bytes() as i64);
             }
         }
         None
@@ -470,7 +472,7 @@ impl QueryCache {
             let d = evicted_value.elapsed_seconds(now);
             self.metrics.evicted_entries_duration.observe(d);
         }
-        let count_bytes = cache.count_bytes() as i64;
+        let count_bytes = cache.memory_count_bytes() as i64;
         self.metrics.count_bytes.set(count_bytes);
         self.metrics.len.set(cache.len() as i64);
     }

--- a/rs/execution_environment/src/query_handler/query_cache/tests.rs
+++ b/rs/execution_environment/src/query_handler/query_cache/tests.rs
@@ -765,7 +765,7 @@ fn query_cache_frees_memory_after_invalidated_entries() {
         .build();
     let id = test.canister_from_wat(QUERY_CACHE_WAT).unwrap();
 
-    let count_bytes = query_cache(&test).count_bytes();
+    let count_bytes = query_cache(&test).memory_count_bytes();
     // Initially the cache should be empty, i.e. less than 1MB.
     assert!(count_bytes < BIG_RESPONSE_SIZE);
 
@@ -773,8 +773,8 @@ fn query_cache_frees_memory_after_invalidated_entries() {
     let res = test
         .non_replicated_query(id, "canister_balance_sized_reply", vec![])
         .unwrap();
-    assert_eq!(BIG_RESPONSE_SIZE, res.count_bytes());
-    let count_bytes = query_cache(&test).count_bytes();
+    assert_eq!(BIG_RESPONSE_SIZE, res.memory_count_bytes());
+    let count_bytes = query_cache(&test).memory_count_bytes();
     // After the first reply, the cache should have more than 1MB of data.
     assert!(count_bytes > BIG_RESPONSE_SIZE);
 
@@ -788,8 +788,8 @@ fn query_cache_frees_memory_after_invalidated_entries() {
     let res = test
         .non_replicated_query(id, "canister_balance_sized_reply", vec![])
         .unwrap();
-    assert_eq!(SMALL_RESPONSE_SIZE, res.count_bytes());
-    let count_bytes = query_cache(&test).count_bytes();
+    assert_eq!(SMALL_RESPONSE_SIZE, res.memory_count_bytes());
+    let count_bytes = query_cache(&test).memory_count_bytes();
     // The second 42 reply should invalidate and replace the first 1MB reply in the cache.
     assert!(count_bytes > SMALL_RESPONSE_SIZE);
     assert!(count_bytes < BIG_RESPONSE_SIZE);
@@ -803,7 +803,7 @@ fn query_cache_respects_cache_capacity() {
     let id = test.universal_canister().unwrap();
 
     // Initially the cache should be empty, i.e. less than REPLY_SIZE.
-    let count_bytes = query_cache(&test).count_bytes();
+    let count_bytes = query_cache(&test).memory_count_bytes();
     assert!(count_bytes < REPLY_SIZE);
 
     // All replies should hit the same cache entry.
@@ -812,7 +812,7 @@ fn query_cache_respects_cache_capacity() {
         let _res =
             test.non_replicated_query(id, "query", wasm().reply_data(&[1; REPLY_SIZE / 2]).build());
         // Now there should be only one reply in the cache.
-        let count_bytes = query_cache(&test).count_bytes();
+        let count_bytes = query_cache(&test).memory_count_bytes();
         assert!(count_bytes > REPLY_SIZE);
         assert!(count_bytes < QUERY_CACHE_CAPACITY);
     }
@@ -822,7 +822,7 @@ fn query_cache_respects_cache_capacity() {
         let _res =
             test.non_replicated_query(id, "query", wasm().reply_data(&[2; REPLY_SIZE / 2]).build());
         // Now there should be two replies in the cache.
-        let count_bytes = query_cache(&test).count_bytes();
+        let count_bytes = query_cache(&test).memory_count_bytes();
         assert!(count_bytes > REPLY_SIZE * 2);
         assert!(count_bytes < QUERY_CACHE_CAPACITY);
     }
@@ -832,7 +832,7 @@ fn query_cache_respects_cache_capacity() {
         let _res =
             test.non_replicated_query(id, "query", wasm().reply_data(&[3; REPLY_SIZE / 2]).build());
         // There should be still just two replies in the cache.
-        let count_bytes = query_cache(&test).count_bytes();
+        let count_bytes = query_cache(&test).memory_count_bytes();
         assert!(count_bytes > REPLY_SIZE * 2);
         assert!(count_bytes < QUERY_CACHE_CAPACITY);
     }
@@ -844,12 +844,12 @@ fn query_cache_works_with_zero_cache_capacity() {
     let id = test.universal_canister().unwrap();
 
     // Even with zero capacity the cache data structure uses some bytes for the pointers etc.
-    let initial_count_bytes = query_cache(&test).count_bytes();
+    let initial_count_bytes = query_cache(&test).memory_count_bytes();
 
     // Replies should not change the initial (zero) capacity.
     for _ in 0..ITERATIONS {
         let _res = test.non_replicated_query(id, "query", wasm().reply_data(&[1]).build());
-        let count_bytes = query_cache(&test).count_bytes();
+        let count_bytes = query_cache(&test).memory_count_bytes();
         assert_eq!(initial_count_bytes, count_bytes);
     }
 }

--- a/rs/http_endpoints/public/src/call.rs
+++ b/rs/http_endpoints/public/src/call.rs
@@ -225,13 +225,13 @@ impl IngressValidator {
         let registry_version = registry_client.get_latest_version();
         let (ingress_registry_settings, provisional_whitelist) =
             get_registry_data(&log, subnet_id, registry_version, registry_client.as_ref())?;
-        if msg.count_bytes() > ingress_registry_settings.max_ingress_bytes_per_message {
+        if msg.memory_count_bytes() > ingress_registry_settings.max_ingress_bytes_per_message {
             Err(HttpError {
                 status: StatusCode::PAYLOAD_TOO_LARGE,
                 message: format!(
                 "Request {} is too large. Message byte size {} is larger than the max allowed {}.",
                 message_id,
-                msg.count_bytes(),
+                msg.memory_count_bytes(),
                 ingress_registry_settings.max_ingress_bytes_per_message
             ),
             })?;

--- a/rs/https_outcalls/consensus/src/payload_builder.rs
+++ b/rs/https_outcalls/consensus/src/payload_builder.rs
@@ -227,7 +227,7 @@ impl CanisterHttpPayloadBuilderImpl {
                 .iter()
             {
                 unique_includable_responses += 1;
-                let candidate_size = callback_id.count_bytes();
+                let candidate_size = callback_id.memory_count_bytes();
                 let size = NumBytes::new((accumulated_size + candidate_size) as u64);
                 if size >= max_payload_size {
                     // All timeouts have the same size, so we can stop iterating.
@@ -325,7 +325,7 @@ impl CanisterHttpPayloadBuilderImpl {
                 match candidate_or_divergence {
                     CandidateOrDivergence::Candidate((metadata, shares, content)) => {
                         let candidate_size =
-                            size_of::<CanisterHttpResponseProof>() + content.count_bytes();
+                            size_of::<CanisterHttpResponseProof>() + content.memory_count_bytes();
                         let size = NumBytes::new((accumulated_size + candidate_size) as u64);
                         if size < max_payload_size {
                             candidates.push((metadata.clone(), shares, content));
@@ -334,7 +334,7 @@ impl CanisterHttpPayloadBuilderImpl {
                         }
                     }
                     CandidateOrDivergence::Divergence(divergence) => {
-                        let divergence_size = divergence.count_bytes();
+                        let divergence_size = divergence.memory_count_bytes();
                         let size = NumBytes::new((accumulated_size + divergence_size) as u64);
                         if size < max_payload_size {
                             divergence_responses.push(divergence);

--- a/rs/ingress_manager/src/ingress_handler.rs
+++ b/rs/ingress_manager/src/ingress_handler.rs
@@ -161,7 +161,7 @@ impl IngressManager {
         registry_version: RegistryVersion,
     ) -> Result<(), IngressMessageValidationError> {
         // If the message is too large, consider the ingress message invalid
-        let size = ingress_object.count_bytes();
+        let size = ingress_object.memory_count_bytes();
         if size > settings.max_ingress_bytes_per_message {
             return Err(IngressMessageValidationError::IngressMessageTooLarge {
                 max: settings.max_ingress_bytes_per_message,

--- a/rs/ingress_manager/src/ingress_selector.rs
+++ b/rs/ingress_manager/src/ingress_selector.rs
@@ -185,7 +185,7 @@ impl IngressSelector for IngressManager {
                         }
                     };
 
-                    let ingress_size = ingress.count_bytes();
+                    let ingress_size = ingress.memory_count_bytes();
 
                     // Break criterion #1: global byte limit
                     if (accumulated_size + ingress_size) as u64 > byte_limit.get() {
@@ -245,7 +245,7 @@ impl IngressSelector for IngressManager {
         // serialized form does not, we need to remove some `SignedIngress` and try again.
         let payload = loop {
             let payload = IngressPayload::from_iter(messages_in_payload.iter().copied());
-            let payload_size = payload.count_bytes();
+            let payload_size = payload.memory_count_bytes();
             if payload_size < byte_limit.get() as usize {
                 break payload;
             }
@@ -263,7 +263,7 @@ impl IngressSelector for IngressManager {
             }
         };
 
-        let payload_size = payload.count_bytes();
+        let payload_size = payload.memory_count_bytes();
         debug_assert!(payload_size <= byte_limit.get() as usize);
 
         payload
@@ -424,7 +424,7 @@ impl IngressManager {
         num_messages: usize,
         cycles_needed: &mut BTreeMap<CanisterId, Cycles>,
     ) -> ValidationResult<IngressPayloadValidationError> {
-        let ingress_message_size = signed_ingress.count_bytes();
+        let ingress_message_size = signed_ingress.memory_count_bytes();
         // The message is invalid if its size is larger than the configured maximum.
         if ingress_message_size > settings.max_ingress_bytes_per_message {
             return Err(ValidationError::InvalidArtifact(

--- a/rs/ingress_manager/src/proptests.rs
+++ b/rs/ingress_manager/src/proptests.rs
@@ -97,7 +97,7 @@ proptest! {
                 assert!(!payload.is_empty());
 
                 // Check the size explicitly
-                assert!((payload.count_bytes() as u64) < MAX_BLOCK_SIZE);
+                assert!((payload.memory_count_bytes() as u64) < MAX_BLOCK_SIZE);
 
                 // Any payload generated should pass verification.
                 // If not, we have an issue with the payload builder

--- a/rs/interfaces/src/execution_environment/errors.rs
+++ b/rs/interfaces/src/execution_environment/errors.rs
@@ -386,7 +386,7 @@ impl std::fmt::Display for HypervisorError {
 }
 
 impl CountBytes for HypervisorError {
-    fn count_bytes(&self) -> usize {
+    fn memory_count_bytes(&self) -> usize {
         std::mem::size_of::<Self>()
     }
 }

--- a/rs/interfaces/src/ingress_pool.rs
+++ b/rs/interfaces/src/ingress_pool.rs
@@ -31,7 +31,7 @@ pub struct IngressPoolObject {
 impl IngressPoolObject {
     pub fn new(originator_id: NodeId, signed_ingress: SignedIngress) -> Self {
         let message_id = signed_ingress.id();
-        let byte_size = signed_ingress.count_bytes();
+        let byte_size = signed_ingress.memory_count_bytes();
 
         Self {
             signed_ingress,
@@ -43,7 +43,7 @@ impl IngressPoolObject {
 }
 
 impl CountBytes for IngressPoolObject {
-    fn count_bytes(&self) -> usize {
+    fn memory_count_bytes(&self) -> usize {
         self.byte_size
     }
 }

--- a/rs/messaging/src/routing/stream_builder.rs
+++ b/rs/messaging/src/routing/stream_builder.rs
@@ -303,7 +303,7 @@ impl StreamBuilderImpl {
             let stream_messages_len = stream.messages().len();
 
             if stream_messages_len >= max_stream_messages
-                || stream.count_bytes() >= target_stream_size_bytes
+                || stream.memory_count_bytes() >= target_stream_size_bytes
             {
                 // At limit if message count or byte size limits (enforced across all outgoing
                 // streams) are hit.
@@ -504,7 +504,7 @@ impl StreamBuilderImpl {
                 (
                     subnet.to_string(),
                     stream.messages().len(),
-                    stream.count_bytes(),
+                    stream.memory_count_bytes(),
                     stream.messages_begin(),
                     stream.signals_end(),
                 )

--- a/rs/messaging/src/routing/stream_builder/tests.rs
+++ b/rs/messaging/src/routing/stream_builder/tests.rs
@@ -179,7 +179,7 @@ fn build_streams_success() {
             ),
             Default::default(),
         );
-        let expected_stream_bytes = expected_stream.count_bytes() as u64;
+        let expected_stream_bytes = expected_stream.memory_count_bytes() as u64;
         let expected_stream_begin = expected_stream.messages_begin().get();
         let expected_signals_end = expected_stream.signals_end().get();
 
@@ -288,7 +288,7 @@ fn build_streams_local_canisters() {
             ),
             Default::default(),
         );
-        let expected_stream_bytes = expected_stream.count_bytes() as u64;
+        let expected_stream_bytes = expected_stream.memory_count_bytes() as u64;
 
         // The expected_canister_states contains both the source canisters with consumed
         // messages, but also the destination canisters of all messages.
@@ -386,7 +386,8 @@ fn build_streams_impl_at_limit_leaves_state_untouched() {
         assert_eq!(
             metric_vec(&[(
                 &[(LABEL_REMOTE, &REMOTE_SUBNET.to_string())],
-                Stream::new(StreamIndexedQueue::default(), Default::default()).count_bytes() as u64
+                Stream::new(StreamIndexedQueue::default(), Default::default()).memory_count_bytes()
+                    as u64
             )]),
             nonzero_values(fetch_int_gauge_vec(&metrics_registry, METRIC_STREAM_BYTES))
         );
@@ -421,7 +422,7 @@ fn build_streams_impl_respects_limits(
         let msgs = generate_messages_for_test(/* senders = */ 2, /* receivers = */ 2);
         let msg_count = msgs.len();
         // All messages returned by `generate_messages_for_test` are of the same size
-        let msg_size = msgs.first().unwrap().count_bytes() as u64;
+        let msg_size = msgs.first().unwrap().memory_count_bytes() as u64;
 
         assert!(
             msg_count > expected_messages as usize,
@@ -499,7 +500,8 @@ fn build_streams_impl_respects_limits(
         assert_eq!(
             metric_vec(&[(
                 &[(LABEL_REMOTE, &REMOTE_SUBNET.to_string())],
-                Stream::new(StreamIndexedQueue::default(), Default::default()).count_bytes() as u64
+                Stream::new(StreamIndexedQueue::default(), Default::default()).memory_count_bytes()
+                    as u64
                     + expected_messages * msg_size
             )]),
             fetch_int_gauge_vec(&metrics_registry, METRIC_STREAM_BYTES)
@@ -611,7 +613,7 @@ fn build_streams_with_messages_targeted_to_other_subnets() {
             ),
             Default::default(),
         );
-        let expected_stream_bytes = expected_stream.count_bytes() as u64;
+        let expected_stream_bytes = expected_stream.memory_count_bytes() as u64;
 
         // Expected ReplicatedState has the message routed from the canister output
         // queue into the remote stream.
@@ -804,7 +806,7 @@ fn build_streams_with_oversized_payloads() {
         expected_stream_messages.push(data_response_reject.into());
         expected_stream_messages.push(reject_response_reject.into());
         let expected_stream = Stream::new(expected_stream_messages, Default::default());
-        let expected_stream_bytes = expected_stream.count_bytes() as u64;
+        let expected_stream_bytes = expected_stream.memory_count_bytes() as u64;
         expected_state.modify_streams(|streams| {
             streams.insert(LOCAL_SUBNET, expected_stream);
         });
@@ -922,7 +924,7 @@ fn requests_into_queue_round_robin(
                     }
                 }
                 let req: RequestOrResponse = request.into();
-                bytes_routed += req.count_bytes() as u64;
+                bytes_routed += req.memory_count_bytes() as u64;
                 queue.push(req);
                 requests.push_back((dst, req_queue));
             }

--- a/rs/messaging/src/routing/stream_handler.rs
+++ b/rs/messaging/src/routing/stream_handler.rs
@@ -1089,7 +1089,7 @@ fn generate_reject_response_for(reason: RejectReason, request: &Request) -> Requ
             RejectCode::CanisterError,
             format!(
                 "Cannot induct request. Out of memory: requested {}",
-                request.count_bytes().max(MAX_RESPONSE_COUNT_BYTES),
+                request.memory_count_bytes().max(MAX_RESPONSE_COUNT_BYTES),
             ),
         ),
         RejectReason::Unknown => (

--- a/rs/messaging/src/routing/stream_handler/tests.rs
+++ b/rs/messaging/src/routing/stream_handler/tests.rs
@@ -230,7 +230,7 @@ fn legacy_induct_loopback_stream_reject_response() {
                 RejectReason::CanisterNotFound,
                 request_in_stream(state.get_stream(&LOCAL_SUBNET), 21),
             );
-            let reject_response_count_bytes = reject_response.count_bytes();
+            let reject_response_count_bytes = reject_response.memory_count_bytes();
 
             let mut expected_state = state.clone();
             // Expecting a loopback stream with begin advanced and a reject response.
@@ -311,7 +311,7 @@ fn induct_loopback_stream_reroute_response() {
             // the request @23 is expected to trigger a reject response which is inducted
             // successfully.
             let inducted_response = message_in_stream(state.get_stream(&LOCAL_SUBNET), 22);
-            let inducted_response_count_bytes = inducted_response.count_bytes();
+            let inducted_response_count_bytes = inducted_response.memory_count_bytes();
             push_inputs(
                 &mut expected_state,
                 [
@@ -408,7 +408,7 @@ fn legacy_induct_loopback_stream_reroute_response() {
             );
             // The response @22 is expected to be inducted successfully.
             let inducted_response = message_in_stream(state.get_stream(&LOCAL_SUBNET), 22).clone();
-            let inducted_response_count_bytes = inducted_response.count_bytes();
+            let inducted_response_count_bytes = inducted_response.memory_count_bytes();
             push_input(&mut expected_state, inducted_response);
 
             // The request @23 is expected to trigger a reject response in the loopback stream.
@@ -416,7 +416,7 @@ fn legacy_induct_loopback_stream_reroute_response() {
                 RejectReason::CanisterMigrating,
                 request_in_stream(state.get_stream(&LOCAL_SUBNET), 23),
             );
-            let reject_response_count_bytes = reject_response.count_bytes();
+            let reject_response_count_bytes = reject_response.memory_count_bytes();
             let loopback_stream = stream_from_config(StreamConfig {
                 begin: 25,
                 messages: vec![reject_response],
@@ -502,7 +502,7 @@ fn induct_loopback_stream_success() {
                 &mut expected_state,
                 messages_in_stream(loopback_stream, 21..=22),
             );
-            let response_count_bytes = response_in_stream(loopback_stream, 22).count_bytes();
+            let response_count_bytes = response_in_stream(loopback_stream, 22).memory_count_bytes();
 
             // The loopback stream should be empty with `begin` and `signals_end` advanced.
             let loopback_stream = stream_from_config(StreamConfig {
@@ -1286,7 +1286,7 @@ fn garbage_collect_local_state_success() {
             let mut expected_state = state.clone();
             // The expected stream has the first two messages gc'ed and the stream flags set.
             let outgoing_stream = state.get_stream(&REMOTE_SUBNET);
-            let response_count_bytes = response_in_stream(outgoing_stream, 32).count_bytes();
+            let response_count_bytes = response_in_stream(outgoing_stream, 32).memory_count_bytes();
             let expected_stream = stream_from_config(StreamConfig {
                 begin: 33,
                 messages: vec![message_in_stream(outgoing_stream, 33).clone()],
@@ -2308,7 +2308,7 @@ fn induct_stream_slices_partial_success() {
                 messages_in_slice(slices.get(&REMOTE_SUBNET), 43..=45),
             );
             let response_count_bytes =
-                response_in_slice(slices.get(&REMOTE_SUBNET), 45).count_bytes();
+                response_in_slice(slices.get(&REMOTE_SUBNET), 45).memory_count_bytes();
 
             // The expected stream has...
             let expected_stream = stream_from_config(StreamConfig {
@@ -2434,13 +2434,13 @@ fn legacy_induct_stream_slices_partial_success() {
                 messages_in_slice(slices.get(&REMOTE_SUBNET), 43..=45),
             );
             let response_count_bytes =
-                response_in_slice(slices.get(&REMOTE_SUBNET), 45).count_bytes();
+                response_in_slice(slices.get(&REMOTE_SUBNET), 45).memory_count_bytes();
 
             let reject_response = generate_reject_response_for(
                 RejectReason::CanisterNotFound,
                 request_in_slice(slices.get(&REMOTE_SUBNET), 46),
             );
-            let reject_response_count_bytes = reject_response.count_bytes();
+            let reject_response_count_bytes = reject_response.memory_count_bytes();
 
             // The expected stream has...
             let expected_stream = stream_from_config(StreamConfig {
@@ -2742,7 +2742,7 @@ fn legacy_induct_stream_slices_with_messages_to_migrating_canister() {
                 RejectReason::CanisterMigrating,
                 request_in_slice(slices.get(&REMOTE_SUBNET), 43),
             );
-            let reject_response_count_bytes = reject_response.count_bytes();
+            let reject_response_count_bytes = reject_response.memory_count_bytes();
 
             let mut expected_state = state.clone();
             // Expecting a stream with...
@@ -2926,7 +2926,7 @@ fn legacy_induct_stream_slices_with_messages_to_migrated_canister() {
                 RejectReason::CanisterMigrating,
                 request_in_slice(slices.get(&REMOTE_SUBNET), 43),
             );
-            let reject_response_count_bytes = reject_response.count_bytes();
+            let reject_response_count_bytes = reject_response.memory_count_bytes();
 
             let mut expected_state = state.clone();
             // Expecting a stream with...

--- a/rs/p2p/artifact_downloader/src/fetch_stripped_artifact/assembler.rs
+++ b/rs/p2p/artifact_downloader/src/fetch_stripped_artifact/assembler.rs
@@ -198,7 +198,7 @@ impl ArtifactAssembler<ConsensusMessage, MaybeStrippedConsensusMessage>
             } else {
                 self.metrics
                     .missing_ingress_messages_bytes
-                    .observe(ingress.count_bytes() as f64);
+                    .observe(ingress.memory_count_bytes() as f64);
                 ingress_messages_from_peers += 1;
             }
 

--- a/rs/replicated_state/src/canister_state/execution_state.rs
+++ b/rs/replicated_state/src/canister_state/execution_state.rs
@@ -651,7 +651,7 @@ impl CustomSection {
 }
 
 impl CountBytes for CustomSection {
-    fn count_bytes(&self) -> usize {
+    fn memory_count_bytes(&self) -> usize {
         size_of_val(&self.visibility) + self.content.len()
     }
 }
@@ -709,7 +709,7 @@ impl WasmMetadata {
             memory_usage: NumBytes::from(
                 custom_sections
                     .iter()
-                    .map(|(k, v)| k.len() + v.count_bytes())
+                    .map(|(k, v)| k.len() + v.memory_count_bytes())
                     .sum::<usize>() as u64,
             ),
             custom_sections: Arc::new(custom_sections),
@@ -735,7 +735,7 @@ impl WasmMetadata {
             NumBytes::from(
                 self.custom_sections
                     .iter()
-                    .map(|(k, v)| k.len() + v.count_bytes())
+                    .map(|(k, v)| k.len() + v.memory_count_bytes())
                     .sum::<usize>() as u64,
             )
         );

--- a/rs/replicated_state/src/canister_state/queues.rs
+++ b/rs/replicated_state/src/canister_state/queues.rs
@@ -1242,7 +1242,7 @@ impl CanisterQueues {
 
     /// Returns the total byte size of enqueued ingress messages.
     pub fn ingress_queue_size_bytes(&self) -> usize {
-        self.ingress_queue.count_bytes()
+        self.ingress_queue.memory_count_bytes()
     }
 
     /// Returns the number of non-stale canister messages enqueued in input queues.
@@ -2015,8 +2015,8 @@ impl QueueStats {
 ///    always return memory.
 ///  * `Ok(())` if `msg` is a guaranteed response `Request` and
 ///    `available_memory` is sufficient.
-///  * `Err(msg.count_bytes())` if `msg` is a guaranteed response `Request` and
-///    `msg.count_bytes() > available_memory`.
+///  * `Err(msg.memory_count_bytes())` if `msg` is a guaranteed response `Request` and
+///    `msg.memory_count_bytes() > available_memory`.
 pub fn can_push(msg: &RequestOrResponse, available_memory: i64) -> Result<(), usize> {
     match msg {
         RequestOrResponse::Request(req) => {
@@ -2036,13 +2036,13 @@ pub fn can_push(msg: &RequestOrResponse, available_memory: i64) -> Result<(), us
 ///
 /// For best-effort requests, this is always zero. For guaranteed response
 /// requests, this is the maximum of `MAX_RESPONSE_COUNT_BYTES` (to be reserved
-/// for a guaranteed response) and `req.count_bytes()` (if larger).
+/// for a guaranteed response) and `req.memory_count_bytes()` (if larger).
 pub fn memory_required_to_push_request(req: &Request) -> usize {
     if req.deadline != NO_DEADLINE {
         return 0;
     }
 
-    req.count_bytes().max(MAX_RESPONSE_COUNT_BYTES)
+    req.memory_count_bytes().max(MAX_RESPONSE_COUNT_BYTES)
 }
 
 pub mod testing {

--- a/rs/replicated_state/src/canister_state/queues/message_pool.rs
+++ b/rs/replicated_state/src/canister_state/queues/message_pool.rs
@@ -454,7 +454,7 @@ impl MessagePool {
         let reference = self.next_reference(class, kind);
         let id = reference.into();
 
-        let size_bytes = msg.count_bytes();
+        let size_bytes = msg.memory_count_bytes();
 
         // Update message stats.
         self.message_stats += MessageStats::stats_delta(&msg, context);
@@ -573,7 +573,7 @@ impl MessagePool {
     /// Removes the given message from the load shedding queue.
     fn remove_from_size_queue(&mut self, id: Id, msg: &RequestOrResponse) {
         if id.class() == Class::BestEffort {
-            let removed = self.size_queue.remove(&(msg.count_bytes(), id));
+            let removed = self.size_queue.remove(&(msg.memory_count_bytes(), id));
             debug_assert!(removed);
         }
     }
@@ -776,13 +776,13 @@ impl MessagePool {
                 // Inbound best-effort responses don't have expiration deadlines, but can be
                 // shed.
                 (Inbound, BestEffort, Response) => {
-                    expected_size_queue.insert((msg.count_bytes(), *id));
+                    expected_size_queue.insert((msg.memory_count_bytes(), *id));
                 }
 
                 // All other best-effort messages are enqueued in both priority queues.
                 (_, BestEffort, _) => {
                     expected_deadline_queue.insert((msg.deadline(), *id));
-                    expected_size_queue.insert((msg.count_bytes(), *id));
+                    expected_size_queue.insert((msg.memory_count_bytes(), *id));
                 }
             }
         });
@@ -939,7 +939,7 @@ impl MessageStats {
         use Class::*;
         use Context::*;
 
-        let size_bytes = req.count_bytes();
+        let size_bytes = req.memory_count_bytes();
         let class = if req.deadline == NO_DEADLINE {
             GuaranteedResponse
         } else {
@@ -1011,7 +1011,7 @@ impl MessageStats {
         use Class::*;
         use Context::*;
 
-        let size_bytes = rep.count_bytes();
+        let size_bytes = rep.memory_count_bytes();
         let class = if rep.deadline == NO_DEADLINE {
             GuaranteedResponse
         } else {

--- a/rs/replicated_state/src/canister_state/queues/message_pool/tests.rs
+++ b/rs/replicated_state/src/canister_state/queues/message_pool/tests.rs
@@ -720,9 +720,9 @@ fn test_message_stats_best_effort() {
     // Insert a bunch of best-effort messages.
     //
     let request = request(time(10));
-    let request_size_bytes = request.count_bytes();
+    let request_size_bytes = request.memory_count_bytes();
     let response = response(time(20));
-    let response_size_bytes = response.count_bytes();
+    let response_size_bytes = response.memory_count_bytes();
 
     let _ = pool.insert_inbound(request.clone().into());
     stats.adjust_and_check(&pool, Push, Inbound, request.clone().into());
@@ -799,9 +799,9 @@ fn test_message_stats_guaranteed_response() {
     // Insert a bunch of guaranteed response messages.
     //
     let request = request(NO_DEADLINE);
-    let request_size_bytes = request.count_bytes();
+    let request_size_bytes = request.memory_count_bytes();
     let response = response(NO_DEADLINE);
-    let response_size_bytes = response.count_bytes();
+    let response_size_bytes = response.memory_count_bytes();
 
     let inbound_request_id = pool.insert_inbound(request.clone().into());
     stats.adjust_and_check(&pool, Push, Inbound, request.clone().into());
@@ -886,12 +886,12 @@ fn test_message_stats_oversized_requests() {
         MAX_INTER_CANISTER_PAYLOAD_IN_BYTES_U64 as usize + 1000,
         time(10),
     );
-    let best_effort_size_bytes = best_effort.count_bytes();
+    let best_effort_size_bytes = best_effort.memory_count_bytes();
     let guaranteed = request_with_payload(
         MAX_INTER_CANISTER_PAYLOAD_IN_BYTES_U64 as usize + 2000,
         NO_DEADLINE,
     );
-    let guaranteed_size_bytes = guaranteed.count_bytes();
+    let guaranteed_size_bytes = guaranteed.memory_count_bytes();
     // The 2000 bytes we added above; plus the method name provided by
     // `RequestBuilder`; plus any difference in size between the `Request` and
     // `Response` structs, so better to compute it
@@ -1096,7 +1096,7 @@ fn request_stats_delta2(req: &Request, context: Context) -> MessageStats {
         Class::BestEffort
     };
 
-    let size_bytes = req.count_bytes();
+    let size_bytes = req.memory_count_bytes();
     let (best_effort_message_bytes, oversized_guaranteed_requests_extra_bytes) = match class {
         GuaranteedResponse => (0, size_bytes.saturating_sub(MAX_RESPONSE_COUNT_BYTES)),
         BestEffort => (size_bytes, 0),
@@ -1143,7 +1143,7 @@ fn response_stats_delta2(rep: &Response, context: Context) -> MessageStats {
         Class::BestEffort
     };
 
-    let size_bytes = rep.count_bytes();
+    let size_bytes = rep.memory_count_bytes();
     let (best_effort_message_bytes, guaranteed_responses_size_bytes) = match class {
         GuaranteedResponse => (0, size_bytes),
         BestEffort => (size_bytes, 0),

--- a/rs/replicated_state/src/canister_state/queues/queue.rs
+++ b/rs/replicated_state/src/canister_state/queues/queue.rs
@@ -490,7 +490,7 @@ impl IngressQueue {
 
     /// Returns an estimate of the size of an ingress message in bytes.
     fn ingress_size_bytes(msg: &Ingress) -> usize {
-        size_of::<Arc<Ingress>>() + msg.count_bytes()
+        size_of::<Arc<Ingress>>() + msg.memory_count_bytes()
     }
 
     /// Calculates the size in bytes of an `IngressQueue` holding the given
@@ -527,7 +527,7 @@ impl Default for IngressQueue {
 
 impl CountBytes for IngressQueue {
     /// Estimate of the queue size in bytes, including metadata.
-    fn count_bytes(&self) -> usize {
+    fn memory_count_bytes(&self) -> usize {
         self.size_bytes
     }
 }

--- a/rs/replicated_state/src/canister_state/queues/queue/tests.rs
+++ b/rs/replicated_state/src/canister_state/queues/queue/tests.rs
@@ -388,19 +388,31 @@ fn ingress_filter() {
     queue.push(msg2.clone());
     queue.push(msg3.clone());
 
-    assert_eq!(IngressQueue::size_bytes(&queue.queues), queue.count_bytes());
+    assert_eq!(
+        IngressQueue::size_bytes(&queue.queues),
+        queue.memory_count_bytes()
+    );
 
     queue.filter_messages(|ingress| *ingress != Arc::new(msg2.clone()));
     assert_eq!(queue.size(), 2);
-    assert_eq!(IngressQueue::size_bytes(&queue.queues), queue.count_bytes());
+    assert_eq!(
+        IngressQueue::size_bytes(&queue.queues),
+        queue.memory_count_bytes()
+    );
 
     assert_eq!(queue.pop(), Some(msg1.into()));
     assert_eq!(queue.size(), 1);
-    assert_eq!(IngressQueue::size_bytes(&queue.queues), queue.count_bytes());
+    assert_eq!(
+        IngressQueue::size_bytes(&queue.queues),
+        queue.memory_count_bytes()
+    );
 
     assert_eq!(queue.pop(), Some(msg3.into()));
     assert_eq!(queue.size(), 0);
-    assert_eq!(IngressQueue::size_bytes(&queue.queues), queue.count_bytes());
+    assert_eq!(
+        IngressQueue::size_bytes(&queue.queues),
+        queue.memory_count_bytes()
+    );
 }
 
 #[test]

--- a/rs/replicated_state/src/canister_state/queues/tests.rs
+++ b/rs/replicated_state/src/canister_state/queues/tests.rs
@@ -2179,14 +2179,14 @@ fn test_stats_best_effort() {
     let request2_ = request(2, t10);
     let request3 = request(3, t10);
     let request4 = request(4, t10);
-    let request_size_bytes = request1_.count_bytes();
-    assert_eq!(request_size_bytes, request2_.count_bytes());
-    assert_eq!(request_size_bytes, request3.count_bytes());
-    assert_eq!(request_size_bytes, request4.count_bytes());
+    let request_size_bytes = request1_.memory_count_bytes();
+    assert_eq!(request_size_bytes, request2_.memory_count_bytes());
+    assert_eq!(request_size_bytes, request3.memory_count_bytes());
+    assert_eq!(request_size_bytes, request4.memory_count_bytes());
     let response1 = response_with_payload(1000, 1, t20);
     let response2 = response_with_payload(1000, 2, t20);
-    let response_size_bytes = response1.count_bytes();
-    assert_eq!(response_size_bytes, response2.count_bytes());
+    let response_size_bytes = response1.memory_count_bytes();
+    assert_eq!(response_size_bytes, response2.memory_count_bytes());
 
     // Make reservations for the responses.
     assert!(queues.push_input(request1_.into(), LocalSubnet).unwrap());
@@ -2281,7 +2281,7 @@ fn test_stats_best_effort() {
     // Only one best-effort reject response (the dropped response is no longer in
     // the pool).
     let reject_response = generate_timeout_response(&request4);
-    let reject_response_size_bytes = reject_response.count_bytes();
+    let reject_response_size_bytes = reject_response.memory_count_bytes();
     assert_eq!(
         &message_pool::MessageStats {
             size_bytes: reject_response_size_bytes,
@@ -2333,16 +2333,16 @@ fn test_stats_guaranteed_response() {
     let request2_ = request_with_payload(100, 2, NO_DEADLINE);
     let request3 = request_with_payload(100, 3, NO_DEADLINE);
     let request4 = request_with_payload(100, 4, NO_DEADLINE);
-    let request_size_bytes = request1_.count_bytes();
-    assert_eq!(request_size_bytes, request2_.count_bytes());
-    assert_eq!(request_size_bytes, request3.count_bytes());
-    assert_eq!(request_size_bytes, request4.count_bytes());
+    let request_size_bytes = request1_.memory_count_bytes();
+    assert_eq!(request_size_bytes, request2_.memory_count_bytes());
+    assert_eq!(request_size_bytes, request3.memory_count_bytes());
+    assert_eq!(request_size_bytes, request4.memory_count_bytes());
     let response1 = response(1, NO_DEADLINE);
     let response2 = response(2, NO_DEADLINE);
     let response4_ = response(4, NO_DEADLINE);
-    let response_size_bytes = response1.count_bytes();
-    assert_eq!(response_size_bytes, response2.count_bytes());
-    assert_eq!(response_size_bytes, response4_.count_bytes());
+    let response_size_bytes = response1.memory_count_bytes();
+    assert_eq!(response_size_bytes, response2.memory_count_bytes());
+    assert_eq!(response_size_bytes, response4_.memory_count_bytes());
 
     // Make reservations for the responses.
     assert!(queues.push_input(request1_.into(), LocalSubnet).unwrap());
@@ -2469,13 +2469,13 @@ fn test_stats_oversized_requests() {
         1,
         SOME_DEADLINE,
     );
-    let best_effort_size_bytes = best_effort.count_bytes();
+    let best_effort_size_bytes = best_effort.memory_count_bytes();
     let guaranteed = request_with_payload(
         MAX_INTER_CANISTER_PAYLOAD_IN_BYTES_U64 as usize + 2000,
         2,
         NO_DEADLINE,
     );
-    let guaranteed_size_bytes = guaranteed.count_bytes();
+    let guaranteed_size_bytes = guaranteed.memory_count_bytes();
     // The 2000 bytes we added above; plus the method name provided by
     // `RequestBuilder`; plus any difference in size between the `Request` and
     // `Response` structs, so better compute it.

--- a/rs/replicated_state/src/canister_state/tests.rs
+++ b/rs/replicated_state/src/canister_state/tests.rs
@@ -756,7 +756,7 @@ fn canister_state_push_input_response_memory_limit_test_impl(
         .unwrap());
 
     assert_eq!(
-        -13 + MAX_RESPONSE_COUNT_BYTES as i64 - response.count_bytes() as i64,
+        -13 + MAX_RESPONSE_COUNT_BYTES as i64 - response.memory_count_bytes() as i64,
         subnet_available_memory
     );
 }

--- a/rs/replicated_state/src/metadata_state/tests.rs
+++ b/rs/replicated_state/src/metadata_state/tests.rs
@@ -157,7 +157,7 @@ fn streams_stats() {
             .response_payload(Payload::Data(payload.as_bytes().to_vec()))
             .build()
             .into();
-        let req_bytes = rep.count_bytes();
+        let req_bytes = rep.memory_count_bytes();
         (rep, req_bytes)
     }
 

--- a/rs/replicated_state/tests/replicated_state.rs
+++ b/rs/replicated_state/tests/replicated_state.rs
@@ -283,7 +283,7 @@ fn memory_taken_by_canister_queues() {
 
     // Memory used by response only.
     assert_execution_memory_taken(0, &fixture);
-    assert_message_memory_taken(response.count_bytes(), &fixture);
+    assert_message_memory_taken(response.memory_count_bytes(), &fixture);
     assert_canister_history_memory_taken(0, &fixture);
     assert_wasm_custom_sections_memory_taken(0, &fixture);
 }
@@ -336,7 +336,7 @@ fn memory_taken_by_subnet_queues() {
 
     // Memory used by response only.
     assert_execution_memory_taken(0, &fixture);
-    assert_message_memory_taken(response.count_bytes(), &fixture);
+    assert_message_memory_taken(response.memory_count_bytes(), &fixture);
     assert_canister_history_memory_taken(0, &fixture);
     assert_wasm_custom_sections_memory_taken(0, &fixture);
 }
@@ -360,7 +360,7 @@ fn memory_taken_by_stream_responses() {
 
     // Memory only used by response, not request.
     assert_execution_memory_taken(0, &fixture);
-    assert_message_memory_taken(response.count_bytes(), &fixture);
+    assert_message_memory_taken(response.memory_count_bytes(), &fixture);
     assert_canister_history_memory_taken(0, &fixture);
     assert_wasm_custom_sections_memory_taken(0, &fixture);
 }
@@ -756,7 +756,7 @@ fn enforce_best_effort_message_limit() {
         let mut request = request_to(*receiver);
         request.deadline = SOME_DEADLINE;
         request.method_name = String::from_utf8(vec![b'x'; i * 10 + 1]).unwrap();
-        message_sizes.push(NumBytes::from(request.count_bytes() as u64));
+        message_sizes.push(NumBytes::from(request.memory_count_bytes() as u64));
         assert!(fixture.push_input(request.into()).unwrap());
     }
 

--- a/rs/state_machine_tests/src/lib.rs
+++ b/rs/state_machine_tests/src/lib.rs
@@ -2021,11 +2021,11 @@ impl StateMachine {
             .unwrap();
 
         // Validate the size of the ingress message.
-        if msg.count_bytes() > ingress_registry_settings.max_ingress_bytes_per_message {
+        if msg.memory_count_bytes() > ingress_registry_settings.max_ingress_bytes_per_message {
             return Err(SubmitIngressError::HttpError(format!(
                 "Request {} is too large. Message byte size {} is larger than the max allowed {}.",
                 msg.id(),
-                msg.count_bytes(),
+                msg.memory_count_bytes(),
                 ingress_registry_settings.max_ingress_bytes_per_message
             )));
         }

--- a/rs/system_api/tests/system_api.rs
+++ b/rs/system_api/tests/system_api.rs
@@ -1817,7 +1817,7 @@ fn push_output_request_oversized_request_memory_limits() {
         .sender(own_canister_id)
         .method_payload(vec![13; 2 * MAX_RESPONSE_COUNT_BYTES])
         .build();
-    let req_size_bytes = req.count_bytes();
+    let req_size_bytes = req.memory_count_bytes();
     assert!(req_size_bytes > MAX_RESPONSE_COUNT_BYTES);
 
     // Pushing succeeds.

--- a/rs/test_utilities/src/ingress_selector.rs
+++ b/rs/test_utilities/src/ingress_selector.rs
@@ -67,7 +67,7 @@ impl IngressSelector for FakeIngressSelector {
             .find(|(_, payloads)| {
                 (payloads
                     .iter()
-                    .map(|payload| payload.count_bytes())
+                    .map(|payload| payload.memory_count_bytes())
                     .sum::<usize>() as u64)
                     < byte_limit.get()
             })

--- a/rs/types/error_types/src/lib.rs
+++ b/rs/types/error_types/src/lib.rs
@@ -559,7 +559,7 @@ impl UserError {
         }
     }
 
-    pub fn count_bytes(&self) -> usize {
+    pub fn memory_count_bytes(&self) -> usize {
         std::mem::size_of_val(self) + self.description.len()
     }
 

--- a/rs/types/types/src/batch.rs
+++ b/rs/types/types/src/batch.rs
@@ -245,8 +245,8 @@ mod tests {
     /// of a payload section actually produces the empty payload,
     #[test]
     fn default_batch_payload_is_empty() {
-        assert_eq!(IngressPayload::default().count_bytes(), 0);
-        assert_eq!(SelfValidatingPayload::default().count_bytes(), 0);
+        assert_eq!(IngressPayload::default().memory_count_bytes(), 0);
+        assert_eq!(SelfValidatingPayload::default().memory_count_bytes(), 0);
     }
 
     #[test]

--- a/rs/types/types/src/batch/ingress.rs
+++ b/rs/types/types/src/batch/ingress.rs
@@ -151,7 +151,7 @@ impl IngressPayload {
 }
 
 impl CountBytes for IngressPayload {
-    fn count_bytes(&self) -> usize {
+    fn memory_count_bytes(&self) -> usize {
         self.buffer.len() + self.id_and_pos.len() * EXPECTED_MESSAGE_ID_LENGTH
     }
 }

--- a/rs/types/types/src/batch/self_validating.rs
+++ b/rs/types/types/src/batch/self_validating.rs
@@ -60,7 +60,7 @@ impl TryFrom<pb::SelfValidatingPayload> for SelfValidatingPayload {
 }
 
 impl CountBytes for SelfValidatingPayload {
-    fn count_bytes(&self) -> usize {
+    fn memory_count_bytes(&self) -> usize {
         self.0.iter().map(|x| x.count_bytes()).sum()
     }
 }

--- a/rs/types/types/src/batch/xnet.rs
+++ b/rs/types/types/src/batch/xnet.rs
@@ -68,7 +68,9 @@ impl XNetPayload {
         self.stream_slices
             .values()
             .map(|slice| {
-                slice.payload.len() + slice.merkle_proof.len() + slice.certification.count_bytes()
+                slice.payload.len()
+                    + slice.merkle_proof.len()
+                    + slice.certification.memory_count_bytes()
             })
             .sum()
     }

--- a/rs/types/types/src/canister_http.rs
+++ b/rs/types/types/src/canister_http.rs
@@ -470,8 +470,8 @@ pub struct CanisterHttpResponse {
 }
 
 impl CountBytes for CanisterHttpResponse {
-    fn count_bytes(&self) -> usize {
-        size_of::<CallbackId>() + size_of::<Time>() + self.content.count_bytes()
+    fn memory_count_bytes(&self) -> usize {
+        size_of::<CallbackId>() + size_of::<Time>() + self.content.memory_count_bytes()
     }
 }
 
@@ -487,10 +487,10 @@ pub enum CanisterHttpResponseContent {
 }
 
 impl CountBytes for CanisterHttpResponseContent {
-    fn count_bytes(&self) -> usize {
+    fn memory_count_bytes(&self) -> usize {
         match self {
             CanisterHttpResponseContent::Success(payload) => payload.len(),
-            CanisterHttpResponseContent::Reject(err) => err.count_bytes(),
+            CanisterHttpResponseContent::Reject(err) => err.memory_count_bytes(),
         }
     }
 }
@@ -513,7 +513,7 @@ impl From<&CanisterHttpReject> for RejectContext {
 }
 
 impl CountBytes for CanisterHttpReject {
-    fn count_bytes(&self) -> usize {
+    fn memory_count_bytes(&self) -> usize {
         size_of::<RejectCode>() + self.message.len()
     }
 }
@@ -568,8 +568,8 @@ pub struct CanisterHttpResponseWithConsensus {
 }
 
 impl CountBytes for CanisterHttpResponseWithConsensus {
-    fn count_bytes(&self) -> usize {
-        self.proof.count_bytes() + self.content.count_bytes()
+    fn memory_count_bytes(&self) -> usize {
+        self.proof.memory_count_bytes() + self.content.memory_count_bytes()
     }
 }
 
@@ -584,8 +584,11 @@ pub struct CanisterHttpResponseDivergence {
 }
 
 impl CountBytes for CanisterHttpResponseDivergence {
-    fn count_bytes(&self) -> usize {
-        self.shares.iter().map(|share| share.count_bytes()).sum()
+    fn memory_count_bytes(&self) -> usize {
+        self.shares
+            .iter()
+            .map(|share| share.memory_count_bytes())
+            .sum()
     }
 }
 
@@ -600,7 +603,7 @@ pub struct CanisterHttpResponseMetadata {
 }
 
 impl CountBytes for CanisterHttpResponseMetadata {
-    fn count_bytes(&self) -> usize {
+    fn memory_count_bytes(&self) -> usize {
         size_of::<CanisterHttpResponseMetadata>()
     }
 }
@@ -637,7 +640,7 @@ pub type CanisterHttpResponseProof =
     Signed<CanisterHttpResponseMetadata, BasicSignatureBatch<CanisterHttpResponseMetadata>>;
 
 impl CountBytes for CanisterHttpResponseProof {
-    fn count_bytes(&self) -> usize {
+    fn memory_count_bytes(&self) -> usize {
         size_of::<CanisterHttpResponseProof>()
     }
 }

--- a/rs/types/types/src/consensus.rs
+++ b/rs/types/types/src/consensus.rs
@@ -1422,14 +1422,14 @@ impl TryFrom<pb::Block> for Block {
 }
 
 impl CountBytes for NiDkgId {
-    fn count_bytes(&self) -> usize {
+    fn memory_count_bytes(&self) -> usize {
         std::mem::size_of::<Self>()
     }
 }
 
 impl<T> CountBytes for ThresholdSignature<T> {
-    fn count_bytes(&self) -> usize {
-        self.signature.get_ref().0.len() + self.signer.count_bytes()
+    fn memory_count_bytes(&self) -> usize {
+        self.signature.get_ref().0.len() + self.signer.memory_count_bytes()
     }
 }
 

--- a/rs/types/types/src/consensus/certification.rs
+++ b/rs/types/types/src/consensus/certification.rs
@@ -218,10 +218,10 @@ impl HasHeight for Certification {
 }
 
 impl CountBytes for Certification {
-    fn count_bytes(&self) -> usize {
+    fn memory_count_bytes(&self) -> usize {
         std::mem::size_of::<Height>()
             + self.signed.content.hash.get_ref().0.len()
-            + self.signed.signature.count_bytes()
+            + self.signed.signature.memory_count_bytes()
     }
 }
 

--- a/rs/types/types/src/crypto.rs
+++ b/rs/types/types/src/crypto.rs
@@ -88,8 +88,8 @@ pub struct Signed<T, S> {
 }
 
 impl<T: CountBytes, S: CountBytes> CountBytes for Signed<T, S> {
-    fn count_bytes(&self) -> usize {
-        self.content.count_bytes() + self.signature.count_bytes()
+    fn memory_count_bytes(&self) -> usize {
+        self.content.memory_count_bytes() + self.signature.memory_count_bytes()
     }
 }
 
@@ -281,7 +281,7 @@ impl fmt::Display for UserPublicKey {
 }
 
 impl CountBytes for UserPublicKey {
-    fn count_bytes(&self) -> usize {
+    fn memory_count_bytes(&self) -> usize {
         self.key.len()
     }
 }
@@ -646,14 +646,14 @@ impl fmt::Debug for BasicSig {
 pub type BasicSigOf<T> = Id<T, BasicSig>; // Use newtype instead? E.g., `pub struct BasicSigOf<T>(Id<T, BasicSig>);`
 
 impl CountBytes for BasicSig {
-    fn count_bytes(&self) -> usize {
+    fn memory_count_bytes(&self) -> usize {
         self.0.len()
     }
 }
 
 impl<T: CountBytes> CountBytes for BasicSigOf<T> {
-    fn count_bytes(&self) -> usize {
-        self.get_ref().count_bytes()
+    fn memory_count_bytes(&self) -> usize {
+        self.get_ref().memory_count_bytes()
     }
 }
 
@@ -664,14 +664,14 @@ pub struct IndividualMultiSig(#[serde(with = "serde_bytes")] pub Vec<u8>);
 pub type IndividualMultiSigOf<T> = Id<T, IndividualMultiSig>; // Use newtype instead?
 
 impl CountBytes for IndividualMultiSig {
-    fn count_bytes(&self) -> usize {
+    fn memory_count_bytes(&self) -> usize {
         self.0.len()
     }
 }
 
 impl<T: CountBytes> CountBytes for IndividualMultiSigOf<T> {
-    fn count_bytes(&self) -> usize {
-        self.get_ref().count_bytes()
+    fn memory_count_bytes(&self) -> usize {
+        self.get_ref().memory_count_bytes()
     }
 }
 
@@ -694,14 +694,14 @@ pub struct CombinedMultiSig(#[serde(with = "serde_bytes")] pub Vec<u8>);
 pub type CombinedMultiSigOf<T> = Id<T, CombinedMultiSig>; // Use newtype instead?
 
 impl CountBytes for CombinedMultiSig {
-    fn count_bytes(&self) -> usize {
+    fn memory_count_bytes(&self) -> usize {
         self.0.len()
     }
 }
 
 impl<T: CountBytes> CountBytes for CombinedMultiSigOf<T> {
-    fn count_bytes(&self) -> usize {
-        self.get_ref().count_bytes()
+    fn memory_count_bytes(&self) -> usize {
+        self.get_ref().memory_count_bytes()
     }
 }
 

--- a/rs/types/types/src/ingress.rs
+++ b/rs/types/types/src/ingress.rs
@@ -107,7 +107,7 @@ impl IngressStatus {
     pub fn payload_bytes(&self) -> usize {
         match self {
             IngressStatus::Known { state, .. } => match state {
-                IngressState::Completed(result) => result.count_bytes(),
+                IngressState::Completed(result) => result.memory_count_bytes(),
                 IngressState::Failed(error) => error.description().as_bytes().len(),
                 _ => 0,
             },
@@ -177,7 +177,7 @@ pub enum WasmResult {
 }
 
 impl CountBytes for WasmResult {
-    fn count_bytes(&self) -> usize {
+    fn memory_count_bytes(&self) -> usize {
         match self {
             WasmResult::Reply(bytes) => bytes.len(),
             WasmResult::Reject(string) => string.as_bytes().len(),

--- a/rs/types/types/src/messages/ingress_messages.rs
+++ b/rs/types/types/src/messages/ingress_messages.rs
@@ -342,7 +342,7 @@ impl TryFrom<HttpRequestEnvelope<HttpCallContent>> for SignedIngress {
 }
 
 impl CountBytes for SignedIngress {
-    fn count_bytes(&self) -> usize {
+    fn memory_count_bytes(&self) -> usize {
         // Since we not only add the message, but also the pointer to the message,
         // we need to account for that when building the length
         self.binary().len() + EXPECTED_MESSAGE_ID_LENGTH
@@ -442,7 +442,7 @@ impl TryFrom<pb_ingress::Ingress> for Ingress {
 }
 
 impl CountBytes for Ingress {
-    fn count_bytes(&self) -> usize {
+    fn memory_count_bytes(&self) -> usize {
         size_of::<Ingress>() + self.method_name.len() + self.method_payload.len()
     }
 }

--- a/rs/types/types/src/messages/inter_canister.rs
+++ b/rs/types/types/src/messages/inter_canister.rs
@@ -44,7 +44,7 @@ pub struct CallbackIdTag;
 pub type CallbackId = Id<CallbackIdTag, u64>;
 
 impl CountBytes for CallbackId {
-    fn count_bytes(&self) -> usize {
+    fn memory_count_bytes(&self) -> usize {
         size_of::<CallbackId>()
     }
 }
@@ -576,10 +576,10 @@ impl RequestOrResponse {
 }
 
 /// Convenience `CountBytes` implementation that returns the same value as
-/// `RequestOrResponse::Request(self).count_bytes()`, so we don't need to wrap
+/// `RequestOrResponse::Request(self).memory_count_bytes()`, so we don't need to wrap
 /// `self` into a `RequestOrResponse` only to calculate its estimated byte size.
 impl CountBytes for Request {
-    fn count_bytes(&self) -> usize {
+    fn memory_count_bytes(&self) -> usize {
         size_of::<RequestOrResponse>()
             + size_of::<Request>()
             + self.payload_size_bytes().get() as usize
@@ -587,10 +587,10 @@ impl CountBytes for Request {
 }
 
 /// Convenience `CountBytes` implementation that returns the same value as
-/// `RequestOrResponse::Response(self).count_bytes()`, so we don't need to wrap
+/// `RequestOrResponse::Response(self).memory_count_bytes()`, so we don't need to wrap
 /// `self` into a `RequestOrResponse` only to calculate its estimated byte size.
 impl CountBytes for Response {
-    fn count_bytes(&self) -> usize {
+    fn memory_count_bytes(&self) -> usize {
         size_of::<RequestOrResponse>()
             + size_of::<Response>()
             + self.payload_size_bytes().get() as usize
@@ -598,10 +598,10 @@ impl CountBytes for Response {
 }
 
 impl CountBytes for RequestOrResponse {
-    fn count_bytes(&self) -> usize {
+    fn memory_count_bytes(&self) -> usize {
         match self {
-            RequestOrResponse::Request(req) => req.count_bytes(),
-            RequestOrResponse::Response(resp) => resp.count_bytes(),
+            RequestOrResponse::Request(req) => req.memory_count_bytes(),
+            RequestOrResponse::Response(resp) => resp.memory_count_bytes(),
         }
     }
 }

--- a/rs/types/types/src/messages/inter_canister/tests.rs
+++ b/rs/types/types/src/messages/inter_canister/tests.rs
@@ -94,7 +94,7 @@ fn max_response_count_bytes() {
         response.payload_size_bytes()
     );
     // And its total size must be exactly `MAX_RESPONSE_COUNT_BYTES`.
-    assert_eq!(MAX_RESPONSE_COUNT_BYTES, response.count_bytes());
+    assert_eq!(MAX_RESPONSE_COUNT_BYTES, response.memory_count_bytes());
 
     // A reject response with a maximum size payload.
     let max_reject_payload_size =
@@ -118,7 +118,7 @@ fn max_response_count_bytes() {
         reject.payload_size_bytes()
     );
     // And its total size must be exactly `MAX_RESPONSE_COUNT_BYTES`.
-    assert_eq!(MAX_RESPONSE_COUNT_BYTES, reject.count_bytes());
+    assert_eq!(MAX_RESPONSE_COUNT_BYTES, reject.memory_count_bytes());
 }
 
 #[test]

--- a/rs/types/types/src/messages/message_id.rs
+++ b/rs/types/types/src/messages/message_id.rs
@@ -58,7 +58,7 @@ impl<'a> Deserialize<'a> for MessageId {
 }
 
 impl CountBytes for MessageId {
-    fn count_bytes(&self) -> usize {
+    fn memory_count_bytes(&self) -> usize {
         self.0.len()
     }
 }

--- a/rs/types/types/src/messages/webauthn.rs
+++ b/rs/types/types/src/messages/webauthn.rs
@@ -46,7 +46,7 @@ impl WebAuthnSignature {
 }
 
 impl CountBytes for WebAuthnSignature {
-    fn count_bytes(&self) -> usize {
+    fn memory_count_bytes(&self) -> usize {
         self.authenticator_data.0.len() + self.client_data_json.0.len() + self.signature.0.len()
     }
 }

--- a/rs/types/types/src/signature.rs
+++ b/rs/types/types/src/signature.rs
@@ -18,8 +18,8 @@ pub struct BasicSignature<T> {
 }
 
 impl<T> CountBytes for BasicSignature<T> {
-    fn count_bytes(&self) -> usize {
-        self.signature.get_ref().count_bytes() + std::mem::size_of::<NodeId>()
+    fn memory_count_bytes(&self) -> usize {
+        self.signature.get_ref().memory_count_bytes() + std::mem::size_of::<NodeId>()
     }
 }
 

--- a/rs/types/wasm_types/src/lib.rs
+++ b/rs/types/wasm_types/src/lib.rs
@@ -175,7 +175,7 @@ impl TryFrom<Vec<u8>> for WasmHash {
 }
 
 impl CountBytes for WasmHash {
-    fn count_bytes(&self) -> usize {
+    fn memory_count_bytes(&self) -> usize {
         self.0.len()
     }
 }

--- a/rs/utils/lru_cache/BUILD.bazel
+++ b/rs/utils/lru_cache/BUILD.bazel
@@ -17,7 +17,9 @@ rust_library(
 rust_test(
     name = "lru_cache_test",
     crate = ":lru_cache",
-    deps = [],
+    deps = [
+        "@crate_index//:proptest",
+    ],
 )
 
 rust_doc_test(

--- a/rs/utils/lru_cache/Cargo.toml
+++ b/rs/utils/lru_cache/Cargo.toml
@@ -11,3 +11,6 @@ documentation.workspace = true
 [dependencies]
 ic-types = { path = "../../types/types" }
 lru = { version = "0.7.8", default-features = false }
+
+[dev-dependencies]
+proptest = { workspace = true }

--- a/rs/utils/lru_cache/src/lib.rs
+++ b/rs/utils/lru_cache/src/lib.rs
@@ -15,8 +15,10 @@ where
     V: CountBytes,
 {
     cache: lru::LruCache<K, V>,
-    capacity: usize,
-    size: usize,
+    memory_capacity: usize,
+    disk_capacity: usize,
+    memory_size: usize,
+    disk_size: usize,
 }
 
 impl<K, V> CountBytes for LruCache<K, V>
@@ -38,15 +40,19 @@ where
     K: CountBytes + Eq + Hash,
     V: CountBytes,
 {
-    /// Constructs a new LRU cache with the given capacity.
-    /// The capacity must not exceed `MAX_SIZE = (2^63 - 1)`.
-    pub fn new(capacity: NumBytes) -> Self {
-        let capacity = capacity.get() as usize;
-        assert!(capacity <= MAX_SIZE);
+    /// Constructs a new LRU cache with the given memory and disk capacity.  The
+    /// capacities must not exceed `MAX_SIZE = (2^63 - 1)`.
+    pub fn new(memory_capacity: NumBytes, disk_capacity: NumBytes) -> Self {
+        let memory_capacity = memory_capacity.get() as usize;
+        let disk_capacity = disk_capacity.get() as usize;
+        assert!(memory_capacity <= MAX_SIZE);
+        assert!(disk_capacity <= MAX_SIZE);
         let lru_cache = Self {
             cache: lru::LruCache::unbounded(),
-            capacity,
-            size: 0,
+            memory_capacity,
+            disk_capacity,
+            memory_size: 0,
+            disk_size: 0,
         };
         lru_cache.check_invariants();
         lru_cache
@@ -54,7 +60,10 @@ where
 
     /// Creates a new LRU Cache that never automatically evicts items.
     pub fn unbounded() -> Self {
-        Self::new(NumBytes::new(MAX_SIZE as u64))
+        Self::new(
+            NumBytes::new(MAX_SIZE as u64),
+            NumBytes::new(MAX_SIZE as u64),
+        )
     }
 
     /// Returns the value corresponding to the given key.
@@ -67,21 +76,33 @@ where
     /// the cache or other cache entries are evicted (due to the cache capacity),
     /// then it returns the old entry's key-value pairs. Otherwise, returns an empty vector.
     pub fn push(&mut self, key: K, value: V) -> Vec<(K, V)> {
-        let size = key.count_bytes() + value.count_bytes();
-        assert!(size <= MAX_SIZE);
+        let memory_size = key.memory_count_bytes() + value.memory_count_bytes();
+        assert!(memory_size <= MAX_SIZE);
+        let disk_size = key.disk_count_bytes() + value.disk_count_bytes();
+        assert!(disk_size <= MAX_SIZE);
 
         let removed_entry = self.cache.push(key, value);
         if let Some((removed_key, removed_value)) = &removed_entry {
-            let removed_size = removed_key.count_bytes() + removed_value.count_bytes();
-            debug_assert!(self.size >= removed_size);
-            // This cannot underflow because we know that `self.size` is
+            let memory_removed_size =
+                removed_key.memory_count_bytes() + removed_value.memory_count_bytes();
+            debug_assert!(self.memory_size >= memory_removed_size);
+            // This cannot underflow because we know that `self.memory_size` is
             // the sum of sizes of all items in the cache.
-            self.size -= removed_size;
+            self.memory_size -= memory_removed_size;
+
+            let disk_removed_size =
+                removed_key.disk_count_bytes() + removed_value.disk_count_bytes();
+            debug_assert!(self.disk_size >= disk_removed_size);
+            // This cannot underflow because we know that `self.disk_size` is
+            // the sum of sizes of all items in the cache.
+            self.disk_size -= disk_removed_size;
         }
         // This cannot overflow because we know that
-        // `self.size <= self.capacity <= MAX_SIZE`
-        // and `size <= MAX_SIZE == usize::MAX / 2`.
-        self.size += size;
+        // `self.memory_size <= self.memory_capacity <= MAX_SIZE`
+        // and `memory_size <= MAX_SIZE == usize::MAX / 2`.
+        self.memory_size += memory_size;
+        // Similar as for `memory_size``.
+        self.disk_size += disk_size;
         let mut evicted_entries = self.evict();
         self.check_invariants();
 
@@ -93,9 +114,14 @@ where
     /// `None` if it does not exist.
     pub fn pop(&mut self, key: &K) -> Option<V> {
         if let Some((key, value)) = self.cache.pop_entry(key) {
-            let size = key.count_bytes() + value.count_bytes();
-            debug_assert!(self.size >= size);
-            self.size -= size;
+            let memory_size = key.memory_count_bytes() + value.memory_count_bytes();
+            debug_assert!(self.memory_size >= memory_size);
+            self.memory_size -= memory_size;
+
+            let disk_size = key.disk_count_bytes() + value.disk_count_bytes();
+            debug_assert!(self.disk_size >= disk_size);
+            self.disk_size -= disk_size;
+
             self.check_invariants();
             Some(value)
         } else {
@@ -106,7 +132,8 @@ where
     /// Clears the cache by removing all items.
     pub fn clear(&mut self) {
         self.cache.clear();
-        self.size = 0;
+        self.memory_size = 0;
+        self.disk_size = 0;
         self.check_invariants();
     }
 
@@ -124,14 +151,20 @@ where
     /// Returns the vector of evicted key-value pairs.
     fn evict(&mut self) -> Vec<(K, V)> {
         let mut ret = vec![];
-        while self.size > self.capacity {
+        while self.memory_size > self.memory_capacity || self.disk_size > self.disk_capacity {
             match self.cache.pop_lru() {
                 Some((key, value)) => {
-                    let size = key.count_bytes() + value.count_bytes();
-                    debug_assert!(self.size >= size);
-                    // This cannot underflow because we know that `self.size` is
-                    // the sum of sizes of all items in the cache.
-                    self.size -= size;
+                    let memory_size = key.memory_count_bytes() + value.memory_count_bytes();
+                    debug_assert!(self.memory_size >= memory_size);
+                    // This cannot underflow because we know that `self.memory_size` is
+                    // the sum of memory sizes of all items in the cache.
+                    self.memory_size -= memory_size;
+
+                    let disk_size = key.disk_count_bytes() + value.disk_count_bytes();
+                    debug_assert!(self.disk_size >= disk_size);
+                    // This cannot underflow because we know that `self.disk_size` is
+                    // the sum of disk sizes of all items in the cache.
+                    self.disk_size -= disk_size;
 
                     ret.push((key, value));
                 }
@@ -147,14 +180,22 @@ where
         #[cfg(debug_assertions)]
         if self.len() < 1_000 {
             debug_assert_eq!(
-                self.size,
+                self.memory_size,
                 self.cache
                     .iter()
-                    .map(|(key, value)| key.count_bytes() + value.count_bytes())
+                    .map(|(key, value)| key.memory_count_bytes() + value.memory_count_bytes())
+                    .sum::<usize>()
+            );
+            debug_assert_eq!(
+                self.disk_size,
+                self.cache
+                    .iter()
+                    .map(|(key, value)| key.disk_count_bytes() + value.disk_count_bytes())
                     .sum::<usize>()
             );
         }
-        debug_assert!(self.size <= self.capacity);
+        debug_assert!(self.memory_size <= self.memory_capacity);
+        debug_assert!(self.disk_size <= self.disk_capacity);
     }
 }
 
@@ -166,8 +207,24 @@ mod tests {
     struct ValueSize(u32, usize);
 
     impl CountBytes for ValueSize {
-        fn count_bytes(&self) -> usize {
+        fn memory_count_bytes(&self) -> usize {
             self.1
+        }
+        fn disk_count_bytes(&self) -> usize {
+            0
+        }
+    }
+
+    #[derive(Eq, PartialEq, Hash, Debug)]
+    struct MemoryDiskValue(u32, usize, usize);
+
+    impl CountBytes for MemoryDiskValue {
+        fn memory_count_bytes(&self) -> usize {
+            self.1
+        }
+
+        fn disk_count_bytes(&self) -> usize {
+            self.2
         }
     }
 
@@ -175,14 +232,18 @@ mod tests {
     struct Key(u32);
 
     impl CountBytes for Key {
-        fn count_bytes(&self) -> usize {
+        fn memory_count_bytes(&self) -> usize {
+            0
+        }
+
+        fn disk_count_bytes(&self) -> usize {
             0
         }
     }
 
     #[test]
     fn lru_cache_single_entry() {
-        let mut lru = LruCache::<Key, ValueSize>::new(NumBytes::new(10));
+        let mut lru = LruCache::<Key, ValueSize>::new(NumBytes::new(10), NumBytes::new(0));
 
         assert!(lru.get(&Key(0)).is_none());
 
@@ -205,7 +266,7 @@ mod tests {
 
     #[test]
     fn lru_cache_multiple_entries() {
-        let mut lru = LruCache::<Key, ValueSize>::new(NumBytes::new(10));
+        let mut lru = LruCache::<Key, ValueSize>::new(NumBytes::new(10), NumBytes::new(0));
 
         for i in 0..20 {
             lru.push(Key(i), ValueSize(i, 1));
@@ -223,7 +284,7 @@ mod tests {
 
     #[test]
     fn lru_cache_value_eviction() {
-        let mut lru = LruCache::<Key, ValueSize>::new(NumBytes::new(10));
+        let mut lru = LruCache::<Key, ValueSize>::new(NumBytes::new(10), NumBytes::new(0));
 
         assert!(lru.get(&Key(0)).is_none());
 
@@ -273,7 +334,7 @@ mod tests {
 
     #[test]
     fn lru_cache_key_eviction() {
-        let mut lru = LruCache::<ValueSize, ValueSize>::new(NumBytes::new(10));
+        let mut lru = LruCache::<ValueSize, ValueSize>::new(NumBytes::new(10), NumBytes::new(0));
 
         assert!(lru.get(&ValueSize(0, 10)).is_none());
 
@@ -329,7 +390,7 @@ mod tests {
 
     #[test]
     fn lru_cache_key_and_value_eviction() {
-        let mut lru = LruCache::<ValueSize, ValueSize>::new(NumBytes::new(10));
+        let mut lru = LruCache::<ValueSize, ValueSize>::new(NumBytes::new(10), NumBytes::new(0));
 
         let evicted = lru.push(ValueSize(0, 5), ValueSize(42, 5));
         assert_eq!(*lru.get(&ValueSize(0, 5)).unwrap(), ValueSize(42, 5));
@@ -363,7 +424,7 @@ mod tests {
 
     #[test]
     fn lru_cache_clear() {
-        let mut lru = LruCache::<Key, ValueSize>::new(NumBytes::new(10));
+        let mut lru = LruCache::<Key, ValueSize>::new(NumBytes::new(10), NumBytes::new(0));
         lru.push(Key(0), ValueSize(0, 10));
         lru.clear();
         assert!(lru.get(&Key(0)).is_none());
@@ -371,7 +432,7 @@ mod tests {
 
     #[test]
     fn lru_cache_pop() {
-        let mut lru = LruCache::<Key, ValueSize>::new(NumBytes::new(10));
+        let mut lru = LruCache::<Key, ValueSize>::new(NumBytes::new(10), NumBytes::new(0));
         lru.push(Key(0), ValueSize(0, 5));
         lru.push(Key(1), ValueSize(1, 5));
         lru.pop(&Key(0));
@@ -383,25 +444,160 @@ mod tests {
 
     #[test]
     fn lru_cache_count_bytes_and_len() {
-        let mut lru = LruCache::<Key, ValueSize>::new(NumBytes::new(10));
-        assert_eq!(0, lru.count_bytes());
+        let mut lru = LruCache::<Key, MemoryDiskValue>::new(NumBytes::new(10), NumBytes::new(20));
+        assert_eq!(0, lru.memory_count_bytes());
+        assert_eq!(0, lru.disk_count_bytes());
         assert_eq!(0, lru.len());
         assert!(lru.is_empty());
-        lru.push(Key(0), ValueSize(0, 4));
-        assert_eq!(4, lru.count_bytes());
+        lru.push(Key(0), MemoryDiskValue(0, 4, 10));
+        assert_eq!(4, lru.memory_count_bytes());
+        assert_eq!(10, lru.disk_count_bytes());
         assert_eq!(1, lru.len());
         assert!(!lru.is_empty());
-        lru.push(Key(1), ValueSize(1, 6));
-        assert_eq!(10, lru.count_bytes());
+        lru.push(Key(1), MemoryDiskValue(1, 6, 2));
+        assert_eq!(10, lru.memory_count_bytes());
+        assert_eq!(12, lru.disk_count_bytes());
         assert_eq!(2, lru.len());
         assert!(!lru.is_empty());
         lru.pop(&Key(0));
-        assert_eq!(6, lru.count_bytes());
+        assert_eq!(6, lru.memory_count_bytes());
+        assert_eq!(2, lru.disk_count_bytes());
         assert_eq!(1, lru.len());
         assert!(!lru.is_empty());
         lru.pop(&Key(1));
-        assert_eq!(0, lru.count_bytes());
+        assert_eq!(0, lru.memory_count_bytes());
+        assert_eq!(0, lru.disk_count_bytes());
         assert_eq!(0, lru.len());
         assert!(lru.is_empty());
+    }
+
+    #[test]
+    fn lru_cache_disk_and_memory_single_entry() {
+        let mut lru = LruCache::<Key, MemoryDiskValue>::new(NumBytes::new(10), NumBytes::new(20));
+
+        assert!(lru.get(&Key(0)).is_none());
+
+        // Can't insert a value if memory or disk is too large.
+        let evicted = lru.push(Key(0), MemoryDiskValue(42, 11, 0));
+        assert_eq!(lru.get(&Key(0)), None);
+        assert_eq!(evicted, vec![(Key(0), MemoryDiskValue(42, 11, 0))]);
+
+        let evicted = lru.push(Key(0), MemoryDiskValue(42, 0, 21));
+        assert_eq!(lru.get(&Key(0)), None);
+        assert_eq!(evicted, vec![(Key(0), MemoryDiskValue(42, 0, 21))]);
+
+        // Can insert if both sizes fit.
+        let evicted = lru.push(Key(0), MemoryDiskValue(42, 10, 20));
+        assert_eq!(*lru.get(&Key(0)).unwrap(), MemoryDiskValue(42, 10, 20));
+        assert_eq!(evicted, vec![]);
+
+        // Inserting a new value removes the old one if memory or disk is
+        // non-zero (since both are at capacity).
+        let evicted = lru.push(Key(1), MemoryDiskValue(42, 1, 0));
+        assert_eq!(*lru.get(&Key(1)).unwrap(), MemoryDiskValue(42, 1, 0));
+        assert_eq!(evicted, vec![(Key(0), MemoryDiskValue(42, 10, 20))]);
+
+        lru.clear();
+        let _ = lru.push(Key(0), MemoryDiskValue(42, 10, 20));
+        let evicted = lru.push(Key(1), MemoryDiskValue(42, 0, 1));
+        assert_eq!(*lru.get(&Key(1)).unwrap(), MemoryDiskValue(42, 0, 1));
+        assert_eq!(evicted, vec![(Key(0), MemoryDiskValue(42, 10, 20))]);
+    }
+
+    #[test]
+    fn lru_cache_key_and_value_eviction_mixing_memory_and_disk() {
+        let mut lru =
+            LruCache::<MemoryDiskValue, MemoryDiskValue>::new(NumBytes::new(10), NumBytes::new(10));
+
+        let evicted = lru.push(MemoryDiskValue(0, 5, 1), MemoryDiskValue(42, 5, 1));
+        assert_eq!(
+            *lru.get(&MemoryDiskValue(0, 5, 1)).unwrap(),
+            MemoryDiskValue(42, 5, 1)
+        );
+        assert_eq!(evicted, vec![]);
+
+        let evicted = lru.push(MemoryDiskValue(1, 0, 0), MemoryDiskValue(20, 0, 0));
+        assert_eq!(
+            *lru.get(&MemoryDiskValue(0, 5, 1)).unwrap(),
+            MemoryDiskValue(42, 5, 1)
+        );
+        assert_eq!(
+            *lru.get(&MemoryDiskValue(1, 0, 0)).unwrap(),
+            MemoryDiskValue(20, 0, 0)
+        );
+        assert_eq!(evicted, vec![]);
+
+        let evicted = lru.push(MemoryDiskValue(2, 5, 1), MemoryDiskValue(10, 5, 1));
+        assert!(lru.get(&MemoryDiskValue(0, 5, 1)).is_none());
+        assert_eq!(
+            *lru.get(&MemoryDiskValue(1, 0, 0)).unwrap(),
+            MemoryDiskValue(20, 0, 0)
+        );
+        assert_eq!(
+            *lru.get(&MemoryDiskValue(2, 5, 1)).unwrap(),
+            MemoryDiskValue(10, 5, 1)
+        );
+        // The least recently used is the first entry.
+        assert_eq!(
+            evicted,
+            vec![(MemoryDiskValue(0, 5, 1), MemoryDiskValue(42, 5, 1))]
+        );
+
+        let evicted = lru.push(MemoryDiskValue(3, 4, 9), MemoryDiskValue(30, 0, 1));
+        assert!(lru.get(&MemoryDiskValue(1, 0, 0)).is_none());
+        assert!(lru.get(&MemoryDiskValue(2, 5, 1)).is_none());
+        assert_eq!(
+            *lru.get(&MemoryDiskValue(3, 4, 9)).unwrap(),
+            MemoryDiskValue(30, 0, 1)
+        );
+        // Now the second and third entries are evicted.
+        assert_eq!(
+            evicted,
+            vec![
+                (MemoryDiskValue(1, 0, 0), MemoryDiskValue(20, 0, 0)),
+                (MemoryDiskValue(2, 5, 1), MemoryDiskValue(10, 5, 1))
+            ]
+        );
+    }
+
+    mod proptests {
+        use super::*;
+        use proptest::prelude::*;
+
+        fn arb_value() -> impl Strategy<Value = MemoryDiskValue> {
+            (0..100_u32, 0..50_usize, 0..50_usize).prop_map(|(a, b, c)| MemoryDiskValue(a, b, c))
+        }
+
+        proptest! {
+            /// Proptest checking that the internal invariants are maintained
+            /// and that the total space of inserted entries equals the total
+            /// space of evicted entries plus the space of the cache itself.
+            #[test]
+            fn test_invariants(entries in prop::collection::vec((arb_value(), arb_value()), 100)) {
+                let mut lru = LruCache::<MemoryDiskValue, MemoryDiskValue>::new(NumBytes::new(100), NumBytes::new(100));
+                let mut total_memory = 0;
+                let mut total_disk = 0;
+                let mut evicted_memory = 0;
+                let mut evicted_disk = 0;
+
+                fn update(memory: &mut usize, disk: &mut usize, k: &MemoryDiskValue, v: &MemoryDiskValue) {
+                    *memory += k.memory_count_bytes();
+                    *memory += v.memory_count_bytes();
+                    *disk += k.disk_count_bytes();
+                    *disk += v.disk_count_bytes();
+                }
+
+                for (k,v) in entries {
+                    update(&mut total_memory, &mut total_disk, &k, &v);
+                    let evicted = lru.push(k,v);
+                    for (k,v) in evicted {
+                        update(&mut evicted_memory, &mut evicted_disk, &k, &v);
+                    }
+
+                    assert_eq!(total_memory, evicted_memory + lru.memory_count_bytes());
+                    assert_eq!(total_disk, evicted_disk + lru.disk_count_bytes());
+                }
+            }
+        }
     }
 }

--- a/rs/utils/lru_cache/src/lib.rs
+++ b/rs/utils/lru_cache/src/lib.rs
@@ -24,8 +24,12 @@ where
     K: CountBytes + Eq + Hash,
     V: CountBytes,
 {
-    fn count_bytes(&self) -> usize {
-        self.size
+    fn memory_count_bytes(&self) -> usize {
+        self.memory_size
+    }
+
+    fn disk_count_bytes(&self) -> usize {
+        self.disk_size
     }
 }
 

--- a/rs/xnet/payload_builder/tests/xnet_payload_builder.rs
+++ b/rs/xnet/payload_builder/tests/xnet_payload_builder.rs
@@ -142,7 +142,7 @@ impl XNetPayloadBuilderFixture {
         let certified_slice = in_slice(stream, from, from, msg_count, log);
         let slice_size_bytes = UnpackedStreamSlice::try_from(certified_slice.clone())
             .unwrap()
-            .count_bytes();
+            .memory_count_bytes();
         {
             let mut slice_pool = self.certified_slice_pool.lock().unwrap();
             slice_pool
@@ -801,7 +801,7 @@ proptest! {
                 .returning(move |_, _, _| Ok(slice.clone()));
             let metrics_registry = MetricsRegistry::new();
             let pool = Arc::new(Mutex::new(CertifiedSlicePool::new(Arc::new(certified_stream_store) as Arc<_>, &metrics_registry)));
-            let prefix_size_bytes = UnpackedStreamSlice::try_from(certified_prefix.clone()).unwrap().count_bytes();
+            let prefix_size_bytes = UnpackedStreamSlice::try_from(certified_prefix.clone()).unwrap().memory_count_bytes();
             {
                 let mut pool = pool.lock().unwrap();
                 pool.put(REMOTE_SUBNET, certified_prefix, REGISTRY_VERSION, log.clone()).unwrap();
@@ -975,7 +975,7 @@ proptest! {
                 .returning(move |_, _, _| Err(DecodeStreamError::InvalidSignature(REMOTE_SUBNET)));
             let metrics_registry = MetricsRegistry::new();
             let pool = Arc::new(Mutex::new(CertifiedSlicePool::new(Arc::new(certified_stream_store) as Arc<_>, &metrics_registry)));
-            let prefix_size_bytes = UnpackedStreamSlice::try_from(certified_prefix.clone()).unwrap().count_bytes();
+            let prefix_size_bytes = UnpackedStreamSlice::try_from(certified_prefix.clone()).unwrap().memory_count_bytes();
 
             {
                 let mut pool = pool.lock().unwrap();


### PR DESCRIPTION
EXC-1795

Add the ability for the LRU cache to limit space used on disk as well as in memory and use this in the `CompilationCache` so that it doesn't grow to large.