### PR TITLE
fix(PocketIC): PocketIC HTTP handler uses PocketIC time for ingress expiry checks

### DIFF
--- a/packages/pocket-ic/tests/tests.rs
+++ b/packages/pocket-ic/tests/tests.rs
@@ -8,12 +8,12 @@ use ic_management_canister_types::{
     SchnorrKeyId as SchnorrPublicKeyArgsKeyId, SchnorrPublicKeyResult,
 };
 use ic_transport_types::Envelope;
-use ic_transport_types::EnvelopeContent::ReadState;
+use ic_transport_types::EnvelopeContent::{Call, ReadState};
 use pocket_ic::common::rest::{BlockmakerConfigs, RawSubnetBlockmaker, TickConfigs};
 use pocket_ic::{
     common::rest::{
         BlobCompression, CanisterHttpReply, CanisterHttpResponse, MockCanisterHttpResponse,
-        RawEffectivePrincipal, SubnetKind,
+        RawEffectivePrincipal, RawMessageId, SubnetKind,
     },
     query_candid, update_candid, DefaultEffectiveCanisterIdError, ErrorCode, IngressStatusResult,
     PocketIc, PocketIcBuilder, RejectCode,
@@ -2093,6 +2093,95 @@ fn read_state_request_status(
         .body(serialized_bytes)
         .send()
         .unwrap()
+}
+
+#[test]
+fn call_ingress_expiry() {
+    let pic = PocketIcBuilder::new()
+        .with_nns_subnet()
+        .with_application_subnet()
+        .build();
+    let canister_id = pic.create_canister();
+    pic.add_cycles(canister_id, INIT_CYCLES);
+    pic.install_canister(canister_id, test_canister_wasm(), vec![], None);
+
+    // submit an update call via /api/v2/canister/.../call using an ingress expiry in the future
+    let unix_time_secs = 2272143600; // Wed Jan 01 2042 00:00:00 GMT+0100
+    let time = SystemTime::UNIX_EPOCH + std::time::Duration::from_secs(unix_time_secs);
+    pic.set_certified_time(time);
+    let ingress_expiry = pic
+        .get_time()
+        .duration_since(std::time::SystemTime::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos() as u64
+        + 240_000_000_000;
+    let (resp, msg_id) = call_request(&pic, ingress_expiry, canister_id);
+    assert_eq!(resp.status(), reqwest::StatusCode::ACCEPTED);
+
+    // execute a round on the PocketIC instance to process that update call
+    pic.tick();
+
+    // check the update call status
+    let raw_message_id = RawMessageId {
+        effective_principal: RawEffectivePrincipal::CanisterId(canister_id.as_slice().to_vec()),
+        message_id: msg_id.to_vec(),
+    };
+    let reply = pic.ingress_status(raw_message_id).unwrap().unwrap();
+    let principal = Decode!(&reply, String).unwrap();
+    assert_eq!(principal, canister_id.to_string());
+
+    // use an invalid ingress expiry
+    let ingress_expiry = SystemTime::now()
+        .duration_since(std::time::SystemTime::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos() as u64
+        + 240_000_000_000;
+    let (resp, _msg_id) = call_request(&pic, ingress_expiry, canister_id);
+    assert_eq!(resp.status(), reqwest::StatusCode::BAD_REQUEST);
+    let err = String::from_utf8(resp.bytes().unwrap().to_vec()).unwrap();
+    assert!(
+        err.contains("Invalid request expiry: Specified ingress_expiry not within expected range")
+    );
+}
+
+fn call_request(
+    pic: &PocketIc,
+    ingress_expiry: u64,
+    canister_id: Principal,
+) -> (reqwest::blocking::Response, [u8; 32]) {
+    let content = Call {
+        nonce: None,
+        ingress_expiry,
+        sender: Principal::anonymous(),
+        canister_id,
+        method_name: "whoami".to_string(),
+        arg: Encode!(&()).unwrap(),
+    };
+    let envelope = Envelope {
+        content: std::borrow::Cow::Borrowed(&content),
+        sender_pubkey: None,
+        sender_sig: None,
+        sender_delegation: None,
+    };
+
+    let mut serialized_bytes = Vec::new();
+    let mut serializer = serde_cbor::Serializer::new(&mut serialized_bytes);
+    serializer.self_describe().unwrap();
+    envelope.serialize(&mut serializer).unwrap();
+
+    let endpoint = format!(
+        "instances/{}/api/v2/canister/{}/call",
+        pic.instance_id(),
+        canister_id.to_text()
+    );
+    let client = reqwest::blocking::Client::new();
+    let resp = client
+        .post(pic.get_server_url().join(&endpoint).unwrap())
+        .header(reqwest::header::CONTENT_TYPE, "application/cbor")
+        .body(serialized_bytes)
+        .send()
+        .unwrap();
+    (resp, *content.to_request_id())
 }
 
 #[test]

--- a/rs/http_endpoints/public/src/query.rs
+++ b/rs/http_endpoints/public/src/query.rs
@@ -19,6 +19,7 @@ use ic_error_types::{ErrorCode, RejectCode};
 use ic_interfaces::{
     crypto::BasicSigner,
     execution_environment::{QueryExecutionError, QueryExecutionService},
+    time_source::{SysTimeSource, TimeSource},
 };
 use ic_interfaces_registry::RegistryClient;
 use ic_logger::{error, ReplicaLogger};
@@ -31,7 +32,6 @@ use ic_types::{
         HttpQueryResponseReply, HttpRequest, HttpRequestEnvelope, HttpSignedQueryResponse,
         NodeSignature, Query, QueryResponseHash,
     },
-    time::current_time,
     CanisterId, NodeId,
 };
 use ic_validator::HttpRequestVerifier;
@@ -50,6 +50,7 @@ pub struct QueryService {
     signer: Arc<dyn BasicSigner<QueryResponseHash> + Send + Sync>,
     health_status: Arc<AtomicCell<ReplicaHealthStatus>>,
     delegation_from_nns: Arc<OnceCell<CertificateDelegation>>,
+    time_source: Arc<dyn TimeSource>,
     validator: Arc<dyn HttpRequestVerifier<Query, RegistryRootOfTrustProvider>>,
     registry_client: Arc<dyn RegistryClient>,
     query_execution_service: Arc<Mutex<QueryExecutionService>>,
@@ -62,6 +63,7 @@ pub struct QueryServiceBuilder {
     health_status: Option<Arc<AtomicCell<ReplicaHealthStatus>>>,
     malicious_flags: Option<MaliciousFlags>,
     delegation_from_nns: Arc<OnceCell<CertificateDelegation>>,
+    time_source: Option<Arc<dyn TimeSource>>,
     ingress_verifier: Arc<dyn IngressSigVerifier + Send + Sync>,
     registry_client: Arc<dyn RegistryClient>,
     query_execution_service: QueryExecutionService,
@@ -90,6 +92,7 @@ impl QueryServiceBuilder {
             health_status: None,
             malicious_flags: None,
             delegation_from_nns,
+            time_source: None,
             ingress_verifier,
             registry_client,
             query_execution_service,
@@ -98,6 +101,11 @@ impl QueryServiceBuilder {
 
     pub(crate) fn with_malicious_flags(mut self, malicious_flags: MaliciousFlags) -> Self {
         self.malicious_flags = Some(malicious_flags);
+        self
+    }
+
+    pub fn with_time_source(mut self, time_source: Arc<dyn TimeSource>) -> Self {
+        self.time_source = Some(time_source);
         self
     }
 
@@ -119,6 +127,7 @@ impl QueryServiceBuilder {
                 .health_status
                 .unwrap_or_else(|| Arc::new(AtomicCell::new(ReplicaHealthStatus::Healthy))),
             delegation_from_nns: self.delegation_from_nns,
+            time_source: self.time_source.unwrap_or(Arc::new(SysTimeSource::new())),
             validator: build_validator(self.ingress_verifier, self.malicious_flags),
             registry_client: self.registry_client,
             query_execution_service: Arc::new(Mutex::new(self.query_execution_service)),
@@ -143,6 +152,7 @@ pub(crate) async fn query(
         log,
         node_id,
         registry_client,
+        time_source,
         validator,
         health_status,
         signer,
@@ -188,7 +198,11 @@ pub(crate) async fn query(
     // Since spawn blocking requires 'static we can't use any references
     let request_c = request.clone();
     match tokio::task::spawn_blocking(move || {
-        validator.validate_request(&request_c, current_time(), &root_of_trust_provider)
+        validator.validate_request(
+            &request_c,
+            time_source.get_relative_time(),
+            &root_of_trust_provider,
+        )
     })
     .await
     {

--- a/rs/http_endpoints/public/src/read_state/canister.rs
+++ b/rs/http_endpoints/public/src/read_state/canister.rs
@@ -15,6 +15,7 @@ use http::Request;
 use hyper::StatusCode;
 use ic_crypto_interfaces_sig_verification::IngressSigVerifier;
 use ic_crypto_tree_hash::{sparse_labeled_tree_from_paths, Label, Path, TooLongPathError};
+use ic_interfaces::time_source::{SysTimeSource, TimeSource};
 use ic_interfaces_registry::RegistryClient;
 use ic_interfaces_state_manager::StateReader;
 use ic_logger::ReplicaLogger;
@@ -26,7 +27,6 @@ use ic_types::{
         Blob, Certificate, CertificateDelegation, HttpReadStateContent, HttpReadStateResponse,
         HttpRequest, HttpRequestEnvelope, MessageId, ReadState, EXPECTED_MESSAGE_ID_LENGTH,
     },
-    time::current_time,
     CanisterId, PrincipalId, UserId,
 };
 use ic_validator::{CanisterIdSet, HttpRequestVerifier};
@@ -43,6 +43,7 @@ pub struct CanisterReadStateService {
     health_status: Arc<AtomicCell<ReplicaHealthStatus>>,
     delegation_from_nns: Arc<OnceCell<CertificateDelegation>>,
     state_reader: Arc<dyn StateReader<State = ReplicatedState>>,
+    time_source: Arc<dyn TimeSource>,
     validator: Arc<dyn HttpRequestVerifier<ReadState, RegistryRootOfTrustProvider>>,
     registry_client: Arc<dyn RegistryClient>,
 }
@@ -53,6 +54,7 @@ pub struct CanisterReadStateServiceBuilder {
     malicious_flags: Option<MaliciousFlags>,
     delegation_from_nns: Arc<OnceCell<CertificateDelegation>>,
     state_reader: Arc<dyn StateReader<State = ReplicatedState>>,
+    time_source: Option<Arc<dyn TimeSource>>,
     ingress_verifier: Arc<dyn IngressSigVerifier + Send + Sync>,
     registry_client: Arc<dyn RegistryClient>,
 }
@@ -77,6 +79,7 @@ impl CanisterReadStateServiceBuilder {
             malicious_flags: None,
             delegation_from_nns,
             state_reader,
+            time_source: None,
             ingress_verifier,
             registry_client,
         }
@@ -84,6 +87,11 @@ impl CanisterReadStateServiceBuilder {
 
     pub(crate) fn with_malicious_flags(mut self, malicious_flags: MaliciousFlags) -> Self {
         self.malicious_flags = Some(malicious_flags);
+        self
+    }
+
+    pub fn with_time_source(mut self, time_source: Arc<dyn TimeSource>) -> Self {
+        self.time_source = Some(time_source);
         self
     }
 
@@ -103,6 +111,7 @@ impl CanisterReadStateServiceBuilder {
                 .unwrap_or_else(|| Arc::new(AtomicCell::new(ReplicaHealthStatus::Healthy))),
             delegation_from_nns: self.delegation_from_nns,
             state_reader: self.state_reader,
+            time_source: self.time_source.unwrap_or(Arc::new(SysTimeSource::new())),
             validator: build_validator(self.ingress_verifier, self.malicious_flags),
             registry_client: self.registry_client,
         };
@@ -127,6 +136,7 @@ pub(crate) async fn canister_read_state(
         health_status,
         delegation_from_nns,
         state_reader,
+        time_source,
         validator,
         registry_client,
     }): State<CanisterReadStateService>,
@@ -165,14 +175,17 @@ pub(crate) async fn canister_read_state(
     // Since spawn blocking requires 'static we can't use any references
     let request_c = request.clone();
     let response = tokio::task::spawn_blocking(move || {
-        let targets =
-            match validator.validate_request(&request_c, current_time(), &root_of_trust_provider) {
-                Ok(targets) => targets,
-                Err(err) => {
-                    let http_err = validation_error_to_http_error(&request, err, &log);
-                    return (http_err.status, http_err.message).into_response();
-                }
-            };
+        let targets = match validator.validate_request(
+            &request_c,
+            time_source.get_relative_time(),
+            &root_of_trust_provider,
+        ) {
+            Ok(targets) => targets,
+            Err(err) => {
+                let http_err = validation_error_to_http_error(&request, err, &log);
+                return (http_err.status, http_err.message).into_response();
+            }
+        };
 
         let certified_state_reader = match state_reader.get_certified_state_snapshot() {
             Some(reader) => reader,

--- a/rs/pocket_ic_server/src/pocket_ic.rs
+++ b/rs/pocket_ic_server/src/pocket_ic.rs
@@ -2040,6 +2040,7 @@ impl Operation for CallRequest {
                     Arc::new(RwLock::new(PocketIngressPoolThrottler)),
                     s,
                 )
+                .with_time_source(subnet.time_source.clone())
                 .build();
 
                 // Task that waits for call service to submit the ingress message, and
@@ -2170,6 +2171,7 @@ impl Operation for QueryRequest {
                     Arc::new(OnceCell::new_with(delegation)),
                     query_handler,
                 )
+                .with_time_source(subnet.time_source.clone())
                 .build_service();
 
                 let request = axum::http::Request::builder()
@@ -2225,6 +2227,7 @@ impl Operation for CanisterReadStateRequest {
                     Arc::new(StandaloneIngressSigVerifier),
                     Arc::new(OnceCell::new_with(delegation)),
                 )
+                .with_time_source(subnet.time_source.clone())
                 .build_service();
 
                 let request = axum::http::Request::builder()

--- a/rs/state_machine_tests/src/lib.rs
+++ b/rs/state_machine_tests/src/lib.rs
@@ -843,7 +843,7 @@ pub struct StateMachine {
     pub log_level: Option<Level>,
     pub nodes: Vec<StateMachineNode>,
     pub batch_summary: Option<BatchSummary>,
-    time_source: Arc<FastForwardTimeSource>,
+    pub time_source: Arc<FastForwardTimeSource>,
     consensus_pool_cache: Arc<FakeConsensusPoolCache>,
     canister_http_pool: Arc<RwLock<CanisterHttpPoolImpl>>,
     canister_http_payload_builder: Arc<CanisterHttpPayloadBuilderImpl>,


### PR DESCRIPTION
This PR fixes the PocketIC HTTP handler of the ICP's HTTP interface (endpoints /api/v2/... and /api/v3/...) to use the PocketIC time instead of the current time.