### PR TITLE
fix: Use lower case for Wasm persistence modes

### DIFF
--- a/rs/types/management_canister_types/src/lib.rs
+++ b/rs/types/management_canister_types/src/lib.rs
@@ -1220,9 +1220,11 @@ pub enum CanisterInstallMode {
 pub enum WasmMemoryPersistence {
     /// Retain the main memory across upgrades.
     /// Used for enhanced orthogonal persistence, as implemented in Motoko
+    #[serde(rename = "keep")]
     Keep,
     /// Reinitialize the main memory on upgrade.
     /// Default behavior without enhanced orthogonal persistence.
+    #[serde(rename = "replace")]
     Replace,
 }
 


### PR DESCRIPTION
Change variant names for the Wasm memory persistence to lower case in line with the IC specification, i.e. using `keep` and `replace` instead of `Keep` and `Replace`. The Wasm memory persistence option is used for Motoko's enhanced orthogonal persistence, which is currently still in beta testing. 

The following components need to be updated once these changes are released on IC mainnet and `dfx`:
* The Motoko compiler (https://github.com/dfinity/motoko/pull/4854)
* The Motoko playground (https://github.com/dfinity/motoko-playground/pull/275)

No change is needed for `dfx`.

For installed Motoko programs using enhanced orthogonal persistence, the change only affects the programmatic upgrades of Motoko actor class instances. Existing such programs would need to be recompiled with a new Motoko compiler and upgraded. The IC detects mismatching variant names of Wasm memory persistence by raising an error while still preserving persistent memory.