### PR TITLE
refactor: Rename field in InsufficientCyclesInMemoryGrow error

### DIFF
--- a/rs/execution_environment/src/canister_manager.rs
+++ b/rs/execution_environment/src/canister_manager.rs
@@ -1708,7 +1708,7 @@ impl CanisterManager {
                         } => CanisterManagerError::InsufficientCyclesInMemoryGrow {
                             bytes: chunk_bytes,
                             available,
-                            threshold: requested,
+                            required: requested,
                         },
                         ReservationError::ReservedLimitExceed { requested, limit } => {
                             CanisterManagerError::ReservedCyclesLimitExceededInMemoryGrow {
@@ -1914,7 +1914,7 @@ impl CanisterManager {
                     Err(CanisterManagerError::InsufficientCyclesInMemoryGrow {
                         bytes: new_snapshot_increase,
                         available: canister.system_state.balance(),
-                        threshold: threshold + reservation_cycles,
+                        required: threshold + reservation_cycles,
                     }),
                     NumInstructions::new(0),
                 );
@@ -1948,7 +1948,7 @@ impl CanisterManager {
                     } => CanisterManagerError::InsufficientCyclesInMemoryGrow {
                         bytes: new_snapshot_increase,
                         available,
-                        threshold: requested,
+                        required: requested,
                     },
                     ReservationError::ReservedLimitExceed { requested, limit } => {
                         CanisterManagerError::ReservedCyclesLimitExceededInMemoryGrow {
@@ -2403,7 +2403,7 @@ pub(crate) enum CanisterManagerError {
     InsufficientCyclesInMemoryGrow {
         bytes: NumBytes,
         available: Cycles,
-        threshold: Cycles,
+        required: Cycles,
     },
     ReservedCyclesLimitExceededInMemoryAllocation {
         memory_allocation: MemoryAllocation,
@@ -2831,7 +2831,7 @@ impl From<CanisterManagerError> for UserError {
                 )
 
             }
-            InsufficientCyclesInMemoryGrow { bytes, available, threshold} =>
+            InsufficientCyclesInMemoryGrow { bytes, available, required} =>
             {
                 Self::new(
                     ErrorCode::InsufficientCyclesInMemoryGrow,
@@ -2839,7 +2839,7 @@ impl From<CanisterManagerError> for UserError {
                         "Canister cannot grow memory by {} bytes due to insufficient cycles. \
                          At least {} additional cycles are required.{additional_help}",
                          bytes,
-                         threshold - available)
+                         required - available)
                 )
             }
             ReservedCyclesLimitExceededInMemoryAllocation { memory_allocation, requested, limit} =>

--- a/rs/execution_environment/src/execution/install_code.rs
+++ b/rs/execution_environment/src/execution/install_code.rs
@@ -332,7 +332,7 @@ impl InstallCodeHelper {
                         } => CanisterManagerError::InsufficientCyclesInMemoryGrow {
                             bytes,
                             available,
-                            threshold: requested,
+                            required: requested,
                         },
                         ReservationError::ReservedLimitExceed { requested, limit } => {
                             CanisterManagerError::ReservedCyclesLimitExceededInMemoryGrow {
@@ -366,7 +366,7 @@ impl InstallCodeHelper {
                 let err = CanisterManagerError::InsufficientCyclesInMemoryGrow {
                     bytes,
                     available: self.canister.system_state.balance(),
-                    threshold,
+                    required: threshold,
                 };
                 return finish_err(
                     clean_canister,


### PR DESCRIPTION
The field `threshold` in `InsufficientCyclesInMemoryGrow` error is not quite accurate. Some times it's not only the freezing threshold that might need to be taken into account (assuming the naming comes from that) but also other sources of consuming cycles, like for example the storage reservation cycles. Rename the field to `required` which also matches with the naming of other similar errors that deal with out of cycles cases.