### PR TITLE
fix(sns): Don't let very old upgrade proposals block future upgrades

### DIFF
--- a/rs/sns/governance/src/governance/advance_target_sns_version_tests.rs
+++ b/rs/sns/governance/src/governance/advance_target_sns_version_tests.rs
@@ -61,7 +61,7 @@ async fn test_initiate_upgrade_blocked_by_upgrade_proposal() {
     let proposal = ProposalData {
         action: (&action).into(),
         id: Some(proposal_id.into()),
-        decided_timestamp_seconds: 1,
+        decided_timestamp_seconds: NativeEnvironment::DEFAULT_TEST_START_TIMESTAMP_SECONDS - 10,
         latest_tally: Some(Tally {
             yes: 1,
             no: 0,

--- a/rs/sns/governance/src/types.rs
+++ b/rs/sns/governance/src/types.rs
@@ -2677,25 +2677,21 @@ pub mod test_helpers {
                 default_canister_call_response: Ok(vec![]),
                 required_canister_call_invocations: Arc::new(RwLock::new(vec![])),
                 // This needs to be non-zero
-                now: std::time::SystemTime::now()
-                    .duration_since(std::time::UNIX_EPOCH)
-                    .unwrap()
-                    .as_secs(),
+                now: Self::DEFAULT_TEST_START_TIMESTAMP_SECONDS,
             }
         }
     }
 
     impl NativeEnvironment {
+        pub const DEFAULT_TEST_START_TIMESTAMP_SECONDS: u64 = 999_111_000_u64;
+
         pub fn new(local_canister_id: Option<CanisterId>) -> Self {
             Self {
                 local_canister_id,
                 canister_calls_map: Default::default(),
                 default_canister_call_response: Ok(vec![]),
                 required_canister_call_invocations: Arc::new(RwLock::new(vec![])),
-                now: std::time::SystemTime::now()
-                    .duration_since(std::time::UNIX_EPOCH)
-                    .unwrap()
-                    .as_secs(),
+                now: Self::DEFAULT_TEST_START_TIMESTAMP_SECONDS,
             }
         }
 

--- a/rs/sns/integration_tests/src/neuron.rs
+++ b/rs/sns/integration_tests/src/neuron.rs
@@ -724,7 +724,10 @@ fn test_neuron_action_is_not_authorized() {
 // This is a bit hacky and fragile, as it depends on how `SnsCanisters` is setup.
 // TODO(NNS1-1892): expose SnsCanisters' current time via API.
 fn get_sns_canisters_now_seconds() -> i64 {
-    (NativeEnvironment::default().now() as i64)
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs() as i64
         + (NervousSystemParameters::with_default_values()
             .initial_voting_period_seconds
             .unwrap() as i64)

--- a/rs/sns/test_utils/src/itest_helpers.rs
+++ b/rs/sns/test_utils/src/itest_helpers.rs
@@ -1281,7 +1281,7 @@ impl SnsCanisters<'_> {
                 );
                 return;
             }
-            tokio::time::sleep(Duration::from_millis(100)).await;
+            self.governance.runtime().tick().await;
         }
 
         panic!(


### PR DESCRIPTION
For those who don't know, upgrade proposals (e.g. UpgradeSnsToNextVersion) block all other upgrade actions while they're adopted until they're done executing. If a proposal were to get stuck, this would be a major problem, since the SNS would be un-upgradable. This obviously is a pretty bad scenario, so this PR makes it so only upgrade proposals decided within the last day can block other upgrades.