### PR TITLE
feat(PocketIC): new builder function PocketIcBuilder::with_server_binary

### DIFF
--- a/packages/pocket-ic/CHANGELOG.md
+++ b/packages/pocket-ic/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The function `PocketIc::set_certified_time` to set the current certified time on all subnets of the PocketIC instance.
 - The function `PocketIc::update_call_with_effective_principal` is made public. It is helpful, e.g., for
   modeling management canister calls that need to be routed to the right subnet using effective principals.
-- The function `PocketIcBuilder::with_server_binary` to provide a path to the PocketIC server binary used instead of the environment variable `POCKET_IC_BIN`.
+- The function `PocketIcBuilder::with_server_binary` to provide a path to the PocketIC server binary used instead of the environment variable `POCKET_IC_BIN` and the current working directory.
 
 ### Changed
 - The response types `pocket_ic::WasmResult`, `pocket_ic::UserError`, and `pocket_ic::CallError` are replaced by a single reject response type `pocket_ic::RejectResponse`.

--- a/packages/pocket-ic/CHANGELOG.md
+++ b/packages/pocket-ic/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The function `PocketIc::set_certified_time` to set the current certified time on all subnets of the PocketIC instance.
 - The function `PocketIc::update_call_with_effective_principal` is made public. It is helpful, e.g., for
   modeling management canister calls that need to be routed to the right subnet using effective principals.
-- The function `PocketIcBuilder::with_server_binary` to provide a path to the PocketIC server binary used to start a server process if necessary.
+- The function `PocketIcBuilder::with_server_binary` to provide a path to the PocketIC server binary used instead of the environment variable `POCKET_IC_BIN`.
 
 ### Changed
 - The response types `pocket_ic::WasmResult`, `pocket_ic::UserError`, and `pocket_ic::CallError` are replaced by a single reject response type `pocket_ic::RejectResponse`.

--- a/packages/pocket-ic/CHANGELOG.md
+++ b/packages/pocket-ic/CHANGELOG.md
@@ -19,7 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (round execution must be triggered separarely, e.g., on a "live" instance or by separate PocketIC library calls).
 - The function `PocketIc::set_certified_time` to set the current certified time on all subnets of the PocketIC instance.
 - The function `PocketIc::update_call_with_effective_principal` is made public. It is helpful, e.g., for
-modeling management canister calls that need to be routed to the right subnet using effective principals.
+  modeling management canister calls that need to be routed to the right subnet using effective principals.
+- The function `PocketIcBuilder::with_server_binary` to provide a path to the PocketIC server binary used to start a server process if necessary.
 
 ### Changed
 - The response types `pocket_ic::WasmResult`, `pocket_ic::UserError`, and `pocket_ic::CallError` are replaced by a single reject response type `pocket_ic::RejectResponse`.

