### PR TITLE
fix: avoid enabling "js" feature of getrandom for wasm32 target

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8855,6 +8855,7 @@ dependencies = [
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
+ "ulid",
  "url",
 ]
 
@@ -21613,11 +21614,10 @@ dependencies = [
 
 [[package]]
 name = "ulid"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04f903f293d11f31c0c29e4148f6dc0d033a7f80cebc0282bea147611667d289"
+checksum = "f294bff79170ed1c5633812aff1e565c35d993a36e757f9bc0accf5eec4e6045"
 dependencies = [
- "getrandom",
  "rand 0.8.5",
  "web-time",
 ]

--- a/rs/rosetta-api/icrc1/Cargo.toml
+++ b/rs/rosetta-api/icrc1/Cargo.toml
@@ -54,6 +54,7 @@ tower-request-id = "^0.3.0"
 tracing = { workspace = true }
 tracing-appender = { workspace = true }
 tracing-subscriber = { workspace = true }
+ulid = ">=1.1.4"
 url = { workspace = true }
 
 [lib]


### PR DESCRIPTION
The dependency "tower-request-id" will pull in crate "ulid", which enables the "js" feature of crate "getrandom" for wasm32 targets. This is at odds for our canister compilation using cargo because because cargo works at global level and both "js" and "custom" features would be enabled, and the result wasm file would have unresolved symbols like `__wbindgen_placeholder__`.

Note that this problem does not exist for bazel compilation, but still is worth fixing.

The fix is simply to require a more recent version of "ulid" that does not enable the "js" feature of "getrandom".