### PR TITLE
chore(ICP_Ledger): FI-1684: Add proposal-cli support for 4th ICP archive

### DIFF
--- a/rs/cross-chain/proposal-cli/src/candid/tests.rs
+++ b/rs/cross-chain/proposal-cli/src/candid/tests.rs
@@ -38,6 +38,7 @@ fn should_parse_constructor_parameters() {
         if canister == TargetCanister::IcpArchive1
             || canister == TargetCanister::IcpArchive2
             || canister == TargetCanister::IcpArchive3
+            || canister == TargetCanister::IcpArchive4
             //canister lives outside the monorepo
             || canister == TargetCanister::EvmRpc
             || canister == TargetCanister::CyclesLedger

--- a/rs/cross-chain/proposal-cli/src/canister/mod.rs
+++ b/rs/cross-chain/proposal-cli/src/canister/mod.rs
@@ -22,6 +22,7 @@ pub enum TargetCanister {
     IcpArchive1,
     IcpArchive2,
     IcpArchive3,
+    IcpArchive4,
     IcpIndex,
     IcpLedger,
     LedgerSuiteOrchestrator,
@@ -41,6 +42,7 @@ impl TargetCanister {
             TargetCanister::IcpArchive1 => "icp-archive1",
             TargetCanister::IcpArchive2 => "icp-archive2",
             TargetCanister::IcpArchive3 => "icp-archive3",
+            TargetCanister::IcpArchive4 => "icp-archive4",
             TargetCanister::IcpIndex => "icp-index",
             TargetCanister::IcpLedger => "icp-ledger",
             TargetCanister::LedgerSuiteOrchestrator => "orchestrator",
@@ -64,6 +66,7 @@ impl TargetCanister {
             | TargetCanister::IcpArchive1
             | TargetCanister::IcpArchive2
             | TargetCanister::IcpArchive3
+            | TargetCanister::IcpArchive4
             | TargetCanister::IcpIndex
             | TargetCanister::IcpLedger
             | TargetCanister::LedgerSuiteOrchestrator => "https://github.com/dfinity/ic.git",
@@ -99,7 +102,8 @@ impl TargetCanister {
             }
             TargetCanister::IcpArchive1
             | TargetCanister::IcpArchive2
-            | TargetCanister::IcpArchive3 => {
+            | TargetCanister::IcpArchive3
+            | TargetCanister::IcpArchive4 => {
                 PathBuf::from("rs/ledger_suite/icp/ledger_archive.did")
             }
             TargetCanister::IcpIndex => PathBuf::from("rs/ledger_suite/icp/index/index.did"),
@@ -127,6 +131,7 @@ impl TargetCanister {
             | TargetCanister::IcpArchive1
             | TargetCanister::IcpArchive2
             | TargetCanister::IcpArchive3
+            | TargetCanister::IcpArchive4
             | TargetCanister::IcpIndex
             | TargetCanister::IcpLedger
             | TargetCanister::LedgerSuiteOrchestrator => {
@@ -142,7 +147,8 @@ impl TargetCanister {
         match &self {
             TargetCanister::IcpArchive1
             | TargetCanister::IcpArchive2
-            | TargetCanister::IcpArchive3 => {
+            | TargetCanister::IcpArchive3
+            | TargetCanister::IcpArchive4 => {
                 vec![
                     PathBuf::from("packages/icrc-ledger_types"),
                     PathBuf::from("rs/ledger_suite/icp/archive"),
@@ -201,6 +207,7 @@ impl TargetCanister {
             | TargetCanister::IcpArchive1
             | TargetCanister::IcpArchive2
             | TargetCanister::IcpArchive3
+            | TargetCanister::IcpArchive4
             | TargetCanister::IcpIndex
             | TargetCanister::IcpLedger
             | TargetCanister::LedgerSuiteOrchestrator => {
@@ -225,7 +232,8 @@ impl TargetCanister {
             TargetCanister::CkEthMinter => "ic-cketh-minter.wasm.gz",
             TargetCanister::IcpArchive1
             | TargetCanister::IcpArchive2
-            | TargetCanister::IcpArchive3 => "ledger-archive-node-canister.wasm.gz",
+            | TargetCanister::IcpArchive3
+            | TargetCanister::IcpArchive4 => "ledger-archive-node-canister.wasm.gz",
             TargetCanister::IcpIndex => "ic-icp-index-canister.wasm.gz",
             TargetCanister::IcpLedger => "ledger-canister_notify-method.wasm.gz",
             TargetCanister::LedgerSuiteOrchestrator => {
@@ -251,6 +259,7 @@ impl TargetCanister {
             | TargetCanister::IcpArchive1
             | TargetCanister::IcpArchive2
             | TargetCanister::IcpArchive3
+            | TargetCanister::IcpArchive4
             | TargetCanister::IcpIndex
             | TargetCanister::IcpLedger
             | TargetCanister::LedgerSuiteOrchestrator => {
@@ -292,6 +301,7 @@ impl TargetCanister {
             TargetCanister::IcpArchive1
             | TargetCanister::IcpArchive2
             | TargetCanister::IcpArchive3
+            | TargetCanister::IcpArchive4
             | TargetCanister::IcpIndex
             | TargetCanister::IcpLedger => PathBuf::from("rs/ledger_suite/icp/canister_ids.json"),
             TargetCanister::EvmRpc
@@ -326,6 +336,7 @@ impl FromStr for TargetCanister {
             ["icp", "archive1"] => Ok(TargetCanister::IcpArchive1),
             ["icp", "archive2"] => Ok(TargetCanister::IcpArchive2),
             ["icp", "archive3"] => Ok(TargetCanister::IcpArchive3),
+            ["icp", "archive4"] => Ok(TargetCanister::IcpArchive4),
             ["icp", "index"] => Ok(TargetCanister::IcpIndex),
             ["icp", "ledger"] => Ok(TargetCanister::IcpLedger),
             ["evm", "rpc"] => Ok(TargetCanister::EvmRpc),
@@ -351,6 +362,7 @@ impl Display for TargetCanister {
             TargetCanister::IcpArchive1 => write!(f, "ICP archive1"),
             TargetCanister::IcpArchive2 => write!(f, "ICP archive2"),
             TargetCanister::IcpArchive3 => write!(f, "ICP archive3"),
+            TargetCanister::IcpArchive4 => write!(f, "ICP archive4"),
             TargetCanister::IcpIndex => write!(f, "ICP index"),
             TargetCanister::IcpLedger => write!(f, "ICP ledger"),
             TargetCanister::LedgerSuiteOrchestrator => write!(f, "ledger suite orchestrator"),

--- a/rs/ledger_suite/icp/BUILD.bazel
+++ b/rs/ledger_suite/icp/BUILD.bazel
@@ -8,6 +8,7 @@ load("//bazel:prost.bzl", "generated_files_check")
 package(default_visibility = ["//visibility:public"])
 
 exports_files([
+    "canister_ids.json",
     "ledger.did",
     "ledger_archive.did",
 ])

--- a/rs/ledger_suite/icp/canister_ids.json
+++ b/rs/ledger_suite/icp/canister_ids.json
@@ -8,6 +8,9 @@
   "icp-archive3": {
     "ic": "q4eej-kyaaa-aaaaa-aaaha-cai"
   },
+  "icp-archive4": {
+    "ic": "q3fc5-haaaa-aaaaa-aaahq-cai"
+  },
   "icp-index": {
     "ic": "qhbym-qaaaa-aaaaa-aaafq-cai"
   },


### PR DESCRIPTION
Add `proposal-cli` support for the 4th ICP ledger archive canister.