### PR TITLE
test(ICP_Rosetta): FI-1646: Revert ICP Rosetta integration tests timeout bump

### DIFF
--- a/rs/rosetta-api/icp/tests/integration_tests/BUILD.bazel
+++ b/rs/rosetta-api/icp/tests/integration_tests/BUILD.bazel
@@ -37,7 +37,6 @@ rust_library(
 
 rust_test_suite(
     name = "rosetta-integration",
-    timeout = "long",
     srcs = ["tests/tests.rs"],
     data = [
         "//rs/canister_sandbox",


### PR DESCRIPTION
Revert the timeout bump for the ICP Rosetta integration tests.