### PR TITLE
feat(crypto): CRP-2670 store registry version in threshold sig data store

### DIFF
--- a/rs/crypto/src/sign/threshold_sig/ni_dkg/transcript.rs
+++ b/rs/crypto/src/sign/threshold_sig/ni_dkg/transcript.rs
@@ -240,6 +240,7 @@ mod loading {
             lockable_threshold_sig_data_store,
             &csp_transcript,
             &transcript.dkg_id,
+            transcript.registry_version,
             &transcript.committee,
         );
         let epoch = epoch(transcript.registry_version);
@@ -321,6 +322,7 @@ mod loading {
         lockable_threshold_sig_data_store: &LockableThresholdSigDataStore,
         csp_transcript: &CspNiDkgTranscript,
         dkg_id: &NiDkgId,
+        registry_version: RegistryVersion,
         committee: &NiDkgReceivers,
     ) {
         lockable_threshold_sig_data_store
@@ -329,6 +331,7 @@ mod loading {
                 dkg_id,
                 CspPublicCoefficients::from(csp_transcript),
                 indices(committee),
+                registry_version,
             );
     }
 

--- a/rs/crypto/src/sign/threshold_sig/store.rs
+++ b/rs/crypto/src/sign/threshold_sig/store.rs
@@ -26,6 +26,7 @@ pub trait ThresholdSigDataStore {
         dkg_id: &NiDkgId,
         public_coefficients: CspPublicCoefficients,
         indices: BTreeMap<NodeId, NodeIndex>,
+        registry_version: RegistryVersion,
     );
 
     /// Inserts an individual public key for a given `dkg_id` and a given
