### PR TITLE
chore(ckbtc): proposal to upgrade ckbtc minter

### DIFF
--- a/rs/bitcoin/ckbtc/mainnet/minter_upgrade_2025_02_12.md
+++ b/rs/bitcoin/ckbtc/mainnet/minter_upgrade_2025_02_12.md
@@ -1,0 +1,39 @@
+# Proposal to upgrade the ckBTC minter canister
+
+Repository: `git@github.com:dfinity/ic-private.git`
+
+Git hash: `41cba4e8db84de1cc79c26ddf7377b52e41de30a`
+
+New compressed Wasm hash: `ece9b7e0b7565071461cba2e67c823821c5423c818066b32d0b9fae314296d51`
+
+Upgrade args hash: `445734292959382834da46c68370d87f8117d50271f6b8a97d5eb8dadac8cb94`
+
+Target canister: `mqygn-kiaaa-aaaar-qaadq-cai`
+
+Previous ckBTC minter proposal: https://dashboard.internetcomputer.org/proposal/135200
+
+---
+
+## Motivation
+
+Fix a potential vulnerability in ckBTC minter that was discovered during an internal security review.
+
+## Upgrade args
+
+```
+git fetch
+git checkout 41cba4e8db84de1cc79c26ddf7377b52e41de30a
+cd rs/bitcoin/ckbtc/minter
+didc encode -d ckbtc_minter.did -t '(MinterArg)' '(variant { Upgrade = null })' | xxd -r -p | sha256sum
+```
+
+## Wasm Verification
+
+Verify that the hash of the gzipped WASM matches the proposed hash.
+
+```
+git fetch
+git checkout 41cba4e8db84de1cc79c26ddf7377b52e41de30a
+"./ci/container/build-ic.sh" "--canisters"
+sha256sum ./artifacts/canisters/ic-ckbtc-minter.wasm.gz
+```

--- a/rs/bitcoin/ckbtc/mainnet/minter_upgrade_2025_02_12.md
+++ b/rs/bitcoin/ckbtc/mainnet/minter_upgrade_2025_02_12.md
@@ -1,39 +1,7 @@
 # Proposal to upgrade the ckBTC minter canister
 
-Repository: `git@github.com:dfinity/ic-private.git`
+In accordance with the Security Patch Policy and Procedure that was adopted in proposal [48792](https://dashboard.internetcomputer.org/proposal/48792), the source code that was used to build this canister release will be exposed at the latest 10 days after the fix is rolled out.
 
-Git hash: `41cba4e8db84de1cc79c26ddf7377b52e41de30a`
+The community will be able to retroactively verify the wasm binaries that were rolled out.
 
-New compressed Wasm hash: `ece9b7e0b7565071461cba2e67c823821c5423c818066b32d0b9fae314296d51`
-
-Upgrade args hash: `445734292959382834da46c68370d87f8117d50271f6b8a97d5eb8dadac8cb94`
-
-Target canister: `mqygn-kiaaa-aaaar-qaadq-cai`
-
-Previous ckBTC minter proposal: https://dashboard.internetcomputer.org/proposal/135200
-
----
-
-## Motivation
-
-Fix a potential vulnerability in ckBTC minter that was discovered during an internal security review.
-
-## Upgrade args
-
-```
-git fetch
-git checkout 41cba4e8db84de1cc79c26ddf7377b52e41de30a
-cd rs/bitcoin/ckbtc/minter
-didc encode -d ckbtc_minter.did -t '(MinterArg)' '(variant { Upgrade = null })' | xxd -r -p | sha256sum
-```
-
-## Wasm Verification
-
-Verify that the hash of the gzipped WASM matches the proposed hash.
-
-```
-git fetch
-git checkout 41cba4e8db84de1cc79c26ddf7377b52e41de30a
-"./ci/container/build-ic.sh" "--canisters"
-sha256sum ./artifacts/canisters/ic-ckbtc-minter.wasm.gz
-```
+Forum post link: https://forum.dfinity.org/t/ckbtc-a-canister-issued-bitcoin-twin-token-on-the-ic-1-1-backed-by-btc/17606/190


### PR DESCRIPTION
This was [the security fix](https://dashboard.internetcomputer.org/proposal/135282)  that has already been adopted by NNS.

Verification instructions:

```
git checkout ddf05d2c70905a99b54c63520b69deef6a4fcc48
"./ci/container/build-ic.sh" "--canisters"
sha256sum ./artifacts/canisters/ic-ckbtc-minter.wasm.gz
```