### PR TITLE
feat(nervous-system): Add crate candid-utils and add proper Candid service argument validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1772,6 +1772,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "candid-utils"
+version = "0.9.0"
+dependencies = [
+ "candid",
+ "candid_parser",
+]
+
+[[package]]
 name = "candid_derive"
 version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -172,6 +172,7 @@ members = [
     "rs/monitoring/tracing/jaeger_exporter",
     "rs/monitoring/tracing/logging_layer",
     "rs/nervous_system/agent",
+    "rs/nervous_system/candid_utils",
     "rs/nervous_system/clients",
     "rs/nervous_system/collections/union_multi_map",
     "rs/nervous_system/common",

--- a/rs/nervous_system/candid_utils/BUILD.bazel
+++ b/rs/nervous_system/candid_utils/BUILD.bazel
@@ -1,0 +1,46 @@
+load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test")
+
+package(default_visibility = ["//visibility:public"])
+
+# See rs/nervous_system/feature_test.md
+DEPENDENCIES = [
+    # Keep sorted.
+    "@crate_index//:candid",
+    "@crate_index//:candid_parser",
+]
+
+MACRO_DEPENDENCIES = []
+
+DEV_DEPENDENCIES = []
+
+MACRO_DEV_DEPENDENCIES = []
+
+ALIASES = {}
+
+rust_library(
+    name = "candid_utils",
+    srcs = glob(
+        ["src/**/*.rs"],
+        exclude = [
+            "**/*tests.rs",
+        ],
+    ),
+    aliases = ALIASES,
+    crate_name = "candid_utils",
+    proc_macro_deps = MACRO_DEPENDENCIES,
+    version = "1.0.0",
+    deps = DEPENDENCIES,
+)
+
+rust_test(
+    name = "candid_utils_test",
+    srcs = glob(
+        ["src/**"],
+    ),
+    aliases = ALIASES,
+    crate_root = "src/lib.rs",
+    data = [],
+    env = {},
+    proc_macro_deps = MACRO_DEPENDENCIES + MACRO_DEV_DEPENDENCIES,
+    deps = DEPENDENCIES + DEV_DEPENDENCIES,
+)

--- a/rs/nervous_system/candid_utils/Cargo.toml
+++ b/rs/nervous_system/candid_utils/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "candid-utils"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+description.workspace = true
+documentation.workspace = true
+
+[lib]
+path = "src/lib.rs"
+
+[dependencies]
+candid = { workspace = true }
+candid_parser = { workspace = true }

--- a/rs/nervous_system/candid_utils/src/lib.rs
+++ b/rs/nervous_system/candid_utils/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod validation;

--- a/rs/nervous_system/candid_utils/src/validation.rs
+++ b/rs/nervous_system/candid_utils/src/validation.rs
@@ -1,8 +1,74 @@
-use candid::types::{subtype::subtype, Type};
+use candid::types::{
+    subtype::{subtype_with_config, OptReport},
+    Type,
+};
 use candid_parser::{
     parse_idl_args,
     utils::{instantiate_candid, CandidSource},
 };
+
+fn fmt_type_vec(types: &[Type]) -> String {
+    let tab = " ".repeat(4);
+    let types_str = if types.is_empty() {
+        "// <empty>".to_string()
+    } else {
+        types
+            .iter()
+            .map(|typ| typ.to_string())
+            .collect::<Vec<_>>()
+            .join(&format!(",\n{tab}"))
+    };
+    format!("```candid\n(\n{tab}{types_str}\n)\n```\n")
+}
+
+#[derive(Debug)]
+pub enum CandidServiceArgValidationError {
+    BadService(String),
+    ArgsParseError(String),
+    WrongArgumentCount(String),
+    SubtypingErrors(String),
+    ArgsSerializationError(String),
+}
+
+impl PartialEq for CandidServiceArgValidationError {
+    fn eq(&self, other: &Self) -> bool {
+        matches!(
+            (self, other),
+            (Self::BadService(_), Self::BadService(_))
+                | (Self::ArgsParseError(_), Self::ArgsParseError(_))
+                | (Self::WrongArgumentCount(_), Self::WrongArgumentCount(_))
+                | (Self::SubtypingErrors(_), Self::SubtypingErrors(_))
+                | (
+                    Self::ArgsSerializationError(_),
+                    Self::ArgsSerializationError(_)
+                )
+        )
+    }
+}
+
+impl CandidServiceArgValidationError {
+    fn deconstruct(&self) -> (String, String) {
+        match self {
+            Self::BadService(err) => ("BadService".to_string(), err.clone()),
+            Self::ArgsParseError(err) => ("ArgsParseError".to_string(), err.clone()),
+            Self::WrongArgumentCount(err) => ("WrongArgumentCount".to_string(), err.clone()),
+            Self::SubtypingErrors(err) => ("SubtypingErrors".to_string(), err.clone()),
+            Self::ArgsSerializationError(err) => {
+                ("ArgsSerializationError".to_string(), err.clone())
+            }
+        }
+    }
+
+    pub fn message(&self) -> String {
+        let (_, msg) = self.deconstruct();
+        msg
+    }
+
+    pub fn kind(&self) -> String {
+        let (kind, _) = self.deconstruct();
+        kind
+    }
+}
 
 /// Checks whether `upgrade_args` is a valid argument sequence for `candid_service`.
 ///
@@ -10,33 +76,24 @@ use candid_parser::{
 pub fn validate_upgrade_args(
     candid_service: String,
     upgrade_args: String,
-) -> Result<Vec<u8>, String> {
-    let upgrade_args = parse_idl_args(&upgrade_args).map_err(|err| format!("{err:?}"))?;
+) -> Result<Vec<u8>, CandidServiceArgValidationError> {
+    let (expected_args_types, (env, _)) =
+        instantiate_candid(CandidSource::Text(&candid_service))
+            .map_err(|err| CandidServiceArgValidationError::BadService(format!("{err:?}")))?;
+
+    let upgrade_args = parse_idl_args(&upgrade_args)
+        .map_err(|err| CandidServiceArgValidationError::ArgsParseError(format!("{err:?}")))?;
+
     let args_types = upgrade_args.get_types();
 
-    let (expected_args_types, (env, _)) = instantiate_candid(CandidSource::Text(&candid_service))
-        .map_err(|err| format!("{err:?}"))?;
-
-    fn fmt_type_vec(types: &[Type]) -> String {
-        let tab = " ".repeat(4);
-        let types_str = if types.is_empty() {
-            "// <empty>".to_string()
-        } else {
-            types
-                .iter()
-                .map(|typ| typ.to_string())
-                .collect::<Vec<_>>()
-                .join(&format!(",\n{tab}"))
-        };
-        format!("```candid\n(\n{tab}{types_str}\n)\n```\n")
-    }
-
     if args_types.len() != expected_args_types.len() {
-        return Err(format!(
-            "Number of specified upgrade arguments ({}) does not match expected number \
+        return Err(CandidServiceArgValidationError::WrongArgumentCount(
+            format!(
+                "Number of specified upgrade arguments ({}) does not match expected number \
              of arguments for the target canister ({}).",
-            args_types.len(),
-            expected_args_types.len(),
+                args_types.len(),
+                expected_args_types.len(),
+            ),
         ));
     }
 
@@ -46,22 +103,30 @@ pub fn validate_upgrade_args(
         .iter()
         .zip(expected_args_types.iter())
         .map(|(observed_type, expected_type)| {
-            subtype(&mut gamma, &env, observed_type, expected_type)
-                .map_err(|err| format!("{err:?}"))
+            subtype_with_config(
+                OptReport::Error,
+                &mut gamma,
+                &env,
+                observed_type,
+                expected_type,
+            )
+            .map_err(|err| format!("{err:?}"))
         })
         .collect::<Vec<_>>();
 
     if subtyping_subresults != vec![Ok(()); subtyping_subresults.len()] {
-        return Err(format!(
+        return Err(CandidServiceArgValidationError::SubtypingErrors(format!(
             "Specified upgrade arguments have types:\n{}\
              that are not subtypes of the Candid service arguments' types:\n{}\n\
              {subtyping_subresults:#?}",
             fmt_type_vec(&args_types),
             fmt_type_vec(&expected_args_types),
-        ));
+        )));
     }
 
-    let upgrade_args = upgrade_args.to_bytes().map_err(|err| format!("{err:?}"))?;
+    let upgrade_args = upgrade_args.to_bytes().map_err(|err| {
+        CandidServiceArgValidationError::ArgsSerializationError(format!("{err:?}"))
+    })?;
 
     Ok(upgrade_args)
 }

--- a/rs/nervous_system/candid_utils/src/validation.rs
+++ b/rs/nervous_system/candid_utils/src/validation.rs
@@ -1,0 +1,70 @@
+use candid::types::{subtype::subtype, Type};
+use candid_parser::{
+    parse_idl_args,
+    utils::{instantiate_candid, CandidSource},
+};
+
+/// Checks whether `upgrade_args` is a valid argument sequence for `candid_service`.
+///
+/// Returns the byte encoding of `upgrade_args` in the successful case.
+pub fn validate_upgrade_args(
+    candid_service: String,
+    upgrade_args: String,
+) -> Result<Vec<u8>, String> {
+    let upgrade_args = parse_idl_args(&upgrade_args).map_err(|err| format!("{err:?}"))?;
+    let args_types = upgrade_args.get_types();
+
+    let (expected_args_types, (env, _)) = instantiate_candid(CandidSource::Text(&candid_service))
+        .map_err(|err| format!("{err:?}"))?;
+
+    fn fmt_type_vec(types: &Vec<Type>) -> String {
+        let tab = " ".repeat(4);
+        let types_str = if types.is_empty() {
+            "// <empty>".to_string()
+        } else {
+            types
+                .iter()
+                .map(|typ| typ.to_string())
+                .collect::<Vec<_>>()
+                .join(&format!(",\n{tab}"))
+        };
+        format!("```candid\n(\n{tab}{types_str}\n)\n```\n")
+    }
+
+    if args_types.len() != expected_args_types.len() {
+        return Err(format!(
+            "Number of specified upgrade arguments ({}) does not match expected number \
+             of arguments for the target canister ({}).",
+            args_types.len(),
+            expected_args_types.len(),
+        ));
+    }
+
+    let mut gamma = std::collections::HashSet::new();
+
+    let subtyping_subresults = args_types
+        .iter()
+        .zip(expected_args_types.iter())
+        .map(|(observed_type, expected_type)| {
+            subtype(&mut gamma, &env, &observed_type, &expected_type)
+                .map_err(|err| format!("{err:?}"))
+        })
+        .collect::<Vec<_>>();
+
+    if subtyping_subresults != vec![Ok(()); subtyping_subresults.len()] {
+        return Err(format!(
+            "Specified upgrade arguments have types:\n{}\
+             that are not subtypes of the Candid service arguments' types:\n{}\n\
+             {subtyping_subresults:#?}",
+            fmt_type_vec(&args_types),
+            fmt_type_vec(&expected_args_types),
+        ));
+    }
+
+    let upgrade_args = upgrade_args.to_bytes().map_err(|err| format!("{err:?}"))?;
+
+    Ok(upgrade_args)
+}
+
+#[cfg(test)]
+mod tests;

--- a/rs/nervous_system/candid_utils/src/validation.rs
+++ b/rs/nervous_system/candid_utils/src/validation.rs
@@ -17,7 +17,7 @@ pub fn validate_upgrade_args(
     let (expected_args_types, (env, _)) = instantiate_candid(CandidSource::Text(&candid_service))
         .map_err(|err| format!("{err:?}"))?;
 
-    fn fmt_type_vec(types: &Vec<Type>) -> String {
+    fn fmt_type_vec(types: &[Type]) -> String {
         let tab = " ".repeat(4);
         let types_str = if types.is_empty() {
             "// <empty>".to_string()
@@ -46,7 +46,7 @@ pub fn validate_upgrade_args(
         .iter()
         .zip(expected_args_types.iter())
         .map(|(observed_type, expected_type)| {
-            subtype(&mut gamma, &env, &observed_type, &expected_type)
+            subtype(&mut gamma, &env, observed_type, expected_type)
                 .map_err(|err| format!("{err:?}"))
         })
         .collect::<Vec<_>>();

--- a/rs/nervous_system/candid_utils/src/validation/tests.rs
+++ b/rs/nervous_system/candid_utils/src/validation/tests.rs
@@ -4,6 +4,16 @@ use super::*;
 fn test_candid_service_arg_validation() {
     for (label, candid_service, upgrade_arg, expected_result) in [
         (
+            "Service without args",
+            r#"
+                service : {
+                    g : () -> (int) query;
+                }
+            "#,
+            "()",
+            Ok(()),
+        ),
+        (
             "Invalid service",
             r#"
                 service : (x : record { foo : opt record {} }, y : nat32) -> {

--- a/rs/nervous_system/candid_utils/src/validation/tests.rs
+++ b/rs/nervous_system/candid_utils/src/validation/tests.rs
@@ -1,0 +1,128 @@
+use super::*;
+
+#[test]
+fn test_candid_service_arg_validation() {
+    for (label, candid_service, upgrade_arg, expected_result) in [
+        (
+            "Invalid service",
+            r#"
+                service : (x : record { foo : opt record {} }, y : nat32) -> {
+                    f : (byte, int, nat, int8) -> (List);
+                    g : (List) -> (int) query;
+                }
+            "#,
+            "()",
+            Err(()),
+        ),
+        (
+            "Invalid arg",
+            r#"
+                type List = opt record { head: int; tail: List };
+                type byte = nat8;
+                service : (x : record { foo : opt record {} }, y : nat32) -> {
+                    f : (byte, int, nat, int8) -> (List);
+                    g : (List) -> (int) query;
+                }
+            "#,
+            "",
+            Err(()),
+        ),
+        (
+            "Complex service with two arguments (happy)",
+            r#"
+                type List = opt record { head: int; tail: List };
+                type byte = nat8;
+                service : (x : record { foo : opt record {} }, y : nat32) -> {
+                    f : (byte, int, nat, int8) -> (List);
+                    g : (List) -> (int) query;
+                }
+            "#,
+            "(record {}, (11 : nat32))",
+            Ok(()),
+        ),
+        (
+            "Complex service with two arguments (missing 1st arg)",
+            r#"
+                type List = opt record { head: int; tail: List };
+                type byte = nat8;
+                service : (x : record { foo : opt record {} }, y : nat32) -> {
+                    f : (byte, int, nat, int8) -> (List);
+                    g : (List) -> (int) query;
+                }
+            "#,
+            "((11 : nat32))",
+            Err(()),
+        ),
+        (
+            "Complex service with two arguments (missing 2nd arg)",
+            r#"
+                type List = opt record { head: int; tail: List };
+                type byte = nat8;
+                service : (x : record { foo : opt record {} }, y : nat32) -> {
+                    f : (byte, int, nat, int8) -> (List);
+                    g : (List) -> (int) query;
+                }
+            "#,
+            "(record {})",
+            Err(()),
+        ),
+        (
+            "Complex service with two arguments (missing both args)",
+            r#"
+                type List = opt record { head: int; tail: List };
+                type byte = nat8;
+                service : (x : record { foo : opt record {} }, y : nat32) -> {
+                    f : (byte, int, nat, int8) -> (List);
+                    g : (List) -> (int) query;
+                }
+            "#,
+            "()",
+            Err(()),
+        ),
+        (
+            "Trivial service with two arguments (wrong arg order)",
+            r#"
+                service : (x : record { foo : opt record {} }, y : nat32) -> {
+                    g : () -> (int) query;
+                }
+            "#,
+            "((11 : nat32), record {})",
+            Err(()),
+        ),
+        (
+            "Trivial service with one record argument (subtyping holds)",
+            r#"
+                service : (x : record { foo : opt nat; bar : opt nat }) -> {
+                    g : () -> (int) query;
+                }
+            "#,
+            "(record { foobar = opt (1984 : nat); foo = opt (42 : nat) })",
+            Ok(()),
+        ),
+        (
+            "Trivial service with one record argument (extra field breaks subtyping)",
+            r#"
+                service : (x : record { foo : opt nat; bar : nat }) -> {
+                    g : () -> (int) query;
+                }
+            "#,
+            "(record { foobar = (1984 : nat); foo = opt (42 : nat) })",
+            Err(()),
+        ),
+    ] {
+        let observed_result =
+            validate_upgrade_args(candid_service.to_string(), upgrade_arg.to_string());
+
+        match (observed_result, expected_result) {
+            (Ok(_), Ok(())) => (),
+            (Err(_), Err(())) => (),
+            (Err(err), Ok(())) => {
+                println!("{}", err);
+                panic!("Test `{label}` FAILED, although it is expected to succeed.");
+            }
+            (Ok(_), Err(())) => {
+                panic!("Test `{label}` SUCCEEDED, although it is expected to fail.");
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a new crate dedicated to Candid utilities that are likely to be useful in multiple places in the mono repo.

First, we add `candid_utils::validation::validate_upgrade_args`, which takes a full Candid service and checks if a given upgrade argument complies with it, using Candid subtyping. In particular, this function will soon be required in a tool for submitting upgrade proposals for SNS-controlled canisters.

| [Next PR](https://github.com/dfinity/ic/pull/3439) >