### PR TITLE
chore(nns): Refactor NeuronId::from_subaccount to test_utils since it's only used in tests

### DIFF
--- a/rs/nns/common/src/lib.rs
+++ b/rs/nns/common/src/lib.rs
@@ -1,8 +1,7 @@
 use crate::pb::v1::{NeuronId, ProposalId};
-use ic_crypto_sha2::Sha256;
 use ic_stable_structures::{storable::Bound, Storable};
 use num_traits::bounds::{LowerBounded, UpperBounded};
-use std::{borrow::Cow, convert::TryInto};
+use std::borrow::Cow;
 
 pub mod access_control;
 pub mod init;

--- a/rs/nns/common/src/lib.rs
+++ b/rs/nns/common/src/lib.rs
@@ -14,18 +14,6 @@ impl NeuronId {
     pub const MIN: Self = Self { id: u64::MIN };
     pub const MAX: Self = Self { id: u64::MAX };
 
-    pub fn from_subaccount(subaccount: &[u8; 32]) -> Self {
-        Self {
-            id: {
-                let mut state = Sha256::new();
-                state.write(subaccount);
-                // TODO(NNS1-192) We should just store the Sha256, but for now
-                // we convert it to a number
-                u64::from_ne_bytes(state.finish()[0..8].try_into().unwrap())
-            },
-        }
-    }
-
     pub fn next(&self) -> Option<NeuronId> {
         self.id.checked_add(1).map(|id| NeuronId { id })
     }

--- a/rs/nns/test_utils/src/gtc_helpers.rs
+++ b/rs/nns/test_utils/src/gtc_helpers.rs
@@ -254,6 +254,7 @@ fn make_neuron(
 
     let subaccount_hash = Sha256::hash(&subaccount);
     let neuron_id = NeuronId {
+        // We just need a unique ID for the neuron, so we use the first 8 bytes to create a u64.
         id: u64::from_ne_bytes(subaccount_hash[0..8].try_into().unwrap()),
     };
 

--- a/rs/nns/test_utils/src/gtc_helpers.rs
+++ b/rs/nns/test_utils/src/gtc_helpers.rs
@@ -252,8 +252,13 @@ fn make_neuron(
         )
     };
 
+    let subaccount_hash = Sha256::hash(&subaccount);
+    let neuron_id = NeuronId {
+        id: u64::from_ne_bytes(subaccount_hash[0..8].try_into().unwrap()),
+    };
+
     Neuron {
-        id: Some(NeuronId::from_subaccount(&subaccount)),
+        id: Some(neuron_id),
         account: subaccount.to_vec(),
         controller: Some(GENESIS_TOKEN_CANISTER_ID.get()),
         cached_neuron_stake_e8s: stake_e8s,


### PR DESCRIPTION
This is a trivial inlining, since `NeuronId::from_subaccount` is only used in one place. Putting it together with production code creates confusion about how NNS neuron ids are created in production.