### PR TITLE
feat(icrc-ledger-types): FI-1624: Bump icrc-ledger-types version with the added rustdoc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13995,7 +13995,7 @@ dependencies = [
 
 [[package]]
 name = "icrc-ledger-types"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "assert_matches",
  "base32",

--- a/packages/icrc-ledger-types/CHANGELOG.md
+++ b/packages/icrc-ledger-types/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## 0.1.7
+
+### Added
+
+- Rustdoc.
+
 ## 0.1.6
 
 ### Added

--- a/packages/icrc-ledger-types/Cargo.toml
+++ b/packages/icrc-ledger-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "icrc-ledger-types"
-version = "0.1.6"
+version = "0.1.7"
 description = "Types for interacting with DFINITY's implementation of the ICRC-1 fungible token standard."
 license = "Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION
Bump the version of `icrc-ledger-types` to `0.1.7` in order to release the added rustdoc.