### PR TITLE
feat(crypto): CRP-2646 use AlgorithmID::VetKD in batch delivery for vetKD

### DIFF
--- a/rs/consensus/dkg/src/utils.rs
+++ b/rs/consensus/dkg/src/utils.rs
@@ -68,7 +68,7 @@ pub fn get_vetkey_public_keys(
                 (
                     key_id.clone().into(),
                     MasterPublicKey {
-                        algorithm_id: AlgorithmId::ThresBls12_381,
+                        algorithm_id: AlgorithmId::VetKD,
                         public_key: pubkey.into_bytes().to_vec(),
                     },
                 ),


### PR DESCRIPTION
Since https://github.com/dfinity/ic/pull/3997 we use a dedicated AlgorithmID for vetKD. However, the PR missed to use this algorithm ID also in batch delivery, which led to the long running system test `//rs/tests/consensus/vetkd:vetkd_key_life_cycle_test` getting broken (see https://github.com/dfinity/ic/pull/4060). This PR fixes this by using `AlgorithmID::VetKD` also in batch delivery.