### PR TITLE
chore(fuzzing): extend syscall whitelist in sandbox fuzzers

### DIFF
--- a/rs/execution_environment/fuzz/src/lib.rs
+++ b/rs/execution_environment/fuzz/src/lib.rs
@@ -33,6 +33,11 @@ pub struct SandboxFeatures {
     pub syscall_tracing: bool,
 }
 
+// The number of sandbox threads must be known in advance because:
+//   1. We need to call `ptrace::attach` immediately after the thread is spawned.
+//   2. Detached threads interfere with libfuzzer's cleanup process.
+const SANDBOX_THREADS: usize = 14;
+
 // In general, fuzzers don't include `main()` and the initialisation logic is deferred to libfuzzer.
 // However, to enable canister sandboxing, we override the initialisation by providing our own `main()`
 // which acts as a dispatcher for different sandboxed under certain arguments.
@@ -90,8 +95,16 @@ where
             sandbox();
         }
         Ok(ForkResult::Parent { child }) => {
-            std::thread::sleep(std::time::Duration::from_secs(1));
             let allowed_syscalls: BTreeSet<Sysno> = BTreeSet::from([
+                // Init
+                Sysno::gettid,
+                Sysno::rt_sigprocmask,
+                Sysno::clone,
+                Sysno::sched_yield,
+                Sysno::sched_getaffinity,
+                Sysno::prctl,
+                Sysno::getrandom, // probably due to hashbrown dependency
+                // Execution
                 Sysno::mmap,
                 Sysno::mprotect,
                 Sysno::munmap,
@@ -102,20 +115,29 @@ where
                 Sysno::close,
                 Sysno::restart_syscall,
             ]);
-            let children = get_children(child.into());
-            let threads: Vec<_> = children
-                .iter()
-                .map(|child| {
-                    std::thread::spawn({
+
+            let mut threads: Vec<_> = vec![];
+            let mut visited = BTreeSet::new();
+            while visited.len() < SANDBOX_THREADS {
+                let children = get_children(child.into());
+
+                for pid in children {
+                    if visited.contains(&pid) {
+                        continue;
+                    }
+
+                    visited.insert(pid);
+
+                    threads.push(std::thread::spawn({
                         let allowed_syscalls = allowed_syscalls.clone();
-                        let child = *child;
+                        let child = pid;
                         let name = name.to_string();
                         move || {
                             trace(name, Pid::from_raw(child), allowed_syscalls);
                         }
-                    })
-                })
-                .collect();
+                    }));
+                }
+            }
 
             for handle in threads {
                 handle.join().unwrap();

--- a/rs/execution_environment/fuzz/src/lib.rs
+++ b/rs/execution_environment/fuzz/src/lib.rs
@@ -33,11 +33,6 @@ pub struct SandboxFeatures {
     pub syscall_tracing: bool,
 }
 
-// The number of sandbox threads must be known in advance because:
-//   1. We need to call `ptrace::attach` immediately after the thread is spawned.
-//   2. Detached threads interfere with libfuzzer's cleanup process.
-const SANDBOX_THREADS: usize = 14;
-
 // In general, fuzzers don't include `main()` and the initialisation logic is deferred to libfuzzer.
 // However, to enable canister sandboxing, we override the initialisation by providing our own `main()`
 // which acts as a dispatcher for different sandboxed under certain arguments.
@@ -90,6 +85,12 @@ fn syscall_monitor<F>(name: &str, sandbox: F)
 where
     F: Fn(),
 {
+    // The number of sandbox threads must be known in advance because:
+    //   1. We need to call `ptrace::attach` immediately after the thread is spawned.
+    //   2. Detached threads interfere with libfuzzer's cleanup process.
+
+    const SANDBOX_THREADS: usize = 14;
+
     match unsafe { fork() } {
         Ok(ForkResult::Child) => {
             sandbox();


### PR DESCRIPTION
In the sandbox monitor function, the parent thread calls `std::thread::sleep(std::time::Duration::from_secs(1))` to allow the sandbox to spawn all its threads before tracing begins.

However, this approach is unreliable—the sleep duration is arbitrary, and attachment can occur at any point in execution. This led to `getrandom` failures in CI.

This PR removes the sleep timer and instead continuously fetches `tid`s as threads spawn, attaching to them dynamically. The trade-off is that it requires knowing the number of sandbox threads in advance.