### PR TITLE
fix(IDX): enable colors in clippy

### DIFF
--- a/.github/workflows-source/ci-main.yml
+++ b/.github/workflows-source/ci-main.yml
@@ -378,6 +378,7 @@ jobs:
           BUILDEVENT_APIKEY: ${{ secrets. HONEYCOMB_API_TOKEN }}
         run: |
           set -eExuo pipefail
+          export CARGO_TERM_COLOR=always # ensure output has colors
           buildevents cmd "$CI_RUN_ID" "$CI_JOB_NAME" build-command -- \
               "$CI_PROJECT_DIR"/ci/scripts/rust-lint.sh
 


### PR DESCRIPTION
This sets
[`CARGO_TERM_COLOR`](https://doc.rust-lang.org/cargo/reference/config.html#termcolor) to "always" so that the output from clippy has nice colors.