### PR TITLE
feat: use socks5h schema and log url format

### DIFF
--- a/rs/https_outcalls/adapter/src/metrics.rs
+++ b/rs/https_outcalls/adapter/src/metrics.rs
@@ -52,7 +52,12 @@ impl AdapterMetrics {
             socks_connection_attempts: metrics_registry.int_counter_vec(
                 "socks_connection_attempts_total",
                 "Total number of time the adapter tries to proxy a request via a SOCKS proxy",
-                &["attempt_number", "status", "socks_proxy_address", "url_format"],
+                &[
+                    "attempt_number",
+                    "status",
+                    "socks_proxy_address",
+                    "url_format",
+                ],
             ),
             socks_cache_size: metrics_registry.int_gauge(
                 "socks_cache_size",

--- a/rs/https_outcalls/adapter/src/metrics.rs
+++ b/rs/https_outcalls/adapter/src/metrics.rs
@@ -52,7 +52,7 @@ impl AdapterMetrics {
             socks_connection_attempts: metrics_registry.int_counter_vec(
                 "socks_connection_attempts_total",
                 "Total number of time the adapter tries to proxy a request via a SOCKS proxy",
-                &["attempt_number", "status", "socks_proxy_address"],
+                &["attempt_number", "status", "socks_proxy_address", "url_format"],
             ),
             socks_cache_size: metrics_registry.int_gauge(
                 "socks_cache_size",

--- a/rs/https_outcalls/adapter/src/rpc_server.rs
+++ b/rs/https_outcalls/adapter/src/rpc_server.rs
@@ -27,6 +27,7 @@ use ic_metrics::MetricsRegistry;
 use parking_lot::{RwLock, RwLockUpgradableReadGuard};
 use rand::{seq::SliceRandom, thread_rng};
 use std::collections::BTreeMap;
+use std::net::{Ipv4Addr, Ipv6Addr};
 use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Duration;
@@ -201,6 +202,26 @@ impl CanisterHttp {
         }
     }
 
+    fn classify_uri_host(uri: &Uri) -> String {
+        let host = match uri.host() {
+            Some(h) => h,
+            None => return "empty".to_string(),
+        };
+    
+        if host.parse::<Ipv4Addr>().is_ok() {
+            return format!("v4");
+        }
+    
+        if host.starts_with('[') && host.ends_with(']') {
+            let inside = &host[1..host.len()-1];
+            if inside.parse::<Ipv6Addr>().is_ok() {
+                return format!("v6");
+            }
+        }
+    
+        format!("domain_name")
+    }
+
     async fn do_https_outcall_socks_proxy(
         &self,
         socks_proxy_addrs: Vec<String>,
@@ -230,18 +251,20 @@ impl CanisterHttp {
 
             let socks_client = self.get_socks_client(socks_proxy_uri);
 
+            let url_format = Self::classify_uri_host(&request.uri());
+
             match socks_client.request(request.clone()).await {
                 Ok(resp) => {
                     self.metrics
                         .socks_connection_attempts
-                        .with_label_values(&[&tries.to_string(), "success", socks_proxy_addr])
+                        .with_label_values(&[&tries.to_string(), "success", socks_proxy_addr, &url_format])
                         .inc();
                     return Ok(resp);
                 }
                 Err(socks_err) => {
                     self.metrics
                         .socks_connection_attempts
-                        .with_label_values(&[&tries.to_string(), "failure", socks_proxy_addr])
+                        .with_label_values(&[&tries.to_string(), "failure", socks_proxy_addr, &url_format])
                         .inc();
                     debug!(
                         self.logger,
@@ -626,5 +649,18 @@ mod tests {
         ];
         let headers = validate_headers(header_vec).unwrap();
         assert_eq!(headers.len(), 3);
+    }
+
+    #[test]
+    fn test_classify_uri_host() {
+        let ipv4_url = "http://127.0.0.1/path";
+        let ipv6_url = "http://[2001:db8::1]/path";
+        let domain_name_url = "http://example.com/something";
+        let empty_hostname_url = "/hello/world";
+        
+        assert_eq!(CanisterHttp::classify_uri_host(&Uri::from_str(ipv4_url).unwrap()), "v4");
+        assert_eq!(CanisterHttp::classify_uri_host(&Uri::from_str(ipv6_url).unwrap()), "v6");
+        assert_eq!(CanisterHttp::classify_uri_host(&Uri::from_str(domain_name_url).unwrap()), "domain_name");
+        assert_eq!(CanisterHttp::classify_uri_host(&Uri::from_str(empty_hostname_url).unwrap()), "empty");
     }
 }

--- a/rs/https_outcalls/adapter/src/rpc_server.rs
+++ b/rs/https_outcalls/adapter/src/rpc_server.rs
@@ -202,24 +202,23 @@ impl CanisterHttp {
         }
     }
 
-    fn classify_uri_host(uri: &Uri) -> String {
-        let host = match uri.host() {
-            Some(h) => h,
-            None => return "empty".to_string(),
+    fn classify_uri_host(uri: &Uri) -> &str {
+        let Some(host) = uri.host() else {
+            return "empty";
         };
 
         if host.parse::<Ipv4Addr>().is_ok() {
-            return "v4".to_string();
+            return "v4";
         }
 
         if host.starts_with('[') && host.ends_with(']') {
             let inside = &host[1..host.len() - 1];
             if inside.parse::<Ipv6Addr>().is_ok() {
-                return "v6".to_string();
+                return "v6";
             }
         }
 
-        "domain_name".to_string()
+        "domain_name"
     }
 
     async fn do_https_outcall_socks_proxy(
@@ -261,7 +260,7 @@ impl CanisterHttp {
                             &tries.to_string(),
                             "success",
                             socks_proxy_addr,
-                            &url_format,
+                            url_format,
                         ])
                         .inc();
                     return Ok(resp);
@@ -273,7 +272,7 @@ impl CanisterHttp {
                             &tries.to_string(),
                             "failure",
                             socks_proxy_addr,
-                            &url_format,
+                            url_format,
                         ])
                         .inc();
                     debug!(
@@ -288,7 +287,7 @@ impl CanisterHttp {
         }
 
         if let Some(last_error) = last_error {
-            Err(last_error.to_string())
+            Err(format!("{:?}", last_error))
         } else {
             Err("No SOCKS proxy addresses provided".to_string())
         }

--- a/rs/https_outcalls/adapter/src/rpc_server.rs
+++ b/rs/https_outcalls/adapter/src/rpc_server.rs
@@ -146,11 +146,19 @@ impl CanisterHttp {
         dl_result: &Result<http::Response<Incoming>, String>,
     ) {
         match (result, dl_result) {
-            (Ok(_), Ok(_)) => {
+            (Ok(result), Ok(dl_result)) => {
                 self.metrics
                     .socks_proxy_dl_requests
                     .with_label_values(&[LABEL_SOCKS_PROXY_OK, LABEL_SOCKS_PROXY_OK])
                     .inc();
+                if result.status() != dl_result.status() {
+                    info!(
+                        self.logger,
+                        "SOCKS_PROXY_DL: status code mismatch: {} vs {}",
+                        result.status(),
+                        dl_result.status(),
+                    );
+                }
             }
             (Err(_), Err(_)) => {
                 self.metrics

--- a/rs/https_outcalls/consensus/src/pool_manager.rs
+++ b/rs/https_outcalls/consensus/src/pool_manager.rs
@@ -191,7 +191,7 @@ impl CanisterHttpPoolManagerImpl {
                             None
                         })
                     })
-                    .map(|http_info| format!("socks5://[{0}]:1080", http_info.ip_addr))
+                    .map(|http_info| format!("socks5h://[{0}]:1080", http_info.ip_addr))
             })
             .collect::<Vec<String>>()
     }


### PR DESCRIPTION
The socks proxy dark launch works on ~1% of all requests. on 99% it results in generic Hyper error.

During system testing, it seemed like socks5h had more success.

I also have a suspicion that currently only URLs containing IPv4 work, but it's best to confirm that.

It's important due to privacy reasons not to log the whole URL itself. Instead we are only looking at its "format": IPv4, IPv6, domain name, or empty.