### PR TITLE
refactor: Rename SystemStateChanges to SystemStateModifications for consistency

### DIFF
--- a/rs/canister_sandbox/src/protocol/ctlsvc.rs
+++ b/rs/canister_sandbox/src/protocol/ctlsvc.rs
@@ -67,7 +67,7 @@ mod tests {
         InstanceStats, SystemApiCallCounters, WasmExecutionOutput,
     };
     use ic_replicated_state::{Global, NumWasmPages, PageMap};
-    use ic_system_api::sandbox_safe_system_state::SystemStateChanges;
+    use ic_system_api::sandbox_safe_system_state::SystemStateModifications;
     use ic_types::{ingress::WasmResult, CanisterLog, NumBytes, NumInstructions};
 
     use crate::protocol::{
@@ -125,7 +125,7 @@ mod tests {
                         size: NumWasmPages::new(42),
                     },
                 }),
-                system_state_changes: SystemStateChanges::default(),
+                system_state_modifications: SystemStateModifications::default(),
             },
             execute_total_duration: Duration::from_secs(10),
             execute_run_duration: Duration::from_secs(1),

--- a/rs/canister_sandbox/src/protocol/structs.rs
+++ b/rs/canister_sandbox/src/protocol/structs.rs
@@ -4,7 +4,7 @@ use ic_replicated_state::{
     page_map::PageDeltaSerialization, Global, Memory, NumWasmPages, PageIndex,
 };
 use ic_system_api::{
-    sandbox_safe_system_state::{SandboxSafeSystemState, SystemStateChanges},
+    sandbox_safe_system_state::{SandboxSafeSystemState, SystemStateModifications},
     ApiType, ExecutionParameters,
 };
 use ic_types::{methods::FuncRef, NumBytes};
@@ -67,7 +67,7 @@ pub struct StateModifications {
     /// The system state changes contain parts that are always applied
     /// and parts that are only applied depending on the method executed
     /// (similarly to `execution_state_modifications`).
-    pub system_state_changes: SystemStateChanges,
+    pub system_state_modifications: SystemStateModifications,
 }
 
 #[derive(Serialize, Debug, Deserialize, Clone, PartialEq)]

--- a/rs/canister_sandbox/src/replica_controller/sandboxed_execution_controller.rs
+++ b/rs/canister_sandbox/src/replica_controller/sandboxed_execution_controller.rs
@@ -1587,13 +1587,13 @@ impl SandboxedExecutionController {
 
         let StateModifications {
             execution_state_modifications,
-            system_state_changes,
+            system_state_modifications,
         } = exec_output.take_state_modifications();
 
         match execution_state_modifications {
             None => CanisterStateChanges {
                 execution_state_changes: None,
-                system_state_changes,
+                system_state_modifications,
             },
             Some(execution_state_modifications) => {
                 // TODO: If a canister has broken out of wasm then it might have allocated more
@@ -1647,7 +1647,7 @@ impl SandboxedExecutionController {
                         wasm_memory,
                         stable_memory,
                     }),
-                    system_state_changes,
+                    system_state_modifications,
                 }
             }
         }

