### PR TITLE
fix(IDX): remove unused step output

### DIFF
--- a/ci/bazel-scripts/main.sh
+++ b/ci/bazel-scripts/main.sh
@@ -60,10 +60,6 @@ if [ -n "${CLOUD_CREDENTIALS_CONTENT+x}" ]; then
     unset CLOUD_CREDENTIALS_CONTENT
 fi
 
-if [ -n "${GITHUB_OUTPUT:-}" ]; then
-    echo "upload_artifacts=true" >>"$GITHUB_OUTPUT"
-fi
-
 if [ -z "${KUBECONFIG:-}" ] && [ ! -z "${KUBECONFIG_TNET_CREATOR_LN1:-}" ]; then
     export KUBECONFIG=$(mktemp -t kubeconfig-XXXXXX)
     echo $KUBECONFIG_TNET_CREATOR_LN1 >$KUBECONFIG


### PR DESCRIPTION
This removes the GHA step output `upload_artifacts` that doesn't seem to be used.