### PR TITLE
chore(nns): update root changelog

### DIFF
--- a/rs/nns/handlers/root/CHANGELOG.md
+++ b/rs/nns/handlers/root/CHANGELOG.md
@@ -10,5 +10,14 @@ here were moved from the adjacent `unreleased_changelog.md` file.
 
 INSERT NEW RELEASES HERE
 
+# 2025-02-03: Proposal 135064
+
+https://dashboard.internetcomputer.org/proposal/135064
+
+## Changed
+
+* The `LogVisibility` returned from `canister_status` has one more variant `allowed_viewers`,
+  consistent with the corresponding management canister API. Calling `canister_status` for a
+  canister with such a log visibility setting will no longer panic.
 
 END

--- a/rs/nns/handlers/root/unreleased_changelog.md
+++ b/rs/nns/handlers/root/unreleased_changelog.md
@@ -11,12 +11,6 @@ on the process that this file is part of, see
 
 * Added the `query_stats` field for the `canister_status` method.
 
-## Changed
-
-* The `LogVisibility` returned from `canister_status` has one more variant `allowed_viewers`,
-  consistent with the corresponding management canister API. Calling `canister_status` for a
-  canister with such a log visibility setting will no longer panic.
-
 ## Deprecated
 
 ## Removed


### PR DESCRIPTION
The script that does this automatically seems to be broken for NNS root