### PR TITLE
test(consensus): expand consensus performance test

### DIFF
--- a/rs/tests/consensus/consensus_performance.rs
+++ b/rs/tests/consensus/consensus_performance.rs
@@ -74,7 +74,7 @@ const NODES_COUNT: usize = 13;
 const DKG_INTERVAL: u64 = 999;
 // Network parameters
 const BANDWIDTH_MBITS: u32 = 300; // artificial cap on bandwidth
-const LATENCY: Duration = Duration::from_millis(200); // artificial added latency
+const LATENCY: Duration = Duration::from_millis(150); // artificial added latency
 const NETWORK_SIMULATION: FixedNetworkSimulation = FixedNetworkSimulation::new()
     .with_latency(LATENCY)
     .with_bandwidth(BANDWIDTH_MBITS);
@@ -153,6 +153,9 @@ fn test(env: TestEnv, message_size: usize, rps: f64) {
             test_metrics,
             message_size,
             rps,
+            LATENCY,
+            BANDWIDTH_MBITS * 1_000_000,
+            NODES_COUNT,
             &logger,
         ));
     }
@@ -163,11 +166,15 @@ fn test_few_small_messages(env: TestEnv) {
 }
 
 fn test_small_messages(env: TestEnv) {
-    test(env, 4_000, 500.0)
+    test(env, 4_000, 1_500.0)
+}
+
+fn test_few_large_messages(env: TestEnv) {
+    test(env, 1_999_000, 1.0)
 }
 
 fn test_large_messages(env: TestEnv) {
-    test(env, 950_000, 4.0)
+    test(env, 1_999_000, 4.0)
 }
 
 fn main() -> Result<()> {
@@ -178,6 +185,7 @@ fn main() -> Result<()> {
         .with_setup(setup)
         .add_test(systest!(test_few_small_messages))
         .add_test(systest!(test_small_messages))
+        .add_test(systest!(test_few_large_messages))
         .add_test(systest!(test_large_messages))
         .execute_from_args()?;
     Ok(())

--- a/rs/tests/consensus/utils/src/performance.rs
+++ b/rs/tests/consensus/utils/src/performance.rs
@@ -78,6 +78,9 @@ pub fn test_with_rt_handle(
     }
     info!(log, "{} canisters installed successfully.", canisters.len());
 
+    info!(log, "Sleeping for 30 seconds");
+    std::thread::sleep(Duration::from_secs(30));
+
     info!(log, "Step 2: Instantiate and start the workload..");
     let payload: Vec<u8> = vec![0; message_size];
     let generator = {
@@ -338,6 +341,9 @@ pub async fn persist_metrics(
     metrics: TestMetrics,
     message_size: usize,
     rps: f64,
+    latency: Duration,
+    bandwidth_bits_per_seconds: u32,
+    subnet_size: usize,
     log: &Logger,
 ) {
     // elastic search url
@@ -355,6 +361,9 @@ pub async fn persist_metrics(
             "benchmark_settings": {
                 "message_size": message_size,
                 "rps": rps,
+                "latency_seconds": latency.as_secs_f64(),
+                "bandwith_bits_per_second": bandwidth_bits_per_seconds,
+                "subnet_size": subnet_size,
             },
             "benchmark_results": {
                 "success_rate": metrics.success_rate,


### PR DESCRIPTION
1. Reduced the artificial latency from 200ms to 150ms, which is closer to what we observe on the mainnet
2. Increased the RPS of two test cases - since the hashes-in-blocks feature has been enabled we can handled more requests per second
3. Persist more test settings (latency, number of nodes, bandwith) with each CI run
4. Added one more test case