### PR TITLE
test(IDX): only enable `flaky = True` for tests that are >= 1% flaky

### DIFF
--- a/bazel/README.md
+++ b/bazel/README.md
@@ -296,9 +296,11 @@ Mark the test as **flaky** to make Bazel will retry the test up to three times.
 rust_test(
 	name = "foo_test",
   # lines omitted
-	flaky = True",
+	flaky = True",  # flakiness rate of $f% over the last month on $date.
 )
 ```
+
+Where you can retrieve the flakiness rate $f from Superset.
 
 Instruct rust to only run one test in parallel - this can help when multiple
 concurrent test cases collide but may greatly increase the runtime of the tests.

--- a/packages/pocket-ic/BUILD.bazel
+++ b/packages/pocket-ic/BUILD.bazel
@@ -80,7 +80,6 @@ rust_test_suite(
         "SSL_CERT_FILE": "$(rootpath @mozilla_root_ca_store//file)",
         "TEST_WASM": "$(rootpath //packages/pocket-ic/test_canister:test_canister.wasm)",
     },
-    flaky = False,
     proc_macro_deps = MACRO_DEPENDENCIES,
     tags = [
         "cpu:16",
@@ -104,7 +103,6 @@ rust_test_suite(
         "POCKET_IC_BIN": "$(rootpath //rs/pocket_ic_server:pocket-ic-server)",
         "SSL_CERT_FILE": "$(rootpath @mozilla_root_ca_store//file)",
     },
-    flaky = False,
     proc_macro_deps = MACRO_DEPENDENCIES,
     tags = [
         # TODO: remove 'requires-network' tag when the root cause for sporadic error below on Apple Silicon is identified and fixed.
@@ -129,7 +127,6 @@ rust_test_suite(
         "SSL_CERT_FILE": "$(rootpath @mozilla_root_ca_store//file)",
         "TEST_WASM": "$(rootpath //packages/pocket-ic/test_canister:test_canister.wasm)",
     },
-    flaky = False,
     proc_macro_deps = MACRO_DEPENDENCIES,
     tags = [
         "cpu:16",

--- a/rs/boundary_node/rate_limits/integration_tests/BUILD.bazel
+++ b/rs/boundary_node/rate_limits/integration_tests/BUILD.bazel
@@ -68,7 +68,6 @@ rust_test_suite_with_extra_srcs(
     data = DEV_DATA,
     env = DEV_ENV,
     extra_srcs = [],
-    flaky = False,
     proc_macro_deps = MACRO_DEPENDENCIES + MACRO_DEV_DEPENDENCIES,
     tags = [],
     deps = [":rate_limit_canister_integration_tests"] + DEPENDENCIES + DEV_DEPENDENCIES,

--- a/rs/boundary_node/salt_sharing/integration_tests/BUILD.bazel
+++ b/rs/boundary_node/salt_sharing/integration_tests/BUILD.bazel
@@ -63,7 +63,6 @@ rust_test_suite_with_extra_srcs(
     data = DEV_DATA,
     env = DEV_ENV,
     extra_srcs = [],
-    flaky = False,
     proc_macro_deps = [],
     tags = [],
     deps = [":salt_sharing_canister_integration_tests"] + DEPENDENCIES,

--- a/rs/nervous_system/integration_tests/BUILD.bazel
+++ b/rs/nervous_system/integration_tests/BUILD.bazel
@@ -198,7 +198,6 @@ rust_test_suite_with_extra_srcs(
     data = DEV_DATA,
     env = DEV_ENV,
     extra_srcs = ["tests/sns_upgrade_test_utils.rs"],
-    flaky = True,
     proc_macro_deps = MACRO_DEPENDENCIES + MACRO_DEV_DEPENDENCIES,
     tags = [
         "cpu:6",
@@ -217,7 +216,6 @@ rust_test(
     crate_root = "tests/upgrade_everything_test.rs",
     data = DEV_DATA,
     env = DEV_ENV | {"RUST_TEST_NOCAPTURE": "1"},
-    flaky = True,
     proc_macro_deps = MACRO_DEPENDENCIES + MACRO_DEV_DEPENDENCIES,
     tags = [
         "cpu:6",
@@ -234,7 +232,6 @@ rust_test(
     aliases = ALIASES,
     data = DEV_DATA,
     env = DEV_ENV | {"RUST_TEST_NOCAPTURE": "1"},
-    flaky = True,
     proc_macro_deps = MACRO_DEPENDENCIES + MACRO_DEV_DEPENDENCIES,
     tags = [
         "cpu:4",
@@ -251,7 +248,6 @@ rust_test(
     aliases = ALIASES,
     data = DEV_DATA,
     env = DEV_ENV | {"RUST_TEST_NOCAPTURE": "1"},
-    flaky = True,
     proc_macro_deps = MACRO_DEPENDENCIES + MACRO_DEV_DEPENDENCIES,
     tags = [
         "cpu:4",
@@ -268,7 +264,6 @@ rust_test(
     aliases = ALIASES,
     data = DEV_DATA,
     env = DEV_ENV | {"RUST_TEST_NOCAPTURE": "1"},
-    flaky = True,
     proc_macro_deps = MACRO_DEPENDENCIES + MACRO_DEV_DEPENDENCIES,
     tags = [
         "cpu:4",
@@ -286,7 +281,6 @@ rust_test(
     aliases = ALIASES,
     data = DEV_DATA,
     env = DEV_ENV | {"RUST_TEST_NOCAPTURE": "1"},
-    flaky = True,
     proc_macro_deps = MACRO_DEPENDENCIES + MACRO_DEV_DEPENDENCIES,
     tags = [
         "cpu:4",
@@ -303,7 +297,6 @@ rust_test(
     aliases = ALIASES,
     data = DEV_DATA,
     env = DEV_ENV | {"RUST_TEST_NOCAPTURE": "1"},
-    flaky = True,
     proc_macro_deps = MACRO_DEPENDENCIES + MACRO_DEV_DEPENDENCIES,
     tags = [
         "cpu:4",
@@ -320,7 +313,6 @@ rust_test(
     aliases = ALIASES,
     data = DEV_DATA,
     env = DEV_ENV | {"RUST_TEST_NOCAPTURE": "1"},
-    flaky = False,
     proc_macro_deps = MACRO_DEPENDENCIES + MACRO_DEV_DEPENDENCIES,
     tags = [
         "cpu:4",
@@ -337,7 +329,6 @@ rust_test(
     aliases = ALIASES,
     data = DEV_DATA,
     env = DEV_ENV | {"RUST_TEST_NOCAPTURE": "1"},
-    flaky = False,
     proc_macro_deps = MACRO_DEPENDENCIES + MACRO_DEV_DEPENDENCIES,
     tags = [
         "cpu:4",

--- a/rs/nns/integration_tests/BUILD.bazel
+++ b/rs/nns/integration_tests/BUILD.bazel
@@ -267,7 +267,7 @@ rust_ic_test_suite_with_extra_srcs(
     data = DEV_DATA,
     env = DEV_ENV,
     extra_srcs = ["src/lib.rs"],
-    flaky = True,  # flakiness rate of 1.29% over the last month on 2024-03-11 for the "governance_time_warp" test
+    flaky = True,  # flakiness rate of 1.29% over the month from 2025-02-11 till 2025-03-11 for the "governance_time_warp" test
     proc_macro_deps = MACRO_DEPENDENCIES + MACRO_DEV_DEPENDENCIES,
     deps = DEPENDENCIES_WITH_TEST_FEATURES + DEV_DEPENDENCIES,
 )

--- a/rs/nns/integration_tests/BUILD.bazel
+++ b/rs/nns/integration_tests/BUILD.bazel
@@ -267,7 +267,7 @@ rust_ic_test_suite_with_extra_srcs(
     data = DEV_DATA,
     env = DEV_ENV,
     extra_srcs = ["src/lib.rs"],
-    flaky = True,
+    flaky = True,  # flakiness rate of 1.29% over the last month on 2024-03-11 for the "governance_time_warp" test
     proc_macro_deps = MACRO_DEPENDENCIES + MACRO_DEV_DEPENDENCIES,
     deps = DEPENDENCIES_WITH_TEST_FEATURES + DEV_DEPENDENCIES,
 )

--- a/rs/p2p/consensus_manager/BUILD.bazel
+++ b/rs/p2p/consensus_manager/BUILD.bazel
@@ -58,6 +58,5 @@ rust_test(
 rust_test_suite(
     name = "consensus_manager_integration",
     srcs = ["tests/test.rs"],
-    flaky = True,
     deps = [":consensus_manager"] + DEPENDENCIES + DEV_DEPENDENCIES,
 )

--- a/rs/registry/admin/BUILD.bazel
+++ b/rs/registry/admin/BUILD.bazel
@@ -124,7 +124,6 @@ rust_test(
     aliases = ALIASES,
     data = DEV_DATA,
     env = DEV_ENV,
-    flaky = False,
     proc_macro_deps = MACRO_DEPENDENCIES,
     deps = DEPENDENCIES + DEV_DEPENDENCIES,
 )

--- a/rs/rosetta-api/icp/BUILD.bazel
+++ b/rs/rosetta-api/icp/BUILD.bazel
@@ -196,7 +196,6 @@ rust_test_suite_with_extra_srcs(
         "tests/system_tests/common/*.rs",
         "tests/system_tests/test_cases/*.rs",
     ]),
-    flaky = True,
     proc_macro_deps = MACRO_DEV_DEPENDENCIES,
     tags = ["cpu:4"],
     deps = DEV_DEPENDENCIES + DEPENDENCIES,

--- a/rs/rosetta-api/icp/tests/integration_tests/BUILD.bazel
+++ b/rs/rosetta-api/icp/tests/integration_tests/BUILD.bazel
@@ -59,7 +59,7 @@ rust_test_suite(
     },
     # The test is critical to get resources timely and therefore fails sometimes when run on heavily loaded node.
     # TODO(IDX-2225): reconsider when we will use Remote Execution.
-    flaky = True,  # flakiness rate of over 2% over the last month on 2024-03-11.
+    flaky = True,  # flakiness rate of over 2% over the month from 2025-02-11 till 2025-03-11.
     proc_macro_deps = [
     ],
     tags = ["cpu:4"],

--- a/rs/rosetta-api/icp/tests/integration_tests/BUILD.bazel
+++ b/rs/rosetta-api/icp/tests/integration_tests/BUILD.bazel
@@ -59,7 +59,7 @@ rust_test_suite(
     },
     # The test is critical to get resources timely and therefore fails sometimes when run on heavily loaded node.
     # TODO(IDX-2225): reconsider when we will use Remote Execution.
-    flaky = True,
+    flaky = True,  # flakiness rate of over 2% over the last month on 2024-03-11.
     proc_macro_deps = [
     ],
     tags = ["cpu:4"],

--- a/rs/rosetta-api/icrc1/BUILD.bazel
+++ b/rs/rosetta-api/icrc1/BUILD.bazel
@@ -150,7 +150,6 @@ rust_test_suite_with_extra_srcs(
         "tests/integration_test_components/blocks_synchronizer/*.rs",
         "tests/integration_test_components/storage/*.rs",
     ]),
-    flaky = True,
     proc_macro_deps = MACRO_DEV_DEPENDENCIES,
     deps = DEV_DEPENDENCIES + DEPENDENCIES,
 )
@@ -173,7 +172,6 @@ rust_test_suite_with_extra_srcs(
     extra_srcs = glob([
         "tests/common/*.rs",
     ]),
-    flaky = True,
     proc_macro_deps = MACRO_DEV_DEPENDENCIES,
     deps = DEV_DEPENDENCIES + DEPENDENCIES,
 )

--- a/rs/sns/integration_tests/BUILD.bazel
+++ b/rs/sns/integration_tests/BUILD.bazel
@@ -201,7 +201,7 @@ rust_ic_test_suite_with_extra_srcs(
     data = DATA_DEPS,
     env = ENV,
     extra_srcs = [],
-    flaky = True,  # flakiness rate of over 1% for the "proposals" and "upgrade_canister" tests over the last month on 2024-03-11.
+    flaky = True,  # flakiness rate of over 1% for the "proposals" and "upgrade_canister" tests over the month from 2025-02-11 till 2025-03-11.
     proc_macro_deps = MACRO_DEPENDENCIES + MACRO_DEV_DEPENDENCIES,
     tags = ["cpu:8"],
     deps = DEPENDENCIES_WITH_TEST_FEATURES + TEST_DEV_DEPENDENCIES,

--- a/rs/sns/integration_tests/BUILD.bazel
+++ b/rs/sns/integration_tests/BUILD.bazel
@@ -201,7 +201,7 @@ rust_ic_test_suite_with_extra_srcs(
     data = DATA_DEPS,
     env = ENV,
     extra_srcs = [],
-    flaky = True,
+    flaky = True,  # flakiness rate of over 1% for the "proposals" and "upgrade_canister" tests over the last month on 2024-03-11.
     proc_macro_deps = MACRO_DEPENDENCIES + MACRO_DEV_DEPENDENCIES,
     tags = ["cpu:8"],
     deps = DEPENDENCIES_WITH_TEST_FEATURES + TEST_DEV_DEPENDENCIES,

--- a/rs/tests/boundary_nodes/BUILD.bazel
+++ b/rs/tests/boundary_nodes/BUILD.bazel
@@ -63,7 +63,6 @@ system_test_nns(
         "ASSET_CANISTER_WASM_PATH": "$(rootpath @asset_canister//file)",
         "LONG_ASSET_CANISTER_WASM_PATH": "$(rootpath @long_asset_canister//file)",
     },
-    flaky = True,
     tags = [
         "system_test_hourly",
     ],
@@ -81,7 +80,6 @@ system_test_nns(
 
 system_test_nns(
     name = "bn_update_workload_test",
-    flaky = True,
     tags = [
         "manual",  # TODO(BOUN-1039): remove "manual" and add back "long_test" when the test is not flaky anymore
     ],

--- a/rs/tests/ckbtc/BUILD.bazel
+++ b/rs/tests/ckbtc/BUILD.bazel
@@ -66,7 +66,6 @@ system_test_nns(
         "UNIVERSAL_CANISTER_WASM_PATH": "$(rootpath //rs/universal_canister/impl:universal_canister.wasm.gz)",
     },
     extra_head_nns_tags = [],  # don't run the head_nns variant on nightly since it aleady runs on long_test.
-    flaky = True,
     tags = [
         "k8s",
         "long_test",  # since it takes longer than 5 minutes.
@@ -96,7 +95,6 @@ system_test_nns(
         "LEDGER_WASM_PATH": "$(rootpath //rs/ledger_suite/icrc1/ledger:ledger_canister)",
         "UNIVERSAL_CANISTER_WASM_PATH": "$(rootpath //rs/universal_canister/impl:universal_canister.wasm.gz)",
     },
-    flaky = True,
     tags = [
         "long_test",  # since it takes longer than 5 minutes.
     ],
@@ -126,7 +124,6 @@ system_test_nns(
         "UNIVERSAL_CANISTER_WASM_PATH": "$(rootpath //rs/universal_canister/impl:universal_canister.wasm.gz)",
     },
     extra_head_nns_tags = [],  # don't run the head_nns variant on nightly since it aleady runs on long_test.
-    flaky = True,
     tags = [
         "long_test",  # since it takes longer than 5 minutes.
     ],
@@ -156,7 +153,6 @@ system_test_nns(
         "UNIVERSAL_CANISTER_WASM_PATH": "$(rootpath //rs/universal_canister/impl:universal_canister.wasm.gz)",
     },
     extra_head_nns_tags = [],  # don't run the head_nns variant on nightly since it aleady runs on long_test.
-    flaky = True,
     tags = [
         "long_test",  # since it takes longer than 5 minutes.
     ],
@@ -186,7 +182,6 @@ system_test_nns(
         "UNIVERSAL_CANISTER_WASM_PATH": "$(rootpath //rs/universal_canister/impl:universal_canister.wasm.gz)",
     },
     extra_head_nns_tags = [],  # don't run the head_nns variant on nightly since it aleady runs on long_test.
-    flaky = True,
     tags = [
         "long_test",  # since it takes longer than 5 minutes.
     ],
@@ -216,7 +211,6 @@ system_test_nns(
         "UNIVERSAL_CANISTER_WASM_PATH": "$(rootpath //rs/universal_canister/impl:universal_canister.wasm.gz)",
     },
     extra_head_nns_tags = [],  # don't run the head_nns variant on nightly since it aleady runs on long_test.
-    flaky = True,
     tags = [
         "long_test",  # since it takes longer than 5 minutes.
     ],

--- a/rs/tests/consensus/BUILD.bazel
+++ b/rs/tests/consensus/BUILD.bazel
@@ -22,7 +22,6 @@ rust_library(
 
 system_test(
     name = "catch_up_loop_prevention_test",
-    flaky = True,
     malicious = True,
     # TODO(NET-1683): Adjust test for faster p2p
     tags = [
@@ -153,7 +152,6 @@ system_test(
 system_test(
     name = "max_xnet_payload_size_test",
     env = UNIVERSAL_CANISTER_ENV,
-    flaky = True,
     tags = [
         "k8s",
     ],
@@ -176,7 +174,6 @@ system_test(
 system_test_nns(
     name = "node_graceful_leaving_test",
     env = UNIVERSAL_CANISTER_ENV,
-    flaky = True,
     tags = [
         "k8s",
     ],
@@ -320,7 +317,6 @@ system_test_nns(
         "//conditions:default": [],
     }),
     extra_head_nns_tags = [],
-    flaky = False,
     tags = [
         "experimental_system_test_colocation",
         "manual",

--- a/rs/tests/consensus/backup/BUILD.bazel
+++ b/rs/tests/consensus/backup/BUILD.bazel
@@ -48,7 +48,6 @@ system_test_nns(
     name = "backup_manager_downgrade_test",
     env = BACKUP_ENV | MAINNET_ENV,
     extra_head_nns_tags = [],  # don't run the head_nns variant on nightly since it aleady runs on long_test.
-    flaky = True,
     tags = [
         "experimental_system_test_colocation",
         "long_test",  # since it takes longer than 5 minutes.
@@ -72,7 +71,6 @@ system_test_nns(
     name = "backup_manager_upgrade_test",
     env = BACKUP_ENV | MAINNET_ENV,
     extra_head_nns_tags = [],  # don't run the head_nns variant on nightly since it aleady runs on long_test.
-    flaky = True,
     tags = [
         "experimental_system_test_colocation",
         "long_test",  # since it takes longer than 5 minutes.

--- a/rs/tests/consensus/orchestrator/BUILD.bazel
+++ b/rs/tests/consensus/orchestrator/BUILD.bazel
@@ -114,7 +114,7 @@ system_test_nns(
 
 system_test_nns(
     name = "unstuck_subnet_test",
-    flaky = True,  # flakiness rate of over 2.1% over the last month on 2024-03-11.
+    flaky = True,  # flakiness rate of over 2.1% over the month from 2025-02-11 till 2025-03-11.
     tags = [
         "k8s",
         "long_test",

--- a/rs/tests/consensus/orchestrator/BUILD.bazel
+++ b/rs/tests/consensus/orchestrator/BUILD.bazel
@@ -6,7 +6,6 @@ package(default_visibility = ["//rs:system-tests-pkg"])
 system_test_nns(
     name = "node_assign_test",
     extra_head_nns_tags = [],  # don't run the head_nns variant on nightly since it aleady runs on long_test.
-    flaky = True,
     tags = [
         "k8s",
         "long_test",  # since it takes longer than 5 minutes.
@@ -33,7 +32,6 @@ system_test_nns(
 system_test_nns(
     name = "node_reassignment_test",
     extra_head_nns_tags = [],  # don't run the head_nns variant on nightly since it aleady runs on long_test.
-    flaky = True,
     tags = [
         "k8s",
         "long_test",  # since it takes longer than 5 minutes.
@@ -54,7 +52,6 @@ system_test_nns(
 
 system_test_nns(
     name = "node_registration_test",
-    flaky = True,
     tags = [
         "k8s",
     ],
@@ -98,7 +95,6 @@ system_test(
 system_test_nns(
     name = "ssh_access_to_nodes_test",
     extra_head_nns_tags = [],  # don't run the head_nns variant on nightly since it aleady runs on long_test.
-    flaky = True,
     tags = [
         "k8s",
         "long_test",  # since it takes longer than 5 minutes.
@@ -118,7 +114,7 @@ system_test_nns(
 
 system_test_nns(
     name = "unstuck_subnet_test",
-    flaky = True,
+    flaky = True,  # flakiness rate of over 2.1% over the last month on 2024-03-11.
     tags = [
         "k8s",
         "long_test",
@@ -140,7 +136,6 @@ system_test_nns(
 system_test_nns(
     name = "rotate_ecdsa_idkg_key_test",
     extra_head_nns_tags = [],  # don't run the head_nns variant on nightly since it aleady runs on long_test.
-    flaky = True,
     tags = [
         "k8s",
         "long_test",  # since it takes longer than 5 minutes.

--- a/rs/tests/consensus/subnet_recovery/BUILD.bazel
+++ b/rs/tests/consensus/subnet_recovery/BUILD.bazel
@@ -66,7 +66,7 @@ system_test_nns(
 
 system_test_nns(
     name = "sr_app_same_nodes_enable_tecdsa_test",
-    flaky = True,  # flakiness rate of over 3.33% over the last month on 2024-03-11.
+    flaky = True,  # flakiness rate of over 3.33% over the month from 2025-02-11 till 2025-03-11.
     tags = [
         "experimental_system_test_colocation",
         "k8s",
@@ -122,7 +122,7 @@ system_test_nns(
 
 system_test_nns(
     name = "sr_app_failover_nodes_enable_tecdsa_test",
-    flaky = True,  # flakiness rate of over 1.67% over the last month on 2024-03-11.
+    flaky = True,  # flakiness rate of over 1.67% over the month from 2025-02-11 till 2025-03-11.
     tags = [
         "experimental_system_test_colocation",
         "k8s",
@@ -142,7 +142,7 @@ system_test_nns(
 
 system_test_nns(
     name = "sr_app_failover_nodes_with_tecdsa_test",
-    flaky = True,  # flakiness rate of 3.33% over the last month on 2024-03-11.
+    flaky = True,  # flakiness rate of 3.33% over the month from 2025-02-11 till 2025-03-11.
     tags = [
         "experimental_system_test_colocation",
         "k8s",
@@ -219,7 +219,7 @@ system_test_nns(
 
 system_test_nns(
     name = "sr_app_no_upgrade_with_tecdsa_test",
-    flaky = True,  # flakiness rate of over 6% over the last month on 2024-03-11 (only for //rs/tests/consensus/subnet_recovery:sr_app_no_upgrade_with_tecdsa_test_head_nns_colocate).
+    flaky = True,  # flakiness rate of over 6% over the month from 2025-02-11 till 2025-03-11 (only for //rs/tests/consensus/subnet_recovery:sr_app_no_upgrade_with_tecdsa_test_head_nns_colocate).
     tags = [
         "experimental_system_test_colocation",
         "k8s",
@@ -240,7 +240,7 @@ system_test_nns(
 system_test_nns(
     name = "sr_app_large_with_tecdsa_test",
     extra_head_nns_tags = ["manual"],  # Let's not run this expensive test against the HEAD NNS canisters to save resources.
-    flaky = True,  # flakiness rate of over 2.21% over the last month on 2024-03-11.
+    flaky = True,  # flakiness rate of over 2.21% over the month from 2025-02-11 till 2025-03-11.
     tags = [
         "experimental_system_test_colocation",
         "subnet_recovery",

--- a/rs/tests/consensus/subnet_recovery/BUILD.bazel
+++ b/rs/tests/consensus/subnet_recovery/BUILD.bazel
@@ -48,7 +48,6 @@ rust_library(
 system_test_nns(
     name = "sr_app_same_nodes_test",
     extra_head_nns_tags = [],  # don't run the head_nns variant on nightly since it aleady runs on long_test.
-    flaky = True,
     tags = [
         "experimental_system_test_colocation",
         "k8s",
@@ -67,7 +66,7 @@ system_test_nns(
 
 system_test_nns(
     name = "sr_app_same_nodes_enable_tecdsa_test",
-    flaky = True,
+    flaky = True,  # flakiness rate of over 3.33% over the last month on 2024-03-11.
     tags = [
         "experimental_system_test_colocation",
         "k8s",
@@ -86,7 +85,6 @@ system_test_nns(
 
 system_test_nns(
     name = "sr_app_same_nodes_with_tecdsa_test",
-    flaky = True,
     tags = [
         "experimental_system_test_colocation",
         "k8s",
@@ -106,7 +104,6 @@ system_test_nns(
 system_test_nns(
     name = "sr_app_failover_nodes_test",
     extra_head_nns_tags = [],  # don't run the head_nns variant on nightly since it aleady runs on long_test.
-    flaky = True,
     tags = [
         "experimental_system_test_colocation",
         "k8s",
@@ -125,7 +122,7 @@ system_test_nns(
 
 system_test_nns(
     name = "sr_app_failover_nodes_enable_tecdsa_test",
-    flaky = True,
+    flaky = True,  # flakiness rate of over 1.67% over the last month on 2024-03-11.
     tags = [
         "experimental_system_test_colocation",
         "k8s",
@@ -145,7 +142,7 @@ system_test_nns(
 
 system_test_nns(
     name = "sr_app_failover_nodes_with_tecdsa_test",
-    flaky = True,
+    flaky = True,  # flakiness rate of 3.33% over the last month on 2024-03-11.
     tags = [
         "experimental_system_test_colocation",
         "k8s",
@@ -166,7 +163,6 @@ system_test_nns(
 system_test_nns(
     name = "sr_app_no_upgrade_test",
     extra_head_nns_tags = [],  # don't run the head_nns variant on nightly since it aleady runs on long_test.
-    flaky = True,
     tags = [
         "experimental_system_test_colocation",
         "k8s",
@@ -186,7 +182,6 @@ system_test_nns(
 system_test_nns(
     name = "sr_app_no_upgrade_local_test",
     extra_head_nns_tags = [],  # don't run the head_nns variant on nightly since it aleady runs on long_test.
-    flaky = True,
     tags = [
         "experimental_system_test_colocation",
         "k8s",
@@ -205,7 +200,6 @@ system_test_nns(
 
 system_test_nns(
     name = "sr_app_no_upgrade_enable_tecdsa_test",
-    flaky = True,
     tags = [
         "experimental_system_test_colocation",
         "k8s",
@@ -225,7 +219,7 @@ system_test_nns(
 
 system_test_nns(
     name = "sr_app_no_upgrade_with_tecdsa_test",
-    flaky = True,
+    flaky = True,  # flakiness rate of over 6% over the last month on 2024-03-11 (only for //rs/tests/consensus/subnet_recovery:sr_app_no_upgrade_with_tecdsa_test_head_nns_colocate).
     tags = [
         "experimental_system_test_colocation",
         "k8s",
@@ -246,7 +240,7 @@ system_test_nns(
 system_test_nns(
     name = "sr_app_large_with_tecdsa_test",
     extra_head_nns_tags = ["manual"],  # Let's not run this expensive test against the HEAD NNS canisters to save resources.
-    flaky = True,
+    flaky = True,  # flakiness rate of over 2.21% over the last month on 2024-03-11.
     tags = [
         "experimental_system_test_colocation",
         "subnet_recovery",
@@ -267,7 +261,6 @@ system_test_nns(
 system_test_nns(
     name = "sr_nns_same_nodes_test",
     extra_head_nns_tags = [],  # don't run the head_nns variant on nightly since it aleady runs on long_test.
-    flaky = True,
     tags = [
         "experimental_system_test_colocation",
         "k8s",
@@ -292,7 +285,6 @@ system_test_nns(
 system_test_nns(
     name = "sr_nns_failover_nodes_test",
     extra_head_nns_tags = [],  # don't run the head_nns variant on nightly since it aleady runs on long_test.
-    flaky = False,
     tags = [
         "experimental_system_test_colocation",
         "k8s",

--- a/rs/tests/consensus/tecdsa/BUILD.bazel
+++ b/rs/tests/consensus/tecdsa/BUILD.bazel
@@ -5,7 +5,6 @@ package(default_visibility = ["//rs:system-tests-pkg"])
 
 system_test_nns(
     name = "tecdsa_complaint_test",
-    flaky = True,
     malicious = True,
     tags = [
         "k8s",
@@ -31,7 +30,6 @@ system_test_nns(
 system_test_nns(
     name = "tecdsa_add_nodes_test",
     extra_head_nns_tags = [],  # don't run the head_nns variant on nightly since it aleady runs on long_test.
-    flaky = True,
     tags = [
         "k8s",
         "long_test",  # since it takes longer than 5 minutes.
@@ -59,7 +57,6 @@ system_test_nns(
 system_test_nns(
     name = "tschnorr_message_sizes_test",
     extra_head_nns_tags = [],  # don't run the head_nns variant on nightly since it aleady runs on long_test.
-    flaky = True,
     tags = [
         "k8s",
         "long_test",  # since it takes longer than 5 minutes.
@@ -83,7 +80,6 @@ system_test_nns(
 system_test_nns(
     name = "tecdsa_remove_nodes_test",
     extra_head_nns_tags = [],  # don't run the head_nns variant on nightly since it aleady runs on long_test.
-    flaky = True,
     tags = [
         "k8s",
         "long_test",  # since it takes longer than 5 minutes.
@@ -108,7 +104,6 @@ system_test_nns(
 
 system_test_nns(
     name = "tecdsa_key_rotation_test",
-    flaky = True,
     tags = [
         "k8s",
         "long_test",  # since it takes longer than 5 minutes.
@@ -130,7 +125,7 @@ system_test_nns(
 
 system_test_nns(
     name = "tecdsa_signature_fails_without_cycles_test",
-    flaky = True,
+    flaky = True,  # flakiness rate of over 1.05% over the last month on 2024-03-11.
     tags = [
         "k8s",
         "long_test",
@@ -154,7 +149,7 @@ system_test_nns(
 
 system_test_nns(
     name = "tecdsa_signature_from_nns_without_cycles_test",
-    flaky = True,
+    flaky = True,  # flakiness rate of over 1.67% over the last month on 2024-03-11 only for the //rs/tests/consensus/tecdsa:tecdsa_signature_from_nns_without_cycles_test_head_nns variant.
     tags = [
         "k8s",
         "long_test",
@@ -174,7 +169,6 @@ system_test_nns(
 
 system_test_nns(
     name = "tecdsa_signature_from_other_subnet_test",
-    flaky = True,
     tags = [
         "k8s",
         "long_test",
@@ -195,7 +189,6 @@ system_test_nns(
 
 system_test_nns(
     name = "tecdsa_two_signing_subnets_test",
-    flaky = True,
     tags = [
         "k8s",
         "long_test",
@@ -224,7 +217,7 @@ system_test_nns(
     name = "tecdsa_signature_life_cycle_test",
     extra_head_nns_tags = [],  # don't run the head_nns variant on nightly since it aleady runs on long_test.
     # Remove when CON-937 is resolved
-    flaky = True,
+    flaky = True,  # flakiness rate of 1.57% over the last month on 2024-03-11
     tags = [
         "k8s",
         "long_test",  # since it takes longer than 5 minutes.
@@ -251,7 +244,6 @@ system_test_nns(
 
 system_test_nns(
     name = "tecdsa_signature_same_subnet_test",
-    flaky = True,
     tags = [
         "k8s",
         "long_test",
@@ -272,7 +264,6 @@ system_test_nns(
 system_test_nns(
     name = "tecdsa_signature_timeout_test",
     extra_head_nns_tags = [],  # don't run the head_nns variant on nightly since it aleady runs on long_test.
-    flaky = True,
     tags = [
         "k8s",
         "long_test",  # since it takes longer than 5 minutes.
@@ -304,7 +295,6 @@ tecdsa_performance_test_template = system_test_nns(
         "//bazel:upload_perf_systest_results_enabled": ["upload_perf_systest_results"],
         "//conditions:default": [],
     }),
-    flaky = False,
     tags = [
         "experimental_system_test_colocation",
         "manual",

--- a/rs/tests/consensus/tecdsa/BUILD.bazel
+++ b/rs/tests/consensus/tecdsa/BUILD.bazel
@@ -125,7 +125,7 @@ system_test_nns(
 
 system_test_nns(
     name = "tecdsa_signature_fails_without_cycles_test",
-    flaky = True,  # flakiness rate of over 1.05% over the last month on 2024-03-11.
+    flaky = True,  # flakiness rate of over 1.05% over the month from 2025-02-11 till 2025-03-11.
     tags = [
         "k8s",
         "long_test",
@@ -149,7 +149,7 @@ system_test_nns(
 
 system_test_nns(
     name = "tecdsa_signature_from_nns_without_cycles_test",
-    flaky = True,  # flakiness rate of over 1.67% over the last month on 2024-03-11 only for the //rs/tests/consensus/tecdsa:tecdsa_signature_from_nns_without_cycles_test_head_nns variant.
+    flaky = True,  # flakiness rate of over 1.67% over the month from 2025-02-11 till 2025-03-11 only for the //rs/tests/consensus/tecdsa:tecdsa_signature_from_nns_without_cycles_test_head_nns variant.
     tags = [
         "k8s",
         "long_test",
@@ -217,7 +217,7 @@ system_test_nns(
     name = "tecdsa_signature_life_cycle_test",
     extra_head_nns_tags = [],  # don't run the head_nns variant on nightly since it aleady runs on long_test.
     # Remove when CON-937 is resolved
-    flaky = True,  # flakiness rate of 1.57% over the last month on 2024-03-11
+    flaky = True,  # flakiness rate of 1.57% over the month from 2025-02-11 till 2025-03-11
     tags = [
         "k8s",
         "long_test",  # since it takes longer than 5 minutes.

--- a/rs/tests/consensus/upgrade/BUILD.bazel
+++ b/rs/tests/consensus/upgrade/BUILD.bazel
@@ -59,7 +59,6 @@ system_test_nns(
 system_test_nns(
     name = "upgrade_downgrade_nns_subnet_test",
     env = MAINNET_ENV,
-    flaky = True,
     tags = [
         "system_test_hourly",
     ],
@@ -84,7 +83,7 @@ system_test_nns(
     name = "upgrade_app_subnet_test",
     env = MAINNET_ENV,
     extra_head_nns_tags = [],  # don't run the head_nns variant on nightly since it aleady runs on long_test.
-    flaky = True,
+    flaky = True,  # flakiness rate of over 2.27% over the last month on 2024-03-11.
     tags = [
         "long_test",  # since it takes longer than 5 minutes.
     ],
@@ -110,7 +109,7 @@ system_test_nns(
     name = "downgrade_app_subnet_test",
     env = MAINNET_ENV,
     extra_head_nns_tags = [],  # don't run the head_nns variant on nightly since it aleady runs on long_test.
-    flaky = True,
+    flaky = True,  # flakiness rate of over 2.97% over the last month on 2024-03-11.
     tags = [
         "long_test",  # since it takes longer than 5 minutes.
     ],
@@ -134,7 +133,6 @@ system_test_nns(
 
 system_test_nns(
     name = "upgrade_with_alternative_urls",
-    flaky = True,
     tags = [
         "k8s",
         "long_test",
@@ -157,7 +155,6 @@ system_test_nns(
 
 system_test_nns(
     name = "unassigned_node_upgrade_test",
-    flaky = True,
     tags = [
         "k8s",
         "long_test",

--- a/rs/tests/consensus/upgrade/BUILD.bazel
+++ b/rs/tests/consensus/upgrade/BUILD.bazel
@@ -83,7 +83,7 @@ system_test_nns(
     name = "upgrade_app_subnet_test",
     env = MAINNET_ENV,
     extra_head_nns_tags = [],  # don't run the head_nns variant on nightly since it aleady runs on long_test.
-    flaky = True,  # flakiness rate of over 2.27% over the last month on 2024-03-11.
+    flaky = True,  # flakiness rate of over 2.27% over the month from 2025-02-11 till 2025-03-11.
     tags = [
         "long_test",  # since it takes longer than 5 minutes.
     ],
@@ -109,7 +109,7 @@ system_test_nns(
     name = "downgrade_app_subnet_test",
     env = MAINNET_ENV,
     extra_head_nns_tags = [],  # don't run the head_nns variant on nightly since it aleady runs on long_test.
-    flaky = True,  # flakiness rate of over 2.97% over the last month on 2024-03-11.
+    flaky = True,  # flakiness rate of over 2.97% over the month from 2025-02-11 till 2025-03-11.
     tags = [
         "long_test",  # since it takes longer than 5 minutes.
     ],

--- a/rs/tests/consensus/vetkd/BUILD.bazel
+++ b/rs/tests/consensus/vetkd/BUILD.bazel
@@ -6,7 +6,6 @@ package(default_visibility = ["//rs:system-tests-pkg"])
 system_test_nns(
     name = "vetkd_key_life_cycle_test",
     extra_head_nns_tags = [],  # don't run the head_nns variant on nightly since it aleady runs on long_test.
-    flaky = True,
     tags = [
         "k8s",
         "long_test",  # since it takes longer than 5 minutes.

--- a/rs/tests/crypto/BUILD.bazel
+++ b/rs/tests/crypto/BUILD.bazel
@@ -33,7 +33,6 @@ system_test(
     env = {
         "II_WASM_PATH": "$(rootpath @ii_dev_canister//file)",
     },
-    flaky = False,
     tags = [
         "k8s",
     ],
@@ -45,7 +44,6 @@ system_test(
 system_test(
     name = "request_signature_test",
     env = UNIVERSAL_CANISTER_ENV,
-    flaky = True,
     tags = [
         "k8s",
     ],
@@ -56,7 +54,6 @@ system_test(
 
 system_test(
     name = "rpc_csp_vault_reconnection_test",
-    flaky = True,
     tags = [
         "k8s",
     ],
@@ -67,7 +64,6 @@ system_test(
 
 system_test(
     name = "ic_crypto_csp_metrics_test",
-    flaky = True,
     tags = [
         "k8s",
     ],
@@ -78,7 +74,6 @@ system_test(
 
 system_test(
     name = "ic_crypto_csp_socket_test",
-    flaky = True,
     tags = [
         "k8s",
     ],
@@ -89,7 +84,6 @@ system_test(
 
 system_test(
     name = "ic_crypto_csp_umask_test",
-    flaky = True,
     tags = [
         "k8s",
     ],

--- a/rs/tests/execution/BUILD.bazel
+++ b/rs/tests/execution/BUILD.bazel
@@ -6,7 +6,6 @@ package(default_visibility = ["//rs:system-tests-pkg"])
 system_test(
     name = "compute_allocation_test",
     env = UNIVERSAL_CANISTER_ENV,
-    flaky = True,
     tags = [
         "k8s",
     ],
@@ -29,7 +28,6 @@ system_test(
 system_test(
     name = "cycles_restrictions_test",
     env = UNIVERSAL_CANISTER_ENV,
-    flaky = True,
     tags = [
         "k8s",
     ],
@@ -50,7 +48,6 @@ system_test(
     srcs = glob(["general_execution_tests/*.rs"]),
     crate_root = "general_execution_test.rs",
     env = UNIVERSAL_CANISTER_ENV,
-    flaky = True,
     tags = [
         "k8s",
     ],
@@ -90,7 +87,6 @@ system_test(
     srcs = glob(["inter_canister_queries_tests/*.rs"]),
     crate_root = "inter_canister_queries_test.rs",
     env = UNIVERSAL_CANISTER_ENV,
-    flaky = True,
     tags = [
         "k8s",
     ],
@@ -111,7 +107,6 @@ system_test(
 system_test(
     name = "max_number_of_canisters_test",
     env = UNIVERSAL_CANISTER_ENV,
-    flaky = True,
     tags = [
         "k8s",
     ],
@@ -130,7 +125,6 @@ system_test(
 
 system_test(
     name = "system_api_security_test",
-    flaky = True,
     tags = [
         "k8s",
     ],
@@ -151,7 +145,6 @@ system_test(
 system_test(
     name = "system_subnets_test",
     env = UNIVERSAL_CANISTER_ENV,
-    flaky = True,
     tags = [
         "k8s",
     ],
@@ -169,7 +162,6 @@ system_test(
 
 system_test(
     name = "fill_execution_rounds_workload",
-    flaky = True,
     tags = [
         "manual",
     ],
@@ -224,7 +216,7 @@ system_test_nns(
     env = UNIVERSAL_CANISTER_ENV | {
         "BTC_WASM_PATH": "$(rootpath @btc_canister//file)",
     },
-    flaky = True,
+    flaky = True,  # flakiness rate of over 3% over the last month on 2024-03-11 only for the //rs/tests/execution:btc_get_balance_test_head_nns variant.
     tags = [
         "k8s",
     ],

--- a/rs/tests/execution/BUILD.bazel
+++ b/rs/tests/execution/BUILD.bazel
@@ -216,7 +216,7 @@ system_test_nns(
     env = UNIVERSAL_CANISTER_ENV | {
         "BTC_WASM_PATH": "$(rootpath @btc_canister//file)",
     },
-    flaky = True,  # flakiness rate of over 3% over the last month on 2024-03-11 only for the //rs/tests/execution:btc_get_balance_test_head_nns variant.
+    flaky = True,  # flakiness rate of over 3% over the month from 2025-02-11 till 2025-03-11 only for the //rs/tests/execution:btc_get_balance_test_head_nns variant.
     tags = [
         "k8s",
     ],

--- a/rs/tests/financial_integrations/BUILD.bazel
+++ b/rs/tests/financial_integrations/BUILD.bazel
@@ -13,7 +13,6 @@ system_test(
     env = {
         "LEDGER_WASM_PATH": "$(rootpath //rs/ledger_suite/icrc1/ledger:ledger_canister)",
     },
-    flaky = True,
     tags = [
         "k8s",
     ],
@@ -44,7 +43,6 @@ system_test_nns(
     compile_data = [
         "transaction_ledger_correctness.wasm",
     ],
-    flaky = True,
     proc_macro_deps = [
         "@crate_index//:async-recursion",
     ],

--- a/rs/tests/financial_integrations/rosetta/BUILD.bazel
+++ b/rs/tests/financial_integrations/rosetta/BUILD.bazel
@@ -5,7 +5,6 @@ package(default_visibility = ["//rs:system-tests-pkg"])
 
 system_test_nns(
     name = "rosetta_test",
-    flaky = True,
     tags = ["experimental_system_test_colocation"],
     target_compatible_with = ["@platforms//os:linux"],  # requires libssh that does not build on Mac OS
     test_timeout = "long",
@@ -39,7 +38,6 @@ system_test_nns(
 system_test_nns(
     name = "rosetta_neuron_follow_test",
     extra_head_nns_tags = [],  # don't run the head_nns variant on nightly since it aleady runs on long_test.
-    flaky = True,
     tags = [
         "k8s",
         "long_test",  # since it takes longer than 5 minutes.

--- a/rs/tests/idx/BUILD.bazel
+++ b/rs/tests/idx/BUILD.bazel
@@ -27,7 +27,7 @@ rust_binary(
 system_test(
     name = "basic_health_test",
     env = UNIVERSAL_CANISTER_ENV,
-    flaky = True,  # flakiness rate of 1.22% over the last month on 2024-03-11
+    flaky = True,  # flakiness rate of 1.22% over the month from 2025-02-11 till 2025-03-11
     tags = [
         "k8s",
         "long_test",

--- a/rs/tests/idx/BUILD.bazel
+++ b/rs/tests/idx/BUILD.bazel
@@ -27,7 +27,7 @@ rust_binary(
 system_test(
     name = "basic_health_test",
     env = UNIVERSAL_CANISTER_ENV,
-    flaky = True,
+    flaky = True,  # flakiness rate of 1.22% over the last month on 2024-03-11
     tags = [
         "k8s",
         "long_test",
@@ -48,7 +48,6 @@ system_test(
     env = UNIVERSAL_CANISTER_ENV | {
         "II_WASM_PATH": "$(rootpath @ii_dev_canister//file)",
     },
-    flaky = True,
     tags = [
         "long_test",
     ],

--- a/rs/tests/message_routing/xnet/BUILD.bazel
+++ b/rs/tests/message_routing/xnet/BUILD.bazel
@@ -9,7 +9,6 @@ system_test_nns(
         "XNET_TEST_CANISTER_WASM_PATH": "$(rootpath //rs/rust_canisters/xnet_test:xnet-test-canister)",
     },
     extra_head_nns_tags = ["manual"],  # Let's not run this expensive test against the HEAD NNS canisters to save resources.
-    flaky = False,
     tags = [
         #TODO: enable k8s when there's enough capacity
         # "k8s",
@@ -31,7 +30,6 @@ system_test_nns(
         "XNET_TEST_CANISTER_WASM_PATH": "$(rootpath //rs/rust_canisters/xnet_test:xnet-test-canister)",
     },
     extra_head_nns_tags = ["manual"],  # only run this test with the mainnet NNS canisters.
-    flaky = False,
     tags = [
         "k8s",
         "system_test_hotfix",
@@ -52,7 +50,6 @@ system_test_nns(
         "XNET_TEST_CANISTER_WASM_PATH": "$(rootpath //rs/rust_canisters/xnet_test:xnet-test-canister)",
     },
     extra_head_nns_tags = ["manual"],  # only run this test with the mainnet NNS canisters.
-    flaky = False,
     tags = [
         "k8s",
         "system_test_nightly",
@@ -73,7 +70,6 @@ system_test_nns(
         "XNET_TEST_CANISTER_WASM_PATH": "$(rootpath //rs/rust_canisters/xnet_test:xnet-test-canister)",
     },
     extra_head_nns_tags = ["manual"],  # only run this test with the mainnet NNS canisters.
-    flaky = False,
     tags = [
         #TODO: enable k8s when there's enough capacity
         # "k8s",
@@ -94,7 +90,6 @@ system_test(
     env = {
         "XNET_TEST_CANISTER_WASM_PATH": "$(rootpath //rs/rust_canisters/xnet_test:xnet-test-canister)",
     },
-    flaky = False,
     malicious = True,
     tags = [
         "system_test_nightly",

--- a/rs/tests/nested/BUILD.bazel
+++ b/rs/tests/nested/BUILD.bazel
@@ -38,7 +38,7 @@ rust_library(
 
 system_test_nns(
     name = "registration",
-    flaky = True,
+    flaky = True,  # flakiness rate of over 2% over the last month on 2024-03-11.
     tags = [
         "system_test_hourly",
     ],
@@ -52,7 +52,7 @@ system_test_nns(
 
 system_test_nns(
     name = "upgrade",
-    flaky = True,
+    flaky = True,  # flakiness rate of 5% over the last month on 2024-03-11.
     tags = [
         "system_test_hourly",
     ],

--- a/rs/tests/nested/BUILD.bazel
+++ b/rs/tests/nested/BUILD.bazel
@@ -38,7 +38,7 @@ rust_library(
 
 system_test_nns(
     name = "registration",
-    flaky = True,  # flakiness rate of over 2% over the last month on 2024-03-11.
+    flaky = True,  # flakiness rate of over 2% over the month from 2025-02-11 till 2025-03-11.
     tags = [
         "system_test_hourly",
     ],
@@ -52,7 +52,7 @@ system_test_nns(
 
 system_test_nns(
     name = "upgrade",
-    flaky = True,  # flakiness rate of 5% over the last month on 2024-03-11.
+    flaky = True,  # flakiness rate of 5% over the month from 2025-02-11 till 2025-03-11.
     tags = [
         "system_test_hourly",
     ],

--- a/rs/tests/networking/BUILD.bazel
+++ b/rs/tests/networking/BUILD.bazel
@@ -38,7 +38,6 @@ system_test_nns(
         "PROXY_WASM_PATH": "$(rootpath //rs/rust_canisters/proxy_canister:proxy_canister)",
     },
     extra_head_nns_tags = [],  # don't run the head_nns variant on nightly since it aleady runs on long_test.
-    flaky = True,
     tags = [
         "k8s",
         "long_test",  # since it takes longer than 5 minutes.
@@ -56,7 +55,6 @@ system_test_nns(
     env = {
         "PROXY_WASM_PATH": "$(rootpath //rs/rust_canisters/proxy_canister:proxy_canister)",
     },
-    flaky = True,
     tags = [
         # TODO(NET-1710): enable on CI again when the problematic firewall rule in the IC node has been removed.
         #"long_test",
@@ -80,7 +78,6 @@ system_test_nns(
     env = {
         "PROXY_WASM_PATH": "$(rootpath //rs/rust_canisters/proxy_canister:proxy_canister)",
     },
-    flaky = True,
     target_compatible_with = ["@platforms//os:linux"],  # requires libssh that does not build on Mac OS
     runtime_deps =
         GUESTOS_RUNTIME_DEPS +
@@ -106,7 +103,6 @@ system_test_nns(
     env = {
         "PROXY_WASM_PATH": "$(rootpath //rs/rust_canisters/proxy_canister:proxy_canister)",
     },
-    flaky = True,
     tags = [
         "k8s",
         "manual",
@@ -131,7 +127,6 @@ system_test_nns(
     env = {
         "PROXY_WASM_PATH": "$(rootpath //rs/rust_canisters/proxy_canister:proxy_canister)",
     },
-    flaky = True,
     tags = [
         "k8s",
         "long_test",
@@ -146,7 +141,7 @@ system_test_nns(
 
 system_test_nns(
     name = "firewall_max_connections_test",
-    flaky = True,
+    flaky = True,  # flakiness rate of 5% over the last month on 2024-03-11.
     tags = [
         "long_test",
     ],
@@ -160,7 +155,6 @@ system_test_nns(
 
 system_test_nns(
     name = "firewall_priority_test",
-    flaky = True,
     tags = [
         "long_test",
     ],
@@ -181,7 +175,7 @@ system_test_nns(
 system_test_nns(
     name = "network_large_test",
     extra_head_nns_tags = ["manual"],  # only run this test with the mainnet NNS canisters.
-    flaky = True,
+    flaky = True,  # flakiness rate of 20% over the last month on 2024-03-11.
     tags = [
         "k8s",
         "system_test_nightly",
@@ -199,7 +193,7 @@ system_test_nns(
 system_test_nns(
     name = "network_reliability_test",
     extra_head_nns_tags = ["manual"],  # only run this test with the mainnet NNS canisters.
-    flaky = True,
+    flaky = True,  # flakiness rate of 3.45% over the last month on 2024-03-11.
     tags = [
         "experimental_system_test_colocation",
         "k8s",
@@ -216,7 +210,6 @@ system_test_nns(
 
 system_test_nns(
     name = "p2p_performance_test",
-    flaky = True,
     tags = [
         "k8s",
         "manual",
@@ -233,7 +226,7 @@ system_test_nns(
 
 system_test_nns(
     name = "query_workload_long_test",
-    flaky = True,
+    flaky = True,  # flakiness rate of over 1.1% over the last month on 2024-03-11.
     tags = [
         "experimental_system_test_colocation",
         "k8s",
@@ -249,7 +242,7 @@ system_test_nns(
 
 system_test_nns(
     name = "update_workload_large_payload",
-    flaky = True,
+    flaky = True,  # flakiness rate of 1.83% over the last month on 2024-03-11.
     tags = [
         "experimental_system_test_colocation",
         "system_test_hourly",

--- a/rs/tests/networking/BUILD.bazel
+++ b/rs/tests/networking/BUILD.bazel
@@ -141,7 +141,7 @@ system_test_nns(
 
 system_test_nns(
     name = "firewall_max_connections_test",
-    flaky = True,  # flakiness rate of 5% over the last month on 2024-03-11.
+    flaky = True,  # flakiness rate of 5% over the month from 2025-02-11 till 2025-03-11.
     tags = [
         "long_test",
     ],
@@ -175,7 +175,7 @@ system_test_nns(
 system_test_nns(
     name = "network_large_test",
     extra_head_nns_tags = ["manual"],  # only run this test with the mainnet NNS canisters.
-    flaky = True,  # flakiness rate of 20% over the last month on 2024-03-11.
+    flaky = True,  # flakiness rate of 20% over the month from 2025-02-11 till 2025-03-11.
     tags = [
         "k8s",
         "system_test_nightly",
@@ -193,7 +193,7 @@ system_test_nns(
 system_test_nns(
     name = "network_reliability_test",
     extra_head_nns_tags = ["manual"],  # only run this test with the mainnet NNS canisters.
-    flaky = True,  # flakiness rate of 3.45% over the last month on 2024-03-11.
+    flaky = True,  # flakiness rate of 3.45% over the month from 2025-02-11 till 2025-03-11.
     tags = [
         "experimental_system_test_colocation",
         "k8s",
@@ -226,7 +226,7 @@ system_test_nns(
 
 system_test_nns(
     name = "query_workload_long_test",
-    flaky = True,  # flakiness rate of over 1.1% over the last month on 2024-03-11.
+    flaky = True,  # flakiness rate of over 1.1% over the month from 2025-02-11 till 2025-03-11.
     tags = [
         "experimental_system_test_colocation",
         "k8s",
@@ -242,7 +242,7 @@ system_test_nns(
 
 system_test_nns(
     name = "update_workload_large_payload",
-    flaky = True,  # flakiness rate of 1.83% over the last month on 2024-03-11.
+    flaky = True,  # flakiness rate of 1.83% over the month from 2025-02-11 till 2025-03-11.
     tags = [
         "experimental_system_test_colocation",
         "system_test_hourly",

--- a/rs/tests/nns/BUILD.bazel
+++ b/rs/tests/nns/BUILD.bazel
@@ -18,7 +18,6 @@ system_test(
     },
     env = NNS_CANISTER_ENV | MAINNET_ENV,
     env_inherit = ["SSH_AUTH_SOCK"],
-    flaky = True,
     # TODO: replace 'experimental_system_test_colocation' with 'k8s' once everything is on k8s
     tags = [
         "experimental_system_test_colocation",
@@ -45,7 +44,6 @@ system_test_nns(
         "NNS_DAPP_WASM_PATH": "$(rootpath @nns_dapp_canister//file)",
         "SUBNET_RENTAL_WASM_PATH": "$(rootpath @subnet_rental_canister//file)",
     },
-    flaky = False,
     target_compatible_with = ["@platforms//os:linux"],  # requires libssh that does not build on Mac OS
     runtime_deps = GUESTOS_RUNTIME_DEPS + BOUNDARY_NODE_GUESTOS_RUNTIME_DEPS + [
         "//rs/ledger_suite/icrc1/ledger:ledger_canister",
@@ -69,7 +67,6 @@ system_test_nns(
 system_test(
     name = "create_subnet_pre_master_test",
     env = NNS_CANISTER_ENV | UNIVERSAL_CANISTER_ENV,
-    flaky = True,
     tags = [
         "k8s",
     ],
@@ -90,7 +87,6 @@ system_test(
 system_test(
     name = "nns_token_balance_test",
     env = NNS_CANISTER_ENV | UNIVERSAL_CANISTER_ENV,
-    flaky = True,
     tags = [
         "k8s",
     ],
@@ -119,7 +115,6 @@ system_test(
 system_test(
     name = "nns_cycles_minting_test",
     env = NNS_CANISTER_ENV,
-    flaky = True,
     tags = [
         "k8s",
         "long_test",  # since it takes longer than 5 minutes.
@@ -165,7 +160,6 @@ system_test(
 system_test(
     name = "nns_cycles_minting_multi_app_subnets_test",
     env = NNS_CANISTER_ENV,
-    flaky = True,
     tags = [
         "k8s",
     ],
@@ -196,7 +190,6 @@ system_test(
 system_test(
     name = "node_removal_from_registry_test",
     env = NNS_CANISTER_ENV,
-    flaky = True,
     tags = [
         "k8s",
     ],
@@ -222,7 +215,6 @@ system_test(
     env = dict(NNS_CANISTER_ENV.items() + {
         "BTC_WASM_PATH": "$(rootpath @btc_canister//file)",
     }.items()),
-    flaky = True,
     tags = [
         "k8s",
     ],
@@ -253,7 +245,6 @@ system_test(
 system_test(
     name = "certified_registry_test",
     env = NNS_CANISTER_ENV | UNIVERSAL_CANISTER_ENV,
-    flaky = True,
     tags = [
         "k8s",
     ],

--- a/rs/tests/nns/sns/BUILD.bazel
+++ b/rs/tests/nns/sns/BUILD.bazel
@@ -59,7 +59,6 @@ system_test(
     env = NNS_CANISTER_ENV | SNS_CANISTER_ENV | {
         "SNS_AGGREGATOR_WASM_PATH": "$(rootpath @sns_aggregator//file)",
     },
-    flaky = True,
     # TODO[NNS1-2658]: re-enable this test
     tags = [
         "manual",

--- a/rs/tests/node/BUILD.bazel
+++ b/rs/tests/node/BUILD.bazel
@@ -5,7 +5,6 @@ package(default_visibility = ["//rs:system-tests-pkg"])
 
 system_test_nns(
     name = "ipv4_integration_test",
-    flaky = True,
     proc_macro_deps = [
         "@crate_index//:indoc",
     ],

--- a/rs/tests/query_stats/BUILD.bazel
+++ b/rs/tests/query_stats/BUILD.bazel
@@ -6,7 +6,6 @@ package(default_visibility = ["//rs:system-tests-pkg"])
 system_test(
     name = "query_stats_basic",
     env = UNIVERSAL_CANISTER_ENV,
-    flaky = True,
     tags = [
         "k8s",
     ],
@@ -22,7 +21,7 @@ system_test(
 system_test(
     name = "query_stats_below_threshold",
     env = UNIVERSAL_CANISTER_ENV,
-    flaky = True,
+    flaky = True,  # flakiness rate of 1.22% over the last month on 2024-03-11.
     tags = [
         "k8s",
         "long_test",  # since it takes longer than 5 minutes.
@@ -39,7 +38,6 @@ system_test(
 system_test(
     name = "query_stats_above_threshold",
     env = UNIVERSAL_CANISTER_ENV,
-    flaky = True,
     tags = [
         "k8s",
     ],

--- a/rs/tests/query_stats/BUILD.bazel
+++ b/rs/tests/query_stats/BUILD.bazel
@@ -21,7 +21,7 @@ system_test(
 system_test(
     name = "query_stats_below_threshold",
     env = UNIVERSAL_CANISTER_ENV,
-    flaky = True,  # flakiness rate of 1.22% over the last month on 2024-03-11.
+    flaky = True,  # flakiness rate of 1.22% over the month from 2025-02-11 till 2025-03-11.
     tags = [
         "k8s",
         "long_test",  # since it takes longer than 5 minutes.

--- a/rs/tests/research/BUILD.bazel
+++ b/rs/tests/research/BUILD.bazel
@@ -10,7 +10,6 @@ package(default_visibility = ["//rs:system-tests-pkg"])
         colocated_test_driver_vm_resources = {
             "vcpus": 16,
         },
-        flaky = True,
         tags = ["experimental_system_test_colocation"],
         target_compatible_with = ["@platforms//os:linux"],  # requires libssh that does not build on Mac OS
         runtime_deps = BOUNDARY_NODE_GUESTOS_RUNTIME_DEPS + GUESTOS_RUNTIME_DEPS + UNIVERSAL_VM_RUNTIME_DEPS + CANISTER_HTTP_RUNTIME_DEPS + [

--- a/rs/tests/sdk/BUILD.bazel
+++ b/rs/tests/sdk/BUILD.bazel
@@ -36,7 +36,6 @@ BOUNDARY_NODE_RUNTIME_DEPS = BOUNDARY_NODE_GUESTOS_RUNTIME_DEPS + [
 system_test_nns(
     name = "dfx_smoke_test",
     extra_head_nns_tags = [],  # don't run the head_nns variant on nightly since it aleady runs on long_test.
-    flaky = True,
     tags = [
         "long_test",  # since it takes longer than 5 minutes.
     ],
@@ -59,7 +58,6 @@ system_test(
     env = {
         "WALLET_CANISTER_0_7_2_WASM": "$(rootpath @wallet_canister_0.7.2//file)",
     },
-    flaky = True,
     target_compatible_with = ["@platforms//os:linux"],  # requires libssh that does not build on Mac OS
     runtime_deps = RUNTIME_DEPS + [
         "@wallet_canister_0.7.2//file",

--- a/rs/tests/testnets/BUILD.bazel
+++ b/rs/tests/testnets/BUILD.bazel
@@ -7,7 +7,6 @@ package(default_visibility = ["//rs:system-tests-pkg"])
 
 system_test(
     name = "single_large_node",
-    flaky = False,
     tags = [
         "dynamic_testnet",
         "k8s",
@@ -26,7 +25,6 @@ system_test(
 
 system_test(
     name = "single_app_large_node",
-    flaky = False,
     tags = [
         "dynamic_testnet",
         "k8s",
@@ -44,7 +42,6 @@ system_test(
 
 system_test_nns(
     name = "single_app_large_node_with_nns",
-    flaky = False,
     tags = [
         "dynamic_testnet",
         "k8s",
@@ -63,7 +60,6 @@ system_test_nns(
 
 system_test(
     name = "single_app_small_node",
-    flaky = False,
     tags = [
         "dynamic_testnet",
         "k8s",
@@ -81,7 +77,6 @@ system_test(
 
 system_test_nns(
     name = "small",
-    flaky = False,
     tags = [
         "dynamic_testnet",
         "manual",
@@ -99,7 +94,6 @@ system_test_nns(
 
 system_test_nns(
     name = "small_bitcoin",
-    flaky = False,
     tags = [
         "dynamic_testnet",
         "manual",
@@ -118,7 +112,6 @@ system_test_nns(
 
 system_test_nns(
     name = "small_high_perf",
-    flaky = False,
     tags = [
         "dynamic_testnet",
         "manual",
@@ -138,7 +131,6 @@ system_test_nns(
 system_test(
     name = "from_config",
     env = NNS_CANISTER_ENV,
-    flaky = False,
     tags = [
         "dynamic_testnet",
         "manual",
@@ -155,7 +147,6 @@ system_test(
 
 system_test_nns(
     name = "small_nns",
-    flaky = False,
     tags = [
         "dynamic_testnet",
         "manual",
@@ -179,7 +170,6 @@ system_test_nns(
 
 system_test_nns(
     name = "small_with_api_bn",
-    flaky = False,
     tags = [
         "dynamic_testnet",
         "manual",
@@ -209,7 +199,6 @@ system_test_nns(
         "NNS_DAPP_WASM_PATH": "$(rootpath @nns_dapp_canister//file)",
         "SUBNET_RENTAL_WASM_PATH": "$(rootpath @subnet_rental_canister//file)",
     },
-    flaky = False,
     tags = [
         "dynamic_testnet",
         "manual",
@@ -238,7 +227,6 @@ system_test_nns(
         "SNS_AGGREGATOR_WASM_PATH": "$(rootpath @sns_aggregator//file)",
         "SUBNET_RENTAL_WASM_PATH": "$(rootpath @subnet_rental_canister//file)",
     },
-    flaky = False,
     tags = [
         "dynamic_testnet",
         "manual",
@@ -263,7 +251,6 @@ system_test_nns(
 
 system_test_nns(
     name = "medium",
-    flaky = False,
     tags = [
         "dynamic_testnet",
         "manual",
@@ -287,7 +274,6 @@ system_test_nns(
         "SNS_AGGREGATOR_WASM_PATH": "$(rootpath @sns_aggregator//file)",
         "SUBNET_RENTAL_WASM_PATH": "$(rootpath @subnet_rental_canister//file)",
     },
-    flaky = False,
     tags = [
         "dynamic_testnet",
         "manual",
@@ -318,7 +304,6 @@ system_test_nns(
         "SNS_AGGREGATOR_WASM_PATH": "$(rootpath @sns_aggregator//file)",
         "SUBNET_RENTAL_WASM_PATH": "$(rootpath @subnet_rental_canister//file)",
     },
-    flaky = False,
     tags = [
         "dynamic_testnet",
         "manual",
@@ -357,7 +342,6 @@ system_test(
     },
     env = NNS_CANISTER_ENV,
     env_inherit = ["SSH_AUTH_SOCK"],
-    flaky = True,
     tags = [
         "dynamic_testnet",
         "local",


### PR DESCRIPTION
Many tests marked with `flaky = True` are not actually flaky (anymore) or have a very low flakiness rate (< 1%). To reduce noise we remove these `flaky = True` settings. For the ones that are actually flaky (>= 1% flakiness rate) we make sure they're marked as such and add a comment with their actual flakiness rate to document the motivation for `flaky = True`. 

We also remove `flaky = False` settings since that's the default.