### PR TITLE
fix(system-tests-k8s): hourly targets

### DIFF
--- a/.github/workflows/system-tests-k8s.yml
+++ b/.github/workflows/system-tests-k8s.yml
@@ -131,6 +131,25 @@ jobs:
         env:
           TNET_KUBECONFIG: ${{ secrets.TNET_KUBECONFIG }}
 
+      - name: Get Bazel Target List
+        shell: bash
+        run: |
+          # Query Bazel for targets
+          T=$(bazel query 'attr(tags, "k8s", tests(attr(tags, "long_test|system_test_hourly", //...)))')
+
+          # Handle empty target list
+          if [[ -z "$T" ]]; then
+            echo "No Bazel targets found matching the criteria."
+            echo "TARGETS=" >> $GITHUB_ENV
+            exit 1
+          fi
+
+          # Convert to space-separated list and trim
+          T=$(echo "$T" | tr '\n' ' ' | sed -e 's/,$//' -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+
+          # Export to GitHub environment
+          echo "TARGETS=$T" >> $GITHUB_ENV
+
       - name: Run System Tests on K8s
         id: bazel-test-all
         uses: ./.github/actions/bazel-test-all/
@@ -140,7 +159,7 @@ jobs:
           BAZEL_COMMAND: "test"
           BAZEL_TARGETS: "${{ env.TARGETS }}"
           BAZEL_CI_CONFIG: "--config=ci --repository_cache=/cache/bazel"
-          BAZEL_EXTRA_ARGS: "--jobs=${{ env.JOBS }} --test_tag_filters=k8s,long_test,system_test_hourly,-manual,-colocated,-system_test_nightly --k8s"
+          BAZEL_EXTRA_ARGS: "--jobs=${{ env.JOBS }} --test_tag_filters=k8s,-manual,-colocated,-system_test_nightly --k8s"
           BUILDEVENT_APIKEY: ${{ secrets.HONEYCOMB_API_TOKEN }}
 
       - name: Upload bazel-bep

--- a/.github/workflows/system-tests-k8s.yml
+++ b/.github/workflows/system-tests-k8s.yml
@@ -134,8 +134,8 @@ jobs:
       - name: Get Bazel Target List
         shell: bash
         run: |
-          # Query Bazel for targets
-          T=$(bazel query 'attr(tags, "k8s", tests(attr(tags, "long_test|system_test_hourly", //...)))')
+          # Query Bazel for targets: system tests with k8s flag AND (long_test flag OR system_test_hourly flag)
+          T=$(bazel query 'attr(tags, "k8s", tests(attr(tags, "long_test|system_test_hourly", //...))) except attr(tags, "colocated|manual|system_test_nightly", //...)')
 
           # Handle empty target list
           if [[ -z "$T" ]]; then
@@ -159,7 +159,7 @@ jobs:
           BAZEL_COMMAND: "test"
           BAZEL_TARGETS: "${{ env.TARGETS }}"
           BAZEL_CI_CONFIG: "--config=ci --repository_cache=/cache/bazel"
-          BAZEL_EXTRA_ARGS: "--jobs=${{ env.JOBS }} --test_tag_filters=k8s,-manual,-colocated,-system_test_nightly --k8s"
+          BAZEL_EXTRA_ARGS: "--jobs=${{ env.JOBS }} --k8s"
           BUILDEVENT_APIKEY: ${{ secrets.HONEYCOMB_API_TOKEN }}
 
       - name: Upload bazel-bep

--- a/.github/workflows/system-tests-k8s.yml
+++ b/.github/workflows/system-tests-k8s.yml
@@ -159,7 +159,7 @@ jobs:
           BAZEL_COMMAND: "test"
           BAZEL_TARGETS: "${{ env.TARGETS }}"
           BAZEL_CI_CONFIG: "--config=ci --repository_cache=/cache/bazel"
-          BAZEL_EXTRA_ARGS: "--jobs=${{ env.JOBS }} --k8s"
+          BAZEL_EXTRA_ARGS: "--jobs=${{ env.JOBS }} --test_tag_filters=k8s --k8s"
           BUILDEVENT_APIKEY: ${{ secrets.HONEYCOMB_API_TOKEN }}
 
       - name: Upload bazel-bep

--- a/.github/workflows/system-tests-k8s.yml
+++ b/.github/workflows/system-tests-k8s.yml
@@ -65,37 +65,37 @@ jobs:
           DOCKER_HUB_USER: ${{ vars.DOCKER_HUB_USER }}
           DOCKER_HUB_PASSWORD_RO: ${{ secrets.DOCKER_HUB_PASSWORD_RO }}
 
-      # - name: Set KUBECONFIG
-      #   shell: bash
-      #   run: |
-      #     echo "$TNET_KUBECONFIG" > /tmp/kubeconfig
-      #     echo "KUBECONFIG=/tmp/kubeconfig" >> $GITHUB_ENV
-      #   env:
-      #     TNET_KUBECONFIG: ${{ secrets.TNET_KUBECONFIG }}
-      #
-      # - name: Run System Tests on K8s
-      #   id: bazel-test-all
-      #   uses: ./.github/actions/bazel-test-all/
-      #   env:
-      #     AWS_SHARED_CREDENTIALS_CONTENT: ${{ secrets.AWS_SHARED_CREDENTIALS_FILE }}
-      #   with:
-      #     BAZEL_COMMAND: "test"
-      #     BAZEL_TARGETS: "${{ env.TARGETS }}"
-      #     BAZEL_CI_CONFIG: "--config=ci --repository_cache=/cache/bazel"
-      #     BAZEL_EXTRA_ARGS: "--jobs=${{ env.JOBS }} --test_tag_filters=k8s,-manual,-colocated,-long_test,-system_test_hourly,-system_test_nightly --k8s"
-      #     BUILDEVENT_APIKEY: ${{ secrets.HONEYCOMB_API_TOKEN }}
-      #
-      # - name: Upload bazel-bep
-      #   uses: actions/upload-artifact@v4
-      #   if: success() || failure()
-      #   with:
-      #     name: ${{ github.job }}-bep
-      #     retention-days: 14
-      #     if-no-files-found: ignore
-      #     compression-level: 9
-      #     path: |
-      #       bazel-bep.pb
-      #       profile.json
+      - name: Set KUBECONFIG
+        shell: bash
+        run: |
+          echo "$TNET_KUBECONFIG" > /tmp/kubeconfig
+          echo "KUBECONFIG=/tmp/kubeconfig" >> $GITHUB_ENV
+        env:
+          TNET_KUBECONFIG: ${{ secrets.TNET_KUBECONFIG }}
+
+      - name: Run System Tests on K8s
+        id: bazel-test-all
+        uses: ./.github/actions/bazel-test-all/
+        env:
+          AWS_SHARED_CREDENTIALS_CONTENT: ${{ secrets.AWS_SHARED_CREDENTIALS_FILE }}
+        with:
+          BAZEL_COMMAND: "test"
+          BAZEL_TARGETS: "${{ env.TARGETS }}"
+          BAZEL_CI_CONFIG: "--config=ci --repository_cache=/cache/bazel"
+          BAZEL_EXTRA_ARGS: "--jobs=${{ env.JOBS }} --test_tag_filters=k8s,-manual,-colocated,-long_test,-system_test_hourly,-system_test_nightly --k8s"
+          BUILDEVENT_APIKEY: ${{ secrets.HONEYCOMB_API_TOKEN }}
+
+      - name: Upload bazel-bep
+        uses: actions/upload-artifact@v4
+        if: success() || failure()
+        with:
+          name: ${{ github.job }}-bep
+          retention-days: 14
+          if-no-files-found: ignore
+          compression-level: 9
+          path: |
+            bazel-bep.pb
+            profile.json
 
   system-tests-k8s-hourly:
     name: System Tests K8s Hourly
@@ -111,7 +111,7 @@ jobs:
     timeout-minutes: 150
     needs: [system-tests-k8s]
     # always run after 'system-tests-k8s' job but on schedule event only
-    # if: ${{ always() && github.event_name == 'schedule' }}
+    if: ${{ always() && github.event_name == 'schedule' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/system-tests-k8s.yml
+++ b/.github/workflows/system-tests-k8s.yml
@@ -65,37 +65,37 @@ jobs:
           DOCKER_HUB_USER: ${{ vars.DOCKER_HUB_USER }}
           DOCKER_HUB_PASSWORD_RO: ${{ secrets.DOCKER_HUB_PASSWORD_RO }}
 
-      - name: Set KUBECONFIG
-        shell: bash
-        run: |
-          echo "$TNET_KUBECONFIG" > /tmp/kubeconfig
-          echo "KUBECONFIG=/tmp/kubeconfig" >> $GITHUB_ENV
-        env:
-          TNET_KUBECONFIG: ${{ secrets.TNET_KUBECONFIG }}
-
-      - name: Run System Tests on K8s
-        id: bazel-test-all
-        uses: ./.github/actions/bazel-test-all/
-        env:
-          AWS_SHARED_CREDENTIALS_CONTENT: ${{ secrets.AWS_SHARED_CREDENTIALS_FILE }}
-        with:
-          BAZEL_COMMAND: "test"
-          BAZEL_TARGETS: "${{ env.TARGETS }}"
-          BAZEL_CI_CONFIG: "--config=ci --repository_cache=/cache/bazel"
-          BAZEL_EXTRA_ARGS: "--jobs=${{ env.JOBS }} --test_tag_filters=k8s,-manual,-colocated,-long_test,-system_test_hourly,-system_test_nightly --k8s"
-          BUILDEVENT_APIKEY: ${{ secrets.HONEYCOMB_API_TOKEN }}
-
-      - name: Upload bazel-bep
-        uses: actions/upload-artifact@v4
-        if: success() || failure()
-        with:
-          name: ${{ github.job }}-bep
-          retention-days: 14
-          if-no-files-found: ignore
-          compression-level: 9
-          path: |
-            bazel-bep.pb
-            profile.json
+      # - name: Set KUBECONFIG
+      #   shell: bash
+      #   run: |
+      #     echo "$TNET_KUBECONFIG" > /tmp/kubeconfig
+      #     echo "KUBECONFIG=/tmp/kubeconfig" >> $GITHUB_ENV
+      #   env:
+      #     TNET_KUBECONFIG: ${{ secrets.TNET_KUBECONFIG }}
+      #
+      # - name: Run System Tests on K8s
+      #   id: bazel-test-all
+      #   uses: ./.github/actions/bazel-test-all/
+      #   env:
+      #     AWS_SHARED_CREDENTIALS_CONTENT: ${{ secrets.AWS_SHARED_CREDENTIALS_FILE }}
+      #   with:
+      #     BAZEL_COMMAND: "test"
+      #     BAZEL_TARGETS: "${{ env.TARGETS }}"
+      #     BAZEL_CI_CONFIG: "--config=ci --repository_cache=/cache/bazel"
+      #     BAZEL_EXTRA_ARGS: "--jobs=${{ env.JOBS }} --test_tag_filters=k8s,-manual,-colocated,-long_test,-system_test_hourly,-system_test_nightly --k8s"
+      #     BUILDEVENT_APIKEY: ${{ secrets.HONEYCOMB_API_TOKEN }}
+      #
+      # - name: Upload bazel-bep
+      #   uses: actions/upload-artifact@v4
+      #   if: success() || failure()
+      #   with:
+      #     name: ${{ github.job }}-bep
+      #     retention-days: 14
+      #     if-no-files-found: ignore
+      #     compression-level: 9
+      #     path: |
+      #       bazel-bep.pb
+      #       profile.json
 
   system-tests-k8s-hourly:
     name: System Tests K8s Hourly
@@ -111,7 +111,7 @@ jobs:
     timeout-minutes: 150
     needs: [system-tests-k8s]
     # always run after 'system-tests-k8s' job but on schedule event only
-    if: ${{ always() && github.event_name == 'schedule' }}
+    # if: ${{ always() && github.event_name == 'schedule' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
I filter system tests that have `k8s` tag and are either `long_test` or `system_test_hourly`.