### PR TITLE
chore(IDX): extract repository_cache

### DIFF
--- a/.github/workflows-source/ci-main.yml
+++ b/.github/workflows-source/ci-main.yml
@@ -139,7 +139,7 @@ jobs:
         with:
           BAZEL_COMMAND: "test"
           BAZEL_TARGETS: "//..."
-          BAZEL_CI_CONFIG: "--config=ci --repository_cache=/cache/bazel"
+          BAZEL_CI_CONFIG: "--config=ci"
           # check if PR title contains release and set timeout filters accordingly
           BAZEL_EXTRA_ARGS: ${{ env.BAZEL_EXTRA_ARGS }}
           BUILDEVENT_APIKEY: ${{ secrets.HONEYCOMB_TOKEN }}

--- a/.github/workflows-source/release-testing.yml
+++ b/.github/workflows-source/release-testing.yml
@@ -78,7 +78,7 @@ jobs:
         with:
           BAZEL_COMMAND: "test"
           BAZEL_TARGETS: "//rs/tests/..."
-          BAZEL_CI_CONFIG: "--config=ci --repository_cache=/cache/bazel"
+          BAZEL_CI_CONFIG: "--config=ci"
           BAZEL_EXTRA_ARGS: "--keep_going --test_tag_filters=system_test_nightly"
           BUILDEVENT_APIKEY: ${{ secrets.HONEYCOMB_TOKEN }}
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
@@ -96,7 +96,7 @@ jobs:
         with:
           BAZEL_COMMAND: "test"
           BAZEL_TARGETS: "//rs/tests/..."
-          BAZEL_CI_CONFIG: "--config=ci --repository_cache=/cache/bazel"
+          BAZEL_CI_CONFIG: "--config=ci"
           BAZEL_EXTRA_ARGS: "--keep_going --test_tag_filters=system_test_staging"
           BUILDEVENT_APIKEY: ${{ secrets.HONEYCOMB_TOKEN }}
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
@@ -115,7 +115,7 @@ jobs:
         with:
           BAZEL_COMMAND: "test"
           BAZEL_TARGETS: "//rs/tests/..."
-          BAZEL_CI_CONFIG: "--config=ci --repository_cache=/cache/bazel"
+          BAZEL_CI_CONFIG: "--config=ci"
           BAZEL_EXTRA_ARGS: "--keep_going --test_tag_filters=system_test_hotfix"
           BUILDEVENT_APIKEY: ${{ secrets.HONEYCOMB_TOKEN }}
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
@@ -189,7 +189,7 @@ jobs:
         with:
           BAZEL_COMMAND: "test"
           BAZEL_TARGETS: "//rs/tests/dre:guest_os_qualification"
-          BAZEL_CI_CONFIG: "--config=systest --repository_cache=/cache/bazel"
+          BAZEL_CI_CONFIG: "--config=systest"
           BAZEL_EXTRA_ARGS: "--keep_going --test_timeout=7200 --test_env=OLD_VERSION=${{ matrix.version }}"
           BUILDEVENT_APIKEY: ${{ secrets.HONEYCOMB_TOKEN }}
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}

--- a/.github/workflows-source/schedule-daily.yml
+++ b/.github/workflows-source/schedule-daily.yml
@@ -97,7 +97,7 @@ jobs:
           bazel clean
         env:
           BAZEL_STARTUP_ARGS: "--output_base=/var/tmp/bazel-output/"
-          BAZEL_CI_CONFIG: "--config=ci --repository_cache=/cache/bazel"
+          BAZEL_CI_CONFIG: "--config=ci"
           ZH2_DLL01_CSV_SECRETS: "${{ secrets.ZH2_DLL01_CSV_SECRETS }}"
           ZH2_FILE_SHARE_KEY: "${{ secrets.ZH2_FILE_SHARE_KEY }}"
 
@@ -114,7 +114,7 @@ jobs:
         with:
           BAZEL_COMMAND: "test"
           BAZEL_TARGETS: "//rs/ledger_suite/..."
-          BAZEL_CI_CONFIG: "--config=ci --repository_cache=/cache/bazel"
+          BAZEL_CI_CONFIG: "--config=ci"
           BAZEL_EXTRA_ARGS: "--keep_going --test_tag_filters=fi_tests_nightly --test_env=SSH_AUTH_SOCK --test_timeout=43200"
           BUILDEVENT_APIKEY: ${{ secrets.HONEYCOMB_TOKEN }}
           SSH_PRIVATE_KEY_BACKUP_POD: ${{ secrets.SSH_PRIVATE_KEY_BACKUP_POD }}
