### PR TITLE
fix(PocketIC): make HTTP gateway router in PocketIC more consistent with ic-gateway

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,4 +1,4 @@
 # import default bazelrc fragments, see bazel/conf/README.md
 import %workspace%/bazel/conf/.bazelrc.build
-import %workspace%/bazel/conf/.bazelrc.internal
+#import %workspace%/bazel/conf/.bazelrc.internal
 try-import %workspace%/user.bazelrc

--- a/.bazelrc
+++ b/.bazelrc
@@ -1,4 +1,4 @@
 # import default bazelrc fragments, see bazel/conf/README.md
 import %workspace%/bazel/conf/.bazelrc.build
-#import %workspace%/bazel/conf/.bazelrc.internal
+import %workspace%/bazel/conf/.bazelrc.internal
 try-import %workspace%/user.bazelrc

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17867,6 +17867,7 @@ dependencies = [
  "serde_json",
  "slog",
  "spec-compliance",
+ "strum",
  "tempfile",
  "time",
  "tokio",

--- a/packages/pocket-ic/test_canister/src/canister.rs
+++ b/packages/pocket-ic/test_canister/src/canister.rs
@@ -66,9 +66,9 @@ fn http_request(request: HttpGatewayRequest) -> HttpGatewayResponse {
         }
     } else {
         HttpGatewayResponse {
-            status_code: 404,
+            status_code: 400,
             headers: vec![],
-            body: ByteBuf::from(b"Not Found."),
+            body: ByteBuf::from(b"The request is not supported by the test canister."),
             upgrade: None,
             streaming_strategy: None,
         }

--- a/packages/pocket-ic/tests/tests.rs
+++ b/packages/pocket-ic/tests/tests.rs
@@ -17,7 +17,6 @@ use pocket_ic::{
     query_candid, update_candid, DefaultEffectiveCanisterIdError, ErrorCode, IngressStatusResult,
     PocketIc, PocketIcBuilder, RejectCode,
 };
-#[cfg(unix)]
 use reqwest::blocking::Client;
 use reqwest::header::CONTENT_LENGTH;
 use reqwest::{Method, StatusCode};

--- a/packages/pocket-ic/tests/tests.rs
+++ b/packages/pocket-ic/tests/tests.rs
@@ -19,6 +19,8 @@ use pocket_ic::{
 };
 #[cfg(unix)]
 use reqwest::blocking::Client;
+use reqwest::header::CONTENT_LENGTH;
+use reqwest::{Method, StatusCode};
 use serde::Serialize;
 use sha2::{Digest, Sha256};
 use std::{io::Read, time::SystemTime};
@@ -2307,4 +2309,66 @@ fn test_custom_blockmaker_metrics() {
 
     assert_eq!(blockmaker_2_metrics.num_blocks_proposed_total, 0);
     assert_eq!(blockmaker_2_metrics.num_block_failures_total, daily_blocks);
+}
+
+#[test]
+fn test_http_methods() {
+    // We create a PocketIC instance consisting of the NNS and one application subnet.
+    let mut pic = PocketIcBuilder::new()
+        .with_nns_subnet()
+        .with_application_subnet()
+        .build();
+
+    // We retrieve the app subnet ID from the topology.
+    let topology = pic.topology();
+    let app_subnet = topology.get_app_subnets()[0];
+
+    // We create a canister on the app subnet.
+    let canister = pic.create_canister_on_subnet(None, None, app_subnet);
+    assert_eq!(pic.get_subnet(canister), Some(app_subnet));
+
+    // We top up the canister with cycles and install the test canister WASM to them.
+    pic.add_cycles(canister, INIT_CYCLES);
+    pic.install_canister(canister, test_canister_wasm(), vec![], None);
+
+    // We start the HTTP gateway
+    let endpoint = pic.make_live(None);
+
+    // We request the path `/` with various HTTP methods.
+    // We use raw endpoints as the test canister does not support certification.
+    let gateway_host = endpoint.host().unwrap();
+    let host = format!("{}.raw.{}", canister, gateway_host);
+    let mut url = endpoint;
+    url.set_host(Some(&host)).unwrap();
+    url.set_path("/");
+    for method in [
+        Method::GET,
+        Method::POST,
+        Method::PUT,
+        Method::DELETE,
+        Method::HEAD,
+        Method::PATCH,
+    ] {
+        let client = Client::new();
+        let res = client.request(method.clone(), url.clone()).send().unwrap();
+        // The test canister rejects all request to the path `/` with `StatusCode::BAD_REQUEST`
+        // and the error message "The request is not supported by the test canister.".
+        assert_eq!(res.status(), StatusCode::BAD_REQUEST);
+        let content_length: usize = res
+            .headers()
+            .get(CONTENT_LENGTH)
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .parse()
+            .unwrap();
+        let expected_page = "The request is not supported by the test canister.";
+        assert_eq!(content_length, expected_page.len());
+        let page = String::from_utf8(res.bytes().unwrap().to_vec()).unwrap();
+        if let Method::HEAD = method {
+            assert!(page.is_empty());
+        } else {
+            assert_eq!(page, expected_page);
+        }
+    }
 }

--- a/rs/pocket_ic_server/BUILD.bazel
+++ b/rs/pocket_ic_server/BUILD.bazel
@@ -72,6 +72,7 @@ LIB_DEPENDENCIES = [
     "@crate_index//:serde_cbor",
     "@crate_index//:serde_json",
     "@crate_index//:slog",
+    "@crate_index//:strum",
     "@crate_index//:tempfile",
     "@crate_index//:time",
     "@crate_index//:tokio",

--- a/rs/pocket_ic_server/Cargo.toml
+++ b/rs/pocket_ic_server/Cargo.toml
@@ -71,6 +71,7 @@ serde = { workspace = true }
 serde_cbor = { workspace = true }
 serde_json = { workspace = true }
 slog = { workspace = true }
+strum = { workspace = true }
 tempfile = { workspace = true }
 time = { workspace = true }
 tokio = { workspace = true }

--- a/rs/pocket_ic_server/src/state_api/state.rs
+++ b/rs/pocket_ic_server/src/state_api/state.rs
@@ -26,9 +26,9 @@ use http::{
     },
     HeaderName, Method, StatusCode,
 };
-use http_body_util::{BodyExt, LengthLimitError, Limited};
+use ic_bn_lib::http::body::buffer_body;
 use ic_bn_lib::http::proxy::proxy;
-use ic_bn_lib::http::Client;
+use ic_bn_lib::http::{Client, Error as IcBnError};
 use ic_http_gateway::{CanisterRequest, HttpGatewayClient, HttpGatewayRequestArgs};
 use ic_types::{canister_http::CanisterHttpRequestId, CanisterId, NodeId, PrincipalId, SubnetId};
 use itertools::Itertools;
@@ -41,13 +41,13 @@ use reqwest::Url;
 use serde::{Deserialize, Serialize};
 use std::{
     collections::HashMap,
-    fmt,
     path::PathBuf,
     str::FromStr,
     sync::atomic::AtomicU64,
     sync::Arc,
     time::{Duration, SystemTime},
 };
+use strum::Display;
 use tokio::{
     sync::mpsc::error::TryRecvError,
     sync::mpsc::Receiver,
@@ -423,7 +423,7 @@ fn received_stop_signal(rx: &mut Receiver<()>) -> bool {
 
 // ADAPTED from ic-gateway
 
-const HEADER_IC_CANISTER_ID: HeaderName = HeaderName::from_static("x-ic-canister-id");
+const X_IC_CANISTER_ID: HeaderName = HeaderName::from_static("x-ic-canister-id");
 const MAX_REQUEST_BODY_SIZE: usize = 10 * 1_048_576;
 const MINUTE: Duration = Duration::from_secs(60);
 
@@ -435,7 +435,7 @@ fn layer(methods: &[Method]) -> CorsLayer {
             ACCEPT_RANGES,
             CONTENT_LENGTH,
             CONTENT_RANGE,
-            HEADER_IC_CANISTER_ID,
+            X_IC_CANISTER_ID,
         ])
         .allow_headers([
             USER_AGENT,
@@ -446,47 +446,51 @@ fn layer(methods: &[Method]) -> CorsLayer {
             CONTENT_TYPE,
             RANGE,
             COOKIE,
-            HEADER_IC_CANISTER_ID,
+            X_IC_CANISTER_ID,
         ])
         .max_age(10 * MINUTE)
 }
 
 // Categorized possible causes for request processing failures
 // Not using Error as inner type since it's not cloneable
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Display)]
 enum ErrorCause {
+    ClientBodyTooLarge,
+    ClientBodyTimeout,
+    ClientBodyError(String),
     ConnectionFailure(String),
-    UnableToReadBody(String),
-    RequestTooLarge,
     CanisterIdNotFound,
+    Other(String),
 }
 
 impl ErrorCause {
     const fn status_code(&self) -> StatusCode {
         match self {
+            Self::ClientBodyTooLarge => StatusCode::PAYLOAD_TOO_LARGE,
+            Self::ClientBodyTimeout => StatusCode::REQUEST_TIMEOUT,
+            Self::ClientBodyError(_) => StatusCode::BAD_REQUEST,
             Self::ConnectionFailure(_) => StatusCode::BAD_GATEWAY,
-            Self::UnableToReadBody(_) => StatusCode::REQUEST_TIMEOUT,
-            Self::RequestTooLarge => StatusCode::PAYLOAD_TOO_LARGE,
             Self::CanisterIdNotFound => StatusCode::BAD_REQUEST,
+            Self::Other(_) => StatusCode::INTERNAL_SERVER_ERROR,
         }
     }
 
     fn details(&self) -> Option<String> {
         match self {
+            Self::ClientBodyError(x) => Some(x.clone()),
             Self::ConnectionFailure(x) => Some(x.clone()),
-            Self::UnableToReadBody(x) => Some(x.clone()),
+            Self::Other(x) => Some(x.clone()),
             _ => None,
         }
     }
-}
 
