### PR TITLE
chore: removes an entry that doesn't exist from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -162,7 +162,6 @@ go_deps.bzl               @dfinity/idx
 /rs/memory_tracker/                                     @dfinity/execution
 /rs/messaging/                                          @dfinity/ic-message-routing-owners
 /rs/monitoring/                                         @dfinity/consensus
-/rs/monitoring/backtrace/                               @dfinity/consensus @dfinity/ic-message-routing-owners
 /rs/monitoring/metrics                                  @dfinity/consensus @dfinity/ic-message-routing-owners
 /rs/monitoring/pprof/                                   @dfinity/consensus @dfinity/ic-message-routing-owners
 /rs/nervous_system/                                     @dfinity/nns-team


### PR DESCRIPTION
Perhaps it was just renamed to `monitoring/tracing`. As it is, it doesn't exist.