### PR TITLE
test(nervous-system): Bump Cycles Ledger dependency to the latest version

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -622,8 +622,8 @@ http_file(
 
 http_file(
     name = "cycles-ledger.wasm.gz",
-    sha256 = "4f26aae9edef5b4e2c785c1dc6f312163af055f22954dd99d515d8a862bd59bd",
-    url = "https://github.com/dfinity/cycles-ledger/releases/download/cycles-ledger-v0.2.3/cycles-ledger.wasm.gz",
+    sha256 = "d2aacbd214f20d752fd1696c2e36d7eceaafe07b932b3ae9e7e5564d1bda0178",
+    url = "https://github.com/dfinity/cycles-ledger/releases/download/cycles-ledger-v1.0.3/cycles-ledger.wasm.gz",
 )
 
 # Subnet Rental Canister

--- a/rs/nervous_system/integration_tests/src/pocket_ic_helpers.rs
+++ b/rs/nervous_system/integration_tests/src/pocket_ic_helpers.rs
@@ -641,7 +641,7 @@ pub mod cycles_ledger {
     #[derive(Clone, Eq, PartialEq, Hash, Debug, CandidType)]
     struct CyclesLedgerInitArgs {
         pub index_id: Option<Principal>,
-        pub max_transactions_per_request: u64,
+        pub max_blocks_per_request: u64,
     }
 
     /// Argument taken by the Cycles Ledger canister.
@@ -652,7 +652,7 @@ pub mod cycles_ledger {
     /// (variant {
     ///     Init = record {
     ///         index_id : opt principal;
-    ///         max_transactions_per_request : nat64;
+    ///         max_blocks_per_request : nat64;
     ///     }
     /// })
     /// ```
@@ -668,7 +668,7 @@ pub mod cycles_ledger {
 
         let arg = Encode!(&CyclesLedgerArgs::Init(CyclesLedgerInitArgs {
             index_id: None,
-            max_transactions_per_request: 1000,
+            max_blocks_per_request: 1000,
         }))
         .unwrap();
 

--- a/rs/nns/integration_tests/src/cycles_minting_canister.rs
+++ b/rs/nns/integration_tests/src/cycles_minting_canister.rs
@@ -55,6 +55,8 @@ use maplit::btreemap;
 use serde_bytes::ByteBuf;
 use std::time::Duration;
 
+const CYCLES_LEDGER_FEE: u128 = 100_000_000;
+
 /// Test that the CMC's `icp_xdr_conversion_rate` can be updated via Governance
 /// proposal.
 #[test]
@@ -1327,7 +1329,7 @@ fn cmc_notify_mint_cycles() {
     .unwrap();
     assert_eq!(
         cycles_ledger_balance_of(&state_machine, main_account),
-        100_000_000_000_000
+        100_000_000_000_000 - CYCLES_LEDGER_FEE
     );
 
     // to subaccount
@@ -1344,7 +1346,7 @@ fn cmc_notify_mint_cycles() {
     .unwrap();
     assert_eq!(
         cycles_ledger_balance_of(&state_machine, subaccount_1),
-        200_000_000_000_000
+        200_000_000_000_000 - CYCLES_LEDGER_FEE
     );
 
     // insufficient amount

--- a/rs/nns/test_utils/src/state_test_helpers.rs
+++ b/rs/nns/test_utils/src/state_test_helpers.rs
@@ -2098,7 +2098,7 @@ pub fn setup_cycles_ledger(state_machine: &StateMachine) {
     }
     #[derive(Clone, Eq, PartialEq, Debug, CandidType, Serialize)]
     struct Config {
-        pub max_transactions_per_request: u64,
+        pub max_blocks_per_request: u64,
         pub index_id: Option<candid::Principal>,
     }
 
@@ -2119,7 +2119,7 @@ pub fn setup_cycles_ledger(state_machine: &StateMachine) {
     )
     .unwrap();
     let arg = Encode!(&LedgerArgs::Init(Config {
-        max_transactions_per_request: 50,
+        max_blocks_per_request: 50,
         index_id: None,
     }))
     .unwrap();


### PR DESCRIPTION
This PR bumps the Cycles Ledger dependency to the latest version. This includes adapting to a breaking change (`max_transactions_per_request` was renamed into `max_blocks_per_request`).

| [Next PR](https://github.com/dfinity/ic/pull/3891) >