### PR TITLE
chore: remove obsolete allowed_viewers_feature flag

### DIFF
--- a/rs/config/src/execution_environment.rs
+++ b/rs/config/src/execution_environment.rs
@@ -317,10 +317,6 @@ pub struct Config {
     ///   - let `halfway_to_max = (memory_usage + 4GiB) / 2`
     ///   - use the maximum of `default_wasm_memory_limit` and `halfway_to_max`.
     pub default_wasm_memory_limit: NumBytes,
-
-    // TODO(EXC-1678): remove after release.
-    /// Feature flag to enable/disable allowed viewers for canister log visibility.
-    pub allowed_viewers_feature: FlagStatus,
 }
 
 impl Default for Config {
@@ -398,7 +394,6 @@ impl Default for Config {
             dirty_page_logging: FlagStatus::Disabled,
             max_canister_http_requests_in_flight: MAX_CANISTER_HTTP_REQUESTS_IN_FLIGHT,
             default_wasm_memory_limit: DEFAULT_WASM_MEMORY_LIMIT,
-            allowed_viewers_feature: FlagStatus::Enabled,
         }
     }
 }

--- a/rs/execution_environment/src/query_handler.rs
+++ b/rs/execution_environment/src/query_handler.rs
@@ -210,7 +210,6 @@ impl InternalHttpQueryHandler {
                         query.source(),
                         state.get_ref(),
                         FetchCanisterLogsRequest::decode(&query.method_payload)?,
-                        self.config.allowed_viewers_feature,
                     );
                     self.metrics.observe_subnet_query_message(
                         QueryMethod::FetchCanisterLogs,
@@ -308,7 +307,6 @@ fn fetch_canister_logs(
     sender: PrincipalId,
     state: &ReplicatedState,
     args: FetchCanisterLogsRequest,
-    allowed_viewers_feature: FlagStatus,
 ) -> Result<WasmResult, UserError> {
     let canister_id = args.get_canister_id();
     let canister = state.canister_state(&canister_id).ok_or_else(|| {

--- a/rs/starter/src/lib.rs
+++ b/rs/starter/src/lib.rs
@@ -24,7 +24,6 @@ pub fn hypervisor_config(canister_sandboxing: bool) -> HypervisorConfig {
         rate_limiting_of_heap_delta: FlagStatus::Disabled,
         rate_limiting_of_instructions: FlagStatus::Disabled,
         query_stats_epoch_length: 60,
-        allowed_viewers_feature: FlagStatus::Enabled,
         ..HypervisorConfig::default()
     }
 }


### PR DESCRIPTION
This PR removes an obsolete `allowed_viewers_feature` flag since it was enabled in prod a while ago.