### PR TITLE
refactor(nns-tools): Turn release-runscript to clap-powered CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19069,6 +19069,7 @@ version = "0.9.0"
 dependencies = [
  "anyhow",
  "candid",
+ "clap 4.5.27",
  "colored",
  "futures",
  "ic-agent",

--- a/rs/nervous_system/tools/release-runscript/BUILD.bazel
+++ b/rs/nervous_system/tools/release-runscript/BUILD.bazel
@@ -12,6 +12,7 @@ DEPENDENCIES = [
     "//rs/types/base_types",
     "@crate_index//:anyhow",
     "@crate_index//:candid",
+    "@crate_index//:clap",
     "@crate_index//:colored",
     "@crate_index//:futures",
     "@crate_index//:ic-agent",

--- a/rs/nervous_system/tools/release-runscript/Cargo.toml
+++ b/rs/nervous_system/tools/release-runscript/Cargo.toml
@@ -13,6 +13,7 @@ path = "src/main.rs"
 [dependencies]
 anyhow = { workspace = true }
 candid = { workspace = true }
+clap = { workspace = true }
 colored = "2.0.0"
 futures = { workspace = true }
 ic-agent = { workspace = true }


### PR DESCRIPTION
This will make it simpler to add automation for various steps in the future. It will also enable the person doing the release to start at any step (instead of needing to start at the beginning).

As a reminder, the runscript can be run with:

```
bazel run //rs/nervous_system/tools/release-runscript --config=lint
```

In this chain of PRs, I automate the first few steps of the release process in this script.

[Next PR →](https://github.com/dfinity/ic/pull/3713)