### PR TITLE
chore: use cdk::api::in_replicated_execution

### DIFF
--- a/rs/bitcoin/checker/src/main.rs
+++ b/rs/bitcoin/checker/src/main.rs
@@ -201,7 +201,7 @@ fn post_upgrade(arg: CheckArg) {
 
 #[ic_cdk::query(hidden = true)]
 fn http_request(req: http::HttpRequest) -> http::HttpResponse {
-    if ic_cdk::api::data_certificate().is_none() {
+    if ic_cdk::api::in_replicated_execution() {
         ic_cdk::trap("update call rejected");
     }
 

--- a/rs/bitcoin/ckbtc/minter/src/main.rs
+++ b/rs/bitcoin/ckbtc/minter/src/main.rs
@@ -226,7 +226,7 @@ fn get_deposit_fee() -> u64 {
 
 #[query(hidden = true)]
 fn http_request(req: HttpRequest) -> HttpResponse {
-    if ic_cdk::api::data_certificate().is_none() {
+    if ic_cdk::api::in_replicated_execution() {
         ic_cdk::trap("update call rejected");
     }
 

--- a/rs/ethereum/cketh/minter/src/main.rs
+++ b/rs/ethereum/cketh/minter/src/main.rs
@@ -890,7 +890,7 @@ fn get_events(arg: GetEventsArg) -> GetEventsResult {
 fn http_request(req: HttpRequest) -> HttpResponse {
     use ic_metrics_encoder::MetricsEncoder;
 
-    if ic_cdk::api::data_certificate().is_none() {
+    if ic_cdk::api::in_replicated_execution() {
         ic_cdk::trap("update call rejected");
     }
 

--- a/rs/ethereum/ledger-suite-orchestrator/src/main.rs
+++ b/rs/ethereum/ledger-suite-orchestrator/src/main.rs
@@ -108,7 +108,7 @@ fn http_request(
     use dashboard::DashboardTemplate;
     use ic_canisters_http_types::HttpResponseBuilder;
 
-    if ic_cdk::api::data_certificate().is_none() {
+    if ic_cdk::api::in_replicated_execution() {
         ic_cdk::trap("update call rejected");
     }
 

--- a/rs/ledger_suite/icp/src/lib.rs
+++ b/rs/ledger_suite/icp/src/lib.rs
@@ -1230,7 +1230,7 @@ impl Default for FeatureFlags {
 }
 
 pub fn max_blocks_per_request(principal_id: &PrincipalId) -> usize {
-    if ic_cdk::api::data_certificate().is_none() && principal_id.is_self_authenticating() {
+    if ic_cdk::api::in_replicated_execution() && principal_id.is_self_authenticating() {
         return MAX_BLOCKS_PER_INGRESS_REPLICATED_QUERY_REQUEST;
     }
     MAX_BLOCKS_PER_REQUEST


### PR DESCRIPTION
We used to use `ic_cdk::api::data_certificate().is_none()` to detect whether a canister is running in replicated or query mode. Now the cdk has a function `in_replicated_execution`, so this PR switches all instances to this newer and more readable approach.