### PR TITLE
test(ICP_Rosetta): FI-1678: Set timeout to long for Rosetta ICP integration tests

### DIFF
--- a/rs/rosetta-api/icp/tests/integration_tests/BUILD.bazel
+++ b/rs/rosetta-api/icp/tests/integration_tests/BUILD.bazel
@@ -37,6 +37,7 @@ rust_library(
 
 rust_test_suite(
     name = "rosetta-integration",
+    timeout = "long",
     srcs = ["tests/tests.rs"],
     data = [
         "//rs/canister_sandbox",


### PR DESCRIPTION
The ICP Rosetta integration tests continue to have a flakiness rate of around 2,32%. In the failure cases, it is usually [`test_rosetta_blocks_mode_enabled`](https://sourcegraph.com/github.com/dfinity/ic@edcb5ab41a0faa2801b93a9560b6f7f9a58b033d/-/blob/rs/rosetta-api/icp/tests/integration_tests/tests/tests.rs?L419-421) timing out after 5min. This PR proposes to bump the timeout in an attempt to address the flakiness.