### PR TITLE
fix(sns): Make swap know whether it's in testflight or not, so it can require certain init fields only when not in testflight

### DIFF
--- a/rs/sns/cli/src/deploy.rs
+++ b/rs/sns/cli/src/deploy.rs
@@ -167,11 +167,6 @@ impl DirectSnsDeployerForTests {
             Some(args.initial_cycles_per_canister),
         );
 
-        // Populate the SnsInitPayload with the values that would normally be set by the NNS
-        sns_init_payload.nns_proposal_id = Some(0);
-        sns_init_payload.swap_start_timestamp_seconds = Some(0);
-        sns_init_payload.swap_due_timestamp_seconds = Some(0);
-
         // TODO - add version hash to test upgrade path locally?  Where would we find that?
         // TODO[NNS1-2592]: set neurons_fund_participation_constraints to a non-trivial value.
         let sns_canister_payloads =

--- a/rs/sns/init/src/lib.rs
+++ b/rs/sns/init/src/lib.rs
@@ -533,7 +533,7 @@ impl SnsInitPayload {
             governance: self.governance_init_args(sns_canister_ids, deployed_version)?,
             ledger: self.ledger_init_args(sns_canister_ids)?,
             root: self.root_init_args(sns_canister_ids, testflight),
-            swap: self.swap_init_args(sns_canister_ids)?,
+            swap: self.swap_init_args(sns_canister_ids, testflight)?,
             index_ng: self.index_ng_init_args(sns_canister_ids),
         })
     }
@@ -664,7 +664,7 @@ impl SnsInitPayload {
     ///
     /// Precondition: Either [`Self::validate_pre_execution`] or [`Self::validate_post_execution`]
     /// (or both) must be `Ok(())`.
-    fn swap_init_args(&self, sns_canister_ids: &SnsCanisterIds) -> Result<SwapInit, String> {
+    fn swap_init_args(&self, sns_canister_ids: &SnsCanisterIds, testflight: bool) -> Result<SwapInit, String> {
         // Safe to cast due to validation
         let min_participants = self
             .min_participants
@@ -703,6 +703,7 @@ impl SnsInitPayload {
                 .neurons_fund_participation_constraints
                 .clone(),
             neurons_fund_participation: self.neurons_fund_participation,
+            testflight: Some(testflight),
         })
     }
 

--- a/rs/sns/swap/canister/swap.did
+++ b/rs/sns/swap/canister/swap.did
@@ -213,6 +213,7 @@ type Init = record {
   restricted_countries : opt Countries;
   min_icp_e8s : opt nat64;
   max_direct_participation_icp_e8s : opt nat64;
+  testflight: opt bool;
 };
 
 type InvalidUserAmount = record {

--- a/rs/sns/swap/proto/ic_sns_swap/pb/v1/swap.proto
+++ b/rs/sns/swap/proto/ic_sns_swap/pb/v1/swap.proto
@@ -430,6 +430,9 @@ message Init {
 
   // Whether Neurons' Fund participation is requested.
   optional bool neurons_fund_participation = 32;
+
+  // Whether this is a testflight swap.
+  optional bool testflight = 33;
 }
 
 // Constraints for the Neurons' Fund participation in an SNS swap.

--- a/rs/sns/swap/src/gen/ic_sns_swap.pb.v1.rs
+++ b/rs/sns/swap/src/gen/ic_sns_swap.pb.v1.rs
@@ -394,6 +394,9 @@ pub struct Init {
     /// Whether Neurons' Fund participation is requested.
     #[prost(bool, optional, tag = "32")]
     pub neurons_fund_participation: ::core::option::Option<bool>,
+    /// Whether this is a testflight swap.
+    #[prost(bool, optional, tag = "33")]
+    pub testflight: ::core::option::Option<bool>,
 }
 /// Constraints for the Neurons' Fund participation in an SNS swap.
 #[derive(

--- a/rs/sns/swap/src/swap.rs
+++ b/rs/sns/swap/src/swap.rs
@@ -2861,6 +2861,16 @@ impl Swap {
             return false;
         }
 
+        // Testflight swaps should not have sales
+        let testflight = self
+            .init
+            .as_ref()
+            .and_then(|init| init.testflight)
+            .unwrap_or_default();
+        if testflight {
+            return false;
+        }
+
         let swap_open_timestamp_seconds = self
             .decentralization_sale_open_timestamp_seconds
             .unwrap_or(now_seconds);

--- a/rs/sns/swap/src/swap_builder.rs
+++ b/rs/sns/swap/src/swap_builder.rs
@@ -38,6 +38,7 @@ pub struct SwapBuilder {
     neurons_fund_participation_constraints: Option<NeuronsFundParticipationConstraints>,
     neurons_fund_participation: Option<bool>,
     neuron_recipes: Vec<SnsNeuronRecipe>,
+    testflight: Option<bool>,
     // The following fields are deprecated and thus don't need to be represented here.
     // min_icp_e8s,
     // max_icp_e8s,
@@ -79,6 +80,7 @@ impl Default for SwapBuilder {
             neurons_fund_participation_constraints: None,
             neurons_fund_participation: None,
             neuron_recipes: vec![],
+            testflight: Some(false),
         }
     }
 }
@@ -242,6 +244,7 @@ impl SwapBuilder {
             should_auto_finalize: self.should_auto_finalize,
             neurons_fund_participation_constraints: self.neurons_fund_participation_constraints,
             neurons_fund_participation: self.neurons_fund_participation,
+            testflight: self.testflight,
 
             // The following fields are deprecated.
             min_icp_e8s: None,

--- a/rs/sns/swap/src/types.rs
+++ b/rs/sns/swap/src/types.rs
@@ -216,7 +216,7 @@ impl Init {
             // 21
             missing_swap_opening_field_names.push("max_participant_icp_e8s".to_string());
         }
-        if self.swap_due_timestamp_seconds.is_none() {
+        if !self.testflight.unwrap_or_default() && self.swap_due_timestamp_seconds.is_none() {
             // 23
             missing_swap_opening_field_names.push("swap_due_timestamp_seconds".to_string());
         }
@@ -229,7 +229,7 @@ impl Init {
             missing_swap_opening_field_names
                 .push("neuron_basket_construction_parameters".to_string());
         }
-        if self.nns_proposal_id.is_none() {
+        if !self.testflight.unwrap_or_default() && self.nns_proposal_id.is_none() {
             // 26
             missing_swap_opening_field_names.push("nns_proposal_id".to_string());
         }

--- a/rs/sns/swap/tests/swap.rs
+++ b/rs/sns/swap/tests/swap.rs
@@ -132,6 +132,7 @@ fn init_with_confirmation_text(confirmation_text: Option<String>) -> Init {
         should_auto_finalize: Some(true),
         neurons_fund_participation_constraints: None,
         neurons_fund_participation: None,
+        testflight: Some(false),
 
         // The following fields are deprecated.
         min_icp_e8s: None,


### PR DESCRIPTION
This PR makes swap know whether it's in testflight, so it knows not to fail when not provided certain fields that don't make sense in a testflight context (e.g. nns proposal ID)

TODO: add a test