### PR TITLE
chore(icp-rosetta): add rosetta-icp release v2.1.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11941,7 +11941,7 @@ dependencies = [
 
 [[package]]
 name = "ic-rosetta-api"
-version = "2.1.1"
+version = "2.1.2"
 dependencies = [
  "actix-rt",
  "actix-web",

--- a/rs/rosetta-api/icp/BUILD.bazel
+++ b/rs/rosetta-api/icp/BUILD.bazel
@@ -98,7 +98,7 @@ MACRO_DEV_DEPENDENCIES = []
 ALIASES = {
 }
 
-ROSETTA_VERSION = "2.1.1"
+ROSETTA_VERSION = "2.1.2"
 
 rust_library(
     name = "rosetta-api",

--- a/rs/rosetta-api/icp/CHANGELOG.md
+++ b/rs/rosetta-api/icp/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## Unreleased
 
+## [2.1.2] - 2025-02-21
+### Fixes
+- fixed refresh voting power request so now the neuron controller can be specified.
+
 ## [2.1.1] - 2024-12-13
 ### Added
 - added functionality to refresh voting power on the governance canister

--- a/rs/rosetta-api/icp/Cargo.toml
+++ b/rs/rosetta-api/icp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic-rosetta-api"
-version = "2.1.1"
+version = "2.1.2"
 authors = ["The Internet Computer Project Developers"]
 description = "Build Once. Integrate Your Blockchain Everywhere. "
 edition = "2021"


### PR DESCRIPTION
This PR prepares the v2.1.2 release for ICP Rosetta, which fixes the incomplete request interface for refreshing voting power.