### PR TITLE
feat(nns): Split the active_neurons_in_stable_memory into 2 flags

### DIFF
--- a/rs/nns/governance/src/governance/benches.rs
+++ b/rs/nns/governance/src/governance/benches.rs
@@ -7,9 +7,11 @@ use crate::{
         KnownNeuron, ListNeurons, Neuron as NeuronProto, ProposalData, Topic, Vote,
         VotingPowerEconomics,
     },
-    temporarily_disable_active_neurons_in_stable_memory,
+    temporarily_disable_allow_active_neurons_in_stable_memory,
+    temporarily_disable_migrate_active_neurons_to_stable_memory,
     temporarily_disable_stable_memory_following_index,
-    temporarily_enable_active_neurons_in_stable_memory,
+    temporarily_enable_allow_active_neurons_in_stable_memory,
+    temporarily_enable_migrate_active_neurons_to_stable_memory,
     temporarily_enable_stable_memory_following_index,
     test_utils::{MockEnvironment, StubCMC, StubIcpLedger},
 };
@@ -392,8 +394,9 @@ fn make_neuron(
 
 #[bench(raw)]
 fn cascading_vote_stable_neurons_with_heap_index() -> BenchResult {
-    let _a = temporarily_enable_active_neurons_in_stable_memory();
+    let _a = temporarily_enable_allow_active_neurons_in_stable_memory();
     let _b = temporarily_disable_stable_memory_following_index();
+    let _c = temporarily_enable_migrate_active_neurons_to_stable_memory();
 
     cast_vote_cascade_helper(
         SetUpStrategy::Chain {
@@ -406,8 +409,9 @@ fn cascading_vote_stable_neurons_with_heap_index() -> BenchResult {
 
 #[bench(raw)]
 fn cascading_vote_stable_everything() -> BenchResult {
-    let _a = temporarily_enable_active_neurons_in_stable_memory();
+    let _a = temporarily_enable_allow_active_neurons_in_stable_memory();
     let _b = temporarily_enable_stable_memory_following_index();
+    let _c = temporarily_enable_migrate_active_neurons_to_stable_memory();
 
     cast_vote_cascade_helper(
         SetUpStrategy::Chain {
@@ -420,8 +424,9 @@ fn cascading_vote_stable_everything() -> BenchResult {
 
 #[bench(raw)]
 fn cascading_vote_all_heap() -> BenchResult {
-    let _a = temporarily_disable_active_neurons_in_stable_memory();
+    let _a = temporarily_disable_allow_active_neurons_in_stable_memory();
     let _b = temporarily_disable_stable_memory_following_index();
+    let _c = temporarily_disable_migrate_active_neurons_to_stable_memory();
 
     cast_vote_cascade_helper(
         SetUpStrategy::Chain {
@@ -434,8 +439,9 @@ fn cascading_vote_all_heap() -> BenchResult {
 
 #[bench(raw)]
 fn cascading_vote_heap_neurons_stable_index() -> BenchResult {
-    let _a = temporarily_disable_active_neurons_in_stable_memory();
+    let _a = temporarily_disable_allow_active_neurons_in_stable_memory();
     let _b = temporarily_enable_stable_memory_following_index();
+    let _c = temporarily_disable_migrate_active_neurons_to_stable_memory();
 
     cast_vote_cascade_helper(
         SetUpStrategy::Chain {
@@ -448,8 +454,9 @@ fn cascading_vote_heap_neurons_stable_index() -> BenchResult {
 
 #[bench(raw)]
 fn single_vote_all_stable() -> BenchResult {
-    let _a = temporarily_enable_active_neurons_in_stable_memory();
+    let _a = temporarily_enable_allow_active_neurons_in_stable_memory();
     let _b = temporarily_enable_stable_memory_following_index();
+    let _c = temporarily_enable_migrate_active_neurons_to_stable_memory();
 
     cast_vote_cascade_helper(
         SetUpStrategy::SingleVote { num_neurons: 151 },
@@ -459,8 +466,9 @@ fn single_vote_all_stable() -> BenchResult {
 
 #[bench(raw)]
 fn centralized_following_all_stable() -> BenchResult {
-    let _a = temporarily_enable_active_neurons_in_stable_memory();
+    let _a = temporarily_enable_allow_active_neurons_in_stable_memory();
     let _b = temporarily_enable_stable_memory_following_index();
+    let _c = temporarily_enable_migrate_active_neurons_to_stable_memory();
 
     cast_vote_cascade_helper(
         SetUpStrategy::Centralized { num_neurons: 151 },
@@ -472,7 +480,8 @@ fn centralized_following_all_stable() -> BenchResult {
 fn compute_ballots_for_new_proposal_with_stable_neurons() -> BenchResult {
     let now_seconds = 1732817584;
 
-    let _f = temporarily_enable_active_neurons_in_stable_memory();
+    let _a = temporarily_enable_allow_active_neurons_in_stable_memory();
+    let _b = temporarily_enable_migrate_active_neurons_to_stable_memory();
     let neurons = (0..100)
         .map(|id| {
             (
@@ -558,13 +567,15 @@ fn list_neurons_benchmark() -> BenchResult {
 /// Benchmark list_neurons
 #[bench(raw)]
 fn list_neurons_stable() -> BenchResult {
-    let _f = temporarily_enable_active_neurons_in_stable_memory();
+    let _a = temporarily_enable_allow_active_neurons_in_stable_memory();
+    let _b = temporarily_enable_migrate_active_neurons_to_stable_memory();
     list_neurons_benchmark()
 }
 
 /// Benchmark list_neurons
 #[bench(raw)]
 fn list_neurons_heap() -> BenchResult {
-    let _f = temporarily_disable_active_neurons_in_stable_memory();
+    let _a = temporarily_disable_allow_active_neurons_in_stable_memory();
+    let _b = temporarily_disable_migrate_active_neurons_to_stable_memory();
     list_neurons_benchmark()
 }

--- a/rs/nns/governance/src/lib.rs
+++ b/rs/nns/governance/src/lib.rs
@@ -209,9 +209,11 @@ thread_local! {
 
     static ARE_SET_VISIBILITY_PROPOSALS_ENABLED: Cell<bool> = const { Cell::new(true) };
 
-    static ACTIVE_NEURONS_IN_STABLE_MEMORY_ENABLED: Cell<bool> = const { Cell::new(cfg!(feature = "test")) };
+    static ALLOW_ACTIVE_NEURONS_IN_STABLE_MEMORY: Cell<bool> = const { Cell::new(cfg!(feature = "test")) };
 
     static USE_STABLE_MEMORY_FOLLOWING_INDEX: Cell<bool> = const { Cell::new(cfg!(feature = "test")) };
+
+    static MIGRATE_ACTIVE_NEURONS_TO_STABLE_MEMORY: Cell<bool> = const { Cell::new(cfg!(feature = "test")) };
 }
 
 thread_local! {
@@ -285,20 +287,20 @@ pub fn temporarily_disable_set_visibility_proposals() -> Temporary {
     Temporary::new(&ARE_SET_VISIBILITY_PROPOSALS_ENABLED, false)
 }
 
-pub fn is_active_neurons_in_stable_memory_enabled() -> bool {
-    ACTIVE_NEURONS_IN_STABLE_MEMORY_ENABLED.with(|ok| ok.get())
+pub fn allow_active_neurons_in_stable_memory() -> bool {
+    ALLOW_ACTIVE_NEURONS_IN_STABLE_MEMORY.with(|ok| ok.get())
 }
 
 /// Only integration tests should use this.
 #[cfg(any(test, feature = "canbench-rs", feature = "test"))]
-pub fn temporarily_enable_active_neurons_in_stable_memory() -> Temporary {
-    Temporary::new(&ACTIVE_NEURONS_IN_STABLE_MEMORY_ENABLED, true)
+pub fn temporarily_enable_allow_active_neurons_in_stable_memory() -> Temporary {
+    Temporary::new(&ALLOW_ACTIVE_NEURONS_IN_STABLE_MEMORY, true)
 }
 
 /// Only integration tests should use this.
 #[cfg(any(test, feature = "canbench-rs", feature = "test"))]
-pub fn temporarily_disable_active_neurons_in_stable_memory() -> Temporary {
-    Temporary::new(&ACTIVE_NEURONS_IN_STABLE_MEMORY_ENABLED, false)
+pub fn temporarily_disable_allow_active_neurons_in_stable_memory() -> Temporary {
+    Temporary::new(&ALLOW_ACTIVE_NEURONS_IN_STABLE_MEMORY, false)
 }
 
 pub fn use_stable_memory_following_index() -> bool {
@@ -315,6 +317,22 @@ pub fn temporarily_enable_stable_memory_following_index() -> Temporary {
 #[cfg(any(test, feature = "canbench-rs", feature = "test"))]
 pub fn temporarily_disable_stable_memory_following_index() -> Temporary {
     Temporary::new(&USE_STABLE_MEMORY_FOLLOWING_INDEX, false)
+}
+
+pub fn migrate_active_neurons_to_stable_memory() -> bool {
+    MIGRATE_ACTIVE_NEURONS_TO_STABLE_MEMORY.with(|ok| ok.get())
+}
+
+/// Only integration tests should use this.
+#[cfg(any(test, feature = "canbench-rs", feature = "test"))]
+pub fn temporarily_enable_migrate_active_neurons_to_stable_memory() -> Temporary {
+    Temporary::new(&MIGRATE_ACTIVE_NEURONS_TO_STABLE_MEMORY, true)
+}
+
+/// Only integration tests should use this.
+#[cfg(any(test, feature = "canbench-rs", feature = "test"))]
+pub fn temporarily_disable_migrate_active_neurons_to_stable_memory() -> Temporary {
+    Temporary::new(&MIGRATE_ACTIVE_NEURONS_TO_STABLE_MEMORY, false)
 }
 
 pub fn decoder_config() -> DecoderConfig {

--- a/rs/nns/governance/src/neuron_data_validation.rs
+++ b/rs/nns/governance/src/neuron_data_validation.rs
@@ -1,5 +1,5 @@
 use crate::{
-    is_active_neurons_in_stable_memory_enabled,
+    allow_active_neurons_in_stable_memory,
     neuron::Neuron,
     neuron_store::NeuronStore,
     pb::v1::Topic,
@@ -225,7 +225,7 @@ impl ValidationInProgress {
             KnownNeuronIndexValidator,
         >::new()));
 
-        if !is_active_neurons_in_stable_memory_enabled() {
+        if !allow_active_neurons_in_stable_memory() {
             tasks.push_back(Box::new(StableNeuronStoreValidator::new(
                 INACTIVE_NEURON_VALIDATION_CHUNK_SIZE,
             )));
@@ -688,7 +688,7 @@ mod tests {
         neuron::{DissolveStateAndAge, NeuronBuilder},
         pb::v1::{neuron::Followees, KnownNeuronData},
         storage::{with_stable_neuron_indexes_mut, with_stable_neuron_store_mut},
-        temporarily_disable_active_neurons_in_stable_memory,
+        temporarily_disable_allow_active_neurons_in_stable_memory,
     };
 
     thread_local! {
@@ -996,7 +996,7 @@ mod tests {
 
     #[test]
     fn test_validator_invalid_issues_active_neuron_in_stable() {
-        let _t = temporarily_disable_active_neurons_in_stable_memory();
+        let _t = temporarily_disable_allow_active_neurons_in_stable_memory();
 
         // Step 1: Cause an issue with active neuron in stable storage.
         // Step 1.1 First create it as an inactive neuron so it can be added to stable storage.

--- a/rs/nns/governance/src/neuron_store/benches.rs
+++ b/rs/nns/governance/src/neuron_store/benches.rs
@@ -6,8 +6,10 @@ use crate::{
     neurons_fund::{NeuronsFund, NeuronsFundNeuronPortion, NeuronsFundSnapshot},
     now_seconds,
     pb::v1::{neuron::Followees, BallotInfo, Vote},
-    temporarily_disable_active_neurons_in_stable_memory,
-    temporarily_enable_active_neurons_in_stable_memory,
+    temporarily_disable_allow_active_neurons_in_stable_memory,
+    temporarily_disable_migrate_active_neurons_to_stable_memory,
+    temporarily_enable_allow_active_neurons_in_stable_memory,
+    temporarily_enable_migrate_active_neurons_to_stable_memory,
     temporarily_enable_stable_memory_following_index,
 };
 use canbench_rs::{bench, bench_fn, BenchResult};
@@ -198,8 +200,9 @@ fn add_neuron_inactive_maximum() -> BenchResult {
 
 #[bench(raw)]
 fn update_recent_ballots_stable_memory() -> BenchResult {
-    let _a = temporarily_enable_active_neurons_in_stable_memory();
+    let _a = temporarily_enable_allow_active_neurons_in_stable_memory();
     let _b = temporarily_enable_stable_memory_following_index();
+    let _c = temporarily_enable_migrate_active_neurons_to_stable_memory();
     let mut rng = new_rng();
     let mut neuron_store = set_up_neuron_store(&mut rng, 100, 200);
     let neuron = new_neuron_builder(&mut rng, NeuronLocation::Heap, NeuronSize::Maximum).build();
@@ -239,7 +242,8 @@ fn range_neurons_performance() -> BenchResult {
 
 #[bench(raw)]
 fn neuron_metrics_calculation_heap() -> BenchResult {
-    let _f = temporarily_disable_active_neurons_in_stable_memory();
+    let _a = temporarily_disable_allow_active_neurons_in_stable_memory();
+    let _b = temporarily_disable_migrate_active_neurons_to_stable_memory();
     let mut rng = new_rng();
     let neuron_store = set_up_neuron_store(&mut rng, 100, 0);
 
@@ -250,7 +254,8 @@ fn neuron_metrics_calculation_heap() -> BenchResult {
 
 #[bench(raw)]
 fn neuron_metrics_calculation_stable() -> BenchResult {
-    let _f = temporarily_enable_active_neurons_in_stable_memory();
+    let _a = temporarily_enable_allow_active_neurons_in_stable_memory();
+    let _b = temporarily_enable_migrate_active_neurons_to_stable_memory();
 
     let mut rng = new_rng();
     let neuron_store = set_up_neuron_store(&mut rng, 100, 0);
@@ -284,7 +289,8 @@ fn add_neuron_ready_to_spawn(
 
 #[bench(raw)]
 fn list_ready_to_spawn_neuron_ids_heap() -> BenchResult {
-    let _t = temporarily_disable_active_neurons_in_stable_memory();
+    let _a = temporarily_disable_allow_active_neurons_in_stable_memory();
+    let _b = temporarily_disable_migrate_active_neurons_to_stable_memory();
     let mut rng = new_rng();
     let mut neuron_store = set_up_neuron_store(&mut rng, 1_000, 2_000);
     add_neuron_ready_to_spawn(now_seconds(), &mut rng, &mut neuron_store);
@@ -294,7 +300,8 @@ fn list_ready_to_spawn_neuron_ids_heap() -> BenchResult {
 
 #[bench(raw)]
 fn list_ready_to_spawn_neuron_ids_stable() -> BenchResult {
-    let _t = temporarily_enable_active_neurons_in_stable_memory();
+    let _a = temporarily_enable_allow_active_neurons_in_stable_memory();
+    let _b = temporarily_enable_migrate_active_neurons_to_stable_memory();
     let mut rng = new_rng();
     let mut neuron_store = set_up_neuron_store(&mut rng, 1_000, 2_000);
     add_neuron_ready_to_spawn(now_seconds(), &mut rng, &mut neuron_store);
@@ -327,7 +334,8 @@ fn add_neuron_ready_to_unstake_maturity(
 
 #[bench(raw)]
 fn list_neurons_ready_to_unstake_maturity_heap() -> BenchResult {
-    let _t = temporarily_disable_active_neurons_in_stable_memory();
+    let _a = temporarily_disable_allow_active_neurons_in_stable_memory();
+    let _b = temporarily_disable_migrate_active_neurons_to_stable_memory();
     let mut rng = new_rng();
     let mut neuron_store = set_up_neuron_store(&mut rng, 1_000, 2_000);
     add_neuron_ready_to_unstake_maturity(now_seconds(), &mut rng, &mut neuron_store);
@@ -337,7 +345,8 @@ fn list_neurons_ready_to_unstake_maturity_heap() -> BenchResult {
 
 #[bench(raw)]
 fn list_neurons_ready_to_unstake_maturity_stable() -> BenchResult {
-    let _t = temporarily_enable_active_neurons_in_stable_memory();
+    let _a = temporarily_enable_allow_active_neurons_in_stable_memory();
+    let _b = temporarily_enable_migrate_active_neurons_to_stable_memory();
     let mut rng = new_rng();
     let mut neuron_store = set_up_neuron_store(&mut rng, 1_000, 2_000);
     add_neuron_ready_to_unstake_maturity(now_seconds(), &mut rng, &mut neuron_store);
@@ -367,7 +376,8 @@ fn build_neurons_fund_portion(neuron: &Neuron, amount_icp_e8s: u64) -> NeuronsFu
 
 #[bench(raw)]
 fn draw_maturity_from_neurons_fund_heap() -> BenchResult {
-    let _t = temporarily_disable_active_neurons_in_stable_memory();
+    let _a = temporarily_disable_allow_active_neurons_in_stable_memory();
+    let _b = temporarily_disable_migrate_active_neurons_to_stable_memory();
     let mut rng = new_rng();
     let mut neuron_store = NeuronStore::new(BTreeMap::new());
     let mut neurons_fund_neurons = BTreeSet::new();
@@ -389,7 +399,8 @@ fn draw_maturity_from_neurons_fund_heap() -> BenchResult {
 
 #[bench(raw)]
 fn draw_maturity_from_neurons_fund_stable() -> BenchResult {
-    let _t = temporarily_enable_active_neurons_in_stable_memory();
+    let _a = temporarily_enable_allow_active_neurons_in_stable_memory();
+    let _b = temporarily_enable_migrate_active_neurons_to_stable_memory();
     let mut rng = new_rng();
     let mut neuron_store = NeuronStore::new(BTreeMap::new());
     let mut neurons_fund_neurons = BTreeSet::new();
@@ -411,7 +422,8 @@ fn draw_maturity_from_neurons_fund_stable() -> BenchResult {
 
 #[bench(raw)]
 fn list_active_neurons_fund_neurons_heap() -> BenchResult {
-    let _t = temporarily_disable_active_neurons_in_stable_memory();
+    let _a = temporarily_disable_allow_active_neurons_in_stable_memory();
+    let _b = temporarily_disable_migrate_active_neurons_to_stable_memory();
     let mut rng = new_rng();
     let mut neuron_store = NeuronStore::new(BTreeMap::new());
     for _ in 0..100 {
@@ -426,7 +438,8 @@ fn list_active_neurons_fund_neurons_heap() -> BenchResult {
 
 #[bench(raw)]
 fn list_active_neurons_fund_neurons_stable() -> BenchResult {
-    let _t = temporarily_enable_active_neurons_in_stable_memory();
+    let _a = temporarily_enable_allow_active_neurons_in_stable_memory();
+    let _b = temporarily_enable_migrate_active_neurons_to_stable_memory();
     let mut rng = new_rng();
     let mut neuron_store = NeuronStore::new(BTreeMap::new());
     for _ in 0..100 {
@@ -457,7 +470,8 @@ fn validate_all_neurons(neuron_store: &NeuronStore, validator: &mut NeuronDataVa
 
 #[bench(raw)]
 fn neuron_data_validation_heap() -> BenchResult {
-    let _t = temporarily_disable_active_neurons_in_stable_memory();
+    let _a = temporarily_disable_allow_active_neurons_in_stable_memory();
+    let _b = temporarily_disable_migrate_active_neurons_to_stable_memory();
     let mut rng = new_rng();
     let neuron_store = set_up_neuron_store(&mut rng, 100, 200);
     let mut validator = NeuronDataValidator::new();
@@ -469,7 +483,8 @@ fn neuron_data_validation_heap() -> BenchResult {
 
 #[bench(raw)]
 fn neuron_data_validation_stable() -> BenchResult {
-    let _t = temporarily_enable_active_neurons_in_stable_memory();
+    let _a = temporarily_enable_allow_active_neurons_in_stable_memory();
+    let _b = temporarily_enable_migrate_active_neurons_to_stable_memory();
     let mut rng = new_rng();
     let neuron_store = set_up_neuron_store(&mut rng, 100, 200);
     let mut validator = NeuronDataValidator::new();

--- a/rs/nns/governance/src/neuron_store/metrics.rs
+++ b/rs/nns/governance/src/neuron_store/metrics.rs
@@ -248,7 +248,7 @@ impl NeuronStore {
         voting_power_economics: &VotingPowerEconomics,
         now_seconds: u64,
     ) -> NeuronMetrics {
-        let mut metrics = if self.use_stable_memory_for_all_neurons {
+        let mut metrics = if self.allow_active_neurons_in_stable_memory {
             NeuronMetrics {
                 ..Default::default()
             }
@@ -265,7 +265,7 @@ impl NeuronStore {
             }
         };
 
-        if self.use_stable_memory_for_all_neurons {
+        if self.allow_active_neurons_in_stable_memory {
             self.compute_neuron_metrics_all_stable(
                 &mut metrics,
                 neuron_minimum_stake_e8s,

--- a/rs/nns/governance/src/neuron_store/neuron_store_tests.rs
+++ b/rs/nns/governance/src/neuron_store/neuron_store_tests.rs
@@ -3,7 +3,8 @@ use crate::{
     neuron::{DissolveStateAndAge, NeuronBuilder},
     pb::v1::neuron::Followees,
     storage::with_stable_neuron_indexes,
-    temporarily_disable_active_neurons_in_stable_memory,
+    temporarily_disable_allow_active_neurons_in_stable_memory,
+    temporarily_disable_migrate_active_neurons_to_stable_memory,
 };
 use ic_nervous_system_common::{ONE_DAY_SECONDS, ONE_MONTH_SECONDS};
 use ic_nns_constants::GOVERNANCE_CANISTER_ID;
@@ -192,7 +193,7 @@ fn test_add_neurons() {
 
     // Step 3.1: verify that the active neuron is in the heap, not in the stable neuron store, and
     // can be read.
-    if is_active_neurons_in_stable_memory_enabled() {
+    if migrate_active_neurons_to_stable_memory() {
         assert!(is_neuron_in_stable(active_neuron.id()));
         assert!(!is_neuron_in_heap(&neuron_store, active_neuron.id()));
     } else {
@@ -361,7 +362,7 @@ fn test_batch_validate_neurons_in_stable_store_are_inactive_invalid() {
         neuron_store.batch_validate_neurons_in_stable_store_are_inactive(NeuronId::min_value(), 10);
 
     // Step 3: verifies the results - the active neuron in stable storage should be found as invalid.
-    if is_active_neurons_in_stable_memory_enabled() {
+    if allow_active_neurons_in_stable_memory() {
         assert_eq!(invalid_neuron_ids, vec![]);
     } else {
         assert_eq!(invalid_neuron_ids, vec![neuron.id()]);
@@ -415,7 +416,8 @@ fn assert_neuron_in_neuron_store_eq(neuron_store: &NeuronStore, neuron: &Neuron)
 #[test]
 fn test_from_active_to_active() {
     // This test doesn't make sense after neurons are migrated completely to stable memory.
-    let _f = temporarily_disable_active_neurons_in_stable_memory();
+    let _a = temporarily_disable_allow_active_neurons_in_stable_memory();
+    let _b = temporarily_disable_migrate_active_neurons_to_stable_memory();
 
     // Step 1.1: set up an empty neuron store with an active neuron.
     let mut neuron_store = NeuronStore::new(BTreeMap::new());
@@ -444,7 +446,8 @@ fn test_from_active_to_active() {
 #[test]
 fn test_from_active_to_inactive() {
     // This test doesn't make sense after neurons are migrated completely to stable memory.
-    let _f = temporarily_disable_active_neurons_in_stable_memory();
+    let _a = temporarily_disable_allow_active_neurons_in_stable_memory();
+    let _b = temporarily_disable_migrate_active_neurons_to_stable_memory();
 
     // Step 1.1: set up an empty neuron store with an active neuron which would be inactive if there
     // is no fund.
@@ -475,7 +478,8 @@ fn test_from_active_to_inactive() {
 #[test]
 fn test_from_inactive_to_active() {
     // This test doesn't make sense after neurons are migrated completely to stable memory.
-    let _f = temporarily_disable_active_neurons_in_stable_memory();
+    let _a = temporarily_disable_allow_active_neurons_in_stable_memory();
+    let _b = temporarily_disable_migrate_active_neurons_to_stable_memory();
 
     // Step 1.1: set up an empty neuron store with an inactive neuron.
     let mut neuron_store = NeuronStore::new(BTreeMap::new());
@@ -506,7 +510,8 @@ fn test_from_inactive_to_active() {
 #[test]
 fn test_from_inactive_to_inactive() {
     // This test doesn't make sense after neurons are migrated completely to stable memory.
-    let _f = temporarily_disable_active_neurons_in_stable_memory();
+    let _a = temporarily_disable_allow_active_neurons_in_stable_memory();
+    let _b = temporarily_disable_migrate_active_neurons_to_stable_memory();
 
     // Step 1.1: set up an empty neuron store with an inactive neuron.
     let mut neuron_store = NeuronStore::new(BTreeMap::new());
@@ -537,7 +542,8 @@ fn test_from_inactive_to_inactive() {
 #[test]
 fn test_from_stale_inactive_to_inactive() {
     // This test doesn't make sense after neurons are migrated completely to stable memory.
-    let _f = temporarily_disable_active_neurons_in_stable_memory();
+    let _a = temporarily_disable_allow_active_neurons_in_stable_memory();
+    let _b = temporarily_disable_migrate_active_neurons_to_stable_memory();
 
     // Step 1.1: set up an empty neuron store with an active neuron.
     let mut neuron_store = NeuronStore::new(BTreeMap::new());
@@ -565,7 +571,8 @@ fn test_from_stale_inactive_to_inactive() {
 #[test]
 fn test_from_stale_inactive_to_active() {
     // This test doesn't make sense after neurons are migrated completely to stable memory.
-    let _f = temporarily_disable_active_neurons_in_stable_memory();
+    let _a = temporarily_disable_allow_active_neurons_in_stable_memory();
+    let _b = temporarily_disable_migrate_active_neurons_to_stable_memory();
 
     // Step 1.1: set up an empty neuron store with an active neuron.
     let mut neuron_store = NeuronStore::new(BTreeMap::new());
@@ -909,7 +916,8 @@ fn test_get_non_empty_neuron_ids_readable_by_caller() {
 #[test]
 fn test_batch_adjust_neurons_storage() {
     // This test doesn't make sense after neurons are migrated completely to stable memory.
-    let _f = temporarily_disable_active_neurons_in_stable_memory();
+    let _a = temporarily_disable_allow_active_neurons_in_stable_memory();
+    let _b = temporarily_disable_migrate_active_neurons_to_stable_memory();
 
     // Step 1.1: set up an empty neuron store.
     let mut neuron_store = NeuronStore::new(BTreeMap::new());
@@ -967,7 +975,8 @@ fn test_batch_adjust_neurons_storage() {
 #[test]
 fn test_batch_adjust_neurons_storage_exceeds_instructions_limit() {
     // This test doesn't make sense after neurons are migrated completely to stable memory.
-    let _f = temporarily_disable_active_neurons_in_stable_memory();
+    let _a = temporarily_disable_allow_active_neurons_in_stable_memory();
+    let _b = temporarily_disable_migrate_active_neurons_to_stable_memory();
 
     // Step 1.1: set up an empty neuron store.
     let mut neuron_store = NeuronStore::new(BTreeMap::new());


### PR DESCRIPTION
# Why

The previous set up for the feature flag `active_neurons_in_stable_memory` does not allow us to safely rollback if necessary, because the rolled back version would only look for active neurons in the heap memory, while some would still be in the stable memory until the timer picks them up (if the reverse migration is implemented).

# What

Use `allow_active_neurons_in_stable_memory` for whether the canister allows active neurons to be in stable memory, by checking stable memory when iterating/finding active neurons.

Use `migrate_active_neurons_to_stable_memory` for whether the active neurons should be in stable memory, so that the migration task in the timer would move them accordingly.

## Launch/Rollback Plan

With the new setup, we can:

1. Turn on `allow_active_neurons_in_stable_memory`. If any problems occur, we can roll it back.
2. If there is no problem found, we can turn on `migrate_active_neurons_to_stable_memory`. If any problems occur, we can roll back `migrate_active_neurons_to_stable_memory` and a later PR (which should be merged before launching) will  do the reverse migration. We cannot rollback the 2 flags simultaneously (refer to the "Why" section above).
3. If we have to rollback `allow_active_neurons_in_stable_memory` at this point (however unlikely), we can rollback `migrate_active_neurons_to_stable_memory` first, and do another release to rollback `allow_active_neurons_in_stable_memory` after we confirm that the reverse migration has been completed.
