### PR TITLE
chore(IDX): track ict changes with bazel

### DIFF
--- a/bin/.gitignore
+++ b/bin/.gitignore
@@ -1,1 +1,0 @@
-checksum.txt

--- a/bin/ict
+++ b/bin/ict
@@ -1,62 +1,24 @@
 #!/usr/bin/env bash
-set -Eou pipefail
+set -eou pipefail
 
-GREEN="\x1b[32m"
-RED="\x1b[31m"
-BOLD="\x1b[1m"
-NC="\x1b[0m"
+# convenience wrapper around 'ict' binary
 
-CURRENT_SCRIPT_DIR=$(dirname "${BASH_SOURCE[0]}")
-ICT_DIR="${CURRENT_SCRIPT_DIR}/../rs/tests/ict"
-CHECKSUM_FILE="${CURRENT_SCRIPT_DIR}/checksum.txt" # holds the resulting hash of all files in the ict directory
-BAZEL_ICT_TARGET="//rs/tests/ict:ict"
-# Path to this binary is hard coded, as getting it from Bazel is a bit slow (~0.5 sec) for a good interactivity.
-ICT_BIN="$CURRENT_SCRIPT_DIR/../bazel-out/k8-opt/bin/rs/tests/ict/ict_/ict"
+ICT_TARGET="//rs/tests/ict"
 
-if [ "$(hostname)" != "devenv-container" ]; then
-    echo -e "${BOLD}${RED}This script can only be executed within a devenv-container. Make sure you first executed:\n/ic$ ./ci/container/container-run.sh${NC}"
+ICT_BUILD_CMD='bazel build "$ICT_TARGET"'
+GIT_TOPLEVEL=$(git rev-parse --show-toplevel)
+
+# Bazel 8 has a '--quiet' flag to suppress "info" output:
+# https://github.com/bazelbuild/bazel/issues/4867
+#
+# Once we support bazel 8, we can simply run 'bazel --quiet run ...'
+#
+# Until then, we perform the build separately and pipe the output
+# to /dev/null
+if ! eval "$ICT_BUILD_CMD" &> /dev/null ; then
+    echo "could not build $ICT_TARGET"
+    echo "try running: $ICT_BUILD_CMD"
     exit 1
 fi
 
-compile_ict() {
-    bazel build $BAZEL_ICT_TARGET --config=local >/dev/null 2>&1
-    CODE="$?"
-    if [ "${CODE}" != "0" ]; then
-        echo -e "${BOLD}${RED}ict compilation failed with code=${CODE}${NC}"
-        echo "Try running the build manually: bazel build ${BAZEL_ICT_TARGET}"
-        exit 1
-    fi
-}
-
-# Check if Bazel server is already running. If not print a message for user and start Bazel.
-pgrep -fi bazel >/dev/null >&1
-CODE="$?"
-if [ "${CODE}" != "0" ]; then
-    echo -e "${BOLD}${GREEN}Starting Bazel server ...${NC}"
-    bazel >/dev/null 2>&1
-    CODE="$?"
-    if [ "${CODE}" != "0" ]; then
-        echo -e "${BOLD}${RED}Failed to start Bazel server${NC}"
-        echo "Try starting Bazel manually: $ bazel"
-        exit 1
-    fi
-fi
-# Check whether ict binary exists/up-to-date. If not compile/recompile + handle errors.
-# Take all files in the ict/* for checksum computation.
-checksum=$(find ${ICT_DIR} -type f -exec sha256sum {} \; | sort -z | sha1sum | head -c 40)
-compile_msg=""
-if [ ! -f "$ICT_BIN" ]; then
-    compile_msg="Compiling ict binary ..."
-else
-    if [ ! -f "${CHECKSUM_FILE}" ] || [ $(<$CHECKSUM_FILE) != "$checksum" ]; then
-        compile_msg="ict source file/s changed, recompiling ict ..."
-    fi
-fi
-if [ ! -z "${compile_msg}" ]; then
-    echo -e "${BOLD}${GREEN}${compile_msg}${NC}"
-    compile_ict
-    # write checksum into a file
-    echo ${checksum} >${CHECKSUM_FILE}
-fi
-# Invoke binary with the arguments.
-"$ICT_BIN" "$@"
+"$GIT_TOPLEVEL"/bazel-bin/rs/tests/ict/ict_/ict "$@"


### PR DESCRIPTION
This simplifies the `ict` wrapper script. The script now relies on bazel to figure out if the `ict` tool needs to be rebuilt.

From basic testing, this seems fast enough for a good CLI experience and simplifies things a fair bit (avoid custom hashing & checksum file):

```sh
$ time ./bin/ict -v
ict version 0.1.2

real	0m0.345s
user	0m0.016s
sys	0m0.042s
```