### PR TITLE
fix(nervous-system-agent): propagate candid encode errors

### DIFF
--- a/rs/nervous_system/agent/src/agent_impl.rs
+++ b/rs/nervous_system/agent/src/agent_impl.rs
@@ -25,7 +25,7 @@ impl CallCanisters for Agent {
         request: R,
     ) -> Result<R::Response, Self::Error> {
         let canister_id = canister_id.into();
-        let request_bytes = request.payload();
+        let request_bytes = request.payload().map_err(AgentCallError::CandidEncode)?;
         let response = if request.update() {
             let request = self
                 .update(&canister_id, request.method())

--- a/rs/nervous_system/agent/src/lib.rs
+++ b/rs/nervous_system/agent/src/lib.rs
@@ -22,7 +22,7 @@ mod sealed {
 pub trait Request: Send {
     fn method(&self) -> &'static str;
     fn update(&self) -> bool;
-    fn payload(&self) -> Vec<u8>;
+    fn payload(&self) -> Result<Vec<u8>, candid::Error>;
     type Response: CandidType + DeserializeOwned;
 }
 
@@ -33,8 +33,8 @@ impl<R: ic_nervous_system_clients::Request> Request for R {
     fn update(&self) -> bool {
         Self::UPDATE
     }
-    fn payload(&self) -> Vec<u8> {
-        candid::encode_one(self).unwrap()
+    fn payload(&self) -> Result<Vec<u8>, candid::Error> {
+        candid::encode_one(self)
     }
 
     type Response = <Self as ic_nervous_system_clients::Request>::Response;

--- a/rs/nervous_system/agent/src/null_request.rs
+++ b/rs/nervous_system/agent/src/null_request.rs
@@ -27,8 +27,8 @@ impl<T: CandidType + DeserializeOwned + Send> Request for NullRequest<T> {
     fn update(&self) -> bool {
         self.update
     }
-    fn payload(&self) -> Vec<u8> {
-        Encode!().unwrap()
+    fn payload(&self) -> Result<Vec<u8>, candid::Error> {
+        Encode!()
     }
 
     type Response = T;

--- a/rs/nervous_system/agent/src/pocketic_impl.rs
+++ b/rs/nervous_system/agent/src/pocketic_impl.rs
@@ -27,7 +27,7 @@ impl CallCanisters for PocketIc {
         request: R,
     ) -> Result<R::Response, Self::Error> {
         let canister_id = canister_id.into();
-        let request_bytes = request.payload();
+        let request_bytes = request.payload().map_err(PocketIcCallError::CandidEncode)?;
         let response = if request.update() {
             self.update_call(
                 canister_id,


### PR DESCRIPTION
Previously we were panicking, even though there was already an error case we could be using to propagate these errors.

Pointed out by @aterga 