### PR TITLE
fix(node): fix update-config when reward.conf does not exist

### DIFF
--- a/rs/ic_os/config/src/update_config.rs
+++ b/rs/ic_os/config/src/update_config.rs
@@ -189,10 +189,12 @@ fn read_nns_conf(config_dir: &Path) -> Result<Vec<Url>> {
 
 fn read_reward_conf(config_dir: &Path) -> Result<Option<String>> {
     let reward_conf_path = config_dir.join("reward.conf");
+    if !reward_conf_path.exists() {
+        return Ok(None);
+    }
+
     let conf_map = read_conf_file(&reward_conf_path)?;
-
     let node_reward_type = conf_map.get("node_reward_type").cloned();
-
     Ok(node_reward_type)
 }
 


### PR DESCRIPTION
[NODE-1541](https://dfinity.atlassian.net/browse/NODE-1541)
Handle the update-config case where reward.conf does not exist on the config partition.

[NODE-1541]: https://dfinity.atlassian.net/browse/NODE-1541?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