### PR TITLE
chore(IDX): load ledger suite orchestrator wasm directly

### DIFF
--- a/rs/ethereum/ledger-suite-orchestrator/test_utils/src/lib.rs
+++ b/rs/ethereum/ledger-suite-orchestrator/test_utils/src/lib.rs
@@ -16,7 +16,6 @@ use ic_management_canister_types_private::{
 };
 use ic_metrics_assert::{CanisterHttpQuery, MetricsAssert};
 use ic_state_machine_tests::{StateMachine, StateMachineBuilder, UserError, WasmResult};
-use ic_test_utilities_load_wasm::load_wasm;
 use ic_types::Cycles;
 pub use icrc_ledger_types::icrc::generic_metadata_value::MetadataValue as LedgerMetadataValue;
 pub use icrc_ledger_types::icrc1::account::Account as LedgerAccount;
@@ -371,51 +370,38 @@ pub fn new_state_machine() -> StateMachine {
 }
 
 pub fn ledger_suite_orchestrator_wasm() -> Vec<u8> {
-    load_wasm(
-        std::env::var("CARGO_MANIFEST_DIR").unwrap(),
-        "ledger_suite_orchestrator",
-        &[],
-    )
+    let wasm_path = std::env::var("LEDGER_SUITE_ORCHESTRATOR_WASM_PATH").unwrap();
+    std::fs::read(wasm_path).unwrap()
 }
 
 pub fn ledger_suite_orchestrator_get_blocks_disabled_wasm() -> Vec<u8> {
-    load_wasm(
-        std::env::var("CARGO_MANIFEST_DIR").unwrap(),
-        "ledger_suite_orchestrator_get_blocks_disabled",
-        &[],
-    )
+    let wasm_path =
+        std::env::var("LEDGER_SUITE_ORCHESTRATOR_GET_BLOCKS_DISABLED_WASM_PATH").unwrap();
+    std::fs::read(wasm_path).unwrap()
 }
 
 pub fn ledger_wasm() -> LedgerWasm {
-    LedgerWasm::from(load_wasm(
-        std::env::var("CARGO_MANIFEST_DIR").unwrap(),
-        "ledger_canister",
-        &[],
-    ))
+    let wasm_path = std::env::var("LEDGER_CANISTER_WASM_PATH").unwrap();
+    let wasm = std::fs::read(wasm_path).unwrap();
+    LedgerWasm::from(wasm)
 }
 
 fn ledger_get_blocks_disabled_wasm() -> LedgerWasm {
-    LedgerWasm::from(load_wasm(
-        std::env::var("CARGO_MANIFEST_DIR").unwrap(),
-        "ledger_canister_get_blocks_disabled",
-        &[],
-    ))
+    let wasm_path = std::env::var("LEDGER_CANISTER_GET_BLOCKS_DISABLED_WASM_PATH").unwrap();
+    let wasm = std::fs::read(wasm_path).unwrap();
+    LedgerWasm::from(wasm)
 }
 
 pub fn index_wasm() -> IndexWasm {
-    IndexWasm::from(load_wasm(
-        std::env::var("CARGO_MANIFEST_DIR").unwrap(),
-        "index_canister",
-        &[],
-    ))
+    let wasm_path = std::env::var("INDEX_CANISTER_WASM_PATH").unwrap();
+    let wasm = std::fs::read(wasm_path).unwrap();
+    IndexWasm::from(wasm)
 }
 
 fn archive_wasm() -> ArchiveWasm {
-    ArchiveWasm::from(load_wasm(
-        std::env::var("CARGO_MANIFEST_DIR").unwrap(),
-        "ledger_archive_node_canister",
-        &[],
-    ))
+    let wasm_path = std::env::var("LEDGER_ARCHIVE_NODE_CANISTER_WASM_PATH").unwrap();
+    let wasm = std::fs::read(wasm_path).unwrap();
+    ArchiveWasm::from(wasm)
 }
 
 fn is_gzipped_blob(blob: &[u8]) -> bool {


### PR DESCRIPTION
This removes usages of `ic_test_utilities::load_wasm` from the `ledger_suite_orchestrator` test utils.

The `load_wasm` helper was introduced when both cargo & bazel tests were supported; now it merely adds indirection so we remove it. This also makes navigating the code & dependencies much easier as environment variables are referenced by named, instead of inferred from canister name.