### PR TITLE
fix(PocketIC): run install_backtrace_handler if PocketIC is run as canister sandbox

### DIFF
--- a/rs/canister_sandbox/BUILD.bazel
+++ b/rs/canister_sandbox/BUILD.bazel
@@ -96,7 +96,6 @@ rust_binary(
         # Keep sorted.
         ":backend_lib",
         ":build_script",
-        "@crate_index//:libc",
     ],
 )
 

--- a/rs/canister_sandbox/bin/canister_sandbox.rs
+++ b/rs/canister_sandbox/bin/canister_sandbox.rs
@@ -1,4 +1,4 @@
-#[cfg(target_os = "linux")]
+#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
 extern "C" {
     fn install_backtrace_handler();
 }

--- a/rs/pocket_ic_server/BUILD.bazel
+++ b/rs/pocket_ic_server/BUILD.bazel
@@ -144,7 +144,6 @@ rust_binary(
     deps = LIB_DEPENDENCIES + [
         ":pocket-ic-server-lib",
         "//rs/canister_sandbox:build_script",
-        "@crate_index//:libc",
     ],
 )
 

--- a/rs/pocket_ic_server/BUILD.bazel
+++ b/rs/pocket_ic_server/BUILD.bazel
@@ -141,7 +141,11 @@ rust_binary(
     proc_macro_deps = MACRO_DEPENDENCIES,
     # TODO: restrict the visibility
     visibility = ["//visibility:public"],
-    deps = LIB_DEPENDENCIES + [":pocket-ic-server-lib"],
+    deps = LIB_DEPENDENCIES + [
+        ":pocket-ic-server-lib",
+        "//rs/canister_sandbox:build_script",
+        "@crate_index//:libc",
+    ],
 )
 
 rust_library(

--- a/rs/pocket_ic_server/src/main.rs
+++ b/rs/pocket_ic_server/src/main.rs
@@ -78,7 +78,7 @@ fn current_binary_path() -> Option<PathBuf> {
     std::env::args().next().map(PathBuf::from)
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
 extern "C" {
     fn install_backtrace_handler();
 }

--- a/rs/pocket_ic_server/src/main.rs
+++ b/rs/pocket_ic_server/src/main.rs
@@ -78,6 +78,11 @@ fn current_binary_path() -> Option<PathBuf> {
     std::env::args().next().map(PathBuf::from)
 }
 
+#[cfg(target_os = "linux")]
+extern "C" {
+    fn install_backtrace_handler();
+}
+
 fn main() {
     let current_binary_path = current_binary_path().unwrap();
     let current_binary_name = current_binary_path.file_name().unwrap().to_str().unwrap();
@@ -89,6 +94,10 @@ fn main() {
     // before the arguments are parsed because the parent process does not pass
     // all the normally required arguments of `pocket-ic-server`.
     if std::env::args().any(|arg| arg == RUN_AS_CANISTER_SANDBOX_FLAG) {
+        #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+        unsafe {
+            install_backtrace_handler();
+        }
         canister_sandbox_main();
     } else if std::env::args().any(|arg| arg == RUN_AS_SANDBOX_LAUNCHER_FLAG) {
         sandbox_launcher_main();


### PR DESCRIPTION
This PR runs `install_backtrace_handler` if PocketIC is run as canister sandbox to match the dedicated binary's main function.