### PR TITLE
fix: reduce the bitcoin adapter maximum response size to 1MB for testnet4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6232,6 +6232,7 @@ dependencies = [
  "serde_json",
  "slog",
  "slog-async",
+ "static_assertions",
  "tempfile",
  "thiserror 2.0.11",
  "tokio",

--- a/rs/bitcoin/adapter/BUILD.bazel
+++ b/rs/bitcoin/adapter/BUILD.bazel
@@ -22,6 +22,7 @@ DEPENDENCIES = [
     "@crate_index//:serde_json",
     "@crate_index//:slog",
     "@crate_index//:slog-async",
+    "@crate_index//:static_assertions",
     "@crate_index//:thiserror",
     "@crate_index//:tokio",
     "@crate_index//:tokio-socks",
@@ -42,7 +43,6 @@ DEV_DEPENDENCIES = [
     "@crate_index//:bitcoind",
     "@crate_index//:criterion",
     "@crate_index//:ic-btc-interface",
-    "@crate_index//:static_assertions",
     "@crate_index//:tempfile",
 ]
 

--- a/rs/bitcoin/adapter/BUILD.bazel
+++ b/rs/bitcoin/adapter/BUILD.bazel
@@ -42,6 +42,7 @@ DEV_DEPENDENCIES = [
     "@crate_index//:bitcoind",
     "@crate_index//:criterion",
     "@crate_index//:ic-btc-interface",
+    "@crate_index//:static_assertions",
     "@crate_index//:tempfile",
 ]
 

--- a/rs/bitcoin/adapter/Cargo.toml
+++ b/rs/bitcoin/adapter/Cargo.toml
@@ -30,6 +30,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 slog = { workspace = true }
 slog-async = { workspace = true }
+static_assertions = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 tokio-socks = "0.5.1"
@@ -46,7 +47,6 @@ ic-btc-interface = { workspace = true }
 ic-btc-replica-types = { path = "../replica_types" }
 ic-interfaces-adapter-client = { path = "../../interfaces/adapter_client" }
 ic-test-utilities-logger = { path = "../../test_utilities/logger" }
-static_assertions = { workspace = true }
 tempfile = { workspace = true }
 
 [[bench]]

--- a/rs/bitcoin/adapter/Cargo.toml
+++ b/rs/bitcoin/adapter/Cargo.toml
@@ -46,6 +46,7 @@ ic-btc-interface = { workspace = true }
 ic-btc-replica-types = { path = "../replica_types" }
 ic-interfaces-adapter-client = { path = "../../interfaces/adapter_client" }
 ic-test-utilities-logger = { path = "../../test_utilities/logger" }
+static_assertions = { workspace = true }
 tempfile = { workspace = true }
 
 [[bench]]

--- a/rs/bitcoin/adapter/src/get_successors_handler.rs
+++ b/rs/bitcoin/adapter/src/get_successors_handler.rs
@@ -20,7 +20,7 @@ use crate::{
 //
 // NOTE: Should be = the `MAX_RESPONSE_SIZE` defined in `replicated_state/bitcoin.rs`
 // for pagination on the replica side to work as expected.
-const MAINNET_MAX_RESPONSE_SIZE: usize = 2_000_000;
+const MAX_RESPONSE_SIZE: usize = 2_000_000;
 
 // Lower than mainnet's response size. The main reason is large serialization time
 // for large blocks.
@@ -41,14 +41,11 @@ const MAX_NEXT_BYTES: usize = MAX_NEXT_BLOCK_HEADERS_LENGTH * BLOCK_HEADER_SIZE;
 // The maximum number of bytes the `blocks` in a response can take.
 // NOTE: This is a soft limit, and is only honored if there's > 1 blocks already in the response.
 // Having this as a soft limit as necessary to prevent large blocks from stalling consensus.
-const MAINNET_MAX_BLOCKS_BYTES: usize = MAINNET_MAX_RESPONSE_SIZE - MAX_NEXT_BYTES;
+const MAX_BLOCKS_BYTES: usize = MAX_RESPONSE_SIZE - MAX_NEXT_BYTES;
 
 const TESTNET4_MAX_BLOCKS_BYTES: usize = TESTNET4_MAX_RESPONSE_SIZE - MAX_NEXT_BYTES;
 
-const_assert_eq!(
-    MAX_NEXT_BYTES + MAINNET_MAX_BLOCKS_BYTES,
-    MAINNET_MAX_RESPONSE_SIZE
-);
+const_assert_eq!(MAX_NEXT_BYTES + MAX_BLOCKS_BYTES, MAX_RESPONSE_SIZE);
 const_assert_eq!(
     MAX_NEXT_BYTES + TESTNET4_MAX_BLOCKS_BYTES,
     TESTNET4_MAX_RESPONSE_SIZE
@@ -181,11 +178,8 @@ fn get_successor_blocks(
         .unwrap_or_default();
 
     let max_blocks_size = match network {
-        Network::Testnet | Network::Signet | Network::Regtest | Network::Bitcoin => {
-            MAINNET_MAX_BLOCKS_BYTES
-        }
         Network::Testnet4 => TESTNET4_MAX_BLOCKS_BYTES,
-        other => unreachable!("Unsupported network: {:?}", other),
+        _ => MAX_BLOCKS_BYTES,
     };
 
     // Compute the blocks by starting a breadth-first search.

--- a/rs/bitcoin/adapter/src/get_successors_handler.rs
+++ b/rs/bitcoin/adapter/src/get_successors_handler.rs
@@ -19,7 +19,11 @@ use crate::{
 //
 // NOTE: Should be = the `MAX_RESPONSE_SIZE` defined in `replicated_state/bitcoin.rs`
 // for pagination on the replica side to work as expected.
-const MAX_RESPONSE_SIZE: usize = 2_000_000;
+const MAINNET_MAX_RESPONSE_SIZE: usize = 2_000_000;
+
+// Lower than mainnet's response size. The main reason is large serialization time
+// for large blocks.
+const TESTNET_MAX_RESPONSE_SIZE: usize = 1_000_000;
 
 // Max number of next block headers that can be returned in the `GetSuccessorsResponse`.
 const MAX_NEXT_BLOCK_HEADERS_LENGTH: usize = 100;
@@ -36,7 +40,9 @@ const MAX_NEXT_BYTES: usize = MAX_NEXT_BLOCK_HEADERS_LENGTH * BLOCK_HEADER_SIZE;
 // The maximum number of bytes the `blocks` in a response can take.
 // NOTE: This is a soft limit, and is only honored if there's > 1 blocks already in the response.
 // Having this as a soft limit as necessary to prevent large blocks from stalling consensus.
-const MAX_BLOCKS_BYTES: usize = MAX_RESPONSE_SIZE - MAX_NEXT_BYTES;
+const MAINNET_MAX_BLOCKS_BYTES: usize = MAINNET_MAX_RESPONSE_SIZE - MAX_NEXT_BYTES;
+
+const TESTNET_MAX_BLOCKS_BYTES: usize = TESTNET_MAX_RESPONSE_SIZE - MAX_NEXT_BYTES;
 
 // Max height for sending multiple blocks when connecting the Bitcoin mainnet.
 const MAINNET_MAX_MULTI_BLOCK_ANCHOR_HEIGHT: BlockHeight = 750_000;
@@ -108,6 +114,7 @@ impl GetSuccessorsHandler {
                 &request.anchor,
                 &request.processed_block_hashes,
                 allow_multiple_blocks,
+                self.network,
             );
             let next = get_next_headers(
                 &state,
@@ -151,6 +158,7 @@ fn get_successor_blocks(
     anchor: &BlockHash,
     processed_block_hashes: &[BlockHash],
     allow_multiple_blocks: bool,
+    network: Network,
 ) -> Vec<Arc<Block>> {
     let seen: HashSet<BlockHash> = processed_block_hashes.iter().copied().collect();
 
@@ -162,6 +170,14 @@ fn get_successor_blocks(
         .map(|c| c.children.iter().collect())
         .unwrap_or_default();
 
+    let max_blocks_size = match network {
+        Network::Testnet | Network::Signet | Network::Regtest | Network::Bitcoin => {
+            MAINNET_MAX_BLOCKS_BYTES
+        }
+        Network::Testnet4 => TESTNET_MAX_BLOCKS_BYTES,
+        other => unreachable!("Unsupported network: {:?}", other),
+    };
+
     // Compute the blocks by starting a breadth-first search.
     while let Some(block_hash) = queue.pop_front() {
         if !seen.contains(block_hash) {
@@ -170,7 +186,7 @@ fn get_successor_blocks(
                 Some(block) => {
                     let block_size = block.total_size();
                     if response_block_size == 0
-                        || (response_block_size + block_size <= MAX_BLOCKS_BYTES
+                        || (response_block_size + block_size <= max_blocks_size
                             && successor_blocks.len() < MAX_BLOCKS_LENGTH
                             && allow_multiple_blocks)
                     {
@@ -783,6 +799,13 @@ mod test {
 
     #[test]
     fn response_size() {
-        assert_eq!(MAX_NEXT_BYTES + MAX_BLOCKS_BYTES, MAX_RESPONSE_SIZE);
+        assert_eq!(
+            MAX_NEXT_BYTES + MAINNET_MAX_BLOCKS_BYTES,
+            MAINNET_MAX_RESPONSE_SIZE
+        );
+        assert_eq!(
+            MAX_NEXT_BYTES + TESTNET_MAX_BLOCKS_BYTES,
+            TESTNET_MAX_RESPONSE_SIZE
+        );
     }
 }

--- a/rs/bitcoin/adapter/src/get_successors_handler.rs
+++ b/rs/bitcoin/adapter/src/get_successors_handler.rs
@@ -266,6 +266,7 @@ mod test {
 
     use bitcoin::Network;
     use ic_metrics::MetricsRegistry;
+    use static_assertions::const_assert_eq;
     use tokio::sync::mpsc::channel;
 
     use crate::config::test::ConfigBuilder;
@@ -799,11 +800,11 @@ mod test {
 
     #[test]
     fn response_size() {
-        assert_eq!(
+        const_assert_eq!(
             MAX_NEXT_BYTES + MAINNET_MAX_BLOCKS_BYTES,
             MAINNET_MAX_RESPONSE_SIZE
         );
-        assert_eq!(
+        const_assert_eq!(
             MAX_NEXT_BYTES + TESTNET_MAX_BLOCKS_BYTES,
             TESTNET_MAX_RESPONSE_SIZE
         );


### PR DESCRIPTION
Before, the total response of the `get_successors` rpc in the bitcoin adapter was 2MB, regardless of the bitcoin network. In the worst case, this lead to the response containing either :
- ~100 medium 20KB blocks, each with many small transactions, or
- 2 large 1MB blocks, each with really many small transactions

Both of those cases made serialization take really long, and the `get_successors` request would exceed the [50ms timeout in consensus](https://github.com/dfinity/ic/blob/b7a0b3d3b896cdaabc06c0ee6cd13cd54c939e67/rs/config/src/bitcoin_payload_builder_config.rs#L12).

After, the maximum response size is reduced to just 1MB for the testnet4 network. This speeds up the serialization, while not sacrificing the canister performance too much (on average, there will be 2x more requests to the adapter when the canister starts up, but after it reaches the tip, it anyway receives maximum 1 block per request).

Note that the Bitcoin mainnet network can't suffer from the same problem because:
1. Its blocks are quicker to serialize due to the transactions being larger
2. There are no storm blocks / crazy difficulty variations on it, hence the adapter will always send 1 block per response (which is anyway enforced after block height [750_000](https://github.com/dfinity/ic/blob/b7a0b3d3b896cdaabc06c0ee6cd13cd54c939e67/rs/bitcoin/adapter/src/get_successors_handler.rs#L236)).