### PR TITLE
chore(MR): Increase expected message latency to handle slow upgrades

### DIFF
--- a/rs/tests/message_routing/xnet/xnet_compatibility.rs
+++ b/rs/tests/message_routing/xnet/xnet_compatibility.rs
@@ -166,7 +166,7 @@ pub async fn test_async(env: TestEnv) {
         // while the long running test is running we are generous
         // with error thresholds.
         75.0,
-        40,
+        60,
     )
     .with_call_timeouts(&call_timeouts);
 


### PR DESCRIPTION
This fixes the flaky xnet_compatibility_test by bumping the bound on the expected mean latency from 40 to 60 seconds