### PR TITLE
fix: EXC-1969: Fix in-round DTS for memory copy

### DIFF
--- a/rs/embedders/src/wasm_executor.rs
+++ b/rs/embedders/src/wasm_executor.rs
@@ -705,10 +705,7 @@ pub fn process(
         if execution_parameters.instruction_limits.slicing_enabled()
             && dirty_pages.get() > embedder.config().max_dirty_pages_without_optimization as u64
         {
-            // Passing zero instructions here means that heavy memory execution consumed
-            // all the round time, and the round should be finished now. It does not affect
-            // the actual canister charges.
-            if let Err(err) = system_api.yield_for_dirty_memory_copy(0) {
+            if let Err(err) = system_api.yield_for_dirty_memory_copy() {
                 // If there was an error slicing, propagate this error to the main result and return.
                 // Otherwise, the regular message path takes place.
                 return (

--- a/rs/embedders/src/wasm_executor.rs
+++ b/rs/embedders/src/wasm_executor.rs
@@ -705,7 +705,10 @@ pub fn process(
         if execution_parameters.instruction_limits.slicing_enabled()
             && dirty_pages.get() > embedder.config().max_dirty_pages_without_optimization as u64
         {
-            if let Err(err) = system_api.yield_for_dirty_memory_copy(instruction_counter) {
+            // Passing zero instructions here means that heavy memory execution consumed
+            // all the round time, and the round should be finished now. It does not affect
+            // the actual canister charges.
+            if let Err(err) = system_api.yield_for_dirty_memory_copy(0) {
                 // If there was an error slicing, propagate this error to the main result and return.
                 // Otherwise, the regular message path takes place.
                 return (

--- a/rs/interfaces/src/execution_environment.rs
+++ b/rs/interfaces/src/execution_environment.rs
@@ -569,7 +569,7 @@ pub trait OutOfInstructionsHandler {
 
     // Invoked only when a long execution dirties many memory pages to yield control
     // and start the copy only in a new slice. This is a performance improvement.
-    fn yield_for_dirty_memory_copy(&self, instruction_counter: i64) -> HypervisorResult<i64>;
+    fn yield_for_dirty_memory_copy(&self) -> HypervisorResult<i64>;
 }
 
 /// Indicates the type of stable memory API being used.
@@ -993,7 +993,7 @@ pub trait SystemApi {
     /// This system call is not part of the public spec and it is invoked when
     /// Wasm execution has a large number of dirty pages that, for performance reasons,
     /// should be copied in a new execution slice.
-    fn yield_for_dirty_memory_copy(&mut self, instruction_counter: i64) -> HypervisorResult<i64>;
+    fn yield_for_dirty_memory_copy(&mut self) -> HypervisorResult<i64>;
 
     /// This system call is not part of the public spec. It's called after a
     /// native `memory.grow` has been executed to check whether there's enough


### PR DESCRIPTION
To improve finalization rates, executions generating over one gigabyte of dirty pages were previously split into execution and memory copy slices.
    
The previous implementation paused the canister, but because neither instruction nor heap delta limits were reached, the canister resumed in the next inner loop of the same round.
    
This PR always passes a zero instruction counter to the `yield_for_dirty_memory_copy`, ensuring that the round instruction limit is reached.
    
The memory copy slice reaches the `MAX_HEAP_DELTA_PER_ITERATION` limit, and does not require any fixes.
    
This fixes RUN-878.