### PR TITLE
chore(IDX): introduce the pocket_ic_test macro

### DIFF
--- a/packages/pocket-ic/BUILD.bazel
+++ b/packages/pocket-ic/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test", "rust_test_suite")
+load("//bazel:pocket-ic-tests.bzl", "pocket_ic_test")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -68,46 +69,41 @@ rust_test(
     deps = [":pocket-ic"] + DEPENDENCIES + TEST_DEPENDENCIES,
 )
 
-rust_test_suite(
+pocket_ic_test(
     name = "test",
     size = "medium",
     srcs = ["tests/tests.rs"],
     data = [
         "//packages/pocket-ic/test_canister:test_canister.wasm",
-        "//rs/pocket_ic_server:pocket-ic-server",
         "@mozilla_root_ca_store//file",
     ],
     env = {
         "RUST_TEST_THREADS": "2",
-        "POCKET_IC_BIN": "$(rootpath //rs/pocket_ic_server:pocket-ic-server)",
         "SSL_CERT_FILE": "$(rootpath @mozilla_root_ca_store//file)",
         "TEST_WASM": "$(rootpath //packages/pocket-ic/test_canister:test_canister.wasm)",
     },
     flaky = False,
+    macro = rust_test_suite,
     proc_macro_deps = MACRO_DEPENDENCIES,
     tags = [
         "cpu:16",
-        # TODO: remove 'requires-network' tag when the root cause for sporadic error below on Apple Silicon is identified and fixed.
-        # Failed to crate http gateway: Failed to bind to address 127.0.0.1:0: Operation not permitted (os error 1)
-        "requires-network",
         "test_macos",
     ],
     deps = [":pocket-ic"] + DEPENDENCIES + TEST_DEPENDENCIES,
 )
 
-rust_test_suite(
+pocket_ic_test(
     name = "restart",
     size = "medium",
     srcs = ["tests/restart.rs"],
     data = [
-        "//rs/pocket_ic_server:pocket-ic-server",
         "@mozilla_root_ca_store//file",
     ],
     env = {
-        "POCKET_IC_BIN": "$(rootpath //rs/pocket_ic_server:pocket-ic-server)",
         "SSL_CERT_FILE": "$(rootpath @mozilla_root_ca_store//file)",
     },
     flaky = False,
+    macro = rust_test_suite,
     proc_macro_deps = MACRO_DEPENDENCIES,
     tags = [
         # TODO: remove 'requires-network' tag when the root cause for sporadic error below on Apple Silicon is identified and fixed.
@@ -118,27 +114,23 @@ rust_test_suite(
     deps = [":pocket-ic"] + DEPENDENCIES + TEST_DEPENDENCIES,
 )
 
-rust_test_suite(
+pocket_ic_test(
     name = "slow",
     size = "medium",
     srcs = ["tests/slow.rs"],
     data = [
         "//packages/pocket-ic/test_canister:test_canister.wasm",
-        "//rs/pocket_ic_server:pocket-ic-server",
         "@mozilla_root_ca_store//file",
     ],
     env = {
-        "POCKET_IC_BIN": "$(rootpath //rs/pocket_ic_server:pocket-ic-server)",
         "SSL_CERT_FILE": "$(rootpath @mozilla_root_ca_store//file)",
         "TEST_WASM": "$(rootpath //packages/pocket-ic/test_canister:test_canister.wasm)",
     },
     flaky = False,
+    macro = rust_test_suite,
     proc_macro_deps = MACRO_DEPENDENCIES,
     tags = [
         "cpu:16",
-        # TODO: remove 'requires-network' tag when the root cause for sporadic error below on Apple Silicon is identified and fixed.
-        # Failed to crate http gateway: Failed to bind to address 127.0.0.1:0: Operation not permitted (os error 1)
-        "requires-network",
         "test_macos",
     ],
     deps = [":pocket-ic"] + DEPENDENCIES + TEST_DEPENDENCIES,

--- a/rs/bitcoin/checker/BUILD.bazel
+++ b/rs/bitcoin/checker/BUILD.bazel
@@ -1,6 +1,7 @@
 load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test")
 load("//bazel:canisters.bzl", "rust_canister")
 load("//bazel:defs.bzl", "rust_ic_test")
+load("//bazel:pocket-ic-tests.bzl", "pocket_ic_test")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -81,7 +82,7 @@ rust_canister(
     ],
 )
 
-rust_ic_test(
+pocket_ic_test(
     name = "integration_tests",
     srcs = ["tests/tests.rs"],
     data = [
@@ -91,13 +92,12 @@ rust_ic_test(
     env = {
         "CARGO_MANIFEST_DIR": "rs/bitcoin/checker",
         "IC_BTC_CHECKER_CANISTER_WASM_PATH": "$(rootpath :btc_checker_canister)",
-        "POCKET_IC_BIN": "$(rootpath //:pocket-ic-server)",
         "UNIVERSAL_CANISTER_WASM_PATH": "$(rootpath //rs/universal_canister/impl:universal_canister.wasm.gz)",
     },
+    macro = rust_ic_test,
     deps = [
         # Keep sorted.
         ":btc_checker_lib",
-        "//:pocket-ic-server",
         "//packages/pocket-ic",
         "//rs/rust_canisters/http_types",
         "//rs/test_utilities/load_wasm",

--- a/rs/boundary_node/rate_limits/integration_tests/BUILD.bazel
+++ b/rs/boundary_node/rate_limits/integration_tests/BUILD.bazel
@@ -1,5 +1,6 @@
 load("@rules_rust//rust:defs.bzl", "rust_library")
 load("//bazel:defs.bzl", "rust_test_suite_with_extra_srcs")
+load("//bazel:pocket-ic-tests.bzl", "pocket_ic_test")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -36,7 +37,6 @@ ALIASES = {}
 DEV_DATA = [
     "@mainnet_nns_registry_canister//file",
     "//rs/registry/canister:registry-canister",
-    "//rs/pocket_ic_server:pocket-ic-server",
     "//rs/boundary_node/rate_limits:rate_limit_canister",
 ]
 
@@ -44,7 +44,6 @@ DEV_ENV = {
     "CARGO_MANIFEST_DIR": "rs/nns/integration_tests",
     "REGISTRY_CANISTER_WASM_PATH": "$(rootpath //rs/registry/canister:registry-canister)",
     "MAINNET_REGISTRY_CANISTER_WASM_PATH": "$(rootpath @mainnet_nns_registry_canister//file)",
-    "POCKET_IC_BIN": "$(rootpath //rs/pocket_ic_server:pocket-ic-server)",
     "RATE_LIMITS_CANISTER_WASM_PATH": "$(rootpath //rs/boundary_node/rate_limits:rate_limit_canister)",
 }
 
@@ -58,7 +57,7 @@ rust_library(
     deps = DEPENDENCIES,
 )
 
-rust_test_suite_with_extra_srcs(
+pocket_ic_test(
     name = "integration_tests_test",
     srcs = glob(
         ["tests/**/*.rs"],
@@ -68,6 +67,7 @@ rust_test_suite_with_extra_srcs(
     env = DEV_ENV,
     extra_srcs = [],
     flaky = False,
+    macro = rust_test_suite_with_extra_srcs,
     proc_macro_deps = MACRO_DEPENDENCIES + MACRO_DEV_DEPENDENCIES,
     tags = [],
     deps = [":rate_limit_canister_integration_tests"] + DEPENDENCIES + DEV_DEPENDENCIES,

--- a/rs/ledger_suite/icp/BUILD.bazel
+++ b/rs/ledger_suite/icp/BUILD.bazel
@@ -4,6 +4,7 @@ load("//bazel:candid.bzl", "did_git_test")
 load("//bazel:canisters.bzl", "rust_canister")
 load("//bazel:defs.bzl", "rust_ic_test_suite")
 load("//bazel:prost.bzl", "generated_files_check")
+load("//bazel:pocket-ic-tests.bzl", "pocket_ic_test")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -90,7 +91,7 @@ rust_canister(
     ],
 )
 
-rust_ic_test_suite(
+pocket_ic_test(
     name = "ledger_canister_integration_test",
     timeout = "long",
     srcs = [
@@ -106,7 +107,6 @@ rust_ic_test_suite(
         "//rs/ledger_suite/icp/index:ic-icp-index-canister",
         "//rs/ledger_suite/icp/ledger:ledger-canister-wasm",
         "//rs/ledger_suite/icp/ledger:ledger-canister-wasm-notify-method",
-        "//rs/pocket_ic_server:pocket-ic-server",
         "@mainnet_icp_index_canister//file",
         "@mainnet_icp_ledger-archive-node-canister//file",
         "@mainnet_icp_ledger_canister//file",
@@ -121,9 +121,9 @@ rust_ic_test_suite(
         "MAINNET_ICP_INDEX_CANISTER_WASM_PATH": "$(rootpath @mainnet_icp_index_canister//file)",
         "MAINNET_ICP_LEDGER_ARCHIVE_NODE_CANISTER_WASM_PATH": "$(rootpath @mainnet_icp_ledger-archive-node-canister//file)",
         "MAINNET_ICP_LEDGER_CANISTER_WASM_PATH": "$(rootpath @mainnet_icp_ledger_canister//file)",
-        "POCKET_IC_BIN": "$(rootpath //rs/pocket_ic_server:pocket-ic-server)",
         "TEST_NOTIFIED_WASM_PATH": "$(rootpath :test_notified_canister)",
     },
+    macro = rust_ic_test_suite,
     deps = [
         # Keep sorted.
         ":icp_ledger",

--- a/rs/ledger_suite/icp/archive/BUILD.bazel
+++ b/rs/ledger_suite/icp/archive/BUILD.bazel
@@ -1,6 +1,7 @@
 load("@rules_rust//rust:defs.bzl", "rust_test")
 load("//bazel:canisters.bzl", "rust_canister")
 load("//bazel:defs.bzl", "rust_ic_test")
+load("//bazel:pocket-ic-tests.bzl", "pocket_ic_test")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -48,18 +49,17 @@ rust_test(
     deps = ["@crate_index//:candid_parser"],
 )
 
-rust_ic_test(
+pocket_ic_test(
     name = "ledger_archive_node_canister_integration",
     srcs = ["tests/tests.rs"],
     data = [
         "//rs/ledger_suite/icp/archive:ledger-archive-node-canister-wasm",
-        "//rs/pocket_ic_server:pocket-ic-server",
     ],
     env = {
         "CARGO_MANIFEST_DIR": "rs/ledger_suite/icp/archive",
         "LEDGER_ARCHIVE_NODE_CANISTER_WASM_PATH": "$(rootpath //rs/ledger_suite/icp/archive:ledger-archive-node-canister-wasm)",
-        "POCKET_IC_BIN": "$(rootpath //rs/pocket_ic_server:pocket-ic-server)",
     },
+    macro = rust_ic_test,
     deps = [
         # Keep sorted.
         "//packages/pocket-ic",

--- a/rs/nervous_system/integration_tests/BUILD.bazel
+++ b/rs/nervous_system/integration_tests/BUILD.bazel
@@ -93,7 +93,6 @@ DEV_DATA = [
     "//rs/nns/gtc:genesis-token-canister",
     "//rs/nns/handlers/root/impl:root-canister",
     "//rs/nns/sns-wasm:sns-wasm-canister",
-    "//rs/pocket_ic_server:pocket-ic-server",
     "//rs/registry/canister:registry-canister",
     "//rs/rosetta-api/tvl/xrc_mock:xrc_mock_canister",
     "//rs/sns/governance:sns-governance-canister-test",
@@ -147,7 +146,6 @@ DEV_ENV = {
     "MAINNET_SNS_SWAP_CANISTER_WASM_PATH": "$(rootpath @mainnet_sns-swap-canister//file)",
     "ROOT_CANISTER_WASM_PATH": "$(rootpath //rs/nns/handlers/root/impl:root-canister)",
     "XRC_MOCK_WASM_PATH": "$(rootpath //rs/rosetta-api/tvl/xrc_mock:xrc_mock_canister)",
-    "POCKET_IC_BIN": "$(rootpath //rs/pocket_ic_server:pocket-ic-server)",
     "UNIVERSAL_CANISTER_WASM_PATH": "$(rootpath //rs/universal_canister/impl:universal_canister.wasm.gz)",
 }
 
@@ -162,7 +160,8 @@ rust_library(
     deps = DEPENDENCIES_WITH_TEST_FEATURES,
 )
 
-rust_test_suite_with_extra_srcs(
+pocket_ic_test(
+    macro = rust_test_suite_with_extra_srcs,
     name = "integration_tests_test",
     timeout = "long",
     srcs = glob(
@@ -192,7 +191,8 @@ rust_test_suite_with_extra_srcs(
     deps = [":nervous_system_integration_tests"] + DEPENDENCIES_WITH_TEST_FEATURES + DEV_DEPENDENCIES,
 )
 
-rust_test(
+pocket_ic_test(
+    macro = rust_test,
     name = "upgrade_everything_test",
     timeout = "long",
     srcs = [
@@ -211,7 +211,8 @@ rust_test(
     deps = [":nervous_system_integration_tests"] + DEPENDENCIES_WITH_TEST_FEATURES + DEV_DEPENDENCIES,
 )
 
-rust_test(
+pocket_ic_test(
+    macro = rust_test,
     name = "advance_target_version_upgrades_all_canisters_test",
     timeout = "long",
     srcs = [
@@ -228,7 +229,8 @@ rust_test(
     deps = [":nervous_system_integration_tests"] + DEPENDENCIES_WITH_TEST_FEATURES + DEV_DEPENDENCIES,
 )
 
-rust_test(
+pocket_ic_test(
+    macro = rust_test
     name = "upgrade_existing_sns_test",
     timeout = "long",
     srcs = [
@@ -245,7 +247,8 @@ rust_test(
     deps = [":nervous_system_integration_tests"] + DEPENDENCIES_WITH_TEST_FEATURES + DEV_DEPENDENCIES,
 )
 
-rust_test(
+pocket_ic_test(
+    macro = rust_test,
     name = "deploy_fresh_sns_test",
     timeout = "long",
     srcs = [
@@ -262,7 +265,8 @@ rust_test(
     deps = [":nervous_system_integration_tests"] + DEPENDENCIES_WITH_TEST_FEATURES + DEV_DEPENDENCIES,
 )
 
-rust_test(
+pocket_ic_test(
+    macro = rust_test,
     name = "sns_release_qualification_legacy",
     timeout = "long",
     srcs = [

--- a/rs/nns/integration_tests/BUILD.bazel
+++ b/rs/nns/integration_tests/BUILD.bazel
@@ -1,6 +1,7 @@
 load("@rules_rust//rust:defs.bzl", "rust_library")
 load("//bazel:canisters.bzl", "rust_canister")
 load("//bazel:defs.bzl", "rust_ic_test", "rust_ic_test_suite_with_extra_srcs")
+load("//bazel:pocket-ic-tests.bzl", "pocket_ic_test")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -155,7 +156,6 @@ DEV_DATA = [
     "//rs/nns/handlers/lifeline/impl:lifeline_canister",
     "//rs/nns/handlers/root/impl:root-canister",
     "//rs/nns/sns-wasm:sns-wasm-canister",
-    "//rs/pocket_ic_server:pocket-ic-server",
     "//rs/registry/canister:registry-canister",
     "//rs/rosetta-api/tvl/xrc_mock:xrc_mock_canister",
     "//rs/sns/governance:sns-governance-canister",
@@ -184,7 +184,6 @@ DEV_ENV = {
     "GENESIS_TOKEN_CANISTER_WASM_PATH": "$(rootpath //rs/nns/gtc:genesis-token-canister)",
     "CYCLES_MINTING_CANISTER_WASM_PATH": "$(rootpath //rs/nns/cmc:cycles-minting-canister)",
     "MEM_UTILS_TEST_CANISTER_WASM_PATH": "$(rootpath :mem-utils-test-canister)",
-    "POCKET_IC_BIN": "$(rootpath //rs/pocket_ic_server:pocket-ic-server)",
     "GOVERNANCE_MEM_TEST_CANISTER_WASM_PATH": "$(rootpath :governance-mem-test-canister)",
     "CANISTER_PLAYGROUND_CANISTER_WASM_PATH": "$(rootpath :canister-playground-canister)",
     "SNS_WASM_CANISTER_WASM_PATH": "$(rootpath //rs/nns/sns-wasm:sns-wasm-canister)",
@@ -266,7 +265,7 @@ rust_canister(
     ],
 )
 
-rust_ic_test_suite_with_extra_srcs(
+pocket_ic_test(
     name = "integration_tests_test",
     timeout = "long",
     srcs = glob(
@@ -286,13 +285,14 @@ rust_ic_test_suite_with_extra_srcs(
     env = DEV_ENV,
     extra_srcs = ["src/lib.rs"],
     flaky = True,
+    macro = rust_ic_test_suite_with_extra_srcs,
     proc_macro_deps = MACRO_DEPENDENCIES + MACRO_DEV_DEPENDENCIES,
     deps = DEPENDENCIES_WITH_TEST_FEATURES + DEV_DEPENDENCIES,
 )
 
 # To run this test use `bazel test --config=alltests //rs/nns/integration_tests:governance_mem_test`
 # See the .bazelrc for more configuration information.
-rust_ic_test(
+pocket_ic_test(
     name = "governance_mem_test",
     size = "large",
     srcs = [
@@ -303,6 +303,7 @@ rust_ic_test(
     crate_root = "src/governance_mem_test.rs",
     data = DEV_DATA,
     env = DEV_ENV,
+    macro = rust_ic_test,
     proc_macro_deps = MACRO_DEPENDENCIES + MACRO_DEV_DEPENDENCIES,
     tags = ["manual"],
     deps = DEPENDENCIES + DEV_DEPENDENCIES,
@@ -310,7 +311,7 @@ rust_ic_test(
 
 # To run this test use `bazel test --config=alltests //rs/nns/integration_tests:canister_playground` --test_output=all
 # See the .bazelrc for more configuration information.
-rust_ic_test(
+pocket_ic_test(
     name = "canister_playground",
     srcs = [
         "src/canister_playground.rs",
@@ -320,6 +321,7 @@ rust_ic_test(
     crate_root = "src/canister_playground.rs",
     data = DEV_DATA,
     env = DEV_ENV,
+    macro = rust_ic_test,
     proc_macro_deps = MACRO_DEPENDENCIES + MACRO_DEV_DEPENDENCIES,
     tags = ["manual"],
     deps = DEPENDENCIES + DEV_DEPENDENCIES,
@@ -345,7 +347,7 @@ rust_ic_test(
 # at the end.
 #
 # See the .bazelrc for more configuration information.
-rust_ic_test(
+pocket_ic_test(
     name = "copy_inactive_neurons_to_stable_memory_test",
     # This uses on the order of 10 GB of disk space.
     # Therefore, size = "large" is not large enough.
@@ -357,6 +359,7 @@ rust_ic_test(
     crate_root = "src/copy_inactive_neurons_to_stable_memory.rs",
     data = DEV_DATA,
     env = DEV_ENV,
+    macro = rust_ic_test,
     proc_macro_deps = MACRO_DEPENDENCIES + MACRO_DEV_DEPENDENCIES,
     tags = [
         "manual",  # CI should not be downloading nns_state.tar.zst.
@@ -406,7 +409,7 @@ rust_ic_test(
 # is required in order to proceed with upgrading the CMC.
 #
 # TODO: When the plaform supports best-effort requests, make the CMC use that.
-rust_ic_test(
+pocket_ic_test(
     name = "upgrade_canisters_with_golden_nns_state",
     # This uses on the order of 10 GB of disk space.
     # Therefore, size = "large" is not large enough.
@@ -418,6 +421,7 @@ rust_ic_test(
     crate_root = "src/upgrade_canisters_with_golden_nns_state.rs",
     data = DEV_DATA,
     env = DEV_ENV,
+    macro = rust_ic_test,
     proc_macro_deps = MACRO_DEPENDENCIES + MACRO_DEV_DEPENDENCIES,
     tags = [
         "nns_tests_nightly",  # Run this test in the nns-tests-nightly GitHub Action job.

--- a/rs/pocket_ic_server/BUILD.bazel
+++ b/rs/pocket_ic_server/BUILD.bazel
@@ -1,6 +1,7 @@
 load("@rules_rust//cargo:defs.bzl", "cargo_build_script")
 load("@rules_rust//rust:defs.bzl", "rust_binary", "rust_library", "rust_test")
 load("//bazel:defs.bzl", "rust_ic_test")
+load("//bazel:pocket-ic-tests.bzl", "pocket_ic_test")
 
 BUILD_DEPENDENCIES = []
 
@@ -166,7 +167,7 @@ rust_ic_test(
     deps = LIB_DEPENDENCIES + [":build_script"],
 )
 
-rust_test(
+pocket_ic_test(
     name = "test",
     size = "medium",
     srcs = [
@@ -175,18 +176,17 @@ rust_test(
     ],
     aliases = {},
     data = [
-        ":pocket-ic-server",
         "//rs/registry/canister:registry-canister",
         "@ii_dev_canister//file",
         "@mozilla_root_ca_store//file",
     ],
     env = {
         "RUST_TEST_THREADS": "2",
-        "POCKET_IC_BIN": "$(rootpath :pocket-ic-server)",
         "REGISTRY_WASM": "$(rootpath //rs/registry/canister:registry-canister)",
         "II_WASM": "$(rootpath @ii_dev_canister//file)",
         "SSL_CERT_FILE": "$(rootpath @mozilla_root_ca_store//file)",
     },
+    macro = rust_test,
     tags = [
         "cpu:8",
         # TODO: remove 'requires-network' tag when the root cause for sporadic error below on Apple Silicon is identified and fixed.
@@ -205,7 +205,7 @@ rust_test(
     deps = TEST_DEPENDENCIES,
 )
 
-rust_test(
+pocket_ic_test(
     name = "spec_test",
     size = "medium",
     srcs = [
@@ -213,24 +213,23 @@ rust_test(
         "tests/spec_test.rs",
     ],
     data = [
-        ":pocket-ic-server",
         "//rs/tests/httpbin-rs:httpbin",
         "//rs/tests/research:ic-hs",
         "//rs/universal_canister/impl:universal_canister.wasm.gz",
     ],
     env = {
         "HTTPBIN_BIN": "$(rootpath //rs/tests/httpbin-rs:httpbin)",
-        "POCKET_IC_BIN": "$(rootpath :pocket-ic-server)",
         "IC_REF_TEST_ROOT": "rs/tests/research/ic-hs",
         "UNIVERSAL_CANISTER_WASM_PATH": "$(rootpath //rs/universal_canister/impl:universal_canister.wasm.gz)",
     },
+    macro = rust_test,
     tags = [
         "cpu:8",
     ],
     deps = SPEC_TEST_DEPENDENCIES,
 )
 
-rust_test(
+pocket_ic_test(
     name = "bitcoin_integration_tests",
     size = "small",
     srcs = [
@@ -238,19 +237,18 @@ rust_test(
     ],
     aliases = {},
     data = [
-        ":pocket-ic-server",
         "//:bitcoind",
         "@bitcoin_example_canister//file",
         "@btc_canister//file",
         "@mozilla_root_ca_store//file",
     ],
     env = {
-        "POCKET_IC_BIN": "$(rootpath :pocket-ic-server)",
         "BASIC_BITCOIN_WASM": "$(rootpath @bitcoin_example_canister//file)",
         "BITCOIND_BIN": "$(rootpath //:bitcoind)",
         "BTC_WASM": "$(rootpath @btc_canister//file)",
         "SSL_CERT_FILE": "$(rootpath @mozilla_root_ca_store//file)",
     },
+    macro = rust_test,
     tags = [
         # TODO: remove 'requires-network' tag when the root cause for sporadic error below on Apple Silicon is identified and fixed.
         # Failed to crate http gateway: Failed to bind to address 127.0.0.1:0: Operation not permitted (os error 1)

--- a/rs/registry/admin/BUILD.bazel
+++ b/rs/registry/admin/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@rules_rust//rust:defs.bzl", "rust_binary", "rust_test")
+load("//bazel:pocket-ic-tests.bzl", "pocket_ic_test")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -76,7 +77,6 @@ DEV_DEPENDENCIES = [
     # Keep sorted.
     "//packages/pocket-ic",
     "//rs/nervous_system/integration_tests:nervous_system_integration_tests",
-    "//rs/pocket_ic_server:pocket-ic-server",
     "//rs/registry/admin:ic-admin",
 ]
 
@@ -96,7 +96,6 @@ DEV_ENV = {
     "LIFELINE_CANISTER_WASM_PATH": "$(rootpath //rs/nns/handlers/lifeline/impl:lifeline_canister)",
     "SNS_WASM_CANISTER_WASM_PATH": "$(rootpath //rs/nns/sns-wasm:sns-wasm-canister)",
     "ROOT_CANISTER_WASM_PATH": "$(rootpath //rs/nns/handlers/root/impl:root-canister)",
-    "POCKET_IC_BIN": "$(rootpath //rs/pocket_ic_server:pocket-ic-server)",
     "IC_ADMIN_BIN": "$(rootpath //rs/registry/admin:ic-admin)",
 }
 
@@ -118,13 +117,14 @@ rust_test(
     deps = DEPENDENCIES,
 )
 
-rust_test(
+pocket_ic_test(
     name = "integration_tests",
     srcs = glob(["tests/**/*.rs"]),
     aliases = ALIASES,
     data = DEV_DATA,
     env = DEV_ENV,
     flaky = False,
+    macro = rust_test,
     proc_macro_deps = MACRO_DEPENDENCIES,
     deps = DEPENDENCIES + DEV_DEPENDENCIES,
 )

--- a/rs/rosetta-api/icp/BUILD.bazel
+++ b/rs/rosetta-api/icp/BUILD.bazel
@@ -6,6 +6,7 @@ load("@rules_pkg//:pkg.bzl", "pkg_tar")
 load("@rules_pkg//pkg:mappings.bzl", "pkg_attributes", "pkg_mkdirs")
 load("@rules_rust//rust:defs.bzl", "rust_binary", "rust_library", "rust_test")
 load("//bazel:defs.bzl", "rust_test_suite_with_extra_srcs")
+load("//bazel:pocket-ic-tests.bzl", "pocket_ic_test")
 load("//rs/tests:system_tests.bzl", "oci_tar")
 
 package(default_visibility = ["//visibility:public"])
@@ -158,7 +159,7 @@ rust_test_suite_with_extra_srcs(
     deps = DEPENDENCIES + DEV_DEPENDENCIES,
 )
 
-rust_test_suite_with_extra_srcs(
+pocket_ic_test(
     name = "icp_rosetta_system_tests",
     size = "large",
     srcs = [
@@ -171,7 +172,6 @@ rust_test_suite_with_extra_srcs(
         "//rs/nns/governance:governance-canister-test",
         "//rs/nns/handlers/lifeline/impl:lifeline_canister",
         "//rs/nns/handlers/root/impl:root-canister",
-        "//rs/pocket_ic_server:pocket-ic-server",
         "//rs/registry/canister:registry-canister",
         "//rs/replica",
         "//rs/rosetta-api/icp:ic-rosetta-api-rosetta-blocks",
@@ -182,7 +182,6 @@ rust_test_suite_with_extra_srcs(
         "RUST_TEST_THREADS": "4",
         "CANISTER_LAUNCHER": "$(rootpath //rs/canister_sandbox)",
         "LEDGER_CANISTER_NOTIFY_METHOD_WASM_PATH": "$(rootpath //rs/ledger_suite/icp/ledger:ledger-canister-wasm-notify-method)",
-        "POCKET_IC_BIN": "$(rootpath //rs/pocket_ic_server:pocket-ic-server)",
         "REPLICA_BIN": "$(rootpath //rs/replica)",
         "ROSETTA_BIN_PATH": "$(rootpath //rs/rosetta-api/icp:ic-rosetta-api-rosetta-blocks)",
         "SANDBOX_LAUNCHER": "$(rootpath //rs/canister_sandbox:sandbox_launcher)",
@@ -197,6 +196,7 @@ rust_test_suite_with_extra_srcs(
         "tests/system_tests/test_cases/*.rs",
     ]),
     flaky = True,
+    macro = rust_test_suite_with_extra_srcs,
     proc_macro_deps = MACRO_DEV_DEPENDENCIES,
     tags = ["cpu:4"],
     deps = DEV_DEPENDENCIES + DEPENDENCIES,

--- a/rs/rosetta-api/icp/client/BUILD.bazel
+++ b/rs/rosetta-api/icp/client/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test")
+load("//bazel:pocket-ic-tests.bzl", "pocket_ic_test")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -42,24 +43,23 @@ rust_library(
     deps = DEPENDENCIES,
 )
 
-rust_test(
+pocket_ic_test(
     name = "ic-icp-rosetta-client-tests",
     srcs = ["tests/tests.rs"],
     data = [
         "//rs/canister_sandbox",
         "//rs/canister_sandbox:sandbox_launcher",
         "//rs/ledger_suite/icp/ledger:ledger-canister-wasm-notify-method",
-        "//rs/pocket_ic_server:pocket-ic-server",
         "//rs/replica",
         "//rs/rosetta-api/icp:ic-rosetta-api-rosetta-blocks",
     ],
     env = {
         "CANISTER_LAUNCHER": "$(rootpath //rs/canister_sandbox)",
-        "POCKET_IC_BIN": "$(rootpath //rs/pocket_ic_server:pocket-ic-server)",
         "REPLICA_BIN": "$(rootpath //rs/replica)",
         "ROSETTA_BIN_PATH": "$(rootpath //rs/rosetta-api/icp:ic-rosetta-api-rosetta-blocks)",
         "SANDBOX_LAUNCHER": "$(rootpath //rs/canister_sandbox:sandbox_launcher)",
         "LEDGER_CANISTER_NOTIFY_METHOD_WASM_PATH": "$(rootpath //rs/ledger_suite/icp/ledger:ledger-canister-wasm-notify-method)",
     },
+    macro = rust_test,
     deps = DEV_DEPENDENCIES,
 )

--- a/rs/rosetta-api/icp/runner/BUILD.bazel
+++ b/rs/rosetta-api/icp/runner/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test")
+load("//bazel:pocket-ic-tests.bzl", "pocket_ic_test")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -15,25 +16,24 @@ rust_library(
     ],
 )
 
-rust_test(
+pocket_ic_test(
     name = "ic-icp-rosetta-runner-tests",
     srcs = ["tests/tests.rs"],
     data = [
         "//rs/canister_sandbox",
         "//rs/canister_sandbox:sandbox_launcher",
         "//rs/ledger_suite/icp/ledger:ledger-canister-wasm-notify-method",
-        "//rs/pocket_ic_server:pocket-ic-server",
         "//rs/replica",
         "//rs/rosetta-api/icp:ic-rosetta-api-rosetta-blocks",
     ],
     env = {
         "CANISTER_LAUNCHER": "$(rootpath //rs/canister_sandbox)",
-        "POCKET_IC_BIN": "$(rootpath //rs/pocket_ic_server:pocket-ic-server)",
         "REPLICA_BIN": "$(rootpath //rs/replica)",
         "ROSETTA_BIN_PATH": "$(rootpath //rs/rosetta-api/icp:ic-rosetta-api-rosetta-blocks)",
         "SANDBOX_LAUNCHER": "$(rootpath //rs/canister_sandbox:sandbox_launcher)",
         "LEDGER_CANISTER_NOTIFY_METHOD_WASM_PATH": "$(rootpath //rs/ledger_suite/icp/ledger:ledger-canister-wasm-notify-method)",
     },
+    macro = rust_test,
     deps = [
         # Keep sorted.
         ":ic-icp-rosetta-runner",

--- a/rs/rosetta-api/icp/tests/integration_tests/BUILD.bazel
+++ b/rs/rosetta-api/icp/tests/integration_tests/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test_suite")
+load("//bazel:pocket-ic-tests.bzl", "pocket_ic_test")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -35,14 +36,13 @@ rust_library(
     deps = DEPENDENCIES,
 )
 
-rust_test_suite(
+pocket_ic_test(
     name = "rosetta-integration",
     srcs = ["tests/tests.rs"],
     data = [
         "//rs/canister_sandbox",
         "//rs/canister_sandbox:sandbox_launcher",
         "//rs/ledger_suite/icp/ledger:ledger-canister-wasm-notify-method",
-        "//rs/pocket_ic_server:pocket-ic-server",
         "//rs/replica",
         "//rs/rosetta-api/icp:ic-rosetta-api-rosetta-blocks",
         "//rs/rosetta-api/icp/test_utils/sender_canister:ic-sender-canister",
@@ -51,7 +51,6 @@ rust_test_suite(
     env = {
         "CANISTER_LAUNCHER": "$(rootpath //rs/canister_sandbox)",
         "LEDGER_CANISTER_NOTIFY_METHOD_WASM_PATH": "$(rootpath //rs/ledger_suite/icp/ledger:ledger-canister-wasm-notify-method)",
-        "POCKET_IC_BIN": "$(rootpath //rs/pocket_ic_server:pocket-ic-server)",
         "REPLICA_BIN": "$(rootpath //rs/replica)",
         "ROSETTA_PATH": "$(rootpath //rs/rosetta-api/icp:ic-rosetta-api-rosetta-blocks)",
         "SANDBOX_LAUNCHER": "$(rootpath //rs/canister_sandbox:sandbox_launcher)",
@@ -61,6 +60,7 @@ rust_test_suite(
     # The test is critical to get resources timely and therefore fails sometimes when run on heavily loaded node.
     # TODO(IDX-2225): reconsider when we will use Remote Execution.
     flaky = True,
+    macro = rust_test_suite,
     proc_macro_deps = [
     ],
     # The test runs replica binary that constantly uses more than 100% cpu core + rosetta server.

--- a/rs/rosetta-api/icrc1/BUILD.bazel
+++ b/rs/rosetta-api/icrc1/BUILD.bazel
@@ -119,7 +119,6 @@ LOCAL_REPLICA_DATA = [
     "//rs/ledger_suite/icrc1/ledger:ledger_canister_icrc3_compatible_data_certificate",
     "//rs/rosetta-api/icrc1:ic-icrc-rosetta-bin",
     "//rs/rosetta-api/icrc1/client:ic-icrc-rosetta-client-bin",
-    "//rs/pocket_ic_server:pocket-ic-server",
     "//rs/ledger_suite/icrc1/ledger:ledger_canister",
 ]
 
@@ -128,14 +127,13 @@ LOCAL_REPLICA_ENV = {
     "IC_ICRC1_ARCHIVE_WASM_PATH": "$(rootpath //rs/ledger_suite/icrc1/archive:archive_canister)",
     "IC_ICRC1_LEDGER_WASM_PATH": "$(rootpath //rs/ledger_suite/icrc1/ledger:ledger_canister_icrc3_compatible_data_certificate)",
     "IC_ICRC1_LEDGER_WASM_PATH_OLD_CERTIFICATE": "$(rootpath //rs/ledger_suite/icrc1/ledger:ledger_canister)",
-    "POCKET_IC_BIN": "$(rootpath //rs/pocket_ic_server:pocket-ic-server)",
     "REPLICA_BIN": "$(rootpath //rs/replica)",
     "ROSETTA_BIN_PATH": "$(rootpath //rs/rosetta-api/icrc1:ic-icrc-rosetta-bin)",
     "ROSETTA_CLIENT_BIN_PATH": "$(rootpath //rs/rosetta-api/icrc1/client:ic-icrc-rosetta-client-bin)",
     "SANDBOX_LAUNCHER": "$(rootpath //rs/canister_sandbox:sandbox_launcher)",
 }
 
-rust_test_suite_with_extra_srcs(
+pocket_ic_test(
     name = "icrc_rosetta_integration",
     size = "large",
     srcs = [
@@ -150,11 +148,12 @@ rust_test_suite_with_extra_srcs(
         "tests/integration_test_components/storage/*.rs",
     ]),
     flaky = True,
+    macro = rust_test_suite_with_extra_srcs,
     proc_macro_deps = MACRO_DEV_DEPENDENCIES,
     deps = DEV_DEPENDENCIES + DEPENDENCIES,
 )
 
-rust_test_suite_with_extra_srcs(
+pocket_ic_test(
     name = "icrc_rosetta_system",
     srcs = [
         "tests/system_tests.rs",
@@ -173,6 +172,7 @@ rust_test_suite_with_extra_srcs(
         "tests/common/*.rs",
     ]),
     flaky = True,
+    macro = rust_test_suite_with_extra_srcs,
     proc_macro_deps = MACRO_DEV_DEPENDENCIES,
     deps = DEV_DEPENDENCIES + DEPENDENCIES,
 )

--- a/rs/rosetta-api/icrc1/client/BUILD.bazel
+++ b/rs/rosetta-api/icrc1/client/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@rules_rust//rust:defs.bzl", "rust_binary", "rust_library", "rust_test")
+load("//bazel:pocket-ic-tests.bzl", "pocket_ic_test")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -38,23 +39,22 @@ rust_library(
     deps = DEPENDENCIES,
 )
 
-rust_test(
+pocket_ic_test(
     name = "ic-icrc-rosetta-client-tests",
     srcs = ["tests/tests.rs"],
     data = [
         "//rs/canister_sandbox",
         "//rs/canister_sandbox:sandbox_launcher",
-        "//rs/pocket_ic_server:pocket-ic-server",
         "//rs/replica",
         "//rs/rosetta-api/icrc1:ic-icrc-rosetta-bin",
     ],
     env = {
         "CANISTER_LAUNCHER": "$(rootpath //rs/canister_sandbox)",
-        "POCKET_IC_BIN": "$(rootpath //rs/pocket_ic_server:pocket-ic-server)",
         "REPLICA_BIN": "$(rootpath //rs/replica)",
         "ROSETTA_BIN_PATH": "$(rootpath //rs/rosetta-api/icrc1:ic-icrc-rosetta-bin)",
         "SANDBOX_LAUNCHER": "$(rootpath //rs/canister_sandbox:sandbox_launcher)",
     },
+    macro = rust_test,
     deps = DEV_DEPENDENCIES,
 )
 

--- a/rs/rosetta-api/icrc1/runner/BUILD.bazel
+++ b/rs/rosetta-api/icrc1/runner/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test")
+load("//bazel:pocket-ic-tests.bzl", "pocket_ic_test")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -16,24 +17,23 @@ rust_library(
     ],
 )
 
-rust_test(
+pocket_ic_test(
     name = "ic-icrc-rosetta-runner-tests",
     srcs = ["tests/tests.rs"],
     data = [
         "//rs/canister_sandbox",
         "//rs/canister_sandbox:sandbox_launcher",
-        "//rs/pocket_ic_server:pocket-ic-server",
         "//rs/replica",
         "//rs/rosetta-api/icrc1:ic-icrc-rosetta-bin",
         "//rs/rosetta-api/icrc1/client:ic-icrc-rosetta-client-bin",
     ],
     env = {
         "CANISTER_LAUNCHER": "$(rootpath //rs/canister_sandbox)",
-        "POCKET_IC_BIN": "$(rootpath //rs/pocket_ic_server:pocket-ic-server)",
         "REPLICA_BIN": "$(rootpath //rs/replica)",
         "ROSETTA_BIN_PATH": "$(rootpath //rs/rosetta-api/icrc1:ic-icrc-rosetta-bin)",
         "SANDBOX_LAUNCHER": "$(rootpath //rs/canister_sandbox:sandbox_launcher)",
     },
+    macro = rust_test,
     deps = [
         # Keep sorted.
         ":ic-icrc-rosetta-runner",


### PR DESCRIPTION
This introduces the `pocket_ic_test` macro exported from `//bazel:pocket-ic-tests.bzl`. It abstracts over depending on the `//rs/pocket_ic_server:pocket-ic-server` and setting the `requires-network` hack to work around the `Operation not permitted` error on darwin.