### PR TITLE
test(sns): Deflake `//rs/sns/integration_tests:integration_test_src/proposals`.

### DIFF
--- a/rs/sns/test_utils/src/itest_helpers.rs
+++ b/rs/sns/test_utils/src/itest_helpers.rs
@@ -673,12 +673,7 @@ impl SnsCanisters<'_> {
                     subaccount: to_subaccount,
                 },
                 memo: None,
-                created_at_time: Some(
-                    SystemTime::now()
-                        .duration_since(SystemTime::UNIX_EPOCH)
-                        .unwrap()
-                        .as_nanos() as u64,
-                ),
+                created_at_time: None,
             },
         )
         .await


### PR DESCRIPTION
Previously, symptoms were

```
... panicked at rs/sns/test_utils/src/itest_helpers.rs:685:10:
Couldn't send funds.: "CreatedInFuture { ledger_time: 1739549219813820649 }" 
```

**How we (attempt to) address this**: When a test sends a transfer request to ledger, do not set the creation time.

**Why this change is sound**: It was wrong to set the time in the first place, because the caller never specified the time.

**Verification**: I used `--runs_per_test=256` (and [all runs passed]).

[all runs passed]: https://dash.zh1-idx1.dfinity.network/invocation/c73aaa95-4d33-42d6-a41b-7626c95f63f2?target=%2F%2Frs%2Fsns%2Fintegration_tests%3Aintegration_test_src%2Fproposals&targetStatus=5#256

This was flaking out 2.3% of the time.