### PR TITLE
feat(nns): Make NetworkEconomics inherit recursively.

### DIFF
--- a/rs/nns/governance/src/governance.rs
+++ b/rs/nns/governance/src/governance.rs
@@ -11,6 +11,7 @@ use crate::{
         reassemble_governance_proto, split_governance_proto, HeapGovernanceData, XdrConversionRate,
     },
     migrations::maybe_run_migrations,
+    network_economics::InheritFrom,
     neuron::{DissolveStateAndAge, Neuron, NeuronBuilder, Visibility},
     neuron_data_validation::{NeuronDataValidationSummary, NeuronDataValidator},
     neuron_store::{
@@ -56,7 +57,6 @@ use crate::{
             InstallCode, KnownNeuron, ListKnownNeuronsResponse, ListProposalInfo, ManageNeuron,
             MonthlyNodeProviderRewards, Motion, NetworkEconomics, NeuronState,
             NeuronsFundAuditInfo, NeuronsFundData,
-            NeuronsFundEconomics as NeuronsFundNetworkEconomicsPb,
             NeuronsFundParticipation as NeuronsFundParticipationPb,
             NeuronsFundSnapshot as NeuronsFundSnapshotPb, NnsFunction, NodeProvider, Proposal,
             ProposalData, ProposalRewardStatus, ProposalStatus, RestoreAgingSummary, RewardEvent,
@@ -82,7 +82,6 @@ use ic_nervous_system_common::{
     ONE_YEAR_SECONDS,
 };
 use ic_nervous_system_governance::maturity_modulation::apply_maturity_modulation;
-use ic_nervous_system_linear_map::LinearMap;
 use ic_nervous_system_proto::pb::v1::{GlobalTimeOfDay, Principals};
 use ic_nns_common::{
     pb::v1::{NeuronId, ProposalId},
@@ -111,9 +110,7 @@ use ic_sns_wasm::pb::v1::{
     DeployNewSnsRequest, DeployNewSnsResponse, ListDeployedSnsesRequest, ListDeployedSnsesResponse,
 };
 use ic_stable_structures::{storable::Bound, Storable};
-use icp_ledger::{
-    AccountIdentifier, Subaccount, Tokens, DEFAULT_TRANSFER_FEE, TOKEN_SUBDIVIDABLE_BY,
-};
+use icp_ledger::{AccountIdentifier, Subaccount, Tokens, TOKEN_SUBDIVIDABLE_BY};
 use itertools::Itertools;
 use maplit::hashmap;
 use registry_canister::{
@@ -130,7 +127,6 @@ use std::{
     future::Future,
     ops::RangeInclusive,
     string::ToString,
-    time::Duration,
 };
 
 mod ledger_helper;
@@ -223,9 +219,6 @@ pub const MAX_LIST_NEURONS_RESULTS: usize = 500;
 
 const MAX_LIST_NODE_PROVIDER_REWARDS_RESULTS: usize = 24;
 
-/// The number of e8s per ICP;
-const E8S_PER_ICP: u64 = TOKEN_SUBDIVIDABLE_BY;
-
 /// The max number of unsettled proposals -- that is proposals for which ballots
 /// are still stored.
 pub const MAX_NUMBER_OF_PROPOSALS_WITH_BALLOTS: usize = 200;
@@ -269,152 +262,6 @@ const VALID_MATURITY_MODULATION_BASIS_POINTS_RANGE: RangeInclusive<i32> = -500..
 /// `CreateServiceNervousSystem` proposal execution also needs to be evaluated (currently, each
 /// neuron takes ~120K instructions to draw/refund maturity, so the total is ~600M).
 pub const MAX_NEURONS_FUND_PARTICIPANTS: u64 = 5_000;
-
-impl NetworkEconomics {
-    /// The multiplier applied to minimum_icp_xdr_rate to convert the XDR unit to basis_points
-    pub const ICP_XDR_RATE_TO_BASIS_POINT_MULTIPLIER: u64 = 100;
-
-    // The default values for network economics (until we initialize it).
-    // Can't implement Default since it conflicts with Prost's.
-    pub fn with_default_values() -> Self {
-        Self {
-            reject_cost_e8s: E8S_PER_ICP,                               // 1 ICP
-            neuron_management_fee_per_proposal_e8s: 1_000_000,          // 0.01 ICP
-            neuron_minimum_stake_e8s: E8S_PER_ICP,                      // 1 ICP
-            neuron_spawn_dissolve_delay_seconds: ONE_DAY_SECONDS * 7,   // 7 days
-            maximum_node_provider_rewards_e8s: 1_000_000 * 100_000_000, // 1M ICP
-            minimum_icp_xdr_rate: 100,                                  // 1 XDR
-            transaction_fee_e8s: DEFAULT_TRANSFER_FEE.get_e8s(),
-            max_proposals_to_keep_per_topic: 100,
-            neurons_fund_economics: Some(NeuronsFundNetworkEconomicsPb::with_default_values()),
-            voting_power_economics: Some(VotingPowerEconomics::with_default_values()),
-        }
-    }
-
-    /// Returns a modified copy of self where fields containing the default
-    /// value are replaced with the value from defaults. In particular, 0 and
-    /// None are replaced.
-    fn inherit_from(&self, defaults: &Self) -> Self {
-        /// Returns ours if it is the default (for its type). Otherwise, returns default.
-        fn inherit_from<T>(ours: T, default: T) -> T
-        where
-            T: Default + PartialEq,
-        {
-            if ours == T::default() {
-                return default;
-            }
-
-            ours
-        }
-
-        Self {
-            reject_cost_e8s: inherit_from(self.reject_cost_e8s, defaults.reject_cost_e8s),
-            neuron_minimum_stake_e8s: inherit_from(
-                self.neuron_minimum_stake_e8s,
-                defaults.neuron_minimum_stake_e8s,
-            ),
-            neuron_management_fee_per_proposal_e8s: inherit_from(
-                self.neuron_management_fee_per_proposal_e8s,
-                defaults.neuron_management_fee_per_proposal_e8s,
-            ),
-            minimum_icp_xdr_rate: inherit_from(
-                self.minimum_icp_xdr_rate,
-                defaults.minimum_icp_xdr_rate,
-            ),
-            neuron_spawn_dissolve_delay_seconds: inherit_from(
-                self.neuron_spawn_dissolve_delay_seconds,
-                defaults.neuron_spawn_dissolve_delay_seconds,
-            ),
-            maximum_node_provider_rewards_e8s: inherit_from(
-                self.maximum_node_provider_rewards_e8s,
-                defaults.maximum_node_provider_rewards_e8s,
-            ),
-            transaction_fee_e8s: inherit_from(
-                self.transaction_fee_e8s,
-                defaults.transaction_fee_e8s,
-            ),
-            max_proposals_to_keep_per_topic: inherit_from(
-                self.max_proposals_to_keep_per_topic,
-                defaults.max_proposals_to_keep_per_topic,
-            ),
-
-            // TODO(NNS1-3499): Ideally, we would recurse into T, because
-            // otherwise, you have to set a bundle of parameters all at once. In
-            // other words, the current implementation does not support setting
-            // individual subfields, a la carte.
-            neurons_fund_economics: inherit_from(
-                self.neurons_fund_economics.as_ref(),
-                defaults.neurons_fund_economics.as_ref(),
-            )
-            .cloned(),
-            voting_power_economics: inherit_from(
-                self.voting_power_economics.as_ref(),
-                defaults.voting_power_economics.as_ref(),
-            )
-            .cloned(),
-        }
-    }
-}
-
-impl VotingPowerEconomics {
-    pub const DEFAULT: Self = Self {
-        start_reducing_voting_power_after_seconds: Some(
-            Self::DEFAULT_START_REDUCING_VOTING_POWER_AFTER_SECONDS,
-        ),
-        clear_following_after_seconds: Some(Self::DEFAULT_CLEAR_FOLLOWING_AFTER_SECONDS),
-    };
-
-    pub const DEFAULT_START_REDUCING_VOTING_POWER_AFTER_SECONDS: u64 = 6 * ONE_MONTH_SECONDS;
-    pub const DEFAULT_CLEAR_FOLLOWING_AFTER_SECONDS: u64 = ONE_MONTH_SECONDS;
-
-    pub fn with_default_values() -> Self {
-        Self::DEFAULT
-    }
-
-    /// Returns 1 if a neuron has refreshed (its voting power/following)
-    /// recently.
-    ///
-    /// Otherwise, if a neuron has not refreshed for >
-    /// start_reducing_voting_power_after_seconds, returns < 1 (but >= 0).
-    ///
-    /// Once a neuron has not refresehd for
-    /// start_reducing_voting_power_after_seconds +
-    /// clear_following_after_seconds, this returns 0.
-    ///
-    /// Between these two points, the decrease is linear.
-    pub fn deciding_voting_power_adjustment_factor(
-        &self,
-        time_since_last_voting_power_refreshed: Duration,
-    ) -> Decimal {
-        self.deciding_voting_power_adjustment_factor_function()
-            .apply(time_since_last_voting_power_refreshed.as_secs())
-            .clamp(Decimal::from(0), Decimal::from(1))
-    }
-
-    fn deciding_voting_power_adjustment_factor_function(&self) -> LinearMap {
-        let from_range = {
-            let begin = self.get_start_reducing_voting_power_after_seconds();
-            let end = begin + self.get_clear_following_after_seconds();
-
-            begin..end
-        };
-
-        #[allow(clippy::reversed_empty_ranges)]
-        let to_range = 1..0;
-
-        LinearMap::new(from_range, to_range)
-    }
-
-    pub fn get_start_reducing_voting_power_after_seconds(&self) -> u64 {
-        self.start_reducing_voting_power_after_seconds
-            .unwrap_or(Self::DEFAULT_START_REDUCING_VOTING_POWER_AFTER_SECONDS)
-    }
-
-    pub fn get_clear_following_after_seconds(&self) -> u64 {
-        self.clear_following_after_seconds
-            .unwrap_or(Self::DEFAULT_CLEAR_FOLLOWING_AFTER_SECONDS)
-    }
-}
 
 impl GovernanceError {
     pub fn new(error_type: ErrorType) -> Self {

--- a/rs/nns/governance/src/governance/tests/mod.rs
+++ b/rs/nns/governance/src/governance/tests/mod.rs
@@ -22,7 +22,10 @@ use ic_sns_init::pb::v1::SnsInitPayload;
 use ic_sns_init::pb::v1::{self as sns_init_pb};
 use lazy_static::lazy_static;
 use maplit::{btreemap, hashmap};
-use std::convert::TryFrom;
+use std::{
+    convert::TryFrom,
+    time::Duration,
+};
 
 mod list_neurons;
 mod neurons_fund;

--- a/rs/nns/governance/src/governance/tests/mod.rs
+++ b/rs/nns/governance/src/governance/tests/mod.rs
@@ -22,10 +22,7 @@ use ic_sns_init::pb::v1::SnsInitPayload;
 use ic_sns_init::pb::v1::{self as sns_init_pb};
 use lazy_static::lazy_static;
 use maplit::{btreemap, hashmap};
-use std::{
-    convert::TryFrom,
-    time::Duration,
-};
+use std::{convert::TryFrom, time::Duration};
 
 mod list_neurons;
 mod neurons_fund;

--- a/rs/nns/governance/src/lib.rs
+++ b/rs/nns/governance/src/lib.rs
@@ -162,6 +162,7 @@ pub mod governance_proto_builder;
 mod heap_governance_data;
 mod known_neuron_index;
 mod migrations;
+mod network_economics;
 mod neuron;
 pub mod neuron_data_validation;
 mod neuron_store;

--- a/rs/nns/governance/src/network_economics.rs
+++ b/rs/nns/governance/src/network_economics.rs
@@ -1,0 +1,250 @@
+use crate::pb::v1::{NetworkEconomics, NeuronsFundEconomics, VotingPowerEconomics, NeuronsFundMatchedFundingCurveCoefficients};
+use ic_nervous_system_common::{E8, ONE_DAY_SECONDS, ONE_MONTH_SECONDS};
+use ic_nervous_system_proto::pb::v1::Percentage;
+use ic_nervous_system_linear_map::LinearMap;
+use icp_ledger::DEFAULT_TRANSFER_FEE;
+use rust_decimal::Decimal;
+use std::time::Duration;
+
+impl NetworkEconomics {
+    /// The multiplier applied to minimum_icp_xdr_rate to convert the XDR unit to basis_points
+    pub const ICP_XDR_RATE_TO_BASIS_POINT_MULTIPLIER: u64 = 100;
+
+    // The default values for network economics (until we initialize it).
+    // Can't implement Default since it conflicts with Prost's.
+    pub fn with_default_values() -> Self {
+        Self {
+            reject_cost_e8s: E8,                                        // 1 ICP
+            neuron_management_fee_per_proposal_e8s: 1_000_000,          // 0.01 ICP
+            neuron_minimum_stake_e8s: E8,                               // 1 ICP
+            neuron_spawn_dissolve_delay_seconds: ONE_DAY_SECONDS * 7,   // 7 days
+            maximum_node_provider_rewards_e8s: 1_000_000 * 100_000_000, // 1M ICP
+            minimum_icp_xdr_rate: 100,                                  // 1 XDR
+            transaction_fee_e8s: DEFAULT_TRANSFER_FEE.get_e8s(),
+            max_proposals_to_keep_per_topic: 100,
+            neurons_fund_economics: Some(NeuronsFundEconomics::with_default_values()),
+            voting_power_economics: Some(VotingPowerEconomics::with_default_values()),
+        }
+    }
+}
+
+impl VotingPowerEconomics {
+    pub const DEFAULT: Self = Self {
+        start_reducing_voting_power_after_seconds: Some(
+            Self::DEFAULT_START_REDUCING_VOTING_POWER_AFTER_SECONDS,
+        ),
+        clear_following_after_seconds: Some(Self::DEFAULT_CLEAR_FOLLOWING_AFTER_SECONDS),
+    };
+
+    pub const DEFAULT_START_REDUCING_VOTING_POWER_AFTER_SECONDS: u64 = 6 * ONE_MONTH_SECONDS;
+    pub const DEFAULT_CLEAR_FOLLOWING_AFTER_SECONDS: u64 = ONE_MONTH_SECONDS;
+
+    pub fn with_default_values() -> Self {
+        Self::DEFAULT
+    }
+
+    /// Returns 1 if a neuron has refreshed (its voting power/following)
+    /// recently.
+    ///
+    /// Otherwise, if a neuron has not refreshed for >
+    /// start_reducing_voting_power_after_seconds, returns < 1 (but >= 0).
+    ///
+    /// Once a neuron has not refresehd for
+    /// start_reducing_voting_power_after_seconds +
+    /// clear_following_after_seconds, this returns 0.
+    ///
+    /// Between these two points, the decrease is linear.
+    pub fn deciding_voting_power_adjustment_factor(
+        &self,
+        time_since_last_voting_power_refreshed: Duration,
+    ) -> Decimal {
+        self.deciding_voting_power_adjustment_factor_function()
+            .apply(time_since_last_voting_power_refreshed.as_secs())
+            .clamp(Decimal::from(0), Decimal::from(1))
+    }
+
+    fn deciding_voting_power_adjustment_factor_function(&self) -> LinearMap {
+        let from_range = {
+            let begin = self.get_start_reducing_voting_power_after_seconds();
+            let end = begin + self.get_clear_following_after_seconds();
+
+            begin..end
+        };
+
+        #[allow(clippy::reversed_empty_ranges)]
+        let to_range = 1..0;
+
+        LinearMap::new(from_range, to_range)
+    }
+
+    pub fn get_start_reducing_voting_power_after_seconds(&self) -> u64 {
+        self.start_reducing_voting_power_after_seconds
+            .unwrap_or(Self::DEFAULT_START_REDUCING_VOTING_POWER_AFTER_SECONDS)
+    }
+
+    pub fn get_clear_following_after_seconds(&self) -> u64 {
+        self.clear_following_after_seconds
+            .unwrap_or(Self::DEFAULT_CLEAR_FOLLOWING_AFTER_SECONDS)
+    }
+}
+
+// Seems like there is probably some way we can make #[derive(...)] generate
+// implementations of this, because the hand-crafted implementations below are
+// pretty dang (if not completely) repetitive. OTOH, it would be a lot of work,
+// and it is not clear that we would use it many times.
+pub(crate) trait InheritFrom {
+    /// Returns a modified copy of self where fields containing 0 are replaced
+    /// with the value from filler.
+    fn inherit_from(&self, filler: &Self) -> Self;
+}
+
+// Ideally, we'd use num_traits::Zero to give a generic implementation that
+// applies to all integer types, but Rust refuses to allow that in the presence
+// of impl InheritFrom for Option<T> below. If only there was some way we could
+// tell Rust, "ok, but this impl does not apply when the type happens to be
+// Option", but that doesn't exist (yet). Fortunately, we do not use a wide
+// range of integer types. Therefore, only this one is needed (for now).
+impl InheritFrom for u64 {
+    fn inherit_from(&self, filler: &Self) -> Self {
+        if self == &0_u64 {
+            return *filler;
+        }
+
+        *self
+    }
+}
+
+impl InheritFrom for u32 {
+    fn inherit_from(&self, filler: &Self) -> Self {
+        if self == &0_u32 {
+            return *filler;
+        }
+
+        *self
+    }
+}
+
+impl InheritFrom for ic_nervous_system_proto::pb::v1::Decimal {
+    fn inherit_from(&self, filler: &Self) -> Self {
+        if self == &(ic_nervous_system_proto::pb::v1::Decimal {
+            human_readable: Some("0".to_string()),
+        }) {
+            return filler.clone();
+        }
+
+        self.clone()
+    }
+}
+
+impl InheritFrom for Percentage {
+    fn inherit_from(&self, filler: &Self) -> Self {
+        if self == &(Percentage { basis_points: Some(0) }) {
+            return *filler;
+        }
+
+        *self
+    }
+}
+
+impl<T> InheritFrom for Option<T>
+where
+    T: InheritFrom + Clone,
+{
+    fn inherit_from(&self, filler: &Self) -> Self {
+        match (self, filler) {
+            (Some(me), Some(filler)) => Some(me.inherit_from(filler)),
+            (Some(_), None) => self.clone(),
+            (None, filler) => filler.clone(),
+        }
+    }
+}
+
+impl InheritFrom for NetworkEconomics {
+    fn inherit_from(&self, filler: &Self) -> Self {
+        Self {
+            reject_cost_e8s: self.reject_cost_e8s.inherit_from(&filler.reject_cost_e8s),
+            neuron_minimum_stake_e8s: self
+                .neuron_minimum_stake_e8s
+                .inherit_from(&filler.neuron_minimum_stake_e8s),
+            neuron_management_fee_per_proposal_e8s: self
+                .neuron_management_fee_per_proposal_e8s
+                .inherit_from(&filler.neuron_management_fee_per_proposal_e8s),
+            minimum_icp_xdr_rate: self
+                .minimum_icp_xdr_rate
+                .inherit_from(&filler.minimum_icp_xdr_rate),
+            neuron_spawn_dissolve_delay_seconds: self
+                .neuron_spawn_dissolve_delay_seconds
+                .inherit_from(&filler.neuron_spawn_dissolve_delay_seconds),
+            maximum_node_provider_rewards_e8s: self
+                .maximum_node_provider_rewards_e8s
+                .inherit_from(&filler.maximum_node_provider_rewards_e8s),
+            transaction_fee_e8s: self
+                .transaction_fee_e8s
+                .inherit_from(&filler.transaction_fee_e8s),
+            max_proposals_to_keep_per_topic: self
+                .max_proposals_to_keep_per_topic
+                .inherit_from(&filler.max_proposals_to_keep_per_topic),
+
+            neurons_fund_economics: self
+                .neurons_fund_economics
+                .inherit_from(&filler.neurons_fund_economics),
+            voting_power_economics: self
+                .voting_power_economics
+                .inherit_from(&filler.voting_power_economics),
+        }
+    }
+}
+
+impl InheritFrom for NeuronsFundEconomics {
+    fn inherit_from(&self, filler: &Self) -> Self {
+        Self {
+            max_theoretical_neurons_fund_participation_amount_xdr: self
+                .max_theoretical_neurons_fund_participation_amount_xdr
+                .inherit_from(&filler.max_theoretical_neurons_fund_participation_amount_xdr),
+
+            maximum_icp_xdr_rate: self
+                .maximum_icp_xdr_rate
+                .inherit_from(&filler.maximum_icp_xdr_rate),
+
+            minimum_icp_xdr_rate: self
+                .minimum_icp_xdr_rate
+                .inherit_from(&filler.minimum_icp_xdr_rate),
+
+            neurons_fund_matched_funding_curve_coefficients: self
+                .neurons_fund_matched_funding_curve_coefficients
+                .inherit_from(&filler.neurons_fund_matched_funding_curve_coefficients),
+        }
+    }
+}
+
+impl InheritFrom for NeuronsFundMatchedFundingCurveCoefficients {
+    fn inherit_from(&self, filler: &Self) -> Self {
+        Self {
+            contribution_threshold_xdr: self
+                .contribution_threshold_xdr
+                .inherit_from(&filler.contribution_threshold_xdr),
+
+            full_participation_milestone_xdr: self
+                .full_participation_milestone_xdr
+                .inherit_from(&filler.full_participation_milestone_xdr),
+
+            one_third_participation_milestone_xdr: self
+                .one_third_participation_milestone_xdr
+                .inherit_from(&filler.one_third_participation_milestone_xdr),
+        }
+    }
+}
+
+impl InheritFrom for VotingPowerEconomics {
+    fn inherit_from(&self, filler: &Self) -> Self {
+        Self {
+            start_reducing_voting_power_after_seconds: self
+                .start_reducing_voting_power_after_seconds
+                .inherit_from(&filler.start_reducing_voting_power_after_seconds),
+
+            clear_following_after_seconds: self
+                .clear_following_after_seconds
+                .inherit_from(&filler.clear_following_after_seconds),
+        }
+    }
+}

--- a/rs/nns/governance/src/network_economics.rs
+++ b/rs/nns/governance/src/network_economics.rs
@@ -1,7 +1,10 @@
-use crate::pb::v1::{NetworkEconomics, NeuronsFundEconomics, VotingPowerEconomics, NeuronsFundMatchedFundingCurveCoefficients};
+use crate::pb::v1::{
+    NetworkEconomics, NeuronsFundEconomics, NeuronsFundMatchedFundingCurveCoefficients,
+    VotingPowerEconomics,
+};
 use ic_nervous_system_common::{E8, ONE_DAY_SECONDS, ONE_MONTH_SECONDS};
-use ic_nervous_system_proto::pb::v1::Percentage;
 use ic_nervous_system_linear_map::LinearMap;
+use ic_nervous_system_proto::pb::v1::Percentage;
 use icp_ledger::DEFAULT_TRANSFER_FEE;
 use rust_decimal::Decimal;
 use std::time::Duration;
@@ -126,9 +129,11 @@ impl InheritFrom for u32 {
 
 impl InheritFrom for ic_nervous_system_proto::pb::v1::Decimal {
     fn inherit_from(&self, filler: &Self) -> Self {
-        if self == &(ic_nervous_system_proto::pb::v1::Decimal {
-            human_readable: Some("0".to_string()),
-        }) {
+        if self
+            == &(ic_nervous_system_proto::pb::v1::Decimal {
+                human_readable: Some("0".to_string()),
+            })
+        {
             return filler.clone();
         }
 
@@ -138,7 +143,11 @@ impl InheritFrom for ic_nervous_system_proto::pb::v1::Decimal {
 
 impl InheritFrom for Percentage {
     fn inherit_from(&self, filler: &Self) -> Self {
-        if self == &(Percentage { basis_points: Some(0) }) {
+        if self
+            == &(Percentage {
+                basis_points: Some(0),
+            })
+        {
             return *filler;
         }
 

--- a/rs/nns/governance/src/network_economics.rs
+++ b/rs/nns/governance/src/network_economics.rs
@@ -257,3 +257,7 @@ impl InheritFrom for VotingPowerEconomics {
         }
     }
 }
+
+#[cfg(test)]
+#[path = "./network_economics_tests.rs"]
+mod network_economics_tests;

--- a/rs/nns/governance/src/network_economics.rs
+++ b/rs/nns/governance/src/network_economics.rs
@@ -97,8 +97,8 @@ impl VotingPowerEconomics {
 // and it is not clear that we would use it many times.
 pub(crate) trait InheritFrom {
     /// Returns a modified copy of self where fields containing 0 are replaced
-    /// with the value from filler.
-    fn inherit_from(&self, filler: &Self) -> Self;
+    /// with the value from base.
+    fn inherit_from(&self, base: &Self) -> Self;
 }
 
 // Ideally, we'd use num_traits::Zero to give a generic implementation that
@@ -108,9 +108,9 @@ pub(crate) trait InheritFrom {
 // Option", but that doesn't exist (yet). Fortunately, we do not use a wide
 // range of integer types. Therefore, only this one is needed (for now).
 impl InheritFrom for u64 {
-    fn inherit_from(&self, filler: &Self) -> Self {
+    fn inherit_from(&self, base: &Self) -> Self {
         if self == &0_u64 {
-            return *filler;
+            return *base;
         }
 
         *self
@@ -118,9 +118,9 @@ impl InheritFrom for u64 {
 }
 
 impl InheritFrom for u32 {
-    fn inherit_from(&self, filler: &Self) -> Self {
+    fn inherit_from(&self, base: &Self) -> Self {
         if self == &0_u32 {
-            return *filler;
+            return *base;
         }
 
         *self
@@ -128,13 +128,13 @@ impl InheritFrom for u32 {
 }
 
 impl InheritFrom for ic_nervous_system_proto::pb::v1::Decimal {
-    fn inherit_from(&self, filler: &Self) -> Self {
+    fn inherit_from(&self, base: &Self) -> Self {
         if self
             == &(ic_nervous_system_proto::pb::v1::Decimal {
                 human_readable: Some("0".to_string()),
             })
         {
-            return filler.clone();
+            return base.clone();
         }
 
         self.clone()
@@ -142,13 +142,13 @@ impl InheritFrom for ic_nervous_system_proto::pb::v1::Decimal {
 }
 
 impl InheritFrom for Percentage {
-    fn inherit_from(&self, filler: &Self) -> Self {
+    fn inherit_from(&self, base: &Self) -> Self {
         if self
             == &(Percentage {
                 basis_points: Some(0),
             })
         {
-            return *filler;
+            return *base;
         }
 
         *self
@@ -159,101 +159,101 @@ impl<T> InheritFrom for Option<T>
 where
     T: InheritFrom + Clone,
 {
-    fn inherit_from(&self, filler: &Self) -> Self {
-        match (self, filler) {
-            (Some(me), Some(filler)) => Some(me.inherit_from(filler)),
+    fn inherit_from(&self, base: &Self) -> Self {
+        match (self, base) {
+            (Some(me), Some(base)) => Some(me.inherit_from(base)),
             (Some(_), None) => self.clone(),
-            (None, filler) => filler.clone(),
+            (None, base) => base.clone(),
         }
     }
 }
 
 impl InheritFrom for NetworkEconomics {
-    fn inherit_from(&self, filler: &Self) -> Self {
+    fn inherit_from(&self, base: &Self) -> Self {
         Self {
-            reject_cost_e8s: self.reject_cost_e8s.inherit_from(&filler.reject_cost_e8s),
+            reject_cost_e8s: self.reject_cost_e8s.inherit_from(&base.reject_cost_e8s),
             neuron_minimum_stake_e8s: self
                 .neuron_minimum_stake_e8s
-                .inherit_from(&filler.neuron_minimum_stake_e8s),
+                .inherit_from(&base.neuron_minimum_stake_e8s),
             neuron_management_fee_per_proposal_e8s: self
                 .neuron_management_fee_per_proposal_e8s
-                .inherit_from(&filler.neuron_management_fee_per_proposal_e8s),
+                .inherit_from(&base.neuron_management_fee_per_proposal_e8s),
             minimum_icp_xdr_rate: self
                 .minimum_icp_xdr_rate
-                .inherit_from(&filler.minimum_icp_xdr_rate),
+                .inherit_from(&base.minimum_icp_xdr_rate),
             neuron_spawn_dissolve_delay_seconds: self
                 .neuron_spawn_dissolve_delay_seconds
-                .inherit_from(&filler.neuron_spawn_dissolve_delay_seconds),
+                .inherit_from(&base.neuron_spawn_dissolve_delay_seconds),
             maximum_node_provider_rewards_e8s: self
                 .maximum_node_provider_rewards_e8s
-                .inherit_from(&filler.maximum_node_provider_rewards_e8s),
+                .inherit_from(&base.maximum_node_provider_rewards_e8s),
             transaction_fee_e8s: self
                 .transaction_fee_e8s
-                .inherit_from(&filler.transaction_fee_e8s),
+                .inherit_from(&base.transaction_fee_e8s),
             max_proposals_to_keep_per_topic: self
                 .max_proposals_to_keep_per_topic
-                .inherit_from(&filler.max_proposals_to_keep_per_topic),
+                .inherit_from(&base.max_proposals_to_keep_per_topic),
 
             neurons_fund_economics: self
                 .neurons_fund_economics
-                .inherit_from(&filler.neurons_fund_economics),
+                .inherit_from(&base.neurons_fund_economics),
             voting_power_economics: self
                 .voting_power_economics
-                .inherit_from(&filler.voting_power_economics),
+                .inherit_from(&base.voting_power_economics),
         }
     }
 }
 
 impl InheritFrom for NeuronsFundEconomics {
-    fn inherit_from(&self, filler: &Self) -> Self {
+    fn inherit_from(&self, base: &Self) -> Self {
         Self {
             max_theoretical_neurons_fund_participation_amount_xdr: self
                 .max_theoretical_neurons_fund_participation_amount_xdr
-                .inherit_from(&filler.max_theoretical_neurons_fund_participation_amount_xdr),
+                .inherit_from(&base.max_theoretical_neurons_fund_participation_amount_xdr),
 
             maximum_icp_xdr_rate: self
                 .maximum_icp_xdr_rate
-                .inherit_from(&filler.maximum_icp_xdr_rate),
+                .inherit_from(&base.maximum_icp_xdr_rate),
 
             minimum_icp_xdr_rate: self
                 .minimum_icp_xdr_rate
-                .inherit_from(&filler.minimum_icp_xdr_rate),
+                .inherit_from(&base.minimum_icp_xdr_rate),
 
             neurons_fund_matched_funding_curve_coefficients: self
                 .neurons_fund_matched_funding_curve_coefficients
-                .inherit_from(&filler.neurons_fund_matched_funding_curve_coefficients),
+                .inherit_from(&base.neurons_fund_matched_funding_curve_coefficients),
         }
     }
 }
 
 impl InheritFrom for NeuronsFundMatchedFundingCurveCoefficients {
-    fn inherit_from(&self, filler: &Self) -> Self {
+    fn inherit_from(&self, base: &Self) -> Self {
         Self {
             contribution_threshold_xdr: self
                 .contribution_threshold_xdr
-                .inherit_from(&filler.contribution_threshold_xdr),
+                .inherit_from(&base.contribution_threshold_xdr),
 
             full_participation_milestone_xdr: self
                 .full_participation_milestone_xdr
-                .inherit_from(&filler.full_participation_milestone_xdr),
+                .inherit_from(&base.full_participation_milestone_xdr),
 
             one_third_participation_milestone_xdr: self
                 .one_third_participation_milestone_xdr
-                .inherit_from(&filler.one_third_participation_milestone_xdr),
+                .inherit_from(&base.one_third_participation_milestone_xdr),
         }
     }
 }
 
 impl InheritFrom for VotingPowerEconomics {
-    fn inherit_from(&self, filler: &Self) -> Self {
+    fn inherit_from(&self, base: &Self) -> Self {
         Self {
             start_reducing_voting_power_after_seconds: self
                 .start_reducing_voting_power_after_seconds
-                .inherit_from(&filler.start_reducing_voting_power_after_seconds),
+                .inherit_from(&base.start_reducing_voting_power_after_seconds),
 
             clear_following_after_seconds: self
                 .clear_following_after_seconds
-                .inherit_from(&filler.clear_following_after_seconds),
+                .inherit_from(&base.clear_following_after_seconds),
         }
     }
 }

--- a/rs/nns/governance/src/network_economics_tests.rs
+++ b/rs/nns/governance/src/network_economics_tests.rs
@@ -10,15 +10,17 @@ fn test_inherit_from_recursively() {
         reject_cost_e8s: 99, // Change.
 
         neurons_fund_economics: Some(NeuronsFundEconomics {
-            neurons_fund_matched_funding_curve_coefficients: Some(NeuronsFundMatchedFundingCurveCoefficients {
-                // Deep change.
-                contribution_threshold_xdr: Some(ProtoDecimal {
-                    human_readable: Some("42".to_string()),
-                }),
+            neurons_fund_matched_funding_curve_coefficients: Some(
+                NeuronsFundMatchedFundingCurveCoefficients {
+                    // Deep change.
+                    contribution_threshold_xdr: Some(ProtoDecimal {
+                        human_readable: Some("42".to_string()),
+                    }),
 
-                one_third_participation_milestone_xdr: None,
-                ..Default::default()
-            }),
+                    one_third_participation_milestone_xdr: None,
+                    ..Default::default()
+                },
+            ),
 
             // This is equivalent to None, because 0 is ALWAYS vulnerable to
             // being overridden, even when inside Some. Therefore no change here.
@@ -57,7 +59,12 @@ fn test_inherit_from_recursively() {
             .minimum_icp_xdr_rate
             .as_mut()
             .unwrap();
-        assert_ne!(*minimum_icp_xdr_rate, Percentage { basis_points: Some(0) });
+        assert_ne!(
+            *minimum_icp_xdr_rate,
+            Percentage {
+                basis_points: Some(0)
+            }
+        );
 
         let contribution_threshold_xdr = neurons_fund_economics
             .neurons_fund_matched_funding_curve_coefficients

--- a/rs/nns/governance/src/network_economics_tests.rs
+++ b/rs/nns/governance/src/network_economics_tests.rs
@@ -15,7 +15,7 @@ fn test_inherit_from_recursively() {
             start_reducing_voting_power_after_seconds: Some(42),
 
             // This should not show up in the result.
-            clear_following_after_seconds: None
+            clear_following_after_seconds: None,
         }),
 
         // This should not show up in the result.

--- a/rs/nns/governance/src/network_economics_tests.rs
+++ b/rs/nns/governance/src/network_economics_tests.rs
@@ -1,0 +1,38 @@
+use super::*;
+use pretty_assertions::assert_eq;
+
+#[test]
+fn test_inherit_from_recursively() {
+    let base = NetworkEconomics::with_default_values();
+
+    let changes = NetworkEconomics {
+        reject_cost_e8s: 99,
+
+        // This should not show up in the result.
+        neuron_management_fee_per_proposal_e8s: 0,
+
+        voting_power_economics: Some(VotingPowerEconomics {
+            start_reducing_voting_power_after_seconds: Some(42),
+
+            // This should not show up in the result.
+            clear_following_after_seconds: None
+        }),
+
+        // This should not show up in the result.
+        neurons_fund_economics: None,
+
+        ..Default::default()
+    };
+
+    let observed_network_economics = changes.inherit_from(&base);
+
+    let mut expected_network_economics = NetworkEconomics::with_default_values();
+    expected_network_economics.reject_cost_e8s = 99;
+    expected_network_economics
+        .voting_power_economics
+        .as_mut()
+        .unwrap()
+        .start_reducing_voting_power_after_seconds = Some(42);
+
+    assert_eq!(observed_network_economics, expected_network_economics);
+}

--- a/rs/nns/governance/tests/governance.rs
+++ b/rs/nns/governance/tests/governance.rs
@@ -1693,7 +1693,8 @@ async fn test_minimum_icp_xdr_conversion_rate_limits_monthly_node_provider_rewar
 
 #[tokio::test]
 async fn test_manage_network_economics_change_one_deep_subfield() {
-    // Step 1: Prepare the world. We only really need a super basic Governance.
+    // Step 1: Prepare the world. All we need is a Governance with one neuron.
+    // The neuron will be used to make a ManageNetworkEconomics proposal.
 
     let controller = PrincipalId::new_user_test_id(519_572_717);
     let neuron = Neuron {

--- a/rs/nns/governance/tests/governance.rs
+++ b/rs/nns/governance/tests/governance.rs
@@ -1740,6 +1740,32 @@ async fn test_manage_network_economics_change_one_deep_subfield() {
         ..Default::default()
     });
 
+    // Assert that the proposal contains a different value for contribution_threshold_xdr.
+    {
+        let prior_contribution_threshold_xdr = gov
+            .heap_data
+            .economics
+            .as_ref()
+            .unwrap()
+            .neurons_fund_economics
+            .as_ref()
+            .unwrap()
+            .neurons_fund_matched_funding_curve_coefficients
+            .as_ref()
+            .unwrap()
+            .contribution_threshold_xdr
+            .as_ref()
+            .unwrap()
+            .human_readable
+            .as_deref()
+            .unwrap();
+        let prior_contribution_threshold_xdr =
+            rust_decimal::Decimal::try_from(prior_contribution_threshold_xdr).unwrap();
+
+        let proposal_contribution_threshold_xdr = rust_decimal::Decimal::from(123_456_789);
+
+        assert_ne!(prior_contribution_threshold_xdr, proposal_contribution_threshold_xdr);
+    }
     gov.make_proposal(
         &NeuronId { id: 1 },
         &controller,

--- a/rs/nns/governance/tests/governance.rs
+++ b/rs/nns/governance/tests/governance.rs
@@ -1764,7 +1764,10 @@ async fn test_manage_network_economics_change_one_deep_subfield() {
 
         let proposal_contribution_threshold_xdr = rust_decimal::Decimal::from(123_456_789);
 
-        assert_ne!(prior_contribution_threshold_xdr, proposal_contribution_threshold_xdr);
+        assert_ne!(
+            prior_contribution_threshold_xdr,
+            proposal_contribution_threshold_xdr
+        );
     }
     gov.make_proposal(
         &NeuronId { id: 1 },

--- a/rs/nns/governance/unreleased_changelog.md
+++ b/rs/nns/governance/unreleased_changelog.md
@@ -11,6 +11,9 @@ on the process that this file is part of, see
 
 ## Changed
 
+* ManageNetworkEconomics proposals can now modify deep fields one at a time.
+  Previously, this was only possible for top level fields.
+
 ## Deprecated
 
 ## Removed


### PR DESCRIPTION
This way, people can specify just one the inner/nested subfield at a time.

Some code was moved from src/governance.rs (this file is pretty dang large) to a new file: network_economics.rs.

# References

Close [NNS1-3499].

[NNS1-3499]: https://dfinity.atlassian.net/browse/NNS1-3499