### PR TITLE
chore: remove todo messages in call_v3.rs

### DIFF
--- a/rs/http_endpoints/public/src/call/call_v3.rs
+++ b/rs/http_endpoints/public/src/call/call_v3.rs
@@ -11,7 +11,8 @@ use crate::{
         CALL_V3_EARLY_RESPONSE_DUPLICATE_SUBSCRIPTION,
         CALL_V3_EARLY_RESPONSE_INGRESS_WATCHER_NOT_RUNNING,
         CALL_V3_EARLY_RESPONSE_MESSAGE_ALREADY_IN_CERTIFIED_STATE,
-        CALL_V3_EARLY_RESPONSE_SUBSCRIPTION_TIMEOUT,
+        CALL_V3_EARLY_RESPONSE_SUBSCRIPTION_TIMEOUT, CALL_V3_STATUS_IS_INVALID_UTF8,
+        CALL_V3_STATUS_IS_NOT_LEAF,
     },
     HttpError,
 };
@@ -328,9 +329,12 @@ fn parsed_message_status(tree: &MixedHashTree, message_id: &MessageId) -> Parsed
 
     match tree.lookup(&status_path) {
         LookupStatus::Found(MixedHashTree::Leaf(status)) => ParsedMessageStatus::Known(
-            String::from_utf8(status.clone()).unwrap_or_else(|_| "invalid_utf8_status".to_string()),
+            String::from_utf8(status.clone())
+                .unwrap_or_else(|_| CALL_V3_STATUS_IS_INVALID_UTF8.to_string()),
         ),
-        LookupStatus::Found(_) => ParsedMessageStatus::Known("Status not a leaf".to_string()),
+        LookupStatus::Found(_) => {
+            ParsedMessageStatus::Known(CALL_V3_STATUS_IS_NOT_LEAF.to_string())
+        }
         LookupStatus::Absent | LookupStatus::Unknown => ParsedMessageStatus::Unknown,
     }
 }

--- a/rs/http_endpoints/public/src/call/call_v3.rs
+++ b/rs/http_endpoints/public/src/call/call_v3.rs
@@ -224,16 +224,11 @@ async fn call_sync_v3(
         .await
     {
         Ok(Ok(message_subscriber)) => Ok(message_subscriber),
-        Ok(Err(SubscriptionError::DuplicateSubscriptionError)) => {
-            // TODO: At this point we could return early without submitting the ingress message.
-            Err((
-                "Duplicate request. Message is already being tracked and executed.",
-                CALL_V3_EARLY_RESPONSE_DUPLICATE_SUBSCRIPTION,
-            ))
-        }
+        Ok(Err(SubscriptionError::DuplicateSubscriptionError)) => Err((
+            "Duplicate request. Message is already being tracked and executed.",
+            CALL_V3_EARLY_RESPONSE_DUPLICATE_SUBSCRIPTION,
+        )),
         Ok(Err(SubscriptionError::IngressWatcherNotRunning { error_message })) => {
-            // TODO: Send a warning or notification.
-            // This probably means that the ingress watcher panicked.
             error!(
                 every_n_seconds => LOG_EVERY_N_SECONDS,
                 log,
@@ -335,8 +330,6 @@ fn parsed_message_status(tree: &MixedHashTree, message_id: &MessageId) -> Parsed
         LookupStatus::Found(MixedHashTree::Leaf(status)) => ParsedMessageStatus::Known(
             String::from_utf8(status.clone()).unwrap_or_else(|_| "invalid_utf8_status".to_string()),
         ),
-        // This should never happen. Otherwise the tree is not following the spec.
-        // TODO: Log as error.
         LookupStatus::Found(_) => ParsedMessageStatus::Known("Status not a leaf".to_string()),
         LookupStatus::Absent | LookupStatus::Unknown => ParsedMessageStatus::Unknown,
     }

--- a/rs/http_endpoints/public/src/call/call_v3.rs
+++ b/rs/http_endpoints/public/src/call/call_v3.rs
@@ -298,7 +298,6 @@ async fn call_sync_v3(
         );
     };
 
-    // Log the status of the message.
     let status_label = match parsed_message_status(&tree, &message_id) {
         ParsedMessageStatus::Known(status) => status,
         ParsedMessageStatus::Unknown => "unknown".to_string(),

--- a/rs/http_endpoints/public/src/metrics.rs
+++ b/rs/http_endpoints/public/src/metrics.rs
@@ -17,6 +17,7 @@ pub const LABEL_HEALTH_STATUS_AFTER: &str = "after";
 pub const LABEL_CALL_V3_CERTIFICATE_STATUS: &str = "status";
 
 // Call v3 labels
+// !!! Be careful to update alert queries in k8s repo if changing these constants.!!!
 pub const LABEL_CALL_V3_EARLY_RESPONSE_TRIGGER: &str = "trigger";
 pub const CALL_V3_EARLY_RESPONSE_INGRESS_WATCHER_NOT_RUNNING: &str = "ingress_watcher_not_running";
 pub const CALL_V3_EARLY_RESPONSE_DUPLICATE_SUBSCRIPTION: &str = "duplicate_subscription";
@@ -24,6 +25,8 @@ pub const CALL_V3_EARLY_RESPONSE_SUBSCRIPTION_TIMEOUT: &str = "subscription_time
 pub const CALL_V3_EARLY_RESPONSE_CERTIFICATION_TIMEOUT: &str = "certification_timeout";
 pub const CALL_V3_EARLY_RESPONSE_MESSAGE_ALREADY_IN_CERTIFIED_STATE: &str =
     "message_already_in_certified_state";
+pub const CALL_V3_STATUS_IS_NOT_LEAF: &str = "not_leaf";
+pub const CALL_V3_STATUS_IS_INVALID_UTF8: &str = "is_invalid_utf8";
 
 /// Placeholder used when we can't determine the appropriate prometheus label.
 pub const LABEL_UNKNOWN: &str = "unknown";


### PR DESCRIPTION
The todo messages are completed in a PR that adds alerts/slack notifications.