### PR TITLE
fix(registry): Update the correct node operator ID in node removal

### DIFF
--- a/rs/registry/canister/CHANGELOG.md
+++ b/rs/registry/canister/CHANGELOG.md
@@ -10,6 +10,23 @@ here were moved from the adjacent `unreleased_changelog.md` file.
 
 INSERT NEW RELEASES HERE
 
+## Changed
+
+## Deprecated
+
+## Fixed
+
+### Update the correct node operator ID in do_remove_node_directly
+
+Fix for the do_remove_node_directly function to update the correct node operator ID record.
+In the past the caller_id and the node_operator_id for the node were always the same.
+However, since #3285 the caller_id and the node_operator_id for the removed node may differ,
+and this introduces a bug in this edge case.
+
+The bug resulted in a node reward discrepancy for a few operator records, identified in the
+regular administrative checks before the reward distribution and [described in the forum](https://forum.dfinity.org/t/issue-with-node-provider-rewards/41109/2) and
+mitigated with a few NNS proposals referenced in the forum thread.
+
 
 # 2025-02-07: Proposal 135207
 

--- a/rs/registry/canister/src/common/test_helpers.rs
+++ b/rs/registry/canister/src/common/test_helpers.rs
@@ -22,6 +22,7 @@ use ic_registry_transport::pb::v1::{
 use ic_registry_transport::{insert, upsert};
 use ic_test_utilities_types::ids::subnet_test_id;
 use ic_types::ReplicaVersion;
+use maplit::btreemap;
 use prost::Message;
 use std::collections::BTreeMap;
 
@@ -196,6 +197,7 @@ pub fn registry_add_node_operator_for_node(
     {
         let node_operator_record = NodeOperatorRecord {
             node_allowance,
+            rewardable_nodes: btreemap! { "type0".to_string() => 0, "type1".to_string() => 28 },
             ..Default::default()
         };
 


### PR DESCRIPTION
### Summary

This update refines the logic within the `do_remove_node_directly` function to update the correct node operator ID record.

In the past the `caller_id` and the `node_operator_id` for the node were always the same. However, since #3285 the `caller_id` and the `node_operator_id` for the removed node may differ, and this introduces a bug in this edge case.

The wrong node operator record was retrieved (of the caller), but then written into the correct record id (of the removed node's node operator), resulting in lost data when using this new capability.

The bug resulted in a node reward discrepancy for a few operator records, identified in regular administrative checks and described [in the forum](https://forum.dfinity.org/t/issue-with-node-provider-rewards/41109/3) and mitigated with a few NNS proposals mentioned in the forum thread.

### Changelog

- **Functionality**
  - Use the correct `node_operator_id` when incrementing node allowance in `do_remove_node_directly.rs`.

- **Tests** adjustments