### PR TITLE
feat(nervous-system): release runscript automatically creates changelog PRs

### DIFF
--- a/rs/nervous_system/tools/release-runscript/BUILD.bazel
+++ b/rs/nervous_system/tools/release-runscript/BUILD.bazel
@@ -28,6 +28,7 @@ DEPENDENCIES = [
 rust_binary(
     name = "release-runscript",
     srcs = [
+        "src/commit_switcher.rs",
         "src/main.rs",
         "src/utils.rs",
     ],

--- a/rs/nervous_system/tools/release-runscript/src/commit_switcher.rs
+++ b/rs/nervous_system/tools/release-runscript/src/commit_switcher.rs
@@ -1,6 +1,7 @@
-use std::process::{Command, Stdio};
+use crate::utils::ic_dir;
 use anyhow::Result;
 use colored::*;
+use std::process::Command;
 
 /// Helper struct to switch branches, then switch back when dropped.
 pub(crate) struct CommitSwitcher {
@@ -29,7 +30,7 @@ impl CommitSwitcher {
 
         // stash if we have changes
         if has_changes {
-            println!("{}", format!("Stashing changes...").bright_blue());
+            println!("{}", "Stashing changes...".bright_blue());
             let stash = Command::new("git").current_dir(&ic).arg("stash").output()?;
             if !stash.status.success() {
                 return Err(

--- a/rs/nervous_system/tools/release-runscript/src/main.rs
+++ b/rs/nervous_system/tools/release-runscript/src/main.rs
@@ -1,7 +1,9 @@
+mod commit_switcher;
 mod utils;
 use anyhow::{bail, Result};
 use clap::{Parser, Subcommand};
 use colored::*;
+use commit_switcher::CommitSwitcher;
 use std::path::PathBuf;
 use std::process::{Command, Stdio};
 use url::Url;
@@ -35,6 +37,8 @@ struct CreateProposalTexts {
 
 #[derive(Debug, Parser)]
 struct SubmitProposals {
+    #[arg(long)]
+    commit: String,
     #[arg(long, num_args = 0..,)]
     nns_proposal_text_paths: Vec<PathBuf>,
     #[arg(long, num_args = 0..,)]
@@ -43,6 +47,8 @@ struct SubmitProposals {
 
 #[derive(Debug, Parser)]
 struct CreateForumPost {
+    #[arg(long)]
+    commit: String,
     #[arg(long, num_args = 0..,)]
     nns_proposal_text_paths: Vec<PathBuf>,
     #[arg(long, num_args = 0..,)]
@@ -54,6 +60,8 @@ struct CreateForumPost {
 }
 #[derive(Debug, Parser)]
 struct ScheduleVote {
+    #[arg(long)]
+    commit: String,
     #[arg(long, num_args = 0..,)]
     nns_proposal_ids: Vec<String>,
     #[arg(long, num_args = 0..,)]
@@ -61,7 +69,14 @@ struct ScheduleVote {
 }
 
 #[derive(Debug, Parser)]
-struct UpdateChangelog;
+struct UpdateChangelog {
+    #[arg(long)]
+    commit: String,
+    #[arg(long, num_args = 0..,)]
+    nns_proposal_ids: Vec<String>,
+    #[arg(long, num_args = 0..,)]
+    sns_proposal_ids: Vec<String>,
+}
 
 #[derive(Debug, Subcommand)]
 enum Step {
@@ -102,6 +117,7 @@ fn main() -> Result<()> {
         }
     };
 
+    ensure_gh_setup()?;
     print_header();
 
     match args.step {
@@ -369,6 +385,7 @@ SNS proposal texts: {}",
     )?;
 
     run_submit_proposals(SubmitProposals {
+        commit,
         nns_proposal_text_paths,
         sns_proposal_text_paths,
     })
@@ -376,6 +393,7 @@ SNS proposal texts: {}",
 
 fn run_submit_proposals(cmd: SubmitProposals) -> Result<()> {
     let SubmitProposals {
+        commit,
         nns_proposal_text_paths,
         sns_proposal_text_paths,
     } = cmd;
@@ -480,6 +498,7 @@ fn run_submit_proposals(cmd: SubmitProposals) -> Result<()> {
     )?;
 
     run_create_forum_post(CreateForumPost {
+        commit,
         nns_proposal_text_paths,
         nns_proposal_ids,
         sns_proposal_text_paths,
@@ -489,6 +508,7 @@ fn run_submit_proposals(cmd: SubmitProposals) -> Result<()> {
 
 fn run_create_forum_post(cmd: CreateForumPost) -> Result<()> {
     let CreateForumPost {
+        commit,
         nns_proposal_text_paths,
         nns_proposal_ids,
         sns_proposal_text_paths,
@@ -597,6 +617,7 @@ fn run_create_forum_post(cmd: CreateForumPost) -> Result<()> {
 
     // Continue to the next automated step.
     run_schedule_vote(ScheduleVote {
+        commit,
         nns_proposal_ids,
         sns_proposal_ids,
     })
@@ -604,6 +625,7 @@ fn run_create_forum_post(cmd: CreateForumPost) -> Result<()> {
 
 fn run_schedule_vote(cmd: ScheduleVote) -> Result<()> {
     let ScheduleVote {
+        commit,
         nns_proposal_ids,
         sns_proposal_ids,
     } = cmd;
@@ -667,28 +689,98 @@ Calendar Event Setup:
    - If people don't respond, ping @trusted-neurons in #eng-release channel",
     )?;
 
-    run_update_changelog(UpdateChangelog)
+    run_update_changelog(UpdateChangelog {
+        commit,
+        nns_proposal_ids,
+        sns_proposal_ids,
+    })
 }
 
-fn run_update_changelog(_: UpdateChangelog) -> Result<()> {
+fn run_update_changelog(cmd: UpdateChangelog) -> Result<()> {
+    let UpdateChangelog {
+        commit,
+        nns_proposal_ids,
+        sns_proposal_ids,
+    } = cmd;
+
+    let ic = ic_dir();
+
+    use std::fmt::Write;
     print_step(
         8,
         "Update Changelog",
-        "Update CHANGELOG.md file(s) for each proposal:
-
-1. For each proposal ID:
-   ```bash
-   PROPOSAL_IDS=...
-
-   for PROPOSAL_ID in $PROPOSAL_IDS do
-       ./testnet/tools/nns-tools/add-release-to-changelog.sh \\
-           $PROPOSAL_ID
-   done
-   ```
-
-2. Best Practice:
-   - Combine this change with mainnet-canisters.json update in the same PR",
+        &format!(
+            "Now I'm going to update the changelog for the released canisters. This applies to the following proposals:
+NNS: {}
+SNS: {}",
+            nns_proposal_ids.iter().fold(String::new(), |mut acc, id| {
+                let _ = write!(acc, "\n  - {}", id);
+                acc
+            }),
+            sns_proposal_ids.iter().fold(String::new(), |mut acc, id| {
+                let _ = write!(acc, "\n  - {}", id);
+                acc
+            }),
+        ),
     )?;
+
+    {
+        // switch to the commit being released
+        let _commit_switcher = CommitSwitcher::switch(commit)?;
+
+        // update the changelog for each proposal
+        for proposal_id in nns_proposal_ids.iter().chain(sns_proposal_ids.iter()) {
+            println!("Updating changelog for proposal {}", proposal_id);
+            let script = ic.join("testnet/tools/nns-tools/add-release-to-changelog.sh");
+            let output = Command::new(script)
+                .arg(proposal_id)
+                .current_dir(&ic)
+                .output()?;
+
+            if !output.status.success() {
+                println!("{}", String::from_utf8_lossy(&output.stderr));
+                println!("Failed to update changelog for proposal {}", proposal_id);
+            }
+        }
+
+        println!("Changelogs updated. Now I'm going to create a branch, commit, push it, then create a PR using `gh`.");
+        press_enter_to_continue()?;
+
+        // Create branch with today's date
+        let today = chrono::Local::now().format("%Y-%m-%d").to_string();
+        let branch_name = format!("changelog-update-{}", today);
+        commit_all_into_branch(&branch_name)?;
+
+        // Create PR
+        let title = format!(
+            "chore(nervous-system): Update changelog for release {}",
+            today
+        );
+        let body = &format!(
+            "Update CHANGELOG.md for today's release.
+
+## NNS {}
+
+## SNS {}",
+            nns_proposal_ids.iter().fold(String::new(), |mut acc, id| {
+                let _ = write!(
+                    acc,
+                    "\n  - [{id}](https://dashboard.internetcomputer.org/proposal/{id})",
+                );
+                acc
+            }),
+            sns_proposal_ids.iter().fold(String::new(), |mut acc, id| {
+                let _ = write!(
+                    acc,
+                    "\n  - [{id}](https://dashboard.internetcomputer.org/proposal/{id})",
+                );
+                acc
+            }),
+        );
+        let pr_url = create_pr(&title, body)?;
+        open_webpage(&pr_url)?;
+        println!("PR created. Please share it with the team. It can be merged before the proposals are executed.");
+    }
 
     println!("{}", "\nRelease process complete!".bright_green().bold());
     println!("Please verify that all steps were completed successfully.");

--- a/testnet/tools/nns-tools/add-release-to-changelog.sh
+++ b/testnet/tools/nns-tools/add-release-to-changelog.sh
@@ -7,7 +7,7 @@ source "$NNS_TOOLS_DIR/lib/include.sh"
 help() {
     print_green "
 Usage: $0 <PROPOSAL_ID>
-    PROPOSAL_ID: The ID of a recently executed Governance backend canister upgrade proposal.
+    PROPOSAL_ID: The ID of a recently proposed Governance backend canister upgrade proposal.
 
     Moves the pending new changelog entry from unreleased_changelog.md to CHANGELOG.md.
 
@@ -44,10 +44,10 @@ if [[ "${LEN}" -ne 1 ]]; then
 fi
 PROPOSAL_INFO=$(echo "${PROPOSAL_INFO}" | jq '.[0]')
 
-# Assert was executed.
-EXECUTED_TIMESTAMP_SECONDS=$(echo "${PROPOSAL_INFO}" | jq '.executed_timestamp_seconds | tonumber')
-if [[ "${EXECUTED_TIMESTAMP_SECONDS}" -eq 0 ]]; then
-    print_red "💀 Proposal ${PROPOSAL_ID} exists, but was not successfully executed." >&2
+# Get proposal creation timestam.
+PROPOSED_TIMESTAMP_SECONDS=$(echo "${PROPOSAL_INFO}" | jq '.proposal_creation_timestamp_seconds | tonumber')
+if [[ "${PROPOSED_TIMESTAMP_SECONDS}" -eq 0 ]]; then
+    print_red "💀 Proposal ${PROPOSAL_ID} exists, but had no proposal_creation_timestamp_seconds." >&2
     exit 1
 fi
 
@@ -74,13 +74,13 @@ else
     print_red "(In particular, unable to determine which canister and commit.)" >&2
     exit 1
 fi
-SECONDS_AGO=$(($(date +%s) - "${EXECUTED_TIMESTAMP_SECONDS}"))
-EXECUTED_ON=$(
+SECONDS_AGO=$(($(date +%s) - "${PROPOSED_TIMESTAMP_SECONDS}"))
+PROPOSED_ON=$(
     date --utc \
-        --date=@"${EXECUTED_TIMESTAMP_SECONDS}" \
+        --date=@"${PROPOSED_TIMESTAMP_SECONDS}" \
         --iso-8601
 )
-print_cyan "🏃 ${GOVERNANCE_TYPE} ${CANISTER_NAME} proposal was executed ${SECONDS_AGO} seconds ago." >&2
+print_cyan "🏃 ${GOVERNANCE_TYPE} ${CANISTER_NAME} proposal was submitted ${SECONDS_AGO} seconds ago." >&2
 
 # Fail if the proposal's commit is not checked out.
 if [[ $(git rev-parse HEAD) != $DESTINATION_COMMIT_ID* ]]; then
@@ -117,7 +117,7 @@ if [[ -z "${NEW_FEATURES_AND_FIXES}" ]]; then
     print_red "💀 ${GOVERNANCE_TYPE} ${CANISTER_NAME}'s unreleased_changelog.md is EMPTY." >&2
     exit 1
 fi
-NEW_ENTRY="# ${EXECUTED_ON}: Proposal ${PROPOSAL_ID}
+NEW_ENTRY="# ${PROPOSED_ON}: Proposal ${PROPOSAL_ID}
 
 http://dashboard.internetcomputer.org/proposals/${PROPOSAL_ID}
 


### PR DESCRIPTION
This is the final step in the release process. Now everything is automated!

Here is an example of a PR it creates: #3807

To create the PR, we use `gh`, which we assert you have on your computer before the first step. (This ensures that you don't get to the last step and then hit an error which would be slightly annoying to recover from. Instead, you get the error right away, and it should be smooth sailing after that.)

The intention of this change is that you create the PR to update the changelog right when you create the proposals.

> Yes, we can optimistically assume that the proposal will pass. If it doesn't, we can revert the CHANGELOG.md. Branch predict FTW.
- @daniel-wong-dfinity-org 

A consequence of is that the changelog now shows the date of proposal submission, rather than execution. 

[← Previous PR](https://github.com/dfinity/ic/pull/3796)