### PR TITLE
chore(IDX): drop reverse did test

### DIFF
--- a/bazel/candid.bzl
+++ b/bazel/candid.bzl
@@ -36,15 +36,7 @@ echo DID_PATH={did_path}
 
 {check_did} {did_path} "$tmpfile"
 echo "{did_path} passed candid checks"
-
-# In addition to the usual `didc check after.did before.did` it can be helpful to check the reverse as well.
-# This is This is useful when it is expected that clients will "jump the gun", i.e. upgrade before servers.
-# This is an unusual (but not unheard of) use case.
-if [ {enable_also_reverse} = True ]; then
-    echo "running also-reverse check"
-    {check_did} "$tmpfile" {did_path}
-fi
-    """.format(check_did = check_did.short_path, did_path = ctx.file.did.path, enable_also_reverse = ctx.attr.enable_also_reverse)
+    """.format(check_did = check_did.short_path, did_path = ctx.file.did.path)
 
     ctx.actions.write(output = ctx.outputs.executable, content = script)
 
@@ -67,7 +59,6 @@ _did_git_test = rule(
     implementation = _did_git_test_impl,
     attrs = {
         "did": attr.label(allow_single_file = True),
-        "enable_also_reverse": attr.bool(default = False),
         "_check_did": CHECK_DID,
         "_git": attr.label(allow_single_file = True, default = "//:.git"),
     },
@@ -81,7 +72,6 @@ def did_git_test(name, did, **kwargs):
       name: the test name.
       did: the Candid file, must be a repository file.
       **kwargs: additional keyword arguments to pass to the test rule.
-            enable_also_reverse (bool, optional): whether the test should also run candid checks in reverse order
     """
     kwargs.setdefault("tags", ["local", "no-sandbox", "smoke"])
     _did_git_test(name = name, did = did, **kwargs)

--- a/bazel/candid_integration_tests/BUILD.bazel
+++ b/bazel/candid_integration_tests/BUILD.bazel
@@ -7,13 +7,6 @@ did_git_test(
     tags = ["manual"],  # only executed as part of candid_integration_tests
 )
 
-did_git_test(
-    name = "example_did_git_test_also_reverse",
-    did = ":example.did",
-    enable_also_reverse = True,
-    tags = ["manual"],  # only executed as part of candid_integration_tests
-)
-
 genrule(
     name = "create_new_did_file",
     srcs = [":example.did"],


### PR DESCRIPTION
This removes the `enable_also_reverse` option of candid tests. The option wasn't used.