### PR TITLE
chore(IDX): push checksum logic to Bazel

### DIFF
--- a/bazel/conf/.bazelrc.build
+++ b/bazel/conf/.bazelrc.build
@@ -43,13 +43,13 @@ build --workspace_status_command=$(pwd)/bazel/workspace_status.sh
 
 build --experimental_repository_downloader_retries=3 # https://bazel.build/reference/command-line-reference#flag--experimental_repository_downloader_retries
 
-build --flag_alias=ic_version=//bazel:ic_version
-build --flag_alias=ic_version_rc_only=//bazel:ic_version_rc_only
-build --flag_alias=release_build=//bazel:release_build
-build --flag_alias=s3_endpoint=//ci/src/artifacts:s3_endpoint
-build --flag_alias=s3_upload=//ci/src/artifacts:s3_upload
-build --flag_alias=k8s=//rs/tests:k8s
-build --flag_alias=timeout_value=//bazel:timeout_value
+common --flag_alias=ic_version=//bazel:ic_version
+common --flag_alias=ic_version_rc_only=//bazel:ic_version_rc_only
+common --flag_alias=release_build=//bazel:release_build
+common --flag_alias=s3_endpoint=//ci/src/artifacts:s3_endpoint
+common --flag_alias=s3_upload=//ci/src/artifacts:s3_upload
+common --flag_alias=k8s=//rs/tests:k8s
+common --flag_alias=timeout_value=//bazel:timeout_value
 
 # Exclude system tests by default
 # https://github.com/bazelbuild/bazel/issues/8439

--- a/ci/container/build-ic.sh
+++ b/ci/container/build-ic.sh
@@ -40,9 +40,21 @@ EOF
 
 # Color helpers
 tp() { tput -T xterm "$@"; }
-echo_red() { tp setaf 1; echo "$1"; tp sgr0; }
-echo_green() { tp setaf 2; echo "$1"; tp sgr0; }
-echo_blue() { tp setaf 4; echo "$1"; tp sgr0; }
+echo_red() {
+    tp setaf 1
+    echo "$1"
+    tp sgr0
+}
+echo_green() {
+    tp setaf 2
+    echo "$1"
+    tp sgr0
+}
+echo_blue() {
+    tp setaf 4
+    echo "$1"
+    tp sgr0
+}
 
 export BUILD_BIN=false
 export BUILD_CAN=false
@@ -102,14 +114,13 @@ export BINARIES_DIR_FULL="$ROOT_DIR/$BINARIES_DIR"
 export CANISTERS_DIR_FULL="$ROOT_DIR/$CANISTERS_DIR"
 export DISK_DIR_FULL="$ROOT_DIR/$DISK_DIR"
 
-
 # Join a bash array with a string
 # https://stackoverflow.com/a/17841619
 function join_by {
-  local d=${1-} f=${2-}
-  if shift 2; then
-    printf %s "$f" "${@/#/$d}"
-  fi
+    local d=${1-} f=${2-}
+    if shift 2; then
+        printf %s "$f" "${@/#/$d}"
+    fi
 }
 
 echo_blue "Purging artifact directories"
@@ -117,25 +128,24 @@ rm -rf "$BINARIES_DIR_FULL"
 rm -rf "$CANISTERS_DIR_FULL"
 rm -rf "$DISK_DIR_FULL"
 
-BAZEL_TARGETS=(  )
+BAZEL_TARGETS=()
 
 BAZEL_COMMON_ARGS=(
     --config=local # TODO: explain all args
     --ic_version="$VERSION"
     --ic_version_rc_only="$IC_VERSION_RC_ONLY"
     --release_build="$RELEASE"
-    )
+)
 
 echo_green "Building selected IC artifacts: ${BAZEL_TARGETS[*]}"
 
-if "$BUILD_BIN"; then BAZEL_TARGETS+=( "//publish/binaries:compute_checksums" ); fi
-if "$BUILD_CAN"; then BAZEL_TARGETS+=( "//publish/canisters:compute_checksums" ); fi
+if "$BUILD_BIN"; then BAZEL_TARGETS+=("//publish/binaries:compute_checksums"); fi
+if "$BUILD_CAN"; then BAZEL_TARGETS+=("//publish/canisters:compute_checksums"); fi
 if "$BUILD_IMG"; then BAZEL_TARGETS+=(
     "//ic-os/guestos/envs/prod:compute_checksums"
     "//ic-os/hostos/envs/prod:compute_checksums"
     "//ic-os/setupos/envs/prod:compute_checksums"
 ); fi
-
 
 echo_blue "Bazel targets: ${BAZEL_TARGETS[*]}"
 

--- a/ci/container/build-ic.sh
+++ b/ci/container/build-ic.sh
@@ -151,7 +151,7 @@ echo_blue "Bazel targets: ${BAZEL_TARGETS[*]}"
 
 bazel build "${BAZEL_COMMON_ARGS[@]}" "${BAZEL_TARGETS[@]}"
 
-query="$(join_by "+" "${BAZEL_TARGETS[@]}")"
+query="$(IFS="+"; "${BAZEL_TARGETS[*]}")"
 
 for artifact in $(bazel cquery "${BAZEL_COMMON_ARGS[@]}" --output=files "$query"); do
     target_dir=

--- a/ci/container/build-ic.sh
+++ b/ci/container/build-ic.sh
@@ -140,7 +140,10 @@ echo_blue "Bazel targets: ${BAZEL_TARGETS[*]}"
 
 bazel build "${BAZEL_COMMON_ARGS[@]}" "${BAZEL_TARGETS[@]}"
 
-query="$(IFS="+"; "${BAZEL_TARGETS[*]}")"
+query="$(
+    IFS="+"
+    "${BAZEL_TARGETS[*]}"
+)"
 
 for artifact in $(bazel cquery "${BAZEL_COMMON_ARGS[@]}" --output=files "$query"); do
     target_dir=

--- a/ci/container/build-ic.sh
+++ b/ci/container/build-ic.sh
@@ -131,7 +131,7 @@ rm -rf "$DISK_DIR_FULL"
 BAZEL_TARGETS=()
 
 BAZEL_COMMON_ARGS=(
-    --config=local # TODO: explain all args
+    --config=local
     --ic_version="$VERSION"
     --ic_version_rc_only="$IC_VERSION_RC_ONLY"
     --release_build="$RELEASE"

--- a/ci/container/build-ic.sh
+++ b/ci/container/build-ic.sh
@@ -1,6 +1,24 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Check if the script is nested (more than once). If so,
+# something went wrong with the "inside container" detection
+# and we abort to avoid an infinite loop.
+if [ "${BUILD_IC_NESTED:-}" == 1 ]; then
+    echo "$0 nested, aborting"
+    exit 1
+fi
+export BUILD_IC_NESTED=1
+
+export ROOT_DIR="$(git rev-parse --show-toplevel)"
+
+# Drop into the container if we're not already inside it. This ensures
+# we run in a predictable environment (Ubuntu with known deps).
+if ! ([ -e /home/ubuntu/.DFINITY-TAG ] && ([ -e /.dockerenv ] || [ -e /run/.containerenv ] || [ -n "${CI_JOB_NAME:-}" ])); then
+    echo dropping into container
+    exec "$ROOT_DIR"/ci/container/container-run.sh bash "$0" "$@"
+fi
+
 [ -n "${DEBUG:-}" ] && set -x
 
 usage() {
@@ -20,14 +38,11 @@ Non-Release Build, is for non-protected branches (revision is not in rc--* or ma
 EOF
 }
 
-RED='\033[0;31m'
-BLUE='\033[0;34m'
-GREEN='\033[0;32m'
-NOCOLOR='\033[0m'
-
-echo_red() { echo -e "${RED}${1}${NOCOLOR}"; }
-echo_blue() { echo -e "${BLUE}${1}${NOCOLOR}"; }
-echo_green() { echo -e "${GREEN}${1}${NOCOLOR}"; }
+# Color helpers
+tp() { tput -T xterm "$@"; }
+echo_red() { tp setaf 1; echo "$1"; tp sgr0; }
+echo_green() { tp setaf 2; echo "$1"; tp sgr0; }
+echo_blue() { tp setaf 4; echo "$1"; tp sgr0; }
 
 export BUILD_BIN=false
 export BUILD_CAN=false
@@ -53,7 +68,7 @@ while getopts ':bcinh-:' OPT; do
         i | icos) BUILD_IMG=true ;;
         n | non-release | no-release | norelease) RELEASE=false ;;
         ??*) echo_red "Invalid option --$OPT" && usage && exit 1 ;;
