### PR TITLE
feat(EXC-1930): Add a metric tracking Wasm code section sizes

### DIFF
--- a/rs/embedders/src/lib.rs
+++ b/rs/embedders/src/lib.rs
@@ -56,6 +56,8 @@ pub struct CompilationResult {
     pub compilation_time: Duration,
     /// The maximum function complexity found in the canister's wasm module.
     pub max_complexity: u64,
+    /// The size of this Wasm module's code section.
+    pub code_section_size: NumBytes,
 }
 
 impl CompilationResult {
@@ -64,6 +66,7 @@ impl CompilationResult {
             largest_function_instruction_count: NumInstructions::new(0),
             compilation_time: Duration::from_millis(1),
             max_complexity: 0,
+            code_section_size: NumBytes::from(0),
         }
     }
 }

--- a/rs/embedders/src/wasm_utils.rs
+++ b/rs/embedders/src/wasm_utils.rs
@@ -10,7 +10,7 @@ use ic_replicated_state::{
     EmbedderCache, NumWasmPages, PageIndex,
 };
 use ic_sys::{PageBytes, PAGE_SIZE};
-use ic_types::{methods::WasmMethod, NumInstructions};
+use ic_types::{methods::WasmMethod, NumBytes, NumInstructions};
 use ic_wasm_types::{BinaryEncodedWasm, WasmInstrumentationError};
 use serde::{Deserialize, Serialize};
 
@@ -48,6 +48,7 @@ pub struct WasmValidationDetails {
     pub wasm_metadata: WasmMetadata,
     pub largest_function_instruction_count: NumInstructions,
     pub max_complexity: Complexity,
+    pub code_section_size: NumBytes,
 }
 
 #[derive(Clone, Eq, PartialEq, Debug, Deserialize, Serialize)]
@@ -249,6 +250,7 @@ fn compile_inner(
     let largest_function_instruction_count =
         wasm_validation_details.largest_function_instruction_count;
     let max_complexity = wasm_validation_details.max_complexity.0;
+    let code_section_size = wasm_validation_details.code_section_size;
 
     let is_wasm64 = module
         .get_export(crate::wasmtime_embedder::WASM_HEAP_MEMORY_NAME)
@@ -266,6 +268,7 @@ fn compile_inner(
             largest_function_instruction_count,
             compilation_time: timer.elapsed(),
             max_complexity,
+            code_section_size,
         },
         serialized_module,
     ))

--- a/rs/embedders/src/wasm_utils/validation.rs
+++ b/rs/embedders/src/wasm_utils/validation.rs
@@ -1521,7 +1521,7 @@ fn can_compile(
     })
 }
 
-fn check_code_section_size(wasm: &BinaryEncodedWasm) -> Result<(), WasmValidationError> {
+fn check_code_section_size(wasm: &BinaryEncodedWasm) -> Result<NumBytes, WasmValidationError> {
     let parser = wasmparser::Parser::new(0);
     let payloads = parser.parse_all(wasm.as_slice());
     for payload in payloads {
@@ -1538,11 +1538,11 @@ fn check_code_section_size(wasm: &BinaryEncodedWasm) -> Result<(), WasmValidatio
                     allowed: MAX_CODE_SECTION_SIZE_IN_BYTES,
                 });
             } else {
-                return Ok(());
+                return Ok(NumBytes::from(size as u64));
             }
         }
     }
-    Ok(())
+    Ok(NumBytes::from(0))
 }
 
 /// Validates a Wasm binary against the requirements of the interface spec
@@ -1564,7 +1564,7 @@ pub(super) fn validate_wasm_binary<'a>(
     wasm: &'a BinaryEncodedWasm,
     config: &EmbeddersConfig,
 ) -> Result<(WasmValidationDetails, Module<'a>), WasmValidationError> {
-    check_code_section_size(wasm)?;
+    let code_section_size = check_code_section_size(wasm)?;
     can_compile(wasm, config)?;
     let module = Module::parse(wasm.as_slice(), false)
         .map_err(|err| WasmValidationError::DecodingError(format!("{}", err)))?;
@@ -1593,6 +1593,7 @@ pub(super) fn validate_wasm_binary<'a>(
             wasm_metadata,
             largest_function_instruction_count,
             max_complexity,
+            code_section_size,
         },
         module,
     ))

