### PR TITLE
chore(idx): don't upload artifacts on PRs to rc-*

### DIFF
--- a/.github/actions/bazel-test-all/action.yaml
+++ b/.github/actions/bazel-test-all/action.yaml
@@ -69,7 +69,6 @@ runs:
           BUILDEVENT_APIKEY: ${{ inputs.BUILDEVENT_APIKEY }}
           CI_EVENT_NAME: ${{ github.event_name }}
           CI_JOB_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          CI_PULL_REQUEST_TARGET_BRANCH_NAME: ${{ github.event.pull_request.base.ref }}
           MERGE_BASE_SHA: ${{ github.event.pull_request.base.sha }}
           SSH_PRIVATE_KEY_BACKUP_POD: ${{ inputs.SSH_PRIVATE_KEY_BACKUP_POD }}
           GPG_PASSPHRASE: ${{ inputs.GPG_PASSPHRASE }}

--- a/ci/bazel-scripts/main.sh
+++ b/ci/bazel-scripts/main.sh
@@ -23,7 +23,7 @@ done
 
 # if we are on a protected branch or targeting a rc branch we set release build, ic_version to the commit_sha and
 # upload to s3
-if [[ "${IS_PROTECTED_BRANCH:-}" == "true" ]] || [[ "${CI_PULL_REQUEST_TARGET_BRANCH_NAME:-}" == "rc--"* ]]; then
+if [[ "${IS_PROTECTED_BRANCH:-}" == "true" ]]; then
     ic_version_rc_only="${CI_COMMIT_SHA}"
     s3_upload="True"
     release_build="true"

--- a/ci/src/git_changes/git_changes.py
+++ b/ci/src/git_changes/git_changes.py
@@ -23,8 +23,7 @@ import git
 
 
 def target_branch() -> str:
-    default_branch = os.getenv("CI_DEFAULT_BRANCH", "master")
-    return os.getenv("CI_PULL_REQUEST_TARGET_BRANCH_NAME", default_branch)
+    return os.getenv("CI_DEFAULT_BRANCH", "master")
 
 
 def git_fetch_target_branch(git_repo, max_attempts=10):


### PR DESCRIPTION
This stops uploading artifacts to S3 when a PR is targetting an `rc-*` branch.

We did this at some point as an experiment but we don't have a use case for this anymore.