### PR TITLE
chore(sns): Remove obsolete field `airdrop_distribution`

### DIFF
--- a/rs/nns/governance/src/governance/tests/mod.rs
+++ b/rs/nns/governance/src/governance/tests/mod.rs
@@ -452,7 +452,6 @@ mod convert_from_create_service_nervous_system_to_sns_init_payload_tests {
                         total_e8s: swap_total_e8s,
                         initial_swap_amount_e8s: swap_total_e8s,
                     },),
-                    airdrop_distribution: None,
                 },
             ),
         );
@@ -794,7 +793,6 @@ mod convert_create_service_nervous_system_proposal_to_sns_init_payload_tests_wit
                         total_e8s: swap_total_e8s,
                         initial_swap_amount_e8s: swap_total_e8s,
                     },),
-                    airdrop_distribution: None,
                 },
             ),
         );

--- a/rs/nns/sns-wasm/canister/sns-wasm.did
+++ b/rs/nns/sns-wasm/canister/sns-wasm.did
@@ -7,10 +7,6 @@ type AddWasmResponse = record {
   result : opt Result;
 };
 
-type AirdropDistribution = record {
-  airdrop_neurons : vec NeuronDistribution;
-};
-
 type Canister = record {
   id : opt principal;
 };
@@ -56,9 +52,6 @@ type FractionalDeveloperVotingPower = record {
   treasury_distribution : opt TreasuryDistribution;
   developer_distribution : opt DeveloperDistribution;
   swap_distribution : opt SwapDistribution;
-
-  // Obsolete fields.
-  airdrop_distribution : opt AirdropDistribution;
 };
 
 type GetAllowedPrincipalsResponse = record {

--- a/rs/nns/sns-wasm/unreleased_changelog.md
+++ b/rs/nns/sns-wasm/unreleased_changelog.md
@@ -15,7 +15,9 @@ on the process that this file is part of, see
 
 ## Removed
 
-* Remove (previously deprecated) airdrop neurons from initial SNS configuration. `SnsInitPayload.initial_token_distribution` must not specify any neurons in `airdrop_distribution`.
+* Remove (previously deprecated) airdrop neurons from initial SNS configuration.
+
+  `SnsInitPayload.initial_token_distribution` must not specify `airdrop_distribution`.
 
 ## Fixed
 

--- a/rs/sns/init/proto/ic_sns_init/pb/v1/sns_init.proto
+++ b/rs/sns/init/proto/ic_sns_init/pb/v1/sns_init.proto
@@ -252,8 +252,8 @@ message FractionalDeveloperVotingPower {
   // The swap bucket.
   SwapDistribution swap_distribution = 3;
 
-  // OBSOLETE.
-  AirdropDistribution airdrop_distribution = 4;
+  reserved 4;
+  reserved "airdrop_distribution";
 }
 
 // The distributions awarded to developers at SNS genesis.
@@ -284,11 +284,6 @@ message SwapDistribution {
   // The initial number of tokens denominated in e8s (10E-8 of a token)
   // deposited in the swap canister's account for the initial token swap.
   uint64 initial_swap_amount_e8s = 2;
-}
-
-// OBSOLETE.
-message AirdropDistribution {
-  repeated NeuronDistribution airdrop_neurons = 1;
 }
 
 // A tuple of values used to create a Neuron available at SNS genesis.

--- a/rs/sns/init/src/create_service_nervous_system.rs
+++ b/rs/sns/init/src/create_service_nervous_system.rs
@@ -332,9 +332,6 @@ impl TryFrom<create_service_nervous_system::InitialTokenDistribution>
                 developer_distribution,
                 treasury_distribution,
                 swap_distribution,
-
-                // Obsolete fields.
-                airdrop_distribution: None,
             },
         ))
     }

--- a/rs/sns/init/src/distributions.rs
+++ b/rs/sns/init/src/distributions.rs
@@ -99,16 +99,6 @@ impl FractionalDeveloperVotingPower {
             .as_ref()
             .ok_or("Error: swap_distribution must be specified")?;
 
-        let airdrop_neurons = self
-            .airdrop_distribution
-            .clone()
-            .map(|airdrop_distribution| airdrop_distribution.airdrop_neurons)
-            .unwrap_or_default();
-
-        if !airdrop_neurons.is_empty() {
-            return Err("Error: airdrop_distribution is obsolete.".to_string());
-        }
-
         self.validate_neurons(developer_distribution, nervous_system_parameters)?;
 
         if swap_distribution.initial_swap_amount_e8s == 0 {
@@ -438,7 +428,6 @@ impl FractionalDeveloperVotingPower {
                 total_e8s: 10_000_000_000,
                 initial_swap_amount_e8s: 10_000_000_000,
             }),
-            airdrop_distribution: None,
         }
     }
 }
@@ -577,7 +566,6 @@ mod test {
                 total_e8s: swap_total,
                 initial_swap_amount_e8s: swap_initial_round,
             }),
-            airdrop_distribution: None,
         };
 
         let canister_ids = create_canister_ids();
@@ -685,7 +673,6 @@ mod test {
                 total_e8s: swap_total,
                 initial_swap_amount_e8s: swap_initial_round,
             }),
-            airdrop_distribution: None,
         };
 
         let parameters = NervousSystemParameters::with_default_values();
@@ -776,7 +763,6 @@ mod test {
                 total_e8s: 1_000_000_000,
                 initial_swap_amount_e8s: 100_000_000,
             }),
-            airdrop_distribution: None,
         };
 
         // A basic valid NervousSystemParameter