-        ?) echo_red "Invalid command option.\n" && usage && exit 1 ;;
+        ?) echo_red "Invalid command option." && usage && exit 1 ;;
     esac
 done
 shift "$(($OPTIND - 1))"
@@ -64,15 +79,14 @@ if ! "$BUILD_BIN" && ! "$BUILD_CAN" && ! "$BUILD_IMG"; then
     usage && exit 1
 fi
 
-export ROOT_DIR="$(git rev-parse --show-toplevel)"
 export VERSION="$(git rev-parse HEAD)"
 
 if "$RELEASE"; then
     export IC_VERSION_RC_ONLY="$VERSION"
-    echo_red "\nBuilding release revision (master or rc--*)! Use '--no-release' for non-release revision!\n" && sleep 2
+    echo_red "Building release revision (master or rc--*)! Use '--no-release' for non-release revision!" && sleep 2
 else
     export IC_VERSION_RC_ONLY="0000000000000000000000000000000000000000"
-    echo_red "\nBuilding non-release revision!\n" && sleep 2
+    echo_red "Building non-release revision!" && sleep 2
 fi
 
 export BINARIES_DIR=artifacts/release
@@ -82,136 +96,102 @@ export BINARIES_DIR_FULL="$ROOT_DIR/$BINARIES_DIR"
 export CANISTERS_DIR_FULL="$ROOT_DIR/$CANISTERS_DIR"
 export DISK_DIR_FULL="$ROOT_DIR/$DISK_DIR"
 
