### PR TITLE
chore: Add a metric observing the number of open signature request contexts

### DIFF
--- a/rs/execution_environment/src/scheduler.rs
+++ b/rs/execution_environment/src/scheduler.rs
@@ -1969,7 +1969,8 @@ fn observe_replicated_state_metrics(
     let mut canisters_with_old_open_call_contexts = 0;
     let mut old_call_contexts_count = 0;
     let mut num_stop_canister_calls_without_call_id = 0;
-    let mut open_signature_request_contexts_by_key_id = BTreeMap::<MasterPublicKeyId, u32>::new();
+    let mut in_flight_signature_request_contexts_by_key_id =
+        BTreeMap::<MasterPublicKeyId, u32>::new();
 
     let canister_id_ranges = state.routing_table().ranges(own_subnet_id);
     state.canisters_iter().for_each(|canister| {
@@ -2089,13 +2090,13 @@ fn observe_replicated_state_metrics(
     }
 
     for context in state.signature_request_contexts().values() {
-        *open_signature_request_contexts_by_key_id
+        *in_flight_signature_request_contexts_by_key_id
             .entry(context.key_id())
             .or_default() += 1;
     }
-    for (key_id, count) in open_signature_request_contexts_by_key_id {
+    for (key_id, count) in in_flight_signature_request_contexts_by_key_id {
         metrics
-            .open_signature_request_contexts
+            .in_flight_signature_request_contexts
             .with_label_values(&[&key_id.to_string()])
             .observe(count as f64);
     }

--- a/rs/execution_environment/src/scheduler/scheduler_metrics.rs
+++ b/rs/execution_environment/src/scheduler/scheduler_metrics.rs
@@ -111,7 +111,7 @@ pub(super) struct SchedulerMetrics {
     pub(super) inducted_messages: IntCounterVec,
     pub(super) threshold_signature_agreements: IntGaugeVec,
     pub(super) delivered_pre_signatures: HistogramVec,
-    pub(super) open_signature_request_contexts: HistogramVec,
+    pub(super) in_flight_signature_request_contexts: HistogramVec,
     pub(super) completed_signature_request_contexts: IntCounterVec,
     // TODO(EXC-1466): Remove metric once all calls have `call_id` present.
     pub(super) stop_canister_calls_without_call_id: IntGauge,
@@ -278,9 +278,9 @@ impl SchedulerMetrics {
                 vec![0.0, 1.0, 2.0, 5.0, 10.0, 15.0, 20.0],
                 &["key_id"],
             ),
-            open_signature_request_contexts: metrics_registry.histogram_vec(
-                "execution_open_signature_request_contexts",
-                "Number of open signature request contexts by key ID",
+            in_flight_signature_request_contexts: metrics_registry.histogram_vec(
+                "execution_in_flight_signature_request_contexts",
+                "Number of in flight signature request contexts by key ID",
                 vec![1.0, 2.0, 3.0, 5.0, 10.0, 15.0, 20.0, 50.0],
                 &["key_id"],
             ),

--- a/rs/execution_environment/src/scheduler/tests.rs
+++ b/rs/execution_environment/src/scheduler/tests.rs
@@ -3816,12 +3816,12 @@ fn threshold_signature_agreements_metric_is_updated() {
     );
     test.execute_round(ExecutionRoundType::OrdinaryRound);
 
-    // Metrics are observed at the beginning of the round, so there should be no open contexts yet
-    let open_contexts_metric = fetch_histogram_vec_stats(
+    // Metrics are observed at the beginning of the round, so there should be no in flight contexts yet
+    let in_flight_contexts_metric = fetch_histogram_vec_stats(
         test.metrics_registry(),
-        "execution_open_signature_request_contexts",
+        "execution_in_flight_signature_request_contexts",
     );
-    assert!(open_contexts_metric.is_empty());
+    assert!(in_flight_contexts_metric.is_empty());
 
     // Check that the SubnetCallContextManager contains all requests.
     let sign_with_ecdsa_contexts = &test
@@ -3847,10 +3847,10 @@ fn threshold_signature_agreements_metric_is_updated() {
     test.state_mut().consensus_queue.push(response);
     test.execute_round(ExecutionRoundType::OrdinaryRound);
 
-    // At the beginning of the next round, open contexts should have been observed
-    let open_contexts_metric = fetch_histogram_vec_stats(
+    // At the beginning of the next round, the in flight contexts should have been observed
+    let in_flight_contexts_metric = fetch_histogram_vec_stats(
         test.metrics_registry(),
-        "execution_open_signature_request_contexts",
+        "execution_in_flight_signature_request_contexts",
     );
     assert_eq!(
         metric_vec(&[
@@ -3863,7 +3863,7 @@ fn threshold_signature_agreements_metric_is_updated() {
                 HistogramStats { count: 1, sum: 1.0 }
             ),
         ]),
-        open_contexts_metric,
+        in_flight_contexts_metric,
     );
 
     observe_replicated_state_metrics(
@@ -3875,9 +3875,9 @@ fn threshold_signature_agreements_metric_is_updated() {
     );
 
     // After the round, the rejected context should be observed
-    let open_contexts_metric = fetch_histogram_vec_stats(
+    let in_flight_contexts_metric = fetch_histogram_vec_stats(
         test.metrics_registry(),
-        "execution_open_signature_request_contexts",
+        "execution_in_flight_signature_request_contexts",
     );
     assert_eq!(
         metric_vec(&[
@@ -3890,7 +3890,7 @@ fn threshold_signature_agreements_metric_is_updated() {
                 HistogramStats { count: 2, sum: 2.0 }
             ),
         ]),
-        open_contexts_metric,
+        in_flight_contexts_metric,
     );
 
     let threshold_signature_agreements_before = &test


### PR DESCRIPTION
This will tell us the size of the current request queue for each key ID.