### PR TITLE
feat(sns): Prevent submitting add_generic_nervous_system_function proposals without a topic

### DIFF
--- a/rs/sns/governance/src/governance/assorted_governance_tests.rs
+++ b/rs/sns/governance/src/governance/assorted_governance_tests.rs
@@ -3517,6 +3517,35 @@ fn test_cant_add_generic_nervous_system_functions_to_critical_topics() {
     }
 }
 
+#[test]
+fn test_cant_add_generic_nervous_system_function_without_topic() {
+    let id = 1000;
+    let valid = NervousSystemFunction {
+        id,
+        name: "a".to_string(),
+        description: None,
+        function_type: Some(FunctionType::GenericNervousSystemFunction(
+            GenericNervousSystemFunction {
+                topic: None, // No topic specified
+                target_canister_id: Some(CanisterId::from(200).get()),
+                target_method_name: Some("test_method".to_string()),
+                validator_canister_id: Some(CanisterId::from(100).get()),
+                validator_method_name: Some("test_validator_method".to_string()),
+            },
+        )),
+    };
+
+    match crate::proposal::validate_and_render_add_generic_nervous_system_function(&Default::default(), &valid, &Default::default()) {
+        Ok(_) => panic!(
+            "Should not be able to add generic nervous system functions without a topic, but was able to add it."
+        ),
+        Err(err) => assert_eq!(
+            err,
+            "NervousSystemFunction must have a topic",
+        ),
+    }
+}
+
 fn default_governance_with_proto(governance_proto: GovernanceProto) -> Governance {
     Governance::new(
         governance_proto

--- a/rs/sns/governance/src/proposal.rs
+++ b/rs/sns/governance/src/proposal.rs
@@ -1412,6 +1412,12 @@ pub fn validate_and_render_add_generic_nervous_system_function(
         return Err("Reached maximum number of allowed GenericNervousSystemFunctions".to_string());
     }
 
+    // This isn't done in ValidGenericNervousSystemFunction::try_from because it's only invalid for new functions, not
+    // for existing functions
+    if validated_function.topic.is_none() {
+        return Err("NervousSystemFunction must have a topic".to_string());
+    }
+
     Ok(format!(
         r"Proposal to add new NervousSystemFunction:
 

--- a/rs/sns/governance/src/topics.rs
+++ b/rs/sns/governance/src/topics.rs
@@ -1,4 +1,4 @@
-use crate::pb::v1::NervousSystemFunction;
+use crate::pb::v1::{self as pb, NervousSystemFunction};
 use crate::types::native_action_ids;
 use crate::{governance::Governance, pb::v1::nervous_system_function::FunctionType};
 use ic_sns_governance_api::pb::v1::topics::Topic;
@@ -198,5 +198,13 @@ impl Governance {
             topics,
             uncategorized_functions,
         }
+    }
+}
+
+impl pb::Topic {
+    pub fn is_critical(&self) -> bool {
+        topic_descriptions()
+            .iter()
+            .any(|topic| pb::Topic::from(topic.topic) == *self && topic.is_critical)
     }
 }

--- a/rs/sns/governance/unreleased_changelog.md
+++ b/rs/sns/governance/unreleased_changelog.md
@@ -9,11 +9,13 @@ on the process that this file is part of, see
 
 ## Added
 
-The concept of topics has now been introduced to the SNS. This means that when custom function is being submitted, a topic can be specified for that function to be categorized under. This can be used for organizing the following page, and could be used for more in the future.
+The concept of topics has now been introduced to the SNS. This means that when custom function is added via an `AddGenericNervousSystemFunction` proposal, a topic can be specified for that custom function. This can be used for organizing the following page, and could be used for more in the future.
 
 A `list_topics` API has been added, which returns a list of topics and all the functions categorized in those topics. 
 
 ## Changed
+
+The new `topic` field is required when submitting an `AddGenericNervousSystemFunction` proposal.
 
 ## Deprecated
 


### PR DESCRIPTION
This ensures that all new custom functions will specify a topic.