### PR TITLE
fix(nns/sns): Better implementation for `Root.stop_canister`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10465,7 +10465,7 @@ name = "ic-nervous-system-root"
 version = "0.9.0"
 dependencies = [
  "candid",
- "dfn_core",
+ "ic-base-types",
  "ic-cdk 0.16.0",
  "ic-crypto-sha2",
  "ic-management-canister-types",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10123,7 +10123,6 @@ version = "0.9.0"
 dependencies = [
  "async-trait",
  "candid",
- "dfn_core",
  "ic-base-types",
  "ic-ledger-core",
  "ic-nervous-system-common",
@@ -10243,6 +10242,7 @@ dependencies = [
  "async-trait",
  "dfn_core",
  "futures",
+ "ic-base-types",
  "ic-nervous-system-common",
  "ic-wasm",
  "icp-ledger",

--- a/rs/nervous_system/canisters/BUILD.bazel
+++ b/rs/nervous_system/canisters/BUILD.bazel
@@ -10,7 +10,6 @@ DEPENDENCIES = [
     "//rs/nervous_system/common",
     "//rs/nervous_system/runtime",
     "//rs/nns/constants",
-    "//rs/rust_canisters/dfn_core",
     "//rs/types/base_types",
     "@crate_index//:candid",
 ]

--- a/rs/nervous_system/canisters/Cargo.toml
+++ b/rs/nervous_system/canisters/Cargo.toml
@@ -13,7 +13,6 @@ path = "src/lib.rs"
 [dependencies]
 async-trait = { workspace = true }
 candid = { workspace = true }
-dfn_core = { path = "../../rust_canisters/dfn_core" }
 ic-base-types = { path = "../../types/base_types" }
 ic-ledger-core = { path = "../../ledger_suite/common/ledger_core" }
 ic-nervous-system-common = { path = "../common" }

--- a/rs/nervous_system/canisters/src/ledger.rs
+++ b/rs/nervous_system/canisters/src/ledger.rs
@@ -1,6 +1,5 @@
 use async_trait::async_trait;
 use candid::Nat;
-use dfn_core::CanisterId;
 use ic_ledger_core::block::BlockIndex;
 use ic_nervous_system_common::{
     ledger::{ICRC1Ledger, IcpLedger},

--- a/rs/nervous_system/canisters/src/ledger.rs
+++ b/rs/nervous_system/canisters/src/ledger.rs
@@ -1,5 +1,6 @@
 use async_trait::async_trait;
 use candid::Nat;
+use ic_base_types::CanisterId;
 use ic_ledger_core::block::BlockIndex;
 use ic_nervous_system_common::{
     ledger::{ICRC1Ledger, IcpLedger},

--- a/rs/nervous_system/common/test_utils/BUILD.bazel
+++ b/rs/nervous_system/common/test_utils/BUILD.bazel
@@ -19,7 +19,7 @@ DEPENDENCIES = [
     "//packages/icrc-ledger-types:icrc_ledger_types",
     "//rs/ledger_suite/icp:icp_ledger",
     "//rs/nervous_system/common",
-    "//rs/rust_canisters/dfn_core",
+    "//rs/types/base_types",
     "@crate_index//:futures",
     "@crate_index//:ic-wasm",
     "@crate_index//:libflate",

--- a/rs/nervous_system/common/test_utils/Cargo.toml
+++ b/rs/nervous_system/common/test_utils/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [dependencies]
 async-trait = { workspace = true }
+ic-base-types = { path = "../../../types/base_types" }
 dfn_core = { path = "../../../rust_canisters/dfn_core" }
 futures = { workspace = true }
 ic-nervous-system-common = { path = "../../common" }

--- a/rs/nervous_system/common/test_utils/src/lib.rs
+++ b/rs/nervous_system/common/test_utils/src/lib.rs
@@ -2,7 +2,7 @@
 pub use crate::prometheus::{get_counter, get_gauge, get_samples};
 
 use async_trait::async_trait;
-use dfn_core::CanisterId;
+use ic_base_types::CanisterId;
 use futures::{
     channel::{
         mpsc::{UnboundedReceiver, UnboundedSender},

--- a/rs/nervous_system/root/BUILD.bazel
+++ b/rs/nervous_system/root/BUILD.bazel
@@ -7,7 +7,7 @@ DEPENDENCIES = [
     "//rs/crypto/sha2",
     "//rs/nervous_system/clients",
     "//rs/nervous_system/runtime",
-    "//rs/rust_canisters/dfn_core",
+    "//rs/types/base_types",
     "//rs/types/management_canister_types",
     "@crate_index//:candid",
     "@crate_index//:ic-cdk",

--- a/rs/nervous_system/root/Cargo.toml
+++ b/rs/nervous_system/root/Cargo.toml
@@ -10,7 +10,7 @@ documentation.workspace = true
 
 [dependencies]
 candid = { workspace = true }
-dfn_core = { path = "../../rust_canisters/dfn_core" }
+ic-base-types = { path = "../../types/base_types" }
 ic-cdk = { workspace = true }
 ic-crypto-sha2 = { path = "../../crypto/sha2" }
 ic-management-canister-types = { path = "../../types/management_canister_types" }

--- a/rs/nervous_system/root/src/change_canister.rs
+++ b/rs/nervous_system/root/src/change_canister.rs
@@ -1,8 +1,8 @@
 use crate::LOG_PREFIX;
 use candid::{CandidType, Deserialize, Encode, Principal};
-use dfn_core::api::CanisterId;
+use ic_base_types::CanisterId;
 #[cfg(target_arch = "wasm32")]
-use dfn_core::println;
+use ic_cdk::println;
 use ic_crypto_sha2::Sha256;
 use ic_management_canister_types::{
     CanisterInstallMode, CanisterInstallModeV2, ChunkHash, InstallChunkedCodeArgs, InstallCodeArgs,


### PR DESCRIPTION
This PR improves the `Root.stop_canister` in the following ways: 
1. Retry requesting to stop upon unexpected re-starting (e.g., due to reentrancy).
2. Error out rather than panic if `IC00.canister_status` fails (e.g., due to this canister being deleted or non-existant).