### PR TITLE
chore(nns): Cleanup constants related to neuron-minimum-dissolve-delay-to-vote

### DIFF
--- a/rs/nns/governance/api/src/pb.rs
+++ b/rs/nns/governance/api/src/pb.rs
@@ -102,11 +102,11 @@ impl VotingPowerEconomics {
         ),
         clear_following_after_seconds: Some(Self::DEFAULT_CLEAR_FOLLOWING_AFTER_SECONDS),
         neuron_minimum_dissolve_delay_to_vote_seconds: Some(
-            Self::DEFAULT_NEURON_MINIMUM_DISSOLVE_DELAY_TO_VOTE_SECONDS,
+            Self::DEFAULT_NEURON_MIN_DISSOLVE_DELAY_TO_VOTE_SECONDS,
         ),
     };
 
-    pub const DEFAULT_NEURON_MINIMUM_DISSOLVE_DELAY_TO_VOTE_SECONDS: u64 = 6 * ONE_MONTH_SECONDS;
+    pub const DEFAULT_NEURON_MIN_DISSOLVE_DELAY_TO_VOTE_SECONDS: u64 = 6 * ONE_MONTH_SECONDS;
     pub const DEFAULT_START_REDUCING_VOTING_POWER_AFTER_SECONDS: u64 = 6 * ONE_MONTH_SECONDS;
     pub const DEFAULT_CLEAR_FOLLOWING_AFTER_SECONDS: u64 = ONE_MONTH_SECONDS;
 

--- a/rs/nns/governance/src/governance.rs
+++ b/rs/nns/governance/src/governance.rs
@@ -184,9 +184,6 @@ pub const MAX_DISSOLVE_DELAY_SECONDS: u64 = 8 * ONE_YEAR_SECONDS;
 // computation.
 pub const MAX_NEURON_AGE_FOR_AGE_BONUS: u64 = 4 * ONE_YEAR_SECONDS;
 
-/// The minimum dissolve delay so that a neuron may vote.
-pub const MIN_DISSOLVE_DELAY_FOR_VOTE_ELIGIBILITY_SECONDS: u64 = 6 * ONE_MONTH_SECONDS;
-
 /// The maximum number of followees each neuron can establish for each topic.
 pub const MAX_FOLLOWEES_PER_TOPIC: usize = 15;
 
