### PR TITLE
refactor(consensus): simplify `IngressPayload` implementation

### DIFF
--- a/rs/consensus/src/consensus/malicious_consensus.rs
+++ b/rs/consensus/src/consensus/malicious_consensus.rs
@@ -87,7 +87,9 @@ fn maliciously_propose_blocks(
         .get_block_maker_rank(height, &beacon, my_node_id)
     {
         Ok(Some(rank)) => Some(rank),
-        Ok(None) => Some(Rank(0)),
+        // TODO: introduce a malicious flag which will instruct a malicious node to propose a block
+        // when it's not elected a block maker; implement a system test which uses the flag.
+        Ok(None) => None,
         Err(_) => None,
     };
 

--- a/rs/consensus/src/consensus/metrics.rs
+++ b/rs/consensus/src/consensus/metrics.rs
@@ -157,7 +157,7 @@ impl BatchStats {
         self.ingress_message_bytes_delivered += payload.ingress.count_bytes();
         self.xnet_bytes_delivered += payload.xnet.size_bytes();
         self.ingress_ids
-            .extend_from_slice(&payload.ingress.message_ids());
+            .extend(payload.ingress.message_ids().cloned());
     }
 }
 

--- a/rs/consensus/src/consensus/purger.rs
+++ b/rs/consensus/src/consensus/purger.rs
@@ -905,10 +905,10 @@ mod tests {
                         non_finalized_notarization_2
                     )),
                     ChangeAction::RemoveFromValidated(ConsensusMessage::BlockProposal(
-                        non_finalized_block_proposal_2_1
+                        non_finalized_block_proposal_2_0
                     )),
                     ChangeAction::RemoveFromValidated(ConsensusMessage::BlockProposal(
-                        non_finalized_block_proposal_2_0
+                        non_finalized_block_proposal_2_1
                     )),
                 ]
             );

