### PR TITLE
chore(IDX): don't make nns_dapp_test as long_test

### DIFF
--- a/rs/tests/nns/BUILD.bazel
+++ b/rs/tests/nns/BUILD.bazel
@@ -46,9 +46,6 @@ system_test_nns(
         "SUBNET_RENTAL_WASM_PATH": "$(rootpath @subnet_rental_canister//file)",
     },
     flaky = False,
-    tags = [
-        "long_test",
-    ],
     target_compatible_with = ["@platforms//os:linux"],  # requires libssh that does not build on Mac OS
     runtime_deps = GUESTOS_RUNTIME_DEPS + BOUNDARY_NODE_GUESTOS_RUNTIME_DEPS + [
         "//rs/ledger_suite/icrc1/ledger:ledger_canister",


### PR DESCRIPTION
The test runs comfortably in under 3 minutes.