### PR TITLE
feat(sns-cli): Cleanup store canister after upgrading an SNS-controlled canister

### DIFF
--- a/rs/nervous_system/agent/src/management_canister/mod.rs
+++ b/rs/nervous_system/agent/src/management_canister/mod.rs
@@ -10,6 +10,50 @@ use requests::*;
 
 pub const CHUNK_SIZE: usize = 1024 * 1024; // 1 MiB
 
+pub async fn canister_status<C: CallCanisters>(
+    agent: &C,
+    canister_id: CanisterId,
+) -> Result<CanisterStatusResult, C::Error> {
+    let response = agent
+        .call(
+            Principal::management_canister(),
+            CanisterStatusArgs {
+                canister_id: canister_id.get().0,
+            },
+        )
+        .await?;
+
+    Ok(response)
+}
+
+pub async fn stop_canister<C: CallCanisters>(
+    agent: &C,
+    canister_id: CanisterId,
+) -> Result<(), C::Error> {
+    agent
+        .call(
+            Principal::management_canister(),
+            StopCanisterArgs {
+                canister_id: canister_id.get().0,
+            },
+        )
+        .await
+}
+
+pub async fn delete_canister<C: CallCanisters>(
+    agent: &C,
+    canister_id: CanisterId,
+) -> Result<(), C::Error> {
+    agent
+        .call(
+            Principal::management_canister(),
+            DeleteCanisterArgs {
+                canister_id: canister_id.get().0,
+            },
+        )
+        .await
+}
+
 async fn upload_chunk<C: CallCanisters>(
     agent: &C,
     store_canister_id: CanisterId,

--- a/rs/nervous_system/agent/src/management_canister/requests.rs
+++ b/rs/nervous_system/agent/src/management_canister/requests.rs
@@ -78,3 +78,156 @@ impl Request for StoredChunksArgs {
 
     type Response = StoredChunksResult;
 }
+
+// ```
+// type canister_status_args = record {
+//     canister_id : canister_id;
+// };
+// ```
+
+// ```
+// type canister_status_result = record {
+//     status : variant { running; stopping; stopped };
+//     settings : definite_canister_settings;
+//     module_hash : opt blob;
+//     memory_size : nat;
+//     cycles : nat;
+//     reserved_cycles : nat;
+//     idle_cycles_burned_per_day : nat;
+//     query_stats: record {
+//         num_calls_total: nat;
+//         num_instructions_total: nat;
+//         request_payload_bytes_total: nat;
+//         response_payload_bytes_total: nat;
+//     };
+// };
+// ```
+
+#[derive(CandidType, Deserialize, Debug, Clone)]
+pub enum LogVisibility {
+    #[serde(rename = "controllers")]
+    Controllers,
+    #[serde(rename = "public")]
+    Public,
+    #[serde(rename = "allowed_viewers")]
+    AllowedViewers(Vec<Principal>),
+}
+
+#[derive(CandidType, Deserialize, Debug, Clone)]
+pub enum CanisterStatusResultStatus {
+    #[serde(rename = "stopped")]
+    Stopped,
+    #[serde(rename = "stopping")]
+    Stopping,
+    #[serde(rename = "running")]
+    Running,
+}
+
+#[derive(CandidType, Deserialize, Debug, Clone)]
+pub struct DefiniteCanisterSettings {
+    pub freezing_threshold: candid::Nat,
+    pub controllers: Vec<Principal>,
+    pub reserved_cycles_limit: candid::Nat,
+    pub log_visibility: LogVisibility,
+    pub wasm_memory_limit: candid::Nat,
+    pub memory_allocation: candid::Nat,
+    pub compute_allocation: candid::Nat,
+}
+
+#[derive(CandidType, Deserialize, Debug, Clone)]
+pub struct CanisterStatusResultQueryStats {
+    pub response_payload_bytes_total: candid::Nat,
+    pub num_instructions_total: candid::Nat,
+    pub num_calls_total: candid::Nat,
+    pub request_payload_bytes_total: candid::Nat,
+}
+
+#[derive(CandidType, Deserialize, Debug, Clone)]
+pub struct CanisterStatusResult {
+    pub status: CanisterStatusResultStatus,
+    pub settings: DefiniteCanisterSettings,
+    pub module_hash: Option<Vec<u8>>,
+    pub memory_size: candid::Nat,
+    pub cycles: candid::Nat,
+    pub reserved_cycles: candid::Nat,
+    pub idle_cycles_burned_per_day: candid::Nat,
+    pub query_stats: CanisterStatusResultQueryStats,
+}
+
+// ```
+// type canister_status_args = record {
+//     canister_id : canister_id;
+// };
+// ```
+#[derive(CandidType, Deserialize, Debug, Clone)]
+pub struct CanisterStatusArgs {
+    pub canister_id: Principal,
+}
+
+impl Request for CanisterStatusArgs {
+    fn method(&self) -> &'static str {
+        "canister_status"
+    }
+
+    fn update(&self) -> bool {
+        true
+    }
+
+    fn payload(&self) -> Result<Vec<u8>, candid::Error> {
+        candid::encode_one(self)
+    }
+
+    type Response = CanisterStatusResult;
+}
+
+// ```
+// type stop_canister_args = record {
+//     canister_id : canister_id;
+// };
+// ```
+#[derive(CandidType, Deserialize, Debug, Clone)]
+pub struct StopCanisterArgs {
+    pub canister_id: Principal,
+}
+
+impl Request for StopCanisterArgs {
+    fn method(&self) -> &'static str {
+        "stop_canister"
+    }
+
+    fn update(&self) -> bool {
+        true
+    }
+
+    fn payload(&self) -> Result<Vec<u8>, candid::Error> {
+        candid::encode_one(self)
+    }
+
+    type Response = ();
+}
+
+// ```
+// type delete_canister_args = record {
+//     canister_id : canister_id;
+// };
+// ```
+#[derive(CandidType, Deserialize, Debug, Clone)]
+pub struct DeleteCanisterArgs {
+    pub canister_id: Principal,
+}
+
+impl Request for DeleteCanisterArgs {
+    fn method(&self) -> &'static str {
+        "delete_canister"
+    }
+
+    fn update(&self) -> bool {
+        true
+    }
+
+    fn payload(&self) -> Result<Vec<u8>, candid::Error> {
+        candid::encode_one(self)
+    }
+
+    type Response = ();
+}

