### PR TITLE
test(consensus): change the settings of consensus performance tests

### DIFF
--- a/rs/tests/consensus/consensus_performance.rs
+++ b/rs/tests/consensus/consensus_performance.rs
@@ -74,7 +74,7 @@ const NODES_COUNT: usize = 13;
 const DKG_INTERVAL: u64 = 999;
 // Network parameters
 const BANDWIDTH_MBITS: u32 = 300; // artificial cap on bandwidth
-const LATENCY: Duration = Duration::from_millis(200); // artificial added latency
+const LATENCY: Duration = Duration::from_millis(150); // artificial added latency
 const NETWORK_SIMULATION: FixedNetworkSimulation = FixedNetworkSimulation::new()
     .with_latency(LATENCY)
     .with_bandwidth(BANDWIDTH_MBITS);
@@ -163,11 +163,15 @@ fn test_few_small_messages(env: TestEnv) {
 }
 
 fn test_small_messages(env: TestEnv) {
-    test(env, 4_000, 500.0)
+    test(env, 4_000, 1_500.0)
+}
+
+fn test_few_large_messages(env: TestEnv) {
+    test(env, 1_999_000, 1.0)
 }
 
 fn test_large_messages(env: TestEnv) {
-    test(env, 950_000, 4.0)
+    test(env, 1_999_000, 4.0)
 }
 
 fn main() -> Result<()> {
@@ -178,6 +182,7 @@ fn main() -> Result<()> {
         .with_setup(setup)
         .add_test(systest!(test_few_small_messages))
         .add_test(systest!(test_small_messages))
+        .add_test(systest!(test_few_large_messages))
         .add_test(systest!(test_large_messages))
         .execute_from_args()?;
     Ok(())

--- a/rs/tests/consensus/utils/src/performance.rs
+++ b/rs/tests/consensus/utils/src/performance.rs
@@ -79,6 +79,10 @@ pub fn test_with_rt_handle(
     info!(log, "{} canisters installed successfully.", canisters.len());
 
     info!(log, "Step 2: Instantiate and start the workload..");
+
+    info!(log, "Sleeping for 30 seconds");
+    std::thread::sleep(Duration::from_secs(30));
+
     let payload: Vec<u8> = vec![0; message_size];
     let generator = {
         let (agents, canisters, payload) = (agents.clone(), canisters.clone(), payload.clone());


### PR DESCRIPTION
Since the hashes in blocks feature has been rolled out, we can achieve better performance results.