### PR TITLE
test(consensus): add an option to start a Jaeger instance in consensus performance test

### DIFF
--- a/rs/tests/consensus/BUILD.bazel
+++ b/rs/tests/consensus/BUILD.bazel
@@ -328,7 +328,9 @@ system_test_nns(
     ],
     target_compatible_with = ["@platforms//os:linux"],  # requires libssh that does not build on Mac OS
     test_timeout = "eternal",
-    runtime_deps = GUESTOS_RUNTIME_DEPS + GRAFANA_RUNTIME_DEPS + COUNTER_CANISTER_RUNTIME_DEPS,
+    runtime_deps = GUESTOS_RUNTIME_DEPS + GRAFANA_RUNTIME_DEPS + COUNTER_CANISTER_RUNTIME_DEPS + [
+        "//rs/tests:jaeger_uvm_config_image",
+    ],
     deps = [
         # Keep sorted.
         "//rs/registry/subnet_type",

--- a/rs/tests/consensus/consensus_performance.rs
+++ b/rs/tests/consensus/consensus_performance.rs
@@ -79,6 +79,9 @@ const NETWORK_SIMULATION: FixedNetworkSimulation = FixedNetworkSimulation::new()
     .with_latency(LATENCY)
     .with_bandwidth(BANDWIDTH_MBITS);
 
+/// When set to `true` a [Jaeger](https://www.jaegertracing.io/) instance will be spawned.
+/// Look for "Jaeger frontend available at: $URL" in the logs and follow the link to visualize &
+/// analyze traces.
 const SHOULD_SPAWN_JAEGER_VM: bool = false;
 
 fn setup(env: TestEnv) {


### PR DESCRIPTION
This will allow us, after adding enough instrumentation, to visualize traces like:
<img width="1512" alt="Screenshot 2024-12-23 at 14 08 01" src="https://github.com/user-attachments/assets/fcb9d0fc-ed68-4739-9438-f8bb585f9864" />
Maybe it will be helpful in identifying bottlenecks