### PR TITLE
feat(governance): Automatically remind governance team to update unreleased_changelog.md.

### DIFF
--- a/.github/workflows/ci-pr-only-nns-team-reminder.yml
+++ b/.github/workflows/ci-pr-only-nns-team-reminder.yml
@@ -3,7 +3,7 @@ name: Governance Unreleased Changelog Reminder
 on:
   pull_request:
     types:
-      - labeled
+      - review_requested
 
 jobs:
   mainJob:

--- a/.github/workflows/ci-pr-only-nns-team-reminder.yml
+++ b/.github/workflows/ci-pr-only-nns-team-reminder.yml
@@ -1,4 +1,4 @@
-name: Remind Governance Team to Update unreleased_changelog.md.
+name: Governance Unreleased Changelog Reminder
 
 on:
   pull_request:

--- a/.github/workflows/ci-pr-only-nns-team-reminder.yml
+++ b/.github/workflows/ci-pr-only-nns-team-reminder.yml
@@ -11,6 +11,10 @@ jobs:
     steps:
       - uses: actions/github-script@v6
         id: mainStep
+        # If the PR requires nns-team to approve, GitHub will force nns-team to
+        # be in requested_teams. Therefore, the following condition is always
+        # met when nns-team must approve. (Further filtering takes place in the
+        # script itself.)
         if: contains(github.event.pull_request.requested_teams.*.name, 'nns-team')
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/governance_pull_request_template.yml
+++ b/.github/workflows/governance_pull_request_template.yml
@@ -55,12 +55,19 @@ jobs:
             // TODO: Figure out how to post in such a way that there is a "Resolve" button nearby.
             console.log("Adding reminder to update unreleased_changelog.md...");
             const reminderText = `
-              Did you remember to update unreleased_changes.md? If so (or if this is not
-              necessary), please, explicitly acknowledge this reminder by giving it a
-              thumbs up reaction. To unblock the PR, dismiss the code review by going
-              to the bottom of the pull request page, and use \"Done.\" as the reason.
+              If this pull request affects the behavior of any canister owned by
+              the Governance team, remember to update the corresponding
+              unreleased_changes.md file(s).
+
+              To acknowldge this reminder (and unblock the PR), dismiss this
+              code review by going to the bottom of the pull request page, and
+              supply one of the following reasons:
+
+              1. Done.
+
+              2. No canister behavior changes.
             `
-            .replace(/[\s\n]{2,}/gm, '')
+            .replace(/^ +/gm, '')
             .trim();
             await github.rest.pulls.createReview({
               owner: "dfinity",

--- a/.github/workflows/governance_pull_request_template.yml
+++ b/.github/workflows/governance_pull_request_template.yml
@@ -4,11 +4,6 @@ on:
   pull_request:
     types:
       - assigned
-      - labeled
-      - opened
-      - edited
-      - reopened
-      - synchronize
       - ready_for_review
       - review_requested
 

--- a/.github/workflows/governance_pull_request_template.yml
+++ b/.github/workflows/governance_pull_request_template.yml
@@ -1,0 +1,72 @@
+name: Remind Governance Team to Update unreleased_changelog.md.
+
+on:
+  pull_request:
+    types:
+      - assigned
+      - labeled
+      - opened
+      - edited
+      - reopened
+      - synchronize
+      - ready_for_review
+      - review_requested
+
+jobs:
+  mainJob:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v6
+        id: mainStep
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          retries: 3
+          script: |
+            // nns-team is automatically added as a reviewer if an approval from
+            // nns-team is required. Therefore, this only skips posting a
+            // reminder when nns-team approval is not required.
+            const nnsTeamReviewRequested = context
+              .payload
+              .pull_request
+              .requested_teams
+              .some(team => team.name == 'nns-team')
+            console.log("nnsTeamReviewRequested = " + nnsTeamReviewRequested);
+            if (!nnsTeamReviewRequested) {
+              return;
+            }
+
+            const pullRequestNumber = context.payload.number;
+
+            // Skip reminder if we already reminded (to avoid spam).
+            const reviews = await github.rest.pulls.listReviews({
+              owner: "dfinity",
+              repo: "ic",
+              pull_number: pullRequestNumber,
+            });
+            const alreadyRemindedAboutUnreleasedChangelog = reviews
+              .data
+              .some(review => review.body.startsWith("Did you remember to update unreleased_changes.md?"));
+            console.log("alreadyRemindedAboutUnreleasedChangelog = " + alreadyRemindedAboutUnreleasedChangelog);
+            if (alreadyRemindedAboutUnreleasedChangelog) {
+              return;
+            }
+
+            // Post a review to remind the author to update unreleased_changelog.md.
+            // TODO: Figure out how to post in such a way that there is a "Resolve" button nearby.
+            console.log("Adding reminder to update unreleased_changelog.md...");
+            const reminderText = `
+              Did you remember to update unreleased_changes.md? If so (or if this is not
+              necessary), please, explicitly acknowledge this reminder by giving it a
+              thumbs up reaction. To unblock the PR, dismiss the code review by going
+              to the bottom of the pull request page, and use \"Done.\" as the reason.
+            `
+            .replace(/[\s\n]{2,}/gm, '')
+            .trim();
+            await github.rest.pulls.createReview({
+              owner: "dfinity",
+              repo: "ic",
+              pull_number: pullRequestNumber,
+              body: reminderText,
+              event: "REQUEST_CHANGES",
+            });
+            console.log("Reminder was added successfully.");

--- a/.github/workflows/governance_pull_request_template.yml
+++ b/.github/workflows/governance_pull_request_template.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/github-script@v6
         id: mainStep
-        if: contains(github.event.pull_request.labels.*.name, '@nns-team')
+        if: contains(github.event.requested_teams.*.name, 'nns-team')
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           retries: 3

--- a/.github/workflows/governance_pull_request_template.yml
+++ b/.github/workflows/governance_pull_request_template.yml
@@ -45,7 +45,10 @@ jobs:
             });
             const alreadyRemindedAboutUnreleasedChangelog = reviews
               .data
