### PR TITLE
chore: Remove deprecated CanisterStatusResult type

### DIFF
--- a/rs/rust_canisters/canister_test/src/canister.rs
+++ b/rs/rust_canisters/canister_test/src/canister.rs
@@ -5,7 +5,7 @@ use ic_canister_client::{Agent, Sender};
 use ic_config::Config;
 use ic_management_canister_types::CanisterStatusType::Stopped;
 pub use ic_management_canister_types::{
-    self as ic00, CanisterIdRecord, CanisterInstallMode, CanisterStatusResult, InstallCodeArgs,
+    self as ic00, CanisterIdRecord, CanisterInstallMode, InstallCodeArgs,
     ProvisionalCreateCanisterWithCyclesArgs, IC_00,
 };
 use ic_registry_transport::pb::v1::RegistryMutation;
@@ -808,7 +808,7 @@ impl<'a> Canister<'a> {
             .await;
         stop_res?;
         loop {
-            let status_res: Result<CanisterStatusResult, String> = self
+            let status_res: Result<CanisterStatusResultV2, String> = self
                 .runtime
                 .get_management_canister_with_effective_canister_id(self.canister_id().into())
                 .update_("canister_status", candid, (self.as_record(),))

--- a/rs/rust_canisters/tests/test/canister_management.rs
+++ b/rs/rust_canisters/tests/test/canister_management.rs
@@ -2,7 +2,7 @@ use assert_matches::assert_matches;
 use candid::{Decode, Encode};
 use canister_test::{local_test_e, Canister, Runtime, Wasm};
 use ic_error_types::ErrorCode;
-use ic_management_canister_types::{self as ic00, CanisterIdRecord, CanisterStatusResult, IC_00};
+use ic_management_canister_types::{self as ic00, CanisterIdRecord, CanisterStatusResultV2, IC_00};
 use ic_test_utilities::universal_canister::UNIVERSAL_CANISTER_WASM;
 use ic_test_utilities::universal_canister::{
     wasm as universal_canister_argument_builder, CallArgs,
@@ -32,7 +32,7 @@ fn test_set_controller() {
         // aaaaa-aa"
         //
         // The anonymous user is not allowed to do a "canister_status"
-        let res: Result<CanisterStatusResult, String> = runtime
+        let res: Result<CanisterStatusResultV2, String> = runtime
             .get_management_canister_with_effective_canister_id(
                 universal_canister.canister_id().into(),
             )
@@ -59,7 +59,7 @@ fn test_set_controller() {
             .update_("update", bytes, arg)
             .await
             .unwrap();
-        let status = Decode!(&status_bytes, CanisterStatusResult).unwrap();
+        let status = Decode!(&status_bytes, CanisterStatusResultV2).unwrap();
         assert_eq!(status.controller(), universal_canister.canister_id().get());
 
         Ok(())

--- a/rs/tests/driver/src/util.rs
+++ b/rs/tests/driver/src/util.rs
@@ -29,7 +29,7 @@ use ic_agent::{
 use ic_canister_client::{Agent as DeprecatedAgent, Sender};
 use ic_config::ConfigOptional;
 use ic_limits::MAX_INGRESS_TTL;
-use ic_management_canister_types::{CanisterStatusResult, EmptyBlob, Payload};
+use ic_management_canister_types::{CanisterStatusResultV2, EmptyBlob, Payload};
 use ic_message::ForwardParams;
 use ic_nervous_system_proto::pb::v1::GlobalTimeOfDay;
 use ic_nns_constants::{GOVERNANCE_CANISTER_ID, ROOT_CANISTER_ID};
@@ -1237,7 +1237,7 @@ pub async fn get_balance_via_canister(
         )
         .await
         .map(|res| {
-            Decode!(res.as_slice(), CanisterStatusResult)
+            Decode!(res.as_slice(), CanisterStatusResultV2)
                 .unwrap()
                 .cycles()
                 .into()

--- a/rs/tests/nns/nns_cycles_minting_multi_app_subnets_test.rs
+++ b/rs/tests/nns/nns_cycles_minting_multi_app_subnets_test.rs
@@ -3,7 +3,7 @@ use cycles_minting::{make_user_ed25519, TestAgent, UserHandle};
 use cycles_minting_canister::{SubnetFilter, SubnetSelection, CREATE_CANISTER_REFUND_FEE};
 use dfn_candid::candid_one;
 use ic_canister_client::{HttpClient, Sender};
-use ic_management_canister_types::{CanisterIdRecord, CanisterStatusResult};
+use ic_management_canister_types::{CanisterIdRecord, CanisterStatusResultV2};
 use ic_nervous_system_common_test_keys::{TEST_USER1_KEYPAIR, TEST_USER1_PRINCIPAL};
 use ic_nns_constants::{CYCLES_MINTING_CANISTER_ID, LEDGER_CANISTER_ID};
 use ic_registry_subnet_type::SubnetType;
@@ -242,7 +242,7 @@ pub fn create_canister_on_specific_subnet_type(env: TestEnv) {
             node_on_type1_subnet.effective_canister_id(),
         );
 
-        let _status: CanisterStatusResult = authorized_runtime
+        let _status: CanisterStatusResultV2 = authorized_runtime
             .get_management_canister_with_effective_canister_id(
                 canister_on_authorized_subnet.into(),
             )
@@ -255,7 +255,7 @@ pub fn create_canister_on_specific_subnet_type(env: TestEnv) {
             .await
             .unwrap();
 
-        let _status: CanisterStatusResult = type1_runtime
+        let _status: CanisterStatusResultV2 = type1_runtime
             .get_management_canister_with_effective_canister_id(canister_on_type1_subnet.into())
             .update_from_sender(
                 "canister_status",
@@ -266,7 +266,7 @@ pub fn create_canister_on_specific_subnet_type(env: TestEnv) {
             .await
             .unwrap();
 
-        let _status: CanisterStatusResult = type1_runtime
+        let _status: CanisterStatusResultV2 = type1_runtime
             .get_management_canister_with_effective_canister_id(canister_on_type1_subnet_2.into())
             .update_from_sender(
                 "canister_status",
@@ -277,7 +277,7 @@ pub fn create_canister_on_specific_subnet_type(env: TestEnv) {
             .await
             .unwrap();
 
-        let _status: CanisterStatusResult = authorized_runtime
+        let _status: CanisterStatusResultV2 = authorized_runtime
             .get_management_canister_with_effective_canister_id(
                 canister_on_specific_subnet_authorized.into(),
             )
@@ -290,7 +290,7 @@ pub fn create_canister_on_specific_subnet_type(env: TestEnv) {
             .await
             .unwrap();
 
-        let _status: CanisterStatusResult = type1_runtime
+        let _status: CanisterStatusResultV2 = type1_runtime
             .get_management_canister_with_effective_canister_id(
                 canister_on_specific_subnet_type1.into(),
             )

--- a/rs/tests/nns/nns_cycles_minting_test.rs
+++ b/rs/tests/nns/nns_cycles_minting_test.rs
@@ -13,7 +13,7 @@ use ic_crypto_tree_hash::MixedHashTree;
 use ic_crypto_utils_threshold_sig_der::threshold_sig_public_key_from_der;
 use ic_ledger_core::tokens::CheckedAdd;
 use ic_limits::SMALL_APP_SUBNET_MAX_SIZE;
-use ic_management_canister_types::{CanisterIdRecord, CanisterStatusResult};
+use ic_management_canister_types::{CanisterIdRecord, CanisterStatusResultV2};
 use ic_nervous_system_clients::canister_status::CanisterStatusResult as RootCanisterStatusResult;
 use ic_nervous_system_common_test_keys::{
     TEST_NEURON_1_ID, TEST_NEURON_1_OWNER_KEYPAIR, TEST_USER1_KEYPAIR, TEST_USER1_PRINCIPAL,
@@ -545,7 +545,7 @@ pub fn test(env: TestEnv) {
 
         let nonce_size = 8; // see RemoteTestRuntime::get_nonce_vec
 
-        let new_canister_status: CanisterStatusResult =
+        let new_canister_status: CanisterStatusResultV2 =
             runtime_from_url(app_node.get_public_url(), app_node.effective_canister_id())
                 .get_management_canister_with_effective_canister_id(new_canister_id.into())
                 .update_from_sender(
@@ -634,7 +634,7 @@ pub fn test(env: TestEnv) {
 
             let nonce_size = 8; // see RemoteTestRuntime::get_nonce_vec
 
-            let new_canister_status: CanisterStatusResult =
+            let new_canister_status: CanisterStatusResultV2 =
                 runtime_from_url(app_node.get_public_url(), app_node.effective_canister_id())
                     .get_management_canister_with_effective_canister_id(new_canister_id.into())
                     .update_from_sender(
@@ -698,7 +698,7 @@ pub fn test(env: TestEnv) {
             .unwrap();
 
         /* Check the controller / cycles balance. */
-        let new_canister_status: CanisterStatusResult = nns
+        let new_canister_status: CanisterStatusResultV2 = nns
             .get_management_canister_with_effective_canister_id(new_canister_id.into())
             .update_from_sender(
                 "canister_status",
@@ -730,7 +730,7 @@ pub fn test(env: TestEnv) {
                 .unwrap();
 
             /* Check the controller / cycles balance. */
-            let new_canister_status: CanisterStatusResult = nns
+            let new_canister_status: CanisterStatusResultV2 = nns
                 .get_management_canister_with_effective_canister_id(new_canister_id.into())
                 .update_from_sender(
                     "canister_status",

--- a/rs/types/management_canister_types/src/lib.rs
+++ b/rs/types/management_canister_types/src/lib.rs
@@ -956,62 +956,6 @@ impl DefiniteCanisterSettingsArgs {
 
 impl Payload<'_> for DefiniteCanisterSettingsArgs {}
 
-/// The deprecated version of CanisterStatusResult that is being
-/// used by NNS canisters.
-#[derive(Eq, PartialEq, Debug, CandidType, Deserialize)]
-pub struct CanisterStatusResult {
-    status: CanisterStatusType,
-    module_hash: Option<Vec<u8>>,
-    controller: candid::Principal,
-    memory_size: candid::Nat,
-    cycles: candid::Nat,
-    // this is for compat with Spec 0.12/0.13
-    balance: Vec<(Vec<u8>, candid::Nat)>,
-}
-
-impl CanisterStatusResult {
-    pub fn new(
-        status: CanisterStatusType,
-        module_hash: Option<Vec<u8>>,
-        controller: PrincipalId,
-        memory_size: NumBytes,
-        cycles: u128,
-    ) -> Self {
-        Self {
-            status,
-            module_hash,
-            controller: candid::Principal::from_text(controller.to_string()).unwrap(),
-            memory_size: candid::Nat::from(memory_size.get()),
-            cycles: candid::Nat::from(cycles),
-            // the following is spec 0.12/0.13 compat;
-            // "\x00" denotes cycles
-            balance: vec![(vec![0], candid::Nat::from(cycles))],
-        }
-    }
-
-    pub fn status(&self) -> CanisterStatusType {
-        self.status.clone()
-    }
-
-    pub fn module_hash(&self) -> Option<Vec<u8>> {
-        self.module_hash.clone()
-    }
-
-    pub fn controller(&self) -> PrincipalId {
-        PrincipalId::try_from(self.controller.as_slice()).unwrap()
-    }
-
-    pub fn memory_size(&self) -> NumBytes {
-        NumBytes::from(self.memory_size.0.to_u64().unwrap())
-    }
-
-    pub fn cycles(&self) -> u128 {
-        self.cycles.0.to_u128().unwrap()
-    }
-}
-
-impl Payload<'_> for CanisterStatusResult {}
-
 #[derive(Eq, PartialEq, Debug, CandidType, Deserialize)]
 pub struct QueryStats {
     num_calls_total: candid::Nat,


### PR DESCRIPTION
`CanisterStatusResult` was used by NNS canisters but not anymore