### PR TITLE
chore(IDX): Use repository_ctx.getenv

### DIFF
--- a/bazel/sanitizers_enabled_env/defs.bzl
+++ b/bazel/sanitizers_enabled_env/defs.bzl
@@ -8,7 +8,7 @@ def _impl(repository_ctx):
     )
     repository_ctx.file(
         "defs.bzl",
-        content = "SANITIZERS_ENABLED=" + repository_ctx.os.environ.get("SANITIZERS_ENABLED", "0") + "\n",
+        content = "SANITIZERS_ENABLED=" + repository_ctx.getenv("SANITIZERS_ENABLED", "0") + "\n",
         executable = False,
     )
 
@@ -16,6 +16,5 @@ def sanitizers_enabled_env(name = None):
     rule = repository_rule(
         implementation = _impl,
         local = True,
-        environ = ["SANITIZERS_ENABLED"],
     )
     rule(name = name)


### PR DESCRIPTION
This ensures that the repository rule get re-evaluated when the env var changes without having to specify it as a rule input.