### PR TITLE
chore: Update codeowners NET -> CON

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -27,9 +27,9 @@
 /WORKSPACE.bazel                   @dfinity/idx
 
 # [Rust Lang]
-rust-toolchain.toml       @dfinity/networking
-rustfmt.toml              @dfinity/networking
-deny.toml                 @dfinity/networking
+rust-toolchain.toml       @dfinity/consensus
+rustfmt.toml              @dfinity/consensus
+deny.toml                 @dfinity/consensus
 clippy.toml               @dfinity/ic-interface-owners
 
 # [Golang]
@@ -91,22 +91,22 @@ go_deps.bzl               @dfinity/idx
 /rs/artifact_pool/                                      @dfinity/consensus
 /rs/backup/                                             @dfinity/consensus
 /rs/bitcoin/                                            @dfinity/ic-interface-owners
-/rs/bitcoin/adapter/                                    @dfinity/networking
+/rs/bitcoin/adapter/                                    @dfinity/consensus
 /rs/bitcoin/ckbtc/                                      @dfinity/cross-chain-team
 /rs/bitcoin/mock/                                       @dfinity/cross-chain-team
-/rs/bitcoin/client/                                     @dfinity/networking
+/rs/bitcoin/client/                                     @dfinity/consensus
 /rs/bitcoin/consensus/                                  @dfinity/execution @dfinity/consensus
 /rs/bitcoin/checker/                                    @dfinity/cross-chain-team
-/rs/bitcoin/service/                                    @dfinity/networking
+/rs/bitcoin/service/                                    @dfinity/consensus
 /rs/bitcoin/replica_types/                              @dfinity/execution
-/rs/bitcoin/validation                                  @dfinity/networking @dfinity/execution
+/rs/bitcoin/validation                                  @dfinity/consensus @dfinity/execution
 /rs/boundary_node/                                      @dfinity/boundary-node
-/rs/canister_client/                                    @dfinity/networking
+/rs/canister_client/                                    @dfinity/consensus
 /rs/canister_sandbox/                                   @dfinity/execution
 /rs/canonical_state/                                    @dfinity/ic-message-routing-owners
 /rs/canonical_state/tree_hash/                          @dfinity/ic-message-routing-owners @dfinity/crypto-team
 /rs/certification/                                      @dfinity/ic-message-routing-owners @dfinity/crypto-team
-/rs/config/                                             @dfinity/networking
+/rs/config/                                             @dfinity/consensus
 /rs/config/src/embedders.rs                             @dfinity/execution
 /rs/config/src/execution_environment.rs                 @dfinity/execution
 /rs/config/src/state_manager.rs                         @dfinity/ic-message-routing-owners
@@ -125,18 +125,18 @@ go_deps.bzl               @dfinity/idx
 /rs/ethereum/                                           @dfinity/cross-chain-team
 /rs/execution_environment/                              @dfinity/execution
 /rs/fuzzers/                                            @dfinity/product-security
-/rs/http_endpoints/                                     @dfinity/networking
+/rs/http_endpoints/                                     @dfinity/consensus
 /rs/http_endpoints/fuzz/                                @dfinity/product-security
-/rs/http_endpoints/xnet/                                @dfinity/networking @dfinity/ic-message-routing-owners
+/rs/http_endpoints/xnet/                                @dfinity/consensus @dfinity/ic-message-routing-owners
 /rs/http_utils/                                         @dfinity/consensus
-/rs/https_outcalls/                                     @dfinity/networking
+/rs/https_outcalls/                                     @dfinity/consensus
 /rs/https_outcalls/consensus/                           @dfinity/consensus
 /rs/ic_os/                                              @dfinity/node
 /rs/ic_os/fstrim_tool/                                  @dfinity/node @dfinity/crypto-team
 /rs/ic_os/nss_icos/                                     @dfinity/dre
 /rs/ingress_manager/                                    @dfinity/consensus
 /rs/interfaces/                                         @dfinity/ic-interface-owners
-/rs/interfaces/adapter_client/                          @dfinity/networking
+/rs/interfaces/adapter_client/                          @dfinity/consensus
 /rs/interfaces/certified_stream_store/                  @dfinity/ic-message-routing-owners
 /rs/interfaces/registry/                                @dfinity/nns-team
 /rs/interfaces/src/canister_http.rs                     @dfinity/consensus
@@ -147,22 +147,22 @@ go_deps.bzl               @dfinity/idx
 /rs/interfaces/src/dkg.rs                               @dfinity/consensus
 /rs/interfaces/src/execution_environment.rs             @dfinity/execution
 /rs/interfaces/src/messaging.rs                         @dfinity/ic-message-routing-owners