--- a/rs/canister_sandbox/src/sandbox_manager.rs
+++ b/rs/canister_sandbox/src/sandbox_manager.rs
@@ -160,7 +160,7 @@ impl Execution {
         match wasm_result {
             Ok(_) => {
                 let state_modifications = {
-                    let system_state_changes = match instance_or_system_api {
+                    let system_state_modifications = match instance_or_system_api {
                         // Here we use `store_data_mut` instead of
                         // `into_store_data` because the later will drop the
                         // wasmtime Instance which can be an expensive
@@ -172,8 +172,8 @@ impl Execution {
                             .store_data_mut()
                             .system_api_mut()
                             .expect("System api not present in the wasmtime instance")
-                            .take_system_state_changes(),
-                        Err(system_api) => system_api.into_system_state_changes(),
+                            .take_system_state_modifications(),
+                        Err(system_api) => system_api.into_system_state_modifications(),
                     };
 
                     let execution_state_modifications = deltas.map(
@@ -193,7 +193,7 @@ impl Execution {
 
                     StateModifications {
                         execution_state_modifications,
-                        system_state_changes,
+                        system_state_modifications,
                     }
                 };
                 if state_modifications.execution_state_modifications.is_some() {

--- a/rs/embedders/src/wasm_executor.rs
+++ b/rs/embedders/src/wasm_executor.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use ic_replicated_state::canister_state::execution_state::WasmBinary;
 use ic_replicated_state::page_map::PageAllocatorFileDescriptor;
 use ic_replicated_state::{ExportedFunctions, Global, Memory, NumWasmPages, PageMap};
-use ic_system_api::sandbox_safe_system_state::{SandboxSafeSystemState, SystemStateChanges};
+use ic_system_api::sandbox_safe_system_state::{SandboxSafeSystemState, SystemStateModifications};
 use ic_system_api::{ApiType, DefaultOutOfInstructionsHandler};
 use ic_types::methods::{FuncRef, WasmMethod};
 use ic_types::NumOsPages;
@@ -146,7 +146,7 @@ pub struct ExecutionStateChanges {
 pub struct CanisterStateChanges {
     pub execution_state_changes: Option<ExecutionStateChanges>,
 
-    pub system_state_changes: SystemStateChanges,
+    pub system_state_modifications: SystemStateModifications,
 }
 
 /// The result of WebAssembly execution with deterministic time slicing.
@@ -260,7 +260,7 @@ impl WasmExecutor for WasmExecutorImpl {
             Ok(instance) => instance.into_store_data().system_api.unwrap(),
             Err(system_api) => system_api,
         };
-        let system_state_changes = system_api.into_system_state_changes();
+        let system_state_modifications = system_api.into_system_state_modifications();
 
         (
             compilation_result,
@@ -269,7 +269,7 @@ impl WasmExecutor for WasmExecutorImpl {
                 wasm_execution_output,
                 CanisterStateChanges {
                     execution_state_changes,
-                    system_state_changes,
+                    system_state_modifications,
                 },
             ),
         )
@@ -497,7 +497,7 @@ pub fn wasm_execution_error(
         },
         CanisterStateChanges {
             execution_state_changes: None,
-            system_state_changes: SystemStateChanges::default(),
+            system_state_modifications: SystemStateModifications::default(),
         },
     )
 }

--- a/rs/embedders/tests/wasmtime_embedder.rs
+++ b/rs/embedders/tests/wasmtime_embedder.rs
@@ -3118,14 +3118,14 @@ fn wasm64_saturate_fun_index() {
         .build();
     let _res = instance.run(FuncRef::Method(WasmMethod::Update("test".to_string())));
 
-    let system_state_changes = instance
+    let system_state_modifications = instance
         .store_data_mut()
         .system_api_mut()
         .unwrap()
-        .take_system_state_changes();
+        .take_system_state_modifications();
 
     // call_perform should trigger one callback update
-    let callback_update = system_state_changes
+    let callback_update = system_state_modifications
         .callback_updates
         .first()
         .unwrap()

--- a/rs/execution_environment/src/execution/install_code.rs
+++ b/rs/execution_environment/src/execution/install_code.rs
@@ -743,10 +743,10 @@ impl InstallCodeHelper {
 
         let CanisterStateChanges {
             execution_state_changes,
-            system_state_changes,
+            system_state_modifications,
         } = canister_state_changes;
 
-        if let Err(err) = system_state_changes.apply_changes(
+        if let Err(err) = system_state_modifications.apply_changes(
             original.time,
             &mut self.canister.system_state,
             round.network_topology,

--- a/rs/execution_environment/src/execution/response.rs
+++ b/rs/execution_environment/src/execution/response.rs
@@ -374,7 +374,9 @@ impl ResponseHelper {
         // Check that the cycles balance does not go below zero after applying
         // the Wasm execution state changes.
         let old_balance = self.canister.system_state.balance();
-        let requested = canister_state_changes.system_state_changes.removed_cycles();
+        let requested = canister_state_changes
+            .system_state_modifications
+            .removed_cycles();
         // Note that we ignore the freezing threshold as required by the spec.
         if old_balance < requested {
             let reveal_top_up = self
@@ -462,7 +464,9 @@ impl ResponseHelper {
         // like releasing locks or undoing other state changes.
         let ingress_induction_cycles_debit =
             self.canister.system_state.ingress_induction_cycles_debit();
-        let removed_cycles = canister_state_changes.system_state_changes.removed_cycles();
+        let removed_cycles = canister_state_changes
+            .system_state_modifications
+            .removed_cycles();
         if self.canister.system_state.balance() < ingress_induction_cycles_debit + removed_cycles {
             self.canister
                 .system_state

--- a/rs/execution_environment/src/execution/update.rs
+++ b/rs/execution_environment/src/execution/update.rs
@@ -448,7 +448,9 @@ impl UpdateHelper {
         // Check that the cycles balance does not go below the freezing
         // threshold after applying the Wasm execution state changes.
         let old_balance = self.canister.system_state.balance();
-        let requested = canister_state_changes.system_state_changes.removed_cycles();
+        let requested = canister_state_changes
+            .system_state_modifications
+            .removed_cycles();
         let reveal_top_up = self
             .canister
             .controllers()

--- a/rs/execution_environment/src/hypervisor.rs
+++ b/rs/execution_environment/src/hypervisor.rs
@@ -415,8 +415,8 @@ impl Hypervisor {
             network_topology,
         );
         let (slice, mut output, canister_state_changes) = match execution_result {
-            WasmExecutionResult::Finished(slice, output, system_state_changes) => {
-                (slice, output, system_state_changes)
+            WasmExecutionResult::Finished(slice, output, system_state_modifications) => {
+                (slice, output, system_state_modifications)
             }
             WasmExecutionResult::Paused(_, _) => {
                 unreachable!("DTS is not supported");

--- a/rs/execution_environment/src/scheduler/test_utilities.rs
+++ b/rs/execution_environment/src/scheduler/test_utilities.rs
@@ -39,7 +39,7 @@ use ic_replicated_state::{
     CanisterState, ExecutionState, ExportedFunctions, InputQueueType, Memory, ReplicatedState,
 };
 use ic_system_api::{
-    sandbox_safe_system_state::{SandboxSafeSystemState, SystemStateChanges},
+    sandbox_safe_system_state::{SandboxSafeSystemState, SystemStateModifications},
     ApiType, ExecutionParameters,
 };
 use ic_test_utilities::state_manager::FakeStateManager;
@@ -1209,7 +1209,7 @@ impl TestWasmExecutorCore {
                 output,
                 CanisterStateChanges {
                     execution_state_changes: None,
-                    system_state_changes: SystemStateChanges::default(),
+                    system_state_modifications: SystemStateModifications::default(),
                 },
             );
         }
@@ -1218,7 +1218,7 @@ impl TestWasmExecutorCore {
         let instructions_left = message_limit - paused.instructions_executed;
 
         // Generate all the outgoing calls.
-        let system_state_changes = self.perform_calls(
+        let system_state_modifications = self.perform_calls(
             paused.sandbox_safe_system_state,
             message.calls,
             paused.call_context_id,
@@ -1257,7 +1257,7 @@ impl TestWasmExecutorCore {
             output,
             CanisterStateChanges {
                 execution_state_changes: Some(execution_state_changes),
-                system_state_changes,
+                system_state_modifications,
             },
         )
     }
@@ -1303,7 +1303,7 @@ impl TestWasmExecutorCore {
         call_context_id: Option<CallContextId>,
         canister_current_memory_usage: NumBytes,
         canister_current_message_memory_usage: NumBytes,
-    ) -> SystemStateChanges {
+    ) -> SystemStateModifications {
         for call in calls.into_iter() {
             if let Err(error) = self.perform_call(
                 &mut system_state,

--- a/rs/system_api/src/sandbox_safe_system_state.rs
+++ b/rs/system_api/src/sandbox_safe_system_state.rs
@@ -59,7 +59,7 @@ pub enum CallbackUpdate {
 
 /// Tracks changes to the system state that the canister has requested.
 #[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
-pub struct SystemStateChanges {
+pub struct SystemStateModifications {
     pub(super) new_certified_data: Option<Vec<u8>>,
     // pub for testing
     pub callback_updates: Vec<CallbackUpdate>,
@@ -77,7 +77,7 @@ pub struct SystemStateChanges {
     pub on_low_wasm_memory_hook_condition_check_result: Option<bool>,
 }
 
-impl Default for SystemStateChanges {
+impl Default for SystemStateModifications {
     fn default() -> Self {
         Self {
             new_certified_data: None,
@@ -95,7 +95,7 @@ impl Default for SystemStateChanges {
     }
 }
 
-impl SystemStateChanges {
+impl SystemStateModifications {
     /// Checks that no cycles were created during the execution of this message
     /// (unless the canister is the cycles minting canister).
     fn validate_cycle_change(&self, is_cmc_canister: bool) -> HypervisorResult<()> {
@@ -545,8 +545,8 @@ impl SystemStateChanges {
     fn default_with_cycles_changes(
         cycles_balance_change: CyclesBalanceChange,
         consumed_cycles_by_use_case: BTreeMap<CyclesUseCase, Cycles>,
-    ) -> SystemStateChanges {
-        SystemStateChanges {
+    ) -> SystemStateModifications {
+        SystemStateModifications {
             cycles_balance_change,
             consumed_cycles_by_use_case,
             ..Default::default()
@@ -561,7 +561,7 @@ impl SystemStateChanges {
 pub struct SandboxSafeSystemState {
     /// Only public for tests
     #[doc(hidden)]
-    pub system_state_changes: SystemStateChanges,
+    pub system_state_modifications: SystemStateModifications,
     pub(super) canister_id: CanisterId,
     pub(super) status: CanisterStatusView,
     pub(super) subnet_type: SubnetType,
@@ -638,12 +638,12 @@ impl SandboxSafeSystemState {
             memory_allocation,
             wasm_memory_threshold,
             compute_allocation,
-            system_state_changes: SystemStateChanges {
+            system_state_modifications: SystemStateModifications {
                 // Start indexing new batch of canister log records from the given index.
                 canister_log: CanisterLog::new_with_next_index(next_canister_log_record_idx),
                 call_context_balance_taken: call_context_id
                     .map(|call_context_id| (call_context_id, Cycles::zero())),
-                ..SystemStateChanges::default()
+                ..SystemStateModifications::default()
             },
             initial_cycles_balance,
             initial_reserved_balance,
@@ -793,12 +793,12 @@ impl SandboxSafeSystemState {
 
     pub fn set_global_timer(&mut self, timer: CanisterTimer) {
         // Update both sandbox global timer and the changes.
-        self.system_state_changes.new_global_timer = Some(timer);
+        self.system_state_modifications.new_global_timer = Some(timer);
         self.global_timer = timer;
     }
 
-    pub fn take_changes(&mut self) -> SystemStateChanges {
-        std::mem::take(&mut self.system_state_changes)
+    pub fn take_changes(&mut self) -> SystemStateModifications {
+        std::mem::take(&mut self.system_state_modifications)
     }
 
     /// Only public for use in tests.
@@ -808,7 +808,7 @@ impl SandboxSafeSystemState {
             Some(next_callback_id) => {
                 *next_callback_id += 1;
                 let id = CallbackId::from(*next_callback_id);
-                self.system_state_changes
+                self.system_state_modifications
                     .callback_updates
                     .push(CallbackUpdate::Register(id, callback));
                 Ok(id)
@@ -823,7 +823,7 @@ impl SandboxSafeSystemState {
     /// Only public for use in tests.
     #[doc(hidden)]
     pub fn unregister_callback(&mut self, id: CallbackId) {
-        self.system_state_changes
+        self.system_state_modifications
             .callback_updates
             .push(CallbackUpdate::Unregister(id))
     }
@@ -831,21 +831,21 @@ impl SandboxSafeSystemState {
     /// Computes the current main balance of the canister based
     /// on the initial value and the changes during the execution.
     pub(super) fn cycles_balance(&self) -> Cycles {
-        let cycles_change = self.system_state_changes.cycles_balance_change;
+        let cycles_change = self.system_state_modifications.cycles_balance_change;
         cycles_change.apply(self.initial_cycles_balance)
     }
 
     /// Computes the current reserved balance of the canister based
     /// on the initial value and the changes during the execution.
     pub(super) fn reserved_balance(&self) -> Cycles {
-        self.initial_reserved_balance + self.system_state_changes.reserved_cycles
+        self.initial_reserved_balance + self.system_state_modifications.reserved_cycles
     }
 
     pub(super) fn msg_cycles_available(&self) -> Cycles {
         let initial_available = self.call_context_balance.unwrap_or(Cycles::zero());
 
         let already_taken = self
-            .system_state_changes
+            .system_state_modifications
             .call_context_balance_taken
             .map_or(Cycles::zero(), |(_, balance_taken)| balance_taken);
 
@@ -858,7 +858,7 @@ impl SandboxSafeSystemState {
     }
 
     fn update_balance_change(&mut self, new_balance: Cycles) {
-        self.system_state_changes.cycles_balance_change =
+        self.system_state_modifications.cycles_balance_change =
             CyclesBalanceChange::new(self.initial_cycles_balance, new_balance);
     }
 
@@ -878,7 +878,7 @@ impl SandboxSafeSystemState {
             new_balance
         );
 
-        self.system_state_changes
+        self.system_state_modifications
             .add_consumed_cycles(consumed_cycles);
         self.update_balance_change(new_balance);
     }
@@ -934,14 +934,14 @@ impl SandboxSafeSystemState {
         // It is safe to unwrap since msg_cycles_accept and msg_cycles_accept128 are
         // available only forApiType::{Update, ReplicatedQuery, ReplyCallback,
         // RejectCallBack} and all of them have CallContextId, hence
-        // SystemStateChanges::call_context_balance_taken will never be `None`.
+        // SystemStateModifications::call_context_balance_taken will never be `None`.
         debug_assert!(self
-            .system_state_changes
+            .system_state_modifications
             .call_context_balance_taken
             .is_some());
 
         let balance_taken = &mut self
-            .system_state_changes
+            .system_state_modifications
             .call_context_balance_taken
             .as_mut()
             .unwrap()
@@ -1057,14 +1057,14 @@ impl SandboxSafeSystemState {
             .get(&msg.receiver)
             .unwrap_or(&DEFAULT_QUEUE_CAPACITY);
         let used_slots = self
-            .system_state_changes
+            .system_state_modifications
             .request_slots_used
             .entry(msg.receiver)
             .or_insert(0);
         if *used_slots >= *initial_available_slots {
             return Err(msg);
         }
-        self.system_state_changes.requests.push(msg);
+        self.system_state_modifications.requests.push(msg);
         *used_slots += 1;
         self.update_balance_change_consuming(new_balance, &consumed_cycles);
         Ok(())
@@ -1217,8 +1217,8 @@ impl SandboxSafeSystemState {
     ///
     /// The reserved cycles are removed from the main balance and added to the
     /// reserved balance. In pseudocode, reserving means:
-    ///   - `self.system_state_changes.cycles_balance_change -= reserved_cycles`
-    ///   - `self.system_state_changes.reserved_cycles += reserved_cycles`
+    ///   - `self.system_state_modifications.cycles_balance_change -= reserved_cycles`
+    ///   - `self.system_state_modifications.reserved_cycles += reserved_cycles`
     pub(super) fn reserve_storage_cycles(
         &mut self,
         allocated_bytes: NumBytes,
@@ -1258,7 +1258,7 @@ impl SandboxSafeSystemState {
                 }
                 let new_balance = old_balance - cycles_to_reserve;
                 self.update_balance_change(new_balance);
-                self.system_state_changes.reserved_cycles += cycles_to_reserve;
+                self.system_state_modifications.reserved_cycles += cycles_to_reserve;
                 Ok(())
             }
         }
@@ -1287,7 +1287,7 @@ impl SandboxSafeSystemState {
             self.wasm_memory_threshold,
         );
 
-        self.system_state_changes
+        self.system_state_modifications
             .on_low_wasm_memory_hook_condition_check_result = Some(is_condition_satisfied);
     }
 
@@ -1319,19 +1319,19 @@ impl SandboxSafeSystemState {
 
     /// Appends a log record to the system state changes.
     pub fn append_canister_log(&mut self, time: &Time, content: Vec<u8>) {
-        self.system_state_changes
+        self.system_state_modifications
             .canister_log
             .add_record(time.as_nanos_since_unix_epoch(), content);
     }
 
     /// Takes collected canister log records.
     pub fn take_canister_log(&mut self) -> CanisterLog {
-        std::mem::take(&mut self.system_state_changes.canister_log)
+        std::mem::take(&mut self.system_state_modifications.canister_log)
     }
 
     /// Returns collected canister log records.
     pub fn canister_log(&self) -> &CanisterLog {
-        &self.system_state_changes.canister_log
+        &self.system_state_modifications.canister_log
     }
 
     fn caller_is_controller(&self) -> bool {
@@ -1374,7 +1374,7 @@ mod tests {
     use crate::{
         cycles_balance_change::CyclesBalanceChange,
         sandbox_safe_system_state::{
-            CanisterStatusView, SandboxSafeSystemState, SystemStateChanges,
+            CanisterStatusView, SandboxSafeSystemState, SystemStateModifications,
         },
     };
 
@@ -1391,12 +1391,12 @@ mod tests {
 
         let removed = Cycles::new(500_000);
         let consumed = Cycles::new(100_000);
-        let system_state_changes = SystemStateChanges::default_with_cycles_changes(
+        let system_state_modifications = SystemStateModifications::default_with_cycles_changes(
             CyclesBalanceChange::Removed(removed),
             BTreeMap::from([(CyclesUseCase::RequestAndResponseTransmission, consumed)]),
         );
 
-        system_state_changes.apply_balance_changes(&mut system_state);
+        system_state_modifications.apply_balance_changes(&mut system_state);
 
         assert_eq!(initial_cycles_balance - removed, system_state.balance());
 
@@ -1404,12 +1404,12 @@ mod tests {
 
         let removed = Cycles::new(500_000);
         let consumed = Cycles::new(600_000);
-        let system_state_changes = SystemStateChanges::default_with_cycles_changes(
+        let system_state_modifications = SystemStateModifications::default_with_cycles_changes(
             CyclesBalanceChange::Removed(removed),
             BTreeMap::from([(CyclesUseCase::RequestAndResponseTransmission, consumed)]),
         );
 
-        system_state_changes.apply_balance_changes(&mut system_state);
+        system_state_modifications.apply_balance_changes(&mut system_state);
 
         assert_eq!(initial_cycles_balance - removed, system_state.balance());
 
@@ -1417,12 +1417,12 @@ mod tests {
 
         let added = Cycles::new(500_000);
         let consumed = Cycles::new(100_000);
-        let system_state_changes = SystemStateChanges::default_with_cycles_changes(
+        let system_state_modifications = SystemStateModifications::default_with_cycles_changes(
             CyclesBalanceChange::Added(added),
             BTreeMap::from([(CyclesUseCase::RequestAndResponseTransmission, consumed)]),
         );
 
-        system_state_changes.apply_balance_changes(&mut system_state);
+        system_state_modifications.apply_balance_changes(&mut system_state);
 
         assert_eq!(initial_cycles_balance + added, system_state.balance());
 
@@ -1430,12 +1430,12 @@ mod tests {
 
         let added = Cycles::new(500_000);
         let consumed = Cycles::new(600_000);
-        let system_state_changes = SystemStateChanges::default_with_cycles_changes(
+        let system_state_modifications = SystemStateModifications::default_with_cycles_changes(
             CyclesBalanceChange::Added(added),
             BTreeMap::from([(CyclesUseCase::RequestAndResponseTransmission, consumed)]),
         );
 
-        system_state_changes.apply_balance_changes(&mut system_state);
+        system_state_modifications.apply_balance_changes(&mut system_state);
 
         assert_eq!(initial_cycles_balance + added, system_state.balance());
     }
@@ -1563,7 +1563,7 @@ mod tests {
 
                             assert_eq!(
                                 state
-                                    .system_state_changes
+                                    .system_state_modifications
                                     .on_low_wasm_memory_hook_condition_check_result,
                                 None
                             );
@@ -1579,7 +1579,7 @@ mod tests {
 
                             assert_eq!(
                                 state
-                                    .system_state_changes
+                                    .system_state_modifications
                                     .on_low_wasm_memory_hook_condition_check_result
                                     .unwrap(),
                                 helper_is_condition_satisfied_for_on_low_wasm_memory_hook(

--- a/rs/system_api/tests/sandbox_safe_system_state.rs
+++ b/rs/system_api/tests/sandbox_safe_system_state.rs
@@ -253,7 +253,7 @@ fn correct_charging_source_canister_for_a_request() {
     // => Mock the response_cycles_refund() invocation from the
     // execute_canister_response()
     sandbox_safe_system_state
-        .system_state_changes
+        .system_state_modifications
         .apply_changes(
             UNIX_EPOCH,
             &mut system_state,
@@ -443,8 +443,8 @@ fn call_increases_cycles_consumed_metric() {
     api.ic0_call_new(0, 0, 0, 0, 0, 0, 0, 0, &[]).unwrap();
     api.ic0_call_perform().unwrap();
 
-    let system_state_changes = api.into_system_state_changes();
-    system_state_changes
+    let system_state_modifications = api.into_system_state_modifications();
+    system_state_modifications
         .apply_changes(
             UNIX_EPOCH,
             &mut system_state,
@@ -526,7 +526,7 @@ fn test_inter_canister_call(
         .unwrap();
 
     sandbox_safe_system_state
-        .system_state_changes
+        .system_state_modifications
         .apply_changes(
             UNIX_EPOCH,
             &mut system_state,

--- a/rs/system_api/tests/system_api.rs
+++ b/rs/system_api/tests/system_api.rs
@@ -1142,8 +1142,8 @@ fn certified_data_set() {
     // Copy the certified data into the system state.
     api.ic0_certified_data_set(0, 32, &heap).unwrap();
 
-    let system_state_changes = api.into_system_state_changes();
-    system_state_changes
+    let system_state_modifications = api.into_system_state_modifications();
+    system_state_modifications
         .apply_changes(
             UNIX_EPOCH,
             &mut system_state,
@@ -1315,8 +1315,8 @@ fn call_perform_not_enough_cycles_does_not_trap() {
             res
         ),
     }
-    let system_state_changes = api.into_system_state_changes();
-    system_state_changes
+    let system_state_modifications = api.into_system_state_modifications();
+    system_state_modifications
         .apply_changes(
             UNIX_EPOCH,
             &mut system_state,
@@ -1459,8 +1459,8 @@ fn helper_test_on_low_wasm_memory(
             .unwrap();
     }
 
-    let system_state_changes = api.into_system_state_changes();
-    system_state_changes
+    let system_state_modifications = api.into_system_state_modifications();
+    system_state_modifications
         .apply_changes(
             UNIX_EPOCH,
             &mut system_state,
@@ -1728,8 +1728,8 @@ fn push_output_request_respects_memory_limits() {
     );
 
     // Ensure that exactly one output request was pushed.
-    let system_state_changes = api.into_system_state_changes();
-    system_state_changes
+    let system_state_modifications = api.into_system_state_modifications();
+    system_state_modifications
         .apply_changes(
             UNIX_EPOCH,
             &mut system_state,
@@ -1844,8 +1844,8 @@ fn push_output_request_oversized_request_memory_limits() {
     );
 
     // Ensure that exactly one output request was pushed.
-    let system_state_changes = api.into_system_state_changes();
-    system_state_changes
+    let system_state_modifications = api.into_system_state_modifications();
+    system_state_modifications
         .apply_changes(
             UNIX_EPOCH,
             &mut system_state,
@@ -1880,8 +1880,8 @@ fn ic0_global_timer_set_is_propagated_from_sandbox() {
 
     // Propagate system state changes
     assert_eq!(system_state.global_timer, CanisterTimer::Inactive);
-    let system_state_changes = api.into_system_state_changes();
-    system_state_changes
+    let system_state_modifications = api.into_system_state_modifications();
+    system_state_modifications
         .apply_changes(
             UNIX_EPOCH,
             &mut system_state,


### PR DESCRIPTION
All the other structs that maintain modifications of different parts of the canister state use `*Modifications` in their name, so change `SystemStateChanges` to use it as well for consistency.