### PR TITLE
chore: [EXC-1833] Revert "chore: Ignore wasmtime validation errors (#3338)"

### DIFF
--- a/rs/embedders/src/wasm_utils/validation.rs
+++ b/rs/embedders/src/wasm_utils/validation.rs
@@ -1589,8 +1589,11 @@ fn can_compile(
 ) -> Result<(), WasmValidationError> {
     let config = wasmtime_validation_config(embedders_config);
     let engine = wasmtime::Engine::new(&config).expect("Failed to create wasmtime::Engine");
-    wasmtime::Module::validate(&engine, wasm.as_slice()).map_err(|_err| {
-        WasmValidationError::WasmtimeValidation("wasmtime::Module::validate() failed".into())
+    wasmtime::Module::validate(&engine, wasm.as_slice()).map_err(|err| {
+        WasmValidationError::WasmtimeValidation(format!(
+            "wasmtime::Module::validate() failed with {}",
+            err
+        ))
     })
 }
 

--- a/rs/embedders/src/wasmtime_embedder/wasmtime_embedder_tests.rs
+++ b/rs/embedders/src/wasmtime_embedder/wasmtime_embedder_tests.rs
@@ -164,7 +164,6 @@ fn test_wasmtime_system_api() {
         .expect("call failed");
 }
 
-#[ignore]
 #[test]
 fn test_initial_wasmtime_config() {
     // The following proposals should be disabled: simd, relaxed_simd,
@@ -233,20 +232,4 @@ fn test_initial_wasmtime_config() {
             "Error expecting `{expected_err_msg}`, but got `{err_msg}`"
         );
     }
-}
-
-#[test]
-fn test_wasmtime_validation_error_is_ignored() {
-    let wat = r#"(module (import "env" "memory" (memory 1 1 shared)))"#;
-    let wasm_binary = BinaryEncodedWasm::new(wat::parse_str(wat).unwrap());
-    let err = validate_and_instrument_for_testing(
-        &WasmtimeEmbedder::new(EmbeddersConfig::default(), no_op_logger()),
-        &wasm_binary,
-    )
-    .err()
-    .unwrap();
-    assert_eq!(
-        format!("{:?}", err),
-        r#"InvalidWasm(WasmtimeValidation("wasmtime::Module::validate() failed"))"#
-    );
 }

--- a/rs/execution_environment/tests/execution_test.rs
+++ b/rs/execution_environment/tests/execution_test.rs
@@ -2226,7 +2226,6 @@ fn system_subnets_are_not_rate_limited() {
     );
 }
 
-#[ignore]
 #[test]
 fn toolchain_error_message() {
     let sm = StateMachine::new();


### PR DESCRIPTION
This reverts commit 227e8e3de539e128ab67ca0375fd24e291e93b28. 
Wasmtime 30 contains the fix that makes wasmtime module validation deterministic, so this hotfix can be removed and the concrete error can be returned to the user again. 