### PR TITLE
fix(node): Catch unbound variable errors from sub-scripts

### DIFF
--- a/ic-os/components/setupos-scripts/setupos.sh
+++ b/ic-os/components/setupos-scripts/setupos.sh
@@ -2,11 +2,20 @@
 
 set -o nounset
 set -o pipefail
+set -e
 
 SHELL="/bin/bash"
 PATH="/sbin:/bin:/usr/sbin:/usr/bin"
 
 source /opt/ic/bin/functions.sh
+
+trap 'handle_error $? $LINENO' ERR
+
+function handle_error() {
+    local exit_code="$1"
+    local line="$2"
+    log_and_halt_installation_on_error "$exit_code" "SetupOS encountered an error at line ${line}. Halting installation."
+}
 
 function start_setupos() {
     # Wait until login prompt appears
@@ -38,27 +47,32 @@ function reboot_setupos() {
 main() {
     log_start "$(basename $0)"
     start_setupos
+
     /opt/ic/bin/check-setupos-age.sh
     /opt/ic/bin/check-config.sh
     /opt/ic/bin/check-hardware.sh
     /opt/ic/bin/check-network.sh
     /opt/ic/bin/check-ntp.sh
+
     if kernel_cmdline_bool_default_true ic.setupos.perform_installation; then
         true
     else
         echo "* Installation skipped by request via kernel command line; stopping here"
-        exit
+        exit 0
     fi
+
     /opt/ic/bin/setup-disk.sh
     /opt/ic/bin/install-hostos.sh
     /opt/ic/bin/install-guestos.sh
     /opt/ic/bin/setup-hostos-config.sh
+
     if kernel_cmdline_bool_default_true ic.setupos.reboot_after_installation; then
         true
     else
         echo "* Reboot skipped by request via kernel command line; stopping here"
-        exit
+        exit 0
     fi
+
     reboot_setupos
     log_end "$(basename $0)"
 }


### PR DESCRIPTION
Fixes bug in SetupOS where unbound variable errors are not caught by SetupOS. Now, when a script encounters an unbound variable, SetupOS catches this and halts the installation:
