### PR TITLE
test(crypto): lower `canister_sig_verification_cache_test` test params

### DIFF
--- a/rs/tests/crypto/canister_sig_verification_cache_test.rs
+++ b/rs/tests/crypto/canister_sig_verification_cache_test.rs
@@ -58,9 +58,9 @@ const RETRY_DELAY: Duration = Duration::from_secs(1);
 const NUM_RETRIES: usize = 100;
 
 /// Range for the random initialization of the number of users in this test
-const NUM_USERS_RANGE: RangeInclusive<usize> = 5..=15;
+const NUM_USERS_RANGE: RangeInclusive<usize> = 5..=10;
 /// Range for the random initialization of the number of calls per user in this test
-const NUM_CALLS_PER_USER_RANGE: RangeInclusive<usize> = 5..=15;
+const NUM_CALLS_PER_USER_RANGE: RangeInclusive<usize> = 5..=10;
 
 fn main() -> Result<()> {
     SystemTestGroup::new()


### PR DESCRIPTION
Try to keep the duration of the test always under 5 minutes.