### PR TITLE
docs(nns): Updated CHANGELOGs for NNS canister upgrade proposals that were just made.

### DIFF
--- a/rs/nns/governance/CHANGELOG.md
+++ b/rs/nns/governance/CHANGELOG.md
@@ -103,6 +103,38 @@ END
 INSERT NEW RELEASES HERE
 
 
+# 2025-02-21: Proposal 135436
+
+http://dashboard.internetcomputer.org/proposal/135436
+
+## Changed
+
+* ManageNetworkEconomics proposals can now modify deep fields one at a time.
+  Previously, this was only possible for top level fields.
+
+* Added validation for ManageNetworkEconomics proposals. Previously, there was
+  none. The result must have all the following properties:
+
+  * All "optional" fields are actually set.
+
+  * `maximum_icp_xdr_rate >= minimum_icp_xdr_rate`
+
+  * Decimal fields have parsable `human_readable` values.
+
+  * `one_third_participation_milestone_xdr < full_participation_milestone_xdr`
+
+
+# 2025-02-11: Proposal 135265
+
+https://dashboard.internetcomputer.org/proposal/135265
+
+## Removed
+
+* Neuron migration (`migrate_active_neurons_to_stable_memory`) is rolled back due to issues with
+  reward distribution. It has already been rolled back with a hotfix ([proposal
+  135265](https://dashboard.internetcomputer.org/proposal/135265))
+
+
 # 2025-02-07: Proposal 135206
 
 http://dashboard.internetcomputer.org/proposal/135206
@@ -130,4 +162,3 @@ functional behavior changes, since no APIs rely on where the neurons are stored.
 ## Changed
 
 * The limit of the number of neurons is increased from 380K to 400K.
-

--- a/rs/nns/governance/unreleased_changelog.md
+++ b/rs/nns/governance/unreleased_changelog.md
@@ -11,27 +11,9 @@ on the process that this file is part of, see
 
 ## Changed
 
-* ManageNetworkEconomics proposals can now modify deep fields one at a time.
-  Previously, this was only possible for top level fields.
-
-* Added validation for ManageNetworkEconomics proposals. Previously, there was
-  none. The result must have all the following properties:
-
-  * All "optional" fields are actually set.
-
-  * `maximum_icp_xdr_rate >= minimum_icp_xdr_rate`
-
-  * Decimal fields have parsable `human_readable` values.
-
-  * `one_third_participation_milestone_xdr < full_participation_milestone_xdr`
-
 ## Deprecated
 
 ## Removed
-
-* Neuron migration (`migrate_active_neurons_to_stable_memory`) is rolled back due to issues with
-  reward distribution. It has already been rolled back with a hotfix ([proposal
-  135265](https://dashboard.internetcomputer.org/proposal/135265))
 
 ## Fixed
 

--- a/rs/nns/sns-wasm/CHANGELOG.md
+++ b/rs/nns/sns-wasm/CHANGELOG.md
@@ -11,6 +11,16 @@ here were moved from the adjacent `unreleased_changelog.md` file.
 INSERT NEW RELEASES HERE
 
 
+# 2025-02-21: Proposal 135437
+
+http://dashboard.internetcomputer.org/proposal/135437
+
+## Changed
+
+NNS Root is no longer the controller of a newly deployed SNS's Swap canister. For more details,
+please refer to [this forum thread](https://forum.dfinity.org/t/making-swap-a-proper-sns-canister/36519?u=aterga).
+
+
 # 2025-02-14: Proposal 135314
 
 http://dashboard.internetcomputer.org/proposal/135314

--- a/rs/nns/sns-wasm/unreleased_changelog.md
+++ b/rs/nns/sns-wasm/unreleased_changelog.md
@@ -11,9 +11,6 @@ on the process that this file is part of, see
 
 ## Changed
 
-NNS Root is no longer the controller of a newly deployed SNS's Swap canister. For more details,
-please refer to [this forum thread](https://forum.dfinity.org/t/making-swap-a-proper-sns-canister/36519?u=aterga).
-
 ## Deprecated
 
 ## Removed


### PR DESCRIPTION
Affected canister(s):

* Governance
* SNS-WASM

Also, we forgot to update the NNS Governance CHANGELOG during a [recent emergency upgrade]. This fixes that.

[recent emergency upgrade]: https://dashboard.internetcomputer.org/proposal/135265

No SNS WASMs are being published in this upgrade cycle.