### PR TITLE
chore(nns): Add a comment on MAX_NEURONS_FUND_PARTICIPANTS about its effect on instructions

### DIFF
--- a/rs/nns/governance/src/governance.rs
+++ b/rs/nns/governance/src/governance.rs
@@ -251,10 +251,14 @@ const NODE_PROVIDER_REWARD_PERIOD_SECONDS: u64 = 2629800;
 
 const VALID_MATURITY_MODULATION_BASIS_POINTS_RANGE: RangeInclusive<i32> = -500..=500;
 
-/// Maximum allowed number of Neurons' Fund participants that may participate in an SNS swap.
-/// Given the maximum number of SNS neurons per swap participant (a.k.a. neuron basket count),
-/// this constant can be used to obtain an upper bound for the number of SNS neurons created
-/// for the Neurons' Fund participants. See also `MAX_SNS_NEURONS_PER_BASKET`.
+/// Maximum allowed number of Neurons' Fund participants that may participate in an SNS swap. Given
+/// the maximum number of SNS neurons per swap participant (a.k.a. neuron basket count), this
+/// constant can be used to obtain an upper bound for the number of SNS neurons created for the
+/// Neurons' Fund participants. See also `MAX_SNS_NEURONS_PER_BASKET`. In addition, this constant
+/// also affects the upperbound of instructions needed to draw/refund maturity from/to the Neurons'
+/// Fund, so before increasing this constant, the impact on the instructions used by
+/// `CreateServiceNervousSystem` proposal execution also needs to be evaluated (currently, each
+/// neuron takes ~120K instructions to draw/refund maturity, so the total is ~600M).
 pub const MAX_NEURONS_FUND_PARTICIPANTS: u64 = 5_000;
 
 impl NetworkEconomics {

--- a/rs/nns/governance/src/neuron_store/benches.rs
+++ b/rs/nns/governance/src/neuron_store/benches.rs
@@ -404,6 +404,9 @@ fn draw_maturity_from_neurons_fund_stable() -> BenchResult {
     let mut rng = new_rng();
     let mut neuron_store = NeuronStore::new(BTreeMap::new());
     let mut neurons_fund_neurons = BTreeSet::new();
+    // When extrapolating to `MAX_NEURONS_FUND_PARTICIPANTS` (5K) neurons, the current performance
+    // of 12M instructions (as of the time of writing) becomes 600M instructions. This is relatively
+    // small compared to the instruction limit of 50B (or the 40B limit for application subnets).
     for _ in 0..100 {
         let neuron = new_neuron_builder(&mut rng, NeuronLocation::Heap, NeuronSize::Typical)
             .with_maturity_e8s_equivalent(2_000_000_000)


### PR DESCRIPTION
In the analysis of the safety of migrating neurons from heap to stable memory, one risk is that the `draw_maturity_from_neurons_fund`/`refund_maturity_to_neurons_fund` can take more instructions since reading from stable structures is more expensive. Therefore, the safety of such operations start to depend on how many neurons are involved in those operations. Adding a comment should help preventing any increase of this constant without considering its implications on the instructions cost.