### PR TITLE
feat: Increase max snapshots allowed per canister

### DIFF
--- a/packages/pocket-ic/tests/tests.rs
+++ b/packages/pocket-ic/tests/tests.rs
@@ -1809,11 +1809,20 @@ fn test_canister_snapshots() {
         second_snapshot.taken_at_timestamp
     );
 
-    // Finally, we delete the current snapshot which leaves the canister without any other snapshots.
+    // Attempt to take another snapshot without providing a replace_id. The second snapshot
+    // should be still there.
+    pic.stop_canister(canister_id, None).unwrap();
+    let third_snapshot = pic.take_canister_snapshot(canister_id, None, None).unwrap();
+    pic.start_canister(canister_id, None).unwrap();
+    assert_eq!(snapshots[0].id, second_snapshot.id);
+
+    // Finally, we delete the second snapshot which leaves the canister with the third snapshot
+    // only.
     pic.delete_canister_snapshot(canister_id, None, second_snapshot.id)
         .unwrap();
     let snapshots = pic.list_canister_snapshots(canister_id, None).unwrap();
-    assert_eq!(snapshots.len(), 0);
+    assert_eq!(snapshots.len(), 1);
+    assert_eq!(snapshots[0].id, third_snapshot.id);
 }
 
 #[test]

--- a/packages/pocket-ic/tests/tests.rs
+++ b/packages/pocket-ic/tests/tests.rs
@@ -1814,6 +1814,7 @@ fn test_canister_snapshots() {
     pic.stop_canister(canister_id, None).unwrap();
     let third_snapshot = pic.take_canister_snapshot(canister_id, None, None).unwrap();
     pic.start_canister(canister_id, None).unwrap();
+    let snapshots = pic.list_canister_snapshots(canister_id, None).unwrap();
     assert_eq!(snapshots[0].id, second_snapshot.id);
 
     // Finally, we delete the second snapshot which leaves the canister with the third snapshot

--- a/packages/pocket-ic/tests/tests.rs
+++ b/packages/pocket-ic/tests/tests.rs
@@ -1792,20 +1792,28 @@ fn test_canister_snapshots() {
     let reply = call_counter_canister(&pic, canister_id, "read");
     assert_eq!(reply, 2_u32.to_le_bytes().to_vec());
 
-    // We take one more snapshot: since we already have an active snapshot,
-    // taking another snapshot fails unless we specify the active snapshot to be replaced.
     pic.stop_canister(canister_id, None).unwrap();
-    pic.take_canister_snapshot(canister_id, None, None)
-        .unwrap_err();
+    // We take another snapshot replacing the first one.
     let second_snapshot = pic
         .take_canister_snapshot(canister_id, None, Some(first_snapshot.id))
         .unwrap();
     pic.start_canister(canister_id, None).unwrap();
 
-    // Finally, we delete the current snapshot which allows us to take a snapshot without specifying any snapshot to be replaced.
+    // There should only be the second snapshot in the list of canister snapshots.
+    let snapshots = pic.list_canister_snapshots(canister_id, None).unwrap();
+    assert_eq!(snapshots.len(), 1);
+    assert_eq!(snapshots[0].id, second_snapshot.id);
+    assert_eq!(snapshots[0].total_size, second_snapshot.total_size);
+    assert_eq!(
+        snapshots[0].taken_at_timestamp,
+        second_snapshot.taken_at_timestamp
+    );
+
+    // Finally, we delete the current snapshot which leaves the canister without any other snapshots.
     pic.delete_canister_snapshot(canister_id, None, second_snapshot.id)
         .unwrap();
-    pic.take_canister_snapshot(canister_id, None, None).unwrap();
+    let snapshots = pic.list_canister_snapshots(canister_id, None).unwrap();
+    assert_eq!(snapshots.len(), 0);
 }
 
 #[test]

--- a/rs/config/src/execution_environment.rs
+++ b/rs/config/src/execution_environment.rs
@@ -149,7 +149,7 @@ pub const MAX_COMPILATION_CACHE_SIZE: NumBytes = NumBytes::new(10 * GIB);
 pub const MAX_ALLOWED_CONTROLLERS_COUNT: usize = 10;
 
 /// Maximum number of canister snapshots that can be stored for a single canister.
-pub const MAX_NUMBER_OF_SNAPSHOTS_PER_CANISTER: usize = 1;
+pub const MAX_NUMBER_OF_SNAPSHOTS_PER_CANISTER: usize = 10;
 
 /// Maximum number of http outcall requests in-flight on a subnet.
 /// To support 100 req/s with a worst case request latency of 30s the queue size needs buffer 100 req/s * 30s = 3000 req.
@@ -317,6 +317,9 @@ pub struct Config {
     ///   - let `halfway_to_max = (memory_usage + 4GiB) / 2`
     ///   - use the maximum of `default_wasm_memory_limit` and `halfway_to_max`.
     pub default_wasm_memory_limit: NumBytes,
+
+    /// The maximum number of snapshots allowed per canister.
+    pub max_number_of_snapshots_per_canister: usize,
 }
 
 impl Default for Config {
@@ -395,6 +398,7 @@ impl Default for Config {
             dirty_page_logging: FlagStatus::Disabled,
             max_canister_http_requests_in_flight: MAX_CANISTER_HTTP_REQUESTS_IN_FLIGHT,
             default_wasm_memory_limit: DEFAULT_WASM_MEMORY_LIMIT,
+            max_number_of_snapshots_per_canister: MAX_NUMBER_OF_SNAPSHOTS_PER_CANISTER,
         }
     }
 }

