### PR TITLE
test(ICP_Ledger): FI-1506: Remove flaky flag from ICP ledger and index tests

### DIFF
--- a/rs/ledger_suite/icp/index/BUILD.bazel
+++ b/rs/ledger_suite/icp/index/BUILD.bazel
@@ -102,7 +102,6 @@ rust_ic_test(
         "LEDGER_CANISTER_NOTIFY_METHOD_WASM_PATH": "$(rootpath //rs/ledger_suite/icp/ledger:ledger-canister-wasm-notify-method)",
         "LEDGER_CANISTER_WASM_PATH": "$(rootpath //rs/ledger_suite/icp/ledger:ledger-canister-wasm)",
     },
-    flaky = True,
     tags = ["cpu:4"],
     deps = [":ic-icp-index"] + DEPENDENCIES + DEV_DEPENDENCIES,
 )

--- a/rs/ledger_suite/icp/ledger/BUILD.bazel
+++ b/rs/ledger_suite/icp/ledger/BUILD.bazel
@@ -129,7 +129,6 @@ rust_ic_test(
         "LEDGER_CANISTER_NEXT_VERSION_WASM_PATH": "$(rootpath :ledger-canister-wasm-next-version)",
         "LEDGER_CANISTER_LOW_LIMITS_WASM_PATH": "$(rootpath :ledger-canister-wasm-low-limits)",
     },
-    flaky = True,
     tags = ["cpu:4"],
     deps = [
         # Keep sorted.


### PR DESCRIPTION
After limiting parallelization and dedicating more resources to running the tests, they are no longer flaky (no flakiness observed in the past week). This PR therefore removes the flaky flag, so that failures would show up and wouldn't be masked by automatic flakiness-retries.