### PR TITLE
fix: cargo build registry-canister for wasm32 target

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18340,6 +18340,7 @@ dependencies = [
  "dfn_core",
  "dfn_http_metrics",
  "futures",
+ "getrandom",
  "ic-base-types",
  "ic-canister-client-sender",
  "ic-cdk 0.16.0",

--- a/rs/registry/canister/Cargo.toml
+++ b/rs/registry/canister/Cargo.toml
@@ -51,6 +51,9 @@ prost = { workspace = true }
 serde = { workspace = true }
 url = { workspace = true }
 
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+getrandom = { version = "0.2", features = [ "custom" ] }
+
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 assert_matches = { workspace = true }
 candid_parser = { workspace = true }


### PR DESCRIPTION
The following command currently failed to compile the registry canister if running from the /ic/rs/registery/canister sub-directory: 

  cargo build --profile canister-release --target wasm32-unknown-unknown --bin registry-canister

The fix is to make sure the feature `getrandom/custom` is enabled.

Note that the above command would succeed if running from the top-level directory, but would produce incorrect wasm binary. This is because cargo would bring in global dependencies that enable both `getrandom/custom` and `getrandom/js` features, and the latter will lead to wasm binaries having unwanted imports (See #3309 for more details).

Since this problem does not affect bazel builds, this fix is only relevant to cargo.