### PR TITLE
fix: do not repeat error code in query call reject message

### DIFF
--- a/rs/http_endpoints/public/src/query.rs
+++ b/rs/http_endpoints/public/src/query.rs
@@ -234,7 +234,7 @@ pub(crate) async fn query(
         Err(user_error) => HttpQueryResponse::Rejected {
             error_code: user_error.code().to_string(),
             reject_code: user_error.reject_code() as u64,
-            reject_message: user_error.to_string(),
+            reject_message: user_error.description().to_string(),
         },
     };
 


### PR DESCRIPTION
This PR uses the user error description as the reject message for query calls to make the query call reject message matches the reject message for ingress message produced [here](https://github.com/dfinity/ic/blob/85af5fc7b9963f10bb6fd30d7929814501d783c7/rs/canonical_state/src/lazy_tree_conversion.rs#L517).

Using the `Display` implementation of `UserError` instead of the description [repeats](https://github.com/dfinity/ic/blob/85af5fc7b9963f10bb6fd30d7929814501d783c7/rs/types/error_types/src/lib.rs#L462) the error code in the reject message while the error code is also available as a [separate](https://github.com/dfinity/ic/blob/85af5fc7b9963f10bb6fd30d7929814501d783c7/rs/http_endpoints/public/src/query.rs#L235) field in the query call reject response.