### PR TITLE
chore: simplify bitcoin header validation

### DIFF
--- a/rs/bitcoin/adapter/src/blockchainstate.rs
+++ b/rs/bitcoin/adapter/src/blockchainstate.rs
@@ -338,10 +338,6 @@ impl HeaderStore for BlockchainState {
             .map(|cached| (cached.header, cached.height))
     }
 
-    fn get_height(&self) -> BlockHeight {
-        self.get_active_chain_tip().height
-    }
-
     fn get_initial_hash(&self) -> BlockHash {
         self.genesis().block_hash()
     }

--- a/rs/bitcoin/validation/src/constants.rs
+++ b/rs/bitcoin/validation/src/constants.rs
@@ -1,6 +1,4 @@
-use std::collections::HashMap;
-
-use bitcoin::{hashes::hex::FromHex, util::uint::Uint256, BlockHash, Network};
+use bitcoin::{util::uint::Uint256, Network};
 
 use crate::BlockHeight;
 
@@ -9,53 +7,6 @@ pub const DIFFICULTY_ADJUSTMENT_INTERVAL: BlockHeight = 6 * 24 * 14;
 
 /// Needed to help test check for the 20 minute testnet/regtest rule
 pub const TEN_MINUTES: u32 = 60 * 10;
-
-/// Represents approximately the number of blocks that will be created within one year.
-///
-/// This number is determine by the following formula. A year approximately has 356.25 days. Assuming the
-/// Bitcoin network produces a new block every 10 minutes on average, `6 * 24 * 365.25 = 52,596`.
-pub const BLOCKS_IN_ONE_YEAR: BlockHeight = 52_596;
-
-/// Bitcoin mainnet checkpoints
-#[rustfmt::skip]
-const BITCOIN: &[(BlockHeight, &str)] = &[
-    (11_111, "0000000069e244f73d78e8fd29ba2fd2ed618bd6fa2ee92559f542fdb26e7c1d",),
-    (33_333, "000000002dd5588a74784eaa7ab0507a18ad16a236e7b1ce69f00d7ddfb5d0a6",),
-    (74_000, "0000000000573993a3c9e41ce34471c079dcf5f52a0e824a81e7f953b8661a20",),
-    (105_000, "00000000000291ce28027faea320c8d2b054b2e0fe44a773f3eefb151d6bdc97",),
-    (134_444, "00000000000005b12ffd4cd315cd34ffd4a594f430ac814c91184a0d42d2b0fe",),
-    (168_000, "000000000000099e61ea72015e79632f216fe6cb33d7899acb35b75c8303b763",),
-    (193_000, "000000000000059f452a5f7340de6682a977387c17010ff6e6c3bd83ca8b1317",),
-    (210_000, "000000000000048b95347e83192f69cf0366076336c639f9b7228e9ba171342e",),
-    (216_116, "00000000000001b4f4b433e81ee46494af945cf96014816a4e2370f11b23df4e",),
-    (225_430, "00000000000001c108384350f74090433e7fcf79a606b8e797f065b130575932",),
-    (250_000, "000000000000003887df1f29024b06fc2200b55f8af8f35453d7be294df2d214",),
-    (279_000, "0000000000000001ae8c72a0b0c301f67e3afca10e819efa9041e458e9bd7e40",),
-    (295_000, "00000000000000004d9b4ef50f0f9d686fd69db2e03af35a100370c64632a983",),
-    (393_216, "00000000000000000390df7d2bdc06b9fcb260b39e3fb15b4bc9f62572553924"),
-    (421_888, "000000000000000004b232ad9492d0729d7f9d6737399ffcdaac1c8160db5ef6"),
-    (438_784, "0000000000000000040d6ef667d7a52caf93d8e0d1e40fd7155c787b42667179"),
-    (451_840, "0000000000000000029103c8ade7786e7379623465c72d71d84624eb9c159bea"),
-    (469_766, "000000000000000000130b2bd812c6a7ae9c02a74fc111806b1dd11e8975da45"),
-    (481_824, "0000000000000000001c8018d9cb3b742ef25114f27563e3fc4a1902167f9893"),
-    (514_048, "00000000000000000022fe630be397a62c58972bb81f0a2d1ae8c968511a4659"),
-    (553_472, "0000000000000000000e06b6698a4f65ab9915f24b23ca2f9d1abf30cc3e9173"),
-    (571_392, "00000000000000000019c18b43077775fc299a6646ab0e9dbbd5770bf6ca392d"),
-    (596_000, "0000000000000000000706f93dc673ca366c810f317e7cfe8d951c0107b65223"),
-    (601_723, "000000000000000000009837f74796532b21d8ccf7def3dcfcb45aa92cd86b9e"),
-    (617_056, "0000000000000000000ca51b293fb2be2fbaf1acc76dcbbbff7e4d7796380b9e"),
-    (632_549, "00000000000000000001bae1b2b73ec3fde475c1ed7fdd382c2c49860ec19920"),
-    (643_700, "00000000000000000002959e9b44507120453344794df09bd1276eb325ed7110"),
-    (667_811, "00000000000000000007888a9d01313d69d6335df46ea33e875ee6832670c596"),
-    (688_888, "0000000000000000000e1e3bd783ce0de7b0cdabf2034723595dbcd5a28cf831"),
-    (704_256, "0000000000000000000465f5acfcd603337994261a4d67a647cb49866c98b538"),
-];
-
-/// Bitcoin testnet checkpoints
-#[rustfmt::skip]
-const TESTNET: &[(BlockHeight, &str)] = &[
-    (546, "000000002a936ca763904c3c35fce2f3556c559c0214345d31b1bcebf76acb70")
-];
 
 /// Bitcoin mainnet maximum target value
 const BITCOIN_MAX_TARGET: Uint256 = Uint256([
@@ -118,61 +69,8 @@ pub fn pow_limit_bits(network: &Network) -> u32 {
     }
 }
 
-/// Checkpoints used to validate blocks at certain heights.
-pub fn checkpoints(network: &Network) -> HashMap<BlockHeight, BlockHash> {
-    let points = match network {
-        Network::Bitcoin => BITCOIN,
-        Network::Testnet => TESTNET,
-        Network::Signet => &[],
-        Network::Regtest => &[],
-    };
-    points
-        .iter()
-        .cloned()
-        .map(|(height, hash)| {
-            let hash = BlockHash::from_hex(hash).expect("Programmer error: invalid hash");
-            (height, hash)
-        })
-        .collect()
-}
-
-pub fn latest_checkpoint_height(network: &Network, current_height: BlockHeight) -> BlockHeight {
-    let points = match network {
-        Network::Bitcoin => BITCOIN,
-        Network::Testnet => TESTNET,
-        Network::Signet => &[],
-        Network::Regtest => &[],
-    };
-
-    points
-        .iter()
-        .rev()
-        .find(|(height, _)| *height <= current_height)
-        .map_or(0, |(height, _)| *height)
-}
-
-pub fn last_checkpoint(network: &Network) -> Option<BlockHeight> {
-    let points = match network {
-        Network::Bitcoin => BITCOIN,
-        Network::Testnet => TESTNET,
-        Network::Signet => &[],
-        Network::Regtest => &[],
-    };
-
-    points.last().map(|(height, _)| *height)
-}
-
 #[cfg(test)]
 pub mod test {
-
-    use super::*;
-
-    /// Mainnet 00000000bcb3c8ff4e3e243ad47832d75bb81e922efdc05be63f2696c5dfad09
-    pub const MAINNET_HEADER_11109: &str = "0100000027e37046713f768e57bd9c613f70657048320cab3e016c6ad437dadd00000000a12e0863a26054892799db694b8ccd9f44ad062b4d6ef09d2be12e994d50649b9ca2e649ffff001d2823bacb";
-    /// Mainnet 00000000deaa3a36d8531844fd1cb11faff6a1171d5228d42131d1b302c56271
-    pub const MAINNET_HEADER_11110: &str = "0100000009addfc596263fe65bc0fd2e921eb85bd73278d43a243e4effc8b3bc0000000006413a83ca2d3fbf6b1ac332976043152e0093f17e29fef68c3eb736d379d7365aa3e649ffff001da44e7f02";
-    /// Mainnet 0000000069e244f73d78e8fd29ba2fd2ed618bd6fa2ee92559f542fdb26e7c1d
-    pub const MAINNET_HEADER_11111: &str = "010000007162c502b3d13121d428521d17a1f6af1fb11cfd441853d8363aaade000000007adf7b53a9dc840a210766054aa8a1b2076fd30dadcc3f757c23318a8c8be55213a4e649ffff001d05d9428b";
 
     /// Mainnet 000000000000000000063108ecc1f03f7fd1481eb20f97307d532a612bc97f04
     pub const MAINNET_HEADER_586656: &str ="00008020cff0e07ab39db0f31d4ded81ba2339173155b9c57839110000000000000000007a2d75dce5981ec421a54df706d3d407f66dc9170f1e0d6e48ed1e8a1cad7724e9ed365d083a1f17bc43b10a";
@@ -187,22 +85,4 @@ pub mod test {
     pub const TESTNET_HEADER_2132555: &str = "004000200e1ff99438666c67c649def743fb82117537c2017bcc6ad617000000000000007fa40cf82bf224909e3174281a57af2eb3a4a2a961d33f50ec0772c1221c9e61ddfdc061ffff001a64526636";
     /// Testnet 00000000383cd7fff4692410ccd9bd6201790043bb41b93bacb21e9b85620767
     pub const TESTNET_HEADER_2132556: &str = "00000020974f55e77dff100bc252a01aa7b00d16736c6e04a091b03be200000000000000c44f2d69fc200c4a2211885000b6b67512f42c1bec550f3754e103b6c4046e05a202c161ffff001d09ec1bc4";
-
-    #[test]
-    fn test_latest_checkpoint_height() {
-        let height = latest_checkpoint_height(&Network::Bitcoin, 1_000_000);
-        assert_eq!(height, 704_256);
-
-        let height = latest_checkpoint_height(&Network::Bitcoin, 40_000);
-        assert_eq!(height, 33_333);
-
-        let height = latest_checkpoint_height(&Network::Testnet, 1_000_000);
-        assert_eq!(height, 546);
-    }
-
-    #[test]
-    fn test_last_checkpoint() {
-        assert_eq!(last_checkpoint(&Network::Bitcoin), Some(704_256));
-        assert_eq!(last_checkpoint(&Network::Regtest), None);
-    }
 }

--- a/rs/bitcoin/validation/src/header.rs
+++ b/rs/bitcoin/validation/src/header.rs
@@ -2,20 +2,17 @@ use bitcoin::{util::uint::Uint256, BlockHash, BlockHeader, Network};
 
 use crate::{
     constants::{
-        checkpoints, last_checkpoint, latest_checkpoint_height, max_target, no_pow_retargeting,
-        pow_limit_bits, BLOCKS_IN_ONE_YEAR, DIFFICULTY_ADJUSTMENT_INTERVAL, TEN_MINUTES,
+        max_target, no_pow_retargeting, pow_limit_bits, DIFFICULTY_ADJUSTMENT_INTERVAL, TEN_MINUTES,
     },
     BlockHeight,
 };
 
 /// An error thrown when trying to validate a header.
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub enum ValidateHeaderError {
     /// Used when the timestamp in the header is lower than
     /// the median of timestamps of past 11 headers.
     HeaderIsOld,
-    /// Used when the header doesn't match with a checkpoint.
-    DoesNotMatchCheckpoint,
     /// Used when the PoW in the header is invalid as per the target mentioned
     /// in the header.
     InvalidPoWForHeaderTarget,
@@ -25,19 +22,16 @@ pub enum ValidateHeaderError {
     /// Used when the target in the header is greater than the max possible
     /// value.
     TargetDifficultyAboveMax,
-    /// The next height is less than the tip height - 52_596 (one year worth of blocks).
-    HeightTooLow,
     /// Used when the predecessor of the input header is not found in the
     /// HeaderStore.
     PrevHeaderNotFound,
 }
 
 pub trait HeaderStore {
-    /// Retrieves the header from the store.
+    /// Returns the header with the given block hash.
     fn get_header(&self, hash: &BlockHash) -> Option<(BlockHeader, BlockHeight)>;
-    /// Retrieves the current height of the block chain.
-    fn get_height(&self) -> BlockHeight;
-    /// Retrieves the initial hash the store starts from.
+
+    /// Returns the initial hash the store starts from.
     fn get_initial_hash(&self) -> BlockHash;
 }
 
@@ -48,25 +42,12 @@ pub fn validate_header(
     store: &impl HeaderStore,
     header: &BlockHeader,
 ) -> Result<(), ValidateHeaderError> {
-    let chain_height = store.get_height();
     let (prev_header, prev_height) = match store.get_header(&header.prev_blockhash) {
         Some(result) => result,
         None => {
             return Err(ValidateHeaderError::PrevHeaderNotFound);
         }
     };
-
-    if !is_header_within_one_year_of_tip(prev_height, chain_height) {
-        return Err(ValidateHeaderError::HeightTooLow);
-    }
-
-    if !is_timestamp_valid(store, header) {
-        return Err(ValidateHeaderError::HeaderIsOld);
-    }
-
-    if !is_checkpoint_valid(network, prev_height, header, chain_height) {
-        return Err(ValidateHeaderError::DoesNotMatchCheckpoint);
-    }
 
     let header_target = header.target();
     if header_target > max_target(network) {
@@ -77,7 +58,7 @@ pub fn validate_header(
         return Err(ValidateHeaderError::InvalidPoWForHeaderTarget);
     }
 
-    let target = get_next_target(network, store, &prev_header, prev_height, header);
+    let target = get_next_target(network, store, &prev_header, prev_height, header.time);
     if let Err(err) = header.validate_pow(&target) {
         match err {
             bitcoin::Error::BlockBadProofOfWork => println!("bad proof of work"),
@@ -90,82 +71,14 @@ pub fn validate_header(
     Ok(())
 }
 
-/// Checks if block height is higher than the last checkpoint height.
-/// By beeing beyond the last checkpoint we are sure that we store the correct chain up to the height
-/// of the last checkpoint.  
-pub fn is_beyond_last_checkpoint(network: &Network, height: BlockHeight) -> bool {
-    match last_checkpoint(network) {
-        Some(last) => last <= height,
-        None => true,
-    }
-}
-
-/// This validates the header against the network's checkpoints.
-/// 1. If the next header is at a checkpoint height, the checkpoint is compared to the next header's block hash.
-/// 2. If the header is not the same height, the function then compares the height to the latest checkpoint.
-///    If the next header's height is less than the last checkpoint's height, the header is invalid.
-fn is_checkpoint_valid(
-    network: &Network,
-    prev_height: BlockHeight,
-    header: &BlockHeader,
-    chain_height: BlockHeight,
-) -> bool {
-    let checkpoints = checkpoints(network);
-    let next_height = prev_height.saturating_add(1);
-    if let Some(next_hash) = checkpoints.get(&next_height) {
-        return *next_hash == header.block_hash();
-    }
-
-    let checkpoint_height = latest_checkpoint_height(network, chain_height);
-    next_height > checkpoint_height
-}
-
-/// This validates that the header has a height that is within 1 year of the tip height.
-fn is_header_within_one_year_of_tip(prev_height: BlockHeight, chain_height: BlockHeight) -> bool {
-    // perhaps checked_add would be preferable here, if the next height would cause an overflow,
-    // we should know about it instead of being swallowed.
-    let header_height = prev_height
-        .checked_add(1)
-        .expect("next height causes an overflow");
-
-    let height_one_year_ago = chain_height.saturating_sub(BLOCKS_IN_ONE_YEAR);
-    header_height >= height_one_year_ago
-}
-
-/// Validates if a header's timestamp is valid.
-/// Bitcoin Protocol Rules wiki https://en.bitcoin.it/wiki/Protocol_rules says,
-/// "Reject if timestamp is the median time of the last 11 blocks or before"
-fn is_timestamp_valid(store: &impl HeaderStore, header: &BlockHeader) -> bool {
-    let mut times = vec![];
-    let mut current_header = *header;
-    let initial_hash = store.get_initial_hash();
-    for _ in 0..11 {
-        if let Some((prev_header, _)) = store.get_header(&current_header.prev_blockhash) {
-            times.push(prev_header.time);
-            if current_header.prev_blockhash == initial_hash {
-                break;
-            }
-            current_header = prev_header;
-        }
-    }
-
-    times.sort_unstable();
-    let median = times[times.len() / 2];
-    header.time > median
-}
-
-/// Gets the next target by doing the following:
-/// * If the network allows blocks to have the max target (testnet & regtest),
-///   the next difficulty is searched for unless the header's timestamp is
-///   greater than 20 minutes from the previous header's timestamp.
-/// * If the network does not allow blocks with the max target, the next
-///   difficulty is computed and then cast into the next target.
+// Returns the next required target at the given timestamp.
+// The target is the number that a block hash must be below for it to be accepted.
 fn get_next_target(
     network: &Network,
     store: &impl HeaderStore,
     prev_header: &BlockHeader,
     prev_height: BlockHeight,
-    header: &BlockHeader,
+    timestamp: u32,
 ) -> Uint256 {
     match network {
         Network::Testnet | Network::Regtest => {
@@ -175,7 +88,7 @@ fn get_next_target(
                 // "If no block has been found in 20 minutes, the difficulty automatically
                 // resets back to the minimum for a single block, after which it
                 // returns to its previous value."
-                if header.time > prev_header.time + TEN_MINUTES * 2 {
+                if timestamp > prev_header.time + TEN_MINUTES * 2 {
                     //If no block has been found in 20 minutes, then use the maximum difficulty
                     // target
                     max_target(network)
@@ -219,29 +132,37 @@ fn find_next_difficulty_in_chain(
 ) -> u32 {
     // This is the maximum difficulty target for the network
     let pow_limit_bits = pow_limit_bits(network);
+
     match network {
         Network::Testnet | Network::Regtest => {
             let mut current_header = *prev_header;
             let mut current_height = prev_height;
-            let mut current_hash = prev_header.block_hash();
+            let mut current_hash = current_header.block_hash();
             let initial_header_hash = store.get_initial_hash();
 
             // Keep traversing the blockchain backwards from the recent block to initial
             // header hash.
-            while current_hash != initial_header_hash {
+            loop {
+                // Check if non-limit PoW found or it's time to adjust difficulty.
                 if current_header.bits != pow_limit_bits
                     || current_height % DIFFICULTY_ADJUSTMENT_INTERVAL == 0
                 {
                     return current_header.bits;
                 }
 
-                // Traverse to the previous header
-                let header_info = store
-                    .get_header(&current_header.prev_blockhash)
+                // Stop if we reach the initial header.
+                if current_hash == initial_header_hash {
+                    break;
+                }
+
+                // Traverse to the previous header.
+                let prev_blockhash = current_header.prev_blockhash;
+                (current_header, _) = store
+                    .get_header(&prev_blockhash)
                     .expect("previous header should be in the header store");
-                current_header = header_info.0;
-                current_height = header_info.1;
-                current_hash = current_header.prev_blockhash;
+                // Update the current height and hash.
+                current_height -= 1;
+                current_hash = prev_blockhash;
             }
             pow_limit_bits
         }
@@ -262,7 +183,8 @@ fn compute_next_difficulty(
     // returned Regtest network doesn't adjust PoW difficult levels. For
     // regtest, simply return the previous difficulty target
 
-    if (prev_height + 1) % DIFFICULTY_ADJUSTMENT_INTERVAL != 0 || no_pow_retargeting(network) {
+    let height = prev_height + 1;
+    if height % DIFFICULTY_ADJUSTMENT_INTERVAL != 0 || no_pow_retargeting(network) {
         return prev_header.bits;
     }
 
@@ -283,18 +205,17 @@ fn compute_next_difficulty(
     // actual_interval will deviate slightly from 2 weeks. Our goal is to
     // readjust the difficulty target so that the expected time taken for the next
     // 2016 blocks is again 2 weeks.
-    let actual_interval = (prev_header.time as i64) - (last_adjustment_time as i64);
+    let actual_interval = prev_header.time - last_adjustment_time;
 
     // The target_adjustment_interval_time is 2 weeks of time expressed in seconds
-    let target_adjustment_interval_time: i64 =
-        (DIFFICULTY_ADJUSTMENT_INTERVAL * TEN_MINUTES) as i64;
+    let target_adjustment_interval_time: u32 = DIFFICULTY_ADJUSTMENT_INTERVAL * TEN_MINUTES; //Number of seconds in 2 weeks
 
     // Adjusting the actual_interval to [0.5 week, 8 week] range in case the
     // actual_interval deviates too much from the expected 2 weeks.
     let adjusted_interval = actual_interval.clamp(
         target_adjustment_interval_time / 4,
         target_adjustment_interval_time * 4,
-    ) as u32;
+    );
 
     // Computing new difficulty target.
     // new difficulty target = old difficult target * (adjusted_interval /
@@ -321,8 +242,7 @@ mod test {
 
     use super::*;
     use crate::constants::test::{
-        MAINNET_HEADER_11109, MAINNET_HEADER_11110, MAINNET_HEADER_11111, MAINNET_HEADER_586656,
-        MAINNET_HEADER_705600, MAINNET_HEADER_705601, MAINNET_HEADER_705602,
+        MAINNET_HEADER_586656, MAINNET_HEADER_705600, MAINNET_HEADER_705601, MAINNET_HEADER_705602,
         TESTNET_HEADER_2132555, TESTNET_HEADER_2132556,
     };
 
@@ -335,12 +255,14 @@ mod test {
     struct SimpleHeaderStore {
         headers: HashMap<BlockHash, StoredHeader>,
         height: BlockHeight,
+        tip_hash: BlockHash,
         initial_hash: BlockHash,
     }
 
     impl SimpleHeaderStore {
         fn new(initial_header: BlockHeader, height: BlockHeight) -> Self {
             let initial_hash = initial_header.block_hash();
+            let tip_hash = initial_header.block_hash();
             let mut headers = HashMap::new();
             headers.insert(
                 initial_hash,
@@ -353,6 +275,7 @@ mod test {
             Self {
                 headers,
                 height,
+                tip_hash,
                 initial_hash,
             }
         }
@@ -369,6 +292,7 @@ mod test {
 
             self.height = stored_header.height;
             self.headers.insert(header.block_hash(), stored_header);
+            self.tip_hash = header.block_hash();
         }
     }
 
@@ -377,10 +301,6 @@ mod test {
             self.headers
                 .get(hash)
                 .map(|stored| (stored.header, stored.height))
-        }
-
-        fn get_height(&self) -> BlockHeight {
-            self.height
         }
 
         fn get_initial_hash(&self) -> BlockHash {
@@ -394,8 +314,6 @@ mod test {
     }
 
     /// This function reads `num_headers` headers from `tests/data/headers.csv`
-    /// and returns them.
-    /// This function reads `num_headers` headers from `blockchain_headers.csv`
     /// and returns them.
     fn get_bitcoin_headers() -> Vec<BlockHeader> {
         let rdr = Reader::from_path(
@@ -418,17 +336,6 @@ mod test {
             headers.push(header);
         }
         headers
-    }
-
-    fn genesis_header(bits: u32) -> BlockHeader {
-        BlockHeader {
-            version: 1,
-            prev_blockhash: Default::default(),
-            merkle_root: Default::default(),
-            time: 1296688602,
-            bits,
-            nonce: 0,
-        }
     }
 
     #[test]
@@ -467,39 +374,6 @@ mod test {
     }
 
     #[test]
-    fn test_is_timestamp_valid() {
-        let header_705600 = deserialize_header(MAINNET_HEADER_705600);
-        let header_705601 = deserialize_header(MAINNET_HEADER_705601);
-        let header_705602 = deserialize_header(MAINNET_HEADER_705602);
-        let mut store = SimpleHeaderStore::new(header_705600, 705_600);
-        store.add(header_705601);
-        store.add(header_705602);
-
-        let mut header = BlockHeader {
-            version: 0x20800004,
-            prev_blockhash: BlockHash::from_hex(
-                "00000000000000000001eea12c0de75000c2546da22f7bf42d805c1d2769b6ef",
-            )
-            .unwrap(),
-            merkle_root: TxMerkleNode::from_hex(
-                "c120ff2ae1363593a0b92e0d281ec341a0cc989b4ee836dc3405c9f4215242a6",
-            )
-            .unwrap(),
-            time: 1634590600,
-            bits: 0x170e0408,
-            nonce: 0xb48e8b0a,
-        };
-        assert!(is_timestamp_valid(&store, &header));
-
-        // Monday, October 18, 2021 20:26:40
-        header.time = 1634588800;
-        assert!(!is_timestamp_valid(&store, &header));
-
-        let result = validate_header(&Network::Bitcoin, &store, &header);
-        assert!(matches!(result, Err(ValidateHeaderError::HeaderIsOld)));
-    }
-
-    #[test]
     fn test_is_header_valid_missing_prev_header() {
         let header_705600 = deserialize_header(MAINNET_HEADER_705600);
         let header_705602 = deserialize_header(MAINNET_HEADER_705602);
@@ -508,82 +382,6 @@ mod test {
         assert!(matches!(
             result,
             Err(ValidateHeaderError::PrevHeaderNotFound)
-        ));
-    }
-
-    #[test]
-    fn test_is_header_valid_checkpoint_valid_at_height() {
-        let network = Network::Bitcoin;
-        let header_11110 = deserialize_header(MAINNET_HEADER_11110);
-        let mut header_11111 = deserialize_header(MAINNET_HEADER_11111);
-        let store = SimpleHeaderStore::new(header_11110, 11110);
-        let (_, prev_height) = store.get_header(&header_11111.prev_blockhash).unwrap();
-
-        assert!(is_checkpoint_valid(
-            &network,
-            prev_height,
-            &header_11111,
-            store.get_height()
-        ));
-
-        // Change time to slightly modify the block hash to make it invalid for the
-        // checkpoint.
-        header_11111.time -= 1;
-
-        let result = validate_header(&network, &store, &header_11111);
-        assert!(matches!(
-            result,
-            Err(ValidateHeaderError::DoesNotMatchCheckpoint)
-        ));
-    }
-
-    #[test]
-    fn test_is_header_valid_checkpoint_valid_detect_fork_around_11111() {
-        let network = Network::Bitcoin;
-        let header_11109 = deserialize_header(MAINNET_HEADER_11109);
-        let header_11110 = deserialize_header(MAINNET_HEADER_11110);
-        let header_11111 = deserialize_header(MAINNET_HEADER_11111);
-        // Make a header for height 11110 that would cause a fork.
-        let mut bad_header_11110 = header_11110;
-        bad_header_11110.time -= 1;
-
-        let mut store = SimpleHeaderStore::new(header_11109, 11109);
-        store.add(header_11110);
-
-        let (_, prev_height) = store.get_header(&header_11111.prev_blockhash).unwrap();
-
-        assert!(is_checkpoint_valid(
-            &network,
-            prev_height,
-            &header_11111,
-            store.get_height()
-        ));
-
-        store.add(header_11111);
-
-        // This should return false as bad_header_11110 is a fork.
-        let (_, prev_height) = store.get_header(&header_11111.prev_blockhash).unwrap();
-        assert!(!is_checkpoint_valid(
-            &network,
-            prev_height,
-            &bad_header_11110,
-            store.get_height()
-        ));
-    }
-
-    #[test]
-    fn test_is_header_valid_checkpoint_valid_detect_fork_around_705600() {
-        let network = Network::Bitcoin;
-        let header_705600 = deserialize_header(MAINNET_HEADER_705600);
-        let header_705601 = deserialize_header(MAINNET_HEADER_705601);
-        let store = SimpleHeaderStore::new(header_705600, 705_600);
-        let (_, prev_height) = store.get_header(&header_705601.prev_blockhash).unwrap();
-
-        assert!(is_checkpoint_valid(
-            &network,
-            prev_height,
-            &header_705601,
-            store.get_height()
         ));
     }
 
@@ -602,10 +400,16 @@ mod test {
 
     #[test]
     fn test_is_header_valid_invalid_computed_target() {
-        let header_705600 = deserialize_header(MAINNET_HEADER_705600);
-        let header = deserialize_header(MAINNET_HEADER_705601);
-        let store = SimpleHeaderStore::new(header_705600, 705_600);
-        let result = validate_header(&Network::Regtest, &store, &header);
+        let pow_bitcoin = pow_limit_bits(&Network::Bitcoin);
+        let pow_regtest = pow_limit_bits(&Network::Regtest);
+        let h0 = genesis_header(pow_bitcoin);
+        let h1 = next_block_header(h0, pow_regtest);
+        let h2 = next_block_header(h1, pow_regtest);
+        let h3 = next_block_header(h2, pow_regtest);
+        let mut store = SimpleHeaderStore::new(h0, 0);
+        store.add(h1);
+        store.add(h2);
+        let result = validate_header(&Network::Regtest, &store, &h3);
         assert!(matches!(
             result,
             Err(ValidateHeaderError::InvalidPoWForComputedTarget)
@@ -625,69 +429,72 @@ mod test {
         ));
     }
 
-    #[test]
-    fn test_is_header_within_one_year_of_tip_next_height_is_above_the_minimum() {
-        assert!(
-            is_header_within_one_year_of_tip(700_000, 650_000),
-            "next height is above the one year minimum"
-        );
-        assert!(
-            is_header_within_one_year_of_tip(700_000, 750_000),
-            "next height is within the one year range"
-        );
-        assert!(
-            !is_header_within_one_year_of_tip(700_000, 800_000),
-            "next height is below the one year minimum"
-        );
+    fn genesis_header(bits: u32) -> BlockHeader {
+        BlockHeader {
+            version: 1,
+            prev_blockhash: Default::default(),
+            merkle_root: Default::default(),
+            time: 1296688602,
+            bits,
+            nonce: 0,
+        }
     }
 
-    #[test]
-    #[should_panic(expected = "next height causes an overflow")]
-    fn test_is_header_within_one_year_of_tip_should_panic_as_next_height_is_too_high() {
-        is_header_within_one_year_of_tip(BlockHeight::MAX, 0);
+    fn next_block_header(prev: BlockHeader, bits: u32) -> BlockHeader {
+        BlockHeader {
+            prev_blockhash: prev.block_hash(),
+            time: prev.time + TEN_MINUTES,
+            bits,
+            ..prev
+        }
     }
 
-    #[test]
-    fn test_is_header_within_one_year_of_tip_chain_height_is_less_than_one_year() {
-        assert!(
-            is_header_within_one_year_of_tip(1, 0),
-            "chain height is less than one year"
-        );
-        assert!(
-            is_header_within_one_year_of_tip(1, BLOCKS_IN_ONE_YEAR + 2),
-            "chain height difference is exactly one year"
-        );
-        assert!(
-            !is_header_within_one_year_of_tip(1, BLOCKS_IN_ONE_YEAR + 3),
-            "chain height difference is one year + 1 block"
-        );
-    }
+    /// Creates a chain of headers with the given length and
+    /// proof of work for the first header.
+    fn create_chain(
+        network: &Network,
+        initial_pow: u32,
+        chain_length: u32,
+    ) -> (SimpleHeaderStore, BlockHeader) {
+        let pow_limit = pow_limit_bits(network);
+        let h0 = genesis_header(initial_pow);
+        let mut store = SimpleHeaderStore::new(h0, 0);
+        let mut last_header = h0;
 
-    #[test]
-    fn test_compute_next_difficulty_for_backdated_blocks() {
-        // Arrange: Set up the test network and parameters
-        let network = Network::Testnet;
-        let chain_length = DIFFICULTY_ADJUSTMENT_INTERVAL - 1; // To trigger the difficulty adjustment.
-        let genesis_difficulty = 486604799;
-
-        // Create the genesis header and initialize the header store
-        let genesis_header = genesis_header(genesis_difficulty);
-        let mut store = SimpleHeaderStore::new(genesis_header, 0);
-        let mut last_header = genesis_header;
         for _ in 1..chain_length {
-            let new_header = BlockHeader {
-                prev_blockhash: last_header.block_hash(),
-                time: last_header.time - 1, // Each new block is 1 second earlier
-                ..last_header
-            };
+            let new_header = next_block_header(last_header, pow_limit);
             store.add(new_header);
             last_header = new_header;
         }
 
-        // Act.
-        let difficulty = compute_next_difficulty(&network, &store, &last_header, chain_length);
+        (store, last_header)
+    }
 
-        // Assert.
-        assert_eq!(difficulty, 473956288);
+    #[test]
+    fn test_next_target_regtest() {
+        // This test checks the chain of headers of different lengths
+        // with non-limit PoW in the first block header and PoW limit
+        // in all the other headers.
+        // Expect difficulty to be equal to the non-limit PoW.
+
+        // Arrange.
+        let network = Network::Regtest;
+        let expected_pow = 7; // Some non-limit PoW, the actual value is not important.
+        for chain_length in 1..10 {
+            let (store, last_header) = create_chain(&network, expected_pow, chain_length);
+            // Act.
+            let compact_target = get_next_target(
+                &network,
+                &store,
+                &last_header,
+                chain_length - 1,
+                last_header.time + TEN_MINUTES,
+            );
+            // Assert.
+            assert_eq!(
+                compact_target,
+                BlockHeader::u256_from_compact_target(expected_pow)
+            );
+        }
     }
 }

--- a/rs/bitcoin/validation/src/header.rs
+++ b/rs/bitcoin/validation/src/header.rs
@@ -205,17 +205,18 @@ fn compute_next_difficulty(
     // actual_interval will deviate slightly from 2 weeks. Our goal is to
     // readjust the difficulty target so that the expected time taken for the next
     // 2016 blocks is again 2 weeks.
-    let actual_interval = prev_header.time - last_adjustment_time;
+    let actual_interval = (prev_header.time as i64) - (last_adjustment_time as i64);
 
     // The target_adjustment_interval_time is 2 weeks of time expressed in seconds
-    let target_adjustment_interval_time: u32 = DIFFICULTY_ADJUSTMENT_INTERVAL * TEN_MINUTES; //Number of seconds in 2 weeks
+    let target_adjustment_interval_time: i64 =
+        (DIFFICULTY_ADJUSTMENT_INTERVAL * TEN_MINUTES) as i64; //Number of seconds in 2 weeks
 
     // Adjusting the actual_interval to [0.5 week, 8 week] range in case the
     // actual_interval deviates too much from the expected 2 weeks.
     let adjusted_interval = actual_interval.clamp(
         target_adjustment_interval_time / 4,
         target_adjustment_interval_time * 4,
-    );
+    ) as u32;
 
     // Computing new difficulty target.
     // new difficulty target = old difficult target * (adjusted_interval /
@@ -496,5 +497,33 @@ mod test {
                 BlockHeader::u256_from_compact_target(expected_pow)
             );
         }
+    }
+
+    #[test]
+    fn test_compute_next_difficulty_for_backdated_blocks() {
+        // Arrange: Set up the test network and parameters
+        let network = Network::Testnet;
+        let chain_length = DIFFICULTY_ADJUSTMENT_INTERVAL - 1; // To trigger the difficulty adjustment.
+        let genesis_difficulty = 486604799;
+
+        // Create the genesis header and initialize the header store
+        let genesis_header = genesis_header(genesis_difficulty);
+        let mut store = SimpleHeaderStore::new(genesis_header, 0);
+        let mut last_header = genesis_header;
+        for _ in 1..chain_length {
+            let new_header = BlockHeader {
+                prev_blockhash: last_header.block_hash(),
+                time: last_header.time - 1, // Each new block is 1 second earlier
+                ..last_header
+            };
+            store.add(new_header);
+            last_header = new_header;
+        }
+
+        // Act.
+        let difficulty = compute_next_difficulty(&network, &store, &last_header, chain_length);
+
+        // Assert.
+        assert_eq!(difficulty, 473956288);
     }
 }

--- a/rs/bitcoin/validation/src/lib.rs
+++ b/rs/bitcoin/validation/src/lib.rs
@@ -1,8 +1,6 @@
 mod constants;
 mod header;
 
-pub use crate::header::{
-    is_beyond_last_checkpoint, validate_header, HeaderStore, ValidateHeaderError,
-};
+pub use crate::header::{validate_header, HeaderStore, ValidateHeaderError};
 
 type BlockHeight = u32;


### PR DESCRIPTION
This PR removes all checks regarding the timestamp of the header in the bitcoin adapter.

This is meant to simplify the header validation itself, as the checks are anyway made in the bitcoin canister. 

The main check that remains is the PoW check, which is by far the hardest to "abuse". 

Note that checks such as:

- has this header already been seen
- Is the "previous header" not in the store 

are already made in the adapter. 