### PR TITLE
feat(nns): Change `include_empty_neurons_readable_by_caller` default to false

### DIFF
--- a/rs/nervous_system/integration_tests/src/pocket_ic_helpers.rs
+++ b/rs/nervous_system/integration_tests/src/pocket_ic_helpers.rs
@@ -830,7 +830,7 @@ pub mod nns {
                     Encode!(&ListNeurons {
                         neuron_ids: vec![],
                         include_neurons_readable_by_caller: true,
-                        include_empty_neurons_readable_by_caller: None,
+                        include_empty_neurons_readable_by_caller: Some(true),
                         include_public_neurons_in_full_neurons: None,
                         page_number: None,
                         page_size: None

--- a/rs/nns/governance/src/governance.rs
+++ b/rs/nns/governance/src/governance.rs
@@ -2285,11 +2285,8 @@ impl Governance {
             .unwrap_or(MAX_LIST_NEURONS_RESULTS as u64)
             .min(MAX_LIST_NEURONS_RESULTS as u64);
 
-        let include_empty_neurons_readable_by_caller = include_empty_neurons_readable_by_caller
-            // This default is to maintain the previous behavior. (Unlike
-            // protobuf, we do not have a convention that says "the default
-            // value is falsy".)
-            .unwrap_or(true);
+        let include_empty_neurons_readable_by_caller =
+            include_empty_neurons_readable_by_caller.unwrap_or(false);
         let include_public_neurons_in_full_neurons =
             include_public_neurons_in_full_neurons.unwrap_or(false);
 

--- a/rs/nns/governance/src/governance/tests/list_neurons.rs
+++ b/rs/nns/governance/src/governance/tests/list_neurons.rs
@@ -46,7 +46,7 @@ fn test_list_neurons_with_paging() {
     let mut request = ListNeurons {
         neuron_ids: vec![],
         include_neurons_readable_by_caller: true,
-        include_empty_neurons_readable_by_caller: None,
+        include_empty_neurons_readable_by_caller: Some(true),
         include_public_neurons_in_full_neurons: None,
         page_number: None,
         page_size: None,
@@ -64,7 +64,7 @@ fn test_list_neurons_with_paging() {
         &ListNeurons {
             neuron_ids: vec![],
             include_neurons_readable_by_caller: true,
-            include_empty_neurons_readable_by_caller: None,
+            include_empty_neurons_readable_by_caller: Some(true),
             include_public_neurons_in_full_neurons: None,
             page_number: Some(1),
             page_size: None,
@@ -80,7 +80,7 @@ fn test_list_neurons_with_paging() {
         &ListNeurons {
             neuron_ids: vec![],
             include_neurons_readable_by_caller: true,
-            include_empty_neurons_readable_by_caller: None,
+            include_empty_neurons_readable_by_caller: Some(true),
             include_public_neurons_in_full_neurons: None,
             page_number: Some(0),
             page_size: Some(501),

--- a/rs/nns/governance/unreleased_changelog.md
+++ b/rs/nns/governance/unreleased_changelog.md
@@ -62,6 +62,10 @@ the neuron. More precisely,
 * `InstallCode` proposal payload hashes are now computed when making the proposal instead of when
   listing proposal. Hashes for existing proposals are backfilled.
 
+* The `list_neurons` behavior is slightly changed: the `include_empty_neurons_readable_by_caller`
+  was default to true before, and now it's default to true. More details can be found at:
+  https://forum.dfinity.org/t/listneurons-api-change-empty-neurons/40311
+
 ## Deprecated
 
 ## Removed

--- a/rs/nns/integration_tests/src/governance_neurons.rs
+++ b/rs/nns/integration_tests/src/governance_neurons.rs
@@ -604,6 +604,6 @@ fn test_list_neurons() {
             page_size: None,
         },
     );
-    assert_eq!(list_neurons_response.neuron_infos.len(), 3);
-    assert_eq!(list_neurons_response.full_neurons.len(), 2);
+    assert_eq!(list_neurons_response.neuron_infos.len(), 2);
+    assert_eq!(list_neurons_response.full_neurons.len(), 1);
 }


### PR DESCRIPTION
# Why

The `include_empty_neurons_readable_by_caller` flag was default to true in order to retain the behavior before it was introduced. Now that it has been introduced for a while, changing its default to false will help preserving resources in the NNS Governance.

Details can be found at: https://forum.dfinity.org/t/listneurons-api-change-empty-neurons/40311

