### PR TITLE
chore(PocketIC): remove PocketIc::try_get_controllers

### DIFF
--- a/packages/pocket-ic/CHANGELOG.md
+++ b/packages/pocket-ic/CHANGELOG.md
@@ -8,8 +8,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Added
-- The function `PocketIc::try_get_controllers` which gets the controllers of a canister but doesn't panic if the target canister
-  doesn't exist.
 - The function `PocketIcBuilder::with_bitcoind_addrs` to specify multiple addresses and ports at which `bitcoind` processes are listening.
 - The function `PocketIc::query_call_with_effective_principal` for making generic query calls (including management canister query calls).
 - The function `PocketIc::ingress_status` to fetch the status of an update call submitted through an ingress message.

--- a/packages/pocket-ic/src/lib.rs
+++ b/packages/pocket-ic/src/lib.rs
@@ -70,7 +70,7 @@ use candid::{
     Principal,
 };
 use ic_transport_types::SubnetMetrics;
-use reqwest::{StatusCode, Url};
+use reqwest::Url;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use slog::Level;
@@ -647,16 +647,6 @@ impl PocketIc {
     pub fn get_controllers(&self, canister_id: CanisterId) -> Vec<Principal> {
         let runtime = self.runtime.clone();
         runtime.block_on(async { self.pocket_ic.get_controllers(canister_id).await })
-    }
-
-    /// Get the controllers of a canister.
-    #[instrument(ret, skip(self), fields(instance_id=self.pocket_ic.instance_id, canister_id = %canister_id.to_string()))]
-    pub fn try_get_controllers(
-        &self,
-        canister_id: CanisterId,
-    ) -> Result<Vec<Principal>, (StatusCode, String)> {
-        let runtime = self.runtime.clone();
-        runtime.block_on(async { self.pocket_ic.try_get_controllers(canister_id).await })
     }
 
     /// Get the current cycles balance of a canister.

--- a/packages/pocket-ic/src/nonblocking.rs
+++ b/packages/pocket-ic/src/nonblocking.rs
@@ -519,25 +519,16 @@ impl PocketIc {
     /// Panics if the canister does not exist.
     #[instrument(ret, skip(self), fields(instance_id=self.instance_id, canister_id = %canister_id.to_string()))]
     pub async fn get_controllers(&self, canister_id: CanisterId) -> Vec<Principal> {
-        self.try_get_controllers(canister_id).await.unwrap()
-    }
-
-    /// Get the controllers of a canister.
-    #[instrument(ret, skip(self), fields(instance_id=self.instance_id, canister_id = %canister_id.to_string()))]
-    pub async fn try_get_controllers(
-        &self,
-        canister_id: CanisterId,
-    ) -> Result<Vec<Principal>, (StatusCode, String)> {
         let endpoint = "read/get_controllers";
-        let result: Result<Vec<RawPrincipalId>, (StatusCode, String)> = self
-            .try_post(
+        let result: Vec<RawPrincipalId> = self
+            .post(
                 endpoint,
                 RawCanisterId {
                     canister_id: canister_id.as_slice().to_vec(),
                 },
             )
             .await;
-        result.map(|v| v.into_iter().map(|p| p.into()).collect())
+        result.into_iter().map(|p| p.into()).collect()
     }
 
     /// Get the current cycles balance of a canister.

--- a/packages/pocket-ic/tests/tests.rs
+++ b/packages/pocket-ic/tests/tests.rs
@@ -1740,19 +1740,6 @@ fn get_controllers_of_nonexisting_canister() {
 }
 
 #[test]
-fn try_get_controllers_of_nonexisting_canister() {
-    let pic = PocketIc::new();
-
-    let canister_id = pic.create_canister();
-    pic.add_cycles(canister_id, 100_000_000_000_000);
-    pic.stop_canister(canister_id, None).unwrap();
-    pic.delete_canister(canister_id, None).unwrap();
-
-    let res = pic.try_get_controllers(canister_id);
-    assert!(res.is_err())
-}
-
-#[test]
 fn test_canister_snapshots() {
     let pic = PocketIc::new();
     let canister_id = deploy_counter_canister(&pic);

--- a/rs/nervous_system/agent/src/pocketic_impl.rs
+++ b/rs/nervous_system/agent/src/pocketic_impl.rs
@@ -148,11 +148,12 @@ impl CallCanisters for PocketIcAgent<'_> {
     ) -> Result<CanisterInfo, Self::Error> {
         let canister_id = canister_id.into();
 
-        let controllers = self
-            .pocket_ic
-            .try_get_controllers(canister_id)
-            .await
-            .unwrap_or(vec![]);
+        let canister_exists = self.pocket_ic.canister_exists(canister_id).await;
+        let controllers = if canister_exists {
+            self.pocket_ic.get_controllers(canister_id).await
+        } else {
+            vec![]
+        };
 
         let Some(controller) = controllers.into_iter().last() else {
             return Err(Self::Error::BlackHole);


### PR DESCRIPTION
This PR removes the function `PocketIc::try_get_controllers` since there already exist the functions `PocketIc::get_controllers` to get controllers of a canister that exists and `PocketIc::canister_exists` to check if a canister exists.