### PR TITLE
feat(crypto): CRP-2687 make some conversions to KeyId infallible

### DIFF
--- a/rs/crypto/internal/crypto_service_provider/src/key_id/mod.rs
+++ b/rs/crypto/internal/crypto_service_provider/src/key_id/mod.rs
@@ -7,11 +7,12 @@ use ic_crypto_internal_types::encrypt::forward_secure::CspFsEncryptionPublicKey;
 use ic_crypto_internal_types::sign::threshold_sig::public_coefficients::CspPublicCoefficients;
 use ic_crypto_sha2::{Context, DomainSeparationContext, Sha256};
 use ic_crypto_tls_interfaces::TlsPublicKeyCert;
-use ic_types::crypto::{AlgorithmId, CryptoError};
+use ic_types::crypto::AlgorithmId;
 use std::fmt;
 use std::fmt::Formatter;
 
 const KEY_ID_DOMAIN: &str = "ic-key-id";
+const KEY_ID_LARGE_DOMAIN: &str = "ic-key-id-large";
 const COMMITMENT_KEY_ID_DOMAIN: &str = "ic-key-id-idkg-commitment";
 const THRESHOLD_PUBLIC_COEFFICIENTS_KEY_ID_DOMAIN: &str =
     "KeyId from threshold public coefficients";
@@ -67,52 +68,45 @@ pub enum KeyIdInstantiationError {
     InvalidArguments(String),
 }
 
