### PR TITLE
test(ICRC_Index): FI-1042: Verify ICRC ledger and index block equality

### DIFF
--- a/rs/ledger_suite/icrc1/index-ng/BUILD.bazel
+++ b/rs/ledger_suite/icrc1/index-ng/BUILD.bazel
@@ -79,7 +79,10 @@ rust_library(
 rust_test(
     name = "index_ng_unit_test",
     crate = ":_wasm_index_ng_canister",
-    data = [":index-ng.did"],
+    data = [
+        ":index-ng.did",
+        "//rs/ledger_suite/icrc1/ledger:ledger.did",
+    ],
     deps = [
         # Keep sorted.
         "//rs/ledger_suite/icrc1/test_utils",

--- a/rs/ledger_suite/icrc1/index-ng/src/main.rs
+++ b/rs/ledger_suite/icrc1/index-ng/src/main.rs
@@ -1224,9 +1224,7 @@ fn check_index_and_ledger_block_equality() {
 
     let mut gamma = std::collections::HashSet::new();
     let index_block_type = ledger_env.merge_type(index_env, index_block_type.clone());
-    // Check if the ledger `query_encoded_blocks` response <: the index `get_blocks` response,
-    // i.e., if the index response type is a subtype of the ledger response type.
-    candid::types::subtype::subtype(
+    candid::types::subtype::equal(
         &mut gamma,
         &ledger_env,
         &ledger_block_type,

--- a/rs/ledger_suite/icrc1/index-ng/src/main.rs
+++ b/rs/ledger_suite/icrc1/index-ng/src/main.rs
@@ -1204,3 +1204,33 @@ fn check_candid_interface() {
         )
     });
 }
+
+#[test]
+fn check_index_and_ledger_block_equality() {
+    // check that ledger.did and index-ng.did agree on the block format
+    let manifest_dir = std::path::PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap());
+    let ledger_did_file = manifest_dir.join("../ledger/ledger.did");
+    let index_did_file = manifest_dir.join("index-ng.did");
+    let mut ledger_env = candid_parser::utils::CandidSource::File(ledger_did_file.as_path())
+        .load()
+        .unwrap()
+        .0;
+    let index_env = candid_parser::utils::CandidSource::File(index_did_file.as_path())
+        .load()
+        .unwrap()
+        .0;
+    let ledger_block_type = ledger_env.find_type("Block").unwrap().to_owned();
+    let index_block_type = index_env.find_type("Block").unwrap().to_owned();
+
+    let mut gamma = std::collections::HashSet::new();
+    let index_block_type = ledger_env.merge_type(index_env, index_block_type.clone());
+    // Check if the ledger `query_encoded_blocks` response <: the index `get_blocks` response,
+    // i.e., if the index response type is a subtype of the ledger response type.
+    candid::types::subtype::subtype(
+        &mut gamma,
+        &ledger_env,
+        &ledger_block_type,
+        &index_block_type,
+    )
+    .expect("Ledger and Index block types are different");
+}


### PR DESCRIPTION
Verify that the candid `Block` type returned by the ICRC ledger and index canisters are the same.