### PR TITLE
feat(PocketIC): PocketIC certifies time after setting or advancing time

### DIFF
--- a/packages/pocket-ic/tests/tests.rs
+++ b/packages/pocket-ic/tests/tests.rs
@@ -356,20 +356,24 @@ fn test_get_and_set_and_advance_time() {
 
     let unix_time_secs = 1630328630;
     let set_time = SystemTime::UNIX_EPOCH + std::time::Duration::from_secs(unix_time_secs);
+
     pic.set_time(set_time);
     assert_eq!(pic.get_time(), set_time);
+
     pic.tick();
-    assert_eq!(pic.get_time(), set_time);
+    let current_time = pic.get_time();
+    assert_eq!(current_time, set_time + std::time::Duration::from_nanos(1));
 
     pic.advance_time(std::time::Duration::from_secs(420));
     assert_eq!(
         pic.get_time(),
-        set_time + std::time::Duration::from_secs(420)
+        current_time + std::time::Duration::from_secs(420),
     );
+
     pic.tick();
     assert_eq!(
         pic.get_time(),
-        set_time + std::time::Duration::from_secs(420)
+        current_time + std::time::Duration::from_secs(420) + std::time::Duration::from_nanos(1)
     );
 }
 
@@ -413,12 +417,10 @@ fn query_call_after_advance_time() {
     query_and_check_time(&pic, canister);
 
     pic.advance_time(std::time::Duration::from_secs(420));
-    pic.tick();
 
     query_and_check_time(&pic, canister);
 
     pic.advance_time(std::time::Duration::from_secs(0));
-    pic.tick();
 
     query_and_check_time(&pic, canister);
 }

--- a/rs/pocket_ic_server/CHANGELOG.md
+++ b/rs/pocket_ic_server/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - The response type `RawSubmitIngressResult` is replaced by `Result<RawMessageId, RejectResponse>`.
 - The response types `RawWasmResult` and `UserError` in `RawCanisterResult` are replaced by `Vec<u8>` and `RejectResponse`.
+- The endpoint `/instances/<instance_id>/update/set_time` executes a round after setting time so that
+  a state with that time becomes certified and, e.g., query calls are evaluated on a state with the specified time.
 
 ### Removed
 - The endpoint `/instances/<instance_id>/update/execute_ingress_message`:

--- a/rs/pocket_ic_server/CHANGELOG.md
+++ b/rs/pocket_ic_server/CHANGELOG.md
@@ -22,8 +22,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - The response type `RawSubmitIngressResult` is replaced by `Result<RawMessageId, RejectResponse>`.
 - The response types `RawWasmResult` and `UserError` in `RawCanisterResult` are replaced by `Vec<u8>` and `RejectResponse`.
-- The endpoint `/instances/<instance_id>/update/set_time` executes a round after setting time so that
-  a state with that time becomes certified and, e.g., query calls are evaluated on a state with the specified time.
 
 ### Removed
 - The endpoint `/instances/<instance_id>/update/execute_ingress_message`:

--- a/rs/pocket_ic_server/src/pocket_ic.rs
+++ b/rs/pocket_ic_server/src/pocket_ic.rs
@@ -1178,9 +1178,10 @@ impl Operation for SetTime {
             ))),
             std::cmp::Ordering::Equal => OpOut::NoOutput,
             std::cmp::Ordering::Less => {
-                // Sets the time on all subnets.
+                // Sets the time and execute a round to certify that time on all subnets.
                 for subnet in pic.subnets.get_all() {
                     subnet.state_machine.set_time(set_time);
+                    subnet.state_machine.execute_round();
                 }
                 OpOut::NoOutput
             }

--- a/rs/pocket_ic_server/src/pocket_ic.rs
+++ b/rs/pocket_ic_server/src/pocket_ic.rs
@@ -872,9 +872,6 @@ impl PocketIc {
         for subnet in subnets.get_all() {
             max_time = max(max_time, subnet.state_machine.get_state_time());
         }
-        // Since calling `StateMachine::set_time` with the maximum time might make the `StateMachine` believe
-        // that time already progressed, we add one nanosecond to make time strictly monotone on all subnets.
-        max_time += Duration::from_nanos(1);
         for subnet in subnets.get_all() {
             subnet.state_machine.set_time(max_time.into());
         }
@@ -1178,10 +1175,9 @@ impl Operation for SetTime {
             ))),
             std::cmp::Ordering::Equal => OpOut::NoOutput,
             std::cmp::Ordering::Less => {
-                // Sets the time and execute a round to certify that time on all subnets.
+                // Sets the time on all subnets.
                 for subnet in pic.subnets.get_all() {
                     subnet.state_machine.set_time(set_time);
-                    subnet.state_machine.execute_round();
                 }
                 OpOut::NoOutput
             }

--- a/rs/state_machine_tests/src/lib.rs
+++ b/rs/state_machine_tests/src/lib.rs
@@ -3930,14 +3930,3 @@ impl PayloadBuilder {
         self.ingress_messages.iter().map(|i| i.id()).collect()
     }
 }
-
-// This test should panic on a critical error due to non-monotone timestamps.
-#[should_panic]
-#[test]
-fn critical_error_test() {
-    let sm = StateMachineBuilder::new().build();
-    sm.set_time(SystemTime::UNIX_EPOCH);
-    sm.tick();
-    sm.set_time(SystemTime::UNIX_EPOCH);
-    sm.tick();
-}


### PR DESCRIPTION
This PR makes the endpoint `/instances/<instance_id>/update/set_time` certify state after setting time so that the latest certified state is a state with that time and, e.g., query calls and read state requests are evaluated on a state with the specified time. This also fixes [flakiness](https://github.com/dfinity/ic/actions/runs/12909846684/job/35998504336) when using an IC agent shortly after making a PocketIC instance live, but before the live mode executes a round.