### PR TITLE
chore: handle panics when joining on cancellations in ingress_watcher event loop

### DIFF
--- a/rs/http_endpoints/public/src/call/ingress_watcher.rs
+++ b/rs/http_endpoints/public/src/call/ingress_watcher.rs
@@ -239,10 +239,11 @@ impl IngressWatcher {
                     self.handle_certification(*certified_height.borrow_and_update());
                 }
                 // Cancel the tracking of an ingress message.
-                // TODO: Handle Some(Err(_)) case?
-                Some(Ok((_, message_id))) = self.cancellations.join_next() => {
-                    self.metrics.ingress_watcher_cancelled_subscriptions_total.inc();
-                    self.handle_cancellation(&message_id);
+                Some(cancellation_handle) = self.cancellations.join_next() => {
+                    if let Ok((_, message_id)) = cancellation_handle {
+                        self.metrics.ingress_watcher_cancelled_subscriptions_total.inc();
+                        self.handle_cancellation(&message_id);
+                    }
                 }
 
                 _ = self.cancellation_token.cancelled() => {
@@ -478,7 +479,6 @@ mod tests {
         assert_eq!(ingress_watcher.completed_execution_heights.len(), 0);
     }
 
-    /// TODO: Can be removed. We have integration test covering the sames scenario.
     #[rstest]
     fn test_handling_of_duplicate_requests(mut ingress_watcher: IngressWatcher) {
         let message = MessageId::from([0; EXPECTED_MESSAGE_ID_LENGTH]);

--- a/rs/http_endpoints/public/src/call/ingress_watcher.rs
+++ b/rs/http_endpoints/public/src/call/ingress_watcher.rs
@@ -247,7 +247,7 @@ impl IngressWatcher {
                         }
                         // If the task panics we propagate the panic.
                         Err(join_error) => if join_error.is_panic() {
-                            panic!("Ingress watcher cancellation task panicked.");
+                            std::panic::resume_unwind(join_error.into_panic());
                         }
                     }
                 }


### PR DESCRIPTION
This PR propagates panics from cancellations tasks.