### PR TITLE
chore(nns): Change NNS Root code location to one level up

### DIFF
--- a/testnet/tools/nns-tools/lib/functions.sh
+++ b/testnet/tools/nns-tools/lib/functions.sh
@@ -145,7 +145,7 @@ get_nns_canister_code_location() {
     code_location__governance="$RUST_DIR/nns/governance $SNS_INIT"
     code_location__ledger="$RUST_DIR/rosetta-api/ledger_canister/ledger $LEDGER_COMMON"
     code_location__icp_ledger_archive="$RUST_DIR/ledger_suite/icp/archive $LEDGER_COMMON"
-    code_location__root="$RUST_DIR/nns/handlers/root/impl"
+    code_location__root="$RUST_DIR/nns/handlers/root"
     code_location__cycles_minting="$RUST_DIR/nns/cmc"
     code_location__lifeline="$RUST_DIR/nns/handlers/lifeline"
     code_location__genesis_token="$RUST_DIR/nns/gtc"


### PR DESCRIPTION
The `CHANGELOG.md` and `unreleased_changelog.md` are located in `rs/nns/handlers/root`, and the `code_location_...` is used to figure out where the change logs are. Although one obvious solution is to move the change logs to `//rs/nns/handlers/root/impl/`, there doesn't seem to be a good reason that changes in `rs/nns/handlers/root/interface` should NOT be displayed in upgrade proposals.