### PR TITLE
fix(k8s-system-tests): containerDisk for boundary node

### DIFF
--- a/rs/tests/driver/src/driver/bootstrap.rs
+++ b/rs/tests/driver/src/driver/bootstrap.rs
@@ -284,27 +284,8 @@ pub fn setup_and_start_vms(
             let conf_img_path = PathBuf::from(&node.node_path).join(CONF_IMG_FNAME);
             match InfraProvider::read_attribute(&t_env) {
                 InfraProvider::K8s => {
-                    // https://kubevirt.io/user-guide/storage/disks_and_volumes/#containerdisk
-                    // build container disk that holds config fat disk for guestos
-                    // push it to local container registry
-                    let command = format!(
-                        "set -xe; \
-                        mkdir -p /var/sysimage/tnet; \
-                        ctr=$(sudo buildah --root /var/sysimage/tnet from scratch); \
-                        sudo buildah --root /var/sysimage/tnet copy --chown=107:107 $ctr {0} /disk/; \
-                        sudo buildah --root /var/sysimage/tnet commit $ctr harbor-core.harbor.svc.cluster.local/tnet/config:{1}; \
-                        sudo buildah --root /var/sysimage/tnet push --tls-verify=false --creds 'robot$tnet+tnet:TestingPOC1' harbor-core.harbor.svc.cluster.local/tnet/config:{1}",
-                        conf_img_path.display(), tnet_node.name.clone().unwrap()
-                    );
-                    let output = Command::new("bash")
-                        .arg("-c")
-                        .arg(command)
-                        .output()
-                        .expect("Failed to execute command");
-                    if !output.status.success() {
-                        let stderr = String::from_utf8_lossy(&output.stderr);
-                        bail!("Error building and pushing config container config image: {}", stderr);
-                    }
+                    block_on(tnet_node.build_oci_config_image(
+                            &conf_img_path, &tnet_node.name.clone().unwrap())).expect("asdf");
                     block_on(tnet_node.start()).expect("starting vm failed");
                 }
                 InfraProvider::Farm => {

--- a/rs/tests/driver/src/driver/bootstrap.rs
+++ b/rs/tests/driver/src/driver/bootstrap.rs
@@ -284,8 +284,13 @@ pub fn setup_and_start_vms(
             let conf_img_path = PathBuf::from(&node.node_path).join(CONF_IMG_FNAME);
             match InfraProvider::read_attribute(&t_env) {
                 InfraProvider::K8s => {
-                    block_on(tnet_node.build_oci_config_image(
-                            &conf_img_path, &tnet_node.name.clone().unwrap())).expect("asdf");
+                    block_on(
+                        tnet_node.build_oci_config_image(
+                            &conf_img_path,
+                            &tnet_node.name.clone().unwrap(),
+                        ),
+                    )
+                    .expect("deploying config image failed");
                     block_on(tnet_node.start()).expect("starting vm failed");
                 }
                 InfraProvider::Farm => {

--- a/rs/tests/driver/src/driver/boundary_node.rs
+++ b/rs/tests/driver/src/driver/boundary_node.rs
@@ -343,9 +343,11 @@ impl BoundaryNodeWithVm {
         } else {
             let tnet = TNet::read_attribute(env);
             let tnet_node = tnet.nodes.last().expect("no nodes");
-            block_on(tnet_node.build_oci_config_image(
-                    &compressed_img_path, &tnet_node.name.clone().unwrap()))
-                .expect("deploying config image failed");
+            block_on(
+                tnet_node
+                    .build_oci_config_image(&compressed_img_path, &tnet_node.name.clone().unwrap()),
+            )
+            .expect("deploying config image failed");
             block_on(tnet_node.start()).expect("starting vm failed");
         }
 

--- a/rs/tests/driver/src/driver/boundary_node.rs
+++ b/rs/tests/driver/src/driver/boundary_node.rs
@@ -27,8 +27,6 @@ use crate::{
         },
         test_setup::{GroupSetup, InfraProvider},
     },
-    k8s::datavolume::DataVolumeContentType,
-    k8s::images::upload_image,
     k8s::tnet::TNet,
     retry_with_msg,
     util::{block_on, create_agent, create_agent_mapping},
@@ -345,20 +343,9 @@ impl BoundaryNodeWithVm {
         } else {
             let tnet = TNet::read_attribute(env);
             let tnet_node = tnet.nodes.last().expect("no nodes");
-            block_on(upload_image(
-                compressed_img_path,
-                &format!(
-                    "{}/{}",
-                    tnet_node.config_url.clone().expect("missing config url"),
-                    &mk_compressed_img_path()
-                ),
-            ))?;
-            block_on(tnet_node.deploy_config_image(
-                &mk_compressed_img_path(),
-                "config",
-                DataVolumeContentType::Kubevirt,
-            ))
-            .expect("deploying config image failed");
+            block_on(tnet_node.build_oci_config_image(
+                    &compressed_img_path, &tnet_node.name.clone().unwrap()))
+                .expect("deploying config image failed");
             block_on(tnet_node.start()).expect("starting vm failed");
         }
 

--- a/rs/tests/driver/src/k8s/tnet.rs
+++ b/rs/tests/driver/src/k8s/tnet.rs
@@ -4,11 +4,11 @@ use slog::Logger;
 use std::collections::BTreeMap;
 use std::net::{Ipv4Addr, Ipv6Addr};
 use std::path::Path;
-use std::str::FromStr;
 use std::process::Command;
+use std::str::FromStr;
 use url::Url;
 
-use anyhow::{bail,Result};
+use anyhow::{bail, Result};
 use backon::Retryable;
 use backon::{ConstantBuilder, ExponentialBuilder};
 use k8s_openapi::api::core::v1::{
@@ -145,7 +145,10 @@ impl TNode {
             .expect("Failed to execute command");
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);
-            bail!("Error building and pushing config container config image: {}", stderr);
+            bail!(
+                "Error building and pushing config container config image: {}",
+                stderr
+            );
         }
         Ok(())
     }

--- a/rs/tests/driver/src/k8s/tnet.rs
+++ b/rs/tests/driver/src/k8s/tnet.rs
@@ -3,10 +3,12 @@ use regex::Regex;
 use slog::Logger;
 use std::collections::BTreeMap;
 use std::net::{Ipv4Addr, Ipv6Addr};
+use std::path::Path;
 use std::str::FromStr;
+use std::process::Command;
 use url::Url;
 
-use anyhow::Result;
+use anyhow::{bail,Result};
 use backon::Retryable;
 use backon::{ConstantBuilder, ExponentialBuilder};
 use k8s_openapi::api::core::v1::{
@@ -113,6 +115,39 @@ impl TNode {
             uid: self.owner.metadata.uid.clone().expect("should have uid"),
             ..Default::default()
         }
+    }
+
+    pub async fn build_oci_config_image(&self, file_path: &Path, tag: &str) -> Result<()> {
+        // https://kubevirt.io/user-guide/storage/disks_and_volumes/#containerdisk
+        // build ctr disk that holds config fat disk for guestos & push it to local ctr registry
+        // uncompress zst disk (the case with boundary node image)
+        let command = format!(
+            "set -xe; \
+            mkdir -p /var/sysimage/tnet; \
+            if echo {0} | grep -q '.zst'; then \
+                uncompressed_file=$(echo {0} | sed 's/.zst$//'); \
+                rm -f $uncompressed_file; \
+                unzstd -o $uncompressed_file {0}; \
+                file_to_copy=$uncompressed_file; \
+            else \
+                file_to_copy={0}; \
+            fi; \
+            ctr=$(sudo buildah --root /var/sysimage/tnet from scratch); \
+            sudo buildah --root /var/sysimage/tnet copy --chown=107:107 $ctr $file_to_copy /disk/; \
+            sudo buildah --root /var/sysimage/tnet commit $ctr harbor-core.harbor.svc.cluster.local/tnet/config:{1}; \
+            sudo buildah --root /var/sysimage/tnet push --tls-verify=false --creds 'robot$tnet+tnet:TestingPOC1' harbor-core.harbor.svc.cluster.local/tnet/config:{1}",
+            file_path.display(), tag
+        );
+        let output = Command::new("bash")
+            .arg("-c")
+            .arg(command)
+            .output()
+            .expect("Failed to execute command");
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            bail!("Error building and pushing config container config image: {}", stderr);
+        }
+        Ok(())
     }
 
     pub async fn deploy_config_image(


### PR DESCRIPTION
Adding container disk logic for boundary node config disks. This was missed in https://github.com/dfinity/ic/pull/3481