### PR TITLE
chore(nns): Delete flags related to periodic confirmation of following.

### DIFF
--- a/rs/nns/governance/canister/canister.rs
+++ b/rs/nns/governance/canister/canister.rs
@@ -21,8 +21,7 @@ use ic_nns_constants::LEDGER_CANISTER_ID;
 #[cfg(feature = "test")]
 use ic_nns_governance::governance::TimeWarp as GovTimeWarp;
 use ic_nns_governance::{
-    canister_state::CanisterEnv,
-    canister_state::{governance, governance_mut, set_governance},
+    canister_state::{governance, governance_mut, set_governance, CanisterEnv},
     encode_metrics,
     governance::Governance,
     neuron_data_validation::NeuronDataValidationSummary,

--- a/rs/nns/governance/src/lib.rs
+++ b/rs/nns/governance/src/lib.rs
@@ -200,9 +200,6 @@ pub const DEFAULT_VOTING_POWER_REFRESHED_TIMESTAMP_SECONDS: u64 = 1725148800;
 // leave this here indefinitely, but it will just be clutter after a modest
 // amount of time.
 thread_local! {
-    // TODO(NNS1-3601): Delete these (assuming all goes well, ofc) in mid March.
-    // There is already a draft PR for this.
-    static IS_VOTING_POWER_ADJUSTMENT_ENABLED: Cell<bool> = const { Cell::new(true) };
     static IS_PRUNE_FOLLOWING_ENABLED: Cell<bool> = const { Cell::new(true) };
 
     static ALLOW_ACTIVE_NEURONS_IN_STABLE_MEMORY: Cell<bool> = const { Cell::new(true) };
@@ -224,22 +221,6 @@ thread_local! {
     // begun. (This occurs in one of the prune_some_following functions.)
     static CURRENT_PRUNE_FOLLOWING_FULL_CYCLE_START_TIMESTAMP_SECONDS: Cell<u64> =
         const { Cell::new(0) };
-}
-
-pub fn is_voting_power_adjustment_enabled() -> bool {
-    IS_VOTING_POWER_ADJUSTMENT_ENABLED.get()
-}
-
-/// Only integration tests should use this.
-#[cfg(any(test, feature = "canbench-rs", feature = "test"))]
-pub fn temporarily_enable_voting_power_adjustment() -> Temporary {
-    Temporary::new(&IS_VOTING_POWER_ADJUSTMENT_ENABLED, true)
-}
-
-/// Only integration tests should use this.
-#[cfg(any(test, feature = "canbench-rs", feature = "test"))]
-pub fn temporarily_disable_voting_power_adjustment() -> Temporary {
-    Temporary::new(&IS_VOTING_POWER_ADJUSTMENT_ENABLED, false)
 }
 
 pub fn is_prune_following_enabled() -> bool {

--- a/rs/nns/governance/src/lib.rs
+++ b/rs/nns/governance/src/lib.rs
@@ -200,8 +200,6 @@ pub const DEFAULT_VOTING_POWER_REFRESHED_TIMESTAMP_SECONDS: u64 = 1725148800;
 // leave this here indefinitely, but it will just be clutter after a modest
 // amount of time.
 thread_local! {
-    static IS_PRUNE_FOLLOWING_ENABLED: Cell<bool> = const { Cell::new(true) };
-
     static ALLOW_ACTIVE_NEURONS_IN_STABLE_MEMORY: Cell<bool> = const { Cell::new(true) };
 
     static MIGRATE_ACTIVE_NEURONS_TO_STABLE_MEMORY: Cell<bool> = const { Cell::new(true) };
@@ -221,22 +219,6 @@ thread_local! {
     // begun. (This occurs in one of the prune_some_following functions.)
     static CURRENT_PRUNE_FOLLOWING_FULL_CYCLE_START_TIMESTAMP_SECONDS: Cell<u64> =
         const { Cell::new(0) };
-}
-
-pub fn is_prune_following_enabled() -> bool {
-    IS_PRUNE_FOLLOWING_ENABLED.get()
-}
-
-/// Only integration tests should use this.
-#[cfg(any(test, feature = "canbench-rs", feature = "test"))]
-pub fn temporarily_enable_prune_following() -> Temporary {
-    Temporary::new(&IS_PRUNE_FOLLOWING_ENABLED, true)
-}
-
-/// Only integration tests should use this.
-#[cfg(any(test, feature = "canbench-rs", feature = "test"))]
-pub fn temporarily_disable_prune_following() -> Temporary {
-    Temporary::new(&IS_PRUNE_FOLLOWING_ENABLED, false)
 }
 
 pub fn allow_active_neurons_in_stable_memory() -> bool {

--- a/rs/nns/governance/src/neuron/types.rs
+++ b/rs/nns/governance/src/neuron/types.rs
@@ -3,7 +3,6 @@ use crate::{
         LOG_PREFIX, MAX_DISSOLVE_DELAY_SECONDS, MAX_NEURON_AGE_FOR_AGE_BONUS,
         MAX_NEURON_RECENT_BALLOTS, MAX_NUM_HOT_KEYS_PER_NEURON,
     },
-    is_voting_power_adjustment_enabled,
     neuron::{combine_aged_stakes, dissolve_state_and_age::DissolveStateAndAge, neuron_stake_e8s},
     neuron_store::NeuronStoreError,
     pb::v1::{
@@ -304,15 +303,13 @@ impl Neuron {
     ) -> u64 {
         // Main inputs to main calculation.
 
-        let adjustment_factor: Decimal = if is_voting_power_adjustment_enabled() {
+        let adjustment_factor: Decimal = {
             let time_since_last_refreshed = Duration::from_secs(
                 now_seconds.saturating_sub(self.voting_power_refreshed_timestamp_seconds),
             );
 
             voting_power_economics
                 .deciding_voting_power_adjustment_factor(time_since_last_refreshed)
-        } else {
-            Decimal::from(1)
         };
 
         let potential_voting_power = self.potential_voting_power(now_seconds);

--- a/rs/nns/governance/src/neuron_store/metrics/tests.rs
+++ b/rs/nns/governance/src/neuron_store/metrics/tests.rs
@@ -776,7 +776,6 @@ fn test_compute_neuron_metrics_public_neurons() {
 fn test_compute_neuron_metrics_stale_and_expired_voting_power_neurons() {
     // Step 1: Prepare the world.
 
-    let _reset_on_drop = crate::temporarily_enable_voting_power_adjustment();
     let now_seconds = 1718213756;
 
     // Step 1.1: Construct neurons (as described in the docstring).

--- a/rs/nns/governance/src/timer_tasks/mod.rs
+++ b/rs/nns/governance/src/timer_tasks/mod.rs
@@ -8,9 +8,7 @@ use seeding::SeedingTask;
 use snapshot_voting_power::SnapshotVotingPowerTask;
 use std::cell::RefCell;
 
-use crate::{
-    canister_state::GOVERNANCE, is_prune_following_enabled, storage::VOTING_POWER_SNAPSHOTS,
-};
+use crate::{canister_state::GOVERNANCE, storage::VOTING_POWER_SNAPSHOTS};
 
 mod calculate_distributable_rewards;
 mod distribute_rewards;
@@ -25,10 +23,9 @@ thread_local! {
 pub fn schedule_tasks() {
     SeedingTask::new(&GOVERNANCE).schedule(&METRICS_REGISTRY);
     CalculateDistributableRewardsTask::new(&GOVERNANCE).schedule(&METRICS_REGISTRY);
-    if is_prune_following_enabled() {
-        PruneFollowingTask::new(&GOVERNANCE).schedule(&METRICS_REGISTRY);
-    }
+    PruneFollowingTask::new(&GOVERNANCE).schedule(&METRICS_REGISTRY);
     SnapshotVotingPowerTask::new(&GOVERNANCE, &VOTING_POWER_SNAPSHOTS).schedule(&METRICS_REGISTRY);
+
     run_distribute_rewards_periodic_task();
 }
 

--- a/rs/nns/integration_tests/src/neuron_following.rs
+++ b/rs/nns/integration_tests/src/neuron_following.rs
@@ -12,7 +12,7 @@ use ic_nns_governance_api::pb::v1::{
 };
 use ic_nns_governance_init::GovernanceCanisterInitPayloadBuilder;
 use ic_nns_test_utils::{
-    common::{build_test_governance_wasm, NnsInitPayloadsBuilder},
+    common::{build_governance_wasm, NnsInitPayloadsBuilder},
     neuron_helpers::{
         get_neuron_1, get_neuron_2, get_neuron_3, get_nonexistent_neuron, get_unauthorized_neuron,
         submit_proposal, TestNeuronOwner,
@@ -484,10 +484,7 @@ async fn test_prune_some_following() {
         "NNS Governance",
         GOVERNANCE_CANISTER_ID,
         governance_proto.encode_to_vec(),
-        // TODO(NNS1-3446): Once following pruning is released, replace with
-        // vanilla build_governance_wasm(). For now, the feature is only enabled
-        // when built with feature = "test".
-        build_test_governance_wasm(),
+        build_governance_wasm(),
         Some(ROOT_CANISTER_ID.get()),
     )
     .await;


### PR DESCRIPTION
The "Periodic Confirmation of Following/Voting Power" feature started having its full effect at the beginning of April, and no reason to recall it has emerged (knock on wood). DFINITY has looked at the practical consequences of this, and it does not seem like any interventions are needed. Therefore, now is a good time to get rid of these flags.

As with all such clean ups, it is not super important that this go in soon. If there are any objections to merging this now, then we can definitely delay.

# References

Closes [NNS1-3601].

[NNS1-3601]: https://dfinity.atlassian.net/browse/NNS1-3601