### PR TITLE
test(sns): Add integration test for SetCustomProposalTopics

### DIFF
--- a/rs/nervous_system/agent/src/sns/governance.rs
+++ b/rs/nervous_system/agent/src/sns/governance.rs
@@ -1,10 +1,12 @@
 use crate::{null_request::NullRequest, CallCanisters};
 use ic_base_types::PrincipalId;
 use ic_sns_governance_api::pb::v1::{
-    manage_neuron, manage_neuron_response, GetMetadataRequest, GetMetadataResponse, GetMode,
-    GetModeResponse, GetProposal, GetProposalResponse, GetRunningSnsVersionRequest,
-    GetRunningSnsVersionResponse, GovernanceError, ManageNeuron, ManageNeuronResponse,
-    NervousSystemParameters, NeuronId, Proposal, ProposalId,
+    manage_neuron, manage_neuron_response,
+    topics::{ListTopicsRequest, ListTopicsResponse},
+    GetMetadataRequest, GetMetadataResponse, GetMode, GetModeResponse, GetProposal,
+    GetProposalResponse, GetRunningSnsVersionRequest, GetRunningSnsVersionResponse,
+    GovernanceError, ManageNeuron, ManageNeuronResponse, NervousSystemParameters, NeuronId,
+    Proposal, ProposalId,
 };
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -119,6 +121,13 @@ impl GovernanceCanister {
             proposal_id: Some(proposal_id),
         };
         agent.call(self.canister_id, request).await
+    }
+
+    pub async fn list_topics<C: CallCanisters>(
+        &self,
+        agent: &C,
+    ) -> Result<ListTopicsResponse, C::Error> {
+        agent.call(self.canister_id, ListTopicsRequest {}).await
     }
 }
 

--- a/rs/nervous_system/agent/src/sns/governance/requests.rs
+++ b/rs/nervous_system/agent/src/sns/governance/requests.rs
@@ -1,4 +1,5 @@
 use ic_sns_governance_api::pb::v1::{
+    topics::{ListTopicsRequest, ListTopicsResponse},
     AdvanceTargetVersionRequest, AdvanceTargetVersionResponse, ClaimSwapNeuronsRequest,
     ClaimSwapNeuronsResponse, FailStuckUpgradeInProgressRequest,
     FailStuckUpgradeInProgressResponse, GetMaturityModulationRequest,
@@ -234,4 +235,20 @@ impl Request for AdvanceTargetVersionRequest {
     }
 
     type Response = AdvanceTargetVersionResponse;
+}
+
+impl Request for ListTopicsRequest {
+    fn method(&self) -> &'static str {
+        "list_topics"
+    }
+
+    fn update(&self) -> bool {
+        false
+    }
+
+    fn payload(&self) -> Result<Vec<u8>, candid::Error> {
+        candid::encode_one(self)
+    }
+
+    type Response = ListTopicsResponse;
 }

--- a/rs/nervous_system/integration_tests/BUILD.bazel
+++ b/rs/nervous_system/integration_tests/BUILD.bazel
@@ -190,6 +190,7 @@ rust_test_suite_with_extra_srcs(
             "tests/sns_upgrade_test_utils_legacy.rs",
             "tests/upgrade_sns_controlled_canister_with_large_wasm.rs",
             "tests/custom_upgrade_path.rs",
+            "tests/sns_topics.rs",
         ],
     ),
     aliases = ALIASES,
