### PR TITLE
chore(IDX): remove BAZEL_STARTUP_ARGS

### DIFF
--- a/.github/actions/bazel-test-all/action.yaml
+++ b/.github/actions/bazel-test-all/action.yaml
@@ -13,9 +13,6 @@ inputs:
   BAZEL_EXTRA_ARGS:
     required: false
     default: ''
-  BAZEL_STARTUP_ARGS:
-    required: false
-    default: '--output_base=/var/tmp/bazel-output/'
   BUILDEVENT_APIKEY:
     required: false
   SSH_PRIVATE_KEY_BACKUP_POD:
@@ -72,7 +69,6 @@ runs:
           BAZEL_TARGETS: ${{ inputs.BAZEL_TARGETS }}
           BAZEL_CI_CONFIG: ${{ inputs.BAZEL_CI_CONFIG }}
           BAZEL_EXTRA_ARGS: ${{ inputs.BAZEL_EXTRA_ARGS }}
-          BAZEL_STARTUP_ARGS: ${{ inputs.BAZEL_STARTUP_ARGS }}
           BRANCH_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           BUILDEVENT_APIKEY: ${{ inputs.BUILDEVENT_APIKEY }}
           CI_EVENT_NAME: ${{ github.event_name }}

--- a/.github/workflows-source/ci-main.yml
+++ b/.github/workflows-source/ci-main.yml
@@ -174,7 +174,6 @@ jobs:
           BAZEL_CI_CONFIG: "--config=ci --config macos_ci"
           BAZEL_COMMAND: test
           BAZEL_EXTRA_ARGS: '--test_tag_filters=test_macos'
-          BAZEL_STARTUP_ARGS: "--output_base /var/tmp/bazel-output/"
           BAZEL_TARGETS: "//rs/... //publish/binaries/..."
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
       - <<: *bazel-bep

--- a/.github/workflows-source/schedule-daily.yml
+++ b/.github/workflows-source/schedule-daily.yml
@@ -6,7 +6,6 @@ on:
   workflow_dispatch:
 
 env:
-  BAZEL_STARTUP_ARGS: "--output_base=/var/tmp/bazel-output/"
   BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
   CI_COMMIT_SHA: ${{ github.sha }}
   CI_JOB_NAME: ${{ github.job }}
@@ -73,7 +72,7 @@ jobs:
 
           # Run bare metal installation test
           # shellcheck disable=SC2046,SC2086
-          bazel ${BAZEL_STARTUP_ARGS} run ${BAZEL_CI_CONFIG} \
+          bazel --output_base=/var/tmp/bazel-output run ${BAZEL_CI_CONFIG} \
             //ic-os/setupos/envs/dev:launch_bare_metal -- \
               --config_path "$(realpath  ./ic-os/dev-tools/bare_metal_deployment/zh2-dll01.yaml)" \
               --csv_filename "$(realpath file1)" \
@@ -85,7 +84,7 @@ jobs:
 
           # Run bare metal node performance benchmarks
           # shellcheck disable=SC2046,SC2086
-          bazel ${BAZEL_STARTUP_ARGS} run ${BAZEL_CI_CONFIG} \
+          bazel --output_base=/var/tmp/bazel-output run ${BAZEL_CI_CONFIG} \
             //ic-os/setupos/envs/dev:launch_bare_metal -- \
               --config_path "$(realpath  ./ic-os/dev-tools/bare_metal_deployment/zh2-dll01.yaml)" \
               --csv_filename "$(realpath file1)" \
@@ -96,7 +95,6 @@ jobs:
               --benchmark
           bazel clean
         env:
-          BAZEL_STARTUP_ARGS: "--output_base=/var/tmp/bazel-output/"
           BAZEL_CI_CONFIG: "--config=ci"
           ZH2_DLL01_CSV_SECRETS: "${{ secrets.ZH2_DLL01_CSV_SECRETS }}"
           ZH2_FILE_SHARE_KEY: "${{ secrets.ZH2_FILE_SHARE_KEY }}"

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -144,7 +144,6 @@ jobs:
           BAZEL_CI_CONFIG: "--config=ci --config macos_ci"
           BAZEL_COMMAND: test
           BAZEL_EXTRA_ARGS: '--test_tag_filters=test_macos'
-          BAZEL_STARTUP_ARGS: "--output_base /var/tmp/bazel-output/"
           BAZEL_TARGETS: "//rs/... //publish/binaries/..."
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
       - name: Upload bazel-bep

--- a/.github/workflows/schedule-daily.yml
+++ b/.github/workflows/schedule-daily.yml
@@ -4,7 +4,6 @@ on:
     - cron: "0 1 * * *"
   workflow_dispatch:
 env:
-  BAZEL_STARTUP_ARGS: "--output_base=/var/tmp/bazel-output/"
   BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
   CI_COMMIT_SHA: ${{ github.sha }}
   CI_JOB_NAME: ${{ github.job }}
@@ -39,7 +38,7 @@ jobs:
 
           # Run bare metal installation test
           # shellcheck disable=SC2046,SC2086
-          bazel ${BAZEL_STARTUP_ARGS} run ${BAZEL_CI_CONFIG} \
+          bazel --output_base=/var/tmp/bazel-output run ${BAZEL_CI_CONFIG} \
             //ic-os/setupos/envs/dev:launch_bare_metal -- \
               --config_path "$(realpath  ./ic-os/dev-tools/bare_metal_deployment/zh2-dll01.yaml)" \
               --csv_filename "$(realpath file1)" \
@@ -51,7 +50,7 @@ jobs:
 
           # Run bare metal node performance benchmarks
           # shellcheck disable=SC2046,SC2086
-          bazel ${BAZEL_STARTUP_ARGS} run ${BAZEL_CI_CONFIG} \
+          bazel --output_base=/var/tmp/bazel-output run ${BAZEL_CI_CONFIG} \
             //ic-os/setupos/envs/dev:launch_bare_metal -- \
               --config_path "$(realpath  ./ic-os/dev-tools/bare_metal_deployment/zh2-dll01.yaml)" \
               --csv_filename "$(realpath file1)" \
@@ -62,7 +61,6 @@ jobs:
               --benchmark
           bazel clean
         env:
-          BAZEL_STARTUP_ARGS: "--output_base=/var/tmp/bazel-output/"
           BAZEL_CI_CONFIG: "--config=ci"
           ZH2_DLL01_CSV_SECRETS: "${{ secrets.ZH2_DLL01_CSV_SECRETS }}"
           ZH2_FILE_SHARE_KEY: "${{ secrets.ZH2_FILE_SHARE_KEY }}"

--- a/.github/workflows/schedule-rust-bench.yml
+++ b/.github/workflows/schedule-rust-bench.yml
@@ -46,7 +46,6 @@ jobs:
         env:
           BAZEL_CI_CONFIG: "--config=ci"
           BAZEL_COMMAND: "run"
-          BAZEL_STARTUP_ARGS: "--output_base=/var/tmp/bazel-output/"
           CI_JOB_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           RUST_BACKTRACE: "full"
           TARGETS: ${{ matrix.targets }}

--- a/ci/bazel-scripts/main.sh
+++ b/ci/bazel-scripts/main.sh
@@ -89,7 +89,7 @@ stream_awk_program='
   END { if (stream_url != null) print stream_url > url_out }'
 
 bazel_args=(
-    ${BAZEL_STARTUP_ARGS}
+    --output_base=/var/tmp/bazel-output # Output base wiped after run
     ${BAZEL_COMMAND}
     --color=yes
     ${BAZEL_CI_CONFIG}


### PR DESCRIPTION
This simplifies the bazel action by removing the startup args -- instead, `--output_base` is always set to a path that makes sense for our runners.