### PR TITLE
feat(nns-governance): add `neuron_minimum_dissolve_delay_to_vote_seconds` to `VotingPowerEconomics`

### DIFF
--- a/rs/nns/governance/api/BUILD.bazel
+++ b/rs/nns/governance/api/BUILD.bazel
@@ -10,7 +10,6 @@ DEPENDENCIES = [
     "//rs/nervous_system/clients",
     "//rs/nervous_system/common",
     "//rs/nervous_system/common/validation",
-    "//rs/nervous_system/governance",
     "//rs/nervous_system/proto",
     "//rs/nns/common",
     "//rs/protobuf",

--- a/rs/nns/governance/api/BUILD.bazel
+++ b/rs/nns/governance/api/BUILD.bazel
@@ -10,6 +10,7 @@ DEPENDENCIES = [
     "//rs/nervous_system/clients",
     "//rs/nervous_system/common",
     "//rs/nervous_system/common/validation",
+    "//rs/nervous_system/governance",
     "//rs/nervous_system/proto",
     "//rs/nns/common",
     "//rs/protobuf",

--- a/rs/nns/governance/api/src/ic_nns_governance.pb.v1.rs
+++ b/rs/nns/governance/api/src/ic_nns_governance.pb.v1.rs
@@ -2295,7 +2295,8 @@ pub struct VotingPowerEconomics {
     #[prost(uint64, optional, tag = "2")]
     pub clear_following_after_seconds: ::core::option::Option<u64>,
 
-    /// The minimum dissolve delay a neuron must have in order to be eligible to vote.
+    /// The minimum dissolve delay a neuron must have in order to be eligible to vote or
+    /// make proposals.
     ///
     /// Neurons with a dissolve delay lower than this threshold will not have
     /// voting power, even if they are otherwise active.

--- a/rs/nns/governance/api/src/ic_nns_governance.pb.v1.rs
+++ b/rs/nns/governance/api/src/ic_nns_governance.pb.v1.rs
@@ -2294,6 +2294,16 @@ pub struct VotingPowerEconomics {
     /// Initially, set to 1/12 years.
     #[prost(uint64, optional, tag = "2")]
     pub clear_following_after_seconds: ::core::option::Option<u64>,
+
+    /// The minimum dissolve delay a neuron must have in order to be eligible to vote.
+    ///
+    /// Neurons with a dissolve delay lower than this threshold will not have
+    /// voting power, even if they are otherwise active.
+    ///
+    /// This value is an essential part of the staking mechanism, promoting
+    /// long-term alignment with the network's governance.
+    #[prost(uint64, optional, tag = "3")]
+    pub neuron_minimum_dissolve_delay_to_vote_seconds: ::core::option::Option<u64>,
 }
 
 /// The thresholds specify the shape of the ideal matching function used by the Neurons' Fund to

--- a/rs/nns/governance/api/src/pb.rs
+++ b/rs/nns/governance/api/src/pb.rs
@@ -101,9 +101,12 @@ impl VotingPowerEconomics {
             Self::DEFAULT_START_REDUCING_VOTING_POWER_AFTER_SECONDS,
         ),
         clear_following_after_seconds: Some(Self::DEFAULT_CLEAR_FOLLOWING_AFTER_SECONDS),
-        neuron_minimum_dissolve_delay_to_vote_seconds: None,
+        neuron_minimum_dissolve_delay_to_vote_seconds: Some(
+            Self::DEFAULT_MIN_DISSOLVE_DELAY_FOR_VOTE_ELIGIBILITY_SECONDS,
+        ),
     };
 
+    pub const DEFAULT_MIN_DISSOLVE_DELAY_FOR_VOTE_ELIGIBILITY_SECONDS: u64 = 6 * ONE_MONTH_SECONDS;
     pub const DEFAULT_START_REDUCING_VOTING_POWER_AFTER_SECONDS: u64 = 6 * ONE_MONTH_SECONDS;
     pub const DEFAULT_CLEAR_FOLLOWING_AFTER_SECONDS: u64 = ONE_MONTH_SECONDS;
 

--- a/rs/nns/governance/api/src/pb.rs
+++ b/rs/nns/governance/api/src/pb.rs
@@ -101,6 +101,7 @@ impl VotingPowerEconomics {
             Self::DEFAULT_START_REDUCING_VOTING_POWER_AFTER_SECONDS,
         ),
         clear_following_after_seconds: Some(Self::DEFAULT_CLEAR_FOLLOWING_AFTER_SECONDS),
+        neuron_minimum_dissolve_delay_to_vote_seconds: None,
     };
 
     pub const DEFAULT_START_REDUCING_VOTING_POWER_AFTER_SECONDS: u64 = 6 * ONE_MONTH_SECONDS;

--- a/rs/nns/governance/canister/governance.did
+++ b/rs/nns/governance/canister/governance.did
@@ -644,6 +644,15 @@ type VotingPowerEconomics = record {
   //
   // Initially, set to 1/12 years.
   clear_following_after_seconds : opt nat64;
+
+  // The minimum dissolve delay a neuron must have in order to be eligible to vote.
+  //
+  // Neurons with a dissolve delay lower than this threshold will not have 
+  // voting power, even if they are otherwise active.
+  //
+  // This value is an essential part of the staking mechanism, promoting
+  // long-term alignment with the network's governance.
+  neuron_minimum_dissolve_delay_to_vote_seconds : opt nat64;
 };
 
 type Neuron = record {

--- a/rs/nns/governance/canister/governance_test.did
+++ b/rs/nns/governance/canister/governance_test.did
@@ -610,6 +610,14 @@ type VotingPowerEconomics = record {
   //
   // Initially, set to 1/12 years.
   clear_following_after_seconds : opt nat64;
+  // The minimum dissolve delay a neuron must have in order to be eligible to vote.
+  //
+  // Neurons with a dissolve delay lower than this threshold will not have 
+  // voting power, even if they are otherwise active.
+  //
+  // This value is an essential part of the staking mechanism, promoting
+  // long-term alignment with the network's governance.
+  neuron_minimum_dissolve_delay_to_vote_seconds : opt nat64;
 };
 
 type Neuron = record {

--- a/rs/nns/governance/proto/ic_nns_governance/pb/v1/governance.proto
+++ b/rs/nns/governance/proto/ic_nns_governance/pb/v1/governance.proto
@@ -1672,6 +1672,15 @@ message VotingPowerEconomics {
   //
   // Initially, set to 1/12 years.
   optional uint64 clear_following_after_seconds = 2;
+
+  // The minimum dissolve delay a neuron must have in order to be eligible to vote.
+  //
+  // Neurons with a dissolve delay lower than this threshold will not have 
+  // voting power, even if they are otherwise active.
+  //
+  // This value is an essential part of the staking mechanism, promoting
+  // long-term alignment with the network's governance.
+  optional uint64 neuron_minimum_dissolve_delay_to_vote_seconds = 3;
 }
 
 // The thresholds specify the shape of the ideal matching function used by the Neurons' Fund to

--- a/rs/nns/governance/src/gen/ic_nns_governance.pb.v1.rs
+++ b/rs/nns/governance/src/gen/ic_nns_governance.pb.v1.rs
@@ -2124,6 +2124,15 @@ pub struct VotingPowerEconomics {
     /// Initially, set to 1/12 years.
     #[prost(uint64, optional, tag = "2")]
     pub clear_following_after_seconds: ::core::option::Option<u64>,
+    /// The minimum dissolve delay a neuron must have in order to be eligible to vote.
+    ///
+    /// Neurons with a dissolve delay lower than this threshold will not have
+    /// voting power, even if they are otherwise active.
+    ///
+    /// This value is an essential part of the staking mechanism, promoting
+    /// long-term alignment with the network's governance.
+    #[prost(uint64, optional, tag = "3")]
+    pub neuron_minimum_dissolve_delay_to_vote_seconds: ::core::option::Option<u64>,
 }
 /// The thresholds specify the shape of the ideal matching function used by the Neurons' Fund to
 /// determine how much to contribute for a given direct participation amount. Note that the actual

--- a/rs/nns/governance/src/governance/tests/mod.rs
+++ b/rs/nns/governance/src/governance/tests/mod.rs
@@ -1495,6 +1495,7 @@ fn test_deciding_voting_power_adjustment_factor() {
     let voting_power_economics = VotingPowerEconomics {
         start_reducing_voting_power_after_seconds: Some(60),
         clear_following_after_seconds: Some(30),
+        neuron_minimum_dissolve_delay_to_vote_seconds: Some(60),
     };
 
     let deciding_voting_power = |seconds_since_refresh| {

--- a/rs/nns/governance/src/network_economics.rs
+++ b/rs/nns/governance/src/network_economics.rs
@@ -1,4 +1,3 @@
-use crate::governance::MIN_DISSOLVE_DELAY_FOR_VOTE_ELIGIBILITY_SECONDS;
 use crate::pb::v1::{
     NetworkEconomics, NeuronsFundEconomics, NeuronsFundMatchedFundingCurveCoefficients,
     VotingPowerEconomics,
@@ -275,10 +274,11 @@ impl VotingPowerEconomics {
         ),
         clear_following_after_seconds: Some(Self::DEFAULT_CLEAR_FOLLOWING_AFTER_SECONDS),
         neuron_minimum_dissolve_delay_to_vote_seconds: Some(
-            MIN_DISSOLVE_DELAY_FOR_VOTE_ELIGIBILITY_SECONDS,
+            Self::DEFAULT_MIN_DISSOLVE_DELAY_FOR_VOTE_ELIGIBILITY_SECONDS,
         ),
     };
 
+    pub const DEFAULT_MIN_DISSOLVE_DELAY_FOR_VOTE_ELIGIBILITY_SECONDS: u64 = 6 * ONE_MONTH_SECONDS;
     pub const DEFAULT_START_REDUCING_VOTING_POWER_AFTER_SECONDS: u64 = 6 * ONE_MONTH_SECONDS;
     pub const DEFAULT_CLEAR_FOLLOWING_AFTER_SECONDS: u64 = ONE_MONTH_SECONDS;
 
@@ -353,6 +353,17 @@ impl VotingPowerEconomics {
         if self.clear_following_after_seconds.is_none() {
             // Ditto comment regarding start_reducing_voting_power_after_seconds.
             defects.push("clear_following_after_seconds must be set.".to_string());
+        }
+
+        if let Some(delay) = self.neuron_minimum_dissolve_delay_to_vote_seconds {
+            let three_months = 3 * ONE_MONTH_SECONDS;
+            let six_months = 6 * ONE_MONTH_SECONDS;
+
+            if delay < three_months || delay > six_months {
+                defects.push("neuron_minimum_dissolve_delay_to_vote_seconds must be between three and six months.".to_string());
+            }
+        } else {
+            defects.push("neuron_minimum_dissolve_delay_to_vote_seconds must be set.".to_string());
         }
 
         if !defects.is_empty() {

--- a/rs/nns/governance/src/network_economics.rs
+++ b/rs/nns/governance/src/network_economics.rs
@@ -1,3 +1,4 @@
+use crate::governance::MIN_DISSOLVE_DELAY_FOR_VOTE_ELIGIBILITY_SECONDS;
 use crate::pb::v1::{
     NetworkEconomics, NeuronsFundEconomics, NeuronsFundMatchedFundingCurveCoefficients,
     VotingPowerEconomics,
@@ -273,6 +274,9 @@ impl VotingPowerEconomics {
             Self::DEFAULT_START_REDUCING_VOTING_POWER_AFTER_SECONDS,
         ),
         clear_following_after_seconds: Some(Self::DEFAULT_CLEAR_FOLLOWING_AFTER_SECONDS),
+        neuron_minimum_dissolve_delay_to_vote_seconds: Some(
+            MIN_DISSOLVE_DELAY_FOR_VOTE_ELIGIBILITY_SECONDS,
+        ),
     };
 
     pub const DEFAULT_START_REDUCING_VOTING_POWER_AFTER_SECONDS: u64 = 6 * ONE_MONTH_SECONDS;
@@ -522,6 +526,9 @@ impl InheritFrom for VotingPowerEconomics {
             clear_following_after_seconds: self
                 .clear_following_after_seconds
                 .inherit_from(&base.clear_following_after_seconds),
+            neuron_minimum_dissolve_delay_to_vote_seconds: self
+                .neuron_minimum_dissolve_delay_to_vote_seconds
+                .inherit_from(&base.neuron_minimum_dissolve_delay_to_vote_seconds),
         }
     }
 }

--- a/rs/nns/governance/src/network_economics_tests.rs
+++ b/rs/nns/governance/src/network_economics_tests.rs
@@ -1,5 +1,6 @@
 use super::*;
 use ic_nervous_system_proto::pb::v1::Decimal as ProtoDecimal;
+use crate::governance::MIN_DISSOLVE_DELAY_FOR_VOTE_ELIGIBILITY_SECONDS;
 use pretty_assertions::assert_eq;
 
 #[test]
@@ -86,4 +87,15 @@ fn test_inherit_from_recursively() {
 #[test]
 fn test_network_economics_with_default_values_is_valid() {
     assert_eq!(NetworkEconomics::with_default_values().validate(), Ok(()));
+}
+
+#[test]
+fn test_neuron_minimum_dissolve_delay_to_vote_seconds_out_of_bounds_is_invalid() {
+    let mut default_network_economics = NetworkEconomics::with_default_values();
+    default_network_economics
+        .voting_power_economics
+        .unwrap()
+        .neuron_minimum_dissolve_delay_to_vote_seconds =
+        Some(MIN_DISSOLVE_DELAY_FOR_VOTE_ELIGIBILITY_SECONDS + 1);
+    assert_eq!(default_network_economics.validate(), Ok(()));
 }

--- a/rs/nns/governance/src/neuron_store/neuron_store_tests.rs
+++ b/rs/nns/governance/src/neuron_store/neuron_store_tests.rs
@@ -822,6 +822,7 @@ fn test_prune_some_following_super_strict_voting_power_refresh() {
                 // supposed to be cleared.
                 start_reducing_voting_power_after_seconds: Some(42),
                 clear_following_after_seconds: Some(58),
+                neuron_minimum_dissolve_delay_to_vote_seconds: Some(42)
             },
             &mut neuron_store,
             Bound::Unbounded, // Start new cycle.

--- a/rs/nns/governance/src/pb/conversions.rs
+++ b/rs/nns/governance/src/pb/conversions.rs
@@ -1886,6 +1886,8 @@ impl From<pb_api::VotingPowerEconomics> for pb::VotingPowerEconomics {
             start_reducing_voting_power_after_seconds: item
                 .start_reducing_voting_power_after_seconds,
             clear_following_after_seconds: item.clear_following_after_seconds,
+            neuron_minimum_dissolve_delay_to_vote_seconds: item
+                .neuron_minimum_dissolve_delay_to_vote_seconds,
         }
     }
 }
@@ -1896,6 +1898,8 @@ impl From<pb::VotingPowerEconomics> for pb_api::VotingPowerEconomics {
             start_reducing_voting_power_after_seconds: item
                 .start_reducing_voting_power_after_seconds,
             clear_following_after_seconds: item.clear_following_after_seconds,
+            neuron_minimum_dissolve_delay_to_vote_seconds: item
+                .neuron_minimum_dissolve_delay_to_vote_seconds,
         }
     }
 }

--- a/rs/nns/governance/tests/governance.rs
+++ b/rs/nns/governance/tests/governance.rs
@@ -8361,6 +8361,7 @@ fn test_network_economics_proposal() {
             .as_ref()
             .unwrap()
             .voting_power_economics
+            .unwrap()
             .neuron_minimum_dissolve_delay_to_vote_seconds,
         Some(MIN_DISSOLVE_DELAY_FOR_VOTE_ELIGIBILITY_SECONDS),
     );

--- a/rs/nns/governance/tests/governance.rs
+++ b/rs/nns/governance/tests/governance.rs
@@ -8354,6 +8354,17 @@ fn test_network_economics_proposal() {
         .unwrap()
         .neuron_minimum_stake_e8s = 1234;
 
+    // Verify that neuron_minimum_dissolve_delay_to_vote_seconds is set to 6 months by default.
+    assert_eq!(
+        gov.heap_data
+            .economics
+            .as_ref()
+            .unwrap()
+            .voting_power_economics
+            .neuron_minimum_dissolve_delay_to_vote_seconds,
+        Some(MIN_DISSOLVE_DELAY_FOR_VOTE_ELIGIBILITY_SECONDS),
+    );
+
     // Propose to change some, NetworkEconomics parameters.
     let pid = match gov
         .manage_neuron(
@@ -8370,7 +8381,9 @@ fn test_network_economics_proposal() {
                         voting_power_economics: Some(VotingPowerEconomics {
                             start_reducing_voting_power_after_seconds: Some(42),
                             clear_following_after_seconds: Some(4242),
-                            neuron_minimum_dissolve_delay_to_vote_seconds: Some(42),
+                            neuron_minimum_dissolve_delay_to_vote_seconds: Some(
+                                MIN_DISSOLVE_DELAY_FOR_VOTE_ELIGIBILITY_SECONDS / 2,
+                            ),
                         }),
                         ..Default::default()
                     })),
@@ -8401,7 +8414,9 @@ fn test_network_economics_proposal() {
             voting_power_economics: Some(VotingPowerEconomics {
                 start_reducing_voting_power_after_seconds: Some(42),
                 clear_following_after_seconds: Some(4242),
-                neuron_minimum_dissolve_delay_to_vote_seconds: Some(42)
+                neuron_minimum_dissolve_delay_to_vote_seconds: Some(
+                    MIN_DISSOLVE_DELAY_FOR_VOTE_ELIGIBILITY_SECONDS / 2
+                )
             }),
 
             // No changes to the rest.

--- a/rs/nns/governance/tests/governance.rs
+++ b/rs/nns/governance/tests/governance.rs
@@ -8370,6 +8370,7 @@ fn test_network_economics_proposal() {
                         voting_power_economics: Some(VotingPowerEconomics {
                             start_reducing_voting_power_after_seconds: Some(42),
                             clear_following_after_seconds: Some(4242),
+                            neuron_minimum_dissolve_delay_to_vote_seconds: Some(42),
                         }),
                         ..Default::default()
                     })),
@@ -8400,6 +8401,7 @@ fn test_network_economics_proposal() {
             voting_power_economics: Some(VotingPowerEconomics {
                 start_reducing_voting_power_after_seconds: Some(42),
                 clear_following_after_seconds: Some(4242),
+                neuron_minimum_dissolve_delay_to_vote_seconds: Some(42)
             }),
 
             // No changes to the rest.


### PR DESCRIPTION
 start exposing the min voting dissolve delay value in the API