### PR TITLE
chore: [EXC-1880] Test hook behavior across upgrade

### DIFF
--- a/rs/execution_environment/src/execution_environment/tests/canister_task.rs
+++ b/rs/execution_environment/src/execution_environment/tests/canister_task.rs
@@ -1141,19 +1141,20 @@ fn on_low_wasm_memory_is_executed_after_upgrade_if_condition_holds() {
     );
     assert_eq!(result, Ok(()));
 
+    // Upgrade is executed, and the wasm_memory size is unchanged.
+    // Hook condition is satisfied.
+    assert_eq!(
+        test.execution_state(canister_id).wasm_memory.size,
+        NumWasmPages::new(8)
+    );
+
+    // Status of the hook is still Ready.
     assert_eq!(
         test.canister_state(canister_id)
             .system_state
             .task_queue
             .peek_hook_status(),
         OnLowWasmMemoryHookStatus::Ready
-    );
-
-    // Upgrade is executed, and the wasm_memory size is unchanged.
-    // Hook condition is satisfied.
-    assert_eq!(
-        test.execution_state(canister_id).wasm_memory.size,
-        NumWasmPages::new(8)
     );
 
     // Though we have the second ingress message awaiting to be processed,

--- a/rs/execution_environment/src/execution_environment/tests/canister_task.rs
+++ b/rs/execution_environment/src/execution_environment/tests/canister_task.rs
@@ -1472,9 +1472,6 @@ fn hook_status_remains_executed_if_condition_holds_after_upgrade() {
 #[test]
 fn upgrade_changes_hook_status_to_ready() {
     let wat = r#"(module
-            (func (export "canister_global_timer")
-                (drop (memory.grow (i32.const 10)))
-            )
             (memory 1 20)
         )"#;
     let mut test = ExecutionTestBuilder::new().with_manual_execution().build();
@@ -1509,9 +1506,6 @@ fn upgrade_changes_hook_status_to_ready() {
     );
 
     let wat2 = r#"(module
-        (func (export "canister_global_timer")
-            (drop (memory.grow (i32.const 10)))
-        )
         (memory 2 2)
     )"#;
 

