### PR TITLE
feat(crypto): CRP-2700 support public key validation in ic-vetkd-utils

### DIFF
--- a/packages/ic-vetkd-utils/src/lib.rs
+++ b/packages/ic-vetkd-utils/src/lib.rs
@@ -107,7 +107,7 @@ impl TransportSecretKey {
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 /// A derived public key
-struct DerivedPublicKey {
+pub struct DerivedPublicKey {
     point: G2Affine,
 }
 
@@ -119,16 +119,25 @@ impl From<DerivedPublicKey> for G2Affine {
 
 #[derive(Copy, Clone, Debug)]
 /// Error indicating deserializing a derived public key failed
-enum DerivedPublicKeyDeserializationError {
-    /// The public key was invalid
+pub enum DerivedPublicKeyDeserializationError {
+    /// The public key is invalid
     InvalidPublicKey,
 }
 
 impl DerivedPublicKey {
     const BYTES: usize = G2AFFINE_BYTES;
 
-    /// Deserialize a derived public key
-    fn deserialize(bytes: &[u8]) -> Result<Self, DerivedPublicKeyDeserializationError> {
+    /// Deserializes a (derived) public key.
+    ///
+    /// Only compressed points are supported.
+    ///
+    /// Normally the bytes provided here will have been returned by the
+    /// Internet Computer's `vetkd_public_key`` management canister interface.
+    ///
+    /// Returns an error if the key is invalid (e.g., it has invalid length,
+    /// i.e., not 96 bytes, it is not in compressed format, is is not a point
+    /// on the curve, it is not torsion-free).
+    pub fn deserialize(bytes: &[u8]) -> Result<Self, DerivedPublicKeyDeserializationError> {
         let dpk_bytes: &[u8; Self::BYTES] = bytes.try_into().map_err(|_e: TryFromSliceError| {
             DerivedPublicKeyDeserializationError::InvalidPublicKey
         })?;

--- a/packages/ic-vetkd-utils/tests/tests.rs
+++ b/packages/ic-vetkd-utils/tests/tests.rs
@@ -43,6 +43,11 @@ fn protocol_flow_with_emulated_server_side() {
     );
 
     let dpk_bytes = derived_public_key.to_compressed().to_vec();
+    assert!(DerivedPublicKey::deserialize(&dpk_bytes).is_ok());
+    assert_eq!(
+        G2Affine::from(DerivedPublicKey::deserialize(&dpk_bytes).unwrap()),
+        derived_public_key
+    );
 
     let ibe_key = tsk.decrypt(&ek, &dpk_bytes, &did).unwrap();
 


### PR DESCRIPTION
Makes `ic-vetkd-utils::DerivedPublicKey` and its `DerivedPublicKey::deserialize` `pub`lic, so that public keys returned by the IC's management canister interface `vetkd_public_key` can easily be validated without having to resort to other libraries (e.g., `ic_bls12_381` or `ic_crypto_internal_bls12_381_vetkd`).