### PR TITLE
fix(nns): Avoid applying approve_genesis_kyc for more than 1000 neurons

### DIFF
--- a/rs/nns/governance/src/neuron_store.rs
+++ b/rs/nns/governance/src/neuron_store.rs
@@ -29,7 +29,7 @@ use ic_nns_common::pb::v1::{NeuronId, ProposalId};
 use icp_ledger::{AccountIdentifier, Subaccount};
 use std::{
     borrow::Cow,
-    collections::{BTreeMap, BTreeSet, HashMap},
+    collections::{BTreeMap, BTreeSet, HashMap, HashSet},
     fmt::{Debug, Display, Formatter},
     ops::{Bound, Deref, RangeBounds},
 };
@@ -1436,6 +1436,52 @@ pub fn groom_some_neurons(
             return next;
         }
     }
+}
+
+/// Approves KYC for the neurons with the given principals. Returns an error if the number of
+/// neurons to approve KYC for exceeds the maximum allowed, in which case no neurons are approved.
+pub fn approve_genesis_kyc(
+    neuron_store: &mut NeuronStore,
+    principals: &[PrincipalId],
+) -> Result<(), GovernanceError> {
+    const APPROVE_GENESIS_KYC_MAX_NEURONS: usize = 1000;
+
+    let principal_set: HashSet<PrincipalId> = principals.iter().cloned().collect();
+    let neuron_id_to_principal = principal_set
+        .into_iter()
+        .flat_map(|principal| {
+            neuron_store
+                .get_neuron_ids_readable_by_caller(principal)
+                .into_iter()
+                .map(move |neuron_id| (neuron_id, principal))
+        })
+        .collect::<HashMap<_, _>>();
+
+    if neuron_id_to_principal.len() > APPROVE_GENESIS_KYC_MAX_NEURONS {
+        return Err(GovernanceError::new_with_message(
+            ErrorType::PreconditionFailed,
+            format!(
+                "ApproveGenesisKyc can only change the KYC status of up to {} neurons at a time",
+                APPROVE_GENESIS_KYC_MAX_NEURONS
+            ),
+        ));
+    }
+
+    for (neuron_id, principal) in neuron_id_to_principal {
+        let result = neuron_store.with_neuron_mut(&neuron_id, |neuron| {
+            if neuron.controller() == principal {
+                neuron.kyc_verified = true;
+            }
+        });
+        // Log errors but continue with the rest of the neurons.
+        if let Err(e) = result {
+            eprintln!(
+                "{}ERROR: Failed to approve KYC for neuron {:?}: {:?}",
+                LOG_PREFIX, neuron_id, e
+            );
+        }
+    }
+    Ok(())
 }
 
 /// Number of entries for each neuron indexes (in stable storage)

--- a/rs/nns/governance/src/neuron_store/neuron_store_tests.rs
+++ b/rs/nns/governance/src/neuron_store/neuron_store_tests.rs
@@ -1122,3 +1122,145 @@ fn test_get_full_neuron() {
         })
     );
 }
