### PR TITLE
chore(IDX): show build command in main.sh

### DIFF
--- a/ci/bazel-scripts/main.sh
+++ b/ci/bazel-scripts/main.sh
@@ -97,6 +97,8 @@ if [[ ! " ${bazel_args[*]} " =~ [[:space:]]--repository_cache[[:space:]] ]] && [
     bazel_args+=(--repository_cache=/cache/bazel)
 fi
 
+echo "running build command 'bazel ${bazel_args[@]}'"
+
 bazel_exitcode="0"
 bazel "${bazel_args[@]}" 2>&1 | awk -v url_out="$url_out" "$stream_awk_program" || bazel_exitcode="$?"
 


### PR DESCRIPTION
This adds a log line showing the build command being run. Previously, the last log line was `setting default repository cache`, which made the logs somewhat confusing (because the build command can take some time to show some output).