### PR TITLE
chore: remove reference to a custom jsonrpc version in Cargo.toml

### DIFF
--- a/Cargo.Bazel.Fuzzing.json.lock
+++ b/Cargo.Bazel.Fuzzing.json.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "6bf850e944d04daf1c3efb3074039e55cc51cb44921337dc9e1f7ddc077df72a",
+  "checksum": "179ebd99f400ffee02bd594bde96814d37391a2d4b29798a92daaf4feebf1309",
   "crates": {
     "abnf 0.12.0": {
       "name": "abnf",
@@ -91597,11 +91597,5 @@
     "zstd 0.13.2"
   ],
   "direct_dev_deps": [],
-  "unused_patches": [
-    {
-      "name": "jsonrpc",
-      "version": "0.12.1",
-      "source": "git+https://github.com/apoelstra/rust-jsonrpc?rev=e42044d#e42044d8e0896317488dfbd65eb5563d76e937fe"
-    }
-  ]
+  "unused_patches": []
 }

--- a/Cargo.Bazel.Fuzzing.toml.lock
+++ b/Cargo.Bazel.Fuzzing.toml.lock
@@ -14030,9 +14030,3 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
-
-[[patch.unused]]
-name = "jsonrpc"
-version = "0.12.1"
-source = "git+https://github.com/apoelstra/rust-jsonrpc?rev=e42044d#e42044d8e0896317488dfbd65eb5563d76e937fe"
-

--- a/Cargo.Bazel.json.lock
+++ b/Cargo.Bazel.json.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "1c198a1e523171945768f2579f76f306cd68c8c7ddd074aaa8f5dc8eb8a28426",
+  "checksum": "fdf963ba3ffb1ad926d2a7c4089133ae5e18acd1dbc5632a38f8e81ae58c04aa",
   "crates": {
     "abnf 0.12.0": {
       "name": "abnf",
@@ -91510,11 +91510,5 @@
     "zstd 0.13.2"
   ],
   "direct_dev_deps": [],
-  "unused_patches": [
-    {
-      "name": "jsonrpc",
-      "version": "0.12.1",
-      "source": "git+https://github.com/apoelstra/rust-jsonrpc?rev=e42044d#e42044d8e0896317488dfbd65eb5563d76e937fe"
-    }
-  ]
+  "unused_patches": []
 }

--- a/Cargo.Bazel.toml.lock
+++ b/Cargo.Bazel.toml.lock
@@ -14044,9 +14044,3 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
-
-[[patch.unused]]
-name = "jsonrpc"
-version = "0.12.1"
-source = "git+https://github.com/apoelstra/rust-jsonrpc?rev=e42044d#e42044d8e0896317488dfbd65eb5563d76e937fe"
-

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23890,8 +23890,3 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
-
-[[patch.unused]]
-name = "jsonrpc"
-version = "0.12.1"
-source = "git+https://github.com/apoelstra/rust-jsonrpc?rev=e42044d#e42044d8e0896317488dfbd65eb5563d76e937fe"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -487,11 +487,6 @@ opt-level = 3
 [profile.dev.package.p256]
 opt-level = 3
 
-[patch.crates-io]
-# Current jsonrpc version (0.12.1) does not support ipv6 addressing. When new version is
-# released this can be removed.
-jsonrpc = { git = "https://github.com/apoelstra/rust-jsonrpc", rev = "e42044d" }
-
 [workspace.dependencies]
 actix-web = "4.9.0"
 actix-rt = "2.10.0"

--- a/bazel/cargo.config
+++ b/bazel/cargo.config
@@ -1,4 +1,1 @@
 [patch.crates-io]
-# Current jsonrpc version (0.12.1) does not support ipv6 addressing. When new version is
-# released this can be removed.
-jsonrpc = { git = "https://github.com/apoelstra/rust-jsonrpc", rev = "e42044d" }


### PR DESCRIPTION
Remove the (very old) reference to a custom version of jsonrpc in Cargo.toml and just use the latest version instead.