### PR TITLE
feat(nns): Limit the number of neurons to unstake maturity in a single message

### DIFF
--- a/rs/nns/governance/src/governance.rs
+++ b/rs/nns/governance/src/governance.rs
@@ -6550,9 +6550,15 @@ impl Governance {
 
     /// Unstakes the maturity of neurons that have dissolved.
     pub fn unstake_maturity_of_dissolved_neurons(&mut self) {
+        // We assume that modifying a neuron can use <400 StableBTreeMap read operations and <400
+        // write operations (100 recent ballots + 270 followees entries + others), and one read + one
+        // write operation takes 400K instructions in total, unstaking 100 neurons should take less
+        // than 16B instructions. Note that this is the worst case scenario, and the actual number
+        // of instructions should be much less.
+        const MAX_NEURONS_TO_UNSTAKE: usize = 100;
         let now_seconds = self.env.now();
         self.neuron_store
-            .unstake_maturity_of_dissolved_neurons(now_seconds);
+            .unstake_maturity_of_dissolved_neurons(now_seconds, MAX_NEURONS_TO_UNSTAKE);
     }
 
     fn can_spawn_neurons(&self) -> bool {

--- a/rs/nns/governance/src/neuron_store.rs
+++ b/rs/nns/governance/src/neuron_store.rs
@@ -907,10 +907,15 @@ impl NeuronStore {
     }
 
     /// List all neuron ids whose neurons have staked maturity greater than 0.
-    fn list_neurons_ready_to_unstake_maturity(&self, now_seconds: u64) -> Vec<NeuronId> {
+    fn list_neurons_ready_to_unstake_maturity(
+        &self,
+        now_seconds: u64,
+        max_num_neurons: usize,
+    ) -> Vec<NeuronId> {
         self.with_active_neurons_iter_sections(
             |iter| {
                 iter.filter(|neuron| neuron.ready_to_unstake_maturity(now_seconds))
+                    .take(max_num_neurons)
                     .map(|neuron| neuron.id())
                     .collect()
             },
@@ -983,11 +988,15 @@ impl NeuronStore {
 
     /// When a neuron is finally dissolved, if there is any staked maturity it is moved to regular maturity
     /// which can be spawned (and is modulated).
-    pub fn unstake_maturity_of_dissolved_neurons(&mut self, now_seconds: u64) {
+    pub fn unstake_maturity_of_dissolved_neurons(
+        &mut self,
+        now_seconds: u64,
+        max_num_neurons: usize,
+    ) {
         let neuron_ids = {
             #[cfg(feature = "canbench-rs")]
             let _scope_list = canbench_rs::bench_scope("list_neuron_ids");
-            self.list_neurons_ready_to_unstake_maturity(now_seconds)
+            self.list_neurons_ready_to_unstake_maturity(now_seconds, max_num_neurons)
         };
 
         #[cfg(feature = "canbench-rs")]

--- a/rs/nns/governance/src/neuron_store/benches.rs
+++ b/rs/nns/governance/src/neuron_store/benches.rs
@@ -342,7 +342,7 @@ fn unstake_maturity_of_dissolved_neurons_heap() -> BenchResult {
         add_neuron_ready_to_unstake_maturity(now_seconds(), &mut rng, &mut neuron_store);
     }
 
-    bench_fn(|| neuron_store.unstake_maturity_of_dissolved_neurons(now_seconds()))
+    bench_fn(|| neuron_store.unstake_maturity_of_dissolved_neurons(now_seconds(), 100))
 }
 
 #[bench(raw)]
@@ -356,7 +356,7 @@ fn unstake_maturity_of_dissolved_neurons_stable() -> BenchResult {
     }
 
     bench_fn(|| {
-        neuron_store.unstake_maturity_of_dissolved_neurons(now_seconds());
+        neuron_store.unstake_maturity_of_dissolved_neurons(now_seconds(), 100);
     })
 }
 

--- a/rs/nns/governance/src/neuron_store/neuron_store_tests.rs
+++ b/rs/nns/governance/src/neuron_store/neuron_store_tests.rs
@@ -953,6 +953,53 @@ fn test_batch_adjust_neurons_storage() {
 }
 
 #[test]
+fn test_unstake_maturity() {
+    let mut neuron_store = NeuronStore::new(BTreeMap::new());
+    let now_seconds = neuron_store.now();
+    for id in 1..=5 {
+        let neuron = simple_neuron_builder(id)
+            .with_dissolve_state_and_age(DissolveStateAndAge::DissolvingOrDissolved {
+                when_dissolved_timestamp_seconds: now_seconds,
+            })
+            .with_staked_maturity_e8s_equivalent(1_000_000)
+            .build();
+        neuron_store.add_neuron(neuron).unwrap();
+    }
+
+    let neuron_has_staked_maturity = |neuron_store: &NeuronStore, id: u64| {
+        neuron_store
+            .with_neuron(&NeuronId { id }, |neuron| {
+                neuron.staked_maturity_e8s_equivalent.is_some()
+            })
+            .unwrap()
+    };
+
+    // Initially all neurons have staked maturity.
+    for id in 1..=5 {
+        assert!(neuron_has_staked_maturity(&neuron_store, id));
+    }
+
+    // Unstake the maturity of the first 3 neurons.
+    neuron_store.unstake_maturity_of_dissolved_neurons(now_seconds, 3);
+
+    // Verify that the first 3 neurons have no staked maturity, while the rest do.
+    for id in 1..=3 {
+        assert!(!neuron_has_staked_maturity(&neuron_store, id));
+    }
+    for id in 4..=5 {
+        assert!(neuron_has_staked_maturity(&neuron_store, id));
+    }
+
+    // Unstake the maturity of the remaining neurons.
+    neuron_store.unstake_maturity_of_dissolved_neurons(now_seconds, 3);
+
+    // Verify that all neurons have no staked maturity.
+    for id in 1..=5 {
+        assert!(!neuron_has_staked_maturity(&neuron_store, id));
+    }
+}
+
+#[test]
 fn test_batch_adjust_neurons_storage_exceeds_instructions_limit() {
     // This test doesn't make sense after neurons are migrated completely to stable memory.
     let _a = temporarily_disable_allow_active_neurons_in_stable_memory();

--- a/rs/nns/governance/unreleased_changelog.md
+++ b/rs/nns/governance/unreleased_changelog.md
@@ -12,8 +12,11 @@ on the process that this file is part of, see
 * Collect metrics about timer tasks defined using ic_nervous_system_timer_task library.
 
 ## Changed
+
 * Voting Rewards will be scheduled by a timer instead of by heartbeats.
-* 
+* Unstaking maturity task will be processing up to 100 neurons in a single message, to avoid
+  exceeding the instruction limit in a single execution.
+
 ## Deprecated
 
 ## Removed


### PR DESCRIPTION
The instructions used by unstaking maturity will become larger after migrating neurons to stable memory. Therefore we should bound the number of neurons to process within the same message. Note that the remaining neurons will continue to be processed at the next timer invocation.