### PR TITLE
fix(dep-mgmt): Remove legacy node engine version

### DIFF
--- a/ci/src/dependencies/job/npm_scanner_periodic_job.py
+++ b/ci/src/dependencies/job/npm_scanner_periodic_job.py
@@ -85,7 +85,7 @@ REPOS_TO_SCAN = [
                 owner=Team.GIX_TEAM,
             )
         ],
-        "18.17.1",
+        "18.20.5",
     ),
     Repository(
         "oisy-wallet",


### PR DESCRIPTION
Leftover from #3994 