### PR TITLE
test: Make tests not squelch color when being run by bazel.

### DIFF
--- a/bazel/conf/.bazelrc.build
+++ b/bazel/conf/.bazelrc.build
@@ -141,3 +141,8 @@ common --remote_download_all
 # This option (in conjunction with remote cache issues) creates build failures
 #   https://github.com/bazelbuild/bazel/issues/22387
 common --noexperimental_inmemory_dotd_files
+
+# This is particularly helpful for canbench, but other tests that follow this
+# convention would also benefit. If the test does not support this, this "almost
+# certainly" does no harm.
+test --test_env=CLICOLOR_FORCE=true

--- a/rs/ic_os/fstrim_tool/tests/integration_tests.rs
+++ b/rs/ic_os/fstrim_tool/tests/integration_tests.rs
@@ -177,7 +177,7 @@ fn should_fail_if_arguments_missing() {
         .assert()
         .stdout(predicate::str::is_empty())
         .stderr(predicate::str::contains(
-            "error: the following required arguments were not provided",
+            "the following required arguments were not provided",
         ))
         .failure();
 }

--- a/rs/replica/tests/cli.rs
+++ b/rs/replica/tests/cli.rs
@@ -25,18 +25,10 @@ fn too_many_arguments_causes_exit_code_1() {
     new_replica_command()
         .args(["arg1", "arg2"])
         .assert()
-        .stderr(predicate::str::contains(
-            "error",
-        ))
-        .stderr(predicate::str::contains(
-            "unexpected argument",
-        ))
-        .stderr(predicate::str::contains(
-            "arg1",
-        ))
-        .stderr(predicate::str::contains(
-            "found",
-        ))
+        .stderr(predicate::str::contains("error"))
+        .stderr(predicate::str::contains("unexpected argument"))
+        .stderr(predicate::str::contains("arg1"))
+        .stderr(predicate::str::contains("found"))
         .failure();
 }
 

--- a/rs/replica/tests/cli.rs
+++ b/rs/replica/tests/cli.rs
@@ -25,8 +25,17 @@ fn too_many_arguments_causes_exit_code_1() {
     new_replica_command()
         .args(["arg1", "arg2"])
         .assert()
-        .stderr(predicate::str::starts_with(
-            "error: unexpected argument 'arg1' found",
+        .stderr(predicate::str::contains(
+            "error",
+        ))
+        .stderr(predicate::str::contains(
+            "unexpected argument",
+        ))
+        .stderr(predicate::str::contains(
+            "arg1",
+        ))
+        .stderr(predicate::str::contains(
+            "found",
         ))
         .failure();
 }


### PR DESCRIPTION
What this literally does is sets the `CLICOLOR_FORCE` environment variable to `true`. This causes terminal output to be colored, if the test follows [that convention]. In particular, the Rust `colored` library uses that convention. In particular, canbench uses `colored`. This makes the output of canbench easier for humans to consume (and we should really care about humans, such as ourselves).

[that convention]: http://bixense.com/clicolors/