### PR TITLE
perf: Move file system population to mkfs.ext4 invocation

### DIFF
--- a/toolchains/sysimage/build_ext4_image.py
+++ b/toolchains/sysimage/build_ext4_image.py
@@ -221,6 +221,8 @@ def main():
         "hash_seed=c61251eb-100b-48fe-b089-57dea7368612",
         "-U",
         "clear",
+        "-d",
+        os.path.join(fs_basedir, limit_prefix),
         "-F",
         image_file,
         str(image_size),
@@ -258,7 +260,7 @@ def main():
     e2fsdroid_args += ["-C", fs_config_path]
     if file_contexts_file:
         e2fsdroid_args += ["-S", file_contexts_file]
-    e2fsdroid_args += ["-f", os.path.join(fs_basedir, limit_prefix), image_file]
+    e2fsdroid_args += [image_file]
     subprocess.run(e2fsdroid_args, check=True, env={"E2FSPROGS_FAKE_TIME": "0"})
 
     subprocess.run(["sync"], check=True)


### PR DESCRIPTION
The resulting images are equivalent (verified with `rsync -avnc $DIR1/ $DIR2`).

`$ bazel build //ic-os/guestos/envs/dev:static-partition-root-unsigned.tzst`

Before: 26.593s  
After: 19.926s