### PR TITLE
fix: including dashboards into colocated uvm's when running tests

### DIFF
--- a/rs/tests/driver/src/driver/prometheus_vm.rs
+++ b/rs/tests/driver/src/driver/prometheus_vm.rs
@@ -226,7 +226,7 @@ impl PrometheusVm {
                     continue;
                 }
 
-                let file_name = format!("{}.json", file.file_name().as_os_str().to_str().unwrap());
+                let file_name = file.file_name().as_os_str().to_str().unwrap();
 
                 let destination_path = dashboard_dir.join(&file_name);
 


### PR DESCRIPTION
Previously the UVM's would fail to copy the dashboards over to the farm testnet because they were not copied from local to colocated UVM. 
This PR adds the missing functionality. 

Also fixes the `file_name` formatting. It removes an additional `.json` added to the dashboard name which already includes the extensions.