### PR TITLE
feat(cycles-minting-canister): Enabled automatic refunds.

### DIFF
--- a/rs/nns/cmc/src/lib.rs
+++ b/rs/nns/cmc/src/lib.rs
@@ -12,7 +12,7 @@ use icp_ledger::{
 use icrc_ledger_types::icrc1::account::Account;
 use serde::{Deserialize, Serialize};
 
-pub const IS_AUTOMATIC_REFUND_ENABLED: bool = false;
+pub const IS_AUTOMATIC_REFUND_ENABLED: bool = true;
 
 pub const DEFAULT_CYCLES_PER_XDR: u128 = 1_000_000_000_000u128; // 1T cycles = 1 XDR
 

--- a/rs/nns/cmc/src/lib.rs
+++ b/rs/nns/cmc/src/lib.rs
@@ -12,6 +12,7 @@ use icp_ledger::{
 use icrc_ledger_types::icrc1::account::Account;
 use serde::{Deserialize, Serialize};
 
+// TODO(NNS1-3566): Delete this.
 pub const IS_AUTOMATIC_REFUND_ENABLED: bool = true;
 
 pub const DEFAULT_CYCLES_PER_XDR: u128 = 1_000_000_000_000u128; // 1T cycles = 1 XDR

--- a/rs/nns/cmc/unreleased_changelog.md
+++ b/rs/nns/cmc/unreleased_changelog.md
@@ -9,6 +9,12 @@ on the process that this file is part of, see
 
 ## Added
 
+* Automatically refund when the memo in an incoming ICP transfer is not one of
+  the special values that indicate the purpose of the transfer (e.g. to create a
+  new canister). This was originally proposed without objection in [the forum].
+
+[the forum]: https://forum.dfinity.org/t/extend-cycles-minting-canister-functionality/37749/2
+
 ## Changed
 
 ## Deprecated

--- a/rs/nns/integration_tests/src/cycles_minting_canister.rs
+++ b/rs/nns/integration_tests/src/cycles_minting_canister.rs
@@ -1424,7 +1424,7 @@ fn cmc_notify_mint_cycles() {
         panic!("notify rejected")
     };
     let result = Decode!(&res, Result<NotifyMintCyclesSuccess, NotifyError>).unwrap();
-    if cycles_minting_canister::IS_AUTOMATIC_REFUND_ENABLED {
+    if IS_AUTOMATIC_REFUND_ENABLED {
         let reason = match &result {
             Err(NotifyError::Refunded { reason, block_index: _ }) => reason,
             _ => panic!("{:?}", result),

--- a/rs/nns/integration_tests/src/cycles_minting_canister.rs
+++ b/rs/nns/integration_tests/src/cycles_minting_canister.rs
@@ -1426,13 +1426,21 @@ fn cmc_notify_mint_cycles() {
     let result = Decode!(&res, Result<NotifyMintCyclesSuccess, NotifyError>).unwrap();
     if IS_AUTOMATIC_REFUND_ENABLED {
         let reason = match &result {
-            Err(NotifyError::Refunded { reason, block_index: _ }) => reason,
+            Err(NotifyError::Refunded {
+                reason,
+                block_index: _,
+            }) => reason,
             _ => panic!("{:?}", result),
         };
 
         let reason = reason.to_lowercase();
         for key_word in ["memo", "transfer", "correspond", "offer"] {
-            assert!(reason.contains(key_word), "{} not in reason of {:?}", key_word, result);
+            assert!(
+                reason.contains(key_word),
+                "{} not in reason of {:?}",
+                key_word,
+                result
+            );
         }
     } else {
         // Legacy behavior.


### PR DESCRIPTION
Implementation of this feature was done in an [earlier PR][impl], but was left disabled. For details of this feature, see the description of the aforementioned PR.

[impl]: https://github.com/dfinity/ic/pull/3484

Per the reminder bot, an entry has been added to unreleased_changes.md.