### PR TITLE
fix(IDX): build icos_deploy by default

### DIFF
--- a/testnet/tools/BUILD.bazel
+++ b/testnet/tools/BUILD.bazel
@@ -13,7 +13,7 @@ genrule(
         "//ic-os/guestos/envs/prod:upload_update-img",
         "//ic-os/boundary-guestos/envs/dev:upload_disk-img",
         "//ic-os/boundary-guestos/envs/prod:upload_disk-img",
-        "build-guestos-config.sh",
+        "build-guestos-configs.sh",
         "//publish/binaries:legacy_upload",
         "//publish/canisters:upload",
     ],
@@ -41,5 +41,4 @@ cd "\\$$BUILD_WORKSPACE_DIRECTORY"
 EOF
     """,
     executable = True,
-    tags = ["manual"],
 )


### PR DESCRIPTION
This removes the `manual` tag from `icos_deploy` to make sure it gets built on CI, and also fixes its build.