### PR TITLE
chore(IDX): use github.ref_protected where applicable

### DIFF
--- a/.github/actions/bazel-test-all/action.yaml
+++ b/.github/actions/bazel-test-all/action.yaml
@@ -73,3 +73,4 @@ runs:
           MERGE_BASE_SHA: ${{ github.event.pull_request.base.sha }}
           SSH_PRIVATE_KEY_BACKUP_POD: ${{ inputs.SSH_PRIVATE_KEY_BACKUP_POD }}
           GPG_PASSPHRASE: ${{ inputs.GPG_PASSPHRASE }}
+          IS_PROTECTED_BRANCH: ${{ github.ref_protected }}

--- a/.github/workflows-source/ci-main.yml
+++ b/.github/workflows-source/ci-main.yml
@@ -262,6 +262,7 @@ jobs:
           MERGE_BASE_SHA: ${{ github.event.pull_request.base.sha }}
           BRANCH_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           RUN_ON_DIFF_ONLY: ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'CI_ALL_BAZEL_TARGETS') }}
+          IS_PROTECTED_BRANCH: ${{ github.ref_protected }}
       - name: Upload build-ic.tar
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -302,6 +302,7 @@ jobs:
           MERGE_BASE_SHA: ${{ github.event.pull_request.base.sha }}
           BRANCH_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           RUN_ON_DIFF_ONLY: ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'CI_ALL_BAZEL_TARGETS') }}
+          IS_PROTECTED_BRANCH: ${{ github.ref_protected }}
       - name: Upload build-ic.tar
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/schedule-rust-bench.yml
+++ b/.github/workflows/schedule-rust-bench.yml
@@ -49,3 +49,4 @@ jobs:
           CI_JOB_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           RUST_BACKTRACE: "full"
           TARGETS: ${{ matrix.targets }}
+          IS_PROTECTED_BRANCH: ${{ github.ref_protected }}

--- a/ci/bazel-scripts/main.sh
+++ b/ci/bazel-scripts/main.sh
@@ -11,16 +11,6 @@ ic_version_rc_only="0000000000000000000000000000000000000000"
 release_build="false"
 s3_upload="False"
 
-protected_branches=("master" "rc--*" "hotfix-*" "master-private")
-
-# if we are on a protected branch or targeting a rc branch we set ic_version to the commit_sha and upload to s3
-for pattern in "${protected_branches[@]}"; do
-    if [[ "$BRANCH_NAME" == $pattern ]]; then
-        IS_PROTECTED_BRANCH="true"
-        break
-    fi
-done
-
 # if we are on a protected branch or targeting a rc branch we set release build, ic_version to the commit_sha and
 # upload to s3
 if [[ "${IS_PROTECTED_BRANCH:-}" == "true" ]] || [[ "${CI_PULL_REQUEST_TARGET_BRANCH_NAME:-}" == "rc--"* ]]; then

--- a/ci/scripts/run-build-ic.sh
+++ b/ci/scripts/run-build-ic.sh
@@ -5,16 +5,6 @@ VERSION=$(git rev-parse HEAD)
 
 cd "$CI_PROJECT_DIR"
 
-protected_branches=("master" "rc--*" "hotfix-*" "master-private")
-
-# if we are on a protected branch or targeting a rc branch we set ic_version to the commit_sha and upload to s3
-for pattern in "${protected_branches[@]}"; do
-    if [[ "$BRANCH_NAME" == $pattern ]]; then
-        IS_PROTECTED_BRANCH="true"
-        break
-    fi
-done
-
 # run build with release on protected branches or if a pull_request is targeting an rc branch
 if [ "${IS_PROTECTED_BRANCH:-}" == "true" ] || [[ "${CI_MERGE_REQUEST_TARGET_BRANCH_NAME:-}" == "rc--"* ]]; then
     ci/container/build-ic.sh -i -c -b


### PR DESCRIPTION
This means we don't have to keep track of the protected branches and means we can use unified logic for protected ref detection.