-impl From<KeyIdInstantiationError> for CryptoError {
-    fn from(error: KeyIdInstantiationError) -> Self {
-        CryptoError::InvalidArgument {
-            message: format!("Cannot instantiate KeyId: {:?}", error),
+/// Compute a KeyId from an `AlgorithmId` and a slice of bytes.
+impl<B: AsRef<[u8]>> From<(AlgorithmId, &B)> for KeyId {
+    fn from((alg_id, bytes): (AlgorithmId, &B)) -> Self {
+        let bytes = bytes.as_ref();
+        match u32::try_from(bytes.len()) {
+            Ok(bytes_size_u32) => {
+                // bytes < 4 GiB (==u32::MAX==2^32-1)
+                let dom_sep = DomainSeparationContext::new(KEY_ID_DOMAIN.to_string());
+                let mut hash = Sha256::new_with_context(&dom_sep);
+                hash.write(&[u8::from(alg_id)]); // 1 byte
+                hash.write(&bytes_size_u32.to_be_bytes()); // 4 bytes
+                hash.write(bytes);
+                KeyId::from(hash.finish())
+            }
+            Err(_) => {
+                match u64::try_from(bytes.len()) {
+                    Ok(bytes_size_u64) => {
+                        // 4 GiB <= bytes < 16384 PiB (==u64::MAX==2^64-1)
+                        let dom_sep = DomainSeparationContext::new(KEY_ID_LARGE_DOMAIN.to_string());
+                        let mut hash = Sha256::new_with_context(&dom_sep);
+                        hash.write(&[u8::from(alg_id)]); // 1 byte
+                        hash.write(&bytes_size_u64.to_be_bytes()); // 8 bytes
+                        hash.write(bytes);
+                        KeyId::from(hash.finish())
+                    }
+                    Err(_) => {
+                        // bytes >= 16384 PiB (==u64::MAX==2^64-1)
+                        // It is very reasonable to panic here
+                        panic!("bytes >= 16384 PiB (=2^64-1)")
+                    }
+                }
+            }
         }
     }
 }
 
-/// Compute a KeyId from an `AlgorithmId` and a slice of bytes.
-///
-/// The computed KeyId is the result of applying SHA256 to the bytes:
-/// `domain_separator | algorithm_id | size(bytes) | bytes`
-/// where  domain_separator is DomainSeparationContext(KEY_ID_DOMAIN),
-/// algorithm_id is a 1-byte value, and size(pk_bytes) is the size of
-/// pk_bytes as u32 in BigEndian format.
-///
-/// # Errors
-/// * `KeyIdInstantiationError::InvalidArgument`: if the slice of bytes is too large and its size does not fit in a `u32`.
-impl<B> TryFrom<(AlgorithmId, &B)> for KeyId
-where
-    B: AsRef<[u8]>,
-{
-    type Error = KeyIdInstantiationError;
-
-    fn try_from((alg_id, bytes): (AlgorithmId, &B)) -> Result<Self, Self::Error> {
-        let bytes = bytes.as_ref();
-        let bytes_size = u32::try_from(bytes.len()).map_err(|_error| {
-            KeyIdInstantiationError::InvalidArguments(format!(
-                "Bytes array is too large (number of bytes {} does not fit in a u32)",
-                bytes.len()
-            ))
-        })?;
-        let mut hash =
-            Sha256::new_with_context(&DomainSeparationContext::new(KEY_ID_DOMAIN.to_string()));
-        hash.write(&[u8::from(alg_id)]);
-        hash.write(&bytes_size.to_be_bytes());
-        hash.write(bytes);
-        Ok(KeyId::from(hash.finish()))
-    }
-}
-
-impl TryFrom<&CspPublicKey> for KeyId {
-    type Error = KeyIdInstantiationError;
-
-    fn try_from(public_key: &CspPublicKey) -> Result<Self, Self::Error> {
-        KeyId::try_from((public_key.algorithm_id(), &public_key.pk_bytes()))
+impl From<&CspPublicKey> for KeyId {
+    fn from(public_key: &CspPublicKey) -> Self {
+        KeyId::from((public_key.algorithm_id(), &public_key.pk_bytes()))
     }
 }
 
@@ -121,11 +115,10 @@ impl TryFrom<&MEGaPublicKey> for KeyId {
 
     fn try_from(public_key: &MEGaPublicKey) -> Result<Self, Self::Error> {
         match public_key.curve_type() {
-            EccCurveType::K256 => KeyId::try_from((
+            EccCurveType::K256 => Ok(KeyId::from((
                 AlgorithmId::ThresholdEcdsaSecp256k1,
                 &public_key.serialize(),
-            ))
-            .map_err(|error| format!("cannot instantiate KeyId: {:?}", error)),
+            ))),
             c => Err(format!("unsupported curve: {:?}", c)),
         }
     }
@@ -158,11 +151,9 @@ impl From<&PolynomialCommitment> for KeyId {
     }
 }
 
-impl TryFrom<&TlsPublicKeyCert> for KeyId {
-    type Error = KeyIdInstantiationError;
-
-    fn try_from(cert: &TlsPublicKeyCert) -> Result<Self, Self::Error> {
-        KeyId::try_from((AlgorithmId::Tls, cert.as_der()))
+impl From<&TlsPublicKeyCert> for KeyId {
+    fn from(cert: &TlsPublicKeyCert) -> Self {
+        KeyId::from((AlgorithmId::Tls, cert.as_der()))
     }
 }
 

--- a/rs/crypto/internal/crypto_service_provider/src/key_id/tests.rs
+++ b/rs/crypto/internal/crypto_service_provider/src/key_id/tests.rs
@@ -159,7 +159,7 @@ mod stability_tests {
         ];
 
         for test in &tests {
-            assert_matches!(KeyId::try_from(test.input), Ok(actual) if actual == test.expected_key_id())
+            assert_matches!(KeyId::from(test.input), actual if actual == test.expected_key_id())
         }
     }
 
@@ -197,7 +197,7 @@ mod stability_tests {
         ];
 
         for test in &tests {
-            assert_matches!(KeyId::try_from(&test.input), Ok(actual) if actual == test.expected_key_id())
+            assert_matches!(KeyId::from(&test.input), actual if actual == test.expected_key_id())
         }
     }
 
@@ -339,7 +339,7 @@ t7Ica9iKR8XXVy+W5eyW52YYPbGzXZ0FgxPcOMk3Tm2qx/zJJ7pkN+rJeIEgQHEj
         }];
 
         for test in &tests {
-            assert_matches!(KeyId::try_from(&test.input), Ok(key_id) if key_id == test.expected_key_id());
+            assert_matches!(KeyId::from(&test.input), key_id if key_id == test.expected_key_id());
         }
     }
 

--- a/rs/crypto/internal/crypto_service_provider/src/keygen/tests.rs
+++ b/rs/crypto/internal/crypto_service_provider/src/keygen/tests.rs
@@ -22,7 +22,7 @@ mod gen_node_siging_key_pair_tests {
     fn should_correctly_generate_node_signing_keys() {
         let csp = csp_with_fixed_seed();
         let public_key = csp.csp_vault.gen_node_signing_key_pair().unwrap();
-        let key_id = KeyId::try_from(&public_key).unwrap();
+        let key_id = KeyId::from(&public_key);
 
         assert_eq!(
             key_id,
@@ -95,7 +95,7 @@ mod gen_key_pair_with_pop_tests {
         let test_vector = multi_bls_test_vector();
         let csp = csp_seeded_with(test_vector.seed);
         let (public_key, pop) = csp.csp_vault.gen_committee_signing_key_pair().unwrap();
-        let key_id = KeyId::try_from(&public_key).unwrap();
+        let key_id = KeyId::from(&public_key);
 
         assert_eq!(key_id, test_vector.key_id);
         assert_eq!(public_key, test_vector.public_key);
@@ -262,13 +262,13 @@ fn should_correctly_convert_tls_cert_hash_as_key_id() {
     let cert = TlsPublicKeyCert::new_from_der(cert_der)
         .expect("failed to build TlsPublicKeyCert from DER");
 
-    let key_id = KeyId::try_from(&cert);
+    let key_id = KeyId::from(&cert);
 
     // We expect the following hard coded key id:
     let expected_key_id = KeyId::from(hex_to_32_bytes(
         "bc1f70570a2aaa0904069e1a77b710c729ac1bf026a02f14ad8613c3627b211a",
     ));
-    assert_matches!(key_id, Ok(actual) if actual == expected_key_id);
+    assert_matches!(key_id, actual if actual == expected_key_id);
 }
 
 mod tls {
@@ -284,7 +284,7 @@ mod tls {
             .csp_vault
             .gen_tls_key_pair(node_test_id(NODE_1))
             .expect("Generation of TLS keys failed.");
-        let key_id = KeyId::try_from(&cert).unwrap();
+        let key_id = KeyId::from(&cert);
 
         assert_eq!(
             key_id,

--- a/rs/crypto/internal/crypto_service_provider/src/signer/tests.rs
+++ b/rs/crypto/internal/crypto_service_provider/src/signer/tests.rs
@@ -477,11 +477,7 @@ mod verify_ed25519 {
             let sig = csp
                 .csp_vault
                 .as_ref()
-                .sign(
-                    AlgorithmId::Ed25519,
-                    msg.to_vec(),
-                    KeyId::try_from(&pk).expect("Failed to convert CspPublicKey to KeyId"),
-                )
+                .sign(AlgorithmId::Ed25519, msg.to_vec(), KeyId::from(&pk))
                 .expect("Failed to generate a signature");
 
             Self { csp, pk, sig }
@@ -623,7 +619,7 @@ mod multi {
             .gen_committee_signing_key_pair()
             .expect("Failed to generate key pair with PoP");
         let message = b"Three turtle doves";
-        let key_id = KeyId::try_from(&public_key).unwrap();
+        let key_id = KeyId::from(&public_key);
         let signature = csp
             .sign(AlgorithmId::MultiBls12_381, message.to_vec(), key_id)
             .expect("Signing failed");
@@ -641,7 +637,7 @@ mod multi {
         let (public_key, _pop) = csp.csp_vault.gen_committee_signing_key_pair().unwrap();
         let incompatible_signature = {
             let incompatible_public_key = csp.csp_vault.gen_node_signing_key_pair().unwrap();
-            let incompatible_key_id = KeyId::try_from(&incompatible_public_key).unwrap();
+            let incompatible_key_id = KeyId::from(&incompatible_public_key);
             csp.sign(
                 incompatible_algorithm,
                 message.to_vec(),
@@ -660,7 +656,7 @@ mod multi {
         let algorithm = AlgorithmId::MultiBls12_381;
         let [csp, verifier] = csp_and_verifier_with_different_seeds();
         let (public_key, _pop) = csp.csp_vault.gen_committee_signing_key_pair().unwrap();
-        let key_id = KeyId::try_from(&public_key).unwrap();
+        let key_id = KeyId::from(&public_key);
         let incompatible_public_key = csp.csp_vault.gen_node_signing_key_pair().unwrap();
         let message = b"Three turtle doves";
         let signature = csp
@@ -682,12 +678,12 @@ mod multi {
             .csp_vault
             .gen_committee_signing_key_pair()
             .expect("Failed to generate key pair with PoP");
-        let key_id1 = KeyId::try_from(&public_key1).unwrap();
+        let key_id1 = KeyId::from(&public_key1);
         let (public_key2, _pop2) = csp2
             .csp_vault
             .gen_committee_signing_key_pair()
             .expect("Failed to generate key pair with PoP");
-        let key_id2 = KeyId::try_from(&public_key2).unwrap();
+        let key_id2 = KeyId::from(&public_key2);
 
         // Two signatures combined should verify:
         let message = b"Three turtle doves";
@@ -727,12 +723,12 @@ mod multi {
             .csp_vault
             .gen_committee_signing_key_pair()
             .expect("Failed to generate key pair with PoP");
-        let key_id1 = KeyId::try_from(&public_key1).unwrap();
+        let key_id1 = KeyId::from(&public_key1);
         let (public_key2, _pop2) = csp2
             .csp_vault
             .gen_committee_signing_key_pair()
             .expect("Failed to generate key pair with PoP");
-        let key_id2 = KeyId::try_from(&public_key2).unwrap();
+        let key_id2 = KeyId::from(&public_key2);
 
         // Two signatures combined should verify:
         let message = b"Three turtle doves";
@@ -771,7 +767,7 @@ mod multi {
             .csp_vault
             .gen_committee_signing_key_pair()
             .expect("Failed to generate key pair with PoP");
-        let key_id1 = KeyId::try_from(&public_key1).unwrap();
+        let key_id1 = KeyId::from(&public_key1);
 
         // An incompatible signature:
         let (_, incompatible_public_key2, message, incompatible_signature2) =

--- a/rs/crypto/internal/crypto_service_provider/src/tests.rs
+++ b/rs/crypto/internal/crypto_service_provider/src/tests.rs
@@ -46,7 +46,7 @@ mod csp_tests {
     #[test]
     fn should_sign_and_verify_with_newly_generated_secret_key_from_store() {
         let (csp, public_key) = csp_with_node_signing_key_pair();
-        let key_id = KeyId::try_from(&public_key).unwrap();
+        let key_id = KeyId::from(&public_key);
         let message = "Hello world!".as_bytes();
 
         let signature = csp

--- a/rs/crypto/internal/crypto_service_provider/src/vault/api.rs
+++ b/rs/crypto/internal/crypto_service_provider/src/vault/api.rs
@@ -1,5 +1,5 @@
 use crate::api::{CspCreateMEGaKeyError, CspThresholdSignError};
-use crate::key_id::{KeyId, KeyIdInstantiationError};
+use crate::key_id::KeyId;
 use crate::types::{CspPop, CspPublicKey, CspSignature};
 use crate::ExternalPublicKeys;
 use ic_crypto_internal_logmon::metrics::KeyCounts;
@@ -317,12 +317,6 @@ impl From<&NodeKeysError> for KeyCounts {
 
 #[derive(Clone, Eq, PartialEq, Hash, Debug, Deserialize, Serialize)]
 pub struct ExternalPublicKeyError(pub Box<String>);
-
-impl From<KeyIdInstantiationError> for ExternalPublicKeyError {
-    fn from(error: KeyIdInstantiationError) -> Self {
-        ExternalPublicKeyError(Box::new(format!("Cannot instantiate KeyId: {:?}", error)))
-    }
-}
 
 #[derive(Clone, Eq, PartialEq, Hash, Debug, Deserialize, Serialize)]
 pub enum LocalPublicKeyError {

--- a/rs/crypto/internal/crypto_service_provider/src/vault/local_csp_vault/basic_sig/mod.rs
+++ b/rs/crypto/internal/crypto_service_provider/src/vault/local_csp_vault/basic_sig/mod.rs
@@ -62,7 +62,7 @@ impl<R: Rng + CryptoRng, S: SecretKeyStore, C: SecretKeyStore, P: PublicKeyStore
         let (sk_bytes, pk_bytes) = ed25519::keypair_from_rng(&mut *self.rng_write_lock());
         let secret_key = CspSecretKey::Ed25519(sk_bytes);
         let public_key = CspPublicKey::Ed25519(pk_bytes);
-        let key_id = KeyId::try_from(&public_key)?;
+        let key_id = KeyId::from(&public_key);
         let public_key_proto = node_signing_pk_to_proto(public_key.clone());
         let valid_public_key = validate_node_signing_public_key(public_key_proto)?;
         self.store_node_signing_key_pair(key_id, secret_key, valid_public_key.get().clone())?;

--- a/rs/crypto/internal/crypto_service_provider/src/vault/local_csp_vault/basic_sig/tests.rs
+++ b/rs/crypto/internal/crypto_service_provider/src/vault/local_csp_vault/basic_sig/tests.rs
@@ -37,9 +37,7 @@ fn should_generate_node_signing_key_pair_and_store_keys() {
         .expect("failed creating key pair");
 
     assert_matches!(gen_key_result, CspPublicKey::Ed25519(_));
-    assert!(csp_vault
-        .sks_contains(KeyId::try_from(&gen_key_result).unwrap())
-        .is_ok());
+    assert!(csp_vault.sks_contains(KeyId::from(&gen_key_result)).is_ok());
     assert_eq!(
         csp_vault
             .current_node_public_keys()
@@ -225,7 +223,7 @@ fn should_fail_to_sign_with_unsupported_algorithm_id() {
             let sign_result = csp_vault.sign(
                 AlgorithmId::EcdsaP256,
                 msg.clone(),
-                KeyId::try_from(&public_key).unwrap(),
+                KeyId::from(&public_key),
             );
             assert!(sign_result.is_err());
             let err = sign_result.expect_err("Expected an error.");
@@ -245,7 +243,7 @@ fn should_fail_to_sign_with_non_existent_key() {
         .build_into_arc();
     let (_, pk_bytes) = ed25519::keypair_from_rng(rng);
 
-    let key_id = KeyId::try_from(&CspPublicKey::Ed25519(pk_bytes)).unwrap();
+    let key_id = KeyId::from(&CspPublicKey::Ed25519(pk_bytes));
     let msg = b"some message".to_vec();
     let sign_result = csp_vault.sign(AlgorithmId::Ed25519, msg, key_id);
     assert!(sign_result.is_err());
@@ -303,11 +301,7 @@ pub fn generate_key_pair_and_sign_message(
         CspPublicKey::Ed25519(pk_bytes) => pk_bytes,
         _ => panic!("Wrong CspPublicKey: {:?}", csp_pk),
     };
-    let sign_result = csp_vault.sign(
-        AlgorithmId::Ed25519,
-        message,
-        KeyId::try_from(&csp_pk).unwrap(),
-    );
+    let sign_result = csp_vault.sign(AlgorithmId::Ed25519, message, KeyId::from(&csp_pk));
     (pk_bytes, sign_result)
 }
 

--- a/rs/crypto/internal/crypto_service_provider/src/vault/local_csp_vault/multi_sig/mod.rs
+++ b/rs/crypto/internal/crypto_service_provider/src/vault/local_csp_vault/multi_sig/mod.rs
@@ -62,7 +62,7 @@ impl<R: Rng + CryptoRng, S: SecretKeyStore, C: SecretKeyStore, P: PublicKeyStore
         &self,
     ) -> Result<(CspPublicKey, CspPop), CspMultiSignatureKeygenError> {
         let (secret_key, pk_and_pop) = self.gen_multi_bls12381_keypair_with_pop()?;
-        let key_id = KeyId::try_from(&pk_and_pop.0)?;
+        let key_id = KeyId::from(&pk_and_pop.0);
         let committee_public_key_proto = committee_signing_pk_to_proto(pk_and_pop.clone());
         let valid_public_key = validate_committee_signing_public_key(committee_public_key_proto)?;
         self.store_committee_signing_key_pair(key_id, secret_key, valid_public_key.get().clone())?;

--- a/rs/crypto/internal/crypto_service_provider/src/vault/local_csp_vault/multi_sig/tests.rs
+++ b/rs/crypto/internal/crypto_service_provider/src/vault/local_csp_vault/multi_sig/tests.rs
@@ -29,9 +29,7 @@ fn should_generate_committee_signing_key_pair_and_store_keys() {
         .expect("Failure generating key pair with pop");
 
     assert_matches!(pk, CspPublicKey::MultiBls12_381(_));
-    assert!(csp_vault
-        .sks_contains(KeyId::try_from(&pk).unwrap())
-        .is_ok());
+    assert!(csp_vault.sks_contains(KeyId::from(&pk)).is_ok());
     assert_eq!(
         csp_vault
             .current_node_public_keys()
@@ -182,7 +180,7 @@ fn should_multi_sign_and_verify_with_generated_key() {
     let (csp_pub_key, csp_pop) = csp_vault
         .gen_committee_signing_key_pair()
         .expect("failed to generate keys");
-    let key_id = KeyId::try_from(&csp_pub_key).unwrap();
+    let key_id = KeyId::from(&csp_pub_key);
 
     let msg_len: usize = rng.gen_range(0..1024);
     let msg: Vec<u8> = (0..msg_len).map(|_| rng.gen::<u8>()).collect();
@@ -213,7 +211,7 @@ fn should_fail_to_multi_sign_with_unsupported_algorithm_id() {
     let (csp_pub_key, _csp_pop) = csp_vault
         .gen_committee_signing_key_pair()
         .expect("failed to generate keys");
-    let key_id = KeyId::try_from(&csp_pub_key).unwrap();
+    let key_id = KeyId::from(&csp_pub_key);
 
     let msg = vec![31; 41];
 
@@ -242,7 +240,7 @@ fn should_fail_to_multi_sign_if_secret_key_in_store_has_wrong_type() {
     let result = csp_vault.multi_sign(
         AlgorithmId::MultiBls12_381,
         msg,
-        KeyId::try_from(&wrong_csp_pub_key).unwrap(),
+        KeyId::from(&wrong_csp_pub_key),
     );
 
     assert_eq!(

--- a/rs/crypto/internal/crypto_service_provider/src/vault/local_csp_vault/public_and_secret_key_store/mod.rs
+++ b/rs/crypto/internal/crypto_service_provider/src/vault/local_csp_vault/public_and_secret_key_store/mod.rs
@@ -150,7 +150,7 @@ fn compute_node_signing_key_id(
     }
     let csp_key = CspPublicKey::try_from(external_node_signing_public_key)
         .map_err(|err| ExternalPublicKeyError(Box::new(format!("{:?}", err))))?;
-    Ok(KeyId::try_from(&csp_key)?)
+    Ok(KeyId::from(&csp_key))
 }
 
 fn compute_committee_signing_key_id(
@@ -167,7 +167,7 @@ fn compute_committee_signing_key_id(
     ensure_committee_signing_key_pop_is_well_formed(external_committee_signing_public_key)?;
     let csp_key = CspPublicKey::try_from(external_committee_signing_public_key)
         .map_err(|err| ExternalPublicKeyError(Box::new(format!("{:?}", err))))?;
-    Ok(KeyId::try_from(&csp_key)?)
+    Ok(KeyId::from(&csp_key))
 }
 
 fn ensure_committee_signing_key_pop_is_well_formed(
@@ -249,7 +249,7 @@ fn compute_tls_certificate_key_id(
     )
     .map_err(|e| ExternalPublicKeyError(Box::new(format!("Malformed certificate: {:?}", e))))?;
 
-    Ok(KeyId::try_from(&public_key_cert)?)
+    Ok(KeyId::from(&public_key_cert))
 }
 
 #[derive(Clone, Debug)]

--- a/rs/crypto/internal/crypto_service_provider/src/vault/local_csp_vault/public_and_secret_key_store/tests.rs
+++ b/rs/crypto/internal/crypto_service_provider/src/vault/local_csp_vault/public_and_secret_key_store/tests.rs
@@ -1476,22 +1476,20 @@ mod validate_pks_and_sks {
     }
 
     fn node_signing_secret_key_id() -> KeyId {
-        KeyId::try_from(
+        KeyId::from(
             &CspPublicKey::try_from(&valid_node_signing_public_key()).expect("invalid public key"),
         )
-        .expect("invalid public key")
     }
 
     fn committee_signing_secret_key_id() -> KeyId {
-        KeyId::try_from(
+        KeyId::from(
             &CspPublicKey::try_from(&valid_committee_signing_public_key())
                 .expect("invalid public key"),
         )
-        .expect("invalid public key")
     }
 
     fn tls_certificate_key_id() -> KeyId {
-        KeyId::try_from(
+        KeyId::from(
             &TlsPublicKeyCert::new_from_der(
                 valid_tls_certificate_and_validation_time()
                     .0
@@ -1499,7 +1497,6 @@ mod validate_pks_and_sks {
             )
             .expect("invalid certificate"),
         )
-        .expect("invalid certificate")
     }
 
     fn dkg_dealing_encryption_key_id() -> KeyId {

--- a/rs/crypto/internal/crypto_service_provider/src/vault/local_csp_vault/secret_key_store/tests.rs
+++ b/rs/crypto/internal/crypto_service_provider/src/vault/local_csp_vault/secret_key_store/tests.rs
@@ -15,7 +15,7 @@ fn key_should_be_present_only_after_generation() {
     let public_key1 = csp_vault1
         .gen_node_signing_key_pair()
         .expect("Test setup failed: Failed to generate keys");
-    let key_id1 = KeyId::try_from(&public_key1).unwrap();
+    let key_id1 = KeyId::from(&public_key1);
     assert!(
         csp_vault1.sks_contains(key_id1).expect("SKS call failed"),
         "Key should be present after generation."
@@ -28,7 +28,7 @@ fn key_should_be_present_only_after_generation() {
     let public_key2 = csp_vault2
         .gen_node_signing_key_pair()
         .expect("Test setup failed: Failed to generate keys");
-    let key_id2 = KeyId::try_from(&public_key2).unwrap();
+    let key_id2 = KeyId::from(&public_key2);
     assert_ne!(
         key_id1, key_id2,
         "Test failure: Key IDs from different CSPs were the same.  Check random number generation."
@@ -54,7 +54,7 @@ fn tls_key_should_be_present_only_after_generation() {
     let public_key_cert1 = csp_vault1
         .gen_tls_key_pair(node_test_id(NODE_1))
         .expect("error generating TLS key pair");
-    let key_id1 = KeyId::try_from(&public_key_cert1).unwrap();
+    let key_id1 = KeyId::from(&public_key_cert1);
     assert!(
         csp_vault1.sks_contains(key_id1).expect("SKS call failed"),
         "TLS key should be present after generation."
@@ -67,7 +67,7 @@ fn tls_key_should_be_present_only_after_generation() {
     let public_key_cert2 = csp_vault2
         .gen_tls_key_pair(node_test_id(NODE_1))
         .expect("error generating TLS key pair");
-    let key_id2 = KeyId::try_from(&public_key_cert2).unwrap();
+    let key_id2 = KeyId::from(&public_key_cert2);
     assert_ne!(
         key_id1, key_id2,
         "Test failure: Key IDs from different CSPs were the same.  Check random number generation."

--- a/rs/crypto/internal/crypto_service_provider/src/vault/local_csp_vault/tls/mod.rs
+++ b/rs/crypto/internal/crypto_service_provider/src/vault/local_csp_vault/tls/mod.rs
@@ -83,10 +83,7 @@ impl<R: Rng + CryptoRng, S: SecretKeyStore, C: SecretKeyStore, P: PublicKeyStore
             }
         })?;
 
-        let key_id =
-            KeyId::try_from(&x509_pk_cert).map_err(|error| CspTlsKeygenError::InternalError {
-                internal_error: format!("Cannot instantiate KeyId: {:?}", error),
-            })?;
+        let key_id = KeyId::from(&x509_pk_cert);
         let secret_key = CspSecretKey::TlsEd25519(secret_key);
         let cert_proto = x509_pk_cert.to_proto();
         let valid_cert = validate_tls_certificate(cert_proto, node, issuance_time)?;

--- a/rs/crypto/internal/crypto_service_provider/src/vault/local_csp_vault/tls/tests.rs
+++ b/rs/crypto/internal/crypto_service_provider/src/vault/local_csp_vault/tls/tests.rs
@@ -43,7 +43,7 @@ mod keygen {
         let cert = csp_vault
             .gen_tls_key_pair(node_test_id(NODE_1))
             .expect("Generation of TLS keys failed.");
-        let key_id = KeyId::try_from(&cert).unwrap();
+        let key_id = KeyId::from(&cert);
 
         assert!(csp_vault.sks_contains(key_id).expect("SKS call failed"));
         assert_eq!(
@@ -447,10 +447,7 @@ mod sign {
             .expect("Generation of TLS keys failed.");
 
         assert!(csp_vault
-            .tls_sign(
-                random_message(rng),
-                KeyId::try_from(&public_key_cert).expect("Cannot instantiate KeyId")
-            )
+            .tls_sign(random_message(rng), KeyId::from(&public_key_cert))
             .is_ok());
     }
 
@@ -467,10 +464,7 @@ mod sign {
         let msg = random_message(rng);
 
         let sig = csp_vault
-            .tls_sign(
-                msg.clone(),
-                KeyId::try_from(&public_key_cert).expect("cannot instantiate KeyId"),
-            )
+            .tls_sign(msg.clone(), KeyId::from(&public_key_cert))
             .expect("failed to generate signature");
 
         let csp_pub_key = ed25519_csp_pubkey_from_tls_pubkey_cert(&public_key_cert);
@@ -505,7 +499,7 @@ mod sign {
             .expect("failed to generate keys");
         let msg = random_message(rng);
 
-        let result = csp_vault.tls_sign(msg, KeyId::try_from(&wrong_csp_pub_key).unwrap());
+        let result = csp_vault.tls_sign(msg, KeyId::from(&wrong_csp_pub_key));
 
         assert_eq!(
             result.expect_err("Unexpected success."),

--- a/rs/crypto/internal/crypto_service_provider/src/vault/mod.rs
+++ b/rs/crypto/internal/crypto_service_provider/src/vault/mod.rs
@@ -1,10 +1,8 @@
 use self::api::CspVault;
 use self::local_csp_vault::ProdLocalCspVault;
 use self::remote_csp_vault::RemoteCspVault;
-use crate::key_id::KeyIdInstantiationError;
 use crate::vault::api::{
-    CspBasicSignatureError, CspBasicSignatureKeygenError, CspMultiSignatureError,
-    CspMultiSignatureKeygenError, CspSecretKeyStoreContainsError,
+    CspBasicSignatureError, CspMultiSignatureError, CspSecretKeyStoreContainsError,
 };
 use ic_adapter_metrics_client::AdapterMetrics;
 use ic_config::crypto::{CryptoConfig, CspVaultType};
@@ -166,22 +164,6 @@ impl From<CspSecretKeyStoreContainsError> for CryptoError {
             CspSecretKeyStoreContainsError::TransientInternalError { internal_error } => {
                 CryptoError::TransientInternalError { internal_error }
             }
-        }
-    }
-}
-
-impl From<KeyIdInstantiationError> for CspBasicSignatureKeygenError {
-    fn from(error: KeyIdInstantiationError) -> Self {
-        CspBasicSignatureKeygenError::InternalError {
-            internal_error: format!("Cannot instantiate KeyId: {:?}", error),
-        }
-    }
-}
-
-impl From<KeyIdInstantiationError> for CspMultiSignatureKeygenError {
-    fn from(error: KeyIdInstantiationError) -> Self {
-        CspMultiSignatureKeygenError::InternalError {
-            internal_error: format!("Cannot instantiate KeyId: {:?}", error),
         }
     }
 }

--- a/rs/crypto/internal/crypto_service_provider/src/vault/test_utils/ni_dkg.rs
+++ b/rs/crypto/internal/crypto_service_provider/src/vault/test_utils/ni_dkg.rs
@@ -1,14 +1,14 @@
 pub mod fixtures;
 
-use crate::key_id::KeyId;
+use crate::key_id::{KeyId, KeyIdInstantiationError};
 use crate::keygen::utils::dkg_dealing_encryption_pk_to_proto;
 use crate::types::CspPublicCoefficients;
 use crate::vault::api::CspVault;
+use crate::vault::test_utils;
 use crate::vault::test_utils::ni_dkg::fixtures::{
     random_algorithm_id, MockDkgConfig, MockNetwork, MockNode, StateWithConfig, StateWithDealings,
     StateWithTranscript, StateWithVerifiedDealings,
 };
-use crate::vault::{test_utils, KeyIdInstantiationError};
 use assert_matches::assert_matches;
 use ic_crypto_internal_seed::Seed;
 use ic_crypto_internal_threshold_sig_bls12381::api::dkg_errors::InternalError;

--- a/rs/crypto/internal/crypto_service_provider/tests/remote_vault_basig_signature_delegation.rs
+++ b/rs/crypto/internal/crypto_service_provider/tests/remote_vault_basig_signature_delegation.rs
@@ -81,7 +81,7 @@ fn should_sign_a_large_hundred_megabytes_message() {
         .sign(
             AlgorithmId::Ed25519,
             message.clone(),
-            KeyId::try_from(&node_signing_public_key).unwrap(),
+            KeyId::from(&node_signing_public_key),
         )
         .expect("could not sign large message");
 

--- a/rs/crypto/internal/crypto_service_provider/tests/remote_vault_rpc_connection.rs
+++ b/rs/crypto/internal/crypto_service_provider/tests/remote_vault_rpc_connection.rs
@@ -40,7 +40,7 @@ fn should_reconnect_after_request_from_client_cannot_be_sent_because_too_large()
     let node_signing_public_key = client_cannot_send_large_request
         .gen_node_signing_key_pair()
         .expect("failed generating node signing key pair");
-    let key_id = KeyId::try_from(&node_signing_public_key).unwrap();
+    let key_id = KeyId::from(&node_signing_public_key);
 
     let signature = sign_message(Small, key_id, &client_cannot_send_large_request);
     assert_matches!(signature, Ok(_));
@@ -67,7 +67,7 @@ fn should_reconnect_after_request_from_client_cannot_be_received_by_server_becau
     let node_signing_public_key = client
         .gen_node_signing_key_pair()
         .expect("failed generating node signing key pair");
-    let key_id = KeyId::try_from(&node_signing_public_key).unwrap();
+    let key_id = KeyId::from(&node_signing_public_key);
 
     let signature_before_error = sign_message(Small, key_id, &client);
     assert_matches!(signature_before_error, Ok(_));
@@ -146,7 +146,7 @@ fn should_reconnect_with_existing_client_after_server_killed_and_restarted() {
     let node_signing_public_key = client
         .gen_node_signing_key_pair()
         .expect("failed generating node signing key pair");
-    let key_id = KeyId::try_from(&node_signing_public_key).unwrap();
+    let key_id = KeyId::from(&node_signing_public_key);
 
     let signature_before_shutdown = sign_message(Small, key_id, &client);
     assert_matches!(signature_before_shutdown, Ok(_));
@@ -185,7 +185,7 @@ fn should_connect_with_new_client_after_server_killed_and_restarted() {
     let node_signing_public_key = client
         .gen_node_signing_key_pair()
         .expect("failed generating node signing key pair");
-    let key_id = KeyId::try_from(&node_signing_public_key).unwrap();
+    let key_id = KeyId::from(&node_signing_public_key);
 
     env.shutdown_server_now();
     env.restart_server();

--- a/rs/crypto/src/sign/basic_sig.rs
+++ b/rs/crypto/src/sign/basic_sig.rs
@@ -120,7 +120,7 @@ impl BasicSignerInternal {
             key_from_registry(registry, signer, KeyPurpose::NodeSigning, registry_version)?;
         let algorithm_id = AlgorithmId::from(pk_proto.algorithm);
         let csp_pk = CspPublicKey::try_from(pk_proto)?;
-        let key_id = KeyId::try_from(&csp_pk)?;
+        let key_id = KeyId::from(&csp_pk);
         let csp_sig = csp_signer.sign(algorithm_id, message.as_signed_bytes(), key_id)?;
 
         Ok(BasicSigOf::new(BasicSig(csp_sig.as_ref().to_vec())))

--- a/rs/crypto/src/sign/basic_sig/tests.rs
+++ b/rs/crypto/src/sign/basic_sig/tests.rs
@@ -46,7 +46,7 @@ mod sign_basic {
         let key_record =
             node_signing_record_with(NODE_1, pk.ed25519_bytes().unwrap().to_vec(), REG_V2);
         let mut csp = MockAllCryptoServiceProvider::new();
-        let key_id = KeyId::try_from(&pk).unwrap();
+        let key_id = KeyId::from(&pk);
         let expected_error = CryptoError::SecretKeyNotFound {
             algorithm: AlgorithmId::Ed25519,
             key_id: key_id.to_string(),

--- a/rs/crypto/src/sign/multi_sig.rs
+++ b/rs/crypto/src/sign/multi_sig.rs
@@ -206,7 +206,7 @@ impl MultiSignerInternal {
         let algorithm_id = AlgorithmId::from(pk_proto.algorithm);
         let csp_pk = CspPublicKey::try_from(pk_proto)?;
         let message_bytes = message.as_signed_bytes();
-        let key_id = KeyId::try_from(&csp_pk)?;
+        let key_id = KeyId::from(&csp_pk);
         let csp_sig = csp_signer.sign(algorithm_id, message_bytes, key_id)?;
 
         Ok(IndividualMultiSigOf::new(IndividualMultiSig(

--- a/rs/crypto/src/tls/rustls/client_handshake.rs
+++ b/rs/crypto/src/tls/rustls/client_handshake.rs
@@ -26,11 +26,7 @@ pub fn client_config(
 ) -> Result<ClientConfig, TlsConfigError> {
     let self_tls_cert =
         tls_cert_from_registry(registry_client.as_ref(), self_node_id, registry_version)?;
-    let self_tls_cert_key_id = KeyId::try_from(&self_tls_cert).map_err(|error| {
-        TlsConfigError::MalformedSelfCertificate {
-            internal_error: format!("Cannot instantiate KeyId: {:?}", error),
-        }
-    })?;
+    let self_tls_cert_key_id = KeyId::from(&self_tls_cert);
     let ed25519_signing_key =
         CspServerEd25519SigningKey::new(self_tls_cert_key_id, Arc::clone(vault));
     let server_cert_verifier = NodeServerCertVerifier::new(

--- a/rs/crypto/src/tls/rustls/server_handshake.rs
+++ b/rs/crypto/src/tls/rustls/server_handshake.rs
@@ -26,11 +26,7 @@ pub fn server_config(
 ) -> Result<ServerConfig, TlsConfigError> {
     let self_tls_cert =
         tls_cert_from_registry(registry_client.as_ref(), self_node_id, registry_version)?;
-    let self_tls_cert_key_id = KeyId::try_from(&self_tls_cert).map_err(|error| {
-        TlsConfigError::MalformedSelfCertificate {
-            internal_error: format!("Cannot instantiate KeyId: {:?}", error),
-        }
-    })?;
+    let self_tls_cert_key_id = KeyId::from(&self_tls_cert);
     let client_cert_verifier = NodeClientCertVerifier::new_with_mandatory_client_auth(
         allowed_clients.clone(),
         registry_client,
@@ -54,11 +50,7 @@ pub fn server_config_without_client_auth(
     registry_version: RegistryVersion,
 ) -> Result<ServerConfig, TlsConfigError> {
     let self_tls_cert = tls_cert_from_registry(registry_client, self_node_id, registry_version)?;
-    let self_tls_cert_key_id = KeyId::try_from(&self_tls_cert).map_err(|error| {
-        TlsConfigError::MalformedSelfCertificate {
-            internal_error: format!("Cannot instantiate KeyId: {:?}", error),
-        }
-    })?;
+    let self_tls_cert_key_id = KeyId::from(&self_tls_cert);
     let ed25519_signing_key =
         CspServerEd25519SigningKey::new(self_tls_cert_key_id, Arc::clone(vault));
     let config = server_config_with_tls13_and_aes_ciphersuites_and_ed25519_signing_key(


### PR DESCRIPTION
Makes some conversions to `KeyId` infallible. In particular:
* `impl<B: AsRef<[u8]>> TryFrom<(AlgorithmId, &B)> for KeyId`
* `impl TryFrom<&CspPublicKey> for KeyId`
* `impl TryFrom<&TlsPublicKeyCert> for KeyId`