### PR TITLE
test(IDX): colocate some flaky networking system-tests

### DIFF
--- a/rs/tests/networking/BUILD.bazel
+++ b/rs/tests/networking/BUILD.bazel
@@ -197,6 +197,7 @@ system_test_nns(
     extra_head_nns_tags = ["manual"],  # only run this test with the mainnet NNS canisters.
     flaky = True,
     tags = [
+        "experimental_system_test_colocation",
         "k8s",
         "system_test_nightly",
     ],
@@ -230,6 +231,7 @@ system_test_nns(
     name = "query_workload_long_test",
     flaky = True,
     tags = [
+        "experimental_system_test_colocation",
         "k8s",
         "system_test_hourly",
     ],
@@ -245,6 +247,7 @@ system_test_nns(
     name = "update_workload_large_payload",
     flaky = True,
     tags = [
+        "experimental_system_test_colocation",
         "system_test_hourly",
     ],
     target_compatible_with = ["@platforms//os:linux"],  # requires libssh that does not build on Mac OS


### PR DESCRIPTION
This colocates the test driver with the testnet it deploys for the following flaky system-tests:

* `//rs/tests/networking:network_reliability_test`: 10% flaky
* `//rs/tests/networking:query_workload_long_test` 11% flaky
* `//rs/tests/networking:update_workload_large_payload` 4% flaky

These test generate a workload from the test driver to their testnets so the idea is that if we colocate the driver with the testnet the network in between would be more reliable.

Hourly run: https://github.com/dfinity/ic/actions/runs/13263034379