### PR TITLE
chore(cketh/ckerc20): Replace rpc.sepolia.org by Ankr

### DIFF
--- a/rs/ethereum/cketh/minter/src/eth_rpc_client/mod.rs
+++ b/rs/ethereum/cketh/minter/src/eth_rpc_client/mod.rs
@@ -53,7 +53,7 @@ impl EthRpcClient {
     }
 
     pub fn from_state(state: &State) -> Self {
-        use evm_rpc_client::RpcServices as EvmRpcServices;
+        use evm_rpc_client::{EthSepoliaService, RpcServices as EvmRpcServices};
 
         let mut client = Self::new(state.ethereum_network());
         if let Some(evm_rpc_id) = state.evm_rpc_id {
@@ -61,7 +61,12 @@ impl EthRpcClient {
 
             let providers = match client.chain {
                 EthereumNetwork::Mainnet => EvmRpcServices::EthMainnet(None),
-                EthereumNetwork::Sepolia => EvmRpcServices::EthSepolia(None),
+                EthereumNetwork::Sepolia => EvmRpcServices::EthSepolia(Some(vec![
+                    EthSepoliaService::BlockPi,
+                    EthSepoliaService::PublicNode,
+                    EthSepoliaService::Alchemy,
+                    EthSepoliaService::Ankr,
+                ])),
             };
             let min_threshold = match client.chain {
                 EthereumNetwork::Mainnet => 3_u8,

--- a/rs/ethereum/cketh/minter/src/eth_rpc_client/providers.rs
+++ b/rs/ethereum/cketh/minter/src/eth_rpc_client/providers.rs
@@ -11,7 +11,7 @@ pub(crate) const SEPOLIA_PROVIDERS: [RpcNodeProvider; 4] = [
     RpcNodeProvider::Sepolia(SepoliaProvider::BlockPi),
     RpcNodeProvider::Sepolia(SepoliaProvider::PublicNode),
     RpcNodeProvider::Sepolia(SepoliaProvider::Alchemy),
-    RpcNodeProvider::Sepolia(SepoliaProvider::RpcSepolia),
+    RpcNodeProvider::Sepolia(SepoliaProvider::Ankr),
 ];
 
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Debug)]
@@ -64,7 +64,7 @@ pub(crate) enum SepoliaProvider {
     PublicNode,
     // https://www.alchemy.com/chain-connect/endpoints/rpc-sepolia-sepolia
     Alchemy,
-    RpcSepolia,
+    Ankr,
 }
 
 impl SepoliaProvider {
@@ -73,7 +73,7 @@ impl SepoliaProvider {
             SepoliaProvider::BlockPi => "https://ethereum-sepolia.blockpi.network/v1/rpc/public",
             SepoliaProvider::PublicNode => "https://ethereum-sepolia-rpc.publicnode.com",
             SepoliaProvider::Alchemy => "https://eth-sepolia.g.alchemy.com/v2/demo",
-            SepoliaProvider::RpcSepolia => "https://rpc.sepolia.org",
+            SepoliaProvider::Ankr => "https://rpc.ankr.com/eth_sepolia",
         }
     }
 }

--- a/rs/ethereum/cketh/minter/src/eth_rpc_client/tests.rs
+++ b/rs/ethereum/cketh/minter/src/eth_rpc_client/tests.rs
@@ -21,7 +21,7 @@ mod eth_rpc_client {
                 RpcNodeProvider::Sepolia(SepoliaProvider::BlockPi),
                 RpcNodeProvider::Sepolia(SepoliaProvider::PublicNode),
                 RpcNodeProvider::Sepolia(SepoliaProvider::Alchemy),
-                RpcNodeProvider::Sepolia(SepoliaProvider::RpcSepolia)
+                RpcNodeProvider::Sepolia(SepoliaProvider::Ankr)
             ]
         );
     }

--- a/rs/ethereum/evm-rpc-client/src/lib.rs
+++ b/rs/ethereum/evm-rpc-client/src/lib.rs
@@ -10,10 +10,11 @@ use serde::de::DeserializeOwned;
 use std::fmt::Debug;
 
 pub use evm_rpc_types::{
-    Block, BlockTag, ConsensusStrategy, EthMainnetService, FeeHistory, FeeHistoryArgs, GetLogsArgs,
-    GetTransactionCountArgs, Hex, Hex20, Hex256, Hex32, HexByte, HttpOutcallError, JsonRpcError,
-    LogEntry, MultiRpcResult, Nat256, ProviderError, RpcApi, RpcConfig, RpcError, RpcResult,
-    RpcService, RpcServices, SendRawTransactionStatus, TransactionReceipt, ValidationError,
+    Block, BlockTag, ConsensusStrategy, EthMainnetService, EthSepoliaService, FeeHistory,
+    FeeHistoryArgs, GetLogsArgs, GetTransactionCountArgs, Hex, Hex20, Hex256, Hex32, HexByte,
+    HttpOutcallError, JsonRpcError, LogEntry, MultiRpcResult, Nat256, ProviderError, RpcApi,
+    RpcConfig, RpcError, RpcResult, RpcService, RpcServices, SendRawTransactionStatus,
+    TransactionReceipt, ValidationError,
 };
 
 #[async_trait]


### PR DESCRIPTION
([XC-272](https://dfinity.atlassian.net/browse/XC-272)) Replace rpc.sepolia.org by Ankr

Remove the rpc.sepolia.org RPC Sepolia provider, and replace it with Ankr. Ankr was originally removed due to a lack of IPv6 compatibility, but this seems to have been fixed in the meantime.

[XC-272]: https://dfinity.atlassian.net/browse/XC-272?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