--- a/rs/execution_environment/src/execution_environment/tests/canister_task.rs
+++ b/rs/execution_environment/src/execution_environment/tests/canister_task.rs
@@ -1490,7 +1490,7 @@ fn upgrade_changes_hook_status_to_ready() {
     // wasm_memory_threshold = 9 Wasm Pages
 
     // Initially wasm_memory.size = 1
-    // wasm_memory_limit - used_wasm_memory = wasm_memory_threshold
+    // wasm_capacity - used_wasm_memory = wasm_memory_threshold
     // Hook condition is not satisfied.
     assert_eq!(
         test.execution_state(canister_id).wasm_memory.size,

--- a/rs/execution_environment/src/execution_environment/tests/canister_task.rs
+++ b/rs/execution_environment/src/execution_environment/tests/canister_task.rs
@@ -907,7 +907,7 @@ fn on_low_wasm_memory_hook_is_run_after_freezing() {
     );
 
     // wasm_capacity - used_wasm_memory < self.wasm_memory_threshold
-    // The hook condition is triggered.
+    // Hook condition is satisfied.
     // Hence hook should be executed next.
     assert_eq!(
         test.state()
@@ -1058,7 +1058,7 @@ fn on_low_wasm_memory_is_executed_before_message() {
     // First ingress messages gets executed.
     // wasm_memory.size = 1 + 7 = 8
     // wasm_capacity - used_wasm_memory < self.wasm_memory_threshold
-    // Hook condition is triggered.
+    // Hook condition is satisfied.
     test.execute_slice(canister_id);
     assert_eq!(
         test.execution_state(canister_id).wasm_memory.size,
@@ -1116,11 +1116,19 @@ fn on_low_wasm_memory_is_executed_after_upgrade_if_condition_holds() {
     // First ingress messages gets executed.
     // wasm_memory.size = 1 + 7 = 8
     // wasm_capacity - used_wasm_memory < self.wasm_memory_threshold
-    // Hook condition is triggered.
+    // Hook condition is satisfied.
     test.execute_slice(canister_id);
     assert_eq!(
         test.execution_state(canister_id).wasm_memory.size,
         NumWasmPages::new(8)
+    );
+
+    assert_eq!(
+        test.canister_state(canister_id)
+            .system_state
+            .task_queue
+            .peek_hook_status(),
+        OnLowWasmMemoryHookStatus::Ready
     );
 
     let result = test.upgrade_canister_v2(
@@ -1133,8 +1141,16 @@ fn on_low_wasm_memory_is_executed_after_upgrade_if_condition_holds() {
     );
     assert_eq!(result, Ok(()));
 
+    assert_eq!(
+        test.canister_state(canister_id)
+            .system_state
+            .task_queue
+            .peek_hook_status(),
+        OnLowWasmMemoryHookStatus::Ready
+    );
+
     // Upgrade is executed, and the wasm_memory size is unchanged.
-    // Hook condition is triggered.
+    // Hook condition is satisfied.
     assert_eq!(
         test.execution_state(canister_id).wasm_memory.size,
         NumWasmPages::new(8)
@@ -1146,6 +1162,14 @@ fn on_low_wasm_memory_is_executed_after_upgrade_if_condition_holds() {
     assert_eq!(
         test.execution_state(canister_id).wasm_memory.size,
         NumWasmPages::new(13)
+    );
+
+    assert_eq!(
+        test.canister_state(canister_id)
+            .system_state
+            .task_queue
+            .peek_hook_status(),
+        OnLowWasmMemoryHookStatus::Executed
     );
 
     // The second ingress message is executed after the hook.
@@ -1192,7 +1216,7 @@ fn on_low_wasm_memory_is_not_executed_after_upgrade_if_condition_becomes_unsatis
     // First ingress messages gets executed.
     // wasm_memory.size = 1 + 3 = 4
     // wasm_capacity - used_wasm_memory > self.wasm_memory_threshold
-    // Hook condition is not triggered.
+    // Hook condition is not satisfied.
     test.execute_slice(canister_id);
     assert_eq!(
         test.execution_state(canister_id).wasm_memory.size,
@@ -1202,11 +1226,19 @@ fn on_low_wasm_memory_is_not_executed_after_upgrade_if_condition_becomes_unsatis
     // Second ingress messages gets executed.
     // wasm_memory.size = 4 + 3 = 7
     // wasm_capacity - used_wasm_memory < self.wasm_memory_threshold
-    // Hook condition is triggered.
+    // Hook condition is satisfied.
     test.execute_slice(canister_id);
     assert_eq!(
         test.execution_state(canister_id).wasm_memory.size,
         NumWasmPages::new(7)
+    );
+
+    assert_eq!(
+        test.canister_state(canister_id)
+            .system_state
+            .task_queue
+            .peek_hook_status(),
+        OnLowWasmMemoryHookStatus::Ready
     );
 
     let result = test.upgrade_canister_v2(
@@ -1220,10 +1252,18 @@ fn on_low_wasm_memory_is_not_executed_after_upgrade_if_condition_becomes_unsatis
     assert_eq!(result, Ok(()));
 
     // Upgrade is executed, and the wasm_memory size reset to 1.
-    // Hook condition is not triggered.
+    // Hook condition is not satisfied.
     assert_eq!(
         test.execution_state(canister_id).wasm_memory.size,
         NumWasmPages::new(1)
+    );
+
+    assert_eq!(
+        test.canister_state(canister_id)
+            .system_state
+            .task_queue
+            .peek_hook_status(),
+        OnLowWasmMemoryHookStatus::ConditionNotSatisfied
     );
 
     // Though the hook was initially scheduled, it is now removed
@@ -1239,6 +1279,268 @@ fn on_low_wasm_memory_is_not_executed_after_upgrade_if_condition_becomes_unsatis
     assert_eq!(
         test.execution_state(canister_id).wasm_memory.size,
         NumWasmPages::new(4)
+    );
+}
+
+#[test]
+fn upgrade_changes_hook_status_to_not_satisfied() {
+    let mut test = ExecutionTestBuilder::new().with_manual_execution().build();
+
+    let update_grow_mem_size = 7;
+    let hook_grow_mem_size = 5;
+
+    let wat: String =
+        get_wat_with_update_and_hook_mem_grow(update_grow_mem_size, hook_grow_mem_size, false);
+
+    let canister_id = test.canister_from_wat(wat.as_str()).unwrap();
+
+    test.canister_update_wasm_memory_limit_and_wasm_memory_threshold(
+        canister_id,
+        (20 * WASM_PAGE_SIZE_IN_BYTES as u64).into(),
+        (15 * WASM_PAGE_SIZE_IN_BYTES as u64).into(),
+    )
+    .unwrap();
+
+    // Here we have:
+    // wasm_capacity = wasm_memory_limit = 20 Wasm Pages
+    // wasm_memory_threshold = 15 Wasm Pages
+
+    // Initially wasm_memory.size = 1
+    assert_eq!(
+        test.execution_state(canister_id).wasm_memory.size,
+        NumWasmPages::new(1)
+    );
+
+    test.ingress_raw(canister_id, "grow_mem", vec![]);
+
+    // Ingress messages gets executed.
+    // wasm_memory.size = 1 + 7 = 8
+    // wasm_capacity - used_wasm_memory < self.wasm_memory_threshold
+    // Hook condition is satisfied.
+    test.execute_slice(canister_id);
+    assert_eq!(
+        test.execution_state(canister_id).wasm_memory.size,
+        NumWasmPages::new(8)
+    );
+
+    assert_eq!(
+        test.canister_state(canister_id)
+            .system_state
+            .task_queue
+            .peek_hook_status(),
+        OnLowWasmMemoryHookStatus::Ready
+    );
+
+    // Hook is executed
+    test.execute_slice(canister_id);
+    assert_eq!(
+        test.execution_state(canister_id).wasm_memory.size,
+        NumWasmPages::new(13)
+    );
+
+    assert_eq!(
+        test.canister_state(canister_id)
+            .system_state
+            .task_queue
+            .peek_hook_status(),
+        OnLowWasmMemoryHookStatus::Executed
+    );
+
+    // Canister upgrade.
+    assert!(test
+        .upgrade_canister_v2(
+            canister_id,
+            wat::parse_str(wat).unwrap(),
+            CanisterUpgradeOptions {
+                skip_pre_upgrade: None,
+                wasm_memory_persistence: None,
+            },
+        )
+        .is_ok());
+
+    // Upgrade is executed, and the wasm_memory size reset to 1.
+    // wasm_capacity - used_wasm_memory > self.wasm_memory_threshold
+    // Hook condition is not satisfied.
+    assert_eq!(
+        test.execution_state(canister_id).wasm_memory.size,
+        NumWasmPages::new(1)
+    );
+
+    // Hook status is changed after upgrade.
+    assert_eq!(
+        test.canister_state(canister_id)
+            .system_state
+            .task_queue
+            .peek_hook_status(),
+        OnLowWasmMemoryHookStatus::ConditionNotSatisfied
+    );
+}
+
+#[test]
+fn hook_status_remains_executed_if_condition_holds_after_upgrade() {
+    let mut test = ExecutionTestBuilder::new().with_manual_execution().build();
+
+    let update_grow_mem_size = 7;
+    let hook_grow_mem_size = 5;
+
+    let wat: String =
+        get_wat_with_update_and_hook_mem_grow(update_grow_mem_size, hook_grow_mem_size, true);
+
+    let canister_id = test.canister_from_wat(wat.as_str()).unwrap();
+
+    test.canister_update_wasm_memory_limit_and_wasm_memory_threshold(
+        canister_id,
+        (20 * WASM_PAGE_SIZE_IN_BYTES as u64).into(),
+        (15 * WASM_PAGE_SIZE_IN_BYTES as u64).into(),
+    )
+    .unwrap();
+
+    // Here we have:
+    // wasm_capacity = wasm_memory_limit = 20 Wasm Pages
+    // wasm_memory_threshold = 15 Wasm Pages
+
+    // Initially wasm_memory.size = 1
+    assert_eq!(
+        test.execution_state(canister_id).wasm_memory.size,
+        NumWasmPages::new(1)
+    );
+
+    test.ingress_raw(canister_id, "grow_mem", vec![]);
+    test.ingress_raw(canister_id, "grow_mem", vec![]);
+
+    // First ingress messages gets executed.
+    // wasm_memory.size = 1 + 7 = 8
+    // wasm_capacity - used_wasm_memory < self.wasm_memory_threshold
+    // Hook condition is satisfied.
+    test.execute_slice(canister_id);
+    assert_eq!(
+        test.execution_state(canister_id).wasm_memory.size,
+        NumWasmPages::new(8)
+    );
+
+    assert_eq!(
+        test.canister_state(canister_id)
+            .system_state
+            .task_queue
+            .peek_hook_status(),
+        OnLowWasmMemoryHookStatus::Ready
+    );
+
+    // Hook is executed.
+    test.execute_slice(canister_id);
+    assert_eq!(
+        test.execution_state(canister_id).wasm_memory.size,
+        NumWasmPages::new(13)
+    );
+    assert_eq!(
+        test.canister_state(canister_id)
+            .system_state
+            .task_queue
+            .peek_hook_status(),
+        OnLowWasmMemoryHookStatus::Executed
+    );
+
+    // Upgrade canister.
+    let result = test.upgrade_canister_v2(
+        canister_id,
+        wat::parse_str(wat).unwrap(),
+        CanisterUpgradeOptions {
+            skip_pre_upgrade: None,
+            wasm_memory_persistence: Some(WasmMemoryPersistence::Keep),
+        },
+    );
+    assert_eq!(result, Ok(()));
+
+    // Hook condition is still satisfied.
+    // wasm_capacity - used_wasm_memory < self.wasm_memory_threshold
+    assert_eq!(
+        test.execution_state(canister_id).wasm_memory.size,
+        NumWasmPages::new(13)
+    );
+
+    // Hence hook status should remain executed.
+    assert_eq!(
+        test.canister_state(canister_id)
+            .system_state
+            .task_queue
+            .peek_hook_status(),
+        OnLowWasmMemoryHookStatus::Executed
+    );
+}
+
+#[test]
+fn upgrade_changes_hook_status_to_ready() {
+    let wat = r#"(module
+            (func (export "canister_global_timer")
+                (drop (memory.grow (i32.const 10)))
+            )
+            (memory 1 20)
+        )"#;
+    let mut test = ExecutionTestBuilder::new().with_manual_execution().build();
+
+    let canister_id = test.canister_from_wat(wat).unwrap();
+
+    test.canister_update_wasm_memory_limit_and_wasm_memory_threshold(
+        canister_id,
+        (10 * WASM_PAGE_SIZE_IN_BYTES as u64).into(),
+        (9 * WASM_PAGE_SIZE_IN_BYTES as u64).into(),
+    )
+    .unwrap();
+
+    // Here we have:
+    // wasm_capacity = wasm_memory_limit = 10 Wasm Pages
+    // wasm_memory_threshold = 9 Wasm Pages
+
+    // Initially wasm_memory.size = 1
+    // wasm_memory_limit - used_wasm_memory = wasm_memory_threshold
+    // Hook condition is not satisfied.
+    assert_eq!(
+        test.execution_state(canister_id).wasm_memory.size,
+        NumWasmPages::new(1)
+    );
+
+    assert_eq!(
+        test.canister_state(canister_id)
+            .system_state
+            .task_queue
+            .peek_hook_status(),
+        OnLowWasmMemoryHookStatus::ConditionNotSatisfied
+    );
+
+    let wat2 = r#"(module
+        (func (export "canister_global_timer")
+            (drop (memory.grow (i32.const 10)))
+        )
+        (memory 2 2)
+    )"#;
+
+    // Canister upgrade.
+    assert!(test
+        .upgrade_canister_v2(
+            canister_id,
+            wat::parse_str(wat2).unwrap(),
+            CanisterUpgradeOptions {
+                skip_pre_upgrade: None,
+                wasm_memory_persistence: None,
+            },
+        )
+        .is_ok());
+
+    // Upgrade is executed, and the used_wasm_memory size is 2.
+    // wasm_capacity - used_wasm_memory < self.wasm_memory_threshold
+    // Hook condition is satisfied.
+    assert_eq!(
+        test.execution_state(canister_id).wasm_memory.size,
+        NumWasmPages::new(2)
+    );
+
+    // Hook status is changed after upgrade.
+    assert_eq!(
+        test.canister_state(canister_id)
+            .system_state
+            .task_queue
+            .peek_hook_status(),
+        OnLowWasmMemoryHookStatus::Ready
     );
 }
 


### PR DESCRIPTION
This PR adds code coverage and tests the behavior of the low wasm memory hook in different situations depending on the used wasm memory before and after canister upgrade.