### PR TITLE
test(nns): Use vanilla NNS governance WASM in test of follow pruning.

### DIFF
--- a/rs/nns/integration_tests/src/neuron_following.rs
+++ b/rs/nns/integration_tests/src/neuron_following.rs
@@ -13,7 +13,7 @@ use ic_nns_governance_api::pb::v1::{
 };
 use ic_nns_governance_init::GovernanceCanisterInitPayloadBuilder;
 use ic_nns_test_utils::{
-    common::{build_test_governance_wasm, NnsInitPayloadsBuilder},
+    common::{build_governance_wasm, NnsInitPayloadsBuilder},
     neuron_helpers::{
         get_neuron_1, get_neuron_2, get_neuron_3, get_nonexistent_neuron, get_unauthorized_neuron,
         submit_proposal, TestNeuronOwner,
@@ -485,10 +485,7 @@ async fn test_prune_some_following() {
         "NNS Governance",
         GOVERNANCE_CANISTER_ID,
         governance_proto.encode_to_vec(),
-        // TODO(NNS1-3446): Once following pruning is released, replace with
-        // vanilla build_governance_wasm(). For now, the feature is only enabled
-        // when built with feature = "test".
-        build_test_governance_wasm(),
+        build_governance_wasm(),
         Some(ROOT_CANISTER_ID.get()),
     )
     .await;
@@ -635,7 +632,7 @@ async fn test_backfill_voting_power_refreshed_timestamps() {
         "NNS Governance",
         GOVERNANCE_CANISTER_ID,
         governance_proto.encode_to_vec(),
-        build_test_governance_wasm(),
+        build_governance_wasm(),
         Some(ROOT_CANISTER_ID.get()),
     )
     .await;


### PR DESCRIPTION
Instead of build with `feature = "test"`.

"test" was required originally, because the feature had not been enabled yet. The feature has since been enabled.