### PR TITLE
refactor(registry): Migrate Registry to use MemoryManager instead of raw stable memory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19045,6 +19045,7 @@ dependencies = [
  "ic-registry-subnet-type",
  "ic-registry-transport",
  "ic-replica-tests",
+ "ic-stable-structures",
  "ic-test-utilities",
  "ic-test-utilities-compare-dirs",
  "ic-test-utilities-types",

--- a/rs/registry/canister/BUILD.bazel
+++ b/rs/registry/canister/BUILD.bazel
@@ -43,6 +43,7 @@ DEPENDENCIES = [
     "@crate_index//:ic-cdk",
     "@crate_index//:ic-certified-map",
     "@crate_index//:ic-metrics-encoder",
+    "@crate_index//:ic-stable-structures",
     "@crate_index//:idna",
     "@crate_index//:ipnet",
     "@crate_index//:lazy_static",

--- a/rs/registry/canister/Cargo.toml
+++ b/rs/registry/canister/Cargo.toml
@@ -42,6 +42,7 @@ ic-registry-subnet-features = { path = "../../registry/subnet_features" }
 ic-registry-subnet-type = { path = "../../registry/subnet_type" }
 ic-registry-transport = { path = "../transport" }
 ic-registry-node-provider-rewards = { path = "../node_provider_rewards" }
+ic-stable-structures = { workspace = true }
 ic-types = { path = "../../types/types" }
 idna = { workspace = true }
 lazy_static = { workspace = true }

--- a/rs/registry/canister/canister/canister.rs
+++ b/rs/registry/canister/canister/canister.rs
@@ -181,7 +181,9 @@ fn canister_post_upgrade() {
     let registry = registry_mut();
     let stable_storage = stable::get();
     // delegate real work to more testable function
-    registry_lifecycle::canister_post_upgrade(registry, stable_storage.as_slice());
+    let registry_storage = RegistryCanisterStableStorage::decode(stable_storage.as_slice())
+        .expect("Error decoding from stable.");
+    registry_lifecycle::canister_post_upgrade(registry, registry_storage);
 }
 
 ic_nervous_system_common_build_metadata::define_get_build_metadata_candid_method! {}

--- a/rs/registry/canister/canister/canister.rs
+++ b/rs/registry/canister/canister/canister.rs
@@ -187,8 +187,7 @@ fn canister_post_upgrade() {
 
     let registry_storage: RegistryCanisterStableStorage =
         if &magic_bytes == b"MGR" && mgr_version_byte[0] == 1 {
-            with_upgrades_memory(|memory| load_protobuf(memory))
-                .expect("Failed to decode protobuf post-upgrade")
+            with_upgrades_memory(load_protobuf).expect("Failed to decode protobuf post-upgrade")
         } else {
             let stable_storage = stable::get();
             RegistryCanisterStableStorage::decode(stable_storage.as_slice())

--- a/rs/registry/canister/src/lib.rs
+++ b/rs/registry/canister/src/lib.rs
@@ -11,3 +11,4 @@ pub mod pb;
 pub mod proto_on_wire;
 pub mod registry;
 pub mod registry_lifecycle;
+pub mod storage;

--- a/rs/registry/canister/src/registry_lifecycle.rs
+++ b/rs/registry/canister/src/registry_lifecycle.rs
@@ -10,12 +10,14 @@ use ic_registry_transport::{pb::v1::RegistryMutation, update};
 use prost::Message;
 use std::str::FromStr;
 
-pub fn canister_post_upgrade(registry: &mut Registry, stable_storage: &[u8]) {
+pub fn canister_post_upgrade(
+    registry: &mut Registry,
+    registry_storage: RegistryCanisterStableStorage,
+) {
     // Purposefully fail the upgrade if we can't find authz information.
     // Best to have a broken canister, which we can reinstall, than a
     // canister without authz information.
-    let registry_storage =
-        RegistryCanisterStableStorage::decode(stable_storage).expect("Error decoding from stable.");
+
     registry.from_serializable_form(
         registry_storage
             .registry
@@ -122,7 +124,9 @@ mod test {
 
         // we can use canister_post_upgrade to initialize a new registry correctly
         let mut new_registry = Registry::new();
-        canister_post_upgrade(&mut new_registry, &stable_storage_bytes);
+        let registry_storage = RegistryCanisterStableStorage::decode(&stable_storage_bytes)
+            .expect("Error decoding from stable.");
+        canister_post_upgrade(&mut new_registry, registry_storage);
 
         // and the version is right
         assert_eq!(new_registry.latest_version(), 1);
@@ -134,7 +138,9 @@ mod test {
         let mut registry = Registry::new();
         // try with garbage to check first error condition
         let stable_storage_bytes = [1, 2, 3];
-        canister_post_upgrade(&mut registry, &stable_storage_bytes);
+        let registry_storage = RegistryCanisterStableStorage::decode(&stable_storage_bytes)
+            .expect("Error decoding from stable.");
+        canister_post_upgrade(&mut new_registry, registry_storage);
     }
 
     #[test]
@@ -153,7 +159,9 @@ mod test {
 
         // When we try to run canister_post_upgrade
         // Then we panic
-        canister_post_upgrade(&mut registry, &serialized);
+        let registry_storage = RegistryCanisterStableStorage::decode(&stable_storage_bytes)
+            .expect("Error decoding from stable.");
+        canister_post_upgrade(&mut new_registry, registry_storage);
     }
 
     #[test]
@@ -166,7 +174,9 @@ mod test {
 
         // with our bad mutation, this should throw
         let mut new_registry = Registry::new();
-        canister_post_upgrade(&mut new_registry, &stable_storage_bytes);
+        let registry_storage = RegistryCanisterStableStorage::decode(&stable_storage_bytes)
+            .expect("Error decoding from stable.");
+        canister_post_upgrade(&mut new_registry, registry_storage);
     }
 
     #[test]
@@ -179,7 +189,9 @@ mod test {
         let stable_storage_bytes = stable_storage_from_registry(&registry, Some(7u64));
 
         let mut new_registry = Registry::new();
-        canister_post_upgrade(&mut new_registry, &stable_storage_bytes);
+        let registry_storage = RegistryCanisterStableStorage::decode(&stable_storage_bytes)
+            .expect("Error decoding from stable.");
+        canister_post_upgrade(&mut new_registry, registry_storage);
 
         // missing versions are added by the deserializer
         let mut sorted_changelog_versions = new_registry
@@ -203,7 +215,9 @@ mod test {
         let stable_storage = stable_storage_from_registry(&registry, Some(100u64));
         // then we panic when decoding
         let mut new_registry = Registry::new();
-        canister_post_upgrade(&mut new_registry, &stable_storage);
+        let registry_storage = RegistryCanisterStableStorage::decode(&stable_storage_bytes)
+            .expect("Error decoding from stable.");
+        canister_post_upgrade(&mut new_registry, registry_storage);
     }
 
     #[test]

--- a/rs/registry/canister/src/registry_lifecycle.rs
+++ b/rs/registry/canister/src/registry_lifecycle.rs
@@ -124,8 +124,9 @@ mod test {
 
         // we can use canister_post_upgrade to initialize a new registry correctly
         let mut new_registry = Registry::new();
-        let registry_storage = RegistryCanisterStableStorage::decode(&stable_storage_bytes)
-            .expect("Error decoding from stable.");
+        let registry_storage =
+            RegistryCanisterStableStorage::decode(stable_storage_bytes.as_slice())
+                .expect("Error decoding from stable.");
         canister_post_upgrade(&mut new_registry, registry_storage);
 
         // and the version is right
@@ -138,9 +139,10 @@ mod test {
         let mut registry = Registry::new();
         // try with garbage to check first error condition
         let stable_storage_bytes = [1, 2, 3];
-        let registry_storage = RegistryCanisterStableStorage::decode(&stable_storage_bytes)
-            .expect("Error decoding from stable.");
-        canister_post_upgrade(&mut new_registry, registry_storage);
+        let registry_storage =
+            RegistryCanisterStableStorage::decode(stable_storage_bytes.as_slice())
+                .expect("Error decoding from stable.");
+        canister_post_upgrade(&mut registry, registry_storage);
     }
 
     #[test]
@@ -159,9 +161,9 @@ mod test {
 
         // When we try to run canister_post_upgrade
         // Then we panic
-        let registry_storage = RegistryCanisterStableStorage::decode(&stable_storage_bytes)
+        let registry_storage = RegistryCanisterStableStorage::decode(serialized.as_slice())
             .expect("Error decoding from stable.");
-        canister_post_upgrade(&mut new_registry, registry_storage);
+        canister_post_upgrade(&mut registry, registry_storage);
     }
 
     #[test]
@@ -174,8 +176,9 @@ mod test {
 
         // with our bad mutation, this should throw
         let mut new_registry = Registry::new();
-        let registry_storage = RegistryCanisterStableStorage::decode(&stable_storage_bytes)
-            .expect("Error decoding from stable.");
+        let registry_storage =
+            RegistryCanisterStableStorage::decode(stable_storage_bytes.as_slice())
+                .expect("Error decoding from stable.");
         canister_post_upgrade(&mut new_registry, registry_storage);
     }
 
@@ -189,8 +192,9 @@ mod test {
         let stable_storage_bytes = stable_storage_from_registry(&registry, Some(7u64));
 
         let mut new_registry = Registry::new();
-        let registry_storage = RegistryCanisterStableStorage::decode(&stable_storage_bytes)
-            .expect("Error decoding from stable.");
+        let registry_storage =
+            RegistryCanisterStableStorage::decode(stable_storage_bytes.as_slice())
+                .expect("Error decoding from stable.");
         canister_post_upgrade(&mut new_registry, registry_storage);
 
         // missing versions are added by the deserializer
@@ -212,11 +216,12 @@ mod test {
     fn post_upgrade_fails_when_registry_decodes_different_version() {
         // Given a mismatched stable storage version from the registry
         let registry = invariant_compliant_registry(0);
-        let stable_storage = stable_storage_from_registry(&registry, Some(100u64));
+        let stable_storage_bytes = stable_storage_from_registry(&registry, Some(100u64));
         // then we panic when decoding
         let mut new_registry = Registry::new();
-        let registry_storage = RegistryCanisterStableStorage::decode(&stable_storage_bytes)
-            .expect("Error decoding from stable.");
+        let registry_storage =
+            RegistryCanisterStableStorage::decode(stable_storage_bytes.as_slice())
+                .expect("Error decoding from stable.");
         canister_post_upgrade(&mut new_registry, registry_storage);
     }
 

--- a/rs/registry/canister/src/storage.rs
+++ b/rs/registry/canister/src/storage.rs
@@ -1,0 +1,22 @@
+use ic_stable_structures::memory_manager::{MemoryId, MemoryManager, VirtualMemory};
+use ic_stable_structures::DefaultMemoryImpl;
+use std::cell::RefCell;
+
+const UPGRADES_MEMORY_ID: MemoryId = MemoryId::new(0);
+
+type VM = VirtualMemory<DefaultMemoryImpl>;
+thread_local! {
+    static MEMORY_MANAGER: RefCell<MemoryManager<DefaultMemoryImpl>> =
+        RefCell::new(MemoryManager::init(DefaultMemoryImpl::default()));
+
+    static UPGRADES_MEMORY: RefCell<VM> = RefCell::new({
+        MEMORY_MANAGER.with(|mm| mm.borrow().get(UPGRADES_MEMORY_ID))
+    })
+}
+
+pub fn with_upgrades_memory<R>(f: impl FnOnce(&VM) -> R) -> R {
+    UPGRADES_MEMORY.with(|um| {
+        let upgrades_memory = &um.borrow();
+        f(upgrades_memory)
+    })
+}

--- a/rs/registry/canister/unreleased_changelog.md
+++ b/rs/registry/canister/unreleased_changelog.md
@@ -11,6 +11,11 @@ on the process that this file is part of, see
 
 ## Changed
 
+### Migrate Registry to use ic_stable_structures' MemoryManager
+
+This update migrates registry from using dfn_core to using virtual memory regions provided by ic_stable_structures
+MemoryManager.  This allows in the future to migrate the Registry records into stable memory.
+
 ## Deprecated
 
 ## Removed


### PR DESCRIPTION
## What
Use MemoryManager instead of dfn_core's memory tools for saving and loading the protobuf on upgrades.

## Why
To allow moving registry records into stable memory, so that registry can scale, we first want to allow for multiple memory regions to be available so that different classes of objects can be stored.

Note, this was tested using the golden_state test and adding an additional check that registry state is still intact.