### PR TITLE
chore: Bump canbench to 0.1.9

### DIFF
--- a/Cargo.Bazel.Fuzzing.json.lock
+++ b/Cargo.Bazel.Fuzzing.json.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "d2f87afb142226b1d1eb89350d6c0bd83a38fc74283613f613b6058561be115f",
+  "checksum": "6bed8641f4af14470e0877f17b229644fb9c504d547b34b773230c601c91046b",
   "crates": {
     "abnf 0.12.0": {
       "name": "abnf",
@@ -10567,14 +10567,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "canbench 0.1.8": {
+    "canbench 0.1.9": {
       "name": "canbench",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "package_url": "https://github.com/dfinity/canbench",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/canbench/0.1.8/download",
-          "sha256": "cb548f9e006ad29b160d37e07435c499af7d2741918e18d95ddc87dfe97a0b8d"
+          "url": "https://static.crates.io/crates/canbench/0.1.9/download",
+          "sha256": "c3eba78c84aa78e67f27c5c5a7d6c3d33cc301f95886171748e8f6ed8a31b258"
         }
       },
       "targets": [
@@ -10611,7 +10611,7 @@
         "deps": {
           "common": [
             {
-              "id": "canbench-rs 0.1.8",
+              "id": "canbench-rs 0.1.9",
               "target": "canbench_rs"
             },
             {
@@ -10670,7 +10670,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.1.8"
+        "version": "0.1.9"
       },
       "license": "Apache-2.0",
       "license_ids": [
@@ -10678,14 +10678,14 @@
       ],
       "license_file": null
     },
-    "canbench-rs 0.1.8": {
+    "canbench-rs 0.1.9": {
       "name": "canbench-rs",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "package_url": "https://github.com/dfinity/canbench",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/canbench-rs/0.1.8/download",
-          "sha256": "497d900e11ab1891dd9743dd45dbeaada540ce323aa1adc7fc0ce1da2c6e86ff"
+          "url": "https://static.crates.io/crates/canbench-rs/0.1.9/download",
+          "sha256": "588701e2d05679b79603acca6a6f8b78fe0d21f5f7a9c06fe689f769ae797008"
         }
       },
       "targets": [
@@ -10728,13 +10728,13 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "canbench-rs-macros 0.1.8",
+              "id": "canbench-rs-macros 0.1.9",
               "target": "canbench_rs_macros"
             }
           ],
           "selects": {}
         },
-        "version": "0.1.8"
+        "version": "0.1.9"
       },
       "license": "Apache-2.0",
       "license_ids": [
@@ -10742,14 +10742,14 @@
       ],
       "license_file": null
     },
-    "canbench-rs-macros 0.1.8": {
+    "canbench-rs-macros 0.1.9": {
       "name": "canbench-rs-macros",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "package_url": "https://github.com/dfinity/canbench",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/canbench-rs-macros/0.1.8/download",
-          "sha256": "5a5509bcfe6eeb86f057d46fbf20a2ba6b6bf9a1099b053a8f491cd7a909dfa6"
+          "url": "https://static.crates.io/crates/canbench-rs-macros/0.1.9/download",
+          "sha256": "e05fe21a7dfc85c3be8e40edbbcb3fe23b4c070fac4741eff18129f1d0f11aa9"
         }
       },
       "targets": [
@@ -10789,7 +10789,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.1.8"
+        "version": "0.1.9"
       },
       "license": "Apache-2.0",
       "license_ids": [
@@ -13415,7 +13415,7 @@
         "Git": {
           "remote": "https://github.com/dfinity/cloudflare-rs.git",
           "commitish": {
-            "Rev": "a6538a036926bd756986c9c0a5de356daef48881"
+            "Rev": "0b1805bf11ed526445712559e6f18d3b8e024b06"
           },
           "strip_prefix": "cloudflare"
         }
@@ -19663,11 +19663,11 @@
               "target": "cached"
             },
             {
-              "id": "canbench 0.1.8",
+              "id": "canbench 0.1.9",
               "target": "canbench"
             },
             {
-              "id": "canbench-rs 0.1.8",
+              "id": "canbench-rs 0.1.9",
               "target": "canbench_rs"
             },
             {
@@ -90188,7 +90188,7 @@
     }
   },
   "binary_crates": [
-    "canbench 0.1.8",
+    "canbench 0.1.9",
     "ic-wasm 0.8.4",
     "metrics-proxy 0.1.0"
   ],
@@ -91296,8 +91296,8 @@
     "byteorder 1.5.0",
     "bytes 1.9.0",
     "cached 0.49.2",
