### PR TITLE
feat(nns): Add test-only function `Governance.adopt_proposal`

### DIFF
--- a/rs/nns/governance/canister/canister.rs
+++ b/rs/nns/governance/canister/canister.rs
@@ -738,7 +738,20 @@ fn update_neuron(neuron: Neuron) -> Option<GovernanceError> {
 
 #[cfg(feature = "test")]
 #[update]
-/// Internal method for calling update_neuron.
+/// Adopt the (currently open) proposal with `proposal_id` in a testing environment.
+///
+/// This function simulates a 100% YES vote rate for a given proposal.
+///
+/// ### Applicability
+///
+/// Testing with the golden state often involves open proposals that had been created
+/// before the state snapshot was taken. This function allows observing the effect that such
+/// proposals would have.
+///
+/// When possible, it is recommended to avoid using this function, instead creating a powerful
+/// neuron that gets proposals adopted in testing. Calling this function may result in a less
+/// realistic scenario, e.g., it does not guaranteed that the tally and the ballots will remain
+/// synchronized for `proposal_id`.
 fn adopt_proposal(proposal_id: ProposalIdProto) -> Option<GovernanceError> {
     debug_log("adopt_proposal");
     governance_mut()

--- a/rs/nns/governance/canister/canister.rs
+++ b/rs/nns/governance/canister/canister.rs
@@ -736,6 +736,17 @@ fn update_neuron(neuron: Neuron) -> Option<GovernanceError> {
         .map(GovernanceError::from)
 }
 
+#[cfg(feature = "test")]
+#[update]
+/// Internal method for calling update_neuron.
+fn adopt_proposal(proposal_id: ProposalIdProto) -> Option<GovernanceError> {
+    debug_log("adopt_proposal");
+    governance_mut()
+        .adopt_proposal(proposal_id)
+        .err()
+        .map(GovernanceError::from)
+}
+
 #[update]
 fn simulate_manage_neuron(manage_neuron: ManageNeuronRequest) -> ManageNeuronResponse {
     debug_log("simulate_manage_neuron");

--- a/rs/nns/governance/canister/governance_test.did
+++ b/rs/nns/governance/canister/governance_test.did
@@ -1194,5 +1194,6 @@ service : (Governance) -> {
   simulate_manage_neuron : (ManageNeuronRequest) -> (ManageNeuronResponse);
   transfer_gtc_neuron : (NeuronId, NeuronId) -> (Result);
   update_neuron : (Neuron) -> (opt GovernanceError);
+  adopt_proposal : (ProposalId) -> (opt GovernanceError);
   update_node_provider : (UpdateNodeProvider) -> (Result);
 }

--- a/rs/nns/governance/src/governance.rs
+++ b/rs/nns/governance/src/governance.rs
@@ -2293,6 +2293,38 @@ impl Governance {
         })?
     }
 
+    /// Adopts a proposal by pretending that all potential votes were YES votes in the tally.
+    ///
+    /// Preconditions:
+    /// - the proposal with `proposal_id` already exists in `self.proposal_data`
+    #[cfg(feature = "test")]
+    pub fn adopt_proposal(&mut self, proposal_id: ProposalId) -> Result<(), GovernanceError> {
+        let now = self.env.now();
+
+        let proposal_data = self.mut_proposal_data_or_err(&proposal_id, "in adopt_proposal")?;
+
+        assert_eq!(proposal_data.status(), ProposalStatus::Open);
+
+        let Some(mut tally) = proposal_data.latest_tally else {
+            panic!("No tally specified for proposal {}", proposal_id.id);
+        };
+
+        tally.no = 0;
+        tally.yes = tally.total;
+        tally.timestamp_seconds = now;
+        assert!(
+            tally.is_absolute_majority_for_yes(),
+            "Bug in test-only code"
+        );
+
+        proposal_data.latest_tally.replace(tally);
+
+        // Ensure that the proposal action will be processed ASAP.
+        self.closest_proposal_deadline_timestamp_seconds = now;
+
+        Ok(())
+    }
+
     /// Add a neuron to the list of neurons.
     ///
     /// Fails under the following conditions:

--- a/rs/nns/governance/src/governance.rs
+++ b/rs/nns/governance/src/governance.rs
@@ -2305,7 +2305,7 @@ impl Governance {
 
         assert_eq!(proposal_data.status(), ProposalStatus::Open);
 
-        let Some(mut tally) = proposal_data.latest_tally else {
+        let Some(tally) = proposal_data.latest_tally.as_mut() else {
             panic!("No tally specified for proposal {}", proposal_id.id);
         };
 
@@ -2317,9 +2317,9 @@ impl Governance {
             "Bug in test-only code"
         );
 
-        proposal_data.latest_tally.replace(tally);
-
-        // Ensure that the proposal action will be processed ASAP.
+        // Ensure that the proposal action will be processed ASAP (this ensures that
+        // the precondition of `Governance.process_proposals()` holds in the post-state
+        // of this function).
         self.closest_proposal_deadline_timestamp_seconds = now;
 
         Ok(())

--- a/rs/nns/governance/src/governance/tests/mod.rs
+++ b/rs/nns/governance/src/governance/tests/mod.rs
@@ -1559,6 +1559,102 @@ fn test_update_neuron_errors_out_expectedly() {
     );
 }
 
+#[cfg(feature = "test")]
+#[test]
+fn test_adopt_proposal() {
+    // Prepare the world.
+    let test_start_timestamp_seconds = 1436954400; // Wed Jul 15 2015 10:00:00 GMT+0000
+
+    let old_economics = NetworkEconomics {
+        reject_cost_e8s: 2_500_000_000,
+        neuron_minimum_stake_e8s: 100_000_000,
+        neuron_management_fee_per_proposal_e8s: 1_000_000,
+        minimum_icp_xdr_rate: 100,
+        neuron_spawn_dissolve_delay_seconds: 604_800,
+        maximum_node_provider_rewards_e8s: 10_000_000_000_000,
+        transaction_fee_e8s: 10_000,
+        max_proposals_to_keep_per_topic: 100,
+        neurons_fund_economics: Some(Default::default()),
+        voting_power_economics: Some(Default::default()),
+    };
+
+    // As an example, use a `NetworkEconomics` proposal, as it it expected to have a clearly defined
+    // effect on the NNS Governance in case it gets adopted.
+    // Note: `0` and `None` values indicate that the respective fields are not to be updated.
+    let new_economics = NetworkEconomics {
+        reject_cost_e8s: 8_888_888_000,
+        neuron_minimum_stake_e8s: 0,
+        neuron_management_fee_per_proposal_e8s: 0,
+        minimum_icp_xdr_rate: 0,
+        neuron_spawn_dissolve_delay_seconds: 0,
+        maximum_node_provider_rewards_e8s: 0,
+        transaction_fee_e8s: 0,
+        max_proposals_to_keep_per_topic: 0,
+        neurons_fund_economics: None,
+        voting_power_economics: None,
+    };
+    let manage_network_economics_action =
+        proposal::Action::ManageNetworkEconomics(new_economics.clone());
+
+    let open_proposal = ProposalData {
+        id: Some(ProposalId { id: 1 }),
+        proposal: Some(Proposal {
+            title: Some("Change Network Economics reject_cost_e8s".to_string()),
+            action: Some(manage_network_economics_action),
+            ..Proposal::default()
+        }),
+        latest_tally: Some(Tally {
+            timestamp_seconds: test_start_timestamp_seconds - 100,
+            yes: 20,
+            no: 50,
+            total: 100,
+        }),
+        ..ProposalData::default()
+    };
+
+    let mut governance = Governance::new(
+        GovernanceProto {
+            proposals: btreemap! {
+                1 =>  open_proposal.clone(),
+            },
+            economics: Some(old_economics.clone()),
+            ..GovernanceProto::default()
+        },
+        Box::new(MockEnvironment::new(vec![], test_start_timestamp_seconds)),
+        Box::new(StubIcpLedger {}),
+        Box::new(StubCMC {}),
+    );
+
+    // Run code under test.
+    governance.adopt_proposal(ProposalId { id: 1 }).unwrap();
+    governance.process_proposals();
+
+    // Check that the proposal got adopted.
+    let proposal = governance.get_proposal_data(ProposalId { id: 1 }).unwrap();
+    assert_eq!(
+        proposal.latest_tally,
+        Some(Tally {
+            timestamp_seconds: governance.env.now(),
+            yes: 100,
+            no: 0,
+            total: 100,
+        })
+    );
+    assert_eq!(proposal.failed_timestamp_seconds, 0);
+    assert_eq!(proposal.failure_reason, None);
+    assert_eq!(proposal.decided_timestamp_seconds, governance.env.now());
+    assert_eq!(proposal.executed_timestamp_seconds, governance.env.now());
+
+    // Check that the proposal had the expected effect.
+    assert_eq!(
+        *governance.economics(),
+        NetworkEconomics {
+            reject_cost_e8s: 8_888_888_000,
+            ..old_economics
+        }
+    );
+}
+
 #[test]
 fn test_compute_ballots_for_new_proposal() {
     const CREATED_TIMESTAMP_SECONDS: u64 = 1729791574;


### PR DESCRIPTION
Testing with the golden state often involves open proposals that had been created before the state snapshot was taken. Observing the effect that such proposals would have is currently not possible (even if we have the majority of voting power in a newly created neuron, which can be done in testing, it would not be eligible to vote on proposals that were created earlier than itself). 

With this test-only `adopt_proposal` function, it becomes feasible to adopt the above-mentioned proposals in a testing environment, by simulating a 100% YES vote rate for a given proposal. Note that it is still recommended, when possible, to use the powerful neuron method to get proposals adopted in testing.

| [Next PR](https://github.com/dfinity/ic/pull/3461) >