### PR TITLE
fix(nns): Fix neurons_fund_total_active_neurons metric

### DIFF
--- a/rs/nns/governance/src/neuron_store/metrics.rs
+++ b/rs/nns/governance/src/neuron_store/metrics.rs
@@ -249,9 +249,7 @@ impl NeuronStore {
         now_seconds: u64,
     ) -> NeuronMetrics {
         let mut metrics = if self.allow_active_neurons_in_stable_memory {
-            NeuronMetrics {
-                ..Default::default()
-            }
+            NeuronMetrics::default()
         } else {
             // If we are not using stable memory for all neurons, we still assume
             // these base level metrics
@@ -259,8 +257,6 @@ impl NeuronStore {
                 garbage_collectable_neurons_count: with_stable_neuron_store(
                     |stable_neuron_store| stable_neuron_store.len() as u64,
                 ),
-                neurons_fund_total_active_neurons: self.list_active_neurons_fund_neurons().len()
-                    as u64,
                 ..Default::default()
             }
         };
@@ -497,6 +493,10 @@ impl NeuronStore {
             metrics.total_staked_maturity_e8s_equivalent +=
                 neuron.staked_maturity_e8s_equivalent.unwrap_or(0);
             metrics.total_maturity_e8s_equivalent += neuron.maturity_e8s_equivalent;
+
+            if Self::is_active_neurons_fund_neuron(neuron, now_seconds) {
+                metrics.neurons_fund_total_active_neurons += 1;
+            }
 
             if neuron.joined_community_fund_timestamp_seconds.unwrap_or(0) > 0 {
                 metrics.community_fund_total_staked_e8s += neuron.minted_stake_e8s();

--- a/rs/nns/governance/src/neuron_store/metrics/tests.rs
+++ b/rs/nns/governance/src/neuron_store/metrics/tests.rs
@@ -1,7 +1,12 @@
 use super::*;
 use crate::{
+    allow_active_neurons_in_stable_memory,
     neuron::{DissolveStateAndAge, NeuronBuilder},
     pb::v1::{KnownNeuronData, NeuronType},
+    temporarily_disable_allow_active_neurons_in_stable_memory,
+    temporarily_disable_migrate_active_neurons_to_stable_memory,
+    temporarily_enable_allow_active_neurons_in_stable_memory,
+    temporarily_enable_migrate_active_neurons_to_stable_memory,
 };
 use ic_base_types::PrincipalId;
 use ic_nervous_system_common::{E8, ONE_DAY_SECONDS, ONE_YEAR_SECONDS};
@@ -26,8 +31,7 @@ fn create_test_neuron_builder(
     )
 }
 
-#[test]
-fn test_compute_metrics() {
+fn test_compute_metrics_helper() {
     let mut neuron_store = NeuronStore::new(BTreeMap::new());
     let now = neuron_store.now();
 
@@ -226,6 +230,19 @@ fn test_compute_metrics() {
             .build(),
         )
         .unwrap();
+    // This neuron is inactive - not founded and dissolved "long ago".
+    neuron_store
+        .add_neuron(
+            create_test_neuron_builder(
+                16,
+                DissolveStateAndAge::DissolvingOrDissolved {
+                    when_dissolved_timestamp_seconds: now - ONE_YEAR_SECONDS,
+                },
+            )
+            .with_cached_neuron_stake_e8s(0)
+            .build(),
+        )
+        .unwrap();
 
     let metrics = neuron_store.compute_neuron_metrics(E8, &VotingPowerEconomics::DEFAULT, now);
 
@@ -246,12 +263,29 @@ fn test_compute_metrics() {
             16 => 6087000000.0,
         },
         not_dissolving_neurons_count_buckets: hashmap! {0 => 3, 2 => 1, 8 => 2, 16 => 1},
-        dissolved_neurons_count: 3,
+        dissolved_neurons_count: if allow_active_neurons_in_stable_memory() {
+            // This is accurate.
+            4
+        } else {
+            // This is the incorrect behavior when inactive neurons are migrated to stable
+            // memory, which will be fixed once `allow_active_neurons_in_stable_memory` is
+            // turned on.
+            3
+        },
         dissolved_neurons_e8s: 5770000000,
-        garbage_collectable_neurons_count: 0,
+        garbage_collectable_neurons_count: 1,
         neurons_with_invalid_stake_count: 1,
         total_staked_e8s: 39_894_000_100,
-        neurons_with_less_than_6_months_dissolve_delay_count: 6,
+        neurons_with_less_than_6_months_dissolve_delay_count:
+            if allow_active_neurons_in_stable_memory() {
+                // This is accurate.
+                7
+            } else {
+                // This is the incorrect behavior when inactive neurons are migrated to stable
+                // memory, which will be fixed once `allow_active_neurons_in_stable_memory` is
+                // turned on.
+                6
+            },
         neurons_with_less_than_6_months_dissolve_delay_e8s: 5870000100,
         community_fund_total_staked_e8s: 234_000_000,
         community_fund_total_maturity_e8s_equivalent: 450_988_012,
@@ -302,6 +336,33 @@ fn test_compute_metrics() {
         },
         expected_metrics,
     );
+}
+
+// In this stage, no active neurons can be in stable memory.
+#[test]
+fn test_compute_metrics() {
+    let _t1 = temporarily_disable_allow_active_neurons_in_stable_memory();
+    let _t2 = temporarily_disable_migrate_active_neurons_to_stable_memory();
+
+    test_compute_metrics_helper();
+}
+
+// Migration stage 1: allow active neurons in stable memory, but not migrating yet.
+#[test]
+fn test_compute_metrics_allow_active_neurons_in_stable_memory() {
+    let _t1 = temporarily_enable_allow_active_neurons_in_stable_memory();
+    let _t2 = temporarily_disable_migrate_active_neurons_to_stable_memory();
+
+    test_compute_metrics_helper();
+}
+
+// Migration stage 2: allow active neurons in stable memory and new active neurons are in stable memory.
+#[test]
+fn test_compute_metrics_migrate_active_neurons_to_stable_memory() {
+    let _t1 = temporarily_enable_allow_active_neurons_in_stable_memory();
+    let _t2 = temporarily_enable_migrate_active_neurons_to_stable_memory();
+
+    test_compute_metrics_helper();
 }
 
 #[test]


### PR DESCRIPTION
# Why

The `neurons_fund_total_active_neurons` calculation was wrong when `allow_active_neurons_in_stable_memory = true` and `migrate_active_neurons_to_stable_memory = false` (the first phase of the migration). This was not detected in tests because the 2 flags always have the same value (both true or both false).

# What

- Fix the metric calculation
- Add an inactive neuron into test, and test the metrics calculation under different combinations of the flag
- Documented that the previous calculation of `dissolved_neurons_count` and `neurons_with_less_than_6_months_dissolve_delay_count` are wrong when inactive neurons are in stable memory, and letting the tests reflect that