### PR TITLE
feat(node): add fstrim datadir observability

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8389,6 +8389,7 @@ dependencies = [
  "maplit",
  "predicates",
  "rand 0.8.5",
+ "regex",
  "tempfile",
 ]
 

--- a/rs/ic_os/fstrim_tool/BUILD.bazel
+++ b/rs/ic_os/fstrim_tool/BUILD.bazel
@@ -17,6 +17,7 @@ DEV_DEPENDENCIES = [
     "@crate_index//:assert_matches",
     "@crate_index//:predicates",
     "@crate_index//:rand",
+    "@crate_index//:regex",
     "@crate_index//:tempfile",
 ]
 

--- a/rs/ic_os/fstrim_tool/Cargo.toml
+++ b/rs/ic_os/fstrim_tool/Cargo.toml
@@ -19,4 +19,5 @@ assert_matches = { workspace = true }
 ic-crypto-test-utils-reproducible-rng = { path = "../../crypto/test_utils/reproducible_rng" }
 predicates = { workspace = true }
 rand = { workspace = true }
+regex = { workspace = true }
 tempfile = { workspace = true }

--- a/rs/ic_os/fstrim_tool/src/metrics/mod.rs
+++ b/rs/ic_os/fstrim_tool/src/metrics/mod.rs
@@ -54,33 +54,39 @@ impl FsTrimMetrics {
     }
 
     pub fn to_p8s_metrics_string(&self) -> String {
+        let fstrim_last_run_duration_milliseconds = to_go_f64(self.last_duration_milliseconds);
+        let fstrim_last_run_success = if self.last_run_success { "1" } else { "0" };
+        let fstrim_runs_total = to_go_f64(self.total_runs);
+
+        let fstrim_datadir_last_run_duration_milliseconds =
+            to_go_f64(self.last_duration_milliseconds_datadir);
+        let fstrim_datadir_last_run_success = if self.last_run_success_datadir {
+            "1"
+        } else {
+            "0"
+        };
+        let fstrim_datadir_runs_total = to_go_f64(self.total_runs_datadir);
+
         format!(
             "# HELP fstrim_last_run_duration_milliseconds Duration of last run of fstrim in milliseconds\n\
             # TYPE fstrim_last_run_duration_milliseconds gauge\n\
-            fstrim_last_run_duration_milliseconds {}\n\
+            fstrim_last_run_duration_milliseconds {fstrim_last_run_duration_milliseconds}\n\
             # HELP fstrim_last_run_success Success status of last run of fstrim (success: 1, failure: 0)\n\
             # TYPE fstrim_last_run_success gauge\n\
-            fstrim_last_run_success {}\n\
+            fstrim_last_run_success {fstrim_last_run_success}\n\
             # HELP fstrim_runs_total Total number of runs of fstrim\n\
             # TYPE fstrim_runs_total counter\n\
-            fstrim_runs_total {}\n\
+            fstrim_runs_total {fstrim_runs_total}\n\
             # HELP fstrim_datadir_last_run_duration_milliseconds Duration of last run of fstrim on datadir in milliseconds\n\
             # TYPE fstrim_datadir_last_run_duration_milliseconds gauge\n\
-            fstrim_datadir_last_run_duration_milliseconds {}\n\
+            fstrim_datadir_last_run_duration_milliseconds {fstrim_datadir_last_run_duration_milliseconds}\n\
             # HELP fstrim_datadir_last_run_success Success status of last run of fstrim on datadir (success: 1, failure: 0)\n\
             # TYPE fstrim_datadir_last_run_success gauge\n\
-            fstrim_datadir_last_run_success {}\n\
+            fstrim_datadir_last_run_success {fstrim_datadir_last_run_success}\n\
             # HELP fstrim_datadir_runs_total Total number of runs of fstrim on datadir\n\
             # TYPE fstrim_datadir_runs_total counter\n\
-            fstrim_datadir_runs_total {}\n",
-            to_go_f64(self.last_duration_milliseconds),
-            if self.last_run_success { "1" } else { "0" },
-            to_go_f64(self.total_runs),
-            to_go_f64(self.last_duration_milliseconds_datadir),
-            if self.last_run_success_datadir { "1" } else { "0" },
-            to_go_f64(self.total_runs_datadir),
+            fstrim_datadir_runs_total {fstrim_datadir_runs_total}\n"
         )
-        .to_string()
     }
 
     fn are_valid(&self) -> bool {

--- a/rs/ic_os/fstrim_tool/src/metrics/mod.rs
+++ b/rs/ic_os/fstrim_tool/src/metrics/mod.rs
@@ -8,11 +8,20 @@ const METRICS_LAST_RUN_DURATION_MILLISECONDS: &str = "fstrim_last_run_duration_m
 const METRICS_LAST_RUN_SUCCESS: &str = "fstrim_last_run_success";
 const METRICS_RUNS_TOTAL: &str = "fstrim_runs_total";
 
+const METRICS_LAST_RUN_DURATION_MILLISECONDS_DATADIR: &str =
+    "fstrim_datadir_last_run_duration_milliseconds";
+const METRICS_LAST_RUN_SUCCESS_DATADIR: &str = "fstrim_datadir_last_run_success";
+const METRICS_RUNS_TOTAL_DATADIR: &str = "fstrim_datadir_runs_total";
+
 #[derive(Debug)]
 pub struct FsTrimMetrics {
     pub last_duration_milliseconds: f64,
     pub last_run_success: bool,
     pub total_runs: f64,
+
+    pub last_duration_milliseconds_datadir: f64,
+    pub last_run_success_datadir: bool,
+    pub total_runs_datadir: f64,
 }
 
 impl Default for FsTrimMetrics {
@@ -21,6 +30,10 @@ impl Default for FsTrimMetrics {
             last_duration_milliseconds: 0f64,
             last_run_success: true,
             total_runs: 0f64,
+
+            last_duration_milliseconds_datadir: 0f64,
+            last_run_success_datadir: true,
+            total_runs_datadir: 0f64,
         }
     }
 }
@@ -30,6 +43,13 @@ impl FsTrimMetrics {
         self.total_runs += 1f64;
         self.last_run_success = success;
         self.last_duration_milliseconds = duration.as_millis() as f64;
+        Ok(())
+    }
+
+    pub(crate) fn update_datadir(&mut self, success: bool, duration: Duration) -> Result<()> {
+        self.total_runs_datadir += 1f64;
+        self.last_run_success_datadir = success;
+        self.last_duration_milliseconds_datadir = duration.as_millis() as f64;
         Ok(())
     }
 
@@ -43,16 +63,31 @@ impl FsTrimMetrics {
             fstrim_last_run_success {}\n\
             # HELP fstrim_runs_total Total number of runs of fstrim\n\
             # TYPE fstrim_runs_total counter\n\
-            fstrim_runs_total {}\n",
+            fstrim_runs_total {}\n\
+            # HELP fstrim_datadir_last_run_duration_milliseconds Duration of last run of fstrim on datadir in milliseconds\n\
+            # TYPE fstrim_datadir_last_run_duration_milliseconds gauge\n\
+            fstrim_datadir_last_run_duration_milliseconds {}\n\
+            # HELP fstrim_datadir_last_run_success Success status of last run of fstrim on datadir (success: 1, failure: 0)\n\
+            # TYPE fstrim_datadir_last_run_success gauge\n\
+            fstrim_datadir_last_run_success {}\n\
+            # HELP fstrim_datadir_runs_total Total number of runs of fstrim on datadir\n\
+            # TYPE fstrim_datadir_runs_total counter\n\
+            fstrim_datadir_runs_total {}\n",
             to_go_f64(self.last_duration_milliseconds),
             if self.last_run_success { "1" } else { "0" },
             to_go_f64(self.total_runs),
-        ).to_string()
+            to_go_f64(self.last_duration_milliseconds_datadir),
+            if self.last_run_success_datadir { "1" } else { "0" },
+            to_go_f64(self.total_runs_datadir),
+        )
+        .to_string()
     }
 
     fn are_valid(&self) -> bool {
         is_f64_finite_and_0_or_larger(self.total_runs)
             && is_f64_finite_and_0_or_larger(self.last_duration_milliseconds)
+            && is_f64_finite_and_0_or_larger(self.total_runs_datadir)
+            && is_f64_finite_and_0_or_larger(self.last_duration_milliseconds_datadir)
     }
 }
 
@@ -102,27 +137,41 @@ where
         let mut last_duration_milliseconds: Option<f64> = None;
         let mut last_run_success: Option<bool> = None;
         let mut total_runs: Option<f64> = None;
