### PR TITLE
perf: EXC-1818: Fix embedders heap and stable memory query benches

### DIFF
--- a/rs/embedders/benches/embedders_bench/src/lib.rs
+++ b/rs/embedders/benches/embedders_bench/src/lib.rs
@@ -47,6 +47,7 @@ fn initialize_execution_test(
     }
 
     let mut test = ExecutionTestBuilder::new()
+        .with_query_caching_disabled()
         .with_install_code_instruction_limit(LARGE_INSTRUCTION_LIMIT)
         .with_install_code_slice_instruction_limit(LARGE_INSTRUCTION_LIMIT)
         .with_instruction_limit(LARGE_INSTRUCTION_LIMIT)

--- a/rs/test_utilities/execution_environment/src/lib.rs
+++ b/rs/test_utilities/execution_environment/src/lib.rs
@@ -1991,6 +1991,11 @@ impl ExecutionTestBuilder {
         self
     }
 
+    pub fn with_query_caching_disabled(mut self) -> Self {
+        self.execution_config.query_caching = FlagStatus::Disabled;
+        self
+    }
+
     pub fn with_query_cache_capacity(mut self, capacity_bytes: u64) -> Self {
         self.execution_config.query_cache_capacity = capacity_bytes.into();
         self


### PR DESCRIPTION
Currently, all query benchmarks are near-instantaneous due to query caching. This PR disables caching to provide accurate benchmarks.