### PR TITLE
chore(IDX): move cloud creds to action input

### DIFF
--- a/.github/actions/bazel-test-all/action.yaml
+++ b/.github/actions/bazel-test-all/action.yaml
@@ -41,6 +41,14 @@ runs:
           chmod 0700 ~/.ssh
           echo -e "Host *\nUser github-runner\n" > ~/.ssh/config
 
+      - name: Write AWS credentials
+        shell: bash
+        if: inputs.CLOUD_CREDENTIALS_CONTENT != ''
+        run: |
+          AWS_CREDS="${HOME}/.aws/credentials"
+          mkdir -p "$(dirname "${AWS_CREDS}")"
+          echo '${{ inputs.CLOUD_CREDENTIALS_CONTENT }}' >"$AWS_CREDS"
+
       - name: Run Bazel Test All
         id: bazel-test-all
         shell: bash

--- a/.github/workflows-source/ci-main.yml
+++ b/.github/workflows-source/ci-main.yml
@@ -85,7 +85,6 @@ jobs:
       group: zh1
       labels: dind-large
     env:
-      CLOUD_CREDENTIALS_CONTENT: ${{ secrets.CLOUD_CREDENTIALS_CONTENT }}
       # Only run ci/bazel-scripts/diff.sh on PRs that are not labeled with "CI_ALL_BAZEL_TARGETS".
       OVERRIDE_DIDC_CHECK: ${{ contains(github.event.pull_request.labels.*.name, 'CI_OVERRIDE_DIDC_CHECK') }}
       CI_OVERRIDE_BUF_BREAKING: ${{ contains(github.event.pull_request.labels.*.name, 'CI_OVERRIDE_BUF_BREAKING') }}
@@ -137,6 +136,7 @@ jobs:
           BAZEL_COMMAND: test --config=ci ${{ steps.bazel-extra-args.outputs.BAZEL_EXTRA_ARGS }}
           BAZEL_TARGETS: //...
           BUILDEVENT_APIKEY: ${{ secrets.HONEYCOMB_TOKEN }}
+          CLOUD_CREDENTIALS_CONTENT: ${{ secrets.CLOUD_CREDENTIALS_CONTENT }}
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
 
       - name: Upload SHA256SUMS (cache)
@@ -168,13 +168,12 @@ jobs:
       - name: Run Bazel Test Darwin x86-64
         id: bazel-test-darwin-x86-64
         uses:  ./.github/actions/bazel-test-all/
-        env:
-          CLOUD_CREDENTIALS_CONTENT: ${{ secrets.CLOUD_CREDENTIALS_CONTENT }}
         with:
           BAZEL_COMMAND: >-
             test --config=ci --config=macos_ci
             --test_tag_filters=test_macos
           BAZEL_TARGETS: //rs/... //publish/binaries/...
+          CLOUD_CREDENTIALS_CONTENT: ${{ secrets.CLOUD_CREDENTIALS_CONTENT }}
       - <<: *bazel-bep
       - name: Purge Bazel Output
         if: always()

--- a/.github/workflows-source/schedule-hourly.yml
+++ b/.github/workflows-source/schedule-hourly.yml
@@ -52,8 +52,6 @@ jobs:
       - <<: *checkout
       - name: Run Bazel Build All No Cache
         uses:  ./.github/actions/bazel-test-all/
-        env:
-          CLOUD_CREDENTIALS_CONTENT: ${{ secrets.CLOUD_CREDENTIALS_CONTENT }}
         with:
           # --config=release is required for the BNs as they rely for both dev and prod deployment
           # on images being uploaded to the S3 bucket
@@ -62,6 +60,7 @@ jobs:
               --config=ci --config=release
               --repository_cache= --disk_cache= --noremote_accept_cached --remote_instance_name=${CI_COMMIT_SHA} --@rules_rust//rust/settings:pipelined_compilation=True
           BAZEL_TARGETS: //...
+          CLOUD_CREDENTIALS_CONTENT: ${{ secrets.CLOUD_CREDENTIALS_CONTENT }}
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
       - <<: *bazel-bep
 

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -40,7 +40,6 @@ jobs:
       group: zh1
       labels: dind-large
     env:
-      CLOUD_CREDENTIALS_CONTENT: ${{ secrets.CLOUD_CREDENTIALS_CONTENT }}
       # Only run ci/bazel-scripts/diff.sh on PRs that are not labeled with "CI_ALL_BAZEL_TARGETS".
       OVERRIDE_DIDC_CHECK: ${{ contains(github.event.pull_request.labels.*.name, 'CI_OVERRIDE_DIDC_CHECK') }}
       CI_OVERRIDE_BUF_BREAKING: ${{ contains(github.event.pull_request.labels.*.name, 'CI_OVERRIDE_BUF_BREAKING') }}
