### PR TITLE
feat(ic-admin): Show the proposal URL for --dry-run

### DIFF
--- a/rs/registry/admin-derive/src/lib.rs
+++ b/rs/registry/admin-derive/src/lib.rs
@@ -23,7 +23,7 @@ fn impl_proposal_metadata(ast: &syn::DeriveInput) -> TokenStream {
             }
 
             fn url(&self) -> String {
-                parse_proposal_url(self.proposal_url.clone())
+                parse_proposal_url(&self.proposal_url)
             }
 
             fn proposer_and_sender(&self, sender: Sender) -> (NeuronId, Sender) {

--- a/rs/registry/admin/src/helpers.rs
+++ b/rs/registry/admin/src/helpers.rs
@@ -62,7 +62,7 @@ pub(crate) fn summary_from_string_or_file(
 }
 
 /// Parses the URL of a proposal.
-pub(crate) fn parse_proposal_url(url: Option<Url>) -> String {
+pub(crate) fn parse_proposal_url(url: &Option<Url>) -> String {
     match url {
         Some(url) => {
             if url.scheme() != "https" {

--- a/rs/registry/admin/src/main.rs
+++ b/rs/registry/admin/src/main.rs
@@ -3252,7 +3252,7 @@ async fn propose_to_create_service_nervous_system(
     ));
     let title = cmd.title();
     let summary = cmd.summary.clone().unwrap();
-    let url = parse_proposal_url(cmd.proposal_url.clone());
+    let url = parse_proposal_url(&cmd.proposal_url);
     let proposal = MakeProposalRequest {
         title: Some(title.clone()),
         summary,
@@ -5773,7 +5773,7 @@ async fn propose_to_add_or_remove_node_provider(
     let response = canister_client
         .submit_add_or_remove_node_provider_proposal(
             payload,
-            parse_proposal_url(cmd.proposal_url),
+            parse_proposal_url(&cmd.proposal_url),
             title,
             summary,
         )
@@ -6360,12 +6360,14 @@ fn print_proposal<T: Serialize + Debug, Command: ProposalMetadata + ProposalTitl
         struct Proposal<T> {
             title: String,
             summary: String,
+            url: String,
             payload: T,
         }
 
         let serialized = serde_json::to_string_pretty(&Proposal {
             title: cmd.title(),
             summary: cmd.summary(),
+            url: cmd.url(),
             payload,
         })
         .expect("Serialization for the cmd to JSON failed.");
@@ -6373,6 +6375,7 @@ fn print_proposal<T: Serialize + Debug, Command: ProposalMetadata + ProposalTitl
     } else {
         println!("Title: {}\n", cmd.title());
         println!("Summary: {}\n", cmd.summary());
+        println!("URL: {}\n", cmd.url());
         println!("Payload: {:#?}", payload);
     }
 }


### PR DESCRIPTION
- Extend `print_proposal` to include URL information in its output.
- Adjust related code to align with signature change.