### PR TITLE
test(nns): Fix tests that see less and less voting power.

### DIFF
--- a/rs/nns/governance/init/src/lib.rs
+++ b/rs/nns/governance/init/src/lib.rs
@@ -104,7 +104,7 @@ impl GovernanceCanisterInitPayloadBuilder {
             SystemTime::now()
                 .duration_since(SystemTime::UNIX_EPOCH)
                 .unwrap()
-                .as_secs()
+                .as_secs(),
         );
 
         let mut neuron1 = {

--- a/rs/nns/governance/init/src/lib.rs
+++ b/rs/nns/governance/init/src/lib.rs
@@ -95,6 +95,17 @@ impl GovernanceCanisterInitPayloadBuilder {
             TEST_NEURON_2_OWNER_PRINCIPAL, TEST_NEURON_3_ID, TEST_NEURON_3_OWNER_PRINCIPAL,
         };
         use ic_nns_governance_api::pb::v1::{neuron::DissolveState, Neuron};
+        use std::time::SystemTime;
+
+        // This assumption here is that with_current_time is used.
+        // Alternatively, we could use u64::MAX, but u64::MAX is not as
+        // realistic.
+        let voting_power_refreshed_timestamp_seconds = Some(
+            SystemTime::now()
+                .duration_since(SystemTime::UNIX_EPOCH)
+                .unwrap()
+                .as_secs()
+        );
 
         let mut neuron1 = {
             let neuron_id = NeuronIdProto::from(self.new_neuron_id());
@@ -109,6 +120,7 @@ impl GovernanceCanisterInitPayloadBuilder {
                                                          * TEST_NEURON_TOTAL_STAKE_E8S */
                 account: subaccount,
                 not_for_profit: true,
+                voting_power_refreshed_timestamp_seconds,
                 ..Default::default()
             }
         };
@@ -135,6 +147,7 @@ impl GovernanceCanisterInitPayloadBuilder {
                 aging_since_timestamp_seconds: 1,
                 account: subaccount,
                 not_for_profit: false,
+                voting_power_refreshed_timestamp_seconds,
                 ..Default::default()
             }
         };
@@ -153,6 +166,7 @@ impl GovernanceCanisterInitPayloadBuilder {
                 aging_since_timestamp_seconds: 10,
                 account: subaccount,
                 not_for_profit: false,
+                voting_power_refreshed_timestamp_seconds,
                 ..Default::default()
             }
         };

--- a/rs/nns/integration_tests/src/neuron_following.rs
+++ b/rs/nns/integration_tests/src/neuron_following.rs
@@ -200,9 +200,6 @@ fn follow_same_neuron_multiple_times() {
     );
 }
 
-// This test is failing because of timing issues. We disable it until the NNS team
-// has a fix.
-#[ignore]
 #[test]
 fn vote_propagation_with_following() {
     let state_machine = setup_state_machine_with_nns_canisters();


### PR DESCRIPTION
# Observed Symptom(s)

The later you run these tests, the more that voting power gets reduced.

# Cause

The clock in the test is set to the current real time, but the timestamps in the test are hard-coded; in particular, `voting_power_refreshed_timestamp_seconds` in Neuron was set to [the default value]. Thus, starting on Mar 2 (in the real world), the test starts seeing that neurons have not refreshed in a "long time" (where "long time" is defined by [this parameter]). Thus, voting power reduction started to kick in, leading to the observed exercised voting power being less and less. Whereas, the expected amount of exercised voting power is some hard-coded value. Thus, the `assert` condition stopped being met.

[the default value]: https://sourcegraph.com/github.com/dfinity/ic@9d4240be28224b578e58f3c1f3734a6729905226/-/blob/rs/nns/governance/src/lib.rs?L184-194

[this parameter]: https://sourcegraph.com/github.com/dfinity/ic@9d4240be28224b578e58f3c1f3734a6729905226/-/blob/rs/nns/governance/canister/governance.did?L645-653

# Fix

Set `voting_power_refreshed_timestamp_seconds` of neurons in the test to the current time.

# Moral of the Story

Using the current real time makes tests prone to being non-reproducible. More generally, tests should control the situation.

One way to try to make tests that use the real time work is for all timestamps to be relative to the current real time, which is partially what this fix does. This is not ideal though, because it is very easy to get this wrong. It is "much easier" to ban tests from calling `now`. Ofc, we already have a bunch of tests that do this, and they are working ok, so it is hard to justify going back, and making them compliant to this suggested rule...