@@ -95,6 +94,7 @@ jobs:
           BAZEL_COMMAND: test --config=ci ${{ steps.bazel-extra-args.outputs.BAZEL_EXTRA_ARGS }}
           BAZEL_TARGETS: //...
           BUILDEVENT_APIKEY: ${{ secrets.HONEYCOMB_TOKEN }}
+          CLOUD_CREDENTIALS_CONTENT: ${{ secrets.CLOUD_CREDENTIALS_CONTENT }}
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
       - name: Upload SHA256SUMS (cache)
         uses: actions/upload-artifact@v4
@@ -138,12 +138,11 @@ jobs:
       - name: Run Bazel Test Darwin x86-64
         id: bazel-test-darwin-x86-64
         uses: ./.github/actions/bazel-test-all/
-        env:
-          CLOUD_CREDENTIALS_CONTENT: ${{ secrets.CLOUD_CREDENTIALS_CONTENT }}
         with:
           BAZEL_COMMAND: >-
             test --config=ci --config=macos_ci --test_tag_filters=test_macos
           BAZEL_TARGETS: //rs/... //publish/binaries/...
+          CLOUD_CREDENTIALS_CONTENT: ${{ secrets.CLOUD_CREDENTIALS_CONTENT }}
       - name: Upload bazel-bep
         # runs only if previous step succeeded or failed;
         # we avoid collecting artifacts of jobs that were cancelled

--- a/.github/workflows/schedule-hourly.yml
+++ b/.github/workflows/schedule-hourly.yml
@@ -25,8 +25,6 @@ jobs:
         uses: actions/checkout@v4
       - name: Run Bazel Build All No Cache
         uses: ./.github/actions/bazel-test-all/
-        env:
-          CLOUD_CREDENTIALS_CONTENT: ${{ secrets.CLOUD_CREDENTIALS_CONTENT }}
         with:
           # --config=release is required for the BNs as they rely for both dev and prod deployment
           # on images being uploaded to the S3 bucket
@@ -37,6 +35,7 @@ jobs:
               --config=ci --config=release
               --repository_cache= --disk_cache= --noremote_accept_cached --remote_instance_name=${CI_COMMIT_SHA} --@rules_rust//rust/settings:pipelined_compilation=True
           BAZEL_TARGETS: //...
+          CLOUD_CREDENTIALS_CONTENT: ${{ secrets.CLOUD_CREDENTIALS_CONTENT }}
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
       - name: Upload bazel-bep
         # runs only if previous step succeeded or failed;

--- a/.github/workflows/system-tests-k8s.yml
+++ b/.github/workflows/system-tests-k8s.yml
@@ -149,14 +149,13 @@ jobs:
       - name: Run System Tests on K8s
         id: bazel-test-all
         uses: ./.github/actions/bazel-test-all/
-        env:
-          CLOUD_CREDENTIALS_CONTENT: ${{ secrets.CLOUD_CREDENTIALS_CONTENT }}
         with:
           BAZEL_COMMAND: >-
             test
               --config=ci
               --local_test_jobs=${{ env.JOBS }} --test_tag_filters=k8s --k8s --flaky_test_attempts=3
           BAZEL_TARGETS: ${{ env.TARGETS }}
+          CLOUD_CREDENTIALS_CONTENT: ${{ secrets.CLOUD_CREDENTIALS_CONTENT }}
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
 
       - name: Upload bazel-bep

--- a/ci/bazel-scripts/main.sh
+++ b/ci/bazel-scripts/main.sh
@@ -47,15 +47,6 @@ fi
 echo "Building as user: $(whoami)"
 echo "Bazel version: $(bazel version)"
 
-AWS_CREDS="${HOME}/.aws/credentials"
-mkdir -p "$(dirname "${AWS_CREDS}")"
-
-# add aws credentials file if it's set
-if [ -n "${CLOUD_CREDENTIALS_CONTENT+x}" ]; then
-    echo "$CLOUD_CREDENTIALS_CONTENT" >"$AWS_CREDS"
-    unset CLOUD_CREDENTIALS_CONTENT
-fi
-
 # An awk (mawk) program used to process STDERR to make it easier
 # to find the build event URL when going through logs.
 # Finally we record the URL to 'url_out' (passed via variable)


### PR DESCRIPTION
This avois having the credentials set in the environment for the whole run and instead only have it accessed by the action that needs it.