### PR TITLE
fix(governance-tools): Proposal URL was wrong.

### DIFF
--- a/rs/nns/cmc/CHANGELOG.md
+++ b/rs/nns/cmc/CHANGELOG.md
@@ -13,7 +13,7 @@ INSERT NEW RELEASES HERE
 
 # 2025-02-07: Proposal 135205
 
-http://dashboard.internetcomputer.org/proposals/135205
+http://dashboard.internetcomputer.org/proposal/135205
 
 ## Added
 

--- a/rs/nns/governance/CHANGELOG.md
+++ b/rs/nns/governance/CHANGELOG.md
@@ -105,7 +105,7 @@ INSERT NEW RELEASES HERE
 
 # 2025-02-07: Proposal 135206
 
-http://dashboard.internetcomputer.org/proposals/135206
+http://dashboard.internetcomputer.org/proposal/135206
 
 ## Added
 

--- a/rs/nns/handlers/root/CHANGELOG.md
+++ b/rs/nns/handlers/root/CHANGELOG.md
@@ -13,7 +13,7 @@ INSERT NEW RELEASES HERE
 
 # 2025-02-14: Proposal 135313
 
-http://dashboard.internetcomputer.org/proposals/135313
+http://dashboard.internetcomputer.org/proposal/135313
 
 ## Added
 

--- a/rs/nns/sns-wasm/CHANGELOG.md
+++ b/rs/nns/sns-wasm/CHANGELOG.md
@@ -13,7 +13,7 @@ INSERT NEW RELEASES HERE
 
 # 2025-02-14: Proposal 135314
 
-http://dashboard.internetcomputer.org/proposals/135314
+http://dashboard.internetcomputer.org/proposal/135314
 
 ## Removed
 

--- a/rs/registry/canister/CHANGELOG.md
+++ b/rs/registry/canister/CHANGELOG.md
@@ -30,7 +30,7 @@ mitigated with a few NNS proposals referenced in the forum thread.
 
 # 2025-02-07: Proposal 135207
 
-http://dashboard.internetcomputer.org/proposals/135207
+http://dashboard.internetcomputer.org/proposal/135207
 
 ## Changed
 
@@ -66,7 +66,7 @@ it will be a required field for node registration in the IC.
 
 # 2025-01-20: Proposal 134904
 
-http://dashboard.internetcomputer.org/proposals/134904
+http://dashboard.internetcomputer.org/proposal/134904
 
 ## Changed
 

--- a/rs/sns/governance/CHANGELOG.md
+++ b/rs/sns/governance/CHANGELOG.md
@@ -13,7 +13,7 @@ INSERT NEW RELEASES HERE
 
 # 2025-02-15: Proposal 135315
 
-http://dashboard.internetcomputer.org/proposals/135315
+http://dashboard.internetcomputer.org/proposal/135315
 
 ## Added
 
@@ -28,7 +28,7 @@ The new `topic` field is required when submitting an `AddGenericNervousSystemFun
 
 # 2025-02-07: Proposal 135208
 
-http://dashboard.internetcomputer.org/proposals/135208
+http://dashboard.internetcomputer.org/proposal/135208
 
 ## Added
 
@@ -89,7 +89,7 @@ a potentially large WASM module (over 2 MiB) uploaded to some *store* canister, 
 
 # 2025-01-20: Proposal 134906
 
-http://dashboard.internetcomputer.org/proposals/134906
+http://dashboard.internetcomputer.org/proposal/134906
 
 ## Added
 

--- a/rs/sns/root/CHANGELOG.md
+++ b/rs/sns/root/CHANGELOG.md
@@ -13,7 +13,7 @@ INSERT NEW RELEASES HERE
 
 # 2025-02-07: Proposal 135209
 
-http://dashboard.internetcomputer.org/proposals/135209
+http://dashboard.internetcomputer.org/proposal/135209
 
 ## Added
 

--- a/rs/sns/swap/CHANGELOG.md
+++ b/rs/sns/swap/CHANGELOG.md
@@ -13,7 +13,7 @@ INSERT NEW RELEASES HERE
 
 # 2025-02-15: Proposal 135316
 
-http://dashboard.internetcomputer.org/proposals/135316
+http://dashboard.internetcomputer.org/proposal/135316
 
 ## Added
 
@@ -22,7 +22,7 @@ http://dashboard.internetcomputer.org/proposals/135316
 
 # 2025-01-20: Proposal 134907
 
-http://dashboard.internetcomputer.org/proposals/134907
+http://dashboard.internetcomputer.org/proposal/134907
 
 No behavior changes. This was just a maintenance release.
 

--- a/testnet/tools/nns-tools/add-release-to-changelog.sh
+++ b/testnet/tools/nns-tools/add-release-to-changelog.sh
@@ -120,7 +120,7 @@ if [[ -z "${NEW_FEATURES_AND_FIXES}" ]]; then
 fi
 NEW_ENTRY="# ${PROPOSED_ON}: Proposal ${PROPOSAL_ID}
 
-http://dashboard.internetcomputer.org/proposals/${PROPOSAL_ID}
+http://dashboard.internetcomputer.org/proposal/${PROPOSAL_ID}
 
 ${NEW_FEATURES_AND_FIXES}
 "


### PR DESCRIPTION
Before, it said `proposals` (notice trailing `s`) instead of `proposal`.

These URLs were generated by `add-release-to-changelog.sh`. That has also been fixed.

# Tangent(s)

How `CHANGELOG.md` files were changed:

```bash
for f in $(find rs/{nns,sns,registry} -name 'CHANGELOG.md'); do 
    sed -i '' 's!/proposals/!/proposal/!' $f
done
```

**Pro tip**: when you expect a single character to be added or deleted from a long string of non-space characters (e.g. a URL), try the following:

```
git diff --word-diff-regex=.
```