### PR TITLE
chore(idx): don't gitignore ci/src/artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,7 +88,7 @@ cpp/**/infogetty.o
 cpp/**/network_info.o
 
 # Various build artifacts
-artifacts
+/artifacts
 **/build
 **/build-tmp
 **/build-out

--- a/ci/src/artifacts/rclone_download.py
+++ b/ci/src/artifacts/rclone_download.py
@@ -65,7 +65,6 @@ class RcloneDownload:
         return self._local_repo
 
     def _merge_base(self, merge_base) -> str:
-
         self._git_fetch_branch(merge_base)
         return self.local_repo.merge_base(merge_base, self.local_repo.head.commit)
 

--- a/ci/src/artifacts/rclone_upload.py
+++ b/ci/src/artifacts/rclone_upload.py
@@ -52,9 +52,7 @@ class RcloneUpload:
 
         for i in range(MAX_RCLONE_ATTEMPTS):
             try:
-                subprocess.check_output(
-                    cmd, stderr=subprocess.STDOUT, timeout=self.timeout
-                )
+                subprocess.check_output(cmd, stderr=subprocess.STDOUT, timeout=self.timeout)
                 break
             except subprocess.CalledProcessError as e:
                 # stop-gap solution to IDX-2477
@@ -65,9 +63,7 @@ class RcloneUpload:
                         e.output,
                         e,
                     )
-                    logging.warning(
-                        "Tried to modify a file that already exists. Failing open, see IDX-2477"
-                    )
+                    logging.warning("Tried to modify a file that already exists. Failing open, see IDX-2477")
                     break
                 logging.warning(
                     "rclone failed (%d) with exception: %s\n%s",
@@ -151,8 +147,7 @@ def main():
     version = args.version or os.environ.get("CI_COMMIT_SHA")
     if not version:
         logging.error(
-            "Cannot determine version string either from --version nor "
-            "from CI_COMMIT_SHA environment variable"
+            "Cannot determine version string either from --version nor " "from CI_COMMIT_SHA environment variable"
         )
 
     rclone.upload_artifacts(local_path, args.remote_subdir, version)


### PR DESCRIPTION
This edits the `.gitignore` to only ignore `artifacts` in the top-level directory. Otherwise, directories like `ci/src/artifacts` are ignored by git.

This also formats some Python files that are now taken into account by the formatting checks (were previously git ignored).