### PR TITLE
fix(IDX): don't try to upload bep on macOS intel

### DIFF
--- a/.github/actions/bazel-test-all/action.yaml
+++ b/.github/actions/bazel-test-all/action.yaml
@@ -12,6 +12,7 @@ inputs:
     required: false
   GPG_PASSPHRASE:
     required: false
+    description: "GPG key to encrypt build events. If the key is not set, events won't be uploaded."
 
 runs:
   using: "composite"

--- a/.github/workflows-source/ci-main.yml
+++ b/.github/workflows-source/ci-main.yml
@@ -175,7 +175,6 @@ jobs:
             test --config=ci --config=macos_ci
             --test_tag_filters=test_macos
           BAZEL_TARGETS: //rs/... //publish/binaries/...
-          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
       - <<: *bazel-bep
       - name: Purge Bazel Output
         if: always()

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -144,7 +144,6 @@ jobs:
           BAZEL_COMMAND: >-
             test --config=ci --config=macos_ci --test_tag_filters=test_macos
           BAZEL_TARGETS: //rs/... //publish/binaries/...
-          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
       - name: Upload bazel-bep
         # runs only if previous step succeeded or failed;
         # we avoid collecting artifacts of jobs that were cancelled


### PR DESCRIPTION
The encryption step fails because `gpg` is missing from the machines. Before https://github.com/dfinity/ic/pull/4171 this was a silent failure, but is now explicit. So we disable it.