### PR TITLE
feat(EXC-1800): Use Wasmtime `deserialize_open_file`.

### DIFF
--- a/rs/embedders/src/wasmtime_embedder.rs
+++ b/rs/embedders/src/wasmtime_embedder.rs
@@ -11,8 +11,6 @@ use std::{
     convert::TryFrom,
     fs::File,
     mem::size_of,
-    os::fd::{AsRawFd, IntoRawFd},
-    os::unix::fs::MetadataExt,
     sync::{atomic::Ordering, Arc, Mutex},
 };
 
@@ -39,7 +37,6 @@ use ic_types::{
 };
 use ic_wasm_types::{BinaryEncodedWasm, WasmEngineError};
 use memory_tracker::{DirtyPageTracking, PageBitmap, SigsegvMemoryTracker};
-use nix::sys::mman::{mmap, MapFlags, ProtFlags};
 use signal_stack::WasmtimeSignalStack;
 
 use crate::wasm_utils::instrumentation::{


### PR DESCRIPTION
EXC-1800

When using the on-disk compilation cache, switch to Wasmtime's new `deserialize_open_file` API which allows sandboxes to mmap the existing file so that canister code doesn't take up resident memory in the sandbox.