-is_inside_DFINITY_container() {
-    [ -e /home/ubuntu/.DFINITY-TAG ] && ([ -e /.dockerenv ] || [ -e /run/.containerenv ] || [ -n "${CI_JOB_NAME:-}" ])
+
+# Join a bash array with a string
+# https://stackoverflow.com/a/17841619
+function join_by {
+  local d=${1-} f=${2-}
+  if shift 2; then
+    printf %s "$f" "${@/#/$d}"
+  fi
 }
-
-validate_build_env() {
-    function not_supported_prompt() {
-        echo_red "$1"
-        read -t 7 -r -s -p $'Press ENTER to continue the build anyway...\n'
-    }
-
-    if [ -n "$(git status --porcelain)" ]; then
-        echo_red "Git working directory is not clean! Clean it and retry."
-        exit 1
-    fi
-
-    if [ "$(uname)" != "Linux" ]; then
-        not_supported_prompt "This script is only supported on Linux!"
-    elif ! grep -q 'Ubuntu' /etc/os-release; then
-        not_supported_prompt "Build reproducibility is only supported on Ubuntu!"
-    fi
-}
-
-echo_green "Validating build environment"
-validate_build_env
 
 echo_blue "Purging artifact directories"
 rm -rf "$BINARIES_DIR_FULL"
 rm -rf "$CANISTERS_DIR_FULL"
 rm -rf "$DISK_DIR_FULL"
 
-echo_green "Building selected IC artifacts"
-BAZEL_CMD="bazel build --config=local --ic_version='$VERSION' --ic_version_rc_only='$IC_VERSION_RC_ONLY' \
-           --release_build=$RELEASE"
+BAZEL_TARGETS=(  )
 
-BAZEL_CLEAN_CMD=$(
-    cat <<-END
-    # clear bazel cache
-    bazel clean
-END
-)
+BAZEL_COMMON_ARGS=(
+    --config=local # TODO: explain all args
+    --ic_version="$VERSION"
+    --ic_version_rc_only="$IC_VERSION_RC_ONLY"
+    --release_build="$RELEASE"
+    )
 
-BUILD_BINARIES_CMD=$(
-    cat <<-END
-    # build binaries
-    mkdir -p "$BINARIES_DIR"
-    $BAZEL_CMD //publish/binaries
-    bazel cquery --config=local --output=files //publish/binaries | xargs -I {} cp {} "$BINARIES_DIR"
-END
-)
+echo_green "Building selected IC artifacts: ${BAZEL_TARGETS[*]}"
 
-BUILD_CANISTERS_CMD=$(
-    cat <<-END
-    # build canisters
-    mkdir -p "$CANISTERS_DIR"
-    $BAZEL_CMD //publish/canisters
-    bazel cquery --config=local --output=files //publish/canisters | xargs -I {} cp {} "$CANISTERS_DIR"
-END
-)
+if "$BUILD_BIN"; then BAZEL_TARGETS+=( "//publish/binaries:compute_checksums" ); fi
+if "$BUILD_CAN"; then BAZEL_TARGETS+=( "//publish/canisters:compute_checksums" ); fi
+if "$BUILD_IMG"; then BAZEL_TARGETS+=(
+    "//ic-os/guestos/envs/prod:compute_checksums"
+    "//ic-os/hostos/envs/prod:compute_checksums"
+    "//ic-os/setupos/envs/prod:compute_checksums"
+); fi
 
-BUILD_IMAGES_CMD=$(
-    cat <<-END
-    # build guestos images
-    mkdir -p "${DISK_DIR}/guestos"
-    $BAZEL_CMD //ic-os/guestos/envs/prod
-    bazel cquery --config=local --output=files //ic-os/guestos/envs/prod | xargs -I {} cp {} "${DISK_DIR}/guestos"
-    # build hostos images
-    mkdir -p "${DISK_DIR}/hostos"
-    $BAZEL_CMD //ic-os/hostos/envs/prod
-    bazel cquery --config=local --output=files //ic-os/hostos/envs/prod | xargs -I {} cp {} "${DISK_DIR}/hostos"
-    # build setupos images
-    mkdir -p "${DISK_DIR}/setupos"
-    $BAZEL_CMD //ic-os/setupos/envs/prod
-    bazel cquery --config=local --output=files //ic-os/setupos/envs/prod | xargs -I {} cp {} "${DISK_DIR}/setupos"
-END
-)
-BUILD_CMD="${BAZEL_CLEAN_CMD}"
 
-if "$BUILD_BIN"; then BUILD_CMD="${BUILD_CMD}${BUILD_BINARIES_CMD}"; fi
-if "$BUILD_CAN"; then BUILD_CMD="${BUILD_CMD}${BUILD_CANISTERS_CMD}"; fi
-if "$BUILD_IMG"; then BUILD_CMD="${BUILD_CMD}${BUILD_IMAGES_CMD}"; fi
+echo_blue "Bazel targets: ${BAZEL_TARGETS[*]}"
 
-if is_inside_DFINITY_container; then
-    echo_blue "Building already inside a DFINITY container or CI"
-    eval "$BUILD_CMD"
-else
-    echo_blue "Building by using a new DFINITY container"
-    "$ROOT_DIR"/ci/container/container-run.sh bash -c "$BUILD_CMD"
-fi
+bazel build "${BAZEL_COMMON_ARGS[@]}" "${BAZEL_TARGETS[@]}"
+
+query="$(join_by "+" "${BAZEL_TARGETS[@]}")"
+
+for artifact in $(bazel cquery "${BAZEL_COMMON_ARGS[@]}" --output=files "$query"); do
+    target_dir=
+    case "$artifact" in
+        *guestos*)
+            target_dir="$DISK_DIR/guestos"
+            ;;
+        *hostos*)
+            target_dir="$DISK_DIR/hostos"
+            ;;
+        *setupos*)
+            target_dir="$DISK_DIR/setupos"
+            ;;
+        *binaries*)
+            target_dir="$BINARIES_DIR"
+            ;;
+        *canisters*)
+            target_dir="$CANISTERS_DIR"
+            ;;
+        *)
+            echo "don't know where to put artifact '$artifact'"
+            exit 1
+            ;;
+    esac
+
+    mkdir -p "$target_dir"
+    cp "$artifact" "$target_dir"
+done
 
 if "$BUILD_BIN"; then
     echo_green "##### Binaries SHA256SUMS #####"
