### PR TITLE
chore(system-tests-k8s): use --local_test_jobs

### DIFF
--- a/.github/workflows/system-tests-k8s.yml
+++ b/.github/workflows/system-tests-k8s.yml
@@ -19,9 +19,9 @@ on:
         required: false
         default: '//rs/tests/nns:node_removal_from_registry_test'
       jobs:
-        description: 'Concurrent Bazel Jobs'
+        description: 'Concurrent Bazel Test Jobs'
         required: false
-        default: '32'
+        default: '10'
 
 env:
   TARGETS: |
@@ -29,9 +29,9 @@ env:
     github.event_name == 'workflow_dispatch' && github.event.inputs.targets ||
     '//rs/tests/nns:node_removal_from_registry_test' }}
   JOBS: |
-    ${{ github.event_name == 'schedule' && '12' ||
+    ${{ github.event_name == 'schedule' && '10' ||
     github.event_name == 'workflow_dispatch' && github.event.inputs.jobs ||
-    '32' }}
+    '10' }}
   BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
   CI_COMMIT_SHA: ${{ github.sha }}
   CI_JOB_NAME: ${{ github.job }}
@@ -82,7 +82,7 @@ jobs:
           BAZEL_COMMAND: "test"
           BAZEL_TARGETS: "${{ env.TARGETS }}"
           BAZEL_CI_CONFIG: "--config=ci --repository_cache=/cache/bazel"
-          BAZEL_EXTRA_ARGS: "--jobs=${{ env.JOBS }} --test_tag_filters=k8s,-manual,-colocated,-long_test,-system_test_hourly,-system_test_nightly --k8s"
+          BAZEL_EXTRA_ARGS: "--local_test_jobs=${{ env.JOBS }} --test_tag_filters=k8s,-manual,-colocated,-long_test,-system_test_hourly,-system_test_nightly --k8s"
           BUILDEVENT_APIKEY: ${{ secrets.HONEYCOMB_API_TOKEN }}
 
       - name: Upload bazel-bep
@@ -159,7 +159,7 @@ jobs:
           BAZEL_COMMAND: "test"
           BAZEL_TARGETS: "${{ env.TARGETS }}"
           BAZEL_CI_CONFIG: "--config=ci --repository_cache=/cache/bazel"
-          BAZEL_EXTRA_ARGS: "--jobs=${{ env.JOBS }} --test_tag_filters=k8s --k8s"
+          BAZEL_EXTRA_ARGS: "--local_test_jobs=${{ env.JOBS }} --test_tag_filters=k8s --k8s"
           BUILDEVENT_APIKEY: ${{ secrets.HONEYCOMB_API_TOKEN }}
 
       - name: Upload bazel-bep


### PR DESCRIPTION
Use `--local_test_jobs` to limit parallelism only on test targets and not on build targets. Setting default `--local_test_jobs` to 10. This will be raised on a new cluster. On long term some queuing logic will have to be introduced in `setup` phase of system test driver.