--- a/rs/execution_environment/src/canister_manager.rs
+++ b/rs/execution_environment/src/canister_manager.rs
@@ -13,9 +13,7 @@ use crate::{
 };
 use ic_base_types::NumSeconds;
 use ic_config::embedders::Config as EmbeddersConfig;
-use ic_config::{
-    execution_environment::MAX_NUMBER_OF_SNAPSHOTS_PER_CANISTER, flag_status::FlagStatus,
-};
+use ic_config::flag_status::FlagStatus;
 use ic_cycles_account_manager::{CyclesAccountManager, ResourceSaturation};
 use ic_embedders::wasm_utils::decoding::decode_wasm;
 use ic_error_types::{ErrorCode, RejectCode, UserError};
@@ -131,6 +129,7 @@ pub(crate) struct CanisterMgrConfig {
     wasm_chunk_store_max_size: NumBytes,
     canister_snapshot_baseline_instructions: NumInstructions,
     default_wasm_memory_limit: NumBytes,
+    max_number_of_snapshots_per_canister: usize,
 }
 
 impl CanisterMgrConfig {
@@ -153,6 +152,7 @@ impl CanisterMgrConfig {
         wasm_chunk_store_max_size: NumBytes,
         canister_snapshot_baseline_instructions: NumInstructions,
         default_wasm_memory_limit: NumBytes,
+        max_number_of_snapshots_per_canister: usize,
     ) -> Self {
         Self {
             subnet_memory_capacity,
@@ -172,6 +172,7 @@ impl CanisterMgrConfig {
             wasm_chunk_store_max_size,
             canister_snapshot_baseline_instructions,
             default_wasm_memory_limit,
+            max_number_of_snapshots_per_canister,
         }
     }
 }
@@ -1874,12 +1875,12 @@ impl CanisterManager {
                 if state
                     .canister_snapshots
                     .count_by_canister(&canister.canister_id())
-                    >= MAX_NUMBER_OF_SNAPSHOTS_PER_CANISTER
+                    >= self.config.max_number_of_snapshots_per_canister
                 {
                     return (
                         Err(CanisterManagerError::CanisterSnapshotLimitExceeded {
                             canister_id: canister.canister_id(),
-                            limit: MAX_NUMBER_OF_SNAPSHOTS_PER_CANISTER,
+                            limit: self.config.max_number_of_snapshots_per_canister,
                         }),
                         NumInstructions::new(0),
                     );

--- a/rs/execution_environment/src/canister_manager/tests.rs
+++ b/rs/execution_environment/src/canister_manager/tests.rs
@@ -17,7 +17,7 @@ use ic_base_types::{NumSeconds, PrincipalId};
 use ic_config::{
     execution_environment::{
         Config, CANISTER_GUARANTEED_CALLBACK_QUOTA, DEFAULT_WASM_MEMORY_LIMIT,
-        SUBNET_CALLBACK_SOFT_LIMIT,
+        MAX_NUMBER_OF_SNAPSHOTS_PER_CANISTER, SUBNET_CALLBACK_SOFT_LIMIT,
     },
     flag_status::FlagStatus,
     subnet_config::SchedulerConfig,
@@ -309,6 +309,7 @@ fn canister_manager_config(
         ic_config::embedders::Config::default().wasm_max_size,
         SchedulerConfig::application_subnet().canister_snapshot_baseline_instructions,
         DEFAULT_WASM_MEMORY_LIMIT,
+        MAX_NUMBER_OF_SNAPSHOTS_PER_CANISTER,
     )
 }
 

--- a/rs/execution_environment/src/execution_environment.rs
+++ b/rs/execution_environment/src/execution_environment.rs
@@ -403,6 +403,7 @@ impl ExecutionEnvironment {
             config.embedders_config.wasm_max_size,
             canister_snapshot_baseline_instructions,
             config.default_wasm_memory_limit,
+            config.max_number_of_snapshots_per_canister,
         );
         let metrics = ExecutionEnvironmentMetrics::new(metrics_registry);
         let canister_manager = CanisterManager::new(

--- a/rs/execution_environment/src/execution_environment/tests/canister_snapshots.rs
+++ b/rs/execution_environment/src/execution_environment/tests/canister_snapshots.rs
@@ -387,9 +387,11 @@ fn take_canister_snapshot_fails_when_limit_is_reached() {
     const CYCLES: Cycles = Cycles::new(20_000_000_000_000);
     let own_subnet = subnet_test_id(1);
     let caller_canister = canister_test_id(1);
+    let max_snapshots_per_canister = 5;
     let mut test = ExecutionTestBuilder::new()
         .with_own_subnet_id(own_subnet)
         .with_caller(own_subnet, caller_canister)
+        .with_max_snapshots_per_canister(max_snapshots_per_canister)
         .build();
 
     // Create canister and update controllers.
@@ -438,8 +440,15 @@ fn take_canister_snapshot_fails_when_limit_is_reached() {
             .wasm_chunk_store
     );
 
+    // Take some more snapshots until just before the limit is reached. Should succeed.
+    for _ in 0..(max_snapshots_per_canister - 1) {
+        let args: TakeCanisterSnapshotArgs = TakeCanisterSnapshotArgs::new(canister_id, None);
+        test.subnet_message("take_canister_snapshot", args.encode())
+            .unwrap();
+    }
+
     // Take a new snapshot for the canister without providing a replacement ID.
-    // Should fail as only 1 snapshot per canister is allowed.
+    // Should fail as we have already created `max_snapshots_per_canister`` above.
     let args: TakeCanisterSnapshotArgs = TakeCanisterSnapshotArgs::new(canister_id, None);
     let error = test
         .subnet_message("take_canister_snapshot", args.encode())
@@ -448,8 +457,8 @@ fn take_canister_snapshot_fails_when_limit_is_reached() {
     assert_eq!(
         error.description(),
         format!(
-            "Canister {} has reached the maximum number of snapshots allowed: 1.",
-            canister_id,
+            "Canister {} has reached the maximum number of snapshots allowed: {}.",
+            canister_id, max_snapshots_per_canister,
         )
     );
 }

--- a/rs/test_utilities/execution_environment/src/lib.rs
+++ b/rs/test_utilities/execution_environment/src/lib.rs
@@ -2199,6 +2199,11 @@ impl ExecutionTestBuilder {
         self
     }
 
+    pub fn with_max_snapshots_per_canister(mut self, max_snapshots_per_canister: usize) -> Self {
+        self.execution_config.max_number_of_snapshots_per_canister = max_snapshots_per_canister;
+        self
+    }
+
     pub fn build(self) -> ExecutionTest {
         let own_range = CanisterIdRange {
             start: CanisterId::from(CANISTER_IDS_PER_SUBNET),


### PR DESCRIPTION
This increases the maximum allowed snapshots per canister from 1 to 10. It should allow people to take multiple snapshots at different times and be able to restore their canister to different versions if desired.

The maximum number is moved to the execution config to make it possible to write the test in execution_environment in a more robust way that does not depend on the hardcoded value. In the future, if we need to change the number it should really be one line change.