### PR TITLE
feat: CON-1421 Call crypto in the VetKd client

### DIFF
--- a/rs/consensus/src/idkg/complaints.rs
+++ b/rs/consensus/src/idkg/complaints.rs
@@ -1070,7 +1070,7 @@ mod tests {
     // Tests validation of the received complaints
     #[test]
     fn test_validate_complaints_all_algorithms() {
-        for key_id in fake_master_public_key_ids_for_all_algorithms() {
+        for key_id in fake_master_public_key_ids_for_all_idkg_algorithms() {
             println!("Running test for key ID {key_id}");
             test_validate_complaints(key_id);
         }
@@ -1311,7 +1311,7 @@ mod tests {
     // Tests that openings are sent for eligible complaints
     #[test]
     fn test_send_openings_all_algorithms() {
-        for key_id in fake_master_public_key_ids_for_all_algorithms() {
+        for key_id in fake_master_public_key_ids_for_all_idkg_algorithms() {
             println!("Running test for key ID {key_id}");
             test_send_openings(key_id);
         }
@@ -1427,7 +1427,7 @@ mod tests {
     // Tests the validation of received openings
     #[test]
     fn test_validate_openings_all_algorithms() {
-        for key_id in fake_master_public_key_ids_for_all_algorithms() {
+        for key_id in fake_master_public_key_ids_for_all_idkg_algorithms() {
             println!("Running test for key ID {key_id}");
             test_validate_openings(key_id);
         }
@@ -1899,7 +1899,7 @@ mod tests {
     // Tests that crypto failure when creating complaint leads to transcript load failure
     #[test]
     fn test_load_transcript_failure_to_create_complaint_all_algorithms() {
-        for key_id in fake_master_public_key_ids_for_all_algorithms() {
+        for key_id in fake_master_public_key_ids_for_all_idkg_algorithms() {
             println!("Running test for key ID {key_id}");
             test_load_transcript_failure_to_create_complaint(key_id);
         }

--- a/rs/consensus/src/idkg/payload_builder.rs
+++ b/rs/consensus/src/idkg/payload_builder.rs
@@ -835,7 +835,7 @@ mod tests {
 
     #[test]
     fn test_pre_signature_recreation_all_algorithms() {
-        for key_id in fake_master_public_key_ids_for_all_algorithms() {
+        for key_id in fake_master_public_key_ids_for_all_idkg_algorithms() {
             println!("Running test for key ID {key_id}");
             test_pre_signature_recreation(key_id);
         }
@@ -931,7 +931,7 @@ mod tests {
 
     #[test]
     fn test_signing_request_timeout_all_algorithms() {
-        for key_id in fake_master_public_key_ids_for_all_algorithms() {
+        for key_id in fake_master_public_key_ids_for_all_idkg_algorithms() {
             println!("Running test for key ID {key_id}");
             test_signing_request_timeout(key_id);
         }
@@ -1000,7 +1000,7 @@ mod tests {
 
     #[test]
     fn test_request_with_invalid_key_all_algorithms() {
-        for key_id in fake_master_public_key_ids_for_all_algorithms() {
+        for key_id in fake_master_public_key_ids_for_all_idkg_algorithms() {
             println!("Running test for key ID {key_id}");
             test_request_with_invalid_key(key_id);
         }
@@ -1070,7 +1070,7 @@ mod tests {
 
     #[test]
     fn test_signature_is_only_delivered_once_all_algorithms() {
-        for key_id in fake_master_public_key_ids_for_all_algorithms() {
+        for key_id in fake_master_public_key_ids_for_all_idkg_algorithms() {
             println!("Running test for key ID {key_id}");
             test_signature_is_only_delivered_once(key_id);
         }
@@ -1081,7 +1081,7 @@ mod tests {
         let pre_sig_id = create_available_pre_signature(&mut idkg_payload, key_id.clone(), 13);
         let request_id = request_id(0, Height::from(0));
         let context =
-            fake_signature_request_context_from_id(key_id.clone(), pre_sig_id, request_id);
+            fake_signature_request_context_from_id(key_id.clone().into(), pre_sig_id, request_id);
         let signature_request_contexts = BTreeMap::from([context.clone()]);
         let signature_request_contexts = into_idkg_contexts(&signature_request_contexts);
 
@@ -1159,7 +1159,7 @@ mod tests {
 
     #[test]
     fn test_update_summary_refs_all_algorithms() {
-        for key_id in fake_master_public_key_ids_for_all_algorithms() {
+        for key_id in fake_master_public_key_ids_for_all_idkg_algorithms() {
             println!("Running test for key ID {key_id}");
             test_update_summary_refs(key_id);
         }
@@ -1196,8 +1196,8 @@ mod tests {
             let mut reshare_refs = BTreeMap::new();
             reshare_refs.insert(*reshare_key_transcript_ref.as_ref(), reshare_key_transcript);
 
-            let inputs_1 = create_sig_inputs_with_height(91, summary_height, key_id.clone());
-            let inputs_2 = create_sig_inputs_with_height(92, summary_height, key_id.clone());
+            let inputs_1 = create_sig_inputs_with_height(91, summary_height, key_id.clone().into());
+            let inputs_2 = create_sig_inputs_with_height(92, summary_height, key_id.clone().into());
             let summary_block = create_summary_block_with_transcripts(
                 key_id.clone(),
                 subnet_id,
@@ -1210,12 +1210,14 @@ mod tests {
                 ],
             );
             add_block(summary_block, summary_height.get(), &mut pool);
-            let presig_1 = inputs_2.sig_inputs_ref.pre_signature();
+            let presig_1 = inputs_2.sig_inputs_ref.pre_signature().unwrap();
 
             // Create payload blocks with transcripts
             let payload_height_1 = Height::new(10);
-            let inputs_1 = create_sig_inputs_with_height(93, payload_height_1, key_id.clone());
-            let inputs_2 = create_sig_inputs_with_height(94, payload_height_1, key_id.clone());
+            let inputs_1 =
+                create_sig_inputs_with_height(93, payload_height_1, key_id.clone().into());
+            let inputs_2 =
+                create_sig_inputs_with_height(94, payload_height_1, key_id.clone().into());
             let (reshare_key_transcript, reshare_key_transcript_ref, _) =
                 generate_key_transcript(&key_id, &env, &mut rng, payload_height_1);
             let mut reshare_refs = BTreeMap::new();
@@ -1235,7 +1237,7 @@ mod tests {
                 payload_height_1.get() - summary_height.get(),
                 &mut pool,
             );
-            let presig_2 = inputs_2.sig_inputs_ref.pre_signature();
+            let presig_2 = inputs_2.sig_inputs_ref.pre_signature().unwrap();
 
             // Create a payload block with references to these past blocks
             let mut idkg_payload = empty_idkg_payload_with_key_ids(subnet_id, vec![key_id.clone()]);
@@ -1419,7 +1421,7 @@ mod tests {
 
     #[test]
     fn test_summary_proto_conversion_all_algorithms() {
-        for key_id in fake_master_public_key_ids_for_all_algorithms() {
+        for key_id in fake_master_public_key_ids_for_all_idkg_algorithms() {
             println!("Running test for key ID {key_id}");
             test_summary_proto_conversion(key_id);
         }
@@ -1449,8 +1451,8 @@ mod tests {
             let mut reshare_refs = BTreeMap::new();
             reshare_refs.insert(*reshare_key_transcript_ref.as_ref(), reshare_key_transcript);
 
-            let inputs_1 = create_sig_inputs_with_height(91, summary_height, key_id.clone());
-            let inputs_2 = create_sig_inputs_with_height(92, summary_height, key_id.clone());
+            let inputs_1 = create_sig_inputs_with_height(91, summary_height, key_id.clone().into());
+            let inputs_2 = create_sig_inputs_with_height(92, summary_height, key_id.clone().into());
             let summary_block = create_summary_block_with_transcripts(
                 key_id.clone(),
                 subnet_id,
@@ -1465,12 +1467,14 @@ mod tests {
             let b = add_block(summary_block, summary_height.get(), &mut pool);
             assert_proposal_conversion(b);
 
-            let presig_1 = inputs_2.sig_inputs_ref.pre_signature();
+            let presig_1 = inputs_2.sig_inputs_ref.pre_signature().unwrap();
 
             // Create payload blocks with transcripts
             let payload_height_1 = Height::new(10);
-            let inputs_1 = create_sig_inputs_with_height(93, payload_height_1, key_id.clone());
-            let inputs_2 = create_sig_inputs_with_height(94, payload_height_1, key_id.clone());
+            let inputs_1 =
+                create_sig_inputs_with_height(93, payload_height_1, key_id.clone().into());
+            let inputs_2 =
+                create_sig_inputs_with_height(94, payload_height_1, key_id.clone().into());
             let (reshare_key_transcript, reshare_key_transcript_ref, _) =
                 generate_key_transcript(&key_id, &env, &mut rng, payload_height_1);
             let mut reshare_refs = BTreeMap::new();
@@ -1493,7 +1497,7 @@ mod tests {
             );
             assert_proposal_conversion(b);
 
-            let presig_2 = inputs_2.sig_inputs_ref.pre_signature();
+            let presig_2 = inputs_2.sig_inputs_ref.pre_signature().unwrap();
 
             // Create a payload block with references to these past blocks
             let mut idkg_payload = empty_idkg_payload_with_key_ids(subnet_id, vec![key_id.clone()]);
@@ -1710,7 +1714,7 @@ mod tests {
 
     #[test]
     fn test_no_creation_after_successful_creation_all_algorithms() {
-        for key_id in fake_master_public_key_ids_for_all_algorithms() {
+        for key_id in fake_master_public_key_ids_for_all_idkg_algorithms() {
             println!("Running test for key ID {key_id}");
             test_no_creation_after_successful_creation(key_id);
         }
@@ -1850,7 +1854,7 @@ mod tests {
 
     #[test]
     fn test_incomplete_reshare_doesnt_purge_pre_signatures_all_algorithms() {
-        for key_id in fake_master_public_key_ids_for_all_algorithms() {
+        for key_id in fake_master_public_key_ids_for_all_idkg_algorithms() {
             println!("Running test for key ID {key_id}");
             test_incomplete_reshare_doesnt_purge_pre_signatures(key_id);
         }
@@ -1952,7 +1956,7 @@ mod tests {
             };
             payload_0.available_pre_signatures.insert(
                 payload_0.uid_generator.next_pre_signature_id(),
-                test_inputs.sig_inputs_ref.pre_signature(),
+                test_inputs.sig_inputs_ref.pre_signature().unwrap(),
             );
             for (transcript_ref, transcript) in test_inputs.idkg_transcripts {
                 block_reader.add_transcript(transcript_ref, transcript);
@@ -2199,7 +2203,7 @@ mod tests {
 
     #[test]
     fn test_if_next_in_creation_continues_all_algorithms() {
-        for key_id in fake_master_public_key_ids_for_all_algorithms() {
+        for key_id in fake_master_public_key_ids_for_all_idkg_algorithms() {
             println!("Running test for key ID {key_id}");
             test_if_next_in_creation_continues(key_id);
         }
@@ -2349,7 +2353,7 @@ mod tests {
 
     #[test]
     fn test_next_in_creation_with_initial_dealings_all_algorithms() {
-        for key_id in fake_master_public_key_ids_for_all_algorithms() {
+        for key_id in fake_master_public_key_ids_for_all_idkg_algorithms() {
             println!("Running test for key ID {key_id}");
             test_next_in_creation_with_initial_dealings(key_id);
         }

--- a/rs/consensus/src/idkg/payload_builder/key_transcript.rs
+++ b/rs/consensus/src/idkg/payload_builder/key_transcript.rs
@@ -231,7 +231,7 @@ mod tests {
     use crate::idkg::{
         test_utils::{
             create_reshare_unmasked_transcript_param,
-            fake_master_public_key_ids_for_all_algorithms, set_up_idkg_payload,
+            fake_master_public_key_ids_for_all_idkg_algorithms, set_up_idkg_payload,
             IDkgPayloadTestHelper, TestIDkgBlockReader, TestIDkgTranscriptBuilder,
         },
         utils::algorithm_for_key_id,
@@ -296,7 +296,7 @@ mod tests {
 
     #[test]
     fn test_update_next_key_transcript_single_all_algorithms() {
-        for key_id in fake_master_public_key_ids_for_all_algorithms() {
+        for key_id in fake_master_public_key_ids_for_all_idkg_algorithms() {
             println!("Running test for key ID {key_id}");
             test_update_next_key_transcript_single(key_id);
         }
@@ -484,7 +484,7 @@ mod tests {
 
     #[test]
     fn test_update_next_key_transcript_xnet_target_subnet_all_algorithms() {
-        for key_id in fake_master_public_key_ids_for_all_algorithms() {
+        for key_id in fake_master_public_key_ids_for_all_idkg_algorithms() {
             println!("Running test for key ID {key_id}");
             test_update_next_key_transcript_xnet_target_subnet_single(key_id);
         }

--- a/rs/consensus/src/idkg/payload_builder/pre_signatures.rs
+++ b/rs/consensus/src/idkg/payload_builder/pre_signatures.rs
@@ -539,7 +539,7 @@ pub(super) mod tests {
 
     use crate::idkg::test_utils::{
         create_available_pre_signature, create_available_pre_signature_with_key_transcript,
-        fake_ecdsa_idkg_master_public_key_id, fake_master_public_key_ids_for_all_algorithms,
+        fake_ecdsa_idkg_master_public_key_id, fake_master_public_key_ids_for_all_idkg_algorithms,
         fake_schnorr_idkg_master_public_key_id, fake_schnorr_key_id,
         fake_signature_request_context_with_pre_sig, into_idkg_contexts, request_id,
         set_up_idkg_payload, IDkgPayloadTestHelper, TestIDkgBlockReader, TestIDkgTranscriptBuilder,
@@ -647,7 +647,7 @@ pub(super) mod tests {
 
     #[test]
     fn test_make_new_pre_signatures_if_needed_all_algorithms() {
-        for key_id in fake_master_public_key_ids_for_all_algorithms() {
+        for key_id in fake_master_public_key_ids_for_all_idkg_algorithms() {
             println!("Running test for key ID {key_id}");
             test_make_new_pre_signatures_if_needed(key_id);
         }
@@ -1059,7 +1059,7 @@ pub(super) mod tests {
 
     #[test]
     fn test_matched_pre_signatures_are_not_purged_all_algorithms() {
-        for key_id in fake_master_public_key_ids_for_all_algorithms() {
+        for key_id in fake_master_public_key_ids_for_all_idkg_algorithms() {
             println!("Running test for key ID {key_id}");
             test_matched_pre_signatures_are_not_purged(key_id);
         }
@@ -1129,7 +1129,7 @@ pub(super) mod tests {
 
     #[test]
     fn test_unmatched_pre_signatures_of_current_key_are_not_purged_all_algorithms() {
-        for key_id in fake_master_public_key_ids_for_all_algorithms() {
+        for key_id in fake_master_public_key_ids_for_all_idkg_algorithms() {
             println!("Running test for key ID {key_id}");
             test_unmatched_pre_signatures_of_current_key_are_not_purged(key_id);
         }
@@ -1167,7 +1167,7 @@ pub(super) mod tests {
 
     #[test]
     fn test_unmatched_pre_signatures_of_different_key_are_purged_all_algorithms() {
-        for key_id in fake_master_public_key_ids_for_all_algorithms() {
+        for key_id in fake_master_public_key_ids_for_all_idkg_algorithms() {
             println!("Running test for key ID {key_id}");
             test_unmatched_pre_signatures_of_different_key_are_purged(key_id);
         }

--- a/rs/consensus/src/idkg/payload_builder/resharing.rs
+++ b/rs/consensus/src/idkg/payload_builder/resharing.rs
@@ -193,8 +193,9 @@ mod tests {
     use crate::idkg::{
         test_utils::{
             create_reshare_request, dealings_context_from_reshare_request,
-            fake_ecdsa_idkg_master_public_key_id, fake_master_public_key_ids_for_all_algorithms,
-            set_up_idkg_payload, TestIDkgBlockReader, TestIDkgTranscriptBuilder,
+            fake_ecdsa_idkg_master_public_key_id,
+            fake_master_public_key_ids_for_all_idkg_algorithms, set_up_idkg_payload,
+            TestIDkgBlockReader, TestIDkgTranscriptBuilder,
         },
         utils::algorithm_for_key_id,
     };
@@ -234,7 +235,7 @@ mod tests {
     fn test_make_reshare_dealings_response() {
         let mut contexts = BTreeMap::new();
         let mut initial_dealings = BTreeMap::new();
-        for (i, key_id) in fake_master_public_key_ids_for_all_algorithms()
+        for (i, key_id) in fake_master_public_key_ids_for_all_idkg_algorithms()
             .iter()
             .enumerate()
         {
@@ -251,7 +252,7 @@ mod tests {
             );
         }
 
-        for (i, key_id) in fake_master_public_key_ids_for_all_algorithms()
+        for (i, key_id) in fake_master_public_key_ids_for_all_idkg_algorithms()
             .iter()
             .enumerate()
         {
@@ -289,7 +290,7 @@ mod tests {
 
     #[test]
     fn test_initiate_reshare_requests_should_not_accept_when_key_transcript_not_created() {
-        for key_id in fake_master_public_key_ids_for_all_algorithms() {
+        for key_id in fake_master_public_key_ids_for_all_idkg_algorithms() {
             println!("Running test for key ID {key_id}");
             let (mut payload, _block_reader) = set_up(
                 vec![key_id.clone()],
@@ -306,7 +307,7 @@ mod tests {
 
     #[test]
     fn test_initiate_reshare_requests_good_path() {
-        for key_id in fake_master_public_key_ids_for_all_algorithms() {
+        for key_id in fake_master_public_key_ids_for_all_idkg_algorithms() {
             println!("Running test for key ID {key_id}");
             let (mut payload, _block_reader) = set_up(
                 vec![key_id.clone()],
@@ -328,7 +329,7 @@ mod tests {
 
     #[test]
     fn test_initiate_reshare_requests_incremental() {
-        for key_id in fake_master_public_key_ids_for_all_algorithms() {
+        for key_id in fake_master_public_key_ids_for_all_idkg_algorithms() {
             println!("Running test for key ID {key_id}");
             let (mut payload, _block_reader) = set_up(
                 vec![key_id.clone()],
@@ -359,7 +360,7 @@ mod tests {
 
     #[test]
     fn test_initiate_reshare_requests_should_not_accept_already_completed() {
-        for key_id in fake_master_public_key_ids_for_all_algorithms() {
+        for key_id in fake_master_public_key_ids_for_all_idkg_algorithms() {
             println!("Running test for key ID {key_id}");
             let (mut payload, _block_reader) = set_up(
                 vec![key_id.clone()],
@@ -380,7 +381,7 @@ mod tests {
 
     #[test]
     fn test_ecdsa_update_completed_reshare_requests_all_algorithms() {
-        for key_id in fake_master_public_key_ids_for_all_algorithms() {
+        for key_id in fake_master_public_key_ids_for_all_idkg_algorithms() {
             println!("Running test for key ID {key_id}");
             test_ecdsa_update_completed_reshare_requests(key_id);
         }

--- a/rs/consensus/src/idkg/payload_builder/signatures.rs
+++ b/rs/consensus/src/idkg/payload_builder/signatures.rs
@@ -163,7 +163,7 @@ pub(crate) fn update_signature_agreements(
 mod tests {
     use crate::idkg::test_utils::{
         create_available_pre_signature, empty_idkg_payload_with_key_ids, empty_response,
-        fake_ecdsa_idkg_master_public_key_id, fake_master_public_key_ids_for_all_algorithms,
+        fake_ecdsa_idkg_master_public_key_id, fake_master_public_key_ids_for_all_idkg_algorithms,
         fake_signature_request_context, fake_signature_request_context_from_id,
         fake_signature_request_context_with_pre_sig, fake_vetkd_master_public_key_id,
         into_idkg_contexts, request_id, set_up_idkg_payload, TestThresholdSignatureBuilder,
@@ -258,7 +258,7 @@ mod tests {
 
     #[test]
     fn test_update_signature_agreements_success_all_algorithms() {
-        for key_id in fake_master_public_key_ids_for_all_algorithms() {
+        for key_id in fake_master_public_key_ids_for_all_idkg_algorithms() {
             println!("Running test for key ID {key_id}");
             test_update_signature_agreements_success(key_id);
         }
@@ -278,11 +278,11 @@ mod tests {
 
         let contexts = BTreeMap::from([
             // insert request without completed signature
-            fake_signature_request_context_from_id(key_id.clone(), pre_sig_ids[0], ids[0]),
+            fake_signature_request_context_from_id(key_id.clone().into(), pre_sig_ids[0], ids[0]),
             // insert request to be completed
-            fake_signature_request_context_from_id(key_id.clone(), pre_sig_ids[1], ids[1]),
+            fake_signature_request_context_from_id(key_id.clone().into(), pre_sig_ids[1], ids[1]),
             // insert request that was already completed
-            fake_signature_request_context_from_id(key_id.clone(), pre_sig_ids[2], ids[2]),
+            fake_signature_request_context_from_id(key_id.clone().into(), pre_sig_ids[2], ids[2]),
             // insert request without a matched pre-signature
             fake_signature_request_context_with_pre_sig(ids[3], key_id.clone(), None),
             // insert request matched to a non-existent pre-signature
@@ -383,7 +383,11 @@ mod tests {
 
         let contexts = BTreeMap::from([
             // insert ecdsa request to be completed
-            fake_signature_request_context_from_id(ecdsa_key_id.clone(), pre_sig_ids[0], ids[0]),
+            fake_signature_request_context_from_id(
+                ecdsa_key_id.clone().into(),
+                pre_sig_ids[0],
+                ids[0],
+            ),
             // insert vet kd request to be ignored
             (
                 ids[1].callback_id,

--- a/rs/consensus/src/idkg/payload_verifier.rs
+++ b/rs/consensus/src/idkg/payload_verifier.rs
@@ -648,7 +648,7 @@ mod test {
 
     #[test]
     fn test_validate_transcript_refs_all_algorithms() {
-        for key_id in fake_master_public_key_ids_for_all_algorithms() {
+        for key_id in fake_master_public_key_ids_for_all_idkg_algorithms() {
             println!("Running test for key ID {key_id}");
             test_validate_transcript_refs(key_id);
         }
@@ -763,7 +763,7 @@ mod test {
 
     #[test]
     fn test_validate_reshare_dealings_all_algorithms() {
-        for key_id in fake_master_public_key_ids_for_all_algorithms() {
+        for key_id in fake_master_public_key_ids_for_all_idkg_algorithms() {
             println!("Running test for key ID {key_id}");
             test_validate_reshare_dealings(key_id);
         }
@@ -868,7 +868,7 @@ mod test {
 
     #[test]
     fn test_validate_new_signature_agreements_all_algorithms() {
-        for key_id in fake_master_public_key_ids_for_all_algorithms() {
+        for key_id in fake_master_public_key_ids_for_all_idkg_algorithms() {
             println!("Running test for key ID {key_id}");
             test_validate_new_signature_agreements(key_id);
         }
@@ -899,8 +899,8 @@ mod test {
         // There are three requests in state, two are completed, one is still
         // missing its nonce.
         let signature_request_contexts = BTreeMap::from_iter([
-            fake_signature_request_context_from_id(key_id.clone(), pre_sig_id1, ids[0]),
-            fake_signature_request_context_from_id(key_id.clone(), pre_sig_id2, ids[1]),
+            fake_signature_request_context_from_id(key_id.clone().into(), pre_sig_id1, ids[0]),
+            fake_signature_request_context_from_id(key_id.clone().into(), pre_sig_id2, ids[1]),
             fake_signature_request_context_with_pre_sig(ids[2], key_id.clone(), Some(pre_sig_id3)),
         ]);
         let snapshot =
@@ -1034,7 +1034,7 @@ mod test {
 
     #[test]
     fn test_validate_new_signature_agreements_missing_input_all_algorithms() {
-        for key_id in fake_master_public_key_ids_for_all_algorithms() {
+        for key_id in fake_master_public_key_ids_for_all_idkg_algorithms() {
             println!("Running test for key ID {key_id}");
             test_validate_new_signature_agreements_missing_input(key_id);
         }
@@ -1055,7 +1055,7 @@ mod test {
 
         let signature_request_contexts = BTreeMap::from_iter([
             fake_signature_request_context_with_pre_sig(id1, key_id.clone(), Some(pre_sig_id)),
-            fake_signature_request_context_from_id(key_id.clone(), pre_sig_id2, id2),
+            fake_signature_request_context_from_id(key_id.clone().into(), pre_sig_id2, id2),
         ]);
         let snapshot =
             fake_state_with_signature_requests(height, signature_request_contexts.clone());

--- a/rs/consensus/src/idkg/pre_signer.rs
+++ b/rs/consensus/src/idkg/pre_signer.rs
@@ -1427,7 +1427,7 @@ mod tests {
     // in progress are filtered out.
     #[test]
     fn test_send_dealings_all_algorithms() {
-        for key_id in fake_master_public_key_ids_for_all_algorithms() {
+        for key_id in fake_master_public_key_ids_for_all_idkg_algorithms() {
             println!("Running test for key ID {key_id}");
             test_send_dealings(key_id);
         }
@@ -1529,7 +1529,7 @@ mod tests {
     // specified by the transcript params
     #[test]
     fn test_non_dealers_dont_send_dealings_all_algorithms() {
-        for key_id in fake_master_public_key_ids_for_all_algorithms() {
+        for key_id in fake_master_public_key_ids_for_all_idkg_algorithms() {
             println!("Running test for key ID {key_id}");
             test_non_dealers_dont_send_dealings(key_id);
         }
@@ -1589,7 +1589,7 @@ mod tests {
     // results in complaints.
     #[test]
     fn test_send_dealings_with_complaints_all_algorithms() {
-        for key_id in fake_master_public_key_ids_for_all_algorithms() {
+        for key_id in fake_master_public_key_ids_for_all_idkg_algorithms() {
             println!("Running test for key ID {key_id}");
             test_send_dealings_with_complaints(key_id);
         }
@@ -1667,7 +1667,7 @@ mod tests {
     // requests, and others dealings are either deferred or dropped.
     #[test]
     fn test_validate_dealings_all_algorithms() {
-        for key_id in fake_master_public_key_ids_for_all_algorithms() {
+        for key_id in fake_master_public_key_ids_for_all_idkg_algorithms() {
             println!("Running test for key ID {key_id}");
             test_validate_dealings(key_id);
         }
@@ -1836,7 +1836,7 @@ mod tests {
     // are dropped.
     #[test]
     fn test_duplicate_dealing_all_algorithms() {
-        for key_id in fake_master_public_key_ids_for_all_algorithms() {
+        for key_id in fake_master_public_key_ids_for_all_idkg_algorithms() {
             println!("Running test for key ID {key_id}");
             test_duplicate_dealing(key_id);
         }
@@ -1881,7 +1881,7 @@ mod tests {
     // in the unvalidated pool are dropped.
     #[test]
     fn test_duplicate_dealing_in_batch_all_algorithms() {
-        for key_id in fake_master_public_key_ids_for_all_algorithms() {
+        for key_id in fake_master_public_key_ids_for_all_idkg_algorithms() {
             println!("Running test for key ID {key_id}");
             test_duplicate_dealing_in_batch(key_id);
         }
@@ -1948,7 +1948,7 @@ mod tests {
     // transcript are dropped.
     #[test]
     fn test_unexpected_dealing_all_algorithms() {
-        for key_id in fake_master_public_key_ids_for_all_algorithms() {
+        for key_id in fake_master_public_key_ids_for_all_idkg_algorithms() {
             println!("Running test for key ID {key_id}");
             test_unexpected_dealing(key_id);
         }
@@ -1985,7 +1985,7 @@ mod tests {
     // Tests that support shares are sent to eligible dealings
     #[test]
     fn test_send_support_all_algorithms() {
-        for key_id in fake_master_public_key_ids_for_all_algorithms() {
+        for key_id in fake_master_public_key_ids_for_all_idkg_algorithms() {
             println!("Running test for key ID {key_id}");
             test_send_support(key_id);
         }
@@ -2028,7 +2028,7 @@ mod tests {
     // Tests that sending support shares is deferred if crypto returns transient error.
     #[test]
     fn test_defer_sending_dealing_support_all_algorithms() {
-        for key_id in fake_master_public_key_ids_for_all_algorithms() {
+        for key_id in fake_master_public_key_ids_for_all_idkg_algorithms() {
             println!("Running test for key ID {key_id}");
             test_defer_sending_dealing_support(key_id);
         }
@@ -2076,7 +2076,7 @@ mod tests {
     // Tests that invalid dealings are handled invalid when creating new dealing support.
     #[test]
     fn test_dont_send_support_for_invalid_all_algorithms() {
-        for key_id in fake_master_public_key_ids_for_all_algorithms() {
+        for key_id in fake_master_public_key_ids_for_all_idkg_algorithms() {
             println!("Running test for key ID {key_id}");
             test_dont_send_support_for_invalid(key_id);
         }
@@ -2117,7 +2117,7 @@ mod tests {
     // the transcript
     #[test]
     fn test_non_receivers_dont_send_support_all_algorithms() {
-        for key_id in fake_master_public_key_ids_for_all_algorithms() {
+        for key_id in fake_master_public_key_ids_for_all_idkg_algorithms() {
             println!("Running test for key ID {key_id}");
             test_non_receivers_dont_send_support(key_id);
         }
@@ -2210,7 +2210,7 @@ mod tests {
     // transcript requests, and others dealings are either deferred or dropped.
     #[test]
     fn test_validate_dealing_support_all_algorithms() {
-        for key_id in fake_master_public_key_ids_for_all_algorithms() {
+        for key_id in fake_master_public_key_ids_for_all_idkg_algorithms() {
             println!("Running test for key ID {key_id}");
             test_validate_dealing_support(key_id);
         }
@@ -2740,7 +2740,7 @@ mod tests {
     // Tests transcript builder failures and success
     #[test]
     fn test_transcript_builder_all_algorithms() {
-        for key_id in fake_master_public_key_ids_for_all_algorithms() {
+        for key_id in fake_master_public_key_ids_for_all_idkg_algorithms() {
             println!("Running test for key ID {key_id}");
             test_transcript_builder(key_id);
         }

--- a/rs/consensus/src/idkg/signer.rs
+++ b/rs/consensus/src/idkg/signer.rs
@@ -721,8 +721,8 @@ impl<'a> ThresholdSignatureBuilderImpl<'a> {
                         |share| Ok(CombinedSignature::Schnorr(share)),
                     )
             }
-            // We don't expect to combine VetKd shares here
-            // (this is done by the vetKD payload builder instead).
+            // We don't expect to combine VetKD shares here
+            // (this is done by the VetKD payload builder instead).
             ThresholdSigInputs::VetKd(_) => Err(CombineSigSharesError::VetKdUnexpected),
         };
         stats.record_sig_share_aggregation(request_id, start.elapsed());

--- a/rs/consensus/src/idkg/signer.rs
+++ b/rs/consensus/src/idkg/signer.rs
@@ -201,8 +201,6 @@ impl ThresholdSignerImpl {
             })
             .collect::<BTreeMap<_, _>>();
 
-        println!("{sig_inputs_map:?}");
-
         // Collection of validated shares
         let mut validated_sig_shares = BTreeSet::new();
 
@@ -822,7 +820,6 @@ impl<'a> Action<'a> {
                     // A signature for the received ID was requested and the context was completed.
                     // However, the received share claims a pre-signature was matched at a different
                     // height, therefore drop the message.
-                    println!("AAAAAAAAA");
                     Action::Drop
                 }
             }
@@ -831,7 +828,6 @@ impl<'a> Action<'a> {
             Some(None) => Action::Defer,
             None => {
                 // Its for a signature that has not been requested, drop it
-                println!("BBBBBBBBBBB");
                 Action::Drop
             }
         }
@@ -1774,7 +1770,6 @@ mod tests {
                 let change_set =
                     signer.validate_signature_shares(&idkg_pool, &block_reader, &state);
                 assert_eq!(change_set.len(), 1);
-                println!("{change_set:?}");
                 assert!(is_handle_invalid(&change_set, &msg_id_2));
             })
         })
@@ -1842,7 +1837,6 @@ mod tests {
 
                 let change_set =
                     signer.validate_signature_shares(&idkg_pool, &block_reader, &state);
-                println!("{change_set:?}");
                 assert_eq!(change_set.len(), 3);
                 let msg_1_valid = is_moved_to_validated(&change_set, &msg_id_1)
                     && is_handle_invalid(&change_set, &msg_id_2);

--- a/rs/consensus/src/idkg/signer.rs
+++ b/rs/consensus/src/idkg/signer.rs
@@ -721,6 +721,8 @@ impl<'a> ThresholdSignatureBuilderImpl<'a> {
                         |share| Ok(CombinedSignature::Schnorr(share)),
                     )
             }
+            // We don't expect to combine VetKd shares here
+            // (this is done by the vetKD payload builder instead).
             ThresholdSigInputs::VetKd(_) => Err(CombineSigSharesError::VetKdUnexpected),
         };
         stats.record_sig_share_aggregation(request_id, start.elapsed());

--- a/rs/consensus/src/idkg/signer.rs
+++ b/rs/consensus/src/idkg/signer.rs
@@ -1227,11 +1227,7 @@ mod tests {
                 let state = fake_state_with_signature_requests(
                     height,
                     (0..3).map(|i| {
-                        fake_signature_request_context_from_id(
-                            key_id.clone().into(),
-                            pids[i],
-                            ids[i],
-                        )
+                        fake_signature_request_context_from_id(key_id.clone(), pids[i], ids[i])
                     }),
                 );
 

--- a/rs/consensus/src/idkg/signer.rs
+++ b/rs/consensus/src/idkg/signer.rs
@@ -8,7 +8,7 @@ use ic_consensus_utils::RoundRobin;
 use ic_interfaces::consensus_pool::ConsensusBlockCache;
 use ic_interfaces::crypto::{
     ErrorReproducibility, ThresholdEcdsaSigVerifier, ThresholdEcdsaSigner,
-    ThresholdSchnorrSigVerifier, ThresholdSchnorrSigner,
+    ThresholdSchnorrSigVerifier, ThresholdSchnorrSigner, VetKdProtocol,
 };
 use ic_interfaces::idkg::{IDkgChangeAction, IDkgChangeSet, IDkgPool};
 use ic_interfaces_state_manager::{CertifiedStateSnapshot, StateReader};
@@ -24,7 +24,7 @@ use ic_types::consensus::idkg::common::{
 };
 use ic_types::consensus::idkg::{
     ecdsa_sig_share_prefix, vetkd_key_share_prefix, EcdsaSigShare, IDkgBlockReader, IDkgMessage,
-    IDkgStats, RequestId,
+    IDkgStats, RequestId, VetKdKeyShare,
 };
 use ic_types::consensus::idkg::{schnorr_sig_share_prefix, SchnorrSigShare, SigShare};
 use ic_types::crypto::canister_threshold_sig::error::ThresholdEcdsaCombineSigSharesError;
@@ -33,9 +33,7 @@ use ic_types::crypto::canister_threshold_sig::error::{
     ThresholdSchnorrCombineSigSharesError, ThresholdSchnorrCreateSigShareError,
     ThresholdSchnorrVerifySigShareError,
 };
-use ic_types::crypto::vetkd::{
-    VetKdKeyShareCombinationError, VetKdKeyShareCreationError, VetKdKeyShareVerificationError,
-};
+use ic_types::crypto::vetkd::{VetKdKeyShareCreationError, VetKdKeyShareVerificationError};
 use ic_types::messages::CallbackId;
 use ic_types::{Height, NodeId};
 use std::cell::RefCell;
@@ -54,8 +52,6 @@ enum CreateSigShareError {
 }
 
 #[derive(Clone, Debug)]
-// TODO(CON-1421): Remove once all errors are in use
-#[allow(dead_code)]
 enum VerifySigShareError {
     Ecdsa(ThresholdEcdsaVerifySigShareError),
     Schnorr(ThresholdSchnorrVerifySigShareError),
@@ -75,12 +71,10 @@ impl VerifySigShareError {
 }
 
 #[derive(Clone, Debug)]
-// TODO(CON-1421): Remove once all errors are in use
-#[allow(dead_code)]
 enum CombineSigSharesError {
     Ecdsa(ThresholdEcdsaCombineSigSharesError),
     Schnorr(ThresholdSchnorrCombineSigSharesError),
-    VetKd(VetKdKeyShareCombinationError),
+    VetKdUnexpected,
 }
 
 impl CombineSigSharesError {
@@ -91,8 +85,6 @@ impl CombineSigSharesError {
                 ThresholdEcdsaCombineSigSharesError::UnsatisfiedReconstructionThreshold { .. }
             ) | CombineSigSharesError::Schnorr(
                 ThresholdSchnorrCombineSigSharesError::UnsatisfiedReconstructionThreshold { .. }
-            ) | CombineSigSharesError::VetKd(
-                VetKdKeyShareCombinationError::UnsatisfiedReconstructionThreshold { .. }
             )
         )
     }
@@ -178,7 +170,7 @@ impl ThresholdSignerImpl {
                             idkg_pool,
                             transcript_loader,
                             request_id,
-                            &sig_inputs,
+                            sig_inputs,
                         )
                     })
                     .unwrap_or_default()
@@ -208,6 +200,8 @@ impl ThresholdSignerImpl {
                 (*id, inputs)
             })
             .collect::<BTreeMap<_, _>>();
+
+        println!("{sig_inputs_map:?}");
 
         // Collection of validated shares
         let mut validated_sig_shares = BTreeSet::new();
@@ -379,9 +373,9 @@ impl ThresholdSignerImpl {
         idkg_pool: &dyn IDkgPool,
         transcript_loader: &dyn IDkgTranscriptLoader,
         request_id: RequestId,
-        sig_inputs: &ThresholdSigInputs,
+        sig_inputs: ThresholdSigInputs,
     ) -> IDkgChangeSet {
-        if let Some(changes) = self.load_dependencies(idkg_pool, transcript_loader, sig_inputs) {
+        if let Some(changes) = self.load_dependencies(idkg_pool, transcript_loader, &sig_inputs) {
             return changes;
         }
 
@@ -404,11 +398,11 @@ impl ThresholdSignerImpl {
     fn crypto_create_sig_share(
         &self,
         request_id: RequestId,
-        sig_inputs: &ThresholdSigInputs,
+        sig_inputs: ThresholdSigInputs,
     ) -> Result<IDkgMessage, CreateSigShareError> {
         match sig_inputs {
             ThresholdSigInputs::Ecdsa(inputs) => {
-                ThresholdEcdsaSigner::create_sig_share(&*self.crypto, inputs).map_or_else(
+                ThresholdEcdsaSigner::create_sig_share(&*self.crypto, &inputs).map_or_else(
                     |err| Err(CreateSigShareError::Ecdsa(err)),
                     |share| {
                         let sig_share = EcdsaSigShare {
@@ -421,7 +415,7 @@ impl ThresholdSignerImpl {
                 )
             }
             ThresholdSigInputs::Schnorr(inputs) => {
-                ThresholdSchnorrSigner::create_sig_share(&*self.crypto, inputs).map_or_else(
+                ThresholdSchnorrSigner::create_sig_share(&*self.crypto, &inputs).map_or_else(
                     |err| Err(CreateSigShareError::Schnorr(err)),
                     |share| {
                         let sig_share = SchnorrSigShare {
@@ -433,8 +427,18 @@ impl ThresholdSignerImpl {
                     },
                 )
             }
-            ThresholdSigInputs::VetKd(_inputs) => {
-                todo!("CON-1421: Call crypto endpoint to create a VetKd share");
+            ThresholdSigInputs::VetKd(inputs) => {
+                VetKdProtocol::create_encrypted_key_share(&*self.crypto, inputs).map_or_else(
+                    |err| Err(CreateSigShareError::VetKd(Box::new(err))),
+                    |share| {
+                        let sig_share = VetKdKeyShare {
+                            signer_id: self.node_id,
+                            request_id,
+                            share,
+                        };
+                        Ok(IDkgMessage::VetKdKeyShare(sig_share))
+                    },
+                )
             }
         }
     }
@@ -473,8 +477,17 @@ impl ThresholdSignerImpl {
                     |_| Ok(IDkgMessage::SchnorrSigShare(share)),
                 )
             }
-            (ThresholdSigInputs::VetKd(_inputs), SigShare::VetKd(_share)) => {
-                todo!("CON-1421: Call crypto endpoint to verify VetKd share")
+            (ThresholdSigInputs::VetKd(inputs), SigShare::VetKd(share)) => {
+                VetKdProtocol::verify_encrypted_key_share(
+                    &*self.crypto,
+                    share.signer_id,
+                    &share.share,
+                    inputs,
+                )
+                .map_or_else(
+                    |err| Err(VerifySigShareError::VetKd(err)),
+                    |_| Ok(IDkgMessage::VetKdKeyShare(share)),
+                )
             }
             _ => Err(VerifySigShareError::ThresholdSchemeMismatch),
         };
@@ -710,16 +723,7 @@ impl<'a> ThresholdSignatureBuilderImpl<'a> {
                         |share| Ok(CombinedSignature::Schnorr(share)),
                     )
             }
-            ThresholdSigInputs::VetKd(_inputs) => {
-                // Collect the VetKd shares for the request.
-                let mut sig_shares = BTreeMap::new();
-                for (_, share) in self.idkg_pool.validated().vetkd_key_shares() {
-                    if share.request_id == *request_id {
-                        sig_shares.insert(share.signer_id, share.share.clone());
-                    }
-                }
-                todo!("CON-1421: Call crypto endpoint to combine VetKd shares");
-            }
+            ThresholdSigInputs::VetKd(_) => Err(CombineSigSharesError::VetKdUnexpected),
         };
         stats.record_sig_share_aggregation(request_id, start.elapsed());
         ret
@@ -818,6 +822,7 @@ impl<'a> Action<'a> {
                     // A signature for the received ID was requested and the context was completed.
                     // However, the received share claims a pre-signature was matched at a different
                     // height, therefore drop the message.
+                    println!("AAAAAAAAA");
                     Action::Drop
                 }
             }
@@ -826,6 +831,7 @@ impl<'a> Action<'a> {
             Some(None) => Action::Defer,
             None => {
                 // Its for a signature that has not been requested, drop it
+                println!("BBBBBBBBBBB");
                 Action::Drop
             }
         }
@@ -859,8 +865,9 @@ mod tests {
     use ic_interfaces::p2p::consensus::{MutablePool, UnvalidatedArtifact};
     use ic_management_canister_types::{MasterPublicKeyId, SchnorrAlgorithm};
     use ic_replicated_state::metadata_state::subnet_call_context_manager::{
-        EcdsaArguments, SchnorrArguments, ThresholdArguments,
+        EcdsaArguments, SchnorrArguments, ThresholdArguments, VetKdArguments,
     };
+    use ic_test_utilities::crypto::CryptoReturningOk;
     use ic_test_utilities_consensus::IDkgStatsNoOp;
     use ic_test_utilities_logger::with_test_replica_logger;
     use ic_test_utilities_types::ids::{
@@ -944,7 +951,7 @@ mod tests {
         }
     }
 
-    fn test_signature_shares_purging(key_id: IDkgMasterPublicKeyId) {
+    fn test_signature_shares_purging(key_id: MasterPublicKeyId) {
         ic_test_utilities::artifact_pool_config::with_test_pool_config(|pool_config| {
             with_test_replica_logger(|logger| {
                 let (mut idkg_pool, signer, state_manager) =
@@ -1014,7 +1021,7 @@ mod tests {
         }
     }
 
-    fn test_send_signature_shares(key_id: IDkgMasterPublicKeyId) {
+    fn test_send_signature_shares(key_id: MasterPublicKeyId) {
         let mut generator = IDkgUIDGenerator::new(subnet_test_id(1), Height::new(0));
         let height = Height::from(100);
         let ids: Vec<_> = (0..5).map(|i| request_id(i, height)).collect();
@@ -1119,8 +1126,10 @@ mod tests {
 
     // Tests that no signature shares for incomplete contexts are created
     #[test]
-    fn test_send_signature_shares_incomplete_contexts_all_algorithms() {
-        for key_id in fake_master_public_key_ids_for_all_algorithms() {
+    fn test_send_signature_shares_incomplete_contexts_all_idkg_algorithms() {
+        // Only test IDKG algorithms, as VetKD contexts don't require pre-signatures
+        // and therefore cannot be "incomplete".
+        for key_id in fake_master_public_key_ids_for_all_idkg_algorithms() {
             println!("Running test for key ID {key_id}");
             test_send_signature_shares_incomplete_contexts(key_id);
         }
@@ -1161,11 +1170,11 @@ mod tests {
                 // One context without nonce
                 fake_signature_request_context_with_pre_sig(ids[1], key_id.clone(), Some(pids[1])),
                 // One completed context
-                fake_signature_request_context_from_id(key_id.clone(), pids[2], ids[2]),
+                fake_signature_request_context_from_id(key_id.clone().into(), pids[2], ids[2]),
                 // One completed context matched to a pre-signature of the wrong scheme
-                fake_signature_request_context_from_id(key_id.clone(), pids[3], ids[3]),
+                fake_signature_request_context_from_id(key_id.clone().into(), pids[3], ids[3]),
                 // One completed context matched to a pre-signature that doesn't exist
-                fake_signature_request_context_from_id(key_id.clone(), pids[4], ids[4]),
+                fake_signature_request_context_from_id(key_id.clone().into(), pids[4], ids[4]),
             ],
         );
 
@@ -1200,7 +1209,7 @@ mod tests {
         }
     }
 
-    fn test_send_signature_shares_when_failure(key_id: IDkgMasterPublicKeyId) {
+    fn test_send_signature_shares_when_failure(key_id: MasterPublicKeyId) {
         ic_test_utilities::artifact_pool_config::with_test_pool_config(|pool_config| {
             with_test_replica_logger(|logger| {
                 let mut generator = IDkgUIDGenerator::new(subnet_test_id(1), Height::new(0));
@@ -1220,11 +1229,15 @@ mod tests {
                 let state = fake_state_with_signature_requests(
                     height,
                     (0..3).map(|i| {
-                        fake_signature_request_context_from_id(key_id.clone(), pids[i], ids[i])
+                        fake_signature_request_context_from_id(
+                            key_id.clone().into(),
+                            pids[i],
+                            ids[i],
+                        )
                     }),
                 );
 
-                let (idkg_pool, signer) = create_signer_dependencies(pool_config, logger);
+                let (mut idkg_pool, signer) = create_signer_dependencies(pool_config, logger);
 
                 let transcript_loader =
                     TestIDkgTranscriptLoader::new(TestTranscriptLoadStatus::Failure);
@@ -1235,8 +1248,15 @@ mod tests {
                     &state,
                 );
 
-                // No shares should be created when transcripts fail to load
-                assert!(change_set.is_empty());
+                if key_id.is_idkg_key() {
+                    // No shares should be created for IDKG keys when transcripts fail to load
+                    assert!(change_set.is_empty());
+                } else {
+                    // NiDKG transcripts are loaded ahead of time, so creation should succeed, even if
+                    // IDKG transcripts fail to load.
+                    assert_eq!(change_set.len(), 3);
+                }
+                idkg_pool.apply(change_set);
 
                 let transcript_loader =
                     TestIDkgTranscriptLoader::new(TestTranscriptLoadStatus::Success);
@@ -1247,8 +1267,13 @@ mod tests {
                     &state,
                 );
 
-                // Shares should be created when transcripts succeed to load
-                assert_eq!(change_set.len(), 3);
+                if key_id.is_idkg_key() {
+                    // IDKG key siganture shares should be created when transcripts succeed to load
+                    assert_eq!(change_set.len(), 3);
+                } else {
+                    // No new shares should be created with NiDKG, as they were already created above
+                    assert!(change_set.is_empty());
+                }
             })
         })
     }
@@ -1256,8 +1281,9 @@ mod tests {
     // Tests that complaints are generated and added to the pool if loading transcript
     // results in complaints.
     #[test]
-    fn test_send_signature_shares_with_complaints_all_algorithms() {
-        for key_id in fake_master_public_key_ids_for_all_algorithms() {
+    fn test_send_signature_shares_with_complaints_all_idkg_algorithms() {
+        // Only test IDKG algorithms, as there are no complaints for NiDKG
+        for key_id in fake_master_public_key_ids_for_all_idkg_algorithms() {
             println!("Running test for key ID {key_id}");
             test_send_signature_shares_with_complaints(key_id);
         }
@@ -1283,7 +1309,11 @@ mod tests {
                 let state = fake_state_with_signature_requests(
                     height,
                     (0..3).map(|i| {
-                        fake_signature_request_context_from_id(key_id.clone(), pids[i], ids[i])
+                        fake_signature_request_context_from_id(
+                            key_id.clone().into(),
+                            pids[i],
+                            ids[i],
+                        )
                     }),
                 );
 
@@ -1320,14 +1350,14 @@ mod tests {
     }
 
     #[test]
-    fn test_crypto_verify_sig_share_all_algorithms() {
-        for key_id in fake_master_public_key_ids_for_all_algorithms() {
+    fn test_crypto_verify_sig_share_all_idkg_algorithms() {
+        for key_id in fake_master_public_key_ids_for_all_idkg_algorithms() {
             println!("Running test for key ID {key_id}");
-            test_crypto_verify_sig_share(key_id);
+            test_crypto_verify_idkg_sig_share(key_id);
         }
     }
 
-    fn test_crypto_verify_sig_share(key_id: IDkgMasterPublicKeyId) {
+    fn test_crypto_verify_idkg_sig_share(key_id: IDkgMasterPublicKeyId) {
         let mut rng = reproducible_rng();
         ic_test_utilities::artifact_pool_config::with_test_pool_config(|pool_config| {
             with_test_replica_logger(|logger| {
@@ -1418,7 +1448,7 @@ mod tests {
         }
     }
 
-    fn test_validate_signature_shares(key_id: IDkgMasterPublicKeyId) {
+    fn test_validate_signature_shares(key_id: MasterPublicKeyId) {
         let mut generator = IDkgUIDGenerator::new(subnet_test_id(1), Height::new(0));
         let height = Height::from(100);
         let (id_1, id_2, id_3, id_4) = (
@@ -1500,20 +1530,27 @@ mod tests {
             })
         });
 
-        // Simulate failure when resolving transcripts
+        // Simulate failure when resolving IDKG transcripts
         ic_test_utilities::artifact_pool_config::with_test_pool_config(|pool_config| {
             with_test_replica_logger(|logger| {
                 let (mut idkg_pool, signer) = create_signer_dependencies(pool_config, logger);
                 artifacts.iter().for_each(|a| idkg_pool.insert(a.clone()));
 
                 let block_reader = block_reader.clone().with_fail_to_resolve();
-                // There are no transcripts in the block reader, shares created for transcripts
-                // that cannot be resolved should be handled invalid.
+
                 let change_set =
                     signer.validate_signature_shares(&idkg_pool, &block_reader, &state);
                 assert_eq!(change_set.len(), 3);
-                assert!(is_handle_invalid(&change_set, &msg_id_2));
-                assert!(is_handle_invalid(&change_set, &msg_id_3));
+                if key_id.is_idkg_key() {
+                    // There are no IDKG transcripts in the block reader, shares created for IDKG transcripts
+                    // that cannot be resolved should be handled invalid.
+                    assert!(is_handle_invalid(&change_set, &msg_id_2));
+                    assert!(is_handle_invalid(&change_set, &msg_id_3));
+                } else {
+                    // IDKG transcripts should not affect NiDKG key share validation
+                    assert!(is_moved_to_validated(&change_set, &msg_id_2));
+                    assert!(is_moved_to_validated(&change_set, &msg_id_3));
+                }
                 assert!(is_removed_from_unvalidated(&change_set, &msg_id_4));
             })
         });
@@ -1528,7 +1565,7 @@ mod tests {
         }
     }
 
-    fn test_validate_signature_shares_mismatching_schemes(key_id: IDkgMasterPublicKeyId) {
+    fn test_validate_signature_shares_mismatching_schemes(key_id: MasterPublicKeyId) {
         let mut generator = IDkgUIDGenerator::new(subnet_test_id(1), Height::new(0));
         let height = Height::from(100);
         let (id_1, id_2) = (request_id(1, height), request_id(2, height));
@@ -1566,12 +1603,12 @@ mod tests {
         });
 
         // A share for the second context with mismatching schemes
-        let key_id_wrong_scheme = match key_id.inner() {
+        let key_id_wrong_scheme = match key_id {
             MasterPublicKeyId::Ecdsa(_) => {
-                fake_schnorr_idkg_master_public_key_id(SchnorrAlgorithm::Ed25519)
+                fake_schnorr_idkg_master_public_key_id(SchnorrAlgorithm::Ed25519).into()
             }
-            MasterPublicKeyId::Schnorr(_) => fake_ecdsa_idkg_master_public_key_id(),
-            MasterPublicKeyId::VetKd(_) => panic!("not applicable to vetKD"),
+            MasterPublicKeyId::Schnorr(_) => fake_vetkd_master_public_key_id(),
+            MasterPublicKeyId::VetKd(_) => fake_ecdsa_idkg_master_public_key_id().into(),
         };
         let message = create_signature_share(&key_id_wrong_scheme, NODE_2, id_2);
         let msg_id_2 = message.message_id();
@@ -1598,7 +1635,9 @@ mod tests {
     // Tests that signature shares for incomplete contexts are not validated
     #[test]
     fn test_validate_signature_shares_incomplete_contexts_all_algorithms() {
-        for key_id in fake_master_public_key_ids_for_all_algorithms() {
+        // Only test IDKG algorithms, as VetKD contexts don't require pre-signatures
+        // and therefore cannot be "incomplete".
+        for key_id in fake_master_public_key_ids_for_all_idkg_algorithms() {
             println!("Running test for key ID {key_id}");
             test_validate_signature_shares_incomplete_contexts(key_id);
         }
@@ -1628,7 +1667,7 @@ mod tests {
                 // One context without nonce
                 fake_signature_request_context_with_pre_sig(ids[1], key_id.clone(), Some(pids[1])),
                 // One completed context
-                fake_signature_request_context_from_id(key_id.clone(), pids[2], ids[2]),
+                fake_signature_request_context_from_id(key_id.clone().into(), pids[2], ids[2]),
             ],
         );
 
@@ -1694,7 +1733,7 @@ mod tests {
         }
     }
 
-    fn test_duplicate_signature_shares(key_id: IDkgMasterPublicKeyId) {
+    fn test_duplicate_signature_shares(key_id: MasterPublicKeyId) {
         ic_test_utilities::artifact_pool_config::with_test_pool_config(|pool_config| {
             with_test_replica_logger(|logger| {
                 let height = Height::from(100);
@@ -1735,6 +1774,7 @@ mod tests {
                 let change_set =
                     signer.validate_signature_shares(&idkg_pool, &block_reader, &state);
                 assert_eq!(change_set.len(), 1);
+                println!("{change_set:?}");
                 assert!(is_handle_invalid(&change_set, &msg_id_2));
             })
         })
@@ -1750,7 +1790,7 @@ mod tests {
         }
     }
 
-    fn test_duplicate_signature_shares_in_batch(key_id: IDkgMasterPublicKeyId) {
+    fn test_duplicate_signature_shares_in_batch(key_id: MasterPublicKeyId) {
         ic_test_utilities::artifact_pool_config::with_test_pool_config(|pool_config| {
             with_test_replica_logger(|logger| {
                 let height = Height::from(100);
@@ -1825,7 +1865,7 @@ mod tests {
         }
     }
 
-    fn test_purge_unvalidated_signature_shares(key_id: IDkgMasterPublicKeyId) {
+    fn test_purge_unvalidated_signature_shares(key_id: MasterPublicKeyId) {
         ic_test_utilities::artifact_pool_config::with_test_pool_config(|pool_config| {
             with_test_replica_logger(|logger| {
                 let height = Height::from(100);
@@ -1892,7 +1932,7 @@ mod tests {
         }
     }
 
-    fn test_purge_validated_signature_shares(key_id: IDkgMasterPublicKeyId) {
+    fn test_purge_validated_signature_shares(key_id: MasterPublicKeyId) {
         ic_test_utilities::artifact_pool_config::with_test_pool_config(|pool_config| {
             with_test_replica_logger(|logger| {
                 let height = Height::from(100);
@@ -2209,6 +2249,64 @@ mod tests {
                     &metrics,
                     logger,
                 );
+
+                let result = sig_builder.get_completed_signature(callback_id, &context);
+                assert_matches!(result, None);
+            });
+        })
+    }
+
+    #[test]
+    fn test_vetkd_get_completed_signature_unexpected() {
+        ic_test_utilities::artifact_pool_config::with_test_pool_config(|pool_config| {
+            with_test_replica_logger(|logger| {
+                let (idkg_pool, _) = create_signer_dependencies(pool_config, logger.clone());
+
+                let callback_id = CallbackId::from(1);
+                let key_id = fake_vetkd_key_id();
+                let height = Height::from(100);
+                let context = SignWithThresholdContext {
+                    request: RequestBuilder::new().sender(canister_test_id(1)).build(),
+                    args: ThresholdArguments::VetKd(VetKdArguments {
+                        key_id: key_id.clone(),
+                        derivation_id: vec![],
+                        encryption_public_key: vec![],
+                        ni_dkg_id: fake_dkg_id(key_id),
+                        height,
+                    }),
+                    pseudo_random_id: [1; 32],
+                    derivation_path: vec![],
+                    batch_time: UNIX_EPOCH,
+                    matched_pre_signature: None,
+                    nonce: None,
+                };
+
+                // Set up the block reader
+                let block_reader = TestIDkgBlockReader::for_signer_test(height, vec![]);
+
+                let metrics = IDkgPayloadMetrics::new(MetricsRegistry::new());
+                let crypto: Arc<dyn ConsensusCrypto> = Arc::new(CryptoReturningOk::default());
+
+                let sig_builder = ThresholdSignatureBuilderImpl::new(
+                    &block_reader,
+                    crypto.deref(),
+                    &idkg_pool,
+                    &metrics,
+                    logger,
+                );
+
+                // We don't expect to combine VetKD shares using the ThresholdSignatureBuilder
+                // (they are instead created by the VetKD payload builder).
+                let (request_id, sig_inputs_ref) =
+                    build_signature_inputs(callback_id, &context, &block_reader).unwrap();
+                let sig_inputs = sig_inputs_ref.translate(&block_reader).unwrap();
+
+                let result = sig_builder.crypto_combine_sig_shares(
+                    &request_id,
+                    &sig_inputs,
+                    idkg_pool.stats(),
+                );
+                assert_matches!(result, Err(CombineSigSharesError::VetKdUnexpected));
 
                 let result = sig_builder.get_completed_signature(callback_id, &context);
                 assert_matches!(result, None);

--- a/rs/consensus/src/idkg/test_utils.rs
+++ b/rs/consensus/src/idkg/test_utils.rs
@@ -164,7 +164,7 @@ pub fn fake_signature_request_context_from_id(
     let height = request_id.height;
     let context = SignWithThresholdContext {
         request: RequestBuilder::new().build(),
-        args: fake_signature_request_args(key_id.into(), height),
+        args: fake_signature_request_args(key_id, height),
         derivation_path: vec![],
         batch_time: UNIX_EPOCH,
         pseudo_random_id: [request_id.callback_id.get() as u8; 32],
@@ -1145,10 +1145,9 @@ pub(crate) fn create_sig_inputs_with_height(
     height: Height,
     key_id: MasterPublicKeyId,
 ) -> TestSigInputs {
-    match &key_id {
-        MasterPublicKeyId::VetKd(key_id) => return create_vetkd_inputs_with_args(caller, key_id),
-        _ => (),
-    };
+    if let MasterPublicKeyId::VetKd(key_id) = &key_id {
+        return create_vetkd_inputs_with_args(caller, key_id);
+    }
     let transcript_id = |offset| {
         let val = caller as u64;
         create_transcript_id(val * 214365 + offset)

--- a/rs/consensus/src/idkg/test_utils.rs
+++ b/rs/consensus/src/idkg/test_utils.rs
@@ -3,6 +3,7 @@ use crate::idkg::complaints::{
 };
 use crate::idkg::pre_signer::{IDkgPreSignerImpl, IDkgTranscriptBuilder};
 use crate::idkg::signer::{ThresholdSignatureBuilder, ThresholdSignerImpl};
+use core::convert::TryInto;
 use ic_artifact_pool::idkg_pool::IDkgPoolImpl;
 use ic_config::artifact_pool::ArtifactPoolConfig;
 use ic_consensus_mocks::{dependencies, Dependencies};
@@ -46,7 +47,7 @@ use ic_types::consensus::idkg::{
     SignedIDkgOpening, TranscriptAttributes, TranscriptLookupError, TranscriptRef,
     UnmaskedTranscript,
 };
-use ic_types::consensus::idkg::{HasIDkgMasterPublicKeyId, SchnorrSigShare};
+use ic_types::consensus::idkg::{HasIDkgMasterPublicKeyId, SchnorrSigShare, VetKdKeyShare};
 use ic_types::crypto::canister_threshold_sig::idkg::{
     IDkgComplaint, IDkgDealing, IDkgDealingSupport, IDkgMaskedTranscriptOrigin, IDkgOpening,
     IDkgReceivers, IDkgTranscript, IDkgTranscriptId, IDkgTranscriptOperation, IDkgTranscriptParams,
@@ -59,6 +60,7 @@ use ic_types::crypto::canister_threshold_sig::{
 use ic_types::crypto::threshold_sig::ni_dkg::{
     NiDkgId, NiDkgMasterPublicKeyId, NiDkgTag, NiDkgTargetSubnet,
 };
+use ic_types::crypto::vetkd::{VetKdArgs, VetKdEncryptedKeyShare, VetKdEncryptedKeyShareContent};
 use ic_types::crypto::{AlgorithmId, ExtendedDerivationPath};
 use ic_types::messages::CallbackId;
 use ic_types::time::UNIX_EPOCH;
@@ -93,7 +95,7 @@ pub(crate) fn empty_response() -> ic_types::batch::ConsensusResponse {
     )
 }
 
-fn fake_signature_request_args(key_id: MasterPublicKeyId) -> ThresholdArguments {
+fn fake_signature_request_args(key_id: MasterPublicKeyId, height: Height) -> ThresholdArguments {
     match key_id {
         MasterPublicKeyId::Ecdsa(key_id) => ThresholdArguments::Ecdsa(EcdsaArguments {
             key_id,
@@ -109,7 +111,7 @@ fn fake_signature_request_args(key_id: MasterPublicKeyId) -> ThresholdArguments 
             derivation_id: vec![1; 32],
             encryption_public_key: vec![1; 32],
             ni_dkg_id: fake_dkg_id(key_id),
-            height: Height::from(0),
+            height,
         }),
     }
 }
@@ -127,7 +129,7 @@ pub fn fake_signature_request_context(
 ) -> SignWithThresholdContext {
     SignWithThresholdContext {
         request: RequestBuilder::new().build(),
-        args: fake_signature_request_args(key_id),
+        args: fake_signature_request_args(key_id, Height::from(0)),
         derivation_path: vec![],
         batch_time: UNIX_EPOCH,
         pseudo_random_id,
@@ -141,27 +143,28 @@ pub fn fake_signature_request_context_with_pre_sig(
     key_id: IDkgMasterPublicKeyId,
     pre_signature: Option<PreSigId>,
 ) -> (CallbackId, SignWithThresholdContext) {
+    let height = Height::from(1);
     let context = SignWithThresholdContext {
         request: RequestBuilder::new().build(),
-        args: fake_signature_request_args(key_id.into()),
+        args: fake_signature_request_args(key_id.into(), height),
         derivation_path: vec![],
         batch_time: UNIX_EPOCH,
         pseudo_random_id: [request_id.callback_id.get() as u8; 32],
-        matched_pre_signature: pre_signature.map(|pid| (pid, Height::from(1))),
+        matched_pre_signature: pre_signature.map(|pid| (pid, height)),
         nonce: None,
     };
     (request_id.callback_id, context)
 }
 
 pub fn fake_signature_request_context_from_id(
-    key_id: IDkgMasterPublicKeyId,
+    key_id: MasterPublicKeyId,
     pre_sig_id: PreSigId,
     request_id: RequestId,
 ) -> (CallbackId, SignWithThresholdContext) {
     let height = request_id.height;
     let context = SignWithThresholdContext {
         request: RequestBuilder::new().build(),
-        args: fake_signature_request_args(key_id.into()),
+        args: fake_signature_request_args(key_id.into(), height),
         derivation_path: vec![],
         batch_time: UNIX_EPOCH,
         pseudo_random_id: [request_id.callback_id.get() as u8; 32],
@@ -213,27 +216,29 @@ pub fn insert_test_sig_inputs<T>(
             .for_each(|(transcript_ref, transcript)| {
                 block_reader.add_transcript(*transcript_ref, transcript.clone())
             });
-        idkg_payload
-            .available_pre_signatures
-            .insert(pre_sig_id, inputs.sig_inputs_ref.pre_signature());
-        block_reader.add_available_pre_signature(pre_sig_id, inputs.sig_inputs_ref.pre_signature());
+        if let Some(pre_signature) = inputs.sig_inputs_ref.pre_signature() {
+            idkg_payload
+                .available_pre_signatures
+                .insert(pre_sig_id, pre_signature.clone());
+            block_reader.add_available_pre_signature(pre_sig_id, pre_signature);
+        }
     }
 }
 
 pub(crate) trait HasPreSignature {
-    fn pre_signature(&self) -> PreSignatureRef;
+    fn pre_signature(&self) -> Option<PreSignatureRef>;
 }
 
 impl HasPreSignature for ThresholdSigInputsRef {
-    fn pre_signature(&self) -> PreSignatureRef {
+    fn pre_signature(&self) -> Option<PreSignatureRef> {
         match self {
             ThresholdSigInputsRef::Ecdsa(inputs) => {
-                PreSignatureRef::Ecdsa(inputs.presig_quadruple_ref.clone())
+                Some(PreSignatureRef::Ecdsa(inputs.presig_quadruple_ref.clone()))
             }
-            ThresholdSigInputsRef::Schnorr(inputs) => {
-                PreSignatureRef::Schnorr(inputs.presig_transcript_ref.clone())
-            }
-            ThresholdSigInputsRef::VetKd(_) => panic!("No pre-signatures for VetKd."),
+            ThresholdSigInputsRef::Schnorr(inputs) => Some(PreSignatureRef::Schnorr(
+                inputs.presig_transcript_ref.clone(),
+            )),
+            ThresholdSigInputsRef::VetKd(_) => None,
         }
     }
 }
@@ -412,7 +417,9 @@ impl TestIDkgBlockReader {
             for (transcript_ref, transcript) in sig_inputs.idkg_transcripts {
                 idkg_transcripts.insert(transcript_ref, transcript);
             }
-            available_pre_signatures.insert(pre_sig_id, sig_inputs.sig_inputs_ref.pre_signature());
+            if let Some(pre_signature) = sig_inputs.sig_inputs_ref.pre_signature() {
+                available_pre_signatures.insert(pre_sig_id, pre_signature);
+            }
         }
 
         Self {
@@ -1136,8 +1143,12 @@ pub(crate) fn create_support(
 pub(crate) fn create_sig_inputs_with_height(
     caller: u8,
     height: Height,
-    key_id: IDkgMasterPublicKeyId,
+    key_id: MasterPublicKeyId,
 ) -> TestSigInputs {
+    match &key_id {
+        MasterPublicKeyId::VetKd(key_id) => return create_vetkd_inputs_with_args(caller, key_id),
+        _ => (),
+    };
     let transcript_id = |offset| {
         let val = caller as u64;
         create_transcript_id(val * 214365 + offset)
@@ -1145,6 +1156,7 @@ pub(crate) fn create_sig_inputs_with_height(
     let receivers: BTreeSet<_> = vec![node_test_id(1)].into_iter().collect();
     let key_unmasked_id = transcript_id(50);
     let key_masked_id = transcript_id(40);
+    let idkg_key_id = IDkgMasterPublicKeyId::try_from(key_id).unwrap();
     let key_unmasked = IDkgTranscript {
         transcript_id: key_unmasked_id,
         receivers: IDkgReceivers::new(receivers.clone()).unwrap(),
@@ -1153,10 +1165,10 @@ pub(crate) fn create_sig_inputs_with_height(
         transcript_type: IDkgTranscriptType::Unmasked(IDkgUnmaskedTranscriptOrigin::ReshareMasked(
             key_masked_id,
         )),
-        algorithm_id: algorithm_for_key_id(&key_id),
+        algorithm_id: algorithm_for_key_id(&idkg_key_id),
         internal_transcript_raw: vec![],
     };
-    create_sig_inputs_with_args(caller, &receivers, key_unmasked, height, &key_id)
+    create_sig_inputs_with_args(caller, &receivers, key_unmasked, height, &idkg_key_id)
 }
 
 pub(crate) fn create_sig_inputs_with_args(
@@ -1356,19 +1368,37 @@ pub(crate) fn create_schnorr_sig_inputs_with_args(
     }
 }
 
+// Creates a test vetkd input
+pub(crate) fn create_vetkd_inputs_with_args(caller: u8, key_id: &VetKdKeyId) -> TestSigInputs {
+    let inputs = VetKdArgs {
+        ni_dkg_id: fake_dkg_id(key_id.clone()),
+        derivation_path: ExtendedDerivationPath {
+            caller: PrincipalId::try_from(&vec![caller]).unwrap(),
+            derivation_path: vec![],
+        },
+        derivation_id: vec![],
+        encryption_public_key: vec![1; 32],
+    };
+
+    TestSigInputs {
+        idkg_transcripts: BTreeMap::new(),
+        sig_inputs_ref: ThresholdSigInputsRef::VetKd(inputs),
+    }
+}
+
 // Creates a test signature input
-pub(crate) fn create_sig_inputs(caller: u8, key_id: &IDkgMasterPublicKeyId) -> TestSigInputs {
+pub(crate) fn create_sig_inputs(caller: u8, key_id: &MasterPublicKeyId) -> TestSigInputs {
     create_sig_inputs_with_height(caller, Height::new(0), key_id.clone())
 }
 
 // Creates a test signature share
 pub(crate) fn create_signature_share_with_nonce(
-    key_id: &IDkgMasterPublicKeyId,
+    key_id: &MasterPublicKeyId,
     signer_id: NodeId,
     request_id: RequestId,
     nonce: u8,
 ) -> IDkgMessage {
-    match key_id.inner() {
+    match key_id {
         MasterPublicKeyId::Ecdsa(_) => IDkgMessage::EcdsaSigShare(EcdsaSigShare {
             signer_id,
             request_id,
@@ -1383,13 +1413,20 @@ pub(crate) fn create_signature_share_with_nonce(
                 sig_share_raw: vec![nonce],
             },
         }),
-        MasterPublicKeyId::VetKd(_) => panic!("not applicable to vetKD"),
+        MasterPublicKeyId::VetKd(_) => IDkgMessage::VetKdKeyShare(VetKdKeyShare {
+            signer_id,
+            request_id,
+            share: VetKdEncryptedKeyShare {
+                encrypted_key_share: VetKdEncryptedKeyShareContent(vec![nonce]),
+                node_signature: vec![nonce],
+            },
+        }),
     }
 }
 
 // Creates a test signature share
 pub(crate) fn create_signature_share(
-    key_id: &IDkgMasterPublicKeyId,
+    key_id: &MasterPublicKeyId,
     signer_id: NodeId,
     request_id: RequestId,
 ) -> IDkgMessage {
@@ -1537,25 +1574,27 @@ pub(crate) fn is_opening_added_to_validated(
 // validated pool
 pub(crate) fn is_signature_share_added_to_validated(
     change_set: &[IDkgChangeAction],
-    request_id: &RequestId,
+    expected_request_id: &RequestId,
     requested_height: Height,
 ) -> bool {
     for action in change_set {
-        if let IDkgChangeAction::AddToValidated(IDkgMessage::EcdsaSigShare(share)) = action {
-            if share.request_id.height == requested_height
-                && share.request_id == *request_id
-                && share.signer_id == NODE_1
-            {
-                return true;
+        let (request_id, signer) = match action {
+            IDkgChangeAction::AddToValidated(IDkgMessage::EcdsaSigShare(share)) => {
+                (share.request_id, share.signer_id)
             }
-        }
-        if let IDkgChangeAction::AddToValidated(IDkgMessage::SchnorrSigShare(share)) = action {
-            if share.request_id.height == requested_height
-                && share.request_id == *request_id
-                && share.signer_id == NODE_1
-            {
-                return true;
+            IDkgChangeAction::AddToValidated(IDkgMessage::SchnorrSigShare(share)) => {
+                (share.request_id, share.signer_id)
             }
+            IDkgChangeAction::AddToValidated(IDkgMessage::VetKdKeyShare(share)) => {
+                (share.request_id, share.signer_id)
+            }
+            _ => continue,
+        };
+        if request_id.height == requested_height
+            && request_id == *expected_request_id
+            && signer == NODE_1
+        {
+            return true;
         }
     }
     false
@@ -1696,7 +1735,7 @@ pub(crate) fn fake_dkg_id(key_id: VetKdKeyId) -> NiDkgId {
     }
 }
 
-pub(crate) fn fake_master_public_key_ids_for_all_algorithms() -> Vec<IDkgMasterPublicKeyId> {
+pub(crate) fn fake_master_public_key_ids_for_all_idkg_algorithms() -> Vec<IDkgMasterPublicKeyId> {
     AlgorithmId::iter()
         .flat_map(|alg| match alg {
             AlgorithmId::ThresholdEcdsaSecp256k1 => Some(fake_ecdsa_idkg_master_public_key_id()),
@@ -1708,6 +1747,16 @@ pub(crate) fn fake_master_public_key_ids_for_all_algorithms() -> Vec<IDkgMasterP
             )),
             _ => None,
         })
+        .collect()
+}
+
+pub(crate) fn fake_master_public_key_ids_for_all_algorithms() -> Vec<MasterPublicKeyId> {
+    std::iter::once(fake_vetkd_master_public_key_id())
+        .chain(
+            fake_master_public_key_ids_for_all_idkg_algorithms()
+                .into_iter()
+                .map(MasterPublicKeyId::from),
+        )
         .collect()
 }
 
@@ -1736,9 +1785,10 @@ pub(crate) fn add_available_quadruple_to_payload(
         pre_signature_id.id() as u8,
         &fake_ecdsa_idkg_master_public_key_id(),
     );
-    idkg_payload
-        .available_pre_signatures
-        .insert(pre_signature_id, sig_inputs.sig_inputs_ref.pre_signature());
+    idkg_payload.available_pre_signatures.insert(
+        pre_signature_id,
+        sig_inputs.sig_inputs_ref.pre_signature().unwrap(),
+    );
     for (t_ref, mut transcript) in sig_inputs.idkg_transcripts {
         transcript.registry_version = registry_version;
         idkg_payload
@@ -1768,7 +1818,7 @@ pub fn create_available_pre_signature_with_key_transcript(
 ) -> PreSigId {
     let sig_inputs = create_sig_inputs(caller, &key_id);
     let pre_sig_id = idkg_payload.uid_generator.next_pre_signature_id();
-    let mut pre_signature_ref = sig_inputs.sig_inputs_ref.pre_signature();
+    let mut pre_signature_ref = sig_inputs.sig_inputs_ref.pre_signature().unwrap();
     if let Some(transcript) = key_transcript {
         match pre_signature_ref {
             PreSignatureRef::Ecdsa(ref mut pre_sig) => {

--- a/rs/consensus/src/idkg/utils.rs
+++ b/rs/consensus/src/idkg/utils.rs
@@ -617,7 +617,7 @@ mod tests {
     use super::*;
     use crate::idkg::test_utils::{
         create_available_pre_signature_with_key_transcript, fake_ecdsa_idkg_master_public_key_id,
-        fake_ecdsa_key_id, fake_master_public_key_ids_for_all_algorithms, set_up_idkg_payload,
+        fake_ecdsa_key_id, fake_master_public_key_ids_for_all_idkg_algorithms, set_up_idkg_payload,
         IDkgPayloadTestHelper,
     };
     use ic_config::artifact_pool::ArtifactPoolConfig;
@@ -948,7 +948,7 @@ mod tests {
 
     #[test]
     fn test_get_pre_signature_ids_to_deliver_all_algorithms() {
-        for key_id in fake_master_public_key_ids_for_all_algorithms() {
+        for key_id in fake_master_public_key_ids_for_all_idkg_algorithms() {
             println!("Running test for key ID {key_id}");
             test_get_pre_signature_ids_to_deliver(key_id);
         }
@@ -1020,7 +1020,7 @@ mod tests {
 
     #[test]
     fn test_block_without_key_should_not_deliver_pre_signatures_all_algorithms() {
-        for key_id in fake_master_public_key_ids_for_all_algorithms() {
+        for key_id in fake_master_public_key_ids_for_all_idkg_algorithms() {
             println!("Running test for key ID {key_id}");
             test_block_without_key_should_not_deliver_pre_signatures(key_id);
         }


### PR DESCRIPTION
After the completed implementation of the VetKd protocol in the crypto component, this PR now calls the corresponding endpoints from within the consensus VetKd client.

This PR additionally extends unit tests to also be called for VetKd key IDs where it makes sense. Some unit tests related to IDKG internals and pre-signatures (as required by tSchnorr and tEcdsa) are not executed for VetKd.

Note that initially we intended to combine VetKd key shares using the `ThresholdSignatureBuilder` used in IDKG. Instead, this is now done by the VetKd batch payload builder.