### PR TITLE
feat(sns): Introduce `SetCustomProposalTopics` proposal type

### DIFF
--- a/rs/sns/governance/api/src/ic_sns_governance.pb.v1.rs
+++ b/rs/sns/governance/api/src/ic_sns_governance.pb.v1.rs
@@ -477,7 +477,7 @@ pub struct AdvanceSnsTargetVersion {
     candid::CandidType, candid::Deserialize, comparable::Comparable, Clone, Debug, PartialEq,
 )]
 pub struct SetCustomProposalTopics {
-    pub custom_function_id_to_topic: ::prost::alloc::collections::BTreeMap<u64, i32>,
+    pub custom_function_id_to_topic: BTreeMap<u64, topics::Topic>,
 }
 /// A proposal is the immutable input of a proposal submission.
 #[derive(Default, candid::CandidType, candid::Deserialize, Debug, Clone, PartialEq)]

--- a/rs/sns/governance/api/src/ic_sns_governance.pb.v1.rs
+++ b/rs/sns/governance/api/src/ic_sns_governance.pb.v1.rs
@@ -473,6 +473,12 @@ pub struct AdvanceSnsTargetVersion {
     /// If not specified, the target will advance to the latest SNS version known to this SNS.
     pub new_target: Option<SnsVersion>,
 }
+#[derive(
+    candid::CandidType, candid::Deserialize, comparable::Comparable, Clone, Debug, PartialEq,
+)]
+pub struct SetCustomProposalTopics {
+    pub custom_function_id_to_topic: ::prost::alloc::collections::BTreeMap<u64, i32>,
+}
 /// A proposal is the immutable input of a proposal submission.
 #[derive(Default, candid::CandidType, candid::Deserialize, Debug, Clone, PartialEq)]
 pub struct Proposal {
@@ -584,6 +590,10 @@ pub mod proposal {
         ///
         /// Id = 15.
         AdvanceSnsTargetVersion(super::AdvanceSnsTargetVersion),
+        /// SetCustomProposalTopics
+        ///
+        /// Id = 16;
+        SetCustomProposalTopics(super::SetCustomProposalTopics),
     }
 }
 #[derive(Default, candid::CandidType, candid::Deserialize, Debug, Clone, PartialEq)]
