### PR TITLE
chore(IDX): do not bind-mount home

### DIFF
--- a/ci/container/container-run.sh
+++ b/ci/container/container-run.sh
@@ -111,7 +111,6 @@ fi
 
 PODMAN_RUN_ARGS+=(
     --mount type=bind,source="${REPO_ROOT}",target="${WORKDIR}"
-    --mount type=bind,source="${HOME}",target="${HOME}"
     --mount type=bind,source="${CACHE_DIR:-${HOME}/.cache}",target="${CTR_HOME}/.cache"
     --mount type=bind,source="${HOME}/.ssh",target="${CTR_HOME}/.ssh"
     --mount type=bind,source="${HOME}/.aws",target="${CTR_HOME}/.aws"


### PR DESCRIPTION
Do not bind-mount `$HOME` as this is generally really not safe and clean. User has freedom to bind-mount specific home directories or entire home via `$HOME/.container-run.conf`. See below.

```bash
❯ cat ~/.container-run.conf
PODMAN_RUN_USR_ARGS=(
    --mount type=bind,source=${HOME}/dev,target=/home/ubuntu/dev
    --mount type=bind,source=${HOME}/.kube,target=/home/ubuntu/.kube
)
```
Having `$HOME` bind-mounted presented itself to be an issue with release verification of [this release](https://forum.dfinity.org/t/proposal-to-elect-new-release-rc-2025-02-13-03-06). Users tried to verified the build on AWS EC2 instance. It it yet not clear whether recent related code changes [here](https://github.com/dfinity/ic/pull/3752) are related.