+
+        // Default datadir fields (we treat them as optional in the metrics file)
+        let mut datadir_last_duration_milliseconds: f64 = 0f64;
+        let mut datadir_last_run_success: bool = true;
+        let mut datadir_total_runs: f64 = 0f64;
+
         for line_or_err in lines {
             let line = line_or_err.map_err(|e| format_err!("failed to read line: {}", e))?;
             match line.split(' ').collect::<Vec<_>>()[..] {
                 ["#", ..] => continue,
                 [key, value] => match key {
                     METRICS_LAST_RUN_DURATION_MILLISECONDS => {
-                        let _ = last_duration_milliseconds
-                            .get_or_insert(parse_metrics_value(key, value)?);
+                        last_duration_milliseconds.get_or_insert(parse_metrics_value(key, value)?);
                     }
                     METRICS_LAST_RUN_SUCCESS => {
-                        let _ =
-                            last_run_success.get_or_insert(parse_metrics_value(key, value)? > 0f64);
+                        last_run_success.get_or_insert(parse_metrics_value(key, value)? > 0f64);
                     }
                     METRICS_RUNS_TOTAL => {
-                        let _ = total_runs.get_or_insert(parse_metrics_value(key, value)?);
+                        total_runs.get_or_insert(parse_metrics_value(key, value)?);
+                    }
+                    METRICS_LAST_RUN_DURATION_MILLISECONDS_DATADIR => {
+                        datadir_last_duration_milliseconds = parse_metrics_value(key, value)?;
+                    }
+                    METRICS_LAST_RUN_SUCCESS_DATADIR => {
+                        datadir_last_run_success = parse_metrics_value(key, value)? > 0f64;
+                    }
+                    METRICS_RUNS_TOTAL_DATADIR => {
+                        datadir_total_runs = parse_metrics_value(key, value)?;
                     }
                     _ => return Err(format_err!("unknown metric key: {}", key)),
                 },
                 _ => return Err(format_err!("invalid metric line: {:?}", line)),
             }
         }
