### PR TITLE
fix(IDX): remove unused .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-/hs/generated/* linguist-generated=true


### PR DESCRIPTION
It references `/hs/generated` which doesn't exist anymore.