### PR TITLE
feat(nns): Improve ExecuteNnsFunction proposal validation

### DIFF
--- a/rs/nns/governance/protobuf_generator/src/lib.rs
+++ b/rs/nns/governance/protobuf_generator/src/lib.rs
@@ -68,6 +68,10 @@ pub fn generate_prost_files(proto: ProtoPaths<'_>, out: &Path) {
         "ic_nns_governance.pb.v1.Topic",
         "#[derive(strum_macros::EnumIter)]",
     );
+    config.type_attribute(
+        "ic_nns_governance.pb.v1.NnsFunction",
+        "#[derive(strum_macros::EnumIter)]",
+    );
 
     // Eq
     // --

--- a/rs/nns/governance/src/gen/ic_nns_governance.pb.v1.rs
+++ b/rs/nns/governance/src/gen/ic_nns_governance.pb.v1.rs
@@ -4623,6 +4623,7 @@ impl Vote {
     candid::Deserialize,
     serde::Serialize,
     comparable::Comparable,
+    strum_macros::EnumIter,
     Clone,
     Copy,
     Debug,

--- a/rs/nns/governance/src/governance/tests/mod.rs
+++ b/rs/nns/governance/src/governance/tests/mod.rs
@@ -1371,35 +1371,47 @@ fn test_validate_execute_nns_function() {
                 nns_function: NnsFunction::UpdateAllowedPrincipals as i32,
                 payload: vec![],
             },
-            "NNS_FUNCTION_UPDATE_ALLOWED_PRINCIPALS proposal is obsolete".to_string(),
+            "Proposal is obsolete because NNS_FUNCTION_UPDATE_ALLOWED_PRINCIPALS is only used for \
+            the old SNS initialization mechanism, which is now obsolete. Use \
+            CREATE_SERVICE_NERVOUS_SYSTEM instead."
+                .to_string(),
         ),
         (
             ExecuteNnsFunction {
                 nns_function: NnsFunction::UpdateApiBoundaryNodesVersion as i32,
                 payload: vec![],
             },
-            "NNS_FUNCTION_UPDATE_API_BOUNDARY_NODES_VERSION proposal is obsolete".to_string(),
+            "Proposal is obsolete because NNS_FUNCTION_UPDATE_API_BOUNDARY_NODES_VERSION is obsolete. \
+            Use NNS_FUNCTION_DEPLOY_GUESTOS_TO_SOME_API_BOUNDARY_NODES instead."
+                .to_string(),
         ),
         (
             ExecuteNnsFunction {
                 nns_function: NnsFunction::UpdateUnassignedNodesConfig as i32,
                 payload: vec![],
             },
-            "NNS_FUNCTION_UPDATE_UNASSIGNED_NODES_CONFIG proposal is obsolete".to_string(),
+            "Proposal is obsolete because NNS_FUNCTION_UPDATE_UNASSIGNED_NODES_CONFIG is obsolete. \
+            Use NNS_FUNCTION_DEPLOY_GUESTOS_TO_ALL_UNASSIGNED_NODES/\
+            NNS_FUNCTION_UPDATE_SSH_READONLY_ACCESS_FOR_ALL_UNASSIGNED_NODES instead."
+                .to_string(),
         ),
         (
             ExecuteNnsFunction {
                 nns_function: NnsFunction::UpdateElectedHostosVersions as i32,
                 payload: vec![],
             },
-            "NNS_FUNCTION_UPDATE_ELECTED_HOSTOS_VERSIONS proposal is obsolete".to_string(),
+            "Proposal is obsolete because NNS_FUNCTION_UPDATE_ELECTED_HOSTOS_VERSIONS is obsolete. \
+            Use NNS_FUNCTION_REVISE_ELECTED_HOSTOS_VERSIONS instead."
+                .to_string(),
         ),
         (
             ExecuteNnsFunction {
                 nns_function: NnsFunction::UpdateNodesHostosVersion as i32,
                 payload: vec![],
             },
-            "NNS_FUNCTION_UPDATE_NODES_HOSTOS_VERSION proposal is obsolete".to_string(),
+            "Proposal is obsolete because NNS_FUNCTION_UPDATE_NODES_HOSTOS_VERSION is obsolete. \
+            Use NNS_FUNCTION_DEPLOY_HOSTOS_TO_SOME_NODES instead."
+                .to_string(),
         ),
     ];
 

--- a/rs/nns/governance/src/governance/tests/mod.rs
+++ b/rs/nns/governance/src/governance/tests/mod.rs
@@ -1480,6 +1480,17 @@ fn test_validate_execute_nns_function() {
 }
 
 #[test]
+fn test_canister_and_function_no_unreachable() {
+    use strum::IntoEnumIterator;
+
+    for nns_function in NnsFunction::iter() {
+        // This will return either `Ok(_)` for nns functions that are still used, or `Err(_)` for
+        // obsolete ones. The test just makes sure that it doesn't panic.
+        let _ = nns_function.canister_and_function();
+    }
+}
+
+#[test]
 fn test_deciding_voting_power_adjustment_factor() {
     let voting_power_economics = VotingPowerEconomics {
         start_reducing_voting_power_after_seconds: Some(60),


### PR DESCRIPTION
# Why

Obsolete NNS Functions are not handled very nicely - it just said "... is obsolete". When making `NnsCanisterUpgrade` obsolete previously, there were some confusions since the error message wasn't ideal. In addition, `is_obsolete` happened after `can_have_large_payload`, so obsolete functions might hit the `can_have_large_payload` first.

# What

* Change `is_obsolete` to `check_obsolete` which returns an error message
* Move `can_have_large_payload` after `check_obsolete`
* `UpdateUnassignedNodesConfig` is obsolete but wasn't handled in `canister_and_function`. This PR fixes that.
  * It doesn't really matter, since `is_obsolete` already returns true, so it's impossible for such proposals to be created, so `canister_and_function` won't be called with this nns function at the execution time.