### PR TITLE
fix(IDX): work around libssh2-sys determinism issues

### DIFF
--- a/Cargo.Bazel.Fuzzing.json.lock
+++ b/Cargo.Bazel.Fuzzing.json.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "8f3c46ee2056590eb46190b4f135c020b34bee19b08d6ad3699cc3b5e3169366",
+  "checksum": "437e6f7903120517b815140fc45624e2c220aa4ef007dc6a066da451c97e90aa",
   "crates": {
     "abnf 0.12.0": {
       "name": "abnf",
@@ -39271,7 +39271,13 @@
       "repository": {
         "Http": {
           "url": "https://static.crates.io/crates/libssh2-sys/0.3.0/download",
-          "sha256": "2dc8a030b787e2119a731f1951d6a773e2280c660f8ec4b0f5e1505a386e71ee"
+          "sha256": "2dc8a030b787e2119a731f1951d6a773e2280c660f8ec4b0f5e1505a386e71ee",
+          "patch_args": [
+            "-p1"
+          ],
+          "patches": [
+            "@@//bazel:libssh2-sys.patch"
+          ]
         }
       },
       "targets": [

--- a/Cargo.Bazel.json.lock
+++ b/Cargo.Bazel.json.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "f858ef04dfd7375060841942bd3005d2ad41e9c7bb3b267c1a581c9bc587c2df",
+  "checksum": "7e7fc08d04386a15716037351beec07fdfb1567d38a6b187ad38bb0a0f5412d1",
   "crates": {
     "abnf 0.12.0": {
       "name": "abnf",
@@ -39105,7 +39105,13 @@
       "repository": {
         "Http": {
           "url": "https://static.crates.io/crates/libssh2-sys/0.3.0/download",
-          "sha256": "2dc8a030b787e2119a731f1951d6a773e2280c660f8ec4b0f5e1505a386e71ee"
+          "sha256": "2dc8a030b787e2119a731f1951d6a773e2280c660f8ec4b0f5e1505a386e71ee",
+          "patch_args": [
+            "-p1"
+          ],
+          "patches": [
+            "@@//bazel:libssh2-sys.patch"
+          ]
         }
       },
       "targets": [

--- a/bazel/external_crates.bzl
+++ b/bazel/external_crates.bzl
@@ -33,6 +33,11 @@ def external_crates_repository(name, cargo_lockfile, lockfile, sanitizers_enable
             patch_args = ["-p1"],
             patches = ["@@//bazel:cc_rs.patch"],
         )],
+        "libssh2-sys": [crate.annotation(
+            # Patch for determinism issues
+            patch_args = ["-p1"],
+            patches = ["@@//bazel:libssh2-sys.patch"],
+        )],
         "curve25519-dalek": [crate.annotation(
             rustc_flags = [
                 "-C",

--- a/bazel/libssh2-sys.patch
+++ b/bazel/libssh2-sys.patch
@@ -1,0 +1,22 @@
+# Patch for determinism issues
+# https://github.com/alexcrichton/ssh2-rs/issues/340
+diff --git a/build.rs b/build.rs
+index c4425ee..f99f132 100644
+--- a/build.rs
++++ b/build.rs
+@@ -173,6 +173,7 @@ fn main() {
+         .unwrap();
+     let version = &version_line[version_line.find('"').unwrap() + 1..version_line.len() - 1];
+
++    /*
+     let pkgconfig = dst.join("lib/pkgconfig");
+     fs::create_dir_all(&pkgconfig).unwrap();
+     fs::write(
+@@ -188,6 +189,7 @@ fn main() {
+             .replace("@LIBSSH2VER@", version),
+     )
+     .unwrap();
++    */
+
+     cfg.warnings(false);
+     cfg.compile("ssh2");


### PR DESCRIPTION
This adds a patch that prevents `libssh2-sys` from generating a `.pc` file. The pkg-config file includes absolute paths which makes it non-deterministic.

See: https://github.com/alexcrichton/ssh2-rs/issues/340