### PR TITLE
fix(EXC-1990): Limit compilation cache entries

### DIFF
--- a/rs/canister_sandbox/src/replica_controller/sandboxed_execution_controller.rs
+++ b/rs/canister_sandbox/src/replica_controller/sandboxed_execution_controller.rs
@@ -2228,6 +2228,7 @@ mod tests {
     use ic_config::{
         execution_environment::MAX_COMPILATION_CACHE_SIZE, logger::Config as LoggerConfig,
     };
+    use ic_embedders::CompilationCacheBuilder;
     use ic_logger::{new_replica_logger, replica_logger::no_op_logger};
     use ic_test_utilities::state_manager::FakeStateManager;
     use ic_test_utilities_types::ids::canister_test_id;
@@ -2304,10 +2305,7 @@ mod tests {
                 canister_module,
                 PathBuf::new(),
                 canister_id,
-                Arc::new(CompilationCache::new(
-                    MAX_COMPILATION_CACHE_SIZE,
-                    tempfile::tempdir().unwrap(),
-                )),
+                Arc::new(CompilationCacheBuilder::new().build()),
             )
             .unwrap();
         let sandbox_pid = match controller

--- a/rs/canister_sandbox/src/replica_controller/sandboxed_execution_controller.rs
+++ b/rs/canister_sandbox/src/replica_controller/sandboxed_execution_controller.rs
@@ -2225,9 +2225,7 @@ mod tests {
     use std::fs::{self, File};
 
     use super::*;
-    use ic_config::{
-        execution_environment::MAX_COMPILATION_CACHE_SIZE, logger::Config as LoggerConfig,
-    };
+    use ic_config::logger::Config as LoggerConfig;
     use ic_embedders::CompilationCacheBuilder;
     use ic_logger::{new_replica_logger, replica_logger::no_op_logger};
     use ic_test_utilities::state_manager::FakeStateManager;

--- a/rs/embedders/fuzz/src/wasm_executor.rs
+++ b/rs/embedders/fuzz/src/wasm_executor.rs
@@ -6,7 +6,7 @@ use ic_config::{
 use ic_cycles_account_manager::ResourceSaturation;
 use ic_embedders::{
     wasm_executor::{WasmExecutor, WasmExecutorImpl},
-    CompilationCache, WasmExecutionInput, WasmtimeEmbedder,
+    CompilationCacheBuilder, WasmExecutionInput, WasmtimeEmbedder,
 };
 use ic_interfaces::execution_environment::{ExecutionMode, SubnetAvailableMemory};
 use ic_logger::replica_logger::no_op_logger;
@@ -89,10 +89,7 @@ fn setup_wasm_execution_input(func_ref: FuncRef) -> WasmExecutionInput {
     let api_type = ApiType::init(UNIX_EPOCH, vec![], user_test_id(24).get());
     let canister_current_memory_usage = NumBytes::new(0);
     let canister_current_message_memory_usage = MessageMemoryUsage::ZERO;
-    let compilation_cache = Arc::new(CompilationCache::new(
-        NumBytes::new(0),
-        tempfile::tempdir().unwrap(),
-    ));
+    let compilation_cache = Arc::new(CompilationCacheBuilder::new().build());
     WasmExecutionInput {
         api_type: api_type.clone(),
         sandbox_safe_system_state: get_system_state(api_type),

--- a/rs/embedders/src/compilation_cache.rs
+++ b/rs/embedders/src/compilation_cache.rs
@@ -75,6 +75,11 @@ pub struct CompilationCacheBuilder {
     max_entries: usize,
 }
 
+impl Default for CompilationCacheBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
 impl CompilationCacheBuilder {
     pub fn new() -> Self {
         Self {

--- a/rs/embedders/src/compilation_cache.rs
+++ b/rs/embedders/src/compilation_cache.rs
@@ -21,9 +21,21 @@ use ic_wasm_types::{CanisterModule, WasmHash};
 
 const GB: u64 = 1024 * 1024 * 1024;
 
+/// Each entry holds two file descriptors, so this will limit us to 1M total
+/// descriptors used by the cache.
+const DEFAULT_MAX_ENTRIES: usize = 500_000;
+
+/// 100 GiB should be plenty. Otherwise a large portion of subnet memory would
+/// be in Wasm code even though the x86 is a bit larger.
+const DEFAULT_DISK_CAPACITY: NumBytes = NumBytes::new(100 * GB);
+
+/// 10 GiB is already more than we can support with the entry count limit anyway.
+const DEFAULT_MEMORY_CAPACITY: NumBytes = NumBytes::new(10 * GB);
+
 /// Stores the serialized modules of wasm code that has already been compiled so
 /// that it can be used again without recompiling.
 pub enum CompilationCache {
+    // TODO(EXC-1991): Deprecate in memory version.
     Memory {
         cache: Mutex<LruCache<WasmHash, HypervisorResult<Arc<SerializedModule>>>>,
     },
@@ -35,6 +47,8 @@ pub enum CompilationCache {
         cache: Mutex<LruCache<WasmHash, HypervisorResult<Arc<OnDiskSerializedModule>>>>,
         /// Atomic counter to deduplicate files in the case of concurrent compilations of the same module.
         counter: AtomicU64,
+        /// Limit on the total number of entries in the cache.
+        max_entries: usize,
     },
 }
 
@@ -54,28 +68,71 @@ impl MemoryDiskBytes for CompilationCache {
     }
 }
 
-impl CompilationCache {
-    pub fn new(capacity: NumBytes, dir: TempDir) -> Self {
-        Self::Disk {
-            dir,
-            cache: Mutex::new(LruCache::new(capacity, NumBytes::from(100 * GB))),
-            counter: AtomicU64::new(0),
+pub struct CompilationCacheBuilder {
+    memory_capacity: NumBytes,
+    disk_capacity: NumBytes,
+    dir: Option<TempDir>,
+    max_entries: usize,
+}
+
+impl CompilationCacheBuilder {
+    pub fn new() -> Self {
+        Self {
+            memory_capacity: DEFAULT_MEMORY_CAPACITY,
+            disk_capacity: DEFAULT_DISK_CAPACITY,
+            dir: None,
+            max_entries: DEFAULT_MAX_ENTRIES,
         }
     }
 
+    pub fn with_memory_capacity(mut self, memory_capacity: NumBytes) -> Self {
+        self.memory_capacity = memory_capacity;
+        self
+    }
+
+    pub fn with_disk_capacity(mut self, disk_capacity: NumBytes) -> Self {
+        self.disk_capacity = disk_capacity;
+        self
+    }
+
+    pub fn with_dir(mut self, dir: TempDir) -> Self {
+        self.dir = Some(dir);
+        self
+    }
+
+    pub fn with_max_entries(mut self, max_entries: usize) -> Self {
+        self.max_entries = max_entries;
+        self
+    }
+
+    pub fn build(self) -> CompilationCache {
+        let dir = self.dir.unwrap_or_else(|| tempfile::tempdir().unwrap());
+        CompilationCache::Disk {
+            dir,
+            cache: Mutex::new(LruCache::new(self.memory_capacity, self.disk_capacity)),
+            counter: AtomicU64::new(0),
+            max_entries: self.max_entries,
+        }
+    }
+}
+
+impl CompilationCache {
     pub fn insert_err(&self, canister_module: &CanisterModule, err: HypervisorError) {
         match self {
             Self::Memory { cache } => {
-                cache
-                    .lock()
-                    .unwrap()
-                    .push(WasmHash::from(canister_module), Err(err));
-            }
-            Self::Disk { cache, .. } => {
                 let _ = cache
                     .lock()
                     .unwrap()
                     .push(WasmHash::from(canister_module), Err(err));
+            }
+            Self::Disk {
+                cache, max_entries, ..
+            } => {
+                let mut cache = cache.lock().unwrap();
+                if cache.len() >= *max_entries {
+                    let _ = cache.pop_lru();
+                }
+                let _ = cache.push(WasmHash::from(canister_module), Err(err));
             }
         }
     }
@@ -89,7 +146,7 @@ impl CompilationCache {
             Self::Memory { cache } => {
                 let serialized_module = Arc::new(serialized_module);
                 let copy = Arc::clone(&serialized_module);
-                cache
+                let _ = cache
                     .lock()
                     .unwrap()
                     .push(WasmHash::from(canister_module), Ok(serialized_module));
@@ -99,6 +156,7 @@ impl CompilationCache {
                 dir,
                 cache,
                 counter,
+                max_entries,
                 ..
             } => {
                 // The file paths must not have existing files. To ensure this
@@ -117,7 +175,11 @@ impl CompilationCache {
                     &initial_state_path,
                 ));
 
-                let _ = cache.lock().unwrap().push(hash, Ok(Arc::clone(&on_disk)));
+                let mut cache = cache.lock().unwrap();
+                if cache.len() >= *max_entries {
+                    let _ = cache.pop_lru();
+                }
+                let _ = cache.push(hash, Ok(Arc::clone(&on_disk)));
                 StoredCompilation::Disk(on_disk)
             }
         }
@@ -213,10 +275,7 @@ impl StoredCompilation {
 /// each other if they all try to insert in the cache at the same time.
 #[test]
 fn concurrent_insertions() {
-    let cache = CompilationCache::new(
-        NumBytes::from(30 * 1024 * 1024),
-        tempfile::tempdir().unwrap(),
-    );
+    let cache = CompilationCacheBuilder::new().build();
     let wasm = wat::parse_str("(module)").unwrap();
     let canister_module = CanisterModule::new(wasm.clone());
     let binary = ic_wasm_types::BinaryEncodedWasm::new(wasm.clone());

--- a/rs/embedders/src/lib.rs
+++ b/rs/embedders/src/lib.rs
@@ -7,7 +7,7 @@ pub mod wasmtime_embedder;
 
 use std::{sync::Arc, time::Duration};
 
-pub use compilation_cache::{CompilationCache, StoredCompilation};
+pub use compilation_cache::{CompilationCache, CompilationCacheBuilder, StoredCompilation};
 use ic_interfaces::execution_environment::SubnetAvailableMemory;
 use ic_replicated_state::{Global, MessageMemoryUsage, PageIndex};
 use ic_system_api::{

--- a/rs/embedders/tests/compilation_cache.rs
+++ b/rs/embedders/tests/compilation_cache.rs
@@ -1,0 +1,66 @@
+//! This test is run as an integration test so that it runs as it's own process.
+//! This is required to use /proc to count open file descriptors without
+//! interference from other tests running in the same process.
+
+use std::fs::read_dir;
+
+use ic_config::embedders::Config;
+use ic_embedders::{wasm_utils::compile, CompilationCacheBuilder, WasmtimeEmbedder};
+use ic_logger::no_op_logger;
+use ic_wasm_types::{BinaryEncodedWasm, CanisterModule};
+
+fn count_open_fds() -> usize {
+    read_dir("/proc/self/fd").unwrap().count()
+}
+
+/// With a limit of 1000 entries in the cache we expect it to have about 2000
+/// open file descriptors when full.
+#[test]
+fn check_file_descriptors() {
+    const COUNT: usize = 1_000;
+
+    let cache = CompilationCacheBuilder::new()
+        .with_max_entries(COUNT)
+        .build();
+
+    let serialized = compile(
+        &WasmtimeEmbedder::new(Config::default(), no_op_logger()),
+        &BinaryEncodedWasm::new(wat::parse_str("(module)").unwrap()),
+    )
+    .1
+    .unwrap()
+    .1;
+
+    // Insert 1000 entries to the cache.
+    for i in 0..1_000_u64 {
+        cache.insert_ok(
+            &CanisterModule::new(i.to_le_bytes().to_vec()),
+            serialized.clone(),
+        );
+    }
+    let open_fds = count_open_fds();
+    // We should have at least 2 file descriptors open per entry.
+    assert!(
+        open_fds > 1000,
+        "Number of open file descriptors {open_fds} is less than the expected 100."
+    );
+    // We should not have more than 2000 open file descriptors (with some wiggle room).
+    assert!(
+        open_fds < 2000 + 5,
+        "Number of open file descriptors {open_fds} is greater than the expected 2000 + epsilon."
+    );
+
+    // Insert 1000 new entries to the cache.
+    for i in 1_000..2_000_u64 {
+        cache.insert_ok(
+            &CanisterModule::new(i.to_le_bytes().to_vec()),
+            serialized.clone(),
+        );
+    }
+    let open_fds = count_open_fds();
+    // We should not have more than 2000 open file descriptors (with some wiggle room).
+    assert!(
+        open_fds < 2000 + 5,
+        "Number of open file descriptors {open_fds} is greater than the expected 2000 + epsilon."
+    );
+}

--- a/rs/execution_environment/src/hypervisor.rs
+++ b/rs/execution_environment/src/hypervisor.rs
@@ -2,6 +2,7 @@ use ic_canister_sandbox_backend_lib::replica_controller::sandboxed_execution_con
 use ic_config::execution_environment::{Config, MAX_COMPILATION_CACHE_SIZE};
 use ic_config::flag_status::FlagStatus;
 use ic_cycles_account_manager::CyclesAccountManager;
+use ic_embedders::CompilationCacheBuilder;
 use ic_embedders::{
     wasm_executor::{WasmExecutionResult, WasmExecutor, WasmExecutorImpl},
     wasm_utils::decoding::decoded_wasm_size,
@@ -225,10 +226,12 @@ impl Hypervisor {
             own_subnet_id,
             log,
             cycles_account_manager,
-            compilation_cache: Arc::new(CompilationCache::new(
-                MAX_COMPILATION_CACHE_SIZE,
-                tempfile::tempdir_in(temp_dir).unwrap(),
-            )),
+            compilation_cache: Arc::new(
+                CompilationCacheBuilder::new()
+                    .with_memory_capacity(MAX_COMPILATION_CACHE_SIZE)
+                    .with_dir(tempfile::tempdir_in(temp_dir).unwrap())
+                    .build(),
+            ),
             deterministic_time_slicing: config.deterministic_time_slicing,
             cost_to_compile_wasm_instruction: config
                 .embedders_config
@@ -256,10 +259,12 @@ impl Hypervisor {
             own_subnet_id,
             log,
             cycles_account_manager,
-            compilation_cache: Arc::new(CompilationCache::new(
-                MAX_COMPILATION_CACHE_SIZE,
-                tempfile::tempdir().unwrap(),
-            )),
+            compilation_cache: Arc::new(
+                CompilationCacheBuilder::new()
+                    .with_memory_capacity(MAX_COMPILATION_CACHE_SIZE)
+                    .with_dir(tempfile::tempdir().unwrap())
+                    .build(),
+            ),
             deterministic_time_slicing,
             cost_to_compile_wasm_instruction,
             dirty_page_overhead,

--- a/rs/types/types/src/lib.rs
+++ b/rs/types/types/src/lib.rs
@@ -534,8 +534,8 @@ pub trait CountBytes {
     fn count_bytes(&self) -> usize;
 }
 
-/// Allow an object to reprt its own byte size on disk and in memory. Not
-/// necessarilly exact.
+/// Allow an object to report its own byte size on disk and in memory. Not
+/// necessarily exact.
 pub trait MemoryDiskBytes {
     fn memory_bytes(&self) -> usize;
     fn disk_bytes(&self) -> usize;

--- a/rs/utils/lru_cache/src/lib.rs
+++ b/rs/utils/lru_cache/src/lib.rs
@@ -127,6 +127,11 @@ where
         }
     }
 
+    /// Remove the least recently used entry from the cache.
+    pub fn pop_lru(&mut self) -> Option<(K, V)> {
+        self.cache.pop_lru()
+    }
+
     /// Clears the cache by removing all items.
     pub fn clear(&mut self) {
         self.cache.clear();


### PR DESCRIPTION
Limit the number of entries in the compilation cache so that it doesn't take up too many file descriptors.