### PR TITLE
feat(sns_cli): Add Auto upgrades status to `sns health`

### DIFF
--- a/rs/sns/cli/src/health.rs
+++ b/rs/sns/cli/src/health.rs
@@ -97,7 +97,7 @@ impl TableRow for SnsHealthInfo {
         let automatic_target_version_advancement_sign =
             match self.automatic_target_version_advancement {
                 Some(true) => "🐇",
-                Some(false) => "✍️",
+                Some(false) => "💪",
                 None => "🦕",
             };
 


### PR DESCRIPTION
This PR adds a new column to indicate the status of automatic SNS target version advancement for each SNS.