### PR TITLE
feat(EXC-1847): Support for `ic0.subnet_self()`

### DIFF
--- a/rs/embedders/src/wasm_utils/validation.rs
+++ b/rs/embedders/src/wasm_utils/validation.rs
@@ -637,6 +637,26 @@ fn get_valid_system_apis_common(I: ValType) -> HashMap<String, HashMap<String, F
                 },
             )],
         ),
+        (
+            "subnet_self_size",
+            vec![(
+                API_VERSION_IC0,
+                FunctionSignature {
+                    param_types: vec![],
+                    return_type: vec![I],
+                },
+            )],
+        ),
+        (
+            "subnet_self_copy",
+            vec![(
+                API_VERSION_IC0,
+                FunctionSignature {
+                    param_types: vec![I, I, I],
+                    return_type: vec![],
+                },
+            )],
+        ),
     ];
 
     valid_system_apis

--- a/rs/embedders/src/wasmtime_embedder/system_api.rs
+++ b/rs/embedders/src/wasmtime_embedder/system_api.rs
@@ -459,7 +459,7 @@ pub fn syscalls<
                 charge_for_cpu(&mut caller, overhead::MSG_METHOD_NAME_SIZE)?;
                 with_system_api(&mut caller, |s| s.ic0_msg_method_name_size()).and_then(|s| {
                     I::try_from(s).map_err(|e| {
-                        anyhow::Error::msg(format!("ic0::msg_metohd_name_size failed: {}", e))
+                        anyhow::Error::msg(format!("ic0::msg_method_name_size failed: {}", e))
                     })
                 })
             }
@@ -1043,7 +1043,7 @@ pub fn syscalls<
                 charge_for_cpu(&mut caller, overhead::SUBNET_SELF_SIZE)?;
                 with_system_api(&mut caller, |s| s.ic0_subnet_self_size()).and_then(|s| {
                     I::try_from(s).map_err(|e| {
-                        anyhow::Error::msg(format!("ic0::msg_metohd_name_size failed: {}", e))
+                        anyhow::Error::msg(format!("ic0::subnet_self_size failed: {}", e))
                     })
                 })
             }

--- a/rs/embedders/src/wasmtime_embedder/system_api.rs
+++ b/rs/embedders/src/wasmtime_embedder/system_api.rs
@@ -1037,6 +1037,38 @@ pub fn syscalls<
         })
         .unwrap();
 
