### PR TITLE
chore: Improve some state tool error messages

### DIFF
--- a/rs/state_tool/src/main.rs
+++ b/rs/state_tool/src/main.rs
@@ -28,6 +28,7 @@ enum Opt {
     },
 
     /// Imports replicated state from an external location.
+    /// Deprecated: use `copy` instead.
     #[clap(name = "import")]
     ImportState {
         /// Path to the state to import.


### PR DESCRIPTION
Improves some of the error messages of the `state-tool copy` command. In particular it makes it more clear when the failure might have left the directory contents inconsistent.