### PR TITLE
fix(system-tests-k8s): exclude long tests

### DIFF
--- a/.github/workflows/system-tests-k8s.yml
+++ b/.github/workflows/system-tests-k8s.yml
@@ -140,7 +140,7 @@ jobs:
           BAZEL_COMMAND: "test"
           BAZEL_TARGETS: "${{ env.TARGETS }}"
           BAZEL_CI_CONFIG: "--config=ci --repository_cache=/cache/bazel"
-          BAZEL_EXTRA_ARGS: "--jobs=${{ env.JOBS }} --test_tag_filters=k8s,system_test_hourly,-manual,-colocated,-system_test_nightly --k8s"
+          BAZEL_EXTRA_ARGS: "--jobs=${{ env.JOBS }} --test_tag_filters=k8s,long_test,system_test_hourly,-manual,-colocated,-system_test_nightly --k8s"
           BUILDEVENT_APIKEY: ${{ secrets.HONEYCOMB_API_TOKEN }}
 
       - name: Upload bazel-bep

--- a/.github/workflows/system-tests-k8s.yml
+++ b/.github/workflows/system-tests-k8s.yml
@@ -82,7 +82,7 @@ jobs:
           BAZEL_COMMAND: "test"
           BAZEL_TARGETS: "${{ env.TARGETS }}"
           BAZEL_CI_CONFIG: "--config=ci --repository_cache=/cache/bazel"
-          BAZEL_EXTRA_ARGS: "--jobs=${{ env.JOBS }} --test_tag_filters=k8s,-manual,-colocated,-system_test_hourly,-system_test_nightly --k8s"
+          BAZEL_EXTRA_ARGS: "--jobs=${{ env.JOBS }} --test_tag_filters=k8s,-manual,-colocated,-long_test,-system_test_hourly,-system_test_nightly --k8s"
           BUILDEVENT_APIKEY: ${{ secrets.HONEYCOMB_API_TOKEN }}
 
       - name: Upload bazel-bep


### PR DESCRIPTION
Updating `test_tag_filters` for CI job that cover tests that should be shorter then 5 minutes. Including tests that are longer then 5 minutes in CI job that covers hourly tests. 