### PR TITLE
fix: reject code in synchronous rejects

### DIFF
--- a/hs/spec_compliance/src/IC/Test/Spec.hs
+++ b/hs/spec_compliance/src/IC/Test/Spec.hs
@@ -754,7 +754,7 @@ icTests my_sub other_sub conf =
                                                                                                                    ic_canister_status'' anonymousUser cid >>= isErrOrReject [3, 5]
                                                                                                                    ic_canister_status'' secp256k1User cid >>= isErrOrReject [3, 5],
                                                                                                                  simpleTestCase "> 10 controllers" ecid $ \cid -> do
-                                                                                                                   ic_create_with_controllers' (ic00viaWithCycles cid 20_000_000_000_000) ecid (replicate 11 cid) >>= isReject [3, 5]
+                                                                                                                   ic_create_with_controllers' (ic00viaWithCycles cid 20_000_000_000_000) ecid (replicate 11 cid) >>= isReject [4]
                                                                                                                    ic_set_controllers' ic00 cid (replicate 11 cid) >>= isReject [4],
                                                                                                                  simpleTestCase "No controller" ecid $ \cid -> do
                                                                                                                    cid2 <- ic_create_with_controllers (ic00viaWithCycles cid 20_000_000_000_000) ecid []

--- a/rs/system_api/src/sandbox_safe_system_state.rs
+++ b/rs/system_api/src/sandbox_safe_system_state.rs
@@ -187,7 +187,7 @@ impl SystemStateChanges {
             err
         );
 
-        let reject_context = RejectContext::new(RejectCode::CanisterError, err.to_string());
+        let reject_context = RejectContext::new(err.code().into(), err.to_string());
         system_state
             .reject_subnet_output_request(msg, reject_context, subnet_ids)
             .map_err(|e| Self::error(format!("Failed to push IC00 reject response: {:?}", e)))?;


### PR DESCRIPTION
This PR fixes the reject code in synchronous rejects of mgmt canister calls to be derived from the given `UserError` instead of hard-coded to `CanisterError`.