### PR TITLE
chore: EXC-1969: Remove unused `DIRTY_PAGE_COPY_OVERHEAD`

### DIFF
--- a/rs/config/src/embedders.rs
+++ b/rs/config/src/embedders.rs
@@ -61,9 +61,6 @@ pub(crate) const DEFAULT_MAX_SANDBOXES_RSS: NumBytes = NumBytes::new(50 * 1024 *
 /// This default is 1 GiB.
 pub(crate) const DEFAULT_MAX_DIRTY_PAGES_WITHOUT_OPTIMIZATION: usize = (GiB as usize) / PAGE_SIZE;
 
-/// Scheduling overhead for copying dirty pages, in instructions.
-pub(crate) const DIRTY_PAGE_COPY_OVERHEAD: NumInstructions = NumInstructions::new(3_000);
-
 /// The overhead for dirty pages in Wasm64.
 pub const WASM64_DIRTY_PAGE_OVERHEAD_MULTIPLIER: u64 = 4;
 
@@ -275,9 +272,6 @@ pub struct Config {
     /// page copying by triggering a new execution slice for copying and using prefaulting.
     pub max_dirty_pages_without_optimization: usize,
 
-    /// The dirty page copying overhead, in instructions.
-    pub dirty_page_copy_overhead: NumInstructions,
-
     /// The dirty page overhead factor for Wasm64.
     pub wasm64_dirty_page_overhead_multiplier: u64,
 
@@ -325,7 +319,6 @@ impl Config {
             dirty_page_overhead: NumInstructions::new(0),
             trace_execution: FlagStatus::Disabled,
             max_dirty_pages_without_optimization: DEFAULT_MAX_DIRTY_PAGES_WITHOUT_OPTIMIZATION,
-            dirty_page_copy_overhead: DIRTY_PAGE_COPY_OVERHEAD,
             wasm_max_size: WASM_MAX_SIZE,
             max_wasm_memory_size: NumBytes::new(MAX_WASM_MEMORY_IN_BYTES),
             max_wasm64_memory_size: NumBytes::new(MAX_WASM64_MEMORY_IN_BYTES),

--- a/rs/embedders/src/wasm_executor.rs
+++ b/rs/embedders/src/wasm_executor.rs
@@ -687,7 +687,7 @@ pub fn process(
     // Capping at the limit to preserve the existing behaviour. It should be
     // possible to remove capping after ensuring that all callers can handle
     // instructions executed being larger than the limit.
-    let mut slice_instructions_executed = system_api
+    let slice_instructions_executed = system_api
         .slice_instructions_executed(instruction_counter)
         .min(slice_instruction_limit);
     // Capping at the limit to avoid an underflow when computing the remaining
@@ -699,7 +699,7 @@ pub fn process(
 
     // In case the message dirtied too many pages, as a performance optimization we will
     // yield the control to the replica and then resume copying dirty pages in a new execution slice.
-    let num_dirty_pages = if let Ok(ref res) = run_result {
+    if let Ok(ref res) = run_result {
         let dirty_pages = NumOsPages::from(res.wasm_dirty_pages.len() as u64);
         // Do not perform this optimization for subnets where DTS is not enabled.
         if execution_parameters.instruction_limits.slicing_enabled()
@@ -724,18 +724,9 @@ pub fn process(
                     Ok(instance),
                 );
             }
-            // The optimization was performed. The slice instructions have been accounted
-            // for in the first slice. At the end of this function we will only account
-            // for dirty pages.
-            slice_instructions_executed = NumInstructions::from(0);
-            dirty_pages
-        } else {
-            // The optimization wasn't performed.
-            NumOsPages::from(0)
+            // The optimization was performed. At the end of this function
+            // the round will be finished due to the `MAX_HEAP_DELTA_PER_ITERATION`.
         }
-    } else {
-        // The optimization wasn't performed because the message execution failed.
-        NumOsPages::from(0)
     };
 
     // Has the side effect of deallocating memory if message failed and
@@ -814,10 +805,7 @@ pub fn process(
     // If the optimization wasn't triggered, then num_dirty_pages = 0, therefore the overhead is 0
     // and the number of instructions is the one accounted for at the beginning of this function.
     let output_slice = SliceExecutionOutput {
-        executed_instructions: NumInstructions::from(
-            slice_instructions_executed.get()
-                + num_dirty_pages.get() * embedder.config().dirty_page_copy_overhead.get(),
-        ),
+        executed_instructions: NumInstructions::from(slice_instructions_executed.get()),
     };
 
     (

--- a/rs/embedders/src/wasm_executor.rs
+++ b/rs/embedders/src/wasm_executor.rs
@@ -799,11 +799,6 @@ pub fn process(
         Err(_) => None,
     };
 
-    // If the dirty page optimization slicing has been performed, we know the dirty page copying
-    // was a heavy operation, therefore we take into account its overhead in number of instructions
-    // accounted for this round, when only dirty page copying has happened.
-    // If the optimization wasn't triggered, then num_dirty_pages = 0, therefore the overhead is 0
-    // and the number of instructions is the one accounted for at the beginning of this function.
     let output_slice = SliceExecutionOutput {
         executed_instructions: NumInstructions::from(slice_instructions_executed.get()),
     };


### PR DESCRIPTION
Currently, the `DIRTY_PAGE_COPY_OVERHEAD` parameter has no impact on scheduling or canister charging. The only observable effect is an increase in the slice instruction metric. Increasing `SliceExecutionOutput::executed_instructions` does not charge the canister. Scheduling is unaffected due to `MAX_HEAP_DELTA_PER_ITERATION` being 200MiB (see the comment in https://github.com/dfinity/ic/pull/4066).

This functionality lacks test coverage, and the comments do not clearly state whether it should introduce scheduling overhead, additional charges, or both. Furthermore, this parameter is misleading. It was expected to address our same-round DTS issue by increasing the overhead to ~8k (calculated as 2B / 1GiB * 4096). As a result, considerable time was spent debugging the tests and environment unnecessarily.

As discussed, we will try to fix it to actually increase the canister charge.