### PR TITLE
chore(EXC-1929): Upgrade Wasm crates to wasmtime 29

### DIFF
--- a/Cargo.Bazel.Fuzzing.json.lock
+++ b/Cargo.Bazel.Fuzzing.json.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "9fe333f7bcb42c8778624ad255e6695f1e1ff372cd8dd2da53437a949d1cc3e8",
+  "checksum": "80697a7cc96d758389e1532236c8ade58c159d5521e50cb689d181f3984a9d84",
   "crates": {
     "abnf 0.12.0": {
       "name": "abnf",
@@ -20754,19 +20754,19 @@
               "target": "wasm_bindgen"
             },
             {
-              "id": "wasm-encoder 0.217.0",
+              "id": "wasm-encoder 0.221.2",
               "target": "wasm_encoder"
             },
             {
-              "id": "wasm-smith 0.212.0",
+              "id": "wasm-smith 0.221.2",
               "target": "wasm_smith"
             },
             {
-              "id": "wasmparser 0.217.0",
+              "id": "wasmparser 0.221.2",
               "target": "wasmparser"
             },
             {
-              "id": "wasmprinter 0.217.0",
+              "id": "wasmprinter 0.221.2",
               "target": "wasmprinter"
             },
             {
@@ -20778,11 +20778,11 @@
               "target": "wasmtime_environ"
             },
             {
-              "id": "wast 212.0.0",
+              "id": "wast 221.0.2",
               "target": "wast"
             },
             {
-              "id": "wat 1.212.0",
+              "id": "wat 1.221.2",
               "target": "wat"
             },
             {
@@ -28371,7 +28371,8 @@
         ],
         "crate_features": {
           "common": [
-            "default-hasher"
+            "default-hasher",
+            "serde"
           ],
           "selects": {}
         },
@@ -28380,6 +28381,10 @@
             {
               "id": "foldhash 0.1.4",
               "target": "foldhash"
+            },
+            {
+              "id": "serde 1.0.217",
+              "target": "serde"
             }
           ],
           "selects": {}
@@ -81198,6 +81203,52 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
+    "unicode-width 0.2.0": {
+      "name": "unicode-width",
+      "version": "0.2.0",
+      "package_url": "https://github.com/unicode-rs/unicode-width",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/unicode-width/0.2.0/download",
+          "sha256": "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "unicode_width",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "unicode_width",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": {
+          "common": [
+            "cjk",
+            "default"
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "0.2.0"
+      },
+      "license": "MIT OR Apache-2.0",
+      "license_ids": [
+        "Apache-2.0",
+        "MIT"
+      ],
+      "license_file": "LICENSE-APACHE"
+    },
     "unicode-xid 0.2.4": {
       "name": "unicode-xid",
       "version": "0.2.4",
@@ -83140,21 +83191,11 @@
         "compile_data_glob": [
           "**"
         ],
-        "crate_features": {
-          "common": [
-            "wasmparser"
-          ],
-          "selects": {}
-        },
         "deps": {
           "common": [
             {
               "id": "leb128 0.2.5",
               "target": "leb128"
-            },
-            {
-              "id": "wasmparser 0.212.0",
-              "target": "wasmparser"
             }
           ],
           "selects": {}
@@ -83167,64 +83208,6 @@
         "Apache-2.0"
       ],
       "license_file": "LICENSE"
-    },
-    "wasm-encoder 0.217.0": {
-      "name": "wasm-encoder",
-      "version": "0.217.0",
-      "package_url": "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasm-encoder",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/wasm-encoder/0.217.0/download",
-          "sha256": "7b88b0814c9a2b323a9b46c687e726996c255ac8b64aa237dd11c81ed4854760"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "wasm_encoder",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "wasm_encoder",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "wasmparser"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "leb128 0.2.5",
-              "target": "leb128"
-            },
-            {
-              "id": "wasmparser 0.217.0",
-              "target": "wasmparser"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "version": "0.217.0"
-      },
-      "license": "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT",
-      "license_ids": [
-        "Apache-2.0",
-        "MIT"
-      ],
-      "license_file": null
     },
     "wasm-encoder 0.221.2": {
       "name": "wasm-encoder",
@@ -83258,7 +83241,8 @@
         "crate_features": {
           "common": [
             "component-model",
-            "default"
+            "default",
+            "wasmparser"
           ],
           "selects": {}
         },
@@ -83267,6 +83251,10 @@
             {
               "id": "leb128 0.2.5",
               "target": "leb128"
+            },
+            {
+              "id": "wasmparser 0.221.2",
+              "target": "wasmparser"
             }
           ],
           "selects": {}
@@ -83281,14 +83269,14 @@
       ],
       "license_file": null
     },
