### PR TITLE
fix: retry fetching tip block

### DIFF
--- a/rs/rosetta-api/icp/ledger_canister_blocks_synchronizer/src/ledger_blocks_sync.rs
+++ b/rs/rosetta-api/icp/ledger_canister_blocks_synchronizer/src/ledger_blocks_sync.rs
@@ -10,7 +10,8 @@ use ic_ledger_core::block::{BlockIndex, BlockType, EncodedBlock};
 use ic_ledger_hash_of::HashOf;
 use icp_ledger::{Block, TipOfChainRes};
 use tokio::sync::RwLock;
-use tracing::{debug, error, info, trace, warn};
+use tokio::time::Duration;
+use tracing::{debug, error, info, trace};
 
 use crate::blocks::BlockStoreError;
 use crate::blocks::{Blocks, HashedBlock};
@@ -27,6 +28,9 @@ const PRINT_SYNC_PROGRESS_THRESHOLD: u64 = 1000;
 const DATABASE_WRITE_BLOCKS_BATCH_SIZE: u64 = 500000;
 // Max number of retry in case of query failure while retrieving blocks.
 const MAX_RETRY: u8 = 5;
+
+const MAX_RETRIES_QUERY_TIP_BLOCK: u8 = 5;
+const RETRY_DELAY_QUERY_TIP_BLOCK: Duration = Duration::from_millis(500);
 
 struct BlockWithIndex {
     block: Block,
@@ -223,10 +227,23 @@ impl<B: BlocksAccess> LedgerBlocksSynchronizer<B> {
             tip_index,
             certification,
         } = canister.query_tip().await?;
-        let encoded_block = canister.query_raw_block(tip_index).await?.ok_or(format!(
-            "Tip of the chain has index {} but no block found at that index!",
-            tip_index
-        ))?;
+        // Gets tip block with retries
+        let mut retry = 0;
+        let encoded_block = loop {
+            let tip_block = canister.query_raw_block(tip_index).await?;
+            if tip_block.is_some() {
+                break Ok(tip_block.unwrap());
+            }
+            if retry == MAX_RETRIES_QUERY_TIP_BLOCK {
+                break Err(format!(
+                    "Failed to retrieve tip block after {} retries",
+                    MAX_RETRIES_QUERY_TIP_BLOCK
+                ));
+            }
+            retry += 1;
+            tokio::time::sleep(RETRY_DELAY_QUERY_TIP_BLOCK.into()).await;
+        }?;
+
         let block = Block::decode(encoded_block.clone())?;
         if let Some(info) = &self.verification_info {
             let hash = HashedBlock::hash_block(
@@ -354,7 +371,7 @@ impl<B: BlocksAccess> LedgerBlocksSynchronizer<B> {
             }
 
             debug!("Asking for blocks [{},{})", i, range.end);
-            let retry = 0;
+            let mut retry = 0;
             let batch = loop {
                 let batch = canister
                     .clone()
@@ -367,14 +384,15 @@ impl<B: BlocksAccess> LedgerBlocksSynchronizer<B> {
                 if batch.is_ok() || retry == MAX_RETRY {
                     break batch;
                 }
-                let retry = retry + 1;
-                warn!(
-                    "Failed query while retrieving blocks, retry {}/{} (error: {:?})",
-                    retry,
-                    MAX_RETRY,
-                    batch.unwrap_err()
+                retry = retry + 1;
+            }
+            .map_err(|e| {
+                error!(
+                    "Failed to fetch blocks [{},{}] after {} attempts: {:?}",
+                    i, range.end, MAX_RETRY, e
                 );
-            }?;
+                e
+            })?;
 
             debug!("Got batch of len: {}", batch.len());
             if batch.is_empty() {

--- a/rs/rosetta-api/icp/ledger_canister_blocks_synchronizer/src/ledger_blocks_sync.rs
+++ b/rs/rosetta-api/icp/ledger_canister_blocks_synchronizer/src/ledger_blocks_sync.rs
@@ -241,7 +241,7 @@ impl<B: BlocksAccess> LedgerBlocksSynchronizer<B> {
                 ));
             }
             retry += 1;
-            tokio::time::sleep(RETRY_DELAY_QUERY_TIP_BLOCK.into()).await;
+            tokio::time::sleep(RETRY_DELAY_QUERY_TIP_BLOCK).await;
         }?;
 
         let block = Block::decode(encoded_block.clone())?;
@@ -384,7 +384,7 @@ impl<B: BlocksAccess> LedgerBlocksSynchronizer<B> {
                 if batch.is_ok() || retry == MAX_RETRY {
                     break batch;
                 }
-                retry = retry + 1;
+                retry += 1;
             }
             .map_err(|e| {
                 error!(


### PR DESCRIPTION
We are seeing a high volume of error messages like:

```
Error in syncing blocks: InternalError(false, Details { error_message: Some("Tip of the chain has index 21177563 but no block fou
nd at that index!"), extra_fields: {} })
```

Which is likely caused when we hit a slightly delayed IC node after getting the tip index from a more up-to-date one.

This PR introduces retries for fetching the tip block, so that it can eventually succeed getting the tip block.

It also removes logging failures to get block ranges until all retries have been attempted, cleaning the logs even further.

This was tested locally. Before the change, we were seeing the error logs a few times per minute, with the change the error and warn logs are gone after running for many minutes.