### PR TITLE
feat(governance-tools): Pretty add-release-to-changelog.sh output.

### DIFF
--- a/testnet/tools/nns-tools/add-release-to-changelog.sh
+++ b/testnet/tools/nns-tools/add-release-to-changelog.sh
@@ -25,7 +25,7 @@ cd "$(repo_root)"
 PWD="$(pwd)"
 
 # Fetch the proposal.
-print_purple "Fetching proposal ${PROPOSAL_ID}..." >&2
+print_cyan "⏳ Fetching proposal ${PROPOSAL_ID}..." >&2
 PROPOSAL_INFO=$(
     __dfx --quiet \
         canister call \
@@ -38,7 +38,7 @@ PROPOSAL_INFO=$(
 # Unwrap.
 LEN=$(echo "${PROPOSAL_INFO}" | jq '. | length')
 if [[ "${LEN}" -ne 1 ]]; then
-    print_red "Unexpected result from the get_proposal_info method:" >&2
+    print_red "💀 Unexpected result from the get_proposal_info method:" >&2
     print_red "Should have one element, but has ${LEN}" >&2
     exit 1
 fi
@@ -47,7 +47,7 @@ PROPOSAL_INFO=$(echo "${PROPOSAL_INFO}" | jq '.[0]')
 # Assert was executed.
 EXECUTED_TIMESTAMP_SECONDS=$(echo "${PROPOSAL_INFO}" | jq '.executed_timestamp_seconds | tonumber')
 if [[ "${EXECUTED_TIMESTAMP_SECONDS}" -eq 0 ]]; then
-    print_red "Proposal ${PROPOSAL_ID} exists, but was not successfully executed." >&2
+    print_red "💀 Proposal ${PROPOSAL_ID} exists, but was not successfully executed." >&2
     exit 1
 fi
 SECONDS_AGO=$(($(date +%s) - "${EXECUTED_TIMESTAMP_SECONDS}"))
@@ -56,7 +56,7 @@ EXECUTED_ON=$(
         --date=@"${EXECUTED_TIMESTAMP_SECONDS}" \
         --iso-8601
 )
-print_purple "Proposal ${PROPOSAL_ID} was executed ${SECONDS_AGO} seconds ago." >&2
+print_cyan "🗳️  Proposal ${PROPOSAL_ID} was executed ${SECONDS_AGO} seconds ago." >&2
 
 # Extract which canister was upgraded, and to what commit.
 TITLE=$(echo "${PROPOSAL_INFO}" | jq -r '.proposal[0].title[0]')
@@ -85,10 +85,10 @@ fi
 # Fail if the proposal's commit is not checked out.
 if [[ $(git rev-parse HEAD) != $DESTINATION_COMMIT_ID* ]]; then
     echo >&2
-    print_red "You currently have $(git rev-parse HEAD)" >&2
+    print_red "💀 You currently have $(git rev-parse HEAD)" >&2
     print_red "checked out, but this command only supports being run when" >&2
     print_red "the proposal's commit (${DESTINATION_COMMIT_ID}) is checked out." >&2
-    exit 1
+    # DO NOT MERGE exit 1
 fi
 
 # cd to the canister's primary code path.
@@ -103,7 +103,7 @@ cd "${CANISTER_CODE_PATH}"
 # Assert that there is a CHANGELOG.md file.
 if [[ ! -e CHANGELOG.md ]]; then
     echo >&2
-    print_red "${CANISTER_NAME} has no CHANGELOG.md file." >&2
+    print_red "💀 ${CANISTER_NAME} has no CHANGELOG.md file." >&2
     exit 1
 fi
 # TODO: Also verify that unreleased_changelog.md exists.
@@ -117,7 +117,7 @@ NEW_FEATURES_AND_FIXES=$(
 )
 if [[ -z "${NEW_FEATURES_AND_FIXES}" ]]; then
     echo >&2
-    print_red "The ${CANISTER_NAME} canister has no information in its unreleased_changelog.md." >&2
+    print_red "💀 The ${CANISTER_NAME} canister has no information in its unreleased_changelog.md." >&2
     exit 1
 fi
 NEW_ENTRY="# ${EXECUTED_ON}: Proposal ${PROPOSAL_ID}
@@ -160,3 +160,8 @@ echo -n "${UNRELEASED_CHANGELOG_INTRODUCTION}
 ## Security
 """ \
     >unreleased_changelog.md
+
+echo >&2
+print_green '🎉 Success! Added new entry to CHANGELOG.md.' >&2
+print_cyan '💡 Run `git diff` to see the changes. If you are pleased, commit,' >&2
+print_cyan 'push, request review, and merge them into master, per usual.' >&2

--- a/testnet/tools/nns-tools/add-release-to-changelog.sh
+++ b/testnet/tools/nns-tools/add-release-to-changelog.sh
@@ -88,7 +88,7 @@ if [[ $(git rev-parse HEAD) != $DESTINATION_COMMIT_ID* ]]; then
     print_red "💀 You currently have $(git rev-parse HEAD)" >&2
     print_red "checked out, but this command only supports being run when" >&2
     print_red "the proposal's commit (${DESTINATION_COMMIT_ID}) is checked out." >&2
-    # DO NOT MERGE exit 1
+    exit 1
 fi
 
 # cd to the canister's primary code path.


### PR DESCRIPTION
# More Precisely, What

Added a success message.

Added emojis.

Changed informational messages from purple to cyan. I think dark grey would be best, but we don't (yet) have a function for that; cyan seems like the next best thing.

# Why

Silence is a highly ambiguous way to communicate.

> Explicit is better than implicit.
> --Zen of Python