### PR TITLE
feat(nns): Make neuron migration to stable memory reversible

### DIFF
--- a/rs/nns/governance/canister/canister.rs
+++ b/rs/nns/governance/canister/canister.rs
@@ -158,7 +158,7 @@ fn set_governance(gov: Governance) {
 
 fn schedule_timers() {
     schedule_seeding(Duration::from_nanos(0));
-    schedule_adjust_neurons_storage(Duration::from_nanos(0), NeuronIdProto { id: 0 });
+    schedule_adjust_neurons_storage(Duration::from_nanos(0), Bound::Unbounded);
     schedule_prune_following(Duration::from_secs(0), Bound::Unbounded);
     schedule_spawn_neurons();
     schedule_unstake_maturity_of_dissolved_neurons();
@@ -277,19 +277,15 @@ const ADJUST_NEURON_STORAGE_BATCH_INTERVAL: Duration = Duration::from_secs(5);
 // id.
 const ADJUST_NEURON_STORAGE_ROUND_INTERVAL: Duration = Duration::from_secs(3600);
 
-fn schedule_adjust_neurons_storage(delay: Duration, start_neuron_id: NeuronIdProto) {
+fn schedule_adjust_neurons_storage(delay: Duration, next: Bound<NeuronIdProto>) {
     ic_cdk_timers::set_timer(delay, move || {
-        let next_neuron_id = governance_mut().batch_adjust_neurons_storage(start_neuron_id);
-        match next_neuron_id {
-            Some(next_neuron_id) => schedule_adjust_neurons_storage(
-                ADJUST_NEURON_STORAGE_BATCH_INTERVAL,
-                next_neuron_id,
-            ),
-            None => schedule_adjust_neurons_storage(
-                ADJUST_NEURON_STORAGE_ROUND_INTERVAL,
-                NeuronIdProto { id: 0 },
-            ),
+        let next = governance_mut().batch_adjust_neurons_storage(next);
+        let next_delay = if next == Bound::Unbounded {
+            ADJUST_NEURON_STORAGE_ROUND_INTERVAL
+        } else {
+            ADJUST_NEURON_STORAGE_BATCH_INTERVAL
         };
+        schedule_adjust_neurons_storage(next_delay, next);
     });
 }
 

--- a/rs/nns/governance/src/governance.rs
+++ b/rs/nns/governance/src/governance.rs
@@ -7284,9 +7284,11 @@ impl Governance {
         })
     }
 
-    pub fn batch_adjust_neurons_storage(&mut self, start_neuron_id: NeuronId) -> Option<NeuronId> {
-        self.neuron_store
-            .batch_adjust_neurons_storage(start_neuron_id)
+    pub fn batch_adjust_neurons_storage(
+        &mut self,
+        next: std::ops::Bound<NeuronId>,
+    ) -> std::ops::Bound<NeuronId> {
+        self.neuron_store.batch_adjust_neurons_storage(next)
     }
 
     /// Recompute cached metrics once per day

--- a/rs/nns/governance/src/neuron_store.rs
+++ b/rs/nns/governance/src/neuron_store.rs
@@ -624,68 +624,17 @@ impl NeuronStore {
 
     /// Adjusts the storage location of neurons, since active neurons might become inactive due to
     /// passage of time.
-    pub fn batch_adjust_neurons_storage(&mut self, start_neuron_id: NeuronId) -> Option<NeuronId> {
-        static BATCH_SIZE_FOR_MOVING_NEURONS: usize = 200;
-
+    pub fn batch_adjust_neurons_storage(&mut self, next: Bound<NeuronId>) -> Bound<NeuronId> {
         #[cfg(target_arch = "wasm32")]
         static MAX_NUM_INSTRUCTIONS_PER_BATCH: u64 = 1_000_000_000;
 
         #[cfg(target_arch = "wasm32")]
-        let max_instructions_reached =
-            || ic_cdk::api::instruction_counter() >= MAX_NUM_INSTRUCTIONS_PER_BATCH;
+        let carry_on = || ic_cdk::api::instruction_counter() < MAX_NUM_INSTRUCTIONS_PER_BATCH;
 
         #[cfg(not(target_arch = "wasm32"))]
-        let max_instructions_reached = || false;
+        let carry_on = || true;
 
-        self.adjust_neuron_storage_with_max_instructions(
-            start_neuron_id,
-            BATCH_SIZE_FOR_MOVING_NEURONS,
-            max_instructions_reached,
-        )
-    }
-
-    fn adjust_neuron_storage_with_max_instructions(
-        &mut self,
-        start_neuron_id: NeuronId,
-        max_batch_size: usize,
-        max_instructions_reached: impl Fn() -> bool,
-    ) -> Option<NeuronId> {
-        // We currently only move neurons from heap to stable storage, since it's impossible to have
-        // active neurons in stable storage. In the future, we might need to move neurons from
-        // stable storage to heap as a rollback mechanism, but it is not implemented here yet.
-        let neuron_ids: Vec<_> = self
-            .heap_neurons
-            .range(start_neuron_id.id..)
-            .take(max_batch_size)
-            .map(|(id, _)| NeuronId { id: *id })
-            .collect();
-        // We know it is the last batch if the number of neurons is less than the batch size.
-        let is_last_batch = neuron_ids.len() < max_batch_size;
-
-        if neuron_ids.is_empty() {
-            return None;
-        }
-
-        let mut next_neuron_id = Some(start_neuron_id);
-
-        for neuron_id in neuron_ids {
-            if max_instructions_reached() {
-                // We don't need to look at the `is_last_batch` because at least one neuron is
-                // skipped due to instruction limit.
-                return next_neuron_id;
-            }
-
-            // We don't modify the neuron, but the below just makes sure that the neuron is in the
-            // appropriate storage location given its state and the current time.
-            let _ = self.with_neuron_mut(&neuron_id, |_| {});
-            next_neuron_id = neuron_id.next();
-        }
-
-        if is_last_batch {
-            None
-        } else {
-            next_neuron_id
-        }
+        groom_some_neurons(self, |_| {}, next, carry_on)
     }
 
     fn remove_neuron_from_indexes(&mut self, neuron: &Neuron) {


### PR DESCRIPTION
We are about to migrate neurons from heap memory to stable memory. If anything goes wrong, we'd like to reverse the migration by setting their target location from `Stable` to `Heap`. Previously the `adjust_neuron_storage` procedure only looks at the neurons in the heap, and therefore it can only move neurons from heap memory to stable memory if the target location is different from where they are. In order to make the reverse migration possible, we look at the neurons in the stable memory during `adjust_neuron_storage`.

Testing: ` //rs/nns/integration_tests:integration_tests_test_src/governance_migrations` still passes (which fails if `schedule_adjust_neurons_storage` is commented out)