### PR TITLE
test(ICRC_Ledger): canbench benchmarks for icrc2_approve, icrc2_transfer_from and icrc3_get_blocks

### DIFF
--- a/rs/ledger_suite/icrc1/ledger/canbench_results/canbench_u256.yml
+++ b/rs/ledger_suite/icrc1/ledger/canbench_results/canbench_u256.yml
@@ -1,14 +1,22 @@
 benches:
   bench_icrc1_transfers:
     total:
-      instructions: 58832813883
+      instructions: 58832813772
       heap_increase: 271
       stable_memory_increase: 256
     scopes:
-      approvals:
+      icrc1_transfer:
+        instructions: 13635001695
+        heap_increase: 43
+        stable_memory_increase: 0
+      icrc2_approve:
         instructions: 20413485760
         heap_increase: 41
         stable_memory_increase: 128
+      icrc2_transfer_from:
+        instructions: 24042619927
+        heap_increase: 5
+        stable_memory_increase: 0
       icrc3_get_blocks:
         instructions: 7877258
         heap_increase: 0
@@ -21,16 +29,8 @@ benches:
         instructions: 149556765
         heap_increase: 129
         stable_memory_increase: 128
-      transfers:
-        instructions: 13635001695
-        heap_increase: 43
-        stable_memory_increase: 0
-      transfers_from:
-        instructions: 24042619927
-        heap_increase: 5
-        stable_memory_increase: 0
       upgrade:
-        instructions: 504336032
+        instructions: 504335921
         heap_increase: 182
         stable_memory_increase: 128
   bench_upgrade_baseline:

--- a/rs/ledger_suite/icrc1/ledger/canbench_results/canbench_u256.yml
+++ b/rs/ledger_suite/icrc1/ledger/canbench_results/canbench_u256.yml
@@ -1,28 +1,24 @@
 benches:
   bench_icrc1_transfers:
     total:
-      instructions: 63359785465
-      heap_increase: 307
+      instructions: 58832813883
+      heap_increase: 271
       stable_memory_increase: 256
     scopes:
       approvals:
         instructions: 20413485760
         heap_increase: 41
         stable_memory_increase: 128
-      get_blocks:
-        instructions: 131091462
-        heap_increase: 32
-        stable_memory_increase: 0
       icrc3_get_blocks:
-        instructions: 7825633
+        instructions: 7877258
         heap_increase: 0
         stable_memory_increase: 0
       post_upgrade:
-        instructions: 383013664
-        heap_increase: 57
+        instructions: 354777092
+        heap_increase: 53
         stable_memory_increase: 0
       pre_upgrade:
-        instructions: 161987478
+        instructions: 149556765
         heap_increase: 129
         stable_memory_increase: 128
       transfers:
@@ -34,8 +30,8 @@ benches:
         heap_increase: 5
         stable_memory_increase: 0
       upgrade:
-        instructions: 545003475
-        heap_increase: 186
+        instructions: 504336032
+        heap_increase: 182
         stable_memory_increase: 128
   bench_upgrade_baseline:
     total:

--- a/rs/ledger_suite/icrc1/ledger/canbench_results/canbench_u256.yml
+++ b/rs/ledger_suite/icrc1/ledger/canbench_results/canbench_u256.yml
@@ -1,42 +1,58 @@
 benches:
   bench_icrc1_transfers:
     total:
-      instructions: 13798815361
-      heap_increase: 172
-      stable_memory_increase: 128
+      instructions: 63359785465
+      heap_increase: 307
+      stable_memory_increase: 256
     scopes:
-      before_upgrade:
-        instructions: 13630531777
-        heap_increase: 43
+      approvals:
+        instructions: 20413485760
+        heap_increase: 41
+        stable_memory_increase: 128
+      get_blocks:
+        instructions: 131091462
+        heap_increase: 32
         stable_memory_increase: 0
-      post_upgrade:
-        instructions: 118601062
+      icrc3_get_blocks:
+        instructions: 7825633
         heap_increase: 0
         stable_memory_increase: 0
+      post_upgrade:
+        instructions: 383013664
+        heap_increase: 57
+        stable_memory_increase: 0
       pre_upgrade:
-        instructions: 49679478
+        instructions: 161987478
         heap_increase: 129
         stable_memory_increase: 128
+      transfers:
+        instructions: 13635001695
+        heap_increase: 43
+        stable_memory_increase: 0
+      transfers_from:
+        instructions: 24042619927
+        heap_increase: 5
+        stable_memory_increase: 0
       upgrade:
-        instructions: 168282130
-        heap_increase: 129
+        instructions: 545003475
+        heap_increase: 186
         stable_memory_increase: 128
   bench_upgrade_baseline:
     total:
-      instructions: 8684974
+      instructions: 8684182
       heap_increase: 258
       stable_memory_increase: 128
     scopes:
       post_upgrade:
-        instructions: 8606422
+        instructions: 8605997
         heap_increase: 129
         stable_memory_increase: 0
       pre_upgrade:
-        instructions: 76145
+        instructions: 75778
         heap_increase: 129
         stable_memory_increase: 128
       upgrade:
-        instructions: 8684285
+        instructions: 8683493
         heap_increase: 258
         stable_memory_increase: 128
-version: 0.1.7
+version: 0.1.8

--- a/rs/ledger_suite/icrc1/ledger/canbench_results/canbench_u64.yml
+++ b/rs/ledger_suite/icrc1/ledger/canbench_results/canbench_u64.yml
@@ -1,28 +1,24 @@
 benches:
   bench_icrc1_transfers:
     total:
-      instructions: 61255319729
-      heap_increase: 307
+      instructions: 56837536044
+      heap_increase: 271
       stable_memory_increase: 256
     scopes:
       approvals:
         instructions: 19627513485
         heap_increase: 29
         stable_memory_increase: 128
-      get_blocks:
-        instructions: 124150117
-        heap_increase: 31
-        stable_memory_increase: 0
       icrc3_get_blocks:
-        instructions: 7515525
+        instructions: 7540214
         heap_increase: 0
         stable_memory_increase: 0
       post_upgrade:
-        instructions: 380882715
-        heap_increase: 58
+        instructions: 353134588
+        heap_increase: 53
         stable_memory_increase: 0
       pre_upgrade:
-        instructions: 161460494
+        instructions: 149315334
         heap_increase: 129
         stable_memory_increase: 128
       transfers:
@@ -34,12 +30,12 @@ benches:
         heap_increase: 18
         stable_memory_increase: 0
       upgrade:
