### PR TITLE
fix(IDX): export SSH_AUTH_SOCK in bazel-test-all

### DIFF
--- a/.github/actions/bazel-test-all/action.yaml
+++ b/.github/actions/bazel-test-all/action.yaml
@@ -33,6 +33,7 @@ runs:
           if [ -z "${SSH_AUTH_SOCK:-}" ]; then
             eval "$(ssh-agent -s)"
             ssh-add - <<< '${{ inputs.SSH_PRIVATE_KEY_BACKUP_POD }}'
+            echo "SSH_AUTH_SOCK=$SSH_AUTH_SOCK" >> "$GITHUB_ENV"
           fi
 
           rm -rf ~/.ssh


### PR DESCRIPTION
After https://github.com/dfinity/ic/pull/4171 the `SSH_AUTH_SOCK` was not exported anymore in the step that needed it. The changes here ensure the socket is still set in the actual bazel test step.