### PR TITLE
fix(icp-rosetta): remove deadlock in rosetta blocks

### DIFF
--- a/rs/rosetta-api/icp/src/request_handler.rs
+++ b/rs/rosetta-api/icp/src/request_handler.rs
@@ -327,8 +327,10 @@ impl RosettaRequestHandler {
             }
             _ => {
                 if self.is_rosetta_blocks_mode_enabled().await {
-                    let blocks = self.ledger.read_blocks().await;
-                    let highest_block_index = blocks
+                    let highest_block_index = self
+                        .ledger
+                        .read_blocks()
+                        .await
                         .get_highest_rosetta_block_index()
                         .map_err(ApiError::from)?
                         .ok_or_else(|| ApiError::BlockchainEmpty(false, Default::default()))?;

--- a/rs/rosetta-api/icp/src/request_handler.rs
+++ b/rs/rosetta-api/icp/src/request_handler.rs
@@ -559,10 +559,11 @@ impl RosettaRequestHandler {
         msg: models::NetworkRequest,
     ) -> Result<NetworkStatusResponse, ApiError> {
         verify_network_id(self.ledger.ledger_canister_id(), &msg.network_identifier)?;
-        let blocks = self.ledger.read_blocks().await;
-        let network_status = match blocks.rosetta_blocks_mode {
+        let rosetta_blocks_mode = self.ledger.read_blocks().await.rosetta_blocks_mode;
+        let network_status = match rosetta_blocks_mode {
             // If rosetta mode is not enabled we simply fetched the latest verified block
             RosettaBlocksMode::Disabled => {
+                let blocks = self.ledger.read_blocks().await;
                 let tip_verified_block = blocks.get_latest_verified_hashed_block()?;
                 let genesis_block = blocks.get_hashed_block(&0)?;
                 let first_verified_block = blocks.get_first_verified_hashed_block()?;
@@ -596,8 +597,13 @@ impl RosettaRequestHandler {
             RosettaBlocksMode::Enabled {
                 first_rosetta_block_index,
             } => {
+                let highest_rosetta_block_index = self
+                    .ledger
+                    .read_blocks()
+                    .await
+                    .get_highest_rosetta_block_index()?;
                 // If rosetta blocks mode is enabled we have to check whether the rosetta blocks table has been populated
-                match blocks.get_highest_rosetta_block_index()? {
+                match highest_rosetta_block_index {
                     // If it has been populated we can return the highest rosetta block
                     Some(highest_rosetta_block_index) => {
                         let highest_rosetta_block = self
@@ -605,7 +611,9 @@ impl RosettaRequestHandler {
                             .await?;
                         // If Rosetta Blocks started only after a certain index then the genesis block as well as the first verified block will be the first icp block
                         let genesis_block_id = if first_rosetta_block_index > 0 {
-                            self.hashed_block_to_rosetta_core_block(blocks.get_hashed_block(&0)?)
+                            let hashed_block =
+                                self.ledger.read_blocks().await.get_hashed_block(&0)?;
+                            self.hashed_block_to_rosetta_core_block(hashed_block)
                                 .await?
                                 .block_identifier
                         } else {


### PR DESCRIPTION
`self.ledger.read_blocks()` returns a `Box<RwLock>` that has a RW mutex to the blocks database connection. 

In the current implementation, there are at least a couple of situations in which we get a read lock and then call another function that also gets a read-lock for themselves before the caller released theirs. Most of the time this is ok (since it's a RwLock) but in some rare scenarios a different thread might try to get a write lock in between the two read locks from the first thread, leading to a deadlock (the first read lock won't be released until the second read lock is released, but the second read lock is waiting on the write lock to be released, which is itself waiting for the first read lock to be released).

As far as we know this is only affecting the rosetta blocks implementation, which is not in prod, but there's nothing preventing the same conditions from happening elsewhere and just not being caught by tests at the moment.

This PR simply remediates the rosetta block tests flakiness by releasing the top read locks (by making the returned box go out of scope) when they're not needed, but a more thorough work is being done on fixing the confusing lock handling we have now.

I've run the flaky tests 300x now and didn't get any failure, as opposed to before when ~80 runs were enough to reproduce the issue.