@@ -134,7 +134,7 @@ jobs:
         with:
           BAZEL_COMMAND: "test"
           BAZEL_TARGETS: "//rs/nns/..."
-          BAZEL_CI_CONFIG: "--config=ci --repository_cache=/cache/bazel"
+          BAZEL_CI_CONFIG: "--config=ci"
           BAZEL_EXTRA_ARGS: "--keep_going --test_tag_filters=nns_tests_nightly --test_env=SSH_AUTH_SOCK --test_env=NNS_CANISTER_UPGRADE_SEQUENCE=all"
           BUILDEVENT_APIKEY: ${{ secrets.HONEYCOMB_TOKEN }}
           SSH_PRIVATE_KEY_BACKUP_POD: ${{ secrets.SSH_PRIVATE_KEY_BACKUP_POD }}
@@ -159,7 +159,7 @@ jobs:
         with:
           BAZEL_COMMAND: "test"
           BAZEL_TARGETS: ${{ env.BENCHMARK_TARGETS }}
-          BAZEL_CI_CONFIG: "--config=ci --repository_cache=/cache/bazel"
+          BAZEL_CI_CONFIG: "--config=ci"
           # note: there's just one performance cluster, so the job can't be parallelized
           BAZEL_EXTRA_ARGS: "--test_tag_filters=system_test_benchmark --//bazel:enable_upload_perf_systest_results=True --keep_going --jobs 1"
           BUILDEVENT_APIKEY: ${{ secrets.HONEYCOMB_TOKEN }}

--- a/.github/workflows-source/schedule-hourly.yml
+++ b/.github/workflows-source/schedule-hourly.yml
@@ -83,7 +83,7 @@ jobs:
         with:
           BAZEL_COMMAND: "test"
           BAZEL_TARGETS: "//rs/..."
-          BAZEL_CI_CONFIG: "--config=ci --repository_cache=/cache/bazel"
+          BAZEL_CI_CONFIG: "--config=ci"
           BAZEL_EXTRA_ARGS: "--keep_going --test_tag_filters=system_test_hourly"
           BUILDEVENT_APIKEY: ${{ secrets.HONEYCOMB_TOKEN }}
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -186,7 +186,7 @@ jobs:
         with:
           BAZEL_COMMAND: "build"
           BAZEL_TARGETS: "//rs/..."
-          BAZEL_EXTRA_ARGS: "--keep_going --config=fuzzing --build_tag_filters=libfuzzer --repository_cache="
+          BAZEL_EXTRA_ARGS: "--keep_going --config=fuzzing --build_tag_filters=libfuzzer"
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
       - name: Upload bazel-bep
         # runs only if previous step succeeded or failed;
@@ -221,7 +221,7 @@ jobs:
         with:
           BAZEL_COMMAND: "build"
           BAZEL_TARGETS: "//rs/..."
-          BAZEL_EXTRA_ARGS: "--keep_going --config=afl --repository_cache="
+          BAZEL_EXTRA_ARGS: "--keep_going --config=afl"
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
       - name: Upload bazel-bep
         # runs only if previous step succeeded or failed;

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -96,7 +96,7 @@ jobs:
         with:
           BAZEL_COMMAND: "test"
           BAZEL_TARGETS: "//..."
-          BAZEL_CI_CONFIG: "--config=ci --repository_cache=/cache/bazel"
+          BAZEL_CI_CONFIG: "--config=ci"
           # check if PR title contains release and set timeout filters accordingly
           BAZEL_EXTRA_ARGS: ${{ env.BAZEL_EXTRA_ARGS }}
           BUILDEVENT_APIKEY: ${{ secrets.HONEYCOMB_TOKEN }}
@@ -186,7 +186,7 @@ jobs:
         with:
           BAZEL_COMMAND: "build"
           BAZEL_TARGETS: "//rs/..."
-          BAZEL_EXTRA_ARGS: "--keep_going --config=fuzzing --build_tag_filters=libfuzzer"
+          BAZEL_EXTRA_ARGS: "--keep_going --config=fuzzing --build_tag_filters=libfuzzer --repository_cache="
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
       - name: Upload bazel-bep
         # runs only if previous step succeeded or failed;
@@ -221,7 +221,7 @@ jobs:
         with:
           BAZEL_COMMAND: "build"
           BAZEL_TARGETS: "//rs/..."
-          BAZEL_EXTRA_ARGS: "--keep_going --config=afl"
+          BAZEL_EXTRA_ARGS: "--keep_going --config=afl --repository_cache="
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
       - name: Upload bazel-bep
         # runs only if previous step succeeded or failed;