@@ -314,6 +315,23 @@ rust_test(
     timeout = "long",
     srcs = [
         "tests/custom_upgrade_path.rs",
+    ],
+    aliases = ALIASES,
+    data = DEV_DATA,
+    env = DEV_ENV | {"RUST_TEST_NOCAPTURE": "1"},
+    flaky = False,
+    proc_macro_deps = MACRO_DEPENDENCIES + MACRO_DEV_DEPENDENCIES,
+    tags = [
+        "cpu:4",
+    ],
+    deps = [":nervous_system_integration_tests"] + DEPENDENCIES_WITH_TEST_FEATURES + DEV_DEPENDENCIES,
+)
+
+rust_test(
+    name = "sns_topics",
+    timeout = "long",
+    srcs = [
+        "tests/sns_topics.rs",
     ],
     aliases = ALIASES,
     data = DEV_DATA,

--- a/rs/nervous_system/integration_tests/tests/sns_topics.rs
+++ b/rs/nervous_system/integration_tests/tests/sns_topics.rs
@@ -1,0 +1,196 @@
+use ic_base_types::PrincipalId;
+use ic_nervous_system_agent::pocketic_impl::PocketIcAgent;
+use ic_nervous_system_agent::sns::governance::{GovernanceCanister, SubmittedProposal};
+use ic_nervous_system_integration_tests::pocket_ic_helpers::{nns, sns, NnsInstaller};
+use ic_nervous_system_integration_tests::{
+    create_service_nervous_system_builder::CreateServiceNervousSystemBuilder,
+    pocket_ic_helpers::add_wasms_to_sns_wasm,
+};
+use ic_sns_governance_api::pb::v1::nervous_system_function::{
+    FunctionType, GenericNervousSystemFunction,
+};
+use ic_sns_governance_api::pb::v1::proposal::Action;
+use ic_sns_governance_api::pb::v1::topics::{ListTopicsResponse, Topic};
+use ic_sns_governance_api::pb::v1::{NervousSystemFunction, Proposal, SetCustomProposalTopics};
+use ic_sns_swap::pb::v1::Lifecycle;
+use maplit::btreemap;
+use pocket_ic::PocketIcBuilder;
+
+const DUMMY_URL_FOR_PROPOSALS: &str = "https://forum.dfinity.org";
+
+#[tokio::test]
+async fn test_set_custom_sns_topics() {
+    // 1. Prepare the world
+    let pocket_ic = PocketIcBuilder::new()
+        .with_nns_subnet()
+        .with_sns_subnet()
+        .build_async()
+        .await;
+
+    // Install the NNS canisters.
+    {
+        let mut nns_installer = NnsInstaller::default();
+        nns_installer.with_current_nns_canister_versions();
+        nns_installer.install(&pocket_ic).await;
+    }
+
+    // Publish SNS Wasms to SNS-W.
+    let with_mainnet_sns_canisters = false;
+    add_wasms_to_sns_wasm(&pocket_ic, with_mainnet_sns_canisters)
+        .await
+        .unwrap();
+
+    let sns = {
+        let create_service_nervous_system = CreateServiceNervousSystemBuilder::default().build();
+
+        let sns_instance_label = "1";
+        let (sns, _) = nns::governance::propose_to_deploy_sns_and_wait(
+            &pocket_ic,
+            create_service_nervous_system,
+            sns_instance_label,
+        )
+        .await;
+
+        sns::swap::await_swap_lifecycle(&pocket_ic, sns.swap.canister_id, Lifecycle::Open)
+            .await
+            .unwrap();
+
+        sns
+    };
+
+    // Get an ID of an SNS neuron that can submit proposals. We rely on the fact that this
+    // neuron either holds the majority of the voting power or the follow graph is set up
+    // s.t. when this neuron submits a proposal, that proposal gets through without the need
+    // for any voting.
+    let (sns_neuron_id, sender) = sns::governance::find_neuron_with_majority_voting_power(
+        &pocket_ic,
+        sns.governance.canister_id,
+    )
+    .await
+    .expect("cannot find SNS neuron with dissolve delay over 6 months.");
+
+    let pocket_ic_agent = PocketIcAgent {
+        pocket_ic: &pocket_ic,
+        sender: sender.into(),
+    };
+
+    let governance_canister = GovernanceCanister {
+        canister_id: sns.governance.canister_id,
+    };
+
+    let initial_generic_function = GenericNervousSystemFunction {
+        target_canister_id: Some(PrincipalId::new_user_test_id(42)),
+        target_method_name: Some("do_things".to_string()),
+        validator_canister_id: Some(PrincipalId::new_user_test_id(43)),
+        validator_method_name: Some("validate_things".to_string()),
+        topic: Some(Topic::DaoCommunitySettings),
+    };
+
+    let expected_generic_function = GenericNervousSystemFunction {
+        topic: Some(Topic::ApplicationBusinessLogic),
+        ..initial_generic_function.clone()
+    };
+
+    let initial_function = NervousSystemFunction {
+        id: 1111,
+        name: "Test Custom Proposal Type".to_string(),
+        description: Some("This is a custom proposal type for testing.".to_string()),
+        function_type: Some(FunctionType::GenericNervousSystemFunction(
+            initial_generic_function,
+        )),
+    };
+
+    let expected_function = NervousSystemFunction {
+        function_type: Some(FunctionType::GenericNervousSystemFunction(
+            expected_generic_function,
+        )),
+        ..initial_function.clone()
+    };
+
+    // AddGenericNervousSystemFunction
+    {
+        let response = governance_canister
+            .submit_proposal(
+                &pocket_ic_agent,
+                sns_neuron_id.clone(),
+                Proposal {
+                    title: "Add custom proposal under the DaoCommunitySettings topic.".to_string(),
+                    summary: "Add custom proposal under the DaoCommunitySettings topic."
+                        .to_string(),
+                    url: DUMMY_URL_FOR_PROPOSALS.to_string(),
+                    action: Some(Action::AddGenericNervousSystemFunction(initial_function)),
+                },
+            )
+            .await
+            .unwrap();
+
+        let proposal_id = SubmittedProposal::try_from(response)
+            .unwrap()
+            .proposal_id
+            .id;
+
+        nns::governance::wait_for_proposal_execution(&pocket_ic, proposal_id)
+            .await
+            .unwrap();
+    }
+
+    // SetCustomProposalTopics
+    {
+        let response = governance_canister
+            .submit_proposal(
+                &pocket_ic_agent,
+                sns_neuron_id,
+                Proposal {
+                    title: "Set custom SNS proposal topics.".to_string(),
+                    summary: "Set custom SNS proposal topics.".to_string(),
+                    url: DUMMY_URL_FOR_PROPOSALS.to_string(),
+                    action: Some(Action::SetCustomProposalTopics(SetCustomProposalTopics {
+                        custom_function_id_to_topic: btreemap! {
+                            1111_u64 => Topic::ApplicationBusinessLogic,
+                        },
+                    })),
+                },
+            )
+            .await
+            .unwrap();
+
+        let proposal_id = SubmittedProposal::try_from(response)
+            .unwrap()
+            .proposal_id
+            .id;
+
+        nns::governance::wait_for_proposal_execution(&pocket_ic, proposal_id)
+            .await
+            .unwrap();
+    }
+
+    // Assert that the intended changes took place.
+    let ListTopicsResponse {
+        topics,
+        uncategorized_functions,
+    } = governance_canister.list_topics(&pocket_ic).await.unwrap();
+
+    assert_eq!(uncategorized_functions, Some(vec![]));
+
+    let custom_proposal_topics = topics
+        .unwrap()
+        .into_iter()
+        .map(|topic_info| (topic_info.name.unwrap(), topic_info.custom_functions))
+        .collect::<Vec<_>>();
+
+    assert_eq!(
+        custom_proposal_topics,
+        vec![
+            ("DAO community settings".to_string(), Some(vec![])),
+            ("SNS framework management".to_string(), Some(vec![])),
+            ("Dapp canister management".to_string(), Some(vec![])),
+            (
+                "Application Business Logic".to_string(),
+                Some(vec![expected_function])
+            ),
+            ("Governance".to_string(), Some(vec![])),
+            ("Treasury & asset management".to_string(), Some(vec![])),
+            ("Critical Dapp Operations".to_string(), Some(vec![])),
+        ],
+    );
+}

--- a/rs/sns/governance/api/src/ic_sns_governance.pb.v1.rs
+++ b/rs/sns/governance/api/src/ic_sns_governance.pb.v1.rs
@@ -477,7 +477,7 @@ pub struct AdvanceSnsTargetVersion {
     candid::CandidType, candid::Deserialize, comparable::Comparable, Clone, Debug, PartialEq,
 )]
 pub struct SetCustomProposalTopics {
-    pub custom_function_id_to_topic: ::prost::alloc::collections::BTreeMap<u64, i32>,
+    pub custom_function_id_to_topic: BTreeMap<u64, topics::Topic>,
 }
 /// A proposal is the immutable input of a proposal submission.
 #[derive(Default, candid::CandidType, candid::Deserialize, Debug, Clone, PartialEq)]

