### PR TITLE
fix(nervous-system): resolve issues in the release runscript discovered today

### DIFF
--- a/rs/nervous_system/tools/release-runscript/src/utils.rs
+++ b/rs/nervous_system/tools/release-runscript/src/utils.rs
@@ -1,5 +1,6 @@
 use anyhow::{bail, Result};
 use colored::*;
+use core::result::Result::Ok;
 use std::io::{self, Write};
 use std::path::PathBuf;
 use std::process::{Command, Stdio};
@@ -93,21 +94,62 @@ pub(crate) fn press_enter_to_continue() -> Result<()> {
     Ok(())
 }
 
+pub(crate) fn ensure_coreutils_setup() -> Result<()> {
+    let output = Command::new("brew").arg("list").output()?;
+    if !output.status.success() {
+        // If they don't even have brew installed, we can't ensure anything. Let's just ask them if they want to continue.
+        println!(
+            "{}",
+            "brew is not installed. This is not necessarily a problem, but it is suspicious."
+                .bright_yellow()
+        );
+        press_enter_to_continue()?;
+        return Ok(());
+    }
+
+    // If they do have brew installed, let's make sure coreutils is installed.
+    let stdout = String::from_utf8(output.stdout)?;
+    if !stdout.contains("coreutils") {
+        bail!("'coreutils' is not installed. This is not necessarily a problem, but you may encounter issues running some of the bash scripts which are written by developers that generally will have coreutils installed. Try running `brew install coreutils`.")
+    }
+
+    println!("{}", "brew and coreutils installed ✓".bright_green());
+
+    Ok(())
+}
+
+pub(crate) fn ensure_code_setup() -> Result<()> {
+    let Ok(output) = Command::new("code").arg("--version").output() else {
+        bail!("'code' is not installed. Try by pressing cmd-shift-p in VSCode and searching for `Install 'code' command in path`.")
+    };
+    if !output.status.success() {
+        bail!("'code' is not installed. Try by pressing cmd-shift-p in VSCode and searching for `Install 'code' command in path`.")
+    }
+
+    println!("{}", "VSCode 'code' command installed ✓".bright_green());
+
+    Ok(())
+}
+
 pub(crate) fn ensure_gh_setup() -> Result<()> {
+    // Check if gh is installed
     let output = Command::new("gh").arg("--version").output()?;
     if !output.status.success() {
         bail!("gh is not installed. Try installing with `brew install gh`")
     }
+
+    // Check if the user is logged in to gh
     let output = Command::new("gh").arg("auth").arg("status").output()?;
     if !output.status.success() {
-        bail!("gh is not authenticated. Try running `gh auth login`")
+        bail!("gh is not logged in. Try running `gh auth login`")
     }
+
+    // Check that the user is logged in to github.com specifically
     let stdout = String::from_utf8(output.stdout)?;
     let stderr = String::from_utf8(output.stderr)?;
-
     let logged_in_message = "Logged in to github.com";
     if !stderr.contains(logged_in_message) && !stdout.contains(logged_in_message) {
-        bail!("gh is not logged in. Try running `gh auth login`")
+        bail!("gh is not logged in to github. Try running `gh auth login`")
     }
 
     println!("{}", "GitHub CLI is configured ✓".bright_green());


### PR DESCRIPTION
When helping jason do the release, we discovered a couple small issues.

1. The script requires `code` and some bash scripts require `coreutils`, but it just fails in the middle instead of checking for you
2. It's too easy to accidentally forget a TODO in a proposal text. This leads to a panic later. It's better to just make you fix all of them before continuing.