-    "wasm-smith 0.212.0": {
+    "wasm-smith 0.221.2": {
       "name": "wasm-smith",
-      "version": "0.212.0",
+      "version": "0.221.2",
       "package_url": "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasm-smith",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/wasm-smith/0.212.0/download",
-          "sha256": "a8185faf41a5630ec7cf301fa1f63bb757f4c267a057f8b6b56bde0cba1144c1"
+          "url": "https://static.crates.io/crates/wasm-smith/0.221.2/download",
+          "sha256": "ebbaf9c781fb7091b79ad3baa40862b3afccb2949575bb73bdd77643ed40338c"
         }
       },
       "targets": [
@@ -83339,24 +83327,25 @@
               "target": "leb128"
             },
             {
-              "id": "wasm-encoder 0.212.0",
+              "id": "wasm-encoder 0.221.2",
               "target": "wasm_encoder"
             },
             {
-              "id": "wasmparser 0.212.0",
+              "id": "wasmparser 0.221.2",
               "target": "wasmparser"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.212.0"
+        "version": "0.221.2"
       },
-      "license": "Apache-2.0 WITH LLVM-exception",
+      "license": "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT",
       "license_ids": [
-        "Apache-2.0"
+        "Apache-2.0",
+        "MIT"
       ],
-      "license_file": "LICENSE"
+      "license_file": null
     },
     "wasm-streams 0.4.0": {
       "name": "wasm-streams",
@@ -83553,84 +83542,6 @@
       ],
       "license_file": null
     },
-    "wasmparser 0.217.0": {
-      "name": "wasmparser",
-      "version": "0.217.0",
-      "package_url": "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasmparser",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/wasmparser/0.217.0/download",
-          "sha256": "ca917a21307d3adf2b9857b94dd05ebf8496bdcff4437a9b9fb3899d3e6c74e7"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "wasmparser",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "wasmparser",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "default",
-            "features",
-            "serde",
-            "std",
-            "validate"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "ahash 0.8.11",
-              "target": "ahash"
-            },
-            {
-              "id": "bitflags 2.6.0",
-              "target": "bitflags"
-            },
-            {
-              "id": "hashbrown 0.14.5",
-              "target": "hashbrown"
-            },
-            {
-              "id": "indexmap 2.2.6",
-              "target": "indexmap"
-            },
-            {
-              "id": "semver 1.0.22",
-              "target": "semver"
-            },
-            {
-              "id": "serde 1.0.217",
-              "target": "serde"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "version": "0.217.0"
-      },
-      "license": "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT",
-      "license_ids": [
-        "Apache-2.0",
-        "MIT"
-      ],
-      "license_file": null
-    },
     "wasmparser 0.221.2": {
       "name": "wasmparser",
       "version": "0.221.2",
@@ -83675,7 +83586,9 @@
         "crate_features": {
           "common": [
             "component-model",
+            "default",
             "features",
+            "hash-collections",
             "serde",
             "simd",
             "std",
@@ -83688,6 +83601,14 @@
             {
               "id": "bitflags 2.6.0",
               "target": "bitflags"
+            },
+            {
+              "id": "hashbrown 0.15.2",
+              "target": "hashbrown"
+            },
+            {
+              "id": "indexmap 2.2.6",
+              "target": "indexmap"
             },
             {
               "id": "semver 1.0.22",
@@ -83714,62 +83635,6 @@
         "data_glob": [
           "**"
         ]
-      },
-      "license": "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT",
-      "license_ids": [
-        "Apache-2.0",
-        "MIT"
-      ],
-      "license_file": null
-    },
-    "wasmprinter 0.217.0": {
-      "name": "wasmprinter",
-      "version": "0.217.0",
-      "package_url": "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasmprinter",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/wasmprinter/0.217.0/download",
-          "sha256": "50dc568b3e0d47e8f96ea547c90790cfa783f0205160c40de894a427114185ce"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "wasmprinter",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "wasmprinter",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "anyhow 1.0.93",
-              "target": "anyhow"
-            },
-            {
-              "id": "termcolor 1.4.1",
-              "target": "termcolor"
-            },
-            {
-              "id": "wasmparser 0.217.0",
-              "target": "wasmparser"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "version": "0.217.0"
       },
       "license": "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT",
       "license_ids": [
@@ -85171,14 +85036,14 @@
       ],
       "license_file": null
     },
-    "wast 212.0.0": {
+    "wast 221.0.2": {
       "name": "wast",
-      "version": "212.0.0",
+      "version": "221.0.2",
       "package_url": "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wast",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/wast/212.0.0/download",
-          "sha256": "4606a05fb0aae5d11dd7d8280a640d88a63ee019360ba9be552da3d294b8d1f5"
+          "url": "https://static.crates.io/crates/wast/221.0.2/download",
+          "sha256": "fcc4470b9de917ba199157d1f0ae104f2ae362be728c43e68c571c7715bd629e"
         }
       },
       "targets": [
@@ -85202,6 +85067,7 @@
         ],
         "crate_features": {
           "common": [
+            "component-model",
             "default",
             "wasm-module"
           ],
@@ -85222,33 +85088,34 @@
               "target": "memchr"
             },
             {
-              "id": "unicode-width 0.1.11",
+              "id": "unicode-width 0.2.0",
               "target": "unicode_width"
             },
             {
-              "id": "wasm-encoder 0.212.0",
+              "id": "wasm-encoder 0.221.2",
               "target": "wasm_encoder"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "212.0.0"
+        "version": "221.0.2"
       },
-      "license": "Apache-2.0 WITH LLVM-exception",
+      "license": "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT",
       "license_ids": [
-        "Apache-2.0"
+        "Apache-2.0",
+        "MIT"
       ],
-      "license_file": "LICENSE"
+      "license_file": null
     },