--- a/rs/sns/governance/api/src/ic_sns_governance.pb.v1.rs
+++ b/rs/sns/governance/api/src/ic_sns_governance.pb.v1.rs
@@ -473,6 +473,12 @@ pub struct AdvanceSnsTargetVersion {
     /// If not specified, the target will advance to the latest SNS version known to this SNS.
     pub new_target: Option<SnsVersion>,
 }
+#[derive(
+    candid::CandidType, candid::Deserialize, comparable::Comparable, Clone, Debug, PartialEq,
+)]
+pub struct SetCustomProposalTopics {
+    pub custom_function_id_to_topic: ::prost::alloc::collections::BTreeMap<u64, i32>,
+}
 /// A proposal is the immutable input of a proposal submission.
 #[derive(Default, candid::CandidType, candid::Deserialize, Debug, Clone, PartialEq)]
 pub struct Proposal {
@@ -584,6 +590,10 @@ pub mod proposal {
         ///
         /// Id = 15.
         AdvanceSnsTargetVersion(super::AdvanceSnsTargetVersion),
+        /// SetCustomProposalTopics
+        ///
+        /// Id = 16;
+        SetCustomProposalTopics(super::SetCustomProposalTopics),
     }
 }
 #[derive(Default, candid::CandidType, candid::Deserialize, Debug, Clone, PartialEq)]
