### PR TITLE
fix(sns): Bound SNS Governance response size for proposal submission

### DIFF
--- a/rs/sns/governance/src/governance/assorted_governance_tests.rs
+++ b/rs/sns/governance/src/governance/assorted_governance_tests.rs
@@ -801,8 +801,17 @@ async fn test_disallow_enabling_voting_rewards_while_in_pre_initialization_swap(
     };
 
     let err = err.error_message.to_lowercase();
-    assert!(err.contains("mode"), "{:#?}", err);
-    assert!(err.contains("vot"), "{:#?}", err);
+    assert!(
+        err.contains("manage nervous system parameters"),
+        "{:#?}",
+        err
+    );
+    assert!(err.contains("not allowed"), "{:#?}", err);
+    assert!(
+        err.contains("in preinitializationswap (2) mode"),
+        "{:#?}",
+        err
+    );
 }
 
 #[tokio::test]

--- a/rs/sns/governance/src/types.rs
+++ b/rs/sns/governance/src/types.rs
@@ -16,7 +16,7 @@ use crate::{
             governance::{
                 self,
                 neuron_in_flight_command::{self, SyncCommand},
-                SnsMetadata, Version,
+                Mode, SnsMetadata, Version,
             },
             governance_error::ErrorType,
             manage_neuron,
@@ -274,17 +274,20 @@ impl governance::Mode {
                 );
         }
 
+        let nervous_system_function = NervousSystemFunction::from(action.clone());
+
         let is_action_disallowed = Self::functions_disallowed_in_pre_initialization_swap()
             .into_iter()
-            .any(|t| t.id == NervousSystemFunction::from(action.clone()).id);
+            .any(|t| t.id == nervous_system_function.id);
 
         if is_action_disallowed {
             Err(GovernanceError::new_with_message(
                 ErrorType::PreconditionFailed,
                 format!(
-                    "This proposal type is not allowed while governance is in \
-                     PreInitializationSwap mode: {:#?}",
-                    action,
+                    "Proposal type for {:?} is not allowed while governance is in \
+                     PreInitializationSwap ({}) mode.",
+                    nervous_system_function,
+                    Mode::PreInitializationSwap as i32,
                 ),
             ))
         } else {

--- a/rs/sns/governance/unreleased_changelog.md
+++ b/rs/sns/governance/unreleased_changelog.md
@@ -43,6 +43,9 @@ for newly deployed SNSs. To opt out, please submit a `ManageNervousSystemParamet
 
 ## Fixed
 
-`ManageNervousSystemParameters` proposals now enforce that at least one field is set.
+* `ManageNervousSystemParameters` proposals now enforce that at least one field is set.
+
+* Errors caused by trying to submit proposals restricted in pre-initialization mode should no
+  longer overflow.
 
 ## Security


### PR DESCRIPTION
This PR ensures that the whole proposal payload doesn't get debug-printed into the error that SNS Governance needs to serialize and send back to the client upon proposal rejection.