-    pushd "$BINARIES_DIR_FULL"
-    GLOBIGNORE="SHA256SUMS"
-    # shellcheck disable=SC2035
-    sha256sum -b *.gz | tee SHA256SUMS
-    popd
+    pushd "$BINARIES_DIR_FULL" >/dev/null
+    cat SHA256SUMS
+    popd >/dev/null
 fi
 
 if "$BUILD_CAN"; then
     echo_green "##### Canisters SHA256SUMS #####"
     pushd "$CANISTERS_DIR_FULL"
-    # shellcheck disable=SC2035
-    sha256sum -b *.gz | tee SHA256SUMS
-    # neuron voters need to verify against the unzipped SHA256SUM
-    TMP="$(mktemp -d)"
-    cp *.gz "$TMP/"
-    cd "$TMP"
-    gunzip *
-    # shellcheck disable=SC2035
-    sha256sum *
+    cat SHA256SUMS
     popd
-    rm -fr "$TMP"
 fi
 
 if "$BUILD_IMG"; then
     echo_green "##### GUESTOS SHA256SUMS #####"
-    pushd "$DISK_DIR_FULL/guestos"
-    # shellcheck disable=SC2035
-    sha256sum -b *.tar.* | tee SHA256SUMS
-    popd
+    pushd "$DISK_DIR_FULL/guestos" >/dev/null
+    cat SHA256SUMS
+    popd >/dev/null
     echo_green "##### HOSTOS SHA256SUMS #####"
-    pushd "$DISK_DIR_FULL/hostos"
-    # shellcheck disable=SC2035
-    sha256sum -b *.tar.* | tee SHA256SUMS
-    popd
+    pushd "$DISK_DIR_FULL/hostos" >/dev/null
+    cat SHA256SUMS
+    popd >/dev/null
     echo_green "##### SETUPOS SHA256SUMS #####"
-    pushd "$DISK_DIR_FULL/setupos"
-    # shellcheck disable=SC2035
-    sha256sum -b *.tar.* | tee SHA256SUMS
-    popd
+    pushd "$DISK_DIR_FULL/setupos" >/dev/null
+    cat SHA256SUMS
+    popd >/dev/null
 fi
 
-echo_green "Build complete for revision $(git rev-parse HEAD)"
+echo_green "Build complete for revision $VERSION"

--- a/ci/container/build-ic.sh
+++ b/ci/container/build-ic.sh
@@ -137,8 +137,6 @@ BAZEL_COMMON_ARGS=(
     --release_build="$RELEASE"
 )
 