--- a/rs/embedders/tests/validation.rs
+++ b/rs/embedders/tests/validation.rs
@@ -104,6 +104,7 @@ fn can_validate_valid_export_section() {
         Ok(WasmValidationDetails {
             largest_function_instruction_count: NumInstructions::new(1),
             max_complexity: Complexity(1),
+            code_section_size: NumBytes::from(3),
             ..Default::default()
         })
     );
@@ -431,6 +432,7 @@ fn can_validate_many_exported_functions() {
         Ok(WasmValidationDetails {
             largest_function_instruction_count: NumInstructions::new(1),
             max_complexity: Complexity(1),
+            code_section_size: NumBytes::from(3),
             ..Default::default()
         })
     );
@@ -467,6 +469,7 @@ fn can_validate_large_sum_exported_function_name_lengths() {
         Ok(WasmValidationDetails {
             largest_function_instruction_count: NumInstructions::new(1),
             max_complexity: Complexity(1),
+            code_section_size: NumBytes::from(3),
             ..Default::default()
         })
     );
@@ -510,6 +513,7 @@ fn can_validate_canister_query_update_method_name_with_whitespace() {
         Ok(WasmValidationDetails {
             largest_function_instruction_count: NumInstructions::new(1),
             max_complexity: Complexity(1),
+            code_section_size: NumBytes::from(3),
             ..Default::default()
         })
     );

--- a/rs/execution_environment/src/hypervisor.rs
+++ b/rs/execution_environment/src/hypervisor.rs
@@ -13,7 +13,7 @@ use ic_interfaces::execution_environment::{
 use ic_interfaces_state_manager::StateReader;
 use ic_logger::ReplicaLogger;
 use ic_management_canister_types_private::LogVisibilityV2;
-use ic_metrics::buckets::decimal_buckets_with_zero;
+use ic_metrics::buckets::{decimal_buckets_with_zero, linear_buckets};
 use ic_metrics::{buckets::exponential_buckets, MetricsRegistry};
 use ic_registry_subnet_type::SubnetType;
 use ic_replicated_state::{page_map::allocated_pages_count, ExecutionState, SystemState};
@@ -51,6 +51,7 @@ pub struct HypervisorMetrics {
     mprotect_count: HistogramVec,
     copy_page_count: HistogramVec,
     compilation_cache_size: IntGaugeVec,
+    code_section_size: Histogram,
 }
 
 impl HypervisorMetrics {
@@ -127,6 +128,11 @@ impl HypervisorMetrics {
             ),
             compilation_cache_size: metrics_registry.int_gauge_vec("hypervisor_compilation_cache_size", "Bytes in memory and on disk used by the compilation cache.", &["location"],
             ),
+            code_section_size: metrics_registry.histogram(
+                "hypervisor_code_section_size",
+                "Size of the code section in bytes for a canister Wasm. Only Wasms that successfully compile are counted (which implies the code sections are below the current limit).",
+                linear_buckets(1024.0 * 1024.0, 1024.0 * 1204.0, 10), // 1MiB, 2MiB, ..., 10 MiB. Current limit is 10 MiB.
+            ),
         }
     }
 
@@ -197,11 +203,14 @@ impl HypervisorMetrics {
             largest_function_instruction_count,
             compilation_time,
             max_complexity,
+            code_section_size,
         } = compilation_result;
         self.largest_function_instruction_count
             .observe(largest_function_instruction_count.get() as f64);
         self.compile.observe(compilation_time.as_secs_f64());
         self.max_complexity.observe(*max_complexity as f64);
+        self.code_section_size
+            .observe(code_section_size.get() as f64);
         self.compilation_cache_size
             .with_label_values(&["memory"])
             .set(cache_memory_size as i64);


### PR DESCRIPTION
EXC-1930

There is currently a limit on Wasm code section sizes of 10 MiB. In order to see how often users are getting close to the limit, we add a histogram metric which tracks this value each time a Wasm is compiled.