@@ -785,6 +795,7 @@ pub struct ProposalData {
     /// Id 13 - ManageLedgerParameters proposals.
     /// Id 14 - ManageDappCanisterSettings proposals.
     /// Id 15 - AdvanceSnsTargetVersion proposals.
+    /// Id 16 - SetCustomProposalTopics proposals.
     pub action: u64,
     /// This is stored here temporarily. It is also stored on the map
     /// that contains proposals.

--- a/rs/sns/governance/api/src/topics.rs
+++ b/rs/sns/governance/api/src/topics.rs
@@ -7,6 +7,7 @@ use crate::pb::v1::NervousSystemFunction;
     Debug,
     candid::CandidType,
     candid::Deserialize,
+    comparable::Comparable,
     Ord,
     PartialOrd,
     Eq,

--- a/rs/sns/governance/canister/governance.did
+++ b/rs/sns/governance/canister/governance.did
@@ -6,6 +6,7 @@ type Account = record {
 type Action = variant {
   ManageNervousSystemParameters : NervousSystemParameters;
   AddGenericNervousSystemFunction : NervousSystemFunction;
+  SetCustomProposalTopics : SetCustomProposalTopics;
   ManageDappCanisterSettings : ManageDappCanisterSettings;
   RemoveGenericNervousSystemFunction : nat64;
   UpgradeSnsToNextVersion : record {};
@@ -392,6 +393,10 @@ type SnsVersion = record {
 
 type AdvanceSnsTargetVersion = record {
   new_target : opt SnsVersion;
+};
+
+type SetCustomProposalTopics = record {
+  custom_function_id_to_topic : vec record { nat64; Topic };
 };
 
 type ManageLedgerParameters = record {

--- a/rs/sns/governance/canister/governance_test.did
+++ b/rs/sns/governance/canister/governance_test.did
@@ -6,6 +6,7 @@ type Account = record {
 type Action = variant {
   ManageNervousSystemParameters : NervousSystemParameters;
   AddGenericNervousSystemFunction : NervousSystemFunction;
+  SetCustomProposalTopics : SetCustomProposalTopics;
   ManageDappCanisterSettings : ManageDappCanisterSettings;
   RemoveGenericNervousSystemFunction : nat64;
   UpgradeSnsToNextVersion : record {};
@@ -401,6 +402,10 @@ type SnsVersion = record {
 
 type AdvanceSnsTargetVersion = record {
   new_target : opt SnsVersion;
+};
+
+type SetCustomProposalTopics = record {
+  custom_function_id_to_topic : vec record { nat64; Topic };
 };
 
 type ManageLedgerParameters = record {

--- a/rs/sns/governance/proto/ic_sns_governance/pb/v1/governance.proto
+++ b/rs/sns/governance/proto/ic_sns_governance/pb/v1/governance.proto
@@ -486,6 +486,10 @@ message AdvanceSnsTargetVersion {
   optional SnsVersion new_target = 1;
 }
 
+message SetCustomProposalTopics {
+  map<uint64, Topic> custom_function_id_to_topic = 1;
+}
+
 // A proposal is the immutable input of a proposal submission.
 message Proposal {
   // The proposal's title as a text, which can be at most 256 bytes.
@@ -598,6 +602,11 @@ message Proposal {
     //
     // Id = 15.
     AdvanceSnsTargetVersion advance_sns_target_version = 19;
+
+    // SetCustomProposalTopics
+    //
+    // Id = 16;
+    SetCustomProposalTopics set_custom_proposal_topics = 20;
   }
 }
 
@@ -792,6 +801,7 @@ message ProposalData {
   // Id 13 - ManageLedgerParameters proposals.
   // Id 14 - ManageDappCanisterSettings proposals.
   // Id 15 - AdvanceSnsTargetVersion proposals.
+  // Id 16 - SetCustomProposalTopics proposals.
   uint64 action = 1;
 
   // This is stored here temporarily. It is also stored on the map

--- a/rs/sns/governance/src/gen/ic_sns_governance.pb.v1.rs
+++ b/rs/sns/governance/src/gen/ic_sns_governance.pb.v1.rs
@@ -688,6 +688,18 @@ pub struct AdvanceSnsTargetVersion {
     #[prost(message, optional, tag = "1")]
     pub new_target: ::core::option::Option<SnsVersion>,
 }
+#[derive(
+    candid::CandidType,
+    candid::Deserialize,
+    comparable::Comparable,
+    Clone,
+    PartialEq,
+    ::prost::Message,
+)]
+pub struct SetCustomProposalTopics {
+    #[prost(btree_map = "uint64, enumeration(Topic)", tag = "1")]
+    pub custom_function_id_to_topic: ::prost::alloc::collections::BTreeMap<u64, i32>,
+}
 /// A proposal is the immutable input of a proposal submission.
 #[derive(candid::CandidType, candid::Deserialize, comparable::Comparable)]
 #[compare_default]
@@ -716,7 +728,7 @@ pub struct Proposal {
     /// of this mapping.
     #[prost(
         oneof = "proposal::Action",
-        tags = "4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19"
+        tags = "4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20"
     )]
     pub action: ::core::option::Option<proposal::Action>,
 }
@@ -826,6 +838,11 @@ pub mod proposal {
         /// Id = 15.
         #[prost(message, tag = "19")]
         AdvanceSnsTargetVersion(super::AdvanceSnsTargetVersion),
+        /// SetCustomProposalTopics
+        ///
+        /// Id = 16;
+        #[prost(message, tag = "20")]
+        SetCustomProposalTopics(super::SetCustomProposalTopics),
     }
 }
 #[derive(candid::CandidType, candid::Deserialize, comparable::Comparable)]
@@ -1059,6 +1076,7 @@ pub struct ProposalData {
     /// Id 13 - ManageLedgerParameters proposals.
     /// Id 14 - ManageDappCanisterSettings proposals.
     /// Id 15 - AdvanceSnsTargetVersion proposals.
+    /// Id 16 - SetCustomProposalTopics proposals.
     #[prost(uint64, tag = "1")]
     pub action: u64,
     /// This is stored here temporarily. It is also stored on the map

--- a/rs/sns/governance/src/governance.rs
+++ b/rs/sns/governance/src/governance.rs
@@ -53,7 +53,7 @@ use crate::{
             MintTokensRequest, MintTokensResponse, NervousSystemFunction, NervousSystemParameters,
             Neuron, NeuronId, NeuronPermission, NeuronPermissionList, NeuronPermissionType,
             Proposal, ProposalData, ProposalDecisionStatus, ProposalId, ProposalRewardStatus,
-            RegisterDappCanisters, RewardEvent, SetCustomProposalTopics, Tally, Topic,
+            RegisterDappCanisters, RewardEvent, SetCustomProposalTopics, Tally,
             TransferSnsTreasuryFunds, UpgradeSnsControlledCanister, Vote, WaitForQuietState,
         },
     },
@@ -478,51 +478,6 @@ impl GovernanceProto {
                      the maturity modulation value from the Cycles Minting Canister.",
                 )
             })
-    }
-
-    pub fn custom_functions_to_topics(&self) -> BTreeMap<u64, Option<Topic>> {
-        self.id_to_nervous_system_functions
-            .iter()
-            .filter_map(|(function_id, function)| {
-                match &function.function_type {
-                    Some(FunctionType::GenericNervousSystemFunction(generic)) => {
-                        if let Some(topic) = generic.topic {
-                            let specific_topic = match Topic::try_from(topic) {
-                                Err(err) => {
-                                    log!(
-                                        ERROR,
-                                        "Custom proposal ID {function_id}: Cannot interpret \
-                                            {topic} as Topic: {err}",
-                                    );
-
-                                    // This should never happen; if it somehow does, treat this
-                                    // case as a custom function for which the topic is unknown.
-                                    None
-                                }
-                                Ok(Topic::Unspecified) => {
-                                    log!(
-                                        ERROR,
-                                        "Custom proposal ID {function_id}: topic Unspecified."
-                                    );
-
-                                    // This should never happen, but if it somehow does, treat this
-                                    // case as a custom function for which the topic is unknown.
-                                    None
-                                }
-                                Ok(topic) => Some(topic),
-                            };
-
-                            Some((*function_id, specific_topic))
-                        } else {
-                            // Topic not yet set for this custom function.
-                            Some((*function_id, None))
-                        }
-                    }
-                    // Not a custom function.
-                    _ => None,
-                }
-            })
-            .collect()
     }
 }
 

--- a/rs/sns/governance/src/governance.rs
+++ b/rs/sns/governance/src/governance.rs
@@ -52,8 +52,8 @@ use crate::{
             MintTokensRequest, MintTokensResponse, NervousSystemFunction, NervousSystemParameters,
             Neuron, NeuronId, NeuronPermission, NeuronPermissionList, NeuronPermissionType,
             Proposal, ProposalData, ProposalDecisionStatus, ProposalId, ProposalRewardStatus,
-            RegisterDappCanisters, RewardEvent, Tally, TransferSnsTreasuryFunds,
-            UpgradeSnsControlledCanister, Vote, WaitForQuietState,
+            RegisterDappCanisters, RewardEvent, SetCustomProposalTopics, Tally,
+            TransferSnsTreasuryFunds, UpgradeSnsControlledCanister, Vote, WaitForQuietState,
         },
     },
     proposal::{
@@ -2140,6 +2140,9 @@ impl Governance {
                     })
                     .and_then(|new_target| self.perform_advance_target_version(new_target))
             }
