### PR TITLE
fix(IDX): set GH token

### DIFF
--- a/.github/workflows/update-mainnet-revisions.yaml
+++ b/.github/workflows/update-mainnet-revisions.yaml
@@ -28,6 +28,8 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
 
       - name: Update IC versions file
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           set -eEuxo pipefail
 
@@ -61,6 +63,8 @@ jobs:
           version: 2.53.0
 
       - name: Update Mainnet canisters file
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           set -eEuxo pipefail
 


### PR DESCRIPTION
I thought this wasn't required because we already have the token set in the checkout step, but apparently it fails if it is not set again.