### PR TITLE
fix(nns-tools): Use gdate command instead of date

### DIFF
--- a/testnet/tools/nns-tools/add-release-to-changelog.sh
+++ b/testnet/tools/nns-tools/add-release-to-changelog.sh
@@ -75,9 +75,9 @@ else
     print_red "(In particular, unable to determine which canister and commit.)" >&2
     exit 1
 fi
-SECONDS_AGO=$(($(date +%s) - "${PROPOSED_TIMESTAMP_SECONDS}"))
+SECONDS_AGO=$(($(gdate +%s) - "${PROPOSED_TIMESTAMP_SECONDS}"))
 PROPOSED_ON=$(
-    date --utc \
+    gdate --utc \
         --date=@"${PROPOSED_TIMESTAMP_SECONDS}" \
         --iso-8601
 )


### PR DESCRIPTION
Both Max and jason were unable to run the changelog-related commands because their environment was defaulting to the macos `date` command rather than the gnu one, which is more full-featured. 

I think gdate will work for them though. It comes with coreutils which most people should have already probably (i think you need it to compile rust?). Also the release runscript will tell you to install coreutils if you haven't yet.