### PR TITLE
chore: remove last todo comment in HTTP-handler

### DIFF
--- a/rs/http_endpoints/public/src/common.rs
+++ b/rs/http_endpoints/public/src/common.rs
@@ -91,7 +91,6 @@ pub(crate) async fn map_box_error_to_response(err: BoxError) -> Response<Body> {
     }
 }
 
-// TODO: NET-1667
 pub fn cors_layer() -> CorsLayer {
     CorsLayer::new()
         .allow_methods([Method::GET, Method::POST])


### PR DESCRIPTION
Removing TODO comment for NET-1667 which has previously been resolved as "won't do".