### PR TITLE
test(ICRC_Ledger): FI-1625: Adapt golden state test to V4 migration

### DIFF
--- a/rs/ledger_suite/icrc1/tests/golden_state_upgrade_downgrade.rs
+++ b/rs/ledger_suite/icrc1/tests/golden_state_upgrade_downgrade.rs
@@ -73,8 +73,8 @@ lazy_static! {
         Wasm::from_bytes(archive_wasm()),
         None,
     );
-    pub static ref ALLOWANCES_MIGRATED_LEDGER_MODULE_HASH: Vec<u8> =
-        hex::decode("25071c2c55ad4571293e00d8e277f442aec7aed88109743ac52df3125209ff45").unwrap();
+    pub static ref BALANCES_MIGRATED_LEDGER_MODULE_HASH: Vec<u8> =
+        hex::decode("3b03d1bb1145edbcd11101ab2788517bc0f427c3bd7b342b9e3e7f42e29d5822").unwrap();
 }
 
 #[cfg(feature = "u256-tokens")]
@@ -97,8 +97,8 @@ lazy_static! {
         Wasm::from_bytes(archive_wasm()),
         None,
     );
-    pub static ref ALLOWANCES_MIGRATED_LEDGER_MODULE_HASH: Vec<u8> =
-        hex::decode("9637743e1215a4db376a62ee807a0986faf20833be2b332df09b3d5dbdd7339e").unwrap();
+    pub static ref BALANCES_MIGRATED_LEDGER_MODULE_HASH: Vec<u8> =
+        hex::decode("8b2e3e596a147780b0e99ce36d0b8f1f3ba41a98b819b42980a7c08c309b44c1").unwrap();
 }
 
 pub struct Wasms {
@@ -188,7 +188,7 @@ impl LedgerSuiteConfig {
         let deployed_module_hash = canister_status
             .module_hash()
             .expect("should have ledger canister module hash");
-        if deployed_module_hash.as_slice() == ALLOWANCES_MIGRATED_LEDGER_MODULE_HASH.as_slice() {
+        if deployed_module_hash.as_slice() == BALANCES_MIGRATED_LEDGER_MODULE_HASH.as_slice() {
             ExpectMigration::No
         } else {
             ExpectMigration::Yes


### PR DESCRIPTION
Adapt the ICRC golden state test to handle the case where some canisters have already been upgraded to the V4 version, and further no migration is expected to happen if they are upgraded to the same version again.