### PR TITLE
chore(IDX): split bazel-test-all environment

### DIFF
--- a/.github/actions/bazel-test-all/action.yaml
+++ b/.github/actions/bazel-test-all/action.yaml
@@ -16,59 +16,66 @@ inputs:
 runs:
   using: "composite"
   steps:
-      - name: Run Bazel Test All
-        id: bazel-test-all
+      - name: Prepare worker cache
         shell: bash
         run: |
-          set +e # manual error handling to ensure we can run some post-build commands
-
           # freshly deployed k8s machines require ownership correctly set
           if [ -e /cache ]; then
             sudo find /cache \( -not -user 1001 -or -not -group 1001 \) -exec chown 1001:1001 {} +
           fi
 
-          if [ -n "$SSH_PRIVATE_KEY_BACKUP_POD" ]; then
-            # The following adds the SSH private key to the ssh-agent such that CI can SSH into the backup pod.
-            test -z "${SSH_AUTH_SOCK:-}" && { eval "$(ssh-agent -s)"; ssh-add - <<< "${SSH_PRIVATE_KEY_BACKUP_POD}"; }
-            rm -rf ~/.ssh
-            mkdir -p ~/.ssh
-            chmod 0700 ~/.ssh
-            echo -e "Host *\nUser github-runner\n" > ~/.ssh/config
+      - name: Set up backup pod access
+        shell: bash
+        if: inputs.SSH_PRIVATE_KEY_BACKUP_POD != ''
+        run: |
+          # The following adds the SSH private key to the ssh-agent such that CI can SSH into the backup pod.
+          if [ -z "${SSH_AUTH_SOCK:-}" ]; then
+            eval "$(ssh-agent -s)"
+            ssh-add - <<< '${{ inputs.SSH_PRIVATE_KEY_BACKUP_POD }}'
           fi
 
-          # unset honeycomb api key but use it later for exporter
-          # TODO: remove exporter when users can use superset
-          env -u BUILDEVENT_APIKEY ${GITHUB_WORKSPACE}/ci/bazel-scripts/main.sh
-          BAZEL_EXIT_CODE="$?"
+          rm -rf ~/.ssh
+          mkdir -p ~/.ssh
+          chmod 0700 ~/.ssh
+          echo -e "Host *\nUser github-runner\n" > ~/.ssh/config
 
-          if [ -n "$BUILDEVENT_APIKEY" ] && [ -f ./bazel-bep.pb ]; then
+      - name: Run Bazel Test All
+        id: bazel-test-all
+        shell: bash
+        run: |
+          ${GITHUB_WORKSPACE}/ci/bazel-scripts/main.sh
+        env:
+          BAZEL_COMMAND: ${{ inputs.BAZEL_COMMAND }}
+          BAZEL_TARGETS: ${{ inputs.BAZEL_TARGETS }}
+          BRANCH_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          CI_EVENT_NAME: ${{ github.event_name }}
+          CI_JOB_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          MERGE_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+
+      - name: Export bazel build events to honeycomb
+        shell: bash
+        # only upload on success or failure but _not_ on canceled jobs
+        if: (success() || failure()) && inputs.BUILDEVENT_APIKEY != ''
+        run: |
+          if [ -f ./bazel-bep.pb ]; then
               # avoid output unless an error occurs during bes export. This ensures
               # only the (more relevant) output from the main bazel command is shown.
               exportout=$(mktemp)
-              if ! bazel run //bazel/exporter:exporter --build_event_binary_file= -- -f "$(pwd)/bazel-bep.pb" 2> "$exportout" >&2; then
+              if ! BUILDEVENT_APIKEY='${{ inputs.BUILDEVENT_APIKEY }}' bazel run //bazel/exporter:exporter --build_event_binary_file= -- -f "$(pwd)/bazel-bep.pb" 2> "$exportout" >&2; then
                 echo "bes export failed:"
                 cat "$exportout"
               fi
               rm "$exportout"
               echo "BEP events exported to honeycomb!"
           fi
-          if [ -n "$GPG_PASSPHRASE" ] && [ -f ./bazel-bep.pb ]; then
+
+      - name: Encrypt build events
+        shell: bash
+        # only upload on success or failure but _not_ on canceled jobs
+        if: (success() || failure()) && inputs.GPG_PASSPHRASE != ''
+        run: |
+          if [ -f ./bazel-bep.pb ]; then
               gpg --symmetric --cipher-algo AES256 -o bazel-bep.pb.gpg \
-                  --passphrase "$GPG_PASSPHRASE" --batch --yes bazel-bep.pb
+                  --passphrase '${{ inputs.GPG_PASSPHRASE }}' --batch --yes bazel-bep.pb
+              rm -f ./bazel-bep.pb
           fi
-          rm -f bazel-bep.pb
-
-          # output node name to gihub step summary
-          [ -n "${NODE_NAME:-}" ] && echo "Run on node: $NODE_NAME" >>$GITHUB_STEP_SUMMARY
-
-          exit "$BAZEL_EXIT_CODE"
-        env:
-          BAZEL_COMMAND: ${{ inputs.BAZEL_COMMAND }}
-          BAZEL_TARGETS: ${{ inputs.BAZEL_TARGETS }}
-          BRANCH_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-          BUILDEVENT_APIKEY: ${{ inputs.BUILDEVENT_APIKEY }}
-          CI_EVENT_NAME: ${{ github.event_name }}
-          CI_JOB_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          MERGE_BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          SSH_PRIVATE_KEY_BACKUP_POD: ${{ inputs.SSH_PRIVATE_KEY_BACKUP_POD }}
-          GPG_PASSPHRASE: ${{ inputs.GPG_PASSPHRASE }}


### PR DESCRIPTION
This splits the `bazel-test-all` action's environment to only inject variables for steps that need them. This ensures the bazel build in particular doesn't inherit all the (potentially sensitive) environment variables.