### PR TITLE
chore(ICP-Ledger): migrate non-pb query endpoints from dfn to cdk

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15647,6 +15647,7 @@ dependencies = [
  "ic-base-types",
  "ic-canister-log 0.2.0",
  "ic-cdk 0.17.1",
+ "ic-cdk-macros 0.17.1",
  "ic-cdk-timers",
  "ic-error-types",
  "ic-icrc1",

--- a/rs/ledger_suite/icp/ledger.did
+++ b/rs/ledger_suite/icp/ledger.did
@@ -535,4 +535,6 @@ service: (LedgerCanisterPayload) -> {
     icrc10_supported_standards : () -> (vec record { name : text; url : text }) query;
 
     is_ledger_ready: () -> (bool) query;
+
+    get_nodes: () -> (vec principal) query;
 }

--- a/rs/ledger_suite/icp/ledger.did
+++ b/rs/ledger_suite/icp/ledger.did
@@ -535,6 +535,4 @@ service: (LedgerCanisterPayload) -> {
     icrc10_supported_standards : () -> (vec record { name : text; url : text }) query;
 
     is_ledger_ready: () -> (bool) query;
-
-    get_nodes: () -> (vec principal) query;
 }

--- a/rs/ledger_suite/icp/ledger/Cargo.toml
+++ b/rs/ledger_suite/icp/ledger/Cargo.toml
@@ -23,6 +23,7 @@ hex = { workspace = true }
 ic-base-types = { path = "../../../types/base_types" }
 ic-canister-log = { path = "../../../rust_canisters/canister_log" }
 ic-cdk = { workspace = true }
+ic-cdk-macros = { workspace = true }
 ic-cdk-timers = { workspace = true }
 ic-limits = { path = "../../../limits" }
 ic-icrc1 = { path = "../../icrc1" }

--- a/rs/ledger_suite/icp/ledger/ledger_canisters.bzl
+++ b/rs/ledger_suite/icp/ledger/ledger_canisters.bzl
@@ -61,5 +61,5 @@ def rust_ledger_canister(name, extra_deps = [":ledger"], crate_features = None):
         proc_macro_deps = [
             # Keep sorted.
             "@crate_index//:ic-cdk-macros",
-        ],        
+        ],
     )

--- a/rs/ledger_suite/icp/ledger/ledger_canisters.bzl
+++ b/rs/ledger_suite/icp/ledger/ledger_canisters.bzl
@@ -58,4 +58,8 @@ def rust_ledger_canister(name, extra_deps = [":ledger"], crate_features = None):
         service_file = "//rs/ledger_suite/icp:ledger.did",
         deps = LEDGER_CANISTER_DEPS + extra_deps,
         crate_features = crate_features if crate_features else [],
+        proc_macro_deps = [
+            # Keep sorted.
+            "@crate_index//:ic-cdk-macros",
+        ],        
     )

--- a/rs/ledger_suite/icp/ledger/src/main.rs
+++ b/rs/ledger_suite/icp/ledger/src/main.rs
@@ -1,5 +1,5 @@
 use candid::{candid_method, Decode, Nat, Principal};