-/rs/interfaces/src/p2p.rs                               @dfinity/networking
-/rs/interfaces/src/p2p/                                 @dfinity/networking
+/rs/interfaces/src/p2p.rs                               @dfinity/consensus
+/rs/interfaces/src/p2p/                                 @dfinity/consensus
 /rs/interfaces/state_manager/                           @dfinity/ic-message-routing-owners
 /rs/ledger_suite/                                       @dfinity/finint
 /rs/limits/                                             @dfinity/ic-interface-owners
 /rs/memory_tracker/                                     @dfinity/execution
 /rs/messaging/                                          @dfinity/ic-message-routing-owners
-/rs/monitoring/                                         @dfinity/networking
-/rs/monitoring/backtrace/                               @dfinity/networking @dfinity/ic-message-routing-owners
-/rs/monitoring/metrics                                  @dfinity/networking @dfinity/ic-message-routing-owners
-/rs/monitoring/pprof/                                   @dfinity/networking @dfinity/ic-message-routing-owners
+/rs/monitoring/                                         @dfinity/consensus
+/rs/monitoring/backtrace/                               @dfinity/consensus @dfinity/ic-message-routing-owners
+/rs/monitoring/metrics                                  @dfinity/consensus @dfinity/ic-message-routing-owners
+/rs/monitoring/pprof/                                   @dfinity/consensus @dfinity/ic-message-routing-owners
 /rs/nervous_system/                                     @dfinity/nns-team
 /rs/nns/                                                @dfinity/nns-team
 /rs/orchestrator/                                       @dfinity/consensus
 /rs/orchestrator/src/hostos_upgrade.rs                  @dfinity/consensus @dfinity/node
-/rs/p2p/                                                @dfinity/networking
+/rs/p2p/                                                @dfinity/consensus
 /rs/phantom_newtype/                                    @dfinity/ic-interface-owners
 /rs/pocket_ic_server/                                   @dfinity/pocket-ic
 /rs/prep/                                               @dfinity/utopia
@@ -170,13 +170,13 @@ go_deps.bzl               @dfinity/idx
 /rs/protobuf/def/bitcoin/                               @dfinity/execution
 /rs/protobuf/def/crypto/                                @dfinity/crypto-team
 /rs/protobuf/def/messaging/                             @dfinity/ic-message-routing-owners
-/rs/protobuf/def/p2p/                                   @dfinity/networking
+/rs/protobuf/def/p2p/                                   @dfinity/consensus
 /rs/protobuf/def/registry/                              @dfinity/nns-team
 /rs/protobuf/def/state/                                 @dfinity/execution @dfinity/ic-message-routing-owners
 /rs/protobuf/gen/bitcoin/                               @dfinity/execution
 /rs/protobuf/gen/crypto/                                @dfinity/crypto-team
 /rs/protobuf/gen/messaging/                             @dfinity/ic-message-routing-owners
-/rs/protobuf/gen/p2p/                                   @dfinity/networking
+/rs/protobuf/gen/p2p/                                   @dfinity/consensus
 /rs/protobuf/gen/registry/                              @dfinity/nns-team
 /rs/protobuf/gen/state/                                 @dfinity/execution @dfinity/ic-message-routing-owners
 /rs/query_stats/                                        @dfinity/execution @dfinity/consensus
@@ -184,7 +184,7 @@ go_deps.bzl               @dfinity/idx
 /rs/registry/                                           @dfinity/nns-team
 /rs/registry/helpers/src/crypto.rs                      @dfinity/crypto-team
 /rs/registry/helpers/src/crypto/                        @dfinity/crypto-team
-/rs/registry/helpers/src/firewall.rs                    @dfinity/networking
+/rs/registry/helpers/src/firewall.rs                    @dfinity/consensus
 /rs/registry/helpers/src/node.rs                        @dfinity/node
 /rs/registry/helpers/src/provisional_whitelist.rs       @dfinity/execution
 /rs/registry/helpers/src/routing_table.rs               @dfinity/execution @dfinity/ic-message-routing-owners
@@ -192,7 +192,7 @@ go_deps.bzl               @dfinity/idx
 /rs/registry/helpers/src/unassigned_nodes.rs            @dfinity/consensus
 /rs/registry/helpers/tests/root_of_trust.rs             @dfinity/crypto-team
 /rs/replay/                                             @dfinity/consensus
