### PR TITLE
chore(IDX): rename protected_branches to release_branches

### DIFF
--- a/ci/bazel-scripts/main.sh
+++ b/ci/bazel-scripts/main.sh
@@ -11,19 +11,20 @@ ic_version_rc_only="0000000000000000000000000000000000000000"
 release_build="false"
 s3_upload="False"
 
-protected_branches=("master" "rc--*" "hotfix-*" "master-private")
+# CI will publish artifacts for each commit pushed to the following branches:
+release_branches=("master" "rc--*" "hotfix-*" "master-private")
 
-# if we are on a protected branch or targeting a rc branch we set ic_version to the commit_sha and upload to s3
-for pattern in "${protected_branches[@]}"; do
+# if we are on a releasable branch or targeting a rc branch we set ic_version to the commit_sha and upload to s3
+for pattern in "${release_branches[@]}"; do
     if [[ "$BRANCH_NAME" == $pattern ]]; then
-        IS_PROTECTED_BRANCH="true"
+        IS_RELEASE_BRANCH="true"
         break
     fi
 done
 
 # if we are on a protected branch or targeting a rc branch we set release build, ic_version to the commit_sha and
 # upload to s3
-if [[ "${IS_PROTECTED_BRANCH:-}" == "true" ]] || [[ "${CI_PULL_REQUEST_TARGET_BRANCH_NAME:-}" == "rc--"* ]]; then
+if [[ "${IS_RELEASE_BRANCH:-}" == "true" ]] || [[ "${CI_PULL_REQUEST_TARGET_BRANCH_NAME:-}" == "rc--"* ]]; then
     ic_version_rc_only="${CI_COMMIT_SHA}"
     s3_upload="True"
     release_build="true"

--- a/ci/scripts/run-build-ic.sh
+++ b/ci/scripts/run-build-ic.sh
@@ -5,18 +5,19 @@ VERSION=$(git rev-parse HEAD)
 
 cd "$CI_PROJECT_DIR"
 
-protected_branches=("master" "rc--*" "hotfix-*" "master-private")
+# CI will publish artifacts for each commit pushed to the following branches:
+release_branches=("master" "rc--*" "hotfix-*" "master-private")
 
 # if we are on a protected branch or targeting a rc branch we set ic_version to the commit_sha and upload to s3
-for pattern in "${protected_branches[@]}"; do
+for pattern in "${release_branches[@]}"; do
     if [[ "$BRANCH_NAME" == $pattern ]]; then
-        IS_PROTECTED_BRANCH="true"
+        IS_RELEASE_BRANCH="true"
         break
     fi
 done
 
 # run build with release on protected branches or if a pull_request is targeting an rc branch
-if [ "${IS_PROTECTED_BRANCH:-}" == "true" ] || [[ "${CI_MERGE_REQUEST_TARGET_BRANCH_NAME:-}" == "rc--"* ]]; then
+if [ "${IS_RELEASE_BRANCH:-}" == "true" ] || [[ "${CI_MERGE_REQUEST_TARGET_BRANCH_NAME:-}" == "rc--"* ]]; then
     ci/container/build-ic.sh -i -c -b
 # check if the job requested running only on diff, otherwise run full build with no release
 elif [[ "${RUN_ON_DIFF_ONLY:-}" == "true" ]]; then
@@ -38,7 +39,7 @@ elif [[ "${RUN_ON_DIFF_ONLY:-}" == "true" ]]; then
     fi
 
     if [ ${#ARGS[@]} -eq 1 ]; then
-        if [ "${IS_PROTECTED_BRANCH:-}" == "true" ]; then
+        if [ "${IS_RELEASE_BRANCH:-}" == "true" ]; then
             echo "Error: No changes to build on protected branch. Aborting."
             exit 1
         fi


### PR DESCRIPTION
This is less confusing since not all branches in `protected_branches` are actually protected. It's also more understandable since CI will publish artifacts (release) for all commits pushed to the `release_branches`.