### PR TITLE
chore: upgrade stable-structures

### DIFF
--- a/Cargo.Bazel.Fuzzing.json.lock
+++ b/Cargo.Bazel.Fuzzing.json.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "6b9bbc73f19c134ab18c778db2cc6d1a0a19d3c2733e9403618a2efa3dd5a5d3",
+  "checksum": "cf0198a9598ddfe8d8abce3f21a505da68b376f9934f812f84a7e5a31d2edca6",
   "crates": {
     "abnf 0.12.0": {
       "name": "abnf",
@@ -20913,7 +20913,7 @@
               "target": "ic_sha3"
             },
             {
-              "id": "ic-stable-structures 0.6.5",
+              "id": "ic-stable-structures 0.6.8",
               "target": "ic_stable_structures"
             },
             {
@@ -34969,14 +34969,14 @@
       ],
       "license_file": "LICENSE"
     },
-    "ic-stable-structures 0.6.5": {
+    "ic-stable-structures 0.6.8": {
       "name": "ic-stable-structures",
-      "version": "0.6.5",
+      "version": "0.6.8",
       "package_url": "https://github.com/dfinity/stable-structures",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/ic-stable-structures/0.6.5/download",
-          "sha256": "03f3044466a69802de74e710dc0300b706a05696a0531c942ca856751a13b0db"
+          "url": "https://static.crates.io/crates/ic-stable-structures/0.6.8/download",
+          "sha256": "f0f5684f577e0146738cd11afed789109c4f51ba963c75823c48c1501dc53278"
         }
       },
       "targets": [
@@ -35029,7 +35029,7 @@
           ],
           "selects": {}
         },