+    linker
+        .func_wrap("ic0", "subnet_self_size", {
+            move |mut caller: Caller<'_, StoreData>| {
+                charge_for_cpu(&mut caller, overhead::SUBNET_SELF_SIZE)?;
+                with_system_api(&mut caller, |s| s.ic0_subnet_self_size()).and_then(|s| {
+                    I::try_from(s).map_err(|e| {
+                        anyhow::Error::msg(format!("ic0::msg_metohd_name_size failed: {}", e))
+                    })
+                })
+            }
+        })
+        .unwrap();
+
+    linker
+        .func_wrap("ic0", "subnet_self_copy", {
+            move |mut caller: Caller<'_, StoreData>, dst: I, offset: I, size: I| {
+                let dst: usize = dst.try_into().expect("Failed to convert I to usize");
+                let offset: usize = offset.try_into().expect("Failed to convert I to usize");
+                let size: usize = size.try_into().expect("Failed to convert I to usize");
+                charge_for_cpu_and_mem(&mut caller, overhead::SUBNET_SELF_COPY, size)?;
+                with_memory_and_system_api(&mut caller, |system_api, memory| {
+                    system_api.ic0_subnet_self_copy(dst, offset, size, memory)
+                })?;
+                if feature_flags.write_barrier == FlagStatus::Enabled {
+                    mark_writes_on_bytemap(&mut caller, dst, size)
+                } else {
+                    Ok(())
+                }
+            }
+        })
+        .unwrap();
+
     match main_memory_type {
         WasmMemoryType::Wasm32 => {
             linker

--- a/rs/embedders/src/wasmtime_embedder/system_api_complexity.rs
+++ b/rs/embedders/src/wasmtime_embedder/system_api_complexity.rs
@@ -62,6 +62,8 @@ pub mod overhead {
     pub const MSG_REPLY_DATA_APPEND: NumInstructions = NumInstructions::new(500);
     pub const MSG_REPLY: NumInstructions = NumInstructions::new(500);
     pub const PERFORMANCE_COUNTER: NumInstructions = NumInstructions::new(200);
+    pub const SUBNET_SELF_SIZE: NumInstructions = NumInstructions::new(500);
+    pub const SUBNET_SELF_COPY: NumInstructions = NumInstructions::new(500);
     pub const STABLE_GROW: NumInstructions = NumInstructions::new(500);
     pub const STABLE_READ: NumInstructions = NumInstructions::new(20);
     pub const STABLE_SIZE: NumInstructions = NumInstructions::new(20);

--- a/rs/embedders/tests/wasmtime_embedder.rs
+++ b/rs/embedders/tests/wasmtime_embedder.rs
@@ -2185,6 +2185,11 @@ fn wasm64_import_system_api_functions() {
       (import "ic0" "is_controller"
         (func $ic0_is_controller (param i64) (param i64) (result i32)))
 
+      (import "ic0" "subnet_self_size"
+        (func $ic0_subnet_self_size (result i64)))
+      (import "ic0" "subnet_self_copy"
+        (func $ic0_subnet_self_copy (param i64) (param i64) (param i64)))
+
         (global $g1 (export "g1") (mut i64) (i64.const 0))
         (func $test (export "canister_update test")
             (i64.store (i64.const 0) (memory.grow (i64.const 1)))
@@ -2688,6 +2693,130 @@ fn wasm64_canister_self_copy() {
 
     let mut expected_heap = vec![0; dirty_heap_size];
     expected_heap[0..canister_id.len()].copy_from_slice(canister_id);
+
+    assert_eq!(wasm_heap, expected_heap);
+}
+
+#[test]
+fn wasm64_subnet_self_size() {
+    let wat = r#"
+    (module
+      (import "ic0" "subnet_self_size"
+        (func $ic0_subnet_self_size (result i64)))
+
+      (global $g1 (export "g1") (mut i64) (i64.const 0))
+      (func $test (export "canister_update test")
+        (call $ic0_subnet_self_size)
+        global.set $g1
+      )
+
+      (memory (export "memory") i64 1)
+    )"#;
+
+    let caller = user_test_id(24).get();
+    let payload: Vec<u8> = vec![1, 3, 5, 7];
+    let api = ic_system_api::ApiType::update(
+        UNIX_EPOCH,
+        payload.clone(),
+        Cycles::zero(),
+        caller,
+        call_context_test_id(13),
+    );
+
+    let mut config = ic_config::embedders::Config::default();
+    config.feature_flags.wasm64 = FlagStatus::Enabled;
+    let mut instance = WasmtimeInstanceBuilder::new()
+        .with_config(config)
+        .with_wat(wat)
+        .with_api_type(api)
+        .build();
+
+    let res = instance
+        .run(FuncRef::Method(WasmMethod::Update("test".to_string())))
+        .unwrap();
+
+    assert_eq!(
+        res.exported_globals[0],
+        Global::I64(
+            instance
+                .store_data()
+                .system_api()
+                .unwrap()
+                .ic0_subnet_self_size()
+                .unwrap() as i64
+        )
+    );
+}
+
+#[test]
+fn wasm64_subnet_self_copy() {
+    let wat = r#"
+    (module
+      (import "ic0" "subnet_self_copy"
+        (func $ic0_subnet_self_copy (param i64) (param i64) (param i64)))
+      (import "ic0" "subnet_self_size"
+        (func $ic0_subnet_self_size (result i64)))
+
+      (global $g1 (export "g1") (mut i64) (i64.const 0))
+      (func $test (export "canister_update test")
+        (call $ic0_subnet_self_size)
+        global.set $g1
+        (call $ic0_subnet_self_copy (i64.const 0) (i64.const 0) (call $ic0_subnet_self_size))
+      )
+
+      (memory (export "memory") i64 1)
+    )"#;
+
+    let caller = user_test_id(24).get();
+    let payload: Vec<u8> = vec![1, 3, 5, 7];
+    let api = ic_system_api::ApiType::update(
+        UNIX_EPOCH,
+        payload.clone(),
+        Cycles::zero(),
+        caller,
+        call_context_test_id(13),
+    );
+
+    let mut config = ic_config::embedders::Config::default();
+    config.feature_flags.wasm64 = FlagStatus::Enabled;
+    let mut instance = WasmtimeInstanceBuilder::new()
+        .with_config(config)
+        .with_wat(wat)
+        .with_api_type(api)
+        .build();
+
+    let res = instance
+        .run(FuncRef::Method(WasmMethod::Update("test".to_string())))
+        .unwrap();
+
+    // Only first os page should have been touched.
+    assert_eq!(res.wasm_dirty_pages, vec![ic_sys::PageIndex::new(0)]);
+
+    // Actual heap is larger, but we can only access first os page, the rest is protected.
+    let dirty_heap_size = ic_sys::PAGE_SIZE;
+
+    let wasm_heap: &[u8] = unsafe {
+        let addr = instance.heap_addr(CanisterMemoryType::Heap);
+        let size_in_bytes =
+            instance.heap_size(CanisterMemoryType::Heap).get() * WASM_PAGE_SIZE_IN_BYTES;
+        assert!(size_in_bytes >= dirty_heap_size);
+        std::slice::from_raw_parts_mut(addr as *mut _, dirty_heap_size)
+    };
+
+    let mut expected_heap = vec![0; dirty_heap_size];
+    let subnet_id_size = instance
+        .store_data()
+        .system_api()
+        .unwrap()
+        .ic0_subnet_self_size()
+        .unwrap();
+
+    instance
+        .store_data()
+        .system_api()
+        .unwrap()
+        .ic0_subnet_self_copy(0, 0, subnet_id_size, &mut expected_heap)
+        .unwrap();
 
     assert_eq!(wasm_heap, expected_heap);
 }

--- a/rs/execution_environment/src/query_handler/query_cache/tests.rs
+++ b/rs/execution_environment/src/query_handler/query_cache/tests.rs
@@ -1510,6 +1510,8 @@ fn query_cache_future_proof_test() {
         | SystemApiCallId::MsgReplyDataAppend
         | SystemApiCallId::OutOfInstructions
         | SystemApiCallId::PerformanceCounter
+        | SystemApiCallId::SubnetSelfSize
+        | SystemApiCallId::SubnetSelfCopy
         | SystemApiCallId::Stable64Grow
         | SystemApiCallId::Stable64Read
         | SystemApiCallId::Stable64Size

--- a/rs/execution_environment/tests/hypervisor.rs
+++ b/rs/execution_environment/tests/hypervisor.rs
@@ -2020,15 +2020,23 @@ fn ic0_subnet_self_size_works() {
             (func (export "canister_update test")
                 ;; heap[0] = $subnet_self_size()
                 (i32.store (i32.const 0) (call $subnet_self_size))
-                ;; return heap[0]
-                (call $msg_reply_data_append (i32.const 0) (i32.const 1))
+                ;; return heap[0-4]
+                (call $msg_reply_data_append (i32.const 0) (i32.const 4))
                 (call $msg_reply)
             )
             (memory 1 1)
         )"#;
     let canister_id = test.canister_from_wat(wat).unwrap();
     let result = test.ingress(canister_id, "test", vec![]).unwrap();
-    assert_eq!(WasmResult::Reply(vec![10]), result);
+    assert_eq!(
+        WasmResult::Reply(vec![
+            test.get_own_subnet_id().get().as_slice().len() as u8,
+            0,
+            0,
+            0
+        ]),
+        result
+    );
 }
 
 #[test]

--- a/rs/execution_environment/tests/hypervisor.rs
+++ b/rs/execution_environment/tests/hypervisor.rs
@@ -2007,6 +2007,61 @@ fn ic0_canister_self_copy_works() {
 }
 
 #[test]
+fn ic0_subnet_self_size_works() {
+    let mut test = ExecutionTestBuilder::new().build();
+    let wat = r#"
+        (module
+            (import "ic0" "subnet_self_size"
+                (func $subnet_self_size (result i32))
+            )
+            (import "ic0" "msg_reply" (func $msg_reply))
+            (import "ic0" "msg_reply_data_append"
+            (func $msg_reply_data_append (param i32 i32)))
+            (func (export "canister_update test")
+                ;; heap[0] = $subnet_self_size()
+                (i32.store (i32.const 0) (call $subnet_self_size))
+                ;; return heap[0]
+                (call $msg_reply_data_append (i32.const 0) (i32.const 1))
+                (call $msg_reply)
+            )
+            (memory 1 1)
+        )"#;
+    let canister_id = test.canister_from_wat(wat).unwrap();
+    let result = test.ingress(canister_id, "test", vec![]).unwrap();
+    assert_eq!(WasmResult::Reply(vec![10]), result);
+}
+
+#[test]
+fn ic0_subnet_self_copy_works() {
+    let mut test = ExecutionTestBuilder::new().build();
+    let wat = r#"
+        (module
+            (import "ic0" "subnet_self_copy"
+                (func $subnet_self_copy (param i32 i32 i32))
+            )
+            (import "ic0" "msg_reply" (func $msg_reply))
+            (import "ic0" "msg_reply_data_append"
+            (func $msg_reply_data_append (param i32 i32)))
+            (func (export "canister_update test")
+                ;; heap[0..4] = subnet_id_bytes[0..4]
+                (call $subnet_self_copy (i32.const 0) (i32.const 0) (i32.const 4))
+                ;; heap[4..10] = subnet_id_bytes[4..8]
+                (call $subnet_self_copy (i32.const 4) (i32.const 4) (i32.const 6))
+                ;; return heap[0..10]
+                (call $msg_reply_data_append (i32.const 0) (i32.const 10))
+                (call $msg_reply)
+            )
+            (memory 1 1)
+        )"#;
+    let canister_id = test.canister_from_wat(wat).unwrap();
+    let result = test.ingress(canister_id, "test", vec![]).unwrap();
+    assert_eq!(
+        WasmResult::Reply(test.get_own_subnet_id().get().into_vec()),
+        result
+    );
+}
+
+#[test]
 fn ic0_call_has_no_effect_on_trap() {
     let mut test = ExecutionTestBuilder::new().build();
     let wat = r#"

--- a/rs/interfaces/src/execution_environment.rs
+++ b/rs/interfaces/src/execution_environment.rs
@@ -219,6 +219,10 @@ pub enum SystemApiCallId {
     OutOfInstructions,
     /// Tracker for `ic0.performance_counter()`
     PerformanceCounter,
+    /// Tracker for `ic0.subnet_self_size()`
+    SubnetSelfSize,
+    /// Tracker for `ic0.subnet_self_copy()`
+    SubnetSelfCopy,
     /// Tracker for `ic0.stable64_grow()`
     Stable64Grow,
     /// Tracker for `ic0.stable64_read()`
@@ -1170,6 +1174,19 @@ pub trait SystemApi {
         &mut self,
         amount: Cycles,
         dst: usize,
+        heap: &mut [u8],
+    ) -> HypervisorResult<()>;
+
+    /// Used to look up the size of the subnet Id of the calling canister.
+    fn ic0_subnet_self_size(&self) -> HypervisorResult<usize>;
+
+    /// Used to copy the subnet Id of the calling canister to its heap
+    /// at the location specified by `dst` and `offset`.
+    fn ic0_subnet_self_copy(
+        &self,
+        dst: usize,
+        offset: usize,
+        size: usize,
         heap: &mut [u8],
     ) -> HypervisorResult<()>;
 }

--- a/rs/system_api/src/lib.rs
+++ b/rs/system_api/src/lib.rs
@@ -3541,6 +3541,70 @@ impl SystemApi for SystemApiImpl {
         trace_syscall!(self, CyclesBurn128, result, amount);
         result
     }
+
+    fn ic0_subnet_self_size(&self) -> HypervisorResult<usize> {
+        let result = match &self.api_type {
+            ApiType::Start { .. } => Err(self.error_for("ic0_subnet_self_size")),
+            ApiType::Init { .. }
+            | ApiType::SystemTask { .. }
+            | ApiType::Cleanup { .. }
+            | ApiType::Update { .. }
+            | ApiType::ReplicatedQuery { .. }
+            | ApiType::NonReplicatedQuery { .. }
+            | ApiType::ReplyCallback { .. }
+            | ApiType::RejectCallback { .. }
+            | ApiType::PreUpgrade { .. }
+            | ApiType::InspectMessage { .. } => {
+                let subnet_id = self.sandbox_safe_system_state.get_subnet_id();
+                println!("subnet_id: {:?}", subnet_id);
+                Ok(subnet_id.get_ref().as_slice().len())
+            }
+        };
+
+        trace_syscall!(self, SubnetSelfSize, result);
+        result
+    }
+
+    fn ic0_subnet_self_copy(
+        &self,
+        dst: usize,
+        offset: usize,
+        size: usize,
+        heap: &mut [u8],
+    ) -> HypervisorResult<()> {
+        let result = match &self.api_type {
+            ApiType::Start { .. } => Err(self.error_for("ic0.subnet_self_copy")),
+            ApiType::Init { .. }
+            | ApiType::SystemTask { .. }
+            | ApiType::Cleanup { .. }
+            | ApiType::Update { .. }
+            | ApiType::ReplicatedQuery { .. }
+            | ApiType::NonReplicatedQuery { .. }
+            | ApiType::PreUpgrade { .. }
+            | ApiType::ReplyCallback { .. }
+            | ApiType::RejectCallback { .. }
+            | ApiType::InspectMessage { .. } => {
+                valid_subslice("ic0.subnet_self_copy heap", dst, size, heap)?;
+                let subnet_id = self.sandbox_safe_system_state.get_subnet_id();
+                let id_bytes = subnet_id.get_ref().as_slice();
+                let slice = valid_subslice("ic0.subnet_self_copy id", offset, size, id_bytes)?;
+                deterministic_copy_from_slice(&mut heap[dst..dst + size], slice);
+
+                println!("subnet_id: {:?}", subnet_id);
+                Ok(())
+            }
+        };
+        trace_syscall!(
+            self,
+            SubnetSelfCopy,
+            dst,
+            offset,
+            size,
+            summarize(heap, dst, size)
+        );
+
+        result
+    }
 }
 
 /// The default implementation of the `OutOfInstructionHandler` trait.

--- a/rs/system_api/src/lib.rs
+++ b/rs/system_api/src/lib.rs
@@ -3556,7 +3556,6 @@ impl SystemApi for SystemApiImpl {
             | ApiType::PreUpgrade { .. }
             | ApiType::InspectMessage { .. } => {
                 let subnet_id = self.sandbox_safe_system_state.get_subnet_id();
-                println!("subnet_id: {:?}", subnet_id);
                 Ok(subnet_id.get_ref().as_slice().len())
             }
         };
@@ -3590,7 +3589,6 @@ impl SystemApi for SystemApiImpl {
                 let slice = valid_subslice("ic0.subnet_self_copy id", offset, size, id_bytes)?;
                 deterministic_copy_from_slice(&mut heap[dst..dst + size], slice);
 
-                println!("subnet_id: {:?}", subnet_id);
                 Ok(())
             }
         };

--- a/rs/system_api/src/sandbox_safe_system_state.rs
+++ b/rs/system_api/src/sandbox_safe_system_state.rs
@@ -1341,6 +1341,10 @@ impl SandboxSafeSystemState {
             false
         }
     }
+
+    pub fn get_subnet_id(&self) -> SubnetId {
+        self.cycles_account_manager.get_subnet_id()
+    }
 }
 
 /// Holds the metadata and the number of downstream requests. Requests created during the same

--- a/rs/system_api/tests/system_api.rs
+++ b/rs/system_api/tests/system_api.rs
@@ -299,9 +299,18 @@ fn is_supported(api_type: SystemApiCallId, context: &str) -> bool {
         SystemApiCallId::DebugPrint => vec!["*", "s"],
         SystemApiCallId::Trap => vec!["*", "s"],
         SystemApiCallId::MintCycles => vec!["U", "Ry", "Rt", "T"],
-        SystemApiCallId::MintCycles128 => vec!["U", "Ry", "Rt", "T"]
+        SystemApiCallId::MintCycles128 => vec!["U", "Ry", "Rt", "T"],
+        SystemApiCallId::SubnetSelfSize => vec!["*"],
+        SystemApiCallId::SubnetSelfCopy => vec!["*"],
     };
     // the semantics of "*" is to cover all modes except for "s"
+    println!(
+        "Checking if {:?} is supported in context {:?} and api type {:?}",
+        matrix.get(&api_type).unwrap().contains(&context)
+            || (context != "s" && matrix.get(&api_type).unwrap().contains(&"*")),
+        context,
+        api_type
+    );
     matrix.get(&api_type).unwrap().contains(&context)
         || (context != "s" && matrix.get(&api_type).unwrap().contains(&"*"))
 }
@@ -779,6 +788,26 @@ fn api_availability_test(
         SystemApiCallId::CyclesBurn128 => {
             assert_api_availability(
                 |mut api| api.ic0_cycles_burn128(Cycles::zero(), 0, &mut [42; 128]),
+                api_type,
+                &system_state,
+                cycles_account_manager,
+                api_type_enum,
+                context,
+            );
+        }
+        SystemApiCallId::SubnetSelfSize => {
+            assert_api_availability(
+                |api| api.ic0_subnet_self_size(),
+                api_type,
+                &system_state,
+                cycles_account_manager,
+                api_type_enum,
+                context,
+            );
+        }
+        SystemApiCallId::SubnetSelfCopy => {
+            assert_api_availability(
+                |api| api.ic0_subnet_self_copy(0, 0, 0, &mut [42; 128]),
                 api_type,
                 &system_state,
                 cycles_account_manager,

--- a/rs/system_api/tests/system_api.rs
+++ b/rs/system_api/tests/system_api.rs
@@ -304,13 +304,6 @@ fn is_supported(api_type: SystemApiCallId, context: &str) -> bool {
         SystemApiCallId::SubnetSelfCopy => vec!["*"],
     };
     // the semantics of "*" is to cover all modes except for "s"
-    println!(
-        "Checking if {:?} is supported in context {:?} and api type {:?}",
-        matrix.get(&api_type).unwrap().contains(&context)
-            || (context != "s" && matrix.get(&api_type).unwrap().contains(&"*")),
-        context,
-        api_type
-    );
     matrix.get(&api_type).unwrap().contains(&context)
         || (context != "s" && matrix.get(&api_type).unwrap().contains(&"*"))
 }

--- a/rs/test_utilities/execution_environment/src/lib.rs
+++ b/rs/test_utilities/execution_environment/src/lib.rs
@@ -1711,6 +1711,10 @@ impl ExecutionTest {
     pub fn query_stats_set_epoch_for_testing(&mut self, epoch: QueryStatsEpoch) {
         self.query_handler.query_stats_set_epoch_for_testing(epoch);
     }
+
+    pub fn get_own_subnet_id(&self) -> SubnetId {
+        self.cycles_account_manager.get_subnet_id()
+    }
 }
 
 /// A builder for `ExecutionTest`.

--- a/rs/universal_canister/impl/src/api.rs
+++ b/rs/universal_canister/impl/src/api.rs
@@ -77,6 +77,9 @@ mod ic0 {
         pub fn in_replicated_execution() -> u32;
 
         pub fn cycles_burn128(amount_high: u64, amount_low: u64, dst: u32) -> ();
+
+        pub fn subnet_self_size() -> u32;
+        pub fn subnet_self_copy(dst: u32, offset: u32, size: u32) -> ();
     }
 }
 
@@ -195,6 +198,16 @@ pub fn id() -> Vec<u8> {
     let mut bytes = vec![0; len as usize];
     unsafe {
         ic0::canister_self_copy(bytes.as_mut_ptr() as u32, 0, len);
+    }
+    bytes
+}
+
+/// Returns the subnet id of the canister as a blob.
+pub fn subnet_id() -> Vec<u8> {
+    let len: u32 = unsafe { ic0::subnet_self_size() };
+    let mut bytes = vec![0; len as usize];
+    unsafe {
+        ic0::subnet_self_copy(bytes.as_mut_ptr() as u32, 0, len);
     }
     bytes
 }

--- a/rs/universal_canister/impl/src/api.rs
+++ b/rs/universal_canister/impl/src/api.rs
@@ -77,9 +77,6 @@ mod ic0 {
         pub fn in_replicated_execution() -> u32;
 
         pub fn cycles_burn128(amount_high: u64, amount_low: u64, dst: u32) -> ();
-
-        pub fn subnet_self_size() -> u32;
-        pub fn subnet_self_copy(dst: u32, offset: u32, size: u32) -> ();
     }
 }
 
@@ -198,16 +195,6 @@ pub fn id() -> Vec<u8> {
     let mut bytes = vec![0; len as usize];
     unsafe {
         ic0::canister_self_copy(bytes.as_mut_ptr() as u32, 0, len);
-    }
-    bytes
-}
-
-/// Returns the subnet id of the canister as a blob.
-pub fn subnet_id() -> Vec<u8> {
-    let len: u32 = unsafe { ic0::subnet_self_size() };
-    let mut bytes = vec![0; len as usize];
-    unsafe {
-        ic0::subnet_self_copy(bytes.as_mut_ptr() as u32, 0, len);
     }
     bytes
 }


### PR DESCRIPTION
This PR implements a new system API that enables canisters to learn which subnet they run on. The new functionality is composed of two functions: `ic0.subnet_self_size()` and `ic0.subnet_self_copy()`, described in this [Spec PR](https://github.com/dfinity/portal/pull/3790).