### PR TITLE
feat(nns): list_neurons supports querying by subaccount

### DIFF
--- a/rs/nervous_system/integration_tests/src/pocket_ic_helpers.rs
+++ b/rs/nervous_system/integration_tests/src/pocket_ic_helpers.rs
@@ -20,7 +20,7 @@ use ic_nns_constants::{
 use ic_nns_governance_api::pb::v1::{
     install_code::CanisterInstallMode, manage_neuron_response, CreateServiceNervousSystem,
     ExecuteNnsFunction, GetNeuronsFundAuditInfoRequest, GetNeuronsFundAuditInfoResponse,
-    InstallCodeRequest, ListNeurons, ListNeuronsResponse, MakeProposalRequest,
+    InstallCodeRequest, ListNeuronsProto, ListNeuronsResponse, MakeProposalRequest,
     ManageNeuronCommandRequest, ManageNeuronRequest, ManageNeuronResponse, NetworkEconomics,
     NnsFunction, ProposalActionRequest, ProposalInfo, Topic,
 };
@@ -1101,7 +1101,7 @@ pub mod nns {
                     Principal::from(sender),
                     "list_neurons",
                     // Instead of listing neurons by ID, opt for listing all neurons readable by `sender`.
-                    Encode!(&ListNeurons {
+                    Encode!(&ListNeuronsProto {
                         neuron_ids: vec![],
                         include_neurons_readable_by_caller: true,
                         include_empty_neurons_readable_by_caller: Some(true),

--- a/rs/nervous_system/integration_tests/src/pocket_ic_helpers.rs
+++ b/rs/nervous_system/integration_tests/src/pocket_ic_helpers.rs
@@ -20,7 +20,7 @@ use ic_nns_constants::{
 use ic_nns_governance_api::pb::v1::{
     install_code::CanisterInstallMode, manage_neuron_response, CreateServiceNervousSystem,
     ExecuteNnsFunction, GetNeuronsFundAuditInfoRequest, GetNeuronsFundAuditInfoResponse,
-    InstallCodeRequest, ListNeuronsProto, ListNeuronsResponse, MakeProposalRequest,
+    InstallCodeRequest, ListNeurons, ListNeuronsResponse, MakeProposalRequest,
     ManageNeuronCommandRequest, ManageNeuronRequest, ManageNeuronResponse, NetworkEconomics,
     NnsFunction, ProposalActionRequest, ProposalInfo, Topic,
 };
@@ -1101,7 +1101,7 @@ pub mod nns {
                     Principal::from(sender),
                     "list_neurons",
                     // Instead of listing neurons by ID, opt for listing all neurons readable by `sender`.
-                    Encode!(&ListNeuronsProto {
+                    Encode!(&ListNeurons {
                         neuron_ids: vec![],
                         include_neurons_readable_by_caller: true,
                         include_empty_neurons_readable_by_caller: Some(true),

--- a/rs/nervous_system/integration_tests/src/pocket_ic_helpers.rs
+++ b/rs/nervous_system/integration_tests/src/pocket_ic_helpers.rs
@@ -1107,7 +1107,9 @@ pub mod nns {
                         include_empty_neurons_readable_by_caller: Some(true),
                         include_public_neurons_in_full_neurons: None,
                         page_number: None,
-                        page_size: None
+                        page_size: None,
+                        neuron_subaccounts: vec![],
+                        p
                     })
                     .unwrap(),
                 )

--- a/rs/nervous_system/integration_tests/src/pocket_ic_helpers.rs
+++ b/rs/nervous_system/integration_tests/src/pocket_ic_helpers.rs
@@ -1109,7 +1109,6 @@ pub mod nns {
                         page_number: None,
                         page_size: None,
                         neuron_subaccounts: vec![],
-                        p
                     })
                     .unwrap(),
                 )

--- a/rs/nervous_system/integration_tests/src/pocket_ic_helpers.rs
+++ b/rs/nervous_system/integration_tests/src/pocket_ic_helpers.rs
@@ -1108,7 +1108,7 @@ pub mod nns {
                         include_public_neurons_in_full_neurons: None,
                         page_number: None,
                         page_size: None,
-                        neuron_subaccounts: vec![],
+                        neuron_subaccounts: None,
                     })
                     .unwrap(),
                 )

--- a/rs/nns/governance/api/src/ic_nns_governance.pb.v1.rs
+++ b/rs/nns/governance/api/src/ic_nns_governance.pb.v1.rs
@@ -3526,7 +3526,7 @@ pub struct ListNeurons {
     pub neuron_subaccounts: Vec<list_neurons::NeuronSubaccount>,
 }
 
-mod list_neurons {
+pub mod list_neurons {
     /// A type for the request to list neurons.
     #[derive(candid::CandidType, candid::Deserialize, serde::Serialize, comparable::Comparable)]
     #[allow(clippy::derive_partial_eq_without_eq)]

--- a/rs/nns/governance/api/src/ic_nns_governance.pb.v1.rs
+++ b/rs/nns/governance/api/src/ic_nns_governance.pb.v1.rs
@@ -3520,7 +3520,24 @@ pub struct ListNeurons {
     /// If not set, this defaults to MAX_LIST_NEURONS_RESULTS.
     #[prost(uint64, optional, tag = "6")]
     pub page_size: Option<u64>,
+    /// A list of neurons by subaccounts to return in the response.  If the neurons are not
+    /// found by subaccount, no error is returned, but the page will still be returned.
+    #[prost(message, repeated, tag = "7")]
+    pub neuron_subaccounts: Vec<list_neurons::NeuronSubaccount>,
 }
+
+mod list_neurons {
+    /// A type for the request to list neurons.
+    #[derive(candid::CandidType, candid::Deserialize, serde::Serialize, comparable::Comparable)]
+    #[allow(clippy::derive_partial_eq_without_eq)]
+    #[derive(Clone, PartialEq, ::prost::Message)]
+    pub struct NeuronSubaccount {
+        #[prost(bytes = "vec", tag = "1")]
+        #[serde(with = "serde_bytes")]
+        pub subaccount: Vec<u8>,
+    }
+}
+
 /// A response to a `ListNeurons` request.
 ///
 /// The "requested list" is described in `ListNeurons`.

--- a/rs/nns/governance/api/src/ic_nns_governance.pb.v1.rs
+++ b/rs/nns/governance/api/src/ic_nns_governance.pb.v1.rs
@@ -3523,7 +3523,7 @@ pub struct ListNeurons {
     /// A list of neurons by subaccounts to return in the response.  If the neurons are not
     /// found by subaccount, no error is returned, but the page will still be returned.
     #[prost(message, repeated, tag = "7")]
-    pub neuron_subaccounts: Vec<list_neurons::NeuronSubaccount>,
+    pub neuron_subaccounts: Option<Vec<list_neurons::NeuronSubaccount>>,
 }
 
 pub mod list_neurons {

--- a/rs/nns/governance/api/src/ic_nns_governance.pb.v1.rs
+++ b/rs/nns/governance/api/src/ic_nns_governance.pb.v1.rs
@@ -3463,25 +3463,13 @@ pub struct ListProposalInfo {
 pub struct ListProposalInfoResponse {
     pub proposal_info: Vec<ProposalInfo>,
 }
-/// A request to list neurons. The "requested list", i.e., the list of
-/// neuron IDs to retrieve information about, is the union of the list
-/// of neurons listed in `neuron_ids` and, if `caller_neurons` is true,
-/// the list of neuron IDs of neurons for which the caller is the
-/// controller or one of the hot keys.
+
+/// The same as ListNeurons, but only used in list_neurons_pb, which is deprecated.
+/// This is temporarily split out so that the API changes to list_neurons do not have to
+/// follow both candid and protobuf standards for changes, which simplifies the API design
+/// considerably.
 ///
-/// Paging is available if the result set is larger than `MAX_LIST_NEURONS_RESULTS`,
-/// which is currently 500 neurons.  If you are unsure of the number of results in a set,
-/// you can use the `total_pages_available` field in the response to determine how many
-/// additional pages need to be queried.  It will be based on your `page_size` parameter.  
-/// When paging through results, it is good to keep in mind that newly inserted neurons
-/// could be missed if they are inserted between calls to pages, and this could result in missing
-/// a neuron in the combined responses.
-///
-/// If a user provides neuron_ids that do not exist in the request, there is no guarantee that
-/// each page will contain the exactly the page size, even if it is not the final request.  This is
-/// because neurons are retrieved by their neuron_id, and no additional checks are made on the
-/// validity of the neuron_ids provided by the user before deciding which sets of neuron_ids
-/// will be returned in the current page.
+/// This type should be removed when list_neurons_pb is finally deprecated.
 #[derive(candid::CandidType, candid::Deserialize, serde::Serialize, comparable::Comparable)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -3520,7 +3508,25 @@ pub struct ListNeuronsProto {
     #[prost(uint64, optional, tag = "6")]
     pub page_size: Option<u64>,
 }
-
+/// A request to list neurons. The "requested list", i.e., the list of
+/// neuron IDs to retrieve information about, is the union of the list
+/// of neurons listed in `neuron_ids` and, if `caller_neurons` is true,
+/// the list of neuron IDs of neurons for which the caller is the
+/// controller or one of the hot keys.
+///
+/// Paging is available if the result set is larger than `MAX_LIST_NEURONS_RESULTS`,
+/// which is currently 500 neurons.  If you are unsure of the number of results in a set,
+/// you can use the `total_pages_available` field in the response to determine how many
+/// additional pages need to be queried.  It will be based on your `page_size` parameter.  
+/// When paging through results, it is good to keep in mind that newly inserted neurons
+/// could be missed if they are inserted between calls to pages, and this could result in missing
+/// a neuron in the combined responses.
+///
+/// If a user provides neuron_ids that do not exist in the request, there is no guarantee that
+/// each page will contain the exactly the page size, even if it is not the final request.  This is
+/// because neurons are retrieved by their neuron_id, and no additional checks are made on the
+/// validity of the neuron_ids provided by the user before deciding which sets of neuron_ids
+/// will be returned in the current page.
 #[derive(candid::CandidType, candid::Deserialize, serde::Serialize, comparable::Comparable)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, Debug, Default, PartialEq)]

--- a/rs/nns/governance/api/src/ic_nns_governance.pb.v1.rs
+++ b/rs/nns/governance/api/src/ic_nns_governance.pb.v1.rs
@@ -3484,7 +3484,7 @@ pub struct ListProposalInfoResponse {
 /// will be returned in the current page.
 #[derive(candid::CandidType, candid::Deserialize, serde::Serialize, comparable::Comparable)]
 #[allow(clippy::derive_partial_eq_without_eq)]
-#[derive(Clone, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct ListNeurons {
     /// The neurons to get information about. The "requested list"
     /// contains all of these neuron IDs.
@@ -3523,9 +3523,8 @@ pub mod list_neurons {
     /// A type for the request to list neurons.
     #[derive(candid::CandidType, candid::Deserialize, serde::Serialize, comparable::Comparable)]
     #[allow(clippy::derive_partial_eq_without_eq)]
-    #[derive(Clone, PartialEq, ::prost::Message)]
+    #[derive(Clone, Debug, PartialEq)]
     pub struct NeuronSubaccount {
-        #[prost(bytes = "vec", tag = "1")]
         #[serde(with = "serde_bytes")]
         pub subaccount: Vec<u8>,
     }

--- a/rs/nns/governance/api/src/ic_nns_governance.pb.v1.rs
+++ b/rs/nns/governance/api/src/ic_nns_governance.pb.v1.rs
@@ -3487,6 +3487,7 @@ pub struct ListNeuronsProto {
     /// `neuron_ids` field, then the neuron will be included in the response regardless of the value
     /// of this field. The default value is false (i.e. `None` is treated as `Some(false)`). Here,
     /// being "empty" means 0 stake, 0 maturity and 0 staked maturity.
+    #[prost(bool, optional, tag = "3")]
     pub include_empty_neurons_readable_by_caller: Option<bool>,
     /// If this is set to true, and a neuron in the "requested list" has its
     /// visibility set to public, then, it will (also) be included in the
@@ -3539,10 +3540,9 @@ pub struct ListNeurons {
     pub include_neurons_readable_by_caller: bool,
     /// Whether to also include empty neurons readable by the caller. This field only has an effect
     /// when `include_neurons_readable_by_caller` is true. If a neuron's id already exists in the
-    /// `neuron_ids` field, then the neuron will be included in the response regardless of the value of
-    /// this field. Since the previous behavior was to always include empty neurons readable by caller,
-    /// if this field is not provided, it defaults to true, in order to maintain backwards
-    /// compatibility. Here, being "empty" means 0 stake, 0 maturity and 0 staked maturity.
+    /// `neuron_ids` field, then the neuron will be included in the response regardless of the value
+    /// of this field. The default value is false (i.e. `None` is treated as `Some(false)`). Here,
+    /// being "empty" means 0 stake, 0 maturity and 0 staked maturity.
     pub include_empty_neurons_readable_by_caller: Option<bool>,
     /// If this is set to true, and a neuron in the "requested list" has its
     /// visibility set to public, then, it will (also) be included in the

--- a/rs/nns/governance/api/src/ic_nns_governance.pb.v1.rs
+++ b/rs/nns/governance/api/src/ic_nns_governance.pb.v1.rs
@@ -3484,22 +3484,19 @@ pub struct ListProposalInfoResponse {
 /// will be returned in the current page.
 #[derive(candid::CandidType, candid::Deserialize, serde::Serialize, comparable::Comparable)]
 #[allow(clippy::derive_partial_eq_without_eq)]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq)]
 pub struct ListNeurons {
     /// The neurons to get information about. The "requested list"
     /// contains all of these neuron IDs.
-    #[prost(fixed64, repeated, packed = "false", tag = "1")]
     pub neuron_ids: Vec<u64>,
     /// If true, the "requested list" also contains the neuron ID of the
     /// neurons that the calling principal is authorized to read.
-    #[prost(bool, tag = "2")]
     pub include_neurons_readable_by_caller: bool,
     /// Whether to also include empty neurons readable by the caller. This field only has an effect
     /// when `include_neurons_readable_by_caller` is true. If a neuron's id already exists in the
     /// `neuron_ids` field, then the neuron will be included in the response regardless of the value
     /// of this field. The default value is false (i.e. `None` is treated as `Some(false)`). Here,
     /// being "empty" means 0 stake, 0 maturity and 0 staked maturity.
-    #[prost(bool, optional, tag = "3")]
     pub include_empty_neurons_readable_by_caller: Option<bool>,
     /// If this is set to true, and a neuron in the "requested list" has its
     /// visibility set to public, then, it will (also) be included in the
@@ -3509,20 +3506,16 @@ pub struct ListNeurons {
     /// requested list. In general, you probably want to set this to true, but
     /// since this feature was added later, it is opt in to avoid confusing
     /// existing (unmigrated) callers.
-    #[prost(bool, optional, tag = "4")]
     pub include_public_neurons_in_full_neurons: Option<bool>,
     /// If this is set, we return the batch of neurons at a given page, using the `page_size` to
     /// determine how many neurons are returned in each page.
-    #[prost(uint64, optional, tag = "5")]
     pub page_number: Option<u64>,
     /// If this is set, we use the page limit provided to determine how large pages will be.
     /// This cannot be greater than MAX_LIST_NEURONS_RESULTS, which is set to 500.
     /// If not set, this defaults to MAX_LIST_NEURONS_RESULTS.
-    #[prost(uint64, optional, tag = "6")]
     pub page_size: Option<u64>,
     /// A list of neurons by subaccounts to return in the response.  If the neurons are not
     /// found by subaccount, no error is returned, but the page will still be returned.
-    #[prost(message, repeated, tag = "7")]
     pub neuron_subaccounts: Option<Vec<list_neurons::NeuronSubaccount>>,
 }
 

--- a/rs/nns/governance/api/src/ic_nns_governance.pb.v1.rs
+++ b/rs/nns/governance/api/src/ic_nns_governance.pb.v1.rs
@@ -3485,7 +3485,7 @@ pub struct ListProposalInfoResponse {
 #[derive(candid::CandidType, candid::Deserialize, serde::Serialize, comparable::Comparable)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct ListNeurons {
+pub struct ListNeuronsProto {
     /// The neurons to get information about. The "requested list"
     /// contains all of these neuron IDs.
     #[prost(fixed64, repeated, packed = "false", tag = "1")]
@@ -3519,9 +3519,43 @@ pub struct ListNeurons {
     /// If not set, this defaults to MAX_LIST_NEURONS_RESULTS.
     #[prost(uint64, optional, tag = "6")]
     pub page_size: Option<u64>,
+}
+
+#[derive(candid::CandidType, candid::Deserialize, serde::Serialize, comparable::Comparable)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, Debug, PartialEq)]
+pub struct ListNeurons {
+    /// The neurons to get information about. The "requested list"
+    /// contains all of these neuron IDs.
+    pub neuron_ids: Vec<u64>,
+    /// If true, the "requested list" also contains the neuron ID of the
+    /// neurons that the calling principal is authorized to read.
+    pub include_neurons_readable_by_caller: bool,
+    /// Whether to also include empty neurons readable by the caller. This field only has an effect
+    /// when `include_neurons_readable_by_caller` is true. If a neuron's id already exists in the
+    /// `neuron_ids` field, then the neuron will be included in the response regardless of the value of
+    /// this field. Since the previous behavior was to always include empty neurons readable by caller,
+    /// if this field is not provided, it defaults to true, in order to maintain backwards
+    /// compatibility. Here, being "empty" means 0 stake, 0 maturity and 0 staked maturity.
+    pub include_empty_neurons_readable_by_caller: Option<bool>,
+    /// If this is set to true, and a neuron in the "requested list" has its
+    /// visibility set to public, then, it will (also) be included in the
+    /// full_neurons field in the response (which is of type ListNeuronsResponse).
+    /// Note that this has no effect on which neurons are in the "requested list".
+    /// In particular, this does not cause all public neurons to become part of the
+    /// requested list. In general, you probably want to set this to true, but
+    /// since this feature was added later, it is opt in to avoid confusing
+    /// existing (unmigrated) callers.
+    pub include_public_neurons_in_full_neurons: Option<bool>,
+    /// If this is set, we return the batch of neurons at a given page, using the `page_size` to
+    /// determine how many neurons are returned in each page.
+    pub page_number: Option<u64>,
+    /// If this is set, we use the page limit provided to determine how large pages will be.
+    /// This cannot be greater than MAX_LIST_NEURONS_RESULTS, which is set to 500.
+    /// If not set, this defaults to MAX_LIST_NEURONS_RESULTS.
+    pub page_size: Option<u64>,
     /// A list of neurons by subaccounts to return in the response.  If the neurons are not
     /// found by subaccount, no error is returned, but the page will still be returned.
-    #[prost(message, optional, repeated, tag = "7")]
     pub neuron_subaccounts: Option<Vec<list_neurons::NeuronSubaccount>>,
 }
 
@@ -3529,9 +3563,8 @@ pub mod list_neurons {
     /// A type for the request to list neurons.
     #[derive(candid::CandidType, candid::Deserialize, serde::Serialize, comparable::Comparable)]
     #[allow(clippy::derive_partial_eq_without_eq)]
-    #[derive(Clone, PartialEq, ::prost::Message)]
+    #[derive(Clone, Debug, PartialEq)]
     pub struct NeuronSubaccount {
-        #[prost(bytes = "vec", tag = "1")]
         #[serde(with = "serde_bytes")]
         pub subaccount: Vec<u8>,
     }

--- a/rs/nns/governance/api/src/ic_nns_governance.pb.v1.rs
+++ b/rs/nns/governance/api/src/ic_nns_governance.pb.v1.rs
@@ -3484,13 +3484,15 @@ pub struct ListProposalInfoResponse {
 /// will be returned in the current page.
 #[derive(candid::CandidType, candid::Deserialize, serde::Serialize, comparable::Comparable)]
 #[allow(clippy::derive_partial_eq_without_eq)]
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ListNeurons {
     /// The neurons to get information about. The "requested list"
     /// contains all of these neuron IDs.
+    #[prost(fixed64, repeated, packed = "false", tag = "1")]
     pub neuron_ids: Vec<u64>,
     /// If true, the "requested list" also contains the neuron ID of the
     /// neurons that the calling principal is authorized to read.
+    #[prost(bool, tag = "2")]
     pub include_neurons_readable_by_caller: bool,
     /// Whether to also include empty neurons readable by the caller. This field only has an effect
     /// when `include_neurons_readable_by_caller` is true. If a neuron's id already exists in the
@@ -3506,16 +3508,20 @@ pub struct ListNeurons {
     /// requested list. In general, you probably want to set this to true, but
     /// since this feature was added later, it is opt in to avoid confusing
     /// existing (unmigrated) callers.
+    #[prost(bool, optional, tag = "4")]
     pub include_public_neurons_in_full_neurons: Option<bool>,
     /// If this is set, we return the batch of neurons at a given page, using the `page_size` to
     /// determine how many neurons are returned in each page.
+    #[prost(uint64, optional, tag = "5")]
     pub page_number: Option<u64>,
     /// If this is set, we use the page limit provided to determine how large pages will be.
     /// This cannot be greater than MAX_LIST_NEURONS_RESULTS, which is set to 500.
     /// If not set, this defaults to MAX_LIST_NEURONS_RESULTS.
+    #[prost(uint64, optional, tag = "6")]
     pub page_size: Option<u64>,
     /// A list of neurons by subaccounts to return in the response.  If the neurons are not
     /// found by subaccount, no error is returned, but the page will still be returned.
+    #[prost(message, optional, repeated, tag = "7")]
     pub neuron_subaccounts: Option<Vec<list_neurons::NeuronSubaccount>>,
 }
 
@@ -3523,8 +3529,9 @@ pub mod list_neurons {
     /// A type for the request to list neurons.
     #[derive(candid::CandidType, candid::Deserialize, serde::Serialize, comparable::Comparable)]
     #[allow(clippy::derive_partial_eq_without_eq)]
-    #[derive(Clone, Debug, PartialEq)]
+    #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct NeuronSubaccount {
+        #[prost(bytes = "vec", tag = "1")]
         #[serde(with = "serde_bytes")]
         pub subaccount: Vec<u8>,
     }

--- a/rs/nns/governance/api/src/ic_nns_governance.pb.v1.rs
+++ b/rs/nns/governance/api/src/ic_nns_governance.pb.v1.rs
@@ -3523,7 +3523,7 @@ pub struct ListNeuronsProto {
 
 #[derive(candid::CandidType, candid::Deserialize, serde::Serialize, comparable::Comparable)]
 #[allow(clippy::derive_partial_eq_without_eq)]
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Default, PartialEq)]
 pub struct ListNeurons {
     /// The neurons to get information about. The "requested list"
     /// contains all of these neuron IDs.

--- a/rs/nns/governance/api/src/pb.rs
+++ b/rs/nns/governance/api/src/pb.rs
@@ -1,8 +1,8 @@
 use crate::pb::v1::{
     governance::migration::MigrationStatus, governance_error::ErrorType, neuron::DissolveState,
-    CreateServiceNervousSystem, GovernanceError, NetworkEconomics, Neuron, NeuronState,
-    NeuronsFundEconomics, NeuronsFundMatchedFundingCurveCoefficients, VotingPowerEconomics,
-    XdrConversionRate,
+    CreateServiceNervousSystem, GovernanceError, ListNeurons, ListNeuronsProto, NetworkEconomics,
+    Neuron, NeuronState, NeuronsFundEconomics, NeuronsFundMatchedFundingCurveCoefficients,
+    VotingPowerEconomics, XdrConversionRate,
 };
 use ic_nervous_system_common::{ONE_DAY_SECONDS, ONE_MONTH_SECONDS};
 use ic_nervous_system_proto::pb::v1::{Decimal, Duration, GlobalTimeOfDay, Percentage};
@@ -262,5 +262,22 @@ impl CreateServiceNervousSystem {
             .ok_or("`duration` should not be None")?;
 
         Ok((swap_start_timestamp_seconds, swap_due_timestamp_seconds))
+    }
+}
+
+impl From<ListNeuronsProto> for ListNeurons {
+    fn from(list_neurons_proto: ListNeuronsProto) -> Self {
+        Self {
+            neuron_ids: list_neurons_proto.neuron_ids,
+            include_neurons_readable_by_caller: list_neurons_proto
+                .include_neurons_readable_by_caller,
+            include_empty_neurons_readable_by_caller: list_neurons_proto
+                .include_empty_neurons_readable_by_caller,
+            include_public_neurons_in_full_neurons: list_neurons_proto
+                .include_public_neurons_in_full_neurons,
+            page_number: list_neurons_proto.page_number,
+            page_size: list_neurons_proto.page_size,
+            neuron_subaccounts: None,
+        }
     }
 }

--- a/rs/nns/governance/canbench/canbench_results.yml
+++ b/rs/nns/governance/canbench/canbench_results.yml
@@ -1,169 +1,181 @@
 benches:
   add_neuron_active_maximum:
     total:
-      instructions: 42752796
+      instructions: 42752810
       heap_increase: 1
       stable_memory_increase: 0
     scopes: {}
   add_neuron_active_typical:
     total:
-      instructions: 2170658
+      instructions: 2170672
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   add_neuron_inactive_maximum:
     total:
-      instructions: 112624375
+      instructions: 112624946
       heap_increase: 1
       stable_memory_increase: 0
     scopes: {}
   add_neuron_inactive_typical:
     total:
-      instructions: 8497036
+      instructions: 8497607
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   cascading_vote_all_heap:
     total:
-      instructions: 35676146
+      instructions: 35610228
       heap_increase: 0
       stable_memory_increase: 128
     scopes: {}
   cascading_vote_heap_neurons_stable_index:
     total:
-      instructions: 61811185
+      instructions: 61744033
       heap_increase: 0
       stable_memory_increase: 128
     scopes: {}
   cascading_vote_stable_everything:
     total:
-      instructions: 188611915
+      instructions: 189084050
       heap_increase: 0
       stable_memory_increase: 128
     scopes: {}
   cascading_vote_stable_neurons_with_heap_index:
     total:
-      instructions: 162343480
+      instructions: 162816849
       heap_increase: 0
       stable_memory_increase: 128
     scopes: {}
   centralized_following_all_stable:
     total:
-      instructions: 78265237
+      instructions: 78519736
       heap_increase: 0
       stable_memory_increase: 128
     scopes: {}
   compute_ballots_for_new_proposal_with_stable_neurons:
     total:
-      instructions: 2230000
+      instructions: 2265911
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   draw_maturity_from_neurons_fund_heap:
     total:
-      instructions: 7656798
+      instructions: 7607998
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   draw_maturity_from_neurons_fund_stable:
     total:
-      instructions: 12339498
+      instructions: 12444384
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   list_active_neurons_fund_neurons_heap:
     total:
-      instructions: 435463
+      instructions: 435492
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   list_active_neurons_fund_neurons_stable:
     total:
-      instructions: 2820000
+      instructions: 2819667
       heap_increase: 0
+      stable_memory_increase: 0
+    scopes: {}
+  list_neurons_by_subaccount_heap:
+    total:
+      instructions: 7551696
+      heap_increase: 9
+      stable_memory_increase: 0
+    scopes: {}
+  list_neurons_by_subaccount_stable:
+    total:
+      instructions: 111661652
+      heap_increase: 5
       stable_memory_increase: 0
     scopes: {}
   list_neurons_heap:
     total:
-      instructions: 4950000
+      instructions: 4963821
       heap_increase: 9
       stable_memory_increase: 0
     scopes: {}
   list_neurons_ready_to_unstake_maturity_heap:
     total:
-      instructions: 158253
+      instructions: 158195
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   list_neurons_ready_to_unstake_maturity_stable:
     total:
-      instructions: 43300000
+      instructions: 43332558
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   list_neurons_stable:
     total:
-      instructions: 113606723
+      instructions: 113665560
       heap_increase: 5
       stable_memory_increase: 0
     scopes: {}
   list_proposals:
     total:
-      instructions: 126040
+      instructions: 126041
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   list_ready_to_spawn_neuron_ids_heap:
     total:
-      instructions: 132847
+      instructions: 132789
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   list_ready_to_spawn_neuron_ids_stable:
     total:
-      instructions: 43270000
+      instructions: 43304554
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   neuron_data_validation_heap:
     total:
-      instructions: 406853184
+      instructions: 407435747
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   neuron_data_validation_stable:
     total:
-      instructions: 362648372
+      instructions: 363402784
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   neuron_metrics_calculation_heap:
     total:
-      instructions: 1498869
+      instructions: 1485668
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   neuron_metrics_calculation_stable:
     total:
-      instructions: 3027495
+      instructions: 3085347
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   range_neurons_performance:
     total:
-      instructions: 56447340
+      instructions: 56514456
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   single_vote_all_stable:
     total:
-      instructions: 2805871
+      instructions: 2806911
       heap_increase: 0
       stable_memory_increase: 128
     scopes: {}
   update_recent_ballots_stable_memory:
     total:
-      instructions: 274000
+      instructions: 275035
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}

--- a/rs/nns/governance/canister/canister.rs
+++ b/rs/nns/governance/canister/canister.rs
@@ -954,7 +954,6 @@ fn list_neurons_pb() {
     ic_cdk::setup();
     let request =
         ListNeuronsProto::decode(&arg_data_raw()[..]).expect("Could not decode ListNeuronsProto");
-    // New fields are not supported in list_neurons_pb and it is deprecated anyway.
     let candid_request = ListNeurons::from(request);
     let res: ListNeuronsResponse = list_neurons(candid_request);
     let mut buf = Vec::with_capacity(res.encoded_len());

--- a/rs/nns/governance/canister/canister.rs
+++ b/rs/nns/governance/canister/canister.rs
@@ -43,7 +43,7 @@ use ic_nns_governance_api::{
         manage_neuron_response, ClaimOrRefreshNeuronFromAccount,
         ClaimOrRefreshNeuronFromAccountResponse, GetNeuronsFundAuditInfoRequest,
         GetNeuronsFundAuditInfoResponse, Governance as ApiGovernanceProto, GovernanceError,
-        ListKnownNeuronsResponse, ListNeuronsProto, ListNeuronsResponse,
+        ListKnownNeuronsResponse, ListNeurons, ListNeuronsProto, ListNeuronsResponse,
         ListNodeProviderRewardsRequest, ListNodeProviderRewardsResponse, ListNodeProvidersResponse,
         ListProposalInfo, ListProposalInfoResponse, ManageNeuronCommandRequest,
         ManageNeuronRequest, ManageNeuronResponse, MonthlyNodeProviderRewards, NetworkEconomics,
@@ -67,7 +67,6 @@ use std::{
 
 #[cfg(not(feature = "tla"))]
 use ic_nervous_system_canisters::ledger::IcpLedgerCanister;
-use ic_nns_governance_api::pb::v1::ListNeurons;
 
 #[cfg(feature = "tla")]
 mod tla_ledger;
@@ -954,7 +953,7 @@ fn list_neurons_pb() {
 
     ic_cdk::setup();
     let request =
-        ListNeuronsProto::decode(&arg_data_raw()[..]).expect("Could not decode ListNeurons");
+        ListNeuronsProto::decode(&arg_data_raw()[..]).expect("Could not decode ListNeuronsProto");
     // New fields are not supported in list_neurons_pb and it is deprecated anyway.
     let candid_request = ListNeurons::from(request);
     let res: ListNeuronsResponse = list_neurons(candid_request);

--- a/rs/nns/governance/canister/canister.rs
+++ b/rs/nns/governance/canister/canister.rs
@@ -43,11 +43,11 @@ use ic_nns_governance_api::{
         manage_neuron_response, ClaimOrRefreshNeuronFromAccount,
         ClaimOrRefreshNeuronFromAccountResponse, GetNeuronsFundAuditInfoRequest,
         GetNeuronsFundAuditInfoResponse, Governance as ApiGovernanceProto, GovernanceError,
-        ListKnownNeuronsResponse, ListNeurons, ListNeuronsResponse, ListNodeProviderRewardsRequest,
-        ListNodeProviderRewardsResponse, ListNodeProvidersResponse, ListProposalInfo,
-        ListProposalInfoResponse, ManageNeuronCommandRequest, ManageNeuronRequest,
-        ManageNeuronResponse, MonthlyNodeProviderRewards, NetworkEconomics, Neuron, NeuronInfo,
-        NodeProvider, Proposal, ProposalInfo, RestoreAgingSummary, RewardEvent,
+        ListKnownNeuronsResponse, ListNeuronsProto, ListNeuronsResponse,
+        ListNodeProviderRewardsRequest, ListNodeProviderRewardsResponse, ListNodeProvidersResponse,
+        ListProposalInfo, ListProposalInfoResponse, ManageNeuronCommandRequest,
+        ManageNeuronRequest, ManageNeuronResponse, MonthlyNodeProviderRewards, NetworkEconomics,
+        Neuron, NeuronInfo, NodeProvider, Proposal, ProposalInfo, RestoreAgingSummary, RewardEvent,
         SettleCommunityFundParticipation, SettleNeuronsFundParticipationRequest,
         SettleNeuronsFundParticipationResponse, UpdateNodeProvider, Vote,
     },
@@ -67,6 +67,7 @@ use std::{
 
 #[cfg(not(feature = "tla"))]
 use ic_nervous_system_canisters::ledger::IcpLedgerCanister;
+use ic_nns_governance_api::pb::v1::ListNeurons;
 
 #[cfg(feature = "tla")]
 mod tla_ledger;
@@ -952,8 +953,11 @@ fn list_neurons_pb() {
     );
 
     ic_cdk::setup();
-    let request = ListNeurons::decode(&arg_data_raw()[..]).expect("Could not decode ListNeurons");
-    let res: ListNeuronsResponse = list_neurons(request);
+    let request =
+        ListNeuronsProto::decode(&arg_data_raw()[..]).expect("Could not decode ListNeurons");
+    // New fields are not supported in list_neurons_pb and it is deprecated anyway.
+    let candid_request = ListNeurons::from(request);
+    let res: ListNeuronsResponse = list_neurons(candid_request);
     let mut buf = Vec::with_capacity(res.encoded_len());
     res.encode(&mut buf)
         .map_err(|e| e.to_string())

--- a/rs/nns/governance/canister/governance.did
+++ b/rs/nns/governance/canister/governance.did
@@ -450,6 +450,11 @@ type ListNeurons = record {
 
   page_number: opt nat64;
   page_size: opt nat64;
+  neuron_subaccounts: vec NeuronSubaccount;
+};
+
+type NeuronSubaccount = record {
+  subaccount : blob;
 };
 
 // Output of the list_neurons method.

--- a/rs/nns/governance/canister/governance.did
+++ b/rs/nns/governance/canister/governance.did
@@ -450,7 +450,7 @@ type ListNeurons = record {
 
   page_number: opt nat64;
   page_size: opt nat64;
-  neuron_subaccounts: vec NeuronSubaccount;
+  neuron_subaccounts: opt vec NeuronSubaccount;
 };
 
 type NeuronSubaccount = record {

--- a/rs/nns/governance/canister/governance_test.did
+++ b/rs/nns/governance/canister/governance_test.did
@@ -440,7 +440,7 @@ type ListNeurons = record {
   include_neurons_readable_by_caller : bool;
   page_number: opt nat64;
   page_size: opt nat64;
-  neuron_subaccounts: vec NeuronSubaccount;
+  neuron_subaccounts: opt vec NeuronSubaccount;
 };
 
 type NeuronSubaccount = record {

--- a/rs/nns/governance/canister/governance_test.did
+++ b/rs/nns/governance/canister/governance_test.did
@@ -440,6 +440,11 @@ type ListNeurons = record {
   include_neurons_readable_by_caller : bool;
   page_number: opt nat64;
   page_size: opt nat64;
+  neuron_subaccounts: vec NeuronSubaccount;
+};
+
+type NeuronSubaccount = record {
+subaccount : blob;
 };
 
 type ListNeuronsResponse = record {

--- a/rs/nns/governance/canister/governance_test.did
+++ b/rs/nns/governance/canister/governance_test.did
@@ -444,7 +444,7 @@ type ListNeurons = record {
 };
 
 type NeuronSubaccount = record {
-subaccount : blob;
+  subaccount : blob;
 };
 
 type ListNeuronsResponse = record {

--- a/rs/nns/governance/src/governance.rs
+++ b/rs/nns/governance/src/governance.rs
@@ -100,7 +100,7 @@ use ic_nns_governance_api::{
     pb::v1::{
         self as api,
         manage_neuron_response::{self, MergeMaturityResponse, StakeMaturityResponse},
-        CreateServiceNervousSystem as ApiCreateServiceNervousSystem, ListNeurons,
+        CreateServiceNervousSystem as ApiCreateServiceNervousSystem, ListNeuronsProto,
         ListNeuronsResponse, ListProposalInfoResponse, ManageNeuronResponse, NeuronInfo,
         ProposalInfo,
     },
@@ -2219,12 +2219,12 @@ impl Governance {
     /// See `ListNeurons`.
     pub fn list_neurons(
         &self,
-        list_neurons: &ListNeurons,
+        list_neurons: &ListNeuronsCandid,
         caller: PrincipalId,
     ) -> ListNeuronsResponse {
         let now = self.env.now();
 
-        let ListNeurons {
+        let ListNeuronsProto {
             neuron_ids,
             include_neurons_readable_by_caller,
             include_empty_neurons_readable_by_caller,

--- a/rs/nns/governance/src/governance.rs
+++ b/rs/nns/governance/src/governance.rs
@@ -2267,7 +2267,7 @@ impl Governance {
         };
 
         let mut neurons_by_subaccount: BTreeSet<NeuronId> = neuron_subaccounts
-            .into_iter()
+            .iter()
             .flat_map(|neuron_subaccount| {
                 Self::bytes_to_subaccount(&neuron_subaccount.subaccount)
                     .ok()

--- a/rs/nns/governance/src/governance.rs
+++ b/rs/nns/governance/src/governance.rs
@@ -2267,6 +2267,7 @@ impl Governance {
         };
 
         let mut neurons_by_subaccount: BTreeSet<NeuronId> = neuron_subaccounts
+            .unwrap_or_default()
             .iter()
             .flat_map(|neuron_subaccount| {
                 Self::bytes_to_subaccount(&neuron_subaccount.subaccount)

--- a/rs/nns/governance/src/governance.rs
+++ b/rs/nns/governance/src/governance.rs
@@ -95,7 +95,6 @@ use ic_nns_constants::{
     LIFELINE_CANISTER_ID, REGISTRY_CANISTER_ID, ROOT_CANISTER_ID, SNS_WASM_CANISTER_ID,
     SUBNET_RENTAL_CANISTER_ID,
 };
-use ic_nns_governance_api::pb::v1::list_neurons::NeuronSubaccount;
 use ic_nns_governance_api::{
     pb::v1::{
         self as api,
@@ -2219,7 +2218,7 @@ impl Governance {
     /// See `ListNeurons`.
     pub fn list_neurons(
         &self,
-        list_neurons: &ListNeuronsCandid,
+        list_neurons: &ListNeurons,
         caller: PrincipalId,
     ) -> ListNeuronsResponse {
         let now = self.env.now();

--- a/rs/nns/governance/src/governance.rs
+++ b/rs/nns/governance/src/governance.rs
@@ -2266,10 +2266,22 @@ impl Governance {
             BTreeSet::new()
         };
 
+        let mut neurons_by_subaccount: BTreeSet<NeuronId> = neuron_subaccounts
+            .into_iter()
+            .flat_map(|neuron_subaccount| {
+                Self::bytes_to_subaccount(&neuron_subaccount.subaccount)
+                    .ok()
+                    .and_then(|subaccount| {
+                        self.neuron_store.get_neuron_id_for_subaccount(subaccount)
+                    })
+            })
+            .collect();
+
         // Concatenate (explicit and implicit)-ly included neurons.
         let mut requested_neuron_ids: BTreeSet<NeuronId> =
             neuron_ids.iter().map(|id| NeuronId { id: *id }).collect();
         requested_neuron_ids.append(&mut implicitly_requested_neuron_ids);
+        requested_neuron_ids.append(&mut neurons_by_subaccount);
 
         // These will be assembled into the final result.
         let mut neuron_infos = hashmap![];

--- a/rs/nns/governance/src/governance.rs
+++ b/rs/nns/governance/src/governance.rs
@@ -2230,6 +2230,7 @@ impl Governance {
             include_public_neurons_in_full_neurons,
             page_number,
             page_size,
+            neuron_subaccounts,
         } = list_neurons;
 
         let page_number = page_number.unwrap_or(0);

--- a/rs/nns/governance/src/governance.rs
+++ b/rs/nns/governance/src/governance.rs
@@ -100,7 +100,7 @@ use ic_nns_governance_api::{
     pb::v1::{
         self as api,
         manage_neuron_response::{self, MergeMaturityResponse, StakeMaturityResponse},
-        CreateServiceNervousSystem as ApiCreateServiceNervousSystem, ListNeuronsProto,
+        CreateServiceNervousSystem as ApiCreateServiceNervousSystem, ListNeurons,
         ListNeuronsResponse, ListProposalInfoResponse, ManageNeuronResponse, NeuronInfo,
         ProposalInfo,
     },
@@ -2224,7 +2224,7 @@ impl Governance {
     ) -> ListNeuronsResponse {
         let now = self.env.now();
 
-        let ListNeuronsProto {
+        let ListNeurons {
             neuron_ids,
             include_neurons_readable_by_caller,
             include_empty_neurons_readable_by_caller,

--- a/rs/nns/governance/src/governance/benches.rs
+++ b/rs/nns/governance/src/governance/benches.rs
@@ -1,4 +1,3 @@
-use crate::pb::v1::VotingPowerEconomics;
 use crate::{
     governance::{
         test_data::CREATE_SERVICE_NERVOUS_SYSTEM_WITH_MATCHED_FUNDING, Governance,

--- a/rs/nns/governance/src/governance/benches.rs
+++ b/rs/nns/governance/src/governance/benches.rs
@@ -29,6 +29,7 @@ use ic_nns_common::{
     types::NeuronId,
 };
 use ic_nns_constants::GOVERNANCE_CANISTER_ID;
+use ic_nns_governance_api::pb::v1::list_neurons::NeuronSubaccount;
 use ic_nns_governance_api::pb::v1::ListNeurons;
 use icp_ledger::Subaccount;
 use maplit::hashmap;
@@ -530,6 +531,57 @@ fn compute_ballots_for_new_proposal_with_stable_neurons() -> BenchResult {
     })
 }
 
+fn list_neurons_by_subaccount_benchmark() -> BenchResult {
+    let neurons = (0..100)
+        .map(|id| {
+            (id, {
+                let mut neuron: NeuronProto = make_neuron(
+                    id,
+                    PrincipalId::new_user_test_id(id),
+                    1_000_000_000,
+                    hashmap! {}, // get the default followees
+                )
+                .into_proto(&VotingPowerEconomics::DEFAULT, 123_456_789);
+                neuron.hot_keys = vec![PrincipalId::new_user_test_id(1)];
+                neuron
+            })
+        })
+        .collect::<BTreeMap<u64, NeuronProto>>();
+
+    let subaccounts = neurons
+        .iter()
+        .map(|(_, neuron)| NeuronSubaccount {
+            subaccount: neuron.account.clone(),
+        })
+        .collect();
+
+    let governance_proto = GovernanceProto {
+        neurons,
+        ..GovernanceProto::default()
+    };
+
+    let governance = Governance::new(
+        governance_proto,
+        Box::new(MockEnvironment::new(Default::default(), 0)),
+        Box::new(StubIcpLedger {}),
+        Box::new(StubCMC {}),
+    );
+
+    let request = ListNeurons {
+        neuron_ids: vec![],
+        include_neurons_readable_by_caller: false,
+        include_empty_neurons_readable_by_caller: Some(false),
+        include_public_neurons_in_full_neurons: None,
+        page_number: None,
+        page_size: None,
+        neuron_subaccounts: subaccounts,
+    };
+
+    bench_fn(|| {
+        governance.list_neurons(&request, PrincipalId::new_user_test_id(1));
+    })
+}
+
 fn list_neurons_benchmark() -> BenchResult {
     let neurons = (0..100)
         .map(|id| {
@@ -587,6 +639,22 @@ fn list_neurons_heap() -> BenchResult {
     let _a = temporarily_disable_allow_active_neurons_in_stable_memory();
     let _b = temporarily_disable_migrate_active_neurons_to_stable_memory();
     list_neurons_benchmark()
+}
+
+/// Benchmark list_neurons
+#[bench(raw)]
+fn list_neurons_by_subaccount_stable() -> BenchResult {
+    let _a = temporarily_enable_allow_active_neurons_in_stable_memory();
+    let _b = temporarily_enable_migrate_active_neurons_to_stable_memory();
+    list_neurons_by_subaccount_benchmark()
+}
+
+/// Benchmark list_neurons
+#[bench(raw)]
+fn list_neurons_by_subaccount_heap() -> BenchResult {
+    let _a = temporarily_disable_allow_active_neurons_in_stable_memory();
+    let _b = temporarily_disable_migrate_active_neurons_to_stable_memory();
+    list_neurons_by_subaccount_benchmark()
 }
 
 fn create_service_nervous_system_action_with_large_payload() -> CreateServiceNervousSystem {

--- a/rs/nns/governance/src/governance/benches.rs
+++ b/rs/nns/governance/src/governance/benches.rs
@@ -30,7 +30,7 @@ use ic_nns_common::{
 };
 use ic_nns_constants::GOVERNANCE_CANISTER_ID;
 use ic_nns_governance_api::pb::v1::list_neurons::NeuronSubaccount;
-use ic_nns_governance_api::pb::v1::ListNeurons;
+use ic_nns_governance_api::pb::v1::ListNeuronsProto;
 use icp_ledger::Subaccount;
 use maplit::hashmap;
 use rand::{Rng, SeedableRng};
@@ -567,7 +567,7 @@ fn list_neurons_by_subaccount_benchmark() -> BenchResult {
         Box::new(StubCMC {}),
     );
 
-    let request = ListNeurons {
+    let request = ListNeuronsProto {
         neuron_ids: vec![],
         include_neurons_readable_by_caller: false,
         include_empty_neurons_readable_by_caller: Some(false),
@@ -610,7 +610,7 @@ fn list_neurons_benchmark() -> BenchResult {
         Box::new(StubCMC {}),
     );
 
-    let request = ListNeurons {
+    let request = ListNeuronsProto {
         neuron_ids: vec![],
         include_neurons_readable_by_caller: true,
         include_empty_neurons_readable_by_caller: Some(false),

--- a/rs/nns/governance/src/governance/benches.rs
+++ b/rs/nns/governance/src/governance/benches.rs
@@ -565,6 +565,7 @@ fn list_neurons_benchmark() -> BenchResult {
         include_public_neurons_in_full_neurons: None,
         page_number: None,
         page_size: None,
+        neuron_subaccounts: vec![],
     };
 
     bench_fn(|| {

--- a/rs/nns/governance/src/governance/benches.rs
+++ b/rs/nns/governance/src/governance/benches.rs
@@ -574,7 +574,7 @@ fn list_neurons_by_subaccount_benchmark() -> BenchResult {
         include_public_neurons_in_full_neurons: None,
         page_number: None,
         page_size: None,
-        neuron_subaccounts: subaccounts,
+        neuron_subaccounts: Some(subaccounts),
     };
 
     bench_fn(|| {
@@ -617,7 +617,7 @@ fn list_neurons_benchmark() -> BenchResult {
         include_public_neurons_in_full_neurons: None,
         page_number: None,
         page_size: None,
-        neuron_subaccounts: vec![],
+        neuron_subaccounts: None,
     };
 
     bench_fn(|| {

--- a/rs/nns/governance/src/governance/benches.rs
+++ b/rs/nns/governance/src/governance/benches.rs
@@ -1,3 +1,4 @@
+use crate::pb::v1::VotingPowerEconomics;
 use crate::{
     governance::{
         test_data::CREATE_SERVICE_NERVOUS_SYSTEM_WITH_MATCHED_FUNDING, Governance,
@@ -541,7 +542,7 @@ fn list_neurons_by_subaccount_benchmark() -> BenchResult {
                     1_000_000_000,
                     hashmap! {}, // get the default followees
                 )
-                .into_proto(&VotingPowerEconomics::DEFAULT, 123_456_789);
+                .into();
                 neuron.hot_keys = vec![PrincipalId::new_user_test_id(1)];
                 neuron
             })

--- a/rs/nns/governance/src/governance/benches.rs
+++ b/rs/nns/governance/src/governance/benches.rs
@@ -30,7 +30,7 @@ use ic_nns_common::{
 };
 use ic_nns_constants::GOVERNANCE_CANISTER_ID;
 use ic_nns_governance_api::pb::v1::list_neurons::NeuronSubaccount;
-use ic_nns_governance_api::pb::v1::ListNeuronsProto;
+use ic_nns_governance_api::pb::v1::ListNeurons;
 use icp_ledger::Subaccount;
 use maplit::hashmap;
 use rand::{Rng, SeedableRng};
@@ -567,7 +567,7 @@ fn list_neurons_by_subaccount_benchmark() -> BenchResult {
         Box::new(StubCMC {}),
     );
 
-    let request = ListNeuronsProto {
+    let request = ListNeurons {
         neuron_ids: vec![],
         include_neurons_readable_by_caller: false,
         include_empty_neurons_readable_by_caller: Some(false),
@@ -610,7 +610,7 @@ fn list_neurons_benchmark() -> BenchResult {
         Box::new(StubCMC {}),
     );
 
-    let request = ListNeuronsProto {
+    let request = ListNeurons {
         neuron_ids: vec![],
         include_neurons_readable_by_caller: true,
         include_empty_neurons_readable_by_caller: Some(false),

--- a/rs/nns/governance/src/governance/benches.rs
+++ b/rs/nns/governance/src/governance/benches.rs
@@ -549,8 +549,8 @@ fn list_neurons_by_subaccount_benchmark() -> BenchResult {
         .collect::<BTreeMap<u64, NeuronProto>>();
 
     let subaccounts = neurons
-        .iter()
-        .map(|(_, neuron)| NeuronSubaccount {
+        .values()
+        .map(|neuron| NeuronSubaccount {
             subaccount: neuron.account.clone(),
         })
         .collect();

--- a/rs/nns/governance/src/governance/tests/list_neurons.rs
+++ b/rs/nns/governance/src/governance/tests/list_neurons.rs
@@ -51,7 +51,7 @@ fn test_list_neurons_with_paging() {
         include_public_neurons_in_full_neurons: None,
         page_number: None,
         page_size: None,
-        neuron_subaccounts: vec![],
+        neuron_subaccounts: Some(vec![]),
     };
 
     let response_with_no_page_number = governance.list_neurons(&request, user_id);
@@ -70,7 +70,7 @@ fn test_list_neurons_with_paging() {
             include_public_neurons_in_full_neurons: None,
             page_number: Some(1),
             page_size: None,
-            neuron_subaccounts: vec![],
+            neuron_subaccounts: None,
         },
         user_id,
     );
@@ -87,7 +87,7 @@ fn test_list_neurons_with_paging() {
             include_public_neurons_in_full_neurons: None,
             page_number: Some(0),
             page_size: Some(501),
-            neuron_subaccounts: vec![],
+            neuron_subaccounts: None,
         },
         user_id,
     );
@@ -139,11 +139,13 @@ fn test_list_neurons_by_subaccounts_and_ids() {
         include_public_neurons_in_full_neurons: None,
         page_number: None,
         page_size: None,
-        neuron_subaccounts: (501..1000)
-            .map(|id| NeuronSubaccount {
-                subaccount: crate::test_utils::test_subaccount_for_neuron_id(id),
-            })
-            .collect(),
+        neuron_subaccounts: Some(
+            (501..1000)
+                .map(|id| NeuronSubaccount {
+                    subaccount: crate::test_utils::test_subaccount_for_neuron_id(id),
+                })
+                .collect(),
+        ),
     };
 
     let response_1 = governance.list_neurons(&request, user_id);
@@ -158,11 +160,13 @@ fn test_list_neurons_by_subaccounts_and_ids() {
             include_public_neurons_in_full_neurons: None,
             page_number: Some(1),
             page_size: None,
-            neuron_subaccounts: (501..1000)
-                .map(|id| NeuronSubaccount {
-                    subaccount: crate::test_utils::test_subaccount_for_neuron_id(id),
-                })
-                .collect(),
+            neuron_subaccounts: Some(
+                (501..1000)
+                    .map(|id| NeuronSubaccount {
+                        subaccount: crate::test_utils::test_subaccount_for_neuron_id(id),
+                    })
+                    .collect(),
+            ),
         },
         user_id,
     );

--- a/rs/nns/governance/src/governance/tests/list_neurons.rs
+++ b/rs/nns/governance/src/governance/tests/list_neurons.rs
@@ -6,7 +6,7 @@ use crate::{
 use ic_base_types::PrincipalId;
 use ic_nns_common::pb::v1::NeuronId;
 use ic_nns_governance_api::pb::v1::list_neurons::NeuronSubaccount;
-use ic_nns_governance_api::pb::v1::ListNeuronsProto;
+use ic_nns_governance_api::pb::v1::ListNeurons;
 
 #[test]
 fn test_list_neurons_with_paging() {
@@ -44,7 +44,7 @@ fn test_list_neurons_with_paging() {
         Box::new(StubCMC {}),
     );
 
-    let mut request = ListNeuronsProto {
+    let mut request = ListNeurons {
         neuron_ids: vec![],
         include_neurons_readable_by_caller: true,
         include_empty_neurons_readable_by_caller: Some(true),
@@ -63,7 +63,7 @@ fn test_list_neurons_with_paging() {
     assert_eq!(response_with_0_page_number.total_pages_available, Some(2));
 
     let response = governance.list_neurons(
-        &ListNeuronsProto {
+        &ListNeurons {
             neuron_ids: vec![],
             include_neurons_readable_by_caller: true,
             include_empty_neurons_readable_by_caller: Some(true),
@@ -80,7 +80,7 @@ fn test_list_neurons_with_paging() {
 
     // Assert maximum page size cannot be exceeded
     let response = governance.list_neurons(
-        &ListNeuronsProto {
+        &ListNeurons {
             neuron_ids: vec![],
             include_neurons_readable_by_caller: true,
             include_empty_neurons_readable_by_caller: Some(true),
@@ -132,7 +132,7 @@ fn test_list_neurons_by_subaccounts_and_ids() {
         Box::new(StubCMC {}),
     );
 
-    let request = ListNeuronsProto {
+    let request = ListNeurons {
         neuron_ids: (1..501).collect(),
         include_neurons_readable_by_caller: false,
         include_empty_neurons_readable_by_caller: None,
@@ -153,7 +153,7 @@ fn test_list_neurons_by_subaccounts_and_ids() {
     assert_eq!(response_1.total_pages_available, Some(2));
 
     let response_2 = governance.list_neurons(
-        &ListNeuronsProto {
+        &ListNeurons {
             neuron_ids: (1..501).collect(),
             include_neurons_readable_by_caller: false,
             include_empty_neurons_readable_by_caller: None,

--- a/rs/nns/governance/src/governance/tests/list_neurons.rs
+++ b/rs/nns/governance/src/governance/tests/list_neurons.rs
@@ -5,6 +5,7 @@ use crate::{
 };
 use ic_base_types::PrincipalId;
 use ic_nns_common::pb::v1::NeuronId;
+use ic_nns_governance_api::pb::v1::list_neurons::NeuronSubaccount;
 use ic_nns_governance_api::pb::v1::ListNeurons;
 
 #[test]
@@ -93,4 +94,79 @@ fn test_list_neurons_with_paging() {
 
     assert_eq!(response.full_neurons.len(), 500);
     assert_eq!(response.total_pages_available, Some(2));
+}
+
+#[test]
+fn test_list_neurons_by_subaccounts_and_ids() {
+    let user_id = PrincipalId::new_user_test_id(100);
+
+    let neurons = (1..1000u64)
+        .map(|id| {
+            let dissolve_state = DissolveState::DissolveDelaySeconds(100);
+            let account = crate::test_utils::test_subaccount_for_neuron_id(id);
+            (
+                id,
+                Neuron {
+                    id: Some(NeuronId::from_u64(id)),
+                    controller: Some(user_id),
+                    account,
+                    dissolve_state: Some(dissolve_state),
+                    // Fill in the rest as needed (stake, maturity, etc.)
+                    ..Default::default()
+                },
+            )
+        })
+        .collect();
+
+    let governance = Governance::new(
+        crate::pb::v1::Governance {
+            neurons,
+            economics: Some(NetworkEconomics {
+                voting_power_economics: Some(Default::default()),
+                ..Default::default()
+            }),
+            ..crate::pb::v1::Governance::default()
+        },
+        Box::new(MockEnvironment::new(Default::default(), 0)),
+        Box::new(StubIcpLedger {}),
+        Box::new(StubCMC {}),
+    );
+
+    let request = ListNeurons {
+        neuron_ids: (1..501).collect(),
+        include_neurons_readable_by_caller: false,
+        include_empty_neurons_readable_by_caller: None,
+        include_public_neurons_in_full_neurons: None,
+        page_number: None,
+        page_size: None,
+        neuron_subaccounts: (501..1000)
+            .map(|id| NeuronSubaccount {
+                subaccount: crate::test_utils::test_subaccount_for_neuron_id(id),
+            })
+            .collect(),
+    };
+
+    let response_1 = governance.list_neurons(&request, user_id);
+    assert_eq!(response_1.full_neurons.len(), 500);
+    assert_eq!(response_1.total_pages_available, Some(2));
+
+    let response_2 = governance.list_neurons(
+        &ListNeurons {
+            neuron_ids: (1..501).collect(),
+            include_neurons_readable_by_caller: false,
+            include_empty_neurons_readable_by_caller: None,
+            include_public_neurons_in_full_neurons: None,
+            page_number: Some(1),
+            page_size: None,
+            neuron_subaccounts: (501..1000)
+                .map(|id| NeuronSubaccount {
+                    subaccount: crate::test_utils::test_subaccount_for_neuron_id(id),
+                })
+                .collect(),
+        },
+        user_id,
+    );
+
+    assert_eq!(response_2.full_neurons.len(), 499);
+    assert_eq!(response_2.total_pages_available, Some(2));
 }

--- a/rs/nns/governance/src/governance/tests/list_neurons.rs
+++ b/rs/nns/governance/src/governance/tests/list_neurons.rs
@@ -6,7 +6,7 @@ use crate::{
 use ic_base_types::PrincipalId;
 use ic_nns_common::pb::v1::NeuronId;
 use ic_nns_governance_api::pb::v1::list_neurons::NeuronSubaccount;
-use ic_nns_governance_api::pb::v1::ListNeurons;
+use ic_nns_governance_api::pb::v1::ListNeuronsProto;
 
 #[test]
 fn test_list_neurons_with_paging() {
@@ -44,7 +44,7 @@ fn test_list_neurons_with_paging() {
         Box::new(StubCMC {}),
     );
 
-    let mut request = ListNeurons {
+    let mut request = ListNeuronsProto {
         neuron_ids: vec![],
         include_neurons_readable_by_caller: true,
         include_empty_neurons_readable_by_caller: Some(true),
@@ -63,7 +63,7 @@ fn test_list_neurons_with_paging() {
     assert_eq!(response_with_0_page_number.total_pages_available, Some(2));
 
     let response = governance.list_neurons(
-        &ListNeurons {
+        &ListNeuronsProto {
             neuron_ids: vec![],
             include_neurons_readable_by_caller: true,
             include_empty_neurons_readable_by_caller: Some(true),
@@ -80,7 +80,7 @@ fn test_list_neurons_with_paging() {
 
     // Assert maximum page size cannot be exceeded
     let response = governance.list_neurons(
-        &ListNeurons {
+        &ListNeuronsProto {
             neuron_ids: vec![],
             include_neurons_readable_by_caller: true,
             include_empty_neurons_readable_by_caller: Some(true),
@@ -132,7 +132,7 @@ fn test_list_neurons_by_subaccounts_and_ids() {
         Box::new(StubCMC {}),
     );
 
-    let request = ListNeurons {
+    let request = ListNeuronsProto {
         neuron_ids: (1..501).collect(),
         include_neurons_readable_by_caller: false,
         include_empty_neurons_readable_by_caller: None,
@@ -153,7 +153,7 @@ fn test_list_neurons_by_subaccounts_and_ids() {
     assert_eq!(response_1.total_pages_available, Some(2));
 
     let response_2 = governance.list_neurons(
-        &ListNeurons {
+        &ListNeuronsProto {
             neuron_ids: (1..501).collect(),
             include_neurons_readable_by_caller: false,
             include_empty_neurons_readable_by_caller: None,

--- a/rs/nns/governance/src/governance/tests/list_neurons.rs
+++ b/rs/nns/governance/src/governance/tests/list_neurons.rs
@@ -50,6 +50,7 @@ fn test_list_neurons_with_paging() {
         include_public_neurons_in_full_neurons: None,
         page_number: None,
         page_size: None,
+        neuron_subaccounts: vec![],
     };
 
     let response_with_no_page_number = governance.list_neurons(&request, user_id);
@@ -68,6 +69,7 @@ fn test_list_neurons_with_paging() {
             include_public_neurons_in_full_neurons: None,
             page_number: Some(1),
             page_size: None,
+            neuron_subaccounts: vec![],
         },
         user_id,
     );
@@ -84,6 +86,7 @@ fn test_list_neurons_with_paging() {
             include_public_neurons_in_full_neurons: None,
             page_number: Some(0),
             page_size: Some(501),
+            neuron_subaccounts: vec![],
         },
         user_id,
     );

--- a/rs/nns/governance/src/pb/mod.rs
+++ b/rs/nns/governance/src/pb/mod.rs
@@ -1,5 +1,5 @@
 use crate::pb::v1::ArchivedMonthlyNodeProviderRewards;
-use ic_nns_governance_api::pb::v1::{ListNeurons, ListNeuronsProto};
+use ic_nns_governance_api::pb::v1::ListNeurons;
 use ic_stable_structures::{storable::Bound, Storable};
 use prost::Message;
 use std::borrow::Cow;

--- a/rs/nns/governance/src/pb/mod.rs
+++ b/rs/nns/governance/src/pb/mod.rs
@@ -1,4 +1,5 @@
 use crate::pb::v1::ArchivedMonthlyNodeProviderRewards;
+use ic_nns_governance_api::pb::v1::{ListNeurons, ListNeuronsProto};
 use ic_stable_structures::{storable::Bound, Storable};
 use prost::Message;
 use std::borrow::Cow;

--- a/rs/nns/governance/src/pb/mod.rs
+++ b/rs/nns/governance/src/pb/mod.rs
@@ -1,5 +1,4 @@
 use crate::pb::v1::ArchivedMonthlyNodeProviderRewards;
-use ic_nns_governance_api::pb::v1::ListNeurons;
 use ic_stable_structures::{storable::Bound, Storable};
 use prost::Message;
 use std::borrow::Cow;

--- a/rs/nns/governance/tests/governance.rs
+++ b/rs/nns/governance/tests/governance.rs
@@ -10610,6 +10610,8 @@ fn test_include_public_neurons_in_full_neurons() {
 
             page_number: None,
             page_size: None,
+            // TODO DO NOT MERGE, add something to the test here
+            neuron_subaccounts: vec![],
         },
         caller,
     );
@@ -14674,6 +14676,7 @@ fn test_neuron_info_private_enforcement() {
                         include_public_neurons_in_full_neurons: None,
                         page_number: None,
                         page_size: None,
+                        neuron_subaccounts: vec![],
                     },
                     requester,
                 )

--- a/rs/nns/governance/tests/governance.rs
+++ b/rs/nns/governance/tests/governance.rs
@@ -101,7 +101,7 @@ use ic_nns_governance_api::{
         manage_neuron_response::{self, Command as CommandResponse, ConfigureResponse},
         proposal::Action as ApiAction,
         Ballot as ApiBallot, CreateServiceNervousSystem as ApiCreateServiceNervousSystem,
-        ListNeurons, ListNeuronsResponse, ListProposalInfoResponse, ManageNeuronResponse,
+        ListNeuronsProto, ListNeuronsResponse, ListProposalInfoResponse, ManageNeuronResponse,
         NeuronState,
     },
     proposal_validation::validate_proposal_title,
@@ -2291,7 +2291,7 @@ fn test_enforce_private_neuron() {
         .unwrap();
 
     let list_neurons_response = governance.list_neurons(
-        &ListNeurons {
+        &ListNeuronsProto {
             neuron_ids: vec![1],
             ..Default::default()
         },
@@ -10594,7 +10594,7 @@ fn test_include_public_neurons_in_full_neurons() {
     // Step 2: Call the code under test.
 
     let list_neurons_response = governance.list_neurons(
-        &ListNeurons {
+        &ListNeuronsProto {
             // Try to read all neurons that are not controlled by caller. Only the public ones
             // should appear in full_neurons.
             neuron_ids: vec![1, 2, 3, 4],
@@ -14668,7 +14668,7 @@ fn test_neuron_info_private_enforcement() {
             // Step 2.2: Call list_neurons.
             let list_neurons = |requester| {
                 governance.list_neurons(
-                    &ListNeurons {
+                    &ListNeuronsProto {
                         neuron_ids: vec![neuron_id.id],
                         include_neurons_readable_by_caller: false,
                         include_empty_neurons_readable_by_caller: None,

--- a/rs/nns/governance/tests/governance.rs
+++ b/rs/nns/governance/tests/governance.rs
@@ -10610,7 +10610,7 @@ fn test_include_public_neurons_in_full_neurons() {
 
             page_number: None,
             page_size: None,
-            neuron_subaccounts: vec![],
+            neuron_subaccounts: None,
         },
         caller,
     );
@@ -14675,7 +14675,7 @@ fn test_neuron_info_private_enforcement() {
                         include_public_neurons_in_full_neurons: None,
                         page_number: None,
                         page_size: None,
-                        neuron_subaccounts: vec![],
+                        neuron_subaccounts: None,
                     },
                     requester,
                 )

--- a/rs/nns/governance/tests/governance.rs
+++ b/rs/nns/governance/tests/governance.rs
@@ -10610,7 +10610,6 @@ fn test_include_public_neurons_in_full_neurons() {
 
             page_number: None,
             page_size: None,
-            // TODO DO NOT MERGE, add something to the test here
             neuron_subaccounts: vec![],
         },
         caller,

--- a/rs/nns/governance/tests/governance.rs
+++ b/rs/nns/governance/tests/governance.rs
@@ -101,7 +101,7 @@ use ic_nns_governance_api::{
         manage_neuron_response::{self, Command as CommandResponse, ConfigureResponse},
         proposal::Action as ApiAction,
         Ballot as ApiBallot, CreateServiceNervousSystem as ApiCreateServiceNervousSystem,
-        ListNeuronsProto, ListNeuronsResponse, ListProposalInfoResponse, ManageNeuronResponse,
+        ListNeurons, ListNeuronsResponse, ListProposalInfoResponse, ManageNeuronResponse,
         NeuronState,
     },
     proposal_validation::validate_proposal_title,
@@ -2291,7 +2291,7 @@ fn test_enforce_private_neuron() {
         .unwrap();
 
     let list_neurons_response = governance.list_neurons(
-        &ListNeuronsProto {
+        &ListNeurons {
             neuron_ids: vec![1],
             ..Default::default()
         },
@@ -10594,7 +10594,7 @@ fn test_include_public_neurons_in_full_neurons() {
     // Step 2: Call the code under test.
 
     let list_neurons_response = governance.list_neurons(
-        &ListNeuronsProto {
+        &ListNeurons {
             // Try to read all neurons that are not controlled by caller. Only the public ones
             // should appear in full_neurons.
             neuron_ids: vec![1, 2, 3, 4],
@@ -14668,7 +14668,7 @@ fn test_neuron_info_private_enforcement() {
             // Step 2.2: Call list_neurons.
             let list_neurons = |requester| {
                 governance.list_neurons(
-                    &ListNeuronsProto {
+                    &ListNeurons {
                         neuron_ids: vec![neuron_id.id],
                         include_neurons_readable_by_caller: false,
                         include_empty_neurons_readable_by_caller: None,

--- a/rs/nns/governance/unreleased_changelog.md
+++ b/rs/nns/governance/unreleased_changelog.md
@@ -37,6 +37,17 @@ In this relesae, we turn on 2 features related to migrating active neurons to st
 
 No neurons are actually migrated yet.
 
+### List Neurons API Change: Query by Subaccount
+
+The `list_neurons` API now supports querying by neuron subaccount.  This is useful for neuron holders who
+have many neurons and want to list only the neurons associated with a particular subaccount.
+
+A new field `neuron_subaccounts` is added to the request, which is a list of subaccounts to query
+for.  If this field is present, any neurons found will be added to the response.  If duplicate
+neurons are found between this field and others, they will be deduplicated before returning the value.
+
+This new field works in the same way that the existing `neuron_ids` field works.
+
 ## Changed
 
 * `InstallCode` proposal payload hashes are now computed when making the proposal instead of when

--- a/rs/nns/integration_tests/src/governance_neurons.rs
+++ b/rs/nns/integration_tests/src/governance_neurons.rs
@@ -553,6 +553,7 @@ fn test_list_neurons() {
             include_public_neurons_in_full_neurons: None,
             page_number: None,
             page_size: None,
+            neuron_subaccounts: vec![],
         },
     );
     assert_eq!(list_neurons_response.neuron_infos.len(), 3);
@@ -569,6 +570,7 @@ fn test_list_neurons() {
             include_public_neurons_in_full_neurons: None,
             page_number: None,
             page_size: None,
+            neuron_subaccounts: vec![],
         },
     );
     assert_eq!(list_neurons_response.neuron_infos.len(), 2);
@@ -585,6 +587,7 @@ fn test_list_neurons() {
             include_public_neurons_in_full_neurons: None,
             page_number: None,
             page_size: None,
+            neuron_subaccounts: vec![],
         },
     );
     assert_eq!(list_neurons_response.neuron_infos.len(), 1);
@@ -602,6 +605,7 @@ fn test_list_neurons() {
             include_public_neurons_in_full_neurons: None,
             page_number: None,
             page_size: None,
+            neuron_subaccounts: vec![],
         },
     );
     assert_eq!(list_neurons_response.neuron_infos.len(), 2);

--- a/rs/nns/integration_tests/src/governance_neurons.rs
+++ b/rs/nns/integration_tests/src/governance_neurons.rs
@@ -20,7 +20,7 @@ use ic_nns_governance_api::pb::v1::{
         Command as CommandResponse, {self},
     },
     neuron::DissolveState,
-    GovernanceError, ListNeurons, ManageNeuron, ManageNeuronResponse, Neuron, NeuronState,
+    GovernanceError, ListNeuronsProto, ManageNeuron, ManageNeuronResponse, Neuron, NeuronState,
 };
 use ic_nns_test_utils::{
     common::NnsInitPayloadsBuilder,
@@ -548,7 +548,7 @@ fn test_list_neurons() {
     let list_neurons_response = list_neurons(
         &state_machine,
         PrincipalId::new_anonymous(),
-        ListNeurons {
+        ListNeuronsProto {
             neuron_ids: vec![neuron_id_1.id, neuron_id_2.id, neuron_id_3.id],
             include_neurons_readable_by_caller: false,
             include_empty_neurons_readable_by_caller: Some(false),
@@ -565,7 +565,7 @@ fn test_list_neurons() {
     let list_neurons_response = list_neurons(
         &state_machine,
         principal_1,
-        ListNeurons {
+        ListNeuronsProto {
             neuron_ids: vec![],
             include_neurons_readable_by_caller: true,
             include_empty_neurons_readable_by_caller: Some(true),
@@ -582,7 +582,7 @@ fn test_list_neurons() {
     let list_neurons_response = list_neurons(
         &state_machine,
         principal_1,
-        ListNeurons {
+        ListNeuronsProto {
             neuron_ids: vec![],
             include_neurons_readable_by_caller: true,
             include_empty_neurons_readable_by_caller: Some(false),
@@ -600,7 +600,7 @@ fn test_list_neurons() {
     let list_neurons_response = list_neurons(
         &state_machine,
         principal_1,
-        ListNeurons {
+        ListNeuronsProto {
             neuron_ids: vec![neuron_id_3.id],
             include_neurons_readable_by_caller: true,
             include_empty_neurons_readable_by_caller: Some(true),
@@ -620,7 +620,7 @@ fn test_list_neurons() {
     let list_neurons_response = list_neurons(
         &state_machine,
         principal_1,
-        ListNeurons {
+        ListNeuronsProto {
             neuron_ids: vec![],
             include_neurons_readable_by_caller: true,
             include_empty_neurons_readable_by_caller: Some(true),

--- a/rs/nns/integration_tests/src/governance_neurons.rs
+++ b/rs/nns/integration_tests/src/governance_neurons.rs
@@ -555,7 +555,7 @@ fn test_list_neurons() {
             include_public_neurons_in_full_neurons: None,
             page_number: None,
             page_size: None,
-            neuron_subaccounts: vec![],
+            neuron_subaccounts: None,
         },
     );
     assert_eq!(list_neurons_response.neuron_infos.len(), 3);
@@ -572,7 +572,7 @@ fn test_list_neurons() {
             include_public_neurons_in_full_neurons: None,
             page_number: None,
             page_size: None,
-            neuron_subaccounts: vec![],
+            neuron_subaccounts: None,
         },
     );
     assert_eq!(list_neurons_response.neuron_infos.len(), 2);
@@ -589,7 +589,7 @@ fn test_list_neurons() {
             include_public_neurons_in_full_neurons: None,
             page_number: None,
             page_size: None,
-            neuron_subaccounts: vec![],
+            neuron_subaccounts: Some(vec![]), // Should be equivalent to None
         },
     );
     assert_eq!(list_neurons_response.neuron_infos.len(), 1);
@@ -607,7 +607,7 @@ fn test_list_neurons() {
             include_public_neurons_in_full_neurons: None,
             page_number: None,
             page_size: None,
-            neuron_subaccounts: vec![],
+            neuron_subaccounts: Some(vec![]),
         },
     );
     assert_eq!(list_neurons_response.neuron_infos.len(), 3);
@@ -627,9 +627,9 @@ fn test_list_neurons() {
             include_public_neurons_in_full_neurons: None,
             page_number: None,
             page_size: None,
-            neuron_subaccounts: vec![NeuronSubaccount {
+            neuron_subaccounts: Some(vec![NeuronSubaccount {
                 subaccount: subaccount.to_vec(),
-            }],
+            }]),
         },
     );
     assert_eq!(list_neurons_response.neuron_infos.len(), 3);

--- a/rs/nns/integration_tests/src/governance_neurons.rs
+++ b/rs/nns/integration_tests/src/governance_neurons.rs
@@ -20,7 +20,7 @@ use ic_nns_governance_api::pb::v1::{
         Command as CommandResponse, {self},
     },
     neuron::DissolveState,
-    GovernanceError, ListNeuronsProto, ManageNeuron, ManageNeuronResponse, Neuron, NeuronState,
+    GovernanceError, ListNeurons, ManageNeuron, ManageNeuronResponse, Neuron, NeuronState,
 };
 use ic_nns_test_utils::{
     common::NnsInitPayloadsBuilder,
@@ -548,7 +548,7 @@ fn test_list_neurons() {
     let list_neurons_response = list_neurons(
         &state_machine,
         PrincipalId::new_anonymous(),
-        ListNeuronsProto {
+        ListNeurons {
             neuron_ids: vec![neuron_id_1.id, neuron_id_2.id, neuron_id_3.id],
             include_neurons_readable_by_caller: false,
             include_empty_neurons_readable_by_caller: Some(false),
@@ -565,7 +565,7 @@ fn test_list_neurons() {
     let list_neurons_response = list_neurons(
         &state_machine,
         principal_1,
-        ListNeuronsProto {
+        ListNeurons {
             neuron_ids: vec![],
             include_neurons_readable_by_caller: true,
             include_empty_neurons_readable_by_caller: Some(true),
@@ -582,7 +582,7 @@ fn test_list_neurons() {
     let list_neurons_response = list_neurons(
         &state_machine,
         principal_1,
-        ListNeuronsProto {
+        ListNeurons {
             neuron_ids: vec![],
             include_neurons_readable_by_caller: true,
             include_empty_neurons_readable_by_caller: Some(false),
@@ -600,7 +600,7 @@ fn test_list_neurons() {
     let list_neurons_response = list_neurons(
         &state_machine,
         principal_1,
-        ListNeuronsProto {
+        ListNeurons {
             neuron_ids: vec![neuron_id_3.id],
             include_neurons_readable_by_caller: true,
             include_empty_neurons_readable_by_caller: Some(true),
@@ -620,7 +620,7 @@ fn test_list_neurons() {
     let list_neurons_response = list_neurons(
         &state_machine,
         principal_1,
-        ListNeuronsProto {
+        ListNeurons {
             neuron_ids: vec![],
             include_neurons_readable_by_caller: true,
             include_empty_neurons_readable_by_caller: Some(true),

--- a/rs/nns/integration_tests/src/governance_neurons.rs
+++ b/rs/nns/integration_tests/src/governance_neurons.rs
@@ -5,6 +5,7 @@ use dfn_candid::candid_one;
 use dfn_protobuf::protobuf;
 use ic_base_types::PrincipalId;
 use ic_canister_client_sender::Sender;
+use ic_nervous_system_common::ledger::compute_neuron_staking_subaccount_bytes;
 use ic_nervous_system_common_test_keys::{
     TEST_NEURON_1_ID, TEST_NEURON_1_OWNER_KEYPAIR, TEST_NEURON_1_OWNER_PRINCIPAL, TEST_NEURON_2_ID,
     TEST_NEURON_2_OWNER_PRINCIPAL,
@@ -13,6 +14,7 @@ use ic_nns_common::pb::v1::NeuronId as NeuronIdProto;
 use ic_nns_governance::governance::INITIAL_NEURON_DISSOLVE_DELAY;
 use ic_nns_governance_api::pb::v1::{
     governance_error::ErrorType,
+    list_neurons::NeuronSubaccount,
     manage_neuron::{Command, Merge, NeuronIdOrSubaccount, Spawn},
     manage_neuron_response::{
         Command as CommandResponse, {self},
@@ -601,13 +603,35 @@ fn test_list_neurons() {
         ListNeurons {
             neuron_ids: vec![neuron_id_3.id],
             include_neurons_readable_by_caller: true,
-            include_empty_neurons_readable_by_caller: None,
+            include_empty_neurons_readable_by_caller: Some(true),
             include_public_neurons_in_full_neurons: None,
             page_number: None,
             page_size: None,
             neuron_subaccounts: vec![],
         },
     );
-    assert_eq!(list_neurons_response.neuron_infos.len(), 2);
-    assert_eq!(list_neurons_response.full_neurons.len(), 1);
+    assert_eq!(list_neurons_response.neuron_infos.len(), 3);
+    assert_eq!(list_neurons_response.full_neurons.len(), 2);
+
+    // Step 6: Same but specify neuron 3 by subaccount.
+    // empty neurons, also specifying neuron 3 which the caller does not control.
+
+    let subaccount = compute_neuron_staking_subaccount_bytes(principal_2, 3);
+    let list_neurons_response = list_neurons(
+        &state_machine,
+        principal_1,
+        ListNeurons {
+            neuron_ids: vec![],
+            include_neurons_readable_by_caller: true,
+            include_empty_neurons_readable_by_caller: Some(true),
+            include_public_neurons_in_full_neurons: None,
+            page_number: None,
+            page_size: None,
+            neuron_subaccounts: vec![NeuronSubaccount {
+                subaccount: subaccount.to_vec(),
+            }],
+        },
+    );
+    assert_eq!(list_neurons_response.neuron_infos.len(), 3);
+    assert_eq!(list_neurons_response.full_neurons.len(), 2);
 }

--- a/rs/nns/integration_tests/src/neuron_voting.rs
+++ b/rs/nns/integration_tests/src/neuron_voting.rs
@@ -402,6 +402,7 @@ fn test_voting_can_span_multiple_rounds() {
             include_public_neurons_in_full_neurons: None,
             page_number: None,
             page_size: None,
+            neuron_subaccounts: vec![],
         },
     );
 
@@ -429,6 +430,7 @@ fn test_voting_can_span_multiple_rounds() {
             include_public_neurons_in_full_neurons: None,
             page_number: None,
             page_size: None,
+            neuron_subaccounts: vec![],
         },
     );
 

--- a/rs/nns/integration_tests/src/neuron_voting.rs
+++ b/rs/nns/integration_tests/src/neuron_voting.rs
@@ -423,7 +423,7 @@ fn test_voting_can_span_multiple_rounds() {
     let listed_neurons = list_all_neurons_and_combine_responses(
         &state_machine,
         *TEST_NEURON_1_OWNER_PRINCIPAL,
-        ListNeurons {
+        ListNeuronsProto {
             neuron_ids: (0..1000u64).collect(),
             include_neurons_readable_by_caller: false,
             include_empty_neurons_readable_by_caller: None,

--- a/rs/nns/integration_tests/src/neuron_voting.rs
+++ b/rs/nns/integration_tests/src/neuron_voting.rs
@@ -423,7 +423,7 @@ fn test_voting_can_span_multiple_rounds() {
     let listed_neurons = list_all_neurons_and_combine_responses(
         &state_machine,
         *TEST_NEURON_1_OWNER_PRINCIPAL,
-        ListNeuronsProto {
+        ListNeurons {
             neuron_ids: (0..1000u64).collect(),
             include_neurons_readable_by_caller: false,
             include_empty_neurons_readable_by_caller: None,

--- a/rs/nns/integration_tests/src/neuron_voting.rs
+++ b/rs/nns/integration_tests/src/neuron_voting.rs
@@ -402,7 +402,7 @@ fn test_voting_can_span_multiple_rounds() {
             include_public_neurons_in_full_neurons: None,
             page_number: None,
             page_size: None,
-            neuron_subaccounts: vec![],
+            neuron_subaccounts: Some(vec![]),
         },
     );
 
@@ -410,7 +410,7 @@ fn test_voting_can_span_multiple_rounds() {
 
     // No recent ballots, bc ran out of instructions, should wait til next round.
     for neuron in listed_neurons.full_neurons {
-        assert_eq!(neuron.recent_ballots, vec![], "Neuron: {:?}", neuron);
+        assert_eq!(neuron.recent_ballots, Some(vec![]), "Neuron: {:?}", neuron);
     }
 
     // The timer should run, which should record all the ballots.
@@ -430,7 +430,7 @@ fn test_voting_can_span_multiple_rounds() {
             include_public_neurons_in_full_neurons: None,
             page_number: None,
             page_size: None,
-            neuron_subaccounts: vec![],
+            neuron_subaccounts: Some(vec![]),
         },
     );
 

--- a/rs/nns/integration_tests/src/neuron_voting.rs
+++ b/rs/nns/integration_tests/src/neuron_voting.rs
@@ -410,7 +410,7 @@ fn test_voting_can_span_multiple_rounds() {
 
     // No recent ballots, bc ran out of instructions, should wait til next round.
     for neuron in listed_neurons.full_neurons {
-        assert_eq!(neuron.recent_ballots, Some(vec![]), "Neuron: {:?}", neuron);
+        assert_eq!(neuron.recent_ballots, vec![], "Neuron: {:?}", neuron);
     }
 
     // The timer should run, which should record all the ballots.

--- a/rs/nns/test_utils/src/state_test_helpers.rs
+++ b/rs/nns/test_utils/src/state_test_helpers.rs
@@ -1619,6 +1619,7 @@ pub fn list_neurons_by_principal(
             include_public_neurons_in_full_neurons: None,
             page_number: None,
             page_size: None,
+            neuron_subaccounts: vec![],
         },
     )
 }

--- a/rs/nns/test_utils/src/state_test_helpers.rs
+++ b/rs/nns/test_utils/src/state_test_helpers.rs
@@ -1619,7 +1619,7 @@ pub fn list_neurons_by_principal(
             include_public_neurons_in_full_neurons: None,
             page_number: None,
             page_size: None,
-            neuron_subaccounts: vec![],
+            neuron_subaccounts: None,
         },
     )
 }

--- a/rs/rosetta-api/icp/src/request_handler/construction_payloads.rs
+++ b/rs/rosetta-api/icp/src/request_handler/construction_payloads.rs
@@ -437,7 +437,7 @@ fn handle_list_neurons(
         include_public_neurons_in_full_neurons: None,
         page_number: None,
         page_size: None,
-        neuron_subaccounts: vec![],
+        neuron_subaccounts: None,
     };
     let update = HttpCanisterUpdate {
         canister_id: Blob(ic_nns_constants::GOVERNANCE_CANISTER_ID.get().to_vec()),

--- a/rs/rosetta-api/icp/src/request_handler/construction_payloads.rs
+++ b/rs/rosetta-api/icp/src/request_handler/construction_payloads.rs
@@ -437,6 +437,7 @@ fn handle_list_neurons(
         include_public_neurons_in_full_neurons: None,
         page_number: None,
         page_size: None,
+        neuron_subaccounts: vec![],
     };
     let update = HttpCanisterUpdate {
         canister_id: Blob(ic_nns_constants::GOVERNANCE_CANISTER_ID.get().to_vec()),

--- a/rs/rosetta-api/icp/tests/system_tests/common/utils.rs
+++ b/rs/rosetta-api/icp/tests/system_tests/common/utils.rs
@@ -182,7 +182,7 @@ pub async fn list_neurons(agent: &Agent) -> ListNeuronsResponse {
                     include_public_neurons_in_full_neurons: None,
                     page_number: None,
                     page_size: None,
-                    neuron_subaccounts: vec![]
+                    neuron_subaccounts: None
                 })
                 .unwrap()
             )

--- a/rs/rosetta-api/icp/tests/system_tests/common/utils.rs
+++ b/rs/rosetta-api/icp/tests/system_tests/common/utils.rs
@@ -182,6 +182,7 @@ pub async fn list_neurons(agent: &Agent) -> ListNeuronsResponse {
                     include_public_neurons_in_full_neurons: None,
                     page_number: None,
                     page_size: None,
+                    neuron_subaccounts: vec![]
                 })
                 .unwrap()
             )

--- a/rs/tests/driver/src/canister_api.rs
+++ b/rs/tests/driver/src/canister_api.rs
@@ -3,7 +3,7 @@ use ic_base_types::PrincipalId;
 use ic_ledger_core::Tokens;
 use ic_nns_constants::{GOVERNANCE_CANISTER_ID, LEDGER_CANISTER_ID};
 use ic_nns_governance_api::pb::v1::{
-    ListNeuronsProto as ListNnsNeuronsReq, ListNeuronsResponse as ListNnsNeuronsRes,
+    ListNeurons as ListNnsNeuronsReq, ListNeuronsResponse as ListNnsNeuronsRes,
 };
 use ic_nns_gtc::pb::v1::AccountState;
 use ic_sns_governance::pb::v1::{

--- a/rs/tests/driver/src/canister_api.rs
+++ b/rs/tests/driver/src/canister_api.rs
@@ -740,6 +740,7 @@ impl ListNnsNeuronsRequest {
                 include_public_neurons_in_full_neurons: None,
                 page_number: None,
                 page_size: None,
+                neuron_subaccounts: vec![],
             },
         }
     }

--- a/rs/tests/driver/src/canister_api.rs
+++ b/rs/tests/driver/src/canister_api.rs
@@ -3,7 +3,7 @@ use ic_base_types::PrincipalId;
 use ic_ledger_core::Tokens;
 use ic_nns_constants::{GOVERNANCE_CANISTER_ID, LEDGER_CANISTER_ID};
 use ic_nns_governance_api::pb::v1::{
-    ListNeurons as ListNnsNeuronsReq, ListNeuronsResponse as ListNnsNeuronsRes,
+    ListNeuronsProto as ListNnsNeuronsReq, ListNeuronsResponse as ListNnsNeuronsRes,
 };
 use ic_nns_gtc::pb::v1::AccountState;
 use ic_sns_governance::pb::v1::{

--- a/rs/tests/driver/src/canister_api.rs
+++ b/rs/tests/driver/src/canister_api.rs
@@ -740,7 +740,7 @@ impl ListNnsNeuronsRequest {
                 include_public_neurons_in_full_neurons: None,
                 page_number: None,
                 page_size: None,
-                neuron_subaccounts: vec![],
+                neuron_subaccounts: None,
             },
         }
     }


### PR DESCRIPTION
# Why
This allows users who know the subaccounts of their neurons (i.e. they know the nonce and the principal used when the neurons are created) to specify which neurons they would like to list without needing to know the neuron ids (which are generated at random).

# What 

This adds a new API field to `list_neurons` called `neuron_subaccounts`, which works in the same way that `neuron_ids` works.  By specifying which subaccounts the user would like to list, they are able to retrieve neurons in the same way that they also can provide neuron ids.  Both of these are compatible, and in the case of overlaps, no duplicates are returned.

