### PR TITLE
fix(node): update development nns_url

### DIFF
--- a/ic-os/setupos/defs.bzl
+++ b/ic-os/setupos/defs.bzl
@@ -81,11 +81,11 @@ def _custom_partitions(mode):
     if mode == "dev":
         guest_image = Label("//ic-os/guestos/envs/dev:disk-img.tar.zst")
         host_image = Label("//ic-os/hostos/envs/dev:disk-img.tar.zst")
-        nns_url = "https://wiki.internetcomputer.org"
+        nns_url = "https://cloudflare.com/cdn-cgi/trace"
     elif mode == "local-base-dev":
         guest_image = Label("//ic-os/guestos/envs/local-base-dev:disk-img.tar.zst")
         host_image = Label("//ic-os/hostos/envs/local-base-dev:disk-img.tar.zst")
-        nns_url = "https://wiki.internetcomputer.org"
+        nns_url = "https://cloudflare.com/cdn-cgi/trace"
     elif mode == "local-base-prod":
         guest_image = Label("//ic-os/guestos/envs/local-base-prod:disk-img.tar.zst")
         host_image = Label("//ic-os/hostos/envs/local-base-prod:disk-img.tar.zst")

--- a/rs/ic_os/config/src/generate_testnet_config.rs
+++ b/rs/ic_os/config/src/generate_testnet_config.rs
@@ -181,7 +181,7 @@ fn create_guestos_config(config: GenerateTestnetConfigArgs) -> Result<GuestOSCon
             .iter()
             .map(|s| Url::parse(s))
             .collect::<Result<Vec<Url>, _>>()?,
-        None => vec![Url::parse("https://wiki.internetcomputer.org")?],
+        None => vec![Url::parse("https://cloudflare.com/cdn-cgi/trace")?],
     };
 
     let use_node_operator_private_key = use_node_operator_private_key.unwrap_or(false);


### PR DESCRIPTION
NODE-1560

[wiki.internetcomputer.org](http://wiki.internetcomputer.org/) resolves to only an IPv4 address (107.161.28.131)

```
$ nslookup wiki.internetcomputer.org
Server:         127.0.0.53
Address:        127.0.0.53#53

Non-authoritative answer:
Name:   wiki.internetcomputer.org
Address: 107.161.28.131
```

This caused bare metal deployment tests to fail when only ipv6 info is provided. Changing to a more standard url fixes this.