### PR TITLE
test: try reducing flakiness of the backup_manager_tests

### DIFF
--- a/rs/tests/BUILD.bazel
+++ b/rs/tests/BUILD.bazel
@@ -239,18 +239,6 @@ symlink_dir(
     },
 )
 
-symlink_dir(
-    name = "backup/binaries",
-    testonly = True,
-    targets = {
-        "//rs/backup:ic-backup": "ic-backup",
-        "//rs/replay:ic-replay": "ic-replay",
-        "//rs/canister_sandbox:compiler_sandbox": "compiler_sandbox",
-        "//rs/canister_sandbox:sandbox_launcher": "sandbox_launcher",
-        "//rs/canister_sandbox:canister_sandbox": "canister_sandbox",
-    },
-)
-
 symlink_dir_test(
     name = "cup_compatibility/binaries",
     targets = {

--- a/rs/tests/consensus/backup/BUILD.bazel
+++ b/rs/tests/consensus/backup/BUILD.bazel
@@ -29,10 +29,20 @@ rust_library(
 
 BACKUP_RUNTIME_DEPS = UNIVERSAL_CANISTER_RUNTIME_DEPS + [
     # Keep sorted.
-    "//rs/tests:backup/binaries",
+    "//rs/backup:ic-backup",
+    "//rs/canister_sandbox:canister_sandbox",
+    "//rs/canister_sandbox:compiler_sandbox",
+    "//rs/canister_sandbox:sandbox_launcher",
+    "//rs/replay:ic-replay",
 ]
 
-BACKUP_ENV = UNIVERSAL_CANISTER_ENV
+BACKUP_ENV = UNIVERSAL_CANISTER_ENV | {
+    "IC_BACKUP_PATH": "$(rootpath //rs/backup:ic-backup)",
+    "IC_REPLAY_PATH": "$(rootpath //rs/replay:ic-replay)",
+    "COMPILER_SANDBOX_PATH": "$(rootpath //rs/canister_sandbox:compiler_sandbox)",
+    "SANDBOX_LAUNCHER_PATH": "$(rootpath //rs/canister_sandbox:sandbox_launcher)",
+    "CANISTER_SANDBOX_PATH": "$(rootpath //rs/canister_sandbox:canister_sandbox)",
+}
 
 system_test_nns(
     name = "backup_manager_downgrade_test",
@@ -44,6 +54,7 @@ system_test_nns(
         "long_test",  # since it takes longer than 5 minutes.
     ],
     target_compatible_with = ["@platforms//os:linux"],  # requires libssh that does not build on Mac OS
+    test_timeout = "eternal",  # this test often times out with the default 15 minute timeout so we allow more time
     uses_guestos_dev_test = True,
     runtime_deps =
         GUESTOS_RUNTIME_DEPS +
@@ -68,6 +79,7 @@ system_test_nns(
         "long_test",  # since it takes longer than 5 minutes.
     ],
     target_compatible_with = ["@platforms//os:linux"],  # requires libssh that does not build on Mac OS
+    test_timeout = "eternal",  # this test often times out with the default 15 minute timeout so we allow more time
     uses_guestos_dev_test = True,
     runtime_deps =
         GUESTOS_RUNTIME_DEPS +

--- a/rs/tests/consensus/backup/backup_manager_downgrade_test.rs
+++ b/rs/tests/consensus/backup/backup_manager_downgrade_test.rs
@@ -8,7 +8,7 @@ use std::time::Duration;
 fn main() -> Result<()> {
     SystemTestGroup::new()
         .with_setup(setup_downgrade)
-        .with_timeout_per_test(Duration::from_secs(15 * 60))
+        .with_timeout_per_test(Duration::from_secs(25 * 60))
         .add_test(systest!(test_downgrade))
         .execute_from_args()?;
 

--- a/rs/tests/consensus/backup/backup_manager_upgrade_test.rs
+++ b/rs/tests/consensus/backup/backup_manager_upgrade_test.rs
@@ -8,7 +8,7 @@ use std::time::Duration;
 fn main() -> Result<()> {
     SystemTestGroup::new()
         .with_setup(setup_upgrade)
-        .with_timeout_per_test(Duration::from_secs(15 * 60))
+        .with_timeout_per_test(Duration::from_secs(25 * 60))
         .add_test(systest!(test_upgrade))
         .execute_from_args()?;
 

--- a/rs/tests/consensus/backup/common.rs
+++ b/rs/tests/consensus/backup/common.rs
@@ -181,12 +181,32 @@ fn test(env: TestEnv, binary_version: String, target_version: String) {
     fs::create_dir_all(&backup_binaries_dir).expect("failure creating backup binaries directory");
 
     // Copy all the binaries needed for the replay of the current version in order to avoid downloading them
-    let testing_dir = get_dependency_path("rs/tests");
-    let binaries_path = testing_dir.join("backup/binaries");
-    copy_file(&binaries_path, &backup_binaries_dir, "ic-replay");
-    copy_file(&binaries_path, &backup_binaries_dir, "sandbox_launcher");
-    copy_file(&binaries_path, &backup_binaries_dir, "canister_sandbox");
-    copy_file(&binaries_path, &backup_binaries_dir, "compiler_sandbox");
+    copy_file(
+        &get_dependency_path(std::env::var("IC_REPLAY_PATH").expect("IC_REPLAY_PATH not set")),
+        &backup_binaries_dir,
+        "ic-replay",
+    );
+    copy_file(
+        &get_dependency_path(
+            std::env::var("SANDBOX_LAUNCHER_PATH").expect("SANDBOX_LAUNCHER_PATH not set"),
+        ),
+        &backup_binaries_dir,
+        "sandbox_launcher",
+    );
+    copy_file(
+        &get_dependency_path(
+            std::env::var("CANISTER_SANDBOX_PATH").expect("CANISTER_SANDBOX_PATH not set"),
+        ),
+        &backup_binaries_dir,
+        "canister_sandbox",
+    );
+    copy_file(
+        &get_dependency_path(
+            std::env::var("COMPILER_SANDBOX_PATH").expect("COMPILER_SANDBOX_PATH not set"),
+        ),
+        &backup_binaries_dir,
+        "compiler_sandbox",
+    );
 
     // Generate keypair and store the private key
     info!(log, "Create backup user credentials");
@@ -282,7 +302,8 @@ fn test(env: TestEnv, binary_version: String, target_version: String) {
     write!(f, "{}", config_str).expect("Should be able to write the config file");
 
     info!(log, "Start the backup process in a separate thread");
-    let ic_backup_path = binaries_path.join("ic-backup");
+    let ic_backup_path =
+        &get_dependency_path(std::env::var("IC_BACKUP_PATH").expect("IC_BACKUP_PATH not set"));
     let mut command = Command::new(&ic_backup_path);
     command
         .arg("--config-file")
@@ -498,12 +519,8 @@ fn dir_exists_and_have_file(log: &Logger, dir: &PathBuf) -> bool {
     have_file
 }
 
-fn copy_file(binaries_path: &Path, backup_binaries_dir: &Path, file_name: &str) {
-    fs::copy(
-        binaries_path.join(file_name),
-        backup_binaries_dir.join(file_name),
-    )
-    .expect("failed to copy file");
+fn copy_file(binary_path: &Path, backup_binaries_dir: &Path, file_name: &str) {
+    fs::copy(binary_path, backup_binaries_dir.join(file_name)).expect("failed to copy file");
 }
 
 fn highest_dir_entry(dir: &PathBuf, radix: u32) -> u64 {


### PR DESCRIPTION
The `//rs/tests/consensus/backup:backup_manager_{upgrade, downgrade}_test` are highly flaky caused by timeouts. This commit bumps the timeout as an experiment to see if that makes these tests less flaky.

Additionally this commit also specifies dependencies of these tests in a more modern way by defining environment variables that point to the required binaries like `ic-backup`, `ic-replay`, etc..