### PR TITLE
feat(IC-1579): allow disabling the TLA instrumentation even with test feature

### DIFF
--- a/rs/nns/governance/src/governance/tla/store.rs
+++ b/rs/nns/governance/src/governance/tla/store.rs
@@ -13,4 +13,4 @@ task_local! {
 }
 
 #[cfg(feature = "tla")]
-pub static TLA_TRACES_MUTEX: RwLock<Vec<UpdateTrace>> = RwLock::new(Vec::new());
+pub static TLA_TRACES_MUTEX: Option<RwLock<Vec<UpdateTrace>>> = None;

--- a/rs/tla_instrumentation/tla_instrumentation/tests/multiple_calls.rs
+++ b/rs/tla_instrumentation/tla_instrumentation/tests/multiple_calls.rs
@@ -40,7 +40,7 @@ mod tla_stuff {
         pub static TLA_TRACES_LKEY: std::cell::RefCell<Vec<UpdateTrace>>;
     }
 
-    pub static TLA_TRACES_MUTEX: RwLock<Vec<UpdateTrace>> = RwLock::new(Vec::new());
+    pub static TLA_TRACES_MUTEX: Option<RwLock<Vec<UpdateTrace>>> = Some(RwLock::new(Vec::new()));
 
     pub fn tla_get_globals(c: &StructCanister) -> GlobalState {
         let mut state = GlobalState::new();
@@ -178,7 +178,7 @@ fn multiple_calls_test() {
         let canister = &mut *addr_of_mut!(GLOBAL);
         tokio_test::block_on(canister.my_method());
     }
-    let trace = &TLA_TRACES_MUTEX.read().unwrap()[0];
+    let trace = &TLA_TRACES_MUTEX.as_ref().unwrap().read().unwrap()[0];
     assert_eq!(
         trace.constants.to_map().get("MAX_COUNTER"),
         Some(&3_u64.to_string())

--- a/rs/tla_instrumentation/tla_instrumentation/tests/structs.rs
+++ b/rs/tla_instrumentation/tla_instrumentation/tests/structs.rs
@@ -38,7 +38,7 @@ mod tla_stuff {
         pub static TLA_TRACES_LKEY: std::cell::RefCell<Vec<UpdateTrace>>;
     }
 
-    pub static TLA_TRACES_MUTEX: RwLock<Vec<UpdateTrace>> = RwLock::new(Vec::new());
+    pub static TLA_TRACES_MUTEX: Option<RwLock<Vec<UpdateTrace>>> = Some(RwLock::new(Vec::new()));
 
     pub fn tla_get_globals(c: &StructCanister) -> GlobalState {
         let mut state = GlobalState::new();
@@ -158,7 +158,7 @@ fn struct_test() {
         let canister = &mut *addr_of_mut!(GLOBAL);
         tokio_test::block_on(canister.my_method());
     }
-    let trace = &TLA_TRACES_MUTEX.read().unwrap()[0];
+    let trace = &TLA_TRACES_MUTEX.as_ref().unwrap().read().unwrap()[0];
     assert_eq!(
         trace.constants.to_map().get("MAX_COUNTER"),
         Some(&2_u64.to_string())


### PR DESCRIPTION
When the test feature was on, we have so far always recorded TLA traces in governance. But this can be problematic when a canister is built with this feature turned on, because the traces would be collected in the background. This is a problem for canisters with large states (since the traces keep multiple copies of the state in the Wasm heap), but even with moderate state sizes it would also effectively leak the canister memory over time, since the traces were never emptied.

Change the instrumentation infrastructure to not record any traces when both:
1. a `TLA_TRACES_LKEY` task-local (`LocalKey`) isn't set (this is meant to be used from pure Rust tests and is set by the `with_tla_trace_check` attribute macro)
2. `TLA_TRACES_MUTEX` isn't set (this is currently just disabled in governance, but could be used to collect traces from a canister, but the infrastructure is lacking)