### PR TITLE
test(btc): Port ckBTC tests from legacy ECDSA to chain key Registry API

### DIFF
--- a/rs/consensus/tests/framework/mod.rs
+++ b/rs/consensus/tests/framework/mod.rs
@@ -23,7 +23,7 @@ use ic_protobuf::registry::subnet::v1::{CatchUpPackageContents, InitialNiDkgTran
 use ic_registry_client_fake::FakeRegistryClient;
 use ic_registry_client_helpers::crypto::CryptoRegistry;
 use ic_registry_proto_data_provider::ProtoRegistryDataProvider;
-use ic_registry_subnet_features::{ChainKeyConfig, EcdsaConfig, KeyConfig};
+use ic_registry_subnet_features::{ChainKeyConfig, KeyConfig};
 use ic_test_utilities_consensus::make_genesis;
 use ic_test_utilities_registry::SubnetRecordBuilder;
 use ic_types::{

--- a/rs/messaging/src/message_routing/tests.rs
+++ b/rs/messaging/src/message_routing/tests.rs
@@ -24,7 +24,7 @@ use ic_registry_local_registry::LocalRegistry;
 use ic_registry_local_store::{compact_delta_to_changelog, LocalStoreImpl, LocalStoreWriter};
 use ic_registry_proto_data_provider::{ProtoRegistryDataProvider, ProtoRegistryDataProviderError};
 use ic_registry_routing_table::{routing_table_insert_subnet, CanisterMigrations, RoutingTable};
-use ic_registry_subnet_features::{ChainKeyConfig, EcdsaConfig, KeyConfig};
+use ic_registry_subnet_features::{ChainKeyConfig, KeyConfig};
 use ic_replicated_state::Stream;
 use ic_test_utilities::state_manager::FakeStateManager;
 use ic_test_utilities_logger::with_test_replica_logger;

--- a/rs/messaging/src/message_routing/tests.rs
+++ b/rs/messaging/src/message_routing/tests.rs
@@ -267,10 +267,6 @@ struct SubnetRecord<'a> {
     membership: &'a [NodeId],
     subnet_type: SubnetType,
     features: SubnetFeatures,
-    // TODO: Remove this field
-    #[allow(unused)]
-    ecdsa_config: EcdsaConfig,
-    /// This field will replace ecdsa_config.
     chain_key_config: ChainKeyConfig,
     max_number_of_canisters: u64,
 }
@@ -732,7 +728,6 @@ fn try_read_registry_succeeds_with_fully_specified_registry_records() {
                 http_requests: true,
                 ..Default::default()
             },
-            ecdsa_config: EcdsaConfig::default(),
             chain_key_config: ChainKeyConfig {
                 key_configs: vec![
                     KeyConfig {
@@ -1715,24 +1710,28 @@ fn process_batch_updates_subnet_metrics() {
                 http_requests: true,
                 ..Default::default()
             },
-            ecdsa_config: EcdsaConfig {
-                key_ids: vec![
-                    EcdsaKeyId {
-                        curve: EcdsaCurve::Secp256k1,
-                        name: "ecdsa key 1".to_string(),
+            max_number_of_canisters: 387,
+            chain_key_config: ChainKeyConfig {
+                key_configs: vec![
+                    KeyConfig {
+                        key_id: MasterPublicKeyId::Ecdsa(EcdsaKeyId {
+                            curve: EcdsaCurve::Secp256k1,
+                            name: "ecdsa key 1".to_string(),
+                        }),
+                        max_queue_size: 891,
+                        pre_signatures_to_create_in_advance: 891,
                     },
-                    EcdsaKeyId {
-                        curve: EcdsaCurve::Secp256k1,
-                        name: "ecdsa key 2".to_string(),
+                    KeyConfig {
+                        key_id: MasterPublicKeyId::Ecdsa(EcdsaKeyId {
+                            curve: EcdsaCurve::Secp256k1,
+                            name: "ecdsa key 2".to_string(),
+                        }),
+                        max_queue_size: 891,
+                        pre_signatures_to_create_in_advance: 891,
                     },
                 ],
-                max_queue_size: Some(891),
                 ..Default::default()
             },
-            // TODO[NNS1-2969]: Use this field rather than ecdsa_config.
-            chain_key_config: ChainKeyConfig::default(),
-
-            max_number_of_canisters: 387,
         };
 
         let own_transcript = dummy_transcript_for_tests_with_params(

--- a/rs/registry/admin/src/types.rs
+++ b/rs/registry/admin/src/types.rs
@@ -13,7 +13,7 @@ use ic_protobuf::registry::{
 };
 use ic_registry_nns_data_provider::registry::RegistryCanister;
 use ic_registry_provisional_whitelist::ProvisionalWhitelist;
-use ic_registry_subnet_features::{ChainKeyConfig, EcdsaConfig, SubnetFeatures};
+use ic_registry_subnet_features::{ChainKeyConfig, SubnetFeatures};
 use ic_registry_subnet_type::SubnetType;
 use ic_types::{PrincipalId, SubnetId};
 use indexmap::IndexMap;
@@ -74,7 +74,6 @@ pub(crate) struct SubnetRecord {
     pub max_number_of_canisters: u64,
     pub ssh_readonly_access: Vec<String>,
     pub ssh_backup_access: Vec<String>,
-    pub ecdsa_config: Option<EcdsaConfig>,
     pub chain_key_config: Option<ChainKeyConfig>,
 }
 
@@ -124,10 +123,6 @@ impl From<&SubnetRecordProto> for SubnetRecord {
             max_number_of_canisters: value.max_number_of_canisters,
             ssh_readonly_access: value.ssh_readonly_access.clone(),
             ssh_backup_access: value.ssh_backup_access.clone(),
-            ecdsa_config: value
-                .ecdsa_config
-                .as_ref()
-                .map(|c| c.clone().try_into().unwrap()),
             chain_key_config: value
                 .chain_key_config
                 .as_ref()

--- a/rs/registry/canister/src/mutations/do_update_subnet.rs
+++ b/rs/registry/canister/src/mutations/do_update_subnet.rs
@@ -646,7 +646,7 @@ mod tests {
                 .into(),
             ),
             ecdsa_config: None,
-            ecdsa_key_signing_enable: Some(vec![make_ecdsa_key("key_id_2")]),
+            ecdsa_key_signing_enable: None,
             ecdsa_key_signing_disable: None,
             max_number_of_canisters: Some(10),
             ssh_readonly_access: Some(vec!["pub_key_0".to_string()]),

--- a/rs/registry/canister/src/mutations/do_update_subnet.rs
+++ b/rs/registry/canister/src/mutations/do_update_subnet.rs
@@ -537,13 +537,6 @@ mod tests {
     use maplit::btreemap;
     use std::str::FromStr;
 
-    fn make_ecdsa_key(name: &str) -> EcdsaKeyId {
-        EcdsaKeyId {
-            curve: EcdsaCurve::Secp256k1,
-            name: name.to_string(),
-        }
-    }
-
     fn make_empty_update_payload(subnet_id: SubnetId) -> UpdateSubnetPayload {
         UpdateSubnetPayload {
             subnet_id,

--- a/rs/registry/subnet_features/src/lib.rs
+++ b/rs/registry/subnet_features/src/lib.rs
@@ -97,36 +97,6 @@ pub struct EcdsaConfig {
     pub idkg_key_rotation_period_ms: Option<u64>,
 }
 
-impl From<EcdsaConfig> for pb::EcdsaConfig {
-    fn from(item: EcdsaConfig) -> Self {
-        pb::EcdsaConfig {
-            quadruples_to_create_in_advance: item.quadruples_to_create_in_advance,
-            key_ids: item.key_ids.iter().map(|key| key.into()).collect(),
-            max_queue_size: item.max_queue_size.unwrap_or(DEFAULT_ECDSA_MAX_QUEUE_SIZE),
-            signature_request_timeout_ns: item.signature_request_timeout_ns,
-            idkg_key_rotation_period_ms: item.idkg_key_rotation_period_ms,
-        }
-    }
-}
-
-impl TryFrom<pb::EcdsaConfig> for EcdsaConfig {
-    type Error = ProxyDecodeError;
-
-    fn try_from(value: pb::EcdsaConfig) -> Result<Self, Self::Error> {
-        let mut key_ids = vec![];
-        for key in value.key_ids {
-            key_ids.push(EcdsaKeyId::try_from(key)?);
-        }
-        Ok(EcdsaConfig {
-            quadruples_to_create_in_advance: value.quadruples_to_create_in_advance,
-            key_ids,
-            max_queue_size: Some(value.max_queue_size),
-            signature_request_timeout_ns: value.signature_request_timeout_ns,
-            idkg_key_rotation_period_ms: value.idkg_key_rotation_period_ms,
-        })
-    }
-}
-
 #[derive(Clone, Eq, PartialEq, Debug, CandidType, Deserialize, Serialize)]
 pub struct KeyConfig {
     pub key_id: MasterPublicKeyId,

--- a/rs/tests/ckbtc/src/lib.rs
+++ b/rs/tests/ckbtc/src/lib.rs
@@ -29,8 +29,7 @@ use ic_nns_governance_api::pb::v1::{NnsFunction, ProposalStatus};
 use ic_nns_test_utils::{
     governance::submit_external_update_proposal, itest_helpers::install_rust_canister_from_path,
 };
-use registry_canister::mutations::do_update_subnet::{ChainKeyConfig, KeyConfig};
-use ic_registry_subnet_features::{DEFAULT_ECDSA_MAX_QUEUE_SIZE, SubnetFeatures};
+use ic_registry_subnet_features::{SubnetFeatures, DEFAULT_ECDSA_MAX_QUEUE_SIZE};
 use ic_registry_subnet_type::SubnetType;
 use ic_system_test_driver::{
     driver::{
@@ -49,6 +48,7 @@ use ic_types::Height;
 use ic_types_test_utils::ids::subnet_test_id;
 use icp_ledger::ArchiveOptions;
 use registry_canister::mutations::do_update_subnet::UpdateSubnetPayload;
+use registry_canister::mutations::do_update_subnet::{ChainKeyConfig, KeyConfig};
 use slog::{debug, info, Logger};
 use std::{
     env,
@@ -253,13 +253,11 @@ async fn enable_ecdsa_signing(governance: &Canister<'_>, subnet_id: SubnetId, ke
     let proposal_payload = UpdateSubnetPayload {
         subnet_id,
         chain_key_config: Some(ChainKeyConfig {
-            key_configs: vec![
-                KeyConfig {
-                    key_id: Some(key_id.clone()),
-                    pre_signatures_to_create_in_advance: Some(10),
-                    max_queue_size: Some(DEFAULT_ECDSA_MAX_QUEUE_SIZE),
-                },
-            ],
+            key_configs: vec![KeyConfig {
+                key_id: Some(key_id.clone()),
+                pre_signatures_to_create_in_advance: Some(10),
+                max_queue_size: Some(DEFAULT_ECDSA_MAX_QUEUE_SIZE),
+            }],
             signature_request_timeout_ns: None,
             idkg_key_rotation_period_ms: None,
         }),


### PR DESCRIPTION
This PR adjusts ckBTC tests (and a test in message routing) to use the new chain key API, since the old one is now obsolete.

Additionally, the legacy code is further cleaned in in the Registry component (canister and ic-admin).