### PR TITLE
feat(IC-1579): TLA instrumentation for `disburse_neuron`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20906,6 +20906,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 name = "tla_instrumentation"
 version = "0.9.0"
 dependencies = [
+ "async-trait",
  "candid",
  "local_key",
  "sha2 0.10.8",

--- a/rs/nns/governance/src/governance.rs
+++ b/rs/nns/governance/src/governance.rs
@@ -146,9 +146,9 @@ use crate::storage::with_voting_state_machines_mut;
 use std::collections::BTreeSet;
 #[cfg(feature = "tla")]
 pub use tla::{
-    tla_update_method, InstrumentationState, ToTla, CLAIM_NEURON_DESC, MERGE_NEURONS_DESC,
-    SPAWN_NEURONS_DESC, SPAWN_NEURON_DESC, SPLIT_NEURON_DESC, TLA_INSTRUMENTATION_STATE,
-    TLA_TRACES_LKEY, TLA_TRACES_MUTEX,
+    tla_update_method, InstrumentationState, ToTla, CLAIM_NEURON_DESC, DISBURSE_NEURON_DESC,
+    MERGE_NEURONS_DESC, SPAWN_NEURONS_DESC, SPAWN_NEURON_DESC, SPLIT_NEURON_DESC,
+    TLA_INSTRUMENTATION_STATE, TLA_TRACES_LKEY, TLA_TRACES_MUTEX,
 };
 
 // 70 KB (for executing NNS functions that are not canister upgrades)
@@ -2631,6 +2631,7 @@ impl Governance {
     /// - The neuron exists.
     /// - The caller is the controller of the the neuron.
     /// - The neuron's state is `Dissolved` at the current timestamp.
+    #[cfg_attr(feature = "tla", tla_update_method(DISBURSE_NEURON_DESC.clone()))]
     pub async fn disburse_neuron(
         &mut self,
         id: &NeuronId,
@@ -2735,6 +2736,13 @@ impl Governance {
         // an amount less than the transaction fee.
         if fees_amount_e8s > transaction_fee_e8s {
             let now = self.env.now();
+            tla_log_label!("DisburseNeuron_Fee");
+            tla_log_locals! {
+                fees_amount: fees_amount_e8s,
+                neuron_id: id.id,
+                to_account: tla::account_to_tla(to_account),
+                disburse_amount: disburse_amount_e8s
+            };
             let _result = self
                 .ledger
                 .transfer_funds(
@@ -2762,6 +2770,15 @@ impl Governance {
         // user told us to disburse more than they had in their account (but
         // the burn still happened).
         let now = self.env.now();
+
+        tla_log_label!("DisburseNeuron_Stake");
+        tla_log_locals! {
+            fees_amount: fees_amount_e8s,
+            neuron_id: id.id,
+            to_account: tla::account_to_tla(to_account),
+            disburse_amount: disburse_amount_e8s
+        };
+
         let block_height = self
             .ledger
             .transfer_funds(

--- a/rs/nns/governance/src/governance/tla/common.rs
+++ b/rs/nns/governance/src/governance/tla/common.rs
@@ -52,3 +52,20 @@ pub fn function_domain_union(
     }
     ).collect()
 }
+
+pub fn function_range_union(
+    state_pairs: &[ResolvedStatePair],
+    field_name: &str,
+) -> BTreeSet<TlaValue> {
+    state_pairs.iter().flat_map(|pair| {
+        match (pair.start.get(field_name), pair.end.get(field_name)) {
+            (Some(TlaValue::Function(sf)), Some(TlaValue::Function(ef))) => {
+                sf.values().chain(ef.values()).cloned()
+            }
+            _ => {
+                panic!("Field {} not found in the start or end state, or not a function, when computing the union", field_name)
+            }
+        }
+    }
+    ).collect()
+}

--- a/rs/nns/governance/src/governance/tla/disburse_neuron.rs
+++ b/rs/nns/governance/src/governance/tla/disburse_neuron.rs
@@ -1,0 +1,49 @@
+use super::{
+    account_to_tla, extract_common_constants, function_domain_union, function_range_union,
+    post_process_trace,
+};
+use crate::governance::governance_minting_account;
+use lazy_static::lazy_static;
+use std::collections::BTreeSet;
+use tla_instrumentation::{Label, TlaConstantAssignment, TlaValue, ToTla, Update, VarAssignment};
+
+const PID: &str = "Disburse_Neuron";
+lazy_static! {
+    pub static ref DISBURSE_NEURON_DESC: Update = {
+        let default_locals = VarAssignment::new()
+            .add("neuron_id", 0_u64.to_tla_value())
+            .add("disburse_amount", 0_u64.to_tla_value())
+            .add("to_account", "".to_tla_value())
+            .add("fees_amount", 0_u64.to_tla_value());
+        Update {
+            default_start_locals: default_locals.clone(),
+            default_end_locals: default_locals,
+            start_label: Label::new("DisburseNeuron1"),
+            end_label: Label::new("Done"),
+            process_id: PID.to_string(),
+            canister_name: "governance".to_string(),
+            post_process: |trace| {
+                let mut constants = TlaConstantAssignment {
+                    constants: extract_common_constants(PID, trace).into_iter().collect(),
+                };
+                post_process_trace(trace);
+                constants.constants.insert(
+                    "Minting_Account_Id".to_string(),
+                    account_to_tla(governance_minting_account()),
+                );
+                let all_accounts = function_range_union(trace, "to_account")
+                    .union(&function_domain_union(trace, "neuron_id_by_account"))
+                    .filter(|account| **account != "".to_tla_value())
+                    .into_iter()
+                    .chain(vec![&account_to_tla(governance_minting_account())])
+                    .cloned()
+                    .collect::<BTreeSet<TlaValue>>();
+
+                constants
+                    .constants
+                    .insert("Account_Ids".to_string(), all_accounts.to_tla_value());
+                constants
+            },
+        }
+    };
+}

--- a/rs/nns/governance/src/governance/tla/disburse_neuron.rs
+++ b/rs/nns/governance/src/governance/tla/disburse_neuron.rs
@@ -5,6 +5,7 @@ use super::{
 use crate::governance::governance_minting_account;
 use lazy_static::lazy_static;
 use std::collections::BTreeSet;
+use std::iter::once;
 use tla_instrumentation::{Label, TlaConstantAssignment, TlaValue, ToTla, Update, VarAssignment};
 
 const PID: &str = "Disburse_Neuron";
@@ -34,8 +35,7 @@ lazy_static! {
                 let all_accounts = function_range_union(trace, "to_account")
                     .union(&function_domain_union(trace, "neuron_id_by_account"))
                     .filter(|account| **account != "".to_tla_value())
-                    .into_iter()
-                    .chain(vec![&account_to_tla(governance_minting_account())])
+                    .chain(once(&account_to_tla(governance_minting_account())))
                     .cloned()
                     .collect::<BTreeSet<TlaValue>>();
 

--- a/rs/nns/governance/src/governance/tla/mod.rs
+++ b/rs/nns/governance/src/governance/tla/mod.rs
@@ -10,7 +10,7 @@ pub use tla_instrumentation::{
     Destination, GlobalState, InstrumentationState, Label, ResolvedStatePair,
     TlaConstantAssignment, TlaValue, ToTla, Update, UpdateTrace, VarAssignment,
 };
-pub use tla_instrumentation_proc_macros::tla_update_method;
+pub use tla_instrumentation_proc_macros::{tla_function, tla_update_method};
 
 pub use tla_instrumentation::checker::{check_tla_code_link, PredicateDescription};
 
@@ -21,16 +21,18 @@ mod common;
 mod store;
 
 pub use common::{account_to_tla, opt_subaccount_to_tla, subaccount_to_tla};
-use common::{function_domain_union, governance_account_id};
+use common::{function_domain_union, function_range_union, governance_account_id};
 pub use store::{TLA_INSTRUMENTATION_STATE, TLA_TRACES_LKEY, TLA_TRACES_MUTEX};
 
 mod claim_neuron;
+mod disburse_neuron;
 mod merge_neurons;
 mod spawn_neuron;
 mod spawn_neurons;
 mod split_neuron;
 
 pub use claim_neuron::CLAIM_NEURON_DESC;
+pub use disburse_neuron::DISBURSE_NEURON_DESC;
 pub use merge_neurons::MERGE_NEURONS_DESC;
 pub use spawn_neuron::SPAWN_NEURON_DESC;
 pub use spawn_neurons::SPAWN_NEURONS_DESC;

--- a/rs/nns/governance/tests/fake.rs
+++ b/rs/nns/governance/tests/fake.rs
@@ -289,7 +289,7 @@ impl FakeDriver {
                 tla_log_response!(
                     Destination::new("ledger"),
                     tla::TlaValue::Variant {
-                        tag: "TransferFail".to_string(),
+                        tag: "Fail".to_string(),
                         value: Box::new(tla::TlaValue::Constant("UNIT".to_string()))
                     }
                 );

--- a/rs/nns/governance/tests/fake.rs
+++ b/rs/nns/governance/tests/fake.rs
@@ -243,9 +243,10 @@ impl FakeDriver {
     }
 }
 
-impl FakeDriver {
-    #[cfg_attr(feature = "tla", tla_function)]
-    async fn transfer_funds_impl(
+#[async_trait]
+impl IcpLedger for FakeDriver {
+    #[cfg_attr(feature = "tla", tla_function(async_trait_fn = true))]
+    async fn transfer_funds(
         &self,
         amount_e8s: u64,
         fee_e8s: u64,
@@ -311,21 +312,6 @@ impl FakeDriver {
         );
 
         Ok(0)
-    }
-}
-
-#[async_trait]
-impl IcpLedger for FakeDriver {
-    async fn transfer_funds(
-        &self,
-        amount_e8s: u64,
-        fee_e8s: u64,
-        from_subaccount: Option<Subaccount>,
-        to_account: AccountIdentifier,
-        _: u64,
-    ) -> Result<u64, NervousSystemError> {
-        self.transfer_funds_impl(amount_e8s, fee_e8s, from_subaccount, to_account, 0)
-            .await
     }
 
     async fn total_supply(&self) -> Result<Tokens, NervousSystemError> {

--- a/rs/nns/governance/tests/governance.rs
+++ b/rs/nns/governance/tests/governance.rs
@@ -4738,6 +4738,7 @@ fn test_neuron_lifecycle() {
 }
 
 #[test]
+#[cfg_attr(feature = "tla", with_tla_trace_check)]
 fn test_disburse_to_subaccount() {
     let (driver, mut gov, neuron) = create_mature_neuron(true);
 
@@ -4831,6 +4832,7 @@ fn test_nns1_520() {
 }
 
 #[test]
+#[cfg_attr(feature = "tla", with_tla_trace_check)]
 fn test_disburse_to_main_account() {
     let (driver, mut gov, neuron) = create_mature_neuron(true);
 
@@ -5428,6 +5430,7 @@ fn test_rate_limiting_neuron_creation() {
 }
 
 #[test]
+#[cfg_attr(feature = "tla", with_tla_trace_check)]
 fn test_cant_disburse_without_paying_fees() {
     let (driver, mut gov, neuron) = create_mature_neuron(true);
 
@@ -6589,7 +6592,6 @@ async fn test_neuron_with_non_self_authenticating_controller_is_now_allowed() {
 }
 
 #[test]
-#[cfg_attr(feature = "tla", with_tla_trace_check)]
 fn test_disburse_to_neuron() {
     let from = *TEST_NEURON_1_OWNER_PRINCIPAL;
     // Compute the subaccount to which the transfer would have been made

--- a/rs/nns/governance/tests/governance.rs
+++ b/rs/nns/governance/tests/governance.rs
@@ -4700,6 +4700,7 @@ fn create_mature_neuron(dissolved: bool) -> (fake::FakeDriver, Governance, Neuro
 }
 
 #[test]
+#[cfg_attr(feature = "tla", with_tla_trace_check)]
 fn test_neuron_lifecycle() {
     let (driver, mut gov, neuron) = create_mature_neuron(true);
 
@@ -6588,6 +6589,7 @@ async fn test_neuron_with_non_self_authenticating_controller_is_now_allowed() {
 }
 
 #[test]
+#[cfg_attr(feature = "tla", with_tla_trace_check)]
 fn test_disburse_to_neuron() {
     let from = *TEST_NEURON_1_OWNER_PRINCIPAL;
     // Compute the subaccount to which the transfer would have been made

--- a/rs/nns/governance/tla/Disburse_Neuron.tla
+++ b/rs/nns/governance/tla/Disburse_Neuron.tla
@@ -1,0 +1,246 @@
+---- MODULE Disburse_Neuron ----
+
+EXTENDS TLC, Integers, FiniteSets, Sequences, Variants
+
+CONSTANTS
+    Governance_Account_Ids,
+    Account_Ids,
+    Neuron_Ids,
+    Minting_Account_Id
+
+CONSTANTS
+    Disburse_Neuron_Process_Ids
+
+CONSTANTS
+    \* Minimum stake a neuron can have
+    MIN_STAKE,
+    \* The transfer fee charged by the ledger canister
+    TRANSACTION_FEE
+
+\* Initial value used for uninitialized accounts
+DUMMY_ACCOUNT == ""
+
+\* @type: (a -> b, Set(a)) => a -> b;
+Remove_Arguments(f, S) == [ x \in (DOMAIN f \ S) |-> f[x]]
+Max(x, y) == IF x < y THEN y ELSE x
+
+request(caller, request_args) == [caller |-> caller, method_and_args |-> request_args]
+transfer(from, to, amount, fee) == Variant("Transfer", [from |-> from, to |-> to, amount |-> amount, fee |-> fee])
+
+o_deduct(disb_amount) == disb_amount + TRANSACTION_FEE
+
+(* --algorithm Governance_Ledger_Disburse_Neuron {
+
+variables
+
+    neuron \in [{} -> {}];
+    \* Used to decide whether we should refresh or claim a neuron
+    neuron_id_by_account \in [{} -> {}];
+    \* The set of currently locked neurons
+    locks = {};
+    \* The queue of messages sent from the governance canister to the ledger canister
+    governance_to_ledger = <<>>;
+    ledger_to_governance = {};
+    spawning_neurons = FALSE;
+
+macro send_request(caller_id, request_args) {
+    governance_to_ledger := Append(governance_to_ledger, request(caller_id, request_args))
+};
+
+macro update_fees(neuron_id, fees_amount) {
+    if(neuron[neuron_id].cached_stake > fees_amount) {
+        neuron := [neuron EXCEPT ![neuron_id] = [@ EXCEPT !.cached_stake = @ - fees_amount, !.fees = 0]]
+    } else {
+        neuron := [neuron EXCEPT ![neuron_id] = [@ EXCEPT !.cached_stake = 0, !.fees = 0]];
+    };
+}
+
+macro finish() {
+    locks := locks \ {neuron_id};
+    neuron_id := 0;
+    disburse_amount := 0;
+    to_account := DUMMY_ACCOUNT;
+    fees_amount := 0;
+    goto Done;
+}
+
+process ( Disburse_Neuron \in Disburse_Neuron_Process_Ids )
+    variable
+        \* These model the parameters of the call
+        neuron_id = 0;
+        disburse_amount = 0;
+        to_account = DUMMY_ACCOUNT;
+        \* The model the internal variables of the procedure.
+        \* Since +Cal doesn't allow multiple assignments to the same variable in a single block,
+        \* we also use temporary variables to simulate this and stay closer to the source code
+        fees_amount = 0;
+    {
+    DisburseNeuron1:
+        either {
+            \* Simulate calls that just fail early and don't change the state.
+            \* Not so useful for model checking, but needed to follow the code traces.
+            goto Done;
+        } or {
+            \* This models a few checks at the start of the Rust code.
+            \* We currently omit the check that the neuron is dissolved, and we plan to add this later.
+            \* We omit the other checks: who the caller is, whether the neuron is KYC verified, as well
+            \* as a few well-formedness checks (of the neuron and recipient account) as everything in
+            \* our model is well-formed.
+            with(nid \in DOMAIN(neuron) \ locks; amt \in 0..(neuron[nid].cached_stake - neuron[nid].fees); account \in Account_Ids) {
+                neuron_id := nid;
+                disburse_amount := amt;
+                fees_amount := neuron[neuron_id].fees;
+                to_account := account;
+                \* The Rust code has a more elaborate code path to determine the disburse_amount, where the
+                \* amount argument is left unspecified in the call, and a default value is computed instead.
+                \* As this default value is in the range between 0 and the neuron's cached_stake, our
+                \* non-deterministic choice should cover this case.
+                \* The Rust code throws an error here if the neuron is locked. Instead, we prevent the Disburse_Neuron process from running.
+                \* This is OK since the Rust code doesn't change the canister's state before obtaining the lock (if it
+                \* did, the model wouldn't capture this and we could miss behaviors).
+                locks := locks \union {neuron_id};
+                if(fees_amount > TRANSACTION_FEE) {
+                    send_request(self, transfer(neuron[neuron_id].account, Minting_Account_Id, fees_amount, 0));
+                }
+                else {
+                    update_fees(neuron_id, fees_amount);
+                    send_request(self, transfer(neuron[neuron_id].account, to_account, disburse_amount, TRANSACTION_FEE));
+                    goto DisburseNeuron_Stake_WaitForTransfer;
+                };
+            };
+         };
+    DisburseNeuron_Fee_WaitForTransfer:
+        \* Note that we're here only because the fees amount was larger than the
+        \* transaction fee (otherwise, the goto above would have taken us to DisburseNeuron3)
+        with(answer \in { resp \in ledger_to_governance: resp.caller = self}) {
+            ledger_to_governance := ledger_to_governance \ {answer};
+            if(answer.response = Variant("Fail", UNIT)) {
+                finish();
+            } else {
+                update_fees(neuron_id, fees_amount);
+                send_request(self, transfer(neuron[neuron_id].account, to_account, disburse_amount, TRANSACTION_FEE));
+            };
+        };
+
+    DisburseNeuron_Stake_WaitForTransfer:
+        with(answer \in { resp \in ledger_to_governance: resp.caller = self}) {
+            ledger_to_governance := ledger_to_governance \ {answer};
+            if(answer.response # Variant("Fail", UNIT)) {
+               neuron := [neuron EXCEPT![neuron_id].cached_stake =
+                    Max(0, @ - (disburse_amount + TRANSACTION_FEE))];
+            };
+        };
+        finish();
+    }
+}
+*)
+\* BEGIN TRANSLATION (chksum(pcal) = "6a67a01e" /\ chksum(tla) = "313cf395")
+VARIABLES pc, neuron, neuron_id_by_account, locks, governance_to_ledger,
+          ledger_to_governance, spawning_neurons, neuron_id, disburse_amount,
+          to_account, fees_amount
+
+vars == << pc, neuron, neuron_id_by_account, locks, governance_to_ledger,
+           ledger_to_governance, spawning_neurons, neuron_id, disburse_amount,
+           to_account, fees_amount >>
+
+ProcSet == (Disburse_Neuron_Process_Ids)
+
+Init == (* Global variables *)
+        /\ neuron \in [{} -> {}]
+        /\ neuron_id_by_account \in [{} -> {}]
+        /\ locks = {}
+        /\ governance_to_ledger = <<>>
+        /\ ledger_to_governance = {}
+        /\ spawning_neurons = FALSE
+        (* Process Disburse_Neuron *)
+        /\ neuron_id = [self \in Disburse_Neuron_Process_Ids |-> 0]
+        /\ disburse_amount = [self \in Disburse_Neuron_Process_Ids |-> 0]
+        /\ to_account = [self \in Disburse_Neuron_Process_Ids |-> DUMMY_ACCOUNT]
+        /\ fees_amount = [self \in Disburse_Neuron_Process_Ids |-> 0]
+        /\ pc = [self \in ProcSet |-> "DisburseNeuron1"]
+
+DisburseNeuron1(self) == /\ pc[self] = "DisburseNeuron1"
+                         /\ \/ /\ pc' = [pc EXCEPT ![self] = "Done"]
+                               /\ UNCHANGED <<neuron, locks, governance_to_ledger, neuron_id, disburse_amount, to_account, fees_amount>>
+                            \/ /\ \E nid \in DOMAIN(neuron) \ locks:
+                                    \E amt \in 0..(neuron[nid].cached_stake - neuron[nid].fees):
+                                      \E account \in Account_Ids:
+                                        /\ neuron_id' = [neuron_id EXCEPT ![self] = nid]
+                                        /\ disburse_amount' = [disburse_amount EXCEPT ![self] = amt]
+                                        /\ fees_amount' = [fees_amount EXCEPT ![self] = neuron[neuron_id'[self]].fees]
+                                        /\ to_account' = [to_account EXCEPT ![self] = account]
+                                        /\ locks' = (locks \union {neuron_id'[self]})
+                                        /\ IF fees_amount'[self] > TRANSACTION_FEE
+                                              THEN /\ governance_to_ledger' = Append(governance_to_ledger, request(self, (transfer(neuron[neuron_id'[self]].account, Minting_Account_Id, fees_amount'[self], 0))))
+                                                   /\ pc' = [pc EXCEPT ![self] = "DisburseNeuron_Fee_WaitForTransfer"]
+                                                   /\ UNCHANGED neuron
+                                              ELSE /\ IF neuron[neuron_id'[self]].cached_stake > fees_amount'[self]
+                                                         THEN /\ neuron' = [neuron EXCEPT ![neuron_id'[self]] = [@ EXCEPT !.cached_stake = @ - fees_amount'[self], !.fees = 0]]
+                                                         ELSE /\ neuron' = [neuron EXCEPT ![neuron_id'[self]] = [@ EXCEPT !.cached_stake = 0, !.fees = 0]]
+                                                   /\ governance_to_ledger' = Append(governance_to_ledger, request(self, (transfer(neuron'[neuron_id'[self]].account, to_account'[self], disburse_amount'[self], TRANSACTION_FEE))))
+                                                   /\ pc' = [pc EXCEPT ![self] = "DisburseNeuron_Stake_WaitForTransfer"]
+                         /\ UNCHANGED << neuron_id_by_account,
+                                         ledger_to_governance,
+                                         spawning_neurons >>
+
+DisburseNeuron_Fee_WaitForTransfer(self) == /\ pc[self] = "DisburseNeuron_Fee_WaitForTransfer"
+                                            /\ \E answer \in { resp \in ledger_to_governance: resp.caller = self}:
+                                                 /\ ledger_to_governance' = ledger_to_governance \ {answer}
+                                                 /\ IF answer.response = Variant("Fail", UNIT)
+                                                       THEN /\ locks' = locks \ {neuron_id[self]}
+                                                            /\ neuron_id' = [neuron_id EXCEPT ![self] = 0]
+                                                            /\ disburse_amount' = [disburse_amount EXCEPT ![self] = 0]
+                                                            /\ to_account' = [to_account EXCEPT ![self] = DUMMY_ACCOUNT]
+                                                            /\ fees_amount' = [fees_amount EXCEPT ![self] = 0]
+                                                            /\ pc' = [pc EXCEPT ![self] = "Done"]
+                                                            /\ UNCHANGED << neuron,
+                                                                            governance_to_ledger >>
+                                                       ELSE /\ IF neuron[neuron_id[self]].cached_stake > fees_amount[self]
+                                                                  THEN /\ neuron' = [neuron EXCEPT ![neuron_id[self]] = [@ EXCEPT !.cached_stake = @ - fees_amount[self], !.fees = 0]]
+                                                                  ELSE /\ neuron' = [neuron EXCEPT ![neuron_id[self]] = [@ EXCEPT !.cached_stake = 0, !.fees = 0]]
+                                                            /\ governance_to_ledger' = Append(governance_to_ledger, request(self, (transfer(neuron'[neuron_id[self]].account, to_account[self], disburse_amount[self], TRANSACTION_FEE))))
+                                                            /\ pc' = [pc EXCEPT ![self] = "DisburseNeuron_Stake_WaitForTransfer"]
+                                                            /\ UNCHANGED << locks,
+                                                                            neuron_id,
+                                                                            disburse_amount,
+                                                                            to_account,
+                                                                            fees_amount >>
+                                            /\ UNCHANGED << neuron_id_by_account,
+                                                            spawning_neurons >>
+
+DisburseNeuron_Stake_WaitForTransfer(self) == /\ pc[self] = "DisburseNeuron_Stake_WaitForTransfer"
+                                              /\ \E answer \in { resp \in ledger_to_governance: resp.caller = self}:
+                                                   /\ ledger_to_governance' = ledger_to_governance \ {answer}
+                                                   /\ IF answer.response # Variant("Fail", UNIT)
+                                                         THEN /\ neuron' =      [neuron EXCEPT![neuron_id[self]].cached_stake =
+                                                                           Max(0, @ - (disburse_amount[self] + TRANSACTION_FEE))]
+                                                         ELSE /\ TRUE
+                                                              /\ UNCHANGED neuron
+                                              /\ locks' = locks \ {neuron_id[self]}
+                                              /\ neuron_id' = [neuron_id EXCEPT ![self] = 0]
+                                              /\ disburse_amount' = [disburse_amount EXCEPT ![self] = 0]
+                                              /\ to_account' = [to_account EXCEPT ![self] = DUMMY_ACCOUNT]
+                                              /\ fees_amount' = [fees_amount EXCEPT ![self] = 0]
+                                              /\ pc' = [pc EXCEPT ![self] = "Done"]
+                                              /\ UNCHANGED << neuron_id_by_account,
+                                                              governance_to_ledger,
+                                                              spawning_neurons >>
+
+Disburse_Neuron(self) == DisburseNeuron1(self)
+                            \/ DisburseNeuron_Fee_WaitForTransfer(self)
+                            \/ DisburseNeuron_Stake_WaitForTransfer(self)
+
+(* Allow infinite stuttering to prevent deadlock on termination. *)
+Terminating == /\ \A self \in ProcSet: pc[self] = "Done"
+               /\ UNCHANGED vars
+
+Next == (\E self \in Disburse_Neuron_Process_Ids: Disburse_Neuron(self))
+           \/ Terminating
+
+Spec == Init /\ [][Next]_vars
+
+Termination == <>(\A self \in ProcSet: pc[self] = "Done")
+
+\* END TRANSLATION
+
+====

--- a/rs/nns/governance/tla/Disburse_Neuron.tla
+++ b/rs/nns/governance/tla/Disburse_Neuron.tla
@@ -86,7 +86,9 @@ process ( Disburse_Neuron \in Disburse_Neuron_Process_Ids )
             \* We omit the other checks: who the caller is, whether the neuron is KYC verified, as well
             \* as a few well-formedness checks (of the neuron and recipient account) as everything in
             \* our model is well-formed.
-            with(nid \in DOMAIN(neuron) \ locks; amt \in 0..(neuron[nid].cached_stake - neuron[nid].fees); account \in Account_Ids) {
+            \* Note that the user can request to disburse an arbitrary amount. This will only fail once
+            \* we send a message to the ledger.
+            with(nid \in DOMAIN(neuron) \ locks; amt \in Nat; account \in Account_Ids) {
                 neuron_id := nid;
                 disburse_amount := amt;
                 fees_amount := neuron[neuron_id].fees;
@@ -134,7 +136,7 @@ process ( Disburse_Neuron \in Disburse_Neuron_Process_Ids )
     }
 }
 *)
-\* BEGIN TRANSLATION (chksum(pcal) = "6a67a01e" /\ chksum(tla) = "313cf395")
+\* BEGIN TRANSLATION (chksum(pcal) = "49bb5804" /\ chksum(tla) = "fa8fb71a")
 VARIABLES pc, neuron, neuron_id_by_account, locks, governance_to_ledger,
           ledger_to_governance, spawning_neurons, neuron_id, disburse_amount,
           to_account, fees_amount
@@ -163,7 +165,7 @@ DisburseNeuron1(self) == /\ pc[self] = "DisburseNeuron1"
                          /\ \/ /\ pc' = [pc EXCEPT ![self] = "Done"]
                                /\ UNCHANGED <<neuron, locks, governance_to_ledger, neuron_id, disburse_amount, to_account, fees_amount>>
                             \/ /\ \E nid \in DOMAIN(neuron) \ locks:
-                                    \E amt \in 0..(neuron[nid].cached_stake - neuron[nid].fees):
+                                    \E amt \in Nat:
                                       \E account \in Account_Ids:
                                         /\ neuron_id' = [neuron_id EXCEPT ![self] = nid]
                                         /\ disburse_amount' = [disburse_amount EXCEPT ![self] = amt]

--- a/rs/nns/governance/tla/Disburse_Neuron_Apalache.tla
+++ b/rs/nns/governance/tla/Disburse_Neuron_Apalache.tla
@@ -1,0 +1,70 @@
+---- MODULE Disburse_Neuron_Apalache ----
+
+EXTENDS TLC, Variants
+
+(*
+@typeAlias: proc = Str;
+@typeAlias: account = Str;
+@typeAlias: neuronId = Int;
+@typeAlias: methodCall = Transfer({ from: $account, to: $account, amount: Int, fee: Int}) | AccountBalance({ account: $account });
+@typeAlias: methodResponse = Fail(UNIT) | TransferOk(UNIT) | BalanceQueryOk(Int);
+*)
+_type_alias_dummy == TRUE
+
+\* CODE_LINK_INSERT_CONSTANTS
+
+(*
+CONSTANTS
+    \* @type: Set($account);
+    Account_Ids,
+    \* @type: Set($account);
+    Governance_Account_Ids,
+    \* @type: Set($neuronId);
+    Neuron_Ids,
+    \* @type: $account;
+    Minting_Account_Id
+
+CONSTANTS
+    \* @type: Set($proc);
+    Disburse_Neuron_Process_Ids
+
+CONSTANTS
+    \* Minimum stake a neuron can have
+    \* @type: Int;
+    MIN_STAKE,
+    \* The transfer fee charged by the ledger canister
+    \* @type: Int;
+    TRANSACTION_FEE
+*)
+
+VARIABLES
+    \* @type: $neuronId -> {cached_stake: Int, account: $account, maturity: Int, fees: Int};
+    neuron,
+    \* @type: $account -> $neuronId;
+    neuron_id_by_account,
+    \* @type: Set($neuronId);
+    locks,
+    \* @type: Seq({caller : $proc, method_and_args: $methodCall });
+    governance_to_ledger,
+    \* @type: Set({caller: $proc, response: $methodResponse });
+    ledger_to_governance,
+    \* @type: $proc -> Str;
+    pc,
+    \* Not used by this model, but it's a global variable used by spawn_neurons, so
+    \* it's the easiest to just add it to all the other models
+    \* @type: Bool;
+    spawning_neurons,
+    \* @type: $proc -> Int;
+    neuron_id,
+    \* @type: $proc -> Int;
+    disburse_amount,
+    \* @type: $proc -> $account;
+    to_account,
+    \* @type: $proc -> Int;
+    fees_amount
+
+MOD == INSTANCE Disburse_Neuron
+
+Next == [MOD!Next]_MOD!vars
+
+====

--- a/rs/tla_instrumentation/BUILD.bazel
+++ b/rs/tla_instrumentation/BUILD.bazel
@@ -73,7 +73,10 @@ rust_test(
         "TLA_APALACHE_BIN": "$(rootpath @tla_apalache//:bin/apalache-mc)",
         "TLA_MODULES": "$(locations :tla_models)",
     },
-    proc_macro_deps = [":proc_macros"],
+    proc_macro_deps = [
+        ":proc_macros",
+        "@crate_index//:async-trait",
+    ],
     toolchains = ["@bazel_tools//tools/jdk:current_java_runtime"],
     deps = [
         ":local_key",

--- a/rs/tla_instrumentation/tla_instrumentation/Cargo.toml
+++ b/rs/tla_instrumentation/tla_instrumentation/Cargo.toml
@@ -14,6 +14,7 @@ sha2 = { workspace = true }
 uuid = { workspace = true }
 
 [dev-dependencies]
+async-trait = { workspace = true }
 tokio-test = { workspace = true }
 local_key = { path = "../local_key" }
 tla_instrumentation_proc_macros = { path = "../tla_instrumentation_proc_macros" }

--- a/rs/tla_instrumentation/tla_instrumentation/tests/multiple_calls.rs
+++ b/rs/tla_instrumentation/tla_instrumentation/tests/multiple_calls.rs
@@ -125,12 +125,14 @@ static mut GLOBAL: StructCanister = StructCanister { counter: 0 };
 
 struct CallMaker {}
 
-pub trait CallMakerTrait {
+#[async_trait]
+trait CallMakerTrait {
     async fn call_maker(&self);
 }
 
+#[async_trait]
 impl CallMakerTrait for CallMaker {
-    #[tla_function]
+    #[tla_function(async_trait_fn = true)]
     async fn call_maker(&self) {
         tla_log_request!(
             "WaitForResponse",

--- a/rs/tla_instrumentation/tla_instrumentation/tests/multiple_calls.rs
+++ b/rs/tla_instrumentation/tla_instrumentation/tests/multiple_calls.rs
@@ -12,6 +12,8 @@ use tla_instrumentation::{
 };
 use tla_instrumentation_proc_macros::{tla_function, tla_update_method};
 
+use async_trait::async_trait;
+
 mod common;
 use common::check_tla_trace;
 
@@ -121,36 +123,45 @@ struct StructCanister {
 
 static mut GLOBAL: StructCanister = StructCanister { counter: 0 };
 
-#[tla_function]
-async fn call_maker() {
-    tla_log_request!(
-        "WaitForResponse",
-        Destination::new("othercan"),
-        "Target_Method",
-        2_u64
-    );
-    tla_log_response!(
-        Destination::new("othercan"),
-        TlaValue::Variant {
-            tag: "Ok".to_string(),
-            value: Box::new(3_u64.to_tla_value())
-        }
-    );
+struct CallMaker {}
+
+pub trait CallMakerTrait {
+    async fn call_maker(&self);
+}
+
+impl CallMakerTrait for CallMaker {
+    #[tla_function]
+    async fn call_maker(&self) {
+        tla_log_request!(
+            "WaitForResponse",
+            Destination::new("othercan"),
+            "Target_Method",
+            2_u64
+        );
+        tla_log_response!(
+            Destination::new("othercan"),
+            TlaValue::Variant {
+                tag: "Ok".to_string(),
+                value: Box::new(3_u64.to_tla_value())
+            }
+        );
+    }
 }
 
 impl StructCanister {
     #[tla_update_method(my_f_desc())]
     pub async fn my_method(&mut self) {
         self.counter += 1;
+        let call_maker = CallMaker {};
         let mut my_local: u64 = self.counter;
         tla_log_locals! {my_local: my_local};
         tla_log_label!("Phase1");
-        call_maker().await;
+        call_maker.call_maker().await;
         self.counter += 1;
         my_local = self.counter;
         tla_log_locals! {my_local: my_local};
         tla_log_label!("Phase2");
-        call_maker().await;
+        call_maker.call_maker().await;
         self.counter += 1;
         my_local = self.counter;
         // Note that this would not be necessary (and would be an error) if

--- a/rs/tla_instrumentation/tla_instrumentation_proc_macros/src/lib.rs
+++ b/rs/tla_instrumentation/tla_instrumentation_proc_macros/src/lib.rs
@@ -271,7 +271,6 @@ pub fn tla_function(attr: TokenStream, item: TokenStream) -> TokenStream {
        }).unwrap_or_else(|e| {
            // TODO(RES-152): fail if there's an error and if we're in some kind of strict mode?
             println!("Couldn't find TLA_INSTRUMENTATION_STATE when calling a tla_function; ignoring for the moment");
-           ()
        });
        let res = #call;
        TLA_INSTRUMENTATION_STATE.try_with(|state| {

--- a/rs/tla_instrumentation/tla_instrumentation_proc_macros/src/lib.rs
+++ b/rs/tla_instrumentation/tla_instrumentation_proc_macros/src/lib.rs
@@ -327,25 +327,3 @@ pub fn with_tla_trace_check(_attr: TokenStream, item: TokenStream) -> TokenStrea
     };
     output.into()
 }
-
-/*
-#[proc_macro_attribute]
-/// Apply the tla_function macro to all functions in the given impl
-pub fn tla_function_impl(args: TokenStream, input: TokenStream) -> TokenStream {
-    let mut input = parse_macro_input!(input as syn::ItemImpl);
-    let args = parse_macro_input!(args as syn::AttributeArgs);
-
-    match input {
-        Item::Impl(imp) {
-            for mut item in imp.items {
-                if let syn::ImplItem::Method(method) = item {
-                    let mut attrs = method.attrs;
-                    attrs.push(syn::parse_quote!(#[tla_function]));
-                    method.attrs = attrs;
-                }
-            }
-        }
-    }
-}
-
- */


### PR DESCRIPTION
Adds TLA instrumentation for `disburse_neuron`. Since this calls `transfer_funds` multiple times, we also need some additional functionality to disambiguate the different call sites. The disambiguation requires a small tweak to the existing models (of spawn, split, etc).

Moreover the disambiguation functionality (based on the `tla_function` macro) didn't play well with `async_trait`, so we add a special case to handle that.