### PR TITLE
fix(IDX): remove cog.toml

### DIFF
--- a/cog.toml
+++ b/cog.toml
@@ -1,5 +1,0 @@
-from_latest_tag = false
-ignore_merge_commits = true
-
-[commit_types]
-draft = { changelog_title = "Draft" }


### PR DESCRIPTION
It looks like it was used by `cog verify` in part of a (long gone) GitLab job.