--- a/packages/pocket-ic/src/lib.rs
+++ b/packages/pocket-ic/src/lib.rs
@@ -1678,8 +1678,10 @@ pub(crate) fn start_or_reuse_server(server_binary: Option<PathBuf>) -> Url {
         panic!("
 Could not find the PocketIC binary.
 
-The PocketIC binary could not be found at {:?}{}. Please specify the path to the binary using `PocketIcBuilder::with_server_binary`, the `POCKET_IC_BIN` environment variable, \
-or place it in your current working directory (you are running PocketIC from {:?}).
+The PocketIC binary could not be found at {:?}{}. Please specify the path to the binary\n
+  - using the function `PocketIcBuilder::with_server_binary`,\n
+  - or using the `POCKET_IC_BIN` environment variable,\n
+  - or place it in your current working directory (you are running PocketIC from {:?}).\n
 
 To download the binary, please visit https://github.com/dfinity/pocketic."
 , bin_path, is_dir, &std::env::current_dir().map(|x| x.display().to_string()).unwrap_or_else(|_| "an unknown directory".to_string()));

--- a/packages/pocket-ic/src/lib.rs
+++ b/packages/pocket-ic/src/lib.rs
@@ -1635,9 +1635,10 @@ pub enum IngressStatusResult {
 }
 
 #[cfg(windows)]
-fn wsl_path(path: &std::ffi::OsStr, desc: &str) -> String {
+fn wsl_path(path: &PathBuf, desc: &str) -> String {
     windows_to_wsl(
-        path.to_str()
+        path.as_os_str()
+            .to_str()
             .unwrap_or_else(|| panic!("Could not convert {} path ({:?}) to String", desc, path)),
     )
     .unwrap_or_else(|e| {

--- a/packages/pocket-ic/src/lib.rs
+++ b/packages/pocket-ic/src/lib.rs
@@ -164,7 +164,7 @@ impl PocketIcBuilder {
         .await
     }
 
-    /// Provide a path to the PocketIC server binary used to start a server process if necessary.
+    /// Provide a path to the PocketIC server binary used instead of the environment variable `POCKET_IC_BIN`.
     pub fn with_server_binary(mut self, server_binary: PathBuf) -> Self {
         self.server_binary = Some(server_binary);
         self
@@ -1678,7 +1678,7 @@ pub(crate) fn start_or_reuse_server(server_binary: Option<PathBuf>) -> Url {
         panic!("
 Could not find the PocketIC binary.
 
-The PocketIC binary could not be found at {:?}{}. Please specify the path to the binary with the POCKET_IC_BIN environment variable, \
+The PocketIC binary could not be found at {:?}{}. Please specify the path to the binary using `PocketIcBuilder::with_server_binary`, the `POCKET_IC_BIN` environment variable, \
 or place it in your current working directory (you are running PocketIC from {:?}).
 
 To download the binary, please visit https://github.com/dfinity/pocketic."

--- a/packages/pocket-ic/src/lib.rs
+++ b/packages/pocket-ic/src/lib.rs
@@ -76,7 +76,7 @@ use serde::{Deserialize, Serialize};
 use slog::Level;
 use std::{
     net::SocketAddr,
-    path::{Path, PathBuf},
+    path::PathBuf,
     process::Command,
     sync::{mpsc::channel, Arc},
     thread,
@@ -103,6 +103,7 @@ const LOCALHOST: &str = "127.0.0.1";
 
 pub struct PocketIcBuilder {
     config: Option<ExtendedSubnetConfigSet>,
+    server_binary: Option<PathBuf>,
     server_url: Option<Url>,
     max_request_time_ms: Option<u64>,
     state_dir: Option<PathBuf>,
@@ -116,6 +117,7 @@ impl PocketIcBuilder {
     pub fn new() -> Self {
         Self {
             config: None,
+            server_binary: None,
             server_url: None,
             max_request_time_ms: Some(DEFAULT_MAX_REQUEST_TIME_MS),
             state_dir: None,
@@ -132,7 +134,9 @@ impl PocketIcBuilder {
     }
 
     pub fn build(self) -> PocketIc {
-        let server_url = self.server_url.unwrap_or_else(crate::start_or_reuse_server);
+        let server_url = self
+            .server_url
+            .unwrap_or_else(|| start_or_reuse_server(self.server_binary));
         PocketIc::from_components(
             self.config.unwrap_or_default(),
             server_url,
@@ -145,7 +149,9 @@ impl PocketIcBuilder {
     }
 
     pub async fn build_async(self) -> PocketIcAsync {
-        let server_url = self.server_url.unwrap_or_else(crate::start_or_reuse_server);
+        let server_url = self
+            .server_url
+            .unwrap_or_else(|| start_or_reuse_server(self.server_binary));
         PocketIcAsync::from_components(
             self.config.unwrap_or_default(),
             server_url,
@@ -156,6 +162,12 @@ impl PocketIcBuilder {
             self.bitcoind_addr,
         )
         .await
+    }
+
+    /// Provide a path to the PocketIC server binary used to start a server process if necessary.
+    pub fn with_server_binary(mut self, server_binary: PathBuf) -> Self {
+        self.server_binary = Some(server_binary);
+        self
     }
 
     /// Use an already running PocketIC server.
@@ -485,7 +497,7 @@ impl PocketIc {
     /// List all instances and their status.
     #[instrument(ret)]
     pub fn list_instances() -> Vec<String> {
-        let url = crate::start_or_reuse_server().join("instances").unwrap();
+        let url = start_or_reuse_server(None).join("instances").unwrap();
         let instances: Vec<String> = reqwest::blocking::Client::new()
             .get(url)
             .send()
@@ -1637,24 +1649,27 @@ fn wsl_path(path: &std::ffi::OsStr, desc: &str) -> String {
 }
 
 #[cfg(windows)]
-fn pocket_ic_server_cmd(bin_path: &std::ffi::OsStr) -> Command {
+fn pocket_ic_server_cmd(bin_path: &PathBuf) -> Command {
     let mut cmd = Command::new("wsl");
     cmd.arg(wsl_path(bin_path, "PocketIC binary"));
     cmd
 }
 
 #[cfg(not(windows))]
-fn pocket_ic_server_cmd(bin_path: &std::ffi::OsStr) -> Command {
+fn pocket_ic_server_cmd(bin_path: &PathBuf) -> Command {
     Command::new(bin_path)
 }
 
 /// Attempt to start a new PocketIC server if it's not already running.
-pub fn start_or_reuse_server() -> Url {
-    let bin_path: std::ffi::OsString =
-        std::env::var_os("POCKET_IC_BIN").unwrap_or("./pocket-ic".into());
+pub(crate) fn start_or_reuse_server(server_binary: Option<PathBuf>) -> Url {
+    let bin_path: PathBuf = server_binary.unwrap_or_else(|| {
+        std::env::var_os("POCKET_IC_BIN")
+            .unwrap_or_else(|| "./pocket-ic".into())
+            .into()
+    });
 
-    if !Path::new(&bin_path).is_file() {
-        let is_dir = if Path::new(&bin_path).is_dir() {
+    if !bin_path.as_path().is_file() {
+        let is_dir = if bin_path.as_path().is_dir() {
             " (this is a directory, but it should be a binary file)"
         } else {
             ""
@@ -1666,7 +1681,7 @@ The PocketIC binary could not be found at {:?}{}. Please specify the path to the
 or place it in your current working directory (you are running PocketIC from {:?}).
 
 To download the binary, please visit https://github.com/dfinity/pocketic."
-, &bin_path, is_dir, &std::env::current_dir().map(|x| x.display().to_string()).unwrap_or_else(|_| "an unknown directory".to_string()));
+, bin_path, is_dir, &std::env::current_dir().map(|x| x.display().to_string()).unwrap_or_else(|_| "an unknown directory".to_string()));
     }
 
     // check PocketIC server version compatibility

--- a/packages/pocket-ic/src/lib.rs
+++ b/packages/pocket-ic/src/lib.rs
@@ -1714,10 +1714,7 @@ To download the binary, please visit https://github.com/dfinity/pocketic."
     let mut cmd = pocket_ic_server_cmd(&bin_path);
     cmd.arg("--port-file");
     #[cfg(windows)]
-    cmd.arg(wsl_path(
-        port_file_path.as_path().as_os_str(),
-        "PocketIC port file",
-    ));
+    cmd.arg(wsl_path(&port_file_path, "PocketIC port file"));
     #[cfg(not(windows))]
     cmd.arg(port_file_path.clone());
     if let Ok(mute_server) = std::env::var("POCKET_IC_MUTE_SERVER") {

--- a/packages/pocket-ic/src/lib.rs
+++ b/packages/pocket-ic/src/lib.rs
@@ -164,7 +164,7 @@ impl PocketIcBuilder {
         .await
     }
 
-    /// Provide a path to the PocketIC server binary used instead of the environment variable `POCKET_IC_BIN`.
+    /// Provide a path to the PocketIC server binary used instead of the environment variable `POCKET_IC_BIN` and the current working directory.
     pub fn with_server_binary(mut self, server_binary: PathBuf) -> Self {
         self.server_binary = Some(server_binary);
         self

--- a/packages/pocket-ic/src/lib.rs
+++ b/packages/pocket-ic/src/lib.rs
@@ -1675,7 +1675,8 @@ pub(crate) fn start_or_reuse_server(server_binary: Option<PathBuf>) -> Url {
         } else {
             ""
         };
-        panic!("
+        panic!(
+            "
 Could not find the PocketIC binary.
 
 The PocketIC binary could not be found at {:?}{}. Please specify the path to the binary\n
@@ -1683,8 +1684,13 @@ The PocketIC binary could not be found at {:?}{}. Please specify the path to the
   - or using the `POCKET_IC_BIN` environment variable,\n
   - or place it in your current working directory (you are running PocketIC from {:?}).\n
 
-To download the binary, please visit https://github.com/dfinity/pocketic."
-, bin_path, is_dir, &std::env::current_dir().map(|x| x.display().to_string()).unwrap_or_else(|_| "an unknown directory".to_string()));
+To download the binary, please visit https://github.com/dfinity/pocketic.",
+            bin_path,
+            is_dir,
+            &std::env::current_dir()
+                .map(|x| x.display().to_string())
+                .unwrap_or_else(|_| "an unknown directory".to_string())
+        );
     }
 
     // check PocketIC server version compatibility

--- a/packages/pocket-ic/src/nonblocking.rs
+++ b/packages/pocket-ic/src/nonblocking.rs
@@ -246,7 +246,9 @@ impl PocketIc {
     /// List all instances and their status.
     #[instrument(ret)]
     pub async fn list_instances() -> Vec<String> {
-        let url = crate::start_or_reuse_server().join("instances").unwrap();
+        let url = crate::start_or_reuse_server(None)
+            .join("instances")
+            .unwrap();
         let instances: Vec<String> = reqwest::Client::new()
             .get(url)
             .send()


### PR DESCRIPTION
This PR adds the function `PocketIcBuilder::with_server_binary` to provide a path to the PocketIC server binary used to start a server process if necessary. This is an alternative to use the environment variable `POCKET_IC_BIN` in contexts where setting that environment variable is infeasible or undesirable.