### PR TITLE
fix(IDX): work around missing build checksums

### DIFF
--- a/.github/workflows-source/ci-main.yml
+++ b/.github/workflows-source/ci-main.yml
@@ -295,9 +295,13 @@ jobs:
 
       - name: Build Determinism Test
         run: |
-          n_lines=$(cat shasums-nocache/SHA256SUMS | wc -l)
-          echo "comparing $n_lines lines"
-          if [ "$n_lines" -eq 0 ]; then
+          n_lines_cache=$(cat shasums-cache/SHA256SUMS | wc -l)
+          n_lines_nocache=$(cat shasums-nocache/SHA256SUMS | wc -l)
+          echo "comparing $n_lines_cache (cache) and $n_lines_nocache (nocache) lines"
+
+          # running tests may not pull all targets locally. If that's the case,
+          # there will be 0 lines and nothing to compare.
+          if [ "$n_lines_cache" -eq 0 ] || [ "$n_lines_nocache" -eq 0 ]; then
             echo "No lines to compare"
             exit 0
           fi

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -331,9 +331,13 @@ jobs:
           path: shasums-nocache
       - name: Build Determinism Test
         run: |
-          n_lines=$(cat shasums-nocache/SHA256SUMS | wc -l)
-          echo "comparing $n_lines lines"
-          if [ "$n_lines" -eq 0 ]; then
+          n_lines_cache=$(cat shasums-cache/SHA256SUMS | wc -l)
+          n_lines_nocache=$(cat shasums-nocache/SHA256SUMS | wc -l)
+          echo "comparing $n_lines_cache (cache) and $n_lines_nocache (nocache) lines"
+
+          # running tests may not pull all targets locally. If that's the case,
+          # there will be 0 lines and nothing to compare.
+          if [ "$n_lines_cache" -eq 0 ] || [ "$n_lines_nocache" -eq 0 ]; then
             echo "No lines to compare"
             exit 0
           fi


### PR DESCRIPTION
Currently, the `bazel test` command may not pull all the build checksums from the cache, meaning the build determinism may have nothing to compare.

As a (hopefully temporary) workaround, we skip the checks if the build didn't produce checksums.