### PR TITLE
test(sns): Release qualification tests should take automatic target version advancement into account

### DIFF
--- a/mainnet-canister-revisions.json
+++ b/mainnet-canister-revisions.json
@@ -68,8 +68,8 @@
     "sha256": "fd25a4e2e283b498c3be1aaf63cc9b2726264d78a12b12f43ad453ceeb575e7c"
   },
   "governance": {
-    "rev": "2f17dd8c0203b12ac9d5a9c7a43534624d412728",
-    "sha256": "fb4f2abad21680b1894a8bfbb6d280f9d4cc19fe2038480beaf50aad40d85df8"
+    "rev": "ebb190bf1da0dba3e486b78c95cf5a3c5542e2f3",
+    "sha256": "d1668a798dc235587dfd3d50c0f7655b74d9360d4a5dbafd11ddc47042a7fbe4"
   },
   "index": {
     "rev": "7c6309cb5bec7ab28ed657ac7672af08a59fc1ba",
@@ -104,16 +104,16 @@
     "sha256": "36188e425f4d6d9c0e89252ed6028f6735f1911a4bbdc02312fd009a86d039b8"
   },
   "sns-wasm": {
-    "rev": "2f17dd8c0203b12ac9d5a9c7a43534624d412728",
-    "sha256": "a9af59d2dd667f312d116449a446ffb6bee05a1502212d504ecea275beb90e25"
+    "rev": "ebb190bf1da0dba3e486b78c95cf5a3c5542e2f3",
+    "sha256": "277631fb22c6f2e205f6f99ce602deab30d746193db46f75b3b69316fb031273"
   },
   "sns_archive": {
     "rev": "c741e349451edf0c9792149ad439bb32a0161371",
     "sha256": "2b0970a84976bc2eb9591b68d44501566937994fa5594972f8aac9c8b058672f"
   },
   "sns_governance": {
-    "rev": "00b04a892dfb2fee1459f1de9d4a731aa04f1ca3",
-    "sha256": "5129b3142d6bef7425fd1a88df417bbbd70edd4240eda017758e409d4f2f624c"
+    "rev": "ebb190bf1da0dba3e486b78c95cf5a3c5542e2f3",
+    "sha256": "fc28495a50286e87777b1d0a14107ad02be4722a4b7afe5bd3dc6ec44a5c345f"
   },
   "sns_index": {
     "rev": "c741e349451edf0c9792149ad439bb32a0161371",

--- a/rs/nervous_system/integration_tests/tests/sns_release_qualification.rs
+++ b/rs/nervous_system/integration_tests/tests/sns_release_qualification.rs
@@ -85,18 +85,63 @@ async fn test_deployment_swap_upgrade() {
 
 /// Upgrade Tests
 #[tokio::test]
-async fn test_upgrade_swap() {
-    test_sns_upgrade(vec![SnsCanisterType::Swap]).await;
+async fn test_upgrade_swap_auto() {
+    let automatically_advance_target_version = true;
+    test_sns_upgrade(
+        vec![SnsCanisterType::Swap],
+        automatically_advance_target_version,
+    )
+    .await;
 }
 
 #[tokio::test]
-async fn test_upgrade_sns_gov_root() {
-    test_sns_upgrade(vec![SnsCanisterType::Root, SnsCanisterType::Governance]).await;
+async fn test_upgrade_swap_no_auto() {
+    let automatically_advance_target_version = false;
+    test_sns_upgrade(
+        vec![SnsCanisterType::Swap],
+        automatically_advance_target_version,
+    )
+    .await;
 }
 
 #[tokio::test]
-async fn test_upgrade_upgrade_sns_gov_root() {
-    test_sns_upgrade(vec![SnsCanisterType::Governance, SnsCanisterType::Root]).await;
+async fn test_upgrade_sns_gov_root_auto() {
+    let automatically_advance_target_version = true;
+    test_sns_upgrade(
+        vec![SnsCanisterType::Root, SnsCanisterType::Governance],
+        automatically_advance_target_version,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn test_upgrade_sns_gov_root_no_auto() {
+    let automatically_advance_target_version = false;
+    test_sns_upgrade(
+        vec![SnsCanisterType::Root, SnsCanisterType::Governance],
+        automatically_advance_target_version,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn test_upgrade_upgrade_sns_gov_root_auto() {
+    let automatically_advance_target_version: bool = true;
+    test_sns_upgrade(
+        vec![SnsCanisterType::Governance, SnsCanisterType::Root],
+        automatically_advance_target_version,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn test_upgrade_upgrade_sns_gov_root_no_auto() {
+    let automatically_advance_target_version = false;
+    test_sns_upgrade(
+        vec![SnsCanisterType::Governance, SnsCanisterType::Root],
+        automatically_advance_target_version,
+    )
+    .await;
 }
 
 /// Tests a deployment of the SNS.

--- a/rs/nervous_system/integration_tests/tests/sns_upgrade_test_utils.rs
+++ b/rs/nervous_system/integration_tests/tests/sns_upgrade_test_utils.rs
@@ -2,11 +2,14 @@ use ic_base_types::PrincipalId;
 use ic_nervous_system_common::ONE_MONTH_SECONDS;
 use ic_nervous_system_integration_tests::{
     create_service_nervous_system_builder::CreateServiceNervousSystemBuilder,
-    pocket_ic_helpers,
     pocket_ic_helpers::{
-        await_with_timeout, hash_sns_wasms, nns, sns,
-        sns::governance::{
-            EXPECTED_UPGRADE_DURATION_MAX_SECONDS, EXPECTED_UPGRADE_STEPS_REFRESH_MAX_SECONDS,
+        self, await_with_timeout, hash_sns_wasms, nns,
+        sns::{
+            self,
+            governance::{
+                set_automatically_advance_target_version_flag,
+                EXPECTED_UPGRADE_DURATION_MAX_SECONDS, EXPECTED_UPGRADE_STEPS_REFRESH_MAX_SECONDS,
+            },
         },
     },
     SectionTimer,
@@ -16,7 +19,10 @@ use ic_sns_governance_api::pb::v1::upgrade_journal_entry;
 use ic_sns_swap::pb::v1::Lifecycle;
 use ic_sns_wasm::pb::v1::SnsCanisterType;
 
-pub async fn test_sns_upgrade(sns_canisters_to_upgrade: Vec<SnsCanisterType>) {
+pub async fn test_sns_upgrade(
+    sns_canisters_to_upgrade: Vec<SnsCanisterType>,
+    automatically_advance_target_version: bool,
+) {
     let _timer = SectionTimer::new("Testing the upgrade process");
 
     let (pocket_ic, initial_sns_version) =
@@ -80,6 +86,20 @@ pub async fn test_sns_upgrade(sns_canisters_to_upgrade: Vec<SnsCanisterType>) {
         .await;
     }
 
+    {
+        eprintln!(
+            "Set automatically_advance_target_version to {}",
+            automatically_advance_target_version
+        );
+        set_automatically_advance_target_version_flag(
+            &pocket_ic,
+            sns.governance.canister_id,
+            automatically_advance_target_version,
+        )
+        .await
+        .unwrap();
+    }
+
     let mut latest_sns_version = initial_sns_version;
 
     for upgrade_pass in 0..2 {
@@ -134,7 +154,7 @@ pub async fn test_sns_upgrade(sns_canisters_to_upgrade: Vec<SnsCanisterType>) {
             );
         }
 
-        {
+        if !automatically_advance_target_version {
             let _timer = SectionTimer::new("advance the target version to the latest version.");
             sns::governance::propose_to_advance_sns_target_version(
                 &pocket_ic,

--- a/rs/nervous_system/integration_tests/tests/upgrade_everything_test.rs
+++ b/rs/nervous_system/integration_tests/tests/upgrade_everything_test.rs
@@ -3,14 +3,35 @@ mod sns_upgrade_test_utils;
 use sns_upgrade_test_utils::test_sns_upgrade;
 
 #[tokio::test]
-async fn test_upgrade_everything() {
-    test_sns_upgrade(vec![
-        SnsCanisterType::Root,
-        SnsCanisterType::Governance,
-        SnsCanisterType::Swap,
-        SnsCanisterType::Index,
-        SnsCanisterType::Ledger,
-        SnsCanisterType::Archive,
-    ])
+async fn test_upgrade_everything_auto() {
+    let automatically_advance_target_version = true;
+    test_sns_upgrade(
+        vec![
+            SnsCanisterType::Root,
+            SnsCanisterType::Governance,
+            SnsCanisterType::Swap,
+            SnsCanisterType::Index,
+            SnsCanisterType::Ledger,
+            SnsCanisterType::Archive,
+        ],
+        automatically_advance_target_version,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn test_upgrade_everything_no_auto() {
+    let automatically_advance_target_version = false;
+    test_sns_upgrade(
+        vec![
+            SnsCanisterType::Root,
+            SnsCanisterType::Governance,
+            SnsCanisterType::Swap,
+            SnsCanisterType::Index,
+            SnsCanisterType::Ledger,
+            SnsCanisterType::Archive,
+        ],
+        automatically_advance_target_version,
+    )
     .await;
 }

--- a/rs/nervous_system/integration_tests/tests/upgrade_existing_sns_test.rs
+++ b/rs/nervous_system/integration_tests/tests/upgrade_existing_sns_test.rs
@@ -6,7 +6,9 @@ use ic_nervous_system_integration_tests::{
     create_service_nervous_system_builder::CreateServiceNervousSystemBuilder,
     pocket_ic_helpers::{
         add_wasm_via_nns_proposal, add_wasms_to_sns_wasm, install_canister, install_nns_canisters,
-        nns, sns, upgrade_nns_canister_to_tip_of_master_or_panic,
+        nns,
+        sns::{self, governance::set_automatically_advance_target_version_flag},
+        upgrade_nns_canister_to_tip_of_master_or_panic,
     },
 };
 use ic_nns_constants::{self, GOVERNANCE_CANISTER_ID, SNS_WASM_CANISTER_ID};
@@ -14,6 +16,7 @@ use ic_nns_test_utils::sns_wasm::{
     build_archive_sns_wasm, build_index_ng_sns_wasm, build_ledger_sns_wasm,
     create_modified_sns_wasm,
 };
+use ic_sns_swap::pb::v1::Lifecycle;
 use ic_sns_wasm::pb::v1::SnsCanisterType;
 use ic_test_utilities::universal_canister::UNIVERSAL_CANISTER_WASM;
 use icrc_ledger_types::{
@@ -35,6 +38,10 @@ async fn test_upgrade_existing_sns() {
             0,
         )
         .build();
+    let swap_parameters = create_service_nervous_system
+        .swap_parameters
+        .clone()
+        .unwrap();
 
     let dapp_canister_ids: Vec<_> = create_service_nervous_system
         .dapp_canisters
@@ -96,6 +103,31 @@ async fn test_upgrade_existing_sns() {
         sns_instance_label,
     )
     .await;
+
+    eprintln!("Await the swap lifecycle ...");
+    sns::swap::await_swap_lifecycle(&pocket_ic, sns.swap.canister_id, Lifecycle::Open)
+        .await
+        .unwrap();
+
+    eprintln!("smoke_test_participate_and_finalize ...");
+    sns::swap::smoke_test_participate_and_finalize(
+        &pocket_ic,
+        sns.swap.canister_id,
+        swap_parameters,
+    )
+    .await;
+
+    eprintln!(
+        "Disabling automatic upgrades to have full control over when an upgrade is triggered ..."
+    );
+    let automatically_advance_target_version = false;
+    set_automatically_advance_target_version_flag(
+        &pocket_ic,
+        sns.governance.canister_id,
+        automatically_advance_target_version,
+    )
+    .await
+    .unwrap();
 
     eprintln!("Testing the Archive canister requires that it can be spawned ...");
     sns::ensure_archive_canister_is_spawned_or_panic(


### PR DESCRIPTION
This PR adjusts the SNS qualification tests that used to trigger SNS framework upgrades via proposal. 

The reason is adjustment is needed is that these tests use the mainnet WASMs, and those have recently changed (https://dashboard.internetcomputer.org/proposal/135615). In particular, the new behavior if to have automatic target version advancement from the moment an SNS is deployed. Whereas, tests assumed the old behavior (i.e. new SNS does NOT upgrade automatically, unless someone passes a special proposal).