### PR TITLE
feat(PocketIC): new library function PocketIc::ingress_status_as

### DIFF
--- a/packages/pocket-ic/CHANGELOG.md
+++ b/packages/pocket-ic/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The function `PocketIcBuilder::with_bitcoind_addrs` to specify multiple addresses and ports at which `bitcoind` processes are listening.
 - The function `PocketIc::query_call_with_effective_principal` for making generic query calls (including management canister query calls).
 - The function `PocketIc::ingress_status` to fetch the status of an update call submitted through an ingress message.
+- The function `PocketIc::ingress_status_as` to fetch the status of an update call submitted through an ingress message.
+  If the status of the update call is known, but the update call was submitted by a different caller, then an error is returned.
 - The function `PocketIc::await_call_no_ticks` to await the status of an update call (submitted through an ingress message) becoming known without triggering round execution
   (round execution must be triggered separarely, e.g., on a "live" instance or by separate PocketIC library calls).
 

--- a/packages/pocket-ic/src/lib.rs
+++ b/packages/pocket-ic/src/lib.rs
@@ -699,10 +699,22 @@ impl PocketIc {
     pub fn ingress_status(
         &self,
         message_id: RawMessageId,
-        caller: Option<Principal>,
+    ) -> Option<Result<Vec<u8>, RejectResponse>> {
+        let runtime = self.runtime.clone();
+        runtime.block_on(async { self.pocket_ic.ingress_status(message_id).await })
+    }
+
+    /// Fetch the status of an update call submitted previously by `submit_call` or `submit_call_with_effective_principal`.
+    /// Note that the status of the update call can only change if the PocketIC instance is in live mode
+    /// or a round has been executed due to a separate PocketIC library call.
+    /// If the status of the update call is known, but the update call was submitted by a different caller, then an error is returned.
+    pub fn ingress_status_as(
+        &self,
+        message_id: RawMessageId,
+        caller: Principal,
     ) -> IngressStatusResult {
         let runtime = self.runtime.clone();
-        runtime.block_on(async { self.pocket_ic.ingress_status(message_id, caller).await })
+        runtime.block_on(async { self.pocket_ic.ingress_status_as(message_id, caller).await })
     }
 
     /// Await an update call submitted previously by `submit_call` or `submit_call_with_effective_principal`.

--- a/packages/pocket-ic/src/lib.rs
+++ b/packages/pocket-ic/src/lib.rs
@@ -695,7 +695,7 @@ impl PocketIc {
 
     /// Fetch the status of an update call submitted previously by `submit_call` or `submit_call_with_effective_principal`.
     /// Note that the status of the update call can only change if the PocketIC instance is in live mode
-    /// or a round has been executed due to a separate PocketIC library call.
+    /// or a round has been executed due to a separate PocketIC library call, e.g., `PocketIc::tick()`.
     pub fn ingress_status(
         &self,
         message_id: RawMessageId,
@@ -706,7 +706,7 @@ impl PocketIc {
 
     /// Fetch the status of an update call submitted previously by `submit_call` or `submit_call_with_effective_principal`.
     /// Note that the status of the update call can only change if the PocketIC instance is in live mode
-    /// or a round has been executed due to a separate PocketIC library call.
+    /// or a round has been executed due to a separate PocketIC library call, e.g., `PocketIc::tick()`.
     /// If the status of the update call is known, but the update call was submitted by a different caller, then an error is returned.
     pub fn ingress_status_as(
         &self,
@@ -718,8 +718,8 @@ impl PocketIc {
     }
 
     /// Await an update call submitted previously by `submit_call` or `submit_call_with_effective_principal`.
-    /// This function does not execute rounds and thus should only be called on a "live" PocketIC instance
-    /// or if rounds are executed due to separate PocketIC library calls.
+    /// Note that the status of the update call can only change if the PocketIC instance is in live mode
+    /// or a round has been executed due to a separate PocketIC library call, e.g., `PocketIc::tick()`.
     pub fn await_call_no_ticks(&self, message_id: RawMessageId) -> Result<Vec<u8>, RejectResponse> {
         let runtime = self.runtime.clone();
         runtime.block_on(async { self.pocket_ic.await_call_no_ticks(message_id).await })

--- a/packages/pocket-ic/src/nonblocking.rs
+++ b/packages/pocket-ic/src/nonblocking.rs
@@ -586,7 +586,7 @@ impl PocketIc {
 
     /// Fetch the status of an update call submitted previously by `submit_call` or `submit_call_with_effective_principal`.
     /// Note that the status of the update call can only change if the PocketIC instance is in live mode
-    /// or a round has been executed due to a separate PocketIC library call.
+    /// or a round has been executed due to a separate PocketIC library call, e.g., `PocketIc::tick()`.
     pub async fn ingress_status(
         &self,
         raw_message_id: RawMessageId,
@@ -604,7 +604,7 @@ impl PocketIc {
 
     /// Fetch the status of an update call submitted previously by `submit_call` or `submit_call_with_effective_principal`.
     /// Note that the status of the update call can only change if the PocketIC instance is in live mode
-    /// or a round has been executed due to a separate PocketIC library call.
+    /// or a round has been executed due to a separate PocketIC library call, e.g., `PocketIc::tick()`.
     /// If the status of the update call is known, but the update call was submitted by a different caller, then an error is returned.
     pub async fn ingress_status_as(
         &self,
@@ -638,8 +638,8 @@ impl PocketIc {
     }
 
     /// Await an update call submitted previously by `submit_call` or `submit_call_with_effective_principal`.
-    /// This function does not execute rounds and thus should only be called on a "live" PocketIC instance
-    /// or if rounds are executed due to separate PocketIC library calls.
+    /// Note that the status of the update call can only change if the PocketIC instance is in live mode
+    /// or a round has been executed due to a separate PocketIC library call.
     pub async fn await_call_no_ticks(
         &self,
         message_id: RawMessageId,

--- a/packages/pocket-ic/src/nonblocking.rs
+++ b/packages/pocket-ic/src/nonblocking.rs
@@ -590,6 +590,34 @@ impl PocketIc {
     pub async fn ingress_status(
         &self,
         raw_message_id: RawMessageId,
+    ) -> Option<Result<Vec<u8>, RejectResponse>> {
+        let status = self.ingress_status_as_caller(raw_message_id, None).await;
+        match status {
+            IngressStatusResult::NotAvailable => None,
+            IngressStatusResult::Success(status) => Some(status),
+            IngressStatusResult::Forbidden(err) => panic!(
+                "Retrieving ingress status was forbidden: {}. This is a bug!",
+                err
+            ),
+        }
+    }
+
+    /// Fetch the status of an update call submitted previously by `submit_call` or `submit_call_with_effective_principal`.
+    /// Note that the status of the update call can only change if the PocketIC instance is in live mode
+    /// or a round has been executed due to a separate PocketIC library call.
+    /// If the status of the update call is known, but the update call was submitted by a different caller, then an error is returned.
+    pub async fn ingress_status_as(
+        &self,
+        raw_message_id: RawMessageId,
+        caller: Principal,
+    ) -> IngressStatusResult {
+        self.ingress_status_as_caller(raw_message_id, Some(caller))
+            .await
+    }
+
+    async fn ingress_status_as_caller(
+        &self,
+        raw_message_id: RawMessageId,
         caller: Option<Principal>,
     ) -> IngressStatusResult {
         let endpoint = "read/ingress_status";
@@ -603,7 +631,7 @@ impl PocketIc {
             Ok(None) => IngressStatusResult::NotAvailable,
             Ok(Some(result)) => IngressStatusResult::Success(result.into()),
             Err((status, message)) => {
-                assert_eq!(status, StatusCode::FORBIDDEN, "HTTP error code {} for PocketIc::ingress_status is not StatusCode::FORBIDDEN. This is a bug!", status);
+                assert_eq!(status, StatusCode::FORBIDDEN, "HTTP error code {} for /read/ingress_status is not StatusCode::FORBIDDEN. This is a bug!", status);
                 IngressStatusResult::Forbidden(message)
             }
         }
@@ -622,9 +650,7 @@ impl PocketIc {
             .with_multiplier(2.0)
             .build();
         loop {
-            if let IngressStatusResult::Success(ingress_status) =
-                self.ingress_status(message_id.clone(), None).await
-            {
+            if let Some(ingress_status) = self.ingress_status(message_id.clone()).await {
                 break ingress_status;
             }
             tokio::time::sleep(retry_policy.next_backoff().unwrap()).await;

--- a/rs/pocket_ic_server/CHANGELOG.md
+++ b/rs/pocket_ic_server/CHANGELOG.md
@@ -13,8 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - New endpoint `/instances/<instance_id>/read/ingress_status` to fetch the status of an update call submitted through an ingress message.
-  If an optional caller is provided and a corresponding read state request for the status of the same update call
-  signed by that specified caller was rejected because the update call was submitted by a different caller, then an error is returned.
+  If an optional caller is provided, the status of the update call is known, but the update call was submitted by a different caller, then an error is returned.
 
 ### Fixed
 - Canisters created via `provisional_create_canister_with_cycles` with the management canister ID as the effective canister ID


### PR DESCRIPTION
This PR splits the function `PocketIc::ingress_status` taking an optional caller into a pair of functions:
- `PocketIc::ingress_status` taking no caller and returning a more precise return type;
- `PocketIc::ingress_status_as` taking a non-optional caller and returning the original return type.

This way, the use cases of just fetching the ingress status and also checking the caller are properly separated (no need to pass `None` in the former use case) and the return types are more precise.