### PR TITLE
test: EXC-1818: Test some bench targets

### DIFF
--- a/bazel/defs.bzl
+++ b/bazel/defs.bzl
@@ -204,7 +204,7 @@ def rust_ic_test(env = {}, data = [], **kwargs):
         **kwargs
     )
 
-def rust_bench(name, env = {}, data = [], pin_cpu = False, **kwargs):
+def rust_bench(name, env = {}, data = [], pin_cpu = False, with_test = False, **kwargs):
     """A rule for defining a rust benchmark.
 
     Args:
@@ -212,6 +212,7 @@ def rust_bench(name, env = {}, data = [], pin_cpu = False, **kwargs):
       env: additional environment variables to pass to the benchmark binary.
       data: data dependencies required to run the benchmark.
       pin_cpu: pins the benchmark process to a single CPU if set `True`.
+      with_test: generates name + '_test' target to test that the benchmark work.
       **kwargs: see docs for `rust_binary`.
     """
 
@@ -245,6 +246,17 @@ def rust_bench(name, env = {}, data = [], pin_cpu = False, **kwargs):
         data = data + [":" + binary_name_publish],
         tags = kwargs.get("tags", []) + ["rust_bench"],
     )
+
+    # To test that the benchmarks work.
+    if with_test:
+        native.sh_test(
+            name = name + "_test",
+            testonly = True,
+            env = env,
+            srcs = [":" + binary_name_publish],
+            data = data,
+            tags = kwargs.get("tags", None),
+        )
 
 def rust_ic_bench(env = {}, data = [], **kwargs):
     """A rule for defining a rust benchmark.

--- a/rs/embedders/BUILD.bazel
+++ b/rs/embedders/BUILD.bazel
@@ -176,6 +176,7 @@ rust_bench(
     name = "compilation_bench",
     srcs = ["benches/compilation.rs"],
     compile_data = glob(["benches/test-data/*"]),
+    with_test = True,
     deps = [":embedders"] + DEPENDENCIES + DEV_DEPENDENCIES,
 )
 

--- a/rs/execution_environment/BUILD.bazel
+++ b/rs/execution_environment/BUILD.bazel
@@ -197,6 +197,7 @@ rust_ic_bench(
     srcs = ["benches/system_api/execute_inspect_message.rs"],
     data = DATA,
     env = ENV,
+    with_test = True,
     deps = ["//rs/execution_environment/benches/lib:execution_environment_bench"] + BENCH_DEPENDENCIES,
 )
 
@@ -205,6 +206,7 @@ rust_ic_bench(
     srcs = ["benches/system_api/execute_query.rs"],
     data = DATA,
     env = ENV,
+    with_test = True,
     deps = ["//rs/execution_environment/benches/lib:execution_environment_bench"] + BENCH_DEPENDENCIES,
 )
 
@@ -213,6 +215,7 @@ rust_ic_bench(
     srcs = ["benches/system_api/execute_update.rs"],
     data = DATA,
     env = ENV,
+    with_test = True,
     deps = ["//rs/execution_environment/benches/lib:execution_environment_bench"] + BENCH_DEPENDENCIES,
 )
 


### PR DESCRIPTION
Some benchmarks include assertions on the number of instructions executed, which can be broken when costs are adjusted. This change causes some benchmark targets to also generate corresponding test targets, ensuring their execution on each pipeline run.