### PR TITLE
refactor(EXC-1841): Avoid using static mut references in memory tracker

### DIFF
--- a/rs/memory_tracker/src/tests.rs
+++ b/rs/memory_tracker/src/tests.rs
@@ -9,6 +9,7 @@ use ic_sys::{PageBytes, PAGE_SIZE};
 use ic_types::Height;
 use libc::c_void;
 use nix::sys::mman::{mmap, MapFlags, ProtFlags};
+#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
 use std::ops::{Deref, DerefMut};
 use std::sync::Arc;
 #[cfg(all(target_os = "linux", target_arch = "x86_64"))]

--- a/rs/memory_tracker/src/tests.rs
+++ b/rs/memory_tracker/src/tests.rs
@@ -9,7 +9,9 @@ use ic_sys::{PageBytes, PAGE_SIZE};
 use ic_types::Height;
 use libc::c_void;
 use nix::sys::mman::{mmap, MapFlags, ProtFlags};
-use std::sync::{Arc, LazyLock, Mutex};
+use std::sync::Arc;
+#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+use std::sync::{LazyLock, Mutex};
 
 use crate::{
     new_signal_handler_available, AccessKind, DirtyPageTracking, PageBitmap, SigsegvMemoryTracker,


### PR DESCRIPTION
Using static mut would become a hard error in future Rust version, so the memory tracker tests should avoid using it.

One quick idea was to move the static in the `thread_local` (as the tracker that's already a thread local) but that doesn't work and can lead to a segfault in tests. Each time we call `sigaction` in the tests, we're installing a new signal handler referencing the old one as fallback but if the signal handler is declared as `thread_local`, one thread does not see the signal handlers that were installed by others. This can lead to some of these missing from the chain of handlers we attempt to build (by installing a new and referencing the old one) and thus lead to a segfault in a test if we receive a signal that is expected to be handled by a missing handler.

Instead, it seems that we should use interior mutability so we avoid taking a mutable static reference. Since this needs to be thread-safe as well (per above), an `Mutex` seems to be the right approach.