### PR TITLE
chore(fuzzing): bump `AFL_FORKSRV_INIT_TMOUT` to 1s

### DIFF
--- a/bin/afl_wrapper.sh
+++ b/bin/afl_wrapper.sh
@@ -86,7 +86,7 @@ function afl_env() {
         AFL_DRIVER_DONT_DEFER=1 \
         AFL_EXPAND_HAVOC_NOW=1 \
         AFL_FAST_CAL=1 \
-        AFL_FORKSRV_INIT_TMOUT=100 \
+        AFL_FORKSRV_INIT_TMOUT=1000 \
         AFL_IGNORE_PROBLEMS=1 \
         AFL_IGNORE_TIMEOUTS=1 \
         AFL_KEEP_TIMEOUTS=1 \


### PR DESCRIPTION
Bumping `AFL_FORKSRV_INIT_TMOUT` from 0.1s to 1s since some fuzzers are [timing out](https://github.com/dfinity/ic/actions/runs/13502450001/job/37724002792#step:5:557) where the forkserver is bought up. This doesn't affect the individual run timeout which is specified via `-t` parameter