### PR TITLE
chore: Reduce the size of the random_instructions proptest

### DIFF
--- a/rs/replicated_state/src/page_map/storage/tests.rs
+++ b/rs/replicated_state/src/page_map/storage/tests.rs
@@ -1542,10 +1542,10 @@ mod proptest_tests {
 
     /// A random vector of instructions.
     fn instructions_strategy() -> impl Strategy<Value = Vec<Instruction>> {
-        prop_vec(instruction_strategy(), 1..20)
+        prop_vec(instruction_strategy(), 1..10)
     }
 
-    #[test_strategy::proptest]
+    #[test_strategy::proptest(cases = 10)]
     fn random_instructions(#[strategy(instructions_strategy())] instructions: Vec<Instruction>) {
         write_overlays_and_verify(instructions);
     }


### PR DESCRIPTION
We don't necessarily gain much from running hundreds of times a proptest that writes hundreds of files. Limit it to 10 cases (i.e. runs) instead of the default 256; and 10 instructions (instead of 20).

This reduces the runtime (on my devenv, YMMV) from 2+ minutes to 2 seconds.