### PR TITLE
chore(nns): Remove changelog entries which are already copied to CHANGELOG.md

### DIFF
--- a/rs/nns/governance/unreleased_changelog.md
+++ b/rs/nns/governance/unreleased_changelog.md
@@ -22,13 +22,6 @@ This new field works in the same way that the existing `neuron_ids` field works.
 
 ## Changed
 
-* `InstallCode` proposal payload hashes are now computed when making the proposal instead of when
-  listing proposal. Hashes for existing proposals are backfilled.
-
-* The `list_neurons` behavior is slightly changed: the `include_empty_neurons_readable_by_caller`
-  was default to true before, and now it's default to true. More details can be found at:
-  https://forum.dfinity.org/t/listneurons-api-change-empty-neurons/40311
-
 * The limit of the number of neurons is increased from 380K to 400K.
 
 ## Deprecated


### PR DESCRIPTION
2 changelog entries are already added to CHANGELOG.md. Removing them.