### PR TITLE
feat(candid-utils): Better validation for Candid services without arguments

### DIFF
--- a/rs/nervous_system/candid_utils/src/validation.rs
+++ b/rs/nervous_system/candid_utils/src/validation.rs
@@ -70,32 +70,53 @@ impl CandidServiceArgValidationError {
     }
 }
 
+impl std::fmt::Display for CandidServiceArgValidationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let (kind, message) = self.deconstruct();
+        write!(f, "CandidServiceArgValidationError::{kind}: {message}")
+    }
+}
+
 /// Checks whether `upgrade_args` is a valid argument sequence for `candid_service`.
 ///
-/// Returns the byte encoding of `upgrade_args` in the successful case.
+/// If `upgrade_args` is None, checks that `candid_service` does not require any arguments.
+///
+/// Example `upgrade_args` with two arguments: "((42 : nat32), opt record { foo = opt bar; })".
+///
+/// Returns the byte encoding of `upgrade_args` (if any; otherwise None) in the successful case.
 pub fn validate_upgrade_args(
     candid_service: String,
-    upgrade_args: String,
-) -> Result<Vec<u8>, CandidServiceArgValidationError> {
+    upgrade_args: Option<String>,
+) -> Result<Option<Vec<u8>>, CandidServiceArgValidationError> {
     let (expected_args_types, (env, _)) =
         instantiate_candid(CandidSource::Text(&candid_service))
             .map_err(|err| CandidServiceArgValidationError::BadService(format!("{err:?}")))?;
 
-    let upgrade_args = parse_idl_args(&upgrade_args)
-        .map_err(|err| CandidServiceArgValidationError::ArgsParseError(format!("{err:?}")))?;
+    let (upgrade_args, args_types) = if let Some(upgrade_args) = upgrade_args {
+        let upgrade_args = parse_idl_args(&upgrade_args)
+            .map_err(|err| CandidServiceArgValidationError::ArgsParseError(format!("{err:?}")))?;
 
-    let args_types = upgrade_args.get_types();
+        let types = upgrade_args.get_types();
+
+        (Some(upgrade_args), types)
+    } else {
+        (None, vec![])
+    };
 
     if args_types.len() != expected_args_types.len() {
         return Err(CandidServiceArgValidationError::WrongArgumentCount(
             format!(
                 "Number of specified upgrade arguments ({}) does not match expected number \
-             of arguments for the target canister ({}).",
+                 of arguments for the target canister ({}).",
                 args_types.len(),
                 expected_args_types.len(),
             ),
         ));
     }
+
+    let Some(upgrade_args) = upgrade_args else {
+        return Ok(None);
+    };
 
     let mut gamma = std::collections::HashSet::new();
 
@@ -123,6 +144,23 @@ pub fn validate_upgrade_args(
             fmt_type_vec(&expected_args_types),
         )));
     }
