### PR TITLE
fix: check-network.sh when no ipv4 or domain name provided

### DIFF
--- a/ic-os/components/setupos-scripts/check-network.sh
+++ b/ic-os/components/setupos-scripts/check-network.sh
@@ -101,13 +101,15 @@ function print_network_settings() {
     echo "* Printing user defined network settings..."
     echo "  IPv6 Prefix : ${ipv6_prefix}"
     echo "  IPv6 Gateway: ${ipv6_gateway}"
-    if [[ -n ${ipv4_address} && -n ${ipv4_prefix_length} && -n ${ipv4_gateway} ]]; then
+    if [[ -n ${ipv4_address} && "${ipv4_address}" != "null" && \
+          -n ${ipv4_prefix_length} && "${ipv4_prefix_length}" != "null" && \
+          -n ${ipv4_gateway} && "${ipv4_gateway}" != "null" ]]; then
         echo "  IPv4 Address: ${ipv4_address}"
         echo "  IPv4 Prefix Length: ${ipv4_prefix_length}"
         echo "  IPv4 Gateway: ${ipv4_gateway}"
     fi
-    if [[ -n ${domain_name} ]]; then
-        echo "  Domain name : ${domain_name}"
+    if [[ -n ${domain_name} && "${domain_name}" != "null" ]]; then
+        echo "  Domain name: ${domain_name}"
     fi
     echo " "
 
@@ -212,8 +214,13 @@ main() {
         get_network_settings
         print_network_settings
 
-        if [[ -n ${ipv4_address} && -n ${ipv4_prefix_length} && -n ${ipv4_gateway} ]]; then
+        if [[ -n ${domain_name} && "${domain_name}" != "null" ]]; then
             validate_domain_name
+        fi
+
+        if [[ -n ${ipv4_address} && "${ipv4_address}" != "null" && \
+              -n ${ipv4_prefix_length} && "${ipv4_prefix_length}" != "null" && \
+              -n ${ipv4_gateway} && "${ipv4_gateway}" != "null" ]]; then
             setup_ipv4_network
             ping_ipv4_gateway
         fi


### PR DESCRIPTION
This fixes deployments when ipv4/domain name info is not provided in the config.ini

With the switch to the new config, when the ipv4 and domain name variables are not found in the config object, the call to get_config_value returns "null" where before it returned an empty string. The conditionals have been updated to check for "null"