### PR TITLE
feat(PocketIC): optionally check caller when retrieving ingress status

### DIFF
--- a/packages/pocket-ic/CHANGELOG.md
+++ b/packages/pocket-ic/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - The function `PocketIcBuilder::with_bitcoind_addrs` to specify multiple addresses and ports at which `bitcoind` processes are listening.
 - The function `PocketIc::query_call_with_effective_principal` for making generic query calls (including management canister query calls).
-- The function `PocketIc::ingress_status` to fetch the status of an update call submitted through an ingress message (`None` means that the status is unknown yet).
+- The function `PocketIc::ingress_status` to fetch the status of an update call submitted through an ingress message.
 - The function `PocketIc::await_call_no_ticks` to await the status of an update call (submitted through an ingress message) becoming known without triggering round execution
   (round execution must be triggered separarely, e.g., on a "live" instance or by separate PocketIC library calls).
 

--- a/packages/pocket-ic/src/common/rest.rs
+++ b/packages/pocket-ic/src/common/rest.rs
@@ -123,6 +123,12 @@ pub struct RawMessageId {
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug, JsonSchema)]
+pub struct RawIngressStatusArgs {
+    pub raw_message_id: RawMessageId,
+    pub raw_caller: Option<RawPrincipalId>,
+}
+
+#[derive(Clone, Serialize, Deserialize, Debug, JsonSchema)]
 pub enum RawSubmitIngressResult {
     Ok(RawMessageId),
     Err(UserError),

--- a/packages/pocket-ic/src/lib.rs
+++ b/packages/pocket-ic/src/lib.rs
@@ -1527,6 +1527,10 @@ pub enum CallError {
 }
 
 /// This enum describes the result of retrieving ingress status.
+/// The `IngressStatusResult::Forbidden` variant is produced
+/// if an optional caller is provided and a corresponding read state request
+/// for the status of the same update call signed by that specified caller
+/// was rejected because the update call was submitted by a different caller.
 #[derive(Debug, Serialize, Deserialize)]
 pub enum IngressStatusResult {
     NotAvailable,

--- a/packages/pocket-ic/src/lib.rs
+++ b/packages/pocket-ic/src/lib.rs
@@ -681,9 +681,10 @@ impl PocketIc {
     pub fn ingress_status(
         &self,
         message_id: RawMessageId,
-    ) -> Option<Result<WasmResult, UserError>> {
+        caller: Option<Principal>,
+    ) -> IngressStatusResult {
         let runtime = self.runtime.clone();
-        runtime.block_on(async { self.pocket_ic.ingress_status(message_id).await })
+        runtime.block_on(async { self.pocket_ic.ingress_status(message_id, caller).await })
     }
 
     /// Await an update call submitted previously by `submit_call` or `submit_call_with_effective_principal`.
@@ -1523,6 +1524,14 @@ impl std::fmt::Display for UserError {
 pub enum CallError {
     Reject(String),
     UserError(UserError),
+}
+
+/// This enum describes the result of retrieving ingress status.
+#[derive(Debug, Serialize, Deserialize)]
+pub enum IngressStatusResult {
+    NotAvailable,
+    Forbidden(String),
+    Success(Result<WasmResult, UserError>),
 }
 
 /// This struct describes the different types that executing a WASM function in

--- a/packages/pocket-ic/src/nonblocking.rs
+++ b/packages/pocket-ic/src/nonblocking.rs
@@ -3,9 +3,10 @@ use crate::common::rest::{
     CreateHttpGatewayResponse, CreateInstanceResponse, ExtendedSubnetConfigSet, HttpGatewayBackend,
     HttpGatewayConfig, HttpGatewayInfo, HttpsConfig, InstanceConfig, InstanceId,
     MockCanisterHttpResponse, RawAddCycles, RawCanisterCall, RawCanisterHttpRequest, RawCanisterId,
-    RawCanisterResult, RawCycles, RawEffectivePrincipal, RawMessageId, RawMockCanisterHttpResponse,
-    RawPrincipalId, RawSetStableMemory, RawStableMemory, RawSubmitIngressResult, RawSubnetId,
-    RawTime, RawVerifyCanisterSigArg, RawWasmResult, SubnetId, Topology,
+    RawCanisterResult, RawCycles, RawEffectivePrincipal, RawIngressStatusArgs, RawMessageId,
+    RawMockCanisterHttpResponse, RawPrincipalId, RawSetStableMemory, RawStableMemory,
+    RawSubmitIngressResult, RawSubnetId, RawTime, RawVerifyCanisterSigArg, RawWasmResult, SubnetId,
+    Topology,
 };
 use crate::management_canister::{
     CanisterId, CanisterIdRecord, CanisterInstallMode, CanisterInstallModeUpgradeInner,
@@ -16,7 +17,7 @@ use crate::management_canister::{
     TakeCanisterSnapshotArgs, UpdateSettingsArgs, UploadChunkArgs, UploadChunkResult,
 };
 pub use crate::DefaultEffectiveCanisterIdError;
-use crate::{CallError, PocketIcBuilder, UserError, WasmResult};
+use crate::{CallError, IngressStatusResult, PocketIcBuilder, UserError, WasmResult};
 use backoff::backoff::Backoff;
 use backoff::{ExponentialBackoff, ExponentialBackoffBuilder};
 use candid::{
@@ -599,17 +600,28 @@ impl PocketIc {
     /// or a round has been executed due to a separate PocketIC library call.
     pub async fn ingress_status(
         &self,
-        message_id: RawMessageId,
-    ) -> Option<Result<WasmResult, UserError>> {
+        raw_message_id: RawMessageId,
+        caller: Option<Principal>,
+    ) -> IngressStatusResult {
         let endpoint = "read/ingress_status";
-        let result: Option<RawCanisterResult> = self.post(endpoint, message_id).await;
-        result.map(|result| match result {
-            RawCanisterResult::Ok(raw_wasm_result) => match raw_wasm_result {
-                RawWasmResult::Reply(data) => Ok(WasmResult::Reply(data)),
-                RawWasmResult::Reject(text) => Ok(WasmResult::Reject(text)),
-            },
-            RawCanisterResult::Err(user_error) => Err(user_error),
-        })
+        let raw_ingress_status_args = RawIngressStatusArgs {
+            raw_message_id,
+            raw_caller: caller.map(|caller| caller.into()),
+        };
+        match self.try_post(endpoint, raw_ingress_status_args).await {
+            Ok(None) => IngressStatusResult::NotAvailable,
+            Ok(Some(raw_result)) => {
+                let result = match raw_result {
+                    RawCanisterResult::Ok(raw_wasm_result) => match raw_wasm_result {
+                        RawWasmResult::Reply(data) => Ok(WasmResult::Reply(data)),
+                        RawWasmResult::Reject(text) => Ok(WasmResult::Reject(text)),
+                    },
+                    RawCanisterResult::Err(user_error) => Err(user_error),
+                };
+                IngressStatusResult::Success(result)
+            }
+            Err(message) => IngressStatusResult::Forbidden(message),
+        }
     }
 
     /// Await an update call submitted previously by `submit_call` or `submit_call_with_effective_principal`.
@@ -625,7 +637,9 @@ impl PocketIc {
             .with_multiplier(2.0)
             .build();
         loop {
-            if let Some(ingress_status) = self.ingress_status(message_id.clone()).await {
+            if let IngressStatusResult::Success(ingress_status) =
+                self.ingress_status(message_id.clone(), None).await
+            {
                 break ingress_status;
             }
             tokio::time::sleep(retry_policy.next_backoff().unwrap()).await;
@@ -1361,12 +1375,29 @@ impl PocketIc {
         self.request(HttpMethod::Post, endpoint, body).await
     }
 
+    async fn try_post<T: DeserializeOwned, B: Serialize>(
+        &self,
+        endpoint: &str,
+        body: B,
+    ) -> Result<T, String> {
+        self.try_request(HttpMethod::Post, endpoint, body).await
+    }
+
     async fn request<T: DeserializeOwned, B: Serialize>(
         &self,
         http_method: HttpMethod,
         endpoint: &str,
         body: B,
     ) -> T {
+        self.try_request(http_method, endpoint, body).await.unwrap()
+    }
+
+    async fn try_request<T: DeserializeOwned, B: Serialize>(
+        &self,
+        http_method: HttpMethod,
+        endpoint: &str,
+        body: B,
+    ) -> Result<T, String> {
         // we may have to try several times if the instance is busy
         let start = std::time::SystemTime::now();
         loop {
@@ -1378,8 +1409,8 @@ impl PocketIc {
             };
             let result = builder.send().await.expect("HTTP failure");
             match ApiResponse::<_>::from_response(result).await {
-                ApiResponse::Success(t) => break t,
-                ApiResponse::Error { message } => panic!("{}", message),
+                ApiResponse::Success(t) => break Ok(t),
+                ApiResponse::Error { message } => break Err(message),
                 ApiResponse::Busy { state_label, op_id } => {
                     debug!(
                         "instance_id={} Instance is busy (with a different computation): state_label: {}, op_id: {}",
@@ -1404,24 +1435,30 @@ impl PocketIc {
                             .send()
                             .await
                             .expect("HTTP failure");
-                        match ApiResponse::<_>::from_response(result).await {
-                            ApiResponse::Error { message } => {
-                                debug!("Polling has not succeeded yet: {}", message)
-                            }
-                            ApiResponse::Success(t) => {
-                                return t;
-                            }
-                            ApiResponse::Started { state_label, op_id } => {
-                                warn!(
-                                    "instance_id={} unexpected Started({} {})",
-                                    self.instance_id, state_label, op_id
-                                );
-                            }
-                            ApiResponse::Busy { state_label, op_id } => {
-                                warn!(
-                                    "instance_id={} unexpected Busy({} {})",
-                                    self.instance_id, state_label, op_id
-                                );
+                        if result.status() == reqwest::StatusCode::NOT_FOUND {
+                            let message =
+                                String::from_utf8(result.bytes().await.unwrap().to_vec()).unwrap();
+                            debug!("Polling has not succeeded yet: {}", message);
+                        } else {
+                            match ApiResponse::<_>::from_response(result).await {
+                                ApiResponse::Error { message } => {
+                                    return Err(message);
+                                }
+                                ApiResponse::Success(t) => {
+                                    return Ok(t);
+                                }
+                                ApiResponse::Started { state_label, op_id } => {
+                                    warn!(
+                                        "instance_id={} unexpected Started({} {})",
+                                        self.instance_id, state_label, op_id
+                                    );
+                                }
+                                ApiResponse::Busy { state_label, op_id } => {
+                                    warn!(
+                                        "instance_id={} unexpected Busy({} {})",
+                                        self.instance_id, state_label, op_id
+                                    );
+                                }
                             }
                         }
                         if let Some(max_request_time_ms) = self.max_request_time_ms {

--- a/rs/pocket_ic_server/CHANGELOG.md
+++ b/rs/pocket_ic_server/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - New endpoint `/instances/<instance_id>/read/ingress_status` to fetch the status of an update call submitted through an ingress message.
+  If an optional caller is provided and a corresponding read state request for the status of the same update call
+  signed by that specified caller was rejected because the update call was submitted by a different caller, then an error is returned.
 
 ### Fixed
 - Canisters created via `provisional_create_canister_with_cycles` with the management canister ID as the effective canister ID

--- a/rs/pocket_ic_server/src/pocket_ic.rs
+++ b/rs/pocket_ic_server/src/pocket_ic.rs
@@ -1711,29 +1711,49 @@ impl Operation for ExecuteIngressMessage {
 }
 
 #[derive(Clone, Debug)]
-pub struct IngressMessageStatus(pub MessageId);
+pub struct IngressMessageStatus {
+    pub message_id: MessageId,
+    pub caller: Option<Principal>,
+}
 
 impl Operation for IngressMessageStatus {
     fn compute(&self, pic: &mut PocketIc) -> OpOut {
-        let subnet = route(pic, self.0.effective_principal.clone(), false);
+        let subnet = route(pic, self.message_id.effective_principal.clone(), false);
         match subnet {
-            Ok(subnet) => match subnet.ingress_status(&self.0.msg_id) {
-                IngressStatus::Known {
-                    state: IngressState::Completed(result),
-                    ..
-                } => Ok(result).into(),
-                IngressStatus::Known {
-                    state: IngressState::Failed(error),
-                    ..
-                } => Err(error).into(),
-                _ => OpOut::NoOutput,
-            },
+            Ok(subnet) => {
+                if let Some(caller) = self.caller {
+                    if let Some(actual_caller) = subnet.ingress_caller(&self.message_id.msg_id) {
+                        if caller != actual_caller.get().0 {
+                            return OpOut::Error(PocketIcError::Forbidden(
+                                "The user tries to access Request ID not signed by the caller."
+                                    .to_string(),
+                            ));
+                        }
+                    }
+                }
+                match subnet.ingress_status(&self.message_id.msg_id) {
+                    IngressStatus::Known {
+                        state: IngressState::Completed(result),
+                        ..
+                    } => Ok(result).into(),
+                    IngressStatus::Known {
+                        state: IngressState::Failed(error),
+                        ..
+                    } => Err(error).into(),
+                    _ => OpOut::NoOutput,
+                }
+            }
             Err(e) => OpOut::Error(PocketIcError::BadIngressMessage(e)),
         }
     }
 
     fn id(&self) -> OpId {
-        OpId(format!("ingress_status_{}", self.0.msg_id))
+        OpId(format!(
+            "ingress_status({},{:?},{:?})",
+            self.message_id.msg_id,
+            self.message_id.effective_principal,
+            self.caller.map(|caller| caller.to_string())
+        ))
     }
 }
 

--- a/rs/pocket_ic_server/src/state_api/routes.rs
+++ b/rs/pocket_ic_server/src/state_api/routes.rs
@@ -38,8 +38,8 @@ use ic_types::{CanisterId, SubnetId};
 use pocket_ic::common::rest::{
     self, ApiResponse, AutoProgressConfig, ExtendedSubnetConfigSet, HttpGatewayConfig,
     HttpGatewayDetails, InstanceConfig, MockCanisterHttpResponse, RawAddCycles, RawCanisterCall,
-    RawCanisterHttpRequest, RawCanisterId, RawCanisterResult, RawCycles, RawMessageId,
-    RawMockCanisterHttpResponse, RawPrincipalId, RawSetStableMemory, RawStableMemory,
+    RawCanisterHttpRequest, RawCanisterId, RawCanisterResult, RawCycles, RawIngressStatusArgs,
+    RawMessageId, RawMockCanisterHttpResponse, RawPrincipalId, RawSetStableMemory, RawStableMemory,
     RawSubmitIngressResult, RawSubnetId, RawTime, RawWasmResult, Topology,
 };
 use pocket_ic::WasmResult;
@@ -1032,12 +1032,17 @@ pub async fn handler_ingress_status(
     State(AppState { api_state, .. }): State<AppState>,
     Path(instance_id): Path<InstanceId>,
     headers: HeaderMap,
-    extract::Json(raw_message_id): extract::Json<RawMessageId>,
+    extract::Json(raw_ingress_status_args): extract::Json<RawIngressStatusArgs>,
 ) -> (StatusCode, Json<ApiResponse<Option<RawCanisterResult>>>) {
     let timeout = timeout_or_default(headers);
-    match crate::pocket_ic::MessageId::try_from(raw_message_id) {
+    match crate::pocket_ic::MessageId::try_from(raw_ingress_status_args.raw_message_id) {
         Ok(message_id) => {
-            let ingress_op = IngressMessageStatus(message_id);
+            let ingress_op = IngressMessageStatus {
+                message_id,
+                caller: raw_ingress_status_args
+                    .raw_caller
+                    .map(|caller| caller.into()),
+            };
             let (code, response) = run_operation(api_state, instance_id, timeout, ingress_op).await;
             (code, Json(response))
         }

--- a/rs/pocket_ic_server/src/state_api/state.rs
+++ b/rs/pocket_ic_server/src/state_api/state.rs
@@ -255,6 +255,7 @@ pub enum PocketIcError {
     InvalidMockCanisterHttpResponses((usize, usize)),
     InvalidRejectCode(u64),
     SettingTimeIntoPast((u64, u64)),
+    Forbidden(String),
 }
 
 impl From<Result<ic_state_machine_tests::WasmResult, ic_state_machine_tests::UserError>> for OpOut {
@@ -327,6 +328,9 @@ impl std::fmt::Debug for OpOut {
             }
             OpOut::Error(PocketIcError::SettingTimeIntoPast((current, set))) => {
                 write!(f, "SettingTimeIntoPast(current={},set={})", current, set)
+            }
+            OpOut::Error(PocketIcError::Forbidden(msg)) => {
+                write!(f, "Forbidden({})", msg)
             }
             OpOut::Bytes(bytes) => write!(f, "Bytes({})", base64::encode(bytes)),
             OpOut::StableMemBytes(bytes) => write!(f, "StableMemory({})", base64::encode(bytes)),

--- a/rs/state_machine_tests/src/lib.rs
+++ b/rs/state_machine_tests/src/lib.rs
@@ -3238,6 +3238,11 @@ impl StateMachine {
         (self.ingress_history_reader.get_latest_status())(msg_id)
     }
 
+    /// Returns the caller of the ingress message with the specified ID if available.
+    pub fn ingress_caller(&self, msg_id: &MessageId) -> Option<UserId> {
+        self.get_latest_state().get_ingress_status(msg_id).user_id()
+    }
+
     /// Starts the canister with the specified ID.
     pub fn start_canister(&self, canister_id: CanisterId) -> Result<WasmResult, UserError> {
         self.start_canister_as(PrincipalId::new_anonymous(), canister_id)


### PR DESCRIPTION
This PR extends the PocketIC functionality of retrieving ingress status with an optional caller: if provided and if a corresponding read state request for the status of the same update call signed by that specified caller was rejected because the update call was submitted by a different caller, then an error is returned. To distinguish between the ingress status not being available and forbidden due to the new error condition introduced by this PR, a new enumeration `IngressStatusResult` is introduced in the PocketIC library.

