### PR TITLE
chore: release PocketIC server v8 and PocketIC library v7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17688,7 +17688,7 @@ dependencies = [
 
 [[package]]
 name = "pocket-ic"
-version = "6.0.0"
+version = "7.0.0"
 dependencies = [
  "backoff",
  "base64 0.13.1",
@@ -17725,7 +17725,7 @@ dependencies = [
 
 [[package]]
 name = "pocket-ic-server"
-version = "7.0.0"
+version = "8.0.0"
 dependencies = [
  "aide",
  "askama",

--- a/packages/pocket-ic/BUILD.bazel
+++ b/packages/pocket-ic/BUILD.bazel
@@ -48,7 +48,7 @@ rust_library(
     name = "pocket-ic",
     srcs = glob(["src/**/*.rs"]),
     proc_macro_deps = MACRO_DEPENDENCIES,
-    version = "6.0.0",
+    version = "7.0.0",
     deps = DEPENDENCIES,
 )
 

--- a/packages/pocket-ic/CHANGELOG.md
+++ b/packages/pocket-ic/CHANGELOG.md
@@ -7,17 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 7.0.0 - 2025-02-26
+
 ### Added
 - The function `PocketIcBuilder::with_bitcoind_addrs` to specify multiple addresses and ports at which `bitcoind` processes are listening.
-- The function `PocketIc::query_call_with_effective_principal` for making generic query calls (including management canister query calls).
+- The function `PocketIc::new_from_existing_instance` to create a PocketIC handle to an existing instance on a running server.
+- The function `PocketIc::get_server_url` returning the URL of the PocketIC server on which the PocketIC instance is running.
+- The functions `PocketIc::update_call_with_effective_principal` and `PocketIc::query_call_with_effective_principal` for making generic query calls (including management canister query calls).
 - The function `PocketIc::ingress_status` to fetch the status of an update call submitted through an ingress message.
 - The function `PocketIc::ingress_status_as` to fetch the status of an update call submitted through an ingress message.
   If the status of the update call is known, but the update call was submitted by a different caller, then an error is returned.
 - The function `PocketIc::await_call_no_ticks` to await the status of an update call (submitted through an ingress message) becoming known without triggering round execution
   (round execution must be triggered separarely, e.g., on a "live" instance or by separate PocketIC library calls).
 - The function `PocketIc::set_certified_time` to set the current certified time on all subnets of the PocketIC instance.
-- The function `PocketIc::update_call_with_effective_principal` is made public. It is helpful, e.g., for
-  modeling management canister calls that need to be routed to the right subnet using effective principals.
+- The function `PocketIc::tick_with_configs` extending the function `PocketIc::tick` with an argument optionally containing the blockmaker and failed blockmakers
+  for every subnet used by the endpoint `node_metrics_history` of the management canister.
 - The function `PocketIcBuilder::with_server_binary` to provide the path to the PocketIC server binary used instead of the environment variable `POCKET_IC_BIN`.
 
 ### Changed
@@ -42,8 +46,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The function `PocketIc::install_chunked_canister` to install a canister from WASM chunks in the WASM chunk store of a canister.
 - The function `PocketIc::fetch_canister_logs` to fetch canister logs via a query call to the management canister.
 - The function `Topology::get_subnet` to get a subnet to which a canister belongs independently of whether the canister exists.
-- The function `PocketIc::new_from_existing_instance` to create a PocketIC handle to an existing instance on a running server.
-- The function `PocketIc::get_server_url` returning the URL of the PocketIC server on which the PocketIC instance is running.
 
 ### Removed
 - Functions `PocketIc::from_config`, `PocketIc::from_config_and_max_request_time`, and `PocketIc::from_config_and_server_url`.

--- a/packages/pocket-ic/Cargo.toml
+++ b/packages/pocket-ic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pocket-ic"
-version = "6.0.0"
+version = "7.0.0"
 license = "Apache-2.0"
 description = "PocketIC: A Canister Smart Contract Testing Platform"
 repository = "https://github.com/dfinity/ic"

--- a/packages/pocket-ic/src/lib.rs
+++ b/packages/pocket-ic/src/lib.rs
@@ -98,7 +98,7 @@ pub mod common;
 pub mod management_canister;
 pub mod nonblocking;
 
-const EXPECTED_SERVER_VERSION: &str = "7.0.0";
+const EXPECTED_SERVER_VERSION: &str = "8.0.0";
 
 // the default timeout of a PocketIC operation
 const DEFAULT_MAX_REQUEST_TIME_MS: u64 = 300_000;

--- a/rs/pocket_ic_server/BUILD.bazel
+++ b/rs/pocket_ic_server/BUILD.bazel
@@ -159,7 +159,7 @@ rust_library(
     ]),
     crate_name = "pocket_ic_server",
     proc_macro_deps = MACRO_DEPENDENCIES,
-    version = "7.0.0",
+    version = "8.0.0",
     deps = LIB_DEPENDENCIES + [":build_script"],
 )
 

--- a/rs/pocket_ic_server/CHANGELOG.md
+++ b/rs/pocket_ic_server/CHANGELOG.md
@@ -11,10 +11,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 8.0.0 - 2025-02-26
+
 ### Added
 - New endpoint `/instances/<instance_id>/read/ingress_status` to fetch the status of an update call submitted through an ingress message.
   If an optional caller is provided, the status of the update call is known, but the update call was submitted by a different caller, then an error is returned.
 - New endpoint `/instances/<instance_id>/update/set_certified_time` to set the current certified time on all subnets of the PocketIC instance.
+- The endpoint `/instances/<instance_id>/update/tick` takes an argument optionally containing the blockmaker and failed blockmakers
+  for every subnet used by the endpoint `node_metrics_history` of the management canister.
 
 ### Fixed
 - Canisters created via `provisional_create_canister_with_cycles` with the management canister ID as the effective canister ID

--- a/rs/pocket_ic_server/Cargo.toml
+++ b/rs/pocket_ic_server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pocket-ic-server"
-version = "7.0.0"
+version = "8.0.0"
 edition = "2021"
 
 [dependencies]

--- a/rs/pocket_ic_server/src/main.rs
+++ b/rs/pocket_ic_server/src/main.rs
@@ -54,7 +54,7 @@ const LOG_DIR_PATH_ENV_NAME: &str = "POCKET_IC_LOG_DIR";
 const LOG_DIR_LEVELS_ENV_NAME: &str = "POCKET_IC_LOG_DIR_LEVELS";
 
 #[derive(Parser)]
-#[clap(version = "7.0.0")]
+#[clap(version = "8.0.0")]
 struct Args {
     /// The IP address to which the PocketIC server should bind (defaults to 127.0.0.1)
     #[clap(long, short)]


### PR DESCRIPTION
This PR releases PocketIC server v8 and library v7.