### PR TITLE
feat(nns): Re-enable neuron migration

### DIFF
--- a/rs/nns/governance/canbench/canbench_results.yml
+++ b/rs/nns/governance/canbench/canbench_results.yml
@@ -25,8 +25,8 @@ benches:
     scopes: {}
   add_neuron_inactive_maximum:
     total:
-      instructions: 112621770
-      heap_increase: 1
+      instructions: 114741030
+      heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   add_neuron_inactive_typical:
@@ -169,7 +169,7 @@ benches:
     scopes: {}
   range_neurons_performance:
     total:
-      instructions: 55874297
+      instructions: 83788874
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}

--- a/rs/nns/governance/src/lib.rs
+++ b/rs/nns/governance/src/lib.rs
@@ -207,7 +207,7 @@ thread_local! {
 
     static USE_STABLE_MEMORY_FOLLOWING_INDEX: Cell<bool> = const { Cell::new(true) };
 
-    static MIGRATE_ACTIVE_NEURONS_TO_STABLE_MEMORY: Cell<bool> = const { Cell::new(cfg!(feature = "test")) };
+    static MIGRATE_ACTIVE_NEURONS_TO_STABLE_MEMORY: Cell<bool> = const { Cell::new(true) };
 }
 
 thread_local! {

--- a/rs/nns/governance/unreleased_changelog.md
+++ b/rs/nns/governance/unreleased_changelog.md
@@ -10,6 +10,17 @@ on the process that this file is part of, see
 ## Added
 
 * Collect metrics about timer tasks defined using ic_nervous_system_timer_task library.
+* Re-enable neuron migration to stable memory:
+  * Setting `MIGRATE_ACTIVE_NEURONS_TO_STABLE_MEMORY` to true, which will cause active neurons
+  to be continously moved from heap memory to stable memory.
+  * Compared to the last time it was enabled, several improvements were made:
+    * Distribute rewards is moved to timer, and has a mechanism to distribute in batches in
+    multiple messages.
+    * Unstaking maturity task has a limit of 100 neurons per message, which prevents it from 
+    exceeding instruction limit.
+    * The execution of `ApproveGenesisKyc` proposals have a limit of 1000 neurons, above which
+    the proposal will fail.
+    * More benchmarks were added.
 
 ## Changed
 

--- a/rs/nns/integration_tests/src/governance_migrations.rs
+++ b/rs/nns/integration_tests/src/governance_migrations.rs
@@ -81,8 +81,8 @@ fn test_neuron_migration_from_heap_to_stable() {
         "governance_garbage_collectable_neurons_count",
         0,
     );
-    assert_metric(&state_machine, "governance_heap_neuron_count", 1);
-    assert_metric(&state_machine, "governance_stable_memory_neuron_count", 0);
+    assert_metric(&state_machine, "governance_heap_neuron_count", 0);
+    assert_metric(&state_machine, "governance_stable_memory_neuron_count", 1);
 
     // Advance time and disburse the neuron so that it's empty.
     nns_start_dissolving(&state_machine, test_user_principal, neuron_id).unwrap();


### PR DESCRIPTION
# Why

Re-enable neuron migration to stable memory after several improvements were made:

* Compared to the last time it was enabled, several improvements were made:
* Distribute rewards is moved to timer, and has a mechanism to distribute in batches in multiple messages.
* Unstaking maturity task has a limit of 100 neurons per message, which prevents it from exceeding instruction limit.
* The execution of `ApproveGenesisKyc` proposals have a limit of 1000 neurons, above which the proposal will fail.
* More benchmarks were added.

# What

* Set `MIGRATE_ACTIVE_NEURONS_TO_STABLE_MEMORY` to true, which will cause active neurons to be continously moved from heap memory to stable memory in timers.
* Update benchmarks:
  * The regression of `range_neurons_performance` is expected, since the benchmark loops through all neurons in stable memory, and this feature will cause more neurons to be in the stable memory.
  * The decrease in heap memory for `add_neuron_inactive_maximum` is just some variance due to how heap memory is measured in canbench
* The test in `governance_migrations.rs` is no longer meaningful, since after the flag `MIGRATE_ACTIVE_NEURONS_TO_STABLE_MEMORY` is set to true, before the canister is initialized, no migration will happen, since the neurons will always be in the stable memory.