### PR TITLE
chore(PocketIC): retry in PocketIC bitcoin integration tests

### DIFF
--- a/packages/pocket-ic/HOWTO.md
+++ b/packages/pocket-ic/HOWTO.md
@@ -585,9 +585,16 @@ To mine blocks with rewards credited to a given `bitcoin_address: String`, you c
     .unwrap();
 
     let mut n = 101; // must be more than 100 (Coinbase maturity rule)
-    btc_rpc
-        .generate_to_address(n, &Address::from_str(&bitcoin_address).unwrap())
-        .unwrap();
+    // retry generating blocks until the bitcoind is up and running
+    loop {
+        match btc_rpc.generate_to_address(n, &Address::from_str(&bitcoin_address).unwrap()) {
+            Ok(_) => break,
+            Err(bitcoincore_rpc::Error::JsonRpc(_)) => {
+                std::thread::sleep(std::time::Duration::from_millis(100));
+            }
+            Err(err) => panic!("Unexpected error when talking to bitcoind: {}", err),
+        }
+    }
 ```
 
 For an example of a test canister that can be deployed to an application subnet of the PocketIC instance,

--- a/packages/pocket-ic/HOWTO.md
+++ b/packages/pocket-ic/HOWTO.md
@@ -586,10 +586,14 @@ To mine blocks with rewards credited to a given `bitcoin_address: String`, you c
 
     let mut n = 101; // must be more than 100 (Coinbase maturity rule)
     // retry generating blocks until the bitcoind is up and running
+    let start = std::time::Instant::now();
     loop {
         match btc_rpc.generate_to_address(n, &Address::from_str(&bitcoin_address).unwrap()) {
             Ok(_) => break,
-            Err(bitcoincore_rpc::Error::JsonRpc(_)) => {
+            Err(bitcoincore_rpc::Error::JsonRpc(err)) => {
+                if start.elapsed() > std::time::Duration::from_secs(30) {
+                    panic!("Timed out when waiting for bitcoind; last error: {}", err);
+                }
                 std::thread::sleep(std::time::Duration::from_millis(100));
             }
             Err(err) => panic!("Unexpected error when talking to bitcoind: {}", err),


### PR DESCRIPTION
This PR prevents spurious errors in PocketIC bitcoin integration tests
```
---- bitcoin_integration_test stdout ----
thread 'bitcoin_integration_test' panicked at rs/pocket_ic_server/tests/bitcoin_integration_tests.rs:145:10:
called `Result::unwrap()` on an `Err` value: JsonRpc(Transport(SocketError(Os { code: 111, kind: ConnectionRefused, message: "Connection refused" })))
stack backtrace:
```
by retrying generating blocks until the bitcoind is up and running.