--- a/rs/nervous_system/agent/src/pocketic_impl.rs
+++ b/rs/nervous_system/agent/src/pocketic_impl.rs
@@ -1,5 +1,5 @@
 use crate::management_canister::requests::{
-    CanisterStatusArgs, DeleteCanisterArgs, StoredChunksArgs, UploadChunkArgs,
+    CanisterStatusArgs, DeleteCanisterArgs, StopCanisterArgs, StoredChunksArgs, UploadChunkArgs,
 };
 use crate::Request;
 use crate::{CallCanisters, CanisterInfo};
@@ -73,6 +73,11 @@ impl PocketIcAgent<'_> {
             }
             "canister_status" => {
                 candid::decode_one::<CanisterStatusArgs>(payload.as_slice())
+                    .map_err(PocketIcCallError::CandidDecode)?
+                    .canister_id
+            }
+            "stop_canister" => {
+                candid::decode_one::<StopCanisterArgs>(payload.as_slice())
                     .map_err(PocketIcCallError::CandidDecode)?
                     .canister_id
             }

--- a/rs/nervous_system/agent/src/pocketic_impl.rs
+++ b/rs/nervous_system/agent/src/pocketic_impl.rs
@@ -1,4 +1,6 @@
-use crate::management_canister::requests::{StoredChunksArgs, UploadChunkArgs};
+use crate::management_canister::requests::{
+    CanisterStatusArgs, DeleteCanisterArgs, StoredChunksArgs, UploadChunkArgs,
+};
 use crate::Request;
 use crate::{CallCanisters, CanisterInfo};
 use candid::Principal;
@@ -66,6 +68,16 @@ impl PocketIcAgent<'_> {
             }
             "stored_chunks" => {
                 candid::decode_one::<StoredChunksArgs>(payload.as_slice())
+                    .map_err(PocketIcCallError::CandidDecode)?
+                    .canister_id
+            }
+            "canister_status" => {
+                candid::decode_one::<CanisterStatusArgs>(payload.as_slice())
+                    .map_err(PocketIcCallError::CandidDecode)?
+                    .canister_id
+            }
+            "delete_canister" => {
+                candid::decode_one::<DeleteCanisterArgs>(payload.as_slice())
                     .map_err(PocketIcCallError::CandidDecode)?
                     .canister_id
             }