-impl fmt::Display for ErrorCause {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            Self::ConnectionFailure(_) => write!(f, "connection_failure"),
-            Self::UnableToReadBody(_) => write!(f, "unable_to_read_body"),
-            Self::RequestTooLarge => write!(f, "request_too_large"),
-            Self::CanisterIdNotFound => write!(f, "canister_id_not_found"),
+    // Convert from client-side error
+    pub fn from_client_error(e: IcBnError) -> Self {
+        match e {
+            IcBnError::BodyReadingFailed(v) => Self::ClientBodyError(v),
+            IcBnError::BodyTimedOut => Self::ClientBodyTimeout,
+            IcBnError::BodyTooBig => Self::ClientBodyTooLarge,
+            _ => Self::Other(e.to_string()),
         }
     }
 }
@@ -591,17 +595,13 @@ async fn handler(
         let (parts, body) = request.into_parts();
 
         // Collect the request body up to the limit
-        let body = Limited::new(body, MAX_REQUEST_BODY_SIZE)
-            .collect()
-            .await
-            .map_err(|e| {
-                // TODO improve the inferring somehow
-                e.downcast_ref::<LengthLimitError>().map_or_else(
-                    || ErrorCause::UnableToReadBody(e.to_string()),
-                    |_| ErrorCause::RequestTooLarge,
-                )
-            })?
-            .to_bytes();
+        let body = buffer_body(body, MAX_REQUEST_BODY_SIZE, Duration::from_secs(60)).await;
+        let body = match body {
+            Ok(v) => v,
+            Err(e) => {
+                return Err(ErrorCause::from_client_error(e));
+            }
+        };
 
         let args = HttpGatewayRequestArgs {
             canister_request: CanisterRequest::from_parts(parts, body),

--- a/rs/pocket_ic_server/src/state_api/state.rs
+++ b/rs/pocket_ic_server/src/state_api/state.rs
@@ -882,7 +882,7 @@ impl ApiState {
                     post(proxy_handler).layer(cors_post.clone()),
                 )
                 .fallback(|| async { (StatusCode::NOT_FOUND, "") })
-                .with_state((format!("{}/api/v2", replica_url), backend_client.clone()));
+                .with_state((format!("{}/api/v3", replica_url), backend_client.clone()));
 
             let router_http = Router::new().fallback(
                 post(handler)

--- a/rs/pocket_ic_server/tests/test.rs
+++ b/rs/pocket_ic_server/tests/test.rs
@@ -1190,9 +1190,8 @@ fn test_unresponsive_gateway_backend() {
         .send()
         .unwrap();
     assert_eq!(resp.status(), StatusCode::BAD_GATEWAY);
-    assert!(String::from_utf8(resp.bytes().unwrap().as_ref().to_vec())
-        .unwrap()
-        .contains("connection_failure: HTTP request failed: error sending request for url"));
+    let page = String::from_utf8(resp.bytes().unwrap().as_ref().to_vec()).unwrap();
+    assert!(page.contains("ConnectionFailure: HTTP request failed: error sending request for url"));
 }
 
 #[test]
@@ -1369,7 +1368,7 @@ fn http_gateway_route_underscore() {
     let error_page = client.get(invalid_url).send().unwrap();
     assert_eq!(error_page.status(), StatusCode::BAD_REQUEST);
     let page = String::from_utf8(error_page.bytes().unwrap().to_vec()).unwrap();
-    assert!(page.contains("canister_id_not_found"));
+    assert!(page.contains("CanisterIdNotFound"));
 }
 
 #[test]


### PR DESCRIPTION
This PR makes the HTTP gateway router in PocketIC more consistent with ic-gateway.

See forum post: https://forum.dfinity.org/t/supported-http-methods-for-a-canister/41238