### PR TITLE
feat(node): Add log-config service to GuestOS

### DIFF
--- a/ic-os/components/guestos.bzl
+++ b/ic-os/components/guestos.bzl
@@ -164,6 +164,6 @@ component_files = {
     # fstrim
     Label("fstrim/sync_fstrim.sh"): "/opt/ic/bin/sync_fstrim.sh",
 
-    # TODO(NODE-1519): delete update-config.service after switch to new icos config
+    # TODO(NODE-1518): delete update-config.service after switch to new icos config
     Label("misc/update-config/update-guestos-config.service"): "/etc/systemd/system/update-config.service",
 }

--- a/ic-os/components/guestos.bzl
+++ b/ic-os/components/guestos.bzl
@@ -63,6 +63,8 @@ component_files = {
     Label("misc/guestos/sysctl.d/privileged-ports.conf"): "/etc/sysctl.d/privileged-ports.conf",
     Label("misc/guestos/sysfs.d/hugepage.conf"): "/etc/sysfs.d/hugepage.conf",
     Label("misc/guestos/hsm/pcscd"): "/etc/default/pcscd",
+    Label("misc/log-config/log-config-guestos.service"): "/etc/systemd/system/log-config.service",
+    Label("misc/log-config/log-config.sh"): "/opt/ic/bin/log-config.sh",
 
     # monitoring
     Label("monitoring/filebeat/setup-filebeat-permissions.sh"): "/opt/ic/bin/setup-filebeat-permissions.sh",

--- a/ic-os/components/hostos.bzl
+++ b/ic-os/components/hostos.bzl
@@ -98,6 +98,6 @@ component_files = {
     Label("upgrade/systemd-generators/systemd-gpt-auto-generator"): "/etc/systemd/system-generators/systemd-gpt-auto-generator",
     Label("upgrade/install-upgrade.sh"): "/opt/ic/bin/install-upgrade.sh",
 
-    # TODO(NODE-1519): delete update-config.service after switch to new icos config
+    # TODO(NODE-1518): delete update-config.service after switch to new icos config
     Label("misc/update-config/update-hostos-config.service"): "/etc/systemd/system/update-config.service",
 }

--- a/ic-os/components/hostos.bzl
+++ b/ic-os/components/hostos.bzl
@@ -29,8 +29,6 @@ component_files = {
     Label("hostos-scripts/verbose-logging/verbose-logging.sh"): "/opt/ic/bin/verbose-logging.sh",
     Label("hostos-scripts/verbose-logging/verbose-logging.service"): "/etc/systemd/system/verbose-logging.service",
     Label("hostos-scripts/verbose-logging/logrotate.d/verbose-logging"): "/etc/logrotate.d/verbose-logging",
-    Label("hostos-scripts/log-config/log-config.service"): "/etc/systemd/system/log-config.service",
-    Label("hostos-scripts/log-config/log-config.sh"): "/opt/ic/bin/log-config.sh",
 
     # early-boot
     Label("early-boot/relabel-machine-id/relabel-machine-id.sh"): "/opt/ic/bin/relabel-machine-id.sh",
@@ -73,6 +71,8 @@ component_files = {
     Label("monitoring/metrics-proxy/metrics-proxy.service"): "/etc/systemd/system/metrics-proxy.service",
     Label("monitoring/journald.conf"): "/etc/systemd/journald.conf",
     Label("monitoring/logrotate/override.conf"): "/etc/systemd/system/logrotate.service.d/override.conf",
+    Label("misc/log-config/log-config-hostos.service"): "/etc/systemd/system/log-config.service",
+    Label("misc/log-config/log-config.sh"): "/opt/ic/bin/log-config.sh",
 
     # networking
     Label("networking/generate-network-config/hostos/generate-network-config.service"): "/etc/systemd/system/generate-network-config.service",

--- a/ic-os/components/misc/log-config/log-config-guestos.service
+++ b/ic-os/components/misc/log-config/log-config-guestos.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Log config partition
+After=bootstrap-ic-node.service
+Requires=bootstrap-ic-node.service
+After=update-config.service
+Wants=update-config.service
+
+[Service]
+Type=oneshot
+ExecStart=/opt/ic/bin/log-config.sh
+RemainAfterExit=true
+
+[Install]
+WantedBy=multi-user.target

--- a/ic-os/components/misc/log-config/log-config-hostos.service
+++ b/ic-os/components/misc/log-config/log-config-hostos.service
@@ -1,5 +1,7 @@
 [Unit]
-Description=Log HostOS config partition
+Description=Log config partition
+After=update-config.service
+Wants=update-config.service
 
 [Service]
 Type=oneshot

--- a/ic-os/components/misc/log-config/log-config.sh
+++ b/ic-os/components/misc/log-config/log-config.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 
 CONFIG_DIR="/boot/config"
-CONFIG="/boot/config/config.ini"
-DEPLOYMENT="/boot/config/deployment.json"
+CONFIG="/boot/config/config.json"
 
 log_directory_structure() {
     local dir=$1
@@ -28,7 +27,6 @@ log_file_contents() {
     fi
 }
 
-echo "Logging HostOS config partition"
+echo "Logging config partition"
 log_directory_structure "$CONFIG_DIR"
 log_file_contents "$CONFIG"
-log_file_contents "$DEPLOYMENT"

--- a/ic-os/guestos/defs.bzl
+++ b/ic-os/guestos/defs.bzl
@@ -55,7 +55,7 @@ def image_deps(mode, malicious = False):
             # additional libraries to install
             "//rs/ic_os/release:nss_icos": "/usr/lib/x86_64-linux-gnu/libnss_icos.so.2:0644",  # Allows referring to the guest IPv6 by name guestos from host, and host as hostos from guest.
 
-            # TODO(NODE-1519): delete config tool from guestos after switch to new icos config
+            # TODO(NODE-1518): delete config tool from guestos after switch to new icos config
             "//rs/ic_os/release:config": "/opt/ic/bin/config:0755",
         },
 

--- a/rs/ic_os/config/src/main.rs
+++ b/rs/ic_os/config/src/main.rs
@@ -367,7 +367,7 @@ pub fn main() -> Result<()> {
 
             generate_testnet_config(args, clap_args.guestos_config_json_path)
         }
-        // TODO(NODE-1519): delete UpdateGuestosConfig and UpdateHostosConfig after moved to new config format
+        // TODO(NODE-1518): delete UpdateGuestosConfig and UpdateHostosConfig after moved to new config format
         // Regenerate config.json on *every boot* in case the config structure changes between
         // when we roll out the update-config service and when we roll out the 'config integration'
         Some(Commands::UpdateGuestosConfig) => update_guestos_config(),


### PR DESCRIPTION
Add the log-config service to GuestOS

This service was previously just on HostOS and would log config.ini and deployment.json. Now the service is on HostOS and GuestOS and logs the config object.