### PR TITLE
chore(PocketIC): start PocketIC server in the background

### DIFF
--- a/packages/pocket-ic/src/lib.rs
+++ b/packages/pocket-ic/src/lib.rs
@@ -1711,6 +1711,14 @@ To download the binary, please visit https://github.com/dfinity/pocketic."
         }
     }
 
+    // Start the server in the background so that it doesn't receive signals such as CTRL^C
+    // from the foreground terminal.
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt;
+        cmd.process_group(0);
+    }
+
     // TODO: SDK-1936
     #[allow(clippy::zombie_processes)]
     cmd.spawn()


### PR DESCRIPTION
This PR makes the PocketIC library (Rust) start the PocketIC server in the background so that the server doesn't receive signals such as CTRL^C from the foreground terminal, resulting in data races between killing the canister sandbox processes and the PocketIC server itself.