### PR TITLE
docs(nns): Re-add changed header to root unreleased_changelog

### DIFF
--- a/rs/nns/handlers/root/unreleased_changelog.md
+++ b/rs/nns/handlers/root/unreleased_changelog.md
@@ -11,6 +11,8 @@ on the process that this file is part of, see
 
 ## Changed
 
+## Changed
+
 ## Deprecated
 
 ## Removed


### PR DESCRIPTION
This was accidentally removed in #3866