### PR TITLE
test(ICP_Ledger): FI-1616: Fix upgrade tests and update mainnet canisters

### DIFF
--- a/mainnet-canisters.json
+++ b/mainnet-canisters.json
@@ -1,31 +1,31 @@
 {
   "archive": {
-    "rev": "dac2f36f96d7549d82fa8e3c714979255ce57afd",
-    "sha256": "9c3ef43b1c68223d98bae6a5664d33d490c6abdcec356077022212a1de2b13a4"
+    "rev": "7c6309cb5bec7ab28ed657ac7672af08a59fc1ba",
+    "sha256": "92622a35dc03651a046ef02d48c3d3c3383a25307d719e4a7657601486fa9f4f"
   },
   "ck_btc_archive": {
-    "rev": "e54d3fa34ded227c885d04e64505fa4b5d564743",
-    "sha256": "317771544f0e828a60ad6efc97694c425c169c4d75d911ba592546912dba3116"
+    "rev": "2190613d3b5bcd9b74c382b22d151580b8ac271a",
+    "sha256": "f94cf1db965b7042197e5894fef54f5f413bb2ebc607ff0fb59c9d4dfd3babea"
   },
   "ck_btc_index": {
-    "rev": "e54d3fa34ded227c885d04e64505fa4b5d564743",
-    "sha256": "67b5f0bf128e801adf4a959ea26c3c9ca0cd399940e169a26a2eb237899a94dd"
+    "rev": "2190613d3b5bcd9b74c382b22d151580b8ac271a",
+    "sha256": "2adc74fe5667f26ea4c4006309d99b1dfa71787aa43a5c168cb08ec725677996"
   },
   "ck_btc_ledger": {
-    "rev": "e54d3fa34ded227c885d04e64505fa4b5d564743",
-    "sha256": "3d808fa63a3d8ebd4510c0400aa078e99a31afaa0515f0b68778f929ce4b2a46"
+    "rev": "2190613d3b5bcd9b74c382b22d151580b8ac271a",
+    "sha256": "25071c2c55ad4571293e00d8e277f442aec7aed88109743ac52df3125209ff45"
   },
   "ck_eth_archive": {
-    "rev": "e54d3fa34ded227c885d04e64505fa4b5d564743",
-    "sha256": "3ba6fee3ce3d311eef8df0220ac38a411802ee57c0d073847ef2cf3efa6c60ed"
+    "rev": "2190613d3b5bcd9b74c382b22d151580b8ac271a",
+    "sha256": "2d25f7831894100d48aa9043c65e87c293487523f0958c15760027d004fbbda9"
   },
   "ck_eth_index": {
-    "rev": "e54d3fa34ded227c885d04e64505fa4b5d564743",
-    "sha256": "07dd7a18d047ac41c37be9ea200dc1e0cbe4606bbc737d5dbb89f6e0a6e7450d"
+    "rev": "2190613d3b5bcd9b74c382b22d151580b8ac271a",
+    "sha256": "d615ea66e7ec7e39a3912889ffabfabb9b6f200584b9656789c3578fae1afac7"
   },
   "ck_eth_ledger": {
-    "rev": "e54d3fa34ded227c885d04e64505fa4b5d564743",
-    "sha256": "98a7b7391608dc4a554d6964bad24157b6aaf890a05bbaad3fcc92033d9c7b02"
+    "rev": "2190613d3b5bcd9b74c382b22d151580b8ac271a",
+    "sha256": "9637743e1215a4db376a62ee807a0986faf20833be2b332df09b3d5dbdd7339e"
   },
   "cycles-minting": {
     "rev": "ee52ab3056cf5f39b09b08de70bdd20485c8b2dc",
@@ -40,8 +40,8 @@
     "sha256": "a23918c2c5d1302e5d1149f557b0fb913ab65931c1bce3ffc94a48e3d14ecbac"
   },
   "index": {
-    "rev": "dac2f36f96d7549d82fa8e3c714979255ce57afd",
-    "sha256": "3cc807d6c602be5041635c03522b99049d91c2a2ed18cb87251d5611ef779c98"
+    "rev": "7c6309cb5bec7ab28ed657ac7672af08a59fc1ba",
+    "sha256": "7b884231f230f5fc66ad18e0baaec0c14921bd5da742db5dbaf51f824b8dfc63"
   },
   "ledger": {
     "rev": "7c6309cb5bec7ab28ed657ac7672af08a59fc1ba",

--- a/rs/ledger_suite/icp/ledger/tests/tests.rs
+++ b/rs/ledger_suite/icp/ledger/tests/tests.rs
@@ -1257,6 +1257,7 @@ fn test_upgrade_serialization() {
     );
 }
 
+#[ignore] // TODO: Re-enable as part of FI-1440
 #[test]
 fn test_multi_step_migration() {
     ic_ledger_suite_state_machine_tests::icrc1_test_multi_step_migration(
@@ -1273,10 +1274,11 @@ fn test_downgrade_from_incompatible_version() {
         ledger_wasm_next_version(),
         ledger_wasm(),
         encode_init_args,
-        false,
+        true,
     );
 }
 
+#[ignore] // TODO: Re-enable as part of FI-1440
 #[test]
 fn test_stable_migration_endpoints_disabled() {
     let send_args = SendArgs {
@@ -1314,6 +1316,7 @@ fn test_stable_migration_endpoints_disabled() {
     );
 }
 
+#[ignore] // TODO: Re-enable as part of FI-1440
 #[test]
 fn test_incomplete_migration() {
     ic_ledger_suite_state_machine_tests::test_incomplete_migration(
@@ -1323,6 +1326,7 @@ fn test_incomplete_migration() {
     );
 }
 
+#[ignore] // TODO: Re-enable as part of FI-1440
 #[test]
 fn test_incomplete_migration_to_current() {
     ic_ledger_suite_state_machine_tests::test_incomplete_migration_to_current(
@@ -1332,6 +1336,7 @@ fn test_incomplete_migration_to_current() {
     );
 }
 
+#[ignore] // TODO: Re-enable as part of FI-1440
 #[test]
 fn test_metrics_while_migrating() {
     ic_ledger_suite_state_machine_tests::test_metrics_while_migrating(

--- a/rs/ledger_suite/icp/tests/golden_nns_state.rs
+++ b/rs/ledger_suite/icp/tests/golden_nns_state.rs
@@ -19,7 +19,7 @@ use ic_nns_constants::{
     LEDGER_CANISTER_INDEX_IN_NNS_SUBNET, LEDGER_INDEX_CANISTER_INDEX_IN_NNS_SUBNET,
 };
 use ic_nns_test_utils_golden_nns_state::new_state_machine_with_golden_nns_state_or_panic;
-use ic_state_machine_tests::{ErrorCode, StateMachine, UserError};
+use ic_state_machine_tests::{StateMachine, UserError};
 use icp_ledger::{
     AccountIdentifier, Archives, Block, FeatureFlags, LedgerCanisterPayload, UpgradeArgs,
 };
@@ -302,21 +302,8 @@ impl Setup {
     pub fn downgrade_to_mainnet(&self) {
         println!("Downgrading to mainnet version");
         self.upgrade_index(&self.mainnet_wasms.index);
-        match self.upgrade_ledger(&self.mainnet_wasms.ledger) {
-            Ok(_) => {
-                panic!("should fail to downgrade ledger to mainnet version");
-            }
-            Err(err) => {
-                // The ledger will still be running the master version, while the other canisters
-                // will be downgraded to the mainnet version. This is not an ideal situation, nor
-                // is it expected to happen in practice, but for the moment let's run the test to
-                // completion.
-                err.assert_contains(
-                    ErrorCode::CanisterCalledTrap,
-                    "Trying to downgrade from incompatible version",
-                );
-            }
-        }
+        self.upgrade_ledger(&self.mainnet_wasms.ledger)
+            .expect("should successfully downgrade to the mainnet version");
         self.upgrade_archive_canisters(&self.mainnet_wasms.archive);
     }
 

--- a/rs/ledger_suite/icp/tests/upgrade_downgrade.rs
+++ b/rs/ledger_suite/icp/tests/upgrade_downgrade.rs
@@ -451,7 +451,7 @@ fn should_upgrade_and_downgrade_canister_suite() {
     setup.assert_index_ledger_parity(true);
 
     setup.upgrade_index_canister(UpgradeToVersion::MainNet);
-    setup.upgrade_ledger_canister(UpgradeToVersion::MainNet, false);
+    setup.upgrade_ledger_canister(UpgradeToVersion::MainNet, true);
     setup.upgrade_archive_canisters(UpgradeToVersion::MainNet);
 
     setup.assert_index_ledger_parity(true);

--- a/rs/ledger_suite/icrc1/ledger/tests/tests.rs
+++ b/rs/ledger_suite/icrc1/ledger/tests/tests.rs
@@ -455,6 +455,7 @@ fn icrc1_test_upgrade_serialization() {
     );
 }
 
+#[ignore] // TODO: Re-enable as part of FI-1440
 #[test]
 fn icrc1_test_multi_step_migration() {
     ic_ledger_suite_state_machine_tests::icrc1_test_multi_step_migration(
@@ -471,10 +472,11 @@ fn icrc1_test_downgrade_from_incompatible_version() {
         ledger_wasm_nextledgerversion(),
         ledger_wasm(),
         encode_init_args,
-        false,
+        true,
     );
 }
 
+#[ignore] // TODO: Re-enable as part of FI-1440
 #[test]
 fn icrc1_test_stable_migration_endpoints_disabled() {
     ic_ledger_suite_state_machine_tests::icrc1_test_stable_migration_endpoints_disabled(
@@ -485,6 +487,7 @@ fn icrc1_test_stable_migration_endpoints_disabled() {
     );
 }
 
+#[ignore] // TODO: Re-enable as part of FI-1440
 #[test]
 fn icrc1_test_incomplete_migration() {
     ic_ledger_suite_state_machine_tests::test_incomplete_migration(
@@ -494,6 +497,7 @@ fn icrc1_test_incomplete_migration() {
     );
 }
 
+#[ignore] // TODO: Re-enable as part of FI-1440
 #[test]
 fn icrc1_test_incomplete_migration_to_current() {
     ic_ledger_suite_state_machine_tests::test_incomplete_migration_to_current(
@@ -503,6 +507,7 @@ fn icrc1_test_incomplete_migration_to_current() {
     );
 }
 
+#[ignore] // TODO: Re-enable as part of FI-1440
 #[test]
 fn icrc1_test_migration_resumes_from_frozen() {
     ic_ledger_suite_state_machine_tests::test_migration_resumes_from_frozen(
@@ -512,6 +517,7 @@ fn icrc1_test_migration_resumes_from_frozen() {
     );
 }
 
+#[ignore] // TODO: Re-enable as part of FI-1440
 #[test]
 fn icrc1_test_metrics_while_migrating() {
     ic_ledger_suite_state_machine_tests::test_metrics_while_migrating(

--- a/rs/ledger_suite/icrc1/tests/golden_state_upgrade_downgrade.rs
+++ b/rs/ledger_suite/icrc1/tests/golden_state_upgrade_downgrade.rs
@@ -14,7 +14,7 @@ use ic_ledger_suite_state_machine_tests::{
     wait_ledger_ready, TransactionGenerationParameters,
 };
 use ic_nns_test_utils_golden_nns_state::new_state_machine_with_golden_fiduciary_state_or_panic;
-use ic_state_machine_tests::{ErrorCode, StateMachine, UserError};
+use ic_state_machine_tests::{StateMachine, UserError};
 use icrc_ledger_types::icrc1::account::Account;
 use lazy_static::lazy_static;
 use std::str::FromStr;
@@ -351,19 +351,18 @@ impl LedgerSuiteConfig {
         // Upgrade each canister twice to exercise pre-upgrade
         self.upgrade_index_or_panic(state_machine, &self.mainnet_wasms.index_wasm);
         self.upgrade_index_or_panic(state_machine, &self.mainnet_wasms.index_wasm);
-        match self.upgrade_ledger(
+        self.upgrade_ledger(
             state_machine,
             &self.mainnet_wasms.ledger_wasm,
             ExpectMigration::No,
-        ) {
-            Ok(_) => {
-                panic!("should not successfully downgrade ledger");
-            }
-            Err(user_error) => user_error.assert_contains(
-                ErrorCode::CanisterCalledTrap,
-                "Trying to downgrade from incompatible version",
-            ),
-        }
+        )
+        .expect("should downgrade to mainnet ledger version");
+        self.upgrade_ledger(
+            state_machine,
+            &self.mainnet_wasms.ledger_wasm,
+            ExpectMigration::No,
+        )
+        .expect("should downgrade to mainnet ledger version");
         self.upgrade_archives_or_panic(state_machine, &self.mainnet_wasms.archive_wasm);
         self.upgrade_archives_or_panic(state_machine, &self.mainnet_wasms.archive_wasm);
     }

--- a/rs/ledger_suite/icrc1/tests/upgrade_downgrade.rs
+++ b/rs/ledger_suite/icrc1/tests/upgrade_downgrade.rs
@@ -77,20 +77,12 @@ fn should_upgrade_and_downgrade_ledger_canister_suite() {
     )
     .unwrap();
 
-    match env.upgrade_canister(
+    env.upgrade_canister(
         ledger_id,
         ledger_mainnet_wasm(),
         Encode!(&ledger_upgrade_arg).unwrap(),
-    ) {
-        Ok(_) => {
-            panic!("Upgrade to mainnet should fail!")
-        }
-        Err(e) => {
-            assert!(e
-                .description()
-                .contains("Trying to downgrade from incompatible version"))
-        }
-    };
+    )
+    .unwrap();
 }
 
 fn default_archive_options() -> ArchiveOptions {

--- a/rs/ledger_suite/tests/sm-tests/src/lib.rs
+++ b/rs/ledger_suite/tests/sm-tests/src/lib.rs
@@ -2482,7 +2482,8 @@ pub fn test_upgrade_serialization<Tokens>(
                     ledger_id,
                     ledger_wasm_mainnet.clone(),
                     Encode!(&LedgerArgument::Upgrade(None)).unwrap(),
-                ).expect("Downgrading to mainnet should succeed");
+                )
+                .expect("Downgrading to mainnet should succeed");
                 if verify_blocks {
                     // This will also verify the ledger blocks.
                     // The current implementation of the InMemoryLedger cannot get blocks

--- a/rs/ledger_suite/tests/sm-tests/src/lib.rs
+++ b/rs/ledger_suite/tests/sm-tests/src/lib.rs
@@ -2470,26 +2470,19 @@ pub fn test_upgrade_serialization<Tokens>(
                 };
 
                 // Test if the old serialized approvals and balances are correctly deserialized
-                test_upgrade(ledger_wasm_current.clone(), 1);
+                // TODO: Expected migration steps should be 1 again in FI-1440.
+                // test_upgrade(ledger_wasm_current.clone(), 1);
                 // Test the new wasm serialization
                 test_upgrade(ledger_wasm_current.clone(), 0);
                 // Test deserializing from memory manager
                 test_upgrade(ledger_wasm_current.clone(), 0);
-                // Downgrade from stable structures to mainnet not possible.
-                match env.upgrade_canister(
+                // Downgrade to mainnet should succeed since they are both the same version wrt.
+                // migration to stable structures.
+                env.upgrade_canister(
                     ledger_id,
                     ledger_wasm_mainnet.clone(),
                     Encode!(&LedgerArgument::Upgrade(None)).unwrap(),
-                ) {
-                    Ok(_) => {
-                        panic!("Upgrade from future ledger version should fail!")
-                    }
-                    Err(e) => {
-                        assert!(e
-                            .description()
-                            .contains("Trying to downgrade from incompatible version"))
-                    }
-                };
+                ).expect("Downgrading to mainnet should succeed");
                 if verify_blocks {
                     // This will also verify the ledger blocks.
                     // The current implementation of the InMemoryLedger cannot get blocks


### PR DESCRIPTION
Update the rest of the ledger suite canisters in `mainnet-canisters.json`, and fix the (upgrade) tests that broken as a consequence.