### PR TITLE
feat(sns): Add field `topic` to `ProposalData`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5510,7 +5510,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.4.10",
+ "socket2 0.5.8",
  "tokio",
  "tower-service",
  "tracing",

--- a/rs/sns/governance/api/src/ic_sns_governance.pb.v1.rs
+++ b/rs/sns/governance/api/src/ic_sns_governance.pb.v1.rs
@@ -772,7 +772,7 @@ pub struct WaitForQuietState {
 }
 /// The ProposalData that contains everything related to a proposal:
 /// the proposal itself (immutable), as well as mutable data such as ballots.
-#[derive(Default, candid::CandidType, candid::Deserialize, Debug, Clone, PartialEq)]
+#[derive(candid::CandidType, candid::Deserialize, Debug, Clone, PartialEq)]
 pub struct ProposalData {
     /// The proposal's action.
     /// Types 0-999 are reserved for current (and future) core governance
@@ -897,6 +897,8 @@ pub struct ProposalData {
     /// In general, this holds data retrieved at proposal submission/creation time and used later
     /// during execution. This varies based on the action of the proposal.
     pub action_auxiliary: Option<proposal_data::ActionAuxiliary>,
+    /// This proposal's topic.
+    pub topic: Option<topics::Topic>,
 }
 /// Nested message and enum types in `ProposalData`.
 pub mod proposal_data {

--- a/rs/sns/governance/canister/governance.did
+++ b/rs/sns/governance/canister/governance.did
@@ -611,6 +611,7 @@ type ProposalData = record {
   minimum_yes_proportion_of_exercised : opt Percentage;
   is_eligible_for_rewards : bool;
   executed_timestamp_seconds : nat64;
+  topic : opt Topic;
 };
 
 type ProposalId = record {

--- a/rs/sns/governance/canister/governance.did
+++ b/rs/sns/governance/canister/governance.did
@@ -227,7 +227,7 @@ type GenericNervousSystemFunction = record {
   target_canister_id : opt principal;
   validator_method_name : opt text;
   target_method_name : opt text;
-  topic: opt Topic;
+  topic : opt Topic;
 };
 
 type GetMaturityModulationResponse = record {

--- a/rs/sns/governance/canister/governance_test.did
+++ b/rs/sns/governance/canister/governance_test.did
@@ -236,7 +236,7 @@ type GenericNervousSystemFunction = record {
   target_canister_id : opt principal;
   validator_method_name : opt text;
   target_method_name : opt text;
-  topic: opt Topic;
+  topic : opt Topic;
 };
 
 type GetMaturityModulationResponse = record {
@@ -313,7 +313,6 @@ type Governance = record {
   target_version : opt Version;
   timers : opt Timers;
   upgrade_journal : opt UpgradeJournal;
-  topic : opt Topic;
 };
 
 type Timers = record {
@@ -626,6 +625,7 @@ type ProposalData = record {
   minimum_yes_proportion_of_exercised : opt Percentage;
   is_eligible_for_rewards : bool;
   executed_timestamp_seconds : nat64;
+  topic : opt Topic;
 };
 
 type ProposalId = record {

--- a/rs/sns/governance/canister/governance_test.did
+++ b/rs/sns/governance/canister/governance_test.did
@@ -313,6 +313,7 @@ type Governance = record {
   target_version : opt Version;
   timers : opt Timers;
   upgrade_journal : opt UpgradeJournal;
+  topic : opt Topic;
 };
 
 type Timers = record {

--- a/rs/sns/governance/proto/ic_sns_governance/pb/v1/governance.proto
+++ b/rs/sns/governance/proto/ic_sns_governance/pb/v1/governance.proto
@@ -276,7 +276,7 @@ message NervousSystemFunction {
     // <method_name>(proposal_data: ProposalData) -> Result<String, String>
     optional string validator_method_name = 5;
 
-    // The topic this function belongs to
+    // The topic this proposal belongs to.
     optional Topic topic = 6;
   }
 
@@ -942,6 +942,9 @@ message ProposalData {
     MintSnsTokensActionAuxiliary mint_sns_tokens = 23;
     AdvanceSnsTargetVersionActionAuxiliary advance_sns_target_version = 24;
   }
+
+  // This proposal's topic.
+  optional Topic topic = 25;
 }
 
 message Valuation {

--- a/rs/sns/governance/src/gen/ic_sns_governance.pb.v1.rs
+++ b/rs/sns/governance/src/gen/ic_sns_governance.pb.v1.rs
@@ -310,7 +310,7 @@ pub mod nervous_system_function {
         /// <method_name>(proposal_data: ProposalData) -> Result<String, String>
         #[prost(string, optional, tag = "5")]
         pub validator_method_name: ::core::option::Option<::prost::alloc::string::String>,
-        /// The topic this function belongs to
+        /// The topic this proposal belongs to.
         #[prost(enumeration = "super::Topic", optional, tag = "6")]
         pub topic: ::core::option::Option<i32>,
     }
@@ -1198,6 +1198,9 @@ pub struct ProposalData {
     #[prost(message, optional, tag = "21")]
     pub minimum_yes_proportion_of_exercised:
         ::core::option::Option<::ic_nervous_system_proto::pb::v1::Percentage>,
+    /// This proposal's topic.
+    #[prost(enumeration = "Topic", optional, tag = "25")]
+    pub topic: ::core::option::Option<i32>,
     /// In general, this holds data retrieved at proposal submission/creation time and used later
     /// during execution. This varies based on the action of the proposal.
     #[prost(oneof = "proposal_data::ActionAuxiliary", tags = "22, 23, 24")]

--- a/rs/sns/governance/src/governance.rs
+++ b/rs/sns/governance/src/governance.rs
@@ -3490,7 +3490,6 @@ impl Governance {
         let proposal_id = ProposalId { id: proposal_num };
 
         let proposal_topic = self
-            .proto
             .get_topic_for_action(action)
             .map_err(|err| GovernanceError::new_with_message(ErrorType::InvalidProposal, err))?;
 
@@ -6071,6 +6070,9 @@ mod fail_stuck_upgrade_in_progress_tests;
 
 #[cfg(test)]
 mod advance_target_sns_version_tests;
+
+#[cfg(test)]
+mod proposal_topics_tests;
 
 #[cfg(test)]
 mod test_helpers;

--- a/rs/sns/governance/src/governance.rs
+++ b/rs/sns/governance/src/governance.rs
@@ -3489,6 +3489,8 @@ impl Governance {
         let proposal_num = self.next_proposal_id();
         let proposal_id = ProposalId { id: proposal_num };
 
+        let proposal_topic = todo!("DO NOT MERGE!");
+
         // Create the proposal.
         let mut proposal_data = ProposalData {
             action: u64::from(action),
@@ -3520,6 +3522,7 @@ impl Governance {
             // TODO(NNS1-2731): Delete this.
             is_eligible_for_rewards: true,
             action_auxiliary,
+            topic: Some(i32::from(proposal_topic)),
         };
 
         proposal_data.wait_for_quiet_state = Some(WaitForQuietState {

--- a/rs/sns/governance/src/governance.rs
+++ b/rs/sns/governance/src/governance.rs
@@ -3489,7 +3489,10 @@ impl Governance {
         let proposal_num = self.next_proposal_id();
         let proposal_id = ProposalId { id: proposal_num };
 
-        let proposal_topic = todo!("DO NOT MERGE!");
+        let proposal_topic = self
+            .proto
+            .get_topic_for_action(action)
+            .map_err(|err| GovernanceError::new_with_message(ErrorType::InvalidProposal, err))?;
 
         // Create the proposal.
         let mut proposal_data = ProposalData {
@@ -3522,7 +3525,7 @@ impl Governance {
             // TODO(NNS1-2731): Delete this.
             is_eligible_for_rewards: true,
             action_auxiliary,
-            topic: Some(i32::from(proposal_topic)),
+            topic: proposal_topic.map(i32::from),
         };
 
         proposal_data.wait_for_quiet_state = Some(WaitForQuietState {

--- a/rs/sns/governance/src/governance/assorted_governance_tests.rs
+++ b/rs/sns/governance/src/governance/assorted_governance_tests.rs
@@ -5082,6 +5082,18 @@ fn test_list_topics() {
                             ),
                         ),
                     },
+                    NervousSystemFunction {
+                        id: 16,
+                        name: "Set topics for custom proposals".to_string(),
+                        description: Some(
+                            "Proposal to set the topics for custom SNS proposals.".to_string(),
+                        ),
+                        function_type: Some(
+                            FunctionType::NativeNervousSystemFunction(
+                                Empty {},
+                            ),
+                        ),
+                    },
                 ],
                 custom_functions: vec![
                     function_2

--- a/rs/sns/governance/src/governance/proposal_topics_tests.rs
+++ b/rs/sns/governance/src/governance/proposal_topics_tests.rs
@@ -1,0 +1,178 @@
+use crate::governance::test_helpers::basic_governance_proto;
+use crate::governance::ValidGovernanceProto;
+use crate::governance::{test_helpers::DoNothingLedger, Governance};
+use crate::pb::v1::{self as pb, nervous_system_function};
+use crate::types::{native_action_ids::nervous_system_functions, test_helpers::NativeEnvironment};
+use ic_base_types::PrincipalId;
+use ic_nervous_system_common::cmc::FakeCmc;
+use maplit::btreemap;
+use pb::{ExecuteGenericNervousSystemFunction, NervousSystemFunction};
+
+#[test]
+fn test_all_topics() {
+    // Used to set the fields that are orthogonal to the test but required by the validation.
+    let generic_proposal = nervous_system_function::GenericNervousSystemFunction {
+        target_canister_id: Some(PrincipalId::new_user_test_id(111)),
+        validator_canister_id: Some(PrincipalId::new_user_test_id(222)),
+        target_method_name: Some("foo".to_string()),
+        validator_method_name: Some("bar".to_string()),
+        ..Default::default()
+    };
+
+    let custom_proposal_without_topic = NervousSystemFunction {
+        id: 1002,
+        name: "Custom proposal for tests".to_string(),
+        description: None,
+        function_type: Some(
+            nervous_system_function::FunctionType::GenericNervousSystemFunction(
+                nervous_system_function::GenericNervousSystemFunction {
+                    topic: None,
+                    // The following fields are orthogonal to the test but required in validation.
+                    ..generic_proposal.clone()
+                },
+            ),
+        ),
+    };
+
+    let custom_proposal_with_valid_topic = NervousSystemFunction {
+        id: 1001,
+        name: "Custom proposal for tests".to_string(),
+        description: None,
+        function_type: Some(
+            nervous_system_function::FunctionType::GenericNervousSystemFunction(
+                nervous_system_function::GenericNervousSystemFunction {
+                    topic: Some(pb::Topic::ApplicationBusinessLogic as i32),
+                    ..generic_proposal.clone()
+                },
+            ),
+        ),
+    };
+
+    let governance_proto = pb::Governance {
+        id_to_nervous_system_functions: btreemap! {
+            1001 => custom_proposal_with_valid_topic,
+            1002 => custom_proposal_without_topic,
+        },
+        ..basic_governance_proto()
+    };
+
+    let governance_proto = ValidGovernanceProto::try_from(governance_proto).unwrap();
+
+    let governance = Governance::new(
+        governance_proto,
+        Box::<NativeEnvironment>::default(),
+        Box::new(DoNothingLedger {}),
+        Box::new(DoNothingLedger {}),
+        Box::new(FakeCmc::new()),
+    );
+
+    let mut test_cases = vec![
+        // DaoCommunitySettings
+        (
+            pb::proposal::Action::ManageNervousSystemParameters(Default::default()),
+            Ok(Some(pb::Topic::DaoCommunitySettings)),
+        ),
+        (
+            pb::proposal::Action::ManageLedgerParameters(Default::default()),
+            Ok(Some(pb::Topic::DaoCommunitySettings)),
+        ),
+        (
+            pb::proposal::Action::ManageSnsMetadata(Default::default()),
+            Ok(Some(pb::Topic::DaoCommunitySettings)),
+        ),
+        // SnsFrameworkManagement
+        (
+            pb::proposal::Action::UpgradeSnsToNextVersion(Default::default()),
+            Ok(Some(pb::Topic::SnsFrameworkManagement)),
+        ),
+        (
+            pb::proposal::Action::AdvanceSnsTargetVersion(Default::default()),
+            Ok(Some(pb::Topic::SnsFrameworkManagement)),
+        ),
+        (
+            pb::proposal::Action::SetTopicsForCustomProposals(Default::default()),
+            Ok(Some(pb::Topic::SnsFrameworkManagement)),
+        ),
+        // DappCanisterManagement
+        (
+            pb::proposal::Action::UpgradeSnsControlledCanister(Default::default()),
+            Ok(Some(pb::Topic::DappCanisterManagement)),
+        ),
+        (
+            pb::proposal::Action::RegisterDappCanisters(Default::default()),
+            Ok(Some(pb::Topic::DappCanisterManagement)),
+        ),
+        (
+            pb::proposal::Action::ManageDappCanisterSettings(Default::default()),
+            Ok(Some(pb::Topic::DappCanisterManagement)),
+        ),
+        // ApplicationBusinessLogic - skipped, since this topic is for custom proposals.
+
+        // Governance
+        (
+            pb::proposal::Action::Motion(Default::default()),
+            Ok(Some(pb::Topic::Governance)),
+        ),
+        // TreasuryAssetManagement
+        (
+            pb::proposal::Action::TransferSnsTreasuryFunds(Default::default()),
+            Ok(Some(pb::Topic::TreasuryAssetManagement)),
+        ),
+        (
+            pb::proposal::Action::MintSnsTokens(Default::default()),
+            Ok(Some(pb::Topic::TreasuryAssetManagement)),
+        ),
+        // CriticalDappOperations
+        (
+            pb::proposal::Action::DeregisterDappCanisters(Default::default()),
+            Ok(Some(pb::Topic::CriticalDappOperations)),
+        ),
+        (
+            pb::proposal::Action::AddGenericNervousSystemFunction(Default::default()),
+            Ok(Some(pb::Topic::CriticalDappOperations)),
+        ),
+        (
+            pb::proposal::Action::RemoveGenericNervousSystemFunction(Default::default()),
+            Ok(Some(pb::Topic::CriticalDappOperations)),
+        ),
+    ];
+
+    // Smoke test
+    assert_eq!(
+        test_cases.len(),
+        nervous_system_functions().len() - 1,
+        "Missing some test cases for native proposals."
+    );
+
+    // Special case: Undefined function.
+    test_cases.push((
+        pb::proposal::Action::Unspecified(Default::default()),
+        Err("Invalid action with ID 0.".to_string()),
+    ));
+
+    // Add test cases for custom proposals.
+    test_cases.push((
+        pb::proposal::Action::ExecuteGenericNervousSystemFunction(
+            ExecuteGenericNervousSystemFunction {
+                function_id: 1001,
+                ..Default::default()
+            },
+        ),
+        Ok(Some(pb::Topic::ApplicationBusinessLogic)),
+    ));
+    test_cases.push((
+        pb::proposal::Action::ExecuteGenericNervousSystemFunction(
+            ExecuteGenericNervousSystemFunction {
+                function_id: 1002,
+                ..Default::default()
+            },
+        ),
+        Ok(None),
+    ));
+
+    // Run code under test.
+    for (action, expected) in test_cases.into_iter() {
+        let observed = governance.get_topic_for_action(&action);
+        assert_eq!(observed, expected);
+    }
+}

--- a/rs/sns/governance/src/pb/conversions.rs
+++ b/rs/sns/governance/src/pb/conversions.rs
@@ -968,6 +968,12 @@ impl From<pb::ProposalData> for pb_api::ProposalData {
             minimum_yes_proportion_of_total: item.minimum_yes_proportion_of_total,
             minimum_yes_proportion_of_exercised: item.minimum_yes_proportion_of_exercised,
             action_auxiliary: item.action_auxiliary.map(|x| x.into()),
+            topic: item.topic.and_then(|topic| {
+                let Ok(topic) = pb::Topic::try_from(topic) else {
+                    return None;
+                };
+                pb_api::topics::Topic::try_from(topic).ok()
+            }),
         }
     }
 }
@@ -1000,6 +1006,7 @@ impl From<pb_api::ProposalData> for pb::ProposalData {
             minimum_yes_proportion_of_total: item.minimum_yes_proportion_of_total,
             minimum_yes_proportion_of_exercised: item.minimum_yes_proportion_of_exercised,
             action_auxiliary: item.action_auxiliary.map(|x| x.into()),
+            topic: item.topic.map(|topic| i32::from(pb::Topic::from(topic))),
         }
     }
 }

--- a/rs/sns/governance/src/proposal.rs
+++ b/rs/sns/governance/src/proposal.rs
@@ -2439,6 +2439,7 @@ impl ProposalData {
             minimum_yes_proportion_of_total,
             minimum_yes_proportion_of_exercised,
             action_auxiliary,
+            topic,
         } = self;
 
         let limited_ballots: BTreeMap<_, _> = ballots
@@ -2468,6 +2469,7 @@ impl ProposalData {
             minimum_yes_proportion_of_total: *minimum_yes_proportion_of_total,
             minimum_yes_proportion_of_exercised: *minimum_yes_proportion_of_exercised,
             action_auxiliary: action_auxiliary.clone(),
+            topic: *topic,
 
             // The following fields are truncated:
             payload_text_rendering: None,
@@ -2735,7 +2737,7 @@ mod tests {
         pb::v1::{
             governance::{self, Version},
             Ballot, ChunkedCanisterWasm, Empty, Governance as GovernanceProto, NeuronId, Proposal,
-            ProposalId, Subaccount, WaitForQuietState,
+            ProposalId, Subaccount, Topic, WaitForQuietState,
         },
         sns_upgrade::{
             CanisterSummary, GetNextSnsVersionRequest, GetNextSnsVersionResponse,
@@ -4781,6 +4783,7 @@ Version {
             // This is because the proposal was rejected (see the latest_tally field).
             executed_timestamp_seconds: 0,
             action_auxiliary: None,
+            topic: Some(Topic::Governance as i32),
         };
     }
 

--- a/rs/sns/governance/src/types.rs
+++ b/rs/sns/governance/src/types.rs
@@ -1900,9 +1900,6 @@ fn summarize_blob_field(blob: &[u8]) -> Vec<u8> {
 }
 
 // Mapping of action to the unique function id of that action.
-//
-// When adding/removing an action here, also add/remove from
-// `Action::native_actions_metadata()`.
 impl From<&Action> for u64 {
     fn from(action: &Action) -> Self {
         match action {

--- a/rs/sns/governance/src/types.rs
+++ b/rs/sns/governance/src/types.rs
@@ -139,7 +139,7 @@ pub mod native_action_ids {
     pub const SET_CUSTOM_TOPICS_FOR_CUSTOM_PROPOSALS_ACTION: u64 = 16;
 
     // When adding something to this list, make sure to update the below function.
-    pub fn native_functions() -> Vec<NervousSystemFunction> {
+    pub fn nervous_system_functions() -> Vec<NervousSystemFunction> {
         vec![
             NervousSystemFunction::motion(),
             NervousSystemFunction::manage_nervous_system_parameters(),
@@ -1072,6 +1072,14 @@ impl NervousSystemFunction {
             Some(FunctionType::NativeNervousSystemFunction(_))
         )
     }
+
+    /// The special case if for `EXECUTE_GENERIC_NERVOUS_SYSTEM_FUNCTION` which wraps custom
+    /// proposals of this SNS. While technically being a native function, this one does not have
+    /// its own topic.
+    pub fn needs_topic(&self) -> bool {
+        self.id != native_action_ids::EXECUTE_GENERIC_NERVOUS_SYSTEM_FUNCTION
+    }
+
     fn unspecified() -> NervousSystemFunction {
         NervousSystemFunction {
             id: native_action_ids::UNSPECIFIED,

--- a/rs/sns/governance/unreleased_changelog.md
+++ b/rs/sns/governance/unreleased_changelog.md
@@ -9,6 +9,8 @@ on the process that this file is part of, see
 
 ## Added
 
+* Added `ProposalData.topic : opt Topic`.
+
 ## Changed
 
 ## Deprecated


### PR DESCRIPTION
This PR enables clients to reuse the existing calls they make to obtain the information about which topic this proposal corresponds to (at the time of proposal submission).