### PR TITLE
feat(sns): `SnsGov.list_proposals` includes `chunked_canister_wasm`

### DIFF
--- a/rs/sns/governance/CHANGELOG.md
+++ b/rs/sns/governance/CHANGELOG.md
@@ -10,5 +10,15 @@ here were moved from the adjacent `unreleased_changelog.md` file.
 
 INSERT NEW RELEASES HERE
 
+* https://nns.ic0.app/proposal/?proposal=134906
+
+    Enable upgrading SNS-controlled canisters using chunked WASMs. This is implemented as an extension
+of the existing `UpgradeSnsControllerCanister` proposal type with new field `chunked_canister_wasm`.
+This field can be used for specifying an upgrade of an SNS-controlled *target* canister using
+a potentially large WASM module (over 2 MiB) uploaded to some *store* canister, which:
+    * must be installed on the same subnet as target.
+    * must have SNS Root as one of its controllers.
+    * must have enough cycles for performing the upgrade.
+
 
 END

--- a/rs/sns/governance/src/types.rs
+++ b/rs/sns/governance/src/types.rs
@@ -1769,7 +1769,7 @@ impl UpgradeSnsControlledCanister {
             canister_upgrade_arg: self.canister_upgrade_arg.clone(),
             mode: self.mode,
             new_canister_wasm: Vec::new(),
-            chunked_canister_wasm: None,
+            chunked_canister_wasm: self.chunked_canister_wasm.clone(),
         }
     }
 }

--- a/rs/sns/governance/unreleased_changelog.md
+++ b/rs/sns/governance/unreleased_changelog.md
@@ -9,14 +9,6 @@ on the process that this file is part of, see
 
 ## Added
 
-* Enable upgrading SNS-controlled canisters using chunked WASMs. This is implemented as an extension
-of the existing `UpgradeSnsControllerCanister` proposal type with new field `chunked_canister_wasm`.
-This field can be used for specifying an upgrade of an SNS-controlled *target* canister using
-a potentially large WASM module (over 2 MiB) uploaded to some *store* canister, which:
-    * must be installed on the same subnet as target.
-    * must have SNS Root as one of its controllers.
-    * must have enough cycles for performing the upgrade.
-
 * Enable SNSs to opt in for
 [automatically advancing its target version](https://forum.dfinity.org/t/proposal-opt-in-mechanism-for-automatic-sns-target-version-advancement/39874)
 to the newest version blessed by the NNS. To do so, please submit a `ManageNervousSystemParameters` 
@@ -43,6 +35,8 @@ proposal, e.g.:
     },
     )'
     ```
+
+* Do not redact chunked Wasm data in `ProposalInfo` served from `SnsGov.list_proposals`.
 
 ## Changed
 


### PR DESCRIPTION
This PR makes the `SnsGov.list_proposals` query include the `chunked_canister_wasm` field for `UpgradeSnsControlledCanister` proposals. Previously, this field has been redacted from the response payload.