-echo_green "Building selected IC artifacts: ${BAZEL_TARGETS[*]}"
-
 if "$BUILD_BIN"; then BAZEL_TARGETS+=("//publish/binaries:compute_checksums"); fi
 if "$BUILD_CAN"; then BAZEL_TARGETS+=("//publish/canisters:compute_checksums"); fi
 if "$BUILD_IMG"; then BAZEL_TARGETS+=(

--- a/ci/container/build-ic.sh
+++ b/ci/container/build-ic.sh
@@ -114,15 +114,6 @@ export BINARIES_DIR_FULL="$ROOT_DIR/$BINARIES_DIR"
 export CANISTERS_DIR_FULL="$ROOT_DIR/$CANISTERS_DIR"
 export DISK_DIR_FULL="$ROOT_DIR/$DISK_DIR"
 
-# Join a bash array with a string
-# https://stackoverflow.com/a/17841619
-function join_by {
-    local d=${1-} f=${2-}
-    if shift 2; then
-        printf %s "$f" "${@/#/$d}"
-    fi
-}
-
 echo_blue "Purging artifact directories"
 rm -rf "$BINARIES_DIR_FULL"
 rm -rf "$CANISTERS_DIR_FULL"

--- a/ci/container/build-ic.sh
+++ b/ci/container/build-ic.sh
@@ -79,6 +79,12 @@ if ! "$BUILD_BIN" && ! "$BUILD_CAN" && ! "$BUILD_IMG"; then
     usage && exit 1
 fi
 
+# Ensure working dir is clean
+if [ -n "$(git status --porcelain)" ]; then
+    echo_red "Git working directory is not clean! Clean it and retry."
+    exit 1
+fi
+
 export VERSION="$(git rev-parse HEAD)"
 
 if "$RELEASE"; then

--- a/ci/container/build-ic.sh
+++ b/ci/container/build-ic.sh
@@ -56,6 +56,14 @@ echo_blue() {
     tp sgr0
 }
 
+# Join a bash array with a string
+# https://stackoverflow.com/a/17841619
+function join_by {
+    local IFS="$1"
+    shift
+    echo "$*"
+}
+
 export BUILD_BIN=false
 export BUILD_CAN=false
 export BUILD_IMG=false
@@ -140,10 +148,7 @@ echo_blue "Bazel targets: ${BAZEL_TARGETS[*]}"
 
 bazel build "${BAZEL_COMMON_ARGS[@]}" "${BAZEL_TARGETS[@]}"
 
-query="$(
-    IFS="+"
-    "${BAZEL_TARGETS[*]}"
-)"
+query="$(join_by "+" "${BAZEL_TARGETS[@]}")"
 
 for artifact in $(bazel cquery "${BAZEL_COMMON_ARGS[@]}" --output=files "$query"); do
     target_dir=

--- a/ic-os/guestos/envs/prod/BUILD.bazel
+++ b/ic-os/guestos/envs/prod/BUILD.bazel
@@ -1,5 +1,6 @@
 load("//ic-os:defs.bzl", "icos_build")
 load("//ic-os/guestos:defs.bzl", "image_deps")
+load("//publish:defs.bzl", "checksum_rule")
 
 # The macro contains several targets.
 # Check
@@ -10,4 +11,10 @@ icos_build(
     image_deps_func = image_deps,
     upload_prefix = "guest-os",
     visibility = ["//rs:ic-os-pkg"],
+)
+
+# Export checksums & build artifacts
+checksum_rule(
+    name = "compute_checksums",
+    inputs = [":prod"],
 )

--- a/ic-os/hostos/envs/prod/BUILD.bazel
+++ b/ic-os/hostos/envs/prod/BUILD.bazel
@@ -1,5 +1,6 @@
 load("//ic-os:defs.bzl", "icos_build")
 load("//ic-os/hostos:defs.bzl", "image_deps")
+load("//publish:defs.bzl", "checksum_rule")
 
 # The macro contains several targets.
 # Check
@@ -11,4 +12,10 @@ icos_build(
     upload_prefix = "host-os",
     visibility = ["//rs:ic-os-pkg"],
     vuln_scan = False,
+)
+
+# Export checksums & build artifacts
+checksum_rule(
+    name = "compute_checksums",
+    inputs = [":prod"],
 )

--- a/ic-os/setupos/envs/prod/BUILD.bazel
+++ b/ic-os/setupos/envs/prod/BUILD.bazel
@@ -1,6 +1,7 @@
 load("//ic-os:defs.bzl", "icos_build")
 load("//ic-os/dev-tools/bare_metal_deployment:tools.bzl", "launch_bare_metal")
 load("//ic-os/setupos:defs.bzl", "image_deps")
+load("//publish:defs.bzl", "checksum_rule")
 
 # The macro contains several targets.
 # Check
