### PR TITLE
feat(MR): Basic metrics for best-effort calls

### DIFF
--- a/rs/execution_environment/src/scheduler.rs
+++ b/rs/execution_environment/src/scheduler.rs
@@ -1954,6 +1954,7 @@ fn observe_replicated_state_metrics(
     let mut queues_response_bytes = 0;
     let mut queues_memory_reservations = 0;
     let mut queues_oversized_requests_extra_bytes = 0;
+    let mut queues_best_effort_message_bytes = 0;
     let mut canisters_not_in_routing_table = 0;
     let mut canisters_with_old_open_call_contexts = 0;
     let mut old_call_contexts_count = 0;
@@ -2007,6 +2008,7 @@ fn observe_replicated_state_metrics(
         queues_response_bytes += queues.guaranteed_responses_size_bytes();
         queues_memory_reservations += queues.guaranteed_response_memory_reservations();
         queues_oversized_requests_extra_bytes += queues.oversized_guaranteed_requests_extra_bytes();
+        queues_best_effort_message_bytes += queues.best_effort_message_memory_usage();
         if !canister_id_ranges.contains(&canister.canister_id()) {
             canisters_not_in_routing_table += 1;
         }
@@ -2110,6 +2112,7 @@ fn observe_replicated_state_metrics(
     metrics.observe_queues_response_bytes(queues_response_bytes);
     metrics.observe_queues_memory_reservations(queues_memory_reservations);
     metrics.observe_oversized_requests_extra_bytes(queues_oversized_requests_extra_bytes);
+    metrics.observe_queues_best_effort_message_bytes(queues_best_effort_message_bytes);
 
     metrics
         .ingress_history_length

--- a/rs/execution_environment/src/scheduler/scheduler_metrics.rs
+++ b/rs/execution_environment/src/scheduler/scheduler_metrics.rs
@@ -60,6 +60,7 @@ pub(super) struct SchedulerMetrics {
     pub(super) queues_response_bytes: IntGauge,
     pub(super) queues_memory_reservations: IntGauge,
     pub(super) queues_oversized_requests_extra_bytes: IntGauge,
+    pub(super) queues_best_effort_message_bytes: IntGauge,
     pub(super) canister_messages_where_cycles_were_charged: IntCounter,
     pub(super) current_heap_delta: IntGauge,
     pub(super) round_skipped_due_to_current_heap_delta_above_limit: IntCounter,
@@ -302,6 +303,10 @@ impl SchedulerMetrics {
             queues_oversized_requests_extra_bytes: metrics_registry.int_gauge(
                 "execution_queues_oversized_requests_extra_bytes",
                 "Total bytes above `MAX_RESPONSE_COUNT_BYTES` across oversized local-subnet requests.",
+            ),
+            queues_best_effort_message_bytes: metrics_registry.int_gauge(
+                "execution_queues_best_effort_message_bytes",
+                "Total byte size of all best-effort messages in canister queues.",
             ),
             canister_messages_where_cycles_were_charged: metrics_registry.int_counter(
                 "scheduler_canister_messages_where_cycles_were_charged",
@@ -767,5 +772,9 @@ impl SchedulerMetrics {
     pub(super) fn observe_oversized_requests_extra_bytes(&self, size_bytes: usize) {
         self.queues_oversized_requests_extra_bytes
             .set(size_bytes as i64);
+    }
+
+    pub(super) fn observe_queues_best_effort_message_bytes(&self, size_bytes: usize) {
+        self.queues_best_effort_message_bytes.set(size_bytes as i64);
     }
 }

--- a/rs/messaging/tests/call_tree_tests.rs
+++ b/rs/messaging/tests/call_tree_tests.rs
@@ -6,7 +6,9 @@ use ic_base_types::PrincipalId;
 use ic_registry_routing_table::{routing_table_insert_subnet, RoutingTable};
 use ic_registry_subnet_type::SubnetType;
 use ic_state_machine_tests::{StateMachine, StateMachineBuilder, WasmResult};
-use ic_test_utilities_metrics::fetch_histogram_stats;
+use ic_test_utilities_metrics::fetch_histogram_vec_stats;
+use ic_test_utilities_metrics::metric_vec;
+use ic_test_utilities_metrics::HistogramStats;
 use ic_test_utilities_types::ids::SUBNET_0;
 use ic_types::Cycles;
 use std::collections::VecDeque;
@@ -86,14 +88,21 @@ impl CallTreeTestFixture {
 
         if let WasmResult::Reply(msg) = result {
             let state = Decode!(&msg, State).unwrap();
-            let stats = fetch_histogram_stats(
+            let stats = fetch_histogram_vec_stats(
                 self.0.metrics_registry(),
                 "execution_environment_request_call_tree_depth",
-            )
-            .unwrap();
+            );
 
-            assert_eq!(state.call_count, stats.count);
-            assert_eq!(state.depth_total as f64, stats.sum);
+            assert_eq!(
+                metric_vec(&[(
+                    &[("class", "guaranteed_response")],
+                    HistogramStats {
+                        count: state.call_count,
+                        sum: state.depth_total as f64
+                    }
+                ),]),
+                stats,
+            );
         } else {
             unreachable!();
         }

--- a/rs/system_api/src/sandbox_safe_system_state.rs
+++ b/rs/system_api/src/sandbox_safe_system_state.rs
@@ -356,12 +356,19 @@ impl SystemStateModifications {
 
         // Get a clone of the request metadata of outgoing requests (they are all equivalent)
         // and their number. This will be used for call tree metrics.
+        let best_effort_request_count = self
+            .requests
+            .iter()
+            .filter(|req| req.deadline != NO_DEADLINE)
+            .count() as u64;
         let request_stats = RequestMetadataStats {
             metadata: self
                 .requests
                 .first()
                 .map_or_else(Default::default, |request| request.metadata.clone()),
-            count: self.requests.len() as u64,
+            best_effort_request_count,
+            guaranteed_response_request_count: self.requests.len() as u64
+                - best_effort_request_count,
         };
 
         // Push outgoing messages.
@@ -1359,7 +1366,8 @@ impl SandboxSafeSystemState {
 /// This is used for call tree metrics.
 pub struct RequestMetadataStats {
     pub metadata: RequestMetadata,
-    pub count: u64,
+    pub best_effort_request_count: u64,
+    pub guaranteed_response_request_count: u64,
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Add an `execution_queues_best_effort_message_bytes` metric to track the size of the best-effort message memory pool. And break down the call tree metrics along a message class dimension.