-        "version": "0.6.5"
+        "version": "0.6.8"
       },
       "license": "Apache-2.0",
       "license_ids": [
@@ -94451,7 +94451,7 @@
     "ic-metrics-encoder 1.1.1",
     "ic-response-verification 3.0.3",
     "ic-sha3 1.0.0",
-    "ic-stable-structures 0.6.5",
+    "ic-stable-structures 0.6.8",
     "ic-test-state-machine-client 3.0.1",
     "ic-transport-types 0.39.3",
     "ic-utils 0.39.2",

--- a/Cargo.Bazel.Fuzzing.toml.lock
+++ b/Cargo.Bazel.Fuzzing.toml.lock
@@ -5951,9 +5951,9 @@ dependencies = [
 
 [[package]]
 name = "ic-stable-structures"
-version = "0.6.5"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03f3044466a69802de74e710dc0300b706a05696a0531c942ca856751a13b0db"
+checksum = "f0f5684f577e0146738cd11afed789109c4f51ba963c75823c48c1501dc53278"
 dependencies = [
  "ic_principal",
 ]

--- a/Cargo.Bazel.json.lock
+++ b/Cargo.Bazel.json.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "17e4754ea98e4b08e8762a655c27cb3b7084a68545de7fbdbbbb3183a71cb60c",
+  "checksum": "aa03956d3cc1fb0bf8e71cc635c0ecf4d4cac08a54ad52d48609b22ee79814d8",
   "crates": {
     "abnf 0.12.0": {
       "name": "abnf",
@@ -20741,7 +20741,7 @@
               "target": "ic_sha3"
             },
             {
-              "id": "ic-stable-structures 0.6.5",
+              "id": "ic-stable-structures 0.6.8",
               "target": "ic_stable_structures"
             },
             {
@@ -34824,14 +34824,14 @@
       ],
       "license_file": "LICENSE"
     },
-    "ic-stable-structures 0.6.5": {
+    "ic-stable-structures 0.6.8": {
       "name": "ic-stable-structures",
-      "version": "0.6.5",
+      "version": "0.6.8",
       "package_url": "https://github.com/dfinity/stable-structures",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/ic-stable-structures/0.6.5/download",
-          "sha256": "03f3044466a69802de74e710dc0300b706a05696a0531c942ca856751a13b0db"
+          "url": "https://static.crates.io/crates/ic-stable-structures/0.6.8/download",
+          "sha256": "f0f5684f577e0146738cd11afed789109c4f51ba963c75823c48c1501dc53278"
         }
       },
       "targets": [
@@ -34863,7 +34863,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.6.5"
+        "version": "0.6.8"
       },
       "license": "Apache-2.0",
       "license_ids": [
@@ -94364,7 +94364,7 @@
     "ic-metrics-encoder 1.1.1",
     "ic-response-verification 3.0.3",
     "ic-sha3 1.0.0",
-    "ic-stable-structures 0.6.5",
+    "ic-stable-structures 0.6.8",
     "ic-test-state-machine-client 3.0.1",
     "ic-transport-types 0.39.3",
     "ic-utils 0.39.0",

--- a/Cargo.Bazel.toml.lock
+++ b/Cargo.Bazel.toml.lock
@@ -5941,9 +5941,9 @@ dependencies = [
 
 [[package]]
 name = "ic-stable-structures"
-version = "0.6.5"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03f3044466a69802de74e710dc0300b706a05696a0531c942ca856751a13b0db"
+checksum = "f0f5684f577e0146738cd11afed789109c4f51ba963c75823c48c1501dc53278"
 dependencies = [
  "ic_principal",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12981,9 +12981,9 @@ dependencies = [
 
 [[package]]
 name = "ic-stable-structures"
-version = "0.6.7"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b492c5a16455ae78623eaa12ead96dda6c69a83c535b1b00789f19b381c8a24c"
+checksum = "f0f5684f577e0146738cd11afed789109c4f51ba963c75823c48c1501dc53278"
 dependencies = [
  "ic_principal",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -582,7 +582,7 @@ ic-http-gateway = "0.2.0"
 ic-management-canister-types = "0.2.1"
 ic-response-verification = "3"
 ic-sha3 = "1.0.0"
-ic-stable-structures = "0.6.5"
+ic-stable-structures = "0.6.8"
 ic-transport-types = { version = "0.39.2" }
 ic-utils = { version = "0.39", features = ["raw"] }
 ic_bls12_381 = { version = "0.10.0", default-features = false, features = [

--- a/bazel/external_crates.bzl
+++ b/bazel/external_crates.bzl
@@ -655,7 +655,7 @@ def external_crates_repository(name, cargo_lockfile, lockfile, sanitizers_enable
                 version = "^1.0.0",
             ),
             "ic-stable-structures": crate.spec(
-                version = "^0.6.5",
+                version = "^0.6.8",
             ),
             "icrc1-test-env": crate.spec(
                 git = "https://github.com/dfinity/ICRC-1",

--- a/rs/ledger_suite/icrc1/ledger/canbench_results/canbench_u256.yml
+++ b/rs/ledger_suite/icrc1/ledger/canbench_results/canbench_u256.yml
@@ -1,54 +1,54 @@
 benches:
   bench_icrc1_transfers:
     total:
-      instructions: 67536723756
-      heap_increase: 262
+      instructions: 53699723063
+      heap_increase: 264
       stable_memory_increase: 256
     scopes:
       icrc1_transfer:
-        instructions: 16505736562
-        heap_increase: 31
+        instructions: 12865001922
+        heap_increase: 32
         stable_memory_increase: 0
       icrc2_approve:
-        instructions: 23302128840
+        instructions: 18992665859
         heap_increase: 28
         stable_memory_increase: 128
       icrc2_transfer_from:
-        instructions: 26980407644
-        heap_increase: 3
+        instructions: 21140496297
+        heap_increase: 4
         stable_memory_increase: 0
       icrc3_get_blocks:
-        instructions: 8557135
+        instructions: 8224900
         heap_increase: 0
         stable_memory_increase: 0
       post_upgrade:
-        instructions: 353759761
+        instructions: 350248148
         heap_increase: 71
         stable_memory_increase: 0
       pre_upgrade:
-        instructions: 149186080
+        instructions: 149185689
         heap_increase: 129
         stable_memory_increase: 128
       upgrade:
-        instructions: 502947905
+        instructions: 499435901
         heap_increase: 200
         stable_memory_increase: 128
   bench_upgrade_baseline:
     total:
-      instructions: 8683947
+      instructions: 8680992
       heap_increase: 258
       stable_memory_increase: 128
     scopes:
       post_upgrade:
-        instructions: 8605927
+        instructions: 8603325
         heap_increase: 129
         stable_memory_increase: 0
       pre_upgrade:
-        instructions: 75628
+        instructions: 75275
         heap_increase: 129
         stable_memory_increase: 128
       upgrade:
-        instructions: 8683258
+        instructions: 8680303
         heap_increase: 258
         stable_memory_increase: 128
-version: 0.1.8
+version: 0.1.9

--- a/rs/ledger_suite/icrc1/ledger/canbench_results/canbench_u64.yml
+++ b/rs/ledger_suite/icrc1/ledger/canbench_results/canbench_u64.yml
@@ -1,54 +1,54 @@
 benches:
   bench_icrc1_transfers:
     total:
-      instructions: 65467206107
+      instructions: 51910206427
       heap_increase: 263
       stable_memory_increase: 256
     scopes:
       icrc1_transfer:
-        instructions: 15887391603
+        instructions: 12182817895
         heap_increase: 34
         stable_memory_increase: 0
       icrc2_approve:
-        instructions: 22551561638
+        instructions: 18380258866
         heap_increase: 25
         stable_memory_increase: 128
       icrc2_transfer_from:
-        instructions: 26286355650
+        instructions: 20648809910
         heap_increase: 3
         stable_memory_increase: 0
       icrc3_get_blocks:
-        instructions: 8189132
+        instructions: 7846494
         heap_increase: 0
         stable_memory_increase: 0
       post_upgrade:
-        instructions: 352257721
+        instructions: 354106045
         heap_increase: 72
         stable_memory_increase: 0
       pre_upgrade:
-        instructions: 149186270
+        instructions: 149185877
         heap_increase: 129
         stable_memory_increase: 128
       upgrade:
-        instructions: 501446055
+        instructions: 503293986
         heap_increase: 201
         stable_memory_increase: 128
   bench_upgrade_baseline:
     total:
-      instructions: 8683207
+      instructions: 8684428
       heap_increase: 258
       stable_memory_increase: 128
     scopes:
       post_upgrade:
-        instructions: 8604229
+        instructions: 8605803
         heap_increase: 129
         stable_memory_increase: 0
       pre_upgrade:
-        instructions: 76586
+        instructions: 76233
         heap_increase: 129
         stable_memory_increase: 128
       upgrade:
-        instructions: 8682518
+        instructions: 8683739
         heap_increase: 258
         stable_memory_increase: 128
 version: 0.1.9

--- a/rs/ledger_suite/tests/sm-tests/src/lib.rs
+++ b/rs/ledger_suite/tests/sm-tests/src/lib.rs
@@ -2758,13 +2758,13 @@ pub fn icrc1_test_stable_migration_endpoints_disabled<T>(
 
     const APPROVE_AMOUNT: u64 = 150_000;
 
-    for i in 2..40 {
+    for i in 2..60 {
         let spender = Account::from(PrincipalId::new_user_test_id(i).0);
         let approve_args = default_approve_args(spender, APPROVE_AMOUNT);
         send_approval(&env, canister_id, account.owner, &approve_args).expect("approval failed");
     }
 
-    for i in 2..40 {
+    for i in 2..60 {
         let to = Account::from(PrincipalId::new_user_test_id(i).0);
         transfer(&env, canister_id, account, to, 100).expect("failed to transfer funds");
     }
@@ -3093,8 +3093,8 @@ pub fn test_migration_resumes_from_frozen<T>(
     const APPROVE_AMOUNT: u64 = 150_000;
     const TRANSFER_AMOUNT: u64 = 100;
 
-    const NUM_APPROVALS: u64 = 20;
-    const NUM_TRANSFERS: u64 = 30;
+    const NUM_APPROVALS: u64 = 40;
+    const NUM_TRANSFERS: u64 = 40;
 
     let send_approvals = || {
         for i in 2..2 + NUM_APPROVALS {

--- a/rs/nns/governance/canbench/canbench_results.yml
+++ b/rs/nns/governance/canbench/canbench_results.yml
@@ -1,263 +1,263 @@
 benches:
   add_neuron_active_maximum_heap:
     total:
-      instructions: 42749601
+      instructions: 23774653
       heap_increase: 1
       stable_memory_increase: 0
     scopes: {}
   add_neuron_active_maximum_stable:
     total:
-      instructions: 114740916
+      instructions: 60061051
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   add_neuron_active_typical_heap:
     total:
-      instructions: 2170530
+      instructions: 1183126
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   add_neuron_active_typical_stable:
     total:
-      instructions: 8660783
+      instructions: 4322680
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   add_neuron_inactive_maximum:
     total:
-      instructions: 114741030
+      instructions: 60061164
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   add_neuron_inactive_typical:
     total:
-      instructions: 8497462
+      instructions: 4322793
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   cascading_vote_all_heap:
     total:
-      instructions: 34905155
+      instructions: 34881822
       heap_increase: 0
       stable_memory_increase: 128
     scopes: {}
   cascading_vote_heap_neurons_stable_index:
     total:
-      instructions: 60967269
+      instructions: 49343392
       heap_increase: 0
       stable_memory_increase: 128
     scopes: {}
   cascading_vote_stable_everything:
     total:
-      instructions: 188442754
+      instructions: 106655653
       heap_increase: 0
       stable_memory_increase: 128
     scopes: {}
   cascading_vote_stable_neurons_with_heap_index:
     total:
-      instructions: 162247244
+      instructions: 92065255
       heap_increase: 0
       stable_memory_increase: 128
     scopes: {}
   centralized_following_all_stable:
     total:
-      instructions: 78498019
+      instructions: 43003586
       heap_increase: 0
       stable_memory_increase: 128
     scopes: {}
   compute_ballots_for_new_proposal_with_stable_neurons:
     total:
-      instructions: 2260904
+      instructions: 1790506
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   distribute_rewards_with_stable_neurons:
     total:
-      instructions: 9181325
+      instructions: 7159517
       heap_increase: 0
       stable_memory_increase: 256
     scopes: {}
   draw_maturity_from_neurons_fund_heap:
     total:
-      instructions: 7530194
+      instructions: 7530460
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   draw_maturity_from_neurons_fund_stable:
     total:
-      instructions: 12444380
+      instructions: 7081729
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   list_active_neurons_fund_neurons_heap:
     total:
-      instructions: 427792
+      instructions: 427791
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   list_active_neurons_fund_neurons_stable:
     total:
-      instructions: 2803369
+      instructions: 2169709
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   list_neurons_by_subaccount_heap:
     total:
-      instructions: 7453782
-      heap_increase: 9
+      instructions: 5840597
+      heap_increase: 8
       stable_memory_increase: 0
     scopes: {}
   list_neurons_by_subaccount_stable:
     total:
-      instructions: 110710390
+      instructions: 64762990
       heap_increase: 5
       stable_memory_increase: 0
     scopes: {}
   list_neurons_heap:
     total:
-      instructions: 4946629
+      instructions: 4697992
       heap_increase: 9
       stable_memory_increase: 0
     scopes: {}
   list_neurons_stable:
     total:
-      instructions: 112656694
+      instructions: 66159773
       heap_increase: 5
       stable_memory_increase: 0
     scopes: {}
   list_proposals:
     total:
-      instructions: 125888
+      instructions: 87634
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   list_ready_to_spawn_neuron_ids_heap:
     total:
-      instructions: 132789
+      instructions: 132310
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   list_ready_to_spawn_neuron_ids_stable:
     total:
-      instructions: 43008066
+      instructions: 35189841
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   neuron_data_validation_heap:
     total:
-      instructions: 406519815
+      instructions: 227735829
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   neuron_data_validation_stable:
     total:
-      instructions: 362992103
+      instructions: 199983153
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   neuron_metrics_calculation_heap:
     total:
-      instructions: 1484978
+      instructions: 1485558
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   neuron_metrics_calculation_stable:
     total:
-      instructions: 3076760
+      instructions: 2649543
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   range_neurons_performance:
     total:
-      instructions: 83788874
+      instructions: 53450763
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   single_vote_all_stable:
     total:
-      instructions: 2806940
+      instructions: 2590837
       heap_increase: 0
       stable_memory_increase: 128
     scopes: {}
   unstake_maturity_of_dissolved_neurons_heap:
     total:
-      instructions: 2644396
+      instructions: 2644895
       heap_increase: 0
       stable_memory_increase: 0
     scopes:
       list_neuron_ids:
-        instructions: 225923
+        instructions: 226922
         heap_increase: 0
         stable_memory_increase: 0
       unstake_maturity:
-        instructions: 2416625
+        instructions: 2416125
         heap_increase: 0
         stable_memory_increase: 0
   unstake_maturity_of_dissolved_neurons_stable:
     total:
-      instructions: 92025155
+      instructions: 61147456
       heap_increase: 0
       stable_memory_increase: 0
     scopes:
       list_neuron_ids:
-        instructions: 44555814
+        instructions: 36512314
         heap_increase: 0
         stable_memory_increase: 0
       unstake_maturity:
-        instructions: 47467613
+        instructions: 24633208
         heap_increase: 0
         stable_memory_increase: 0
   update_recent_ballots_stable_memory:
     total:
-      instructions: 275035
+      instructions: 136836
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   with_neuron_mut_all_sections_maximum_heap:
     total:
-      instructions: 1618914
+      instructions: 1483303
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   with_neuron_mut_all_sections_maximum_stable:
     total:
-      instructions: 8240615
+      instructions: 5536655
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   with_neuron_mut_all_sections_typical_heap:
     total:
-      instructions: 383515
+      instructions: 247469
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   with_neuron_mut_all_sections_typical_stable:
     total:
-      instructions: 1931262
+      instructions: 1080740
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   with_neuron_mut_main_section_maximum_heap:
     total:
-      instructions: 1310260
+      instructions: 1309322
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   with_neuron_mut_main_section_maximum_stable:
     total:
-      instructions: 4127686
+      instructions: 2955634
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   with_neuron_mut_main_section_typical_heap:
     total:
-      instructions: 74128
+      instructions: 74200
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   with_neuron_mut_main_section_typical_stable:
     total:
-      instructions: 696379
+      instructions: 413439
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}


### PR DESCRIPTION
To benefit from the performance gains in recent editions of stable-structures, we need to update.