### PR TITLE
feat(sns-cli): Refund unused cycles after upgrading with an auxiliary store canister

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1859,7 +1859,10 @@ version = "0.9.0"
 dependencies = [
  "candid",
  "candid_parser",
+ "ic-crypto-sha2",
+ "ic-wasm",
  "pretty_assertions",
+ "thiserror 2.0.11",
 ]
 
 [[package]]
@@ -12183,7 +12186,6 @@ dependencies = [
  "hex",
  "ic-agent",
  "ic-base-types",
- "ic-crypto-sha2",
  "ic-management-canister-types",
  "ic-nervous-system-agent",
  "ic-nervous-system-common",
@@ -12197,7 +12199,6 @@ dependencies = [
  "ic-sns-init",
  "ic-sns-root",
  "ic-sns-wasm",
- "ic-wasm",
  "itertools 0.12.1",
  "json-patch",
  "lazy_static",
@@ -12206,6 +12207,7 @@ dependencies = [
  "serde_cbor",
  "serde_json",
  "serde_yaml",
+ "store-canister-embedder",
  "tempfile",
  "thiserror 2.0.11",
  "tokio",
@@ -20982,6 +20984,17 @@ dependencies = [
  "cfg-if 1.0.0",
  "futures-core",
  "pin-project-lite",
+]
+
+[[package]]
+name = "store-canister-embedder"
+version = "0.9.0"
+dependencies = [
+ "candid-utils",
+ "flate2",
+ "ic-base-types",
+ "ic-wasm",
+ "wasmprinter 0.217.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12210,6 +12210,7 @@ dependencies = [
  "thiserror 2.0.11",
  "tokio",
  "url",
+ "wat",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -199,6 +199,7 @@ members = [
     "rs/nervous_system/proxied_canister_calls_tracker",
     "rs/nervous_system/root",
     "rs/nervous_system/runtime",
+    "rs/nervous_system/store_canister",
     "rs/nervous_system/string",
     "rs/nervous_system/temporary",
     "rs/nervous_system/tools/release-runscript",

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -156,6 +156,16 @@ crate_repositories()
 # Motoko support
 
 http_archive(
+    name = "motoko_base",
+    build_file_content = """
+filegroup(name = "sources", srcs = glob(["*.mo"]), visibility = ["//visibility:public"])
+      """,
+    sha256 = "0cab6b960d3ab463cfdf8180ed69e46d7d59d035b3ab95fb0abc55b267074acd",
+    strip_prefix = "motoko-base-moc-0.14.0/src",
+    urls = ["https://github.com/dfinity/motoko-base/archive/refs/tags/moc-0.14.0.zip"],
+)
+
+http_archive(
     name = "rules_motoko",
     sha256 = "f7cb0a906c8efe9d2ad8d27f0f6ac11f6409a771d74874f7e47d45959063dfe3",
     strip_prefix = "rules_motoko-0.2.1",

--- a/rs/nervous_system/agent/src/lib.rs
+++ b/rs/nervous_system/agent/src/lib.rs
@@ -4,6 +4,7 @@ use std::collections::BTreeSet;
 use std::fmt::Display;
 
 pub mod agent_impl;
+pub mod ii;
 pub mod management_canister;
 pub mod nns;
 mod null_request;

--- a/rs/nervous_system/agent/src/management_canister/mod.rs
+++ b/rs/nervous_system/agent/src/management_canister/mod.rs
@@ -26,6 +26,30 @@ pub async fn canister_status<C: CallCanisters>(
     Ok(response)
 }
 
+pub async fn install_code<C: CallCanisters>(
+    agent: &C,
+    canister_id: CanisterId,
+    mode: Mode,
+    wasm_module: Vec<u8>,
+    arg: Option<Vec<u8>>,
+    sender_canister_version: Option<u64>,
+) -> Result<(), C::Error> {
+    let response = agent
+        .call(
+            Principal::management_canister(),
+            InstallCodeArgs {
+                canister_id: canister_id.get().0,
+                arg: arg.unwrap_or_default(),
+                mode,
+                wasm_module,
+                sender_canister_version,
+            },
+        )
+        .await?;
+
+    Ok(response)
+}
+
 pub async fn stop_canister<C: CallCanisters>(
     agent: &C,
     canister_id: CanisterId,

--- a/rs/nervous_system/agent/src/management_canister/requests.rs
+++ b/rs/nervous_system/agent/src/management_canister/requests.rs
@@ -181,6 +181,78 @@ impl Request for CanisterStatusArgs {
 }
 
 // ```
+// type wasm_module = blob;
+//
+// type canister_install_mode = variant {
+//     install;
+//     reinstall;
+//     upgrade : opt record {
+//         skip_pre_upgrade : opt bool;
+//         wasm_memory_persistence : opt variant {
+//             keep;
+//             replace;
+//         };
+//     };
+// };
+//
+// type install_code_args = record {
+//     mode : canister_install_mode;
+//     canister_id : canister_id;
+//     wasm_module : wasm_module;
+//     arg : blob;
+//     sender_canister_version : opt nat64;
+// };
+// ```
+#[derive(CandidType, Deserialize, Debug, Clone)]
+pub enum CanisterInstallModeUpgradeInnerWasmMemoryPersistenceInner {
+    #[serde(rename = "keep")]
+    Keep,
+    #[serde(rename = "replace")]
+    Replace,
+}
+
+#[derive(CandidType, Deserialize, Debug, Clone)]
+pub struct CanisterInstallModeUpgradeInner {
+    pub wasm_memory_persistence: Option<CanisterInstallModeUpgradeInnerWasmMemoryPersistenceInner>,
+    pub skip_pre_upgrade: Option<bool>,
+}
+
+#[derive(CandidType, Deserialize, Debug, Clone)]
+pub enum Mode {
+    #[serde(rename = "reinstall")]
+    Reinstall,
+    #[serde(rename = "upgrade")]
+    Upgrade(Option<CanisterInstallModeUpgradeInner>),
+    #[serde(rename = "install")]
+    Install,
+}
+
+#[derive(CandidType, Deserialize, Debug, Clone)]
+pub struct InstallCodeArgs {
+    pub mode: Mode,
+    pub canister_id: Principal,
+    pub wasm_module: Vec<u8>,
+    pub arg: Vec<u8>,
+    pub sender_canister_version: Option<u64>,
+}
+
+impl Request for InstallCodeArgs {
+    fn method(&self) -> &'static str {
+        "install_code"
+    }
+
+    fn update(&self) -> bool {
+        true
+    }
+
+    fn payload(&self) -> Result<Vec<u8>, candid::Error> {
+        candid::encode_one(self)
+    }
+
+    type Response = ();
+}
+
+// ```
 // type stop_canister_args = record {
 //     canister_id : canister_id;
 // };

--- a/rs/nervous_system/agent/src/pocketic_impl.rs
+++ b/rs/nervous_system/agent/src/pocketic_impl.rs
@@ -5,7 +5,7 @@ use crate::Request;
 use crate::{CallCanisters, CanisterInfo};
 use candid::Principal;
 use pocket_ic::common::rest::RawEffectivePrincipal;
-use pocket_ic::management_canister::DefiniteCanisterSettings;
+use pocket_ic::management_canister::{DefiniteCanisterSettings, InstallCodeArgs};
 use pocket_ic::{management_canister::CanisterStatusResult, nonblocking::PocketIc};
 use thiserror::Error;
 
@@ -83,6 +83,11 @@ impl PocketIcAgent<'_> {
             }
             "delete_canister" => {
                 candid::decode_one::<DeleteCanisterArgs>(payload.as_slice())
+                    .map_err(PocketIcCallError::CandidDecode)?
+                    .canister_id
+            }
+            "install_code" => {
+                candid::decode_one::<InstallCodeArgs>(payload.as_slice())
                     .map_err(PocketIcCallError::CandidDecode)?
                     .canister_id
             }

--- a/rs/nervous_system/candid_utils/BUILD.bazel
+++ b/rs/nervous_system/candid_utils/BUILD.bazel
@@ -5,8 +5,11 @@ package(default_visibility = ["//visibility:public"])
 # See rs/nervous_system/feature_test.md
 DEPENDENCIES = [
     # Keep sorted.
+    "//rs/crypto/sha2",
     "@crate_index//:candid",
     "@crate_index//:candid_parser",
+    "@crate_index//:ic-wasm",
+    "@crate_index//:thiserror",
 ]
 
 MACRO_DEPENDENCIES = []

--- a/rs/nervous_system/candid_utils/Cargo.toml
+++ b/rs/nervous_system/candid_utils/Cargo.toml
@@ -12,6 +12,9 @@ path = "src/lib.rs"
 [dependencies]
 candid = { workspace = true }
 candid_parser = { workspace = true }
+ic-crypto-sha2 = { path = "../../crypto/sha2" }
+ic-wasm = { workspace = true }
+thiserror = { workspace = true }
 
 [dev-dependencies]
 pretty_assertions = { workspace = true }

--- a/rs/nervous_system/candid_utils/src/lib.rs
+++ b/rs/nervous_system/candid_utils/src/lib.rs
@@ -1,2 +1,3 @@
 pub mod printing;
 pub mod validation;
+pub mod wasm;

--- a/rs/nervous_system/candid_utils/src/validation.rs
+++ b/rs/nervous_system/candid_utils/src/validation.rs
@@ -1,10 +1,13 @@
-use candid::types::{
-    subtype::{subtype_with_config, OptReport},
-    Type,
+use candid::{
+    pretty::candid::compile,
+    types::{
+        subtype::{subtype_with_config, OptReport},
+        Type,
+    },
 };
 use candid_parser::{
     parse_idl_args,
-    utils::{instantiate_candid, CandidSource},
+    utils::{instantiate_candid, merge_init_args, CandidSource},
 };
 
 fn fmt_type_vec(types: &[Type]) -> String {
@@ -77,6 +80,18 @@ impl std::fmt::Display for CandidServiceArgValidationError {
     }
 }
 
+/// Augments `candid_service` without with `candid_args`. If the service already has init args,
+/// then the exact same service is returned and `candid_args` is ignored.
+pub fn augment_candid_service(
+    candid_service: &str,
+    candid_args: &str,
+) -> Result<String, CandidServiceArgValidationError> {
+    let (env, actor) = merge_init_args(&candid_service, candid_args)
+        .map_err(|err| CandidServiceArgValidationError::BadService(format!("{err:?}")))?;
+
+    Ok(compile(&env, &Some(actor)))
+}
+
 /// Checks whether `upgrade_args` is a valid argument sequence for `candid_service`.
 ///
 /// If `upgrade_args` is None, checks that `candid_service` does not require any arguments.
@@ -86,14 +101,14 @@ impl std::fmt::Display for CandidServiceArgValidationError {
 /// Returns the byte encoding of `upgrade_args` (if any; otherwise None) in the successful case.
 pub fn encode_upgrade_args(
     candid_service: String,
-    upgrade_args: Option<String>,
+    upgrade_args: &Option<String>,
 ) -> Result<Option<Vec<u8>>, CandidServiceArgValidationError> {
     let (expected_args_types, (env, _)) =
         instantiate_candid(CandidSource::Text(&candid_service))
             .map_err(|err| CandidServiceArgValidationError::BadService(format!("{err:?}")))?;
 
     let (upgrade_args, args_types) = if let Some(upgrade_args) = upgrade_args {
-        let upgrade_args = parse_idl_args(&upgrade_args)
+        let upgrade_args = parse_idl_args(upgrade_args)
             .map_err(|err| CandidServiceArgValidationError::ArgsParseError(format!("{err:?}")))?;
 
         let types = upgrade_args.get_types();
@@ -157,9 +172,9 @@ pub fn encode_upgrade_args(
 /// WARNING. Please use the [encode_upgrade_args] function instead. This function is only
 /// suitable for best-effort upgrades in which the Candid service is not available.
 pub fn encode_upgrade_args_without_service(
-    upgrade_args: String,
+    upgrade_args: &String,
 ) -> Result<Vec<u8>, CandidServiceArgValidationError> {
-    let upgrade_args = parse_idl_args(&upgrade_args)
+    let upgrade_args = parse_idl_args(upgrade_args)
         .map_err(|err| CandidServiceArgValidationError::ArgsParseError(format!("{err:?}")))?;
 
     let upgrade_args = upgrade_args.to_bytes().map_err(|err| {

--- a/rs/nervous_system/integration_tests/src/pocket_ic_helpers.rs
+++ b/rs/nervous_system/integration_tests/src/pocket_ic_helpers.rs
@@ -587,7 +587,7 @@ pub fn load_registry_mutations<P: AsRef<Path>>(path: P) -> RegistryAtomicMutateR
 
 pub mod cycles_ledger {
     use super::{install_canister, nns};
-    use candid::{CandidType, Encode, Principal};
+    use candid::{CandidType, Encode, Nat, Principal};
     use canister_test::Wasm;
     use cycles_minting_canister::{NotifyMintCyclesSuccess, MEMO_MINT_CYCLES};
     use ic_base_types::PrincipalId;
@@ -645,11 +645,12 @@ pub mod cycles_ledger {
         .await;
     }
 
+    /// Returns the new cycles balance of `beneficiary`.
     pub async fn mint_icp_and_convert_to_cycles(
         pocket_ic: &PocketIc,
         beneficiary: PrincipalId,
         amount: Tokens,
-    ) {
+    ) -> Nat {
         nns::ledger::mint_icp(
             pocket_ic,
             AccountIdentifier::new(beneficiary, None),
@@ -679,8 +680,10 @@ pub mod cycles_ledger {
         let NotifyMintCyclesSuccess {
             block_index: _,
             minted: _,
-            balance: _,
+            balance,
         } = nns::cmc::notify_mint_cycles(pocket_ic, beneficiary, None, None, block_index).await;
+
+        balance
     }
 }
 

--- a/rs/nervous_system/integration_tests/tests/upgrade_sns_controlled_canister_with_large_wasm.rs
+++ b/rs/nervous_system/integration_tests/tests/upgrade_sns_controlled_canister_with_large_wasm.rs
@@ -146,7 +146,8 @@ async fn upgrade_sns_controlled_canister_with_large_wasm() {
     // so that it can host the large Wasm. To that end, the GM grants this user 10 ICP, for
     // the sake of testing, out of thin air.
     let icp = Tokens::from_tokens(10).unwrap();
-    cycles_ledger::mint_icp_and_convert_to_cycles(&pocket_ic, sender, icp).await;
+    let original_cycles_balance =
+        cycles_ledger::mint_icp_and_convert_to_cycles(&pocket_ic, sender, icp).await;
 
     let cli_arg = UpgradeSnsControlledCanisterArgs {
         sns_neuron_id: Some(ParsedSnsNeuron(sns_neuron_id)),
@@ -237,7 +238,18 @@ async fn upgrade_sns_controlled_canister_with_large_wasm() {
         .await
         .unwrap();
 
-    // 7. Assert that store canister has zero cycles left on its balance.
+    // 7. Assert that the unused cycles got back to the user Cycles Ledger account.
+    let final_cycles_balance = ic_nervous_system_agent::ii::cycles_ledger::icrc1_balance_of(
+        &pocket_ic_agent,
+        sender,
+        None,
+    )
+    .await;
+    // TODO: Consider strengthening these assertions.
+    assert!(final_cycles_balance < original_cycles_balance);
+    assert!(final_cycles_balance > 0);
+
+    // 8. Assert that store canister has been deleted.
     let err = canister_status(
         &pocket_ic_agent,
         CanisterId::unchecked_from_principal(store_canister_id),

--- a/rs/nervous_system/store_canister/BUILD.bazel
+++ b/rs/nervous_system/store_canister/BUILD.bazel
@@ -1,15 +1,37 @@
 load("@rules_motoko//motoko:defs.bzl", "motoko_library")
+load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test")
 load("//bazel:canisters.bzl", "motoko_canister")
 
 package(default_visibility = ["//visibility:public"])
 
-motoko_library(
-    name = "base",
-    srcs = ["@motoko_base//:sources"],
-)
-
 motoko_canister(
     name = "store",
     entry = "store.mo",
-    deps = ["base"],
+    deps = [],
+)
+
+rust_library(
+    name = "store_canister_embedder",
+    srcs = ["src/lib.rs"],
+    compile_data = [":store.wasm"],
+    rustc_env = {
+        "STORE_CANISTER_WASM_PATH": "$(location :store.wasm)",
+    },
+    deps = [
+        "//rs/types/base_types",
+    ]
+)
+
+rust_test(
+    name = "store_wasm_test",
+    compile_data = [":store.wasm"],
+    crate = ":store_canister_embedder",
+    deps = [
+        # Keep sorted.
+        "//rs/nervous_system/candid_utils",
+        "//rs/types/base_types",
+        "@crate_index//:flate2",
+        "@crate_index//:ic-wasm",
+        "@crate_index//:wasmprinter",
+    ],
 )

--- a/rs/nervous_system/store_canister/BUILD.bazel
+++ b/rs/nervous_system/store_canister/BUILD.bazel
@@ -1,0 +1,15 @@
+load("@rules_motoko//motoko:defs.bzl", "motoko_library")
+load("//bazel:canisters.bzl", "motoko_canister")
+
+package(default_visibility = ["//visibility:public"])
+
+motoko_library(
+    name = "base",
+    srcs = ["@motoko_base//:sources"],
+)
+
+motoko_canister(
+    name = "store",
+    entry = "store.mo",
+    deps = ["base"],
+)

--- a/rs/nervous_system/store_canister/store.did
+++ b/rs/nervous_system/store_canister/store.did
@@ -1,8 +1,8 @@
-type RefundResult = variant {
+type WithdrawResult = variant {
+  Ok : nat;
   Error : text;
-  RefundedCycles : nat;
 };
 
-service -> {
-  refund : (to : principal) -> (RefundResult);
+service: (authorized_principal : principal) -> {
+  withdraw_cycles : (to : principal) -> (WithdrawResult);
 }

--- a/rs/nervous_system/store_canister/store.did
+++ b/rs/nervous_system/store_canister/store.did
@@ -1,0 +1,8 @@
+type RefundResult = variant {
+  Error : text;
+  RefundedCycles : nat;
+};
+
+service -> {
+  refund : (to : principal) -> (RefundResult);
+}

--- a/rs/nervous_system/store_canister/store.did
+++ b/rs/nervous_system/store_canister/store.did
@@ -5,4 +5,5 @@ type WithdrawResult = variant {
 
 service: (authorized_principal : principal) -> {
   withdraw_cycles : (to : principal) -> (WithdrawResult);
+  foo : () -> ();
 }

--- a/rs/nervous_system/store_canister/store.mo
+++ b/rs/nervous_system/store_canister/store.mo
@@ -1,4 +1,6 @@
-actor {
+import Prim "mo:prim";
+
+actor class (authorized_principal : Principal) {
     type WithdrawArgs = {
         amount : Nat;
         to : Principal;
@@ -9,24 +11,18 @@ actor {
         #Err : Text;
     };
 
-    private let cycles_ledger = actor "aaaaa-aa" : actor {
-        WithdrawArgs
-        withdraw : WithdrawArgs -> async ({
-           
-        });
+    private let cyclesLedger = actor "um5iw-rqaaa-aaaaq-qaaba-cai" : actor {
+        withdraw : (WithdrawArgs) -> async (WithdrawResult);
     };
 
-    type RefundResult = {
-        #Error : Text;
-        #RefundedCycles : Nat;
-    };
-
-    public shared ({caller}) func refund(to : Principal) : async RefundResult {
-        assert Prim.isController(caller);
-        assert Prim.isController(to);
+    public shared ({caller}) func withdraw_cycles(to : Principal) : async WithdrawResult {
+        assert caller == authorized_principal;
 
         let balance = Prim.cyclesBalance();
 
-        balance
-    };
+        await cyclesLedger.withdraw({
+            amount = balance;
+            to = to;
+        })
+    }
 }

--- a/rs/nervous_system/store_canister/store.mo
+++ b/rs/nervous_system/store_canister/store.mo
@@ -1,0 +1,32 @@
+actor {
+    type WithdrawArgs = {
+        amount : Nat;
+        to : Principal;
+    };
+
+    type WithdrawResult = {
+        #Ok : Nat;
+        #Err : Text;
+    };
+
+    private let cycles_ledger = actor "aaaaa-aa" : actor {
+        WithdrawArgs
+        withdraw : WithdrawArgs -> async ({
+           
+        });
+    };
+
+    type RefundResult = {
+        #Error : Text;
+        #RefundedCycles : Nat;
+    };
+
+    public shared ({caller}) func refund(to : Principal) : async RefundResult {
+        assert Prim.isController(caller);
+        assert Prim.isController(to);
+
+        let balance = Prim.cyclesBalance();
+
+        balance
+    };
+}

--- a/rs/sns/cli/BUILD.bazel
+++ b/rs/sns/cli/BUILD.bazel
@@ -42,6 +42,7 @@ DEPENDENCIES = [
     "@crate_index//:thiserror",
     "@crate_index//:tokio",
     "@crate_index//:url",
+    "@crate_index//:wat",
 ]
 
 MACRO_DEPENDENCIES = []

--- a/rs/sns/cli/BUILD.bazel
+++ b/rs/sns/cli/BUILD.bazel
@@ -42,7 +42,6 @@ DEPENDENCIES = [
     "@crate_index//:thiserror",
     "@crate_index//:tokio",
     "@crate_index//:url",
-    "@crate_index//:wat",
 ]
 
 MACRO_DEPENDENCIES = []
@@ -79,6 +78,12 @@ rust_binary(
     proc_macro_deps = MACRO_DEPENDENCIES,
     version = "1.0.0",
     deps = DEPENDENCIES + [":cli"],
+    data = [
+        "//rs/nervous_system/store_canister:store",
+    ],
+    env = {
+        "STORE_CANISTER_WASM_PATH": "$(rootpath //rs/nervous_system/store_canister:store)",
+    }
 )
 
 rust_test(

--- a/rs/sns/cli/BUILD.bazel
+++ b/rs/sns/cli/BUILD.bazel
@@ -12,6 +12,7 @@ DEPENDENCIES = [
     "//rs/nervous_system/common/test_keys",
     "//rs/nervous_system/humanize",
     "//rs/nervous_system/proto",
+    "//rs/nervous_system/store_canister:store_canister_embedder",
     "//rs/nns/cmc",
     "//rs/nns/common",
     "//rs/nns/constants",
@@ -30,7 +31,6 @@ DEPENDENCIES = [
     "@crate_index//:futures",
     "@crate_index//:hex",
     "@crate_index//:ic-agent",
-    "@crate_index//:ic-wasm",
     "@crate_index//:itertools",
     "@crate_index//:json-patch",
     "@crate_index//:pretty_assertions",
@@ -78,12 +78,6 @@ rust_binary(
     proc_macro_deps = MACRO_DEPENDENCIES,
     version = "1.0.0",
     deps = DEPENDENCIES + [":cli"],
-    data = [
-        "//rs/nervous_system/store_canister:store",
-    ],
-    env = {
-        "STORE_CANISTER_WASM_PATH": "$(rootpath //rs/nervous_system/store_canister:store)",
-    }
 )
 
 rust_test(

--- a/rs/sns/cli/Cargo.toml
+++ b/rs/sns/cli/Cargo.toml
@@ -24,12 +24,12 @@ futures = { workspace = true }
 hex = { workspace = true }
 ic-agent = { workspace = true }
 ic-base-types = { path = "../../types/base_types" }
-ic-crypto-sha2 = { path = "../../crypto/sha2" }
 ic-management-canister-types = { path = "../../types/management_canister_types" }
 ic-nervous-system-agent = { path = "../../nervous_system/agent" }
 ic-nervous-system-common = { path = "../../nervous_system/common" }
 ic-nervous-system-common-test-keys = { path = "../../nervous_system/common/test_keys" }
 ic-nervous-system-humanize = { path = "../../nervous_system/humanize" }
+store-canister-embedder = { path = "../../nervous_system/store_canister" }
 ic-nervous-system-proto = { path = "../../nervous_system/proto" }
 cycles-minting-canister = { path = "../../nns/cmc" }
 ic-nns-common = { path = "../../nns/common" }
@@ -39,7 +39,6 @@ ic-sns-governance-api = { path = "../governance/api" }
 ic-sns-init = { path = "../init" }
 ic-sns-root = { path = "../root" }
 ic-sns-wasm = { path = "../../nns/sns-wasm" }
-ic-wasm = { workspace = true }
 itertools = { workspace = true }
 json-patch = "0.2.6"
 pretty_assertions = { workspace = true }

--- a/rs/sns/cli/Cargo.toml
+++ b/rs/sns/cli/Cargo.toml
@@ -51,6 +51,7 @@ tempfile = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 url = { workspace = true }
+wat = { workspace = true }
 
 [dev-dependencies]
 lazy_static = { workspace = true }


### PR DESCRIPTION
The recently added sns-cli subcommand, upgrade-sns-controlled-cansiter, deploys an auxiliary canister to store the Wasm chunks for the upgrade. Since the precise amount of cycles isn't known upfront, the store canister is most likely going to be left with a non-zero cycles balance which belongs to the user. To withdraw those cycles, we install a small Wasm module that supports only one function, `withdraw_cycles`, which send the remaining cycles back to the Cycles Ledger account of the authorized principal (which is initialized by the user).

Additional refactoring were needed to enable this scenario, which are also included.