### PR TITLE
fix(nns): Reverse neuron migration

### DIFF
--- a/rs/nns/governance/canbench/canbench_results.yml
+++ b/rs/nns/governance/canbench/canbench_results.yml
@@ -1,25 +1,25 @@
 benches:
   add_neuron_active_maximum:
     total:
-      instructions: 114744092
-      heap_increase: 0
+      instructions: 42752810
+      heap_increase: 1
       stable_memory_increase: 0
     scopes: {}
   add_neuron_active_typical:
     total:
-      instructions: 8660928
+      instructions: 2170672
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   add_neuron_inactive_maximum:
     total:
-      instructions: 114744206
-      heap_increase: 0
+      instructions: 112624946
+      heap_increase: 1
       stable_memory_increase: 0
     scopes: {}
   add_neuron_inactive_typical:
     total:
-      instructions: 8661042
+      instructions: 8497607
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
@@ -163,7 +163,7 @@ benches:
     scopes: {}
   range_neurons_performance:
     total:
-      instructions: 84752408
+      instructions: 56514456
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
@@ -179,4 +179,4 @@ benches:
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
-version: 0.1.9
+version: 0.1.8

--- a/rs/nns/governance/src/governance.rs
+++ b/rs/nns/governance/src/governance.rs
@@ -6851,6 +6851,15 @@ impl Governance {
 
     /// Return `true` if rewards should be distributed, `false` otherwise
     fn should_distribute_rewards(&self) -> bool {
+        // This is to mitigate the issue caused by neuron migration. While this early return is in
+        // place, the rewards distribution will pause, which allows the reverse neuron migration to
+        // complete. Before the reverse migration runs, those 2 values are 377K/0. After the reverse
+        // migration is complete, the `stable_neuron_store_len` should be about 284K/92K.
+        if self.neuron_store.stable_neuron_store_len() > 274_000
+            && self.neuron_store.heap_neuron_store_len() < 82_000
+        {
+            return false;
+        }
         let latest_distribution_nominal_end_timestamp_seconds =
             self.latest_reward_event().day_after_genesis * REWARD_DISTRIBUTION_PERIOD_SECONDS
                 + self.heap_data.genesis_timestamp_seconds;

--- a/rs/nns/governance/src/lib.rs
+++ b/rs/nns/governance/src/lib.rs
@@ -204,7 +204,7 @@ thread_local! {
 
     static USE_STABLE_MEMORY_FOLLOWING_INDEX: Cell<bool> = const { Cell::new(true) };
 
-    static MIGRATE_ACTIVE_NEURONS_TO_STABLE_MEMORY: Cell<bool> = const { Cell::new(true) };
+    static MIGRATE_ACTIVE_NEURONS_TO_STABLE_MEMORY: Cell<bool> = const { Cell::new(cfg!(feature = "test")) };
 }
 
 thread_local! {

--- a/rs/nns/governance/unreleased_changelog.md
+++ b/rs/nns/governance/unreleased_changelog.md
@@ -20,13 +20,6 @@ neurons are found between this field and others, they will be deduplicated befor
 
 This new field works in the same way that the existing `neuron_ids` field works.
 
-### Migrating Active Neurons to Stable Memory
-
-In this release, we turn on the feature to migrate active neurons to stable memory:
-`migrate_active_neurons_to_stable_memory`. After the feature is turned on, a timer task will
-gradually move active neurons from the heap to stable memory. Clients should not expect any
-functional behavior changes, since no APIs rely on where the neurons are stored.
-
 ## Changed
 
 * The limit of the number of neurons is increased from 380K to 400K.

--- a/rs/nns/integration_tests/src/governance_migrations.rs
+++ b/rs/nns/integration_tests/src/governance_migrations.rs
@@ -48,7 +48,6 @@ fn assert_metric(state_machine: &StateMachine, name: &str, value: u64) {
     );
 }
 
-// TODO(NNS1-3332): delete this test since the stable memory will be the only storage for neurons.
 #[test]
 fn test_neuron_migration_from_heap_to_stable() {
     let state_machine = state_machine_builder_for_nns_tests().build();
@@ -82,8 +81,8 @@ fn test_neuron_migration_from_heap_to_stable() {
         "governance_garbage_collectable_neurons_count",
         0,
     );
-    assert_metric(&state_machine, "governance_heap_neuron_count", 0);
-    assert_metric(&state_machine, "governance_stable_memory_neuron_count", 1);
+    assert_metric(&state_machine, "governance_heap_neuron_count", 1);
+    assert_metric(&state_machine, "governance_stable_memory_neuron_count", 0);
 
     // Advance time and disburse the neuron so that it's empty.
     nns_start_dissolving(&state_machine, test_user_principal, neuron_id).unwrap();


### PR DESCRIPTION
This hotfix reverses the neuron migration to fix a production incident with voting rewards. A proper fix will be developed and released in the coming days.

This reverts commit https://github.com/dfinity/ic/commit/a3ef9a55e492121eb64216bec0a252e27de760c1.