+
+    let upgrade_args = upgrade_args.to_bytes().map_err(|err| {
+        CandidServiceArgValidationError::ArgsSerializationError(format!("{err:?}"))
+    })?;
+
+    Ok(Some(upgrade_args))
+}
+
+/// Returns the byte encoding of `upgrade_args` in the Ok result.
+///
+/// WARNING. Please use the [validate_upgrade_args] function instead. This function is only
+/// suitable for best-effort upgrades in which the Candid service is not available.
+pub fn encode_upgrade_args_unsafe(
+    upgrade_args: String,
+) -> Result<Vec<u8>, CandidServiceArgValidationError> {
+    let upgrade_args = parse_idl_args(&upgrade_args)
+        .map_err(|err| CandidServiceArgValidationError::ArgsParseError(format!("{err:?}")))?;
 
     let upgrade_args = upgrade_args.to_bytes().map_err(|err| {
         CandidServiceArgValidationError::ArgsSerializationError(format!("{err:?}"))

--- a/rs/nervous_system/candid_utils/src/validation.rs
+++ b/rs/nervous_system/candid_utils/src/validation.rs
@@ -84,7 +84,7 @@ impl std::fmt::Display for CandidServiceArgValidationError {
 /// Example `upgrade_args` with two arguments: "((42 : nat32), opt record { foo = opt bar; })".
 ///
 /// Returns the byte encoding of `upgrade_args` (if any; otherwise None) in the successful case.
-pub fn validate_upgrade_args(
+pub fn encode_upgrade_args(
     candid_service: String,
     upgrade_args: Option<String>,
 ) -> Result<Option<Vec<u8>>, CandidServiceArgValidationError> {
@@ -154,9 +154,9 @@ pub fn validate_upgrade_args(
 
 /// Returns the byte encoding of `upgrade_args` in the Ok result.
 ///
-/// WARNING. Please use the [validate_upgrade_args] function instead. This function is only
+/// WARNING. Please use the [encode_upgrade_args] function instead. This function is only
 /// suitable for best-effort upgrades in which the Candid service is not available.
-pub fn encode_upgrade_args_unsafe(
+pub fn encode_upgrade_args_without_service(
     upgrade_args: String,
 ) -> Result<Vec<u8>, CandidServiceArgValidationError> {
     let upgrade_args = parse_idl_args(&upgrade_args)

--- a/rs/nervous_system/candid_utils/src/validation/tests.rs
+++ b/rs/nervous_system/candid_utils/src/validation/tests.rs
@@ -14,13 +14,35 @@ fn test_candid_service_arg_validation() {
 
     for (label, candid_service, upgrade_arg, expected_result) in [
         (
-            "Service without args",
+            "Service without args (no arguments)",
             r#"
                 service : {
                     g : () -> (int) query;
                 }
             "#,
-            "()",
+            None,
+            Ok(()),
+        ),
+        (
+            "Service with args, but none are supplied",
+            r#"
+                service : (x : nat32) -> {
+                    g : () -> (int) query;
+                }
+            "#,
+            None,
+            Err(CandidServiceArgValidationError::WrongArgumentCount(
+                dummy_error_text.clone(),
+            )),
+        ),
+        (
+            "Service without args (empty tuple of arguments)",
+            r#"
+                service : {
+                    g : () -> (int) query;
+                }
+            "#,
+            Some("()".to_string()),
             Ok(()),
         ),
         (
@@ -31,7 +53,7 @@ fn test_candid_service_arg_validation() {
                     g : (List) -> (int) query;
                 }
             "#,
-            "()",
+            Some("()".to_string()),
             Err(CandidServiceArgValidationError::BadService(
                 dummy_error_text.clone(),
             )),
@@ -45,7 +67,7 @@ fn test_candid_service_arg_validation() {
                     g : () -> (int) query;
                 }
             "#,
-            "",
+            Some("".to_string()),
             Err(CandidServiceArgValidationError::ArgsParseError(
                 dummy_error_text.clone(),
             )),
@@ -53,13 +75,13 @@ fn test_candid_service_arg_validation() {
         (
             "Complex service with two arguments (happy)",
             complex_service,
-            "(record {}, (11 : nat32))",
+            Some("(record {}, (11 : nat32))".to_string()),
             Ok(()),
         ),
         (
             "Complex service with two arguments (missing 1st arg)",
             complex_service,
-            "((11 : nat32))",
+            Some("((11 : nat32))".to_string()),
             Err(CandidServiceArgValidationError::WrongArgumentCount(
                 dummy_error_text.clone(),
             )),
@@ -67,7 +89,7 @@ fn test_candid_service_arg_validation() {
         (
             "Complex service with two arguments (missing 2nd arg)",
             complex_service,
-            "(record {})",
+            Some("(record {})".to_string()),
             Err(CandidServiceArgValidationError::WrongArgumentCount(
                 dummy_error_text.clone(),
             )),
@@ -75,7 +97,7 @@ fn test_candid_service_arg_validation() {
         (
             "Complex service with two arguments (missing both args)",
             complex_service,
-            "()",
+            Some("()".to_string()),
             Err(CandidServiceArgValidationError::WrongArgumentCount(
                 dummy_error_text.clone(),
             )),
@@ -87,7 +109,7 @@ fn test_candid_service_arg_validation() {
                     g : () -> (int) query;
                 }
             "#,
-            "((11 : nat32), record {})",
+            Some("((11 : nat32), record {})".to_string()),
             Err(CandidServiceArgValidationError::SubtypingErrors(
                 dummy_error_text.clone(),
             )),
@@ -99,7 +121,7 @@ fn test_candid_service_arg_validation() {
                     g : () -> (int) query;
                 }
             "#,
-            "(record { foobar = opt (1984 : nat); foo = opt (42 : nat) })",
+            Some("(record { foobar = opt (1984 : nat); foo = opt (42 : nat) })".to_string()),
             Ok(()),
         ),
         (
@@ -109,14 +131,13 @@ fn test_candid_service_arg_validation() {
                     g : () -> (int) query;
                 }
             "#,
-            "(record { bar = (1984 : nat) })",
+            Some("(record { bar = (1984 : nat) })".to_string()),
             Err(CandidServiceArgValidationError::SubtypingErrors(
                 dummy_error_text,
             )),
         ),
     ] {
-        let observed_result =
-            validate_upgrade_args(candid_service.to_string(), upgrade_arg.to_string());
+        let observed_result = validate_upgrade_args(candid_service.to_string(), upgrade_arg);
 
         match (observed_result, expected_result) {
             (Ok(_), Ok(())) => (),

--- a/rs/nervous_system/candid_utils/src/validation/tests.rs
+++ b/rs/nervous_system/candid_utils/src/validation/tests.rs
@@ -137,7 +137,7 @@ fn test_candid_service_arg_validation() {
             )),
         ),
     ] {
-        let observed_result = validate_upgrade_args(candid_service.to_string(), upgrade_arg);
+        let observed_result = encode_upgrade_args(candid_service.to_string(), upgrade_arg);
 
         match (observed_result, expected_result) {
             (Ok(_), Ok(())) => (),


### PR DESCRIPTION
This PR makes the `validate_upgrade_args` function take `upgrade_args: Option<String>` rather than `upgrade_args: String`, making it simpler for the caller to decide if a given service expects no arguments.

Also, we add `encode_upgrade_args_unsafe` which can be used when a Candid service is not available, and thus the upgrade argument cannot be validated against an expected input type.