### PR TITLE
chore(IDX): simplify x64-darwin output base

### DIFF
--- a/.github/workflows-source/ci-main.yml
+++ b/.github/workflows-source/ci-main.yml
@@ -202,7 +202,7 @@ jobs:
           BAZEL_CI_CONFIG: "--config=ci --config macos_ci"
           BAZEL_COMMAND: test
           BAZEL_EXTRA_ARGS: '--test_tag_filters=test_macos'
-          BAZEL_STARTUP_ARGS: "--output_base /var/tmp/bazel-output/${{ github.run_id }}"
+          BAZEL_STARTUP_ARGS: "--output_base /var/tmp/bazel-output/"
           BAZEL_TARGETS: "//rs/... //publish/binaries/..."
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
       - <<: *bazel-bep
@@ -210,7 +210,8 @@ jobs:
         if: always()
         shell: bash
         run: |
-          sudo rm -rf /private/var/tmp/bazel-output
+          # Clean up the output base for the next run
+          sudo rm -rf /var/tmp/bazel-output
 
   bazel-build-fuzzers:
     name: Bazel Build Fuzzers

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -194,7 +194,7 @@ jobs:
           BAZEL_CI_CONFIG: "--config=ci --config macos_ci"
           BAZEL_COMMAND: test
           BAZEL_EXTRA_ARGS: '--test_tag_filters=test_macos'
-          BAZEL_STARTUP_ARGS: "--output_base /var/tmp/bazel-output/${{ github.run_id }}"
+          BAZEL_STARTUP_ARGS: "--output_base /var/tmp/bazel-output/"
           BAZEL_TARGETS: "//rs/... //publish/binaries/..."
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
       - name: Upload bazel-bep
@@ -214,7 +214,8 @@ jobs:
         if: always()
         shell: bash
         run: |
-          sudo rm -rf /private/var/tmp/bazel-output
+          # Clean up the output base for the next run
+          sudo rm -rf /var/tmp/bazel-output
   bazel-build-fuzzers:
     name: Bazel Build Fuzzers
     runs-on:


### PR DESCRIPTION
This simplifies the output base on our x86 darwin builders. Since only one job runs at a time, the output base does not need to include a unique ID.

This also removes `/private/var` which anyway points to `/var`.