### PR TITLE
refactor(nns): Refactor prune following to use timer task

### DIFF
--- a/rs/nns/governance/canister/canister.rs
+++ b/rs/nns/governance/canister/canister.rs
@@ -2,8 +2,8 @@ use candid::candid_method;
 use ic_base_types::PrincipalId;
 use ic_canisters_http_types::{HttpRequest, HttpResponse, HttpResponseBuilder};
 use ic_cdk::{
-    api::{call::arg_data_raw, call_context_instruction_counter},
-    caller as ic_cdk_caller, heartbeat, post_upgrade, pre_upgrade, println, query, spawn, update,
+    api::call::arg_data_raw, caller as ic_cdk_caller, heartbeat, post_upgrade, pre_upgrade,
+    println, query, spawn, update,
 };
 use ic_nervous_system_canisters::cmc::CMCCanister;
 use ic_nervous_system_common::{
@@ -25,7 +25,6 @@ use ic_nns_governance::{
     canister_state::{governance, governance_mut, set_governance},
     encode_metrics,
     governance::Governance,
-    is_prune_following_enabled,
     neuron_data_validation::NeuronDataValidationSummary,
     pb::v1::{self as gov_pb, Governance as InternalGovernanceProto},
     storage::{grow_upgrades_memory_to, validate_stable_storage, with_upgrades_memory},
@@ -77,47 +76,11 @@ pub(crate) const LOG_PREFIX: &str = "[Governance] ";
 
 fn schedule_timers() {
     schedule_adjust_neurons_storage(Duration::from_nanos(0), Bound::Unbounded);
-    schedule_prune_following(Duration::from_secs(0), Bound::Unbounded);
     schedule_spawn_neurons();
     schedule_unstake_maturity_of_dissolved_neurons();
     schedule_neuron_data_validation();
     schedule_vote_processing();
     schedule_tasks();
-}
-
-const PRUNE_FOLLOWING_INTERVAL: Duration = Duration::from_secs(10);
-
-// Once this amount of instructions is used by the
-// Governance::prune_some_following, it stops, saves where it is, schedules more
-// pruning later, and returns.
-//
-// Why this value seems to make sense:
-//
-// I think we can conservatively estimate that it takes 2e6 instructions to pull
-// a neuron from stable memory. If we assume 200e3 neurons are in stable memory,
-// then 400e9 instructions are needed to read all neurons in stable memory.
-// 400e9 instructions / 50e6 instructions per batch = 8e3 batches. If we process
-// 1 batch every 10 s (see PRUNE_FOLLOWING_INTERVAL), then it would take less
-// than 23 hours to complete a full pass.
-//
-// This comes to 1.08 full passes per day. If each full pass uses 400e9
-// instructions, then we use 432e9 instructions per day doing
-// prune_some_following. If we assume 1 terainstruction costs 1 XDR,
-// prune_some_following uses less than half an XDR per day.
-const MAX_PRUNE_SOME_FOLLOWING_INSTRUCTIONS: u64 = 50_000_000;
-
-fn schedule_prune_following(delay: Duration, original_begin: Bound<NeuronIdProto>) {
-    if !is_prune_following_enabled() {
-        return;
-    }
-
-    ic_cdk_timers::set_timer(delay, move || {
-        let carry_on =
-            || call_context_instruction_counter() < MAX_PRUNE_SOME_FOLLOWING_INSTRUCTIONS;
-        let new_begin = governance_mut().prune_some_following(original_begin, carry_on);
-
-        schedule_prune_following(PRUNE_FOLLOWING_INTERVAL, new_begin);
-    });
 }
 
 // The interval before adjusting neuron storage for the next batch of neurons starting from last

--- a/rs/nns/governance/src/timer_tasks/mod.rs
+++ b/rs/nns/governance/src/timer_tasks/mod.rs
@@ -1,13 +1,17 @@
+use calculate_distributable_rewards::CalculateDistributableRewardsTask;
 use ic_metrics_encoder::MetricsEncoder;
-use ic_nervous_system_timer_task::{RecurringAsyncTask, TimerTaskMetricsRegistry};
+use ic_nervous_system_timer_task::{
+    RecurringAsyncTask, RecurringSyncTask, TimerTaskMetricsRegistry,
+};
+use prune_following::PruneFollowingTask;
 use seeding::SeedingTask;
 use std::cell::RefCell;
 
-use crate::canister_state::GOVERNANCE;
-use crate::timer_tasks::calculate_distributable_rewards::CalculateDistributableRewardsTask;
+use crate::{canister_state::GOVERNANCE, is_prune_following_enabled};
 
 mod calculate_distributable_rewards;
 mod distribute_rewards;
+mod prune_following;
 mod seeding;
 
 thread_local! {
@@ -17,6 +21,9 @@ thread_local! {
 pub fn schedule_tasks() {
     SeedingTask::new(&GOVERNANCE).schedule(&METRICS_REGISTRY);
     CalculateDistributableRewardsTask::new(&GOVERNANCE).schedule(&METRICS_REGISTRY);
+    if is_prune_following_enabled() {
+        PruneFollowingTask::new(&GOVERNANCE).schedule(&METRICS_REGISTRY);
+    }
     run_distribute_rewards_periodic_task();
 }
 

--- a/rs/nns/governance/src/timer_tasks/prune_following.rs
+++ b/rs/nns/governance/src/timer_tasks/prune_following.rs
@@ -1,0 +1,64 @@
+use ic_nervous_system_long_message::is_message_over_threshold;
+use ic_nervous_system_timer_task::RecurringSyncTask;
+use ic_nns_common::pb::v1::NeuronId;
+use std::{cell::RefCell, ops::Bound, thread::LocalKey, time::Duration};
+
+use crate::governance::Governance;
+
+const PRUNE_FOLLOWING_INTERVAL: Duration = Duration::from_secs(10);
+
+// Once this amount of instructions is used by the
+// Governance::prune_some_following, it stops, saves where it is, schedules more
+// pruning later, and returns.
+//
+// Why this value seems to make sense:
+//
+// I think we can conservatively estimate that it takes 2e6 instructions to pull
+// a neuron from stable memory. If we assume 200e3 neurons are in stable memory,
+// then 400e9 instructions are needed to read all neurons in stable memory.
+// 400e9 instructions / 50e6 instructions per batch = 8e3 batches. If we process
+// 1 batch every 10 s (see PRUNE_FOLLOWING_INTERVAL), then it would take less
+// than 23 hours to complete a full pass.
+//
+// This comes to 1.08 full passes per day. If each full pass uses 400e9
+// instructions, then we use 432e9 instructions per day doing
+// prune_some_following. If we assume 1 terainstruction costs 1 XDR,
+// prune_some_following uses less than half an XDR per day.
+const MAX_PRUNE_SOME_FOLLOWING_INSTRUCTIONS: u64 = 50_000_000;
+
+pub(super) struct PruneFollowingTask {
+    governance: &'static LocalKey<RefCell<Governance>>,
+    begin: Bound<NeuronId>,
+}
+
+impl PruneFollowingTask {
+    pub fn new(governance: &'static LocalKey<RefCell<Governance>>) -> Self {
+        Self {
+            governance,
+            begin: Bound::Unbounded,
+        }
+    }
+}
+
+impl RecurringSyncTask for PruneFollowingTask {
+    fn execute(self) -> (Duration, Self) {
+        let new_begin = self.governance.with_borrow_mut(|governance| {
+            let carry_on = || !is_message_over_threshold(MAX_PRUNE_SOME_FOLLOWING_INSTRUCTIONS);
+            governance.prune_some_following(self.begin, carry_on)
+        });
+
+        (
+            PRUNE_FOLLOWING_INTERVAL,
+            Self {
+                governance: self.governance,
+                begin: new_begin,
+            },
+        )
+    }
+
+    fn initial_delay(&self) -> Duration {
+        Duration::from_secs(0)
+    }
+
+    const NAME: &'static str = "prune_following";
+}

--- a/rs/nns/governance/unreleased_changelog.md
+++ b/rs/nns/governance/unreleased_changelog.md
@@ -11,6 +11,9 @@ on the process that this file is part of, see
 
 ## Changed
 
+* Refactor `prune_following` task to use the `timer_task` library, and therefore enables metrics to
+  be collected about its execution.
+
 ## Deprecated
 
 ## Removed


### PR DESCRIPTION
# Why

The timer task library has functionalities to collect metrics on the tasks, so refactoring tasks to use the library helps with observability.

# What

* Define a PruneSomeFollowingTask as a RecurringSyncTask and schedule it in `schedule_tasks`
* Change the scheduling from `cansiter.rs` to `schedule_tasks`