### PR TITLE
chore(IDX): don't use template for artifact upload

### DIFF
--- a/ci/src/artifacts/BUILD.bazel
+++ b/ci/src/artifacts/BUILD.bazel
@@ -4,7 +4,7 @@ package(default_visibility = ["//visibility:public"])
 
 exports_files(
     [
-        "upload.bash.template",
+        "upload.sh",
     ],
 )
 

--- a/ci/src/artifacts/upload.bzl
+++ b/ci/src/artifacts/upload.bzl
@@ -10,28 +10,12 @@ def _upload_artifact_impl(ctx):
     Uploads an artifact to s3 and returns download link to it
     """
 
-    uploader = ctx.actions.declare_file(ctx.label.name + "_uploader")
-
     rclone_config = ctx.file.rclone_config
     rclone_endpoint = ctx.attr._s3_endpoint[BuildSettingInfo].value
     if rclone_endpoint != "":
         rclone_config = ctx.file.rclone_anon_config
 
     s3_upload = ctx.attr._s3_upload[BuildSettingInfo].value
-
-    ctx.actions.expand_template(
-        template = ctx.file._artifacts_uploader_template,
-        output = uploader,
-        substitutions = {
-            "@@RCLONE@@": ctx.file._rclone.path,
-            "@@RCLONE_CONFIG@@": rclone_config.path,
-            "@@REMOTE_SUBDIR@@": ctx.attr.remote_subdir,
-            "@@VERSION_FILE@@": ctx.version_file.path,
-            "@@VERSION_TXT@@": ctx.file._version_txt.path,
-            "@@FAKE_IC_VERSION@@": FAKE_IC_VERSION,
-        },
-        is_executable = True,
-    )
 
     out = []
 
@@ -58,10 +42,16 @@ def _upload_artifact_impl(ctx):
         url = ctx.actions.declare_file(filename + ".url")
         proxy_cache_url = ctx.actions.declare_file(filename + ".proxy-cache-url")
         ctx.actions.run(
-            executable = uploader,
+            executable = ctx.file._artifacts_uploader,
             arguments = [f.path, url.path, proxy_cache_url.path],
             env = {
                 "RCLONE_S3_ENDPOINT": rclone_endpoint,
+                "RCLONE": ctx.file._rclone.path,
+                "RCLONE_CONFIG": rclone_config.path,
+                "REMOTE_SUBDIR": ctx.attr.remote_subdir,
+                "VERSION_FILE": ctx.version_file.path,
+                "VERSION_TXT": ctx.file._version_txt.path,
+                "FAKE_IC_VERSION": FAKE_IC_VERSION,
             },
             inputs = [f, ctx.version_file, rclone_config, ctx.file._version_txt],
             outputs = [url, proxy_cache_url],
@@ -92,7 +82,7 @@ _upload_artifacts = rule(
         "rclone_config": attr.label(allow_single_file = True, default = "//:.rclone.conf"),
         "rclone_anon_config": attr.label(allow_single_file = True, default = "//:.rclone-anon.conf"),
         "_rclone": attr.label(allow_single_file = True, default = "@rclone//:rclone"),
-        "_artifacts_uploader_template": attr.label(allow_single_file = True, default = ":upload.bash.template"),
+        "_artifacts_uploader": attr.label(allow_single_file = True, default = ":upload.sh"),
         "_version_txt": attr.label(allow_single_file = True, default = "//bazel:version.txt"),
         "_s3_endpoint": attr.label(default = ":s3_endpoint"),
         "_s3_upload": attr.label(default = ":s3_upload"),

--- a/ci/src/artifacts/upload.sh
+++ b/ci/src/artifacts/upload.sh
@@ -10,11 +10,11 @@ do
             export HOME="$v"
             ;;
     esac
-done < "@@VERSION_FILE@@"
+done < "$VERSION_FILE"
 
-VERSION="$(cat @@VERSION_TXT@@)"
+VERSION="$(cat $VERSION_TXT)"
 
-if [ "${VERSION}" == "@@FAKE_IC_VERSION@@" ]
+if [ "${VERSION}" == "$FAKE_IC_VERSION" ]
 then
     echo "Attempt to upload an artifacts with fake ic version: ${VERSION}" >&2
     exit 1
@@ -44,28 +44,28 @@ if [ -d /opt/namespace ]; then
 fi
 
 # Multipart upload does not work trough the proxy for some reasons. Just disabling it for now.
-"@@RCLONE@@" \
-    --config="@@RCLONE_CONFIG@@" \
+"$RCLONE" \
+    --config="$RCLONE_CONFIG" \
     --stats-one-line \
     --checksum \
     --immutable \
     --s3-upload-cutoff=5G \
     copy \
     "$f" \
-    "public-s3:dfinity-download-public/ic/${VERSION}/@@REMOTE_SUBDIR@@/"
+    "public-s3:dfinity-download-public/ic/${VERSION}/$REMOTE_SUBDIR/"
 
 # Upload to Cloudflare's R2 (S3)
 unset RCLONE_S3_ENDPOINT
-AWS_PROFILE=cf "@@RCLONE@@" \
-    --config="@@RCLONE_CONFIG@@" \
+AWS_PROFILE=cf "$RCLONE" \
+    --config="$RCLONE_CONFIG" \
     --stats-one-line \
     --checksum \
     --immutable \
     --s3-upload-cutoff=5G \
     copy \
     "$f" \
-    "public-s3-cf:dfinity-download-public/ic/${VERSION}/@@REMOTE_SUBDIR@@/"
+    "public-s3-cf:dfinity-download-public/ic/${VERSION}/$REMOTE_SUBDIR/"
 
-URL_PATH="ic/${VERSION}/@@REMOTE_SUBDIR@@/$(basename $f)"
+URL_PATH="ic/${VERSION}/$REMOTE_SUBDIR/$(basename $f)"
 echo "https://download.dfinity.systems/${URL_PATH}" > "$2"
 echo "http://download.proxy-global.dfinity.network:8080/${URL_PATH}" > "$3"

--- a/ci/src/artifacts/upload.sh
+++ b/ci/src/artifacts/upload.sh
@@ -2,27 +2,25 @@
 
 set -eEuo pipefail
 
-while read -r k v
-do
+while read -r k v; do
     case "$k" in
         HOME)
             # Required by rclone to get credentials from $HOME/.aws/credentials
             export HOME="$v"
             ;;
     esac
-done < "$VERSION_FILE"
+done <"$VERSION_FILE"
 
 VERSION="$(cat $VERSION_TXT)"
 
-if [ "${VERSION}" == "$FAKE_IC_VERSION" ]
-then
+if [ "${VERSION}" == "$FAKE_IC_VERSION" ]; then
     echo "Attempt to upload an artifacts with fake ic version: ${VERSION}" >&2
     exit 1
 fi
 # rclone reads the $(dirname $f) to get file attribuates.
 # Therefore symlink should be resolved.
 f="$1"
-if [ -L "$f" ];then
+if [ -L "$f" ]; then
     f=$(readlink "$f")
 fi
 
@@ -67,5 +65,5 @@ AWS_PROFILE=cf "$RCLONE" \
     "public-s3-cf:dfinity-download-public/ic/${VERSION}/$REMOTE_SUBDIR/"
 
 URL_PATH="ic/${VERSION}/$REMOTE_SUBDIR/$(basename $f)"
-echo "https://download.dfinity.systems/${URL_PATH}" > "$2"
-echo "http://download.proxy-global.dfinity.network:8080/${URL_PATH}" > "$3"
+echo "https://download.dfinity.systems/${URL_PATH}" >"$2"
+echo "http://download.proxy-global.dfinity.network:8080/${URL_PATH}" >"$3"


### PR DESCRIPTION
This skips the template variable substition for the artifact uploader, using env vars instead. This simplifies the setup and allows the upload script to be called directly (provided the env is set correctly).