### PR TITLE
fix: ensuring that dashboards dir exists in all tests

### DIFF
--- a/rs/tests/driver/src/driver/prometheus_vm.rs
+++ b/rs/tests/driver/src/driver/prometheus_vm.rs
@@ -253,13 +253,14 @@ for name in replica orchestrator node_exporter; do
   echo '[]' > "{PROMETHEUS_SCRAPING_TARGETS_DIR}/$name.json"
 done
 
+mkdir -p /config/grafana/dashboards
+cp -R /config/grafana/dashboards /var/lib/grafana/
+chown -R grafana:grafana /var/lib/grafana/dashboards
+
 if uname -a | grep -q Ubuntu; then
   # k8s
   chmod g+s /etc/prometheus
   cp -f /config/prometheus/prometheus.yml /etc/prometheus/prometheus.yml
-  mkdir -p /config/grafana/dashboards
-  cp -R /config/grafana/dashboards /var/lib/grafana/
-  chown -R grafana:grafana /var/lib/grafana/dashboards
   chown -R {SSH_USERNAME}:prometheus /etc/prometheus
   systemctl reload prometheus
 else
@@ -271,6 +272,10 @@ fi
             )
             .unwrap();
 
+        let grafana_dashboards_dst = config_dir.join("grafana").join("dashboards");
+        if !grafana_dashboards_dst.exists() {
+            std::fs::create_dir_all(&grafana_dashboards_dst).unwrap()
+        }
         let grafana_dashboards_src = env.get_path(GRAFANA_DASHBOARDS);
         if let Err(e) = Self::transform_dashboards_root_dir(log.clone(), &grafana_dashboards_src) {
             warn!(
@@ -279,7 +284,6 @@ fi
                 e.to_string()
             )
         } else {
-            let grafana_dashboards_dst = config_dir.join("grafana").join("dashboards");
             debug!(log, "Copying Grafana dashboards from {grafana_dashboards_src:?} to {grafana_dashboards_dst:?} ...");
             TestEnv::shell_copy_with_deref(grafana_dashboards_src, grafana_dashboards_dst).unwrap();
         }


### PR DESCRIPTION
This PR ensures that both k8s and farm based testnets have a directory for grafana dashboards (even if they are empty). This is to prevent having log lines like the following:
```log
2024-12-20 03:22:31.400 INFO[uvms_logs_stream:StdOut] [uvm=prometheus] JournalRecord {message: "logger=provisioning.dashboard type=file name=provisioned-grafana-dashboards t=2024-12-20T03:22:30.89689519Z level=error msg="Cannot read directory" error="stat /config/grafana/dashboards: no such file or directory"", system_unit: "grafana.service", comm: "grafana"}
```