### PR TITLE
fix(icp-rosetta): fix icp rosetta metrics reponse time

### DIFF
--- a/rs/rosetta-api/icp/src/rosetta_server.rs
+++ b/rs/rosetta-api/icp/src/rosetta_server.rs
@@ -315,7 +315,7 @@ async fn rosetta_metrics() -> HttpResponse {
     let encoder = prometheus::TextEncoder::new();
     encoder.encode(&metrics, &mut buffer).unwrap();
     HttpResponse::Ok()
-        .content_type("text/html; charset=utf-8")
+        .content_type("text/plain; version=0.0.4; charset=utf-8")
         .body(String::from_utf8(buffer).unwrap())
 }
 


### PR DESCRIPTION
The `/ metrics` endpoint was returning a `text/html` type, which is rejected by metrics collectors like Prometheus.

I've verified that the new type is correctly collected by Prometheus.