### PR TITLE
fix: ic-gateway: remove load shedding

### DIFF
--- a/ic-os/components/boundary-guestos/opt/ic/bin/setup-ic-gateway.sh
+++ b/ic-os/components/boundary-guestos/opt/ic/bin/setup-ic-gateway.sh
@@ -148,9 +148,6 @@ CACHE_XFETCH_BETA="3.0"
 SHED_SYSTEM_EWMA="0.9"
 SHED_SYSTEM_CPU="0.95"
 SHED_SYSTEM_MEMORY="0.95"
-SHED_SHARDED_EWMA="0.6"
-SHED_SHARDED_PASSTHROUGH="20000"
-SHED_SHARDED_LATENCY="query:2s,call:2s,sync_call:13s,read_state:2s,read_state_subnet:2s,status:100ms,health:100ms,registrations:5s,http:5s"
 EOF
 
     if [ ! -z "${DENYLIST_URL:-}" ]; then
@@ -165,10 +162,6 @@ EOF
 
     if [ ! -z "${MAX_CONCURRENCY:-}" ]; then
         echo "LOAD_MAX_CONCURRENCY=\"${MAX_CONCURRENCY}\"" >>"${ENV_FILE}"
-    fi
-
-    if [ ! -z "${SHED_EWMA_PARAM:-}" ]; then
-        echo "LOAD_SHED_EWMA_PARAM=\"${SHED_EWMA_PARAM}\"" >>"${ENV_FILE}"
     fi
 }
 


### PR DESCRIPTION
Disable latency load shedding since it causes some false positives. Also remove deprecated config option.