### PR TITLE
chore(fuzzing): Add `fcntl` to the sandbox monitor whitelist

### DIFF
--- a/rs/execution_environment/fuzz/src/lib.rs
+++ b/rs/execution_environment/fuzz/src/lib.rs
@@ -108,6 +108,7 @@ where
                 Sysno::sendmsg,
                 Sysno::sigaltstack,
                 Sysno::futex,
+                Sysno::fcntl,
                 Sysno::close,
                 Sysno::restart_syscall,
             ]);


### PR DESCRIPTION
Corresponding [failure](https://github.com/dfinity/ic/actions/runs/13637443383/job/38119562486#step:4:1199) observed on the hourly pipeline