### PR TITLE
chore(IDX): clean up status

### DIFF
--- a/bazel/ic_version_or_git_sha.sh
+++ b/bazel/ic_version_or_git_sha.sh
@@ -17,9 +17,6 @@ while read -r k v; do
         COMMIT_SHA)
             VERSION="$v"
             ;;
-        GIT_TREE_STATUS)
-            GIT_TREE_STATUS="$v"
-            ;;
         BUILD_TIMESTAMP)
             BUILD_TIMESTAMP="$v"
             ;;

--- a/bazel/workspace_status.sh
+++ b/bazel/workspace_status.sh
@@ -14,11 +14,11 @@ echo "GIT_TREE_STATUS $git_tree_status"
 echo "HOME ${HOME}"
 
 # Used as farm metadata
-test -n "${CI_JOB_NAME:-}" && echo "CI_JOB_NAME ${CI_JOB_NAME}"
+test -n "${CI_JOB_NAME:-}" && echo "STABLE_FARM_JOB_NAME ${CI_JOB_NAME}"
 if [[ -n "${USER:-}" ]]; then
-    echo "USER ${USER}"
+    echo "STABLE_FARM_USER ${USER}"
 elif [[ -n "${HOSTUSER:-}" ]]; then
-    echo "USER ${HOSTUSER}"
+    echo "STABLE_FARM_USER ${HOSTUSER}"
 fi
 
 # Generate a file that changes every time bazel runs. It can be used as dependency for targets we want to always rebuild.

--- a/rs/tests/driver/src/driver/farm.rs
+++ b/rs/tests/driver/src/driver/farm.rs
@@ -448,14 +448,12 @@ pub struct GroupSpec {
 
 impl GroupSpec {
     pub fn add_meta(mut self, group_base_name: &str) -> Self {
-        // Acquire bazel's volatile status containing key value pairs like USER and CI_JOB_NAME:
+        // Acquire bazel's stable status containing key value pairs like user and job name:
         let farm_metadata_path = std::env::var("FARM_METADATA_PATH")
             .expect("Expected the environment variable FARM_METADATA_PATH to be defined!");
         let farm_metadata = read_dependency_to_string(&farm_metadata_path)
             .unwrap_or_else(|e| {
-                panic!(
-                    "Couldn't read content of the volatile status file {farm_metadata_path}: {e:?}"
-                )
+                panic!("Couldn't read content of the status file {farm_metadata_path}: {e:?}")
             })
             .trim_end()
             .to_string();
@@ -463,11 +461,11 @@ impl GroupSpec {
 
         // Read values from the runtime args and use sensible defaults if unset
         let user = runtime_args_map
-            .get("USER")
+            .get("STABLE_FARM_USER") // Always set by bazel
             .cloned()
             .unwrap_or("CI".to_string());
         let job_schedule = runtime_args_map
-            .get("CI_JOB_NAME")
+            .get("STABLE_FARM_JOB_NAME") // Injected by workspace status
             .cloned()
             .unwrap_or("manual".to_string());
         let metadata = GroupMetadata {


### PR DESCRIPTION
This removes (more) unused status env vars, and removes the workaround used to clean up the volatile status by instead using stable status for farm metadata.

This means farm tests will be retriggered if the jobs are run under a new CI job name, which is actually already the case since ic-os images are not cached (we rely on `diff.sh` for skipping tests).