### PR TITLE
feat(governance-tools): Added TODOs to generated "Features & Fixtures" section.

### DIFF
--- a/testnet/tools/nns-tools/lib/proposals.sh
+++ b/testnet/tools/nns-tools/lib/proposals.sh
@@ -174,6 +174,10 @@ __Source code__: [$NEXT_COMMIT][new-commit]
 
 ## Features & Fixes
 
+TODO: Review this section. In particular, make sure that it matches the "New
+Commits" section, and does not contain anything extraneous from previous
+proposals. If it seems alright, simply delete this TODO.
+
 $FEATURES_AND_FIXES
 
 
@@ -319,6 +323,10 @@ __Source code__: [$NEXT_COMMIT][new-commit]
 [new-commit]: https://github.com/dfinity/ic/tree/$NEXT_COMMIT
 
 ## Features & Fixes
+
+TODO: Review this section. In particular, make sure that it matches the "New
+Commits" section, and does not contain anything extraneous from previous
+proposals. If it seems alright, simply delete this TODO.
 
 $FEATURES_AND_FIXES
 


### PR DESCRIPTION
This forces the release tsar to review generated proposals before submitting them, because [validate_no_todos] stops proposals from being submitted if they contain "TODO".

[validate_no_todos]: https://sourcegraph.com/search?q=repo:%5Egithub%5C.com/dfinity/ic%24+f:nns-tools+%22validate_no_todos+%22&patternType=regexp&case=yes&sm=0

We could delete this later once we get used to and work work out all issues in this new process.