@@ -982,7 +968,6 @@ mod test {
                 total_e8s: 1_000_000_000,
                 initial_swap_amount_e8s: 100_000_000,
             }),
-            airdrop_distribution: None,
         };
 
         // A basic valid NervousSystemParameter
@@ -1030,7 +1015,6 @@ mod test {
                 total_e8s: 1_000_000_000,
                 initial_swap_amount_e8s: 100_000_000,
             }),
-            airdrop_distribution: None,
         };
 
         // A basic valid NervousSystemParameter
@@ -1096,7 +1080,6 @@ mod test {
                 total_e8s: 1_000_000_000,
                 initial_swap_amount_e8s: 100_000_000,
             }),
-            airdrop_distribution: None,
         };
 
         // A basic valid NervousSystemParameter

--- a/rs/sns/init/src/gen/ic_sns_init.pb.v1.rs
+++ b/rs/sns/init/src/gen/ic_sns_init.pb.v1.rs
@@ -274,9 +274,6 @@ pub struct FractionalDeveloperVotingPower {
     /// The swap bucket.
     #[prost(message, optional, tag = "3")]
     pub swap_distribution: ::core::option::Option<SwapDistribution>,
-    /// OBSOLETE.
-    #[prost(message, optional, tag = "4")]
-    pub airdrop_distribution: ::core::option::Option<AirdropDistribution>,
 }
 /// The distributions awarded to developers at SNS genesis.
 #[derive(
@@ -337,20 +334,6 @@ pub struct SwapDistribution {
     /// deposited in the swap canister's account for the initial token swap.
     #[prost(uint64, tag = "2")]
     pub initial_swap_amount_e8s: u64,
-}
-/// OBSOLETE.
-#[derive(
-    candid::CandidType,
-    candid::Deserialize,
-    serde::Serialize,
-    Eq,
-    Clone,
-    PartialEq,
-    ::prost::Message,
-)]
-pub struct AirdropDistribution {
-    #[prost(message, repeated, tag = "1")]
-    pub airdrop_neurons: ::prost::alloc::vec::Vec<NeuronDistribution>,
 }
 /// A tuple of values used to create a Neuron available at SNS genesis.
 #[derive(

--- a/rs/sns/init/src/lib.rs
+++ b/rs/sns/init/src/lib.rs
@@ -2241,7 +2241,6 @@ initial_token_distribution: !FractionalDeveloperVotingPower
   swap_distribution:
     total_e8s: 10000000000
     initial_swap_amount_e8s: 10000000000
-  airdrop_distribution: null
 ".to_string();
 
         assert_eq!(observed, Ok(expected));
@@ -3434,7 +3433,6 @@ initial_token_distribution: !FractionalDeveloperVotingPower
             // Not used in this test.
             developer_distribution: None,
             treasury_distribution: None,
-            airdrop_distribution: None,
         };
         let sns_init_payload = SnsInitPayload {
             max_direct_participation_icp_e8s: Some(MAX_DIRECT_ICP_CONTRIBUTION_TO_SWAP),

--- a/testnet/tools/nns-tools/sns_default_test_init_params.yml
+++ b/testnet/tools/nns-tools/sns_default_test_init_params.yml
@@ -196,7 +196,6 @@ wait_for_quiet_deadline_increase_seconds: 86400
 # The initial token distribution must satisfy the following preconditions to be valid:
 #    - developer_distribution.developer_neurons.stake_e8s.sum <= u64:MAX
 #    - developer_neurons.developer_neurons.stake_e8s.sum <= swap_distribution.total_e8s
-#    - airdrop_distribution.airdrop_neurons.stake_e8s.sum <= u64:MAX
 #    - swap_distribution.initial_swap_amount_e8s > 0
 #    - swap_distribution.initial_swap_amount_e8s <= swap_distribution.total_e8s
 #    - swap_distribution.total_e8s >= developer_distribution.developer_neurons.stake_e8s.sum
@@ -216,11 +215,6 @@ wait_for_quiet_deadline_increase_seconds: 86400
 #    - initial_swap_amount_e8s: The initial amount of tokens deposited in the Swap canister for
 #      the initial token swap.
 #
-# - airdrop_distribution has one field:
-#    - airdrop_neurons: A list of NeuronDistributions that specify the neuron's stake and
-#      controlling principal. These neurons will be available at genesis in PreInitializationSwap
-#      mode. No voting power multiplier is applied to these neurons.
-#
 # Example:
 # initial_token_distribution:
 #   FractionalDeveloperVotingPower:
@@ -239,12 +233,6 @@ wait_for_quiet_deadline_increase_seconds: 86400
 #     swap_distribution:
 #       total_e8s: 6000000000
 #       initial_swap_amount_e8s: 3000000000
-#     airdrop_distribution:
-#       airdrop_neurons:
-#         - controller: fod6j-klqsi-ljm4t-7v54x-2wd6s-6yduy-spdkk-d2vd4-iet7k-nakfi-qqe
-#           stake_e8s: 500000000
-#           memo: 0,
-#           dissolve_delay_seconds: 15780000 # 6 months
 #
 initial_token_distribution:
    FractionalDeveloperVotingPower:
@@ -259,5 +247,3 @@ initial_token_distribution:
      swap_distribution:
        total_e8s: 3000000000000
        initial_swap_amount_e8s: 3000000000000
-     airdrop_distribution:
-       airdrop_neurons: []


### PR DESCRIPTION
This PR removes the field `airdrop_distribution` from `FractionalDeveloperVotingPower` since it's now obsolete.