@@ -56,6 +57,7 @@ pub trait ThresholdSigDataStore {
 pub struct TranscriptData {
     public_coeffs: CspPublicCoefficients,
     indices: BTreeMap<NodeId, NodeIndex>,
+    registry_version: RegistryVersion,
 }
 
 impl TranscriptData {
@@ -67,6 +69,15 @@ impl TranscriptData {
     /// Returns a reference to the index of the node with ID `node_id`.
     pub fn index(&self, node_id: NodeId) -> Option<&NodeIndex> {
         self.indices.get(&node_id)
+    }
+
+    /// Returns a reference to the registry version.
+    /////////////////////////////////////////
+    // TODO: remove allow(unused) once in use
+    /////////////////////////////////////////
+    #[allow(unused)]
+    pub fn registry_version(&self) -> RegistryVersion {
+        self.registry_version
     }
 }
 
@@ -215,11 +226,13 @@ impl ThresholdSigDataStore for ThresholdSigDataStoreImpl {
         dkg_id: &NiDkgId,
         public_coefficients: CspPublicCoefficients,
         indices: BTreeMap<NodeId, NodeIndex>,
+        registry_version: RegistryVersion,
     ) {
         let data = self.entry_for(dkg_id);
         data.transcript_data = Some(TranscriptData {
             public_coeffs: public_coefficients,
             indices,
+            registry_version,
         });
 
         self.purge_entry_for_oldest_dkg_id_if_necessary(&dkg_id.dkg_tag);

--- a/rs/crypto/src/sign/threshold_sig/store.rs
+++ b/rs/crypto/src/sign/threshold_sig/store.rs
@@ -73,8 +73,7 @@ impl TranscriptData {
 
     /// Returns a reference to the registry version.
     /////////////////////////////////////////
-    // TODO: remove allow(unused) once in use
-    /////////////////////////////////////////
+    // TODO(CRP-2599): remove allow(unused) once this method is used
     #[allow(unused)]
     pub fn registry_version(&self) -> RegistryVersion {
         self.registry_version

--- a/rs/crypto/src/sign/threshold_sig/store/tests.rs
+++ b/rs/crypto/src/sign/threshold_sig/store/tests.rs
@@ -6,6 +6,7 @@ use ic_management_canister_types::{VetKdCurve, VetKdKeyId};
 use ic_types::crypto::threshold_sig::ni_dkg::{NiDkgId, NiDkgTargetId, NiDkgTargetSubnet};
 use ic_types::Height;
 use ic_types_test_utils::ids::{node_test_id, SUBNET_1};
+use sign::tests::{REG_V1, REG_V2};
 use strum::{EnumCount, IntoEnumIterator};
 
 const NODE_1: u64 = 1;
@@ -42,7 +43,7 @@ fn should_contain_transcript_data_after_insertion_with_nidkg_id() {
 
         let dkg_id = ni_dkg_id_with_tag(tag.clone(), 42);
 
-        store.insert_transcript_data(&dkg_id, public_coeffs.clone(), indices);
+        store.insert_transcript_data(&dkg_id, public_coeffs.clone(), indices, REG_V1);
 
         let transcript_data = store.transcript_data(&dkg_id).unwrap();
         assert_eq!(transcript_data.public_coefficients(), &public_coeffs);
@@ -54,6 +55,7 @@ fn should_contain_transcript_data_after_insertion_with_nidkg_id() {
             transcript_data.index(node_test_id(NODE_2)),
             Some(&NODE_2_INDEX)
         );
+        assert_eq!(transcript_data.registry_version(), REG_V1);
     }
 }
 
@@ -127,8 +129,8 @@ fn should_overwrite_existing_public_coefficients() {
         assert_ne!(public_coeffs_1, public_coeffs_2);
         let ni_dkg_id = ni_dkg_id_with_tag(tag.clone(), 1);
 
-        store.insert_transcript_data(&ni_dkg_id, public_coeffs_1, BTreeMap::new());
-        store.insert_transcript_data(&ni_dkg_id, public_coeffs_2.clone(), BTreeMap::new());
+        store.insert_transcript_data(&ni_dkg_id, public_coeffs_1, BTreeMap::new(), REG_V1);
+        store.insert_transcript_data(&ni_dkg_id, public_coeffs_2.clone(), BTreeMap::new(), REG_V1);
 
         let transcript_data = store.transcript_data(&ni_dkg_id).unwrap();
         assert_eq!(transcript_data.public_coefficients(), &public_coeffs_2);
@@ -144,8 +146,8 @@ fn should_overwrite_existing_indices() {
         let public_coeffs = public_coeffs();
         let ni_dkg_id = ni_dkg_id_with_tag(tag.clone(), 1);
 
-        store.insert_transcript_data(&ni_dkg_id, public_coeffs.clone(), indices_1);
-        store.insert_transcript_data(&ni_dkg_id, public_coeffs, indices_2);
+        store.insert_transcript_data(&ni_dkg_id, public_coeffs.clone(), indices_1, REG_V1);
+        store.insert_transcript_data(&ni_dkg_id, public_coeffs, indices_2, REG_V1);
 
         let transcript_data = store.transcript_data(&ni_dkg_id).unwrap();
         assert_eq!(transcript_data.index(node_test_id(NODE_1)), None);
@@ -153,6 +155,22 @@ fn should_overwrite_existing_indices() {
             transcript_data.index(node_test_id(NODE_2)),
             Some(&NODE_2_INDEX)
         );
+    }
+}
+
+#[test]
+fn should_overwrite_existing_registry_version() {
+    for tag in all_tags() {
+        let mut store = ThresholdSigDataStoreImpl::new();
+        let (reg_v1, reg_v2) = (REG_V1, REG_V2);
+        assert_ne!(reg_v1, reg_v2);
+        let ni_dkg_id = ni_dkg_id_with_tag(tag.clone(), 1);
+
+        store.insert_transcript_data(&ni_dkg_id, public_coeffs(), BTreeMap::new(), reg_v1);
+        store.insert_transcript_data(&ni_dkg_id, public_coeffs(), BTreeMap::new(), reg_v2);
+
+        let transcript_data = store.transcript_data(&ni_dkg_id).unwrap();
+        assert_eq!(transcript_data.registry_version(), reg_v2);
     }
 }
 
@@ -176,7 +194,7 @@ fn should_overwrite_existing_individual_public_keys() {
 }
 
 #[test]
-fn should_not_purge_data_on_inserting_coeffs_and_indices_if_capacity_not_exceeded() {
+fn should_not_purge_data_on_inserting_transcript_data_if_capacity_not_exceeded() {
     for tag in all_tags() {
         let mut store = ThresholdSigDataStoreImpl::new();
 
@@ -185,6 +203,7 @@ fn should_not_purge_data_on_inserting_coeffs_and_indices_if_capacity_not_exceede
                 &ni_dkg_id_with_tag(tag.clone(), i),
                 public_coeffs(),
                 BTreeMap::new(),
+                REG_V1,
             );
         }
 
@@ -216,16 +235,18 @@ fn should_not_purge_data_on_inserting_pubkeys_if_capacity_not_exceeded() {
 }
 
 #[test]
-fn should_purge_data_on_inserting_coeffs_and_indices_if_capacity_exceeded() {
+fn should_purge_data_on_inserting_transcript_data_if_capacity_exceeded() {
     for tag in all_tags() {
         let mut store = ThresholdSigDataStoreImpl::new();
         let pub_coeffs = public_coeffs();
+        let registry_version = REG_V1;
 
         for i in 1..=ThresholdSigDataStoreImpl::CAPACITY_PER_TAG_OR_KEY + 1 {
             store.insert_transcript_data(
                 &ni_dkg_id_with_tag(tag.clone(), i),
                 pub_coeffs.clone(),
                 BTreeMap::new(),
+                registry_version,
             );
         }
 
@@ -246,16 +267,18 @@ fn should_purge_data_on_inserting_coeffs_and_indices_if_capacity_exceeded() {
 }
 
 #[test]
-fn should_purge_data_in_insertion_order_on_inserting_coeffs_and_indices_if_capacity_exceeded() {
+fn should_purge_data_in_insertion_order_on_inserting_transcript_data_if_capacity_exceeded() {
     for tag in all_tags() {
         let mut store = ThresholdSigDataStoreImpl::new();
         let pub_coeffs = public_coeffs();
+        let registry_version = REG_V1;
 
         for i in (1..=ThresholdSigDataStoreImpl::CAPACITY_PER_TAG_OR_KEY + 1).rev() {
             store.insert_transcript_data(
                 &ni_dkg_id_with_tag(tag.clone(), i),
                 pub_coeffs.clone(),
                 BTreeMap::new(),
+                registry_version,
             );
         }
 
@@ -284,17 +307,20 @@ fn should_not_purge_all_transcripts_of_certain_threshold_if_capacity_exceeded(
 ) {
     let mut store = ThresholdSigDataStoreImpl::new();
     let pub_coeffs = public_coeffs();
+    let registry_version = REG_V1;
 
     store.insert_transcript_data(
         &ni_dkg_id_with_tag(single_transcript_threshold.clone(), 1),
         pub_coeffs.clone(),
         BTreeMap::new(),
+        registry_version,
     );
     for i in 0..ThresholdSigDataStoreImpl::CAPACITY_PER_TAG_OR_KEY + 1 {
         store.insert_transcript_data(
             &ni_dkg_id_with_tag(other_transcripts_threshold.clone(), i),
             pub_coeffs.clone(),
             BTreeMap::new(),
+            registry_version,
         );
     }
 
@@ -409,6 +435,7 @@ fn should_purge_data_in_insertion_order_on_inserting_pubkeys_if_max_size_exceede
 fn should_store_up_to_capacity_per_tag_for_all_tags() {
     let mut store = ThresholdSigDataStoreImpl::new();
     let pub_coeffs = public_coeffs();
+    let registry_version = REG_V1;
 
     for i in 0..ThresholdSigDataStoreImpl::CAPACITY_PER_TAG_OR_KEY {
         for tag in all_tags() {
@@ -416,6 +443,7 @@ fn should_store_up_to_capacity_per_tag_for_all_tags() {
                 &ni_dkg_id_with_tag(tag.clone(), i),
                 pub_coeffs.clone(),
                 BTreeMap::new(),
+                registry_version,
             );
         }
     }
@@ -430,6 +458,7 @@ fn should_store_up_to_capacity_per_tag_for_all_tags() {
             &ni_dkg_id_with_tag(tag, ThresholdSigDataStoreImpl::CAPACITY_PER_TAG_OR_KEY),
             pub_coeffs.clone(),
             BTreeMap::new(),
+            registry_version,
         );
     }
 

--- a/rs/crypto/src/sign/threshold_sig/tests.rs
+++ b/rs/crypto/src/sign/threshold_sig/tests.rs
@@ -22,6 +22,7 @@ use ic_types::crypto::{CombinedThresholdSig, SignableMock, ThresholdSigShare};
 use ic_types::Height;
 use ic_types::SubnetId;
 use ic_types_test_utils::ids::{NODE_1, SUBNET_1};
+use sign::tests::REG_V1;
 
 pub const NODE_ID: NodeId = NODE_1;
 
@@ -344,7 +345,7 @@ mod verify_threshold_sig_share {
     fn should_return_ok_if_sig_verification_ok_and_public_key_not_in_store() {
         let (sig_share, message, csp_public_key) = (sig_share(), signable_mock(), csp_public_key());
         let threshold_sig_data_store =
-            threshold_sig_data_store_with_non_empty_coeffs_and_indices_for_dkg_id(&NI_DKG_ID_1);
+            threshold_sig_data_store_with_non_empty_transcript_data_for_dkg_id(&NI_DKG_ID_1);
         let mut csp = MockAllCryptoServiceProvider::new();
         csp.expect_threshold_individual_public_key()
             .times(1)
@@ -391,7 +392,7 @@ mod verify_threshold_sig_share {
         let verification_error = sig_verification_error();
         let (sig_share, message, csp_public_key) = (sig_share(), signable_mock(), csp_public_key());
         let threshold_sig_data_store =
-            threshold_sig_data_store_with_non_empty_coeffs_and_indices_for_dkg_id(&NI_DKG_ID_1);
+            threshold_sig_data_store_with_non_empty_transcript_data_for_dkg_id(&NI_DKG_ID_1);
         let mut csp = MockAllCryptoServiceProvider::new();
         csp.expect_threshold_individual_public_key()
             .times(1)
@@ -417,7 +418,7 @@ mod verify_threshold_sig_share {
     fn should_have_correct_public_key_in_store_after_sig_verification_if_not_in_store_before() {
         let (sig_share, message, csp_public_key) = (sig_share(), signable_mock(), csp_public_key());
         let threshold_sig_data_store =
-            threshold_sig_data_store_with_non_empty_coeffs_and_indices_for_dkg_id(&NI_DKG_ID_1);
+            threshold_sig_data_store_with_non_empty_transcript_data_for_dkg_id(&NI_DKG_ID_1);
         let mut csp = MockAllCryptoServiceProvider::new();
         csp.expect_threshold_individual_public_key()
             .times(1)
@@ -521,7 +522,7 @@ mod verify_threshold_sig_share {
     fn should_fail_with_malformed_signature_if_signature_has_invalid_length() {
         let (sig_share, message) = (invalid_threshold_sig_share(), signable_mock());
         let threshold_sig_data_store =
-            threshold_sig_data_store_with_non_empty_coeffs_and_indices_for_dkg_id(&NI_DKG_ID_1);
+            threshold_sig_data_store_with_non_empty_transcript_data_for_dkg_id(&NI_DKG_ID_1);
         let mut csp = MockAllCryptoServiceProvider::new();
         csp.expect_threshold_individual_public_key().times(0);
         csp.expect_threshold_verify_individual_signature().times(0);
@@ -1598,17 +1599,20 @@ fn threshold_sig_data_store_with(
     let store = LockableThresholdSigDataStore::new();
     store
         .write()
-        .insert_transcript_data(dkg_id, public_coeffs, indices);
+        .insert_transcript_data(dkg_id, public_coeffs, indices, REG_V1);
     store
 }
 
-fn threshold_sig_data_store_with_non_empty_coeffs_and_indices_for_dkg_id(
+fn threshold_sig_data_store_with_non_empty_transcript_data_for_dkg_id(
     ni_dkg_id: &NiDkgId,
 ) -> LockableThresholdSigDataStore {
     let store = LockableThresholdSigDataStore::new();
-    store
-        .write()
-        .insert_transcript_data(ni_dkg_id, pub_coeffs(), indices(vec![(NODE_ID, 1)]));
+    store.write().insert_transcript_data(
+        ni_dkg_id,
+        pub_coeffs(),
+        indices(vec![(NODE_ID, 1)]),
+        REG_V1,
+    );
     store
 }
 
@@ -1621,6 +1625,7 @@ fn threshold_sig_data_store_with_coeffs(
         dkg_id,
         csp_public_coefficients,
         BTreeMap::new(),
+        REG_V1,
     );
     threshold_sig_data_store
 }
@@ -1633,7 +1638,7 @@ fn threshold_sig_data_store_with_coeffs_and_pubkey(
     let threshold_sig_data_store = LockableThresholdSigDataStore::new();
     {
         let mut locked_store = threshold_sig_data_store.write();
-        locked_store.insert_transcript_data(dkg_id, pub_coeffs(), BTreeMap::new());
+        locked_store.insert_transcript_data(dkg_id, pub_coeffs(), BTreeMap::new(), REG_V1);
         locked_store.insert_individual_public_key(dkg_id, node_id, public_key);
     }
     threshold_sig_data_store


### PR DESCRIPTION
Stores the registry version in the threshold sig data store whenever an NI-DKG transcript is loaded. This will later be needed for implementing the VetKdProtocol.