### PR TITLE
test(consensus): adjust the parameters of consensus performance tests

### DIFF
--- a/rs/tests/consensus/consensus_performance.rs
+++ b/rs/tests/consensus/consensus_performance.rs
@@ -189,9 +189,8 @@ fn test_few_large_messages(env: TestEnv) {
     test(env, 1_999_000, 1.0)
 }
 
-#[allow(dead_code)]
 fn test_large_messages(env: TestEnv) {
-    test(env, 1_999_000, 4.0)
+    test(env, 950_000, 4.0)
 }
 
 fn main() -> Result<()> {
@@ -203,9 +202,7 @@ fn main() -> Result<()> {
         .add_test(systest!(test_few_small_messages))
         .add_test(systest!(test_small_messages))
         .add_test(systest!(test_few_large_messages))
-        // TODO: re-enable this once hashes-in-blocks feature is re-enabled, without the feature
-        // consensus cannot handle such a load
-        //.add_test(systest!(test_large_messages))
+        .add_test(systest!(test_large_messages))
         .execute_from_args()?;
     Ok(())
 }

--- a/rs/tests/consensus/consensus_performance.rs
+++ b/rs/tests/consensus/consensus_performance.rs
@@ -182,13 +182,14 @@ fn test_few_small_messages(env: TestEnv) {
 }
 
 fn test_small_messages(env: TestEnv) {
-    test(env, 4_000, 1_500.0)
+    test(env, 4_000, 500.0)
 }
 
 fn test_few_large_messages(env: TestEnv) {
     test(env, 1_999_000, 1.0)
 }
 
+#[allow(dead_code)]
 fn test_large_messages(env: TestEnv) {
     test(env, 1_999_000, 4.0)
 }
@@ -202,7 +203,9 @@ fn main() -> Result<()> {
         .add_test(systest!(test_few_small_messages))
         .add_test(systest!(test_small_messages))
         .add_test(systest!(test_few_large_messages))
-        .add_test(systest!(test_large_messages))
+        // TODO: re-enable this once hashes-in-blocks feature is re-enabled, without the feature
+        // consensus cannot handle such a load
+        //.add_test(systest!(test_large_messages))
         .execute_from_args()?;
     Ok(())
 }


### PR DESCRIPTION
After the hashes-in-blocks feature has been turned off in https://github.com/dfinity/ic/commit/5716305a58110031dac133f7182b1e3efd50257e the consensus can no longer handle the load simulated in the test.

To make the test not fail we temporarily go back to the parameters from https://github.com/dfinity/ic/pull/3279