### PR TITLE
fix(consensus): fix the `hashes-in-blocks` feature implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5416,6 +5416,7 @@ dependencies = [
  "futures",
  "http-body-util",
  "ic-base-types",
+ "ic-canister-client-sender",
  "ic-consensus-manager",
  "ic-interfaces",
  "ic-logger",

--- a/rs/p2p/artifact_downloader/BUILD.bazel
+++ b/rs/p2p/artifact_downloader/BUILD.bazel
@@ -27,6 +27,7 @@ DEPENDENCIES = [
 ]
 
 DEV_DEPENDENCIES = [
+    "//rs/canister_client/sender",
     "//rs/p2p/test_utils",
     "//rs/test_utilities/consensus",
     "//rs/test_utilities/types",

--- a/rs/p2p/artifact_downloader/Cargo.toml
+++ b/rs/p2p/artifact_downloader/Cargo.toml
@@ -13,6 +13,7 @@ axum = { workspace = true }
 backoff = { workspace = true }
 bytes = { workspace = true }
 ic-base-types = { path = "../../types/base_types" }
+ic-canister-client-sender = { path = "../../canister_client/sender" }
 ic-consensus-manager = { path = "../consensus_manager" }
 ic-interfaces = { path = "../../interfaces" }
 ic-logger = { path = "../../monitoring/logger" }

--- a/rs/p2p/artifact_downloader/src/fetch_stripped_artifact/assembler.rs
+++ b/rs/p2p/artifact_downloader/src/fetch_stripped_artifact/assembler.rs
@@ -26,8 +26,11 @@ use super::{
     download::download_ingress,
     metrics::{FetchStrippedConsensusArtifactMetrics, IngressMessageSource, IngressSenderMetrics},
     stripper::Strippable,
-    types::stripped::{
-        MaybeStrippedConsensusMessage, StrippedBlockProposal, StrippedConsensusMessageId,
+    types::{
+        stripped::{
+            MaybeStrippedConsensusMessage, StrippedBlockProposal, StrippedConsensusMessageId,
+        },
+        SignedIngressId,
     },
 };
 
@@ -246,7 +249,7 @@ impl ArtifactAssembler<ConsensusMessage, MaybeStrippedConsensusMessage>
 /// Tries to get the missing object either from the pool(s) or from the peers who are advertising
 /// it.
 async fn get_or_fetch<P: Peers>(
-    ingress_message_id: IngressMessageId,
+    signed_ingress_id: SignedIngressId,
     ingress_pool: ValidatedPoolReaderRef<SignedIngress>,
     transport: Arc<dyn Transport>,
     // Id of the *full* artifact which should contain the missing data
@@ -257,13 +260,19 @@ async fn get_or_fetch<P: Peers>(
     peer_rx: P,
 ) -> (SignedIngress, NodeId) {
     // First check if the ingress message exists in the Ingress Pool.
-    if let Some(ingress_message) = ingress_pool.read().unwrap().get(&ingress_message_id) {
-        return (ingress_message, node_id);
+    if let Some(ingress_message) = ingress_pool
+        .read()
+        .unwrap()
+        .get(&signed_ingress_id.ingress_message_id)
+    {
+        if SignedIngressId::from(&ingress_message) == signed_ingress_id {
+            return (ingress_message, node_id);
+        }
     }
 
     download_ingress(
         transport,
-        ingress_message_id,
+        signed_ingress_id,
         full_consensus_message_id,
         &log,
         &metrics,
@@ -290,7 +299,7 @@ pub(crate) enum AssemblyError {
 
 struct BlockProposalAssembler {
     stripped_block_proposal: StrippedBlockProposal,
-    ingress_messages: Vec<(IngressMessageId, Option<SignedIngress>)>,
+    ingress_messages: Vec<(SignedIngressId, Option<SignedIngress>)>,
 }
 
 impl BlockProposalAssembler {
@@ -300,14 +309,14 @@ impl BlockProposalAssembler {
                 .stripped_ingress_payload
                 .ingress_messages
                 .iter()
-                .map(|ingress_message_id| (ingress_message_id.clone(), None))
+                .map(|ingress_message| (ingress_message.clone(), None))
                 .collect(),
             stripped_block_proposal,
         }
     }
 
-    /// Returns the list of [`IngressMessageId`]s which have been stripped from the block.
-    pub(crate) fn missing_ingress_messages(&self) -> Vec<IngressMessageId> {
+    /// Returns the list of ingress messages which have been stripped from the block.
+    pub(crate) fn missing_ingress_messages(&self) -> Vec<SignedIngressId> {
         self.ingress_messages
             .iter()
             .filter_map(|(ingress_message_id, maybe_ingress)| {
@@ -326,14 +335,14 @@ impl BlockProposalAssembler {
         &mut self,
         ingress_message: SignedIngress,
     ) -> Result<(), InsertionError> {
-        let ingress_message_id = IngressMessageId::from(&ingress_message);
+        let signed_ingress_id = SignedIngressId::from(&ingress_message);
 
         // We can have at most 1000 elements in the vector, so it should be reasonably fast to do a
         // linear scan here.
         let (_, ingress) = self
             .ingress_messages
             .iter_mut()
-            .find(|(id, _maybe_ingress)| *id == ingress_message_id)
+            .find(|(id, _maybe_ingress)| *id == signed_ingress_id)
             .ok_or(InsertionError::NotNeeded)?;
 
         if ingress.is_some() {
@@ -356,7 +365,9 @@ impl BlockProposalAssembler {
         let ingresses = self
             .ingress_messages
             .into_iter()
-            .map(|(id, message)| message.ok_or_else(|| AssemblyError::Missing(id)))
+            .map(|(id, message)| {
+                message.ok_or_else(|| AssemblyError::Missing(id.ingress_message_id))
+            })
             .collect::<Result<Vec<_>, _>>()?;
         let reconstructed_ingress_payload = IngressPayload::from(ingresses);
 
@@ -377,8 +388,18 @@ impl BlockProposalAssembler {
 mod tests {
     use crate::fetch_stripped_artifact::test_utils::{
         fake_block_proposal_with_ingresses, fake_ingress_message,
-        fake_ingress_message_with_arg_size, fake_stripped_block_proposal_with_ingresses,
+        fake_ingress_message_with_arg_size, fake_ingress_message_with_sig,
+        fake_stripped_block_proposal_with_ingresses,
     };
+    use crate::fetch_stripped_artifact::types::rpc::GetIngressMessageInBlockResponse;
+    use bytes::Bytes;
+    use ic_interfaces::p2p::consensus::BouncerValue;
+    use ic_logger::no_op_logger;
+    use ic_p2p_test_utils::mocks::MockBouncerFactory;
+    use ic_p2p_test_utils::mocks::MockTransport;
+    use ic_p2p_test_utils::mocks::MockValidatedPoolReader;
+    use ic_protobuf::proxy::ProtoProxy;
+    use ic_types_test_utils::ids::NODE_1;
 
     use super::*;
 
@@ -500,6 +521,96 @@ mod tests {
         assert_eq!(
             assembler.try_insert_ingress_message(ingress_1),
             Err(InsertionError::NotNeeded)
+        );
+    }
+
+    #[derive(Clone)]
+    struct MockPeers(NodeId);
+
+    impl Peers for MockPeers {
+        fn peers(&self) -> Vec<NodeId> {
+            vec![self.0]
+        }
+    }
+
+    fn set_up_assembler_with_fake_dependencies(
+        ingress_pool_message: Option<SignedIngress>,
+        peers_message: Option<SignedIngress>,
+    ) -> FetchStrippedConsensusArtifact {
+        let mut mock_transport = MockTransport::new();
+        let mut ingress_pool = MockValidatedPoolReader::<SignedIngress>::default();
+
+        if let Some(ingress_message) = ingress_pool_message {
+            ingress_pool.expect_get().return_const(ingress_message);
+        }
+
+        if let Some(ingress_message) = peers_message {
+            let fake_response = axum::response::Response::builder()
+                .body(Bytes::from(
+                    pb::GetIngressMessageInBlockResponse::proxy_encode(
+                        GetIngressMessageInBlockResponse {
+                            serialized_ingress_message: ingress_message.binary().clone(),
+                        },
+                    ),
+                ))
+                .unwrap();
+
+            mock_transport
+                .expect_rpc()
+                .returning(move |_, _| (Ok(fake_response.clone())));
+        }
+
+        let consensus_pool = MockValidatedPoolReader::<ConsensusMessage>::default();
+        let mut mock_bouncer_factory = MockBouncerFactory::default();
+        mock_bouncer_factory
+            .expect_new_bouncer()
+            .returning(|_| Box::new(|_| BouncerValue::Wants));
+
+        let f = FetchStrippedConsensusArtifact::new(
+            no_op_logger(),
+            tokio::runtime::Handle::current(),
+            Arc::new(RwLock::new(consensus_pool)),
+            Arc::new(RwLock::new(ingress_pool)),
+            Arc::new(mock_bouncer_factory),
+            MetricsRegistry::new(),
+            NODE_1,
+        )
+        .0;
+
+        (f)(Arc::new(mock_transport))
+    }
+
+    /// Tests whether the assembler uses the ingress message with the correct signature in the case
+    /// when the local ingress pool contains an ingress message with the same content as the one in
+    /// the stripped block proposal but with a different signature.
+    #[tokio::test]
+    async fn roundtrip_test_with_two_identical_ingress_messages_different_signatures() {
+        let (ingress_1, _ingress_1_id) = fake_ingress_message_with_sig("fake_1", vec![1, 2, 3]);
+        let (ingress_2, _ingress_2_id) = fake_ingress_message_with_sig("fake_1", vec![2, 3, 4]);
+        assert_eq!(
+            IngressMessageId::from(&ingress_1),
+            IngressMessageId::from(&ingress_2)
+        );
+        let block_proposal = fake_block_proposal_with_ingresses(vec![ingress_2.clone()]);
+
+        let assembler = set_up_assembler_with_fake_dependencies(
+            /*ingress_pool_message=*/ Some(ingress_1.clone()),
+            /*consensus_pool_message=*/ Some(ingress_2.clone()),
+        );
+        let stripped_block_proposal =
+            assembler.disassemble_message(ConsensusMessage::BlockProposal(block_proposal.clone()));
+        let reassembled_block_proposal = assembler
+            .assemble_message(
+                stripped_block_proposal.id(),
+                Some((stripped_block_proposal, NODE_1)),
+                MockPeers(NODE_1),
+            )
+            .await
+            .expect("should reassemble the message given the dependencies");
+
+        assert_eq!(
+            reassembled_block_proposal,
+            (ConsensusMessage::BlockProposal(block_proposal), NODE_1)
         );
     }
 }

--- a/rs/p2p/artifact_downloader/src/fetch_stripped_artifact/download.rs
+++ b/rs/p2p/artifact_downloader/src/fetch_stripped_artifact/download.rs
@@ -16,9 +16,9 @@ use ic_logger::{warn, ReplicaLogger};
 use ic_protobuf::{proxy::ProtoProxy, types::v1 as pb};
 use ic_quic_transport::Transport;
 use ic_types::{
-    artifact::{ConsensusMessageId, IngressMessageId},
+    artifact::ConsensusMessageId,
     consensus::{BlockPayload, ConsensusMessage},
-    messages::SignedIngress,
+    messages::{SignedIngress, SignedRequestBytes},
     NodeId,
 };
 use rand::{rngs::SmallRng, seq::IteratorRandom, SeedableRng};
@@ -26,7 +26,10 @@ use tokio::time::{sleep_until, timeout_at, Instant};
 
 use super::{
     metrics::{FetchStrippedConsensusArtifactMetrics, IngressSenderMetrics},
-    types::rpc::{GetIngressMessageInBlockRequest, GetIngressMessageInBlockResponse},
+    types::{
+        rpc::{GetIngressMessageInBlockRequest, GetIngressMessageInBlockResponse},
+        SignedIngressId,
+    },
 };
 
 type ValidatedPoolReaderRef<T> = Arc<RwLock<dyn ValidatedPoolReader<T> + Send + Sync>>;
@@ -58,13 +61,17 @@ impl Pools {
     /// Retrieves the request [`SignedIngress`] from either of the pools.
     fn get(
         &self,
-        ingress_message_id: &IngressMessageId,
+        signed_ingress_id: &SignedIngressId,
         block_proposal_id: &ConsensusMessageId,
-    ) -> Result<SignedIngress, PoolsAccessError> {
+    ) -> Result<SignedRequestBytes, PoolsAccessError> {
+        let ingress_message_id = &signed_ingress_id.ingress_message_id;
+
         // First check if the requested ingress message exists in the Ingress Pool.
         if let Some(ingress_message) = self.ingress_pool.read().unwrap().get(ingress_message_id) {
-            self.metrics.ingress_messages_in_ingress_pool.inc();
-            return Ok(ingress_message);
+            if SignedIngressId::from(&ingress_message) == *signed_ingress_id {
+                self.metrics.ingress_messages_in_ingress_pool.inc();
+                return Ok(ingress_message.into());
+            }
         }
 
         // Otherwise find the block which should contain the ingress message.
@@ -83,10 +90,17 @@ impl Pools {
             return Err(PoolsAccessError::SummaryBlock);
         };
 
-        match data_payload.batch.ingress.get_by_id(ingress_message_id) {
-            Ok(Some(ingress_message)) => {
+        match data_payload
+            .batch
+            .ingress
+            .get_serialized_by_id(ingress_message_id)
+        {
+            Some(bytes)
+                if SignedIngressId::new(ingress_message_id.clone(), bytes)
+                    == *signed_ingress_id =>
+            {
                 self.metrics.ingress_messages_in_block.inc();
-                Ok(ingress_message)
+                Ok(bytes.clone())
             }
             _ => {
                 self.metrics.ingress_messages_not_found.inc();
@@ -112,10 +126,12 @@ async fn rpc_handler(State(pools): State<Pools>, payload: Bytes) -> Result<Bytes
         let request = GetIngressMessageInBlockRequest::try_from(request_proto)
             .map_err(|_| StatusCode::BAD_REQUEST)?;
 
-        match pools.get(&request.ingress_message_id, &request.block_proposal_id) {
-            Ok(ingress_message) => Ok::<_, StatusCode>(Bytes::from(
+        match pools.get(&request.signed_ingress_id, &request.block_proposal_id) {
+            Ok(serialized_ingress_message) => Ok::<_, StatusCode>(Bytes::from(
                 pb::GetIngressMessageInBlockResponse::proxy_encode(
-                    GetIngressMessageInBlockResponse { ingress_message },
+                    GetIngressMessageInBlockResponse {
+                        serialized_ingress_message,
+                    },
                 ),
             )),
             Err(PoolsAccessError::IngressMessageNotFound | PoolsAccessError::BlockNotFound) => {
@@ -137,7 +153,7 @@ async fn rpc_handler(State(pools): State<Pools>, payload: Bytes) -> Result<Bytes
 /// Downloads the missing ingress messages from a random peer.
 pub(crate) async fn download_ingress<P: Peers>(
     transport: Arc<dyn Transport>,
-    ingress_message_id: IngressMessageId,
+    signed_ingress_id: SignedIngressId,
     block_proposal_id: ConsensusMessageId,
     log: &ReplicaLogger,
     metrics: &FetchStrippedConsensusArtifactMetrics,
@@ -153,7 +169,7 @@ pub(crate) async fn download_ingress<P: Peers>(
     let mut rng = SmallRng::from_entropy();
 
     let request = GetIngressMessageInBlockRequest {
-        ingress_message_id: ingress_message_id.clone(),
+        signed_ingress_id: signed_ingress_id.clone(),
         block_proposal_id,
     };
     let bytes = Bytes::from(pb::GetIngressMessageInBlockRequest::proxy_encode(request));
@@ -167,16 +183,12 @@ pub(crate) async fn download_ingress<P: Peers>(
         if let Some(peer) = { peer_rx.peers().into_iter().choose(&mut rng) } {
             match timeout_at(next_request_at, transport.rpc(&peer, request.clone())).await {
                 Ok(Ok(response)) if response.status() == StatusCode::OK => {
-                    let body = response.into_body();
-                    if let Ok(response) = pb::GetIngressMessageInBlockResponse::proxy_decode(&body)
-                        .and_then(|proto: pb::GetIngressMessageInBlockResponse| {
-                            GetIngressMessageInBlockResponse::try_from(proto)
-                        })
-                    {
-                        if IngressMessageId::from(&response.ingress_message) == ingress_message_id {
+                    if let Some(ingress_message) = parse_response(response.into_body(), metrics) {
+                        if SignedIngressId::from(&ingress_message) == signed_ingress_id {
                             metrics.active_ingress_message_downloads.dec();
-                            return (response.ingress_message, peer);
+                            return (ingress_message, peer);
                         } else {
+                            metrics.report_download_error("mismatched_signed_ingress_id");
                             warn!(
                                 log,
                                 "Peer {} responded with wrong artifact for advert", peer
@@ -184,14 +196,41 @@ pub(crate) async fn download_ingress<P: Peers>(
                         }
                     }
                 }
-                _ => {
-                    metrics.total_ingress_message_download_errors.inc();
+                Ok(Ok(_response)) => {
+                    metrics.report_download_error("status_not_ok");
+                }
+                Ok(Err(_rpc_error)) => {
+                    metrics.report_download_error("rpc_error");
+                }
+                Err(_timeout) => {
+                    metrics.report_download_error("timeout");
                 }
             }
         }
 
         sleep_until(next_request_at).await;
     }
+}
+
+fn parse_response(
+    body: Bytes,
+    metrics: &FetchStrippedConsensusArtifactMetrics,
+) -> Option<SignedIngress> {
+    let Ok(response) = pb::GetIngressMessageInBlockResponse::proxy_decode(&body).and_then(
+        |proto: pb::GetIngressMessageInBlockResponse| {
+            GetIngressMessageInBlockResponse::try_from(proto)
+        },
+    ) else {
+        metrics.report_download_error("response_decoding_failed");
+        return None;
+    };
+
+    let Ok(ingress) = SignedIngress::try_from(response.serialized_ingress_message) else {
+        metrics.report_download_error("ingress_deserializedion_failed");
+        return None;
+    };
+
+    Some(ingress)
 }
 
 #[cfg(test)]
@@ -203,19 +242,20 @@ mod tests {
     use super::*;
 
     use http_body_util::Full;
+    use ic_canister_client_sender::Sender;
     use ic_logger::no_op_logger;
     use ic_metrics::MetricsRegistry;
     use ic_p2p_test_utils::mocks::{MockPeers, MockTransport, MockValidatedPoolReader};
     use ic_test_utilities_types::messages::SignedIngressBuilder;
+    use ic_types::{artifact::IngressMessageId, time::UNIX_EPOCH};
     use ic_types_test_utils::ids::NODE_1;
     use tower::ServiceExt;
 
     fn mock_pools(
         ingress_message: Option<SignedIngress>,
         consensus_message: Option<ConsensusMessage>,
+        expect_consensus_pool_access: bool,
     ) -> Pools {
-        let should_call_consensus_pool = ingress_message.is_none();
-
         let mut ingress_pool = MockValidatedPoolReader::<SignedIngress>::default();
         if let Some(ingress_message) = ingress_message {
             ingress_pool
@@ -238,7 +278,7 @@ mod tests {
                 )))
                 .once()
                 .return_const(consensus_message.clone());
-        } else if should_call_consensus_pool {
+        } else if expect_consensus_pool_access {
             consensus_pool.expect_get().once().return_const(None);
         }
 
@@ -278,54 +318,114 @@ mod tests {
     async fn rpc_get_from_ingress_pool_test() {
         let ingress_message = SignedIngressBuilder::new().nonce(1).build();
         let block = fake_block_proposal(vec![]);
-        let pools = mock_pools(Some(ingress_message.clone()), None);
+        let pools = mock_pools(
+            Some(ingress_message.clone()),
+            None,
+            /*expect_consensus_pool_acces=*/ false,
+        );
         let router = build_axum_router(pools);
 
         let response = send_request(
             router,
             request(
                 ConsensusMessageId::from(&block),
-                IngressMessageId::from(&ingress_message),
+                SignedIngressId::from(&ingress_message),
             ),
         )
         .await
         .expect("Should return a valid response");
 
-        assert_eq!(response.ingress_message, ingress_message);
+        assert_eq!(
+            &response.serialized_ingress_message,
+            ingress_message.binary()
+        );
     }
 
     #[tokio::test]
     async fn rpc_get_from_consensus_pool_test() {
         let ingress_message = SignedIngressBuilder::new().nonce(1).build();
         let block = fake_block_proposal(vec![ingress_message.clone()]);
-        let pools = mock_pools(None, Some(block.clone()));
+        let pools = mock_pools(
+            None,
+            Some(block.clone()),
+            /*expect_consensus_pool_acces=*/ true,
+        );
         let router = build_axum_router(pools);
 
         let response = send_request(
             router,
             request(
                 ConsensusMessageId::from(&block),
-                IngressMessageId::from(&ingress_message),
+                SignedIngressId::from(&ingress_message),
             ),
         )
         .await
         .expect("Should return a valid response");
 
-        assert_eq!(response.ingress_message, ingress_message);
+        assert_eq!(
+            &response.serialized_ingress_message,
+            ingress_message.binary()
+        );
     }
 
     #[tokio::test]
     async fn rpc_get_not_found_test() {
         let ingress_message = SignedIngressBuilder::new().nonce(1).build();
         let block = fake_block_proposal(vec![]);
-        let pools = mock_pools(None, None);
+        let pools = mock_pools(None, None, /*expect_consensus_pool_acces=*/ true);
         let router = build_axum_router(pools);
 
         let response = send_request(
             router,
             request(
                 ConsensusMessageId::from(&block),
-                IngressMessageId::from(&ingress_message),
+                SignedIngressId::from(&ingress_message),
+            ),
+        )
+        .await;
+
+        assert_eq!(response, Err(StatusCode::NOT_FOUND));
+    }
+
+    #[tokio::test]
+    async fn rpc_get_not_found_mismatched_hash_test() {
+        let ingress_message = |signature: Vec<u8>| {
+            SignedIngressBuilder::new()
+                .nonce(1)
+                .expiry_time(UNIX_EPOCH)
+                .sign_for_sender(&Sender::Node {
+                    pub_key: vec![0, 1, 2, 3],
+                    sign: Arc::new(move |_| Ok(signature.clone())),
+                })
+                .build()
+        };
+
+        let ingress_message_1 = ingress_message(vec![1, 1, 1]);
+        let ingress_message_2 = ingress_message(vec![2, 2, 2]);
+        let ingress_message_3 = ingress_message(vec![3, 3, 3]);
+
+        assert_eq!(
+            IngressMessageId::from(&ingress_message_1),
+            IngressMessageId::from(&ingress_message_2)
+        );
+        assert_eq!(
+            IngressMessageId::from(&ingress_message_2),
+            IngressMessageId::from(&ingress_message_3)
+        );
+
+        let block = fake_block_proposal(vec![ingress_message_2.clone()]);
+        let pools = mock_pools(
+            Some(ingress_message_1.clone()),
+            Some(block.clone()),
+            /*expect_consensus_pool_acces=*/ true,
+        );
+        let router = build_axum_router(pools);
+
+        let response = send_request(
+            router,
+            request(
+                ConsensusMessageId::from(&block),
+                SignedIngressId::from(&ingress_message_3),
             ),
         )
         .await;
@@ -337,14 +437,18 @@ mod tests {
     async fn rpc_get_summary_block_returns_bad_request_test() {
         let ingress_message = SignedIngressBuilder::new().nonce(1).build();
         let block = fake_summary_block_proposal();
-        let pools = mock_pools(None, Some(block.clone()));
+        let pools = mock_pools(
+            None,
+            Some(block.clone()),
+            /*expect_consensus_pool_acces=*/ true,
+        );
         let router = build_axum_router(pools);
 
         let response = send_request(
             router,
             request(
                 ConsensusMessageId::from(&block),
-                IngressMessageId::from(&ingress_message),
+                SignedIngressId::from(&ingress_message),
             ),
         )
         .await;
@@ -366,7 +470,7 @@ mod tests {
 
         let response = download_ingress(
             Arc::new(mock_transport),
-            IngressMessageId::from(&ingress_message),
+            SignedIngressId::from(&ingress_message),
             ConsensusMessageId::from(&block),
             &no_op_logger(),
             &FetchStrippedConsensusArtifactMetrics::new(&MetricsRegistry::new()),
@@ -378,7 +482,6 @@ mod tests {
     }
 
     // Utility functions below
-
     fn fake_block_proposal(ingress_messages: Vec<SignedIngress>) -> ConsensusMessage {
         let block_proposal = fake_block_proposal_with_ingresses(ingress_messages);
 
@@ -387,10 +490,10 @@ mod tests {
 
     fn request(
         consensus_message_id: ConsensusMessageId,
-        ingress_message_id: IngressMessageId,
+        signed_ingress_id: SignedIngressId,
     ) -> Bytes {
         let request = GetIngressMessageInBlockRequest {
-            ingress_message_id,
+            signed_ingress_id,
             block_proposal_id: consensus_message_id,
         };
 
@@ -401,7 +504,9 @@ mod tests {
         axum::response::Response::builder()
             .body(Bytes::from(
                 pb::GetIngressMessageInBlockResponse::proxy_encode(
-                    GetIngressMessageInBlockResponse { ingress_message },
+                    GetIngressMessageInBlockResponse {
+                        serialized_ingress_message: ingress_message.binary().clone(),
+                    },
                 ),
             ))
             .unwrap()

--- a/rs/p2p/artifact_downloader/src/fetch_stripped_artifact/stripper.rs
+++ b/rs/p2p/artifact_downloader/src/fetch_stripped_artifact/stripper.rs
@@ -3,8 +3,9 @@ use ic_types::{
     artifact::IdentifiableArtifact, batch::IngressPayload, consensus::ConsensusMessage,
 };
 
-use super::types::stripped::{
-    MaybeStrippedConsensusMessage, StrippedBlockProposal, StrippedIngressPayload,
+use super::types::{
+    stripped::{MaybeStrippedConsensusMessage, StrippedBlockProposal, StrippedIngressPayload},
+    SignedIngressId,
 };
 
 /// Provides functionality for stripping objects of given information.
@@ -25,11 +26,11 @@ impl Strippable for ConsensusMessage {
 
         match self {
             // We only strip data blocks.
-            ConsensusMessage::BlockProposal(block_proposal)
+            ConsensusMessage::BlockProposal(ref block_proposal)
                 if block_proposal.as_ref().payload.payload_type()
                     == ic_types::consensus::PayloadType::Data =>
             {
-                let mut proto = pb::BlockProposal::from(&block_proposal);
+                let mut proto = pb::BlockProposal::from(block_proposal);
 
                 // Remove the ingress payload from the proto.
                 if let Some(block) = proto.value.as_mut() {
@@ -54,9 +55,12 @@ impl Strippable for &IngressPayload {
     type Output = StrippedIngressPayload;
 
     fn strip(self) -> Self::Output {
-        Self::Output {
-            ingress_messages: self.message_ids().cloned().collect(),
-        }
+        let ingress_messages = self
+            .iter_serialized()
+            .map(|(id, bytes)| SignedIngressId::new(id.clone(), bytes))
+            .collect();
+
+        StrippedIngressPayload { ingress_messages }
     }
 }
 

--- a/rs/p2p/artifact_downloader/src/fetch_stripped_artifact/types.rs
+++ b/rs/p2p/artifact_downloader/src/fetch_stripped_artifact/types.rs
@@ -1,2 +1,47 @@
+use ic_protobuf::proxy::{try_from_option_field, ProxyDecodeError};
+use ic_protobuf::types::v1 as pb;
+use ic_types::crypto::CryptoHash;
+use ic_types::messages::SignedIngress;
+use ic_types::{artifact::IngressMessageId, crypto::CryptoHashOf, messages::SignedRequestBytes};
+
 pub(super) mod rpc;
 pub(super) mod stripped;
+
+type IngressBytesHash = CryptoHashOf<SignedRequestBytes>;
+
+/// A unique identifier of a `[SignedIngress]`.
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) struct SignedIngressId {
+    pub(crate) ingress_message_id: IngressMessageId,
+    pub(crate) ingress_bytes_hash: IngressBytesHash,
+}
+
+impl SignedIngressId {
+    pub(crate) fn new(ingress_message_id: IngressMessageId, bytes: &SignedRequestBytes) -> Self {
+        Self {
+            ingress_message_id,
+            ingress_bytes_hash: ic_types::crypto::crypto_hash(bytes),
+        }
+    }
+}
+
+impl From<&SignedIngress> for SignedIngressId {
+    fn from(value: &SignedIngress) -> Self {
+        Self::new(IngressMessageId::from(value), value.binary())
+    }
+}
+
+impl TryFrom<pb::StrippedIngressMessage> for SignedIngressId {
+    type Error = ProxyDecodeError;
+
+    fn try_from(value: pb::StrippedIngressMessage) -> Result<Self, Self::Error> {
+        let ingress_message_id =
+            try_from_option_field(value.stripped, "StrippedIngressMessage::stripped")?;
+        let ingress_bytes_hash = CryptoHashOf::from(CryptoHash(value.ingress_bytes_hash));
+
+        Ok(SignedIngressId {
+            ingress_message_id,
+            ingress_bytes_hash,
+        })
+    }
+}

--- a/rs/p2p/artifact_downloader/src/fetch_stripped_artifact/types.rs
+++ b/rs/p2p/artifact_downloader/src/fetch_stripped_artifact/types.rs
@@ -9,7 +9,11 @@ pub(super) mod stripped;
 
 type IngressBytesHash = CryptoHashOf<SignedRequestBytes>;
 
-/// A unique identifier of a `[SignedIngress]`.
+/// A unique identifier of a [`SignedIngress`].
+/// Note that the hash of [`SignedIngress::binary`] should be enough to uniquely identify a
+/// [`SignedIngress`] because all the fields of [`SignedIngress`] are derived from it.
+/// Note also that [`IngressMessageId`] is not strictly required here to uniquely identify
+/// [`SignedIngress`] but we keep it here because of [`IngressPool`] API.
 #[derive(Clone, Debug, PartialEq)]
 pub(crate) struct SignedIngressId {
     pub(crate) ingress_message_id: IngressMessageId,

--- a/rs/protobuf/def/types/v1/consensus.proto
+++ b/rs/protobuf/def/types/v1/consensus.proto
@@ -219,6 +219,7 @@ message IngressPayload {
 message GetIngressMessageInBlockRequest {
   IngressMessageId ingress_message_id = 1;
   ConsensusMessageId block_proposal_id = 2;
+  bytes ingress_bytes_hash = 3;
 }
 
 message GetIngressMessageInBlockResponse {
@@ -233,6 +234,7 @@ message StrippedBlockProposal {
 
 message StrippedIngressMessage {
   IngressMessageId stripped = 1;
+  bytes ingress_bytes_hash = 2;
 }
 
 message StrippedConsensusMessage {

--- a/rs/protobuf/src/gen/types/types.v1.rs
+++ b/rs/protobuf/src/gen/types/types.v1.rs
@@ -1548,6 +1548,8 @@ pub struct GetIngressMessageInBlockRequest {
     pub ingress_message_id: ::core::option::Option<IngressMessageId>,
     #[prost(message, optional, tag = "2")]
     pub block_proposal_id: ::core::option::Option<ConsensusMessageId>,
+    #[prost(bytes = "vec", tag = "3")]
+    pub ingress_bytes_hash: ::prost::alloc::vec::Vec<u8>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetIngressMessageInBlockResponse {
@@ -1567,6 +1569,8 @@ pub struct StrippedBlockProposal {
 pub struct StrippedIngressMessage {
     #[prost(message, optional, tag = "1")]
     pub stripped: ::core::option::Option<IngressMessageId>,
+    #[prost(bytes = "vec", tag = "2")]
+    pub ingress_bytes_hash: ::prost::alloc::vec::Vec<u8>,
 }
 #[allow(clippy::large_enum_variant)]
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/rs/types/types/src/batch/ingress.rs
+++ b/rs/types/types/src/batch/ingress.rs
@@ -89,16 +89,12 @@ impl IngressPayload {
         self.serialized_ingress_messages.is_empty()
     }
 
-    /// Return the [`SignedIngress`] referenced by the [`IngressMessageId`].
-    /// Return [`IngressPayloadError`] if we fail to deserialize the message.
-    pub fn get_by_id(
+    /// Return the [`SignedRequestBytes`] referenced by the [`IngressMessageId`].
+    pub fn get_serialized_by_id(
         &self,
         ingress_message_id: &IngressMessageId,
-    ) -> Result<Option<SignedIngress>, IngressPayloadError> {
-        self.serialized_ingress_messages
-            .get(ingress_message_id)
-            .map(|bytes| SignedIngress::try_from(bytes.clone()).map_err(IngressPayloadError))
-            .transpose()
+    ) -> Option<&SignedRequestBytes> {
+        self.serialized_ingress_messages.get(ingress_message_id)
     }
 
     /// Iterates over the ingress messages in their deserialized form.
@@ -116,6 +112,12 @@ impl IngressPayload {
                 SignedIngress::try_from(bytes.clone()).map_err(IngressPayloadError),
             )
         })
+    }
+
+    pub fn iter_serialized(
+        &self,
+    ) -> impl Iterator<Item = (&IngressMessageId, &SignedRequestBytes)> {
+        self.serialized_ingress_messages.iter()
     }
 }
 
@@ -149,7 +151,6 @@ impl From<Vec<SignedIngress>> for IngressPayload {
 
 impl TryFrom<IngressPayload> for Vec<SignedIngress> {
     type Error = IngressPayloadError;
-
     fn try_from(payload: IngressPayload) -> Result<Vec<SignedIngress>, Self::Error> {
         payload
             .serialized_ingress_messages
@@ -267,10 +268,10 @@ mod tests {
             payload
         );
         // Individual lookup works.
-        assert_eq!(payload.get_by_id(&id1), Ok(Some(m1)));
-        assert_eq!(payload.get_by_id(&id2), Ok(Some(m2)));
-        assert_eq!(payload.get_by_id(&id3), Ok(Some(m3)));
-        assert_eq!(payload.get_by_id(&id4), Ok(None));
+        assert_eq!(payload.get_serialized_by_id(&id1), Some(m1.binary()));
+        assert_eq!(payload.get_serialized_by_id(&id2), Some(m2.binary()));
+        assert_eq!(payload.get_serialized_by_id(&id3), Some(m3.binary()));
+        assert_eq!(payload.get_serialized_by_id(&id4), None);
         // Converting back to messages should match original
         assert_eq!(msgs, <Vec<SignedIngress>>::try_from(payload).unwrap());
     }


### PR DESCRIPTION
# Problem
Currently, with the feature flag enabled, when a node sends a block proposal to their peers it first removes all the ingress messages from the block's payload, leaving behind only the `IngressMessageId`s which identify the ingress messages. When a node receives such a "stripped" block proposal it _reconstructs_ the block by retrieving the referenced ingress messages from:

1. either their local ingress pools if there exists an ingress message with the given `IngressMessageId` there,
2. or by requesting the missing ingress messages from peers who are advertising the block.

The problem with the approach is that the `IngressMessageId`s do _not_ uniquely identify the the ingress messages and two ingresses with the same content _but_ with different signatures have the same id. We thus could end up in a situation where peers reconstruct blocks different than what the block maker created.

## Note
The feature is disabled on the Mainnet so no subnet is currently affected by the issue

# Proposal
To address this problem we introduce a new type `SignedIngressId` (which contains both `IngressMessageId` and the hash of a original ingress message bytes) which uniquely identifies a `SignedIngress`, which is used only within the the block proposal assembler module. Everything else remains basically the same but we add several checks to make sure we put the correct ingress message in the block:
1. when retrieving ingress messages from ingress pools by `IngressMessageId`s we double check that the `SignedIngressId` of the ingress message matches what we are expecting;
2. same for when we get an ingress message from a peer.

# Alternatives considered
Instead of introducing a new type, we could modify the existing `IngressMessageId` so that it uniquely identifies ingress messages.

disadvantages over the proposed solution:
1. without any changes to the ingress pool we would end up with duplicates of the same ingress messages (but different signatures) in the pool & which would be further broadcasted to the other peers
2. the duplication detection in the ingress selector would have to be modified
3. computing `IngressMessageId` would be more expensive and we currently do it quite often
4. the change would affect multiple more components

advantages over the proposed solution:
1. in some corner-case situations in the proposed solution a node might have to fetch more ingress message from their peers