### PR TITLE
test(sns): Upgrade SNS-W before deploying SNS (and bump the canister mainnet versions)

### DIFF
--- a/mainnet-canister-revisions.json
+++ b/mainnet-canister-revisions.json
@@ -68,8 +68,8 @@
     "sha256": "fd25a4e2e283b498c3be1aaf63cc9b2726264d78a12b12f43ad453ceeb575e7c"
   },
   "governance": {
-    "rev": "ebb190bf1da0dba3e486b78c95cf5a3c5542e2f3",
-    "sha256": "d1668a798dc235587dfd3d50c0f7655b74d9360d4a5dbafd11ddc47042a7fbe4"
+    "rev": "7286063eaecd4d3625a8bf991213e27e21d3c2cf",
+    "sha256": "73ec598e1e372b74843f269ea21cdb58b91e9b1553c8a05aeff98a360edd8735"
   },
   "index": {
     "rev": "7c6309cb5bec7ab28ed657ac7672af08a59fc1ba",
@@ -112,8 +112,8 @@
     "sha256": "2b0970a84976bc2eb9591b68d44501566937994fa5594972f8aac9c8b058672f"
   },
   "sns_governance": {
-    "rev": "ebb190bf1da0dba3e486b78c95cf5a3c5542e2f3",
-    "sha256": "fc28495a50286e87777b1d0a14107ad02be4722a4b7afe5bd3dc6ec44a5c345f"
+    "rev": "7286063eaecd4d3625a8bf991213e27e21d3c2cf",
+    "sha256": "4da18c93286ce9513452531487d5ce107d7c8277671500ebff46ee696bcfa6bd"
   },
   "sns_index": {
     "rev": "c741e349451edf0c9792149ad439bb32a0161371",

--- a/rs/nervous_system/integration_tests/src/pocket_ic_helpers.rs
+++ b/rs/nervous_system/integration_tests/src/pocket_ic_helpers.rs
@@ -967,7 +967,7 @@ pub async fn upgrade_nns_canister_to_tip_of_master_or_panic(
     pocket_ic: &PocketIc,
     canister_id: CanisterId,
 ) {
-    // What we really want here is `match canister_id { ... }`, but this does not work because
+    // What we really want here is test_upgrade_swap`match canister_id { ... }`, but this does not work because
     // `CanisterId` encapsulates `PrincipalId` which has a manual implementation for `PartialEq`,
     // whereas Rust requires constants used in match expressions to **derive** `PartialEq`.
     let (wasm, controller, label) = if canister_id == GOVERNANCE_CANISTER_ID {

--- a/rs/nervous_system/integration_tests/src/pocket_ic_helpers.rs
+++ b/rs/nervous_system/integration_tests/src/pocket_ic_helpers.rs
@@ -967,7 +967,7 @@ pub async fn upgrade_nns_canister_to_tip_of_master_or_panic(
     pocket_ic: &PocketIc,
     canister_id: CanisterId,
 ) {
-    // What we really want here is test_upgrade_swap`match canister_id { ... }`, but this does not work because
+    // What we really want here is `match canister_id { ... }`, but this does not work because
     // `CanisterId` encapsulates `PrincipalId` which has a manual implementation for `PartialEq`,
     // whereas Rust requires constants used in match expressions to **derive** `PartialEq`.
     let (wasm, controller, label) = if canister_id == GOVERNANCE_CANISTER_ID {

--- a/rs/nervous_system/integration_tests/tests/sns_release_qualification.rs
+++ b/rs/nervous_system/integration_tests/tests/sns_release_qualification.rs
@@ -56,8 +56,11 @@ async fn test_deployment_with_only_nns_upgrades() {
 
 #[tokio::test]
 async fn test_deployment_with_only_sns_upgrades() {
+    // TODO[NNS1-3657]: Do not upgrade SNS-W, use the mainnet version.
+    let nns_canisters_to_upgrade = vec![SNS_WASM_CANISTER_ID];
+
     test_sns_deployment(
-        vec![],
+        nns_canisters_to_upgrade,
         vec![
             SnsCanisterType::Root,
             SnsCanisterType::Governance,
@@ -71,8 +74,11 @@ async fn test_deployment_with_only_sns_upgrades() {
 
 #[tokio::test]
 async fn test_deployment_with_sns_root_and_governance_upgrade() {
+    // TODO[NNS1-3657]: Do not upgrade SNS-W, use the mainnet version.
+    let nns_canisters_to_upgrade = vec![SNS_WASM_CANISTER_ID];
+
     test_sns_deployment(
-        vec![],
+        nns_canisters_to_upgrade,
         vec![SnsCanisterType::Root, SnsCanisterType::Governance],
     )
     .await;
@@ -80,7 +86,10 @@ async fn test_deployment_with_sns_root_and_governance_upgrade() {
 
 #[tokio::test]
 async fn test_deployment_swap_upgrade() {
-    test_sns_deployment(vec![], vec![SnsCanisterType::Swap]).await;
+    // TODO[NNS1-3657]: Do not upgrade SNS-W, use the mainnet version.
+    let nns_canisters_to_upgrade = vec![SNS_WASM_CANISTER_ID];
+
+    test_sns_deployment(nns_canisters_to_upgrade, vec![SnsCanisterType::Swap]).await;
 }
 
 /// Upgrade Tests

--- a/rs/nervous_system/integration_tests/tests/sns_upgrade_test_utils.rs
+++ b/rs/nervous_system/integration_tests/tests/sns_upgrade_test_utils.rs
@@ -11,9 +11,11 @@ use ic_nervous_system_integration_tests::{
                 EXPECTED_UPGRADE_DURATION_MAX_SECONDS, EXPECTED_UPGRADE_STEPS_REFRESH_MAX_SECONDS,
             },
         },
+        upgrade_nns_canister_to_tip_of_master_or_panic,
     },
     SectionTimer,
 };
+use ic_nns_constants::SNS_WASM_CANISTER_ID;
 use ic_sns_governance::governance::UPGRADE_STEPS_INTERVAL_REFRESH_BACKOFF_SECONDS;
 use ic_sns_governance_api::pb::v1::upgrade_journal_entry;
 use ic_sns_swap::pb::v1::Lifecycle;
@@ -27,6 +29,9 @@ pub async fn test_sns_upgrade(
 
     let (pocket_ic, initial_sns_version) =
         pocket_ic_helpers::pocket_ic_for_sns_tests_with_mainnet_versions().await;
+
+    // TODO[NNS1-3657]: Do not upgrade SNS-W, use the mainnet version.
+    upgrade_nns_canister_to_tip_of_master_or_panic(&pocket_ic, SNS_WASM_CANISTER_ID).await;
 
     let create_service_nervous_system = {
         let _timer = SectionTimer::new("Creating SNS");

--- a/rs/nervous_system/integration_tests/tests/sns_upgrade_test_utils_legacy.rs
+++ b/rs/nervous_system/integration_tests/tests/sns_upgrade_test_utils_legacy.rs
@@ -5,8 +5,10 @@ use ic_nervous_system_integration_tests::{
     pocket_ic_helpers::{
         self, add_wasm_via_nns_proposal, nns,
         sns::{self, governance::set_automatically_advance_target_version_flag},
+        upgrade_nns_canister_to_tip_of_master_or_panic,
     },
 };
+use ic_nns_constants::SNS_WASM_CANISTER_ID;
 use ic_nns_test_utils::sns_wasm::{
     build_archive_sns_wasm, build_governance_sns_wasm, build_index_ng_sns_wasm,
     build_ledger_sns_wasm, build_root_sns_wasm, build_swap_sns_wasm, create_modified_sns_wasm,

--- a/rs/nervous_system/integration_tests/tests/sns_upgrade_test_utils_legacy.rs
+++ b/rs/nervous_system/integration_tests/tests/sns_upgrade_test_utils_legacy.rs
@@ -20,6 +20,9 @@ pub async fn test_sns_upgrade_legacy(sns_canisters_to_upgrade: Vec<SnsCanisterTy
     let (pocket_ic, _initial_sns_version) =
         pocket_ic_helpers::pocket_ic_for_sns_tests_with_mainnet_versions().await;
 
+    // TODO[NNS1-3657]: Do not upgrade SNS-W, use the mainnet version.
+    upgrade_nns_canister_to_tip_of_master_or_panic(&pocket_ic, SNS_WASM_CANISTER_ID).await;
+
     eprintln!("Creating SNS ...");
     let create_service_nervous_system = CreateServiceNervousSystemBuilder::default()
         .with_governance_parameters_neuron_minimum_dissolve_delay_to_vote(ONE_MONTH_SECONDS * 6)

--- a/rs/nervous_system/integration_tests/tests/upgrade_existing_sns_test.rs
+++ b/rs/nervous_system/integration_tests/tests/upgrade_existing_sns_test.rs
@@ -92,6 +92,9 @@ async fn test_upgrade_existing_sns() {
         pocket_ic
     };
 
+    // TODO[NNS1-3657]: Do not upgrade SNS-W, use the mainnet version.
+    upgrade_nns_canister_to_tip_of_master_or_panic(&pocket_ic, SNS_WASM_CANISTER_ID).await;
+
     // We don't publish or upgrade any release candidate canisters yet. We want to deploy a mainnet
     // version of the SNS first, then upgrade and validate.
 


### PR DESCRIPTION
This PR adds a temporary step to all SNS qualification tests that normally work with mainnet SNS-W version to first upgrade it to the latest version on the master branch. This prepares for an urgent SNS-W release needed to fix the SNS deployment error caused by NNS Governance and SNS-W APIs being out of sync (namely, NNS Governance no longer sets the neurons field, while the mainnet SNS-W still requires that).

This change is also enabling us to bump the mainnet canister versions.