### PR TITLE
chore(IDX): remove ic-os pre-check

### DIFF
--- a/ic-os/defs.bzl
+++ b/ic-os/defs.bzl
@@ -47,19 +47,6 @@ def icos_build(
 
     image_deps = image_deps_func(mode, malicious)
 
-    # -------------------- Pre-check --------------------
-
-    # Verify that all the referenced components exist
-    native.genrule(
-        name = name + "_pre_check",
-        srcs = [k for k, v in image_deps["component_files"].items()],
-        outs = [name + "_pre_check_result.txt"],
-        cmd = """
-            echo "Running pre_check for {name}"
-            echo "All paths exist" > $@
-        """,
-    )
-
     # -------------------- Version management --------------------
 
     copy_file(
@@ -606,7 +593,6 @@ EOF
         name = name,
         testonly = malicious,
         srcs = [
-            name + "_pre_check_result.txt",
             ":disk-img.tar.zst",
         ] + ([
             ":update-img.tar.zst",


### PR DESCRIPTION
The `_pre_check` pre checks were used to ensure all inputs did exist before the action ran. Bazel does however ensure that the files exist, and it's not even guaranteed that Bazel will build the pre-check before the action that actually requires said inputs, making the check speedups unreliable.