### PR TITLE
feat(ICRC_Ledger): FI-1664: Forbid setting interpreted ICRC ledger metadata

### DIFF
--- a/rs/ledger_suite/icrc1/ledger/tests/tests.rs
+++ b/rs/ledger_suite/icrc1/ledger/tests/tests.rs
@@ -248,6 +248,20 @@ fn encode_init_args_with_small_sized_archive(
     }
 }
 
+fn encode_init_args_with_provided_metadata(
+    args: ic_ledger_suite_state_machine_tests::InitArgs,
+) -> LedgerArgument {
+    match encode_init_args(args.clone()) {
+        LedgerArgument::Init(mut init_args) => {
+            init_args.metadata = args.metadata;
+            LedgerArgument::Init(init_args)
+        }
+        LedgerArgument::Upgrade(_) => {
+            panic!("BUG: Expected Init argument")
+        }
+    }
+}
+
 fn encode_upgrade_args() -> LedgerArgument {
     LedgerArgument::Upgrade(None)
 }
@@ -695,6 +709,22 @@ fn icrc1_test_upgrade_from_v1_not_possible() {
         ledger_mainnet_v1_wasm(),
         ledger_wasm(),
         encode_init_args,
+    );
+}
+
+#[test]
+fn test_setting_forbidden_metadata_in_init_works_in_v3_ledger() {
+    ic_ledger_suite_state_machine_tests::metadata::test_setting_forbidden_metadata_works_in_v3_ledger(
+        ledger_mainnet_v3_wasm(),
+        encode_init_args_with_provided_metadata,
+    );
+}
+
+#[test]
+fn test_setting_forbidden_metadata_not_possible() {
+    ic_ledger_suite_state_machine_tests::metadata::test_setting_forbidden_metadata_not_possible(
+        ledger_wasm(),
+        encode_init_args_with_provided_metadata,
     );
 }
 


### PR DESCRIPTION
Disallow setting the following metadata in the initialization and upgrade arguments of the ICRC ledger:

- `icrc1:symbol`
- `icrc1:name`
- `icrc1:decimals`
- `icrc1:fee`
- `icrc1:max_memo_length`

These fields are already set explicitly in the arguments, from there the ledger reads them and interprets them. Setting them in the vector of metadata is confusing, since they are then returned in the response to `icrc1_metadata` queries, but they have no effect on the operation of the ledger.