@@ -17,4 +18,10 @@ icos_build(
 launch_bare_metal(
     name = "launch_bare_metal",
     image_zst_file = ":disk-img.tar.zst",
+)
+
+# Export checksums & build artifacts
+checksum_rule(
+    name = "compute_checksums",
+    inputs = [":prod"],
 )

--- a/publish/binaries/BUILD.bazel
+++ b/publish/binaries/BUILD.bazel
@@ -1,6 +1,6 @@
 load("//bazel:defs.bzl", "gzip_compress")
 load("//ci/src/artifacts:upload.bzl", "upload_artifacts")
-load("//publish:defs.bzl", "release_nostrip_binary", "release_strip_binary", "release_strip_binary_test")
+load("//publish:defs.bzl", "checksum_rule", "release_nostrip_binary", "release_strip_binary", "release_strip_binary_test")
 
 package(default_visibility = ["//rs:ic-os-pkg"])
 
@@ -117,6 +117,11 @@ TEST_BINARIES = [
 filegroup(
     name = "binaries",
     srcs = [name + ".gz" for name in ALL_BINARIES],
+)
+
+checksum_rule(
+    name = "compute_checksums",
+    inputs = [":binaries"],
 )
 
 upload_artifacts(

--- a/publish/canisters/BUILD.bazel
+++ b/publish/canisters/BUILD.bazel
@@ -1,5 +1,6 @@
 load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
 load("//ci/src/artifacts:upload.bzl", "upload_artifacts")
+load("//publish:defs.bzl", "checksum_rule")
 load("//rs/nns:nns.bzl", NNS_CANISTER_NAME_TO_MAX_COMPRESSED_WASM_SIZE_E5_BYTES = "CANISTER_NAME_TO_MAX_COMPRESSED_WASM_SIZE_E5_BYTES")
 load("//rs/sns:sns.bzl", SNS_CANISTER_NAME_TO_MAX_COMPRESSED_WASM_SIZE_E5_BYTES = "CANISTER_NAME_TO_MAX_COMPRESSED_WASM_SIZE_E5_BYTES")
 
@@ -123,6 +124,12 @@ filegroup(
     name = "canisters",
     srcs = [name for name in CANISTERS] +
            [name for name in COMPRESSED_CANISTERS],
+)
+
+# Export checksums & build artifacts
+checksum_rule(
+    name = "compute_checksums",
+    inputs = [":canisters"],
 )
 
 # the further targets are all testonly for simplicity because if a target was

--- a/publish/defs.bzl
+++ b/publish/defs.bzl
@@ -153,7 +153,8 @@ def _checksum_rule_impl(ctx):
         for input in "$@"; do
             {sha256} "$input" "$output"
             cat "$output" >> "$out_checksums"
-            echo " $(basename $input)" >> "$out_checksums"
+            # '*' added for compatibility with determinism tests
+            echo " *$(basename $input)" >> "$out_checksums"
         done
 
         cat "$out_checksums"

--- a/publish/defs.bzl
+++ b/publish/defs.bzl
@@ -151,6 +151,10 @@ def _checksum_rule_impl(ctx):
         output=$(mktemp) # temporary file bc sha256 doesn't support writing to stdout (or /dev/stdout) directly
 
         for input in "$@"; do
+            if ! [[ $input =~ (\\.tar|\\.gz) ]]; then
+                echo "skipping non-archive file $input"
+                continue
+            fi
             {sha256} "$input" "$output"
             cat "$output" >> "$out_checksums"
             # '*' added for compatibility with determinism tests


### PR DESCRIPTION
This tries to improve the `build-ic.sh` script in a couple of ways:

* Push the checksum logic to bazel so that it can be used without `build-ic.sh` (e.g. for repro checks)
* Re-use bazel arguments in both build & `cquery` to ensure the same targets are actually used
* Discard environment validation (since the script is forcing use inside the container) and `exec` into container with script itself (ensures the whole script runs in the container and not just the build)
* Drop `*` from shasum output
* Use `tput` for terminal colors
* Use the built-in bazel `sha256` tool