### PR TITLE
feat: new system API to retrieve liquid cycle balance of a canister

### DIFF
--- a/rs/embedders/src/wasm_utils/validation.rs
+++ b/rs/embedders/src/wasm_utils/validation.rs
@@ -558,6 +558,16 @@ fn get_valid_system_apis_common(I: ValType) -> HashMap<String, HashMap<String, F
             )],
         ),
         (
+            "canister_liquid_cycle_balance128",
+            vec![(
+                API_VERSION_IC0,
+                FunctionSignature {
+                    param_types: vec![I],
+                    return_type: vec![],
+                },
+            )],
+        ),
+        (
             "msg_cycles_available128",
             vec![(
                 API_VERSION_IC0,

--- a/rs/embedders/src/wasmtime_embedder/system_api.rs
+++ b/rs/embedders/src/wasmtime_embedder/system_api.rs
@@ -941,6 +941,23 @@ pub fn syscalls<
         .unwrap();
 
     linker
+        .func_wrap("ic0", "canister_liquid_cycle_balance128", {
+            move |mut caller: Caller<'_, StoreData>, dst: I| {
+                let dst: usize = dst.try_into().expect("Failed to convert I to usize");
+                charge_for_cpu(&mut caller, overhead::CANISTER_LIQUID_CYCLE_BALANCE128)?;
+                with_memory_and_system_api(&mut caller, |s, memory| {
+                    s.ic0_canister_liquid_cycle_balance128(dst, memory)
+                })?;
+                if feature_flags.write_barrier == FlagStatus::Enabled {
+                    mark_writes_on_bytemap(&mut caller, dst, 16)
+                } else {
+                    Ok(())
+                }
+            }
+        })
+        .unwrap();
+
+    linker
         .func_wrap("ic0", "msg_cycles_available", {
             move |mut caller: Caller<'_, StoreData>| {
                 charge_for_cpu(&mut caller, overhead::MSG_CYCLES_AVAILABLE)?;

--- a/rs/embedders/src/wasmtime_embedder/system_api_complexity.rs
+++ b/rs/embedders/src/wasmtime_embedder/system_api_complexity.rs
@@ -28,6 +28,7 @@ pub mod overhead {
     pub const CYCLES_BURN128: NumInstructions = NumInstructions::new(500);
     pub const CANISTER_CYCLE_BALANCE: NumInstructions = NumInstructions::new(500);
     pub const CANISTER_CYCLE_BALANCE128: NumInstructions = NumInstructions::new(500);
+    pub const CANISTER_LIQUID_CYCLE_BALANCE128: NumInstructions = NumInstructions::new(500);
     pub const CANISTER_SELF_COPY: NumInstructions = NumInstructions::new(500);
     pub const CANISTER_SELF_SIZE: NumInstructions = NumInstructions::new(500);
     pub const CANISTER_STATUS: NumInstructions = NumInstructions::new(500);

--- a/rs/execution_environment/src/query_handler/query_cache/tests.rs
+++ b/rs/execution_environment/src/query_handler/query_cache/tests.rs
@@ -1474,6 +1474,7 @@ fn query_cache_future_proof_test() {
         | SystemApiCallId::CallWithBestEffortResponse
         | SystemApiCallId::CanisterCycleBalance
         | SystemApiCallId::CanisterCycleBalance128
+        | SystemApiCallId::CanisterLiquidCycleBalance128
         | SystemApiCallId::CanisterSelfCopy
         | SystemApiCallId::CanisterSelfSize
         | SystemApiCallId::CanisterStatus

--- a/rs/execution_environment/tests/execution_test.rs
+++ b/rs/execution_environment/tests/execution_test.rs
@@ -3070,7 +3070,7 @@ fn test_canister_liquid_cycle_balance() {
         .execute_ingress(
             canister_id,
             "update",
-            wasm().cycles_liquid_balance128().append_and_reply().build(),
+            wasm().liquid_cycles_balance128().append_and_reply().build(),
         )
         .unwrap();
     let liquid_balance = match res {

--- a/rs/execution_environment/tests/execution_test.rs
+++ b/rs/execution_environment/tests/execution_test.rs
@@ -3116,7 +3116,7 @@ fn test_canister_liquid_cycle_balance() {
     // and that the accepted cycles are way more than that.
     let lost_cycles = liquid_balance - accepted_cycles;
     assert!(lost_cycles < 100 * B);
-    assert!(accepted_cycles > 100 * T - 100 * B);
+    assert!(accepted_cycles > INITIAL_CYCLES_BALANCE.get() - 100 * B);
 
     // Finally, we assert that the cycles have indeed moved from one universal canister to the other one.
     // The remaining balance of the sender is larger than the lost cycles by the unspent cycles in the execution of the ingress message,
@@ -3125,5 +3125,5 @@ fn test_canister_liquid_cycle_balance() {
     assert!(balance < 100 * B);
     // The receiver now holds the joint cycles balance of both canisters at the beginning minus some overhead.
     let receiver_balance = env.cycle_balance(callee);
-    assert!(receiver_balance > 200 * T - 100 * B);
+    assert!(receiver_balance > 2 * INITIAL_CYCLES_BALANCE.get() - 100 * B);
 }

--- a/rs/execution_environment/tests/execution_test.rs
+++ b/rs/execution_environment/tests/execution_test.rs
@@ -3053,3 +3053,77 @@ fn failed_stable_memory_grow_cost_and_time_multiple_canisters() {
     );
     assert!(cycles_m > 800);
 }
+
+/// Verifies that canister liquid cycle balance can be used to transfer as many cycles as possible.
+#[test]
+fn test_canister_liquid_cycle_balance() {
+    let env = StateMachine::new_with_config(StateMachineConfig::new(
+        SubnetConfig::new(SubnetType::Application),
+        HypervisorConfig::default(),
+    ));
+
+    // Install the universal canister.
+    let canister_id = create_universal_canister_with_cycles(&env, None, INITIAL_CYCLES_BALANCE);
+
+    // Read the liquid cycle balance of the universal canister.
+    let res = env
+        .execute_ingress(
+            canister_id,
+            "update",
+            wasm().cycles_liquid_balance128().append_and_reply().build(),
+        )
+        .unwrap();
+    let liquid_balance = match res {
+        WasmResult::Reply(blob) => u128::from_le_bytes(blob.try_into().unwrap()),
+        WasmResult::Reject(msg) => panic!("Unexpected reject: {}", msg),
+    };
+
+    // Install another universal canister to receive as many cycles as possible from the existing universal canister.
+    let callee = create_universal_canister_with_cycles(&env, None, INITIAL_CYCLES_BALANCE);
+
+    // Make an inter-canister call to the other universal canister attaching the maximum amount of cycles.
+    // The other universal canister accepts as many cycles as possible and replies with the actual amount of accepted cycles.
+    // The caller universal canister then forwards the actual amount of accepted cycles in the ingress message reply.
+    let res = env
+        .execute_ingress(
+            canister_id,
+            "update",
+            wasm()
+                .call_with_max_cycles(
+                    callee,
+                    "update",
+                    call_args()
+                        .other_side(
+                            wasm()
+                                .accept_cycles(u128::MAX.into())
+                                .append_and_reply()
+                                .build(),
+                        )
+                        .on_reject(wasm().reject_message().trap())
+                        .on_reply(wasm().message_payload().append_and_reply()),
+                )
+                .build(),
+        )
+        .unwrap();
+    let accepted_cycles = match res {
+        WasmResult::Reply(blob) => u128::from_le_bytes(blob.try_into().unwrap()),
+        WasmResult::Reject(msg) => panic!("Unexpected reject: {}", msg),
+    };
+    assert!(0 < accepted_cycles && accepted_cycles < liquid_balance);
+
+    // Lost cycles consist of the cost of an inter-canister call and the cost of an ingress message.
+    // We assert that the lost cycles are less than 100B (this value was derived by printing the actual value in the test and rounding up)
+    // and that the accepted cycles are way more than that.
+    let lost_cycles = liquid_balance - accepted_cycles;
+    assert!(lost_cycles < 100 * B);
+    assert!(accepted_cycles > 100 * T - 100 * B);
+
+    // Finally, we assert that the cycles have indeed moved from one universal canister to the other one.
+    // The remaining balance of the sender is larger than the lost cycles by the unspent cycles in the execution of the ingress message,
+    // but still less than 100B.
+    let balance = env.cycle_balance(canister_id);
+    assert!(balance < 100 * B);
+    // The receiver now holds the joint cycles balance of both canisters at the beginning minus some overhead.
+    let receiver_balance = env.cycle_balance(callee);
+    assert!(receiver_balance > 200 * T - 100 * B);
+}

--- a/rs/interfaces/src/execution_environment.rs
+++ b/rs/interfaces/src/execution_environment.rs
@@ -146,6 +146,8 @@ pub enum SystemApiCallId {
     CanisterCycleBalance,
     /// Tracker for `ic0.canister_cycle_balance128()`
     CanisterCycleBalance128,
+    /// Tracker for `ic0.canister_liquid_cycle_balance128()`
+    CanisterLiquidCycleBalance128,
     /// Tracker for `ic0.canister_self_copy()`
     CanisterSelfCopy,
     /// Tracker for `ic0.canister_self_size()`
@@ -268,6 +270,8 @@ pub struct SystemApiCallCounters {
     pub canister_cycle_balance: usize,
     /// Counter for `ic0.canister_cycle_balance128()`
     pub canister_cycle_balance128: usize,
+    /// Counter for `ic0.canister_liquid_cycle_balance128()`
+    pub canister_liquid_cycle_balance128: usize,
     /// Counter for `ic0.time()`
     pub time: usize,
 }
@@ -283,6 +287,9 @@ impl SystemApiCallCounters {
         self.canister_cycle_balance128 = self
             .canister_cycle_balance128
             .saturating_add(rhs.canister_cycle_balance128);
+        self.canister_liquid_cycle_balance128 = self
+            .canister_liquid_cycle_balance128
+            .saturating_add(rhs.canister_liquid_cycle_balance128);
         self.time = self.time.saturating_add(rhs.time);
     }
 }
@@ -1025,6 +1032,18 @@ pub trait SystemApi {
     /// and is copied in the canister memory starting
     /// starting at the location `dst`.
     fn ic0_canister_cycle_balance128(
+        &mut self,
+        dst: usize,
+        heap: &mut [u8],
+    ) -> HypervisorResult<()>;
+
+    /// This system call indicates the current liquid cycle balance
+    /// of the canister that the canister can spend without getting frozen.
+    ///
+    /// The amount of cycles is represented by a 128-bit value
+    /// and is copied in the canister memory starting
+    /// starting at the location `dst`.
+    fn ic0_canister_liquid_cycle_balance128(
         &mut self,
         dst: usize,
         heap: &mut [u8],

--- a/rs/system_api/src/lib.rs
+++ b/rs/system_api/src/lib.rs
@@ -3107,6 +3107,42 @@ impl SystemApi for SystemApiImpl {
         result
     }
 
+    fn ic0_canister_liquid_cycle_balance128(
+        &mut self,
+        dst: usize,
+        heap: &mut [u8],
+    ) -> HypervisorResult<()> {
+        self.call_counters.canister_liquid_cycle_balance128 += 1;
+        let method_name = "ic0_canister_liquid_cycle_balance128";
+        let result = match &self.api_type {
+            ApiType::Start { .. } => Err(self.error_for(method_name)),
+            ApiType::Init { .. }
+            | ApiType::SystemTask { .. }
+            | ApiType::Update { .. }
+            | ApiType::Cleanup { .. }
+            | ApiType::ReplicatedQuery { .. }
+            | ApiType::NonReplicatedQuery { .. }
+            | ApiType::PreUpgrade { .. }
+            | ApiType::ReplyCallback { .. }
+            | ApiType::RejectCallback { .. }
+            | ApiType::InspectMessage { .. } => {
+                let cycles = self.sandbox_safe_system_state.liquid_cycles_balance(
+                    self.memory_usage.current_usage,
+                    self.memory_usage.current_message_usage,
+                );
+                copy_cycles_to_heap(cycles, dst, heap, method_name)?;
+                Ok(())
+            }
+        };
+        trace_syscall!(
+            self,
+            CanisterLiquidCycleBalance128,
+            dst,
+            summarize(heap, dst, 16)
+        );
+        result
+    }
+
     fn ic0_msg_cycles_available(&self) -> HypervisorResult<u64> {
         let result = {
             let (high_amount, low_amount) = self

--- a/rs/system_api/src/sandbox_safe_system_state.rs
+++ b/rs/system_api/src/sandbox_safe_system_state.rs
@@ -858,6 +858,27 @@ impl SandboxSafeSystemState {
         cycles_change.apply(self.initial_cycles_balance)
     }
 
+    /// Computes the current liquid main balance of the canister that the canister can spend
+    /// without getting frozen based on the initial value and the changes during the execution.
+    pub(super) fn liquid_cycles_balance(
+        &self,
+        current_memory_usage: NumBytes,
+        current_message_memory_usage: MessageMemoryUsage,
+    ) -> Cycles {
+        let cycles = self.cycles_balance();
+        let threshold = self.cycles_account_manager.freeze_threshold_cycles(
+            self.freeze_threshold,
+            self.memory_allocation,
+            current_memory_usage,
+            current_message_memory_usage,
+            self.compute_allocation,
+            self.subnet_size,
+            self.reserved_balance(),
+        );
+        // Here we rely on the saturating subtraction for Cycles.
+        cycles - threshold
+    }
+
     /// Computes the current reserved balance of the canister based
     /// on the initial value and the changes during the execution.
     pub(super) fn reserved_balance(&self) -> Cycles {

--- a/rs/system_api/tests/system_api.rs
+++ b/rs/system_api/tests/system_api.rs
@@ -269,6 +269,7 @@ fn is_supported(api_type: SystemApiCallId, context: &str) -> bool {
         SystemApiCallId::CanisterSelfCopy => vec!["*"],
         SystemApiCallId::CanisterCycleBalance => vec!["*"],
         SystemApiCallId::CanisterCycleBalance128 => vec!["*"],
+        SystemApiCallId::CanisterLiquidCycleBalance128 => vec!["*"],
         SystemApiCallId::CanisterStatus => vec!["*"],
         SystemApiCallId::CanisterVersion => vec!["*"],
         SystemApiCallId::MsgMethodNameSize => vec!["F"],
@@ -639,6 +640,16 @@ fn api_availability_test(
         SystemApiCallId::CanisterCycleBalance128 => {
             assert_api_availability(
                 |mut api| api.ic0_canister_cycle_balance128(0, &mut [42; 128]),
+                api_type,
+                &system_state,
+                cycles_account_manager,
+                api_type_enum,
+                context,
+            );
+        }
+        SystemApiCallId::CanisterLiquidCycleBalance128 => {
+            assert_api_availability(
+                |mut api| api.ic0_canister_liquid_cycle_balance128(0, &mut [42; 128]),
                 api_type,
                 &system_state,
                 cycles_account_manager,

--- a/rs/test_utilities/embedders/src/lib.rs
+++ b/rs/test_utilities/embedders/src/lib.rs
@@ -33,6 +33,7 @@ pub struct WasmtimeInstanceBuilder {
     network_topology: NetworkTopology,
     config: ic_config::embedders::Config,
     canister_memory_limit: NumBytes,
+    memory_usage: NumBytes,
 }
 
 impl Default for WasmtimeInstanceBuilder {
@@ -47,6 +48,7 @@ impl Default for WasmtimeInstanceBuilder {
             network_topology: NetworkTopology::default(),
             config: ic_config::embedders::Config::default(),
             canister_memory_limit: NumBytes::from(4 << 30), // Set to 4 GiB by default
+            memory_usage: NumBytes::from(0),
         }
     }
 }
@@ -103,6 +105,13 @@ impl WasmtimeInstanceBuilder {
         }
     }
 
+    pub fn with_memory_usage(self, memory_usage: NumBytes) -> Self {
+        Self {
+            memory_usage,
+            ..self
+        }
+    }
+
     pub fn try_build(self) -> Result<WasmtimeInstance, (HypervisorError, SystemApiImpl)> {
         let log = no_op_logger();
 
@@ -145,7 +154,7 @@ impl WasmtimeInstanceBuilder {
         let api = ic_system_api::SystemApiImpl::new(
             self.api_type,
             sandbox_safe_system_state,
-            ic_types::NumBytes::from(0),
+            self.memory_usage,
             ic_replicated_state::MessageMemoryUsage::ZERO,
             ExecutionParameters {
                 instruction_limits: InstructionLimits::new(

--- a/rs/universal_canister/impl/src/api.rs
+++ b/rs/universal_canister/impl/src/api.rs
@@ -34,6 +34,7 @@ mod ic0 {
         pub fn msg_cycles_accept128(max_amount_high: u64, max_amount_low: u64, dst: u32) -> ();
         pub fn canister_cycle_balance() -> u64;
         pub fn canister_cycle_balance128(dst: u32) -> ();
+        pub fn canister_liquid_cycle_balance128(dst: u32) -> ();
         pub fn trap(offset: u32, size: u32) -> !;
         pub fn call_new(
             callee_src: u32,
@@ -296,6 +297,12 @@ pub fn balance() -> u64 {
 pub fn balance128() -> Vec<u8> {
     let mut bytes = vec![0u8; CYCLES_SIZE];
     unsafe { ic0::canister_cycle_balance128(bytes.as_mut_ptr() as u32) }
+    bytes
+}
+
+pub fn liquid_balance128() -> Vec<u8> {
+    let mut bytes = vec![0u8; CYCLES_SIZE];
+    unsafe { ic0::canister_liquid_cycle_balance128(bytes.as_mut_ptr() as u32) }
     bytes
 }
 

--- a/rs/universal_canister/impl/src/lib.rs
+++ b/rs/universal_canister/impl/src/lib.rs
@@ -119,5 +119,7 @@ try_from_u8!(
         CostSignWithEcdsa = 89,
         CostSignWithSchnorr = 90,
         CostVetkdDeriveEncryptedKey = 91,
+        LiquidCyclesBalance128 = 92,
+        CallCyclesAddMax = 93,
     }
 );

--- a/rs/universal_canister/impl/src/lib.rs
+++ b/rs/universal_canister/impl/src/lib.rs
@@ -120,6 +120,6 @@ try_from_u8!(
         CostSignWithSchnorr = 90,
         CostVetkdDeriveEncryptedKey = 91,
         LiquidCyclesBalance128 = 92,
-        CallCyclesAddMax = 93,
+        CallDataAppendCyclesAddMax = 93,
     }
 );

--- a/rs/universal_canister/impl/src/main.rs
+++ b/rs/universal_canister/impl/src/main.rs
@@ -486,9 +486,11 @@ fn eval(ops_bytes: OpsBytes) {
                 }
             }
             Ops::LiquidCyclesBalance128 => stack.push_blob(api::liquid_balance128()),
-            Ops::CallCyclesAddMax => {
-                let payload_size = stack.pop_int64();
+            Ops::CallDataAppendCyclesAddMax => {
                 let method_name_size = stack.pop_int64();
+                let payload = stack.pop_blob();
+                api::call_data_append(&payload);
+                let payload_size = payload.len() as u64;
                 let cost_call = u128::from_le_bytes(
                     api::cost_call(method_name_size, payload_size)
                         .try_into()

--- a/rs/universal_canister/impl/src/main.rs
+++ b/rs/universal_canister/impl/src/main.rs
@@ -485,6 +485,22 @@ fn eval(ops_bytes: OpsBytes) {
                     )),
                 }
             }
+            Ops::LiquidCyclesBalance128 => stack.push_blob(api::liquid_balance128()),
+            Ops::CallCyclesAddMax => {
+                let payload_size = stack.pop_int64();
+                let method_name_size = stack.pop_int64();
+                let cost_call = u128::from_le_bytes(
+                    api::cost_call(method_name_size, payload_size)
+                        .try_into()
+                        .unwrap(),
+                );
+                let liquid_balance =
+                    u128::from_le_bytes(api::liquid_balance128().try_into().unwrap());
+                let balance = liquid_balance.saturating_sub(cost_call);
+                let amount_low = (balance & 0xffff_ffff_ffff_ffff) as u64;
+                let amount_high = (balance >> 64) as u64;
+                api::call_cycles_add128(amount_high, amount_low)
+            }
         }
     }
 }

--- a/rs/universal_canister/lib/src/lib.rs
+++ b/rs/universal_canister/lib/src/lib.rs
@@ -744,7 +744,7 @@ impl PayloadBuilder {
     }
 
     /// Push `blob` with canister liquid cycles balance.
-    pub fn cycles_liquid_balance128(mut self) -> Self {
+    pub fn liquid_cycles_balance128(mut self) -> Self {
         self.0.push(Ops::LiquidCyclesBalance128 as u8);
         self
     }


### PR DESCRIPTION
This PR implements a new system API `ic0.canister_liquid_cycle_balance128` returning the current amount of cycles that is available for spending in calls and execution without getting frozen. This way, canisters can bound the amount of cycles attached to a call to prevent spurious traps when calling `ic0.call_cycles_add` or `ic0.call_cycles_add128`.