### PR TITLE
chore: mute panics if a child process exits in PocketIC

### DIFF
--- a/rs/canister_sandbox/src/replica_controller/sandboxed_execution_controller.rs
+++ b/rs/canister_sandbox/src/replica_controller/sandboxed_execution_controller.rs
@@ -1198,12 +1198,14 @@ impl SandboxedExecutionController {
 
         // We spawn a thread to wait for the exit notification of the launcher
         // process.
-        thread::spawn(move || {
-            let pid = child.id();
-            let output = child.wait().unwrap();
+        if let FlagStatus::Enabled = embedder_config.panic_due_to_exit {
+            thread::spawn(move || {
+                let pid = child.id();
+                let output = child.wait().unwrap();
 
-            panic_due_to_exit(output, pid);
-        });
+                panic_due_to_exit(output, pid);
+            });
+        }
 
         Ok(Self {
             backends,

--- a/rs/canister_sandbox/src/replica_controller/sandboxed_execution_controller.rs
+++ b/rs/canister_sandbox/src/replica_controller/sandboxed_execution_controller.rs
@@ -2010,7 +2010,7 @@ pub fn panic_due_to_exit(output: ExitStatus, pid: u32) {
             pid, code
         ),
         None => panic!(
-            "Error from launcher process, pid {} exited due to signal! In test environments (e.g., PocketIC), you can safely ignore this message.",
+            "Error from launcher process, pid {} exited due to signal!",
             pid
         ),
     }

--- a/rs/config/src/embedders.rs
+++ b/rs/config/src/embedders.rs
@@ -247,6 +247,9 @@ pub struct Config {
 
     /// The maximum size of the stable memory.
     pub max_stable_memory_size: NumBytes,
+
+    /// If this flag is enabled, then child process exits result in a panic.
+    pub panic_due_to_exit: FlagStatus,
 }
 
 impl Config {
@@ -286,6 +289,7 @@ impl Config {
             max_wasm_memory_size: NumBytes::new(MAX_WASM_MEMORY_IN_BYTES),
             max_stable_memory_size: NumBytes::new(MAX_STABLE_MEMORY_IN_BYTES),
             wasm64_dirty_page_overhead_multiplier: WASM64_DIRTY_PAGE_OVERHEAD_MULTIPLIER,
+            panic_due_to_exit: FlagStatus::Enabled,
         }
     }
 }

--- a/rs/pocket_ic_server/src/pocket_ic.rs
+++ b/rs/pocket_ic_server/src/pocket_ic.rs
@@ -545,6 +545,8 @@ impl PocketIc {
             .embedders_config
             .feature_flags
             .rate_limiting_of_debug_prints = FlagStatus::Disabled;
+        // do not panic if a child process exits
+        hypervisor_config.embedders_config.panic_due_to_exit = FlagStatus::Disabled;
         let state_machine_config = StateMachineConfig::new(subnet_config, hypervisor_config);
         let t = time
             .duration_since(SystemTime::UNIX_EPOCH)


### PR DESCRIPTION
This PR mutes panics if a child process exits in PocketIC:
```
thread '<unnamed>' panicked at rs/canister_sandbox/src/replica_controller/sandboxed_execution_controller.rs:1827:17:
Error from launcher process, pid 8882 exited due to signal! In test environments (e.g., PocketIC), you can safely ignore this message.
```