### PR TITLE
chore: state-tool copy commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12524,6 +12524,7 @@ dependencies = [
  "ic-registry-subnet-type",
  "ic-replicated-state",
  "ic-state-layout",
+ "ic-state-machine-tests",
  "ic-state-manager",
  "ic-sys",
  "ic-types",

--- a/rs/state_layout/src/state_layout.rs
+++ b/rs/state_layout/src/state_layout.rs
@@ -473,21 +473,36 @@ impl TipHandler {
 }
 
 impl StateLayout {
-    /// Needs to be pub for criterion performance regression tests.
+    /// Create a new StateLayout and initialize it by creating all necessary
+    /// directories if they do not exist already and clear all tmp directories
+    /// that are expected to be empty when the replica starts.
+    /// Needs to be pub for tests.
     pub fn try_new(
         log: ReplicaLogger,
         root: PathBuf,
         metrics_registry: &MetricsRegistry,
     ) -> Result<Self, LayoutError> {
-        let state_layout = Self {
+        let state_layout = Self::new_no_init(log, root, metrics_registry);
+        state_layout.init()?;
+        Ok(state_layout)
+    }
+
+    /// Create a new StateLayout without initializing it. Useful for tests and
+    /// tools that want to create a StateLayout without interferring with
+    /// replicas / state managers that are already running using the same state
+    /// directory.
+    pub fn new_no_init(
+        log: ReplicaLogger,
+        root: PathBuf,
+        metrics_registry: &MetricsRegistry,
+    ) -> Self {
+        Self {
             root,
             log,
             metrics: StateLayoutMetrics::new(metrics_registry),
             tip_handler_captured: Arc::new(false.into()),
             checkpoint_ref_registry: Arc::new(Mutex::new(BTreeMap::new())),
-        };
-        state_layout.init()?;
-        Ok(state_layout)
+        }
     }
 
     fn init(&self) -> Result<(), LayoutError> {
@@ -1171,7 +1186,7 @@ impl StateLayout {
     /// path into the specified dst path.
     ///
     /// If a thread-pool is provided then files are copied in parallel.
-    fn copy_and_sync_checkpoint(
+    pub fn copy_and_sync_checkpoint(
         &self,
         name: &str,
         src: &Path,

--- a/rs/state_machine_tests/src/lib.rs
+++ b/rs/state_machine_tests/src/lib.rs
@@ -1177,7 +1177,7 @@ impl StateMachineBuilder {
             self.is_root_subnet,
             self.seed,
             self.log_level,
-            self.remove_old_states
+            self.remove_old_states,
         )
     }
 

--- a/rs/state_manager/src/lib.rs
+++ b/rs/state_manager/src/lib.rs
@@ -329,7 +329,7 @@ impl MergeMetrics {
 // very first metric update should be visible to Prometheus.
 
 impl StateManagerMetrics {
-    fn new(metrics_registry: &MetricsRegistry, log: ReplicaLogger) -> Self {
+    pub fn new(metrics_registry: &MetricsRegistry, log: ReplicaLogger) -> Self {
         let checkpoint_op_duration = metrics_registry.histogram_vec(
             "state_manager_checkpoint_op_duration_seconds",
             "Duration of checkpoint operations in seconds.",
@@ -1815,7 +1815,7 @@ impl StateManagerImpl {
                     match StateMetadata::try_from(pb) {
                         Ok(meta) => {
                             if let Some(root_hash) = meta.root_hash() {
-                                info!(log, "Recomputed root hash {:?} when loading state metadata at height {}", root_hash, h);
+                                info!(log, "Root hash {:?} when loading state metadata at height {}", root_hash, h);
                             }
                             map.insert(Height::new(h), meta);
                         }

--- a/rs/state_manager/src/lib.rs
+++ b/rs/state_manager/src/lib.rs
@@ -1815,7 +1815,12 @@ impl StateManagerImpl {
                     match StateMetadata::try_from(pb) {
                         Ok(meta) => {
                             if let Some(root_hash) = meta.root_hash() {
-                                info!(log, "Root hash {:?} when loading state metadata at height {}", root_hash, h);
+                                info!(
+                                    log,
+                                    "Root hash {:?} when loading state metadata at height {}",
+                                    root_hash,
+                                    h
+                                );
                             }
                             map.insert(Height::new(h), meta);
                         }

--- a/rs/state_tool/BUILD.bazel
+++ b/rs/state_tool/BUILD.bazel
@@ -1,6 +1,5 @@
-load("@rules_rust//rust:defs.bzl", "rust_binary", "rust_library", "rust_test")
-load("//bazel:defs.bzl", "rust_bench", "rust_ic_test")
-
+load("@rules_rust//rust:defs.bzl", "rust_binary", "rust_library")
+load("//bazel:defs.bzl", "rust_ic_test")
 
 DEPENDENCIES = [
     # Keep sorted.
@@ -71,8 +70,8 @@ rust_ic_test(
 
 rust_ic_test(
     name = "state_tool_integration_test",
-    aliases = ALIASES,
     srcs = ["src/main.rs"],
+    aliases = ALIASES,
     proc_macro_deps = MACRO_DEPENDENCIES + MACRO_DEV_DEPENDENCIES,
     deps = DEPENDENCIES + DEV_DEPENDENCIES + [":state_tool_lib"],
 )

--- a/rs/state_tool/BUILD.bazel
+++ b/rs/state_tool/BUILD.bazel
@@ -1,4 +1,6 @@
 load("@rules_rust//rust:defs.bzl", "rust_binary", "rust_library", "rust_test")
+load("//bazel:defs.bzl", "rust_bench", "rust_ic_test")
+
 
 DEPENDENCIES = [
     # Keep sorted.
@@ -25,6 +27,7 @@ MACRO_DEPENDENCIES = []
 
 DEV_DEPENDENCIES = [
     # Keep sorted.
+    "//rs/state_machine_tests",
     "@crate_index//:tempfile",
 ]
 
@@ -58,10 +61,18 @@ rust_binary(
     deps = DEPENDENCIES + [":state_tool_lib"],
 )
 
-rust_test(
+rust_ic_test(
     name = "state_tool_test",
     aliases = ALIASES,
     crate = ":state_tool_lib",
     proc_macro_deps = MACRO_DEPENDENCIES + MACRO_DEV_DEPENDENCIES,
     deps = DEPENDENCIES + DEV_DEPENDENCIES,
+)
+
+rust_ic_test(
+    name = "state_tool_integration_test",
+    aliases = ALIASES,
+    srcs = ["src/main.rs"],
+    proc_macro_deps = MACRO_DEPENDENCIES + MACRO_DEV_DEPENDENCIES,
+    deps = DEPENDENCIES + DEV_DEPENDENCIES + [":state_tool_lib"],
 )

--- a/rs/state_tool/Cargo.toml
+++ b/rs/state_tool/Cargo.toml
@@ -32,4 +32,5 @@ slog = { workspace = true }
 slog-term = { workspace = true }
 
 [dev-dependencies]
+ic-state-machine-tests = { path = "../state_machine_tests" }
 tempfile = { workspace = true }

--- a/rs/state_tool/src/commands.rs
+++ b/rs/state_tool/src/commands.rs
@@ -2,6 +2,7 @@
 pub mod cdiff;
 pub mod chash;
 pub mod convert_ids;
+pub mod copy;
 pub mod decode;
 pub mod import_state;
 pub mod list;

--- a/rs/state_tool/src/commands/import_state.rs
+++ b/rs/state_tool/src/commands/import_state.rs
@@ -1,71 +1,9 @@
 //! Imports replicated state from an external location.
 
 use crate::commands::utils;
-use ic_state_layout::{CheckpointLayout, RwPolicy};
-use ic_sys::fs::{clone_file, copy_file_sparse};
+use ic_state_layout::StateLayout;
 use ic_types::Height;
-use std::fs;
-use std::path::{Path, PathBuf};
-use std::string::ToString;
-
-/// Copies SRC into DST recursively.
-///
-/// Function is not crash-safe. Caller is responsible to follow guidelines
-/// regarding crash-safe I/O.
-fn copy_recursively(src: &Path, dst: &Path) -> Result<(), String> {
-    enum CanCloneFiles {
-        Yes,
-        No,
-    }
-    fn go(src: &Path, dst: &Path, can_clone: &mut CanCloneFiles) -> Result<(), String> {
-        let src_metadata = src
-            .metadata()
-            .map_err(|e| format!("failed to get metadata of path {}: {}", src.display(), e))?;
-
-        if src_metadata.is_dir() {
-            let entries = src
-                .read_dir()
-                .map_err(|e| format!("failed to read directory {}: {}", src.display(), e))?;
-
-            fs::create_dir_all(dst)
-                .map_err(|e| format!("failed to create directory {}: {}", dst.display(), e))?;
-
-            for entry_result in entries {
-                let entry = entry_result.map_err(|e| {
-                    format!("failed to read entry of directory {}: {}", src.display(), e)
-                })?;
-                let dst_entry = dst.join(entry.file_name());
-
-                go(&entry.path(), &dst_entry, can_clone)?;
-            }
-        } else {
-            if let CanCloneFiles::Yes = can_clone {
-                match clone_file(src, dst) {
-                    Ok(_) => return Ok(()),
-                    Err(_) => {
-                        *can_clone = CanCloneFiles::No;
-                    }
-                }
-            }
-
-            copy_file_sparse(src, dst).map_err(|e| {
-                format!(
-                    "Failed to copy {} -> {}: {}",
-                    src.display(),
-                    dst.display(),
-                    e
-                )
-            })?;
-        }
-
-        Ok(())
-    }
-    // We try to clone files first because it's much faster for big files.
-    // If cloning fails (most likely, because SRC and DST are on different file
-    // systems), we fall back to usual copying.
-    let mut can_clone = CanCloneFiles::Yes;
-    go(src, dst, &mut can_clone)
-}
+use std::path::PathBuf;
 
 /// Imports a checkpoint of replicated state into the replica state directory.
 ///
@@ -83,24 +21,16 @@ pub fn do_import(state_path: PathBuf, config_path: PathBuf, height: u64) -> Resu
         ));
     }
 
-    let scratchpad_dir = state_layout
-        .state_sync_scratchpad(height)
-        .map_err(|e| format!("Failed to get a scratchpad directory: {}", e))?;
-
-    copy_recursively(&state_path, &scratchpad_dir)?;
-
-    let cp_layout = CheckpointLayout::<RwPolicy<()>>::new_untracked(scratchpad_dir, height)
-        .map_err(|e| format!("Failed to create scratchpad checkpoint layout: {}", e))?;
-
     state_layout
-        .scratchpad_to_checkpoint(cp_layout, height, None)
-        .map_err(|e| e.to_string())?;
-
-    println!(
-        "Successfully created checkpoint {} in state root {}",
-        height,
-        state_layout.raw_path().display()
-    );
+        .copy_and_sync_checkpoint(
+            &format!("import_{}", height),
+            &state_path,
+            &state_layout
+                .checkpoints()
+                .join(StateLayout::checkpoint_name(height)),
+            None,
+        )
+        .map_err(|e| format!("Failed to import checkpoint: {}", e))?;
 
     Ok(())
 }

--- a/rs/state_tool/src/main.rs
+++ b/rs/state_tool/src/main.rs
@@ -43,7 +43,7 @@ enum Opt {
         height: u64,
     },
 
-    /// Copies states from one ic_state directory to another.
+    /// Copies states from one ic_state directory to another including their metadata.
     #[clap(name = "copy")]
     CopyStates {
         /// Path to the source ic_state directory.

--- a/rs/state_tool/src/main.rs
+++ b/rs/state_tool/src/main.rs
@@ -170,7 +170,7 @@ struct HeightsArgs {
     /// Mutually exclusive with `--heights`. If neither is specified, all heights are copied.
     #[clap(long = "latest")]
     latest: bool,
-    /// List of heights to copy. If not specified, all heights are copied.
+    /// List of heights to copy.
     ///
     /// Heights can be specified as a comma separated list of heights. Optionally, a state can be renamed by specifiying the source and destination height separated by '->'.
     ///

--- a/rs/state_tool/src/main.rs
+++ b/rs/state_tool/src/main.rs
@@ -165,7 +165,7 @@ enum Opt {
 #[derive(Debug, Clone, clap::Args)]
 #[group(multiple = false)]
 struct HeightsArgs {
-    /// Copy the latest state only.
+    /// Copy the latest state only, or none if there are no states in the source.
     ///
     /// Mutually exclusive with `--heights`. If neither is specified, all heights are copied.
     #[clap(long = "latest")]

--- a/rs/state_tool/src/main.rs
+++ b/rs/state_tool/src/main.rs
@@ -8,8 +8,8 @@ use clap::Parser;
 use ic_registry_routing_table::CanisterIdRange;
 use ic_registry_subnet_type::SubnetType;
 use ic_state_tool::commands;
-use ic_types::{PrincipalId, Time};
-use std::path::PathBuf;
+use ic_types::{Height, PrincipalId, Time};
+use std::{error::Error, path::PathBuf};
 
 /// Supported `state_tool` commands and their arguments.
 #[derive(Debug, Parser)]
@@ -41,6 +41,24 @@ enum Opt {
         /// The height to label the state with.
         #[clap(long = "height", short = 'h')]
         height: u64,
+    },
+
+    /// Copies states from one ic_state directory to another.
+    #[clap(name = "copy")]
+    CopyStates {
+        /// Path to the source ic_state directory.
+        source: PathBuf,
+        /// Path to the destination ic_state directory.
+        destination: PathBuf,
+        /// List of heights to copy. If not specified, all heights are copied.
+        ///
+        /// Heights can be specified as a comma separated list of heights. Optionally, a state can be renamed by specifiying the source and destination height separated by '->'.
+        ///
+        /// Examples:
+        ///     - `--heights 1,2,3` copies states at heights 1, 2, and 3.
+        ///     - `--heights 1->2` copies the state at height 1 and renames it to height 2.
+        #[clap(long = "heights", value_parser = parse_height_pair, value_delimiter = ',', verbatim_doc_comment)]
+        heights: Option<Vec<(Height, Option<Height>)>>,
     },
 
     /// Computes manifest of a checkpoint.
@@ -149,8 +167,27 @@ enum Opt {
     },
 }
 
+/// Parser for either a single height or a pair of heights separated by '->'.
+/// Used to parse the `--heights` argument of the `copy` command.
+fn parse_height_pair(
+    s: &str,
+) -> Result<(Height, Option<Height>), Box<dyn Error + Send + Sync + 'static>> {
+    match s.find("->") {
+        Some(pos) => Ok((
+            Height::new(s[..pos].parse()?),
+            Some(Height::new(s[pos + 2..].parse()?)),
+        )),
+        None => Ok((Height::new(s.parse()?), None)),
+    }
+}
+
 fn main() {
-    let opt = Parser::parse();
+    let args = std::env::args().collect();
+    main_inner(args);
+}
+
+pub(crate) fn main_inner(args: Vec<String>) {
+    let opt = Parser::parse_from(args);
     let result = match opt {
         Opt::CDiff { path_a, path_b } => commands::cdiff::do_diff(path_a, path_b),
         Opt::CHash { path } => commands::chash::do_hash(path),
@@ -159,6 +196,11 @@ fn main() {
             config,
             height,
         } => commands::import_state::do_import(state, config, height),
+        Opt::CopyStates {
+            source,
+            destination,
+            heights,
+        } => commands::copy::do_copy(source, destination, heights),
         Opt::Manifest { path } => commands::manifest::do_compute_manifest(path),
         Opt::VerifyManifest { file } => commands::verify_manifest::do_verify_manifest(&file),
         Opt::ListStates { config } => commands::list::do_list(config),
@@ -205,5 +247,119 @@ fn main() {
     if let Err(e) = result {
         eprintln!("{}", e);
         std::process::exit(1);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ic_logger::no_op_logger;
+    use ic_metrics::MetricsRegistry;
+    use ic_state_layout::StateLayout;
+    use ic_state_machine_tests::StateMachineBuilder;
+    use tempfile::TempDir;
+
+    #[test]
+    fn copy_command_line_test() {
+        let env = StateMachineBuilder::new().build();
+        env.checkpointed_tick();
+        env.state_manager.flush_tip_channel();
+
+        let dst_dir = TempDir::new().unwrap();
+
+        main_inner(vec![
+            "state-tool".to_string(),
+            "copy".to_string(),
+            env.state_manager
+                .state_layout()
+                .raw_path()
+                .display()
+                .to_string(),
+            dst_dir.path().display().to_string(),
+        ]);
+
+        let dst_layout = StateLayout::try_new(
+            no_op_logger(),
+            dst_dir.path().to_path_buf(),
+            &MetricsRegistry::new(),
+        )
+        .unwrap();
+
+        assert_eq!(
+            dst_layout.checkpoint_heights().unwrap(),
+            vec![Height::new(1)]
+        );
+    }
+
+    #[test]
+    fn copy_command_line_rename_test() {
+        let env = StateMachineBuilder::new().build();
+        env.checkpointed_tick();
+        env.state_manager.flush_tip_channel();
+
+        let dst_dir = TempDir::new().unwrap();
+
+        main_inner(vec![
+            "state-tool".to_string(),
+            "copy".to_string(),
+            env.state_manager
+                .state_layout()
+                .raw_path()
+                .display()
+                .to_string(),
+            dst_dir.path().display().to_string(),
+            "--heights".to_string(),
+            "1->2".to_string(),
+        ]);
+
+        let dst_layout = StateLayout::try_new(
+            no_op_logger(),
+            dst_dir.path().to_path_buf(),
+            &MetricsRegistry::new(),
+        )
+        .unwrap();
+
+        assert_eq!(
+            dst_layout.checkpoint_heights().unwrap(),
+            vec![Height::new(2)]
+        );
+    }
+
+    #[test]
+    fn copy_command_line_filter_test() {
+        let env = StateMachineBuilder::new()
+            .with_remove_old_states(false)
+            .build();
+        env.checkpointed_tick();
+        env.checkpointed_tick();
+        env.checkpointed_tick();
+        env.state_manager.flush_tip_channel();
+
+        let dst_dir = TempDir::new().unwrap();
+
+        main_inner(vec![
+            "state-tool".to_string(),
+            "copy".to_string(),
+            env.state_manager
+                .state_layout()
+                .raw_path()
+                .display()
+                .to_string(),
+            dst_dir.path().display().to_string(),
+            "--heights".to_string(),
+            "1,3".to_string(),
+        ]);
+
+        let dst_layout = StateLayout::try_new(
+            no_op_logger(),
+            dst_dir.path().to_path_buf(),
+            &MetricsRegistry::new(),
+        )
+        .unwrap();
+
+        assert_eq!(
+            dst_layout.checkpoint_heights().unwrap(),
+            vec![Height::new(1), Height::new(3)]
+        );
     }
 }


### PR DESCRIPTION
This commit introduces the "copy" subcommand to the state-tool copying checkpoints from one place to another.

This command can both be used to backup a state as well as importing a state to an existing directory. It handles both the checkpoint files itself as well as the accompanying metadata such as manifests.

The new subcommand is more general than the existing "import" subcommand, as the old one only allows for imports and does not handle metadata. This commit does however not remove "import" in case somebody relies on it, and simplifies its internals a bit instead.