### PR TITLE
chore(IDX): use proper regex for branch matching

### DIFF
--- a/ci/bazel-scripts/main.sh
+++ b/ci/bazel-scripts/main.sh
@@ -11,11 +11,11 @@ ic_version_rc_only="0000000000000000000000000000000000000000"
 release_build="false"
 s3_upload="False"
 
-protected_branches=("master" "rc--*" "hotfix-*" "master-private")
+protected_branches=("^master$" "^rc--" "^hotfix-" "^master-private$")
 
 # if we are on a protected branch or targeting a rc branch we set ic_version to the commit_sha and upload to s3
 for pattern in "${protected_branches[@]}"; do
-    if [[ "$BRANCH_NAME" == $pattern ]]; then
+    if [[ "$BRANCH_NAME" =~ $pattern ]]; then
         IS_PROTECTED_BRANCH="true"
         break
     fi


### PR DESCRIPTION
This uses actual regexes to avoid globbing-related issues when matching on branch names.