### PR TITLE
test(EXC-1983): Add a query benchmark to compilation benches

### DIFF
--- a/rs/embedders/BUILD.bazel
+++ b/rs/embedders/BUILD.bazel
@@ -172,14 +172,6 @@ rust_ic_test_suite_with_extra_srcs(
     deps = [":embedders"] + DEPENDENCIES + DEV_DEPENDENCIES,
 )
 
-rust_bench(
-    name = "compilation_bench",
-    srcs = ["benches/compilation.rs"],
-    compile_data = glob(["benches/test-data/*"]),
-    with_test = True,
-    deps = [":embedders"] + DEPENDENCIES + DEV_DEPENDENCIES,
-)
-
 rust_library(
     name = "embedders_bench",
     testonly = True,
@@ -202,6 +194,17 @@ UNIVERSAL_CANISTER_TEST_DEPS = UNIVERSAL_CANISTER_RUNTIME_DEPS + [
 UNIVERSAL_CANISTER_TEST_ENV = UNIVERSAL_CANISTER_ENV | {
     "UNIVERSAL_CANISTER_SERIALIZED_MODULE_PATH": "$(rootpath //rs/universal_canister/impl:universal_canister.module)",
 }
+
+rust_ic_bench(
+    name = "compilation_bench",
+    testonly = True,
+    srcs = ["benches/compilation.rs"],
+    compile_data = glob(["benches/test-data/*"]),
+    with_test = True,
+    data = DATA + UNIVERSAL_CANISTER_TEST_DEPS,
+    env = ENV | UNIVERSAL_CANISTER_TEST_ENV,
+    deps = [":embedders", ":embedders_bench"] + DEPENDENCIES + DEV_DEPENDENCIES,
+)
 
 rust_ic_bench(
     name = "stable_memory_bench",

--- a/rs/embedders/BUILD.bazel
+++ b/rs/embedders/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@rules_rust//rust:defs.bzl", "rust_binary", "rust_library", "rust_test")
-load("//bazel:defs.bzl", "rust_bench", "rust_ic_bench", "rust_ic_test_suite_with_extra_srcs")
+load("//bazel:defs.bzl", "rust_ic_bench", "rust_ic_test_suite_with_extra_srcs")
 load("//bazel:fuzz_testing.bzl", "DEFAULT_RUSTC_FLAGS_FOR_FUZZING")
 load("//rs/tests:common.bzl", "UNIVERSAL_CANISTER_ENV", "UNIVERSAL_CANISTER_RUNTIME_DEPS")
 
@@ -200,10 +200,13 @@ rust_ic_bench(
     testonly = True,
     srcs = ["benches/compilation.rs"],
     compile_data = glob(["benches/test-data/*"]),
-    with_test = True,
     data = DATA + UNIVERSAL_CANISTER_TEST_DEPS,
     env = ENV | UNIVERSAL_CANISTER_TEST_ENV,
-    deps = [":embedders", ":embedders_bench"] + DEPENDENCIES + DEV_DEPENDENCIES,
+    with_test = True,
+    deps = [
+        ":embedders",
+        ":embedders_bench",
+    ] + DEPENDENCIES + DEV_DEPENDENCIES,
 )
 
 rust_ic_bench(

--- a/rs/embedders/benches/compilation.rs
+++ b/rs/embedders/benches/compilation.rs
@@ -227,8 +227,6 @@ fn execution(c: &mut Criterion) {
     set_production_rayon_threads();
 
     let binaries = generate_binaries();
-    // let mut group = c.benchmark_group("execution");
-    // let config = EmbeddersConfig::default();
     for (name, wasm) in binaries {
         embedders_bench::query_bench(
             c,
@@ -241,7 +239,6 @@ fn execution(c: &mut Criterion) {
             PostSetupAction::None,
         );
     }
-    // group.finish();
 }
 
 criterion_group!(


### PR DESCRIPTION
EXC-1983

This will allow us to benchmark changes to the compilation process to see if there is a trade off between compilation and execution times.