### PR TITLE
feat(nns): Increase the _pb method failure rate to 0.7 again

### DIFF
--- a/rs/nns/governance/canister/canister.rs
+++ b/rs/nns/governance/canister/canister.rs
@@ -600,7 +600,7 @@ async fn heartbeat() {
 fn manage_neuron_pb() {
     debug_log("manage_neuron_pb");
     panic_with_probability(
-        0.1,
+        0.7,
         "manage_neuron_pb is deprecated. Please use manage_neuron instead.",
     );
 
@@ -635,7 +635,7 @@ fn list_proposals_pb() {
 fn list_neurons_pb() {
     debug_log("list_neurons_pb");
     panic_with_probability(
-        0.1,
+        0.7,
         "list_neurons_pb is deprecated. Please use list_neurons instead.",
     );
 

--- a/rs/nns/governance/unreleased_changelog.md
+++ b/rs/nns/governance/unreleased_changelog.md
@@ -18,6 +18,7 @@ on the process that this file is part of, see
   exceeding the instruction limit in a single execution.
 * Voting Rewards will be distributed asynchronously in the background after being calculated.  
   * This will allow rewards to be compatible with neurons being stored in Stable Memory. 
+* Ramp up the failure rate of _pb method to 0.7 again.
 
 ## Deprecated
 


### PR DESCRIPTION
The failure rate was 0.7: https://github.com/dfinity/ic/pull/1659 before we were notified about integrators needing more time to migrate. Now that they have migrated, ramping back to 0.7 again.