--- a/rs/ingress_manager/src/ingress_selector.rs
+++ b/rs/ingress_manager/src/ingress_selector.rs
@@ -330,10 +330,29 @@ impl IngressSelector for IngressManager {
 
         // Tracks the sum of cycles needed per canister.
         let mut cycles_needed: BTreeMap<CanisterId, Cycles> = BTreeMap::new();
-        for i in 0..payload.message_count() {
-            let (ingress_id, ingress) = payload
-                .get(i)
-                .map_err(InvalidIngressPayloadReason::IngressPayloadError)?;
+
+        // Validate each ingress message in the payload
+        for (ingress_id, maybe_ingress) in payload.iter() {
+            let ingress = match maybe_ingress {
+                Ok(ingress) => ingress,
+                Err(deserialization_error) => {
+                    return Err(ValidationError::InvalidArtifact(
+                        InvalidIngressPayloadReason::IngressMessageDeserializationFailure(
+                            ingress_id.clone(),
+                            deserialization_error.to_string(),
+                        ),
+                    ));
+                }
+            };
+
+            if IngressMessageId::from(&ingress) != *ingress_id {
+                return Err(ValidationError::InvalidArtifact(
+                    InvalidIngressPayloadReason::MismatchedMessageId {
+                        expected: ingress_id.clone(),
+                        computed: IngressMessageId::from(&ingress),
+                    },
+                ));
+            }
 
             self.validate_ingress(
                 ingress_id.clone(),
@@ -373,7 +392,7 @@ impl IngressSelector for IngressManager {
                     let ingress = ingress_payload_cache
                         .entry((*height, payload_hash.clone()))
                         .or_insert_with(|| {
-                            Arc::new(batch.ingress.message_ids().into_iter().collect())
+                            Arc::new(batch.ingress.message_ids().cloned().collect())
                         });
                     Some(ingress.clone())
                 }
@@ -1046,11 +1065,8 @@ mod tests {
                 assert_eq!(first_ingress_payload.message_count(), 1);
 
                 // we should not get it again because it is part of past payloads
-                let mut hash_set = HashSet::new();
-                for i in 0..first_ingress_payload.message_count() {
-                    let (id, _) = first_ingress_payload.get(i).unwrap();
-                    hash_set.insert(id);
-                }
+                let hash_set = HashSet::from_iter(first_ingress_payload.message_ids().cloned());
+
                 let second_ingress_payload = ingress_manager.get_ingress_payload(
                     &hash_set,
                     &validation_context,

--- a/rs/interfaces/src/ingress_manager.rs
+++ b/rs/interfaces/src/ingress_manager.rs
@@ -6,7 +6,7 @@ use crate::{
 use ic_interfaces_state_manager::StateManagerError;
 use ic_types::{
     artifact::IngressMessageId,
-    batch::{IngressPayload, IngressPayloadError, ValidationContext},
+    batch::{IngressPayload, ValidationContext},
     consensus::Payload,
     ingress::IngressSets,
     messages::MessageId,
@@ -52,8 +52,14 @@ impl IngressSetQuery for IngressSets {
 /// Reasons for why an ingress payload might be invalid.
 #[derive(Eq, PartialEq, Debug)]
 pub enum InvalidIngressPayloadReason {
+    /// In [`IngressMessageId`] inside the payload doesn't match the referenced [`SignedIngress`].
+    MismatchedMessageId {
+        expected: IngressMessageId,
+        computed: IngressMessageId,
+    },
+    /// Failed to deserialize an ingress message.
+    IngressMessageDeserializationFailure(IngressMessageId, String),
     IngressValidationError(MessageId, String),
-    IngressPayloadError(IngressPayloadError),
     IngressExpired(MessageId, String),
     IngressMessageTooBig(usize, usize),
     IngressPayloadTooManyMessages(usize, usize),

--- a/rs/interfaces/src/ingress_manager.rs
+++ b/rs/interfaces/src/ingress_manager.rs
@@ -52,7 +52,7 @@ impl IngressSetQuery for IngressSets {
 /// Reasons for why an ingress payload might be invalid.
 #[derive(Eq, PartialEq, Debug)]
 pub enum InvalidIngressPayloadReason {
-    /// In [`IngressMessageId`] inside the payload doesn't match the referenced [`SignedIngress`].
+    /// An [`IngressMessageId`] inside the payload doesn't match the referenced [`SignedIngress`].
     MismatchedMessageId {
         expected: IngressMessageId,
         computed: IngressMessageId,

--- a/rs/p2p/artifact_downloader/src/fetch_stripped_artifact/download.rs
+++ b/rs/p2p/artifact_downloader/src/fetch_stripped_artifact/download.rs
@@ -84,7 +84,7 @@ impl Pools {
         };
 
         match data_payload.batch.ingress.get_by_id(ingress_message_id) {
-            Some(Ok(ingress_message)) => {
+            Ok(Some(ingress_message)) => {
                 self.metrics.ingress_messages_in_block.inc();
                 Ok(ingress_message)
             }

--- a/rs/p2p/artifact_downloader/src/fetch_stripped_artifact/download.rs
+++ b/rs/p2p/artifact_downloader/src/fetch_stripped_artifact/download.rs
@@ -84,11 +84,11 @@ impl Pools {
         };
 
         match data_payload.batch.ingress.get_by_id(ingress_message_id) {
-            Some(ingress_message) => {
+            Some(Ok(ingress_message)) => {
                 self.metrics.ingress_messages_in_block.inc();
                 Ok(ingress_message)
             }
-            None => {
+            _ => {
                 self.metrics.ingress_messages_not_found.inc();
                 Err(PoolsAccessError::IngressMessageNotFound)
             }

--- a/rs/p2p/artifact_downloader/src/fetch_stripped_artifact/stripper.rs
+++ b/rs/p2p/artifact_downloader/src/fetch_stripped_artifact/stripper.rs
@@ -55,7 +55,7 @@ impl Strippable for &IngressPayload {
 
     fn strip(self) -> Self::Output {
         Self::Output {
-            ingress_messages: self.message_ids(),
+            ingress_messages: self.message_ids().cloned().collect(),
         }
     }
 }

--- a/rs/protobuf/def/types/v1/consensus.proto
+++ b/rs/protobuf/def/types/v1/consensus.proto
@@ -204,9 +204,15 @@ message IngressIdOffset {
   uint64 offset = 3;
 }
 
+message IngressMessage {
+  bytes message_id = 1;
+  uint64 expiry = 2;
+  bytes signed_request_bytes = 3;
+}
+
 message IngressPayload {
-  repeated IngressIdOffset id_and_pos = 1;
-  bytes buffer = 2;
+  reserved 1, 2;
+  repeated IngressMessage ingress_messages = 3;
 }
 
 // Stripped consensus artifacts messages below

--- a/rs/protobuf/src/gen/types/types.v1.rs
+++ b/rs/protobuf/src/gen/types/types.v1.rs
@@ -1528,11 +1528,18 @@ pub struct IngressIdOffset {
     pub offset: u64,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
+pub struct IngressMessage {
+    #[prost(bytes = "vec", tag = "1")]
+    pub message_id: ::prost::alloc::vec::Vec<u8>,
+    #[prost(uint64, tag = "2")]
+    pub expiry: u64,
+    #[prost(bytes = "vec", tag = "3")]
+    pub signed_request_bytes: ::prost::alloc::vec::Vec<u8>,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct IngressPayload {
-    #[prost(message, repeated, tag = "1")]
-    pub id_and_pos: ::prost::alloc::vec::Vec<IngressIdOffset>,
-    #[prost(bytes = "vec", tag = "2")]
-    pub buffer: ::prost::alloc::vec::Vec<u8>,
+    #[prost(message, repeated, tag = "3")]
+    pub ingress_messages: ::prost::alloc::vec::Vec<IngressMessage>,
 }
 /// Stripped consensus artifacts messages below
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/rs/state_machine_tests/src/lib.rs
+++ b/rs/state_machine_tests/src/lib.rs
@@ -1362,9 +1362,7 @@ impl StateMachine {
         // used by the function `Self::execute_payload` of the `StateMachine`.
         let xnet_payload = batch_payload.xnet.clone();
         let ingress = &batch_payload.ingress;
-        let ingress_messages = (0..ingress.message_count())
-            .map(|i| ingress.get(i).unwrap().1)
-            .collect();
+        let ingress_messages = ingress.clone().try_into().unwrap();
         let (http_responses, _) =
             CanisterHttpPayloadBuilderImpl::into_messages(&batch_payload.canister_http);
         let inducted: Vec<_> = http_responses

--- a/rs/types/types/src/batch/ingress.rs
+++ b/rs/types/types/src/batch/ingress.rs
@@ -1,45 +1,42 @@
 use crate::{
     artifact::IngressMessageId,
-    messages::{MessageId, SignedIngress, SignedRequestBytes, EXPECTED_MESSAGE_ID_LENGTH},
+    messages::{
+        HttpRequestError, MessageId, SignedIngress, SignedRequestBytes, EXPECTED_MESSAGE_ID_LENGTH,
+    },
     CountBytes, Time,
 };
 #[cfg(test)]
 use ic_exhaustive_derive::ExhaustiveSet;
 use ic_protobuf::{proxy::ProxyDecodeError, types::v1 as pb};
 use serde::{Deserialize, Serialize};
-use std::{
-    convert::TryFrom,
-    io::{Cursor, Write},
-};
+use std::{collections::BTreeMap, convert::TryFrom, fmt::Display};
 
 /// Payload that contains Ingress messages
 #[derive(Clone, Eq, PartialEq, Hash, Debug, Default, Deserialize, Serialize)]
 #[cfg_attr(test, derive(ExhaustiveSet))]
 pub struct IngressPayload {
-    /// Pairs of MessageId and its serialized byte position in the buffer.
-    id_and_pos: Vec<(IngressMessageId, u64)>,
-    /// All messages are serialized in a single byte buffer, so individual
+    /// Keep ingress messages in a serialized form, so individual
     /// deserialization is delayed. This allows faster deserialization of
     /// IngressPayload when individual message is not needed (e.g. in
     /// ingress payload deduplication).
-    #[serde(with = "serde_bytes")]
-    buffer: Vec<u8>,
+    serialized_ingress_messages: BTreeMap<IngressMessageId, SignedRequestBytes>,
 }
 
 impl From<&IngressPayload> for pb::IngressPayload {
     fn from(ingress_payload: &IngressPayload) -> Self {
-        Self {
-            id_and_pos: ingress_payload
-                .id_and_pos
-                .iter()
-                .map(|(msg_id, offset)| pb::IngressIdOffset {
-                    expiry: msg_id.expiry().as_nanos_since_unix_epoch(),
-                    message_id: msg_id.message_id.as_bytes().to_vec(),
-                    offset: *offset,
-                })
-                .collect(),
-            buffer: ingress_payload.buffer.clone(),
-        }
+        let ingress_messages = ingress_payload
+            .serialized_ingress_messages
+            .iter()
+            .map(
+                |(ingress_message_id, serialized_ingress_message)| pb::IngressMessage {
+                    expiry: ingress_message_id.expiry().as_nanos_since_unix_epoch(),
+                    message_id: ingress_message_id.message_id.as_bytes().to_vec(),
+                    signed_request_bytes: serialized_ingress_message.as_ref().to_vec(),
+                },
+            )
+            .collect();
+
+        pb::IngressPayload { ingress_messages }
     }
 }
 
@@ -47,131 +44,98 @@ impl TryFrom<pb::IngressPayload> for IngressPayload {
     type Error = ProxyDecodeError;
 
     fn try_from(payload: pb::IngressPayload) -> Result<Self, Self::Error> {
+        let mut serialized_ingress_messages = BTreeMap::new();
+
+        for ingress_message_proto in payload.ingress_messages {
+            let ingress_message_id = IngressMessageId::new(
+                Time::from_nanos_since_unix_epoch(ingress_message_proto.expiry),
+                MessageId::try_from(ingress_message_proto.message_id.as_slice())?,
+            );
+
+            serialized_ingress_messages.insert(
+                ingress_message_id,
+                SignedRequestBytes::from(ingress_message_proto.signed_request_bytes),
+            );
+        }
+
         Ok(Self {
-            id_and_pos: payload
-                .id_and_pos
-                .iter()
-                .map(|ingress_offset| {
-                    Ok((
-                        IngressMessageId::new(
-                            Time::from_nanos_since_unix_epoch(ingress_offset.expiry),
-                            MessageId::try_from(ingress_offset.message_id.as_slice())?,
-                        ),
-                        ingress_offset.offset,
-                    ))
-                })
-                .collect::<Result<Vec<_>, ProxyDecodeError>>()?,
-            buffer: payload.buffer,
+            serialized_ingress_messages,
         })
     }
 }
 
-/// Index of an ingress message in the IngressPayload.
-type IngressIndex = usize;
+#[derive(Debug, PartialEq)]
+pub struct IngressPayloadError(HttpRequestError);
 
-/// Position of serialized ingress message in the payload buffer.
-type BufferPosition = u64;
-
-#[derive(Eq, PartialEq, Debug)]
-/// Possible errors when accessing messages in an [`IngressPayload`].
-pub enum IngressPayloadError {
-    IndexOutOfBound(IngressIndex),
-    IngressPositionOutOfBound(IngressIndex, BufferPosition),
-    DeserializationFailure(String),
-    MismatchedMessageIdAtIndex(IngressIndex),
+impl Display for IngressPayloadError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
 }
 
 impl IngressPayload {
     /// Return the number of ingress messages contained in this payload
     pub fn message_count(&self) -> usize {
-        self.id_and_pos.len()
+        self.serialized_ingress_messages.len()
     }
 
-    /// Return all MessageIds in the payload.
-    pub fn message_ids(&self) -> Vec<IngressMessageId> {
-        self.id_and_pos
-            .iter()
-            .map(|(id, _)| id.clone())
-            .collect::<Vec<_>>()
+    /// Return all [`IngressMessageId`]s in the payload.
+    pub fn message_ids(&self) -> impl Iterator<Item = &IngressMessageId> {
+        self.serialized_ingress_messages.keys()
     }
 
     /// Return true if the payload is empty.
     pub fn is_empty(&self) -> bool {
-        self.id_and_pos.is_empty()
+        self.serialized_ingress_messages.is_empty()
     }
 
-    // TODO(kpop): run some benchmarks and see if it makes sense to change the type of
-    // `[IngressPayload::id_and_pos]`
-    pub fn get_by_id(&self, ingress_message_id: &IngressMessageId) -> Option<SignedIngress> {
-        let (index, _) = self
-            .id_and_pos
-            .iter()
-            .enumerate()
-            .find(|(_, (id, _))| id == ingress_message_id)?;
-
-        self.get(index)
-            .map(|(_, ingress_message)| ingress_message)
-            .ok()
-    }
-
-    /// Return the ingress message at a given index, which is expected to be
-    /// less than `message_count`.
-    pub fn get(
+    /// Return the [`SignedIngress`] referenced by the [`IngressMessageId`].
+    /// Return [`IngressPayloadError`] if we fail to deserialize the message.
+    pub fn get_by_id(
         &self,
-        index: usize,
-    ) -> Result<(IngressMessageId, SignedIngress), IngressPayloadError> {
-        self.id_and_pos
-            .get(index)
-            .ok_or(IngressPayloadError::IndexOutOfBound(index))
-            .and_then(|(id, pos)| {
-                // Return error if pos is out of bound.
-                if *pos > self.buffer.len() as u64 {
-                    Err(IngressPayloadError::IngressPositionOutOfBound(index, *pos))
-                } else {
-                    let end = {
-                        if index == self.id_and_pos.len() - 1 {
-                            self.buffer.len()
-                        } else {
-                            self.id_and_pos[index + 1].1 as usize
-                        }
-                    };
-                    let ingress = SignedIngress::try_from(SignedRequestBytes::from(Vec::from(
-                        &self.buffer[*pos as usize..end],
-                    )))
-                    .map_err(|e| IngressPayloadError::DeserializationFailure(e.to_string()))?;
-                    let ingress_id = IngressMessageId::from(&ingress);
-                    if *id == ingress_id {
-                        Ok((ingress_id, ingress))
-                    } else {
-                        Err(IngressPayloadError::MismatchedMessageIdAtIndex(index))
-                    }
-                }
-            })
+        ingress_message_id: &IngressMessageId,
+    ) -> Option<Result<SignedIngress, IngressPayloadError>> {
+        self.serialized_ingress_messages
+            .get(ingress_message_id)
+            .map(|bytes| SignedIngress::try_from(bytes.clone()).map_err(IngressPayloadError))
+    }
+
+    /// Iterates over the ingress messages in their deserialized form.
+    pub fn iter(
+        &self,
+    ) -> impl Iterator<
+        Item = (
+            &IngressMessageId,
+            Result<SignedIngress, IngressPayloadError>,
+        ),
+    > {
+        self.serialized_ingress_messages.iter().map(|(id, bytes)| {
+            (
+                id,
+                SignedIngress::try_from(bytes.clone()).map_err(IngressPayloadError),
+            )
+        })
     }
 }
 
 impl CountBytes for IngressPayload {
     fn count_bytes(&self) -> usize {
-        self.buffer.len() + self.id_and_pos.len() * EXPECTED_MESSAGE_ID_LENGTH
+        self.serialized_ingress_messages
+            .values()
+            .map(|message| EXPECTED_MESSAGE_ID_LENGTH + message.len())
+            .sum()
     }
 }
 
 impl<'a> FromIterator<&'a SignedIngress> for IngressPayload {
     fn from_iter<I: IntoIterator<Item = &'a SignedIngress>>(msgs: I) -> Self {
-        let mut buf = Cursor::new(Vec::new());
-        let mut id_and_pos = Vec::new();
-        for ingress in msgs {
-            let id = IngressMessageId::from(ingress);
-            let pos = buf.position();
-            // This panic will only happen when we run out of memory.
-            buf.write_all(ingress.binary().as_ref())
-                .unwrap_or_else(|err| panic!("SignedIngress serialization error: {:?}", err));
+        let serialized_ingress_messages = msgs
+            .into_iter()
+            .map(|ingress| (IngressMessageId::from(ingress), ingress.binary().clone()))
+            .collect();
 
-            id_and_pos.push((id, pos));
-        }
         Self {
-            id_and_pos,
-            buffer: buf.into_inner(),
+            serialized_ingress_messages,
         }
     }
 }
@@ -184,13 +148,14 @@ impl From<Vec<SignedIngress>> for IngressPayload {
 
 impl TryFrom<IngressPayload> for Vec<SignedIngress> {
     type Error = IngressPayloadError;
+
     fn try_from(payload: IngressPayload) -> Result<Vec<SignedIngress>, Self::Error> {
         payload
-            .id_and_pos
-            .iter()
-            .enumerate()
-            .map(|(i, _)| payload.get(i).map(|m| m.1))
-            .collect::<Result<_, _>>()
+            .serialized_ingress_messages
+            .into_values()
+            .map(SignedIngress::try_from)
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(IngressPayloadError)
     }
 }
 
@@ -204,7 +169,6 @@ mod tests {
         },
         time::expiry_time_from_now,
     };
-    use assert_matches::assert_matches;
     use std::convert::TryFrom;
 
     fn fake_http_call_content(method_name: &str) -> HttpCallContent {
@@ -247,12 +211,19 @@ mod tests {
                 )]),
             },
         ];
-        let signed_ingresses: Vec<SignedIngress> = update_messages
+        let mut signed_ingresses: Vec<SignedIngress> = update_messages
             .into_iter()
             .map(|msg| SignedIngress::try_from(msg).unwrap())
             .collect();
+
         let ingress_payload = IngressPayload::from(signed_ingresses.clone());
         let signed_ingresses1 = Vec::<SignedIngress>::try_from(ingress_payload).unwrap();
+        // ingress messages are sorted by id in the ingress payload, hence the sort below
+        signed_ingresses.sort_by(|msg_1, msg_2| {
+            IngressMessageId::from(msg_1)
+                .partial_cmp(&IngressMessageId::from(msg_2))
+                .unwrap()
+        });
         assert_eq!(signed_ingresses, signed_ingresses1);
     }
 
@@ -274,50 +245,32 @@ mod tests {
                 sender_delegation: None,
             };
 
-            SignedIngress::try_from(message).unwrap()
+            let ingress = SignedIngress::try_from(message).unwrap();
+            let id = IngressMessageId::from(&ingress);
+
+            (ingress, id)
         };
 
         // Some test messages.
-        let m1 = fake_ingress_message("m1");
-        let m1_id = m1.id();
-        let m2 = fake_ingress_message("m2");
-        let m3 = fake_ingress_message("m3");
+        let (m1, id1) = fake_ingress_message("m1");
+        let (m2, id2) = fake_ingress_message("m2");
+        let (m3, id3) = fake_ingress_message("m3");
+        let (_m4, id4) = fake_ingress_message("m4");
 
-        let msgs = vec![m1, m2, m3];
+        let msgs = vec![m1.clone(), m2.clone(), m3.clone()];
         let payload = IngressPayload::from(msgs.clone());
         // Serialization/deserialization works.
-        let mut bytes = bincode::serialize(&payload).unwrap();
+        let bytes = bincode::serialize(&payload).unwrap();
         assert_eq!(
             bincode::deserialize::<IngressPayload>(&bytes).unwrap(),
             payload
         );
         // Individual lookup works.
-        assert_matches!(payload.get(0).unwrap(), (_, msg) if msg == msgs[0]);
-        assert_matches!(payload.get(1).unwrap(), (_, msg) if msg == msgs[1]);
-        assert_matches!(payload.get(2).unwrap(), (_, msg) if msg == msgs[2]);
-        // Test IndexOutOfBound.
-        assert_matches!(payload.get(3), Err(IngressPayloadError::IndexOutOfBound(3)));
+        assert_eq!(payload.get_by_id(&id1).unwrap().unwrap(), m1);
+        assert_eq!(payload.get_by_id(&id2).unwrap().unwrap(), m2);
+        assert_eq!(payload.get_by_id(&id3).unwrap().unwrap(), m3);
+        assert_eq!(payload.get_by_id(&id4), None);
         // Converting back to messages should match original
         assert_eq!(msgs, <Vec<SignedIngress>>::try_from(payload).unwrap());
-
-        // A sub-sequence search function
-        fn find(array: &[u8], subseq: &[u8]) -> Option<usize> {
-            (0..array.len() - subseq.len() + 1).find(|&i| array[i..i + subseq.len()] == subseq[..])
-        }
-
-        // Mutate some byte, deserialization works, but casting back to messages fail.
-        let pos = find(&bytes, m1_id.as_bytes()).unwrap();
-        // `+= 1` may overflow in debug mode.
-        bytes[pos] ^= 1;
-        let payload = bincode::deserialize::<IngressPayload>(&bytes);
-        assert!(payload.is_ok());
-        let payload = payload.unwrap();
-        // get(0) should return error.
-        assert_matches!(
-            payload.get(0),
-            Err(IngressPayloadError::MismatchedMessageIdAtIndex(0))
-        );
-        // Conversion should also fail.
-        assert!(<Vec<_>>::try_from(payload).is_err());
     }
 }

--- a/rs/types/types/src/batch/ingress.rs
+++ b/rs/types/types/src/batch/ingress.rs
@@ -94,10 +94,11 @@ impl IngressPayload {
     pub fn get_by_id(
         &self,
         ingress_message_id: &IngressMessageId,
-    ) -> Option<Result<SignedIngress, IngressPayloadError>> {
+    ) -> Result<Option<SignedIngress>, IngressPayloadError> {
         self.serialized_ingress_messages
             .get(ingress_message_id)
             .map(|bytes| SignedIngress::try_from(bytes.clone()).map_err(IngressPayloadError))
+            .transpose()
     }
 
     /// Iterates over the ingress messages in their deserialized form.
@@ -266,10 +267,10 @@ mod tests {
             payload
         );
         // Individual lookup works.
-        assert_eq!(payload.get_by_id(&id1).unwrap().unwrap(), m1);
-        assert_eq!(payload.get_by_id(&id2).unwrap().unwrap(), m2);
-        assert_eq!(payload.get_by_id(&id3).unwrap().unwrap(), m3);
-        assert_eq!(payload.get_by_id(&id4), None);
+        assert_eq!(payload.get_by_id(&id1), Ok(Some(m1)));
+        assert_eq!(payload.get_by_id(&id2), Ok(Some(m2)));
+        assert_eq!(payload.get_by_id(&id3), Ok(Some(m3)));
+        assert_eq!(payload.get_by_id(&id4), Ok(None));
         // Converting back to messages should match original
         assert_eq!(msgs, <Vec<SignedIngress>>::try_from(payload).unwrap());
     }

--- a/rs/types/types/src/exhaustive.rs
+++ b/rs/types/types/src/exhaustive.rs
@@ -1,5 +1,6 @@
 //! Implementations and serialization tests of the ExhaustiveSet trait
 
+use crate::artifact::IngressMessageId;
 use crate::consensus::hashed::Hashed;
 use crate::consensus::idkg::common::{PreSignatureInCreation, PreSignatureRef};
 use crate::consensus::idkg::ecdsa::QuadrupleInCreation;
@@ -28,6 +29,7 @@ use crate::crypto::{
     CombinedThresholdSig, CombinedThresholdSigOf, CryptoHash, CryptoHashOf, CryptoHashable,
     IndividualMultiSig, IndividualMultiSigOf, Signed, ThresholdSigShare, ThresholdSigShareOf,
 };
+use crate::messages::SignedRequestBytes;
 use crate::signature::{
     BasicSignature, BasicSignatureBatch, MultiSignature, MultiSignatureShare, ThresholdSignature,
     ThresholdSignatureShare,
@@ -1001,6 +1003,8 @@ impl HasId<IDkgMasterPublicKeyId> for MasterKeyTranscript {
         Some(self.key_id())
     }
 }
+
+impl HasId<IngressMessageId> for SignedRequestBytes {}
 
 impl HasId<IDkgReshareRequest> for ReshareOfUnmaskedParams {}
 impl HasId<PseudoRandomId> for CompletedSignature {}

--- a/rs/types/types/src/messages.rs
+++ b/rs/types/types/src/messages.rs
@@ -270,6 +270,7 @@ impl TryFrom<pb::StopCanisterContext> for StopCanisterContext {
 /// format. Use `TryFrom` or `TryInto` to convert between `SignedRequestBytes`
 /// and other types, corresponding to serialization/deserialization.
 #[derive(Clone, Eq, PartialEq, Hash, Debug, Deserialize, Serialize)]
+#[cfg_attr(test, derive(ExhaustiveSet))]
 pub struct SignedRequestBytes(#[serde(with = "serde_bytes")] Vec<u8>);
 
 impl AsRef<[u8]> for SignedRequestBytes {


### PR DESCRIPTION
Currently the payload is one big bytes buffer which contains all ingress messages in a packed representation. This makes it a big hard to work with. 
In this PR we simplify the structure by replacing the buffer with a map from `IngressMessageId`s to a _serialized_ ingress messages.
The following two important properties are preserved:
1. The individual ingress messages deserialization is delayed until it's actually needed
2. We preserve the original byte representation of the ingress messages

I've ran multiple benchmarks and didn't notice a _big_ change:
1. `consensus-performance` system test showed the same throughput / block rates with both implementations
2. the [serialization/deserialization ](https://github.com/dfinity/ic/blob/master/rs/consensus/benches/validate_payload.rs#L374-L404) of ingress payload gets about 2x slower, but it's still in sub 1ms territory