### PR TITLE
fix(sns): Correctly translate `ManageLedgerParameters` into `LedgerUpgradeArgs`

### DIFF
--- a/rs/sns/governance/src/types.rs
+++ b/rs/sns/governance/src/types.rs
@@ -1914,16 +1914,18 @@ impl From<ManageLedgerParameters> for LedgerUpgradeArgs {
             token_symbol,
             token_logo,
         } = manage_ledger_parameters;
-        let metadata = [("icrc1:logo", token_logo.map(MetadataValue::Text))]
-            .into_iter()
-            .filter_map(|(k, v)| v.map(|v| (k.to_string(), v)))
-            .collect();
+
+        let metadata = token_logo.map(|token_logo| {
+            let key = "icrc1:logo".to_string();
+            let value = MetadataValue::Text(token_logo);
+            vec![(key, value)]
+        });
 
         LedgerUpgradeArgs {
             transfer_fee: transfer_fee.map(|tf| tf.into()),
             token_name,
             token_symbol,
-            metadata: Some(metadata),
+            metadata,
             ..LedgerUpgradeArgs::default()
         }
     }

--- a/rs/sns/governance/src/types/tests.rs
+++ b/rs/sns/governance/src/types/tests.rs
@@ -6,6 +6,7 @@ use crate::pb::v1::{
     neuron::Followees,
     ExecuteGenericNervousSystemFunction, Proposal, ProposalData, VotingRewardsParameters,
 };
+use candid::Nat;
 use futures::FutureExt;
 use ic_base_types::PrincipalId;
 use ic_management_canister_types::ChunkHash;
@@ -1490,5 +1491,34 @@ fn test_validate_chunked_wasm_management_canister_call_returns_junk() {
             "Cannot decode response from calling stored_chunks for {}: Cannot parse header ",
             store_canister_id
         )]),
+    );
+}
+
+#[test]
+fn test_from_manage_ledger_parameters_into_ledger_upgrade_args() {
+    let manage_ledger_parameters = ManageLedgerParameters {
+        transfer_fee: Some(111),
+        token_name: Some("abc".to_string()),
+        token_symbol: Some("xyz".to_string()),
+        token_logo: Some("<logo>".to_string()),
+    };
+
+    let observed = LedgerUpgradeArgs::from(manage_ledger_parameters);
+
+    assert_eq!(
+        observed,
+        LedgerUpgradeArgs {
+            metadata: Some(vec![(
+                "icrc1:logo".to_string(),
+                MetadataValue::Text("<logo>".to_string())
+            )]),
+            token_name: Some("abc".to_string()),
+            token_symbol: Some("xyz".to_string()),
+            transfer_fee: Some(Nat::from(111_u64)),
+            change_fee_collector: None,
+            max_memo_length: None,
+            feature_flags: None,
+            change_archive_options: None,
+        }
     );
 }

--- a/rs/sns/governance/src/types/tests.rs
+++ b/rs/sns/governance/src/types/tests.rs
@@ -1522,3 +1522,29 @@ fn test_from_manage_ledger_parameters_into_ledger_upgrade_args() {
         }
     );
 }
+
+#[test]
+fn test_from_manage_ledger_parameters_into_ledger_upgrade_args_no_logo() {
+    let manage_ledger_parameters = ManageLedgerParameters {
+        transfer_fee: Some(111),
+        token_name: Some("abc".to_string()),
+        token_symbol: Some("xyz".to_string()),
+        token_logo: None,
+    };
+
+    let observed = LedgerUpgradeArgs::from(manage_ledger_parameters);
+
+    assert_eq!(
+        observed,
+        LedgerUpgradeArgs {
+            metadata: None,
+            token_name: Some("abc".to_string()),
+            token_symbol: Some("xyz".to_string()),
+            transfer_fee: Some(Nat::from(111_u64)),
+            change_fee_collector: None,
+            max_memo_length: None,
+            feature_flags: None,
+            change_archive_options: None,
+        }
+    );
+}

--- a/rs/sns/governance/unreleased_changelog.md
+++ b/rs/sns/governance/unreleased_changelog.md
@@ -38,6 +38,8 @@ proposal, e.g.:
 
 * Do not redact chunked Wasm data in `ProposalInfo` served from `SnsGov.list_proposals`.
 * Added the `query_stats` field for `canister_status`/`get_sns_canisters_summary` methods.
+* Fix a bug due to which SNS ledger logos were sometimes unset after changing unrelated
+  SNS ledger metadata fields.
 
 ## Changed
 


### PR DESCRIPTION
This PR fixes a bug due to which the SNS ledger logo was being unset as a result of changes in unrelated SNS ledger metadata fields.