### PR TITLE
chore: increase state hash timeout in SM tests

### DIFF
--- a/rs/state_machine_tests/src/lib.rs
+++ b/rs/state_machine_tests/src/lib.rs
@@ -2620,12 +2620,14 @@ impl StateMachine {
     pub fn await_state_hash(&self) -> CryptoHashOfState {
         let h = self.state_manager.latest_state_height();
         let started_at = Instant::now();
-        let mut tries = 0;
-        while tries < 100 {
+        loop {
+            let elapsed = started_at.elapsed();
+            if elapsed > Duration::from_secs(5 * 60) {
+                panic!("State hash computation took too long ({:?})", elapsed);
+            }
             match self.state_manager.get_state_hash_at(h) {
                 Ok(hash) => return hash,
                 Err(StateHashError::Transient(_)) => {
-                    tries += 1;
                     std::thread::sleep(Duration::from_millis(100));
                     continue;
                 }
@@ -2634,10 +2636,6 @@ impl StateMachine {
                 }
             }
         }
-        panic!(
-            "State hash computation took too long ({:?})",
-            started_at.elapsed()
-        )
     }
 
     /// Blocks until the result of the ingress message with the specified ID is


### PR DESCRIPTION
This PR increases state hash timeout in SM tests from 10s to 5min to avoid test [flakiness](https://dash.zh1-idx1.dfinity.network/invocation/47b7b0bd-80d9-4e50-8a6e-3353db2d5142?target=%2F%2Frs%2Fpocket_ic_server%3Atest&targetStatus=6#@110) of the form:
```
thread 'tokio-runtime-worker' panicked at rs/state_machine_tests/src/lib.rs:2637:9:
State hash computation took too long (10.009051501s)
```