### PR TITLE
fix(PocketIC): simplify PocketIc::try_get_controllers

### DIFF
--- a/packages/pocket-ic/CHANGELOG.md
+++ b/packages/pocket-ic/CHANGELOG.md
@@ -8,8 +8,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Added
-- The function `PocketIc::try_get_controllers` which gets the controllers of a canister but doesn't panic if the target canister
-  doesn't exist.
 - The function `PocketIcBuilder::with_bitcoind_addrs` to specify multiple addresses and ports at which `bitcoind` processes are listening.
 - The function `PocketIc::query_call_with_effective_principal` for making generic query calls (including management canister query calls).
 - The function `PocketIc::ingress_status` to fetch the status of an update call submitted through an ingress message.
@@ -19,7 +17,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (round execution must be triggered separarely, e.g., on a "live" instance or by separate PocketIC library calls).
 - The function `PocketIc::set_certified_time` to set the current certified time on all subnets of the PocketIC instance.
 - The function `PocketIc::update_call_with_effective_principal` is made public. It is helpful, e.g., for
-modeling management canister calls that need to be routed to the right subnet using effective principals.
+  modeling management canister calls that need to be routed to the right subnet using effective principals.
+- The function `PocketIc::try_get_controllers` which gets the controllers of a canister but doesn't panic if the target canister
+  doesn't exist.
 
 ### Changed
 - The response types `pocket_ic::WasmResult`, `pocket_ic::UserError`, and `pocket_ic::CallError` are replaced by a single reject response type `pocket_ic::RejectResponse`.

--- a/packages/pocket-ic/src/lib.rs
+++ b/packages/pocket-ic/src/lib.rs
@@ -70,7 +70,7 @@ use candid::{
     Principal,
 };
 use ic_transport_types::SubnetMetrics;
-use reqwest::{StatusCode, Url};
+use reqwest::Url;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use slog::Level;
@@ -650,11 +650,9 @@ impl PocketIc {
     }
 
     /// Get the controllers of a canister.
+    /// Returns `None` if the canister does not exist.
     #[instrument(ret, skip(self), fields(instance_id=self.pocket_ic.instance_id, canister_id = %canister_id.to_string()))]
-    pub fn try_get_controllers(
-        &self,
-        canister_id: CanisterId,
-    ) -> Result<Vec<Principal>, (StatusCode, String)> {
+    pub fn try_get_controllers(&self, canister_id: CanisterId) -> Option<Vec<Principal>> {
         let runtime = self.runtime.clone();
         runtime.block_on(async { self.pocket_ic.try_get_controllers(canister_id).await })
     }

--- a/packages/pocket-ic/src/nonblocking.rs
+++ b/packages/pocket-ic/src/nonblocking.rs
@@ -519,25 +519,27 @@ impl PocketIc {
     /// Panics if the canister does not exist.
     #[instrument(ret, skip(self), fields(instance_id=self.instance_id, canister_id = %canister_id.to_string()))]
     pub async fn get_controllers(&self, canister_id: CanisterId) -> Vec<Principal> {
-        self.try_get_controllers(canister_id).await.unwrap()
-    }
-
-    /// Get the controllers of a canister.
-    #[instrument(ret, skip(self), fields(instance_id=self.instance_id, canister_id = %canister_id.to_string()))]
-    pub async fn try_get_controllers(
-        &self,
-        canister_id: CanisterId,
-    ) -> Result<Vec<Principal>, (StatusCode, String)> {
         let endpoint = "read/get_controllers";
-        let result: Result<Vec<RawPrincipalId>, (StatusCode, String)> = self
-            .try_post(
+        let result: Vec<RawPrincipalId> = self
+            .post(
                 endpoint,
                 RawCanisterId {
                     canister_id: canister_id.as_slice().to_vec(),
                 },
             )
             .await;
-        result.map(|v| v.into_iter().map(|p| p.into()).collect())
+        result.into_iter().map(|p| p.into()).collect()
+    }
+
+    /// Get the controllers of a canister.
+    /// Returns `None` if the canister does not exist.
+    #[instrument(ret, skip(self), fields(instance_id=self.instance_id, canister_id = %canister_id.to_string()))]
+    pub async fn try_get_controllers(&self, canister_id: CanisterId) -> Option<Vec<Principal>> {
+        if self.canister_exists(canister_id).await {
+            Some(self.get_controllers(canister_id).await)
+        } else {
+            None
+        }
     }
 
     /// Get the current cycles balance of a canister.

--- a/packages/pocket-ic/tests/tests.rs
+++ b/packages/pocket-ic/tests/tests.rs
@@ -1744,12 +1744,14 @@ fn try_get_controllers_of_nonexisting_canister() {
     let pic = PocketIc::new();
 
     let canister_id = pic.create_canister();
+    pic.try_get_controllers(canister_id).unwrap();
+
     pic.add_cycles(canister_id, 100_000_000_000_000);
     pic.stop_canister(canister_id, None).unwrap();
     pic.delete_canister(canister_id, None).unwrap();
 
     let res = pic.try_get_controllers(canister_id);
-    assert!(res.is_err())
+    assert!(res.is_none());
 }
 
 #[test]


### PR DESCRIPTION
This PR simplifies the function `PocketIc::try_get_controllers` introduced by this [PR](https://github.com/dfinity/ic/pull/3979).