-    "canbench 0.1.8",
-    "canbench-rs 0.1.8",
+    "canbench 0.1.9",
+    "canbench-rs 0.1.9",
     "candid 0.10.13",
     "candid_parser 0.1.2",
     "cargo_metadata 0.14.2",

--- a/Cargo.Bazel.Fuzzing.toml.lock
+++ b/Cargo.Bazel.Fuzzing.toml.lock
@@ -1784,9 +1784,9 @@ dependencies = [
 
 [[package]]
 name = "canbench"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb548f9e006ad29b160d37e07435c499af7d2741918e18d95ddc87dfe97a0b8d"
+checksum = "c3eba78c84aa78e67f27c5c5a7d6c3d33cc301f95886171748e8f6ed8a31b258"
 dependencies = [
  "canbench-rs",
  "candid",
@@ -1806,9 +1806,9 @@ dependencies = [
 
 [[package]]
 name = "canbench-rs"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "497d900e11ab1891dd9743dd45dbeaada540ce323aa1adc7fc0ce1da2c6e86ff"
+checksum = "588701e2d05679b79603acca6a6f8b78fe0d21f5f7a9c06fe689f769ae797008"
 dependencies = [
  "canbench-rs-macros",
  "candid",
@@ -1818,9 +1818,9 @@ dependencies = [
 
 [[package]]
 name = "canbench-rs-macros"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5509bcfe6eeb86f057d46fbf20a2ba6b6bf9a1099b053a8f491cd7a909dfa6"
+checksum = "e05fe21a7dfc85c3be8e40edbbcb3fe23b4c070fac4741eff18129f1d0f11aa9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2182,7 +2182,7 @@ dependencies = [
 [[package]]
 name = "cloudflare"
 version = "0.12.0"
-source = "git+https://github.com/dfinity/cloudflare-rs.git?rev=a6538a036926bd756986c9c0a5de356daef48881#a6538a036926bd756986c9c0a5de356daef48881"
+source = "git+https://github.com/dfinity/cloudflare-rs.git?rev=0b1805bf11ed526445712559e6f18d3b8e024b06#0b1805bf11ed526445712559e6f18d3b8e024b06"
 dependencies = [
  "chrono",
  "http 0.2.12",
@@ -3233,7 +3233,7 @@ dependencies = [
  "ciborium",
  "cidr",
  "clap 4.5.20",
- "cloudflare 0.12.0 (git+https://github.com/dfinity/cloudflare-rs.git?rev=a6538a036926bd756986c9c0a5de356daef48881)",
+ "cloudflare 0.12.0 (git+https://github.com/dfinity/cloudflare-rs.git?rev=0b1805bf11ed526445712559e6f18d3b8e024b06)",
  "colored",
  "comparable",
  "console 0.11.3",

--- a/Cargo.Bazel.json.lock
+++ b/Cargo.Bazel.json.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "bfc8ee26e96128dcc97b852714a8aba08b1b808bc98b6f33406e6d73098eb224",
+  "checksum": "33919baeab8c98c77bdaab8b898698318b1076055c731d76e84d3e185ddb2c74",
   "crates": {
     "abnf 0.12.0": {
       "name": "abnf",
@@ -10484,14 +10484,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "canbench 0.1.8": {
+    "canbench 0.1.9": {
       "name": "canbench",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "package_url": "https://github.com/dfinity/canbench",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/canbench/0.1.8/download",
-          "sha256": "cb548f9e006ad29b160d37e07435c499af7d2741918e18d95ddc87dfe97a0b8d"
+          "url": "https://static.crates.io/crates/canbench/0.1.9/download",
+          "sha256": "c3eba78c84aa78e67f27c5c5a7d6c3d33cc301f95886171748e8f6ed8a31b258"
         }
       },
       "targets": [
@@ -10528,7 +10528,7 @@
         "deps": {
           "common": [
             {
-              "id": "canbench-rs 0.1.8",
+              "id": "canbench-rs 0.1.9",
               "target": "canbench_rs"
             },
             {
@@ -10587,7 +10587,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.1.8"
+        "version": "0.1.9"
       },
       "license": "Apache-2.0",
       "license_ids": [
@@ -10595,14 +10595,14 @@
       ],
       "license_file": null
     },
-    "canbench-rs 0.1.8": {
+    "canbench-rs 0.1.9": {
       "name": "canbench-rs",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "package_url": "https://github.com/dfinity/canbench",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/canbench-rs/0.1.8/download",
-          "sha256": "497d900e11ab1891dd9743dd45dbeaada540ce323aa1adc7fc0ce1da2c6e86ff"
+          "url": "https://static.crates.io/crates/canbench-rs/0.1.9/download",
+          "sha256": "588701e2d05679b79603acca6a6f8b78fe0d21f5f7a9c06fe689f769ae797008"
         }
       },
       "targets": [
@@ -10645,13 +10645,13 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "canbench-rs-macros 0.1.8",
+              "id": "canbench-rs-macros 0.1.9",
               "target": "canbench_rs_macros"
             }
           ],
           "selects": {}
         },
-        "version": "0.1.8"
+        "version": "0.1.9"
       },
       "license": "Apache-2.0",
       "license_ids": [
@@ -10659,14 +10659,14 @@
       ],
       "license_file": null
     },
-    "canbench-rs-macros 0.1.8": {
+    "canbench-rs-macros 0.1.9": {
       "name": "canbench-rs-macros",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "package_url": "https://github.com/dfinity/canbench",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/canbench-rs-macros/0.1.8/download",
-          "sha256": "5a5509bcfe6eeb86f057d46fbf20a2ba6b6bf9a1099b053a8f491cd7a909dfa6"
+          "url": "https://static.crates.io/crates/canbench-rs-macros/0.1.9/download",
+          "sha256": "e05fe21a7dfc85c3be8e40edbbcb3fe23b4c070fac4741eff18129f1d0f11aa9"
         }
       },
       "targets": [
@@ -10706,7 +10706,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.1.8"
+        "version": "0.1.9"
       },
       "license": "Apache-2.0",
       "license_ids": [
@@ -19491,11 +19491,11 @@
               "target": "cached"
             },
             {
-              "id": "canbench 0.1.8",
+              "id": "canbench 0.1.9",
               "target": "canbench"
             },
             {
-              "id": "canbench-rs 0.1.8",
+              "id": "canbench-rs 0.1.9",
               "target": "canbench_rs"
             },
             {
@@ -90179,7 +90179,7 @@
     }
   },
   "binary_crates": [
-    "canbench 0.1.8",
+    "canbench 0.1.9",
     "ic-wasm 0.8.4",
     "metrics-proxy 0.1.0"
   ],
@@ -91209,8 +91209,8 @@
     "byteorder 1.5.0",
     "bytes 1.9.0",
     "cached 0.49.2",
-    "canbench 0.1.8",
-    "canbench-rs 0.1.8",
+    "canbench 0.1.9",
+    "canbench-rs 0.1.9",
     "candid 0.10.13",
     "candid_parser 0.1.2",
     "cargo_metadata 0.14.2",

--- a/Cargo.Bazel.toml.lock
+++ b/Cargo.Bazel.toml.lock
@@ -1785,9 +1785,9 @@ dependencies = [
 
 [[package]]
 name = "canbench"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb548f9e006ad29b160d37e07435c499af7d2741918e18d95ddc87dfe97a0b8d"
+checksum = "c3eba78c84aa78e67f27c5c5a7d6c3d33cc301f95886171748e8f6ed8a31b258"
 dependencies = [
  "canbench-rs",
  "candid",
@@ -1807,9 +1807,9 @@ dependencies = [
 
 [[package]]
 name = "canbench-rs"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "497d900e11ab1891dd9743dd45dbeaada540ce323aa1adc7fc0ce1da2c6e86ff"
+checksum = "588701e2d05679b79603acca6a6f8b78fe0d21f5f7a9c06fe689f769ae797008"
 dependencies = [
  "canbench-rs-macros",
  "candid",
@@ -1819,9 +1819,9 @@ dependencies = [
 
 [[package]]
 name = "canbench-rs-macros"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5509bcfe6eeb86f057d46fbf20a2ba6b6bf9a1099b053a8f491cd7a909dfa6"
+checksum = "e05fe21a7dfc85c3be8e40edbbcb3fe23b4c070fac4741eff18129f1d0f11aa9"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/bazel/external_crates.bzl
+++ b/bazel/external_crates.bzl
@@ -332,10 +332,10 @@ def external_crates_repository(name, cargo_lockfile, lockfile, sanitizers_enable
                 default_features = False,
             ),
             "canbench": crate.spec(
-                version = "^0.1.8",
+                version = "^0.1.9",
             ),
             "canbench-rs": crate.spec(
-                version = "^0.1.8",
+                version = "^0.1.9",
             ),
             "candid": crate.spec(
                 version = "^0.10.13",


### PR DESCRIPTION
# Motivation

Bump the canbench to [0.1.9](https://github.com/dfinity/canbench/releases/tag/v0.1.9) so that custom noise threshold can be set.