### PR TITLE
feat(node): Log guestos.service console logs to tty1

### DIFF
--- a/ic-os/components/hostos-scripts/guestos/guestos.service
+++ b/ic-os/components/hostos-scripts/guestos/guestos.service
@@ -13,6 +13,7 @@ ExecStart=/opt/ic/bin/start-guestos.sh
 ExecStartPost=/opt/ic/bin/manageboot.sh hostos confirm
 ExecStop=/opt/ic/bin/stop-guestos.sh
 Restart=on-failure
+RestartSec=300
 
 [Install]
 WantedBy=multi-user.target

--- a/ic-os/components/hostos-scripts/guestos/start-guestos.sh
+++ b/ic-os/components/hostos-scripts/guestos/start-guestos.sh
@@ -82,7 +82,7 @@ function start_guestos() {
             write_tty1_log "#################################################"
             write_tty1_log "###          TROUBLESHOOTING INFO...          ###"
             write_tty1_log "#################################################"
-            host_ipv6_address="$(/opt/ic/bin/hostos_tool generate-ipv6-address --node-type GuestOS 2>/dev/null)"
+            host_ipv6_address="$(/opt/ic/bin/hostos_tool generate-ipv6-address --node-type HostOS 2>/dev/null)"
             write_tty1_log "Host ipv6 address: $host_ipv6_address"
 
             if [ -f /var/log/libvirt/qemu/guestos-serial.log ]; then
@@ -102,6 +102,8 @@ function start_guestos() {
 
         sleep 10
         write_tty1_log "GuestOS virtual machine successfully launched.\nIf onboarding, please wait for up to 10 minutes for a 'Join request successful!' message\n\n\n"
+        host_ipv6_address="$(/opt/ic/bin/hostos_tool generate-ipv6-address --node-type HostOS 2>/dev/null)"
+        write_tty1_log "Host ipv6 address: $host_ipv6_address\n"
 
         write_log "Starting GuestOS virtual machine."
         write_metric "hostos_guestos_service_start" \

--- a/ic-os/components/hostos-scripts/guestos/start-guestos.sh
+++ b/ic-os/components/hostos-scripts/guestos/start-guestos.sh
@@ -68,9 +68,8 @@ function start_guestos() {
         write_log "Starting GuestOS virtual machine."
         # Attempt to start; if it fails, dump logs.
         if ! virsh start guestos; then
-            # The sleep below gives QEMU time to clear/reinitialize its console
-            # so that error messages won't be immediately overwritten. This helps
-            # ensure the logs and troubleshooting info remain visible on the host console.
+            # The sleep below gives QEMU time to clear the console so that
+            # error messages won't be immediately overwritten.
             sleep 10
 
             write_tty1_log "ERROR: Failed to start GuestOS virtual machine.\n\n\n"

--- a/ic-os/components/hostos-scripts/guestos/start-guestos.sh
+++ b/ic-os/components/hostos-scripts/guestos/start-guestos.sh
@@ -72,7 +72,7 @@ function start_guestos() {
             # error messages won't be immediately overwritten.
             sleep 10
 
-            write_tty1_log "ERROR: Failed to start GuestOS virtual machine.\n\n\n"
+            write_tty1_log "ERROR: Failed to start GuestOS virtual machine."
 
             write_tty1_log "#################################################"
             write_tty1_log "###      LOGGING GUESTOS.SERVICE LOGS...      ###"

--- a/ic-os/components/hostos-scripts/guestos/start-guestos.sh
+++ b/ic-os/components/hostos-scripts/guestos/start-guestos.sh
@@ -32,6 +32,14 @@ done
 # Set arguments if undefined
 CONFIG="${CONFIG:=/var/lib/libvirt/guestos.xml}"
 
+write_tty1_log() {
+    local message=$1
+
+    echo "${SCRIPT} ${message}" > /dev/tty1
+
+    logger -t "${SCRIPT}" "${message}"
+}
+
 function define_guestos() {
     if [ "$(virsh list --all | grep 'guestos')" ]; then
         write_log "GuestOS virtual machine is already defined."
@@ -57,7 +65,44 @@ function start_guestos() {
             "GuestOS virtual machine start state" \
             "gauge"
     else
-        virsh start guestos
+        # Attempt to start; if it fails, dump logs.
+        if ! virsh start guestos; then
+            # The sleep below gives QEMU time to clear/reinitialize its console 
+            # so that error messages won't be immediately overwritten. This helps
+            # ensure the logs and troubleshooting info remain visible on the host console.
+            sleep 10
+
+            write_tty1_log "ERROR: Failed to start GuestOS virtual machine.\n\n\n"
+
+            write_tty1_log "#################################################"
+            write_tty1_log "###      LOGGING GUESTOS.SERVICE LOGS...      ###"
+            write_tty1_log "#################################################"
+            journalctl -u guestos.service > /dev/tty1
+
+            write_tty1_log "#################################################"
+            write_tty1_log "###          TROUBLESHOOTING INFO...          ###"
+            write_tty1_log "#################################################"
+            host_ipv6_address="$(/opt/ic/bin/hostos_tool generate-ipv6-address --node-type GuestOS 2>/dev/null)"
+            write_tty1_log "Host ipv6 address: $host_ipv6_address"
+
+            if [ -f /var/log/libvirt/qemu/guestos-serial.log ]; then
+                write_tty1_log "#################################################"
+                write_tty1_log "###  LOGGING GUESTOS CONSOLE LOGS, IF ANY...  ###"
+                write_tty1_log "#################################################"
+                tail -n 30 /var/log/libvirt/qemu/guestos-serial.log | while IFS= read -r line; do
+                    write_tty1_log "$line"
+                done
+            else
+                write_tty1_log "No /var/log/libvirt/qemu/guestos-serial.log file found."
+            fi
+
+            write_tty1_log "Exiting start-guestos.sh so that systemd can restart guestos.service in 5 minutes."
+            exit 1
+        fi
+
+        sleep 10
+        write_tty1_log "GuestOS virtual machine successfully launched.\nIf onboarding, please wait for up to 10 minutes for a 'Join request successful!' message\n\n\n"
+
         write_log "Starting GuestOS virtual machine."
         write_metric "hostos_guestos_service_start" \
             "1" \

--- a/ic-os/components/hostos-scripts/guestos/start-guestos.sh
+++ b/ic-os/components/hostos-scripts/guestos/start-guestos.sh
@@ -48,8 +48,8 @@ function define_guestos() {
             "GuestOS virtual machine define state" \
             "gauge"
     else
-        virsh define ${CONFIG}
         write_log "Defining GuestOS virtual machine."
+        virsh define ${CONFIG}
         write_metric "hostos_guestos_service_define" \
             "1" \
             "GuestOS virtual machine define state" \
@@ -65,6 +65,7 @@ function start_guestos() {
             "GuestOS virtual machine start state" \
             "gauge"
     else
+        write_log "Starting GuestOS virtual machine."
         # Attempt to start; if it fails, dump logs.
         if ! virsh start guestos; then
             # The sleep below gives QEMU time to clear/reinitialize its console

--- a/ic-os/components/hostos-scripts/guestos/start-guestos.sh
+++ b/ic-os/components/hostos-scripts/guestos/start-guestos.sh
@@ -84,7 +84,7 @@ function start_guestos() {
             write_tty1_log "###          TROUBLESHOOTING INFO...          ###"
             write_tty1_log "#################################################"
             host_ipv6_address="$(/opt/ic/bin/hostos_tool generate-ipv6-address --node-type HostOS 2>/dev/null)"
-            write_tty1_log "Host ipv6 address: $host_ipv6_address"
+            write_tty1_log "Host IPv6 address: $host_ipv6_address"
 
             if [ -f /var/log/libvirt/qemu/guestos-serial.log ]; then
                 write_tty1_log "#################################################"
@@ -107,7 +107,7 @@ function start_guestos() {
         write_tty1_log "GuestOS virtual machine launched"
         write_tty1_log "IF ONBOARDING, please wait for up to 10 MINUTES for a 'Join request successful!' message"
         host_ipv6_address="$(/opt/ic/bin/hostos_tool generate-ipv6-address --node-type HostOS 2>/dev/null)"
-        write_tty1_log "Host ipv6 address: $host_ipv6_address"
+        write_tty1_log "Host IPv6 address: $host_ipv6_address"
         write_tty1_log "#################################################"
 
         write_log "Starting GuestOS virtual machine."

--- a/ic-os/components/hostos-scripts/guestos/start-guestos.sh
+++ b/ic-os/components/hostos-scripts/guestos/start-guestos.sh
@@ -102,9 +102,13 @@ function start_guestos() {
         fi
 
         sleep 10
-        write_tty1_log "GuestOS virtual machine successfully launched.\nIf onboarding, please wait for up to 10 minutes for a 'Join request successful!' message\n\n\n"
+        write_tty1_log ""
+        write_tty1_log "#################################################"
+        write_tty1_log "GuestOS virtual machine launched"
+        write_tty1_log "IF ONBOARDING, please wait for up to 10 MINUTES for a 'Join request successful!' message"
         host_ipv6_address="$(/opt/ic/bin/hostos_tool generate-ipv6-address --node-type HostOS 2>/dev/null)"
-        write_tty1_log "Host ipv6 address: $host_ipv6_address\n"
+        write_tty1_log "Host ipv6 address: $host_ipv6_address"
+        write_tty1_log "#################################################"
 
         write_log "Starting GuestOS virtual machine."
         write_metric "hostos_guestos_service_start" \

--- a/ic-os/components/hostos-scripts/guestos/start-guestos.sh
+++ b/ic-os/components/hostos-scripts/guestos/start-guestos.sh
@@ -35,7 +35,7 @@ CONFIG="${CONFIG:=/var/lib/libvirt/guestos.xml}"
 write_tty1_log() {
     local message=$1
 
-    echo "${SCRIPT} ${message}" > /dev/tty1
+    echo "${SCRIPT} ${message}" >/dev/tty1
 
     logger -t "${SCRIPT}" "${message}"
 }
@@ -67,7 +67,7 @@ function start_guestos() {
     else
         # Attempt to start; if it fails, dump logs.
         if ! virsh start guestos; then
-            # The sleep below gives QEMU time to clear/reinitialize its console 
+            # The sleep below gives QEMU time to clear/reinitialize its console
             # so that error messages won't be immediately overwritten. This helps
             # ensure the logs and troubleshooting info remain visible on the host console.
             sleep 10
@@ -77,7 +77,7 @@ function start_guestos() {
             write_tty1_log "#################################################"
             write_tty1_log "###      LOGGING GUESTOS.SERVICE LOGS...      ###"
             write_tty1_log "#################################################"
-            journalctl -u guestos.service > /dev/tty1
+            journalctl -u guestos.service >/dev/tty1
 
             write_tty1_log "#################################################"
             write_tty1_log "###          TROUBLESHOOTING INFO...          ###"


### PR DESCRIPTION
[ICSUP-3863](https://dfinity.atlassian.net/browse/ICSUP-3863)

This fixes the "blank console" issue where, after completing a successful SetupOS installation, HostOS starts the guestos service, the console is cleared as QEMU is launched, and then node providers just see a blank console like:
![image](https://github.com/user-attachments/assets/13eb86b5-16e4-45af-affe-6f1f0a3af8fa)

This PR fixes this error so that now, the start-guestos script pipes failure logs from the `virsh start guestos` command to the console:
<img width="1152" alt="Pasted Graphic 5" src="https://github.com/user-attachments/assets/db37a39e-869d-42f9-bbc1-9d667e13dbc9" />


[ICSUP-3863]: https://dfinity.atlassian.net/browse/ICSUP-3863?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


Also adds an onboarding message for the success case:
<img width="1165" alt="image" src="https://github.com/user-attachments/assets/f9d3039a-280f-45d9-a73b-e1f70e2eb402" />
