### PR TITLE
feat(nns): Bump neurons limit

### DIFF
--- a/rs/nns/governance/src/governance.rs
+++ b/rs/nns/governance/src/governance.rs
@@ -207,7 +207,7 @@ pub const MAX_NEURON_RECENT_BALLOTS: usize = 100;
 pub const REWARD_DISTRIBUTION_PERIOD_SECONDS: u64 = ONE_DAY_SECONDS;
 
 /// The maximum number of neurons supported.
-pub const MAX_NUMBER_OF_NEURONS: usize = 380_000;
+pub const MAX_NUMBER_OF_NEURONS: usize = 420_000;
 
 // Spawning is exempted from rate limiting, so we don't need large of a limit here.
 pub const MAX_SUSTAINED_NEURONS_PER_HOUR: u64 = 15;

--- a/rs/nns/governance/src/governance.rs
+++ b/rs/nns/governance/src/governance.rs
@@ -207,7 +207,7 @@ pub const MAX_NEURON_RECENT_BALLOTS: usize = 100;
 pub const REWARD_DISTRIBUTION_PERIOD_SECONDS: u64 = ONE_DAY_SECONDS;
 
 /// The maximum number of neurons supported.
-pub const MAX_NUMBER_OF_NEURONS: usize = 420_000;
+pub const MAX_NUMBER_OF_NEURONS: usize = 400_000;
 
 // Spawning is exempted from rate limiting, so we don't need large of a limit here.
 pub const MAX_SUSTAINED_NEURONS_PER_HOUR: u64 = 15;

--- a/rs/nns/governance/unreleased_changelog.md
+++ b/rs/nns/governance/unreleased_changelog.md
@@ -78,6 +78,8 @@ No neurons are actually migrated yet.
   was default to true before, and now it's default to true. More details can be found at:
   https://forum.dfinity.org/t/listneurons-api-change-empty-neurons/40311
 
+* The limit of the number of neurons is increased from 380K to 400K.
+
 ## Deprecated
 
 ## Removed


### PR DESCRIPTION
The number of neurons keeps growing. Some analysis showed that we would be able to increase the limit to 500K (note that the maximum number changes over time because it takes into account the number of neurons that are already created). However, given that we are actively working on moving all neurons to stable storage, we would like to increase the limit in a more conservative way. The 400K limit should give us ~10 weeks.