### PR TITLE
fix(nns): Revert spawn state when ledger unavailable and drop lock

### DIFF
--- a/rs/nns/governance/src/governance.rs
+++ b/rs/nns/governance/src/governance.rs
@@ -6992,19 +6992,30 @@ impl Governance {
                             // This is different from what we do in most places because we usually rely
                             // on trapping to retain the lock, but we can't do that here since we're not
                             // working on a single neuron.
-                            self.with_neuron_mut(&neuron_id, |neuron| {
+                            println!(
+                                "{}Error spawning neuron: {:?}. Ledger update failed with err: {:?}. \
+                                Reverting state, so another attempt can be made.",
+                                LOG_PREFIX,
+                                neuron_id,
+                                error,
+                            );
+                            match self.with_neuron_mut(&neuron_id, |neuron| {
                                 neuron.maturity_e8s_equivalent = neuron_stake;
                                 neuron.cached_neuron_stake_e8s = 0;
                                 neuron.spawn_at_timestamp_seconds =
                                     original_spawn_at_timestamp_seconds;
-                            });
-                            println!(
-                                "{}Error spawning neuron: {:?}. Ledger update failed with err: {:?}. \
-                                Reverted state, so another attempt can be made.",
-                                LOG_PREFIX,
-                                neuron_id,
-                                error,
-                                );
+                            }) {
+                                Ok(_) => (),
+                                Err(e) => {
+                                    println!(
+                                        "{} Error reverting state for neuron: {:?}. Retaining lock: {}",
+                                        LOG_PREFIX,
+                                        neuron_id,
+                                        e
+                                    );
+                                    lock.retain();
+                                }
+                            };
                         }
                     };
                 }

--- a/rs/nns/governance/src/governance.rs
+++ b/rs/nns/governance/src/governance.rs
@@ -6987,11 +6987,6 @@ impl Governance {
                             );
                         }
                         Err(error) => {
-                            // Retain the neuron lock, the neuron won't be able to undergo stake changing
-                            // operations until this is fixed.
-                            // This is different from what we do in most places because we usually rely
-                            // on trapping to retain the lock, but we can't do that here since we're not
-                            // working on a single neuron.
                             println!(
                                 "{}Error spawning neuron: {:?}. Ledger update failed with err: {:?}. \
                                 Reverting state, so another attempt can be made.",
@@ -7013,6 +7008,11 @@ impl Governance {
                                         neuron_id,
                                         e
                                     );
+                                    // Retain the neuron lock, the neuron won't be able to undergo stake changing
+                                    // operations until this is fixed.
+                                    // This is different from what we do in most places because we usually rely
+                                    // on trapping to retain the lock, but we can't do that here since we're not
+                                    // working on a single neuron.
                                     lock.retain();
                                 }
                             };


### PR DESCRIPTION
This removes an edge case where a neuron can become locked when the ledger is unavailable during a neuron operation (such as during an upgrade).

If the neuron happens to spawn during a ledger upgrade, the neuron will become locked, and therefore stuck.