@@ -785,6 +795,7 @@ pub struct ProposalData {
     /// Id 13 - ManageLedgerParameters proposals.
     /// Id 14 - ManageDappCanisterSettings proposals.
     /// Id 15 - AdvanceSnsTargetVersion proposals.
+    /// Id 16 - SetCustomProposalTopics proposals.
     pub action: u64,
     /// This is stored here temporarily. It is also stored on the map
     /// that contains proposals.

--- a/rs/sns/governance/api/src/topics.rs
+++ b/rs/sns/governance/api/src/topics.rs
@@ -7,6 +7,7 @@ use crate::pb::v1::NervousSystemFunction;
     Debug,
     candid::CandidType,
     candid::Deserialize,
+    comparable::Comparable,
     Ord,
     PartialOrd,
     Eq,

--- a/rs/sns/governance/canister/governance.did
+++ b/rs/sns/governance/canister/governance.did
@@ -6,6 +6,7 @@ type Account = record {
 type Action = variant {
   ManageNervousSystemParameters : NervousSystemParameters;
   AddGenericNervousSystemFunction : NervousSystemFunction;
+  SetCustomProposalTopics : SetCustomProposalTopics;
   ManageDappCanisterSettings : ManageDappCanisterSettings;
   RemoveGenericNervousSystemFunction : nat64;
   UpgradeSnsToNextVersion : record {};
@@ -392,6 +393,10 @@ type SnsVersion = record {
 
 type AdvanceSnsTargetVersion = record {
   new_target : opt SnsVersion;
+};
+
+type SetCustomProposalTopics = record {
+  custom_function_id_to_topic : vec record { nat64; Topic };
 };
 
 type ManageLedgerParameters = record {

--- a/rs/sns/governance/canister/governance_test.did
+++ b/rs/sns/governance/canister/governance_test.did
@@ -6,6 +6,7 @@ type Account = record {
 type Action = variant {
   ManageNervousSystemParameters : NervousSystemParameters;
   AddGenericNervousSystemFunction : NervousSystemFunction;
+  SetCustomProposalTopics : SetCustomProposalTopics;
   ManageDappCanisterSettings : ManageDappCanisterSettings;
   RemoveGenericNervousSystemFunction : nat64;
   UpgradeSnsToNextVersion : record {};
@@ -401,6 +402,10 @@ type SnsVersion = record {
 
 type AdvanceSnsTargetVersion = record {
   new_target : opt SnsVersion;
+};
+
+type SetCustomProposalTopics = record {
+  custom_function_id_to_topic : vec record { nat64; Topic };
 };
 
 type ManageLedgerParameters = record {

--- a/rs/sns/governance/proto/ic_sns_governance/pb/v1/governance.proto
+++ b/rs/sns/governance/proto/ic_sns_governance/pb/v1/governance.proto
@@ -603,7 +603,7 @@ message Proposal {
     // Id = 15.
     AdvanceSnsTargetVersion advance_sns_target_version = 19;
 
-    // SetCustomProposalTopics
+    // Change the mapping from custom proposal types to topics.
     //
     // Id = 16;
     SetCustomProposalTopics set_custom_proposal_topics = 20;

--- a/rs/sns/governance/proto/ic_sns_governance/pb/v1/governance.proto
+++ b/rs/sns/governance/proto/ic_sns_governance/pb/v1/governance.proto
@@ -486,6 +486,10 @@ message AdvanceSnsTargetVersion {
   optional SnsVersion new_target = 1;
 }
 
+message SetCustomProposalTopics {
+  map<uint64, Topic> custom_function_id_to_topic = 1;
+}
+
 // A proposal is the immutable input of a proposal submission.
 message Proposal {
   // The proposal's title as a text, which can be at most 256 bytes.
@@ -598,6 +602,11 @@ message Proposal {
     //
     // Id = 15.
     AdvanceSnsTargetVersion advance_sns_target_version = 19;
+
+    // SetCustomProposalTopics
+    //
+    // Id = 16;
+    SetCustomProposalTopics set_custom_proposal_topics = 20;
   }
 }
 
@@ -792,6 +801,7 @@ message ProposalData {
   // Id 13 - ManageLedgerParameters proposals.
   // Id 14 - ManageDappCanisterSettings proposals.
   // Id 15 - AdvanceSnsTargetVersion proposals.
+  // Id 16 - SetCustomProposalTopics proposals.
   uint64 action = 1;
 
   // This is stored here temporarily. It is also stored on the map

--- a/rs/sns/governance/src/gen/ic_sns_governance.pb.v1.rs
+++ b/rs/sns/governance/src/gen/ic_sns_governance.pb.v1.rs
@@ -838,7 +838,7 @@ pub mod proposal {
         /// Id = 15.
         #[prost(message, tag = "19")]
         AdvanceSnsTargetVersion(super::AdvanceSnsTargetVersion),
-        /// SetCustomProposalTopics
+        /// Change the mapping from custom proposal types to topics.
         ///
         /// Id = 16;
         #[prost(message, tag = "20")]

--- a/rs/sns/governance/src/gen/ic_sns_governance.pb.v1.rs
+++ b/rs/sns/governance/src/gen/ic_sns_governance.pb.v1.rs
@@ -688,6 +688,18 @@ pub struct AdvanceSnsTargetVersion {
     #[prost(message, optional, tag = "1")]
     pub new_target: ::core::option::Option<SnsVersion>,
 }
+#[derive(
+    candid::CandidType,
+    candid::Deserialize,
+    comparable::Comparable,
+    Clone,
+    PartialEq,
+    ::prost::Message,
+)]
+pub struct SetCustomProposalTopics {
+    #[prost(btree_map = "uint64, enumeration(Topic)", tag = "1")]
+    pub custom_function_id_to_topic: ::prost::alloc::collections::BTreeMap<u64, i32>,
+}
 /// A proposal is the immutable input of a proposal submission.
 #[derive(candid::CandidType, candid::Deserialize, comparable::Comparable)]
 #[compare_default]
@@ -716,7 +728,7 @@ pub struct Proposal {
     /// of this mapping.
     #[prost(
         oneof = "proposal::Action",
-        tags = "4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19"
+        tags = "4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20"
     )]
     pub action: ::core::option::Option<proposal::Action>,
 }
@@ -826,6 +838,11 @@ pub mod proposal {
         /// Id = 15.
         #[prost(message, tag = "19")]
         AdvanceSnsTargetVersion(super::AdvanceSnsTargetVersion),
+        /// SetCustomProposalTopics
+        ///
+        /// Id = 16;
+        #[prost(message, tag = "20")]
+        SetCustomProposalTopics(super::SetCustomProposalTopics),
     }
 }
 #[derive(candid::CandidType, candid::Deserialize, comparable::Comparable)]
@@ -1059,6 +1076,7 @@ pub struct ProposalData {
     /// Id 13 - ManageLedgerParameters proposals.
     /// Id 14 - ManageDappCanisterSettings proposals.
     /// Id 15 - AdvanceSnsTargetVersion proposals.
+    /// Id 16 - SetCustomProposalTopics proposals.
     #[prost(uint64, tag = "1")]
     pub action: u64,
     /// This is stored here temporarily. It is also stored on the map

--- a/rs/sns/governance/src/governance.rs
+++ b/rs/sns/governance/src/governance.rs
@@ -53,7 +53,7 @@ use crate::{
             MintTokensRequest, MintTokensResponse, NervousSystemFunction, NervousSystemParameters,
             Neuron, NeuronId, NeuronPermission, NeuronPermissionList, NeuronPermissionType,
             Proposal, ProposalData, ProposalDecisionStatus, ProposalId, ProposalRewardStatus,
-            RegisterDappCanisters, RewardEvent, SetCustomProposalTopics, Tally, Topic,
+            RegisterDappCanisters, RewardEvent, SetCustomProposalTopics, Tally,
             TransferSnsTreasuryFunds, UpgradeSnsControlledCanister, Vote, WaitForQuietState,
         },
     },
@@ -478,51 +478,6 @@ impl GovernanceProto {
                      the maturity modulation value from the Cycles Minting Canister.",
                 )
             })
-    }
-
-    pub fn custom_functions_to_topics(&self) -> BTreeMap<u64, Option<Topic>> {
-        self.id_to_nervous_system_functions
-            .iter()
-            .filter_map(|(function_id, function)| {
-                match &function.function_type {
-                    Some(FunctionType::GenericNervousSystemFunction(generic)) => {
-                        if let Some(topic) = generic.topic {
-                            let specific_topic = match Topic::try_from(topic) {
-                                Err(err) => {
-                                    log!(
-                                        ERROR,
-                                        "Custom proposal ID {function_id}: Cannot interpret \
-                                            {topic} as Topic: {err}",
-                                    );
-
-                                    // This should never happen; if it somehow does, treat this
-                                    // case as a custom function for which the topic is unknown.
-                                    None
-                                }
-                                Ok(Topic::Unspecified) => {
-                                    log!(
-                                        ERROR,
-                                        "Custom proposal ID {function_id}: topic Unspecified."
-                                    );
-
-                                    // This should never happen, but if it somehow does, treat this
-                                    // case as a custom function for which the topic is unknown.
-                                    None
-                                }
-                                Ok(topic) => Some(topic),
-                            };
-
-                            Some((*function_id, specific_topic))
-                        } else {
-                            // Topic not yet set for this custom function.
-                            Some((*function_id, None))
-                        }
-                    }
-                    // Not a custom function.
-                    _ => None,
-                }
-            })
-            .collect()
     }
 }
 

--- a/rs/sns/governance/src/governance.rs
+++ b/rs/sns/governance/src/governance.rs
@@ -3147,7 +3147,7 @@ impl Governance {
             custom_function_id_to_topic,
         } = set_custom_proposal_topics;
 
-        for (custom_function_id, new_topic) in custom_function_id_to_topic.into_iter() {
+        for (custom_function_id, new_topic) in custom_function_id_to_topic {
             let nervous_system_function = self
                 .proto
                 .id_to_nervous_system_functions
@@ -3155,10 +3155,17 @@ impl Governance {
 
             if let Some(nervous_system_function) = nervous_system_function {
                 let proposal_type = nervous_system_function.function_type.as_mut();
+
                 if let Some(FunctionType::GenericNervousSystemFunction(custom_proposal_type)) =
                     proposal_type
                 {
                     custom_proposal_type.topic = Some(new_topic);
+                } else {
+                    log!(
+                        ERROR,
+                        "Unexpected situation: Cannot change the topic of a native proposal type: \
+                        {proposal_type:?}",
+                    )
                 }
             }
         }

--- a/rs/sns/governance/src/governance.rs
+++ b/rs/sns/governance/src/governance.rs
@@ -52,8 +52,8 @@ use crate::{
             MintTokensRequest, MintTokensResponse, NervousSystemFunction, NervousSystemParameters,
             Neuron, NeuronId, NeuronPermission, NeuronPermissionList, NeuronPermissionType,
             Proposal, ProposalData, ProposalDecisionStatus, ProposalId, ProposalRewardStatus,
-            RegisterDappCanisters, RewardEvent, Tally, TransferSnsTreasuryFunds,
-            UpgradeSnsControlledCanister, Vote, WaitForQuietState,
+            RegisterDappCanisters, RewardEvent, SetCustomProposalTopics, Tally,
+            TransferSnsTreasuryFunds, UpgradeSnsControlledCanister, Vote, WaitForQuietState,
         },
     },
     proposal::{
@@ -2140,6 +2140,9 @@ impl Governance {
                     })
                     .and_then(|new_target| self.perform_advance_target_version(new_target))
             }
+            Action::SetCustomProposalTopics(set_custom_proposal_topics) => {
+                self.perform_set_custom_proposal_topics(set_custom_proposal_topics)
+            }
             // This should not be possible, because Proposal validation is performed when
             // a proposal is first made.
             Action::Unspecified(_) => Err(GovernanceError::new_with_message(
@@ -3118,6 +3121,24 @@ impl Governance {
 
         self.proto.target_version = Some(target_version);
 
+        Ok(())
+    }
+
+    // Make a change to the mapping from custom proposal types to topics.
+    fn perform_set_custom_proposal_topics(
+        &mut self,
+        set_custom_proposal_topics: SetCustomProposalTopics,
+    ) -> Result<(), GovernanceError> {
+        // TODO: Validate set_custom_proposal_topics.topic_infos
+        // - all function are registered
+        // - topics can be decoded
+
+        // for (custom_function_id, topic) in topic_infos.into_iter() {
+        //     // self.proto
+        //     //     .id_to_nervous_system_functions
+        //     //     .
+        //     todo!();
+        // }
         Ok(())
     }
 

--- a/rs/sns/governance/src/pb/conversions.rs
+++ b/rs/sns/governance/src/pb/conversions.rs
@@ -577,14 +577,37 @@ impl From<pb::AdvanceSnsTargetVersion> for pb_api::AdvanceSnsTargetVersion {
 impl From<pb_api::SetCustomProposalTopics> for pb::SetCustomProposalTopics {
     fn from(item: pb_api::SetCustomProposalTopics) -> Self {
         Self {
-            custom_function_id_to_topic: item.custom_function_id_to_topic.into_iter().collect(),
+            custom_function_id_to_topic: item
+                .custom_function_id_to_topic
+                .into_iter()
+                .map(|(custom_function_id, topic)| {
+                    let topic = i32::from(pb::Topic::from(topic));
+                    (custom_function_id, topic)
+                })
+                .collect(),
         }
     }
 }
 impl From<pb::SetCustomProposalTopics> for pb_api::SetCustomProposalTopics {
     fn from(item: pb::SetCustomProposalTopics) -> Self {
+        let custom_function_id_to_topic = item
+            .custom_function_id_to_topic
+            .into_iter()
+            .filter_map(|(custom_function_id, topic)| {
+                let Ok(topic) = pb::Topic::try_from(topic) else {
+                    return None;
+                };
+
+                let Ok(topic) = pb_api::topics::Topic::try_from(topic) else {
+                    return None;
+                };
+
+                Some((custom_function_id, topic))
+            })
+            .collect();
+
         Self {
-            custom_function_id_to_topic: item.custom_function_id_to_topic.into_iter().collect(),
+            custom_function_id_to_topic,
         }
     }
 }

--- a/rs/sns/governance/src/pb/conversions.rs
+++ b/rs/sns/governance/src/pb/conversions.rs
@@ -574,6 +574,21 @@ impl From<pb::AdvanceSnsTargetVersion> for pb_api::AdvanceSnsTargetVersion {
     }
 }
 
+impl From<pb_api::SetCustomProposalTopics> for pb::SetCustomProposalTopics {
+    fn from(item: pb_api::SetCustomProposalTopics) -> Self {
+        Self {
+            custom_function_id_to_topic: item.custom_function_id_to_topic.into_iter().collect(),
+        }
+    }
+}
+impl From<pb::SetCustomProposalTopics> for pb_api::SetCustomProposalTopics {
+    fn from(item: pb::SetCustomProposalTopics) -> Self {
+        Self {
+            custom_function_id_to_topic: item.custom_function_id_to_topic.into_iter().collect(),
+        }
+    }
+}
+
 impl From<pb::Proposal> for pb_api::Proposal {
     fn from(item: pb::Proposal) -> Self {
         Self {
@@ -642,6 +657,9 @@ impl From<pb::proposal::Action> for pb_api::proposal::Action {
             pb::proposal::Action::AdvanceSnsTargetVersion(v) => {
                 pb_api::proposal::Action::AdvanceSnsTargetVersion(v.into())
             }
+            pb::proposal::Action::SetCustomProposalTopics(v) => {
+                pb_api::proposal::Action::SetCustomProposalTopics(v.into())
+            }
         }
     }
 }
@@ -691,6 +709,9 @@ impl From<pb_api::proposal::Action> for pb::proposal::Action {
             }
             pb_api::proposal::Action::AdvanceSnsTargetVersion(v) => {
                 pb::proposal::Action::AdvanceSnsTargetVersion(v.into())
+            }
+            pb_api::proposal::Action::SetCustomProposalTopics(v) => {
+                pb::proposal::Action::SetCustomProposalTopics(v.into())
             }
         }
     }

--- a/rs/sns/governance/src/proposal.rs
+++ b/rs/sns/governance/src/proposal.rs
@@ -2726,6 +2726,9 @@ mod minting_tests;
 mod advance_sns_target_version;
 
 #[cfg(test)]
+mod set_custom_proposal_topics;
+
+#[cfg(test)]
 mod tests {
     use super::*;
     use crate::{

--- a/rs/sns/governance/src/proposal/set_custom_proposal_topics.rs
+++ b/rs/sns/governance/src/proposal/set_custom_proposal_topics.rs
@@ -4,24 +4,79 @@ use pretty_assertions::assert_eq;
 
 #[test]
 fn test_validate_and_render_set_custom_proposal_topics() {
-    for (set_custom_proposal_topics, existing_custom_functions, expected) in [(
-        SetCustomProposalTopics {
-            custom_function_id_to_topic: btreemap! {
-                111_u64 => Topic::DaoCommunitySettings as i32,
+    for (set_custom_proposal_topics, existing_custom_functions, expected) in [
+        (
+            SetCustomProposalTopics {
+                custom_function_id_to_topic: btreemap! {
+                    111_u64 => Topic::DaoCommunitySettings as i32,
+                },
             },
-        },
-        btreemap! {
-            111 => Some(Topic::Governance),
-        },
-        Ok::<String, String>(
-            r#"# Proposal to set topics for custom SNS proposal types
+            btreemap! {
+                111 => ("AAA".to_string(), Some(Topic::Governance)),
+            },
+            Ok::<String, String>(
+                r#"# Set topics for custom SNS proposal types
 
-### If adopted, the following custom functions will be categorized under the specified topics:
+### If adopted, the following proposals will be categorized under the specified topics:
 
-DaoCommunitySettings (changing from Governance)"#
-                .to_string(),
+  - AAA under topic DaoCommunitySettings (changing from Governance)"#
+                    .to_string(),
+            ),
         ),
-    )] {
+        (
+            SetCustomProposalTopics {
+                custom_function_id_to_topic: btreemap! {
+                    222_u64 => Topic::DaoCommunitySettings as i32,
+                    111_u64 => Topic::DaoCommunitySettings as i32,
+                    444_u64 => Topic::DaoCommunitySettings as i32,
+                },
+            },
+            btreemap! {
+                111 => ("AAA".to_string(), Some(Topic::DaoCommunitySettings)),
+                222 => ("BBB".to_string(), Some(Topic::Governance)),
+                333 => ("CCC".to_string(), Some(Topic::Governance)),
+                444 => ("DDD".to_string(), None),
+            },
+            Ok::<String, String>(
+                r#"# Set topics for custom SNS proposal types
+
+### If adopted, the following proposals will be categorized under the specified topics:
+
+  - AAA under topic DaoCommunitySettings (keeping unchanged)
+  - BBB under topic DaoCommunitySettings (changing from Governance)
+  - DDD under topic DaoCommunitySettings (topic not currently set)"#
+                    .to_string(),
+            ),
+        ),
+        (
+            SetCustomProposalTopics {
+                custom_function_id_to_topic: btreemap! {},
+            },
+            btreemap! {
+                111 => ("AAA".to_string(), Some(Topic::Governance)),
+            },
+            Err::<String, String>(
+                "SetCustomProposalTopics.custom_function_id_to_topic must not be empty."
+                    .to_string(),
+            ),
+        ),
+        (
+            SetCustomProposalTopics {
+                custom_function_id_to_topic: btreemap! {
+                    111_u64 => Topic::DaoCommunitySettings as i32,
+                },
+            },
+            btreemap! {
+                222 => ("BBB".to_string(), Some(Topic::Governance)),
+            },
+            Err::<String, String>(
+                "Cannot set topic for proposal(s) with ID(s) 111 since they have not been \
+                 registered as custom proposals in this SNS yet. Please use \
+                 `AddGenericNervousSystemFunction` proposals to register new custom SNS proposals."
+                    .to_string(),
+            ),
+        ),
+    ] {
         let observed = validate_and_render_set_custom_proposal_topics(
             &set_custom_proposal_topics,
             &existing_custom_functions,

--- a/rs/sns/governance/src/proposal/set_custom_proposal_topics.rs
+++ b/rs/sns/governance/src/proposal/set_custom_proposal_topics.rs
@@ -1,0 +1,31 @@
+use super::*;
+use maplit::btreemap;
+use pretty_assertions::assert_eq;
+
+#[test]
+fn test_validate_and_render_set_custom_proposal_topics() {
+    for (set_custom_proposal_topics, existing_custom_functions, expected) in [(
+        SetCustomProposalTopics {
+            custom_function_id_to_topic: btreemap! {
+                111_u64 => Topic::DaoCommunitySettings as i32,
+            },
+        },
+        btreemap! {
+            111 => Some(Topic::Governance),
+        },
+        Ok::<String, String>(
+            r#"# Proposal to set topics for custom SNS proposal types
+
+### If adopted, the following custom functions will be categorized under the specified topics:
+
+DaoCommunitySettings (changing from Governance)"#
+                .to_string(),
+        ),
+    )] {
+        let observed = validate_and_render_set_custom_proposal_topics(
+            &set_custom_proposal_topics,
+            &existing_custom_functions,
+        );
+        assert_eq!(observed, expected);
+    }
+}

--- a/rs/sns/governance/src/topics.rs
+++ b/rs/sns/governance/src/topics.rs
@@ -1,9 +1,11 @@
+use crate::logs::ERROR;
 use crate::pb::v1::{self as pb, NervousSystemFunction};
 use crate::types::native_action_ids;
 use crate::{governance::Governance, pb::v1::nervous_system_function::FunctionType};
+use ic_canister_log::log;
 use ic_sns_governance_api::pb::v1::topics::Topic;
 use itertools::Itertools;
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 
 /// Each topic has some information associated with it. This information is for the benefit of the user but has
 /// no effect on the behavior of the SNS.
@@ -198,6 +200,56 @@ impl Governance {
             topics,
             uncategorized_functions,
         }
+    }
+}
+
+impl pb::Governance {
+    /// For each custom function ID, returns a pair (`function_name`, `topic`).
+    pub fn custom_functions_to_topics(&self) -> BTreeMap<u64, (String, Option<pb::Topic>)> {
+        self.id_to_nervous_system_functions
+            .iter()
+            .filter_map(|(function_id, function)| {
+                match &function.function_type {
+                    Some(FunctionType::GenericNervousSystemFunction(generic)) => {
+                        let function_name = function.name.clone();
+
+                        if let Some(topic) = generic.topic {
+                            let specific_topic = match pb::Topic::try_from(topic) {
+                                Err(err) => {
+                                    log!(
+                                        ERROR,
+                                        "Custom proposal ID {function_id}: Cannot interpret \
+                                            {topic} as Topic: {err}",
+                                    );
+
+                                    // This should never happen; if it somehow does, treat this
+                                    // case as a custom function for which the topic is unknown.
+                                    None
+                                }
+                                Ok(pb::Topic::Unspecified) => {
+                                    log!(
+                                        ERROR,
+                                        "Custom proposal ID {function_id}: topic Unspecified."
+                                    );
+
+                                    // This should never happen, but if it somehow does, treat this
+                                    // case as a custom function for which the topic is unknown.
+                                    None
+                                }
+                                Ok(topic) => Some(topic),
+                            };
+
+                            Some((*function_id, (function_name, specific_topic)))
+                        } else {
+                            // Topic not yet set for this custom function.
+                            Some((*function_id, (function_name, None)))
+                        }
+                    }
+                    // Not a custom function.
+                    _ => None,
+                }
+            })
+            .collect()
     }
 }
 

--- a/rs/sns/governance/src/types.rs
+++ b/rs/sns/governance/src/types.rs
@@ -135,6 +135,9 @@ pub mod native_action_ids {
     /// AdvanceSnsTargetVersion Action.
     pub const ADVANCE_SNS_TARGET_VERSION: u64 = 15;
 
+    /// SetCustomProposalTopics Action.
+    pub const SET_CUSTOM_PROPOSAL_ACTION: u64 = 16;
+
     // When adding something to this list, make sure to update the below function.
     pub fn native_functions() -> Vec<NervousSystemFunction> {
         vec![
@@ -153,6 +156,7 @@ pub mod native_action_ids {
             NervousSystemFunction::manage_ledger_parameters(),
             NervousSystemFunction::manage_dapp_canister_settings(),
             NervousSystemFunction::advance_sns_target_version(),
+            NervousSystemFunction::set_custom_proposal_topics(),
         ]
     }
 }
@@ -1231,6 +1235,15 @@ impl NervousSystemFunction {
             function_type: Some(FunctionType::NativeNervousSystemFunction(Empty {})),
         }
     }
+
+    fn set_custom_proposal_topics() -> NervousSystemFunction {
+        NervousSystemFunction {
+            id: native_action_ids::SET_CUSTOM_PROPOSAL_ACTION,
+            name: "Set custom proposal topics".to_string(),
+            description: Some("Proposal to set the topics of custom SNS proposals.".to_string()),
+            function_type: Some(FunctionType::NativeNervousSystemFunction(Empty {})),
+        }
+    }
 }
 
 impl From<Action> for NervousSystemFunction {
@@ -1273,6 +1286,9 @@ impl From<Action> for NervousSystemFunction {
             }
             Action::AdvanceSnsTargetVersion(_) => {
                 NervousSystemFunction::advance_sns_target_version()
+            }
+            Action::SetCustomProposalTopics(_) => {
+                NervousSystemFunction::set_custom_proposal_topics()
             }
         }
     }
@@ -1713,9 +1729,10 @@ impl Action {
     fn proposal_criticality(&self) -> ProposalCriticality {
         use Action::*;
         match self {
-            DeregisterDappCanisters(_) | TransferSnsTreasuryFunds(_) | MintSnsTokens(_) => {
-                ProposalCriticality::Critical
-            }
+            DeregisterDappCanisters(_)
+            | TransferSnsTreasuryFunds(_)
+            | MintSnsTokens(_)
+            | Action::SetCustomProposalTopics(_) => ProposalCriticality::Critical,
 
             Unspecified(_)
             | ManageNervousSystemParameters(_)
@@ -1915,6 +1932,7 @@ impl From<&Action> for u64 {
                 native_action_ids::MANAGE_DAPP_CANISTER_SETTINGS
             }
             Action::AdvanceSnsTargetVersion(_) => native_action_ids::ADVANCE_SNS_TARGET_VERSION,
+            Action::SetCustomProposalTopics(_) => native_action_ids::SET_CUSTOM_PROPOSAL_ACTION,
         }
     }
 }

--- a/rs/sns/governance/src/types.rs
+++ b/rs/sns/governance/src/types.rs
@@ -1732,7 +1732,7 @@ impl Action {
             DeregisterDappCanisters(_)
             | TransferSnsTreasuryFunds(_)
             | MintSnsTokens(_)
-            | Action::SetCustomProposalTopics(_) => ProposalCriticality::Critical,
+            | SetCustomProposalTopics(_) => ProposalCriticality::Critical,
 
             Unspecified(_)
             | ManageNervousSystemParameters(_)

--- a/rs/sns/governance/unreleased_changelog.md
+++ b/rs/sns/governance/unreleased_changelog.md
@@ -9,6 +9,39 @@ on the process that this file is part of, see
 
 ## Added
 
+* New type of SNS proposals `SetCustomProposalTopics` can be used to batch-set topics for all custom proposals (or any non-empty subset thereof) at once.
+
+    Example usage:
+
+    ```bash
+    dfx canister --ic call ${SNS_GOVERNANCE_CANISTER_ID} manage_neuron '(
+        record {
+            subaccount = blob "'${PROPOSER_SNS_NEURON_SUBACCOUNT}'";
+            command = opt variant {
+                MakeProposal = record {
+                    url = "https://forum.dfinity.org/t/sns-topics-plan";
+                    title = "Set topics for custom SNS proposals";
+                    action = opt variant {
+                        SetCustomProposalTopics = record {
+                            custom_function_id_to_topic = vec {
+                                record {
+                                    42; variant { ApplicationBusinessLogic }
+                                }
+                                record {
+                                    123; variant { DaoCommunitySettings }
+                                }
+                            };
+                        }
+                    };
+                    summary = "Set topics ApplicationBusinessLogic and \
+                            DaoCommunitySettings for SNS proposals with \
+                            IDs 42 and 123 resp.";
+                }
+            };
+        },
+    )'
+    ```
+
 ## Changed
 
 * Enable


### PR DESCRIPTION
This PR introduces a new type of SNS proposals, `SetCustomProposalTopics`, which can be used to batch-set topics for all custom proposals (or any non-empty subset thereof) at once.

| [Next PR](https://github.com/dfinity/ic/pull/4170) >