### PR TITLE
feat: icrc-cbor: initial version of the library

### DIFF
--- a/packages/icrc-cbor/CHANGELOG.md
+++ b/packages/icrc-cbor/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## 0.1.0
+
 ### Added
 
 - Initial version of the library


### PR DESCRIPTION
Adding the initial library version to be able to publish to crates.io.