--- a/.github/workflows/release-testing.yml
+++ b/.github/workflows/release-testing.yml
@@ -47,7 +47,7 @@ jobs:
         with:
           BAZEL_COMMAND: "test"
           BAZEL_TARGETS: "//rs/tests/..."
-          BAZEL_CI_CONFIG: "--config=ci --repository_cache=/cache/bazel"
+          BAZEL_CI_CONFIG: "--config=ci"
           BAZEL_EXTRA_ARGS: "--keep_going --test_tag_filters=system_test_nightly"
           BUILDEVENT_APIKEY: ${{ secrets.HONEYCOMB_TOKEN }}
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
@@ -90,7 +90,7 @@ jobs:
         with:
           BAZEL_COMMAND: "test"
           BAZEL_TARGETS: "//rs/tests/..."
-          BAZEL_CI_CONFIG: "--config=ci --repository_cache=/cache/bazel"
+          BAZEL_CI_CONFIG: "--config=ci"
           BAZEL_EXTRA_ARGS: "--keep_going --test_tag_filters=system_test_staging"
           BUILDEVENT_APIKEY: ${{ secrets.HONEYCOMB_TOKEN }}
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
@@ -133,7 +133,7 @@ jobs:
         with:
           BAZEL_COMMAND: "test"
           BAZEL_TARGETS: "//rs/tests/..."
-          BAZEL_CI_CONFIG: "--config=ci --repository_cache=/cache/bazel"
+          BAZEL_CI_CONFIG: "--config=ci"
           BAZEL_EXTRA_ARGS: "--keep_going --test_tag_filters=system_test_hotfix"
           BUILDEVENT_APIKEY: ${{ secrets.HONEYCOMB_TOKEN }}
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
@@ -250,7 +250,7 @@ jobs:
         with:
           BAZEL_COMMAND: "test"
           BAZEL_TARGETS: "//rs/tests/dre:guest_os_qualification"
-          BAZEL_CI_CONFIG: "--config=systest --repository_cache=/cache/bazel"
+          BAZEL_CI_CONFIG: "--config=systest"
           BAZEL_EXTRA_ARGS: "--keep_going --test_timeout=7200 --test_env=OLD_VERSION=${{ matrix.version }}"
           BUILDEVENT_APIKEY: ${{ secrets.HONEYCOMB_TOKEN }}
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}

--- a/.github/workflows/schedule-daily.yml
+++ b/.github/workflows/schedule-daily.yml
@@ -63,7 +63,7 @@ jobs:
           bazel clean
         env:
           BAZEL_STARTUP_ARGS: "--output_base=/var/tmp/bazel-output/"
-          BAZEL_CI_CONFIG: "--config=ci --repository_cache=/cache/bazel"
+          BAZEL_CI_CONFIG: "--config=ci"
           ZH2_DLL01_CSV_SECRETS: "${{ secrets.ZH2_DLL01_CSV_SECRETS }}"
           ZH2_FILE_SHARE_KEY: "${{ secrets.ZH2_FILE_SHARE_KEY }}"
   fi-tests-nightly:
@@ -90,7 +90,7 @@ jobs:
         with:
           BAZEL_COMMAND: "test"
           BAZEL_TARGETS: "//rs/ledger_suite/..."
-          BAZEL_CI_CONFIG: "--config=ci --repository_cache=/cache/bazel"
+          BAZEL_CI_CONFIG: "--config=ci"
           BAZEL_EXTRA_ARGS: "--keep_going --test_tag_filters=fi_tests_nightly --test_env=SSH_AUTH_SOCK --test_timeout=43200"
           BUILDEVENT_APIKEY: ${{ secrets.HONEYCOMB_TOKEN }}
           SSH_PRIVATE_KEY_BACKUP_POD: ${{ secrets.SSH_PRIVATE_KEY_BACKUP_POD }}
@@ -132,7 +132,7 @@ jobs:
         with:
           BAZEL_COMMAND: "test"
           BAZEL_TARGETS: "//rs/nns/..."
-          BAZEL_CI_CONFIG: "--config=ci --repository_cache=/cache/bazel"
+          BAZEL_CI_CONFIG: "--config=ci"
           BAZEL_EXTRA_ARGS: "--keep_going --test_tag_filters=nns_tests_nightly --test_env=SSH_AUTH_SOCK --test_env=NNS_CANISTER_UPGRADE_SEQUENCE=all"
           BUILDEVENT_APIKEY: ${{ secrets.HONEYCOMB_TOKEN }}
           SSH_PRIVATE_KEY_BACKUP_POD: ${{ secrets.SSH_PRIVATE_KEY_BACKUP_POD }}
