### PR TITLE
chore(ckbtc): upgrade ckBTC ledger suite

### DIFF
--- a/rs/bitcoin/ckbtc/mainnet/ckbtc_archive_upgrade_2025_01_17.md
+++ b/rs/bitcoin/ckbtc/mainnet/ckbtc_archive_upgrade_2025_01_17.md
@@ -15,8 +15,8 @@ Previous ckBTC archive proposal: https://dashboard.internetcomputer.org/proposal
 ---
 
 ## Motivation
-TODO: THIS MUST BE FILLED OUT
 
+Upgrade the ckBTC archive canister to the same version ([ledger-suite-icrc-2025-01-07](https://github.com/dfinity/ic/releases/tag/ledger-suite-icrc-2025-01-07)) as the ckBTC ledger canister to maintain a consistent versioning across the ckBTC ledger suite.
 
 ## Upgrade args
 

--- a/rs/bitcoin/ckbtc/mainnet/ckbtc_archive_upgrade_2025_01_17.md
+++ b/rs/bitcoin/ckbtc/mainnet/ckbtc_archive_upgrade_2025_01_17.md
@@ -29,9 +29,10 @@ didc encode '()' | xxd -r -p | sha256sum
 
 ## Release Notes
 
+No changes since last version (`2190613d3b5bcd9b74c382b22d151580b8ac271a`).
+
 ```
 git log --format='%C(auto) %h %s' 2190613d3b5bcd9b74c382b22d151580b8ac271a..c741e349451edf0c9792149ad439bb32a0161371 -- rs/ledger_suite/icrc1/archive
-
  ```
 
 ## Wasm Verification

--- a/rs/bitcoin/ckbtc/mainnet/ckbtc_archive_upgrade_2025_01_17.md
+++ b/rs/bitcoin/ckbtc/mainnet/ckbtc_archive_upgrade_2025_01_17.md
@@ -1,0 +1,46 @@
+# Proposal to upgrade the ckBTC archive canister
+
+Repository: `https://github.com/dfinity/ic.git`
+
+Git hash: `c741e349451edf0c9792149ad439bb32a0161371`
+
+New compressed Wasm hash: `2b0970a84976bc2eb9591b68d44501566937994fa5594972f8aac9c8b058672f`
+
+Upgrade args hash: `0fee102bd16b053022b69f2c65fd5e2f41d150ce9c214ac8731cfaf496ebda4e`
+
+Target canister: `nbsys-saaaa-aaaar-qaaga-cai`
+
+Previous ckBTC archive proposal: https://dashboard.internetcomputer.org/proposal/134451
+
+---
+
+## Motivation
+TODO: THIS MUST BE FILLED OUT
+
+
+## Upgrade args
+
+```
+git fetch
+git checkout c741e349451edf0c9792149ad439bb32a0161371
+cd rs/ledger_suite/icrc1/archive
+didc encode '()' | xxd -r -p | sha256sum
+```
+
+## Release Notes
+
+```
+git log --format='%C(auto) %h %s' 2190613d3b5bcd9b74c382b22d151580b8ac271a..c741e349451edf0c9792149ad439bb32a0161371 -- rs/ledger_suite/icrc1/archive
+
+ ```
+
+## Wasm Verification
+
+Verify that the hash of the gzipped WASM matches the proposed hash.
+
+```
+git fetch
+git checkout c741e349451edf0c9792149ad439bb32a0161371
+"./ci/container/build-ic.sh" "--canisters"
+sha256sum ./artifacts/canisters/ic-icrc1-archive.wasm.gz
+```

--- a/rs/bitcoin/ckbtc/mainnet/ckbtc_index_upgrade_2025_01_17.md
+++ b/rs/bitcoin/ckbtc/mainnet/ckbtc_index_upgrade_2025_01_17.md
@@ -15,8 +15,8 @@ Previous ckBTC index proposal: https://dashboard.internetcomputer.org/proposal/1
 ---
 
 ## Motivation
-TODO: THIS MUST BE FILLED OUT
 
+Upgrade the ckBTC index canister to the same version ([ledger-suite-icrc-2025-01-07](https://github.com/dfinity/ic/releases/tag/ledger-suite-icrc-2025-01-07)) as the ckBTC ledger canister to maintain a consistent versioning across the ckBTC ledger suite.
 
 ## Upgrade args
 

--- a/rs/bitcoin/ckbtc/mainnet/ckbtc_index_upgrade_2025_01_17.md
+++ b/rs/bitcoin/ckbtc/mainnet/ckbtc_index_upgrade_2025_01_17.md
@@ -1,0 +1,49 @@
+# Proposal to upgrade the ckBTC index canister
+
+Repository: `https://github.com/dfinity/ic.git`
+
+Git hash: `c741e349451edf0c9792149ad439bb32a0161371`
+
+New compressed Wasm hash: `e155db9d06b6147ece4f9defe599844f132a7db21693265671aa6ac60912935f`
+
+Upgrade args hash: `0fee102bd16b053022b69f2c65fd5e2f41d150ce9c214ac8731cfaf496ebda4e`
+
+Target canister: `n5wcd-faaaa-aaaar-qaaea-cai`
+
+Previous ckBTC index proposal: https://dashboard.internetcomputer.org/proposal/134449
+
+---
+
+## Motivation
+TODO: THIS MUST BE FILLED OUT
+
+
+## Upgrade args
+
+```
+git fetch
+git checkout c741e349451edf0c9792149ad439bb32a0161371
+cd rs/ledger_suite/icrc1/index-ng
+didc encode '()' | xxd -r -p | sha256sum
+```
+
+## Release Notes
+
+```
+git log --format='%C(auto) %h %s' 2190613d3b5bcd9b74c382b22d151580b8ac271a..c741e349451edf0c9792149ad439bb32a0161371 -- rs/ledger_suite/icrc1/index-ng
+c741e34945 feat: ICRC-ledger: FI-1439: Implement V4 for ICRC ledger - migrate balances to stable structures (#2901)
+575ca531a7 chore(ICRC_Index): FI-1468: Remove old ICRC index canister (#3286)
+8d4fcddc6e test(ICRC_Index): FI-1617: Optimize retrieve_blocks_from_ledger_interval tests (#3236)
+e369646b76 fix: Use default rust edition instead of specifying it in the BUILD rules (#3047)
+ ```
+
+## Wasm Verification
+
+Verify that the hash of the gzipped WASM matches the proposed hash.
+
+```
+git fetch
+git checkout c741e349451edf0c9792149ad439bb32a0161371
+"./ci/container/build-ic.sh" "--canisters"
+sha256sum ./artifacts/canisters/ic-icrc1-index-ng.wasm.gz
+```

--- a/rs/bitcoin/ckbtc/mainnet/ckbtc_ledger_upgrade_2025_01_17.md
+++ b/rs/bitcoin/ckbtc/mainnet/ckbtc_ledger_upgrade_2025_01_17.md
@@ -15,8 +15,8 @@ Previous ckBTC ledger proposal: https://dashboard.internetcomputer.org/proposal/
 ---
 
 ## Motivation
-TODO: THIS MUST BE FILLED OUT
 
+Upgrade the ckBTC ledger canister to the latest version ([ledger-suite-icrc-2025-01-07](https://github.com/dfinity/ic/releases/tag/ledger-suite-icrc-2025-01-07)) to continue the migration towards stable memory.
 
 ## Upgrade args
 

--- a/rs/bitcoin/ckbtc/mainnet/ckbtc_ledger_upgrade_2025_01_17.md
+++ b/rs/bitcoin/ckbtc/mainnet/ckbtc_ledger_upgrade_2025_01_17.md
@@ -1,0 +1,49 @@
+# Proposal to upgrade the ckBTC ledger canister
+
+Repository: `https://github.com/dfinity/ic.git`
+
+Git hash: `c741e349451edf0c9792149ad439bb32a0161371`
+
+New compressed Wasm hash: `3b03d1bb1145edbcd11101ab2788517bc0f427c3bd7b342b9e3e7f42e29d5822`
+
+Upgrade args hash: `0fee102bd16b053022b69f2c65fd5e2f41d150ce9c214ac8731cfaf496ebda4e`
+
+Target canister: `mxzaz-hqaaa-aaaar-qaada-cai`
+
+Previous ckBTC ledger proposal: https://dashboard.internetcomputer.org/proposal/134450
+
+---
+
+## Motivation
+TODO: THIS MUST BE FILLED OUT
+
+
+## Upgrade args
+
+```
+git fetch
+git checkout c741e349451edf0c9792149ad439bb32a0161371
+cd rs/ledger_suite/icrc1/ledger
+didc encode '()' | xxd -r -p | sha256sum
+```
+
+## Release Notes
+
+```
+git log --format='%C(auto) %h %s' 2190613d3b5bcd9b74c382b22d151580b8ac271a..c741e349451edf0c9792149ad439bb32a0161371 -- rs/ledger_suite/icrc1/ledger
+c741e34945 feat: ICRC-ledger: FI-1439: Implement V4 for ICRC ledger - migrate balances to stable structures (#2901)
+ddadaafd51 test(ICP_Ledger): FI-1616: Fix ICP ledger upgrade tests (#3213)
+dfc3810851 fix(ICRC-Ledger): changed certificate version (#2848)
+b006ae9934 feat(ICP-ledger): FI-1438: Implement V3 for ICP ledger - migrate allowances to stable structures (#2818)
+ ```
+
+## Wasm Verification
+
+Verify that the hash of the gzipped WASM matches the proposed hash.
+
+```
+git fetch
+git checkout c741e349451edf0c9792149ad439bb32a0161371
+"./ci/container/build-ic.sh" "--canisters"
+sha256sum ./artifacts/canisters/ic-icrc1-ledger.wasm.gz
+```


### PR DESCRIPTION
Proposals to upgrade the ckBTC ledger suite (index, ledger and archive canisters) to [ledger-suite-icrc-2025-01-07](https://github.com/dfinity/ic/releases/tag/ledger-suite-icrc-2025-01-07).