### PR TITLE
feat: Introduce the store canister, capable of refunding unused cycles 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1859,7 +1859,10 @@ version = "0.9.0"
 dependencies = [
  "candid",
  "candid_parser",
+ "ic-crypto-sha2",
+ "ic-wasm",
  "pretty_assertions",
+ "thiserror 2.0.11",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10310,6 +10310,7 @@ version = "0.9.0"
 dependencies = [
  "assert_matches",
  "candid",
+ "candid-utils",
  "canister-test",
  "cycles-minting-canister",
  "futures",
@@ -10371,6 +10372,7 @@ dependencies = [
  "rust_decimal_macros",
  "rustc-hash 1.1.0",
  "serde",
+ "store-canister-embedder",
  "tempfile",
  "tokio",
  "url",
@@ -20987,6 +20989,17 @@ dependencies = [
  "cfg-if 1.0.0",
  "futures-core",
  "pin-project-lite",
+]
+
+[[package]]
+name = "store-canister-embedder"
+version = "0.9.0"
+dependencies = [
+ "candid-utils",
+ "flate2",
+ "ic-base-types",
+ "ic-wasm",
+ "wasmprinter 0.217.0",
 ]
 
 [[package]]

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -622,8 +622,8 @@ http_file(
 
 http_file(
     name = "cycles-ledger.wasm.gz",
-    sha256 = "4f26aae9edef5b4e2c785c1dc6f312163af055f22954dd99d515d8a862bd59bd",
-    url = "https://github.com/dfinity/cycles-ledger/releases/download/cycles-ledger-v0.2.3/cycles-ledger.wasm.gz",
+    sha256 = "d2aacbd214f20d752fd1696c2e36d7eceaafe07b932b3ae9e7e5564d1bda0178",
+    url = "https://github.com/dfinity/cycles-ledger/releases/download/cycles-ledger-v1.0.3/cycles-ledger.wasm.gz",
 )
 
 # Subnet Rental Canister

--- a/rs/nervous_system/agent/src/ii/cycles_ledger.rs
+++ b/rs/nervous_system/agent/src/ii/cycles_ledger.rs
@@ -1,0 +1,43 @@
+use crate::CallCanisters;
+use candid::Nat;
+use cycles_minting_canister::{CanisterSettingsArgs, CreateCanister, SubnetSelection};
+use ic_base_types::PrincipalId;
+use ic_nns_constants::CYCLES_LEDGER_CANISTER_ID;
+
+pub mod requests;
+
+use requests::*;
+
+pub async fn create_canister<C: CallCanisters>(
+    agent: &C,
+    cycles_amount: u128,
+    subnet_selection: Option<SubnetSelection>,
+    settings: Option<CanisterSettingsArgs>,
+) -> Result<CreateCanisterSuccess, CreateCanisterError> {
+    let request = CreateCanisterArgs {
+        from_subaccount: None,
+        created_at_time: None,
+        amount: Nat::from(cycles_amount),
+        creation_args: Some(CreateCanister {
+            subnet_selection,
+            settings,
+            ..Default::default()
+        }),
+    };
+    agent
+        .call(CYCLES_LEDGER_CANISTER_ID, request)
+        .await
+        .expect("Cannot create canister")
+}
+
+pub async fn icrc1_balance_of<C: CallCanisters>(
+    agent: &C,
+    owner: PrincipalId,
+    subaccount: Option<Vec<u8>>,
+) -> Nat {
+    let request = Account { owner, subaccount };
+    agent
+        .call(CYCLES_LEDGER_CANISTER_ID, request)
+        .await
+        .expect("Cannot check cycles balance")
+}

--- a/rs/nervous_system/agent/src/ii/cycles_ledger/requests.rs
+++ b/rs/nervous_system/agent/src/ii/cycles_ledger/requests.rs
@@ -1,0 +1,102 @@
+use crate::Request;
+use candid::{CandidType, Encode, Nat, Principal};
+use cycles_minting_canister::CreateCanister;
+use ic_base_types::PrincipalId;
+use serde::Deserialize;
+
+pub type BlockIndex = Nat;
+
+#[derive(CandidType, Deserialize, Debug, Clone)]
+pub enum CreateCanisterError {
+    InsufficientFunds {
+        balance: Nat,
+    },
+    TooOld,
+    CreatedInFuture {
+        ledger_time: u64,
+    },
+    TemporarilyUnavailable,
+    Duplicate {
+        duplicate_of: Nat,
+        // If the original transaction created a canister then this field will contain the canister id.
+        canister_id: Option<Principal>,
+    },
+    FailedToCreate {
+        fee_block: Option<BlockIndex>,
+        refund_block: Option<BlockIndex>,
+        error: String,
+    },
+    GenericError {
+        message: String,
+        error_code: Nat,
+    },
+}
+
+// ```candid
+// type CreateCanisterArgs = record {
+//     from_subaccount : opt vec nat8;
+//     created_at_time : opt nat64;
+//     amount : nat;
+//     creation_args : opt CmcCreateCanisterArgs;
+// };
+// ```
+#[derive(Clone, Eq, PartialEq, Debug, CandidType, Deserialize)]
+pub struct CreateCanisterArgs {
+    pub from_subaccount: Option<Vec<u8>>,
+    pub created_at_time: Option<u64>,
+    pub amount: Nat,
+    pub creation_args: Option<CreateCanister>,
+}
+
+// ```candid
+// type CreateCanisterSuccess = record {
+//     block_id : BlockIndex;
+//     canister_id : principal;
+// };
+// ```
+#[derive(Clone, Eq, PartialEq, Debug, CandidType, Deserialize)]
+pub struct CreateCanisterSuccess {
+    pub block_id: BlockIndex,
+    pub canister_id: PrincipalId,
+}
+
+impl Request for CreateCanisterArgs {
+    fn method(&self) -> &'static str {
+        "create_canister"
+    }
+
+    fn update(&self) -> bool {
+        true
+    }
+
+    fn payload(&self) -> std::result::Result<Vec<u8>, candid::Error> {
+        Encode!(self)
+    }
+
+    type Response = Result<CreateCanisterSuccess, CreateCanisterError>;
+}
+
+// ```
+// type Account = record { owner : principal; subaccount : opt vec nat8 };
+// ```
+#[derive(Clone, Eq, PartialEq, Debug, CandidType, Deserialize)]
+pub struct Account {
+    pub owner: PrincipalId,
+    pub subaccount: Option<Vec<u8>>,
+}
+
+impl Request for Account {
+    fn method(&self) -> &'static str {
+        "icrc1_balance_of"
+    }
+
+    fn update(&self) -> bool {
+        false
+    }
+
+    fn payload(&self) -> Result<Vec<u8>, candid::Error> {
+        Encode!(self)
+    }
+
+    type Response = Nat;
+}

--- a/rs/nervous_system/agent/src/ii/mod.rs
+++ b/rs/nervous_system/agent/src/ii/mod.rs
@@ -1,0 +1,2 @@
+pub mod cycles_ledger;
+pub mod store;

--- a/rs/nervous_system/agent/src/ii/store.rs
+++ b/rs/nervous_system/agent/src/ii/store.rs
@@ -1,0 +1,36 @@
+use crate::CallCanisters;
+use crate::Request;
+use candid::{CandidType, Encode, Nat};
+use ic_base_types::{CanisterId, PrincipalId};
+
+#[derive(CandidType, Clone, Eq, PartialEq, Debug)]
+struct WithdrawCyclesArg {
+    pub to: PrincipalId,
+}
+
+impl Request for WithdrawCyclesArg {
+    fn method(&self) -> &'static str {
+        "withdraw_cycles"
+    }
+
+    fn update(&self) -> bool {
+        true
+    }
+
+    fn payload(&self) -> Result<Vec<u8>, candid::Error> {
+        Encode!(&self.to)
+    }
+
+    type Response = Nat;
+}
+
+pub async fn withdraw_cycles<C: CallCanisters>(
+    agent: &C,
+    store_canister_id: CanisterId,
+    to: PrincipalId,
+) -> Nat {
+    agent
+        .call(store_canister_id, WithdrawCyclesArg { to })
+        .await
+        .expect("Cannot withdraw cycles")
+}

--- a/rs/nervous_system/agent/src/lib.rs
+++ b/rs/nervous_system/agent/src/lib.rs
@@ -4,6 +4,7 @@ use std::collections::BTreeSet;
 use std::fmt::Display;
 
 pub mod agent_impl;
+pub mod ii;
 pub mod management_canister;
 pub mod nns;
 mod null_request;

--- a/rs/nervous_system/candid_utils/BUILD.bazel
+++ b/rs/nervous_system/candid_utils/BUILD.bazel
@@ -5,8 +5,11 @@ package(default_visibility = ["//visibility:public"])
 # See rs/nervous_system/feature_test.md
 DEPENDENCIES = [
     # Keep sorted.
+    "//rs/crypto/sha2",
     "@crate_index//:candid",
     "@crate_index//:candid_parser",
+    "@crate_index//:ic-wasm",
+    "@crate_index//:thiserror",
 ]
 
 MACRO_DEPENDENCIES = []

--- a/rs/nervous_system/candid_utils/Cargo.toml
+++ b/rs/nervous_system/candid_utils/Cargo.toml
@@ -12,6 +12,9 @@ path = "src/lib.rs"
 [dependencies]
 candid = { workspace = true }
 candid_parser = { workspace = true }
+ic-crypto-sha2 = { path = "../../crypto/sha2" }
+ic-wasm = { workspace = true }
+thiserror = { workspace = true }
 
 [dev-dependencies]
 pretty_assertions = { workspace = true }

--- a/rs/nervous_system/candid_utils/src/lib.rs
+++ b/rs/nervous_system/candid_utils/src/lib.rs
@@ -1,2 +1,3 @@
 pub mod printing;
 pub mod validation;
+pub mod wasm;

--- a/rs/nervous_system/candid_utils/src/validation/tests.rs
+++ b/rs/nervous_system/candid_utils/src/validation/tests.rs
@@ -137,7 +137,7 @@ fn test_candid_service_arg_validation() {
             )),
         ),
     ] {
-        let observed_result = encode_upgrade_args(candid_service.to_string(), upgrade_arg);
+        let observed_result = encode_upgrade_args(candid_service.to_string(), &upgrade_arg);
 
         match (observed_result, expected_result) {
             (Ok(_), Ok(())) => (),

--- a/rs/nervous_system/candid_utils/src/wasm.rs
+++ b/rs/nervous_system/candid_utils/src/wasm.rs
@@ -1,0 +1,190 @@
+use crate::validation::{
+    augment_candid_service, encode_upgrade_args, CandidServiceArgValidationError,
+};
+use ic_wasm::{metadata, utils::parse_wasm};
+use std::io::Read;
+use std::{
+    fs::File,
+    path::{Path, PathBuf},
+};
+use thiserror::Error;
+
+const RAW_WASM_HEADER: [u8; 4] = [0, 0x61, 0x73, 0x6d];
+const GZIPPED_WASM_HEADER: [u8; 3] = [0x1f, 0x8b, 0x08];
+
+#[derive(Debug, Error)]
+pub enum CandidError {
+    #[error("agent interaction failed: {0}")]
+    WasmParseError(String),
+    #[error("Wasm metadata has no Candid service declaration.")]
+    NoCandidService,
+    #[error("Candid service args are invalid: {0}.")]
+    CandidServiceArgValidationError(CandidServiceArgValidationError),
+}
+
+pub trait Wasm {
+    fn bytes(&self) -> &[u8];
+
+    fn module_hash(&self) -> [u8; 32];
+
+    fn list_metadata_sections(&self) -> Result<Vec<String>, CandidError> {
+        let module = parse_wasm(self.bytes(), false)
+            .map_err(|err| CandidError::WasmParseError(format!("{err:?}")))?;
+
+        let metadata_sections = metadata::list_metadata(&module)
+            .iter()
+            .map(|metadata| metadata.to_string())
+            .collect();
+
+        Ok(metadata_sections)
+    }
+
+    fn canidid_service(&self) -> Result<Option<String>, CandidError> {
+        let module = parse_wasm(self.bytes(), false)
+            .map_err(|err| CandidError::WasmParseError(format!("{err:?}")))?;
+
+        let read_section = |name: &str| -> Option<String> {
+            let bytes = metadata::get_metadata(&module, name).map(|contents| contents.to_vec());
+            bytes.map(|bytes| std::str::from_utf8(&bytes).unwrap().to_string())
+        };
+
+        let (mut candid_service, mut candid_args) = (None, None);
+
+        for section in metadata::list_metadata(&module) {
+            let mut section = section.split(' ').collect::<Vec<&str>>();
+
+            if section.is_empty() {
+                // This cannot practically happen, as it would imply that all characters of
+                // the section are whitespaces.
+                continue;
+            }
+
+            // Consume this section's visibility specification, e.g. "icp:public" or "icp:private".
+            let _visibility = section.remove(0).to_string();
+
+            // The conjunction of the remaining parts are the section's name.
+            let name = section.join(" ");
+
+            if name == "candid:service" {
+                candid_service = read_section(&name);
+            }
+            if name == "candid:args" {
+                candid_args = read_section(&name);
+            }
+        }
+
+        match (candid_service, candid_args) {
+            (None, _) => Ok(None),
+            (Some(candid_service), None) => Ok(Some(candid_service)),
+            (Some(candid_service), Some(candid_args)) => {
+                let candid_service = augment_candid_service(&candid_service, &candid_args)
+                    .map_err(CandidError::CandidServiceArgValidationError)?;
+
+                Ok(Some(candid_service))
+            }
+        }
+    }
+
+    /// Attempts to validate `args` against the Candid service from `self`'s metadata.
+    ///
+    /// If `args` is Some, returns the byte encoding of `args` in the Ok result.
+    fn encode_candid_args(&self, args: &Option<String>) -> Result<Option<Vec<u8>>, CandidError> {
+        let candid_service = self.canidid_service()?;
+
+        let Some(candid_service) = candid_service else {
+            return Err(CandidError::NoCandidService);
+        };
+
+        let candid_arg_bytes = encode_upgrade_args(candid_service, args)
+            .map_err(CandidError::CandidServiceArgValidationError)?;
+
+        Ok(candid_arg_bytes)
+    }
+}
+
+pub struct WasmFile {
+    path: PathBuf,
+    bytes: Vec<u8>,
+    module_hash: [u8; 32],
+}
+
+impl WasmFile {
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl Wasm for WasmFile {
+    fn bytes(&self) -> &[u8] {
+        &self.bytes
+    }
+
+    fn module_hash(&self) -> [u8; 32] {
+        self.module_hash
+    }
+}
+
+pub struct InMemoryWasm {
+    bytes: Vec<u8>,
+    module_hash: [u8; 32],
+}
+
+impl Wasm for InMemoryWasm {
+    fn bytes(&self) -> &[u8] {
+        &self.bytes
+    }
+
+    fn module_hash(&self) -> [u8; 32] {
+        self.module_hash
+    }
+}
+
+impl TryFrom<&[u8]> for InMemoryWasm {
+    type Error = String;
+
+    fn try_from(bytes: &[u8]) -> Result<Self, Self::Error> {
+        // Smoke test: Is this a ICP Wasm?
+        if !bytes.starts_with(&RAW_WASM_HEADER) && !bytes.starts_with(&GZIPPED_WASM_HEADER) {
+            return Err("The file does not look like a valid ICP Wasm module.".to_string());
+        }
+
+        let module_hash = ic_crypto_sha2::Sha256::hash(bytes);
+
+        let bytes = bytes.to_vec();
+
+        Ok(Self { bytes, module_hash })
+    }
+}
+
+impl TryFrom<PathBuf> for WasmFile {
+    type Error = String;
+
+    fn try_from(path: PathBuf) -> Result<Self, Self::Error> {
+        let mut file = match File::open(&path) {
+            Err(err) => {
+                return Err(format!(
+                    "Cannot open Wasm file under {}: {}",
+                    path.display(),
+                    err,
+                ));
+            }
+            Ok(file) => file,
+        };
+
+        // Create a buffer to store the file's content
+        let mut bytes = Vec::new();
+
+        // Read the file's content into the buffer
+        if let Err(err) = file.read_to_end(&mut bytes) {
+            return Err(format!("Cannot read Wasm file {}: {}", path.display(), err,));
+        }
+
+        let InMemoryWasm { bytes, module_hash } = InMemoryWasm::try_from(bytes.as_slice())?;
+
+        Ok(Self {
+            path,
+            bytes,
+            module_hash,
+        })
+    }
+}

--- a/rs/nervous_system/integration_tests/BUILD.bazel
+++ b/rs/nervous_system/integration_tests/BUILD.bazel
@@ -13,10 +13,12 @@ BASE_DEPENDENCIES = [
     "//rs/ledger_suite/icrc1/index-ng",
     "//rs/ledger_suite/icrc1/tokens_u64",
     "//rs/nervous_system/agent",
+    "//rs/nervous_system/candid_utils",
     "//rs/nervous_system/clients",
     "//rs/nervous_system/common",
     "//rs/nervous_system/proto",
     "//rs/nervous_system/root",
+    "//rs/nervous_system/store_canister:store_canister_embedder",
     "//rs/nns/cmc",
     "//rs/nns/common",
     "//rs/nns/governance/api",
@@ -298,6 +300,23 @@ rust_test(
         "tests/upgrade_sns_controlled_canister_with_large_wasm.rs",
     ],
     aliases = ALIASES,
+    data = DEV_DATA,
+    env = DEV_ENV | {"RUST_TEST_NOCAPTURE": "1"},
+    flaky = True,
+    proc_macro_deps = MACRO_DEPENDENCIES + MACRO_DEV_DEPENDENCIES,
+    tags = [
+        "cpu:4",
+    ],
+    deps = [":nervous_system_integration_tests"] + DEPENDENCIES_WITH_TEST_FEATURES + DEV_DEPENDENCIES,
+)
+
+rust_test(
+    name = "store_canister_integration",
+    timeout = "long",
+    srcs = [
+        "tests/store_canister_integration.rs",
+    ],
+        aliases = ALIASES,
     data = DEV_DATA,
     env = DEV_ENV | {"RUST_TEST_NOCAPTURE": "1"},
     flaky = True,

--- a/rs/nervous_system/integration_tests/BUILD.bazel
+++ b/rs/nervous_system/integration_tests/BUILD.bazel
@@ -316,7 +316,7 @@ rust_test(
     srcs = [
         "tests/store_canister_integration.rs",
     ],
-        aliases = ALIASES,
+    aliases = ALIASES,
     data = DEV_DATA,
     env = DEV_ENV | {"RUST_TEST_NOCAPTURE": "1"},
     flaky = True,

--- a/rs/nervous_system/integration_tests/Cargo.toml
+++ b/rs/nervous_system/integration_tests/Cargo.toml
@@ -10,6 +10,7 @@ documentation.workspace = true
 [dependencies]
 assert_matches = { workspace = true }
 candid = { workspace = true }
+candid-utils = { path = "../candid_utils" }
 cycles-minting-canister = { path = "../../nns/cmc" }
 futures = { workspace = true }
 ic-base-types = { path = "../../types/base_types" }
@@ -39,6 +40,7 @@ pocket-ic = { path = "../../../packages/pocket-ic" }
 prost = { workspace = true }
 rust_decimal = "1.36.0"
 rust_decimal_macros = "1.36.0"
+store-canister-embedder = { path = "../store_canister" }
 tempfile = { workspace = true }
 tokio = { workspace = true }
 url = { workspace = true }

--- a/rs/nervous_system/integration_tests/src/pocket_ic_helpers.rs
+++ b/rs/nervous_system/integration_tests/src/pocket_ic_helpers.rs
@@ -603,7 +603,7 @@ pub mod cycles_ledger {
     #[derive(Clone, Eq, PartialEq, Hash, Debug, CandidType)]
     struct CyclesLedgerInitArgs {
         pub index_id: Option<Principal>,
-        pub max_transactions_per_request: u64,
+        pub max_blocks_per_request: u64,
     }
 
     /// Argument taken by the Cycles Ledger canister.
@@ -614,7 +614,7 @@ pub mod cycles_ledger {
     /// (variant {
     ///     Init = record {
     ///         index_id : opt principal;
-    ///         max_transactions_per_request : nat64;
+    ///         max_blocks_per_request : nat64;
     ///     }
     /// })
     /// ```
@@ -630,7 +630,7 @@ pub mod cycles_ledger {
 
         let arg = Encode!(&CyclesLedgerArgs::Init(CyclesLedgerInitArgs {
             index_id: None,
-            max_transactions_per_request: 1000,
+            max_blocks_per_request: 1000,
         }))
         .unwrap();
 

--- a/rs/nervous_system/integration_tests/tests/store_canister_integration.rs
+++ b/rs/nervous_system/integration_tests/tests/store_canister_integration.rs
@@ -1,0 +1,152 @@
+use candid::Nat;
+use candid_utils::wasm::{InMemoryWasm, Wasm};
+use cycles_minting_canister::{CanisterSettingsArgs, SubnetSelection};
+use ic_base_types::CanisterId;
+use ic_base_types::PrincipalId;
+use ic_base_types::SubnetId;
+use ic_management_canister_types::BoundedVec;
+use ic_nervous_system_agent::ii::cycles_ledger as production_cycles_ledger;
+use ic_nervous_system_agent::ii::store::withdraw_cycles;
+use ic_nervous_system_agent::management_canister as production_management_canister;
+use ic_nervous_system_agent::management_canister::requests::Mode;
+use ic_nervous_system_agent::pocketic_impl::PocketIcAgent;
+use ic_nervous_system_integration_tests::pocket_ic_helpers::{
+    cycles_ledger, load_registry_mutations, NnsInstaller,
+};
+use ic_sns_cli::upgrade_sns_controlled_canister::STORE_CANISTER_INITIAL_CYCLES_BALANCE;
+use icp_ledger::Tokens;
+use pocket_ic::PocketIcBuilder;
+use store_canister_embedder::{StoreCanisterInitArgs, STORE_CANISTER_WASM};
+use tempfile::TempDir;
+
+const CYCLES_LEDGER_FEE: u128 = 100_000_000;
+const RESERVED_CYCLES: u128 = 140_000_000_000;
+
+#[tokio::test]
+async fn store_canister_integration() {
+    // 1. Prepare the world
+    let state_dir = TempDir::new().unwrap();
+    let state_dir = state_dir.path().to_path_buf();
+
+    let pocket_ic = PocketIcBuilder::new()
+        .with_state_dir(state_dir.clone())
+        .with_nns_subnet()
+        .with_ii_subnet()
+        .with_application_subnet()
+        .build_async()
+        .await;
+
+    // 1.1. Install the NNS canisters.
+    {
+        let registry_proto_path = state_dir.join("registry.proto");
+        let initial_mutations = load_registry_mutations(registry_proto_path);
+
+        let mut nns_installer = NnsInstaller::default();
+        nns_installer.with_current_nns_canister_versions();
+        nns_installer.with_cycles_minting_canister();
+        nns_installer.with_cycles_ledger();
+        nns_installer.with_custom_registry_mutations(vec![initial_mutations]);
+        nns_installer.install(&pocket_ic).await;
+    }
+
+    // 1.2. Prepare a user with 10 ICP worth of cycles in the Cycles Ledger account.
+    let sender = PrincipalId::new_user_test_id(42);
+    let icp = Tokens::from_tokens(10).unwrap();
+    cycles_ledger::mint_icp_and_convert_to_cycles(&pocket_ic, sender, icp).await;
+    let pocket_ic_agent = PocketIcAgent {
+        pocket_ic: &pocket_ic,
+        sender: sender.into(),
+    };
+
+    // 1.3. Install the store canister on an app subnet.
+    let (store_wasm, store_arg) = {
+        let store_wasm = InMemoryWasm::try_from(STORE_CANISTER_WASM).unwrap();
+        let store_arg = StoreCanisterInitArgs {
+            authorized_principal: sender,
+        }
+        .render();
+        let store_arg = store_wasm.encode_candid_args(&Some(store_arg)).unwrap();
+        (store_wasm, store_arg)
+    };
+
+    // 1.4. Deploy the store canister.
+    let app_subnet = pocket_ic.topology().await.get_app_subnets()[0];
+    let subnet_selection = Some(SubnetSelection::Subnet {
+        subnet: SubnetId::from(PrincipalId(app_subnet)),
+    });
+    let store_canister_id = production_cycles_ledger::create_canister(
+        &pocket_ic_agent,
+        STORE_CANISTER_INITIAL_CYCLES_BALANCE,
+        subnet_selection,
+        Some(CanisterSettingsArgs {
+            controllers: Some(BoundedVec::new(vec![sender])),
+            freezing_threshold: Some(Nat::from(0_u128)),
+            reserved_cycles_limit: Some(Nat::from(0_u128)),
+            ..Default::default()
+        }),
+    )
+    .await
+    .map(|create_canister_success| {
+        CanisterId::unchecked_from_principal(create_canister_success.canister_id)
+    })
+    .unwrap();
+    production_management_canister::install_code(
+        &pocket_ic_agent,
+        store_canister_id,
+        Mode::Install,
+        store_wasm.bytes().to_vec(),
+        store_arg,
+        None,
+    )
+    .await
+    .unwrap();
+
+    // 2. Run code under test.
+
+    // 2.1. Fetch the relevant bits from the pre-state.
+    let initial_store_cycles_balance = pocket_ic
+        .canister_status(store_canister_id.into(), Some(sender.into()))
+        .await
+        .unwrap()
+        .cycles;
+    let initial_cycles_balance = ic_nervous_system_agent::ii::cycles_ledger::icrc1_balance_of(
+        &pocket_ic_agent,
+        sender,
+        None,
+    )
+    .await;
+    // 2.1.1. Smoke test.
+    assert!(initial_store_cycles_balance.clone() > RESERVED_CYCLES);
+
+    // 2.2. Trigger the ultimate state transition.
+    let amount_cycles_withdrawn =
+        withdraw_cycles(&pocket_ic_agent, store_canister_id, sender).await;
+
+    // 2.3. Fetch the relevant bits from the post-state.
+    let final_store_cycles_balance = pocket_ic
+        .canister_status(store_canister_id.into(), Some(sender.into()))
+        .await
+        .unwrap()
+        .cycles;
+    let final_cycles_balance = ic_nervous_system_agent::ii::cycles_ledger::icrc1_balance_of(
+        &pocket_ic_agent,
+        sender,
+        None,
+    )
+    .await;
+
+    // 3. Inspect the results.
+    let fee = Nat::from(CYCLES_LEDGER_FEE);
+    assert_eq!(
+        final_cycles_balance,
+        initial_cycles_balance + amount_cycles_withdrawn.clone() - fee.clone()
+    );
+    assert!(amount_cycles_withdrawn > fee);
+
+    assert!(final_store_cycles_balance < Nat::from(RESERVED_CYCLES));
+    assert!(
+        initial_store_cycles_balance.clone() - final_store_cycles_balance.clone() > Nat::from(RESERVED_CYCLES),
+        "initial_store_cycles_balance ({}) - final_store_cycles_balance ({}) should be > RESERVED_CYCLES ({})",
+        initial_store_cycles_balance, final_store_cycles_balance, RESERVED_CYCLES,
+    );
+}

--- a/rs/nervous_system/integration_tests/tests/upgrade_sns_controlled_canister_with_large_wasm.rs
+++ b/rs/nervous_system/integration_tests/tests/upgrade_sns_controlled_canister_with_large_wasm.rs
@@ -1,7 +1,6 @@
 use assert_matches::assert_matches;
 use canister_test::Wasm;
 use ic_base_types::CanisterId;
-use ic_management_canister_types::CanisterInstallMode;
 use ic_nervous_system_agent::management_canister::canister_status;
 use ic_nervous_system_agent::pocketic_impl::{
     PocketIcAgent, PocketIcCallError::CanisterSubnetNotFound,
@@ -18,6 +17,7 @@ use ic_nervous_system_integration_tests::{
     pocket_ic_helpers::add_wasms_to_sns_wasm,
 };
 use ic_nns_constants::ROOT_CANISTER_ID;
+use ic_nns_governance::pb::v1::install_code::CanisterInstallMode;
 use ic_nns_test_utils::common::modify_wasm_bytes;
 use ic_sns_cli::neuron_id_to_candid_subaccount::ParsedSnsNeuron;
 use ic_sns_cli::upgrade_sns_controlled_canister::{
@@ -248,7 +248,7 @@ async fn upgrade_sns_controlled_canister_with_large_wasm() {
     .await;
     // TODO: Consider strengthening these assertions.
     assert!(final_cycles_balance < original_cycles_balance);
-    assert!(final_cycles_balance > candid::Nat::from(0_u64));
+    assert!(final_cycles_balance > 0_u64);
 
     // 8. Assert that store canister has been deleted.
     let err = canister_status(

--- a/rs/nervous_system/store_canister/BUILD.bazel
+++ b/rs/nervous_system/store_canister/BUILD.bazel
@@ -1,0 +1,37 @@
+load("@rules_motoko//motoko:defs.bzl", "motoko_library")
+load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test")
+load("//bazel:canisters.bzl", "motoko_canister")
+
+package(default_visibility = ["//visibility:public"])
+
+motoko_canister(
+    name = "store",
+    entry = "store.mo",
+    deps = [],
+)
+
+rust_library(
+    name = "store_canister_embedder",
+    srcs = ["src/lib.rs"],
+    compile_data = [":store.wasm"],
+    rustc_env = {
+        "STORE_CANISTER_WASM_PATH": "$(location :store.wasm)",
+    },
+    deps = [
+        "//rs/types/base_types",
+    ]
+)
+
+rust_test(
+    name = "store_wasm_test",
+    compile_data = [":store.wasm"],
+    crate = ":store_canister_embedder",
+    deps = [
+        # Keep sorted.
+        "//rs/nervous_system/candid_utils",
+        "//rs/types/base_types",
+        "@crate_index//:flate2",
+        "@crate_index//:ic-wasm",
+        "@crate_index//:wasmprinter",
+    ],
+)

--- a/rs/nervous_system/store_canister/BUILD.bazel
+++ b/rs/nervous_system/store_canister/BUILD.bazel
@@ -1,4 +1,3 @@
-load("@rules_motoko//motoko:defs.bzl", "motoko_library")
 load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test")
 load("//bazel:canisters.bzl", "motoko_canister")
 
@@ -19,7 +18,7 @@ rust_library(
     },
     deps = [
         "//rs/types/base_types",
-    ]
+    ],
 )
 
 rust_test(

--- a/rs/nervous_system/store_canister/Cargo.toml
+++ b/rs/nervous_system/store_canister/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "store-canister-embedder"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+description.workspace = true
+documentation.workspace = true
+
+[lib]
+path = "src/lib.rs"
+
+[dependencies]
+ic-base-types = { path = "../../types/base_types" }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
+candid-utils = { path = "../candid_utils" }
+flate2 = { workspace = true }
+ic-wasm = { workspace = true }
+wasmprinter = { workspace = true }

--- a/rs/nervous_system/store_canister/src/lib.rs
+++ b/rs/nervous_system/store_canister/src/lib.rs
@@ -1,0 +1,60 @@
+//! Exposes the store canister Wasm as a constant.
+//! This crate is NOT part of the store canister itself: it only exposes it
+//! into rust.
+use ic_base_types::PrincipalId;
+
+pub const STORE_CANISTER_WASM: &[u8] = include_bytes!(env!("STORE_CANISTER_WASM_PATH"));
+
+pub struct StoreCanisterInitArgs {
+    pub authorized_principal: PrincipalId,
+}
+
+impl StoreCanisterInitArgs {
+    pub fn render(&self) -> String {
+        format!("(principal \"{}\")", self.authorized_principal)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use candid_utils::wasm::{InMemoryWasm, Wasm};
+    use std::io::Read;
+
+    #[test]
+    fn check_that_store_wasm_is_legal() {
+        let mut decoder = flate2::read::GzDecoder::new(STORE_CANISTER_WASM);
+        let mut decoded_wasm = vec![];
+        decoder.read_to_end(&mut decoded_wasm).unwrap();
+        wasmprinter::print_bytes(decoded_wasm).unwrap();
+    }
+
+    #[test]
+    fn check_that_store_wasm_has_candid_metadata() {
+        let store_canister = InMemoryWasm::try_from(STORE_CANISTER_WASM).unwrap();
+
+        let metadata = store_canister.list_metadata_sections().unwrap();
+        assert_ne!(metadata, Vec::<String>::new());
+
+        store_canister.encode_candid_args(&None).unwrap_err();
+
+        {
+            let store_arg = format!(
+                "({{ authorized_principal = {} : nat64 }})",
+                PrincipalId::new_user_test_id(42)
+            );
+            store_canister
+                .encode_candid_args(&Some(store_arg))
+                .unwrap_err();
+        }
+
+        {
+            let store_arg = StoreCanisterInitArgs {
+                authorized_principal: PrincipalId::new_user_test_id(42),
+            };
+            store_canister
+                .encode_candid_args(&Some(store_arg.render()))
+                .unwrap();
+        }
+    }
+}

--- a/rs/nervous_system/store_canister/store.did
+++ b/rs/nervous_system/store_canister/store.did
@@ -1,0 +1,9 @@
+type WithdrawResult = variant {
+  Ok : nat;
+  Error : text;
+};
+
+service: (authorized_principal : principal) -> {
+  withdraw_cycles : (to : principal) -> (WithdrawResult);
+  foo : () -> ();
+}

--- a/rs/nervous_system/store_canister/store.did
+++ b/rs/nervous_system/store_canister/store.did
@@ -1,9 +1,0 @@
-type WithdrawResult = variant {
-  Ok : nat;
-  Error : text;
-};
-
-service: (authorized_principal : principal) -> {
-  withdraw_cycles : (to : principal) -> (WithdrawResult);
-  foo : () -> ();
-}

--- a/rs/nervous_system/store_canister/store.mo
+++ b/rs/nervous_system/store_canister/store.mo
@@ -1,0 +1,47 @@
+import Prim "mo:prim";
+
+actor class (authorized_principal : Principal) {
+    // Approximate amount of cycles that this canister cannot operate without.
+    private let RESERVED_CYCLES: Nat = 100_000_000_000;
+
+    type Account = {
+        owner : Principal;
+        subaccount : ?Blob;
+    };
+
+    type DepositArgs = {
+        to : Account;
+        memo : ?Blob;
+    };
+
+    type DepositResult = {
+        balance : Nat;
+        block_index : Nat;
+    };
+
+    private let cyclesLedger = actor "um5iw-rqaaa-aaaaq-qaaba-cai" : actor {
+        deposit : (DepositArgs) -> async (DepositResult);
+    };
+
+    public shared ({caller}) func withdraw_cycles(to : Principal) : async Nat {
+        assert caller == authorized_principal;
+
+        let balance = Prim.cyclesBalance();
+        if (balance <= RESERVED_CYCLES) {
+            return 0;
+        };
+        let withdraw_amount = balance - RESERVED_CYCLES;
+
+        Prim.cyclesAdd(withdraw_amount);
+
+        let _ = await cyclesLedger.deposit({
+            to = {
+                owner = authorized_principal;
+                subaccount = null;
+            };
+            memo = null;
+        });
+
+        withdraw_amount
+    };
+}

--- a/rs/nns/integration_tests/src/cycles_minting_canister.rs
+++ b/rs/nns/integration_tests/src/cycles_minting_canister.rs
@@ -56,6 +56,8 @@ use maplit::btreemap;
 use serde_bytes::ByteBuf;
 use std::time::Duration;
 
+const CYCLES_LEDGER_FEE: u128 = 100_000_000;
+
 /// Test that the CMC's `icp_xdr_conversion_rate` can be updated via Governance
 /// proposal.
 #[test]
@@ -1358,7 +1360,7 @@ fn cmc_notify_mint_cycles() {
     .unwrap();
     assert_eq!(
         cycles_ledger_balance_of(&state_machine, main_account),
-        100_000_000_000_000
+        100_000_000_000_000 - CYCLES_LEDGER_FEE
     );
 
     // to subaccount
@@ -1375,7 +1377,7 @@ fn cmc_notify_mint_cycles() {
     .unwrap();
     assert_eq!(
         cycles_ledger_balance_of(&state_machine, subaccount_1),
-        200_000_000_000_000
+        200_000_000_000_000 - CYCLES_LEDGER_FEE
     );
 
     // insufficient amount

--- a/rs/nns/test_utils/src/state_test_helpers.rs
+++ b/rs/nns/test_utils/src/state_test_helpers.rs
@@ -2136,7 +2136,7 @@ pub fn setup_cycles_ledger(state_machine: &StateMachine) {
     }
     #[derive(Clone, Eq, PartialEq, Debug, CandidType, Serialize)]
     struct Config {
-        pub max_transactions_per_request: u64,
+        pub max_blocks_per_request: u64,
         pub index_id: Option<candid::Principal>,
     }
 
@@ -2157,7 +2157,7 @@ pub fn setup_cycles_ledger(state_machine: &StateMachine) {
     )
     .unwrap();
     let arg = Encode!(&LedgerArgs::Init(Config {
-        max_transactions_per_request: 50,
+        max_blocks_per_request: 50,
         index_id: None,
     }))
     .unwrap();

--- a/rs/sns/cli/src/upgrade_sns_controlled_canister.rs
+++ b/rs/sns/cli/src/upgrade_sns_controlled_canister.rs
@@ -183,7 +183,7 @@ pub fn validate_candid_arg_for_wasm(wasm: &Wasm, args: Option<String>) -> Result
 
         print!("Validating the upgrade arg against the Candid service definition ... ");
         std::io::stdout().flush().unwrap();
-        let candid_arg_bytes = encode_upgrade_args(candid_service, args).unwrap();
+        let candid_arg_bytes = encode_upgrade_args(candid_service, &args).unwrap();
         println!("✔️");
 
         candid_arg_bytes
@@ -199,7 +199,8 @@ pub fn validate_candid_arg_for_wasm(wasm: &Wasm, args: Option<String>) -> Result
         );
 
         // Proceed with whatever argument the user has specified without validation.
-        args.map(|args| encode_upgrade_args_without_service(args).unwrap())
+        args.as_ref()
+            .map(|args| encode_upgrade_args_without_service(args).unwrap())
     };
 
     std::io::stdout().flush().unwrap();


### PR DESCRIPTION
This PR adds a minimalistic canister, called `store`, that is capable of refunding unused cycles. The point of this canister is to install it when an empty canister would suffice modulo the problem of cycles refunds.

For example, upgrading decentralized canisters with large Wasms (e.g., SNS-controlled canisters) requires uploading the Wasm, in chunks, into _some_ canister controlled by the upgrade proposer. But the proposer cannot know upfront the amount of cycles it would take e2e, so they typically top up their Wasm store canister excessively. If they install the code of `store`, then at the end of the process the only call needed would be `store.withdraw_cycles` which deposits (most of) the leftover cycles into the Cycles Ledger account specified by that user.

< [Previous PR](https://github.com/dfinity/ic/pull/3890) |