### PR TITLE
chore(IDX): add colors to build-ic builds

### DIFF
--- a/ci/container/build-ic.sh
+++ b/ci/container/build-ic.sh
@@ -111,6 +111,7 @@ BAZEL_TARGETS=()
 
 BAZEL_COMMON_ARGS=(
     --config=local
+    --color=yes
 )
 
 if [[ $release_build == true ]]; then


### PR DESCRIPTION
This makes the build output easier to read and aligns the format with that of `ci/bazel-scripts/main.sh`.