### PR TITLE
fix(sns): rename `proposal_types_disallowed_in_pre_initialization_swap` → `functions_disallowed_in_pre_initialization_swap`

### DIFF
--- a/rs/sns/cli/src/propose.rs
+++ b/rs/sns/cli/src/propose.rs
@@ -204,7 +204,7 @@ Then, if the swap completes successfully, the SNS will take sole control. If the
         r#"A CreateServiceNervousSystem proposal will be submitted. If adopted, this proposal will create an SNS that controls no canisters."#.to_string()
     };
 
-    let disallowed_types = Mode::proposal_types_disallowed_in_pre_initialization_swap()
+    let disallowed_types = Mode::functions_disallowed_in_pre_initialization_swap()
         .into_iter()
         .map(|t| format!("  - {}", t.name))
         .join("\n");

--- a/rs/sns/governance/src/types.rs
+++ b/rs/sns/governance/src/types.rs
@@ -215,7 +215,7 @@ impl governance::Mode {
         }
     }
 
-    pub fn proposal_types_disallowed_in_pre_initialization_swap() -> Vec<NervousSystemFunction> {
+    pub fn functions_disallowed_in_pre_initialization_swap() -> Vec<NervousSystemFunction> {
         vec![
             NervousSystemFunction::manage_nervous_system_parameters(),
             NervousSystemFunction::transfer_sns_treasury_funds(),
@@ -241,7 +241,7 @@ impl governance::Mode {
                 );
         }
 
-        let is_action_disallowed = Self::proposal_types_disallowed_in_pre_initialization_swap()
+        let is_action_disallowed = Self::functions_disallowed_in_pre_initialization_swap()
             .into_iter()
             .any(|t| t.id == NervousSystemFunction::from(action.clone()).id);
 


### PR DESCRIPTION
This is a little clearer I think since the type returns `Vec<NervousSystemFunction>`. 