### PR TITLE
test: don't run //rs/tests/cross_chain:ic_xc_cketh_test by default on PRs

### DIFF
--- a/rs/tests/cross_chain/BUILD.bazel
+++ b/rs/tests/cross_chain/BUILD.bazel
@@ -53,6 +53,7 @@ system_test_nns(
         "LEDGER_WASM_PATH": "$(rootpath //rs/ledger_suite/icrc1/ledger:ledger_canister_u256.wasm.gz)",
         "LEDGER_SUITE_ORCHESTRATOR_WASM_PATH": "$(rootpath //rs/ethereum/ledger-suite-orchestrator:ledger_suite_orchestrator_canister.wasm.gz)",
     },
+    tags = ["long_test"],
     target_compatible_with = ["@platforms//os:linux"],  # requires libssh that does not build on Mac OS
     runtime_deps =
         BOUNDARY_NODE_GUESTOS_RUNTIME_DEPS +


### PR DESCRIPTION
The P90 duration of the `//rs/tests/cross_chain:ic_xc_cketh_test` is 7 minutes which is too long to run on PRs by default. So we tag it as a `long_test` which only runs this test on pushes to master or when CI Main is manually triggered on the PR branch or when the PR is labelled with `CI_ALL_BAZEL_TARGETS`.