### PR TITLE
revert: "refactor(IDX): move rust-benchmarks to daily workflow"

### DIFF
--- a/.github/workflows-source/schedule-daily.yml
+++ b/.github/workflows-source/schedule-daily.yml
@@ -227,36 +227,3 @@ jobs:
           compression-level: 9
           path: |
             cov_html.zip
-
-  rust-benchmarks:
-    name: Bazel Run Rust Benchmarks
-    runs-on:
-      # see linux-x86-64 runner group
-      labels: rust-benchmarks
-    container:
-      <<: *image
-      # running on bare metal machine using ubuntu user
-      options: --user ubuntu -v /cache:/cache
-    timeout-minutes: 720 # 12 hours
-    strategy:
-      matrix:
-        targets:
-          - "//rs/crypto/..."
-          - "//rs/state_manager/..."
-          - "//rs/certification/..."
-          - "//rs/boundary_node/ic_boundary/..."
-          - "//rs/artifact_pool/..."
-          - "//rs/consensus/..."
-          - "//rs/ingress_manager/..."
-    steps:
-      - <<: *checkout
-
-      - name: Run Rust Benchmarks
-        id: rust-benchmarks
-        shell: bash
-        run: |
-          BAZEL_CI_CONFIG="--config=ci" ./ci/scripts/rust-benchmarks.sh
-        env:
-          CI_JOB_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          RUST_BACKTRACE: "full"
-          TARGETS: ${{ matrix.targets }}

--- a/.github/workflows/schedule-daily.yml
+++ b/.github/workflows/schedule-daily.yml
@@ -268,35 +268,3 @@ jobs:
           compression-level: 9
           path: |
             cov_html.zip
-  rust-benchmarks:
-    name: Bazel Run Rust Benchmarks
-    runs-on:
-      # see linux-x86-64 runner group
-      labels: rust-benchmarks
-    container:
-      image: ghcr.io/dfinity/ic-build@sha256:908c9b2abe0647cd54a2485117c263b0dae4a8aba8f25bc073813b09be9b1d59
-      # running on bare metal machine using ubuntu user
-      options: --user ubuntu -v /cache:/cache
-    timeout-minutes: 720 # 12 hours
-    strategy:
-      matrix:
-        targets:
-          - "//rs/crypto/..."
-          - "//rs/state_manager/..."
-          - "//rs/certification/..."
-          - "//rs/boundary_node/ic_boundary/..."
-          - "//rs/artifact_pool/..."
-          - "//rs/consensus/..."
-          - "//rs/ingress_manager/..."
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Run Rust Benchmarks
-        id: rust-benchmarks
-        shell: bash
-        run: |
-          BAZEL_CI_CONFIG="--config=ci" ./ci/scripts/rust-benchmarks.sh
-        env:
-          CI_JOB_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          RUST_BACKTRACE: "full"
-          TARGETS: ${{ matrix.targets }}

--- a/.github/workflows/schedule-rust-bench.yml
+++ b/.github/workflows/schedule-rust-bench.yml
@@ -1,0 +1,49 @@
+name: Schedule Rust Benchmarks
+
+on:
+  schedule:
+    - cron: "0 1 * * *"
+  workflow_dispatch:
+
+env:
+  BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
+  CI_COMMIT_SHA: ${{ github.sha }}
+  CI_JOB_NAME: ${{ github.job }}
+  CI_PROJECT_DIR: ${{ github.workspace }}
+  CI_RUN_ID: ${{ github.run_id }}
+
+jobs:
+
+  rust-benchmarks:
+    name: Bazel Run Rust Benchmarks
+    runs-on:
+      # see linux-x86-64 runner group
+      labels: rust-benchmarks
+    container:
+      image: ghcr.io/dfinity/ic-build@sha256:908c9b2abe0647cd54a2485117c263b0dae4a8aba8f25bc073813b09be9b1d59
+      # running on bare metal machine using ubuntu user
+      options: --user ubuntu -v /cache:/cache
+    timeout-minutes: 720 # 12 hours
+    strategy:
+      matrix:
+        targets:
+          - "//rs/crypto/..."
+          - "//rs/state_manager/..."
+          - "//rs/certification/..."
+          - "//rs/boundary_node/ic_boundary/..."
+          - "//rs/artifact_pool/..."
+          - "//rs/consensus/..."
+          - "//rs/ingress_manager/..."
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run Rust Benchmarks
+        id: rust-benchmarks
+        shell: bash
+        run: |
+          BAZEL_CI_CONFIG="--config=ci" ./ci/scripts/rust-benchmarks.sh
+        env:
+          CI_JOB_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          RUST_BACKTRACE: "full"
+          TARGETS: ${{ matrix.targets }}


### PR DESCRIPTION
Reverts dfinity/ic#4159

Rust benchmark runs on dedicated machine and is excluded with monitoring workflow runs that are in the wait queue for more then 20 minutes. Having it on daily workflow would be OK if it wouldn't run on `workflow_dispatch` but then maybe Crypto team does want to run them on `workflow_dispatch`, therefore the best is if they're in it's own workflow.