### PR TITLE
ci: change cross-chain team notification channel

### DIFF
--- a/.github/workflows/team-channels.json
+++ b/.github/workflows/team-channels.json
@@ -1,7 +1,7 @@
 {
     "boundary-node": "eng-boundary-nodes",
     "Consensus": "eng-consensus-prs",
-    "cross-chain-team": "eng-cross-chain",
+    "cross-chain-team": "eng-cross-chain-prs",
     "crypto-team": "eng-crypto-mr",
     "DRE": "eng-release-bots",
     "execution": "eng-execution-mrs",


### PR DESCRIPTION
Change the Slack notification channel for the cross-chain team to a dedicated channel `eng-cross-chain-prs` 