### PR TITLE
test(sns): bump expected max ballot age to reduce flakiness in //rs/sns/integration_tests:integration_test_src/proposals

### DIFF
--- a/rs/sns/integration_tests/src/proposals.rs
+++ b/rs/sns/integration_tests/src/proposals.rs
@@ -36,6 +36,8 @@ use std::{
     time::{SystemTime, UNIX_EPOCH},
 };
 
+const EXPECTED_MAX_BALLOT_AGE: f64 = 60.0;
+
 const MOTION_PROPOSAL_ACTION_TYPE: u64 = 1;
 
 const VOTING_REWARDS_PARAMETERS: VotingRewardsParameters = VotingRewardsParameters {
@@ -346,7 +348,7 @@ fn test_voting_with_three_neurons_with_the_same_stake() {
                     ballot
                 );
                 assert!(
-                    age_seconds < 30.0,
+                    age_seconds < EXPECTED_MAX_BALLOT_AGE,
                     "age_seconds = {}. ballot = {:?}",
                     age_seconds,
                     ballot


### PR DESCRIPTION
The `//rs/sns/integration_tests:integration_test_src/proposals` is more than 4% flaky. Every time it fails it's because the                `assert!(age_seconds < 30.0, ...)` fails ([example](https://dash.zh1-idx1.dfinity.network/invocation/777191ad-ed01-4bcc-84a9-48d820d23fec?target=%2F%2Frs%2Fsns%2Fintegration_tests%3Aintegration_test_src%2Fproposals&targetStatus=11)). This commit attempts to fix it by bumping the expected maximum ballot age from 30 to 60 seconds. 