### PR TITLE
fix(IDX): check that bazel-out exists

### DIFF
--- a/.github/workflows-source/ci-main.yml
+++ b/.github/workflows-source/ci-main.yml
@@ -258,8 +258,12 @@ jobs:
           "$CI_PROJECT_DIR"/ci/scripts/run-build-ic.sh
           rm -rf "/cache/job/${CI_JOB_NAME}/${CI_RUN_ID}"
 
-          # List and aggregate all SHA256SUMS files.
-          find -L bazel-out -name SHA256SUMS | xargs cat | sort | uniq > SHA256SUMS
+          # List and aggregate all SHA256SUMS files (if bazel-out exists)
+          if [ -e bazel-out]; then
+            find -L bazel-out -name SHA256SUMS | xargs cat | sort | uniq > SHA256SUMS
+          else
+            touch SHA256SUMS
+          fi
 
         env:
           BAZEL_COMMAND: build --config=ci

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -294,8 +294,12 @@ jobs:
           "$CI_PROJECT_DIR"/ci/scripts/run-build-ic.sh
           rm -rf "/cache/job/${CI_JOB_NAME}/${CI_RUN_ID}"
 
-          # List and aggregate all SHA256SUMS files.
-          find -L bazel-out -name SHA256SUMS | xargs cat | sort | uniq > SHA256SUMS
+          # List and aggregate all SHA256SUMS files (if bazel-out exists)
+          if [ -e bazel-out]; then
+            find -L bazel-out -name SHA256SUMS | xargs cat | sort | uniq > SHA256SUMS
+          else
+            touch SHA256SUMS
+          fi
         env:
           BAZEL_COMMAND: build --config=ci
           BAZEL_TARGETS: //...

--- a/ci/bazel-scripts/main.sh
+++ b/ci/bazel-scripts/main.sh
@@ -108,8 +108,13 @@ fi
 rm "$url_out"
 
 # List and aggregate all SHA256SUMS files.
-for shafile in $(find bazel-out/ -name SHA256SUMS); do
-    if [ -f "$shafile" ]; then
-        echo "$shafile"
-    fi
-done | xargs cat | sort | uniq >SHA256SUMS
+if [ -e ./bazel-out/ ]; then
+    for shafile in $(find bazel-out/ -name SHA256SUMS); do
+        if [ -f "$shafile" ]; then
+            echo "$shafile"
+        fi
+    done | xargs cat | sort | uniq >SHA256SUMS
+else
+    # if no bazel-out, assume no targets were built
+    touch SHA256SUMS
+fi


### PR DESCRIPTION
This adds a check to make sure that `bazel-out` exists before we scan it for checksums. If `bazel-out` (a symlink) doesn't exist, then we create an empty `SHA256SUMS`.