### PR TITLE
test(ICRC_Index): FI-1617: Optimize retrieve_blocks_from_ledger_interval tests

### DIFF
--- a/rs/ledger_suite/icrc1/index-ng/BUILD.bazel
+++ b/rs/ledger_suite/icrc1/index-ng/BUILD.bazel
@@ -104,12 +104,14 @@ rust_test(
             conf["ledger_wasm"],
         ],
         env = {
+            "RUST_TEST_THREADS": "4",
             "CARGO_MANIFEST_DIR": "rs/ledger_suite/icrc1/index-ng",
             "IC_ICRC1_INDEX_NG_WASM_PATH": "$(rootpath " + conf["index_wasm"] + ")",
             "IC_ICRC1_INDEX_WASM_PATH": "$(rootpath //rs/ledger_suite/icrc1/index:index_canister.wasm)",
             "IC_ICRC1_LEDGER_WASM_PATH": "$(rootpath " + conf["ledger_wasm"] + ")",
         },
         extra_srcs = ["tests/common/mod.rs"],
+        tags = ["cpu:4"],
         deps = [
             # Keep sorted.
             ":index-ng",

--- a/rs/ledger_suite/icrc1/index-ng/tests/retrieve_blocks_from_ledger_interval.rs
+++ b/rs/ledger_suite/icrc1/index-ng/tests/retrieve_blocks_from_ledger_interval.rs
@@ -23,7 +23,7 @@ mod common;
 /// Corresponds to ic_icrc1_index_ng::DEFAULT_MAX_WAIT_TIME_IN_SECS
 const DEFAULT_MAX_WAIT_TIME_IN_SECS: u64 = 1;
 const GENESIS: Time = Time::from_nanos_since_unix_epoch(1_620_328_630_000_000_000);
-const IDLE_TIME_IN_SECS: u64 = 60;
+const IDLE_TIME_IN_SECS: u64 = 10;
 const INDEX_SYNC_TIME_TO_ADVANCE: Duration = Duration::from_secs(60);
 const MINTER_PRINCIPAL: Principal = Principal::from_slice(&[3_u8; 29]);
 
@@ -172,7 +172,7 @@ fn should_sync_according_to_interval() {
         assert_eq!(ledger_chain_length, index_num_blocks_synced);
     }
 
-    let mut runner = TestRunner::new(proptest::test_runner::Config::with_cases(10));
+    let mut runner = TestRunner::new(proptest::test_runner::Config::with_cases(4));
     runner
         .run(
             &(
@@ -375,8 +375,8 @@ fn should_consume_expected_amount_of_cycles() {
             initial_interval: Some(DEFAULT_MAX_WAIT_TIME_IN_SECS),
             upgrade_interval: Some(DEFAULT_MAX_WAIT_TIME_IN_SECS),
             assert_cost: |initial, upgrade| {
-                const EXPECTED_LEDGER_CYCLES_CONSUMPTION: i128 = 706_075_016;
-                const EXPECTED_INDEX_CYCLES_CONSUMPTION: i128 = 2_783_783_209;
+                const EXPECTED_LEDGER_CYCLES_CONSUMPTION: i128 = 126_800_287;
+                const EXPECTED_INDEX_CYCLES_CONSUMPTION: i128 = 474_143_016;
                 for ledger_consumption in [initial.ledger, upgrade.ledger] {
                     assert!(
                         abs_relative_difference(


### PR DESCRIPTION
This PR proposes two things to optimize the `//rs/ledger_suite/icrc1/index-ng:index_ng_test_..._tests/retrieve_blocks_from_ledger_interval` tests which has seen P90 durations of over 5min:

- Shorten the runtime of a couple of tests (from `10` to `4` cases for a `proptest`, and from `60s` to `10s` for a test checking the idle canister cycles consumption)
- Limit the parallelism and increase the allocated resources, since the runtime of the test was increasing with increasing values of `--runs_per_test`