### PR TITLE
feat(EXC-1795): Limit cache disk space

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13279,6 +13279,7 @@ version = "0.9.0"
 dependencies = [
  "ic-types",
  "lru",
+ "proptest",
 ]
 
 [[package]]

--- a/rs/embedders/src/compilation_cache.rs
+++ b/rs/embedders/src/compilation_cache.rs
@@ -15,7 +15,7 @@ use crate::{
 };
 use ic_interfaces::execution_environment::{HypervisorError, HypervisorResult};
 use ic_replicated_state::canister_state::execution_state::WasmMetadata;
-use ic_types::{methods::WasmMethod, NumBytes, NumInstructions};
+use ic_types::{methods::WasmMethod, MemoryDiskBytes, NumBytes, NumInstructions};
 use ic_utils_lru_cache::LruCache;
 use ic_wasm_types::{CanisterModule, WasmHash};
 
@@ -34,6 +34,22 @@ pub enum CompilationCache {
         /// Atomic counter to deduplicate files in the case of concurrent compilations of the same module.
         counter: AtomicU64,
     },
+}
+
+impl MemoryDiskBytes for CompilationCache {
+    fn memory_bytes(&self) -> usize {
+        match self {
+            CompilationCache::Memory { cache } => cache.lock().unwrap().memory_bytes(),
+            CompilationCache::Disk { cache, .. } => cache.lock().unwrap().memory_bytes(),
+        }
+    }
+
+    fn disk_bytes(&self) -> usize {
+        match self {
+            CompilationCache::Memory { cache } => cache.lock().unwrap().disk_bytes(),
+            CompilationCache::Disk { cache, .. } => cache.lock().unwrap().disk_bytes(),
+        }
+    }
 }
 
 impl CompilationCache {

--- a/rs/embedders/src/compilation_cache.rs
+++ b/rs/embedders/src/compilation_cache.rs
@@ -39,7 +39,7 @@ pub enum CompilationCache {
 impl CompilationCache {
     pub fn new(capacity: NumBytes) -> Self {
         Self::Memory {
-            cache: Mutex::new(LruCache::new(capacity)),
+            cache: Mutex::new(LruCache::new(capacity, NumBytes::from(1024 * 1024 * 1024))),
         }
     }
 

--- a/rs/embedders/src/compilation_cache.rs
+++ b/rs/embedders/src/compilation_cache.rs
@@ -19,6 +19,8 @@ use ic_types::{methods::WasmMethod, MemoryDiskBytes, NumBytes, NumInstructions};
 use ic_utils_lru_cache::LruCache;
 use ic_wasm_types::{CanisterModule, WasmHash};
 
+const GB: u64 = 1024 * 1024 * 1024;
+
 /// Stores the serialized modules of wasm code that has already been compiled so
 /// that it can be used again without recompiling.
 pub enum CompilationCache {
@@ -55,7 +57,7 @@ impl MemoryDiskBytes for CompilationCache {
 impl CompilationCache {
     pub fn new(capacity: NumBytes) -> Self {
         Self::Memory {
-            cache: Mutex::new(LruCache::new(capacity, NumBytes::from(1024 * 1024 * 1024))),
+            cache: Mutex::new(LruCache::new(capacity, NumBytes::from(GB))),
         }
     }
 

--- a/rs/embedders/src/serialized_module.rs
+++ b/rs/embedders/src/serialized_module.rs
@@ -157,7 +157,6 @@ impl MemoryDiskBytes for OnDiskSerializedModule {
     }
 
     fn disk_bytes(&self) -> usize {
-        // TODO: cache to avoid repeated syscalls.
         (self.bytes.metadata().unwrap().len() + self.initial_state_data.metadata().unwrap().len())
             as usize
     }

--- a/rs/execution_environment/src/hypervisor.rs
+++ b/rs/execution_environment/src/hypervisor.rs
@@ -21,11 +21,11 @@ use ic_replicated_state::{NetworkTopology, ReplicatedState};
 use ic_system_api::ExecutionParameters;
 use ic_system_api::{sandbox_safe_system_state::SandboxSafeSystemState, ApiType};
 use ic_types::{
-    messages::RequestMetadata, methods::FuncRef, CanisterId, NumBytes, NumInstructions, SubnetId,
-    Time,
+    messages::RequestMetadata, methods::FuncRef, CanisterId, MemoryDiskBytes, NumBytes,
+    NumInstructions, SubnetId, Time,
 };
 use ic_wasm_types::CanisterModule;
-use prometheus::{Histogram, HistogramVec, IntCounter, IntGauge};
+use prometheus::{Histogram, HistogramVec, IntCounter, IntGauge, IntGaugeVec};
 use std::{
     path::{Path, PathBuf},
     sync::Arc,
@@ -50,6 +50,7 @@ pub struct HypervisorMetrics {
     mmap_count: HistogramVec,
     mprotect_count: HistogramVec,
     copy_page_count: HistogramVec,
+    compilation_cache_size: IntGaugeVec,
 }
 
 impl HypervisorMetrics {
@@ -124,6 +125,8 @@ impl HypervisorMetrics {
                 decimal_buckets_with_zero(0,8),
                 &["api_type", "memory_type"]
             ),
+            compilation_cache_size: metrics_registry.int_gauge_vec("hypervisor_compilation_cache_size", "Bytes in memory and on disk used by the compilation cache.", &["location"],
+            ),
         }
     }
 
@@ -184,7 +187,12 @@ impl HypervisorMetrics {
         }
     }
 
-    fn observe_compilation_metrics(&self, compilation_result: &CompilationResult) {
+    fn observe_compilation_metrics(
+        &self,
+        compilation_result: &CompilationResult,
+        cache_memory_size: NumBytes,
+        cache_disk_size: NumBytes,
+    ) {
         let CompilationResult {
             largest_function_instruction_count,
             compilation_time,
@@ -194,6 +202,12 @@ impl HypervisorMetrics {
             .observe(largest_function_instruction_count.get() as f64);
         self.compile.observe(compilation_time.as_secs_f64());
         self.max_complexity.observe(*max_complexity as f64);
+        self.compilation_cache_size
+            .with_label_values(&["memory"])
+            .set(cache_memory_size.get() as i64);
+        self.compilation_cache_size
+            .with_label_values(&["disk"])
+            .set(cache_disk_size.get() as i64);
     }
 }
 
@@ -255,8 +269,11 @@ impl Hypervisor {
         match creation_result {
             Ok((execution_state, compilation_cost, compilation_result)) => {
                 if let Some(compilation_result) = compilation_result {
-                    self.metrics
-                        .observe_compilation_metrics(&compilation_result);
+                    self.metrics.observe_compilation_metrics(
+                        &compilation_result,
+                        self.compilation_cache.memory_bytes(),
+                        self.compilation_cache.disk_bytes(),
+                    );
                 }
                 round_limits.instructions -= as_round_instructions(
                     compilation_cost_handling.adjusted_compilation_cost(compilation_cost),
@@ -489,8 +506,11 @@ impl Hypervisor {
             execution_state,
         );
         if let Some(compilation_result) = compilation_result {
-            self.metrics
-                .observe_compilation_metrics(&compilation_result);
+            self.metrics.observe_compilation_metrics(
+                &compilation_result,
+                self.compilation_cache.memory_bytes(),
+                self.compilation_cache.disk_bytes(),
+            );
         }
         self.metrics.observe(&execution_result, api_type_str);
 

--- a/rs/execution_environment/src/hypervisor.rs
+++ b/rs/execution_environment/src/hypervisor.rs
@@ -190,8 +190,8 @@ impl HypervisorMetrics {
     fn observe_compilation_metrics(
         &self,
         compilation_result: &CompilationResult,
-        cache_memory_size: NumBytes,
-        cache_disk_size: NumBytes,
+        cache_memory_size: usize,
+        cache_disk_size: usize,
     ) {
         let CompilationResult {
             largest_function_instruction_count,
@@ -204,10 +204,10 @@ impl HypervisorMetrics {
         self.max_complexity.observe(*max_complexity as f64);
         self.compilation_cache_size
             .with_label_values(&["memory"])
-            .set(cache_memory_size.get() as i64);
+            .set(cache_memory_size as i64);
         self.compilation_cache_size
             .with_label_values(&["disk"])
-            .set(cache_disk_size.get() as i64);
+            .set(cache_disk_size as i64);
     }
 }
 

--- a/rs/execution_environment/src/query_handler/query_cache.rs
+++ b/rs/execution_environment/src/query_handler/query_cache.rs
@@ -8,7 +8,7 @@ use ic_types::{
     batch::QueryStats,
     ingress::WasmResult,
     messages::{Query, QuerySource},
-    CountBytes, Cycles, PrincipalId, Time, UserId,
+    Cycles, MemoryDiskBytes, PrincipalId, Time, UserId,
 };
 use ic_utils_lru_cache::LruCache;
 use prometheus::{Histogram, IntCounter, IntGauge};
@@ -36,7 +36,7 @@ pub(crate) struct QueryCacheMetrics {
     pub invalidated_entries_by_canister_balance: IntCounter,
     pub invalidated_entries_by_transient_error: IntCounter,
     pub invalidated_entries_duration: Histogram,
-    pub count_bytes: IntGauge,
+    pub memory_bytes: IntGauge,
     pub len: IntGauge,
     pub push_errors: IntCounter,
     pub validation_errors: IntCounter,
@@ -103,8 +103,8 @@ impl QueryCacheMetrics {
                 "The duration of invalidated cache entries in seconds",
                 metrics_registry,
             ),
-            count_bytes: metrics_registry.int_gauge(
-                "execution_query_cache_count_bytes",
+            memory_bytes: metrics_registry.int_gauge(
+                "execution_query_cache_memory_bytes",
                 "The current replica side query cache size in bytes",
             ),
             len: metrics_registry.int_gauge(
@@ -140,9 +140,13 @@ pub(crate) struct EntryKey {
     pub method_payload: Vec<u8>,
 }
 
-impl CountBytes for EntryKey {
-    fn count_bytes(&self) -> usize {
+impl MemoryDiskBytes for EntryKey {
+    fn memory_bytes(&self) -> usize {
         size_of_val(self) + self.method_name.len() + self.method_payload.len()
+    }
+
+    fn disk_bytes(&self) -> usize {
+        0
     }
 }
 
@@ -211,9 +215,13 @@ pub(crate) struct EntryValue {
     ignore_canister_balances: bool,
 }
 
-impl CountBytes for EntryValue {
-    fn count_bytes(&self) -> usize {
-        size_of_val(self) + self.result.count_bytes()
+impl MemoryDiskBytes for EntryValue {
+    fn memory_bytes(&self) -> usize {
+        size_of_val(self) + self.result.memory_bytes()
+    }
+
+    fn disk_bytes(&self) -> usize {
+        0
     }
 }
 
@@ -377,9 +385,13 @@ pub(crate) struct QueryCache {
     pub(crate) metrics: QueryCacheMetrics,
 }
 
-impl CountBytes for QueryCache {
-    fn count_bytes(&self) -> usize {
-        size_of_val(self) + self.cache.lock().unwrap().count_bytes()
+impl MemoryDiskBytes for QueryCache {
+    fn memory_bytes(&self) -> usize {
+        size_of_val(self) + self.cache.lock().unwrap().memory_bytes()
+    }
+
+    fn disk_bytes(&self) -> usize {
+        0
     }
 }
 
@@ -392,7 +404,7 @@ impl QueryCache {
         data_certificate_expiry_time: Duration,
     ) -> Self {
         QueryCache {
-            cache: Mutex::new(LruCache::new(capacity)),
+            cache: Mutex::new(LruCache::new(capacity, NumBytes::from(0))),
             max_expiry_time,
             data_certificate_expiry_time,
             metrics: QueryCacheMetrics::new(metrics_registry),
@@ -421,8 +433,8 @@ impl QueryCache {
             } else {
                 // The cache entry is no longer valid, remove it.
                 cache.pop(key);
-                // Update the `count_bytes` metric.
-                self.metrics.count_bytes.set(cache.count_bytes() as i64);
+                // Update the `memory_bytes` metric.
+                self.metrics.memory_bytes.set(cache.memory_bytes() as i64);
             }
         }
         None
@@ -470,8 +482,8 @@ impl QueryCache {
             let d = evicted_value.elapsed_seconds(now);
             self.metrics.evicted_entries_duration.observe(d);
         }
-        let count_bytes = cache.count_bytes() as i64;
-        self.metrics.count_bytes.set(count_bytes);
+        let memory_bytes = cache.memory_bytes() as i64;
+        self.metrics.memory_bytes.set(memory_bytes);
         self.metrics.len.set(cache.len() as i64);
     }
 }

--- a/rs/execution_environment/src/query_handler/query_cache.rs
+++ b/rs/execution_environment/src/query_handler/query_cache.rs
@@ -36,7 +36,7 @@ pub(crate) struct QueryCacheMetrics {
     pub invalidated_entries_by_canister_balance: IntCounter,
     pub invalidated_entries_by_transient_error: IntCounter,
     pub invalidated_entries_duration: Histogram,
-    pub memory_bytes: IntGauge,
+    pub count_bytes: IntGauge,
     pub len: IntGauge,
     pub push_errors: IntCounter,
     pub validation_errors: IntCounter,
@@ -103,8 +103,8 @@ impl QueryCacheMetrics {
                 "The duration of invalidated cache entries in seconds",
                 metrics_registry,
             ),
-            memory_bytes: metrics_registry.int_gauge(
-                "execution_query_cache_memory_bytes",
+            count_bytes: metrics_registry.int_gauge(
+                "execution_query_cache_count_bytes",
                 "The current replica side query cache size in bytes",
             ),
             len: metrics_registry.int_gauge(
@@ -433,8 +433,8 @@ impl QueryCache {
             } else {
                 // The cache entry is no longer valid, remove it.
                 cache.pop(key);
-                // Update the `memory_bytes` metric.
-                self.metrics.memory_bytes.set(cache.memory_bytes() as i64);
+                // Update the `count_bytes` metric.
+                self.metrics.count_bytes.set(cache.memory_bytes() as i64);
             }
         }
         None
@@ -483,7 +483,7 @@ impl QueryCache {
             self.metrics.evicted_entries_duration.observe(d);
         }
         let memory_bytes = cache.memory_bytes() as i64;
-        self.metrics.memory_bytes.set(memory_bytes);
+        self.metrics.count_bytes.set(memory_bytes);
         self.metrics.len.set(cache.len() as i64);
     }
 }

--- a/rs/execution_environment/src/query_handler/query_cache/tests.rs
+++ b/rs/execution_environment/src/query_handler/query_cache/tests.rs
@@ -16,7 +16,7 @@ use ic_types::{
     batch::QueryStats,
     ingress::WasmResult,
     messages::{CanisterTask, Query, QuerySource},
-    time, CountBytes,
+    time, MemoryDiskBytes,
 };
 use ic_types_test_utils::ids::subnet_test_id;
 use ic_universal_canister::call_args;
@@ -166,7 +166,7 @@ fn query_cache_reports_hits_and_misses_metrics() {
 }
 
 #[test]
-fn query_cache_reports_evicted_entries_and_count_bytes_metrics() {
+fn query_cache_reports_evicted_entries_and_memory_bytes_metrics() {
     const QUERY_CACHE_SIZE: usize = 2;
     /// Includes some room for the keys, headers etc.
     const QUERY_CACHE_CAPACITY: usize = REPLY_SIZE * (QUERY_CACHE_SIZE + 1);
@@ -202,16 +202,16 @@ fn query_cache_reports_evicted_entries_and_count_bytes_metrics() {
     );
     assert_eq!(0, m.invalidated_entries.get());
 
-    let count_bytes = m.count_bytes.get() as usize;
+    let memory_bytes = m.count_bytes.get() as usize;
     // We can't match the size exactly, as it includes the key and the captured environment.
     // But we can assert that the sum of the sizes should be:
-    // REPLY_SIZE < count_bytes < REPLY_SIZE * 2
-    assert!(REPLY_SIZE < count_bytes);
-    assert!(REPLY_SIZE * 2 * QUERY_CACHE_SIZE > count_bytes);
+    // REPLY_SIZE < memory_bytes < REPLY_SIZE * 2
+    assert!(REPLY_SIZE < memory_bytes);
+    assert!(REPLY_SIZE * 2 * QUERY_CACHE_SIZE > memory_bytes);
 }
 
 #[test]
-fn query_cache_reports_count_bytes_metric_on_invalidation() {
+fn query_cache_reports_memory_bytes_metric_on_invalidation() {
     let mut test = builder_with_query_caching().build();
     let a_id = test.universal_canister().unwrap();
     let key = EntryKey {
@@ -225,8 +225,8 @@ fn query_cache_reports_count_bytes_metric_on_invalidation() {
     let m = query_cache_metrics(&test);
     assert_eq!(0, m.hits.get());
     assert_eq!(0, m.misses.get());
-    let initial_count_bytes = m.count_bytes.get();
-    assert!((initial_count_bytes as usize) < BIG_REPLY_SIZE);
+    let initial_memory_bytes = m.count_bytes.get();
+    assert!((initial_memory_bytes as usize) < BIG_REPLY_SIZE);
 
     // Push a big result into the cache.
     let big_result = Ok(WasmResult::Reply(vec![0; BIG_REPLY_SIZE]));
@@ -243,8 +243,8 @@ fn query_cache_reports_count_bytes_metric_on_invalidation() {
     );
     assert_eq!(0, m.hits.get());
     assert_eq!(1, m.misses.get());
-    let count_bytes = m.count_bytes.get();
-    assert!(((count_bytes - initial_count_bytes) as usize) > BIG_REPLY_SIZE);
+    let memory_bytes = m.count_bytes.get();
+    assert!(((memory_bytes - initial_memory_bytes) as usize) > BIG_REPLY_SIZE);
 
     // Bump up the version
     test.canister_state_mut(a_id).system_state.canister_version += 1;
@@ -255,8 +255,8 @@ fn query_cache_reports_count_bytes_metric_on_invalidation() {
     let m = query_cache_metrics(&test);
     assert_eq!(0, m.hits.get());
     assert_eq!(1, m.misses.get());
-    let final_count_bytes = m.count_bytes.get();
-    assert!((final_count_bytes as usize) < BIG_REPLY_SIZE);
+    let final_memory_bytes = m.count_bytes.get();
+    assert!((final_memory_bytes as usize) < BIG_REPLY_SIZE);
 }
 
 #[test]
@@ -765,18 +765,18 @@ fn query_cache_frees_memory_after_invalidated_entries() {
         .build();
     let id = test.canister_from_wat(QUERY_CACHE_WAT).unwrap();
 
-    let count_bytes = query_cache(&test).count_bytes();
+    let memory_bytes = query_cache(&test).memory_bytes();
     // Initially the cache should be empty, i.e. less than 1MB.
-    assert!(count_bytes < BIG_RESPONSE_SIZE);
+    assert!(memory_bytes < BIG_RESPONSE_SIZE);
 
     // The 1MB result will be cached internally.
     let res = test
         .non_replicated_query(id, "canister_balance_sized_reply", vec![])
         .unwrap();
-    assert_eq!(BIG_RESPONSE_SIZE, res.count_bytes());
-    let count_bytes = query_cache(&test).count_bytes();
+    assert_eq!(BIG_RESPONSE_SIZE, res.memory_bytes());
+    let memory_bytes = query_cache(&test).memory_bytes();
     // After the first reply, the cache should have more than 1MB of data.
-    assert!(count_bytes > BIG_RESPONSE_SIZE);
+    assert!(memory_bytes > BIG_RESPONSE_SIZE);
 
     // Set the canister balance to 42, so the second reply will have just 42 bytes.
     test.canister_state_mut(id).system_state.remove_cycles(
@@ -788,11 +788,11 @@ fn query_cache_frees_memory_after_invalidated_entries() {
     let res = test
         .non_replicated_query(id, "canister_balance_sized_reply", vec![])
         .unwrap();
-    assert_eq!(SMALL_RESPONSE_SIZE, res.count_bytes());
-    let count_bytes = query_cache(&test).count_bytes();
+    assert_eq!(SMALL_RESPONSE_SIZE, res.memory_bytes());
+    let memory_bytes = query_cache(&test).memory_bytes();
     // The second 42 reply should invalidate and replace the first 1MB reply in the cache.
-    assert!(count_bytes > SMALL_RESPONSE_SIZE);
-    assert!(count_bytes < BIG_RESPONSE_SIZE);
+    assert!(memory_bytes > SMALL_RESPONSE_SIZE);
+    assert!(memory_bytes < BIG_RESPONSE_SIZE);
 }
 
 #[test]
@@ -803,8 +803,8 @@ fn query_cache_respects_cache_capacity() {
     let id = test.universal_canister().unwrap();
 
     // Initially the cache should be empty, i.e. less than REPLY_SIZE.
-    let count_bytes = query_cache(&test).count_bytes();
-    assert!(count_bytes < REPLY_SIZE);
+    let memory_bytes = query_cache(&test).memory_bytes();
+    assert!(memory_bytes < REPLY_SIZE);
 
     // All replies should hit the same cache entry.
     for _ in 0..ITERATIONS {
@@ -812,9 +812,9 @@ fn query_cache_respects_cache_capacity() {
         let _res =
             test.non_replicated_query(id, "query", wasm().reply_data(&[1; REPLY_SIZE / 2]).build());
         // Now there should be only one reply in the cache.
-        let count_bytes = query_cache(&test).count_bytes();
-        assert!(count_bytes > REPLY_SIZE);
-        assert!(count_bytes < QUERY_CACHE_CAPACITY);
+        let memory_bytes = query_cache(&test).memory_bytes();
+        assert!(memory_bytes > REPLY_SIZE);
+        assert!(memory_bytes < QUERY_CACHE_CAPACITY);
     }
 
     // Now the replies should hit another entry.
@@ -822,9 +822,9 @@ fn query_cache_respects_cache_capacity() {
         let _res =
             test.non_replicated_query(id, "query", wasm().reply_data(&[2; REPLY_SIZE / 2]).build());
         // Now there should be two replies in the cache.
-        let count_bytes = query_cache(&test).count_bytes();
-        assert!(count_bytes > REPLY_SIZE * 2);
-        assert!(count_bytes < QUERY_CACHE_CAPACITY);
+        let memory_bytes = query_cache(&test).memory_bytes();
+        assert!(memory_bytes > REPLY_SIZE * 2);
+        assert!(memory_bytes < QUERY_CACHE_CAPACITY);
     }
 
     // Now the replies should evict the first entry.
@@ -832,9 +832,9 @@ fn query_cache_respects_cache_capacity() {
         let _res =
             test.non_replicated_query(id, "query", wasm().reply_data(&[3; REPLY_SIZE / 2]).build());
         // There should be still just two replies in the cache.
-        let count_bytes = query_cache(&test).count_bytes();
-        assert!(count_bytes > REPLY_SIZE * 2);
-        assert!(count_bytes < QUERY_CACHE_CAPACITY);
+        let memory_bytes = query_cache(&test).memory_bytes();
+        assert!(memory_bytes > REPLY_SIZE * 2);
+        assert!(memory_bytes < QUERY_CACHE_CAPACITY);
     }
 }
 
@@ -844,13 +844,13 @@ fn query_cache_works_with_zero_cache_capacity() {
     let id = test.universal_canister().unwrap();
 
     // Even with zero capacity the cache data structure uses some bytes for the pointers etc.
-    let initial_count_bytes = query_cache(&test).count_bytes();
+    let initial_memory_bytes = query_cache(&test).memory_bytes();
 
     // Replies should not change the initial (zero) capacity.
     for _ in 0..ITERATIONS {
         let _res = test.non_replicated_query(id, "query", wasm().reply_data(&[1]).build());
-        let count_bytes = query_cache(&test).count_bytes();
-        assert_eq!(initial_count_bytes, count_bytes);
+        let memory_bytes = query_cache(&test).memory_bytes();
+        assert_eq!(initial_memory_bytes, memory_bytes);
     }
 }
 

--- a/rs/interfaces/src/execution_environment/errors.rs
+++ b/rs/interfaces/src/execution_environment/errors.rs
@@ -1,6 +1,6 @@
 use ic_base_types::{NumBytes, PrincipalIdBlobParseError};
 use ic_error_types::UserError;
-use ic_types::{methods::WasmMethod, CanisterId, CountBytes, Cycles, NumInstructions};
+use ic_types::{methods::WasmMethod, CanisterId, Cycles, MemoryDiskBytes, NumInstructions};
 use ic_wasm_types::{
     doc_ref, AsErrorHelp, ErrorHelp, WasmEngineError, WasmInstrumentationError, WasmValidationError,
 };
@@ -385,9 +385,13 @@ impl std::fmt::Display for HypervisorError {
     }
 }
 
-impl CountBytes for HypervisorError {
-    fn count_bytes(&self) -> usize {
+impl MemoryDiskBytes for HypervisorError {
+    fn memory_bytes(&self) -> usize {
         std::mem::size_of::<Self>()
+    }
+
+    fn disk_bytes(&self) -> usize {
+        0
     }
 }
 

--- a/rs/types/types/src/ingress.rs
+++ b/rs/types/types/src/ingress.rs
@@ -1,7 +1,7 @@
 //! Ingress types.
 
 use crate::artifact::IngressMessageId;
-use crate::{CanisterId, CountBytes, PrincipalId, Time, UserId};
+use crate::{CanisterId, MemoryDiskBytes, PrincipalId, Time, UserId};
 use ic_error_types::{ErrorCode, UserError};
 #[cfg(test)]
 use ic_exhaustive_derive::ExhaustiveSet;
@@ -107,7 +107,7 @@ impl IngressStatus {
     pub fn payload_bytes(&self) -> usize {
         match self {
             IngressStatus::Known { state, .. } => match state {
-                IngressState::Completed(result) => result.count_bytes(),
+                IngressState::Completed(result) => result.memory_bytes(),
                 IngressState::Failed(error) => error.description().as_bytes().len(),
                 _ => 0,
             },
@@ -176,12 +176,16 @@ pub enum WasmResult {
     Reject(String),
 }
 
-impl CountBytes for WasmResult {
-    fn count_bytes(&self) -> usize {
+impl MemoryDiskBytes for WasmResult {
+    fn memory_bytes(&self) -> usize {
         match self {
             WasmResult::Reply(bytes) => bytes.len(),
             WasmResult::Reject(string) => string.as_bytes().len(),
         }
+    }
+
+    fn disk_bytes(&self) -> usize {
+        0
     }
 }
 

--- a/rs/types/types/src/lib.rs
+++ b/rs/types/types/src/lib.rs
@@ -529,6 +529,8 @@ pub trait CountBytes {
     fn count_bytes(&self) -> usize;
 }
 
+/// Allow an object to reprt its own byte size on disk and in memory. Not
+/// necessarilly exact.
 pub trait MemoryDiskBytes {
     fn memory_bytes(&self) -> usize;
     fn disk_bytes(&self) -> usize;

--- a/rs/types/types/src/lib.rs
+++ b/rs/types/types/src/lib.rs
@@ -529,30 +529,54 @@ pub trait CountBytes {
     fn count_bytes(&self) -> usize;
 }
 
-impl CountBytes for Time {
-    fn count_bytes(&self) -> usize {
+pub trait MemoryDiskBytes {
+    fn memory_bytes(&self) -> usize;
+    fn disk_bytes(&self) -> usize;
+}
+
+impl MemoryDiskBytes for Time {
+    fn memory_bytes(&self) -> usize {
         8
+    }
+
+    fn disk_bytes(&self) -> usize {
+        0
     }
 }
 
-impl<T: CountBytes, E: CountBytes> CountBytes for Result<T, E> {
-    fn count_bytes(&self) -> usize {
+impl<T: MemoryDiskBytes, E: MemoryDiskBytes> MemoryDiskBytes for Result<T, E> {
+    fn memory_bytes(&self) -> usize {
         match self {
-            Ok(result) => result.count_bytes(),
-            Err(err) => err.count_bytes(),
+            Ok(result) => result.memory_bytes(),
+            Err(err) => err.memory_bytes(),
+        }
+    }
+
+    fn disk_bytes(&self) -> usize {
+        match self {
+            Ok(result) => result.disk_bytes(),
+            Err(err) => err.disk_bytes(),
         }
     }
 }
 
-impl<T: CountBytes> CountBytes for Arc<T> {
-    fn count_bytes(&self) -> usize {
-        self.as_ref().count_bytes()
+impl<T: MemoryDiskBytes> MemoryDiskBytes for Arc<T> {
+    fn memory_bytes(&self) -> usize {
+        self.as_ref().memory_bytes()
+    }
+
+    fn disk_bytes(&self) -> usize {
+        self.as_ref().disk_bytes()
     }
 }
 
-// Implementing `CountBytes` in `ic_error_types` introduces a circular dependency.
-impl CountBytes for ic_error_types::UserError {
-    fn count_bytes(&self) -> usize {
+// Implementing `MemoryDiskBytes` in `ic_error_types` introduces a circular dependency.
+impl MemoryDiskBytes for ic_error_types::UserError {
+    fn memory_bytes(&self) -> usize {
         self.count_bytes()
+    }
+
+    fn disk_bytes(&self) -> usize {
+        0
     }
 }

--- a/rs/types/wasm_types/src/lib.rs
+++ b/rs/types/wasm_types/src/lib.rs
@@ -6,7 +6,7 @@ pub use errors::{
     doc_ref, AsErrorHelp, ErrorHelp, WasmEngineError, WasmError, WasmInstrumentationError,
     WasmValidationError,
 };
-use ic_types::CountBytes;
+use ic_types::MemoryDiskBytes;
 use ic_utils::byte_slice_fmt::truncate_and_format;
 use ic_validate_eq::ValidateEq;
 use ic_validate_eq_derive::ValidateEq;
@@ -174,9 +174,13 @@ impl TryFrom<Vec<u8>> for WasmHash {
     }
 }
 
-impl CountBytes for WasmHash {
-    fn count_bytes(&self) -> usize {
+impl MemoryDiskBytes for WasmHash {
+    fn memory_bytes(&self) -> usize {
         self.0.len()
+    }
+
+    fn disk_bytes(&self) -> usize {
+        0
     }
 }
 

--- a/rs/utils/lru_cache/BUILD.bazel
+++ b/rs/utils/lru_cache/BUILD.bazel
@@ -17,7 +17,9 @@ rust_library(
 rust_test(
     name = "lru_cache_test",
     crate = ":lru_cache",
-    deps = [],
+    deps = [
+        "@crate_index//:proptest",
+    ],
 )
 
 rust_doc_test(

--- a/rs/utils/lru_cache/Cargo.toml
+++ b/rs/utils/lru_cache/Cargo.toml
@@ -11,3 +11,6 @@ documentation.workspace = true
 [dependencies]
 ic-types = { path = "../../types/types" }
 lru = { version = "0.7.8", default-features = false }
+
+[dev-dependencies]
+proptest = { workspace = true }

--- a/rs/utils/lru_cache/src/lib.rs
+++ b/rs/utils/lru_cache/src/lib.rs
@@ -1,4 +1,4 @@
-use ic_types::{CountBytes, NumBytes};
+use ic_types::{MemoryDiskBytes, NumBytes};
 use std::hash::Hash;
 
 /// The upper bound on cache item size and cache capacity.
@@ -11,38 +11,48 @@ const MAX_SIZE: usize = usize::MAX / 2;
 /// sizes of the cached items does not exceed the pre-configured capacity.
 pub struct LruCache<K, V>
 where
-    K: CountBytes + Eq + Hash,
-    V: CountBytes,
+    K: MemoryDiskBytes + Eq + Hash,
+    V: MemoryDiskBytes,
 {
     cache: lru::LruCache<K, V>,
-    capacity: usize,
-    size: usize,
+    memory_capacity: usize,
+    disk_capacity: usize,
+    memory_size: usize,
+    disk_size: usize,
 }
 
-impl<K, V> CountBytes for LruCache<K, V>
+impl<K, V> MemoryDiskBytes for LruCache<K, V>
 where
-    K: CountBytes + Eq + Hash,
-    V: CountBytes,
+    K: MemoryDiskBytes + Eq + Hash,
+    V: MemoryDiskBytes,
 {
-    fn count_bytes(&self) -> usize {
-        self.size
+    fn memory_bytes(&self) -> usize {
+        self.memory_size
+    }
+
+    fn disk_bytes(&self) -> usize {
+        self.disk_size
     }
 }
 
 impl<K, V> LruCache<K, V>
 where
-    K: CountBytes + Eq + Hash,
-    V: CountBytes,
+    K: MemoryDiskBytes + Eq + Hash,
+    V: MemoryDiskBytes,
 {
-    /// Constructs a new LRU cache with the given capacity.
-    /// The capacity must not exceed `MAX_SIZE = (2^63 - 1)`.
-    pub fn new(capacity: NumBytes) -> Self {
-        let capacity = capacity.get() as usize;
-        assert!(capacity <= MAX_SIZE);
+    /// Constructs a new LRU cache with the given memory and disk capacity.  The
+    /// capacities must not exceed `MAX_SIZE = (2^63 - 1)`.
+    pub fn new(memory_capacity: NumBytes, disk_capacity: NumBytes) -> Self {
+        let memory_capacity = memory_capacity.get() as usize;
+        let disk_capacity = disk_capacity.get() as usize;
+        assert!(memory_capacity <= MAX_SIZE);
+        assert!(disk_capacity <= MAX_SIZE);
         let lru_cache = Self {
             cache: lru::LruCache::unbounded(),
-            capacity,
-            size: 0,
+            memory_capacity,
+            disk_capacity,
+            memory_size: 0,
+            disk_size: 0,
         };
         lru_cache.check_invariants();
         lru_cache
@@ -50,7 +60,10 @@ where
 
     /// Creates a new LRU Cache that never automatically evicts items.
     pub fn unbounded() -> Self {
-        Self::new(NumBytes::new(MAX_SIZE as u64))
+        Self::new(
+            NumBytes::new(MAX_SIZE as u64),
+            NumBytes::new(MAX_SIZE as u64),
+        )
     }
 
     /// Returns the value corresponding to the given key.
@@ -63,21 +76,31 @@ where
     /// the cache or other cache entries are evicted (due to the cache capacity),
     /// then it returns the old entry's key-value pairs. Otherwise, returns an empty vector.
     pub fn push(&mut self, key: K, value: V) -> Vec<(K, V)> {
-        let size = key.count_bytes() + value.count_bytes();
-        assert!(size <= MAX_SIZE);
+        let memory_size = key.memory_bytes() + value.memory_bytes();
+        assert!(memory_size <= MAX_SIZE);
+        let disk_size = key.disk_bytes() + value.disk_bytes();
+        assert!(disk_size <= MAX_SIZE);
 
         let removed_entry = self.cache.push(key, value);
         if let Some((removed_key, removed_value)) = &removed_entry {
-            let removed_size = removed_key.count_bytes() + removed_value.count_bytes();
-            debug_assert!(self.size >= removed_size);
-            // This cannot underflow because we know that `self.size` is
+            let memory_removed_size = removed_key.memory_bytes() + removed_value.memory_bytes();
+            debug_assert!(self.memory_size >= memory_removed_size);
+            // This cannot underflow because we know that `self.memory_size` is
             // the sum of sizes of all items in the cache.
-            self.size -= removed_size;
+            self.memory_size -= memory_removed_size;
+
+            let disk_removed_size = removed_key.disk_bytes() + removed_value.disk_bytes();
+            debug_assert!(self.disk_size >= disk_removed_size);
+            // This cannot underflow because we know that `self.disk_size` is
+            // the sum of sizes of all items in the cache.
+            self.disk_size -= disk_removed_size;
         }
         // This cannot overflow because we know that
-        // `self.size <= self.capacity <= MAX_SIZE`
-        // and `size <= MAX_SIZE == usize::MAX / 2`.
-        self.size += size;
+        // `self.memory_size <= self.memory_capacity <= MAX_SIZE`
+        // and `memory_size <= MAX_SIZE == usize::MAX / 2`.
+        self.memory_size += memory_size;
+        // Similar as for `memory_size``.
+        self.disk_size += disk_size;
         let mut evicted_entries = self.evict();
         self.check_invariants();
 
@@ -89,9 +112,14 @@ where
     /// `None` if it does not exist.
     pub fn pop(&mut self, key: &K) -> Option<V> {
         if let Some((key, value)) = self.cache.pop_entry(key) {
-            let size = key.count_bytes() + value.count_bytes();
-            debug_assert!(self.size >= size);
-            self.size -= size;
+            let memory_size = key.memory_bytes() + value.memory_bytes();
+            debug_assert!(self.memory_size >= memory_size);
+            self.memory_size -= memory_size;
+
+            let disk_size = key.disk_bytes() + value.disk_bytes();
+            debug_assert!(self.disk_size >= disk_size);
+            self.disk_size -= disk_size;
+
             self.check_invariants();
             Some(value)
         } else {
@@ -102,7 +130,8 @@ where
     /// Clears the cache by removing all items.
     pub fn clear(&mut self) {
         self.cache.clear();
-        self.size = 0;
+        self.memory_size = 0;
+        self.disk_size = 0;
         self.check_invariants();
     }
 
@@ -120,14 +149,20 @@ where
     /// Returns the vector of evicted key-value pairs.
     fn evict(&mut self) -> Vec<(K, V)> {
         let mut ret = vec![];
-        while self.size > self.capacity {
+        while self.memory_size > self.memory_capacity || self.disk_size > self.disk_capacity {
             match self.cache.pop_lru() {
                 Some((key, value)) => {
-                    let size = key.count_bytes() + value.count_bytes();
-                    debug_assert!(self.size >= size);
-                    // This cannot underflow because we know that `self.size` is
-                    // the sum of sizes of all items in the cache.
-                    self.size -= size;
+                    let memory_size = key.memory_bytes() + value.memory_bytes();
+                    debug_assert!(self.memory_size >= memory_size);
+                    // This cannot underflow because we know that `self.memory_size` is
+                    // the sum of memory sizes of all items in the cache.
+                    self.memory_size -= memory_size;
+
+                    let disk_size = key.disk_bytes() + value.disk_bytes();
+                    debug_assert!(self.disk_size >= disk_size);
+                    // This cannot underflow because we know that `self.disk_size` is
+                    // the sum of disk sizes of all items in the cache.
+                    self.disk_size -= disk_size;
 
                     ret.push((key, value));
                 }
@@ -143,14 +178,22 @@ where
         #[cfg(debug_assertions)]
         if self.len() < 1_000 {
             debug_assert_eq!(
-                self.size,
+                self.memory_size,
                 self.cache
                     .iter()
-                    .map(|(key, value)| key.count_bytes() + value.count_bytes())
+                    .map(|(key, value)| key.memory_bytes() + value.memory_bytes())
+                    .sum::<usize>()
+            );
+            debug_assert_eq!(
+                self.disk_size,
+                self.cache
+                    .iter()
+                    .map(|(key, value)| key.disk_bytes() + value.disk_bytes())
                     .sum::<usize>()
             );
         }
-        debug_assert!(self.size <= self.capacity);
+        debug_assert!(self.memory_size <= self.memory_capacity);
+        debug_assert!(self.disk_size <= self.disk_capacity);
     }
 }
 
@@ -161,24 +204,45 @@ mod tests {
     #[derive(Eq, PartialEq, Hash, Debug)]
     struct ValueSize(u32, usize);
 
-    impl CountBytes for ValueSize {
-        fn count_bytes(&self) -> usize {
+    impl MemoryDiskBytes for ValueSize {
+        fn memory_bytes(&self) -> usize {
             self.1
+        }
+
+        fn disk_bytes(&self) -> usize {
+            0
+        }
+    }
+
+    #[derive(Eq, PartialEq, Hash, Debug)]
+    struct MemoryDiskValue(u32, usize, usize);
+
+    impl MemoryDiskBytes for MemoryDiskValue {
+        fn memory_bytes(&self) -> usize {
+            self.1
+        }
+
+        fn disk_bytes(&self) -> usize {
+            self.2
         }
     }
 
     #[derive(Eq, PartialEq, Hash, Debug)]
     struct Key(u32);
 
-    impl CountBytes for Key {
-        fn count_bytes(&self) -> usize {
+    impl MemoryDiskBytes for Key {
+        fn memory_bytes(&self) -> usize {
+            0
+        }
+
+        fn disk_bytes(&self) -> usize {
             0
         }
     }
 
     #[test]
     fn lru_cache_single_entry() {
-        let mut lru = LruCache::<Key, ValueSize>::new(NumBytes::new(10));
+        let mut lru = LruCache::<Key, ValueSize>::new(NumBytes::new(10), NumBytes::new(0));
 
         assert!(lru.get(&Key(0)).is_none());
 
@@ -201,7 +265,7 @@ mod tests {
 
     #[test]
     fn lru_cache_multiple_entries() {
-        let mut lru = LruCache::<Key, ValueSize>::new(NumBytes::new(10));
+        let mut lru = LruCache::<Key, ValueSize>::new(NumBytes::new(10), NumBytes::new(0));
 
         for i in 0..20 {
             lru.push(Key(i), ValueSize(i, 1));
@@ -219,7 +283,7 @@ mod tests {
 
     #[test]
     fn lru_cache_value_eviction() {
-        let mut lru = LruCache::<Key, ValueSize>::new(NumBytes::new(10));
+        let mut lru = LruCache::<Key, ValueSize>::new(NumBytes::new(10), NumBytes::new(0));
 
         assert!(lru.get(&Key(0)).is_none());
 
@@ -269,7 +333,7 @@ mod tests {
 
     #[test]
     fn lru_cache_key_eviction() {
-        let mut lru = LruCache::<ValueSize, ValueSize>::new(NumBytes::new(10));
+        let mut lru = LruCache::<ValueSize, ValueSize>::new(NumBytes::new(10), NumBytes::new(0));
 
         assert!(lru.get(&ValueSize(0, 10)).is_none());
 
@@ -325,7 +389,7 @@ mod tests {
 
     #[test]
     fn lru_cache_key_and_value_eviction() {
-        let mut lru = LruCache::<ValueSize, ValueSize>::new(NumBytes::new(10));
+        let mut lru = LruCache::<ValueSize, ValueSize>::new(NumBytes::new(10), NumBytes::new(0));
 
         let evicted = lru.push(ValueSize(0, 5), ValueSize(42, 5));
         assert_eq!(*lru.get(&ValueSize(0, 5)).unwrap(), ValueSize(42, 5));
@@ -359,7 +423,7 @@ mod tests {
 
     #[test]
     fn lru_cache_clear() {
-        let mut lru = LruCache::<Key, ValueSize>::new(NumBytes::new(10));
+        let mut lru = LruCache::<Key, ValueSize>::new(NumBytes::new(10), NumBytes::new(0));
         lru.push(Key(0), ValueSize(0, 10));
         lru.clear();
         assert!(lru.get(&Key(0)).is_none());
@@ -367,7 +431,7 @@ mod tests {
 
     #[test]
     fn lru_cache_pop() {
-        let mut lru = LruCache::<Key, ValueSize>::new(NumBytes::new(10));
+        let mut lru = LruCache::<Key, ValueSize>::new(NumBytes::new(10), NumBytes::new(0));
         lru.push(Key(0), ValueSize(0, 5));
         lru.push(Key(1), ValueSize(1, 5));
         lru.pop(&Key(0));
@@ -379,25 +443,160 @@ mod tests {
 
     #[test]
     fn lru_cache_count_bytes_and_len() {
-        let mut lru = LruCache::<Key, ValueSize>::new(NumBytes::new(10));
-        assert_eq!(0, lru.count_bytes());
+        let mut lru = LruCache::<Key, MemoryDiskValue>::new(NumBytes::new(10), NumBytes::new(20));
+        assert_eq!(0, lru.memory_bytes());
+        assert_eq!(0, lru.disk_bytes());
         assert_eq!(0, lru.len());
         assert!(lru.is_empty());
-        lru.push(Key(0), ValueSize(0, 4));
-        assert_eq!(4, lru.count_bytes());
+        lru.push(Key(0), MemoryDiskValue(0, 4, 10));
+        assert_eq!(4, lru.memory_bytes());
+        assert_eq!(10, lru.disk_bytes());
         assert_eq!(1, lru.len());
         assert!(!lru.is_empty());
-        lru.push(Key(1), ValueSize(1, 6));
-        assert_eq!(10, lru.count_bytes());
+        lru.push(Key(1), MemoryDiskValue(1, 6, 2));
+        assert_eq!(10, lru.memory_bytes());
+        assert_eq!(12, lru.disk_bytes());
         assert_eq!(2, lru.len());
         assert!(!lru.is_empty());
         lru.pop(&Key(0));
-        assert_eq!(6, lru.count_bytes());
+        assert_eq!(6, lru.memory_bytes());
+        assert_eq!(2, lru.disk_bytes());
         assert_eq!(1, lru.len());
         assert!(!lru.is_empty());
         lru.pop(&Key(1));
-        assert_eq!(0, lru.count_bytes());
+        assert_eq!(0, lru.memory_bytes());
+        assert_eq!(0, lru.disk_bytes());
         assert_eq!(0, lru.len());
         assert!(lru.is_empty());
+    }
+
+    #[test]
+    fn lru_cache_disk_and_memory_single_entry() {
+        let mut lru = LruCache::<Key, MemoryDiskValue>::new(NumBytes::new(10), NumBytes::new(20));
+
+        assert!(lru.get(&Key(0)).is_none());
+
+        // Can't insert a value if memory or disk is too large.
+        let evicted = lru.push(Key(0), MemoryDiskValue(42, 11, 0));
+        assert_eq!(lru.get(&Key(0)), None);
+        assert_eq!(evicted, vec![(Key(0), MemoryDiskValue(42, 11, 0))]);
+
+        let evicted = lru.push(Key(0), MemoryDiskValue(42, 0, 21));
+        assert_eq!(lru.get(&Key(0)), None);
+        assert_eq!(evicted, vec![(Key(0), MemoryDiskValue(42, 0, 21))]);
+
+        // Can insert if both sizes fit.
+        let evicted = lru.push(Key(0), MemoryDiskValue(42, 10, 20));
+        assert_eq!(*lru.get(&Key(0)).unwrap(), MemoryDiskValue(42, 10, 20));
+        assert_eq!(evicted, vec![]);
+
+        // Inserting a new value removes the old one if memory or disk is
+        // non-zero (since both are at capacity).
+        let evicted = lru.push(Key(1), MemoryDiskValue(42, 1, 0));
+        assert_eq!(*lru.get(&Key(1)).unwrap(), MemoryDiskValue(42, 1, 0));
+        assert_eq!(evicted, vec![(Key(0), MemoryDiskValue(42, 10, 20))]);
+
+        lru.clear();
+        let _ = lru.push(Key(0), MemoryDiskValue(42, 10, 20));
+        let evicted = lru.push(Key(1), MemoryDiskValue(42, 0, 1));
+        assert_eq!(*lru.get(&Key(1)).unwrap(), MemoryDiskValue(42, 0, 1));
+        assert_eq!(evicted, vec![(Key(0), MemoryDiskValue(42, 10, 20))]);
+    }
+
+    #[test]
+    fn lru_cache_key_and_value_eviction_mixing_memory_and_disk() {
+        let mut lru =
+            LruCache::<MemoryDiskValue, MemoryDiskValue>::new(NumBytes::new(10), NumBytes::new(10));
+
+        let evicted = lru.push(MemoryDiskValue(0, 5, 1), MemoryDiskValue(42, 5, 1));
+        assert_eq!(
+            *lru.get(&MemoryDiskValue(0, 5, 1)).unwrap(),
+            MemoryDiskValue(42, 5, 1)
+        );
+        assert_eq!(evicted, vec![]);
+
+        let evicted = lru.push(MemoryDiskValue(1, 0, 0), MemoryDiskValue(20, 0, 0));
+        assert_eq!(
+            *lru.get(&MemoryDiskValue(0, 5, 1)).unwrap(),
+            MemoryDiskValue(42, 5, 1)
+        );
+        assert_eq!(
+            *lru.get(&MemoryDiskValue(1, 0, 0)).unwrap(),
+            MemoryDiskValue(20, 0, 0)
+        );
+        assert_eq!(evicted, vec![]);
+
+        let evicted = lru.push(MemoryDiskValue(2, 5, 1), MemoryDiskValue(10, 5, 1));
+        assert!(lru.get(&MemoryDiskValue(0, 5, 1)).is_none());
+        assert_eq!(
+            *lru.get(&MemoryDiskValue(1, 0, 0)).unwrap(),
+            MemoryDiskValue(20, 0, 0)
+        );
+        assert_eq!(
+            *lru.get(&MemoryDiskValue(2, 5, 1)).unwrap(),
+            MemoryDiskValue(10, 5, 1)
+        );
+        // The least recently used is the first entry.
+        assert_eq!(
+            evicted,
+            vec![(MemoryDiskValue(0, 5, 1), MemoryDiskValue(42, 5, 1))]
+        );
+
+        let evicted = lru.push(MemoryDiskValue(3, 4, 9), MemoryDiskValue(30, 0, 1));
+        assert!(lru.get(&MemoryDiskValue(1, 0, 0)).is_none());
+        assert!(lru.get(&MemoryDiskValue(2, 5, 1)).is_none());
+        assert_eq!(
+            *lru.get(&MemoryDiskValue(3, 4, 9)).unwrap(),
+            MemoryDiskValue(30, 0, 1)
+        );
+        // Now the second and third entries are evicted.
+        assert_eq!(
+            evicted,
+            vec![
+                (MemoryDiskValue(1, 0, 0), MemoryDiskValue(20, 0, 0)),
+                (MemoryDiskValue(2, 5, 1), MemoryDiskValue(10, 5, 1))
+            ]
+        );
+    }
+
+    mod proptests {
+        use super::*;
+        use proptest::prelude::*;
+
+        fn arb_value() -> impl Strategy<Value = MemoryDiskValue> {
+            (0..100_u32, 0..50_usize, 0..50_usize).prop_map(|(a, b, c)| MemoryDiskValue(a, b, c))
+        }
+
+        proptest! {
+            /// Proptest checking that the internal invariants are maintained
+            /// and that the total space of inserted entries equals the total
+            /// space of evicted entries plus the space of the cache itself.
+            #[test]
+            fn test_invariants(entries in prop::collection::vec((arb_value(), arb_value()), 100)) {
+                let mut lru = LruCache::<MemoryDiskValue, MemoryDiskValue>::new(NumBytes::new(100), NumBytes::new(100));
+                let mut total_memory = 0;
+                let mut total_disk = 0;
+                let mut evicted_memory = 0;
+                let mut evicted_disk = 0;
+
+                fn update(memory: &mut usize, disk: &mut usize, k: &MemoryDiskValue, v: &MemoryDiskValue) {
+                    *memory += k.memory_bytes();
+                    *memory += v.memory_bytes();
+                    *disk += k.disk_bytes();
+                    *disk += v.disk_bytes();
+                }
+
+                for (k,v) in entries {
+                    update(&mut total_memory, &mut total_disk, &k, &v);
+                    let evicted = lru.push(k,v);
+                    for (k,v) in evicted {
+                        update(&mut evicted_memory, &mut evicted_disk, &k, &v);
+                    }
+
+                    assert_eq!(total_memory, evicted_memory + lru.memory_bytes());
+                    assert_eq!(total_disk, evicted_disk + lru.disk_bytes());
+                }
+            }
+        }
     }
 }

--- a/rs/utils/lru_cache/src/lib.rs
+++ b/rs/utils/lru_cache/src/lib.rs
@@ -156,13 +156,13 @@ where
                     debug_assert!(self.memory_size >= memory_size);
                     // This cannot underflow because we know that `self.memory_size` is
                     // the sum of memory sizes of all items in the cache.
-                    self.memory_size -= memory_size;
+                    self.memory_size = self.memory_size.saturating_sub(memory_size);
 
                     let disk_size = key.disk_bytes() + value.disk_bytes();
                     debug_assert!(self.disk_size >= disk_size);
                     // This cannot underflow because we know that `self.disk_size` is
                     // the sum of disk sizes of all items in the cache.
-                    self.disk_size -= disk_size;
+                    self.disk_size = self.disk_size.saturating_sub(disk_size);
 
                     ret.push((key, value));
                 }


### PR DESCRIPTION
EXC-1795

Add the ability for the LRU cache to limit space used on disk as well as in memory and use this in the `CompilationCache` so that it doesn't grow to large.