### PR TITLE
test(nns): Use a separate binary to prepare golden state to speed up experimentation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11072,6 +11072,7 @@ version = "0.0.1"
 dependencies = [
  "ic-base-types",
  "ic-config",
+ "ic-nns-test-utils-prepare-golden-state",
  "ic-registry-routing-table",
  "ic-registry-subnet-type",
  "ic-state-machine-tests",
@@ -11085,6 +11086,14 @@ version = "0.9.0"
 dependencies = [
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "ic-nns-test-utils-prepare-golden-state"
+version = "0.0.1"
+dependencies = [
+ "clap 4.5.27",
+ "tempfile",
 ]
 
 [[package]]

--- a/rs/nns/test_utils/golden_nns_state/BUILD.bazel
+++ b/rs/nns/test_utils/golden_nns_state/BUILD.bazel
@@ -5,6 +5,7 @@ package(default_visibility = ["//visibility:public"])
 DEPENDENCIES = [
     # Keep sorted.
     "//rs/config",
+    "//rs/nns/test_utils/prepare_golden_state",
     "//rs/registry/routing_table",
     "//rs/registry/subnet_type",
     "//rs/state_machine_tests",

--- a/rs/nns/test_utils/golden_nns_state/Cargo.toml
+++ b/rs/nns/test_utils/golden_nns_state/Cargo.toml
@@ -9,5 +9,6 @@ ic-config = { path = "../../../config" }
 ic-registry-routing-table = { path = "../../../registry/routing_table" }
 ic-registry-subnet-type = { path = "../../../registry/subnet_type" }
 ic-state-machine-tests = { path = "../../../state_machine_tests" }
+ic-nns-test-utils-prepare-golden-state = { path = "../prepare_golden_state" }
 ic-types = { path = "../../../types/types" }
 tempfile = { workspace = true }

--- a/rs/nns/test_utils/prepare_golden_state/BUILD.bazel
+++ b/rs/nns/test_utils/prepare_golden_state/BUILD.bazel
@@ -1,0 +1,24 @@
+load("@rules_rust//rust:defs.bzl", "rust_binary", "rust_library")
+
+package(default_visibility = ["//visibility:public"])
+
+DEPENDENCIES = [
+    # Keep sorted.
+    "@crate_index//:clap",
+    "@crate_index//:tempfile",
+]
+
+rust_library(
+    name = "prepare_golden_state",
+    srcs = ["src/lib.rs"],
+    crate_name = "ic_nns_test_utils_prepare_golden_state",
+    version = "0.0.1",
+    deps = DEPENDENCIES,
+)
+
+rust_binary(
+    name = "watch_and_prepare",
+    srcs = ["src/watch_and_prepare.rs"],
+    version = "0.0.1",
+    deps = [":prepare_golden_state"] + DEPENDENCIES,
+)

--- a/rs/nns/test_utils/prepare_golden_state/Cargo.toml
+++ b/rs/nns/test_utils/prepare_golden_state/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "ic-nns-test-utils-prepare-golden-state"
+version = "0.0.1"
+edition = "2021"
+
+[dependencies]
+clap = { workspace = true }
+tempfile = { workspace = true }
+
+[[bin]]
+name = "watch-and-prepare"
+path = "src/watch_and_prepare.rs"

--- a/rs/nns/test_utils/prepare_golden_state/src/lib.rs
+++ b/rs/nns/test_utils/prepare_golden_state/src/lib.rs
@@ -1,0 +1,170 @@
+use std::{
+    path::{Path, PathBuf},
+    process::Command,
+    str::FromStr,
+};
+use tempfile::TempDir;
+
+#[derive(Debug, Clone, Copy)]
+pub enum StateSource {
+    Fiduciary,
+    Nns,
+    Sns,
+}
+
+const STATE_SOURCE_USER: &str = "dev";
+const STATE_SOURCE_HOST: &str = "zh1-pyr07.zh1.dfinity.network";
+
+impl StateSource {
+    pub fn state_dir_name(&self) -> &'static str {
+        match self {
+            StateSource::Fiduciary => "fiduciary_state",
+            StateSource::Nns => "nns_state",
+            StateSource::Sns => "sns_state",
+        }
+    }
+
+    fn to_argument(self) -> String {
+        format!(
+            "{}@{}:/home/dev/{}.tar.zst",
+            STATE_SOURCE_USER,
+            STATE_SOURCE_HOST,
+            self.state_dir_name()
+        )
+    }
+}
+
+impl FromStr for StateSource {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "fiduciary" => Ok(StateSource::Fiduciary),
+            "nns" => Ok(StateSource::Nns),
+            "sns" => Ok(StateSource::Sns),
+            _ => Err(format!("Unknown state source: {}", s)),
+        }
+    }
+}
+
+/// If available, uses the `TEST_TMPDIR` environment variable, which is set by
+/// `bazel test`, and points to where you are allowed to write to disk.
+/// Otherwise, this just falls back on vanilla TempDir::new.
+fn bazel_test_compatible_temp_dir_or_panic() -> TempDir {
+    match std::env::var("TEST_TMPDIR") {
+        Ok(dir) => TempDir::new_in(dir).unwrap(),
+        Err(_err) => TempDir::new().unwrap(),
+    }
+}
+
+pub fn maybe_download_and_untar_golden_state_or_panic(state_source: StateSource) -> TempDir {
+    match std::env::var_os("USE_EXISTING_STATE_DIR") {
+        Some(existing_state_dir_name) => {
+            let existing_state_dir = PathBuf::from(existing_state_dir_name.clone());
+            let existing_state = existing_state_dir.join(state_source.state_dir_name());
+            let destination_dir = TempDir::new_in(&existing_state_dir).unwrap();
+            if !existing_state.exists() {
+                panic!(
+                    "USE_EXISTING_STATE_DIR is set to {:?}, but {:?} does not exist",
+                    existing_state_dir_name, existing_state
+                );
+            }
+            std::fs::rename(&existing_state, &destination_dir).unwrap();
+            destination_dir
+        }
+        None => download_and_untar_golden_state_or_panic(state_source),
+    }
+}
+
+fn download_and_untar_golden_state_or_panic(state_source: StateSource) -> TempDir {
+    let download_destination = bazel_test_compatible_temp_dir_or_panic();
+    let download_destination = download_destination
+        .path()
+        .join(format!("{}.tar.zst", state_source.state_dir_name()));
+    download_golden_state_or_panic(state_source, &download_destination);
+
+    let state_dir = bazel_test_compatible_temp_dir_or_panic();
+    untar_state_archive_or_panic(
+        &download_destination,
+        state_dir.path(),
+        state_source.state_dir_name(),
+        bazel_test_compatible_temp_dir_or_panic,
+    );
+    state_dir
+}
+
+pub fn download_golden_state_or_panic(state_source: StateSource, destination: &Path) {
+    let source = state_source.to_argument();
+    println!("Downloading {} to {:?} ...", source, destination);
+
+    // Actually download.
+    let scp_out = Command::new("scp")
+        .arg("-oUserKnownHostsFile=/dev/null")
+        .arg("-oStrictHostKeyChecking=no")
+        .arg("-v")
+        .arg(source.clone())
+        .arg(destination)
+        .output()
+        .unwrap_or_else(|err| panic!("Could not scp from {:?} because: {:?}!", source, err));
+
+    // Inspect result.
+    if !scp_out.status.success() {
+        panic!("Could not scp from {}\n{:#?}", source, scp_out);
+    }
+
+    let size = std::fs::metadata(destination)
+        .map(|metadata| {
+            let len = metadata.len() as f64;
+            let len = len / (1 << 30) as f64;
+            format!("{:.2} GiB", len)
+        })
+        .unwrap_or_else(|_err| "???".to_string());
+
+    let destination = destination.to_string_lossy();
+    println!("Downloaded {} to {}. size = {}", source, destination, size);
+}
+
+pub fn untar_state_archive_or_panic(
+    source: &Path,
+    destination: &Path,
+    state_dir: &str,
+    create_temp_dir: impl Fn() -> TempDir,
+) {
+    println!(
+        "Unpacking {} from {:?} to {:?}...",
+        state_dir, source, destination
+    );
+
+    // TODO: Mathias reports having problems with this (or something similar) on Mac.
+    let unpack_destination = create_temp_dir();
+    let unpack_destination = unpack_destination
+        .path()
+        .to_str()
+        .expect("Was trying to convert a Path to a string.");
+    let tar_out = Command::new("tar")
+        .arg("--extract")
+        .arg("--file")
+        .arg(source)
+        .arg("--directory")
+        .arg(unpack_destination)
+        .output()
+        .unwrap_or_else(|err| panic!("Could not unpack {:?}: {}", source, err));
+
+    if !tar_out.status.success() {
+        panic!("Could not unpack {:?}\n{:#?}", source, tar_out);
+    }
+
+    // Move $UNTAR_DESTINATION/nns_state/ic_state to final output dir path, StateMachine's so-called
+    // state_dir.
+    println!(
+        "Renaming {:?}/{}/ic_state to {:?}...",
+        unpack_destination, state_dir, destination
+    );
+    std::fs::rename(
+        format!("{}/{}/ic_state", unpack_destination, state_dir),
+        destination,
+    )
+    .unwrap();
+
+    println!("Unpacked {:?} to {:?}", source, destination);
+}

