### PR TITLE
refactor(tests): Reorganize build_*_wasm functions

### DIFF
--- a/rs/nns/test_utils/src/common.rs
+++ b/rs/nns/test_utils/src/common.rs
@@ -310,26 +310,11 @@ pub fn modify_wasm_bytes(wasm_bytes: &[u8], modify_with: u32) -> Vec<u8> {
     new_wasm_bytes
 }
 
-/// Build Wasm for NNS Governance canister
-pub fn build_test_governance_wasm() -> Wasm {
-    let features = ["test"];
-    build_governance_wasm_with_features(&features)
-}
-/// Build Wasm for NNS Governance canister with no features
-pub fn build_governance_wasm() -> Wasm {
-    let features = [];
-    build_governance_wasm_with_features(&features)
-}
+// NOTE, keep the functions for building wasms in the same order as the constants in
+// rs/nns/constants/src/lib.rs
 
-/// Build Wasm for NNS Governance canister
-pub fn build_governance_wasm_with_features(features: &[&str]) -> Wasm {
-    Project::cargo_bin_maybe_from_env("governance-canister", features)
-}
-/// Build Wasm for NNS Root canister
-pub fn build_root_wasm() -> Wasm {
-    let features = [];
-    Project::cargo_bin_maybe_from_env("root-canister", &features)
-}
+// REGISTRY
+
 /// Build Wasm for NNS Registry canister
 pub fn build_registry_wasm() -> Wasm {
     let features = [];
@@ -340,11 +325,61 @@ pub fn build_mainnet_registry_wasm() -> Wasm {
     let features = [];
     Project::cargo_bin_maybe_from_env("mainnet-registry-canister", &features)
 }
+
+// GOVERNANCE
+
+/// Build Wasm for NNS Governance canister
+pub fn build_governance_wasm_with_features(features: &[&str]) -> Wasm {
+    Project::cargo_bin_maybe_from_env("governance-canister", features)
+}
+
+/// Build Wasm for NNS Governance canister
+pub fn build_test_governance_wasm() -> Wasm {
+    let features = ["test"];
+    build_governance_wasm_with_features(&features)
+}
+
+/// Build Wasm for NNS Governance canister with no features
+pub fn build_governance_wasm() -> Wasm {
+    let features = [];
+    build_governance_wasm_with_features(&features)
+}
+
+/// Build mainnet Wasm for NNS Governance Canister
+pub fn build_mainnet_governance_wasm() -> Wasm {
+    let features = [];
+    Project::cargo_bin_maybe_from_env("mainnet-governance-canister", &features)
+}
+
+// LEDGER
+
 /// Build Wasm for NNS Ledger canister
 pub fn build_ledger_wasm() -> Wasm {
     let features = ["notify-method"];
     Project::cargo_bin_maybe_from_env("ledger-canister", &features)
 }
+
+/// Build mainnet Wasm for NNS Ledger Canister
+pub fn build_mainnet_ledger_wasm() -> Wasm {
+    Project::cargo_bin_maybe_from_env("mainnet-icp-ledger-canister", &[])
+}
+
+// ROOT
+
+/// Build Wasm for NNS Root canister
+pub fn build_root_wasm() -> Wasm {
+    let features = [];
+    Project::cargo_bin_maybe_from_env("root-canister", &features)
+}
+
+/// Build mainnet Wasm for NNS Root Canister
+pub fn build_mainnet_root_wasm() -> Wasm {
+    let features = [];
+    Project::cargo_bin_maybe_from_env("mainnet-root-canister", &features)
+}
+
+// CYCLES-MINTING
+
 /// Build Wasm for NNS CMC
 pub fn build_cmc_wasm() -> Wasm {
     let features = [];
@@ -355,6 +390,9 @@ pub fn build_mainnet_cmc_wasm() -> Wasm {
     let features = [];
     Project::cargo_bin_maybe_from_env("mainnet-cycles-minting-canister", &features)
 }
+
+// LIFELINE
+
 /// Build Wasm for NNS Lifeline canister
 pub fn build_lifeline_wasm() -> Wasm {
     Wasm::from_location_specified_by_env_var("lifeline_canister", &[])
@@ -367,21 +405,26 @@ pub fn build_mainnet_lifeline_wasm() -> Wasm {
     Project::cargo_bin_maybe_from_env("mainnet-lifeline-canister", &features)
 }
 
+// GENESIS TOKEN
+
 /// Build Wasm for NNS Genesis Token canister
 pub fn build_genesis_token_wasm() -> Wasm {
     let features = [];
     Project::cargo_bin_maybe_from_env("genesis-token-canister", &features)
 }
+
+// IDENTITY (not used in tests yet)
+
+// NNS UI (not used in tests yet)
+
+// LEDGER ARCHIVE (not used in tests yet)
+
+// SNS WASM
+
 /// Build Wasm for NNS SnsWasm canister
 pub fn build_sns_wasms_wasm() -> Wasm {
     let features = [];
     Project::cargo_bin_maybe_from_env("sns-wasm-canister", &features)
-}
-
-/// Build Wasm for Index canister for the ICP Ledger
-pub fn build_index_wasm() -> Wasm {
-    let features = [];
-    Project::cargo_bin_maybe_from_env("ic-icp-index", &features)
 }
 
 /// Build mainnet Wasm for NNS SnsWasm canister
@@ -390,21 +433,12 @@ pub fn build_mainnet_sns_wasms_wasm() -> Wasm {
     Project::cargo_bin_maybe_from_env("mainnet-sns-wasm-canister", &features)
 }
 
-/// Build mainnet Wasm for NNS Root Canister
-pub fn build_mainnet_root_wasm() -> Wasm {
-    let features = [];
-    Project::cargo_bin_maybe_from_env("mainnet-root-canister", &features)
-}
+// LEDGER INDEX
 
-/// Build mainnet Wasm for NNS Ledger Canister
-pub fn build_mainnet_ledger_wasm() -> Wasm {
-    Project::cargo_bin_maybe_from_env("mainnet-icp-ledger-canister", &[])
-}
-
-/// Build mainnet Wasm for NNS Governance Canister
-pub fn build_mainnet_governance_wasm() -> Wasm {
+/// Build Wasm for Index canister for the ICP Ledger
+pub fn build_index_wasm() -> Wasm {
     let features = [];
-    Project::cargo_bin_maybe_from_env("mainnet-governance-canister", &features)
+    Project::cargo_bin_maybe_from_env("ic-icp-index", &features)
 }
 
 /// Build mainnet Wasm for Index canister for the ICP Ledger
@@ -412,3 +446,5 @@ pub fn build_mainnet_index_wasm() -> Wasm {
     let features = [];
     Project::cargo_bin_maybe_from_env("mainnet-ic-icp-index-canister", &features)
 }
+
+// SUBNET RENTAL (not used in tests yet)


### PR DESCRIPTION
Move the build_*_wasm functions into the same order that is in nns/constants/src/lib.rs, so that it is easier to find out if a given function exists, and to keep the file organized.