### PR TITLE
fix: replace removed ic-admin's subcommands in ic-recovery

### DIFF
--- a/rs/recovery/src/admin_helper.rs
+++ b/rs/recovery/src/admin_helper.rs
@@ -147,8 +147,6 @@ impl AdminHelper {
         let mut ic_admin = self.get_ic_admin_cmd_base();
 
         ic_admin
-            // TODO: Switch to the new command name:
-            // .add_positional_argument("propose-to-deploy-guestos-to-all-subnet-nodes")
             .add_positional_argument("propose-to-deploy-guestos-to-all-subnet-nodes")
             .add_positional_argument(subnet_id)
             .add_positional_argument(upgrade_version)


### PR DESCRIPTION
1187a89cfde9bf7bb0ab226c60f99dde7ccb7748 removed some ic-admin's subcommands and replaced them with other commands. However the `ic-recovery` tool, which is used in the `//rs/tests/consensus/subnet_recovery:...` tests, was still using these removed subcommands which caused these tests to fail during release qualification.

`ict test //rs/tests/consensus/subnet_recovery:sr_app_same_nodes_test_colocate` passes on this commit.