### PR TITLE
test: Miscellaneous XNet test improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22850,6 +22850,7 @@ dependencies = [
  "rand 0.8.5",
  "rand_pcg 0.3.1",
  "serde",
+ "serde_bytes",
 ]
 
 [[package]]

--- a/rs/rust_canisters/xnet_test/BUILD.bazel
+++ b/rs/rust_canisters/xnet_test/BUILD.bazel
@@ -11,6 +11,7 @@ DEPENDENCIES = [
     "@crate_index//:rand",
     "@crate_index//:rand_pcg",
     "@crate_index//:serde",
+    "@crate_index//:serde_bytes",
 ]
 
 MACRO_DEPENDENCIES = [

--- a/rs/rust_canisters/xnet_test/Cargo.toml
+++ b/rs/rust_canisters/xnet_test/Cargo.toml
@@ -18,3 +18,4 @@ ic-cdk-macros = { workspace = true }
 rand = { workspace = true }
 rand_pcg = "0.3"
 serde = { workspace = true }
+serde_bytes = { workspace = true }

--- a/rs/rust_canisters/xnet_test/src/main.rs
+++ b/rs/rust_canisters/xnet_test/src/main.rs
@@ -70,6 +70,7 @@ struct Request {
     /// Local time observed in the round when this message was sent.
     time_nanos: u64,
     /// Optional padding, to bring the payload to the desired byte size.
+    #[serde(with = "serde_bytes")]
     padding: Vec<u8>,
 }
 
@@ -80,6 +81,7 @@ struct Reply {
     /// roundtrip latency on the caller side.
     time_nanos: u64,
     /// Optional padding, to bring the payload to the desired byte size.
+    #[serde(with = "serde_bytes")]
     padding: Vec<u8>,
 }
 

--- a/rs/tests/message_routing/xnet/BUILD.bazel
+++ b/rs/tests/message_routing/xnet/BUILD.bazel
@@ -38,7 +38,7 @@ system_test_nns(
     ],
     target_compatible_with = ["@platforms//os:linux"],  # requires libssh that does not build on Mac OS
     test_timeout = "long",
-    runtime_deps = GUESTOS_RUNTIME_DEPS + XNET_TEST_CANISTER_RUNTIME_DEPS,
+    runtime_deps = GUESTOS_RUNTIME_DEPS + XNET_TEST_CANISTER_RUNTIME_DEPS + GRAFANA_RUNTIME_DEPS,
     deps = [
         "//rs/tests/driver:ic-system-test-driver",
         "//rs/tests/message_routing/xnet/slo_test_lib:xnet_slo_test_lib",
@@ -59,7 +59,7 @@ system_test_nns(
     ],
     target_compatible_with = ["@platforms//os:linux"],  # requires libssh that does not build on Mac OS
     test_timeout = "long",
-    runtime_deps = GUESTOS_RUNTIME_DEPS + XNET_TEST_CANISTER_RUNTIME_DEPS,
+    runtime_deps = GUESTOS_RUNTIME_DEPS + XNET_TEST_CANISTER_RUNTIME_DEPS + GRAFANA_RUNTIME_DEPS,
     deps = [
         "//rs/tests/driver:ic-system-test-driver",
         "//rs/tests/message_routing/xnet/slo_test_lib:xnet_slo_test_lib",
@@ -81,7 +81,7 @@ system_test_nns(
     ],
     target_compatible_with = ["@platforms//os:linux"],  # requires libssh that does not build on Mac OS
     test_timeout = "eternal",
-    runtime_deps = GUESTOS_RUNTIME_DEPS + XNET_TEST_CANISTER_RUNTIME_DEPS,
+    runtime_deps = GUESTOS_RUNTIME_DEPS + XNET_TEST_CANISTER_RUNTIME_DEPS + GRAFANA_RUNTIME_DEPS,
     deps = [
         "//rs/tests/driver:ic-system-test-driver",
         "//rs/tests/message_routing/xnet/slo_test_lib:xnet_slo_test_lib",


### PR DESCRIPTION
* Install large numbers of canisters in batches, to prevent failures due to HTTP endpoint rate limits.
* Annotate blobs in types used by `xnet_test_canister` endpoints with `#{with(serde_bytes)]`, making them a lot cheaper to encode and decode.
* Add Prometheus/Grafana runtime dependencies to all XNet tests, to avoid mysterious failures when running `.with_prometheus()`.