### PR TITLE
test(IDX): move most system_test_hourly to long_test

### DIFF
--- a/rs/tests/boundary_nodes/BUILD.bazel
+++ b/rs/tests/boundary_nodes/BUILD.bazel
@@ -80,7 +80,7 @@ system_test_nns(
     name = "bn_update_workload_test",
     flaky = True,
     tags = [
-        "manual",  # TODO(BOUN-1039): remove "manual" and add back "system_test_hourly" and "system_test_nightly" when the test is not flaky anymore
+        "manual",  # TODO(BOUN-1039): remove "manual" and add back "long_test" when the test is not flaky anymore
     ],
     target_compatible_with = ["@platforms//os:linux"],  # requires libssh that does not build on Mac OS
     test_timeout = "long",

--- a/rs/tests/consensus/BUILD.bazel
+++ b/rs/tests/consensus/BUILD.bazel
@@ -27,7 +27,7 @@ system_test(
     # TODO(NET-1683): Adjust test for faster p2p
     tags = [
         "k8s",
-        "system_test_hourly",
+        "long_test",
     ],
     target_compatible_with = ["@platforms//os:linux"],  # requires libssh that does not build on Mac OS
     test_timeout = "eternal",
@@ -49,7 +49,7 @@ system_test(
     # TODO(NET-1683): Adjust test for faster p2p
     tags = [
         "k8s",
-        "system_test_hourly",
+        "long_test",
     ],
     target_compatible_with = ["@platforms//os:linux"],  # requires libssh that does not build on Mac OS
     uses_guestos_dev = True,

--- a/rs/tests/consensus/orchestrator/BUILD.bazel
+++ b/rs/tests/consensus/orchestrator/BUILD.bazel
@@ -120,7 +120,7 @@ system_test_nns(
     flaky = True,
     tags = [
         "k8s",
-        "system_test_hourly",
+        "long_test",
     ],
     target_compatible_with = ["@platforms//os:linux"],
     uses_guestos_dev_test = True,

--- a/rs/tests/consensus/subnet_recovery/BUILD.bazel
+++ b/rs/tests/consensus/subnet_recovery/BUILD.bazel
@@ -71,8 +71,8 @@ system_test_nns(
     tags = [
         "experimental_system_test_colocation",
         "k8s",
+        "long_test",
         "subnet_recovery",
-        "system_test_hourly",
     ],
     target_compatible_with = ["@platforms//os:linux"],  # requires libssh that does not build on Mac OS
     uses_guestos_dev_test = True,
@@ -129,8 +129,8 @@ system_test_nns(
     tags = [
         "experimental_system_test_colocation",
         "k8s",
+        "long_test",
         "subnet_recovery",
-        "system_test_hourly",
     ],
     target_compatible_with = ["@platforms//os:linux"],  # requires libssh that does not build on Mac OS
     uses_guestos_dev = True,
@@ -149,8 +149,8 @@ system_test_nns(
     tags = [
         "experimental_system_test_colocation",
         "k8s",
+        "long_test",
         "subnet_recovery",
-        "system_test_hourly",
     ],
     target_compatible_with = ["@platforms//os:linux"],  # requires libssh that does not build on Mac OS
     uses_guestos_dev = True,
@@ -189,8 +189,8 @@ system_test_nns(
     tags = [
         "experimental_system_test_colocation",
         "k8s",
+        "long_test",
         "subnet_recovery",
-        "system_test_hourly",
     ],
     target_compatible_with = ["@platforms//os:linux"],  # requires libssh that does not build on Mac OS
     uses_guestos_dev = True,
@@ -209,8 +209,8 @@ system_test_nns(
     tags = [
         "experimental_system_test_colocation",
         "k8s",
+        "long_test",
         "subnet_recovery",
-        "system_test_hourly",
     ],
     target_compatible_with = ["@platforms//os:linux"],  # requires libssh that does not build on Mac OS
     uses_guestos_dev = True,

--- a/rs/tests/consensus/tecdsa/BUILD.bazel
+++ b/rs/tests/consensus/tecdsa/BUILD.bazel
@@ -133,7 +133,7 @@ system_test_nns(
     flaky = True,
     tags = [
         "k8s",
-        "system_test_hourly",
+        "long_test",
     ],
     target_compatible_with = ["@platforms//os:linux"],  # requires libssh that does not build on Mac OS
     runtime_deps = GUESTOS_RUNTIME_DEPS,
@@ -157,7 +157,7 @@ system_test_nns(
     flaky = True,
     tags = [
         "k8s",
-        "system_test_hourly",
+        "long_test",
     ],
     target_compatible_with = ["@platforms//os:linux"],  # requires libssh that does not build on Mac OS
     runtime_deps = GUESTOS_RUNTIME_DEPS,
@@ -177,7 +177,7 @@ system_test_nns(
     flaky = True,
     tags = [
         "k8s",
-        "system_test_hourly",
+        "long_test",
     ],
     target_compatible_with = ["@platforms//os:linux"],  # requires libssh that does not build on Mac OS
     runtime_deps = GUESTOS_RUNTIME_DEPS,
@@ -198,7 +198,7 @@ system_test_nns(
     flaky = True,
     tags = [
         "k8s",
-        "system_test_hourly",
+        "long_test",
     ],
     target_compatible_with = ["@platforms//os:linux"],  # requires libssh that does not build on Mac OS
     runtime_deps = GUESTOS_RUNTIME_DEPS,
@@ -254,7 +254,7 @@ system_test_nns(
     flaky = True,
     tags = [
         "k8s",
-        "system_test_hourly",
+        "long_test",
     ],
     target_compatible_with = ["@platforms//os:linux"],  # requires libssh that does not build on Mac OS
     runtime_deps = GUESTOS_RUNTIME_DEPS,

--- a/rs/tests/consensus/upgrade/BUILD.bazel
+++ b/rs/tests/consensus/upgrade/BUILD.bazel
@@ -137,7 +137,7 @@ system_test_nns(
     flaky = True,
     tags = [
         "k8s",
-        "system_test_hourly",
+        "long_test",
     ],
     target_compatible_with = ["@platforms//os:linux"],
     uses_guestos_dev = True,
@@ -160,7 +160,7 @@ system_test_nns(
     flaky = True,
     tags = [
         "k8s",
-        "system_test_hourly",
+        "long_test",
     ],
     target_compatible_with = ["@platforms//os:linux"],
     uses_guestos_dev = True,

--- a/rs/tests/idx/BUILD.bazel
+++ b/rs/tests/idx/BUILD.bazel
@@ -30,7 +30,7 @@ system_test(
     flaky = True,
     tags = [
         "k8s",
-        "system_test_hourly",
+        "long_test",
     ],
     target_compatible_with = ["@platforms//os:linux"],  # requires libssh that does not build on Mac OS
     runtime_deps = GUESTOS_RUNTIME_DEPS + GRAFANA_RUNTIME_DEPS + UNIVERSAL_CANISTER_RUNTIME_DEPS,
@@ -50,7 +50,7 @@ system_test(
     },
     flaky = True,
     tags = [
-        "system_test_hourly",
+        "long_test",
     ],
     target_compatible_with = ["@platforms//os:linux"],  # requires libssh that does not build on Mac OS
     runtime_deps = GUESTOS_RUNTIME_DEPS + COUNTER_CANISTER_RUNTIME_DEPS + UNIVERSAL_CANISTER_RUNTIME_DEPS + [

--- a/rs/tests/message_routing/BUILD.bazel
+++ b/rs/tests/message_routing/BUILD.bazel
@@ -40,7 +40,7 @@ system_test(
     ],
     tags = [
         "k8s",
-        "system_test_hourly",
+        "long_test",
     ],
     target_compatible_with = ["@platforms//os:linux"],  # requires libssh that does not build on Mac OS
     runtime_deps = GUESTOS_RUNTIME_DEPS,
@@ -65,7 +65,7 @@ system_test_nns(
     env = UNIVERSAL_CANISTER_ENV,
     tags = [
         "k8s",
-        "system_test_hourly",
+        "long_test",
     ],
     target_compatible_with = ["@platforms//os:linux"],  # requires libssh that does not build on Mac OS
     runtime_deps =

--- a/rs/tests/networking/BUILD.bazel
+++ b/rs/tests/networking/BUILD.bazel
@@ -59,7 +59,7 @@ system_test_nns(
     flaky = True,
     tags = [
         # TODO(NET-1710): enable on CI again when the problematic firewall rule in the IC node has been removed.
-        #"system_test_hourly",
+        #"long_test",
         #"system_test_nightly",
         "manual",
     ],
@@ -133,7 +133,7 @@ system_test_nns(
     flaky = True,
     tags = [
         "k8s",
-        "system_test_hourly",
+        "long_test",
     ],
     target_compatible_with = ["@platforms//os:linux"],  # requires libssh that does not build on Mac OS
     runtime_deps =
@@ -147,7 +147,7 @@ system_test_nns(
     name = "firewall_max_connections_test",
     flaky = True,
     tags = [
-        "system_test_hourly",
+        "long_test",
     ],
     target_compatible_with = ["@platforms//os:linux"],
     runtime_deps = GUESTOS_RUNTIME_DEPS + UNIVERSAL_VM_RUNTIME_DEPS,
@@ -161,7 +161,7 @@ system_test_nns(
     name = "firewall_priority_test",
     flaky = True,
     tags = [
-        "system_test_hourly",
+        "long_test",
     ],
     target_compatible_with = ["@platforms//os:linux"],
     runtime_deps = GUESTOS_RUNTIME_DEPS + UNIVERSAL_VM_RUNTIME_DEPS,

--- a/rs/tests/nns/BUILD.bazel
+++ b/rs/tests/nns/BUILD.bazel
@@ -47,7 +47,7 @@ system_test_nns(
     },
     flaky = False,
     tags = [
-        "system_test_hourly",
+        "long_test",
     ],
     target_compatible_with = ["@platforms//os:linux"],  # requires libssh that does not build on Mac OS
     runtime_deps = GUESTOS_RUNTIME_DEPS + BOUNDARY_NODE_GUESTOS_RUNTIME_DEPS + [


### PR DESCRIPTION
What
===
This moves all system-tests that only run hourly (tagged with `system_test_hourly`) to run on every push to `master` (tagged with `long_test`) except for the following hourly tests that are kept back (for now) because of the mentioned reason:

* `//rs/tests/boundary_nodes:bn_integration_on_playnet_test`: >1% flakiness rate
* `//rs/tests/consensus/subnet_recovery:sr_app_large_with_tecdsa_test`: >1% flakiness rate & >10 minutes
* `//rs/tests/consensus/subnet_recovery:sr_app_same_nodes_with_tecdsa_test`: >10 minutes
* `//rs/tests/consensus/upgrade:upgrade_downgrade_app_subnet_test`: >10 minutes
* `//rs/tests/consensus/upgrade:upgrade_downgrade_nns_subnet_test`: >10 minutes
* `//rs/tests/nested:registration`: >10 minutes
* `//rs/tests/nested:upgrade`: >1% flakiness rate & >10 minutes
* `//rs/tests/networking:query_workload_long_test`: >1% flakiness rate
* `//rs/tests/networking:update_workload_large_payload`:  >1% flakiness rate

Why
===
In order to simplify CI it would be good to get rid of the hourly job and just run all hourly tests on pushes to master. 

Additionally failing hourly tests currently don't block a release which is obviously problematic. By moving them to the normal CI Main workflow they will start blocking releases in case they fail.

Future Work
===

We should go over the tests mentioned above that still run hourly and ask the owning teams to reduce the flakiness rate to <1% and to optimise the test to run faster. If a test can't be optimised we should consider just running it on the daily workflow instead.