### PR TITLE
chore(nns): Fix NNS Governance release log

### DIFF
--- a/rs/nns/governance/CHANGELOG.md
+++ b/rs/nns/governance/CHANGELOG.md
@@ -8,6 +8,69 @@ The process that populates this file is described in
 here were moved from the adjacent `unreleased_changelog.md` file.
 
 
+INSERT NEW RELEASES HERE
+
+
+# 2025-02-21: Proposal 135436
+
+http://dashboard.internetcomputer.org/proposal/135436
+
+## Changed
+
+* ManageNetworkEconomics proposals can now modify deep fields one at a time.
+  Previously, this was only possible for top level fields.
+
+* Added validation for ManageNetworkEconomics proposals. Previously, there was
+  none. The result must have all the following properties:
+
+  * All "optional" fields are actually set.
+
+  * `maximum_icp_xdr_rate >= minimum_icp_xdr_rate`
+
+  * Decimal fields have parsable `human_readable` values.
+
+  * `one_third_participation_milestone_xdr < full_participation_milestone_xdr`
+
+
+# 2025-02-11: Proposal 135265
+
+https://dashboard.internetcomputer.org/proposal/135265
+
+## Removed
+
+* Neuron migration (`migrate_active_neurons_to_stable_memory`) is rolled back due to issues with
+  reward distribution. It has already been rolled back with a hotfix ([proposal
+  135265](https://dashboard.internetcomputer.org/proposal/135265))
+
+
+# 2025-02-07: Proposal 135206
+
+http://dashboard.internetcomputer.org/proposal/135206
+
+## Added
+
+### List Neurons API Change: Query by Subaccount
+
+The `list_neurons` API now supports querying by neuron subaccount.  This is useful for neuron holders who
+have many neurons and want to list only the neurons associated with a particular subaccount.
+
+A new field `neuron_subaccounts` is added to the request, which is a list of subaccounts to query
+for.  If this field is present, any neurons found will be added to the response.  If duplicate
+neurons are found between this field and others, they will be deduplicated before returning the value.
+
+This new field works in the same way that the existing `neuron_ids` field works.
+
+### Migrating Active Neurons to Stable Memory
+
+In this release, we turn on the feature to migrate active neurons to stable memory:
+`migrate_active_neurons_to_stable_memory`. After the feature is turned on, a timer task will
+gradually move active neurons from the heap to stable memory. Clients should not expect any
+functional behavior changes, since no APIs rely on where the neurons are stored.
+
+## Changed
+
+* The limit of the number of neurons is increased from 380K to 400K.
+
 # 2025-02-03: Proposal 135063
 
 http://dashboard.internetcomputer.org/proposal/135063
@@ -98,67 +161,3 @@ the neuron. More precisely,
 
 
 END
-
-
-INSERT NEW RELEASES HERE
-
-
-# 2025-02-21: Proposal 135436
-
-http://dashboard.internetcomputer.org/proposal/135436
-
-## Changed
-
-* ManageNetworkEconomics proposals can now modify deep fields one at a time.
-  Previously, this was only possible for top level fields.
-
-* Added validation for ManageNetworkEconomics proposals. Previously, there was
-  none. The result must have all the following properties:
-
-  * All "optional" fields are actually set.
-
-  * `maximum_icp_xdr_rate >= minimum_icp_xdr_rate`
-
-  * Decimal fields have parsable `human_readable` values.
-
-  * `one_third_participation_milestone_xdr < full_participation_milestone_xdr`
-
-
-# 2025-02-11: Proposal 135265
-
-https://dashboard.internetcomputer.org/proposal/135265
-
-## Removed
-
-* Neuron migration (`migrate_active_neurons_to_stable_memory`) is rolled back due to issues with
-  reward distribution. It has already been rolled back with a hotfix ([proposal
-  135265](https://dashboard.internetcomputer.org/proposal/135265))
-
-
-# 2025-02-07: Proposal 135206
-
-http://dashboard.internetcomputer.org/proposal/135206
-
-## Added
-
-### List Neurons API Change: Query by Subaccount
-
-The `list_neurons` API now supports querying by neuron subaccount.  This is useful for neuron holders who
-have many neurons and want to list only the neurons associated with a particular subaccount.
-
-A new field `neuron_subaccounts` is added to the request, which is a list of subaccounts to query
-for.  If this field is present, any neurons found will be added to the response.  If duplicate
-neurons are found between this field and others, they will be deduplicated before returning the value.
-
-This new field works in the same way that the existing `neuron_ids` field works.
-
-### Migrating Active Neurons to Stable Memory
-
-In this release, we turn on the feature to migrate active neurons to stable memory:
-`migrate_active_neurons_to_stable_memory`. After the feature is turned on, a timer task will
-gradually move active neurons from the heap to stable memory. Clients should not expect any
-functional behavior changes, since no APIs rely on where the neurons are stored.
-
-## Changed
-
-* The limit of the number of neurons is increased from 380K to 400K.


### PR DESCRIPTION
The releases should be added in chronological order, with the newest at the top. In addition, `INSERT NEW RELEASES HERE` text should be on top of all the releases (so that new ones can be placed there)