### PR TITLE
chore: change redirect code from 303 to 307

### DIFF
--- a/rs/http_endpoints/public/src/lib.rs
+++ b/rs/http_endpoints/public/src/lib.rs
@@ -580,14 +580,13 @@ fn make_router(
         GlobalConcurrencyLimitLayer::new(config.max_pprof_concurrent_requests);
 
     let base_router = Router::new()
-        // TODO this is 303 instead of 302
         .route(
             "/",
-            get(|| async { Redirect::to(DashboardService::route()) }),
+            get(|| async { Redirect::temporary(DashboardService::route()) }),
         )
         .route(
             "/_/",
-            get(|| async { Redirect::to(DashboardService::route()) }),
+            get(|| async { Redirect::temporary(DashboardService::route()) }),
         )
         .fallback(|| async {
             make_plaintext_response(StatusCode::NOT_FOUND, "Endpoint not found.".to_string())


### PR DESCRIPTION
the redirect from `/` and `/_/` to the dashboard service, `/_/dashboard` should return `307`

We can use `307` instead of `302` as the endpoints `/` and `/_/` ony support the method `GET`, meaning that clients preserving the method for the redirect gives the same behavior as using `302`.