### PR TITLE
chore(PocketIC): update PocketIC docs on live mode

### DIFF
--- a/packages/pocket-ic/HOWTO.md
+++ b/packages/pocket-ic/HOWTO.md
@@ -56,7 +56,7 @@ The function `PocketIc::make_live()` also creates an HTTP gateway serving
   - and the ICP's HTTP gateway interface (as defined in the [HTTP Gateway Protocol Specification](https://internetcomputer.org/docs/references/http-gateway-protocol-spec))
 and returns its URL.
 
-**Attention**: Enabling the "live" mode makes the PocketIC instance non-deterministic! For instance, there is no way to tell in which order messages are gonna be executed.
+**Attention**: Enabling the "live" mode makes the PocketIC instance non-deterministic! For instance, there is no way to tell in which order messages are going to be executed.
 The function `PocketIc::stop_live` can be used to disable the "live" mode: it stops the HTTP gateway and the background thread ensuring progress on the PocketIC instance.
 However, the non-deterministic state changes during the "live" mode (e.g., time changes) could affect the PocketIC instance even after disabling the "live" mode.
 

--- a/packages/pocket-ic/HOWTO.md
+++ b/packages/pocket-ic/HOWTO.md
@@ -42,48 +42,93 @@ See the [examples](README.md#examples) for more.
 
 ## Live Mode
 
-Since version 4.0.0, the PocketIC server also exposes the IC's HTTP interface, just like the IC mainnet and the replica launched by dfx. This means that PocketIC instances can now be targeted by agent-based tools (agent.rs, agent.js, IC-Repl, etc). Note that PocketIC instances, if launched in the regular way, do not "make progress" by themselves, i.e., the state machines that represent the IC do not execute any messages without a call to `tick()` and their timestamps do not advance without a call to `advance_time(...)`. But the agent-based tools expect their target to make progress automatically (as the IC mainnet and the replica launched by dfx do) and use the current time as the IC time, since they dispatch asynchronous requests and poll for the result, checking for its freshness with respect to the current time.
+The PocketIC server exposes the ICP's HTTP interface (as defined in the [Interface Specification](https://internetcomputer.org/docs/references/ic-interface-spec#http-interface)) used by the ICP mainnet. This means that PocketIC instances can also be targeted by agent-based tools, e.g., the [Rust](https://crates.io/crates/ic-agent) and [JavaScript](https://www.npmjs.com/package/@dfinity/agent) agents.
 
-For that reason, you need to explicitly make an instance "live" by calling `make_live()` on it. This will do three things: 
+Note that PocketIC instances do not "make progress" by default, i.e., they do not execute any messages and time does not advance unless dedicated operations are triggered by separate HTTP requests. The "live" mode enabled by calling the function `PocketIc::make_live()` automates those steps by launching a background thread that
 
-- It launches a thread that calls `tick()` and `advance_time(...)` on the instance regularly - several times per second. 
-- It creates a gateway which points to this live instance.
-- It returns a gateway URL which can then be passed to agent-like tools.
+- sets the current time as the PocketIC instance time;
+- advances time on the PocketIC instance regularly;
+- executes messages on the PocketIC instance;
+- executes canister HTTP outcalls of the PocketIC instance.
 
-Of course, other instances on the same PocketIC server remain unchanged - neither do they receive `tick`s nor can the gateway route requests to them. 
+The function `PocketIc::make_live()` also creates an HTTP gateway serving
+  - the ICP's HTTP interface (as defined in the [Interface Specification](https://internetcomputer.org/docs/references/ic-interface-spec#http-interface))
+  - and the ICP's HTTP gateway interface (as defined in the [HTTP Gateway Protocol Specification](https://internetcomputer.org/docs/references/http-gateway-protocol-spec))
+and returns its URL.
 
-**Attention**: Enabling auto-progress makes instances non-deterministic! There is no way to guarantee message order when agents dispatch async requests, which may interleave with each other and with the `tick`s from the auto-progress thread. If you need determinism, use the old, manually-`tick`ed API. 
+**Attention**: Enabling the "live" mode makes the PocketIC instance non-deterministic! For instance, there is no way to tell in which order messages are gonna be executed.
+The function `PocketIc::stop_live` can be used to disable the "live" mode: it stops the HTTP gateway and the background thread ensuring progress on the PocketIC instance.
+However, the non-deterministic state changes during the "live" mode (e.g., time changes) could affect the PocketIC instance even after disabling the "live" mode.
 
-**Attention**: It is strongly discouraged to use the PocketIC library for interacting with a live instance.
-Live instances can be made non-live again by disabling auto-progress and disabling the gateway.
-This is done by calling `stop_live()` on the instance.
-Once this call returns, you can use the PocketIC library for testing again.
-The instance will only make progress when you call `tick()` - but the state in which the instance halts is not deterministic.
-So be extra careful with tests which are setup with a live phase and which then transition to non-live for the test section. 
+**Attention**: The "live" mode requires the PocketIC instance to have an NNS subnet.
 
-Here is a sketch on how to use the live mode: 
+**Attention**: It is strongly discouraged to override time of a "live" PocketIC instance.
+
+Here is a sketch on how to use the PocketIC library to make an update call in the "live" mode:
 
 ```rust
+// We create a PocketIC instance with an NNS subnet
+// (the "live" mode requires the NNS subnet).
 let mut pic = PocketIcBuilder::new()
     .with_nns_subnet()
     .with_application_subnet()
     .build();
+
+// Enable the "live" mode.
+let _ = pic.make_live(None);
+
+// Create and install a test canister.
+// ...
+
+// Submit an update call to the test canister making a canister http outcall.
+let call_id = pic
+    .submit_call(
+        canister_id,
+        Principal::anonymous(),
+        "canister_http",
+        encode_one(()).unwrap(),
+    )
+    .unwrap();
+
+// Await the update call without making additional progress (the PocketIC instance
+// is already in the "live" mode making progress automatically).
+let reply = pic.await_call_no_ticks(call_id).unwrap();
+
+// Process the reply.
+// ...
+```
+
+Here is a sketch on how to use the IC agent in the "live" mode:
+
+```rust
+// We create a PocketIC instance with an NNS subnet
+// (the "live" mode requires the NNS subnet).
+let mut pic = PocketIcBuilder::new()
+    .with_nns_subnet()
+    .with_application_subnet()
+    .build();
+
+// Enable the "live" mode.
 let endpoint = pic.make_live(None);
-// the local agent needs a runtime
-let rt = tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap();
-let res = rt.block_on(async {
+
+// We use a tokio runtime to run the asynchronous IC agent.
+let rt = tokio::runtime::Builder::new_current_thread()
+    .enable_all()
+    .build()
+    .unwrap();
+rt.block_on(async {
+    // We create an IC agent.
     let agent = ic_agent::Agent::builder()
-            .with_url(endpoint.clone())
-            .build()
-            .unwrap();
-    // proof that the agent can communicate with the instance
+        .with_url(endpoint)
+        .build()
+        .unwrap();
+
+    // We fetch the PocketIC (i.e., non-mainnet) root key to successfully verify responses.
     agent.fetch_root_key().await.unwrap();
-    // do something useful with the agent
-    let res = agent.[...]
-    res
+
+    // Finally, we use the IC agent in tests.
+    // ...
 });
-// stop the HTTP gateway and auto progress
-pic.stop_live();
 ```
 
 ## Concurrent update calls

--- a/rs/pocket_ic_server/tests/test.rs
+++ b/rs/pocket_ic_server/tests/test.rs
@@ -429,7 +429,7 @@ fn test_specified_id() {
         .unwrap();
     let canister_id = rt.block_on(async {
         let agent = ic_agent::Agent::builder()
-            .with_url(endpoint.clone())
+            .with_url(endpoint)
             .build()
             .unwrap();
         agent.fetch_root_key().await.unwrap();


### PR DESCRIPTION
This PR updates the PocketIC docs on the "live" mode to address the confusion reported in this [forum post](https://forum.dfinity.org/t/pocket-ic-7-0-issue-with-http-outcalls-in-live-mode/39110).