### PR TITLE
fix: Compatibility xnet test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1887,6 +1887,7 @@ dependencies = [
  "ic-types",
  "on_wire",
  "rand 0.8.5",
+ "serde",
  "tokio",
  "wasmprinter",
  "wat",

--- a/rs/rust_canisters/canister_test/BUILD.bazel
+++ b/rs/rust_canisters/canister_test/BUILD.bazel
@@ -19,6 +19,7 @@ DEPENDENCIES = [
     "@crate_index//:cargo_metadata",
     "@crate_index//:escargot",
     "@crate_index//:rand",
+    "@crate_index//:serde",
     "@crate_index//:tokio",
     "@crate_index//:wasmprinter",
     "@crate_index//:wat",

--- a/rs/rust_canisters/canister_test/Cargo.toml
+++ b/rs/rust_canisters/canister_test/Cargo.toml
@@ -22,6 +22,7 @@ ic-state-machine-tests = { path = "../../state_machine_tests" }
 ic-types = { path = "../../types/types" }
 on_wire = { path = "../on_wire" }
 rand = { workspace = true }
+serde = { workspace = true }
 tokio = { workspace = true }
 wasmprinter = { workspace = true }
 wat = { workspace = true }

--- a/rs/rust_canisters/canister_test/src/canister.rs
+++ b/rs/rust_canisters/canister_test/src/canister.rs
@@ -29,7 +29,7 @@ use std::{
     time::Duration,
 };
 
-// Temporary copy of `ic_management_canister_typesL::private::CanisterStatusResultV2`
+// Temporary copy of `ic_management_canister_types_private::CanisterStatusResultV2`
 // without the new `memory_metrics` field until the change is rolled out to production.
 #[derive(Eq, PartialEq, Debug, CandidType, Deserialize)]
 pub struct CanisterStatusResultV2 {


### PR DESCRIPTION
This [commit](https://github.com/dfinity/ic/commit/a944a8b331f1562508a5dde68f6eafcfbb54fe44) broke the xnet compatibility test by adding a new field to `CanisterStatusResultV2`. This is an artifact of depending on the private management types instead of using the public version of the types as client code is supposed to do. Replicas never attempt to decode this type, they only produce it so there's no real issue with the IC's compatibility.

The quick fix here is to make a temporary copy of the type without the new field until the change is rolled out and then drop the copy in favour of using the public types. Additionally, the [check](https://sourcegraph.com/github.com/dfinity/ic@6c12598a8e5ab3a1a241af5b51d5a27990b8177e/-/blob/rs/rust_canisters/canister_test/src/canister.rs?L810-L820) of `canister_status` can be removed altogether when stopping a canister as it's redundant -- if the `canister_stop` request receives a reply, then the canister is stopped (otherwise a timeout error would be received). 