### PR TITLE
chore(IDX): disable failing NNS test

### DIFF
--- a/rs/nns/integration_tests/src/neuron_following.rs
+++ b/rs/nns/integration_tests/src/neuron_following.rs
@@ -200,6 +200,9 @@ fn follow_same_neuron_multiple_times() {
     );
 }
 
+// This test is failing because of timing issues. We disable it until the NNS team
+// has a fix.
+#[ignore]
 #[test]
 fn vote_propagation_with_following() {
     let state_machine = setup_state_machine_with_nns_canisters();


### PR DESCRIPTION
This disables a test that is currently failing due to a timing issue. The test will be re-enabled by the NNS team once fixed.