### PR TITLE
test(ckbtc): add a test that replays mainnet events and dumps stable memory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6891,6 +6891,7 @@ dependencies = [
  "minicbor-derive",
  "mockall",
  "num-traits",
+ "pocket-ic",
  "proptest 1.6.0",
  "ripemd",
  "scopeguard",

--- a/rs/bitcoin/ckbtc/minter/BUILD.bazel
+++ b/rs/bitcoin/ckbtc/minter/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test")
+load("@rules_rust//rust:defs.bzl", "rust_binary", "rust_library", "rust_test")
 load("//bazel:canisters.bzl", "rust_canister")
 load("//bazel:defs.bzl", "rust_ic_test")
 
@@ -131,6 +131,24 @@ rust_test(
     ],
 )
 
+rust_binary(
+    name = "ckbtc_minter_dump_stable_memory",
+    testonly = True,
+    srcs = ["tests/dump_stable_memory.rs"],
+    deps = [
+        # Keep sorted.
+        ":ckbtc_minter_lib",
+        "//packages/pocket-ic",
+        "//rs/config",
+        "//rs/test_utilities/load_wasm",
+        "//rs/types/base_types",
+        "@crate_index//:candid",
+        "@crate_index//:flate2",
+        "@crate_index//:ic-btc-interface",
+        "@crate_index//:serde",
+    ],
+)
+
 rust_test(
     name = "ckbtc_minter_replay_events_tests",
     srcs = ["tests/replay_events.rs"],
@@ -193,4 +211,26 @@ rust_ic_test(
         "@crate_index//:serde_bytes",
         "@crate_index//:serde_json",
     ],
+)
+
+genrule(
+    name = "mainnet_events.mem.gz",
+    testonly = True,
+    srcs = [
+        ":ckbtc_minter_dump_stable_memory",
+        "test_resources/mainnet_events.gz",
+        ":ckbtc_minter_debug.wasm",
+        "//:pocket-ic-server",
+        "//rs/bitcoin/mock:bitcoin_canister_mock",
+    ],
+    outs = ["test_resources/mainnet_events.mem.gz"],
+    cmd_bash = """
+    export CARGO_MANIFEST_DIR=rs/bitcoin/ckbtc/minter
+    export IC_BITCOIN_CANISTER_MOCK_WASM_PATH="$(location //rs/bitcoin/mock:bitcoin_canister_mock)"
+    export IC_CKBTC_MINTER_WASM_PATH="$(location :ckbtc_minter_debug.wasm)"
+    export POCKET_IC_BIN="$(location //:pocket-ic-server)"
+
+    $(location :ckbtc_minter_dump_stable_memory) $(location test_resources/mainnet_events.gz) | gzip -c > $@
+""",
+    visibility = ["//visibility:private"],
 )

