### PR TITLE
Verify that we can add oneof to RegistryValue.

### DIFF
--- a/rs/nns/integration_tests/src/upgrade_canisters_with_golden_nns_state.rs
+++ b/rs/nns/integration_tests/src/upgrade_canisters_with_golden_nns_state.rs
@@ -271,6 +271,7 @@ fn test_upgrade_canisters_with_golden_nns_state() {
         Ok(WasmResult::Reply(ok)) => ok,
         _ => panic!("{:?}", result),
     };
+    use candid::Decode;
     println!();
     println!();
     println!("{}", Decode!(&result, String).unwrap());

--- a/rs/nns/integration_tests/src/upgrade_canisters_with_golden_nns_state.rs
+++ b/rs/nns/integration_tests/src/upgrade_canisters_with_golden_nns_state.rs
@@ -16,6 +16,7 @@ use ic_nns_test_utils::{
     },
 };
 use ic_nns_test_utils_golden_nns_state::new_state_machine_with_golden_nns_state_or_panic;
+use ic_types::ingress::WasmResult;
 use std::{
     env,
     fmt::{Debug, Formatter},
@@ -142,6 +143,7 @@ fn test_upgrade_canisters_with_golden_nns_state() {
     // Step 0: Read configuration. To wit, what canisters does the user want to upgrade in this
     // test? To do this, they set the NNS_CANISTER_UPGRADE_SEQUENCE environment variable.
 
+    /*
     let mut nns_canister_upgrade_sequence = env::var("NNS_CANISTER_UPGRADE_SEQUENCE").expect(
         "This test requires that the NNS_CANISTER_UPGRADE_SEQUENCE environment\n\
              variable to be set to something like 'governance,registry'.\n\
@@ -165,6 +167,8 @@ fn test_upgrade_canisters_with_golden_nns_state() {
         ]
         .join(",");
     }
+     */
+    let nns_canister_upgrade_sequence = "registry";
 
     let mut nns_canister_upgrade_sequence = nns_canister_upgrade_sequence
         .split(',')
@@ -258,10 +262,27 @@ fn test_upgrade_canisters_with_golden_nns_state() {
 
     perform_sequence_of_upgrades(&nns_canister_upgrade_sequence);
 
+    let result = state_machine.execute_ingress(
+        REGISTRY_CANISTER_ID,
+        "assert_RegistryValue_survives_round_trip",
+        Encode!().unwrap(),
+    );
+    let result = match result {
+        Ok(WasmResult::Reply(ok)) => ok,
+        _ => panic!("{:?}", result),
+    };
+    println!();
+    println!();
+    println!("{}", Decode!(&result, String).unwrap());
+    println!();
+    println!();
+
     // Modify all WASMs, but preserve their behavior.
+    /*
     for nns_canister_upgrade in &mut nns_canister_upgrade_sequence {
         nns_canister_upgrade.modify_wasm_but_preserve_behavior();
     }
 
     perform_sequence_of_upgrades(&nns_canister_upgrade_sequence);
+    */
 }

--- a/rs/registry/canister/canister/canister.rs
+++ b/rs/registry/canister/canister/canister.rs
@@ -22,7 +22,7 @@ use ic_registry_transport::{
     pb::v1::{
         registry_error::Code, CertifiedResponse, RegistryAtomicMutateResponse, RegistryError,
         RegistryGetChangesSinceRequest, RegistryGetChangesSinceResponse,
-        RegistryGetLatestVersionResponse, RegistryGetValueResponse,
+        RegistryGetLatestVersionResponse, RegistryGetValueResponse, RegistryValueV2, RegistryValue,
     },
     serialize_atomic_mutate_response, serialize_get_changes_since_response,
     serialize_get_value_response,
@@ -200,6 +200,29 @@ fn canister_post_upgrade() {
 }
 
 ic_nervous_system_common_build_metadata::define_get_build_metadata_candid_method! {}
+
+#[export_name = "canister_query assert_RegistryValue_survives_round_trip"]
+fn assert_it_works() {
+    over(candid, |_: ()| -> String{
+        let mut count = 0;
+        for values in registry().store().values() {
+            for v in values {
+                let blob = v.encode_to_vec();
+                let v2 = RegistryValueV2::decode(blob.as_slice()).unwrap();
+                let blob = v2.encode_to_vec();
+                let copy = RegistryValue::decode(blob.as_slice()).unwrap();
+                /*pretty_assertions::*/assert_eq!(&copy, v);
+
+                count += 1;
+                if count % 250 == 0 {
+                    println!("Number of RegistryValues verified: {}", count);
+                }
+            }
+        }
+
+        "Yay!".to_string()
+    });
+}
 
 #[export_name = "canister_query get_changes_since"]
 fn get_changes_since() {

--- a/rs/registry/canister/src/registry.rs
+++ b/rs/registry/canister/src/registry.rs
@@ -101,6 +101,10 @@ impl Registry {
         Self::default()
     }
 
+    pub fn store(&self) -> &RegistryMap {
+        &self.store
+    }
+
     /// Returns the deltas applied since `version`, exclusive; optionally
     /// limited to the subsequent `max_versions` (i.e. changes applied in
     /// versions `(version, version + max_versions]`).

--- a/rs/registry/transport/proto/ic_registry_transport/pb/v1/transport.proto
+++ b/rs/registry/transport/proto/ic_registry_transport/pb/v1/transport.proto
@@ -79,6 +79,20 @@ message RegistryValue {
   bool deletion_marker = 3;
 }
 
+message RegistryValueV2 {
+  uint64 version = 2;
+
+  oneof content {
+    bytes value = 1;
+    bool deletion_marker = 3;
+    LargeValueChunkKeys large_value_chunk_keys = 4;
+  }
+}
+
+message LargeValueChunkKeys {
+  repeated bytes chunk_content_sha256s = 1;
+}
+
 // A sequence of changes made to a key in the registry.
 message RegistryDelta {
   bytes key = 1;

--- a/rs/registry/transport/src/gen/ic_registry_transport.pb.v1.rs
+++ b/rs/registry/transport/src/gen/ic_registry_transport.pb.v1.rs
@@ -83,6 +83,30 @@ pub struct RegistryValue {
     #[prost(bool, tag = "3")]
     pub deletion_marker: bool,
 }
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct RegistryValueV2 {
+    #[prost(uint64, tag = "2")]
+    pub version: u64,
+    #[prost(oneof = "registry_value_v2::Content", tags = "1, 3, 4")]
+    pub content: ::core::option::Option<registry_value_v2::Content>,
+}
+/// Nested message and enum types in `RegistryValueV2`.
+pub mod registry_value_v2 {
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    pub enum Content {
+        #[prost(bytes, tag = "1")]
+        Value(::prost::alloc::vec::Vec<u8>),
+        #[prost(bool, tag = "3")]
+        DeletionMarker(bool),
+        #[prost(message, tag = "4")]
+        LargeValueChunkKeys(super::LargeValueChunkKeys),
+    }
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct LargeValueChunkKeys {
+    #[prost(bytes = "vec", repeated, tag = "1")]
+    pub chunk_content_sha256s: ::prost::alloc::vec::Vec<::prost::alloc::vec::Vec<u8>>,
+}
 /// A sequence of changes made to a key in the registry.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RegistryDelta {


### PR DESCRIPTION
There is no intention to merge this. This PR exists just to share code.

More precisely, this shows that moving both the `value` and `deletion_marker` fields into the new oneof would not result in data loss. This is verified by doing a "round trip" conversion (from RegistryValue to RegistryValueV2 and back to RegistryValue), and comparing to the original object.

Golden data is used.

To run this,

```
bazel test \
    --test_env=SSH_AUTH_SOCK \
    --test_output=streamed \
    --test_arg=--nocapture \
    //rs/nns/integration_tests:upgrade_canisters_with_golden_nns_state
```

This maybe also means that we could just drop the `deletion_marker` field later. Deletion would simply be indicated by the absence of all the (two remaining) fields in the oneof. (In Prost generated Rust, the struct field corresponding to the oneof would simply contain None, instead of Some in the case of a deletion.)