### PR TITLE
chore: Log HTTP request body on signature verification failure

### DIFF
--- a/rs/http_endpoints/public/src/call.rs
+++ b/rs/http_endpoints/public/src/call.rs
@@ -251,7 +251,7 @@ impl IngressValidator {
             message: "".into(),
         })?
         .map_err(|validation_error| {
-            validation_error_to_http_error(message_id, validation_error, &log)
+            validation_error_to_http_error(msg.signed(), message_id, validation_error, &log)
         })?;
 
         let ingress_filter = ingress_filter.lock().unwrap().clone();

--- a/rs/http_endpoints/public/src/query.rs
+++ b/rs/http_endpoints/public/src/query.rs
@@ -194,7 +194,7 @@ pub(crate) async fn query(
     {
         Ok(Ok(_)) => {}
         Ok(Err(err)) => {
-            let http_err = validation_error_to_http_error(request.id(), err, &log);
+            let http_err = validation_error_to_http_error(&request, request.id(), err, &log);
             return (http_err.status, http_err.message).into_response();
         }
         Err(_) => {

--- a/rs/http_endpoints/public/src/read_state/canister.rs
+++ b/rs/http_endpoints/public/src/read_state/canister.rs
@@ -169,7 +169,8 @@ pub(crate) async fn canister_read_state(
             match validator.validate_request(&request_c, current_time(), &root_of_trust_provider) {
                 Ok(targets) => targets,
                 Err(err) => {
-                    let http_err = validation_error_to_http_error(request.id(), err, &log);
+                    let http_err =
+                        validation_error_to_http_error(&request, request.id(), err, &log);
                     return (http_err.status, http_err.message).into_response();
                 }
             };


### PR DESCRIPTION
There have been reports both internally and in support channels of ingress messages failing signature verification. So far these have not been reproducible, and the cause is unknown. To assist debugging, if verification fails log the HTTP request body.