### PR TITLE
feat: branch for syncing grafana dashboards

### DIFF
--- a/rs/tests/ict/cmd/helpers.go
+++ b/rs/tests/ict/cmd/helpers.go
@@ -152,7 +152,7 @@ func get_closest_target_matches(all_targets []string, target string) []string {
 	})
 }
 
-func sparse_checkout(repoUrl, repoDir string, sparseCheckoutPaths []string) (string, error) {
+func sparse_checkout(repoUrl, repoDir string, sparseCheckoutPaths []string, branch string) (string, error) {
 	startingPoint, err := os.Getwd()
 	if err != nil {
 		return "", fmt.Errorf("Could not get current dir: %v", err)
@@ -179,7 +179,7 @@ func sparse_checkout(repoUrl, repoDir string, sparseCheckoutPaths []string) (str
 		return "", fmt.Errorf("Could not create repo directory: %v", err)
 	}
 
-	cloneCmd := exec.Command("git", "clone", "--filter=blob:none", "--no-checkout", repoUrl, repoDir)
+	cloneCmd := exec.Command("git", "clone", "--filter=blob:none", "--no-checkout", "--branch", branch, repoUrl, repoDir)
 	stdErrBuffer := &bytes.Buffer{}
 	cloneCmd.Stderr = stdErrBuffer
 	if err := cloneCmd.Run(); err != nil {

--- a/rs/tests/ict/cmd/testCmd.go
+++ b/rs/tests/ict/cmd/testCmd.go
@@ -20,6 +20,7 @@ type Config struct {
 	filterTests          string
 	farmBaseUrl          string
 	requiredHostFeatures string
+	k8sBranch            string
 }
 
 func TestCommandWithConfig(cfg *Config) func(cmd *cobra.Command, args []string) error {
@@ -42,7 +43,8 @@ func TestCommandWithConfig(cfg *Config) func(cmd *cobra.Command, args []string) 
 		command := []string{"bazel", "test", target, "--config=systest"}
 		command = append(command, "--cache_test_results=no")
 		// Try and sync k8s dashboards
-		icDashboardsDir, err := sparse_checkout("git@github.com:dfinity-ops/k8s.git", "", []string{"bases/apps/ic-dashboards"})
+		cmd.Println(GREEN + "Will try to sync dashboards from k8s branch: " + cfg.k8sBranch)
+		icDashboardsDir, err := sparse_checkout("git@github.com:dfinity-ops/k8s.git", "", []string{"bases/apps/ic-dashboards"}, cfg.k8sBranch)
 		if err != nil {
 			cmd.PrintErrln(YELLOW + "Failed to sync k8s dashboards. Received the following error: " + err.Error())
 		} else {
@@ -100,6 +102,7 @@ func NewTestCmd() *cobra.Command {
 	testCmd.PersistentFlags().StringVarP(&cfg.filterTests, "include-tests", "i", "", "Execute only those test functions which contain a substring.")
 	testCmd.PersistentFlags().StringVarP(&cfg.farmBaseUrl, "farm-url", "", "", "Use a custom url for the Farm webservice.")
 	testCmd.PersistentFlags().StringVarP(&cfg.requiredHostFeatures, "set-required-host-features", "", "", "Set and override required host features of all hosts spawned.\nFeatures must be one or more of [dc=<dc-name>, host=<host-name>, AMD-SEV-SNP, SNS-load-test, performance], separated by comma (see Examples).")
+	testCmd.PersistentFlags().StringVarP(&cfg.k8sBranch, "k8s-branch", "", "main", "Override the branch from which the dashboards are being synced. Default: main")
 	testCmd.SetOut(os.Stdout)
 	return testCmd
 }

--- a/rs/tests/ict/cmd/testnetCreateCmd.go
+++ b/rs/tests/ict/cmd/testnetCreateCmd.go
@@ -83,6 +83,7 @@ type TestnetConfig struct {
 	farmBaseUrl          string
 	requiredHostFeatures string
 	icConfigPath         string
+	k8sBranch            string
 }
 
 // Testnet config summary published to json file.
@@ -183,7 +184,8 @@ func TestnetCommand(cfg *TestnetConfig) func(cmd *cobra.Command, args []string) 
 		}
 		command := []string{"bazel", "test", target, "--config=systest"}
 		command = append(command, "--cache_test_results=no")
-		icDashboardsDir, err := sparse_checkout("git@github.com:dfinity-ops/k8s.git", "", []string{"bases/apps/ic-dashboards"})
+		cmd.Println(GREEN + "Will try to sync dashboards from k8s branch: " + cfg.k8sBranch)
+		icDashboardsDir, err := sparse_checkout("git@github.com:dfinity-ops/k8s.git", "", []string{"bases/apps/ic-dashboards"}, cfg.k8sBranch)
 		if err != nil {
 			cmd.PrintErrln(YELLOW + "Failed to sync k8s dashboards. Received the following error: " + err.Error())
 		} else {
@@ -299,6 +301,7 @@ func NewTestnetCreateCmd() *cobra.Command {
 	cmd.PersistentFlags().StringVarP(&cfg.farmBaseUrl, "farm-url", "", "", "Use a custom url for the Farm webservice.")
 	cmd.PersistentFlags().StringVarP(&cfg.requiredHostFeatures, "set-required-host-features", "", "", "Set and override required host features of all hosts spawned.\nFeatures must be one or more of [dc=<dc-name>, host=<host-name>, AMD-SEV-SNP, SNS-load-test, performance], separated by comma (see Examples).")
 	cmd.SetOut(os.Stdout)
+	cmd.PersistentFlags().StringVarP(&cfg.k8sBranch, "k8s-branch", "", "main", "Override the branch from which the dashboards are being synced. Default: main")
 	return cmd
 }
 


### PR DESCRIPTION
Wit this PR we add the possibility to override the branch from which the dashboards will be synced.

Usage:
```bash
# If creating a testnet
ict testnet create small --lifetime-mins 60 --k8s-branch release-controller-new
# If running a test
ict test qualification --k8s-branch release-controller-new
```