### PR TITLE
feat(cycles-minting): Cycles Minting canister refunds automatically.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10638,6 +10638,7 @@ dependencies = [
  "ic-stable-structures",
  "ic-state-machine-tests",
  "ic-test-utilities",
+ "ic-test-utilities-metrics",
  "ic-types",
  "ic-types-test-utils",
  "ic-xrc-types",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3129,6 +3129,7 @@ dependencies = [
  "icp-ledger",
  "icrc-ledger-types",
  "lazy_static",
+ "maplit",
  "on_wire",
  "prost 0.13.4",
  "rand 0.8.5",

--- a/publish/canisters/BUILD.bazel
+++ b/publish/canisters/BUILD.bazel
@@ -97,7 +97,7 @@ CANISTERS_MAX_SIZE_COMPRESSED_E5_BYTES = {
 # amount of growth happens.
 
 NNS_CANISTERS_MAX_SIZE_COMPRESSED_E5_BYTES = {
-    "cycles-minting-canister.wasm.gz": "5",
+    "cycles-minting-canister.wasm.gz": "6",
     "genesis-token-canister.wasm.gz": "3",
     "governance-canister.wasm.gz": "17",
     "governance-canister_test.wasm.gz": "17",

--- a/rs/nns/cmc/BUILD.bazel
+++ b/rs/nns/cmc/BUILD.bazel
@@ -55,6 +55,7 @@ DEV_DEPENDENCIES = [
     "//rs/types/types_test_utils",
     "@crate_index//:candid_parser",
     "@crate_index//:futures",
+    "@crate_index//:maplit",
     "@crate_index//:serde_bytes",
 ]
 

--- a/rs/nns/cmc/Cargo.toml
+++ b/rs/nns/cmc/Cargo.toml
@@ -45,6 +45,7 @@ yansi = "0.5.0"
 
 [dev-dependencies]
 candid_parser = { workspace = true }
+maplit = "1.0.2"
 futures = { workspace = true }
 ic-types-test-utils = { path = "../../types/types_test_utils" }
 serde_bytes = { workspace = true }

--- a/rs/nns/cmc/src/lib.rs
+++ b/rs/nns/cmc/src/lib.rs
@@ -313,9 +313,22 @@ pub struct CyclesLedgerDepositResult {
     pub block_index: Nat,
 }
 
+// When a user sends us ICP, they indicate via memo (or icrc1_memo) what
+// operation they want to perform.
+//
+// We promise that we will NEVER use 0 as one of these values. (This would be
+// very bad, because if no memo is explicitly supplied, the Transaction might
+// implicitly have 0 in the memo field.)
+//
+// Note to developers: If you add new values, update MEANINGFUL_MEMOS.
 pub const MEMO_CREATE_CANISTER: Memo = Memo(0x41455243); // == 'CREA'
 pub const MEMO_TOP_UP_CANISTER: Memo = Memo(0x50555054); // == 'TPUP'
 pub const MEMO_MINT_CYCLES: Memo = Memo(0x544e494d); // == 'MINT'
+
+// New values might be added to this later. Do NOT assume that values won't be
+// added to this array later.
+pub const MEANINGFUL_MEMOS: [Memo; 3] =
+    [MEMO_CREATE_CANISTER, MEMO_TOP_UP_CANISTER, MEMO_MINT_CYCLES];
 
 pub fn create_canister_txn(
     amount: Tokens,

--- a/rs/nns/cmc/src/lib.rs
+++ b/rs/nns/cmc/src/lib.rs
@@ -12,6 +12,8 @@ use icp_ledger::{
 use icrc_ledger_types::icrc1::account::Account;
 use serde::{Deserialize, Serialize};
 
+pub const IS_AUTOMATIC_REFUND_ENABLED: bool = false;
+
 pub const DEFAULT_CYCLES_PER_XDR: u128 = 1_000_000_000_000u128; // 1T cycles = 1 XDR
 
 pub const PERMYRIAD_DECIMAL_PLACES: u32 = 4;

--- a/rs/nns/cmc/src/lib.rs
+++ b/rs/nns/cmc/src/lib.rs
@@ -319,8 +319,8 @@ pub struct CyclesLedgerDepositResult {
 // operation they want to perform.
 //
 // We promise that we will NEVER use 0 as one of these values. (This would be
-// very bad, because if no memo is explicitly supplied, the Transaction might
-// implicitly have 0 in the memo field.)
+// very bad, because then, we would have no way to disambiguate between "the
+// user wanted X" vs. "the user made an oversight".)
 //
 // Note to developers: If you add new values, update MEANINGFUL_MEMOS.
 pub const MEMO_CREATE_CANISTER: Memo = Memo(0x41455243); // == 'CREA'

--- a/rs/nns/cmc/src/main.rs
+++ b/rs/nns/cmc/src/main.rs
@@ -244,6 +244,9 @@ pub struct StateV1 {
     // canister (i.e. ledger). Once that comes back, we update the block's
     // status. This avoids using the same ICP to perform multiple operations.
     pub blocks_notified: BTreeMap<BlockIndex, NotificationStatus>,
+    // The status of blocks not new than this is ambiguous. This is because we
+    // must bound how much memory we use; in particular, blocks_notified must
+    // not grow without bound.
     pub last_purged_notification: BlockIndex,
 
     /// The current maturity modulation in basis points (permyriad), i.e.,

--- a/rs/nns/cmc/src/main.rs
+++ b/rs/nns/cmc/src/main.rs
@@ -1697,7 +1697,9 @@ fn get_u64_memo(transaction: &Transaction) -> Memo {
 /// too old (<= last_purged_notification), or it already has a status, no
 /// changes are made, and the block's current status is returned. (None
 /// indicates that the block is too old to have a status.)
-fn set_block_status_to_processing(block_index: BlockIndex) -> Result<(), Option<NotificationStatus>> {
+fn set_block_status_to_processing(
+    block_index: BlockIndex,
+) -> Result<(), Option<NotificationStatus>> {
     with_state_mut(|state| {
         if block_index <= state.last_purged_notification {
             return Err(None);
@@ -1853,9 +1855,9 @@ async fn issue_automatic_refund_if_memo_not_offerred(
     if let Err(prior_block_status) = set_block_status_to_processing(incoming_block_index) {
         let Some(prior_block_status) = prior_block_status else {
             // Callers of fetch_transaction generally do this already.
-            return Err(NotifyError::TransactionTooOld(
-                with_state(|state| state.last_purged_notification + 1)
-            ));
+            return Err(NotifyError::TransactionTooOld(with_state(|state| {
+                state.last_purged_notification + 1
+            })));
         };
 
         // Do not proceed, because block is either being processed, or was

--- a/rs/nns/cmc/src/main.rs
+++ b/rs/nns/cmc/src/main.rs
@@ -1708,6 +1708,8 @@ fn set_block_status_to_processing(block_index: BlockIndex) -> Result<(), Notific
     })
 }
 
+/// If the block's status in blocks_notified is Processing, clear it. Otherwise,
+/// makes no changes (and logs an error).
 fn clear_block_processing_status(block_index: BlockIndex) {
     with_state_mut(|state| {
         // Fetch the block's status.

--- a/rs/nns/cmc/src/main.rs
+++ b/rs/nns/cmc/src/main.rs
@@ -1800,8 +1800,9 @@ async fn issue_automatic_refund_if_memo_not_offerred(
     incoming_block_index: BlockIndex,
     // This is needed because transaction only has an AccountIdentifier.
     // Although it is possible to go from PrincipalId + Subaccount to
-    // AccountIdentifier, the reverse is not possible. This is a super confusing
-    // feature of the ICP ledger, but for better or worse, it is intentional.
+    // AccountIdentifier, the reverse is not possible. The reader might find it
+    // surprising that conversion in only one direction is possible, but this
+    // really is how it works, for better or worse.
     incoming_to_subaccount: Subaccount,
     incoming_transaction: &Transaction,
 ) -> Result<(), NotifyError> {

--- a/rs/nns/cmc/src/main.rs
+++ b/rs/nns/cmc/src/main.rs
@@ -1870,20 +1870,16 @@ async fn issue_automatic_refund_if_memo_not_offerred(
     }
 
     // Now, it is safe to call ledger to send the ICP back, so do it.
-    let refund_result = refund_icp(
+    let refund_block_index = refund_icp(
         incoming_to_subaccount,
         incoming_from,
         incoming_amount,
         Tokens::from_e8s(0), // extra_fee
     )
-    .await;
-    // Handle errors.
-    let refund_block_index = refund_result.map_err(|err| {
-        // Allow the user to retry.
+    .await
+    .inspect_err(|err| {
+        // This allows the user to retry.
         clear_block_processing_status(incoming_block_index);
-
-        // Do not actually change the err.
-        err
     })?;
 
     // Sending the ICP back succeeded. Therefore, update the block's status to

--- a/rs/nns/cmc/src/main.rs
+++ b/rs/nns/cmc/src/main.rs
@@ -1877,7 +1877,7 @@ async fn issue_automatic_refund_if_memo_not_offerred(
         Tokens::from_e8s(0), // extra_fee
     )
     .await
-    .inspect_err(|err| {
+    .inspect_err(|_err| {
         // This allows the user to retry.
         clear_block_processing_status(incoming_block_index);
     })?;

--- a/rs/nns/cmc/src/main.rs
+++ b/rs/nns/cmc/src/main.rs
@@ -52,8 +52,6 @@ mod environment;
 mod exchange_rate_canister;
 mod limiter;
 
-const IS_AUTOMATIC_REFUND_ENABLED: bool = false;
-
 /// The past 30 days are used for the average ICP/XDR rate.
 const NUM_DAYS_FOR_ICP_XDR_AVERAGE: usize = 30;
 /// The ICP/XDR start-of-day conversion rate of the past 60 days is cached.
@@ -1841,7 +1839,7 @@ async fn issue_automatic_refund_if_memo_not_offerred(
 
     // Set block's status to Processing before calling ledger.
     let reason_for_refund = format!(
-        "Memo ({}) in the incoming ICP transfer does not correspond to \
+        "Memo ({:#08X}) in the incoming ICP transfer does not correspond to \
          any of the operations that the Cycles Minting canister offers.",
         memo.0,
     );

--- a/rs/nns/cmc/src/main.rs
+++ b/rs/nns/cmc/src/main.rs
@@ -1878,11 +1878,12 @@ async fn issue_automatic_refund_if_memo_not_offerred(
         return match prior_block_status {
             Processing => Err(NotifyError::Processing),
 
-            Status::NotMeaningfulMemo(NotMeaningfulMemo { refund_block_index }) =>
+            Status::NotMeaningfulMemo(NotMeaningfulMemo { refund_block_index }) => {
                 Err(NotifyError::Refunded {
                     block_index: refund_block_index,
                     reason: reason_for_refund,
-                }),
+                })
+            }
 
             // There is no (known) way to reach this case, since we already
             // verified that memo is in MEANINGFUL_MEMOS.
@@ -1913,9 +1914,7 @@ async fn issue_automatic_refund_if_memo_not_offerred(
     let old_entry_value = with_state_mut(|state| {
         state.blocks_notified.insert(
             incoming_block_index,
-            NotificationStatus::NotMeaningfulMemo(NotMeaningfulMemo {
-                refund_block_index
-            }),
+            NotificationStatus::NotMeaningfulMemo(NotMeaningfulMemo { refund_block_index }),
         )
     });
     // Log if the block's previous status somehow changed out from under us

--- a/rs/nns/cmc/src/main.rs
+++ b/rs/nns/cmc/src/main.rs
@@ -238,8 +238,9 @@ pub struct StateV1 {
     // canister(s), in particular ledger, it is possible for duplicate requests
     // to interleave. In such cases, we want subsequent operations to see that
     // an operation is already in flight. Therefore, before making any canister
-    // calls, we check that the block does not already have a status, and set
-    // its status to Processing. Only then do we proceed with calling the other
+    // calls, we check that the block does not already have a status. If it
+    // already has a status, do not proceed. If it dos not already have a
+    // status, set it to Processing. Then, we can proceed with calling the other
     // canister (i.e. ledger). Once that comes back, we update the block's
     // status. This avoids using the same ICP to perform multiple operations.
     pub blocks_notified: BTreeMap<BlockIndex, NotificationStatus>,

--- a/rs/nns/cmc/src/main.rs
+++ b/rs/nns/cmc/src/main.rs
@@ -232,7 +232,7 @@ pub struct StateV1 {
 
     pub total_cycles_minted: Cycles,
 
-    // We use this for synchronization/journaling.
+    // We use this for synchronization.
     //
     // Because our operations (e.g. minting cycles) require calling other
     // canister(s), in particular ledger, it is possible for duplicate requests
@@ -1199,7 +1199,7 @@ async fn notify_top_up(
     //
     //     2. The block is "sufficiently recent". More precisely, it must be
     //        more recent than last_purged_notification. (To avoid unbounded
-    //        growth of the journal.)
+    //        growth of the blocks_notified.)
     let maybe_early_result = with_state_mut(|state| {
         state.purge_old_notifications(MAX_NOTIFY_HISTORY);
 
@@ -1771,8 +1771,8 @@ fn clear_block_processing_status(block_index: BlockIndex) {
 ///
 /// If the ledger call failed, the user can retry.
 ///
-/// Like the rest of this canister, uses blocks_notified for "journaling". More
-/// precisely, before calling ledger, there are two things:
+/// Like the rest of this canister, uses blocks_notified for synchronization.
+/// More precisely, before calling ledger, there are two things:
 ///
 ///     1. The block MUST have no status. If it does, this returns Err, and no
 ///        ledger call is attempted.

--- a/rs/nns/cmc/src/main.rs
+++ b/rs/nns/cmc/src/main.rs
@@ -1754,8 +1754,7 @@ fn clear_block_processing_status(block_index: BlockIndex) {
 /// Regardless of whether that ledger call succeeds, Err is returned, but the
 /// value in the Err depends on how the ledger call turns out.
 ///
-/// If the ledger call fails failed, the user can retry whatever they were
-/// trying to do.
+/// If the ledger call failed, the user can retry.
 ///
 /// Like the rest of this canister, uses blocks_notified for "journaling". More
 /// precisely, before calling ledger, there are two things:
@@ -1857,7 +1856,8 @@ async fn issue_automatic_refund_if_memo_not_offerred(
                 reason: reason_for_refund,
             }),
 
-            // This should not be possible, since we already verified that memo is in MEANINGFUL_MEMOS.
+            // There is no (known) way to reach this case, since we already
+            // verified that memo is in MEANINGFUL_MEMOS.
             NotifiedCreateCanister(_) | NotifiedMint(_) | NotifiedTopUp(_) => {
                 Err(NotifyError::InvalidTransaction(format!(
                     "Block has already been processed: {:?}",

--- a/rs/nns/integration_tests/BUILD.bazel
+++ b/rs/nns/integration_tests/BUILD.bazel
@@ -121,6 +121,7 @@ DEV_DEPENDENCIES = [
     "//rs/nervous_system/common/test_utils",
     "//rs/nervous_system/integration_tests:nervous_system_integration_tests",
     "//rs/nns/test_utils/golden_nns_state",
+    "//rs/test_utilities/metrics",
     "//rs/types/types_test_utils",
     "@crate_index//:ic-cbor",
     "@crate_index//:ic-certificate-verification",

--- a/rs/nns/integration_tests/Cargo.toml
+++ b/rs/nns/integration_tests/Cargo.toml
@@ -55,6 +55,7 @@ ic-nns-governance-init = { path = "../governance/init" }
 ic-sns-root = { path = "../../sns/root" }
 ic-sns-swap = { path = "../../sns/swap" }
 ic-stable-structures = { workspace = true }
+ic-test-utilities-metrics = { path = "../../test_utilities/metrics" }
 icp-ledger = { path = "../../ledger_suite/icp" }
 icrc-ledger-types = { path = "../../../packages/icrc-ledger-types" }
 lazy_static = { workspace = true }

--- a/rs/nns/integration_tests/src/cycles_minting_canister.rs
+++ b/rs/nns/integration_tests/src/cycles_minting_canister.rs
@@ -822,7 +822,7 @@ fn test_cmc_automatically_refunds_when_memo_is_garbage() {
             &state_machine,
             LEDGER_CANISTER_ID,
             Account {
-                owner: Principal::from(TEST_USER1_PRINCIPAL.clone()),
+                owner: Principal::from(*TEST_USER1_PRINCIPAL),
                 subaccount: None,
             },
         );
@@ -992,7 +992,7 @@ fn test_cmc_automatically_refunds_when_memo_is_garbage() {
                 let lower_reason = reason.to_lowercase();
                 for key_word in ["memo", "0xdeadbeef", "does not correspond", "offer"] {
                     assert!(
-                        lower_reason.contains(&key_word),
+                        lower_reason.contains(key_word),
                         r#""{}" not in {:?}"#,
                         key_word,
                         last_err
@@ -1016,7 +1016,7 @@ fn test_cmc_automatically_refunds_when_memo_is_garbage() {
                     "createcanister",
                 ] {
                     assert!(
-                        lower_reason.contains(&key_word),
+                        lower_reason.contains(key_word),
                         r#""{}" not in {:?}"#,
                         key_word,
                         last_err

--- a/rs/nns/integration_tests/src/cycles_minting_canister.rs
+++ b/rs/nns/integration_tests/src/cycles_minting_canister.rs
@@ -797,7 +797,7 @@ fn test_cmc_automatically_refunds_when_memo_is_garbage() {
         .build();
     setup_nns_canisters(&state_machine, nns_init_payloads);
 
-    let assert_canister_statuses_fixed = |narrative_phase| {
+    let assert_canister_statuses_fixed = |test_phase| {
         assert_eq!(
             btreemap! {
                 btreemap! { "status".to_string() => "running".to_string() } => 11,
@@ -809,7 +809,7 @@ fn test_cmc_automatically_refunds_when_memo_is_garbage() {
                 "replicated_state_registered_canisters"
             ),
             "{}",
-            narrative_phase
+            test_phase,
         );
     };
     // This will be called again later to verify that no canisters were added.
@@ -817,7 +817,7 @@ fn test_cmc_automatically_refunds_when_memo_is_garbage() {
     // understanding of how many canisters there are originally.
     assert_canister_statuses_fixed("start");
 
-    let assert_balance = |nominal_amount_tokens: u64, fee_count: u64, narrative_phase: &str| {
+    let assert_balance = |nominal_amount_tokens: u64, fee_count: u64, test_phase: &str| {
         let observed_balance = icrc1_balance(
             &state_machine,
             LEDGER_CANISTER_ID,
@@ -832,7 +832,7 @@ fn test_cmc_automatically_refunds_when_memo_is_garbage() {
             .unwrap()
             .checked_sub(&total_fees)
             .unwrap();
-        assert_eq!(observed_balance, expected_balance, "{}", narrative_phase);
+        assert_eq!(observed_balance, expected_balance, "{}", test_phase);
     };
     // This is more to gain confidence that assert_balance works; there is very
     // little risk that USER1's balance is not 100.

--- a/rs/nns/integration_tests/src/cycles_minting_canister.rs
+++ b/rs/nns/integration_tests/src/cycles_minting_canister.rs
@@ -903,6 +903,9 @@ fn test_cmc_automatically_refunds_when_memo_is_garbage() {
     .unwrap();
     let results = (0..100)
         .map(|_i| {
+            // Launch (another) notify_create_canister call, but crucially, do
+            // NOT wait for it to complete. That takes place a little further
+            // down.
             state_machine
                 .send_ingress_safe(
                     *TEST_USER1_PRINCIPAL,

--- a/rs/nns/integration_tests/src/cycles_minting_canister.rs
+++ b/rs/nns/integration_tests/src/cycles_minting_canister.rs
@@ -901,13 +901,13 @@ fn test_cmc_automatically_refunds_when_memo_is_garbage() {
         settings: None,
     })
     .unwrap();
-    let results = (0..100)
+    let results = (0..2)
         .map(|_i| {
             // Launch (another) notify_create_canister call, but crucially, do
             // NOT wait for it to complete. That takes place a little further
             // down.
             state_machine
-                .send_ingress_safe(
+                .submit_ingress_as(
                     *TEST_USER1_PRINCIPAL,
                     CYCLES_MINTING_CANISTER_ID,
                     "notify_create_canister",
@@ -921,7 +921,7 @@ fn test_cmc_automatically_refunds_when_memo_is_garbage() {
         .collect::<Vec<_>>()
         .into_iter()
         .map(|message_id| {
-            let result = state_machine.await_ingress(message_id, 500).unwrap();
+            let result = state_machine.await_ingress(message_id, 5000).unwrap();
 
             let result = match result {
                 WasmResult::Reply(ok) => ok,

--- a/rs/nns/integration_tests/src/cycles_minting_canister.rs
+++ b/rs/nns/integration_tests/src/cycles_minting_canister.rs
@@ -43,6 +43,7 @@ use ic_nns_test_utils::{
 };
 use ic_state_machine_tests::{StateMachine, WasmResult};
 use ic_test_utilities::universal_canister::{call_args, wasm};
+use ic_test_utilities_metrics::fetch_int_gauge_vec;
 use ic_types::{CanisterId, Cycles, PrincipalId};
 use ic_types_test_utils::ids::subnet_test_id;
 use icp_ledger::{
@@ -54,7 +55,6 @@ use icrc_ledger_types::icrc1::{self, account::Account};
 use maplit::btreemap;
 use serde_bytes::ByteBuf;
 use std::time::Duration;
-use ic_test_utilities_metrics::fetch_int_gauge_vec;
 
 /// Test that the CMC's `icp_xdr_conversion_rate` can be updated via Governance
 /// proposal.

--- a/rs/nns/integration_tests/src/cycles_minting_canister.rs
+++ b/rs/nns/integration_tests/src/cycles_minting_canister.rs
@@ -840,8 +840,8 @@ fn test_cmc_automatically_refunds_when_memo_is_garbage() {
 
     // Step 2: Run code under test.
 
-    // Step 2.1: Send ICP from USER1 to CMC, but use a garbage memo. There is no
-    // immediate explosion; "the bomb is only being planted" so to speak.
+    // Step 2.1: Send ICP from USER1 to CMC, but use a garbage memo. Even though
+    // the problem is created here, it is not detected until later.
 
     let garbage_memo = [0xEF, 0xBE, 0xAD, 0xDE, 0, 0, 0, 0]; // little endian 0x_DEAD_BEEF
     assert!(!MEANINGFUL_MEMOS.contains(&Memo(u64::from_le_bytes(garbage_memo))));

--- a/rs/nns/integration_tests/src/cycles_minting_canister.rs
+++ b/rs/nns/integration_tests/src/cycles_minting_canister.rs
@@ -903,13 +903,14 @@ fn test_cmc_automatically_refunds_when_memo_is_garbage() {
     .unwrap();
     let results = (0..100)
         .map(|_i| {
-            state_machine.send_ingress_safe(
-                *TEST_USER1_PRINCIPAL,
-                CYCLES_MINTING_CANISTER_ID,
-                "notify_create_canister",
-                notify_create_canister.clone(),
-            )
-            .unwrap()
+            state_machine
+                .send_ingress_safe(
+                    *TEST_USER1_PRINCIPAL,
+                    CYCLES_MINTING_CANISTER_ID,
+                    "notify_create_canister",
+                    notify_create_canister.clone(),
+                )
+                .unwrap()
         })
         // It might seem silly to call collect, and then immediately after that
         // call into_iter, but this is to ensure that await_ingress is not
@@ -949,12 +950,10 @@ fn test_cmc_automatically_refunds_when_memo_is_garbage() {
     // Step 3.3.1: Filter out Err(Processing), and freak out if there are any Ok.
     let mut errs = results
         .into_iter()
-        .filter_map(|result| {
-            match result {
-                Err(NotifyError::Processing) => None,
-                Ok(_) => panic!("{:?}", result),
-                Err(err) => Some(err),
-            }
+        .filter_map(|result| match result {
+            Err(NotifyError::Processing) => None,
+            Ok(_) => panic!("{:?}", result),
+            Err(err) => Some(err),
         })
         .collect::<Vec<NotifyError>>();
 
@@ -963,12 +962,14 @@ fn test_cmc_automatically_refunds_when_memo_is_garbage() {
     assert!(
         errs.iter().all(|other_err| other_err == &last_err),
         "{:?}\nvs.\n{:#?}",
-        last_err, errs,
+        last_err,
+        errs,
     );
     assert!(
         errs.len() >= 2, // If errs is empty, then the previous assert is trivial.
         "{}: {:#?}",
-        errs.len(), errs,
+        errs.len(),
+        errs,
     );
     // I tried cranking up the concurrent calls, but I could never get
     // Processing to occur. That is, this would always print concurrency - 1.

--- a/rs/nns/integration_tests/src/cycles_minting_canister.rs
+++ b/rs/nns/integration_tests/src/cycles_minting_canister.rs
@@ -901,13 +901,13 @@ fn test_cmc_automatically_refunds_when_memo_is_garbage() {
         settings: None,
     })
     .unwrap();
-    let results = (0..2)
+    let results = (0..100)
         .map(|_i| {
             // Launch (another) notify_create_canister call, but crucially, do
             // NOT wait for it to complete. That takes place a little further
             // down.
             state_machine
-                .submit_ingress_as(
+                .send_ingress_safe(
                     *TEST_USER1_PRINCIPAL,
                     CYCLES_MINTING_CANISTER_ID,
                     "notify_create_canister",
@@ -921,7 +921,7 @@ fn test_cmc_automatically_refunds_when_memo_is_garbage() {
         .collect::<Vec<_>>()
         .into_iter()
         .map(|message_id| {
-            let result = state_machine.await_ingress(message_id, 5000).unwrap();
+            let result = state_machine.await_ingress(message_id, 500).unwrap();
 
             let result = match result {
                 WasmResult::Reply(ok) => ok,

--- a/rs/nns/test_utils/src/common.rs
+++ b/rs/nns/test_utils/src/common.rs
@@ -88,7 +88,7 @@ impl NnsInitPayloadsBuilder {
                 governance_canister_id: Some(GOVERNANCE_CANISTER_ID),
                 exchange_rate_canister: None,
                 minting_account_id: Some(GOVERNANCE_CANISTER_ID.get().into()),
-                last_purged_notification: Some(1),
+                last_purged_notification: None,
                 cycles_ledger_canister_id: Some(CYCLES_LEDGER_CANISTER_ID),
             }),
             lifeline: LifelineCanisterInitPayloadBuilder::new(),

--- a/rs/nns/test_utils/src/state_test_helpers.rs
+++ b/rs/nns/test_utils/src/state_test_helpers.rs
@@ -6,8 +6,7 @@ use crate::common::{
 use candid::{CandidType, Decode, Encode, Nat};
 use canister_test::Wasm;
 use cycles_minting_canister::{
-    IcpXdrConversionRateCertifiedResponse, NotifyCreateCanister, NotifyError,
-    SetAuthorizedSubnetworkListArgs,
+    IcpXdrConversionRateCertifiedResponse, SetAuthorizedSubnetworkListArgs,
 };
 use dfn_http::types::{HttpRequest, HttpResponse};
 use dfn_protobuf::ToProto;
@@ -2098,33 +2097,6 @@ pub fn get_average_icp_xdr_conversion_rate(
     )
     .expect("Failed to retrieve the average conversion rate");
     Decode!(&bytes, IcpXdrConversionRateCertifiedResponse).unwrap()
-}
-
-pub fn notify_create_canister(
-    state_machine: &StateMachine,
-    caller: PrincipalId,
-    request: &NotifyCreateCanister,
-) -> Result<CanisterId, NotifyError> {
-    let result = state_machine
-        .execute_ingress_as(
-            caller,
-            CYCLES_MINTING_CANISTER_ID,
-            "notify_create_canister",
-            Encode!(&request).unwrap(),
-        )
-        .unwrap();
-
-    let result = match result {
-        WasmResult::Reply(reply) => reply,
-        WasmResult::Reject(reject) => {
-            panic!(
-                "get_changes_since was rejected by the NNS registry canister: {:#?}",
-                reject
-            )
-        }
-    };
-
-    Decode!(&result, Result<CanisterId, NotifyError>).unwrap()
 }
 
 pub fn cmc_set_default_authorized_subnetworks(

--- a/rs/nns/test_utils/src/state_test_helpers.rs
+++ b/rs/nns/test_utils/src/state_test_helpers.rs
@@ -6,7 +6,8 @@ use crate::common::{
 use candid::{CandidType, Decode, Encode, Nat};
 use canister_test::Wasm;
 use cycles_minting_canister::{
-    IcpXdrConversionRateCertifiedResponse, SetAuthorizedSubnetworkListArgs,
+    IcpXdrConversionRateCertifiedResponse, NotifyCreateCanister, NotifyError,
+    SetAuthorizedSubnetworkListArgs,
 };
 use dfn_http::types::{HttpRequest, HttpResponse};
 use dfn_protobuf::ToProto;
@@ -2097,6 +2098,33 @@ pub fn get_average_icp_xdr_conversion_rate(
     )
     .expect("Failed to retrieve the average conversion rate");
     Decode!(&bytes, IcpXdrConversionRateCertifiedResponse).unwrap()
+}
+
+pub fn notify_create_canister(
+    state_machine: &StateMachine,
+    caller: PrincipalId,
+    request: &NotifyCreateCanister,
+) -> Result<CanisterId, NotifyError> {
+    let result = state_machine
+        .execute_ingress_as(
+            caller,
+            CYCLES_MINTING_CANISTER_ID,
+            "notify_create_canister",
+            Encode!(&request).unwrap(),
+        )
+        .unwrap();
+
+    let result = match result {
+        WasmResult::Reply(reply) => reply,
+        WasmResult::Reject(reject) => {
+            panic!(
+                "get_changes_since was rejected by the NNS registry canister: {:#?}",
+                reject
+            )
+        }
+    };
+
+    Decode!(&result, Result<CanisterId, NotifyError>).unwrap()
 }
 
 pub fn cmc_set_default_authorized_subnetworks(


### PR DESCRIPTION
This happens when the `memo` (or `icrc1_memo`) in an ICP transfer is not one of the special values that CMC recognizes as signaling the purpose of the transfer.

This behavior gets triggered when one of the `notify_*` methods gets called.

The new behavior is not actually active yet. To turn it on, we simply need to set `IS_AUTOMATIC_REFUND_ENABLED` to true. I have run the tests with this set to true locally, and they pass.

# Motivation

Avoids ICP getting stuck, which can result from people making mistakes when sending ICP to the CMC.

# Implementation Overview

Added `issue_automatic_refund_if_memo_not_offerred`. As indicated by the name, this is the heart of the implementation of this new functionality. This is called from `fetch_transaction`. The call is guarded behind the aforementioned `IS_AUTOMATIC_REFUND_ENABLED` flag.

Added `MEANINGFUL_MEMOS` constant. This is used to detect when automatic refund should be performed.

# Minor Changes

Added `AutomaticallyRefunded` to `NotificationStatus`. This ensures that we do NOT duplicate refunds.

Changed one parameter of `fetch_transaction` from `AccountIdentifier` to `Subaccount`, because you cannot go "backwards" from `AccountIdentifier` to `Subaccount`.

Factored out the `memo` + `icrc1_memo` unifying code which used to live in `transaction_has_expected_memo`. Now, that code lives in a new `get_u64_memo` function.

# Future Work

Added a couple of other helpers. One is `set_block_status_to_processing`. This could be used to reduce code duplication in `notify_*` methods, but such refactoring is left to future PRs.

# References

We promised to do [this in this forum post][promise].

[promise]: https://forum.dfinity.org/t/extend-cycles-minting-canister-functionality/37749/2?u=daniel-wong

The other feature that we promised in that thread (use icrc1_memo) was implemented in [an earlier PR][icrc1_memo].

[icrc1_memo]: https://github.com/dfinity/ic/pull/3336