### PR TITLE
fix(sns): Don't log when maturity modulation can't be refreshed

### DIFF
--- a/rs/sns/governance/src/governance.rs
+++ b/rs/sns/governance/src/governance.rs
@@ -5042,16 +5042,8 @@ impl Governance {
         let maturity_modulation = self.cmc.neuron_maturity_modulation().await;
 
         // Unwrap response.
-        let maturity_modulation = match maturity_modulation {
-            Ok(ok) => ok,
-            Err(err) => {
-                println!(
-                    "{}Couldn't update maturity modulation. Error: {}",
-                    log_prefix(),
-                    err,
-                );
-                return;
-            }
+        let Ok(maturity_modulation) = maturity_modulation else {
+            return;
         };
 
         // Construct new MaturityModulation.


### PR DESCRIPTION
These logs appear all the time when debugging SNS Governance, e.g:

```
2021-05-08 19:19:57.000000035 UTC: [Canister rrkah-fqaaa-aaaaa-aaaaq-cai] [Governance] Couldn't update maturity modulation. Error: Canister rkp4c-7iaaa-aaaaa-aaaca-cai not found
2021-05-08 19:19:58.000000035 UTC: [Canister 7tjcv-pp777-77776-qaaaa-cai] [Root Canister] start_canister call successful. Ok(())
2021-05-08 19:19:58.000000035 UTC: [Canister 7tjcv-pp777-77776-qaaaa-cai] change_canister: Canister change completed successfully.
2021-05-08 19:19:59.000000035 UTC: [Canister rrkah-fqaaa-aaaaa-aaaaq-cai] [Governance] Couldn't update maturity modulation. Error: Canister rkp4c-7iaaa-aaaaa-aaaca-cai not found
2021-05-08 19:20:01.000000035 UTC: [Canister rrkah-fqaaa-aaaaa-aaaaq-cai] [Governance] Couldn't update maturity modulation. Error: Canister rkp4c-7iaaa-aaaaa-aaaca-cai not found
2021-05-08 19:20:03.000000035 UTC: [Canister rrkah-fqaaa-aaaaa-aaaaq-cai] [Governance] Couldn't update maturity modulation. Error: Canister rkp4c-7iaaa-aaaaa-aaaca-cai not found
2021-05-08 19:20:05.000000035 UTC: [Canister rrkah-fqaaa-aaaaa-aaaaq-cai] [Governance] Couldn't update maturity modulation. Error: Canister rkp4c-7iaaa-aaaaa-aaaca-cai not found
2021-05-08 19:20:05.000000035 UTC: [Canister 7tjcv-pp777-77776-qaaaa-cai] get_sns_canisters_summary
2021-05-08 19:20:07.000000035 UTC: [Canister rrkah-fqaaa-aaaaa-aaaaq-cai] [Governance] Couldn't update maturity modulation. Error: Canister rkp4c-7iaaa-aaaaa-aaaca-cai not found
2021-05-08 19:20:09.000000035 UTC: [Canister rrkah-fqaaa-aaaaa-aaaaq-cai] [Governance] Couldn't update maturity modulation. Error: Canister rkp4c-7iaaa-aaaaa-aaaca-cai not found
2021-05-08 19:20:11.000000035 UTC: [Canister rrkah-fqaaa-aaaaa-aaaaq-cai] [Governance] Couldn't update maturity modulation. Error: Canister rkp4c-7iaaa-aaaaa-aaaca-cai not found
2021-05-08 19:20:13.000000035 UTC: [Canister rrkah-fqaaa-aaaaa-aaaaq-cai] [Governance] Couldn't update maturity modulation. Error: Canister rkp4c-7iaaa-aaaaa-aaaca-cai not found
2021-05-08 19:20:15.000000035 UTC: [Canister rrkah-fqaaa-aaaaa-aaaaq-cai] [Governance] Couldn't update maturity modulation. Error: Canister rkp4c-7iaaa-aaaaa-aaaca-cai not found
2021-05-08 19:20:15.000000035 UTC: [Canister 7tjcv-pp777-77776-qaaaa-cai] get_sns_canisters_summary
2021-05-08 19:20:17.000000035 UTC: [Canister rrkah-fqaaa-aaaaa-aaaaq-cai] [Governance] Couldn't update maturity modulation. Error: Canister rkp4c-7iaaa-aaaaa-aaaca-cai not found
2021-05-08 19:20:19.000000035 UTC: [Canister rrkah-fqaaa-aaaaa-aaaaq-cai] [Governance] Couldn't update maturity modulation. Error: Canister rkp4c-7iaaa-aaaaa-aaaca-cai not found
2021-05-08 19:20:21.000000035 UTC: [Canister rrkah-fqaaa-aaaaa-aaaaq-cai] [Governance] Couldn't update maturity modulation. Error: Canister rkp4c-7iaaa-aaaaa-aaaca-cai not found
2021-05-08 19:20:23.000000035 UTC: [Canister rrkah-fqaaa-aaaaa-aaaaq-cai] [Governance] Couldn't update maturity modulation. Error: Canister rkp4c-7iaaa-aaaaa-aaaca-cai not found
2021-05-08 19:20:25.000000035 UTC: [Canister rrkah-fqaaa-aaaaa-aaaaq-cai] [Governance] Couldn't update maturity modulation. Error: Canister rkp4c-7iaaa-aaaaa-aaaca-cai not found
2021-05-08 19:20:25.000000035 UTC: [Canister 7tjcv-pp777-77776-qaaaa-cai] get_sns_canisters_summary
2021-05-08 19:20:27.000000035 UTC: [Canister rrkah-fqaaa-aaaaa-aaaaq-cai] [Governance] Couldn't update maturity modulation. Error: Canister rkp4c-7iaaa-aaaaa-aaaca-cai not found
2021-05-08 19:20:29.000000035 UTC: [Canister rrkah-fqaaa-aaaaa-aaaaq-cai] [Governance] Couldn't update maturity modulation. Error: Canister rkp4c-7iaaa-aaaaa-aaaca-cai not found
2021-05-08 19:20:31.000000035 UTC: [Canister rrkah-fqaaa-aaaaa-aaaaq-cai] [Governance] Couldn't update maturity modulation. Error: Canister rkp4c-7iaaa-aaaaa-aaaca-cai not found
2021-05-08 19:20:33.000000035 UTC: [Canister rrkah-fqaaa-aaaaa-aaaaq-cai] [Governance] Couldn't update maturity modulation. Error: Canister rkp4c-7iaaa-aaaaa-aaaca-cai not found
2021-05-08 19:20:35.000000035 UTC: [Canister rrkah-fqaaa-aaaaa-aaaaq-cai] [Governance] Couldn't update maturity modulation. Error: Canister rkp4c-7iaaa-aaaaa-aaaca-cai not found
2021-05-08 19:20:35.000000035 UTC: [Canister 7tjcv-pp777-77776-qaaaa-cai] get_sns_canisters_summary
thread 'test_upgrade_upgrade_sns_gov_root' panicked at rs/nervous_system/integration_tests/src/pocket_ic_helpers.rs:1499:13:
Looks like the SNS proposal ProposalId { id: 1 } is never going to be decided: Some([...])
```

Logs are supposed to save us time, not waste it, and I'm currently wasting a lot of time trying to find the signal in the "Couldn't update maturity modulation" noise .