### PR TITLE
feat(governance-tools): Use unreleased_changelog.md when generating proposals.

### DIFF
--- a/rs/nns/governance/unreleased_changelog.md
+++ b/rs/nns/governance/unreleased_changelog.md
@@ -15,9 +15,7 @@ because this new function has no user-visible behavior change yet. Wait until it
 is active (e.g. the feature flag is flipped to "enable") before adding an entry
 to this file.
 
-TODO: Perhaps, the script that drafts the proposal summary can also move content
-from here to CHANGELOG.md (step 3.). OTOH, it might be better if this is done by
-a second (new) script, because the proposal ID is not known until later?
+TODO: Automate moving content from unreleased_changelog.md to CHANGELOG.md.
 
 
 # How to Write a Good Entry

--- a/rs/nns/governance/unreleased_changelog.md
+++ b/rs/nns/governance/unreleased_changelog.md
@@ -15,12 +15,6 @@ because this new function has no user-visible behavior change yet. Wait until it
 is active (e.g. the feature flag is flipped to "enable") before adding an entry
 to this file.
 
-TODO: Automate step 2. by modifying the script that composes the proposal
-summary. It might be helpful to look at nns-dapp's [split-changelog] script for
-inspiration.
-
-[split-changelog]: https://github.com/dfinity/nns-dapp/blob/main/scripts/nns-dapp/split-changelog
-
 TODO: Perhaps, the script that drafts the proposal summary can also move content
 from here to CHANGELOG.md (step 3.). OTOH, it might be better if this is done by
 a second (new) script, because the proposal ID is not known until later?

--- a/testnet/tools/nns-tools/lib/proposals.sh
+++ b/testnet/tools/nns-tools/lib/proposals.sh
@@ -128,6 +128,22 @@ generate_nns_upgrade_proposal_text() {
     ESCAPED_IC_REPO=$(printf '%s\n' "$IC_REPO" | sed -e 's/[]\/$*.^[]/\\&/g')
     RELATIVE_CODE_LOCATION="$(echo "$CANISTER_CODE_LOCATION" | sed "s/$ESCAPED_IC_REPO/./g")"
 
+    # If the canister has an unrelease_changelog.md file, use that to populate
+    # the "Features & Fixes" section of the upgrade proposal. Eventually, all of
+    # our canisters will have such a file, but for now, we are still test
+    # driving this process.
+    FEATURES_AND_FIXES="TODO Hand-craft this section."
+    PRIMARY_RELATIVE_CODE_LOCATION=$(echo "${RELATIVE_CODE_LOCATION}" | cut -d' ' -f1)
+    UNRELEASED_CHANGELOG_PATH="${PRIMARY_RELATIVE_CODE_LOCATION}/unreleased_changelog.md"
+    if [[ -e "${UNRELEASED_CHANGELOG_PATH}" ]]; then
+        FEATURES_AND_FIXES=$( \
+            sed -n '/# Next Upgrade Proposal/,$p' \
+                "${UNRELEASED_CHANGELOG_PATH}" \
+                | tail -n +3 \
+                | sed 's/^## /### /g' \
+        )
+    fi
+
     ARGS_HASH=""
     if [ ! -z "$CANDID_ARGS" ]; then
         FILE=$(encode_candid_args_in_file "$CANDID_ARGS")
@@ -144,9 +160,11 @@ __Source code__: [$NEXT_COMMIT][new-commit]
 
 [new-commit]: https://github.com/dfinity/ic/tree/$NEXT_COMMIT
 
-## Summary
 
-TODO add a summary of changes
+## Features & Fixes
+
+$FEATURES_AND_FIXES
+
 
 ## New Commits
 

--- a/testnet/tools/nns-tools/lib/proposals.sh
+++ b/testnet/tools/nns-tools/lib/proposals.sh
@@ -136,11 +136,11 @@ generate_nns_upgrade_proposal_text() {
     PRIMARY_RELATIVE_CODE_LOCATION=$(echo "${RELATIVE_CODE_LOCATION}" | cut -d' ' -f1)
     UNRELEASED_CHANGELOG_PATH="${PRIMARY_RELATIVE_CODE_LOCATION}/unreleased_changelog.md"
     if [[ -e "${UNRELEASED_CHANGELOG_PATH}" ]]; then
-        FEATURES_AND_FIXES=$( \
+        FEATURES_AND_FIXES=$(
             sed -n '/# Next Upgrade Proposal/,$p' \
                 "${UNRELEASED_CHANGELOG_PATH}" \
                 | tail -n +3 \
-                | sed 's/^## /### /g' \
+                | sed 's/^## /### /g'
         )
     fi
 


### PR DESCRIPTION
If the canister does not yet have an unreleased_changelog.md file, the "Features & Fixes" section defaults to a TODO, forcing the release tsar to hand-craft that section.

If this works well, we will also do this for SNS later.

# References

[👈 Previous PR][prev]

[prev]: https://github.com/dfinity/ic/pull/3332