### PR TITLE
feat: [NODE-1499] Run chown/chmod in setup-permissions in parallel

### DIFF
--- a/ic-os/components/ic/setup-permissions/erestorecon.sh
+++ b/ic-os/components/ic/setup-permissions/erestorecon.sh
@@ -5,4 +5,4 @@ set -e
 # erestorecon (easy prestorecon) uses UNIX tools to parallelize restorecon,
 # instead of the cpp based prestorecon.
 
-find $@ -print0 | xargs -0 -P 0 restorecon
+find $@ -print0 | xargs -0 -P 0 restorecon -F

--- a/ic-os/components/ic/setup-permissions/setup-permissions.sh
+++ b/ic-os/components/ic/setup-permissions/setup-permissions.sh
@@ -24,8 +24,8 @@ function make_group_owned_and_sticky() {
     local GROUP="$3"
 
     mkdir -p "${TARGET_DIR}"
-    chown -R "${USER}:${GROUP}" "${TARGET_DIR}"
-    chmod u=rwX,g=rX,o= -R "${TARGET_DIR}"
+    find "${TARGET_DIR}" -print0 | xargs -0 -P 0 chown "${USER}:${GROUP}"
+    find "${TARGET_DIR}" -print0 | xargs -0 -P 0 chmod u=rwX,g=rX,o=
     find "${TARGET_DIR}" -type d | xargs chmod g+s
 }
 


### PR DESCRIPTION
This further increases the speed of the [reboot toy](https://github.com/dfinity/ic/blob/36e2b45d4712908b8ddca1c05b50b8fc1d6562d1/rs/tests/node/BUILD.bazel#L31) from 56.578s to 33.395s.