-        instructions: 542345542
-        heap_increase: 187
+        instructions: 502452097
+        heap_increase: 182
         stable_memory_increase: 128
   bench_upgrade_baseline:
     total:
-      instructions: 8683394
+      instructions: 8683414
       heap_increase: 258
       stable_memory_increase: 128
     scopes:
@@ -48,11 +44,11 @@ benches:
         heap_increase: 129
         stable_memory_increase: 0
       pre_upgrade:
-        instructions: 76683
+        instructions: 76703
         heap_increase: 129
         stable_memory_increase: 128
       upgrade:
-        instructions: 8682705
+        instructions: 8682725
         heap_increase: 258
         stable_memory_increase: 128
 version: 0.1.8

--- a/rs/ledger_suite/icrc1/ledger/canbench_results/canbench_u64.yml
+++ b/rs/ledger_suite/icrc1/ledger/canbench_results/canbench_u64.yml
@@ -1,42 +1,58 @@
 benches:
   bench_icrc1_transfers:
     total:
-      instructions: 13237283790
-      heap_increase: 171
-      stable_memory_increase: 128
+      instructions: 61255319729
+      heap_increase: 307
+      stable_memory_increase: 256
     scopes:
-      before_upgrade:
-        instructions: 13068913917
-        heap_increase: 42
+      approvals:
+        instructions: 19627513485
+        heap_increase: 29
+        stable_memory_increase: 128
+      get_blocks:
+        instructions: 124150117
+        heap_increase: 31
         stable_memory_increase: 0
-      post_upgrade:
-        instructions: 118797275
+      icrc3_get_blocks:
+        instructions: 7515525
         heap_increase: 0
         stable_memory_increase: 0
+      post_upgrade:
+        instructions: 380882715
+        heap_increase: 58
+        stable_memory_increase: 0
       pre_upgrade:
-        instructions: 49569466
+        instructions: 161460494
         heap_increase: 129
         stable_memory_increase: 128
+      transfers:
+        instructions: 13071791984
+        heap_increase: 42
+        stable_memory_increase: 0
+      transfers_from:
+        instructions: 23404082941
+        heap_increase: 18
+        stable_memory_increase: 0
       upgrade:
-        instructions: 168368331
-        heap_increase: 129
+        instructions: 542345542
+        heap_increase: 187
         stable_memory_increase: 128
   bench_upgrade_baseline:
     total:
-      instructions: 8686052
+      instructions: 8683394
       heap_increase: 258
       stable_memory_increase: 128
     scopes:
       post_upgrade:
-        instructions: 8606533
+        instructions: 8604304
         heap_increase: 129
         stable_memory_increase: 0
       pre_upgrade:
-        instructions: 77112
+        instructions: 76683
         heap_increase: 129
         stable_memory_increase: 128
       upgrade:
-        instructions: 8685363
+        instructions: 8682705
         heap_increase: 258
         stable_memory_increase: 128
-version: 0.1.7
+version: 0.1.8

--- a/rs/ledger_suite/icrc1/ledger/canbench_results/canbench_u64.yml
+++ b/rs/ledger_suite/icrc1/ledger/canbench_results/canbench_u64.yml
@@ -1,14 +1,22 @@
 benches:
   bench_icrc1_transfers:
     total:
-      instructions: 56837536044
+      instructions: 56837535933
       heap_increase: 271
       stable_memory_increase: 256
     scopes:
-      approvals:
+      icrc1_transfer:
+        instructions: 13071791984
+        heap_increase: 42
+        stable_memory_increase: 0
+      icrc2_approve:
         instructions: 19627513485
         heap_increase: 29
         stable_memory_increase: 128
+      icrc2_transfer_from:
+        instructions: 23404082941
+        heap_increase: 18
+        stable_memory_increase: 0
       icrc3_get_blocks:
         instructions: 7540214
         heap_increase: 0
@@ -21,16 +29,8 @@ benches:
         instructions: 149315334
         heap_increase: 129
         stable_memory_increase: 128
-      transfers:
-        instructions: 13071791984
-        heap_increase: 42
-        stable_memory_increase: 0
-      transfers_from:
-        instructions: 23404082941
-        heap_increase: 18
-        stable_memory_increase: 0
       upgrade:
-        instructions: 502452097
+        instructions: 502451986
         heap_increase: 182
         stable_memory_increase: 128
   bench_upgrade_baseline:

--- a/rs/ledger_suite/icrc1/ledger/src/benches/benches_u256.rs
+++ b/rs/ledger_suite/icrc1/ledger/src/benches/benches_u256.rs
@@ -1,7 +1,7 @@
 use crate::{
     benches::{
         assert_has_num_balances, emulate_archive_blocks, icrc_transfer, mint_tokens, test_account,
-        upgrade, NUM_APPROVALS, NUM_GET_BLOCKS, NUM_TRANSFERS, NUM_TRANSFERS_FROM,
+        upgrade, NUM_GET_BLOCKS, NUM_OPERATIONS,
     },
     icrc2_approve_not_async, icrc3_get_blocks, init_state, Access, Account, LOG,
 };