-    "wat 1.212.0": {
+    "wat 1.221.2": {
       "name": "wat",
-      "version": "1.212.0",
+      "version": "1.221.2",
       "package_url": "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wat",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/wat/1.212.0/download",
-          "sha256": "c74ca7f93f11a5d6eed8499f2a8daaad6e225cab0151bc25a091fff3b987532f"
+          "url": "https://static.crates.io/crates/wat/1.221.2/download",
+          "sha256": "6b1f3c6d82af47286494c6caea1d332037f5cbeeac82bbf5ef59cb8c201c466e"
         }
       },
       "targets": [
@@ -85270,23 +85137,31 @@
         "compile_data_glob": [
           "**"
         ],
+        "crate_features": {
+          "common": [
+            "component-model",
+            "default"
+          ],
+          "selects": {}
+        },
         "deps": {
           "common": [
             {
-              "id": "wast 212.0.0",
+              "id": "wast 221.0.2",
               "target": "wast"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "1.212.0"
+        "version": "1.221.2"
       },
-      "license": "Apache-2.0 WITH LLVM-exception",
+      "license": "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT",
       "license_ids": [
-        "Apache-2.0"
+        "Apache-2.0",
+        "MIT"
       ],
-      "license_file": "LICENSE"
+      "license_file": null
     },
     "web-sys 0.3.64": {
       "name": "web-sys",
@@ -91690,14 +91565,14 @@
     "walkdir 2.3.3",
     "warp 0.3.7",
     "wasm-bindgen 0.2.95",
-    "wasm-encoder 0.217.0",
-    "wasm-smith 0.212.0",
-    "wasmparser 0.217.0",
-    "wasmprinter 0.217.0",
+    "wasm-encoder 0.221.2",
+    "wasm-smith 0.221.2",
+    "wasmparser 0.221.2",
+    "wasmprinter 0.221.2",
     "wasmtime 29.0.1",
     "wasmtime-environ 29.0.1",
-    "wast 212.0.0",
-    "wat 1.212.0",
+    "wast 221.0.2",
+    "wat 1.221.2",
     "wee_alloc 0.4.5",
     "which 4.4.2",
     "wsl 0.1.0",

--- a/Cargo.Bazel.Fuzzing.toml.lock
+++ b/Cargo.Bazel.Fuzzing.toml.lock
@@ -2228,7 +2228,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
 dependencies = [
  "termcolor",
- "unicode-width",
+ "unicode-width 0.1.11",
 ]
 
 [[package]]
@@ -2315,7 +2315,7 @@ dependencies = [
  "regex",
  "terminal_size",
  "termios",
- "unicode-width",
+ "unicode-width 0.1.11",
  "winapi 0.3.9",
  "winapi-util",
 ]
@@ -2329,7 +2329,7 @@ dependencies = [
  "encode_unicode",
  "lazy_static",
  "libc",
- "unicode-width",
+ "unicode-width 0.1.11",
  "windows-sys 0.45.0",
 ]
 
@@ -3503,10 +3503,10 @@ dependencies = [
  "walkdir",
  "warp",
  "wasm-bindgen",
- "wasm-encoder 0.217.0",
+ "wasm-encoder 0.221.2",
  "wasm-smith",
- "wasmparser 0.217.0",
- "wasmprinter 0.217.0",
+ "wasmparser 0.221.2",
+ "wasmprinter",
  "wasmtime",
  "wasmtime-environ",
  "wast",
@@ -4528,7 +4528,7 @@ version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14dbbfd5c71d70241ecf9e6f13737f7b5ce823821063188d7e46c41d371eebd5"
 dependencies = [
- "unicode-width",
+ "unicode-width 0.1.11",
 ]
 
 [[package]]
@@ -6155,7 +6155,7 @@ dependencies = [
  "instant",
  "number_prefix",
  "portable-atomic",
- "unicode-width",
+ "unicode-width 0.1.11",
 ]
 
 [[package]]
@@ -8873,7 +8873,7 @@ checksum = "b55c4d17d994b637e2f4daf6e5dc5d660d209d5642377d675d7a1c3ab69fa579"
 dependencies = [
  "arrayvec 0.5.2",
  "typed-arena",
- "unicode-width",
+ "unicode-width 0.1.11",
 ]
 
 [[package]]
@@ -12700,6 +12700,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
 
 [[package]]
+name = "unicode-width"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13021,17 +13027,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "501940df4418b8929eb6d52f1aade1fdd15a5b86c92453cb696e3c906bd3fc33"
 dependencies = [
  "leb128",
- "wasmparser 0.212.0",
-]
-
-[[package]]
-name = "wasm-encoder"
-version = "0.217.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b88b0814c9a2b323a9b46c687e726996c255ac8b64aa237dd11c81ed4854760"
-dependencies = [
- "leb128",
- "wasmparser 0.217.0",
 ]
 
 [[package]]
@@ -13046,17 +13041,17 @@ dependencies = [
 
 [[package]]
 name = "wasm-smith"
-version = "0.212.0"
+version = "0.221.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8185faf41a5630ec7cf301fa1f63bb757f4c267a057f8b6b56bde0cba1144c1"
+checksum = "ebbaf9c781fb7091b79ad3baa40862b3afccb2949575bb73bdd77643ed40338c"
 dependencies = [
  "anyhow",
  "arbitrary",
  "flagset",
  "indexmap 2.2.6",
  "leb128",
- "wasm-encoder 0.212.0",
- "wasmparser 0.212.0",
+ "wasm-encoder 0.221.2",
+ "wasmparser 0.221.2",
 ]
 
 [[package]]
@@ -13099,20 +13094,6 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.217.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca917a21307d3adf2b9857b94dd05ebf8496bdcff4437a9b9fb3899d3e6c74e7"
-dependencies = [
- "ahash 0.8.11",
- "bitflags 2.6.0",
- "hashbrown 0.14.5",
- "indexmap 2.2.6",
- "semver",
- "serde",
-]
-
-[[package]]
-name = "wasmparser"
 version = "0.221.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9845c470a2e10b61dd42c385839cdd6496363ed63b5c9e420b5488b77bd22083"
@@ -13122,17 +13103,6 @@ dependencies = [
  "indexmap 2.2.6",
  "semver",
  "serde",
-]
-
-[[package]]
-name = "wasmprinter"
-version = "0.217.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50dc568b3e0d47e8f96ea547c90790cfa783f0205160c40de894a427114185ce"
-dependencies = [
- "anyhow",
- "termcolor",
- "wasmparser 0.217.0",
 ]
 
 [[package]]
@@ -13265,7 +13235,7 @@ dependencies = [
  "target-lexicon",
  "wasm-encoder 0.221.2",
  "wasmparser 0.221.2",
- "wasmprinter 0.221.2",
+ "wasmprinter",
 ]
 
 [[package]]
@@ -13352,22 +13322,22 @@ dependencies = [
 
 [[package]]
 name = "wast"
-version = "212.0.0"
+version = "221.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4606a05fb0aae5d11dd7d8280a640d88a63ee019360ba9be552da3d294b8d1f5"
+checksum = "fcc4470b9de917ba199157d1f0ae104f2ae362be728c43e68c571c7715bd629e"
 dependencies = [
  "bumpalo",
  "leb128",
  "memchr",
- "unicode-width",
- "wasm-encoder 0.212.0",
+ "unicode-width 0.2.0",
+ "wasm-encoder 0.221.2",
 ]
 
 [[package]]
 name = "wat"
-version = "1.212.0"
+version = "1.221.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c74ca7f93f11a5d6eed8499f2a8daaad6e225cab0151bc25a091fff3b987532f"
+checksum = "6b1f3c6d82af47286494c6caea1d332037f5cbeeac82bbf5ef59cb8c201c466e"
 dependencies = [
  "wast",
 ]

--- a/Cargo.Bazel.json.lock
+++ b/Cargo.Bazel.json.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "bd637db9477147f09bb148ec55e61a1ad17e91b31b39ab4e53cf948be68026dd",
+  "checksum": "5d9368317f6e6f843baf2dbccd941c8a68017add420948f9c281d4983f4853ca",
   "crates": {
     "abnf 0.12.0": {
       "name": "abnf",
@@ -20582,19 +20582,19 @@
               "target": "wasm_bindgen"
             },
             {
-              "id": "wasm-encoder 0.217.0",
+              "id": "wasm-encoder 0.221.2",
               "target": "wasm_encoder"
             },
             {
-              "id": "wasm-smith 0.212.0",
+              "id": "wasm-smith 0.221.2",
               "target": "wasm_smith"
             },
             {
-              "id": "wasmparser 0.217.0",
+              "id": "wasmparser 0.221.2",
               "target": "wasmparser"
             },
             {
-              "id": "wasmprinter 0.217.0",
+              "id": "wasmprinter 0.221.2",
               "target": "wasmprinter"
             },
             {
@@ -20606,11 +20606,11 @@
               "target": "wasmtime_environ"
             },
             {
-              "id": "wast 212.0.0",
+              "id": "wast 221.0.2",
               "target": "wast"
             },
             {
-              "id": "wat 1.212.0",
+              "id": "wat 1.221.2",
               "target": "wat"
             },
             {
@@ -28222,7 +28222,8 @@
         ],
         "crate_features": {
           "common": [
-            "default-hasher"
+            "default-hasher",
+            "serde"
           ],
           "selects": {}
         },
@@ -28231,6 +28232,10 @@
             {
               "id": "foldhash 0.1.4",
               "target": "foldhash"
+            },
+            {
+              "id": "serde 1.0.217",
+              "target": "serde"
             }
           ],
           "selects": {}
@@ -81077,6 +81082,52 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
+    "unicode-width 0.2.0": {
+      "name": "unicode-width",
+      "version": "0.2.0",
+      "package_url": "https://github.com/unicode-rs/unicode-width",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/unicode-width/0.2.0/download",
+          "sha256": "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "unicode_width",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "unicode_width",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": {
+          "common": [
+            "cjk",
+            "default"
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "0.2.0"
+      },
+      "license": "MIT OR Apache-2.0",
+      "license_ids": [
+        "Apache-2.0",
+        "MIT"
+      ],
+      "license_file": "LICENSE-APACHE"
+    },
     "unicode-xid 0.2.4": {
       "name": "unicode-xid",
       "version": "0.2.4",
@@ -83019,21 +83070,11 @@
         "compile_data_glob": [
           "**"
         ],
-        "crate_features": {
-          "common": [
-            "wasmparser"
-          ],
-          "selects": {}
-        },
         "deps": {
           "common": [
             {
               "id": "leb128 0.2.5",
               "target": "leb128"
-            },
-            {
-              "id": "wasmparser 0.212.0",
-              "target": "wasmparser"
             }
           ],
           "selects": {}
@@ -83046,64 +83087,6 @@
         "Apache-2.0"
       ],
       "license_file": "LICENSE"
-    },
-    "wasm-encoder 0.217.0": {
-      "name": "wasm-encoder",
-      "version": "0.217.0",
-      "package_url": "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasm-encoder",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/wasm-encoder/0.217.0/download",
-          "sha256": "7b88b0814c9a2b323a9b46c687e726996c255ac8b64aa237dd11c81ed4854760"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "wasm_encoder",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "wasm_encoder",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "wasmparser"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "leb128 0.2.5",
-              "target": "leb128"
-            },
-            {
-              "id": "wasmparser 0.217.0",
-              "target": "wasmparser"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "version": "0.217.0"
-      },
-      "license": "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT",
-      "license_ids": [
-        "Apache-2.0",
-        "MIT"
-      ],
-      "license_file": null
     },
     "wasm-encoder 0.221.2": {
       "name": "wasm-encoder",
@@ -83137,7 +83120,8 @@
         "crate_features": {
           "common": [
             "component-model",
-            "default"
+            "default",
+            "wasmparser"
           ],
           "selects": {}
         },
@@ -83146,6 +83130,10 @@
             {
               "id": "leb128 0.2.5",
               "target": "leb128"
+            },
+            {
+              "id": "wasmparser 0.221.2",
+              "target": "wasmparser"
             }
           ],
           "selects": {}
@@ -83160,14 +83148,14 @@
       ],
       "license_file": null
     },
-    "wasm-smith 0.212.0": {
+    "wasm-smith 0.221.2": {
       "name": "wasm-smith",
-      "version": "0.212.0",
+      "version": "0.221.2",
       "package_url": "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasm-smith",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/wasm-smith/0.212.0/download",
-          "sha256": "a8185faf41a5630ec7cf301fa1f63bb757f4c267a057f8b6b56bde0cba1144c1"
+          "url": "https://static.crates.io/crates/wasm-smith/0.221.2/download",
+          "sha256": "ebbaf9c781fb7091b79ad3baa40862b3afccb2949575bb73bdd77643ed40338c"
         }
       },
       "targets": [
@@ -83218,24 +83206,25 @@
               "target": "leb128"
             },
             {
-              "id": "wasm-encoder 0.212.0",
+              "id": "wasm-encoder 0.221.2",
               "target": "wasm_encoder"
             },
             {
-              "id": "wasmparser 0.212.0",
+              "id": "wasmparser 0.221.2",
               "target": "wasmparser"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.212.0"
+        "version": "0.221.2"
       },
-      "license": "Apache-2.0 WITH LLVM-exception",
+      "license": "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT",
       "license_ids": [
-        "Apache-2.0"
+        "Apache-2.0",
+        "MIT"
       ],
-      "license_file": "LICENSE"
+      "license_file": null
     },
     "wasm-streams 0.4.0": {
       "name": "wasm-streams",
@@ -83432,84 +83421,6 @@
       ],
       "license_file": null
     },
-    "wasmparser 0.217.0": {
-      "name": "wasmparser",
-      "version": "0.217.0",
-      "package_url": "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasmparser",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/wasmparser/0.217.0/download",
-          "sha256": "ca917a21307d3adf2b9857b94dd05ebf8496bdcff4437a9b9fb3899d3e6c74e7"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "wasmparser",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "wasmparser",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "default",
-            "features",
-            "serde",
-            "std",
-            "validate"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "ahash 0.8.11",
-              "target": "ahash"
-            },
-            {
-              "id": "bitflags 2.6.0",
-              "target": "bitflags"
-            },
-            {
-              "id": "hashbrown 0.14.5",
-              "target": "hashbrown"
-            },
-            {
-              "id": "indexmap 2.2.6",
-              "target": "indexmap"
-            },
-            {
-              "id": "semver 1.0.22",
-              "target": "semver"
-            },
-            {
-              "id": "serde 1.0.217",
-              "target": "serde"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "version": "0.217.0"
-      },
-      "license": "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT",
-      "license_ids": [
-        "Apache-2.0",
-        "MIT"
-      ],
-      "license_file": null
-    },
     "wasmparser 0.221.2": {
       "name": "wasmparser",
       "version": "0.221.2",
@@ -83554,7 +83465,9 @@
         "crate_features": {
           "common": [
             "component-model",
+            "default",
             "features",
+            "hash-collections",
             "serde",
             "simd",
             "std",
@@ -83567,6 +83480,14 @@
             {
               "id": "bitflags 2.6.0",
               "target": "bitflags"
+            },
+            {
+              "id": "hashbrown 0.15.2",
+              "target": "hashbrown"
+            },
+            {
+              "id": "indexmap 2.2.6",
+              "target": "indexmap"
             },
             {
               "id": "semver 1.0.22",
@@ -83593,62 +83514,6 @@
         "data_glob": [
           "**"
         ]
-      },
-      "license": "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT",
-      "license_ids": [
-        "Apache-2.0",
-        "MIT"
-      ],
-      "license_file": null
-    },
-    "wasmprinter 0.217.0": {
-      "name": "wasmprinter",
-      "version": "0.217.0",
-      "package_url": "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasmprinter",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/wasmprinter/0.217.0/download",
-          "sha256": "50dc568b3e0d47e8f96ea547c90790cfa783f0205160c40de894a427114185ce"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "wasmprinter",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "wasmprinter",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "anyhow 1.0.93",
-              "target": "anyhow"
-            },
-            {
-              "id": "termcolor 1.4.1",
-              "target": "termcolor"
-            },
-            {
-              "id": "wasmparser 0.217.0",
-              "target": "wasmparser"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "version": "0.217.0"
       },
       "license": "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT",
       "license_ids": [
@@ -85029,14 +84894,14 @@
       ],
       "license_file": null
     },
-    "wast 212.0.0": {
+    "wast 221.0.2": {
       "name": "wast",
-      "version": "212.0.0",
+      "version": "221.0.2",
       "package_url": "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wast",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/wast/212.0.0/download",
-          "sha256": "4606a05fb0aae5d11dd7d8280a640d88a63ee019360ba9be552da3d294b8d1f5"
+          "url": "https://static.crates.io/crates/wast/221.0.2/download",
+          "sha256": "fcc4470b9de917ba199157d1f0ae104f2ae362be728c43e68c571c7715bd629e"
         }
       },
       "targets": [
@@ -85060,6 +84925,7 @@
         ],
         "crate_features": {
           "common": [
+            "component-model",
             "default",
             "wasm-module"
           ],
@@ -85080,33 +84946,34 @@
               "target": "memchr"
             },
             {
-              "id": "unicode-width 0.1.10",
+              "id": "unicode-width 0.2.0",
               "target": "unicode_width"
             },
             {
-              "id": "wasm-encoder 0.212.0",
+              "id": "wasm-encoder 0.221.2",
               "target": "wasm_encoder"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "212.0.0"
+        "version": "221.0.2"
       },
-      "license": "Apache-2.0 WITH LLVM-exception",
+      "license": "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT",
       "license_ids": [
-        "Apache-2.0"
+        "Apache-2.0",
+        "MIT"
       ],
-      "license_file": "LICENSE"
+      "license_file": null
     },
-    "wat 1.212.0": {
+    "wat 1.221.2": {
       "name": "wat",
-      "version": "1.212.0",
+      "version": "1.221.2",
       "package_url": "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wat",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/wat/1.212.0/download",
-          "sha256": "c74ca7f93f11a5d6eed8499f2a8daaad6e225cab0151bc25a091fff3b987532f"
+          "url": "https://static.crates.io/crates/wat/1.221.2/download",
+          "sha256": "6b1f3c6d82af47286494c6caea1d332037f5cbeeac82bbf5ef59cb8c201c466e"
         }
       },
       "targets": [
@@ -85128,23 +84995,31 @@
         "compile_data_glob": [
           "**"
         ],
+        "crate_features": {
+          "common": [
+            "component-model",
+            "default"
+          ],
+          "selects": {}
+        },
         "deps": {
           "common": [
             {
-              "id": "wast 212.0.0",
+              "id": "wast 221.0.2",
               "target": "wast"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "1.212.0"
+        "version": "1.221.2"
       },
-      "license": "Apache-2.0 WITH LLVM-exception",
+      "license": "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT",
       "license_ids": [
-        "Apache-2.0"
+        "Apache-2.0",
+        "MIT"
       ],
-      "license_file": "LICENSE"
+      "license_file": null
     },
     "web-sys 0.3.64": {
       "name": "web-sys",
@@ -91603,14 +91478,14 @@
     "walkdir 2.3.3",
     "warp 0.3.7",
     "wasm-bindgen 0.2.95",
-    "wasm-encoder 0.217.0",
-    "wasm-smith 0.212.0",
-    "wasmparser 0.217.0",
-    "wasmprinter 0.217.0",
+    "wasm-encoder 0.221.2",
+    "wasm-smith 0.221.2",
+    "wasmparser 0.221.2",
+    "wasmprinter 0.221.2",
     "wasmtime 29.0.1",
     "wasmtime-environ 29.0.1",
-    "wast 212.0.0",
-    "wat 1.212.0",
+    "wast 221.0.2",
+    "wat 1.221.2",
     "wee_alloc 0.4.5",
     "which 4.4.0",
     "wsl 0.1.0",

--- a/Cargo.Bazel.toml.lock
+++ b/Cargo.Bazel.toml.lock
@@ -2229,7 +2229,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
 dependencies = [
  "termcolor",
- "unicode-width",
+ "unicode-width 0.1.10",
 ]
 
 [[package]]
@@ -2316,7 +2316,7 @@ dependencies = [
  "regex",
  "terminal_size",
  "termios",
- "unicode-width",
+ "unicode-width 0.1.10",
  "winapi 0.3.9",
  "winapi-util",
 ]
@@ -2330,7 +2330,7 @@ dependencies = [
  "encode_unicode",
  "lazy_static",
  "libc",
- "unicode-width",
+ "unicode-width 0.1.10",
  "windows-sys 0.45.0",
 ]
 
@@ -3492,10 +3492,10 @@ dependencies = [
  "walkdir",
  "warp",
  "wasm-bindgen",
- "wasm-encoder 0.217.0",
+ "wasm-encoder 0.221.2",
  "wasm-smith",
- "wasmparser 0.217.0",
- "wasmprinter 0.217.0",
+ "wasmparser 0.221.2",
+ "wasmprinter",
  "wasmtime",
  "wasmtime-environ",
  "wast",
@@ -4517,7 +4517,7 @@ version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14dbbfd5c71d70241ecf9e6f13737f7b5ce823821063188d7e46c41d371eebd5"
 dependencies = [
- "unicode-width",
+ "unicode-width 0.1.10",
 ]
 
 [[package]]
@@ -6145,7 +6145,7 @@ dependencies = [
  "instant",
  "number_prefix",
  "portable-atomic",
- "unicode-width",
+ "unicode-width 0.1.10",
 ]
 
 [[package]]
@@ -12696,6 +12696,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
 
 [[package]]
+name = "unicode-width"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13017,17 +13023,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "501940df4418b8929eb6d52f1aade1fdd15a5b86c92453cb696e3c906bd3fc33"
 dependencies = [
  "leb128",
- "wasmparser 0.212.0",
-]
-
-[[package]]
-name = "wasm-encoder"
-version = "0.217.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b88b0814c9a2b323a9b46c687e726996c255ac8b64aa237dd11c81ed4854760"
-dependencies = [
- "leb128",
- "wasmparser 0.217.0",
 ]
 
 [[package]]
@@ -13042,17 +13037,17 @@ dependencies = [
 
 [[package]]
 name = "wasm-smith"
-version = "0.212.0"
+version = "0.221.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8185faf41a5630ec7cf301fa1f63bb757f4c267a057f8b6b56bde0cba1144c1"
+checksum = "ebbaf9c781fb7091b79ad3baa40862b3afccb2949575bb73bdd77643ed40338c"
 dependencies = [
  "anyhow",
  "arbitrary",
  "flagset",
  "indexmap 2.2.6",
  "leb128",
- "wasm-encoder 0.212.0",
- "wasmparser 0.212.0",
+ "wasm-encoder 0.221.2",
+ "wasmparser 0.221.2",
 ]
 
 [[package]]
@@ -13095,20 +13090,6 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.217.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca917a21307d3adf2b9857b94dd05ebf8496bdcff4437a9b9fb3899d3e6c74e7"
-dependencies = [
- "ahash 0.8.11",
- "bitflags 2.6.0",
- "hashbrown 0.14.5",
- "indexmap 2.2.6",
- "semver",
- "serde",
-]
-
-[[package]]
-name = "wasmparser"
 version = "0.221.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9845c470a2e10b61dd42c385839cdd6496363ed63b5c9e420b5488b77bd22083"
@@ -13118,17 +13099,6 @@ dependencies = [
  "indexmap 2.2.6",
  "semver",
  "serde",
-]
-
-[[package]]
-name = "wasmprinter"
-version = "0.217.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50dc568b3e0d47e8f96ea547c90790cfa783f0205160c40de894a427114185ce"
-dependencies = [
- "anyhow",
- "termcolor",
- "wasmparser 0.217.0",
 ]
 
 [[package]]
@@ -13261,7 +13231,7 @@ dependencies = [
  "target-lexicon",
  "wasm-encoder 0.221.2",
  "wasmparser 0.221.2",
- "wasmprinter 0.221.2",
+ "wasmprinter",
 ]
 
 [[package]]
@@ -13348,22 +13318,22 @@ dependencies = [
 
 [[package]]
 name = "wast"
-version = "212.0.0"
+version = "221.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4606a05fb0aae5d11dd7d8280a640d88a63ee019360ba9be552da3d294b8d1f5"
+checksum = "fcc4470b9de917ba199157d1f0ae104f2ae362be728c43e68c571c7715bd629e"
 dependencies = [
  "bumpalo",
  "leb128",
  "memchr",
- "unicode-width",
- "wasm-encoder 0.212.0",
+ "unicode-width 0.2.0",
+ "wasm-encoder 0.221.2",
 ]
 
 [[package]]
 name = "wat"
-version = "1.212.0"
+version = "1.221.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c74ca7f93f11a5d6eed8499f2a8daaad6e225cab0151bc25a091fff3b987532f"
+checksum = "6b1f3c6d82af47286494c6caea1d332037f5cbeeac82bbf5ef59cb8c201c466e"
 dependencies = [
  "wast",
 ]

--- a/bazel/external_crates.bzl
+++ b/bazel/external_crates.bzl
@@ -1434,23 +1434,23 @@ def external_crates_repository(name, cargo_lockfile, lockfile, sanitizers_enable
                 version = "^0.2",
             ),
             "wasm-encoder": crate.spec(
-                version = "^0.217.0",
+                version = "^0.221.0",
                 features = [
                     "wasmparser",
                 ],
             ),
             "wasm-smith": crate.spec(
-                version = "^0.212.0",
+                version = "^0.221.0",
                 default_features = False,
                 features = [
                     "wasmparser",
                 ],
             ),
             "wasmparser": crate.spec(
-                version = "^0.217.0",
+                version = "^0.221.0",
             ),
             "wasmprinter": crate.spec(
-                version = "^0.217.0",
+                version = "^0.221.0",
             ),
             "wasmtime": crate.spec(
                 version = "^29.0.0",
@@ -1467,10 +1467,10 @@ def external_crates_repository(name, cargo_lockfile, lockfile, sanitizers_enable
                 version = "^29.0.0",
             ),
             "wast": crate.spec(
-                version = "^212.0.0",
+                version = "^221.0.0",
             ),
             "wat": crate.spec(
-                version = "1.212.0",
+                version = "^1.221.0",
             ),
             "wee_alloc": crate.spec(
                 version = "^0.4.3",


### PR DESCRIPTION
EXC-1929

Upgrade various Wasm utility crates to match the version used by wasmtime 29. This allows us to compile fewer versions of each of these crates.