### PR TITLE
feat(sns): add release runscript to replace runbook in notion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18430,6 +18430,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
 
 [[package]]
+name = "release-runscript"
+version = "0.9.0"
+dependencies = [
+ "anyhow",
+ "candid",
+ "colored",
+ "futures",
+ "ic-agent",
+ "ic-base-types",
+ "ic-nervous-system-agent",
+ "ic-nervous-system-clients",
+ "ic-nervous-system-common-test-keys",
+ "ic-nns-common",
+ "ic-nns-constants",
+ "rgb",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "tokio",
+]
+
+[[package]]
 name = "rend"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -197,6 +197,7 @@ members = [
     "rs/nervous_system/runtime",
     "rs/nervous_system/string",
     "rs/nervous_system/temporary",
+    "rs/nervous_system/tools/release-runscript",
     "rs/nervous_system/tools/sync-with-released-nervous-system-wasms",
     "rs/nns/constants",
     "rs/nns/common",

--- a/rs/nervous_system/tools/release-runscript/BUILD.bazel
+++ b/rs/nervous_system/tools/release-runscript/BUILD.bazel
@@ -1,0 +1,31 @@
+load("@rules_rust//rust:defs.bzl", "rust_binary")
+
+package(default_visibility = ["//visibility:public"])
+
+# See rs/nervous_system/feature_test.md
+DEPENDENCIES = [
+    # Keep sorted.
+    "//rs/nervous_system/agent",
+    "//rs/nervous_system/clients",
+    "//rs/nns/common",
+    "//rs/nns/constants",
+    "//rs/types/base_types",
+    "@crate_index//:anyhow",
+    "@crate_index//:candid",
+    "@crate_index//:colored",
+    "@crate_index//:futures",
+    "@crate_index//:ic-agent",
+    "@crate_index//:rgb",
+    "@crate_index//:serde",
+    "@crate_index//:serde_json",
+    "@crate_index//:tempfile",
+    "@crate_index//:tokio",
+]
+
+rust_binary(
+    name = "release-runscript",
+    srcs = [
+        "src/main.rs",
+    ],
+    deps = DEPENDENCIES,
+)

--- a/rs/nervous_system/tools/release-runscript/Cargo.toml
+++ b/rs/nervous_system/tools/release-runscript/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "release-runscript"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+description.workspace = true
+documentation.workspace = true
+
+[[bin]]
+name = "release-runscript"
+path = "src/main.rs"
+
+[dependencies]
+anyhow = { workspace = true }
+candid = { workspace = true }
+colored = "2.0.0"
+futures = { workspace = true }
+ic-agent = { workspace = true }
+ic-base-types = { path = "../../../types/base_types" }
+ic-nervous-system-agent = { path = "../../agent" }
+ic-nervous-system-clients = { path = "../../clients" }
+ic-nervous-system-common-test-keys = { path = "../../common/test_keys" }
+ic-nns-common = { path = "../../../nns/common" }
+ic-nns-constants = { path = "../../../nns/constants" }
+rgb = "0.8.37"
+serde = { workspace = true }
+serde_json = { workspace = true }
+tempfile = { workspace = true }
+tokio = { workspace = true }

--- a/rs/nervous_system/tools/release-runscript/src/main.rs
+++ b/rs/nervous_system/tools/release-runscript/src/main.rs
@@ -10,9 +10,11 @@ fn main() {
     let steps = vec![
         Step {
             title: "Pick Release Candidate Commit",
-            description: "1. Go to https://github.com/dfinity/ic/actions/workflows/ci-main.yml?query=branch%3Amaster+event%3Apush+is%3Asuccess
-2. Find a recent commit with passing CI Main in the master branch
-3. Record this commit (e.g., post to Slack)
+            description: "Run `./testnet/tools/nns-tools/cmd.sh latest_commit_with_prebuilt_artifacts`.
+If you would like to pick a different commit, follow these steps:
+2. Go to https://github.com/dfinity/ic/actions/workflows/ci-main.yml?query=branch%3Amaster+event%3Apush+is%3Asuccess
+3. Find a recent commit with passing CI Main in the master branch
+4. Record this commit (e.g., post to Slack)
 
 Pre-built artifacts check:
 - Install aws tool if needed
@@ -39,14 +41,15 @@ For SNS ledger suite (ledger, archive, and index canisters):
         },
         Step {
             title: "Run NNS Upgrade Tests",
-            description: "1. Run NNS upgrade tests:
-   - Follow instructions in: testnet/tools/nns-tools/README.md#upgrade-testing-via-bazel
+            description: "Verify the commit you chose at the previous step has a green check on this page: https://github.com/dfinity/ic/actions/workflows/ci-main.yml?query=branch:master+event:push+is:success
+
+If not, you can also run the upgrade tests manually:
+    - Follow instructions in: testnet/tools/nns-tools/README.md#upgrade-testing-via-bazel
    
 2. SNS Testing Note:
    - No manual testing needed for SNS
    - Covered by sns_release_qualification in CI
-   - Example: Test at rs/nervous_system/integration_tests/tests/sns_release_qualification.rs
-   - Verify this passed in CI (e.g., https://dash.zh1-idx1.dfinity.network/invocation/...)",
+   - Example: Test at rs/nervous_system/integration_tests/tests/sns_release_qualification.rs",
         },
         Step {
             title: "Create Proposal Texts",
@@ -138,27 +141,6 @@ Calendar Event Setup:
    - Click 'Save' to create event
    - Send email invitations when prompted
    - If people don't respond, ping @trusted-neurons in #eng-release channel",
-        },
-        Step {
-            title: "Post to Slack",
-            description: "1. Post to #eng-nns-releases:
-   - Paste the proposal text
-   - Include dashboard link (https://dashboard.internetcomputer.org/proposal/<PROPOSAL_ID>)
-   - Command to copy proposal: cat /path/to/proposal_text.md | pbcopy
-
-2. For bigger feature releases:
-   - Ping comms team in #social-media
-   - They may share additional information over forum/socials
-   - They can encourage manual voting",
-        },
-        Step {
-            title: "Alert FITS",
-            description: "Important: Upgrades might trigger IC_NNS_SubnetMessageInstructionsNearLimit or similar alerts
-
-Required Communications:
-1. Notify FITS oncall in #first-incident-responder-team:
-   - Alert them ahead of time about the upcoming upgrade
-   - Send another notification right before trusted neurons vote",
         },
         Step {
             title: "Update Mainnet Canisters",

--- a/rs/nervous_system/tools/release-runscript/src/main.rs
+++ b/rs/nervous_system/tools/release-runscript/src/main.rs
@@ -1,0 +1,228 @@
+use colored::*;
+use std::io::{self, Write};
+
+struct Step {
+    title: &'static str,
+    description: &'static str,
+}
+
+fn main() {
+    let steps = vec![
+        Step {
+            title: "Pick Release Candidate Commit",
+            description: "1. Go to https://github.com/dfinity/ic/actions/workflows/ci-main.yml?query=branch%3Amaster+event%3Apush+is%3Asuccess
+2. Find a recent commit with passing CI Main in the master branch
+3. Record this commit (e.g., post to Slack)
+
+Pre-built artifacts check:
+- Install aws tool if needed
+- List available files: 
+  aws s3 ls --no-sign-request s3://dfinity-download-public/ic/${COMMIT}/canisters/
+- Note: Our tools download from the analogous https://download.dfinity.systems/... URL",
+        },
+        Step {
+            title: "Determine Upgrade Targets",
+            description: "Determine which NNS canisters and/or SNS WASMs need to be upgraded/published.
+Only those with 'interesting' changes need to be released.
+
+Required checks:
+1. Run: ./testnet/tools/nns-tools/list-new-commits.sh
+2. Check Monday team sync meeting minutes at:
+   https://docs.google.com/document/d/1CPM1RlMz6UMSUQzqvdP7EDiLMomK4YeuEV7UnxQ9DAE/edit
+
+For SNS ledger suite (ledger, archive, and index canisters):
+- Consult Financial Integrations team
+- FI team should contact NNS team Friday morning about significant changes
+- FI team should provide the 'Features' section of proposals
+- This agreement is new - you may need to remind them
+- This applies to ledger, archive, and index canisters",
+        },
+        Step {
+            title: "Run NNS Upgrade Tests",
+            description: "1. Run NNS upgrade tests:
+   - Follow instructions in: testnet/tools/nns-tools/README.md#upgrade-testing-via-bazel
+   
+2. SNS Testing Note:
+   - No manual testing needed for SNS
+   - Covered by sns_release_qualification in CI
+   - Example: Test at rs/nervous_system/integration_tests/tests/sns_release_qualification.rs
+   - Verify this passed in CI (e.g., https://dash.zh1-idx1.dfinity.network/invocation/...)",
+        },
+        Step {
+            title: "Create Proposal Texts",
+            description: "Create proposal text for each canister to be upgraded.
+This can be done in parallel with the previous testing step.
+
+Instructions:
+1. Follow format in: testnet/tools/nns-tools/README.md#nnssns-canister-upgrade-proposal-process
+2. Name conventions:
+   - NNS proposals: nns-*.md
+   - SNS proposals: sns-*.md
+3. Organization:
+   - Put all proposal files in a dedicated directory
+   - Keep directory clean (nothing else in there)
+   - This will help with forum post generation later",
+        },
+        Step {
+            title: "Submit Proposals",
+            description: "Submit the proposals on Friday
+
+Follow detailed instructions at:
+testnet/tools/nns-tools/README.md#submit-the-proposals",
+        },
+        Step {
+            title: "Create Forum Post",
+            description: "Create a forum post with the following specifications:
+
+1. Title Format: 
+   'NNS Updates <ISO 8601 DATE>(: <Anything interesting to announce>)'
+
+2. Category: 
+   Governance > NNS proposal discussion
+   Reference: https://forum.dfinity.org/t/nns-proposal-discussions/34492
+
+3. Tags:
+   - Protocol-canister-management / Service-nervous-system-management
+   - nns / sns
+
+4. Content:
+   - Link to proposals in IC Dashboard
+   - Include all proposal texts
+   - Use six consecutive backticks (```````) to wrap proposal text
+   - Call out any 'interesting' changes, breaking changes, or required actions
+
+5. Generate Forum Content:
+   If your proposals are in a dedicated directory:
+
+   For NNS upgrades:
+   ```bash
+   ./testnet/tools/nns-tools/cmd.sh \\
+       generate_forum_post_nns_upgrades \\
+       $PROPOSALS_DIR/nns-*.md \\
+       | pbcopy
+   ```
+
+   For SNS WASM publishing:
+   ```bash
+   ./testnet/tools/nns-tools/cmd.sh \\
+       generate_forum_post_sns_wasm_publish \\
+       $PROPOSALS_DIR/sns-*.md \\
+       | pbcopy
+   ```
+
+6. Required Follow-ups:
+   - Reply to NNS Updates Aggregation Thread (https://forum.dfinity.org/t/nns-updates-aggregation-thread/23551)
+   - If SNS canister WASMs were published, update SNS Upgrades Aggregation Thread
+     (https://forum.dfinity.org/t/sns-upgrade-aggregation-thread/24259/2)",
+        },
+        Step {
+            title: "Schedule Trusted Neurons Vote",
+            description: "Schedule calendar event for Trusted Neurons to vote the following Monday.
+
+Calendar Event Setup:
+1. Duplicate a past event from:
+   https://calendar.google.com/calendar/u/0/r/eventedit/duplicate/MjJvMTdva2xtdGJuZDhoYjRjN2poZzNwM2ogY182NGYwZDdmZDYzYjNlMDYxZjE1Zjk2MTU1NWYzMmFiN2EyZmY3M2NjMWJmM2Q3ZTRkNGI3NGVjYjk1ZWVhM2M0QGc
+
+2. Use 'NNS Upgrades' calendar
+
+3. Timing:
+   - Usually scheduled at 6 pm Central European Time
+   - For multiple proposals, schedule separate sequential events
+
+4. Required Fields:
+   - Date and Time
+   - Title: Include canister name and proposal ID
+   - Description: Link to the proposal
+
+5. Actions:
+   - Click 'Save' to create event
+   - Send email invitations when prompted
+   - If people don't respond, ping @trusted-neurons in #eng-release channel",
+        },
+        Step {
+            title: "Post to Slack",
+            description: "1. Post to #eng-nns-releases:
+   - Paste the proposal text
+   - Include dashboard link (https://dashboard.internetcomputer.org/proposal/<PROPOSAL_ID>)
+   - Command to copy proposal: cat /path/to/proposal_text.md | pbcopy
+
+2. For bigger feature releases:
+   - Ping comms team in #social-media
+   - They may share additional information over forum/socials
+   - They can encourage manual voting",
+        },
+        Step {
+            title: "Alert FITS",
+            description: "Important: Upgrades might trigger IC_NNS_SubnetMessageInstructionsNearLimit or similar alerts
+
+Required Communications:
+1. Notify FITS oncall in #first-incident-responder-team:
+   - Alert them ahead of time about the upcoming upgrade
+   - Send another notification right before trusted neurons vote",
+        },
+        Step {
+            title: "Update Mainnet Canisters",
+            description: "After proposal execution, update mainnet-canisters.json:
+
+1. Run the sync command:
+   bazel run //rs/nervous_system/tools/sync-with-released-nevous-system-wasms
+
+   Note: If you encounter problems, try adding --config=local
+
+2. Purpose of these changes:
+   - Tells bazel what versions are running in production
+   - Used by tests to verify upgrade compatibility
+   - Maintains build hermeticity
+
+3. Note on automation:
+   - There was a ticket for automating this (NNS1-2201)
+   - Currently marked as won't do",
+        },
+        Step {
+            title: "Update Changelog",
+            description: "Update CHANGELOG.md file(s) for each proposal:
+
+1. For each proposal ID:
+   ```bash
+   PROPOSAL_IDS=...
+
+   for PROPOSAL_ID in $PROPOSAL_IDS do
+       ./testnet/tools/nns-tools/add-release-to-changelog.sh \\
+           $PROPOSAL_ID
+   done
+   ```
+
+2. Best Practice:
+   - Combine this change with mainnet-canisters.json update in the same PR",
+        },
+    ];
+
+    println!("{}", "\nNNS Release Runscript".bright_green().bold());
+    println!("{}", "===================".bright_green());
+    println!("This script will guide you through the NNS release process.\n");
+
+    for (index, step) in steps.iter().enumerate() {
+        print_step(index + 1, step);
+
+        print!("\nPress Enter to continue to next step...");
+        io::stdout().flush().unwrap();
+        let mut input = String::new();
+        io::stdin().read_line(&mut input).unwrap();
+
+        // Clear screen for next step
+        print!("\x1B[2J\x1B[1;1H");
+    }
+
+    println!("{}", "\nRelease process complete!".bright_green().bold());
+    println!("Please verify that all steps were completed successfully.");
+}
+
+fn print_step(number: usize, step: &Step) {
+    println!(
+        "{} {}",
+        format!("Step {}:", number).bright_blue().bold(),
+        step.title.white().bold()
+    );
+    println!("{}", "---".bright_blue());
+    println!("{}\n", step.description);
+}


### PR DESCRIPTION
This PR introduces a simple interactive "runscript" version of our NNS release runbook. 

A runscript is what I call a program that walks you through a procedure step-by-step, waiting for confirmation before showing the next step.

Runscripts have one big advantage over runbooks: They're easy to automate incrementally. Just replace "press enter to continue" with actual automation for specific step.

This first version is intentionally simple - it just shows the steps and waits for the user to press enter. But it provides a foundation we can build on to gradually automate pieces of the release process.