--- a/rs/bitcoin/ckbtc/minter/BUILD.bazel
+++ b/rs/bitcoin/ckbtc/minter/BUILD.bazel
@@ -230,7 +230,7 @@ genrule(
     export IC_CKBTC_MINTER_WASM_PATH="$(location :ckbtc_minter_debug.wasm)"
     export POCKET_IC_BIN="$(location //:pocket-ic-server)"
 
-    $(location :ckbtc_minter_dump_stable_memory) $(location test_resources/mainnet_events.gz) | gzip -c > $@
+    $(location :ckbtc_minter_dump_stable_memory) $(location test_resources/mainnet_events.gz) $@
 """,
     visibility = ["//visibility:private"],
 )

--- a/rs/bitcoin/ckbtc/minter/Cargo.toml
+++ b/rs/bitcoin/ckbtc/minter/Cargo.toml
@@ -62,6 +62,7 @@ ic-test-utilities-load-wasm = { path = "../../../test_utilities/load_wasm" }
 ic-types = { path = "../../../types/types" }
 maplit = "1.0.2"
 mockall = { workspace = true }
+pocket-ic = { path = "../../../../packages/pocket-ic" }
 proptest = { workspace = true }
 simple_asn1 = { workspace = true }
 tokio = { workspace = true }

--- a/rs/bitcoin/ckbtc/minter/src/main.rs
+++ b/rs/bitcoin/ckbtc/minter/src/main.rs
@@ -199,6 +199,23 @@ async fn get_canister_status() -> ic_cdk::api::management_canister::main::Canist
     .0
 }
 
+#[cfg(feature = "self_check")]
+#[update]
+async fn upload_events(events: Vec<Event>) {
+    for event in events {
+        storage::record_event_v0(event.payload, &IC_CANISTER_RUNTIME);
+    }
+}
+
+#[cfg(feature = "self_check")]
+#[update]
+async fn finish_upload() -> (u64, Option<u64>) {
+    let count_start = ic_cdk::api::instruction_counter();
+    let removed = storage::migrate_old_events_if_not_empty();
+    let count_end = ic_cdk::api::instruction_counter();
+    (count_end - count_start, removed)
+}
+
 #[query]
 fn estimate_withdrawal_fee(arg: EstimateFeeArg) -> WithdrawalFee {
     read_state(|s| {

--- a/rs/bitcoin/ckbtc/minter/src/main.rs
+++ b/rs/bitcoin/ckbtc/minter/src/main.rs
@@ -207,15 +207,6 @@ async fn upload_events(events: Vec<Event>) {
     }
 }
 
-#[cfg(feature = "self_check")]
-#[update]
-async fn finish_upload() -> (u64, Option<u64>) {
-    let count_start = ic_cdk::api::instruction_counter();
-    let removed = storage::migrate_old_events_if_not_empty();
-    let count_end = ic_cdk::api::instruction_counter();
-    (count_end - count_start, removed)
-}
-
 #[query]
 fn estimate_withdrawal_fee(arg: EstimateFeeArg) -> WithdrawalFee {
     read_state(|s| {

--- a/rs/bitcoin/ckbtc/minter/src/storage.rs
+++ b/rs/bitcoin/ckbtc/minter/src/storage.rs
@@ -173,3 +173,16 @@ pub fn record_event<R: CanisterRuntime>(payload: EventType, runtime: &R) {
             .expect("failed to append an entry to the event log");
     })
 }
+
+pub fn record_event_v0<R: CanisterRuntime>(payload: EventType, runtime: &R) {
+    let bytes = encode_event(&Event {
+        timestamp: Some(runtime.time()),
+        payload,
+    });
+    V0_EVENTS.with(|events| {
+        events
+            .borrow()
+            .append(&bytes)
+            .expect("failed to append an entry to the event log");
+    })
+}

--- a/rs/bitcoin/ckbtc/minter/tests/dump_stable_memory.rs
+++ b/rs/bitcoin/ckbtc/minter/tests/dump_stable_memory.rs
@@ -1,0 +1,174 @@
+use candid::{CandidType, Decode, Deserialize, Encode, Principal};
+use ic_base_types::{CanisterId, PrincipalId};
+use ic_btc_interface::Network;
+use ic_ckbtc_minter::lifecycle::init::{InitArgs as CkbtcMinterInitArgs, MinterArg};
+use ic_ckbtc_minter::state::eventlog::Event;
+use ic_ckbtc_minter::state::Mode;
+use ic_test_utilities_load_wasm::load_wasm;
+use pocket_ic::{PocketIc, PocketIcBuilder};
+use std::io::Write;
+use std::path::PathBuf;
+
+#[derive(Clone, Debug, CandidType, Deserialize)]
+pub struct GetEventsResult {
+    pub events: Vec<Event>,
+    pub total_event_count: u64,
+}
+
+fn read_events_file(file_name: &str) -> GetEventsResult {
+    use candid::Decode;
+    use flate2::read::GzDecoder;
+    use std::fs::File;
+    use std::io::Read;
+
+    let file = File::open(file_name).unwrap();
+    let mut gz = GzDecoder::new(file);
+    let mut decompressed_buffer = Vec::new();
+    gz.read_to_end(&mut decompressed_buffer)
+        .expect("BUG: failed to decompress events");
+    Decode!(&decompressed_buffer, GetEventsResult).expect("Failed to decode events")
+}
+
+struct Setup {
+    minter_id: Principal,
+    env: PocketIc,
+}
+
+impl Setup {
+    pub fn new(btc_network: Network) -> Self {
+        let env = PocketIcBuilder::new().with_application_subnet().build();
+
+        // install bitcoin canister
+        let bitcoin_id = bitcoin_canister_id(btc_network);
+        env.create_canister_with_id(None, None, bitcoin_id).unwrap();
+        env.install_canister(
+            bitcoin_id,
+            bitcoin_mock_wasm(),
+            Encode!(&btc_network).unwrap(),
+            None,
+        );
+
+        let ledger_id = env.create_canister();
+        let minter_id = env.create_canister();
+        let btc_checker_id = env.create_canister();
+        env.add_cycles(minter_id, 100_000_000_000_000);
+
+        let init_args = Encode!(&MinterArg::Init(CkbtcMinterInitArgs {
+            btc_network: btc_network.into(),
+            retrieve_btc_min_amount: 100_000,
+            ledger_id: CanisterId::try_from(PrincipalId::from(ledger_id)).unwrap(),
+            max_time_in_queue_nanos: 100,
+            check_fee: Some(100),
+            btc_checker_principal: Some(
+                CanisterId::try_from(PrincipalId::from(btc_checker_id)).unwrap()
+            ),
+            ..default_init_args()
+        }))
+        .unwrap();
+
+        // println!("{:02x?}", init_args);
+
+        env.install_canister(minter_id, minter_wasm(), init_args, None);
+        Self { env, minter_id }
+    }
+}
+
+fn bitcoin_canister_id(btc_network: Network) -> Principal {
+    Principal::from_text(match btc_network {
+        Network::Testnet | Network::Regtest => {
+            ic_config::execution_environment::BITCOIN_TESTNET_CANISTER_ID
+        }
+        Network::Mainnet => ic_config::execution_environment::BITCOIN_MAINNET_CANISTER_ID,
+    })
+    .unwrap()
+}
+
+fn bitcoin_mock_wasm() -> Vec<u8> {
+    load_wasm(
+        PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap())
+            .parent()
+            .unwrap()
+            .parent()
+            .unwrap()
+            .join("mock"),
+        "ic-bitcoin-canister-mock",
+        &[],
+    )
+}
+
+fn minter_wasm() -> Vec<u8> {
+    load_wasm(
+        std::env::var("CARGO_MANIFEST_DIR").unwrap(),
+        "ic-ckbtc-minter",
+        &[],
+    )
+}
+
+#[allow(deprecated)]
+fn default_init_args() -> CkbtcMinterInitArgs {
+    CkbtcMinterInitArgs {
+        btc_network: Network::Regtest.into(),
+        ecdsa_key_name: "master_ecdsa_public_key".into(),
+        retrieve_btc_min_amount: 2000,
+        ledger_id: CanisterId::from(0),
+        max_time_in_queue_nanos: 10_000_000_000,
+        min_confirmations: Some(6),
+        mode: Mode::GeneralAvailability,
+        check_fee: None,
+        btc_checker_principal: Some(CanisterId::from(0)),
+        kyt_principal: None,
+        kyt_fee: None,
+    }
+}
+
+fn upload_events(setup: &Setup, file_name: &str) {
+    let events = read_events_file(file_name);
+    let total = events.events.len();
+    let mut start = 0;
+    while start < total {
+        let mut end = start + 2000;
+        if end > total {
+            end = total;
+        };
+        setup
+            .env
+            .update_call(
+                setup.minter_id,
+                Principal::anonymous(),
+                "upload_events",
+                Encode!(&events.events[start..end].to_vec()).unwrap(),
+            )
+            .unwrap();
+        start = end;
+    }
+}
+
+fn upload_events_and_dump_stable_memory<Out: Write>(input_file: &str, mut output: Out) {
+    let setup = Setup::new(Network::Mainnet);
+    upload_events(&setup, input_file);
+
+    let mem = setup.env.get_stable_memory(setup.minter_id);
+    output.write_all(&mem).unwrap();
+}
+
+// This is used by Bazel to build an executable.
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    if args.len() != 2 {
+        panic!("Expecting path to events.gz file as argument");
+    }
+    upload_events_and_dump_stable_memory(&args[1], std::io::stdout());
+}
+
+#[test]
+fn test_minter_dump_stable_mem_mainnet() {
+    fn path_to_events_file(file_name: &str) -> PathBuf {
+        let mut path = PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap());
+        path.push(format!("test_resources/{}", file_name));
+        path
+    }
+    let input_file = path_to_events_file("mainnet_events.gz");
+    let mem_path = path_to_events_file("mainnet_events.mem");
+    let file = std::fs::File::create(mem_path).unwrap();
+    upload_events_and_dump_stable_memory(input_file.to_str().unwrap(), file);
+}


### PR DESCRIPTION
Add a test and bazel rules that replays mainnet events and then dump stable memory to a file.

The bazel target `mainnet_events.mem.gz` can then be used as run time input to canbench benchmarks.