### PR TITLE
fix: extracting of sampling period for power measurements

### DIFF
--- a/ic-os/components/hostos-scripts/monitoring/monitor-power.sh
+++ b/ic-os/components/hostos-scripts/monitoring/monitor-power.sh
@@ -38,8 +38,7 @@ write_line() {
     #    Minimum during sampling period:                132 Watts
     #    Maximum during sampling period:                384 Watts
     #    Average power reading over sample period:      204 Watts
-    #    IPMI timestamp:                           Thu Dec  1 20:05:44 2022
-    #    Sampling period:                          00000005 Seconds.
+    #    IPMI timestamp:                           03/06/2025 07:40:35 PM UTC    Sampling period:                          00000001 Seconds.
     #    Power reading state is:                   activated
 
     ipmi_output="$(ipmitool dcmi power reading 2>/dev/null)"
@@ -58,7 +57,7 @@ write_line() {
         "Average power reading, Watts" \
         "gauge"
 
-    value=$(echo "${ipmi_output}" | grep "Sampling period:" | awk '{print $3}')
+    value=$(echo "${ipmi_output}" | grep "Sampling period:" | awk '{print $9}')
     value=${value:-"-1"}
     write_line "sampling_period_seconds" \
         "${value}" \


### PR DESCRIPTION
The output of the IPMI tool changed. Now, both the IPMI timestamp and the Sampling period are on the same line. With that the script was actually extracting the date. The affected nodes were encountering the following issue:
```
ts=2025-03-06T12:12:11.776Z caller=textfile.go:245 level=error collector=textfile msg="failed to collect textfile data" file=power_metrics.prom err="failed to parse textfile data from \"/run/node_exporter/collector_textfile/power_metrics.prom\": text format parsing error in line 11: expected float as value, got \"03/06/25\""
```