### PR TITLE
chore: EXC-1932: Add types to memory tracker

### DIFF
--- a/rs/embedders/src/signal_handler.rs
+++ b/rs/embedders/src/signal_handler.rs
@@ -1,5 +1,6 @@
 use crate::wasmtime_embedder::host_memory::MemoryPageSize;
 
+use ic_types::NumBytes;
 use libc::c_void;
 use memory_tracker::{signal_access_kind_and_address, SigsegvMemoryTracker};
 use std::convert::TryFrom;
@@ -81,7 +82,7 @@ pub(crate) fn sigsegv_memory_tracker_handler(
         } else if let Some(heap_size) =
             check_if_expanded(&mut memory_tracker, si_addr, memory_page_size)
         {
-            let delta = heap_size - memory_tracker.area().size();
+            let delta = NumBytes::new(heap_size as u64) - memory_tracker.area().size();
             memory_tracker.expand(delta);
             true
         } else {

--- a/rs/embedders/src/wasmtime_embedder.rs
+++ b/rs/embedders/src/wasmtime_embedder.rs
@@ -33,7 +33,7 @@ use ic_replicated_state::{
 use ic_sys::PAGE_SIZE;
 use ic_types::{
     methods::{FuncRef, WasmMethod},
-    CanisterId, NumInstructions, NumOsPages, MAX_STABLE_MEMORY_IN_BYTES,
+    CanisterId, NumBytes, NumInstructions, NumOsPages, MAX_STABLE_MEMORY_IN_BYTES,
 };
 use ic_wasm_types::{BinaryEncodedWasm, WasmEngineError};
 use memory_tracker::{DirtyPageTracking, PageBitmap, SigsegvMemoryTracker};
@@ -739,8 +739,14 @@ fn sigsegv_memory_tracker<S>(
             }
 
             Arc::new(Mutex::new(
-                SigsegvMemoryTracker::new(base, size, log.clone(), dirty_page_tracking, page_map)
-                    .expect("failed to instantiate SIGSEGV memory tracker"),
+                SigsegvMemoryTracker::new(
+                    base,
+                    NumBytes::new(size as u64),
+                    log.clone(),
+                    dirty_page_tracking,
+                    page_map,
+                )
+                .expect("failed to instantiate SIGSEGV memory tracker"),
             ))
         };
         result.insert(mem_type, Arc::clone(&sigsegv_memory_tracker));

--- a/rs/memory_tracker/BUILD.bazel
+++ b/rs/memory_tracker/BUILD.bazel
@@ -8,6 +8,7 @@ DEPENDENCIES = [
     "//rs/monitoring/logger",
     "//rs/replicated_state",
     "//rs/sys",
+    "//rs/types/types",
     "@crate_index//:bit-vec",
     "@crate_index//:lazy_static",
     "@crate_index//:libc",

--- a/rs/memory_tracker/Cargo.toml
+++ b/rs/memory_tracker/Cargo.toml
@@ -13,6 +13,7 @@ bit-vec = "0.6.3"
 ic-logger = { path = "../monitoring/logger" }
 ic-replicated-state = { path = "../replicated_state" }
 ic-sys = { path = "../sys" }
+ic-types = { path = "../types/types" }
 lazy_static = { workspace = true }
 libc = { workspace = true }
 nix = { workspace = true }
@@ -24,7 +25,6 @@ sigsegv_handler_checksum = []
 
 [dev-dependencies]
 criterion = { workspace = true }
-ic-types = { path = "../types/types" }
 memmap2 = { workspace = true }
 proptest = { workspace = true }
 rayon = { workspace = true }

--- a/rs/memory_tracker/benches/traps.rs
+++ b/rs/memory_tracker/benches/traps.rs
@@ -1,4 +1,5 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use ic_types::NumBytes;
 use memory_tracker::*;
 
 use libc::{self, c_void};
@@ -49,7 +50,7 @@ fn criterion_fault_handler_sim_read(criterion: &mut Criterion) {
                     ptr,
                     tracker: SigsegvMemoryTracker::new(
                         ptr,
-                        PAGE_SIZE,
+                        NumBytes::new(PAGE_SIZE as u64),
                         no_op_logger(),
                         DirtyPageTracking::Track,
                         page_map.clone(),
@@ -97,7 +98,7 @@ fn criterion_fault_handler_sim_write(criterion: &mut Criterion) {
                     ptr,
                     tracker: SigsegvMemoryTracker::new(
                         ptr,
-                        PAGE_SIZE,
+                        NumBytes::new(PAGE_SIZE as u64),
                         no_op_logger(),
                         DirtyPageTracking::Track,
                         page_map.clone(),

--- a/rs/memory_tracker/src/tests.rs
+++ b/rs/memory_tracker/src/tests.rs
@@ -6,7 +6,7 @@ use ic_replicated_state::{
     PageIndex, PageMap,
 };
 use ic_sys::{PageBytes, PAGE_SIZE};
-use ic_types::Height;
+use ic_types::{Height, NumBytes, NumOsPages};
 use libc::c_void;
 use nix::sys::mman::{mmap, MapFlags, ProtFlags};
 use std::sync::Arc;
@@ -69,7 +69,7 @@ fn setup(
 
     let tracker = SigsegvMemoryTracker::new(
         memory,
-        memory_pages * PAGE_SIZE,
+        NumBytes::new((memory_pages * PAGE_SIZE) as u64),
         no_op_logger(),
         dirty_page_tracking,
         page_map.clone(),
@@ -629,7 +629,7 @@ fn prefetch_for_write_after_read_unordered() {
 
 #[test]
 fn page_bitmap_restrict_to_unaccessed() {
-    let mut bitmap = PageBitmap::new(10);
+    let mut bitmap = PageBitmap::new(NumOsPages::new(10));
     bitmap.mark(PageIndex::new(5));
     assert_eq!(
         Range {
@@ -662,7 +662,7 @@ fn page_bitmap_restrict_to_unaccessed() {
 
 #[test]
 fn page_bitmap_restrict_to_predicted() {
-    let mut bitmap = PageBitmap::new(10);
+    let mut bitmap = PageBitmap::new(NumOsPages::new(10));
     bitmap.mark(PageIndex::new(5));
     assert_eq!(
         Range {
@@ -695,7 +695,7 @@ fn page_bitmap_restrict_to_predicted() {
 
 #[test]
 fn page_bitmap_restrict_to_predicted_stops_at_end() {
-    let mut bitmap = PageBitmap::new(10);
+    let mut bitmap = PageBitmap::new(NumOsPages::new(10));
     bitmap.mark(PageIndex::new(0));
     bitmap.mark(PageIndex::new(1));
     bitmap.mark(PageIndex::new(2));
@@ -716,7 +716,7 @@ fn page_bitmap_restrict_to_predicted_stops_at_end() {
 
 #[test]
 fn page_bitmap_restrict_to_predicted_stops_at_start() {
-    let mut bitmap = PageBitmap::new(10);
+    let mut bitmap = PageBitmap::new(NumOsPages::new(10));
     bitmap.mark(PageIndex::new(0));
     bitmap.mark(PageIndex::new(1));
     bitmap.mark(PageIndex::new(2));


### PR DESCRIPTION
This PR adds `NumBytes` and `NumOsPages` to the memory tracker, making it easier to distinguish between bytes and pages.

No functional changes.