### PR TITLE
chore(node): export cpu microcode metrics

### DIFF
--- a/ic-os/components/hostos-scripts/monitoring/custom-metrics.service
+++ b/ic-os/components/hostos-scripts/monitoring/custom-metrics.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Custom HostOS metrics
+After=node_exporter.service
+
+[Service]
+Type=oneshot
+ExecStart=/opt/ic/bin/custom-metrics.sh
+
+[Install]
+WantedBy=multi-user.target

--- a/ic-os/components/hostos-scripts/monitoring/custom-metrics.service
+++ b/ic-os/components/hostos-scripts/monitoring/custom-metrics.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Custom HostOS metrics
-After=node_exporter.service
+Before=node_exporter.service
 
 [Service]
 Type=oneshot

--- a/ic-os/components/hostos-scripts/monitoring/custom-metrics.sh
+++ b/ic-os/components/hostos-scripts/monitoring/custom-metrics.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+set -e
+
+# Custom HostOS metrics
+
+source /opt/ic/bin/logging.sh
+source /opt/ic/bin/metrics.sh
+
+MICROCODE_FILE="/sys/devices/system/cpu/cpu0/microcode/version"
+
+function update_microcode_metric() {
+    if [[ ! -r "${MICROCODE_FILE}" ]]; then
+        write_log "ERROR: Cannot read microcode version file: ${MICROCODE_FILE}"
+        return 1
+    fi
+
+    microcode=$(tr -d '\n' < "${MICROCODE_FILE}")
+    write_log "Found microcode version: ${microcode}"
+    write_metric_attr "node_cpu_microcode" \
+            "{version=\"${microcode}\"}" \
+            "1" \
+            "CPU microcode version" \
+            "gauge"
+}
+
+function main() {
+    update_microcode_metric
+}
+
+main

--- a/ic-os/components/hostos-scripts/monitoring/custom-metrics.sh
+++ b/ic-os/components/hostos-scripts/monitoring/custom-metrics.sh
@@ -15,13 +15,13 @@ function update_microcode_metric() {
         return 1
     fi
 
-    microcode=$(tr -d '\n' < "${MICROCODE_FILE}")
+    microcode=$(tr -d '\n' <"${MICROCODE_FILE}")
     write_log "Found microcode version: ${microcode}"
     write_metric_attr "node_cpu_microcode" \
-            "{version=\"${microcode}\"}" \
-            "1" \
-            "CPU microcode version" \
-            "gauge"
+        "{version=\"${microcode}\"}" \
+        "1" \
+        "CPU microcode version" \
+        "gauge"
 }
 
 function main() {

--- a/ic-os/components/hostos.bzl
+++ b/ic-os/components/hostos.bzl
@@ -19,6 +19,8 @@ component_files = {
     Label("hostos-scripts/monitoring/monitor-guestos.sh"): "/opt/ic/bin/monitor-guestos.sh",
     Label("hostos-scripts/monitoring/monitor-guestos.service"): "/etc/systemd/system/monitor-guestos.service",
     Label("hostos-scripts/monitoring/monitor-guestos.timer"): "/etc/systemd/system/monitor-guestos.timer",
+    Label("hostos-scripts/monitoring/custom-metrics.sh"): "/opt/ic/bin/custom-metrics.sh",
+    Label("hostos-scripts/monitoring/custom-metrics.service"): "/etc/systemd/system/custom-metrics.service",
     Label("hostos-scripts/monitoring/monitor-nvme.sh"): "/opt/ic/bin/monitor-nvme.sh",
     Label("hostos-scripts/monitoring/monitor-nvme.service"): "/etc/systemd/system/monitor-nvme.service",
     Label("hostos-scripts/monitoring/monitor-nvme.timer"): "/etc/systemd/system/monitor-nvme.timer",


### PR DESCRIPTION
NODE-1567

CPU microcode version now exported as a metric:
![# HELP node_cpu_microcode CPU microcode version](https://github.com/user-attachments/assets/f1a0825a-99de-4c72-bd74-f8a17d326d05)

