### PR TITLE
feat(testing): Add new testnet `single_app_small_node`

### DIFF
--- a/rs/tests/testnets/BUILD.bazel
+++ b/rs/tests/testnets/BUILD.bazel
@@ -61,6 +61,24 @@ system_test_nns(
     ],
 )
 
+system_test(
+    name = "single_app_small_node",
+    flaky = False,
+    tags = [
+        "dynamic_testnet",
+        "k8s",
+        "manual",
+    ],
+    target_compatible_with = ["@platforms//os:linux"],  # requires libssh that does not build on Mac OS
+    runtime_deps = GUESTOS_RUNTIME_DEPS + GRAFANA_RUNTIME_DEPS,
+    deps = [
+        # Keep sorted.
+        "//rs/registry/subnet_type",
+        "//rs/tests/driver:ic-system-test-driver",
+        "@crate_index//:anyhow",
+    ],
+)
+
 system_test_nns(
     name = "small",
     flaky = False,

--- a/rs/tests/testnets/Cargo.toml
+++ b/rs/tests/testnets/Cargo.toml
@@ -42,6 +42,10 @@ name = "single_app_large_node"
 path = "single_app_large_node.rs"
 
 [[bin]]
+name = "single_app_small_node"
+path = "single_app_small_node.rs"
+
+[[bin]]
 name = "single_large_node"
 path = "single_large_node.rs"
 

--- a/rs/tests/testnets/single_app_small_node.rs
+++ b/rs/tests/testnets/single_app_small_node.rs
@@ -1,0 +1,71 @@
+// Set up a testnet containing:
+//   one 1-node Application subnet and a p8s (with grafana) VM.
+// All replica nodes use the following resources: 16 vCPUs, 64GiB of RAM, and 100 GiB disk.
+//
+// You can setup this testnet with a lifetime of 180 mins by executing the following commands:
+//
+//   $ ./ci/tools/docker-run
+//   $ ict testnet create single_app_small_node --lifetime-mins=180 --output-dir=./single_app_small_node -- --test_tmpdir=./single_app_small_node
+//
+// The --output-dir=./single_app_small_node will store the debug output of the test driver in the specified directory.
+// The --test_tmpdir=./single_app_small_node will store the remaining test output in the specified directory.
+// This is useful to have access to in case you need to SSH into an IC node for example like:
+//
+//   $ ssh -i single_app_small_node/_tmp/*/setup/ssh/authorized_priv_keys/admin admin@
+//
+// Note that you can get the  address of the IC node from the ict console output:
+//
+//   {
+//     nodes: [
+//       {
+//         id: y4g5e-dpl4n-swwhv-la7ec-32ngk-w7f3f-pr5bt-kqw67-2lmfy-agipc-zae,
+//         ipv6: 2a0b:21c0:4003:2:5034:46ff:fe3c:e76f
+//       }
+//     ],
+//     subnet_id: 5hv4k-srndq-xgw53-r6ldt-wtv4x-6xvbj-6lvpf-sbu5n-sqied-63bgv-eqe,
+//     subnet_type: application
+//   },
+//
+// To get access to P8s and Grafana look for the following lines in the ict console output:
+//
+//     prometheus: Prometheus Web UI at http://prometheus.single_app_small_node--1692597750709.testnet.farm.dfinity.systems,
+//     grafana: Grafana at http://grafana.single_app_small_node--1692597750709.testnet.farm.dfinity.systems,
+//     progress_clock: IC Progress Clock at http://grafana.single_app_small_node--1692597750709.testnet.farm.dfinity.systems/d/ic-progress-clock/ic-progress-clock?refresh=10su0026from=now-5mu0026to=now,
+//
+// Happy testing!
+
+use anyhow::Result;
+
+use ic_registry_subnet_type::SubnetType;
+use ic_system_test_driver::driver::group::SystemTestGroup;
+use ic_system_test_driver::driver::ic::{
+    AmountOfMemoryKiB, ImageSizeGiB, InternetComputer, NrOfVCPUs, Subnet, VmResources,
+};
+use ic_system_test_driver::driver::prometheus_vm::{HasPrometheus, PrometheusVm};
+use ic_system_test_driver::driver::test_env::TestEnv;
+
+fn main() -> Result<()> {
+    SystemTestGroup::new()
+        .with_setup(setup)
+        .execute_from_args()?;
+    Ok(())
+}
+
+pub fn setup(env: TestEnv) {
+    PrometheusVm::default()
+        .start(&env)
+        .expect("failed to start prometheus VM");
+    InternetComputer::new()
+        .add_subnet(
+            Subnet::new(SubnetType::Application)
+                .with_default_vm_resources(VmResources {
+                    vcpus: Some(NrOfVCPUs::new(16)),
+                    memory_kibibytes: Some(AmountOfMemoryKiB::new(67_108_864)),
+                    boot_image_minimal_size_gibibytes: Some(ImageSizeGiB::new(100)),
+                })
+                .add_nodes(1),
+        )
+        .setup_and_start(&env)
+        .expect("failed to setup IC under test");
+    env.sync_with_prometheus();
+}


### PR DESCRIPTION
The new testnet configuration is similar to `single_app_large_node` but the single node is allocated significantly less resources (16 vCPUs, 64GiB of RAM, and 100 GiB disk) than the current config. While `single_app_large_node` is for performance testing, `single_app_small_node` is created for security to look into interaction between host and replica. With each node occupying less resource, we can afford frequent teardown without affecting the overall load. 