### PR TITLE
feat(MR): [MR-638] Include best-effort calls in `xnet_compatibility` test

### DIFF
--- a/rs/messaging/tests/queue_tests.rs
+++ b/rs/messaging/tests/queue_tests.rs
@@ -15,8 +15,8 @@ use ic_types::{
     Cycles,
 };
 use maplit::btreemap;
-use std::collections::BTreeSet;
 use std::sync::Arc;
+use std::{collections::BTreeSet, vec};
 use xnet_test::{Metrics, StartArgs};
 
 const MAX_TICKS: u64 = 100;
@@ -103,7 +103,7 @@ impl SubnetPairProxy {
             network_topology,
             canister_to_subnet_rate,
             request_payload_size_bytes: payload_size_bytes,
-            request_timeout_seconds: 0,
+            call_timeouts_seconds: vec![None],
             response_payload_size_bytes: payload_size_bytes,
         })
     }

--- a/rs/rust_canisters/xnet_test/src/lib.rs
+++ b/rs/rust_canisters/xnet_test/src/lib.rs
@@ -15,7 +15,7 @@ pub struct StartArgs {
     pub network_topology: NetworkTopology,
     pub canister_to_subnet_rate: u64,
     pub request_payload_size_bytes: u64,
-    pub request_timeout_seconds: u32,
+    pub call_timeouts_seconds: Vec<Option<u32>>,
     pub response_payload_size_bytes: u64,
 }
 

--- a/rs/rust_canisters/xnet_test/src/main.rs
+++ b/rs/rust_canisters/xnet_test/src/main.rs
@@ -44,10 +44,10 @@ thread_local! {
 
     /// State of the messaging that we use to check invariants (e.g., sequence
     /// numbers).
-    static STATE: RefCell<MessagingState> = RefCell::new(Default::default());
+    static STATE: RefCell<MessagingState> = RefCell::default();
 
     /// Various metrics observed by this canister, e.g. message latency distribution.
-    static METRICS: RefCell<Metrics> = RefCell::new(Default::default());
+    static METRICS: RefCell<Metrics> = RefCell::default();
 
     /// The pseudo-random number generator we use to pick the next canister to talk to.
     /// It doesn't need to be cryptographically secure, we just want it to be simple and fast.

--- a/rs/tests/message_routing/common/common.rs
+++ b/rs/tests/message_routing/common/common.rs
@@ -14,7 +14,7 @@ use xnet_test::StartArgs;
 pub async fn start_all_canisters(
     canisters: &[Vec<Canister<'_>>],
     request_payload_size_bytes: u64,
-    request_timeout_seconds: u32,
+    call_timeouts_seconds: &[Option<u32>],
     response_payload_size_bytes: u64,
     canister_to_subnet_rate: u64,
 ) {
@@ -36,7 +36,7 @@ pub async fn start_all_canisters(
             network_topology: topology.clone(),
             canister_to_subnet_rate,
             request_payload_size_bytes,
-            request_timeout_seconds,
+            call_timeouts_seconds: call_timeouts_seconds.to_vec(),
             response_payload_size_bytes,
         };
         futures.push(async move {

--- a/rs/tests/message_routing/global_reboot_test.rs
+++ b/rs/tests/message_routing/global_reboot_test.rs
@@ -190,7 +190,7 @@ pub fn start_all_canisters(
                 network_topology: topology.clone(),
                 canister_to_subnet_rate,
                 request_payload_size_bytes: payload_size_bytes,
-                request_timeout_seconds: 0,
+                call_timeouts_seconds: vec![None],
                 response_payload_size_bytes: payload_size_bytes,
             };
             let _: String = canister

--- a/rs/tests/message_routing/xnet/xnet_malicious_slices.rs
+++ b/rs/tests/message_routing/xnet/xnet_malicious_slices.rs
@@ -153,10 +153,11 @@ pub async fn test_async(env: TestEnv, config: Config) {
     // Start all canisters (via update `start` call).
     info!(logger, "Calling start() on all canisters...");
     start_all_canisters(
-        &canisters, 1024, // send messages with 1024 byte payloads
-        0,    // guaranteed response calls
-        1024, // same response size
-        10,   // each canister sends 10 RPS
+        &canisters,
+        1024,    // send messages with 1024 byte payloads
+        &[None], // guaranteed response calls
+        1024,    // same response size
+        10,      // each canister sends 10 RPS
     )
     .await;
     info!(logger, "Starting chatter: 10 messages/round * 1024 bytes",);

--- a/rs/tests/message_routing/xnet/xnet_slo_3_subnets_best_effort_test.rs
+++ b/rs/tests/message_routing/xnet/xnet_slo_3_subnets_best_effort_test.rs
@@ -8,14 +8,14 @@ const SUBNETS: usize = 3;
 const NODES_PER_SUBNET: usize = 4;
 const RUNTIME: Duration = Duration::from_secs(60);
 const REQUEST_RATE: usize = 100;
-const RESPONSE_TIMEOUT_SECONDS: u32 = 300;
+const CALL_TIMEOUT_SECONDS: u32 = 300;
 
 const PER_TASK_TIMEOUT: Duration = Duration::from_secs(15 * 60);
 const OVERALL_TIMEOUT: Duration = Duration::from_secs(25 * 60);
 
 fn main() -> Result<()> {
     let config = Config::new(SUBNETS, NODES_PER_SUBNET, RUNTIME, REQUEST_RATE)
-        .with_best_effort_response(RESPONSE_TIMEOUT_SECONDS);
+        .with_call_timeouts(&[Some(CALL_TIMEOUT_SECONDS)]);
     let test = config.clone().test();
     SystemTestGroup::new()
         .with_setup(config.build())


### PR DESCRIPTION
Make both guaranteed response and best-effort calls in the subnet upgrade-downgrade `xnet_compatibility` test.