### PR TITLE
fix(IDX): don't shortcut main.sh on failure

### DIFF
--- a/ci/bazel-scripts/main.sh
+++ b/ci/bazel-scripts/main.sh
@@ -97,7 +97,8 @@ if [[ ! " ${bazel_args[*]} " =~ [[:space:]]--repository_cache[[:space:]] ]] && [
     bazel_args+=(--repository_cache=/cache/bazel)
 fi
 
-bazel "${bazel_args[@]}" 2>&1 | awk -v url_out="$url_out" "$stream_awk_program"
+bazel_exitcode="0"
+bazel "${bazel_args[@]}" 2>&1 | awk -v url_out="$url_out" "$stream_awk_program" || bazel_exitcode="$?"
 
 # Write the bes link & summary
 echo "Build results uploaded to $(<"$url_out")"
@@ -118,3 +119,5 @@ else
     # if no bazel-out, assume no targets were built
     touch SHA256SUMS
 fi
+
+exit "$bazel_exitcode"


### PR DESCRIPTION
This stores the bazel exit code and ensures the `main.sh` script can finish instead of directly exiting on error.