--- a/rs/nervous_system/agent/src/sns/governance.rs
+++ b/rs/nervous_system/agent/src/sns/governance.rs
@@ -2,8 +2,9 @@ use crate::{null_request::NullRequest, CallCanisters};
 use ic_base_types::PrincipalId;
 use ic_sns_governance_api::pb::v1::{
     manage_neuron, manage_neuron_response, GetMetadataRequest, GetMetadataResponse, GetMode,
-    GetModeResponse, GetRunningSnsVersionRequest, GetRunningSnsVersionResponse, GovernanceError,
-    ManageNeuron, ManageNeuronResponse, NervousSystemParameters, NeuronId, Proposal, ProposalId,
+    GetModeResponse, GetProposal, GetProposalResponse, GetRunningSnsVersionRequest,
+    GetRunningSnsVersionResponse, GovernanceError, ManageNeuron, ManageNeuronResponse,
+    NervousSystemParameters, NeuronId, Proposal, ProposalId,
 };
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -107,6 +108,17 @@ impl GovernanceCanister {
             .await?;
 
         Ok(response)
+    }
+
+    pub async fn get_proposal<C: CallCanisters>(
+        &self,
+        agent: &C,
+        proposal_id: ProposalId,
+    ) -> Result<GetProposalResponse, C::Error> {
+        let request = GetProposal {
+            proposal_id: Some(proposal_id),
+        };
+        agent.call(self.canister_id, request).await
     }
 }
 

--- a/rs/sns/cli/src/lib.rs
+++ b/rs/sns/cli/src/lib.rs
@@ -28,6 +28,7 @@ use std::{
     sync::Once,
 };
 use tempfile::NamedTempFile;
+use upgrade_sns_controlled_canister::RefundAfterSnsControlledCanisterUpgradeArgs;
 pub mod deploy;
 pub mod health;
 pub mod init_config_file;
@@ -127,6 +128,8 @@ pub enum SubCommand {
     /// Uploads a given Wasm to a (newly deployed) store canister and submits a proposal to upgrade
     /// using that Wasm.
     UpgradeSnsControlledCanister(UpgradeSnsControlledCanisterArgs),
+    /// Attempts to refund the unused cycles after an SNS-controlled canister has been upgraded.
+    RefundAfterSnsControlledCanisterUpgrade(RefundAfterSnsControlledCanisterUpgradeArgs),
 }
 
 impl CliArgs {

--- a/rs/sns/cli/src/main.rs
+++ b/rs/sns/cli/src/main.rs
@@ -37,5 +37,13 @@ async fn main() -> Result<()> {
                 }
             }
         }
+        SubCommand::RefundAfterSnsControlledCanisterUpgrade(args) => {
+            match upgrade_sns_controlled_canister::refund(args, &agent).await {
+                Ok(_) => Ok(()),
+                Err(err) => {
+                    bail!("{}", err);
+                }
+            }
+        }
     }
 }

--- a/rs/sns/cli/src/upgrade_sns_controlled_canister.rs
+++ b/rs/sns/cli/src/upgrade_sns_controlled_canister.rs
@@ -6,17 +6,21 @@ use candid_utils::{
     validation::{encode_upgrade_args, encode_upgrade_args_without_service},
 };
 use clap::Parser;
+use core::convert::From;
 use cycles_minting_canister::{CanisterSettingsArgs, CreateCanister, SubnetSelection};
 use ic_base_types::{CanisterId, PrincipalId};
 use ic_management_canister_types::{BoundedVec, CanisterInstallMode};
 use ic_nervous_system_agent::{
-    management_canister, nns,
-    sns::{self, governance::SubmittedProposal, root::SnsCanisters},
+    management_canister::{self, delete_canister, stop_canister},
+    nns,
+    sns::{self, governance::SubmittedProposal, root::SnsCanisters, Sns},
     CallCanisters, CanisterInfo, Request,
 };
 use ic_nns_constants::CYCLES_LEDGER_CANISTER_ID;
 use ic_sns_governance_api::pb::v1::{
-    proposal::Action, ChunkedCanisterWasm, Proposal, ProposalId, UpgradeSnsControlledCanister,
+    get_proposal_response,
+    proposal::{self, Action},
+    ChunkedCanisterWasm, Proposal, ProposalData, ProposalId, UpgradeSnsControlledCanister,
 };
 use ic_wasm::{metadata, utils::parse_wasm};
 use itertools::{Either, Itertools};
