### PR TITLE
fix: No best-effort messages in RC qualification test

### DIFF
--- a/rs/tests/dre/utils/steps/xnet.rs
+++ b/rs/tests/dre/utils/steps/xnet.rs
@@ -33,12 +33,16 @@ impl Step for XNet {
         env: ic_system_test_driver::driver::test_env::TestEnv,
         rt: tokio::runtime::Handle,
     ) -> anyhow::Result<()> {
+        // Only guaranteed response calls, for now.
+        // TODO(MR-638): Drop `.with_call_timeouts(&[None])` once best-effort calls are 
+        // supported on mainnet.
         let config = Config::new(
             self.subnets,
             self.nodes_per_subnet,
             self.runtime,
             self.request_rate,
-        );
+        )
+        .with_call_timeouts(&[None]);
 
         let mut subnets = env
             .topology_snapshot()

--- a/rs/tests/dre/utils/steps/xnet.rs
+++ b/rs/tests/dre/utils/steps/xnet.rs
@@ -34,7 +34,7 @@ impl Step for XNet {
         rt: tokio::runtime::Handle,
     ) -> anyhow::Result<()> {
         // Only guaranteed response calls, for now.
-        // TODO(MR-638): Drop `.with_call_timeouts(&[None])` once best-effort calls are 
+        // TODO(MR-638): Drop `.with_call_timeouts(&[None])` once best-effort calls are
         // supported on mainnet.
         let config = Config::new(
             self.subnets,


### PR DESCRIPTION
Currently the versions running on mainnet don't support best-effort response message. Having the XNet step in the qualification test attempt sending them prevents the canisters from sending any message and will consequently fail the test.