### PR TITLE
fix(IDX): remove leftover BAZEL_CI_CONFIG

### DIFF
--- a/.github/workflows-source/schedule-hourly.yml
+++ b/.github/workflows-source/schedule-hourly.yml
@@ -62,7 +62,6 @@ jobs:
         env:
           CLOUD_CREDENTIALS_CONTENT: ${{ secrets.CLOUD_CREDENTIALS_CONTENT }}
         with:
-          BAZEL_CI_CONFIG: ""
           BAZEL_COMMAND: >-
             build
               --config=ci

--- a/.github/workflows/schedule-hourly.yml
+++ b/.github/workflows/schedule-hourly.yml
@@ -33,7 +33,6 @@ jobs:
         env:
           CLOUD_CREDENTIALS_CONTENT: ${{ secrets.CLOUD_CREDENTIALS_CONTENT }}
         with:
-          BAZEL_CI_CONFIG: ""
           BAZEL_COMMAND: >-
             build
 


### PR DESCRIPTION
The `--config=ci` argument was inlined but the action input `BAZEL_CI_CONFIG` was left behind.