### PR TITLE
fix(EXC-1843): Make reservation test robust to costs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8380,6 +8380,7 @@ dependencies = [
  "prometheus",
  "proptest",
  "rand 0.8.5",
+ "regex",
  "scoped_threadpool",
  "serde",
  "serde_bytes",

--- a/rs/execution_environment/BUILD.bazel
+++ b/rs/execution_environment/BUILD.bazel
@@ -82,6 +82,7 @@ DEV_DEPENDENCIES = [
     "@crate_index//:libflate",
     "@crate_index//:maplit",
     "@crate_index//:proptest",
+    "@crate_index//:regex",
     "@crate_index//:wasmparser",
     "@crate_index//:wat",
 ]

--- a/rs/execution_environment/Cargo.toml
+++ b/rs/execution_environment/Cargo.toml
@@ -83,6 +83,7 @@ itertools = { workspace = true }
 libflate = { workspace = true }
 maplit = "1.0.2"
 proptest = { workspace = true }
+regex = { workspace = true }
 test-strategy = "0.3.1"
 wasmparser = { workspace = true }
 wat = { workspace = true }

--- a/rs/execution_environment/tests/storage_reservation.rs
+++ b/rs/execution_environment/tests/storage_reservation.rs
@@ -200,7 +200,7 @@ fn test_storage_reservation_triggered_in_canister_snapshot_without_enough_cycles
         .expect_err("Expected an error, but got Ok(_)");
     err.assert_contains(
         ErrorCode::InsufficientCyclesInMemoryGrow,
-        "Canister cannot grow memory by 200068382 bytes due to insufficient cycles.",
+        "Canister cannot grow memory by",
     );
 
     // Match on a substring of the error message. Due to a difference in instructions consumed on

--- a/rs/execution_environment/tests/storage_reservation.rs
+++ b/rs/execution_environment/tests/storage_reservation.rs
@@ -195,20 +195,29 @@ fn test_storage_reservation_triggered_in_canister_snapshot_without_enough_cycles
 
     // Take a snapshot to trigger more storage reservation. The canister does not have
     // enough cycles in its balance, so this should fail.
-    let res = env.take_canister_snapshot(TakeCanisterSnapshotArgs::new(canister_id, None));
-    match res {
-        Ok(_) => panic!("Expected an error but got Ok(_)"),
-        Err(err) => {
-            assert_eq!(err.code(), ErrorCode::InsufficientCyclesInMemoryGrow);
-            // Match on a substring of the error message. Due to a difference in instructions consumed on
-            // Mac vs Linux, we cannot match on the exact number of cycles but we only need to verify it's
-            // a non-zero amount.
-            assert!(
-                err.description()
-                    .contains("due to insufficient cycles. At least 339_559_"),
-                "Error message: {}",
-                err.description()
-            );
-        }
-    }
+    let err = env
+        .take_canister_snapshot(TakeCanisterSnapshotArgs::new(canister_id, None))
+        .expect_err("Expected an error, but got Ok(_)");
+    err.assert_contains(
+        ErrorCode::InsufficientCyclesInMemoryGrow,
+        "Canister cannot grow memory by 200068382 bytes due to insufficient cycles.",
+    );
+
+    // Match on a substring of the error message. Due to a difference in instructions consumed on
+    // Mac vs Linux, we cannot match on the exact number of cycles but we only need to verify it's
+    // a non-zero amount.
+    let regex = regex::Regex::new("At least ([0-9_]+) additional cycles are required.").unwrap();
+    let cycles_needed: u128 = regex
+        .captures(err.description())
+        .expect("Number regex match failed.")
+        .get(1)
+        .expect("No match for cycles needed.")
+        .as_str()
+        .replace("_", "")
+        .parse()
+        .expect("Failed to parse regex match for cycle count.");
+    assert!(
+        cycles_needed > 0,
+        "The amount of cycles needed is {cycles_needed} which is not positive."
+    );
 }


### PR DESCRIPTION
EXC-1843

Adjust a test on reservation costs so that it doesn't rely on the exact cycles costs because these might change.