@@ -179,7 +179,7 @@ jobs:
         with:
           BAZEL_COMMAND: "test"
           BAZEL_TARGETS: ${{ env.BENCHMARK_TARGETS }}
-          BAZEL_CI_CONFIG: "--config=ci --repository_cache=/cache/bazel"
+          BAZEL_CI_CONFIG: "--config=ci"
           # note: there's just one performance cluster, so the job can't be parallelized
           BAZEL_EXTRA_ARGS: "--test_tag_filters=system_test_benchmark --//bazel:enable_upload_perf_systest_results=True --keep_going --jobs 1"
           BUILDEVENT_APIKEY: ${{ secrets.HONEYCOMB_TOKEN }}

--- a/.github/workflows/schedule-hourly.yml
+++ b/.github/workflows/schedule-hourly.yml
@@ -74,7 +74,7 @@ jobs:
         with:
           BAZEL_COMMAND: "test"
           BAZEL_TARGETS: "//rs/..."
-          BAZEL_CI_CONFIG: "--config=ci --repository_cache=/cache/bazel"
+          BAZEL_CI_CONFIG: "--config=ci"
           BAZEL_EXTRA_ARGS: "--keep_going --test_tag_filters=system_test_hourly"
           BUILDEVENT_APIKEY: ${{ secrets.HONEYCOMB_TOKEN }}
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}

--- a/.github/workflows/schedule-rust-bench.yml
+++ b/.github/workflows/schedule-rust-bench.yml
@@ -44,7 +44,7 @@ jobs:
         run: |
           ./ci/scripts/rust-benchmarks.sh
         env:
-          BAZEL_CI_CONFIG: "--config=ci --repository_cache=/cache/bazel"
+          BAZEL_CI_CONFIG: "--config=ci"
           BAZEL_COMMAND: "run"
           BAZEL_STARTUP_ARGS: "--output_base=/var/tmp/bazel-output/"
           CI_JOB_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/ci/bazel-scripts/main.sh
+++ b/ci/bazel-scripts/main.sh
@@ -88,21 +88,30 @@ stream_awk_program='
   # Finally, record the URL
   END { if (stream_url != null) print stream_url > url_out }'
 
+bazel_args=(
+    ${BAZEL_STARTUP_ARGS}
+    ${BAZEL_COMMAND}
+    --color=yes
+    ${BAZEL_CI_CONFIG}
+    --build_metadata=BUILDBUDDY_LINKS="[CI Job](${CI_JOB_URL})"
+    --ic_version="${CI_COMMIT_SHA}"
+    --ic_version_rc_only="${ic_version_rc_only}"
+    --release_build="${release_build}"
+    --s3_upload="${s3_upload:-"False"}"
+    ${BAZEL_EXTRA_ARGS:-}
+    ${BAZEL_TARGETS}
+)
+
+# Unless explicitly provided, we set a default --repository_cache to a volume mounted
+# inside our runners
+if [[ ! " ${bazel_args[*]} " =~ [[:space:]]--repository_cache[[:space:]] ]]; then
+    echo "setting default repository cache"
+    bazel_args+=(--repository_cache=/cache/bazel)
+fi
+
 # shellcheck disable=SC2086
 # ${BAZEL_...} variables are expected to contain several arguments. We have `set -f` set above to disable globbing (and therefore only allow splitting)"
-bazel \
-    ${BAZEL_STARTUP_ARGS} \
-    ${BAZEL_COMMAND} \
-    --color=yes \
-    ${BAZEL_CI_CONFIG} \
-    --build_metadata=BUILDBUDDY_LINKS="[CI Job](${CI_JOB_URL})" \
-    --ic_version="${CI_COMMIT_SHA}" \
-    --ic_version_rc_only="${ic_version_rc_only}" \
-    --release_build="${release_build}" \
-    --s3_upload="${s3_upload:-"False"}" \
-    ${BAZEL_EXTRA_ARGS:-} \
-    ${BAZEL_TARGETS} \
-    2>&1 | awk -v url_out="$url_out" "$stream_awk_program"
+bazel "${bazel_args[@]}" 2>&1 | awk -v url_out="$url_out" "$stream_awk_program"
 
 # Write the bes link & summary
 echo "Build results uploaded to $(<"$url_out")"


### PR DESCRIPTION
This specifies a default `--repository_cache` so that it doesn't have to be set for each job