@@ -36,7 +40,7 @@ const GZIPPED_WASM_HEADER: [u8; 3] = [0x1f, 0x8b, 0x08];
 // The cycle fee for create request is 0.1T cycles.
 pub const CANISTER_CREATE_FEE: u128 = 100_000_000_000_u128;
 
-pub const STORE_CANISTER_INITIAL_CYCLES_BALANCE: u128 = 5_000_000_000_000_u128; // 5T
+pub const STORE_CANISTER_INITIAL_CYCLES_BALANCE: u128 = 1_000_000_000_000_u128; // 1T
 
 /// The arguments used to configure the upgrade_sns_controlled_canister command.
 #[derive(Debug, Parser)]
@@ -66,6 +70,18 @@ pub struct UpgradeSnsControlledCanisterArgs {
     /// Human-readable text explaining why this upgrade is being done (may be markdown).
     #[clap(long)]
     pub summary: String,
+}
+
+/// The arguments used to configure the refund_after_sns_controlled_canister_upgrade command.
+#[derive(Debug, Parser)]
+pub struct RefundAfterSnsControlledCanisterUpgradeArgs {
+    /// ID of the target canister that was to be upgraded using upgrade-sns-controlled-canister.
+    #[clap(long)]
+    pub target_canister_id: CanisterId,
+
+    /// ID of the proposal created by upgrade-sns-controlled-canister. Must be
+    #[clap(long)]
+    pub proposal_id: u64,
 }
 
 pub struct Wasm {
@@ -255,6 +271,74 @@ pub struct UpgradeSnsControlledCanisterInfo {
     pub proposal_id: Option<ProposalId>,
 }
 
+pub async fn find_sns<C: CallCanisters>(
+    agent: &C,
+    caller_principal: PrincipalId,
+    target_canister_id: CanisterId,
+    target_controllers: BTreeSet<PrincipalId>,
+) -> Result<Option<Sns>, UpgradeSnsControlledCanisterError<C::Error>> {
+    let (user_controllers, canister_controllers): (Vec<_>, Vec<_>) =
+        target_controllers.into_iter().partition_map(|controller| {
+            if controller.is_self_authenticating() {
+                Either::Left(controller)
+            } else {
+                Either::Right(controller)
+            }
+        });
+
+    if user_controllers.contains(&caller_principal) {
+        println!(
+            "\n\
+                ⚠️ the target is controlled by the caller, which means it is not decentralized.\n\
+                ⚠️ Proceed upgrading it directly."
+        );
+
+        Ok(None)
+    } else {
+        assert!(
+            !canister_controllers.is_empty(),
+            "The target canister is not controlled by an SNS."
+        );
+
+        assert_eq!(
+            canister_controllers.len(),
+            1,
+            "The target canister has more than one canister controller!"
+        );
+
+        let canister_id = *canister_controllers.first().unwrap();
+
+        // TODO: Check that this is indeed an SNS canister controlling the target.
+        //
+        // This is expected to be `None` if we're running against a local replica.
+        // let root_subnet = nns::registry::get_subnet_for_canister(agent, canister_id)
+        //     .await
+        //     .ok();
+        // let sns_subnets = sns_w.list_sns_subnets().await.unwrap();
+        // assert!(
+        //     sns_subnets.contains(&root_subnet),
+        //     "Target canister is not controlled by an SNS!",
+        // );
+
+        let root_canister = sns::root::RootCanister { canister_id };
+
+        let response = root_canister.list_sns_canisters(agent).await?;
+        let SnsCanisters { sns, dapps } =
+            SnsCanisters::try_from(response).map_err(UpgradeSnsControlledCanisterError::Client)?;
+
+        // Check that the target is indeed controlled by this SNS.
+        if !BTreeSet::from_iter(&dapps[..]).contains(&target_canister_id.get()) {
+            return Err(UpgradeSnsControlledCanisterError::Client(format!(
+                "{} is not one of the canisters controlled by the SNS with Root canister {}",
+                target_canister_id.get(),
+                root_canister.canister_id,
+            )));
+        }
+
+        Ok(Some(sns))
+    }
+}
+
 pub async fn exec<C: CallCanisters>(
     args: UpgradeSnsControlledCanisterArgs,
     agent: &C,
@@ -291,68 +375,13 @@ pub async fn exec<C: CallCanisters>(
 
     print!("Finding the SNS controlling this target canister ... ");
     std::io::stdout().flush().unwrap();
-    let sns = {
-        let (user_controllers, canister_controllers): (Vec<_>, Vec<_>) =
-            target_controllers.into_iter().partition_map(|controller| {
-                if controller.is_self_authenticating() {
-                    Either::Left(controller)
-                } else {
-                    Either::Right(controller)
-                }
-            });
-
-        if user_controllers.contains(&caller_principal) {
-            println!(
-                "\n\
-                 ⚠️ the target is controlled by the caller, which means it is not decentralized.\n\
-                 ⚠️ Proceed upgrading it directly."
-            );
-
-            None // no SNS
-        } else {
-            assert!(
-                !canister_controllers.is_empty(),
-                "The target canister is not controlled by an SNS."
-            );
-
-            assert_eq!(
-                canister_controllers.len(),
-                1,
-                "The target canister has more than one canister controller!"
-            );
-
-            let canister_id = *canister_controllers.first().unwrap();
-
-            // TODO: Check that this is indeed an SNS canister controlling the target.
-            //
-            // This is expected to be `None` if we're running against a local replica.
-            // let root_subnet = nns::registry::get_subnet_for_canister(agent, canister_id)
-            //     .await
-            //     .ok();
-            // let sns_subnets = sns_w.list_sns_subnets().await.unwrap();
-            // assert!(
-            //     sns_subnets.contains(&root_subnet),
-            //     "Target canister is not controlled by an SNS!",
-            // );
-
-            let root_canister = sns::root::RootCanister { canister_id };
-
-            let response = root_canister.list_sns_canisters(agent).await?;
-            let SnsCanisters { sns, dapps } = SnsCanisters::try_from(response)
-                .map_err(UpgradeSnsControlledCanisterError::Client)?;
-
-            // Check that the target is indeed controlled by this SNS.
-            if !BTreeSet::from_iter(&dapps[..]).contains(&target_canister_id.get()) {
-                return Err(UpgradeSnsControlledCanisterError::Client(format!(
-                    "{} is not one of the canisters controlled by the SNS with Root canister {}",
-                    target_canister_id.get(),
-                    root_canister.canister_id,
-                )));
-            }
-
-            Some(sns)
-        }
-    };
+    let sns = find_sns(
+        agent,
+        caller_principal,
+        target_canister_id,
+        target_controllers,
+    )
+    .await?;
     println!("✔️");
 
     print!("Checking that we have a viable Wasm for this upgrade ... ");
@@ -480,6 +509,138 @@ pub async fn exec<C: CallCanisters>(
         wasm_module_hash: wasm.module_hash().to_vec(),
         proposal_id,
     })
+}
+
+pub async fn refund<C: CallCanisters>(
+    args: RefundAfterSnsControlledCanisterUpgradeArgs,
+    agent: &C,
+) -> Result<(), UpgradeSnsControlledCanisterError<C::Error>> {
+    let RefundAfterSnsControlledCanisterUpgradeArgs {
+        target_canister_id,
+        proposal_id,
+    } = args;
+
+    let proposal_id = ProposalId { id: proposal_id };
+
+    let caller_principal = PrincipalId(agent.caller()?);
+
+    print!("Getting target canister info ... ");
+    std::io::stdout().flush().unwrap();
+    let CanisterInfo {
+        controllers: target_controllers,
+        module_hash: _,
+    } = agent
+        .canister_info(target_canister_id)
+        .await
+        .map_err(|err| {
+            UpgradeSnsControlledCanisterError::Client(format!(
+                "Cannot refund cycles, target canister {} does not seem to be installed: {}",
+                target_canister_id.get(),
+                err
+            ))
+        })?;
+    println!("✔️");
+
+    let target_controllers = target_controllers
+        .into_iter()
+        .map(PrincipalId)
+        .collect::<BTreeSet<_>>();
+
+    print!("Finding the SNS controlling this target canister ... ");
+    std::io::stdout().flush().unwrap();
+    let sns = find_sns(
+        agent,
+        caller_principal,
+        target_canister_id,
+        target_controllers,
+    )
+    .await?;
+    let sns = match sns {
+        Some(sns) => sns,
+        None => {
+            return Err(UpgradeSnsControlledCanisterError::Client(format!(
+                "Cannot find SNS controlling target canister {}",
+                target_canister_id.get()
+            )));
+        }
+    };
+    println!("✔️");
+
+    print!("Fetching the store canister ID ... ");
+    std::io::stdout().flush().unwrap();
+    let sns_governance = sns::governance::GovernanceCanister {
+        canister_id: sns.governance.canister_id,
+    };
+    let get_proposal_result = sns_governance
+        .get_proposal(agent, proposal_id)
+        .await
+        .map_err(UpgradeSnsControlledCanisterError::Agent)?
+        .result
+        .ok_or("Missing GetProposalResponse.result")
+        .map_err(|err| UpgradeSnsControlledCanisterError::Client(err.to_string()))?;
+
+    let proposal = match get_proposal_result {
+        get_proposal_response::Result::Error(err) => {
+            return Err(UpgradeSnsControlledCanisterError::Client(format!(
+                "{err:?}"
+            )));
+        }
+        get_proposal_response::Result::Proposal(ProposalData {
+            proposal,
+            executed_timestamp_seconds,
+            failed_timestamp_seconds,
+            ..
+        }) if executed_timestamp_seconds > 0 || failed_timestamp_seconds > 0 => proposal,
+        get_proposal_response::Result::Proposal(_) => {
+            return Err(UpgradeSnsControlledCanisterError::Client(format!(
+                "Proposal {} is still live; please repeat this command after it executes or fails.",
+                proposal_id.id,
+            )));
+        }
+    };
+
+    let store_canister_id = match proposal {
+        Some(Proposal {
+            action:
+                Some(proposal::Action::UpgradeSnsControlledCanister(UpgradeSnsControlledCanister {
+                    chunked_canister_wasm:
+                        Some(ChunkedCanisterWasm {
+                            store_canister_id: Some(store_canister_id),
+                            ..
+                        }),
+                    ..
+                })),
+            ..
+        }) => store_canister_id,
+        _ => {
+            return Err(UpgradeSnsControlledCanisterError::Client(format!(
+                "Proposal {} is invalid or does not correspond to an SNS-controlled canister upgrade
+                with chunked Wasm.",
+                proposal_id.id,
+            )));
+        }
+    };
+    println!("✔️");
+
+    // TODO: Implement the actual reimbursement.
+
+    print!("Deleting the store canister {} ... ", store_canister_id);
+    std::io::stdout().flush().unwrap();
+    stop_canister(
+        agent,
+        CanisterId::unchecked_from_principal(store_canister_id),
+    )
+    .await
+    .map_err(UpgradeSnsControlledCanisterError::Agent)?;
+    delete_canister(
+        agent,
+        CanisterId::unchecked_from_principal(store_canister_id),
+    )
+    .await
+    .map_err(UpgradeSnsControlledCanisterError::Agent)?;
+    println!("✔️");
+
+    Ok(())
 }
 
 pub type BlockIndex = Nat;

--- a/rs/sns/governance/api/src/ic_sns_governance.pb.v1.rs
+++ b/rs/sns/governance/api/src/ic_sns_governance.pb.v1.rs
@@ -303,7 +303,9 @@ pub struct UpgradeSnsControlledCanister {
     /// Arguments passed to the post-upgrade method of the new wasm module.
     #[serde(deserialize_with = "ic_utils::deserialize::deserialize_option_blob")]
     pub canister_upgrade_arg: Option<Vec<u8>>,
-    /// Canister install_code mode.
+    /// Canister install_code mode. If specified, the integer value corresponds to
+    /// `ic_protobuf::types::v1::v1CanisterInstallMode` or `canister_install_mode`
+    /// (as per https://internetcomputer.org/docs/current/references/ic-interface-spec#ic-candid).
     pub mode: Option<i32>,
     /// If the entire WASM does not fit into the 2 MiB ingress limit, then `new_canister_wasm` should be
     /// an empty, and this field should be set instead.


### PR DESCRIPTION
This PR prepares for adding a new subcommand to sns-cli, so users who proposed to upgrade an SNS-controlled canister can easily request the unused cycles to be refunded to the original Cycles Ledger account that they used for uploading and storing the chunked Wasm in a store canister.

The corresponding integration test was updated to exercise the happy scenario.

For now, the subcommand does not refund cycles, but simply deletes the store canister. Refunding will be implemented in a follow-up PR.