### PR TITLE
fix: CON-1313 Don't panic in `make_registry_cup`

### DIFF
--- a/rs/consensus/src/cup_utils.rs
+++ b/rs/consensus/src/cup_utils.rs
@@ -161,13 +161,16 @@ pub fn make_registry_cup(
     subnet_id: SubnetId,
     logger: &ReplicaLogger,
 ) -> Option<CatchUpPackage> {
-    let Ok(versioned_record) = registry.get_cup_contents(subnet_id, registry.get_latest_version())
-    else {
-        warn!(
-            logger,
-            "Failed to retrieve registry CUP contents from the registry {:?}", e,
-        );
-        return None;
+    let versioned_record = match registry.get_cup_contents(subnet_id, registry.get_latest_version())
+    {
+        Ok(versioned_record) => versioned_record,
+        Err(e) => {
+            warn!(
+                logger,
+                "Failed to retrieve versioned record from the registry {:?}", e,
+            );
+            return None;
+        }
     };
 
     let Some(cup_contents) = versioned_record.value else {


### PR DESCRIPTION
This code is called by the orchestrator to create registry CUPs, so it shouldn't panic.