-/rs/replica/                                            @dfinity/networking
+/rs/replica/                                            @dfinity/consensus
 /rs/replica_tests/                                      @dfinity/execution
 /rs/replicated_state/                                   @dfinity/execution @dfinity/ic-message-routing-owners
 /rs/replicated_state/src/canister_state/queues.rs       @dfinity/ic-message-routing-owners
@@ -204,7 +204,7 @@ go_deps.bzl               @dfinity/idx
 /rs/rust_canisters/backtrace_canister                   @dfinity/execution
 /rs/rust_canisters/memory_test/                         @dfinity/execution
 /rs/rust_canisters/call_tree_test/                      @dfinity/execution
-/rs/rust_canisters/proxy_canister/                      @dfinity/networking
+/rs/rust_canisters/proxy_canister/                      @dfinity/consensus
 /rs/rust_canisters/response_payload_test/               @dfinity/execution
 /rs/rust_canisters/stable_structures/                   @dfinity/execution
 /rs/rust_canisters/stable_memory_integrity              @dfinity/execution
@@ -215,7 +215,7 @@ go_deps.bzl               @dfinity/idx
 /rs/rust_canisters/downstream_calls_test/               @dfinity/ic-message-routing-owners
 /rs/rust_canisters/random_traffic_test/                 @dfinity/ic-message-routing-owners
 /rs/sns/                                                @dfinity/nns-team
-/rs/starter/                                            @dfinity/networking
+/rs/starter/                                            @dfinity/consensus
 /rs/state_layout/                                       @dfinity/ic-message-routing-owners
 /rs/state_machine_tests/                                @dfinity/ic-message-routing-owners @dfinity/pocket-ic
 /rs/state_manager/                                      @dfinity/ic-message-routing-owners
@@ -228,7 +228,7 @@ go_deps.bzl               @dfinity/idx
 /rs/test_utilities/embedders/                           @dfinity/execution
 /rs/test_utilities/execution_environment/               @dfinity/execution
 /rs/test_utilities/in_memory_logger/                    @dfinity/crypto-team
-/rs/test_utilities/metrics                              @dfinity/networking @dfinity/ic-message-routing-owners
+/rs/test_utilities/metrics                              @dfinity/consensus @dfinity/ic-message-routing-owners
 /rs/test_utilities/src/crypto.rs                        @dfinity/crypto-team
 /rs/test_utilities/src/crypto/                          @dfinity/crypto-team
 /rs/test_utilities/src/cycles_account_manager.rs        @dfinity/execution
@@ -238,7 +238,7 @@ go_deps.bzl               @dfinity/idx
 /rs/tests/idx/                                          @dfinity/idx
 /rs/tests/testnets/                                     @dfinity/idx
 /rs/tests/research                                      @dfinity/research
-/rs/tests/driver/src/driver/simulate_network.rs         @dfinity/networking @dfinity/idx
+/rs/tests/driver/src/driver/simulate_network.rs         @dfinity/consensus @dfinity/idx
 /rs/tests/boundary_nodes/                               @dfinity/boundary-node
 /rs/tests/ckbtc/                                        @dfinity/cross-chain-team
 /rs/tests/consensus/                                    @dfinity/consensus
@@ -248,7 +248,7 @@ go_deps.bzl               @dfinity/idx
 /rs/tests/execution/                                    @dfinity/execution
 /rs/tests/financial_integrations/                       @dfinity/finint
 /rs/tests/message_routing/                              @dfinity/ic-message-routing-owners
-/rs/tests/networking/                                   @dfinity/networking
+/rs/tests/networking/                                   @dfinity/consensus
 /rs/tests/nns/                                          @dfinity/nns-team
 /rs/tests/node/                                         @dfinity/node
 /rs/tests/query_stats/                                  @dfinity/execution @dfinity/consensus
@@ -264,7 +264,7 @@ go_deps.bzl               @dfinity/idx
 /rs/types/                                              @dfinity/ic-interface-owners
 /rs/types/exhaustive_derive/                            @dfinity/consensus
 /rs/types/management_canister_types/                    @dfinity/execution
-/rs/types/types/src/artifact.rs                         @dfinity/consensus @dfinity/networking
+/rs/types/types/src/artifact.rs                         @dfinity/consensus
 /rs/types/types/src/batch.rs                            @dfinity/consensus
 /rs/types/types/src/batch/                              @dfinity/consensus
 /rs/types/types/src/canister_http.rs                    @dfinity/execution @dfinity/consensus


### PR DESCRIPTION
This PR updates the CODEOWNERS file to reflect the merge of the Networking team into the Consensus team.