### PR TITLE
test(ICRC_Ledger): FI-1043: Verify ICRC ledger and archive block equality

### DIFF
--- a/rs/ledger_suite/icrc1/archive/BUILD.bazel
+++ b/rs/ledger_suite/icrc1/archive/BUILD.bazel
@@ -56,6 +56,7 @@ rust_test(
     crate = ":_wasm_archive_canister",
     data = [
         ":archive.did",
+        "//rs/ledger_suite/icrc1/ledger:ledger.did",
     ],
     env = {
         "CARGO_MANIFEST_DIR": "rs/ledger_suite/icrc1/archive",


### PR DESCRIPTION
Verify that the candid `Block` type returned by the ICRC ledger and archive canisters are the same.