### PR TITLE
chore(IDX): don't create buf bins in PWD

### DIFF
--- a/pre-commit/check-incompatibilities.sh
+++ b/pre-commit/check-incompatibilities.sh
@@ -12,9 +12,16 @@ MERGE_BASE=${MERGE_BASE_SHA:-HEAD}
 BUF="$(readlink "$buf_path")"
 CONF="$(readlink "$buf_config")"
 REPO_PATH="$(dirname "$(readlink "$WORKSPACE")")"
+
+tempdir=$(mktemp -d)
+against="$tempdir/against.bin"
+current="$tempdir/current.bin"
+
+trap "rm -rf '$tempdir'" EXIT
+
 cd "$REPO_PATH"
 
-"$BUF" build -o current.bin
-"$BUF" build ".git#ref=$MERGE_BASE" -o against.bin
+"$BUF" build -o "$current"
+"$BUF" build ".git#ref=$MERGE_BASE" -o "$against"
 
-"$BUF" breaking current.bin --against against.bin --config="$CONF"
+"$BUF" breaking "$current" --against "$against" --config="$CONF"


### PR DESCRIPTION
This tweaks the buf incompatibility checks to use temporary dirs instead of creating temporary files in the source tree.