### PR TITLE
chore(IDX): replace chown

### DIFF
--- a/.github/actions/bazel-test-all/action.yaml
+++ b/.github/actions/bazel-test-all/action.yaml
@@ -23,7 +23,7 @@ runs:
           set +e # manual error handling to ensure we can run some post-build commands
 
           # freshly deployed k8s machines require ownership correctly set
-          if [ -d /cache ]; then
+          if [ -e /cache ]; then
             sudo find /cache -not -user 1001 -or -not -group 1001 -exec chown 1001:1001 {} +
           fi
 

--- a/.github/actions/bazel-test-all/action.yaml
+++ b/.github/actions/bazel-test-all/action.yaml
@@ -23,8 +23,8 @@ runs:
           set +e # manual error handling to ensure we can run some post-build commands
 
           # freshly deployed k8s machines require ownership correctly set
-          if [ -e /cache ]; then
-            sudo chown -RL 1001:1001 /cache
+          if [ -d /cache ]; then
+            sudo find /cache -not -user 1001 -or -not -group 1001 -exec chown 1001:1001 {} +
           fi
 
           if [ -n "$SSH_PRIVATE_KEY_BACKUP_POD" ]; then


### PR DESCRIPTION
The find approach processes files individually, reducing the window for race conditions compared to the recursive chown. We try to mitigate the following issue until `/cache` has proper ownership set when we deploy new K8s node:
```
chown: cannot dereference '/cache/bazel/_bazel_buildifier/6222b2212f4432660c3f74d6b773699d/sandbox/sandbox_stash/CargoBuildScriptRun/36/execroot/_main/bazel-out/k8-opt/bin/external/crate_index__ring-0.16.20/_bs-': No such file or directory
```
