### PR TITLE
chore(node): remove command from error_msg

### DIFF
--- a/ic-os/dev-tools/bare_metal_deployment/deploy.py
+++ b/ic-os/dev-tools/bare_metal_deployment/deploy.py
@@ -308,7 +308,7 @@ class DeploymentError(Exception):
 
 
 def gen_failure(result: invoke.Result, bmc_info: BMCInfo) -> DeploymentError:
-    error_msg = f"Failed on {result.command}: {result.stderr}"
+    error_msg = f"Failure: {result.stderr}"
     return DeploymentError(OperationResult(bmc_info, success=False, error_msg=error_msg))
 
 


### PR DESCRIPTION
Remove command log from bare metal installation error log to prevent BMC IP and password from printing.

![Pasted Graphic 2](https://github.com/user-attachments/assets/448e1b36-fd19-4192-9755-5da4b35297f8)
