### PR TITLE
feat(EXC-1943): Bump allowed code section size

### DIFF
--- a/rs/embedders/src/wasm_utils/validation.rs
+++ b/rs/embedders/src/wasm_utils/validation.rs
@@ -42,7 +42,7 @@ pub const RESERVED_SYMBOLS: [&str; 6] = [
 
 const WASM_FUNCTION_COMPLEXITY_LIMIT: Complexity = Complexity(1_000_000);
 pub const WASM_FUNCTION_SIZE_LIMIT: usize = 1_000_000;
-pub const MAX_CODE_SECTION_SIZE_IN_BYTES: u32 = 10 * 1024 * 1024;
+pub const MAX_CODE_SECTION_SIZE_IN_BYTES: u32 = 11 * 1024 * 1024;
 
 // Represents the expected function signature for any System APIs the Internet
 // Computer provides or any special exported user functions.

--- a/rs/embedders/tests/validation.rs
+++ b/rs/embedders/tests/validation.rs
@@ -1049,7 +1049,7 @@ fn wasm_with_fixed_sizes(code_section_size: u32, data_section_size: u32) -> Bina
 
 #[test]
 fn large_code_section_rejected() {
-    let wasm = wasm_with_fixed_sizes(10 * KB * KB + 10, 0);
+    let wasm = wasm_with_fixed_sizes(11 * KB * KB + 10, 0);
     let embedder = WasmtimeEmbedder::new(EmbeddersConfig::default(), no_op_logger());
     let result = validate_and_instrument_for_testing(&embedder, &wasm);
     assert_matches!(

--- a/rs/execution_environment/src/hypervisor.rs
+++ b/rs/execution_environment/src/hypervisor.rs
@@ -131,7 +131,7 @@ impl HypervisorMetrics {
             code_section_size: metrics_registry.histogram(
                 "hypervisor_code_section_size",
                 "Size of the code section in bytes for a canister Wasm. Only Wasms that successfully compile are counted (which implies the code sections are below the current limit).",
-                linear_buckets(1024.0 * 1024.0, 1024.0 * 1204.0, 10), // 1MiB, 2MiB, ..., 10 MiB. Current limit is 10 MiB.
+                linear_buckets(1024.0 * 1024.0, 1024.0 * 1204.0, 11), // 1MiB, 2MiB, ..., 11 MiB. Current limit is 11 MiB.
             ),
         }
     }


### PR DESCRIPTION
EXC-1943

Increase the size of allowed canister Wasm code section sizes from 10 MiB to 11 MiB.