### PR TITLE
feat(governance): Enable periodic confirmation.

### DIFF
--- a/rs/nns/governance/canbench/canbench_results.yml
+++ b/rs/nns/governance/canbench/canbench_results.yml
@@ -55,7 +55,7 @@ benches:
     scopes: {}
   compute_ballots_for_new_proposal_with_stable_neurons:
     total:
-      instructions: 2019526
+      instructions: 2197226
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
@@ -85,7 +85,7 @@ benches:
     scopes: {}
   list_neurons_heap:
     total:
-      instructions: 4345595
+      instructions: 4700995
       heap_increase: 9
       stable_memory_increase: 0
     scopes: {}
@@ -133,13 +133,13 @@ benches:
     scopes: {}
   neuron_metrics_calculation_heap:
     total:
-      instructions: 954474
+      instructions: 1457674
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   neuron_metrics_calculation_stable:
     total:
-      instructions: 2479136
+      instructions: 2982336
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}

--- a/rs/nns/governance/src/lib.rs
+++ b/rs/nns/governance/src/lib.rs
@@ -196,9 +196,9 @@ pub const DEFAULT_VOTING_POWER_REFRESHED_TIMESTAMP_SECONDS: u64 = 1725148800;
 // amount of time.
 thread_local! {
 
-    static IS_VOTING_POWER_ADJUSTMENT_ENABLED: Cell<bool> = const { Cell::new(cfg!(feature = "test")) };
+    static IS_VOTING_POWER_ADJUSTMENT_ENABLED: Cell<bool> = const { Cell::new(true) };
 
-    static IS_PRUNE_FOLLOWING_ENABLED: Cell<bool> = const { Cell::new(cfg!(feature = "test")) };
+    static IS_PRUNE_FOLLOWING_ENABLED: Cell<bool> = const { Cell::new(true) };
 
     // TODO(NNS1-3247): To release the feature, set this to true. Do not simply
     // delete. That way, if we need to recall the feature, we can do that via a

--- a/rs/nns/governance/unreleased_changelog.md
+++ b/rs/nns/governance/unreleased_changelog.md
@@ -59,8 +59,12 @@ the neuron. More precisely,
 1. If a neuron has not refreshed in 6 months, then votes have less influence on
    the outcome of proposals.
 
-2. If a neuron has not refreshed in 7 months, it stops following other neurons
-   (except on the NeuronManagement topic; those followees are retained).
+2. If a neuron has not refreshed in 7 months,
+
+    a. It stops following other neurons (except on the NeuronManagement topic;
+       those followees are retained).
+
+    b. Its influence on proposals goes to 0.
 
 ## Changed
 

--- a/rs/nns/governance/unreleased_changelog.md
+++ b/rs/nns/governance/unreleased_changelog.md
@@ -34,6 +34,21 @@ links to keepachangelog.com as its source of inspiration.
 
 ## Added
 
+### Periodic Confirmation
+
+Enabled voting power adjustment and follow pruning.
+
+This feature was proposed and approved in motion [proposal 132411].
+
+[proposal 132411]: https://dashboard.internetcomputer.org/proposal/132411
+
+We have already been recording how long it's been since neurons refreshed their
+voting power/following. We also supported refreshing. Those who have never
+refreshed are considered as having refreshed on Sep 1, 2024.
+
+With this enablement, not refreshing for > 6 months will start to affect the
+neuron.
+
 ## Changed
 
 ## Deprecated

--- a/rs/nns/governance/unreleased_changelog.md
+++ b/rs/nns/governance/unreleased_changelog.md
@@ -38,16 +38,29 @@ links to keepachangelog.com as its source of inspiration.
 
 Enabled voting power adjustment and follow pruning.
 
+#### Prior Work
+
+This section describes related changes in previous releases.
+
+We already started recording how long it's been since neurons have confirmed
+their following (aka refreshed voting power). Neurons were also given the
+ability to confirm their following. Those who have never confirmed are
+considered as having refreshed on Sep 1, 2024.
+
 This feature was proposed and approved in motion [proposal 132411].
 
 [proposal 132411]: https://dashboard.internetcomputer.org/proposal/132411
 
-We have already been recording how long it's been since neurons refreshed their
-voting power/following. We also supported refreshing. Those who have never
-refreshed are considered as having refreshed on Sep 1, 2024.
+#### New Behavior(s) (In This Release)
 
-With this enablement, not refreshing for > 6 months will start to affect the
-neuron.
+With this enablement, not refreshing for more than 6 months will start to affect
+the neuron. More precisely,
+
+1. If a neuron has not refreshed in 6 months, then votes have less influence on
+   the outcome of proposals.
+
+2. If a neuron has not refreshed in 7 months, it stops following other neurons
+   (except on the NeuronManagement topic; those followees are retained).
 
 ## Changed
 


### PR DESCRIPTION
This is done by flipping a couple of flags.

This is the last step in the release of "periodic confirmation". There is still some post-launch follow up work.

All the usual consequences of this being a flag flip apply. In particular, if we need to roll back, it will be fairly easy and low risk.

This causes a performance regression for metrics. [A ticket][regression] has been opened to follow up on that. For now, this has been deemed acceptable, because metrics are calculated in the background, and is performed infrequently.

[regression]: https://dfinity.atlassian.net/browse/NNS1-3535

# References

This is part of the "periodic confirmation" feature that was recently approved in proposal [132411][prop].

[prop]: https://dashboard.internetcomputer.org/proposal/132411

Closes [NNS1-3444].

[NNS1-3444]: https://dfinity.atlassian.net/browse/NNS1-3444