### PR TITLE
fix(nns/sns): Minor fixes for release_runscript

### DIFF
--- a/rs/nervous_system/tools/release-runscript/src/main.rs
+++ b/rs/nervous_system/tools/release-runscript/src/main.rs
@@ -295,7 +295,7 @@ fn run_create_proposal_texts(cmd: CreateProposalTexts) -> Result<()> {
                 .output()
                 .expect("Failed to run NNS proposal text script")
         } else {
-            let upgrade_arg = input_with_default("Upgrade arg for CMC?", "'()'")?;
+            let upgrade_arg = input_with_default("Upgrade arg for CMC?", "()")?;
             Command::new(script)
                 .arg(canister)
                 .arg(&commit)

--- a/rs/nervous_system/tools/release-runscript/src/utils.rs
+++ b/rs/nervous_system/tools/release-runscript/src/utils.rs
@@ -102,8 +102,11 @@ pub(crate) fn ensure_gh_setup() -> Result<()> {
     if !output.status.success() {
         bail!("gh is not authenticated. Try running `gh auth login`")
     }
+    let stdout = String::from_utf8(output.stdout)?;
     let stderr = String::from_utf8(output.stderr)?;
-    if !stderr.contains("Logged in to github.com") {
+
+    let logged_in_message = "Logged in to github.com";
+    if !stderr.contains(logged_in_message) && !stdout.contains(logged_in_message) {
         bail!("gh is not logged in. Try running `gh auth login`")
     }
 


### PR DESCRIPTION
Changes:

* CMC default upgrades args candid textual format shouldn't have single quotes around them
* Check both stdout and stderr for GH login message