@@ -4977,7 +4974,7 @@ impl Governance {
     pub fn neuron_minimum_dissolve_delay_to_vote_seconds(&self) -> u64 {
         self.voting_power_economics()
             .neuron_minimum_dissolve_delay_to_vote_seconds
-            .unwrap_or(VotingPowerEconomics::DEFAULT_NEURON_MINIMUM_DISSOLVE_DELAY_TO_VOTE_SECONDS)
+            .unwrap_or(VotingPowerEconomics::DEFAULT_NEURON_MIN_DISSOLVE_DELAY_TO_VOTE_SECONDS)
     }
 
     /// The proposal id of the next proposal.

--- a/rs/nns/governance/src/governance/benches.rs
+++ b/rs/nns/governance/src/governance/benches.rs
@@ -5,7 +5,7 @@ use crate::test_utils::MockRandomness;
 use crate::{
     governance::{
         test_data::CREATE_SERVICE_NERVOUS_SYSTEM_WITH_MATCHED_FUNDING, Governance,
-        MAX_NUMBER_OF_NEURONS, MIN_DISSOLVE_DELAY_FOR_VOTE_ELIGIBILITY_SECONDS,
+        MAX_NUMBER_OF_NEURONS,
     },
     neuron::{DissolveStateAndAge, Neuron, NeuronBuilder},
     neuron_store::NeuronStore,
@@ -368,9 +368,13 @@ fn make_neuron(
     let subaccount = Subaccount::try_from(account.as_slice()).unwrap();
 
     let now = 123_456_789;
+    let dissolve_delay_seconds =
+        VotingPowerEconomics::DEFAULT_NEURON_MIN_DISSOLVE_DELAY_TO_VOTE_SECONDS;
+    let aging_since_timestamp_seconds = now - dissolve_delay_seconds;
+
     let dissolve_state_and_age = DissolveStateAndAge::NotDissolving {
-        dissolve_delay_seconds: MIN_DISSOLVE_DELAY_FOR_VOTE_ELIGIBILITY_SECONDS,
-        aging_since_timestamp_seconds: now - MIN_DISSOLVE_DELAY_FOR_VOTE_ELIGIBILITY_SECONDS,
+        dissolve_delay_seconds,
+        aging_since_timestamp_seconds,
     };
 
     let hot_keys = (0..15).map(PrincipalId::new_user_test_id).collect();

--- a/rs/nns/governance/src/network_economics.rs
+++ b/rs/nns/governance/src/network_economics.rs
@@ -275,16 +275,18 @@ impl VotingPowerEconomics {
         ),
         clear_following_after_seconds: Some(Self::DEFAULT_CLEAR_FOLLOWING_AFTER_SECONDS),
         neuron_minimum_dissolve_delay_to_vote_seconds: Some(
-            Self::DEFAULT_NEURON_MINIMUM_DISSOLVE_DELAY_TO_VOTE_SECONDS,
+            Self::DEFAULT_NEURON_MIN_DISSOLVE_DELAY_TO_VOTE_SECONDS,
         ),
     };
 
-    // [DEFAULT_NEURON_MINIMUM_DISSOLVE_DELAY_TO_VOTE_SECONDS] represents the default time threshold (in seconds)
-    // after which voting power begins to decrease in the network economics configuration. This is a preset
-    // value for the system, but it should be updated to align with [MIN_DISSOLVE_DELAY_FOR_VOTE_ELIGIBILITY_SECONDS].
-    pub const DEFAULT_NEURON_MINIMUM_DISSOLVE_DELAY_TO_VOTE_SECONDS: u64 =
-        crate::governance::MIN_DISSOLVE_DELAY_FOR_VOTE_ELIGIBILITY_SECONDS;
+    /// The minimum dissolve delay so that a neuron may vote.
+    pub const DEFAULT_NEURON_MIN_DISSOLVE_DELAY_TO_VOTE_SECONDS: u64 = 6 * ONE_MONTH_SECONDS;
+
+    pub const NEURON_MIN_DISSOLVE_DELAY_TO_VOTE_SECONDS_BOUNDS: RangeInclusive<u64> =
+        (3 * ONE_MONTH_SECONDS)..=(6 * ONE_MONTH_SECONDS);
+
     pub const DEFAULT_START_REDUCING_VOTING_POWER_AFTER_SECONDS: u64 = 6 * ONE_MONTH_SECONDS;
+
     pub const DEFAULT_CLEAR_FOLLOWING_AFTER_SECONDS: u64 = ONE_MONTH_SECONDS;
 
     pub fn with_default_values() -> Self {
@@ -361,14 +363,14 @@ impl VotingPowerEconomics {
         }
 
         if let Some(delay) = self.neuron_minimum_dissolve_delay_to_vote_seconds {
-            pub const MIN_DISSOLVE_DELAY_FOR_VOTE_ELIGIBILITY_SECONDS_BOUNDS: RangeInclusive<u64> =
-                (3 * ONE_MONTH_SECONDS)..=(6 * ONE_MONTH_SECONDS);
-
-            if !MIN_DISSOLVE_DELAY_FOR_VOTE_ELIGIBILITY_SECONDS_BOUNDS.contains(&delay) {
+            if !VotingPowerEconomics::NEURON_MIN_DISSOLVE_DELAY_TO_VOTE_SECONDS_BOUNDS
+                .contains(&delay)
+            {
                 let defect = format!(
-                    "neuron_minimum_dissolve_delay_to_vote_seconds ({:?}) must be between three and six months.",
+                    "neuron_minimum_dissolve_delay_to_vote_seconds ({:?}) must be between three \
+                     and six months.",
                     self.neuron_minimum_dissolve_delay_to_vote_seconds
-                 );
+                );
                 defects.push(defect);
             }
         } else {

--- a/rs/nns/governance/src/network_economics_tests.rs
+++ b/rs/nns/governance/src/network_economics_tests.rs
@@ -1,5 +1,4 @@
 use super::*;
-use crate::governance::MIN_DISSOLVE_DELAY_FOR_VOTE_ELIGIBILITY_SECONDS;
 use ic_nervous_system_proto::pb::v1::Decimal as ProtoDecimal;
 use pretty_assertions::assert_eq;
 
@@ -92,8 +91,8 @@ fn test_network_economics_with_default_values_is_valid() {
 #[test]
 fn test_neuron_minimum_dissolve_delay_to_vote_seconds_bounds() {
     // Define constants for better readability and maintainability
-    const LOWER_BOUND_SECONDS: u64 = MIN_DISSOLVE_DELAY_FOR_VOTE_ELIGIBILITY_SECONDS / 2; // 3 months
-    const UPPER_BOUND_SECONDS: u64 = MIN_DISSOLVE_DELAY_FOR_VOTE_ELIGIBILITY_SECONDS; // 6 months
+    const LOWER_BOUND_SECONDS: u64 = 3 * ONE_MONTH_SECONDS;
+    const UPPER_BOUND_SECONDS: u64 = 6 * ONE_MONTH_SECONDS;
     const DEFAULT_SECONDS: u64 = LOWER_BOUND_SECONDS; // Assuming default is the minimum
 
     // Test cases: (delay in seconds, expected result)

--- a/rs/nns/governance/src/neuron_store.rs
+++ b/rs/nns/governance/src/neuron_store.rs
@@ -955,7 +955,7 @@ impl NeuronStore {
 
         let min_dissolve_delay_seconds = voting_power_economics
             .neuron_minimum_dissolve_delay_to_vote_seconds
-            .unwrap_or(VotingPowerEconomics::DEFAULT_NEURON_MINIMUM_DISSOLVE_DELAY_TO_VOTE_SECONDS);
+            .unwrap_or(VotingPowerEconomics::DEFAULT_NEURON_MIN_DISSOLVE_DELAY_TO_VOTE_SECONDS);
 
         let mut process_neuron = |neuron: &Neuron| {
             if neuron.is_inactive(now_seconds)

--- a/rs/nns/governance/src/reward/distribution.rs
+++ b/rs/nns/governance/src/reward/distribution.rs
@@ -229,7 +229,7 @@ impl From<RewardsDistributionInProgress> for RewardsDistribution {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::governance::{Governance, MIN_DISSOLVE_DELAY_FOR_VOTE_ELIGIBILITY_SECONDS};
+    use crate::governance::Governance;
     use crate::neuron::{DissolveStateAndAge, Neuron, NeuronBuilder};
     use crate::pb::v1::Governance as GovernanceProto;
     use crate::test_utils::{
@@ -244,10 +244,15 @@ mod test {
     fn make_neuron(id: u64, maturity_e8s: u64, staked_maturity_e8s: u64) -> Neuron {
         let subaccount =
             Subaccount::try_from(test_subaccount_for_neuron_id(id).as_slice()).unwrap();
-        let now = 123_234_789;
+
+        let now = 123_456_789;
+        let dissolve_delay_seconds =
+            VotingPowerEconomics::DEFAULT_NEURON_MIN_DISSOLVE_DELAY_TO_VOTE_SECONDS;
+        let aging_since_timestamp_seconds = now - dissolve_delay_seconds;
+
         let dissolve_state_and_age = DissolveStateAndAge::NotDissolving {
-            dissolve_delay_seconds: MIN_DISSOLVE_DELAY_FOR_VOTE_ELIGIBILITY_SECONDS,
-            aging_since_timestamp_seconds: now - MIN_DISSOLVE_DELAY_FOR_VOTE_ELIGIBILITY_SECONDS,
+            dissolve_delay_seconds,
+            aging_since_timestamp_seconds,
         };
 
         NeuronBuilder::new(

--- a/rs/nns/governance/src/voting.rs
+++ b/rs/nns/governance/src/voting.rs
@@ -589,10 +589,7 @@ mod test {
     use crate::canister_state::{governance_mut, set_governance_for_tests};
     use crate::test_utils::MockRandomness;
     use crate::{
-        governance::{
-            Governance, MIN_DISSOLVE_DELAY_FOR_VOTE_ELIGIBILITY_SECONDS,
-            REWARD_DISTRIBUTION_PERIOD_SECONDS,
-        },
+        governance::{Governance, REWARD_DISTRIBUTION_PERIOD_SECONDS},
         neuron::{DissolveStateAndAge, Neuron, NeuronBuilder},
         neuron_store::NeuronStore,
         pb::v1::{
@@ -642,9 +639,13 @@ mod test {
         let subaccount = Subaccount::try_from(account.as_slice()).unwrap();
 
         let now = 123_456_789;
+        let dissolve_delay_seconds =
+            VotingPowerEconomics::DEFAULT_NEURON_MIN_DISSOLVE_DELAY_TO_VOTE_SECONDS;
+        let aging_since_timestamp_seconds = now - dissolve_delay_seconds;
+
         let dissolve_state_and_age = DissolveStateAndAge::NotDissolving {
-            dissolve_delay_seconds: MIN_DISSOLVE_DELAY_FOR_VOTE_ELIGIBILITY_SECONDS,
-            aging_since_timestamp_seconds: now - MIN_DISSOLVE_DELAY_FOR_VOTE_ELIGIBILITY_SECONDS,
+            dissolve_delay_seconds,
+            aging_since_timestamp_seconds,
         };
 
         NeuronBuilder::new(

--- a/rs/nns/governance/tests/governance.rs
+++ b/rs/nns/governance/tests/governance.rs
@@ -57,9 +57,8 @@ use ic_nns_governance::{
         Environment, Governance, HeapGrowthPotential,
         EXECUTE_NNS_FUNCTION_PAYLOAD_LISTING_BYTES_MAX, INITIAL_NEURON_DISSOLVE_DELAY,
         MAX_DISSOLVE_DELAY_SECONDS, MAX_NEURON_AGE_FOR_AGE_BONUS, MAX_NEURON_CREATION_SPIKE,
-        MAX_NUMBER_OF_PROPOSALS_WITH_BALLOTS, MIN_DISSOLVE_DELAY_FOR_VOTE_ELIGIBILITY_SECONDS,
-        PROPOSAL_MOTION_TEXT_BYTES_MAX, REWARD_DISTRIBUTION_PERIOD_SECONDS,
-        WAIT_FOR_QUIET_DEADLINE_INCREASE_SECONDS,
+        MAX_NUMBER_OF_PROPOSALS_WITH_BALLOTS, PROPOSAL_MOTION_TEXT_BYTES_MAX,
+        REWARD_DISTRIBUTION_PERIOD_SECONDS, WAIT_FOR_QUIET_DEADLINE_INCREASE_SECONDS,
     },
     governance_proto_builder::GovernanceProtoBuilder,
     pb::v1::{
@@ -247,9 +246,10 @@ fn check_proposal_status_after_voting_and_after_expiration_new(
     nns
 }
 
-const NOTDISSOLVING_MIN_DISSOLVE_DELAY_TO_VOTE: Option<DissolveState> = Some(
-    DissolveState::DissolveDelaySeconds(MIN_DISSOLVE_DELAY_FOR_VOTE_ELIGIBILITY_SECONDS),
-);
+const NOTDISSOLVING_MIN_DISSOLVE_DELAY_TO_VOTE: Option<DissolveState> =
+    Some(DissolveState::DissolveDelaySeconds(
+        VotingPowerEconomics::DEFAULT_NEURON_MIN_DISSOLVE_DELAY_TO_VOTE_SECONDS,
+    ));
 
 const NOTDISSOLVING_MAX_DISSOLVE_DELAY: Option<DissolveState> = Some(
     DissolveState::DissolveDelaySeconds(MAX_DISSOLVE_DELAY_SECONDS),
@@ -5119,7 +5119,8 @@ fn create_mature_neuron(dissolved: bool) -> (fake::FakeDriver, Governance, Neuro
     let nonce = 1234u64;
 
     let block_height = 543212234;
-    let dissolve_delay_seconds = MIN_DISSOLVE_DELAY_FOR_VOTE_ELIGIBILITY_SECONDS;
+    let dissolve_delay_seconds =
+        VotingPowerEconomics::DEFAULT_NEURON_MIN_DISSOLVE_DELAY_TO_VOTE_SECONDS;
     let neuron_stake_e8s = 100_000_000;
 
     let (mut driver, mut gov, id, to_subaccount) = governance_with_staked_neuron(
@@ -5172,7 +5173,9 @@ fn create_mature_neuron(dissolved: bool) -> (fake::FakeDriver, Governance, Neuro
             .expect("Neuron not found")
             .expect("Configure neuron failed.");
         // Advance the time in the env
-        driver.advance_time_by(MIN_DISSOLVE_DELAY_FOR_VOTE_ELIGIBILITY_SECONDS + 1);
+        driver.advance_time_by(
+            VotingPowerEconomics::DEFAULT_NEURON_MIN_DISSOLVE_DELAY_TO_VOTE_SECONDS + 1,
+        );
 
         // The neuron state should now be "Dissolved", meaning we can
         // now disburse the neuron.
@@ -5191,7 +5194,9 @@ fn create_mature_neuron(dissolved: bool) -> (fake::FakeDriver, Governance, Neuro
             NeuronState::Dissolved
         );
     } else {
-        driver.advance_time_by(MIN_DISSOLVE_DELAY_FOR_VOTE_ELIGIBILITY_SECONDS + 1);
+        driver.advance_time_by(
+            VotingPowerEconomics::DEFAULT_NEURON_MIN_DISSOLVE_DELAY_TO_VOTE_SECONDS + 1,
+        );
     }
 
     gov.neuron_store
@@ -5841,7 +5846,7 @@ fn test_rate_limiting_neuron_creation() {
                 maturity_e8s_equivalent: 10 * E8,
                 staked_maturity_e8s_equivalent: Some(10 * E8),
                 dissolve_state: Some(DissolveState::DissolveDelaySeconds(
-                    MIN_DISSOLVE_DELAY_FOR_VOTE_ELIGIBILITY_SECONDS,
+                    VotingPowerEconomics::DEFAULT_NEURON_MIN_DISSOLVE_DELAY_TO_VOTE_SECONDS,
                 )),
                 ..Default::default()
             }
@@ -6061,7 +6066,8 @@ fn test_neuron_split_fails() {
     let nonce = 1234u64;
 
     let block_height = 543212234;
-    let dissolve_delay_seconds = MIN_DISSOLVE_DELAY_FOR_VOTE_ELIGIBILITY_SECONDS;
+    let dissolve_delay_seconds =
+        VotingPowerEconomics::DEFAULT_NEURON_MIN_DISSOLVE_DELAY_TO_VOTE_SECONDS;
     let neuron_stake_e8s = 1_000_000_000;
 
     let (driver, mut gov, id, _) = governance_with_staked_neuron(
@@ -6191,7 +6197,8 @@ fn test_neuron_split() {
     let nonce = 1234u64;
 
     let block_height = 543212234;
-    let dissolve_delay_seconds = MIN_DISSOLVE_DELAY_FOR_VOTE_ELIGIBILITY_SECONDS;
+    let dissolve_delay_seconds =
+        VotingPowerEconomics::DEFAULT_NEURON_MIN_DISSOLVE_DELAY_TO_VOTE_SECONDS;
     let neuron_stake_e8s = 1_000_000_000;
     let maturity_e8s = 500_000_000;
     let staked_maturity_e8s = 400_000_000;
@@ -6318,7 +6325,8 @@ fn test_seed_neuron_split() {
     let nonce = 1234u64;
 
     let block_height = 543212234;
-    let dissolve_delay_seconds = MIN_DISSOLVE_DELAY_FOR_VOTE_ELIGIBILITY_SECONDS;
+    let dissolve_delay_seconds =
+        VotingPowerEconomics::DEFAULT_NEURON_MIN_DISSOLVE_DELAY_TO_VOTE_SECONDS;
     let neuron_stake_e8s = 1_000_000_000;
 
     let (driver, mut gov, id, _) = governance_with_staked_neuron(
@@ -6410,7 +6418,8 @@ fn test_neuron_spawn() {
     let nonce = 1234u64;
 
     let block_height = 543212234;
-    let dissolve_delay_seconds = MIN_DISSOLVE_DELAY_FOR_VOTE_ELIGIBILITY_SECONDS;
+    let dissolve_delay_seconds =
+        VotingPowerEconomics::DEFAULT_NEURON_MIN_DISSOLVE_DELAY_TO_VOTE_SECONDS;
     let neuron_stake_e8s = 1_000_000_000;
 
     let (mut driver, mut gov, id, _) = governance_with_staked_neuron(
@@ -6600,7 +6609,8 @@ fn test_neuron_spawn_with_subaccount() {
     let nonce = 1234u64;
 
     let block_height = 543212234;
-    let dissolve_delay_seconds = MIN_DISSOLVE_DELAY_FOR_VOTE_ELIGIBILITY_SECONDS;
+    let dissolve_delay_seconds =
+        VotingPowerEconomics::DEFAULT_NEURON_MIN_DISSOLVE_DELAY_TO_VOTE_SECONDS;
     let neuron_stake_e8s = 1_000_000_000;
 
     let (mut driver, mut gov, id, _) = governance_with_staked_neuron(
@@ -6757,7 +6767,8 @@ fn test_maturity_correctly_reset_if_spawn_fails() {
     let nonce = 1234u64;
 
     let block_height = 543212234;
-    let dissolve_delay_seconds = MIN_DISSOLVE_DELAY_FOR_VOTE_ELIGIBILITY_SECONDS;
+    let dissolve_delay_seconds =
+        VotingPowerEconomics::DEFAULT_NEURON_MIN_DISSOLVE_DELAY_TO_VOTE_SECONDS;
     let neuron_stake_e8s = 1_000_000_000;
 
     let (mut driver, mut gov, id, _) = governance_with_staked_neuron(
@@ -6901,7 +6912,8 @@ fn assert_neuron_spawn_partial(
     let nonce = 1234u64;
 
     let block_height = 543212234;
-    let dissolve_delay_seconds = MIN_DISSOLVE_DELAY_FOR_VOTE_ELIGIBILITY_SECONDS;
+    let dissolve_delay_seconds =
+        VotingPowerEconomics::DEFAULT_NEURON_MIN_DISSOLVE_DELAY_TO_VOTE_SECONDS;
     let neuron_stake_e8s = 1_000_000_000;
 
     let (mut driver, mut gov, id, _) = governance_with_staked_neuron(
@@ -7027,7 +7039,8 @@ fn test_staked_maturity() {
     let nonce = 1234u64;
 
     let block_height = 543212234;
-    let dissolve_delay_seconds = MIN_DISSOLVE_DELAY_FOR_VOTE_ELIGIBILITY_SECONDS;
+    let dissolve_delay_seconds =
+        VotingPowerEconomics::DEFAULT_NEURON_MIN_DISSOLVE_DELAY_TO_VOTE_SECONDS;
     let neuron_stake_e8s = 10 * 100_000_000; // 10 ICP
 
     let (mut driver, gov, id, _to_subaccount) = governance_with_staked_neuron(
@@ -7153,7 +7166,7 @@ fn test_staked_maturity() {
         .expect("Neuron not found")
         .expect("Configuring neuron failed");
 
-    driver.advance_time_by(MIN_DISSOLVE_DELAY_FOR_VOTE_ELIGIBILITY_SECONDS);
+    driver.advance_time_by(VotingPowerEconomics::DEFAULT_NEURON_MIN_DISSOLVE_DELAY_TO_VOTE_SECONDS);
     run_pending_timers();
     gov.unstake_maturity_of_dissolved_neurons();
 
@@ -7243,7 +7256,8 @@ fn test_disburse_to_neuron() {
     let nonce = 1234u64;
 
     let block_height = 543212234;
-    let dissolve_delay_seconds = MIN_DISSOLVE_DELAY_FOR_VOTE_ELIGIBILITY_SECONDS;
+    let dissolve_delay_seconds =
+        VotingPowerEconomics::DEFAULT_NEURON_MIN_DISSOLVE_DELAY_TO_VOTE_SECONDS;
     let neuron_stake_e8s = 10 * 100_000_000; // 10 ICP
 
     let (mut driver, mut gov, id, _to_subaccount) = governance_with_staked_neuron(
@@ -7295,7 +7309,9 @@ fn test_disburse_to_neuron() {
     }
 
     // Advance the time in the env
-    driver.advance_time_by(MIN_DISSOLVE_DELAY_FOR_VOTE_ELIGIBILITY_SECONDS + 1);
+    driver.advance_time_by(
+        VotingPowerEconomics::DEFAULT_NEURON_MIN_DISSOLVE_DELAY_TO_VOTE_SECONDS + 1,
+    );
 
     let parent_neuron = gov.with_neuron(&id, |neuron| neuron.clone()).unwrap();
     // The neuron state should now be "Dissolved", meaning we can
@@ -7685,7 +7701,10 @@ fn test_manage_and_reward_node_providers() {
 
     let voter_neuron = init_neurons[&42].id.unwrap();
     init_neurons.get_mut(&42).unwrap().dissolve_state = Some(
-        DissolveState::DissolveDelaySeconds(MIN_DISSOLVE_DELAY_FOR_VOTE_ELIGIBILITY_SECONDS).into(),
+        DissolveState::DissolveDelaySeconds(
+            VotingPowerEconomics::DEFAULT_NEURON_MIN_DISSOLVE_DELAY_TO_VOTE_SECONDS,
+        )
+        .into(),
     );
     let np_pid = PrincipalId::new_self_authenticating(&[14]);
 
@@ -8039,7 +8058,10 @@ fn test_manage_and_reward_multiple_node_providers() {
 
     let voter_neuron = init_neurons[&42].id.unwrap();
     init_neurons.get_mut(&42).unwrap().dissolve_state = Some(
-        DissolveState::DissolveDelaySeconds(MIN_DISSOLVE_DELAY_FOR_VOTE_ELIGIBILITY_SECONDS).into(),
+        DissolveState::DissolveDelaySeconds(
+            VotingPowerEconomics::DEFAULT_NEURON_MIN_DISSOLVE_DELAY_TO_VOTE_SECONDS,
+        )
+        .into(),
     );
     let np_pid_0 = PrincipalId::new_self_authenticating(&[14]);
     let np_pid_1 = PrincipalId::new_self_authenticating(&[15]);
@@ -8417,7 +8439,10 @@ fn test_network_economics_proposal() {
     let voter_pid = *init_neurons[&42].controller.as_ref().unwrap();
     let voter_neuron = init_neurons[&42].id.unwrap();
     init_neurons.get_mut(&42).unwrap().dissolve_state = Some(
-        DissolveState::DissolveDelaySeconds(MIN_DISSOLVE_DELAY_FOR_VOTE_ELIGIBILITY_SECONDS).into(),
+        DissolveState::DissolveDelaySeconds(
+            VotingPowerEconomics::DEFAULT_NEURON_MIN_DISSOLVE_DELAY_TO_VOTE_SECONDS,
+        )
+        .into(),
     );
     let (_, mut gov) = governance_with_neurons(
         &init_neurons
@@ -8442,12 +8467,12 @@ fn test_network_economics_proposal() {
             .voting_power_economics
             .unwrap()
             .neuron_minimum_dissolve_delay_to_vote_seconds,
-        Some(MIN_DISSOLVE_DELAY_FOR_VOTE_ELIGIBILITY_SECONDS),
+        Some(VotingPowerEconomics::DEFAULT_NEURON_MIN_DISSOLVE_DELAY_TO_VOTE_SECONDS),
     );
 
     // A value that differs from the default, useful for testing that the proposal has the intended effect.
-    let non_default_neuron_minimum_dissolve_delay_to_vote_seconds =
-        MIN_DISSOLVE_DELAY_FOR_VOTE_ELIGIBILITY_SECONDS / 2;
+    let non_VotingPowerEconomics::DEFAULT_NEURON_MIN_DISSOLVE_DELAY_TO_VOTE_SECONDS =
+        VotingPowerEconomics::DEFAULT_NEURON_MIN_DISSOLVE_DELAY_TO_VOTE_SECONDS / 2;
 
     // Propose to change some, NetworkEconomics parameters.
     let pid = match gov
@@ -8466,7 +8491,7 @@ fn test_network_economics_proposal() {
                             start_reducing_voting_power_after_seconds: Some(42),
                             clear_following_after_seconds: Some(4242),
                             neuron_minimum_dissolve_delay_to_vote_seconds: Some(
-                                non_default_neuron_minimum_dissolve_delay_to_vote_seconds,
+                                non_VotingPowerEconomics::DEFAULT_NEURON_MIN_DISSOLVE_DELAY_TO_VOTE_SECONDS,
                             ),
                         }),
                         ..Default::default()
@@ -8499,7 +8524,7 @@ fn test_network_economics_proposal() {
                 start_reducing_voting_power_after_seconds: Some(42),
                 clear_following_after_seconds: Some(4242),
                 neuron_minimum_dissolve_delay_to_vote_seconds: Some(
-                    non_default_neuron_minimum_dissolve_delay_to_vote_seconds
+                    non_VotingPowerEconomics::DEFAULT_NEURON_MIN_DISSOLVE_DELAY_TO_VOTE_SECONDS
                 )
             }),
 
@@ -9424,7 +9449,7 @@ async fn test_make_proposal_message() {
                 hot_keys: vec![],
                 cached_neuron_stake_e8s: 10 * E8,
                 account: driver.random_byte_array().expect("Could not get random byte array").to_vec(),
-                dissolve_state: Some(DissolveState::DissolveDelaySeconds(MIN_DISSOLVE_DELAY_FOR_VOTE_ELIGIBILITY_SECONDS)),
+                dissolve_state: Some(DissolveState::DissolveDelaySeconds(VotingPowerEconomics::DEFAULT_NEURON_MIN_DISSOLVE_DELAY_TO_VOTE_SECONDS)),
                 ..Default::default()
             },
         },
@@ -9983,10 +10008,9 @@ fn test_can_follow_by_subaccount_and_neuron_id() {
 #[test]
 fn test_merge_maturity_returns_expected_error() {
     let mut nns = NNSBuilder::new()
-        .add_neuron(
-            NeuronBuilder::new(100, 1, principal(1))
-                .set_dissolve_delay(MIN_DISSOLVE_DELAY_FOR_VOTE_ELIGIBILITY_SECONDS),
-        )
+        .add_neuron(NeuronBuilder::new(100, 1, principal(1)).set_dissolve_delay(
+            VotingPowerEconomics::DEFAULT_NEURON_MIN_DISSOLVE_DELAY_TO_VOTE_SECONDS,
+        ))
         .create();
 
     let id = NeuronId { id: 100 };
@@ -10012,7 +10036,9 @@ fn test_manage_neuron_merge_maturity_returns_expected_error() {
     // This fixture works well for us since we just need a single neuron to make this call with.
     let fixture: GovernanceProto = fixture_for_dissolving_neuron_tests(
         id,
-        DissolveState::DissolveDelaySeconds(MIN_DISSOLVE_DELAY_FOR_VOTE_ELIGIBILITY_SECONDS),
+        DissolveState::DissolveDelaySeconds(
+            VotingPowerEconomics::DEFAULT_NEURON_MIN_DISSOLVE_DELAY_TO_VOTE_SECONDS,
+        ),
         DEFAULT_TEST_START_TIMESTAMP_SECONDS,
     );
     let mut gov = Governance::new(
@@ -10083,7 +10109,9 @@ fn test_start_dissolving() {
     let id: u64 = 1;
     let fixture: GovernanceProto = fixture_for_dissolving_neuron_tests(
         id,
-        DissolveState::DissolveDelaySeconds(MIN_DISSOLVE_DELAY_FOR_VOTE_ELIGIBILITY_SECONDS),
+        DissolveState::DissolveDelaySeconds(
+            VotingPowerEconomics::DEFAULT_NEURON_MIN_DISSOLVE_DELAY_TO_VOTE_SECONDS,
+        ),
         DEFAULT_TEST_START_TIMESTAMP_SECONDS,
     );
     let mut gov = Governance::new(
@@ -10102,7 +10130,7 @@ fn test_start_dissolving() {
         .unwrap();
     assert_eq!(
         neuron_info.dissolve_delay_seconds,
-        MIN_DISSOLVE_DELAY_FOR_VOTE_ELIGIBILITY_SECONDS
+        VotingPowerEconomics::DEFAULT_NEURON_MIN_DISSOLVE_DELAY_TO_VOTE_SECONDS
     );
     assert_eq!(neuron_info.state, NeuronState::NotDissolving as i32);
     assert_eq!(neuron_info.age_seconds, 1);
@@ -10188,7 +10216,8 @@ fn test_stop_dissolving() {
     let fixture: GovernanceProto = fixture_for_dissolving_neuron_tests(
         id,
         DissolveState::WhenDissolvedTimestampSeconds(
-            DEFAULT_TEST_START_TIMESTAMP_SECONDS + MIN_DISSOLVE_DELAY_FOR_VOTE_ELIGIBILITY_SECONDS,
+            DEFAULT_TEST_START_TIMESTAMP_SECONDS
+                + VotingPowerEconomics::DEFAULT_NEURON_MIN_DISSOLVE_DELAY_TO_VOTE_SECONDS,
         ),
         u64::MAX,
     );
@@ -10206,7 +10235,7 @@ fn test_stop_dissolving() {
     assert_eq!(neuron_info.state, NeuronState::Dissolving as i32);
     assert_eq!(
         neuron_info.dissolve_delay_seconds,
-        MIN_DISSOLVE_DELAY_FOR_VOTE_ELIGIBILITY_SECONDS
+        VotingPowerEconomics::DEFAULT_NEURON_MIN_DISSOLVE_DELAY_TO_VOTE_SECONDS
     );
 
     gov.manage_neuron(
@@ -10236,7 +10265,7 @@ fn test_stop_dissolving() {
     assert_eq!(neuron_info.state, NeuronState::NotDissolving as i32);
     assert_eq!(
         neuron_info.dissolve_delay_seconds,
-        MIN_DISSOLVE_DELAY_FOR_VOTE_ELIGIBILITY_SECONDS
+        VotingPowerEconomics::DEFAULT_NEURON_MIN_DISSOLVE_DELAY_TO_VOTE_SECONDS
     );
     assert_eq!(neuron_info.age_seconds, 1);
 }
@@ -10252,7 +10281,9 @@ fn test_stop_dissolving_panics() {
     let id: u64 = 1;
     let fixture: GovernanceProto = fixture_for_dissolving_neuron_tests(
         id,
-        DissolveState::DissolveDelaySeconds(MIN_DISSOLVE_DELAY_FOR_VOTE_ELIGIBILITY_SECONDS),
+        DissolveState::DissolveDelaySeconds(
+            VotingPowerEconomics::DEFAULT_NEURON_MIN_DISSOLVE_DELAY_TO_VOTE_SECONDS,
+        ),
         DEFAULT_TEST_START_TIMESTAMP_SECONDS,
     );
     let mut gov = Governance::new(
@@ -10269,7 +10300,7 @@ fn test_stop_dissolving_panics() {
     assert_eq!(neuron_info.state, NeuronState::NotDissolving as i32);
     assert_eq!(
         neuron_info.dissolve_delay_seconds,
-        MIN_DISSOLVE_DELAY_FOR_VOTE_ELIGIBILITY_SECONDS
+        VotingPowerEconomics::DEFAULT_NEURON_MIN_DISSOLVE_DELAY_TO_VOTE_SECONDS
     );
 
     gov.manage_neuron(
@@ -10401,7 +10432,7 @@ fn test_increase_dissolve_delay() {
                 account: account(1),
                 controller: Some(principal(principal_id)),
                 dissolve_state: Some(DissolveState::DissolveDelaySeconds(
-                    MIN_DISSOLVE_DELAY_FOR_VOTE_ELIGIBILITY_SECONDS,
+                    VotingPowerEconomics::DEFAULT_NEURON_MIN_DISSOLVE_DELAY_TO_VOTE_SECONDS,
                 )),
                 ..Neuron::default()
             },
@@ -10411,7 +10442,7 @@ fn test_increase_dissolve_delay() {
                 controller: Some(principal(principal_id)),
                 dissolve_state: Some(DissolveState::WhenDissolvedTimestampSeconds(
                     DEFAULT_TEST_START_TIMESTAMP_SECONDS
-                        + MIN_DISSOLVE_DELAY_FOR_VOTE_ELIGIBILITY_SECONDS,
+                        + VotingPowerEconomics::DEFAULT_NEURON_MIN_DISSOLVE_DELAY_TO_VOTE_SECONDS,
                 )),
                 aging_since_timestamp_seconds: u64::MAX,
                 ..Neuron::default()
@@ -10445,7 +10476,7 @@ fn test_increase_dissolve_delay() {
     assert_eq!(neuron_info.state, NeuronState::NotDissolving as i32);
     assert_eq!(
         neuron_info.dissolve_delay_seconds,
-        MIN_DISSOLVE_DELAY_FOR_VOTE_ELIGIBILITY_SECONDS + 1
+        VotingPowerEconomics::DEFAULT_NEURON_MIN_DISSOLVE_DELAY_TO_VOTE_SECONDS + 1
     );
 
     increase_dissolve_delay(
@@ -10472,7 +10503,7 @@ fn test_increase_dissolve_delay() {
     assert_eq!(neuron_info.state, NeuronState::Dissolving as i32);
     assert_eq!(
         neuron_info.dissolve_delay_seconds,
-        MIN_DISSOLVE_DELAY_FOR_VOTE_ELIGIBILITY_SECONDS + 1
+        VotingPowerEconomics::DEFAULT_NEURON_MIN_DISSOLVE_DELAY_TO_VOTE_SECONDS + 1
     );
 
     increase_dissolve_delay(
@@ -10496,8 +10527,8 @@ fn test_increase_dissolve_delay() {
         &mut gov,
         principal_id,
         3,
-        u32::try_from(MIN_DISSOLVE_DELAY_FOR_VOTE_ELIGIBILITY_SECONDS)
-            .expect("MIN_DISSOLVE_DELAY_FOR_VOTE_ELIGIBILITY_SECONDS larger than u32"),
+        u32::try_from(VotingPowerEconomics::DEFAULT_NEURON_MIN_DISSOLVE_DELAY_TO_VOTE_SECONDS)
+            .expect("VotingPowerEconomics::DEFAULT_NEURON_MIN_DISSOLVE_DELAY_TO_VOTE_SECONDS larger than u32"),
     );
     let neuron_info = gov
         .get_neuron_info(&NeuronId { id: 3 }, *RANDOM_PRINCIPAL_ID)
@@ -10505,7 +10536,7 @@ fn test_increase_dissolve_delay() {
     assert_eq!(neuron_info.state, NeuronState::NotDissolving as i32);
     assert_eq!(
         neuron_info.dissolve_delay_seconds,
-        MIN_DISSOLVE_DELAY_FOR_VOTE_ELIGIBILITY_SECONDS
+        VotingPowerEconomics::DEFAULT_NEURON_MIN_DISSOLVE_DELAY_TO_VOTE_SECONDS
     );
 }
 


### PR DESCRIPTION
This PR clean up after the recent change that exposed the (priorly code-constant) neuron-minimum-dissolve-delay-to-vote constraint in NNS Governance. In particular: TODO