### PR TITLE
test(nns): Revert "test(nns): Support caching of the golden NNS state when runni…

### DIFF
--- a/rs/nns/test_utils/golden_nns_state/src/lib.rs
+++ b/rs/nns/test_utils/golden_nns_state/src/lib.rs
@@ -1,18 +1,12 @@
 use ic_base_types::{CanisterId, PrincipalId, SubnetId};
 use ic_config::{execution_environment::Config, subnet_config::SubnetConfig};
 use ic_registry_subnet_type::SubnetType;
-use ic_state_machine_tests::{
-    StateMachine, StateMachineBuilder, StateMachineConfig, StateMachineStateDir,
-};
+use ic_state_machine_tests::{StateMachine, StateMachineBuilder, StateMachineConfig};
 
 use ic_config::flag_status::FlagStatus;
 use ic_registry_routing_table::{CanisterIdRange, RoutingTable, CANISTER_IDS_PER_SUBNET};
 use std::ops::RangeInclusive;
-use std::{
-    path::{Path, PathBuf},
-    process::Command,
-    str::FromStr,
-};
+use std::{path::Path, process::Command, str::FromStr};
 use tempfile::TempDir;
 // TODO: Add support for PocketIc.
 
@@ -104,7 +98,8 @@ fn new_state_machine_with_golden_state_or_panic(setup_config: SetupConfig) -> St
         hypervisor_config.unwrap_or_default(),
     )));
 
-    let state_dir = maybe_download_golden_nns_state_or_panic(scp_location, archive_state_dir_name);
+    let state_dir =
+        download_and_untar_golden_nns_state_or_panic(scp_location, archive_state_dir_name);
     let state_machine_builder = state_machine_builder
         .with_state_machine_state_dir(Box::new(state_dir))
         // Patch StateMachine. This is a bit of a hack that we need because we
@@ -119,67 +114,23 @@ fn new_state_machine_with_golden_state_or_panic(setup_config: SetupConfig) -> St
     state_machine
 }
 
-/// A directory for storing the golden state which can be either a temporary directory or a cached
-/// directory which can be used across multiple tests.
-enum StateDir {
-    // A temporary directory that will be deleted after the test is done.
-    Temp(TempDir),
-    // A directory that will be cached and reused across tests.
-    Cache(PathBuf),
-}
-
-impl StateMachineStateDir for StateDir {
-    fn path(&self) -> PathBuf {
-        match self {
-            Self::Temp(temp_dir) => temp_dir.path().to_path_buf(),
-            Self::Cache(path) => path.clone(),
-        }
-    }
-}
-
-fn maybe_download_golden_nns_state_or_panic(
-    scp_location: ScpLocation,
-    archive_state_dir_name: &str,
-) -> StateDir {
-    let maybe_use_cached_state_dir = std::env::var_os("USE_CACHED_STATE_DIR");
-
-    match maybe_use_cached_state_dir {
-        Some(cached_state_dir) => {
-            let destination = PathBuf::from(cached_state_dir).join(archive_state_dir_name);
-            if !destination.exists() {
-                std::fs::create_dir(&destination)
-                    .unwrap_or_else(|_| panic!("Failed to create directory {destination:?}"));
-                download_and_untar_golden_nns_state_or_panic(
-                    scp_location,
-                    archive_state_dir_name,
-                    &destination,
-                );
-            }
-            StateDir::Cache(destination)
-        }
-        None => {
-            let state_dir = bazel_test_compatible_temp_dir_or_panic();
-            download_and_untar_golden_nns_state_or_panic(
-                scp_location,
-                archive_state_dir_name,
-                state_dir.path(),
-            );
-            StateDir::Temp(state_dir)
-        }
-    }
-}
-
 fn download_and_untar_golden_nns_state_or_panic(
     scp_location: ScpLocation,
     archive_state_dir_name: &str,
-    destination: &Path,
-) {
+) -> TempDir {
     let download_destination = bazel_test_compatible_temp_dir_or_panic();
     let download_destination = download_destination
         .path()
         .join(format!("{}.tar.zst", archive_state_dir_name));
     download_golden_nns_state_or_panic(scp_location, &download_destination);
-    untar_state_archive_or_panic(&download_destination, destination, archive_state_dir_name);
+
+    let state_dir = bazel_test_compatible_temp_dir_or_panic();
+    untar_state_archive_or_panic(
+        &download_destination,
+        state_dir.path(),
+        archive_state_dir_name,
+    );
+    state_dir
 }
 
 // Privates


### PR DESCRIPTION
Since the state machine tests modifies the state in place, running tests this way more than one time (which is the whole point of caching it) might yield surprising results. Therefore the `USE_CACHED_STATE_DIR` should be removed.