### PR TITLE
refactor: Use saturating subtraction for simplicity

### DIFF
--- a/rs/execution_environment/src/canister_settings.rs
+++ b/rs/execution_environment/src/canister_settings.rs
@@ -7,7 +7,7 @@ use ic_types::{
     ComputeAllocation, Cycles, InvalidComputeAllocationError, InvalidMemoryAllocationError,
     MemoryAllocation, PrincipalId,
 };
-use num_traits::cast::ToPrimitive;
+use num_traits::{cast::ToPrimitive, SaturatingSub};
 use std::convert::TryFrom;
 
 use crate::canister_manager::CanisterManagerError;
@@ -541,12 +541,7 @@ pub(crate) fn validate_canister_settings(
         }
     }
 
-    let allocated_bytes = if new_memory_bytes > old_memory_bytes {
-        new_memory_bytes - old_memory_bytes
-    } else {
-        NumBytes::new(0)
-    };
-
+    let allocated_bytes = new_memory_bytes.saturating_sub(&old_memory_bytes);
     let reservation_cycles = cycles_account_manager.storage_reservation_cycles(
         allocated_bytes,
         subnet_memory_saturation,


### PR DESCRIPTION
We have nowadays saturating arithmetic implemented for `AmountOf`s, so use this to simplify the code instead of having an `if-else` statement.