-              .some(review => review.body.startsWith("Did you remember to update unreleased_changes.md?"));
+              .some(review => review
+                .body
+                .startsWith("If this pull request affects the behavior of any canister owned by")
+              );
             console.log("alreadyRemindedAboutUnreleasedChangelog = " + alreadyRemindedAboutUnreleasedChangelog);
             if (alreadyRemindedAboutUnreleasedChangelog) {
               return;

--- a/.github/workflows/governance_pull_request_template.yml
+++ b/.github/workflows/governance_pull_request_template.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/github-script@v6
         id: mainStep
-        if: contains(github.event.requested_teams.*.name, 'nns-team')
+        if: contains(github.event.pull_request.requested_teams.*.name, 'nns-team')
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           retries: 3

--- a/.github/workflows/governance_pull_request_template.yml
+++ b/.github/workflows/governance_pull_request_template.yml
@@ -3,9 +3,7 @@ name: Remind Governance Team to Update unreleased_changelog.md.
 on:
   pull_request:
     types:
-      - assigned
-      - ready_for_review
-      - review_requested
+      - labeled
 
 jobs:
   mainJob:
@@ -13,23 +11,11 @@ jobs:
     steps:
       - uses: actions/github-script@v6
         id: mainStep
+        if: contains(github.event.pull_request.labels.*.name, '@nns-team')
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           retries: 3
           script: |
-            // nns-team is automatically added as a reviewer if an approval from
-            // nns-team is required. Therefore, this only skips posting a
-            // reminder when nns-team approval is not required.
-            const nnsTeamReviewRequested = context
-              .payload
-              .pull_request
-              .requested_teams
-              .some(team => team.name == 'nns-team')
-            console.log("nnsTeamReviewRequested = " + nnsTeamReviewRequested);
-            if (!nnsTeamReviewRequested) {
-              return;
-            }
-
             const pullRequestNumber = context.payload.number;
 
             // Skip reminder if we already reminded (to avoid spam).

--- a/.github/workflows/governance_pull_request_template.yml
+++ b/.github/workflows/governance_pull_request_template.yml
@@ -72,6 +72,7 @@ jobs:
               repo: "ic",
               pull_number: pullRequestNumber,
               body: reminderText,
+              // This is what forces the author to explicitly acknowledge.
               event: "REQUEST_CHANGES",
             });
             console.log("Reminder was added successfully.");


### PR DESCRIPTION
This happens via a new GitHub Action. What it does is

```
if review is not requested from nns-team {
  return;
}

if already reminded {
  return;
}

Add a review that reminds the author that they need to update unreleased_changelog.md.
```

Because the reminder is done as a code review, the author is FORCED to acknowledge the reminder.