### PR TITLE
fix: EXC-1889 Hook condition should be checked after every mgmt canister call

### DIFF
--- a/rs/execution_environment/src/canister_manager.rs
+++ b/rs/execution_environment/src/canister_manager.rs
@@ -645,7 +645,6 @@ impl CanisterManager {
         }
         // Change of `wasm_memory_limit` or `new_wasm_memory_threshold` or `memory_allocation`,
         // can influence the satisfaction of the condition for `low_wasm_memory` hook.
-        canister.update_on_low_wasm_memory_hook_condition();
     }
 
     /// Tries to apply the requested settings on the canister identified by
@@ -875,10 +874,7 @@ impl CanisterManager {
                 message: _,
                 instructions_used,
                 result,
-            } => {
-                canister.update_on_low_wasm_memory_hook_condition();
-                (result, instructions_used, Some(canister))
-            }
+            } => (result, instructions_used, Some(canister)),
             DtsInstallCodeResult::Paused {
                 canister: _,
                 paused_execution,

--- a/rs/execution_environment/src/canister_manager.rs
+++ b/rs/execution_environment/src/canister_manager.rs
@@ -875,8 +875,6 @@ impl CanisterManager {
                 instructions_used,
                 result,
             } => {
-                // This is requeired since IC0::InstallCode and IC0::InstallChunkedCode
-                // are the only two management canister execution types that use DTS.
                 canister.update_on_low_wasm_memory_hook_condition();
                 (result, instructions_used, Some(canister))
             }

--- a/rs/execution_environment/src/canister_manager.rs
+++ b/rs/execution_environment/src/canister_manager.rs
@@ -874,7 +874,12 @@ impl CanisterManager {
                 message: _,
                 instructions_used,
                 result,
-            } => (result, instructions_used, Some(canister)),
+            } => {
+                // This is requeired since IC0::InstallCode and IC0::InstallChunkedCode
+                // are the only two management canister execution types that use DTS.
+                canister.update_on_low_wasm_memory_hook_condition();
+                (result, instructions_used, Some(canister))
+            }
             DtsInstallCodeResult::Paused {
                 canister: _,
                 paused_execution,

--- a/rs/execution_environment/src/canister_manager.rs
+++ b/rs/execution_environment/src/canister_manager.rs
@@ -643,8 +643,6 @@ impl CanisterManager {
         if let Some(wasm_memory_limit) = settings.wasm_memory_limit() {
             canister.system_state.wasm_memory_limit = Some(wasm_memory_limit);
         }
-        // Change of `wasm_memory_limit` or `new_wasm_memory_threshold` or `memory_allocation`,
-        // can influence the satisfaction of the condition for `low_wasm_memory` hook.
     }
 
     /// Tries to apply the requested settings on the canister identified by

--- a/rs/execution_environment/src/canister_manager/tests.rs
+++ b/rs/execution_environment/src/canister_manager/tests.rs
@@ -8146,19 +8146,17 @@ fn helper_update_settings_updates_hook_status(
         initial_memory_state.hook_status
     );
 
-    let mut updated_settings = CanisterSettingsArgsBuilder::new();
+    let mut settings = CanisterSettingsArgsBuilder::new();
 
     if updated_memory_state.wasm_memory_threshold != initial_memory_state.wasm_memory_threshold {
         if let Some(updated_wasm_memory_threshold) = updated_memory_state.wasm_memory_threshold {
-            updated_settings =
-                updated_settings.with_wasm_memory_threshold(updated_wasm_memory_threshold.get());
+            settings = settings.with_wasm_memory_threshold(updated_wasm_memory_threshold.get());
         }
     }
 
     if updated_memory_state.wasm_memory_limit != initial_memory_state.wasm_memory_limit {
         if let Some(updated_wasm_memory_limit) = updated_memory_state.wasm_memory_limit {
-            updated_settings =
-                updated_settings.with_wasm_memory_limit(updated_wasm_memory_limit.get());
+            settings = settings.with_wasm_memory_limit(updated_wasm_memory_limit.get());
         }
     }
 
@@ -8166,14 +8164,13 @@ fn helper_update_settings_updates_hook_status(
         if let Some(MemoryAllocation::Reserved(updated_memory_allocation)) =
             updated_memory_state.memory_allocation
         {
-            updated_settings =
-                updated_settings.with_memory_allocation(updated_memory_allocation.get());
+            settings = settings.with_memory_allocation(updated_memory_allocation.get());
         }
     }
 
     let payload = UpdateSettingsArgs {
         canister_id: canister_id.get(),
-        settings: updated_settings.build(),
+        settings: settings.build(),
         sender_canister_version: None,
     }
     .encode();

--- a/rs/execution_environment/src/canister_manager/tests.rs
+++ b/rs/execution_environment/src/canister_manager/tests.rs
@@ -8103,118 +8103,91 @@ fn helper_update_settings_updates_hook_status(
     updated_memory_state: MemoryState,
     execute_hook_after_install: bool,
 ) {
-    with_setup(|canister_manager, mut state, subnet_id| {
-        let mut round_limits = RoundLimits {
-            instructions: as_round_instructions(EXECUTION_PARAMETERS.instruction_limits.message()),
-            subnet_available_memory: (*MAX_SUBNET_AVAILABLE_MEMORY),
-            subnet_available_callbacks: SUBNET_CALLBACK_SOFT_LIMIT as i64,
-            compute_allocation_used: state.total_compute_allocation(),
-        };
+    let mut test = ExecutionTestBuilder::new().build();
 
-        let wat = format!("(module (memory {used_wasm_memory_pages}))");
+    let mut initial_settings = CanisterSettingsArgsBuilder::new();
 
-        let wasm = wat::parse_str(wat).unwrap();
+    if let Some(MemoryAllocation::Reserved(memory_allocation)) =
+        initial_memory_state.memory_allocation
+    {
+        initial_settings = initial_settings.with_memory_allocation(memory_allocation.get());
+    }
 
-        let sender = canister_test_id(100).get();
+    if let Some(wasm_memory_limit) = initial_memory_state.wasm_memory_limit {
+        initial_settings = initial_settings.with_wasm_memory_limit(wasm_memory_limit.get());
+    }
 
-        let initial_settings = CanisterSettings {
-            wasm_memory_limit: initial_memory_state.wasm_memory_limit,
-            wasm_memory_threshold: initial_memory_state.wasm_memory_threshold,
-            memory_allocation: initial_memory_state.memory_allocation,
-            ..Default::default()
-        };
+    if let Some(wasm_memory_threshold) = initial_memory_state.wasm_memory_threshold {
+        initial_settings = initial_settings.with_wasm_memory_threshold(wasm_memory_threshold.get());
+    }
 
-        let canister_id = canister_manager
-            .create_canister(
-                canister_change_origin_from_principal(&sender),
-                subnet_id,
-                *INITIAL_CYCLES,
-                initial_settings,
-                MAX_NUMBER_OF_CANISTERS,
-                &mut state,
-                SMALL_APP_SUBNET_MAX_SIZE,
-                &mut round_limits,
-                ResourceSaturation::default(),
-                &no_op_counter(),
-            )
-            .0
-            .unwrap();
+    let canister_id = test
+        .create_canister_with_settings(*INITIAL_CYCLES, initial_settings.build())
+        .unwrap();
 
-        let res = install_code(
-            &canister_manager,
-            InstallCodeContext {
-                origin: canister_change_origin_from_principal(&sender),
-                canister_id,
-                wasm_source: WasmSource::CanisterModule(CanisterModule::new(wasm)),
-                arg: vec![],
-                compute_allocation: None,
-                memory_allocation: None,
-                mode: CanisterInstallModeV2::Install,
-            },
-            &mut state,
-            &mut round_limits,
-        );
-        assert!(res.1.is_ok(), "{:?}", res.1);
+    let wat = format!("(module (memory {used_wasm_memory_pages}))");
 
-        let mut c_state = res.2.unwrap();
+    let wasm = wat::parse_str(wat).unwrap();
 
-        if execute_hook_after_install {
-            c_state.system_state.task_queue.pop_front();
+    test.install_canister(canister_id, wasm).unwrap();
+
+    if execute_hook_after_install {
+        test.canister_state_mut(canister_id)
+            .system_state
+            .task_queue
+            .pop_front();
+    }
+
+    assert_eq!(
+        test.canister_state_mut(canister_id)
+            .system_state
+            .task_queue
+            .peek_hook_status(),
+        initial_memory_state.hook_status
+    );
+
+    let mut updated_settings = CanisterSettingsArgsBuilder::new();
+
+    if updated_memory_state.wasm_memory_threshold != initial_memory_state.wasm_memory_threshold {
+        if let Some(updated_wasm_memory_threshold) = updated_memory_state.wasm_memory_threshold {
+            updated_settings =
+                updated_settings.with_wasm_memory_threshold(updated_wasm_memory_threshold.get());
         }
+    }
 
-        assert_eq!(
-            c_state.system_state.task_queue.peek_hook_status(),
-            initial_memory_state.hook_status
-        );
+    if updated_memory_state.wasm_memory_limit != initial_memory_state.wasm_memory_limit {
+        if let Some(updated_wasm_memory_limit) = updated_memory_state.wasm_memory_limit {
+            updated_settings =
+                updated_settings.with_wasm_memory_limit(updated_wasm_memory_limit.get());
+        }
+    }
 
-        state.put_canister_state(c_state);
-
-        let mut settings = CanisterSettingsBuilder::new();
-
-        if updated_memory_state.wasm_memory_threshold != initial_memory_state.wasm_memory_threshold
+    if updated_memory_state.memory_allocation != initial_memory_state.memory_allocation {
+        if let Some(MemoryAllocation::Reserved(updated_memory_allocation)) =
+            updated_memory_state.memory_allocation
         {
-            if let Some(updated_wasm_memory_threshold) = updated_memory_state.wasm_memory_threshold
-            {
-                settings = settings.with_wasm_memory_threshold(updated_wasm_memory_threshold);
-            }
+            updated_settings =
+                updated_settings.with_memory_allocation(updated_memory_allocation.get());
         }
+    }
 
-        if updated_memory_state.wasm_memory_limit != initial_memory_state.wasm_memory_limit {
-            if let Some(updated_wasm_memory_limit) = updated_memory_state.wasm_memory_limit {
-                settings = settings.with_wasm_memory_limit(updated_wasm_memory_limit);
-            }
-        }
+    let payload = UpdateSettingsArgs {
+        canister_id: canister_id.get(),
+        settings: updated_settings.build(),
+        sender_canister_version: None,
+    }
+    .encode();
 
-        if updated_memory_state.memory_allocation != initial_memory_state.memory_allocation {
-            if let Some(updated_memory_allocation) = updated_memory_state.memory_allocation {
-                settings = settings.with_memory_allocation(updated_memory_allocation);
-            }
-        }
+    test.subnet_message(Method::UpdateSettings, payload)
+        .unwrap();
 
-        let canister = state.canister_state_mut(&canister_id).unwrap();
-
-        assert!(canister_manager
-            .update_settings(
-                Time::from_nanos_since_unix_epoch(777),
-                canister_change_origin_from_principal(&sender),
-                settings.build(),
-                canister,
-                &mut round_limits,
-                ResourceSaturation::default(),
-                SMALL_APP_SUBNET_MAX_SIZE,
-            )
-            .is_ok());
-
-        assert_eq!(
-            state
-                .canister_state_mut(&canister_id)
-                .unwrap()
-                .system_state
-                .task_queue
-                .peek_hook_status(),
-            updated_memory_state.hook_status
-        );
-    })
+    assert_eq!(
+        test.canister_state_mut(canister_id)
+            .system_state
+            .task_queue
+            .peek_hook_status(),
+        updated_memory_state.hook_status
+    );
 }
 
 #[test]

--- a/rs/execution_environment/src/execution_environment.rs
+++ b/rs/execution_environment/src/execution_environment.rs
@@ -1580,8 +1580,6 @@ impl ExecutionEnvironment {
         // Note that some branches above have early returns:
         //   - `InstallCode`
         //   - `InstallChunkedCode`
-        //   - `TakeCanisterSnapshot`
-        //   - `LoadCanisterSnapshot`
         //   - `SignWithECDSA`
         // If you modify code below, please also update
         // these cases.

--- a/rs/execution_environment/src/execution_environment.rs
+++ b/rs/execution_environment/src/execution_environment.rs
@@ -1636,9 +1636,9 @@ impl ExecutionEnvironment {
                 let res = match response {
                     Ok((res, canister_id)) => {
                         if let Some(canister_id) = canister_id {
-                            state.canister_state_mut(canister_id).map(|canister_state| {
+                            if let Some(canister_state) = state.canister_state_mut(canister_id) {
                                 canister_state.update_on_low_wasm_memory_hook_condition()
-                            });
+                            }
                         }
                         Ok(res)
                     }

--- a/rs/execution_environment/src/execution_environment.rs
+++ b/rs/execution_environment/src/execution_environment.rs
@@ -511,6 +511,8 @@ impl ExecutionEnvironment {
     ) -> (ReplicatedState, Option<NumInstructions>) {
         let since = Instant::now(); // Start logging execution time.
 
+        let canister_id_rec = msg.effective_canister_id();
+
         let mut msg = match msg {
             CanisterMessage::Response(response) => {
                 let context = state
@@ -1572,6 +1574,12 @@ impl ExecutionEnvironment {
             }
         };
 
+        if let Some(canister_id) = canister_id_rec {
+            println!("Here: {}", canister_id);
+            if let Some(canister_state) = state.canister_state_mut(&canister_id) {
+                canister_state.update_on_low_wasm_memory_hook_condition();
+            }
+        }
         // Note that some branches above have early returns:
         //   - `InstallCode`
         //   - `InstallChunkedCode`
@@ -3121,7 +3129,6 @@ impl ExecutionEnvironment {
                         Err(err.into())
                     }
                 };
-                canister.update_on_low_wasm_memory_hook_condition();
                 state.put_canister_state(canister);
                 let refund = message.take_cycles();
                 // The message can be removed because a response was produced.

--- a/rs/execution_environment/src/execution_environment.rs
+++ b/rs/execution_environment/src/execution_environment.rs
@@ -1637,7 +1637,7 @@ impl ExecutionEnvironment {
                     Ok((res, canister_id)) => {
                         if let Some(canister_id) = canister_id {
                             if let Some(canister_state) = state.canister_state_mut(canister_id) {
-                                canister_state.update_on_low_wasm_memory_hook_condition()
+                                canister_state.update_on_low_wasm_memory_hook_condition();
                             }
                         }
                         Ok(res)

--- a/rs/execution_environment/src/execution_environment.rs
+++ b/rs/execution_environment/src/execution_environment.rs
@@ -1575,7 +1575,6 @@ impl ExecutionEnvironment {
         };
 
         if let Some(canister_id) = canister_id_rec {
-            println!("Here: {}", canister_id);
             if let Some(canister_state) = state.canister_state_mut(&canister_id) {
                 canister_state.update_on_low_wasm_memory_hook_condition();
             }
@@ -3129,6 +3128,9 @@ impl ExecutionEnvironment {
                         Err(err.into())
                     }
                 };
+                // This is requeired since IC0::InstallCode and IC0::InstallChunkedCode
+                // are the only two management canister execution types that use DTS.
+                canister.update_on_low_wasm_memory_hook_condition();
                 state.put_canister_state(canister);
                 let refund = message.take_cycles();
                 // The message can be removed because a response was produced.

--- a/rs/execution_environment/src/execution_environment.rs
+++ b/rs/execution_environment/src/execution_environment.rs
@@ -1636,9 +1636,9 @@ impl ExecutionEnvironment {
                 let res = match response {
                     Ok((res, canister_id)) => {
                         if let Some(canister_id) = canister_id {
-                            if let Some(canister_state) = state.canister_state_mut(canister_id) {
-                                canister_state.update_on_low_wasm_memory_hook_condition();
-                            }
+                            state.canister_state_mut(canister_id).map(|canister_state| {
+                                canister_state.update_on_low_wasm_memory_hook_condition()
+                            });
                         }
                         Ok(res)
                     }

--- a/rs/execution_environment/src/execution_environment/tests.rs
+++ b/rs/execution_environment/src/execution_environment/tests.rs
@@ -718,7 +718,7 @@ fn get_canister_status_from_another_canister_when_memory_low() {
     let controller = test.universal_canister().unwrap();
     let binary = wat::parse_str("(module)").unwrap();
     let canister = test.create_canister(Cycles::new(1_000_000_000_000));
-    let memory_allocation = NumBytes::from(300);
+    let memory_allocation = NumBytes::from(450);
     test.install_canister_with_allocation(canister, binary, None, Some(memory_allocation.get()))
         .unwrap();
     let canister_status_args = Encode!(&CanisterIdRecord::from(canister)).unwrap();

--- a/rs/replicated_state/src/canister_state/system_state/task_queue.rs
+++ b/rs/replicated_state/src/canister_state/system_state/task_queue.rs
@@ -391,12 +391,6 @@ pub fn is_low_wasm_memory_hook_condition_satisfied(
     let wasm_capacity = memory_allocation.map_or_else(
         || wasm_memory_limit,
         |memory_allocation| {
-            debug_assert!(
-                memory_usage_without_wasm_memory <= memory_allocation,
-                "Used non-Wasm memory: {:?} is larger than memory allocation: {:?}.",
-                memory_usage_without_wasm_memory,
-                memory_allocation
-            );
             std::cmp::min(
                 memory_allocation.saturating_sub(&memory_usage_without_wasm_memory),
                 wasm_memory_limit,


### PR DESCRIPTION
This PR ensures that the condition for a low-wasm memory hook will be met after every mgmt canister call.
Since we already have tests that condition is checked after Updating settings and Installing code, we will only add tests that snapshot operations influence hook in the floow-up https://github.com/dfinity/ic/pull/4023/files.