### PR TITLE
chore(ckbtc): property tests for event serialization and deserialization

### DIFF
--- a/rs/bitcoin/ckbtc/minter/src/storage/tests.rs
+++ b/rs/bitcoin/ckbtc/minter/src/storage/tests.rs
@@ -1,48 +1,38 @@
-use crate::state::eventlog::{Event, EventType};
-use crate::test_fixtures::{ignored_utxo, ledger_account};
+use super::{decode_event, encode_event};
+use crate::{
+    state::eventlog::{Event, EventType},
+    test_fixtures::arbitrary,
+};
+use proptest::proptest;
 
-#[test]
-fn should_decode_encoded_event() {
-    let event = Event {
-        timestamp: Some(123),
-        payload: event_type(),
-    };
+proptest! {
+    #[test]
+    fn should_decode_encoded_event(event in arbitrary::event()) {
+        let encoded = encode_event(&event);
+        let decoded = decode_event(&encoded);
 
-    let encoded = super::encode_event(&event);
-    let decoded = super::decode_event(&encoded);
-
-    assert_eq!(event, decoded);
-}
-
-#[test]
-fn should_decode_encoded_legacy_event() {
-    /// Legacy events simply consisted of an event type instance. The
-    /// encoding logic is the exact same as for new events, only the type
-    /// being encoded differs.
-    fn encode_legacy_event(event: &EventType) -> Vec<u8> {
-        let mut buf = Vec::new();
-        ciborium::ser::into_writer(event, &mut buf).expect("failed to encode a minter event");
-        buf
+        assert_eq!(event, decoded);
     }
 
-    let legacy_event = event_type();
-
-    let encoded = encode_legacy_event(&legacy_event);
-    let decoded = super::decode_event(&encoded);
-
-    assert_eq!(
-        decoded,
-        Event {
-            timestamp: None,
-            payload: legacy_event,
+    #[test]
+    fn should_decode_encoded_legacy_event(legacy_event in arbitrary::event_type()) {
+        /// Legacy events just consist of an event type instance. The encoding logic
+        /// is the exact same as for new events. Only the type being encoded differs.
+        fn encode_legacy_event(event: &EventType) -> Vec<u8> {
+            let mut buf = Vec::new();
+            ciborium::ser::into_writer(event, &mut buf).expect("failed to encode a minter event");
+            buf
         }
-    );
-}
 
-fn event_type() -> EventType {
-    EventType::ReceivedUtxos {
-        mint_txid: Some(1),
-        to_account: ledger_account(),
-        utxos: vec![ignored_utxo()],
+        let encoded = encode_legacy_event(&legacy_event);
+        let decoded = decode_event(&encoded);
+
+        assert_eq!(
+            decoded,
+            Event {
+                timestamp: None,
+                payload: legacy_event,
+            }
+        );
     }
 }

--- a/rs/bitcoin/ckbtc/minter/src/test_fixtures.rs
+++ b/rs/bitcoin/ckbtc/minter/src/test_fixtures.rs
@@ -186,10 +186,7 @@ pub mod arbitrary {
     }
 
     fn txid() -> impl Strategy<Value = Txid> {
-        pvec(any::<u8>(), 32).prop_map(|bytes| {
-            let bytes: [u8; 32] = bytes.try_into().expect("Can't convert to [u8; 32]");
-            bytes.into()
-        })
+        uniform32(any::<u8>()).prop_map(Txid::from)
     }
 
     fn outpoint() -> impl Strategy<Value = OutPoint> {

--- a/rs/bitcoin/ckbtc/minter/src/tests.rs
+++ b/rs/bitcoin/ckbtc/minter/src/tests.rs
@@ -1,33 +1,29 @@
-use crate::state::invariants::CheckInvariantsImpl;
 use crate::{
-    address::BitcoinAddress, build_unsigned_transaction, estimate_retrieve_btc_fee, fake_sign,
-    greedy, signature::EncodedSignature, tx, BuildTxError,
-};
-use crate::{evaluate_minter_fee, MINTER_ADDRESS_DUST_LIMIT};
-use crate::{
+    address::BitcoinAddress,
+    build_unsigned_transaction, estimate_retrieve_btc_fee, evaluate_minter_fee, fake_sign, greedy,
     lifecycle::init::InitArgs,
+    state::invariants::CheckInvariantsImpl,
     state::{
         ChangeOutput, CkBtcMinterState, Mode, RetrieveBtcRequest, RetrieveBtcStatus,
         SubmittedBtcTransaction,
     },
+    test_fixtures::arbitrary,
+    tx, BuildTxError, MINTER_ADDRESS_DUST_LIMIT,
 };
 use bitcoin::network::constants::Network as BtcNetwork;
 use bitcoin::util::psbt::serialize::{Deserialize, Serialize};
 use candid::Principal;
-use ic_base_types::{CanisterId, PrincipalId};
-use ic_btc_interface::{Network, OutPoint, Satoshi, Txid, Utxo};
+use ic_base_types::CanisterId;
+use ic_btc_interface::{Network, OutPoint, Utxo};
 use icrc_ledger_types::icrc1::account::Account;
 use maplit::btreeset;
-use proptest::proptest;
 use proptest::{
     array::uniform20,
-    array::uniform32,
-    collection::{btree_set, vec as pvec, SizeRange},
+    collection::{btree_set, vec as pvec},
     option,
-    prelude::{any, Strategy},
+    prelude::any,
+    prop_assert, prop_assert_eq, prop_assume, proptest,
 };
-use proptest::{prop_assert, prop_assert_eq, prop_assume, prop_oneof};
-use serde_bytes::ByteBuf;
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::str::FromStr;
 
@@ -444,121 +440,6 @@ fn test_no_dust_in_change_output() {
     }
 }
 
-fn arb_amount() -> impl Strategy<Value = Satoshi> {
-    1..10_000_000_000u64
-}
-
-fn vec_to_txid(vec: Vec<u8>) -> Txid {
-    let bytes: [u8; 32] = vec.try_into().expect("Can't convert to [u8; 32]");
-    bytes.into()
-}
-
-fn arb_out_point() -> impl Strategy<Value = tx::OutPoint> {
-    (pvec(any::<u8>(), 32), any::<u32>()).prop_map(|(txid, vout)| tx::OutPoint {
-        txid: vec_to_txid(txid),
-        vout,
-    })
-}
-
-fn arb_unsigned_input(
-    value: impl Strategy<Value = Satoshi>,
-) -> impl Strategy<Value = tx::UnsignedInput> {
-    (arb_out_point(), value, any::<u32>()).prop_map(|(previous_output, value, sequence)| {
-        tx::UnsignedInput {
-            previous_output,
-            value,
-            sequence,
-        }
-    })
-}
-
-fn arb_signed_input() -> impl Strategy<Value = tx::SignedInput> {
-    (
-        arb_out_point(),
-        any::<u32>(),
-        pvec(1u8..0xff, 64),
-        pvec(any::<u8>(), 32),
-    )
-        .prop_map(
-            |(previous_output, sequence, sec1, pubkey)| tx::SignedInput {
-                previous_output,
-                sequence,
-                signature: EncodedSignature::from_sec1(&sec1),
-                pubkey: ByteBuf::from(pubkey),
-            },
-        )
-}
-
-fn arb_address() -> impl Strategy<Value = BitcoinAddress> {
-    prop_oneof![
-        uniform20(any::<u8>()).prop_map(BitcoinAddress::P2wpkhV0),
-        uniform32(any::<u8>()).prop_map(BitcoinAddress::P2wshV0),
-        uniform32(any::<u8>()).prop_map(BitcoinAddress::P2trV1),
-        uniform20(any::<u8>()).prop_map(BitcoinAddress::P2pkh),
-        uniform20(any::<u8>()).prop_map(BitcoinAddress::P2sh),
-    ]
-}
-
-fn arb_tx_out() -> impl Strategy<Value = tx::TxOut> {
-    (arb_amount(), arb_address()).prop_map(|(value, address)| tx::TxOut { value, address })
-}
-
-fn arb_utxo(amount: impl Strategy<Value = Satoshi>) -> impl Strategy<Value = Utxo> {
-    (amount, pvec(any::<u8>(), 32), 0..5u32).prop_map(|(value, txid, vout)| Utxo {
-        outpoint: OutPoint {
-            txid: vec_to_txid(txid),
-            vout,
-        },
-        value,
-        height: 0,
-    })
-}
-
-fn arb_account() -> impl Strategy<Value = Account> {
-    (pvec(any::<u8>(), 32), option::of(uniform32(any::<u8>()))).prop_map(|(pk, subaccount)| {
-        Account {
-            owner: PrincipalId::new_self_authenticating(&pk).0,
-            subaccount,
-        }
-    })
-}
-
-fn arb_retrieve_btc_requests(
-    amount: impl Strategy<Value = Satoshi>,
-    num: impl Into<SizeRange>,
-) -> impl Strategy<Value = Vec<RetrieveBtcRequest>> {
-    let request_strategy = (
-        amount,
-        arb_address(),
-        any::<u64>(),
-        1569975147000..2069975147000u64,
-        option::of(any::<u64>()),
-        option::of(arb_account()),
-    )
-        .prop_map(
-            |(amount, address, block_index, received_at, provider, reimbursement_account)| {
-                RetrieveBtcRequest {
-                    amount,
-                    address,
-                    block_index,
-                    received_at,
-                    kyt_provider: provider
-                        .map(|id| Principal::from(CanisterId::from_u64(id).get())),
-                    reimbursement_account,
-                }
-            },
-        );
-    pvec(request_strategy, num).prop_map(|mut reqs| {
-        reqs.sort_by_key(|req| req.received_at);
-
-        for (i, req) in reqs.iter_mut().enumerate() {
-            req.block_index = i as u64;
-        }
-
-        reqs
-    })
-}
-
 proptest! {
     #[test]
     fn greedy_solution_properties(
@@ -621,8 +502,8 @@ proptest! {
 
     #[test]
     fn unsigned_tx_encoding_model(
-        inputs in pvec(arb_unsigned_input(5_000u64..1_000_000_000), 1..20),
-        outputs in pvec(arb_tx_out(), 1..20),
+        inputs in pvec(arbitrary::unsigned_input(5_000u64..1_000_000_000), 1..20),
+        outputs in pvec(arbitrary::tx_out(), 1..20),
         lock_time in any::<u32>(),
     ) {
         let arb_tx = tx::UnsignedTransaction { inputs, outputs, lock_time };
@@ -643,13 +524,13 @@ proptest! {
     fn unsigned_tx_sighash_model(
         inputs_data in pvec(
             (
-                arb_utxo(5_000u64..1_000_000_000),
+                arbitrary::utxo(5_000u64..1_000_000_000),
                 any::<u32>(),
                 pvec(any::<u8>(), tx::PUBKEY_LEN)
             ),
             1..20
         ),
-        outputs in pvec(arb_tx_out(), 1..20),
+        outputs in pvec(arbitrary::tx_out(), 1..20),
         lock_time in any::<u32>(),
     ) {
         let inputs: Vec<tx::UnsignedInput> = inputs_data
@@ -686,8 +567,8 @@ proptest! {
 
     #[test]
     fn signed_tx_encoding_model(
-        inputs in pvec(arb_signed_input(), 1..20),
-        outputs in pvec(arb_tx_out(), 1..20),
+        inputs in pvec(arbitrary::signed_input(), 1..20),
+        outputs in pvec(arbitrary::tx_out(), 1..20),
         lock_time in any::<u32>(),
     ) {
         let arb_tx = tx::SignedTransaction { inputs, outputs, lock_time };
@@ -707,7 +588,7 @@ proptest! {
 
     #[test]
     fn build_tx_splits_utxos(
-        mut utxos in btree_set(arb_utxo(5_000u64..1_000_000_000), 1..20),
+        mut utxos in btree_set(arbitrary::utxo(5_000u64..1_000_000_000), 1..20),
         dst_pkhash in uniform20(any::<u8>()),
         main_pkhash in uniform20(any::<u8>()),
         fee_per_vbyte in 1000..2000u64,
@@ -754,7 +635,7 @@ proptest! {
 
     #[test]
     fn check_output_order(
-        mut utxos in btree_set(arb_utxo(1_000_000u64..1_000_000_000), 1..20),
+        mut utxos in btree_set(arbitrary::utxo(1_000_000u64..1_000_000_000), 1..20),
         dst_pkhash in uniform20(any::<u8>()),
         main_pkhash in uniform20(any::<u8>()),
         target in 50000..100000u64,
@@ -776,7 +657,7 @@ proptest! {
 
     #[test]
     fn build_tx_handles_change_from_inputs(
-        mut utxos in btree_set(arb_utxo(1_000_000u64..1_000_000_000), 1..20),
+        mut utxos in btree_set(arbitrary::utxo(1_000_000u64..1_000_000_000), 1..20),
         dst_pkhash in uniform20(any::<u8>()),
         main_pkhash in uniform20(any::<u8>()),
         target in 50000..100000u64,
@@ -824,7 +705,7 @@ proptest! {
 
     #[test]
     fn build_tx_does_not_modify_utxos_on_error(
-        mut utxos in btree_set(arb_utxo(5_000u64..1_000_000_000), 1..20),
+        mut utxos in btree_set(arbitrary::utxo(5_000u64..1_000_000_000), 1..20),
         dst_pkhash in uniform20(any::<u8>()),
         main_pkhash in uniform20(any::<u8>()),
         fee_per_vbyte in 1000..2000u64,
@@ -858,8 +739,8 @@ proptest! {
 
     #[test]
     fn add_utxos_maintains_invariants(
-        utxos_acc_idx in pvec((arb_utxo(5_000u64..1_000_000_000), 0..5usize), 10..20),
-        accounts in pvec(arb_account(), 5),
+        utxos_acc_idx in pvec((arbitrary::utxo(5_000u64..1_000_000_000), 0..5usize), 10..20),
+        accounts in pvec(arbitrary::account(), 5),
     ) {
         let mut state = CkBtcMinterState::from(InitArgs {
             retrieve_btc_min_amount: 1000,
@@ -873,9 +754,9 @@ proptest! {
 
     #[test]
     fn batching_preserves_invariants(
-        utxos_acc_idx in pvec((arb_utxo(5_000u64..1_000_000_000), 0..5usize), 10..20),
-        accounts in pvec(arb_account(), 5),
-        requests in arb_retrieve_btc_requests(5_000u64..1_000_000_000, 1..25),
+        utxos_acc_idx in pvec((arbitrary::utxo(5_000u64..1_000_000_000), 0..5usize), 10..20),
+        accounts in pvec(arbitrary::account(), 5),
+        requests in arbitrary::retrieve_btc_requests(5_000u64..1_000_000_000, 1..25),
         limit in 1..25usize,
     ) {
         let mut state = CkBtcMinterState::from(InitArgs {
@@ -907,9 +788,9 @@ proptest! {
 
     #[test]
     fn tx_replacement_preserves_invariants(
-        accounts in pvec(arb_account(), 5),
-        utxos_acc_idx in pvec((arb_utxo(5_000_000u64..1_000_000_000), 0..5usize), 10..=10),
-        requests in arb_retrieve_btc_requests(5_000_000u64..10_000_000, 1..5),
+        accounts in pvec(arbitrary::account(), 5),
+        utxos_acc_idx in pvec((arbitrary::utxo(5_000_000u64..1_000_000_000), 0..5usize), 10..=10),
+        requests in arbitrary::retrieve_btc_requests(5_000_000u64..10_000_000, 1..5),
         main_pkhash in uniform20(any::<u8>()),
         resubmission_chain_length in 1..=5,
     ) {
@@ -1029,7 +910,7 @@ proptest! {
     }
 
     #[test]
-    fn btc_address_display_model(address in arb_address()) {
+    fn btc_address_display_model(address in arbitrary::address()) {
         for network in [Network::Mainnet, Network::Testnet].iter() {
             let addr_str = address.display(*network);
             let btc_addr = address_to_btc_address(&address, *network);
@@ -1038,7 +919,7 @@ proptest! {
     }
 
     #[test]
-    fn address_roundtrip(address in arb_address()) {
+    fn address_roundtrip(address in arbitrary::address()) {
         for network in [Network::Mainnet, Network::Testnet, Network::Regtest].iter() {
             let addr_str = address.display(*network);
             prop_assert_eq!(BitcoinAddress::parse(&addr_str, *network), Ok(address.clone()));
@@ -1110,7 +991,7 @@ proptest! {
 
     #[test]
     fn test_fee_range(
-        utxos in btree_set(arb_utxo(5_000u64..1_000_000_000), 0..20),
+        utxos in btree_set(arbitrary::utxo(5_000u64..1_000_000_000), 0..20),
         amount in option::of(any::<u64>()),
         fee_per_vbyte in 2000..10000u64,
     ) {


### PR DESCRIPTION
[(XC-238)](https://dfinity.atlassian.net/browse/XC-238) Add property tests for the ckBTC event serialization/deserialization logic where events (both legacy and new) are arbitrarily generated from all possible event types. See [this comment](https://github.com/dfinity/ic/pull/3157#discussion_r1891578520).