### PR TITLE
feat: Turn on the features to allow active neurons in stable memory and use stable following index

### DIFF
--- a/rs/nns/governance/src/lib.rs
+++ b/rs/nns/governance/src/lib.rs
@@ -209,9 +209,9 @@ thread_local! {
 
     static ARE_SET_VISIBILITY_PROPOSALS_ENABLED: Cell<bool> = const { Cell::new(true) };
 
-    static ALLOW_ACTIVE_NEURONS_IN_STABLE_MEMORY: Cell<bool> = const { Cell::new(cfg!(feature = "test")) };
+    static ALLOW_ACTIVE_NEURONS_IN_STABLE_MEMORY: Cell<bool> = const { Cell::new(true) };
 
-    static USE_STABLE_MEMORY_FOLLOWING_INDEX: Cell<bool> = const { Cell::new(cfg!(feature = "test")) };
+    static USE_STABLE_MEMORY_FOLLOWING_INDEX: Cell<bool> = const { Cell::new(true) };
 
     static MIGRATE_ACTIVE_NEURONS_TO_STABLE_MEMORY: Cell<bool> = const { Cell::new(cfg!(feature = "test")) };
 }

--- a/rs/nns/governance/unreleased_changelog.md
+++ b/rs/nns/governance/unreleased_changelog.md
@@ -57,6 +57,18 @@ the neuron. More precisely,
 
     b. Its influence on proposals goes to 0.
 
+### Migrating Active Neurons to Stable Memory
+
+In this relesae, we turn on 2 features related to migrating active neurons to stable memory:
+
+1. `allow_active_neurons_in_stable_memory`: this allows the canister to look for active neurons in
+   stable memory, while previously the canister always assumes active neurons are always in the heap.
+
+2. `use_stable_memory_following_index`: this lets the canister use the neuron following index in the
+   stable memory, instead of the one in the heap.
+
+No neurons are actually migrated yet.
+
 ## Changed
 
 * `InstallCode` proposal payload hashes are now computed when making the proposal instead of when


### PR DESCRIPTION
Turn on 2 features:

- ALLOW_ACTIVE_NEURONS_IN_STABLE_MEMORY: this feature enables the canister to read active neurons in stable memory

- USE_STABLE_MEMORY_FOLLOWING_INDEX: this feature starts to let the canister use the neuron following index in the stable memory, instead of the one in the heap

Those will prepare us to turn on the active neurons migration into stable memory, in the next proposal.