### PR TITLE
chore(CI): intel macos label

### DIFF
--- a/.github/workflows-source/ci-main.yml
+++ b/.github/workflows-source/ci-main.yml
@@ -179,7 +179,12 @@ jobs:
     runs-on:
       labels: macOS
     # Run on protected branches, but only on public repo
-    if: ${{ github.ref_protected && github.repository == 'dfinity/ic' }}
+    # Allow running if CI_MACOS_INTEL label is used
+    if: >
+      ${{
+        (github.ref_protected && github.repository == 'dfinity/ic') ||
+        (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'CI_MACOS_INTEL'))
+      }}
     steps:
       - <<: *checkout
       - name: Set PATH

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -170,7 +170,15 @@ jobs:
     runs-on:
       labels: macOS
     # Run on protected branches, but only on public repo
-    if: ${{ github.ref_protected && github.repository == 'dfinity/ic' }}
+    # Allow running if CI_MACOS_INTEL label is used
+    if: >
+      ${{
+
+
+        (github.ref_protected && github.repository == 'dfinity/ic') ||
+        (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'CI_MACOS_INTEL'))
+      }}
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Introducing `CI_MACOS_INTEL` label that allows users to run *Bazel Test macOS Intel* CI job within the PR, if they for some reason want to do so.