### PR TITLE
feat(MR): [MR-661] Expose best-effort memory usage

### DIFF
--- a/rs/replicated_state/tests/replicated_state.rs
+++ b/rs/replicated_state/tests/replicated_state.rs
@@ -364,7 +364,7 @@ fn memory_taken_by_subnet_queues() {
     assert_canister_history_memory_taken(0, &fixture);
     assert_wasm_custom_sections_memory_taken(0, &fixture);
 
-    // Push a request into the subnet input queues.
+    // Push a guaranteed resoibse request into the subnet input queues.
     assert!(fixture
         .state
         .push_input(
@@ -538,7 +538,7 @@ fn push_subnet_queues_input_respects_subnet_available_memory() {
     assert_canister_history_memory_taken(0, &fixture);
     assert_wasm_custom_sections_memory_taken(0, &fixture);
 
-    // Push a request into the subnet input queues.
+    // Push a guarnteed response request into the subnet input queues.
     assert!(fixture
         .state
         .push_input(
@@ -558,13 +558,13 @@ fn push_subnet_queues_input_respects_subnet_available_memory() {
         subnet_available_memory,
     );
 
-    // Push a second request into the subnet input queues.
+    // Push a second guaranteed response request into the subnet input queues.
     let res = fixture.state.push_input(
         request_to(SUBNET_ID.into()).into(),
         &mut subnet_available_memory,
     );
 
-    // No more memory for a second request.
+    // No more memory for a second guaranteed response request.
     assert_eq!(
         Err((
             StateError::OutOfMemory {

--- a/rs/replicated_state/tests/replicated_state.rs
+++ b/rs/replicated_state/tests/replicated_state.rs
@@ -58,10 +58,26 @@ fn request_from(canister_id: CanisterId) -> Request {
         .build()
 }
 
+fn best_effort_request_from(canister_id: CanisterId) -> Request {
+    RequestBuilder::default()
+        .sender(canister_id)
+        .receiver(CANISTER_ID)
+        .deadline(SOME_DEADLINE)
+        .build()
+}
+
 fn request_to(canister_id: CanisterId) -> Request {
     RequestBuilder::default()
         .sender(CANISTER_ID)
         .receiver(canister_id)
+        .build()
+}
+
+fn best_effort_request_to(canister_id: CanisterId) -> Request {
+    RequestBuilder::default()
+        .sender(CANISTER_ID)
+        .receiver(canister_id)
+        .deadline(SOME_DEADLINE)
         .build()
 }
 
@@ -169,6 +185,10 @@ impl ReplicatedStateFixture {
         self.state.guaranteed_response_message_memory_taken()
     }
 
+    fn best_effort_message_memory_taken(&self) -> NumBytes {
+        self.state.best_effort_message_memory_taken()
+    }
+
     fn remote_subnet_input_schedule(&self, canister: &CanisterId) -> &VecDeque<CanisterId> {
         self.state
             .canister_state(canister)
@@ -195,14 +215,32 @@ fn assert_execution_memory_taken(total_memory_usage: usize, fixture: &Replicated
     );
 }
 
-fn assert_message_memory_taken(queues_memory_usage: usize, fixture: &ReplicatedStateFixture) {
+fn assert_message_memory_taken(
+    guaranteed_response_memory_usage: usize,
+    best_effort_memory_usage: usize,
+    fixture: &ReplicatedStateFixture,
+) {
+    let guaranteed_response_memory_usage = guaranteed_response_memory_usage as u64;
+    let best_effort_memory_usage = best_effort_memory_usage as u64;
     assert_eq!(
-        queues_memory_usage as u64,
+        guaranteed_response_memory_usage,
         fixture.memory_taken().guaranteed_response_messages().get()
     );
     assert_eq!(
-        queues_memory_usage as u64,
+        guaranteed_response_memory_usage,
         fixture.guaranteed_response_message_memory_taken().get()
+    );
+    assert_eq!(
+        best_effort_memory_usage,
+        fixture.memory_taken().best_effort_messages().get()
+    );
+    assert_eq!(
+        best_effort_memory_usage,
+        fixture.best_effort_message_memory_taken().get()
+    );
+    assert_eq!(
+        guaranteed_response_memory_usage + best_effort_memory_usage,
+        fixture.memory_taken().messages_total().get()
     );
 }
 
@@ -228,11 +266,11 @@ fn assert_wasm_custom_sections_memory_taken(
 
 fn assert_subnet_available_memory(
     initial_available_memory: i64,
-    queues_memory_usage: usize,
+    guaranteed_response_memory_usage: usize,
     actual: i64,
 ) {
     assert_eq!(
-        initial_available_memory - queues_memory_usage as i64,
+        initial_available_memory - guaranteed_response_memory_usage as i64,
         actual
     );
 }
@@ -244,7 +282,7 @@ fn memory_taken_by_canister_queues() {
 
     // Zero memory used initially.
     assert_execution_memory_taken(0, &fixture);
-    assert_message_memory_taken(0, &fixture);
+    assert_message_memory_taken(0, 0, &fixture);
     assert_canister_history_memory_taken(0, &fixture);
     assert_wasm_custom_sections_memory_taken(0, &fixture);
 
@@ -259,7 +297,7 @@ fn memory_taken_by_canister_queues() {
 
     // Reserved memory for one response.
     assert_execution_memory_taken(0, &fixture);
-    assert_message_memory_taken(MAX_RESPONSE_COUNT_BYTES, &fixture);
+    assert_message_memory_taken(MAX_RESPONSE_COUNT_BYTES, 0, &fixture);
     assert_canister_history_memory_taken(0, &fixture);
     assert_wasm_custom_sections_memory_taken(0, &fixture);
     assert_subnet_available_memory(
@@ -273,7 +311,7 @@ fn memory_taken_by_canister_queues() {
 
     // Unchanged memory usage.
     assert_execution_memory_taken(0, &fixture);
-    assert_message_memory_taken(MAX_RESPONSE_COUNT_BYTES, &fixture);
+    assert_message_memory_taken(MAX_RESPONSE_COUNT_BYTES, 0, &fixture);
     assert_canister_history_memory_taken(0, &fixture);
     assert_wasm_custom_sections_memory_taken(0, &fixture);
 
@@ -283,7 +321,34 @@ fn memory_taken_by_canister_queues() {
 
     // Memory used by response only.
     assert_execution_memory_taken(0, &fixture);
-    assert_message_memory_taken(response.count_bytes(), &fixture);
+    assert_message_memory_taken(response.count_bytes(), 0, &fixture);
+    assert_canister_history_memory_taken(0, &fixture);
+    assert_wasm_custom_sections_memory_taken(0, &fixture);
+
+    // Push a best-effort request into a canister input queue.
+    let request = best_effort_request_from(OTHER_CANISTER_ID);
+    assert!(fixture
+        .state
+        .push_input(request.clone().into(), &mut subnet_available_memory)
+        .unwrap());
+
+    // Best-effort memory used by the response (no reservation).
+    assert_execution_memory_taken(0, &fixture);
+    assert_message_memory_taken(response.count_bytes(), request.count_bytes(), &fixture);
+    assert_canister_history_memory_taken(0, &fixture);
+    assert_wasm_custom_sections_memory_taken(0, &fixture);
+    assert_subnet_available_memory(
+        SUBNET_AVAILABLE_MEMORY,
+        MAX_RESPONSE_COUNT_BYTES,
+        subnet_available_memory,
+    );
+
+    // Pop input request.
+    assert!(fixture.pop_input().is_some());
+
+    // Zero best-effort memory usage.
+    assert_execution_memory_taken(0, &fixture);
+    assert_message_memory_taken(response.count_bytes(), 0, &fixture);
     assert_canister_history_memory_taken(0, &fixture);
     assert_wasm_custom_sections_memory_taken(0, &fixture);
 }
@@ -295,7 +360,7 @@ fn memory_taken_by_subnet_queues() {
 
     // Zero memory used initially.
     assert_execution_memory_taken(0, &fixture);
-    assert_message_memory_taken(0, &fixture);
+    assert_message_memory_taken(0, 0, &fixture);
     assert_canister_history_memory_taken(0, &fixture);
     assert_wasm_custom_sections_memory_taken(0, &fixture);
 
@@ -310,7 +375,7 @@ fn memory_taken_by_subnet_queues() {
 
     // Reserved memory for one response.
     assert_execution_memory_taken(0, &fixture);
-    assert_message_memory_taken(MAX_RESPONSE_COUNT_BYTES, &fixture);
+    assert_message_memory_taken(MAX_RESPONSE_COUNT_BYTES, 0, &fixture);
     assert_canister_history_memory_taken(0, &fixture);
     assert_wasm_custom_sections_memory_taken(0, &fixture);
     assert_subnet_available_memory(
@@ -324,7 +389,7 @@ fn memory_taken_by_subnet_queues() {
 
     // Unchanged memory usage.
     assert_execution_memory_taken(0, &fixture);
-    assert_message_memory_taken(MAX_RESPONSE_COUNT_BYTES, &fixture);
+    assert_message_memory_taken(MAX_RESPONSE_COUNT_BYTES, 0, &fixture);
     assert_canister_history_memory_taken(0, &fixture);
     assert_wasm_custom_sections_memory_taken(0, &fixture);
 
@@ -336,7 +401,34 @@ fn memory_taken_by_subnet_queues() {
 
     // Memory used by response only.
     assert_execution_memory_taken(0, &fixture);
-    assert_message_memory_taken(response.count_bytes(), &fixture);
+    assert_message_memory_taken(response.count_bytes(), 0, &fixture);
+    assert_canister_history_memory_taken(0, &fixture);
+    assert_wasm_custom_sections_memory_taken(0, &fixture);
+
+    // Push a best-effort request into the subnet input queues.
+    let request = best_effort_request_to(SUBNET_ID.into());
+    assert!(fixture
+        .state
+        .push_input(request.clone().into(), &mut subnet_available_memory)
+        .unwrap());
+
+    // Best-effort memory used by the response (no reservation).
+    assert_execution_memory_taken(0, &fixture);
+    assert_message_memory_taken(response.count_bytes(), request.count_bytes(), &fixture);
+    assert_canister_history_memory_taken(0, &fixture);
+    assert_wasm_custom_sections_memory_taken(0, &fixture);
+    assert_subnet_available_memory(
+        SUBNET_AVAILABLE_MEMORY,
+        MAX_RESPONSE_COUNT_BYTES,
+        subnet_available_memory,
+    );
+
+    // Pop subnet input request.
+    assert!(fixture.state.pop_subnet_input().is_some());
+
+    // Zero best-effort memory usage.
+    assert_execution_memory_taken(0, &fixture);
+    assert_message_memory_taken(response.count_bytes(), 0, &fixture);
     assert_canister_history_memory_taken(0, &fixture);
     assert_wasm_custom_sections_memory_taken(0, &fixture);
 }
@@ -369,7 +461,7 @@ fn memory_taken_by_wasm_custom_sections() {
 
     // Reserved memory for one response.
     assert_execution_memory_taken(wasm_metadata_memory.get() as usize, &fixture);
-    assert_message_memory_taken(MAX_RESPONSE_COUNT_BYTES, &fixture);
+    assert_message_memory_taken(MAX_RESPONSE_COUNT_BYTES, 0, &fixture);
     assert_canister_history_memory_taken(0, &fixture);
     assert_wasm_custom_sections_memory_taken(wasm_metadata_memory.get(), &fixture);
     assert_subnet_available_memory(
@@ -388,7 +480,7 @@ fn memory_taken_by_canister_history() {
 
     // No memory is used initially.
     assert_execution_memory_taken(0, &fixture);
-    assert_message_memory_taken(0, &fixture);
+    assert_message_memory_taken(0, 0, &fixture);
     assert_canister_history_memory_taken(0, &fixture);
     assert_wasm_custom_sections_memory_taken(0, &fixture);
 
@@ -442,7 +534,7 @@ fn push_subnet_queues_input_respects_subnet_available_memory() {
 
     // Zero memory used initially.
     assert_execution_memory_taken(0, &fixture);
-    assert_message_memory_taken(0, &fixture);
+    assert_message_memory_taken(0, 0, &fixture);
     assert_canister_history_memory_taken(0, &fixture);
     assert_wasm_custom_sections_memory_taken(0, &fixture);
 
@@ -457,7 +549,7 @@ fn push_subnet_queues_input_respects_subnet_available_memory() {
 
     // Reserved memory for one response.
     assert_execution_memory_taken(0, &fixture);
-    assert_message_memory_taken(MAX_RESPONSE_COUNT_BYTES, &fixture);
+    assert_message_memory_taken(MAX_RESPONSE_COUNT_BYTES, 0, &fixture);
     assert_canister_history_memory_taken(0, &fixture);
     assert_wasm_custom_sections_memory_taken(0, &fixture);
     assert_subnet_available_memory(
@@ -486,7 +578,21 @@ fn push_subnet_queues_input_respects_subnet_available_memory() {
 
     // Unchanged memory usage.
     assert_execution_memory_taken(0, &fixture);
-    assert_message_memory_taken(MAX_RESPONSE_COUNT_BYTES, &fixture);
+    assert_message_memory_taken(MAX_RESPONSE_COUNT_BYTES, 0, &fixture);
+    assert_canister_history_memory_taken(0, &fixture);
+    assert_wasm_custom_sections_memory_taken(0, &fixture);
+    assert_eq!(0, subnet_available_memory);
+
+    // Push a best-effort request into the subnet input queues.
+    let request = best_effort_request_to(SUBNET_ID.into());
+    assert!(fixture
+        .state
+        .push_input(request.clone().into(), &mut subnet_available_memory)
+        .unwrap());
+
+    // Best-effort memory consumed by the request; otherwise, memory usage unchanged.
+    assert_execution_memory_taken(0, &fixture);
+    assert_message_memory_taken(MAX_RESPONSE_COUNT_BYTES, request.count_bytes(), &fixture);
     assert_canister_history_memory_taken(0, &fixture);
     assert_wasm_custom_sections_memory_taken(0, &fixture);
     assert_eq!(0, subnet_available_memory);


### PR DESCRIPTION
Have `ReplicatedState` expose best-effort and total message memory usage, both directly and via the `MemoryTaken` struct.

Also extend `ReplicatedState` tests to cover best-effort message memory usage.