-use dfn_candid::{candid, candid_one, CandidOne};
+use dfn_candid::{candid_one, CandidOne};
 #[allow(unused_imports)]
 use dfn_core::BytesS;
 use dfn_core::{
@@ -1371,15 +1371,14 @@ fn archives() -> Archives {
     Archives { archives }
 }
 
-#[export_name = "canister_query get_nodes"]
-fn get_nodes_() {
-    over(candid, |()| {
-        archives()
-            .archives
-            .iter()
-            .map(|archive| archive.canister_id)
-            .collect::<Vec<CanisterId>>()
-    });
+#[query(name = "get_nodes")]
+#[candid_method(query, rename = "get_nodes")]
+fn get_nodes_() -> Vec<CanisterId> {
+    archives()
+        .archives
+        .iter()
+        .map(|archive| archive.canister_id)
+        .collect::<Vec<CanisterId>>()
 }
 
 fn encode_metrics(w: &mut ic_metrics_encoder::MetricsEncoder<Vec<u8>>) -> std::io::Result<()> {

--- a/rs/ledger_suite/icp/ledger/src/main.rs
+++ b/rs/ledger_suite/icp/ledger/src/main.rs
@@ -12,6 +12,7 @@ use ic_canister_log::{LogEntry, Sink};
 use ic_cdk::api::{
     caller, data_certificate, instruction_counter, print, set_certified_data, time, trap,
 };
+use ic_cdk_macros::query;
 use ic_icrc1::endpoints::{convert_transfer_error, StandardRecord};
 use ic_ledger_canister_core::ledger::LedgerContext;
 use ic_ledger_canister_core::runtime::heap_memory_size_bytes;
@@ -593,12 +594,14 @@ fn account_balance(account: AccountIdentifier) -> Tokens {
     LEDGER.read().unwrap().balances().account_balance(&account)
 }
 
-#[candid_method(query, rename = "icrc1_balance_of")]
+#[query]
+#[candid_method(query)]
 fn icrc1_balance_of(acc: Account) -> Nat {
     Nat::from(account_balance(AccountIdentifier::from(acc)).get_e8s())
 }
 
-#[candid_method(query, rename = "icrc1_supported_standards")]
+#[query]
+#[candid_method(query)]
 fn icrc1_supported_standards() -> Vec<StandardRecord> {
     let mut standards = vec![StandardRecord {
         name: "ICRC-1".to_string(),
@@ -620,17 +623,20 @@ fn icrc1_supported_standards() -> Vec<StandardRecord> {
     standards
 }
 
-#[candid_method(query, rename = "icrc1_minting_account")]
+#[query]
+#[candid_method(query)]
 fn icrc1_minting_account() -> Option<Account> {
     LEDGER.read().unwrap().icrc1_minting_account
 }
 
-#[candid_method(query, rename = "transfer_fee")]
+#[query]
+#[candid_method(query)]
 fn transfer_fee(_: TransferFeeArgs) -> TransferFee {
     LEDGER.read().unwrap().transfer_fee()
 }
 
-#[candid_method(query, rename = "icrc1_metadata")]
+#[query]
+#[candid_method(query)]
 fn icrc1_metadata() -> Vec<(String, Value)> {
     vec![
         Value::entry("icrc1:decimals", DECIMAL_PLACES as u64),
@@ -643,7 +649,8 @@ fn icrc1_metadata() -> Vec<(String, Value)> {
     ]
 }
 
-#[candid_method(query, rename = "icrc1_fee")]
+#[query]
+#[candid_method(query)]
 fn icrc1_fee() -> Nat {
     Nat::from(LEDGER.read().unwrap().transfer_fee.get_e8s())
 }
@@ -653,11 +660,13 @@ fn total_supply() -> Tokens {
     LEDGER.read().unwrap().balances().total_supply()
 }
 
-#[candid_method(query, rename = "icrc1_total_supply")]
+#[query]
+#[candid_method(query)]
 fn icrc1_total_supply() -> Nat {
     Nat::from(LEDGER.read().unwrap().balances().total_supply().get_e8s())
 }
 
+#[query(name = "symbol")]
 #[candid_method(query, rename = "symbol")]
 fn token_symbol() -> Symbol {
     Symbol {
@@ -665,6 +674,7 @@ fn token_symbol() -> Symbol {
     }
 }
 
+#[query(name = "name")]
 #[candid_method(query, rename = "name")]
 fn token_name() -> Name {
     Name {
@@ -672,16 +682,19 @@ fn token_name() -> Name {
     }
 }
 
+#[query]
 #[candid_method(query)]
 fn icrc1_name() -> String {
     LEDGER.read().unwrap().token_name.clone()
 }
 
-#[candid_method(query, rename = "icrc1_symbol")]
+#[query]
+#[candid_method(query)]
 fn icrc1_symbol() -> String {
     LEDGER.read().unwrap().token_symbol.to_string()
 }
 
+#[query(name = "decimals")]
 #[candid_method(query, rename = "decimals")]
 fn token_decimals() -> Decimals {
     Decimals {
@@ -689,7 +702,8 @@ fn token_decimals() -> Decimals {
     }
 }
 
-#[candid_method(query, rename = "icrc1_decimals")]
+#[query]
+#[candid_method(query)]
 fn icrc1_decimals() -> u8 {
     debug_assert!(ic_ledger_core::tokens::DECIMAL_PLACES <= u8::MAX as u32);
     ic_ledger_core::tokens::DECIMAL_PLACES as u8
@@ -1221,6 +1235,7 @@ fn account_balance_() {
     })
 }
 
+#[query(name = "account_balance")]
 #[candid_method(query, rename = "account_balance")]
 fn account_balance_candid_(arg: AccountIdentifierByteBuf) -> Tokens {
     match BinaryAccountBalanceArgs::try_from(arg) {
@@ -1234,45 +1249,17 @@ fn account_balance_candid_(arg: AccountIdentifierByteBuf) -> Tokens {
     }
 }
 
-#[export_name = "canister_query account_balance"]
-fn account_balance_candid() {
-    over(candid_one, account_balance_candid_)
-}
-
+/// See caveats of use on send_dfx
+#[query(name = "account_balance_dfx")]
 #[candid_method(query, rename = "account_balance_dfx")]
 fn account_balance_dfx_(args: AccountBalanceArgs) -> Tokens {
     account_balance(args.account)
 }
 
-/// See caveats of use on send_dfx
-#[export_name = "canister_query account_balance_dfx"]
-fn account_balance_dfx() {
-    over(candid_one, account_balance_dfx_);
-}
-
+#[query(name = "account_identifier")]
 #[candid_method(query, rename = "account_identifier")]
 fn compute_account_identifier(arg: Account) -> AccountIdBlob {
     AccountIdentifier::from(arg).to_address()
-}
-
-#[export_name = "canister_query account_identifier"]
-fn compute_account_identifier_candid() {
-    over(candid_one, compute_account_identifier)
-}
-
-#[export_name = "canister_query icrc1_balance_of"]
-fn icrc1_balance_of_candid() {
-    over(candid_one, icrc1_balance_of)
-}
-
-#[export_name = "canister_query transfer_fee"]
-fn transfer_fee_candid() {
-    over(candid_one, transfer_fee)
-}
-
-#[export_name = "canister_query icrc1_fee"]
-fn icrc1_fee_candid() {
-    over(candid_one, |()| icrc1_fee())
 }
 
 #[export_name = "canister_query transfer_fee_pb"]
@@ -1280,41 +1267,11 @@ fn transfer_fee_() {
     over(protobuf, transfer_fee)
 }
 
-#[export_name = "canister_query symbol"]
-fn token_symbol_candid() {
-    over(candid_one, |()| token_symbol())
-}
-
-#[export_name = "canister_query name"]
-fn token_name_candid() {
-    over(candid_one, |()| token_name())
-}
-
-#[export_name = "canister_query icrc1_name"]
-fn icrc1_name_candid() {
-    over(candid_one, |()| icrc1_name())
-}
-
-#[export_name = "canister_query decimals"]
-fn token_decimals_candid() {
-    over(candid_one, |()| token_decimals())
-}
-
-#[export_name = "canister_query icrc1_decimals"]
-fn icrc1_decimals_candid() {
-    over(candid_one, |()| icrc1_decimals())
-}
-
 #[export_name = "canister_query total_supply_pb"]
 fn total_supply_() {
     over(protobuf, |_: TotalSupplyArgs| {
         tokens_into_proto(total_supply())
     })
-}
-
-#[export_name = "canister_query icrc1_total_supply"]
-fn icrc1_total_supply_candid() {
-    over(candid_one, |()| icrc1_total_supply())
 }
 
 /// Get multiple blocks by *offset into the container* (not BlockIndex) and
@@ -1353,12 +1310,8 @@ fn get_blocks_() {
     });
 }
 
-#[export_name = "canister_query icrc1_supported_standards"]
-fn icrc1_supported_standards_candid() {
-    over(candid_one, |()| icrc1_supported_standards())
-}
-
-#[candid_method(query, rename = "query_blocks")]
+#[query]
+#[candid_method(query)]
 fn query_blocks(GetBlocksArgs { start, length }: GetBlocksArgs) -> QueryBlocksResponse {
     let ledger = LEDGER.read().unwrap();
     let locations = block_locations(&*ledger, start, length.min(usize::MAX as u64) as usize);
@@ -1400,22 +1353,8 @@ fn query_blocks(GetBlocksArgs { start, length }: GetBlocksArgs) -> QueryBlocksRe
     }
 }
 
-#[export_name = "canister_query query_blocks"]
-fn query_blocks_() {
-    over(candid_one, query_blocks)
-}
-
-#[export_name = "canister_query icrc1_minting_account"]
-fn icrc1_minting_account_candid() {
-    over(candid_one, |()| icrc1_minting_account())
-}
-
-#[export_name = "canister_query icrc1_symbol"]
-fn icrc1_symbol_candid() {
-    over(candid_one, |()| icrc1_symbol())
-}
-
-#[candid_method(query, rename = "archives")]
+#[query]
+#[candid_method(query)]
 fn archives() -> Archives {
     let ledger_guard = LEDGER.try_read().expect("Failed to get ledger read lock");
     let archive_guard = ledger_guard.blockchain.archive.read().unwrap();
@@ -1441,16 +1380,6 @@ fn get_nodes_() {
             .map(|archive| archive.canister_id)
             .collect::<Vec<CanisterId>>()
     });
-}
-
-#[export_name = "canister_query archives"]
-fn archives_candid() {
-    over(candid_one, |()| archives());
-}
-
-#[export_name = "canister_query icrc1_metadata"]
-fn icrc1_metadata_candid() {
-    over(candid_one, |()| icrc1_metadata())
 }
 
 fn encode_metrics(w: &mut ic_metrics_encoder::MetricsEncoder<Vec<u8>>) -> std::io::Result<()> {
@@ -1578,7 +1507,8 @@ fn http_request() {
     dfn_http_metrics::serve_metrics(encode_metrics);
 }
 
-#[candid_method(query, rename = "query_encoded_blocks")]
+#[query]
+#[candid_method(query)]
 fn query_encoded_blocks(
     GetBlocksArgs { start, length }: GetBlocksArgs,
 ) -> QueryEncodedBlocksResponse {
@@ -1614,11 +1544,6 @@ fn query_encoded_blocks(
         first_block_index: local_blocks.start as BlockIndex,
         archived_blocks,
     }
-}
-
-#[export_name = "canister_query query_encoded_blocks"]
-fn query_encoded_blocks_() {
-    over(candid_one, query_encoded_blocks)
 }
 
 #[candid_method(update, rename = "icrc2_approve")]
@@ -1743,7 +1668,8 @@ fn get_allowance(from: AccountIdentifier, spender: AccountIdentifier) -> Allowan
     }
 }
 
-#[candid_method(query, rename = "icrc2_allowance")]
+#[query]
+#[candid_method(query)]
 fn icrc2_allowance(arg: AllowanceArgs) -> Allowance {
     if !LEDGER.read().unwrap().feature_flags.icrc2 {
         trap("ICRC-2 features are not enabled on the ledger.");
@@ -1753,21 +1679,11 @@ fn icrc2_allowance(arg: AllowanceArgs) -> Allowance {
     get_allowance(from, spender)
 }
 
-#[export_name = "canister_query icrc2_allowance"]
-fn icrc2_allowance_candid() {
-    over(candid_one, icrc2_allowance)
-}
-
 #[cfg(feature = "icp-allowance-getter")]
+#[query(name = "allowance")]
 #[candid_method(query, rename = "allowance")]
 fn icp_allowance(arg: IcpAllowanceArgs) -> Allowance {
     get_allowance(arg.account, arg.spender)
-}
-
-#[cfg(feature = "icp-allowance-getter")]
-#[export_name = "canister_query allowance"]
-fn allowance_candid() {
-    over(candid_one, icp_allowance)
 }
 
 #[candid_method(update, rename = "icrc21_canister_call_consent_message")]
@@ -1793,24 +1709,16 @@ fn icrc21_canister_call_consent_message_candid() {
     over(candid_one, icrc21_canister_call_consent_message)
 }
 
-#[candid_method(query, rename = "icrc10_supported_standards")]
+#[query]
+#[candid_method(query)]
 fn icrc10_supported_standards() -> Vec<StandardRecord> {
     icrc1_supported_standards()
 }
 
-#[export_name = "canister_query icrc10_supported_standards"]
-fn icrc10_supported_standards_candid() {
-    over(candid_one, |()| icrc10_supported_standards())
-}
-
-#[candid_method(query, rename = "is_ledger_ready")]
+#[query]
+#[candid_method(query)]
 fn is_ledger_ready() -> bool {
     is_ready()
-}
-
-#[export_name = "canister_query is_ledger_ready"]
-fn is_ledger_ready_candid() {
-    over(candid_one, |()| is_ledger_ready())
 }
 
 candid::export_service!();

--- a/rs/ledger_suite/icp/ledger/src/main.rs
+++ b/rs/ledger_suite/icp/ledger/src/main.rs
@@ -1,5 +1,5 @@
 use candid::{candid_method, Decode, Nat, Principal};
-use dfn_candid::{candid_one, CandidOne};
+use dfn_candid::{candid, candid_one, CandidOne};
 #[allow(unused_imports)]
 use dfn_core::BytesS;
 use dfn_core::{
@@ -1371,14 +1371,15 @@ fn archives() -> Archives {
     Archives { archives }
 }
 
-#[query(name = "get_nodes")]
-#[candid_method(query, rename = "get_nodes")]
-fn get_nodes_() -> Vec<CanisterId> {
-    archives()
-        .archives
-        .iter()
-        .map(|archive| archive.canister_id)
-        .collect::<Vec<CanisterId>>()
+#[export_name = "canister_query get_nodes"]
+fn get_nodes_() {
+    over(candid, |()| {
+        archives()
+            .archives
+            .iter()
+            .map(|archive| archive.canister_id)
+            .collect::<Vec<CanisterId>>()
+    });
 }
 
 fn encode_metrics(w: &mut ic_metrics_encoder::MetricsEncoder<Vec<u8>>) -> std::io::Result<()> {


### PR DESCRIPTION
I only migrate simple, non-protocol buffer query endpoints in this PR.