### PR TITLE
chore(system-tests-k8s): untag broken k8s tests

### DIFF
--- a/rs/tests/ckbtc/BUILD.bazel
+++ b/rs/tests/ckbtc/BUILD.bazel
@@ -98,7 +98,6 @@ system_test_nns(
     },
     flaky = True,
     tags = [
-        "k8s",
         "long_test",  # since it takes longer than 5 minutes.
     ],
     target_compatible_with = ["@platforms//os:linux"],  # requires libssh that does not build on Mac OS
@@ -129,7 +128,6 @@ system_test_nns(
     extra_head_nns_tags = [],  # don't run the head_nns variant on nightly since it aleady runs on long_test.
     flaky = True,
     tags = [
-        "k8s",
         "long_test",  # since it takes longer than 5 minutes.
     ],
     target_compatible_with = ["@platforms//os:linux"],  # requires libssh that does not build on Mac OS
@@ -160,7 +158,6 @@ system_test_nns(
     extra_head_nns_tags = [],  # don't run the head_nns variant on nightly since it aleady runs on long_test.
     flaky = True,
     tags = [
-        "k8s",
         "long_test",  # since it takes longer than 5 minutes.
     ],
     target_compatible_with = ["@platforms//os:linux"],  # requires libssh that does not build on Mac OS
@@ -191,7 +188,6 @@ system_test_nns(
     extra_head_nns_tags = [],  # don't run the head_nns variant on nightly since it aleady runs on long_test.
     flaky = True,
     tags = [
-        "k8s",
         "long_test",  # since it takes longer than 5 minutes.
     ],
     target_compatible_with = ["@platforms//os:linux"],  # requires libssh that does not build on Mac OS
@@ -222,7 +218,6 @@ system_test_nns(
     extra_head_nns_tags = [],  # don't run the head_nns variant on nightly since it aleady runs on long_test.
     flaky = True,
     tags = [
-        "k8s",
         "long_test",  # since it takes longer than 5 minutes.
     ],
     target_compatible_with = ["@platforms//os:linux"],  # requires libssh that does not build on Mac OS

--- a/rs/tests/cross_chain/BUILD.bazel
+++ b/rs/tests/cross_chain/BUILD.bazel
@@ -53,9 +53,6 @@ system_test_nns(
         "LEDGER_WASM_PATH": "$(rootpath //rs/ledger_suite/icrc1/ledger:ledger_canister_u256.wasm.gz)",
         "LEDGER_SUITE_ORCHESTRATOR_WASM_PATH": "$(rootpath //rs/ethereum/ledger-suite-orchestrator:ledger_suite_orchestrator_canister.wasm.gz)",
     },
-    tags = [
-        "k8s",
-    ],
     target_compatible_with = ["@platforms//os:linux"],  # requires libssh that does not build on Mac OS
     runtime_deps =
         BOUNDARY_NODE_GUESTOS_RUNTIME_DEPS +

--- a/rs/tests/message_routing/BUILD.bazel
+++ b/rs/tests/message_routing/BUILD.bazel
@@ -88,7 +88,6 @@ system_test_nns(
     },
     extra_head_nns_tags = ["manual"],  # only run this test with the mainnet NNS canisters.
     tags = [
-        "k8s",
         "system_test_hotfix",
     ],
     target_compatible_with = ["@platforms//os:linux"],  # requires libssh that does not build on Mac OS

--- a/rs/tests/networking/BUILD.bazel
+++ b/rs/tests/networking/BUILD.bazel
@@ -81,9 +81,6 @@ system_test_nns(
         "PROXY_WASM_PATH": "$(rootpath //rs/rust_canisters/proxy_canister:proxy_canister)",
     },
     flaky = True,
-    tags = [
-        "k8s",
-    ],
     target_compatible_with = ["@platforms//os:linux"],  # requires libssh that does not build on Mac OS
     runtime_deps =
         GUESTOS_RUNTIME_DEPS +


### PR DESCRIPTION
Removing `k8s` tag from tests that are not functional on k8s. Tag will be added back again once the cause is identified and resolved. This change is **only relevant for having system tests functional on k8s** (this project is still in incubation phase).