### PR TITLE
perf(MR): Look up `SubnetIds` from a `BTreeSet` instead of from a `Vec`

### DIFF
--- a/rs/replicated_state/src/canister_state/queues.rs
+++ b/rs/replicated_state/src/canister_state/queues.rs
@@ -1124,7 +1124,7 @@ impl CanisterQueues {
         &mut self,
         request: Request,
         reject_context: RejectContext,
-        subnet_ids: &[PrincipalId],
+        subnet_ids: &BTreeSet<PrincipalId>,
     ) -> Result<(), StateError> {
         assert!(
             request.receiver == IC_00 || subnet_ids.contains(&request.receiver.get()),

--- a/rs/replicated_state/src/canister_state/queues/tests.rs
+++ b/rs/replicated_state/src/canister_state/queues/tests.rs
@@ -2689,7 +2689,7 @@ fn test_reject_subnet_output_request() {
 
     // Reject an output request without having enqueued it first.
     queues
-        .reject_subnet_output_request(request, reject_context.clone(), &[])
+        .reject_subnet_output_request(request, reject_context.clone(), &BTreeSet::new())
         .unwrap();
 
     // There is now a reject response.

--- a/rs/replicated_state/src/canister_state/system_state.rs
+++ b/rs/replicated_state/src/canister_state/system_state.rs
@@ -1152,7 +1152,7 @@ impl SystemState {
         &mut self,
         request: Request,
         reject_context: RejectContext,
-        subnet_ids: &[PrincipalId],
+        subnet_ids: &BTreeSet<PrincipalId>,
     ) -> Result<(), StateError> {
         assert_eq!(
             request.sender, self.canister_id,

--- a/rs/system_api/src/sandbox_safe_system_state.rs
+++ b/rs/system_api/src/sandbox_safe_system_state.rs
@@ -151,7 +151,7 @@ impl SystemStateModifications {
 
     fn reject_subnet_message_routing(
         system_state: &mut SystemState,
-        subnet_ids: &[PrincipalId],
+        subnet_ids: &BTreeSet<PrincipalId>,
         msg: Request,
         err: ResolveDestinationError,
         logger: &ReplicaLogger,
@@ -178,7 +178,7 @@ impl SystemStateModifications {
 
     fn reject_subnet_message_user_error(
         system_state: &mut SystemState,
-        subnet_ids: &[PrincipalId],
+        subnet_ids: &BTreeSet<PrincipalId>,
         msg: Request,
         err: UserError,
         logger: &ReplicaLogger,
@@ -367,7 +367,7 @@ impl SystemStateModifications {
         // Push outgoing messages.
         let mut callback_changes = BTreeMap::new();
         let nns_subnet_id = network_topology.nns_subnet_id;
-        let subnet_ids: Vec<PrincipalId> =
+        let subnet_ids: BTreeSet<PrincipalId> =
             network_topology.subnets.keys().map(|s| s.get()).collect();
         for mut msg in self.requests {
             if msg.receiver == IC_00 {


### PR DESCRIPTION
This is a minor optimization that has `SystemStateModifications::apply_changes()` build a `BTreeSet<SubnetId>` instead of a `Vec<SubnetId>`, since the resulting collection is only ever used for looking up specific `SubnetIds`.