### PR TITLE
feat(BOUN-1364): ic-boundary: make self-health-checking more smart

### DIFF
--- a/rs/boundary_node/ic_boundary/src/check/test.rs
+++ b/rs/boundary_node/ic_boundary/src/check/test.rs
@@ -99,7 +99,7 @@ fn check_result(height: u64) -> CheckResult {
 }
 
 // Ensure that nodes that have failed healthcheck or lag behind are excluded
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test]
 async fn test_check_some_unhealthy() -> Result<(), Error> {
     let routes = Arc::new(ArcSwapOption::empty());
     let persister = Arc::new(Persister::new(Arc::clone(&routes)));
@@ -162,7 +162,7 @@ async fn test_check_some_unhealthy() -> Result<(), Error> {
 }
 
 // Ensure that when nodes are removed from routing table -> they're removed from the resulting lookup table
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test]
 async fn test_check_nodes_gone() -> Result<(), Error> {
     let routes = Arc::new(ArcSwapOption::empty());
     let persister = Arc::new(Persister::new(Arc::clone(&routes)));
@@ -250,7 +250,7 @@ async fn test_check_nodes_gone() -> Result<(), Error> {
     Ok(())
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test]
 async fn test_runner() -> Result<(), Error> {
     let mut checker = MockCheck::new();
     checker.expect_check().returning(|_| Ok(check_result(1000)));

--- a/rs/boundary_node/ic_boundary/src/cli.rs
+++ b/rs/boundary_node/ic_boundary/src/cli.rs
@@ -40,8 +40,8 @@ pub struct Cli {
     #[command(flatten, next_help_heading = "Registry")]
     pub registry: Registry,
 
-    #[command(flatten, next_help_heading = "Health Checking")]
-    pub health: HealthChecks,
+    #[command(flatten, next_help_heading = "Health")]
+    pub health: Health,
 
     #[command(flatten, next_help_heading = "Observability")]
     pub obs: Observability,
@@ -149,7 +149,7 @@ pub struct Network {
 }
 
 #[derive(Args)]
-pub struct HealthChecks {
+pub struct Health {
     /// How frequently to run health checks
     #[clap(env, long, default_value = "1s", value_parser = parse_duration)]
     pub health_check_interval: Duration,
@@ -167,6 +167,14 @@ pub struct HealthChecks {
     /// Maximum block height lag for a replica to be included in the routing table
     #[clap(env, long, default_value = "50")]
     pub health_max_height_lag: u64,
+
+    /// Fraction of nodes that should be healthy in the subnet to consider the subnet healthy
+    #[clap(env, long, default_value = "0.6666")]
+    pub health_nodes_per_subnet_alive_threshold: f64,
+
+    /// Fraction of subnets that should be healthy to consider our node healthy
+    #[clap(env, long, default_value = "0.51")]
+    pub health_subnets_alive_threshold: f64,
 }
 
 #[derive(Args)]

--- a/rs/boundary_node/ic_boundary/src/core.rs
+++ b/rs/boundary_node/ic_boundary/src/core.rs
@@ -838,6 +838,8 @@ pub fn setup_router(
         http_client.clone(),
         Arc::clone(&routing_table),
         Arc::clone(&registry_snapshot),
+        cli.health.health_subnets_alive_threshold,
+        cli.health.health_nodes_per_subnet_alive_threshold,
     );
 
     let proxy_router = Arc::new(proxy_router);

--- a/rs/boundary_node/ic_boundary/src/routes.rs
+++ b/rs/boundary_node/ic_boundary/src/routes.rs
@@ -413,8 +413,6 @@ impl RootKey for ProxyRouter {
 
 impl Health for ProxyRouter {
     fn health(&self) -> ReplicaHealthStatus {
-        // Return healthy state if we have at least one healthy replica node
-        // TODO increase threshold? change logic?
         match (
             self.published_routes.load_full(),
             self.published_registry_snapshot.load_full(),

--- a/rs/boundary_node/ic_boundary/src/routes.rs
+++ b/rs/boundary_node/ic_boundary/src/routes.rs
@@ -326,14 +326,12 @@ pub trait Lookup: Sync + Send {
     fn lookup_subnet_by_id(&self, id: &SubnetId) -> Result<Arc<RouteSubnet>, ErrorCause>;
 }
 
-#[async_trait]
 pub trait Health: Sync + Send {
-    async fn health(&self) -> ReplicaHealthStatus;
+    fn health(&self) -> ReplicaHealthStatus;
 }
 
-#[async_trait]
 pub trait RootKey: Sync + Send {
-    async fn root_key(&self) -> Option<Vec<u8>>;
+    fn root_key(&self) -> Option<Vec<u8>>;
 }
 
 // Router that helps handlers do their job by looking up in routing table
@@ -343,6 +341,8 @@ pub struct ProxyRouter {
     http_client: Arc<dyn HttpClient>,
     published_routes: Arc<ArcSwapOption<Routes>>,
     published_registry_snapshot: Arc<ArcSwapOption<RegistrySnapshot>>,
+    subnets_alive_threshold: f64,
+    nodes_per_subnet_alive_threshold: f64,
 }
 
 impl ProxyRouter {
@@ -350,11 +350,15 @@ impl ProxyRouter {
         http_client: Arc<dyn HttpClient>,
         published_routes: Arc<ArcSwapOption<Routes>>,
         published_registry_snapshot: Arc<ArcSwapOption<RegistrySnapshot>>,
+        subnets_alive_threshold: f64,
+        nodes_per_subnet_alive_threshold: f64,
     ) -> Self {
         Self {
             http_client,
             published_routes,
             published_registry_snapshot,
+            subnets_alive_threshold,
+            nodes_per_subnet_alive_threshold,
         }
     }
 }
@@ -399,23 +403,46 @@ impl Lookup for ProxyRouter {
     }
 }
 
-#[async_trait]
 impl RootKey for ProxyRouter {
-    async fn root_key(&self) -> Option<Vec<u8>> {
+    fn root_key(&self) -> Option<Vec<u8>> {
         self.published_registry_snapshot
             .load_full()
             .map(|x| x.nns_public_key.clone())
     }
 }
 
-#[async_trait]
 impl Health for ProxyRouter {
-    async fn health(&self) -> ReplicaHealthStatus {
+    fn health(&self) -> ReplicaHealthStatus {
         // Return healthy state if we have at least one healthy replica node
         // TODO increase threshold? change logic?
-        match self.published_routes.load_full() {
-            Some(rt) => {
-                if rt.node_count > 0 {
+        match (
+            self.published_routes.load_full(),
+            self.published_registry_snapshot.load_full(),
+        ) {
+            (Some(rt), Some(snap)) => {
+                // Count the number of healthy subnets
+                let healthy_subnets_count = snap
+                    .subnets
+                    .iter()
+                    .filter(|&subnet| {
+                        // Get number of nodes in this subnet from the active routing table.
+                        // If, for some reason, the subnet isn't there (it should be) - assume the number is 0
+                        let healthy_nodes = rt
+                            .subnet_map
+                            .get(&subnet.id)
+                            .map(|x| x.nodes.len())
+                            .unwrap_or_default();
+
+                        // See if this subnet can be considered healthy
+                        (healthy_nodes as f64) / (subnet.nodes.len() as f64)
+                            >= self.nodes_per_subnet_alive_threshold
+                    })
+                    .count();
+
+                // See if we have enough healthy subnets to consider ourselves healthy
+                if (healthy_subnets_count as f64) / (snap.subnets.len() as f64)
+                    >= self.subnets_alive_threshold
+                {
                     ReplicaHealthStatus::Healthy
                 } else {
                     // There's no generic "Unhealthy" state it seems, should we use Starting?
@@ -424,7 +451,7 @@ impl Health for ProxyRouter {
             }
 
             // Usually this is only for the first 10sec after startup
-            None => ReplicaHealthStatus::Starting,
+            _ => ReplicaHealthStatus::Starting,
         }
     }
 }
@@ -771,7 +798,7 @@ pub async fn postprocess_response(request: Request, next: Next) -> impl IntoResp
 
 // Handler: emit an HTTP status code that signals the service's state
 pub async fn health(State(h): State<Arc<dyn Health>>) -> impl IntoResponse {
-    if h.health().await == ReplicaHealthStatus::Healthy {
+    if h.health() == ReplicaHealthStatus::Healthy {
         StatusCode::NO_CONTENT
     } else {
         StatusCode::SERVICE_UNAVAILABLE
@@ -782,10 +809,10 @@ pub async fn health(State(h): State<Arc<dyn Health>>) -> impl IntoResponse {
 pub async fn status(
     State((rk, h)): State<(Arc<dyn RootKey>, Arc<dyn Health>)>,
 ) -> impl IntoResponse {
-    let health = h.health().await;
+    let health = h.health();
 
     let status = HttpStatusResponse {
-        root_key: rk.root_key().await.map(|x| x.into()),
+        root_key: rk.root_key().map(|x| x.into()),
         impl_version: None,
         impl_hash: None,
         replica_health_status: Some(health),

--- a/rs/boundary_node/ic_boundary/src/routes/test.rs
+++ b/rs/boundary_node/ic_boundary/src/routes/test.rs
@@ -264,43 +264,6 @@ async fn test_middleware_validate_subnet_request() -> Result<(), Error> {
     Ok(())
 }
 
-// #[tokio::test]
-// async fn test_health() -> Result<(), Error> {
-//     let root_key = vec![8, 6, 7, 5, 3, 0, 9];
-
-//     let proxy_router = Arc::new(TestProxyRouter {
-//         root_key: root_key.clone(),
-//         health: Arc::new(Mutex::new(ReplicaHealthStatus::Healthy)),
-//     });
-
-//     let state_health = proxy_router.clone() as Arc<dyn Health>;
-//     let mut app = Router::new().route(PATH_HEALTH, get(health).with_state(state_health));
-
-//     // Test healthy
-//     let request = Request::builder()
-//         .method("GET")
-//         .uri("http://localhost/health")
-//         .body(Body::from(""))
-//         .unwrap();
-
-//     let resp = app.call(request).await.unwrap();
-//     assert_eq!(resp.status(), StatusCode::NO_CONTENT);
-
-//     // Test starting
-//     proxy_router.set_health(ReplicaHealthStatus::Starting);
-
-//     let request = Request::builder()
-//         .method("GET")
-//         .uri("http://localhost/health")
-//         .body(Body::from(""))
-//         .unwrap();
-
-//     let resp = app.call(request).await.unwrap();
-//     assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
-
-//     Ok(())
-// }
-
 #[tokio::test]
 async fn test_health() -> Result<(), Error> {
     let published_routes = Arc::new(ArcSwapOption::empty());

--- a/rs/boundary_node/ic_boundary/src/routes/test.rs
+++ b/rs/boundary_node/ic_boundary/src/routes/test.rs
@@ -1,12 +1,9 @@
 use super::*;
 
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
 use anyhow::Error;
-use axum::{
-    body::Body, http::Request, middleware, response::IntoResponse, routing::method_routing::get,
-    Router,
-};
+use axum::{body::Body, http::Request, middleware, routing::method_routing::get, Router};
 use ethnum::u256;
 use http::header::{
     HeaderName, HeaderValue, CONTENT_TYPE, X_CONTENT_TYPE_OPTIONS, X_FRAME_OPTIONS,
@@ -18,14 +15,13 @@ use ic_types::{
     },
     PrincipalId,
 };
-use prometheus::Registry;
 use tower::{Service, ServiceBuilder};
 use tower_http::{request_id::MakeRequestUuid, ServiceBuilderExt};
 
 use crate::{
-    metrics::{metrics_middleware_status, HttpMetricParamsStatus},
-    persist::test::node,
-    test_utils::setup_test_router,
+    persist::{test::node, Persist, Persister},
+    snapshot::test::test_registry_snapshot,
+    test_utils::{setup_test_router, TestHttpClient},
 };
 
 pub fn test_node(id: u64) -> Arc<Node> {
@@ -64,54 +60,6 @@ fn assert_header(headers: &http::HeaderMap, name: HeaderName, expected_value: &s
         name,
         expected_value,
     );
-}
-
-#[derive(Clone)]
-struct ProxyRouter {
-    root_key: Vec<u8>,
-    health: Arc<Mutex<ReplicaHealthStatus>>,
-}
-
-impl ProxyRouter {
-    fn set_health(&self, new: ReplicaHealthStatus) {
-        let mut h = self.health.lock().unwrap();
-        *h = new;
-    }
-}
-
-#[async_trait]
-impl Proxy for ProxyRouter {
-    async fn proxy(&self, _request: Request<Body>, _url: Url) -> Result<Response, ErrorCause> {
-        let mut resp = "test_response".into_response();
-
-        let status = StatusCode::OK;
-
-        *resp.status_mut() = status;
-        Ok(resp)
-    }
-}
-
-impl Lookup for ProxyRouter {
-    fn lookup_subnet_by_canister_id(&self, _: &CanisterId) -> Result<Arc<RouteSubnet>, ErrorCause> {
-        Ok(Arc::new(test_route_subnet(1)))
-    }
-    fn lookup_subnet_by_id(&self, _: &SubnetId) -> Result<Arc<RouteSubnet>, ErrorCause> {
-        Ok(Arc::new(test_route_subnet(1)))
-    }
-}
-
-#[async_trait]
-impl RootKey for ProxyRouter {
-    async fn root_key(&self) -> Option<Vec<u8>> {
-        Some(self.root_key.clone())
-    }
-}
-
-#[async_trait]
-impl Health for ProxyRouter {
-    async fn health(&self) -> ReplicaHealthStatus {
-        *self.health.lock().unwrap()
-    }
 }
 
 #[tokio::test]
@@ -316,14 +264,63 @@ async fn test_middleware_validate_subnet_request() -> Result<(), Error> {
     Ok(())
 }
 
+// #[tokio::test]
+// async fn test_health() -> Result<(), Error> {
+//     let root_key = vec![8, 6, 7, 5, 3, 0, 9];
+
+//     let proxy_router = Arc::new(TestProxyRouter {
+//         root_key: root_key.clone(),
+//         health: Arc::new(Mutex::new(ReplicaHealthStatus::Healthy)),
+//     });
+
+//     let state_health = proxy_router.clone() as Arc<dyn Health>;
+//     let mut app = Router::new().route(PATH_HEALTH, get(health).with_state(state_health));
+
+//     // Test healthy
+//     let request = Request::builder()
+//         .method("GET")
+//         .uri("http://localhost/health")
+//         .body(Body::from(""))
+//         .unwrap();
+
+//     let resp = app.call(request).await.unwrap();
+//     assert_eq!(resp.status(), StatusCode::NO_CONTENT);
+
+//     // Test starting
+//     proxy_router.set_health(ReplicaHealthStatus::Starting);
+
+//     let request = Request::builder()
+//         .method("GET")
+//         .uri("http://localhost/health")
+//         .body(Body::from(""))
+//         .unwrap();
+
+//     let resp = app.call(request).await.unwrap();
+//     assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
+
+//     Ok(())
+// }
+
 #[tokio::test]
 async fn test_health() -> Result<(), Error> {
-    let root_key = vec![8, 6, 7, 5, 3, 0, 9];
+    let published_routes = Arc::new(ArcSwapOption::empty());
+    let published_registry_snapshot = Arc::new(ArcSwapOption::empty());
 
-    let proxy_router = Arc::new(ProxyRouter {
-        root_key: root_key.clone(),
-        health: Arc::new(Mutex::new(ReplicaHealthStatus::Healthy)),
-    });
+    let persister = Persister::new(published_routes.clone());
+    let (snapshot, _, _) = test_registry_snapshot(5, 3);
+    published_registry_snapshot.store(Some(Arc::new(snapshot.clone())));
+
+    let http_client = Arc::new(TestHttpClient(1));
+    let proxy_router = Arc::new(ProxyRouter::new(
+        http_client,
+        published_routes,
+        published_registry_snapshot,
+        0.51,
+        0.6666,
+    ));
+
+    // Initial state
+    assert_eq!(proxy_router.health(), ReplicaHealthStatus::Starting);
 
     let state_health = proxy_router.clone() as Arc<dyn Health>;
     let mut app = Router::new().route(PATH_HEALTH, get(health).with_state(state_health));
@@ -336,11 +333,13 @@ async fn test_health() -> Result<(), Error> {
         .unwrap();
 
     let resp = app.call(request).await.unwrap();
-    assert_eq!(resp.status(), StatusCode::NO_CONTENT);
+    assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
 
-    // Test starting
-    proxy_router.set_health(ReplicaHealthStatus::Starting);
+    // Check when all nodes healthy
+    persister.persist(snapshot.subnets.clone());
+    assert_eq!(proxy_router.health(), ReplicaHealthStatus::Healthy);
 
+    // Test healthy
     let request = Request::builder()
         .method("GET")
         .uri("http://localhost/health")
@@ -348,37 +347,158 @@ async fn test_health() -> Result<(), Error> {
         .unwrap();
 
     let resp = app.call(request).await.unwrap();
-    assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
+    assert_eq!(resp.status(), StatusCode::NO_CONTENT);
+
+    // Check when 3/5 subnets present (> threshold)
+    let subnets = snapshot
+        .subnets
+        .clone()
+        .into_iter()
+        .enumerate()
+        .filter(|(i, _)| *i <= 2)
+        .map(|x| x.1)
+        .collect::<Vec<_>>();
+
+    persister.persist(subnets);
+    assert_eq!(proxy_router.health(), ReplicaHealthStatus::Healthy);
+
+    // Check when 2/5 subnets present (< threshold)
+    let subnets = snapshot
+        .subnets
+        .clone()
+        .into_iter()
+        .enumerate()
+        .filter(|(i, _)| *i <= 1)
+        .map(|x| x.1)
+        .collect::<Vec<_>>();
+    persister.persist(subnets);
+
+    assert_eq!(
+        proxy_router.health(),
+        ReplicaHealthStatus::CertifiedStateBehind
+    );
+
+    // Check when 2/3 nodes in each subnet are healthy (> threshold)
+    let subnets = snapshot
+        .subnets
+        .clone()
+        .into_iter()
+        .map(|mut x| {
+            x.nodes = x
+                .nodes
+                .into_iter()
+                .enumerate()
+                .filter(|(i, _)| *i <= 1)
+                .map(|x| x.1)
+                .collect::<Vec<_>>();
+            x
+        })
+        .collect::<Vec<_>>();
+
+    persister.persist(subnets);
+    assert_eq!(proxy_router.health(), ReplicaHealthStatus::Healthy);
+
+    // Check when 1/3 nodes in each subnet are healthy (< threshold)
+    let subnets = snapshot
+        .subnets
+        .clone()
+        .into_iter()
+        .map(|mut x| {
+            x.nodes = vec![x.nodes[0].clone()];
+            x
+        })
+        .collect::<Vec<_>>();
+    persister.persist(subnets);
+    assert_eq!(
+        proxy_router.health(),
+        ReplicaHealthStatus::CertifiedStateBehind
+    );
+
+    // Check when 2/3 nodes in 3/5 subnets are available (> threshold) and 1/3 nodes in 2/5 subnets (< threshold)
+    let subnets = snapshot
+        .subnets
+        .clone()
+        .into_iter()
+        .enumerate()
+        .map(|(i, mut x)| {
+            if i > 2 {
+                x.nodes = vec![x.nodes[0].clone()];
+            } else {
+                x.nodes = vec![x.nodes[0].clone(), x.nodes[1].clone()];
+            }
+
+            x
+        })
+        .collect::<Vec<_>>();
+    persister.persist(subnets);
+    assert_eq!(proxy_router.health(), ReplicaHealthStatus::Healthy);
+
+    // Check when 1/3 nodes in 3/5 subnets are available (< threshold) and 2/3 nodes in 2/5 subnets (> threshold)
+    let subnets = snapshot
+        .subnets
+        .clone()
+        .into_iter()
+        .enumerate()
+        .map(|(i, mut x)| {
+            if i > 2 {
+                x.nodes = vec![x.nodes[0].clone(), x.nodes[1].clone()];
+            } else {
+                x.nodes = vec![x.nodes[0].clone()];
+            }
+
+            x
+        })
+        .collect::<Vec<_>>();
+    persister.persist(subnets);
+    assert_eq!(
+        proxy_router.health(),
+        ReplicaHealthStatus::CertifiedStateBehind
+    );
 
     Ok(())
 }
 
 #[tokio::test]
 async fn test_status() -> Result<(), Error> {
-    let root_key = vec![8, 6, 7, 5, 3, 0, 9];
+    const ROOT_KEY: &[u8] = &[
+        48, 129, 130, 48, 29, 6, 13, 43, 6, 1, 4, 1, 130, 220, 124, 5, 3, 1, 2, 1, 6, 12, 43, 6, 1,
+        4, 1, 130, 220, 124, 5, 3, 2, 1, 3, 97, 0, 164, 11, 155, 160, 188, 41, 117, 229, 63, 252,
+        167, 119, 29, 30, 227, 98, 237, 74, 46, 188, 146, 183, 47, 146, 73, 22, 138, 98, 134, 4,
+        227, 191, 162, 241, 66, 98, 49, 165, 59, 251, 105, 165, 137, 20, 84, 15, 168, 196, 17, 178,
+        140, 45, 29, 63, 7, 53, 150, 40, 122, 4, 40, 149, 203, 233, 231, 66, 46, 244, 167, 99, 183,
+        61, 131, 19, 223, 201, 237, 51, 94, 24, 59, 178, 188, 224, 198, 44, 183, 41, 121, 43, 119,
+        84, 128, 45, 105, 10,
+    ];
 
-    let proxy_router = Arc::new(ProxyRouter {
-        root_key: root_key.clone(),
-        health: Arc::new(Mutex::new(ReplicaHealthStatus::Healthy)),
-    });
+    let published_routes = Arc::new(ArcSwapOption::empty());
+    let published_registry_snapshot = Arc::new(ArcSwapOption::empty());
+
+    let persister = Persister::new(published_routes.clone());
+    let (mut snapshot, _, _) = test_registry_snapshot(5, 3);
+    snapshot.nns_public_key = ROOT_KEY.into();
+    published_registry_snapshot.store(Some(Arc::new(snapshot.clone())));
+
+    let http_client = Arc::new(TestHttpClient(1));
+    let proxy_router = Arc::new(ProxyRouter::new(
+        http_client,
+        published_routes,
+        published_registry_snapshot,
+        0.51,
+        0.6666,
+    ));
+
+    // Mark all nodes healthy
+    persister.persist(snapshot.subnets.clone());
 
     let (state_rootkey, state_health) = (
         proxy_router.clone() as Arc<dyn RootKey>,
         proxy_router.clone() as Arc<dyn Health>,
     );
 
-    let registry: Registry = Registry::new_custom(None, None)?;
-    let metric_params = HttpMetricParamsStatus::new(&registry);
-
-    let mut app = Router::new()
-        .route(
-            PATH_STATUS,
-            get(status).with_state((state_rootkey, state_health)),
-        )
-        .layer(middleware::from_fn_with_state(
-            metric_params,
-            metrics_middleware_status,
-        ));
+    let mut app = Router::new().route(
+        PATH_STATUS,
+        get(status).with_state((state_rootkey, state_health)),
+    );
 
     // Test healthy
     let request = Request::builder()
@@ -402,37 +522,7 @@ async fn test_status() -> Result<(), Error> {
         health.replica_health_status,
         Some(ReplicaHealthStatus::Healthy)
     );
-    assert_eq!(health.root_key.as_deref(), Some(&root_key),);
-
-    let headers = parts.headers;
-    assert_header(&headers, CONTENT_TYPE, "application/cbor");
-    assert_header(&headers, X_CONTENT_TYPE_OPTIONS, "nosniff");
-    assert_header(&headers, X_FRAME_OPTIONS, "DENY");
-
-    // Test starting
-    proxy_router.set_health(ReplicaHealthStatus::Starting);
-
-    let request = Request::builder()
-        .method("GET")
-        .uri("http://localhost/api/v2/status")
-        .body(Body::from(""))
-        .unwrap();
-
-    let resp = app.call(request).await.unwrap();
-
-    assert_eq!(resp.status(), StatusCode::OK);
-
-    let (parts, body) = resp.into_parts();
-    let body = axum::body::to_bytes(body, usize::MAX)
-        .await
-        .unwrap()
-        .to_vec();
-
-    let health: HttpStatusResponse = serde_cbor::from_slice(&body)?;
-    assert_eq!(
-        health.replica_health_status,
-        Some(ReplicaHealthStatus::Starting)
-    );
+    assert_eq!(health.root_key.as_deref(), Some(&ROOT_KEY.to_vec()));
 
     let headers = parts.headers;
     assert_header(&headers, CONTENT_TYPE, "application/cbor");

--- a/rs/boundary_node/ic_boundary/src/snapshot/test.rs
+++ b/rs/boundary_node/ic_boundary/src/snapshot/test.rs
@@ -2,6 +2,7 @@ use super::*;
 use crate::test_utils::{create_fake_registry_client, valid_tls_certificate_and_validation_time};
 use ic_registry_routing_table::CanisterIdRange;
 
+#[allow(clippy::type_complexity)]
 pub fn test_registry_snapshot(
     subnets: usize,
     nodes_per_subnet: usize,

--- a/rs/boundary_node/ic_boundary/src/snapshot/test.rs
+++ b/rs/boundary_node/ic_boundary/src/snapshot/test.rs
@@ -1,19 +1,35 @@
 use super::*;
-
 use crate::test_utils::{create_fake_registry_client, valid_tls_certificate_and_validation_time};
+use ic_registry_routing_table::CanisterIdRange;
 
-#[tokio::test]
-async fn test_routing_table() -> Result<(), Error> {
+pub fn test_registry_snapshot(
+    subnets: usize,
+    nodes_per_subnet: usize,
+) -> (
+    RegistrySnapshot,
+    Vec<(NodeId, String)>,
+    Vec<(SubnetId, CanisterIdRange)>,
+) {
     let snapshot = Arc::new(ArcSwapOption::empty());
 
-    let (reg, nodes, ranges) = create_fake_registry_client(4, 1, None);
+    let (reg, nodes, ranges) = create_fake_registry_client(subnets, nodes_per_subnet, None);
     let reg = Arc::new(reg);
 
     let (channel_send, _) = watch::channel(None);
     let mut snapshotter =
         Snapshotter::new(Arc::clone(&snapshot), channel_send, reg, Duration::ZERO);
-    snapshotter.snapshot()?;
-    let snapshot = snapshot.load_full().unwrap();
+    snapshotter.snapshot().unwrap();
+
+    (
+        snapshot.load_full().unwrap().as_ref().clone(),
+        nodes,
+        ranges,
+    )
+}
+
+#[tokio::test]
+async fn test_routing_table() -> Result<(), Error> {
+    let (snapshot, nodes, ranges) = test_registry_snapshot(4, 1);
 
     assert_eq!(snapshot.version, 1);
     assert_eq!(snapshot.subnets.len(), 4);

--- a/rs/boundary_node/ic_boundary/src/test_utils.rs
+++ b/rs/boundary_node/ic_boundary/src/test_utils.rs
@@ -34,7 +34,6 @@ use ic_types::{
     CanisterId, RegistryVersion, SubnetId,
 };
 use prometheus::Registry;
-use rand::Rng;
 use reqwest;
 
 use crate::{
@@ -55,7 +54,7 @@ macro_rules! principal {
 pub use principal;
 
 #[derive(Debug)]
-struct TestHttpClient(usize);
+pub struct TestHttpClient(pub usize);
 
 #[async_trait]
 impl HttpClient for TestHttpClient {
@@ -74,10 +73,9 @@ impl HttpClient for TestHttpClient {
     }
 }
 
-fn new_random_certified_data() -> Digest {
-    let mut random_certified_data: [u8; 32] = [0; 32];
-    rand::thread_rng().fill(&mut random_certified_data);
-    Digest(random_certified_data)
+fn new_certified_data() -> Digest {
+    let data: [u8; 32] = [0; 32];
+    Digest(data)
 }
 
 pub fn valid_tls_certificate_and_validation_time() -> (X509PublicKeyCert, Time) {
@@ -107,7 +105,7 @@ pub fn valid_tls_certificate_and_validation_time() -> (X509PublicKeyCert, Time) 
 pub fn new_threshold_key() -> ThresholdSigPublicKey {
     let (_, pk, _) = CertificateBuilder::new(CanisterData {
         canister_id: CanisterId::from_u64(1),
-        certified_data: new_random_certified_data(),
+        certified_data: new_certified_data(),
     })
     .build();
 

--- a/rs/pocket_ic_server/src/pocket_ic.rs
+++ b/rs/pocket_ic_server/src/pocket_ic.rs
@@ -1,5 +1,5 @@
 use crate::state_api::state::{HasStateLabel, OpOut, PocketIcError, StateLabel};
-use crate::{async_trait, copy_dir, BlobStore, OpId, Operation, SubnetBlockmaker};
+use crate::{copy_dir, BlobStore, OpId, Operation, SubnetBlockmaker};
 use askama::Template;
 use axum::{
     extract::State,
@@ -1375,7 +1375,7 @@ impl SingleResponseAdapter {
     }
 }
 
-#[tonic::async_trait]
+#[async_trait::async_trait]
 impl HttpsOutcallsService for SingleResponseAdapter {
     async fn https_outcall(
         &self,
@@ -1942,18 +1942,16 @@ pub struct StatusRequest {
 
 struct PocketHealth;
 
-#[async_trait]
 impl Health for PocketHealth {
-    async fn health(&self) -> ReplicaHealthStatus {
+    fn health(&self) -> ReplicaHealthStatus {
         ReplicaHealthStatus::Healthy
     }
 }
 
 struct PocketRootKey(pub Option<Vec<u8>>);
 
-#[async_trait]
 impl RootKey for PocketRootKey {
-    async fn root_key(&self) -> Option<Vec<u8>> {
+    fn root_key(&self) -> Option<Vec<u8>> {
         self.0.clone()
     }
 }


### PR DESCRIPTION
This adds two parameters:
* `health_nodes_per_subnet_alive_threshold`: fraction of nodes to be healthy in the subnet to consider the subnet alive (defaults to 0.6666)
* `health_subnets_alive_threshold`: fraction of healthy subnets visible to consider ourselves healthy (defaults to 0.51)

Previously we were considering ourselves healthy when we had 1 or more nodes alive total.