### PR TITLE
fix(IDX): skip build determinism if files were not rebuilt

### DIFF
--- a/ci/scripts/build-determinism.sh
+++ b/ci/scripts/build-determinism.sh
@@ -6,9 +6,14 @@ VERSION="$(git rev-parse HEAD)"
 
 # PATH0
 mkdir -p "$PATH0"
-curl -sfS --retry 5 --retry-delay 10 \
+if ! curl -sfS --retry 5 --retry-delay 10 \
     "https://download.dfinity.systems/ic/$VERSION/$PATH0/SHA256SUMS" \
-    -o "$PATH0/SHA256SUMS"
+    -o "$PATH0/SHA256SUMS"; then
+
+    # workaround until we have a better way to pass SHA256SUMS files around
+    echo "Assuming artifacts were not rebuilt"
+    exit 0
+fi
 
 # ignore *.wasm.gz.did files (these are checksummed by upload_artifacts but
 # not by build-ic.sh)


### PR DESCRIPTION
This implements a workaround to return successfully from the build determinism check if no artifacts were built/uploaded.

The correct fix would be to pass the shasums via GHA artifacts. Until then, we make sure not to fail if the artifacts were not uploaded to S3 (i.e. returning 403).