### PR TITLE
chore(fuzzing): Add missing syscalls to the sandbox monitor whitelist

### DIFF
--- a/rs/execution_environment/fuzz/src/lib.rs
+++ b/rs/execution_environment/fuzz/src/lib.rs
@@ -97,6 +97,7 @@ where
                 Sysno::clone,
                 Sysno::sched_yield,
                 Sysno::sched_getaffinity,
+                Sysno::set_robust_list,
                 Sysno::prctl,
                 Sysno::getrandom, // probably due to hashbrown dependency
                 // Execution


### PR DESCRIPTION
This PR is to keep track of any missed syscalls in the existing whitelist and add them if necessary. The hourly fuzzing CI job is used as a testbed.

1. `set_robust_list` - [failures](https://github.com/dfinity/ic/actions/runs/13068049429/job/36463716667)

Update: Observed over a week and didn't see other failures.