### PR TITLE
feat(nns-tools): tool to get the ledger account for a neuron 

### DIFF
--- a/testnet/tools/nns-tools/lib/functions.sh
+++ b/testnet/tools/nns-tools/lib/functions.sh
@@ -265,6 +265,24 @@ nns_neuron_info() {
         $(nns_canister_id governance) get_neuron_info "( $NEURON_ID : nat64 )"
 }
 
+##: nns_get_full_neuron
+## Usage: $1 <NNS_URL> <NEURON_ID>
+## Get the full neuron record for a given neuron ID
+## Note: You must be logged into the correct DFX identity to access the full neuron.
+## If using HSM keys, you must set the environment variable DFX_HSM_PIN correctly.
+nns_get_full_neuron() {
+       local NNS_URL=$1
+       local NEURON_ID=$2
+
+       local IC=$(repo_root)
+       local GOV_DID="$IC/rs/nns/governance/canister/governance.did"
+
+
+       __dfx -q canister --network $NNS_URL \
+           call --candid "$GOV_DID" \
+           $(nns_canister_id governance) get_full_neuron "( $NEURON_ID : nat64 )"
+}
+
 ##: top_up_canister
 ## Tops up the wallet from the current dfx user's ICP balance
 top_up_canister() {

--- a/testnet/tools/nns-tools/lib/nns_neurons.sh
+++ b/testnet/tools/nns-tools/lib/nns_neurons.sh
@@ -30,3 +30,63 @@ nns_claim_or_refresh() {
         }
       )"
 }
+
+##: nns_account_for_neuron_id
+## Usage: $1 <NETWORK> <NEURON_ID>
+##  Get the account for a neuron with a particular ID
+## Your DFX identity must be set to a neuron that is authorized
+## to query the full neuron record.  See nns_get_full_neuron
+nns_account_for_neuron_id() {
+    local network=$1
+    local neuron_id=$2
+
+    local IC=$(repo_root)
+    local GOV_DID="$IC/rs/nns/governance/canister/governance.did"
+
+    local full_neuron=$(nns_get_full_neuron "$network" "$neuron_id")
+     if [[ "$full_neuron" == *"error_message"* ]]; then
+        echo "Error: $full_neuron"
+        return 1
+    fi
+
+    local account=$(echo "$full_neuron" | grep "account = blob" | awk '{print $4}' | tr -d '";')
+
+    local hex=$(candid_blob_to_hex "$account")
+    dfx ledger account-id --of-principal $(nns_canister_id governance) --subaccount "$hex"
+}
+
+ # account = blob "\der\93\daH/\ff\f4\1f\fe\9e\05\8c\1f\0b\c4X\f9\15\c2p\f3\90\80\ff\ecO\0d%S\0c\1a";
+
+candid_blob_to_hex() {
+    local raw_string=$1
+
+    python3 -c '
+import sys
+
+def parse_candid_escapes(s):
+    i = 0
+    out = bytearray()
+    while i < len(s):
+        if s[i] == "\\":
+            if i + 1 < len(s):
+                hex_digits = []
+                j = i + 1
+                while j < len(s) and len(hex_digits) < 2 and s[j] in "0123456789abcdefABCDEF":
+                    hex_digits.append(s[j])
+                    j += 1
+                if hex_digits:
+                    out.append(int("".join(hex_digits), 16))
+                    i = j
+                    continue
+            i += 1
+        else:
+            out.append(ord(s[i]))
+            i += 1
+    return bytes(out)
+
+if __name__ == "__main__":
+    raw_string = sys.argv[1]
+    parsed_bytes = parse_candid_escapes(raw_string)
+    print(parsed_bytes.hex())
+    ' "$raw_string"
+}


### PR DESCRIPTION
This script allows you to get the hex version of a ledger account for a particular neuron id you control.

Usage: `./cmd.sh nns_account_for_neuron_id ic 55555` (where ic refers to mainnet, but this can work on testnets as well)