+
         let metrics = FsTrimMetrics {
             last_duration_milliseconds: last_duration_milliseconds.ok_or(format_err!(
                 "missing metric: {}",
@@ -131,6 +180,9 @@ where
             last_run_success: last_run_success
                 .ok_or(format_err!("missing metric: {}", METRICS_LAST_RUN_SUCCESS))?,
             total_runs: total_runs.ok_or(format_err!("missing metric: {}", METRICS_RUNS_TOTAL))?,
+            last_duration_milliseconds_datadir: datadir_last_duration_milliseconds,
+            last_run_success_datadir: datadir_last_run_success,
+            total_runs_datadir: datadir_total_runs,
         };
         if !metrics.are_valid() {
             return Err(format_err!("parsed metrics are invalid"));
@@ -148,6 +200,12 @@ impl PartialEq for FsTrimMetrics {
                 other.last_duration_milliseconds,
             )
             && (self.last_run_success == other.last_run_success)
+            && f64_approx_eq(
+                self.last_duration_milliseconds_datadir,
+                other.last_duration_milliseconds_datadir,
+            )
+            && (self.last_run_success_datadir == other.last_run_success_datadir)
+            && f64_approx_eq(self.total_runs_datadir, other.total_runs_datadir)
     }
 }
 

--- a/rs/ic_os/fstrim_tool/src/metrics/tests.rs
+++ b/rs/ic_os/fstrim_tool/src/metrics/tests.rs
@@ -7,7 +7,7 @@ use std::time::Duration;
 use tempfile::tempdir;
 
 #[test]
-fn should_compare_f64() {
+fn test_f64_comparison() {
     assert!(f64_approx_eq(f64::NAN, f64::NAN));
     assert!(f64_approx_eq(f64::INFINITY, f64::INFINITY));
     assert!(f64_approx_eq(f64::INFINITY + 1f64, f64::INFINITY));
@@ -18,7 +18,7 @@ fn should_compare_f64() {
 }
 
 #[test]
-fn should_parse_valid_metrics_file() {
+fn test_parse_valid_metrics_file() {
     let temp_dir = tempdir().expect("failed to create a temporary directory");
     let test_file = temp_dir.as_ref().join("test_file");
     let metrics_file_content =
@@ -46,7 +46,7 @@ fn should_parse_valid_metrics_file() {
 }
 
 #[test]
-fn should_only_consider_first_parsed_value_when_parsing_metrics_file() {
+fn test_ignore_subsequent_values_for_same_metric() {
     let temp_dir = tempdir().expect("failed to create a temporary directory");
     let test_file = temp_dir.as_ref().join("test_file");
     let metrics_file_content =
@@ -77,7 +77,7 @@ fn should_only_consider_first_parsed_value_when_parsing_metrics_file() {
 }
 
 #[test]
-fn should_return_error_when_parsing_empty_metrics_file() {
+fn test_error_on_empty_metrics_file() {
     let temp_dir = tempfile::TempDir::new().expect("failed to create a temporary directory");
     let test_file = temp_dir.as_ref().join("test_file");
     write(&test_file, "").expect("error writing to file");
@@ -86,7 +86,7 @@ fn should_return_error_when_parsing_empty_metrics_file() {
 }
 
 #[test]
-fn should_return_error_for_metrics_file_with_too_many_tokens() {
+fn test_error_when_metrics_file_has_too_many_tokens() {
     let temp_dir = tempfile::TempDir::new().expect("failed to create a temporary directory");
     let test_file = temp_dir.as_ref().join("test_file");
     write(&test_file, "pineapple on pizza is delicious").expect("error writing to file");
@@ -97,7 +97,7 @@ fn should_return_error_for_metrics_file_with_too_many_tokens() {
 }
 
 #[test]
-fn should_return_error_for_metrics_file_with_unknown_metric_name() {
+fn test_error_when_unknown_metric_name() {
     let temp_dir = tempfile::TempDir::new().expect("failed to create a temporary directory");
     let test_file = temp_dir.as_ref().join("test_file");
     write(&test_file, "pineapple pizza").expect("error writing to file");
@@ -108,7 +108,7 @@ fn should_return_error_for_metrics_file_with_unknown_metric_name() {
 }
 
 #[test]
-fn should_return_error_for_metrics_file_with_timestamp() {
+fn test_error_when_metrics_file_has_timestamp() {
     let temp_dir = tempfile::TempDir::new().expect("failed to create a temporary directory");
     let test_file = temp_dir.as_ref().join("test_file");
     write(
@@ -123,7 +123,7 @@ fn should_return_error_for_metrics_file_with_timestamp() {
 }
 
 #[test]
-fn should_return_error_for_metrics_file_with_non_numeric_value() {
+fn test_error_when_metrics_file_has_non_numeric_value() {
     let temp_dir = tempfile::TempDir::new().expect("failed to create a temporary directory");
     let test_file = temp_dir.as_ref().join("test_file");
     write(&test_file, format!("{} pizza", METRICS_RUNS_TOTAL).as_str())
@@ -135,7 +135,7 @@ fn should_return_error_for_metrics_file_with_non_numeric_value() {
 }
 
 #[test]
-fn should_return_none_when_parsing_if_metrics_file_does_not_exist() {
+fn test_if_file_does_not_exist() {
     let temp_dir = tempfile::TempDir::new().expect("failed to create a temporary directory");
     let test_file = temp_dir.as_ref().join("test_file");
     let parsed_metrics = parse_existing_metrics_from_file(&test_file.to_string_lossy()).unwrap();
@@ -143,7 +143,7 @@ fn should_return_none_when_parsing_if_metrics_file_does_not_exist() {
 }
 
 #[test]
-fn should_set_metrics() {
+fn test_set_metrics() {
     let mut existing_metrics = FsTrimMetrics::default();
     existing_metrics
         .update(true, Duration::from_millis(110))
@@ -158,7 +158,7 @@ fn should_set_metrics() {
 }
 
 #[test]
-fn should_update_metrics() {
+fn test_update_metrics() {
     let mut rng = reproducible_rng();
     for _ in 0..100 {
         let total_runs: u64 = rng.gen_range(0..10000000);
@@ -196,7 +196,7 @@ fn update_metrics_locally(metrics: &mut FsTrimMetrics, success: bool, duration: 
 }
 
 #[test]
-fn should_update_metric_with_infinite_values() {
+fn test_update_metrics_with_infinite_values() {
     let mut existing_metrics = FsTrimMetrics {
         total_runs: f64::INFINITY,
         ..FsTrimMetrics::default()
@@ -217,7 +217,7 @@ fn should_update_metric_with_infinite_values() {
 }
 
 #[test]
-fn should_update_metric_with_nan_values() {
+fn test_update_metrics_with_nan_values() {
     let mut existing_metrics = FsTrimMetrics {
         total_runs: f64::NAN,
         ..FsTrimMetrics::default()
@@ -244,7 +244,7 @@ fn verify_invariants(i: f64, existing_metrics: &FsTrimMetrics) {
 }
 
 #[test]
-fn should_maintain_invariants() {
+fn test_maintain_invariants() {
     let mut existing_metrics = FsTrimMetrics::default();
     let rng = &mut reproducible_rng();
     for i in 0..100 {
@@ -258,7 +258,7 @@ fn should_maintain_invariants() {
 }
 
 #[test]
-fn should_update_datadir_metrics() {
+fn test_update_datadir_metrics() {
     let mut metrics = FsTrimMetrics::default();
     assert_eq!(metrics.total_runs_datadir, 0.0);
     assert_eq!(metrics.last_duration_milliseconds_datadir, 0.0);

--- a/rs/ic_os/fstrim_tool/src/metrics/tests.rs
+++ b/rs/ic_os/fstrim_tool/src/metrics/tests.rs
@@ -277,3 +277,39 @@ fn update_datadir_metrics() {
     assert_eq!(metrics.last_duration_milliseconds, 0.0);
     assert!(metrics.last_run_success);
 }
+
+#[test]
+fn format_metrics_output() {
+    let metrics = FsTrimMetrics {
+        last_duration_milliseconds: 123.45,
+        last_run_success: true,
+        total_runs: 6.0,
+        last_duration_milliseconds_datadir: 678.9,
+        last_run_success_datadir: false,
+        total_runs_datadir: 4.0,
+    };
+
+    let metrics_str = metrics.to_p8s_metrics_string();
+    let expected_str = "\
+# HELP fstrim_last_run_duration_milliseconds Duration of last run of fstrim in milliseconds
+# TYPE fstrim_last_run_duration_milliseconds gauge
+fstrim_last_run_duration_milliseconds 123.45
+# HELP fstrim_last_run_success Success status of last run of fstrim (success: 1, failure: 0)
+# TYPE fstrim_last_run_success gauge
+fstrim_last_run_success 1
+# HELP fstrim_runs_total Total number of runs of fstrim
+# TYPE fstrim_runs_total counter
+fstrim_runs_total 6
+# HELP fstrim_datadir_last_run_duration_milliseconds Duration of last run of fstrim on datadir in milliseconds
+# TYPE fstrim_datadir_last_run_duration_milliseconds gauge
+fstrim_datadir_last_run_duration_milliseconds 678.9
+# HELP fstrim_datadir_last_run_success Success status of last run of fstrim on datadir (success: 1, failure: 0)
+# TYPE fstrim_datadir_last_run_success gauge
+fstrim_datadir_last_run_success 0
+# HELP fstrim_datadir_runs_total Total number of runs of fstrim on datadir
+# TYPE fstrim_datadir_runs_total counter
+fstrim_datadir_runs_total 4
+";
+
+    assert_eq!(metrics_str, expected_str);
+}

--- a/rs/ic_os/fstrim_tool/src/metrics/tests.rs
+++ b/rs/ic_os/fstrim_tool/src/metrics/tests.rs
@@ -7,7 +7,7 @@ use std::time::Duration;
 use tempfile::tempdir;
 
 #[test]
-fn test_f64_comparison() {
+fn compare_f64() {
     assert!(f64_approx_eq(f64::NAN, f64::NAN));
     assert!(f64_approx_eq(f64::INFINITY, f64::INFINITY));
     assert!(f64_approx_eq(f64::INFINITY + 1f64, f64::INFINITY));
@@ -18,7 +18,7 @@ fn test_f64_comparison() {
 }
 
 #[test]
-fn test_parse_valid_metrics_file() {
+fn parse_valid_metrics_file() {
     let temp_dir = tempdir().expect("failed to create a temporary directory");
     let test_file = temp_dir.as_ref().join("test_file");
     let metrics_file_content =
@@ -46,7 +46,7 @@ fn test_parse_valid_metrics_file() {
 }
 
 #[test]
-fn test_ignore_subsequent_values_for_same_metric() {
+fn ignore_subsequent_values_for_same_metric() {
     let temp_dir = tempdir().expect("failed to create a temporary directory");
     let test_file = temp_dir.as_ref().join("test_file");
     let metrics_file_content =
@@ -77,7 +77,7 @@ fn test_ignore_subsequent_values_for_same_metric() {
 }
 
 #[test]
-fn test_error_on_empty_metrics_file() {
+fn should_error_on_empty_metrics_file() {
     let temp_dir = tempfile::TempDir::new().expect("failed to create a temporary directory");
     let test_file = temp_dir.as_ref().join("test_file");
     write(&test_file, "").expect("error writing to file");
@@ -86,7 +86,7 @@ fn test_error_on_empty_metrics_file() {
 }
 
 #[test]
-fn test_error_when_metrics_file_has_too_many_tokens() {
+fn should_error_when_metrics_file_has_too_many_tokens() {
     let temp_dir = tempfile::TempDir::new().expect("failed to create a temporary directory");
     let test_file = temp_dir.as_ref().join("test_file");
     write(&test_file, "pineapple on pizza is delicious").expect("error writing to file");
@@ -97,7 +97,7 @@ fn test_error_when_metrics_file_has_too_many_tokens() {
 }
 
 #[test]
-fn test_error_when_unknown_metric_name() {
+fn should_error_when_unknown_metric_name() {
     let temp_dir = tempfile::TempDir::new().expect("failed to create a temporary directory");
     let test_file = temp_dir.as_ref().join("test_file");
     write(&test_file, "pineapple pizza").expect("error writing to file");
@@ -108,7 +108,7 @@ fn test_error_when_unknown_metric_name() {
 }
 
 #[test]
-fn test_error_when_metrics_file_has_timestamp() {
+fn should_error_when_metrics_file_has_timestamp() {
     let temp_dir = tempfile::TempDir::new().expect("failed to create a temporary directory");
     let test_file = temp_dir.as_ref().join("test_file");
     write(
@@ -123,7 +123,7 @@ fn test_error_when_metrics_file_has_timestamp() {
 }
 
 #[test]
-fn test_error_when_metrics_file_has_non_numeric_value() {
+fn should_error_when_metrics_file_has_non_numeric_value() {
     let temp_dir = tempfile::TempDir::new().expect("failed to create a temporary directory");
     let test_file = temp_dir.as_ref().join("test_file");
     write(&test_file, format!("{} pizza", METRICS_RUNS_TOTAL).as_str())
@@ -135,7 +135,7 @@ fn test_error_when_metrics_file_has_non_numeric_value() {
 }
 
 #[test]
-fn test_if_file_does_not_exist() {
+fn file_does_not_exist() {
     let temp_dir = tempfile::TempDir::new().expect("failed to create a temporary directory");
     let test_file = temp_dir.as_ref().join("test_file");
     let parsed_metrics = parse_existing_metrics_from_file(&test_file.to_string_lossy()).unwrap();
@@ -143,7 +143,7 @@ fn test_if_file_does_not_exist() {
 }
 
 #[test]
-fn test_set_metrics() {
+fn set_metrics() {
     let mut existing_metrics = FsTrimMetrics::default();
     existing_metrics
         .update(true, Duration::from_millis(110))
@@ -158,7 +158,7 @@ fn test_set_metrics() {
 }
 
 #[test]
-fn test_update_metrics() {
+fn update_metrics() {
     let mut rng = reproducible_rng();
     for _ in 0..100 {
         let total_runs: u64 = rng.gen_range(0..10000000);
@@ -196,7 +196,7 @@ fn update_metrics_locally(metrics: &mut FsTrimMetrics, success: bool, duration: 
 }
 
 #[test]
-fn test_update_metrics_with_infinite_values() {
+fn update_metrics_with_infinite_values() {
     let mut existing_metrics = FsTrimMetrics {
         total_runs: f64::INFINITY,
         ..FsTrimMetrics::default()
@@ -217,7 +217,7 @@ fn test_update_metrics_with_infinite_values() {
 }
 
 #[test]
-fn test_update_metrics_with_nan_values() {
+fn update_metrics_with_nan_values() {
     let mut existing_metrics = FsTrimMetrics {
         total_runs: f64::NAN,
         ..FsTrimMetrics::default()
@@ -244,7 +244,7 @@ fn verify_invariants(i: f64, existing_metrics: &FsTrimMetrics) {
 }
 
 #[test]
-fn test_maintain_invariants() {
+fn maintain_invariants() {
     let mut existing_metrics = FsTrimMetrics::default();
     let rng = &mut reproducible_rng();
     for i in 0..100 {
@@ -258,7 +258,7 @@ fn test_maintain_invariants() {
 }
 
 #[test]
-fn test_update_datadir_metrics() {
+fn update_datadir_metrics() {
     let mut metrics = FsTrimMetrics::default();
     assert_eq!(metrics.total_runs_datadir, 0.0);
     assert_eq!(metrics.last_duration_milliseconds_datadir, 0.0);

--- a/rs/ic_os/fstrim_tool/src/metrics/tests.rs
+++ b/rs/ic_os/fstrim_tool/src/metrics/tests.rs
@@ -188,7 +188,7 @@ fn should_update_metrics() {
     }
 }
 
-/// Simple local "update" for the test reference
+// Simple local "update" for the test reference
 fn update_metrics_locally(metrics: &mut FsTrimMetrics, success: bool, duration: Duration) {
     metrics.total_runs += 1f64;
     metrics.last_run_success = success;
@@ -258,7 +258,7 @@ fn should_maintain_invariants() {
 }
 
 #[test]
-fn should_update_datadir_metrics_in_isolation() {
+fn should_update_datadir_metrics() {
     let mut metrics = FsTrimMetrics::default();
     assert_eq!(metrics.total_runs_datadir, 0.0);
     assert_eq!(metrics.last_duration_milliseconds_datadir, 0.0);
@@ -272,7 +272,7 @@ fn should_update_datadir_metrics_in_isolation() {
     assert_eq!(metrics.last_duration_milliseconds_datadir, 123.0);
     assert!(!metrics.last_run_success_datadir);
 
-    // Also check that normal fields remain untouched
+    // Check that normal fields remain untouched
     assert_eq!(metrics.total_runs, 0.0);
     assert_eq!(metrics.last_duration_milliseconds, 0.0);
     assert!(metrics.last_run_success);

--- a/rs/ic_os/fstrim_tool/src/tests.rs
+++ b/rs/ic_os/fstrim_tool/src/tests.rs
@@ -4,47 +4,47 @@ use std::fs::write;
 use std::time::Duration;
 use tempfile::tempdir;
 
-const EXISTING_METRICS_WITH_DATADIR: &str =
-    "# HELP fstrim_last_run_duration_milliseconds Duration of last run of fstrim in milliseconds\n\
-     # TYPE fstrim_last_run_duration_milliseconds gauge\n\
-     fstrim_last_run_duration_milliseconds 42\n\
-     # HELP fstrim_last_run_success Success status of last run of fstrim (success: 1, failure: 0)\n\
-     # TYPE fstrim_last_run_success gauge\n\
-     fstrim_last_run_success 0\n\
-     # HELP fstrim_runs_total Total number of runs of fstrim\n\
-     # TYPE fstrim_runs_total counter\n\
-     fstrim_runs_total 7\n\
-     # HELP fstrim_datadir_last_run_duration_milliseconds Duration of last run of fstrim on datadir in milliseconds\n\
-     # TYPE fstrim_datadir_last_run_duration_milliseconds gauge\n\
-     fstrim_datadir_last_run_duration_milliseconds 999\n\
-     # HELP fstrim_datadir_last_run_success Success status of last run of fstrim on datadir (success: 1, failure: 0)\n\
-     # TYPE fstrim_datadir_last_run_success gauge\n\
-     fstrim_datadir_last_run_success 1\n\
-     # HELP fstrim_datadir_runs_total Total number of runs of fstrim on datadir\n\
-     # TYPE fstrim_datadir_runs_total counter\n\
-     fstrim_datadir_runs_total 12\n";
+const EXISTING_METRICS_CONTENT: &str = r#"# HELP fstrim_last_run_duration_milliseconds Duration of last run of fstrim in milliseconds
+# TYPE fstrim_last_run_duration_milliseconds gauge
+fstrim_last_run_duration_milliseconds 0
+# HELP fstrim_last_run_success Success status of last run of fstrim (success: 1, failure: 0)
+# TYPE fstrim_last_run_success gauge
+fstrim_last_run_success 1
+# HELP fstrim_runs_total Total number of runs of fstrim
+# TYPE fstrim_runs_total counter
+fstrim_runs_total 1
+"#;
 
-const EXISTING_METRICS_CONTENT: &str =
-    "# HELP fstrim_last_run_duration_milliseconds Duration of last run of fstrim in milliseconds\n\
-     # TYPE fstrim_last_run_duration_milliseconds gauge\n\
-     fstrim_last_run_duration_milliseconds 0\n\
-     # HELP fstrim_last_run_success Success status of last run of fstrim (success: 1, failure: 0)\n\
-     # TYPE fstrim_last_run_success gauge\n\
-     fstrim_last_run_success 1\n\
-     # HELP fstrim_runs_total Total number of runs of fstrim\n\
-     # TYPE fstrim_runs_total counter\n\
-     fstrim_runs_total 1\n";
+const EXISTING_METRICS_WITH_DATADIR: &str = r#"# HELP fstrim_last_run_duration_milliseconds Duration of last run of fstrim in milliseconds
+# TYPE fstrim_last_run_duration_milliseconds gauge
+fstrim_last_run_duration_milliseconds 42
+# HELP fstrim_last_run_success Success status of last run of fstrim (success: 1, failure: 0)
+# TYPE fstrim_last_run_success gauge
+fstrim_last_run_success 0
+# HELP fstrim_runs_total Total number of runs of fstrim
+# TYPE fstrim_runs_total counter
+fstrim_runs_total 7
+# HELP fstrim_datadir_last_run_duration_milliseconds Duration of last run of fstrim on datadir in milliseconds
+# TYPE fstrim_datadir_last_run_duration_milliseconds gauge
+fstrim_datadir_last_run_duration_milliseconds 999
+# HELP fstrim_datadir_last_run_success Success status of last run of fstrim on datadir (success: 1, failure: 0)
+# TYPE fstrim_datadir_last_run_success gauge
+fstrim_datadir_last_run_success 1
+# HELP fstrim_datadir_runs_total Total number of runs of fstrim on datadir
+# TYPE fstrim_datadir_runs_total counter
+fstrim_datadir_runs_total 12
+"#;
 
-const EXISTING_METRICS_CONTENT_WITH_SPECIAL_VALUES: &str =
-    "# HELP fstrim_last_run_duration_milliseconds Duration of last run of fstrim in milliseconds\n\
-     # TYPE fstrim_last_run_duration_milliseconds gauge\n\
-     fstrim_last_run_duration_milliseconds 0\n\
-     # HELP fstrim_last_run_success Success status of last run of fstrim (success: 1, failure: 0)\n\
-     # TYPE fstrim_last_run_success gauge\n\
-     fstrim_last_run_success 1\n\
-     # HELP fstrim_runs_total Total number of runs of fstrim\n\
-     # TYPE fstrim_runs_total counter\n\
-     fstrim_runs_total +Inf\n";
+const EXISTING_METRICS_CONTENT_WITH_SPECIAL_VALUES: &str = r#"# HELP fstrim_last_run_duration_milliseconds Duration of last run of fstrim in milliseconds
+# TYPE fstrim_last_run_duration_milliseconds gauge
+fstrim_last_run_duration_milliseconds 0
+# HELP fstrim_last_run_success Success status of last run of fstrim (success: 1, failure: 0)
+# TYPE fstrim_last_run_success gauge
+fstrim_last_run_success 1
+# HELP fstrim_runs_total Total number of runs of fstrim
+# TYPE fstrim_runs_total counter
+fstrim_runs_total +Inf
+"#;
 
 #[test]
 fn should_parse_metrics_without_datadir_fields() {

--- a/rs/ic_os/fstrim_tool/src/tests.rs
+++ b/rs/ic_os/fstrim_tool/src/tests.rs
@@ -28,7 +28,7 @@ fstrim_runs_total +Inf
 "#;
 
 #[test]
-fn test_parse_metrics_without_datadir_fields() {
+fn parse_metrics_without_datadir_fields() {
     let tmp_dir = tempdir().expect("temp dir creation should succeed");
     let metrics_file = tmp_dir.path().join("fstrim.prom");
     write(&metrics_file, EXISTING_METRICS_CONTENT).expect("error writing to file");
@@ -54,7 +54,7 @@ fn test_parse_metrics_without_datadir_fields() {
 }
 
 #[test]
-fn test_parse_metrics_with_datadir_fields() {
+fn parse_metrics_with_datadir_fields() {
     let tmp_dir = tempdir().expect("temp dir creation should succeed");
     let metrics_file = tmp_dir.path().join("fstrim.prom");
 
@@ -82,7 +82,7 @@ fn test_parse_metrics_with_datadir_fields() {
 }
 
 #[test]
-fn test_error_if_metrics_in_file_has_special_values() {
+fn should_error_if_metrics_in_file_has_special_values() {
     let tmp_dir = tempdir().expect("temp dir creation should succeed");
     let metrics_file = tmp_dir.path().join("fstrim.prom");
     write(&metrics_file, EXISTING_METRICS_CONTENT_WITH_SPECIAL_VALUES)
@@ -97,7 +97,7 @@ fn test_error_if_metrics_in_file_has_special_values() {
 }
 
 #[test]
-fn test_write_metrics_to_file() {
+fn write_metrics_to_file() {
     let tmp_dir = tempdir().expect("temp dir creation should succeed");
     let metrics_file = tmp_dir.path().join("fstrim.prom");
 
@@ -180,7 +180,7 @@ fn test_update_metrics() {
 }
 
 #[test]
-fn test_update_datadir_metrics() {
+fn update_datadir_metrics() {
     let tmp_dir = tempdir().expect("temp dir creation should succeed");
     let metrics_file = tmp_dir.path().join("fstrim.prom");
 
@@ -228,7 +228,7 @@ fn test_update_datadir_metrics() {
 }
 
 #[test]
-fn test_start_from_empty_metrics_when_file_has_special_values() {
+fn start_from_empty_metrics_when_file_has_special_values() {
     let tmp_dir = tempdir().expect("temp dir creation should succeed");
     let metrics_file = tmp_dir.path().join("fstrim.prom");
     write(&metrics_file, EXISTING_METRICS_CONTENT_WITH_SPECIAL_VALUES)
@@ -264,18 +264,18 @@ fn test_start_from_empty_metrics_when_file_has_special_values() {
 }
 
 #[test]
-fn test_successfully_run_command() {
+fn successfully_run_command() {
     run_command("true", "/").expect("running command should succeed");
 }
 
 #[test]
-fn test_unsuccessfully_run_command() {
+fn unsuccessfully_run_command() {
     let res = run_command("false", "/");
     assert_matches!(res, Err(err) if err.to_string().contains("Failed to run command"));
 }
 
 #[test]
-fn test_command_fails_but_writes_metrics() {
+fn command_fails_but_writes_metrics() {
     let tmp_dir = tempdir().expect("temp dir creation should succeed");
     let tmp_dir2 = tempdir().expect("temp dir creation should succeed");
 
@@ -318,7 +318,7 @@ fn test_command_fails_but_writes_metrics() {
 }
 
 #[test]
-fn test_fails_if_command_cannot_be_run() {
+fn fails_if_command_cannot_be_run() {
     let tmp_dir = tempdir().expect("temp dir creation should succeed");
     let tmp_dir2 = tempdir().expect("temp dir creation should succeed");
 
@@ -348,7 +348,7 @@ fn test_fails_if_command_cannot_be_run() {
 }
 
 #[test]
-fn test_init_flag() {
+fn init_flag() {
     let tmp_dir = tempdir().expect("temp dir creation should succeed");
     let tmp_dir2 = tempdir().expect("temp dir creation should succeed");
     let metrics_file = tmp_dir.path().join("fstrim.prom");
@@ -382,7 +382,7 @@ fn test_init_flag() {
 }
 
 #[test]
-fn test_init_flag_does_not_overwrite_existing_metrics() {
+fn init_flag_does_not_overwrite_existing_metrics() {
     let tmp_dir = tempdir().expect("temp dir creation should succeed");
     let tmp_dir2 = tempdir().expect("temp dir creation should succeed");
 
@@ -432,7 +432,7 @@ fn test_init_flag_does_not_overwrite_existing_metrics() {
 }
 
 #[test]
-fn test_fails_if_metrics_file_cannot_be_written() {
+fn should_fail_if_metrics_file_cannot_be_written() {
     let metrics_file = PathBuf::from("/non/existent/directory/fstrim.prom");
     let tmp_dir = tempdir().expect("temp dir creation should succeed");
     let tmp_dir2 = tempdir().expect("temp dir creation should succeed");
@@ -462,7 +462,7 @@ fn test_fails_if_metrics_file_cannot_be_written() {
 }
 
 #[test]
-fn test_fails_if_target_is_not_a_directory() {
+fn should_fail_if_target_is_not_a_directory() {
     let tmp_dir = tempdir().expect("temp dir creation should succeed");
     let tmp_dir2 = tempdir().expect("temp dir creation should succeed");
 

--- a/rs/ic_os/fstrim_tool/src/tests.rs
+++ b/rs/ic_os/fstrim_tool/src/tests.rs
@@ -65,7 +65,7 @@ fn normalize_duration_line(input: &str) -> String {
 }
 
 #[test]
-fn should_parse_metrics_without_datadir_fields() {
+fn test_parse_metrics_without_datadir_fields() {
     let tmp_dir = tempdir().expect("temp dir creation should succeed");
     let metrics_file = tmp_dir.path().join("fstrim.prom");
     write(&metrics_file, EXISTING_METRICS_CONTENT).expect("error writing to file");
@@ -102,7 +102,7 @@ fstrim_datadir_runs_total 0
 }
 
 #[test]
-fn should_parse_metrics_with_datadir_fields() {
+fn test_parse_metrics_with_datadir_fields() {
     let tmp_dir = tempdir().expect("temp dir creation should succeed");
     let metrics_file = tmp_dir.path().join("fstrim.prom");
     write(&metrics_file, EXISTING_METRICS_WITH_DATADIR).expect("error writing to file");
@@ -120,7 +120,7 @@ fn should_parse_metrics_with_datadir_fields() {
 }
 
 #[test]
-fn should_return_error_if_metrics_in_file_contain_special_values() {
+fn test_error_if_metrics_in_file_has_special_values() {
     let tmp_dir = tempdir().expect("temp dir creation should succeed");
     let metrics_file = tmp_dir.path().join("fstrim.prom");
     write(&metrics_file, EXISTING_METRICS_CONTENT_WITH_SPECIAL_VALUES)
@@ -135,7 +135,7 @@ fn should_return_error_if_metrics_in_file_contain_special_values() {
 }
 
 #[test]
-fn should_write_metrics_to_file() {
+fn test_write_metrics_to_file() {
     let tmp_dir = tempdir().expect("temp dir creation should succeed");
     let metrics_file = tmp_dir.path().join("fstrim.prom");
     let default_metrics = FsTrimMetrics::default();
@@ -162,7 +162,7 @@ fn should_write_metrics_to_file() {
 }
 
 #[test]
-fn should_update_metrics() {
+fn test_update_metrics() {
     let tmp_dir = tempdir().expect("temp dir creation should succeed");
     let metrics_file = tmp_dir.path().join("fstrim.prom");
     write(&metrics_file, EXISTING_METRICS_CONTENT).expect("error writing to file");
@@ -209,7 +209,7 @@ fstrim_datadir_runs_total 0
 }
 
 #[test]
-fn should_update_datadir_metrics() {
+fn test_update_datadir_metrics() {
     let tmp_dir = tempdir().expect("temp dir creation should succeed");
     let metrics_file = tmp_dir.path().join("fstrim.prom");
     write(&metrics_file, EXISTING_METRICS_CONTENT).expect("error writing to file");
@@ -254,7 +254,7 @@ fstrim_datadir_runs_total 1
 }
 
 #[test]
-fn should_start_from_empty_metrics_for_update_if_metrics_in_file_contain_special_values() {
+fn test_start_from_empty_metrics_when_file_has_special_values() {
     let tmp_dir = tempdir().expect("temp dir creation should succeed");
     let metrics_file = tmp_dir.path().join("fstrim.prom");
     write(&metrics_file, EXISTING_METRICS_CONTENT_WITH_SPECIAL_VALUES)
@@ -301,18 +301,18 @@ fstrim_datadir_runs_total 0
 }
 
 #[test]
-fn should_return_ok_from_successfully_run_command() {
+fn test_successfully_run_command() {
     run_command("true", "/").expect("running command should succeed");
 }
 
 #[test]
-fn should_return_error_from_unsuccessfully_run_command() {
+fn test_unsuccessfully_run_command() {
     let res = run_command("false", "/");
     assert_matches!(res, Err(err) if err.to_string().contains("Failed to run command"));
 }
 
 #[test]
-fn should_fail_but_write_metrics_if_command_fails() {
+fn test_command_fails_but_writes_metrics() {
     let tmp_dir = tempdir().expect("temp dir creation should succeed");
     let tmp_dir2 = tempdir().expect("temp dir creation should succeed");
 
@@ -367,7 +367,7 @@ fstrim_datadir_runs_total 1
 }
 
 #[test]
-fn should_fail_if_command_cannot_be_run() {
+fn test_fails_if_command_cannot_be_run() {
     let tmp_dir = tempdir().expect("temp dir creation should succeed");
     let tmp_dir2 = tempdir().expect("temp dir creation should succeed");
 
@@ -397,7 +397,7 @@ fn should_fail_if_command_cannot_be_run() {
 }
 
 #[test]
-fn should_not_run_command_but_initialize_metrics_if_flag_set() {
+fn test_init_flag() {
     let tmp_dir = tempdir().expect("temp dir creation should succeed");
     let tmp_dir2 = tempdir().expect("temp dir creation should succeed");
     let metrics_file = tmp_dir.path().join("fstrim.prom");
@@ -428,7 +428,7 @@ fn should_not_run_command_but_initialize_metrics_if_flag_set() {
 }
 
 #[test]
-fn should_not_overwrite_existing_metrics_if_metrics_init_flag_set() {
+fn test_init_flag_does_not_overwrite_existing_metrics() {
     let tmp_dir = tempdir().expect("temp dir creation should succeed");
     let tmp_dir2 = tempdir().expect("temp dir creation should succeed");
 
@@ -478,7 +478,7 @@ fn should_not_overwrite_existing_metrics_if_metrics_init_flag_set() {
 }
 
 #[test]
-fn should_fail_if_metrics_file_cannot_be_written_to() {
+fn test_fails_if_metrics_file_cannot_be_written() {
     let metrics_file = PathBuf::from("/non/existent/directory/fstrim.prom");
     let tmp_dir = tempdir().expect("temp dir creation should succeed");
     let tmp_dir2 = tempdir().expect("temp dir creation should succeed");
@@ -508,7 +508,7 @@ fn should_fail_if_metrics_file_cannot_be_written_to() {
 }
 
 #[test]
-fn should_fail_if_target_is_not_a_directory() {
+fn test_fails_if_target_is_not_a_directory() {
     let tmp_dir = tempdir().expect("temp dir creation should succeed");
     let tmp_dir2 = tempdir().expect("temp dir creation should succeed");
 

--- a/rs/ic_os/fstrim_tool/src/tests.rs
+++ b/rs/ic_os/fstrim_tool/src/tests.rs
@@ -138,10 +138,17 @@ fn test_error_if_metrics_in_file_has_special_values() {
 fn test_write_metrics_to_file() {
     let tmp_dir = tempdir().expect("temp dir creation should succeed");
     let metrics_file = tmp_dir.path().join("fstrim.prom");
-    let default_metrics = FsTrimMetrics::default();
+    let metrics = FsTrimMetrics {
+        last_duration_milliseconds: 64.,
+        last_run_success: false,
+        total_runs: 60.,
+        last_duration_milliseconds_datadir: 3.,
+        last_run_success_datadir: true,
+        total_runs_datadir: 16.,
+    };
 
     write_metrics_using_tmp_file(
-        &default_metrics,
+        &metrics,
         metrics_file
             .to_str()
             .expect("metrics file path should be valid"),
@@ -155,10 +162,13 @@ fn test_write_metrics_to_file() {
     )
     .expect("parsing metrics should succeed")
     .expect("parsed metrics should be some");
-    let parsed_metrics_str = parsed_metrics.to_p8s_metrics_string();
-    let default_str = FsTrimMetrics::default().to_p8s_metrics_string();
 
-    assert_eq!(parsed_metrics_str, default_str);
+    assert_eq!(parsed_metrics.last_duration_milliseconds, 64.);
+    assert!(!parsed_metrics.last_run_success);
+    assert_eq!(parsed_metrics.total_runs, 60.);
+    assert_eq!(parsed_metrics.last_duration_milliseconds_datadir, 3.);
+    assert!(parsed_metrics.last_run_success_datadir);
+    assert_eq!(parsed_metrics.total_runs_datadir, 16.);
 }
 
 #[test]

--- a/rs/ic_os/fstrim_tool/tests/integration_tests.rs
+++ b/rs/ic_os/fstrim_tool/tests/integration_tests.rs
@@ -30,7 +30,7 @@ fn normalize_duration_line(input: &str) -> String {
 }
 
 #[test]
-fn should_successfully_initialize_metrics_if_flag_is_set() {
+fn test_initialize_metrics_if_flag_is_set() {
     let tmp_dir = tempdir().expect("temp dir creation should succeed");
     let metrics_file = tmp_dir.path().join("fstrim.prom");
 
@@ -76,7 +76,7 @@ fstrim_datadir_runs_total 0
 }
 
 #[test]
-fn should_fail_but_write_metrics_if_target_is_not_a_directory() {
+fn test_fails_but_writes_metrics_if_target_not_a_directory() {
     let tmp_dir = tempdir().expect("temp dir creation should succeed");
     let metrics_file = tmp_dir.path().join("fstrim.prom");
 
@@ -95,7 +95,7 @@ fn should_fail_but_write_metrics_if_target_is_not_a_directory() {
         .failure();
 
     let actual = read_to_string(&metrics_file).expect("reading metrics file should succeed");
-    // The command fails, so success=0, runs=1. Datadir not updated => datadir success=1, runs=0 by default
+    // The command fails, so success=0, runs=1. Datadir not updated => datadir success=1, runs=0
     let expected = r#"# HELP fstrim_last_run_duration_milliseconds Duration of last run of fstrim in milliseconds
 # TYPE fstrim_last_run_duration_milliseconds gauge
 fstrim_last_run_duration_milliseconds 0
@@ -120,7 +120,7 @@ fstrim_datadir_runs_total 0
 }
 
 #[test]
-fn should_fail_but_write_metrics_with_discard_not_supported_with_correct_parameters() {
+fn test_fails_but_writes_metrics_when_discard_not_supported() {
     let tmp_dir = tempdir().expect("temp dir creation should succeed");
     let metrics_file = tmp_dir.path().join("fstrim.prom");
 
@@ -172,7 +172,7 @@ fstrim_datadir_runs_total 0
 }
 
 #[test]
-fn should_fail_if_arguments_missing() {
+fn test_fails_if_arguments_missing() {
     new_fstrim_tool_command()
         .assert()
         .stdout(predicate::str::is_empty())

--- a/rs/ic_os/fstrim_tool/tests/integration_tests.rs
+++ b/rs/ic_os/fstrim_tool/tests/integration_tests.rs
@@ -30,7 +30,7 @@ fn normalize_duration_line(input: &str) -> String {
 }
 
 #[test]
-fn test_initialize_metrics_if_flag_is_set() {
+fn initialize_metrics() {
     let tmp_dir = tempdir().expect("temp dir creation should succeed");
     let metrics_file = tmp_dir.path().join("fstrim.prom");
 
@@ -76,7 +76,7 @@ fstrim_datadir_runs_total 0
 }
 
 #[test]
-fn test_fails_but_writes_metrics_if_target_not_a_directory() {
+fn should_fail_but_write_metrics_if_target_not_a_directory() {
     let tmp_dir = tempdir().expect("temp dir creation should succeed");
     let metrics_file = tmp_dir.path().join("fstrim.prom");
 
@@ -120,7 +120,7 @@ fstrim_datadir_runs_total 0
 }
 
 #[test]
-fn test_fails_but_writes_metrics_when_discard_not_supported() {
+fn should_fail_but_writes_metrics_when_discard_not_supported() {
     let tmp_dir = tempdir().expect("temp dir creation should succeed");
     let metrics_file = tmp_dir.path().join("fstrim.prom");
 
@@ -172,7 +172,7 @@ fstrim_datadir_runs_total 0
 }
 
 #[test]
-fn test_fails_if_arguments_missing() {
+fn should_fail_if_arguments_missing() {
     new_fstrim_tool_command()
         .assert()
         .stdout(predicate::str::is_empty())

--- a/rs/ic_os/fstrim_tool/tests/integration_tests.rs
+++ b/rs/ic_os/fstrim_tool/tests/integration_tests.rs
@@ -8,54 +8,138 @@ use tempfile::tempdir;
 fn new_fstrim_tool_command() -> Command {
     match Command::cargo_bin("fstrim_tool") {
         // When in Cargo environment.
-        Ok(v) => v,
+        Ok(cmd) => cmd,
         // When in Bazel environment
         Err(_) => Command::new("rs/ic_os/fstrim_tool/fstrim_tool_bin"),
     }
 }
 
-fn assert_metrics_file_content(metrics_filename: &PathBuf, is_success: bool, total_runs: u32) {
+fn assert_metrics_file_content(
+    metrics_filename: &PathBuf,
+    is_success: bool,
+    total_runs: u32,
+    datadir_is_success: bool,
+    datadir_total_runs: u32,
+) {
     let file = File::open(metrics_filename).expect("should succeed in opening metrics file");
     let reader = BufReader::new(file);
-    let lines = reader.lines();
-    for (i, line) in lines.enumerate() {
-        match i {
-            0 => assert_eq!(
-                line.unwrap(),
-                "# HELP fstrim_last_run_duration_milliseconds Duration of last run of fstrim in milliseconds"
-            ),
-            1 => assert_eq!(
-                line.unwrap(),
-                "# TYPE fstrim_last_run_duration_milliseconds gauge"
-            ),
-            2 => assert!(line.unwrap().starts_with("fstrim_last_run_duration_milliseconds")),
-            3 => assert_eq!(
-                line.unwrap(), "# HELP fstrim_last_run_success Success status of last run of fstrim (success: 1, failure: 0)"
-            ),
-            4 => assert_eq!(
-                line.unwrap(), "# TYPE fstrim_last_run_success gauge"
-            ),
-            5 => {
-                let line_str = line.unwrap();
-                let mut tokens = line_str.split(' ');
-                assert_eq!(tokens.next().unwrap(), "fstrim_last_run_success", "{}", line_str);
-                let success_str = if is_success { "1" } else { "0" };
-                assert_eq!(tokens.next().unwrap(), success_str, "{}", line_str);
-            },
-            6 => assert_eq!(
-                line.unwrap(), "# HELP fstrim_runs_total Total number of runs of fstrim"
-            ),
-            7 => assert_eq!(
-                line.unwrap(), "# TYPE fstrim_runs_total counter"
-            ),
-            8 => {
-                let line_str = line.unwrap();
-                let mut tokens = line_str.split(' ');
-                assert_eq!(tokens.next().unwrap(), "fstrim_runs_total", "{}", line_str);
-                assert_eq!(tokens.next().unwrap().parse::<u32>().unwrap(), total_runs, "{}", line_str);
-            },
-            _ => panic!("unexpected line: {}", line.unwrap()),
-        }
+    let lines: Vec<String> = reader
+        .lines()
+        .collect::<Result<Vec<_>, _>>()
+        .expect("failed to read lines from metrics file");
+
+    // We expect 18 lines total:
+    //   0..2:   last_run_duration (HELP/TYPE/value)
+    //   3..5:   last_run_success (HELP/TYPE/value)
+    //   6..8:   runs_total       (HELP/TYPE/value)
+    //   9..11:  datadir_last_run_duration (HELP/TYPE/value)
+    //   12..14: datadir_last_run_success  (HELP/TYPE/value)
+    //   15..17: datadir_runs_total        (HELP/TYPE/value)
+
+    // Lines 0..2: fstrim_last_run_duration_milliseconds
+    assert_eq!(
+        lines[0],
+        "# HELP fstrim_last_run_duration_milliseconds Duration of last run of fstrim in milliseconds"
+    );
+    assert_eq!(
+        lines[1],
+        "# TYPE fstrim_last_run_duration_milliseconds gauge"
+    );
+    assert!(lines[2].starts_with("fstrim_last_run_duration_milliseconds"));
+
+    // Lines 3..5: fstrim_last_run_success
+    assert_eq!(
+        lines[3],
+        "# HELP fstrim_last_run_success Success status of last run of fstrim (success: 1, failure: 0)"
+    );
+    assert_eq!(lines[4], "# TYPE fstrim_last_run_success gauge");
+    let success_line = &lines[5];
+    {
+        let mut tokens = success_line.split(' ');
+        assert_eq!(
+            tokens.next().unwrap(),
+            "fstrim_last_run_success",
+            "{}",
+            success_line
+        );
+        let success_str = if is_success { "1" } else { "0" };
+        assert_eq!(
+            tokens.next().unwrap(),
+            success_str,
+            "line[5]: {}",
+            success_line
+        );
+    }
+
+    // Lines 6..8: fstrim_runs_total
+    assert_eq!(
+        lines[6],
+        "# HELP fstrim_runs_total Total number of runs of fstrim"
+    );
+    assert_eq!(lines[7], "# TYPE fstrim_runs_total counter");
+    let runs_line = &lines[8];
+    {
+        let mut tokens = runs_line.split(' ');
+        assert_eq!(tokens.next().unwrap(), "fstrim_runs_total");
+        let found_total = tokens.next().unwrap().parse::<u32>().unwrap();
+        assert_eq!(
+            found_total, total_runs,
+            "mismatch on normal runs_total in line[8]: {}",
+            runs_line
+        );
+    }
+
+    // Lines 9..11: fstrim_datadir_last_run_duration_milliseconds
+    assert_eq!(
+        lines[9],
+        "# HELP fstrim_datadir_last_run_duration_milliseconds Duration of last run of fstrim on datadir in milliseconds"
+    );
+    assert_eq!(
+        lines[10],
+        "# TYPE fstrim_datadir_last_run_duration_milliseconds gauge"
+    );
+    assert!(lines[11].starts_with("fstrim_datadir_last_run_duration_milliseconds"));
+
+    // Lines 12..14: fstrim_datadir_last_run_success
+    assert_eq!(
+        lines[12],
+        "# HELP fstrim_datadir_last_run_success Success status of last run of fstrim on datadir (success: 1, failure: 0)"
+    );
+    assert_eq!(lines[13], "# TYPE fstrim_datadir_last_run_success gauge");
+    let datadir_success_line = &lines[14];
+    {
+        let mut tokens = datadir_success_line.split(' ');
+        assert_eq!(
+            tokens.next().unwrap(),
+            "fstrim_datadir_last_run_success",
+            "{}",
+            datadir_success_line
+        );
+        let success_str = if datadir_is_success { "1" } else { "0" };
+        assert_eq!(
+            tokens.next().unwrap(),
+            success_str,
+            "line[14]: {}",
+            datadir_success_line
+        );
+    }
+
+    // Lines 15..17: fstrim_datadir_runs_total
+    assert_eq!(
+        lines[15],
+        "# HELP fstrim_datadir_runs_total Total number of runs of fstrim on datadir"
+    );
+    assert_eq!(lines[16], "# TYPE fstrim_datadir_runs_total counter");
+    let datadir_runs_line = &lines[17];
+    {
+        let mut tokens = datadir_runs_line.split(' ');
+        assert_eq!(tokens.next().unwrap(), "fstrim_datadir_runs_total");
+        let found_total = tokens.next().unwrap().parse::<u32>().unwrap();
+        assert_eq!(
+            found_total, datadir_total_runs,
+            "mismatch on datadir runs_total in line[17]: {}",
+            datadir_runs_line
+        );
     }
 }
 
@@ -81,7 +165,7 @@ fn should_successfully_initialize_metrics_if_flag_is_set() {
         .stderr(predicate::str::is_empty())
         .success();
 
-    assert_metrics_file_content(&metrics_file, true, 0);
+    assert_metrics_file_content(&metrics_file, true, 0, true, 0);
 }
 
 #[test]
@@ -102,7 +186,8 @@ fn should_fail_but_write_metrics_if_target_is_not_a_directory() {
         .stderr(predicate::str::contains("not a directory"))
         .failure();
 
-    assert_metrics_file_content(&metrics_file, false, 1);
+    // The command fails, so success=0, runs=1. Datadir not updated => datadir success=1, runs=0 by default
+    assert_metrics_file_content(&metrics_file, false, 1, true, 0);
 }
 
 // This fails if not tested under root user as the successful execution of the 1st target calls fstrim
@@ -129,8 +214,9 @@ fn should_fail_but_write_metrics_if_target_is_not_a_directory() {
 //         .stderr(predicate::str::contains("not a directory"))
 //         .failure();
 //
-//     // As metrics now only target the main target, success will be reported
-//     assert_metrics_file_content(&metrics_file, true, 1);
+//     // The first target is valid, so normal metrics are updated as success => success=1, runs=1
+//     // The datadir target fails => datadir success=0, runs=1
+//     assert_metrics_file_content(&metrics_file, true, 1, false, 1);
 // }
 
 #[test]
@@ -151,12 +237,14 @@ fn should_fail_but_write_metrics_with_discard_not_supported_with_correct_paramet
         ])
         .assert()
         .stdout(predicate::str::is_empty())
-        .stderr(predicate::str::contains(
-            "the discard operation is not supported",
-        ))
+        .stderr(
+            predicate::str::contains("the discard operation is not supported")
+                .or(predicate::str::contains("Operation not permitted")),
+        )
         .failure();
 
-    assert_metrics_file_content(&metrics_file, false, 1);
+    // The tool fails => success=0, runs=1. Datadir not updated => success=1, runs=0
+    assert_metrics_file_content(&metrics_file, false, 1, true, 0);
 }
 
 #[test]

--- a/rs/ic_os/fstrim_tool/tests/integration_tests.rs
+++ b/rs/ic_os/fstrim_tool/tests/integration_tests.rs
@@ -1,8 +1,7 @@
 use assert_cmd::Command;
 use predicates::prelude::*;
-use std::fs::File;
-use std::io::{BufRead, BufReader};
-use std::path::PathBuf;
+use regex::Regex;
+use std::fs::read_to_string;
 use tempfile::tempdir;
 
 fn new_fstrim_tool_command() -> Command {
@@ -14,139 +13,27 @@ fn new_fstrim_tool_command() -> Command {
     }
 }
 
-fn assert_metrics_file_content(
-    metrics_filename: &PathBuf,
-    is_success: bool,
-    total_runs: u32,
-    datadir_is_success: bool,
-    datadir_total_runs: u32,
-) {
-    let file = File::open(metrics_filename).expect("should succeed in opening metrics file");
-    let reader = BufReader::new(file);
-    let lines: Vec<String> = reader
-        .lines()
-        .collect::<Result<Vec<_>, _>>()
-        .expect("failed to read lines from metrics file");
-
-    // We expect 18 lines total:
-    //   0..2:   last_run_duration (HELP/TYPE/value)
-    //   3..5:   last_run_success (HELP/TYPE/value)
-    //   6..8:   runs_total       (HELP/TYPE/value)
-    //   9..11:  datadir_last_run_duration (HELP/TYPE/value)
-    //   12..14: datadir_last_run_success  (HELP/TYPE/value)
-    //   15..17: datadir_runs_total        (HELP/TYPE/value)
-
-    // Lines 0..2: fstrim_last_run_duration_milliseconds
-    assert_eq!(
-        lines[0],
-        "# HELP fstrim_last_run_duration_milliseconds Duration of last run of fstrim in milliseconds"
-    );
-    assert_eq!(
-        lines[1],
-        "# TYPE fstrim_last_run_duration_milliseconds gauge"
-    );
-    assert!(lines[2].starts_with("fstrim_last_run_duration_milliseconds"));
-
-    // Lines 3..5: fstrim_last_run_success
-    assert_eq!(
-        lines[3],
-        "# HELP fstrim_last_run_success Success status of last run of fstrim (success: 1, failure: 0)"
-    );
-    assert_eq!(lines[4], "# TYPE fstrim_last_run_success gauge");
-    let success_line = &lines[5];
-    {
-        let mut tokens = success_line.split(' ');
-        assert_eq!(
-            tokens.next().unwrap(),
-            "fstrim_last_run_success",
-            "{}",
-            success_line
-        );
-        let success_str = if is_success { "1" } else { "0" };
-        assert_eq!(
-            tokens.next().unwrap(),
-            success_str,
-            "line[5]: {}",
-            success_line
-        );
-    }
-
-    // Lines 6..8: fstrim_runs_total
-    assert_eq!(
-        lines[6],
-        "# HELP fstrim_runs_total Total number of runs of fstrim"
-    );
-    assert_eq!(lines[7], "# TYPE fstrim_runs_total counter");
-    let runs_line = &lines[8];
-    {
-        let mut tokens = runs_line.split(' ');
-        assert_eq!(tokens.next().unwrap(), "fstrim_runs_total");
-        let found_total = tokens.next().unwrap().parse::<u32>().unwrap();
-        assert_eq!(
-            found_total, total_runs,
-            "mismatch on normal runs_total in line[8]: {}",
-            runs_line
-        );
-    }
-
-    // Lines 9..11: fstrim_datadir_last_run_duration_milliseconds
-    assert_eq!(
-        lines[9],
-        "# HELP fstrim_datadir_last_run_duration_milliseconds Duration of last run of fstrim on datadir in milliseconds"
-    );
-    assert_eq!(
-        lines[10],
-        "# TYPE fstrim_datadir_last_run_duration_milliseconds gauge"
-    );
-    assert!(lines[11].starts_with("fstrim_datadir_last_run_duration_milliseconds"));
-
-    // Lines 12..14: fstrim_datadir_last_run_success
-    assert_eq!(
-        lines[12],
-        "# HELP fstrim_datadir_last_run_success Success status of last run of fstrim on datadir (success: 1, failure: 0)"
-    );
-    assert_eq!(lines[13], "# TYPE fstrim_datadir_last_run_success gauge");
-    let datadir_success_line = &lines[14];
-    {
-        let mut tokens = datadir_success_line.split(' ');
-        assert_eq!(
-            tokens.next().unwrap(),
-            "fstrim_datadir_last_run_success",
-            "{}",
-            datadir_success_line
-        );
-        let success_str = if datadir_is_success { "1" } else { "0" };
-        assert_eq!(
-            tokens.next().unwrap(),
-            success_str,
-            "line[14]: {}",
-            datadir_success_line
-        );
-    }
-
-    // Lines 15..17: fstrim_datadir_runs_total
-    assert_eq!(
-        lines[15],
-        "# HELP fstrim_datadir_runs_total Total number of runs of fstrim on datadir"
-    );
-    assert_eq!(lines[16], "# TYPE fstrim_datadir_runs_total counter");
-    let datadir_runs_line = &lines[17];
-    {
-        let mut tokens = datadir_runs_line.split(' ');
-        assert_eq!(tokens.next().unwrap(), "fstrim_datadir_runs_total");
-        let found_total = tokens.next().unwrap().parse::<u32>().unwrap();
-        assert_eq!(
-            found_total, datadir_total_runs,
-            "mismatch on datadir runs_total in line[17]: {}",
-            datadir_runs_line
-        );
-    }
+/// Replaces lines that contain:
+/// - `fstrim_last_run_duration_milliseconds X`
+/// - `fstrim_datadir_last_run_duration_milliseconds X`
+///
+/// with a placeholder:
+/// - `fstrim_last_run_duration_milliseconds <DURATION>`
+/// - `fstrim_datadir_last_run_duration_milliseconds <DURATION>`
+///
+/// This ensures that the duration numeric values do not cause test flakiness.
+fn normalize_duration_line(input: &str) -> String {
+    let re =
+        Regex::new(r"(?m)^(fstrim(?:_datadir)?_last_run_duration_milliseconds)\s+\d+(\.\d+)?$")
+            .unwrap();
+    re.replace_all(input, "$1 <DURATION>").into_owned()
 }
 
 #[test]
 fn should_successfully_initialize_metrics_if_flag_is_set() {
     let tmp_dir = tempdir().expect("temp dir creation should succeed");
     let metrics_file = tmp_dir.path().join("fstrim.prom");
+
     new_fstrim_tool_command()
         .args([
             "--metrics",
@@ -165,13 +52,34 @@ fn should_successfully_initialize_metrics_if_flag_is_set() {
         .stderr(predicate::str::is_empty())
         .success();
 
-    assert_metrics_file_content(&metrics_file, true, 0, true, 0);
+    let actual = read_to_string(&metrics_file).expect("reading metrics file should succeed");
+    let expected = r#"# HELP fstrim_last_run_duration_milliseconds Duration of last run of fstrim in milliseconds
+# TYPE fstrim_last_run_duration_milliseconds gauge
+fstrim_last_run_duration_milliseconds 0
+# HELP fstrim_last_run_success Success status of last run of fstrim (success: 1, failure: 0)
+# TYPE fstrim_last_run_success gauge
+fstrim_last_run_success 1
+# HELP fstrim_runs_total Total number of runs of fstrim
+# TYPE fstrim_runs_total counter
+fstrim_runs_total 0
+# HELP fstrim_datadir_last_run_duration_milliseconds Duration of last run of fstrim on datadir in milliseconds
+# TYPE fstrim_datadir_last_run_duration_milliseconds gauge
+fstrim_datadir_last_run_duration_milliseconds 0
+# HELP fstrim_datadir_last_run_success Success status of last run of fstrim on datadir (success: 1, failure: 0)
+# TYPE fstrim_datadir_last_run_success gauge
+fstrim_datadir_last_run_success 1
+# HELP fstrim_datadir_runs_total Total number of runs of fstrim on datadir
+# TYPE fstrim_datadir_runs_total counter
+fstrim_datadir_runs_total 0
+"#;
+    assert_eq!(actual, expected);
 }
 
 #[test]
 fn should_fail_but_write_metrics_if_target_is_not_a_directory() {
     let tmp_dir = tempdir().expect("temp dir creation should succeed");
     let metrics_file = tmp_dir.path().join("fstrim.prom");
+
     new_fstrim_tool_command()
         .args([
             "--metrics",
@@ -186,43 +94,36 @@ fn should_fail_but_write_metrics_if_target_is_not_a_directory() {
         .stderr(predicate::str::contains("not a directory"))
         .failure();
 
+    let actual = read_to_string(&metrics_file).expect("reading metrics file should succeed");
     // The command fails, so success=0, runs=1. Datadir not updated => datadir success=1, runs=0 by default
-    assert_metrics_file_content(&metrics_file, false, 1, true, 0);
-}
+    let expected = r#"# HELP fstrim_last_run_duration_milliseconds Duration of last run of fstrim in milliseconds
+# TYPE fstrim_last_run_duration_milliseconds gauge
+fstrim_last_run_duration_milliseconds 0
+# HELP fstrim_last_run_success Success status of last run of fstrim (success: 1, failure: 0)
+# TYPE fstrim_last_run_success gauge
+fstrim_last_run_success 0
+# HELP fstrim_runs_total Total number of runs of fstrim
+# TYPE fstrim_runs_total counter
+fstrim_runs_total 1
+# HELP fstrim_datadir_last_run_duration_milliseconds Duration of last run of fstrim on datadir in milliseconds
+# TYPE fstrim_datadir_last_run_duration_milliseconds gauge
+fstrim_datadir_last_run_duration_milliseconds 0
+# HELP fstrim_datadir_last_run_success Success status of last run of fstrim on datadir (success: 1, failure: 0)
+# TYPE fstrim_datadir_last_run_success gauge
+fstrim_datadir_last_run_success 1
+# HELP fstrim_datadir_runs_total Total number of runs of fstrim on datadir
+# TYPE fstrim_datadir_runs_total counter
+fstrim_datadir_runs_total 0
+"#;
 
-// This fails if not tested under root user as the successful execution of the 1st target calls fstrim
-// #[test]
-// fn should_fail_but_write_metrics_if_data_target_is_not_a_directory() {
-//     let tmp_dir = tempdir().expect("temp dir creation should succeed");
-//     let metrics_file = tmp_dir.path().join("fstrim.prom");
-//     new_fstrim_tool_command()
-//         .args([
-//             "--metrics",
-//             metrics_file
-//                 .to_str()
-//                 .expect("metrics file path should be valid"),
-//             "--target",
-//             tmp_dir
-//                 .path()
-//                 .to_str()
-//                 .expect("tmp_dir path should be valid"),
-//             "--datadir_target",
-//             "/not/a/directory",
-//         ])
-//         .assert()
-//         .stdout(predicate::str::is_empty())
-//         .stderr(predicate::str::contains("not a directory"))
-//         .failure();
-//
-//     // The first target is valid, so normal metrics are updated as success => success=1, runs=1
-//     // The datadir target fails => datadir success=0, runs=1
-//     assert_metrics_file_content(&metrics_file, true, 1, false, 1);
-// }
+    assert_eq!(actual, expected);
+}
 
 #[test]
 fn should_fail_but_write_metrics_with_discard_not_supported_with_correct_parameters() {
     let tmp_dir = tempdir().expect("temp dir creation should succeed");
     let metrics_file = tmp_dir.path().join("fstrim.prom");
+
     new_fstrim_tool_command()
         .args([
             "--metrics",
@@ -243,8 +144,31 @@ fn should_fail_but_write_metrics_with_discard_not_supported_with_correct_paramet
         )
         .failure();
 
+    let actual_raw = read_to_string(&metrics_file).expect("reading metrics file should succeed");
+    let actual = normalize_duration_line(&actual_raw);
     // The tool fails => success=0, runs=1. Datadir not updated => success=1, runs=0
-    assert_metrics_file_content(&metrics_file, false, 1, true, 0);
+    let expected_raw = r#"# HELP fstrim_last_run_duration_milliseconds Duration of last run of fstrim in milliseconds
+# TYPE fstrim_last_run_duration_milliseconds gauge
+fstrim_last_run_duration_milliseconds 2
+# HELP fstrim_last_run_success Success status of last run of fstrim (success: 1, failure: 0)
+# TYPE fstrim_last_run_success gauge
+fstrim_last_run_success 0
+# HELP fstrim_runs_total Total number of runs of fstrim
+# TYPE fstrim_runs_total counter
+fstrim_runs_total 1
+# HELP fstrim_datadir_last_run_duration_milliseconds Duration of last run of fstrim on datadir in milliseconds
+# TYPE fstrim_datadir_last_run_duration_milliseconds gauge
+fstrim_datadir_last_run_duration_milliseconds 0
+# HELP fstrim_datadir_last_run_success Success status of last run of fstrim on datadir (success: 1, failure: 0)
+# TYPE fstrim_datadir_last_run_success gauge
+fstrim_datadir_last_run_success 1
+# HELP fstrim_datadir_runs_total Total number of runs of fstrim on datadir
+# TYPE fstrim_datadir_runs_total counter
+fstrim_datadir_runs_total 0
+"#;
+    let expected = normalize_duration_line(expected_raw);
+
+    assert_eq!(actual, expected);
 }
 
 #[test]


### PR DESCRIPTION
NODE-1537

Node decommissioning stage 2 was rolled out in a hurry so that we could make the holiday-release cutoff: https://github.com/dfinity/ic/pull/2953 

These changes add the missing observability logic.

Main commits:

- [Add datadir metrics](https://github.com/dfinity/ic/pull/3322/commits/a1e6dbb99e60c8397d5ff9b7b8b1b839a5d0c0e2)
- [Update unit tests](https://github.com/dfinity/ic/pull/3322/commits/513ba80c20709d74fd7631fe3566ba6f92bd8679)


Screenshot of metrics:
<img width="1448" alt="image" src="https://github.com/user-attachments/assets/a80cecd7-cde7-444b-85b6-a973a10331ab" />
