### PR TITLE
refactor(EXC-1905): Take cycles from call context when a refund is to be returned

### DIFF
--- a/rs/replicated_state/src/canister_state/system_state/call_context_manager.rs
+++ b/rs/replicated_state/src/canister_state/system_state/call_context_manager.rs
@@ -123,6 +123,11 @@ impl CallContext {
         self.responded = true;
     }
 
+    /// Takes the available cycles out of the call context and returns them.
+    fn take_available_cycles(&mut self) -> Cycles {
+        self.available_cycles.take()
+    }
+
     /// The point in time at which the call context was created.
     pub fn time(&self) -> Time {
         self.time
@@ -690,18 +695,18 @@ impl CallContextManager {
 
             (Ok(None), Responded::No, OutstandingCalls::No) => {
                 self.stats.on_call_context_response(&context.call_origin);
-                let refund = context.available_cycles;
+                let refund = context.take_available_cycles();
                 (CallContextAction::NoResponse { refund }, Some(context))
             }
 
             (Ok(Some(WasmResult::Reply(payload))), Responded::No, OutstandingCalls::No) => {
                 self.stats.on_call_context_response(&context.call_origin);
-                let refund = context.available_cycles;
+                let refund = context.take_available_cycles();
                 (CallContextAction::Reply { payload, refund }, Some(context))
             }
             (Ok(Some(WasmResult::Reply(payload))), Responded::No, OutstandingCalls::Yes) => {
                 self.stats.on_call_context_response(&context.call_origin);
-                let refund = context.available_cycles;
+                let refund = context.take_available_cycles();
                 context.mark_responded();
                 self.call_contexts.insert(call_context_id, context);
                 (CallContextAction::Reply { payload, refund }, None)
@@ -709,12 +714,12 @@ impl CallContextManager {
 
             (Ok(Some(WasmResult::Reject(payload))), Responded::No, OutstandingCalls::No) => {
                 self.stats.on_call_context_response(&context.call_origin);
-                let refund = context.available_cycles;
+                let refund = context.take_available_cycles();
                 (CallContextAction::Reject { payload, refund }, Some(context))
             }
             (Ok(Some(WasmResult::Reject(payload))), Responded::No, OutstandingCalls::Yes) => {
                 self.stats.on_call_context_response(&context.call_origin);
-                let refund = context.available_cycles;
+                let refund = context.take_available_cycles();
                 context.mark_responded();
                 self.call_contexts.insert(call_context_id, context);
                 (CallContextAction::Reject { payload, refund }, None)
@@ -722,7 +727,7 @@ impl CallContextManager {
 
             (Err(error), Responded::No, OutstandingCalls::No) => {
                 self.stats.on_call_context_response(&context.call_origin);
-                let refund = context.available_cycles;
+                let refund = context.take_available_cycles();
                 (CallContextAction::Fail { error, refund }, Some(context))
             }
 

--- a/rs/system_api/src/lib.rs
+++ b/rs/system_api/src/lib.rs
@@ -1469,14 +1469,6 @@ impl SystemApiImpl {
         max_amount: Cycles,
     ) -> HypervisorResult<Cycles> {
         match &mut self.api_type {
-            ApiType::ReplyCallback {
-                response_status: ResponseStatus::AlreadyReplied,
-                ..
-            }
-            | ApiType::RejectCallback {
-                response_status: ResponseStatus::AlreadyReplied,
-                ..
-            } => Ok(Cycles::new(0)),
             ApiType::Start { .. }
             | ApiType::Init { .. }
             | ApiType::SystemTask { .. }


### PR DESCRIPTION
This change makes it more clear that whenever a refund needs to be computed when processing a result of a canister execution, the available cycles in the call context would need to be emptied. This is important to maintain spec compliance and disallow accepting cycles after the call has been replied to.

In the current version of the code, this was not happening in the call context manager and instead we kinda relied on some logic in the system API that would return 0 cycles can be accepted when the call was already responded (without looking anything up in the call context). This is a bit error prone as two different components are attempting to uphold a property. In fact, we had filed a bug ticket thinking that we are not properly maintaining spec compliance in this case. This was incorrect but it shows that the current version of the code is hard to verify (especially if one only looks at one place, namely the call context manager).

With the changes here the logic of clearing the available cycles remains encapsulated in the call context manager module and the system api will always look up the cycles in the call context without any special cases.