+            Action::SetCustomProposalTopics(set_custom_proposal_topics) => {
+                self.perform_set_custom_proposal_topics(set_custom_proposal_topics)
+            }
             // This should not be possible, because Proposal validation is performed when
             // a proposal is first made.
             Action::Unspecified(_) => Err(GovernanceError::new_with_message(
@@ -3118,6 +3121,24 @@ impl Governance {
 
         self.proto.target_version = Some(target_version);
 
+        Ok(())
+    }
+
+    // Make a change to the mapping from custom proposal types to topics.
+    fn perform_set_custom_proposal_topics(
+        &mut self,
+        set_custom_proposal_topics: SetCustomProposalTopics,
+    ) -> Result<(), GovernanceError> {
+        // TODO: Validate set_custom_proposal_topics.topic_infos
+        // - all function are registered
+        // - topics can be decoded
+
+        // for (custom_function_id, topic) in topic_infos.into_iter() {
+        //     // self.proto
+        //     //     .id_to_nervous_system_functions
+        //     //     .
+        //     todo!();
+        // }
         Ok(())
     }
 

--- a/rs/sns/governance/src/pb/conversions.rs
+++ b/rs/sns/governance/src/pb/conversions.rs
@@ -577,14 +577,37 @@ impl From<pb::AdvanceSnsTargetVersion> for pb_api::AdvanceSnsTargetVersion {
 impl From<pb_api::SetCustomProposalTopics> for pb::SetCustomProposalTopics {
     fn from(item: pb_api::SetCustomProposalTopics) -> Self {
         Self {
-            custom_function_id_to_topic: item.custom_function_id_to_topic.into_iter().collect(),
+            custom_function_id_to_topic: item
+                .custom_function_id_to_topic
+                .into_iter()
+                .map(|(custom_function_id, topic)| {
+                    let topic = i32::from(pb::Topic::from(topic));
+                    (custom_function_id, topic)
+                })
+                .collect(),
         }
     }
 }
 impl From<pb::SetCustomProposalTopics> for pb_api::SetCustomProposalTopics {
     fn from(item: pb::SetCustomProposalTopics) -> Self {
+        let custom_function_id_to_topic = item
+            .custom_function_id_to_topic
+            .into_iter()
+            .filter_map(|(custom_function_id, topic)| {
+                let Ok(topic) = pb::Topic::try_from(topic) else {
+                    return None;
+                };
+
+                let Ok(topic) = pb_api::topics::Topic::try_from(topic) else {
+                    return None;
+                };
+
+                Some((custom_function_id, topic))
+            })
+            .collect();
+
         Self {
-            custom_function_id_to_topic: item.custom_function_id_to_topic.into_iter().collect(),
+            custom_function_id_to_topic,
         }
     }
 }

--- a/rs/sns/governance/src/pb/conversions.rs
+++ b/rs/sns/governance/src/pb/conversions.rs
@@ -574,6 +574,21 @@ impl From<pb::AdvanceSnsTargetVersion> for pb_api::AdvanceSnsTargetVersion {
     }
 }
 
+impl From<pb_api::SetCustomProposalTopics> for pb::SetCustomProposalTopics {
+    fn from(item: pb_api::SetCustomProposalTopics) -> Self {
+        Self {
+            custom_function_id_to_topic: item.custom_function_id_to_topic.into_iter().collect(),
+        }
+    }
+}
+impl From<pb::SetCustomProposalTopics> for pb_api::SetCustomProposalTopics {
+    fn from(item: pb::SetCustomProposalTopics) -> Self {
+        Self {
+            custom_function_id_to_topic: item.custom_function_id_to_topic.into_iter().collect(),
+        }
+    }
+}
+
 impl From<pb::Proposal> for pb_api::Proposal {
     fn from(item: pb::Proposal) -> Self {
         Self {
@@ -642,6 +657,9 @@ impl From<pb::proposal::Action> for pb_api::proposal::Action {
             pb::proposal::Action::AdvanceSnsTargetVersion(v) => {
                 pb_api::proposal::Action::AdvanceSnsTargetVersion(v.into())
             }
+            pb::proposal::Action::SetCustomProposalTopics(v) => {
+                pb_api::proposal::Action::SetCustomProposalTopics(v.into())
+            }
         }
     }
 }
@@ -691,6 +709,9 @@ impl From<pb_api::proposal::Action> for pb::proposal::Action {
             }
             pb_api::proposal::Action::AdvanceSnsTargetVersion(v) => {
                 pb::proposal::Action::AdvanceSnsTargetVersion(v.into())
+            }
+            pb_api::proposal::Action::SetCustomProposalTopics(v) => {
+                pb::proposal::Action::SetCustomProposalTopics(v.into())
             }
         }
     }

--- a/rs/sns/governance/src/proposal.rs
+++ b/rs/sns/governance/src/proposal.rs
@@ -2726,6 +2726,9 @@ mod minting_tests;
 mod advance_sns_target_version;
 
 #[cfg(test)]
+mod set_custom_proposal_topics;
+
+#[cfg(test)]
 mod tests {
     use super::*;
     use crate::{

--- a/rs/sns/governance/src/proposal/set_custom_proposal_topics.rs
+++ b/rs/sns/governance/src/proposal/set_custom_proposal_topics.rs
@@ -4,24 +4,79 @@ use pretty_assertions::assert_eq;
 
 #[test]
 fn test_validate_and_render_set_custom_proposal_topics() {
-    for (set_custom_proposal_topics, existing_custom_functions, expected) in [(
-        SetCustomProposalTopics {
-            custom_function_id_to_topic: btreemap! {
-                111_u64 => Topic::DaoCommunitySettings as i32,
+    for (set_custom_proposal_topics, existing_custom_functions, expected) in [
+        (
+            SetCustomProposalTopics {
+                custom_function_id_to_topic: btreemap! {
+                    111_u64 => Topic::DaoCommunitySettings as i32,
+                },
             },
-        },
-        btreemap! {
-            111 => Some(Topic::Governance),
-        },
-        Ok::<String, String>(
-            r#"# Proposal to set topics for custom SNS proposal types
+            btreemap! {
+                111 => ("AAA".to_string(), Some(Topic::Governance)),
+            },
+            Ok::<String, String>(
+                r#"# Set topics for custom SNS proposal types
 
-### If adopted, the following custom functions will be categorized under the specified topics:
+### If adopted, the following proposals will be categorized under the specified topics:
 
-DaoCommunitySettings (changing from Governance)"#
-                .to_string(),
+  - AAA under topic DaoCommunitySettings (changing from Governance)"#
+                    .to_string(),
+            ),
         ),
-    )] {
+        (
+            SetCustomProposalTopics {
+                custom_function_id_to_topic: btreemap! {
+                    222_u64 => Topic::DaoCommunitySettings as i32,
+                    111_u64 => Topic::DaoCommunitySettings as i32,
+                    444_u64 => Topic::DaoCommunitySettings as i32,
+                },
+            },
+            btreemap! {
+                111 => ("AAA".to_string(), Some(Topic::DaoCommunitySettings)),
+                222 => ("BBB".to_string(), Some(Topic::Governance)),
+                333 => ("CCC".to_string(), Some(Topic::Governance)),
+                444 => ("DDD".to_string(), None),
+            },
+            Ok::<String, String>(
+                r#"# Set topics for custom SNS proposal types
+
+### If adopted, the following proposals will be categorized under the specified topics:
+
+  - AAA under topic DaoCommunitySettings (keeping unchanged)
+  - BBB under topic DaoCommunitySettings (changing from Governance)
+  - DDD under topic DaoCommunitySettings (topic not currently set)"#
+                    .to_string(),
+            ),
+        ),
+        (
+            SetCustomProposalTopics {
+                custom_function_id_to_topic: btreemap! {},
+            },
+            btreemap! {
+                111 => ("AAA".to_string(), Some(Topic::Governance)),
+            },
+            Err::<String, String>(
+                "SetCustomProposalTopics.custom_function_id_to_topic must not be empty."
+                    .to_string(),
+            ),
+        ),
+        (
+            SetCustomProposalTopics {
+                custom_function_id_to_topic: btreemap! {
+                    111_u64 => Topic::DaoCommunitySettings as i32,
+                },
+            },
+            btreemap! {
+                222 => ("BBB".to_string(), Some(Topic::Governance)),
+            },
+            Err::<String, String>(
+                "Cannot set topic for proposal(s) with ID(s) 111 since they have not been \
+                 registered as custom proposals in this SNS yet. Please use \
+                 `AddGenericNervousSystemFunction` proposals to register new custom SNS proposals."
+                    .to_string(),
+            ),
+        ),
+    ] {
         let observed = validate_and_render_set_custom_proposal_topics(
             &set_custom_proposal_topics,
             &existing_custom_functions,

--- a/rs/sns/governance/src/proposal/set_custom_proposal_topics.rs
+++ b/rs/sns/governance/src/proposal/set_custom_proposal_topics.rs
@@ -1,0 +1,31 @@
+use super::*;
+use maplit::btreemap;
+use pretty_assertions::assert_eq;
+
+#[test]
+fn test_validate_and_render_set_custom_proposal_topics() {
+    for (set_custom_proposal_topics, existing_custom_functions, expected) in [(
+        SetCustomProposalTopics {
+            custom_function_id_to_topic: btreemap! {
+                111_u64 => Topic::DaoCommunitySettings as i32,
+            },
+        },
+        btreemap! {
+            111 => Some(Topic::Governance),
+        },
+        Ok::<String, String>(
+            r#"# Proposal to set topics for custom SNS proposal types
+
+### If adopted, the following custom functions will be categorized under the specified topics:
+
+DaoCommunitySettings (changing from Governance)"#
+                .to_string(),
+        ),
+    )] {
+        let observed = validate_and_render_set_custom_proposal_topics(
+            &set_custom_proposal_topics,
+            &existing_custom_functions,
+        );
+        assert_eq!(observed, expected);
+    }
+}

--- a/rs/sns/governance/src/topics.rs
+++ b/rs/sns/governance/src/topics.rs
@@ -1,9 +1,11 @@
+use crate::logs::ERROR;
 use crate::pb::v1::{self as pb, NervousSystemFunction};
 use crate::types::native_action_ids;
 use crate::{governance::Governance, pb::v1::nervous_system_function::FunctionType};
+use ic_canister_log::log;
 use ic_sns_governance_api::pb::v1::topics::Topic;
 use itertools::Itertools;
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 
 /// Each topic has some information associated with it. This information is for the benefit of the user but has
 /// no effect on the behavior of the SNS.
@@ -198,6 +200,56 @@ impl Governance {
             topics,
             uncategorized_functions,
         }
+    }
+}
+
+impl pb::Governance {
+    /// For each custom function ID, returns a pair (`function_name`, `topic`).
+    pub fn custom_functions_to_topics(&self) -> BTreeMap<u64, (String, Option<pb::Topic>)> {
+        self.id_to_nervous_system_functions
+            .iter()
+            .filter_map(|(function_id, function)| {
+                match &function.function_type {
+                    Some(FunctionType::GenericNervousSystemFunction(generic)) => {
+                        let function_name = function.name.clone();
+
+                        if let Some(topic) = generic.topic {
+                            let specific_topic = match pb::Topic::try_from(topic) {
+                                Err(err) => {
+                                    log!(
+                                        ERROR,
+                                        "Custom proposal ID {function_id}: Cannot interpret \
+                                            {topic} as Topic: {err}",
+                                    );
+
+                                    // This should never happen; if it somehow does, treat this
+                                    // case as a custom function for which the topic is unknown.
+                                    None
+                                }
+                                Ok(pb::Topic::Unspecified) => {
+                                    log!(
+                                        ERROR,
+                                        "Custom proposal ID {function_id}: topic Unspecified."
+                                    );
+
+                                    // This should never happen, but if it somehow does, treat this
+                                    // case as a custom function for which the topic is unknown.
+                                    None
+                                }
+                                Ok(topic) => Some(topic),
+                            };
+
+                            Some((*function_id, (function_name, specific_topic)))
+                        } else {
+                            // Topic not yet set for this custom function.
+                            Some((*function_id, (function_name, None)))
+                        }
+                    }
+                    // Not a custom function.
+                    _ => None,
+                }
+            })
+            .collect()
     }
 }
 

--- a/rs/sns/governance/src/types.rs
+++ b/rs/sns/governance/src/types.rs
@@ -135,6 +135,9 @@ pub mod native_action_ids {
     /// AdvanceSnsTargetVersion Action.
     pub const ADVANCE_SNS_TARGET_VERSION: u64 = 15;
 
+    /// SetCustomProposalTopics Action.
+    pub const SET_CUSTOM_PROPOSAL_ACTION: u64 = 16;
+
     // When adding something to this list, make sure to update the below function.
     pub fn native_functions() -> Vec<NervousSystemFunction> {
         vec![
@@ -153,6 +156,7 @@ pub mod native_action_ids {
             NervousSystemFunction::manage_ledger_parameters(),
             NervousSystemFunction::manage_dapp_canister_settings(),
             NervousSystemFunction::advance_sns_target_version(),
+            NervousSystemFunction::set_custom_proposal_topics(),
         ]
     }
 }
@@ -1231,6 +1235,15 @@ impl NervousSystemFunction {
             function_type: Some(FunctionType::NativeNervousSystemFunction(Empty {})),
         }
     }
+
+    fn set_custom_proposal_topics() -> NervousSystemFunction {
+        NervousSystemFunction {
+            id: native_action_ids::SET_CUSTOM_PROPOSAL_ACTION,
+            name: "Set custom proposal topics".to_string(),
+            description: Some("Proposal to set the topics of custom SNS proposals.".to_string()),
+            function_type: Some(FunctionType::NativeNervousSystemFunction(Empty {})),
+        }
+    }
 }
 
 impl From<Action> for NervousSystemFunction {
@@ -1273,6 +1286,9 @@ impl From<Action> for NervousSystemFunction {
             }
             Action::AdvanceSnsTargetVersion(_) => {
                 NervousSystemFunction::advance_sns_target_version()
+            }
+            Action::SetCustomProposalTopics(_) => {
+                NervousSystemFunction::set_custom_proposal_topics()
             }
         }
     }
@@ -1713,9 +1729,10 @@ impl Action {
     fn proposal_criticality(&self) -> ProposalCriticality {
         use Action::*;
         match self {
-            DeregisterDappCanisters(_) | TransferSnsTreasuryFunds(_) | MintSnsTokens(_) => {
-                ProposalCriticality::Critical
-            }
+            DeregisterDappCanisters(_)
+            | TransferSnsTreasuryFunds(_)
+            | MintSnsTokens(_)
+            | Action::SetCustomProposalTopics(_) => ProposalCriticality::Critical,
 
             Unspecified(_)
             | ManageNervousSystemParameters(_)
@@ -1915,6 +1932,7 @@ impl From<&Action> for u64 {
                 native_action_ids::MANAGE_DAPP_CANISTER_SETTINGS
             }
             Action::AdvanceSnsTargetVersion(_) => native_action_ids::ADVANCE_SNS_TARGET_VERSION,
+            Action::SetCustomProposalTopics(_) => native_action_ids::SET_CUSTOM_PROPOSAL_ACTION,
         }
     }
 }

--- a/rs/sns/governance/unreleased_changelog.md
+++ b/rs/sns/governance/unreleased_changelog.md
@@ -9,6 +9,39 @@ on the process that this file is part of, see
 
 ## Added
 
+* New type of SNS proposals `SetCustomProposalTopics` can be used to batch-set topics for all custom proposals (or any non-empty subset thereof) at once.
+
+    Example usage:
+
+    ```bash
+    dfx canister --ic call ${SNS_GOVERNANCE_CANISTER_ID} manage_neuron '(
+        record {
+            subaccount = blob "'${PROPOSER_SNS_NEURON_SUBACCOUNT}'";
+            command = opt variant {
+                MakeProposal = record {
+                    url = "https://forum.dfinity.org/t/sns-topics-plan";
+                    title = "Set topics for custom SNS proposals";
+                    action = opt variant {
+                        SetCustomProposalTopics = record {
+                            custom_function_id_to_topic = vec {
+                                record {
+                                    42; variant { ApplicationBusinessLogic }
+                                }
+                                record {
+                                    123; variant { DaoCommunitySettings }
+                                }
+                            };
+                        }
+                    };
+                    summary = "Set topics ApplicationBusinessLogic and \
+                            DaoCommunitySettings for SNS proposals with \
+                            IDs 42 and 123 resp.";
+                }
+            };
+        },
+    )'
+    ```
+
 ## Changed
 
 * Enable


### PR DESCRIPTION
This PR adds an integration test for the scenario in which the topic is changed for a custom SNS proposal type.

< [Previous PR](https://github.com/dfinity/ic/pull/4162) |