### PR TITLE
chore: remove todo for creating domains at compile time

### DIFF
--- a/rs/http_endpoints/public/src/lib.rs
+++ b/rs/http_endpoints/public/src/lib.rs
@@ -917,7 +917,6 @@ async fn try_fetch_delegation_from_nns(
         .connect(
             irrelevant_domain
                 .try_into()
-                // TODO: ideally the expect should run at compile time
                 .expect("failed to create domain"),
             tcp_stream,
         )


### PR DESCRIPTION
The todo message to create [DnsName](https://docs.rs/rustls-pki-types/latest/rustls_pki_types/struct.DnsName.html) at compile time to avoid panics is not possible without a `const` constructor of `DnsName`.

