### PR TITLE
refactor(nns): Optimize deciding_voting_power.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10623,7 +10623,6 @@ dependencies = [
  "ic-nervous-system-common-test-keys",
  "ic-nervous-system-common-test-utils",
  "ic-nervous-system-governance",
- "ic-nervous-system-linear-map",
  "ic-nervous-system-long-message",
  "ic-nervous-system-proto",
  "ic-nervous-system-root",

--- a/rs/nns/governance/BUILD.bazel
+++ b/rs/nns/governance/BUILD.bazel
@@ -48,7 +48,6 @@ DEPENDENCIES = [
     "//rs/nervous_system/clients",
     "//rs/nervous_system/common",
     "//rs/nervous_system/governance",
-    "//rs/nervous_system/linear_map",
     "//rs/nervous_system/long_message",
     "//rs/nervous_system/neurons_fund",
     "//rs/nervous_system/proto",

--- a/rs/nns/governance/Cargo.toml
+++ b/rs/nns/governance/Cargo.toml
@@ -49,7 +49,6 @@ ic-nervous-system-clients = { path = "../../nervous_system/clients" }
 ic-nervous-system-common = { path = "../../nervous_system/common" }
 ic-nervous-system-common-build-metadata = { path = "../../nervous_system/common/build_metadata" }
 ic-nervous-system-governance = { path = "../../nervous_system/governance" }
-ic-nervous-system-linear-map = { path = "../../nervous_system/linear_map" }
 ic-nervous-system-long-message = { path = "../../nervous_system/long_message" }
 ic-nervous-system-root = { path = "../../nervous_system/root" }
 ic-nervous-system-runtime = { path = "../../nervous_system/runtime" }

--- a/rs/nns/governance/canbench/canbench_results.yml
+++ b/rs/nns/governance/canbench/canbench_results.yml
@@ -151,13 +151,13 @@ benches:
     scopes: {}
   neuron_metrics_calculation_heap:
     total:
-      instructions: 937000
+      instructions: 863000
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   neuron_metrics_calculation_stable:
     total:
-      instructions: 2540000
+      instructions: 2460000
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}

--- a/rs/nns/governance/canbench/canbench_results.yml
+++ b/rs/nns/governance/canbench/canbench_results.yml
@@ -55,7 +55,7 @@ benches:
     scopes: {}
   compute_ballots_for_new_proposal_with_stable_neurons:
     total:
-      instructions: 2265911
+      instructions: 2010000
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
@@ -85,7 +85,7 @@ benches:
     scopes: {}
   list_neurons_by_subaccount_heap:
     total:
-      instructions: 7551696
+      instructions: 7150000
       heap_increase: 9
       stable_memory_increase: 0
     scopes: {}
@@ -97,7 +97,7 @@ benches:
     scopes: {}
   list_neurons_heap:
     total:
-      instructions: 4963821
+      instructions: 4560000
       heap_increase: 9
       stable_memory_increase: 0
     scopes: {}
@@ -151,13 +151,13 @@ benches:
     scopes: {}
   neuron_metrics_calculation_heap:
     total:
-      instructions: 1485668
+      instructions: 937000
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   neuron_metrics_calculation_stable:
     total:
-      instructions: 3085347
+      instructions: 2540000
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}

--- a/rs/nns/governance/src/neuron/types.rs
+++ b/rs/nns/governance/src/neuron/types.rs
@@ -24,11 +24,7 @@ use ic_nervous_system_common::ONE_DAY_SECONDS;
 use ic_nns_common::pb::v1::{NeuronId, ProposalId};
 use ic_nns_governance_api::pb::v1::{self as api, NeuronInfo};
 use icp_ledger::Subaccount;
-use rust_decimal::{Decimal, RoundingStrategy};
-use std::{
-    collections::{BTreeSet, HashMap},
-    time::Duration,
-};
+use std::collections::{BTreeSet, HashMap};
 
 // It might make sense for Private to be the default; however, the default of
 // pb::Visibility is Unspecified. Therefore, instead of doing things such as
@@ -302,35 +298,22 @@ impl Neuron {
     ) -> u64 {
         // Main inputs to main calculation.
 
-        let adjustment_factor: Decimal = if is_voting_power_adjustment_enabled() {
-            let time_since_last_refreshed = Duration::from_secs(
-                now_seconds.saturating_sub(self.voting_power_refreshed_timestamp_seconds),
-            );
+        let adjustment_factor: f64 = if is_voting_power_adjustment_enabled() {
+            let seconds_since_last_refreshed =
+                now_seconds.saturating_sub(self.voting_power_refreshed_timestamp_seconds);
 
             voting_power_economics
-                .deciding_voting_power_adjustment_factor(time_since_last_refreshed)
+                .deciding_voting_power_adjustment_factor(seconds_since_last_refreshed)
         } else {
-            Decimal::from(1)
+            1.0
         };
 
         let potential_voting_power = self.potential_voting_power(now_seconds);
 
         // Main calculation.
-        let result = adjustment_factor * Decimal::from(potential_voting_power);
+        let result = adjustment_factor * (potential_voting_power as f64);
 
-        // Convert (back) to u64. The particular type of rounding used here does
-        // not matter to us very much, because we are not for example
-        // apportioning (where rounding down is best), nor anything like that.
-        let result = result.round_dp_with_strategy(0, RoundingStrategy::MidpointNearestEven);
-        u64::try_from(result).unwrap_or_else(|err| {
-            // Log and fall back to potential voting power. Assuming
-            // adjustment_factor is in [0, 1], I see no way this can happen.
-            println!(
-                "{}ERROR: Unable to convert deciding voting power {} * {} back to u64: {:?}",
-                LOG_PREFIX, adjustment_factor, potential_voting_power, err,
-            );
-            potential_voting_power
-        })
+        result as u64
     }
 
     /// Return the voting power of this neuron.


### PR DESCRIPTION
A couple of changes:

1. Switch from using Decimal to using float. This results a 37% improvement to neuron_metrics_calculation_heap in canbench.

2. Avoid recalculating deciding voting power when refreshing metrics. By itself (i.e. without switching to float), this results in a 23% improvement to neuron_metrics_calculation_heap.

Together, neuron_metrics_calculation_heap is improved by 42%.

# Impact on Benchmarks

Other benches are also improved, but not by as much. The next biggest winner is neuron_metrics_calculation_stable. It is not surprising that these two benches see the biggest uplift, because in these tests, deciding_voting_power is called against ALL neurons, unlike in other tests.

# Is This Worthwhile?

TBH, I am really not sure we need these optimizations. I did them, because I promised to look into why some bench results got worse in [PR 3371]. This seems to mostly affect metrics, which get calculated in the background. Therefore, the impact of these changes on latency is probably small.

[PR 3371]: https://github.com/dfinity/ic/pull/3371

> Premature optimization is the root of all evil.
> --Donald Knuth

The second change is particularly nasty. Furthermore, if we skip the second change (and only do 1), then we are only missing out on an 8% improvement.

# Why Focus on `deciding_voting_power`

To help me figure out what I should try to optimize, I used [this] to generate flame graphs. The flame graphs showed that almost half the time spent in NeuronSubsetMetrics::increment was spent in deciding_voting_power, which seemed really inordinate.

[this]: https://github.com/dfinity/ic/pull/3964

# References

Closes [NNS1-3535].

[NNS1-3535]: https://dfinity.atlassian.net/browse/NNS1-3535