--- a/rs/nns/test_utils/prepare_golden_state/src/watch_and_prepare.rs
+++ b/rs/nns/test_utils/prepare_golden_state/src/watch_and_prepare.rs
@@ -1,0 +1,109 @@
+//! Example usage:
+//!
+//! In one shell:
+//!
+//! ```
+//! bazel run //rs/nns/test_utils/prepare_golden_state --
+//! --state-dir-path=/some/directory --state-source=nns
+//! ```
+//!
+//! In another shell:
+//!
+//! ```
+//! bazel test --test_env=USE_EXISTING_STATE_DIR=/some/directory \
+//!   --test_env=SSH_AUTH_SOCK \
+//!   --test_env=NNS_CANISTER_UPGRADE_SEQUENCE=governance \
+//!   --test_output=streamed \
+//!   --test_arg=--nocapture \
+//!   //rs/nns/integration_tests:upgrade_canisters_with_golden_nns_state
+//! ```
+//!
+//! The test in the second shell can be run multiple times, and as soon as the test starts running,
+//! the `StateMachine` will take away the state directory from the first shell and use it for the
+//! test, and the first shell will notice that the state directory is gone and start untarring the
+//! state again.
+
+use clap::Parser;
+use ic_nns_test_utils_prepare_golden_state::{
+    download_golden_state_or_panic, untar_state_archive_or_panic, StateSource,
+};
+use std::{path::PathBuf, str::FromStr, thread::sleep, time::Duration};
+use tempfile::TempDir;
+
+#[derive(Parser, Debug)]
+#[command(author, version, about, long_about = None)]
+struct Args {
+    #[clap(long)]
+    state_dir_path: PathBuf,
+
+    #[clap(long)]
+    state_source: String,
+
+    #[clap(long)]
+    clean: bool,
+}
+
+fn main() {
+    let args = Args::parse();
+    println!("Args: {:?}", args);
+
+    let state_source = StateSource::from_str(&args.state_source).expect("Invalid state source");
+
+    let download_destination = args
+        .state_dir_path
+        .join(format!("{}.tar.zst", state_source.state_dir_name()));
+    let untar_destination = args.state_dir_path.join(state_source.state_dir_name());
+
+    if args.clean {
+        println!(
+            "The --clean flag is set, removing the existing downloaded state file {} and state directory {} if they exist",
+            download_destination.display(),
+            untar_destination.display()
+        );
+        if download_destination.exists() {
+            std::fs::remove_file(download_destination.as_path())
+                .expect("Failed to remove state file");
+            println!(
+                "Removed the existing downloaded state file {}",
+                download_destination.display()
+            );
+        }
+        if untar_destination.exists() {
+            std::fs::remove_dir_all(untar_destination.as_path())
+                .expect("Failed to remove state directory");
+            println!(
+                "Removed the existing state directory {}",
+                untar_destination.display()
+            );
+        }
+    }
+
+    if !download_destination.exists() {
+        download_golden_state_or_panic(state_source, download_destination.as_path());
+    }
+
+    if untar_destination.exists() {
+        println!(
+            "State directory found at {}, doing nothing for now but will keep monitoring...",
+            untar_destination.display()
+        );
+    }
+
+    loop {
+        if untar_destination.exists() {
+            sleep(Duration::from_secs(5));
+            continue;
+        }
+        println!(
+            "State directory not found at {}, untarring from {}...",
+            untar_destination.display(),
+            download_destination.display()
+        );
+        untar_state_archive_or_panic(
+            download_destination.as_path(),
+            untar_destination.as_path(),
+            state_source.state_dir_name(),
+            || TempDir::new_in(args.state_dir_path.as_path()).expect("Failed to create temp dir"),
+        );
+    }
+}


### PR DESCRIPTION
# Why

Currently, if we have to run tests against golden NNS/SNS state many times, each iteration will download and untar the state before doing anything meaningful. However, if we use a separate binary to watch and prepare for the next iteration, the download/untar time can be hidden behind any time needed for the user to analyze and decide what to do with the next iteration.

# What

* Refactor the download/untar operations to a library
* Use the library to implement a binary to watch a directory and untar if the state directory is taken (by the `StateMachine`)