### PR TITLE
feat(nns): Enable timer task metrics

### DIFF
--- a/rs/nns/governance/src/lib.rs
+++ b/rs/nns/governance/src/lib.rs
@@ -140,6 +140,7 @@ use std::{
     io,
     time::{Duration, SystemTime},
 };
+use timer_tasks::encode_timer_task_metrics;
 
 #[cfg(any(test, feature = "canbench-rs"))]
 pub mod test_utils;
@@ -641,6 +642,9 @@ pub fn encode_metrics(
             .value(labels.as_slice(), Metric::into(*deadline_ts))
             .unwrap();
     }
+
+    // Timer tasks
+    encode_timer_task_metrics(w)?;
 
     // Periodically Calculated (almost entirely detailed neuron breakdowns/rollups)
 

--- a/rs/nns/governance/src/timer_tasks/mod.rs
+++ b/rs/nns/governance/src/timer_tasks/mod.rs
@@ -1,3 +1,4 @@
+use ic_metrics_encoder::MetricsEncoder;
 use ic_nervous_system_timer_task::{RecurringAsyncTask, TimerTaskMetricsRegistry};
 use seeding::SeedingTask;
 use std::cell::RefCell;
@@ -21,4 +22,9 @@ pub fn schedule_tasks() {
 
 pub fn run_distribute_rewards_periodic_task() {
     distribute_rewards::run_distribute_rewards_periodic_task(&GOVERNANCE, &METRICS_REGISTRY);
+}
+
+/// Encodes the metrics for timer tasks.
+pub fn encode_timer_task_metrics(encoder: &mut MetricsEncoder<Vec<u8>>) -> std::io::Result<()> {
+    METRICS_REGISTRY.with(|registry| registry.borrow().encode("governance", encoder))
 }

--- a/rs/nns/governance/src/timer_tasks/seeding.rs
+++ b/rs/nns/governance/src/timer_tasks/seeding.rs
@@ -55,5 +55,5 @@ impl RecurringAsyncTask for SeedingTask {
         Duration::from_secs(0)
     }
 
-    const NAME: &'static str = "Seeding";
+    const NAME: &'static str = "seeding";
 }

--- a/rs/nns/governance/unreleased_changelog.md
+++ b/rs/nns/governance/unreleased_changelog.md
@@ -21,6 +21,7 @@ on the process that this file is part of, see
     * The execution of `ApproveGenesisKyc` proposals have a limit of 1000 neurons, above which
     the proposal will fail.
     * More benchmarks were added.
+* Enable timer task metrics for better observability.
 
 ## Changed
 


### PR DESCRIPTION
# Why

To better observe timer tasks, enable the metrics to be encoded into '/metrics' endpoint.

# What

* Encode the timer task metrics
* Correct the 'seeding' task name to be lower case.