### PR TITLE
feat(ckbtc): add check_transaction_str to Bitcoin Checker

### DIFF
--- a/rs/bitcoin/checker/btc_checker_canister.did
+++ b/rs/bitcoin/checker/btc_checker_canister.did
@@ -9,6 +9,8 @@ type CheckAddressResponse = variant { Passed; Failed };
 
 type CheckTransactionArgs = record { txid : blob };
 
+type CheckTransactionStrArgs = record { txid : text };
+
 // The result of a check_transaction call.
 type CheckTransactionResponse = variant {
     // When check finishes and all input addresses passed.
@@ -85,7 +87,11 @@ service : (CheckArg) -> {
     // of the return result.
     check_transaction: (CheckTransactionArgs) -> (CheckTransactionResponse);
 
+    // Same as check_transaction, but taking the transaction id argument as a string.
+    check_transaction_str: (CheckTransactionStrArgs) -> (CheckTransactionResponse);
+
     // Return `Passed` if the given Bitcoin address passes the Bitcoin checker, or `Failed` otherwise.
     // May throw error (trap) if the given address is malformed or not a mainnet address.
     check_address: (CheckAddressArgs) -> (CheckAddressResponse) query;
+
 }

--- a/rs/bitcoin/checker/src/main.rs
+++ b/rs/bitcoin/checker/src/main.rs
@@ -43,10 +43,10 @@ pub fn is_response_too_large(code: &RejectionCode, message: &str) -> bool {
         && (message.contains("size limit") || message.contains("length limit"))
 }
 
-#[ic_cdk::query]
 /// Return `Passed` if the given bitcion address passed the check, or
 /// `Failed` otherwise.
 /// May throw error (trap) if the given address is malformed or not a mainnet address.
+#[ic_cdk::query]
 fn check_address(args: CheckAddressArgs) -> CheckAddressResponse {
     let config = get_config();
     let btc_network = config.btc_network();
@@ -70,7 +70,6 @@ fn check_address(args: CheckAddressArgs) -> CheckAddressResponse {
     }
 }
 
-#[ic_cdk::update]
 /// Return `Passed` if all input addresses of the transaction of the given
 /// transaction id passed the check, or `Failed` if any of them did not.
 ///
@@ -88,6 +87,7 @@ fn check_address(args: CheckAddressArgs) -> CheckAddressResponse {
 /// If a permanent error occurred in the process, e.g, when a transaction data
 /// fails to decode or its transaction id does not match, then `Error` is returned
 /// together with a text description.
+#[ic_cdk::update]
 async fn check_transaction(args: CheckTransactionArgs) -> CheckTransactionResponse {
     check_transaction_with(|| Txid::try_from(args.txid.as_ref()).map_err(|err| err.to_string()))
         .await

--- a/rs/bitcoin/checker/src/types.rs
+++ b/rs/bitcoin/checker/src/types.rs
@@ -19,6 +19,11 @@ pub struct CheckTransactionArgs {
     pub txid: Vec<u8>,
 }
 
+#[derive(CandidType, Debug, Deserialize, Serialize)]
+pub struct CheckTransactionStrArgs {
+    pub txid: String,
+}
+
 #[derive(CandidType, Debug, Clone, Deserialize, Serialize)]
 pub enum CheckTransactionResponse {
     /// When check finishes and all input addresses passed.

--- a/rs/bitcoin/checker/tests/tests.rs
+++ b/rs/bitcoin/checker/tests/tests.rs
@@ -29,11 +29,11 @@ const TEST_SUBNET_NODES: u16 = 34;
 // by a small margin. Namely, the universal_canister itself would consume
 // some cycle for decoding args and sending the call.
 //
-// The number 42_000_000 is obtained empirically by running tests with pocket-ic
+// The number 43_000_000 is obtained empirically by running tests with pocket-ic
 // and checking the actual consumptions. It is both big enough to allow tests to
 // succeed, and small enough not to interfere with the expected cycle cost we
 // are testing for.
-const UNIVERSAL_CANISTER_CYCLE_MARGIN: u128 = 42_000_000;
+const UNIVERSAL_CANISTER_CYCLE_MARGIN: u128 = 43_000_000;
 
 struct Setup {
     // Owner of canisters created for the setup.

--- a/rs/bitcoin/checker/tests/tests.rs
+++ b/rs/bitcoin/checker/tests/tests.rs
@@ -673,11 +673,15 @@ fn test_check_transaction_error() {
 
     // Test for malformatted txid in string form
     let cycles_before = setup.env.cycle_balance(setup.caller);
-    let txid = "a80763842edc9a697a2114517cf0c138c5403a761ef63cfad1fa6993fa3475".to_string();
+    let too_short_txid =
+        "a80763842edc9a697a2114517cf0c138c5403a761ef63cfad1fa6993fa3475".to_string();
     let call_id = setup
         .submit_btc_checker_call(
             "check_transaction_str",
-            Encode!(&CheckTransactionStrArgs { txid }).unwrap(),
+            Encode!(&CheckTransactionStrArgs {
+                txid: too_short_txid
+            })
+            .unwrap(),
             CHECK_TRANSACTION_CYCLES_REQUIRED,
         )
         .expect("submit_call failed to return call id");


### PR DESCRIPTION
XC-259: Add a new public method `check_transaction_str` to Bitcoin Checker that takes transaction id as a text argument.