### PR TITLE
feat(EXC-1795): Limit cache disk space

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13279,6 +13279,7 @@ version = "0.9.0"
 dependencies = [
  "ic-types",
  "lru",
+ "proptest",
 ]
 
 [[package]]

--- a/rs/canister_sandbox/src/replica_controller/sandboxed_execution_controller.rs
+++ b/rs/canister_sandbox/src/replica_controller/sandboxed_execution_controller.rs
@@ -2053,7 +2053,8 @@ mod tests {
 
     use super::*;
     use ic_config::{
-        execution_environment::MAX_COMPILATION_CACHE_SIZE, logger::Config as LoggerConfig,
+        execution_environment::{MAX_COMPILATION_CACHE_DISK_SIZE, MAX_COMPILATION_CACHE_SIZE},
+        logger::Config as LoggerConfig,
     };
     use ic_logger::{new_replica_logger, replica_logger::no_op_logger};
     use ic_test_utilities::state_manager::FakeStateManager;
@@ -2131,7 +2132,11 @@ mod tests {
                 canister_module,
                 PathBuf::new(),
                 canister_id,
-                Arc::new(CompilationCache::new(MAX_COMPILATION_CACHE_SIZE)),
+                Arc::new(CompilationCache::new(
+                    MAX_COMPILATION_CACHE_SIZE,
+                    MAX_COMPILATION_CACHE_DISK_SIZE,
+                    tempfile::tempdir().unwrap(),
+                )),
             )
             .unwrap();
         let sandbox_pid = match controller

--- a/rs/config/src/execution_environment.rs
+++ b/rs/config/src/execution_environment.rs
@@ -141,8 +141,11 @@ pub const BITCOIN_MAINNET_CANISTER_ID: &str = "ghsi2-tqaaa-aaaan-aaaca-cai";
 // TODO(EXC-1298): Uninstall this canister once the bitcoin mainnet canister is live.
 const BITCOIN_MAINNET_SOFT_LAUNCH_CANISTER_ID: &str = "gsvzx-syaaa-aaaan-aaabq-cai";
 
-/// The capacity of the Wasm compilation cache.
+/// The capacity in memory of the Wasm compilation cache.
 pub const MAX_COMPILATION_CACHE_SIZE: NumBytes = NumBytes::new(10 * GIB);
+
+/// The capacity on disk for the Wasm compilation cache.
+pub const MAX_COMPILATION_CACHE_DISK_SIZE: NumBytes = NumBytes::new(100 * GIB);
 
 /// Maximum number of controllers allowed in a request (specified in the interface spec).
 pub const MAX_ALLOWED_CONTROLLERS_COUNT: usize = 10;
@@ -288,8 +291,11 @@ pub struct Config {
     /// The upper limit on how long the data certificate stays valid in the query cache.
     pub query_cache_data_certificate_expiry_time: Duration,
 
-    /// The capacity of the Wasm compilation cache.
+    /// The capacity of the Wasm compilation cache in memory.
     pub max_compilation_cache_size: NumBytes,
+
+    /// The capacity of the Wasm compilation cache on disk.
+    pub max_compilation_cache_disk_size: NumBytes,
 
     /// Indicate whether query stats should be collected or not.
     pub query_stats_aggregation: FlagStatus,
@@ -383,6 +389,7 @@ impl Default for Config {
             query_cache_max_expiry_time: QUERY_CACHE_MAX_EXPIRY_TIME,
             query_cache_data_certificate_expiry_time: QUERY_CACHE_DATA_CERTIFICATE_EXPIRY_TIME,
             max_compilation_cache_size: MAX_COMPILATION_CACHE_SIZE,
+            max_compilation_cache_disk_size: MAX_COMPILATION_CACHE_DISK_SIZE,
             query_stats_aggregation: FlagStatus::Enabled,
             query_stats_epoch_length: QUERY_STATS_EPOCH_LENGTH,
             stop_canister_timeout_duration: STOP_CANISTER_TIMEOUT_DURATION,

--- a/rs/embedders/src/compilation_cache.rs
+++ b/rs/embedders/src/compilation_cache.rs
@@ -37,9 +37,11 @@ pub enum CompilationCache {
 }
 
 impl CompilationCache {
-    pub fn new(capacity: NumBytes) -> Self {
-        Self::Memory {
-            cache: Mutex::new(LruCache::new(capacity, NumBytes::from(1024 * 1024 * 1024))),
+    pub fn new(memory_capacity: NumBytes, disk_capacity: NumBytes, dir: TempDir) -> Self {
+        Self::Disk {
+            cache: Mutex::new(LruCache::new(memory_capacity, disk_capacity)),
+            dir,
+            counter: AtomicU64::new(0),
         }
     }
 
@@ -190,7 +192,11 @@ impl StoredCompilation {
 /// each other if they all try to insert in the cache at the same time.
 #[test]
 fn concurrent_insertions() {
-    let cache = CompilationCache::new(NumBytes::from(30 * 1024 * 1024));
+    let cache = CompilationCache::new(
+        NumBytes::from(30 * 1024 * 1024),
+        NumBytes::from(30 * 1024 * 1024),
+        tempfile::tempdir().unwrap(),
+    );
     let wasm = wat::parse_str("(module)").unwrap();
     let canister_module = CanisterModule::new(wasm.clone());
     let binary = ic_wasm_types::BinaryEncodedWasm::new(wasm.clone());

--- a/rs/embedders/src/compilation_cache.rs
+++ b/rs/embedders/src/compilation_cache.rs
@@ -39,7 +39,7 @@ pub enum CompilationCache {
 impl CompilationCache {
     pub fn new(capacity: NumBytes) -> Self {
         Self::Memory {
-            cache: Mutex::new(LruCache::new(capacity)),
+            cache: Mutex::new(LruCache::new(capacity, NumBytes::from(1024 * 1024 * 1024))),
         }
     }
 

--- a/rs/execution_environment/src/query_handler/query_cache.rs
+++ b/rs/execution_environment/src/query_handler/query_cache.rs
@@ -392,7 +392,7 @@ impl QueryCache {
         data_certificate_expiry_time: Duration,
     ) -> Self {
         QueryCache {
-            cache: Mutex::new(LruCache::new(capacity)),
+            cache: Mutex::new(LruCache::new(capacity, NumBytes::from(0))),
             max_expiry_time,
             data_certificate_expiry_time,
             metrics: QueryCacheMetrics::new(metrics_registry),

--- a/rs/utils/lru_cache/BUILD.bazel
+++ b/rs/utils/lru_cache/BUILD.bazel
@@ -17,7 +17,9 @@ rust_library(
 rust_test(
     name = "lru_cache_test",
     crate = ":lru_cache",
-    deps = [],
+    deps = [
+        "@crate_index//:proptest",
+    ],
 )
 
 rust_doc_test(

--- a/rs/utils/lru_cache/Cargo.toml
+++ b/rs/utils/lru_cache/Cargo.toml
@@ -11,3 +11,6 @@ documentation.workspace = true
 [dependencies]
 ic-types = { path = "../../types/types" }
 lru = { version = "0.7.8", default-features = false }
+
+[dev-dependencies]
+proptest = { workspace = true }

--- a/rs/utils/lru_cache/src/lib.rs
+++ b/rs/utils/lru_cache/src/lib.rs
@@ -15,8 +15,10 @@ where
     V: CountBytes,
 {
     cache: lru::LruCache<K, V>,
-    capacity: usize,
-    size: usize,
+    memory_capacity: usize,
+    disk_capacity: usize,
+    memory_size: usize,
+    disk_size: usize,
 }
 
 impl<K, V> CountBytes for LruCache<K, V>
@@ -38,15 +40,19 @@ where
     K: CountBytes + Eq + Hash,
     V: CountBytes,
 {
-    /// Constructs a new LRU cache with the given capacity.
-    /// The capacity must not exceed `MAX_SIZE = (2^63 - 1)`.
-    pub fn new(capacity: NumBytes) -> Self {
-        let capacity = capacity.get() as usize;
-        assert!(capacity <= MAX_SIZE);
+    /// Constructs a new LRU cache with the given memory and disk capacity.  The
+    /// capacities must not exceed `MAX_SIZE = (2^63 - 1)`.
+    pub fn new(memory_capacity: NumBytes, disk_capacity: NumBytes) -> Self {
+        let memory_capacity = memory_capacity.get() as usize;
+        let disk_capacity = disk_capacity.get() as usize;
+        assert!(memory_capacity <= MAX_SIZE);
+        assert!(disk_capacity <= MAX_SIZE);
         let lru_cache = Self {
             cache: lru::LruCache::unbounded(),
-            capacity,
-            size: 0,
+            memory_capacity,
+            disk_capacity,
+            memory_size: 0,
+            disk_size: 0,
         };
         lru_cache.check_invariants();
         lru_cache
@@ -54,7 +60,10 @@ where
 
     /// Creates a new LRU Cache that never automatically evicts items.
     pub fn unbounded() -> Self {
-        Self::new(NumBytes::new(MAX_SIZE as u64))
+        Self::new(
+            NumBytes::new(MAX_SIZE as u64),
+            NumBytes::new(MAX_SIZE as u64),
+        )
     }
 
     /// Returns the value corresponding to the given key.
@@ -67,21 +76,33 @@ where
     /// the cache or other cache entries are evicted (due to the cache capacity),
     /// then it returns the old entry's key-value pairs. Otherwise, returns an empty vector.
     pub fn push(&mut self, key: K, value: V) -> Vec<(K, V)> {
-        let size = key.count_bytes() + value.count_bytes();
-        assert!(size <= MAX_SIZE);
+        let memory_size = key.memory_count_bytes() + value.memory_count_bytes();
+        assert!(memory_size <= MAX_SIZE);
+        let disk_size = key.disk_count_bytes() + value.disk_count_bytes();
+        assert!(disk_size <= MAX_SIZE);
 
         let removed_entry = self.cache.push(key, value);
         if let Some((removed_key, removed_value)) = &removed_entry {
-            let removed_size = removed_key.count_bytes() + removed_value.count_bytes();
-            debug_assert!(self.size >= removed_size);
-            // This cannot underflow because we know that `self.size` is
+            let memory_removed_size =
+                removed_key.memory_count_bytes() + removed_value.memory_count_bytes();
+            debug_assert!(self.memory_size >= memory_removed_size);
+            // This cannot underflow because we know that `self.memory_size` is
             // the sum of sizes of all items in the cache.
-            self.size -= removed_size;
+            self.memory_size -= memory_removed_size;
+
+            let disk_removed_size =
+                removed_key.disk_count_bytes() + removed_value.disk_count_bytes();
+            debug_assert!(self.disk_size >= disk_removed_size);
+            // This cannot underflow because we know that `self.disk_size` is
+            // the sum of sizes of all items in the cache.
+            self.disk_size -= disk_removed_size;
         }
         // This cannot overflow because we know that
-        // `self.size <= self.capacity <= MAX_SIZE`
-        // and `size <= MAX_SIZE == usize::MAX / 2`.
-        self.size += size;
+        // `self.memory_size <= self.memory_capacity <= MAX_SIZE`
+        // and `memory_size <= MAX_SIZE == usize::MAX / 2`.
+        self.memory_size += memory_size;
+        // Similar as for `memory_size``.
+        self.disk_size += disk_size;
         let mut evicted_entries = self.evict();
         self.check_invariants();
 
@@ -93,9 +114,14 @@ where
     /// `None` if it does not exist.
     pub fn pop(&mut self, key: &K) -> Option<V> {
         if let Some((key, value)) = self.cache.pop_entry(key) {
-            let size = key.count_bytes() + value.count_bytes();
-            debug_assert!(self.size >= size);
-            self.size -= size;
+            let memory_size = key.memory_count_bytes() + value.memory_count_bytes();
+            debug_assert!(self.memory_size >= memory_size);
+            self.memory_size -= memory_size;
+
+            let disk_size = key.disk_count_bytes() + value.disk_count_bytes();
+            debug_assert!(self.disk_size >= disk_size);
+            self.disk_size -= disk_size;
+
             self.check_invariants();
             Some(value)
         } else {
@@ -106,7 +132,8 @@ where
     /// Clears the cache by removing all items.
     pub fn clear(&mut self) {
         self.cache.clear();
-        self.size = 0;
+        self.memory_size = 0;
+        self.disk_size = 0;
         self.check_invariants();
     }
 
@@ -124,14 +151,20 @@ where
     /// Returns the vector of evicted key-value pairs.
     fn evict(&mut self) -> Vec<(K, V)> {
         let mut ret = vec![];
-        while self.size > self.capacity {
+        while self.memory_size > self.memory_capacity || self.disk_size > self.disk_capacity {
             match self.cache.pop_lru() {
                 Some((key, value)) => {
-                    let size = key.count_bytes() + value.count_bytes();
-                    debug_assert!(self.size >= size);
-                    // This cannot underflow because we know that `self.size` is
-                    // the sum of sizes of all items in the cache.
-                    self.size -= size;
+                    let memory_size = key.memory_count_bytes() + value.memory_count_bytes();
+                    debug_assert!(self.memory_size >= memory_size);
+                    // This cannot underflow because we know that `self.memory_size` is
+                    // the sum of memory sizes of all items in the cache.
+                    self.memory_size -= memory_size;
+
+                    let disk_size = key.disk_count_bytes() + value.disk_count_bytes();
+                    debug_assert!(self.disk_size >= disk_size);
+                    // This cannot underflow because we know that `self.disk_size` is
+                    // the sum of disk sizes of all items in the cache.
+                    self.disk_size -= disk_size;
 
                     ret.push((key, value));
                 }
@@ -147,14 +180,22 @@ where
         #[cfg(debug_assertions)]
         if self.len() < 1_000 {
             debug_assert_eq!(
-                self.size,
+                self.memory_size,
                 self.cache
                     .iter()
-                    .map(|(key, value)| key.count_bytes() + value.count_bytes())
+                    .map(|(key, value)| key.memory_count_bytes() + value.memory_count_bytes())
+                    .sum::<usize>()
+            );
+            debug_assert_eq!(
+                self.disk_size,
+                self.cache
+                    .iter()
+                    .map(|(key, value)| key.disk_count_bytes() + value.disk_count_bytes())
                     .sum::<usize>()
             );
         }
-        debug_assert!(self.size <= self.capacity);
+        debug_assert!(self.memory_size <= self.memory_capacity);
+        debug_assert!(self.disk_size <= self.disk_capacity);
     }
 }
 
@@ -166,8 +207,24 @@ mod tests {
     struct ValueSize(u32, usize);
 
     impl CountBytes for ValueSize {
-        fn count_bytes(&self) -> usize {
+        fn memory_count_bytes(&self) -> usize {
             self.1
+        }
+        fn disk_count_bytes(&self) -> usize {
+            0
+        }
+    }
+
+    #[derive(Eq, PartialEq, Hash, Debug)]
+    struct MemoryDiskValue(u32, usize, usize);
+
+    impl CountBytes for MemoryDiskValue {
+        fn memory_count_bytes(&self) -> usize {
+            self.1
+        }
+
+        fn disk_count_bytes(&self) -> usize {
+            self.2
         }
     }
 
@@ -175,14 +232,18 @@ mod tests {
     struct Key(u32);
 
     impl CountBytes for Key {
-        fn count_bytes(&self) -> usize {
+        fn memory_count_bytes(&self) -> usize {
+            0
+        }
+
+        fn disk_count_bytes(&self) -> usize {
             0
         }
     }
 
     #[test]
     fn lru_cache_single_entry() {
-        let mut lru = LruCache::<Key, ValueSize>::new(NumBytes::new(10));
+        let mut lru = LruCache::<Key, ValueSize>::new(NumBytes::new(10), NumBytes::new(0));
 
         assert!(lru.get(&Key(0)).is_none());
 
@@ -205,7 +266,7 @@ mod tests {
 
     #[test]
     fn lru_cache_multiple_entries() {
-        let mut lru = LruCache::<Key, ValueSize>::new(NumBytes::new(10));
+        let mut lru = LruCache::<Key, ValueSize>::new(NumBytes::new(10), NumBytes::new(0));
 
         for i in 0..20 {
             lru.push(Key(i), ValueSize(i, 1));
@@ -223,7 +284,7 @@ mod tests {
 
     #[test]
     fn lru_cache_value_eviction() {
-        let mut lru = LruCache::<Key, ValueSize>::new(NumBytes::new(10));
+        let mut lru = LruCache::<Key, ValueSize>::new(NumBytes::new(10), NumBytes::new(0));
 
         assert!(lru.get(&Key(0)).is_none());
 
@@ -273,7 +334,7 @@ mod tests {
 
     #[test]
     fn lru_cache_key_eviction() {
-        let mut lru = LruCache::<ValueSize, ValueSize>::new(NumBytes::new(10));
+        let mut lru = LruCache::<ValueSize, ValueSize>::new(NumBytes::new(10), NumBytes::new(0));
 
         assert!(lru.get(&ValueSize(0, 10)).is_none());
 
@@ -329,7 +390,7 @@ mod tests {
 
     #[test]
     fn lru_cache_key_and_value_eviction() {
-        let mut lru = LruCache::<ValueSize, ValueSize>::new(NumBytes::new(10));
+        let mut lru = LruCache::<ValueSize, ValueSize>::new(NumBytes::new(10), NumBytes::new(0));
 
         let evicted = lru.push(ValueSize(0, 5), ValueSize(42, 5));
         assert_eq!(*lru.get(&ValueSize(0, 5)).unwrap(), ValueSize(42, 5));
@@ -363,7 +424,7 @@ mod tests {
 
     #[test]
     fn lru_cache_clear() {
-        let mut lru = LruCache::<Key, ValueSize>::new(NumBytes::new(10));
+        let mut lru = LruCache::<Key, ValueSize>::new(NumBytes::new(10), NumBytes::new(0));
         lru.push(Key(0), ValueSize(0, 10));
         lru.clear();
         assert!(lru.get(&Key(0)).is_none());
@@ -371,7 +432,7 @@ mod tests {
 
     #[test]
     fn lru_cache_pop() {
-        let mut lru = LruCache::<Key, ValueSize>::new(NumBytes::new(10));
+        let mut lru = LruCache::<Key, ValueSize>::new(NumBytes::new(10), NumBytes::new(0));
         lru.push(Key(0), ValueSize(0, 5));
         lru.push(Key(1), ValueSize(1, 5));
         lru.pop(&Key(0));
@@ -383,25 +444,160 @@ mod tests {
 
     #[test]
     fn lru_cache_count_bytes_and_len() {
-        let mut lru = LruCache::<Key, ValueSize>::new(NumBytes::new(10));
-        assert_eq!(0, lru.count_bytes());
+        let mut lru = LruCache::<Key, MemoryDiskValue>::new(NumBytes::new(10), NumBytes::new(20));
+        assert_eq!(0, lru.memory_count_bytes());
+        assert_eq!(0, lru.disk_count_bytes());
         assert_eq!(0, lru.len());
         assert!(lru.is_empty());
-        lru.push(Key(0), ValueSize(0, 4));
-        assert_eq!(4, lru.count_bytes());
+        lru.push(Key(0), MemoryDiskValue(0, 4, 10));
+        assert_eq!(4, lru.memory_count_bytes());
+        assert_eq!(10, lru.disk_count_bytes());
         assert_eq!(1, lru.len());
         assert!(!lru.is_empty());
-        lru.push(Key(1), ValueSize(1, 6));
-        assert_eq!(10, lru.count_bytes());
+        lru.push(Key(1), MemoryDiskValue(1, 6, 2));
+        assert_eq!(10, lru.memory_count_bytes());
+        assert_eq!(12, lru.disk_count_bytes());
         assert_eq!(2, lru.len());
         assert!(!lru.is_empty());
         lru.pop(&Key(0));
-        assert_eq!(6, lru.count_bytes());
+        assert_eq!(6, lru.memory_count_bytes());
+        assert_eq!(2, lru.disk_count_bytes());
         assert_eq!(1, lru.len());
         assert!(!lru.is_empty());
         lru.pop(&Key(1));
-        assert_eq!(0, lru.count_bytes());
+        assert_eq!(0, lru.memory_count_bytes());
+        assert_eq!(0, lru.disk_count_bytes());
         assert_eq!(0, lru.len());
         assert!(lru.is_empty());
+    }
+
+    #[test]
+    fn lru_cache_disk_and_memory_single_entry() {
+        let mut lru = LruCache::<Key, MemoryDiskValue>::new(NumBytes::new(10), NumBytes::new(20));
+
+        assert!(lru.get(&Key(0)).is_none());
+
+        // Can't insert a value if memory or disk is too large.
+        let evicted = lru.push(Key(0), MemoryDiskValue(42, 11, 0));
+        assert_eq!(lru.get(&Key(0)), None);
+        assert_eq!(evicted, vec![(Key(0), MemoryDiskValue(42, 11, 0))]);
+
+        let evicted = lru.push(Key(0), MemoryDiskValue(42, 0, 21));
+        assert_eq!(lru.get(&Key(0)), None);
+        assert_eq!(evicted, vec![(Key(0), MemoryDiskValue(42, 0, 21))]);
+
+        // Can insert if both sizes fit.
+        let evicted = lru.push(Key(0), MemoryDiskValue(42, 10, 20));
+        assert_eq!(*lru.get(&Key(0)).unwrap(), MemoryDiskValue(42, 10, 20));
+        assert_eq!(evicted, vec![]);
+
+        // Inserting a new value removes the old one if memory or disk is
+        // non-zero (since both are at capacity).
+        let evicted = lru.push(Key(1), MemoryDiskValue(42, 1, 0));
+        assert_eq!(*lru.get(&Key(1)).unwrap(), MemoryDiskValue(42, 1, 0));
+        assert_eq!(evicted, vec![(Key(0), MemoryDiskValue(42, 10, 20))]);
+
+        lru.clear();
+        let _ = lru.push(Key(0), MemoryDiskValue(42, 10, 20));
+        let evicted = lru.push(Key(1), MemoryDiskValue(42, 0, 1));
+        assert_eq!(*lru.get(&Key(1)).unwrap(), MemoryDiskValue(42, 0, 1));
+        assert_eq!(evicted, vec![(Key(0), MemoryDiskValue(42, 10, 20))]);
+    }
+
+    #[test]
+    fn lru_cache_key_and_value_eviction_mixing_memory_and_disk() {
+        let mut lru =
+            LruCache::<MemoryDiskValue, MemoryDiskValue>::new(NumBytes::new(10), NumBytes::new(10));
+
+        let evicted = lru.push(MemoryDiskValue(0, 5, 1), MemoryDiskValue(42, 5, 1));
+        assert_eq!(
+            *lru.get(&MemoryDiskValue(0, 5, 1)).unwrap(),
+            MemoryDiskValue(42, 5, 1)
+        );
+        assert_eq!(evicted, vec![]);
+
+        let evicted = lru.push(MemoryDiskValue(1, 0, 0), MemoryDiskValue(20, 0, 0));
+        assert_eq!(
+            *lru.get(&MemoryDiskValue(0, 5, 1)).unwrap(),
+            MemoryDiskValue(42, 5, 1)
+        );
+        assert_eq!(
+            *lru.get(&MemoryDiskValue(1, 0, 0)).unwrap(),
+            MemoryDiskValue(20, 0, 0)
+        );
+        assert_eq!(evicted, vec![]);
+
+        let evicted = lru.push(MemoryDiskValue(2, 5, 1), MemoryDiskValue(10, 5, 1));
+        assert!(lru.get(&MemoryDiskValue(0, 5, 1)).is_none());
+        assert_eq!(
+            *lru.get(&MemoryDiskValue(1, 0, 0)).unwrap(),
+            MemoryDiskValue(20, 0, 0)
+        );
+        assert_eq!(
+            *lru.get(&MemoryDiskValue(2, 5, 1)).unwrap(),
+            MemoryDiskValue(10, 5, 1)
+        );
+        // The least recently used is the first entry.
+        assert_eq!(
+            evicted,
+            vec![(MemoryDiskValue(0, 5, 1), MemoryDiskValue(42, 5, 1))]
+        );
+
+        let evicted = lru.push(MemoryDiskValue(3, 4, 9), MemoryDiskValue(30, 0, 1));
+        assert!(lru.get(&MemoryDiskValue(1, 0, 0)).is_none());
+        assert!(lru.get(&MemoryDiskValue(2, 5, 1)).is_none());
+        assert_eq!(
+            *lru.get(&MemoryDiskValue(3, 4, 9)).unwrap(),
+            MemoryDiskValue(30, 0, 1)
+        );
+        // Now the second and third entries are evicted.
+        assert_eq!(
+            evicted,
+            vec![
+                (MemoryDiskValue(1, 0, 0), MemoryDiskValue(20, 0, 0)),
+                (MemoryDiskValue(2, 5, 1), MemoryDiskValue(10, 5, 1))
+            ]
+        );
+    }
+
+    mod proptests {
+        use super::*;
+        use proptest::prelude::*;
+
+        fn arb_value() -> impl Strategy<Value = MemoryDiskValue> {
+            (0..100_u32, 0..50_usize, 0..50_usize).prop_map(|(a, b, c)| MemoryDiskValue(a, b, c))
+        }
+
+        proptest! {
+            /// Proptest checking that the internal invariants are maintained
+            /// and that the total space of inserted entries equals the total
+            /// space of evicted entries plus the space of the cache itself.
+            #[test]
+            fn test_invariants(entries in prop::collection::vec((arb_value(), arb_value()), 100)) {
+                let mut lru = LruCache::<MemoryDiskValue, MemoryDiskValue>::new(NumBytes::new(100), NumBytes::new(100));
+                let mut total_memory = 0;
+                let mut total_disk = 0;
+                let mut evicted_memory = 0;
+                let mut evicted_disk = 0;
+
+                fn update(memory: &mut usize, disk: &mut usize, k: &MemoryDiskValue, v: &MemoryDiskValue) {
+                    *memory += k.memory_count_bytes();
+                    *memory += v.memory_count_bytes();
+                    *disk += k.disk_count_bytes();
+                    *disk += v.disk_count_bytes();
+                }
+
+                for (k,v) in entries {
+                    update(&mut total_memory, &mut total_disk, &k, &v);
+                    let evicted = lru.push(k,v);
+                    for (k,v) in evicted {
+                        update(&mut evicted_memory, &mut evicted_disk, &k, &v);
+                    }
+
+                    assert_eq!(total_memory, evicted_memory + lru.memory_count_bytes());
+                    assert_eq!(total_disk, evicted_disk + lru.disk_count_bytes());
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
[EXC-1795](https://dfinity.atlassian.net/browse/EXC-1795)

Add the ability for the LRU cache to limit space used on disk as well as in memory and use this in the CompilationCache so that it doesn't grow to large.