### PR TITLE
fix(nervous-system-tools): changelog script looks at correct field for NNS

### DIFF
--- a/testnet/tools/nns-tools/add-release-to-changelog.sh
+++ b/testnet/tools/nns-tools/add-release-to-changelog.sh
@@ -44,7 +44,8 @@ if [[ "${LEN}" -ne 1 ]]; then
 fi
 PROPOSAL_INFO=$(echo "${PROPOSAL_INFO}" | jq '.[0]')
 
-# Get proposal creation timestam.
+# Get proposal creation timestamp.
+# It's under proposal_creation_timestamp_seconds on SNS, and proposal_timestamp_seconds on NNS
 PROPOSED_TIMESTAMP_SECONDS=$(echo "${PROPOSAL_INFO}" | jq '.proposal_creation_timestamp_seconds // .proposal_timestamp_seconds | tonumber')
 if [[ "${PROPOSED_TIMESTAMP_SECONDS}" -eq 0 ]]; then
     print_red "💀 Proposal ${PROPOSAL_ID} exists, but had no proposal_creation_timestamp_seconds." >&2


### PR DESCRIPTION
It was looking for the timestamp under "proposal_creation_timestamp_seconds", but this only exists for SNS. On NNS the analogous field is "proposal_timestamp_seconds".