### PR TITLE
perf(nns): Set NNS Governance governance noise threshold to 5%

### DIFF
--- a/bazel/canbench.bzl
+++ b/bazel/canbench.bzl
@@ -17,6 +17,8 @@ def rust_canbench(name, results_file, add_test = False, opt = "3", noise_thresho
         add_test: If True add an additional :${name}_test rule that fails if canbench benchmark fails.
         opt: The optimization level to use for the rust_binary compilation.
         **kwargs: Additional arguments to pass to rust_binary.
+        noise_threshold: The noise threshold to use for the benchmark. If None, the default value from
+            canbench is used.
     """
 
     rust_binary(

--- a/bazel/canbench.bzl
+++ b/bazel/canbench.bzl
@@ -5,7 +5,7 @@ This module defines functions to run benchmarks using canbench.
 load("@rules_rust//rust:defs.bzl", "rust_binary")
 load("//bazel:canisters.bzl", "wasm_rust_binary_rule")
 
-def rust_canbench(name, results_file, add_test = False, opt = "3", **kwargs):
+def rust_canbench(name, results_file, add_test = False, opt = "3", noise_threshold = None, **kwargs):
     """ Run a Rust benchmark using canbench. 
 
     This creates 2 executable rules: :${name} for running the benchmark and :${name}_update for
@@ -49,6 +49,9 @@ def rust_canbench(name, results_file, add_test = False, opt = "3", **kwargs):
         # Hack to escape the sandbox and update the actual repository
         "WORKSPACE": "$(rootpath //:WORKSPACE.bazel)",
     }
+
+    if noise_threshold:
+        env["NOISE_THRESHOLD"] = str(noise_threshold)
 
     native.sh_binary(
         name = name,

--- a/bazel/canbench.sh
+++ b/bazel/canbench.sh
@@ -9,6 +9,8 @@
 #     - updated if --update is specified.
 #     - used for comparison if it's not empty.
 # - WASM_PATH: Path to the wasm file to be benchmarked.
+# - NOISE_THRESHOLD: The noise threshold in percentage. If the difference between the current
+#     benchmark and the results file is above this threshold, the benchmark test will fail.
 
 set -eEuo pipefail
 
@@ -28,8 +30,6 @@ if [ -s "${REPO_RESULTS_PATH}" ]; then
     echo "  ${REPO_RESULTS_PATH}" >>${CANBENCH_YML}
 fi
 
-echo ${RUNFILES}
-
 if [ $# -eq 0 ]; then
     # Runs the benchmark without updating the results file.
     ${CANBENCH_BIN} --no-runtime-integrity-check --runtime-path ${POCKET_IC_BIN}
@@ -43,8 +43,14 @@ elif [ "$1" = "--update" ]; then
         cp "${RUNFILES}/canbench_results.yml" "${REPO_RESULTS_PATH}"
     fi
 else
+    if [[ -z "${NOISE_THRESHOLD}" ]]; then
+        NOISE_THRESHOLD_ARG=""
+    else
+        NOISE_THRESHOLD_ARG="--noise-threshold ${NOISE_THRESHOLD}"
+    fi
+
     # Runs the benchmark test that fails if the diffs are new or above the threshold.
-    ${CANBENCH_BIN} --no-runtime-integrity-check --runtime-path ${POCKET_IC_BIN} >$CANBENCH_OUTPUT
+    ${CANBENCH_BIN} --no-runtime-integrity-check --runtime-path ${POCKET_IC_BIN} ${NOISE_THRESHOLD_ARG} >$CANBENCH_OUTPUT
     if grep -q "(regress\|(improved by \|(new)" "$CANBENCH_OUTPUT"; then
         cat "$CANBENCH_OUTPUT"
         echo "**\`$REPO_RESULTS_PATH\` is not up to date ❌**

--- a/bazel/canbench.sh
+++ b/bazel/canbench.sh
@@ -43,12 +43,7 @@ elif [ "$1" = "--update" ]; then
         cp "${RUNFILES}/canbench_results.yml" "${REPO_RESULTS_PATH}"
     fi
 else
-    if [[ -z "${NOISE_THRESHOLD}" ]]; then
-        NOISE_THRESHOLD_ARG=""
-    else
-        NOISE_THRESHOLD_ARG="--noise-threshold ${NOISE_THRESHOLD}"
-    fi
-
+    NOISE_THRESHOLD_ARG="${NOISE_THRESHOLD:+--noise-threshold ${NOISE_THRESHOLD}}"
     # Runs the benchmark test that fails if the diffs are new or above the threshold.
     ${CANBENCH_BIN} --no-runtime-integrity-check --runtime-path ${POCKET_IC_BIN} ${NOISE_THRESHOLD_ARG} >$CANBENCH_OUTPUT
     if grep -q "(regress\|(improved by \|(new)" "$CANBENCH_OUTPUT"; then

--- a/rs/nns/governance/BUILD.bazel
+++ b/rs/nns/governance/BUILD.bazel
@@ -223,6 +223,7 @@ rust_canbench(
     # We would like to figure out why and fix it, but for now, we are reducing the optimization
     # level so that tests against the optimization level can be added.
     opt = "s",
+    noise_threshold = 5.0,
     results_file = "canbench/canbench_results.yml",
     deps = [
         # Keep sorted.

--- a/rs/nns/governance/BUILD.bazel
+++ b/rs/nns/governance/BUILD.bazel
@@ -219,11 +219,11 @@ rust_canbench(
     name = "governance-canbench",
     srcs = ["canbench/main.rs"],
     add_test = True,
+    noise_threshold = 5.0,
     # For some reason, the NNS Governance benchmarks are sensitive to the optimization level.
     # We would like to figure out why and fix it, but for now, we are reducing the optimization
     # level so that tests against the optimization level can be added.
     opt = "s",
-    noise_threshold = 5.0,
     results_file = "canbench/canbench_results.yml",
     deps = [
         # Keep sorted.


### PR DESCRIPTION
# Motivation

NNS Governance benchmarks sometimes have variance slightly over 2%. Overall, the loss of productivity (in updating the results file and resolve conflicts) doesn't seem to be worth the benefit of keeping a tight threshold.