### PR TITLE
feat(ckbtc): Place update_balance and retrieve_btc guards on user accounts

### DIFF
--- a/rs/bitcoin/ckbtc/minter/src/dashboard.rs
+++ b/rs/bitcoin/ckbtc/minter/src/dashboard.rs
@@ -508,16 +508,16 @@ pub fn build_unconfirmed_change(s: &CkBtcMinterState) -> String {
 
 pub fn build_update_balance_principals(s: &CkBtcMinterState) -> String {
     with_utf8_buffer(|buf| {
-        for p in &s.update_balance_principals {
-            writeln!(buf, "<li>{}</li>", p).unwrap();
+        for account in &s.update_balance_accounts {
+            writeln!(buf, "<li>{}</li>", account).unwrap();
         }
     })
 }
 
 pub fn build_retrieve_btc_principals(s: &CkBtcMinterState) -> String {
     with_utf8_buffer(|buf| {
-        for p in &s.retrieve_btc_principals {
-            writeln!(buf, "<li>{}</li>", p).unwrap();
+        for account in &s.retrieve_btc_accounts {
+            writeln!(buf, "<li>{}</li>", account).unwrap();
         }
     })
 }

--- a/rs/bitcoin/ckbtc/minter/src/guard.rs
+++ b/rs/bitcoin/ckbtc/minter/src/guard.rs
@@ -1,5 +1,5 @@
 use crate::state::{mutate_state, CkBtcMinterState};
-use candid::Principal;
+use icrc_ledger_types::icrc1::account::Account;
 use std::collections::BTreeSet;
 use std::marker::PhantomData;
 
@@ -12,21 +12,21 @@ pub enum GuardError {
 }
 
 pub trait PendingRequests {
-    fn pending_requests(state: &mut CkBtcMinterState) -> &mut BTreeSet<Principal>;
+    fn pending_requests(state: &mut CkBtcMinterState) -> &mut BTreeSet<Account>;
 }
 
 pub struct PendingBalanceUpdates;
 
 impl PendingRequests for PendingBalanceUpdates {
-    fn pending_requests(state: &mut CkBtcMinterState) -> &mut BTreeSet<Principal> {
-        &mut state.update_balance_principals
+    fn pending_requests(state: &mut CkBtcMinterState) -> &mut BTreeSet<Account> {
+        &mut state.update_balance_accounts
     }
 }
 pub struct RetrieveBtcUpdates;
 
 impl PendingRequests for RetrieveBtcUpdates {
-    fn pending_requests(state: &mut CkBtcMinterState) -> &mut BTreeSet<Principal> {
-        &mut state.retrieve_btc_principals
+    fn pending_requests(state: &mut CkBtcMinterState) -> &mut BTreeSet<Account> {
+        &mut state.retrieve_btc_accounts
     }
 }
 
@@ -34,7 +34,7 @@ impl PendingRequests for RetrieveBtcUpdates {
 /// executed [MAX_CONCURRENT] or more times in parallel.
 #[must_use]
 pub struct Guard<PR: PendingRequests> {
-    principal: Principal,
+    account: Account,
     _marker: PhantomData<PR>,
 }
 
@@ -42,18 +42,18 @@ impl<PR: PendingRequests> Guard<PR> {
     /// Attempts to create a new guard for the current block. Fails if there is
     /// already a pending request for the specified [principal] or if there
     /// are at least [MAX_CONCURRENT] pending requests.
-    pub fn new(principal: Principal) -> Result<Self, GuardError> {
+    pub fn new(account: Account) -> Result<Self, GuardError> {
         mutate_state(|s| {
-            let principals = PR::pending_requests(s);
-            if principals.contains(&principal) {
+            let accounts = PR::pending_requests(s);
+            if accounts.contains(&account) {
                 return Err(GuardError::AlreadyProcessing);
             }
-            if principals.len() >= MAX_CONCURRENT {
+            if accounts.len() >= MAX_CONCURRENT {
                 return Err(GuardError::TooManyConcurrentRequests);
             }
-            principals.insert(principal);
+            accounts.insert(account);
             Ok(Self {
-                principal,
+                account,
                 _marker: PhantomData,
             })
         })
@@ -62,7 +62,7 @@ impl<PR: PendingRequests> Guard<PR> {
 
 impl<PR: PendingRequests> Drop for Guard<PR> {
     fn drop(&mut self) {
-        mutate_state(|s| PR::pending_requests(s).remove(&self.principal));
+        mutate_state(|s| PR::pending_requests(s).remove(&self.account));
     }
 }
 
@@ -89,12 +89,12 @@ impl Drop for TimerLogicGuard {
     }
 }
 
-pub fn balance_update_guard(p: Principal) -> Result<Guard<PendingBalanceUpdates>, GuardError> {
-    Guard::new(p)
+pub fn balance_update_guard(account: Account) -> Result<Guard<PendingBalanceUpdates>, GuardError> {
+    Guard::new(account)
 }
 
-pub fn retrieve_btc_guard(p: Principal) -> Result<Guard<RetrieveBtcUpdates>, GuardError> {
-    Guard::new(p)
+pub fn retrieve_btc_guard(account: Account) -> Result<Guard<RetrieveBtcUpdates>, GuardError> {
+    Guard::new(account)
 }
 
 #[cfg(test)]
@@ -107,10 +107,17 @@ mod tests {
     use candid::Principal;
     use ic_base_types::CanisterId;
 
-    use super::{balance_update_guard, TimerLogicGuard};
+    use super::{balance_update_guard, Account, TimerLogicGuard};
 
     fn test_principal(id: u64) -> Principal {
         Principal::try_from_slice(&id.to_le_bytes()).unwrap()
+    }
+
+    fn test_account(id: u64, sub: Option<u8>) -> Account {
+        Account {
+            owner: test_principal(id),
+            subaccount: sub.map(|i| [i; 32]),
+        }
     }
 
     #[allow(deprecated)]
@@ -136,13 +143,15 @@ mod tests {
         // and that a guard is properly dropped at end of the block
 
         init(test_state_args());
-        let p = test_principal(0);
+        // a1 and a2 are effectively the same Account
+        let a1 = test_account(0, None);
+        let a2 = test_account(0, Some(0));
         {
-            let _guard = balance_update_guard(p).unwrap();
-            let res = balance_update_guard(p).err();
+            let _guard = balance_update_guard(a1).unwrap();
+            let res = balance_update_guard(a2).err();
             assert_eq!(res, Some(GuardError::AlreadyProcessing));
         }
-        let _ = balance_update_guard(p).unwrap();
+        let _ = balance_update_guard(a1).unwrap();
     }
 
     #[test]
@@ -153,14 +162,14 @@ mod tests {
         init(test_state_args());
         let guards: Vec<_> = (0..MAX_CONCURRENT)
             .map(|id| {
-                balance_update_guard(test_principal(id as u64)).unwrap_or_else(|e| {
+                balance_update_guard(test_account(id as u64, None)).unwrap_or_else(|e| {
                     panic!("Could not create guard for principal num {}: {:#?}", id, e)
                 })
             })
             .collect();
         assert_eq!(guards.len(), MAX_CONCURRENT);
-        let pid = test_principal(MAX_CONCURRENT as u64 + 1);
-        let res = balance_update_guard(pid).err();
+        let account = test_account(MAX_CONCURRENT as u64 + 1, None);
+        let res = balance_update_guard(account).err();
         assert_eq!(res, Some(GuardError::TooManyConcurrentRequests));
     }
 

--- a/rs/bitcoin/ckbtc/minter/src/metrics.rs
+++ b/rs/bitcoin/ckbtc/minter/src/metrics.rs
@@ -225,13 +225,13 @@ pub fn encode_metrics(
 
     metrics.encode_gauge(
         "ckbtc_minter_concurrent_update_balance_count",
-        state::read_state(|s| s.update_balance_principals.len()) as f64,
+        state::read_state(|s| s.update_balance_accounts.len()) as f64,
         "Total number of concurrent update_balance requests.",
     )?;
 
     metrics.encode_gauge(
         "ckbtc_minter_concurrent_retrieve_btc_count",
-        state::read_state(|s| s.retrieve_btc_principals.len()) as f64,
+        state::read_state(|s| s.retrieve_btc_accounts.len()) as f64,
         "Total number of concurrent retrieve_btc requests.",
     )?;
 

--- a/rs/bitcoin/ckbtc/minter/src/state.rs
+++ b/rs/bitcoin/ckbtc/minter/src/state.rs
@@ -301,11 +301,11 @@ pub struct CkBtcMinterState {
     /// before being sent.
     pub max_time_in_queue_nanos: u64,
 
-    /// Per-principal lock for update_balance
-    pub update_balance_principals: BTreeSet<Principal>,
+    /// Per-account lock for update_balance
+    pub update_balance_accounts: BTreeSet<Account>,
 
-    /// Per-principal lock for retrieve_btc
-    pub retrieve_btc_principals: BTreeSet<Principal>,
+    /// Per-account lock for retrieve_btc
+    pub retrieve_btc_accounts: BTreeSet<Account>,
 
     /// Minimum amount of bitcoin that can be retrieved
     pub retrieve_btc_min_amount: u64,
@@ -367,14 +367,13 @@ pub struct CkBtcMinterState {
     pub utxos_state_addresses: BTreeMap<Account, BTreeSet<Utxo>>,
 
     /// This map contains the UTXOs we removed due to a transaction finalization
-    /// while there was a concurrent update_balance call for the principal whose
-    /// UTXOs participated in the transaction. The UTXOs can belong to any
-    /// subaccount of the principal.
+    /// while there was a concurrent update_balance call for the account whose
+    /// UTXOs participated in the transaction.
     ///
     /// We insert a new entry into this map if we discover a concurrent
     /// update_balance calls during a transaction finalization and remove the
     /// entry once the update_balance call completes.
-    pub finalized_utxos: BTreeMap<Principal, BTreeSet<Utxo>>,
+    pub finalized_utxos: BTreeMap<Account, BTreeSet<Utxo>>,
 
     /// Process one timer event at a time.
     pub is_timer_running: bool,
@@ -696,9 +695,9 @@ impl CkBtcMinterState {
 
     fn forget_utxo(&mut self, utxo: &Utxo) {
         if let Some(account) = self.outpoint_account.remove(&utxo.outpoint) {
-            if self.update_balance_principals.contains(&account.owner) {
+            if self.update_balance_accounts.contains(&account) {
                 self.finalized_utxos
-                    .entry(account.owner)
+                    .entry(account)
                     .or_default()
                     .insert(utxo.clone());
             }
@@ -932,7 +931,7 @@ impl CkBtcMinterState {
     /// Return UTXOs of the given account that are known to the minter.
     pub fn known_utxos_for_account(&self, account: &Account) -> Vec<Utxo> {
         let maybe_existing_utxos = self.utxos_state_addresses.get(account);
-        let maybe_finalized_utxos = self.finalized_utxos.get(&account.owner);
+        let maybe_finalized_utxos = self.finalized_utxos.get(&account);
         match (maybe_existing_utxos, maybe_finalized_utxos) {
             (Some(existing_utxos), Some(finalized_utxos)) => existing_utxos
                 .union(finalized_utxos)
@@ -965,7 +964,7 @@ impl CkBtcMinterState {
                 .unwrap_or(false)
                 || self
                     .finalized_utxos
-                    .get(&account.owner)
+                    .get(&account)
                     .map(|utxos| utxos.contains(utxo))
                     .unwrap_or(false)
         };
@@ -1452,8 +1451,8 @@ impl From<InitArgs> for CkBtcMinterState {
                 .min_confirmations
                 .unwrap_or(crate::lifecycle::init::DEFAULT_MIN_CONFIRMATIONS),
             max_time_in_queue_nanos: args.max_time_in_queue_nanos,
-            update_balance_principals: Default::default(),
-            retrieve_btc_principals: Default::default(),
+            update_balance_accounts: Default::default(),
+            retrieve_btc_accounts: Default::default(),
             retrieve_btc_min_amount: args.retrieve_btc_min_amount,
             fee_based_retrieve_btc_min_amount: args.retrieve_btc_min_amount,
             pending_retrieve_btc_requests: Default::default(),

--- a/rs/bitcoin/ckbtc/minter/src/state.rs
+++ b/rs/bitcoin/ckbtc/minter/src/state.rs
@@ -931,7 +931,7 @@ impl CkBtcMinterState {
     /// Return UTXOs of the given account that are known to the minter.
     pub fn known_utxos_for_account(&self, account: &Account) -> Vec<Utxo> {
         let maybe_existing_utxos = self.utxos_state_addresses.get(account);
-        let maybe_finalized_utxos = self.finalized_utxos.get(&account);
+        let maybe_finalized_utxos = self.finalized_utxos.get(account);
         match (maybe_existing_utxos, maybe_finalized_utxos) {
             (Some(existing_utxos), Some(finalized_utxos)) => existing_utxos
                 .union(finalized_utxos)
@@ -964,7 +964,7 @@ impl CkBtcMinterState {
                 .unwrap_or(false)
                 || self
                     .finalized_utxos
-                    .get(&account)
+                    .get(account)
                     .map(|utxos| utxos.contains(utxo))
                     .unwrap_or(false)
         };

--- a/rs/bitcoin/ckbtc/minter/src/updates/retrieve_btc.rs
+++ b/rs/bitcoin/ckbtc/minter/src/updates/retrieve_btc.rs
@@ -165,7 +165,10 @@ pub async fn retrieve_btc(args: RetrieveBtcArgs) -> Result<RetrieveBtcOk, Retrie
         ic_cdk::trap("illegal retrieve_btc target");
     }
 
-    let _guard = retrieve_btc_guard(caller)?;
+    let _guard = retrieve_btc_guard(Account {
+        owner: caller,
+        subaccount: None,
+    })?;
     let (min_retrieve_amount, btc_network) =
         read_state(|s| (s.fee_based_retrieve_btc_min_amount, s.btc_network));
 
@@ -269,8 +272,11 @@ pub async fn retrieve_btc_with_approval(
     if args.address == main_address.display(state::read_state(|s| s.btc_network)) {
         ic_cdk::trap("illegal retrieve_btc target");
     }
-
-    let _guard = retrieve_btc_guard(caller)?;
+    let caller_account = Account {
+        owner: caller,
+        subaccount: args.from_subaccount,
+    };
+    let _guard = retrieve_btc_guard(caller_account)?;
     let (min_retrieve_amount, btc_network) =
         read_state(|s| (s.fee_based_retrieve_btc_min_amount, s.btc_network));
     if args.amount < min_retrieve_amount {
@@ -320,10 +326,7 @@ pub async fn retrieve_btc_with_approval(
         status: None,
     };
     let block_index = burn_ckbtcs_icrc2(
-        Account {
-            owner: caller,
-            subaccount: args.from_subaccount,
-        },
+        caller_account,
         args.amount,
         crate::memo::encode(&burn_memo_icrc2).into(),
     )

--- a/rs/bitcoin/ckbtc/minter/src/updates/update_balance.rs
+++ b/rs/bitcoin/ckbtc/minter/src/updates/update_balance.rs
@@ -159,12 +159,12 @@ pub async fn update_balance<R: CanisterRuntime>(
         .map_err(UpdateBalanceError::TemporarilyUnavailable)?;
 
     init_ecdsa_public_key().await;
-    let _guard = balance_update_guard(args.owner.unwrap_or(caller))?;
 
     let caller_account = Account {
         owner: args.owner.unwrap_or(caller),
         subaccount: args.subaccount,
     };
+    let _guard = balance_update_guard(caller_account)?;
 
     let address = state::read_state(|s| {
         get_btc_address::account_to_p2wpkh_address_from_state(s, &caller_account)
@@ -187,8 +187,8 @@ pub async fn update_balance<R: CanisterRuntime>(
     let (processable_utxos, suspended_utxos) =
         state::read_state(|s| s.processable_utxos_for_account(utxos, &caller_account, &now));
 
-    // Remove pending finalized transactions for the affected principal.
-    state::mutate_state(|s| s.finalized_utxos.remove(&caller_account.owner));
+    // Remove pending finalized transactions for the affected account.
+    state::mutate_state(|s| s.finalized_utxos.remove(&caller_account));
 
     let satoshis_to_mint = processable_utxos.iter().map(|u| u.value).sum::<u64>();
 


### PR DESCRIPTION
XC-299: Change the reentrancy guards used in update_balance and retrieve_btc from user principals to accounts.

This allows more concurrency in update_balance or retrieve_btc calls.