@@ -34,7 +34,7 @@ fn bench_icrc1_transfers() -> BenchResult {
     canbench_rs::bench_fn(|| {
         {
             let _p = canbench_rs::bench_scope("icrc1_transfer");
-            for i in 0..NUM_TRANSFERS {
+            for i in 0..NUM_OPERATIONS {
                 let transfer = TransferArg {
                     from_subaccount: account_with_tokens.subaccount,
                     to: test_account(i),
@@ -45,11 +45,11 @@ fn bench_icrc1_transfers() -> BenchResult {
                 assert_matches!(result, Ok(_));
                 emulate_archive_blocks::<Access>(&LOG);
             }
-            assert_has_num_balances(NUM_TRANSFERS + 2);
+            assert_has_num_balances(NUM_OPERATIONS + 2);
         }
         {
             let _p = canbench_rs::bench_scope("icrc2_approve");
-            for i in 0..NUM_APPROVALS {
+            for i in 0..NUM_OPERATIONS {
                 let approve = ApproveArgs {
                     from_subaccount: account_with_tokens.subaccount,
                     spender: test_account(i),
@@ -67,7 +67,7 @@ fn bench_icrc1_transfers() -> BenchResult {
         }
         {
             let _p = canbench_rs::bench_scope("icrc2_transfer_from");
-            for i in 0..NUM_TRANSFERS_FROM {
+            for i in 0..NUM_OPERATIONS {
                 let spender = test_account(i);
                 let transfer = TransferArg {
                     from_subaccount: account_with_tokens.subaccount,
@@ -80,7 +80,7 @@ fn bench_icrc1_transfers() -> BenchResult {
                 assert_matches!(result, Ok(_));
                 emulate_archive_blocks::<Access>(&LOG);
             }
-            assert_has_num_balances(NUM_TRANSFERS_FROM + NUM_TRANSFERS + 2);
+            assert_has_num_balances(2 * NUM_OPERATIONS + 2);
         }
         for i in 0..NUM_GET_BLOCKS {
             let spender = test_account(i);
@@ -95,7 +95,7 @@ fn bench_icrc1_transfers() -> BenchResult {
         }
         {
             let req = GetBlocksRequest {
-                start: Nat::from(NUM_TRANSFERS_FROM + NUM_TRANSFERS + NUM_APPROVALS),
+                start: Nat::from(3 * NUM_OPERATIONS),
                 length: Nat::from(NUM_GET_BLOCKS),
             };
             let _p = canbench_rs::bench_scope("icrc3_get_blocks");

--- a/rs/ledger_suite/icrc1/ledger/src/benches/benches_u256.rs
+++ b/rs/ledger_suite/icrc1/ledger/src/benches/benches_u256.rs
@@ -33,7 +33,7 @@ fn bench_icrc1_transfers() -> BenchResult {
 
     canbench_rs::bench_fn(|| {
         {
-            let _p = canbench_rs::bench_scope("transfers");
+            let _p = canbench_rs::bench_scope("icrc1_transfer");
             for i in 0..NUM_TRANSFERS {
                 let transfer = TransferArg {
                     from_subaccount: account_with_tokens.subaccount,
@@ -51,7 +51,7 @@ fn bench_icrc1_transfers() -> BenchResult {
             assert_has_num_balances(NUM_TRANSFERS + 2);
         }
         {
-            let _p = canbench_rs::bench_scope("approvals");
+            let _p = canbench_rs::bench_scope("icrc2_approve");
             for i in 0..NUM_APPROVALS {
                 let approve = ApproveArgs {
                     from_subaccount: account_with_tokens.subaccount,
@@ -72,7 +72,7 @@ fn bench_icrc1_transfers() -> BenchResult {
             }
         }
         {
-            let _p = canbench_rs::bench_scope("transfers_from");
+            let _p = canbench_rs::bench_scope("icrc2_transfer_from");
             for i in 0..NUM_TRANSFERS_FROM {
                 let spender = Account {
                     owner: max_length_principal(i),

--- a/rs/ledger_suite/icrc1/ledger/src/benches/benches_u256.rs
+++ b/rs/ledger_suite/icrc1/ledger/src/benches/benches_u256.rs
@@ -1,9 +1,9 @@
 use crate::{
     benches::{
-        assert_has_num_balances, emulate_archive_blocks, icrc1_transfer, max_length_principal,
-        mint_tokens, upgrade, NUM_TRANSFERS,
+        assert_has_num_balances, emulate_archive_blocks, icrc_transfer, max_length_principal,
+        mint_tokens, upgrade, NUM_APPROVALS, NUM_TRANSFERS, NUM_TRANSFERS_FROM,
     },
-    init_state, Access, Account, LOG,
+    icrc2_approve_not_async, init_state, Access, Account, LOG,
 };
 use assert_matches::assert_matches;
 use canbench_rs::{bench, BenchResult};
@@ -11,6 +11,7 @@ use candid::Principal;
 use ic_icrc1_ledger::{FeatureFlags, InitArgs, InitArgsBuilder};
 use ic_ledger_canister_core::archive::ArchiveOptions;
 use icrc_ledger_types::icrc1::transfer::TransferArg;
+use icrc_ledger_types::icrc2::approve::ApproveArgs;
 
 const MINTER_PRINCIPAL: Principal = Principal::from_slice(&[0_u8, 0, 0, 0, 2, 48, 0, 156, 1, 1]);
 
@@ -31,7 +32,7 @@ fn bench_icrc1_transfers() -> BenchResult {
 
     canbench_rs::bench_fn(|| {
         {
-            let _p = canbench_rs::bench_scope("before_upgrade");
+            let _p = canbench_rs::bench_scope("transfers");
             for i in 0..NUM_TRANSFERS {
                 let transfer = TransferArg {
                     from_subaccount: account_with_tokens.subaccount,
@@ -42,11 +43,55 @@ fn bench_icrc1_transfers() -> BenchResult {
                     created_at_time: Some(start_time + i as u64),
                     ..cketh_transfer()
                 };
-                let result = icrc1_transfer(account_with_tokens.owner, transfer.clone());
+                let result = icrc_transfer(account_with_tokens.owner, None, transfer.clone());
                 assert_matches!(result, Ok(_));
                 emulate_archive_blocks::<Access>(&LOG);
             }
             assert_has_num_balances(NUM_TRANSFERS + 2);
+        }
+        {
+            let _p = canbench_rs::bench_scope("approvals");
+            for i in 0..NUM_APPROVALS {
+                let approve = ApproveArgs {
+                    from_subaccount: account_with_tokens.subaccount,
+                    spender: Account {
+                        owner: max_length_principal(i),
+                        subaccount: Some([11_u8; 32]),
+                    },
+                    created_at_time: Some(start_time + i as u64),
+                    amount: u128::MAX.into(),
+                    expected_allowance: Some(0u64.into()),
+                    expires_at: Some(u64::MAX),
+                    fee: None,
+                    memo: Some(MEMO.to_vec().into()),
+                };
+                let result = icrc2_approve_not_async(account_with_tokens.owner, approve.clone());
+                assert_matches!(result, Ok(_));
+                emulate_archive_blocks::<Access>(&LOG);
+            }
+        }
+        {
+            let _p = canbench_rs::bench_scope("transfers_from");
+            for i in 0..NUM_TRANSFERS_FROM {
+                let spender = Account {
+                    owner: max_length_principal(i),
+                    subaccount: Some([11_u8; 32]),
+                };
+                let transfer = TransferArg {
+                    from_subaccount: account_with_tokens.subaccount,
+                    to: Account {
+                        owner: max_length_principal(1_000_000_000 + i),
+                        subaccount: Some([11_u8; 32]),
+                    },
+                    created_at_time: Some(start_time + i as u64),
+                    ..cketh_transfer()
+                };
+                let result =
+                    icrc_transfer(account_with_tokens.owner, Some(spender), transfer.clone());
+                assert_matches!(result, Ok(_));
+                emulate_archive_blocks::<Access>(&LOG);
+            }
+            assert_has_num_balances(NUM_TRANSFERS_FROM + NUM_TRANSFERS + 2);
         }
         upgrade();
     })
@@ -85,6 +130,13 @@ fn cketh_ledger_init_args_with_archive() -> InitArgs {
         .build()
 }
 
+const MEMO: [u8; 61] = [
+    0x82_u8, 0x00, 0x83, 0x54, 0x04, 0xc5, 0x63, 0x84, 0x17, 0x78, 0xc9, 0x3f, 0x41, 0xdc, 0x1a,
+    0x89, 0x82, 0x1a, 0xe1, 0xc6, 0x75, 0xbb, 0xe8, 0x15, 0x58, 0x20, 0xb5, 0xa1, 0x01, 0xfb, 0x96,
+    0xc5, 0xcf, 0x22, 0x4d, 0xf0, 0xd5, 0x02, 0x9b, 0x56, 0xbe, 0x81, 0xfc, 0x65, 0xce, 0x61, 0xf8,
+    0x99, 0x11, 0xb7, 0x71, 0x23, 0x27, 0x8a, 0xe7, 0xf4, 0x67, 0xb7, 0x19, 0x01, 0x2c,
+];
+
 /// ckETH ledger transaction 495542
 fn cketh_transfer() -> TransferArg {
     TransferArg {
@@ -98,16 +150,7 @@ fn cketh_transfer() -> TransferArg {
         },
         fee: None,
         created_at_time: None,
-        memo: Some(
-            vec![
-                0x82_u8, 0x00, 0x83, 0x54, 0x04, 0xc5, 0x63, 0x84, 0x17, 0x78, 0xc9, 0x3f, 0x41,
-                0xdc, 0x1a, 0x89, 0x82, 0x1a, 0xe1, 0xc6, 0x75, 0xbb, 0xe8, 0x15, 0x58, 0x20, 0xb5,
-                0xa1, 0x01, 0xfb, 0x96, 0xc5, 0xcf, 0x22, 0x4d, 0xf0, 0xd5, 0x02, 0x9b, 0x56, 0xbe,
-                0x81, 0xfc, 0x65, 0xce, 0x61, 0xf8, 0x99, 0x11, 0xb7, 0x71, 0x23, 0x27, 0x8a, 0xe7,
-                0xf4, 0x67, 0xb7, 0x19, 0x01, 0x2c,
-            ]
-            .into(),
-        ),
+        memo: Some(MEMO.to_vec().into()),
         amount: 19_998_200_000_000_000_000_u128.into(),
     }
 }

--- a/rs/ledger_suite/icrc1/ledger/src/benches/benches_u256.rs
+++ b/rs/ledger_suite/icrc1/ledger/src/benches/benches_u256.rs
@@ -1,7 +1,7 @@
 use crate::{
     benches::{
-        assert_has_num_balances, emulate_archive_blocks, icrc_transfer, max_length_principal,
-        mint_tokens, upgrade, NUM_APPROVALS, NUM_GET_BLOCKS, NUM_TRANSFERS, NUM_TRANSFERS_FROM,
+        assert_has_num_balances, emulate_archive_blocks, icrc_transfer, mint_tokens, test_account,
+        upgrade, NUM_APPROVALS, NUM_GET_BLOCKS, NUM_TRANSFERS, NUM_TRANSFERS_FROM,
     },
     icrc2_approve_not_async, icrc3_get_blocks, init_state, Access, Account, LOG,
 };
@@ -37,10 +37,7 @@ fn bench_icrc1_transfers() -> BenchResult {
             for i in 0..NUM_TRANSFERS {
                 let transfer = TransferArg {
                     from_subaccount: account_with_tokens.subaccount,
-                    to: Account {
-                        owner: max_length_principal(i),
-                        subaccount: Some([11_u8; 32]),
-                    },
+                    to: test_account(i),
                     created_at_time: Some(start_time + i as u64),
                     ..cketh_transfer()
                 };
@@ -55,10 +52,7 @@ fn bench_icrc1_transfers() -> BenchResult {
             for i in 0..NUM_APPROVALS {
                 let approve = ApproveArgs {
                     from_subaccount: account_with_tokens.subaccount,
-                    spender: Account {
-                        owner: max_length_principal(i),
-                        subaccount: Some([11_u8; 32]),
-                    },
+                    spender: test_account(i),
                     created_at_time: Some(start_time + i as u64),
                     amount: u128::MAX.into(),
                     expected_allowance: Some(0u64.into()),
@@ -74,16 +68,10 @@ fn bench_icrc1_transfers() -> BenchResult {
         {
             let _p = canbench_rs::bench_scope("icrc2_transfer_from");
             for i in 0..NUM_TRANSFERS_FROM {
-                let spender = Account {
-                    owner: max_length_principal(i),
-                    subaccount: Some([11_u8; 32]),
-                };
+                let spender = test_account(i);
                 let transfer = TransferArg {
                     from_subaccount: account_with_tokens.subaccount,
-                    to: Account {
-                        owner: max_length_principal(1_000_000_000 + i),
-                        subaccount: Some([11_u8; 32]),
-                    },
+                    to: test_account(1_000_000_000 + i),
                     created_at_time: Some(start_time + i as u64),
                     ..cketh_transfer()
                 };
@@ -95,16 +83,10 @@ fn bench_icrc1_transfers() -> BenchResult {
             assert_has_num_balances(NUM_TRANSFERS_FROM + NUM_TRANSFERS + 2);
         }
         for i in 0..NUM_GET_BLOCKS {
-            let spender = Account {
-                owner: max_length_principal(i),
-                subaccount: Some([11_u8; 32]),
-            };
+            let spender = test_account(i);
             let transfer = TransferArg {
                 from_subaccount: account_with_tokens.subaccount,
-                to: Account {
-                    owner: max_length_principal(1_000_000_000 + i),
-                    subaccount: Some([11_u8; 32]),
-                },
+                to: test_account(1_000_000_000 + i),
                 created_at_time: Some(1_000_000_000 + start_time + i as u64),
                 ..cketh_transfer()
             };

--- a/rs/ledger_suite/icrc1/ledger/src/benches/benches_u256.rs
+++ b/rs/ledger_suite/icrc1/ledger/src/benches/benches_u256.rs
@@ -1,7 +1,7 @@
 use crate::{
     benches::{
         assert_has_num_balances, emulate_archive_blocks, icrc_transfer, mint_tokens, test_account,
-        upgrade, NUM_GET_BLOCKS, NUM_OPERATIONS,
+        test_account_offset, upgrade, NUM_GET_BLOCKS, NUM_OPERATIONS,
     },
     icrc2_approve_not_async, icrc3_get_blocks, init_state, Access, Account, LOG,
 };
@@ -71,7 +71,7 @@ fn bench_icrc1_transfers() -> BenchResult {
                 let spender = test_account(i);
                 let transfer = TransferArg {
                     from_subaccount: account_with_tokens.subaccount,
-                    to: test_account(1_000_000_000 + i),
+                    to: test_account_offset(i),
                     created_at_time: Some(start_time + i as u64),
                     ..cketh_transfer()
                 };
@@ -86,7 +86,7 @@ fn bench_icrc1_transfers() -> BenchResult {
             let spender = test_account(i);
             let transfer = TransferArg {
                 from_subaccount: account_with_tokens.subaccount,
-                to: test_account(1_000_000_000 + i),
+                to: test_account_offset(i),
                 created_at_time: Some(1_000_000_000 + start_time + i as u64),
                 ..cketh_transfer()
             };

--- a/rs/ledger_suite/icrc1/ledger/src/benches/benches_u256.rs
+++ b/rs/ledger_suite/icrc1/ledger/src/benches/benches_u256.rs
@@ -3,7 +3,7 @@ use crate::{
         assert_has_num_balances, emulate_archive_blocks, icrc_transfer, max_length_principal,
         mint_tokens, upgrade, NUM_APPROVALS, NUM_GET_BLOCKS, NUM_TRANSFERS, NUM_TRANSFERS_FROM,
     },
-    get_blocks, icrc2_approve_not_async, icrc3_get_blocks, init_state, Access, Account, LOG,
+    icrc2_approve_not_async, icrc3_get_blocks, init_state, Access, Account, LOG,
 };
 use assert_matches::assert_matches;
 use canbench_rs::{bench, BenchResult};
@@ -111,19 +111,14 @@ fn bench_icrc1_transfers() -> BenchResult {
             let result = icrc_transfer(account_with_tokens.owner, Some(spender), transfer.clone());
             assert_matches!(result, Ok(_));
         }
-        let req = GetBlocksRequest {
-            start: Nat::from(NUM_TRANSFERS_FROM + NUM_TRANSFERS + NUM_APPROVALS),
-            length: Nat::from(NUM_GET_BLOCKS),
-        };
         {
-            let _p = canbench_rs::bench_scope("get_blocks");
-            let blocks_res = get_blocks(req.clone());
-            assert_eq!(blocks_res.blocks.len(), NUM_GET_BLOCKS as usize);
-        }
-        {
+            let req = GetBlocksRequest {
+                start: Nat::from(NUM_TRANSFERS_FROM + NUM_TRANSFERS + NUM_APPROVALS),
+                length: Nat::from(NUM_GET_BLOCKS),
+            };
             let _p = canbench_rs::bench_scope("icrc3_get_blocks");
             let blocks_res = icrc3_get_blocks(vec![req]);
-            assert_eq!(blocks_res.blocks.len(), 100usize); // this is the max for `icrc3_get_blocks`
+            assert_eq!(blocks_res.blocks.len(), NUM_GET_BLOCKS as usize);
         }
         upgrade();
     })

--- a/rs/ledger_suite/icrc1/ledger/src/benches/benches_u64.rs
+++ b/rs/ledger_suite/icrc1/ledger/src/benches/benches_u64.rs
@@ -2,7 +2,7 @@ use crate::benches::{
     assert_has_num_balances, emulate_archive_blocks, icrc_transfer, max_length_principal,
     mint_tokens, upgrade, NUM_APPROVALS, NUM_GET_BLOCKS, NUM_TRANSFERS, NUM_TRANSFERS_FROM,
 };
-use crate::{get_blocks, icrc2_approve_not_async, icrc3_get_blocks, init_state, Access, LOG};
+use crate::{icrc2_approve_not_async, icrc3_get_blocks, init_state, Access, LOG};
 use assert_matches::assert_matches;
 use canbench_rs::{bench, BenchResult};
 use candid::{Nat, Principal};
@@ -110,19 +110,14 @@ fn bench_icrc1_transfers() -> BenchResult {
             let result = icrc_transfer(account_with_tokens.owner, Some(spender), transfer.clone());
             assert_matches!(result, Ok(_));
         }
-        let req = GetBlocksRequest {
-            start: Nat::from(NUM_TRANSFERS_FROM + NUM_TRANSFERS + NUM_APPROVALS),
-            length: Nat::from(NUM_GET_BLOCKS),
-        };
         {
-            let _p = canbench_rs::bench_scope("get_blocks");
-            let blocks_res = get_blocks(req.clone());
-            assert_eq!(blocks_res.blocks.len(), NUM_GET_BLOCKS as usize);
-        }
-        {
+            let req = GetBlocksRequest {
+                start: Nat::from(NUM_TRANSFERS_FROM + NUM_TRANSFERS + NUM_APPROVALS),
+                length: Nat::from(NUM_GET_BLOCKS),
+            };
             let _p = canbench_rs::bench_scope("icrc3_get_blocks");
             let blocks_res = icrc3_get_blocks(vec![req]);
-            assert_eq!(blocks_res.blocks.len(), 100usize); // this is the max for `icrc3_get_blocks`
+            assert_eq!(blocks_res.blocks.len(), NUM_GET_BLOCKS as usize);
         }
         upgrade();
     })

--- a/rs/ledger_suite/icrc1/ledger/src/benches/benches_u64.rs
+++ b/rs/ledger_suite/icrc1/ledger/src/benches/benches_u64.rs
@@ -1,6 +1,6 @@
 use crate::benches::{
     assert_has_num_balances, emulate_archive_blocks, icrc_transfer, mint_tokens, test_account,
-    upgrade, NUM_GET_BLOCKS, NUM_OPERATIONS,
+    test_account_offset, upgrade, NUM_GET_BLOCKS, NUM_OPERATIONS,
 };
 use crate::{icrc2_approve_not_async, icrc3_get_blocks, init_state, Access, LOG};
 use assert_matches::assert_matches;
@@ -70,7 +70,7 @@ fn bench_icrc1_transfers() -> BenchResult {
                 let spender = test_account(i);
                 let transfer = TransferArg {
                     from_subaccount: account_with_tokens.subaccount,
-                    to: test_account(1_000_000_000 + i),
+                    to: test_account_offset(i),
                     created_at_time: Some(start_time + i as u64),
                     ..ckbtc_transfer()
                 };
@@ -85,7 +85,7 @@ fn bench_icrc1_transfers() -> BenchResult {
             let spender = test_account(i);
             let transfer = TransferArg {
                 from_subaccount: account_with_tokens.subaccount,
-                to: test_account(1_000_000_000 + i),
+                to: test_account_offset(i),
                 created_at_time: Some(1_000_000_000 + start_time + i as u64),
                 ..ckbtc_transfer()
             };

--- a/rs/ledger_suite/icrc1/ledger/src/benches/benches_u64.rs
+++ b/rs/ledger_suite/icrc1/ledger/src/benches/benches_u64.rs
@@ -1,16 +1,17 @@
 use crate::benches::{
     assert_has_num_balances, emulate_archive_blocks, icrc_transfer, max_length_principal,
-    mint_tokens, upgrade, NUM_APPROVALS, NUM_TRANSFERS, NUM_TRANSFERS_FROM,
+    mint_tokens, upgrade, NUM_APPROVALS, NUM_GET_BLOCKS, NUM_TRANSFERS, NUM_TRANSFERS_FROM,
 };
-use crate::{icrc2_approve_not_async, init_state, Access, LOG};
+use crate::{get_blocks, icrc2_approve_not_async, icrc3_get_blocks, init_state, Access, LOG};
 use assert_matches::assert_matches;
 use canbench_rs::{bench, BenchResult};
-use candid::Principal;
+use candid::{Nat, Principal};
 use ic_icrc1_ledger::{FeatureFlags, InitArgs, InitArgsBuilder};
 use ic_ledger_canister_core::archive::ArchiveOptions;
 use icrc_ledger_types::icrc1::account::Account;
 use icrc_ledger_types::icrc1::transfer::TransferArg;
 use icrc_ledger_types::icrc2::approve::ApproveArgs;
+use icrc_ledger_types::icrc3::blocks::GetBlocksRequest;
 
 const MINTER_PRINCIPAL: Principal = Principal::from_slice(&[0_u8, 0, 0, 0, 2, 48, 0, 7, 1, 1]);
 
@@ -91,6 +92,37 @@ fn bench_icrc1_transfers() -> BenchResult {
                 emulate_archive_blocks::<Access>(&LOG);
             }
             assert_has_num_balances(NUM_TRANSFERS_FROM + NUM_TRANSFERS + 2);
+        }
+        for i in 0..NUM_GET_BLOCKS {
+            let spender = Account {
+                owner: max_length_principal(i),
+                subaccount: Some([11_u8; 32]),
+            };
+            let transfer = TransferArg {
+                from_subaccount: account_with_tokens.subaccount,
+                to: Account {
+                    owner: max_length_principal(1_000_000_000 + i),
+                    subaccount: Some([11_u8; 32]),
+                },
+                created_at_time: Some(1_000_000_000 + start_time + i as u64),
+                ..ckbtc_transfer()
+            };
+            let result = icrc_transfer(account_with_tokens.owner, Some(spender), transfer.clone());
+            assert_matches!(result, Ok(_));
+        }
+        let req = GetBlocksRequest {
+            start: Nat::from(NUM_TRANSFERS_FROM + NUM_TRANSFERS + NUM_APPROVALS),
+            length: Nat::from(NUM_GET_BLOCKS),
+        };
+        {
+            let _p = canbench_rs::bench_scope("get_blocks");
+            let blocks_res = get_blocks(req.clone());
+            assert_eq!(blocks_res.blocks.len(), NUM_GET_BLOCKS as usize);
+        }
+        {
+            let _p = canbench_rs::bench_scope("icrc3_get_blocks");
+            let blocks_res = icrc3_get_blocks(vec![req]);
+            assert_eq!(blocks_res.blocks.len(), 100usize); // this is the max for `icrc3_get_blocks`
         }
         upgrade();
     })

--- a/rs/ledger_suite/icrc1/ledger/src/benches/benches_u64.rs
+++ b/rs/ledger_suite/icrc1/ledger/src/benches/benches_u64.rs
@@ -32,7 +32,7 @@ fn bench_icrc1_transfers() -> BenchResult {
 
     canbench_rs::bench_fn(|| {
         {
-            let _p = canbench_rs::bench_scope("transfers");
+            let _p = canbench_rs::bench_scope("icrc1_transfer");
             for i in 0..NUM_TRANSFERS {
                 let transfer = TransferArg {
                     from_subaccount: account_with_tokens.subaccount,
@@ -50,7 +50,7 @@ fn bench_icrc1_transfers() -> BenchResult {
             assert_has_num_balances(NUM_TRANSFERS + 2);
         }
         {
-            let _p = canbench_rs::bench_scope("approvals");
+            let _p = canbench_rs::bench_scope("icrc2_approve");
             for i in 0..NUM_APPROVALS {
                 let approve = ApproveArgs {
                     from_subaccount: account_with_tokens.subaccount,
@@ -71,7 +71,7 @@ fn bench_icrc1_transfers() -> BenchResult {
             }
         }
         {
-            let _p = canbench_rs::bench_scope("transfers_from");
+            let _p = canbench_rs::bench_scope("icrc2_transfer_from");
             for i in 0..NUM_TRANSFERS_FROM {
                 let spender = Account {
                     owner: max_length_principal(i),

--- a/rs/ledger_suite/icrc1/ledger/src/benches/benches_u64.rs
+++ b/rs/ledger_suite/icrc1/ledger/src/benches/benches_u64.rs
@@ -1,6 +1,6 @@
 use crate::benches::{
     assert_has_num_balances, emulate_archive_blocks, icrc_transfer, mint_tokens, test_account,
-    upgrade, NUM_APPROVALS, NUM_GET_BLOCKS, NUM_TRANSFERS, NUM_TRANSFERS_FROM,
+    upgrade, NUM_GET_BLOCKS, NUM_OPERATIONS,
 };
 use crate::{icrc2_approve_not_async, icrc3_get_blocks, init_state, Access, LOG};
 use assert_matches::assert_matches;
@@ -33,7 +33,7 @@ fn bench_icrc1_transfers() -> BenchResult {
     canbench_rs::bench_fn(|| {
         {
             let _p = canbench_rs::bench_scope("icrc1_transfer");
-            for i in 0..NUM_TRANSFERS {
+            for i in 0..NUM_OPERATIONS {
                 let transfer = TransferArg {
                     from_subaccount: account_with_tokens.subaccount,
                     to: test_account(i),
@@ -44,11 +44,11 @@ fn bench_icrc1_transfers() -> BenchResult {
                 assert_matches!(result, Ok(_));
                 emulate_archive_blocks::<Access>(&LOG);
             }
-            assert_has_num_balances(NUM_TRANSFERS + 2);
+            assert_has_num_balances(NUM_OPERATIONS + 2);
         }
         {
             let _p = canbench_rs::bench_scope("icrc2_approve");
-            for i in 0..NUM_APPROVALS {
+            for i in 0..NUM_OPERATIONS {
                 let approve = ApproveArgs {
                     from_subaccount: account_with_tokens.subaccount,
                     spender: test_account(i),
@@ -66,7 +66,7 @@ fn bench_icrc1_transfers() -> BenchResult {
         }
         {
             let _p = canbench_rs::bench_scope("icrc2_transfer_from");
-            for i in 0..NUM_TRANSFERS_FROM {
+            for i in 0..NUM_OPERATIONS {
                 let spender = test_account(i);
                 let transfer = TransferArg {
                     from_subaccount: account_with_tokens.subaccount,
@@ -79,7 +79,7 @@ fn bench_icrc1_transfers() -> BenchResult {
                 assert_matches!(result, Ok(_));
                 emulate_archive_blocks::<Access>(&LOG);
             }
-            assert_has_num_balances(NUM_TRANSFERS_FROM + NUM_TRANSFERS + 2);
+            assert_has_num_balances(2 * NUM_OPERATIONS + 2);
         }
         for i in 0..NUM_GET_BLOCKS {
             let spender = test_account(i);
@@ -94,7 +94,7 @@ fn bench_icrc1_transfers() -> BenchResult {
         }
         {
             let req = GetBlocksRequest {
-                start: Nat::from(NUM_TRANSFERS_FROM + NUM_TRANSFERS + NUM_APPROVALS),
+                start: Nat::from(3 * NUM_OPERATIONS),
                 length: Nat::from(NUM_GET_BLOCKS),
             };
             let _p = canbench_rs::bench_scope("icrc3_get_blocks");

--- a/rs/ledger_suite/icrc1/ledger/src/benches/benches_u64.rs
+++ b/rs/ledger_suite/icrc1/ledger/src/benches/benches_u64.rs
@@ -1,6 +1,6 @@
 use crate::benches::{
-    assert_has_num_balances, emulate_archive_blocks, icrc_transfer, max_length_principal,
-    mint_tokens, upgrade, NUM_APPROVALS, NUM_GET_BLOCKS, NUM_TRANSFERS, NUM_TRANSFERS_FROM,
+    assert_has_num_balances, emulate_archive_blocks, icrc_transfer, mint_tokens, test_account,
+    upgrade, NUM_APPROVALS, NUM_GET_BLOCKS, NUM_TRANSFERS, NUM_TRANSFERS_FROM,
 };
 use crate::{icrc2_approve_not_async, icrc3_get_blocks, init_state, Access, LOG};
 use assert_matches::assert_matches;
@@ -36,10 +36,7 @@ fn bench_icrc1_transfers() -> BenchResult {
             for i in 0..NUM_TRANSFERS {
                 let transfer = TransferArg {
                     from_subaccount: account_with_tokens.subaccount,
-                    to: Account {
-                        owner: max_length_principal(i),
-                        subaccount: Some([11_u8; 32]),
-                    },
+                    to: test_account(i),
                     created_at_time: Some(start_time + i as u64),
                     ..ckbtc_transfer()
                 };
@@ -54,10 +51,7 @@ fn bench_icrc1_transfers() -> BenchResult {
             for i in 0..NUM_APPROVALS {
                 let approve = ApproveArgs {
                     from_subaccount: account_with_tokens.subaccount,
-                    spender: Account {
-                        owner: max_length_principal(i),
-                        subaccount: Some([11_u8; 32]),
-                    },
+                    spender: test_account(i),
                     created_at_time: Some(start_time + i as u64),
                     amount: u64::MAX.into(),
                     expected_allowance: Some(0u64.into()),
@@ -73,16 +67,10 @@ fn bench_icrc1_transfers() -> BenchResult {
         {
             let _p = canbench_rs::bench_scope("icrc2_transfer_from");
             for i in 0..NUM_TRANSFERS_FROM {
-                let spender = Account {
-                    owner: max_length_principal(i),
-                    subaccount: Some([11_u8; 32]),
-                };
+                let spender = test_account(i);
                 let transfer = TransferArg {
                     from_subaccount: account_with_tokens.subaccount,
-                    to: Account {
-                        owner: max_length_principal(1_000_000_000 + i),
-                        subaccount: Some([11_u8; 32]),
-                    },
+                    to: test_account(1_000_000_000 + i),
                     created_at_time: Some(start_time + i as u64),
                     ..ckbtc_transfer()
                 };
@@ -94,16 +82,10 @@ fn bench_icrc1_transfers() -> BenchResult {
             assert_has_num_balances(NUM_TRANSFERS_FROM + NUM_TRANSFERS + 2);
         }
         for i in 0..NUM_GET_BLOCKS {
-            let spender = Account {
-                owner: max_length_principal(i),
-                subaccount: Some([11_u8; 32]),
-            };
+            let spender = test_account(i);
             let transfer = TransferArg {
                 from_subaccount: account_with_tokens.subaccount,
-                to: Account {
-                    owner: max_length_principal(1_000_000_000 + i),
-                    subaccount: Some([11_u8; 32]),
-                },
+                to: test_account(1_000_000_000 + i),
                 created_at_time: Some(1_000_000_000 + start_time + i as u64),
                 ..ckbtc_transfer()
             };

--- a/rs/ledger_suite/icrc1/ledger/src/benches/mod.rs
+++ b/rs/ledger_suite/icrc1/ledger/src/benches/mod.rs
@@ -15,7 +15,7 @@ mod benches_u64;
 pub const NUM_TRANSFERS: u32 = 10_000;
 pub const NUM_APPROVALS: u32 = 10_000;
 pub const NUM_TRANSFERS_FROM: u32 = 10_000;
-pub const NUM_GET_BLOCKS: u32 = 2_000;
+pub const NUM_GET_BLOCKS: u32 = 100;
 
 pub fn upgrade() {
     let _p = canbench_rs::bench_scope("upgrade");

--- a/rs/ledger_suite/icrc1/ledger/src/benches/mod.rs
+++ b/rs/ledger_suite/icrc1/ledger/src/benches/mod.rs
@@ -12,9 +12,7 @@ mod benches_u256;
 #[cfg(not(feature = "u256-tokens"))]
 mod benches_u64;
 
-pub const NUM_TRANSFERS: u32 = 10_000;
-pub const NUM_APPROVALS: u32 = 10_000;
-pub const NUM_TRANSFERS_FROM: u32 = 10_000;
+pub const NUM_OPERATIONS: u32 = 10_000;
 pub const NUM_GET_BLOCKS: u32 = 100;
 
 pub fn upgrade() {

--- a/rs/ledger_suite/icrc1/ledger/src/benches/mod.rs
+++ b/rs/ledger_suite/icrc1/ledger/src/benches/mod.rs
@@ -15,6 +15,7 @@ mod benches_u64;
 pub const NUM_TRANSFERS: u32 = 10_000;
 pub const NUM_APPROVALS: u32 = 10_000;
 pub const NUM_TRANSFERS_FROM: u32 = 10_000;
+pub const NUM_GET_BLOCKS: u32 = 2_000;
 
 pub fn upgrade() {
     let _p = canbench_rs::bench_scope("upgrade");

--- a/rs/ledger_suite/icrc1/ledger/src/benches/mod.rs
+++ b/rs/ledger_suite/icrc1/ledger/src/benches/mod.rs
@@ -61,6 +61,10 @@ pub fn test_account(i: u32) -> Account {
     }
 }
 
+pub fn test_account_offset(i: u32) -> Account {
+    test_account(1_000_000_000 + i)
+}
+
 fn mint_tokens<T: Into<Nat>>(minter: Principal, amount: T) -> Account {
     let account_with_tokens = Account {
         owner: max_length_principal(u32::MAX),

--- a/rs/ledger_suite/icrc1/ledger/src/benches/mod.rs
+++ b/rs/ledger_suite/icrc1/ledger/src/benches/mod.rs
@@ -13,6 +13,8 @@ mod benches_u256;
 mod benches_u64;
 
 pub const NUM_TRANSFERS: u32 = 10_000;
+pub const NUM_APPROVALS: u32 = 10_000;
+pub const NUM_TRANSFERS_FROM: u32 = 10_000;
 
 pub fn upgrade() {
     let _p = canbench_rs::bench_scope("upgrade");
@@ -20,8 +22,9 @@ pub fn upgrade() {
     post_upgrade(None);
 }
 
-pub fn icrc1_transfer(
+pub fn icrc_transfer(
     from: Principal,
+    spender: Option<Account>,
     arg: TransferArg,
 ) -> Result<BlockIndex, ic_ledger_canister_core::ledger::TransferError<Tokens>> {
     let from_account = Account {
@@ -31,7 +34,7 @@ pub fn icrc1_transfer(
     execute_transfer_not_async(
         from_account,
         arg.to,
-        None,
+        spender,
         arg.fee,
         arg.amount,
         arg.memo,
@@ -58,8 +61,9 @@ fn mint_tokens<T: Into<Nat>>(minter: Principal, amount: T) -> Account {
         subaccount: Some([255_u8; 32]),
     };
     assert_matches!(
-        icrc1_transfer(
+        icrc_transfer(
             minter,
+            None,
             TransferArg {
                 from_subaccount: None,
                 to: account_with_tokens,

--- a/rs/ledger_suite/icrc1/ledger/src/benches/mod.rs
+++ b/rs/ledger_suite/icrc1/ledger/src/benches/mod.rs
@@ -56,6 +56,13 @@ pub fn max_length_principal(index: u32) -> Principal {
     Principal::from_slice(&principal)
 }
 
+pub fn test_account(i: u32) -> Account {
+    Account {
+        owner: max_length_principal(i),
+        subaccount: Some([11_u8; 32]),
+    }
+}
+
 fn mint_tokens<T: Into<Nat>>(minter: Principal, amount: T) -> Account {
     let account_with_tokens = Account {
         owner: max_length_principal(u32::MAX),

--- a/rs/ledger_suite/icrc1/ledger/src/main.rs
+++ b/rs/ledger_suite/icrc1/ledger/src/main.rs
@@ -1,8 +1,8 @@
 #[cfg(feature = "canbench-rs")]
 mod benches;
 
-use candid::candid_method;
 use candid::types::number::Nat;
+use candid::{candid_method, Principal};
 use ic_canister_log::{declare_log_buffer, export, log};
 use ic_canisters_http_types::{HttpRequest, HttpResponse, HttpResponseBuilder};
 use ic_cdk::api::stable::StableReader;
@@ -810,15 +810,13 @@ fn get_data_certificate() -> DataCertificate {
     }
 }
 
-#[update]
-#[candid_method(update)]
-async fn icrc2_approve(arg: ApproveArgs) -> Result<Nat, ApproveError> {
+fn icrc2_approve_not_async(caller: Principal, arg: ApproveArgs) -> Result<u64, ApproveError> {
     panic_if_not_ready();
     let block_idx = Access::with_ledger_mut(|ledger| {
         let now = TimeStamp::from_nanos_since_unix_epoch(ic_cdk::api::time());
 
         let from_account = Account {
-            owner: ic_cdk::api::caller(),
+            owner: caller,
             subaccount: arg.from_subaccount,
         };
         if from_account.owner == arg.spender.owner {
@@ -880,6 +878,14 @@ async fn icrc2_approve(arg: ApproveArgs) -> Result<Nat, ApproveError> {
             })?;
         Ok(block_idx)
     })?;
+
+    Ok(block_idx)
+}
+
+#[update]
+#[candid_method(update)]
+async fn icrc2_approve(arg: ApproveArgs) -> Result<Nat, ApproveError> {
+    let block_idx = icrc2_approve_not_async(ic_cdk::api::caller(), arg)?;
 
     // NB. we need to set the certified data before the first async call to make sure that the
     // blockchain state agrees with the certificate while archiving is in progress.


### PR DESCRIPTION
Scopes for `icrc2_approve`, `icrc2_transfer_from` and `icrc3_get_blocks` were added. Scope `before_upgrade` was renamed to `icrc1_transfer`. Since we now test with more approvals, balances and blocks, the benchmark files need to be completely regenerated.