### PR TITLE
fix(IDX): don't run system tests with 'local' by default

### DIFF
--- a/rs/tests/kubeconfig.bzl
+++ b/rs/tests/kubeconfig.bzl
@@ -7,6 +7,13 @@ def _kubeconfig_impl(ctx):
     ctx.file("kubeconfig.yaml", content = cfg.stdout)
     ctx.file("BUILD.bazel", content = """exports_files(glob(['*']))""")
 
+    # (possibly empty) list of tags required for tests tagged with `k8s`.
+    if ctx.getenv("KUBECONFIG"):
+        # set "local" tag for k8s system tests due to rootful container image builds
+        ctx.file("defs.bzl", content = """k8s_tags = ['local']""")
+    else:
+        ctx.file("defs.bzl", content = """k8s_tags = []""")
+
 kubeconfig_rule = repository_rule(
     _kubeconfig_impl,
     local = True,

--- a/rs/tests/system_tests.bzl
+++ b/rs/tests/system_tests.bzl
@@ -4,6 +4,7 @@ Rules for system-tests.
 
 load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
 load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
+load("@kubeconfig//:defs.bzl", "k8s_tags")
 load("@rules_oci//oci:defs.bzl", "oci_load")
 load("@rules_rust//rust:defs.bzl", "rust_binary")
 load("//bazel:defs.bzl", "mcopy", "zstd_compress")
@@ -274,12 +275,6 @@ def system_test(
     if uses_boundary_guestos:
         icos_images["ENV_DEPS__BOUNDARY_GUESTOS_DISK_IMG"] = "//ic-os/boundary-guestos/envs/dev:disk-img.tar.zst"
 
-    # set "local" tag for k8s system tests due to rootful container image builds
-    is_k8s = select({
-        "//rs/tests:k8s": True,
-        "//conditions:default": False,
-    })
-
     run_system_test(
         name = name,
         src = test_driver_target,
@@ -288,7 +283,8 @@ def system_test(
         env = env,
         icos_images = icos_images,
         env_inherit = env_inherit,
-        tags = tags + ["requires-network", "system_test"] + (["local"] if is_k8s else []) +
+        tags = tags + ["requires-network", "system_test"] +
+               k8s_tags +
                (["manual"] if "experimental_system_test_colocation" in tags else []),
         target_compatible_with = ["@platforms//os:linux"],
         timeout = test_timeout,


### PR DESCRIPTION
This ensures that -- by default -- system tests are not with run the `local` strategy. When run `local`ly, system tests don't seem to get cached across server restarts.

The `select()` which was evaluated as a boolean was truthy meaning the `local` tag was always added. Instead, the `local` strategy is specified as a CLI arg in the k8s CI job.