### PR TITLE
feat(PocketIC): new PocketIC operation to set certified time

### DIFF
--- a/packages/pocket-ic/CHANGELOG.md
+++ b/packages/pocket-ic/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   If the status of the update call is known, but the update call was submitted by a different caller, then an error is returned.
 - The function `PocketIc::await_call_no_ticks` to await the status of an update call (submitted through an ingress message) becoming known without triggering round execution
   (round execution must be triggered separarely, e.g., on a "live" instance or by separate PocketIC library calls).
+- The function `PocketIc::set_certified_time` to set the current certified time on all subnets of the PocketIC instance.
 
 ### Changed
 - The response types `pocket_ic::WasmResult`, `pocket_ic::UserError`, and `pocket_ic::CallError` are replaced by a single reject response type `pocket_ic::RejectResponse`.

--- a/packages/pocket-ic/src/lib.rs
+++ b/packages/pocket-ic/src/lib.rs
@@ -619,6 +619,13 @@ impl PocketIc {
         runtime.block_on(async { self.pocket_ic.set_time(time).await })
     }
 
+    /// Set the current certified time of the IC, on all subnets.
+    #[instrument(skip(self), fields(instance_id=self.pocket_ic.instance_id, time = ?time))]
+    pub fn set_certified_time(&self, time: SystemTime) {
+        let runtime = self.runtime.clone();
+        runtime.block_on(async { self.pocket_ic.set_certified_time(time).await })
+    }
+
     /// Advance the time on the IC on all subnets by some nanoseconds.
     #[instrument(skip(self), fields(instance_id=self.pocket_ic.instance_id, duration = ?duration))]
     pub fn advance_time(&self, duration: Duration) {

--- a/packages/pocket-ic/src/nonblocking.rs
+++ b/packages/pocket-ic/src/nonblocking.rs
@@ -302,7 +302,7 @@ impl PocketIc {
     #[instrument(skip(self), fields(instance_id=self.instance_id))]
     pub async fn auto_progress(&self) -> Url {
         let now = std::time::SystemTime::now();
-        self.set_time(now).await;
+        self.set_certified_time(now).await;
         let endpoint = "auto_progress";
         let auto_progress_config = AutoProgressConfig {
             artificial_delay_ms: None,
@@ -473,6 +473,22 @@ impl PocketIc {
     #[instrument(skip(self), fields(instance_id=self.instance_id, time = ?time))]
     pub async fn set_time(&self, time: SystemTime) {
         let endpoint = "update/set_time";
+        self.post::<(), _>(
+            endpoint,
+            RawTime {
+                nanos_since_epoch: time
+                    .duration_since(SystemTime::UNIX_EPOCH)
+                    .expect("Time went backwards")
+                    .as_nanos() as u64,
+            },
+        )
+        .await;
+    }
+
+    /// Set the current certified time of the IC, on all subnets.
+    #[instrument(skip(self), fields(instance_id=self.instance_id, time = ?time))]
+    pub async fn set_certified_time(&self, time: SystemTime) {
+        let endpoint = "update/set_certified_time";
         self.post::<(), _>(
             endpoint,
             RawTime {

--- a/rs/pocket_ic_server/CHANGELOG.md
+++ b/rs/pocket_ic_server/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - New endpoint `/instances/<instance_id>/read/ingress_status` to fetch the status of an update call submitted through an ingress message.
   If an optional caller is provided, the status of the update call is known, but the update call was submitted by a different caller, then an error is returned.
+- New endpoint `/instances/<instance_id>/update/set_certified_time` to set the current certified time on all subnets of the PocketIC instance.
 
 ### Changed
 - The default IP address to which the PocketIC server and HTTP gateway bind is [::1] instead of 127.0.0.1.

--- a/rs/state_machine_tests/src/lib.rs
+++ b/rs/state_machine_tests/src/lib.rs
@@ -2513,7 +2513,8 @@ impl StateMachine {
             .unwrap_or_else(|_| error!(self.replica_logger, "Time went backwards."));
     }
 
-    /// Certifies the specified time by executing an empty block with that time.
+    /// Certifies the specified time by modifying the time in the replicated state
+    /// and certifying that new state.
     pub fn set_certified_time(&self, time: SystemTime) {
         let t = time
             .duration_since(SystemTime::UNIX_EPOCH)


### PR DESCRIPTION
This PR introduces a new PocketIC operation to set certified time so that query calls and read state requests are evaluated on a state with that (certified) time. Using this new operation to set time in the "live" mode also fixes test [flakiness](https://github.com/dfinity/ic/actions/runs/12909846684/job/35998504336).