### PR TITLE
fix: Correct the value returned for replicated vs non replicated execution in system api

### DIFF
--- a/rs/system_api/src/lib.rs
+++ b/rs/system_api/src/lib.rs
@@ -3396,15 +3396,18 @@ impl SystemApi for SystemApiImpl {
         let result = match &self.api_type {
             ApiType::Start { .. }
             | ApiType::Init { .. }
-            | ApiType::ReplyCallback { .. }
-            | ApiType::RejectCallback { .. }
             | ApiType::Cleanup { .. }
             | ApiType::PreUpgrade { .. }
-            | ApiType::InspectMessage { .. }
             | ApiType::Update { .. }
             | ApiType::SystemTask { .. }
             | ApiType::ReplicatedQuery { .. } => Ok(1),
-            ApiType::NonReplicatedQuery { .. } => Ok(0),
+            ApiType::ReplyCallback { .. } | ApiType::RejectCallback { .. } => {
+                match self.execution_parameters.execution_mode {
+                    ExecutionMode::NonReplicated => Ok(0),
+                    ExecutionMode::Replicated => Ok(1),
+                }
+            }
+            ApiType::InspectMessage { .. } | ApiType::NonReplicatedQuery { .. } => Ok(0),
         };
         trace_syscall!(self, ic0_in_replicated_execution, result);
         result

--- a/rs/system_api/tests/common/mod.rs
+++ b/rs/system_api/tests/common/mod.rs
@@ -99,6 +99,10 @@ impl ApiTypeBuilder {
         )
     }
 
+    pub fn build_replicated_query_api() -> ApiType {
+        ApiType::replicated_query(UNIX_EPOCH, vec![], user_test_id(1).get())
+    }
+
     pub fn build_non_replicated_query_api() -> ApiType {
         ApiType::non_replicated_query(
             UNIX_EPOCH,
@@ -174,6 +178,27 @@ impl ApiTypeBuilder {
             ExecutionMode::NonReplicated,
             0.into(),
         )
+    }
+
+    pub fn build_inspect_message_api() -> ApiType {
+        ApiType::inspect_message(
+            PrincipalId::new_anonymous(),
+            "test".to_string(),
+            vec![],
+            UNIX_EPOCH,
+        )
+    }
+
+    pub fn build_start_api() -> ApiType {
+        ApiType::start(UNIX_EPOCH)
+    }
+
+    pub fn build_init_api() -> ApiType {
+        ApiType::init(UNIX_EPOCH, vec![], user_test_id(1).get())
+    }
+
+    pub fn build_pre_upgrade_api() -> ApiType {
+        ApiType::pre_upgrade(UNIX_EPOCH, user_test_id(1).get())
     }
 }
 


### PR DESCRIPTION
This PR fixes some bugs in how the system API was reporting replicated vs non-replicated mode. Specifically, it was incorrectly reporting that `inspect_message`, a composite query `reply_callback` and `reject_callback` were running in replicated mode, although they are really running in non-replicated mode.