### PR TITLE
fix(icp-rosetta): [FI-1694] add watchdog thread to oversee the sync thread

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19825,6 +19825,8 @@ dependencies = [
  "serde_bytes",
  "serde_json",
  "serde_with 1.14.0",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/rs/rosetta-api/common/rosetta_core/BUILD.bazel
+++ b/rs/rosetta-api/common/rosetta_core/BUILD.bazel
@@ -18,6 +18,8 @@ DEPENDENCIES = [
     "@crate_index//:serde_bytes",
     "@crate_index//:serde_json",
     "@crate_index//:serde_with",
+    "@crate_index//:tokio",
+    "@crate_index//:tracing",
 ]
 
 MACRO_DEPENDENCIES = [

--- a/rs/rosetta-api/common/rosetta_core/Cargo.toml
+++ b/rs/rosetta-api/common/rosetta_core/Cargo.toml
@@ -23,6 +23,8 @@ serde = { workspace = true }
 serde_bytes = { workspace = true }
 serde_json = { workspace = true }
 serde_with = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }
 icp-ledger = { path = "../../../ledger_suite/icp" }
 
 [dev-dependencies]

--- a/rs/rosetta-api/common/rosetta_core/src/lib.rs
+++ b/rs/rosetta-api/common/rosetta_core/src/lib.rs
@@ -5,3 +5,4 @@ pub mod models;
 pub mod objects;
 pub mod request_types;
 pub mod response_types;
+pub mod watchdog;

--- a/rs/rosetta-api/common/rosetta_core/src/watchdog.rs
+++ b/rs/rosetta-api/common/rosetta_core/src/watchdog.rs
@@ -1,0 +1,332 @@
+//! Module providing a simple watchdog that monitors a thread via periodic heartbeats.
+
+use std::sync::{
+    atomic::{AtomicBool, AtomicU64, Ordering},
+    Arc,
+};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use tracing::{error, info};
+
+/// A watchdog thread that monitors a monitored task by checking periodic heartbeats.
+/// If the heartbeat is not updated within a specified timeout, the watchdog will trigger
+/// a restart callback and abort the monitored task.
+///
+/// The `skip_first_heartbeat_check` configuration determines whether the loss of heartbeats
+/// before the first heartbeat is observed is tolerated (true) or treated as a timeout (false).
+pub struct WatchdogThread {
+    /// Indicates whether the watchdog has been stopped.
+    stopped: Arc<AtomicBool>,
+    /// Maximum allowed duration between heartbeats (monitored task's responsiveness timeout).
+    heartbeat_timeout: Duration,
+    /// Handle to the internal watchdog monitoring task.
+    handle: Option<tokio::task::JoinHandle<()>>,
+    /// Optional callback invoked when the monitored task is restarted.
+    on_restart: Option<Arc<dyn Fn() + Send + Sync>>,
+    /// Timestamp (in milliseconds) of the last heartbeat received.
+    last_heartbeat_ms: Arc<AtomicU64>,
+    /// If true, missing the first heartbeat is tolerated and does not trigger a restart.
+    skip_first_heartbeat_check: bool,
+}
+
+impl WatchdogThread {
+    /// Creates a new `WatchdogThread` with the specified `heartbeat_timeout` and `skip_first_heartbeat` mode.
+    ///
+    /// # Arguments
+    ///
+    /// * `heartbeat_timeout` - Duration that the watchdog will wait before considering the monitored task stalled.
+    /// * `on_restart` - Optional callback function that is called when the watchdog restarts the task.
+    /// * `skip_first_heartbeat` - If true, the watchdog will not trigger a restart if no heartbeat is received before the first heartbeat.
+    pub fn new(
+        heartbeat_timeout: Duration,
+        on_restart: Option<Arc<dyn Fn() + Send + Sync>>,
+        skip_first_heartbeat_check: bool,
+    ) -> Self {
+        Self {
+            stopped: Arc::new(AtomicBool::new(false)),
+            heartbeat_timeout,
+            handle: None,
+            on_restart,
+            last_heartbeat_ms: Arc::new(AtomicU64::new(0)),
+            skip_first_heartbeat_check,
+        }
+    }
+
+    /// Returns the current timestamp in milliseconds since the UNIX epoch.
+    fn current_timestamp() -> u64 {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("Time went backwards")
+            .as_millis() as u64
+    }
+
+    /// Starts monitoring a thread.
+    ///
+    /// The provided closure `create_thread` should spawn the monitored task and call the provided heartbeat callback periodically.
+    /// If the monitored task does not update the heartbeat within the timeout, the watchdog will log an error,
+    /// call the optional restart callback, and abort the monitored task.
+    ///
+    /// # Arguments
+    ///
+    /// * `create_thread` - A closure that receives a heartbeat callback and returns a JoinHandle of the spawned task.
+    pub fn start<F>(&mut self, mut create_thread: F)
+    where
+        F: FnMut(
+                Box<dyn Fn() + Send + Sync>
+            ) -> tokio::task::JoinHandle<()>
+            + Send
+            + 'static,
+    {
+        let stopped = self.stopped.clone();
+        let heartbeat_timeout = self.heartbeat_timeout;
+        let on_restart = self.on_restart.clone();
+        let last_heartbeat_ms = self.last_heartbeat_ms.clone();
+        let skip_first = self.skip_first_heartbeat_check;
+
+        let handle = tokio::spawn(async move {
+            loop {
+                if stopped.load(Ordering::SeqCst) {
+                    info!("Stopping the watchdog thread");
+                    break;
+                }
+
+                // Clone for this iteration so the closures below have their own copies.
+                let last_heartbeat_clone = last_heartbeat_ms.clone();
+
+                let thread_handle = create_thread(
+                    Box::new(move || {
+                        last_heartbeat_clone
+                            .store(Self::current_timestamp(), Ordering::SeqCst);
+                    }),
+                );
+
+                loop {
+                    tokio::time::sleep(heartbeat_timeout).await;
+                    let last = last_heartbeat_ms.load(Ordering::SeqCst);
+                    if last == 0 {
+                        if skip_first {
+                            continue;
+                        } else {
+                            error!("No heartbeat received and skip_first_heartbeat disabled, restarting");
+                        }
+                    }
+                    let now = Self::current_timestamp();
+                    if now - last > heartbeat_timeout.as_millis() as u64 {
+                        if stopped.load(Ordering::SeqCst) {
+                            break;
+                        }
+                        error!("Thread is not responding, restarting");
+                        if let Some(ref on_restart_fn) = on_restart {
+                            on_restart_fn();
+                        }
+                        thread_handle.abort();
+                        if let Err(e) = thread_handle.await {
+                            if e.is_cancelled() {
+                                info!("Monitored task stopped");
+                            } else {
+                                error!("Monitored task aborted: {:?}", e);
+                            }
+                        }
+                        break;
+                    }
+                }
+            }
+        });
+
+        self.handle = Some(handle);
+    }
+
+    /// Stops the watchdog thread gracefully, aborting the monitored task if needed.
+    pub async fn stop(&mut self) {
+        info!("Stopping watchdog thread");
+        self.stopped.store(true, Ordering::SeqCst);
+        if let Some(handle) = self.handle.take() {
+            handle.abort();
+            if let Err(e) = handle.await {
+                if e.is_cancelled() {
+                    info!("Watchdog thread stopped");
+                } else {
+                    error!("Error stopping watchdog thread: {:?}", e);
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::AtomicUsize;
+    use std::sync::Arc;
+    use tokio::time::sleep;
+
+    #[tokio::test]
+    async fn test_watchdog_thread_starts_and_stops() {
+        let mut watchdog = WatchdogThread::new(Duration::from_secs(1), None, false);
+
+        watchdog.start(|heartbeat| {
+            tokio::spawn(async move {
+                loop {
+                    heartbeat();
+                    sleep(Duration::from_secs(1)).await;
+                }
+            })
+        });
+
+        sleep(Duration::from_secs(2)).await;
+        watchdog.stop().await;
+    }
+
+    #[tokio::test]
+    async fn test_watchdog_thread_restarts_on_no_heartbeat() {
+        let restart_count = Arc::new(AtomicUsize::new(0));
+        let restart_count_clone = restart_count.clone();
+        let mut watchdog = WatchdogThread::new(
+            Duration::from_secs(1),
+            Some(Arc::new(move || {
+                restart_count_clone.fetch_add(1, Ordering::SeqCst);
+            })),
+            false,
+        );
+
+        watchdog.start(|heartbeat| {
+            tokio::spawn(async move {
+                heartbeat();
+                println!(">> HERE 0");
+                loop {
+                    println!(">> HERE 1");
+                    // Do not send heartbeats.
+                    sleep(Duration::from_secs(2)).await;
+                }
+            })
+        });
+
+        sleep(Duration::from_secs(3)).await;
+        watchdog.stop().await;
+
+        assert!(
+            restart_count.load(Ordering::SeqCst) > 0,
+            "Watchdog thread should have restarted at least once"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_watchdog_thread_receives_heartbeat() {
+        let mut watchdog = WatchdogThread::new(Duration::from_secs(1), None, false);
+
+        watchdog.start(|heartbeat| {
+            tokio::spawn(async move {
+                loop {
+                    heartbeat();
+                    sleep(Duration::from_millis(500)).await;
+                }
+            })
+        });
+
+        sleep(Duration::from_secs(3)).await;
+        watchdog.stop().await;
+    }
+
+    #[tokio::test]
+    async fn test_watchdog_thread_stops_properly() {
+        let mut watchdog = WatchdogThread::new(Duration::from_secs(1), None, false);
+
+        watchdog.start(|heartbeat| {
+            tokio::spawn(async move {
+                loop {
+                    heartbeat();
+                    sleep(Duration::from_millis(500)).await;
+                }
+            })
+        });
+
+        sleep(Duration::from_secs(1)).await;
+        watchdog.stop().await;
+
+        // Ensure the watchdog thread has stopped.
+        assert!(
+            watchdog.handle.is_none(),
+            "Watchdog thread should be stopped"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_watchdog_thread_handles_multiple_restarts() {
+        let restart_count = Arc::new(AtomicUsize::new(0));
+        let restart_count_clone = restart_count.clone();
+        let mut watchdog = WatchdogThread::new(
+            Duration::from_secs(1),
+            Some(Arc::new(move || {
+                restart_count_clone.fetch_add(1, Ordering::SeqCst);
+            })),
+            false,
+        );
+
+        watchdog.start(|heartbeat| {
+            heartbeat();
+            tokio::spawn(async move {
+                loop {
+                    // Do not send heartbeats.
+                    sleep(Duration::from_secs(2)).await;
+                }
+            })
+        });
+
+        sleep(Duration::from_secs(5)).await;
+        watchdog.stop().await;
+
+        assert!(
+            restart_count.load(Ordering::SeqCst) >= 2,
+            "Watchdog thread should have restarted at least twice"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_skip_first_heartbeat_enabled() {
+        // When skip_first_heartbeat is enabled, lack of initial heartbeat should be tolerated.
+        let mut watchdog = WatchdogThread::new(Duration::from_secs(1), None, true);
+        // Spawn a task which delays the first call to heartbeat.
+        let start = std::time::Instant::now();
+        watchdog.start(|heartbeat| {
+            tokio::spawn(async move {
+                // Delay longer than heartbeat_timeout for the first heartbeat.
+                sleep(Duration::from_secs(2)).await;
+                heartbeat();
+                loop {
+                    sleep(Duration::from_secs(1)).await;
+                    heartbeat();
+                }
+            })
+        });
+        // Sleep enough time to cover the initial delay plus one timeout period.
+        sleep(Duration::from_secs(4)).await;
+        watchdog.stop().await;
+        // If skip_first_heartbeat works, no restart should have been triggered.
+        // (In this test, we do not count restarts, so absence of panic is the test.)
+        assert!(start.elapsed() >= Duration::from_secs(4));
+    }
+
+    #[tokio::test]
+    async fn test_skip_first_heartbeat_disabled() {
+        // When skip_first_heartbeat is disabled, absence of the first heartbeat should trigger a restart.
+        let restart_count = Arc::new(AtomicUsize::new(0));
+        let restart_clone = restart_count.clone();
+        let mut watchdog = WatchdogThread::new(Duration::from_secs(1), Some(Arc::new(move || {
+            restart_clone.fetch_add(1, Ordering::SeqCst);
+        })), false);
+        // Spawn a task that deliberately delays the heartbeat beyond the timeout.
+        watchdog.start(|heartbeat| {
+            tokio::spawn(async move {
+                // Delay for 2 seconds (exceeds timeout) before sending any heartbeat.
+                sleep(Duration::from_secs(2)).await;
+                heartbeat();
+                loop {
+                    sleep(Duration::from_secs(1)).await;
+                    heartbeat();
+                }
+            })
+        });
+        sleep(Duration::from_secs(3)).await;
+        watchdog.stop().await;
+        assert!(restart_count.load(Ordering::SeqCst) > 0, "Expected at least one restart when skip_first_heartbeat is disabled");
+    }
+}

--- a/rs/rosetta-api/icp/src/main.rs
+++ b/rs/rosetta-api/icp/src/main.rs
@@ -97,6 +97,7 @@ fn init_logging(level: Level) -> std::io::Result<WorkerGuard> {
     fn rosetta_filter(module: &str) -> bool {
         module.starts_with("ic_rosetta_api")
             || module.starts_with("ic_ledger_canister_blocks_synchronizer")
+            || module.starts_with("rosetta_core")
     }
     let rosetta_filter =
         FilterFn::new(|metadata| metadata.module_path().map_or(true, rosetta_filter));


### PR DESCRIPTION
This PR introduces an implementation of a watchdog thread that monitors heartbeats from a monitored thread and restarts it when there's no heartbeat during a specified timeout interval.

The watchdog class is used to monitor the background synchronization thread in ICP Rosetta, so any potential deadlock is eventually mitigated within 10 seconds. 

The watchdog implementation will later be used for ICRC1 Rosetta as well.

Tests:
Besides unit tests for the watchdog thread itself, I've manually tested this by introducing random delays in the sync thread (not being committed here) and observed the successful restarts.