### PR TITLE
chore(execution-environment): Specify image-classification canister WASM as a Bazel dependency

### DIFF
--- a/rs/execution_environment/BUILD.bazel
+++ b/rs/execution_environment/BUILD.bazel
@@ -139,11 +139,13 @@ rust_ic_test_suite(
         "//rs/rust_canisters/backtrace_canister:backtrace-canister",
         "//rs/universal_canister/impl:universal_canister.module",
         "//rs/universal_canister/impl:universal_canister.wasm.gz",
+        "//testnet/prebuilt-canisters:image-classification",
     ],
     env = dict(ENV.items() + [
         ("BACKTRACE_CANISTER_WASM_PATH", "$(rootpath //rs/rust_canisters/backtrace_canister:backtrace-canister)"),
         ("UNIVERSAL_CANISTER_WASM_PATH", "$(rootpath //rs/universal_canister/impl:universal_canister.wasm.gz)"),
         ("UNIVERSAL_CANISTER_SERIALIZED_MODULE_PATH", "$(rootpath //rs/universal_canister/impl:universal_canister.module)"),
+        ("IMAGE_CLASSIFICATION_CANISTER_WASM_PATH", "$(rootpath //testnet/prebuilt-canisters:image-classification)"),
     ]),
     proc_macro_deps = MACRO_DEPENDENCIES + MACRO_DEV_DEPENDENCIES,
     tags = [

--- a/rs/execution_environment/tests/smoke.rs
+++ b/rs/execution_environment/tests/smoke.rs
@@ -14,7 +14,15 @@ const COPYING_GC: &[u8] = include_bytes!("test-data/copying-gc.wasm.gz");
 const SHA256: &[u8] = include_bytes!("test-data/sha256.wasm");
 
 // https://github.com/dfinity/examples/tree/master/rust/image-classification
-const IMAGE_CLASSIFICATION: &[u8] = include_bytes!("test-data/image-classification.wasm.gz");
+fn image_classification_canister_wasm() -> Vec<u8> {
+    let image_classification_canister_wasm_path =
+        std::env::var("IMAGE_CLASSIFICATION_CANISTER_WASM_PATH")
+            .expect("Please ensure that this Bazel test target correctly specifies env and data.");
+
+    let wasm_path = std::path::PathBuf::from(image_classification_canister_wasm_path);
+
+    std::fs::read(&wasm_path).expect("Failed to read WASM file")
+}
 
 #[test]
 fn qr() {
@@ -89,7 +97,7 @@ fn image_classification() {
     let env = StateMachine::new();
     let image_classification = env
         .install_canister(
-            IMAGE_CLASSIFICATION.to_vec(),
+            image_classification_canister_wasm(),
             encode_args(()).unwrap(),
             None,
         )

--- a/testnet/prebuilt-canisters/BUILD.bazel
+++ b/testnet/prebuilt-canisters/BUILD.bazel
@@ -1,0 +1,7 @@
+package(default_visibility = ["//visibility:public"])
+
+# https://github.com/dfinity/examples/tree/master/rust/image-classification
+filegroup(
+    name = "image-classification",
+    srcs = ["image-classification.wasm.gz"],
+)


### PR DESCRIPTION
This PR makes image-classification.wasm.gz (currently, a checked-in binary artifact) a Bazel dependency, so multiple tests that require either specifically this canister, or just a very large WASM, can share it. This change required adjusting `//rs/execution_environment:execution_environment_misc_integration_tests/smoke`.