### PR TITLE
chore(fuzzing): Enable `bes` config for sandbox based fuzzers

### DIFF
--- a/bin/run-all-fuzzers.sh
+++ b/bin/run-all-fuzzers.sh
@@ -24,7 +24,7 @@ EOF
         done
         LIST_OF_FUZZERS=$(bazel query 'attr(tags, "sandbox_libfuzzer", //rs/...)')
         for FUZZER in $LIST_OF_FUZZERS; do
-            bazel run --config=sandbox_fuzzing $FUZZER -- -runs=$MAX_EXECUTIONS
+            bazel run --config=bes --config=sandbox_fuzzing $FUZZER -- -runs=$MAX_EXECUTIONS
         done
         ;;
 


### PR DESCRIPTION
We recently saw a few spurious failures in the fuzzing hourly job and have been unable to reproduce them locally. This PR enables remote upload of artifacts for sandbox based fuzzers to debug the build artifacts further. 