+
+#[test]
+fn test_approve_genesis_kyc() {
+    let principal_1 = PrincipalId::new_self_authenticating(b"SID1");
+    let principal_2 = PrincipalId::new_self_authenticating(b"SID2");
+    let principal_3 = PrincipalId::new_self_authenticating(b"SID3");
+    let neuron_1 = simple_neuron_builder(1)
+        .with_controller(principal_1)
+        .with_kyc_verified(false)
+        .build();
+    let neuron_2 = simple_neuron_builder(2)
+        .with_controller(principal_2)
+        .with_kyc_verified(false)
+        .build();
+    let neuron_3 = simple_neuron_builder(3)
+        .with_controller(principal_2)
+        .with_kyc_verified(false)
+        .build();
+    let neuron_4 = simple_neuron_builder(4)
+        .with_controller(principal_3)
+        .with_kyc_verified(false)
+        .build();
+    let mut neuron_store = NeuronStore::new(btreemap! {
+        neuron_1.id().id => neuron_1.clone(),
+        neuron_2.id().id => neuron_2.clone(),
+        neuron_3.id().id => neuron_3.clone(),
+        neuron_4.id().id => neuron_4.clone(),
+    });
+    // Before calling `approve_genesis_kyc`, none of the neurons have KYC verified.
+    assert!(!neuron_store
+        .with_neuron(&neuron_1.id(), |n| n.kyc_verified)
+        .unwrap());
+    assert!(!neuron_store
+        .with_neuron(&neuron_2.id(), |n| n.kyc_verified)
+        .unwrap());
+    assert!(!neuron_store
+        .with_neuron(&neuron_3.id(), |n| n.kyc_verified)
+        .unwrap());
+    assert!(!neuron_store
+        .with_neuron(&neuron_4.id(), |n| n.kyc_verified)
+        .unwrap());
+
+    // Approve KYC for neuron_1, neuron_2 and neuron_3.
+    approve_genesis_kyc(&mut neuron_store, &[principal_1, principal_2]).unwrap();
+
+    assert!(neuron_store
+        .with_neuron(&neuron_1.id(), |n| n.kyc_verified)
+        .unwrap());
+    assert!(neuron_store
+        .with_neuron(&neuron_2.id(), |n| n.kyc_verified)
+        .unwrap());
+    assert!(neuron_store
+        .with_neuron(&neuron_3.id(), |n| n.kyc_verified)
+        .unwrap());
+    assert!(!neuron_store
+        .with_neuron(&neuron_4.id(), |n| n.kyc_verified)
+        .unwrap());
+}
+
+// Prepares `num_neurons_same_controller` neurons with the same controller and
+// `num_neurons_diff_controllers` neurons with different controllers.
+fn prepare_neurons_for_kyc(
+    num_neurons_same_controller: u64,
+    num_neurons_diff_controllers: u64,
+) -> (Vec<Neuron>, Vec<PrincipalId>) {
+    let mut neurons = Vec::new();
+    let principal_id = PrincipalId::new_self_authenticating(b"SID");
+    let mut principal_ids = hashset! { principal_id };
+    for id in 1..=num_neurons_same_controller {
+        let neuron = simple_neuron_builder(id)
+            .with_controller(principal_id)
+            .with_kyc_verified(false)
+            .build();
+        neurons.push(neuron);
+    }
+    for id in (num_neurons_same_controller + 1)
+        ..=(num_neurons_same_controller + num_neurons_diff_controllers)
+    {
+        let neuron = simple_neuron_builder(id).with_kyc_verified(false).build();
+        principal_ids.insert(neuron.controller());
+        neurons.push(neuron);
+    }
+    (neurons, principal_ids.into_iter().collect())
+}
+
+#[test]
+fn test_approve_genesis_kyc_cap_not_exceeded() {
+    let mut neuron_store = NeuronStore::new(BTreeMap::new());
+    // Set up 1000 neurons that should be KYC verified.
+    let (neurons, principal_ids) = prepare_neurons_for_kyc(500, 500);
+    for neuron in &neurons {
+        neuron_store.add_neuron(neuron.clone()).unwrap();
+    }
+    // Set up a neuron that should not be KYC verified.
+    let neuron_should_not_have_kyc_verified =
+        simple_neuron_builder(1001).with_kyc_verified(false).build();
+    neuron_store
+        .add_neuron(neuron_should_not_have_kyc_verified.clone())
+        .unwrap();
+
+    // Approve KYC for 1000 neurons.
+    approve_genesis_kyc(&mut neuron_store, &principal_ids).unwrap();
+
+    // All 1000 neurons should have KYC verified.
+    for neuron in &neurons {
+        assert!(neuron_store
+            .with_neuron(&neuron.id(), |n| n.kyc_verified)
+            .unwrap());
+    }
+
+    // The neuron with id 1001 should not have KYC verified.
+    assert!(!neuron_store
+        .with_neuron(&neuron_should_not_have_kyc_verified.id(), |n| n
+            .kyc_verified)
+        .unwrap());
+}
+
+#[test]
+fn test_approve_genesis_kyc_cap_exceeded() {
+    let mut neuron_store = NeuronStore::new(BTreeMap::new());
+    let (neurons, principal_ids) = prepare_neurons_for_kyc(500, 501);
+    for neuron in &neurons {
+        neuron_store.add_neuron(neuron.clone()).unwrap();
+    }
+
+    // Approve KYC for 1001 neurons.
+    let result = approve_genesis_kyc(&mut neuron_store, &principal_ids);
+    assert_eq!(
+        result,
+        Err(GovernanceError::new_with_message(
+            ErrorType::PreconditionFailed,
+            "ApproveGenesisKyc can only change the KYC status of up to 1000 neurons at a time",
+        ),)
+    );
+
+    // None of the neurons should have KYC verified.
+    for neuron in &neurons {
+        assert!(!neuron_store
+            .with_neuron(&neuron.id(), |n| n.kyc_verified)
+            .unwrap());
+    }
+}

--- a/rs/nns/governance/tests/governance.rs
+++ b/rs/nns/governance/tests/governance.rs
@@ -4860,7 +4860,7 @@ fn test_approve_kyc() {
         .with_neuron(&NeuronId::from_u64(4), |n| n.kyc_verified)
         .expect("Neuron not found"));
 
-    gov.approve_genesis_kyc(&[principal1, principal2]);
+    gov.approve_genesis_kyc(&[principal1, principal2]).unwrap();
 
     assert!(gov
         .neuron_store

--- a/rs/nns/governance/unreleased_changelog.md
+++ b/rs/nns/governance/unreleased_changelog.md
@@ -25,4 +25,6 @@ on the process that this file is part of, see
 
 ## Fixed
 
+* Avoid applying `approve_genesis_kyc` to an unbounded number of neurons, but at most 1000 neurons.
+
 ## Security


### PR DESCRIPTION
# Why

Currently, the execution of `ApproveGenesisKyc` proposals don't have a bound. However unlikely, it's possible for such proposals to get through. It's not a big issue now since changing neurons have lower instruction cost. However, after neurons are migrated to stable memory, this can become a problem.

# What

Apply a limit of 1000 for the maximum number of neurons to set `kyc_verified`. This should be safe as `with_neuron_mut` should take ~5M instructions at maximum. Also, we don't expect a single kyc to apply to 1000 neurons.