### PR TITLE
fix(sns-cli): Read DFX network from environment until DFX extensions fix passing it through

### DIFF
--- a/rs/sns/cli/src/lib.rs
+++ b/rs/sns/cli/src/lib.rs
@@ -137,10 +137,15 @@ impl CliArgs {
         let network = match self.network.to_network_name() {
             Some(network) => network,
             None => {
-                eprintln!(
-                    "No network specified. Defaulting to the local network. To connect to the mainnet IC instead, try passing `--network=ic`"
-                );
-                "local".to_string()
+                // TODO[SDK-1962]: Stop reading the environment variable.
+                if let Ok(network) = std::env::var("DFX_NETWORK") {
+                    network
+                } else {
+                    eprintln!(
+                        "No network specified. Defaulting to the local network. To connect to the mainnet IC instead, try passing `--network=ic`"
+                    );
+                    "local".to_string()
+                }
             }
         };
 


### PR DESCRIPTION
This PR adds a workaround for passing the DFX network parameter to SNS CLI. Conceptually, DFX already has the `--network` option, but it doesn't currently pass it to the extensions; therefore, we read the value of that parameter from the `DFX_NETWORK` environment variable.